### PR TITLE
Objptr copy-prop bug 

### DIFF
--- a/lib/Backend/GlobOptFields.cpp
+++ b/lib/Backend/GlobOptFields.cpp
@@ -1607,6 +1607,7 @@ GlobOpt::CreateFieldSrcValue(PropertySym * sym, PropertySym * originalSym, IR::O
         // We don't clear the value when we kill the field.
         // Clear it to make sure we don't use the old value.
         this->blockData.symToValueMap->Clear(sym->m_id);
+        this->blockData.symToValueMap->Clear(originalSym->m_id);
     }
 
     Assert((*ppOpnd)->AsSymOpnd()->m_sym == sym || this->IsLoopPrePass());

--- a/test/fieldopts/objptrcopyprop_typescript.js
+++ b/test/fieldopts/objptrcopyprop_typescript.js
@@ -1,0 +1,38 @@
+function foo(obj, obj2)
+{
+    if (obj.x == 10)
+    {
+	obj = obj2;
+
+	if (obj.x == 20)
+	{
+	    return;
+	}
+    }
+
+    return obj.x;
+}
+
+
+function test()
+{
+    var o1 = new Object();
+    var o2 = new Object();
+
+    o1.x = 10;
+    o2.x = 30;
+
+    for (var i = 0; i < 1000; i++)
+    {
+        var result = foo(o1,o2);
+        if (result != 30)
+        {
+            WScript.Echo("FAILED\n");
+            return;
+        }
+    }
+
+    WScript.Echo("Passed");
+}
+
+test();

--- a/test/fieldopts/objptrcopyprop_typescript.js
+++ b/test/fieldopts/objptrcopyprop_typescript.js
@@ -1,3 +1,8 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
 function foo(obj, obj2)
 {
     if (obj.x == 10)

--- a/test/fieldopts/rlexe.xml
+++ b/test/fieldopts/rlexe.xml
@@ -335,6 +335,11 @@
   </test>
   <test>
     <default>
+      <files>objptrcopyprop_typescript.js</files>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>fieldcopyprop_typespec.js</files>
       <baseline>fieldcopyprop_typespec.baseline</baseline>
       <compile-flags>-force:fieldcopyprop</compile-flags>


### PR DESCRIPTION
The typescript compiler hit a nasty field copy-prop bug when dealing with objptr copy-prop.  If the symbol had been killed, we would invalidate the propertySym using the new objptr, but not the old one.  In typescript, we ended up with an invalid field copy-prop. The fix is to symply invalidate both.  No impact on octane.