### PR TITLE
Fix SIMD alignment AV on Dev12 build.

### DIFF
--- a/lib/Runtime/Language/SimdUint32x4OperationX86X64.cpp
+++ b/lib/Runtime/Language/SimdUint32x4OperationX86X64.cpp
@@ -53,7 +53,7 @@ namespace Js
         }
         // CVTTPS2DQ does a range check over signed range [-2^31, 2^31-1], so will fail to convert values >= 2^31.
         // To fix this, subtract 2^31 from values >= 2^31, do CVTTPS2DQ, then add 2^31 back.
-        _mm_store_ps(two_31_f4.simdValue.f32, X86_TWO_31_F4.m128_value);
+        _mm_store_ps(two_31_f4.f32, X86_TWO_31_F4.m128_value);
         // any lanes >= 2^31 ?
         temp.m128_value = _mm_cmpge_ps(v.m128_value, two_31_f4.m128_value);
         // two_31_f4 has f32(2^31) for lanes >= 2^31, 0 otherwise
@@ -77,7 +77,7 @@ namespace Js
         // add 2^31 values back to adjusted values.
         // Use first bit from the 2^31 float mask (0x4f000...0 << 1)
         // and result with 2^31 int mask (0x8000..0) setting first bit to zero if lane hasn't been adjusted
-        _mm_store_ps(two_31_i4.simdValue.f32, X86_TWO_31_I4.m128_value);
+        _mm_store_ps(two_31_i4.f32, X86_TWO_31_I4.m128_value);
         two_31_f4.m128i_value = _mm_slli_epi32(two_31_f4.m128i_value, 1);
         two_31_i4.m128i_value = _mm_and_si128(two_31_i4.m128i_value, two_31_f4.m128i_value);
         // add 2^31 back to adjusted values

--- a/lib/Runtime/Language/SimdUtils.cpp
+++ b/lib/Runtime/Language/SimdUtils.cpp
@@ -60,7 +60,7 @@ namespace Js
         X86SIMDValue x86Result;
         X86SIMDValue v = X86SIMDValue::ToX86SIMDValue(value);
 
-        _mm_store_ps(x86Result.simdValue.f32, v.m128_value);
+        _mm_store_ps(x86Result.f32, v.m128_value);
 
         return X86SIMDValue::ToSIMDValue(x86Result);
     }

--- a/lib/Runtime/Language/SimdUtils.h
+++ b/lib/Runtime/Language/SimdUtils.h
@@ -18,19 +18,20 @@
 #define INT8_SIZE    1
 #define SIMD_INDEX_VALUE_MAX     5
 #define SIMD_STRING_BUFFER_MAX   1024
-
+#define SIMD_DATA 	\
+	int32   i32[4];\
+	int16   i16[8];\
+	int8    i8[16];\
+	uint32  u32[4];\
+	uint16  u16[8];\
+	uint8   u8[16];\
+	float   f32[4];\
+	double  f64[2];
 
 struct _SIMDValue
 {
     union{
-        int32   i32[4];
-        int16   i16[8];
-        int8    i8[16];
-        uint32  u32[4];
-        uint16  u16[8];
-        uint8   u8[16];
-        float   f32[4];
-        double  f64[2];
+		SIMD_DATA
     };
 
     void SetValue(_SIMDValue value)
@@ -79,7 +80,7 @@ struct DefaultComparer<_SIMDValue>
 struct _x86_SIMDValue
 {
     union{
-        _SIMDValue simdValue;
+		SIMD_DATA
         __m128  m128_value;
         __m128d m128d_value;
         __m128i m128i_value;
@@ -88,20 +89,20 @@ struct _x86_SIMDValue
     static _x86_SIMDValue ToX86SIMDValue(const SIMDValue& val)
     {
         _x86_SIMDValue result;
-        result.simdValue.i32[SIMD_X] = val.i32[SIMD_X];
-        result.simdValue.i32[SIMD_Y] = val.i32[SIMD_Y];
-        result.simdValue.i32[SIMD_Z] = val.i32[SIMD_Z];
-        result.simdValue.i32[SIMD_W] = val.i32[SIMD_W];
+        result.i32[SIMD_X] = val.i32[SIMD_X];
+        result.i32[SIMD_Y] = val.i32[SIMD_Y];
+        result.i32[SIMD_Z] = val.i32[SIMD_Z];
+        result.i32[SIMD_W] = val.i32[SIMD_W];
         return result;
     }
 
     static SIMDValue ToSIMDValue(const _x86_SIMDValue& val)
     {
         SIMDValue result;
-        result.i32[SIMD_X] = val.simdValue.i32[SIMD_X];
-        result.i32[SIMD_Y] = val.simdValue.i32[SIMD_Y];
-        result.i32[SIMD_Z] = val.simdValue.i32[SIMD_Z];
-        result.i32[SIMD_W] = val.simdValue.i32[SIMD_W];
+        result.i32[SIMD_X] = val.i32[SIMD_X];
+        result.i32[SIMD_Y] = val.i32[SIMD_Y];
+        result.i32[SIMD_Z] = val.i32[SIMD_Z];
+        result.i32[SIMD_W] = val.i32[SIMD_W];
         return result;
     }
 };

--- a/lib/Runtime/Language/SimdUtils.h
+++ b/lib/Runtime/Language/SimdUtils.h
@@ -18,20 +18,20 @@
 #define INT8_SIZE    1
 #define SIMD_INDEX_VALUE_MAX     5
 #define SIMD_STRING_BUFFER_MAX   1024
-#define SIMD_DATA 	\
-	int32   i32[4];\
-	int16   i16[8];\
-	int8    i8[16];\
-	uint32  u32[4];\
-	uint16  u16[8];\
-	uint8   u8[16];\
-	float   f32[4];\
-	double  f64[2];
+#define SIMD_DATA     \
+    int32   i32[4];\
+    int16   i16[8];\
+    int8    i8[16];\
+    uint32  u32[4];\
+    uint16  u16[8];\
+    uint8   u8[16];\
+    float   f32[4];\
+    double  f64[2];
 
 struct _SIMDValue
 {
     union{
-		SIMD_DATA
+        SIMD_DATA
     };
 
     void SetValue(_SIMDValue value)
@@ -80,7 +80,7 @@ struct DefaultComparer<_SIMDValue>
 struct _x86_SIMDValue
 {
     union{
-		SIMD_DATA
+        SIMD_DATA
         __m128  m128_value;
         __m128d m128d_value;
         __m128i m128i_value;


### PR DESCRIPTION
This fix separates the two SIMDValue structs.
Fix AV on Dev12 build. For SIMD value, we use a generic value (_SIMDValue) and an IA specific value with an intrinsic variable (_x86_SIMDValue). Initially, we had the IA specific one include the _SIMDValue struct. This causes the compiler to copy-prop pointers to _SIMDValue to _x86_SIMDValue, even though alignment is not guaranteed. For this particular case, it was when passing a parameter by reference to a SIMD op handler. A pointer to the stack slot in the caller holding the _SIMDValue is passed, it gets copied inside the hanlder to a _x86_SIMDValue. The compiler decides to eliminate the copy, and reference the pointer to the stack directly which causes hardware exception if it happens not to be aligned.