### PR TITLE
Show String.prototype.search in the debugger call stack

### DIFF
--- a/lib/Runtime/Library/JavascriptString.cpp
+++ b/lib/Runtime/Library/JavascriptString.cpp
@@ -1638,6 +1638,9 @@ case_2:
         Assert(!(callInfo.Flags & CallFlags_New));
 
         PCWSTR const varName = L"String.prototype.search";
+
+        AUTO_TAG_NATIVE_LIBRARY_ENTRY(function, callInfo, varName);
+
         auto fallback = [&](JavascriptRegExp* regExObj, JavascriptString* stringObj)
         {
             return RegexHelper::RegexSearch(scriptContext, regExObj, stringObj);


### PR DESCRIPTION
This change tags `String.prototype.search` so that it shows up in the debugger call stack when it delegates the work to `RegExp.prototype[@@search]`.