### PR TITLE
Invalidate proto caches in the correct script context

### DIFF
--- a/lib/Runtime/Base/CrossSiteObject.h
+++ b/lib/Runtime/Base/CrossSiteObject.h
@@ -223,21 +223,13 @@ namespace Js
     template <typename T>
     void CrossSiteObject<T>::RemoveFromPrototype(ScriptContext * requestContext)
     {
-        if (GetScriptContext() == requestContext)
-        {
-            __super::RemoveFromPrototype(requestContext);
-        }
-        // else do nothing because we never cache cross-context
+        __super::RemoveFromPrototype(GetScriptContext());
     }
 
     template <typename T>
     void CrossSiteObject<T>::AddToPrototype(ScriptContext * requestContext)
     {
-        if (GetScriptContext() == requestContext)
-        {
-            __super::AddToPrototype(requestContext);
-        }
-        // else do nothing because we never cache cross-context
+        __super::AddToPrototype(GetScriptContext());
     }
 
     template <typename T>


### PR DESCRIPTION
If the prototype of an object is changed in a different context, we need to invalidate proto inline caches in the script context of the old prototype. We were only invalidating the caches in the current context, but the prototype being changed could have had property loads from it cached in a different context.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/399)
<!-- Reviewable:end -->
