### PR TITLE
linux: internal builds compat

### DIFF
--- a/lib/common/CommonPal.h
+++ b/lib/common/CommonPal.h
@@ -5,13 +5,6 @@
 #pragma once
 
 
-// ms-specific keywords
-#ifdef _MSC_VER
-#define ABSTRACT abstract
-#else
-#define ABSTRACT
-#endif
-
 #ifdef _WIN32
 #pragma warning(push)
 #pragma warning(disable: 4995) /* 'function': name was marked as #pragma deprecated */
@@ -202,10 +195,23 @@ PALIMPORT PSLIST_ENTRY PALAPI InterlockedPopEntrySList(IN OUT PSLIST_HEADER List
 
 #endif // _WIN32
 
+
+// Use intsafe.h for internal builds (currently missing some files with stdint.h)
+#if defined(_WIN32) && defined(NTBUILD)
+#define ENABLE_INTSAFE_SIGNED_FUNCTIONS 1
+#include<intsafe.h>
+#else
+#include<stdint.h>
+#endif
+
+
 #ifdef _MSC_VER
+// ms-specific keywords
+#define _ABSTRACT abstract
 // MSVC2015 does not support C++11 semantics for `typename QualifiedName` declarations
 // outside of template code.
-#    define TYPENAME
+#define _TYPENAME
 #else
-#    define TYPENAME typename
+#define _ABSTRACT
+#define _TYPENAME typename
 #endif

--- a/lib/common/DataStructures/BaseDictionary.h
+++ b/lib/common/DataStructures/BaseDictionary.h
@@ -1142,7 +1142,7 @@ namespace JsUtil
 
     protected:
         template<class TDictionary, class Leaf>
-        class IteratorBase ABSTRACT
+        class IteratorBase _ABSTRACT
         {
         protected:
             EntryType *const entries;

--- a/lib/common/DataStructures/Dlist.h
+++ b/lib/common/DataStructures/Dlist.h
@@ -453,7 +453,7 @@ private:
 
 #define FOREACH_DLISTBASE_ENTRY(T, data, list) \
 { \
-    TYPENAME DListBase<T>::Iterator __iter(list); \
+    _TYPENAME DListBase<T>::Iterator __iter(list); \
     while (__iter.Next()) \
     { \
         T& data = __iter.Data();
@@ -463,7 +463,7 @@ private:
 }
 
 #define FOREACH_DLISTBASE_ENTRY_EDITING(T, data, list, iter) \
-    TYPENAME DListBase<T>::EditingIterator iter(list); \
+    _TYPENAME DListBase<T>::EditingIterator iter(list); \
     while (iter.Next()) \
     { \
         T& data = iter.Data();

--- a/lib/common/common/DateUtilities.cpp
+++ b/lib/common/common/DateUtilities.cpp
@@ -12,8 +12,6 @@
 #include "common/DateUtilities.h"
 #include "common/Int64Math.h"
 
-#include <stdint.h>
-
 namespace Js
 {
     const INT64 DateUtilities::ticksPerMillisecond = 10000;

--- a/lib/common/common/Int64Math.cpp
+++ b/lib/common/common/Int64Math.cpp
@@ -4,13 +4,9 @@
 //-------------------------------------------------------------------------------------------------------
 #include "CommonCommonPch.h"
 #include "common/Int64Math.h"
-#include <stdint.h>
 
-#if _WIN32
-#include <intrin.h>
-#if _M_X64
+#if defined(_M_X64) && defined(_MSC_VER)
 #pragma intrinsic(_mul128)
-#endif
 #endif
 
 bool


### PR DESCRIPTION
linux: internal builds compat

Fix 2 issues seen in internal builds: (1) Currently missing some files
with stdint.h. Use intsafe.h instead. (2) There is a TYPENAME macro
conflict. Add an underscore.
