### PR TITLE
Use correct error message for String functions prohibiting a RegExp argument

### DIFF
--- a/lib/Parser/rterrors.h
+++ b/lib/Parser/rterrors.h
@@ -322,3 +322,5 @@ RT_ERROR_MSG(JSERR_ClassSuperInBaseClass, 5629, "", "Unexpected call to 'super' 
 RT_ERROR_MSG(JSERR_ClassDerivedConstructorInvalidReturnType, 5630, "", "Derived class constructor can return only object or undefined", kjstTypeError, 0)
 RT_ERROR_MSG(JSERR_ClassStaticMethodCannotBePrototype, 5631, "", "Class static member cannot be named 'prototype'", kjstTypeError, 0)
 RT_ERROR_MSG(JSERR_ClassConstructorCannotBeCalledWithoutNew, 5632, "%s: cannot be called without the new keyword", "Class constructor cannot be called without the new keyword", kjstTypeError, 0)
+
+RT_ERROR_MSG(JSERR_FunctionArgument_FirstCannotBeRegExp, 5633, "%s: first argument cannot be a RegExp", "First argument cannot be a RegExp", kjstTypeError, 0)

--- a/lib/Runtime/Library/JavascriptString.cpp
+++ b/lib/Runtime/Library/JavascriptString.cpp
@@ -1266,7 +1266,7 @@ case_2:
         {
             if (!isRegExpAnAllowedArg && JavascriptRegExp::Is(args[1]))
             {
-                JavascriptError::ThrowTypeError(scriptContext, JSERR_This_NeedString, apiNameForErrorMsg);
+                JavascriptError::ThrowTypeError(scriptContext, JSERR_FunctionArgument_FirstCannotBeRegExp, apiNameForErrorMsg);
             }
             else if (JavascriptString::Is(args[1]))
             {


### PR DESCRIPTION
"includes", "startsWith", and "endsWith" String functions don't allow the "searchString" argument to be a RegExp. Previously, the error message for the exception would say:

    'this' is not a String object

which is incorrect. This change updates it to say:

    invalid argument

instead.