### PR TITLE
Uint32 constant

### DIFF
--- a/lib/Backend/Chakra.Backend.vcxproj.filters
+++ b/lib/Backend/Chakra.Backend.vcxproj.filters
@@ -102,10 +102,12 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)arm\UnwindInfoManager.cpp">
       <Filter>arm</Filter>
     </ClCompile>
-    <ClCompile Include="$(MSBuildThisFileDirectory)arm64\EncoderMD.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)Inline.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)GlobOptSimd128.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)SwitchIRBuilder.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)arm64\EncoderMD.cpp">
+      <Filter>arm64</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="AgenPeeps.h" />

--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -14904,7 +14904,7 @@ Lowerer::GenerateFastStringLdElem(IR::Instr * ldElem, IR::LabelInstr * labelHelp
     //  CMP [baseOpnd + offset(length)], indexOpnd     --  string length
     //  JBE $helper                                    -- unsigned compare, and string length are at most INT_MAX - 1
     //                                                 -- so that even if we have a negative index, this will fail
-    InsertCompareBranch(IR::IndirOpnd::New(baseOpnd, offsetof(Js::JavascriptString, m_charLength), TyInt32, this->m_func)
+    InsertCompareBranch(IR::IndirOpnd::New(baseOpnd, offsetof(Js::JavascriptString, m_charLength), TyUint32, this->m_func)
         , index32CmpOpnd, Js::OpCode::BrLe_A, true, labelHelper, ldElem);
 
     // Load the string buffer and make sure it is not null
@@ -14920,7 +14920,7 @@ Lowerer::GenerateFastStringLdElem(IR::Instr * ldElem, IR::LabelInstr * labelHelp
     //  MOV charOpnd, [bufferOpnd + index32Opnd]
     //  CMP charOpnd, 0x80
     //  JAE $helper
-    IR::RegOpnd * charOpnd = IR::RegOpnd::New(TyInt32, this->m_func);
+    IR::RegOpnd * charOpnd = IR::RegOpnd::New(TyUint32, this->m_func);
     const IR::AutoReuseOpnd autoReuseCharOpnd(charOpnd, m_func);
     InsertMove(charOpnd, charIndirOpnd, ldElem);
     InsertCompareBranch(charOpnd, IR::IntConstOpnd::New(Js::CharStringCache::CharStringCacheSize, TyUint16, this->m_func),

--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -14897,7 +14897,7 @@ Lowerer::GenerateFastStringLdElem(IR::Instr * ldElem, IR::LabelInstr * labelHelp
     {
         // Just use the offset to indirect into the string buffer
         charIndirOpnd = IR::IndirOpnd::New(bufferOpnd, indirOpnd->GetOffset() * sizeof(wchar_t), TyUint16, this->m_func);
-        index32CmpOpnd = IR::IntConstOpnd::New(indirOpnd->GetOffset(), TyUint32, this->m_func);
+        index32CmpOpnd = IR::IntConstOpnd::New((uint32)indirOpnd->GetOffset(), TyUint32, this->m_func);
     }
 
     // Check if the index is in range of the string length

--- a/test/Strings/neg_index.js
+++ b/test/Strings/neg_index.js
@@ -1,0 +1,20 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+//reduced switches: -maxsimplejitruncount:1 -maxinterpretcount:1
+
+var zibhbj;
+
+for (i=0; i<500; i++) {
+   zibhbj = 'u{3402e}'[-1];
+}
+if (zibhbj === undefined) 
+{
+    WScript.Echo("Passed");    
+}
+else
+{
+    WScript.Echo("FAILED");
+}

--- a/test/Strings/neg_index.js
+++ b/test/Strings/neg_index.js
@@ -7,7 +7,7 @@
 
 var zibhbj;
 
-for (i=0; i<500; i++) {
+for (i=0; i<10000; i++) {
    zibhbj = 'u{3402e}'[-1];
 }
 if (zibhbj === undefined) 

--- a/test/Strings/rlexe.xml
+++ b/test/Strings/rlexe.xml
@@ -135,6 +135,11 @@
   </test>
   <test>
     <default>
+      <files>neg_index.js</files>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>substring.js</files>
       <baseline>substring.baseline</baseline>
       <compile-flags>-Intl-</compile-flags>


### PR DESCRIPTION
Properly cast to uint32 a TyUint32 offset to avoid having it sign extended to 64bit on x64.
