### PR TITLE
Adding a new configuration to build binaries for code coverage analysis

### DIFF
--- a/Build/Chakra.Build.props
+++ b/Build/Chakra.Build.props
@@ -44,6 +44,14 @@
         $(ChakraCoreRootDirectory)\lib\common\placeholder;
         %(AdditionalIncludeDirectories)
       </AdditionalIncludeDirectories>
+
+      <!-- ======== For Code Covearge ======== -->
+      <Optimization Condition="'$(ENABLE_CODECOVERAGE)'=='true'">Disabled</Optimization>
     </ClCompile>
+
+    <Link>
+      <!-- ======== For Code Covearge ======== -->
+      <AdditionalOptions Condition="'$(ENABLE_CODECOVERAGE)'=='true'">%(AdditionalOptions) /DEBUGTYPE:CV,FIXUP</AdditionalOptions>
+    </Link>
   </ItemDefinitionGroup>
 </Project>

--- a/Build/Common.Build.Default.props
+++ b/Build/Common.Build.Default.props
@@ -64,6 +64,7 @@
 
   <!-- Output directories -->
   <PropertyGroup>
+    <OutDirName Condition="'$(ENABLE_CODECOVERAGE)'=='true'">codecoverage</OutDirName>
     <OutDirName Condition="'$(OutDirName)'==''">$(Configuration.ToLower())</OutDirName>
     <OutDir>$(OutBaseDir)\bin\$(PlatformPathName.ToLower())_$(OutDirName)\</OutDir>
     <IntDir>$(IntBaseDir)\obj\$(PlatformPathName.ToLower())_$(Configuration.ToLower())\$(MSBuildProjectName)\</IntDir>

--- a/Build/scripts/post_build.ps1
+++ b/Build/scripts/post_build.ps1
@@ -2,7 +2,7 @@ param (
     [ValidateSet("x86", "x64", "arm", "*")]
     [string]$arch="*",
 
-    [ValidateSet("debug", "release", "test", "*")]
+    [ValidateSet("debug", "release", "test", "codecoverage", "*")]
     [string]$flavor = "*",
 
     [string]$srcpath = "",
@@ -22,7 +22,6 @@ param (
 )
 
 $global:exitcode = 0
-
 
 if ($arch -eq "*") {
 

--- a/test/runtests.cmd
+++ b/test/runtests.cmd
@@ -48,6 +48,7 @@ goto :main
   echo.
   echo   -debug         Build type of binaries is debug
   echo   -test          Build type of binaries is test
+  echo   -codecoverage  Build type of binaries is codecoverage
   echo.
   echo   Shorthand combinations can be used, e.g. -x64debug
   echo.
@@ -134,6 +135,7 @@ goto :main
   if /i "%1" == "-arm"              set _BuildArch=arm&                                         goto :ArgOk
   if /i "%1" == "-debug"            set _BuildType=debug&                                       goto :ArgOk
   if /i "%1" == "-test"             set _BuildType=test&                                        goto :ArgOk
+  if /i "%1" == "-codecoverage"     set _BuildType=codecoverage&                                goto :ArgOk
 
   if /i "%1" == "-x86debug"         set _BuildArch=x86&set _BuildType=debug&                    goto :ArgOk
   if /i "%1" == "-x64debug"         set _BuildArch=x64&set _BuildType=debug&                    goto :ArgOk
@@ -141,6 +143,9 @@ goto :main
   if /i "%1" == "-x86test"          set _BuildArch=x86&set _BuildType=test&                     goto :ArgOk
   if /i "%1" == "-x64test"          set _BuildArch=x64&set _BuildType=test&                     goto :ArgOk
   if /i "%1" == "-armtest"          set _BuildArch=arm&set _BuildType=test&                     goto :ArgOk
+  if /i "%1" == "-x86codecoverage"  set _BuildArch=x86&set _BuildType=codecoverage&             goto :ArgOk
+  if /i "%1" == "-x64codecoverage"  set _BuildArch=x64&set _BuildType=codecoverage&             goto :ArgOk
+  if /i "%1" == "-armcodecoverage"  set _BuildArch=arm&set _BuildType=codecoverage&             goto :ArgOk
 
   if /i "%1" == "-binary"           set _Binary=-binary:%2&                                     goto :ArgOkShift2
   if /i "%1" == "-bindir"           set _BinDir=%~f2&                                           goto :ArgOkShift2
@@ -318,6 +323,7 @@ goto :main
   if "%_BuildArchMapped%" == "x64" set _BuildArchMapped=amd64
   if "%_BuildTypeMapped%" == "debug" set _BuildTypeMapped=chk
   if "%_BuildTypeMapped%" == "test" set _BuildTypeMapped=fre
+  if "%_BuildTypeMapped%" == "codecoverage" set _BuildTypeMapped=fre
 
   if "%Disable_JIT%" == "1" (
       set _dynamicprofilecache=


### PR DESCRIPTION
The build is enabled by setting the environment variable ENABLE_CODECOVERAGE. For code coveage, optimization is turned off and additional arguments are passed during linking to include more debug information.
