### PR TITLE
New JsRT API to parse script as library (internal) code. Scripts marked as libraryCode are internal and hidden from debugger

### DIFF
--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -1589,7 +1589,7 @@ namespace Js
         Js::JavascriptError::MapAndThrowError(this, E_FAIL);
     }
 
-    JavascriptFunction* ScriptContext::LoadScript(const wchar_t* script, SRCINFO const * pSrcInfo, CompileScriptException * pse, bool isExpression, bool disableDeferredParse, bool isByteCodeBufferForLibrary, Utf8SourceInfo** ppSourceInfo, const wchar_t *rootDisplayName, bool disableAsmJs)
+    JavascriptFunction* ScriptContext::LoadScript(const wchar_t* script, SRCINFO const * pSrcInfo, CompileScriptException * pse, bool isExpression, bool disableDeferredParse, bool isByteCodeBufferForLibrary, Utf8SourceInfo** ppSourceInfo, const wchar_t *rootDisplayName, bool isLibraryCode, bool disableAsmJs)
     {
         if (pSrcInfo == nullptr)
         {
@@ -1668,6 +1668,12 @@ namespace Js
                 grfscr |= (fscrNoAsmJs | fscrNoPreJit);
             }
 
+            if (isLibraryCode)
+            {
+                grfscr |= fscrIsLibraryCode;
+                (*ppSourceInfo)->SetIsLibraryCode();
+            }
+
             ParseNodePtr parseTree;
             hr = parser.ParseCesu8Source(&parseTree, utf8Script, cbNeeded, grfscr, pse, &sourceContextInfo->nextLocalFunctionId,
                 sourceContextInfo);
@@ -1688,7 +1694,7 @@ namespace Js
                 Assert(!disableAsmJs);
 
                 pse->Clear();
-                return LoadScript(script, pSrcInfo, pse, isExpression, disableDeferredParse, isByteCodeBufferForLibrary, ppSourceInfo, rootDisplayName, true);
+                return LoadScript(script, pSrcInfo, pse, isExpression, disableDeferredParse, isByteCodeBufferForLibrary, ppSourceInfo, rootDisplayName, isLibraryCode, true);
             }
 
             if (pFunction != nullptr && this->IsProfiling())
@@ -1709,7 +1715,7 @@ namespace Js
         }
     }
 
-    JavascriptFunction* ScriptContext::LoadScript(LPCUTF8 script, size_t cb, SRCINFO const * pSrcInfo, CompileScriptException * pse, bool isExpression, bool disableDeferredParse, bool isByteCodeBufferForLibrary, Utf8SourceInfo** ppSourceInfo, const wchar_t *rootDisplayName, bool disableAsmJs)
+    JavascriptFunction* ScriptContext::LoadScript(LPCUTF8 script, size_t cb, SRCINFO const * pSrcInfo, CompileScriptException * pse, bool isExpression, bool disableDeferredParse, bool isByteCodeBufferForLibrary, Utf8SourceInfo** ppSourceInfo, const wchar_t *rootDisplayName, bool isLibraryCode, bool disableAsmJs)
     {
         if (pSrcInfo == nullptr)
         {
@@ -1753,6 +1759,12 @@ namespace Js
                 grfscr |= (fscrNoAsmJs | fscrNoPreJit);
             }
 
+            if (isLibraryCode)
+            {
+                grfscr |= fscrIsLibraryCode;
+                (*ppSourceInfo)->SetIsLibraryCode();
+            }
+
 #if DBG_DUMP
             if (Js::Configuration::Global.flags.TraceMemory.IsEnabled(Js::ParsePhase) && Configuration::Global.flags.Verbose)
             {
@@ -1784,7 +1796,7 @@ namespace Js
                 Assert(!disableAsmJs);
 
                 pse->Clear();
-                return LoadScript(script, cb, pSrcInfo, pse, isExpression, disableDeferredParse, isByteCodeBufferForLibrary, ppSourceInfo, rootDisplayName, true);
+                return LoadScript(script, cb, pSrcInfo, pse, isExpression, disableDeferredParse, isByteCodeBufferForLibrary, ppSourceInfo, rootDisplayName, isLibraryCode, true);
             }
 
             if (pFunction != nullptr && this->IsProfiling())

--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -1762,7 +1762,6 @@ namespace Js
             if (isLibraryCode)
             {
                 grfscr |= fscrIsLibraryCode;
-                (*ppSourceInfo)->SetIsLibraryCode();
             }
 
 #if DBG_DUMP
@@ -1787,6 +1786,12 @@ namespace Js
             // We do not own the memory passed into DefaultLoadScriptUtf8. We need to save it so we copy the memory.
             *ppSourceInfo = Utf8SourceInfo::New(this, script, parser.GetSourceIchLim(), cb, pSrcInfo);
             (*ppSourceInfo)->SetParseFlags(grfscr);
+
+            if (isLibraryCode)
+            {
+                (*ppSourceInfo)->SetIsLibraryCode();
+            }
+
             uint sourceIndex = this->SaveSourceNoCopy(*ppSourceInfo, parser.GetSourceIchLim(), /* isCesu8*/ false);
 
             JavascriptFunction * pFunction = GenerateRootFunction(parseTree, sourceIndex, &parser, grfscr, pse, rootDisplayName);

--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -1074,8 +1074,8 @@ private:
         WellKnownHostType GetWellKnownHostType(Js::TypeId typeId) { return threadContext->GetWellKnownHostType(typeId); }
         void SetWellKnownHostTypeId(WellKnownHostType wellKnownType, Js::TypeId typeId) { threadContext->SetWellKnownHostTypeId(wellKnownType, typeId); }
 
-        JavascriptFunction* LoadScript(const wchar_t* script, SRCINFO const * pSrcInfo, CompileScriptException * pse, bool isExpression, bool disableDeferredParse, bool isByteCodeBufferForLibrary, Utf8SourceInfo** ppSourceInfo, const wchar_t *rootDisplayName, bool disableAsmJs = false);
-        JavascriptFunction* LoadScript(LPCUTF8 script, size_t cb, SRCINFO const * pSrcInfo, CompileScriptException * pse, bool isExpression, bool disableDeferredParse, bool isByteCodeBufferForLibrary, Utf8SourceInfo** ppSourceInfo, const wchar_t *rootDisplayName, bool disableAsmJs = false);
+        JavascriptFunction* LoadScript(const wchar_t* script, SRCINFO const * pSrcInfo, CompileScriptException * pse, bool isExpression, bool disableDeferredParse, bool isByteCodeBufferForLibrary, Utf8SourceInfo** ppSourceInfo, const wchar_t *rootDisplayName, bool isLibraryCode, bool disableAsmJs);
+        JavascriptFunction* LoadScript(LPCUTF8 script, size_t cb, SRCINFO const * pSrcInfo, CompileScriptException * pse, bool isExpression, bool disableDeferredParse, bool isByteCodeBufferForLibrary, Utf8SourceInfo** ppSourceInfo, const wchar_t *rootDisplayName, bool isLibraryCode, bool disableAsmJs);
 
         ArenaAllocator* GeneralAllocator() { return &generalAllocator; }
 

--- a/lib/jsrt/Jsrt.cpp
+++ b/lib/jsrt/Jsrt.cpp
@@ -2407,7 +2407,7 @@ STDAPI_(JsErrorCode) JsSetPromiseContinuationCallback(_In_ JsPromiseContinuation
     /*allowInObjectBeforeCollectCallback*/true);
 }
 
-JsErrorCode RunScriptCore(const wchar_t *script, JsSourceContext sourceContext, const wchar_t *sourceUrl, bool parseOnly, JsValueRef *result)
+JsErrorCode RunScriptCore(const wchar_t *script, JsSourceContext sourceContext, const wchar_t *sourceUrl, bool parseOnly, JsParseScriptAttributes parseAttributes, JsValueRef *result)
 {
     Js::JavascriptFunction *scriptFunction;
     CompileScriptException se;
@@ -2437,8 +2437,15 @@ JsErrorCode RunScriptCore(const wchar_t *script, JsSourceContext sourceContext, 
             /* grfsi               */ 0
         };
 
+        bool isLibraryCode = (parseAttributes & JsParseScriptAttributeLibraryCode) == JsParseScriptAttributeLibraryCode;
+
         Js::Utf8SourceInfo* utf8SourceInfo;
-        scriptFunction = scriptContext->LoadScript(script, &si, &se, result != nullptr, false /*disableDeferredParse*/, false /*isByteCodeBufferForLibrary*/, &utf8SourceInfo, Js::Constants::GlobalCode);
+        scriptFunction = scriptContext->LoadScript(script, &si, &se, result != nullptr,
+            false /*disableDeferredParse*/,
+            false /*isByteCodeBufferForLibrary*/,
+            &utf8SourceInfo, Js::Constants::GlobalCode,
+            isLibraryCode,
+            false /*disableAsmJs*/);
 
         JsrtContext * context = JsrtContext::GetCurrent();
         context->OnScriptLoad(scriptFunction, utf8SourceInfo);
@@ -2488,12 +2495,22 @@ JsErrorCode RunScriptCore(const wchar_t *script, JsSourceContext sourceContext, 
 
 STDAPI_(JsErrorCode) JsParseScript(_In_z_ const wchar_t * script, _In_ JsSourceContext sourceContext, _In_z_ const wchar_t *sourceUrl, _Out_ JsValueRef * result)
 {
-    return RunScriptCore(script, sourceContext, sourceUrl, true, result);
+    return RunScriptCore(script, sourceContext, sourceUrl, true, JsParseScriptAttributeNone, result);
+}
+
+STDAPI_(JsErrorCode) JsParseScriptWithFlags(
+    _In_z_ const wchar_t *script,
+    _In_ JsSourceContext sourceContext,
+    _In_z_ const wchar_t *sourceUrl,
+    _In_ JsParseScriptAttributes parseAttributes,
+    _Out_ JsValueRef *result)
+{
+    return RunScriptCore(script, sourceContext, sourceUrl, true, parseAttributes, result);
 }
 
 STDAPI_(JsErrorCode) JsRunScript(_In_z_ const wchar_t * script, _In_ JsSourceContext sourceContext, _In_z_ const wchar_t *sourceUrl, _Out_ JsValueRef * result)
 {
-    return RunScriptCore(script, sourceContext, sourceUrl, false, result);
+    return RunScriptCore(script, sourceContext, sourceUrl, false, JsParseScriptAttributeNone, result);
 }
 
 JsErrorCode JsSerializeScriptCore(const wchar_t *script, BYTE *functionTable, int functionTableSize, unsigned char *buffer, unsigned long *bufferSize)
@@ -2536,7 +2553,13 @@ JsErrorCode JsSerializeScriptCore(const wchar_t *script, BYTE *functionTable, in
 #endif
 
         Js::Utf8SourceInfo* sourceInfo;
-        function = scriptContext->LoadScript(script, &si, &se, !isSerializeByteCodeForLibrary, true, isSerializeByteCodeForLibrary, &sourceInfo, Js::Constants::GlobalCode);
+        function = scriptContext->LoadScript(script, &si, &se,
+            !isSerializeByteCodeForLibrary /*isExpression*/,
+            true /*disableDeferredParse*/,
+            isSerializeByteCodeForLibrary, &sourceInfo, Js::Constants::GlobalCode,
+            false /*isLibraryCode*/,
+            false /*disableAsmJs*/);
+
         return JsNoError;
     });
 

--- a/lib/jsrt/JsrtCommonExports.inc
+++ b/lib/jsrt/JsrtCommonExports.inc
@@ -90,6 +90,7 @@
     JsParseSerializedScriptWithCallback
     JsRunSerializedScriptWithCallback
     JsParseScript
+    JsParseScriptWithFlags
     JsConstructObject
     JsGetPropertyIdFromName
     JsGetPropertyNameFromId

--- a/lib/jsrt/chakracommon.h
+++ b/lib/jsrt/chakracommon.h
@@ -379,6 +379,20 @@
     } JsMemoryEventType;
 
     /// <summary>
+    ///     Attribute mask for JsParseScriptWithFlags
+    /// </summary>
+    typedef enum _JsParseScriptAttributes {
+        /// <summary>
+        ///     Default attribute
+        /// </summary>
+        JsParseScriptAttributeNone = 0x0,
+        /// <summary>
+        ///     Specified script is internal and non-user code. Hidden from debugger
+        /// </summary>
+        JsParseScriptAttributeLibraryCode = 0x1
+    } JsParseScriptAttributes;
+
+    /// <summary>
     ///     User implemented callback routine for memory allocation events
     /// </summary>
     /// <remarks>
@@ -811,20 +825,6 @@
             _In_ JsSourceContext sourceContext,
             _In_z_ const wchar_t *sourceUrl,
             _Out_ JsValueRef *result);
-
-    /// <summary>
-    ///     Attribute mask for JsParseScriptWithFlags
-    /// </summary>
-    typedef enum _JsParseScriptAttributes {
-        /// <summary>
-        ///     Default attribute
-        /// </summary>
-        JsParseScriptAttributeNone = 0x0,
-        /// <summary>
-        ///     Specified script is internal and non-user code. Hidden from debugger
-        /// </summary>
-        JsParseScriptAttributeLibraryCode = 0x1
-    } JsParseScriptAttributes;
 
     /// <summary>
     ///     Parses a script and returns a function representing the script.

--- a/lib/jsrt/chakracommon.h
+++ b/lib/jsrt/chakracommon.h
@@ -813,6 +813,44 @@
             _Out_ JsValueRef *result);
 
     /// <summary>
+    ///     Attribute mask for JsParseScriptWithFlags
+    /// </summary>
+    typedef enum _JsParseScriptAttributes {
+        /// <summary>
+        ///     Default attribute
+        /// </summary>
+        JsParseScriptAttributeNone = 0x0,
+        /// <summary>
+        ///     Specified script is internal and non-user code. Hidden from debugger
+        /// </summary>
+        JsParseScriptAttributeLibraryCode = 0x1
+    } JsParseScriptAttributes;
+
+    /// <summary>
+    ///     Parses a script and returns a function representing the script.
+    /// </summary>
+    /// <remarks>
+    ///     Requires an active script context.
+    /// </remarks>
+    /// <param name="script">The script to parse.</param>
+    /// <param name="sourceContext">
+    ///     A cookie identifying the script that can be used by debuggable script contexts.
+    /// </param>
+    /// <param name="sourceUrl">The location the script came from.</param>
+    /// <param name="parseAttributes">Attribute mask for parsing the script</param>
+    /// <param name="result">A function representing the script code.</param>
+    /// <returns>
+    ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
+    /// </returns>
+    STDAPI_(JsErrorCode)
+        JsParseScriptWithFlags(
+            _In_z_ const wchar_t *script,
+            _In_ JsSourceContext sourceContext,
+            _In_z_ const wchar_t *sourceUrl,
+            _In_ JsParseScriptAttributes parseAttributes,
+            _Out_ JsValueRef *result);
+
+    /// <summary>
     ///     Executes a script.
     /// </summary>
     /// <remarks>


### PR DESCRIPTION
This API can be used to hide host code written in JavaScript 