### PR TITLE
linux: make NumberUtils.cpp build

### DIFF
--- a/lib/common/common/CMakeLists.txt
+++ b/lib/common/common/CMakeLists.txt
@@ -9,7 +9,7 @@ set (SOURCES
   Int64Math.cpp
   # Jobs.cpp
   # MathUtil.cpp
-  # NumberUtilities.cpp
+  NumberUtilities.cpp
   # NumberUtilities_strtod.cpp
   RejitReason.cpp
   # SmartFPUControl.cpp

--- a/lib/common/common/CMakeLists.txt
+++ b/lib/common/common/CMakeLists.txt
@@ -12,7 +12,7 @@ set (SOURCES
   NumberUtilities.cpp
   # NumberUtilities_strtod.cpp
   RejitReason.cpp
-  # SmartFPUControl.cpp
+  SmartFPUControl.cpp
   Tick.cpp
   unicode.cpp
   vtinfo.cpp

--- a/lib/common/common/MathUtil.cpp
+++ b/lib/common/common/MathUtil.cpp
@@ -3,7 +3,6 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "CommonCommonPch.h"
-#include "math.h"
 
 bool
 Math::FitsInDWord(size_t value)

--- a/lib/common/common/NumberUtilities.cpp
+++ b/lib/common/common/NumberUtilities.cpp
@@ -3,8 +3,9 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "CommonCommonPch.h"
-#include "Common\UInt32Math.h"
-#include "common\NumberUtilities.inl"
+#include "common/UInt32Math.h"
+#include "common/NumberUtilities.inl"
+#include <intsafe.h>
 
 namespace Js
 {
@@ -59,8 +60,6 @@ namespace Js
 #pragma warning(disable:4035)   // Turn off warning that there is no return value
     ulong NumberUtilities::MulLu(ulong lu1, ulong lu2, ulong *pluHi)
     {
-#if _WIN32 || _WIN64
-
 #if I386_ASM
         __asm
         {
@@ -75,10 +74,6 @@ namespace Js
         *pluHi = (ulong)(llu >> 32);
         return (ulong)llu;
 #endif //!I386_ASM
-
-#else
-#error Neither _WIN32, nor _WIN64 is defined
-#endif
     }
 #pragma warning(pop)
 

--- a/lib/common/common/NumberUtilities.inl
+++ b/lib/common/common/NumberUtilities.inl
@@ -27,7 +27,7 @@ namespace Js
 #endif //!BIG_ENDIAN
     }
 
-#if defined(_M_X64)
+#if defined(_M_X64) && defined(_MSC_VER)
     NUMBER_UTIL_INLINE INT64 NumberUtilities::TryToInt64(double T1)
     {
         // _mm_cvttsd_si64x will result in 0x8000000000000000 if the value is NaN Inf or Zero, or overflows int64

--- a/lib/common/common/SmartFPUControl.cpp
+++ b/lib/common/common/SmartFPUControl.cpp
@@ -3,8 +3,11 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "CommonCommonPch.h"
+#include "common/SmartFPUControl.h"
+
+#if _WIN32
 #include <float.h>
-#include "Common\SmartFPUControl.h"
+#endif
 
 //
 // Floating point unit utility functions
@@ -12,6 +15,7 @@
 
 static errno_t SetFPUControlDefault(void)
 {
+#if _WIN32
 #if _M_AMD64 || _M_ARM
     return _controlfp_s(0, _RC_NEAR + _DN_SAVE + _EM_INVALID + _EM_ZERODIVIDE +
         _EM_OVERFLOW + _EM_UNDERFLOW + _EM_INEXACT,
@@ -22,21 +26,29 @@ static errno_t SetFPUControlDefault(void)
 #else
     return _controlfp_s(0, _CW_DEFAULT, _MCW_EM | _MCW_DN | _MCW_PC | _MCW_RC | _MCW_IC);
 #endif
+#else //!_Win32
+    return 0;
+#endif
 }
 
 static errno_t GetFPUControl(unsigned int *pctrl)
 {
     Assert(pctrl != nullptr);
+#if _WIN32
 #if _M_IX86
     *pctrl = _control87(0, 0);
     return 0;
 #else
     return _controlfp_s(pctrl, 0, 0);
 #endif
+#else //!_Win32
+    return 0;
+#endif
 }
 
 static errno_t SetFPUControl(unsigned int fpctrl)
 {
+#if _WIN32
 #if _M_AMD64 || _M_ARM
     return _controlfp_s(0, fpctrl, _MCW_EM | _MCW_DN | _MCW_RC);
 #elif _M_IX86
@@ -45,14 +57,19 @@ static errno_t SetFPUControl(unsigned int fpctrl)
 #else
     return _controlfp_s(0, fpctrl, (unsigned int)(-1));
 #endif
+#else //!_Win32
+    return 0;
+#endif
 }
 
 static void ClearFPUStatus(void)
 {
+#if _WIN32
     // WinSE 187789
     // _clearfp gives up the thread's time slice, so clear only if flags are set
     if (_statusfp())
         _clearfp();
+#endif
 }
 
 template <bool enabled>


### PR DESCRIPTION
- Provide 32 and 64bit implementations for NumberUtilities::MulLu
- Fallback gracefully in NumberUtilities::TryToInt64

OK, I feel like I'm constantly providing implementations for this large int multiplication thing, but here's another one.