### PR TITLE
[Proxy]: do not erroneously report invariant check failure in [[SetPrototypeOf]]

### DIFF
--- a/lib/Parser/rterrors.h
+++ b/lib/Parser/rterrors.h
@@ -334,3 +334,5 @@ RT_ERROR_MSG(JSERR_SimdUint8x16TypeMismatch, 5639, "SIMD.Uint8x16.%s: Invalid SI
 
 RT_ERROR_MSG(JSERR_FunctionArgument_FirstCannotBeRegExp, 5640, "%s: first argument cannot be a RegExp", "First argument cannot be a RegExp", kjstTypeError, 0)
 RT_ERROR_MSG(JSERR_RegExpExecInvalidReturnType, 5641, "%s: Return value of RegExp 'exec' is not an Object and is not null", "Return value of RegExp 'exec' is not an Object and is not null", kjstTypeError, 0)
+
+RT_ERROR_MSG(JSERR_ProxyTrapReturnedFalse, 5642, "Proxy trap `%s` returned false", "Proxy trap returned false", kjstTypeError, 0)

--- a/lib/Runtime/Library/JavascriptProxy.cpp
+++ b/lib/Runtime/Library/JavascriptProxy.cpp
@@ -1410,7 +1410,7 @@ namespace Js
         {
             if (!prototypeSetted && shouldThrow)
             {
-                JavascriptError::ThrowTypeError(scriptContext, JSERR_InconsistentTrapResult, L"setPrototypeOf");
+                JavascriptError::ThrowTypeError(scriptContext, JSERR_ProxyTrapReturnedFalse, L"setPrototypeOf");
             }
             return prototypeSetted;
         }

--- a/test/es6/ProxySetPrototypeOf.js
+++ b/test/es6/ProxySetPrototypeOf.js
@@ -1,0 +1,31 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+
+var tests = [
+    {
+        name: "Object.setPrototypeOf(proxy), setPrototypeOf trap returns false",
+        body() {
+            var called = false;
+            var proxy = new Proxy({}, { setPrototypeOf() { called = true; return false; } });
+
+            assert.throws(() => Object.setPrototypeOf(proxy, {}), TypeError, "expected TypeError", "Proxy trap `setPrototypeOf` returned false");
+            assert.areEqual(true, called, "`setPrototypeOf` trap was called");
+        }
+    },
+    {
+        name: "Assignment to proxy.__proto__, setPrototypeOf trap returns false",
+        body() {
+            var called = false;
+            var proxy = new Proxy({}, { setPrototypeOf() { called = true; return false; } });
+
+            assert.throws(() => proxy.__proto__ = {}, TypeError, "expected TypeError", "Proxy trap `setPrototypeOf` returned false");
+            assert.areEqual(true, called, "`setPrototypeOf` trap was called");
+        }
+    }
+];
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -936,6 +936,12 @@
   </test>
   <test>
     <default>
+      <files>ProxySetPrototypeOf.js</files>
+      <compile-flags>-args summary -endargs</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>arraywithproxy.js</files>
       <baseline>arraywithproxy.baseline</baseline>
     </default>


### PR DESCRIPTION
Provides an error which more closely resembles V8's
"TypeError: 'setPrototypeOf' on proxy: trap returned falsish" message, to
replace the incorrect "invariant check failure" error.

Fixes #271