### PR TITLE
Prevent double fclose()

### DIFF
--- a/lib/common/core/AutoFILE.h
+++ b/lib/common/core/AutoFILE.h
@@ -22,6 +22,7 @@ public:
         if (ptr != nullptr)
         {
             fclose(ptr);
+            ptr = nullptr;
         }
     }
 };


### PR DESCRIPTION
fclose() may be called twice for same ptr: in Close() and then in dror.