### PR TITLE
Remove intrinsic pragma for unused function

### DIFF
--- a/lib/Runtime/Library/MathLibrary.cpp
+++ b/lib/Runtime/Library/MathLibrary.cpp
@@ -6,10 +6,6 @@
 #include "Language\JavascriptMathOperators.h"
 #include "Math\CrtSSE2Math.h"
 
-#if defined(_M_IX86) || defined(_M_X64)
-#pragma intrinsic(_mm_round_sd)
-#endif
-
 void UCrtC99MathApis::Ensure()
 {
     if (m_isInit)


### PR DESCRIPTION
I was about to port this one to *nix but then I saw it wasn’t used anyway.