### PR TITLE
Disable recently enabled inlining in jitted loop bodies till the issues around stackwalker get fixed

### DIFF
--- a/lib/Backend/Encoder.cpp
+++ b/lib/Backend/Encoder.cpp
@@ -592,7 +592,7 @@ void Encoder::RecordInlineeFrame(Func* inlinee, uint32 currentOffset)
 {
     // The only restriction for not supporting loop bodies is that inlinee frame map is created on FunctionEntryPointInfo & not
     // the base class EntryPointInfo.
-    if (!this->m_func->IsSimpleJit())
+    if (!this->m_func->IsLoopBody() && !this->m_func->IsSimpleJit())
     {
         InlineeFrameRecord* record = nullptr;
         if (inlinee->frameInfo && inlinee->m_hasInlineArgsOpt)

--- a/lib/Backend/Func.cpp
+++ b/lib/Backend/Func.cpp
@@ -138,14 +138,14 @@ Func::Func(JitArenaAllocator *alloc, CodeGenWorkItem* workItem, const Js::Functi
         m_workItem->GetEntryPoint()->SetHasJittedStackClosure();
     }
 
-    if (m_jnFunction->GetDoBackendArgumentsOptimization() && !m_jnFunction->GetHasTry())
-    {
-        // doBackendArgumentsOptimization bit is set when there is no eval inside a function
-        // as determined by the bytecode generator.
-        SetHasStackArgs(true);
-    }
     if (m_workItem->Type() == JsFunctionType)
     {
+        if (m_jnFunction->GetDoBackendArgumentsOptimization() && !m_jnFunction->GetHasTry())
+        {
+            // doBackendArgumentsOptimization bit is set when there is no eval inside a function
+            // as determined by the bytecode generator.
+            SetHasStackArgs(true);
+        }
         if (doStackNestedFunc && m_jnFunction->GetNestedCount() != 0)
         {
             Assert(!(this->IsJitInDebugMode() && !m_jnFunction->GetUtf8SourceInfo()->GetIsLibraryCode()));

--- a/lib/Backend/InliningDecider.cpp
+++ b/lib/Backend/InliningDecider.cpp
@@ -190,7 +190,7 @@ Js::FunctionInfo *InliningDecider::Inline(Js::FunctionBody *const inliner, Js::F
     Js::FunctionProxy * proxy = functionInfo->GetFunctionProxy();
     if (proxy && proxy->IsFunctionBody())
     {
-        if (isLoopBody && PHASE_OFF(Js::InlineInJitLoopBodyPhase, this->topFunc))
+        if (isLoopBody && !PHASE_ON(Js::InlineInJitLoopBodyPhase, this->topFunc))
         {
             INLINE_TESTTRACE_VERBOSE(L"INLINING: Skip Inline: Jit loop body: %s (%s)\n", this->topFunc->GetDisplayName(),
                 this->topFunc->GetDebugNumberSet(debugStringBuffer));

--- a/lib/Backend/NativeCodeGenerator.cpp
+++ b/lib/Backend/NativeCodeGenerator.cpp
@@ -1708,6 +1708,7 @@ NativeCodeGenerator::GatherCodeGenData(
     Assert(functionBody);
     Assert(jitTimeData);
     Assert(IsInlinee == !!runtimeData);
+    Assert(!IsInlinee || !inliningDecider.GetIsLoopBody());
     Assert(topFunctionBody != nullptr && (!entryPoint->GetWorkItem() || entryPoint->GetWorkItem()->GetFunctionBody() == topFunctionBody));
     Assert(objTypeSpecFldInfoList != nullptr);
 

--- a/test/Optimizer/test143.baseline
+++ b/test/Optimizer/test143.baseline
@@ -5,5 +5,7 @@ Testtrace: ArrayCheckHoist function test0 ( (#1.1), #2): Separating array checks
 Testtrace: ArrayCheckHoist function test0 ( (#1.1), #2): Hoisting array checks with bailout out of loop
 Testtrace: ArrayCheckHoist function test0 ( (#1.1), #2): Eliminating array checks
 Testtrace: ArrayCheckHoist function test0 ( (#1.1), #2): Separating array checks with bailout
+Testtrace: ArrayCheckHoist function test0 ( (#1.1), #2): Eliminating array checks
+Testtrace: ArrayCheckHoist function test0 ( (#1.1), #2): Separating array checks with bailout
 Testtrace: ArrayCheckHoist function test0 ( (#1.1), #2): Hoisting array checks with bailout out of loop
 Testtrace: ArrayCheckHoist function test0 ( (#1.1), #2): Eliminating array checks


### PR DESCRIPTION
Inlining in jitted loop bodies has presented us with a host of issues to look at. Disabling it for now as I work through the bugs.
