### PR TITLE
Define a SimpleTypeHandler for functions with length and name properties

### DIFF
--- a/lib/Runtime/Library/JavascriptLibrary.h
+++ b/lib/Runtime/Library/JavascriptLibrary.h
@@ -443,6 +443,7 @@ namespace Js
         static SimpleTypeHandler<1> SharedFunctionWithPrototypeTypeHandlerV11;
         static SimpleTypeHandler<2> SharedFunctionWithPrototypeTypeHandler;
         static SimpleTypeHandler<1> SharedFunctionWithLengthTypeHandler;
+        static SimpleTypeHandler<2> SharedFunctionWithLengthAndNameTypeHandler;
         static SimpleTypeHandler<1> SharedIdMappedFunctionWithPrototypeTypeHandler;
         static MissingPropertyTypeHandler MissingPropertyHolderTypeHandler;
 
@@ -450,6 +451,7 @@ namespace Js
         static SimplePropertyDescriptor const HeapArgumentsPropertyDescriptorsV11[2];
         static SimplePropertyDescriptor const HeapArgumentsPropertyDescriptors[3];
         static SimplePropertyDescriptor const FunctionWithLengthAndPrototypeTypeDescriptors[2];
+        static SimplePropertyDescriptor const FunctionWithLengthAndNameTypeDescriptors[2];
 
     public:
 
@@ -819,8 +821,10 @@ namespace Js
         DynamicType * CreateDeferredPrototypeFunctionTypeNoProfileThunk(JavascriptMethod entrypoint, bool isShared = false);
         DynamicType * CreateFunctionType(JavascriptMethod entrypoint, RecyclableObject* prototype = nullptr);
         DynamicType * CreateFunctionWithLengthType(FunctionInfo * functionInfo);
+        DynamicType * CreateFunctionWithLengthAndNameType(FunctionInfo * functionInfo);
         DynamicType * CreateFunctionWithLengthAndPrototypeType(FunctionInfo * functionInfo);
         DynamicType * CreateFunctionWithLengthType(DynamicObject * prototype, FunctionInfo * functionInfo);
+        DynamicType * CreateFunctionWithLengthAndNameType(DynamicObject * prototype, FunctionInfo * functionInfo);
         DynamicType * CreateFunctionWithLengthAndPrototypeType(DynamicObject * prototype, FunctionInfo * functionInfo);
         ScriptFunction * CreateScriptFunction(FunctionProxy* proxy);
         AsmJsScriptFunction * CreateAsmJsScriptFunction(FunctionProxy* proxy);


### PR DESCRIPTION
When creating a function's type without prototype, we instantiate a
SimpleTypeHandler, with a max property size of 1, with just the length
property. Later, when we add the name
property we end up having to convert the simple type handler to simple
dictionary type handler.

This change prevents the conversion by instantiating the SimpleTypeHandler
with properties length and name (whether we need to have the name property
is governed by the config flags, so is statically determined)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/196)
<!-- Reviewable:end -->
