### PR TITLE
linux: builds lib/common/core

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ if(CLR_CMAKE_PLATFORM_UNIX)
     add_definitions("-stdlib=libc++")
     add_definitions(
         -DPAL_STDCPP_COMPAT=1
+        -DUNICODE
         -D_SAFECRT_USE_CPP_OVERLOADS=1
         )
 
@@ -67,6 +68,9 @@ if(CLR_CMAKE_PLATFORM_UNIX)
         -Wno-inconsistent-missing-override
         -Wno-c++14-extensions
         -Wno-macro-redefined
+        -Wno-ignored-pragmas
+        -Wno-invalid-token-paste
+        -Wno-format
     )
 endif(CLR_CMAKE_PLATFORM_UNIX)
 

--- a/lib/common/CommonDefines.h
+++ b/lib/common/CommonDefines.h
@@ -458,7 +458,9 @@
 #endif
 
 #if DBG || defined(CHECK_MEMORY_LEAK) || defined(LEAK_REPORT) || defined(TRACK_DISPATCH) || defined(ENABLE_TRACE) || defined(RECYCLER_PAGE_HEAP)
+#ifdef _WIN32
 #define STACK_BACK_TRACE
+#endif
 #endif
 
 #if defined(STACK_BACK_TRACE) || defined(CONTROL_FLOW_GUARD_LOGGER)

--- a/lib/common/CommonPal.h
+++ b/lib/common/CommonPal.h
@@ -32,6 +32,8 @@ typedef wchar_t wchar16;
 // xplat-todo: get a better name for this macro
 #define CH_WSTR(s) L##s
 
+#define get_cpuid __cpuid
+
 #else // !_WIN32
 
 #include "inc/pal.h"
@@ -40,6 +42,18 @@ typedef wchar_t wchar16;
 
 typedef char16_t wchar16;
 #define CH_WSTR(s) u##s
+
+// xplat-todo: verify below is correct
+#include <cpuid.h>
+inline int get_cpuid(int cpuInfo[4], int function_id)
+{
+    return __get_cpuid(
+            static_cast<unsigned int>(function_id),
+            reinterpret_cast<unsigned int*>(&cpuInfo[0]),
+            reinterpret_cast<unsigned int*>(&cpuInfo[1]),
+            reinterpret_cast<unsigned int*>(&cpuInfo[2]),
+            reinterpret_cast<unsigned int*>(&cpuInfo[3]));
+}
 
 #define _BitScanForward BitScanForward
 #define _BitScanForward64 BitScanForward64
@@ -57,16 +71,30 @@ typedef char16_t wchar16;
 #define __in    _SAL1_Source_(__in, (), _In_)
 #define __out   _SAL1_Source_(__out, (), _Out_)
 
-#define wcscmp        PAL_wcscmp
-#define wcslen        PAL_wcslen
-#define wcsncmp       PAL_wcsncmp
-#define wprintf       PAL_wprintf
+#define fclose          PAL_fclose
+#define fflush          PAL_fflush
+#define fwprintf        PAL_fwprintf
+#define wcschr          PAL_wcschr
+#define wcscmp          PAL_wcscmp
+#define wcslen          PAL_wcslen
+#define wcsncmp         PAL_wcsncmp
+#define wcsrchr         PAL_wcsrchr
+#define wcsstr          PAL_wcsstr
+#define wprintf         PAL_wprintf
+
+#define stdout          PAL_stdout
 #endif // PAL_STDCPP_COMPAT
 
-// wmemcmp not defined in pal
-#define wmemcmp       wcsncmp
-// sprintf_s overloaded in safecrt.h. Not sure why palrt.h redefines sprintf_s. 
+#define FILE PAL_FILE
+
+// These are not available in pal
+#define fwprintf_s      fwprintf
+#define wmemcmp         wcsncmp
+// sprintf_s overloaded in safecrt.h. Not sure why palrt.h redefines sprintf_s.
 #undef sprintf_s
+
+// PAL LoadLibraryExW not supported
+#define LOAD_LIBRARY_SEARCH_SYSTEM32 0
 
 // _countof
 #if defined _M_X64 || defined _M_ARM || defined _M_ARM64

--- a/lib/common/ConfigFlagsList.h
+++ b/lib/common/ConfigFlagsList.h
@@ -603,7 +603,7 @@ PHASE(All)
 #define DEFAULT_CONFIG_FixPropsOnPathTypes    (true)
 #define DEFAULT_CONFIG_BailoutTraceFilter (-1)
 #define DEFAULT_CONFIG_TempMin    (0)
-#define DEFAULT_CONFIG_TempMax    (MAXINT)
+#define DEFAULT_CONFIG_TempMax    (INT_MAX)
 
 #define DEFAULT_CONFIG_LibraryStackFrame            (true)
 #define DEFAULT_CONFIG_LibraryStackFrameDebugger    (false)

--- a/lib/common/DataStructures/BaseDictionary.h
+++ b/lib/common/DataStructures/BaseDictionary.h
@@ -792,7 +792,7 @@ namespace JsUtil
                 EntryType * localEntries = entries;
                 for (int i = localBuckets[targetBucket]; i >= 0; i = localEntries[i].next)
                 {
-                    if (localEntries[i].KeyEquals<Comparer<TKey>>(key, hashCode))
+                    if (localEntries[i].template KeyEquals<Comparer<TKey>>(key, hashCode))
                     {
 #if PROFILE_DICTIONARY
                         if (stats)
@@ -1391,7 +1391,7 @@ namespace JsUtil
         friend struct JsDiag::RemoteDictionary<BaseHashSet<TElement, TAllocator, SizePolicy, TKey, Comparer, Entry, Lock>>;
 
     public:
-        BaseHashSet(AllocatorType * allocator, int capacity = 0) : BaseDictionary(allocator, capacity) {}
+        BaseHashSet(AllocatorType * allocator, int capacity = 0) : Base(allocator, capacity) {}
 
         using Base::GetAllocator;
 

--- a/lib/common/DataStructures/DictionaryEntry.h
+++ b/lib/common/DataStructures/DictionaryEntry.h
@@ -95,7 +95,7 @@ namespace JsUtil
     class ImplicitKeyValueEntry : public ValueEntry<TValue>
     {
     public:
-        TKey Key() const { return ValueToKey<TKey, TValue>::ToKey(value); }
+        TKey Key() const { return ValueToKey<TKey, TValue>::ToKey(this->value); }
 
         void Set(TKey const& key, TValue const& value)
         {
@@ -152,13 +152,13 @@ namespace JsUtil
         template<typename Comparer, typename TLookup>
         __inline bool KeyEquals(TLookup const& otherKey, hash_t otherHashCode)
         {
-            return Comparer::Equals(Key(), otherKey);
+            return Comparer::Equals(this->Key(), otherKey);
         }
 
         template<typename Comparer>
         __inline hash_t GetHashCode()
         {
-            return ((Comparer::GetHashCode(Key()) & 0x7fffffff) << 1) | 1;
+            return ((Comparer::GetHashCode(this->Key()) & 0x7fffffff) << 1) | 1;
         }
 
         void Set(TKey const& key, TValue const& value, int hashCode)

--- a/lib/common/codex/Utf8Codex.h
+++ b/lib/common/codex/Utf8Codex.h
@@ -4,9 +4,9 @@
 //-------------------------------------------------------------------------------------------------------
 #pragma once
 #ifdef _WIN32
-typedef wchar_t wchar16;
 #include <windows.h>
 #include <wtypes.h>
+typedef wchar_t wchar16;
 #else
 typedef char16_t wchar16;
 

--- a/lib/common/core/CMakeLists.txt
+++ b/lib/common/core/CMakeLists.txt
@@ -1,22 +1,22 @@
 set (SOURCES
   BinaryFeatureControl.cpp
   CmdParser.cpp
-  # CodexAssert.cpp
-  # CommonCorePch.cpp
-  # ConfigFlagsTable.cpp
-  # ConfigParser.cpp
-  # DbgHelpSymbolManager.cpp
-  # DelayLoadLibrary.cpp
-  # EtwTraceCore.cpp
-  # FaultInjection.cpp
-  # Output.cpp
-  # PerfCounter.cpp
-  # PerfCounterImpl.cpp
-  # PerfCounterSet.cpp
-  # ProfileInstrument.cpp
-  # ProfileMemory.cpp
-  # StackBackTrace.cpp
-  # SysInfo.cpp  
+  CodexAssert.cpp
+  CommonCorePch.cpp
+  ConfigFlagsTable.cpp
+  ConfigParser.cpp
+  DbgHelpSymbolManager.cpp
+  DelayLoadLibrary.cpp
+  EtwTraceCore.cpp
+  FaultInjection.cpp
+  Output.cpp
+  PerfCounter.cpp
+  PerfCounterImpl.cpp
+  PerfCounterSet.cpp
+  ProfileInstrument.cpp
+  ProfileMemory.cpp
+  StackBackTrace.cpp
+  SysInfo.cpp
 )
 
 add_library (Chakra.Common.core

--- a/lib/common/core/ConfigFlagsTable.cpp
+++ b/lib/common/core/ConfigFlagsTable.cpp
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "CommonCorePch.h"
-#include "Memory\PageHeapBlockTypeFilter.h"
+#include "Memory/PageHeapBlockTypeFilter.h"
 
 #include <initguid.h>
 // {17DC713D-8B3E-4434-9DC8-90C275C75194}
@@ -99,7 +99,7 @@ namespace Js
         if(NULL != pszValue)
         {
             size_t size    = 1 + wcslen(pszValue);
-            this->pszValue  = NoCheckHeapNewArray(wchar_t, size);
+            this->pszValue  = NoCheckHeapNewArray(wchar16, size);
             wcscpy_s(this->pszValue, size, pszValue);
         }
         else
@@ -117,22 +117,22 @@ namespace Js
             (n.sourceContextId <= unit.j.sourceContextId)
             )
         {
-            if ((n.sourceContextId == unit.j.sourceContextId) && (-2 == unit.j.functionId) ||  //#.#-#.* case
-                (n.sourceContextId == unit.i.sourceContextId) && (-2 == unit.i.functionId)     //#.*-#.# case
+            if ((n.sourceContextId == unit.j.sourceContextId && -2 == unit.j.functionId) ||  //#.#-#.* case
+                (n.sourceContextId == unit.i.sourceContextId && -2 == unit.i.functionId)     //#.*-#.# case
                 )
             {
                 return true;
             }
 
-            if ((n.sourceContextId == unit.j.sourceContextId) && (-1 == unit.j.functionId) || //#.#-#.+ case
-                (n.sourceContextId == unit.i.sourceContextId) && (-1 == unit.i.functionId)     //#.+-#.# case
+            if ((n.sourceContextId == unit.j.sourceContextId && -1 == unit.j.functionId) || //#.#-#.+ case
+                (n.sourceContextId == unit.i.sourceContextId && -1 == unit.i.functionId)     //#.+-#.# case
                 )
             {
                 return n.functionId != 0;
             }
 
-            if (((n.sourceContextId == unit.i.sourceContextId) && (n.functionId < unit.i.functionId)) || //excludes all values less than functionId LHS
-                ((n.sourceContextId == unit.j.sourceContextId) && (n.functionId > unit.j.functionId))) ////excludes all values greater than functionId RHS
+            if ((n.sourceContextId == unit.i.sourceContextId && n.functionId < unit.i.functionId) || //excludes all values less than functionId LHS
+                (n.sourceContextId == unit.j.sourceContextId && n.functionId > unit.j.functionId)) ////excludes all values greater than functionId RHS
             {
                 return false;
             }
@@ -202,9 +202,9 @@ namespace Js
     // List of names of all the flags
     //
 
-    const wchar_t* const FlagNames[FlagCount + 1] =
+    const wchar16* const FlagNames[FlagCount + 1] =
     {
-    #define FLAG(type, name, ...) L## #name ,
+    #define FLAG(type, name, ...) CH_WSTR(#name),
     #include "ConfigFlagsList.h"
         NULL
     #undef FLAG
@@ -215,9 +215,9 @@ namespace Js
     // List of names of all the Phases
     //
 
-    const wchar_t* const PhaseNames[PhaseCount + 1] =
+    const wchar16* const PhaseNames[PhaseCount + 1] =
     {
-    #define PHASE(name) L## #name,
+    #define PHASE(name) CH_WSTR(#name),
     #include "ConfigFlagsList.h"
         NULL
     #undef PHASE
@@ -227,9 +227,9 @@ namespace Js
     //
     // Description of flags
     //
-    const wchar_t* const FlagDecriptions[FlagCount + 1] =
+    const wchar16* const FlagDecriptions[FlagCount + 1] =
     {
-    #define FLAG(type, name, description, ...) L##description,
+    #define FLAG(type, name, description, ...) CH_WSTR(description),
     #include "ConfigFlagsList.h"
         NULL
     #undef FLAG
@@ -895,26 +895,26 @@ namespace Js
 #define FLAG(type, name, ...) \
         if (IsEnabled(name##Flag)) \
         { \
-            Output::Print(L"-%s", L#name); \
+            Output::Print(CH_WSTR("-%s"), CH_WSTR(#name)); \
             switch (Flag##type) \
             { \
             case FlagBoolean: \
                 if (!*GetAsBoolean(name##Flag)) \
                 { \
-                    Output::Print(L"-"); \
+                    Output::Print(CH_WSTR("-")); \
                 } \
                 break; \
             case FlagString: \
                 if (GetAsString(name##Flag) != nullptr) \
                 { \
-                    Output::Print(L":%s", *GetAsString(name##Flag)); \
+                    Output::Print(CH_WSTR(":%s"), (LPCWSTR)*GetAsString(name##Flag)); \
                 } \
                 break; \
             case FlagNumber: \
-                Output::Print(L":%d", *GetAsNumber(name##Flag)); \
+                Output::Print(CH_WSTR(":%d"), *GetAsNumber(name##Flag)); \
                 break; \
             }; \
-            Output::Print(L"\n"); \
+            Output::Print(CH_WSTR("\n")); \
         }
 #include "ConfigFlagsList.h"
 #undef FLAG
@@ -1001,7 +1001,7 @@ namespace Js
         Boolean* settingAsBoolean = this->GetAsBoolean(flag);
         Assert(settingAsBoolean != nullptr);
 
-        Output::VerboseNote(L"FLAG %s = %d\n", FlagNames[(int) flag], value);
+        Output::VerboseNote(CH_WSTR("FLAG %s = %d\n"), FlagNames[(int) flag], value);
         *settingAsBoolean = value;
 
         // check if parent flag
@@ -1017,7 +1017,7 @@ namespace Js
                 // if the parent flag is FALSE, the children flag values are FALSE (always - as disabled)
                 Boolean childValue = value == TRUE ? childDefaultValue : FALSE;
 
-                Output::VerboseNote(L"FLAG %s = %d - setting child flag %s = %d\n", FlagNames[(int) flag], value, FlagNames[(int) childFlag], childValue);
+                Output::VerboseNote(CH_WSTR("FLAG %s = %d - setting child flag %s = %d\n"), FlagNames[(int) flag], value, FlagNames[(int) childFlag], childValue);
                 this->SetAsBoolean(childFlag, childValue);
 
                 // get next child flag

--- a/lib/common/core/ConfigFlagsTable.h
+++ b/lib/common/core/ConfigFlagsTable.h
@@ -84,8 +84,8 @@ namespace Js
 #undef PHASE
     };
 
-    extern const wchar_t* const FlagNames[FlagCount + 1];
-    extern const wchar_t* const PhaseNames[PhaseCount + 1];
+    extern const wchar16* const FlagNames[FlagCount + 1];
+    extern const wchar16* const PhaseNames[PhaseCount + 1];
     extern const Flag           FlagParents[FlagCount + 1];
 
     typedef     int             Number;
@@ -101,9 +101,9 @@ namespace Js
     /// fiddling to make this class as interoperable with strings as possible :-
     ///
     ///     1.  Single argument constructor takes care of initialization
-    ///     2.  Assignment operator overloaded for wchar_t*
-    ///     3.  JavascriptConversion to const wchar_t * is defined. Making this constant ensures
-    ///         that a non constant wchar_t * does not point to our buffer which can
+    ///     2.  Assignment operator overloaded for wchar16*
+    ///     3.  JavascriptConversion to const wchar16 * is defined. Making this constant ensures
+    ///         that a non constant wchar16 * does not point to our buffer which can
     ///         potentially corrupt it.
     ///
     ///----------------------------------------------------------------------------

--- a/lib/common/core/ConfigParser.h
+++ b/lib/common/core/ConfigParser.h
@@ -47,7 +47,7 @@ private:
 public:
     static ConfigParser s_moduleConfigParser;
 
-    ConfigParser(Js::ConfigFlagsTable& outputFlags, __in LPCWSTR configFileName = L"jscript") :
+    ConfigParser(Js::ConfigFlagsTable& outputFlags, __in LPCWSTR configFileName = CH_WSTR("jscript")) :
         _flags(outputFlags),
         _hasReadConfig(false),
         _configFileName(configFileName)

--- a/lib/common/core/DbgHelpSymbolManager.cpp
+++ b/lib/common/core/DbgHelpSymbolManager.cpp
@@ -5,7 +5,7 @@
 #include "CommonCorePch.h"
 
 #ifdef DBGHELP_SYMBOL_MANAGER
-#include "core\DbgHelpSymbolManager.h"
+#include "core/DbgHelpSymbolManager.h"
 
 // Initialization order
 //  AB AutoSystemInfo

--- a/lib/common/core/DelayLoadLibrary.cpp
+++ b/lib/common/core/DelayLoadLibrary.cpp
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "CommonCorePch.h"
-#include "core\DelayLoadLibrary.h"
+#include "core/DelayLoadLibrary.h"
 
 DelayLoadLibrary::DelayLoadLibrary()
 {
@@ -57,7 +57,7 @@ NtdllLibrary* NtdllLibrary::Instance = &NtdllLibraryObject;
 
 LPCTSTR NtdllLibrary::GetLibraryName() const
 {
-    return L"ntdll.dll";
+    return CH_WSTR("ntdll.dll");
 }
 
 _Success_(return == 0)

--- a/lib/common/core/EtwTraceCore.cpp
+++ b/lib/common/core/EtwTraceCore.cpp
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "CommonCorePch.h"
-#include "core\EtwTraceCore.h"
+#include "core/EtwTraceCore.h"
 
 #ifdef ENABLE_JS_ETW
 extern "C" {

--- a/lib/common/core/Output.cpp
+++ b/lib/common/core/Output.cpp
@@ -32,7 +32,7 @@ unsigned int Output::s_traceEntryId = 0;
 #endif
 
 THREAD_ST FILE*    Output::s_file = nullptr;
-THREAD_ST wchar_t* Output::buffer = nullptr;
+THREAD_ST wchar16* Output::buffer = nullptr;
 THREAD_ST size_t   Output::bufferAllocSize = 0;
 THREAD_ST size_t   Output::bufferFreeSize = 0;
 THREAD_ST size_t   Output::s_Column  = 0;
@@ -43,7 +43,7 @@ THREAD_ST bool     Output::s_capture = false;
 #define MAX_OUTPUT_BUFFER_SIZE 10 * 1024 * 1024  // 10 MB maximum before we force a flush
 
 size_t __cdecl
-Output::VerboseNote(const wchar_t * format, ...)
+Output::VerboseNote(const wchar16 * format, ...)
 {
 #ifdef ENABLE_TRACE
     if (Js::Configuration::Global.flags.Verbose)
@@ -61,7 +61,7 @@ Output::VerboseNote(const wchar_t * format, ...)
 
 #ifdef ENABLE_TRACE
 size_t __cdecl
-Output::Trace(Js::Phase phase, const wchar_t *form, ...)
+Output::Trace(Js::Phase phase, const wchar16 *form, ...)
 {
     size_t retValue = 0;
 
@@ -69,14 +69,14 @@ Output::Trace(Js::Phase phase, const wchar_t *form, ...)
     {
         va_list argptr;
         va_start(argptr, form);
-        retValue += Output::VTrace(L"%s: ", Js::PhaseNames[static_cast<int>(phase)], form, argptr);
+        retValue += Output::VTrace(CH_WSTR("%s: "), Js::PhaseNames[static_cast<int>(phase)], form, argptr);
     }
 
     return retValue;
 }
 
 size_t __cdecl
-Output::Trace2(Js::Phase phase, const wchar_t *form, ...)
+Output::Trace2(Js::Phase phase, const wchar16 *form, ...)
 {
     size_t retValue = 0;
 
@@ -91,7 +91,7 @@ Output::Trace2(Js::Phase phase, const wchar_t *form, ...)
 }
 
 size_t __cdecl
-Output::TraceWithPrefix(Js::Phase phase, const wchar_t prefix[], const wchar_t *form, ...)
+Output::TraceWithPrefix(Js::Phase phase, const wchar16 prefix[], const wchar16 *form, ...)
 {
     size_t retValue = 0;
 
@@ -100,15 +100,15 @@ Output::TraceWithPrefix(Js::Phase phase, const wchar_t prefix[], const wchar_t *
         va_list argptr;
         va_start(argptr, form);
         WCHAR prefixValue[512];
-        swprintf_s(prefixValue, L"%s: %s: ", Js::PhaseNames[static_cast<int>(phase)], prefix);
-        retValue += Output::VTrace(L"%s", prefixValue, form, argptr);
+        swprintf_s(prefixValue, CH_WSTR("%s: %s: "), Js::PhaseNames[static_cast<int>(phase)], prefix);
+        retValue += Output::VTrace(CH_WSTR("%s"), prefixValue, form, argptr);
     }
 
     return retValue;
 }
 
 size_t __cdecl
-Output::TraceWithFlush(Js::Phase phase, const wchar_t *form, ...)
+Output::TraceWithFlush(Js::Phase phase, const wchar16 *form, ...)
 {
     size_t retValue = 0;
 
@@ -116,7 +116,7 @@ Output::TraceWithFlush(Js::Phase phase, const wchar_t *form, ...)
     {
         va_list argptr;
         va_start(argptr, form);
-        retValue += Output::VTrace(L"%s:", Js::PhaseNames[static_cast<int>(phase)], form, argptr);
+        retValue += Output::VTrace(CH_WSTR("%s:"), Js::PhaseNames[static_cast<int>(phase)], form, argptr);
         Output::Flush();
     }
 
@@ -124,7 +124,7 @@ Output::TraceWithFlush(Js::Phase phase, const wchar_t *form, ...)
 }
 
 size_t __cdecl
-Output::TraceWithFlush(Js::Flag flag, const wchar_t *form, ...)
+Output::TraceWithFlush(Js::Flag flag, const wchar16 *form, ...)
 {
     size_t retValue = 0;
 
@@ -132,7 +132,7 @@ Output::TraceWithFlush(Js::Flag flag, const wchar_t *form, ...)
     {
         va_list argptr;
         va_start(argptr, form);
-        retValue += Output::VTrace(L"[-%s]::", Js::FlagNames[static_cast<int>(flag)], form, argptr);
+        retValue += Output::VTrace(CH_WSTR("[-%s]::"), Js::FlagNames[static_cast<int>(flag)], form, argptr);
         Output::Flush();
     }
 
@@ -140,14 +140,14 @@ Output::TraceWithFlush(Js::Flag flag, const wchar_t *form, ...)
 }
 
 size_t
-Output::VTrace(const wchar_t* shortPrefixFormat, const wchar_t* prefix, const wchar_t *form, va_list argptr)
+Output::VTrace(const wchar16* shortPrefixFormat, const wchar16* prefix, const wchar16 *form, va_list argptr)
 {
     size_t retValue = 0;
 
     if (CONFIG_FLAG(RichTraceFormat))
     {
         InterlockedIncrement(&s_traceEntryId);
-        retValue += Output::Print(L"[%d ~%d %s] ", s_traceEntryId, ::GetCurrentThreadId(), prefix);
+        retValue += Output::Print(CH_WSTR("[%d ~%d %s] "), s_traceEntryId, ::GetCurrentThreadId(), prefix);
     }
     else
     {
@@ -160,18 +160,18 @@ Output::VTrace(const wchar_t* shortPrefixFormat, const wchar_t* prefix, const wc
     {
         const ULONG c_framesToSkip = 2; // Skip 2 frames -- Output::VTrace and Output::Trace.
         const ULONG c_frameCount = 10;  // TODO: make it configurable.
-        const wchar_t callStackPrefix[] = L"call stack:";
+        const wchar16 callStackPrefix[] = CH_WSTR("call stack:");
         if (s_inMemoryLogger)
         {
             // Trace just addresses of functions, avoid symbol info as it takes too much memory.
             // One line for whole stack trace for easier parsing on the jd side.
             const size_t c_msgCharCount = _countof(callStackPrefix) + (1 + sizeof(void*) * 2) * c_frameCount; // 2 hexadecimal digits per byte + 1 for space.
-            wchar_t callStackMsg[c_msgCharCount];
+            wchar16 callStackMsg[c_msgCharCount];
             void* frames[c_frameCount];
             size_t start = 0;
             size_t temp;
 
-            temp = _snwprintf_s(callStackMsg, _countof(callStackMsg), _TRUNCATE, L"%s", callStackPrefix);
+            temp = _snwprintf_s(callStackMsg, _countof(callStackMsg), _TRUNCATE, CH_WSTR("%s"), callStackPrefix);
             Assert(temp != -1);
             start += temp;
 
@@ -180,17 +180,17 @@ Output::VTrace(const wchar_t* shortPrefixFormat, const wchar_t* prefix, const wc
             for (ULONG i = 0; i < framesObtained && i < c_frameCount; ++i)
             {
                 Assert(_countof(callStackMsg) >= start);
-                temp = _snwprintf_s(callStackMsg + start, _countof(callStackMsg) - start, _TRUNCATE, L" %p", frames[i]);
+                temp = _snwprintf_s(callStackMsg + start, _countof(callStackMsg) - start, _TRUNCATE, CH_WSTR(" %p"), frames[i]);
                 Assert(temp != -1);
                 start += temp;
             }
 
-            retValue += Output::Print(L"%s\n", callStackMsg);
+            retValue += Output::Print(CH_WSTR("%s\n"), callStackMsg);
         }
         else
         {
             // Trace with full symbol info.
-            retValue += Output::Print(L"%s\n", callStackPrefix);
+            retValue += Output::Print(CH_WSTR("%s\n"), callStackPrefix);
             retValue += s_stackTraceHelper->PrintStackTrace(c_framesToSkip, c_frameCount);
         }
     }
@@ -200,7 +200,7 @@ Output::VTrace(const wchar_t* shortPrefixFormat, const wchar_t* prefix, const wc
 
 #ifdef BGJIT_STATS
 size_t __cdecl
-Output::TraceStats(Js::Phase phase, const wchar_t *form, ...)
+Output::TraceStats(Js::Phase phase, const wchar16 *form, ...)
 {
     if(PHASE_STATS1(phase))
     {
@@ -223,7 +223,7 @@ Output::TraceStats(Js::Phase phase, const wchar_t *form, ...)
 ///----------------------------------------------------------------------------
 
 size_t __cdecl
-Output::Print(const wchar_t *form, ...)
+Output::Print(const wchar16 *form, ...)
 {
     va_list argptr;
     va_start(argptr, form);
@@ -231,7 +231,7 @@ Output::Print(const wchar_t *form, ...)
 }
 
 size_t __cdecl
-Output::Print(int column, const wchar_t *form, ...)
+Output::Print(int column, const wchar16 *form, ...)
 {
     Output::SkipToColumn(column);
     va_list argptr;
@@ -240,9 +240,9 @@ Output::Print(int column, const wchar_t *form, ...)
 }
 
 size_t __cdecl
-Output::VPrint(const wchar_t *form, va_list argptr)
+Output::VPrint(const wchar16 *form, va_list argptr)
 {
-    wchar_t buf[2048];
+    wchar16 buf[2048];
     size_t size;
 
     size = _vsnwprintf_s(buf, _countof(buf), _TRUNCATE, form, argptr);
@@ -254,10 +254,10 @@ Output::VPrint(const wchar_t *form, va_list argptr)
 }
 
 size_t __cdecl
-Output::PrintBuffer(const wchar_t * buf, size_t size)
+Output::PrintBuffer(const wchar16 * buf, size_t size)
 {
     Output::s_Column += size;
-    const wchar_t * endbuf = wcschr(buf, '\n');
+    const wchar16 * endbuf = wcschr(buf, '\n');
     while (endbuf != nullptr)
     {
         Output::s_Column = size - (endbuf - buf) - 1;
@@ -301,7 +301,7 @@ Output::PrintBuffer(const wchar_t * buf, size_t size)
                 {
                     size_t oldBufferSize = bufferAllocSize - bufferFreeSize;
                     size_t newBufferAllocSize = (bufferAllocSize + size + 1) * 4 / 3;
-                    wchar_t * newBuffer = (wchar_t *)realloc(buffer, (newBufferAllocSize * sizeof(wchar_t)));
+                    wchar16 * newBuffer = (wchar16 *)realloc(buffer, (newBufferAllocSize * sizeof(wchar16)));
                     if (newBuffer == nullptr)
                     {
                         // See if I can just flush it and print directly
@@ -328,19 +328,19 @@ Output::PrintBuffer(const wchar_t * buf, size_t size)
             if (addToBuffer)
             {
                 Assert(Output::bufferFreeSize >= size + 1);
-                memcpy_s(Output::buffer + Output::bufferAllocSize - Output::bufferFreeSize, Output::bufferFreeSize * sizeof(wchar_t),
-                    buf, (size + 1) * sizeof(wchar_t));
+                memcpy_s(Output::buffer + Output::bufferAllocSize - Output::bufferFreeSize, Output::bufferFreeSize * sizeof(wchar16),
+                    buf, (size + 1) * sizeof(wchar16));
                 bufferFreeSize -= size;
             }
         }
         else
         {
-            fwprintf_s(Output::s_file, L"%s", buf);
+            fwprintf_s(Output::s_file, CH_WSTR("%s"), buf);
         }
 
         if(s_outputFile != nullptr && !Output::s_capture)
         {
-            fwprintf_s(s_outputFile, L"%s", buf);
+            fwprintf_s(s_outputFile, CH_WSTR("%s"), buf);
         }
     }
 
@@ -370,9 +370,12 @@ void Output::Flush()
     _flushall();
 }
 
-void Output::DirectPrint(wchar_t const * string)
+void Output::DirectPrint(wchar16 const * string)
 {
     AutoCriticalSection autocs(&s_critsect);
+
+    // xplat-todo: support console color
+#ifdef _WIN32
     WORD oldValue = 0;
     BOOL restoreColor = FALSE;
     HANDLE hConsole = NULL;
@@ -387,12 +390,17 @@ void Output::DirectPrint(wchar_t const * string)
             restoreColor = SetConsoleTextAttribute(hConsole, Output::s_color);
         }
     }
-    fwprintf(stdout, L"%s", string);
+#endif // _WIN32
 
+    fwprintf(stdout, CH_WSTR("%s"), string);
+
+    // xplat-todo: support console color
+#ifdef _WIN32
     if (restoreColor)
     {
         SetConsoleTextAttribute(hConsole, oldValue);
     }
+#endif // _WIN32
 }
 ///----------------------------------------------------------------------------
 ///
@@ -407,7 +415,7 @@ Output::SkipToColumn(size_t column)
 {
     if (column <= Output::s_Column)
     {
-        Output::Print(L" ");
+        Output::Print(CH_WSTR(" "));
         return;
     }
 
@@ -418,7 +426,7 @@ Output::SkipToColumn(size_t column)
     // Print at least one space
     while (dist > 0)
     {
-        Output::Print(L" ");
+        Output::Print(CH_WSTR(" "));
         dist--;
     }
 }
@@ -484,6 +492,9 @@ WORD
 Output::SetConsoleForeground(WORD color)
 {
     AutoCriticalSection autocs(&s_critsect);
+
+    // xplat-todo: support console color
+#ifdef _WIN32
     _CONSOLE_SCREEN_BUFFER_INFO info;
     HANDLE hConsole = GetStdHandle(STD_OUTPUT_HANDLE);
 
@@ -494,6 +505,7 @@ Output::SetConsoleForeground(WORD color)
         Output::s_hasColor = Output::s_color != info.wAttributes;
         return info.wAttributes;
     }
+#endif // _WIN32
 
     return 0;
 }
@@ -506,14 +518,14 @@ Output::CaptureStart()
     s_capture = true;
 }
 
-wchar_t *
+wchar16 *
 Output::CaptureEnd()
 {
     Assert(s_capture);
     s_capture = false;
     bufferFreeSize = 0;
     bufferAllocSize = 0;
-    wchar_t * returnBuffer = buffer;
+    wchar16 * returnBuffer = buffer;
     buffer = nullptr;
     return returnBuffer;
 }

--- a/lib/common/core/Output.h
+++ b/lib/common/core/Output.h
@@ -52,7 +52,7 @@ namespace Js
     // decouple implementation so that in common.lib we don't have dependency on memory.lib
     struct ILogger
     {
-        virtual void Write(const wchar_t* msg) = 0;
+        virtual void Write(const wchar16* msg) = 0;
     };
     struct IStackTraceHelper
     {
@@ -65,17 +65,17 @@ namespace Js
 class Output
 {
 public:
-    static size_t __cdecl VerboseNote(const wchar_t * format, ...);
+    static size_t __cdecl VerboseNote(const wchar16 * format, ...);
 #ifdef ENABLE_TRACE
-    static size_t __cdecl Trace(Js::Phase phase, const wchar_t *form, ...);
-    static size_t __cdecl Trace2(Js::Phase phase, const wchar_t *form, ...);
-    static size_t __cdecl TraceWithPrefix(Js::Phase phase, const wchar_t prefix[], const wchar_t *form, ...);
-    static size_t __cdecl TraceWithFlush(Js::Phase phase, const wchar_t *form, ...);
-    static size_t __cdecl TraceWithFlush(Js::Flag flag, const wchar_t *form, ...);
-    static size_t __cdecl TraceStats(Js::Phase phase, const wchar_t *form, ...);
+    static size_t __cdecl Trace(Js::Phase phase, const wchar16 *form, ...);
+    static size_t __cdecl Trace2(Js::Phase phase, const wchar16 *form, ...);
+    static size_t __cdecl TraceWithPrefix(Js::Phase phase, const wchar16 prefix[], const wchar16 *form, ...);
+    static size_t __cdecl TraceWithFlush(Js::Phase phase, const wchar16 *form, ...);
+    static size_t __cdecl TraceWithFlush(Js::Flag flag, const wchar16 *form, ...);
+    static size_t __cdecl TraceStats(Js::Phase phase, const wchar16 *form, ...);
     template<class Fn>
     static size_t __cdecl
-    TraceWithCallback(Js::Phase phase, Fn callback, const wchar_t *form, ...)
+    TraceWithCallback(Js::Phase phase, Fn callback, const wchar16 *form, ...)
     {
         size_t retValue = 0;
 
@@ -93,10 +93,10 @@ public:
     static void     SetInMemoryLogger(Js::ILogger* logger);
     static void     SetStackTraceHelper(Js::IStackTraceHelper* helper);
 #endif // ENABLE_TRACE
-    static size_t __cdecl Print(const wchar_t *form, ...);
-    static size_t __cdecl Print(int column, const wchar_t *form, ...);
-    static size_t __cdecl PrintBuffer(const wchar_t * buffer, size_t size);
-    static size_t __cdecl VPrint(const wchar_t *form, va_list argptr);
+    static size_t __cdecl Print(const wchar16 *form, ...);
+    static size_t __cdecl Print(int column, const wchar16 *form, ...);
+    static size_t __cdecl PrintBuffer(const wchar16 * buffer, size_t size);
+    static size_t __cdecl VPrint(const wchar16 *form, va_list argptr);
     static void     SkipToColumn(size_t column);
     static FILE*    SetFile(FILE *);
     static FILE*    GetFile();
@@ -107,10 +107,10 @@ public:
 
     static WORD     SetConsoleForeground(WORD color);
     static void     CaptureStart();
-    static wchar_t* CaptureEnd();
+    static wchar16* CaptureEnd();
 
 private:
-    static void     DirectPrint(const wchar_t * string);
+    static void     DirectPrint(const wchar16 * string);
 
     static AutoFILE s_outputFile;
     static bool     s_useDebuggerWindow;
@@ -122,14 +122,14 @@ private:
 #ifdef STACK_BACK_TRACE
     static Js::IStackTraceHelper* s_stackTraceHelper; // Used for capturing stack trace.
 #endif
-    static size_t VTrace(const wchar_t* shortPrefixFormat, const wchar_t* prefix, const wchar_t *form, va_list argptr);
+    static size_t VTrace(const wchar16* shortPrefixFormat, const wchar16* prefix, const wchar16 *form, va_list argptr);
 #endif // ENABLE_TRACE
 
 #define THREAD_ST __declspec(thread)
 
     THREAD_ST static bool s_capture;
     THREAD_ST static FILE * s_file;
-    THREAD_ST static wchar_t * buffer;
+    THREAD_ST static wchar16 * buffer;
     THREAD_ST static size_t bufferFreeSize;
     THREAD_ST static size_t bufferAllocSize;
     THREAD_ST static size_t s_Column;

--- a/lib/common/core/StackBackTrace.cpp
+++ b/lib/common/core/StackBackTrace.cpp
@@ -5,8 +5,8 @@
 #include "CommonCorePch.h"
 
 #ifdef STACK_BACK_TRACE
-#include "core\StackBackTrace.h"
-#include "core\DbgHelpSymbolManager.h"
+#include "core/StackBackTrace.h"
+#include "core/DbgHelpSymbolManager.h"
 
 StackBackTrace::StackBackTrace(ULONG framesToSkip, ULONG framesToCapture) : requestedFramesToCapture(framesToCapture)
 {

--- a/pal/inc/rt/guiddef.h
+++ b/pal/inc/rt/guiddef.h
@@ -1,0 +1,27 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+//
+
+//
+// ===========================================================================
+// File: guiddef.h
+// 
+// ===========================================================================
+// simplified guiddef.h for PAL
+
+#include "palrt.h"
+
+#ifdef DEFINE_GUID
+#undef DEFINE_GUID
+#endif
+
+#ifdef INITGUID
+#define DEFINE_GUID(name, l, w1, w2, b1, b2, b3, b4, b5, b6, b7, b8) \
+        EXTERN_C const GUID DECLSPEC_SELECTANY name \
+                = { l, w1, w2, { b1, b2,  b3,  b4,  b5,  b6,  b7,  b8 } }
+#else
+#define DEFINE_GUID(name, l, w1, w2, b1, b2, b3, b4, b5, b6, b7, b8) \
+    EXTERN_C const GUID FAR name
+#endif // INITGUID

--- a/pal/inc/rt/initguid.h
+++ b/pal/inc/rt/initguid.h
@@ -1,0 +1,10 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+#pragma once
+
+#ifndef INITGUID
+#define INITGUID
+#include <guiddef.h>
+#endif

--- a/pal/inc/rt/wincrypt.h
+++ b/pal/inc/rt/wincrypt.h
@@ -1,0 +1,14 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+//
+
+//
+// ===========================================================================
+// File: wincrypt.h
+// 
+// ===========================================================================
+// dummy wincrypt.h for PAL
+
+#include "palrt.h"


### PR DESCRIPTION
This enables building other files under lib/common/core.

Disabled some features for non-Windows:
- Stack back trace (depending on stack and dbg symbol APIs).
- ConfigParser: read Windows Registry
- SysInfo: differentiate physical/logical #processors, read VERSION
  resource