### PR TITLE
linux: build lib/common/common/Jobs.cpp

### DIFF
--- a/lib/Runtime/Language/JavascriptExceptionObject.h
+++ b/lib/Runtime/Language/JavascriptExceptionObject.h
@@ -19,7 +19,7 @@ namespace Js {
 
     class JavascriptExceptionContext;
 
-    class JavascriptExceptionObject
+    class JavascriptExceptionObject: public InScriptExceptionBase
     {
     public:
         typedef Var (__stdcall *HostWrapperCreateFuncType)(Var var, ScriptContext * sourceScriptContext, ScriptContext * destScriptContext);

--- a/lib/common/Common.h
+++ b/lib/common/Common.h
@@ -76,6 +76,7 @@ template<> struct IntMath<int64> { using Type = Int64Math; };
 
 // Exceptions
 #include "Exceptions/Exceptionbase.h"
+#include "Exceptions/InScriptExceptionBase.h"
 #include "Exceptions/InternalErrorException.h"
 #include "Exceptions/OutOfMemoryException.h"
 #include "Exceptions/OperationAbortedException.h"

--- a/lib/common/CommonPal.h
+++ b/lib/common/CommonPal.h
@@ -193,6 +193,20 @@ PALIMPORT PSLIST_ENTRY PALAPI InterlockedPopEntrySList(IN OUT PSLIST_HEADER List
 
 #define WRITE_WATCH_FLAG_RESET 1
 
+// xplat-todo: implement these for JIT and Concurrent/Partial GC
+uintptr_t _beginthreadex(
+   void *security,
+   unsigned stack_size,
+   unsigned ( __stdcall *start_address )( void * ),
+   void *arglist,
+   unsigned initflag,
+   unsigned *thrdaddr);
+BOOL WINAPI GetModuleHandleEx(
+  _In_     DWORD   dwFlags,
+  _In_opt_ LPCTSTR lpModuleName,
+  _Out_    HMODULE *phModule
+);
+
 #endif // _WIN32
 
 

--- a/lib/common/CommonPal.h
+++ b/lib/common/CommonPal.h
@@ -207,6 +207,9 @@ BOOL WINAPI GetModuleHandleEx(
   _Out_    HMODULE *phModule
 );
 
+// xplat-todo: cryptographically secure PRNG?
+errno_t rand_s(unsigned int* randomValue);
+
 #endif // _WIN32
 
 

--- a/lib/common/Exceptions/Chakra.Common.Exceptions.vcxproj
+++ b/lib/common/Exceptions/Chakra.Common.Exceptions.vcxproj
@@ -45,6 +45,7 @@
     <ClInclude Include="EvalDisabledException.h" />
     <ClInclude Include="ExceptionBase.h" />
     <ClInclude Include="ExceptionCheck.h" />
+    <ClInclude Include="InScriptExceptionBase.h" />
     <ClInclude Include="InternalErrorException.h" />
     <ClInclude Include="NotImplementedException.h" />
     <ClInclude Include="OperationAbortedException.h" />

--- a/lib/common/Exceptions/InScriptExceptionBase.h
+++ b/lib/common/Exceptions/InScriptExceptionBase.h
@@ -1,0 +1,15 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+#pragma once
+
+namespace Js {
+
+    // This class serves as base class for runtime in-script exception objects, so that code here
+    // (lib/common) can catch and handle runtime in-script exceptions.
+    class InScriptExceptionBase
+    {
+    };
+
+} // namespace Js

--- a/lib/common/common/CMakeLists.txt
+++ b/lib/common/common/CMakeLists.txt
@@ -7,7 +7,7 @@ set (SOURCES
   Event.cpp
   Int32Math.cpp
   Int64Math.cpp
-  # Jobs.cpp
+  Jobs.cpp
   # MathUtil.cpp
   NumberUtilities.cpp
   # NumberUtilities_strtod.cpp

--- a/lib/common/common/CMakeLists.txt
+++ b/lib/common/common/CMakeLists.txt
@@ -8,7 +8,7 @@ set (SOURCES
   Int32Math.cpp
   Int64Math.cpp
   Jobs.cpp
-  # MathUtil.cpp
+  MathUtil.cpp
   NumberUtilities.cpp
   # NumberUtilities_strtod.cpp
   RejitReason.cpp

--- a/lib/common/common/Jobs.inl
+++ b/lib/common/common/Jobs.inl
@@ -52,7 +52,7 @@ namespace JsUtil
     template<class TJobManager, class TJobHolder>
     void JobProcessor::PrioritizeJobAndWait(TJobManager *const manager, const TJobHolder holder, void* function)
     {
-        TemplateParameter::SameOrDerivedFrom<TJobManager, WaitableJobManager>;
+        TemplateParameter::SameOrDerivedFrom<TJobManager, WaitableJobManager>();
         Assert(manager);
         Assert(!isClosed);
 
@@ -164,7 +164,7 @@ namespace JsUtil
     template<class TJobManager, class TJobHolder>
     void ForegroundJobProcessor::PrioritizeJobAndWait(TJobManager *const manager, const TJobHolder holder, void* function)
     {
-        TemplateParameter::SameOrDerivedFrom<TJobManager, WaitableJobManager>;
+        TemplateParameter::SameOrDerivedFrom<TJobManager, WaitableJobManager>();
         Assert(manager);
         Assert(manager->isWaitable);
         Assert(!IsClosed());
@@ -369,7 +369,7 @@ namespace JsUtil
     template<class TJobManager, class TJobHolder>
     void BackgroundJobProcessor::PrioritizeJobAndWait(TJobManager *const manager, const TJobHolder holder, void* function)
     {
-        TemplateParameter::SameOrDerivedFrom<TJobManager, WaitableJobManager>;
+        TemplateParameter::SameOrDerivedFrom<TJobManager, WaitableJobManager>();
         Assert(manager);
         Assert(manager->isWaitable);
         Assert(!IsClosed());


### PR DESCRIPTION
clang does not allow catch(JavascriptExceptionObject*) when
JavascriptExceptionObject is an incomplete type (defined in
lib/runtime/language). Add a base class to lib/common to solve this.

Add declarations of _beginthreadex and GetModuleHandleEx. Will need to
revisit implementations later (used by JIT and Concurrent/Partial GC).
