### PR TITLE
Bug with lossy int type spec

### DIFF
--- a/lib/Backend/BackwardPass.cpp
+++ b/lib/Backend/BackwardPass.cpp
@@ -6134,7 +6134,7 @@ BackwardPass::ProcessDef(IR::Opnd * opnd)
             case IR::BailOutExpectingInteger:
             case IR::BailOutPrimitiveButString:
             case IR::BailOutExpectingString:
-            case IR::BailOutOnLossyToInt32ImplicitCalls:
+            case IR::BailOutOnNotPrimitive:
             case IR::BailOutFailedInlineTypeCheck:
             case IR::BailOutOnFloor:
             case IR::BailOnModByPowerOf2:

--- a/lib/Backend/BailOut.cpp
+++ b/lib/Backend/BailOut.cpp
@@ -1707,7 +1707,7 @@ void BailOutRecord::ScheduleFunctionCodeGen(Js::ScriptFunction * function, Js::S
         }
         else switch(bailOutKind)
         {
-            case IR::BailOutOnLossyToInt32ImplicitCalls:
+            case IR::BailOutOnNotPrimitive:
                 if (profileInfo->IsLossyIntTypeSpecDisabled())
                 {
                     reThunk = true;
@@ -2152,7 +2152,7 @@ void BailOutRecord::ScheduleLoopBodyCodeGen(Js::ScriptFunction * function, Js::S
         }
         else switch(bailOutKind)
         {
-            case IR::BailOutOnLossyToInt32ImplicitCalls:
+            case IR::BailOutOnNotPrimitive:
                 profileInfo->DisableLossyIntTypeSpec();
                 executeFunction->SetDontRethunkAfterBailout();
                 rejitReason = RejitReason::LossyIntTypeSpecDisabled;

--- a/lib/Backend/BailOutKind.h
+++ b/lib/Backend/BailOutKind.h
@@ -12,7 +12,7 @@ BAIL_OUT_KIND(BailOutNumberOnly,                    IR::BailOutMarkTempObject)
 BAIL_OUT_KIND(BailOutPrimitiveButString,            IR::BailOutMarkTempObject)
 BAIL_OUT_KIND(BailOutOnImplicitCalls,               IR::BailOutForArrayBits)
 BAIL_OUT_KIND(BailOutOnImplicitCallsPreOp,          (IR::BailOutOnResultConditions | IR::BailOutForArrayBits | IR::BailOutMarkTempObject) & ~IR::BailOutOnArrayAccessHelperCall )
-BAIL_OUT_KIND(BailOutOnLossyToInt32ImplicitCalls,   IR::BailOutMarkTempObject) // separate from BailOutOnImplicitCalls so that the bailout can disable LossyIntTypeSpec, but otherwise equivalent in functionality
+BAIL_OUT_KIND(BailOutOnNotPrimitive,                IR::BailOutMarkTempObject)
 BAIL_OUT_KIND(BailOutOnMemOpError,                  IR::BailOutForArrayBits)
 BAIL_OUT_KIND(BailOutOnInlineFunction,              0)
 BAIL_OUT_KIND(BailOutOnNoProfile,                   0)

--- a/lib/Backend/Func.cpp
+++ b/lib/Backend/Func.cpp
@@ -71,6 +71,7 @@ Func::Func(JitArenaAllocator *alloc, CodeGenWorkItem* workItem, const Js::Functi
     tryCatchNestingLevel(0),
     m_localStackHeight(0),
     tempSymDouble(nullptr),
+    tempSymBool(nullptr),
     hasInlinee(false),
     thisOrParentInlinerHasArguments(false),
     hasStackArgs(false),

--- a/lib/Backend/Func.h
+++ b/lib/Backend/Func.h
@@ -502,6 +502,7 @@ public:
     unsigned int        m_labelCount;
     BitVector           m_regsUsed;
     StackSym *          tempSymDouble;
+    StackSym *          tempSymBool;
     uint32              loopCount;
     Js::ProfileId       callSiteIdInParentFunc;
     bool                m_isLeaf: 1;  // This is set in the IRBuilder and might be inaccurate after inlining

--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -13686,7 +13686,7 @@ GlobOpt::ToTypeSpecUse(IR::Instr *instr, IR::Opnd *opnd, BasicBlock *block, Valu
                     // supposed to happen, so the resulting lossy int32 value cannot be reused. Bail out on implicit calls.
                     Assert(DoLossyIntTypeSpec());
 
-                    bailOutKind = IR::BailOutOnLossyToInt32ImplicitCalls;
+                    bailOutKind = IR::BailOutOnNotPrimitive;
                     isBailout = true;
                 }
             }

--- a/lib/Backend/JnHelperMethodList.h
+++ b/lib/Backend/JnHelperMethodList.h
@@ -115,6 +115,7 @@ HELPERCALL_MATH(Op_ShiftRightU_Full, Js::JavascriptMath::ShiftRightU_Full, Js::S
 
 HELPERCALL_MATH(Conv_ToInt32_Full, Js::JavascriptMath::ToInt32_Full, Js::SSE2::JavascriptMath::ToInt32_Full, AttrCanThrow)
 HELPERCALL_MATH(Conv_ToInt32, (int32 (*)(Js::Var, Js::ScriptContext *))Js::JavascriptMath::ToInt32, (int32 (*)(Js::Var, Js::ScriptContext *))Js::SSE2::JavascriptMath::ToInt32, AttrCanThrow)
+HELPERCALL_MATH(Conv_ToInt32_NoObjects, Js::JavascriptMath::ToInt32_NoObjects, Js::SSE2::JavascriptMath::ToInt32_NoObjects, AttrCanThrow)
 
 HELPERCALL_MATH(Op_FinishOddDivByPow2, Js::JavascriptMath::FinishOddDivByPow2, Js::SSE2::JavascriptMath::FinishOddDivByPow2, 0)
 HELPERCALL_MATH(Op_FinishOddDivByPow2InPlace, Js::JavascriptMath::FinishOddDivByPow2_InPlace, Js::SSE2::JavascriptMath::FinishOddDivByPow2_InPlace, 0)

--- a/lib/Backend/Lower.h
+++ b/lib/Backend/Lower.h
@@ -184,12 +184,13 @@ private:
     void            LoadArgumentCount(IR::Instr *const instr);
     void            LoadStackArgPtr(IR::Instr *const instr);
     void            LoadArgumentsFromFrame(IR::Instr *const instr);
-    IR::Instr *     LowerUnaryHelper(IR::Instr *instr, IR::JnHelperMethod helperMethod);
-    IR::Instr *     LowerUnaryHelperMem(IR::Instr *instr, IR::JnHelperMethod helperMethod);
+    IR::Instr *     LowerUnaryHelper(IR::Instr *instr, IR::JnHelperMethod helperMethod, IR::Opnd* opndBailoutArg = nullptr);
+    IR::Instr *     LowerUnaryHelperMem(IR::Instr *instr, IR::JnHelperMethod helperMethod, IR::Opnd* opndBailoutArg = nullptr);
     IR::Instr *     LowerUnaryHelperMemWithFuncBody(IR::Instr *instr, IR::JnHelperMethod helperMethod);
     IR::Instr *     LowerBinaryHelperMemWithFuncBody(IR::Instr *instr, IR::JnHelperMethod helperMethod);
     IR::Instr *     LowerUnaryHelperMemWithTemp(IR::Instr *instr, IR::JnHelperMethod helperMethod);
     IR::Instr *     LowerUnaryHelperMemWithTemp2(IR::Instr *instr, IR::JnHelperMethod helperMethod, IR::JnHelperMethod helperMethodWithTemp);
+    IR::Instr *     LowerUnaryHelperMemWithBoolReference(IR::Instr *instr, IR::JnHelperMethod helperMethod, bool useBoolForBailout);
     IR::Instr *     LowerBinaryHelperMem(IR::Instr *instr, IR::JnHelperMethod helperMethod);
     IR::Instr *     LowerBinaryHelperMemWithTemp(IR::Instr *instr, IR::JnHelperMethod helperMethod);
     IR::Instr *     LowerBinaryHelperMemWithTemp2(IR::Instr *instr, IR::JnHelperMethod helperMethod, IR::JnHelperMethod helperMethodWithTemp);
@@ -378,6 +379,7 @@ private:
     IR::Instr *     LowerBailOnNotPolymorphicInlinee(IR::Instr * instr);
     IR::Instr *     LowerBailOnNotStackArgs(IR::Instr * instr);
     IR::Instr *     LowerBailOnNotObject(IR::Instr *instr, IR::BranchInstr *branchInstr = nullptr, IR::LabelInstr *labelBailOut = nullptr);
+    IR::Instr *     LowerBailOnTrue(IR::Instr *instr, IR::LabelInstr *labelBailOut = nullptr);
     IR::Instr *     LowerBailOnNotBuiltIn(IR::Instr *instr, IR::BranchInstr *branchInstr = nullptr, IR::LabelInstr *labelBailOut = nullptr);
     IR::Instr *     LowerBailOnNotInteger(IR::Instr *instr, IR::BranchInstr *branchInstr = nullptr, IR::LabelInstr *labelBailOut = nullptr);
     IR::Instr *     LowerBailOnIntMin(IR::Instr *instr, IR::BranchInstr *branchInstr = nullptr, IR::LabelInstr *labelBailOut = nullptr);

--- a/lib/Backend/LowerMDShared.h
+++ b/lib/Backend/LowerMDShared.h
@@ -195,7 +195,7 @@ public:
      static void            EmitPtrInstr(IR::Instr *instr);
             void            EmitLoadVar(IR::Instr *instr, bool isFromUint32 = false, bool isHelper = false);
             void            EmitLoadVarNoCheck(IR::RegOpnd * dst, IR::RegOpnd * src, IR::Instr *instrLoad, bool isFromUint32, bool isHelper);
-            bool            EmitLoadInt32(IR::Instr *instr);
+            bool            EmitLoadInt32(IR::Instr *instr, bool conversionFromObjectAllowed);
             void            EmitIntToFloat(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsert);
             void            EmitUIntToFloat(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsert);
             void            EmitFloatToInt(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsert);

--- a/lib/Backend/amd64/LowererMDArch.cpp
+++ b/lib/Backend/amd64/LowererMDArch.cpp
@@ -2274,7 +2274,7 @@ LowererMDArch::EmitUIntToFloat(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrIns
 }
 
 bool
-LowererMDArch::EmitLoadInt32(IR::Instr *instrLoad)
+LowererMDArch::EmitLoadInt32(IR::Instr *instrLoad, bool conversionFromObjectAllowed)
 {
     //
     //    r1 = MOV src1
@@ -2415,7 +2415,15 @@ LowererMDArch::EmitLoadInt32(IR::Instr *instrLoad)
             // Need to bail out instead of calling a helper
             return true;
         }
-        lowererMD->m_lowerer->LowerUnaryHelperMem(instrLoad, IR::HelperConv_ToInt32);
+        
+        if (conversionFromObjectAllowed)
+        {
+            lowererMD->m_lowerer->LowerUnaryHelperMem(instrLoad, IR::HelperConv_ToInt32);
+        }
+        else
+        {
+            lowererMD->m_lowerer->LowerUnaryHelperMemWithBoolReference(instrLoad, IR::HelperConv_ToInt32_NoObjects, true /*useBoolForBailout*/);
+        }
     }
     else
     {

--- a/lib/Backend/amd64/LowererMDArch.h
+++ b/lib/Backend/amd64/LowererMDArch.h
@@ -92,7 +92,7 @@ public:
     void                EmitLoadVar(IR::Instr *instrLoad, bool isFromUint32 = false, bool isHelper = false);
     void                EmitIntToFloat(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsert);
     void                EmitUIntToFloat(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsert);
-    bool                EmitLoadInt32(IR::Instr *instrLoad);
+    bool                EmitLoadInt32(IR::Instr *instrLoad, bool conversionFromObjectAllowed);
 
     IR::Instr *         LoadCheckedFloat(IR::RegOpnd *opndOrig, IR::RegOpnd *opndFloat, IR::LabelInstr *labelInline, IR::LabelInstr *labelHelper, IR::Instr *instrInsert, const bool checkForNullInLoopBody = false);
 

--- a/lib/Backend/arm/LowerMD.h
+++ b/lib/Backend/arm/LowerMD.h
@@ -140,7 +140,7 @@ public:
      static void            EmitInt4Instr(IR::Instr *instr);
      static void            EmitPtrInstr(IR::Instr *instr);
             void            EmitLoadVar(IR::Instr *instr, bool isFromUint32 = false, bool isHelper = false);
-            bool            EmitLoadInt32(IR::Instr *instr);
+            bool            EmitLoadInt32(IR::Instr *instr, bool conversionFromObjectAllowed);
 
      static void            LowerInt4NegWithBailOut(IR::Instr *const instr, const IR::BailOutKind bailOutKind, IR::LabelInstr *const bailOutLabel, IR::LabelInstr *const skipBailOutLabel);
      static void            LowerInt4AddWithBailOut(IR::Instr *const instr, const IR::BailOutKind bailOutKind, IR::LabelInstr *const bailOutLabel, IR::LabelInstr *const skipBailOutLabel);

--- a/lib/Backend/arm64/LowerMD.h
+++ b/lib/Backend/arm64/LowerMD.h
@@ -139,7 +139,7 @@ public:
        static void            EmitInt4Instr(IR::Instr *instr) { __debugbreak(); }
        static void            EmitPtrInstr(IR::Instr *instr) { __debugbreak(); }
               void            EmitLoadVar(IR::Instr *instr, bool isFromUint32 = false, bool isHelper = false) { __debugbreak(); }
-              bool            EmitLoadInt32(IR::Instr *instr) { __debugbreak(); return 0; }
+              bool            EmitLoadInt32(IR::Instr *instr, bool conversionFromObjectAllowed) { __debugbreak(); return 0; }
 
        static void            LowerInt4NegWithBailOut(IR::Instr *const instr, const IR::BailOutKind bailOutKind, IR::LabelInstr *const bailOutLabel, IR::LabelInstr *const skipBailOutLabel) { __debugbreak(); }
        static void            LowerInt4AddWithBailOut(IR::Instr *const instr, const IR::BailOutKind bailOutKind, IR::LabelInstr *const bailOutLabel, IR::LabelInstr *const skipBailOutLabel) { __debugbreak(); }

--- a/lib/Backend/i386/LowererMDArch.cpp
+++ b/lib/Backend/i386/LowererMDArch.cpp
@@ -2194,7 +2194,7 @@ LowererMDArch::EmitUIntToFloat(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrIns
 }
 
 bool
-LowererMDArch::EmitLoadInt32(IR::Instr *instrLoad)
+LowererMDArch::EmitLoadInt32(IR::Instr *instrLoad, bool conversionFromObjectAllowed)
 {
     // if(doShiftFirst)
     // {
@@ -2370,7 +2370,14 @@ LowererMDArch::EmitLoadInt32(IR::Instr *instrLoad)
             return true;
         }
 
-        this->lowererMD->m_lowerer->LowerUnaryHelperMem(instrLoad, IR::HelperConv_ToInt32);
+        if (conversionFromObjectAllowed)
+        {
+            lowererMD->m_lowerer->LowerUnaryHelperMem(instrLoad, IR::HelperConv_ToInt32);
+        }
+        else
+        {
+            lowererMD->m_lowerer->LowerUnaryHelperMemWithBoolReference(instrLoad, IR::HelperConv_ToInt32_NoObjects, true /*useBoolForBailout*/);
+        }
     }
     else
     {

--- a/lib/Backend/i386/LowererMDArch.h
+++ b/lib/Backend/i386/LowererMDArch.h
@@ -77,7 +77,7 @@ public:
             void                EmitLoadVar(IR::Instr *instrLoad, bool isFromUint32 = false, bool isHelper = false);
             void                EmitIntToFloat(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsert);
             void                EmitUIntToFloat(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsert);
-            bool                EmitLoadInt32(IR::Instr *instrLoad);
+            bool                EmitLoadInt32(IR::Instr *instrLoad, bool conversionFromObjectAllowed);
 
             IR::Instr *         LoadCheckedFloat(IR::RegOpnd *opndOrig, IR::RegOpnd *opndFloat, IR::LabelInstr *labelInline, IR::LabelInstr *labelHelper, IR::Instr *instrInsert, const bool checkForNullInLoopBody = false);
 

--- a/lib/Runtime/ByteCode/OpCodes.h
+++ b/lib/Runtime/ByteCode/OpCodes.h
@@ -632,6 +632,7 @@ MACRO_BACKEND_ONLY(     BailTarget,                  Empty,          OpBailOutRe
 MACRO_BACKEND_ONLY(     BailOnNoProfile,             Empty,          OpBailOutRec|OpDeadFallThrough)
 MACRO_BACKEND_ONLY(     BailOnNoSimdTypeSpec,        Empty,          OpBailOutRec|OpDeadFallThrough)
 MACRO_BACKEND_ONLY(     BailOnNotObject,             Empty,          OpBailOutRec|OpTempNumberSources|OpTempObjectSources|OpCanCSE|OpTempObjectSources)
+MACRO_BACKEND_ONLY(     BailOnNotPrimitive,          Empty,          OpBailOutRec|OpTempNumberSources|OpTempObjectSources|OpCanCSE|OpTempObjectSources)
 MACRO_BACKEND_ONLY(     BailOnNotArray,              Empty,          OpBailOutRec|OpTempNumberSources|OpTempObjectSources|OpCanCSE|OpTempObjectSources)
 MACRO_BACKEND_ONLY(     BailForDebugger,             Empty,          OpBailOutRec|OpTempNumberSources|OpTempObjectSources|OpSideEffect)    // Bail out so that we can continue the function under debugger. Disable optimizations for this instr so that it's not moved.
 MACRO_BACKEND_ONLY(     BailOnNotBuiltIn,            Empty,          OpBailOutRec|OpTempNumberSources|OpTempObjectSources|OpCanCSE)

--- a/lib/Runtime/Math/JavascriptMath.h
+++ b/lib/Runtime/Math/JavascriptMath.h
@@ -92,6 +92,7 @@ namespace Js
             static int32 ToInt32Core(double T1);
             static uint32 ToUInt32(double value);
             static int64 TryToInt64(double T1);
+            static int32 ToInt32_NoObjects(Var aValue, ScriptContext* scriptContext, bool& isObject);
             static int32 ToInt32(Var aValue, ScriptContext* scriptContext);
             static int32 ToInt32(double value);
             static int32 ToInt32_Full(Var aValue, ScriptContext* scriptContext);

--- a/lib/Runtime/Math/JavascriptMath.inl
+++ b/lib/Runtime/Math/JavascriptMath.inl
@@ -327,6 +327,18 @@ namespace Js
             return Js::NumberUtilities::TryToInt64(T1);
         }
 
+        __inline int32 JavascriptMath::ToInt32_NoObjects(Var aValue, ScriptContext* scriptContext, bool& isObject)
+        {
+            if (JavascriptOperators::IsObject(aValue))
+            {
+                isObject = true; // jitted code should bailout
+                return 0;
+            }
+
+            isObject = false;
+            return ToInt32(aValue, scriptContext);
+        }
+
         __inline int32 JavascriptMath::ToInt32(Var aValue, ScriptContext* scriptContext)
         {
             return


### PR DESCRIPTION
We dont kill type specialized values across calls for perf reasons. This
can be a problem when we lossy int type specialize an object. If a
call following the conversion overrides, for example, valueOf on the
object and the object is used as an int after the call (for example, in a
shift), we will use the already available int version and end up not
executing valueOf.

Fix is to have FromVar bailout if the source is an
object and conversion was lossy.

Fixes #277

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/275)
<!-- Reviewable:end -->
