### PR TITLE
CrossPlatform: Hide VirtualUnwind from not supported platforms

### DIFF
--- a/pal/inc/pal.h
+++ b/pal/inc/pal.h
@@ -3458,12 +3458,14 @@ PAL_GetLogicalProcessorCacheSizeFromOS();
 
 typedef BOOL (*ReadMemoryWordCallback)(SIZE_T address, SIZE_T *value);
 
+#if defined(_AMD64_) || defined(_ARM_) || defined(_ARM64_)
 PALIMPORT BOOL PALAPI PAL_VirtualUnwind(CONTEXT *context, KNONVOLATILE_CONTEXT_POINTERS *contextPointers);
 
 PALIMPORT BOOL PALAPI PAL_VirtualUnwindOutOfProc(CONTEXT *context, 
                                                  KNONVOLATILE_CONTEXT_POINTERS *contextPointers, 
                                                  DWORD pid, 
                                                  ReadMemoryWordCallback readMemCallback);
+#endif
 
 #define GetLogicalProcessorCacheSizeFromOS PAL_GetLogicalProcessorCacheSizeFromOS
 


### PR DESCRIPTION
`KNONVOLATILE_CONTEXT_POINTERS` is supported for X64, ARM, and ARM64 only. 

See also https://msdn.microsoft.com/en-us/library/windows/desktop/ms680617.aspx