### PR TITLE
fix assert from Math.round inlining, remove OpHelperCheck flag

### DIFF
--- a/lib/Backend/DbCheckPostLower.cpp
+++ b/lib/Backend/DbCheckPostLower.cpp
@@ -9,7 +9,7 @@
 void
 DbCheckPostLower::Check()
 {
-    bool doOpHelperCheck = (Js::Configuration::Global.flags.CheckOpHelpers && !this->func->isPostLayout);
+    bool doOpHelperCheck = !this->func->isPostLayout;
     bool isInHelperBlock = false;
 
     FOREACH_INSTR_IN_FUNC_EDITING(instr, instrNext, this->func)

--- a/lib/Backend/LowerMDShared.cpp
+++ b/lib/Backend/LowerMDShared.cpp
@@ -8805,8 +8805,7 @@ void LowererMD::GenerateFastInlineBuiltInCall(IR::Instr* instr, IR::JnHelperMeth
                 if (instr->GetDst()->IsInt32())
                 {
                     // if we are specializing dst to int, we will bailout on overflow so don't need upperbound check
-                    // JP $skipRoundSd
-                    this->m_lowerer->InsertBranch(Js::OpCode::JP, skipRoundSd, instr);
+                    // Also, we will bailout on NaN, so it doesn't need special handling either
                     // J $addHalfToRoundSrcLabel
                     this->m_lowerer->InsertBranch(Js::OpCode::Br, addHalfToRoundSrcLabel, instr);
                 }
@@ -8876,6 +8875,16 @@ void LowererMD::GenerateFastInlineBuiltInCall(IR::Instr* instr, IR::JnHelperMeth
                     this->m_lowerer->InsertCompareBranch(roundedFloat, negTwoToFraction, Js::OpCode::BrGt_A, addHalfToRoundSrcLabel, instr);
                     // J $skipRoundSd
                     this->m_lowerer->InsertBranch(Js::OpCode::Br, skipRoundSd, instr);
+                }
+
+                if (src->IsFloat64())
+                {
+                    pointFive = IR::MemRefOpnd::New((double*)&(Js::JavascriptNumber::k_PointFive), TyFloat64, this->m_func, IR::AddrOpndKindDynamicDoubleRef);
+                }
+                else
+                {
+                    Assert(src->IsFloat32());
+                    pointFive = IR::MemRefOpnd::New((float*)&Js::JavascriptNumber::k_Float32PointFive, TyFloat32, this->m_func, IR::AddrOpndKindDynamicFloatRef);
                 }
 
                 // $addHalfToRoundSrcLabel

--- a/lib/common/ConfigFlagsList.h
+++ b/lib/common/ConfigFlagsList.h
@@ -793,7 +793,6 @@ FLAGNR(Boolean, CheckEmitBufferPermissions, "Check JIT code buffers at commit an
 FLAGR (Boolean, CheckMemoryLeak       , "Check for heap memory leak", false)
 FLAGR (String,  DumpOnLeak            , "Create a dump on failed memory leak check", nullptr)
 #endif
-FLAGNR(Boolean, CheckOpHelpers        , "Verify opHelper labels in the JIT are set properly", false)
 FLAGNR(Boolean, CloneInlinedPolymorphicCaches, "Clones polymorphic inline caches in inlined functions", DEFAULT_CONFIG_CloneInlinedPolymorphicCaches)
 FLAGNR(Boolean, ConcurrentRuntime     , "Enable Concurrent GC and background JIT when creating runtime", DEFAULT_CONFIG_ConcurrentRuntime)
 FLAGNR(Boolean, Console               , "Create console window in GUI app", false)


### PR DESCRIPTION
After merging #215, some UTs hit assert on internal testing due to pattern of
```
JE (nonhelper)
JA (helper)
JMP (helper)
```
Assert doesn't want mainline code to have path that can only lead to helper blocks (for sake of improved locality on main path). I added a helper label here so layout can move this block down.
This assert should have hit on core tests, but the assert is behind a flag that was disabled by default in ch.exe. I removed the flag so these checks will always run in debug mode.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/267)
<!-- Reviewable:end -->
