### PR TITLE
Fix build break

### DIFF
--- a/lib/Runtime/Language/Chakra.Runtime.Language.vcxproj
+++ b/lib/Runtime/Language/Chakra.Runtime.Language.vcxproj
@@ -193,7 +193,7 @@
       <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
     </MASM>
     <MASM Include="$(MSBuildThisFileDirectory)amd64\amd64_Thunks.asm">
-      <PreprocessorDefinitions Condition="'$(BuildJIT)'!='false'">_ENABLE_DYNAMIC_THUNKS</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(BuildJIT)'!='false'">%(PreprocessorDefinitions);_ENABLE_DYNAMIC_THUNKS=1</PreprocessorDefinitions>
       <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
     </MASM>
     <ARMASM Include="$(MSBuildThisFileDirectory)arm\arm_Thunks.asm">

--- a/lib/Runtime/Library/Chakra.Runtime.Library.vcxproj
+++ b/lib/Runtime/Library/Chakra.Runtime.Library.vcxproj
@@ -251,7 +251,7 @@
   </ItemGroup>
   <ItemGroup>
     <MASM Include="$(MSBuildThisFileDirectory)amd64\javascriptfunctiona.asm">
-      <PreprocessorDefinitions Condition="'$(BuildJIT)'!='false'">_ENABLE_ASM_JS</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(BuildJIT)'!='false'">%(PreprocessorDefinitions);_ENABLE_ASM_JS=1</PreprocessorDefinitions>
       <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
     </MASM>
     <ARMASM Include="$(MSBuildThisFileDirectory)arm\arm_DeferredDeserializeThunk.asm">


### PR DESCRIPTION
If preprocessor definitions for asm files are already defined, don't clobber them
