### PR TITLE
Fix assert in array opts

### DIFF
--- a/lib/Backend/GlobOpt.h
+++ b/lib/Backend/GlobOpt.h
@@ -1457,18 +1457,20 @@ private:
 
 private:
     void                    ChangeValueType(BasicBlock *const block, Value *const value, const ValueType newValueType, const bool preserveSubclassInfo, const bool allowIncompatibleType = false) const;
-    void                    ChangeValueInfo(BasicBlock *const block, Value *const value, ValueInfo *const newValueInfo, const bool allowIncompatibleType = false) const;
+    void                    ChangeValueInfo(BasicBlock *const block, Value *const value, ValueInfo *const newValueInfo, const bool allowIncompatibleType = false, const bool compensated = false) const;
     bool                    AreValueInfosCompatible(const ValueInfo *const v0, const ValueInfo *const v1) const;
 
 private:
+#if DBG
     void                    VerifyArrayValueInfoForTracking(const ValueInfo *const valueInfo, const bool isJsArray, const BasicBlock *const block, const bool ignoreKnownImplicitCalls = false) const;
+#endif
     void                    TrackNewValueForKills(Value *const value);
     void                    DoTrackNewValueForKills(Value *const value);
     void                    TrackCopiedValueForKills(Value *const value);
     void                    DoTrackCopiedValueForKills(Value *const value);
     void                    TrackMergedValueForKills(Value *const value, GlobOptBlockData *const blockData, BVSparse<JitArenaAllocator> *const mergedValueTypesTrackedForKills) const;
     void                    DoTrackMergedValueForKills(Value *const value, GlobOptBlockData *const blockData, BVSparse<JitArenaAllocator> *const mergedValueTypesTrackedForKills) const;
-    void                    TrackValueInfoChangeForKills(BasicBlock *const block, Value *const value, ValueInfo *const newValueInfo) const;
+    void                    TrackValueInfoChangeForKills(BasicBlock *const block, Value *const value, ValueInfo *const newValueInfo, const bool compensated) const;
     void                    ProcessValueKills(IR::Instr *const instr);
     void                    ProcessValueKills(BasicBlock *const block, GlobOptBlockData *const blockData);
     void                    ProcessValueKillsForLoopHeaderAfterBackEdgeMerge(BasicBlock *const block, GlobOptBlockData *const blockData);


### PR DESCRIPTION
Fix assert in array opts

When merging array value infos, VerifyArrayValueInfoForTracking already ignores implicit calls to
determine if we can do segment length hoist. Also ignore implicit calls
when we are changing an array value info as part of value compensation in
a predecessor block.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/276)
<!-- Reviewable:end -->
