### PR TITLE
Add daily build tasks.

### DIFF
--- a/test/jenkins.build.init.cmd
+++ b/test/jenkins.build.init.cmd
@@ -12,9 +12,35 @@ if not "%JENKINS_BUILD%" == "True" (
 
 set REPO_ROOT=%~dp0\..
 
+set JENKINS_BUILD_ARGS=
+set JENKINS_USE_MSBUILD_12=
+:ContinueArgParse
+if not [%1]==[] (
+    if [%1]==[msbuild12] (
+        set JENKINS_USE_MSBUILD_12=True
+        goto :ContinueArgParseEnd
+    )
+
+    :: DEFAULT - add any other params to %JENKINS_BUILD_ARGS%
+    if [%1] NEQ [] (
+        set JENKINS_BUILD_ARGS=%JENKINS_BUILD_ARGS% %1
+        goto :ContinueArgParseEnd
+    )
+
+    :ContinueArgParseEnd
+    shift
+    goto :ContinueArgParse
+)
+
 :: ========================================
 :: Set up msbuild.exe
 :: ========================================
+
+if "%JENKINS_USE_MSBUILD_12%" == "True" (
+    echo Skipping Dev14 and trying Dev12...
+    goto :LABEL_USE_MSBUILD_12
+)
+
 where /q msbuild.exe
 IF "%ERRORLEVEL%" == "0" (
     goto :SkipMsBuildSetup
@@ -36,9 +62,15 @@ if exist %MSBUILD_PATH%\msbuild.exe (
     goto :MSBuildFound
 )
 
+echo Dev14 not found, trying Dev %MSBUILD_VERSION%
+
+:LABEL_USE_MSBUILD_12
 set MSBUILD_VERSION=12.0
 set MSBUILD_PATH="%ProgramFiles%\msbuild\%MSBUILD_VERSION%\Bin\x86"
-echo Dev14 not found, trying Dev %MSBUILD_VERSION%
+
+if not exist %MSBUILD_PATH%\msbuild.exe (
+    set MSBUILD_PATH="%ProgramFiles(x86)%\msbuild\%MSBUILD_VERSION%\Bin"
+)
 
 if not exist %MSBUILD_PATH%\msbuild.exe (
     set MSBUILD_PATH="%ProgramFiles(x86)%\msbuild\%MSBUILD_VERSION%\Bin\amd64"
@@ -53,6 +85,7 @@ if not exist %MSBUILD_PATH%\msbuild.exe (
 echo MSBuild located at %MSBUILD_PATH%
 
 set PATH=%MSBUILD_PATH%;%PATH%
+set JENKINS_USE_MSBUILD_12=
 set MSBUILD_PATH=
 
 :SkipMsBuildSetup

--- a/test/jenkins.buildone.cmd
+++ b/test/jenkins.buildone.cmd
@@ -17,12 +17,12 @@ if "%_ENTRY_SCRIPT_NAME%"=="" (
 
 pushd %~dp0
 
-call jenkins.build.init.cmd
+call jenkins.build.init.cmd %*
 
 set _BuildArch=
 set _BuildType=
 
-call jenkins.build.cmd %*
+call jenkins.build.cmd %JENKINS_BUILD_ARGS%
 
 popd
 


### PR DESCRIPTION
We are adding some daily build tasks which will build in a configuration not usually used for our PR and per-commit builds.

We don't want to add daily builds of the same configurations we already use for each PR and each commit, as they would be redundant. However there are some configurations that are worth testing at least on a daily basis: {x86, x64} x {debug, test, release} x {Windows 7} x {MsBuild 12 from VS 2013 aka Dev12}.

For these configurations we add a `@daily` task with a trigger to allow a commenter to request `@dotnet-bot` to run the daily build configurations on any PR if desired, in the same way that `test this please` can be used to trigger all of the usual tests.
