### PR TITLE
linux: lib/common/common WIP

### DIFF
--- a/lib/common/EnumHelp.h
+++ b/lib/common/EnumHelp.h
@@ -21,7 +21,7 @@
 #define BEGIN_ENUM(name, storage)           \
     struct name                             \
     {                                       \
-        enum _E;                             \
+        enum _E : storage;                  \
                                             \
         inline name()                       \
         {                                   \
@@ -118,7 +118,7 @@
             return (_E) _value;               \
         }                                   \
                                             \
-        enum _E                              \
+        enum _E : storage                   \
         {                                   \
 
 

--- a/lib/common/common/CMakeLists.txt
+++ b/lib/common/common/CMakeLists.txt
@@ -11,7 +11,7 @@ set (SOURCES
   # MathUtil.cpp
   # NumberUtilities.cpp
   # NumberUtilities_strtod.cpp
-  # RejitReason.cpp
+  RejitReason.cpp
   # SmartFPUControl.cpp
   Tick.cpp
   unicode.cpp

--- a/lib/common/common/CMakeLists.txt
+++ b/lib/common/common/CMakeLists.txt
@@ -2,7 +2,7 @@ set (SOURCES
   Api.cpp
   cfglogger.cpp
   CommonCommonPch.cpp
-  # DateUtilities.cpp
+  DateUtilities.cpp
   # DaylightTimeHelper.cpp
   Event.cpp
   Int32Math.cpp

--- a/pal/inc/rt/palrt.h
+++ b/pal/inc/rt/palrt.h
@@ -117,6 +117,8 @@ Revision History:
 
 #define DBG_PRINTEXCEPTION_C             _HRESULT_TYPEDEF_(0x40010006L)
 
+#define INTSAFE_E_ARITHMETIC_OVERFLOW    _HRESULT_TYPEDEF_(0x80070216L)
+
 /********************** errorrep.h ****************************************/
 
 typedef enum tagEFaultRepRetVal


### PR DESCRIPTION
Forward declaring enums is not allowed by the C++ standard (I assume
this just happens to work in MSVC). To fix the build error declare the
storage type of the enum in the forward declaration and its
definition. This is allowed since C++0x.