### PR TITLE
Generate fast paths for LdSuper, LdSuperCtor, and SetHomeObj

### DIFF
--- a/lib/Backend/Backend.h
+++ b/lib/Backend/Backend.h
@@ -24,6 +24,8 @@
 #include "Library/JavascriptGenerator.h"
 #include "Library/JavascriptRegularExpression.h"
 #include "Library/StackScriptFunction.h"
+#include "Library/JavascriptProxy.h"
+#include "Library/JavascriptGeneratorFunction.h"
 
 #include "Language/InterpreterStackFrame.h"
 #include "Language/ReadOnlyDynamicProfileInfo.h"

--- a/lib/Backend/Lower.h
+++ b/lib/Backend/Lower.h
@@ -457,6 +457,12 @@ private:
     void            GenerateFastCmTypeOf(IR::Instr *compare, IR::RegOpnd *object, IR::IntConstOpnd *typeIdOpnd, IR::Instr *typeOf, bool *pfNoLower);
     void            GenerateFalsyObjectTest(IR::Instr *insertInstr, IR::RegOpnd *TypeOpnd, Js::TypeId typeIdToCheck, IR::LabelInstr* target, IR::LabelInstr* done, bool isNeqOp);
 
+    void            GenerateJavascriptOperatorsIsConstructorGotoElse(IR::Instr *instrInsert, IR::RegOpnd *instanceRegOpnd, IR::LabelInstr *labelTrue, IR::LabelInstr *labelFalse);
+    void            GenerateRecyclableObjectGetPrototypeNullptrGoto(IR::Instr *instrInsert, IR::RegOpnd *instanceRegOpnd, IR::LabelInstr *labelReturnNullptr);
+    void            GenerateRecyclableObjectIsElse(IR::Instr *instrInsert, IR::RegOpnd *instanceRegOpnd, IR::LabelInstr *labelFalse);
+    void            GenerateLdSuper(IR::Instr* instrInsert);
+    void            GenerateLdSuperCtor(IR::Instr* instrInsert);
+    void            GenerateSetHomeObj(IR::Instr* instrInsert);
     void            GenerateLoadNewTarget(IR::Instr* instrInsert);
     void            GenerateCheckForCallFlagNew(IR::Instr* instrInsert);
     void            GenerateGetCurrentFunctionObject(IR::Instr * instr);

--- a/lib/Backend/amd64/LowererMDArch.cpp
+++ b/lib/Backend/amd64/LowererMDArch.cpp
@@ -636,7 +636,7 @@ LowererMDArch::GeneratePreCall(IR::Instr * callInstr, IR::Opnd  *functionObjOpnd
     {
         functionTypeRegOpnd = IR::RegOpnd::New(TyMachReg, m_func);
 
-        IR::IndirOpnd* functionInfoIndirOpnd = IR::IndirOpnd::New(functionObjOpnd->AsRegOpnd(), Js::RecyclableObject::GetTypeOffset(), TyMachReg, m_func);
+        IR::IndirOpnd* functionInfoIndirOpnd = IR::IndirOpnd::New(functionObjOpnd->AsRegOpnd(), Js::RecyclableObject::GetOffsetOfType(), TyMachReg, m_func);
 
         IR::Instr* instr = IR::Instr::New(Js::OpCode::MOV, functionTypeRegOpnd, functionInfoIndirOpnd, m_func);
 

--- a/lib/Backend/i386/LowererMDArch.cpp
+++ b/lib/Backend/i386/LowererMDArch.cpp
@@ -830,7 +830,7 @@ LowererMDArch::LowerAsmJsCallI(IR::Instr * callInstr)
 
     IR::RegOpnd* functionTypeRegOpnd = IR::RegOpnd::New(TyMachReg, m_func);
 
-    IR::IndirOpnd* functionInfoIndirOpnd = IR::IndirOpnd::New(functionObjOpnd->AsRegOpnd(), Js::RecyclableObject::GetTypeOffset(), TyMachReg, m_func);
+    IR::IndirOpnd* functionInfoIndirOpnd = IR::IndirOpnd::New(functionObjOpnd->AsRegOpnd(), Js::RecyclableObject::GetOffsetOfType(), TyMachReg, m_func);
 
     IR::Instr* instr = IR::Instr::New(Js::OpCode::MOV, functionTypeRegOpnd, functionInfoIndirOpnd, m_func);
 

--- a/lib/Common/BackendApi.h
+++ b/lib/Common/BackendApi.h
@@ -258,6 +258,8 @@ enum VTableValue {
     VtableNativeFloatArray,
     VtableJavascriptNativeIntArray,
     VtableJavascriptRegExp,
+    VtableScriptFunction,
+    VtableJavascriptGeneratorFunction,
     VtableStackScriptFunction,
     VtableConcatStringMulti,
     VtableCompoundString,

--- a/lib/Parser/rterrors.h
+++ b/lib/Parser/rterrors.h
@@ -250,7 +250,7 @@ RT_ERROR_MSG(JSERR_WeakMapSetKeyNotAnObject, 5117, "%s: 'key' is not an object",
 
 RT_ERROR_MSG(JSERR_OptionValueOutOfRange, 5118, "Option value '%s' for '%s' is outside of valid range. Expected: %s", "Option value is outside of valid range", kjstRangeError, 0)
 RT_ERROR_MSG(JSERR_NeedObjectOrString, 5119, "%s is not an object or a string", "Object or string expected", kjstTypeError, 0)
-RT_ERROR_MSG(JSERR_NotAConstructor, 5120, "Function '%s' is not a constructor", "This can't be used in a new statement", kjstTypeError, 0)
+RT_ERROR_MSG(JSERR_NotAConstructor, 5120, "Function '%s' is not a constructor", "Function is not a constructor", kjstTypeError, 0)
 
 //Intl Specific
 RT_ERROR_MSG(JSERR_LocaleNotWellFormed, 5121, "Locale '%s' is not well-formed", "Locale is not well-formed", kjstRangeError, 0)

--- a/lib/Runtime/Base/FunctionInfo.h
+++ b/lib/Runtime/Base/FunctionInfo.h
@@ -40,6 +40,7 @@ namespace Js
         FunctionInfo(JavascriptMethod entryPoint, Attributes attributes = None, LocalFunctionId functionId = Js::Constants::NoFunctionId, FunctionBody* functionBodyImpl = NULL);
 
         static DWORD GetFunctionBodyImplOffset() { return offsetof(FunctionInfo, functionBodyImpl); }
+        static DWORD GetAttributesOffset() { return offsetof(FunctionInfo, attributes); }
 
         void VerifyOriginalEntryPoint() const;
         JavascriptMethod GetOriginalEntryPoint() const;

--- a/lib/Runtime/Language/i386/AsmJsJitTemplate.cpp
+++ b/lib/Runtime/Language/i386/AsmJsJitTemplate.cpp
@@ -3349,7 +3349,7 @@ namespace Js
 
             size += PUSH::EncodeInstruction<int>( buffer, InstrParamsReg(reg));
 
-            size += MOV::EncodeInstruction<int>(buffer, InstrParamsRegAddr(RegEAX, reg, RecyclableObject::GetTypeOffset()));
+            size += MOV::EncodeInstruction<int>(buffer, InstrParamsRegAddr(RegEAX, reg, RecyclableObject::GetOffsetOfType()));
 
             size += MOV::EncodeInstruction<int>(buffer, InstrParamsRegAddr(RegEAX, RegEAX, ScriptFunctionType::GetEntryPointInfoOffset()));
 

--- a/lib/Runtime/Library/JavascriptGeneratorFunction.h
+++ b/lib/Runtime/Library/JavascriptGeneratorFunction.h
@@ -34,6 +34,7 @@ namespace Js
 
         static JavascriptGeneratorFunction* OP_NewScGenFunc(FrameDisplay* environment, FunctionProxy** proxyRef);
         static Var EntryGeneratorFunctionImplementation(RecyclableObject* function, CallInfo callInfo, ...);
+        static DWORD GetOffsetOfScriptFunction() { return offsetof(JavascriptGeneratorFunction, scriptFunction); }
 
         virtual Var GetHomeObj() const override;
         virtual void SetHomeObj(Var homeObj) override;

--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -3185,6 +3185,8 @@ namespace Js
         vtableAddresses[VTableValue::VtableJavascriptNativeIntArray] = VirtualTableInfo<Js::JavascriptNativeIntArray>::Address;
         vtableAddresses[VTableValue::VtableJavascriptRegExp] = VirtualTableInfo<Js::JavascriptRegExp>::Address;
         vtableAddresses[VTableValue::VtableStackScriptFunction] = VirtualTableInfo<Js::StackScriptFunction>::Address;
+        vtableAddresses[VTableValue::VtableScriptFunction] = VirtualTableInfo<Js::ScriptFunction>::Address;
+        vtableAddresses[VTableValue::VtableJavascriptGeneratorFunction] = VirtualTableInfo<Js::JavascriptGeneratorFunction>::Address;
         vtableAddresses[VTableValue::VtableConcatStringMulti] = VirtualTableInfo<Js::ConcatStringMulti>::Address;
         vtableAddresses[VTableValue::VtableCompoundString] = VirtualTableInfo<Js::CompoundString>::Address;
 

--- a/lib/Runtime/Library/JavascriptProxy.h
+++ b/lib/Runtime/Library/JavascriptProxy.h
@@ -65,6 +65,8 @@ namespace Js
         static BOOL GetOwnPropertyDescriptor(RecyclableObject* obj, PropertyId propertyId, ScriptContext* scriptContext, PropertyDescriptor* propertyDescriptor);
         static BOOL DefineOwnPropertyDescriptor(RecyclableObject* obj, PropertyId propId, const PropertyDescriptor& descriptor, bool throwOnError, ScriptContext* scriptContext);
 
+        static DWORD GetOffsetOfTarget() { return offsetof(JavascriptProxy, target); }
+
         virtual BOOL HasProperty(PropertyId propertyId) override;
         virtual BOOL HasOwnProperty(PropertyId propertyId) override;
         virtual BOOL HasOwnPropertyNoHostObject(PropertyId propertyId) override;

--- a/lib/Runtime/Library/ScriptFunction.h
+++ b/lib/Runtime/Library/ScriptFunction.h
@@ -69,6 +69,7 @@ namespace Js
         static uint32 GetOffsetOfEnvironment() { return offsetof(ScriptFunction, environment); }
         static uint32 GetOffsetOfCachedScopeObj() { return offsetof(ScriptFunction, cachedScopeObj); };
         static uint32 GetOffsetOfHasInlineCaches() { return offsetof(ScriptFunction, hasInlineCaches); };
+        static uint32 GetOffsetOfHomeObj() { return  offsetof(ScriptFunction, homeObj); }
 
         void ChangeEntryPoint(ProxyEntryPointInfo* entryPointInfo, JavascriptMethod entryPoint);
         JavascriptMethod UpdateThunkEntryPoint(FunctionEntryPointInfo* entryPointInfo, JavascriptMethod entryPoint);

--- a/lib/Runtime/Types/RecyclableObject.cpp
+++ b/lib/Runtime/Types/RecyclableObject.cpp
@@ -202,12 +202,6 @@ namespace Js
         return this->GetType()->SkipsPrototype();
     }
 
-    uint32
-    RecyclableObject::GetOffsetOfType()
-    {
-        return offsetof(RecyclableObject, type);
-    }
-
     RecyclableObject * RecyclableObject::CloneToScriptContext(ScriptContext* requestContext)
     {
         switch (JavascriptOperators::GetTypeId(this))

--- a/lib/Runtime/Types/RecyclableObject.h
+++ b/lib/Runtime/Types/RecyclableObject.h
@@ -214,7 +214,6 @@ namespace Js {
         static bool Is(Var aValue);
         static RecyclableObject* FromVar(Var varValue);
         RecyclableObject(Type * type);
-        static DWORD GetTypeOffset() { return offsetof(RecyclableObject, type); }
 #if DBG_EXTRAFIELD
         // This dtor should only be call when OOM occurs and RecyclableObject ctor has completed
         // as the base class, or we have a stack instance
@@ -366,7 +365,7 @@ namespace Js {
         }
         virtual void Mark(Recycler *recycler) override { AssertMsg(false, "Mark called on object that isn't TrackableObject"); }
 
-        static uint32 GetOffsetOfType();
+        static uint32 GetOffsetOfType() { return offsetof(RecyclableObject, type); }
 
         virtual void InvalidateCachedScope() { return; }
         virtual BOOL HasDeferredTypeHandler() const { return false; }

--- a/test/es6/ES6Class_SuperChain.js
+++ b/test/es6/ES6Class_SuperChain.js
@@ -609,7 +609,7 @@ var tests = [
             class NullExtendsExpression extends null {
             };
 
-            assert.throws(function() { new NullExtendsExpression(); }, TypeError, "Class that extends null throws when we attempt to call super as [[construct]]", "Function 'super' is not a constructor");
+            assert.throws(function() { new NullExtendsExpression(); }, TypeError, "Class that extends null throws when we attempt to call super as [[construct]]");
         }
     },
     {


### PR DESCRIPTION
Generate fast paths for LdSuper, LdSuperCtor, and SetHomeObj

Replace lowerer code that generate helper calls with code that generate fast paths
for these opcodes. The goal is to improve performance of jitted code for class methods
with super dot property access, class constructors with super calls, and class
instantiation operations.
