### PR TITLE
Accepting both -- or - as a valid argument to ch.exe

### DIFF
--- a/lib/common/core/CmdParser.cpp
+++ b/lib/common/core/CmdParser.cpp
@@ -591,10 +591,11 @@ int CmdLineArgsParser::Parse(__in LPWSTR oneArg) throw()
                 PrintUsage();
                 return -1;
             }
-            else
+            else if ('-' == CurChar())
             {
-                ParseFlag();
+                NextChar();
             }
+            ParseFlag();
             break;
         default:
             if(NULL != this->flagTable.Filename)

--- a/lib/common/core/CmdParser.cpp
+++ b/lib/common/core/CmdParser.cpp
@@ -584,16 +584,18 @@ int CmdLineArgsParser::Parse(__in LPWSTR oneArg) throw()
         switch(CurChar())
         {
         case '-' :
+            if ('-' == PeekChar())
+            {
+                //support --
+                NextChar();
+            }
+            //fallthrough
         case '/':
             NextChar();
             if('?' == CurChar())
             {
                 PrintUsage();
                 return -1;
-            }
-            else if ('-' == CurChar())
-            {
-                NextChar();
             }
             ParseFlag();
             break;

--- a/lib/common/core/CmdParser.h
+++ b/lib/common/core/CmdParser.h
@@ -85,7 +85,6 @@ private:
                 return this->pszCurrentArg[1];
             }
 
-
             void NextChar()
             {
                 this->pszCurrentArg++;

--- a/lib/common/core/CmdParser.h
+++ b/lib/common/core/CmdParser.h
@@ -80,6 +80,12 @@ private:
                 return this->pszCurrentArg[0];
             }
 
+            wchar_t PeekChar()
+            {
+                return this->pszCurrentArg[1];
+            }
+
+
             void NextChar()
             {
                 this->pszCurrentArg++;


### PR DESCRIPTION
For example: Accepting --es6all or -es6 a valid argument to ch.exe
