### PR TITLE
Monorphic type check fix

### DIFF
--- a/lib/Backend/BackwardPass.cpp
+++ b/lib/Backend/BackwardPass.cpp
@@ -4015,28 +4015,32 @@ BackwardPass::TrackObjTypeSpecProperties(IR::PropertySymOpnd *opnd, BasicBlock *
             Assert(guardedPropertyOps != nullptr);
             opnd->EnsureGuardedPropOps(this->func->m_alloc);
             opnd->AddGuardedPropOps(guardedPropertyOps);
-            if (bucket->NeedsMonoCheck() && !opnd->IsTypeAvailable())
+            if (!opnd->IsTypeAvailable())
             {
-                if (this->currentInstr->HasEquivalentTypeCheckBailOut())
+                if (bucket->NeedsMonoCheck())
                 {
-                    // Some instr protected by this one requires a monomorphic type check. (E.g., final type opt,
-                    // fixed field not loaded from prototype.) Note the IsTypeAvailable test above: only do this at
-                    // the initial type check that protects this path.
-                    opnd->SetMonoGuardType(bucket->GetMonoGuardType());
-                    this->currentInstr->ChangeEquivalentToMonoTypeCheckBailOut();
+                    if (this->currentInstr->HasEquivalentTypeCheckBailOut())
+                    {
+                        // Some instr protected by this one requires a monomorphic type check. (E.g., final type opt,
+                        // fixed field not loaded from prototype.) Note the IsTypeAvailable test above: only do this at
+                        // the initial type check that protects this path.
+                        opnd->SetMonoGuardType(bucket->GetMonoGuardType());
+                        this->currentInstr->ChangeEquivalentToMonoTypeCheckBailOut();
+                    }
+                    bucket->SetMonoGuardType(nullptr);
                 }
-                bucket->SetMonoGuardType(nullptr);
+
+                bucket->SetGuardedPropertyOps(nullptr);
+                JitAdelete(this->tempAlloc, guardedPropertyOps);
+                block->stackSymToGuardedProperties->Clear(objSym->m_id);
             }
-
-            bucket->SetGuardedPropertyOps(nullptr);
-            JitAdelete(this->tempAlloc, guardedPropertyOps);
-            block->stackSymToGuardedProperties->Clear(objSym->m_id);
-
 #if DBG
-            // If there is no upstream type check that is live and could protect guarded properties, we better
-            // not have any properties remaining.
-            ObjTypeGuardBucket* bucket = block->stackSymToGuardedProperties->Get(opnd->GetObjectSym()->m_id);
-            Assert(opnd->IsTypeAvailable() || bucket == nullptr || bucket->GetGuardedPropertyOps()->IsEmpty());
+            {
+                // If there is no upstream type check that is live and could protect guarded properties, we better
+                // not have any properties remaining.
+                ObjTypeGuardBucket* bucket = block->stackSymToGuardedProperties->Get(opnd->GetObjectSym()->m_id);
+                Assert(opnd->IsTypeAvailable() || bucket == nullptr || bucket->GetGuardedPropertyOps()->IsEmpty());
+            }
 #endif
         }
     }

--- a/test/fieldopts/fixedfieldmonocheck4.js
+++ b/test/fieldopts/fixedfieldmonocheck4.js
@@ -1,0 +1,57 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function test0() {
+    var obj0 = {};
+    var protoObj0 = {};
+    var obj1 = {};
+    var func0 = function () {
+        (function () {
+        }(c++));
+    };
+    var func2 = function () {
+    };
+    var func4 = function () {
+    };
+    obj0.method0 = func0;
+    obj0.method1 = func4;
+    obj1.method0 = func2;
+    obj1.method1 = obj0.method0;
+    var a = -647661593;
+    var c = 1650427918.1;
+    Object.create(obj1);
+    arrObj0 = obj1;
+    var __loopvar0 = 7 + 9;
+    while (a) {
+        __loopvar0 -= 3;
+        if (__loopvar0 == 7) {
+            break;
+        }
+        function __callback1(__bar) {
+            obj1.method0 = protoObj0;
+            __bar();
+        }
+        function __callback2() {
+            var uniqobj7 = {
+                nd1: {
+                    nd0: {
+                        lf0: { method1: arrObj0.method1 },
+                        lf1: { method0: obj0.method1 },
+                        nd2: { lf0: { method0: arrObj0.method0 } }
+                    }
+                }
+            };
+            var id40 = arrObj0.method1();
+        }
+        __callback1(__callback2);
+    }
+    if (c !== 1650427920.1) {
+        WScript.Echo('fail: c === ' + c);
+    }
+}
+test0();
+test0();
+
+WScript.Echo('pass');

--- a/test/fieldopts/rlexe.xml
+++ b/test/fieldopts/rlexe.xml
@@ -854,4 +854,9 @@
       <compile-flags>-maxinterpretcount:2 -force:jitloopbody -force:rejit -off:bailonnoprofile</compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>fixedfieldmonocheck4.js</files>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
Since we don't want to perform monomorphic type checks at points where the type is already available, avoid clearing the monomorphic type check bucket in such a case.