### PR TITLE
Bug with missing StatementBoundary in native span sequence

### DIFF
--- a/lib/Backend/Encoder.cpp
+++ b/lib/Backend/Encoder.cpp
@@ -170,6 +170,12 @@ Encoder::Encode()
 
                 if (instr->m_opcode == Js::OpCode::InlineeStart)
                 {
+                    Assert(!instr->isInlineeEntryInstr);
+                    if (pragmaInstr)
+                    {
+                        m_pragmaInstrToRecordMap->Add(pragmaInstr);
+                        pragmaInstr = nullptr;
+                    }
                     Func* inlinee = instr->m_func;
                     if (inlinee->frameInfo && inlinee->frameInfo->record)
                     {

--- a/test/inlining/TrimStackTracePath.js
+++ b/test/inlining/TrimStackTracePath.js
@@ -1,0 +1,8 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function TrimStackTracePath(line) {
+    return line && line.replace(/\(.+\\test.StackTrace./ig, "(");
+}

--- a/test/inlining/rlexe.xml
+++ b/test/inlining/rlexe.xml
@@ -226,4 +226,11 @@
       <baseline>builtInApplyTarget.baseline</baseline>
     </default>
   </test>
+  <test>
+    <default>
+      <files>stackTrace.js</files>
+      <compile-flags>-extendederrorstackfortesthost</compile-flags>
+      <baseline>stackTrace.baseline</baseline>
+    </default>
+  </test>
 </regress-exe>

--- a/test/inlining/stackTrace.baseline
+++ b/test/inlining/stackTrace.baseline
@@ -1,0 +1,5 @@
+ReferenceError: 'argMath5' is undefined
+	at func0 (stacktrace.js:31:7)
+	at func4 (stacktrace.js:27:5)
+	at test0 (stacktrace.js:39:3)
+	at Global code (stacktrace.js:43:3)

--- a/test/inlining/stackTrace.js
+++ b/test/inlining/stackTrace.js
@@ -1,0 +1,47 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+if (this.WScript && this.WScript.LoadScriptFile) {
+    this.WScript.LoadScriptFile("TrimStackTracePath.js");
+}
+
+function Dump(output)
+{
+  if (this.WScript)
+  {
+    WScript.Echo(output);
+  }
+  else
+  {
+    alert(output);
+  }
+}
+
+function test0() {
+  var obj0 = {};
+ 
+  var func4 = function () {
+    var a = ui8;
+    func0();
+  };
+  var func0 = function() {
+    for (; prop0 < 100; ) {
+      argMath5;
+    }
+  }
+  obj0.method1 = func4;
+  var ui8 = new Uint8Array(256);
+  prop0 = Infinity;
+  obj0.method1();
+  prop0 = -1766989739;
+  obj0.method1();
+}
+
+try {
+  test0();
+} catch(e) {
+  Dump(TrimStackTracePath(e.stack));
+}
+


### PR DESCRIPTION
When we get rid of the arguments overhead for an inlinee, we
are inadvertently missing to add the StatementBoundary for the inlinee
call to the native span sequence. If the inlinee throws, this leads to a difference in line
numbers in the stack trace between interpreter and jit.

Fixed by adding the missing StatementBoundary to the span sequence

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/463)
<!-- Reviewable:end -->
