### PR TITLE
Fix 'jenkins.testone.cmd ... -disablejit' path to use the correct _BinDir. Unblocks ref #114.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.user
 *.i
 Build/VCBuild/
+Build/VCBuild.NoJIT/
 Build/ipch/
 Build/.vs/
 build_*.log

--- a/test/jenkins.parsetestargs.cmd
+++ b/test/jenkins.parsetestargs.cmd
@@ -51,6 +51,11 @@ if not "%1"=="" (
         goto :ContinueArgParse
     )
 
+    if "%1"=="-disablejit" (
+        set _NoJIT=.NoJIT
+        REM fallthrough to default (also add this to %_ExtraTestArgs%)
+    )
+
     :: default
     set _ExtraTestArgs=%_ExtraTestArgs% %1
     shift

--- a/test/jenkins.testone.cmd
+++ b/test/jenkins.testone.cmd
@@ -29,7 +29,6 @@
 setlocal
 
 set _RootDir=%~dp0..
-set _BinDir=%_RootDir%\Build\VcBuild\bin
 set _HadFailures=0
 
 :: ============================================================================
@@ -48,6 +47,7 @@ set _HadFailures=0
   call jenkins.parsetestargs.cmd %*
   set _LogDir=%_TestDir%\logs\%_TestArch%_%_TestType%
   set _TestArgs=%_TestArch%%_TestType%
+  set _BinDir=%_RootDir%\Build\VcBuild%_NoJIT%\bin
 
   call :doSilent rd /s/q %_LogDir%
 


### PR DESCRIPTION
Fix 'jenkins.testone.cmd ... -disablejit' path to use the correct _BinDir. Unblocks ref #114.
