### PR TITLE
Replace wrong delete[] calls by free() function calls.

### DIFF
--- a/bin/rl/rl.h
+++ b/bin/rl/rl.h
@@ -711,18 +711,20 @@ class CThreadInfo
     struct TmpFileList
     {
         TmpFileList* _next;
-        char* _fullPath;
+        char* const _fullPath;
 
         TmpFileList(TmpFileList* next, char* fullPath)
-            : _next(next)
+            : _next(next), _fullPath(_strdup(fullPath))
         {
-            _fullPath = _strdup(fullPath);
         }
 
         ~TmpFileList()
         {
-            delete [] _fullPath;
+            free(_fullPath);
         }
+
+        TmpFileList(const TmpFileList&) = delete;
+        void operator=(const TmpFileList&) = delete;
     };
 
     TmpFileList* _head;

--- a/bin/rl/rlmp.cpp
+++ b/bin/rl/rlmp.cpp
@@ -455,7 +455,7 @@ COutputBuffer::~COutputBuffer()
     _start = _end = NULL;
     _bufSize = 0;
     if (_type == OUT_FILENAME) {
-        delete[] _filename;
+        free(_filename);
         _filename = NULL;
     }
 }


### PR DESCRIPTION
As specified in MSDN (https://msdn.microsoft.com/ru-ru/library/y471khhc.aspx | [English](https://msdn.microsoft.com/en-us/library/y471khhc.aspx)),
`The _strdup function calls malloc to allocate storage space for a copy of strSource and then copies strSource to the allocated space.`

That's why call to `delete[] ptr_from_strdup;` is wrong and leads to undefined behavior.
Also, to be sure that public field _fullPath won't be changed after TmpFileList constructor, I made it const.

What about std::string here and in other places?
Is it forbidden? Why so many calls to new char[]/delete[]/strdup instead of standart STL class use?