### PR TITLE
Construct TypedArray from an iterable object

### DIFF
--- a/lib/Runtime/Library/TypedArray.cpp
+++ b/lib/Runtime/Library/TypedArray.cpp
@@ -46,6 +46,54 @@ namespace Js
     {
     }
 
+    inline JsUtil::List<Var, ArenaAllocator>* IterableToList(RecyclableObject *object, ScriptContext *scriptContext, ArenaAllocator *alloc)
+    {
+        Assert(JavascriptOperators::IsIterable(object, scriptContext));
+
+        Var nextValue;
+        RecyclableObject* iterator = JavascriptOperators::GetIterator(object, scriptContext);
+        JsUtil::List<Var, ArenaAllocator>* retList = JsUtil::List<Var, ArenaAllocator>::New(alloc);
+
+        while (JavascriptOperators::IteratorStepAndValue(iterator, scriptContext, &nextValue))
+        {
+            retList->Add(nextValue);
+        }
+
+        return retList;
+    }
+
+    Var TypedArrayBase::CreateNewInstanceFromIterableObj(RecyclableObject *object, ScriptContext *scriptContext, uint32 elementSize, PFNCreateTypedArray pfnCreateTypedArray)
+    {
+        TypedArrayBase *newArr = nullptr;
+
+        DECLARE_TEMP_GUEST_ALLOCATOR(tempAlloc);
+
+        ACQUIRE_TEMP_GUEST_ALLOCATOR(tempAlloc, scriptContext, L"Runtime");
+        {
+            JsUtil::List<Var, ArenaAllocator>* tempList = IterableToList(object, scriptContext, tempAlloc);
+
+            uint32 len = tempList->Count();
+            uint32 byteLen;
+
+            if (UInt32Math::Mul(len, elementSize, &byteLen))
+            {
+                JavascriptError::ThrowRangeError(scriptContext, JSERR_InvalidTypedArrayLength);
+            }
+
+            ArrayBuffer *arrayBuffer = scriptContext->GetLibrary()->CreateArrayBuffer(byteLen);
+            newArr = static_cast<TypedArrayBase*>(pfnCreateTypedArray(arrayBuffer, 0, len, scriptContext->GetLibrary()));
+
+            for (uint32 k = 0; k < len; k++)
+            {
+                Var kValue = tempList->Item(k);
+                newArr->SetItem(k, kValue);
+            }
+        }
+        RELEASE_TEMP_GUEST_ALLOCATOR(tempAlloc, scriptContext);
+
+        return newArr;
+    }
+
     Var TypedArrayBase::CreateNewInstance(Arguments& args, ScriptContext* scriptContext, uint32 elementSize, PFNCreateTypedArray pfnCreateTypedArray)
     {
         uint32 byteLength = 0;
@@ -93,38 +141,46 @@ namespace Js
             }
             else
             {
-                if (JavascriptOperators::IsObject(firstArgument) && JavascriptConversion::ToObject(firstArgument, scriptContext, &jsArraySource))
+                if (JavascriptOperators::IsObject(firstArgument))
                 {
-                    HRESULT hr = scriptContext->GetHostScriptContext()->ArrayBufferFromExternalObject(jsArraySource, &arrayBuffer);
-                    switch (hr)
+                    if (JavascriptOperators::IsIterable(RecyclableObject::FromVar(firstArgument), scriptContext))
                     {
-                    case S_OK:
-                        // We found an IBuffer
-                        fromExternalObject = true;
-                        OUTPUT_TRACE(TypedArrayPhase, L"Projection ArrayBuffer query succeeded with HR=0x%08X\n", hr);
-                        // We have an ArrayBuffer now, so we can skip all the object probing.
-                        break;
-
-                    case S_FALSE:
-                        // We didn't find an IBuffer - fall through
-                        OUTPUT_TRACE(TypedArrayPhase, L"Projection ArrayBuffer query aborted safely with HR=0x%08X (non-handled type)\n", hr);
-                        break;
-
-                    default:
-                        // Any FAILURE HRESULT or unexpected HRESULT
-                        OUTPUT_TRACE(TypedArrayPhase, L"Projection ArrayBuffer query failed with HR=0x%08X\n", hr);
-                        JavascriptError::ThrowTypeError(scriptContext, JSERR_InvalidTypedArray_Constructor);
-                        break;
+                        return CreateNewInstanceFromIterableObj(RecyclableObject::FromVar(firstArgument), scriptContext, elementSize, pfnCreateTypedArray);
                     }
-                    if (!fromExternalObject)
+                    else if (JavascriptConversion::ToObject(firstArgument, scriptContext, &jsArraySource))
                     {
-                        Var lengthVar = JavascriptOperators::OP_GetProperty(jsArraySource, PropertyIds::length, scriptContext);
-                        if (JavascriptOperators::GetTypeId(lengthVar) == TypeIds_Undefined)
+                        HRESULT hr = scriptContext->GetHostScriptContext()->ArrayBufferFromExternalObject(jsArraySource, &arrayBuffer);
+                        switch (hr)
                         {
-                            JavascriptError::ThrowTypeError(
-                                scriptContext, JSERR_InvalidTypedArray_Constructor);
+                        case S_OK:
+                            // We found an IBuffer
+                            fromExternalObject = true;
+                            OUTPUT_TRACE(TypedArrayPhase, L"Projection ArrayBuffer query succeeded with HR=0x%08X\n", hr);
+                            // We have an ArrayBuffer now, so we can skip all the object probing.
+                            break;
+
+                        case S_FALSE:
+                            // We didn't find an IBuffer - fall through
+                            OUTPUT_TRACE(TypedArrayPhase, L"Projection ArrayBuffer query aborted safely with HR=0x%08X (non-handled type)\n", hr);
+                            break;
+
+                        default:
+                            // Any FAILURE HRESULT or unexpected HRESULT
+                            OUTPUT_TRACE(TypedArrayPhase, L"Projection ArrayBuffer query failed with HR=0x%08X\n", hr);
+                            JavascriptError::ThrowTypeError(scriptContext, JSERR_InvalidTypedArray_Constructor);
+                            break;
                         }
-                        elementCount = ToLengthChecked(lengthVar, elementSize, scriptContext);
+                        if (!fromExternalObject)
+                        {
+                            Var lengthVar = JavascriptOperators::OP_GetProperty(jsArraySource, PropertyIds::length, scriptContext);
+                            if (JavascriptOperators::GetTypeId(lengthVar) == TypeIds_Undefined)
+                            {
+                                JavascriptError::ThrowTypeError(
+                                    scriptContext, JSERR_InvalidTypedArray_Constructor);
+                            }
+
+                            elementCount = ToLengthChecked(lengthVar, elementSize, scriptContext);
+                        }
                     }
                 }
                 else
@@ -1363,9 +1419,6 @@ namespace Js
 
         if (JavascriptOperators::IsIterable(items, scriptContext))
         {
-            RecyclableObject* iterator = JavascriptOperators::GetIterator(items, scriptContext);
-            Var nextValue;
-
             DECLARE_TEMP_GUEST_ALLOCATOR(tempAlloc);
 
             ACQUIRE_TEMP_GUEST_ALLOCATOR(tempAlloc, scriptContext, L"Runtime");
@@ -1379,12 +1432,7 @@ namespace Js
                 //       for types we know such as TypedArray. We know the length of a TypedArray but we still
                 //       have to be careful in case there is a proxy which could return anything from [[Get]]
                 //       or the built-in @@iterator has been replaced.
-                JsUtil::List<Var, ArenaAllocator>* tempList = JsUtil::List<Var, ArenaAllocator>::New(tempAlloc);
-
-                while (JavascriptOperators::IteratorStepAndValue(iterator, scriptContext, &nextValue))
-                {
-                    tempList->Add(nextValue);
-                }
+                JsUtil::List<Var, ArenaAllocator>* tempList = IterableToList(items, scriptContext, tempAlloc);
 
                 uint32 len = tempList->Count();
 

--- a/lib/Runtime/Library/TypedArray.h
+++ b/lib/Runtime/Library/TypedArray.h
@@ -167,6 +167,7 @@ namespace Js
 
     protected:
         inline BOOL IsBuiltinProperty(PropertyId);
+        static Var CreateNewInstanceFromIterableObj(RecyclableObject *object, ScriptContext *scriptContext, uint32 elementSize, PFNCreateTypedArray pfnCreateTypedArray);
         static Var CreateNewInstance(Arguments& args, ScriptContext* scriptContext, uint32 elementSize, PFNCreateTypedArray pfnCreateTypedArray );
         static int32 ToLengthChecked(Var lengthVar, uint32 elementSize, ScriptContext* scriptContext);
 

--- a/test/typedarray/TypedArrayBuiltins.baseline
+++ b/test/typedarray/TypedArrayBuiltins.baseline
@@ -1,3 +1,5 @@
 *** Running test #1 (0): TypedArray builtin properties can't be overwritten, but writing to them does not throw an error
 PASSED
-Summary of tests: total executed: 1; passed: 1; failed: 0
+*** Running test #2 (1): TypedArray constructed out of an iterable object
+PASSED
+Summary of tests: total executed: 2; passed: 2; failed: 0

--- a/test/typedarray/TypedArrayBuiltins.js
+++ b/test/typedarray/TypedArrayBuiltins.js
@@ -44,6 +44,46 @@ var tests = [
             assert.throws(function() { Array.prototype.push.call(u8, 100); }, TypeError, "Array.prototype.push tries to set the length property of the TypedArray object which will throw", "Cannot define property: object is not extensible");
             assert.areEqual([0,1,2,3,1,2,3,4,5,7], u8, "Array.prototype.push doesn't modify the TypedArray");
         }
+    },
+    {
+        name: "TypedArray constructed out of an iterable object",
+        body: function () {
+            function getIterableObj (array)
+            {
+                return {
+                    [Symbol.iterator]: ()=> {
+                        return {
+                            next: () => {
+                                return {
+                                    value: array.shift(),
+                                    done: array.length == 0
+                                };
+                            }
+                        };
+                    }
+                };
+            }
+
+            var TypedArray = [
+                'Int8Array',
+                'Uint8Array',
+                'Uint8ClampedArray',
+                'Int16Array',
+                'Uint16Array',
+                'Int32Array',
+                'Uint32Array',
+                'Float32Array',
+                'Float64Array'
+            ];
+
+            for(var t of TypedArray) {
+                var arr = new this[t](getIterableObj([1,2,3,4]));
+                assert.areEqual(3, arr.length, "TypedArray " + t + " created from iterable has length == 3");
+                assert.areEqual(1, arr[0], "TypedArray " + t + " created from iterable has element #0 == 1");
+                assert.areEqual(2, arr[1], "TypedArray " + t + " created from iterable has element #1 == 2");
+                assert.areEqual(3, arr[2], "TypedArray " + t + " created from iterable has element #2 == 3");
+            }
+        }
     }
 ];
 


### PR DESCRIPTION
Construct TypedArray from an iterable object

TypeArray( object )
Applicable when a TypedArray constructor is called with at least one argument
and the Type of the first argument is Object and that object does not
have either a [[TypedArrayName]] or an [[ArrayBufferData]] internal slot.

TypedArray called with argument object performs the following steps:
1.Assert: Type(object) is Object and object does not have either a [[TypedArrayName]] or an [[ArrayBufferData]] internal slot.
2.If NewTarget is undefined, throw a TypeError exception.
3.Let O be ? AllocateTypedArray(TypedArray.[[TypedArrayConstructorName]], NewTarget, "%TypedArrayPrototype%").
4.Let arrayLike be ? IterableToArrayLike(object).
5.Let len be ? ToLength(? Get(arrayLike, "length")).
6.Perform ? AllocateTypedArrayBuffer(O, len).
7.Let k be 0.
8.Repeat, while k < lena.Let Pk be ! ToString(k).
b.Let kValue be ? Get(arrayLike, Pk).
c.Perform ? Set(O, Pk, kValue, true).
d.Increase k by 1.

9.Return O.
