### PR TITLE
Implementation of decoding and compilation of tableswitch opcodes

### DIFF
--- a/lib/WasmReader/WasmBinaryOpcodes.h
+++ b/lib/WasmReader/WasmBinaryOpcodes.h
@@ -68,7 +68,7 @@ WASM_CTRL_OPCODE(IfElse,         0x04,       IF_ELSE,            Limit)
 WASM_CTRL_OPCODE(Select,         0x05,       LIMIT,              Limit)
 WASM_CTRL_OPCODE(Br,             0x06,       BREAK,              Limit)
 WASM_CTRL_OPCODE(BrIf,           0x07,       LIMIT,              Limit)
-WASM_CTRL_OPCODE(TableSwitch,    0x08,       LIMIT,              Limit)
+WASM_CTRL_OPCODE(TableSwitch,    0x08,       SWITCH,             Limit)
 WASM_CTRL_OPCODE(Return,         0x14,       RETURN,             Limit)
 WASM_CTRL_OPCODE(Unreachable,    0x15,       LIMIT,              Limit)
 

--- a/lib/WasmReader/WasmBinaryReader.cpp
+++ b/lib/WasmReader/WasmBinaryReader.cpp
@@ -236,6 +236,9 @@ WasmBinaryReader::ASTNode()
     case wbBrIf:
         BrNode();
         break;
+    case wbTableSwitch:
+        TableSwitchNode();
+        break;
     case wbReturn:
         // Watch out for optional implicit block
         // (non-void return expression)
@@ -308,6 +311,20 @@ WasmBinaryReader::BrNode()
 {
     m_currentNode.br.depth = ReadConst<UINT8>();
     m_funcState.count++;
+}
+
+void
+WasmBinaryReader::TableSwitchNode()
+{
+    m_currentNode.tableswitch.numCases = ReadConst<UINT16>();
+    m_currentNode.tableswitch.numEntries = ReadConst<UINT16>();
+    m_funcState.count += 2*sizeof(UINT16);
+    m_currentNode.tableswitch.jumpTable = AnewArray(&m_alloc, UINT16, m_currentNode.tableswitch.numEntries);
+    for (int i = 0; i < m_currentNode.tableswitch.numEntries; i++)
+    {
+        m_currentNode.tableswitch.jumpTable[i] = ReadConst<UINT16>();
+        m_funcState.count += sizeof(UINT16);
+    }
 }
 
 // Locals/Globals

--- a/lib/WasmReader/WasmBinaryReader.h
+++ b/lib/WasmReader/WasmBinaryReader.h
@@ -115,6 +115,7 @@ namespace Wasm
             void CallNode();
             void BlockNode();
             void BrNode();
+            void TableSwitchNode();
             void VarNode();
             template <WasmTypes::LocalType type> void ConstNode();
             // readers

--- a/lib/WasmReader/WasmBytecodeGenerator.h
+++ b/lib/WasmReader/WasmBytecodeGenerator.h
@@ -109,6 +109,7 @@ namespace Wasm
         EmitInfo EmitCall();
         EmitInfo EmitIfExpr();
         EmitInfo EmitIfElseExpr();
+        EmitInfo EmitSwitch();
         EmitInfo EmitGetLocal();
         EmitInfo EmitSetLocal();
         EmitInfo EmitReturnExpr(EmitInfo *lastStmtExprInfo = nullptr);

--- a/lib/WasmReader/WasmParseTree.h
+++ b/lib/WasmReader/WasmParseTree.h
@@ -87,6 +87,14 @@ namespace Wasm
     {
         UINT8 depth;
     };
+
+    struct WasmTableSwitchNode
+    {
+        UINT16 numCases;
+        UINT16 numEntries;
+        UINT16* jumpTable;
+    };
+
     struct WasmNode
     {
         WasmOp op;
@@ -99,6 +107,7 @@ namespace Wasm
             WasmOptionalNode opt;
             WasmBlockNode block;
             WasmBrNode br;
+            WasmTableSwitchNode tableswitch;
         };
     };
 }


### PR DESCRIPTION
Because the BytecodeGenerator is missing support for ConstRegs,
this implementation is using TempRegs to substitute for now.