### PR TITLE
Add IRBuilder codepath for CallIExtendedFlags

### DIFF
--- a/lib/Backend/IRBuilder.h
+++ b/lib/Backend/IRBuilder.h
@@ -186,7 +186,7 @@ private:
     void                BuildProfiled2CallIExtended(Js::OpCode opcode, uint32 offset, Js::RegSlot returnValue, Js::RegSlot function,
                             Js::ArgSlot argCount, Js::ProfileId profileId, Js::ProfileId profileId2, Js::CallIExtendedOptions options, uint32 spreadAuxOffset);
     void                BuildLdSpreadIndices(uint32 offset, uint32 spreadAuxOffset);
-    void                BuildCallIExtended(Js::OpCode newOpcode, uint32 offset, Js::RegSlot returnValue, Js::RegSlot function,
+    IR::Instr *         BuildCallIExtended(Js::OpCode newOpcode, uint32 offset, Js::RegSlot returnValue, Js::RegSlot function,
                             Js::ArgSlot argCount, Js::CallIExtendedOptions options, uint32 spreadAuxOffset);
     void                BuildCallCommon(IR::Instr *instr, StackSym *symDst, Js::ArgSlot argCount);
     void                BuildRegexFromPattern(Js::RegSlot dstRegSlot, uint32 patternIndex, uint32 offset);

--- a/test/Bugs/OS_5248645.js
+++ b/test/Bugs/OS_5248645.js
@@ -1,0 +1,15 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+//Switches: -maxinterpretCount:2 -off:simplejit -off:dynamicProfile
+// Exercises IRBuilder::BuildCallIExtendedFlags()
+
+function f() {
+    eval("");
+};
+
+f();
+f();
+f();
+print("pass");

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -228,4 +228,11 @@
       <baseline>fabs1.baseline</baseline>
     </default>
   </test>
+  <test>
+    <default>
+      <files>OS_5248645.js</files>
+      <tags>exclude_dynapogo</tags>
+      <compile-flags>-maxinterpretCount:2 -off:simplejit -off:dynamicProfile -args summary -endargs</compile-flags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
Add IRBuilder codepath for CallIExtendedFlags

A fuzzer-generated test case uncovered a not-yet-implemented codepath
in IRBuilder for CallIExtendedFlags.

This changeset implements that codepath and adds the test case to
core tests.
