### PR TITLE
SIMD alignment in ASM.js interpreter. 

### DIFF
--- a/lib/Runtime/Language/AsmJSModule.cpp
+++ b/lib/Runtime/Language/AsmJSModule.cpp
@@ -93,7 +93,9 @@ namespace Js
             if (IsSimdjsEnabled())
             {
                 const auto& simdRegisterSpace = func->GetRegisterSpace<AsmJsSIMDValue>();
-                varCount += (int)(simdRegisterSpace.GetTotalVarCount() * SIMD_SLOTS_SPACE);
+                varCount += (int)((simdRegisterSpace.GetTotalVarCount() + 1) * SIMD_SLOTS_SPACE); /* + 1 to make room for possible alignment of SIMD values*/
+                // Aligned SIMD values.
+                Assert(asmInfo->GetSimdByteOffset() % sizeof(AsmJsSIMDValue) == 0);
             }
 
             functionBody->SetOutParamDepth(func->GetMaxArgOutDepth());
@@ -2005,13 +2007,14 @@ namespace Js
 
         if (IsSimdjsEnabled())
         {
+            // mSimdOffset is in SIMDValues, hence aligned
+            // mMemorySize is in Vars
             mModuleMemory.mSimdOffset = (int) ::ceil(mModuleMemory.mMemorySize / SIMD_SLOTS_SPACE);
             if (mSimdVarSpace.GetTotalVarCount())
             {
                 mModuleMemory.mMemorySize = (int)((mModuleMemory.mSimdOffset + mSimdVarSpace.GetTotalVarCount()) * SIMD_SLOTS_SPACE);
-                // no alignment
-                // mModuleMemory.mMemorySize += (int)SIMD_SLOTS_SPACE;
             }
+            
         }
     }
 

--- a/lib/Runtime/Language/AsmJSTypes.cpp
+++ b/lib/Runtime/Language/AsmJSTypes.cpp
@@ -927,12 +927,13 @@ namespace Js
         // Offset of doubles from (double*)m_localSlot
         mDoubleByteOffset = (doubleOffset32bitsFix *sizeof(int));
 
+        // SIMD_JS
+        const int totalDoubleCount = mDoubleConstCount + mDoubleVarCount + mDoubleTmpCount;
+        mSimdByteOffset = mDoubleByteOffset + totalDoubleCount * sizeof(double);
+        // Alignment
+        mSimdByteOffset = ::Math::Align<int>((int)mSimdByteOffset, sizeof(AsmJsSIMDValue));
+        
 
-        if (isSimdjsEnabled)
-        {
-            const int totalDoubleCount = mDoubleConstCount + mDoubleVarCount + mDoubleTmpCount;
-            mSimdByteOffset = mDoubleByteOffset + totalDoubleCount * sizeof(double);
-        }
 
         if (PHASE_TRACE1(AsmjsInterpreterStackPhase))
         {
@@ -956,10 +957,12 @@ namespace Js
 
     int AsmJsFunctionInfo::GetTotalSizeinBytes() const
     {
-        int size = mDoubleByteOffset + (mDoubleConstCount + mDoubleVarCount + mDoubleTmpCount) * sizeof(double);
+        int size;
 
-        // SimdJs values
-        size += GetSimdAllCount()* sizeof(AsmJsSIMDValue);
+        // SIMD values are aligned
+        Assert(mSimdByteOffset % sizeof(AsmJsSIMDValue) == 0);
+        size = mSimdByteOffset + GetSimdAllCount()* sizeof(AsmJsSIMDValue);
+        
         return size;
     }
 

--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -2315,15 +2315,6 @@ namespace Js
         {
             localSimdSlots = ((AsmJsSIMDValue*)moduleMemoryPtr) + moduleMemory.mSimdOffset; // simdOffset is in SIMDValues
         }
-#if 0
-        // Align SIMD regs to 128 bits.
-        // We only have space to align if there are any SIMD variables. Otherwise, leave unaligned.
-        if (info->GetSimdRegCount())
-        {
-            AssertMsg((moduleMemory.mMemorySize / SIMD_SLOTS_SPACE) - moduleMemory.mSimdOffset >= 1, "Not enough space in module memory to align SIMD vars");
-            localSimdSlots = (AsmJsSIMDValue*)::Math::Align<int>((int)localSimdSlots, sizeof(AsmJsSIMDValue));
-        }
-#endif
 
         ThreadContext* threadContext = this->scriptContext->GetThreadContext();
         *stdLibPtr = (m_inSlotsCount > 1) ? m_inParams[1] : nullptr;


### PR DESCRIPTION
Fixes AV when compiling with Dev'12. It aligns SIMD values in Interpreter stack frame, and module env memory for Asm.js
