### PR TITLE
Fix crawler assert

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -1953,7 +1953,7 @@ void Parser::ReduceDeferredScriptLength(size_t chars)
     if ((m_grfscr & fscrDeferFncParse) &&
         (
             PHASE_OFF1(Js::DeferEventHandlersPhase) || 
-            !(m_grfscr & (fscrImplicitThis|fscrImplicitParents))
+            (m_grfscr & fscrGlobalCode)
         )
     )
     {
@@ -10380,7 +10380,7 @@ ParseNodePtr Parser::Parse(LPCUTF8 pszSrc, size_t offset, size_t length, charcou
         // by command-line switch.
         grfscr &= ~fscrDeferFncParse;
     }
-    else if ((grfscr & (fscrImplicitThis | fscrImplicitParents)) &&
+    else if (!(grfscr & fscrGlobalCode) &&
              (
                  PHASE_OFF1(Js::Phase::DeferEventHandlersPhase) ||
                  this->m_scriptContext->IsInDebugOrSourceRundownMode()


### PR DESCRIPTION
Avoid deferring all code passed to ParseProcedureText in debug/rundown mode. (I was only avoiding deferral for code with event handler semantics.)