### PR TITLE
Force -win7 on Legacy Daily Builds because the test machinery doesn't automatically detect Windows Server 2008 R2 as Windows 7.

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -138,7 +138,7 @@ CreateBuildTasks('Windows_NT', null, null, null, null, null)
 // -----------------
 
 // build and test on Windows 7 with VS 2013 (Dev12/MsBuild12)
-CreateBuildTasks('Windows 7', 'daily_dev12', ' msbuild12', null,
+CreateBuildTasks('Windows 7', 'daily_dev12', ' msbuild12', ' -win7',
     /* excludeConfigIf */ { isPR, buildArch, buildType -> (buildArch == 'arm') },
     /* nonDefaultTaskSetup */ { newJob, isPR, config ->
         DailyBuildTaskSetup(newJob, isPR,


### PR DESCRIPTION
Force -win7 on Legacy Daily Builds because the test machinery doesn't automatically detect Windows Server 2008 R2 as Windows 7.

Fixes some of the current issues with Legacy Daily Builds.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/284)
<!-- Reviewable:end -->
