### PR TITLE
fix asm.js issue where fixnum was causing us to use uint div/mod

### DIFF
--- a/lib/Runtime/Language/AsmJsByteCodeGenerator.cpp
+++ b/lib/Runtime/Language/AsmJsByteCodeGenerator.cpp
@@ -663,7 +663,8 @@ namespace Js
         {
             CheckNodeLocation( lhsEmit, int );
             CheckNodeLocation( rhsEmit, int );
-            auto opType = lType.isUnsigned() ? BMOT_UInt : BMOT_Int;
+            // because fixnum can be either signed or unsigned, use both lhs and rhs to infer sign
+            auto opType = (lType.isSigned() && rType.isSigned()) ? BMOT_Int : BMOT_UInt;
             if (op == BMO_REM || op == BMO_DIV)
             {
                 // div and rem must have explicit sign

--- a/test/AsmJs/rlexe.xml
+++ b/test/AsmJs/rlexe.xml
@@ -771,4 +771,11 @@
       <compile-flags>-forcedeferparse -testtrace:asmjs -simdjs</compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>uint.js</files>
+      <baseline>uint.baseline</baseline>
+      <compile-flags>-maic:1 -testtrace:asmjs -simdjs</compile-flags>
+    </default>
+  </test>
 </regress-exe>

--- a/test/AsmJs/uint.baseline
+++ b/test/AsmJs/uint.baseline
@@ -1,0 +1,6 @@
+Successfully compiled asm.js code
+Successfully compiled asm.js code
+0
+0
+1
+1

--- a/test/AsmJs/uint.js
+++ b/test/AsmJs/uint.js
@@ -1,0 +1,27 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+let asmHeap = new ArrayBuffer(1 << 20);
+let m = function (stdlib, foreign, heap) {
+  'use asm';
+  function f(d0) {
+    d0 = +d0;
+    return 1 % ~~d0 | 0;
+  }
+  return f;
+}({}, {}, asmHeap);
+print(m(4294967295));
+print(m(4294967295));
+
+m = function (stdlib, foreign, heap) {
+  'use asm';
+  function f(d0) {
+    d0 = +d0;
+    return 1 % (~~d0 >>> 0) | 0;
+  }
+  return f;
+}({}, {}, asmHeap);
+print(m(4294967295));
+print(m(4294967295));


### PR DESCRIPTION
fixnum can be used as either signed or unsigned, so we need to look at both lhs and rhs to infer the correct context for binary operators.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/409)
<!-- Reviewable:end -->
