### PR TITLE
Fixes `get` and `set` not parsing in object literal shorthand syntax

### DIFF
--- a/Lib/Parser/Parse.h
+++ b/Lib/Parser/Parse.h
@@ -370,22 +370,22 @@ private:
 
     struct WellKnownPropertyPids
     {
-        IdentPtr arguments; // m_pidArguments; // 'arguments' identifier
-        IdentPtr async; // m_pidAsync;
-        IdentPtr eval; // m_pidEval;
-        IdentPtr setter; // m_pidSetter;
-        IdentPtr getter; // m_pidGetter;
-        IdentPtr let; // m_pidLet;
-        IdentPtr constructor; // m_pidConstructor;
-        IdentPtr prototype; // m_pidPrototype;
-        IdentPtr __proto__; // m_pid__proto__;
-        IdentPtr of; // m_pidOf;
-        IdentPtr target; // m_pidTarget;
-        IdentPtr from; // m_pidFrom;
-        IdentPtr as; // m_pidAs;
-        IdentPtr default; // m_pidDefault;
-        IdentPtr _star; // m_pidStar; // '*' identifier
-        IdentPtr _starDefaultStar; // m_pidStarDefaultStar; // '*default*' identifier
+        IdentPtr arguments;
+        IdentPtr async;
+        IdentPtr eval;
+        IdentPtr set;
+        IdentPtr get;
+        IdentPtr let;
+        IdentPtr constructor;
+        IdentPtr prototype;
+        IdentPtr __proto__;
+        IdentPtr of;
+        IdentPtr target;
+        IdentPtr from;
+        IdentPtr as;
+        IdentPtr default;
+        IdentPtr _star; // Special '*' identifier for modules
+        IdentPtr _starDefaultStar; // Special '*default*' identifier for modules
     };
 
     WellKnownPropertyPids wellKnownPropertyPids;
@@ -442,6 +442,7 @@ private:
     bool IsNodeAllowedForDeferParse(OpCode op) {return !this->m_deferringAST ||
         (op == knopBlock || op == knopVarDecl || op == knopConstDecl || op == knopLetDecl || op == knopFncDecl); }
     bool NextTokenConfirmsLetDecl() const { return m_token.tk == tkID || m_token.tk == tkLBrack || m_token.tk == tkLCurly || m_token.IsReservedWord(); }
+    bool NextTokenIsPropertyNameStart() const { return m_token.tk == tkID || m_token.tk == tkStrCon || m_token.tk == tkIntCon || m_token.tk == tkFltCon || m_token.tk == tkLBrack || m_token.IsReservedWord(); }
 
     template<bool buildAST>
     void PushStmt(StmtNest *pStmt, ParseNodePtr pnode, OpCode op, ParseNodePtr pnodeLab, LabelId* pLabelIdList)

--- a/test/es5/ObjLitGetSet.baseline
+++ b/test/es5/ObjLitGetSet.baseline
@@ -23,3 +23,4 @@ PASS
  (test 5): Object literal get set function toString
 function foo() { return _foo; }
 function foo(value) { _foo = value; }
+PASS

--- a/test/es5/ObjLitGetSet.js
+++ b/test/es5/ObjLitGetSet.js
@@ -173,6 +173,8 @@ function Test5()
 
     WScript.Echo("" + fooDescriptor.get);
     WScript.Echo("" + fooDescriptor.set);
+
+    return true;
 }
 
 // Note: test for Object literal duplicate set\get property is in the file ObjLitGetSetDuplicate.js.

--- a/test/es6/destructuring_obj.js
+++ b/test/es6/destructuring_obj.js
@@ -166,8 +166,25 @@ var tests = [
     }
   },
   {
+    name: "Object destructuring with `get` and `set` identifiers",
+    body: function () {
+        var { get } = { get: 1 };
+        let { set } = { set: 2 };
+        assert.areEqual(1, get, "`get` is a valid object destructuring name");
+        assert.areEqual(2, set, "`set` is a valid object destructuring name");
+
+        assert.throws(function () { eval("var { get foo() { } } = { get: 1 };"); }, SyntaxError, "getter accessor is not a valid object destructuring name", "Invalid destructuring assignment target");
+        assert.throws(function () { eval("var { set bar(x) { } } = { set: 2 };"); }, SyntaxError, "setter accessor is not a valid object destructuring name", "Invalid destructuring assignment target");
+
+        const { get: x } = { get: 3 };
+        var { set: y } = { set: 4 };
+        assert.areEqual(3, x, "`get` is a valid object destructuring name mapping");
+        assert.areEqual(4, y, "`set` is a valid object destructuring name mapping");
+    }
+  },
+  {
     name: "Object destructuring basic functionality",
-    body : function () {
+    body: function () {
         {
            var x3, x4;
            let {x:x1} = {x:20};

--- a/test/es6/objlit.js
+++ b/test/es6/objlit.js
@@ -15,15 +15,58 @@ var tests = [
         }
     },
     {
-        name: "Method shorthand",
+        name: "Shorthand names `get` and `set` parse without error (they are not keywords in these cases)",
+        body: function () {
+            var a = 0;
+            var get = 1;
+            var set = 2;
+            var z = 3;
+
+            var o = { get };
+            var p = { set };
+            var q = { get, set };
+            var r = { set, get };
+            var s = { get, z };
+            var t = { a, set };
+            var u = { a, get, z };
+
+            assert.areEqual(1, o.get, "o.get = 1");
+            assert.areEqual(2, p.set, "p.set = 2");
+            assert.areEqual(1, q.get, "q.get = 1");
+            assert.areEqual(2, q.set, "q.set = 2");
+            assert.areEqual(2, r.set, "r.set = 2");
+            assert.areEqual(1, r.get, "r.get = 1");
+            assert.areEqual(1, s.get, "s.get = 1");
+            assert.areEqual(3, s.z, "s.z = 3");
+            assert.areEqual(0, t.a, "t.a = 0");
+            assert.areEqual(2, t.set, "t.set = 2");
+            assert.areEqual(0, u.a, "u.a = 0");
+            assert.areEqual(1, u.get, "u.get = 1");
+            assert.areEqual(3, u.z, "u.z = 3");
+        }
+    },
+    {
+        name: "Concise method shorthand",
         body: function() {
             var obj = {
-            foo() { return "foo"; }
+                foo() { return "foo"; }
             };
 
-            assert.areEqual(obj.foo(), "foo");
-            assert.areEqual(({ foo: function() { }, foo() { return "foo"; } }).foo(), "foo");
-            assert.areEqual(({ foo(x) { }, foo() { return "foo"; } }).foo(), "foo");
+            assert.areEqual("foo", obj.foo());
+            assert.areEqual("foo", ({ foo: function() { }, foo() { return "foo"; } }).foo());
+            assert.areEqual("foo", ({ foo(x) { }, foo() { return "foo"; } }).foo());
+        }
+    },
+    {
+        name: "Concise method shorthand with `get` and `set` names",
+        body: function () {
+            var o = {
+                get() { return "g"; },
+                set() { return "s"; }
+            };
+
+            assert.areEqual('g', o.get(), "o.get returns 'g'");
+            assert.areEqual('s', o.set(), "o.set returns 's'");
         }
     },
     {


### PR DESCRIPTION
Fixes #320

Also renamed wellKnownPropertyPids.getter/setter to get/set to reflect
the actual PID they represent.