### PR TITLE
Fix AV in unittest when setting pointer to nullptr, we should never promote the AuxPtrs so remove the dependency on recycler on that case

### DIFF
--- a/lib/Runtime/Base/AuxPtrs.h
+++ b/lib/Runtime/Base/AuxPtrs.h
@@ -167,6 +167,7 @@ namespace Js
     template<class T, typename FieldsEnum>
     void AuxPtrs<T, FieldsEnum>::AllocAuxPtrFix(T* _this, uint8 size, Recycler* recycler)
     {
+        Assert(recycler != nullptr);
         if (size == 16)
         {
             _this->auxPtrs = (AuxPtrs<T, FieldsEnum>*)RecyclerNewWithBarrierStructZ(recycler, AuxPtrs16);

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -78,7 +78,8 @@ namespace Js
     }
     inline void FunctionProxy::SetAuxPtr(AuxPointerType e, void* ptr)
     {
-        return auxPtrs->SetAuxPtr(this, e, ptr, m_scriptContext->GetRecycler());
+        return auxPtrs->SetAuxPtr(this, e, ptr, 
+            ptr == nullptr ? nullptr : m_scriptContext->GetRecycler());// when setting ptr to null we never need to promote
     }
 
     uint FunctionProxy::GetSourceContextId() const

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -74,11 +74,11 @@ namespace Js
 
     inline void* FunctionProxy::GetAuxPtr(AuxPointerType e) const
     {
-        return auxPtrs->GetAuxPtr(this, e);
+        return AuxPtrsT::GetAuxPtr(this, e);
     }
     inline void FunctionProxy::SetAuxPtr(AuxPointerType e, void* ptr)
     {
-        return auxPtrs->SetAuxPtr(this, e, ptr, 
+        return AuxPtrsT::SetAuxPtr(this, e, ptr,
             ptr == nullptr ? nullptr : m_scriptContext->GetRecycler());// when setting ptr to null we never need to promote
     }
 


### PR DESCRIPTION
Fix AV in unittest
when setting pointer to nullptr, we should never promote the AuxPtrs so remove the dependency on recycler on that case
