### PR TITLE
Fix -Wextra-tokens warnings.

### DIFF
--- a/lib/Parser/idiom.h
+++ b/lib/Parser/idiom.h
@@ -111,4 +111,4 @@
 #define ARG_POINTER(p) do { if (NULL == (p)) return E_INVALIDARG; } while (0)
 #endif
 
-#endif __IDIOM_H__
+#endif // __IDIOM_H__

--- a/lib/Runtime/Base/ScriptMemoryDumper.cpp
+++ b/lib/Runtime/Base/ScriptMemoryDumper.cpp
@@ -224,4 +224,4 @@ void ScriptMemoryDumper::FillObjectWithStats(Js::DynamicObject* dynamicObject, H
     dynamicObject->SetProperty(finalizeCountId, Js::JavascriptNumber::New(stats.finalizeCount, scriptContext),  Js::PropertyOperation_None, NULL);
 }
 
-#endif ENABLE_DEBUG_CONFIG_OPTIONS
+#endif // ENABLE_DEBUG_CONFIG_OPTIONS

--- a/lib/Runtime/Language/JavascriptStackWalker.cpp
+++ b/lib/Runtime/Language/JavascriptStackWalker.cpp
@@ -284,7 +284,7 @@ namespace Js
             return inlinedFrameWalker.GetArgv(/* includeThis = */ false);
         }
         else 
-#endif            
+#endif
             if (this->GetCurrentFunction()->GetFunctionInfo()->IsGenerator())
         {
             JavascriptGenerator* gen = JavascriptGenerator::FromVar(this->GetCurrentArgv()[JavascriptFunctionArgIndex_This]);

--- a/lib/common/ConfigFlagsList.h
+++ b/lib/common/ConfigFlagsList.h
@@ -1111,8 +1111,8 @@ FLAGNR(Number,  InMemoryTraceBufferSize, "The size of circular buffer for in-mem
 FLAGNR(Boolean, RichTraceFormat, "Whether to use extra data in Output/Trace header.", DEFAULT_CONFIG_RichTraceFormat)
 #ifdef STACK_BACK_TRACE
 FLAGNR(Boolean, TraceWithStack, "Whether the trace need to include stack trace (for each trace entry).", DEFAULT_CONFIG_TraceWithStack)
-#endif STACK_BACK_TRACE
-#endif ENABLE_TRACE
+#endif // STACK_BACK_TRACE
+#endif // ENABLE_TRACE
 FLAGNR(Boolean, PrintRunTimeDataCollectionTrace, "Print traces needed for runtime data collection", false)
 #ifdef ENABLE_PREJIT
 FLAGR (Boolean, Prejit                , "Prejit everything, including things that are not called, ignoring limits (default: false)", DEFAULT_CONFIG_Prejit)

--- a/lib/common/Memory/HeapAllocator.cpp
+++ b/lib/common/Memory/HeapAllocator.cpp
@@ -182,7 +182,7 @@ bool HeapAllocator::CheckLeaks()
 {
     return Instance.data.CheckLeaks();
 }
-#endif HEAP_TRACK_ALLOC
+#endif // HEAP_TRACK_ALLOC
 
 char * NoThrowHeapAllocator::AllocZero(size_t byteSize)
 {
@@ -205,14 +205,14 @@ NoThrowHeapAllocator * NoThrowHeapAllocator::TrackAllocInfo(TrackAllocData const
     HeapAllocator::Instance.TrackAllocInfo(data);
     return this;
 }
-#endif TRACK_ALLOC
+#endif // TRACK_ALLOC
 
 #ifdef TRACK_ALLOC
 void NoThrowHeapAllocator::ClearTrackAllocInfo(TrackAllocData* data /*= NULL*/)
 {
     HeapAllocator::Instance.ClearTrackAllocInfo(data);
 }
-#endif TRACK_ALLOC
+#endif // TRACK_ALLOC
 
 HeapAllocator * HeapAllocator::GetNoMemProtectInstance()
 {
@@ -293,14 +293,14 @@ NoThrowNoMemProtectHeapAllocator * NoThrowNoMemProtectHeapAllocator::TrackAllocI
     HeapAllocator::GetNoMemProtectInstance()->TrackAllocInfo(data);
     return this;
 }
-#endif TRACK_ALLOC
+#endif // TRACK_ALLOC
 
 #ifdef TRACK_ALLOC
 void NoThrowNoMemProtectHeapAllocator::ClearTrackAllocInfo(TrackAllocData* data /*= NULL*/)
 {
     HeapAllocator::GetNoMemProtectInstance()->ClearTrackAllocInfo(data);
 }
-#endif TRACK_ALLOC
+#endif // TRACK_ALLOC
 #endif
 
 #if defined(HEAP_TRACK_ALLOC) || defined(INTERNAL_MEM_PROTECT_HEAP_ALLOC)

--- a/lib/common/Memory/MemoryLogger.cpp
+++ b/lib/common/Memory/MemoryLogger.cpp
@@ -99,6 +99,6 @@ namespace Js
     }
 
     __declspec(thread) StackBackTrace* StackTraceHelper::s_stackBackTrace = nullptr;
-#endif STACK_BACK_TRACE
+#endif // STACK_BACK_TRACE
 }
-#endif ENABLE_TRACE
+#endif // ENABLE_TRACE

--- a/lib/common/Memory/MemoryLogger.h
+++ b/lib/common/Memory/MemoryLogger.h
@@ -46,6 +46,6 @@ namespace Js
         StackTraceHelper(TAllocator* alloc) : m_alloc(alloc) {}
         void Print();
     };
-#endif STACK_BACK_TRACE
+#endif // STACK_BACK_TRACE
 } // namespace Js.
-#endif ENABLE_TRACE
+#endif // ENABLE_TRACE

--- a/lib/common/common/vtinfo.inl
+++ b/lib/common/common/vtinfo.inl
@@ -28,4 +28,4 @@ inline INT_PTR VirtualTableInfo<T>::RegisterVirtualTable(INT_PTR vtable)
 {
     return vtable;
 }
-#endif DBG
+#endif // DBG

--- a/lib/common/core/ConfigParser.cpp
+++ b/lib/common/core/ConfigParser.cpp
@@ -415,8 +415,8 @@ void ConfigParser::ProcessConfiguration(HANDLE hmod)
     {
         Output::SetStackTraceHelper(Js::StackTraceHelper::Create(::GetOutputAllocator2()));
     }
-#endif STACK_BACK_TRACE
-#endif ENABLE_TRACE
+#endif // STACK_BACK_TRACE
+#endif // ENABLE_TRACE
 
     if (hasOutput)
     {

--- a/lib/common/core/Output.cpp
+++ b/lib/common/core/Output.cpp
@@ -211,7 +211,7 @@ Output::TraceStats(Js::Phase phase, const wchar_t *form, ...)
     return 0;
 }
 #endif
-#endif ENABLE_TRACE
+#endif // ENABLE_TRACE
 
 ///----------------------------------------------------------------------------
 ///
@@ -474,7 +474,7 @@ Output::SetStackTraceHelper(Js::IStackTraceHelper* helper)
 #endif
     s_stackTraceHelper = helper;
 }
-#endif ENABLE_TRACE
+#endif // ENABLE_TRACE
 
 //
 // Sets the foreground color and returns the old color. Returns 0 on failure

--- a/lib/common/core/Output.h
+++ b/lib/common/core/Output.h
@@ -88,7 +88,7 @@ public:
     }
     static void     SetInMemoryLogger(Js::ILogger* logger);
     static void     SetStackTraceHelper(Js::IStackTraceHelper* helper);
-#endif ENABLE_TRACE
+#endif // ENABLE_TRACE
     static size_t __cdecl Print(const wchar_t *form, ...);
     static size_t __cdecl Print(int column, const wchar_t *form, ...);
     static size_t __cdecl PrintBuffer(const wchar_t * buffer, size_t size);
@@ -119,7 +119,7 @@ private:
     static Js::IStackTraceHelper* s_stackTraceHelper; // Used for capturing stack trace.
 #endif
     static size_t VTrace(const wchar_t* shortPrefixFormat, const wchar_t* prefix, const wchar_t *form, va_list argptr);
-#endif ENABLE_TRACE
+#endif // ENABLE_TRACE
 
 #define THREAD_ST __declspec(thread)
 


### PR DESCRIPTION
Extra tokens after an #endif result in a warning with clang:

  warning: extra tokens at end of #endif directive [-Wextra-tokens]

Convert all such usages to ones that comment out the extra tokens.