### PR TITLE
Separate scopes for parameter and body scopes

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -74,6 +74,7 @@ bool BlockHasOwnScope(ParseNode* pnodeBlock, ByteCodeGenerator *byteCodeGenerato
     Assert(pnodeBlock->nop == knopBlock);
     return pnodeBlock->sxBlock.scope != nullptr &&
         (!(pnodeBlock->grfpn & fpnSyntheticNode) ||
+            (pnodeBlock->sxBlock.blockType == Parameter && !pnodeBlock->sxBlock.scope->GetCanMergeWithBodyScope()) ||
             (pnodeBlock->sxBlock.blockType == PnodeBlockType::Global && byteCodeGenerator->IsEvalWithBlockScopingNoParentScopeInfo()));
 }
 
@@ -967,6 +968,10 @@ void ByteCodeGenerator::RestoreScopeInfo(Js::FunctionBody* functionBody)
             {
                 paramScope = Anew(alloc, Scope, alloc, ScopeType_Parameter, true);
             }
+            if (!paramScopeInfo->GetCanMergeWithBodyScope())
+            {
+                paramScope->SetCannotMergeWithBodyScope();
+            }
             // We need the funcInfo before continuing the restoration of the param scope, so wait for the funcInfo to be created.
         }
 
@@ -984,12 +989,16 @@ void ByteCodeGenerator::RestoreScopeInfo(Js::FunctionBody* functionBody)
                 bodyScope = Anew(alloc, Scope, alloc, ScopeType_FunctionBody, true);
             }
         }
+
         FuncInfo* func = Anew(alloc, FuncInfo, functionBody->GetDisplayName(), alloc, paramScope, bodyScope, nullptr, functionBody);
 
         if (paramScope != nullptr)
         {
             paramScope->SetFunc(func);
-            paramScopeInfo->GetScopeInfo(nullptr, this, func, paramScope);
+            if (paramScope->GetCanMergeWithBodyScope())
+            {
+                paramScopeInfo->GetScopeInfo(nullptr, this, func, paramScope);
+            }
         }
 
         if (bodyScope->GetScopeType() == ScopeType_GlobalEvalBlock)
@@ -1018,6 +1027,11 @@ void ByteCodeGenerator::RestoreScopeInfo(Js::FunctionBody* functionBody)
         }
 
         scopeInfo->GetScopeInfo(nullptr, this, func, bodyScope);
+        if (paramScope && !paramScope->GetCanMergeWithBodyScope())
+        {
+            // If the param and body scopes are not merged the param scope needs to be treated like an inner scope
+            paramScopeInfo->GetScopeInfo(nullptr, this, func, paramScope);
+        }
     }
     else
     {
@@ -1395,7 +1409,12 @@ FuncInfo * ByteCodeGenerator::StartBindFunction(const wchar_t *name, uint nameLe
     }
 
     PushFuncInfo(L"StartBindFunction", funcInfo);
-    PushScope(paramScope);
+    if (paramScope->GetCanMergeWithBodyScope())
+    {
+        // When param scope is not merged with body scope we don't have to push the param scope here.
+        // Symbols in both scopes are separate and can't reference each other.
+        PushScope(paramScope);
+    }
     PushScope(bodyScope);
 
     if (funcExprScope)
@@ -1416,6 +1435,7 @@ FuncInfo * ByteCodeGenerator::StartBindFunction(const wchar_t *name, uint nameLe
 void ByteCodeGenerator::EndBindFunction(bool funcExprWithName)
 {
     bool isGlobalScope = currentScope->GetScopeType() == ScopeType_Global;
+    Scope* bodyScope = currentScope;
 
     Assert(currentScope->GetScopeType() == ScopeType_FunctionBody || isGlobalScope);
     PopScope(); // function body
@@ -1426,8 +1446,12 @@ void ByteCodeGenerator::EndBindFunction(bool funcExprWithName)
     }
     else
     {
-        Assert(currentScope->GetScopeType() == ScopeType_Parameter);
-        PopScope(); // parameter scope
+        Scope* paramScope = bodyScope->GetFunc()->GetParamScope();
+        if (paramScope->GetCanMergeWithBodyScope())
+        {
+            Assert(currentScope->GetScopeType() == ScopeType_Parameter);
+            PopScope(); // parameter scope
+        }
     }
 
     if (funcExprWithName)
@@ -1462,16 +1486,41 @@ void ByteCodeGenerator::PushScope(Scope *innerScope)
 {
     Assert(innerScope != nullptr);
 
-    if (isBinding
-        && currentScope != nullptr
-        && currentScope->GetScopeType() == ScopeType_FunctionBody
-        && innerScope->GetMustInstantiate())
+    if (isBinding && currentScope != nullptr && innerScope->GetMustInstantiate())
     {
-        // If the current scope is a function body, we don't expect another function body
-        // without going through a function expression or parameter scope first. This may
-        // not be the case in the emit phase, where we can merge the two scopes. This also
-        // does not apply to incoming scopes marked as !mustInstantiate.
-        Assert(innerScope->GetScopeType() != ScopeType_FunctionBody);
+        if (currentScope->GetScopeType() == ScopeType_FunctionBody)
+        {
+            // If the current scope is a function body, we don't expect another function body without going through a function expression or parameter
+            // scope (which is not merged with body scope) first. This also does not apply to incoming scopes marked as !mustInstantiate.
+            Assert(innerScope->GetScopeType() != ScopeType_FunctionBody || !innerScope->GetFunc()->GetParamScope()->GetCanMergeWithBodyScope());
+        }
+
+        if (currentScope->GetScopeType() == ScopeType_Parameter)
+        {
+            if (innerScope->GetScopeType() == ScopeType_FunctionBody)
+            {
+                // The current scope is a parameter scope and we are pushing in a function body scope then,
+                if (currentScope->GetFunc() == innerScope->GetFunc())
+                {
+                    // If both the param scope and the body scope belongs to the same function then both can be merged together.
+                    Assert(currentScope->GetCanMergeWithBodyScope());
+                }
+                else
+                {
+                    // If both the scopes belong to a different function then both functions have split scope.
+                    Assert(!innerScope->GetFunc()->GetParamScope()->GetCanMergeWithBodyScope()
+                            && !currentScope->GetCanMergeWithBodyScope());
+                }
+            }
+            else if (innerScope->GetScopeType() == ScopeType_Parameter)
+            {
+                // If we are pushing a parameter scope on top of another parameter scope then,
+                // Both of them cannot belong to the same function.
+                Assert(currentScope->GetFunc() != innerScope->GetFunc());
+                // Current function should have split scope.
+                Assert(!currentScope->GetCanMergeWithBodyScope());
+            }
+        }
     }
 
     innerScope->SetEnclosingScope(currentScope);
@@ -1819,6 +1868,13 @@ Scope * ByteCodeGenerator::FindScopeForSym(Scope *symScope, Scope *scope, Js::Pr
         }
         if (scope == symScope || scope->GetIsDynamic())
         {
+            break;
+        }
+        else if (symScope->GetScopeType() == ScopeType_Parameter && scope->GetFunc() == symScope->GetFunc())
+        {
+            // During VisitNestedScope the param scope will not be on the stack for the unmerged scope case.
+            // So if the symbol's scope is a param scope, check whether it is the current function or not.
+            scope = symScope;
             break;
         }
     }
@@ -2576,7 +2632,12 @@ FuncInfo* PostVisitFunction(ParseNode* pnode, ByteCodeGenerator* byteCodeGenerat
         if (!top->IsGlobalFunction())
         {
             PostVisitBlock(pnode->sxFnc.pnodeBodyScope, byteCodeGenerator);
-            PostVisitBlock(pnode->sxFnc.pnodeScopes, byteCodeGenerator);
+            if (pnode->sxFnc.pnodeScopes->nop != knopBlock
+                || pnode->sxFnc.pnodeBodyScope->sxBlock.scope->GetScopeType() != ScopeType_Parameter
+                || pnode->sxFnc.pnodeBodyScope->sxBlock.scope->GetCanMergeWithBodyScope())
+            {
+                PostVisitBlock(pnode->sxFnc.pnodeScopes, byteCodeGenerator);
+            }
         }
 
         if ((byteCodeGenerator->GetFlags() & fscrEvalCode) && top->GetCallsEval())
@@ -3073,7 +3134,12 @@ void VisitNestedScopes(ParseNode* pnodeScopeList, ParseNode* pnodeParent, ByteCo
                 Visit(pnode, byteCodeGenerator, prefix, postfix);
 
                 EndVisitBlock(pnodeScope->sxFnc.pnodeBodyScope, byteCodeGenerator);
-                EndVisitBlock(pnodeScope->sxFnc.pnodeScopes, byteCodeGenerator);
+                if (containerScope->nop != knopBlock || containerScope->sxBlock.blockType != Parameter
+                    || containerScope->sxBlock.scope->GetCanMergeWithBodyScope())
+                {
+                    // When the param scope has own scope, the scope stack handling for it is done separate.
+                    EndVisitBlock(pnodeScope->sxFnc.pnodeScopes, byteCodeGenerator);
+                }
             }
             else if (pnodeScope->sxFnc.nestedCount)
             {
@@ -3098,7 +3164,7 @@ void VisitNestedScopes(ParseNode* pnodeScopeList, ParseNode* pnodeParent, ByteCo
             // Merge parameter and body scopes, unless we are deferring the function.
             // If we are deferring the function, we will need both scopes to do the proper binding when
             // the function is undeferred. After the function is undeferred, it is safe to merge the scopes.
-            if (pnodeScope->sxFnc.funcInfo->paramScope != nullptr && pnodeScope->sxFnc.pnodeBody != nullptr)
+            if (pnodeScope->sxFnc.funcInfo->paramScope != nullptr && pnodeScope->sxFnc.pnodeBody != nullptr && pnodeScope->sxFnc.funcInfo->paramScope->GetCanMergeWithBodyScope())
             {
                 Scope::MergeParamAndBodyScopes(pnodeScope, byteCodeGenerator);
             }

--- a/lib/Runtime/ByteCode/FuncInfo.cpp
+++ b/lib/Runtime/ByteCode/FuncInfo.cpp
@@ -438,7 +438,7 @@ void FuncInfo::OnStartVisitScope(Scope *scope)
     if (scope->GetScopeType() == ScopeType_Parameter)
     {
         // If the scopes are unmerged and we are visiting the parameter scope, the child scope will be the function body scope.
-        Assert(this->GetCurrentChildScope()->GetEnclosingScope() == scope || this->GetCurrentChildScope() == nullptr);
+        Assert(!scope->GetCanMergeWithBodyScope() || this->GetCurrentChildScope()->GetEnclosingScope() == scope || this->GetCurrentChildScope() == nullptr);
     }
     else
     {
@@ -454,7 +454,7 @@ void FuncInfo::OnEndVisitScope(Scope *scope)
     {
         return;
     }
-    Assert(this->GetCurrentChildScope() == scope);
+    Assert(this->GetCurrentChildScope() == scope || (scope->GetScopeType() == ScopeType_Parameter && this->GetParamScope() == scope));
 
     this->SetCurrentChildScope(scope->GetEnclosingScope());
 }

--- a/lib/Runtime/ByteCode/Scope.cpp
+++ b/lib/Runtime/ByteCode/Scope.cpp
@@ -18,7 +18,10 @@ void Scope::SetHasLocalInClosure(bool has)
 {
     // (Note: if any catch var is closure-captured, we won't merge the catch scope with the function scope.
     // So don't mark the function scope "has local in closure".)
-    if (has && (this == func->GetBodyScope() || this == func->GetParamScope()) || (GetCanMerge() && (this->scopeType != ScopeType_Catch && this->scopeType != ScopeType_CatchParamPattern)))
+    // Do not mark the entire function if the closure is just inside the param scope and is not merged.
+    bool isMergedParamScope = this == func->GetParamScope() && func->GetParamScope()->GetCanMergeWithBodyScope();
+    bool notCatch = this->scopeType != ScopeType_Catch && this->scopeType != ScopeType_CatchParamPattern;
+    if (has && (this == func->GetBodyScope() || isMergedParamScope) || (GetCanMerge() && notCatch))
     {
         func->SetHasLocalInClosure(true);
     }

--- a/lib/Runtime/ByteCode/ScopeInfo.cpp
+++ b/lib/Runtime/ByteCode/ScopeInfo.cpp
@@ -67,6 +67,7 @@ namespace Js
         scopeInfo->mustInstantiate = scope->GetMustInstantiate();
         scopeInfo->isCached = (scope->GetFunc()->GetBodyScope() == scope) && scope->GetFunc()->GetHasCachedScope();
         scopeInfo->isGlobalEval = scope->GetScopeType() == ScopeType_GlobalEvalBlock;
+        scopeInfo->canMergeWithBodyScope = scope->GetCanMergeWithBodyScope();
 
         TRACE_BYTECODE(L"\nSave ScopeInfo: %s parent: %s #symbols: %d %s\n",
             scope->GetFunc()->name, parent->GetDisplayName(), count, scopeInfo->isObject ? L"isObject" : L"");
@@ -193,7 +194,8 @@ namespace Js
         // We will have to implement encoding block scope info to enable, which will also
         // enable defer parsing function that are in block scopes.
 
-        Assert(byteCodeGenerator->GetCurrentScope() == funcInfo->GetBodyScope());
+        Scope* currentScope = byteCodeGenerator->GetCurrentScope();
+        Assert(currentScope == funcInfo->GetBodyScope());
         if (funcInfo->IsDeferred())
         {
             // Don't need to remember the parent function if we have a global function
@@ -204,14 +206,16 @@ namespace Js
 #if DBG
                 if (funcInfo->GetFuncExprScope() && funcInfo->GetFuncExprScope()->GetIsObject())
                 {
-                    Assert(byteCodeGenerator->GetCurrentScope()->GetEnclosingScope() == funcInfo->GetFuncExprScope() &&
-                        byteCodeGenerator->GetCurrentScope()->GetEnclosingScope()->GetEnclosingScope() ==
+                    Assert(currentScope->GetEnclosingScope() == funcInfo->GetFuncExprScope() &&
+                        currentScope->GetEnclosingScope()->GetEnclosingScope() ==
                         (parentFunc->IsGlobalFunction() ? parentFunc->GetGlobalEvalBlockScope() : parentFunc->GetBodyScope()));
                 }
                 else
                 {
-                    Assert(byteCodeGenerator->GetCurrentScope()->GetEnclosingScope() ==
-                        (parentFunc->IsGlobalFunction() ? parentFunc->GetGlobalEvalBlockScope() : parentFunc->GetBodyScope()));
+                    Assert((currentScope->GetEnclosingScope() ==
+                        (parentFunc->IsGlobalFunction() ? parentFunc->GetGlobalEvalBlockScope() : parentFunc->GetBodyScope())) ||
+                        // The method can be defined in the parameter scope of the parent function
+                        (currentScope->GetEnclosingScope() == parentFunc->GetParamScope() && !parentFunc->GetParamScope()->GetCanMergeWithBodyScope()));
                 }
 #endif
                 Js::ScopeInfo::SaveParentScopeInfo(parentFunc, funcInfo);
@@ -244,6 +248,10 @@ namespace Js
             scope->SetIsObject();
         }
         scope->SetMustInstantiate(this->mustInstantiate);
+        if (!this->GetCanMergeWithBodyScope())
+        {
+            scope->SetCannotMergeWithBodyScope();
+        }
         if (parser)
         {
             scriptContext = parser->GetScriptContext();

--- a/lib/Runtime/ByteCode/ScopeInfo.h
+++ b/lib/Runtime/ByteCode/ScopeInfo.h
@@ -40,6 +40,7 @@ namespace Js {
         BYTE isCached : 1;              // indicates that local vars and functions are cached across invocations
         BYTE isGlobalEval : 1;
         BYTE areNamesCached : 1;
+        BYTE canMergeWithBodyScope : 1;
 
         Scope *scope;
         int scopeId;
@@ -48,7 +49,7 @@ namespace Js {
 
     private:
         ScopeInfo(FunctionBody * parent, int symbolCount)
-            : parent(parent), funcExprScopeInfo(nullptr), paramScopeInfo(nullptr), symbolCount(symbolCount), scope(nullptr), areNamesCached(false)
+            : parent(parent), funcExprScopeInfo(nullptr), paramScopeInfo(nullptr), symbolCount(symbolCount), scope(nullptr), areNamesCached(false), canMergeWithBodyScope(true)
         {
         }
 
@@ -185,6 +186,11 @@ namespace Js {
         bool IsGlobalEval() const
         {
             return isGlobalEval;
+        }
+
+        bool GetCanMergeWithBodyScope() const
+        {
+            return canMergeWithBodyScope;
         }
 
         static void SaveScopeInfoForDeferParse(ByteCodeGenerator* byteCodeGenerator, FuncInfo* parentFunc, FuncInfo* func);

--- a/lib/Runtime/ByteCode/Symbol.cpp
+++ b/lib/Runtime/ByteCode/Symbol.cpp
@@ -86,6 +86,12 @@ bool Symbol::IsInSlot(FuncInfo *funcInfo, bool ensureSlotAlloc)
     {
         return true;
     }
+    // If body and param scopes are not merged then an inner scope slot is used
+    if (!this->GetIsArguments() && this->scope->GetScopeType() == ScopeType_Parameter && !this->scope->GetCanMergeWithBodyScope())
+    {
+        return true;
+    }
+
     return this->GetHasNonLocalReference() && (ensureSlotAlloc || this->GetIsCommittedToSlot());
 }
 

--- a/test/es6/default.js
+++ b/test/es6/default.js
@@ -71,6 +71,19 @@ var tests = [
       function thisTest(a = this.val, b = this.val = 1.1, c = this.val, d = this.val2 = 2, e = this.val2) { return [a,b,c,d,e]; }
       assert.areEqual([{test:"test"}, 1.1, 1.1, 2, 2], thisTest(), "'this' is able to be referenced and modified");
 
+      var expAValue, expBValue, expCValue;
+      function f(a = 10, b = 20, c) {
+          assert.areEqual(a, expAValue, "First argument");
+          assert.areEqual(b, expBValue, "Second argument");
+          assert.areEqual(c, expCValue, "Third argument");
+      }
+      expAValue = null, expBValue = 20, expCValue = 1;
+      f(null, undefined, 1);
+      expAValue = null, expBValue = null, expCValue = null;
+      f(null, null, null);
+      expAValue = 10, expBValue = null, expCValue = 3;
+      f(undefined, null, 3);
+
       function lambdaCapture() {
         this.propA = 1;
         var lambda = (a = this.propA++) => {
@@ -324,6 +337,110 @@ var tests = [
   {
     name: "Split parameter scope",
     body: function () {
+      function f1(a = 10, b = function () { return a; }) {
+          assert.areEqual(a, 10, "Initial value of parameter in the body scope should be the same as the one in param scope");
+          var a = 20;
+          assert.areEqual(a, 20, "New assignment in the body scope updates the variable's value in body scope");
+          return b;
+      }
+      assert.areEqual(f1()(), 10, "Function defined in the param scope captures the formals from the param scope not body scope");
+
+      function f2(a = 10, b = function () { return a; }, c = b() + a) {
+          assert.areEqual(a, 10, "Initial value of parameter in the body scope should be the same as the one in param scope");
+          assert.areEqual(c, 20, "Initial value of the third parameter in the body scope should be twice the value of the first parameter");
+          var a = 20;
+          assert.areEqual(a, 20, "New assignment in the body scope updates the variable's value in body scope");
+          return b;
+      }
+      assert.areEqual(f2()(), 10, "Function defined in the param scope captures the formals from the param scope not body scope");
+
+      var obj = {
+          f(a = 10, b = function () { return a; }) {
+              assert.areEqual(a, 10, "Initial value of parameter in the body scope of the method should be the same as the one in param scope");
+              var a = 20;
+              assert.areEqual(a, 20, "New assignment in the body scope of the method updates the variable's value in body scope");
+              return b;
+          }
+      }
+      assert.areEqual(obj.f()(), 10, "Function defined in the param scope of the object method captures the formals from the param scope not body scope");
+
+      function f3(a = 10, b = function c() { return a; }) {
+          assert.areEqual(a, 10, "Initial value of parameter in the body scope of the method should be the same as the one in param scope");
+          var a = 20;
+          assert.areEqual(a, 20, "New assignment in the body scope of the method updates the variable's value in body scope");
+          return b;
+      }
+      assert.areEqual(f3()(), 10, "Function expression defined in the param scope captures the formals from the param scope not body scope");
+
+      function f4(a = 10, b = function () { return a; }) {
+        assert.areEqual(a, 1, "Initial value of parameter in the body scope should be the same as the one passed in");
+        var a = 20;
+        assert.areEqual(a, 20, "Assignment in the body scope updates the variable's value in body scope");
+        return b;
+      }
+      assert.areEqual(f4(1)(), 1, "Function defined in the param scope captures the formals from the param scope even when the default expression is not applied for that param");
+
+      (function (a = 10, b = a += 10, c = function () { return a + b; }) {
+        assert.areEqual(a, 20, "Initial value of parameter in the body scope should be same as the corresponding symbol's final value in the param scope");
+        var a2 = 40;
+        (function () { assert.areEqual(a2, 40, "Symbols defined in the body scope should be unaffected by the duplicate formal symbols"); })();
+        assert.areEqual(c(), 40, "Function defined in param scope uses the formals from param scope even when executed inside the body");
+      })();
+
+      (function (a = 10, b = function () { assert.areEqual(a, 10, "Function defined in the param scope captures the formals from the param scope when exectued from the param scope"); }, c = b()) {
+      })();
+
+      function f5(a = 10, b = function () { return a; }) {
+          a = 20;
+          return b;
+      }
+      assert.areEqual(f5()(), 10, "Even if the formals are not redeclared in the function body the symbol in the param scope and body scope are different");
+
+      function f6(a = 10, b = function () { return function () { return a; } }) {
+        var a = 20
+        return b;
+      }
+      assert.areEqual(f6()()(), 10, "Parameter scope works fine with nested functions");
+
+      var a1 = 10
+      function f7(b = function () { return a1; }) {
+        assert.areEqual(a1, undefined, "Inside the function body the assignment hasn't happened yet");
+        var a1 = 20;
+        assert.areEqual(a1, 20, "Assignment to the symbol inside the function changes the value");
+        return b;
+      }
+      assert.areEqual(f7()(), 10, "Function in the param scope correctly binds to the outer variable");
+
+      var arr = [2, 3, 4];
+      function f8(a = 10, b = function () { return a; }, ...c) {
+          assert.areEqual(arr.length, c.length, "Rest parameter should contain the same number of elements as the spread arg");
+          for (i = 0; i < arr.length; i++) {
+              assert.areEqual(arr[i], c[i], "Elements in the rest and the spread should be in the same order");
+          }
+          return b;
+      }
+      assert.areEqual(f8(undefined, undefined, ...arr)(), 10, "Presence of rest parameter shouldn't affect the binding");
+
+      function f9( {a:a1, b:b1}, c = function() { return a1 + b1; } ) {
+          assert.areEqual(a1, 10, "Initial value of the first destructuring parameter in the body scope should be the same as the one in param scope");
+          assert.areEqual(b1, 20, "Initial value of the second destructuring parameter in the body scope should be the same as the one in param scope");
+          a1 = 1;
+          b1 = 2;
+          assert.areEqual(a1, 1, "New assignment in the body scope updates the first formal's value in body scope");
+          assert.areEqual(b1, 2, "New assignment in the body scope updates the second formal's value in body scope");
+          assert.areEqual(c(), 30, "The param scope method should return the sum of the destructured formals from the param scope");
+          return c;
+      }
+      assert.areEqual(f9({ a : 10, b : 20 })(), 30, "Returned method should return the sum of the destructured formals from the param scope");
+
+      function f10({x:x = 10, y:y = function () { return x; }}) {
+          assert.areEqual(x, 10, "Initial value of the first destructuring parameter in the body scope should be the same as the one in param scope");
+          x = 20;
+          assert.areEqual(x, 20, "Assignment in the body updates the formal's value");
+          return y;
+      }
+      assert.areEqual(f10({ })(), 10, "Returned method should return the value of the destructured formal from the param scope");
+
       function g() {
         return 3 * 3;
       }


### PR DESCRIPTION
Split Scope:
This is the base changelist to enable split scopes for parameter and body
scopes. Symbols in param scope and body scope needs to be treated
separate. Right now we merge both scopes together. But if there is
a function or eval which captures one of the formals we can no longer
merge the scopes.

This changelist lays out the basic structure required for enabling these
scenarios. This only addresses the scenario where a function definition is present in
the param scope. Other scenarios will be addressed in later changelists.

When a function definition occurs in the param scope it is marked
to indicate that it cannot be merged with the body scope. After all the
formals are parsed one duplicate symbol is created for each formal
parameter in the body scope. When emitting the param scope it is treated
similar to a new inner scope. Emits bytecodes to copy the final value of a
formal parameter as the initial value of the corresponding symbol in the
body scope.
