### PR TITLE
Adding do..while trick on the assert code so that missing semicolon error will be caught during debug mode.

### DIFF
--- a/lib/Backend/Encoder.cpp
+++ b/lib/Backend/Encoder.cpp
@@ -965,7 +965,7 @@ void Encoder::CopyMaps(OffsetList **m_origInlineeFrameRecords
         Assert(origPInstrList->Count() == pInstrList->Count());
 
 #if DBG_DUMP
-        Assert(m_origOffsetBuffer)
+        Assert(m_origOffsetBuffer);
         Assert((uint32)(*m_origOffsetBuffer)->Count() == m_instrNumber);
 #endif
     }

--- a/lib/Runtime/Library/ScriptFunction.cpp
+++ b/lib/Runtime/Library/ScriptFunction.cpp
@@ -37,7 +37,7 @@ namespace Js
         hasInlineCaches(false), hasSuperReference(false), isActiveScript(false)
     {
         Assert(proxy->GetFunctionProxy() == proxy);
-        Assert(proxy->EnsureDeferredPrototypeType() == deferredPrototypeType)
+        Assert(proxy->EnsureDeferredPrototypeType() == deferredPrototypeType);
         DebugOnly(VerifyEntryPoint());
 
 #if ENABLE_NATIVE_CODEGEN

--- a/lib/common/core/Assertions.h
+++ b/lib/common/core/Assertions.h
@@ -31,7 +31,7 @@ _declspec(thread, selectany) int IsInAssert = false;
 #endif
 
 #define AssertMsg(f, comment) \
-    { \
+    do { \
         if (!(f)) \
         { \
             AssertCount++; \
@@ -44,7 +44,7 @@ _declspec(thread, selectany) int IsInAssert = false;
             IsInAssert = FALSE; \
             __analysis_assume(false); \
         } \
-    }
+    } while (false)
 
 #define Assert(exp)           AssertMsg(exp, #exp)
 #define AssertVerify(exp)     Assert(exp)


### PR DESCRIPTION
Adding do..while trick on the assert code so that missing semicolon error will be caught during debug mode.
