### PR TITLE
Add assert to catch browser issue

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -4325,6 +4325,7 @@ void ByteCodeGenerator::EmitLoadInstance(Symbol *sym, IdentPtr pid, Js::RegSlot 
         }
         else
         {
+            Assert(funcInfo->frameObjRegister != Js::Constants::NoRegister);
             this->m_writer.Reg1(Js::OpCode::LdLocalObj, instLocation);
         }
 


### PR DESCRIPTION
Invalid instances of LdLocalObj are showing up in browser dumps. Add an assert to catch those instruction emissions at compile time.