### PR TITLE
Remove invalid assert in inner scope enumeration

### DIFF
--- a/lib/Runtime/ByteCode/Scope.h
+++ b/lib/Runtime/ByteCode/Scope.h
@@ -289,7 +289,7 @@ public:
 
     bool HasInnerScopeIndex() const { return innerScopeIndex != (uint)-1; }
     uint GetInnerScopeIndex() const { return innerScopeIndex; }
-    void SetInnerScopeIndex(uint index) { Assert(innerScopeIndex == (uint)-1 || innerScopeIndex == index); innerScopeIndex = index; }
+    void SetInnerScopeIndex(uint index) { innerScopeIndex = index; }
 
     int AddScopeSlot();
 


### PR DESCRIPTION
Remove invalid assert. Inner scope enumeration can happen multiple times if we re-visit the AST during byte code gen. The re-enumeration is valid, so just let it happen.
