### PR TITLE
fix asm.js incorrectly casting int literals outside valid range

### DIFF
--- a/lib/Runtime/Language/AsmJSBytecodeGenerator.cpp
+++ b/lib/Runtime/Language/AsmJSBytecodeGenerator.cpp
@@ -558,6 +558,10 @@ namespace Js
             {
                 return EmitExpressionInfo(mFunction->GetConstRegister<int>((uint32)pnode->sxFlt.dbl), AsmJsType::Unsigned);
             }
+            else if (pnode->sxFlt.maybeInt)
+            {
+                throw AsmJsCompilationException(L"Int literal must be in the range [-2^31, 2^32)");
+            }
             else
             {
                 return EmitExpressionInfo(mFunction->GetConstRegister<double>(pnode->sxFlt.dbl), AsmJsType::DoubleLit);

--- a/lib/Runtime/Language/AsmJSUtils.h
+++ b/lib/Runtime/Language/AsmJSUtils.h
@@ -62,7 +62,14 @@ namespace Js {
         static inline uint GetUInt(ParseNode *node);
         static inline bool IsNegativeZero(ParseNode* node);
         static inline bool IsMinInt(ParseNode *node){ return node && node->nop == knopFlt && node->sxFlt.maybeInt && node->sxFlt.dbl == -2147483648.0; };
-        static inline bool IsUnsigned(ParseNode *node){ return node && node->nop == knopFlt && node->sxFlt.maybeInt && (((uint32)node->sxFlt.dbl) >> 31); };
+        static inline bool IsUnsigned(ParseNode *node)
+        {
+            return node &&
+                node->nop == knopFlt &&
+                node->sxFlt.maybeInt &&
+                node->sxFlt.dbl > (double)INT_MAX &&
+                node->sxFlt.dbl <= (double)UINT_MAX;
+        }
 
         static bool IsDefinition( ParseNode *arg );
         static bool ParseVarOrConstStatement( AsmJSParser &parser, ParseNode **var );

--- a/test/AsmJs/invalidIntLiteral.baseline
+++ b/test/AsmJs/invalidIntLiteral.baseline
@@ -1,3 +1,10 @@
 Var declaration with integer literal outside range [-2^31, 2^32)
 Asm.js compilation failed.
 -2147483649
+
+invalidIntLiteral.js(25, 3)
+	Asm.js Compilation Error function : None::f
+	Int literal must be in the range [-2^31, 2^32)
+
+Asm.js compilation failed.
+-137438953473

--- a/test/AsmJs/invalidIntLiteral.js
+++ b/test/AsmJs/invalidIntLiteral.js
@@ -18,4 +18,13 @@ var stdlib = {}
 var env = {}
 var buffer = new ArrayBuffer(1<<20);
 var asmModule = AsmModule(stdlib,env,buffer);
-WScript.Echo(asmModule.f1());
+print(asmModule.f1());
+
+var m = function (stdlib, foreign, heap) {
+  'use asm';
+  function f() {
+    return +-137438953473;
+  }
+  return f;
+}(stdlib,env, buffer);
+print(m());

--- a/test/AsmJs/rlexe.xml
+++ b/test/AsmJs/rlexe.xml
@@ -566,16 +566,16 @@
   </test>
   <test>
     <default>
-      <files>invalidIntLiteral.js</files>
-      <baseline>invalidIntLiteral.baseline</baseline>
-      <compile-flags>-testtrace:asmjs -simdjs</compile-flags>
+      <files>floatmod.js</files>
+      <baseline>floatmod.baseline</baseline>
+      <compile-flags>-forceserialized -testtrace:asmjs -simdjs</compile-flags>
     </default>
   </test>
   <test>
     <default>
       <files>invalidIntLiteral.js</files>
       <baseline>invalidIntLiteral.baseline</baseline>
-      <compile-flags>-forceserialized -testtrace:asmjs -simdjs</compile-flags>
+      <compile-flags>-testtrace:asmjs -simdjs -force:deferparse</compile-flags>
     </default>
   </test>
   <test>


### PR DESCRIPTION
In asm.js in some cases instead of throwing an asm.js parse error and falling back to javascript we would cast int literals outside of the range [-2^31, 2^32) to int32, leading to incorrect behavior.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/291)
<!-- Reviewable:end -->
