### PR TITLE
Fix max length condition + prevent assert crash

### DIFF
--- a/lib/jsrt/JsrtSourceHolder.cpp
+++ b/lib/jsrt/JsrtSourceHolder.cpp
@@ -33,8 +33,10 @@ namespace Js
             Js::JavascriptError::ThrowOutOfMemoryError(nullptr);
         }
 
-        size_t cbUtf8Buffer = (length + 1) * 3;
-        if (cbUtf8Buffer > UINT_MAX)
+        // `length` should not be bigger than MAXLONG 
+        // UINT_MAX / 3 < MAXLONG
+        size_t cbUtf8Buffer = ((UINT_MAX / 3) - 1 > length) ? (length + 1) * 3 : UINT_MAX;
+        if (cbUtf8Buffer >= UINT_MAX)
         {
             Js::JavascriptError::ThrowOutOfMemoryError(nullptr);
         }
@@ -49,7 +51,6 @@ namespace Js
             *utf8Script = HeapNewArray(utf8char_t, cbUtf8Buffer);
         }
 
-        Assert(length < MAXLONG);
         *utf8Length = utf8::EncodeIntoAndNullTerminate(*utf8Script, script, static_cast<charcount_t>(length));
         *scriptLength = length;
 


### PR DESCRIPTION
1 - `UINT_MAX/3 < MAXLONG`
2 - x86/? max `size_t` == UINT_MAX

Current `if` statement wouldn’t work for x86/? arch. Perhaps it wasn’t
an issue thanks to following `assert`.

So, success of `if` statement prevents the necessity for following
`Assert`. As a result, application would throw instead of `assert`
crash.