### PR TITLE
Revert the original fix to 5424307

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -5593,14 +5593,19 @@ void EmitReference(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator, FuncI
         case knopName:
         {
             Symbol *sym = pnode->sxCall.pnodeTarget->sxPid.sym;
-            if (!sym || 
-                sym->GetLocation() == Js::Constants::NoRegister || 
-                sym->IsInSlot(funcInfo) ||
-                sym->GetScope()->GetFunc() != funcInfo)
+            if (!sym || sym->GetLocation() == Js::Constants::NoRegister)
             {
                 funcInfo->AcquireLoc(pnode->sxCall.pnodeTarget);
             }
-            EmitReference(pnode->sxCall.pnodeTarget, byteCodeGenerator, funcInfo);
+            if (sym && (sym->IsInSlot(funcInfo) || sym->GetScope()->GetFunc() != funcInfo))
+            {
+                // Can't get the value from the assigned register, so load it here.
+                EmitLoad(pnode->sxCall.pnodeTarget, byteCodeGenerator, funcInfo);
+            }
+            else
+            {
+                EmitReference(pnode->sxCall.pnodeTarget, byteCodeGenerator, funcInfo);
+            }
             break;
         }
         default:

--- a/test/LetConst/tdz1.baseline
+++ b/test/LetConst/tdz1.baseline
@@ -17,8 +17,8 @@ ReferenceError: Use before declaration
 ReferenceError: Use before declaration
 ReferenceError: Use before declaration
 ReferenceError: Use before declaration
-ReferenceError: Invalid left-hand side in assignment
-ReferenceError: Invalid left-hand side in assignment
+ReferenceError: Use before declaration
+ReferenceError: Use before declaration
 false
 ReferenceError: Use before declaration
 false


### PR DESCRIPTION
Revert the original fix to 5424307 (difference in error thrown in deferred and non-deferred case of assignment to function result) as it was causing more problems than it fixed. Will come up with a proper fix for the original bug.
