### PR TITLE
Cross Platform (OSX/iOS): Do not redefine uintptr_t for __APPLE__

### DIFF
--- a/pal/inc/pal_mstypes.h
+++ b/pal/inc/pal_mstypes.h
@@ -596,15 +596,19 @@ typedef LONG_PTR LPARAM;
 
 #ifdef PAL_STDCPP_COMPAT
 
+#ifdef __APPLE__
+static_assert(sizeof(unsigned long) == sizeof(void*), "This platform is not supported");
+#else
 #ifdef BIT64
 typedef unsigned long int uintptr_t;
 #else // !BIT64
 typedef unsigned int uintptr_t;
 #endif // !BIT64
+#endif
 
 typedef char16_t WCHAR;
 
-#else // PAL_STDCPP_COMPAT
+#else // !PAL_STDCPP_COMPAT
 
 typedef wchar_t WCHAR;
 #if defined(__LINUX__) 


### PR DESCRIPTION
!!!Considering `PAL_STDCPP_COMPAT` is defined;

`uintptr_t` is a builtin supported type for OSX/iOS... So, when `PAL_STDCPP_COMPAT` is set without BIT64 (ARM, x86?), `uintptr_t` is defined as `unsigned int`. However it should be `unsigned long` for
OSX/iOS/WatchOS regardless from arch.

 In order to prevent the accidents in future, a separate `static_assert` is added.