### PR TITLE
Fix helper paths for ceil/floor in asm.js

### DIFF
--- a/lib/Backend/JnHelperMethod.cpp
+++ b/lib/Backend/JnHelperMethod.cpp
@@ -173,20 +173,7 @@ DECLSPEC_GUARDIGNORE __declspec(noinline) void * const GetNonTableMethodAddress(
     //
     //  DllImport methods
     //
-#if defined(_M_X64)
-    case HelperDirectMath_FloorDb:
-        return (double(*)(double))floor;
-
-    case HelperDirectMath_FloorFlt:
-        return (float(*)(float))floor;
-
-    case HelperDirectMath_CeilDb:
-        return (double(*)(double))ceil;
-
-    case HelperDirectMath_CeilFlt:
-        return (float(*)(float))ceil;
-
-#elif defined(_M_IX86)
+#if defined(_M_IX86)
 
     case HelperDirectMath_Acos:
         return (double(*)(double))__libm_sse2_acos;
@@ -220,6 +207,18 @@ DECLSPEC_GUARDIGNORE __declspec(noinline) void * const GetNonTableMethodAddress(
     case HelperGuardCheckCall:
         return __guard_check_icall_fptr;
 #endif
+
+    case HelperDirectMath_FloorDb:
+        return (double(*)(double))floor;
+
+    case HelperDirectMath_FloorFlt:
+        return (float(*)(float))floor;
+
+    case HelperDirectMath_CeilDb:
+        return (double(*)(double))ceil;
+
+    case HelperDirectMath_CeilFlt:
+        return (float(*)(float))ceil;
 
     //
     // These are statically initialized to an import thunk, but let's keep them out of the table in case a new CRT changes this

--- a/lib/Backend/JnHelperMethodList.h
+++ b/lib/Backend/JnHelperMethodList.h
@@ -510,7 +510,6 @@ HELPERCALL_MATH(DirectMath_Random,  (double(*)(Js::ScriptContext*))Js::Javascrip
 // as dynamic initialization is require to load these addresses.  Use nullptr instead and handle these function in GetNonTableMethodAddress().
 //
 
-
 HELPERCALL(MemCmp, nullptr, 0)
 HELPERCALL(MemCpy, nullptr, 0)
 

--- a/lib/Backend/JnHelperMethodList.h
+++ b/lib/Backend/JnHelperMethodList.h
@@ -510,8 +510,14 @@ HELPERCALL_MATH(DirectMath_Random,  (double(*)(Js::ScriptContext*))Js::Javascrip
 // as dynamic initialization is require to load these addresses.  Use nullptr instead and handle these function in GetNonTableMethodAddress().
 //
 
+
 HELPERCALL(MemCmp, nullptr, 0)
 HELPERCALL(MemCpy, nullptr, 0)
+
+HELPERCALL(DirectMath_FloorDb, nullptr, 0)
+HELPERCALL(DirectMath_FloorFlt, nullptr, 0)
+HELPERCALL(DirectMath_CeilDb, nullptr, 0)
+HELPERCALL(DirectMath_CeilFlt, nullptr, 0)
 
 #ifdef _M_IX86
 HELPERCALL(DirectMath_Acos, nullptr, 0)
@@ -534,10 +540,6 @@ HELPERCALL(DirectMath_Exp, nullptr, 0)
 HELPERCALL(DirectMath_Log, nullptr, 0)
 HELPERCALL(DirectMath_Sin, nullptr, 0)
 HELPERCALL(DirectMath_Tan, nullptr, 0)
-HELPERCALL(DirectMath_FloorDb, nullptr, 0)
-HELPERCALL(DirectMath_FloorFlt, nullptr, 0)
-HELPERCALL(DirectMath_CeilDb, nullptr, 0)
-HELPERCALL(DirectMath_CeilFlt, nullptr, 0)
 #elif defined(_M_ARM32_OR_ARM64)
 // ARM is similar to AMD64 -- regular CRT calls as calling convention is already what we want -- args/result in VFP registers.
 HELPERCALL(DirectMath_Acos, nullptr, 0)

--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -597,20 +597,24 @@ Lowerer::LowerRange(IR::Instr *instrStart, IR::Instr *instrEnd, bool defaultDoFa
             break;
 
         case Js::OpCode::InlineMathFloor:
+#ifdef ASMJS_PLAT
             if (!AutoSystemInfo::Data.SSE4_1Available() && instr->m_func->GetJnFunction()->GetIsAsmjsMode())
             {
                 m_lowererMD.HelperCallForAsmMathBuiltin(instr, IR::HelperDirectMath_FloorFlt, IR::HelperDirectMath_FloorDb);
                 break;
             }
+#endif
             m_lowererMD.GenerateFastInlineBuiltInCall(instr, (IR::JnHelperMethod)0);
             break;
 
         case Js::OpCode::InlineMathCeil:
+#ifdef ASMJS_PLAT
             if (!AutoSystemInfo::Data.SSE4_1Available() && instr->m_func->GetJnFunction()->GetIsAsmjsMode())
             {
                 m_lowererMD.HelperCallForAsmMathBuiltin(instr, IR::HelperDirectMath_CeilFlt, IR::HelperDirectMath_CeilDb);
                 break;
             }
+#endif
             m_lowererMD.GenerateFastInlineBuiltInCall(instr, (IR::JnHelperMethod)0);
             break;
 

--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -597,24 +597,20 @@ Lowerer::LowerRange(IR::Instr *instrStart, IR::Instr *instrEnd, bool defaultDoFa
             break;
 
         case Js::OpCode::InlineMathFloor:
-#if _M_X64
             if (!AutoSystemInfo::Data.SSE4_1Available() && instr->m_func->GetJnFunction()->GetIsAsmjsMode())
             {
                 m_lowererMD.HelperCallForAsmMathBuiltin(instr, IR::HelperDirectMath_FloorFlt, IR::HelperDirectMath_FloorDb);
                 break;
             }
-#endif
             m_lowererMD.GenerateFastInlineBuiltInCall(instr, (IR::JnHelperMethod)0);
             break;
 
         case Js::OpCode::InlineMathCeil:
-#if _M_X64
             if (!AutoSystemInfo::Data.SSE4_1Available() && instr->m_func->GetJnFunction()->GetIsAsmjsMode())
             {
                 m_lowererMD.HelperCallForAsmMathBuiltin(instr, IR::HelperDirectMath_CeilFlt, IR::HelperDirectMath_CeilDb);
                 break;
             }
-#endif
             m_lowererMD.GenerateFastInlineBuiltInCall(instr, (IR::JnHelperMethod)0);
             break;
 

--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -597,7 +597,7 @@ Lowerer::LowerRange(IR::Instr *instrStart, IR::Instr *instrEnd, bool defaultDoFa
             break;
 
         case Js::OpCode::InlineMathFloor:
-#ifdef ASMJS_PLAT
+#if defined(ASMJS_PLAT) && (defined(_M_X64) || defined(_M_IX86))
             if (!AutoSystemInfo::Data.SSE4_1Available() && instr->m_func->GetJnFunction()->GetIsAsmjsMode())
             {
                 m_lowererMD.HelperCallForAsmMathBuiltin(instr, IR::HelperDirectMath_FloorFlt, IR::HelperDirectMath_FloorDb);
@@ -608,7 +608,7 @@ Lowerer::LowerRange(IR::Instr *instrStart, IR::Instr *instrEnd, bool defaultDoFa
             break;
 
         case Js::OpCode::InlineMathCeil:
-#ifdef ASMJS_PLAT
+#if defined(ASMJS_PLAT) && (defined(_M_X64) || defined(_M_IX86))
             if (!AutoSystemInfo::Data.SSE4_1Available() && instr->m_func->GetJnFunction()->GetIsAsmjsMode())
             {
                 m_lowererMD.HelperCallForAsmMathBuiltin(instr, IR::HelperDirectMath_CeilFlt, IR::HelperDirectMath_CeilDb);

--- a/lib/Backend/LowerMDShared.h
+++ b/lib/Backend/LowerMDShared.h
@@ -243,6 +243,7 @@ public:
             IR::Instr *         LowerCallPut(IR::Instr * callInstr);
             IR::Instr *         LoadHelperArgument(IR::Instr * instr, IR::Opnd * opndArg);
             IR::Instr *         LoadDoubleHelperArgument(IR::Instr * instr, IR::Opnd * opndArg);
+            IR::Instr *         LoadFloatHelperArgument(IR::Instr * instr, IR::Opnd * opndArg);
             IR::Instr *         LowerEntryInstr(IR::EntryInstr * entryInstr);
             IR::Instr *         LowerExitInstr(IR::ExitInstr * exitInstr);
             IR::Instr *         LowerEntryInstrAsmJs(IR::EntryInstr * entryInstr);

--- a/lib/Backend/amd64/LowererMDArch.cpp
+++ b/lib/Backend/amd64/LowererMDArch.cpp
@@ -1198,6 +1198,13 @@ LowererMDArch::LoadDoubleHelperArgument(IR::Instr * instrInsert, IR::Opnd * opnd
     return LoadHelperArgument(instrInsert, opndArg);
 }
 
+IR::Instr *
+LowererMDArch::LoadFloatHelperArgument(IR::Instr * instrInsert, IR::Opnd * opndArg)
+{
+    Assert(opndArg->IsFloat32());
+    return LoadHelperArgument(instrInsert, opndArg);
+}
+
 //
 // Emits the code to allocate 'size' amount of space on stack. for values smaller than PAGE_SIZE
 // this will just emit sub rsp,size otherwise calls _chkstk.

--- a/lib/Backend/amd64/LowererMDArch.h
+++ b/lib/Backend/amd64/LowererMDArch.h
@@ -77,6 +77,7 @@ public:
     IR::Instr *         LoadDynamicArgument(IR::Instr * instr, uint argNumber);
     IR::Instr *         LoadDynamicArgumentUsingLength(IR::Instr *instr);
     IR::Instr *         LoadDoubleHelperArgument(IR::Instr * instr, IR::Opnd * opndArg);
+    IR::Instr *         LoadFloatHelperArgument(IR::Instr * instr, IR::Opnd * opndArg);
     IR::Instr *         LoadStackArgPtr(IR::Instr * instr);
     IR::Instr *         LoadHeapArguments(IR::Instr * instr, bool force = false, IR::Opnd* opndInputParamCount = nullptr);
     IR::Instr *         LoadHeapArgsCached(IR::Instr * instr);

--- a/lib/Backend/arm/LowerMD.h
+++ b/lib/Backend/arm/LowerMD.h
@@ -114,6 +114,7 @@ public:
             void            GenerateFastBrS(IR::BranchInstr *brInstr);
             IR::IndirOpnd * GenerateFastElemIStringIndexCommon(IR::Instr * instr, bool isStore, IR::IndirOpnd *indirOpnd, IR::LabelInstr * labelHelper);
             void            GenerateFastInlineBuiltInCall(IR::Instr* instr, IR::JnHelperMethod helperMethod);
+            void            HelperCallForAsmMathBuiltin(IR::Instr* instr, IR::JnHelperMethod helperMethodFloat, IR::JnHelperMethod helperMethodDouble) { Assert(UNREACHED); } // only for asm.js
             IR::Opnd *      CreateStackArgumentsSlotOpnd();
             void            GenerateSmIntTest(IR::Opnd *opndSrc, IR::Instr *insertInstr, IR::LabelInstr *labelHelper, IR::Instr **instrFirst = nullptr, bool fContinueLabel = false);
             IR::RegOpnd *   LoadNonnegativeIndex(IR::RegOpnd *indexOpnd, const bool skipNegativeCheck, IR::LabelInstr *const notTaggedIntLabel, IR::LabelInstr *const negativeLabel, IR::Instr *const insertBeforeInstr);

--- a/lib/Backend/arm/LowerMD.h
+++ b/lib/Backend/arm/LowerMD.h
@@ -187,6 +187,7 @@ public:
             IR::Instr *         LoadDynamicArgument(IR::Instr * instr, uint argNumber = 1);
             IR::Instr *         LoadDynamicArgumentUsingLength(IR::Instr *instr);
             IR::Instr *         LoadDoubleHelperArgument(IR::Instr * instr, IR::Opnd * opndArg);
+            IR::Instr *         LoadFloatHelperArgument(IR::Instr * instr, IR::Opnd * opndArg) { Assert(UNREACHED); return nullptr; } // only used for asm.js right now
             IR::Instr *         LowerToFloat(IR::Instr *instr);
      static IR::BranchInstr *   LowerFloatCondBranch(IR::BranchInstr *instrBranch, bool ignoreNaN = false);
             void                ConvertFloatToInt32(IR::Opnd* intOpnd, IR::Opnd* floatOpnd, IR::LabelInstr * labelHelper, IR::LabelInstr * labelDone, IR::Instr * instInsert);

--- a/lib/Backend/arm64/LowerMD.h
+++ b/lib/Backend/arm64/LowerMD.h
@@ -109,6 +109,7 @@ public:
               void            GenerateFastBrS(IR::BranchInstr *brInstr) { __debugbreak(); }
               IR::IndirOpnd * GenerateFastElemIStringIndexCommon(IR::Instr * instr, bool isStore, IR::IndirOpnd *indirOpnd, IR::LabelInstr * labelHelper) { __debugbreak(); return 0; }
               void            GenerateFastInlineBuiltInCall(IR::Instr* instr, IR::JnHelperMethod helperMethod) { __debugbreak(); }
+              void            HelperCallForAsmMathBuiltin(IR::Instr* instr, IR::JnHelperMethod helperMethodFloat, IR::JnHelperMethod helperMethodDouble) { __debugbreak(); }
               IR::Opnd *      CreateStackArgumentsSlotOpnd() { __debugbreak(); return 0; }
               void            GenerateSmIntTest(IR::Opnd *opndSrc, IR::Instr *insertInstr, IR::LabelInstr *labelHelper, IR::Instr **instrFirst = nullptr, bool fContinueLabel = false) { __debugbreak(); }
               IR::RegOpnd *   LoadNonnegativeIndex(IR::RegOpnd *indexOpnd, const bool skipNegativeCheck, IR::LabelInstr *const notTaggedIntLabel, IR::LabelInstr *const negativeLabel, IR::Instr *const insertBeforeInstr) { __debugbreak(); return nullptr; }

--- a/lib/Backend/arm64/LowerMD.h
+++ b/lib/Backend/arm64/LowerMD.h
@@ -186,6 +186,7 @@ public:
               IR::Instr *         LoadDynamicArgument(IR::Instr * instr, uint argNumber = 1) { __debugbreak(); return 0; }
               IR::Instr *         LoadDynamicArgumentUsingLength(IR::Instr *instr) { __debugbreak(); return 0; }
               IR::Instr *         LoadDoubleHelperArgument(IR::Instr * instr, IR::Opnd * opndArg) { __debugbreak(); return 0; }
+              IR::Instr *         LoadFloatHelperArgument(IR::Instr * instr, IR::Opnd * opndArg) { __debugbreak(); return 0; }
               IR::Instr *         LowerToFloat(IR::Instr *instr) { __debugbreak(); return 0; }
        static IR::BranchInstr *   LowerFloatCondBranch(IR::BranchInstr *instrBranch, bool ignoreNaN = false) { __debugbreak(); return 0; }
               void                ConvertFloatToInt32(IR::Opnd* intOpnd, IR::Opnd* floatOpnd, IR::LabelInstr * labelHelper, IR::LabelInstr * labelDone, IR::Instr * instInsert) { __debugbreak(); }

--- a/lib/Backend/i386/LowererMDArch.cpp
+++ b/lib/Backend/i386/LowererMDArch.cpp
@@ -1156,7 +1156,7 @@ LowererMDArch::LowerCall(IR::Instr * callInstr, uint32 argCount, RegNum regNum)
 
             StackSym * newDstStackSym = StackSym::New(dstType, this->m_func);
 
-            Assert(dstType == TyMachDouble);
+            Assert(dstOpnd->IsFloat());
             this->m_func->StackAllocate(newDstStackSym, MachDouble);
 
             IR::SymOpnd * newDstOpnd = IR::SymOpnd::New(newDstStackSym, dstType, this->m_func);
@@ -1164,7 +1164,7 @@ LowererMDArch::LowerCall(IR::Instr * callInstr, uint32 argCount, RegNum regNum)
             floatPopInstr->SetDst(newDstOpnd);
             callInstr->InsertAfter(floatPopInstr);
 
-            movInstr = IR::Instr::New(Js::OpCode::MOVSD, oldDst, newDstOpnd, this->m_func);
+            movInstr = IR::Instr::New(assignOp, oldDst, newDstOpnd, this->m_func);
             floatPopInstr->InsertAfter(movInstr);
         }
         else
@@ -1368,6 +1368,26 @@ LowererMDArch::LoadDoubleHelperArgument(IR::Instr * instrInsert, IR::Opnd * opnd
         float64Opnd = opndArg;
     }
     instr = IR::Instr::New(Js::OpCode::MOVSD, opnd, float64Opnd, this->m_func);
+    instrInsert->InsertBefore(instr);
+    LowererMD::Legalize(instr);
+    return instrPrev;
+}
+
+IR::Instr *
+LowererMDArch::LoadFloatHelperArgument(IR::Instr * instrInsert, IR::Opnd * opndArg)
+{
+    IR::Instr * instrPrev;
+    IR::Instr * instr;
+    IR::Opnd * opnd;
+    IR::RegOpnd * espOpnd = IR::RegOpnd::New(nullptr, this->GetRegStackPointer(), TyMachReg, this->m_func);
+
+    opnd = IR::IndirOpnd::New(espOpnd, -4, TyMachReg, this->m_func);
+    instrPrev = IR::Instr::New(Js::OpCode::LEA, espOpnd, opnd, this->m_func);
+    instrInsert->InsertBefore(instrPrev);
+
+    opnd = IR::IndirOpnd::New(espOpnd, (int32)0, TyFloat32, this->m_func);
+
+    instr = IR::Instr::New(Js::OpCode::MOVSS, opnd, opndArg, this->m_func);
     instrInsert->InsertBefore(instr);
     LowererMD::Legalize(instr);
     return instrPrev;

--- a/lib/Backend/i386/LowererMDArch.cpp
+++ b/lib/Backend/i386/LowererMDArch.cpp
@@ -1157,7 +1157,7 @@ LowererMDArch::LowerCall(IR::Instr * callInstr, uint32 argCount, RegNum regNum)
             StackSym * newDstStackSym = StackSym::New(dstType, this->m_func);
 
             Assert(dstOpnd->IsFloat());
-            this->m_func->StackAllocate(newDstStackSym, MachDouble);
+            this->m_func->StackAllocate(newDstStackSym, TySize[dstType]);
 
             IR::SymOpnd * newDstOpnd = IR::SymOpnd::New(newDstStackSym, dstType, this->m_func);
 

--- a/lib/Backend/i386/LowererMDArch.h
+++ b/lib/Backend/i386/LowererMDArch.h
@@ -61,6 +61,7 @@ public:
             IR::Instr *         LoadHelperArgument(IR::Instr * instr, IR::Opnd * opndArg);
             IR::Instr *         LoadDynamicArgument(IR::Instr * instr, uint argNumber = 1);
             IR::Instr *         LoadDoubleHelperArgument(IR::Instr * instr, IR::Opnd * opndArg);
+            IR::Instr *         LoadFloatHelperArgument(IR::Instr * instr, IR::Opnd * opndArg);
             IR::Instr *         LoadStackArgPtr(IR::Instr * instr);
             IR::Instr *         LoadHeapArguments(IR::Instr * instr, bool force = false, IR::Opnd* opndInputParamCount = nullptr);
             IR::Instr *         LoadHeapArgsCached(IR::Instr * instr);


### PR DESCRIPTION
asm.js ceil/floor instructions are JIT incorrectly on x86 machines with SSE2 but without SSE4.1. There was previously a path for this, but only implemented on x64.
I have removed architecture specific nature and moved to use more standard APIs for emitting the call. I also added various asserts to catch this type of issue when using -sse switches without needing specific machine hardware.