### PR TITLE
Native for loop's head has destructuring declaration which must have an initializer.

### DIFF
--- a/lib/Parser/parse.h
+++ b/lib/Parser/parse.h
@@ -641,7 +641,8 @@ private:
         BOOL singleDefOnly = FALSE,
         BOOL allowInit = TRUE,
         BOOL isTopVarParse = TRUE,
-        BOOL isFor = FALSE);
+        BOOL isFor = FALSE,
+        BOOL* nativeForOk = nullptr);
     BOOL TokIsForInOrForOf();
 
     template<bool buildAST>
@@ -841,7 +842,8 @@ private:
         bool topLevel = true,
         DestructuringInitializerContext initializerContext = DIC_None,
         bool allowIn = true,
-        BOOL *forInOfOkay = nullptr);
+        BOOL *forInOfOkay = nullptr,
+        BOOL *nativeForOkay = nullptr);
 
     template <bool buildAST>
     ParseNodePtr ParseDestructuredVarDecl(tokens declarationType, bool isDecl, bool *hasSeenRest, bool topLevel = true);
@@ -852,7 +854,8 @@ private:
         bool topLevel,
         DestructuringInitializerContext initializerContext,
         bool allowIn,
-        BOOL *forInOfOkay);
+        BOOL *forInOfOkay,
+        BOOL *nativeForOkay);
 
     template<bool CheckForNegativeInfinity> static bool IsNaNOrInfinityLiteral(LPCOLESTR str);
 

--- a/test/es6/destructuring_bugs.js
+++ b/test/es6/destructuring_bugs.js
@@ -19,6 +19,12 @@ var tests = [
       assert.throws(function () { eval("let a = [a] = [10]"); }, ReferenceError, "A let variable is used in the array pattern in the same statement where it is declared", "Use before declaration");
       assert.throws(function () { eval("let a = {a:a} = {}"); }, ReferenceError, "A let variable is used in object pattern in the same statement where it is declared", "Use before declaration");
       assert.throws(function () { eval("var a = 1; (delete [a] = [2]);"); }, ReferenceError, "Array literal in unary expression should not be converted to array pattern", "Invalid left-hand side in assignment");
+      assert.throws(function () { eval("var x, b; for ([x] = [((b) = 1)] of ' ') { }"); }, ReferenceError, "Initializer in for..in is not valid but no assert should be thrown", "Invalid left-hand side in assignment");
+      assert.throws(function () { eval("for (let []; ;) { }"); }, SyntaxError, "Native for loop's head has one destructuring pattern without initializer", "Destructuring declarations must have an initializer");
+      assert.throws(function () { eval("for (let a = 1, []; ;) { }"); }, SyntaxError, "Native for loop's head has second param as destructuring pattern without initializer", "Destructuring declarations must have an initializer");
+      assert.throws(function () { eval("for (let [] = [], a = 1, {}; ;) { }"); }, SyntaxError, "Native for loop's head has third param as object destructuring pattern without initializer", "Destructuring declarations must have an initializer");
+      assert.throws(function () { eval("for (let [[a] = []]; ;) { }"); }, SyntaxError, "Native for loop's head as destructuring pattern without initializer", "Destructuring declarations must have an initializer");
+      assert.doesNotThrow(function () { eval("for ([]; ;) { break; }"); }, SyntaxError, "Native for loop's head is an expression without initializer is valid syntax");
     }
   },
   {


### PR DESCRIPTION
Native for loop's head has destructuring declaration which must have an initializer.

Native for loop with destructuring does not enforce that it must have an initializer. For that purpose the ParseVariableDeclaration takes another param which is actually deducing whether native for loop is okay or not. We do this kind of checking as we don't know whether current loop turned out to be native loop or for..in/of loop.
If the current syntax turned out to be native for loop and during declaration we deduced that native for loop will not be okay then we throw error.
While playing with different test cases  I found that TrackAssignment assert requires adjustment as in the case of for..in loop we rescan the loop head again for validating destructuring grammar. Due that assert is not valid as the symbol span require re-adjustment.
Added few tests to cover more cases.