### PR TITLE
Don't allocate new strings when re-casing a string which didn't need it

### DIFF
--- a/lib/Runtime/Library/JavascriptString.cpp
+++ b/lib/Runtime/Library/JavascriptString.cpp
@@ -2204,8 +2204,55 @@ case_2:
     {
         charcount_t count = pThis->GetLength();
 
+        const char16* inStr = pThis->GetString();
+        const char16* inStrLim = inStr + count;
+        const char16* i = inStr;
+
+        // Try to find out the chars that do not need casing (in the ASCII range)
+        if (toCase == ToUpper)
+        {
+            while (i < inStrLim)
+            {
+
+                // first range of ascii lower-case (97-122)
+                // second range of ascii lower-case (223-255)
+                // non-ascii chars (255+)
+                if ('a' <= *i)
+                {
+                    if (*i <= 'z') { break; }
+                    if ('ß' <= *i) { break; }
+                }
+
+                i++;
+            }
+        } else {
+            Assert(toCase == ToLower);
+            while (i < inStrLim)
+            {
+
+                // first range of ascii uppercase (65-90)
+                // second range of ascii uppercase (192-222)
+                // non-ascii chars (255+)
+                if ('A' <= *i)
+                {
+                    if (*i <= 'Z') { break; }
+                    if ('À' <= *i)
+                    { 
+                        if (*i < 'ß') { break; }
+                        if ('ÿ' < *i) { break; }
+                    }
+                }
+
+                i++;
+            }
+        }
+
+        // If no char needs casing, return immediately
+        if (i == inStrLim) return pThis;
+
+        // Otherwise, copy the string and start casing
+        charcount_t countToCase = (charcount_t)(inStrLim - i);
         BufferStringBuilder builder(count, pThis->type->GetScriptContext());
-        const char16 *inStr = pThis->GetString();
         char16 *outStr = builder.DangerousGetWritableBuffer();
 
         char16* outStrLim = outStr + count;
@@ -2222,9 +2269,9 @@ case_2:
             DWORD converted =
 #endif
                 PlatformAgnostic::UnicodeText::ChangeStringCaseInPlace(
-                    PlatformAgnostic::UnicodeText::CaseFlags::CaseFlagsUpper, outStr, count);
+                    PlatformAgnostic::UnicodeText::CaseFlags::CaseFlagsUpper, outStrLim - countToCase, countToCase);
 
-            Assert(converted == count);
+            Assert(converted == countToCase);
         }
         else
         {
@@ -2233,9 +2280,9 @@ case_2:
             DWORD converted =
 #endif
                 PlatformAgnostic::UnicodeText::ChangeStringCaseInPlace(
-                    PlatformAgnostic::UnicodeText::CaseFlags::CaseFlagsLower, outStr, count);
+                    PlatformAgnostic::UnicodeText::CaseFlags::CaseFlagsLower, outStrLim - countToCase, countToCase);
 
-            Assert(converted == count);
+            Assert(converted == countToCase);
         }
 
         return builder.ToString();

--- a/lib/Runtime/Library/JavascriptString.cpp
+++ b/lib/Runtime/Library/JavascriptString.cpp
@@ -2213,42 +2213,40 @@ case_2:
         {
             while (i < inStrLim)
             {
-
                 // first range of ascii lower-case (97-122)
                 // second range of ascii lower-case (223-255)
                 // non-ascii chars (255+)
-                if ('a' <= *i)
+                if (*i >= 'a')
                 {
                     if (*i <= 'z') { break; }
-                    if ('ß' <= *i) { break; }
+                    if (*i >= 'ß') { break; }
                 }
-
                 i++;
             }
-        } else {
+        }
+        else
+        {
             Assert(toCase == ToLower);
             while (i < inStrLim)
             {
-
                 // first range of ascii uppercase (65-90)
                 // second range of ascii uppercase (192-222)
                 // non-ascii chars (255+)
-                if ('A' <= *i)
+                if (*i >= 'A')
                 {
                     if (*i <= 'Z') { break; }
-                    if ('À' <= *i)
+                    if (*i >= 'À')
                     { 
                         if (*i < 'ß') { break; }
-                        if ('ÿ' < *i) { break; }
+                        if (*i >= 'ÿ') { break; }
                     }
                 }
-
                 i++;
             }
         }
 
         // If no char needs casing, return immediately
-        if (i == inStrLim) return pThis;
+        if (i == inStrLim) { return pThis; }
 
         // Otherwise, copy the string and start casing
         charcount_t countToCase = (charcount_t)(inStrLim - i);


### PR DESCRIPTION
As I noticed a while ago, calling ```toLowerCase``` or ```toUpperCase``` always allocates a new string, even if the initial string does not require any change. This results in increased GC pressure, and possibly other time being lost for instance when doing ```if(x==x.toLowerCase())``` which can be performed without string comparison in valid cases if you return ```x``` as a result of ```toLowerCase``` when possible.

We discussed this already in pull request #338 but I wanted to start fresh now that I have a better idea of what I am doing. Concerns are that this increase code complexity for small gains only. I tried to assess this on my own, but I lack a general-purpose String benchmark to validate entirely.

That being said, I performed three tests on both versions:
- Calling both ToLowerCase and ToUpperCase on a Wikipedia text (mostly lower case)
- Calling ToLowerCase on a Wikipedia text (mostly lower case)
- Calling ToUpperCase on a Wikipedia text (mostly upper case)

As expected, the proposed version is faster than the current one when recasing is not necessary. To simulate real-word, I measure performance on a code that does involve more computations than just toLowerCase and toUpperCase, to put this in perspective with real-word scripting where those functions will rarely be the bottleneck. In a case where recasing is necessary about half of the cases, overall gain is still 5% of total execution time, which is relevant considering the overall weight.

The good thing is that it doesn't seem significantly slower when most cases degenerate to a recasing, though I guess it may if you very long strings whose only last character needs recasing. This does't seem to be something that will happen frequently.

Here is the test case I used:

```javascript
void function() {
    var console = { log: print, ln: '\n' };
    
    var testResults = [];
    function test() {
        var text = 
            (
                "A tag cloud (word cloud, or weighted list in visual design) is a visual representation of text data, typically used to depict keyword metadata (tags) on websites, or to visualize free form text. "+
                "Tags are usually single words, and the importance of each tag is shown with font size or color. "+
                "This format is useful for quickly perceiving the most prominent terms and for locating a term alphabetically to determine its relative prominence. "+
                "When used as website navigation aids, the terms are hyperlinked to items associated with the tag. "+
                "LaTeX est un langage et un système de composition de documents créé par Leslie Lamport en 1983. "+
                "Plus exactement, il s'agit d'une collection de macro-commandes destinées à faciliter l'utilisation du « processeur de texte » TeX de Donald Knuth. "+
                "Depuis 1993, il est maintenu par le LATEX3 Project team. "+
                "La première version utilisée largement, appelée LaTeX2.09, est sortie en 1984. "+
                "Une révision majeure, appelée LaTeX2ε, est sortie en 1991."+
                "Le nom est l'abréviation de Lamport TeX. On écrit souvent LATEX, le logiciel permettant les mises en forme correspondant au logo. "+
                "Du fait de sa relative simplicité, il est devenu la méthode privilégiée d'écriture de documents scientifiques employant TeX. "+
                "Il est particulièrement utilisé dans les domaines techniques et scientifiques pour la production de documents de taille moyenne ou importante (thèse ou livre, par exemple). "+
                "Néanmoins, il peut être aussi employé pour générer des documents de types variés (par exemple, des lettres, ou des transparents). "+
                "Le moteur actuel (2014) de LaTeX est PdfTeX mais ses limites, notamment concernant le traitement des textes Unicode, ont entraîné l'adoption officielle de LuaTeX comme futur successeur. "+
                "Lorsque le développement en sera stabilisé, LuaLaTeX sera probablement l'implémentation standard de LaTeX. "
            );
        var rawWords = text.match(/[-a-zéèα-ω]+/gi);
        var words = Object.create(null);
        for(var word of rawWords) {
            var word1 = word.toLowerCase();
            var word2 = word.toUpperCase();
            words[word1] = 1 + (words[word1]|0);
            words[word2] = 1 + (words[word2]|0);
        }
        testResults=words;
        //console.log(JSON.stringify(words,null,' '));
    }
    
    var start = Date.now();
    for(var i = 25000; i--;) { test(); }
    console.log(Date.now() - start);
    console.log(JSON.stringify(testResults));
    
}();
```

Here are the approximate execution times on my machine:

```
MASTER
- 5200
- 3400
- 3400

OPTIMIZED
- 4900
- 2900
- 3300
```

What would be the next steps to assess the soundness of this change? Are there known benchmarks that use toLowerCase/toUpperCase we could try this build on?