### PR TITLE
Bugfix:OS6135311: Incorrect base register assignment in inlined LdNewTarget

### DIFF
--- a/Lib/Backend/Lower.h
+++ b/Lib/Backend/Lower.h
@@ -429,6 +429,7 @@ private:
     IR::Opnd*       GenerateArgOutForInlineeStackArgs(IR::Instr* callInstr, IR::Instr* stackArgsInstr);
     IR::Opnd*       GenerateArgOutForStackArgs(IR::Instr* callInstr, IR::Instr* stackArgsInstr);
 
+    void            GenerateLoadStackArgumentByIndex(IR::Opnd *dst, IR::RegOpnd *indexOpnd, IR::Instr *instr, int32 offset, Func *func);
     bool            GenerateFastStackArgumentsLdElemI(IR::Instr* ldElem);
     IR::IndirOpnd*  GetArgsIndirOpndForInlinee(IR::Instr* ldElem, IR::Opnd* valueOpnd);
     IR::IndirOpnd*  GetArgsIndirOpndForTopFunction(IR::Instr* ldElem, IR::Opnd* valueOpnd);

--- a/test/es6/classes_bugfixes.js
+++ b/test/es6/classes_bugfixes.js
@@ -299,6 +299,21 @@ var tests = [
         var bar = new B();
     }
   },
+  {
+    name: "OS6135311: Incorrect base register assignment in inlined LdNewTarget",
+    body: function () {
+        function func5 () {
+            assert.areEqual(class0, new.target, "new.target should return subclass constructor for super constructor call");
+            function v0() {};
+        }
+        class class0 extends func5 {  }
+
+        new class0();
+        new class0(-1);
+        new class0([2,3], NaN);
+        new class0("cat", 100, {});
+    }
+  },
 ];
 
 testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });


### PR DESCRIPTION
Bugfix:OS6135311: Incorrect base register assignment in inlined LdNewTarget

LdNewTarget inliner uses a base operand that is not properly assigned for indirect load of 'new.target' from stack.
This change re-factors generation of said indirect load for use in both stack argument load (arguments[i]) and in LdNewTarget.
Add unit test.
