### PR TITLE
HTML Comment Spec Compliance

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 *.baseline -crlf
 *.cmd -crlf
 test/*.js -crlf
+test/es6/HTMLComments.js binary diff=cpp

--- a/lib/Parser/Scan.h
+++ b/lib/Parser/Scan.h
@@ -663,7 +663,7 @@ private:
     ErrHandler *m_perr;                // error handler to use
     uint16 m_fStringTemplateDepth;     // we should treat } as string template middle starting character (depth instead of flag)
     BOOL m_fHadEol;
-    BOOL m_fHtmlComments : 1;
+    BOOL m_fIsModuleCode : 1;
     BOOL m_doubleQuoteOnLastTkStrCon :1;
     bool m_OctOrLeadingZeroOnLastTKNumber :1;
     BOOL m_fSyntaxColor : 1;            // whether we're just syntax coloring
@@ -761,26 +761,6 @@ private:
     OLECHAR ReadNextChar(void)
     {
         return ReadFull<true>(m_currentCharacter, m_pchLast);
-    }
-    OLECHAR NextNonWhiteChar(EncodedCharPtr p, EncodedCharPtr last)
-    {
-        OLECHAR ch;
-        do
-        {
-            ch = ReadFull<false>(p, last);
-        }
-        while (this->charClassifier->IsWhiteSpace(ch));
-        return ch;
-    }
-    OLECHAR NextNonWhiteCharPlusOne(EncodedCharPtr p, EncodedCharPtr last)
-    {
-        OLECHAR ch;
-        do
-        {
-            ch = ReadFull<false>(p, last);
-        }
-        while (this->charClassifier->IsWhiteSpace(ch));
-        return ReadFull<false>(p, last);
     }
 
     EncodedCharPtr AdjustedLast() const

--- a/test/es6/HTMLComments.baseline
+++ b/test/es6/HTMLComments.baseline
@@ -1,0 +1,13 @@
+Code before CRLF--> is reachable
+Code before CR--> is reachable
+Code before LF--> is reachable
+Code before LS--> is reachable
+Code before PS--> is reachable
+Code before CRLS--> is reachable
+Code before CRPS--> is reachable
+Code before <!-- is reachable
+Code before <!-- --> is reachable
+Code before <!-- LineTerminator --> is reachable
+Code before /* */ --> is reachable
+Code before /* */--> is reachable
+Code after post-decrement with a greater-than comparison (-->) is reachable

--- a/test/es6/HTMLComments.js
+++ b/test/es6/HTMLComments.js
@@ -1,0 +1,66 @@
+﻿//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+/* NOTE: This file needs to be treated as binary. It contains mixed line endings, including non-standard
+ *       line endings. Most text editors will not handle the file correctly. If you need to edit this
+ *       file, make sure you do a binary compare to ensure the non-standard line endings have not been lost.
+ *
+ *       'LS' refers to Unicode Character 'LINE SEPARATOR' (U+2028)
+ *       'PS' refers to Unicode Character 'PARAGRAPH SEPARATOR' (U+2029)
+ */
+
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+
+/*
+ * Line terminator sequences - standard (11.3 LineTerminator)
+ */
+ 
+// CRLF
+WScript.Echo("Code before CRLF--> is reachable");
+--> WScript.Echo("Code after CRLF--> is unreachable");
+
+// CR
+WScript.Echo("Code before CR--> is reachable");--> WScript.Echo("Code after CR--> is unreachable");
+
+// LF
+WScript.Echo("Code before LF--> is reachable");
+--> WScript.Echo("Code after LF--> is unreachable");
+
+// LS
+WScript.Echo("Code before LS--> is reachable"); --> WScript.Echo("Code after LS--> is unreachable");
+
+// PS
+WScript.Echo("Code before PS--> is reachable"); --> WScript.Echo("Code after PS--> is unreachable");
+
+/*
+ * Line terminator sequences - non-standard (11.3 LineTerminatorSequence <CR>[lookahead != <LF>])
+ */
+
+// CRLS
+WScript.Echo("Code before CRLS--> is reachable"); --> WScript.Echo("Code after CRLS--> is unreachable");
+
+// CRPS
+WScript.Echo("Code before CRPS--> is reachable"); --> WScript.Echo("Code after CRPS--> is unreachable");
+
+// HTML open comment comments out the rest of the line
+WScript.Echo("Code before <!-- is reachable"); <!-- WScript.Echo("Code after <!-- is unreachable");
+WScript.Echo("Code before <!-- --> is reachable"); <!-- --> WScript.Echo("Code after <!-- --> is unreachable");
+
+// Split multiline HTML comment comments out both lines
+WScript.Echo("Code before <!-- LineTerminator --> is reachable"); <!-- WScript.Echo("Code after multiline <!-- is unreachable");
+--> WScript.Echo("Code after <!-- LineTerminator --> is unreachable");
+
+// Delimited comments syntax
+/* Multi
+   Line
+   Comment */ --> WScript.Echo("Code after */ --> is unreachable");
+WScript.Echo("Code before /* */ --> is reachable"); /* Comment */ --> WScript.Echo("Code after /* */ --> is unreachable");
+WScript.Echo("Code before /* */--> is reachable"); /* Comment */--> WScript.Echo("Code after /* */--> is unreachable"); // No WhiteSpaceSequence
+
+// Post-decrement with a greater-than comparison does not get interpreted as a comment
+var a = 1; a-->a; WScript.Echo("Code after post-decrement with a greater-than comparison (-->) is reachable");
+assert.areEqual(0, a, "Post decrement executes");
+
+assert.throws(function () { eval('/* */ --->'); }, SyntaxError, "HTMLCloseComment causes syntax error with an extra -", "Syntax error");

--- a/test/es6/module-syntax.js
+++ b/test/es6/module-syntax.js
@@ -9,21 +9,21 @@ WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
 
 function testModuleScript(source, message, shouldFail) {
     let testfunc = () => WScript.LoadModule(source, 'samethread');
-    
+
     if (shouldFail) {
         let caught = false;
-        
+
         // We can't use assert.throws here because the SyntaxError used to construct the thrown error
         // is from a different context so it won't be strictly equal to our SyntaxError.
         try {
             testfunc();
         } catch(e) {
             caught = true;
-            
+
             // Compare toString output of SyntaxError and other context SyntaxError constructor.
             assert.areEqual(e.constructor.toString(), SyntaxError.toString(), message);
         }
-        
+
         assert.isTrue(caught, `Expected error not thrown: ${message}`);
     } else {
         assert.doesNotThrow(testfunc, message);
@@ -124,6 +124,16 @@ var tests = [
             assert.doesNotThrow(function () { WScript.LoadModuleFile('.\\module\\ValidReExportStatements.js', 'samethread'); }, "Valid re-export statements");
         }
     },
+    {
+        name: "HTML comments do not parse in module code",
+        body: function () {
+            testModuleScript("<!--\n",     "HTML open comment does not parse in module code",  true);
+            testModuleScript("\n-->",      "HTML close comment does not parse in module code", true);
+            testModuleScript("<!-- -->",   "HTML comment does not parse in module code",       true);
+            testModuleScript("/* */ -->",  "HTML comment after delimited comment does not parse in module code", true);
+            testModuleScript("/* */\n-->", "HTML comment after delimited comment does not parse in module code", true);
+        }
+    }
 ];
 
 testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -1141,7 +1141,12 @@
       <compile-flags>-args summary -endargs</compile-flags>
     </default>
   </test>
-
+<test>
+    <default>
+        <files>HTMLComments.js</files>
+        <baseline>HTMLComments.baseline</baseline>
+    </default>
+</test>
 <test>
     <default>
         <files>module-syntax.js</files>


### PR DESCRIPTION
Removed custom logic from HTML comment handling and brought up to date with B.1.3 HTML-like Comments.
- Removed HTML comment flag and replaced with a flag for checking if we are parsing a module (the only place we don't allow HTML comments in the standard.)
- Removed custom logic involving looking for EOF and } when parsing HTML end comment and jump to single line comment handling instead.
- Added line separator / paragraph separator handling to the main scanner loop to keep track of whether we saw an EOL.
- Added negative parsing cases to modules syntax testing

The unit test added for this commit is a special file and must be treated like binary to preserve the mixed and non-standard line endings. I added a line to .gitattributes to ensure this.

Fixes #20.
