### PR TITLE
Syntax error for strict function decl outside statement context

### DIFF
--- a/lib/Parser/parse.h
+++ b/lib/Parser/parse.h
@@ -704,8 +704,9 @@ private:
     template<bool buildAST> ParseNodePtr ParseFncDecl(ushort flags, LPCOLESTR pNameHint = NULL, const bool isSourceElement = false, const bool needsPIDOnRCurlyScan = false, bool resetParsingSuperRestrictionState = true, bool fUnaryOrParen = false);
     template<bool buildAST> bool ParseFncNames(ParseNodePtr pnodeFnc, ParseNodePtr pnodeFncParent, ushort flags, ParseNodePtr **pLastNodeRef);
     template<bool buildAST> void ParseFncFormals(ParseNodePtr pnodeFnc, ushort flags);
-    template<bool buildAST> bool ParseFncDeclHelper(ParseNodePtr pnodeFnc, ParseNodePtr pnodeFncParent, LPCOLESTR pNameHint, ushort flags, bool *pHasName, bool fUnaryOrParen, bool *pNeedScanRCurly);
+    template<bool buildAST> bool ParseFncDeclHelper(ParseNodePtr pnodeFnc, ParseNodePtr pnodeFncParent, LPCOLESTR pNameHint, ushort flags, bool *pHasName, bool fUnaryOrParen, bool noStmtContext, bool *pNeedScanRCurly);
     template<bool buildAST> void ParseExpressionLambdaBody(ParseNodePtr pnodeFnc);
+    bool FncDeclAllowedWithoutContext(ushort flags);
     void FinishFncDecl(ParseNodePtr pnodeFnc, LPCOLESTR pNameHint, ParseNodePtr *lastNodeRef);
     void ParseTopLevelDeferredFunc(ParseNodePtr pnodeFnc, ParseNodePtr pnodeFncParent, LPCOLESTR pNameHint);
     void ParseNestedDeferredFunc(ParseNodePtr pnodeFnc, bool fLambda, bool *pNeedScanRCurly, bool *pStrictModeTurnedOn);

--- a/test/es6/blockscope-functionbinding.baseline
+++ b/test/es6/blockscope-functionbinding.baseline
@@ -192,6 +192,25 @@ Test 20: Function declaration in statement context without {}
 1
 0
 
+Test 21: Function declaration in statement context without {}, strict mode
+
+21.1: Syntax error
+21.2: Syntax error
+21.3: Syntax error
+21.4: Syntax error
+
+Test 22: Function declaration in statement context without {}, illegal in sloppy mode
+
+22.1: Syntax error
+22.2: Syntax error
+22.3: Syntax error
+22.4: Syntax error
+22.5: Syntax error
+22.6: Syntax error
+22.7: Syntax error
+22.8: Syntax error
+22.8: Syntax error
+
 Test Global: Global scope has the same semantics for block-scoped function declarations
 
 undefined

--- a/test/es6/blockscope-functionbinding.js
+++ b/test/es6/blockscope-functionbinding.js
@@ -558,10 +558,170 @@ print('\nTest 20: Function declaration in statement context without {}\n');
             function f4() { print('0'); }
     }
 
+    while (false)
+        function f5() {}
+
+    for (;false;)
+        function f6() {}
+
+    for (var p in {a:'a'})
+        function f7() {}
+
+    for (var e of [1])
+        function f8() {}
+
+    with ({})
+        function f9() {}
+
     f1();
     f2();
     f3();
     f4();
+
+    f7();
+    f8();
+    f9();
+})();
+
+print('\nTest 21: Function declaration in statement context without {}, strict mode\n');
+(function() {
+    "use strict";
+
+    // The B.3.4 exceptions are not allowed in strict mode
+
+    try {
+        eval('if (true)' +
+             '    function f() { return "not allowed in strict mode"; }' +
+             'else' +
+             '    void 0;');
+    }
+    catch(ex) {
+        print('21.1: ' + ex.message);
+    }
+
+    try {
+        eval('if (true)' +
+             '    void 0;' +
+             'else' +
+             '    function f() { return "not allowed in strict mode"; }');
+    }
+    catch(ex) {
+        print('21.2: ' + ex.message);
+    }
+
+    try {
+        eval('if (true)' +
+             '    function f() { return "not allowed in strict mode"; }' +
+             'else' +
+             '    function f() { return "not allowed in strict mode"; }');
+    }
+    catch(ex) {
+        print('21.3: ' + ex.message);
+    }
+
+    try {
+        eval('if (true)' +
+             '    function f() { return "not allowed in strict mode"; }');
+    }
+    catch(ex) {
+        print('21.4: ' + ex.message);
+    }
+})();
+
+print('\nTest 22: Function declaration in statement context without {}, illegal in sloppy mode\n');
+(function() {
+    // Always illegal syntax regardless of strict mode
+    // generator functions are GeneratorFunctionDeclaration, not FunctionDeclaration
+    // so are also not allowed by the B.3.4 exception
+
+    try {
+        eval('if (true)' +
+             '    function* f() { return "never allowed"; }' +
+             'else' +
+             '    void 0;');
+    }
+    catch(ex) {
+        print('22.1: ' + ex.message);
+    }
+
+    try {
+        eval('if (true)' +
+             '    void 0;' +
+             'else' +
+             '    function* f() { return "never allowed"; }');
+    }
+    catch(ex) {
+        print('22.2: ' + ex.message);
+    }
+
+    try {
+        eval('if (true)' +
+             '    function* f() { return "never allowed"; }' +
+             'else' +
+             '    function* f() { return "never allowed"; }');
+    }
+    catch(ex) {
+        print('22.3: ' + ex.message);
+    }
+
+    try {
+        eval('if (true)' +
+             '    function* f() { return "never allowed"; }');
+    }
+    catch(ex) {
+        print('22.4: ' + ex.message);
+    }
+
+    // async is ES7 but presumably will also not be FunctionDeclaration in the grammar
+    // and so are also not allowed by the B.3.4 exception
+
+    try {
+        eval('if (true)' +
+             '    async function f() { return "never allowed"; }' +
+             'else' +
+             '    void 0;');
+    }
+    catch(ex) {
+        print('22.5: ' + ex.message);
+    }
+
+    try {
+        eval('if (true)' +
+             '    void 0;' +
+             'else' +
+             '    async function f() { return "never allowed"; }');
+    }
+    catch(ex) {
+        print('22.6: ' + ex.message);
+    }
+
+    try {
+        eval('if (true)' +
+             '    async function f() { return "never allowed"; }' +
+             'else' +
+             '    async function f() { return "never allowed"; }');
+    }
+    catch(ex) {
+        print('22.7: ' + ex.message);
+    }
+
+    try {
+        eval('if (true)' +
+             '    async function f() { return "never allowed"; }' +
+             'else' +
+             '    async function f() { return "never allowed"; }');
+    }
+    catch(ex) {
+        print('22.8: ' + ex.message);
+    }
+
+    try {
+        eval('if (true)' +
+             '    async function f() { return "never allowed"; }');
+    }
+    catch(ex) {
+        print('22.8: ' + ex.message);
+    }
 })();
 
 // Leave this test last since it is at global scope and would be awkward to place in the middle of the cleanly contained tests

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -233,20 +233,21 @@
   <test>
     <default>
       <files>blockscope-functionbinding.js</files>
+      <compile-flags>-ES7AsyncAwait</compile-flags>
       <baseline>blockscope-functionbinding.baseline</baseline>
     </default>
   </test>
   <test>
     <default>
       <files>blockscope-functionbinding.js</files>
-      <compile-flags>-force:deferparse</compile-flags>
+      <compile-flags>-force:deferparse -ES7AsyncAwait</compile-flags>
       <baseline>blockscope-functionbinding.baseline</baseline>
     </default>
   </test>
   <test>
     <default>
       <files>blockscope-functionbinding.js</files>
-      <compile-flags>-lic:1 -InitializeInterpreterSlotsWithInvalidStackVar</compile-flags>
+      <compile-flags>-lic:1 -InitializeInterpreterSlotsWithInvalidStackVar -ES7AsyncAwait</compile-flags>
       <baseline>blockscope-functionbinding.baseline</baseline>
       <tags>exclude_fre</tags>
     </default>

--- a/test/strict/21.functionDeclaration_sm.baseline
+++ b/test/strict/21.functionDeclaration_sm.baseline
@@ -1,11 +1,11 @@
 Return: Program.SourceElement.FunctionDeclaration
 Return: FunctionBody.FunctionDeclaration
 Return: Block.StatementList.Statement.FunctionDeclaration
-Return: IfStatement.Statement.FunctionDeclaration
-Return: IterationStatement(do-while).Statement.FunctionDeclaration
-Return: IterationStatement(while).Statement.FunctionDeclaration
-Return: IterationStatement(for).Statement.FunctionDeclaration
-Return: IterationStatement(for-in).Statement.FunctionDeclaration
+Exception: IfStatement.Statement.FunctionDeclaration - SyntaxError
+Exception: IterationStatement(do-while).Statement.FunctionDeclaration - SyntaxError
+Exception: IterationStatement(while).Statement.FunctionDeclaration - SyntaxError
+Exception: IterationStatement(for).Statement.FunctionDeclaration - SyntaxError
+Exception: IterationStatement(for-in).Statement.FunctionDeclaration - SyntaxError
 Return: SourceElement.Statement.LabelledStatement.Statement.FunctionDeclaration
 Return: Block.Statement.LabelledStatement.Statement.FunctionDeclaration
 Return: SwitchStatement.CaseBlock.CaseClause.StatementList.Statement.FunctionDeclaration


### PR DESCRIPTION
Make it a syntax error to declare a function outside statement context in strict mode, or to declare generator/async functions outside statement context in either mode.
