### PR TITLE
Bugfix:OS5553123:Freeze while comparing valueOf()-injected null

### DIFF
--- a/Lib/Runtime/Language/JavascriptOperators.cpp
+++ b/Lib/Runtime/Language/JavascriptOperators.cpp
@@ -708,6 +708,9 @@ Redo:
             dblRight = JavascriptConversion::ToNumber(aRight, scriptContext);
             break;
         case TypeIds_Boolean:
+        case TypeIds_Null:
+        case TypeIds_Undefined:
+        case TypeIds_Symbol:
             dblLeft = JavascriptConversion::ToNumber(aLeft, scriptContext);
             dblRight = JavascriptConversion::ToNumber(aRight, scriptContext);
             break;

--- a/test/Bugs/OS_5553123.js
+++ b/test/Bugs/OS_5553123.js
@@ -1,0 +1,31 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+
+function testRelationalComparison (retVal)
+{
+    var ObjectV = function ObjectV(v){ }
+
+    ObjectV.prototype = {
+        valueOf : function(){ return retVal; }
+    };
+
+    function f()
+    {
+        var x = new ObjectV(0);
+        x<"1";
+    }
+
+    f();
+    f();
+    f();
+}
+
+testRelationalComparison(null);
+testRelationalComparison(undefined);
+assert.throws(function() { testRelationalComparison(Symbol("abc")); }, TypeError, "Number expected");
+
+WScript.Echo("Passed");

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -235,4 +235,9 @@
       <compile-flags>-maxinterpretCount:2 -off:simplejit -off:dynamicProfile -args summary -endargs</compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>OS_5553123.js</files>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
Bugfix:OS5553123:Freeze while comparing valueOf()-injected null

Chakra implementation of Abstract Relational Comparison operation fails to
handle 'null'. Specifically, it cause a browser tab to freeze when a comparison ("<")
is done with the left value being 'null' injected by valueOf() call through a prototype.
Add 'null' checking to fix this problem.
Add unit test.
