### PR TITLE
Change CustomHeap to on demand update on whether a page should be in the full list or not.

### DIFF
--- a/lib/Common/Memory/PageAllocator.cpp
+++ b/lib/Common/Memory/PageAllocator.cpp
@@ -2312,7 +2312,7 @@ bool HeapPageAllocator<T>::AllocSecondary(void* segmentParam, ULONG_PTR function
 }
 
 template<typename T>
-void HeapPageAllocator<T>::ReleaseSecondary(const SecondaryAllocation& allocation, void* segmentParam)
+bool HeapPageAllocator<T>::ReleaseSecondary(const SecondaryAllocation& allocation, void* segmentParam)
 {
     SegmentBase<T> * segment = (SegmentBase<T>*)segmentParam;
     Assert(allocation.address != nullptr);
@@ -2335,6 +2335,7 @@ void HeapPageAllocator<T>::ReleaseSecondary(const SecondaryAllocation& allocatio
             AssertMsg(fromList == &fullSegments, "Releasing a secondary allocator should make a state change only if the segment was originally in the full list");
             AssertMsg(pageSegment->CanAllocSecondary(), "It should be allocate secondary now");
             this->AddFreePageCount(pageSegment->GetFreePageCount());
+            return true;
         }
     }
     else
@@ -2342,6 +2343,7 @@ void HeapPageAllocator<T>::ReleaseSecondary(const SecondaryAllocation& allocatio
         Assert(segment->CanAllocSecondary());
         segment->GetSecondaryAllocator()->Release(allocation);
     }
+    return false;
 }
 
 template<typename T>

--- a/lib/Common/Memory/PageAllocator.cpp
+++ b/lib/Common/Memory/PageAllocator.cpp
@@ -2419,14 +2419,15 @@ bool HeapPageAllocator<T>::CreateSecondaryAllocator(SegmentBase<T>* segment, boo
     // If we are not allocating xdata there is nothing to do
 
     // ARM might allocate XDATA but not have a reserved region for it (no secondary alloc reserved space)
-    if(!allocXdata)
+    if (!allocXdata)
     {
         Assert(segment->GetSecondaryAllocSize() == 0);
         *allocator = nullptr;
         return true;
     }
 
-    if (!committed && !this->GetVirtualAllocator()->Alloc(segment->GetSecondaryAllocStartAddress(), segment->GetSecondaryAllocSize(),
+    if (!committed && segment->GetSecondaryAllocSize() != 0 &&
+        !this->GetVirtualAllocator()->Alloc(segment->GetSecondaryAllocStartAddress(), segment->GetSecondaryAllocSize(),
         MEM_COMMIT, PAGE_READWRITE, true))
     {
         *allocator = nullptr;
@@ -2435,9 +2436,9 @@ bool HeapPageAllocator<T>::CreateSecondaryAllocator(SegmentBase<T>* segment, boo
 
     XDataAllocator* secondaryAllocator = HeapNewNoThrow(XDataAllocator, (BYTE*)segment->GetSecondaryAllocStartAddress(), segment->GetSecondaryAllocSize());
     bool success = false;
-    if(secondaryAllocator)
+    if (secondaryAllocator)
     {
-        if(secondaryAllocator->Initialize((BYTE*)segment->GetAddress(), (BYTE*)segment->GetEndAddress()))
+        if (secondaryAllocator->Initialize((BYTE*)segment->GetAddress(), (BYTE*)segment->GetEndAddress()))
         {
             success = true;
         }

--- a/lib/Common/Memory/PageAllocator.h
+++ b/lib/Common/Memory/PageAllocator.h
@@ -719,7 +719,7 @@ public:
 
     BOOL ProtectPages(__in char* address, size_t pageCount, __in void* segment, DWORD dwVirtualProtectFlags, DWORD desiredOldProtectFlag);
     bool AllocSecondary(void* segment, ULONG_PTR functionStart, DWORD functionSize, ushort pdataCount, ushort xdataSize, SecondaryAllocation* allocation);
-    void ReleaseSecondary(const SecondaryAllocation& allocation, void* segment);
+    bool ReleaseSecondary(const SecondaryAllocation& allocation, void* segment);
     void TrackDecommittedPages(void * address, uint pageCount, __in void* segment);
     void DecommitPages(__in char* address, size_t pageCount = 1);
 

--- a/lib/Common/Memory/VirtualAllocWrapper.cpp
+++ b/lib/Common/Memory/VirtualAllocWrapper.cpp
@@ -113,17 +113,22 @@ PreReservedVirtualAllocWrapper::IsInRange(void * address)
     {
         return false;
     }
-#if DBG
-    //Check if the region is in MEM_COMMIT state.
-    MEMORY_BASIC_INFORMATION memBasicInfo;
-    size_t bytes = VirtualQuery(address, &memBasicInfo, sizeof(memBasicInfo));
-    if (bytes == 0 || memBasicInfo.State != MEM_COMMIT)
-    {
-        AssertMsg(false, "Memory not committed? Checking for uncommitted address region?");
-    }
-#endif
 
-    return address >= GetPreReservedStartAddress() && address < GetPreReservedEndAddress();
+    if (address >= GetPreReservedStartAddress() && address < GetPreReservedEndAddress())
+    {
+#if DBG
+        //Check if the region is in MEM_COMMIT state.
+        MEMORY_BASIC_INFORMATION memBasicInfo;
+        size_t bytes = VirtualQuery(address, &memBasicInfo, sizeof(memBasicInfo));
+        if (bytes == 0 || memBasicInfo.State != MEM_COMMIT)
+        {
+            AssertMsg(false, "Memory not committed? Checking for uncommitted address region?");
+        }
+#endif
+        return true;
+    }
+
+    return false;
 }
 
 LPVOID

--- a/lib/Common/Memory/amd64/XDataAllocator.cpp
+++ b/lib/Common/Memory/amd64/XDataAllocator.cpp
@@ -21,7 +21,7 @@ XDataAllocator::XDataAllocator(BYTE* address, uint size) :
     functionTableHandles(nullptr)
 {
 #ifdef RECYCLER_MEMORY_VERIFY
-        memset(this->start, Recycler::VerifyMemFill, this->size);
+    memset(this->start, Recycler::VerifyMemFill, this->size);
 #endif
     Assert(size > 0);
     Assert(address != nullptr);
@@ -97,7 +97,7 @@ bool XDataAllocator::Alloc(ULONG_PTR functionStart, DWORD functionSize, ushort p
     Assert(current != nullptr);
     Assert(current >= start);
     Assert(xdataSize <= XDATA_SIZE);
-    Assert(AutoSystemInfo::Data.IsWin8OrLater() || pdataCount == 1);
+    Assert(pdataCount == 1);
 
     // Allocate a new xdata entry
     if((End() - current) >= XDATA_SIZE)


### PR DESCRIPTION
Now that the page allocator for the code pages are shared amongst multiple CustomHeap, the state of the secondary allocator may change by other CustomHeap, making it impossible to maintain that full list are block that are really full (no more allocable space in the page and/or no more secondary space for the segment).  So, walking all the block to and move the pages between full list and the bucket list if the current CustomHeap when secondary allocator state changes, do it when we allocate on demand.

In PreReservedVirtualAllocWrapper::IsInRange, only check if the addres is committed when it is in the preserved region. We don't care otherwise.
