### PR TITLE
in asm.js ! operator should give type int, not signed

### DIFF
--- a/lib/Runtime/Language/AsmJsByteCodeGenerator.cpp
+++ b/lib/Runtime/Language/AsmJsByteCodeGenerator.cpp
@@ -2740,7 +2740,7 @@ namespace Js
         const EmitExpressionInfo& rhsEmit = Emit( rhs );
         const AsmJsType& rType = rhsEmit.type;
         StartStatement(pnode);
-        EmitExpressionInfo emitInfo( AsmJsType::Signed );
+        EmitExpressionInfo emitInfo( AsmJsType::Int );
         if( rType.isInt() )
         {
             CheckNodeLocation( rhsEmit, int );

--- a/test/AsmJs/return1.baseline
+++ b/test/AsmJs/return1.baseline
@@ -1,3 +1,11 @@
 Successfully compiled asm.js code
+
+return1.js(46, 12)
+	Asm.js Compilation Error function : None::f
+	Expression for return must be subtype of Signed, Double, or Float
+
+Asm.js compilation failed.
 124
 124
+true
+true

--- a/test/AsmJs/return1.js
+++ b/test/AsmJs/return1.js
@@ -35,5 +35,17 @@
 }
 
 var f3 = AsmModule();
-print(f3  (1,1.5))  
-print(f3  (1,1.5))   
+print(f3  (1,1.5));
+print(f3  (1,1.5));
+
+let asmHeap = new ArrayBuffer(1 << 20);
+let m = function (stdlib, foreign, heap) {
+  'use asm';
+  function f(i0) {
+    i0 = i0 | 0;
+    return !i0;
+  }
+  return f;
+}({}, {}, asmHeap);
+print(m());
+print(m());

--- a/test/AsmJs/rlexe.xml
+++ b/test/AsmJs/rlexe.xml
@@ -617,7 +617,7 @@
     <default>
       <files>return1.js</files>
       <baseline>return1.baseline</baseline>
-      <compile-flags>-testtrace:asmjs -simdjs -bgjit- -lic:1</compile-flags>
+      <compile-flags>-off:deferparse -testtrace:asmjs -simdjs -bgjit- -lic:1</compile-flags>
     </default>
   </test>
   <test>


### PR DESCRIPTION
This is a bug which gives semantic difference between asm.js and normal js in case of return or ffi calls, where js semantics it should be `true` or `false`, but we were giving `1` or `0`. Correct result is that asm.js should not validate these cases.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/411)
<!-- Reviewable:end -->
