### PR TITLE
Change the sym binding of debugger from bytecode binding to parser binding.

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -712,7 +712,7 @@ bool ByteCodeGenerator::IsFalse(ParseNode* node)
 
 bool ByteCodeGenerator::UseParserBindings() const
 {
-    return IsInNonDebugMode() && !PHASE_OFF1(Js::ParserBindPhase);
+    return !PHASE_OFF1(Js::ParserBindPhase);
 }
 
 bool ByteCodeGenerator::IsES6DestructuringEnabled() const


### PR DESCRIPTION
The debugger does the bytecode binding for the symbol even though it was already done during the parser time. Removing this unnecessary binding.