### PR TITLE
Fix a stack walker bug with loop bodies

### DIFF
--- a/lib/Runtime/Language/JavascriptStackWalker.cpp
+++ b/lib/Runtime/Language/JavascriptStackWalker.cpp
@@ -472,7 +472,7 @@ namespace Js
                     }
 
                     bool inlinedFramesOnStack = InlinedFrameWalker::FromPhysicalFrame(inlinedFrameWalker, currentFrame,
-                        ScriptFunction::FromVar(function), true /*fromBailout*/, loopNum, this);
+                        ScriptFunction::FromVar(function), true /*fromBailout*/, loopNum);
                     if (inlinedFramesOnStack)
                     {
                         inlinedFramesBeingWalked = inlinedFrameWalker.Next(inlinedFrameCallInfo);
@@ -804,7 +804,7 @@ namespace Js
                 Assert((this->interpreterFrame->GetFlags() & Js::InterpreterStackFrameFlags_FromBailOut) != 0);
                 InlinedFrameWalker tmpFrameWalker;
                 Assert(InlinedFrameWalker::FromPhysicalFrame(tmpFrameWalker, currentFrame, Js::ScriptFunction::FromVar(argv[JavascriptFunctionArgIndex_Function]),
-                    true /*fromBailout*/, this->tempInterpreterFrame->GetCurrentLoopNum(), this, true /*noAlloc*/));
+                    true /*fromBailout*/, this->tempInterpreterFrame->GetCurrentLoopNum(), nullptr, true /*noAlloc*/));
                 tmpFrameWalker.Close();
             }
 #endif
@@ -871,7 +871,7 @@ namespace Js
             {
                 if (includeInlineFrames &&
                     InlinedFrameWalker::FromPhysicalFrame(inlinedFrameWalker, currentFrame, Js::ScriptFunction::FromVar(argv[JavascriptFunctionArgIndex_Function]),
-                        false /*fromBailout*/, this->tempInterpreterFrame->GetCurrentLoopNum(), this))
+                        false /*fromBailout*/, this->tempInterpreterFrame->GetCurrentLoopNum()))
                 {
                     // Found inlined frames in a jitted loop body. We dont want to skip the inlined frames; walk all of them before setting codeAddress on lastInternalFrameInfo.
                     inlinedFramesBeingWalked = inlinedFrameWalker.Next(inlinedFrameCallInfo);
@@ -1107,12 +1107,8 @@ namespace Js
         FunctionBody* parentFunctionBody = parent->GetFunctionBody();
         EntryPointInfo *entryPointInfo;
 
-        if (loopNum != -1)
-        {
-            Assert(stackWalker);
-        }
-        void *nativeCodeAddress = (loopNum == -1 || !stackWalker->GetCachedInternalFrameInfo().codeAddress) ? physicalFrame.GetInstructionPointer() : stackWalker->GetCachedInternalFrameInfo().codeAddress;
-        void *framePointer = (loopNum == -1 || !stackWalker->GetCachedInternalFrameInfo().codeAddress) ? physicalFrame.GetFrame() : stackWalker->GetCachedInternalFrameInfo().framePointer;
+        void *nativeCodeAddress = (loopNum == -1 || !stackWalker || !stackWalker->GetCachedInternalFrameInfo().codeAddress) ? physicalFrame.GetInstructionPointer() : stackWalker->GetCachedInternalFrameInfo().codeAddress;
+        void *framePointer = (loopNum == -1 || !stackWalker || !stackWalker->GetCachedInternalFrameInfo().codeAddress) ? physicalFrame.GetFrame() : stackWalker->GetCachedInternalFrameInfo().framePointer;
 
         if (loopNum != -1)
         {

--- a/lib/Runtime/Language/JavascriptStackWalker.cpp
+++ b/lib/Runtime/Language/JavascriptStackWalker.cpp
@@ -476,6 +476,10 @@ namespace Js
                     if (inlinedFramesOnStack)
                     {
                         inlinedFramesBeingWalked = inlinedFrameWalker.Next(inlinedFrameCallInfo);
+                        if (this->lastInternalFrameInfo.frameConsumed)
+                        {
+                            ClearCachedInternalFrameInfo();
+                        }
                         Assert(inlinedFramesBeingWalked);
                         Assert(StackScriptFunction::GetCurrentFunctionObject(this->interpreterFrame->GetJavascriptFunction()) == inlinedFrameWalker.GetFunctionObject());
                         // We're now back in the state where currentFrame == physical frame of the inliner, but

--- a/lib/Runtime/Library/StackScriptFunction.cpp
+++ b/lib/Runtime/Library/StackScriptFunction.cpp
@@ -240,7 +240,7 @@ namespace Js
                         this->UpdateFrameDisplay(stackFunction);
                     }
 
-                    if (walker.IsBailedOutFromInlinee())
+                    if (walker.IsBailedOutFromInlinee() && !walker.IsCurrentPhysicalFrameForLoopBody())
                     {
                         // this is the interpret frame from bailing out of inline frame
                         // Just mark we have inlinee to box so we will walk the native frame's list when we get there.


### PR DESCRIPTION
Fix a stack walker bug with loop bodies

Fix places where we should be using the current frame's instruction
pointer instead of the cached last internal frames's instruction pointer
