### PR TITLE
re-enable CustomHeap build on linux

### DIFF
--- a/lib/Common/Memory/CMakeLists.txt
+++ b/lib/Common/Memory/CMakeLists.txt
@@ -5,9 +5,7 @@ add_library (Chakra.Common.Memory
     Allocator.cpp
     ArenaAllocator.cpp
 
-    # xplat-todo: This is needed for allocating jitted code memory
-    # CustomHeap.cpp
-
+    CustomHeap.cpp
     CommonMemoryPch.cpp
     EtwMemoryTracking.cpp
     ForcedMemoryConstraints.cpp

--- a/pal/inc/rt/no_sal2.h
+++ b/pal/inc/rt/no_sal2.h
@@ -25,6 +25,8 @@
 #ifndef _NO_SAL_2_H_
 #define _NO_SAL_2_H_
 
+#undef __notnull
+#define __notnull
 #undef _When_
 #define _When_(c,a)
 #undef _At_


### PR DESCRIPTION
Should help with bug #347, get CustomHeap compiling on Linux.
This compiles, but without the patch to the type of address initially, I get
the following errors compiling:

  * https://gist.github.com/bewest/89a1fd7be74218a37f98

    In file included from /home/bewest/src/ChakraCore/lib/Common/Memory/CustomHeap.cpp:14:
    [1m/home/bewest/src/ChakraCore/lib/Common/Memory/CustomHeap.h:92:5: [0m[0;1;31merror: [0m[1munknown type name '__notnull'[0m
        __field_bcount(size) char* address;

    /home/bewest/src/ChakraCore/pal/inc/rt/specstrings.h:278:45: [0m[0;1;30mnote: [0mexpanded from macro '__field_bcount'[0m
    #define __field_bcount(size)                __notnull __byte_writableTo(size)

For some reason __notnull doesn't exist.  A quick grepping through the source
reveals that it's only used here, in CustomHeap, and that the rest of the
address variables are typed with either char * or void *.  There is one __in
annotation, but since I'm not sure what these do, the simplest thing for time
being is this change.