### PR TITLE
Use smaller data type to represent the counter fields of FunctionBody.

### DIFF
--- a/lib/Backend/BailOut.cpp
+++ b/lib/Backend/BailOut.cpp
@@ -1433,8 +1433,8 @@ BailOutRecord::BailOutHelper(Js::JavascriptCallStackLayout * layout, Js::ScriptF
         memset(newInstance->m_localSlots + constantCount, 0, varCount * sizeof(Js::Var));
     }
 
-    Js::RegSlot localFrameDisplayReg = executeFunction->GetLocalFrameDisplayReg();
-    Js::RegSlot localClosureReg = executeFunction->GetLocalClosureReg();
+    Js::RegSlot localFrameDisplayReg = executeFunction->GetLocalFrameDisplayRegister();
+    Js::RegSlot localClosureReg = executeFunction->GetLocalClosureRegister();
 
     if (!isInlinee)
     {
@@ -1503,7 +1503,7 @@ BailOutRecord::BailOutHelper(Js::JavascriptCallStackLayout * layout, Js::ScriptF
     uint32 innerScopeCount = executeFunction->GetInnerScopeCount();
     for (uint32 i = 0; i < innerScopeCount; i++)
     {
-        Js::RegSlot reg = executeFunction->FirstInnerScopeReg() + i;
+        Js::RegSlot reg = executeFunction->GetFirstInnerScopeRegister() + i;
         newInstance->SetInnerScopeFromIndex(i, newInstance->GetNonVarReg(reg));
         newInstance->SetNonVarReg(reg, nullptr);
     }

--- a/lib/Backend/CodeGenWorkItem.h
+++ b/lib/Backend/CodeGenWorkItem.h
@@ -279,7 +279,7 @@ public:
 
     uint GetInterpretedCount() const override
     {
-        return this->functionBody->interpretedCount;
+        return this->functionBody->GetInterpretedCount();
     }
 
     void Delete() override

--- a/lib/Backend/Func.cpp
+++ b/lib/Backend/Func.cpp
@@ -956,7 +956,7 @@ void Func::InitLocalClosureSyms()
     // Allocate stack space for closure pointers. Do this only if we're jitting for stack closures, and
     // tell bailout that these are not byte code symbols so that we don't try to encode them in the bailout record,
     // as they don't have normal lifetimes.
-    Js::RegSlot regSlot = this->GetJnFunction()->GetLocalClosureReg();
+    Js::RegSlot regSlot = this->GetJnFunction()->GetLocalClosureRegister();
     if (regSlot != Js::Constants::NoRegister)
     {
         this->m_localClosureSym =
@@ -964,7 +964,7 @@ void Func::InitLocalClosureSyms()
                                    this->DoStackFrameDisplay() ? (Js::RegSlot)-1 : regSlot,
                                    this);
     }
-    regSlot = this->GetJnFunction()->GetLocalFrameDisplayReg();
+    regSlot = this->GetJnFunction()->GetLocalFrameDisplayRegister();
     if (regSlot != Js::Constants::NoRegister)
     {
         this->m_localFrameDisplaySym =

--- a/lib/Backend/IRBuilder.cpp
+++ b/lib/Backend/IRBuilder.cpp
@@ -278,13 +278,13 @@ IRBuilder::GetLoopBodyExitInstrOffset() const
 Js::RegSlot
 IRBuilder::GetEnvReg() const
 {
-    return this->m_func->GetJnFunction()->GetEnvReg();
+    return this->m_func->GetJnFunction()->GetEnvRegister();
 }
 
 Js::RegSlot
 IRBuilder::GetEnvRegForInnerFrameDisplay() const
 {
-    Js::RegSlot envReg = this->m_func->GetJnFunction()->GetLocalFrameDisplayReg();
+    Js::RegSlot envReg = this->m_func->GetJnFunction()->GetLocalFrameDisplayRegister();
     if (envReg == Js::Constants::NoRegister)
     {
         envReg = this->GetEnvReg();
@@ -300,7 +300,7 @@ IRBuilder::AddEnvOpndForInnerFrameDisplay(IR::Instr *instr, uint offset)
     if (envReg != Js::Constants::NoRegister)
     {
         IR::RegOpnd *src2Opnd;
-        if (envReg == this->m_functionBody->GetLocalFrameDisplayReg() &&
+        if (envReg == this->m_functionBody->GetLocalFrameDisplayRegister() &&
             this->m_functionBody->DoStackFrameDisplay() &&
             m_func->IsTopFunc())
         {
@@ -424,7 +424,7 @@ IRBuilder::Build()
     m_func->m_headInstr->InsertAfter(m_func->m_tailInstr);
     m_func->m_isLeaf = true;  // until proven otherwise
 
-    if (this->m_func->GetJnFunction()->GetLocalClosureReg() != Js::Constants::NoRegister)
+    if (this->m_func->GetJnFunction()->GetLocalClosureRegister() != Js::Constants::NoRegister)
     {
         m_func->InitLocalClosureSyms();
     }
@@ -509,11 +509,11 @@ IRBuilder::Build()
         IR::Instr *instr;
 
         // Do the implicit operations LdEnv, NewScopeSlots, LdFrameDisplay, as indicated by function body attributes.
-        Js::RegSlot envReg = funcBody->GetEnvReg();
+        Js::RegSlot envReg = funcBody->GetEnvRegister();
         if (envReg != Js::Constants::NoRegister && !this->RegIsConstant(envReg))
         {
             Js::OpCode newOpcode;
-            Js::RegSlot thisReg = funcBody->GetThisRegForEventHandler();
+            Js::RegSlot thisReg = funcBody->GetThisRegisterForEventHandler();
             IR::RegOpnd *srcOpnd = nullptr;
             IR::RegOpnd *dstOpnd = nullptr;
             if (thisReg != Js::Constants::NoRegister)
@@ -540,8 +540,8 @@ IRBuilder::Build()
             this->AddInstr(instr, offset);
         }
 
-        Js::RegSlot frameDisplayReg = funcBody->GetLocalFrameDisplayReg();
-        Js::RegSlot funcExprScopeReg = funcBody->GetFuncExprScopeReg();
+        Js::RegSlot frameDisplayReg = funcBody->GetLocalFrameDisplayRegister();
+        Js::RegSlot funcExprScopeReg = funcBody->GetFuncExprScopeRegister();
         IR::RegOpnd *frameDisplayOpnd = nullptr;
         if (funcExprScopeReg != Js::Constants::NoRegister)
         {
@@ -558,7 +558,7 @@ IRBuilder::Build()
             this->AddInstr(instr, (uint)-1);
         }
 
-        Js::RegSlot closureReg = funcBody->GetLocalClosureReg();
+        Js::RegSlot closureReg = funcBody->GetLocalClosureRegister();
         IR::RegOpnd *closureOpnd = nullptr;
         if (closureReg != Js::Constants::NoRegister)
         {
@@ -1482,7 +1482,7 @@ IRBuilder::BuildReg1(Js::OpCode newOpcode, uint32 offset, Js::RegSlot R0)
         {
             Js::Throw::FatalInternalError();
         }
-        srcOpnd = BuildSrcOpnd(m_func->GetJnFunction()->GetLocalClosureReg());
+        srcOpnd = BuildSrcOpnd(m_func->GetJnFunction()->GetLocalClosureRegister());
         isNotInt = true;
         break;
 
@@ -1491,7 +1491,7 @@ IRBuilder::BuildReg1(Js::OpCode newOpcode, uint32 offset, Js::RegSlot R0)
         {
             Js::Throw::FatalInternalError();
         }
-        srcOpnd = BuildSrcOpnd(m_func->GetJnFunction()->GetLocalClosureReg());
+        srcOpnd = BuildSrcOpnd(m_func->GetJnFunction()->GetLocalClosureRegister());
         isNotInt = true;
         newOpcode = Js::OpCode::Ld_A;
         break;
@@ -1700,7 +1700,7 @@ IRBuilder::BuildReg2(Js::OpCode newOpcode, uint32 offset, Js::RegSlot R0, Js::Re
             src1Opnd->m_sym->m_instrDef &&
             src1Opnd->m_sym->m_instrDef->m_opcode == Js::OpCode::LdPropIds)
         {
-            Js::RegSlot regFrameObj = m_func->GetJnFunction()->GetLocalClosureReg();
+            Js::RegSlot regFrameObj = m_func->GetJnFunction()->GetLocalClosureRegister();
             Assert(regFrameObj != Js::Constants::NoRegister);
             opndFrameObj = BuildSrcOpnd(regFrameObj);
         }
@@ -1750,7 +1750,7 @@ IRBuilder::BuildReg2(Js::OpCode newOpcode, uint32 offset, Js::RegSlot R0, Js::Re
 
         IR::RegOpnd *src2Opnd = dstOpnd;
         src1Opnd = BuildSrcOpnd(R0);
-        dstOpnd = BuildDstOpnd(this->m_func->GetJnFunction()->GetLocalFrameDisplayReg());
+        dstOpnd = BuildDstOpnd(this->m_func->GetJnFunction()->GetLocalFrameDisplayRegister());
         instr = IR::Instr::New(Js::OpCode::LdFrameDisplay, dstOpnd, src1Opnd, src2Opnd, m_func);
         dstOpnd->m_sym->m_isNotInt = true;
         this->AddInstr(instr, offset);
@@ -2063,7 +2063,7 @@ IRBuilder::BuildReg3(Js::OpCode newOpcode, uint32 offset, Js::RegSlot dstRegSlot
             Js::Throw::FatalInternalError();
         }
         newOpcode = Js::OpCode::NewScopeSlotsWithoutPropIds;
-        dstRegSlot += m_func->GetJnFunction()->FirstInnerScopeReg();
+        dstRegSlot += m_func->GetJnFunction()->GetFirstInnerScopeRegister();
         instr = IR::Instr::New(newOpcode, BuildDstOpnd(dstRegSlot),
                                IR::IntConstOpnd::New(src1RegSlot, TyVar, m_func),
                                IR::IntConstOpnd::New(src2RegSlot, TyVar, m_func),
@@ -2514,7 +2514,7 @@ IRBuilder::BuildUnsigned1(Js::OpCode newOpcode, uint32 offset, uint32 num)
             {
                 Js::Throw::FatalInternalError();
             }
-            Js::RegSlot dstRegSlot = num + m_func->GetJnFunction()->FirstInnerScopeReg();
+            Js::RegSlot dstRegSlot = num + m_func->GetJnFunction()->GetFirstInnerScopeRegister();
             IR::RegOpnd * dstOpnd = BuildDstOpnd(dstRegSlot);
             IR::Instr * instr = IR::Instr::New(newOpcode, dstOpnd, m_func);
             this->AddInstr(instr, offset);
@@ -2532,7 +2532,7 @@ IRBuilder::BuildUnsigned1(Js::OpCode newOpcode, uint32 offset, uint32 num)
             {
                 Js::Throw::FatalInternalError();
             }
-            Js::RegSlot srcRegSlot = num + m_func->GetJnFunction()->FirstInnerScopeReg();
+            Js::RegSlot srcRegSlot = num + m_func->GetJnFunction()->GetFirstInnerScopeRegister();
             IR::RegOpnd * srcOpnd = BuildSrcOpnd(srcRegSlot);
             IR::Instr * instr = IR::Instr::New(newOpcode, m_func);
             instr->SetSrc1(srcOpnd);
@@ -2677,7 +2677,7 @@ IRBuilder::BuildUnsigned1(Js::OpCode newOpcode, uint32 offset, uint32 num)
         {
             // The reg and constant are both src operands.
             IR::Instr* instr = IR::Instr::New(Js::OpCode::InvalCachedScope, m_func);
-            IR::RegOpnd *envOpnd = this->BuildSrcOpnd(m_func->GetJnFunction()->GetEnvReg());
+            IR::RegOpnd *envOpnd = this->BuildSrcOpnd(m_func->GetJnFunction()->GetEnvRegister());
             instr->SetSrc1(envOpnd);
             IR::IntConstOpnd *envIndex = IR::IntConstOpnd::New(num, TyInt32, m_func, true);
             instr->SetSrc2(envIndex);
@@ -2849,7 +2849,7 @@ IRBuilder::BuildReg1Unsigned1(Js::OpCode newOpcode, uint offset, Js::RegSlot R0,
 
         case Js::OpCode::GetCachedFunc:
         {
-            IR::RegOpnd *src1Opnd = this->BuildSrcOpnd(m_func->GetJnFunction()->GetLocalClosureReg());
+            IR::RegOpnd *src1Opnd = this->BuildSrcOpnd(m_func->GetJnFunction()->GetLocalClosureRegister());
             IR::Opnd *src2Opnd = IR::IntConstOpnd::New(C1, TyUint32, m_func);
             IR::RegOpnd *dstOpnd = this->BuildDstOpnd(R0);
             IR::Instr *instr = IR::Instr::New(newOpcode, dstOpnd, src1Opnd, src2Opnd, m_func);
@@ -2940,7 +2940,7 @@ IRBuilder::BuildReg2Int1(Js::OpCode newOpcode, uint32 offset, Js::RegSlot dstReg
         {
             Js::Throw::FatalInternalError();
         }
-        IR::RegOpnd *src1Opnd = this->BuildSrcOpnd(value + m_func->GetJnFunction()->FirstInnerScopeReg());
+        IR::RegOpnd *src1Opnd = this->BuildSrcOpnd(value + m_func->GetJnFunction()->GetFirstInnerScopeRegister());
         IR::RegOpnd *src2Opnd = this->BuildSrcOpnd(srcRegSlot);
         IR::RegOpnd *dstOpnd = this->BuildDstOpnd(dstRegSlot);
         instr = IR::Instr::New(newOpcode, dstOpnd, src1Opnd, src2Opnd, m_func);
@@ -3388,7 +3388,7 @@ IRBuilder::BuildElementSlotI1(Js::OpCode newOpcode, uint32 offset, Js::RegSlot r
             }
             else
             {
-                symID = m_func->GetJnFunction()->GetLocalClosureReg();
+                symID = m_func->GetJnFunction()->GetLocalClosureRegister();
                 if (IsLoopBody())
                 {
                     this->EnsureLoopBodyLoadSlot(symID);
@@ -3424,7 +3424,7 @@ IRBuilder::BuildElementSlotI1(Js::OpCode newOpcode, uint32 offset, Js::RegSlot r
                 this->AddInstr(byteCodeUse, offset);
             }
 
-            fieldOpnd = this->BuildFieldOpnd(newOpcode, m_func->GetJnFunction()->GetLocalClosureReg(), (Js::DynamicObject::GetOffsetOfAuxSlots())/sizeof(Js::Var), (Js::PropertyIdIndexType)-1, PropertyKindSlotArray);
+            fieldOpnd = this->BuildFieldOpnd(newOpcode, m_func->GetJnFunction()->GetLocalClosureRegister(), (Js::DynamicObject::GetOffsetOfAuxSlots())/sizeof(Js::Var), (Js::PropertyIdIndexType)-1, PropertyKindSlotArray);
             regOpnd = IR::RegOpnd::New(TyVar, m_func);
             instr = IR::Instr::New(Js::OpCode::LdSlotArr, regOpnd, fieldOpnd, m_func);
             this->AddInstr(instr, offset);
@@ -3485,7 +3485,7 @@ IRBuilder::BuildElementSlotI1(Js::OpCode newOpcode, uint32 offset, Js::RegSlot r
             }
             else
             {
-                symID = m_func->GetJnFunction()->GetLocalClosureReg();
+                symID = m_func->GetJnFunction()->GetLocalClosureRegister();
                 if (IsLoopBody())
                 {
                     this->EnsureLoopBodyLoadSlot(symID);
@@ -3520,7 +3520,7 @@ IRBuilder::BuildElementSlotI1(Js::OpCode newOpcode, uint32 offset, Js::RegSlot r
             }
 
             regOpnd = IR::RegOpnd::New(TyVar, m_func);
-            fieldOpnd = this->BuildFieldOpnd(Js::OpCode::LdSlotArr, m_func->GetJnFunction()->GetLocalClosureReg(), (Js::DynamicObject::GetOffsetOfAuxSlots())/sizeof(Js::Var), (Js::PropertyIdIndexType)-1, PropertyKindSlotArray);
+            fieldOpnd = this->BuildFieldOpnd(Js::OpCode::LdSlotArr, m_func->GetJnFunction()->GetLocalClosureRegister(), (Js::DynamicObject::GetOffsetOfAuxSlots())/sizeof(Js::Var), (Js::PropertyIdIndexType)-1, PropertyKindSlotArray);
             instr = IR::Instr::New(Js::OpCode::LdSlotArr, regOpnd, fieldOpnd, m_func);
             this->AddInstr(instr, offset);
 
@@ -3730,7 +3730,7 @@ IRBuilder::BuildElementSlotI2(Js::OpCode newOpcode, uint32 offset, Js::RegSlot r
                 Js::Throw::FatalInternalError();
             }
             regOpnd = this->BuildSrcOpnd(regSlot);
-            slotId1 += this->m_func->GetJnFunction()->FirstInnerScopeReg();
+            slotId1 += this->m_func->GetJnFunction()->GetFirstInnerScopeRegister();
             if ((uint)slotId1 >= this->m_func->GetJnFunction()->GetLocalsCount())
             {
                 Js::Throw::FatalInternalError();
@@ -3773,7 +3773,7 @@ IRBuilder::BuildElementSlotI2(Js::OpCode newOpcode, uint32 offset, Js::RegSlot r
             {
                 Js::Throw::FatalInternalError();
             }
-            slotId1 += this->m_func->GetJnFunction()->FirstInnerScopeReg();
+            slotId1 += this->m_func->GetJnFunction()->GetFirstInnerScopeRegister();
             if ((uint)slotId1 >= this->m_func->GetJnFunction()->GetLocalsCount())
             {
                 Js::Throw::FatalInternalError();
@@ -3926,11 +3926,11 @@ Js::RegSlot IRBuilder::GetEnvRegForEvalCode() const
 
     if (functionBody->GetIsStrictMode() && functionBody->GetIsGlobalFunc())
     {
-        return functionBody->GetLocalFrameDisplayReg();
+        return functionBody->GetLocalFrameDisplayRegister();
     }
     else
     {
-        return functionBody->GetEnvReg();
+        return functionBody->GetEnvRegister();
     }
 }
 
@@ -3983,7 +3983,7 @@ IRBuilder::BuildElementP(Js::OpCode newOpcode, uint32 offset, Js::RegSlot regSlo
         }
 
         newOpcode = Js::OpCode::LdFld;
-        fieldSymOpnd = this->BuildFieldOpnd(newOpcode, m_func->GetJnFunction()->GetLocalClosureReg(), propertyId, (Js::PropertyIdIndexType)-1, PropertyKindData, inlineCacheIndex);
+        fieldSymOpnd = this->BuildFieldOpnd(newOpcode, m_func->GetJnFunction()->GetLocalClosureRegister(), propertyId, (Js::PropertyIdIndexType)-1, PropertyKindData, inlineCacheIndex);
         if (fieldSymOpnd->IsPropertySymOpnd())
         {
             fieldSymOpnd->AsPropertySymOpnd()->TryDisableRuntimePolymorphicCache();
@@ -4012,7 +4012,7 @@ IRBuilder::BuildElementP(Js::OpCode newOpcode, uint32 offset, Js::RegSlot regSlo
             this->AddInstr(byteCodeUse, offset);
         }
 
-        fieldSymOpnd = this->BuildFieldOpnd(newOpcode, m_func->GetJnFunction()->GetLocalClosureReg(), propertyId, (Js::PropertyIdIndexType)-1, PropertyKindData, inlineCacheIndex);
+        fieldSymOpnd = this->BuildFieldOpnd(newOpcode, m_func->GetJnFunction()->GetLocalClosureRegister(), propertyId, (Js::PropertyIdIndexType)-1, PropertyKindData, inlineCacheIndex);
         if (fieldSymOpnd->IsPropertySymOpnd())
         {
             fieldSymOpnd->AsPropertySymOpnd()->TryDisableRuntimePolymorphicCache();
@@ -4034,7 +4034,7 @@ IRBuilder::BuildElementP(Js::OpCode newOpcode, uint32 offset, Js::RegSlot regSlo
             this->AddInstr(byteCodeUse, offset);
         }
 
-        fieldSymOpnd = this->BuildFieldOpnd(newOpcode, m_func->GetJnFunction()->GetLocalClosureReg(), propertyId, (Js::PropertyIdIndexType)-1, PropertyKindData, inlineCacheIndex);
+        fieldSymOpnd = this->BuildFieldOpnd(newOpcode, m_func->GetJnFunction()->GetLocalClosureRegister(), propertyId, (Js::PropertyIdIndexType)-1, PropertyKindData, inlineCacheIndex);
         // Store
         if (newOpcode == Js::OpCode::InitUndeclLocalLetFld)
         {
@@ -4504,7 +4504,7 @@ IRBuilder::BuildElementScopedU(Js::OpCode newOpcode, uint32 offset)
     Assert(!OpCodeAttr::IsProfiledOp(newOpcode));
     Assert(OpCodeAttr::HasMultiSizeLayout(newOpcode));
     auto layout = m_jnReader.GetLayout<Js::OpLayoutT_ElementScopedU<SizePolicy>>();
-    BuildElementU(newOpcode, offset, m_func->GetJnFunction()->GetEnvReg(), layout->PropertyIdIndex);
+    BuildElementU(newOpcode, offset, m_func->GetJnFunction()->GetEnvRegister(), layout->PropertyIdIndex);
 }
 
 void
@@ -4527,7 +4527,7 @@ IRBuilder::BuildElementU(Js::OpCode newOpcode, uint32 offset, Js::RegSlot instan
                 this->AddInstr(byteCodeUse, offset);
             }
 
-            instance = m_func->GetJnFunction()->GetLocalClosureReg();
+            instance = m_func->GetJnFunction()->GetLocalClosureRegister();
             newOpcode = Js::OpCode::LdElemUndef;
             fieldSymOpnd = this->BuildFieldOpnd(newOpcode, instance, propertyId, propertyIdIndex, PropertyKindData);
             instr = IR::Instr::New(newOpcode, fieldSymOpnd, m_func);
@@ -4557,7 +4557,7 @@ IRBuilder::BuildElementU(Js::OpCode newOpcode, uint32 offset, Js::RegSlot instan
         }
 
         case Js::OpCode::StLocalFuncExpr:
-            fieldSymOpnd = this->BuildFieldOpnd(newOpcode, m_func->GetJnFunction()->GetLocalClosureReg(), propertyId, propertyIdIndex, PropertyKindData);
+            fieldSymOpnd = this->BuildFieldOpnd(newOpcode, m_func->GetJnFunction()->GetLocalClosureRegister(), propertyId, propertyIdIndex, PropertyKindData);
             regOpnd = this->BuildSrcOpnd(instance);
             newOpcode = Js::OpCode::StFuncExpr;
             instr = IR::Instr::New(newOpcode, fieldSymOpnd, regOpnd, m_func);
@@ -4565,7 +4565,7 @@ IRBuilder::BuildElementU(Js::OpCode newOpcode, uint32 offset, Js::RegSlot instan
 
         case Js::OpCode::DeleteLocalFld:
             newOpcode = Js::OpCode::DeleteFld;
-            fieldSymOpnd = BuildFieldOpnd(newOpcode, m_func->GetJnFunction()->GetLocalClosureReg(), propertyId, propertyIdIndex, PropertyKindData);
+            fieldSymOpnd = BuildFieldOpnd(newOpcode, m_func->GetJnFunction()->GetLocalClosureRegister(), propertyId, propertyIdIndex, PropertyKindData);
             regOpnd = BuildDstOpnd(instance);
             instr = IR::Instr::New(newOpcode, regOpnd, fieldSymOpnd, m_func);
             break;
@@ -4605,7 +4605,7 @@ IRBuilder::BuildAuxNoReg(Js::OpCode newOpcode, uint32 offset)
             IR::RegOpnd *   src1Opnd;
             IR::Opnd*       src2Opnd;
 
-            src1Opnd = this->BuildSrcOpnd(m_func->GetJnFunction()->GetLocalClosureReg());
+            src1Opnd = this->BuildSrcOpnd(m_func->GetJnFunction()->GetLocalClosureRegister());
             src2Opnd = IR::IntConstOpnd::New(auxInsn->Offset, TyUint32, this->m_func);
 
             IR::LabelInstr *labelNull = IR::LabelInstr::New(Js::OpCode::Label, this->m_func);
@@ -4630,8 +4630,8 @@ IRBuilder::BuildAuxNoReg(Js::OpCode newOpcode, uint32 offset)
 
         case Js::OpCode::InitCachedFuncs:
         {
-            IR::Opnd   *src1Opnd = this->BuildSrcOpnd(m_func->GetJnFunction()->GetLocalClosureReg());
-            IR::Opnd   *src2Opnd = this->BuildSrcOpnd(m_func->GetJnFunction()->GetLocalFrameDisplayReg());
+            IR::Opnd   *src1Opnd = this->BuildSrcOpnd(m_func->GetJnFunction()->GetLocalClosureRegister());
+            IR::Opnd   *src2Opnd = this->BuildSrcOpnd(m_func->GetJnFunction()->GetLocalFrameDisplayRegister());
             IR::Opnd   *src3Opnd = this->BuildAuxArrayOpnd(AuxArrayValue::AuxFuncInfoArray, offset, auxInsn->Offset);
 
             instr = IR::Instr::New(Js::OpCode::ArgOut_A, IR::RegOpnd::New(TyVar, m_func), src3Opnd, m_func);
@@ -4999,7 +4999,7 @@ void IRBuilder::BuildInitCachedScope(int auxOffset, int offset)
     src2Opnd = this->BuildAuxArrayOpnd(AuxArrayValue::AuxPropertyIdArray, offset, auxOffset, Js::ActivationObjectEx::ExtraSlotCount());
     Js::PropertyIdArray * propIds = (Js::PropertyIdArray *)src2Opnd->AsAddrOpnd()->m_address;
     src3Opnd = this->BuildAuxObjectLiteralTypeRefOpnd(Js::ActivationObjectEx::GetLiteralObjectRef(propIds), offset);
-    dstOpnd = this->BuildDstOpnd(m_func->GetJnFunction()->GetLocalClosureReg());
+    dstOpnd = this->BuildDstOpnd(m_func->GetJnFunction()->GetLocalClosureRegister());
 
     formalsAreLetDeclOpnd = IR::IntConstOpnd::New(propIds->hasNonSimpleParams, TyUint8, m_func);
 
@@ -6911,7 +6911,7 @@ IRBuilder::BuildBrLocalProperty(Js::OpCode newOpcode, uint32 offset)
     Js::PropertyId    propertyId =
         this->m_func->GetJnFunction()->GetReferencedPropertyIdWithLock(branchInsn->PropertyIdIndex);
     unsigned int      targetOffset = m_jnReader.GetCurrentOffset() + branchInsn->RelativeJumpOffset;
-    IR::SymOpnd *     fieldSymOpnd = this->BuildFieldOpnd(newOpcode, m_func->GetJnFunction()->GetLocalClosureReg(), propertyId, branchInsn->PropertyIdIndex, PropertyKindData);
+    IR::SymOpnd *     fieldSymOpnd = this->BuildFieldOpnd(newOpcode, m_func->GetJnFunction()->GetLocalClosureRegister(), propertyId, branchInsn->PropertyIdIndex, PropertyKindData);
 
     branchInstr = IR::BranchInstr::New(newOpcode, nullptr, fieldSymOpnd, m_func);
     this->AddBranchInstr(branchInstr, offset, targetOffset);
@@ -7241,9 +7241,9 @@ IRBuilder::DoClosureRegCheck(Js::RegSlot reg)
     }
 
     Js::FunctionBody * functionBody = this->m_func->GetJnFunction();
-    if (reg == functionBody->GetEnvReg() ||
-        reg == functionBody->GetLocalClosureReg() ||
-        reg == functionBody->GetLocalFrameDisplayReg())
+    if (reg == functionBody->GetEnvRegister() ||
+        reg == functionBody->GetLocalClosureRegister() ||
+        reg == functionBody->GetLocalFrameDisplayRegister())
     {
         Js::Throw::FatalInternalError();
     }
@@ -7256,7 +7256,7 @@ IRBuilder::InnerScopeIndexToRegSlot(uint32 index) const
     {
         Js::Throw::FatalInternalError();
     }
-    Js::RegSlot reg = m_func->GetJnFunction()->FirstInnerScopeReg() + index;
+    Js::RegSlot reg = m_func->GetJnFunction()->GetFirstInnerScopeRegister() + index;
     if (reg >= m_func->GetJnFunction()->GetLocalsCount())
     {
         Js::Throw::FatalInternalError();

--- a/lib/Runtime/Base/AuxPtrs.h
+++ b/lib/Runtime/Base/AuxPtrs.h
@@ -182,10 +182,9 @@ namespace Js
     template<class T, typename FieldsEnum>
     void AuxPtrs<T, FieldsEnum>::AllocAuxPtr(T* host, uint8 count)
     {
-        Assert(count >= AuxPtrs32::MaxCount);
-
         Recycler* recycler = host->GetRecycler();
         Assert(recycler != nullptr);
+        Assert(count >= AuxPtrs32::MaxCount);
 
         auto requestSize = sizeof(AuxPtrs<T, FieldsEnum>) + (count - 1)*sizeof(void*);
         auto allocSize = ::Math::Align<uint8>((uint8)requestSize, 16);
@@ -218,6 +217,7 @@ namespace Js
     template<class T, typename FieldsEnum>
     void AuxPtrs<T, FieldsEnum>::SetAuxPtr(T* host, FieldsEnum e, void* ptr)
     {
+
         if (host->auxPtrs == nullptr)
         {
             AuxPtrs<FunctionProxy, FieldsEnum>::AllocAuxPtrFix(host, 16);

--- a/lib/Runtime/Base/Chakra.Runtime.Base.vcxproj
+++ b/lib/Runtime/Base/Chakra.Runtime.Base.vcxproj
@@ -69,6 +69,7 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="CompactCounters.h" />
     <ClInclude Include="RuntimeBasePch.h" />
     <ClInclude Include="AuxPtrs.h" />
     <ClInclude Include="CallInfo.h" />

--- a/lib/Runtime/Base/CompactCounters.h
+++ b/lib/Runtime/Base/CompactCounters.h
@@ -12,7 +12,7 @@ namespace Js
     template<class T, typename CountT = T::CounterFields>
     struct CompactCounters
     {
-        volatile uint8 fieldSize;
+        uint8 fieldSize;
 #if DBG
         mutable bool bgThreadCallStarted;
         bool isCleaningUp;
@@ -25,7 +25,6 @@ namespace Js
             WriteBarrierPtr<int16> i16Fields;
             WriteBarrierPtr<int32> i32Fields;
         };
-
 
         CompactCounters()
             :fieldSize(1)

--- a/lib/Runtime/Base/CompactCounters.h
+++ b/lib/Runtime/Base/CompactCounters.h
@@ -1,0 +1,274 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+#pragma once
+
+#pragma warning(push)
+#pragma warning(disable:6200) // C6200: Index is out of valid index range, compiler complains here we use variable length array
+
+namespace Js
+{
+    template<class T, typename CountT = T::CounterFields>
+    struct CompactCounters
+    {
+        volatile uint8 fieldSize;
+#if DBG
+        mutable bool bgThreadCallStarted;
+        bool isCleaningUp;
+#endif
+        union {
+            uint8 u8fields[CountT::Max];
+            int8 i8fields[CountT::Max];
+            WriteBarrierPtr<uint16> u16Fields;
+            WriteBarrierPtr<uint32> u32Fields;
+            WriteBarrierPtr<int16> i16Fields;
+            WriteBarrierPtr<int32> i32Fields;
+        };
+
+
+        CompactCounters()
+            :fieldSize(1)
+#if DBG
+            , bgThreadCallStarted(false), isCleaningUp(false)
+#endif
+        {
+            memset(u8fields, 0, (uint8)CountT::Max);
+        }
+
+        void AllocCounters(T* host, uint8 newSize);
+
+        uint32 Get(CountT typeEnum) const
+        {
+#if DBG
+            if (ThreadContext::GetContextForCurrentThread() == nullptr)
+            {
+                bgThreadCallStarted = true;
+            }
+#endif
+            uint8 type = static_cast<uint8>(typeEnum);
+            uint8 localFieldSize = fieldSize;
+            uint32 value = 0;
+            if (localFieldSize == 1)
+            {
+                value = this->u8fields[type];
+            }
+            else if (localFieldSize == 2)
+            {
+                value = this->u16Fields[type];
+            }
+            else
+            {
+                Assert(localFieldSize == 4);
+                value = this->u32Fields[type];
+            }
+
+            return value;
+        }
+
+        int32 GetSigned(CountT typeEnum) const
+        {
+#if DBG
+            if (ThreadContext::GetContextForCurrentThread() == nullptr)
+            {
+                bgThreadCallStarted = true;
+            }
+#endif
+
+            uint8 type = static_cast<uint8>(typeEnum);
+            uint8 localFieldSize = fieldSize;
+            int32 value = 0;
+            if (localFieldSize == 1)
+            {
+                value = this->i8fields[type];
+            }
+            else if (localFieldSize == 2)
+            {
+                value = this->i16Fields[type];
+            }
+            else
+            {
+                Assert(localFieldSize == 4);
+                value = this->i32Fields[type];
+            }
+            return value;
+        }
+
+        uint32 Set(CountT typeEnum, uint32 val, T* host)
+        {            
+            Assert(bgThreadCallStarted == false || isCleaningUp == true);
+
+            uint8 type = static_cast<uint8>(typeEnum);
+            if (fieldSize == 1)
+            {
+                if (val <= UINT8_MAX)
+                {
+                    return this->u8fields[type] = static_cast<uint8>(val);
+                }
+                else
+                {
+                    AllocCounters(host, val <= UINT16_MAX ? 2 : 4);
+                }
+                return this->Set(typeEnum, val, host);
+            }
+
+            if (fieldSize == 2)
+            {
+                if (val <= UINT16_MAX)
+                {
+                    return this->u16Fields[type] = static_cast<uint16>(val);
+                }
+                else
+                {
+                    AllocCounters(host, 4);
+                }
+                return this->Set(typeEnum, val, host);
+            }
+
+            Assert(fieldSize == 4);
+            return this->u32Fields[type] = val;
+        }
+
+        int32 SetSigned(CountT typeEnum, int32 val, T* host)
+        {
+            Assert(bgThreadCallStarted == false || isCleaningUp == true);
+
+            uint8 type = static_cast<uint8>(typeEnum);
+            if (fieldSize == 1)
+            {
+                if (val <= INT8_MAX && val >= INT8_MIN)
+                {
+                    return this->i8fields[type] = static_cast<uint8>(val);
+                }
+                else
+                {
+                    AllocCounters(host, (val <= INT16_MAX && val >= INT16_MIN) ? 2 : 4);
+                }
+                return this->SetSigned(typeEnum, val, host);
+            }
+
+            if (fieldSize == 2)
+            {
+                if (val <= INT16_MAX && val >= INT16_MIN)
+                {
+                    return this->i16Fields[type] = static_cast<uint16>(val);
+                }
+                else
+                {
+                    AllocCounters(host, 4);
+                }
+                return this->SetSigned(typeEnum, val, host);
+            }
+
+            Assert(fieldSize == 4);
+            return this->i32Fields[type] = val;
+        }
+
+        uint32 Increase(CountT typeEnum, T* host)
+        {
+            Assert(bgThreadCallStarted == false);
+
+            uint8 type = static_cast<uint8>(typeEnum);
+            if (fieldSize == 1)
+            {
+                if (this->u8fields[type] < UINT8_MAX)
+                {
+                    return this->u8fields[type]++;
+                }
+                else
+                {
+                    AllocCounters(host, 2);
+                }
+                return this->Increase(typeEnum, host);
+            }
+
+            if (fieldSize == 2)
+            {
+                if (this->u16Fields[type] < UINT16_MAX)
+                {
+                    return this->u16Fields[type]++;
+                }
+                else
+                {
+                    AllocCounters(host, 4);
+                }
+                return this->Increase(typeEnum, host);
+            }
+
+            Assert(fieldSize == 4);
+            return this->u32Fields[type]++;
+        }
+    };
+
+
+    template<class T, typename CountT>
+    void CompactCounters<T, CountT>::AllocCounters(T* host, uint8 newSize)
+    {
+        Assert(ThreadContext::GetContextForCurrentThread() || ThreadContext::GetCriticalSection()->IsLocked());
+
+        typedef CompactCounters<T, CountT> CounterT;
+        Assert(host->GetRecycler() != nullptr);
+
+        const uint8 signedStart = static_cast<uint8>(CountT::SignedFieldsStart);
+        const uint8 max = static_cast<uint8>(CountT::Max);
+
+        void* newFieldsArray = nullptr;
+        if (newSize == 2) 
+        {
+            newFieldsArray = RecyclerNewArrayLeafZ(host->GetRecycler(), uint16, max);
+        }
+        else 
+        {
+            Assert(newSize == 4);
+            newFieldsArray = RecyclerNewArrayLeafZ(host->GetRecycler(), uint32, max);
+        }
+
+        uint8 i = 0;
+        if (this->fieldSize == 1)
+        {
+            if (newSize == 2)
+            {
+                for (; i < signedStart; i++)
+                {
+                    ((uint16*)newFieldsArray)[i] = this->u8fields[i];
+                }
+                for (; i < max; i++)
+                {
+                    ((int16*)newFieldsArray)[i] = this->i8fields[i];
+                }
+            }
+            else
+            {
+                for (; i < signedStart; i++)
+                {
+                    ((uint32*)newFieldsArray)[i] = this->u8fields[i];
+                }
+                for (; i < max; i++)
+                {
+                    ((int32*)newFieldsArray)[i] = this->i8fields[i];
+                }
+            }
+        }
+        else if (this->fieldSize == 2)
+        {
+            for (; i < signedStart; i++)
+            {
+                ((uint32*)newFieldsArray)[i] = this->u16Fields[i];
+            }
+            for (; i < max; i++)
+            {
+                ((int32*)newFieldsArray)[i] = this->i16Fields[i];
+            }
+        }
+        else
+        {
+            Assert(false);
+        }
+        
+        this->fieldSize = newSize;
+        this->u16Fields = (uint16*)newFieldsArray;        
+
+    }
+}
+
+#pragma warning(pop)

--- a/lib/Runtime/Base/CompactCounters.h
+++ b/lib/Runtime/Base/CompactCounters.h
@@ -18,8 +18,8 @@ namespace Js
         bool isCleaningUp;
 #endif
         union {
-            uint8 u8fields[CountT::Max];
-            int8 i8fields[CountT::Max];
+            uint8 u8Fields[CountT::Max];
+            int8 i8Fields[CountT::Max];
             WriteBarrierPtr<uint16> u16Fields;
             WriteBarrierPtr<uint32> u32Fields;
             WriteBarrierPtr<int16> i16Fields;
@@ -33,7 +33,7 @@ namespace Js
             , bgThreadCallStarted(false), isCleaningUp(false)
 #endif
         {
-            memset(u8fields, 0, (uint8)CountT::Max);
+            memset(u8Fields, 0, (uint8)CountT::Max);
         }
 
         void AllocCounters(T* host, uint8 newSize);
@@ -51,7 +51,7 @@ namespace Js
             uint32 value = 0;
             if (localFieldSize == 1)
             {
-                value = this->u8fields[type];
+                value = this->u8Fields[type];
             }
             else if (localFieldSize == 2)
             {
@@ -80,7 +80,7 @@ namespace Js
             int32 value = 0;
             if (localFieldSize == 1)
             {
-                value = this->i8fields[type];
+                value = this->i8Fields[type];
             }
             else if (localFieldSize == 2)
             {
@@ -103,7 +103,7 @@ namespace Js
             {
                 if (val <= UINT8_MAX)
                 {
-                    return this->u8fields[type] = static_cast<uint8>(val);
+                    return this->u8Fields[type] = static_cast<uint8>(val);
                 }
                 else
                 {
@@ -138,7 +138,7 @@ namespace Js
             {
                 if (val <= INT8_MAX && val >= INT8_MIN)
                 {
-                    return this->i8fields[type] = static_cast<uint8>(val);
+                    return this->i8Fields[type] = static_cast<uint8>(val);
                 }
                 else
                 {
@@ -171,9 +171,9 @@ namespace Js
             uint8 type = static_cast<uint8>(typeEnum);
             if (fieldSize == 1)
             {
-                if (this->u8fields[type] < UINT8_MAX)
+                if (this->u8Fields[type] < UINT8_MAX)
                 {
-                    return this->u8fields[type]++;
+                    return this->u8Fields[type]++;
                 }
                 else
                 {
@@ -230,22 +230,22 @@ namespace Js
             {
                 for (; i < signedStart; i++)
                 {
-                    ((uint16*)newFieldsArray)[i] = this->u8fields[i];
+                    ((uint16*)newFieldsArray)[i] = this->u8Fields[i];
                 }
                 for (; i < max; i++)
                 {
-                    ((int16*)newFieldsArray)[i] = this->i8fields[i];
+                    ((int16*)newFieldsArray)[i] = this->i8Fields[i];
                 }
             }
             else
             {
                 for (; i < signedStart; i++)
                 {
-                    ((uint32*)newFieldsArray)[i] = this->u8fields[i];
+                    ((uint32*)newFieldsArray)[i] = this->u8Fields[i];
                 }
                 for (; i < max; i++)
                 {
-                    ((int32*)newFieldsArray)[i] = this->i8fields[i];
+                    ((int32*)newFieldsArray)[i] = this->i8Fields[i];
                 }
             }
         }

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "AuxPtrs.h"
+#include "CompactCounters.h"
 
 struct CodeGenWorkItem;
 class SourceContextInfo;
@@ -1156,8 +1157,9 @@ namespace Js
     //
     class FunctionProxy : public FunctionInfo
     {
-        static CriticalSection auxPtrsLock;
+        static CriticalSection GlobalLock;
     public:
+        static CriticalSection* GetLock() { return &GlobalLock; }
         typedef RecyclerWeakReference<DynamicType> FunctionTypeWeakRef;
         typedef JsUtil::List<FunctionTypeWeakRef*, Recycler, false, WeakRefFreeListedRemovePolicy> FunctionTypeWeakRefList;
 
@@ -1676,6 +1678,65 @@ namespace Js
             // same as MachDouble, used in the Func.h
             static const uint DIAGLOCALSLOTSIZE = 8;
 
+            enum class CounterFields : uint8
+            {
+                VarCount                                = 0,
+                ConstantCount                           = 1,
+                OutParamMaxDepth                        = 2,
+                ByteCodeCount                           = 3,
+                ByteCodeWithoutLDACount                 = 4,
+                ByteCodeInLoopCount                     = 5,
+                LoopCount                               = 6,
+                InlineCacheCount                        = 7,
+                RootObjectLoadInlineCacheStart          = 8,
+                RootObjectLoadMethodInlineCacheStart    = 9,
+                RootObjectStoreInlineCacheStart         = 10,
+                IsInstInlineCacheCount                  = 11,
+                ReferencedPropertyIdCount               = 12,
+                ObjLiteralCount                         = 13,
+                LiteralRegexCount                       = 14,
+                InnerScopeCount                         = 15,
+
+                // Following counters uses ((uint32)-1) as default value
+                LocalClosureRegister                    = 16,
+                LocalFrameDisplayRegister               = 17,
+                EnvRegister                             = 18,
+                ThisRegisterForEventHandler             = 19,
+                FirstInnerScopeRegister                 = 20,
+                FuncExprScopeRegister                   = 21,
+                FirstTmpRegister                        = 22,
+
+                // Signed integers need keep the sign when promoting 
+                SignedFieldsStart                       = 23,
+                SerializationIndex                      = 23,
+
+                Max
+            };
+
+            typedef CompactCounters<FunctionBody> CounterT;
+            CounterT counters;
+
+            uint32 GetCountField(FunctionBody::CounterFields fieldEnum) const
+            {
+                return counters.Get(fieldEnum);
+            }
+            uint32 SetCountField(FunctionBody::CounterFields fieldEnum, uint32 val)
+            {
+                return counters.Set(fieldEnum, val, this);
+            }
+            uint32 IncreaseCountField(FunctionBody::CounterFields fieldEnum)
+            {
+                return counters.Increase(fieldEnum, this);
+            }
+            int32 GetCountFieldSigned(FunctionBody::CounterFields fieldEnum) const
+            {
+                return counters.GetSigned(fieldEnum);
+            }
+            int32 SetCountFieldSigned(FunctionBody::CounterFields fieldEnum, int32 val)
+            {
+                return counters.SetSigned(fieldEnum, val, this);
+            }
+
             struct StatementMap
             {
                 StatementMap() : isSubexpression(false) {}
@@ -1814,8 +1875,6 @@ namespace Js
         NoWriteBarrierField<uint> regAllocLoadCount;
         NoWriteBarrierField<uint> callCountStats;
 #endif
-        NoWriteBarrierField<uint> interpretedCount;
-        NoWriteBarrierField<uint> loopInterpreterLimit;
 
         // >>>>>>WARNING! WARNING!<<<<<<<<<<
         //
@@ -1896,6 +1955,13 @@ namespace Js
         bool m_isFromNativeCodeModule : 1;
         bool m_isPartialDeserializedFunction : 1;
         bool m_isAsmJsScheduledForFullJIT : 1;
+        bool m_hasLocalClosureRegister : 1;
+        bool m_hasLocalFrameDisplayRegister : 1;
+        bool m_hasEnvRegister : 1;
+        bool m_hasThisRegisterForEventHandler : 1;
+        bool m_hasFirstInnerScopeRegister : 1;
+        bool m_hasFuncExprScopeRegister : 1;
+        bool m_hasFirstTmpRegister : 1;
 #ifdef PERF_COUNTERS
         bool m_isDeserializedFunction : 1;
 #endif
@@ -1932,6 +1998,10 @@ namespace Js
 
         NoWriteBarrierField<uint> m_depth; // Indicates how many times the function has been entered (so increases by one on each recursive call, decreases by one when we're done)
 
+        uint32 interpretedCount;
+        uint32 loopInterpreterLimit;
+        uint32 debuggerScopeIndex;
+        uint32 savedPolymorphicCacheState;
 
         // >>>>>>WARNING! WARNING!<<<<<<<<<<
         //
@@ -1940,7 +2010,6 @@ namespace Js
         //
 
         NoWriteBarrierPtr<Js::ByteCodeCache> byteCodeCache;  // Not GC allocated so naked pointer
-        NoWriteBarrierField<int> serializationIndex;
 #ifdef ENABLE_DEBUG_CONFIG_OPTIONS
         static bool shareInlineCaches;
 #endif
@@ -1957,14 +2026,6 @@ namespace Js
 #if ENABLE_NATIVE_CODEGEN
         NoWriteBarrierField<ImplicitCallFlags> savedImplicitCallsFlags;
 #endif
-
-        // State of inline caches (polymorphic vs. monomorphic) reflected in
-        // last jitted version of this func.
-        NoWriteBarrierField<uint32> savedPolymorphicCacheState;
-
-        // Used to track where we are when adding debugger scopes to the scope chain
-        // in order to avoid re-adding existing entries.
-        NoWriteBarrierField<int> debuggerScopeIndex;
 
         FunctionBody(ScriptContext* scriptContext, const wchar_t* displayName, uint displayNameLength, uint displayShortNameOffset, uint nestedCount, Utf8SourceInfo* sourceInfo,
             uint uFunctionNumber, uint uScriptId, Js::LocalFunctionId functionId, Js::PropertyRecordList* propRecordList, Attributes attributes
@@ -1983,10 +2044,6 @@ namespace Js
 #if ENABLE_DEBUG_CONFIG_OPTIONS
         void DumpRegStats(FunctionBody *funcBody);
 #endif
-
-        // Gets the next index for tracking debugger scopes (increments the internal counter as well).
-        int GetNextDebuggerScopeIndex();
-
 
     public:
         FunctionBody(ByteCodeCache* cache, Utf8SourceInfo* sourceInfo, ScriptContext* scriptContext):
@@ -2031,31 +2088,54 @@ namespace Js
                 this->byteCodeCache = byteCodeCache;
             }
         }
-        void SetSerializationIndex(int index) { Assert(serializationIndex == -1 && index != -1); serializationIndex = index; }
+        void SetSerializationIndex(int index);
         const int GetSerializationIndex() const;
-        uint GetByteCodeCount() const { return m_byteCodeCount; }
-        uint GetByteCodeWithoutLDACount() const { return m_byteCodeWithoutLDACount; }
-        uint GetByteCodeInLoopCount() const { return m_byteCodeInLoopCount; }
+        uint GetByteCodeCount() const { return GetCountField(CounterFields::ByteCodeCount); }
+        void SetByteCodeCount(uint count) { SetCountField(CounterFields::ByteCodeCount, count); }
+        uint GetByteCodeWithoutLDACount() const { return GetCountField(CounterFields::ByteCodeWithoutLDACount); }
+        void SetByteCodeWithoutLDACount(uint count) { SetCountField(CounterFields::ByteCodeWithoutLDACount, count); }
+        uint GetByteCodeInLoopCount() const { return GetCountField(CounterFields::ByteCodeInLoopCount); }
+        void SetByteCodeInLoopCount(uint count) { SetCountField(CounterFields::ByteCodeInLoopCount, count); }
         uint16 GetEnvDepth() const { return m_envDepth; }
         void SetEnvDepth(uint16 depth) { m_envDepth = depth; }
-        RegSlot GetEnvReg() const { return envRegister; }
-        void SetEnvReg(RegSlot reg) { Assert(envRegister == Constants::NoRegister); envRegister = this->MapRegSlot(reg); }
-        RegSlot GetThisRegForEventHandler() const { return thisRegisterForEventHandler; }
-        void SetThisRegForEventHandler(RegSlot reg) { Assert(thisRegisterForEventHandler == Constants::NoRegister); thisRegisterForEventHandler = this->MapRegSlot(reg); }
+
+        void SetEnvRegister(RegSlot reg);
+        void MapAndSetEnvRegister(RegSlot reg);
+        RegSlot GetEnvRegister() const;
+        void SetThisRegisterForEventHandler(RegSlot reg);
+        void MapAndSetThisRegisterForEventHandler(RegSlot reg);
+        RegSlot GetThisRegisterForEventHandler() const;
+        void SetLocalClosureRegister(RegSlot reg);
+        void MapAndSetLocalClosureRegister(RegSlot reg);
+        RegSlot GetLocalClosureRegister() const;
+
+        void SetLocalFrameDisplayRegister(RegSlot reg);
+        void MapAndSetLocalFrameDisplayRegister(RegSlot reg);
+        RegSlot GetLocalFrameDisplayRegister() const;
+        void SetFirstInnerScopeRegister(RegSlot reg);
+        void MapAndSetFirstInnerScopeRegister(RegSlot reg);
+        RegSlot GetFirstInnerScopeRegister() const;
+        void SetFuncExprScopeRegister(RegSlot reg);
+        void MapAndSetFuncExprScopeRegister(RegSlot reg);
+        RegSlot GetFuncExprScopeRegister() const;
+
         bool HasScopeObject() const { return hasScopeObject; }
         void SetHasScopeObject(bool has) { hasScopeObject = has; }
-        void SetLocalClosureReg(RegSlot reg) { Assert(localClosureRegister == Constants::NoRegister); localClosureRegister = this->MapRegSlot(reg); }
-        RegSlot GetLocalClosureReg() const { return localClosureRegister; }
-        void SetLocalFrameDisplayReg(RegSlot reg) { Assert(localFrameDisplayRegister == Constants::NoRegister); localFrameDisplayRegister = this->MapRegSlot(reg); }
-        RegSlot GetLocalFrameDisplayReg() const { return localFrameDisplayRegister; /*localClosureRegister == Constants::NoRegister ? Constants::NoRegister : localClosureRegister + 1;*/ }
-        RegSlot FirstInnerScopeReg() const { Assert(firstInnerScopeRegister != Constants::NoRegister); return firstInnerScopeRegister; }
-        void SetFirstInnerScopeReg(RegSlot reg) { Assert(reg != Constants::NoRegister); firstInnerScopeRegister = this->MapRegSlot(reg); }
-        RegSlot GetFuncExprScopeReg() const { return funcExprScopeRegister; }
-        void SetFuncExprScopeReg(RegSlot reg) { Assert(reg != Constants::NoRegister); funcExprScopeRegister = this->MapRegSlot(reg); }
-        uint GetInnerScopeCount() const { return innerScopeCount; }
-        void SetInnerScopeCount(uint count) { innerScopeCount = count; }
+        uint GetInnerScopeCount() const { return GetCountField(CounterFields::InnerScopeCount); }
+        void SetInnerScopeCount(uint count) { SetCountField(CounterFields::InnerScopeCount, count); }
         bool HasCachedScopePropIds() const { return hasCachedScopePropIds; }
         void SetHasCachedScopePropIds(bool has) { hasCachedScopePropIds = has; }
+
+        uint32 GetInterpretedCount() const { return interpretedCount; }
+        uint32 SetInterpretedCount(uint32 val) { return interpretedCount = val; }
+        uint32 IncreaseInterpretedCount() { return interpretedCount++; }
+
+        uint32 GetLoopInterpreterLimit() const { return loopInterpreterLimit; }
+        uint32 SetLoopInterpreterLimit(uint32 val) { return loopInterpreterLimit = val; }
+
+        // Gets the next index for tracking debugger scopes (increments the internal counter as well).
+        uint32 GetNextDebuggerScopeIndex() { return debuggerScopeIndex++; }
+        void SetDebuggerScopeIndex(uint32 index) { debuggerScopeIndex = index; }
 
         size_t GetLoopBodyName(uint loopNumber, _Out_writes_opt_z_(sizeInChars) WCHAR* displayName, _In_ size_t sizeInChars);
 
@@ -2426,9 +2506,10 @@ namespace Js
         bool GetIsFuncRegistered() { return m_isFuncRegistered; }
         void SetIsFuncRegistered(bool isRegistered) { m_isFuncRegistered = isRegistered; }
 
-        bool GetHasLoops() const { return loopCount != 0; }
-        uint IncrLoopCount() { return this->loopCount++; }
-        uint GetLoopCount() const { return this->loopCount; }
+        bool GetHasLoops() const { return this->GetLoopCount() != 0; }
+        uint IncrLoopCount() { return this->IncreaseCountField(CounterFields::LoopCount); }
+        uint GetLoopCount() const { return this->GetCountField(CounterFields::LoopCount); }
+        uint SetLoopCount(uint count) { return this->SetCountField(CounterFields::LoopCount, count); }
 
         bool AllocProfiledDivOrRem(ProfileId* profileId) { if (this->profiledDivOrRemCount != Constants::NoProfileId) { *profileId = this->profiledDivOrRemCount++; return true; } return false; }
         ProfileId GetProfiledDivOrRemCount() { return this->profiledDivOrRemCount; }
@@ -2604,10 +2685,12 @@ namespace Js
         void SetFrameHeight(EntryPointInfo* entryPointInfo, uint32 frameHeight);
 
         RegSlot GetLocalsCount();
-        RegSlot GetConstantCount() const { return m_constCount; }
+        RegSlot GetConstantCount() const { return this->GetCountField(CounterFields::ConstantCount); }
+        void CheckAndSetConstantCount(RegSlot cNewConstants);
         void SetConstantCount(RegSlot cNewConstants);
         RegSlot GetVarCount();
         void SetVarCount(RegSlot cNewVars);
+        void CheckAndSetVarCount(RegSlot cNewVars);
         RegSlot MapRegSlot(RegSlot reg)
         {
             if (this->RegIsConst(reg))
@@ -2630,10 +2713,14 @@ namespace Js
         bool IsNonTempLocalVar(uint32 varIndex);
         bool GetSlotOffset(RegSlot slotId, int32 * slotOffset, bool allowTemp = false);
 
-        RegSlot GetOutParamsDepth();
-        void SetOutParamDepth(RegSlot cOutParamsDepth);
+        RegSlot GetOutParamMaxDepth();
+        void SetOutParamMaxDepth(RegSlot cOutParamsDepth);
+        void CheckAndSetOutParamMaxDepth(RegSlot cOutParamsDepth);
 
         RegSlot GetYieldRegister();
+
+        RegSlot GetFirstTmpRegister() const;
+        void SetFirstTmpRegister(RegSlot reg);
 
         RegSlot GetFirstTmpReg();
         void SetFirstTmpReg(RegSlot firstTmpReg);
@@ -2672,12 +2759,33 @@ namespace Js
 
         static bool ShouldShareInlineCaches() { return CONFIG_FLAG(ShareInlineCaches); }
 
-        uint GetInlineCacheCount() const { return inlineCacheCount; }
-        uint GetRootObjectLoadInlineCacheStart() const { return rootObjectLoadInlineCacheStart; }
-        uint GetRootObjectLoadMethodInlineCacheStart() const { return rootObjectLoadMethodInlineCacheStart; }
-        uint GetRootObjectStoreInlineCacheStart() const { return rootObjectStoreInlineCacheStart; }
-        uint GetIsInstInlineCacheCount() const { return isInstInlineCacheCount; }
-        uint GetReferencedPropertyIdCount() const { return referencedPropertyIdCount; }
+        uint GetInlineCacheCount() const { return GetCountField(CounterFields::InlineCacheCount); }
+        void SetInlineCacheCount(uint count) { SetCountField(CounterFields::InlineCacheCount, count); }
+
+        uint GetRootObjectLoadInlineCacheStart() const { return GetCountField(CounterFields::RootObjectLoadInlineCacheStart); }
+        void SetRootObjectLoadInlineCacheStart(uint count) { SetCountField(CounterFields::RootObjectLoadInlineCacheStart, count); }
+
+        uint GetRootObjectLoadMethodInlineCacheStart() const { return GetCountField(CounterFields::RootObjectLoadMethodInlineCacheStart); }
+        void SetRootObjectLoadMethodInlineCacheStart(uint count) { SetCountField(CounterFields::RootObjectLoadMethodInlineCacheStart, count); }
+
+        uint GetRootObjectStoreInlineCacheStart() const { return GetCountField(CounterFields::RootObjectStoreInlineCacheStart); }
+        void SetRootObjectStoreInlineCacheStart(uint count) { SetCountField(CounterFields::RootObjectStoreInlineCacheStart, count); }
+
+        uint GetIsInstInlineCacheCount() const { return GetCountField(CounterFields::IsInstInlineCacheCount); }
+        void SetIsInstInlineCacheCount(uint count) { SetCountField(CounterFields::IsInstInlineCacheCount, count); }
+
+        uint GetReferencedPropertyIdCount() const { return GetCountField(CounterFields::ReferencedPropertyIdCount); }
+        void SetReferencedPropertyIdCount(uint count) { SetCountField(CounterFields::ReferencedPropertyIdCount, count); }
+
+        uint GetObjLiteralCount() const { return GetCountField(CounterFields::ObjLiteralCount); }
+        void SetObjLiteralCount(uint count) { SetCountField(CounterFields::ObjLiteralCount, count); }
+        uint IncObjLiteralCount() { return IncreaseCountField(CounterFields::ObjLiteralCount); }
+
+        uint GetLiteralRegexCount() const { return GetCountField(CounterFields::LiteralRegexCount); }
+        void SetLiteralRegexCount(uint count) { SetCountField(CounterFields::LiteralRegexCount, count); }
+        uint IncLiteralRegexCount() { return IncreaseCountField(CounterFields::LiteralRegexCount); }
+
+
         void AllocateInlineCache();
         InlineCache * GetInlineCache(uint index);
         bool CanFunctionObjectHaveInlineCaches();
@@ -2686,7 +2794,6 @@ namespace Js
 #if DBG
         byte* GetInlineCacheTypes();
 #endif
-        InlineCache * GetRootObjectInlineCache(uint index);
         IsInstInlineCache * GetIsInstInlineCache(uint index);
         PolymorphicInlineCache * GetPolymorphicInlineCache(uint index);
         PolymorphicInlineCache * CreateNewPolymorphicInlineCache(uint index, PropertyId propertyId, InlineCache * inlineCache);
@@ -2735,7 +2842,6 @@ namespace Js
         DynamicType ** GetObjectLiteralTypeRef(uint index);
         DynamicType ** GetObjectLiteralTypeRefWithLock(uint index);
         uint NewLiteralRegex();
-        uint GetLiteralRegexCount() const;
         void AllocateLiteralRegexArray();
         UnifiedRegex::RegexPattern **GetLiteralRegexes() const { return static_cast<UnifiedRegex::RegexPattern **>(this->GetAuxPtr(AuxPointerType::LiteralRegexes)); }
         UnifiedRegex::RegexPattern **GetLiteralRegexesWithLock() const { return static_cast<UnifiedRegex::RegexPattern **>(this->GetAuxPtrWithLock(AuxPointerType::LiteralRegexes)); }
@@ -2778,7 +2884,7 @@ namespace Js
         const FunctionCodeGenRuntimeData *GetLdFldInlineeCodeGenRuntimeData(const InlineCacheIndex inlineCacheIndex) const;
         FunctionCodeGenRuntimeData *EnsureLdFldInlineeCodeGenRuntimeData(
             Recycler *const recycler,
-            __in_range(0, this->inlineCacheCount - 1) const InlineCacheIndex inlineCacheIndex,
+            const InlineCacheIndex inlineCacheIndex,
             FunctionBody *const inlinee);
 
         void LoadDynamicProfileInfo();
@@ -2791,6 +2897,7 @@ namespace Js
         DynamicProfileInfo * AllocateDynamicProfile();
         BYTE GetSavedInlinerVersion() const;
         uint32 GetSavedPolymorphicCacheState() const;
+        void SetSavedPolymorphicCacheState(uint32 state);
         ImplicitCallFlags GetSavedImplicitCallsFlags() const;
         bool HasNonBuiltInCallee();
 
@@ -2891,6 +2998,7 @@ namespace Js
             Js::LoopHeader* loopHeaderArray = this->GetLoopHeaderArray();
             if(loopHeaderArray)
             {
+                uint loopCount = this->GetLoopCount();
                 for(uint i = 0; i < loopCount; i++)
                 {
                     fn(i , &loopHeaderArray[i]);
@@ -2903,6 +3011,7 @@ namespace Js
             Js::LoopHeader* loopHeaderArray = this->GetLoopHeaderArrayWithLock();
             if (loopHeaderArray)
             {
+                uint loopCount = this->GetLoopCount();
                 for (uint i = 0; i < loopCount; i++)
                 {
                     fn(i, &loopHeaderArray[i]);

--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -600,7 +600,7 @@ namespace Js
                 // because otherwise ETW events might not get fired if a GC doesn't happen
                 // and the thread context isn't shut down cleanly (process detach case)
                 this->MapFunction([this](Js::FunctionBody* functionBody) {
-                    Assert(functionBody->GetScriptContext() == this);
+                    Assert(functionBody->GetScriptContext() == nullptr || functionBody->GetScriptContext() == this);
                     functionBody->Cleanup(/* isScriptContextClosing */ true);
                 });
             }
@@ -4438,7 +4438,7 @@ void ScriptContext::RegisterPrototypeChainEnsuredToHaveOnlyWritableDataPropertie
                 newDynamicProfileInfo = functionBody->AllocateDynamicProfile();
                 *dynamicProfileInfo = newDynamicProfileInfo;
             }
-            Assert(functionBody->interpretedCount == 0);
+            Assert(functionBody->GetInterpretedCount() == 0);
 #if DBG_DUMP || defined(DYNAMIC_PROFILE_STORAGE) || defined(RUNTIME_DATA_COLLECTION)
             if (profileInfoList)
             {
@@ -4725,7 +4725,7 @@ void ScriptContext::RegisterPrototypeChainEnsuredToHaveOnlyWritableDataPropertie
                     bool isNativeCode = false;
 
                     // Filtering interpreted count lowers a lot of noise
-                    if (body->interpretedCount > 1 || Js::Configuration::Global.flags.IsEnabled(Js::ForceFlag))
+                    if (body->GetInterpretedCount() > 1 || Js::Configuration::Global.flags.IsEnabled(Js::ForceFlag))
                     {
                         body->MapEntryPoints([&](uint entryPointIndex, FunctionEntryPointInfo* entryPoint)
                         {
@@ -4736,7 +4736,7 @@ void ScriptContext::RegisterPrototypeChainEnsuredToHaveOnlyWritableDataPropertie
                                 body->GetExternalDisplayName(),
                                 body->GetDebugNumberSet(debugStringBuffer),
                                 rejit,
-                                body->interpretedCount,
+                                body->GetInterpretedCount(),
                                 body->GetByteCodeInLoopCount(),
                                 body->GetByteCodeCount(),
                                 entryPoint->IsNativeCode() ? L"Jitted" : L"Interpreted",
@@ -4744,7 +4744,7 @@ void ScriptContext::RegisterPrototypeChainEnsuredToHaveOnlyWritableDataPropertie
                                 entryPoint->IsNativeCode() ? entryPoint->GetCodeSize() : 0);
                         });
                     }
-                    if (body->interpretedCount == 0)
+                    if (body->GetInterpretedCount() == 0)
                     {
                         zeroInterpretedFunctions++;
                         if (body->GetByteCodeCount() > 0)
@@ -4752,7 +4752,7 @@ void ScriptContext::RegisterPrototypeChainEnsuredToHaveOnlyWritableDataPropertie
                             nonZeroBytecodeFunctions++;
                         }
                     }
-                    else if (body->interpretedCount == 1)
+                    else if (body->GetInterpretedCount() == 1)
                     {
                         oneInterpretedFunctions++;
                     }
@@ -4760,7 +4760,7 @@ void ScriptContext::RegisterPrototypeChainEnsuredToHaveOnlyWritableDataPropertie
 
                     // Generate a histogram using interpreted counts.
                     uint bucket;
-                    uint intrpCount = body->interpretedCount;
+                    uint intrpCount = body->GetInterpretedCount();
                     if (intrpCount < 100)
                     {
                         bucket = intrpCount / bucketSize1;

--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -1676,21 +1676,21 @@ void ByteCodeGenerator::FinalizeRegisters(FuncInfo * funcInfo, Js::FunctionBody 
 
     // Set the function body's constant count before emitting anything so that the byte code writer
     // can distinguish constants from variables.
-    byteCodeFunction->SetConstantCount(funcInfo->constRegsCount);
+    byteCodeFunction->CheckAndSetConstantCount(funcInfo->constRegsCount);
 
     if (funcInfo->frameDisplayRegister != Js::Constants::NoRegister)
     {
-        byteCodeFunction->SetLocalFrameDisplayReg(funcInfo->frameDisplayRegister);
+        byteCodeFunction->MapAndSetLocalFrameDisplayRegister(funcInfo->frameDisplayRegister);
     }
 
     if (funcInfo->frameObjRegister != Js::Constants::NoRegister)
     {
-        byteCodeFunction->SetLocalClosureReg(funcInfo->frameObjRegister);
+        byteCodeFunction->MapAndSetLocalClosureRegister(funcInfo->frameObjRegister);
         byteCodeFunction->SetHasScopeObject(true);
     }
     else if (funcInfo->frameSlotsRegister != Js::Constants::NoRegister)
     {
-        byteCodeFunction->SetLocalClosureReg(funcInfo->frameSlotsRegister);
+        byteCodeFunction->MapAndSetLocalClosureRegister(funcInfo->frameSlotsRegister);
     }
 
     if (this->IsInDebugMode())
@@ -1863,7 +1863,7 @@ void ByteCodeGenerator::LoadAllConstants(FuncInfo *funcInfo)
 
     if (funcInfo->funcExprScope && funcInfo->funcExprScope->GetIsObject())
     {
-        byteCodeFunction->SetFuncExprScopeReg(funcInfo->funcExprScope->GetLocation());
+        byteCodeFunction->MapAndSetFuncExprScopeRegister(funcInfo->funcExprScope->GetLocation());
         byteCodeFunction->SetEnvDepth((uint16)-1);
     }
 
@@ -1871,10 +1871,10 @@ void ByteCodeGenerator::LoadAllConstants(FuncInfo *funcInfo)
 
     if (funcInfo->NeedEnvRegister())
     {
-        byteCodeFunction->SetEnvReg(funcInfo->GetEnvRegister());
+        byteCodeFunction->MapAndSetEnvRegister(funcInfo->GetEnvRegister());
         if (funcInfo->GetIsEventHandler())
         {
-            byteCodeFunction->SetThisRegForEventHandler(funcInfo->thisPointerRegister);
+            byteCodeFunction->MapAndSetThisRegisterForEventHandler(funcInfo->thisPointerRegister);
             // The environment is the namespace hierarchy starting with "this".
             Assert(!funcInfo->RegIsConst(funcInfo->GetEnvRegister()));
             thisLoadedFromParams = true;
@@ -3231,8 +3231,8 @@ void ByteCodeGenerator::EmitOneFunction(ParseNode *pnode)
         Assert(funcInfo->curTmpReg == firstTmpReg);
         Assert(byteCodeFunction->GetFirstTmpReg() == firstTmpReg + byteCodeFunction->GetConstantCount());
 
-        byteCodeFunction->SetVarCount(funcInfo->varRegsCount);
-        byteCodeFunction->SetOutParamDepth(funcInfo->outArgsMaxDepth);
+        byteCodeFunction->CheckAndSetVarCount(funcInfo->varRegsCount);
+        byteCodeFunction->CheckAndSetOutParamMaxDepth(funcInfo->outArgsMaxDepth);
 
         // Do a uint32 add just to verify that we haven't overflowed the reg slot type.
         UInt32Math::Add(funcInfo->varRegsCount, funcInfo->constRegsCount);

--- a/lib/Runtime/ByteCode/FuncInfo.cpp
+++ b/lib/Runtime/ByteCode/FuncInfo.cpp
@@ -389,7 +389,7 @@ Js::RegSlot FuncInfo::FirstInnerScopeReg() const
 {
     // FunctionBody stores this as a mapped reg. Callers of this function want the pre-mapped value.
 
-    Js::RegSlot reg = this->GetParsedFunctionBody()->FirstInnerScopeReg();
+    Js::RegSlot reg = this->GetParsedFunctionBody()->GetFirstInnerScopeRegister();
     Assert(reg != Js::Constants::NoRegister);
 
     return reg - this->constRegsCount;
@@ -398,7 +398,7 @@ Js::RegSlot FuncInfo::FirstInnerScopeReg() const
 void FuncInfo::SetFirstInnerScopeReg(Js::RegSlot reg)
 {
     // Just forward to the FunctionBody.
-    this->GetParsedFunctionBody()->SetFirstInnerScopeReg(reg);
+    this->GetParsedFunctionBody()->MapAndSetFirstInnerScopeRegister(reg);
 }
 
 void FuncInfo::AddCapturedSym(Symbol *sym)

--- a/lib/Runtime/Language/AsmJsByteCodeGenerator.cpp
+++ b/lib/Runtime/Language/AsmJsByteCodeGenerator.cpp
@@ -195,7 +195,7 @@ namespace Js
             nbConst += (int)((mFunction->GetRegisterSpace<AsmJsSIMDValue>().GetConstCount() + 1) * SIMD_SLOTS_SPACE); // Return register is already reserved in the register space.
         }
 
-        byteCodeFunction->SetConstantCount(nbConst);
+        byteCodeFunction->CheckAndSetConstantCount(nbConst);
 
         // add 3 for each of I0, F0, and D0
         RegSlot regCount = mInfo->RegCount() + 3 + AsmJsFunctionMemory::RequiredVarConstants;

--- a/lib/Runtime/Language/AsmJsModule.cpp
+++ b/lib/Runtime/Language/AsmJsModule.cpp
@@ -98,8 +98,8 @@ namespace Js
                 Assert(asmInfo->GetSimdByteOffset() % sizeof(AsmJsSIMDValue) == 0);
             }
 
-            functionBody->SetOutParamDepth(func->GetMaxArgOutDepth());
-            functionBody->SetVarCount(varCount);
+            functionBody->CheckAndSetOutParamMaxDepth(func->GetMaxArgOutDepth());
+            functionBody->CheckAndSetVarCount(varCount);
             // should be set in EmitOneFunction
             Assert(functionBody->GetIsAsmjsMode());
             Assert(functionBody->GetIsAsmJsFunction());
@@ -168,9 +168,9 @@ namespace Js
 
         functionBody->SetInParamsCount(4); // Always set 4 inParams so the memory space is the same (globalEnv,stdlib,foreign,buffer)
         functionBody->SetReportedInParamsCount(4);
-        functionBody->SetConstantCount(2); // Return register + Root
+        functionBody->CheckAndSetConstantCount(2); // Return register + Root
         functionBody->CreateConstantTable();
-        functionBody->SetVarCount(varCount);
+        functionBody->CheckAndSetVarCount(varCount);
         functionBody->SetIsAsmjsMode(true);
         functionBody->NewObjectLiteral(); // allocate one object literal for the export object
 

--- a/lib/Runtime/Language/DynamicProfileInfo.cpp
+++ b/lib/Runtime/Language/DynamicProfileInfo.cpp
@@ -1458,7 +1458,7 @@ namespace Js
         functionBody->DumpFunctionId(true);
         Js::ArgSlot paramcount = functionBody->GetProfiledInParamsCount();
         Output::Print(L": %-20s Interpreted:%6d, Param:%2d, ImpCall:%s, Callsite:%3d, ReturnType:%3d, LdElem:%3d, StElem:%3d, Fld%3d\n",
-            functionBody->GetDisplayName(), functionBody->interpretedCount, paramcount, DynamicProfileInfo::GetImplicitCallFlagsString(this->GetImplicitCallFlags()),
+            functionBody->GetDisplayName(), functionBody->GetInterpretedCount(), paramcount, DynamicProfileInfo::GetImplicitCallFlagsString(this->GetImplicitCallFlags()),
             functionBody->GetProfiledCallSiteCount(),
             functionBody->GetProfiledReturnTypeCount(),
             functionBody->GetProfiledLdElemCount(),
@@ -1645,7 +1645,7 @@ namespace Js
                     }
                 }
 
-                if (hasHotLoop || info->functionBody->interpretedCount >= 10)
+                if (hasHotLoop || info->functionBody->GetInterpretedCount() >= 10)
                 {
                     functionSaved++;
                     loopSaved += info->functionBody->GetLoopCount();
@@ -2123,7 +2123,7 @@ namespace Js
             WriteData((byte)1, file);
             WriteData(info->functionBody, file);
             WriteData(info->functionBody->GetDisplayName(), file);
-            WriteData(info->functionBody->interpretedCount, file);
+            WriteData(info->functionBody->GetInterpretedCount(), file);
             uint loopCount = info->functionBody->GetLoopCount();
             WriteData(loopCount, file);
             for (uint i = 0; i < loopCount; i++)

--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -946,7 +946,7 @@ namespace Js
 
     Var InterpreterStackFrame::InnerScopeFromRegSlot(RegSlot reg) const
     {
-        return InnerScopeFromIndex(reg - m_functionBody->FirstInnerScopeReg());
+        return InnerScopeFromIndex(reg - m_functionBody->GetFirstInnerScopeRegister());
     }
 
     Var InterpreterStackFrame::InnerScopeFromIndex(uint32 index) const
@@ -1010,7 +1010,7 @@ namespace Js
         }
 #endif
 
-        this->varAllocCount = k_stackFrameVarCount + localCount + this->executeFunction->GetOutParamsDepth() + extraVarCount + this->executeFunction->GetInnerScopeCount();
+        this->varAllocCount = k_stackFrameVarCount + localCount + this->executeFunction->GetOutParamMaxDepth() + extraVarCount + this->executeFunction->GetInnerScopeCount();
 
         if (this->executeFunction->DoStackNestedFunc() && this->executeFunction->GetNestedCount() != 0)
         {
@@ -1140,7 +1140,7 @@ namespace Js
         // the savedLoopImplicitCallFlags is allocated at the end of the out param array
         newInstance->savedLoopImplicitCallFlags = nullptr;
 #endif
-        char * nextAllocBytes = (char *)(newInstance->m_outParams + this->executeFunction->GetOutParamsDepth());
+        char * nextAllocBytes = (char *)(newInstance->m_outParams + this->executeFunction->GetOutParamMaxDepth());
 
         if (this->executeFunction->GetInnerScopeCount())
         {
@@ -1176,7 +1176,7 @@ namespace Js
         if (Js::DynamicProfileInfo::EnableImplicitCallFlags(this->executeFunction))
         {
             /*
-            __analysis_assume(varAllocCount == (k_stackFrameVarCount + localCount + executeFunction->GetOutParamsDepth()
+            __analysis_assume(varAllocCount == (k_stackFrameVarCount + localCount + executeFunction->GetOutParamMaxDepth()
                                                 + ((sizeof(ImplicitCallFlags) * executeFunction->GetLoopCount() + sizeof(Var) - 1) / sizeof(Var))));
            */
             newInstance->savedLoopImplicitCallFlags = (ImplicitCallFlags *)nextAllocBytes;
@@ -1221,12 +1221,12 @@ namespace Js
         // That way we avoid trying to box these structures before they've been initialized in the byte code.
         if (this->executeFunction->DoStackFrameDisplay())
         {
-            newInstance->SetNonVarReg(executeFunction->GetLocalFrameDisplayReg(), nullptr);
+            newInstance->SetNonVarReg(executeFunction->GetLocalFrameDisplayRegister(), nullptr);
         }
         if (this->executeFunction->DoStackScopeSlots())
         {
             Assert(!executeFunction->HasScopeObject());
-            newInstance->SetNonVarReg(executeFunction->GetLocalClosureReg(), nullptr);
+            newInstance->SetNonVarReg(executeFunction->GetLocalClosureRegister(), nullptr);
         }
 
         Var *prestDest = &newInstance->m_localSlots[this->executeFunction->GetConstantCount()];
@@ -1259,10 +1259,10 @@ namespace Js
             InitializeRestParam(newInstance, prestDest);
         }
 
-        Js::RegSlot envReg = executeFunction->GetEnvReg();
+        Js::RegSlot envReg = executeFunction->GetEnvRegister();
         if (envReg != Js::Constants::NoRegister && envReg < executeFunction->GetConstantCount())
         {
-            Assert(this->executeFunction->GetThisRegForEventHandler() == Constants::NoRegister);
+            Assert(this->executeFunction->GetThisRegisterForEventHandler() == Constants::NoRegister);
             // The correct FD (possibly distinct from the one on the function) is passed in the constant table.
             this->function->SetEnvironment((Js::FrameDisplay*)newInstance->GetNonVarReg(envReg));
         }
@@ -1362,7 +1362,7 @@ namespace Js
         FunctionBody *executeFunction = this->function->GetFunctionBody();
         Var environment;
 
-        RegSlot thisRegForEventHandler = executeFunction->GetThisRegForEventHandler();
+        RegSlot thisRegForEventHandler = executeFunction->GetThisRegisterForEventHandler();
         if (thisRegForEventHandler != Constants::NoRegister)
         {
             Var varThis = OP_ArgIn0();
@@ -1375,13 +1375,13 @@ namespace Js
             environment = this->LdEnv();
         }
 
-        RegSlot closureReg = executeFunction->GetLocalClosureReg();
+        RegSlot closureReg = executeFunction->GetLocalClosureRegister();
         if (closureReg != Js::Constants::NoRegister)
         {
             Assert(closureReg >= executeFunction->GetConstantCount());
             if (executeFunction->HasScopeObject())
             {
-                Js::RegSlot funcExprScopeReg = executeFunction->GetFuncExprScopeReg();
+                Js::RegSlot funcExprScopeReg = executeFunction->GetFuncExprScopeRegister();
                 if (funcExprScopeReg != Constants::NoRegister)
                 {
                     // t0 = NewPseudoScope
@@ -1401,7 +1401,7 @@ namespace Js
             this->SetNonVarReg(closureReg, nullptr);
         }
 
-        Js::RegSlot frameDisplayReg = executeFunction->GetLocalFrameDisplayReg();
+        Js::RegSlot frameDisplayReg = executeFunction->GetLocalFrameDisplayRegister();
         if (frameDisplayReg != Js::Constants::NoRegister && closureReg != Js::Constants::NoRegister)
         {
             Assert(frameDisplayReg >= executeFunction->GetConstantCount());
@@ -1701,7 +1701,7 @@ namespace Js
         }
 #endif
 
-        if (executeFunction->interpretedCount == 0)
+        if (executeFunction->GetInterpretedCount() == 0)
         {
             executeFunction->TraceInterpreterExecutionMode();
         }
@@ -1746,10 +1746,10 @@ namespace Js
         const bool doProfile = false;
 #endif
 
-        executeFunction->interpretedCount++;
+        executeFunction->IncreaseInterpretedCount();
 #ifdef BGJIT_STATS
         functionScriptContext->interpretedCount++;
-        functionScriptContext->maxFuncInterpret = max(functionScriptContext->maxFuncInterpret, executeFunction->interpretedCount);
+        functionScriptContext->maxFuncInterpret = max(functionScriptContext->maxFuncInterpret, executeFunction->GetInterpretedCount());
 #endif
 
         AssertMsg(!executeFunction->IsDeferredParseFunction(),
@@ -2135,7 +2135,7 @@ namespace Js
         m_outParams = (Var*)*m_outSp;
 
         AssertMsg(m_localSlots + this->m_functionBody->GetLocalsCount() <= m_outSp &&
-                  m_outSp < (m_localSlots + this->m_functionBody->GetLocalsCount() + this->m_functionBody->GetOutParamsDepth()),
+                  m_outSp < (m_localSlots + this->m_functionBody->GetLocalsCount() + this->m_functionBody->GetOutParamMaxDepth()),
                   "out args Stack pointer not in range after Pop");
     }
 
@@ -3406,7 +3406,7 @@ namespace Js
         m_outSp += outParamCount;
 
         AssertMsg(m_localSlots + this->m_functionBody->GetLocalsCount() < m_outSp &&
-            m_outSp <= (m_localSlots + this->m_functionBody->GetLocalsCount() + this->m_functionBody->GetOutParamsDepth()),
+            m_outSp <= (m_localSlots + this->m_functionBody->GetLocalsCount() + this->m_functionBody->GetOutParamMaxDepth()),
             "out args Stack pointer not in range after Push");
 
     }
@@ -5652,14 +5652,14 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
 
             entryPointInfo->EnsureIsReadyToCall();
 
-            RegSlot envReg = this->m_functionBody->GetEnvReg();
+            RegSlot envReg = this->m_functionBody->GetEnvRegister();
             if (envReg != Constants::NoRegister)
             {
                 this->SetNonVarReg(envReg, this->LdEnv());
             }
 
-            RegSlot localClosureReg = this->m_functionBody->GetLocalClosureReg();
-            RegSlot localFrameDisplayReg = this->m_functionBody->GetLocalFrameDisplayReg();
+            RegSlot localClosureReg = this->m_functionBody->GetLocalClosureRegister();
+            RegSlot localFrameDisplayReg = this->m_functionBody->GetLocalFrameDisplayRegister();
 
             if (entryPointInfo->HasJittedStackClosure())
             {
@@ -5696,7 +5696,7 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
             {
                 // As with the function-level scope, transfer the inner scopes from the interpreter's side storage
                 // to their dedicated register slots.
-                SetNonVarReg(this->m_functionBody->FirstInnerScopeReg() + i, InnerScopeFromIndex(i));
+                SetNonVarReg(this->m_functionBody->GetFirstInnerScopeRegister() + i, InnerScopeFromIndex(i));
             }
 
             uint newOffset = 0;
@@ -5731,7 +5731,7 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
                 // Get the (possibly updated) scopes from their registers and put them back in side storage.
                 // (Getting the updated values may not be necessary, actually, but it can't hurt.)
                 // Then null out the registers.
-                RegSlot reg = this->m_functionBody->FirstInnerScopeReg() + i;
+                RegSlot reg = this->m_functionBody->GetFirstInnerScopeRegister() + i;
                 SetInnerScopeFromIndex(i, GetNonVarReg(reg));
                 SetNonVarReg(reg, nullptr);
             }
@@ -6763,11 +6763,11 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
         bool strict = this->m_functionBody->GetIsStrictMode();
 
         Var argEnv = nullptr;
-        if (innerFD && this->m_functionBody->GetLocalFrameDisplayReg() != Constants::NoRegister)
+        if (innerFD && this->m_functionBody->GetLocalFrameDisplayRegister() != Constants::NoRegister)
         {
             argEnv = this->GetLocalFrameDisplay();
         }
-        if (argEnv == nullptr && this->m_functionBody->GetEnvReg() != Constants::NoRegister)
+        if (argEnv == nullptr && this->m_functionBody->GetEnvRegister() != Constants::NoRegister)
         {
             argEnv = this->LdEnv();
         }
@@ -7481,7 +7481,7 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
     void InterpreterStackFrame::OP_ArgOut_Env(const unaligned T * playout)
     {
         Var argEnv;
-        if (this->m_functionBody->GetLocalFrameDisplayReg() != Constants::NoRegister)
+        if (this->m_functionBody->GetLocalFrameDisplayRegister() != Constants::NoRegister)
         {
             argEnv = this->GetLocalFrameDisplay();
         }

--- a/lib/Runtime/Library/ScriptFunction.cpp
+++ b/lib/Runtime/Library/ScriptFunction.cpp
@@ -594,7 +594,7 @@ namespace Js
                     {
                         memset(this->m_inlineCaches[i], 0, sizeof(InlineCache));
                     }
-                    else if(!scriptContext->IsClosed())
+                    else if(scriptContext != nullptr && !scriptContext->IsClosed())
                     {
                         if (inlineCache->RemoveFromInvalidationList())
                         {

--- a/lib/Runtime/Library/ScriptFunction.cpp
+++ b/lib/Runtime/Library/ScriptFunction.cpp
@@ -594,7 +594,7 @@ namespace Js
                     {
                         memset(this->m_inlineCaches[i], 0, sizeof(InlineCache));
                     }
-                    else if(scriptContext != nullptr && !scriptContext->IsClosed())
+                    else if(!scriptContext->IsClosed())
                     {
                         if (inlineCache->RemoveFromInvalidationList())
                         {

--- a/lib/Runtime/SerializableFunctionFields.h
+++ b/lib/Runtime/SerializableFunctionFields.h
@@ -12,6 +12,10 @@
 #define DECLARE_SERIALIZABLE_FIELD(type, name, serializableType) type name
 #endif
 
+#ifndef DECLARE_SERIALIZABLE_ACCESSOR_FIELD
+#define DECLARE_SERIALIZABLE_ACCESSOR_FIELD(type, name, serializableType)
+#endif
+
 
 #ifdef CURRENT_ACCESS_MODIFIER
 #define PROTECTED_FIELDS protected:
@@ -41,13 +45,13 @@ CURRENT_ACCESS_MODIFIER
 
 #if DEFINE_FUNCTION_BODY_FIELDS
 PUBLIC_FIELDS
-    DECLARE_SERIALIZABLE_FIELD(RegSlot, m_varCount, RegSlot);           // Count of non-constant locals
-    DECLARE_SERIALIZABLE_FIELD(RegSlot, m_constCount, RegSlot);         // Count of enregistered constants
-    DECLARE_SERIALIZABLE_FIELD(RegSlot, m_firstTmpReg, RegSlot);
-    DECLARE_SERIALIZABLE_FIELD(RegSlot, m_outParamMaxDepth, RegSlot);   // Count of call depth in a nested expression
-    DECLARE_SERIALIZABLE_FIELD(uint, m_byteCodeCount, RegSlot);
-    DECLARE_SERIALIZABLE_FIELD(uint, m_byteCodeWithoutLDACount, RegSlot);
-    DECLARE_SERIALIZABLE_FIELD(uint, m_byteCodeInLoopCount, UInt32);
+    DECLARE_SERIALIZABLE_ACCESSOR_FIELD(RegSlot, VarCount, RegSlot);           // Count of non-constant locals
+    DECLARE_SERIALIZABLE_ACCESSOR_FIELD(RegSlot, ConstantCount, RegSlot);         // Count of enregistered constants
+    DECLARE_SERIALIZABLE_ACCESSOR_FIELD(RegSlot, FirstTmpRegister, RegSlot);
+    DECLARE_SERIALIZABLE_ACCESSOR_FIELD(RegSlot, OutParamMaxDepth, RegSlot);   // Count of call depth in a nested expression
+    DECLARE_SERIALIZABLE_ACCESSOR_FIELD(uint, ByteCodeCount, RegSlot);
+    DECLARE_SERIALIZABLE_ACCESSOR_FIELD(uint, ByteCodeWithoutLDACount, RegSlot);
+    DECLARE_SERIALIZABLE_ACCESSOR_FIELD(uint, ByteCodeInLoopCount, UInt32);
     DECLARE_SERIALIZABLE_FIELD(uint16, m_envDepth, UInt16);
     DECLARE_SERIALIZABLE_FIELD(uint16, m_argUsedForBranch, UInt16);
 
@@ -60,26 +64,26 @@ PRIVATE_FIELDS
     DECLARE_SERIALIZABLE_FIELD(ProfileId, profiledSwitchCount, UInt16);
     DECLARE_SERIALIZABLE_FIELD(ProfileId, profiledReturnTypeCount, UInt16);
     DECLARE_SERIALIZABLE_FIELD(ProfileId, profiledSlotCount, UInt16);
-    DECLARE_SERIALIZABLE_FIELD(uint, loopCount, RegSlot);
+    DECLARE_SERIALIZABLE_ACCESSOR_FIELD(uint, LoopCount, RegSlot);
     DECLARE_SERIALIZABLE_FIELD(FunctionBodyFlags, flags, FunctionBodyFlags);
     DECLARE_SERIALIZABLE_FIELD(bool, m_hasFinally, Bool);
     DECLARE_SERIALIZABLE_FIELD(bool, hasScopeObject, Bool);
     DECLARE_SERIALIZABLE_FIELD(bool, hasCachedScopePropIds, Bool);
-    DECLARE_SERIALIZABLE_FIELD(uint, inlineCacheCount, UInt32);
-    DECLARE_SERIALIZABLE_FIELD(uint, rootObjectLoadInlineCacheStart, UInt32);
-    DECLARE_SERIALIZABLE_FIELD(uint, rootObjectLoadMethodInlineCacheStart, UInt32);
-    DECLARE_SERIALIZABLE_FIELD(uint, rootObjectStoreInlineCacheStart, UInt32);
-    DECLARE_SERIALIZABLE_FIELD(uint, isInstInlineCacheCount, UInt32);
-    DECLARE_SERIALIZABLE_FIELD(uint, referencedPropertyIdCount, UInt32);
-    DECLARE_SERIALIZABLE_FIELD(uint, objLiteralCount, UInt32);
-    DECLARE_SERIALIZABLE_FIELD(uint, literalRegexCount, UInt32);
-    DECLARE_SERIALIZABLE_FIELD(uint, innerScopeCount, UInt32);
-    DECLARE_SERIALIZABLE_FIELD(RegSlot, localClosureRegister, RegSlot);
-    DECLARE_SERIALIZABLE_FIELD(RegSlot, localFrameDisplayRegister, RegSlot);
-    DECLARE_SERIALIZABLE_FIELD(RegSlot, envRegister, RegSlot);
-    DECLARE_SERIALIZABLE_FIELD(RegSlot, thisRegisterForEventHandler, RegSlot);
-    DECLARE_SERIALIZABLE_FIELD(RegSlot, firstInnerScopeRegister, RegSlot);
-    DECLARE_SERIALIZABLE_FIELD(RegSlot, funcExprScopeRegister, RegSlot);
+    DECLARE_SERIALIZABLE_ACCESSOR_FIELD(uint, InlineCacheCount, UInt32);
+    DECLARE_SERIALIZABLE_ACCESSOR_FIELD(uint, RootObjectLoadInlineCacheStart, UInt32);
+    DECLARE_SERIALIZABLE_ACCESSOR_FIELD(uint, RootObjectLoadMethodInlineCacheStart, UInt32);
+    DECLARE_SERIALIZABLE_ACCESSOR_FIELD(uint, RootObjectStoreInlineCacheStart, UInt32);
+    DECLARE_SERIALIZABLE_ACCESSOR_FIELD(uint, IsInstInlineCacheCount, UInt32);
+    DECLARE_SERIALIZABLE_ACCESSOR_FIELD(uint, ReferencedPropertyIdCount, UInt32);
+    DECLARE_SERIALIZABLE_ACCESSOR_FIELD(uint, ObjLiteralCount, UInt32);
+    DECLARE_SERIALIZABLE_ACCESSOR_FIELD(uint, LiteralRegexCount, UInt32);
+    DECLARE_SERIALIZABLE_ACCESSOR_FIELD(uint, InnerScopeCount, UInt32);
+    DECLARE_SERIALIZABLE_ACCESSOR_FIELD(RegSlot, LocalClosureRegister, RegSlot);
+    DECLARE_SERIALIZABLE_ACCESSOR_FIELD(RegSlot, LocalFrameDisplayRegister, RegSlot);
+    DECLARE_SERIALIZABLE_ACCESSOR_FIELD(RegSlot, EnvRegister, RegSlot);
+    DECLARE_SERIALIZABLE_ACCESSOR_FIELD(RegSlot, ThisRegisterForEventHandler, RegSlot);
+    DECLARE_SERIALIZABLE_ACCESSOR_FIELD(RegSlot, FirstInnerScopeRegister, RegSlot);
+    DECLARE_SERIALIZABLE_ACCESSOR_FIELD(RegSlot, FuncExprScopeRegister, RegSlot);
 
 CURRENT_ACCESS_MODIFIER
 #endif
@@ -89,6 +93,7 @@ CURRENT_ACCESS_MODIFIER
 #undef DEFINE_FUNCTION_BODY_FIELDS
 #undef CURRENT_ACCESS_MODIFIER
 #undef DECLARE_SERIALIZABLE_FIELD
+#undef DECLARE_SERIALIZABLE_ACCESSOR_FIELD
 #undef PROTECTED_FIELDS
 #undef PRIVATE_FIELDS
 #undef PUBLIC_FIELDS


### PR DESCRIPTION
Use smaller data type to represent the counter fields of FunctionBody.

Most of the counters has value less than 256, use single byte to hold them. And can promote to short or full 32 bit integer when necessary.
