### PR TITLE
Int64common

### DIFF
--- a/lib/common/CMakeLists.txt
+++ b/lib/common/CMakeLists.txt
@@ -3,5 +3,6 @@ project(CHAKRA_COMMON)
 include_directories(${CHAKRA_COMMON_SOURCE_DIR})
 
 add_subdirectory (codex)
+add_subdirectory (common)
 add_subdirectory (core)
 add_subdirectory (DataStructures)

--- a/lib/common/common/CMakeLists.txt
+++ b/lib/common/common/CMakeLists.txt
@@ -1,0 +1,25 @@
+set (SOURCES
+  Api.cpp
+  cfglogger.cpp
+  CommonCommonPch.cpp
+  # DateUtilities.cpp
+  # DaylightTimeHelper.cpp
+  Event.cpp
+  Int32Math.cpp
+  # Int64Math.cpp
+  # Jobs.cpp
+  # MathUtil.cpp
+  # NumberUtilities.cpp
+  # NumberUtilities_strtod.cpp
+  # RejitReason.cpp
+  # SmartFPUControl.cpp
+  Tick.cpp
+  unicode.cpp
+  vtinfo.cpp
+)
+
+add_library (Chakra.Common.common
+  ${SOURCES}
+)
+
+target_include_directories (Chakra.Common.common PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/lib/common/common/CMakeLists.txt
+++ b/lib/common/common/CMakeLists.txt
@@ -6,7 +6,7 @@ set (SOURCES
   # DaylightTimeHelper.cpp
   Event.cpp
   Int32Math.cpp
-  # Int64Math.cpp
+  Int64Math.cpp
   # Jobs.cpp
   # MathUtil.cpp
   # NumberUtilities.cpp

--- a/lib/common/common/CommonCommonPch.h
+++ b/lib/common/common/CommonCommonPch.h
@@ -14,11 +14,11 @@
 #endif
 
 // === Codex Header Files ===
-#include "codex\Utf8Codex.h"
+#include "codex/Utf8Codex.h"
 
 // === Common Header Files ===
-#include "Common\NumberUtilitiesBase.h"
-#include "Common\NumberUtilities.h"
+#include "common/NumberUtilitiesBase.h"
+#include "common/NumberUtilities.h"
 
 #pragma warning(push)
 #if defined(PROFILE_RECYCLER_ALLOC) || defined(HEAP_TRACK_ALLOC) || defined(ENABLE_DEBUG_CONFIG_OPTIONS)

--- a/lib/common/common/Event.cpp
+++ b/lib/common/common/Event.cpp
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "CommonCommonPch.h"
-#include "Common\Event.h"
+#include "common/Event.h"
 
 Event::Event(const bool autoReset, const bool signaled) : handle(CreateEvent(0, !autoReset, signaled, 0))
 {

--- a/lib/common/common/Int32Math.cpp
+++ b/lib/common/common/Int32Math.cpp
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "CommonCommonPch.h"
-#include "Common\Int32Math.h"
+#include "common/Int32Math.h"
 
 bool
 Int32Math::Add(int32 left, int32 right, int32 *pResult)

--- a/lib/common/common/Int64Math.cpp
+++ b/lib/common/common/Int64Math.cpp
@@ -3,8 +3,9 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "CommonCommonPch.h"
-#include "Common\Int64Math.h"
+#include "common/Int64Math.h"
 #include <intrin.h>
+#include <stdint.h>
 
 #if _M_X64
 #pragma intrinsic(_mul128)
@@ -52,7 +53,7 @@ Int64Math::Div(int64 left, int64 right, int64 *pResult)
 {
     AssertMsg(right != 0, "Divide by zero...");
 
-    if (right == -1 && left == MININT64)
+    if (right == -1 && left == INT64_MIN)
     {
         //Special check for INT64_MIN/-1
         return true;
@@ -66,7 +67,7 @@ bool
 Int64Math::Mod(int64 left, int64 right, int64 *pResult)
 {
     AssertMsg(right != 0, "Mod by zero...");
-    if (right == -1 && left == MININT64)
+    if (right == -1 && left == INT64_MIN)
     {
         //Special check for INT64_MIN/-1
         return true;
@@ -115,7 +116,7 @@ bool
 Int64Math::Neg(int64 val, int64 *pResult)
 {
     *pResult = -val;
-    return *pResult == MININT64;
+    return *pResult == INT64_MIN;
 }
 
 bool

--- a/lib/common/common/Int64Math.cpp
+++ b/lib/common/common/Int64Math.cpp
@@ -4,11 +4,13 @@
 //-------------------------------------------------------------------------------------------------------
 #include "CommonCommonPch.h"
 #include "common/Int64Math.h"
-#include <intrin.h>
 #include <stdint.h>
 
+#if _WIN32
+#include <intrin.h>
 #if _M_X64
 #pragma intrinsic(_mul128)
+#endif
 #endif
 
 bool
@@ -22,7 +24,8 @@ Int64Math::Add(int64 left, int64 right, int64 *pResult)
 bool
 Int64Math::Mul(int64 left, int64 right, int64 *pResult)
 {
-#if _M_X64
+// TODO: we should use an optimized version of mul128 in !windows too.
+#if defined(_M_X64) && defined(_MSC_VER)
     int64 high;
     *pResult = _mul128(left, right, &high);
     return high != 0;

--- a/lib/common/common/Tick.cpp
+++ b/lib/common/common/Tick.cpp
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "CommonCommonPch.h"
-#include "Common\Tick.h"
+#include "common/Tick.h"
 
 namespace Js {
     uint64      Tick::s_luFreq;

--- a/lib/common/common/unicode.cpp
+++ b/lib/common/common/unicode.cpp
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "CommonCommonPch.h"
-#include "Common\unicode.h"
+#include "common/unicode.h"
 //
 // This file contains tables used for operations on the Unicode character
 // set, such as changing case.

--- a/lib/common/common/vtinfo.cpp
+++ b/lib/common/common/vtinfo.cpp
@@ -3,8 +3,8 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "CommonCommonPch.h"
-#include "common\vtregistry.h"
-#include "Common\vtinfo.h"
+#include "common/vtregistry.h"
+#include "common/vtinfo.h"
 
 #if DBG
 VirtualTableRegistry::TableEntry VirtualTableRegistry::m_knownVtables[MAX_KNOWN_VTABLES];


### PR DESCRIPTION
Per previous reviews:

- Just use the stdint.h int64 min value everywhere.
- Fallback to the !_mul128 implementation on !windows, this seems simpler for now.