### PR TITLE
Include a note about why VBSERR macros in lib/Parser/rterrors.h should not be "cleaned up".

### DIFF
--- a/lib/Parser/rterrors.h
+++ b/lib/Parser/rterrors.h
@@ -20,6 +20,9 @@
 #define RT_ERROR_MSG_UNUSED_ENTRY
 #endif
 
+// These VBS macros were taken from VBScript and the names and definitions are
+// written in stone. Other projects depend on these definitions as well.
+// Keep the commented lines as documentation of values that should not be reused.
 
 RT_ERROR_MSG(VBSERR_None, 0,    "", "", kjstError, 0)
 //RT_ERROR_MSG(VBSERR_ReturnWOGoSub, 3,    "",   "Return without GoSub")


### PR DESCRIPTION
Investigation revealed that these names and definitions are depended-on as-is in Chakra as well as other projects outside of Chakra, so we should not change their names or values.

Added a note to remind future maintainers about this.

Reviewed by @tcare

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/214)
<!-- Reviewable:end -->
