### PR TITLE
Fix GCStress on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,7 @@ if(CMAKE_BUILD_TYPE STREQUAL Debug)
     add_definitions(
         -DDBG=1
         -DDEBUG=1
+        -D_DEBUG=1 # for PAL
         -DDBG_DUMP=1        
     )
     # xplat-todo: reenable this warning

--- a/lib/Common/CommonPal.h
+++ b/lib/Common/CommonPal.h
@@ -55,8 +55,7 @@ inline int get_cpuid(int cpuInfo[4], int function_id)
 
 inline void DebugBreak()
 {
-    asm ("int3");
-    __builtin_unreachable();
+    __builtin_trap();
 }
 
 #define _BitScanForward BitScanForward
@@ -67,7 +66,7 @@ inline void DebugBreak()
 #define _bittestandset BitTestAndSet
 #define _interlockedbittestandset InterlockedBitTestAndSet
 
-#define DbgRaiseAssertionFailure() __asm__ volatile("int $0x03");
+#define DbgRaiseAssertionFailure() __builtin_trap()
 
 // These are not available in pal
 #define fwprintf_s      fwprintf

--- a/lib/Common/Memory/Recycler.cpp
+++ b/lib/Common/Memory/Recycler.cpp
@@ -324,7 +324,7 @@ Recycler::Recycler(AllocationPolicyManager * policyManager, IdleDecommitPageAllo
 
 #ifdef ENABLE_DEBUG_CONFIG_OPTIONS
     // recycler requires at least Recycler::PrimaryMarkStackReservedPageCount to function properly for the main mark context
-    this->markContext.SetMaxPageCount(max(GetRecyclerFlagsTable().MaxMarkStackPageCount, Recycler::PrimaryMarkStackReservedPageCount));
+    this->markContext.SetMaxPageCount(max(static_cast<size_t>(GetRecyclerFlagsTable().MaxMarkStackPageCount), static_cast<size_t>(Recycler::PrimaryMarkStackReservedPageCount)));
     this->parallelMarkContext1.SetMaxPageCount(GetRecyclerFlagsTable().MaxMarkStackPageCount);
     this->parallelMarkContext2.SetMaxPageCount(GetRecyclerFlagsTable().MaxMarkStackPageCount);
     this->parallelMarkContext3.SetMaxPageCount(GetRecyclerFlagsTable().MaxMarkStackPageCount);


### PR DESCRIPTION
Complete the port of GCStress to linux.
1. Fix bugs in implementation of BitTestAndSet etc.
2. Support passing in command line flags to GCStress
3. Use sigtrap for assertion failures to break into both lldb and gdb
4. Lower threshold of initial object count/op count to show progress
   on my VM. We'll have a future investigation item to understand what
   operations are slower on linux and how they can be sped up.
