### PR TITLE
Improve JIT code page allocator virtual address use and reduced standing free page.

### DIFF
--- a/lib/Backend/CodeGenAllocators.cpp
+++ b/lib/Backend/CodeGenAllocators.cpp
@@ -10,18 +10,21 @@ CodeGenAllocators::CodeGenAllocators(AllocationPolicyManager * policyManager, Js
                  PageAllocator::DefaultLowMaxFreePageCount :
                  PageAllocator::DefaultMaxFreePageCount))
 , allocator(L"NativeCode", &pageAllocator, Js::Throw::OutOfMemory)
-, emitBufferManager(policyManager, &allocator, scriptContext, L"JIT code buffer", ALLOC_XDATA)
+, emitBufferManager(&allocator, scriptContext->GetThreadContext()->GetCodePageAllocators(), scriptContext, L"JIT code buffer")
 #if !_M_X64_OR_ARM64 && _CONTROL_FLOW_GUARD
 , canCreatePreReservedSegment(false)
-#endif
-#ifdef PERF_COUNTERS
-, staticNativeCodeData(0)
 #endif
 {
 }
 
 CodeGenAllocators::~CodeGenAllocators()
 {
-    PERF_COUNTER_SUB(Code, StaticNativeCodeDataSize, staticNativeCodeData);
-    PERF_COUNTER_SUB(Code, TotalNativeCodeDataSize, staticNativeCodeData);
 }
+
+#if DBG
+void
+CodeGenAllocators::ClearConcurrentThreadId()
+{    
+    this->pageAllocator.ClearConcurrentThreadId();
+}
+#endif

--- a/lib/Backend/CodeGenAllocators.h
+++ b/lib/Backend/CodeGenAllocators.h
@@ -4,27 +4,22 @@
 //-------------------------------------------------------------------------------------------------------
 #pragma once
 
-#if PDATA_ENABLED
-#define ALLOC_XDATA (true)
-#else
-#define ALLOC_XDATA (false)
-#endif
-
-struct CodeGenAllocators
+class CodeGenAllocators
 {
     // emitBufferManager depends on allocator which in turn depends on pageAllocator, make sure the sequence is right
+private:
     PageAllocator pageAllocator;
-    NoRecoverMemoryArenaAllocator    allocator;
+    NoRecoverMemoryArenaAllocator  allocator;
+public:
     EmitBufferManager<CriticalSection> emitBufferManager;
 #if !_M_X64_OR_ARM64 && _CONTROL_FLOW_GUARD
     bool canCreatePreReservedSegment;
 #endif
 
-#ifdef PERF_COUNTERS
-    size_t staticNativeCodeData;
-#endif
-
-    CodeGenAllocators(AllocationPolicyManager * policyManager, Js::ScriptContext * scriptContext);
-    PageAllocator *GetPageAllocator() { return &pageAllocator; };
+    CodeGenAllocators(AllocationPolicyManager * policyManager, Js::ScriptContext * scriptContext);    
     ~CodeGenAllocators();
+
+#if DBG
+    void ClearConcurrentThreadId();
+#endif
 };

--- a/lib/Backend/CodeGenNumberAllocator.cpp
+++ b/lib/Backend/CodeGenNumberAllocator.cpp
@@ -106,7 +106,7 @@ CodeGenNumberThreadAllocator::AllocNewNumberBlock()
     {
         Assert(cs.IsLocked());
         // Reserve the segment, but not committing it
-        currentNumberSegment = PageAllocator::AllocPageSegment(pendingIntegrationNumberSegment, this->recycler->GetRecyclerLeafPageAllocator(), true);
+        currentNumberSegment = PageAllocator::AllocPageSegment(pendingIntegrationNumberSegment, this->recycler->GetRecyclerLeafPageAllocator(), false, true);
         if (currentNumberSegment == nullptr)
         {
             currentNumberBlockEnd = nullptr;
@@ -153,7 +153,7 @@ CodeGenNumberThreadAllocator::AllocNewChunkBlock()
     {
         Assert(cs.IsLocked());
         // Reserve the segment, but not committing it
-        currentChunkSegment = PageAllocator::AllocPageSegment(pendingIntegrationChunkSegment, this->recycler->GetRecyclerPageAllocator(), true);
+        currentChunkSegment = PageAllocator::AllocPageSegment(pendingIntegrationChunkSegment, this->recycler->GetRecyclerPageAllocator(), false, true);
         if (currentChunkSegment == nullptr)
         {
             currentChunkBlockEnd = nullptr;

--- a/lib/Backend/EmitBuffer.h
+++ b/lib/Backend/EmitBuffer.h
@@ -30,7 +30,7 @@ template <class SyncObject = FakeCriticalSection>
 class EmitBufferManager
 {
 public:
-    EmitBufferManager(AllocationPolicyManager * policyManager, ArenaAllocator * allocator, Js::ScriptContext * scriptContext, LPCWSTR name, bool allocXdata);
+    EmitBufferManager(ArenaAllocator * allocator, CustomHeap::CodePageAllocators * codePageAllocators, Js::ScriptContext * scriptContext, LPCWSTR name);
     ~EmitBufferManager();
 
     // All the following methods are guarded with the SyncObject
@@ -45,58 +45,7 @@ public:
     bool FreeAllocation(void* address);
     //Ends here
 
-    bool IsInRange(void* address)
-    {
-        return this->allocationHeap.IsInRange(address);
-    }
-
-    HeapPageAllocator<VirtualAllocWrapper>* GetHeapPageAllocator()
-    {
-        return this->allocationHeap.GetHeapPageAllocator();
-    }
-
-    HeapPageAllocator<PreReservedVirtualAllocWrapper>* GetPreReservedHeapPageAllocator()
-    {
-        return this->allocationHeap.GetPreReservedHeapPageAllocator();
-    }
-
-    char * EnsurePreReservedPageAllocation(PreReservedVirtualAllocWrapper * preReservedVirtualAllocator)
-    {
-#if !_M_X64_OR_ARM64 && _CONTROL_FLOW_GUARD
-        bool canPreReserveSegmentForCustomHeap = scriptContext && scriptContext->GetThreadContext()->CanPreReserveSegmentForCustomHeap();
-#endif
-        AssertMsg(preReservedVirtualAllocator, "Virtual Allocator for pre reserved Segment should not be null when EnsurePreReservedPageAllocation is called");
-
-        if (this->GetPreReservedHeapPageAllocator()->GetVirtualAllocator() == nullptr)
-        {
-            this->GetPreReservedHeapPageAllocator()->SetVirtualAllocator(preReservedVirtualAllocator);
-        }
-
-        if (preReservedVirtualAllocator->IsPreReservedRegionPresent())
-        {
-            return (char*) preReservedVirtualAllocator->GetPreReservedStartAddress();
-        }
-
-#if !_M_X64_OR_ARM64 && _CONTROL_FLOW_GUARD
-        if (!canPreReserveSegmentForCustomHeap)
-        {
-            VerboseHeapTrace(L"PRE-RESERVE: Upper Cap for PreReservedSegment reached.\n");
-            return nullptr;
-        }
-#endif
-        char * startAddressOfPreReservedRegion = this->allocationHeap.EnsurePreReservedPageAllocation(preReservedVirtualAllocator);
-
-        //We have newly reserved a segment at this point
-        if (startAddressOfPreReservedRegion != nullptr)
-        {
-#if !_M_X64_OR_ARM64 && _CONTROL_FLOW_GUARD
-            Assert(canPreReserveSegmentForCustomHeap);
-            this->scriptContext->GetThreadContext()->IncrementThreadContextsWithPreReservedSegment();
-#endif
-        }
-
-        return startAddressOfPreReservedRegion;
-    }
+    bool IsInHeap(void* address);
 
 #if DBG_DUMP
     void DumpAndResetStats(wchar_t const * source);

--- a/lib/Backend/Func.h
+++ b/lib/Backend/Func.h
@@ -75,7 +75,6 @@ public:
         Js::RegSlot returnValueRegSlot = Js::Constants::NoRegister, const bool isInlinedConstructor = false,
         Js::ProfileId callSiteIdInParentFunc = UINT16_MAX, bool isGetterSetter = false);
 public:
-    ArenaAllocator *GetCodeGenAllocator() const { return &this->m_codeGenAllocators->allocator; }
     CodeGenAllocators * const GetCodeGenAllocators()
     {
         return this->GetTopFunc()->m_codeGenAllocators;

--- a/lib/Backend/InterpreterThunkEmitter.cpp
+++ b/lib/Backend/InterpreterThunkEmitter.cpp
@@ -189,8 +189,8 @@ const BYTE InterpreterThunkEmitter::HeaderSize = sizeof(InterpreterThunk);
 const BYTE InterpreterThunkEmitter::ThunkSize = sizeof(Call);
 const uint InterpreterThunkEmitter::ThunksPerBlock = (BlockSize - HeaderSize) / ThunkSize;
 
-InterpreterThunkEmitter::InterpreterThunkEmitter(AllocationPolicyManager * policyManager, ArenaAllocator* allocator, void * interpreterThunk) :
-    emitBufferManager(policyManager, allocator, /*scriptContext*/ nullptr, L"Interpreter thunk buffer", /*allocXdata*/ false),
+InterpreterThunkEmitter::InterpreterThunkEmitter(ArenaAllocator* allocator, CustomHeap::CodePageAllocators * codePageAllocators, void * interpreterThunk) :
+    emitBufferManager(allocator, codePageAllocators, /*scriptContext*/ nullptr, L"Interpreter thunk buffer"),
     allocation(nullptr),
     allocator(allocator),
     thunkCount(0),

--- a/lib/Backend/InterpreterThunkEmitter.h
+++ b/lib/Backend/InterpreterThunkEmitter.h
@@ -116,7 +116,7 @@ public:
     static const uint BlockSize;
     static void* ConvertToEntryPoint(PVOID dynamicInterpreterThunk);
 
-    InterpreterThunkEmitter(AllocationPolicyManager * policyManager, ArenaAllocator* allocator, void * interpreterThunk);
+    InterpreterThunkEmitter(ArenaAllocator* allocator, CustomHeap::CodePageAllocators * codePageAllocators, void * interpreterThunk);
 
     BYTE* GetNextThunk(PVOID* ppDynamicInterpreterThunk);
 
@@ -124,10 +124,11 @@ public:
 
     void Close();
     void Release(BYTE* thunkAddress, bool addtoFreeList);
+
     // Returns true if the argument falls within the range managed by this buffer.
-    inline bool IsInRange(void* address)
+    inline bool IsInHeap(void* address)
     {
-        return emitBufferManager.IsInRange(address);
+        return emitBufferManager.IsInHeap(address);
     }
     const EmitBufferManager<>* GetEmitBufferManager() const
     {

--- a/lib/Backend/LowerMDShared.cpp
+++ b/lib/Backend/LowerMDShared.cpp
@@ -5820,7 +5820,7 @@ LowererMD::GenerateCFGCheck(IR::Opnd * entryPointOpnd, IR::Instr * insertBeforeI
     if (m_func->CanAllocInPreReservedHeapPageSegment())
     {
         PreReservedVirtualAllocWrapper * preReservedVirtualAllocator = m_func->GetScriptContext()->GetThreadContext()->GetPreReservedVirtualAllocator();
-        preReservedRegionStartAddress = m_func->GetEmitBufferManager()->EnsurePreReservedPageAllocation(preReservedVirtualAllocator);
+        preReservedRegionStartAddress = (char *)preReservedVirtualAllocator->EnsurePreReservedRegion();
         if (preReservedRegionStartAddress != nullptr)
         {
             Assert(preReservedVirtualAllocator);

--- a/lib/Backend/NativeCodeData.h
+++ b/lib/Backend/NativeCodeData.h
@@ -9,7 +9,7 @@
 #define NativeCodeDataNewArray(alloc, T, count) AllocatorNewArray(NativeCodeData::Allocator, alloc, T, count)
 #define NativeCodeDataNewArrayZ(alloc, T, count) AllocatorNewArrayZ(NativeCodeData::Allocator, alloc, T, count)
 
-struct CodeGenAllocators;
+class CodeGenAllocators;
 
 class NativeCodeData
 {

--- a/lib/Backend/NativeCodeGenerator.h
+++ b/lib/Backend/NativeCodeGenerator.h
@@ -97,7 +97,6 @@ public:
     void UpdateQueueForDebugMode();
     bool IsBackgroundJIT() const;
     void EnterScriptStart();
-    bool IsNativeFunctionAddr(void * address);
     void FreeNativeCodeGenAllocation(void* address);
     bool TryReleaseNonHiPriWorkItem(CodeGenWorkItem* workItem);
 

--- a/lib/Backend/Opnd.cpp
+++ b/lib/Backend/Opnd.cpp
@@ -3355,8 +3355,7 @@ Opnd::GetAddrDescription(__out_ecount(count) wchar_t *const description, const s
                 WriteToBuffer(&buffer, &n, L" (&StackLimit)");
             }
             else if (func->CanAllocInPreReservedHeapPageSegment() &&
-                func->GetScriptContext()->GetThreadContext()->GetPreReservedVirtualAllocator()->IsPreReservedRegionPresent() &&
-                address == func->GetScriptContext()->GetThreadContext()->GetPreReservedVirtualAllocator()->GetPreReservedEndAddress())
+                func->GetScriptContext()->GetThreadContext()->GetPreReservedVirtualAllocator()->IsPreReservedEndAddress(address))
             {
                 WriteToBuffer(&buffer, &n, L" (PreReservedCodeSegmentEnd)");
             }

--- a/lib/Common/BackendApi.h
+++ b/lib/Common/BackendApi.h
@@ -57,7 +57,6 @@ void UpdateNativeCodeGeneratorForDebugMode(NativeCodeGenerator* nativeCodeGen);
 CriticalSection *GetNativeCodeGenCriticalSection(NativeCodeGenerator *pNativeCodeGen);
 bool TryReleaseNonHiPriWorkItem(Js::ScriptContext* scriptContext, CodeGenWorkItem* workItem);
 void NativeCodeGenEnterScriptStart(NativeCodeGenerator * nativeCodeGen);
-bool IsNativeFunctionAddr(Js::ScriptContext *scriptContext, void * address);
 void FreeNativeCodeGenAllocation(Js::ScriptContext* scriptContext, void* address);
 CodeGenAllocators* GetForegroundAllocator(NativeCodeGenerator * nativeCodeGen, PageAllocator* pageallocator);
 void GenerateFunction(NativeCodeGenerator * nativeCodeGen, Js::FunctionBody * functionBody, Js::ScriptFunction * function = NULL);

--- a/lib/Runtime/Base/Constants.h
+++ b/lib/Runtime/Base/Constants.h
@@ -111,10 +111,6 @@ namespace Js
         static const unsigned MaxProcessJITCodeHeapSize = 1024 * 1024 * 1024;
 #endif
 
-#if !_M_X64_OR_ARM64 && _CONTROL_FLOW_GUARD
-        static const unsigned MaxThreadContextsWithPreReserveSegment = 6;
-#endif
-
         static const PBYTE StackLimitForScriptInterrupt;
 
 

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -2867,7 +2867,7 @@ namespace Js
     BOOL FunctionBody::IsNativeOriginalEntryPoint() const
     {
 #if ENABLE_NATIVE_CODEGEN
-        return IsNativeFunctionAddr(this->GetScriptContext(), this->originalEntryPoint);
+        return this->GetScriptContext()->IsNativeAddress(this->originalEntryPoint);
 #else
         return false;
 #endif

--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -715,8 +715,9 @@ private:
 
         // DisableJIT-TODO: Switch this to Dynamic thunk ifdef instead
 #if ENABLE_NATIVE_CODEGEN
+#if DYNAMIC_INTERPRETER_THUNK
         InterpreterThunkEmitter* interpreterThunkEmitter;
-
+#endif
         BackgroundParser *backgroundParser;
 #ifdef ASMJS_PLAT
         InterpreterThunkEmitter* asmJsInterpreterThunkEmitter;

--- a/lib/Runtime/Base/ThreadContext.h
+++ b/lib/Runtime/Base/ThreadContext.h
@@ -372,8 +372,9 @@ public:
         WorkerThread(HANDLE handle = nullptr) :threadHandle(handle){};
     };
 
+#if ENABLE_NATIVE_CODEGEN
     void ReleasePreReservedSegment();
-    void IncrementThreadContextsWithPreReservedSegment();
+#endif
 
     void SetCurrentThreadId(DWORD threadId) { this->currentThreadId = threadId; }
     DWORD GetCurrentThreadId() const { return this->currentThreadId; }
@@ -416,8 +417,6 @@ public:
     }
 #endif
 
-    bool CanPreReserveSegmentForCustomHeap();
-
 #if ENABLE_NATIVE_CODEGEN
     // used by inliner. Maps Simd FuncInfo (library func) to equivalent opcode.
     typedef JsUtil::BaseDictionary<Js::FunctionInfo *, Js::OpCode, ArenaAllocator> FuncInfoToOpcodeMap;
@@ -451,10 +450,6 @@ private:
     StackProber * GetStackProber() const { return this->stackProber; }
     PBYTE GetStackLimitForCurrentThread() const;
     void SetStackLimitForCurrentThread(PBYTE limit);
-
-#if !_M_X64_OR_ARM64 && _CONTROL_FLOW_GUARD
-    static uint numOfThreadContextsWithPreReserveSegment;
-#endif
 
     // The current heap enumeration object being used during enumeration.
     IActiveScriptProfilerHeapEnum* heapEnum;
@@ -591,8 +586,6 @@ private:
     AllocationPolicyManager * allocationPolicyManager;
 
     JsUtil::ThreadService threadService;
-    PreReservedVirtualAllocWrapper preReservedVirtualAllocator;
-
     uint callRootLevel;
 
     // The thread page allocator is used by the recycler and need the background page queue
@@ -641,6 +634,11 @@ private:
     JsUtil::JobProcessor *jobProcessor;
     Js::Var * bailOutRegisterSaveSpace;
     CodeGenNumberThreadAllocator * codeGenNumberThreadAllocator;
+    PreReservedVirtualAllocWrapper preReservedVirtualAllocator;
+#if DYNAMIC_INTERPRETER_THUNK || defined(ASMJS_PLAT)
+    CustomHeap::CodePageAllocators thunkPageAllocators;
+#endif
+    CustomHeap::CodePageAllocators codePageAllocators;
 #endif
 
     RecyclerRootPtr<RecyclableData> recyclableData;
@@ -783,7 +781,14 @@ public:
     PageAllocator * GetPageAllocator() { return &pageAllocator; }
 
     AllocationPolicyManager * GetAllocationPolicyManager() { return allocationPolicyManager; }
+
+#if ENABLE_NATIVE_CODEGEN
     PreReservedVirtualAllocWrapper * GetPreReservedVirtualAllocator() { return &preReservedVirtualAllocator; }
+#if DYNAMIC_INTERPRETER_THUNK || defined(ASMJS_PLAT)
+    CustomHeap::CodePageAllocators * GetThunkPageAllocators() { return &thunkPageAllocators; }
+#endif
+    CustomHeap::CodePageAllocators * GetCodePageAllocators() { return &codePageAllocators; }
+#endif // ENABLE_NATIVE_CODEGEN
 
     void ResetIsAllJITCodeInPreReservedRegion() { isAllJITCodeInPreReservedRegion = false; }
     bool IsAllJITCodeInPreReservedRegion() { return isAllJITCodeInPreReservedRegion; }
@@ -1101,9 +1106,8 @@ public:
     void RegisterCodeGenRecyclableData(Js::CodeGenRecyclableData *const codeGenRecyclableData);
     void UnregisterCodeGenRecyclableData(Js::CodeGenRecyclableData *const codeGenRecyclableData);
 #if ENABLE_NATIVE_CODEGEN
-    BOOL IsNativeAddress(void *pCodeAddr);
+    BOOL IsNativeAddress(void * pCodeAddr);
     JsUtil::JobProcessor *GetJobProcessor();
-    static void CloseSharedJobProcessor(const bool waitForThread);
     Js::Var * GetBailOutRegisterSaveSpace() const { return bailOutRegisterSaveSpace; }
     CodeGenNumberThreadAllocator * GetCodeGenNumberThreadAllocator() const
     {

--- a/lib/Runtime/Language/DynamicProfileInfo.cpp
+++ b/lib/Runtime/Language/DynamicProfileInfo.cpp
@@ -336,7 +336,7 @@ namespace Js
         }
         else
         {
-            Assert(directEntryPoint == ProfileEntryThunk || IsNativeFunctionAddr(functionBody->GetScriptContext(), directEntryPoint));
+            Assert(directEntryPoint == ProfileEntryThunk || functionBody->GetScriptContext()->IsNativeAddress(directEntryPoint));
             Assert(functionBody->HasExecutionDynamicProfileInfo());
         }
 


### PR DESCRIPTION
Share CodePageAllocator within a thread by moving it into ThreadContext.
This reduce the amount of virtual address we reserved, and tighter usage of the prereserved segment.

Also commit only page requested instead of the whole segment if the maxFreePageCount will be exceeded.
When we don't have a lot of page used within a page allocator, we waste about ~100K per page allocator,
because we commit the whole segment (128K), and only use a couple of page. So in general, we wastes
about 500K-1M per thread depending on how many script context is in the thread context.

Refactor the code that manages HeapPageAllocators in CustomHeap into CodePageAllocator.
Rationalize the locking and IsNativeAddress checks
Reimplement IsInRange as IsInHeap to work the heap list instead of the page allocator, instead of
relying on the page allocator, which is now shared.
