### PR TITLE
Fixes global let shadowing non-configurable global properties

### DIFF
--- a/lib/Runtime/Library/RootObjectBase.cpp
+++ b/lib/Runtime/Library/RootObjectBase.cpp
@@ -214,7 +214,9 @@ namespace Js
     {
         Assert(!Js::IsInternalPropertyId(propertyId));
         bool isDeclared = false;
-        if (GetTypeHandler()->HasRootProperty(this, propertyId, nullptr, &isDeclared) && isDeclared)
+        bool isNonconfigurable = false;
+        if (GetTypeHandler()->HasRootProperty(this, propertyId, nullptr, &isDeclared, &isNonconfigurable) &&
+            (isDeclared || isNonconfigurable))
         {
             JavascriptError::ThrowReferenceError(this->GetScriptContext(), ERRRedeclaration);
         }

--- a/lib/Runtime/Types/DictionaryTypeHandler.cpp
+++ b/lib/Runtime/Types/DictionaryTypeHandler.cpp
@@ -385,18 +385,18 @@ namespace Js
     template <typename T>
     BOOL DictionaryTypeHandlerBase<T>::HasProperty(DynamicObject* instance, PropertyId propertyId, bool *noRedecl)
     {
-        return HasProperty_Internal<false>(instance, propertyId, noRedecl, nullptr);
+        return HasProperty_Internal<false>(instance, propertyId, noRedecl, nullptr, nullptr);
     }
 
     template <typename T>
-    BOOL DictionaryTypeHandlerBase<T>::HasRootProperty(DynamicObject* instance, PropertyId propertyId, bool *noRedecl, bool *pDeclaredProperty = nullptr)
+    BOOL DictionaryTypeHandlerBase<T>::HasRootProperty(DynamicObject* instance, PropertyId propertyId, bool *noRedecl, bool *pDeclaredProperty, bool *pNonconfigurableProperty)
     {
-        return HasProperty_Internal<true>(instance, propertyId, noRedecl, pDeclaredProperty);
+        return HasProperty_Internal<true>(instance, propertyId, noRedecl, pDeclaredProperty, pNonconfigurableProperty);
     }
 
     template <typename T>
     template <bool allowLetConstGlobal>
-    BOOL DictionaryTypeHandlerBase<T>::HasProperty_Internal(DynamicObject* instance, PropertyId propertyId, bool *noRedecl, bool *pDeclaredProperty)
+    BOOL DictionaryTypeHandlerBase<T>::HasProperty_Internal(DynamicObject* instance, PropertyId propertyId, bool *noRedecl, bool *pDeclaredProperty, bool *pNonconfigurableProperty)
     {
         // HasProperty is called with NoProperty in JavascriptDispatch.cpp to for undeferral of the
         // deferred type system that DOM objects use.  Allow NoProperty for this reason, but only
@@ -422,6 +422,10 @@ namespace Js
             if (pDeclaredProperty && descriptor->Attributes & (PropertyNoRedecl | PropertyDeclaredGlobal))
             {
                 *pDeclaredProperty = true;
+            }
+            if (pNonconfigurableProperty && !(descriptor->Attributes & PropertyConfigurable))
+            {
+                *pNonconfigurableProperty = true;
             }
             return true;
         }

--- a/lib/Runtime/Types/DictionaryTypeHandler.h
+++ b/lib/Runtime/Types/DictionaryTypeHandler.h
@@ -93,7 +93,7 @@ namespace Js
 
         virtual PropertyIndex GetRootPropertyIndex(PropertyRecord const* propertyRecord) override;
 
-        virtual BOOL HasRootProperty(DynamicObject* instance, PropertyId propertyId, bool *noRedecl, bool *pDeclaredProperty = nullptr) override;
+        virtual BOOL HasRootProperty(DynamicObject* instance, PropertyId propertyId, bool *noRedecl, bool *pDeclaredProperty = nullptr, bool *pNonconfigurableProperty = nullptr) override;
         virtual BOOL GetRootProperty(DynamicObject* instance, Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;
         virtual BOOL SetRootProperty(DynamicObject* instance, PropertyId propertyId, Var value, PropertyOperationFlags flags, PropertyValueInfo* info) override;
         virtual DescriptorFlags GetRootSetter(DynamicObject* instance, PropertyId propertyId, Var* setterValue, PropertyValueInfo* info, ScriptContext* requestContext) override;
@@ -214,7 +214,7 @@ namespace Js
         void SetPropertyValueInfo(PropertyValueInfo* info, RecyclableObject* instance, T propIndex, PropertyAttributes attributes, InlineCacheFlags flags = InlineCacheNoFlags);
 
         template<bool allowLetConstGlobal>
-        __inline BOOL HasProperty_Internal(DynamicObject* instance, PropertyId propertyId, bool *noRedecl, bool *pDeclaredProperty);
+        __inline BOOL HasProperty_Internal(DynamicObject* instance, PropertyId propertyId, bool *noRedecl, bool *pDeclaredProperty, bool *pNonconfigurableProperty);
         template<bool allowLetConstGlobal>
         __inline PropertyIndex GetPropertyIndex_Internal(PropertyRecord const* propertyRecord);
         template<bool allowLetConstGlobal>

--- a/lib/Runtime/Types/SimpleDictionaryTypeHandler.cpp
+++ b/lib/Runtime/Types/SimpleDictionaryTypeHandler.cpp
@@ -1060,18 +1060,18 @@ namespace Js
     template <typename TPropertyIndex, typename TMapKey, bool IsNotExtensibleSupported>
     BOOL SimpleDictionaryTypeHandlerBase<TPropertyIndex, TMapKey, IsNotExtensibleSupported>::HasProperty(DynamicObject* instance, PropertyId propertyId, bool *noRedecl)
     {
-        return HasProperty_Internal<false>(instance, propertyId, noRedecl, nullptr);
+        return HasProperty_Internal<false>(instance, propertyId, noRedecl, nullptr, nullptr);
     }
 
     template <typename TPropertyIndex, typename TMapKey, bool IsNotExtensibleSupported>
-    BOOL SimpleDictionaryTypeHandlerBase<TPropertyIndex, TMapKey, IsNotExtensibleSupported>::HasRootProperty(DynamicObject* instance, PropertyId propertyId, bool *noRedecl, bool *pDeclaredProperty)
+    BOOL SimpleDictionaryTypeHandlerBase<TPropertyIndex, TMapKey, IsNotExtensibleSupported>::HasRootProperty(DynamicObject* instance, PropertyId propertyId, bool *noRedecl, bool *pDeclaredProperty, bool *pNonconfigurableProperty)
     {
-        return HasProperty_Internal<true>(instance, propertyId, noRedecl, pDeclaredProperty);
+        return HasProperty_Internal<true>(instance, propertyId, noRedecl, pDeclaredProperty, pNonconfigurableProperty);
     }
 
     template <typename TPropertyIndex, typename TMapKey, bool IsNotExtensibleSupported>
     template <bool allowLetConstGlobal>
-    BOOL SimpleDictionaryTypeHandlerBase<TPropertyIndex, TMapKey, IsNotExtensibleSupported>::HasProperty_Internal(DynamicObject* instance, PropertyId propertyId, bool *noRedecl, bool *pDeclaredProperty)
+    BOOL SimpleDictionaryTypeHandlerBase<TPropertyIndex, TMapKey, IsNotExtensibleSupported>::HasProperty_Internal(DynamicObject* instance, PropertyId propertyId, bool *noRedecl, bool *pDeclaredProperty, bool *pNonconfigurableProperty)
     {
         // HasProperty is called with NoProperty in JavascriptDispatch.cpp to for undeferral of the
         // deferred type system that DOM objects use.  Allow NoProperty for this reason, but only
@@ -1097,6 +1097,10 @@ namespace Js
             if (pDeclaredProperty && descriptor->Attributes & (PropertyNoRedecl | PropertyDeclaredGlobal))
             {
                 *pDeclaredProperty = true;
+            }
+            if (pNonconfigurableProperty && !(descriptor->Attributes & PropertyConfigurable))
+            {
+                *pNonconfigurableProperty = true;
             }
             return true;
         }

--- a/lib/Runtime/Types/SimpleDictionaryTypeHandler.h
+++ b/lib/Runtime/Types/SimpleDictionaryTypeHandler.h
@@ -136,7 +136,7 @@ namespace Js
 
         virtual PropertyIndex GetRootPropertyIndex(const PropertyRecord* propertyRecord) override;
 
-        virtual BOOL HasRootProperty(DynamicObject* instance, PropertyId propertyId, bool *noRedecl, bool *pDeclaredProperty = nullptr) override;
+        virtual BOOL HasRootProperty(DynamicObject* instance, PropertyId propertyId, bool *noRedecl, bool *pDeclaredProperty = nullptr, bool *pNonconfigurableProperty = nullptr) override;
         virtual BOOL GetRootProperty(DynamicObject* instance, Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;
         virtual BOOL SetRootProperty(DynamicObject* instance, PropertyId propertyId, Var value, PropertyOperationFlags flags, PropertyValueInfo* info) override;
         virtual DescriptorFlags GetRootSetter(DynamicObject* instance, PropertyId propertyId, Var* setterValue, PropertyValueInfo* info, ScriptContext* requestContext) override;
@@ -263,7 +263,7 @@ namespace Js
         virtual BOOL FreezeImpl(DynamicObject* instance, bool isConvertedType) override;
 
         template <bool allowLetConstGlobal>
-        __inline BOOL HasProperty_Internal(DynamicObject* instance, PropertyId propertyId, bool *noRedecl, bool *pDeclaredProperty);
+        __inline BOOL HasProperty_Internal(DynamicObject* instance, PropertyId propertyId, bool *noRedecl, bool *pDeclaredProperty, bool *pNonconfigurableProperty);
         template <bool allowLetConstGlobal>
         __inline PropertyIndex GetPropertyIndex_Internal(const PropertyRecord* propertyRecord);
         template <bool allowLetConstGlobal>

--- a/lib/Runtime/Types/TypeHandler.h
+++ b/lib/Runtime/Types/TypeHandler.h
@@ -435,7 +435,7 @@ namespace Js
         //
         virtual PropertyIndex GetRootPropertyIndex(PropertyRecord const* propertyRecord) { Throw::FatalInternalError(); }
 
-        virtual BOOL HasRootProperty(DynamicObject* instance, PropertyId propertyId, __out_opt bool *pNoRedecl = nullptr, __out_opt bool *pDeclaredProperty = nullptr) { Throw::FatalInternalError(); }
+        virtual BOOL HasRootProperty(DynamicObject* instance, PropertyId propertyId, __out_opt bool *pNoRedecl = nullptr, __out_opt bool *pDeclaredProperty = nullptr, __out_opt bool *pNonconfigurableProperty = nullptr) { Throw::FatalInternalError(); }
         virtual BOOL GetRootProperty(DynamicObject* instance, Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) { Throw::FatalInternalError(); }
         virtual BOOL SetRootProperty(DynamicObject* instance, PropertyId propertyId, Var value, PropertyOperationFlags flags, PropertyValueInfo* info) { Throw::FatalInternalError(); }
         virtual DescriptorFlags GetRootSetter(DynamicObject* instance, PropertyId propertyId, Var* setterValue, PropertyValueInfo* info, ScriptContext* requestContext) { Throw::FatalInternalError(); }

--- a/test/es6/letconst_global_shadow_builtins.baseline
+++ b/test/es6/letconst_global_shadow_builtins.baseline
@@ -1,4 +1,6 @@
 [object Math]
+ReferenceError: Use before declaration
+ReferenceError: Use before declaration
 [object Math]
 3.141592653589793
 undefined
@@ -6,15 +8,11 @@ undefined
 undefined
 delicious
 [object JSON]
+ReferenceError: Use before declaration
+ReferenceError: Use before declaration
 [object JSON]
 function stringify() { [native code] }
 undefined
 [object Object]
 undefined
 no dice
-NaN
-NaN
-Infinity
-Infinity
-undefined
-undefined

--- a/test/es6/letconst_global_shadow_builtins.js
+++ b/test/es6/letconst_global_shadow_builtins.js
@@ -6,11 +6,18 @@
 function print(x) { WScript.Echo(x+'') }
 
 print(this.Math);
-// REVIEW: Should a let that shadows a built-in (or undeclared)
-// cause Use Before Declaration errors at naked references?
-// I would say yes.
-//print(Math.PI);
-//print(Math);
+
+try {
+    print(Math.PI);
+} catch (e) {
+    print(e);
+}
+
+try {
+    print(Math);
+} catch (e) {
+    print(e);
+}
 
 let Math = { PIE: "delicious" };
 
@@ -22,8 +29,18 @@ print(Math.PI);
 print(Math.PIE);
 
 print(this.JSON);
-//print(JSON.stringify);
-//print(JSON);
+
+try {
+    print(JSON.stringify);
+} catch (e) {
+    print(e);
+}
+
+try {
+    print(JSON);
+} catch (e) {
+    print(e);
+}
 
 const JSON = { stringifize: "no dice" };
 
@@ -33,21 +50,3 @@ print(this.JSON.stringifize);
 print(JSON);
 print(JSON.stringify);
 print(JSON.stringifize);
-
-// Test for bugfix 822845
-//   Exprgen:CAS::CHK: ASSERT:  info->IsWritable() (jscript9test!Js::CacheOperators::CachePropertyWrite<1,Js::InlineCache> 811
-let NaN;
-NaN=1;
-print(NaN);  // output:"NaN" desired:"1" pending:bug896007
-print(this.NaN);
-
-let Infinity;
-Infinity=2;
-print(Infinity);  // output:"Infinity" desired:"2" pending:bug896007
-print(this.Infinity);
-
-let undefined;
-undefined=3;
-print(undefined);  // output:"Infinity" desired:"2" pending:bug896007
-print(this.undefined);
-

--- a/test/es6/letconst_global_shadow_builtins_nonconfigurable.baseline
+++ b/test/es6/letconst_global_shadow_builtins_nonconfigurable.baseline
@@ -1,0 +1,2 @@
+ReferenceError: Let/Const redeclaration
+	at Global code (letconst_global_shadow_builtins_nonconfigurable.js:8:1)

--- a/test/es6/letconst_global_shadow_builtins_nonconfigurable.js
+++ b/test/es6/letconst_global_shadow_builtins_nonconfigurable.js
@@ -1,0 +1,10 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+// Non-configurable global properties are not shadowable.  Instead this causes an early error.
+
+print(undefined); // shouldn't execute
+let undefined = "foo";
+print(undefined); // shouldn't execute

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -243,6 +243,12 @@
   </test>
   <test>
     <default>
+      <files>letconst_global_shadow_builtins_nonconfigurable.js</files>
+      <baseline>letconst_global_shadow_builtins_nonconfigurable.baseline</baseline>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>letconst_global_shadow_deleted.js</files>
       <baseline>letconst_global_shadow_deleted.baseline</baseline>
     </default>


### PR DESCRIPTION
Fixes #165

The ES6 spec states that an early error should be thrown if a global
lexical declaration conflicts with a non-configurable global property.

Fix by updating the global script preamble check for declaration
conflicts to also incorporate non-configurable globals.
