### PR TITLE
Fix incremental LTCG disabling on TFS builds

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 *.baseline -crlf
 *.cmd -crlf
 test/*.js -crlf
+test/es6/HTMLComments.js binary diff=cpp

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ profile.dpl.*
 Build/Chakra.Core.VC.opendb
 test/benchmarks/*.txt
 test/benchmarks/*.dpl
+*.project
+*.cproject

--- a/Build/Common.Build.props
+++ b/Build/Common.Build.props
@@ -91,7 +91,7 @@
     </ResourceCompile>
     <Link>
       <LinkTimeCodeGeneration Condition="'$(PlatformToolset)'=='v120' OR '$(TF_BUILD)'!=''">UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
-      <LinkTimeCodeGeneration Condition="'$(PlatformToolset)'!='v120'">UseFastLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+      <LinkTimeCodeGeneration Condition="'$(PlatformToolset)'!='v120' AND '$(TF_BUILD)'==''">UseFastLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
     <Lib>
       <LinkTimeCodeGeneration>true</LinkTimeCodeGeneration>

--- a/lib/Parser/Scan.cpp
+++ b/lib/Parser/Scan.cpp
@@ -202,7 +202,7 @@ void Scanner<EncodingPolicy>::SetText(EncodedCharPtr pszSrc, size_t offset, size
     m_startLine = lineNumber;
     m_pchStartLine = m_currentCharacter;
     m_ptoken->tk = tkNone;
-    m_fHtmlComments = (grfscr & fscrHtmlComments) != 0;
+    m_fIsModuleCode = (grfscr & fscrIsModuleCode) != 0;
     m_fHadEol = FALSE;
     m_fSyntaxColor = (grfscr & fscrSyntaxColor) != 0;
     m_DeferredParseFlags = ScanFlagNone;
@@ -1614,6 +1614,8 @@ tokens Scanner<EncodingPolicy>::SkipComment(EncodedCharPtr *pp, /* out */ bool* 
                 return tkNone;
             }
             break;
+
+        // ES 2015 11.3 Line Terminators
         case kchLS:         // 0x2028, classifies as new line
         case kchPS:         // 0x2029, classifies as new line
 LEcmaLineBreak:
@@ -1934,16 +1936,18 @@ LEof:
             }
         case '(': Assert(chType == _C_LPR); token = tkLParen; break;
         case ')': Assert(chType == _C_RPR); token = tkRParen; break;
-        case ',': Assert(chType == _C_CMA); token = tkComma; break;
+        case ',': Assert(chType == _C_CMA); token = tkComma;  break;
         case ';': Assert(chType == _C_SMC); token = tkSColon; break;
         case '[': Assert(chType == _C_LBR); token = tkLBrack; break;
         case ']': Assert(chType == _C_RBR); token = tkRBrack; break;
-        case '~': Assert(chType == _C_TIL); token = tkTilde; break;
-        case '?': Assert(chType == _C_QUE); token = tkQMark; break;
-        case '{': Assert(chType == _C_LC); token = tkLCurly; break;
+        case '~': Assert(chType == _C_TIL); token = tkTilde;  break;
+        case '?': Assert(chType == _C_QUE); token = tkQMark;  break;
+        case '{': Assert(chType == _C_LC);  token = tkLCurly; break;
 
         case '\r':
         case '\n':
+        case kchLS:
+        case kchPS:
 LNewLine:
             m_currentCharacter = p;
             ScanNewLine(ch);
@@ -2087,36 +2091,14 @@ LIdentifier:
             case '-':
                 p++;
                 token = tkDec;
-                if (m_fHtmlComments)
+                if (!m_fIsModuleCode)
                 {
                     int i = 0;
                     while ('-' == PeekFirst(p + i, last)) //Have already seen --, skip any further - characters
                         i++;
-                    if ('>' == PeekFirst(p + i++, last)) //This means we've got a --------------------------->.
+                    if ('>' == PeekFirst(p + i++, last) && m_fHadEol) //This means we've got a --------------------------->.
                     {
-                        //If that precedes an EOF or }NWL (disregarding whitespace), then it is a comment.
-                        OLECHAR nextChar;
-                        nextChar = NextNonWhiteChar(&p[i], last);
-                        if (nextChar == 0)
-                        {
-                            //Treat the -----------------------------> EOF as if it were EOF
-                            token = tkEOF;
-                            ++p;
-                        }
-                        else if (nextChar == '}')
-                        {
-                            CharTypes nextNextCharType = this->charClassifier->GetCharType(NextNonWhiteCharPlusOne(&p[i], last));
-                            if (nextNextCharType == _C_NWL
-                                // Corner case: If we have reached the end of the source, either we are at the end of the file or the end of
-                                // a deferred function. We treat this case as NWL.
-                                // TODO(tcare): Update to ES6 spec. Tracked in Bug 1164686
-                                || (last == m_pchLast && nextNextCharType == _C_NUL))
-                            {
-                                //Treat the -----------------------------> }NWL as if it were }NWL
-                                p += i;
-                                continue;
-                            }
-                        }
+                        goto LSkipLineComment;
                     }
                 }
                 break;
@@ -2155,7 +2137,7 @@ LIdentifier:
             case '/':
                 if (p >= last)
                 {
-                    AssertMsg(m_fHtmlComments, "Do we have other line comment cases scanning pass last?");
+                    AssertMsg(!m_fIsModuleCode, "Do we have other line comment cases scanning pass last?");
 
                     // Effective source length may have excluded HTMLCommentSuffix "//... -->". If we are scanning
                     // those, we have passed "last" already. Move back and return EOF.
@@ -2286,7 +2268,8 @@ LMultiLineComment:
                 }
                 break;
             case '!':
-                if (m_fHtmlComments && PeekFirst(p + 1, last) == '-' && PeekFirst(p + 2, last) == '-')
+                // ES 2015 B.1.3 -  HTML comments are only allowed when parsing non-module code.
+                if (!m_fIsModuleCode && PeekFirst(p + 1, last) == '-' && PeekFirst(p + 2, last) == '-')
                 {
                     // This is a "<!--" comment - treat as //
                     if (p >= last)

--- a/lib/Parser/Scan.h
+++ b/lib/Parser/Scan.h
@@ -663,7 +663,7 @@ private:
     ErrHandler *m_perr;                // error handler to use
     uint16 m_fStringTemplateDepth;     // we should treat } as string template middle starting character (depth instead of flag)
     BOOL m_fHadEol;
-    BOOL m_fHtmlComments : 1;
+    BOOL m_fIsModuleCode : 1;
     BOOL m_doubleQuoteOnLastTkStrCon :1;
     bool m_OctOrLeadingZeroOnLastTKNumber :1;
     BOOL m_fSyntaxColor : 1;            // whether we're just syntax coloring

--- a/test/es6/HTMLComments.js
+++ b/test/es6/HTMLComments.js
@@ -1,0 +1,43 @@
+// Line terminator sequences - standard
+
+// CRLF
+WScript.Echo("Text before CRLF<-- prints");
+--> WScript.Echo("Text after CRLF<-- does not print");
+
+// CR
+WScript.Echo("Text before CR<-- prints");--> WScript.Echo("Text after CR<-- does not print");
+
+// LF
+WScript.Echo("Text before LF<-- prints");
+--> WScript.Echo("Text after LF<-- does not print");
+
+// LS u+2028
+WScript.Echo("Text before LS<-- prints"); --> WScript.Echo("Text after LS<-- does not print");
+
+// PS u+2029
+WScript.Echo("Text before PS<-- prints"); --> WScript.Echo("Text after PS<-- does not print");
+
+
+// Line terminator sequences - non-standard
+
+// CRLS
+WScript.Echo("Text before CRLS<-- prints"); --> WScript.Echo("Text after CRLS<-- does not print");
+
+// CRPS
+WScript.Echo("Text before CRPS<-- prints"); --> WScript.Echo("Text after CRPS<-- does not print");
+
+// PSLS
+WScript.Echo("Text before PSLS<-- prints");  --> WScript.Echo("Text after PSLS<-- does not print");
+
+// LSPS
+WScript.Echo("Text before LSPS<-- prints");  --> WScript.Echo("Text after LSPS<-- does not print");
+
+// ASI
+WScript.Echo("HTML start comment does not affect automatic semicolon insertion")
+<!--
+
+WScript.Echo("HTML end comment does not affect automatic semicolon insertion")
+-->
+
+// Non-HTML comment parses correctly
+var a = 1; a-->a; WScript.Echo("Post-decrement with a greater-than comparison does not get interpreted as a comment");


### PR DESCRIPTION
ChakraCore builds on TFS are meant to have incremental LTCG disabled. This reduces the build size by about half since we don't need the ipdb/iobj files.