### PR TITLE
[linux] Build Chakra.Common.Memory

### DIFF
--- a/lib/Common/CommonDefines.h
+++ b/lib/Common/CommonDefines.h
@@ -100,8 +100,19 @@
 #define SUPPORT_FIXED_FIELDS_ON_PATH_TYPES          // *** TODO: Won't build if disabled currently
 
 // GC features
+
+// Concurrent and Partial GC are disabled on non-Windows builds
+// xplat-todo: re-enable this in the future
+// These are disabled because these GC features depend on hardware
+// write-watch support that the Windows Memory Manager provides.
+#ifdef _WIN32
 #define ENABLE_CONCURRENT_GC 1
-#define ENABLE_PARTIAL_GC 1  
+#define ENABLE_PARTIAL_GC 1
+#else
+#define ENABLE_CONCURRENT_GC 0
+#define ENABLE_PARTIAL_GC 0
+#endif
+
 #define BUCKETIZE_MEDIUM_ALLOCATIONS 1              // *** TODO: Won't build if disabled currently
 #define SMALLBLOCK_MEDIUM_ALLOC 1                   // *** TODO: Won't build if disabled currently
 #define LARGEHEAPBLOCK_ENCODING 1                   // Large heap block metadata encoding
@@ -462,8 +473,9 @@
 #define ENABLE_TRACE
 #endif
 
-#if DBG || defined(CHECK_MEMORY_LEAK) || defined(LEAK_REPORT) || defined(TRACK_DISPATCH) || defined(ENABLE_TRACE) || defined(RECYCLER_PAGE_HEAP)
+// xplat-todo: Capture stack backtrace on non-win32 platforms
 #ifdef _WIN32
+#if DBG || defined(CHECK_MEMORY_LEAK) || defined(LEAK_REPORT) || defined(TRACK_DISPATCH) || defined(ENABLE_TRACE) || defined(RECYCLER_PAGE_HEAP)
 #define STACK_BACK_TRACE
 #endif
 #endif

--- a/lib/Common/CommonPal.h
+++ b/lib/Common/CommonPal.h
@@ -29,7 +29,7 @@ typedef wchar_t wchar16;
 
 #else // !_WIN32
 
-#include "inc/pal.h"
+#include "pal.h"
 #include "inc/rt/palrt.h"
 #include "inc/rt/no_sal2.h"
 
@@ -191,8 +191,6 @@ PALIMPORT VOID PALAPI InitializeSListHead(IN OUT PSLIST_HEADER ListHead);
 PALIMPORT PSLIST_ENTRY PALAPI InterlockedPushEntrySList(IN OUT PSLIST_HEADER ListHead, IN OUT PSLIST_ENTRY  ListEntry);
 PALIMPORT PSLIST_ENTRY PALAPI InterlockedPopEntrySList(IN OUT PSLIST_HEADER ListHead);
 
-#define WRITE_WATCH_FLAG_RESET 1
-
 // xplat-todo: implement these for JIT and Concurrent/Partial GC
 uintptr_t _beginthreadex(
    void *security,
@@ -206,6 +204,12 @@ BOOL WINAPI GetModuleHandleEx(
   _In_opt_ LPCTSTR lpModuleName,
   _Out_    HMODULE *phModule
 );
+
+// xplat-todo: implement this function to get the stack bounds of the current
+// thread
+// For Linux, we could use pthread_getattr_np to get the stack limit (end)
+// and then use the stack size to calculate the stack base
+int GetCurrentThreadStackBounds(char** stackBase, char** stackEnd);
 
 // xplat-todo: cryptographically secure PRNG?
 errno_t rand_s(unsigned int* randomValue);
@@ -238,4 +242,12 @@ errno_t rand_s(unsigned int* randomValue);
 #define _NOEXCEPT
 #else
 #define _NOEXCEPT noexcept
+#endif
+
+// xplat-todo: can we get rid of this for clang?
+// Including xmmintrin.h right now creates a ton of
+// compile errors, so temporarily defining this for clang
+// to avoid including that header
+#ifndef _MSC_VER
+#define _MM_HINT_T0 3
 #endif

--- a/lib/Common/Exceptions/Throw.cpp
+++ b/lib/Common/Exceptions/Throw.cpp
@@ -60,7 +60,7 @@ extern "C"{
 }
 
 namespace Js {
-#ifdef GENERATE_DUMP
+#if defined(GENERATE_DUMP) && defined(STACK_BACK_TRACE)
     StackBackTrace * Throw::stackBackTrace = nullptr;
 #endif
     void Throw::FatalInternalError()
@@ -245,8 +245,11 @@ namespace Js {
     void Throw::LogAssert()
     {
         IsInAssert = true;
+
+#ifdef STACK_BACK_TRACE
         // This should be the last thing to happen in the process. Therefore, leaks are not an issue.
         stackBackTrace = StackBackTrace::Capture(&NoCheckHeapAllocator::Instance, Throw::StackToSkip, Throw::StackTraceDepth);
+#endif
     }
 
 #ifdef ENABLE_DEBUG_CONFIG_OPTIONS

--- a/lib/Common/Exceptions/Throw.h
+++ b/lib/Common/Exceptions/Throw.h
@@ -4,7 +4,9 @@
 //-------------------------------------------------------------------------------------------------------
 #pragma once
 
+#ifdef STACK_BACK_TRACE
 class StackBackTrace;
+#endif
 
 namespace Js {
 
@@ -29,9 +31,12 @@ namespace Js {
         static void GenerateDumpForAssert(LPCWSTR filePath);
     private:
         static CriticalSection csGenerateDump;
+#ifdef STACK_BACK_TRACE
         __declspec(thread) static  StackBackTrace * stackBackTrace;
+        
         static const int StackToSkip = 2;
         static const int StackTraceDepth = 40;
+#endif
 #endif
     };
 

--- a/lib/Common/Memory/ArenaAllocator.h
+++ b/lib/Common/Memory/ArenaAllocator.h
@@ -158,7 +158,7 @@ public:
     static const bool FakeZeroLengthArray = true;
     static const size_t MaxSmallObjectSize = 1024;
 
-    ArenaAllocatorBase(__in LPCWSTR name, PageAllocator * pageAllocator, void (*outOfMemoryFunc)(), void (*recoverMemoryFunc)() = JsUtil::ExternalApi::RecoverUnusedMemory);
+    ArenaAllocatorBase(__in wchar16 const* name, PageAllocator * pageAllocator, void (*outOfMemoryFunc)(), void (*recoverMemoryFunc)() = JsUtil::ExternalApi::RecoverUnusedMemory);
     ~ArenaAllocatorBase();
 
     void Reset()

--- a/lib/Common/Memory/AutoAllocatorObjectPtr.h
+++ b/lib/Common/Memory/AutoAllocatorObjectPtr.h
@@ -15,7 +15,7 @@ private:
     AllocatorType* m_allocator;
 
 public:
-    AutoAllocatorObjectPtr(T* ptr, AllocatorType* allocator) : BasePtr(ptr), m_allocator(allocator)
+    AutoAllocatorObjectPtr(T* ptr, AllocatorType* allocator) : BasePtr<T>(ptr), m_allocator(allocator)
     {
         Assert(allocator);
     }
@@ -28,10 +28,10 @@ public:
 private:
     void Clear()
     {
-        if (ptr != nullptr)
+        if (this->ptr != nullptr)
         {
-            DeleteObject<TAllocator>(m_allocator, ptr);
-            ptr = nullptr;
+            DeleteObject<TAllocator>(m_allocator, this->ptr);
+            this->ptr = nullptr;
         }
     }
 };
@@ -77,11 +77,13 @@ private:
 //      TAllocator      The allocator type used to allocate/free the objects.
 //      ArrayAllocator  The allocator type used to allocate/free the array.
 //
-template <typename T, typename TAllocator, typename ArrayAllocator = ForceNonLeafAllocator<TAllocator>::AllocatorType>
+template <typename T, typename TAllocator, typename ArrayAllocator = typename ForceNonLeafAllocator<TAllocator>::AllocatorType>
 class AutoAllocatorObjectArrayPtr : public AutoAllocatorArrayPtr<T*, ArrayAllocator>
 {
+    typedef AutoAllocatorArrayPtr<T*, ArrayAllocator> Base;
+    
 public:
-    AutoAllocatorObjectArrayPtr(T** ptr, size_t elementCount, AllocatorType* allocator) :
+    AutoAllocatorObjectArrayPtr(T** ptr, size_t elementCount, typename Base::AllocatorType* allocator) :
         AutoAllocatorArrayPtr(ptr, elementCount, allocator)
     {
     }

--- a/lib/Common/Memory/CMakeLists.txt
+++ b/lib/Common/Memory/CMakeLists.txt
@@ -1,45 +1,37 @@
 add_library (Chakra.Common.Memory
+    # xplat-todo: Include platform\XDataAllocator.cpp
+    # Needed on windows, need a replacement for linux to do
+    # amd64 stack walking
     Allocator.cpp
     ArenaAllocator.cpp
+
+    # xplat-todo: This is needed for allocating jitted code memory
+    # CustomHeap.cpp
+
     CommonMemoryPch.cpp
     EtwMemoryTracking.cpp
     ForcedMemoryConstraints.cpp
     HeapAllocator.cpp
     HeapAllocatorOperators.cpp
-
-    # xplat-todo: Fix me
-    #HeapBlock.cpp
-
+    HeapBlock.cpp
     HeapBlockMap.cpp
     HeapBucket.cpp
-
-    # xplat-todo: Fix me
-    #HeapInfo.cpp
-
+    HeapInfo.cpp
     IdleDecommitPageAllocator.cpp
-
-    # xplat-todo: Fix me
-    #LargeHeapBlock.cpp
-
+    LargeHeapBlock.cpp
     LargeHeapBucket.cpp
     LeakReport.cpp
     MarkContext.cpp
     MemoryLogger.cpp
     MemoryTracking.cpp
     PageAllocator.cpp
-
-    # xplat-todo: Fix me
-    #Recycler.cpp
-
+    Recycler.cpp
     RecyclerHeuristic.cpp
     RecyclerObjectDumper.cpp
     RecyclerObjectGraphDumper.cpp
     RecyclerPageAllocator.cpp
-    RecyclerSweep.cpp
-
-    # xplat-todo: Fix me
-    #RecyclerWriteBarrierManager.cpp
-
+    RecyclerSweep.cpp    
+    RecyclerWriteBarrierManager.cpp
     SmallFinalizableHeapBlock.cpp
     SmallFinalizableHeapBucket.cpp
     SmallHeapBlockAllocator.cpp
@@ -47,10 +39,7 @@ add_library (Chakra.Common.Memory
     SmallLeafHeapBucket.cpp
     SmallNormalHeapBlock.cpp
     SmallNormalHeapBucket.cpp
-
-    # xplat-todo: Are all the APIs used here ported?
-    # StressTest.cpp
-
+    StressTest.cpp
     VirtualAllocWrapper.cpp
     )
 

--- a/lib/Common/Memory/EtwMemoryTracking.cpp
+++ b/lib/Common/Memory/EtwMemoryTracking.cpp
@@ -4,6 +4,8 @@
 //-------------------------------------------------------------------------------------------------------
 #include "CommonMemoryPch.h"
 
+// xplat-todo: Need to figure out equivalent method for allocation tracing
+// on platforms other than Windows
 #ifdef ETW_MEMORY_TRACKING
 #include "microsoft-scripting-jscript9.internalevents.h"
 

--- a/lib/Common/Memory/HeapBlock.cpp
+++ b/lib/Common/Memory/HeapBlock.cpp
@@ -54,6 +54,7 @@ HeapBlock::SetNeedOOMRescan(Recycler * recycler)
     recycler->SetNeedOOMRescan();
 }
 
+#ifdef STACK_BACK_TRACE
 #ifdef RECYCLER_PAGE_HEAP
 void
 HeapBlock::CapturePageHeapAllocStack()
@@ -96,6 +97,7 @@ HeapBlock::CapturePageHeapFreeStack()
         this->pageHeapFreeStack = StackBackTrace::Capture(&NoCheckHeapAllocator::Instance, Recycler::s_numFramesToSkipForPageHeapFree, Recycler::s_numFramesToCaptureForPageHeap);
     }
 }
+#endif
 #endif
 
 //========================================================================================================
@@ -178,6 +180,7 @@ SmallHeapBlockT<TBlockAttributes>::~SmallHeapBlockT()
 #endif
 
 #ifdef RECYCLER_PAGE_HEAP
+#ifdef STACK_BACK_TRACE
     if (this->pageHeapAllocStack != nullptr)
     {
         this->pageHeapAllocStack->Delete(&NoCheckHeapAllocator::Instance);
@@ -191,6 +194,7 @@ SmallHeapBlockT<TBlockAttributes>::~SmallHeapBlockT()
         this->pageHeapFreeStack->Delete(&NoCheckHeapAllocator::Instance);
         this->pageHeapFreeStack = nullptr;
     }
+#endif
 #endif
 }
 
@@ -319,6 +323,7 @@ SmallHeapBlockT<TBlockAttributes>::Init(ushort objectSize, ushort objectCount)
     Assert(!this->isIntegratedBlock);
 
 #ifdef RECYCLER_PAGE_HEAP
+#ifdef STACK_BACK_TRACE
     if (this->pageHeapAllocStack != nullptr)
     {
         this->pageHeapAllocStack->Delete(&NoCheckHeapAllocator::Instance);
@@ -331,7 +336,8 @@ SmallHeapBlockT<TBlockAttributes>::Init(ushort objectSize, ushort objectCount)
     {
         this->pageHeapFreeStack->Delete(&NoCheckHeapAllocator::Instance);
         this->pageHeapFreeStack = nullptr;
-    }
+    }    
+#endif
 #endif
 }
 
@@ -637,6 +643,7 @@ SmallHeapBlockT<TBlockAttributes>::Reset()
 #endif
 
 #ifdef RECYCLER_PAGE_HEAP
+#ifdef STACK_BACK_TRACE
     if (this->pageHeapFreeStack != nullptr)
     {
         this->pageHeapFreeStack->Delete(&NoCheckHeapAllocator::Instance);
@@ -648,7 +655,7 @@ SmallHeapBlockT<TBlockAttributes>::Reset()
         this->pageHeapAllocStack->Delete(&NoCheckHeapAllocator::Instance);
         this->pageHeapAllocStack = nullptr;
     }
-
+#endif
 #endif
 
     // There is no page associated with this heap block,
@@ -2225,9 +2232,12 @@ SmallHeapBlockT<TBlockAttributes>::IsWithBarrier() const
 }
 #endif
 
+namespace Memory
+{
 // Instantiate the template
 template class SmallHeapBlockT<SmallAllocationBlockAttributes>;
 template class SmallHeapBlockT<MediumAllocationBlockAttributes>;
+};
 
 #define TBlockTypeAttributes SmallAllocationBlockAttributes
 #include "SmallBlockDeclarations.inl"

--- a/lib/Common/Memory/HeapBlock.h
+++ b/lib/Common/Memory/HeapBlock.h
@@ -285,13 +285,18 @@ protected:
     PageHeapMode pageHeapMode;
     DWORD guardPageOldProtectFlags;
     char* guardPageAddress;
+
+#ifdef STACK_BACK_TRACE
     StackBackTrace* pageHeapAllocStack;
     StackBackTrace* pageHeapFreeStack;
-
+#endif
+    
 public:
     __inline bool InPageHeapMode() const { return pageHeapMode != PageHeapMode::PageHeapModeOff; }
+#ifdef STACK_BACK_TRACE
     void CapturePageHeapAllocStack();
     void CapturePageHeapFreeStack();
+#endif
 #endif
 
 public:
@@ -303,7 +308,9 @@ public:
         heapBlockType(heapBlockType),
         needOOMRescan(false)
 #ifdef RECYCLER_PAGE_HEAP
+#ifdef STACK_BACK_TRACE
         , pageHeapAllocStack(nullptr), pageHeapFreeStack(nullptr)
+#endif
 #endif
     {
         Assert(GetHeapBlockType() <= HeapBlock::HeapBlockType::BlockTypeCount);
@@ -719,6 +726,14 @@ private:
     void ** GetTrackerDataArray();
 #endif
 };
+
+// Forward declare specializations
+template<>
+SmallHeapBlockT<MediumAllocationBlockAttributes>::SmallHeapBlockT(HeapBucket * bucket, ushort objectSize, ushort objectCount, HeapBlockType heapBlockType);
+
+template <>
+uint
+SmallHeapBlockT<MediumAllocationBlockAttributes>::GetObjectBitDeltaForBucketIndex(uint bucketIndex);
 
 // Declare the class templates
 typedef SmallHeapBlockT<SmallAllocationBlockAttributes>  SmallHeapBlock;

--- a/lib/Common/Memory/HeapInfo.h
+++ b/lib/Common/Memory/HeapInfo.h
@@ -277,7 +277,14 @@ private:
     template <typename TBlockAttributes>
     class ValidPointersMap
     {
+        // xplat-todo: fix up vpm.64b.h generation to generate correctly 
+        // templatized code
+#ifdef _WIN32
 #define USE_STATIC_VPM 1 // Disable to force generation at runtime
+#else
+#define USE_STATIC_VPM 0
+#endif
+        
     private:
         static const uint rowSize = TBlockAttributes::MaxSmallObjectCount * 2;
         typedef ushort ValidPointersMapRow[rowSize];
@@ -547,6 +554,13 @@ HeapInfo::SmallAllocatorAlloc(Recycler * recycler, SmallHeapBlockAllocatorType *
     return bucket.SnailAlloc(recycler, allocator, sizeCat, attributes, /* nothrow = */ false);
 }
 
+// Forward declaration of explicit specialization before instantiation
+template <>
+HRESULT HeapInfo::ValidPointersMap<SmallAllocationBlockAttributes>::GenerateValidPointersMapForBlockType(FILE* file);
+template <>
+HRESULT HeapInfo::ValidPointersMap<MediumAllocationBlockAttributes>::GenerateValidPointersMapForBlockType(FILE* file);
+
+// Template instantiation
 extern template class HeapInfo::ValidPointersMap<SmallAllocationBlockAttributes>;
 extern template class HeapInfo::ValidPointersMap<MediumAllocationBlockAttributes>;
 

--- a/lib/Common/Memory/LargeHeapBlock.cpp
+++ b/lib/Common/Memory/LargeHeapBlock.cpp
@@ -194,7 +194,7 @@ LargeHeapBlock::~LargeHeapBlock()
         "ReleasePages needs to be called before delete");
     RECYCLER_PERF_COUNTER_DEC(LargeHeapBlockCount);
 
-#ifdef RECYCLER_PAGE_HEAP
+#if defined(RECYCLER_PAGE_HEAP) && defined(STACK_BACK_TRACE)
     if (this->pageHeapAllocStack != nullptr)
     {
         this->pageHeapAllocStack->Delete(&NoCheckHeapAllocator::Instance);
@@ -461,7 +461,7 @@ LargeHeapBlock::AllocFreeListEntry(size_t size, ObjectInfoBits attributes, Large
     header->objectIndex = headerIndex;
     header->objectSize = originalSize;
     header->SetAttributes(this->heapInfo->recycler->Cookie, (attributes & StoredObjectInfoBitMask));
-    header->markOnOOMRescan = nullptr;
+    header->markOnOOMRescan = false;
     header->SetNext(this->heapInfo->recycler->Cookie, nullptr);
 
     HeaderList()[headerIndex] = header;

--- a/lib/Common/Memory/LargeHeapBucket.cpp
+++ b/lib/Common/Memory/LargeHeapBucket.cpp
@@ -234,7 +234,9 @@ LargeHeapBucket::PageHeapAlloc(Recycler * recycler, size_t size, ObjectInfoBits 
     Assert(memBlock != nullptr);
     if (recycler->ShouldCapturePageHeapAllocStack())
     {
+#ifdef STACK_BACK_TRACE
         heapBlock->CapturePageHeapAllocStack();
+#endif
     }
 
     return memBlock;

--- a/lib/Common/Memory/MarkContext.inl
+++ b/lib/Common/Memory/MarkContext.inl
@@ -2,6 +2,7 @@
 // Copyright (C) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
+
 __inline
 bool MarkContext::AddMarkedObject(void * objectAddress, size_t objectSize)
 {

--- a/lib/Common/Memory/Recycler.h
+++ b/lib/Common/Memory/Recycler.h
@@ -728,7 +728,7 @@ private:
 
     struct GuestArenaAllocator : public ArenaAllocator
     {
-        GuestArenaAllocator(__in LPCWSTR name, PageAllocator * pageAllocator, void (*outOfMemoryFunc)())
+        GuestArenaAllocator(__in wchar16 const*  name, PageAllocator * pageAllocator, void (*outOfMemoryFunc)())
             : ArenaAllocator(name, pageAllocator, outOfMemoryFunc), pendingDelete(false)
         {
         }
@@ -1189,7 +1189,7 @@ public:
     HeapInfo* CreateHeap();
     void DestroyHeap(HeapInfo* heapInfo);
 
-    ArenaAllocator * CreateGuestArena(wchar_t const * name, void (*outOfMemoryFunc)());
+    ArenaAllocator * CreateGuestArena(wchar16 const * name, void (*outOfMemoryFunc)());
     void DeleteGuestArena(ArenaAllocator * arenaAllocator);
 
     ArenaData ** RegisterExternalGuestArena(ArenaData* guestArena)
@@ -2080,7 +2080,9 @@ public:
         {
             Assert(recycler->IsPageHeapEnabled());
 
+#ifdef STACK_BACK_TRACE
             this->m_heapBlock->CapturePageHeapFreeStack();
+#endif
         }
 #endif
 

--- a/lib/Common/Memory/Recycler.inl
+++ b/lib/Common/Memory/Recycler.inl
@@ -445,7 +445,7 @@ Recycler::NotifyFree(T * heapBlock)
         this->isForceSweeping = true;
         heapBlock->isForceSweeping = true;
 #endif
-        heapBlock->SweepObjects<pageheap, SweepMode_InThread>(this);
+        heapBlock->template SweepObjects<pageheap, SweepMode_InThread>(this);
 #if DBG || defined(RECYCLER_STATS)
         heapBlock->isForceSweeping = false;
         this->isForceSweeping = false;

--- a/lib/Common/Memory/SmallHeapBlockAllocator.h
+++ b/lib/Common/Memory/SmallHeapBlockAllocator.h
@@ -166,7 +166,9 @@ SmallHeapBlockAllocator<TBlockType>::PageHeapAlloc(Recycler * recycler, size_t s
 
         if (recycler->ShouldCapturePageHeapAllocStack())
         {
+#ifdef STACK_BACK_TRACE
             smallBlock->CapturePageHeapAllocStack();
+#endif
         }
     }
 


### PR DESCRIPTION
This change gets Chakra.Common.Memory compiling on linux. It includes
the following:
1. Disable concurrent and partial GC on non-Windows build
2. Disable stack trace collection in page heap mode by wrapping under
the existing STACK_BACK_TRACE macro
3. Added a declaration for a wrapper method GetCurrentThreadStackBounds,
which would abstract out the getting of thread stack bounds on at least
x86 base platforms. Replaced cases where we were using kernel APIs to
get the stack bounds with this API (not yet implemented)
4. Disable static valid pointer map on Linux
5. Replace string usage in valid pointer map generation code with
CH_WSTRs/wchar16
6. Added a few template specialization forward declarations

There are xplat-todos sprinkled around this change- I'll collate them
and start opening issues where it makes sense.
