### PR TITLE
linux: make NumberUtilities_strtod.cpp compile

### DIFF
--- a/lib/Common/Common/CMakeLists.txt
+++ b/lib/Common/Common/CMakeLists.txt
@@ -10,7 +10,7 @@ add_library (Chakra.Common.Common
     Jobs.cpp
     MathUtil.cpp
     NumberUtilities.cpp
-    # NumberUtilities_strtod.cpp
+    NumberUtilities_strtod.cpp
     RejitReason.cpp
     SmartFpuControl.cpp
     Tick.cpp

--- a/lib/Common/Common/NumberUtilities.cpp
+++ b/lib/Common/Common/NumberUtilities.cpp
@@ -37,7 +37,7 @@ namespace Js
         return ch >= '0' && ch <= '9';
     }
 
-    BOOL NumberUtilities::FHexDigit(wchar_t ch, int *pw)
+    BOOL NumberUtilities::FHexDigit(wchar16 ch, int *pw)
     {
         if ((ch -= '0') <= 9)
         {
@@ -231,7 +231,7 @@ namespace Js
         return cchWritten;
     }
 
-    BOOL NumberUtilities::TryConvertToUInt32(const wchar_t* str, int length, uint32* intVal)
+    BOOL NumberUtilities::TryConvertToUInt32(const wchar16* str, int length, uint32* intVal)
     {
         if (length <= 0 || length > 10)
         {
@@ -628,12 +628,12 @@ namespace Js
         return Js::NumberUtilities::StrToDbl<EncodedChar>(psz, ppchLim, likelyInt);
     }
 
-    template double NumberUtilities::StrToDbl<wchar_t>(const wchar_t * psz, const wchar_t **ppchLim, Js::ScriptContext *const scriptContext);
+    template double NumberUtilities::StrToDbl<wchar16>(const wchar16 * psz, const wchar16 **ppchLim, Js::ScriptContext *const scriptContext);
     template double NumberUtilities::StrToDbl<utf8char_t>(const utf8char_t * psz, const utf8char_t **ppchLim, Js::ScriptContext *const scriptContext);
-    template double NumberUtilities::DblFromHex<wchar_t>(const wchar_t *psz, const wchar_t **ppchLim);
+    template double NumberUtilities::DblFromHex<wchar16>(const wchar16 *psz, const wchar16 **ppchLim);
     template double NumberUtilities::DblFromHex<utf8char_t>(const utf8char_t *psz, const utf8char_t **ppchLim);
-    template double NumberUtilities::DblFromBinary<wchar_t>(const wchar_t *psz, const wchar_t **ppchLim);
+    template double NumberUtilities::DblFromBinary<wchar16>(const wchar16 *psz, const wchar16 **ppchLim);
     template double NumberUtilities::DblFromBinary<utf8char_t>(const utf8char_t *psz, const utf8char_t **ppchLim);
-    template double NumberUtilities::DblFromOctal<wchar_t>(const wchar_t *psz, const wchar_t **ppchLim);
+    template double NumberUtilities::DblFromOctal<wchar16>(const wchar16 *psz, const wchar16 **ppchLim);
     template double NumberUtilities::DblFromOctal<utf8char_t>(const utf8char_t *psz, const utf8char_t **ppchLim);
 }

--- a/lib/Common/Common/NumberUtilities.h
+++ b/lib/Common/Common/NumberUtilities.h
@@ -55,7 +55,7 @@ namespace Js
     {
     public:
         static bool IsDigit(int ch);
-        static BOOL NumberUtilities::FHexDigit(wchar_t ch, int *pw);
+        static BOOL NumberUtilities::FHexDigit(wchar16 ch, int *pw);
         static ulong MulLu(ulong lu1, ulong lu2, ulong *pluHi);
         static int AddLu(ulong *plu1, ulong lu2);
 
@@ -79,7 +79,7 @@ namespace Js
         static charcount_t UInt16ToString(uint16 integer, __out __ecount(outBufferSize) WCHAR* outBuffer, charcount_t outBufferSize, char widthForPaddingZerosInsteadSpaces);
 
         // Try to parse an integer string to find out if the string contains an index property name.
-        static BOOL TryConvertToUInt32(const wchar_t* str, int length, uint32* intVal);
+        static BOOL TryConvertToUInt32(const wchar16* str, int length, uint32* intVal);
 
         static double Modulus(double dblLeft, double dblRight);
 
@@ -94,15 +94,15 @@ namespace Js
         template<typename EncodedChar>
         static double StrToDbl(const EncodedChar *psz, const EncodedChar **ppchLim, bool& likelyInt);
 
-        static BOOL FDblToStr(double dbl, __out_ecount(nDstBufSize) wchar_t *psz, int nDstBufSize);
-        static int FDblToStr(double dbl, NumberUtilities::FormatType ft, int nDigits, __out_ecount(cchDst) wchar_t *pchDst, int cchDst);
+        static BOOL FDblToStr(double dbl, __out_ecount(nDstBufSize) wchar16 *psz, int nDstBufSize);
+        static int FDblToStr(double dbl, NumberUtilities::FormatType ft, int nDigits, __out_ecount(cchDst) wchar16 *pchDst, int cchDst);
 
         static BOOL FNonZeroFiniteDblToStr(double dbl, _Out_writes_(nDstBufSize) WCHAR* psz, int nDstBufSize);
         _Success_(return) static BOOL FNonZeroFiniteDblToStr(double dbl, _In_range_(2, 36) int radix, _Out_writes_(nDstBufSize) WCHAR* psz, int nDstBufSize);
 
         static double DblFromDecimal(DECIMAL * pdecIn);
 
-        static void CodePointAsSurrogatePair(codepoint_t codePointValue, __out wchar_t* first, __out wchar_t* second);
+        static void CodePointAsSurrogatePair(codepoint_t codePointValue, __out wchar16* first, __out wchar16* second);
         static codepoint_t SurrogatePairAsCodePoint(codepoint_t first, codepoint_t second);
 
         static bool IsSurrogateUpperPart(codepoint_t codePointValue);

--- a/lib/Common/Common/NumberUtilities_strtod.cpp
+++ b/lib/Common/Common/NumberUtilities_strtod.cpp
@@ -24,9 +24,9 @@ static const double g_rgdblTens[] =
     1e20, 1e21, 1e22, 1e23, 1e24, 1e25, 1e26, 1e27, 1e28
 };
 
-static inline wchar_t ToDigit(long wVal)
+static inline wchar16 ToDigit(long wVal)
 {
-    //return reinterpret_cast<wchar_t>((wVal < 10) ? '0' + (ushort) wVal : 'a' - 10 + (ushort) wVal);
+    //return reinterpret_cast<wchar16>((wVal < 10) ? '0' + (ushort) wVal : 'a' - 10 + (ushort) wVal);
     return (ushort)((wVal < 10) ? '0' + (ushort) wVal : 'a' - 10 + (ushort) wVal);
 }
 
@@ -1256,7 +1256,7 @@ LDone:
     return dbl;
 }
 
-template double Js::NumberUtilities::StrToDbl<wchar_t>( const wchar_t * psz, const wchar_t **ppchLim, bool& likelyInt );
+template double Js::NumberUtilities::StrToDbl<wchar16>( const wchar16 * psz, const wchar16 **ppchLim, bool& likelyInt );
 template double Js::NumberUtilities::StrToDbl<utf8char_t>(const utf8char_t * psz, const utf8char_t **ppchLim, bool& likelyInt);
 
 /***************************************************************************
@@ -1919,18 +1919,18 @@ static BOOL FormatDigits(_In_reads_(pbLim - pbSrc) byte *pbSrc, byte *pbLim, int
         Assert(wExp10 < 1000);
         if (wExp10 >= 100)
         {
-            *pchDst++ = (wchar_t)('0' + wExp10 / 100);
+            *pchDst++ = (wchar16)('0' + wExp10 / 100);
             wExp10 %= 100;
-            *pchDst++ = (wchar_t)('0' + wExp10 / 10);
+            *pchDst++ = (wchar16)('0' + wExp10 / 10);
             wExp10 %= 10;
         }
         else if (wExp10 >= 10)
         {
-            *pchDst++ = (wchar_t)('0' + wExp10 / 10);
+            *pchDst++ = (wchar16)('0' + wExp10 / 10);
             wExp10 %= 10;
         }
 #pragma prefast(suppress:26014, "We have calculate the check the buffer size above already")
-        *pchDst++ = (wchar_t)('0' + wExp10);
+        *pchDst++ = (wchar16)('0' + wExp10);
         *pchDst = 0;
     }
     else if (wExp10 <= 0)
@@ -1963,7 +1963,7 @@ static BOOL FormatDigits(_In_reads_(pbLim - pbSrc) byte *pbSrc, byte *pbLim, int
 
 __success(return <= nDstBufSize)
 #pragma prefast(suppress:6101, "when return value is > nDstBufSize, the pchDst is not initialized.  Prefast doesn't seems to pick that up in the annotation")
-static int FormatDigitsFixed(byte *pbSrc, byte *pbLim, int wExp10, int nFractionDigits, __out_ecount_part(nDstBufSize, return) wchar_t *pchDst, int nDstBufSize)
+static int FormatDigitsFixed(byte *pbSrc, byte *pbLim, int wExp10, int nFractionDigits, __out_ecount_part(nDstBufSize, return) wchar16 *pchDst, int nDstBufSize)
 {
     AnalysisAssert(pbLim > pbSrc);
     AssertArrMem(pbSrc, pbLim - pbSrc);
@@ -2054,7 +2054,7 @@ static int FormatDigitsExponential(
                             byte *  pbLim,
                             int     wExp10,
                             int     nFractionDigits,
-                            __out_ecount_part(cchDst,return) wchar_t * pchDst,
+                            __out_ecount_part(cchDst,return) wchar16 * pchDst,
                             int     cchDst
                             )
 {
@@ -2105,7 +2105,7 @@ static int FormatDigitsExponential(
     if (cchDst < n) return n;
 
 #if DBG // save pchDst to validate n
-    wchar_t * pchDstStart = pchDst;
+    wchar16 * pchDstStart = pchDst;
 #endif
 
     // First digit
@@ -2148,17 +2148,17 @@ static int FormatDigitsExponential(
     // Exponent Digits
     if (wExp10 >= 100)
     {
-        *pchDst++ = (wchar_t)('0' + wExp10 / 100);
+        *pchDst++ = (wchar16)('0' + wExp10 / 100);
         wExp10 %= 100;
-        *pchDst++ = (wchar_t)('0' + wExp10 / 10);
+        *pchDst++ = (wchar16)('0' + wExp10 / 10);
         wExp10 %= 10;
     }
     else if (wExp10 >= 10)
     {
-        *pchDst++ = (wchar_t)('0' + wExp10 / 10);
+        *pchDst++ = (wchar16)('0' + wExp10 / 10);
         wExp10 %= 10;
     }
-    *pchDst++ = (wchar_t)('0' + wExp10);
+    *pchDst++ = (wchar16)('0' + wExp10);
 
     *pchDst = 0;
     Assert(1 + pchDst - pchDstStart == n);
@@ -2241,7 +2241,7 @@ static int RoundTo(byte *pbSrc, byte *pbLim, int nDigits, __out_bcount(nDigits+1
 * Returns the number of chars. in the result. If 'nDstBufSize'
 * is less than this number, no data is written to the buffer 'pchDst'.
 */
-int Js::NumberUtilities::FDblToStr(double dbl, Js::NumberUtilities::FormatType ft, int nDigits, __out_ecount(cchDst) wchar_t *pchDst, int cchDst)
+int Js::NumberUtilities::FDblToStr(double dbl, Js::NumberUtilities::FormatType ft, int nDigits, __out_ecount(cchDst) wchar16 *pchDst, int cchDst)
 {
     int n = 0; // the no. of chars in the result.
     int wExp10;
@@ -2254,7 +2254,7 @@ int Js::NumberUtilities::FDblToStr(double dbl, Js::NumberUtilities::FormatType f
         {
             n = 4; //(int)wcslen(OLESTR("NaN")) + 1;
             if( cchDst >= n )
-                wcscpy_s(pchDst, cchDst, L"NaN");
+                wcscpy_s(pchDst, cchDst, CH_WSTR("NaN"));
         }
         else
         {
@@ -2269,7 +2269,7 @@ int Js::NumberUtilities::FDblToStr(double dbl, Js::NumberUtilities::FormatType f
             {
                 if (neg)
                     *pchDst++ = '-';
-                wcscpy_s(pchDst, cchDst - neg, L"Infinity");
+                wcscpy_s(pchDst, cchDst - neg, CH_WSTR("Infinity"));
             }
         }
         return n;
@@ -2362,12 +2362,12 @@ int Js::NumberUtilities::FDblToStr(double dbl, Js::NumberUtilities::FormatType f
     return n;
 }
 
-BOOL Js::NumberUtilities::FDblToStr(double dbl, __out_ecount(cchDst) wchar_t *pchDst, int cchDst)
+BOOL Js::NumberUtilities::FDblToStr(double dbl, __out_ecount(cchDst) wchar16 *pchDst, int cchDst)
 {
     if (!Js::NumberUtilities::IsFinite(dbl))
     {
         if (Js::NumberUtilities::IsNan(dbl))
-            return 0 == wcscpy_s(pchDst, cchDst, L"NaN");
+            return 0 == wcscpy_s(pchDst, cchDst, CH_WSTR("NaN"));
         else
         {
             if (dbl < 0)
@@ -2377,7 +2377,7 @@ BOOL Js::NumberUtilities::FDblToStr(double dbl, __out_ecount(cchDst) wchar_t *pc
                 cchDst--;
             }
 
-            return 0 == wcscpy_s(pchDst, cchDst, L"Infinity");
+            return 0 == wcscpy_s(pchDst, cchDst, CH_WSTR("Infinity"));
         }
     }
 
@@ -2412,7 +2412,7 @@ BOOL Js::NumberUtilities::FNonZeroFiniteDblToStr(double dbl, __out_ecount(cchDst
 
 #if DBG
     double dblT;
-    const wchar_t *pch;
+    const wchar16 *pch;
 
     // In Debug, always call FDblToRgbPrecise and verify that it converts back.
     if (FDblToRgbPrecise(dbl, rgb, &wExp10, &pbLim))
@@ -2420,7 +2420,7 @@ BOOL Js::NumberUtilities::FNonZeroFiniteDblToStr(double dbl, __out_ecount(cchDst
         if (FormatDigits(rgb, pbLim, wExp10, pchDst, cchDst))
         {
             bool likelyInt = true;
-            dblT = StrToDbl<wchar_t>(pchDst, &pch,likelyInt);
+            dblT = StrToDbl<wchar16>(pchDst, &pch,likelyInt);
             Assert(0 == *pch);
             Assert(dblT == dbl);
         }
@@ -2446,7 +2446,7 @@ BOOL Js::NumberUtilities::FNonZeroFiniteDblToStr(double dbl, __out_ecount(cchDst
 
 #if DBG
     bool likelyInt = true;
-    dblT = StrToDbl<wchar_t>(pchDst, &pch, likelyInt);
+    dblT = StrToDbl<wchar16>(pchDst, &pch, likelyInt);
     Assert(0 == *pch);
     Assert(dblT == dbl);
 #endif //DBG
@@ -2484,7 +2484,7 @@ BOOL Js::NumberUtilities::FNonZeroFiniteDblToStr(double dbl, _In_range_(2, 36) i
     int wExp2, wExp, wDig;
     int maxOutDigits, cchSig, cch;
     int len = nDstBufSize;
-    wchar_t * ppsz = psz;
+    wchar16 * ppsz = psz;
 
     if (0x80000000 & Js::NumberUtilities::LuHiDbl(dbl))
     {
@@ -2611,16 +2611,16 @@ BOOL Js::NumberUtilities::FNonZeroFiniteDblToStr(double dbl, _In_range_(2, 36) i
             {
                 if (wExp >= 1000)
                 {
-                    *ppsz++ = (wchar_t)('0' + wExp / 1000);
+                    *ppsz++ = (wchar16)('0' + wExp / 1000);
                     wExp %= 1000;
                 }
-                *ppsz++ = (wchar_t)('0' + wExp / 100);
+                *ppsz++ = (wchar16)('0' + wExp / 100);
                 wExp %= 100;
             }
-            *ppsz++ = (wchar_t)('0' + wExp / 10);
+            *ppsz++ = (wchar16)('0' + wExp / 10);
             wExp %= 10;
         }
-        *ppsz++ = (wchar_t)('0' + wExp);
+        *ppsz++ = (wchar16)('0' + wExp);
         *ppsz++ = ')';
         *ppsz = 0;
 
@@ -2747,13 +2747,13 @@ double Js::NumberUtilities::DblFromDecimal(DECIMAL * pdecIn)
     return dblRet;
 }
 
-void Js::NumberUtilities::CodePointAsSurrogatePair(codepoint_t codePointValue, __out wchar_t* first, __out wchar_t* second)
+void Js::NumberUtilities::CodePointAsSurrogatePair(codepoint_t codePointValue, __out wchar16* first, __out wchar16* second)
 {
     AssertMsg(first != nullptr && second != nullptr, "Null ptr's passed in for out.");
     AssertMsg(IsInSupplementaryPlane(codePointValue), "Code point is not a surrogate pair.");
     codePointValue -= 0x10000;
-    *first = (wchar_t)(codePointValue >> 10) + 0xD800;
-    *second = (wchar_t)(codePointValue & 0x3FF /* This is same as cpv % 0x400 */) + 0xDC00;
+    *first = (wchar16)(codePointValue >> 10) + 0xD800;
+    *second = (wchar16)(codePointValue & 0x3FF /* This is same as cpv % 0x400 */) + 0xDC00;
 }
 
 codepoint_t Js::NumberUtilities::SurrogatePairAsCodePoint(codepoint_t first, codepoint_t second)

--- a/pal/inc/rt/palrt.h
+++ b/pal/inc/rt/palrt.h
@@ -486,9 +486,9 @@ typedef struct tagDEC {
         struct {
             BYTE sign;
             BYTE scale;
-        } u;
+        };
         USHORT signscale;
-    } u;
+    };
     USHORT wReserved;
 #else
     USHORT wReserved;
@@ -496,31 +496,19 @@ typedef struct tagDEC {
         struct {
             BYTE scale;
             BYTE sign;
-        } u;
+        };
         USHORT signscale;
-    } u;
+    };
 #endif
     ULONG Hi32;
     union {
         struct {
             ULONG Lo32;
             ULONG Mid32;
-        } v;
+        };
         ULONGLONG Lo64;
-    } v;
+    };
 } DECIMAL, *LPDECIMAL;
-
-#define DECIMAL_NEG ((BYTE)0x80)
-#define DECIMAL_SCALE(dec)       ((dec).u.u.scale)
-#define DECIMAL_SIGN(dec)        ((dec).u.u.sign)
-#define DECIMAL_SIGNSCALE(dec)   ((dec).u.signscale)
-#define DECIMAL_LO32(dec)        ((dec).v.v.Lo32)
-#define DECIMAL_MID32(dec)       ((dec).v.v.Mid32)
-#define DECIMAL_HI32(dec)        ((dec).Hi32)
-#define DECIMAL_LO64_GET(dec)    ((dec).v.Lo64)
-#define DECIMAL_LO64_SET(dec,value)   {(dec).v.Lo64 = value; }
-
-#define DECIMAL_SETZERO(dec) {DECIMAL_LO32(dec) = 0; DECIMAL_MID32(dec) = 0; DECIMAL_HI32(dec) = 0; DECIMAL_SIGNSCALE(dec) = 0;}
 
 typedef struct tagBLOB {
     ULONG cbSize;


### PR DESCRIPTION
Two issues here:

- wchar_t and WCHAR have different sizes on Linux (32bit and
  16bit). This can happen since wchar_t is compiler defined and WCHAR
  is defined as an unsigned short. To avoid ambiguities just change
  all uses of wchar_t for wchar16 in NumberUtilities*. This should
  probably done everywhere, including changing WCHAR to wchar16 too,
  but for now this is the minimum patch that makes this file compile
  while leaving it in a consistent state.

- The way the DECIMAL structure is accessed does not match its
  definition in pal/. Change the code to use the macros provided, that
  should work everywhere if they are correctly defined.