### PR TITLE
Clean up and fix concurrent/partial GC macro

### DIFF
--- a/Lib/Common/CommonDefines.h
+++ b/Lib/Common/CommonDefines.h
@@ -100,8 +100,8 @@
 #define SUPPORT_FIXED_FIELDS_ON_PATH_TYPES          // *** TODO: Won't build if disabled currently
 
 // GC features
-#define CONCURRENT_GC_ENABLED 1                     // *** TODO: Won't build if disabled currently
-#define PARTIAL_GC_ENABLED 1                        // *** TODO: Won't build if disabled currently
+#define ENABLE_CONCURRENT_GC 1
+#define ENABLE_PARTIAL_GC 1  
 #define BUCKETIZE_MEDIUM_ALLOCATIONS 1              // *** TODO: Won't build if disabled currently
 #define SMALLBLOCK_MEDIUM_ALLOC 1                   // *** TODO: Won't build if disabled currently
 #define LARGEHEAPBLOCK_ENCODING 1                   // Large heap block metadata encoding
@@ -445,7 +445,7 @@
 //  - flags values that are dependent on other flags
 //----------------------------------------------------------------------------------------------------
 
-#ifndef CONCURRENT_GC_ENABLED
+#if !ENABLE_CONCURRENT_GC
 #undef IDLE_DECOMMIT_ENABLED   // Currently idle decommit can only be enabled if concurrent gc is enabled
 #endif
 

--- a/Lib/Common/ConfigFlagsList.h
+++ b/Lib/Common/ConfigFlagsList.h
@@ -1127,19 +1127,19 @@ FLAGNR(Boolean, LibraryStackFrame           , "Display library stack frame", DEF
 FLAGNR(Boolean, LibraryStackFrameDebugger   , "Assume debugger support for library stack frame", DEFAULT_CONFIG_LibraryStackFrameDebugger)
 #ifdef RECYCLER_STRESS
 FLAGNR(Boolean, RecyclerStress        , "Stress the recycler by collect on every allocation call", false)
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
 FLAGNR(Boolean, RecyclerBackgroundStress        , "Stress the recycler by collect in the background thread on every allocation call", false)
 FLAGNR(Boolean, RecyclerConcurrentStress        , "Stress the concurrent recycler by concurrent collect on every allocation call", false)
 FLAGNR(Boolean, RecyclerConcurrentRepeatStress  , "Stress the concurrent recycler by concurrent collect on every allocation call and repeat mark and rescan in the background thread", false)
 #endif
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
 FLAGNR(Boolean, RecyclerPartialStress , "Stress the partial recycler by partial collect on every allocation call", false)
 #endif
 FLAGNR(Boolean, RecyclerTrackStress, "Stress tracked object handling by simulating tracked objects for regular allocations", false)
 FLAGNR(Boolean, RecyclerInduceFalsePositives, "Stress recycler by forcing false positive object marks", false)
 #endif // RECYCLER_STRESS
 FLAGNR(Boolean, RecyclerForceMarkInterior, "Force all the mark as interior", DEFAULT_CONFIG_RecyclerForceMarkInterior)
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
 FLAGNR(Number,  RecyclerPriorityBoostTimeout, "Adjust priority boost timeout", 5000)
 FLAGNR(Number,  RecyclerThreadCollectTimeout, "Adjust thread collect timeout", 1000)
 #endif
@@ -1269,12 +1269,12 @@ FLAGNR(Boolean, MemProtectHeap, "Use the mem protect heap as the default heap", 
 #endif
 #ifdef RECYCLER_STRESS
 FLAGNR(Boolean, MemProtectHeapStress, "Stress the recycler by collect on every allocation call", false)
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
 FLAGNR(Boolean, MemProtectHeapBackgroundStress, "Stress the recycler by collect in the background thread on every allocation call", false)
 FLAGNR(Boolean, MemProtectHeapConcurrentStress, "Stress the concurrent recycler by concurrent collect on every allocation call", false)
 FLAGNR(Boolean, MemProtectHeapConcurrentRepeatStress, "Stress the concurrent recycler by concurrent collect on every allocation call and repeat mark and rescan in the background thread", false)
 #endif
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
 FLAGNR(Boolean, MemProtectHeapPartialStress, "Stress the partial recycler by partial collect on every allocation call", false)
 #endif
 #endif

--- a/Lib/Common/Memory/Chakra.Common.Memory.vcxproj
+++ b/Lib/Common/Memory/Chakra.Common.Memory.vcxproj
@@ -143,6 +143,7 @@
     <None Include="LargeHeapBucket.inl" />
     <None Include="MarkContext.inl" />
     <None Include="Recycler.inl" />
+    <None Include="SmallBlockDeclarations.inl" />
   </ItemGroup>
   <ItemGroup>
     <MASM Include="$(MSBuildThisFileDirectory)amd64\amd64_SAVE_REGISTERS.asm">

--- a/Lib/Common/Memory/Chakra.Common.Memory.vcxproj.filters
+++ b/Lib/Common/Memory/Chakra.Common.Memory.vcxproj.filters
@@ -113,6 +113,7 @@
     <None Include="LargeHeapBucket.inl" />
     <None Include="MarkContext.inl" />
     <None Include="Recycler.inl" />
+    <None Include="SmallBlockDeclarations.inl" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="amd64">

--- a/Lib/Common/Memory/CollectionState.h
+++ b/Lib/Common/Memory/CollectionState.h
@@ -12,22 +12,20 @@ enum CollectionState
     // Mark related states
     Collection_ResetMarks           = 0x00000010,
     Collection_FindRoots            = 0x00000020,
-#if defined(PARTIAL_GC_ENABLED) || defined(CONCURRENT_GC_ENABLED)
     Collection_Rescan               = 0x00000040,
-#endif
     Collection_FinishMark           = 0x00000080,
 
     // Sweep related states
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     Collection_ConcurrentSweepSetup = 0x00000100,
 #endif
     Collection_TransferSwept        = 0x00000200,
 
     // State attributes
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     Collection_Partial              = 0x00001000,
 #endif
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     Collection_Concurrent           = 0x00002000,
     Collection_ExecutingConcurrent  = 0x00004000,
     Collection_FinishConcurrent     = 0x00008000,
@@ -51,11 +49,11 @@ enum CollectionState
     CollectionStateExit                   = Collection_Exit,                                                  // exiting concurrent thread
 
 
-#if defined(PARTIAL_GC_ENABLED) || defined(CONCURRENT_GC_ENABLED)
+    // Generally, Rescan is available only when concurrent is enabled
+    // But we need Rescan for mark on OOM too
     CollectionStateRescanFindRoots        = Collection_Mark | Collection_Rescan | Collection_FindRoots,       // rescan (after concurrent mark)
     CollectionStateRescanMark             = Collection_Mark | Collection_Rescan,                              // rescan (after concurrent mark)
-#endif
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     CollectionStateConcurrentResetMarks   = Collection_ConcurrentMark | Collection_ResetMarks | Collection_ExecutingConcurrent,    // concurrent reset mark
     CollectionStateConcurrentFindRoots    = Collection_ConcurrentMark | Collection_FindRoots | Collection_ExecutingConcurrent,     // concurrent findroot
     CollectionStateConcurrentMark         = Collection_ConcurrentMark | Collection_ExecutingConcurrent,                            // concurrent marking
@@ -67,10 +65,10 @@ enum CollectionState
     CollectionStateTransferSweptWait      = Collection_ConcurrentSweep | Collection_FinishConcurrent,         // transfer swept objects (after concurrent sweep)
 #endif
     CollectionStateParallelMark           = Collection_Mark | Collection_Parallel,
+#if ENABLE_CONCURRENT_GC
     CollectionStateBackgroundParallelMark = Collection_ConcurrentMark | Collection_ExecutingConcurrent | Collection_Parallel,
+    CollectionStateConcurrentWrapperCallback = Collection_Concurrent | Collection_ExecutingConcurrent | Collection_WrapperCallback,
+#endif
 
     CollectionStatePostCollectionCallback = Collection_PostCollectionCallback,
-
-    CollectionStateConcurrentWrapperCallback = Collection_Concurrent | Collection_ExecutingConcurrent | Collection_WrapperCallback,
-
 };

--- a/Lib/Common/Memory/HeapBlock.h
+++ b/Lib/Common/Memory/HeapBlock.h
@@ -277,7 +277,7 @@ protected:
     Segment * segment;
     HeapBlockType const heapBlockType;
     bool needOOMRescan;                             // Set if we OOMed while marking a particular object
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     bool isPendingConcurrentSweep;
 #endif
 
@@ -356,9 +356,9 @@ public:
 enum SweepMode
 {
     SweepMode_InThread,
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     SweepMode_Concurrent,
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     SweepMode_ConcurrentPartial
 #endif
 #endif
@@ -371,7 +371,7 @@ enum SweepState
     SweepStateSwept,                // the block is partially allocated, no object needs to be swept or finalized
     SweepStateFull,                 // the block is full, no object needs to be swept or finalized
     SweepStatePendingDispose,       // the block has object that needs to be finalized
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     SweepStatePendingSweep,         // the block has object that needs to be swept
 #endif
 };
@@ -431,7 +431,7 @@ public:
     ushort lastFreeCount;
     ushort markCount;
 
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     ushort oldFreeCount;
 #endif
     bool   isInAllocator;
@@ -586,8 +586,8 @@ public:
     void SweepObjects(Recycler * recycler);
 
     uint GetAndClearLastFreeCount();
-#ifdef PARTIAL_GC_ENABLED
     void ClearAllAllocBytes();      // Reset all unaccounted alloc bytes and the new alloc count
+#if ENABLE_PARTIAL_GC
     uint GetAndClearUnaccountedAllocBytes();
     void AdjustPartialUncollectedAllocBytes(RecyclerSweep& recyclerSweep, uint const expectSweepCount);
     bool DoPartialReusePage(RecyclerSweep const& recyclerSweep, uint& expectFreeByteCount);

--- a/Lib/Common/Memory/HeapBlock.inl
+++ b/Lib/Common/Memory/HeapBlock.inl
@@ -163,8 +163,11 @@ HeapBlock::UpdateAttributesOfMarkedObjects(MarkContext * markContext, void * obj
     {
         FinalizableObject * trackedObject = (FinalizableObject *)objectAddress;
 
+#if ENABLE_PARTIAL_GC
         if (!markContext->GetRecycler()->inPartialCollectMode)
+#endif
         {
+#if ENABLE_CONCURRENT_GC
             if (markContext->GetRecycler()->DoQueueTrackedObject())
             {
                 if (!markContext->AddTrackedObject(trackedObject))
@@ -173,6 +176,7 @@ HeapBlock::UpdateAttributesOfMarkedObjects(MarkContext * markContext, void * obj
                 }
             }
             else
+#endif
             {
                 // Process the tracked object right now
                 markContext->MarkTrackedObject(trackedObject);

--- a/Lib/Common/Memory/HeapBlockMap.h
+++ b/Lib/Common/Memory/HeapBlockMap.h
@@ -69,12 +69,12 @@ public:
 
     void ResetMarks();
 
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC || ENABLE_PARTIAL_GC
     void ResetWriteWatch(Recycler * recycler);
     uint Rescan(Recycler * recycler, bool resetWriteWatch);
+#endif
     void MakeAllPagesReadOnly(Recycler* recycler);
     void MakeAllPagesReadWrite(Recycler* recycler);
-#endif
 
     void Cleanup(bool concurrentFindImplicitRoot);
 
@@ -257,16 +257,15 @@ public:
 
     void ResetMarks();
 
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC || ENABLE_PARTIAL_GC
     void ResetWriteWatch(Recycler * recycler);
     uint Rescan(Recycler * recycler, bool resetWriteWatch);
+#endif
     void MakeAllPagesReadOnly(Recycler* recycler);
     void MakeAllPagesReadWrite(Recycler* recycler);
-#endif
+    bool OOMRescan(Recycler * recycler);
 
     void Cleanup(bool concurrentFindImplicitRoot);
-
-    bool OOMRescan(Recycler * recycler);
 
 #ifdef RECYCLER_STRESS
     void InduceFalsePositives(Recycler * recycler);

--- a/Lib/Common/Memory/HeapBucket.cpp
+++ b/Lib/Common/Memory/HeapBucket.cpp
@@ -160,6 +160,7 @@ HeapBucketT<TBlockType>::ClearAllocators()
     this->explicitFreeList = nullptr;
 }
 
+#if ENABLE_CONCURRENT_GC
 template <typename TBlockType>
 void
 HeapBucketT<TBlockType>::PrepareSweep()
@@ -171,6 +172,7 @@ HeapBucketT<TBlockType>::PrepareSweep()
     // (And remove rescan from leaf bucket, so this function doesn't need to exist)
     ClearAllocators();
 }
+#endif
 
 template <typename TBlockType>
 void
@@ -295,7 +297,7 @@ HeapBucketT<TBlockType>::GetNonEmptyHeapBlockCount(bool checkCount) const
 {
     size_t currentHeapBlockCount = HeapBlockList::Count(fullBlockList);
     currentHeapBlockCount += HeapBlockList::Count(heapBlockList);
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     // Recycler can be null if we have OOM in the ctor
     if (this->GetRecycler() && this->GetRecycler()->recyclerSweep != nullptr)
     {
@@ -490,9 +492,13 @@ HeapBucketT<TBlockType>::SnailAlloc(Recycler * recycler, TBlockAllocatorType * a
         return memBlock;
     }
 
+#if ENABLE_CONCURRENT_GC
     // No free memory, try to collect with allocated bytes and time heuristic, and concurrently
     BOOL collected = recycler->disableCollectOnAllocationHeuristics ? recycler->FinishConcurrent<FinishConcurrentOnAllocation>() :
         recycler->CollectNow<CollectOnAllocation>();
+#else
+    BOOL collected = recycler->disableCollectOnAllocationHeuristics ? FALSE : recycler->CollectNow<CollectOnAllocation>();
+#endif
 
     AllocationVerboseTrace(recycler->GetRecyclerFlagsTable(), L"TryAlloc failed, forced collection on allocation [Collected: %d]\n", collected);
     if (!collected)
@@ -597,7 +603,7 @@ HeapBucketT<TBlockType>::CreateHeapBlock(Recycler * recycler)
     // Add it to head of heap block list so we will keep track of the block
     recycler->autoHeap.AppendNewHeapBlock(heapBlock, this);
 #ifdef RECYCLER_SLOW_CHECK_ENABLED
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     ::InterlockedIncrement(&this->newHeapBlockCount);
 #else
     this->heapBlockCount++;
@@ -622,7 +628,7 @@ HeapBucketT<TBlockType>::ResetMarks(ResetMarkFlags flags)
 {
     RECYCLER_SLOW_CHECK(this->VerifyHeapBlockCount((flags & ResetMarkFlags_Background) != 0));
 
-#ifndef CONCURRENT_GC_ENABLED
+#if !ENABLE_CONCURRENT_GC
     Assert((flags & ResetMarkFlags_Background) == 0);
 #endif
 
@@ -779,7 +785,7 @@ HeapBucketT<TBlockType>::VerifyBlockConsistencyInList(TBlockType * heapBlock, Re
 }
 #endif // DBG
 
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
 template <typename TBlockType>
 bool
 HeapBucketT<TBlockType>::DoQueuePendingSweep(Recycler * recycler)
@@ -838,7 +844,7 @@ HeapBucketT<TBlockType>::SweepHeapBlockList(RecyclerSweep& recyclerSweep, TBlock
     // only if we are doing partial GC so we can calculate the heuristics before
     // determinate we want to fully sweep the block or partially sweep the block
 
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     // CONCURRENT-TODO: Add a mode where we can do in thread sweep, and concurrent partial sweep?
     bool const queuePendingSweep = this->DoQueuePendingSweep(recycler);
 #else
@@ -857,7 +863,7 @@ HeapBucketT<TBlockType>::SweepHeapBlockList(RecyclerSweep& recyclerSweep, TBlock
 
         switch (state)
         {
-#if defined(PARTIAL_GC_ENABLED) || defined(CONCURRENT_GC_ENABLED)
+#if ENABLE_CONCURRENT_GC
         case SweepStatePendingSweep:
         {
             Assert(IsNormalBucket);
@@ -866,7 +872,7 @@ HeapBucketT<TBlockType>::SweepHeapBlockList(RecyclerSweep& recyclerSweep, TBlock
             TBlockType *& pendingSweepList = recyclerSweep.GetPendingSweepBlockList(this);
             heapBlock->SetNextBlock(pendingSweepList);
             pendingSweepList = heapBlock;
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
             recyclerSweep.NotifyAllocableObjects(heapBlock);
 #endif
             break;
@@ -902,7 +908,7 @@ HeapBucketT<TBlockType>::SweepHeapBlockList(RecyclerSweep& recyclerSweep, TBlock
             Assert(heapBlock->HasFreeObject());
             heapBlock->SetNextBlock(this->heapBlockList);
             this->heapBlockList = heapBlock;
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
             recyclerSweep.NotifyAllocableObjects(heapBlock);
 #endif
             break;
@@ -927,6 +933,7 @@ HeapBucketT<TBlockType>::SweepHeapBlockList(RecyclerSweep& recyclerSweep, TBlock
 
             RECYCLER_STATS_INC(recycler, numEmptySmallBlocks[heapBlock->GetHeapBlockType()]);
 
+#if ENABLE_CONCURRENT_GC
             // CONCURRENT-TODO: Finalizable block never have background == true and always be processed
             // in thread, so it will not queue up the pages even if we are doing concurrent GC
             if (recyclerSweep.IsBackground())
@@ -942,6 +949,7 @@ HeapBucketT<TBlockType>::SweepHeapBlockList(RecyclerSweep& recyclerSweep, TBlock
                 RECYCLER_STATS_INC(recycler, numZeroedOutSmallBlocks);
             }
             else
+#endif
             {
                 // Just free the page in thread (and zero the page)
                 heapBlock->ReleasePagesSweep<pageheap>(recycler);
@@ -962,6 +970,7 @@ HeapBucketT<TBlockType>::SweepBucket(RecyclerSweep& recyclerSweep)
 {
     DebugOnly(TBlockType * savedNextAllocableBlockHead);
     RECYCLER_SLOW_CHECK(this->VerifyHeapBlockCount(recyclerSweep.IsBackground()));
+#if ENABLE_CONCURRENT_GC
     if (recyclerSweep.HasSetupBackgroundSweep())
     {
         // SetupBackgroundSweep set nextAllocableBlockHead to null already
@@ -969,6 +978,7 @@ HeapBucketT<TBlockType>::SweepBucket(RecyclerSweep& recyclerSweep)
         DebugOnly(savedNextAllocableBlockHead = recyclerSweep.GetSavedNextAllocableBlockHead(this));
     }
     else
+#endif
     {
         Assert(AllocatorsAreEmpty());
         DebugOnly(savedNextAllocableBlockHead = this->nextAllocableBlockHead);
@@ -976,7 +986,7 @@ HeapBucketT<TBlockType>::SweepBucket(RecyclerSweep& recyclerSweep)
     }
 
     // We just started sweeping.  These pending lists should be empty
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     Assert(recyclerSweep.GetPendingSweepBlockList(this) == nullptr);
 #else
     Assert(!recyclerSweep.IsBackground());
@@ -1058,12 +1068,17 @@ HeapBucketT<TBlockType>::IsAllocationStopped() const
 }
 #endif
 
-#if defined(PARTIAL_GC_ENABLED) || defined(CONCURRENT_GC_ENABLED)
 template <typename TBlockType>
 uint
 HeapBucketT<TBlockType>::Rescan(Recycler * recycler, RescanFlags flags)
 {
+#if ENABLE_CONCURRENT_GC
     RECYCLER_SLOW_CHECK(this->VerifyHeapBlockCount(!!recycler->IsConcurrentMarkState()));
+#else
+    RECYCLER_SLOW_CHECK(this->VerifyHeapBlockCount(false /* background */));
+#endif
+
+#if ENABLE_CONCURRENT_GC
     // If we do the final rescan concurrently, the main thread will prepare for sweep concurrently
     // If we do rescan in thread, we will need to prepare sweep here.
     // However, if we are in the rescan for OOM, we have already done it, so no need to do it again
@@ -1071,14 +1086,13 @@ HeapBucketT<TBlockType>::Rescan(Recycler * recycler, RescanFlags flags)
     {
         this->PrepareSweep();
     }
+#endif
 
     // By default heap bucket doesn't rescan anything
     return 0;
 }
 
-#endif
-
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
 template <typename TBlockType>
 void
 HeapBucketT<TBlockType>::MergeNewHeapBlock(TBlockType * heapBlock)
@@ -1105,6 +1119,7 @@ HeapBucketT<TBlockType>::SetupBackgroundSweep(RecyclerSweep& recyclerSweep)
 
     this->StopAllocationBeforeSweep();
 }
+#endif
 
 #ifdef RECYCLER_PAGE_HEAP
 template <typename TBlockType>
@@ -1121,10 +1136,12 @@ HeapBucketT<TBlockType>::PageHeapCheckSweepLists(RecyclerSweep& recyclerSweep)
         {
             Assert(!heapBlock->InPageHeapMode());
         });
+#if ENABLE_CONCURRENT_GC
         HeapBlockList::ForEach(recyclerSweep.GetPendingSweepBlockList(this), [](TBlockType * heapBlock)
         {
             Assert(!heapBlock->InPageHeapMode());
         });
+#endif
     }
 #endif
 }
@@ -1157,7 +1174,6 @@ HeapBucketT<TBlockType>::AppendAllocableHeapBlockList(TBlockType * list)
         }
     }
 }
-#endif
 
 template <typename TBlockType>
 void
@@ -1444,7 +1460,6 @@ HeapBucketGroup<TBlockAttributes>::FinalizeAllObjects()
 #endif
 }
 
-#if defined(PARTIAL_GC_ENABLED) || defined(CONCURRENT_GC_ENABLED)
 template <class TBlockAttributes>
 uint
 HeapBucketGroup<TBlockAttributes>::Rescan(Recycler * recycler, RescanFlags flags)
@@ -1457,8 +1472,8 @@ HeapBucketGroup<TBlockAttributes>::Rescan(Recycler * recycler, RescanFlags flags
 #endif
         finalizableHeapBucket.Rescan(recycler, flags);
 }
-#endif
-#ifdef CONCURRENT_GC_ENABLED
+
+#if ENABLE_CONCURRENT_GC
 template <class TBlockAttributes>
 void
 HeapBucketGroup<TBlockAttributes>::PrepareSweep()
@@ -1483,7 +1498,7 @@ HeapBucketGroup<TBlockAttributes>::SetupBackgroundSweep(RecyclerSweep& recyclerS
 #endif
 }
 #endif
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
 template <class TBlockAttributes>
 void
 HeapBucketGroup<TBlockAttributes>::SweepPartialReusePages(RecyclerSweep& recyclerSweep)
@@ -1526,7 +1541,7 @@ HeapBucketGroup<TBlockAttributes>::FinishPartialCollect(RecyclerSweep * recycler
 }
 #endif
 
-#if defined(PARTIAL_GC_ENABLED) || defined(CONCURRENT_GC_ENABLED)
+#if ENABLE_CONCURRENT_GC
 template <class TBlockAttributes>
 void
 HeapBucketGroup<TBlockAttributes>::SweepPendingObjects(RecyclerSweep& recyclerSweep)
@@ -1544,9 +1559,7 @@ HeapBucketGroup<TBlockAttributes>::SweepPendingObjects(RecyclerSweep& recyclerSw
 
     finalizableHeapBucket.SweepPendingObjects(recyclerSweep);
 }
-#endif
 
-#ifdef CONCURRENT_GC_ENABLED
 template <class TBlockAttributes>
 void
 HeapBucketGroup<TBlockAttributes>::TransferPendingEmptyHeapBlocks(RecyclerSweep& recyclerSweep)

--- a/Lib/Common/Memory/HeapBucket.h
+++ b/Lib/Common/Memory/HeapBucket.h
@@ -136,10 +136,8 @@ public:
 #ifdef DUMP_FRAGMENTATION_STATS
     void AggregateBucketStats(HeapBucketStats& stats);
 #endif
-#if defined(PARTIAL_GC_ENABLED) || defined(CONCURRENT_GC_ENABLED)
     uint Rescan(Recycler * recycler, RescanFlags flags);
-#endif
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     void MergeNewHeapBlock(TBlockType * heapBlock);
     void PrepareSweep();
     void SetupBackgroundSweep(RecyclerSweep& recyclerSweep);
@@ -195,7 +193,7 @@ protected:
 #endif
     template<bool pageheap>
     void SweepHeapBlockList(RecyclerSweep& recyclerSweep, TBlockType * heapBlockList, bool allocable);
-#if defined(PARTIAL_GC_ENABLED)
+#if ENABLE_PARTIAL_GC
     bool DoQueuePendingSweep(Recycler * recycler);
     bool DoPartialReuseSweep(Recycler * recycler);
 #endif
@@ -274,12 +272,14 @@ HeapBucketT<TBlockType>::SweepBucket(RecyclerSweep& recyclerSweep, Fn sweepFn)
     // Continue to sweep other list from derived class
     sweepFn(recyclerSweep);
 
-#if defined(PARTIAL_GC_ENABLED)
+#if ENABLE_PARTIAL_GC
     if (!this->DoPartialReuseSweep(recyclerSweep.GetRecycler()))
 #endif
     {
+#if ENABLE_CONCURRENT_GC
         // We should only queue up pending sweep if we are doing partial collect
         Assert(recyclerSweep.GetPendingSweepBlockList(this) == nullptr);
+#endif
 
         // Every thing is swept immediately in non partial collect, so we can allocate
         // from the heap block list now

--- a/Lib/Common/Memory/HeapInfo.h
+++ b/Lib/Common/Memory/HeapInfo.h
@@ -64,8 +64,8 @@ public:
     void ScanInitialImplicitRoots();
     void ScanNewImplicitRoots();
 
-#if defined(PARTIAL_GC_ENABLED) || defined(CONCURRENT_GC_ENABLED)
     size_t Rescan(RescanFlags flags);
+#if ENABLE_PARTIAL_GC || ENABLE_CONCURRENT_GC
     void SweepPendingObjects(RecyclerSweep& recyclerSweep);
 #endif
     void Sweep(RecyclerSweep& recyclerSweep, bool concurrent);
@@ -76,17 +76,17 @@ public:
     template <ObjectInfoBits attributes>
     void FreeMediumObject(void* object, size_t bytes);
 
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     void SweepPartialReusePages(RecyclerSweep& recyclerSweep);
     void FinishPartialCollect(RecyclerSweep * recyclerSweep);
 #endif
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     void PrepareSweep();
 
     void TransferPendingHeapBlocks(RecyclerSweep& recyclerSweep);
     void ConcurrentTransferSweptObjects(RecyclerSweep& recyclerSweep);
 
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     void ConcurrentPartialTransferSweptObjects(RecyclerSweep& recyclerSweep);
 #endif
 #endif
@@ -192,7 +192,7 @@ private:
         heapBlock->SetNextBlock(list);
         list = heapBlock;
     }
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     template <typename TBlockType> TBlockType *& GetNewHeapBlockList(HeapBucketT<TBlockType> * heapBucket);
     template <>
     SmallLeafHeapBlock *& GetNewHeapBlockList<SmallLeafHeapBlock>(HeapBucketT<SmallLeafHeapBlock> * heapBucket)
@@ -261,15 +261,16 @@ private:
 #endif
 
     void SetupBackgroundSweep(RecyclerSweep& recyclerSweep);
-    template<bool pageheap>
-    void SweepSmallNonFinalizable(RecyclerSweep& recyclerSweep);
-    void SweepLargeNonFinalizable(RecyclerSweep& recyclerSweep);
 #else
     template <typename TBlockType> TBlockType *& GetNewHeapBlockList(HeapBucketT<TBlockType> * heapBucket)
     {
         return heapBucket->heapBlockList;
     }
 #endif
+ 
+    template<bool pageheap>
+    void SweepSmallNonFinalizable(RecyclerSweep& recyclerSweep);
+    void SweepLargeNonFinalizable(RecyclerSweep& recyclerSweep);
 
 #if DBG || defined(RECYCLER_SLOW_CHECK_ENABLED)
     size_t GetSmallHeapBlockCount(bool checkCount = false) const;
@@ -389,14 +390,14 @@ private:
     size_t lastUncollectedAllocBytes;
     size_t uncollectedExternalBytes;
     uint pendingZeroPageCount;
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     size_t uncollectedNewPageCount;
     size_t unusedPartialCollectFreeBytes;
 #endif
 
     Recycler * recycler;
 
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     SmallLeafHeapBlock * newLeafHeapBlockList;
     SmallNormalHeapBlock * newNormalHeapBlockList;
     SmallFinalizableHeapBlock * newFinalizableHeapBlockList;
@@ -407,7 +408,7 @@ private:
 #endif
 #endif
 
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     MediumLeafHeapBlock * newMediumLeafHeapBlockList;
     MediumNormalHeapBlock * newMediumNormalHeapBlockList;
     MediumFinalizableHeapBlock * newMediumFinalizableHeapBlockList;

--- a/Lib/Common/Memory/LargeHeapBlock.cpp
+++ b/Lib/Common/Memory/LargeHeapBlock.cpp
@@ -179,7 +179,9 @@ LargeHeapBlock::LargeHeapBlock(__in char * address, size_t pageCount, Segment * 
 
     this->address = address;
     this->segment = segment;
+#if ENABLE_CONCURRENT_GC
     this->isPendingConcurrentSweep = false;
+#endif
     this->addressEnd = this->address + this->pageCount * AutoSystemInfo::PageSize;
 
     RECYCLER_PERF_COUNTER_INC(LargeHeapBlockCount);
@@ -485,7 +487,7 @@ LargeHeapBlock::Alloc(size_t size, ObjectInfoBits attributes)
     AssertMsg((attributes & TrackBit) == 0, "Large tracked object collection not implemented");
 
     LargeObjectHeader * header = (LargeObjectHeader *)allocAddressEnd;
-#if defined(PARTIAL_GC_ENABLED) && defined(CONCURRENT_GC_ENABLED)
+#if ENABLE_PARTIAL_GC && ENABLE_CONCURRENT_GC
     Assert(!IsPartialSweptHeader(header));
 #endif
     char * allocObject = allocAddressEnd + sizeof(LargeObjectHeader);       // shouldn't overflow
@@ -669,7 +671,9 @@ LargeHeapBlock::ResetMarks(ResetMarkFlags flags, Recycler* recycler)
 
     Assert(this->GetMarkCount() == 0);
 
+#if ENABLE_CONCURRENT_GC
     Assert(!this->isPendingConcurrentSweep);
+#endif
 
     if (flags & ResetMarkFlags_ScanImplicitRoot)
     {
@@ -712,7 +716,11 @@ LargeHeapBlock::GetRealAddressFromInterior(void * interiorAddress)
     {
         LargeObjectHeader * header = this->HeaderList()[i];
 
+#if ENABLE_PARTIAL_GC && ENABLE_CONCURRENT_GC
         if (header != nullptr && !IsPartialSweptHeader(header))
+#else
+        if (header != nullptr)
+#endif
         {
             Assert(header->objectIndex == i);
             byte * startAddress = (byte *)header->GetAddress();
@@ -890,9 +898,13 @@ LargeHeapBlock::ScanNewImplicitRoots(Recycler * recycler)
     }
 }
 
-#if defined(PARTIAL_GC_ENABLED) || defined(CONCURRENT_GC_ENABLED)
+#if ENABLE_CONCURRENT_GC
 bool
 LargeHeapBlock::RescanOnePage(Recycler * recycler, DWORD const writeWatchFlags)
+#else
+bool
+LargeHeapBlock::RescanOnePage(Recycler * recycler)
+#endif
 {
     Assert(this->GetPageCount() == 1);
     bool const oldNeedOOMRescan = this->needOOMRescan;
@@ -900,6 +912,7 @@ LargeHeapBlock::RescanOnePage(Recycler * recycler, DWORD const writeWatchFlags)
     // Reset this, we'll increment this if we OOM again
     this->needOOMRescan = false;
 
+#if ENABLE_CONCURRENT_GC
     // don't need to get the write watch bit if we already need to oom rescan
     if (!oldNeedOOMRescan)
     {
@@ -918,6 +931,10 @@ LargeHeapBlock::RescanOnePage(Recycler * recycler, DWORD const writeWatchFlags)
             return false;
         }
     }
+#else
+    // Shouldn't be rescanning in cases other than OOM if GetWriteWatch 
+    Assert(oldNeedOOMRescan);
+#endif
 
     RECYCLER_STATS_INC(recycler, markData.rescanLargePageCount);
 
@@ -976,14 +993,21 @@ LargeHeapBlock::Rescan(Recycler * recycler, bool isPartialSwept, RescanFlags fla
     // Update the lastCollectAllocCount for sweep
     this->lastCollectAllocCount = this->allocCount;
 
+#if ENABLE_CONCURRENT_GC
     Assert(recycler->collectionState != CollectionStateConcurrentFinishMark || (flags & RescanFlags_ResetWriteWatch));
 
     DWORD const writeWatchFlags = (flags & RescanFlags_ResetWriteWatch? WRITE_WATCH_FLAG_RESET : 0);
+#endif
     if (this->GetPageCount() == 1)
     {
+#if ENABLE_CONCURRENT_GC
         return RescanOnePage(recycler, writeWatchFlags);
+#else
+        return RescanOnePage(recycler);
+#endif
     }
 
+#if ENABLE_CONCURRENT_GC
     // Need to rescan for finish mark even if it is done on the background thread
     if (recycler->collectionState != CollectionStateConcurrentFinishMark && recycler->IsConcurrentMarkState())
     {
@@ -991,12 +1015,22 @@ LargeHeapBlock::Rescan(Recycler * recycler, bool isPartialSwept, RescanFlags fla
         // we don't track which page we have queued up
         return 0;
     }
+#endif
 
+#if ENABLE_CONCURRENT_GC
     return RescanMultiPage(recycler, writeWatchFlags);
+#else
+    return RescanMultiPage(recycler);
+#endif
 }
 
+#if ENABLE_CONCURRENT_GC
 size_t
 LargeHeapBlock::RescanMultiPage(Recycler * recycler, DWORD const writeWatchFlags)
+#else
+size_t
+LargeHeapBlock::RescanMultiPage(Recycler * recycler)
+#endif
 {
     Assert(this->GetPageCount() != 1);
     DebugOnly(bool oldNeedOOMRescan = this->needOOMRescan);
@@ -1005,10 +1039,12 @@ LargeHeapBlock::RescanMultiPage(Recycler * recycler, DWORD const writeWatchFlags
     this->needOOMRescan = false;
 
     size_t rescanCount = 0;
-    DWORD pageSize = AutoSystemInfo::PageSize;
     uint objectIndex = 0;
+#if ENABLE_CONCURRENT_GC
+    DWORD pageSize = AutoSystemInfo::PageSize;
     char * lastPageCheckedForWriteWatch = nullptr;
     bool isLastPageCheckedForWriteWatchDirty = false;
+#endif
 
     const HeapBlockMap& heapBlockMap = recycler->heapBlockMap;
 
@@ -1084,6 +1120,7 @@ LargeHeapBlock::RescanMultiPage(Recycler * recycler, DWORD const writeWatchFlags
             objectScanned = true;
 #endif
         }
+#if ENABLE_CONCURRENT_GC
         else if (!recycler->inEndMarkOnLowMemory)
         {
             char * objectAddressEnd = objectAddress + header->objectSize;
@@ -1146,12 +1183,17 @@ LargeHeapBlock::RescanMultiPage(Recycler * recycler, DWORD const writeWatchFlags
             }
             while (objectAddress < objectAddressEnd);
         }
+#else
+        else
+        {
+            Assert(recycler->inEndMarkOnLowMemory);
+        }
+#endif
         RECYCLER_STATS_ADD(recycler, markData.rescanLargeObjectCount, objectScanned);
     }
 
     return rescanCount;
 }
-#endif
 
 /*
 * Sweep the large heap block
@@ -1191,7 +1233,9 @@ LargeHeapBlock::Sweep(RecyclerSweep& recyclerSweep, bool queuePendingSweep)
     this->expectedSweepCount = allocCount - markCount;
 #endif
 
+#if ENABLE_CONCURRENT_GC
     Assert(!this->isPendingConcurrentSweep);
+#endif
 
     bool isAllFreed = (finalizeCount == 0 && markCount == 0);
     if (isAllFreed)
@@ -1223,7 +1267,7 @@ LargeHeapBlock::Sweep(RecyclerSweep& recyclerSweep, bool queuePendingSweep)
         // in other script during concurrent sweep or finalizer called before.
 
         Assert(!recyclerSweep.IsBackground());
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
         if (queuePendingSweep && finalizeCount == 0)
         {
             this->isPendingConcurrentSweep = true;
@@ -1412,7 +1456,7 @@ LargeHeapBlock::FinalizeObject(Recycler* recycler, LargeObjectHeader* header)
 // Explicitly instantiate all the sweep modes
 template void LargeHeapBlock::SweepObjects<false, SweepMode_InThread>(Recycler * recycler);
 template void LargeHeapBlock::SweepObjects<true, SweepMode_InThread>(Recycler * recycler);
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
 template <>
 void
 LargeHeapBlock::SweepObject<SweepMode_Concurrent>(Recycler * recycler, LargeObjectHeader * header)
@@ -1425,7 +1469,7 @@ LargeHeapBlock::SweepObject<SweepMode_Concurrent>(Recycler * recycler, LargeObje
 
 // Explicitly instantiate all the sweep modes
 template void LargeHeapBlock::SweepObjects<false, SweepMode_Concurrent>(Recycler * recycler);
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
 template <>
 void
 LargeHeapBlock::SweepObject<SweepMode_ConcurrentPartial>(Recycler * recycler, LargeObjectHeader * header)
@@ -1482,14 +1526,18 @@ template <bool pageheap, SweepMode mode>
 void
 LargeHeapBlock::SweepObjects(Recycler * recycler)
 {
+#if ENABLE_CONCURRENT_GC
     Assert(mode == SweepMode_InThread || this->isPendingConcurrentSweep);
+#else
+    Assert(mode == SweepMode_InThread);
+#endif
 
     const HeapBlockMap& heapBlockMap = recycler->heapBlockMap;
 #if DBG
     uint markCount = GetMarkCount();
 
     // mark count included newly allocated objects
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     Assert(expectedSweepCount == allocCount - markCount || recycler->collectionState == CollectionStateConcurrentSweep);
 #else
     Assert(expectedSweepCount == allocCount - markCount);
@@ -1553,7 +1601,9 @@ LargeHeapBlock::SweepObjects(Recycler * recycler)
     }
 
     Assert(sweepCount == expectedSweepCount);
+#if ENABLE_CONCURRENT_GC
     this->isPendingConcurrentSweep = false;
+#endif
 }
 
 bool
@@ -1608,7 +1658,7 @@ LargeHeapBlock::DisposeObjects(Recycler * recycler)
     }
 }
 
-#if defined(PARTIAL_GC_ENABLED) && defined(CONCURRENT_GC_ENABLED)
+#if ENABLE_PARTIAL_GC && ENABLE_CONCURRENT_GC
 void
 LargeHeapBlock::PartialTransferSweptObjects()
 {
@@ -1675,7 +1725,7 @@ LargeHeapBlock::Check(bool expectFull, bool expectPending)
         {
             continue;
         }
-#if defined(PARTIAL_GC_ENABLED) && defined(CONCURRENT_GC_ENABLED)
+#if ENABLE_PARTIAL_GC && ENABLE_CONCURRENT_GC
         header = (LargeObjectHeader *)((size_t)header & ~PartialFreeBit);
         Assert(this->hasPartialFreeObjects || header == this->HeaderList()[i]);
 #endif

--- a/Lib/Common/Memory/LargeHeapBlock.h
+++ b/Lib/Common/Memory/LargeHeapBlock.h
@@ -118,10 +118,8 @@ public:
 
     ~LargeHeapBlock();
 
-#if defined(PARTIAL_GC_ENABLED) || defined(CONCURRENT_GC_ENABLED)
     size_t Rescan(Recycler* recycler, bool isPartialSwept, RescanFlags flags);
-#endif
-#if defined(PARTIAL_GC_ENABLED) && defined(CONCURRENT_GC_ENABLED)
+#if ENABLE_PARTIAL_GC && ENABLE_CONCURRENT_GC
     void PartialTransferSweptObjects();
     void FinishPartialCollect(Recycler * recycler);
 #endif
@@ -187,7 +185,7 @@ private:
     {
         Assert(index < this->allocCount);
         LargeObjectHeader * header = this->HeaderList()[index];
-#if defined(PARTIAL_GC_ENABLED) && defined(CONCURRENT_GC_ENABLED)
+#if ENABLE_PARTIAL_GC && ENABLE_CONCURRENT_GC
         if (IsPartialSweptHeader(header))
         {
             return nullptr;
@@ -202,9 +200,12 @@ private:
     static size_t GetAllocPlusSize(uint objectCount);
     char * AllocFreeListEntry(size_t size, ObjectInfoBits attributes, LargeHeapBlockFreeListEntry* entry);
 
-#if defined(PARTIAL_GC_ENABLED) || defined(CONCURRENT_GC_ENABLED)
+#if ENABLE_CONCURRENT_GC
     bool RescanOnePage(Recycler * recycler, DWORD const writeWatchFlags);
     size_t RescanMultiPage(Recycler * recycler, DWORD const writeWatchFlags);
+#else
+    bool RescanOnePage(Recycler * recycler);
+    size_t RescanMultiPage(Recycler * recycler);
 #endif
 
     template <SweepMode>
@@ -215,7 +216,7 @@ private:
     void FinalizeObject(Recycler* recycler, LargeObjectHeader* header);
 
     void FillFreeMemory(Recycler * recycler, __in_bcount(size) void * address, size_t size);
-#if defined(PARTIAL_GC_ENABLED) && defined(CONCURRENT_GC_ENABLED)
+#if ENABLE_PARTIAL_GC && ENABLE_CONCURRENT_GC
     bool IsPartialSweptHeader(LargeObjectHeader * header) const
     {
         Assert(this->hasPartialFreeObjects || (((size_t)header & PartialFreeBit) != PartialFreeBit));

--- a/Lib/Common/Memory/LargeHeapBucket.h
+++ b/Lib/Common/Memory/LargeHeapBucket.h
@@ -25,11 +25,11 @@ public:
         largePageHeapBlockList(nullptr),
 #endif
         pendingDisposeLargeBlockList(nullptr)
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
         , pendingSweepLargeBlockList(nullptr)
-#endif
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
         , partialSweptLargeBlockList(nullptr)
+#endif
 #endif
     {
     }
@@ -69,16 +69,16 @@ public:
     void VerifyMark();
     void VerifyLargeHeapBlockCount();
 
-#if defined(PARTIAL_GC_ENABLED) || defined(CONCURRENT_GC_ENABLED)
     size_t Rescan(RescanFlags flags);
+#if ENABLE_PARTIAL_GC || ENABLE_CONCURRENT_GC
     void SweepPendingObjects(RecyclerSweep& recyclerSweep);
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     void FinishPartialCollect(RecyclerSweep * recyclerSweep);
 #endif
 
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     void ConcurrentTransferSweptObjects(RecyclerSweep& recyclerSweep);
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     void ConcurrentPartialTransferSweptObjects(RecyclerSweep& recyclerSweep);
 #endif
 #endif
@@ -108,9 +108,7 @@ private:
 
     void ConstructFreelist(LargeHeapBlock * heapBlock);
 
-#if defined(PARTIAL_GC_ENABLED) || defined(CONCURRENT_GC_ENABLED)
     size_t Rescan(LargeHeapBlock * list, Recycler * recycler, bool isPartialSwept, RescanFlags flags);
-#endif
 
     LargeHeapBlock * fullLargeBlockList;
     LargeHeapBlock * largeBlockList;
@@ -118,9 +116,10 @@ private:
     LargeHeapBlock * largePageHeapBlockList;
 #endif
     LargeHeapBlock * pendingDisposeLargeBlockList;
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     LargeHeapBlock * pendingSweepLargeBlockList;
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
+    // Used for concurrent-partial GC
     LargeHeapBlock * partialSweptLargeBlockList;
 #endif
 #endif

--- a/Lib/Common/Memory/LargeHeapBucket.inl
+++ b/Lib/Common/Memory/LargeHeapBucket.inl
@@ -81,9 +81,9 @@ LargeHeapBucket::ForEachLargeHeapBlock(Fn fn)
     HeapBlockList::ForEach(largePageHeapBlockList, fn);
 #endif
     HeapBlockList::ForEach(pendingDisposeLargeBlockList, fn);
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     HeapBlockList::ForEach(pendingSweepLargeBlockList, fn);
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     HeapBlockList::ForEach(partialSweptLargeBlockList, fn);
 #endif
 #endif
@@ -99,9 +99,9 @@ LargeHeapBucket::ForEachEditingLargeHeapBlock(Fn fn)
     HeapBlockList::ForEachEditing(largePageHeapBlockList, fn);
 #endif
     HeapBlockList::ForEachEditing(pendingDisposeLargeBlockList, fn);
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     HeapBlockList::ForEachEditing(pendingSweepLargeBlockList, fn);
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     HeapBlockList::ForEachEditing(partialSweptLargeBlockList, fn);
 #endif
 #endif

--- a/Lib/Common/Memory/MarkContext.h
+++ b/Lib/Common/Memory/MarkContext.h
@@ -29,7 +29,9 @@ public:
     Recycler * GetRecycler() { return this->recycler; }
 
     bool AddMarkedObject(void * obj, size_t byteCount);
+#if ENABLE_CONCURRENT_GC
     bool AddTrackedObject(FinalizableObject * obj);
+#endif
 
     template <bool parallel, bool interior>
     void Mark(void * candidate, void * parentReference);

--- a/Lib/Common/Memory/Recycler.cpp
+++ b/Lib/Common/Memory/Recycler.cpp
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "CommonMemoryPch.h"
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
 #include <process.h>
 #endif
 
@@ -139,7 +139,9 @@ Recycler::Recycler(AllocationPolicyManager * policyManager, IdleDecommitPageAllo
     parallelMarkContext1(this, &this->parallelMarkPagePool1),
     parallelMarkContext2(this, &this->parallelMarkPagePool2),
     parallelMarkContext3(this, &this->parallelMarkPagePool3),
+#if ENABLE_PARTIAL_GC
     clientTrackedObjectAllocator(L"CTO-List", GetPageAllocator(), Js::Throw::OutOfMemory),
+#endif
     outOfMemoryFunc(outOfMemoryFunc),
 #ifdef RECYCLER_TEST_SUPPORT
     checkFn(NULL),
@@ -151,7 +153,9 @@ Recycler::Recycler(AllocationPolicyManager * policyManager, IdleDecommitPageAllo
     enableScanInteriorPointers(CUSTOM_CONFIG_FLAG(configFlagsTable, RecyclerForceMarkInterior)),
     enableScanImplicitRoots(false),
     disableCollectOnAllocationHeuristics(false),
-#ifdef CONCURRENT_GC_ENABLED
+    skipStack(false),
+    mainThreadHandle(NULL),
+#if ENABLE_CONCURRENT_GC
     backgroundFinishMarkCount(0),
     hasPendingUnpinnedObject(false),
     hasPendingConcurrentFindRoot(false),
@@ -162,31 +166,33 @@ Recycler::Recycler(AllocationPolicyManager * policyManager, IdleDecommitPageAllo
     concurrentThread(NULL),
     concurrentWorkReadyEvent(NULL),
     concurrentWorkDoneEvent(NULL),
-    mainThreadHandle(NULL),
     parallelThread1(this, &Recycler::ParallelWorkFunc<0>),
     parallelThread2(this, &Recycler::ParallelWorkFunc<1>),
     priorityBoost(false),
-    skipStack(false),
     isAborting(false),
 #if DBG
     concurrentThreadExited(true),
     isProcessingTrackedObjects(false),
-    hasIncompletedDoCollect(false),
+    hasIncompleteDoCollect(false),
     isConcurrentGCOnIdle(false),
     isFinishGCOnIdle(false),
-    isExternalStackSkippingGC(false),
-    isProcessingRescan(false),
 #endif
 #ifdef IDLE_DECOMMIT_ENABLED
     concurrentIdleDecommitEvent(nullptr),
 #endif
 #endif
-#ifdef PARTIAL_GC_ENABLED
+#if DBG
+    isExternalStackSkippingGC(false),
+    isProcessingRescan(false),
+#endif
+#if ENABLE_PARTIAL_GC
     inPartialCollectMode(false),
     scanPinnedObjectMap(false),
     partialUncollectedAllocBytes(0),
     uncollectedNewPageCountPartialCollect((size_t)-1),
+#if ENABLE_CONCURRENT_GC
     partialConcurrentNextCollection(false),
+#endif
 #ifdef RECYCLER_STRESS
     forcePartialScanStack(false),
 #endif
@@ -212,7 +218,9 @@ Recycler::Recycler(AllocationPolicyManager * policyManager, IdleDecommitPageAllo
     inCacheCleanupCollection(false),
     hasPendingDeleteGuestArena(false),
     needOOMRescan(false),
+#if ENABLE_CONCURRENT_GC && ENABLE_PARTIAL_GC
     hasBackgroundFinishPartial(false),
+#endif
     decommitOnFinish(false)
 #ifdef PROFILE_EXEC
     , profiler(nullptr)
@@ -275,7 +283,9 @@ Recycler::Recycler(AllocationPolicyManager * policyManager, IdleDecommitPageAllo
     this->heapBlockCount = 0;
     this->collectionCount = 0;
     this->disableThreadAccessCheck = false;
+#if ENABLE_CONCURRENT_GC
     this->disableConcurrentThreadExitedCheck = false;
+#endif
 #endif
 #if DBG || defined RECYCLER_TRACE
     this->inResolveExternalWeakReferences = false;
@@ -348,12 +358,12 @@ Recycler::SetMemProtectMode()
     this->disableCollectOnAllocationHeuristics = true;
 #ifdef RECYCLER_STRESS
     this->recyclerStress = GetRecyclerFlagsTable().MemProtectHeapStress;
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     this->recyclerBackgroundStress = GetRecyclerFlagsTable().MemProtectHeapBackgroundStress;
     this->recyclerConcurrentStress = GetRecyclerFlagsTable().MemProtectHeapConcurrentStress;
     this->recyclerConcurrentRepeatStress = GetRecyclerFlagsTable().MemProtectHeapConcurrentRepeatStress;
 #endif
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     this->recyclerPartialStress = GetRecyclerFlagsTable().MemProtectHeapPartialStress;
 #endif
 #endif
@@ -399,15 +409,17 @@ Recycler::LogMemProtectHeapSize(bool fromGC)
 void
 Recycler::SetDisableConcurrentThreadExitedCheck()
 {
+#if ENABLE_CONCURRENT_GC
     disableConcurrentThreadExitedCheck = true;
+#endif
 #ifdef RECYCLER_STRESS
     this->recyclerStress = false;
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     this->recyclerBackgroundStress = false;
     this->recyclerConcurrentStress = false;
     this->recyclerConcurrentRepeatStress = false;
 #endif
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     this->recyclerPartialStress = false;
 #endif
 #endif
@@ -420,7 +432,7 @@ Recycler::ResetThreadId()
 {
     // Transfer all the page allocator to the current thread id
     ForRecyclerPageAllocator(ClearConcurrentThreadId());
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     if (this->IsConcurrentEnabled())
     {
         markContext.GetPageAllocator()->ClearConcurrentThreadId();
@@ -434,7 +446,9 @@ Recycler::ResetThreadId()
 
 Recycler::~Recycler()
 {
+#if ENABLE_CONCURRENT_GC
     Assert(!this->isAborting);
+#endif
 
     // Stop any further collection
     this->isShuttingDown = true;
@@ -471,7 +485,7 @@ Recycler::~Recycler()
 
     AUTO_LEAK_REPORT_SECTION(this->GetRecyclerFlagsTable(), L"Skipped finalizers");
 
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     Assert(concurrentThread == nullptr);
 
     // We only sometime clean up the state after abort concurrent to not collection
@@ -518,7 +532,7 @@ Recycler::~Recycler()
         return false;
     });
 
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     clientTrackedObjectList.Clear(&this->clientTrackedObjectAllocator);
 #endif
 
@@ -545,7 +559,7 @@ Recycler::~Recycler()
     ForRecyclerPageAllocator(ShutdownIdleDecommit());
 #endif
     Assert(this->collectionState == CollectionStateExit || this->collectionState == CollectionStateNotCollecting);
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     Assert(this->disableConcurrentThreadExitedCheck || this->concurrentThreadExited == true);
 #endif
 }
@@ -656,6 +670,7 @@ Recycler::RootRelease(void* obj, uint *count)
         StackBackTraceNode::DeleteAll(&NoCheckHeapAllocator::Instance, refCount->stackBackTraces);
         refCount->stackBackTraces = nullptr;
 #endif
+#if ENABLE_CONCURRENT_GC
         // Don't delete the entry if we are in concurrent find root state
         // We will delete it later on in-thread find root
         if (this->hasPendingConcurrentFindRoot)
@@ -663,6 +678,7 @@ Recycler::RootRelease(void* obj, uint *count)
             this->hasPendingUnpinnedObject = true;
         }
         else
+#endif
         {
             pinnedObjectMap.Remove(obj);
         }
@@ -691,11 +707,11 @@ Recycler::Initialize(const bool forceInThread, JsUtil::ThreadService *threadServ
 #ifdef ENABLE_DEBUG_CONFIG_OPTIONS
     this->disableCollection = CUSTOM_PHASE_OFF1(GetRecyclerFlagsTable(), Js::RecyclerPhase);
 #endif
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     this->skipStack = false;
 #endif
 
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
 #if ENABLE_DEBUG_CONFIG_OPTIONS
     this->enablePartialCollect = !CUSTOM_PHASE_OFF1(GetRecyclerFlagsTable(), Js::PartialCollectPhase);
 #else
@@ -774,27 +790,29 @@ Recycler::Initialize(const bool forceInThread, JsUtil::ThreadService *threadServ
 #endif
 
 #ifdef RECYCLER_STRESS
+#if ENABLE_PARTIAL_GC
     if (GetRecyclerFlagsTable().RecyclerTrackStress)
     {
         // Disable partial if we are doing track stress, since partial relies on ClientTracked processing
         // and track stress doesn't support this.
         this->enablePartialCollect = false;
     }
+#endif
 
     this->recyclerStress = GetRecyclerFlagsTable().RecyclerStress;
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     this->recyclerBackgroundStress = GetRecyclerFlagsTable().RecyclerBackgroundStress;
     this->recyclerConcurrentStress = GetRecyclerFlagsTable().RecyclerConcurrentStress;
     this->recyclerConcurrentRepeatStress = GetRecyclerFlagsTable().RecyclerConcurrentRepeatStress;
 #endif
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     this->recyclerPartialStress = GetRecyclerFlagsTable().RecyclerPartialStress;
 #endif
 #endif
 
     bool needWriteWatch = false;
 
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     // Default to non-concurrent
     uint numProcs = (uint)AutoSystemInfo::Data.GetNumberOfPhysicalProcessors();
     this->maxParallelism = (numProcs > 4) || CUSTOM_PHASE_FORCE1(GetRecyclerFlagsTable(), Js::ParallelMarkPhase) ? 4 : numProcs;
@@ -829,19 +847,23 @@ Recycler::Initialize(const bool forceInThread, JsUtil::ThreadService *threadServ
     }
 #endif
 
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     if (this->enablePartialCollect)
     {
         needWriteWatch = true;
     }
 #endif
 
+#if ENABLE_CONCURRENT_GC
     if (needWriteWatch)
     {
         // need write watch to support concurrent and/or partial collection
         recyclerPageAllocator.EnableWriteWatch();
         recyclerLargeBlockPageAllocator.EnableWriteWatch();
     }
+#else
+    Assert(!needWriteWatch);
+#endif
 }
 
 #if DBG
@@ -1048,8 +1070,12 @@ bool Recycler::ExplicitFreeInternal(void* buffer, size_t size, size_t sizeCat)
         return false;
     }
 
+#if ENABLE_CONCURRENT_GC
     // We shouldn't be freeing object when we are running GC in thread
     Assert(this->IsConcurrentState() || !this->CollectionInProgress() || this->collectionState == CollectionStatePostCollectionCallback);
+#else
+    Assert(!this->CollectionInProgress() || this->collectionState == CollectionStatePostCollectionCallback);
+#endif
 
     DebugOnly(RecyclerHeapObjectInfo info);
     Assert(this->FindHeapObject(buffer, FindHeapObjectFlags_NoFreeBitVerify, info));
@@ -1343,7 +1369,7 @@ Recycler::ScanArena(ArenaData * alloc, bool background)
     size_t scanRootBytes = 0;
     BEGIN_DUMP_OBJECT_ADDRESS(L"Guest Arena", alloc);
 
-#if defined(PARTIAL_GC_ENABLED) || defined(CONCURRENT_GC_ENABLED)
+#if ENABLE_PARTIAL_GC || ENABLE_CONCURRENT_GC
 // The new write watch batching logic broke the write watch handling here.
 // For now, just disable write watch for guest arenas.
 // Re-enable this in the future.
@@ -1416,17 +1442,19 @@ Recycler::ExpectStackSkip() const
 size_t
 Recycler::ScanStack()
 {
-#ifdef CONCURRENT_GC_ENABLED
     if (this->skipStack)
     {
 #ifdef RECYCLER_TRACE
         CUSTOM_PHASE_PRINT_VERBOSE_TRACE1(GetRecyclerFlagsTable(), Js::ScanStackPhase, L"[%04X] Skipping the stack scan\n", ::GetCurrentThreadId());
 #endif
 
+#if ENABLE_CONCURRENT_GC
         Assert(this->isFinishGCOnIdle || this->isConcurrentGCOnIdle || this->ExpectStackSkip());
+#else
+        Assert(this->ExpectStackSkip());
+#endif
         return 0;
     }
-#endif
 
 #ifdef RECYCLER_STATS
     size_t lastMarkCount = this->collectionStats.markData.markCount;
@@ -1558,7 +1586,7 @@ Recycler::FindRoots()
     // Do this first because the host might unpin stuff in the process
     if (externalRootMarker != NULL)
     {
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
         if (!this->inPartialCollectMode)
 #endif
         {
@@ -1610,12 +1638,15 @@ Recycler::FindRoots()
     }
 #endif
 
+#if ENABLE_CONCURRENT_GC
     Assert(!this->hasPendingConcurrentFindRoot);
+#endif
     RECYCLER_PROFILE_EXEC_BEGIN(this, Js::FindRootArenaPhase);
     DListBase<GuestArenaAllocator>::EditingIterator guestArenaIter(&guestArenaList);
     while (guestArenaIter.Next())
     {
         GuestArenaAllocator& allocator = guestArenaIter.Data();
+#if ENABLE_CONCURRENT_GC
         if (allocator.pendingDelete)
         {
             Assert(this->hasPendingDeleteGuestArena);
@@ -1624,8 +1655,10 @@ Recycler::FindRoots()
             guestArenaIter.RemoveCurrent(&HeapAllocator::Instance);
         }
         else if (this->backgroundFinishMarkCount == 0)
+#endif
         {
             // Only scan arena if we haven't finished mark in the background
+            // (which is true if concurrent GC is disabled)
             scanRootBytes += ScanArena(&allocator, false);
         }
     }
@@ -1681,6 +1714,7 @@ Recycler::TryMarkArenaMemoryBlockList(ArenaMemoryBlock * memoryBlocks)
     return scanRootBytes;
 }
 
+#if ENABLE_CONCURRENT_GC
 size_t
 Recycler::TryMarkBigBlockListWithWriteWatch(BigBlock * memoryBlocks)
 {
@@ -1714,6 +1748,7 @@ Recycler::TryMarkBigBlockListWithWriteWatch(BigBlock * memoryBlocks)
     }
     return scanRootBytes;
 }
+#endif
 
 size_t
 Recycler::TryMarkBigBlockList(BigBlock * memoryBlocks)
@@ -1793,7 +1828,7 @@ Recycler::CheckAllocExternalMark() const
 {
     Assert(!disableThreadAccessCheck);
     Assert(GetCurrentThreadContextId() == mainThreadId);
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
   #ifdef HEAP_ENUMERATION_VALIDATION
     Assert((this->IsMarkState() || this->IsPostEnumHeapValidationInProgress()) && collectionState != CollectionStateConcurrentMark);
   #else
@@ -1834,6 +1869,7 @@ template <bool parallel, bool interior>
 void
 Recycler::ProcessMarkContext(MarkContext * markContext)
 {
+#if ENABLE_CONCURRENT_GC
     // Copying the markContext onto the stack messes up tracked object handling, because
     // the tracked object will call TryMark[Non]Interior to report its references.
     // These functions implicitly use the main markContext on the Recycler, but this will
@@ -1843,7 +1879,11 @@ Recycler::ProcessMarkContext(MarkContext * markContext)
     // In this case we shouldn't be parallel anyway, so we don't need to worry about cache behavior.
     // We should revisit how we manage markContexts in general in the future, and clean this up
     // by passing the MarkContext through to the tracked object's Mark method.
+#if ENABLE_PARTIAL_GC
     if (this->inPartialCollectMode || DoQueueTrackedObject())
+#else
+    if (DoQueueTrackedObject())
+#endif
     {
         // The markContext as passed is one of the markContexts that lives on the Recycler.
         // Copy it locally for processing.
@@ -1865,6 +1905,7 @@ Recycler::ProcessMarkContext(MarkContext * markContext)
         localMarkContext.Clear();
     }
     else
+#endif
     {
         Assert(!parallel);
         markContext->ProcessMark<parallel, interior>();
@@ -1953,14 +1994,16 @@ Recycler::Mark()
     RootMark(CollectionStateMark);
 }
 
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
 void
 Recycler::StartQueueTrackedObject()
 {
     Assert(!this->queueTrackedObject);
     Assert(!this->HasPendingTrackObjects());
+#if ENABLE_PARTIAL_GC
     Assert(this->clientTrackedObjectList.Empty());
     Assert(!this->inPartialCollectMode);
+#endif
     this->queueTrackedObject = true;
 }
 
@@ -1968,10 +2011,12 @@ bool
 Recycler::DoQueueTrackedObject() const
 {
     Assert(this->queueTrackedObject || !this->IsConcurrentMarkState());
-    Assert(this->queueTrackedObject || this->inPartialCollectMode || !(this->collectionState == CollectionStateParallelMark));
     Assert(this->queueTrackedObject || this->isProcessingTrackedObjects || !this->HasPendingTrackObjects());
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
+    Assert(this->queueTrackedObject || this->inPartialCollectMode || !(this->collectionState == CollectionStateParallelMark));
     Assert(!this->queueTrackedObject || (this->clientTrackedObjectList.Empty() && !this->inPartialCollectMode));
+#else
+    Assert(this->queueTrackedObject || !(this->collectionState == CollectionStateParallelMark));
 #endif
     return this->queueTrackedObject;
 }
@@ -1985,19 +2030,23 @@ Recycler::ResetCollectionState()
     Assert(IsMarkStackEmpty());
 
     this->collectionState = CollectionStateNotCollecting;
+#if ENABLE_CONCURRENT_GC
     this->backgroundFinishMarkCount = 0;
+#endif
     this->inExhaustiveCollection = false;
     this->inDecommitNowCollection = false;
 
+#if ENABLE_CONCURRENT_GC
     CleanupPendingUnroot();
+#endif
 
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     if (inPartialCollectMode)
     {
         FinishPartialCollect();
     }
 #endif
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     Assert(!this->DoQueueTrackedObject());
 #endif
 #ifdef RECYCLER_FINALIZE_CHECK
@@ -2022,7 +2071,7 @@ Recycler::ResetMarkCollectionState()
     this->ClearNeedOOMRescan();
     DebugOnly(this->isProcessingRescan = false);
 
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     // If we're reseting the mark collection state, we need to unlock the block list
     DListBase<GuestArenaAllocator>::EditingIterator guestArenaIter(&guestArenaList);
     while (guestArenaIter.Next())
@@ -2047,7 +2096,7 @@ Recycler::ResetHeuristicCounters()
 
 void Recycler::ResetPartialHeuristicCounters()
 {
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     autoHeap.uncollectedNewPageCount = 0;
 #endif
 }
@@ -2059,7 +2108,7 @@ Recycler::ScheduleNextCollection()
     this->tickCountNextFinishCollection = ::GetTickCount() + RecyclerHeuristic::TickCountFinishCollection;
 }
 
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
 void
 Recycler::PrepareSweep()
 {
@@ -2071,7 +2120,17 @@ size_t
 Recycler::RescanMark(DWORD waitTime)
 {
     bool const onLowMemory = this->NeedOOMRescan();
+    
+    // REVIEW: Why are we asserting for DoQueueTrackedObject here? 
+    // Should we split this into different asserts depending on whether
+    // concurrent or partial is enabled?
+#if ENABLE_CONCURRENT_GC
+#if ENABLE_PARTIAL_GC
     Assert(this->inPartialCollectMode || DoQueueTrackedObject());
+#else
+    Assert(DoQueueTrackedObject());
+#endif
+#endif
 
     {
         // We are about to do a rescan mark, which for consistency requires the runtime to stop any additional mutator threads
@@ -2081,7 +2140,7 @@ Recycler::RescanMark(DWORD waitTime)
 
     // Always called in-thread
     Assert(collectionState == CollectionStateRescanFindRoots);
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     if (!onLowMemory && // Don't do background finish mark if we are low on memory
         // Only do background finish mark if we have a time limit or it is forced
         (CUSTOM_PHASE_FORCE1(GetRecyclerFlagsTable(), Js::BackgroundFinishMarkPhase) || waitTime != INFINITE) &&
@@ -2117,11 +2176,12 @@ Recycler::RescanMark(DWORD waitTime)
         this->RevertPrepareBackgroundFindRoots();
     }
 #endif
+#if ENABLE_CONCURRENT_GC
     this->backgroundFinishMarkCount = 0;
+#endif
     return FinishMarkRescan(false) * AutoSystemInfo::PageSize;
 }
 
-#if defined(PARTIAL_GC_ENABLED) || defined(CONCURRENT_GC_ENABLED)
 size_t
 Recycler::FinishMark(DWORD waitTime)
 {
@@ -2129,11 +2189,11 @@ Recycler::FinishMark(DWORD waitTime)
     Assert(waitTime != INFINITE || scannedRootBytes != Recycler::InvalidScanRootBytes);
     if (scannedRootBytes != Recycler::InvalidScanRootBytes)
     {
-#if DBG
+#if DBG && ENABLE_PARTIAL_GC
         RecyclerVerboseTrace(GetRecyclerFlagsTable(), L"CTO: %d\n", this->clientTrackedObjectList.Count());
 #endif
 
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
         if (this->inPartialCollectMode)
         {
             RecyclerVerboseTrace(GetRecyclerFlagsTable(), L"Processing client tracked objects\n");
@@ -2141,6 +2201,7 @@ Recycler::FinishMark(DWORD waitTime)
         }
         else
 #endif
+#if ENABLE_CONCURRENT_GC
         if (DoQueueTrackedObject())
         {
             RecyclerVerboseTrace(GetRecyclerFlagsTable(), L"Processing regular tracked objects\n");
@@ -2150,14 +2211,15 @@ Recycler::FinishMark(DWORD waitTime)
                 (this->recyclerPageAllocator.GetWriteWatchPageCount() == 0 &&
                 this->recyclerLargeBlockPageAllocator.GetWriteWatchPageCount() == 0));
         }
+#endif
 
         // Continue to mark from root one more time
         scannedRootBytes += RootMark(CollectionStateRescanMark);
     }
     return scannedRootBytes;
 }
-#endif
 
+#if ENABLE_CONCURRENT_GC
 void
 Recycler::DoParallelMark()
 {
@@ -2180,7 +2242,9 @@ Recycler::DoParallelMark()
 
     // We need to queue tracked objects while we mark in parallel.
     // (Unless it's a partial collect, in which case we don't process tracked objects at all)
+#if ENABLE_PARTIAL_GC
     if (!this->inPartialCollectMode)
+#endif
     {
         StartQueueTrackedObject();
     }
@@ -2243,15 +2307,19 @@ Recycler::DoParallelMark()
 
     // Process tracked objects, if any, then do one final mark phase in case they marked any new objects.
     // (Unless it's a partial collect, in which case we don't process tracked objects at all)
+#if ENABLE_PARTIAL_GC
     if (!this->inPartialCollectMode)
+#endif
     {
         this->ProcessTrackedObjects();
         this->ProcessMark(false);
     }
+#if ENABLE_PARTIAL_GC
     else
     {
         Assert(!this->HasPendingTrackObjects());
     }
+#endif
 }
 
 
@@ -2281,8 +2349,12 @@ Recycler::DoBackgroundParallelMark()
         return;
     }
 
+#if ENABLE_PARTIAL_GC
     // We should already be set up to queue tracked objects, unless this is a partial collect
     Assert(this->DoQueueTrackedObject() || this->inPartialCollectMode);
+#else
+    Assert(this->DoQueueTrackedObject());
+#endif
 
     this->collectionState = CollectionStateBackgroundParallelMark;
 
@@ -2324,13 +2396,18 @@ Recycler::DoBackgroundParallelMark()
 
     this->collectionState = CollectionStateConcurrentMark;
 }
+#endif
 
 size_t
 Recycler::RootMark(CollectionState markState)
 {
     size_t scannedRootBytes = 0;
     Assert(!this->NeedOOMRescan() || markState == CollectionStateRescanMark);
+#if ENABLE_PARTIAL_GC
     RecyclerVerboseTrace(GetRecyclerFlagsTable(), L"PreMark done, partial collect: %d\n", this->inPartialCollectMode);
+#else
+    RecyclerVerboseTrace(GetRecyclerFlagsTable(), L"PreMark done, partial collect not available\n");
+#endif
 
     Assert(collectionState == (markState == CollectionStateMark? CollectionStateFindRoots : CollectionStateRescanFindRoots));
 
@@ -2352,19 +2429,25 @@ Recycler::RootMark(CollectionState markState)
 
     this->collectionState = markState;
 
+#if ENABLE_CONCURRENT_GC
     if (this->enableParallelMark)
     {
         this->DoParallelMark();
     }
     else
+#endif
     {
         this->ProcessMark(false);
     }
 
     if (this->EndMark())
     {
+        // REVIEW: This heuristic doesn't apply when partial is off so there's no need 
+        // to modify scannedRootBytes here, correct?
+#if ENABLE_PARTIAL_GC
         // return large root scanned byte to not get into partial mode if we are low on memory
         scannedRootBytes = RecyclerSweep::MaxPartialCollectRescanRootBytes + 1;
+#endif
     }
 
     return scannedRootBytes;
@@ -2402,8 +2485,12 @@ Recycler::EndMarkCheckOOMRescan()
 bool
 Recycler::EndMark()
 {
+#if ENABLE_CONCURRENT_GC
     Assert(!this->DoQueueTrackedObject());
+#endif
+#if ENABLE_PARTIAL_GC
     Assert(this->clientTrackedObjectList.Empty());
+#endif
 
     {
         // We have finished marking
@@ -2459,17 +2546,21 @@ Recycler::EndMarkOnLowMemory()
 
     do
     {
+#if ENABLE_PARTIAL_GC
         Assert(this->clientTrackedObjectList.Empty());
+#endif
 
+#if ENABLE_CONCURRENT_GC
         // Always queue tracked objects during rescan, to avoid changes to mark state.
         // (Unless we're in a partial, in which case we ignore tracked objects)
         Assert(!this->DoQueueTrackedObject());
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
         if (!this->inPartialCollectMode)
 #endif
         {
             this->StartQueueTrackedObject();
         }
+#endif
 
         this->collectionState = CollectionStateRescanFindRoots;
 
@@ -2496,13 +2587,15 @@ Recycler::EndMarkOnLowMemory()
 
         this->ProcessMark(false);
 
+#if ENABLE_CONCURRENT_GC
         // Process any tracked objects we found
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
         if (!this->inPartialCollectMode)
 #endif
         {
             ProcessTrackedObjects();
         }
+#endif
 
         // Drain the mark stack
         ProcessMark(false);
@@ -2519,10 +2612,14 @@ Recycler::EndMarkOnLowMemory()
     Assert(!parallelMarkContext3.GetPageAllocator()->DisableAllocationOutOfMemory());
     CUSTOM_PHASE_PRINT_TRACE1(GetRecyclerFlagsTable(), Js::RecyclerPhase, L"EndMarkOnLowMemory iterations: %d\n", iterations);
 
+#if ENABLE_PARTIAL_GC
     Assert(this->clientTrackedObjectList.Empty());
+#endif
+#if ENABLE_CONCURRENT_GC
     Assert(!this->DoQueueTrackedObject());
+#endif
     this->inEndMarkOnLowMemory = false;
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     if (this->inPartialCollectMode)
     {
         this->FinishPartialCollect();
@@ -2556,11 +2653,13 @@ Recycler::PostHeapEnumScan(PostHeapEnumScanCallback callback, void *data)
 }
 #endif
 
+#if ENABLE_CONCURRENT_GC
 bool
 Recycler::QueueTrackedObject(FinalizableObject * trackableObject)
 {
     return markContext.AddTrackedObject(trackableObject);
 }
+#endif
 
 bool
 Recycler::FindImplicitRootObject(void* candidate, RecyclerHeapObjectInfo& heapObject)
@@ -2615,12 +2714,19 @@ Recycler::GetRealAddressFromInterior(void* candidate)
  * Sweep
  *------------------------------------------------------------------------------------------------*/
 
+#if ENABLE_PARTIAL_GC
 bool
 Recycler::Sweep(size_t rescanRootBytes, bool concurrent, bool adjustPartialHeuristics)
+#else
+bool
+Recycler::Sweep(bool concurrent)
+#endif
 {
+#if ENABLE_PARTIAL_GC && ENABLE_CONCURRENT_GC
     Assert(!this->hasBackgroundFinishPartial);
+#endif
 
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     if (!this->enableConcurrentSweep)
 #endif
     {
@@ -2629,14 +2735,21 @@ Recycler::Sweep(size_t rescanRootBytes, bool concurrent, bool adjustPartialHeuri
 
     RECYCLER_PROFILE_EXEC_BEGIN(this, concurrent? Js::ConcurrentSweepPhase : Js::SweepPhase);
 
+#if ENABLE_PARTIAL_GC
     recyclerSweepInstance.BeginSweep(this, rescanRootBytes, adjustPartialHeuristics);
+#else
+    recyclerSweepInstance.BeginSweep(this);
+#endif
+
     this->SweepHeap(concurrent, *recyclerSweep);
+#if ENABLE_CONCURRENT_GC
     if (concurrent)
     {
         // If we finished mark in the background, all the relevant write watches should already be reset
         // Only reset write watch if we didn't finish mark in the background
         if (this->backgroundFinishMarkCount == 0)
         {
+#if ENABLE_PARTIAL_GC
             if (this->inPartialCollectMode)
             {
                 RECYCLER_PROFILE_EXEC_BEGIN(this, Js::ResetWriteWatchPhase);
@@ -2652,9 +2765,11 @@ Recycler::Sweep(size_t rescanRootBytes, bool concurrent, bool adjustPartialHeuri
                 }
                 RECYCLER_PROFILE_EXEC_END(this, Js::ResetWriteWatchPhase);
             }
+#endif
         }
     }
     else
+#endif
     {
         recyclerSweep->FinishSweep();
         recyclerSweep->EndSweep();
@@ -2662,7 +2777,7 @@ Recycler::Sweep(size_t rescanRootBytes, bool concurrent, bool adjustPartialHeuri
 
     RECYCLER_PROFILE_EXEC_END(this, concurrent? Js::ConcurrentSweepPhase : Js::SweepPhase);
 
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     if (concurrent)
     {
         if (!StartConcurrent(CollectionStateConcurrentSweep))
@@ -2742,7 +2857,7 @@ Recycler::SweepHeap(bool concurrent, RecyclerSweep& recyclerSweep)
     Assert(!this->hasPendingDeleteGuestArena);
     Assert(!this->isHeapEnumInProgress);
 
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     Assert(!this->DoQueueTrackedObject());
     if (concurrent)
     {
@@ -2764,7 +2879,7 @@ Recycler::SweepHeap(bool concurrent, RecyclerSweep& recyclerSweep)
 
     this->SweepWeakReference();
 
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     if (concurrent)
     {
         GCETW(GC_SETUPBACKGROUNDSWEEP_START, (this));
@@ -2786,7 +2901,7 @@ Recycler::SweepHeap(bool concurrent, RecyclerSweep& recyclerSweep)
     recyclerPageAllocator.ResumeIdleDecommit();
     recyclerLargeBlockPageAllocator.ResumeIdleDecommit();
 
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     if (concurrent)
     {
         recyclerPageAllocator.StopQueueZeroPage();
@@ -2815,6 +2930,7 @@ Recycler::SweepHeap(bool concurrent, RecyclerSweep& recyclerSweep)
 #endif
 }
 
+#if ENABLE_PARTIAL_GC && ENABLE_CONCURRENT_GC
 void
 Recycler::BackgroundFinishPartialCollect(RecyclerSweep * recyclerSweep)
 {
@@ -2824,6 +2940,7 @@ Recycler::BackgroundFinishPartialCollect(RecyclerSweep * recyclerSweep)
     this->autoHeap.FinishPartialCollect(recyclerSweep);
     this->inPartialCollectMode = false;
 }
+#endif
 
 void
 Recycler::DisposeObjects()
@@ -3004,7 +3121,7 @@ Recycler::FinishDisposeObjectsWrapped()
 BOOL
 Recycler::CollectOnAllocatorThread()
 {
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     Assert(!inPartialCollectMode);
 #endif
 #ifdef RECYCLER_TRACE
@@ -3093,7 +3210,7 @@ template <CollectionFlags flags>
 BOOL
 Recycler::GetPartialFlag()
 {
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
 #pragma prefast(suppress:6313, "flags is a template parameter and can be 0")
     return(flags & CollectMode_Partial) && inPartialCollectMode;
 #else
@@ -3142,7 +3259,7 @@ Recycler::CollectInternal()
     CaptureCollectionParam(flags);
 #endif
 
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     const BOOL concurrent = flags & CollectMode_Concurrent;
     const BOOL finishConcurrent = flags & CollectOverride_FinishConcurrent;
 
@@ -3177,7 +3294,7 @@ Recycler::CollectWithHeuristic()
     const BOOL timedIfInScript = flags & CollectHeuristic_TimeIfInScript;
     const BOOL timed = (timedIfScriptActive && isScriptActive) || (timedIfInScript && isInScript) || (flags & CollectHeuristic_Time);
 
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     if (GetPartialFlag<flags>())
     {
         Assert(enablePartialCollect);
@@ -3228,7 +3345,7 @@ template <CollectionFlags flags>
 BOOL
 Recycler::Collect()
 {
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     if (this->CollectionInProgress())
     {
         // If we are forced in thread, we can't be concurrent
@@ -3251,7 +3368,7 @@ Recycler::Collect()
     // ExecuteRecyclerCollectionFunction may cause exception. In which case, we may trigger the assert
     // in SetupPostCollectionFlags because we didn't reset the inExhausitvECollection variable if
     // an exception. Use this flag to disable it the assertion if exception occur
-    DebugOnly(this->hasIncompletedDoCollect = true);
+    DebugOnly(this->hasIncompleteDoCollect = true);
 
     {
         RECORD_TIMESTAMP(initialCollectionStartTime);
@@ -3265,9 +3382,9 @@ Recycler::Collect()
 template <CollectionFlags flags>
 void Recycler::SetupPostCollectionFlags()
 {
-    // If we are not in a collection (collection in progress or in dispose), inExhastivecollection should not be set
+    // If we are not in a collection (collection in progress or in dispose), inExhaustiveCollection should not be set
     // Otherwise, we have missed an exhaustive collection.
-    Assert(this->hasIncompletedDoCollect ||
+    Assert(this->hasIncompleteDoCollect ||
         this->CollectionInProgress() || this->inDispose || (!this->inExhaustiveCollection && !this->inDecommitNowCollection));
 
     // Record whether we want to start exhaustive detection or do decommit now after GC
@@ -3292,7 +3409,7 @@ void Recycler::SetupPostCollectionFlags()
 BOOL
 Recycler::DoCollectWrapped(CollectionFlags flags)
 {
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     this->skipStack = ((flags & CollectOverride_SkipStack) != 0);
     DebugOnly(this->isConcurrentGCOnIdle = (flags == CollectOnScriptIdle));
 #endif
@@ -3300,7 +3417,7 @@ Recycler::DoCollectWrapped(CollectionFlags flags)
     this->allowDispose = (flags & CollectOverride_AllowDispose) == CollectOverride_AllowDispose;
     BOOL collected = collectionWrapper->ExecuteRecyclerCollectionFunction(this, &Recycler::DoCollect, flags);
 
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     Assert(IsConcurrentExecutingState() || IsConcurrentFinishedState() || !CollectionInProgress());
 #else
     Assert(!CollectionInProgress());
@@ -3320,9 +3437,9 @@ BOOL
 Recycler::DoCollect(CollectionFlags flags)
 {
     // ExecuteRecyclerCollectionFunction may cause exception. In which case, we may trigger the assert
-    // in SetupPostCollectionFlags because we didn't reset the inExhausitvECollection variable if
+    // in SetupPostCollectionFlags because we didn't reset the inExhaustiveCollection variable if
     // an exception. We are not in DoCollect, there shouldn't be any more exception. Reset the flag
-    DebugOnly(this->hasIncompletedDoCollect = false);
+    DebugOnly(this->hasIncompleteDoCollect = false);
 
 #ifdef RECYCLER_MEMORY_VERIFY
     this->Verify(Js::RecyclerPhase);
@@ -3330,7 +3447,7 @@ Recycler::DoCollect(CollectionFlags flags)
 #ifdef RECYCLER_FINALIZE_CHECK
     autoHeap.VerifyFinalize();
 #endif
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     BOOL partial = flags & CollectMode_Partial;
 
 #if DBG && defined(RECYCLER_DUMP_OBJECT_GRAPH)
@@ -3357,19 +3474,25 @@ Recycler::DoCollect(CollectionFlags flags)
         DumpObjectGraph();
         dumpObjectOnceOnCollect = false;
 
+#if ENABLE_PARTIAL_GC
         // Can't do a partial collect if DumpObjectGraph is set since it'll call FinishPartial
         // which will set inPartialCollectMode to false.
         partial = false;
+#endif
     }
 #endif
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     const bool concurrent = (flags & CollectMode_Concurrent) != 0;
     const BOOL forceInThread = flags & CollectOverride_ForceInThread;
+#else
+    const bool concurrent = false;
 #endif
 
     // Flush the pending dispose objects first if dispose is allowed
     Assert(!this->CollectionInProgress());
+#if ENABLE_CONCURRENT_GC
     Assert(this->backgroundFinishMarkCount == 0);
+#endif
 
     bool collected = FinishDisposeObjects();
 
@@ -3379,7 +3502,7 @@ Recycler::DoCollect(CollectionFlags flags)
         RECORD_TIMESTAMP(currentCollectionStartTime);
         this->telemetryBlock->currentCollectionStartProcessUsedBytes = PageAllocator::GetProcessUsedBytes();
 
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
         // DisposeObject may call script again and start another GC, so we may still be in concurrent GC state
 
         if (this->CollectionInProgress())
@@ -3394,8 +3517,8 @@ Recycler::DoCollect(CollectionFlags flags)
 
             return true;
         }
-#endif
         Assert(this->backgroundFinishMarkCount == 0);
+#endif
 
 #if DBG
         collectionCount++;
@@ -3407,21 +3530,21 @@ Recycler::DoCollect(CollectionFlags flags)
         hasExhaustiveCandidate = false;         // reset the candidate detection
 
 #ifdef RECYCLER_STATS
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
         RecyclerCollectionStats oldCollectionStats = collectionStats;
 #endif
         memset(&collectionStats, 0, sizeof(RecyclerCollectionStats));
         this->collectionStats.startCollectAllocBytes = autoHeap.uncollectedAllocBytes;
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
         this->collectionStats.startCollectNewPageCount = autoHeap.uncollectedNewPageCount;
         this->collectionStats.uncollectedNewPageCountPartialCollect = this->uncollectedNewPageCountPartialCollect;
 #endif
 #endif
 
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
         if (partial)
         {
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
             Assert(!forceInThread);
 #endif
 #ifdef RECYCLER_STATS
@@ -3463,7 +3586,7 @@ Recycler::DoCollect(CollectionFlags flags)
         }
 #endif
 
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
 
         bool skipConcurrent = false;
 #ifdef ENABLE_DEBUG_CONFIG_OPTIONS
@@ -3532,7 +3655,7 @@ Recycler::DoCollect(CollectionFlags flags)
     }
     while (this->NeedExhaustiveRepeatCollect());
 
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     // DisposeObject may call script again and start another GC, so we may still be in concurrent GC state
 
     if (this->CollectionInProgress())
@@ -3552,7 +3675,9 @@ Recycler::DoCollect(CollectionFlags flags)
 void
 Recycler::EndCollection()
 {
+#if ENABLE_CONCURRENT_GC
     Assert(this->backgroundFinishMarkCount == 0);
+#endif
     Assert(!this->CollectionInProgress());
 
     // no more collection is requested, we can turn exhaustive back off
@@ -3573,7 +3698,7 @@ Recycler::EndCollection()
 }
 
 
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
 
 bool
 Recycler::PartialCollect(bool concurrent)
@@ -3583,6 +3708,7 @@ Recycler::PartialCollect(bool concurrent)
     Assert(collectionState == CollectionStateNotCollecting);
     // Rescan again
     collectionState = CollectionStateRescanFindRoots;
+#if ENABLE_CONCURRENT_GC
     if (concurrent && enableConcurrentMark && this->partialConcurrentNextCollection)
     {
         this->PrepareBackgroundFindRoots();
@@ -3595,6 +3721,7 @@ Recycler::PartialCollect(bool concurrent)
         }
         this->RevertPrepareBackgroundFindRoots();
     }
+#endif
 
 #ifdef RECYCLER_STRESS
     if (forcePartialScanStack)
@@ -3632,7 +3759,7 @@ Recycler::ProcessClientTrackedObjects()
     GCETW(GC_PROCESS_CLIENT_TRACKED_OBJECT_START, (this));
 
     Assert(this->inPartialCollectMode);
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     Assert(!this->DoQueueTrackedObject());
 #endif
 
@@ -3655,7 +3782,9 @@ Recycler::ProcessClientTrackedObjects()
 void
 Recycler::ClearPartialCollect()
 {
+#if ENABLE_CONCURRENT_GC
     Assert(!this->DoQueueTrackedObject());
+#endif
     this->autoHeap.unusedPartialCollectFreeBytes = 0;
     this->partialUncollectedAllocBytes = 0;
     this->clientTrackedObjectList.Clear(&this->clientTrackedObjectAllocator);
@@ -3668,7 +3797,7 @@ Recycler::FinishPartialCollect(RecyclerSweep * recyclerSweep)
     Assert(recyclerSweep == nullptr || !recyclerSweep->IsBackground());
     RECYCLER_PROFILE_EXEC_BEGIN(this, Js::FinishPartialPhase);
     Assert(inPartialCollectMode);
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     Assert(!this->DoQueueTrackedObject());
 #endif
 
@@ -3681,7 +3810,7 @@ Recycler::FinishPartialCollect(RecyclerSweep * recyclerSweep)
 void
 Recycler::EnsureNotCollecting()
 {
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     FinishConcurrent<ForceFinishCollection>();
 #endif
     Assert(!this->CollectionInProgress());
@@ -3692,7 +3821,7 @@ void Recycler::EnumerateObjects(ObjectInfoBits infoBits, void (*CallBackFunction
     // Make sure we are not collecting
     EnsureNotCollecting();
 
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     // We are updating the free bit vector, messing up the partial collection state.
     // Just get out of partial collect mode
     // GC-CONSIDER: consider adding an option in FinishConcurrent to not get into partial collect mode during sweep.
@@ -3722,7 +3851,7 @@ Recycler::IsFindRootsState() const
 BOOL
 Recycler::IsReentrantState() const
 {
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     return !this->CollectionInProgress() || this->IsConcurrentState();
 #else
     return !this->CollectionInProgress();
@@ -3766,7 +3895,7 @@ Recycler::CollectionEnd()
     RECYCLER_PROFILE_EXEC_END2(this, phase, Js::RecyclerPhase);
 }
 
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
 size_t
 Recycler::BackgroundRescan(RescanFlags rescanFlags)
 {
@@ -3809,10 +3938,13 @@ Recycler::BackgroundResetWriteWatchAll()
 }
 #endif
 
-#if defined(PARTIAL_GC_ENABLED) || defined(CONCURRENT_GC_ENABLED)
 size_t
 Recycler::FinishMarkRescan(bool background)
 {
+#if !ENABLE_CONCURRENT_GC
+    Assert(!background);
+#endif
+
     if (background)
     {
         GCETW(GC_BACKGROUNDRESCAN_START, (this, 0));
@@ -3824,7 +3956,7 @@ Recycler::FinishMarkRescan(bool background)
 
     RECYCLER_PROFILE_EXEC_THREAD_BEGIN(background, this, Js::RescanPhase);
 
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     RescanFlags const flags = (background ? RescanFlags_ResetWriteWatch : RescanFlags_None);
 #else
     Assert(!background);
@@ -3836,9 +3968,13 @@ Recycler::FinishMarkRescan(bool background)
     this->isProcessingRescan = true;
 #endif
 
+#if ENABLE_CONCURRENT_GC
     size_t scannedPageCount = heapBlockMap.Rescan(this, ((flags & RescanFlags_ResetWriteWatch) != 0));
 
     scannedPageCount += autoHeap.Rescan(flags);
+#else
+    size_t scannedPageCount = 0;
+#endif
 
     DebugOnly(this->isProcessingRescan = false);
 
@@ -3857,16 +3993,16 @@ Recycler::FinishMarkRescan(bool background)
 }
 
 
+#if ENABLE_CONCURRENT_GC
 void
 Recycler::ProcessTrackedObjects()
 {
     GCETW(GC_PROCESS_TRACKED_OBJECT_START, (this));
 
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     Assert(this->clientTrackedObjectList.Empty());
     Assert(!this->inPartialCollectMode);
 #endif
-#ifdef CONCURRENT_GC_ENABLED
     Assert(this->DoQueueTrackedObject());
 
     this->queueTrackedObject = false;
@@ -3881,17 +4017,15 @@ Recycler::ProcessTrackedObjects()
     parallelMarkContext3.ProcessTracked();
 
     DebugOnly(this->isProcessingTrackedObjects = false);
-#endif
 
     GCETW(GC_PROCESS_TRACKED_OBJECT_STOP, (this));
 }
-
-#endif // defined(PARTIAL_GC_ENABLED) || defined(CONCURRENT_GC_ENABLED)
+#endif
 
 BOOL
 Recycler::RequestConcurrentWrapperCallback()
 {
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     Assert(!IsConcurrentExecutingState());
 
     // Save the original collection state
@@ -3913,14 +4047,14 @@ Recycler::RequestConcurrentWrapperCallback()
     return false;
 }
 
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
 /*------------------------------------------------------------------------------------------------
  * Concurrent
  *------------------------------------------------------------------------------------------------*/
 BOOL
 Recycler::CollectOnConcurrentThread()
 {
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     Assert(!inPartialCollectMode);
 #endif
 #ifdef RECYCLER_TRACE
@@ -4017,7 +4151,7 @@ Recycler::FinishConcurrent()
             collectionParam.finishOnly = true;
             collectionParam.flags = flags;
 #endif
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
             // If SkipStack is provided, and we're not forcing the finish (i.e we're not in concurrent executing state)
             // then, it's fine to set the skipStack flag to true, so that during the in-thread find-roots, we'll skip
             // the stack scan
@@ -4681,7 +4815,11 @@ Recycler::StartConcurrentSweepCollect()
 
     // We don't have rescan data if we disabled concurrent mark, assume the worst
     // (which means it is harder to get into partial collect mode)
+#if ENABLE_PARTIAL_GC
     bool needConcurrentSweep = this->Sweep(RecyclerSweep::MaxPartialCollectRescanRootBytes, true, true);
+#else
+    bool needConcurrentSweep = this->Sweep(true);
+#endif
     this->CollectionEnd<Js::ConcurrentCollectPhase>();
     FinishCollection(needConcurrentSweep);
     return true;
@@ -4884,7 +5022,11 @@ Recycler::BackgroundFindRoots()
     size_t scanRootBytes = 0;
     Assert(this->IsConcurrentFindRootState());
     Assert(this->hasPendingConcurrentFindRoot);
+#if ENABLE_PARTIAL_GC
     Assert(this->inPartialCollectMode || this->DoQueueTrackedObject());
+#else
+    Assert(this->DoQueueTrackedObject());
+#endif
 
     // Only mark pinned object and guest arenas, which is where most of the roots are.
     // When we go back to the main thread to rescan, we will scan the rest of the root.
@@ -4932,7 +5074,11 @@ Recycler::BackgroundFindRoots()
 size_t
 Recycler::BackgroundFinishMark()
 {
+#if ENABLE_PARTIAL_GC
     Assert(this->inPartialCollectMode || this->DoQueueTrackedObject());
+#else
+    Assert(this->DoQueueTrackedObject());
+#endif
     Assert(collectionState == CollectionStateConcurrentFinishMark);
     size_t rescannedRootBytes = FinishMarkRescan(true) * AutoSystemInfo::PageSize;
     this->collectionState = CollectionStateConcurrentFindRoots;
@@ -4955,15 +5101,17 @@ Recycler::ConcurrentTransferSweptObjects(RecyclerSweep& recyclerSweep)
 {
     Assert(!recyclerSweep.IsBackground());
     Assert((this->collectionState & Collection_TransferSwept) == Collection_TransferSwept);
+#if ENABLE_PARTIAL_GC
     if (this->hasBackgroundFinishPartial)
     {
         this->hasBackgroundFinishPartial = false;
         this->ClearPartialCollect();
     }
+#endif
     autoHeap.ConcurrentTransferSweptObjects(recyclerSweep);
 }
 
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
 void
 Recycler::ConcurrentPartialTransferSweptObjects(RecyclerSweep& recyclerSweep)
 {
@@ -4977,7 +5125,7 @@ BOOL
 Recycler::FinishConcurrentCollectWrapped(CollectionFlags flags)
 {
     this->allowDispose = (flags & CollectOverride_AllowDispose) == CollectOverride_AllowDispose;
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     this->skipStack = ((flags & CollectOverride_SkipStack) != 0);
     DebugOnly(this->isConcurrentGCOnIdle = (flags == CollectOnScriptIdle));
 #endif
@@ -5083,9 +5231,14 @@ Recycler::FinishConcurrentCollect(CollectionFlags flags)
 #ifdef PROFILE_EXEC
     Js::Phase concurrentPhase = Js::ConcurrentCollectPhase;
 #endif
+#if ENABLE_PARTIAL_GC
     RECYCLER_PROFILE_EXEC_BEGIN2(this, Js::RecyclerPhase,
         (concurrentPhase = ((this->inPartialCollectMode && this->IsConcurrentMarkState())?
             Js::ConcurrentPartialCollectPhase : Js::ConcurrentCollectPhase)));
+#else
+    RECYCLER_PROFILE_EXEC_BEGIN2(this, Js::RecyclerPhase,
+        (concurrentPhase = Js::ConcurrentCollectPhase));
+#endif
 
     // Don't do concurrent sweep if we have priority boosted.
     const BOOL forceInThread = flags & CollectOverride_ForceInThread;
@@ -5117,7 +5270,11 @@ Recycler::FinishConcurrentCollect(CollectionFlags flags)
 #endif
 
 #ifdef RECYCLER_TRACE
+#if ENABLE_PARTIAL_GC
         PrintCollectTrace(this->inPartialCollectMode ? Js::ConcurrentPartialCollectPhase : Js::ConcurrentMarkPhase, true);
+#else
+        PrintCollectTrace(Js::ConcurrentMarkPhase, true);
+#endif
 #endif
         collectionState = CollectionStateRescanFindRoots;
 
@@ -5166,7 +5323,11 @@ Recycler::FinishConcurrentCollect(CollectionFlags flags)
         protectPages.Unprotect();
 #endif
 
+#if ENABLE_PARTIAL_GC
         needConcurrentSweep = this->Sweep(rescanRootBytes, concurrent, true);
+#else
+        needConcurrentSweep = this->Sweep(concurrent);
+#endif
         GCETW(GC_STOP, (this, ETWEvent_ConcurrentRescan));
     }
     else
@@ -5196,7 +5357,7 @@ Recycler::FinishConcurrentCollect(CollectionFlags flags)
 
         Assert(this->recyclerSweep != nullptr);
         Assert(!this->recyclerSweep->IsBackground());
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
         if (this->inPartialCollectMode)
         {
             ConcurrentPartialTransferSweptObjects(*this->recyclerSweep);
@@ -5566,12 +5727,16 @@ Recycler::ThreadProc()
     }
 }
 
-#endif //defined(CONCURRENT_GC_ENABLED)
+#endif //ENABLE_CONCURRENT_GC
 
 void
 Recycler::FinishCollection(bool needConcurrentSweep)
 {
+#if ENABLE_CONCURRENT_GC
     Assert(!!this->InConcurrentSweep() == needConcurrentSweep);
+#else
+    Assert(!needConcurrentSweep);
+#endif
     if (!needConcurrentSweep)
     {
         FinishCollection();
@@ -5585,7 +5750,9 @@ Recycler::FinishCollection(bool needConcurrentSweep)
 void
 Recycler::FinishCollection()
 {
+#if ENABLE_PARTIAL_GC && ENABLE_CONCURRENT_GC
     Assert(!this->hasBackgroundFinishPartial);
+#endif
     Assert(!this->hasPendingDeleteGuestArena);
 
     // Reset the time heuristics
@@ -5599,7 +5766,9 @@ Recycler::FinishCollection()
         collectionWrapper->PostCollectionCallBack();
     }
 
+#if ENABLE_CONCURRENT_GC
     this->backgroundFinishMarkCount = 0;
+#endif
 
     // Do a partial page decommit now
     if (decommitOnFinish)
@@ -5795,6 +5964,7 @@ Recycler::ShouldIdleCollectOnExit()
     return (autoHeap.uncollectedAllocBytes >= RecyclerHeuristic::IdleUncollectedAllocBytesCollection);
 }
 
+#if ENABLE_CONCURRENT_GC
 bool
 RecyclerParallelThread::StartConcurrent()
 {
@@ -6053,7 +6223,7 @@ RecyclerParallelThread::StaticBackgroundWorkCallback(void * callbackData)
 
     SetEvent(parallelThread->concurrentWorkDoneEvent);
 }
-
+#endif
 
 #ifdef RECYCLER_TRACE
 void
@@ -6064,7 +6234,7 @@ Recycler::CaptureCollectionParam(CollectionFlags flags, bool repeat)
     collectionParam.finishOnly = false;
     collectionParam.flags = flags;
     collectionParam.uncollectedAllocBytes = autoHeap.uncollectedAllocBytes;
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     collectionParam.uncollectedNewPageCountPartialCollect = this->uncollectedNewPageCountPartialCollect;
     collectionParam.inPartialCollectMode = inPartialCollectMode;
     collectionParam.uncollectedNewPageCount = autoHeap.uncollectedNewPageCount;
@@ -6088,7 +6258,7 @@ Recycler::PrintCollectTrace(Js::Phase phase, bool finish, bool noConcurrentWork)
         const BOOL forceInThread = collectionParam.flags & CollectOverride_ForceInThread;
         const BOOL forceFinish = collectionParam.flags & CollectOverride_ForceFinish;
 
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
         BOOL partial = collectionParam.flags & CollectMode_Partial ;
 #endif
 
@@ -6110,7 +6280,7 @@ Recycler::PrintCollectTrace(Js::Phase phase, bool finish, bool noConcurrentWork)
         {
             Assert(!collectionParam.repeat);
             Assert(finish);
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
             if (collectionState == CollectionStateRescanWait)
             {
                 if (forceFinish)
@@ -6145,7 +6315,7 @@ Recycler::PrintCollectTrace(Js::Phase phase, bool finish, bool noConcurrentWork)
                     Output::Print(L" Finish sweep");
                 }
             }
-#endif // CONCURRENT_GC_ENABLED
+#endif // ENABLE_CONCURRENT_GC
         }
         else
         {
@@ -6157,7 +6327,7 @@ Recycler::PrintCollectTrace(Js::Phase phase, bool finish, bool noConcurrentWork)
             {
                 Output::Print(L" No heuristic");
             }
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
             else if (finish && priorityBoost)
             {
                 Output::Print(L" Priority boost no heuristic");
@@ -6169,7 +6339,7 @@ Recycler::PrintCollectTrace(Js::Phase phase, bool finish, bool noConcurrentWork)
                 bool byteCountUsed = false;
                 bool timeUsed = false;
 
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
                 bool newPageUsed = false;
                 if (phase == Js::PartialCollectPhase || phase == Js::ConcurrentPartialCollectPhase)
                 {
@@ -6181,7 +6351,7 @@ Recycler::PrintCollectTrace(Js::Phase phase, bool finish, bool noConcurrentWork)
                     newPageUsed = true;
                 }
                 else
-#endif // PARTIAL_GC_ENABLED
+#endif // ENABLE_PARTIAL_GC
                 {
                     byteCountUsed = !!allocSize;
                     timeUsed = !!timed;
@@ -6191,7 +6361,7 @@ Recycler::PrintCollectTrace(Js::Phase phase, bool finish, bool noConcurrentWork)
                 Output::Print(L"B:%8d ", collectionParam.uncollectedAllocBytes);
                 Output::Print(timeUsed? L"*" : (timed? L" " : L"~"));
                 Output::Print(L"T:%4d ", -collectionParam.timeDiff);
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
                 if (collectionParam.inPartialCollectMode)
                 {
                     Output::Print(L"L:%5d ", collectionParam.uncollectedNewPageCountPartialCollect);
@@ -6203,7 +6373,7 @@ Recycler::PrintCollectTrace(Js::Phase phase, bool finish, bool noConcurrentWork)
                 Output::Print(newPageUsed? L"*" : (partial? L" " : L"~"));
                 Output::Print(L"P:%5d(%9d) ", collectionParam.uncollectedNewPageCount, collectionParam.uncollectedNewPageCount * AutoSystemInfo::PageSize);
                 Output::Print(L"U:%8d", collectionParam.unusedPartialCollectFreeBytes);
-#endif // PARTIAL_GC_ENABLED
+#endif // ENABLE_PARTIAL_GC
             }
         }
         Output::Print(L"\n");
@@ -6236,6 +6406,7 @@ void
 Recycler::PrintHeapBlockMemoryStats(wchar_t const * name, HeapBlock::HeapBlockType type)
 {
     size_t allocableFreeByteCount = collectionStats.heapBlockFreeByteCount[type];
+#if ENABLE_PARTIAL_GC
     size_t partialUnusedBytes = 0;
     if (this->enablePartialCollect)
     {
@@ -6243,11 +6414,12 @@ Recycler::PrintHeapBlockMemoryStats(wchar_t const * name, HeapBlock::HeapBlockTy
             - collectionStats.smallNonLeafHeapBlockPartialReuseBytes[type];
         allocableFreeByteCount -= partialUnusedBytes;
     }
+#endif
     size_t totalByteCount = (collectionStats.heapBlockCount[type] - collectionStats.heapBlockFreeCount[type]) * AutoSystemInfo::PageSize;
     size_t liveByteCount = totalByteCount - collectionStats.heapBlockFreeByteCount[type];
     Output::Print(L" %6s: %10d %10d", name, liveByteCount, allocableFreeByteCount);
 
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     if (this->enablePartialCollect &&
         (type == HeapBlock::HeapBlockType::SmallNormalBlockType
       || type == HeapBlock::HeapBlockType::SmallFinalizableBlockType
@@ -6274,7 +6446,7 @@ Recycler::PrintHeapBlockMemoryStats(wchar_t const * name, HeapBlock::HeapBlockTy
     Output::Print(L" %10d %6.1f", totalByteCount,
         (double)allocableFreeByteCount / (double)totalByteCount * 100);
 
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     if (this->enablePartialCollect &&
         (type == HeapBlock::HeapBlockType::SmallNormalBlockType
         || type == HeapBlock::HeapBlockType::SmallFinalizableBlockType
@@ -6300,7 +6472,7 @@ Recycler::PrintHeuristicCollectionStats()
 {
     Output::Print(L"---------------------------------------------------------------------------------------------------------------\n");
     Output::Print(L"GC Trigger   : %10s %10s %10s", L"Start", L"Continue", L"Finish");
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     if (this->enablePartialCollect)
     {
         Output::Print(L" | Heuristics                   : %10s %10s %5s", L"", L"", L"%");
@@ -6310,7 +6482,7 @@ Recycler::PrintHeuristicCollectionStats()
 
     Output::Print(L"---------------------------------------------------------------------------------------------------------------\n");
     Output::Print(L" Alloc bytes : %10d %10d %10d", collectionStats.startCollectAllocBytes, collectionStats.continueCollectAllocBytes, this->autoHeap.uncollectedAllocBytes);
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     if (this->enablePartialCollect)
     {
         Output::Print(L" | Cost                         : %10d %10d %5.1f", collectionStats.rescanRootBytes, collectionStats.estimatedPartialReuseBytes, collectionStats.collectCost * 100);
@@ -6318,14 +6490,14 @@ Recycler::PrintHeuristicCollectionStats()
 #endif
     Output::Print(L"\n");
 
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     if (this->enablePartialCollect)
     {
         Output::Print(L"                                                | Efficacy                     : %10s %10s %5.1f\n", L"", L"", collectionStats.collectEfficacy * 100);
     }
 #endif
 
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     if (this->enablePartialCollect)
     {
         Output::Print(L" New page    : %10d %10s %10d", collectionStats.startCollectNewPageCount, L"", autoHeap.uncollectedNewPageCount);
@@ -6335,7 +6507,7 @@ Recycler::PrintHeuristicCollectionStats()
 #endif
 
     Output::Print(L" Finish try  : %10d %10s %10s", collectionStats.finishCollectTryCount, L"", L"");
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     if (this->enablePartialCollect)
     {
         Output::Print(L" | Partial Reuse Min Free Bytes :            %10d", collectionStats.partialCollectSmallHeapBlockReuseMinFreeBytes * AutoSystemInfo::PageSize);
@@ -6406,7 +6578,7 @@ Recycler::PrintBackgroundCollectionStat(RecyclerCollectionStats::MarkData const&
 void
 Recycler::PrintBackgroundCollectionStats()
 {
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     Output::Print(L"---------------------------------------------------------------------------------------------------------------\n");
     Output::Print(L"BgSmall : %5s %6s %10s | BgLarge : %5s %6s %10s | BgMark :%9s %4s %s\n",
         L"Pages", L"Count", L"Bytes", L"Pages", L"Count", L"Bytes", L"Count", L"%", L"NonLeafBytes   %");
@@ -6508,16 +6680,16 @@ Recycler::PrintCollectStats()
     size_t freeBytes = collectionStats.objectSweptBytes - collectionStats.objectSweptFreeListBytes;
 
     Output::Print(L"---------------------------------------------------------------------------------------------------------------\n");
-#if defined(PARTIAL_GC_ENABLED) || defined(CONCURRENT_GC_ENABLED)
+#if ENABLE_PARTIAL_GC || ENABLE_CONCURRENT_GC
     Output::Print(L"Rescan  : %5s %6s %10s | Track   : %5s | ", L"Pages", L"Count", L"Bytes", L"Count");
 #endif
     Output::Print(L"Sweep     : %7s | SweptObj  : %5s %5s %10s\n", L"Count", L"Count", L"%%", L"Bytes");
     Output::Print(L"---------------------------------------------------------------------------------------------------------------\n");
     Output::Print(L"  Small : ");
-#if defined(PARTIAL_GC_ENABLED) || defined(CONCURRENT_GC_ENABLED)
+#if ENABLE_PARTIAL_GC || ENABLE_CONCURRENT_GC
     Output::Print(L"%5d %6d %10d | ", collectionStats.markData.rescanPageCount, collectionStats.markData.rescanObjectCount, collectionStats.markData.rescanObjectByteCount);
 #endif
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     Output::Print(L"Process : %5d | ", collectionStats.trackedObjectCount);
 #else
     Output::Print(L"              | ");
@@ -6527,11 +6699,11 @@ Recycler::PrintCollectStats()
         freeCount, (double)freeCount / (double) collectionStats.objectSweptCount * 100, freeBytes);
 
     Output::Print(L"  Large : ");
-#if defined(PARTIAL_GC_ENABLED) || defined(CONCURRENT_GC_ENABLED)
+#if ENABLE_PARTIAL_GC || ENABLE_CONCURRENT_GC
     Output::Print(L"%5d %6d %10d | ",
         collectionStats.markData.rescanLargePageCount, collectionStats.markData.rescanLargeObjectCount, collectionStats.markData.rescanLargeByteCount);
 #endif
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     Output::Print(L"Client  : %5d | ", collectionStats.clientTrackedObjectCount);
 #else
     Output::Print(L"                | ");
@@ -6542,7 +6714,7 @@ Recycler::PrintCollectStats()
 
     Output::Print(L"---------------------------------------------------------------------------------------------------------------\n");
     Output::Print(L"SweptBlk:  Live  Free Total Free%% : Swept Swept%% : CSwpt CSwpt%%");
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     if (this->enablePartialCollect)
     {
         Output::Print(L" | Partial    : Count      Bytes     Existing");
@@ -6552,7 +6724,7 @@ Recycler::PrintCollectStats()
     Output::Print(L"---------------------------------------------------------------------------------------------------------------\n");
 
     PrintHeapBlockStats(L"Small", HeapBlock::SmallNormalBlockType);
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     if (this->enablePartialCollect)
     {
         Output::Print(L" |  Reuse     : %5d %10d %10d",
@@ -6564,7 +6736,7 @@ Recycler::PrintCollectStats()
 #endif
     Output::Print(L"\n");
     PrintHeapBlockStats(L"SmFin", HeapBlock::SmallFinalizableBlockType);
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     if (this->enablePartialCollect)
     {
         Output::Print(L" |  Unused    : %5d %10d %10d",
@@ -6578,7 +6750,7 @@ Recycler::PrintCollectStats()
 
 #ifdef RECYCLER_WRITE_BARRIER
     PrintHeapBlockStats(L"SmSWB", HeapBlock::SmallNormalBlockWithBarrierType);
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     if (this->enablePartialCollect)
     {
         Output::Print(L" |  Unused    : %5d %10d %10d",
@@ -6590,7 +6762,7 @@ Recycler::PrintCollectStats()
 #endif
     Output::Print(L"\n");
     PrintHeapBlockStats(L"SmFin", HeapBlock::SmallFinalizableBlockWithBarrierType);
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     if (this->enablePartialCollect)
     {
         Output::Print(L" |  Unused    : %5d %10d %10d",
@@ -6605,7 +6777,7 @@ Recycler::PrintCollectStats()
 
     // TODO: This seems suspicious- why are we looking at smallNonLeaf while print out leaf...
     PrintHeapBlockStats(L"SmLeaf", HeapBlock::SmallLeafBlockType);
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     if (this->enablePartialCollect)
     {
         Output::Print(L" |  ReuseFin  : %5d %10d %10d",
@@ -6618,7 +6790,7 @@ Recycler::PrintCollectStats()
     Output::Print(L"\n");
 
     PrintHeapBlockStats(L"Medium", HeapBlock::MediumNormalBlockType);
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     if (this->enablePartialCollect)
     {
         Output::Print(L" |  Reuse     : %5d %10d %10d",
@@ -6630,7 +6802,7 @@ Recycler::PrintCollectStats()
 #endif
     Output::Print(L"\n");
     PrintHeapBlockStats(L"MdFin", HeapBlock::MediumFinalizableBlockType);
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     if (this->enablePartialCollect)
     {
         Output::Print(L" |  Unused    : %5d %10d %10d",
@@ -6644,7 +6816,7 @@ Recycler::PrintCollectStats()
 
 #ifdef RECYCLER_WRITE_BARRIER
     PrintHeapBlockStats(L"MdSWB", HeapBlock::MediumNormalBlockWithBarrierType);
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     if (this->enablePartialCollect)
     {
         Output::Print(L" |  Unused    : %5d %10d %10d",
@@ -6656,7 +6828,7 @@ Recycler::PrintCollectStats()
 #endif
     Output::Print(L"\n");
     PrintHeapBlockStats(L"MdFin", HeapBlock::MediumFinalizableBlockWithBarrierType);
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     if (this->enablePartialCollect)
     {
         Output::Print(L" |  Unused    : %5d %10d %10d",
@@ -6671,7 +6843,7 @@ Recycler::PrintCollectStats()
 
     // TODO: This seems suspicious- why are we looking at smallNonLeaf while print out leaf...
     PrintHeapBlockStats(L"MdLeaf", HeapBlock::MediumNormalBlockType);
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     if (this->enablePartialCollect)
     {
         Output::Print(L" |  ReuseFin  : %5d %10d %10d",
@@ -6685,7 +6857,7 @@ Recycler::PrintCollectStats()
 
     // TODO: This can't possibly be correct...check on this later
     PrintHeapBlockStats(L"Large", HeapBlock::LargeBlockType);
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     if (this->enablePartialCollect)
     {
         Output::Print(L"                               |  UnusedFin : %5d %10d %10d",
@@ -6824,8 +6996,10 @@ Recycler::AutoSetupRecyclerForNonCollectingMark::AutoSetupRecyclerForNonCollecti
 void Recycler::AutoSetupRecyclerForNonCollectingMark::DoCommonSetup()
 {
     Assert(m_recycler.collectionState == CollectionStateNotCollecting || m_recycler.collectionState == CollectionStateExit);
+#if ENABLE_CONCURRENT_GC
     Assert(!m_recycler.DoQueueTrackedObject());
-#ifdef PARTIAL_GC_ENABLED
+#endif
+#if ENABLE_PARTIAL_GC
     // We need to get out of partial collect before we do the mark because we
     // will mess with the free bit vector state
     // GC-CONSIDER: don't mess with the free bit vector?
@@ -6951,7 +7125,7 @@ Recycler::StressCollectNow()
         this->CollectNow<CollectStress>();
         return true;
     }
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     else if (this->recyclerBackgroundStress)
     {
         this->CollectNow<CollectBackgroundStress>();
@@ -6961,27 +7135,27 @@ Recycler::StressCollectNow()
         && (this->recyclerConcurrentStress
         || this->recyclerConcurrentRepeatStress))
     {
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
         if (this->recyclerPartialStress)
         {
             this->CollectNow<CollectConcurrentPartialStress>();
             return true;
         }
         else
-#endif // PARTIAL_GC_ENABLED
+#endif // ENABLE_PARTIAL_GC
         {
             this->CollectNow<CollectConcurrentStress>();
             return true;
         }
     }
-#endif // CONCURRENT_GC_ENABLED
-#ifdef PARTIAL_GC_ENABLED
+#endif // ENABLE_CONCURRENT_GC
+#if ENABLE_PARTIAL_GC
     else if (this->recyclerPartialStress)
     {
         this->CollectNow<CollectPartialStress>();
         return true;
     }
-#endif // PARTIAL_GC_ENABLED
+#endif // ENABLE_PARTIAL_GC
     return false;
 }
 #endif // RECYCLER_STRESS
@@ -7484,6 +7658,7 @@ void
 Recycler::DeleteGuestArena(ArenaAllocator * arenaAllocator)
 {
     GuestArenaAllocator * guestArenaAllocator = static_cast<GuestArenaAllocator *>(arenaAllocator);
+#if ENABLE_CONCURRENT_GC
     if (this->hasPendingConcurrentFindRoot)
     {
         // We are doing concurrent find root, don't modify the list and mark the arena to be delete
@@ -7493,6 +7668,7 @@ Recycler::DeleteGuestArena(ArenaAllocator * arenaAllocator)
         guestArenaAllocator->pendingDelete = true;
     }
     else
+#endif
     {
         guestArenaList.RemoveElement(&HeapAllocator::Instance, guestArenaAllocator);
     }
@@ -7638,6 +7814,7 @@ Recycler::ReportOnProcessDetach(Fn fn)
     this->markContext.GetPageAllocator()->SetDisableThreadAccessCheck();
 #endif
 
+#if ENABLE_CONCURRENT_GC
     if (this->IsConcurrentState())
     {
         this->AbortConcurrent(true);
@@ -7648,6 +7825,9 @@ Recycler::ReportOnProcessDetach(Fn fn)
         Output::Print(L"WARNING: Thread terminated during GC.  Can't dump object graph\n");
         return;
     }
+#else
+    Assert(!this->CollectionInProgress());
+#endif
     // Don't mark external roots on another thread
     this->SetExternalRootMarker(NULL, NULL);
 #if DBG

--- a/Lib/Common/Memory/Recycler.h
+++ b/Lib/Common/Memory/Recycler.h
@@ -288,13 +288,13 @@ enum CollectionFlags
 
 #ifdef RECYCLER_STRESS
     CollectStress                   = CollectNowForceInThread,
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     CollectPartialStress            = CollectMode_Partial,
 #endif
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     CollectBackgroundStress         = CollectNowDefault,
     CollectConcurrentStress         = CollectNowConcurrent,
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     CollectConcurrentPartialStress  = CollectConcurrentStress | CollectPartialStress,
 #endif
 #endif
@@ -375,7 +375,7 @@ private:
 struct RecyclerCollectionStats
 {
     size_t startCollectAllocBytes;
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     size_t startCollectNewPageCount;
 #endif
     size_t continueCollectAllocBytes;
@@ -383,7 +383,7 @@ struct RecyclerCollectionStats
     size_t finishCollectTryCount;
 
     // Heuristic Stats
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     size_t rescanRootBytes;
     size_t estimatedPartialReuseBytes;
     size_t uncollectedNewPageCountPartialCollect;
@@ -413,24 +413,22 @@ struct RecyclerCollectionStats
     struct MarkData
     {
         // Rescan stats
-#if defined(PARTIAL_GC_ENABLED) || defined(CONCURRENT_GC_ENABLED)
         size_t rescanPageCount;
         size_t rescanObjectCount;
         size_t rescanObjectByteCount;
         size_t rescanLargePageCount;
         size_t rescanLargeObjectCount;
         size_t rescanLargeByteCount;
-#endif
         size_t markCount;           // total number of object marked
         size_t markBytes;           // size of all objects marked.
     } markData;
 
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     MarkData backgroundMarkData[RecyclerHeuristic::MaxBackgroundRepeatMarkCount];
     size_t trackedObjectCount;
 #endif
 
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     size_t clientTrackedObjectCount;
 #endif
 
@@ -447,7 +445,7 @@ struct RecyclerCollectionStats
     size_t objectSweepScanCount;            // number of objects walked for sweeping (exclude whole page freed)
     size_t finalizeSweepCount;              // number of objects finalizer/dispose called
 
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     size_t smallNonLeafHeapBlockPartialReuseCount[HeapBlock::SmallBlockTypeCount];
     size_t smallNonLeafHeapBlockPartialReuseBytes[HeapBlock::SmallBlockTypeCount];
     size_t smallNonLeafHeapBlockPartialUnusedCount[HeapBlock::SmallBlockTypeCount];
@@ -493,7 +491,7 @@ struct CollectionParam
     int timeDiff;
     size_t uncollectedAllocBytes;
     size_t uncollectedPinnedObjects;
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     size_t uncollectedNewPageCountPartialCollect;
     size_t uncollectedNewPageCount;
     size_t unusedPartialCollectFreeBytes;
@@ -540,6 +538,7 @@ struct CollectionParam
 #endif
 
 
+#if ENABLE_CONCURRENT_GC
 class RecyclerParallelThread
 {
 public:
@@ -581,6 +580,7 @@ private:
     HANDLE concurrentThread;
     bool synchronizeOnStartup;
 };
+#endif
 
 #ifdef ENABLE_DEBUG_CONFIG_OPTIONS
 class AutoProtectPages
@@ -604,7 +604,9 @@ class Recycler
     friend class MarkContext;
     friend class HeapBlock;
     friend class HeapBlockMap32;
+#if ENABLE_CONCURRENT_GC
     friend class RecyclerParallelThread;
+#endif
 #ifdef ENABLE_DEBUG_CONFIG_OPTIONS
     friend class AutoProtectPages;
 #endif
@@ -786,6 +788,43 @@ private:
     bool HasPendingTrackObjects() const { return markContext.HasPendingTrackObjects() || parallelMarkContext1.HasPendingTrackObjects() || parallelMarkContext2.HasPendingTrackObjects() || parallelMarkContext3.HasPendingTrackObjects(); }
 
     RecyclerCollectionWrapper * collectionWrapper;
+    HANDLE mainThreadHandle;
+    void * stackBase;
+    class SavedRegisterState
+    {
+    public:
+#if _M_IX86
+        static const int NumRegistersToSave = 8;
+#elif _M_ARM
+        static const int NumRegistersToSave = 13;
+#elif _M_ARM64
+        static const int NumRegistersToSave = 13;
+#elif _M_AMD64
+        static const int NumRegistersToSave = 16;
+#endif
+
+        SavedRegisterState()
+        {
+            memset(registers, 0, sizeof(void*) * NumRegistersToSave);
+        }
+
+        void** GetRegisters()
+        {
+            return registers;
+        }
+
+        void*  GetStackTop()
+        {
+            // By convention, our register-saving routine will always
+            // save the stack pointer as the first item in the array
+            return registers[0];
+        }
+
+    private:
+        void* registers[NumRegistersToSave];
+    };
+
+    SavedRegisterState savedThreadContext;
 
     bool inDispose;
 
@@ -822,30 +861,34 @@ private:
     bool disableCollection;
 #endif
 
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     bool enablePartialCollect;
     bool inPartialCollectMode;
+#if ENABLE_CONCURRENT_GC
     bool hasBackgroundFinishPartial;
     bool partialConcurrentNextCollection;
+#endif
+#endif
 #ifdef RECYCLER_STRESS
     bool forcePartialScanStack;
     bool recyclerStress;
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     bool recyclerBackgroundStress;
     bool recyclerConcurrentStress;
     bool recyclerConcurrentRepeatStress;
 #endif
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     bool recyclerPartialStress;
 #endif
 #endif
+#if DBG
+    bool isExternalStackSkippingGC;
 #endif
-#ifdef CONCURRENT_GC_ENABLED
     bool skipStack;
+#if ENABLE_CONCURRENT_GC
 #if DBG
     bool isConcurrentGCOnIdle;
     bool isFinishGCOnIdle;
-    bool isExternalStackSkippingGC;
 #endif
 
     bool queueTrackedObject;
@@ -864,51 +907,13 @@ private:
     HANDLE concurrentWorkReadyEvent; // main thread uses this event to tell concurrent threads that the work is ready
     HANDLE concurrentWorkDoneEvent; // concurrent threads use this event to tell main thread that the work allocated is done
     HANDLE concurrentThread;
-    HANDLE mainThreadHandle;
 
-    class SavedRegisterState
-    {
-    public:
-#if _M_IX86
-        static const int NumRegistersToSave = 8;
-#elif _M_ARM
-        static const int NumRegistersToSave = 13;
-#elif _M_ARM64
-        static const int NumRegistersToSave = 13;
-#elif _M_AMD64
-        static const int NumRegistersToSave = 16;
-#endif
-
-        SavedRegisterState()
-        {
-            memset(registers, 0, sizeof(void*) * NumRegistersToSave);
-        }
-
-        void** GetRegisters()
-        {
-            return registers;
-        }
-
-        void*  GetStackTop()
-        {
-            // By convention, our register-saving routine will always
-            // save the stack pointer as the first item in the array
-            return registers[0];
-        }
-
-    private:
-        void* registers[NumRegistersToSave];
-    };
-
-    void * stackBase;
-    SavedRegisterState savedThreadContext;
 
     template <uint parallelId>
     void ParallelWorkFunc();
 
     RecyclerParallelThread parallelThread1;
     RecyclerParallelThread parallelThread2;
-    Js::ConfigFlagsTable&  recyclerFlagsTable;
 
 #if DBG
     // Variable indicating if the concurrent thread has exited or not
@@ -918,8 +923,15 @@ private:
     bool concurrentThreadExited;
     bool disableConcurrentThreadExitedCheck;
     bool isProcessingTrackedObjects;
-    bool hasIncompletedDoCollect;
+#endif
 
+    uint tickCountStartConcurrent;
+
+    bool isAborting;
+#endif
+
+#if DBG
+    bool hasIncompleteDoCollect;
     // This is set to true when we begin a Rescan, and set to false when either:
     // (1) We finish the final in-thread Rescan and are about to Mark
     // (2) We do a conditional ResetWriteWatch and are about to Mark
@@ -928,11 +940,7 @@ private:
     bool isProcessingRescan;
 #endif
 
-    uint tickCountStartConcurrent;
-
-    bool isAborting;
-#endif
-
+    Js::ConfigFlagsTable&  recyclerFlagsTable;
     RecyclerSweep recyclerSweepInstance;
     RecyclerSweep * recyclerSweep;
 
@@ -943,7 +951,7 @@ private:
     DWORD needIdleDecommitSignal;
 #endif
 
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     SListBase<void *> clientTrackedObjectList;
     ArenaAllocator clientTrackedObjectAllocator;
 
@@ -1139,7 +1147,7 @@ public:
 #endif
 
     BOOL IsShuttingDown() const { return this->isShuttingDown; }
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
 #if DBG
     BOOL IsConcurrentMarkEnabled() const { return enableConcurrentMark; }
     BOOL IsConcurrentSweepEnabled() const { return enableConcurrentSweep; }
@@ -1160,7 +1168,9 @@ public:
     void SetupPostCollectionFlags();
     void EnsureNotCollecting();
 
+#if ENABLE_CONCURRENT_GC
     bool QueueTrackedObject(FinalizableObject * trackableObject);
+#endif
 
     // FindRoots
     void TryMarkNonInterior(void* candidate, void* parentReference = nullptr);
@@ -1548,7 +1558,9 @@ private:
     size_t FindRoots();
     size_t TryMarkArenaMemoryBlockList(ArenaMemoryBlock * memoryBlocks);
     size_t TryMarkBigBlockList(BigBlock * memoryBlocks);
+#if ENABLE_CONCURRENT_GC
     size_t TryMarkBigBlockListWithWriteWatch(BigBlock * memoryBlocks);
+#endif
 
     // Mark
     void ResetMarks(ResetMarkFlags flags);
@@ -1556,8 +1568,10 @@ private:
     bool EndMark();
     bool EndMarkCheckOOMRescan();
     void EndMarkOnLowMemory();
+#if ENABLE_CONCURRENT_GC
     void DoParallelMark();
     void DoBackgroundParallelMark();
+#endif
 
     size_t RootMark(CollectionState markState);
 
@@ -1593,7 +1607,11 @@ private:
     bool AddMark(void * candidate, size_t byteCount);
 
     // Sweep
+#if ENABLE_PARTIAL_GC
     bool Sweep(size_t rescanRootBytes = (size_t)-1, bool concurrent = false, bool adjustPartialHeuristics = false);
+#else
+    bool Sweep(bool concurrent = false);
+#endif
     void SweepWeakReference();
     void SweepHeap(bool concurrent, RecyclerSweep& recyclerSweep);
     void FinishSweep(RecyclerSweep& recyclerSweep);
@@ -1620,22 +1638,24 @@ private:
     template <Js::Phase phase>
     void CollectionEnd();
 
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     void ProcessClientTrackedObjects();
     bool PartialCollect(bool concurrent);
     void FinishPartialCollect(RecyclerSweep * recyclerSweep = nullptr);
     void ClearPartialCollect();
+#if ENABLE_CONCURRENT_GC
     void BackgroundFinishPartialCollect(RecyclerSweep * recyclerSweep);
 #endif
+#endif
 
-#if defined(PARTIAL_GC_ENABLED) || defined(CONCURRENT_GC_ENABLED)
     size_t RescanMark(DWORD waitTime);
     size_t FinishMark(DWORD waitTime);
     size_t FinishMarkRescan(bool background);
+#if ENABLE_CONCURRENT_GC
     void ProcessTrackedObjects();
 #endif
 
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     // Concurrent GC
     BOOL IsConcurrentEnabled() const { return this->enableConcurrentMark || this->enableParallelMark || this->enableConcurrentSweep; }
     BOOL IsConcurrentMarkState() const;
@@ -1693,10 +1713,10 @@ private:
 
     void SweepPendingObjects(RecyclerSweep& recyclerSweep);
     void ConcurrentTransferSweptObjects(RecyclerSweep& recyclerSweep);
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     void ConcurrentPartialTransferSweptObjects(RecyclerSweep& recyclerSweep);
-#endif // PARTIAL_GC_ENABLED
-#endif // CONCURRENT_GC_ENABLED
+#endif // ENABLE_PARTIAL_GC
+#endif // ENABLE_CONCURRENT_GC
 
     bool ForceSweepObject();
     void NotifyFree(__in char * address, size_t size);
@@ -2139,7 +2159,12 @@ public:
     static CollectedRecyclerWeakRefHeapBlock Instance;
 private:
 
-    CollectedRecyclerWeakRefHeapBlock() : HeapBlock(BlockTypeCount) { isPendingConcurrentSweep = false; }
+    CollectedRecyclerWeakRefHeapBlock() : HeapBlock(BlockTypeCount) 
+    { 
+#if ENABLE_CONCURRENT_GC
+        isPendingConcurrentSweep = false; 
+#endif
+    }
 };
 
 class AutoIdleDecommit

--- a/Lib/Common/Memory/Recycler.inl
+++ b/Lib/Common/Memory/Recycler.inl
@@ -55,8 +55,13 @@ Recycler::AllocWithAttributesInlined(size_t size)
     Assert(size != 0);
     AssertMsg(collectionState != Collection_PreCollection, "we cannot have allocation in precollection callback");
 
+#if ENABLE_CONCURRENT_GC
     // We shouldn't be allocating memory when we are running GC in thread, including finalizers
     Assert(this->IsConcurrentState() || !this->CollectionInProgress() || this->collectionState == CollectionStatePostCollectionCallback);
+#else
+    // We shouldn't be allocating memory when we are running GC in thread, including finalizers
+    Assert(!this->CollectionInProgress() || this->collectionState == CollectionStatePostCollectionCallback);
+#endif
 
     // There are some cases where we allow allocation during heap enum that doesn't affect the enumeration
     // Those should be really rare and not rely upon.
@@ -165,7 +170,7 @@ Recycler::AllocWithAttributesInlined(size_t size)
     }
 #endif
 
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
 #pragma prefast(suppress:6313, "attributes is a template parameter and can be 0")
     if (attributes & ClientTrackedBit)
     {
@@ -178,7 +183,11 @@ Recycler::AllocWithAttributesInlined(size_t size)
         }
         else
         {
+#if ENABLE_CONCURRENT_GC
             Assert(this->hasBackgroundFinishPartial || this->clientTrackedObjectList.Empty());
+#else
+            Assert(this->clientTrackedObjectList.Empty());
+#endif
         }
     }
 #endif

--- a/Lib/Common/Memory/RecyclerHeuristic.cpp
+++ b/Lib/Common/Memory/RecyclerHeuristic.cpp
@@ -76,7 +76,7 @@ RecyclerHeuristic::UncollectedAllocBytesCollection()
     return DefaultUncollectedAllocBytesCollection;
 }
 
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
 uint
 RecyclerHeuristic::MaxBackgroundFinishMarkCount(Js::ConfigFlagsTable& flags)
 {
@@ -155,7 +155,7 @@ RecyclerHeuristic::PriorityBoostTimeout(Js::ConfigFlagsTable& flags)
 }
 #endif
 
-#if defined(PARTIAL_GC_ENABLED) && defined(CONCURRENT_GC_ENABLED)
+#if ENABLE_PARTIAL_GC && ENABLE_CONCURRENT_GC
 bool
 RecyclerHeuristic::PartialConcurrentNextCollection(double ratio, Js::ConfigFlagsTable& flags)
 {

--- a/Lib/Common/Memory/RecyclerHeuristic.h
+++ b/Lib/Common/Memory/RecyclerHeuristic.h
@@ -36,14 +36,14 @@ public:
 
     // Constant heuristic that may be changed by switches
     static uint UncollectedAllocBytesCollection();
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     static uint MaxBackgroundFinishMarkCount(Js::ConfigFlagsTable&);
     static DWORD BackgroundFinishMarkWaitTime(bool, Js::ConfigFlagsTable&);
     static size_t MinBackgroundRepeatMarkRescanBytes(Js::ConfigFlagsTable&);
     static DWORD FinishConcurrentCollectWaitTime(Js::ConfigFlagsTable&);
     static DWORD PriorityBoostTimeout(Js::ConfigFlagsTable&);
 #endif
-#if defined(PARTIAL_GC_ENABLED) && defined(CONCURRENT_GC_ENABLED)
+#if ENABLE_PARTIAL_GC && ENABLE_CONCURRENT_GC
     static bool PartialConcurrentNextCollection(double ratio, Js::ConfigFlagsTable& flags);
 #endif
 
@@ -55,7 +55,7 @@ public:
                                                                                             // This heuristic is currently used for dispose on stack probes
     void ConfigureBaseFactor(uint baseFactor);
 
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     static const uint MaxBackgroundRepeatMarkCount = 2;
 
     // If we rescan at least 128 pages in the first background repeat mark,
@@ -69,7 +69,7 @@ private:
 #endif
     static const uint DefaultUncollectedAllocBytesCollection = 1 MEGABYTES;
 
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     static const uint TickCountConcurrentPriorityBoost = 5000;                              // 5 second
     static const DWORD DefaultFinishConcurrentCollectWaitTime = 1000;                       // 1 second
     static const uint DefaultMaxBackgroundFinishMarkCount = 1;

--- a/Lib/Common/Memory/RecyclerPageAllocator.cpp
+++ b/Lib/Common/Memory/RecyclerPageAllocator.cpp
@@ -25,6 +25,7 @@ bool RecyclerPageAllocator::IsMemProtectMode()
     return recycler->IsMemProtectMode();
 }
 
+#if ENABLE_CONCURRENT_GC
 void
 RecyclerPageAllocator::EnableWriteWatch()
 {
@@ -222,4 +223,5 @@ RecyclerPageAllocator::GetAllWriteWatchPageCount(DListBase<T> * segmentList)
     }
     return totalCount;
 }
+#endif
 #endif

--- a/Lib/Common/Memory/RecyclerPageAllocator.h
+++ b/Lib/Common/Memory/RecyclerPageAllocator.h
@@ -14,11 +14,14 @@ public:
         Js::ConfigFlagsTable& flagTable,
 #endif
         uint maxFreePageCount, uint maxAllocPageCount = PageAllocator::DefaultMaxAllocPageCount);
+#if ENABLE_CONCURRENT_GC
     void EnableWriteWatch();
     bool ResetWriteWatch();
+#endif
 
     static uint const DefaultPrimePageCount = 0x1000; // 16MB
 
+#if ENABLE_CONCURRENT_GC
 #if DBG
     size_t GetWriteWatchPageCount();
 #endif
@@ -31,6 +34,7 @@ private:
     static size_t GetWriteWatchPageCount(DListBase<PageSegment> * segmentList);
     template <typename T>
     static size_t GetAllWriteWatchPageCount(DListBase<T> * segmentList);
+#endif
 #endif
     ZeroPageQueue zeroPageQueue;
     Recycler* recycler;

--- a/Lib/Common/Memory/SmallBlockDeclarations.inl
+++ b/Lib/Common/Memory/SmallBlockDeclarations.inl
@@ -53,7 +53,7 @@ template bool SmallHeapBlockT<TBlockTypeAttributes>::GetFreeObjectListOnAllocato
 // Explicit instantiate all the sweep mode
 template void SmallHeapBlockT<TBlockTypeAttributes>::SweepObjects<true, SweepMode_InThread>(Recycler * recycler);
 template void SmallHeapBlockT<TBlockTypeAttributes>::SweepObjects<false, SweepMode_InThread>(Recycler * recycler);
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
 template <>
 template <>
 void
@@ -64,7 +64,7 @@ SmallHeapBlockT<TBlockTypeAttributes>::SweepObject<SweepMode_Concurrent>(Recycle
 }
 // Explicit instantiate all the sweep mode
 template void SmallHeapBlockT<TBlockTypeAttributes>::SweepObjects<false, SweepMode_Concurrent>(Recycler * recycler);
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
 template <>
 template <>
 void
@@ -96,7 +96,7 @@ SmallHeapBlockT<TBlockTypeAttributes>::SweepObject<SweepMode_InThread>(Recycler 
     {
         Assert(this->IsAnyFinalizableBlock());
 
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
         Assert(!recycler->IsConcurrentExecutingState());
 #endif
 

--- a/Lib/Common/Memory/SmallFinalizableHeapBlock.cpp
+++ b/Lib/Common/Memory/SmallFinalizableHeapBlock.cpp
@@ -126,7 +126,7 @@ SmallFinalizableHeapBlockT<TBlockAttributes>::ProcessMarkedObject(void* objectAd
     }
 }
 
-#if defined(PARTIAL_GC_ENABLED) || defined(CONCURRENT_GC_ENABLED)
+#if ENABLE_PARTIAL_GC || ENABLE_CONCURRENT_GC
 // static
 template <class TBlockAttributes>
 bool
@@ -197,7 +197,8 @@ bool
 SmallFinalizableHeapBlockT<TBlockAttributes>::RescanTrackedObject(FinalizableObject * object, uint objectIndex, Recycler * recycler)
 {
     RecyclerVerboseTrace(recycler->GetRecyclerFlagsTable(), L"Marking 0x%08x during rescan\n", object);
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
+#if ENABLE_PARTIAL_GC
     if (recycler->inPartialCollectMode)
     {
         Assert(!recycler->DoQueueTrackedObject());
@@ -221,6 +222,10 @@ SmallFinalizableHeapBlockT<TBlockAttributes>::RescanTrackedObject(FinalizableObj
     ObjectInfo(objectIndex) &= ~NewTrackBit;
 
     return true;
+#else
+    // REVIEW: Is this correct? Or should we remove the track bit always?
+    return false;
+#endif
 }
 #endif
 
@@ -393,7 +398,7 @@ SmallFinalizableHeapBlockT<TBlockAttributes>::Init(ushort objectSize, ushort obj
     __super::Init(objectSize, objectCount);
 }
 
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
 template <class TBlockAttributes>
 void
 SmallFinalizableHeapBlockT<TBlockAttributes>::FinishPartialCollect()

--- a/Lib/Common/Memory/SmallFinalizableHeapBlock.h
+++ b/Lib/Common/Memory/SmallFinalizableHeapBlock.h
@@ -27,7 +27,7 @@ public:
 
     void SetAttributes(void * address, unsigned char attributes);
 
-#if defined(PARTIAL_GC_ENABLED) || defined(CONCURRENT_GC_ENABLED)
+#if ENABLE_PARTIAL_GC || ENABLE_CONCURRENT_GC
     static bool CanRescanFullBlock();
     static bool RescanObject(SmallFinalizableHeapBlockT<TBlockAttributes> * block, __in_ecount(localObjectSize) char * objectAddress, uint localObjectSize, uint objectIndex, Recycler * recycler);
     bool RescanTrackedObject(FinalizableObject * object, uint objectIndex,  Recycler * recycler);
@@ -84,7 +84,7 @@ public:
     virtual bool GetFreeObjectListOnAllocator(FreeObject ** freeObjectList) override;
 #endif
 #if DBG
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     void FinishPartialCollect();
 #endif
     bool IsPendingDispose() const { return isPendingDispose; }

--- a/Lib/Common/Memory/SmallFinalizableHeapBucket.cpp
+++ b/Lib/Common/Memory/SmallFinalizableHeapBucket.cpp
@@ -31,13 +31,13 @@ SmallFinalizableHeapBucketBaseT<TBlockType>::FinalizeAllObjects()
     // Walk through the allocated object and call finalize and dispose on them
     this->ClearAllocators();
     FinalizeHeapBlockList(this->pendingDisposeList);
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     FinalizeHeapBlockList(this->partialHeapBlockList);
 #endif
     FinalizeHeapBlockList(this->heapBlockList);
     FinalizeHeapBlockList(this->fullBlockList);
 
-#if defined(PARTIAL_GC_ENABLED) && defined(CONCURRENT_GC_ENABLED)
+#if ENABLE_PARTIAL_GC && ENABLE_CONCURRENT_GC
     FinalizeHeapBlockList(this->partialSweptHeapBlockList);
 #endif
 }

--- a/Lib/Common/Memory/SmallFinalizableHeapBucket.h
+++ b/Lib/Common/Memory/SmallFinalizableHeapBucket.h
@@ -208,15 +208,15 @@ public:
 
     template<bool pageheap>
     void Sweep(RecyclerSweep& recyclerSweep);
-#if defined(PARTIAL_GC_ENABLED) || defined(CONCURRENT_GC_ENABLED)
     uint Rescan(Recycler * recycler, RescanFlags flags);
+#if ENABLE_CONCURRENT_GC
     void SweepPendingObjects(RecyclerSweep& recyclerSweep);
 #endif
-#ifdef PARTIAL_GC_ENABLED
+#if ENABLE_PARTIAL_GC
     void SweepPartialReusePages(RecyclerSweep& recyclerSweep);
     void FinishPartialCollect(RecyclerSweep * recyclerSweep);
 #endif
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     void PrepareSweep();
     void SetupBackgroundSweep(RecyclerSweep& recyclerSweep);
     void TransferPendingEmptyHeapBlocks(RecyclerSweep& recyclerSweep);

--- a/Lib/Common/Memory/SmallNormalHeapBlock.cpp
+++ b/Lib/Common/Memory/SmallNormalHeapBlock.cpp
@@ -72,8 +72,6 @@ SmallNormalHeapBlockT<MediumAllocationBlockAttributes>::SmallNormalHeapBlockT(He
 {
 }
 
-#if defined(PARTIAL_GC_ENABLED) || defined(CONCURRENT_GC_ENABLED)
-
 template <class TBlockAttributes>
 void
 SmallNormalHeapBlockT<TBlockAttributes>::ScanInitialImplicitRoots(Recycler * recycler)
@@ -171,9 +169,8 @@ SmallNormalHeapBlockT<TBlockAttributes>::CalculateMarkCountForPage(SmallHeapBloc
     return rescanMarkCount;
 }
 
-#endif
 
-#if defined(PARTIAL_GC_ENABLED) && defined(CONCURRENT_GC_ENABLED)
+#if ENABLE_PARTIAL_GC || ENABLE_CONCURRENT_GC
 template <class TBlockAttributes>
 void
 SmallNormalHeapBlockT<TBlockAttributes>::FinishPartialCollect()

--- a/Lib/Common/Memory/SmallNormalHeapBlock.h
+++ b/Lib/Common/Memory/SmallNormalHeapBlock.h
@@ -24,13 +24,11 @@ public:
     void ScanInitialImplicitRoots(Recycler * recycler);
     void ScanNewImplicitRoots(Recycler * recycler);
 
-#if defined(PARTIAL_GC_ENABLED) || defined(CONCURRENT_GC_ENABLED)
     static uint CalculateMarkCountForPage(SmallHeapBlockBitVector* markBits, uint bucketIndex, uint pageStartBitIndex);
 
     static bool CanRescanFullBlock();
     static bool RescanObject(SmallNormalHeapBlockT<TBlockAttributes> * block, __in_ecount(localObjectSize) char * objectAddress, uint localObjectSize, uint objectIndex, Recycler * recycler);
-#endif
-#if defined(PARTIAL_GC_ENABLED) && defined(CONCURRENT_GC_ENABLED)
+#if ENABLE_PARTIAL_GC || ENABLE_CONCURRENT_GC
     void FinishPartialCollect();
 #endif
 

--- a/Lib/Common/Memory/SmallNormalHeapBucket.h
+++ b/Lib/Common/Memory/SmallNormalHeapBucket.h
@@ -32,18 +32,18 @@ protected:
     void ScanInitialImplicitRoots(Recycler * recycler);
     void ScanNewImplicitRoots(Recycler * recycler);
 
-#if defined(PARTIAL_GC_ENABLED) || defined(CONCURRENT_GC_ENABLED)
     static bool RescanObjectsOnPage(TBlockType * block, char * address, char * blockStartAddress, BVStatic<TBlockAttributes::BitVectorCount>* markBits, const uint localObjectSize, uint bucketIndex, __out_opt bool* anyObjectRescanned, Recycler* recycler);
 
+#if ENABLE_CONCURRENT_GC
     void SweepPendingObjects(RecyclerSweep& recyclerSweep);
     template <SweepMode mode>
     static TBlockType * SweepPendingObjects(Recycler * recycler, TBlockType * list);
 #endif
-#ifdef PARTIAL_GC_ENABLED
-    ~SmallNormalHeapBucketBase();
-
     template<bool pageheap>
     void Sweep(RecyclerSweep& recyclerSweep);
+#if ENABLE_PARTIAL_GC
+    ~SmallNormalHeapBucketBase();
+
     template <class Fn>
     static void SweepPartialReusePages(RecyclerSweep& recyclerSweep, TBlockType * heapBlockList,
         TBlockType *& reuseBlocklist, TBlockType *&unusedBlockList, Fn callBack);
@@ -75,7 +75,7 @@ protected:
                                             // are not full but don't have a large amount of free space
                                             // where allocating from it causing a write watch to be triggered
                                             // is not worth the effort
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
     TBlockType * partialSweptHeapBlockList; // list of blocks that is partially swept
 #endif
 #endif

--- a/Lib/Runtime/Base/ScriptMemoryDumper.cpp
+++ b/Lib/Runtime/Base/ScriptMemoryDumper.cpp
@@ -150,9 +150,11 @@ void ScriptMemoryDumper::DumpLargeBucket(LargeHeapBucket* heapBucket)
     DumpLargeHeapBlockList(heapBucket->largePageHeapBlockList);
 #endif
     DumpLargeHeapBlockList(heapBucket->pendingDisposeLargeBlockList);
+#if ENABLE_CONCURRENT_GC
     DumpLargeHeapBlockList(heapBucket->pendingSweepLargeBlockList);
-#if defined(PARTIAL_GC_ENABLED) && defined(CONCURRENT_GC_ENABLED)
+#if ENABLE_PARTIAL_GC 
     DumpLargeHeapBlockList(heapBucket->partialSweptLargeBlockList);
+#endif
 #endif
 }
 

--- a/Lib/Runtime/Base/ThreadContext.cpp
+++ b/Lib/Runtime/Base/ThreadContext.cpp
@@ -656,7 +656,7 @@ public:
     AutoRecyclerPtr(Recycler * ptr) : AutoPtr<Recycler>(ptr) {}
     ~AutoRecyclerPtr()
     {
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
         if (ptr != nullptr)
         {
             ptr->ShutdownThread();
@@ -1298,7 +1298,7 @@ ThreadContext::EnterScriptStart(Js::ScriptEntryExitRecord * record, bool doClean
         if (doCleanup)
         {
             recycler->EnterIdleDecommit();
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
             recycler->FinishConcurrent<FinishConcurrentOnEnterScript>();
 #endif
             if (threadServiceWrapper == NULL)

--- a/Lib/Runtime/Base/ThreadContext.h
+++ b/Lib/Runtime/Base/ThreadContext.h
@@ -962,7 +962,7 @@ public:
             jobProcessor->Close();
         }
 #endif
-#ifdef CONCURRENT_GC_ENABLED
+#if ENABLE_CONCURRENT_GC
         if (this->recycler != nullptr)
         {
             this->recycler->ShutdownThread();

--- a/Lib/Runtime/Base/ThreadServiceWrapperBase.cpp
+++ b/Lib/Runtime/Base/ThreadServiceWrapperBase.cpp
@@ -95,6 +95,7 @@ bool ThreadServiceWrapperBase::IdleCollect()
 
     AutoBooleanToggle autoInIdleCollect(&inIdleCollect);
     Recycler* recycler = threadContext->GetRecycler();
+#if ENABLE_CONCURRENT_GC
     // Finish concurrent on timer heart beat if needed
     // We wouldn't try to finish if we need to schedule
     // an idle task to finish the collection
@@ -103,6 +104,7 @@ bool ThreadServiceWrapperBase::IdleCollect()
         IDLE_COLLECT_TRACE(L"Idle callback: finish concurrent\n");
         JS_ETW(EventWriteJSCRIPT_GC_IDLE_CALLBACK_FINISH(this));
     }
+#endif
 
     while (true)
     {
@@ -170,7 +172,9 @@ bool ThreadServiceWrapperBase::ScheduleNextCollectOnExit()
     Assert(!needIdleCollect || hasScheduledIdleCollect);
 
     Recycler* recycler = threadContext->GetRecycler();
+#if ENABLE_CONCURRENT_GC
     recycler->FinishConcurrent<FinishConcurrentOnExitScript>();
+#endif
 
 #ifdef RECYCLER_TRACE
     bool oldNeedIdleCollect = needIdleCollect;


### PR DESCRIPTION
Renamed `CONCURRENT_GC_ENABLED/PARTIAL_GC_ENABLED` to `ENABLE_CONCURRENT_GC/ENABLE_PARTIAL_GC` to follow the same pattern as other ENABLE_* macros in Chakra.
Converted #ifdef usage of these macros to #if so that setting them to 1 or 0 has an effect

ChakraCore can now be compiled with `ENABLE_CONCURRENT_GC = 0` and `ENABLE_PARTIAL_GC = 0`.
Note that by default, Concurrent and Partial GCs are enabled.

Some Rescan functionality has been moved out of being scoped under Concurrent-Enabled because Rescan is also used for marking in low-memory situations. However, the code has
been modified to not depend on write-watch behavior when Concurrent and Partial is off.
This change makes it easier to stand up the Recycler code in the linux branch.
