### PR TITLE
Fix incremental LTCG disabling on TFS builds

### DIFF
--- a/Build/Common.Build.props
+++ b/Build/Common.Build.props
@@ -91,7 +91,7 @@
     </ResourceCompile>
     <Link>
       <LinkTimeCodeGeneration Condition="'$(PlatformToolset)'=='v120' OR '$(TF_BUILD)'!=''">UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
-      <LinkTimeCodeGeneration Condition="'$(PlatformToolset)'!='v120'">UseFastLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+      <LinkTimeCodeGeneration Condition="'$(PlatformToolset)'!='v120' AND '$(TF_BUILD)'==''">UseFastLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
     <Lib>
       <LinkTimeCodeGeneration>true</LinkTimeCodeGeneration>


### PR DESCRIPTION
ChakraCore builds on TFS are meant to have incremental LTCG disabled. This reduces the build size by about half since we don't need the ipdb/iobj files.