### PR TITLE
Disable the ES6 module test file temporarily pending test hook changes

### DIFF
--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -1123,7 +1123,8 @@
       <compile-flags>-args summary -endargs</compile-flags>
     </default>
   </test>
-  
+
+<!--  
 <test>
     <default>
         <files>module-syntax.js</files>
@@ -1138,4 +1139,5 @@
         <tags>exclude_dynapogo</tags>
     </default>
 </test>
+!-->
 </regress-exe>


### PR DESCRIPTION
Simple change to disable the ES6 module test temporarily. This is breaking internal builds due to missing test hook. We'll turn this test back on after Yong checks-in his module test hook.