### PR TITLE
Add -includeSlow to dev12 builds to improve test coverage.

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -151,7 +151,7 @@ CreateBuildTasks('Windows_NT', null, null, null, true, null, null)
 // -----------------
 
 // build and test on Windows 7 with VS 2013 (Dev12/MsBuild12)
-CreateBuildTasks('Windows 7', 'daily_dev12', ' msbuild12', ' -win7', false,
+CreateBuildTasks('Windows 7', 'daily_dev12', ' msbuild12', ' -win7 -includeSlow', false,
     /* excludeConfigIf */ { isPR, buildArch, buildType -> (buildArch == 'arm') },
     /* nonDefaultTaskSetup */ { newJob, isPR, config ->
         DailyBuildTaskSetup(newJob, isPR,


### PR DESCRIPTION
Fixes #283