### PR TITLE
Don't allocate new strings when re-casing a string which didn't need it

### DIFF
--- a/lib/Runtime/Library/JavascriptString.cpp
+++ b/lib/Runtime/Library/JavascriptString.cpp
@@ -2195,7 +2195,7 @@ case_2:
 #endif
                 CharLowerBuffW(outStr + countToSkip, countToConvert);
 
-            Assert(converted == count);
+            Assert(converted == countToConvert);
         }
 
         return builder.ToString();

--- a/lib/Runtime/Library/JavascriptString.cpp
+++ b/lib/Runtime/Library/JavascriptString.cpp
@@ -2158,7 +2158,8 @@ case_2:
         }
         
         // if we reached the end of the string and didn't need recasing, we can return immediately
-        if(i == iLim) { 
+        if(i == iLim)
+        { 
             return pThis;
         }
         

--- a/lib/Runtime/Library/JavascriptString.cpp
+++ b/lib/Runtime/Library/JavascriptString.cpp
@@ -2135,7 +2135,6 @@ case_2:
     {
         charcount_t count = pThis->GetLength();
 
-        BufferStringBuilder builder(count, pThis->type->GetScriptContext());
         const wchar_t* inStr = pThis->GetString();
         wchar_t* i = inStr; 
         wchar_t* iLim = i + count;
@@ -2168,6 +2167,7 @@ case_2:
         charcount_t countToConvert = count - countToSkip; 
 
         // start by copying the whole string in a new buffer
+        BufferStringBuilder builder(count, pThis->type->GetScriptContext());
         wchar_t* outStr = builder.DangerousGetWritableBuffer();
         wchar_t* outStrLim = outStr + count;
         wchar_t* o = outStr;

--- a/lib/Runtime/Library/JavascriptString.cpp
+++ b/lib/Runtime/Library/JavascriptString.cpp
@@ -2166,9 +2166,9 @@ case_2:
         // if not, we have to copy the first part of the string, then case the rest
         charcount_t countToSkip = i - inStr;
         charcount_t countToConvert = count - countToSkip; 
-        wchar_t* outStr = builder.DangerousGetWritableBuffer();
 
         // start by copying the whole string in a new buffer
+        wchar_t* outStr = builder.DangerousGetWritableBuffer();
         wchar_t* outStrLim = outStr + count;
         wchar_t* o = outStr;
 

--- a/lib/Runtime/Library/JavascriptString.cpp
+++ b/lib/Runtime/Library/JavascriptString.cpp
@@ -2137,67 +2137,67 @@ case_2:
 
         BufferStringBuilder builder(count, pThis->type->GetScriptContext());
         const wchar_t* inStr = pThis->GetString();
-		wchar_t* i = inStr; 
-		wchar_t* iLim = i + count;
-		
-		// first, try to see if the string needs recasing at all
-		while(i < iLim)
-		{
-			
-			// copy the current char into a temporary variable, then case it
-			wchar_t inChar = *i;
-			wchar_t outChar = *i;
-			CharUpperBuffW(&outChar, 1);
-			
-			// if the output is different from the input, the string needs recasing from here
-			if(outChar != inChar) { break; }
-			
-			// otherwise, we can keep going on
-			i++;
-			
-		}
-		
-		// if we reached the end of the string and didn't need recasing, we can return immediately
-		if(i == iLim) { 
-			return pThis;
-		}
-		
-		// if not, we have to copy the first part of the string, then case the rest
-		charcount_t countToSkip = i - inStr;
-		charcount_t countToConvert = count - countToSkip; 
-		wchar_t* outStr = builder.DangerousGetWritableBuffer();
+        wchar_t* i = inStr; 
+        wchar_t* iLim = i + count;
+        
+        // first, try to see if the string needs recasing at all
+        while(i < iLim)
+        {
+            
+            // copy the current char into a temporary variable, then case it
+            wchar_t inChar = *i;
+            wchar_t outChar = *i;
+            CharUpperBuffW(&outChar, 1);
+            
+            // if the output is different from the input, the string needs recasing from here
+            if(outChar != inChar) { break; }
+            
+            // otherwise, we can keep going on
+            i++;
+            
+        }
+        
+        // if we reached the end of the string and didn't need recasing, we can return immediately
+        if(i == iLim) { 
+            return pThis;
+        }
+        
+        // if not, we have to copy the first part of the string, then case the rest
+        charcount_t countToSkip = i - inStr;
+        charcount_t countToConvert = count - countToSkip; 
+        wchar_t* outStr = builder.DangerousGetWritableBuffer();
 
-		// start by copying the whole string in a new buffer
-		wchar_t* outStrLim = outStr + count;
-		wchar_t* o = outStr;
+        // start by copying the whole string in a new buffer
+        wchar_t* outStrLim = outStr + count;
+        wchar_t* o = outStr;
 
-		while (o < outStrLim)
-		{
-			*o++ = *inStr++;
-		}
-		
-		// then recase it
-		if(toCase == ToUpper)
-		{
+        while (o < outStrLim)
+        {
+            *o++ = *inStr++;
+        }
+        
+        // then recase it
+        if(toCase == ToUpper)
+        {
 #if DBG
-			DWORD converted =
+            DWORD converted =
 #endif
-				CharUpperBuffW(outStr + countToSkip, countToConvert);
+                CharUpperBuffW(outStr + countToSkip, countToConvert);
 
-			Assert(converted == countToConvert);
-		}
-		else
-		{
-			Assert(toCase == ToLower);
+            Assert(converted == countToConvert);
+        }
+        else
+        {
+            Assert(toCase == ToLower);
 #if DBG
-			DWORD converted =
+            DWORD converted =
 #endif
-				CharLowerBuffW(outStr + countToSkip, countToConvert);
+                CharLowerBuffW(outStr + countToSkip, countToConvert);
 
-			Assert(converted == count);
-		}
+            Assert(converted == count);
+        }
 
-		return builder.ToString();
+        return builder.ToString();
     }
 
     Var JavascriptString::EntryTrim(RecyclableObject* function, CallInfo callInfo, ...)

--- a/lib/Runtime/Library/JavascriptString.cpp
+++ b/lib/Runtime/Library/JavascriptString.cpp
@@ -2136,8 +2136,8 @@ case_2:
         charcount_t count = pThis->GetLength();
 
         const wchar_t* inStr = pThis->GetString();
-        wchar_t* i = inStr; 
-        wchar_t* iLim = i + count;
+        const wchar_t* i = inStr; 
+        const wchar_t* iLim = i + count;
         
         // first, try to see if the string needs recasing at all
         while(i < iLim)


### PR DESCRIPTION
This is my first ChakraCore pull request. As you can probably guess from the code I'm not a very experienced C++ developer. I am not even sure this code actually improves performance, since it makes it longer, but I wanted to see what you guys thought about the idea.

Being a Microsoft Employee I don't think I need to sign a CLA or something, but if I am wrong let me know.