### PR TITLE
Improve ch.exe error message for Release build

### DIFF
--- a/bin/ch/chakrartinterface.cpp
+++ b/bin/ch/chakrartinterface.cpp
@@ -45,7 +45,7 @@ HINSTANCE ChakraRTInterface::LoadChakraDll(ArgInfo& argInfo)
 
     if (!m_testHooksInitialized)
     {
-        fwprintf(stderr, L"The binary %ls is not test enabled, please use %ls from debug/test flavor\n", chakraDllName, chakraDllName);
+        fwprintf(stderr, L"ch.exe does not work with Release builds of '%ls'. Please use Debug or Test builds to use ch.exe.\n", chakraDllName);
         UnloadChakraDll(library);
         return nullptr;
     }


### PR DESCRIPTION
Fixes #90

ch.exe does not currently work with Release builds of ChakraCore.dll.
Existing error message was not clear on this.  Improve the error message
to hopefully be more clear on what is wrong and what to do about it.