### PR TITLE
Empty pattern for destructuring case.

### DIFF
--- a/lib/Parser/parse.cpp
+++ b/lib/Parser/parse.cpp
@@ -5364,12 +5364,12 @@ void Parser::ParseFncFormals(ParseNodePtr pnodeFnc, ushort flags)
                         {
                             // When only validating formals, we won't have a function node.
                             pnodeFnc->sxFnc.pnodeRest = pnodeT;
-                        }
-                        if (!isNonSimpleParameterList)
-                        {
-                            // This is the first non-simple parameter we've seen. We need to go back
-                            // and set the Symbols of all previous parameters.
-                            MapFormalsWithoutRest(m_currentNodeFunc, [&](ParseNodePtr pnodeArg) { pnodeArg->sxVar.sym->SetIsNonSimpleParameter(true); });
+                            if (!isNonSimpleParameterList)
+                            {
+                                // This is the first non-simple parameter we've seen. We need to go back
+                                // and set the Symbols of all previous parameters.
+                                MapFormalsWithoutRest(m_currentNodeFunc, [&](ParseNodePtr pnodeArg) { pnodeArg->sxVar.sym->SetIsNonSimpleParameter(true); });
+                            }
                         }
                     }
 
@@ -5430,9 +5430,12 @@ void Parser::ParseFncFormals(ParseNodePtr pnodeFnc, ushort flags)
                         pnodeT->sxVar.sym->SetIsNonSimpleParameter(true);
                         if (!isNonSimpleParameterList)
                         {
-                            // This is the first non-simple parameter we've seen. We need to go back
-                            // and set the Symbols of all previous parameters.
-                            MapFormalsWithoutRest(m_currentNodeFunc, [&](ParseNodePtr pnodeArg) { pnodeArg->sxVar.sym->SetIsNonSimpleParameter(true); });
+                            if (buildAST)
+                            {
+                                // This is the first non-simple parameter we've seen. We need to go back
+                                // and set the Symbols of all previous parameters.
+                                MapFormalsWithoutRest(m_currentNodeFunc, [&](ParseNodePtr pnodeArg) { pnodeArg->sxVar.sym->SetIsNonSimpleParameter(true); });
+                            }
 
                             // There may be previous parameters that need to be checked for duplicates.
                             isNonSimpleParameterList = true;

--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -3864,7 +3864,7 @@ void ByteCodeGenerator::StartEmitCatch(ParseNode *pnodeCatch)
     if (pnodeCatch->sxCatch.pnodeParam->nop == knopParamPattern)
     {
         scope->SetCapturesAll(funcInfo->GetCallsEval() || funcInfo->GetChildCallsEval());
-        scope->SetMustInstantiate(scope->GetMustInstantiate() || scope->GetCapturesAll() || funcInfo->IsGlobalFunction());
+        scope->SetMustInstantiate(scope->Count() > 0 && (scope->GetMustInstantiate() || scope->GetCapturesAll() || funcInfo->IsGlobalFunction()));
 
         Parser::MapBindIdentifier(pnodeCatch->sxCatch.pnodeParam->sxParamPattern.pnode1, [&](ParseNodePtr item)
         {

--- a/test/es6/destructuring_bugs.js
+++ b/test/es6/destructuring_bugs.js
@@ -24,7 +24,10 @@ var tests = [
       assert.throws(function () { eval("for (let a = 1, []; ;) { }"); }, SyntaxError, "Native for loop's head has second param as destructuring pattern without initializer", "Destructuring declarations must have an initializer");
       assert.throws(function () { eval("for (let [] = [], a = 1, {}; ;) { }"); }, SyntaxError, "Native for loop's head has third param as object destructuring pattern without initializer", "Destructuring declarations must have an initializer");
       assert.throws(function () { eval("for (let [[a] = []]; ;) { }"); }, SyntaxError, "Native for loop's head as destructuring pattern without initializer", "Destructuring declarations must have an initializer");
-      assert.doesNotThrow(function () { eval("for ([]; ;) { break; }"); }, SyntaxError, "Native for loop's head is an expression without initializer is valid syntax");
+      assert.doesNotThrow(function () { eval("for ([]; ;) { break; }"); }, "Native for loop's head is an expression without initializer is valid syntax");
+      assert.doesNotThrow(function () { eval("try { y; } catch({}) { }"); }, "Catching exception to empty pattern should not assert and is a valid syntax");
+      assert.doesNotThrow(function () { eval("for({} = function (...a) { } in '' ) { }"); }, "Having a function with rest parameter as initializer should not assert and is a valid syntax");
+      assert.doesNotThrow(function () { eval("for([] = ((...a) => {}) in '' ) { }"); }, "Having a lambda function with rest parameter as initializer should not assert and is a valid syntax");
     }
   },
   {


### PR DESCRIPTION
Empty pattern for destructuring case.

Catch can take empty destructuring pattern, in that case we don't need to instantiate the scope as there is no need to create slot array or scope object because there is no catch param. Add a check as count being nonzero.
Another place (parse.cpp) where the m_currentNodeFunc is null because that is deferred parse case. Move the code under buildAST flag (as it was done other places). Added tests
