### PR TITLE
Fix #246 by always reporting the 'use strict' directive in the parser

### DIFF
--- a/lib/Parser/parse.cpp
+++ b/lib/Parser/parse.cpp
@@ -10192,14 +10192,6 @@ bool Parser::CheckForDirective(bool* pIsUseStrict, bool *pIsUseAsm, bool* pIsOct
 
 bool Parser::CheckStrictModeStrPid(IdentPtr pid)
 {
-    // If we're already in strict mode, no need to check if the string would put us in strict mode. So, this function would only
-    // return true if it detects a transition from non-strict to strict, which is what matters for callers.
-    // This is a minor optimization to avoid redundant string comparisons of nested "use strict" directives.
-    if (IsStrictMode())
-    {
-        return false;
-    }
-
 #ifdef ENABLE_DEBUG_CONFIG_OPTIONS
     if (Js::Configuration::Global.flags.NoStrictMode)
         return false;

--- a/test/strict/nonSimpleParameterList.baseline
+++ b/test/strict/nonSimpleParameterList.baseline
@@ -1,0 +1,2 @@
+SyntaxError: Cannot apply strict mode on functions with non-simple parameter list
+	at code (nonSimpleParameterList.js:8:30)

--- a/test/strict/nonSimpleParameterList.js
+++ b/test/strict/nonSimpleParameterList.js
@@ -1,0 +1,9 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function f() {
+    "use strict";
+    function g(a, b, ...r) { "use strict"; }
+}

--- a/test/strict/rlexe.xml
+++ b/test/strict/rlexe.xml
@@ -708,4 +708,11 @@
       <tags>BugFix</tags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>nonSimpleParameterList.js</files>
+      <baseline>nonSimpleParameterList.baseline</baseline>
+      <tags>exclude_dynapogo</tags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
Fix #246

There was a micro optimization in the directive parsing that didn't
bother doing a string comparison to check for the 'use strict' directive
in a function if the function was already in a strict mode context.

That used to be fine but now ES6 says that it is an error if a
function's parameter list is 'non-simple' and the function has a 'use
strict' directive.

Removing the early out and always reporting the directive fixes this bug
by letting the error detection we already had in place do its job.