### PR TITLE
perftest.pl: fix a hard-coded path separator

### DIFF
--- a/test/benchmarks/perftest.pl
+++ b/test/benchmarks/perftest.pl
@@ -10,6 +10,7 @@
 
 use strict;
 use File::Basename;
+use File::Spec;
 
 my $defaultIter = 35;
 my $iter = $defaultIter;
@@ -509,7 +510,8 @@ sub runtest
     }
     else
     {
-        system("$binary $switches{$variant} $other_switches $dir\\$testcasename.js > _time.txt");
+        my $testpath = File::Spec->catfile($dir, $testcasename);
+        system("$binary $switches{$variant} $other_switches $testpath.js > _time.txt");
     }
 
     open(my $IN, '<', "_time.txt") or die;


### PR DESCRIPTION
"$dir\\$testcasename.js" does not work cross-platform. Replaced with
File::Spec->catfile call.
