### PR TITLE
Fix "NoJIT" build

### DIFF
--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -1351,6 +1351,7 @@ namespace Js
             DeferredTypeHandler<InitializeMathObject>::GetDefaultInstance()));
         AddMember(globalObject, PropertyIds::Math, mathObject);
 
+#if ENABLE_NATIVE_CODEGEN
         // SIMD_JS
         // we declare global objects and lib functions only if SSE2 is available. Else, we use the polyfill.
         if (GetScriptContext()->GetConfig()->IsSimdjsEnabled())
@@ -1377,6 +1378,7 @@ namespace Js
             simdUint16x8ToStringFunction = DefaultCreateFunction(&JavascriptSIMDUint16x8::EntryInfo::ToString, 1, nullptr, nullptr, PropertyIds::toString);
             simdUint8x16ToStringFunction = DefaultCreateFunction(&JavascriptSIMDUint8x16::EntryInfo::ToString, 1, nullptr, nullptr, PropertyIds::toString);
         }
+#endif
 
         debugObject = nullptr;
 

--- a/lib/Runtime/Library/SIMDBool16x8Lib.cpp
+++ b/lib/Runtime/Library/SIMDBool16x8Lib.cpp
@@ -6,6 +6,7 @@
 
 // SIMD_JS
 
+#if ENABLE_NATIVE_CODEGEN
 namespace Js
 {
     Var SIMDBool16x8Lib::EntryBool16x8(RecyclableObject* function, CallInfo callInfo, ...)
@@ -282,3 +283,4 @@ namespace Js
         JavascriptError::ThrowTypeError(scriptContext, JSERR_SimdBool16x8TypeMismatch, L"xor");
     }
 }
+#endif

--- a/lib/Runtime/Library/SIMDBool32x4Lib.cpp
+++ b/lib/Runtime/Library/SIMDBool32x4Lib.cpp
@@ -6,6 +6,7 @@
 
 // SIMD_JS
 
+#if ENABLE_NATIVE_CODEGEN
 namespace Js
 {
     Var SIMDBool32x4Lib::EntryBool32x4(RecyclableObject* function, CallInfo callInfo, ...)
@@ -272,3 +273,4 @@ namespace Js
     }
 
 }
+#endif

--- a/lib/Runtime/Library/SIMDBool8x16Lib.cpp
+++ b/lib/Runtime/Library/SIMDBool8x16Lib.cpp
@@ -6,6 +6,7 @@
 
 // SIMD_JS
 
+#if ENABLE_NATIVE_CODEGEN
 namespace Js
 {
     Var SIMDBool8x16Lib::EntryBool8x16(RecyclableObject* function, CallInfo callInfo, ...)
@@ -279,3 +280,4 @@ namespace Js
     }
 
 }
+#endif

--- a/lib/Runtime/Library/SIMDInt16x8Lib.cpp
+++ b/lib/Runtime/Library/SIMDInt16x8Lib.cpp
@@ -5,6 +5,7 @@
 
 #include "RuntimeLibraryPch.h"
 
+#if ENABLE_NATIVE_CODEGEN
 namespace Js
 {
 
@@ -940,4 +941,4 @@ namespace Js
         JavascriptError::ThrowTypeError(scriptContext, JSERR_SimdInt16x8TypeMismatch, L"select");
     }
 }
-
+#endif

--- a/lib/Runtime/Library/SIMDInt8x16Lib.cpp
+++ b/lib/Runtime/Library/SIMDInt8x16Lib.cpp
@@ -4,6 +4,7 @@
 //-------------------------------------------------------------------------------------------------------
 #include "RuntimeLibraryPch.h"
 
+#if ENABLE_NATIVE_CODEGEN
 namespace Js
 {
 
@@ -942,3 +943,4 @@ namespace Js
         JavascriptError::ThrowTypeError(scriptContext, JSERR_SimdInt8x16TypeMismatch, L"ReplaceLane");
     }
 }
+#endif

--- a/lib/Runtime/Library/SIMDUInt32x4Lib.cpp
+++ b/lib/Runtime/Library/SIMDUInt32x4Lib.cpp
@@ -4,6 +4,7 @@
 //-------------------------------------------------------------------------------------------------------
 #include "RuntimeLibraryPch.h"
 
+#if ENABLE_NATIVE_CODEGEN
 namespace Js
 {
 
@@ -989,3 +990,4 @@ namespace Js
     }
 
 }
+#endif

--- a/lib/Runtime/Library/SIMDUint16x8Lib.cpp
+++ b/lib/Runtime/Library/SIMDUint16x8Lib.cpp
@@ -5,6 +5,7 @@
 
 #include "RuntimeLibraryPch.h"
 
+#if ENABLE_NATIVE_CODEGEN
 namespace Js
 {
     Var SIMDUint16x8Lib::EntryUint16x8(RecyclableObject* function, CallInfo callInfo, ...)
@@ -911,3 +912,4 @@ namespace Js
         JavascriptError::ThrowTypeError(scriptContext, JSERR_SimdUint16x8TypeMismatch, L"select");
     }
 }
+#endif

--- a/lib/Runtime/Library/SIMDUint8x16Lib.cpp
+++ b/lib/Runtime/Library/SIMDUint8x16Lib.cpp
@@ -5,6 +5,7 @@
 
 #include "RuntimeLibraryPch.h"
 
+#if ENABLE_NATIVE_CODEGEN
 namespace Js
 {
     Var SIMDUint8x16Lib::EntryUint8x16(RecyclableObject* function, CallInfo callInfo, ...)
@@ -920,3 +921,4 @@ namespace Js
         JavascriptError::ThrowTypeError(scriptContext, JSERR_SimdUint8x16TypeMismatch, L"select");
     }
 }
+#endif


### PR DESCRIPTION
Fix "NoJIT" build

The "NoJIT" build disables native codegen and we don't initialize SIMD
when native codegen is disabled. In Git commit "0af32b1", we removed the
check for native codegen around some SIMD initialization code, and since
this initialization depends on code that would be disabled without
native codegen, the "NoJIT" build wasn't succeeding.

Also, some SIMD code (e.g. lib\Runtime\Library\SIMDInt16x8Lib.cpp)
depends on types that aren't available when native codegen is disabled
(e.g. TySize & TyInt16). Their status now matches native codegen's.
