### PR TITLE
Cross Platform: fix __int64 size + _Is_integral duplication

### DIFF
--- a/pal/inc/type_traits
+++ b/pal/inc/type_traits
@@ -334,6 +334,7 @@ namespace std
     };
  #endif /* _HAS_CHAR16_T_LANGUAGE_SUPPORT */
 
+#ifndef BIT64
     template<>
     struct _Is_integral<unsigned __int64>
         : true_type
@@ -345,6 +346,7 @@ namespace std
         : true_type
     {    // determine whether _Ty is integral
     };
+#endif
 
     // TEMPLATE CLASS is_integral
     template<class _Ty>


### PR DESCRIPTION
1 ) Under `pal/inc/pal_mstypes.h` `__int64` was defined as `long` for
BIT64 while it was `long long` for non-BIT64.. x86, ARM?

2 ) When it is set to `long` it was raising another issue that `struct
_Is_integral<unsigned __int64>` has duplicate definition.