### PR TITLE
One-line type-check fix

### DIFF
--- a/lib/Backend/BackwardPass.cpp
+++ b/lib/Backend/BackwardPass.cpp
@@ -3995,7 +3995,7 @@ BackwardPass::TrackObjTypeSpecProperties(IR::PropertySymOpnd *opnd, BasicBlock *
         if (opnd->NeedsMonoCheck())
         {
             Assert(opnd->IsMono());
-            Js::Type *monoGuardType = opnd->HasInitialType() ? opnd->GetInitialType() : opnd->GetType();
+            Js::Type *monoGuardType = opnd->IsInitialTypeChecked() ? opnd->GetInitialType() : opnd->GetType();
             bucket->SetMonoGuardType(monoGuardType);
         }
 

--- a/test/fieldopts/fixedfieldmonocheck2.js
+++ b/test/fieldopts/fixedfieldmonocheck2.js
@@ -1,0 +1,45 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function test0() {
+    function leaf() {
+    }
+    var obj0 = {};
+    var obj1 = {};
+    var arrObj0 = {};
+    var func1 = function () {
+        (function () {
+            while (this) {
+                arrObj0.prop5 = { 6: arrObj0.prop1 };
+                for (; arrObj0.prop5.prop1; i32) {
+                }
+                if (78) {
+                    leaf(arguments);
+                    break;
+                }
+            }
+        }());
+    };
+    var func2 = function () {
+        eval();
+    };
+    obj0.method0 = func1;
+    obj0.method1 = obj0.method0;
+    obj1.method1 = obj0.method1;
+    var ary = Array();
+    var i32 = new Int32Array();
+    arrObj0.prop1 = -195;
+    obj0.method0();
+    function v37() {
+        for (var __loopvar1001 = 7; obj1.method1() ;) {
+        }
+    }
+    var v44 = v37();
+}
+test0();
+test0();
+test0();
+
+WScript.Echo('pass');

--- a/test/fieldopts/rlexe.xml
+++ b/test/fieldopts/rlexe.xml
@@ -842,4 +842,10 @@
       <compile-flags>-force:fixdataprops</compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>fixedfieldmonocheck2.js</files>
+      <compile-flags>-force:deferparse -force:inline -force:scriptfunctionwithinlinecache</compile-flags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
My previous fix to monomorphic type checks had a subtle mistake. To handle the case where a downstream store adds a property, I grabbed the store's cached initial type to use as the guard type at the monomorphic check. But in some cases, the type we checked upstream is the final type, not the initial one. One-line fix for that.