### PR TITLE
Reset variable lifetime to be valid if not dead in DeadStorePhase

### DIFF
--- a/lib/Backend/BackwardPass.cpp
+++ b/lib/Backend/BackwardPass.cpp
@@ -34,12 +34,21 @@ BackwardPass::BackwardPass(Func * func, GlobOpt * globOpt, Js::Phase tag)
 #endif
 }
 
-bool
-BackwardPass::DoSetDead() const
+void
+BackwardPass::DoSetDead(IR::Opnd * opnd, bool isDead) const
 {
     // Note: Dead bit on the Opnd records flow-based liveness.
     // This is distinct from isLastUse, which records lexical last-ness.
-    return this->tag == Js::BackwardPhase && !this->IsPrePass();
+    if (isDead && this->tag == Js::BackwardPhase && !this->IsPrePass())
+    {
+        opnd->SetIsDead();
+    }
+    else if (this->tag == Js::DeadStorePhase)
+    {
+        // Set or reset in DeadStorePhase.
+        // CSE could make previous dead operand not the last use, so reset it.
+        opnd->SetIsDead(isDead);
+    }
 }
 
 bool
@@ -4554,10 +4563,7 @@ BackwardPass::ProcessUse(IR::Opnd * opnd)
                 this->CollectCloneStrCandidate(opnd);
             }
 
-            if (!this->ProcessSymUse(sym, true, regOpnd->GetIsJITOptimizedReg()) && this->DoSetDead())
-            {
-                regOpnd->SetIsDead();
-            }
+            this->DoSetDead(regOpnd, !this->ProcessSymUse(sym, true, regOpnd->GetIsJITOptimizedReg()));
 
             if (IsCollectionPass())
             {
@@ -4602,10 +4608,8 @@ BackwardPass::ProcessUse(IR::Opnd * opnd)
         {
             IR::SymOpnd *symOpnd = opnd->AsSymOpnd();
             Sym * sym = symOpnd->m_sym;
-            if (!this->ProcessSymUse(sym, false, opnd->GetIsJITOptimizedReg()) && this->DoSetDead())
-            {
-                symOpnd->SetIsDead();
-            }
+
+            this->DoSetDead(symOpnd, !this->ProcessSymUse(sym, false, opnd->GetIsJITOptimizedReg()));
 
             if (IsCollectionPass())
             {
@@ -4641,18 +4645,12 @@ BackwardPass::ProcessUse(IR::Opnd * opnd)
             IR::IndirOpnd * indirOpnd = opnd->AsIndirOpnd();
             IR::RegOpnd * baseOpnd = indirOpnd->GetBaseOpnd();
 
-            if (!this->ProcessSymUse(baseOpnd->m_sym, false, baseOpnd->GetIsJITOptimizedReg()) && this->DoSetDead())
-            {
-                baseOpnd->SetIsDead();
-            }
+            this->DoSetDead(baseOpnd, !this->ProcessSymUse(baseOpnd->m_sym, false, baseOpnd->GetIsJITOptimizedReg()));
 
             IR::RegOpnd * indexOpnd = indirOpnd->GetIndexOpnd();
             if (indexOpnd)
             {
-                if (!this->ProcessSymUse(indexOpnd->m_sym, false, indexOpnd->GetIsJITOptimizedReg()) && this->DoSetDead())
-                {
-                    indexOpnd->SetIsDead();
-                }
+                this->DoSetDead(indexOpnd, !this->ProcessSymUse(indexOpnd->m_sym, false, indexOpnd->GetIsJITOptimizedReg()));
             }
 
             if(IsCollectionPass())
@@ -5996,10 +5994,8 @@ BackwardPass::ProcessDef(IR::Opnd * opnd)
             }
         }
 
-        if (!block->upwardExposedFields->TestAndClear(propertySym->m_id) && this->DoSetDead())
-        {
-            opnd->SetIsDead();
-        }
+        this->DoSetDead(opnd, !block->upwardExposedFields->TestAndClear(propertySym->m_id));
+
         ProcessStackSymUse(propertySym->m_stackSym, isJITOptimizedReg);
         if (tag == Js::BackwardPhase)
         {

--- a/lib/Backend/BackwardPass.h
+++ b/lib/Backend/BackwardPass.h
@@ -96,7 +96,7 @@ private:
     bool ProcessBailOnNoProfile(IR::Instr *instr, BasicBlock *block);
 
     bool DoByteCodeUpwardExposedUsed() const;
-    bool DoSetDead() const;
+    void DoSetDead(IR::Opnd * opnd, bool isDead) const;
     bool DoFieldHoistCandidates() const;
     bool DoFieldHoistCandidates(Loop * loop) const;
     bool DoMarkTempObjects() const;

--- a/lib/Backend/PreLowerPeeps.cpp
+++ b/lib/Backend/PreLowerPeeps.cpp
@@ -6,7 +6,7 @@
 
 IR::Instr *Lowerer::PreLowerPeepInstr(IR::Instr *instr, IR::Instr **pInstrPrev)
 {
-    if (!PHASE_OFF(Js::PreLowererPeepsPhase, this->m_func))
+    if (PHASE_OFF(Js::PreLowererPeepsPhase, this->m_func))
     {
         return instr;
     }

--- a/lib/Backend/PreLowerPeeps.cpp
+++ b/lib/Backend/PreLowerPeeps.cpp
@@ -6,7 +6,7 @@
 
 IR::Instr *Lowerer::PreLowerPeepInstr(IR::Instr *instr, IR::Instr **pInstrPrev)
 {
-    if (!PHASE_ON(Js::PreLowererPeepsPhase, this->m_func))
+    if (!PHASE_OFF(Js::PreLowererPeepsPhase, this->m_func))
     {
         return instr;
     }

--- a/test/Bugs/Bug_resetisdead.js
+++ b/test/Bugs/Bug_resetisdead.js
@@ -16,5 +16,6 @@ function test(p1, p2, p3, p4) {
 
 test(1, 20, 3, -1);
 test(5, 4, 2, -2);
+test(15, 3, -11, 4);
 
 WScript.Echo("PASSED");

--- a/test/Bugs/Bug_resetisdead.js
+++ b/test/Bugs/Bug_resetisdead.js
@@ -1,0 +1,20 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function test(p1, p2, p3, p4) {
+    var a = p1 + p3; var b = p2 + p4; if ((p1 + p2) > (p3 + p4) & a > b) {
+        return 1;
+    }
+
+    if ((p1 + p2) > (p3 + p4) | (p1 + p3) > (p2 + p4)) {
+        return 2;
+    }
+    return 3;
+}
+
+test(1, 20, 3, -1);
+test(5, 4, 2, -2);
+
+WScript.Echo("PASSED");

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -252,4 +252,10 @@
       <compile-flags>-forcedeferparse -forceundodefer</compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>bug_resetisdead.js</files>
+      <compile-flags>-mic:1 -off:simplejit -on:prelowererpeeps -bgjit-</compile-flags>
+    </default>
+  </test>
 </regress-exe>

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -255,7 +255,7 @@
   <test>
     <default>
       <files>bug_resetisdead.js</files>
-      <compile-flags>-mic:1 -off:simplejit -on:prelowererpeeps -bgjit-</compile-flags>
+      <compile-flags>-on:prelowererpeeps</compile-flags>
     </default>
   </test>
 </regress-exe>


### PR DESCRIPTION
CSE could add new reference to previous value def, thus extend its lifetime and make the previous use to be valid and not the last use. The DeadStorePhase is supposed to reset the last use information for each variable, but it assumes the variable is live and doesn't reset it if it is not dead. Miss resurrecting such variables will lead to incorrect lifetime calculated by SccLiveness and fail PrelowerPeeps optimization.