### PR TITLE
toString() on ES6 class constructors returns class declaration or expression

### DIFF
--- a/lib/Parser/parse.cpp
+++ b/lib/Parser/parse.cpp
@@ -6404,6 +6404,11 @@ ParseNodePtr Parser::ParseClassDecl(BOOL isDeclaration, LPCOLESTR pNameHint, ulo
         }
     }
 
+    if (buildAST)
+    {
+        pnodeClass->ichLim = m_pscan->IchLimTok();
+    }
+
     if (!hasConstructor)
     {
         OUTPUT_TRACE_DEBUGONLY(Js::ES6VerboseFlag, L"Generating constructor (%s) : %s\n", GetParseType(), name ? name->Psz() : L"anonymous class");
@@ -6436,6 +6441,11 @@ ParseNodePtr Parser::ParseClassDecl(BOOL isDeclaration, LPCOLESTR pNameHint, ulo
 
     if (buildAST)
     {
+        pnodeConstructor->sxFnc.cbMin = pnodeClass->ichMin;
+        pnodeConstructor->sxFnc.cbLim = pnodeClass->ichLim;
+        pnodeConstructor->ichMin = pnodeClass->ichMin;
+        pnodeConstructor->ichLim = pnodeClass->ichLim;
+
         PopFuncBlockScope(ppnodeScopeSave, ppnodeExprScopeSave);
 
         pnodeClass->sxClass.pnodeDeclName = pnodeDeclName;

--- a/lib/Runtime/Base/FunctionInfo.h
+++ b/lib/Runtime/Base/FunctionInfo.h
@@ -31,7 +31,6 @@ namespace Js
             SuperReference                 = 0x00100,
             ClassMethod                    = 0x00200, // The function is a class method
             ClassConstructor               = 0x00400, // The function is a class constructor
-            DefaultConstructor             = 0x00800, // The function is a default class constructor
             Lambda                         = 0x01000,
             CapturesThis                   = 0x02000, // Only lambdas will set this; denotes whether the lambda referred to this, used by debugger
             Generator                      = 0x04000,
@@ -52,7 +51,6 @@ namespace Js
         bool IsLambda() const { return ((this->attributes & Lambda) != 0); }
         bool IsConstructor() const { return ((this->attributes & ErrorOnNew) == 0); }
         bool IsGenerator() const { return ((this->attributes & Generator) != 0); }
-        bool IsDefaultConstructor() const { return ((this->attributes & DefaultConstructor) != 0); }
         bool IsClassConstructor() const { return ((this->attributes & ClassConstructor) != 0); }
         bool IsClassMethod() const { return ((this->attributes & ClassMethod) != 0); }
         bool HasSuperReference() const { return ((this->attributes & SuperReference) != 0); }

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -1251,11 +1251,6 @@ FuncInfo * ByteCodeGenerator::StartBindFunction(const wchar_t *name, uint nameLe
             if (pnode->sxFnc.IsClassConstructor())
             {
                 attributes = (Js::FunctionInfo::Attributes)(attributes | Js::FunctionInfo::Attributes::ClassConstructor);
-
-                if (pnode->sxFnc.IsGeneratedDefault())
-                {
-                    attributes = (Js::FunctionInfo::Attributes)(attributes | Js::FunctionInfo::Attributes::DefaultConstructor);
-                }
             }
             else
             {

--- a/lib/Runtime/ByteCode/ByteCodeSerializer.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeSerializer.cpp
@@ -2031,14 +2031,13 @@ public:
         AssertMsg((function->GetAttributes() &
                 ~(FunctionInfo::Attributes::ErrorOnNew
                   | FunctionInfo::Attributes::SuperReference
-                  | FunctionInfo::Attributes::DefaultConstructor
                   | FunctionInfo::Attributes::Lambda
                   | FunctionInfo::Attributes::Async
                   | FunctionInfo::Attributes::CapturesThis
                   | FunctionInfo::Attributes::Generator
                   | FunctionInfo::Attributes::ClassConstructor
                   | FunctionInfo::Attributes::ClassMethod)) == 0,
-                "Only the ErrorOnNew|SuperReference|DefaultConstructor|Lambda|CapturesThis|Generator|ClassConstructor|Async|ClassMember attributes should be set on a serialized function");
+                "Only the ErrorOnNew|SuperReference|Lambda|CapturesThis|Generator|ClassConstructor|Async|ClassMember attributes should be set on a serialized function");
 
         PrependInt32(builder, L"Offset Into Source", sourceDiff);
         if (function->GetNestedCount() > 0)

--- a/lib/Runtime/Library/JavascriptGeneratorFunction.cpp
+++ b/lib/Runtime/Library/JavascriptGeneratorFunction.cpp
@@ -49,9 +49,6 @@ namespace Js
         ScriptContext* scriptContext = functionProxy->GetScriptContext();
 
         bool hasSuperReference = functionProxy->HasSuperReference();
-        bool isDefaultConstructor = functionProxy->IsDefaultConstructor();
-
-        AssertMsg(!isDefaultConstructor, "How is generator function is a default constructor?");
 
         GeneratorVirtualScriptFunction* scriptFunction = scriptContext->GetLibrary()->CreateGeneratorVirtualScriptFunction(functionProxy);
         scriptFunction->SetEnvironment(environment);

--- a/lib/Runtime/Library/ScriptFunction.h
+++ b/lib/Runtime/Library/ScriptFunction.h
@@ -34,10 +34,7 @@ namespace Js
         Var computedNameVar;
         bool hasInlineCaches;
         bool hasSuperReference;
-        bool isDefaultConstructor;
         bool isActiveScript;
-        static const wchar_t diagDefaultCtor[];
-        static const wchar_t diagDefaultExtendsCtor[];
 
         bool HasFunctionBody();
         Var FormatToString(JavascriptString* inputString);
@@ -88,9 +85,6 @@ namespace Js
         bool HasSuperReference() { return hasSuperReference; }
         void SetHasSuperReference(bool has) { hasSuperReference = has; }
 
-        bool IsDefaultConstructor() { return isDefaultConstructor; }
-        void SetIsDefaultConstructor(bool has) { isDefaultConstructor = has; }
-
         void SetIsActiveScript(bool is) { isActiveScript = is; }
 
         virtual Var GetHomeObj() const override { return homeObj; }
@@ -101,7 +95,6 @@ namespace Js
         virtual JavascriptString* GetDisplayNameImpl() const;
         JavascriptString* GetComputedName() const;
         virtual bool IsAnonymousFunction() const override;
-        virtual BOOL GetDiagValueString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext) override;
 
         virtual JavascriptFunction* GetRealFunctionObject() { return this; }
     };

--- a/lib/Runtime/RuntimeCommon.h
+++ b/lib/Runtime/RuntimeCommon.h
@@ -222,9 +222,5 @@ namespace JSON
 #define JS_DIAG_VALUE_JavascriptRegExpConstructor   L"{...}"
 #define JS_DIAG_TYPE_JavascriptRegExpConstructor    L"Object, (RegExp constructor)"
 
-#define JS_DEFAULT_CTOR_DISPLAY_STRING              L"constructor() {}"
-#define JS_DEFAULT_EXTENDS_CTOR_DISPLAY_STRING      L"constructor(...args) { super(...args); }"
-
-
 #include "Language\SIMDUtils.h"
 

--- a/test/es6/classes.baseline
+++ b/test/es6/classes.baseline
@@ -95,4 +95,6 @@ PASSED
 PASSED
 *** Running test #30 (29): Classes with caller/arguments methods
 PASSED
-Summary of tests: total executed: 30; passed: 30; failed: 0
+*** Running test #31 (30): toString on constructor should return class declaration or expression
+PASSED
+Summary of tests: total executed: 31; passed: 31; failed: 0

--- a/test/es6/classes.js
+++ b/test/es6/classes.js
@@ -568,8 +568,8 @@ var tests = [
       class a { };
       class b extends a { };
 
-      assert.areEqual("constructor() {}", a.prototype.constructor.toString());
-      assert.areEqual("constructor(...args) { super(...args); }", b.prototype.constructor.toString());
+      assert.areEqual("class a { }", a.prototype.constructor.toString());
+      assert.areEqual("class b extends a { }", b.prototype.constructor.toString());
 
       var result = [];
       var test = [];
@@ -1021,7 +1021,26 @@ var tests = [
             for (s of new ClassWithArgumentsAndCallerComputedNameGeneratorMethods().caller()) {}
             assert.areEqual('456', s, "s of new ClassWithArgumentsAndCallerComputedNameGeneratorMethods().caller() === '456'");
         }
-    }
+    },
+    {
+        name: "toString on constructor should return class declaration or expression",
+        body: function () {
+            var B = class { };
+            var A = class A extends B { constructor (...args) { super(...args); }  set x(a) { this._x = a; } set y(a) { this._y = a; } };
+            class C {
+                set x(a) { this._x = a; }
+                set y(a) { this._y = a; }
+            };
+            class D { constructor() {}  get x() { return 0; } };
+            var E = D;
+
+            assert.areEqual("class A extends B { constructor (...args) { super(...args); }  set x(a) { this._x = a; } set y(a) { this._y = a; } }", A.prototype.constructor.toString());
+            assert.areEqual("class { }", B.prototype.constructor.toString());
+            assert.areEqual("class C {\r\n                set x(a) { this._x = a; }\r\n                set y(a) { this._y = a; }\r\n            }", C.prototype.constructor.toString());
+            assert.areEqual("class D { constructor() {}  get x() { return 0; } }", D.prototype.constructor.toString());
+            assert.areEqual("class D { constructor() {}  get x() { return 0; } }", E.prototype.constructor.toString());
+        }
+    },
 ];
 
 testRunner.runTests(tests);


### PR DESCRIPTION
toString() on ES6 class constructors returns class declaration or expression

The ES6 spec states at http://www.ecma-international.org/ecma-262/6.0/#sec-function.prototype.tostring:
If the object was defined using ECMAScript code and the returned string
representation is not in the form of a MethodDefinition or GeneratorMethod
then the representation must be such that if the string is evaluated, using
eval in a lexical context that is equivalent to the lexical context used to
create the original object, it will result in a new functionally equivalent
object.

This means ES6 class constructors, when toStringed, should return a string
in a form of either a ClassDeclaration or a ClassExpression.
