### PR TITLE
add jenkins support for .wasm files

### DIFF
--- a/jenkins.check_copyright.sh
+++ b/jenkins.check_copyright.sh
@@ -26,6 +26,7 @@ git diff --name-only `git merge-base origin/master HEAD` HEAD |
     grep -v -E '\.txt$' |
     grep -v -E '\.baseline$' |
     grep -v -E '\.sln$' |
+    grep -v -E '\.wasm$' |
     grep -v -E '\.vcxproj$' |
     grep -v -E '\.filters$' |
     grep -v -E '\.targets$' |

--- a/jenkins.check_eol.sh
+++ b/jenkins.check_eol.sh
@@ -15,7 +15,7 @@ fi
 ERRFILE=jenkins.check_eol.sh.err
 rm -f $ERRFILE
 
-git diff --name-only `git merge-base origin/master HEAD` HEAD | grep -v -E "(test/.*\\.js|\\.cmd|\\.baseline)" | xargs -I % ./jenkins.check_file_eol.sh %
+git diff --name-only `git merge-base origin/master HEAD` HEAD | grep -v -E "(test/.*\\.js|\\.cmd|\\.wasm|\\.baseline)" | xargs -I % ./jenkins.check_file_eol.sh %
 
 if [ -e $ERRFILE ]; then # if error file exists then there were errors
     >&2 echo "--------------" # leading >&2 means echo to stderr


### PR DESCRIPTION
add jenkins support for .wasm files. Note, that this is the binary format for WebAssembly, and we have a couple of these files in the wasm branch. This is causing test failures in #60 
