### PR TITLE
Quick implementation of section and module headers

### DIFF
--- a/lib/WasmReader/WasmBinaryReader.h
+++ b/lib/WasmReader/WasmBinaryReader.h
@@ -72,8 +72,11 @@ namespace Wasm
             bSectFunctions      = 0x02,
             bSectGlobals        = 0x03,
             bSectDataSegments   = 0x04,
-            bSectFunctionTable  = 0x05,
+            bSectIndirectFunctionTable = 0x05,
             bSectEnd            = 0x06, // marks end of module
+            bSectStartFunction  = 0x07,
+            bSectImportTable    = 0x08,
+            bSectExportTable    = 0x09,
             bSectLimit
         };
 
@@ -111,6 +114,7 @@ namespace Wasm
             WasmOp GetWasmToken(WasmBinOp op);
             WasmBinOp ASTNode();
 
+            void ModuleHeader();
             void CallNode();
             void BlockNode();
             void BrNode();
@@ -126,7 +130,7 @@ namespace Wasm
             UINT32 Offset();
             UINT LEB128(UINT &length);
             template <typename T> T ReadConst();
-
+            SectionCode SectionHeader();
 
 
 
@@ -147,6 +151,7 @@ namespace Wasm
         private:
 
             static bool isInit;
+            static bool seenModuleHeader;
             static WasmTypes::Signature opSignatureTable[WasmTypes::OpSignatureId::bSigLimit]; // table of opcode signatures
             static WasmTypes::OpSignatureId opSignature[WasmBinOp::wbLimit];                   // opcode -> opcode signature ID
             // maps from binary format to sexpr codes


### PR DESCRIPTION
This is an implementation of the string-form of section headers
and the new module header. It currently uses a suboptimal
chain of string comparisons, but this is a placeholder for
something more efficient as the discussion on whether to
use an LEB128-like encoding or brotli instead of general strings
is settled. Ideally, we would just hash the string using
JsUtil::CharacterBuffer<char>::StaticGetHashCode() or some faster
alternative and do lookup of the hash map. This commit will be
helpful to establish the section handling in preparation for
breaking up the function section into decls and defs.
