### PR TITLE
Symbol.toString returns invalid string.

### DIFF
--- a/lib/Runtime/Library/JavascriptSymbol.cpp
+++ b/lib/Runtime/Library/JavascriptSymbol.cpp
@@ -287,16 +287,12 @@ namespace Js
 
     JavascriptString* JavascriptSymbol::ToString(ScriptContext * requestContext)
     {
-        // Reject implicit call
-        ThreadContext* threadContext = requestContext->GetThreadContext();
-        if (threadContext->IsDisableImplicitCall())
+        if (requestContext->GetThreadContext()->RecordImplicitException())
         {
-            threadContext->AddImplicitCallFlags(Js::ImplicitCall_External);
-            return nullptr;
+            JavascriptError::ThrowTypeError(requestContext, VBSERR_OLENoPropOrMethod, L"ToString");
         }
-        // This keeps getting revisited but as of ES6 spec revision 20,
-        // implicit string conversion of symbol primitives is supposed to throw a TypeError.
-        JavascriptError::ThrowTypeError(requestContext, VBSERR_OLENoPropOrMethod, L"ToString");
+
+        return requestContext->GetLibrary()->GetEmptyString();
     }
 
     JavascriptString* JavascriptSymbol::ToString(const PropertyRecord* propertyRecord, ScriptContext * requestContext)

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -240,4 +240,10 @@
       <files>OS_5553123.js</files>
     </default>
   </test>
+  <test>
+    <default>
+      <files>symbol_tostring.js</files>
+      <compile-flags>-maxsimplejitruncount:1 -maxinterpretcount:1 -force:fieldcopyprop</compile-flags>
+    </default>
+  </test>
 </regress-exe>

--- a/test/Bugs/symbol_tostring.js
+++ b/test/Bugs/symbol_tostring.js
@@ -1,0 +1,20 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+var k;
+function test0() {
+  try {
+    // Below will throw an error and we will try to do implicit toString call on Symbol which will also throw.
+    // Under disableImplicit call we were returning nullptr which was wrong.
+    [] = ab[Object(Symbol())] = null;
+    } catch (e) {
+  }
+  var ab = '';
+}
+test0();
+test0();
+test0();
+
+print("Pass");


### PR DESCRIPTION
Call to JavascriptSymbol::ToString should throw an error - but we have a check for disabledimplicit call which return nullptr which leads to AV. Fixing that by checking RecordImplicitException. Now we will either throw or return an empty string.
