### PR TITLE
Avoid undo defer for function which has non simple param list.

### DIFF
--- a/test/Bugs/default_undodefer.js
+++ b/test/Bugs/default_undodefer.js
@@ -1,0 +1,13 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+// Validating that function with default does not assert with ForceUndoDefer
+var bar = function () { }
+
+function foo(a = function () {} ) { 
+    print("Pass");
+}
+
+foo();

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -246,4 +246,10 @@
       <compile-flags>-maxsimplejitruncount:1 -maxinterpretcount:1 -force:fieldcopyprop</compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>default_undodefer.js</files>
+      <compile-flags>-forcedeferparse -forceundodefer</compile-flags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
There is a duplicated logic in the FinishDeferredFunction code path (can
be tried using ForceUndoDefer) for parsing function. It does not make
sense to write the code for handling the default scenario again. So avoid
undeferring such function immediately until they are called.
