### PR TITLE
Fix static analysis issues reported by PVS-Studio

### DIFF
--- a/bin/rl/rl.cpp
+++ b/bin/rl/rl.cpp
@@ -1385,7 +1385,7 @@ stristr
       {
          if (tolower(str[i]) != tolower(sub[i]))
          {
-            if ((str[i] != '/' && str[i] != '-') || (sub[i] != '-' && sub[i] == '/')) {
+            if ((str[i] != '/' && str[i] != '-') || (sub[i] != '-' && sub[i] != '/')) {
                // if the mismatch is not between '/' and '-'
                break;
             }
@@ -2272,18 +2272,6 @@ DumpTestList
 
 #endif
 
-// how we translate testinfo into env.lst specific stuffs
-const char * const TestInfoEnvLstFmt[] =
-{
-   " TESTFILE=\"%s\"",
-   " BASELINE=\"%s\"",
-   " CFLAGS=\"%s\"",
-   " LFLAGS=\"%s\"",
-   NULL,
-   NULL,
-   NULL,
-   NULL
-};
 
 void
 PadSpecialChars
@@ -2368,6 +2356,22 @@ WriteEnvLst
             }
             LstFilesOut->Add("\"");
          }
+
+         // how we translate testinfo into env.lst specific stuffs
+         static const char * const TestInfoEnvLstFmt[] =
+         {
+             " TESTFILE=\"%s\"",
+             " BASELINE=\"%s\"",
+             " CFLAGS=\"%s\"",
+             " LFLAGS=\"%s\"",
+             NULL,
+             NULL,
+             NULL,
+             NULL,
+             NULL
+         };
+
+         static_assert((sizeof(TestInfoEnvLstFmt) / sizeof(TestInfoEnvLstFmt[0])) == TestInfoKind::_TIK_COUNT, "Fix the buffer size");
 
          // print the other TIK_*
          for(int i=0;i < _TIK_COUNT; i++) {

--- a/bin/rl/rl.cpp
+++ b/bin/rl/rl.cpp
@@ -2358,7 +2358,7 @@ WriteEnvLst
          }
 
          // how we translate testinfo into env.lst specific stuffs
-         static const char * const TestInfoEnvLstFmt[] =
+         const char * const TestInfoEnvLstFmt[] =
          {
              " TESTFILE=\"%s\"",
              " BASELINE=\"%s\"",

--- a/lib/Backend/FlowGraph.cpp
+++ b/lib/Backend/FlowGraph.cpp
@@ -1811,6 +1811,8 @@ FlowGraph::PeepTypedCm(IR::Instr *instr)
         return nullptr;
     }
 
+    AssertMsg(instrLd || (!instrLd && !instrLd2), "Either instrLd is non-null or both null");
+
     // if we have intermediate Lds, then make sure pattern is:
     //      t1 = CmEq a, b
     //      t2 = Ld_A t1

--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -9738,7 +9738,7 @@ GlobOpt::TypeSpecializeIntBinary(IR::Instr **pInstr, Value *src1Val, Value *src2
             }
 
             // Don't specialize if the element is not likelyInt or a IntConst which is a missing item value.
-            if(!src2Val || !(src2Val->GetValueInfo()->IsLikelyInt()) || isIntConstMissingItem)
+            if(!(src2Val->GetValueInfo()->IsLikelyInt()) || isIntConstMissingItem)
             {
                 return false;
             }
@@ -12549,7 +12549,7 @@ GlobOpt::TypeSpecializeFloatBinary(IR::Instr *instr, Value *src1Val, Value *src2
                     isFloatConstMissingItem = Js::SparseArraySegment<double>::IsMissingItem(&floatValue);
                 }
                 // Don't specialize if the element is not likelyNumber - we will surely bailout
-                if(!src2Val || !(src2Val->GetValueInfo()->IsLikelyNumber()) || isFloatConstMissingItem)
+                if(!(src2Val->GetValueInfo()->IsLikelyNumber()) || isFloatConstMissingItem)
                 {
                     return false;
                 }

--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -20846,7 +20846,7 @@ GlobOpt::EmitMemop(Loop * loop, LoopCount *loopCount, const MemOpEmitData* emitD
         IR::RegOpnd *srcIndexOpnd = nullptr;
         IRType srcType;
         GetMemOpSrcInfo(loop, data->ldElemInstr, srcBaseOpnd, srcIndexOpnd, srcType);
-        Assert(GetVarSymID(srcIndexOpnd->GetStackSym()) == GetVarSymID(srcIndexOpnd->GetStackSym()));
+        Assert(GetVarSymID(srcIndexOpnd->GetStackSym()) == GetVarSymID(indexOpnd->GetStackSym()));
 
         src1 = IR::IndirOpnd::New(srcBaseOpnd, startIndexOpnd, srcType, localFunc);
     }

--- a/lib/Backend/IRBuilder.cpp
+++ b/lib/Backend/IRBuilder.cpp
@@ -1113,7 +1113,7 @@ IRBuilder::AddInstr(IR::Instr *instr, uint32 offset)
         }
         instr->SetByteCodeOffset(offset);
     }
-    else if (m_lastInstr)
+    else
     {
         instr->SetByteCodeOffset(m_lastInstr->GetByteCodeOffset());
     }

--- a/lib/Backend/IRBuilderAsmJs.cpp
+++ b/lib/Backend/IRBuilderAsmJs.cpp
@@ -225,7 +225,7 @@ IRBuilderAsmJs::AddInstr(IR::Instr * instr, uint32 offset)
         }
         instr->SetByteCodeOffset(offset);
     }
-    else if (m_lastInstr)
+    else
     {
         instr->SetByteCodeOffset(m_lastInstr->GetByteCodeOffset());
     }
@@ -1943,7 +1943,7 @@ IRBuilderAsmJs::BuildReg1Double1(Js::OpCodeAsmJs newOpcode, uint32 offset, Js::R
     {
     case Js::OpCodeAsmJs::ArgOut_Db:
         symDst = m_func->m_symTable->GetArgSlotSym((uint16)(dstReg+1));
-        if (symDst == nullptr || (uint16)(dstReg + 1) != (dstReg + 1))
+        if ((uint16)(dstReg + 1) != (dstReg + 1))
         {
             AssertMsg(UNREACHED, "Arg count too big...");
             Fatal();
@@ -1964,7 +1964,7 @@ IRBuilderAsmJs::BuildReg1Double1(Js::OpCodeAsmJs newOpcode, uint32 offset, Js::R
     case Js::OpCodeAsmJs::I_ArgOut_Db:
         symDst = StackSym::NewArgSlotSym((uint16)dstReg, m_func, TyFloat64);
         symDst->m_allocated = true;
-        if (symDst == nullptr || (uint16)(dstReg) != (dstReg))
+        if ((uint16)(dstReg) != (dstReg))
         {
             AssertMsg(UNREACHED, "Arg count too big...");
             Fatal();
@@ -2008,7 +2008,7 @@ IRBuilderAsmJs::BuildReg1Float1(Js::OpCodeAsmJs newOpcode, uint32 offset, Js::Re
     {
         StackSym * symDst = StackSym::NewArgSlotSym((uint16)dstReg, m_func, TyFloat32);
         symDst->m_allocated = true;
-        if (symDst == nullptr || (uint16)(dstReg) != (dstReg))
+        if ((uint16)(dstReg) != (dstReg))
         {
             AssertMsg(UNREACHED, "Arg count too big...");
             Fatal();
@@ -2053,7 +2053,7 @@ IRBuilderAsmJs::BuildReg1Int1(Js::OpCodeAsmJs newOpcode, uint32 offset, Js::RegS
     {
     case Js::OpCodeAsmJs::ArgOut_Int:
         symDst = m_func->m_symTable->GetArgSlotSym((uint16)(dstReg + 1));
-        if (symDst == nullptr || (uint16)(dstReg + 1) != (dstReg + 1))
+        if ((uint16)(dstReg + 1) != (dstReg + 1))
         {
             AssertMsg(UNREACHED, "Arg count too big...");
             Fatal();
@@ -2074,7 +2074,7 @@ IRBuilderAsmJs::BuildReg1Int1(Js::OpCodeAsmJs newOpcode, uint32 offset, Js::RegS
     case Js::OpCodeAsmJs::I_ArgOut_Int:
         symDst = StackSym::NewArgSlotSym((uint16)dstReg, m_func, TyInt32);
         symDst->m_allocated = true;
-        if (symDst == nullptr || (uint16)(dstReg) != (dstReg))
+        if ((uint16)(dstReg) != (dstReg))
         {
             AssertMsg(UNREACHED, "Arg count too big...");
             Fatal();
@@ -3589,7 +3589,7 @@ void IRBuilderAsmJs::BuildReg1Float32x4_1(Js::OpCodeAsmJs newOpcode, uint32 offs
     {
         symDst = StackSym::NewArgSlotSym((uint16)dstRegSlot, m_func, TySimd128F4);
         symDst->m_allocated = true;
-        if (symDst == nullptr || (uint16)(dstRegSlot) != (dstRegSlot))
+        if ((uint16)(dstRegSlot) != (dstRegSlot))
         {
             AssertMsg(UNREACHED, "Arg count too big...");
             Fatal();
@@ -4111,7 +4111,7 @@ void IRBuilderAsmJs::BuildReg1Int32x4_1(Js::OpCodeAsmJs newOpcode, uint32 offset
     {
         symDst = StackSym::NewArgSlotSym((uint16)dstRegSlot, m_func, TySimd128I4);
         symDst->m_allocated = true;
-        if (symDst == nullptr || (uint16)(dstRegSlot) != (dstRegSlot))
+        if ((uint16)(dstRegSlot) != (dstRegSlot))
         {
             AssertMsg(UNREACHED, "Arg count too big...");
             Fatal();
@@ -4508,7 +4508,7 @@ void IRBuilderAsmJs::BuildReg1Float64x2_1(Js::OpCodeAsmJs newOpcode, uint32 offs
     {
         symDst = StackSym::NewArgSlotSym((uint16)dstRegSlot, m_func, TySimd128D2);
         symDst->m_allocated = true;
-        if (symDst == nullptr || (uint16)(dstRegSlot) != (dstRegSlot))
+        if ((uint16)(dstRegSlot) != (dstRegSlot))
         {
             AssertMsg(UNREACHED, "Arg count too big...");
             Fatal();

--- a/lib/Backend/Inline.cpp
+++ b/lib/Backend/Inline.cpp
@@ -1178,7 +1178,6 @@ Inline::BuildInlinee(Js::FunctionBody* funcBody, const InlineeData& inlineeData,
 {
     Assert(callInstr->IsProfiledInstr());
     Js::ProfileId callSiteId = static_cast<Js::ProfileId>(callInstr->AsProfiledInstr()->u.profileId);
-    Assert(callSiteId >= 0);
 
     Js::ProxyEntryPointInfo *defaultEntryPointInfo = funcBody->GetDefaultEntryPointInfo();
     Assert(defaultEntryPointInfo->IsFunctionEntryPointInfo());
@@ -2631,7 +2630,6 @@ Inline::InlineCallApplyTarget_Shared(IR::Instr *callInstr, StackSym* originalCal
 
     Assert(callInstr->IsProfiledInstr());
     Js::ProfileId callSiteId = static_cast<Js::ProfileId>(callInstr->AsProfiledInstr()->u.profileId);
-    Assert(callSiteId >= 0);
 
     // inlinee
     Js::ProxyEntryPointInfo *defaultEntryPointInfo = funcBody->GetDefaultEntryPointInfo();
@@ -3668,7 +3666,6 @@ Inline::InlineScriptFunction(IR::Instr *callInstr, const Js::FunctionCodeGenJitT
 
     Assert(callInstr->IsProfiledInstr());
     Js::ProfileId callSiteId = static_cast<Js::ProfileId>(callInstr->AsProfiledInstr()->u.profileId);
-    Assert(callSiteId >= 0);
 
     Js::ProxyEntryPointInfo *defaultEntryPointInfo = funcBody->GetDefaultEntryPointInfo();
     Assert(defaultEntryPointInfo->IsFunctionEntryPointInfo());

--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -3230,7 +3230,7 @@ Lowerer::GenerateFastBrSrEq(IR::Instr * instr, IR::RegOpnd * srcReg1, IR::RegOpn
         this->LowerBrCMem(instr, IR::HelperOp_StrictEqualEmptyString, noMathFastPath, false);
         return true;
     }
-    else if (srcReg1 && (srcReg1->m_sym->m_isStrConst))
+    else if (srcReg1 && (srcReg1->m_sym->m_isStrEmpty))
     {
         instr->SwapOpnds();
         this->LowerBrCMem(instr, IR::HelperOp_StrictEqualEmptyString, noMathFastPath, false);

--- a/lib/Runtime/Base/Constants.h
+++ b/lib/Runtime/Base/Constants.h
@@ -36,7 +36,7 @@ namespace Js
         static const PropertyIndex      PropertyIndexMax            = 0xFFFE;
         static const BigPropertyIndex   NoBigSlot                   = (BigPropertyIndex)-1;
         static const int                IntMaxValue                 = 2147483647;
-        static const int                Int31MinValue               = -1 << 30;
+        static const int                Int31MinValue               = -1073741824; //0xC0000000
         static const int                Int31MaxValue               = ~Int31MinValue;
         static const unsigned int       UShortMaxValue              = 0xFFFF;
         static const uint               InvalidSourceIndex          = (uint)-1;

--- a/lib/Runtime/Debug/DiagHelperMethodWrapper.cpp
+++ b/lib/Runtime/Debug/DiagHelperMethodWrapper.cpp
@@ -212,8 +212,7 @@ namespace Js
         // Note: there also could be plain OutOfMemoryException and StackOverflowException, no special handling for these.
         if (!exceptionObject->IsDebuggerSkip() ||
             exceptionObject == scriptContext->GetThreadContext()->GetPendingOOMErrorObject() ||
-            exceptionObject == scriptContext->GetThreadContext()->GetPendingSOErrorObject() ||
-            !scriptContext)
+            exceptionObject == scriptContext->GetThreadContext()->GetPendingSOErrorObject())
         {
             throw exceptionObject->CloneIfStaticExceptionObject(scriptContext);
         }

--- a/lib/Runtime/Debug/DiagObjectModel.cpp
+++ b/lib/Runtime/Debug/DiagObjectModel.cpp
@@ -120,7 +120,7 @@ namespace Js
             pOMDisplay = Anew(pRefArena->Arena(), RecyclableObjectDisplay, this);
         }
 
-        if (this->isConst || this->propId == Js::PropertyIds::_superReferenceSymbol || this->propId == Js::PropertyIds::_superReferenceSymbol)
+        if (this->isConst || this->propId == Js::PropertyIds::_superReferenceSymbol || this->propId == Js::PropertyIds::_superCtorReferenceSymbol)
         {
             pOMDisplay->SetDefaultTypeAttribute(DBGPROP_ATTRIB_VALUE_READONLY);
         }
@@ -2009,13 +2009,14 @@ namespace Js
         AssertMsg(pResolvedObject, "Bad usage of RecyclableObjectWalker::Get");
 
         int fakeObjCount = fakeGroupObjectWalkerList ? fakeGroupObjectWalkerList->Count() : 0;
-        int nonArrayElementCount = Js::RecyclableObject::Is(instance) ? pMembersList->Count() : 0;
         int arrayItemCount = innerArrayObjectWalker ? innerArrayObjectWalker->GetChildrenCount() : 0;
 
         if (index < 0 || !pMembersList || index >= (pMembersList->Count() + arrayItemCount + fakeObjCount))
         {
             return FALSE;
         }
+
+        int nonArrayElementCount = Js::RecyclableObject::Is(instance) ? pMembersList->Count() : 0;
 
         // First the virtual groups
         if (index < fakeObjCount)

--- a/lib/Runtime/Language/FunctionCodeGenJitTimeData.h
+++ b/lib/Runtime/Language/FunctionCodeGenJitTimeData.h
@@ -622,7 +622,6 @@ namespace Js
             }
             inlinees[profiledCallSiteId] = this;
             inlineeCount++;
-            this->isInlined = isInlined;
         }
 
         uint16 GetProfiledIterations() const;

--- a/lib/Runtime/Library/SparseArraySegment.inl
+++ b/lib/Runtime/Library/SparseArraySegment.inl
@@ -352,7 +352,7 @@ namespace Js
         }
         dst->length = newLen;
         Assert(dst->length <= dst->size);
-        AssertMsg(srcIndex - src->left >= 0,"src->left > srcIndex resulting in negative indexing of src->elements");
+        AssertMsg(srcIndex >= src->left,"src->left > srcIndex resulting in negative indexing of src->elements");
         js_memcpy_s(dst->elements + dstIndex - dst->left, sizeof(T) * inputLen, src->elements + srcIndex - src->left, sizeof(T) * inputLen);
         return dst;
     }


### PR DESCRIPTION
This PR fixes the issues reported in https://github.com/Microsoft/ChakraCore/issues/177

Following two are bug with ChakraCore:
* There are identical sub-expressions 'this->propId == Js::PropertyIds::_superReferenceSymbol' to the left and to the right of the '||' operator Comment: This is a bug. The superCtorReferenceSymbol is misspelled ( ec8d276 )
* The use of 'if (A) {...} else if (A) {...}' pattern was detected. There is a probability of logical error presence (16b407b)

Following two are bug with test driver which runs ChakraCore:
* Array overrun is possible. Comments:  This is in test code rl.exe not in shipping ChakraCore or Chakra.dll (9765e7c)
* Consider inspecting the 'sub[i] != '-' && sub[i] == '/'' expression. The expression is excessive or contains a misprint. rl.cpp (9765e7c)

Following are incorrect asserts with no product impact:
* There are identical sub-expressions 'GetVarSymID(srcIndexOpnd->GetStackSym())' to the left and to the right of the '==' operator (201fa36)
* Expression 'srcIndex - src->left >= 0' is always true. Unsigned type value is always >= 0. (5e8716b)
* Expression 'callSiteId >= 0' is always true. (723d946)
* Expression is always true. Probably the '&&' operator should be used here. *I haven't fix this assert in ByteCodeGenerator::AssignRegister as it seem to hit in unittest. I will open a issue for the same.*

Following are not  bugs as they are mostly redudant checks. Good to fix from code hygiene perspective:
* Undefined behavior. Check the shift operator '<<'. The left operand '-1' is negative. ( 8d36f95)
* The 'this->isInlined' variable is assigned to itself. (ab04762)
* The pointer scriptContext was utilized in the logical expression before it was verified against nullptr in the same logical expression. (3252d0d)
* The 'symDst' pointer was utilized before it was verified against nullptr. (4cb0212)
* The 'm_lastInstr' pointer was utilized before it was verified against nullptr. (54c6ccb)
* The 'src2Val' pointer was utilized before it was verified against nullptr. (9ade8e3)
* The 'instrLd' pointer was utilized before it was verified against nullptr (Added an assert) (73d8aea)
* The 'pMembersList' pointer was utilized before it was verified against nullptr ( ec8d276 )

Following are not bugs and I haven't fixed them either
* The object was created but it is not being used. If you wish to call constructor, 'this->StringCopyInfo::StringCopyInfo(....)' should be used   *This function is unused but required for avoiding errors in the linker due to force-inline. See comments in the function.*
* The 'walkerRef' pointer was utilized before it was verified against nullptr. *Guaranteed to be non-null if walker is initialized*
* The 'block->loop' pointer was utilized before it was verified against nullptr. *Control flow gauranees block->loop to be non-null. The block->isLoopHeader is checked rightly before accessing the block->loop.*  