### PR TITLE
MSEdge developer blog link -- http to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ChakraCore is the core part of Chakra, the high-performance JavaScript engine that powers Microsoft Edge and Windows applications written in HTML/CSS/JS.  ChakraCore supports Just-in-time (JIT) compilation of JavaScript for x86/x64/ARM, garbage collection, and a wide range of the latest JavaScript features.  ChakraCore also supports the [JavaScript Runtime (JSRT) APIs](https://github.com/Microsoft/ChakraCore/wiki/JavaScript-Runtime-%28JSRT%29-Overview), which allows you to easily embed ChakraCore in your applications.
 
-You can stay up-to-date on progress by following the [MSEdge developer blog](http://blogs.windows.com/msedgedev/).
+You can stay up-to-date on progress by following the [MSEdge developer blog](https://blogs.windows.com/msedgedev/).
 
 ## [Build Status](https://github.com/Microsoft/ChakraCore/wiki/Build-Status)
 


### PR DESCRIPTION
Change http://blogs.windows.com/msedgedev/ to https://blogs.windows.com/msedgedev/ to avoid the need of a redirect.