### PR TITLE
Stack Arguments Optimization extended - With Formal's presence.

### DIFF
--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -3827,19 +3827,9 @@ GlobOpt::OptArguments(IR::Instr *instr)
         return;
     }
 
-    if (instr->m_opcode == Js::OpCode::LdHeapArguments || instr->m_opcode == Js::OpCode::LdLetHeapArguments)
+    if (instr->m_opcode == Js::OpCode::LdHeapArguments || instr->m_opcode == Js::OpCode::LdLetHeapArguments || 
+        instr->m_opcode == Js::OpCode::LdHeapArgsCached || instr->m_opcode == Js::OpCode::LdLetHeapArgsCached)
     {
-        // Stackargs optimization is designed to work with only when function doesn't have formals.
-        if (instr->m_func->GetJnFunction()->GetInParamsCount() != 1)
-        {
-#ifdef PERF_HINT
-            if (PHASE_TRACE1(Js::PerfHintPhase))
-            {
-                WritePerfHint(PerfHints::HeapArgumentsDueToFormals, instr->m_func->GetJnFunction(), instr->GetByteCodeOffset());
-            }
-#endif
-            CannotAllocateArgumentsObjectOnStack();
-        }
         TrackArgumentsSym(dst->AsRegOpnd());
         return;
     }
@@ -3891,16 +3881,16 @@ GlobOpt::OptArguments(IR::Instr *instr)
         id = baseOpnd->m_sym->m_id;
         if (IsArgumentsSymID(id, this->blockData))
         {
-            instr->usesStackArgumentsObject = true;
+            instr->usesStackArguments = true;
         }
         break;
     }
     case Js::OpCode::LdLen_A:
     {
         Assert(src1->IsRegOpnd());
-        if(IsArgumentsOpnd(src1))
+        if (IsArgumentsOpnd(src1))
         {
-            instr->usesStackArgumentsObject = true;
+            instr->usesStackArguments = true;
         }
         break;
     }

--- a/lib/Backend/IR.cpp
+++ b/lib/Backend/IR.cpp
@@ -69,7 +69,7 @@ Instr::IsPlainInstr() const
 bool
 Instr::DoStackArgsOpt(Func *topFunc) const
 {
-    return this->usesStackArgumentsObject && this->m_func->GetHasStackArgs() && topFunc->GetHasStackArgs();
+    return this->usesStackArguments && this->m_func->GetHasStackArgs() && topFunc->GetHasStackArgs();
 }
 
 bool
@@ -494,7 +494,7 @@ Instr::Copy()
     {
         instrCopy->SetByteCodeOffset(this->GetByteCodeOffset());
     }
-    instrCopy->usesStackArgumentsObject = this->usesStackArgumentsObject;
+    instrCopy->usesStackArguments = this->usesStackArguments;
     return instrCopy;
 }
 
@@ -657,7 +657,7 @@ Instr::Clone()
     {
         instrClone->SetByteCodeOffset(this->GetByteCodeOffset());
     }
-    instrClone->usesStackArgumentsObject = this->usesStackArgumentsObject;
+    instrClone->usesStackArguments = this->usesStackArguments;
     cloner->AddInstr(this, instrClone);
 
     return instrClone;
@@ -2904,7 +2904,7 @@ Instr::TransferTo(Instr * instr)
     Assert(instr->m_src1 == nullptr);
     Assert(instr->m_src2 == nullptr);
     this->TransferDstAttributesTo(instr);
-    instr->usesStackArgumentsObject = this->usesStackArgumentsObject;
+    instr->usesStackArguments = this->usesStackArguments;
     instr->isCloned = this->isCloned;
     instr->ignoreNegativeZero = this->ignoreNegativeZero;
     instr->ignoreIntOverflow = this->ignoreIntOverflow;

--- a/lib/Backend/IR.h
+++ b/lib/Backend/IR.h
@@ -137,7 +137,7 @@ protected:
         hasBailOutInfo(hasBailOutInfo),
         hasAuxBailOut(false),
         forcePreOpBailOutIfNeeded(false),
-        usesStackArgumentsObject(false),
+        usesStackArguments(false),
         isInlineeEntryInstr(false),
         ignoreNegativeZero(false),
         dstIsAlwaysConvertedToInt32(false),
@@ -465,7 +465,7 @@ public:
     bool            dstIsTempNumber : 1;
     bool            dstIsTempNumberTransferred : 1;
     bool            dstIsTempObject : 1;
-    bool            usesStackArgumentsObject: 1;
+    bool            usesStackArguments: 1;
     // An inlinee entry instruction initializes the InlineeCallInfo on the frame.
     bool            isInlineeEntryInstr: 1;
     bool            ignoreNegativeZero: 1;

--- a/lib/Backend/amd64/LowererMDArch.cpp
+++ b/lib/Backend/amd64/LowererMDArch.cpp
@@ -184,7 +184,7 @@ LowererMDArch::LoadHeapArgsCached(IR::Instr *instrArgs)
     IR::Instr *instrPrev = instrArgs->m_prev;
     
     // s8 = isStackArgOptimization
-    IR::Opnd * isStackArgOpt = IR::IntConstOpnd::New((IntConstType)(func->GetHasStackArgs() && this->m_func->GetHasStackArgs()? TRUE : FALSE), TyUint8, func);
+    IR::Opnd * isStackArgOpt = IR::IntConstOpnd::New((IntConstType)((func->GetHasStackArgs() && this->m_func->GetHasStackArgs())? TRUE : FALSE), TyUint8, func);
     this->LoadHelperArgument(instrArgs, isStackArgOpt);
 
     // s7 = formals are let decls
@@ -300,7 +300,7 @@ LowererMDArch::LoadHeapArguments(IR::Instr *instrArgs, bool force /* = false */,
         // dst = JavascriptOperators::LoadHeapArguments(s1, s2, s3, s4, s5, s6, s7)
 
         // s8 = IsStackArgsOpt
-        this->LoadHelperArgument(instrArgs, IR::IntConstOpnd::New(!force && func->GetHasStackArgs() && this->m_func->GetHasStackArgs() ? TRUE : FALSE, TyUint8, func));
+        this->LoadHelperArgument(instrArgs, IR::IntConstOpnd::New((!force && func->GetHasStackArgs() && this->m_func->GetHasStackArgs()) ? TRUE : FALSE, TyUint8, func));
 
         // s7 = formals are let decls
         this->LoadHelperArgument(instrArgs, IR::IntConstOpnd::New(instrArgs->m_opcode == Js::OpCode::LdLetHeapArguments ? TRUE : FALSE, TyUint8, func));

--- a/lib/Backend/amd64/LowererMDArch.cpp
+++ b/lib/Backend/amd64/LowererMDArch.cpp
@@ -169,6 +169,7 @@ LowererMDArch::LoadStackArgPtr(IR::Instr * instrArgPtr)
 IR::Instr *
 LowererMDArch::LoadHeapArgsCached(IR::Instr *instrArgs)
 {
+    // s8 = isStackArgOptimization
     // s7 = formals are let decls
     // s6 = memory context
     // s5 = local frame instance
@@ -181,6 +182,10 @@ LowererMDArch::LoadHeapArgsCached(IR::Instr *instrArgs)
     ASSERT_INLINEE_FUNC(instrArgs);
     Func *func = instrArgs->m_func;
     IR::Instr *instrPrev = instrArgs->m_prev;
+    
+    // s8 = isStackArgOptimization
+    IR::Opnd * isStackArgOpt = IR::IntConstOpnd::New((IntConstType)(func->GetHasStackArgs() && this->m_func->GetHasStackArgs()? TRUE : FALSE), TyUint8, func);
+    this->LoadHelperArgument(instrArgs, isStackArgOpt);
 
     // s7 = formals are let decls
     IR::Opnd * formalsAreLetDecls = IR::IntConstOpnd::New((IntConstType)(instrArgs->m_opcode == Js::OpCode::LdLetHeapArgsCached), TyUint8, func);
@@ -275,7 +280,7 @@ LowererMDArch::LoadHeapArguments(IR::Instr *instrArgs, bool force /* = false */,
     Func *func = instrArgs->m_func;
 
     IR::Instr *instrPrev = instrArgs->m_prev;
-    if (!force && func->GetHasStackArgs() && this->m_func->GetHasStackArgs())
+    if (!force && func->GetHasStackArgs() && this->m_func->GetHasStackArgs() && (instrArgs->m_func->GetJnFunction()->GetInParamsCount() == 1))
     {
         // The initial args slot value is zero. (TODO: it should be possible to dead-store the LdHeapArgs in this case.)
         instrArgs->m_opcode = Js::OpCode::MOV;
@@ -284,6 +289,7 @@ LowererMDArch::LoadHeapArguments(IR::Instr *instrArgs, bool force /* = false */,
     }
     else
     {
+        // s8 = IsStackArgsOpt
         // s7 = formals are let decls
         // s6 = memory context
         // s5 = array of property ID's
@@ -292,6 +298,9 @@ LowererMDArch::LoadHeapArguments(IR::Instr *instrArgs, bool force /* = false */,
         // s2 = actual argument count
         // s1 = current function
         // dst = JavascriptOperators::LoadHeapArguments(s1, s2, s3, s4, s5, s6, s7)
+
+        // s8 = IsStackArgsOpt
+        this->LoadHelperArgument(instrArgs, IR::IntConstOpnd::New(!force && func->GetHasStackArgs() && this->m_func->GetHasStackArgs() ? TRUE : FALSE, TyUint8, func));
 
         // s7 = formals are let decls
         this->LoadHelperArgument(instrArgs, IR::IntConstOpnd::New(instrArgs->m_opcode == Js::OpCode::LdLetHeapArguments ? TRUE : FALSE, TyUint8, func));

--- a/lib/Backend/arm/LowerMD.cpp
+++ b/lib/Backend/arm/LowerMD.cpp
@@ -2189,7 +2189,7 @@ LowererMD::LoadHeapArguments(IR::Instr * instrArgs, bool force /* = false */, IR
     else
     {
         // s8 = Stack Args Optimization
-        this->LoadHelperArgument(instrArgs, IR::IntConstOpnd::New(!force && func->GetHasStackArgs() && this->m_func->GetHasStackArgs() ? TRUE : FALSE, TyUint8, func));
+        this->LoadHelperArgument(instrArgs, IR::IntConstOpnd::New((!force && func->GetHasStackArgs() && this->m_func->GetHasStackArgs()) ? TRUE : FALSE, TyUint8, func));
 
         // s7 = formals are let decls
         this->LoadHelperArgument(instrArgs, IR::IntConstOpnd::New(instrArgs->m_opcode == Js::OpCode::LdLetHeapArguments ? TRUE : FALSE, TyUint8, func));
@@ -2282,7 +2282,7 @@ LowererMD::LoadHeapArgsCached(IR::Instr * instrArgs)
     IR::Instr * instrPrev = instrArgs->m_prev;
 
     // s8 = isStackArgOptimization
-    IR::Opnd * isStackArgOpt = IR::IntConstOpnd::New((IntConstType)(func->GetHasStackArgs() && this->m_func->GetHasStackArgs() ? TRUE : FALSE), TyUint8, func);
+    IR::Opnd * isStackArgOpt = IR::IntConstOpnd::New((IntConstType)((func->GetHasStackArgs() && this->m_func->GetHasStackArgs()) ? TRUE : FALSE), TyUint8, func);
     this->LoadHelperArgument(instrArgs, isStackArgOpt);
 
     // s7 = formals are let decls

--- a/lib/Backend/i386/LowererMDArch.cpp
+++ b/lib/Backend/i386/LowererMDArch.cpp
@@ -256,7 +256,7 @@ LowererMDArch::LoadHeapArguments(IR::Instr *instrArgs, bool force, IR::Opnd* opn
         // dst = JavascriptOperators::LoadHeapArguments(s1, s2, s3, s4, s5, s6, s7)
 
         // s8 = IsStackArgsOpt
-        this->LoadHelperArgument(instrArgs, IR::IntConstOpnd::New(!force && func->GetHasStackArgs() && this->m_func->GetHasStackArgs() ? TRUE : FALSE, TyUint8, func));
+        this->LoadHelperArgument(instrArgs, IR::IntConstOpnd::New((!force && func->GetHasStackArgs() && this->m_func->GetHasStackArgs()) ? TRUE : FALSE, TyUint8, func));
 
         // s7 = formals are let decls
         this->LoadHelperArgument(instrArgs, IR::IntConstOpnd::New(instrArgs->m_opcode == Js::OpCode::LdLetHeapArguments ? TRUE : FALSE, TyUint8, func));
@@ -377,7 +377,7 @@ LowererMDArch::LoadHeapArgsCached(IR::Instr *instrArgs)
     IR::Instr *instrPrev = instrArgs->m_prev;
 
     // s8 = isStackArgOptimization
-    IR::Opnd * isStackArgOpt = IR::IntConstOpnd::New((IntConstType)(func->GetHasStackArgs() && this->m_func->GetHasStackArgs() ? TRUE : FALSE), TyUint8, func);
+    IR::Opnd * isStackArgOpt = IR::IntConstOpnd::New((IntConstType)((func->GetHasStackArgs() && this->m_func->GetHasStackArgs()) ? TRUE : FALSE), TyUint8, func);
     this->LoadHelperArgument(instrArgs, isStackArgOpt);
 
     // s7 = formals are let decls

--- a/lib/Backend/i386/LowererMDArch.cpp
+++ b/lib/Backend/i386/LowererMDArch.cpp
@@ -234,7 +234,9 @@ LowererMDArch::LoadHeapArguments(IR::Instr *instrArgs, bool force, IR::Opnd* opn
     Func *func = instrArgs->m_func;
 
     IR::Instr * instrPrev = instrArgs->m_prev;
-    if (!force && func->GetHasStackArgs() && this->m_func->GetHasStackArgs()) //both inlinee & inliner has stack args. We don't support other scenarios.
+    //both inlinee & inliner has stack args. We don't support other scenarios.
+    //also we MOV NULL only for no-formals and arg optimization cases.
+    if (!force && func->GetHasStackArgs() && this->m_func->GetHasStackArgs() && (instrArgs->m_func->GetJnFunction()->GetInParamsCount() == 1)) 
     {
         // The initial args slot value is zero. (TODO: it should be possible to dead-store the LdHeapArgs in this case.)
         instrArgs->m_opcode = Js::OpCode::MOV;
@@ -243,6 +245,7 @@ LowererMDArch::LoadHeapArguments(IR::Instr *instrArgs, bool force, IR::Opnd* opn
     }
     else
     {
+        // s8 = Stack Args Optimization
         // s7 = formals are let decls
         // s6 = memory context
         // s5 = array of property ID's
@@ -251,6 +254,9 @@ LowererMDArch::LoadHeapArguments(IR::Instr *instrArgs, bool force, IR::Opnd* opn
         // s2 = actual argument count
         // s1 = current function
         // dst = JavascriptOperators::LoadHeapArguments(s1, s2, s3, s4, s5, s6, s7)
+
+        // s8 = IsStackArgsOpt
+        this->LoadHelperArgument(instrArgs, IR::IntConstOpnd::New(!force && func->GetHasStackArgs() && this->m_func->GetHasStackArgs() ? TRUE : FALSE, TyUint8, func));
 
         // s7 = formals are let decls
         this->LoadHelperArgument(instrArgs, IR::IntConstOpnd::New(instrArgs->m_opcode == Js::OpCode::LdLetHeapArguments ? TRUE : FALSE, TyUint8, func));
@@ -356,6 +362,7 @@ LowererMDArch::LoadHeapArguments(IR::Instr *instrArgs, bool force, IR::Opnd* opn
 IR::Instr *
 LowererMDArch::LoadHeapArgsCached(IR::Instr *instrArgs)
 {
+    // s8 = isStackArgOptimization
     // s7 = formals are let decls
     // s6 = memory context
     // s5 = local frame instance
@@ -368,6 +375,10 @@ LowererMDArch::LoadHeapArgsCached(IR::Instr *instrArgs)
     ASSERT_INLINEE_FUNC(instrArgs);
     Func *func = instrArgs->m_func;
     IR::Instr *instrPrev = instrArgs->m_prev;
+
+    // s8 = isStackArgOptimization
+    IR::Opnd * isStackArgOpt = IR::IntConstOpnd::New((IntConstType)(func->GetHasStackArgs() && this->m_func->GetHasStackArgs() ? TRUE : FALSE), TyUint8, func);
+    this->LoadHelperArgument(instrArgs, isStackArgOpt);
 
     // s7 = formals are let decls
     IR::Opnd * formalsAreLetDecls = IR::IntConstOpnd::New((IntConstType)(instrArgs->m_opcode == Js::OpCode::LdLetHeapArgsCached), TyUint8, func);

--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -685,6 +685,7 @@ void Parser::InitNode(OpCode nop,ParseNodePtr pnode) {
     pnode->notEscapedUse = false;
     pnode->isInList = false;
     pnode->isCallApplyTargetLoad = false;
+    pnode->isArgElemOrArgLenLoad = false;
 }
 
 // Create nodes using Arena
@@ -8252,11 +8253,11 @@ ParseNodePtr Parser::ParseExpr(int oplMin,
             if (nodeType & fnopBin)
             {
                 ParseNodePtr lhs = pnode->sxBin.pnode1;
-
                 Assert(lhs);
+
                 if (lhs->nop == knopDot)
                 {
-                    ParseNodePtr propertyNode = lhs->sxBin.pnode2;                    
+                    ParseNodePtr propertyNode = lhs->sxBin.pnode2;
                     if (propertyNode->nop == knopName)
                     {
                         propertyNode->sxPid.pid->PromoteAssignmentState();

--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -1744,6 +1744,10 @@ void Parser::BindPidRefsInScopeImpl(IdentPtr pid, Symbol *sym, int blockId, uint
 
         if (ref->IsAssignment())
         {
+            if (m_currentNodeFunc && sym->GetIsFormal())
+            {
+                m_currentNodeFunc->sxFnc.SetHasAnyWriteToFormals(true);
+            }
             sym->PromoteAssignmentState();
         }
 
@@ -8252,7 +8256,7 @@ ParseNodePtr Parser::ParseExpr(int oplMin,
                 Assert(lhs);
                 if (lhs->nop == knopDot)
                 {
-                    ParseNodePtr propertyNode = lhs->sxBin.pnode2;
+                    ParseNodePtr propertyNode = lhs->sxBin.pnode2;                    
                     if (propertyNode->nop == knopName)
                     {
                         propertyNode->sxPid.pid->PromoteAssignmentState();
@@ -8547,6 +8551,10 @@ ParseNodePtr Parser::ParseVariableDeclaration(
                 if (pnodeThis && pnodeThis->sxVar.pnodeInit != nullptr)
                 {
                     pnodeThis->sxVar.sym->PromoteAssignmentState();
+                    if (m_currentNodeFunc && pnodeThis->sxVar.sym->GetIsFormal())
+                    {
+                        m_currentNodeFunc->sxFnc.SetHasAnyWriteToFormals(true);
+                    }
                 }
             }
             else if (declarationType == tkCONST /*pnodeThis->nop == knopConstDecl*/

--- a/lib/Parser/ptree.h
+++ b/lib/Parser/ptree.h
@@ -579,6 +579,7 @@ struct ParseNode
     bool notEscapedUse;         // Use by byte code generator.  Currently, only used by child of knopComma
     bool isInList;
     bool isCallApplyTargetLoad;
+    bool isArgElemOrArgLenLoad; // Use by byte code generator. Set to true if arguments[i] or arguments.length, false otherwise
 #ifdef EDIT_AND_CONTINUE
     ParseNodePtr parent;
 #endif
@@ -688,6 +689,10 @@ struct ParseNode
 
     bool IsCallApplyTargetLoad() { return isCallApplyTargetLoad; }
     void SetIsCallApplyTargetLoad() { isCallApplyTargetLoad = true; }
+
+    bool IsArgElemOrArgLenLoad() { return isArgElemOrArgLenLoad; }
+    void SetIsArgElemOrArgLenLoad() { isArgElemOrArgLenLoad = true; }
+
     bool IsVarLetOrConst() const
     {
         return this->nop == knopVarDecl || this->nop == knopLetDecl || this->nop == knopConstDecl;

--- a/lib/Parser/ptree.h
+++ b/lib/Parser/ptree.h
@@ -202,6 +202,7 @@ enum FncFlags
     kFunctionHasNewTargetReference              = 1 << 27, // function has a reference to new.target
     kFunctionIsAsync                            = 1 << 28, // function is async
     kFunctionHasDirectSuper                     = 1 << 29, // super()
+    kFunctionHasAnyWriteToFormals               = 1 << 30, // function has writes to formal parameters.
 };
 
 struct RestorePoint;
@@ -277,6 +278,7 @@ public:
     void SetDoesNotEscape(bool set = true) { SetFlags(kFunctionDoesNotEscape, set); }
     void SetHasDefaultArguments(bool set = true) { SetFlags(kFunctionHasDefaultArguments, set); }
     void SetHasHeapArguments(bool set = true) { SetFlags(kFunctionHasHeapArguments, set); }
+    void SetHasAnyWriteToFormals(bool set = true) { SetFlags(kFunctionHasAnyWriteToFormals, set); }
     void SetHasNonSimpleParameterList(bool set = true) { SetFlags(kFunctionHasNonSimpleParameterList, set); }
     void SetHasNonThisStmt(bool set = true) { SetFlags(kFunctionHasNonThisStmt, set); }
     void SetHasReferenceableBuiltInArguments(bool set = true) { SetFlags(kFunctionHasReferenceableBuiltInArguments, set); }
@@ -308,6 +310,7 @@ public:
     bool GetAsmjsMode() const { return HasFlags(kFunctionAsmjsMode); }
     bool GetStrictMode() const { return HasFlags(kFunctionStrictMode); }
     bool HasDefaultArguments() const { return HasFlags(kFunctionHasDefaultArguments); }
+    bool HasAnyWriteToFormals() const {return HasFlags(kFunctionHasAnyWriteToFormals); }
     bool HasHeapArguments() const { return true; /* HasFlags(kFunctionHasHeapArguments); Disabling stack arguments. Always return HeapArguments as True */ }
     bool HasOnlyThisStmts() const { return !HasFlags(kFunctionHasNonThisStmt); }
     bool HasReferenceableBuiltInArguments() const { return HasFlags(kFunctionHasReferenceableBuiltInArguments); }

--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -3683,7 +3683,7 @@ void ByteCodeGenerator::StartEmitFunction(ParseNode *pnodeFnc)
 
     Scope * const bodyScope = funcInfo->GetBodyScope();
     Scope * const paramScope = funcInfo->GetParamScope();
-
+    
     if (pnodeFnc->nop != knopProg)
     {
         if (!bodyScope->GetIsObject() && NeedObjectAsFunctionScope(funcInfo, pnodeFnc))

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -1900,7 +1900,7 @@ void ByteCodeGenerator::Generate(__in ParseNode *pnode, ulong grfscr, __in ByteC
     byteCodeGenerator->Begin(&localAlloc, grfscr, *ppRootFunc);
     byteCodeGenerator->functionRef = functionRef;
     Visit(pnode, byteCodeGenerator, Bind, AssignRegisters);
-
+ 
     byteCodeGenerator->forceNoNative = forceNoNative;
     byteCodeGenerator->EmitProgram(pnode);
 
@@ -2417,7 +2417,9 @@ FuncInfo* PreVisitFunction(ParseNode* pnode, ByteCodeGenerator* byteCodeGenerato
             funcInfo->SetHasArguments(true);
             if (pnode->sxFnc.HasHeapArguments())
             {
-                funcInfo->SetHasHeapArguments(true, !pnode->sxFnc.IsGenerator() && !pnode->sxFnc.HasAnyWriteToFormals() /*= Optimize arguments in backend*/);
+                bool doStackArgsOpt = !pnode->sxFnc.HasAnyWriteToFormals();
+
+                funcInfo->SetHasHeapArguments(true, !pnode->sxFnc.IsGenerator() && doStackArgsOpt /*= Optimize arguments in backend*/);
                 if (funcInfo->inArgsCount == 0)
                 {
                     // If no formals to function, no need to create the propertyid array
@@ -4023,13 +4025,82 @@ void SetAdditionalBindInfoForVariables(ParseNode *pnode, ByteCodeGenerator *byte
     }
 }
 
+bool IsArgsObjElementOrLen(ParseNodePtr pnode, ByteCodeGenerator * byteCodeGenerator)
+{
+    switch (pnode->nop)
+    {
+    /*arguments.length*/
+    case knopDot:
+    {
+        return (pnode->sxBin.pnode1->nop == knopName && pnode->sxBin.pnode1->sxPid.pid == byteCodeGenerator->GetParser()->GetArgumentsPid() &&
+            pnode->sxBin.pnode2->nop == knopName && wcscmp(pnode->sxBin.pnode2->sxPid.pid->Psz(), L"length") == 0);
+    }
+    /*arguments[<expr>]*/
+    case knopIndex:
+    {
+        return (pnode->sxBin.pnode1->nop == knopName && pnode->sxBin.pnode1->sxPid.pid == byteCodeGenerator->GetParser()->GetArgumentsPid());
+    }
+    }
+    return false;
+}
+
+void TrackLdElemOrLdLenOfArgumentsObject(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator)
+{
+    if (pnode == nullptr || 
+        !byteCodeGenerator->TopFuncInfo() || 
+        !byteCodeGenerator->TopFuncInfo()->byteCodeFunction->IsFunctionParsed() /*we don't care if the function is deferred*/||
+        byteCodeGenerator->TopFuncInfo()->inArgsCount == 1 /*no formals*/ ||
+        !byteCodeGenerator->TopFuncInfo()->byteCodeFunction->GetDoBackendArgumentsOptimization() /*ArgsOpt already switched off*/)
+    {
+        return;
+    }
+    
+    OpCode nop = pnode->nop;
+    uint nodeType = ParseNode::Grfnop(pnode->nop);
+
+    //To Track =, +=, ++
+    if (nodeType & fnopAsg)
+    {
+        ParseNodePtr pnode1 = nullptr;
+        if (nodeType & fnopBin)
+        {
+            pnode1 = pnode->sxBin.pnode1;
+        }
+        else if (nodeType & fnopUni)
+        {
+            pnode1 = pnode->sxUni.pnode1;
+        }
+
+        //Stores to arguments[i] or arguments.length - Disable the optimization
+        if (IsArgsObjElementOrLen(pnode1, byteCodeGenerator))
+        {
+            byteCodeGenerator->TopFuncInfo()->byteCodeFunction->SetDoBackendArgumentsOptimization(false);
+            return;
+        }
+    }
+    //Unmarked arguments object means that it is a reads of arguments object itself
+    //Handle var arguments =
+    else if ((nop == knopName && pnode->sxPid.pid == byteCodeGenerator->GetParser()->GetArgumentsPid() && !pnode->IsArgElemOrArgLenLoad()) ||
+        (nop == knopVarDecl && pnode->sxVar.pid == byteCodeGenerator->GetParser()->GetArgumentsPid()))
+    {
+        byteCodeGenerator->TopFuncInfo()->byteCodeFunction->SetDoBackendArgumentsOptimization(false);
+    }
+    else if(IsArgsObjElementOrLen(pnode, byteCodeGenerator))
+    {
+        //Mark the arguments node, if it is a Load of arguments[i] or arguments.length
+        pnode->sxBin.pnode1->SetIsArgElemOrArgLenLoad();
+    }
+}
+
 // bind references to definitions (prefix pass)
 void Bind(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator)
 {
     if (pnode == nullptr)
-{
+    {
         return;
     }
+
+    TrackLdElemOrLdLenOfArgumentsObject(pnode, byteCodeGenerator);
 
     switch (pnode->nop)
     {
@@ -4469,7 +4540,6 @@ inline bool ContainsDirectSuper(ParseNodePtr pnode)
     return pnode->sxCall.pnodeTarget->nop == knopSuper; // super()
 }
 
-
 // Assign permanent (non-temp) registers for the function.
 // These include constants (null, 3.7, this) and locals that use registers as their home locations.
 // Assign the location fields of parse nodes whose values are constants/locals with permanent/known registers.
@@ -4522,7 +4592,7 @@ void AssignRegisters(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator)
 
     case knopAsg:
         {
-        Symbol * sym = pnode->sxBin.pnode1->nop == knopName ? pnode->sxBin.pnode1->sxPid.sym : nullptr;
+            Symbol * sym = pnode->sxBin.pnode1->nop == knopName ? pnode->sxBin.pnode1->sxPid.sym : nullptr;
             CheckFuncAssignment(sym, pnode->sxBin.pnode2, byteCodeGenerator);
 
             if (pnode->IsInList())
@@ -4539,9 +4609,8 @@ void AssignRegisters(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator)
                 // Any rest parameter in a destructured array will need a 0 constant.
                 byteCodeGenerator->EnregisterConstant(0);
             }
-
         break;
-    }
+        }
 
     case knopEllipsis:
         if (byteCodeGenerator->InDestructuredPattern())

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -2417,7 +2417,7 @@ FuncInfo* PreVisitFunction(ParseNode* pnode, ByteCodeGenerator* byteCodeGenerato
             funcInfo->SetHasArguments(true);
             if (pnode->sxFnc.HasHeapArguments())
             {
-                funcInfo->SetHasHeapArguments(true, !pnode->sxFnc.IsGenerator() /*= Optimize arguments in backend*/);
+                funcInfo->SetHasHeapArguments(true, !pnode->sxFnc.IsGenerator() && !pnode->sxFnc.HasAnyWriteToFormals() /*= Optimize arguments in backend*/);
                 if (funcInfo->inArgsCount == 0)
                 {
                     // If no formals to function, no need to create the propertyid array

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -6419,8 +6419,7 @@ CommonNumber:
         DynamicObject* frameObject,
         Js::PropertyIdArray *propIds,
         uint32 formalsCount,
-        ScriptContext* scriptContext,
-        bool isStackArgs)
+        ScriptContext* scriptContext)
     {
         Var *paramIter = paramAddr;
         uint32 i = 0;
@@ -6488,7 +6487,7 @@ CommonNumber:
 
             if (nonSimpleParamList)
             {
-                return ConvertToUnmappedArguments(argsObj, paramCount, paramAddr, frameObject, propIds, formalsCount, scriptContext, isStackArgsOpt);
+                return ConvertToUnmappedArguments(argsObj, paramCount, paramAddr, frameObject, propIds, formalsCount, scriptContext);
             }
 
             for (i = 0; i < formalsCount && i < paramCount; i++, tmpAddr++)
@@ -6555,7 +6554,7 @@ CommonNumber:
 
             if (nonSimpleParamList)
             {
-                return ConvertToUnmappedArguments(argsObj, actualsCount, paramAddr, frameObject, nullptr /*propIds*/, formalsCount, scriptContext, isStackArgOpt);
+                return ConvertToUnmappedArguments(argsObj, actualsCount, paramAddr, frameObject, nullptr /*propIds*/, formalsCount, scriptContext);
             }
 
             for (i = 0; i < formalsCount && i < actualsCount; i++, tmpAddr++)

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -6419,17 +6419,21 @@ CommonNumber:
         DynamicObject* frameObject,
         Js::PropertyIdArray *propIds,
         uint32 formalsCount,
-        ScriptContext* scriptContext)
+        ScriptContext* scriptContext,
+        bool isStackArgs)
     {
         Var *paramIter = paramAddr;
         uint32 i = 0;
 
-        for (paramIter = paramAddr + i; i < paramCount; i++, paramIter++)
+        if (argumentsObject)
         {
-            JavascriptOperators::SetItem(argumentsObject, argumentsObject, i, *paramIter, scriptContext, PropertyOperation_None, /* skipPrototypeCheck = */ TRUE);
-        }
+            for (paramIter = paramAddr + i; i < paramCount; i++, paramIter++)
+            {
+                JavascriptOperators::SetItem(argumentsObject, argumentsObject, i, *paramIter, scriptContext, PropertyOperation_None, /* skipPrototypeCheck = */ TRUE);
+            }
 
-        argumentsObject = argumentsObject->ConvertToUnmappedArgumentsObject();
+            argumentsObject = argumentsObject->ConvertToUnmappedArgumentsObject();
+        }
 
         // Now as the unmapping is done we need to fill those frame object with Undecl
         for (i = 0; i < formalsCount; i++)
@@ -6440,7 +6444,7 @@ CommonNumber:
         return argumentsObject;
     }
 
-    Var JavascriptOperators::LoadHeapArguments(JavascriptFunction *funcCallee, uint32 paramCount, Var *paramAddr, Var frameObj, Var vArray, ScriptContext* scriptContext, bool nonSimpleParamList)
+    Var JavascriptOperators::LoadHeapArguments(JavascriptFunction *funcCallee, uint32 paramCount, Var *paramAddr, Var frameObj, Var vArray, ScriptContext* scriptContext, bool nonSimpleParamList, bool isStackArgsOpt)
     {
         AssertMsg(paramCount != (unsigned int)-1, "Loading the arguments object in the global function?");
 
@@ -6454,7 +6458,11 @@ CommonNumber:
             formalsCount = propIds->count;
         }
 
-        HeapArgumentsObject *argsObj = JavascriptOperators::CreateHeapArguments(funcCallee, paramCount, formalsCount, frameObj, scriptContext);
+        HeapArgumentsObject *argsObj = nullptr;
+        if (!isStackArgsOpt)
+        {
+            argsObj = JavascriptOperators::CreateHeapArguments(funcCallee, paramCount, formalsCount, frameObj, scriptContext);
+        }
 
         // Transfer formal arguments (that were actually passed) from their ArgIn slots to the local frame object.
         uint32 i;
@@ -6480,7 +6488,7 @@ CommonNumber:
 
             if (nonSimpleParamList)
             {
-                return ConvertToUnmappedArguments(argsObj, paramCount, paramAddr, frameObject, propIds, formalsCount, scriptContext);
+                return ConvertToUnmappedArguments(argsObj, paramCount, paramAddr, frameObject, propIds, formalsCount, scriptContext, isStackArgsOpt);
             }
 
             for (i = 0; i < formalsCount && i < paramCount; i++, tmpAddr++)
@@ -6499,33 +6507,41 @@ CommonNumber:
             }
         }
 
-        // Transfer the unnamed actual arguments, if any, to the Arguments object itself.
-        for (i = formalsCount, tmpAddr = paramAddr + i; i < paramCount; i++, tmpAddr++)
+        if (!isStackArgsOpt)
         {
-            // ES5 10.6.11: use [[DefineOwnProperty]] semantics (instead of [[Put]]):
-            // do not check whether property is non-writable/etc in the prototype.
-            // ES3 semantics is same.
-            JavascriptOperators::SetItem(argsObj, argsObj, i, *tmpAddr, scriptContext, PropertyOperation_None, /* skipPrototypeCheck = */ TRUE);
-        }
+            Assert(argsObj);
+            // Transfer the unnamed actual arguments, if any, to the Arguments object itself.
+            for (i = formalsCount, tmpAddr = paramAddr + i; i < paramCount; i++, tmpAddr++)
+            {
+                // ES5 10.6.11: use [[DefineOwnProperty]] semantics (instead of [[Put]]):
+                // do not check whether property is non-writable/etc in the prototype.
+                // ES3 semantics is same.
+                JavascriptOperators::SetItem(argsObj, argsObj, i, *tmpAddr, scriptContext, PropertyOperation_None, /* skipPrototypeCheck = */ TRUE);
+            }
 
-        if (funcCallee->IsStrictMode())
-        {
-            // If the formals are let decls, then we just overwrote the frame object slots with
-            // Undecl sentinels, and we can use the original arguments that were passed to the HeapArgumentsObject.
-            return argsObj->ConvertToUnmappedArgumentsObject(!nonSimpleParamList);
+            if (funcCallee->IsStrictMode())
+            {
+                // If the formals are let decls, then we just overwrote the frame object slots with
+                // Undecl sentinels, and we can use the original arguments that were passed to the HeapArgumentsObject.
+                return argsObj->ConvertToUnmappedArgumentsObject(!nonSimpleParamList);
+            }
         }
 
         return argsObj;
     }
 
-    Var JavascriptOperators::LoadHeapArgsCached(JavascriptFunction *funcCallee, uint32 actualsCount, uint32 formalsCount, Var *paramAddr, Var frameObj, ScriptContext* scriptContext, bool nonSimpleParamList)
+    Var JavascriptOperators::LoadHeapArgsCached(JavascriptFunction *funcCallee, uint32 actualsCount, uint32 formalsCount, Var *paramAddr, Var frameObj, ScriptContext* scriptContext, bool nonSimpleParamList, bool isStackArgOpt)
     {
         // Disregard the "this" param.
         AssertMsg(actualsCount != (uint32)-1 && formalsCount != (uint32)-1,
                   "Loading the arguments object in the global function?");
 
         // Create and initialize the Arguments object.
-        HeapArgumentsObject *argsObj = JavascriptOperators::CreateHeapArguments(funcCallee, actualsCount, formalsCount, frameObj, scriptContext);
+        HeapArgumentsObject *argsObj = nullptr;
+        if (!isStackArgOpt)
+        {
+            argsObj = JavascriptOperators::CreateHeapArguments(funcCallee, actualsCount, formalsCount, frameObj, scriptContext);
+        }
 
         // Transfer formal arguments (that were actually passed) from their ArgIn slots to the local frame object.
         uint32 i;
@@ -6539,7 +6555,7 @@ CommonNumber:
 
             if (nonSimpleParamList)
             {
-                return ConvertToUnmappedArguments(argsObj, actualsCount, paramAddr, frameObject, nullptr /*propIds*/, formalsCount, scriptContext);
+                return ConvertToUnmappedArguments(argsObj, actualsCount, paramAddr, frameObject, nullptr /*propIds*/, formalsCount, scriptContext, isStackArgOpt);
             }
 
             for (i = 0; i < formalsCount && i < actualsCount; i++, tmpAddr++)
@@ -6560,20 +6576,24 @@ CommonNumber:
             }
         }
 
-        // Transfer the unnamed actual arguments, if any, to the Arguments object itself.
-        for (i = formalsCount, tmpAddr = paramAddr + i; i < actualsCount; i++, tmpAddr++)
+        if (!isStackArgOpt)
         {
-            // ES5 10.6.11: use [[DefineOwnProperty]] semantics (instead of [[Put]]):
-            // do not check whether property is non-writable/etc in the prototype.
-            // ES3 semantics is same.
-            JavascriptOperators::SetItem(argsObj, argsObj, i, *tmpAddr, scriptContext, PropertyOperation_None, /* skipPrototypeCheck = */ TRUE);
-        }
+            Assert(argsObj);
+            // Transfer the unnamed actual arguments, if any, to the Arguments object itself.
+            for (i = formalsCount, tmpAddr = paramAddr + i; i < actualsCount; i++, tmpAddr++)
+            {
+                // ES5 10.6.11: use [[DefineOwnProperty]] semantics (instead of [[Put]]):
+                // do not check whether property is non-writable/etc in the prototype.
+                // ES3 semantics is same.
+                JavascriptOperators::SetItem(argsObj, argsObj, i, *tmpAddr, scriptContext, PropertyOperation_None, /* skipPrototypeCheck = */ TRUE);
+            }
 
-        if (funcCallee->IsStrictMode())
-        {
-            // If the formals are let decls, then we just overwrote the frame object slots with
-            // Undecl sentinels, and we can use the original arguments that were passed to the HeapArgumentsObject.
-            return argsObj->ConvertToUnmappedArgumentsObject(!nonSimpleParamList);
+            if (funcCallee->IsStrictMode())
+            {
+                // If the formals are let decls, then we just overwrote the frame object slots with
+                // Undecl sentinels, and we can use the original arguments that were passed to the HeapArgumentsObject.
+                return argsObj->ConvertToUnmappedArgumentsObject(!nonSimpleParamList);
+            }
         }
 
         return argsObj;

--- a/lib/Runtime/Language/JavascriptOperators.h
+++ b/lib/Runtime/Language/JavascriptOperators.h
@@ -404,7 +404,7 @@ namespace Js
 
         static void TraceUseConstructorCache(const ConstructorCache* ctorCache, const JavascriptFunction* ctor, bool isHit);
         static void TraceUpdateConstructorCache(const ConstructorCache* ctorCache, const FunctionBody* ctorBody, bool updated, const wchar_t* reason);
-        static Var ConvertToUnmappedArguments(HeapArgumentsObject *argumentsObject, uint32 paramCount, Var *paramAddr, DynamicObject* frameObject, Js::PropertyIdArray *propIds, uint32 formalsCount, ScriptContext* scriptContext, bool isStackArgs);
+        static Var ConvertToUnmappedArguments(HeapArgumentsObject *argumentsObject, uint32 paramCount, Var *paramAddr, DynamicObject* frameObject, Js::PropertyIdArray *propIds, uint32 formalsCount, ScriptContext* scriptContext);
 
         static Js::GlobalObject * OP_LdRoot(ScriptContext* scriptContext);
         static Js::ModuleRoot * GetModuleRoot(int moduleID, ScriptContext* scriptContext);

--- a/lib/Runtime/Language/JavascriptOperators.h
+++ b/lib/Runtime/Language/JavascriptOperators.h
@@ -404,7 +404,7 @@ namespace Js
 
         static void TraceUseConstructorCache(const ConstructorCache* ctorCache, const JavascriptFunction* ctor, bool isHit);
         static void TraceUpdateConstructorCache(const ConstructorCache* ctorCache, const FunctionBody* ctorBody, bool updated, const wchar_t* reason);
-        static Var ConvertToUnmappedArguments(HeapArgumentsObject *argumentsObject, uint32 paramCount, Var *paramAddr, DynamicObject* frameObject, Js::PropertyIdArray *propIds, uint32 formalsCount, ScriptContext* scriptContext);
+        static Var ConvertToUnmappedArguments(HeapArgumentsObject *argumentsObject, uint32 paramCount, Var *paramAddr, DynamicObject* frameObject, Js::PropertyIdArray *propIds, uint32 formalsCount, ScriptContext* scriptContext, bool isStackArgs);
 
         static Js::GlobalObject * OP_LdRoot(ScriptContext* scriptContext);
         static Js::ModuleRoot * GetModuleRoot(int moduleID, ScriptContext* scriptContext);
@@ -423,8 +423,8 @@ namespace Js
         static FrameDisplay* OP_LdStrictInnerFrameDisplay(void *argHead, void *argEnv, ScriptContext* scriptContext);
         static FrameDisplay* OP_LdStrictInnerFrameDisplayNoParent(void *argHead, ScriptContext* scriptContext);
         static void CheckInnerFrameDisplayArgument(void *argHead);
-        static Var LoadHeapArguments(JavascriptFunction *funcCallee, unsigned int count, Var *pParams, Var frameObj, Var vArray, ScriptContext* scriptContext, bool nonSimpleParamList);
-        static Var LoadHeapArgsCached(JavascriptFunction *funcCallee, uint32 actualsCount, uint32 formalsCount, Var *pParams, Var frameObj, ScriptContext* scriptContext, bool nonSimpleParamList);
+        static Var LoadHeapArguments(JavascriptFunction *funcCallee, unsigned int count, Var *pParams, Var frameObj, Var vArray, ScriptContext* scriptContext, bool nonSimpleParamList, bool isStackArgsOpt = false);
+        static Var LoadHeapArgsCached(JavascriptFunction *funcCallee, uint32 actualsCount, uint32 formalsCount, Var *pParams, Var frameObj, ScriptContext* scriptContext, bool nonSimpleParamList, bool isStackArgOpt = false);
         static HeapArgumentsObject *CreateHeapArguments(JavascriptFunction *funcCallee, uint32 actualsCount, uint32 formalsCount, Var frameObj, ScriptContext* scriptContext);
         static Var OP_InitCachedScope(Var varFunc, const PropertyIdArray *propIds, DynamicType ** literalType, bool formalsAreLetDecls, ScriptContext *scriptContext);
         static void OP_InvalidateCachedScope(Var varEnv, int32 envIndex);

--- a/test/PerfHint/arguments1.baseline
+++ b/test/PerfHint/arguments1.baseline
@@ -1,8 +1,3 @@
-PerfHint: Not optimized : Arguments object not optimized {
-      Function : arguments_test1 [arguments1.js @ 17, 5]
-  Consequences : Slower lookups, high overhead in the JIT code
-    Suggestion : Check the usage of arguments in the function
-}
 PerfHint: Not optimized : Modification to arguments {
       Function : arguments_test2 [arguments1.js @ 26, 5]
   Consequences : Slower lookups, high overhead in the JIT code

--- a/test/PerfHint/arguments1.baseline
+++ b/test/PerfHint/arguments1.baseline
@@ -1,7 +1,7 @@
-PerfHint: Not optimized : Arguments object not optimized due to formals {
+PerfHint: Not optimized : Arguments object not optimized {
       Function : arguments_test1 [arguments1.js @ 17, 5]
-  Consequences : Slower lookups, affects inlining, high overhead in the JIT code
-    Suggestion : Check the usage of formals in the function
+  Consequences : Slower lookups, high overhead in the JIT code
+    Suggestion : Check the usage of arguments in the function
 }
 PerfHint: Not optimized : Modification to arguments {
       Function : arguments_test2 [arguments1.js @ 26, 5]


### PR DESCRIPTION
Issue:

We optimize arguments object elements read by reading the values directly from the stack slot instead of creating a heap arguments object(as done in general case).
But this optimization works only in the absence of formals. We have few hot functions in node as reported by Kunal, that has arguments object and formals.

Fix:
This change extends the stack arguments optimization even when formals are
present. But we give up when there are writes to formals, as mapping will
be wrong.
Also, formals' accesses are still from the Activation object and hence is not optimized for this iteration and is the next workitem.

Test:
Exprgen looks fine. I have started other runs.

Perf:
Console perf runs look fine.
