### PR TITLE
Enabling JIT for split scope scenarios in default parameters

### DIFF
--- a/lib/Backend/Func.cpp
+++ b/lib/Backend/Func.cpp
@@ -38,6 +38,7 @@ Func::Func(JitArenaAllocator *alloc, CodeGenWorkItem* workItem, const Js::Functi
     m_loopParamSym(nullptr),
     m_funcObjSym(nullptr),
     m_localClosureSym(nullptr),
+    m_paramClosureSym(nullptr),
     m_localFrameDisplaySym(nullptr),
     m_bailoutReturnValueSym(nullptr),
     m_hasBailedOutSym(nullptr),
@@ -964,6 +965,13 @@ void Func::InitLocalClosureSyms()
                                    this->DoStackFrameDisplay() ? (Js::RegSlot)-1 : regSlot,
                                    this);
     }
+
+    if (!this->GetJnFunction()->IsParamAndBodyScopeMerged())
+    {
+        Assert(this->GetParamClosureSym() == nullptr);
+        this->m_paramClosureSym = StackSym::New(TyVar, this);
+    }
+
     regSlot = this->GetJnFunction()->GetLocalFrameDisplayRegister();
     if (regSlot != Js::Constants::NoRegister)
     {

--- a/lib/Backend/Func.h
+++ b/lib/Backend/Func.h
@@ -266,6 +266,9 @@ static const unsigned __int64 c_debugFillPattern8 = 0xcececececececece;
     StackSym *GetLocalClosureSym() const { return m_localClosureSym; }
     void SetLocalClosureSym(StackSym *sym) { m_localClosureSym = sym; }
 
+    StackSym *GetParamClosureSym() const { return m_paramClosureSym; }
+    void SetParamClosureSym(StackSym *sym) { m_paramClosureSym = sym; }
+
     StackSym *GetLocalFrameDisplaySym() const { return m_localFrameDisplaySym; }
     void SetLocalFrameDisplaySym(StackSym *sym) { m_localFrameDisplaySym = sym; }
 
@@ -468,6 +471,7 @@ public:
     StackSym *          m_scriptContextSym;
     StackSym *          m_functionBodySym;
     StackSym *          m_localClosureSym;
+    StackSym *          m_paramClosureSym;
     StackSym *          m_localFrameDisplaySym;
     StackSym *          m_bailoutReturnValueSym;
     StackSym *          m_hasBailedOutSym;

--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -1866,7 +1866,8 @@ void ByteCodeGenerator::LoadAllConstants(FuncInfo *funcInfo)
     else if (funcInfo->frameSlotsRegister != Js::Constants::NoRegister)
     {
         int scopeSlotCount = funcInfo->bodyScope->GetScopeSlotCount();
-        if (scopeSlotCount == 0)
+        int paramSlotCount = funcInfo->paramScope->GetScopeSlotCount();
+        if (scopeSlotCount == 0 && paramSlotCount == 0)
         {
             AssertMsg(funcInfo->frameDisplayRegister != Js::Constants::NoRegister, "Why do we need scope slots?");
             m_writer.Reg1(Js::OpCode::LdC_A_Null, funcInfo->frameSlotsRegister);
@@ -3485,7 +3486,6 @@ void ByteCodeGenerator::EmitScopeList(ParseNode *pnode, bool breakOnNonFunc)
                     ParseNodePtr paramBlock = pnode->sxFnc.pnodeScopes;
                     Assert(paramBlock->nop == knopBlock && paramBlock->sxBlock.blockType == Parameter);
 
-                    // Push the param scope
                     PushScope(paramScope);
 
                     // While emitting the functions we have to stop when we see the body scope block.

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -689,15 +689,13 @@
   <test>
     <default>
       <files>default-splitscope.js</files>
-      <compile-flags>-off:deferparse -nonative -ES6DefaultArgsSplitScope -ES6Generators -args summary -endargs</compile-flags>
-      <tags>exclude_dynapogo</tags>
+      <compile-flags>-off:deferparse -ES6DefaultArgsSplitScope -ES6Generators -args summary -endargs</compile-flags>
     </default>
   </test>
   <test>
     <default>
       <files>default-splitscope.js</files>
-      <compile-flags>-force:deferparse -nonative -ES6DefaultArgsSplitScope -ES6Generators -args summary -endargs</compile-flags>
-      <tags>exclude_dynapogo</tags>
+      <compile-flags>-force:deferparse -ES6DefaultArgsSplitScope -ES6Generators -args summary -endargs</compile-flags>
     </default>
   </test>
   <test>


### PR DESCRIPTION
Enabling JIT for split scope scenarios in default parameters

The default parameter split scope introduced two new opcodes.
BeginBodyScope marks the end of param scope and the start of body scope.
In split scope we have to have separate scopes for both param and body. So
a new scope slot array is created for the body scope in this opcode.

At the beginning of the body the initial values of the body symbols
corresponding to the params should get the final value from the
param scope symbols. To load the old value from the old param scope slots
LdParamSlot opcode is used.
