### PR TITLE
Remark on JsCallFunction - need thisArg as first argument

### DIFF
--- a/lib/jsrt/chakracommon.h
+++ b/lib/jsrt/chakracommon.h
@@ -2192,6 +2192,7 @@
     ///     Invokes a function.
     /// </summary>
     /// <remarks>
+    ///     Requires thisArg as first argument of arguments. 
     ///     Requires an active script context.
     /// </remarks>
     /// <param name="function">The function to invoke.</param>


### PR DESCRIPTION
JsCallFunction emulates Function.prototype.call and requires thisArg as first argument, which people tend to miss.