### PR TITLE
pal: remove extra spaces and tabs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ if(CLR_CMAKE_PLATFORM_UNIX)
     add_definitions(
         -DDISABLE_JIT=1
         )
-      
+
     # xplat-todo: revisit these
     # also, we should change this from add_definitions- the intent of that
     # is to just add -D flags
@@ -105,7 +105,7 @@ if(CMAKE_BUILD_TYPE STREQUAL Debug)
         -DDBG=1
         -DDEBUG=1
         -D_DEBUG=1 # for PAL
-        -DDBG_DUMP=1        
+        -DDBG_DUMP=1
     )
     # xplat-todo: reenable this warning
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-writable-strings")

--- a/pal/inc/mbusafecrt.h
+++ b/pal/inc/mbusafecrt.h
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /***
@@ -29,7 +29,7 @@ typedef int errno_t;
 /* errno value that specific to SafeCRT */
 #define STRUNCATE       80
 
-// define the return value for success 
+// define the return value for success
 #define SAFECRT_SUCCESS 0
 
 /*

--- a/pal/inc/pal.h
+++ b/pal/inc/pal.h
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -29,7 +29,7 @@ Abstract:
 
     If you want to add a PAL_ wrapper function to a native function in
     here, you also need to edit palinternal.h and win32pal.h.
-    
+
 
 
 --*/
@@ -177,7 +177,7 @@ extern "C" {
 #if defined(_MSC_VER) || defined(__llvm__)
 #define DECLSPEC_ALIGN(x)   __declspec(align(x))
 #else
-#define DECLSPEC_ALIGN(x) 
+#define DECLSPEC_ALIGN(x)
 #endif
 
 #define DECLSPEC_NORETURN   PAL_NORETURN
@@ -333,7 +333,7 @@ PALIMPORT
 BOOL
 PALAPI
 PAL_IsDebuggerPresent();
- 
+
 #define MAXIMUM_SUSPEND_COUNT  MAXCHAR
 
 #define CHAR_BIT      8
@@ -486,7 +486,7 @@ typedef long time_t;
 #define PAL_INITIALIZE                 PAL_INITIALIZE_SYNC_THREAD
 
 // PAL_InitializeDLL() flags - don't start any of the helper threads
-#define PAL_INITIALIZE_DLL             PAL_INITIALIZE_NONE       
+#define PAL_INITIALIZE_DLL             PAL_INITIALIZE_NONE
 
 // PAL_InitializeChakraCore() flags
 #define PAL_INITIALIZE_CHAKRACORE         (PAL_INITIALIZE | PAL_INITIALIZE_EXEC_ALLOCATOR)
@@ -606,7 +606,7 @@ PAL_RegisterModule(
     IN LPCSTR lpLibFileName);
 
 PALIMPORT
-VOID 
+VOID
 PALAPI
 PAL_UnregisterModule(
     IN HINSTANCE hInstance);
@@ -643,7 +643,7 @@ PAL_Random(
 // if an address lies inside CoreCLR or not.
 //
 // This shouldnt be used by any other component that links into the PAL.
-PALIMPORT 
+PALIMPORT
 BOOL
 PALAPI
 PAL_IsIPInCoreCLR(IN PVOID address);
@@ -1066,7 +1066,7 @@ RemoveDirectoryA(
 #define RemoveDirectory RemoveDirectoryA
 #endif
 
-typedef struct _BY_HANDLE_FILE_INFORMATION {  
+typedef struct _BY_HANDLE_FILE_INFORMATION {
     DWORD dwFileAttributes;
     FILETIME ftCreationTime;
     FILETIME ftLastAccessTime;
@@ -3407,7 +3407,7 @@ GetThreadTimes(
         OUT LPFILETIME lpExitTime,
         OUT LPFILETIME lpKernelTime,
         OUT LPFILETIME lpUserTime);
-		
+
 #define TLS_OUT_OF_INDEXES ((DWORD)0xFFFFFFFF)
 
 PALIMPORT
@@ -3460,9 +3460,9 @@ typedef BOOL (*ReadMemoryWordCallback)(SIZE_T address, SIZE_T *value);
 #if defined(_AMD64_) || defined(_ARM_) || defined(_ARM64_)
 PALIMPORT BOOL PALAPI PAL_VirtualUnwind(CONTEXT *context, KNONVOLATILE_CONTEXT_POINTERS *contextPointers);
 
-PALIMPORT BOOL PALAPI PAL_VirtualUnwindOutOfProc(CONTEXT *context, 
-                                                 KNONVOLATILE_CONTEXT_POINTERS *contextPointers, 
-                                                 DWORD pid, 
+PALIMPORT BOOL PALAPI PAL_VirtualUnwindOutOfProc(CONTEXT *context,
+                                                 KNONVOLATILE_CONTEXT_POINTERS *contextPointers,
+                                                 DWORD pid,
                                                  ReadMemoryWordCallback readMemCallback);
 #endif
 
@@ -3490,14 +3490,14 @@ PALIMPORT BOOL PALAPI PAL_VirtualUnwindOutOfProc(CONTEXT *context,
 #define PAL_CS_NATIVE_DATA_SIZE 80
 #elif defined(__LINUX__) && defined(_ARM64_)
 #define PAL_CS_NATIVE_DATA_SIZE 116
-#else 
-#warning 
+#else
+#warning
 #error  PAL_CS_NATIVE_DATA_SIZE is not defined for this architecture
 #endif
-    
+
 #endif // PLATFORM_UNIX
 
-// 
+//
 typedef struct _CRITICAL_SECTION {
     PVOID DebugInfo;
     LONG LockCount;
@@ -3511,10 +3511,10 @@ typedef struct _CRITICAL_SECTION {
     volatile DWORD dwInitState;
     union CSNativeDataStorage
     {
-        BYTE rgNativeDataStorage[PAL_CS_NATIVE_DATA_SIZE]; 
+        BYTE rgNativeDataStorage[PAL_CS_NATIVE_DATA_SIZE];
         VOID * pvAlign; // make sure the storage is machine-pointer-size aligned
-    } csnds;    
-#endif // PLATFORM_UNIX    
+    } csnds;
+#endif // PLATFORM_UNIX
 } CRITICAL_SECTION, *PCRITICAL_SECTION, *LPCRITICAL_SECTION;
 
 PALIMPORT VOID PALAPI EnterCriticalSection(IN OUT LPCRITICAL_SECTION lpCriticalSection);
@@ -3635,7 +3635,7 @@ MapViewOfFileEx(
           IN DWORD dwFileOffsetLow,
           IN SIZE_T dwNumberOfBytesToMap,
           IN LPVOID lpBaseAddress);
-          
+
 PALIMPORT
 BOOL
 PALAPI
@@ -3721,7 +3721,7 @@ Return value:
     TRUE - success
     FALSE - failure (incorrect ptr, etc.)
 --*/
-BOOL 
+BOOL
 PALAPI
 PAL_LOADUnloadPEFile(void * ptr);
 
@@ -3798,7 +3798,7 @@ GetModuleFileNameExW(
 #define GetModuleFileNameEx GetModuleFileNameExW
 #endif
 
-// Get base address of the module containing a given symbol 
+// Get base address of the module containing a given symbol
 PALAPI
 LPCVOID
 PAL_GetSymbolModuleBase(void *symbol);
@@ -3841,7 +3841,7 @@ typedef struct _MEMORYSTATUSEX {
   DWORDLONG ullAvailExtendedVirtual;
 } MEMORYSTATUSEX, *LPMEMORYSTATUSEX;
 
-PALIMPORT 
+PALIMPORT
 BOOL
 PALAPI
 GlobalMemoryStatusEx(
@@ -4018,11 +4018,11 @@ GetStringTypeExW(
 #endif // __APPLE__
 
 
-typedef struct nlsversioninfo { 
-  DWORD     dwNLSVersionInfoSize; 
-  DWORD     dwNLSVersion; 
-  DWORD     dwDefinedVersion; 
-} NLSVERSIONINFO, *LPNLSVERSIONINFO; 
+typedef struct nlsversioninfo {
+  DWORD     dwNLSVersionInfoSize;
+  DWORD     dwNLSVersion;
+  DWORD     dwDefinedVersion;
+} NLSVERSIONINFO, *LPNLSVERSIONINFO;
 
 #define CSTR_LESS_THAN     1
 #define CSTR_EQUAL         2
@@ -4114,7 +4114,7 @@ BOOL
 PALAPI
 IsValidCodePage(
         IN UINT CodePage);
-        
+
 
 #define MB_PRECOMPOSED            0x00000001
 #define MB_ERR_INVALID_CHARS      0x00000008
@@ -4325,7 +4325,7 @@ GetThreadLocale(
 #define LOCALE_SSCRIPTS               0x0000006c    /* Typical scripts in the locale */
 #define LOCALE_SPARENT                0x0000006d    /* Fallback name for resources */
 #define LOCALE_SCONSOLEFALLBACKNAME   0x0000006e    /* Fallback name for within the console */
-#define LOCALE_SLANGDISPLAYNAME       0x0000006f    /* Language Display Name for a language */ 
+#define LOCALE_SLANGDISPLAYNAME       0x0000006f    /* Language Display Name for a language */
 #define LOCALE_IREADINGLAYOUT         0x00000070   // Returns one of the following 4 reading layout values:
                                                    // 0 - Left to right (eg en-US)
                                                    // 1 - Right to left (eg arabic locales)
@@ -4438,36 +4438,36 @@ GetLocaleInfoEx(
 
 
 PALIMPORT
-int 
+int
 PALAPI
 CompareStringOrdinal(
-    IN LPCWSTR lpString1, 
-	IN int cchCount1, 
-	IN LPCWSTR lpString2, 
-	IN int cchCount2, 
+    IN LPCWSTR lpString1,
+	IN int cchCount1,
+	IN LPCWSTR lpString2,
+	IN int cchCount2,
 	IN BOOL bIgnoreCase);
 
-typedef struct _nlsversioninfoex { 
-  DWORD  dwNLSVersionInfoSize; 
-  DWORD  dwNLSVersion; 
-  DWORD  dwDefinedVersion; 
-  DWORD  dwEffectiveId;   
-  GUID  guidCustomVersion; 
-  } NLSVERSIONINFOEX, *LPNLSVERSIONINFOEX; 
+typedef struct _nlsversioninfoex {
+  DWORD  dwNLSVersionInfoSize;
+  DWORD  dwNLSVersion;
+  DWORD  dwDefinedVersion;
+  DWORD  dwEffectiveId;
+  GUID  guidCustomVersion;
+  } NLSVERSIONINFOEX, *LPNLSVERSIONINFOEX;
 
 PALIMPORT
-int 
+int
 PALAPI
 FindNLSStringEx(
-    IN LPCWSTR lpLocaleName, 
-	IN DWORD dwFindNLSStringFlags, 
-	IN LPCWSTR lpStringSource, 
-	IN int cchSource, 
-    IN LPCWSTR lpStringValue, 
-	IN int cchValue, 
-	OUT LPINT pcchFound, 
-	IN LPNLSVERSIONINFOEX lpVersionInformation, 
-	IN LPVOID lpReserved, 
+    IN LPCWSTR lpLocaleName,
+	IN DWORD dwFindNLSStringFlags,
+	IN LPCWSTR lpStringSource,
+	IN int cchSource,
+    IN LPCWSTR lpStringValue,
+	IN int cchValue,
+	OUT LPINT pcchFound,
+	IN LPNLSVERSIONINFOEX lpVersionInformation,
+	IN LPVOID lpReserved,
 	IN LPARAM lParam );
 
 typedef enum {
@@ -4475,13 +4475,13 @@ typedef enum {
 } NLS_FUNCTION;
 
 PALIMPORT
-BOOL 
+BOOL
 PALAPI
 IsNLSDefinedString(
-    IN NLS_FUNCTION Function, 
-	IN DWORD dwFlags, 
-	IN LPNLSVERSIONINFOEX lpVersionInfo, 
-	IN LPCWSTR lpString, 
+    IN NLS_FUNCTION Function,
+	IN DWORD dwFlags,
+	IN LPNLSVERSIONINFOEX lpVersionInfo,
+	IN LPCWSTR lpString,
 	IN int cchStr );
 
 
@@ -4494,7 +4494,7 @@ ResolveLocaleName(
         IN int cchLocaleName );
 
 PALIMPORT
-BOOL 
+BOOL
 PALAPI
 GetThreadPreferredUILanguages(
     IN DWORD  dwFlags,
@@ -4504,10 +4504,10 @@ GetThreadPreferredUILanguages(
 
 
 PALIMPORT
-int 
+int
 PALAPI
 GetSystemDefaultLocaleName(
-    OUT LPWSTR lpLocaleName, 
+    OUT LPWSTR lpLocaleName,
 	IN int cchLocaleName);
 
 #ifdef UNICODE
@@ -4736,8 +4736,8 @@ LCMapStringEx(
     IN int     cchSrc,
     OUT LPWSTR lpDestStr,
     IN int     cchDest,
-    IN LPNLSVERSIONINFO lpVersionInformation, 
-    IN LPVOID lpReserved, 
+    IN LPNLSVERSIONINFO lpVersionInformation,
+    IN LPVOID lpReserved,
     IN LPARAM lParam );
 
 PALIMPORT
@@ -4801,7 +4801,7 @@ PALIMPORT int PALAPI PAL_FormatScientific(LPCWSTR sLocale, LPWSTR pBuffer, SIZE_
 PALIMPORT int PALAPI  PAL_FormatCurrency(LPCWSTR sLocale, LPWSTR pBuffer, SIZE_T cchBuffer, PALNUMBER number, int nMinDigits, int nMaxDigits, int iNegativeFormat, int iPositiveFormat,
                       int iPrimaryGroup, int iSecondaryGroup, LPCWSTR sCurrencyDecimal, LPCWSTR sCurrencyGroup, LPCWSTR sNegative, LPCWSTR sCurrency, LPCWSTR sZero);
 
-PALIMPORT int PALAPI  PAL_FormatPercent(LPCWSTR sLocale, LPWSTR pBuffer, SIZE_T cchBuffer, PALNUMBER number,  int nMinDigits, int nMaxDigits,int iNegativeFormat, int iPositiveFormat, 
+PALIMPORT int PALAPI  PAL_FormatPercent(LPCWSTR sLocale, LPWSTR pBuffer, SIZE_T cchBuffer, PALNUMBER number,  int nMinDigits, int nMaxDigits,int iNegativeFormat, int iPositiveFormat,
                       int iPrimaryGroup, int iSecondaryGroup, LPCWSTR sPercentDecimal, LPCWSTR sPercentGroup, LPCWSTR sNegative, LPCWSTR sPercent, LPCWSTR sZero);
 
 PALIMPORT int PALAPI  PAL_FormatDecimal(LPCWSTR sLocale, LPWSTR pBuffer, SIZE_T cchBuffer, PALNUMBER number, int nMinDigits, int nMaxDigits, int iNegativeFormat,
@@ -4952,7 +4952,7 @@ WriteProcessMemory(IN HANDLE hProcess,
 
 #define EVENT_MODIFY_STATE        (0x0002)
 #define EVENT_ALL_ACCESS          (STANDARD_RIGHTS_REQUIRED | SYNCHRONIZE | \
-                                   0x3) 
+                                   0x3)
 
 #define MUTANT_QUERY_STATE        (0x0001)
 #define MUTANT_ALL_ACCESS         (STANDARD_RIGHTS_REQUIRED | SYNCHRONIZE | \
@@ -4963,18 +4963,18 @@ WriteProcessMemory(IN HANDLE hProcess,
 #define SEMAPHORE_ALL_ACCESS      (STANDARD_RIGHTS_REQUIRED | SYNCHRONIZE | \
                                    0x3)
 
-#define PROCESS_TERMINATE         (0x0001)  
-#define PROCESS_CREATE_THREAD     (0x0002)  
-#define PROCESS_SET_SESSIONID     (0x0004)  
-#define PROCESS_VM_OPERATION      (0x0008)  
-#define PROCESS_VM_READ           (0x0010)  
-#define PROCESS_VM_WRITE          (0x0020)  
-#define PROCESS_DUP_HANDLE        (0x0040)  
-#define PROCESS_CREATE_PROCESS    (0x0080)  
-#define PROCESS_SET_QUOTA         (0x0100)  
-#define PROCESS_SET_INFORMATION   (0x0200)  
-#define PROCESS_QUERY_INFORMATION (0x0400)  
-#define PROCESS_SUSPEND_RESUME    (0x0800)  
+#define PROCESS_TERMINATE         (0x0001)
+#define PROCESS_CREATE_THREAD     (0x0002)
+#define PROCESS_SET_SESSIONID     (0x0004)
+#define PROCESS_VM_OPERATION      (0x0008)
+#define PROCESS_VM_READ           (0x0010)
+#define PROCESS_VM_WRITE          (0x0020)
+#define PROCESS_DUP_HANDLE        (0x0040)
+#define PROCESS_CREATE_PROCESS    (0x0080)
+#define PROCESS_SET_QUOTA         (0x0100)
+#define PROCESS_SET_INFORMATION   (0x0200)
+#define PROCESS_QUERY_INFORMATION (0x0400)
+#define PROCESS_SUSPEND_RESUME    (0x0800)
 #define PROCESS_ALL_ACCESS        (STANDARD_RIGHTS_REQUIRED | SYNCHRONIZE | \
                                    0xFFF)
 
@@ -5340,12 +5340,12 @@ simultaneously.
 
 Parameters
 
-lpAddend 
-[in/out] Pointer to the variable to increment. 
+lpAddend
+[in/out] Pointer to the variable to increment.
 
 Return Values
 
-The return value is the resulting incremented value. 
+The return value is the resulting incremented value.
 
 --*/
 EXTERN_C
@@ -5369,7 +5369,7 @@ InterlockedIncrement16(
 {
     return __sync_add_and_fetch(lpAddend, (SHORT)1);
 }
-    
+
 EXTERN_C
 PALIMPORT
 inline
@@ -5392,8 +5392,8 @@ simultaneously.
 
 Parameters
 
-lpAddend 
-[in/out] Pointer to the variable to decrement. 
+lpAddend
+[in/out] Pointer to the variable to decrement.
 
 Return Values
 
@@ -5432,15 +5432,15 @@ variable simultaneously.
 
 Parameters
 
-Target 
+Target
 [in/out] Pointer to the value to exchange. The function sets
 this variable to Value, and returns its prior value.
-Value 
-[in] Specifies a new value for the variable pointed to by Target. 
+Value
+[in] Specifies a new value for the variable pointed to by Target.
 
 Return Values
 
-The function returns the initial value pointed to by Target. 
+The function returns the initial value pointed to by Target.
 
 --*/
 EXTERN_C
@@ -5595,9 +5595,9 @@ InterlockedAdd(
     IN OUT LONG volatile *Addend,
     IN LONG Value)
 {
-    return InterlockedExchangeAdd(Addend, Value) + Value; 
+    return InterlockedExchangeAdd(Addend, Value) + Value;
 }
-    
+
 EXTERN_C
 PALIMPORT
 inline
@@ -5636,7 +5636,7 @@ InterlockedOr(
 
 #define BITS_IN_BYTE 8
 #define BITS_IN_LONG (sizeof(LONG) * BITS_IN_BYTE)
-  
+
 EXTERN_C
 PALIMPORT
 inline
@@ -5649,7 +5649,7 @@ InterlockedBitTestAndReset(
     // The BitTestAndReset family of functions allow for arbitrary bit
     // indices- so a bit index can be greater than the number of bits in
     // LONG. We need to account for this in all BitTest/BitTestAndSet
-    // related functions.    
+    // related functions.
     volatile LONG* longToTest = Base + (Bit / BITS_IN_LONG);
     LONG bitToTest  = Bit % BITS_IN_LONG;
     return (InterlockedAnd(longToTest, ~(1 << bitToTest)) & (1 << bitToTest)) != 0;
@@ -5668,7 +5668,7 @@ InterlockedBitTestAndSet(
     LONG bitToTest  = Bit % BITS_IN_LONG;
     return (InterlockedOr(longToTest, (1 << bitToTest)) & (1 << bitToTest)) != 0;
 }
-  
+
 EXTERN_C
 PALIMPORT
 inline
@@ -5682,7 +5682,7 @@ BitTest(
     LONG bitToTest  = Bit % BITS_IN_LONG;
     return ((*longToTest) & (1 << bitToTest)) != 0;
 }
-  
+
 EXTERN_C
 PALIMPORT
 inline
@@ -5698,7 +5698,7 @@ BitTestAndSet(
     LONG bitToTest  = Bit % BITS_IN_LONG;
 
     // Save whether the bit was set or not. Then, unconditionally set the
-    // bit. Return whether the bit was set or not.   
+    // bit. Return whether the bit was set or not.
     UCHAR wasBitSet = (((*longToTest) & (1 << bitToTest)) != 0);
     *longToTest = *longToTest | (1 << bitToTest);
     return wasBitSet;
@@ -5758,7 +5758,7 @@ PALIMPORT
 BOOL
 PALAPI
 PAL_HasGetCurrentProcessorNumber();
-    
+
 #define FORMAT_MESSAGE_ALLOCATE_BUFFER 0x00000100
 #define FORMAT_MESSAGE_IGNORE_INSERTS  0x00000200
 #define FORMAT_MESSAGE_FROM_STRING     0x00000400
@@ -5806,23 +5806,23 @@ GetCommandLineW(
 #endif
 
 PALIMPORT
-VOID 
-PALAPI 
+VOID
+PALAPI
 RtlRestoreContext(
   IN PCONTEXT ContextRecord,
   IN PEXCEPTION_RECORD ExceptionRecord
 );
 
 PALIMPORT
-VOID 
-PALAPI 
+VOID
+PALAPI
 RtlCaptureContext(
   OUT PCONTEXT ContextRecord
 );
 
 PALIMPORT
-UINT 
-PALAPI 
+UINT
+PALAPI
 GetWriteWatch(
   IN DWORD dwFlags,
   IN PVOID lpBaseAddress,
@@ -5833,16 +5833,16 @@ GetWriteWatch(
 );
 
 PALIMPORT
-UINT 
-PALAPI 
+UINT
+PALAPI
 ResetWriteWatch(
   IN LPVOID lpBaseAddress,
   IN SIZE_T dwRegionSize
 );
 
 PALIMPORT
-VOID 
-PALAPI 
+VOID
+PALAPI
 FlushProcessWriteBuffers();
 
 typedef void (*PAL_ActivationFunction)(CONTEXT *context);
@@ -6173,7 +6173,7 @@ CoCreateGuid(OUT GUID * pguid);
 #define _wcstoui64    PAL__wcstoui64
 #define _flushall     PAL__flushall
 
-#ifdef _AMD64_ 
+#ifdef _AMD64_
 #define _mm_getcsr    PAL__mm_getcsr
 #define _mm_setcsr    PAL__mm_setcsr
 #endif // _AMD64_
@@ -6358,7 +6358,7 @@ unsigned int __cdecl _rotr(unsigned int value, int shift)
 }
 
 PALIMPORT int __cdecl abs(int);
-PALIMPORT double __cdecl fabs(double); 
+PALIMPORT double __cdecl fabs(double);
 #ifndef PAL_STDCPP_COMPAT
 PALIMPORT LONG __cdecl labs(LONG);
 PALIMPORT double __cdecl fabs(double);
@@ -6433,9 +6433,9 @@ PALIMPORT char * __cdecl _strdup(const char *);
 #define max(a, b) (((a) > (b)) ? (a) : (b))
 #define min(a, b) (((a) < (b)) ? (a) : (b))
 #endif
-    
+
 #define USING_PAL_MINMAX 1
-    
+
 #endif // !PAL_STDCPP_COMPAT
 
 PALIMPORT PAL_NORETURN void __cdecl exit(int);
@@ -6647,7 +6647,7 @@ typedef enum _PAL_Boundary {
     PAL_BoundaryTop,            // closer to main()
     PAL_BoundaryBottom,         // closer to execution
     PAL_BoundaryEH,             // out-of-band during EH
-    
+
     PAL_BoundaryMax = PAL_BoundaryEH
 } PAL_Boundary;
 
@@ -6756,10 +6756,10 @@ public:
     {
         return m_palError;
     }
-    
+
     void SuppressRelease()
     {
-        // Used to avoid calling PAL_Leave() when 
+        // Used to avoid calling PAL_Leave() when
         // another code path will explicitly do so.
         m_fEntered = FALSE;
     }
@@ -6835,12 +6835,12 @@ public:
 
     PAL_SEHException()
     {
-    }    
+    }
 
     PAL_SEHException(const PAL_SEHException& ex)
     {
         *this = ex;
-    }    
+    }
 
     bool IsFirstPass()
     {
@@ -6856,7 +6856,7 @@ public:
         TargetFrameSp = ex.TargetFrameSp;
 
         return *this;
-    }    
+    }
 };
 
 typedef VOID (PALAPI *PHARDWARE_EXCEPTION_HANDLER)(PAL_SEHException* ex);
@@ -6883,7 +6883,7 @@ public:
 };
 
 //
-// NOTE: Catching hardware exceptions are only enabled in the DAC and SOS 
+// NOTE: Catching hardware exceptions are only enabled in the DAC and SOS
 // builds. A hardware exception in coreclr code will fail fast/terminate
 // the process.
 //
@@ -6898,14 +6898,14 @@ public:
 extern "C++" {
 
 //
-// This is the base class of native exception holder used to provide 
+// This is the base class of native exception holder used to provide
 // the filter function to the exception dispatcher. This allows the
 // filter to be called during the first pass to better emulate SEH
 // the xplat platforms that only have C++ exception support.
 //
 class NativeExceptionHolderBase
 {
-    // Save the address of the holder head so the destructor 
+    // Save the address of the holder head so the destructor
     // doesn't have access the slow (on Linux) TLS value again.
     NativeExceptionHolderBase **m_head;
 
@@ -6934,7 +6934,7 @@ public:
 //
 // This is the second part of the native exception filter holder. It is
 // templated because the lambda used to wrap the exception filter is a
-// unknown type. 
+// unknown type.
 //
 template<class FilterType>
 class NativeExceptionHolder : public NativeExceptionHolderBase
@@ -6995,8 +6995,8 @@ public:
     auto tryBlock = [](__ParamType __paramDef)                                  \
     {
 
-// Start of an exception handler. If an exception raised by the RaiseException 
-// occurs in the try block and the disposition is EXCEPTION_EXECUTE_HANDLER, 
+// Start of an exception handler. If an exception raised by the RaiseException
+// occurs in the try block and the disposition is EXCEPTION_EXECUTE_HANDLER,
 // the handler code is executed. If the disposition is EXCEPTION_CONTINUE_SEARCH,
 // the exception is rethrown. The EXCEPTION_CONTINUE_EXECUTION disposition is
 // not supported.
@@ -7039,7 +7039,7 @@ public:
     };                                  \
     const bool isFinally = true;        \
     auto finallyBlock = [&]()           \
-    {                       
+    {
 
 // End of an except or a finally block.
 #define PAL_ENDTRY                      \
@@ -7105,7 +7105,7 @@ public:
 #endif // __cplusplus
 
 // Platform-specific library naming
-// 
+//
 #ifdef PLATFORM_UNIX
 #ifdef __APPLE__
 #define MAKEDLLNAME_W(name) u"lib" name u".dylib"
@@ -7143,16 +7143,16 @@ public:
 #define PAL_SHLIB_SUFFIX ".so"
 #endif
 
-#define DBG_EXCEPTION_HANDLED            ((DWORD   )0x00010001L)    
-#define DBG_CONTINUE                     ((DWORD   )0x00010002L)    
-#define DBG_EXCEPTION_NOT_HANDLED        ((DWORD   )0x80010001L)    
+#define DBG_EXCEPTION_HANDLED            ((DWORD   )0x00010001L)
+#define DBG_CONTINUE                     ((DWORD   )0x00010002L)
+#define DBG_EXCEPTION_NOT_HANDLED        ((DWORD   )0x80010001L)
 
-#define DBG_TERMINATE_THREAD             ((DWORD   )0x40010003L)    
-#define DBG_TERMINATE_PROCESS            ((DWORD   )0x40010004L)    
-#define DBG_CONTROL_C                    ((DWORD   )0x40010005L)    
-#define DBG_RIPEXCEPTION                 ((DWORD   )0x40010007L)    
-#define DBG_CONTROL_BREAK                ((DWORD   )0x40010008L)    
-#define DBG_COMMAND_EXCEPTION            ((DWORD   )0x40010009L)    
+#define DBG_TERMINATE_THREAD             ((DWORD   )0x40010003L)
+#define DBG_TERMINATE_PROCESS            ((DWORD   )0x40010004L)
+#define DBG_CONTROL_C                    ((DWORD   )0x40010005L)
+#define DBG_RIPEXCEPTION                 ((DWORD   )0x40010007L)
+#define DBG_CONTROL_BREAK                ((DWORD   )0x40010008L)
+#define DBG_COMMAND_EXCEPTION            ((DWORD   )0x40010009L)
 
 #define STATUS_USER_APC                  ((DWORD   )0x000000C0L)
 #define STATUS_GUARD_PAGE_VIOLATION      ((DWORD   )0x80000001L)

--- a/pal/inc/pal_assert.h
+++ b/pal/inc/pal_assert.h
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++

--- a/pal/inc/pal_char16.h
+++ b/pal/inc/pal_char16.h
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -50,4 +50,3 @@ typedef unsigned short wchar_t;
 #endif // !_WCHAR_T_DEFINED
 #endif // !_WCHAR_T_DEFINED || !_MSC_VER
 #endif // !PAL_STDCPP_COMPAT
-

--- a/pal/inc/pal_endian.h
+++ b/pal/inc/pal_endian.h
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -45,7 +45,7 @@ inline UINT32 VAL32(UINT32 x)
     return SWAP32(x);
 }
 
-inline UINT64 VAL64(UINT64 x)   
+inline UINT64 VAL64(UINT64 x)
 {
     return ((UINT64)VAL32(x) << 32) | VAL32(x >> 32);
 }
@@ -68,8 +68,8 @@ inline void SwapStringLength(WCHAR *szString, ULONG StringLength)
     }
 }
 
-inline void SwapGuid(GUID *pGuid) 
-{ 
+inline void SwapGuid(GUID *pGuid)
+{
     pGuid->Data1 = VAL32(pGuid->Data1);
     pGuid->Data2 = VAL16(pGuid->Data2);
     pGuid->Data3 = VAL16(pGuid->Data3);
@@ -108,19 +108,19 @@ inline UINT16 GET_UNALIGNED_16(const void *pObject)
 {
     UINT16 temp;
     memcpy(&temp, pObject, sizeof(temp));
-    return temp; 
+    return temp;
 }
 inline UINT32 GET_UNALIGNED_32(const void *pObject)
 {
     UINT32 temp;
     memcpy(&temp, pObject, sizeof(temp));
-    return temp; 
+    return temp;
 }
 inline UINT64 GET_UNALIGNED_64(const void *pObject)
 {
     UINT64 temp;
     memcpy(&temp, pObject, sizeof(temp));
-    return temp; 
+    return temp;
 }
 
 // Set Value on an potentially unaligned object
@@ -146,10 +146,10 @@ inline void SET_UNALIGNED_64(void *pObject, UINT64 Value)
 #define GET_UNALIGNED_32(_pObject)  (*(UINT32 UNALIGNED *)(_pObject))
 #define GET_UNALIGNED_64(_pObject)  (*(UINT64 UNALIGNED *)(_pObject))
 
-// Set Value on an potentially unaligned object 
+// Set Value on an potentially unaligned object
 #define SET_UNALIGNED_16(_pObject, _Value)  (*(UNALIGNED UINT16 *)(_pObject)) = (UINT16)(_Value)
 #define SET_UNALIGNED_32(_pObject, _Value)  (*(UNALIGNED UINT32 *)(_pObject)) = (UINT32)(_Value)
-#define SET_UNALIGNED_64(_pObject, _Value)  (*(UNALIGNED UINT64 *)(_pObject)) = (UINT64)(_Value) 
+#define SET_UNALIGNED_64(_pObject, _Value)  (*(UNALIGNED UINT64 *)(_pObject)) = (UINT64)(_Value)
 
 #endif
 
@@ -158,7 +158,7 @@ inline void SET_UNALIGNED_64(void *pObject, UINT64 Value)
 #define GET_UNALIGNED_VAL32(_pObject) VAL32(GET_UNALIGNED_32(_pObject))
 #define GET_UNALIGNED_VAL64(_pObject) VAL64(GET_UNALIGNED_64(_pObject))
 
-// Set a swap Value on an potentially unaligned object 
+// Set a swap Value on an potentially unaligned object
 #define SET_UNALIGNED_VAL16(_pObject, _Value) SET_UNALIGNED_16(_pObject, VAL16((UINT16)_Value))
 #define SET_UNALIGNED_VAL32(_pObject, _Value) SET_UNALIGNED_32(_pObject, VAL32((UINT32)_Value))
 #define SET_UNALIGNED_VAL64(_pObject, _Value) SET_UNALIGNED_64(_pObject, VAL64((UINT64)_Value))

--- a/pal/inc/pal_error.h
+++ b/pal/inc/pal_error.h
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++

--- a/pal/inc/pal_mstypes.h
+++ b/pal/inc/pal_mstypes.h
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -187,21 +187,21 @@ extern "C" {
 // LLP64 => longs = 32 bits, long long = 64 bits)
 //
 // To handle this difference, we #define long to be int (and thus 32 bits) when
-// compiling those files.  (See the bottom of this file or search for 
-// #define long to see where we do this.)  
+// compiling those files.  (See the bottom of this file or search for
+// #define long to see where we do this.)
 //
-// But this fix is more complicated than it seems, because we also use the 
+// But this fix is more complicated than it seems, because we also use the
 // preprocessor to #define __int64 to long for LP64 architectures (__int64
-// isn't a builtin in gcc).   We don't want __int64 to be an int (by cascading 
-// macro rules).  So we play this little trick below where we add 
-// __cppmungestrip before "long", which is what we're really #defining __int64 
-// to.  The preprocessor sees __cppmungestriplong as something different than 
-// long, so it doesn't replace it with int.  The during the cppmunge phase, we 
+// isn't a builtin in gcc).   We don't want __int64 to be an int (by cascading
+// macro rules).  So we play this little trick below where we add
+// __cppmungestrip before "long", which is what we're really #defining __int64
+// to.  The preprocessor sees __cppmungestriplong as something different than
+// long, so it doesn't replace it with int.  The during the cppmunge phase, we
 // remove the __cppmungestrip part, leaving long for the compiler to see.
 //
-// Note that we can't just use a typedef to define __int64 as long before 
-// #defining long because typedefed types can't be signedness-agnostic (i.e. 
-// they must be either signed or unsigned) and we want to be able to use 
+// Note that we can't just use a typedef to define __int64 as long before
+// #defining long because typedefed types can't be signedness-agnostic (i.e.
+// they must be either signed or unsigned) and we want to be able to use
 // __int64 as though it were intrinsic
 
 #ifdef BIT64
@@ -228,7 +228,7 @@ typedef __int16 int16_t;
 typedef unsigned __int16 uint16_t;
 typedef __int8 int8_t;
 #define __int8_t_defined
-    
+
 typedef unsigned __int8 uint8_t;
 #endif // PAL_IMPLEMENTATION
 
@@ -617,7 +617,7 @@ typedef char16_t WCHAR;
 #else // !PAL_STDCPP_COMPAT
 
 typedef wchar_t WCHAR;
-#if defined(__LINUX__) 
+#if defined(__LINUX__)
 #ifdef BIT64
 typedef long int intptr_t;
 typedef unsigned long int uintptr_t;

--- a/pal/inc/pal_safecrt.h
+++ b/pal/inc/pal_safecrt.h
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++

--- a/pal/inc/pal_unwind.h
+++ b/pal/inc/pal_unwind.h
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 //

--- a/pal/inc/rt/ntimage.h
+++ b/pal/inc/rt/ntimage.h
@@ -6,8 +6,8 @@
 
 //
 // ===========================================================================
-// File: ntimage.h 
-// 
+// File: ntimage.h
+//
 // ===========================================================================
 
 //
@@ -17,7 +17,7 @@
 //
 //Author:
 //
-//     
+//
 //
 //Revision History:
 //
@@ -31,7 +31,7 @@
 #endif
 
 //
-// Define the linker version number.  
+// Define the linker version number.
 
 #define IMAGE_MAJOR_LINKER_VERSION 2
 
@@ -1007,7 +1007,7 @@ typedef IMAGE_RELOCATION UNALIGNED *PIMAGE_RELOCATION;
 #define IMAGE_REL_IA64_SECREL22         0x000C
 #define IMAGE_REL_IA64_SECREL64I        0x000D
 #define IMAGE_REL_IA64_SECREL32         0x000E
-// 
+//
 #define IMAGE_REL_IA64_DIR32NB          0x0010
 #define IMAGE_REL_IA64_SREL14           0x0011
 #define IMAGE_REL_IA64_SREL22           0x0012
@@ -1585,7 +1585,7 @@ typedef struct _IMAGE_DEBUG_DIRECTORY {
 
 // end_winnt
 
-// 
+//
 
 // begin_winnt
 
@@ -1808,24 +1808,24 @@ typedef enum ReplacesCorHdrNumericDefines
     COR_VTABLEGAP_NAME_LENGTH           =8,
 
 // Maximum size of a NativeType descriptor.
-    NATIVE_TYPE_MAX_CB                  =1,   
+    NATIVE_TYPE_MAX_CB                  =1,
     COR_ILMETHOD_SECT_SMALL_MAX_DATASIZE=0xFF,
 
 // #defines for the MIH FLAGS
     IMAGE_COR_MIH_METHODRVA             =0x01,
-    IMAGE_COR_MIH_EHRVA                 =0x02,    
+    IMAGE_COR_MIH_EHRVA                 =0x02,
     IMAGE_COR_MIH_BASICBLOCK            =0x08,
 
 // V-table constants
-    COR_VTABLE_32BIT                    =0x01,          // V-table slots are 32-bits in size.   
-    COR_VTABLE_64BIT                    =0x02,          // V-table slots are 64-bits in size.   
+    COR_VTABLE_32BIT                    =0x01,          // V-table slots are 32-bits in size.
+    COR_VTABLE_64BIT                    =0x02,          // V-table slots are 64-bits in size.
     COR_VTABLE_FROM_UNMANAGED           =0x04,          // If set, transition from unmanaged.
     COR_VTABLE_CALL_MOST_DERIVED        =0x10,          // Call most derived method described by
 
 // EATJ constants
     IMAGE_COR_EATJ_THUNK_SIZE           =32,            // Size of a jump thunk reserved range.
 
-// Max name lengths    
+// Max name lengths
     //<TODO> Change to unlimited name lengths. </TODO>
     MAX_CLASS_NAME                      =1024,
     MAX_PACKAGE_NAME                    =1024,
@@ -1835,13 +1835,13 @@ typedef enum ReplacesCorHdrNumericDefines
 typedef struct IMAGE_COR20_HEADER
 {
     // Header versioning
-    ULONG                   cb;              
+    ULONG                   cb;
     USHORT                  MajorRuntimeVersion;
     USHORT                  MinorRuntimeVersion;
-    
+
     // Symbol table and startup information
-    IMAGE_DATA_DIRECTORY    MetaData;        
-    ULONG                   Flags;           
+    IMAGE_DATA_DIRECTORY    MetaData;
+    ULONG                   Flags;
 
     // If COMIMAGE_FLAGS_NATIVE_ENTRYPOINT is not set, EntryPointToken represents a managed entrypoint.
     // If COMIMAGE_FLAGS_NATIVE_ENTRYPOINT is set, EntryPointRVA represents an RVA to a native entrypoint.
@@ -1849,7 +1849,7 @@ typedef struct IMAGE_COR20_HEADER
         ULONG               EntryPointToken;
         ULONG               EntryPointRVA;
     };
-    
+
     // Binding information
     IMAGE_DATA_DIRECTORY    Resources;
     IMAGE_DATA_DIRECTORY    StrongNameSignature;
@@ -1861,7 +1861,7 @@ typedef struct IMAGE_COR20_HEADER
 
     // Precompiled image info (internal use only - set to zero)
     IMAGE_DATA_DIRECTORY    ManagedNativeHeader;
-    
+
 } IMAGE_COR20_HEADER, *PIMAGE_COR20_HEADER;
 
 #endif // __IMAGE_COR20_HEADER_DEFINED__

--- a/pal/inc/rt/specstrings_strict.h
+++ b/pal/inc/rt/specstrings_strict.h
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /************************************************************************* 
@@ -18,12 +18,12 @@
 *  There are several levels of strictness, each level includes the behavior of
 *  all previous levels.
 *
-*  0 - Disable strict checking 
-*  1 - Break on unapproved macros and misuse of statement 
+*  0 - Disable strict checking
+*  1 - Break on unapproved macros and misuse of statement
 *      macros such as __fallthrough (default)
 *  2 - Deprecated some old macros that should not be used
-*  3 - Use VS 2005 Source Annotation to make sure every macro 
-*      is used in the right context. For example placing __in on a return 
+*  3 - Use VS 2005 Source Annotation to make sure every macro
+*      is used in the right context. For example placing __in on a return
 *      parameter will result in an error.
 *
 
@@ -38,32 +38,32 @@
 *  specstrings.h provides a set of annotations to describe how a function uses
 *  its parameters - the assumptions it makes about them, and the guarantees it
 *  makes upon finishing.
-* 
+*
 *  Annotations must be placed before a function parameter's type or its return
 *  type. There are two basic classes of common annotations buffer annotations
 *  and advanced annotations.  Buffer annotations describe how functions use
 *  their pointer parameters, and advanced annotations either describe
 *  complex/unusual buffer behavior, or provide additional information about a
 *  parameter that is not otherwise expressible.
-* 
+*
 *  Buffer Annotations
-* 
+*
 *  The most important annotations in SpecStrings.h provide a consistent way to
 *  annotate buffer parameters or return values for a function. Each of these
 *  annotations describes a single buffer (which could be a string, a
 *  fixed-length or variable-length array, or just a pointer) that the function
 *  interacts with: where it is, how large it is, how much is initialized, and
 *  what the function does with it.
-* 
+*
 *  The appropriate macro for a given buffer can be constructed using the table
 *  below.  Just pick the appropriate values from each category, and combine
 *  them together with a leading underscore. Some combinations of values do not
 *  make sense as buffer annotations. Only meaningful annotations can be added
 *  to your code; for a list of these, see the buffer annotation definitions
 *  section.
-* 
+*
 *  Only a single buffer annotation should be used for each parameter.
-* 
+*
 *  |------------|------------|---------|--------|----------|---------------|
 *  |   Level    |   Usage    |  Size   | Output | Optional |  Parameters   |
 *  |------------|------------|---------|--------|----------|---------------|
@@ -75,17 +75,17 @@
 *  |------------|------------|---------|--------|----------|---------------|
 *
 *  Note: "<>" represents the empty string.
-* 
+*
 *  Level: Describes the buffer pointer's level of indirection from the
 *  parameter or return value 'p'.
-* 
+*
 *  <>         : p is the buffer pointer.
 *  _deref     : *p is the buffer pointer. p must not be NULL.
-*  _deref_opt : *p may be the buffer pointer. p may be NULL, in which case the 
+*  _deref_opt : *p may be the buffer pointer. p may be NULL, in which case the
 *               rest of the annotation is ignored.
-* 
+*
 *  Usage: Describes how the function uses the buffer.
-* 
+*
 *  <> : The buffer is not accessed. If used on the return value or with
 *  _deref, the function will provide the buffer, and it will be uninitialized
 *  at exit.  Otherwise, the caller must provide the buffer. This should only
@@ -106,7 +106,7 @@
 *  Size: Describes the total size of the buffer. This may be less than the
 *  space actually allocated for the buffer, in which case it describes the
 *  accessible amount.
-* 
+*
 *  <> : No buffer size is given. If the type specifies the buffer size (such
 *  as with LPSTR and LPWSTR), that amount is used. Otherwise, the buffer is
 *  one element long. Must be used with _in, _out, or _inout.
@@ -114,12 +114,12 @@
 *  _ecount : The buffer size is an explicit element count.
 *
 *  _bcount : The buffer size is an explicit byte count.
-* 
+*
 *  Output: Describes how much of the buffer will be initialized by the
 *  function. For _inout buffers, this also describes how much is initialized
 *  at entry. Omit this category for _in buffers; they must be fully
 *  initialized by the caller.
-* 
+*
 *  <> : The type specifies how much is initialized. For instance, a function
 *  initializing an LPWSTR must NULL-terminate the string.
 *
@@ -127,16 +127,16 @@
 *
 *  _part : The function initializes part of the buffer, and explicitly
 *  indicates how much.
-* 
+*
 *  Optional: Describes if the buffer itself is optional.
-* 
+*
 *  <>   : The pointer to the buffer must not be NULL.
 *
 *  _opt : The pointer to the buffer might be NULL. It will be checked before
 *  being dereferenced.
-* 
+*
 *  Parameters: Gives explicit counts for the size and length of the buffer.
-* 
+*
 *  <> : There is no explicit count. Use when neither _ecount nor _bcount is
 *  used.
 *
@@ -145,47 +145,47 @@
 *
 *  (size,length) : The buffer's total size and initialized length are
 *  given. Use with _ecount_part and _bcount_part.
-* 
+*
 *  ----------------------------------------------------------------------------
 *  Buffer Annotation Examples
-* 
+*
 *  LWSTDAPI_(BOOL) StrToIntExA(
 *      LPCSTR pszString,  //  No annotation required, const implies __in.
 *      DWORD dwFlags,
 *      __out int *piRet   // A pointer whose dereference will be filled in.
 *  );
-* 
+*
 *  void MyPaintingFunction(
 *      __in HWND hwndControl,     //  An initialized read-only parameter.
-*      __in_opt HDC hdcOptional,  //  An initialized read-only parameter that 
+*      __in_opt HDC hdcOptional,  //  An initialized read-only parameter that
 *                                 //  might be NULL.
-*      __inout IPropertyStore *ppsStore // An initialized parameter that 
+*      __inout IPropertyStore *ppsStore // An initialized parameter that
 *                                       // may be freely used and modified.
 *  );
-* 
+*
 *  LWSTDAPI_(BOOL) PathCompactPathExA(
 *      __out_ecount(cchMax) LPSTR pszOut, //  A string buffer with cch elements
-*                                         //  that will be '\0' terminated 
+*                                         //  that will be '\0' terminated
 *                                         //  on exit.
-*      LPCSTR pszSrc,                     //  No annotation required, 
+*      LPCSTR pszSrc,                     //  No annotation required,
 *                                         //  const implies __in.
-*      UINT cchMax,                              
+*      UINT cchMax,
 *      DWORD dwFlags
 *  );
-* 
+*
 *  HRESULT SHLocalAllocBytes(
 *      size_t cb,
 *      __deref_bcount(cb) T **ppv //  A pointer whose dereference will be set
 *                                 //  to an uninitialized buffer with cb bytes.
 *  );
-* 
+*
 *  __inout_bcount_full(cb) : A buffer with cb elements that is fully
 *  initialized at entry and exit, and may be written to by this function.
-* 
+*
 *  __out_ecount_part(count, *countOut) : A buffer with count elements that
 *  will be partially initialized by this function. The function indicates how
 *  much it initialized by setting *countOut.
-* 
+*
 ************************************************************************/
 
 #if (_MSC_VER >= 1400) && !defined(__midl) && !defined(_PREFAST_) && (__SPECSTRINGS_STRICT_LEVEL > 0)
@@ -376,7 +376,7 @@
 #define __deref_opt_out_xcount_part_opt(size,len)     __allowed(on_parameter)
 #define __deref_opt_out_ecount_full_opt(size)         __allowed(on_parameter)
 #define __deref_opt_out_bcount_full_opt(size)         __allowed(on_parameter)
-#define __deref_opt_out_xcount_full_opt(size)         __allowed(on_parameter)  
+#define __deref_opt_out_xcount_full_opt(size)         __allowed(on_parameter)
 #define __deref_opt_out_z_opt                         __allowed(on_parameter)
 #define __deref_opt_out_ecount_z_opt(size)            __allowed(on_parameter)
 #define __deref_opt_out_bcount_z_opt(size)            __allowed(on_parameter)
@@ -384,7 +384,7 @@
 #define __deref_opt_inout_ecount_opt(size)            __allowed(on_parameter)
 #define __deref_opt_inout_bcount_opt(size)            __allowed(on_parameter)
 #define __deref_opt_inout_xcount_opt(size)            __allowed(on_parameter)
-#define __deref_opt_inout_ecount_part_opt(size,len)   __allowed(on_parameter) 
+#define __deref_opt_inout_ecount_part_opt(size,len)   __allowed(on_parameter)
 #define __deref_opt_inout_bcount_part_opt(size,len)   __allowed(on_parameter)
 #define __deref_opt_inout_xcount_part_opt(size,len)   __allowed(on_parameter)
 #define __deref_opt_inout_ecount_full_opt(size)       __allowed(on_parameter)
@@ -467,12 +467,12 @@
 
 /************************************************************************
 *  Advanced Annotations
-* 
+*
 *  Advanced annotations describe behavior that is not expressible with the
 *  regular buffer macros. These may be used either to annotate buffer
 *  parameters that involve complex or conditional behavior, or to enrich
 *  existing annotations with additional information.
-* 
+*
 *  _At_(expr, annotes) : annotation list annotes applies to target 'expr'
 *
 *  _When_(expr, annotes) : annotation list annotes applies when 'expr' is true
@@ -484,57 +484,57 @@
 *  the function must always satisfy its guarantees. Added automatically to
 *  functions that indicate success in standard ways, such as by returning an
 *  HRESULT.
-* 
+*
 *  __out_awcount(expr, size) T *p : Pointer p is a buffer whose size may be
 *  given in either bytes or elements. If <expr> is true, this acts like
 *  __out_bcount. If <expr> is false, this acts like __out_ecount. This
 *  should only be used to annotate old APIs.
-* 
+*
 *  __in_awcount(expr, size) T* p : Pointer p is a buffer whose size may be given
 *  in either bytes or elements. If <expr> is true, this acts like
 *  __in_bcount. If <expr> is false, this acts like __in_ecount. This should
 *  only be used to annotate old APIs.
-* 
+*
 *  __nullterminated T* p : Pointer p is a buffer that may be read or written
 *  up to and including the first '\0' character or pointer. May be used on
 *  typedefs, which marks valid (properly initialized) instances of that type
 *  as being null-terminated.
-* 
+*
 *  __nullnullterminated T* p : Pointer p is a buffer that may be read or
 *  written up to and including the first sequence of two '\0' characters or
 *  pointers. May be used on typedefs, which marks valid instances of that
 *  type as being double-null terminated.
-* 
+*
 *  __reserved T v : Value v must be 0/NULL, reserved for future use.
-* 
+*
 *  __checkReturn T f(); : Return value of f must not be ignored by callers
 *  of this function.
-* 
+*
 *  __typefix(ctype) T v : Value v should be treated as an instance of ctype,
 *  rather than its declared type when considering validity.
-* 
+*
 *  __override T f(); : Specify C#-style 'override' behaviour for overriding
 *  virtual methods.
-* 
+*
 *  __callback T f(); : Function f can be used as a function pointer.
-* 
+*
 *  __format_string T p : Pointer p is a string that contains % markers in
 *  the style of printf.
-* 
+*
 *  __blocksOn(resource) f(); : Function f blocks on the resource 'resource'.
-* 
+*
 *  __fallthrough : Annotates switch statement labels where fall-through is
 *  desired, to distinguish from forgotten break statements.
-* 
+*
 *  __range(low_bnd, up_bnd) int f(): The return from the function "f" must
 *  be in the inclusive numeric range [low_bnd, up_bnd].
 *
 *  __in_range(low_bnd, up_bnd) int i : Precondition that integer i must be
 *  in the inclusive numeric range [low_bnd, up_bnd].
-* 
+*
 *  __out_range(low_bnd, up_bnd) int i : Postcondition that integer i must be
 *  in the inclusive numeric range [low_bnd, up_bnd].
-* 
+*
 *  __deref_in_range(low_bnd, up_bnd) int* pi : Precondition that integer *pi
 *  must be in the inclusive numeric range [low_bnd, up_bnd].
 *
@@ -546,16 +546,16 @@
 *
 *  The first argument of a range macro may also be a C relational operator
 *  (<,>,!=, ==, <=, >=).
-*  
+*
 *  __range(rel_op, j) int f(): Postcondition that "f() rel_op j" must be
 *  true.  Note that j may be a expression known only at runtime.
 *
 *  __in_range(rel_op, j) int i : Precondition that "i rel_op j" must be
 *  true.  Note that j may be a expression known only at runtime.
-* 
+*
 *  __out_range(rel_op, j) int i : Postcondition that integer "i rel_op j"
 *  must be true.  Note that j may be a expression known only at runtime.
-* 
+*
 *  __deref_in_range(rel_op, j) int *pi : Precondition that "*pi rel_op j"
 *  must be true.  Note that j may be a expression known only at runtime.
 *
@@ -578,11 +578,11 @@
 *  __out_bound int i : Postcondition that integer i must be bound, but the
 *  exact range can't be specified at compile time.  __out_range should be
 *  used if the range can be explicitly stated.
-* 
+*
 *  __deref_out_bound int pi : Postcondition that integer *pi must be bound,
 *  but the exact range can't be specified at compile time.
 *  __deref_out_range should be used if the range can be explicitly stated.
-* 
+*
 *  __assume_bound(expr); : Assume that the expression is bound to some known
 *  range. This can be used to suppress integer overflow warnings on integral
 *  expressions that are known to be bound due to reasons not explicit in the
@@ -591,8 +591,8 @@
 *  __analysis_assume_nulltermianted(expr); : Assume that the expression is
 *  a null terminated buffer. Use this to suppress tool noise specific to
 *  nulltermination warnings, and capture deeper invariants tools can not
-*  discover. 
-* 
+*  discover.
+*
 *  __allocator void f(): Function allocates memory using an integral size
 *  argument
 *
@@ -602,69 +602,69 @@
 *  void myfree(__deallocate_opt(Mem) void *p) : Memory is freed, no longer
 *  usable upon return, and p may be null.
 *
-*  void free(__post_invalid void* x): Mark memory as untouchable when 
+*  void free(__post_invalid void* x): Mark memory as untouchable when
 *  function returns.
 *
 *  ----------------------------------------------------------------------------
 *  Advanced Annotation Examples
-* 
-*  __success(return == TRUE) LWSTDAPI_(BOOL) 
+*
+*  __success(return == TRUE) LWSTDAPI_(BOOL)
 *  PathCanonicalizeA(__out_ecount(MAX_PATH) LPSTR pszBuf, LPCSTR pszPath);
 *  //  pszBuf is only guaranteed to be null-terminated when TRUE is returned.
-* 
+*
 *  // Initialized LPWSTRs are null-terminated strings.
 *  typedef __nullterminated WCHAR* LPWSTR;
-* 
+*
 *  __out_ecount(cch) __typefix(LPWSTR) void *psz;
-*  // psz is a buffer parameter which will be a null-terminated WCHAR string 
+*  // psz is a buffer parameter which will be a null-terminated WCHAR string
 *  // at exit, and which initially contains cch WCHARs.
-* 
+*
 ************************************************************************/
 #define _At_(expr, annotes)      __allowed(on_parameter_or_return)
 #define _When_(expr, annotes)    __allowed(on_parameter_or_return)
 #define __success(expr)          _SAL_VERSION_CHECK(__success)
-#define __out_awcount(expr,size) __allowed(on_parameter) 
-#define __in_awcount(expr,size)  __allowed(on_parameter)   
+#define __out_awcount(expr,size) __allowed(on_parameter)
+#define __in_awcount(expr,size)  __allowed(on_parameter)
 #define __nullterminated         _SAL_VERSION_CHECK(__nullterminated)
 #define __nullnullterminated     _SAL_VERSION_CHECK(__nullnullterminated)
 #define __reserved               _SAL_VERSION_CHECK(__reserved)
 #define __checkReturn            _SAL_VERSION_CHECK(__checkReturn)
-#define __typefix(ctype)         __allowed(on_parameter_or_return) 
-#define __override               __allowed(on_function) 
-#define __callback               __allowed(on_function) 
-#define __format_string          __allowed(on_parameter_or_return) 
-#define __blocksOn(resource)     __allowed(on_function) 
+#define __typefix(ctype)         __allowed(on_parameter_or_return)
+#define __override               __allowed(on_function)
+#define __callback               __allowed(on_function)
+#define __format_string          __allowed(on_parameter_or_return)
+#define __blocksOn(resource)     __allowed(on_function)
 #define __fallthrough            __allowed(as_statement)
-#define __range(lb,ub)           __allowed(on_return) 
+#define __range(lb,ub)           __allowed(on_return)
 #define __in_range(lb,ub)        _SAL_VERSION_CHECK(__in_range)
 #define __out_range(lb,ub)       _SAL_VERSION_CHECK(__out_range)
-#define __deref_in_range(lb,ub)  __allowed(on_parameter) 
+#define __deref_in_range(lb,ub)  __allowed(on_parameter)
 #define __deref_out_range(lb,ub) _SAL_VERSION_CHECK(__deref_out_range)
-#define __deref_inout_range(lb,ub) __allowed(on_parameter) 
+#define __deref_inout_range(lb,ub) __allowed(on_parameter)
 #define __field_range(lb,ub)     _SAL_VERSION_CHECK(__field_range)
-#define __range_max(a,b)         __allowed(on_return) 
-#define __range_min(a,b)         __allowed(on_return) 
-#define __bound                  __allowed(on_return) 
-#define __in_bound               __allowed(on_parameter) 
-#define __out_bound              __allowed(on_parameter) 
-#define __deref_out_bound        __allowed(on_parameter) 
+#define __range_max(a,b)         __allowed(on_return)
+#define __range_min(a,b)         __allowed(on_return)
+#define __bound                  __allowed(on_return)
+#define __in_bound               __allowed(on_parameter)
+#define __out_bound              __allowed(on_parameter)
+#define __deref_out_bound        __allowed(on_parameter)
 #define __assume_bound(i)        __allowed(as_statement_with_arg(i))
 #define __analysis_assume_nullterminated(x) \
                                  __allowed(as_statement_with_arg(x))
-#define __allocator              __allowed(on_function) 
-#define __deallocate(kind)       __allowed(on_parameter) 
-#define __deallocate_opt(kind)   __allowed(on_parameter) 
-#define __post_invalid           __allowed(on_parameter_or_return) 
+#define __allocator              __allowed(on_function)
+#define __deallocate(kind)       __allowed(on_parameter)
+#define __deallocate_opt(kind)   __allowed(on_parameter)
+#define __post_invalid           __allowed(on_parameter_or_return)
 #define __post_nullnullterminated           \
                                  __allowed(on_parameter_or_return)
-/*************************************************************************** 
+/***************************************************************************
 * Expert Macros
 ***************************************************************************/
 #define __null                  __allowed(on_typedecl)
 #define __notnull               __allowed(on_typedecl)
 #define __maybenull             __allowed(on_typedecl)
 #define __exceptthat            __allowed(on_typedecl)
-/*************************************************************************** 
+/***************************************************************************
 * Macros to classify fields of structures.
 *                          Structure Annotations
 *
@@ -765,54 +765,54 @@
 *                        The pointer to the block of memory is may be
 *                        NULL
 *
-*     
-*   // Basic Usage of Struct Annotations                         
-*   #include <stdio.h>                                           
-*   #include <stdlib.h>                                          
-*   struct buf_s {                                               
-*    int sz;                                                     
-*    __field_bcount_full(sz)                                     
-*    char *buf;                                                  
-*   };                                                           
-*   void InitBuf(__out struct *buf_s b,int sz) {                 
-*        b->buf = calloc(sz,sizeof(char));                       
-*        b->sz = sz;                                             
-*   }                                                            
-*   void WriteBuf(__in FILE *fp,__in struct *buf_s b) {          
-*     fwrite(b->buf,b->sz,sizeof(char),fp);                      
-*   }                                                            
-*   void ReadBuf(__in FILE *fp,__inout struct *buf_s b) {        
-*     fread(b->buf,b->sz,sizeof(char),fp);                       
-*   }                                                            
-*                                                                 
-*                                                                 
-*                                                                 
-*   // Inline Allocated Buffer                                   
-*   struct buf_s {                                               
-*    int sz;                                                     
-*    __field_bcount(sz)                                          
-*    char buf[1];                                                
-*   };                                                           
-*   void WriteBuf(__in FILE *fp,__in struct *buf_s b) {          
-*     fwrite(&(b->buf),b->sz,sizeof(char),fp);                   
-*   }                                                            
-*   void ReadBuf(__in FILE *fp,__inout struct *buf_s b) {        
-*     fread(&(b->buf),b->sz,sizeof(char),fp);                    
-*   }                                                            
-*                                                                 
-*                                                                 
-*                                                                 
-*   // Embedded Header Structure                                 
-*   __struct_bcount(sz)                                          
-*   struct buf_s {                                               
-*    int sz;                                                     
-*   };                                                           
-*   void WriteBuf(__in FILE *fp,__in struct *buf_s b) {          
-*     fwrite(&b,b->sz,sizeof(char),fp);                          
-*   }                                                            
-*   void ReadBuf(__in FILE *fp,__inout struct *buf_s b) {        
-*     fread(&b,b->sz,sizeof(char),fp);                           
-*   }                                                            
+*
+*   // Basic Usage of Struct Annotations
+*   #include <stdio.h>
+*   #include <stdlib.h>
+*   struct buf_s {
+*    int sz;
+*    __field_bcount_full(sz)
+*    char *buf;
+*   };
+*   void InitBuf(__out struct *buf_s b,int sz) {
+*        b->buf = calloc(sz,sizeof(char));
+*        b->sz = sz;
+*   }
+*   void WriteBuf(__in FILE *fp,__in struct *buf_s b) {
+*     fwrite(b->buf,b->sz,sizeof(char),fp);
+*   }
+*   void ReadBuf(__in FILE *fp,__inout struct *buf_s b) {
+*     fread(b->buf,b->sz,sizeof(char),fp);
+*   }
+*
+*
+*
+*   // Inline Allocated Buffer
+*   struct buf_s {
+*    int sz;
+*    __field_bcount(sz)
+*    char buf[1];
+*   };
+*   void WriteBuf(__in FILE *fp,__in struct *buf_s b) {
+*     fwrite(&(b->buf),b->sz,sizeof(char),fp);
+*   }
+*   void ReadBuf(__in FILE *fp,__inout struct *buf_s b) {
+*     fread(&(b->buf),b->sz,sizeof(char),fp);
+*   }
+*
+*
+*
+*   // Embedded Header Structure
+*   __struct_bcount(sz)
+*   struct buf_s {
+*    int sz;
+*   };
+*   void WriteBuf(__in FILE *fp,__in struct *buf_s b) {
+*     fwrite(&b,b->sz,sizeof(char),fp);
+*   }
+*   void ReadBuf(__in FILE *fp,__inout struct *buf_s b) {
+*     fread(&b,b->sz,sizeof(char),fp);
+*   }
 *
 *
 ****************************************************************************/
@@ -832,13 +832,13 @@
 #define __field_bcount_full(size)          __allowed(on_field)
 #define __field_xcount_full(size)          __allowed(on_field)
 #define __field_ecount_full_opt(size)      __allowed(on_field)
-#define __field_bcount_full_opt(size)      __allowed(on_field) 
+#define __field_bcount_full_opt(size)      __allowed(on_field)
 #define __field_xcount_full_opt(size)      __allowed(on_field)
 #define __field_nullterminated             __allowed(on_field)
-#define __struct_bcount(size)              __allowed(on_struct) 
-#define __struct_xcount(size)              __allowed(on_struct) 
+#define __struct_bcount(size)              __allowed(on_struct)
+#define __struct_xcount(size)              __allowed(on_struct)
 
-/*************************************************************************** 
+/***************************************************************************
 * Macros to classify the entrypoints and indicate their category.
 *
 * Pre-defined control point categories include: RPC, KERNEL, GDI.
@@ -846,12 +846,12 @@
 * Pre-defined control point macros include:
 *  __rpc_entry, __kernel_entry, __gdi_entry.
 ***************************************************************************/
-#define __control_entrypoint(category)     __allowed(on_function) 
-#define __rpc_entry                        __allowed(on_function) 
-#define __kernel_entry                     __allowed(on_function) 
-#define __gdi_entry                        __allowed(on_function)  
+#define __control_entrypoint(category)     __allowed(on_function)
+#define __rpc_entry                        __allowed(on_function)
+#define __kernel_entry                     __allowed(on_function)
+#define __gdi_entry                        __allowed(on_function)
 
-/*************************************************************************** 
+/***************************************************************************
 * Macros to track untrusted data and their validation. The list of untrusted
 * sources include:
 *
@@ -860,15 +860,15 @@
 * INTERNET                 - WinInet and WinHttp readers
 * USER_REGISTRY            - HKCU portions of the registry
 * USER_MODE                - Parameters to kernel entry points
-* RPC                      - Parameters to RPC entry points 
-* DRIVER                   - Device driver 
+* RPC                      - Parameters to RPC entry points
+* DRIVER                   - Device driver
 ***************************************************************************/
-#define __in_data_source(src_sym)       __allowed(on_parameter) 
-#define __out_data_source(src_sym)      __allowed(on_parameter) 
+#define __in_data_source(src_sym)       __allowed(on_parameter)
+#define __out_data_source(src_sym)      __allowed(on_parameter)
 #define __field_data_source(src_sym)    __allowed(on_field)
 #define __this_out_data_source(src_syn) __allowed(on_function)
 
-/************************************************************************** 
+/**************************************************************************
 * Macros to tag file parsing code. Predefined formats include:
 *  PNG                     - Portable Network Graphics
 *  JPEG                    - Joint Photographic Experts Group
@@ -888,40 +888,40 @@
 *  AVI                     - Audio Visual Interchange
 *  ACM                     - Audio Compression Manager
 **************************************************************************/
-#define __out_validated(filetype_sym)         __allowed(on_parameter) 
-#define __this_out_validated(filetype_sym)    __allowed(on_function)   
-#define __file_parser(filetype_sym)           __allowed(on_function) 
-#define __file_parser_class(filetype_sym)     __allowed(on_struct)  
-#define __file_parser_library(filetype_sym)   __allowed(as_global_decl)  
+#define __out_validated(filetype_sym)         __allowed(on_parameter)
+#define __this_out_validated(filetype_sym)    __allowed(on_function)
+#define __file_parser(filetype_sym)           __allowed(on_function)
+#define __file_parser_class(filetype_sym)     __allowed(on_struct)
+#define __file_parser_library(filetype_sym)   __allowed(as_global_decl)
 
-/*************************************************************************** 
+/***************************************************************************
 * Macros to track the code content in the file. The type of code
 * contents currently tracked:
 *
-* NDIS_DRIVER                   - NDIS Device driver 
+* NDIS_DRIVER                   - NDIS Device driver
 ***************************************************************************/
-#define __source_code_content(codetype_sym)     __allowed(as_global_decl) 
+#define __source_code_content(codetype_sym)     __allowed(as_global_decl)
 
-/*************************************************************************** 
+/***************************************************************************
 * Macros to track the code content in the class. The type of code
 * contents currently tracked:
 *
 * DCOM                          - Class implementing DCOM
 ***************************************************************************/
-#define __class_code_content(codetype_sym)    __allowed(on_struct) 
+#define __class_code_content(codetype_sym)    __allowed(on_struct)
 
 /*************************************************************************
 * Macros to tag encoded function pointers
 **************************************************************************/
-#define __encoded_pointer                 
-#define __encoded_array                   
+#define __encoded_pointer
+#define __encoded_array
 #define __field_encoded_pointer           __allowed(on_field)
 #define __field_encoded_array             __allowed(on_field)
 
-#define __transfer(formal)                __allowed(on_parameter_or_return) 
+#define __transfer(formal)                __allowed(on_parameter_or_return)
 #define __assume_validated(exp)           __allowed(as_statement_with_arg(exp))
 
-/************************************************************************* 
+/*************************************************************************
 * __analysis_assume(expr) : Expert macro use only when directed. Use this to
 * tell static analysis tools like PREfix and PREfast about a non-coded
 * assumption that you wish the tools to assume. The assumption will be
@@ -938,7 +938,7 @@
 #define __analysis_assume(expr) __allowed(as_statement_with_arg(expr))
 #define __analysis_assert(expr) __allowed(as_statement_with_arg(expr))
 
-/************************************************************************* 
+/*************************************************************************
 * __analysis_hint(hint_sym) : Expert macro use only when
 * directed. Use this to influence certain analysis heuristics
 * used by the tools. These hints do not describe the semantics
@@ -948,13 +948,13 @@
 * Current hints that are supported are:
 *
 * INLINE   - inline this function during analysis overrides any
-*            default heuristics 
-* NOINLINE - do not inline this function during analysis overrides 
+*            default heuristics
+* NOINLINE - do not inline this function during analysis overrides
 *            and default heuristics
 *************************************************************************/
 #define __analysis_hint(hint) __allowed(on_function)
 
-/************************************************************************* 
+/*************************************************************************
 * Macros to encode abstract properties of values. Used by SALadt.h
 *************************************************************************/
 #define __type_has_adt_prop(adt,prop)     __allowed(on_typdecl)
@@ -963,9 +963,9 @@
 #define __out_transfer_adt_prop(arg)      __allowed(on_parameter)
 #define __out_has_type_adt_props(typ)     __allowed(on_parameter)
 
-/************************************************************************* 
-* Macros used by Prefast for Drivers 
-* 
+/*************************************************************************
+* Macros used by Prefast for Drivers
+*
 *  __possibly_notnullterminated :
 *
 *  Used for return values of parameters or functions that do not
@@ -974,18 +974,18 @@
 *************************************************************************/
 #define __possibly_notnullterminated    __allowed(on_parameter_or_return)
 
-/************************************************************************* 
+/*************************************************************************
 * Advanced macros
-* 
-*  __volatile 
+*
+*  __volatile
 * The __volatile annotation identifies a global variable or
-* structure field that: 
-*   1) is not declared volatile; 
+* structure field that:
+*   1) is not declared volatile;
 *   2) is accessed concurrently by multiple threads.
 *
 * The __deref_volatile annotation identifies a global variable
 * or structure field that stores a pointer to some data that:
-*   1) is not declared volatile; 
+*   1) is not declared volatile;
 *   2) is accessed concurrently by multiple threads.
 *
 * Prefast uses these annotations to find patterns of code that
@@ -1005,7 +1005,7 @@
 #define __nonvolatile                    __allowed(on_global_or_field)
 #define __deref_nonvolatile              __allowed(on_global_or_field)
 
-/************************************************************************* 
+/*************************************************************************
 * Macros deprecated with strict level greater then 1.
 **************************************************************************/
 #if (__SPECSTRINGS_STRICT_LEVEL > 1)
@@ -1020,33 +1020,33 @@
 #pragma deprecated(__inout_nz)
 #pragma deprecated(__inout_ecount_nz)
 #pragma deprecated(__inout_bcount_nz)
-#pragma deprecated(__in_nz_opt)          
+#pragma deprecated(__in_nz_opt)
 #pragma deprecated(__in_ecount_nz_opt)
 #pragma deprecated(__in_bcount_nz_opt)
 #pragma deprecated(__out_ecount_nz_opt)
 #pragma deprecated(__out_bcount_nz_opt)
-#pragma deprecated(__inout_nz_opt)       
+#pragma deprecated(__inout_nz_opt)
 #pragma deprecated(__inout_ecount_nz_opt)
 #pragma deprecated(__inout_bcount_nz_opt)
-#pragma deprecated(__deref_out_nz)                 
+#pragma deprecated(__deref_out_nz)
 #pragma deprecated(__deref_out_ecount_nz)
 #pragma deprecated(__deref_out_bcount_nz)
-#pragma deprecated(__deref_inout_nz)               
+#pragma deprecated(__deref_inout_nz)
 #pragma deprecated(__deref_inout_ecount_nz)
 #pragma deprecated(__deref_inout_bcount_nz)
-#pragma deprecated(__deref_out_nz_opt)             
+#pragma deprecated(__deref_out_nz_opt)
 #pragma deprecated(__deref_out_ecount_nz_opt)
 #pragma deprecated(__deref_out_bcount_nz_opt)
-#pragma deprecated(__deref_inout_nz_opt)           
+#pragma deprecated(__deref_inout_nz_opt)
 #pragma deprecated(__deref_inout_ecount_nz_opt)
 #pragma deprecated(__deref_inout_bcount_nz_opt)
-#pragma deprecated(__deref_opt_inout_nz)           
+#pragma deprecated(__deref_opt_inout_nz)
 #pragma deprecated(__deref_opt_inout_ecount_nz)
 #pragma deprecated(__deref_opt_inout_bcount_nz)
-#pragma deprecated(__deref_opt_out_nz_opt)         
+#pragma deprecated(__deref_opt_out_nz_opt)
 #pragma deprecated(__deref_opt_out_ecount_nz_opt)
 #pragma deprecated(__deref_opt_out_bcount_nz_opt)
-#pragma deprecated(__deref_opt_inout_nz_opt)       
+#pragma deprecated(__deref_opt_inout_nz_opt)
 #pragma deprecated(__deref_opt_inout_ecount_nz_opt)
 #pragma deprecated(__deref_opt_inout_bcount_nz_opt)
 #pragma deprecated(__deref)
@@ -1068,52 +1068,52 @@
 #pragma deprecated(__precond)
 #endif
 /* Define soon to be deprecated macros to nops. */
-#define __in_nz                                       
-#define __in_ecount_nz(size)                          
-#define __in_bcount_nz(size)                          
-#define __out_nz                                      
-#define __out_nz_opt                                  
-#define __out_ecount_nz(size)                         
-#define __out_bcount_nz(size)                         
-#define __inout_nz                                    
-#define __inout_ecount_nz(size)                       
-#define __inout_bcount_nz(size)                       
-#define __in_nz_opt                                   
-#define __in_ecount_nz_opt(size)                      
-#define __in_bcount_nz_opt(size)                      
-#define __out_ecount_nz_opt(size)                     
-#define __out_bcount_nz_opt(size)                     
-#define __inout_nz_opt                                
-#define __inout_ecount_nz_opt(size)                   
-#define __inout_bcount_nz_opt(size)                   
-#define __deref_out_nz                                
-#define __deref_out_ecount_nz(size)                   
-#define __deref_out_bcount_nz(size)                   
-#define __deref_inout_nz                              
-#define __deref_inout_ecount_nz(size)                 
-#define __deref_inout_bcount_nz(size)                 
-#define __deref_out_nz_opt                            
-#define __deref_out_ecount_nz_opt(size)               
-#define __deref_out_bcount_nz_opt(size)               
-#define __deref_inout_nz_opt                          
-#define __deref_inout_ecount_nz_opt(size)             
-#define __deref_inout_bcount_nz_opt(size)             
-#define __deref_opt_inout_nz                          
-#define __deref_opt_inout_ecount_nz(size)             
-#define __deref_opt_inout_bcount_nz(size)             
-#define __deref_opt_out_nz_opt                        
-#define __deref_opt_out_ecount_nz_opt(size)           
-#define __deref_opt_out_bcount_nz_opt(size)           
-#define __deref_opt_inout_nz_opt                      
-#define __deref_opt_inout_ecount_nz_opt(size)         
-#define __deref_opt_inout_bcount_nz_opt(size)         
-#define __deref             
-#define __pre               
-#define __post              
-#define __readableTo(count) 
-#define __writableTo(count) 
-#define __maybevalid        
-#define __inexpressible_readableTo(string) 
+#define __in_nz
+#define __in_ecount_nz(size)
+#define __in_bcount_nz(size)
+#define __out_nz
+#define __out_nz_opt
+#define __out_ecount_nz(size)
+#define __out_bcount_nz(size)
+#define __inout_nz
+#define __inout_ecount_nz(size)
+#define __inout_bcount_nz(size)
+#define __in_nz_opt
+#define __in_ecount_nz_opt(size)
+#define __in_bcount_nz_opt(size)
+#define __out_ecount_nz_opt(size)
+#define __out_bcount_nz_opt(size)
+#define __inout_nz_opt
+#define __inout_ecount_nz_opt(size)
+#define __inout_bcount_nz_opt(size)
+#define __deref_out_nz
+#define __deref_out_ecount_nz(size)
+#define __deref_out_bcount_nz(size)
+#define __deref_inout_nz
+#define __deref_inout_ecount_nz(size)
+#define __deref_inout_bcount_nz(size)
+#define __deref_out_nz_opt
+#define __deref_out_ecount_nz_opt(size)
+#define __deref_out_bcount_nz_opt(size)
+#define __deref_inout_nz_opt
+#define __deref_inout_ecount_nz_opt(size)
+#define __deref_inout_bcount_nz_opt(size)
+#define __deref_opt_inout_nz
+#define __deref_opt_inout_ecount_nz(size)
+#define __deref_opt_inout_bcount_nz(size)
+#define __deref_opt_out_nz_opt
+#define __deref_opt_out_ecount_nz_opt(size)
+#define __deref_opt_out_bcount_nz_opt(size)
+#define __deref_opt_inout_nz_opt
+#define __deref_opt_inout_ecount_nz_opt(size)
+#define __deref_opt_inout_bcount_nz_opt(size)
+#define __deref
+#define __pre
+#define __post
+#define __readableTo(count)
+#define __writableTo(count)
+#define __maybevalid
+#define __inexpressible_readableTo(string)
 #define __data_entrypoint(category)
 #define __readonly
 #define __byte_writableTo(count)
@@ -1125,7 +1125,7 @@
 #define __refparam
 #define __precond(condition)
 
-/************************************************************************* 
+/*************************************************************************
 * Definitions to force a compile error when macros are used improperly.
 * Relies on VS 2005 source annotations.
 *************************************************************************/
@@ -1161,7 +1161,7 @@
 #define __$allowed_on_function [method: OnFunctionOnly]
 #define __$allowed_on_struct [OnStructOnly]
 #define __$allowed_on_field [OnFieldOnly]
-#define __$allowed_on_parameter_or_return [OnParameterOrReturnOnly] 
+#define __$allowed_on_parameter_or_return [OnParameterOrReturnOnly]
 #define __$allowed_on_global_or_field /* empty */
 #pragma push_macro( "DECL_SA" )
 #pragma push_macro( "SA" )
@@ -1170,7 +1170,7 @@
 #define DECL_SA(name,loc) \
   [repeatable] \
   [source_annotation_attribute( loc )] \
-  struct name##Attribute { name##Attribute(); const char* ignored; }; 
+  struct name##Attribute { name##Attribute(); const char* ignored; };
 #else
 #define SA(x) SA_##x
 #define DECL_SA(name,loc) \
@@ -1186,6 +1186,6 @@ DECL_SA(OnFieldOnly,SA(Field));
 DECL_SA(OnParameterOrReturnOnly,SA(Parameter) | SA(ReturnValue));
 #pragma pop_macro( "SA" )
 #pragma pop_macro( "DECL_SA" )
-#endif 
-#endif 
+#endif
+#endif
 #endif

--- a/pal/inc/safemath.h
+++ b/pal/inc/safemath.h
@@ -20,11 +20,11 @@
 #define _ASSERTE_SAFEMATH _ASSERTE
 #else
 // Otherwise (eg. we're being used from a tool like SOS) there isn't much
-// we can rely on that is both available everywhere and rotor-safe.  In 
+// we can rely on that is both available everywhere and rotor-safe.  In
 // several other tools we just take the recourse of disabling asserts,
-// we'll do the same here.  
+// we'll do the same here.
 // Ideally we'd have a collection of common utilities available evererywhere.
-#define _ASSERTE_SAFEMATH(a) 
+#define _ASSERTE_SAFEMATH(a)
 #endif
 #endif
 
@@ -153,12 +153,12 @@ inline bool DoubleFitsInIntType(double val)
 // http://msdn.microsoft.com/library/en-us/dncode/html/secure01142004.asp
 //
 // Modified to track an overflow bit instead of throwing exceptions.  In most
-// cases the Visual C++ optimizer (Whidbey beta1 - v14.00.40607) is able to 
+// cases the Visual C++ optimizer (Whidbey beta1 - v14.00.40607) is able to
 // optimize the bool away completely.
 // Note that using a sentinal value (IntMax for example) to represent overflow
 // actually results in poorer code-gen.
 //
-// This has also been simplified significantly to remove functionality we 
+// This has also been simplified significantly to remove functionality we
 // don't currently want (division, implicit conversions, many additional operators etc.)
 //
 // Example:
@@ -171,19 +171,19 @@ inline bool DoubleFitsInIntType(double val)
 //   or:
 //      UINT32 tmp, bufSize;
 //      if( !ClrSafeInt<UINT32>::multiply( elementCount, sizeof(void*), tmp ) ||
-//              !ClrSafeInt<UINT32>::addition( tmp, headerSize, bufSize ) ) 
+//              !ClrSafeInt<UINT32>::addition( tmp, headerSize, bufSize ) )
 //      { <overflow-error> }
 //      else { use bufSize }
-//      
+//
 //-----------------------------------------------------------------------------
 // TODO: Any way to prevent unintended instantiations?  This is only designed to
-//  work with unsigned integral types (signed types will work but we probably 
+//  work with unsigned integral types (signed types will work but we probably
 //  don't need signed support).
 template<typename T> class ClrSafeInt
 {
 public:
     // Default constructor - 0 value by default
-    ClrSafeInt() : 
+    ClrSafeInt() :
         m_value(0),
         m_overflow(false)
         COMMA_INDEBUG( m_checkedOverflow( false ) )
@@ -191,7 +191,7 @@ public:
     }
 
     // Value constructor
-    // This is explicit because otherwise it would be harder to 
+    // This is explicit because otherwise it would be harder to
     // differentiate between checked and unchecked usage of an operator.
     // I.e. si + x + y  vs. si + ( x + y )
     //
@@ -201,7 +201,7 @@ public:
     // be used:
     //      if (val.IsOverflow())
     //          val = ClrSafeInt<T>(some_value);
-    explicit ClrSafeInt( T v ) : 
+    explicit ClrSafeInt( T v ) :
         m_value(v),
         m_overflow(false)
         COMMA_INDEBUG( m_checkedOverflow( true ) )
@@ -242,20 +242,20 @@ public:
 
     // Note: compiler-generated copy constructor and assignment operator
     // are correct for our purposes.
-    
-    // Note: The MS compiler will sometimes silently perform value-destroying 
-    // conversions when calling the operators below.  
+
+    // Note: The MS compiler will sometimes silently perform value-destroying
+    // conversions when calling the operators below.
     // Eg. "ClrSafeInt<unsigned> s(0); s += int(-1);" will result in s
     // having the value 0xffffffff without generating a compile-time warning.
     // Narrowing conversions are generally level 4 warnings so may or may not
     // be visible.
     //
-    // In the original SafeInt class, all operators have an 
-    // additional overload that takes an arbitrary type U and then safe 
+    // In the original SafeInt class, all operators have an
+    // additional overload that takes an arbitrary type U and then safe
     // conversions are performed (resulting in overflow whenever the value
     // cannot be preserved).
-    // We could do the same thing, but currently don't because: 
-    //  - we don't believe there are common cases where this would result in a 
+    // We could do the same thing, but currently don't because:
+    //  - we don't believe there are common cases where this would result in a
     //    security hole.
     //  - the extra complexity isn't worth the benefits
     //  - it would prevent compiler warnings in the cases we do get warnings for.
@@ -271,8 +271,8 @@ public:
         return m_overflow;
     }
 
-    // Get the value of this integer.  
-    // Must only be called when IsOverflow()==false.  If this is called 
+    // Get the value of this integer.
+    // Must only be called when IsOverflow()==false.  If this is called
     // on overflow we'll assert in Debug and return 0 in release.
     inline T Value() const
     {
@@ -281,36 +281,36 @@ public:
         return m_value;
     }
 
-    // force the value into the overflow state.  
+    // force the value into the overflow state.
     inline void SetOverflow()
     {
         INDEBUG( this->m_checkedOverflow = false; )
         this->m_overflow = true;
         // incase someone manages to call Value in release mode - should be optimized out
-        this->m_value = 0;      
+        this->m_value = 0;
     }
 
-    
+
     //
     // OPERATORS
-    // 
+    //
 
     // Addition and multiplication.  Only permitted when both sides are explicitly
-    // wrapped inside of a ClrSafeInt and when the types match exactly.  
+    // wrapped inside of a ClrSafeInt and when the types match exactly.
     // If we permitted a RHS of type 'T', then there would be differences
-    // in correctness between mathematically equivalent expressions such as 
+    // in correctness between mathematically equivalent expressions such as
     // "si + x + y" and "si + ( x + y )".  Unfortunately, not permitting this
     // makes expressions involving constants tedius and ugly since the constants
-    // must be wrapped in ClrSafeInt instances.  If we become confident that 
+    // must be wrapped in ClrSafeInt instances.  If we become confident that
     // our tools (PreFast) will catch all integer overflows, then we can probably
     // safely add this.
     inline ClrSafeInt<T> operator +(ClrSafeInt<T> rhs) const
     {
         ClrSafeInt<T> result;       // value is initialized to 0
         if( this->m_overflow ||
-            rhs.m_overflow || 
+            rhs.m_overflow ||
             !addition( this->m_value, rhs.m_value, result.m_value ) )
-        {           
+        {
             result.m_overflow = true;
         }
 
@@ -321,9 +321,9 @@ public:
     {
         ClrSafeInt<T> result;       // value is initialized to 0
         if( this->m_overflow ||
-            rhs.m_overflow || 
+            rhs.m_overflow ||
             !subtraction( this->m_value, rhs.m_value, result.m_value ) )
-        {           
+        {
             result.m_overflow = true;
         }
 
@@ -334,12 +334,12 @@ public:
     {
         ClrSafeInt<T> result;       // value is initialized to 0
         if( this->m_overflow ||
-            rhs.m_overflow || 
+            rhs.m_overflow ||
             !multiply( this->m_value, rhs.m_value, result.m_value ) )
         {
             result.m_overflow = true;
         }
-        
+
         return result;
     }
 
@@ -349,7 +349,7 @@ public:
     inline ClrSafeInt<T>& operator +=(ClrSafeInt<T> rhs)
     {
         INDEBUG( this->m_checkedOverflow = false; )
-        if( this->m_overflow || 
+        if( this->m_overflow ||
             rhs.m_overflow ||
             !ClrSafeInt<T>::addition( this->m_value, rhs.m_value, this->m_value ) )
         {
@@ -372,7 +372,7 @@ public:
     inline ClrSafeInt<T>& operator *=(ClrSafeInt<T> rhs)
     {
         INDEBUG( this->m_checkedOverflow = false; )
-        if( this->m_overflow || 
+        if( this->m_overflow ||
             rhs.m_overflow ||
             !ClrSafeInt<T>::multiply( this->m_value, rhs.m_value, this->m_value ) )
         {
@@ -395,9 +395,9 @@ public:
 
     //
     // STATIC HELPER METHODS
-    //these compile down to something as efficient as macros and allow run-time testing 
+    //these compile down to something as efficient as macros and allow run-time testing
     //of type by the developer
-    // 
+    //
 
     template <typename U> static bool IsSigned(U)
     {
@@ -449,7 +449,7 @@ public:
     {
         _ASSERTE_SAFEMATH( IsPowerOf2( alignment ) );
         *this += (alignment - 1);
-        if( !this->m_overflow ) 
+        if( !this->m_overflow )
         {
             m_value &= ~(alignment - 1);
         }
@@ -459,7 +459,7 @@ public:
     // Arithmetic implementation functions
     //
 
-    //note - this looks complex, but most of the conditionals 
+    //note - this looks complex, but most of the conditionals
     //are constant and optimize away
     //for example, a signed 64-bit check collapses to:
 /*
@@ -534,11 +534,11 @@ public:
                 {
                     //mixed sign - this case is difficult
                     //test case is lhs * rhs < MinInt => overflow
-                    //if lhs < 0 (implies rhs > 0), 
+                    //if lhs < 0 (implies rhs > 0),
                     //lhs < MinInt/rhs is the correct test
-                    //else if lhs > 0 
+                    //else if lhs > 0
                     //rhs < MinInt/lhs is the correct test
-                    //avoid dividing MinInt by a negative number, 
+                    //avoid dividing MinInt by a negative number,
                     //because MinInt/-1 is a corner case
 
                     if(lhs < 0)
@@ -585,7 +585,7 @@ public:
 
                 //upper 33 bits must be the same
                 //most common case is likely that both are positive - test first
-                if( (tmp & 0xffffffff80000000LL) == 0 || 
+                if( (tmp & 0xffffffff80000000LL) == 0 ||
                     (tmp & 0xffffffff80000000LL) == 0xffffffff80000000LL)
                 {
                     //this is OK
@@ -595,7 +595,7 @@ public:
 
                 //overflow
                 return false;
-                
+
             }
             else
             {
@@ -677,14 +677,14 @@ public:
         if(IsSigned())
         {
             //test for +/- combo
-            if(!IsMixedSign(lhs, rhs)) 
+            if(!IsMixedSign(lhs, rhs))
             {
                 //either two negatives, or 2 positives
 #ifdef __GNUC__
                 // Workaround for GCC warning: "comparison is always
                 // false due to limited range of data type."
                 if (!(rhs == 0 || rhs > 0))
-#else                
+#else
                 if(rhs < 0)
 #endif // __GNUC__ else
                 {
@@ -714,7 +714,7 @@ public:
             if((T)(MaxInt() - lhs) < rhs)
             {
                 return false;
-                
+
             }
             result = lhs + rhs;
             return true;
@@ -759,7 +759,7 @@ public:
                     //or      -X < MinInt() + Y
                     //we do not have the same issues because abs(MinInt()) > MaxInt()
                     //tmp should be LTE lhs
-                    
+
                     //if(lhs < (T)(MinInt() + rhs)) // old test - leave in for clarity
                     if(tmp > lhs)
                     {
@@ -768,7 +768,7 @@ public:
                     //fall through to return value
                 }
             }
-            // else 
+            // else
             //both negative, or both positive
             //no possible overflow
             result = tmp;
@@ -802,10 +802,10 @@ private:
             testPow = testPow << 1;           // advance to next power of 2
             if( testPow <= 0 )
             {
-                return false;       // overflow 
+                return false;       // overflow
             }
         }
-        
+
         return( testPow == x );
     }
 
@@ -819,8 +819,8 @@ private:
     // True if overflow has been reached.  Once this is set, it cannot be cleared.
     bool m_overflow;
 
-    // In debug builds we verify that our caller checked the overflow bit before 
-    // accessing the value.  This flag is cleared on initialization, and whenever 
+    // In debug builds we verify that our caller checked the overflow bit before
+    // accessing the value.  This flag is cleared on initialization, and whenever
     // m_value or m_overflow changes, and set only when IsOverflow
     // is called.
     INDEBUG( mutable bool m_checkedOverflow; )
@@ -839,22 +839,22 @@ ClrSafeInt<T> AsClrSafeInt(ClrSafeInt<T> t)
     return t;
 }
 
-// Convenience safe-integer types.  Currently these are the only types 
+// Convenience safe-integer types.  Currently these are the only types
 // we are using ClrSafeInt with.  We may want to add others.
 // These type names are based on our standardized names in clrtypes.h
 typedef ClrSafeInt<UINT8> S_UINT8;
 typedef ClrSafeInt<UINT16> S_UINT16;
 //typedef ClrSafeInt<UINT32> S_UINT32;
 #define S_UINT32 ClrSafeInt<UINT32>
-typedef ClrSafeInt<UINT64> S_UINT64; 
+typedef ClrSafeInt<UINT64> S_UINT64;
 typedef ClrSafeInt<SIZE_T> S_SIZE_T;
 
 // Note: we can get bogus /Wp64 compiler warnings when S_SIZE_T is used.
-// This is due to VSWhidbey 138322 which the C++ folks have said they can't 
+// This is due to VSWhidbey 138322 which the C++ folks have said they can't
 // currently fix. We can work around the problem by using this macro to force
 // a no-op cast on 32-bit MSVC platforms.  It's not yet clear why we need to
 // use this in some places (specifically, rotor lkgvc builds) and not others.
-// We also make the error less likely by using a #define instead of a 
+// We also make the error less likely by using a #define instead of a
 // typedef for S_UINT32 above since that means we're less likely to instantiate
 // ClrSafeInt<UINT32> AND ClrSafeInt<SIZE_T> in the same compliation unit.
 #if defined(_TARGET_X86_) && defined( _MSC_VER )

--- a/pal/inc/strsafe.h
+++ b/pal/inc/strsafe.h
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -179,7 +179,7 @@ Routine Description:
 
     This routine is not a replacement for strncpy.  That function will pad the
     destination string with extra null termination characters if the count is
-    greater than the length of the source string, and it will fail to null 
+    greater than the length of the source string, and it will fail to null
     terminate the destination string if the source string length is greater
     than or equal to the count. You can not blindly use this instead of strncpy:
     it is common for code to use it to "patch" strings and you would introduce
@@ -200,9 +200,9 @@ Arguments:
 
     pszSrc      -   source string which must be null terminated
 
-Notes: 
+Notes:
     Behavior is undefined if source and destination strings overlap.
-   
+
     pszDest and pszSrc should not be NULL. See StringCchCopyEx if you require
     the handling of NULL values.
 
@@ -214,7 +214,7 @@ Return Value:
     failure     -   you can use the macro HRESULT_CODE() to get a win32 error
                     code for all hresult falure cases
 
-    STRSAFE_E_INSUFFICIENT_BUFFER / 
+    STRSAFE_E_INSUFFICIENT_BUFFER /
     HRESULT_CODE(hr) == ERROR_INSUFFICIENT_BUFFER
                 -   this return value is an indication that the copy operation
                     failed due to insufficient space. When this error occurs,
@@ -289,7 +289,7 @@ Routine Description:
 
     This routine is not a replacement for strncpy.  That function will pad the
     destination string with extra null termination characters if the count is
-    greater than the length of the source string, and it will fail to null 
+    greater than the length of the source string, and it will fail to null
     terminate the destination string if the source string length is greater
     than or equal to the count. You can not blindly use this instead of strncpy:
     it is common for code to use it to "patch" strings and you would introduce
@@ -310,10 +310,10 @@ Arguments:
 
     pszSrc      -   source string which must be null terminated
 
-Notes: 
+Notes:
     Behavior is undefined if source and destination strings overlap.
-   
-    pszDest and pszSrc should not be NULL.  See StringCbCopyEx if you require 
+
+    pszDest and pszSrc should not be NULL.  See StringCbCopyEx if you require
     the handling of NULL values.
 
 Return Value:
@@ -324,7 +324,7 @@ Return Value:
     failure     -   you can use the macro HRESULT_CODE() to get a win32 error
                     code for all hresult falure cases
 
-    STRSAFE_E_INSUFFICIENT_BUFFER / 
+    STRSAFE_E_INSUFFICIENT_BUFFER /
     HRESULT_CODE(hr) == ERROR_INSUFFICIENT_BUFFER
                 -   this return value is an indication that the copy operation
                     failed due to insufficient space. When this error occurs,
@@ -350,7 +350,7 @@ STRSAFEAPI StringCbCopyA(char* pszDest, size_t cbDest, const char* pszSrc)
 {
     HRESULT hr;
     size_t cchDest;
-    
+
     // convert to count of characters
     cchDest = cbDest / sizeof(char);
 
@@ -371,7 +371,7 @@ STRSAFEAPI StringCbCopyW(WCHAR* pszDest, size_t cbDest, const WCHAR* pszSrc)
 {
     HRESULT hr;
     size_t cchDest;
-    
+
     // convert to count of characters
     cchDest = cbDest / sizeof(WCHAR);
 
@@ -442,7 +442,7 @@ Arguments:
         STRSAFE_FILL_ON_FAILURE
                     if the function fails, the low byte of dwFlags will be
                     used to fill all of the destination buffer, and it will
-                    be null terminated. This will overwrite any truncated 
+                    be null terminated. This will overwrite any truncated
                     string returned when the failure is
                     STRSAFE_E_INSUFFICIENT_BUFFER
 
@@ -468,7 +468,7 @@ Return Value:
     failure     -   you can use the macro HRESULT_CODE() to get a win32 error
                     code for all falure cases
 
-    STRSAFE_E_INSUFFICIENT_BUFFER / 
+    STRSAFE_E_INSUFFICIENT_BUFFER /
     HRESULT_CODE(hr) == ERROR_INSUFFICIENT_BUFFER
                 -   this return value is an indication that the copy operation
                     failed due to insufficient space. When this error occurs,
@@ -515,7 +515,7 @@ STRSAFEAPI StringCchCopyExA(char* pszDest, size_t cchDest, const char* pszSrc, c
 STRSAFEAPI StringCchCopyExW(WCHAR* pszDest, size_t cchDest, const WCHAR* pszSrc, WCHAR** ppszDestEnd, size_t* pcchRemaining, unsigned long dwFlags)
 {
     HRESULT hr;
-    
+
     if (cchDest > STRSAFE_MAX_CCH)
     {
         hr = STRSAFE_E_INVALID_PARAMETER;
@@ -551,7 +551,7 @@ Routine Description:
 
     This routine is a safer version of the C built-in function 'strcpy' with
     some additional parameters.  In addition to functionality provided by
-    StringCbCopy, this routine also returns a pointer to the end of the 
+    StringCbCopy, this routine also returns a pointer to the end of the
     destination string and the number of bytes left in the destination string
     including the null terminator. The flags parameter allows additional controls.
 
@@ -560,7 +560,7 @@ Arguments:
     pszDest         -   destination string
 
     cbDest          -   size of destination buffer in bytes.
-                        length must be ((_tcslen(pszSrc) + 1) * sizeof(TCHAR)) to 
+                        length must be ((_tcslen(pszSrc) + 1) * sizeof(TCHAR)) to
                         hold all of the source including the null terminator
 
     pszSrc          -   source string which must be null terminated
@@ -571,7 +571,7 @@ Arguments:
                         null termination character
 
     pcbRemaining    -   pcbRemaining is non-null,the function will return the
-                        number of bytes left in the destination string, 
+                        number of bytes left in the destination string,
                         including the null terminator
 
     dwFlags         -   controls some details of the string copy:
@@ -588,7 +588,7 @@ Arguments:
         STRSAFE_FILL_ON_FAILURE
                     if the function fails, the low byte of dwFlags will be
                     used to fill all of the destination buffer, and it will
-                    be null terminated. This will overwrite any truncated 
+                    be null terminated. This will overwrite any truncated
                     string returned when the failure is
                     STRSAFE_E_INSUFFICIENT_BUFFER
 
@@ -614,7 +614,7 @@ Return Value:
     failure     -   you can use the macro HRESULT_CODE() to get a win32 error
                     code for all falure cases
 
-    STRSAFE_E_INSUFFICIENT_BUFFER / 
+    STRSAFE_E_INSUFFICIENT_BUFFER /
     HRESULT_CODE(hr) == ERROR_INSUFFICIENT_BUFFER
                 -   this return value is an indication that the copy operation
                     failed due to insufficient space. When this error occurs,
@@ -736,9 +736,9 @@ Arguments:
 
     cchSrc      -   maximum number of characters to copy from source string
 
-Notes: 
+Notes:
     Behavior is undefined if source and destination strings overlap.
-   
+
     pszDest and pszSrc should not be NULL. See StringCchCopyNEx if you require
     the handling of NULL values.
 
@@ -750,7 +750,7 @@ Return Value:
     failure     -   you can use the macro HRESULT_CODE() to get a win32 error
                     code for all hresult falure cases
 
-    STRSAFE_E_INSUFFICIENT_BUFFER / 
+    STRSAFE_E_INSUFFICIENT_BUFFER /
     HRESULT_CODE(hr) == ERROR_INSUFFICIENT_BUFFER
                 -   this return value is an indication that the copy operation
                     failed due to insufficient space. When this error occurs,
@@ -794,7 +794,7 @@ STRSAFEAPI StringCchCopyNW(WCHAR* pszDest, size_t cchDest, const WCHAR* pszSrc, 
 {
     HRESULT hr;
 
-    if ((cchDest > STRSAFE_MAX_CCH) || 
+    if ((cchDest > STRSAFE_MAX_CCH) ||
         (cchSrc > STRSAFE_MAX_CCH))
     {
         hr = STRSAFE_E_INVALID_PARAMETER;
@@ -848,10 +848,10 @@ Arguments:
 
     cbSrc       -   maximum number of bytes to copy from source string
 
-Notes: 
+Notes:
     Behavior is undefined if source and destination strings overlap.
-   
-    pszDest and pszSrc should not be NULL.  See StringCbCopyEx if you require 
+
+    pszDest and pszSrc should not be NULL.  See StringCbCopyEx if you require
     the handling of NULL values.
 
 Return Value:
@@ -862,7 +862,7 @@ Return Value:
     failure     -   you can use the macro HRESULT_CODE() to get a win32 error
                     code for all hresult falure cases
 
-    STRSAFE_E_INSUFFICIENT_BUFFER / 
+    STRSAFE_E_INSUFFICIENT_BUFFER /
     HRESULT_CODE(hr) == ERROR_INSUFFICIENT_BUFFER
                 -   this return value is an indication that the copy operation
                     failed due to insufficient space. When this error occurs,
@@ -894,7 +894,7 @@ STRSAFEAPI StringCbCopyNA(char* pszDest, size_t cbDest, const char* pszSrc, size
     cchDest = cbDest / sizeof(char);
     cchSrc = cbSrc / sizeof(char);
 
-    if ((cchDest > STRSAFE_MAX_CCH) || 
+    if ((cchDest > STRSAFE_MAX_CCH) ||
         (cchSrc > STRSAFE_MAX_CCH))
     {
         hr = STRSAFE_E_INVALID_PARAMETER;
@@ -913,7 +913,7 @@ STRSAFEAPI StringCbCopyNW(WCHAR* pszDest, size_t cbDest, const WCHAR* pszSrc, si
     HRESULT hr;
     size_t cchDest;
     size_t cchSrc;
-    
+
     // convert to count of characters
     cchDest = cbDest / sizeof(WCHAR);
     cchSrc = cbSrc / sizeof(WCHAR);
@@ -995,7 +995,7 @@ Arguments:
         STRSAFE_FILL_ON_FAILURE
                     if the function fails, the low byte of dwFlags will be
                     used to fill all of the destination buffer, and it will
-                    be null terminated. This will overwrite any truncated 
+                    be null terminated. This will overwrite any truncated
                     string returned when the failure is
                     STRSAFE_E_INSUFFICIENT_BUFFER
 
@@ -1021,7 +1021,7 @@ Return Value:
     failure     -   you can use the macro HRESULT_CODE() to get a win32 error
                     code for all falure cases
 
-    STRSAFE_E_INSUFFICIENT_BUFFER / 
+    STRSAFE_E_INSUFFICIENT_BUFFER /
     HRESULT_CODE(hr) == ERROR_INSUFFICIENT_BUFFER
                 -   this return value is an indication that the copy operation
                     failed due to insufficient space. When this error occurs,
@@ -1069,7 +1069,7 @@ STRSAFEAPI StringCchCopyNExA(char* pszDest, size_t cchDest, const char* pszSrc, 
 STRSAFEAPI StringCchCopyNExW(WCHAR* pszDest, size_t cchDest, const WCHAR* pszSrc, size_t cchSrc, WCHAR** ppszDestEnd, size_t* pcchRemaining, unsigned long dwFlags)
 {
     HRESULT hr;
-    
+
     if ((cchDest > STRSAFE_MAX_CCH) ||
         (cchSrc > STRSAFE_MAX_CCH))
     {
@@ -1107,7 +1107,7 @@ Routine Description:
 
     This routine is a safer version of the C built-in function 'strncpy' with
     some additional parameters.  In addition to functionality provided by
-    StringCbCopyN, this routine also returns a pointer to the end of the 
+    StringCbCopyN, this routine also returns a pointer to the end of the
     destination string and the number of bytes left in the destination string
     including the null terminator. The flags parameter allows additional controls.
 
@@ -1120,7 +1120,7 @@ Arguments:
     pszDest         -   destination string
 
     cbDest          -   size of destination buffer in bytes.
-                        length must be ((_tcslen(pszSrc) + 1) * sizeof(TCHAR)) to 
+                        length must be ((_tcslen(pszSrc) + 1) * sizeof(TCHAR)) to
                         hold all of the source including the null terminator
 
     pszSrc          -   source string
@@ -1133,7 +1133,7 @@ Arguments:
                         null termination character
 
     pcbRemaining    -   pcbRemaining is non-null,the function will return the
-                        number of bytes left in the destination string, 
+                        number of bytes left in the destination string,
                         including the null terminator
 
     dwFlags         -   controls some details of the string copy:
@@ -1150,7 +1150,7 @@ Arguments:
         STRSAFE_FILL_ON_FAILURE
                     if the function fails, the low byte of dwFlags will be
                     used to fill all of the destination buffer, and it will
-                    be null terminated. This will overwrite any truncated 
+                    be null terminated. This will overwrite any truncated
                     string returned when the failure is
                     STRSAFE_E_INSUFFICIENT_BUFFER
 
@@ -1176,7 +1176,7 @@ Return Value:
     failure     -   you can use the macro HRESULT_CODE() to get a win32 error
                     code for all falure cases
 
-    STRSAFE_E_INSUFFICIENT_BUFFER / 
+    STRSAFE_E_INSUFFICIENT_BUFFER /
     HRESULT_CODE(hr) == ERROR_INSUFFICIENT_BUFFER
                 -   this return value is an indication that the copy operation
                     failed due to insufficient space. When this error occurs,
@@ -1293,14 +1293,14 @@ Arguments:
 
     cchDest     -  size of destination buffer in characters.
                    length must be = (_tcslen(pszDest) + _tcslen(pszSrc) + 1)
-                   to hold all of the combine string plus the null 
+                   to hold all of the combine string plus the null
                    terminator
 
     pszSrc      -  source string which must be null terminated
 
-Notes: 
+Notes:
     Behavior is undefined if source and destination strings overlap.
-   
+
     pszDest and pszSrc should not be NULL.  See StringCchCatEx if you require
     the handling of NULL values.
 
@@ -1312,7 +1312,7 @@ Return Value:
     failure     -   you can use the macro HRESULT_CODE() to get a win32 error
                     code for all falure cases
 
-    STRSAFE_E_INSUFFICIENT_BUFFER / 
+    STRSAFE_E_INSUFFICIENT_BUFFER /
     HRESULT_CODE(hr) == ERROR_INSUFFICIENT_BUFFER
                 -   this return value is an indication that the operation
                     failed due to insufficient space. When this error occurs,
@@ -1396,14 +1396,14 @@ Arguments:
 
     cbDest      -  size of destination buffer in bytes.
                    length must be = ((_tcslen(pszDest) + _tcslen(pszSrc) + 1) * sizeof(TCHAR)
-                   to hold all of the combine string plus the null 
+                   to hold all of the combine string plus the null
                    terminator
 
     pszSrc      -  source string which must be null terminated
 
-Notes: 
+Notes:
     Behavior is undefined if source and destination strings overlap.
-   
+
     pszDest and pszSrc should not be NULL.  See StringCbCatEx if you require
     the handling of NULL values.
 
@@ -1415,7 +1415,7 @@ Return Value:
     failure     -   you can use the macro HRESULT_CODE() to get a win32 error
                     code for all falure cases
 
-    STRSAFE_E_INSUFFICIENT_BUFFER / 
+    STRSAFE_E_INSUFFICIENT_BUFFER /
     HRESULT_CODE(hr) == ERROR_INSUFFICIENT_BUFFER
                 -   this return value is an indication that the operation
                     failed due to insufficient space. When this error occurs,
@@ -1441,7 +1441,7 @@ STRSAFEAPI StringCbCatA(char* pszDest, size_t cbDest, const char* pszSrc)
 {
     HRESULT hr;
     size_t cchDest;
-    
+
     cchDest = cbDest / sizeof(char);
 
     if (cchDest > STRSAFE_MAX_CCH)
@@ -1461,7 +1461,7 @@ STRSAFEAPI StringCbCatW(WCHAR* pszDest, size_t cbDest, const WCHAR* pszSrc)
 {
     HRESULT hr;
     size_t cchDest;
-    
+
     cchDest = cbDest / sizeof(WCHAR);
 
     if (cchDest > STRSAFE_MAX_CCH)
@@ -1491,10 +1491,10 @@ STDAPI StringCchCatEx(LPTSTR pszDest,
                       DWORD dwFlags);
 
 Routine Description:
-    
+
     This routine is a safer version of the C built-in function 'strcat' with
     some additional parameters.  In addition to functionality provided by
-    StringCchCat, this routine also returns a pointer to the end of the 
+    StringCchCat, this routine also returns a pointer to the end of the
     destination string and the number of characters left in the destination string
     including the null terminator. The flags parameter allows additional controls.
 
@@ -1560,7 +1560,7 @@ Return Value:
     failure     -   you can use the macro HRESULT_CODE() to get a win32 error
                     code for all falure cases
 
-    STRSAFE_E_INSUFFICIENT_BUFFER / 
+    STRSAFE_E_INSUFFICIENT_BUFFER /
     HRESULT_CODE(hr) == ERROR_INSUFFICIENT_BUFFER
                 -   this return value is an indication that the operation
                     failed due to insufficient space. When this error occurs,
@@ -1607,7 +1607,7 @@ STRSAFEAPI StringCchCatExA(char* pszDest, size_t cchDest, const char* pszSrc, ch
 STRSAFEAPI StringCchCatExW(WCHAR* pszDest, size_t cchDest, const WCHAR* pszSrc, WCHAR** ppszDestEnd, size_t* pcchRemaining, unsigned long dwFlags)
 {
     HRESULT hr;
-    
+
     if (cchDest > STRSAFE_MAX_CCH)
     {
         hr = STRSAFE_E_INVALID_PARAMETER;
@@ -1643,7 +1643,7 @@ Routine Description:
 
     This routine is a safer version of the C built-in function 'strcat' with
     some additional parameters.  In addition to functionality provided by
-    StringCbCat, this routine also returns a pointer to the end of the 
+    StringCbCat, this routine also returns a pointer to the end of the
     destination string and the number of bytes left in the destination string
     including the null terminator. The flags parameter allows additional controls.
 
@@ -1652,7 +1652,7 @@ Arguments:
     pszDest         -   destination string which must be null terminated
 
     cbDest          -   size of destination buffer in bytes.
-                        length must be ((_tcslen(pszDest) + _tcslen(pszSrc) + 1) * sizeof(TCHAR) 
+                        length must be ((_tcslen(pszDest) + _tcslen(pszSrc) + 1) * sizeof(TCHAR)
                         to hold all of the combine string plus the null
                         terminator.
 
@@ -1663,7 +1663,7 @@ Arguments:
                         function appended any data, the result will point to the
                         null termination character
 
-    pcbRemaining    -   if pcbRemaining is non-null, the function will return 
+    pcbRemaining    -   if pcbRemaining is non-null, the function will return
                         the number of bytes left in the destination string,
                         including the null terminator
 
@@ -1709,7 +1709,7 @@ Return Value:
     failure     -   you can use the macro HRESULT_CODE() to get a win32 error
                     code for all falure cases
 
-    STRSAFE_E_INSUFFICIENT_BUFFER / 
+    STRSAFE_E_INSUFFICIENT_BUFFER /
     HRESULT_CODE(hr) == ERROR_INSUFFICIENT_BUFFER
                 -   this return value is an indication that the operation
                     failed due to insufficient space. When this error occurs,
@@ -1837,14 +1837,14 @@ Notes:
 
 Return Value:
 
-    S_OK        -   if all of pszSrc or the first cchMaxAppend characters were 
+    S_OK        -   if all of pszSrc or the first cchMaxAppend characters were
                     concatenated to pszDest and the resultant dest string was
                     null terminated
 
     failure     -   you can use the macro HRESULT_CODE() to get a win32 error
                     code for all falure cases
 
-    STRSAFE_E_INSUFFICIENT_BUFFER / 
+    STRSAFE_E_INSUFFICIENT_BUFFER /
     HRESULT_CODE(hr) == ERROR_INSUFFICIENT_BUFFER
                 -   this return value is an indication that the operation
                     failed due to insufficient space. When this error occurs,
@@ -1886,7 +1886,7 @@ STRSAFEAPI StringCchCatNA(char* pszDest, size_t cchDest, const char* pszSrc, siz
 STRSAFEAPI StringCchCatNW(WCHAR* pszDest, size_t cchDest, const WCHAR* pszSrc, size_t cchMaxAppend)
 {
     HRESULT hr;
-    
+
     if (cchDest > STRSAFE_MAX_CCH)
     {
         hr = STRSAFE_E_INVALID_PARAMETER;
@@ -1930,7 +1930,7 @@ Arguments:
     pszDest         -   destination string which must be null terminated
 
     cbDest          -   size of destination buffer in bytes.
-                        length must be ((_tcslen(pszDest) + min(cbMaxAppend / sizeof(TCHAR), _tcslen(pszSrc)) + 1) * sizeof(TCHAR) 
+                        length must be ((_tcslen(pszDest) + min(cbMaxAppend / sizeof(TCHAR), _tcslen(pszSrc)) + 1) * sizeof(TCHAR)
                         to hold all of the combine string plus the null
                         terminator.
 
@@ -1946,14 +1946,14 @@ Notes:
 
 Return Value:
 
-    S_OK        -   if all of pszSrc or the first cbMaxAppend bytes were 
+    S_OK        -   if all of pszSrc or the first cbMaxAppend bytes were
                     concatenated to pszDest and the resultant dest string was
                     null terminated
 
     failure     -   you can use the macro HRESULT_CODE() to get a win32 error
                     code for all falure cases
 
-    STRSAFE_E_INSUFFICIENT_BUFFER / 
+    STRSAFE_E_INSUFFICIENT_BUFFER /
     HRESULT_CODE(hr) == ERROR_INSUFFICIENT_BUFFER
                 -   this return value is an indication that the operation
                     failed due to insufficient space. When this error occurs,
@@ -1989,7 +1989,7 @@ STRSAFEAPI StringCbCatNA(char* pszDest, size_t cbDest, const char* pszSrc, size_
     else
     {
         size_t cchMaxAppend;
-        
+
         cchMaxAppend = cbMaxAppend / sizeof(char);
 
         hr = StringCatNWorkerA(pszDest, cchDest, pszSrc, cchMaxAppend);
@@ -2038,10 +2038,10 @@ STDAPI StringCchCatNEx(LPTSTR pszDest,
                        DWORD dwFlags);
 
 Routine Description:
- 
-    This routine is a safer version of the C built-in function 'strncat', with 
+
+    This routine is a safer version of the C built-in function 'strncat', with
     some additional parameters.  In addition to functionality provided by
-    StringCchCatN, this routine also returns a pointer to the end of the 
+    StringCchCatN, this routine also returns a pointer to the end of the
     destination string and the number of characters left in the destination string
     including the null terminator. The flags parameter allows additional controls.
 
@@ -2102,14 +2102,14 @@ Notes:
 
 Return Value:
 
-    S_OK        -   if all of pszSrc or the first cchMaxAppend characters were 
+    S_OK        -   if all of pszSrc or the first cchMaxAppend characters were
                     concatenated to pszDest and the resultant dest string was
                     null terminated
 
     failure     -   you can use the macro HRESULT_CODE() to get a win32 error
                     code for all falure cases
 
-    STRSAFE_E_INSUFFICIENT_BUFFER / 
+    STRSAFE_E_INSUFFICIENT_BUFFER /
     HRESULT_CODE(hr) == ERROR_INSUFFICIENT_BUFFER
                 -   this return value is an indication that the operation
                     failed due to insufficient space. When this error occurs,
@@ -2156,7 +2156,7 @@ STRSAFEAPI StringCchCatNExA(char* pszDest, size_t cchDest, const char* pszSrc, s
 STRSAFEAPI StringCchCatNExW(WCHAR* pszDest, size_t cchDest, const WCHAR* pszSrc, size_t cchMaxAppend, WCHAR** ppszDestEnd, size_t* pcchRemaining, unsigned long dwFlags)
 {
     HRESULT hr;
-    
+
     if (cchDest > STRSAFE_MAX_CCH)
     {
         hr = STRSAFE_E_INVALID_PARAMETER;
@@ -2190,10 +2190,10 @@ STDAPI StringCbCatNEx(LPTSTR pszDest,
                       DWORD dwFlags);
 
 Routine Description:
-    
-    This routine is a safer version of the C built-in function 'strncat', with 
+
+    This routine is a safer version of the C built-in function 'strncat', with
     some additional parameters.  In addition to functionality provided by
-    StringCbCatN, this routine also returns a pointer to the end of the 
+    StringCbCatN, this routine also returns a pointer to the end of the
     destination string and the number of bytes left in the destination string
     including the null terminator. The flags parameter allows additional controls.
 
@@ -2202,7 +2202,7 @@ Arguments:
     pszDest         -   destination string which must be null terminated
 
     cbDest          -   size of destination buffer in bytes.
-                        length must be ((_tcslen(pszDest) + min(cbMaxAppend / sizeof(TCHAR), _tcslen(pszSrc)) + 1) * sizeof(TCHAR) 
+                        length must be ((_tcslen(pszDest) + min(cbMaxAppend / sizeof(TCHAR), _tcslen(pszSrc)) + 1) * sizeof(TCHAR)
                         to hold all of the combine string plus the null
                         terminator.
 
@@ -2254,14 +2254,14 @@ Notes:
 
 Return Value:
 
-    S_OK        -   if all of pszSrc or the first cbMaxAppend bytes were 
+    S_OK        -   if all of pszSrc or the first cbMaxAppend bytes were
                     concatenated to pszDest and the resultant dest string was
                     null terminated
 
     failure     -   you can use the macro HRESULT_CODE() to get a win32 error
                     code for all falure cases
 
-    STRSAFE_E_INSUFFICIENT_BUFFER / 
+    STRSAFE_E_INSUFFICIENT_BUFFER /
     HRESULT_CODE(hr) == ERROR_INSUFFICIENT_BUFFER
                 -   this return value is an indication that the operation
                     failed due to insufficient space. When this error occurs,
@@ -2298,7 +2298,7 @@ STRSAFEAPI StringCbCatNExA(char* pszDest, size_t cbDest, const char* pszSrc, siz
     else
     {
         size_t cchMaxAppend;
-        
+
         cchMaxAppend = cbMaxAppend / sizeof(char);
 
         hr = StringCatNExWorkerA(pszDest, cchDest, cbDest, pszSrc, cchMaxAppend, ppszDestEnd, &cchRemaining, dwFlags);
@@ -2332,7 +2332,7 @@ STRSAFEAPI StringCbCatNExW(WCHAR* pszDest, size_t cbDest, const WCHAR* pszSrc, s
     else
     {
         size_t cchMaxAppend;
-        
+
         cchMaxAppend = cbMaxAppend / sizeof(WCHAR);
 
         hr = StringCatNExWorkerW(pszDest, cchDest, cbDest, pszSrc, cchMaxAppend, ppszDestEnd, &cchRemaining, dwFlags);
@@ -2387,10 +2387,10 @@ Arguments:
     argList     -  va_list from the variable arguments according to the
                    stdarg.h convention
 
-Notes: 
+Notes:
     Behavior is undefined if destination, format strings or any arguments
     strings overlap.
-   
+
     pszDest and pszFormat should not be NULL.  See StringCchVPrintfEx if you
     require the handling of NULL values.
 
@@ -2402,7 +2402,7 @@ Return Value:
     failure     -   you can use the macro HRESULT_CODE() to get a win32 error
                     code for all falure cases
 
-    STRSAFE_E_INSUFFICIENT_BUFFER / 
+    STRSAFE_E_INSUFFICIENT_BUFFER /
     HRESULT_CODE(hr) == ERROR_INSUFFICIENT_BUFFER
                 -   this return value is an indication that the print operation
                     failed due to insufficient space. When this error occurs,
@@ -2494,10 +2494,10 @@ Arguments:
     argList     -  va_list from the variable arguments according to the
                    stdarg.h convention
 
-Notes: 
+Notes:
     Behavior is undefined if destination, format strings or any arguments
     strings overlap.
-   
+
     pszDest and pszFormat should not be NULL.  See StringCbVPrintfEx if you
     require the handling of NULL values.
 
@@ -2510,7 +2510,7 @@ Return Value:
     failure     -   you can use the macro HRESULT_CODE() to get a win32 error
                     code for all falure cases
 
-    STRSAFE_E_INSUFFICIENT_BUFFER / 
+    STRSAFE_E_INSUFFICIENT_BUFFER /
     HRESULT_CODE(hr) == ERROR_INSUFFICIENT_BUFFER
                 -   this return value is an indication that the print operation
                     failed due to insufficient space. When this error occurs,
@@ -2608,10 +2608,10 @@ Arguments:
     ...         -  additional parameters to be formatted according to
                    the format string
 
-Notes: 
+Notes:
     Behavior is undefined if destination, format strings or any arguments
     strings overlap.
-   
+
     pszDest and pszFormat should not be NULL.  See StringCchPrintfEx if you
     require the handling of NULL values.
 
@@ -2623,7 +2623,7 @@ Return Value:
     failure     -   you can use the macro HRESULT_CODE() to get a win32 error
                     code for all falure cases
 
-    STRSAFE_E_INSUFFICIENT_BUFFER / 
+    STRSAFE_E_INSUFFICIENT_BUFFER /
     HRESULT_CODE(hr) == ERROR_INSUFFICIENT_BUFFER
                 -   this return value is an indication that the print operation
                     failed due to insufficient space. When this error occurs,
@@ -2660,7 +2660,7 @@ STRSAFEAPI StringCchPrintfA(char* pszDest, size_t cchDest, const char* pszFormat
         va_start(argList, pszFormat);
 
         hr = StringVPrintfWorkerA(pszDest, cchDest, pszFormat, argList);
-        
+
         va_end(argList);
     }
 
@@ -2683,7 +2683,7 @@ STRSAFEAPI StringCchPrintfW(WCHAR* pszDest, size_t cchDest, const WCHAR* pszForm
         va_start(argList, pszFormat);
 
         hr = StringVPrintfWorkerW(pszDest, cchDest, pszFormat, argList);
-    
+
         va_end(argList);
     }
 
@@ -2727,10 +2727,10 @@ Arguments:
     ...         -  additional parameters to be formatted according to
                    the format string
 
-Notes: 
+Notes:
     Behavior is undefined if destination, format strings or any arguments
     strings overlap.
-   
+
     pszDest and pszFormat should not be NULL.  See StringCbPrintfEx if you
     require the handling of NULL values.
 
@@ -2743,7 +2743,7 @@ Return Value:
     failure     -   you can use the macro HRESULT_CODE() to get a win32 error
                     code for all falure cases
 
-    STRSAFE_E_INSUFFICIENT_BUFFER / 
+    STRSAFE_E_INSUFFICIENT_BUFFER /
     HRESULT_CODE(hr) == ERROR_INSUFFICIENT_BUFFER
                 -   this return value is an indication that the print operation
                     failed due to insufficient space. When this error occurs,
@@ -2769,7 +2769,7 @@ STRSAFEAPI StringCbPrintfA(char* pszDest, size_t cbDest, const char* pszFormat, 
 {
     HRESULT hr;
     size_t cchDest;
-    
+
     cchDest = cbDest / sizeof(char);
 
     if (cchDest > STRSAFE_MAX_CCH)
@@ -2781,7 +2781,7 @@ STRSAFEAPI StringCbPrintfA(char* pszDest, size_t cbDest, const char* pszFormat, 
         va_list argList;
 
         va_start(argList, pszFormat);
-   
+
         hr = StringVPrintfWorkerA(pszDest, cchDest, pszFormat, argList);
 
         va_end(argList);
@@ -2795,7 +2795,7 @@ STRSAFEAPI StringCbPrintfW(WCHAR* pszDest, size_t cbDest, const WCHAR* pszFormat
 {
     HRESULT hr;
     size_t cchDest;
-    
+
     cchDest = cbDest / sizeof(WCHAR);
 
     if (cchDest > STRSAFE_MAX_CCH)
@@ -2807,7 +2807,7 @@ STRSAFEAPI StringCbPrintfW(WCHAR* pszDest, size_t cbDest, const WCHAR* pszFormat
         va_list argList;
 
         va_start(argList, pszFormat);
-    
+
         hr = StringVPrintfWorkerW(pszDest, cchDest, pszFormat, argList);
 
         va_end(argList);
@@ -2835,7 +2835,7 @@ Routine Description:
 
     This routine is a safer version of the C built-in function 'sprintf' with
     some additional parameters.  In addition to functionality provided by
-    StringCchPrintf, this routine also returns a pointer to the end of the 
+    StringCchPrintf, this routine also returns a pointer to the end of the
     destination string and the number of characters left in the destination string
     including the null terminator. The flags parameter allows additional controls.
 
@@ -2852,7 +2852,7 @@ Arguments:
                         function printed any data, the result will point to the
                         null termination character
 
-    pcchRemaining   -   if pcchRemaining is non-null, the function will return 
+    pcchRemaining   -   if pcchRemaining is non-null, the function will return
                         the number of characters left in the destination string,
                         including the null terminator
 
@@ -2869,7 +2869,7 @@ Arguments:
         STRSAFE_FILL_ON_FAILURE
                     if the function fails, the low byte of dwFlags will be
                     used to fill all of the destination buffer, and it will
-                    be null terminated. This will overwrite any truncated 
+                    be null terminated. This will overwrite any truncated
                     string returned when the failure is
                     STRSAFE_E_INSUFFICIENT_BUFFER
 
@@ -2901,7 +2901,7 @@ Return Value:
     failure     -   you can use the macro HRESULT_CODE() to get a win32 error
                     code for all falure cases
 
-    STRSAFE_E_INSUFFICIENT_BUFFER / 
+    STRSAFE_E_INSUFFICIENT_BUFFER /
     HRESULT_CODE(hr) == ERROR_INSUFFICIENT_BUFFER
                 -   this return value is an indication that the print operation
                     failed due to insufficient space. When this error occurs,
@@ -2941,7 +2941,7 @@ STRSAFEAPI StringCchPrintfExA(char* pszDest, size_t cchDest, char** ppszDestEnd,
         va_start(argList, pszFormat);
 
         hr = StringVPrintfExWorkerA(pszDest, cchDest, cbDest, ppszDestEnd, pcchRemaining, dwFlags, pszFormat, argList);
-        
+
         va_end(argList);
     }
 
@@ -2967,7 +2967,7 @@ STRSAFEAPI StringCchPrintfExW(WCHAR* pszDest, size_t cchDest, WCHAR** ppszDestEn
         va_start(argList, pszFormat);
 
         hr = StringVPrintfExWorkerW(pszDest, cchDest, cbDest, ppszDestEnd, pcchRemaining, dwFlags, pszFormat, argList);
-    
+
         va_end(argList);
     }
 
@@ -2993,7 +2993,7 @@ Routine Description:
 
     This routine is a safer version of the C built-in function 'sprintf' with
     some additional parameters.  In addition to functionality provided by
-    StringCbPrintf, this routine also returns a pointer to the end of the 
+    StringCbPrintf, this routine also returns a pointer to the end of the
     destination string and the number of bytes left in the destination string
     including the null terminator. The flags parameter allows additional controls.
 
@@ -3010,7 +3010,7 @@ Arguments:
                         function printed any data, the result will point to the
                         null termination character
 
-    pcbRemaining    -   if pcbRemaining is non-null, the function will return 
+    pcbRemaining    -   if pcbRemaining is non-null, the function will return
                         the number of bytes left in the destination string,
                         including the null terminator
 
@@ -3027,7 +3027,7 @@ Arguments:
         STRSAFE_FILL_ON_FAILURE
                     if the function fails, the low byte of dwFlags will be
                     used to fill all of the destination buffer, and it will
-                    be null terminated. This will overwrite any truncated 
+                    be null terminated. This will overwrite any truncated
                     string returned when the failure is
                     STRSAFE_E_INSUFFICIENT_BUFFER
 
@@ -3059,7 +3059,7 @@ Return Value:
     failure     -   you can use the macro HRESULT_CODE() to get a win32 error
                     code for all falure cases
 
-    STRSAFE_E_INSUFFICIENT_BUFFER / 
+    STRSAFE_E_INSUFFICIENT_BUFFER /
     HRESULT_CODE(hr) == ERROR_INSUFFICIENT_BUFFER
                 -   this return value is an indication that the print operation
                     failed due to insufficient space. When this error occurs,
@@ -3100,7 +3100,7 @@ STRSAFEAPI StringCbPrintfExA(char* pszDest, size_t cbDest, char** ppszDestEnd, s
         va_start(argList, pszFormat);
 
         hr = StringVPrintfExWorkerA(pszDest, cchDest, cbDest, ppszDestEnd, &cchRemaining, dwFlags, pszFormat, argList);
-    
+
         va_end(argList);
     }
 
@@ -3136,7 +3136,7 @@ STRSAFEAPI StringCbPrintfExW(WCHAR* pszDest, size_t cbDest, WCHAR** ppszDestEnd,
         va_start(argList, pszFormat);
 
         hr = StringVPrintfExWorkerW(pszDest, cchDest, cbDest, ppszDestEnd, &cchRemaining, dwFlags, pszFormat, argList);
-    
+
         va_end(argList);
     }
 
@@ -3171,7 +3171,7 @@ Routine Description:
 
     This routine is a safer version of the C built-in function 'vsprintf' with
     some additional parameters.  In addition to functionality provided by
-    StringCchVPrintf, this routine also returns a pointer to the end of the 
+    StringCchVPrintf, this routine also returns a pointer to the end of the
     destination string and the number of characters left in the destination string
     including the null terminator. The flags parameter allows additional controls.
 
@@ -3183,9 +3183,9 @@ Arguments:
                         length must be sufficient to contain the resulting
                         formatted string plus the null terminator.
 
-    ppszDestEnd     -   if ppszDestEnd is non-null, the function will return a 
-                        pointer to the end of the destination string.  If the 
-                        function printed any data, the result will point to the 
+    ppszDestEnd     -   if ppszDestEnd is non-null, the function will return a
+                        pointer to the end of the destination string.  If the
+                        function printed any data, the result will point to the
                         null termination character
 
     pcchRemaining   -   if pcchRemaining is non-null, the function will return
@@ -3205,7 +3205,7 @@ Arguments:
         STRSAFE_FILL_ON_FAILURE
                     if the function fails, the low byte of dwFlags will be
                     used to fill all of the destination buffer, and it will
-                    be null terminated. This will overwrite any truncated 
+                    be null terminated. This will overwrite any truncated
                     string returned when the failure is
                     STRSAFE_E_INSUFFICIENT_BUFFER
 
@@ -3237,7 +3237,7 @@ Return Value:
     failure     -   you can use the macro HRESULT_CODE() to get a win32 error
                     code for all falure cases
 
-    STRSAFE_E_INSUFFICIENT_BUFFER / 
+    STRSAFE_E_INSUFFICIENT_BUFFER /
     HRESULT_CODE(hr) == ERROR_INSUFFICIENT_BUFFER
                 -   this return value is an indication that the print operation
                     failed due to insufficient space. When this error occurs,
@@ -3273,7 +3273,7 @@ STRSAFEAPI StringCchVPrintfExA(char* pszDest, size_t cchDest, char** ppszDestEnd
 
         // safe to multiply cchDest * sizeof(char) since cchDest < STRSAFE_MAX_CCH and sizeof(char) is 1
         cbDest = cchDest * sizeof(char);
-        
+
         hr = StringVPrintfExWorkerA(pszDest, cchDest, cbDest, ppszDestEnd, pcchRemaining, dwFlags, pszFormat, argList);
     }
 
@@ -3321,7 +3321,7 @@ Routine Description:
 
     This routine is a safer version of the C built-in function 'vsprintf' with
     some additional parameters.  In addition to functionality provided by
-    StringCbVPrintf, this routine also returns a pointer to the end of the 
+    StringCbVPrintf, this routine also returns a pointer to the end of the
     destination string and the number of characters left in the destination string
     including the null terminator. The flags parameter allows additional controls.
 
@@ -3333,7 +3333,7 @@ Arguments:
                         length must be sufficient to contain the resulting
                         formatted string plus the null terminator.
 
-    ppszDestEnd     -   if ppszDestEnd is non-null, the function will return 
+    ppszDestEnd     -   if ppszDestEnd is non-null, the function will return
                         a pointer to the end of the destination string.  If the
                         function printed any data, the result will point to the
                         null termination character
@@ -3355,7 +3355,7 @@ Arguments:
         STRSAFE_FILL_ON_FAILURE
                     if the function fails, the low byte of dwFlags will be
                     used to fill all of the destination buffer, and it will
-                    be null terminated. This will overwrite any truncated 
+                    be null terminated. This will overwrite any truncated
                     string returned when the failure is
                     STRSAFE_E_INSUFFICIENT_BUFFER
 
@@ -3387,7 +3387,7 @@ Return Value:
     failure     -   you can use the macro HRESULT_CODE() to get a win32 error
                     code for all falure cases
 
-    STRSAFE_E_INSUFFICIENT_BUFFER / 
+    STRSAFE_E_INSUFFICIENT_BUFFER /
     HRESULT_CODE(hr) == ERROR_INSUFFICIENT_BUFFER
                 -   this return value is an indication that the print operation
                     failed due to insufficient space. When this error occurs,
@@ -3444,7 +3444,7 @@ STRSAFEAPI StringCbVPrintfExW(WCHAR* pszDest, size_t cbDest, WCHAR** ppszDestEnd
     HRESULT hr;
     size_t cchDest;
     size_t cchRemaining = 0;
-    
+
     cchDest = cbDest / sizeof(WCHAR);
 
     if (cchDest > STRSAFE_MAX_CCH)
@@ -3498,8 +3498,8 @@ Arguments:
 
     cchDest     -   size of destination buffer in characters.
 
-Notes: 
-    pszDest should not be NULL. See StringCchGetsEx if you require the handling 
+Notes:
+    pszDest should not be NULL. See StringCchGetsEx if you require the handling
     of NULL values.
 
     cchDest must be > 1 for this function to succeed.
@@ -3516,7 +3516,7 @@ Return Value:
                 -   this return value indicates an error or end-of-file condition,
                     use feof or ferror to determine which one has occurred.
 
-    STRSAFE_E_INSUFFICIENT_BUFFER / 
+    STRSAFE_E_INSUFFICIENT_BUFFER /
     HRESULT_CODE(hr) == ERROR_INSUFFICIENT_BUFFER
                 -   this return value is an indication that there was insufficient
                     space in the destination buffer to copy any data
@@ -3547,7 +3547,7 @@ STRSAFE_INLINE_API StringCchGetsA(char* pszDest, size_t cchDest)
     else
     {
         size_t cbDest;
-        
+
         // safe to multiply cchDest * sizeof(char) since cchDest < STRSAFE_MAX_CCH and sizeof(char) is 1
         cbDest = cchDest * sizeof(char);
 
@@ -3569,7 +3569,7 @@ STRSAFE_INLINE_API StringCchGetsW(WCHAR* pszDest, size_t cchDest)
     else
     {
         size_t cbDest;
-        
+
         // safe to multiply cchDest * sizeof(WCHAR) since cchDest < STRSAFE_MAX_CCH and sizeof(WCHAR) is 2
         cbDest = cchDest * sizeof(WCHAR);
 
@@ -3609,8 +3609,8 @@ Arguments:
 
     cbDest      -   size of destination buffer in bytes.
 
-Notes: 
-    pszDest should not be NULL. See StringCbGetsEx if you require the handling 
+Notes:
+    pszDest should not be NULL. See StringCbGetsEx if you require the handling
     of NULL values.
 
     cbDest must be > sizeof(TCHAR) for this function to succeed.
@@ -3627,7 +3627,7 @@ Return Value:
                 -   this return value indicates an error or end-of-file condition,
                     use feof or ferror to determine which one has occurred.
 
-    STRSAFE_E_INSUFFICIENT_BUFFER / 
+    STRSAFE_E_INSUFFICIENT_BUFFER /
     HRESULT_CODE(hr) == ERROR_INSUFFICIENT_BUFFER
                 -   this return value is an indication that there was insufficient
                     space in the destination buffer to copy any data
@@ -3651,7 +3651,7 @@ STRSAFE_INLINE_API StringCbGetsA(char* pszDest, size_t cbDest)
 {
     HRESULT hr;
     size_t cchDest;
-    
+
     // convert to count of characters
     cchDest = cbDest / sizeof(char);
 
@@ -3672,7 +3672,7 @@ STRSAFE_INLINE_API StringCbGetsW(WCHAR* pszDest, size_t cbDest)
 {
     HRESULT hr;
     size_t cchDest;
-    
+
     // convert to count of characters
     cchDest = cbDest / sizeof(WCHAR);
 
@@ -3714,7 +3714,7 @@ Arguments:
     pszDest         -   destination string
 
     cchDest         -   size of destination buffer in characters.
-                     
+
     ppszDestEnd     -   if ppszDestEnd is non-null, the function will return a
                         pointer to the end of the destination string.  If the
                         function copied any data, the result will point to the
@@ -3742,11 +3742,11 @@ Arguments:
         STRSAFE_NO_TRUNCATION /
         STRSAFE_NULL_ON_FAILURE
                     if the function fails, the destination buffer will be set
-                    to the empty string. 
-                    
+                    to the empty string.
+
 Notes:
     pszDest should not be NULL unless the STRSAFE_IGNORE_NULLS flag is specified.
-    If STRSAFE_IGNORE_NULLS is passed and pszDest is NULL, an error may still be 
+    If STRSAFE_IGNORE_NULLS is passed and pszDest is NULL, an error may still be
     returned even though NULLS are ignored
 
     cchDest must be > 1 for this function to succeed.
@@ -3763,7 +3763,7 @@ Return Value:
                 -   this return value indicates an error or end-of-file condition,
                     use feof or ferror to determine which one has occurred.
 
-    STRSAFE_E_INSUFFICIENT_BUFFER / 
+    STRSAFE_E_INSUFFICIENT_BUFFER /
     HRESULT_CODE(hr) == ERROR_INSUFFICIENT_BUFFER
                 -   this return value is an indication that there was insufficient
                     space in the destination buffer to copy any data
@@ -3794,7 +3794,7 @@ STRSAFE_INLINE_API StringCchGetsExA(char* pszDest, size_t cchDest, char** ppszDe
     else
     {
         size_t cbDest;
-        
+
         // safe to multiply cchDest * sizeof(char) since cchDest < STRSAFE_MAX_CCH and sizeof(char) is 1
         cbDest = cchDest * sizeof(char);
 
@@ -3816,7 +3816,7 @@ STRSAFE_INLINE_API StringCchGetsExW(WCHAR* pszDest, size_t cchDest, WCHAR** ppsz
     else
     {
         size_t cbDest;
-        
+
         // safe to multiply cchDest * sizeof(WCHAR) since cchDest < STRSAFE_MAX_CCH and sizeof(WCHAR) is 2
         cbDest = cchDest * sizeof(WCHAR);
 
@@ -3852,7 +3852,7 @@ Arguments:
     pszDest         -   destination string
 
     cbDest          -   size of destination buffer in bytes.
-                     
+
     ppszDestEnd     -   if ppszDestEnd is non-null, the function will return a
                         pointer to the end of the destination string.  If the
                         function copied any data, the result will point to the
@@ -3880,11 +3880,11 @@ Arguments:
         STRSAFE_NO_TRUNCATION /
         STRSAFE_NULL_ON_FAILURE
                     if the function fails, the destination buffer will be set
-                    to the empty string. 
-                    
+                    to the empty string.
+
 Notes:
     pszDest should not be NULL unless the STRSAFE_IGNORE_NULLS flag is specified.
-    If STRSAFE_IGNORE_NULLS is passed and pszDest is NULL, an error may still be 
+    If STRSAFE_IGNORE_NULLS is passed and pszDest is NULL, an error may still be
     returned even though NULLS are ignored
 
     cbDest must be > sizeof(TCHAR) for this function to succeed
@@ -3901,7 +3901,7 @@ Return Value:
                 -   this return value indicates an error or end-of-file condition,
                     use feof or ferror to determine which one has occurred.
 
-    STRSAFE_E_INSUFFICIENT_BUFFER / 
+    STRSAFE_E_INSUFFICIENT_BUFFER /
     HRESULT_CODE(hr) == ERROR_INSUFFICIENT_BUFFER
                 -   this return value is an indication that there was insufficient
                     space in the destination buffer to copy any data
@@ -4017,7 +4017,7 @@ Arguments:
                     in characters of psz excluding the null terminator will be returned.
                     This out parameter is equivalent to the return value of strlen(psz)
 
-Notes: 
+Notes:
     psz can be null but the function will fail
 
     cchMax should be greater than zero or the function will fail
@@ -4047,7 +4047,7 @@ STRSAFEAPI StringCchLengthW(const WCHAR* psz, size_t cchMax, size_t* pcch);
 STRSAFEAPI StringCchLengthA(const char* psz, size_t cchMax, size_t* pcch)
 {
     HRESULT hr;
-    
+
     if ((psz == NULL) || (cchMax > STRSAFE_MAX_CCH))
     {
         hr = STRSAFE_E_INVALID_PARAMETER;
@@ -4092,7 +4092,7 @@ Routine Description:
 
     This routine is a safer version of the C built-in function 'strlen'.
     It is used to make sure a string is not larger than a given length, and
-    it optionally returns the current length in bytes not including 
+    it optionally returns the current length in bytes not including
     the null terminator.
 
     This function returns a hresult, and not a pointer.  It returns a S_OK
@@ -4110,7 +4110,7 @@ Arguments:
                     in bytes of psz excluding the null terminator will be returned.
                     This out parameter is equivalent to the return value of strlen(psz) * sizeof(TCHAR)
 
-Notes: 
+Notes:
     psz can be null but the function will fail
 
     cbMax should be greater than or equal to sizeof(TCHAR) or the function will fail
@@ -4266,7 +4266,7 @@ STRSAFEAPI StringCopyExWorkerA(char* pszDest, size_t cchDest, size_t cbDest, con
 
     // ASSERT(cbDest == (cchDest * sizeof(char))    ||
     //        cbDest == (cchDest * sizeof(char)) + (cbDest % sizeof(char)));
- 
+
     // only accept valid flags
     if (dwFlags & (~STRSAFE_VALID_FLAGS))
     {
@@ -4321,7 +4321,7 @@ STRSAFEAPI StringCopyExWorkerA(char* pszDest, size_t cchDest, size_t cbDest, con
                     *pszDestEnd++= *pszSrc++;
                     cchRemaining--;
                 }
-    
+
                 if (cchRemaining > 0)
                 {
                     if (dwFlags & STRSAFE_FILL_BEHIND_NULL)
@@ -4350,7 +4350,7 @@ STRSAFEAPI StringCopyExWorkerA(char* pszDest, size_t cchDest, size_t cbDest, con
             if (dwFlags & STRSAFE_FILL_ON_FAILURE)
             {
                 memset(pszDest, STRSAFE_GET_FILL_PATTERN(dwFlags), cbDest);
-            
+
                 if (STRSAFE_GET_FILL_PATTERN(dwFlags) == 0)
                 {
                     pszDestEnd = pszDest;
@@ -4382,7 +4382,7 @@ STRSAFEAPI StringCopyExWorkerA(char* pszDest, size_t cchDest, size_t cbDest, con
 
     if (SUCCEEDED(hr) || (hr == STRSAFE_E_INSUFFICIENT_BUFFER))
     {
-        if (ppszDestEnd) 
+        if (ppszDestEnd)
         {
             *ppszDestEnd = pszDestEnd;
         }
@@ -4405,7 +4405,7 @@ STRSAFEAPI StringCopyExWorkerW(WCHAR* pszDest, size_t cchDest, size_t cbDest, co
 
     // ASSERT(cbDest == (cchDest * sizeof(WCHAR)) ||
     //        cbDest == (cchDest * sizeof(WCHAR)) + (cbDest % sizeof(WCHAR)));
- 
+
     // only accept valid flags
     if (dwFlags & (~STRSAFE_VALID_FLAGS))
     {
@@ -4460,7 +4460,7 @@ STRSAFEAPI StringCopyExWorkerW(WCHAR* pszDest, size_t cchDest, size_t cbDest, co
                     *pszDestEnd++= *pszSrc++;
                     cchRemaining--;
                 }
-    
+
                 if (cchRemaining > 0)
                 {
                     if (dwFlags & STRSAFE_FILL_BEHIND_NULL)
@@ -4489,7 +4489,7 @@ STRSAFEAPI StringCopyExWorkerW(WCHAR* pszDest, size_t cchDest, size_t cbDest, co
             if (dwFlags & STRSAFE_FILL_ON_FAILURE)
             {
                 memset(pszDest, STRSAFE_GET_FILL_PATTERN(dwFlags), cbDest);
-                           
+
                 if (STRSAFE_GET_FILL_PATTERN(dwFlags) == 0)
                 {
                     pszDestEnd = pszDest;
@@ -4521,7 +4521,7 @@ STRSAFEAPI StringCopyExWorkerW(WCHAR* pszDest, size_t cchDest, size_t cbDest, co
 
     if (SUCCEEDED(hr) || (hr == STRSAFE_E_INSUFFICIENT_BUFFER))
     {
-        if (ppszDestEnd) 
+        if (ppszDestEnd)
         {
             *ppszDestEnd = pszDestEnd;
         }
@@ -4608,7 +4608,7 @@ STRSAFEAPI StringCopyNExWorkerA(char* pszDest, size_t cchDest, size_t cbDest, co
 
     // ASSERT(cbDest == (cchDest * sizeof(char))    ||
     //        cbDest == (cchDest * sizeof(char)) + (cbDest % sizeof(char)));
- 
+
     // only accept valid flags
     if (dwFlags & (~STRSAFE_VALID_FLAGS))
     {
@@ -4664,7 +4664,7 @@ STRSAFEAPI StringCopyNExWorkerA(char* pszDest, size_t cchDest, size_t cbDest, co
                     cchRemaining--;
                     cchSrc--;
                 }
-    
+
                 if (cchRemaining > 0)
                 {
                     if (dwFlags & STRSAFE_FILL_BEHIND_NULL)
@@ -4693,7 +4693,7 @@ STRSAFEAPI StringCopyNExWorkerA(char* pszDest, size_t cchDest, size_t cbDest, co
             if (dwFlags & STRSAFE_FILL_ON_FAILURE)
             {
                 memset(pszDest, STRSAFE_GET_FILL_PATTERN(dwFlags), cbDest);
-            
+
                 if (STRSAFE_GET_FILL_PATTERN(dwFlags) == 0)
                 {
                     pszDestEnd = pszDest;
@@ -4725,7 +4725,7 @@ STRSAFEAPI StringCopyNExWorkerA(char* pszDest, size_t cchDest, size_t cbDest, co
 
     if (SUCCEEDED(hr) || (hr == STRSAFE_E_INSUFFICIENT_BUFFER))
     {
-        if (ppszDestEnd) 
+        if (ppszDestEnd)
         {
             *ppszDestEnd = pszDestEnd;
         }
@@ -4748,7 +4748,7 @@ STRSAFEAPI StringCopyNExWorkerW(WCHAR* pszDest, size_t cchDest, size_t cbDest, c
 
     // ASSERT(cbDest == (cchDest * sizeof(WCHAR)) ||
     //        cbDest == (cchDest * sizeof(WCHAR)) + (cbDest % sizeof(WCHAR)));
- 
+
     // only accept valid flags
     if (dwFlags & (~STRSAFE_VALID_FLAGS))
     {
@@ -4804,7 +4804,7 @@ STRSAFEAPI StringCopyNExWorkerW(WCHAR* pszDest, size_t cchDest, size_t cbDest, c
                     cchRemaining--;
                     cchSrc--;
                 }
-    
+
                 if (cchRemaining > 0)
                 {
                     if (dwFlags & STRSAFE_FILL_BEHIND_NULL)
@@ -4833,7 +4833,7 @@ STRSAFEAPI StringCopyNExWorkerW(WCHAR* pszDest, size_t cchDest, size_t cbDest, c
             if (dwFlags & STRSAFE_FILL_ON_FAILURE)
             {
                 memset(pszDest, STRSAFE_GET_FILL_PATTERN(dwFlags), cbDest);
-            
+
                 if (STRSAFE_GET_FILL_PATTERN(dwFlags) == 0)
                 {
                     pszDestEnd = pszDest;
@@ -4865,7 +4865,7 @@ STRSAFEAPI StringCopyNExWorkerW(WCHAR* pszDest, size_t cchDest, size_t cbDest, c
 
     if (SUCCEEDED(hr) || (hr == STRSAFE_E_INSUFFICIENT_BUFFER))
     {
-        if (ppszDestEnd) 
+        if (ppszDestEnd)
         {
             *ppszDestEnd = pszDestEnd;
         }
@@ -5006,7 +5006,7 @@ STRSAFEAPI StringCatExWorkerA(char* pszDest, size_t cchDest, size_t cbDest, cons
             }
         }
     }
-    
+
     if (FAILED(hr))
     {
         if (pszDest)
@@ -5049,7 +5049,7 @@ STRSAFEAPI StringCatExWorkerA(char* pszDest, size_t cchDest, size_t cbDest, cons
 
     if (SUCCEEDED(hr) || (hr == STRSAFE_E_INSUFFICIENT_BUFFER))
     {
-        if (ppszDestEnd) 
+        if (ppszDestEnd)
         {
             *ppszDestEnd = pszDestEnd;
         }
@@ -5150,7 +5150,7 @@ STRSAFEAPI StringCatExWorkerW(WCHAR* pszDest, size_t cchDest, size_t cbDest, con
                                          pszSrc,
                                          &pszDestEnd,
                                          &cchRemaining,
-                                         dwFlags & (~(STRSAFE_FILL_ON_FAILURE | STRSAFE_NULL_ON_FAILURE)));            
+                                         dwFlags & (~(STRSAFE_FILL_ON_FAILURE | STRSAFE_NULL_ON_FAILURE)));
             }
         }
     }
@@ -5164,7 +5164,7 @@ STRSAFEAPI StringCatExWorkerW(WCHAR* pszDest, size_t cchDest, size_t cbDest, con
             if (dwFlags & STRSAFE_FILL_ON_FAILURE)
             {
                 memset(pszDest, STRSAFE_GET_FILL_PATTERN(dwFlags), cbDest);
-            
+
                 if (STRSAFE_GET_FILL_PATTERN(dwFlags) == 0)
                 {
                     pszDestEnd = pszDest;
@@ -5196,7 +5196,7 @@ STRSAFEAPI StringCatExWorkerW(WCHAR* pszDest, size_t cchDest, size_t cbDest, con
 
     if (SUCCEEDED(hr) || (hr == STRSAFE_E_INSUFFICIENT_BUFFER))
     {
-        if (ppszDestEnd) 
+        if (ppszDestEnd)
         {
             *ppszDestEnd = pszDestEnd;
         }
@@ -5224,7 +5224,7 @@ STRSAFEAPI StringCatNWorkerA(char* pszDest, size_t cchDest, const char* pszSrc, 
                                 cchDest - cchDestCurrent,
                                 pszSrc,
                                 cchMaxAppend);
-    }    
+    }
 
     return hr;
 }
@@ -5594,7 +5594,7 @@ STRSAFEAPI StringVPrintfWorkerW(WCHAR* pszDest, size_t cchDest, const WCHAR* psz
         // can not null terminate a zero-byte dest buffer
         hr = STRSAFE_E_INVALID_PARAMETER;
     }
-    else    
+    else
     {
         int iRet;
         size_t cchMax;
@@ -5658,7 +5658,7 @@ STRSAFEAPI StringVPrintfExWorkerA(char* pszDest, size_t cchDest, size_t cbDest, 
                 pszFormat = "";
             }
         }
-    
+
         if (SUCCEEDED(hr))
         {
             if (cchDest == 0)
@@ -5764,7 +5764,7 @@ STRSAFEAPI StringVPrintfExWorkerA(char* pszDest, size_t cchDest, size_t cbDest, 
 
     if (SUCCEEDED(hr) || (hr == STRSAFE_E_INSUFFICIENT_BUFFER))
     {
-        if (ppszDestEnd) 
+        if (ppszDestEnd)
         {
             *ppszDestEnd = pszDestEnd;
         }
@@ -5877,7 +5877,7 @@ STRSAFEAPI StringVPrintfExWorkerW(WCHAR* pszDest, size_t cchDest, size_t cbDest,
             }
         }
     }
-    
+
     if (FAILED(hr))
     {
         if (pszDest)
@@ -5917,7 +5917,7 @@ STRSAFEAPI StringVPrintfExWorkerW(WCHAR* pszDest, size_t cchDest, size_t cbDest,
 
     if (SUCCEEDED(hr) || (hr == STRSAFE_E_INSUFFICIENT_BUFFER))
     {
-        if (ppszDestEnd) 
+        if (ppszDestEnd)
         {
             *ppszDestEnd = pszDestEnd;
         }
@@ -6075,7 +6075,7 @@ STRSAFE_INLINE_API StringGetsExWorkerA(char* pszDest, size_t cchDest, size_t cbD
             if (dwFlags & STRSAFE_FILL_ON_FAILURE)
             {
                 memset(pszDest, STRSAFE_GET_FILL_PATTERN(dwFlags), cbDest);
-            
+
                 if (STRSAFE_GET_FILL_PATTERN(dwFlags) == 0)
                 {
                     pszDestEnd = pszDest;

--- a/pal/inc/type_traits
+++ b/pal/inc/type_traits
@@ -374,7 +374,7 @@ namespace std
 
 // In PAL, we define long as int and so this becomes int double,
 // which is a nonsense
-#ifndef FEATURE_PAL  
+#ifndef FEATURE_PAL
     template<>
     struct _Is_floating_point<long double>
         : true_type
@@ -463,7 +463,7 @@ namespace std
         };
 
         template <class T>
-        struct conversion<T, T>    
+        struct conversion<T, T>
         {
             static const bool exists = true;
             static const bool exists2Way = true;
@@ -471,7 +471,7 @@ namespace std
         };
 
         template <class T>
-        struct conversion<void, T>    
+        struct conversion<void, T>
         {
             static const bool exists = false;
             static const bool exists2Way = false;
@@ -479,7 +479,7 @@ namespace std
         };
 
         template <class T>
-        struct conversion<T, void>    
+        struct conversion<T, void>
         {
             static const bool exists = false;
             static const bool exists2Way = false;
@@ -487,7 +487,7 @@ namespace std
         };
 
         template <>
-        struct conversion<void, void>    
+        struct conversion<void, void>
         {
             static const bool exists = true;
             static const bool exists2Way = true;
@@ -532,7 +532,7 @@ namespace std
                 std::is_same<typename std::remove_cv<T>::type, wchar_t>::value,
             std::true_type,
             std::false_type>::type
-        
+
     { };
 
 } // namespace std
@@ -547,4 +547,3 @@ namespace std
 #define REF_CT(T)       REM_REF(REM_CONST(T)) const &
 
 #endif // __clr_std_type_traits_h__
-

--- a/pal/inc/unixasmmacrosamd64.inc
+++ b/pal/inc/unixasmmacrosamd64.inc
@@ -121,16 +121,16 @@ C_FUNC(\Name\()_End):
 .macro save_xmm128_postrsp Reg, Offset
         __Offset = \Offset
         movdqa  xmmword ptr [rsp + __Offset], \Reg
-        // NOTE: We cannot use ".cfi_rel_offset \Reg, __Offset" here, 
+        // NOTE: We cannot use ".cfi_rel_offset \Reg, __Offset" here,
         // the xmm registers are not supported by the libunwind
 .endm
 
 .macro restore_xmm128 Reg, ofs
         __Offset = \ofs
         movdqa          \Reg, xmmword ptr [rsp + __Offset]
-        // NOTE: We cannot use ".cfi_restore \Reg" here, 
+        // NOTE: We cannot use ".cfi_restore \Reg" here,
         // the xmm registers are not supported by the libunwind
-        
+
 .endm
 
 .macro PUSH_CALLEE_SAVED_REGISTERS

--- a/pal/inc/volatile.h
+++ b/pal/inc/volatile.h
@@ -4,55 +4,55 @@
 //
 //
 // Volatile.h
-// 
+//
 
-// 
+//
 // Defines the Volatile<T> type, which provides uniform volatile-ness on
 // Visual C++ and GNU C++.
-// 
+//
 // Visual C++ treats accesses to volatile variables as follows: no read or write
 // can be removed by the compiler, no global memory access can be moved backwards past
 // a volatile read, and no global memory access can be moved forward past a volatile
 // write.
-// 
-// The GCC volatile semantic is straight out of the C standard: the compiler is not 
-// allowed to remove accesses to volatile variables, and it is not allowed to reorder 
-// volatile accesses relative to other volatile accesses.  It is allowed to freely 
+//
+// The GCC volatile semantic is straight out of the C standard: the compiler is not
+// allowed to remove accesses to volatile variables, and it is not allowed to reorder
+// volatile accesses relative to other volatile accesses.  It is allowed to freely
 // reorder non-volatile accesses relative to volatile accesses.
 //
-// We have lots of code that assumes that ordering of non-volatile accesses will be 
-// constrained relative to volatile accesses.  For example, this pattern appears all 
+// We have lots of code that assumes that ordering of non-volatile accesses will be
+// constrained relative to volatile accesses.  For example, this pattern appears all
 // over the place:
 //
 //     static volatile int lock = 0;
 //
-//     while (InterlockedCompareExchange(&lock, 0, 1)) 
+//     while (InterlockedCompareExchange(&lock, 0, 1))
 //     {
 //         //spin
 //     }
-//                
+//
 //     //read and write variables protected by the lock
 //
 //     lock = 0;
 //
-// This depends on the reads and writes in the critical section not moving past the 
-// final statement, which releases the lock.  If this should happen, then you have an 
+// This depends on the reads and writes in the critical section not moving past the
+// final statement, which releases the lock.  If this should happen, then you have an
 // unintended race.
-// 
+//
 // The solution is to ban the use of the "volatile" keyword, and instead define our
 // own type Volatile<T>, which acts like a variable of type T except that accesses to
 // the variable are always given VC++'s volatile semantics.
-// 
-// (NOTE: The code above is not intended to be an example of how a spinlock should be 
-// implemented; it has many flaws, and should not be used. This code is intended only 
+//
+// (NOTE: The code above is not intended to be an example of how a spinlock should be
+// implemented; it has many flaws, and should not be used. This code is intended only
 // to illustrate where we might get into trouble with GCC's volatile semantics.)
-// 
-// @TODO: many of the variables marked volatile in the CLR do not actually need to be 
+//
+// @TODO: many of the variables marked volatile in the CLR do not actually need to be
 // volatile.  For example, if a variable is just always passed to Interlocked functions
-// (such as a refcount variable), there is no need for it to be volatile.  A future 
+// (such as a refcount variable), there is no need for it to be volatile.  A future
 // cleanup task should be to examine each volatile variable and make them non-volatile
 // if possible.
-// 
+//
 // @TODO: link to a "Memory Models for CLR Devs" doc here (this doc does not yet exist).
 //
 
@@ -65,10 +65,10 @@
 // #endif
 
 //
-// This code is extremely compiler- and CPU-specific, and will need to be altered to 
+// This code is extremely compiler- and CPU-specific, and will need to be altered to
 // support new compilers and/or CPUs.  Here we enforce that we can only compile using
 // VC++, or GCC on x86 or AMD64.
-// 
+//
 #if !defined(_MSC_VER) && !defined(__GNUC__)
 #error The Volatile type is currently only defined for Visual C++ and GNU C++
 #endif
@@ -84,12 +84,12 @@
 #else
 //
 // For GCC, we prevent reordering by the compiler by inserting the following after a volatile
-// load (to prevent subsequent operations from moving before the read), and before a volatile 
+// load (to prevent subsequent operations from moving before the read), and before a volatile
 // write (to prevent prior operations from moving past the write).  We don't need to do anything
 // special to prevent CPU reorderings, because the x86 and AMD64 architectures are already
 // sufficiently constrained for our purposes.  If we ever need to run on weaker CPU architectures
 // (such as PowerPC), then we will need to do more work.
-// 
+//
 // Please do not use this macro outside of this file.  It is subject to change or removal without
 // notice.
 //
@@ -103,7 +103,7 @@
 #define VOLATILE_MEMORY_BARRIER() MemoryBarrier()
 #else
 //
-// On VC++, reorderings at the compiler and machine level are prevented by the use of the 
+// On VC++, reorderings at the compiler and machine level are prevented by the use of the
 // "volatile" keyword in VolatileLoad and VolatileStore.  This should work on any CPU architecture
 // targeted by VC++ with /iso_volatile-.
 //
@@ -176,15 +176,15 @@ void VolatileStoreWithoutBarrier(T* pt, T val)
 
 //
 // Volatile<T> implements accesses with our volatile semantics over a variable of type T.
-// Wherever you would have used a "volatile Foo" or, equivalently, "Foo volatile", use Volatile<Foo> 
+// Wherever you would have used a "volatile Foo" or, equivalently, "Foo volatile", use Volatile<Foo>
 // instead.  If Foo is a pointer type, use VolatilePtr.
-// 
+//
 // Note that there are still some things that don't work with a Volatile<T>,
 // that would have worked with a "volatile T".  For example, you can't cast a Volatile<int> to a float.
 // You must instead cast to an int, then to a float.  Or you can call Load on the Volatile<int>, and
-// cast the result to a float.  In general, calling Load or Store explicitly will work around 
+// cast the result to a float.  In general, calling Load or Store explicitly will work around
 // any problems that can't be solved by operator overloading.
-// 
+//
 // @TODO: it's not clear that we actually *want* any operator overloading here.  It's in here primarily
 // to ease the task of converting all of the old uses of the volatile keyword, but in the long
 // run it's probably better if users of this class are forced to call Load() and Store() explicitly.
@@ -204,7 +204,7 @@ public:
     //
     // Default constructor.  Results in an unitialized value!
     //
-    inline Volatile() 
+    inline Volatile()
     {
         // STATIC_CONTRACT_SUPPORTS_DAC;
     }
@@ -212,7 +212,7 @@ public:
     //
     // Allow initialization of Volatile<T> from a T
     //
-    inline Volatile(const T& val) 
+    inline Volatile(const T& val)
     {
         // STATIC_CONTRACT_SUPPORTS_DAC;
         ((volatile T &)m_val) = val;
@@ -249,7 +249,7 @@ public:
     // Stores a new value to the volatile variable.  See code:VolatileStore for the semantics of this
     // operation.
     //
-    inline void Store(const T& val) 
+    inline void Store(const T& val)
     {
         // STATIC_CONTRACT_SUPPORTS_DAC;
         VolatileStore(&m_val, val);
@@ -284,7 +284,7 @@ public:
     // Allow casts from Volatile<T> to T.  Note that this allows implicit casts, so you can
     // pass a Volatile<T> directly to a method that expects a T.
     //
-    inline operator T() const 
+    inline operator T() const
     {
         // STATIC_CONTRACT_SUPPORTS_DAC;
         return this->Load();
@@ -296,10 +296,10 @@ public:
     inline Volatile<T>& operator=(T val) {Store(val); return *this;}
 
     //
-    // Get the address of the volatile variable.  This is dangerous, as it allows the value of the 
+    // Get the address of the volatile variable.  This is dangerous, as it allows the value of the
     // volatile variable to be accessed directly, without going through Load and Store, but it is
     // necessary for passing Volatile<T> to APIs like InterlockedIncrement.  Note that we are returning
-    // a pointer to a volatile T here, so we cannot accidentally pass this pointer to an API that 
+    // a pointer to a volatile T here, so we cannot accidentally pass this pointer to an API that
     // expects a normal pointer.
     //
     inline T volatile * operator&() {return this->GetPointer();}
@@ -351,7 +351,7 @@ public:
 //
 // A VolatilePtr builds on Volatile<T> by adding operators appropriate to pointers.
 // Wherever you would have used "Foo * volatile", use "VolatilePtr<Foo>" instead.
-// 
+//
 // VolatilePtr also allows the substution of other types for the underlying pointer.  This
 // allows you to wrap a VolatilePtr around a custom type that looks like a pointer.  For example,
 // if what you want is a "volatile DPTR<Foo>", use "VolatilePtr<Foo, DPTR<Foo>>".
@@ -363,7 +363,7 @@ public:
     //
     // Default constructor.  Results in an uninitialized pointer!
     //
-    inline VolatilePtr() 
+    inline VolatilePtr()
     {
         // STATIC_CONTRACT_SUPPORTS_DAC;
     }
@@ -371,7 +371,7 @@ public:
     //
     // Allow assignment from the pointer type.
     //
-    inline VolatilePtr(P val) : Volatile<P>(val) 
+    inline VolatilePtr(P val) : Volatile<P>(val)
     {
         // STATIC_CONTRACT_SUPPORTS_DAC;
     }
@@ -379,7 +379,7 @@ public:
     //
     // Copy constructor
     //
-    inline VolatilePtr(const VolatilePtr& other) : Volatile<P>(other) 
+    inline VolatilePtr(const VolatilePtr& other) : Volatile<P>(other)
     {
         // STATIC_CONTRACT_SUPPORTS_DAC;
     }
@@ -387,7 +387,7 @@ public:
     //
     // Cast to the pointer type
     //
-    inline operator P() const 
+    inline operator P() const
     {
         // STATIC_CONTRACT_SUPPORTS_DAC;
         return (P)this->Load();
@@ -396,7 +396,7 @@ public:
     //
     // Member access
     //
-    inline P operator->() const 
+    inline P operator->() const
     {
         // STATIC_CONTRACT_SUPPORTS_DAC;
         return (P)this->Load();
@@ -405,7 +405,7 @@ public:
     //
     // Dereference the pointer
     //
-    inline T& operator*() const 
+    inline T& operator*() const
     {
         // STATIC_CONTRACT_SUPPORTS_DAC;
         return *(P)this->Load();
@@ -415,7 +415,7 @@ public:
     // Access the pointer as an array
     //
     template <typename TIndex>
-    inline T& operator[](TIndex index) 
+    inline T& operator[](TIndex index)
     {
         // STATIC_CONTRACT_SUPPORTS_DAC;
         return ((P)this->Load())[index];
@@ -425,11 +425,11 @@ public:
 
 //
 // Warning: workaround
-// 
+//
 // At the bottom of this file, we are going to #define the "volatile" keyword such that it is illegal
 // to use it.  Unfortunately, VC++ uses the volatile keyword in stddef.h, in the definition of "offsetof".
 // GCC does not use volatile in its definition.
-// 
+//
 // To get around this, we include stddef.h here (even if we're on GCC, for consistency).  We then need
 // to redefine offsetof such that it does not use volatile, if we're building with VC++.
 //

--- a/pal/src/CMakeLists.txt
+++ b/pal/src/CMakeLists.txt
@@ -159,7 +159,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL Linux)
       unwind-x86_64
     )
   endif()
-    
+
   target_link_libraries(Chakra.Pal
     gcc_s
     pthread

--- a/pal/src/arch/i386/context2.S
+++ b/pal/src/arch/i386/context2.S
@@ -47,16 +47,16 @@ LEAF_ENTRY CONTEXT_CaptureContext, _TEXT
     mov     [rdi + CONTEXT_R12], r12
     mov     [rdi + CONTEXT_R13], r13
     mov     [rdi + CONTEXT_R14], r14
-    mov     [rdi + CONTEXT_R15], r15   
+    mov     [rdi + CONTEXT_R15], r15
 LOCAL_LABEL(Done_CONTEXT_INTEGER):
 
     test    BYTE PTR [rdi + CONTEXT_ContextFlags], CONTEXT_CONTROL
     je      LOCAL_LABEL(Done_CONTEXT_CONTROL)
-    
+
     // Return address is @ (RSP + 8)
     mov     rdx, [rsp + 8]
     mov     [rdi + CONTEXT_Rip], rdx
-.att_syntax 
+.att_syntax
     mov     %cs, CONTEXT_SegCs(%rdi)
 .intel_syntax noprefix
     // Get the value of EFlags that was pushed on stack at the beginning of the function
@@ -64,7 +64,7 @@ LOCAL_LABEL(Done_CONTEXT_INTEGER):
     mov     [rdi + CONTEXT_EFlags], edx
     lea     rdx, [rsp + 16]
     mov     [rdi + CONTEXT_Rsp], rdx
-.att_syntax 
+.att_syntax
     mov     %ss, CONTEXT_SegSs(%rdi)
 .intel_syntax noprefix
 LOCAL_LABEL(Done_CONTEXT_CONTROL):
@@ -105,7 +105,7 @@ LEAF_END RtlCaptureContext, _TEXT
 LEAF_ENTRY RtlRestoreContext, _TEXT
     push_nonvol_reg rbp
     alloc_stack (IRetFrameLengthAligned)
-    
+
     test    BYTE PTR [rdi + CONTEXT_ContextFlags], CONTEXT_DEBUG_REGISTERS
     je      LOCAL_LABEL(Done_Restore_CONTEXT_DEBUG_REGISTERS)
     mov     rdx, [rdi + CONTEXT_Dr0]
@@ -133,15 +133,15 @@ LOCAL_LABEL(Done_Restore_CONTEXT_FLOATING_POINT):
     // The control registers are restored via the iret instruction
     // so we build the frame for the iret on the stack.
 #ifdef __APPLE__
-.att_syntax 
+.att_syntax
     // On OSX, we cannot read SS via the thread_get_context and RtlRestoreContext
-    // needs to be used on context extracted by thread_get_context. So we 
+    // needs to be used on context extracted by thread_get_context. So we
     // don't change the SS.
     mov     %ss, %ax
 .intel_syntax noprefix
-#else    
+#else
     mov     ax, [rdi + CONTEXT_SegSs]
-#endif    
+#endif
     mov     [rsp + IRETFRAME_SegSs], ax
     mov     rax, [rdi + CONTEXT_Rsp]
     mov     [rsp + IRETFRAME_Rsp], rax
@@ -170,7 +170,7 @@ LOCAL_LABEL(Done_Restore_CONTEXT_CONTROL):
     mov     r12, [rdi + CONTEXT_R12]
     mov     r13, [rdi + CONTEXT_R13]
     mov     r14, [rdi + CONTEXT_R14]
-    mov     r15, [rdi + CONTEXT_R15]   
+    mov     r15, [rdi + CONTEXT_R15]
     mov     rdi, [rdi + CONTEXT_Rdi]
 LOCAL_LABEL(Done_Restore_CONTEXT_INTEGER):
 
@@ -178,9 +178,9 @@ LOCAL_LABEL(Done_Restore_CONTEXT_INTEGER):
     pop_eflags
     je      LOCAL_LABEL(No_Restore_CONTEXT_CONTROL)
     // The function was asked to restore the control registers, so
-    // we perform iretq that restores them all. 
+    // we perform iretq that restores them all.
     // We don't return to the caller in this case.
-    iretq 
+    iretq
 LOCAL_LABEL(No_Restore_CONTEXT_CONTROL):
 
     // The function was not asked to restore the control registers

--- a/pal/src/arch/i386/debugbreak.S
+++ b/pal/src/arch/i386/debugbreak.S
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 .intel_syntax noprefix
@@ -10,4 +10,3 @@ LEAF_ENTRY DBG_DebugBreak, _TEXT
         int3
         ret
 LEAF_END DBG_DebugBreak, _TEXT
-

--- a/pal/src/arch/i386/processor.cpp
+++ b/pal/src/arch/i386/processor.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -42,4 +42,3 @@ YieldProcessor(
         "nop"
     );
 }
-

--- a/pal/src/configure.cmake
+++ b/pal/src/configure.cmake
@@ -943,7 +943,7 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
   else()
     message(FATAL_ERROR "Cannot find libc on this system.")
   endif()
-  
+
 elseif(CMAKE_SYSTEM_NAME STREQUAL SunOS)
   if(NOT HAVE_LIBUNWIND_H)
     unset(HAVE_LIBUNWIND_H CACHE)
@@ -989,4 +989,3 @@ else() # Anything else is Linux
 endif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.in ${CMAKE_CURRENT_BINARY_DIR}/config.h)
-

--- a/pal/src/cruntime/filecrt.cpp
+++ b/pal/src/cruntime/filecrt.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -55,7 +55,7 @@ _open_osfhandle( INT_PTR osfhandle, int flags )
     IPalObject *pobjFile = NULL;
     CFileProcessLocalData *pLocalData = NULL;
     IDataLock *pDataLock = NULL;
-    INT nRetVal = -1;  
+    INT nRetVal = -1;
     INT openFlags = 0;
 
     PERF_ENTRY(_open_osfhandle);
@@ -109,7 +109,7 @@ _open_osfhandle( INT_PTR osfhandle, int flags )
 
             nRetVal = pLocalData->unix_fd;
         }
-        
+
         if ( nRetVal == -1 )
         {
             ERROR( "Error: %s.\n", strerror( errno ) );
@@ -131,7 +131,7 @@ EXIT:
     {
         pobjFile->ReleaseReference(pthrCurrent);
     }
- 
+
     LOGEXIT( "_open_osfhandle return nRetVal:%d\n", nRetVal);
     PERF_EXIT(_open_osfhandle);
     return nRetVal;
@@ -173,12 +173,12 @@ is copied into szBuf.
 nSize = size, in bytes, of the array referenced by szBuf.
 
 Return value:
-    A pointer to the pathname if successful, otherwise NULL is returned 
+    A pointer to the pathname if successful, otherwise NULL is returned
 --*/
-char * 
-__cdecl 
+char *
+__cdecl
 PAL__getcwd(
-    char *szBuf, 
+    char *szBuf,
     size_t nSize
     )
 {
@@ -198,8 +198,8 @@ szNameTemplate = template to follow when naming the created file
 Return value:
     Open file descriptor on success, -1 if file could not be created
 --*/
-int 
-__cdecl 
+int
+__cdecl
 PAL_mkstemp(char *szNameTemplate)
 {
     return InternalMkstemp(szNameTemplate);
@@ -217,7 +217,7 @@ szNameTemplate = template to follow when naming the created file
 Return value:
     Open file descriptor on success, -1 if file could not be created
 --*/
-int 
+int
 CorUnix::InternalMkstemp(
     char *szNameTemplate
     )
@@ -249,15 +249,15 @@ Return value:
 int
 __cdecl
 PAL__open(
-    const char *szPath, 
-    int nFlags, 
+    const char *szPath,
+    int nFlags,
     ...
     )
 {
     int nRet = -1;
     int mode = 0;
     va_list ap;
-    
+
     // If nFlags does not contain O_CREAT, the mode parameter will be ignored.
     if (nFlags & O_CREAT)
     {
@@ -265,7 +265,7 @@ PAL__open(
         mode = va_arg(ap, int);
         va_end(ap);
     }
-    
+
     nRet = InternalOpen(szPath, nFlags, mode);
     return nRet;
 }
@@ -376,7 +376,7 @@ Return value:
 int
 __cdecl
 PAL_rename(
-    const char *szOldName, 
+    const char *szOldName,
     const char *szNewName
     )
 {
@@ -399,19 +399,19 @@ Return value:
     Returns a pointer to the string storing the characters on success
     and NULL on failure.
 --*/
-char * 
-__cdecl 
+char *
+__cdecl
 PAL_fgets(
-    char *sz, 
-    int nSize, 
+    char *sz,
+    int nSize,
     PAL_FILE *pf
     )
 {
     char * szBuf;
-    
+
     PERF_ENTRY(fgets);
     ENTRY( "fgets(sz=%p (%s) nSize=%d pf=%p)\n", sz, sz, nSize, pf);
-    
+
     if (pf != NULL)
     {
         szBuf = InternalFgets(sz, nSize, pf->bsdFilePtr, pf->bTextMode);
@@ -420,7 +420,7 @@ PAL_fgets(
     {
         szBuf = NULL;
     }
-    
+
     LOGEXIT("fgets() returns %p\n", szBuf);
     PERF_EXIT(fgets);
 
@@ -517,12 +517,12 @@ pf = stream to write characters to
 Return value:
     Returns the number of objects written.
 --*/
-size_t 
-__cdecl 
+size_t
+__cdecl
 PAL_fwrite(
-    const void *pvBuffer, 
-    size_t nSize, 
-    size_t nCount, 
+    const void *pvBuffer,
+    size_t nSize,
+    size_t nCount,
     PAL_FILE *pf
     )
 {
@@ -574,10 +574,10 @@ CorUnix::InternalFwrite(
 
     nWrittenBytes = fwrite(pvBuffer, nSize, nCount, f);
 
-    // Make sure no error ocurred. 
+    // Make sure no error ocurred.
     if ( nWrittenBytes < nCount )
     {
-        // Set the FILE* error code 
+        // Set the FILE* error code
         *pnErrorCode = PAL_FILE_ERROR;
     }
 
@@ -602,8 +602,8 @@ Return value:
 int
 _cdecl
 PAL_fseek(
-    PAL_FILE * pf, 
-    LONG lOffset, 
+    PAL_FILE * pf,
+    LONG lOffset,
     int nWhence
     )
 {

--- a/pal/src/cruntime/lstr.cpp
+++ b/pal/src/cruntime/lstr.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -30,19 +30,19 @@ SET_DEFAULT_DEBUG_CHANNEL(CRT);
 Function:
   lstrcatW
 
-The lstrcat function appends one string to another. 
+The lstrcat function appends one string to another.
 
 Parameters
 
 lpString1        [in/out] Pointer to a null-terminated string. The buffer must be large
-                          enough to contain both strings. 
+                          enough to contain both strings.
 lpString2        [in]     Pointer to the null-terminated string to be appended to the
-                          string specified in the lpString1 parameter. 
+                          string specified in the lpString1 parameter.
 
 Return Values
 
 If the function succeeds, the return value is a pointer to the buffer.
-If the function fails, the return value is NULL. 
+If the function fails, the return value is NULL.
 
 --*/
 LPWSTR
@@ -99,7 +99,7 @@ lstrcatW(
 Function:
   lstrcpyW
 
-The lstrcpy function copies a string to a buffer. 
+The lstrcpy function copies a string to a buffer.
 
 To copy a specified number of characters, use the lstrcpyn function.
 
@@ -107,14 +107,14 @@ Parameters
 
 lpString1        [out] Pointer to a buffer to receive the contents of the string pointed
                        to by the lpString2 parameter. The buffer must be large enough to
-                       contain the string, including the terminating null character. 
+                       contain the string, including the terminating null character.
 
-lpString2        [in] Pointer to the null-terminated string to be copied. 
+lpString2        [in] Pointer to the null-terminated string to be copied.
 
 Return Values
 
 If the function succeeds, the return value is a pointer to the buffer.
-If the function fails, the return value is NULL. 
+If the function fails, the return value is NULL.
 
 --*/
 LPWSTR
@@ -171,7 +171,7 @@ the terminating null character).
 
 Parameters
 
-lpString        [in] Pointer to a null-terminated string. 
+lpString        [in] Pointer to a null-terminated string.
 
 Return Values
 
@@ -192,7 +192,7 @@ lstrlenA( IN LPCSTR lpString)
     {
         while (*lpString++)
         {
-            nChar++;      
+            nChar++;
         }
     }
     LOGEXIT("lstrlenA returning int %d\n", nChar);
@@ -211,7 +211,7 @@ the terminating null character).
 
 Parameters
 
-lpString        [in] Pointer to a null-terminated string. 
+lpString        [in] Pointer to a null-terminated string.
 
 Return Values
 
@@ -233,7 +233,7 @@ lstrlenW(
     {
         while (*lpString++)
         {
-            nChar++;      
+            nChar++;
         }
     }
     LOGEXIT("lstrlenW returning int %d\n", nChar);
@@ -253,9 +253,9 @@ Parameters
 
 lpString1        [out] Pointer to a buffer into which the function copies characters.
                        The buffer must be large enough to contain the number of TCHARs
-                       specified by iMaxLength, including room for a terminating null character. 
+                       specified by iMaxLength, including room for a terminating null character.
 lpString2        [in]  Pointer to a null-terminated string from which the function copies
-                       characters. 
+                       characters.
 iMaxLength       [in]  Specifies the number of TCHARs to be copied from the string pointed
                        to by lpString2 into the buffer pointed to by lpString1, including a
                        terminating null character.
@@ -263,7 +263,7 @@ iMaxLength       [in]  Specifies the number of TCHARs to be copied from the stri
 Return Values
 
 If the function succeeds, the return value is a pointer to the buffer.
-If the function fails, the return value is NULL. 
+If the function fails, the return value is NULL.
 
 --*/
 LPWSTR
@@ -313,5 +313,3 @@ lstrcpynW(
     return lpStart;
 
 }
-
-

--- a/pal/src/cruntime/malloc.cpp
+++ b/pal/src/cruntime/malloc.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -51,8 +51,8 @@ CorUnix::InternalRealloc(
     void *pvMem;
 
     PERF_ENTRY(InternalRealloc);
-    ENTRY("realloc (memblock:%p size=%d)\n", pvMemblock, szSize);    
-       
+    ENTRY("realloc (memblock:%p size=%d)\n", pvMemblock, szSize);
+
     if (szSize == 0)
     {
         // If pvMemblock is NULL, there's no reason to call free.
@@ -89,7 +89,7 @@ CorUnix::InternalFree(
     free(pvMem);
 }
 
-void * 
+void *
 __cdecl
 PAL_malloc(
     size_t szSize

--- a/pal/src/cruntime/misc.cpp
+++ b/pal/src/cruntime/misc.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -53,12 +53,12 @@ Function:
 
 See MSDN doc.
 --*/
-char * 
-__cdecl 
+char *
+__cdecl
 _gcvt_s( char * buffer, int iSize, double value, int digits )
 {
     PERF_ENTRY(_gcvt);
-    ENTRY( "_gcvt( value:%f digits=%d, buffer=%p )\n", value, digits, buffer );    
+    ENTRY( "_gcvt( value:%f digits=%d, buffer=%p )\n", value, digits, buffer );
 
     if ( !buffer )
     {
@@ -74,20 +74,20 @@ _gcvt_s( char * buffer, int iSize, double value, int digits )
     case 15 :
         /* Fall through */
     case 17 :
-        
+
         sprintf_s( buffer, iSize, "%.*g", digits, value );
         break;
-    
+
     default :
         ASSERT( "Only the digits 7, 8, 15, and 17 are valid.\n" );
         *buffer = '\0';
     }
-    
+
     LOGEXIT( "_gcvt returns %p (%s)\n", buffer , buffer );
     PERF_EXIT(_gcvt);
     return buffer;
 }
-    
+
 
 /*++
 Function :
@@ -97,7 +97,7 @@ Function :
 See MSDN for more details.
 --*/
 int
-__cdecl 
+__cdecl
 __iscsym( int c )
 {
     PERF_ENTRY(__iscsym);
@@ -121,7 +121,7 @@ __iscsym( int c )
 Function :
 
     PAL_errno
-    
+
     Returns the address of the errno.
 
 --*/
@@ -139,21 +139,21 @@ int * __cdecl PAL_errno( int caller )
 /*++
 
 Function : _putenv.
-    
+
 See MSDN for more details.
 
 Note:   The BSD implementation can cause
         memory leaks. See man pages for more details.
 --*/
 int
-__cdecl 
+__cdecl
 _putenv( const char * envstring )
 {
     int ret = -1;
 
     PERF_ENTRY(_putenv);
     ENTRY( "_putenv( %p (%s) )\n", envstring ? envstring : "NULL", envstring ? envstring : "NULL") ;
-    
+
     if (!envstring)
     {
         ERROR( "_putenv() called with NULL envstring!\n");
@@ -162,7 +162,7 @@ _putenv( const char * envstring )
 
     ret = MiscPutenv(envstring, TRUE) ? 0 : -1;
 
-EXIT:    
+EXIT:
     LOGEXIT( "_putenv returning %d\n", ret);
     PERF_EXIT(_putenv);
     return ret;
@@ -171,7 +171,7 @@ EXIT:
 /*++
 
 Function : PAL_getenv
-    
+
 See MSDN for more details.
 --*/
 char * __cdecl PAL_getenv(const char *varname)
@@ -180,7 +180,7 @@ char * __cdecl PAL_getenv(const char *varname)
 
     PERF_ENTRY(getenv);
     ENTRY("getenv (%p (%s))\n", varname ? varname : "NULL", varname ? varname : "NULL");
-    
+
     if (strcmp(varname, "") == 0)
     {
         ERROR("getenv called with a empty variable name\n");
@@ -203,8 +203,8 @@ Function:
 See MSDN for more details.
 --*/
 
-PAL_time_t 
-__cdecl 
+PAL_time_t
+__cdecl
 PAL_mktime(struct PAL_tm *tm)
 {
     time_t result;
@@ -243,7 +243,7 @@ Function:
 See MSDN for more details.
 --*/
 int
-__cdecl 
+__cdecl
 PAL_rand(void)
 {
     int ret;
@@ -258,16 +258,16 @@ PAL_rand(void)
 }
 
 
-PALIMPORT 
-void __cdecl 
-PAL_qsort(void *base, size_t nmemb, size_t size, 
+PALIMPORT
+void __cdecl
+PAL_qsort(void *base, size_t nmemb, size_t size,
           int (__cdecl *compar )(const void *, const void *))
 {
     PERF_ENTRY(qsort);
     ENTRY("qsort(base=%p, nmemb=%lu, size=%lu, compar=%p\n",
           base,(unsigned long) nmemb,(unsigned long) size, compar);
 
-/* reset ENTRY nesting level back to zero, qsort will invoke app-defined 
+/* reset ENTRY nesting level back to zero, qsort will invoke app-defined
    callbacks and we want their entry traces... */
 #if _ENABLE_DEBUG_MESSAGES_
 {
@@ -287,18 +287,18 @@ PAL_qsort(void *base, size_t nmemb, size_t size,
     PERF_EXIT(qsort);
 }
 
-PALIMPORT 
-void * __cdecl 
+PALIMPORT
+void * __cdecl
 PAL_bsearch(const void *key, const void *base, size_t nmemb, size_t size,
             int (__cdecl *compar)(const void *, const void *))
 {
     void *retval;
 
     PERF_ENTRY(bsearch);
-    ENTRY("bsearch(key=%p, base=%p, nmemb=%lu, size=%lu, compar=%p\n", 
+    ENTRY("bsearch(key=%p, base=%p, nmemb=%lu, size=%lu, compar=%p\n",
           key, base, (unsigned long) nmemb, (unsigned long) size, compar);
 
-/* reset ENTRY nesting level back to zero, bsearch will invoke app-defined 
+/* reset ENTRY nesting level back to zero, bsearch will invoke app-defined
    callbacks and we want their entry traces... */
 #if _ENABLE_DEBUG_MESSAGES_
 {
@@ -319,7 +319,7 @@ PAL_bsearch(const void *key, const void *base, size_t nmemb, size_t size,
     return retval;
 }
 
-#ifdef _AMD64_ 
+#ifdef _AMD64_
 
 PALIMPORT
 unsigned int PAL__mm_getcsr(void)
@@ -333,7 +333,7 @@ void PAL__mm_setcsr(unsigned int i)
     _mm_setcsr(i);
 }
 
-#endif // _AMD64_ 
+#endif // _AMD64_
 
 /*++
 Function:
@@ -341,8 +341,8 @@ Function:
 
 Get a reference to the process's environ array into palEnvironment
 
-NOTE: This function MUST be called while holding the gcsEnvironment 
-      critical section (except if the caller is the initialization 
+NOTE: This function MUST be called while holding the gcsEnvironment
+      critical section (except if the caller is the initialization
       routine)
 --*/
 void
@@ -362,8 +362,8 @@ Function:
 
 Make sure the process's environ array is in sync with palEnvironment variable
 
-NOTE: This function MUST be called while holding the gcsEnvironment 
-      critical section (except if the caller is the initialization 
+NOTE: This function MUST be called while holding the gcsEnvironment
+      critical section (except if the caller is the initialization
       routine)
 --*/
 void
@@ -436,8 +436,8 @@ char *MiscGetenv(const char *name)
             {
                 pRet = (char *) "";
                 goto done;
-            } 
-            else if (*equals == '=') 
+            }
+            else if (*equals == '=')
             {
                 pRet = equals + 1;
                 goto done;
@@ -468,7 +468,7 @@ BOOL MiscPutenv(const char *string, BOOL deleteIfEmpty)
     bool fOwningCS = false;
     BOOL result = FALSE;
     CPalThread * pthrCurrent = InternalGetCurrentThread();
-    
+
     equals = strchr(string, '=');
     if (equals == string || equals == NULL)
     {
@@ -496,19 +496,19 @@ BOOL MiscPutenv(const char *string, BOOL deleteIfEmpty)
     else
     {
         // See if we are replacing an item or adding one.
-        
+
         // Make our copy up front, since we'll use it either way.
         copy = InternalStrdup(string);
         if (copy == NULL)
         {
             goto done;
         }
-        
+
         length = equals - string;
 
         InternalEnterCriticalSection(pthrCurrent, &gcsEnvironment);
         fOwningCS = true;
-        
+
         for(i = 0; palEnvironment[i] != NULL; i++)
         {
             existingEquals = strchr(palEnvironment[i], '=');
@@ -529,25 +529,25 @@ BOOL MiscPutenv(const char *string, BOOL deleteIfEmpty)
                     // references to it that were acquired via
                     // getenv. This is an unavoidable memory leak.
                     palEnvironment[i] = copy;
-                    
+
                     // Set 'copy' to NULL so it won't be freed
                     copy = NULL;
-                    
+
                     result = TRUE;
                     break;
                 }
             }
         }
         if (palEnvironment[i] == NULL)
-        {            
+        {
             static BOOL sAllocatedEnviron = FALSE;
             // Add a new environment variable.
             // We'd like to realloc palEnvironment, but we can't do that the
             // first time through.
             char **newEnviron = NULL;
-            
+
             if (sAllocatedEnviron) {
-                if (NULL == (newEnviron = 
+                if (NULL == (newEnviron =
                         (char **)InternalRealloc(palEnvironment, (i + 2) * sizeof(char *))))
                 {
                     goto done;
@@ -574,7 +574,7 @@ BOOL MiscPutenv(const char *string, BOOL deleteIfEmpty)
 
             // Set 'copy' to NULL so it won't be freed
             copy = NULL;
-            
+
             result = TRUE;
         }
     }
@@ -604,7 +604,7 @@ void MiscUnsetenv(const char *name)
     int length;
     int i, j;
     CPalThread * pthrCurrent = InternalGetCurrentThread();
-    
+
     length = strlen(name);
 
     InternalEnterCriticalSection(pthrCurrent, &gcsEnvironment);

--- a/pal/src/cruntime/printfcpp.cpp
+++ b/pal/src/cruntime/printfcpp.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -322,13 +322,13 @@ BOOL Internal_ExtractFormatA(CPalThread *pthrCurrent, LPCSTR *Fmt, LPSTR Out, LP
 #ifdef BIT64
         // Only want to change the prefix on 64 bit when printing characters.
         if (**Fmt == 'c' || **Fmt == 's')
-#endif       
+#endif
         {
             *Prefix = PFF_PREFIX_LONG;
         }
         if (**Fmt == 'l')
         {
-            *Prefix = PFF_PREFIX_LONGLONG;   
+            *Prefix = PFF_PREFIX_LONGLONG;
             ++(*Fmt);
         }
     }
@@ -625,7 +625,7 @@ BOOL Internal_ExtractFormatW(CPalThread *pthrCurrent, LPCWSTR *Fmt, LPSTR Out, L
  #ifdef BIT64
         // Only want to change the prefix on 64 bit when printing characters.
         if (**Fmt == 'C' || **Fmt == 'S')
-#endif   
+#endif
         {
             *Prefix = PFF_PREFIX_LONG_W;
         }
@@ -797,7 +797,7 @@ BOOL Internal_AddPaddingW(LPWSTR *Out, INT Count, LPWSTR In, INT Padding, INT Fl
     INT PaddingOriginal = Padding;
     INT LengthInStr;
     LengthInStr = PAL_wcslen(In);
-    
+
 
     if (Padding < 0)
     {
@@ -940,7 +940,7 @@ INT Internal_AddPaddingVfprintf(CPalThread *pthrCurrent, PAL_FILE *stream, LPSTR
 #if FILE_OPS_CHECK_FERROR_OF_PREVIOUS_CALL
     clearerr (stream->bsdFilePtr);
 #endif
-    
+
     Written = InternalFwrite(OutOriginal, 1, Length, stream->bsdFilePtr, &stream->PALferrorCode);
     if (stream->PALferrorCode == PAL_FILE_ERROR)
     {
@@ -1039,7 +1039,7 @@ static INT Internal_AddPaddingVfwprintf(CPalThread *pthrCurrent, PAL_FILE *strea
     }
 
     if (Length > 0) {
-        Written = Internal_Convertfwrite(pthrCurrent, OutOriginal, sizeof(wchar_16), Length, 
+        Written = Internal_Convertfwrite(pthrCurrent, OutOriginal, sizeof(wchar_16), Length,
             (FILE*)(stream->bsdFilePtr), convert);
 
         if (-1 == Written)
@@ -1169,7 +1169,7 @@ int CoreVfwprintf(CPalThread *pthrCurrent, PAL_FILE *stream, const wchar_16 *for
     PERF_ENTRY(vfwprintf);
     ENTRY("vfwprintf (stream=%p, format=%p (%S))\n",
           stream, format, format);
-    
+
     va_copy(ap, aparg);
 
     while (*Fmt)
@@ -1404,9 +1404,9 @@ int CoreVfwprintf(CPalThread *pthrCurrent, PAL_FILE *stream, const wchar_16 *for
                     trunc1 = va_arg(ap, LONG);
                     trunc2 = (short)trunc1;
                     trunc1 = trunc2;
-                    
+
                     TempInt = snprintf(TempSprintfStr, TEMP_COUNT, TempBuff, trunc1);
-                    
+
                     if (TempInt < 0 || static_cast<size_t>(TempInt) >= TEMP_COUNT)
                     {
                         if (NULL == (TempSprintfStrPtr = (char*)InternalMalloc(++TempInt)))
@@ -1418,7 +1418,7 @@ int CoreVfwprintf(CPalThread *pthrCurrent, PAL_FILE *stream, const wchar_16 *for
                             va_end(ap);
                             return -1;
                         }
-                        
+
                         TempSprintfStr = TempSprintfStrPtr;
                         snprintf(TempSprintfStr, TempInt, TempBuff, trunc2);
                     }
@@ -1446,7 +1446,7 @@ int CoreVfwprintf(CPalThread *pthrCurrent, PAL_FILE *stream, const wchar_16 *for
                             va_end(ap);
                             return -1;
                         }
-                        
+
                         TempSprintfStr = TempSprintfStrPtr;
                         snprintf(TempSprintfStr, TempInt, TempBuff, s);
                     }
@@ -1471,7 +1471,7 @@ int CoreVfwprintf(CPalThread *pthrCurrent, PAL_FILE *stream, const wchar_16 *for
                             va_end(ap);
                             return -1;
                         }
-                        
+
                         TempSprintfStr = TempSprintfStrPtr;
                         va_copy(apcopy, ap);
                         vsnprintf(TempSprintfStr, TempInt, TempBuff, apcopy);
@@ -1483,7 +1483,7 @@ int CoreVfwprintf(CPalThread *pthrCurrent, PAL_FILE *stream, const wchar_16 *for
                 mbtowcResult = MultiByteToWideChar(CP_ACP, 0,
                                                    TempSprintfStr, -1,
                                                    NULL, 0);
- 
+
                 if (mbtowcResult == 0)
                 {
                     ERROR("MultiByteToWideChar failed\n");
@@ -1514,12 +1514,12 @@ int CoreVfwprintf(CPalThread *pthrCurrent, PAL_FILE *stream, const wchar_16 *for
 
                 MultiByteToWideChar(CP_ACP, 0, TempSprintfStr, -1,
                                     TempWideBuffer, mbtowcResult);
- 
+
                 ret = Internal_Convertfwrite(
-                                    pthrCurrent, 
-                                    TempWideBuffer, 
-                                    sizeof(wchar_16), 
-                                    mbtowcResult-1, 
+                                    pthrCurrent,
+                                    TempWideBuffer,
+                                    sizeof(wchar_16),
+                                    mbtowcResult-1,
                                     (FILE*)stream->bsdFilePtr,
                                     textMode);
 
@@ -1546,13 +1546,13 @@ int CoreVfwprintf(CPalThread *pthrCurrent, PAL_FILE *stream, const wchar_16 *for
         else
         {
             ret = Internal_Convertfwrite(
-                                    pthrCurrent, 
-                                    Fmt++, 
-                                    sizeof(wchar_16), 
-                                    1, 
+                                    pthrCurrent,
+                                    Fmt++,
+                                    sizeof(wchar_16),
+                                    1,
                                     (FILE*)stream->bsdFilePtr,
                                     textMode); /* copy regular chars into buffer */
-            
+
             if (-1 == ret)
             {
                 ERROR("fwrite() failed with errno == %d\n", errno);
@@ -1589,7 +1589,7 @@ int CoreVsnprintf(CPalThread *pthrCurrent, LPSTR Buffer, size_t Count, LPCSTR Fo
     INT TempInt;
     int wctombResult;
     va_list ap;
-    
+
     va_copy(ap, aparg);
 
     while (*Fmt)
@@ -1630,7 +1630,7 @@ int CoreVsnprintf(CPalThread *pthrCurrent, LPSTR Buffer, size_t Count, LPCSTR Fo
                 Length = WideCharToMultiByte(CP_ACP, 0, TempWStr, -1, 0,
                                              0, 0, 0);
                 if (!Length)
-                {              
+                {
                     ASSERT("WideCharToMultiByte failed.  Error is %d\n",
                           GetLastError());
                     va_end(ap);
@@ -1638,7 +1638,7 @@ int CoreVsnprintf(CPalThread *pthrCurrent, LPSTR Buffer, size_t Count, LPCSTR Fo
                 }
                 TempStr = (LPSTR) InternalMalloc(Length);
                 if (!TempStr)
-                {        
+                {
                     ERROR("InternalMalloc failed\n");
                     pthrCurrent->SetLastError(ERROR_NOT_ENOUGH_MEMORY);
                     va_end(ap);
@@ -1672,7 +1672,7 @@ int CoreVsnprintf(CPalThread *pthrCurrent, LPSTR Buffer, size_t Count, LPCSTR Fo
                     wctombResult = WideCharToMultiByte(CP_ACP, 0, TempWStr, -1,
                                                        TempStr, Length, 0, 0);
                     if (!wctombResult)
-                    {               
+                    {
                         ASSERT("WideCharToMultiByte failed.  Error is %d\n",
                               GetLastError());
                         InternalFree(TempStr);
@@ -1713,7 +1713,7 @@ int CoreVsnprintf(CPalThread *pthrCurrent, LPSTR Buffer, size_t Count, LPCSTR Fo
                                              TempBuffer, sizeof(TempBuffer),
                                              0, 0);
                 if (!Length)
-                {                
+                {
                     ASSERT("WideCharToMultiByte failed.  Error is %d\n",
                           GetLastError());
                     va_end(ap);
@@ -1888,7 +1888,7 @@ int CoreWvsnprintf(CPalThread *pthrCurrent, LPWSTR Buffer, size_t Count, LPCWSTR
     PERF_ENTRY(wvsnprintf);
     ENTRY("wvsnprintf (buffer=%p, count=%u, format=%p (%S))\n",
           Buffer, Count, Format, Format);
-    
+
     va_copy(ap, aparg);
 
     while (*Fmt)
@@ -1907,7 +1907,7 @@ int CoreWvsnprintf(CPalThread *pthrCurrent, LPWSTR Buffer, size_t Count, LPCWSTR
                 (Type == PFF_TYPE_STRING || Type == PFF_TYPE_WSTRING)) ||
                 (Prefix == PFF_PREFIX_SHORT && Type == PFF_TYPE_STRING) ||
                 (Type == PFF_TYPE_WSTRING && (Flags & PFF_ZERO) != 0))
-            {             
+            {
                 BOOL needToFree = FALSE;
 
                 if (WIDTH_STAR == Width)
@@ -1952,22 +1952,22 @@ int CoreWvsnprintf(CPalThread *pthrCurrent, LPWSTR Buffer, size_t Count, LPCWSTR
                                                  TempWStr, Length );
                         }
                         else
-                        {                           
+                        {
                             ERROR( "InternalMalloc failed.\n" );
                             va_end(ap);
                             return -1;
                         }
                     }
                     else
-                    {                  
+                    {
                         ASSERT( "Unable to convert from multibyte "
-                               " to wide char.\n" );    
+                               " to wide char.\n" );
                         va_end(ap);
                         return -1;
                     }
 
                 }
-                
+
                 INT Length = PAL_wcslen(TempWStr);
                 WorkingWStr = (LPWSTR) InternalMalloc(sizeof(WCHAR) * (Length + 1));
                 if (!WorkingWStr)
@@ -2145,7 +2145,7 @@ int CoreWvsnprintf(CPalThread *pthrCurrent, LPWSTR Buffer, size_t Count, LPCWSTR
                         va_end(ap);
                         return -1;
                     }
-                    
+
                     if (strncpy_s(TempNumberBuffer, TempCount+1, (LPSTR) BufferPtr, TempCount) != SAFECRT_SUCCESS)
                     {
                         ASSERT("strncpy_s failed!\n");
@@ -2159,7 +2159,7 @@ int CoreWvsnprintf(CPalThread *pthrCurrent, LPWSTR Buffer, size_t Count, LPCWSTR
                                                        TempCount,
                                                        BufferPtr, TempCount);
                     if (!mbtowcResult)
-                    {                 
+                    {
                         ASSERT("MultiByteToWideChar failed.  Error is %d\n",
                               GetLastError());
                         InternalFree(TempNumberBuffer);
@@ -2173,17 +2173,17 @@ int CoreWvsnprintf(CPalThread *pthrCurrent, LPWSTR Buffer, size_t Count, LPCWSTR
                 {
                     TempNumberBuffer = (LPSTR) InternalMalloc(TempInt+1);
                     if (!TempNumberBuffer)
-                    {          
+                    {
                         ERROR("InternalMalloc failed\n");
                         pthrCurrent->SetLastError(ERROR_NOT_ENOUGH_MEMORY);
                         va_end(ap);
                         return -1;
                     }
-                    
+
                     if (strncpy_s(TempNumberBuffer, TempInt+1, (LPSTR) BufferPtr, TempInt) != SAFECRT_SUCCESS)
                     {
                         ASSERT("strncpy_s failed!\n");
-                        InternalFree(TempNumberBuffer); 
+                        InternalFree(TempNumberBuffer);
                         va_end(ap);
                         return -1;
                     }
@@ -2193,10 +2193,10 @@ int CoreWvsnprintf(CPalThread *pthrCurrent, LPWSTR Buffer, size_t Count, LPCWSTR
                                                        TempInt,
                                                        BufferPtr, TempInt);
                     if (!mbtowcResult)
-                    {          
+                    {
                         ASSERT("MultiByteToWideChar failed.  Error is %d\n",
                               GetLastError());
-                        InternalFree(TempNumberBuffer); 
+                        InternalFree(TempNumberBuffer);
                         va_end(ap);
                         return -1;
                     }
@@ -2215,7 +2215,7 @@ int CoreWvsnprintf(CPalThread *pthrCurrent, LPWSTR Buffer, size_t Count, LPCWSTR
     {
         *BufferPtr = 0; /* end the string */
     }
-    
+
     va_end(ap);
 
     if (BufferRanOut)
@@ -2247,11 +2247,11 @@ int CoreVfprintf(CPalThread *pthrCurrent, PAL_FILE *stream, const char *format, 
     int written = 0;
     int paddingReturnValue;
     va_list ap;
-    
+
     PERF_ENTRY(vfprintf);
-    
+
     va_copy(ap, aparg);
-        
+
     while (*Fmt)
     {
         if (*Fmt == '%' &&
@@ -2297,7 +2297,7 @@ int CoreVfprintf(CPalThread *pthrCurrent, PAL_FILE *stream, const char *format, 
                 {
                     ERROR("InternalMalloc failed\n");
                     pthrCurrent->SetLastError(ERROR_NOT_ENOUGH_MEMORY);
-                    PERF_EXIT(vfprintf);  
+                    PERF_EXIT(vfprintf);
                     va_end(ap);
                     return -1;
                 }
@@ -2349,7 +2349,7 @@ int CoreVfprintf(CPalThread *pthrCurrent, PAL_FILE *stream, const char *format, 
                 {
                     ERROR("Internal_AddPaddingVfprintf failed\n");
                     InternalFree(TempStr);
-                    PERF_EXIT(vfprintf);  
+                    PERF_EXIT(vfprintf);
                     va_end(ap);
                     return -1;
                 }
@@ -2372,7 +2372,7 @@ int CoreVfprintf(CPalThread *pthrCurrent, PAL_FILE *stream, const char *format, 
                     /* ignore (because it's a char), and remove arg */
                     TempInt = va_arg(ap, INT); /* value not used */
                 }
-                
+
                 TempWChar = va_arg(ap, int);
                 Length = WideCharToMultiByte(CP_ACP, 0, &TempWChar, 1,
                                              TempBuffer, sizeof(TempBuffer),
@@ -2433,7 +2433,7 @@ int CoreVfprintf(CPalThread *pthrCurrent, PAL_FILE *stream, const char *format, 
                 ch[1] = '\0';
                 Length = 1;
                 paddingReturnValue = Internal_AddPaddingVfprintf(
-                                                pthrCurrent, 
+                                                pthrCurrent,
                                                 stream,
                                                 ch,
                                                 Width - Length,
@@ -2464,7 +2464,7 @@ int CoreVfprintf(CPalThread *pthrCurrent, PAL_FILE *stream, const char *format, 
                 if (-1 == paddingReturnValue)
                 {
                     ERROR("Internal_AddPaddingVfprintf failed\n");
-                    PERF_EXIT(vfprintf);    
+                    PERF_EXIT(vfprintf);
                     va_end(ap);
                     return -1;
                 }
@@ -2531,7 +2531,7 @@ int CoreVfprintf(CPalThread *pthrCurrent, PAL_FILE *stream, const char *format, 
             if (stream->PALferrorCode == PAL_FILE_ERROR)
             {
                 ERROR("fwrite() failed with errno == %d\n", errno);
-                PERF_EXIT(vfprintf);    
+                PERF_EXIT(vfprintf);
                 va_end(ap);
                 return -1;
             }

--- a/pal/src/cruntime/string.cpp
+++ b/pal/src/cruntime/string.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -40,19 +40,19 @@ Function:
 compare at most count characters from two strings, ignoring case
 
 The strnicmp() function compares, with case insensitivity, at most count
-characters from s1 to s2. All uppercase characters from s1 and s2 are 
+characters from s1 to s2. All uppercase characters from s1 and s2 are
 mapped to lowercase for the purposes of doing the comparison.
 
 Returns:
 
 Value Meaning
 
-< 0   s1 is less than s2 
-0     s1 is equal to s2 
+< 0   s1 is less than s2
+0     s1 is equal to s2
 > 0   s1 is greater than s2
 
 --*/
-int 
+int
 __cdecl
 _strnicmp( const char *s1, const char *s2, size_t count )
 {
@@ -83,15 +83,15 @@ Returns:
 
 Value Meaning
 
-< 0   s1 is less than s2 
-0     s1 is equal to s2 
+< 0   s1 is less than s2
+0     s1 is equal to s2
 > 0   s1 is greater than s2
 
 --*/
-int 
+int
 __cdecl
 _stricmp(
-         const char *s1, 
+         const char *s1,
          const char *s2)
 {
     int ret;
@@ -131,7 +131,7 @@ current locale. Other characters are not affected. For more
 information on LC_CTYPE, see setlocale.
 
 --*/
-char *  
+char *
 __cdecl
 _strlwr(
         char *str)
@@ -145,8 +145,8 @@ _strlwr(
     {
         *str = tolower(*str);
         str++;
-    } 
-   
+    }
+
     LOGEXIT("_strlwr returning char* %p (%s)\n", orig?orig:"NULL", orig?orig:"NULL");
     PERF_EXIT(_strlwr);
     return orig;
@@ -243,30 +243,30 @@ Notes :
     tests indicate that other whitespace characters (newline, carriage return,
     etc) are also accepted. This matches the behavior on Unix systems.
 
-    For strtoul, we need to check if the value to be returned 
+    For strtoul, we need to check if the value to be returned
     is outside the 32 bit range. If so, the returned value needs to be set
-    as appropriate, according to the MSDN pages and in all instances errno 
-    must be set to ERANGE (The one exception is converting a string 
+    as appropriate, according to the MSDN pages and in all instances errno
+    must be set to ERANGE (The one exception is converting a string
     representing a negative value to unsigned long).
     Note that on 64 bit Windows, long's are still 32 bit. Thus, to match
     Windows behavior, we must return long's in the 32 bit range.
     --*/
 
-/* The use of ULONG is by design, to ensure that a 32 bit value is always 
+/* The use of ULONG is by design, to ensure that a 32 bit value is always
 returned from this function. If "unsigned long" is used instead of ULONG,
 then a 64 bit value could be returned on 64 bit platforms like HP-UX, thus
 breaking Windows behavior. */
-ULONG 
-__cdecl 
+ULONG
+__cdecl
 PAL_strtoul(const char *szNumber, char **pszEnd, int nBase)
 {
     unsigned long ulResult;
-    
+
     PERF_ENTRY(strtoul);
-    ENTRY("strtoul (szNumber=%p (%s), pszEnd=%p, nBase=%d)\n", 
-        szNumber?szNumber:"NULL", 
+    ENTRY("strtoul (szNumber=%p (%s), pszEnd=%p, nBase=%d)\n",
         szNumber?szNumber:"NULL",
-        pszEnd, 
+        szNumber?szNumber:"NULL",
+        pszEnd,
         nBase);
 
     ulResult = strtoul(szNumber, pszEnd, nBase);
@@ -279,7 +279,7 @@ PAL_strtoul(const char *szNumber, char **pszEnd, int nBase)
         {
 	    ch = *szNumber++;
         }
-        /* If the string represents a positive number that is greater than 
+        /* If the string represents a positive number that is greater than
             _UI32_MAX, set errno to ERANGE. Otherwise, don't set errno
             to match Windows behavior. */
         if (ch != '-')
@@ -292,17 +292,17 @@ PAL_strtoul(const char *szNumber, char **pszEnd, int nBase)
 
     LOGEXIT("strtoul returning unsigned long %lu\n", ulResult);
     PERF_EXIT(wcstoul);
-    
-    /* When returning unsigned long res from this function, it will be 
+
+    /* When returning unsigned long res from this function, it will be
         implicitly cast to ULONG. This handles situations where a string that
         represents a negative number is passed in to strtoul. The Windows
         behavior is analogous to taking the binary equivalent of the negative
         value and treating it as a positive number. Returning a ULONG from
         this function, as opposed to native unsigned long, allows us to match
         this behavior. The explicit cast to ULONG below is used to silence any
-        potential warnings due to the implicit casting.  */    
+        potential warnings due to the implicit casting.  */
     return (ULONG)ulResult;
-    
+
 }
 
 
@@ -314,7 +314,7 @@ Convert string to a long value.
 
 Return Value
 
-atol returns the converted value, if any. In the case of overflow, 
+atol returns the converted value, if any. In the case of overflow,
 the return value is undefined.
 
 Parameters
@@ -322,21 +322,21 @@ Parameters
 szNumber  Null-terminated string to convert to a LONG
 --*/
 
-/* The use of LONG is by design, to ensure that a 32 bit value is always 
-returned from this function. If "long" is used instead of LONG, then a 64 bit 
-value could be returned on 64 bit platforms like HP-UX, thus breaking 
+/* The use of LONG is by design, to ensure that a 32 bit value is always
+returned from this function. If "long" is used instead of LONG, then a 64 bit
+value could be returned on 64 bit platforms like HP-UX, thus breaking
 Windows behavior. */
-LONG 
+LONG
 __cdecl
 PAL_atol(const char *szNumber)
 {
     long lResult;
 
     PERF_ENTRY(atol);
-    ENTRY("atol (szNumber=%p (%s))\n", 
+    ENTRY("atol (szNumber=%p (%s))\n",
         szNumber?szNumber:"NULL"
         );
-    
+
     lResult = atol(szNumber);
 
     LOGEXIT("atol returning long %ld\n", (LONG)lResult);
@@ -344,6 +344,5 @@ PAL_atol(const char *szNumber)
     /* This explicit cast to LONG is used to silence any potential warnings
         due to implicitly casting the native long lResult to LONG when returning. */
     return (LONG)lResult;
-    
-}
 
+}

--- a/pal/src/debug/debug.cpp
+++ b/pal/src/debug/debug.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -105,7 +105,7 @@ DBGWriteProcMem_IntWithMask(DWORD processId, int *addr, int data,
 
 #if !HAVE_VM_READ && !HAVE_PROCFS_CTL
 
-static BOOL 
+static BOOL
 DBGAttachProcess(CPalThread *pThread, HANDLE hProcess, DWORD dwProcessId);
 
 static BOOL
@@ -175,15 +175,15 @@ OutputDebugStringA(
     ENTRY("OutputDebugStringA (lpOutputString=%p (%s))\n",
           lpOutputString?lpOutputString:"NULL",
           lpOutputString?lpOutputString:"NULL");
-    
+
     /* as we don't support debug events, we are going to output the debug string
       to stderr instead of generating OUT_DEBUG_STRING_EVENT */
-    if ( (lpOutputString != NULL) && 
+    if ( (lpOutputString != NULL) &&
          (NULL != MiscGetenv(PAL_OUTPUTDEBUGSTRING)))
     {
         fprintf(stderr, "%s", lpOutputString);
     }
-        
+
     LOGEXIT("OutputDebugStringA returns\n");
     PERF_EXIT(OutputDebugStringA);
 }
@@ -206,15 +206,15 @@ OutputDebugStringW(
     ENTRY("OutputDebugStringW (lpOutputString=%p (%S))\n",
           lpOutputString ? lpOutputString: W16_NULLSTRING,
           lpOutputString ? lpOutputString: W16_NULLSTRING);
-    
-    if (lpOutputString == NULL) 
+
+    if (lpOutputString == NULL)
     {
         OutputDebugStringA("");
         goto EXIT;
     }
 
-    if ((strLen = WideCharToMultiByte(CP_ACP, 0, lpOutputString, -1, NULL, 0, 
-                                      NULL, NULL)) 
+    if ((strLen = WideCharToMultiByte(CP_ACP, 0, lpOutputString, -1, NULL, 0,
+                                      NULL, NULL))
         == 0)
     {
         ASSERT("failed to get wide chars length\n");
@@ -230,15 +230,15 @@ OutputDebugStringW(
         goto EXIT;
     }
 
-    if(! WideCharToMultiByte(CP_ACP, 0, lpOutputString, -1, 
-                             lpOutputStringA, strLen, NULL, NULL)) 
+    if(! WideCharToMultiByte(CP_ACP, 0, lpOutputString, -1,
+                             lpOutputStringA, strLen, NULL, NULL))
     {
         ASSERT("failed to convert wide chars to multibytes\n");
         SetLastError(ERROR_INTERNAL_ERROR);
         InternalFree(lpOutputStringA);
         goto EXIT;
     }
-    
+
     OutputDebugStringA(lpOutputStringA);
     InternalFree(lpOutputStringA);
 
@@ -291,7 +291,7 @@ run_debug_command (const char *command)
     }
 
     printf("Spawning command: %s\n", command);
-    
+
     pid = fork();
     if (pid == -1) {
         return -1;
@@ -350,10 +350,10 @@ DebugBreakCommand()
         {
             libNameLength = PAL_wcslen(exe_module.lib_name);
         }
-        
+
         SIZE_T dwexe_buf = strlen(EXE_TEXT) + libNameLength + 1;
         CHAR * exe_buf = exe_bufString.OpenStringBuffer(dwexe_buf);
-        
+
         if (NULL == exe_buf)
         {
             goto FAILED;
@@ -407,7 +407,7 @@ DebugBreak(
         TRACE("Calling DBG_DebugBreak\n");
         DBG_DebugBreak();
     }
-    
+
     LOGEXIT("DebugBreak returns\n");
     PERF_EXIT(DebugBreak);
 }
@@ -442,7 +442,7 @@ GetThreadContext(
     CPalThread *pTargetThread;
     IPalObject *pobjThread = NULL;
     BOOL ret = FALSE;
-    
+
     PERF_ENTRY(GetThreadContext);
     ENTRY("GetThreadContext (hThread=%p, lpContext=%p)\n",hThread,lpContext);
 
@@ -481,7 +481,7 @@ GetThreadContext(
     {
         pobjThread->ReleaseReference(pThread);
     }
-    
+
     LOGEXIT("GetThreadContext returns ret:%d\n", ret);
     PERF_EXIT(GetThreadContext);
     return ret;
@@ -504,7 +504,7 @@ SetThreadContext(
     CPalThread *pTargetThread;
     IPalObject *pobjThread = NULL;
     BOOL ret = FALSE;
-    
+
     PERF_ENTRY(SetThreadContext);
     ENTRY("SetThreadContext (hThread=%p, lpContext=%p)\n",hThread,lpContext);
 
@@ -543,7 +543,7 @@ SetThreadContext(
     {
         pobjThread->ReleaseReference(pThread);
     }
-        
+
     return ret;
 }
 
@@ -591,20 +591,20 @@ ReadProcessMemory(
           lpBuffer, (unsigned int)nSize, lpNumberOfBytesRead);
 
     pThread = InternalGetCurrentThread();
-    
+
     if (!(processId = PROCGetProcessIDFromHandle(hProcess)))
     {
         ERROR("Invalid process handler hProcess:%p.",hProcess);
-        SetLastError(ERROR_INVALID_HANDLE);        
+        SetLastError(ERROR_INVALID_HANDLE);
         goto EXIT;
     }
-    
-    // Check if the read request is for the current process. 
+
+    // Check if the read request is for the current process.
     // We don't need ptrace in that case.
-    if (GetCurrentProcessId() == processId) 
+    if (GetCurrentProcessId() == processId)
     {
         TRACE("We are in the same process, so ptrace is not needed\n");
-        
+
         struct Param
         {
             LPCVOID lpBaseAddress;
@@ -622,7 +622,7 @@ ReadProcessMemory(
         PAL_TRY(Param *, pParam, &param)
         {
             SIZE_T i;
-            
+
             // Seg fault in memcpy can't be caught
             // so we simulate the memcpy here
 
@@ -642,7 +642,7 @@ ReadProcessMemory(
 
         numberOfBytesRead = param.numberOfBytesRead;
         ret = param.ret;
-        goto EXIT;        
+        goto EXIT;
     }
 
 #if HAVE_VM_READ
@@ -664,7 +664,7 @@ ReadProcessMemory(
     while (nSize > 0)
     {
         vm_size_t bytesRead;
-        
+
         bytesToRead = VIRTUAL_PAGE_SIZE - offset;
         if (bytesToRead > (LONG_PTR)nSize)
         {
@@ -718,7 +718,7 @@ ReadProcessMemory(
         SetLastError(ERROR_INVALID_ACCESS);
         goto PROCFSCLEANUP;
     }
-    
+
     numberOfBytesRead = read(fd, lpBuffer, nSize);
     ret = TRUE;
 
@@ -729,12 +729,12 @@ ReadProcessMemory(
 #if HAVE_TTRACE
         if (ttrace(TT_PROC_RDDATA, processId, 0, (__uint64_t)lpBaseAddress, (__uint64_t)nSize, (__uint64_t)lpBuffer) == -1)
         {
-            if (errno == EFAULT) 
+            if (errno == EFAULT)
             {
                 ERROR("ttrace(TT_PROC_RDDATA, pid:%d, 0, addr:%p, data:%d, addr2:%d) failed"
                       " errno=%d (%s)\n", processId, lpBaseAddress, (int)nSize, lpBuffer,
                       errno, strerror(errno));
-                
+
                 SetLastError(ERROR_ACCESS_DENIED);
             }
             else
@@ -750,15 +750,15 @@ ReadProcessMemory(
 
         numberOfBytesRead = nSize;
         ret = TRUE;
-        
+
 #else   // HAVE_TTRACE
 
         offset = (SIZE_T)lpBaseAddress % sizeof(int);
         lpBaseAddressAligned =  (int*)((char*)lpBaseAddress - offset);
-        nbInts = (nSize + offset)/sizeof(int) + 
+        nbInts = (nSize + offset)/sizeof(int) +
                  ((nSize + offset)%sizeof(int) ? 1:0);
-        
-        /* before transferring any data to lpBuffer we should make sure that all 
+
+        /* before transferring any data to lpBuffer we should make sure that all
            data is accessible for read. so we need to use a temp buffer for that.*/
         if (!(lpTmpBuffer = (int*)InternalMalloc((nbInts * sizeof(int)))))
         {
@@ -766,22 +766,22 @@ ReadProcessMemory(
             SetLastError(ERROR_NOT_ENOUGH_MEMORY);
             goto CLEANUP1;
         }
-        
+
         for (ptrInt = lpTmpBuffer; nbInts; ptrInt++,
             lpBaseAddressAligned++, nbInts--)
         {
             errno = 0;
             *ptrInt =
                 PAL_PTRACE(PAL_PT_READ_D, processId, lpBaseAddressAligned, 0);
-            if (*ptrInt == -1 && errno) 
+            if (*ptrInt == -1 && errno)
             {
-                if (errno == EFAULT) 
+                if (errno == EFAULT)
                 {
                     ERROR("ptrace(PT_READ_D, pid:%d, addr:%p, data:0) failed"
                           " errno=%d (%s)\n", processId, lpBaseAddressAligned,
                           errno, strerror(errno));
-                    
-                    SetLastError(ptrInt == lpTmpBuffer ? ERROR_ACCESS_DENIED : 
+
+                    SetLastError(ptrInt == lpTmpBuffer ? ERROR_ACCESS_DENIED :
                                                          ERROR_PARTIAL_COPY);
                 }
                 else
@@ -791,21 +791,21 @@ ReadProcessMemory(
                           errno, strerror(errno));
                     SetLastError(ERROR_INTERNAL_ERROR);
                 }
-                
+
                 goto CLEANUP2;
             }
         }
-        
+
         /* transfer data from temp buffer to lpBuffer */
         memcpy( (char *)lpBuffer, ((char*)lpTmpBuffer) + offset, nSize);
         numberOfBytesRead = nSize;
         ret = TRUE;
-#endif // HAVE_TTRACE        
+#endif // HAVE_TTRACE
     }
     else
     {
         /* Failed to attach processId */
-        goto EXIT;    
+        goto EXIT;
     }
 #endif  // HAVE_PROCFS_CTL
 
@@ -814,10 +814,10 @@ PROCFSCLEANUP:
     if (fd != -1)
     {
         close(fd);
-    }    
+    }
 #elif !HAVE_TTRACE
 CLEANUP2:
-    if (lpTmpBuffer) 
+    if (lpTmpBuffer)
     {
         InternalFree(lpTmpBuffer);
     }
@@ -885,10 +885,10 @@ WriteProcessMemory(
     PERF_ENTRY(WriteProcessMemory);
     ENTRY("WriteProcessMemory (hProcess=%p,lpBaseAddress=%p, lpBuffer=%p, "
            "nSize=%u, lpNumberOfBytesWritten=%p)\n",
-           hProcess,lpBaseAddress, lpBuffer, (unsigned int)nSize, lpNumberOfBytesWritten); 
+           hProcess,lpBaseAddress, lpBuffer, (unsigned int)nSize, lpNumberOfBytesWritten);
 
     pThread = InternalGetCurrentThread();
-    
+
     if (!(nSize && (processId = PROCGetProcessIDFromHandle(hProcess))))
     {
         ERROR("Invalid nSize:%u number or invalid process handler "
@@ -896,13 +896,13 @@ WriteProcessMemory(
         SetLastError(ERROR_INVALID_PARAMETER);
         goto EXIT;
     }
-    
+
     // Check if the write request is for the current process.
     // In that case we don't need ptrace.
-    if (GetCurrentProcessId() == processId) 
+    if (GetCurrentProcessId() == processId)
     {
         TRACE("We are in the same process so we don't need ptrace\n");
-        
+
         struct Param
         {
             LPVOID lpBaseAddress;
@@ -920,7 +920,7 @@ WriteProcessMemory(
         PAL_TRY(Param *, pParam, &param)
         {
             SIZE_T i;
-            
+
             // Seg fault in memcpy can't be caught
             // so we simulate the memcpy here
 
@@ -931,7 +931,7 @@ WriteProcessMemory(
 
             pParam->numberOfBytesWritten = pParam->nSize;
             pParam->ret = TRUE;
-        } 
+        }
         PAL_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
         {
             SetLastError(ERROR_ACCESS_DENIED);
@@ -940,7 +940,7 @@ WriteProcessMemory(
 
         numberOfBytesWritten = param.numberOfBytesWritten;
         ret = param.ret;
-        goto EXIT;        
+        goto EXIT;
     }
 
 #if HAVE_VM_READ
@@ -951,7 +951,7 @@ WriteProcessMemory(
         SetLastError(ERROR_INVALID_HANDLE);
         goto EXIT;
     }
-    result = vm_write(task, (vm_address_t) lpBaseAddress, 
+    result = vm_write(task, (vm_address_t) lpBaseAddress,
                       (vm_address_t) lpBuffer, nSize);
     if (result != KERN_SUCCESS)
     {
@@ -993,7 +993,7 @@ WriteProcessMemory(
         SetLastError(ERROR_INVALID_ACCESS);
         goto PROCFSCLEANUP;
     }
-    
+
     bytesWritten = write(fd, lpBuffer, nSize);
     if (bytesWritten < 0)
     {
@@ -1012,12 +1012,12 @@ WriteProcessMemory(
 #if HAVE_TTRACE
         if (ttrace(TT_PROC_WRDATA, processId, 0, (__uint64_t)lpBaseAddress, (__uint64_t)nSize, (__uint64_t)lpBuffer) == -1)
         {
-            if (errno == EFAULT) 
+            if (errno == EFAULT)
             {
                 ERROR("ttrace(TT_PROC_WRDATA, pid:%d, addr:%p, data:%d, addr2:%d) failed"
                       " errno=%d (%s)\n", processId, lpBaseAddress, nSize, lpBuffer,
                       errno, strerror(errno));
-                
+
                 SetLastError(ERROR_ACCESS_DENIED);
             }
             else
@@ -1033,17 +1033,17 @@ WriteProcessMemory(
 
         numberOfBytesWritten = nSize;
         ret = TRUE;
-        
+
 #else   // HAVE_TTRACE
 
-        FirstIntOffset = (SIZE_T)lpBaseAddress % sizeof(int);    
+        FirstIntOffset = (SIZE_T)lpBaseAddress % sizeof(int);
         FirstIntMask = -1;
         FirstIntMask <<= (FirstIntOffset * 8);
-        
-        nbInts = (nSize + FirstIntOffset) / sizeof(int) + 
+
+        nbInts = (nSize + FirstIntOffset) / sizeof(int) +
                  (((nSize + FirstIntOffset)%sizeof(int)) ? 1:0);
         lpBaseAddressAligned = (int*)((char*)lpBaseAddress - FirstIntOffset);
-        
+
         if ((lpTmpBuffer = (int*)InternalMalloc((nbInts * sizeof(int)))) == NULL)
         {
             ERROR("Insufficient memory available !\n");
@@ -1060,7 +1060,7 @@ WriteProcessMemory(
 
         if (nbInts == 1)
         {
-            if (DBGWriteProcMem_IntWithMask(processId, lpBaseAddressAligned, 
+            if (DBGWriteProcMem_IntWithMask(processId, lpBaseAddressAligned,
                                             *lpInt,
                                             LastIntMask & FirstIntMask)
                   == 0)
@@ -1074,21 +1074,21 @@ WriteProcessMemory(
 
         if (DBGWriteProcMem_IntWithMask(processId,
                                         lpBaseAddressAligned++,
-                                        *lpInt++, FirstIntMask) 
+                                        *lpInt++, FirstIntMask)
             == 0)
         {
             goto CLEANUP2;
         }
 
         while (--nbInts > 1)
-        {      
+        {
           if (DBGWriteProcMem_Int(processId, lpBaseAddressAligned++,
                                   *lpInt++) == 0)
           {
               goto CLEANUP2;
           }
         }
-        
+
         if (DBGWriteProcMem_IntWithMask(processId, lpBaseAddressAligned,
                                         *lpInt, LastIntMask ) == 0)
         {
@@ -1114,7 +1114,7 @@ PROCFSCLEANUP:
     }
 #elif !HAVE_TTRACE
 CLEANUP2:
-    if (lpTmpBuffer) 
+    if (lpTmpBuffer)
     {
         InternalFree(lpTmpBuffer);
     }
@@ -1159,13 +1159,13 @@ Return
 --*/
 static
 int
-DBGWriteProcMem_Int(IN DWORD processId, 
+DBGWriteProcMem_Int(IN DWORD processId,
                     IN int *addr,
                     IN int data)
 {
     if (PAL_PTRACE( PAL_PT_WRITE_D, processId, addr, data ) == -1)
     {
-        if (errno == EFAULT) 
+        if (errno == EFAULT)
         {
             ERROR("ptrace(PT_WRITE_D, pid:%d caddr_t:%p data:%x) failed "
                   "errno:%d (%s)\n", processId, addr, data, errno, strerror(errno));
@@ -1214,7 +1214,7 @@ DBGWriteProcMem_IntWithMask(IN DWORD processId,
         if (((readInt = PAL_PTRACE( PAL_PT_READ_D, processId, addr, 0 )) == -1)
              && errno)
         {
-            if (errno == EFAULT) 
+            if (errno == EFAULT)
             {
                 ERROR("ptrace(PT_READ_D, pid:%d, caddr_t:%p, 0) failed "
                       "errno:%d (%s)\n", processId, addr, errno, strerror(errno));
@@ -1230,7 +1230,7 @@ DBGWriteProcMem_IntWithMask(IN DWORD processId,
             return 0;
         }
         data = (data & mask) | (readInt & ~mask);
-    }    
+    }
     return DBGWriteProcMem_Int(processId, addr, data);
 }
 #endif  // !HAVE_VM_READ && !HAVE_PROCFS_CTL && !HAVE_TTRACE
@@ -1241,12 +1241,12 @@ DBGWriteProcMem_IntWithMask(IN DWORD processId,
 Function:
   DBGAttachProcess
 
-Abstract  
-  
-  Attach the indicated process to the current process. 
-  
-  if the indicated process is already attached by the current process, then 
-  increment the number of attachment pending. if ot, attach it to the current 
+Abstract
+
+  Attach the indicated process to the current process.
+
+  if the indicated process is already attached by the current process, then
+  increment the number of attachment pending. if ot, attach it to the current
   process (with PT_ATTACH).
 
 Parameter
@@ -1256,7 +1256,7 @@ Return
   Return true if it succeeds, or false if it's fails
 --*/
 static
-BOOL 
+BOOL
 DBGAttachProcess(
     CPalThread *pThread,
     HANDLE hProcess,
@@ -1270,7 +1270,7 @@ DBGAttachProcess(
     char ctlPath[1024];
 #endif  // HAVE_PROCFS_CTL
 
-    attchmentCount = 
+    attchmentCount =
         DBGSetProcessAttached(pThread, hProcess, DBG_ATTACH);
 
     if (attchmentCount == -1)
@@ -1278,7 +1278,7 @@ DBGAttachProcess(
         /* Failed to set the process as attached */
         goto EXIT;
     }
-    
+
     if (attchmentCount == 1)
     {
 #if HAVE_PROCFS_CTL
@@ -1293,7 +1293,7 @@ DBGAttachProcess(
         waitTime.tv_sec = 0;
         waitTime.tv_nsec = 50000000;
         nanosleep(&waitTime, NULL);
-        
+
         sprintf_s(ctlPath, sizeof(ctlPath), "/proc/%d/ctl", processId);
         fd = InternalOpen(ctlPath, O_WRONLY);
         if (fd == -1)
@@ -1302,7 +1302,7 @@ DBGAttachProcess(
                   errno, strerror(errno));
             goto DETACH1;
         }
-        
+
         if (write(fd, CTL_ATTACH, sizeof(CTL_ATTACH)) < (int)sizeof(CTL_ATTACH))
         {
             ERROR("Failed to attach to %s: errno is %d (%s)\n", ctlPath,
@@ -1310,20 +1310,20 @@ DBGAttachProcess(
             close(fd);
             goto DETACH1;
         }
-        
+
         if (write(fd, CTL_WAIT, sizeof(CTL_WAIT)) < (int)sizeof(CTL_WAIT))
         {
             ERROR("Failed to wait for %s: errno is %d (%s)\n", ctlPath,
                   errno, strerror(errno));
             goto DETACH2;
         }
-        
+
         close(fd);
 #elif HAVE_TTRACE
         if (ttrace(TT_PROC_ATTACH, processId, 0, TT_DETACH_ON_EXIT, TT_VERSION, 0) == -1)
         {
             if (errno != ESRCH)
-            {                
+            {
                 ASSERT("ttrace(TT_PROC_ATTACH, pid:%d) failed errno:%d (%s)\n",
                      processId, errno, strerror(errno));
             }
@@ -1333,13 +1333,13 @@ DBGAttachProcess(
         if (PAL_PTRACE( PAL_PT_ATTACH, processId, 0, 0 ) == -1)
         {
             if (errno != ESRCH)
-            {                
+            {
                 ASSERT("ptrace(PT_ATTACH, pid:%d) failed errno:%d (%s)\n",
                      processId, errno, strerror(errno));
             }
             goto DETACH1;
         }
-                    
+
         if (waitpid(processId, NULL, WUNTRACED) == -1)
         {
             if (errno != ESRCH)
@@ -1351,7 +1351,7 @@ DBGAttachProcess(
         }
 #endif  // HAVE_PROCFS_CTL
     }
-    
+
     return TRUE;
 
 #if HAVE_PROCFS_CTL
@@ -1366,7 +1366,7 @@ DETACH2:
 DETACH2:
     if (PAL_PTRACE(PAL_PT_DETACH, processId, 0, 0) == -1)
     {
-        ASSERT("ptrace(PT_DETACH, pid:%d) failed. errno:%d (%s)\n", processId, 
+        ASSERT("ptrace(PT_DETACH, pid:%d) failed. errno:%d (%s)\n", processId,
               errno, strerror(errno));
     }
 #endif  // HAVE_PROCFS_CTL
@@ -1394,11 +1394,11 @@ Function:
 
 Abstract
   Detach the indicated process from the current process.
-  
-  if the indicated process is already attached by the current process, then 
-  decrement the number of attachment pending and detach it from the current 
-  process (with PT_DETACH) if there's no more attachment left. 
-  
+
+  if the indicated process is already attached by the current process, then
+  decrement the number of attachment pending and detach it from the current
+  process (with PT_DETACH) if there's no more attachment left.
+
 Parameter
   hProcess : process handle
   processId : process ID
@@ -1413,21 +1413,21 @@ DBGDetachProcess(
     HANDLE hProcess,
     DWORD processId
     )
-{     
+{
     int nbAttachLeft;
 #if HAVE_PROCFS_CTL
     int fd;
     char ctlPath[1024];
 #endif  // HAVE_PROCFS_CTL
 
-    nbAttachLeft = DBGSetProcessAttached(pThread, hProcess, DBG_DETACH);    
+    nbAttachLeft = DBGSetProcessAttached(pThread, hProcess, DBG_DETACH);
 
     if (nbAttachLeft == -1)
     {
         /* Failed to set the process as detached */
         return FALSE;
     }
-    
+
     /* check if there's no more attachment left on processId */
     if (nbAttachLeft == 0)
     {
@@ -1449,7 +1449,7 @@ DBGDetachProcess(
             }
             return FALSE;
         }
-        
+
         if (write(fd, CTL_DETACH, sizeof(CTL_DETACH)) < (int)sizeof(CTL_DETACH))
         {
             ERROR("Failed to detach from %s: errno is %d (%s)\n", ctlPath,
@@ -1459,7 +1459,7 @@ DBGDetachProcess(
         }
         close(fd);
 
-#elif HAVE_TTRACE  
+#elif HAVE_TTRACE
         if (ttrace(TT_PROC_DETACH, processId, 0, 0, 0, 0) == -1)
         {
             if (errno == ESRCH)
@@ -1469,7 +1469,7 @@ DBGDetachProcess(
             }
             else
             {
-                ASSERT("ttrace(TT_PROC_DETACH, pid:%d) failed. errno:%d (%s)\n", 
+                ASSERT("ttrace(TT_PROC_DETACH, pid:%d) failed. errno:%d (%s)\n",
                       processId, errno, strerror(errno));
                 SetLastError(ERROR_INTERNAL_ERROR);
             }
@@ -1477,7 +1477,7 @@ DBGDetachProcess(
         }
 #else   // HAVE_TTRACE
         if (PAL_PTRACE(PAL_PT_DETACH, processId, 1, 0) == -1)
-        {            
+        {
             if (errno == ESRCH)
             {
                 ERROR("Invalid process ID: %d\n", processId);
@@ -1485,7 +1485,7 @@ DBGDetachProcess(
             }
             else
             {
-                ASSERT("ptrace(PT_DETACH, pid:%d) failed. errno:%d (%s)\n", 
+                ASSERT("ptrace(PT_DETACH, pid:%d) failed. errno:%d (%s)\n",
                       processId, errno, strerror(errno));
                 SetLastError(ERROR_INTERNAL_ERROR);
             }
@@ -1500,7 +1500,7 @@ DBGDetachProcess(
                   processId, errno, strerror(errno));
             return FALSE;
         }
-#endif  // !HAVE_TTRACE        
+#endif  // !HAVE_TTRACE
     }
     return TRUE;
 }
@@ -1574,7 +1574,7 @@ DBGSetProcessAttached(
     }
 
     ret = pLocalData->lAttachCount;
-    
+
 DBGSetProcessAttachedExit:
 
     if (NULL != pDataLock)
@@ -1586,7 +1586,7 @@ DBGSetProcessAttachedExit:
     {
         pobjProcess->ReleaseReference(pThread);
     }
-    
+
     return ret;
 }
 
@@ -1648,7 +1648,7 @@ PAL_CreateExecWatchpoint(
     {
         TRACE("Watchpoint requested on sysenter instruction -- ignoring");
         dwError = ERROR_SUCCESS;
-        goto PAL_CreateExecWatchpointExit;        
+        goto PAL_CreateExecWatchpointExit;
     }
 #else
 #error Need syscall instruction for this platform
@@ -1692,7 +1692,7 @@ PAL_CreateExecWatchpoint(
     }
 
     dwError = ERROR_SUCCESS;
-    
+
 PAL_CreateExecWatchpointExit:
 
     if (NULL != pobjThread)
@@ -1705,8 +1705,8 @@ PAL_CreateExecWatchpointExit:
         close(fd);
     }
 
-#endif // HAVE_PRWATCH_T     
-    
+#endif // HAVE_PRWATCH_T
+
     LOGEXIT("PAL_CreateExecWatchpoint returns ret:%d\n", dwError);
     PERF_EXIT(PAL_CreateExecWatchpoint);
     return dwError;
@@ -1795,7 +1795,7 @@ PAL_DeleteExecWatchpoint(
     }
 
     dwError = ERROR_SUCCESS;
-    
+
 PAL_DeleteExecWatchpointExit:
 
     if (NULL != pobjThread)
@@ -1808,8 +1808,8 @@ PAL_DeleteExecWatchpointExit:
         close(fd);
     }
 
-#endif // HAVE_PRWATCH_T    
-    
+#endif // HAVE_PRWATCH_T
+
     LOGEXIT("PAL_DeleteExecWatchpoint returns ret:%d\n", dwError);
     PERF_EXIT(PAL_DeleteExecWatchpoint);
     return dwError;

--- a/pal/src/exception/machexception.cpp
+++ b/pal/src/exception/machexception.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -200,7 +200,7 @@ static exception_mask_t GetExceptionMask()
 
 /*++
 Function :
-    CPalThread::EnableMachExceptions 
+    CPalThread::EnableMachExceptions
 
     Hook Mach exceptions, i.e., call thread_swap_exception_ports
     to replace the thread's current exception ports with our own.
@@ -247,7 +247,7 @@ PAL_ERROR CorUnix::CPalThread::EnableMachExceptions()
         mach_port_t hExceptionPort;
         CThreadMachExceptionHandlerNode *pSavedHandlers =
             m_sMachExceptionHandlers.GetNodeForInitialization(&hExceptionPort);
-        
+
         NONPAL_TRACE("Enabling %s handlers for thread %08X\n",
                      hExceptionPort == s_TopExceptionPort ? "top" : "bottom",
                      GetMachPortSelf());
@@ -397,11 +397,11 @@ PAL_ERROR CorUnix::CPalThread::DisableMachExceptions()
     TRACE("%08X: Leave()\n", (unsigned int)(size_t)this);
 
     PAL_ERROR palError = NO_ERROR;
-    
+
     // We only store exceptions when we're installing exceptions.
     if (0 == GetExceptionMask())
         return palError;
-    
+
     // Get the handlers to restore. It isn't really as simple as this. We keep two sets of handlers (which
     // improves our ability to chain correctly in more scenarios) but this means we can encounter dilemmas
     // where we've recorded two different handlers for the same port and can only re-register one of them
@@ -430,11 +430,11 @@ PAL_ERROR CorUnix::CPalThread::DisableMachExceptions()
                                              flavor);
         kern_return_t MachRetDeallocate = mach_port_deallocate(mach_task_self(), thread);
         CHECK_MACH("mach_port_deallocate", MachRetDeallocate);
-                                             
+
         if (MachRet != KERN_SUCCESS)
             break;
     }
-    
+
     if (MachRet != KERN_SUCCESS)
     {
         ASSERT("thread_set_exception_ports failed: %d\n", MachRet);
@@ -449,7 +449,7 @@ PAL_ERROR CorUnix::CPalThread::DisableMachExceptions()
 
 /*++
 Function :
-    SEHEnableMachExceptions 
+    SEHEnableMachExceptions
 
     Enable SEH-related stuff related to mach exceptions
 
@@ -582,12 +582,12 @@ static DWORD exception_from_trap_code(
 
     switch(exception)
     {
-    // Could not access memory. subcode contains the bad memory address. 
+    // Could not access memory. subcode contains the bad memory address.
     case EXC_BAD_ACCESS:
         if (code_count != 2)
         {
             NONPAL_RETAIL_ASSERT("Got an unexpected sub code");
-            return EXCEPTION_ILLEGAL_INSTRUCTION; 
+            return EXCEPTION_ILLEGAL_INSTRUCTION;
         }
         pExceptionRecord->NumberParameters = 2;
         pExceptionRecord->ExceptionInformation[0] = 0;
@@ -610,18 +610,18 @@ static DWORD exception_from_trap_code(
         }
 #endif // _AMD64_
 
-        return EXCEPTION_ACCESS_VIOLATION; 
+        return EXCEPTION_ACCESS_VIOLATION;
 
-    // Instruction failed. Illegal or undefined instruction or operand. 
+    // Instruction failed. Illegal or undefined instruction or operand.
     case EXC_BAD_INSTRUCTION :
-        return EXCEPTION_ILLEGAL_INSTRUCTION; 
+        return EXCEPTION_ILLEGAL_INSTRUCTION;
 
-    // Arithmetic exception; exact nature of exception is in subcode field. 
+    // Arithmetic exception; exact nature of exception is in subcode field.
     case EXC_ARITHMETIC:
         if (code_count != 2)
         {
             NONPAL_RETAIL_ASSERT("Got an unexpected sub code");
-            return EXCEPTION_ILLEGAL_INSTRUCTION; 
+            return EXCEPTION_ILLEGAL_INSTRUCTION;
         }
         switch (*(unsigned *)code)
         {
@@ -638,7 +638,7 @@ static DWORD exception_from_trap_code(
 #error Trap code to exception mapping not defined for this architecture
 #endif
         default:
-            return EXCEPTION_ILLEGAL_INSTRUCTION; 
+            return EXCEPTION_ILLEGAL_INSTRUCTION;
         }
         break;
 
@@ -649,7 +649,7 @@ static DWORD exception_from_trap_code(
 #error Trap code to exception mapping not defined for this architecture
 #endif
 
-    // Trace, breakpoint, etc. Details in subcode field. 
+    // Trace, breakpoint, etc. Details in subcode field.
     case EXC_BREAKPOINT:
 #if defined(_X86_) || defined(_AMD64_)
         if (*(unsigned *)code == EXC_I386_SGL)
@@ -671,14 +671,14 @@ static DWORD exception_from_trap_code(
         break;
 
 
-    // System call requested. Details in subcode field. 
+    // System call requested. Details in subcode field.
     case EXC_SYSCALL:
-        return EXCEPTION_ILLEGAL_INSTRUCTION; 
+        return EXCEPTION_ILLEGAL_INSTRUCTION;
         break;
 
-    // System call with a number in the Mach call range requested. Details in subcode field. 
+    // System call with a number in the Mach call range requested. Details in subcode field.
     case EXC_MACH_SYSCALL:
-        return EXCEPTION_ILLEGAL_INSTRUCTION; 
+        return EXCEPTION_ILLEGAL_INSTRUCTION;
         break;
 
     default:
@@ -744,7 +744,7 @@ catch_exception_raise(
    mach_port_t task,                    // [in] task the exception happened on
    exception_type_t exception,          // [in] The type of the exception
    MACH_EH_TYPE(exception_data_t) code, // [in] A machine dependent array indicating a particular instance of exception
-   mach_msg_type_number_t code_count)   // [in] The size of the buffer (in natural-sized units). 
+   mach_msg_type_number_t code_count)   // [in] The size of the buffer (in natural-sized units).
 {
     kern_return_t MachRet;
 #if defined(_X86_)
@@ -766,8 +766,8 @@ catch_exception_raise(
         , thread
 #endif // _AMD64_
         );
-    
-    // Don't save/restore the debug registers because loading them on OSx causes a 
+
+    // Don't save/restore the debug registers because loading them on OSx causes a
     // priviledged instruction fault. The "DE" in CR4 is set.
 #ifdef _X86_
     ThreadContext.ContextFlags = CONTEXT_CONTROL | CONTEXT_INTEGER | CONTEXT_SEGMENTS | CONTEXT_FLOATING_POINT | CONTEXT_EXTENDED_REGISTERS
@@ -953,7 +953,7 @@ catch_exception_raise(
         ThreadState.eflags &= ~EFL_TF;
     }
 
-    ExceptionRecord.ExceptionFlags = EXCEPTION_IS_SIGNAL; 
+    ExceptionRecord.ExceptionFlags = EXCEPTION_IS_SIGNAL;
     ExceptionRecord.ExceptionRecord = NULL;
     ExceptionRecord.ExceptionAddress = (void *)ThreadContext.Eip;
 
@@ -1001,7 +1001,7 @@ catch_exception_raise(
         ThreadState.__rflags &= ~EFL_TF;
     }
 
-    ExceptionRecord.ExceptionFlags = EXCEPTION_IS_SIGNAL; 
+    ExceptionRecord.ExceptionFlags = EXCEPTION_IS_SIGNAL;
     ExceptionRecord.ExceptionRecord = NULL;
     ExceptionRecord.ExceptionAddress = (void *)ThreadContext.Rip;
 
@@ -1133,10 +1133,10 @@ bool IsWithinCoreCLR(void *pAddr)
 BOOL PALAPI PAL_IsIPInCoreCLR(IN PVOID address)
 {
     BOOL fIsAddressWithinCoreCLR = FALSE;
-    
+
     PERF_ENTRY(PAL_IsIPInCoreCLR);
     ENTRY("PAL_IsIPInCoreCLR (address=%p)\n", address);
-    
+
     if (address != NULL)
     {
         if (IsWithinCoreCLR(address))
@@ -1144,10 +1144,10 @@ BOOL PALAPI PAL_IsIPInCoreCLR(IN PVOID address)
             fIsAddressWithinCoreCLR = TRUE;
         }
     }
-    
+
     LOGEXIT("PAL_IsIPInCoreCLR returns %d\n", fIsAddressWithinCoreCLR);
     PERF_EXIT(PAL_IsIPInCoreCLR);
-    
+
     return fIsAddressWithinCoreCLR;
 }
 
@@ -1155,7 +1155,7 @@ BOOL PALAPI PAL_IsIPInCoreCLR(IN PVOID address)
 
 extern malloc_zone_t *s_pExecutableHeap; // from heap.cpp in #ifdef CACHE_HEAP_ZONE
 
-#pragma mark - 
+#pragma mark -
 #pragma mark malloc_zone utilities
 
 // Ultimately, this may be more appropriate for heap.cpp, and rewritten in terms of
@@ -1171,17 +1171,17 @@ static void malloc_zone_owns_addr_helper(task_t task, void *context, unsigned ty
     vm_range_t *ranges, unsigned range_count)
 {
     malloc_zone_owns_addr_context_t *our_context = (malloc_zone_owns_addr_context_t *)context;
-    
+
     if (our_context->fInUse)
         return;
-    
+
     vm_range_t *pRange = ranges;
     vm_range_t *pRangeMac = ranges + range_count;
     void *addr = our_context->addr;
     for (; pRange < pRangeMac; pRange++)
     {
         vm_range_t range = *pRange;
-        
+
         if ((range.address <= (vm_address_t)addr) && ((range.address + range.size) > (vm_address_t)addr))
         {
             our_context->fInUse = true;
@@ -1194,10 +1194,10 @@ static bool malloc_zone_owns_addr(malloc_zone_t *zone, void * const addr)
 {
     malloc_introspection_t *introspect = zone->introspect;
     malloc_zone_owns_addr_context_t context = { addr, false };
-    
-    (*introspect->enumerator)(mach_task_self(), &context, MALLOC_PTR_IN_USE_RANGE_TYPE, 
+
+    (*introspect->enumerator)(mach_task_self(), &context, MALLOC_PTR_IN_USE_RANGE_TYPE,
         (vm_address_t)zone, NULL /* memory_reader_t */, &malloc_zone_owns_addr_helper);
-    
+
     return context.fInUse;
 }
 
@@ -1250,7 +1250,7 @@ bool IsHandledException(MachMessage *pNotification, CorUnix::CPalThread *pThread
         NONPAL_TRACE("    IP (%p) is in the executable heap (%p).\n", ip, s_pExecutableHeap);
         return true;
     }
-    
+
     // Check inside our virtual alloc reserves.
     if (VIRTUALOwnedRegion((UINT_PTR)ip))
     {
@@ -1367,7 +1367,7 @@ void *SEHExceptionThread(void *args)
                 MachRet = thread_resume(hThread);
                 CHECK_MACH("thread_resume", MachRet);
             }
-            
+
             MachRet = CONTEXT_SetThreadContextOnPort(hThread, &sContext);
             CHECK_MACH("CONTEXT_SetThreadContextOnPort", MachRet);
 
@@ -1405,7 +1405,7 @@ void *SEHExceptionThread(void *args)
             {
                 // This is one of ours, pass the relevant exception data to our handler.
                 MACH_EH_TYPE(exception_data_type_t) rgCodes[2];
-                
+
                 int cCodes = sMessage.GetExceptionCodeCount();
                 if (cCodes < 0 || cCodes > 2)
                     NONPAL_RETAIL_ASSERT("Bad exception code count: %d", cCodes);
@@ -1478,7 +1478,7 @@ void *SEHExceptionThread(void *args)
 
                         pReq = pReq->m_pNext;
                     }
-                    
+
                     if (!fReplied)
                     {
                         // Store enough detail about the notification that we can create a reply once the
@@ -1492,22 +1492,22 @@ void *SEHExceptionThread(void *args)
                         pNewNotification->m_eNotificationType = sMessage.GetMessageType();
                         pNewNotification->m_eNotificationFlavor = sMessage.GetThreadStateFlavor();
                         pNewNotification->m_fTopException = fTopException;
-    
+
                         // Forward the notification. A port is returned upon which the reply will be received at
                         // some point.
                         pNewNotification->m_hListenReplyPort = sReplyOrForward.ForwardNotification(&sHandler,
                                                                                                    &sMessage);
-    
+
                         // Move the reply port into the listen set so we'll receive the reply as soon as it's sent.
                         MachRet = mach_port_move_member(mach_task_self(),
                                                         pNewNotification->m_hListenReplyPort,
                                                         s_ExceptionPortSet);
                         CHECK_MACH("mach_port_move_member", MachRet);
-    
+
                         // Link the forward records into our list of outstanding forwards.
                         pNewNotification->m_pNext = pOutstandingForwards;
                         pOutstandingForwards = pNewNotification;
-    
+
                         NONPAL_TRACE("    Forwarded request to %08X (reply expected on %08X).\n",
                                      sHandler.m_handler,
                                      pNewNotification->m_hListenReplyPort);
@@ -1641,7 +1641,7 @@ PAL_NORETURN void MachSetThreadContext(CONTEXT *lpContext)
 
 /*++
 Function :
-    SEHInitializeMachExceptions 
+    SEHInitializeMachExceptions
 
     Initialize all SEH-related stuff related to mach exceptions
 
@@ -1785,7 +1785,7 @@ BOOL SEHInitializeMachExceptions (void)
 
 /*++
 Function :
-    MachExceptionInitializeDebug 
+    MachExceptionInitializeDebug
 
     Initialize the mach exception handlers necessary for a managed debugger
     to work
@@ -1823,7 +1823,7 @@ Function :
     Restore default exception port handler
 
     (no parameters, no return value)
-    
+
 Note :
 During PAL_Terminate, we reach a point where SEH isn't possible any more
 (handle manager is off, etc). Past that point, we can't avoid crashing on

--- a/pal/src/exception/machexception.h
+++ b/pal/src/exception/machexception.h
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -51,4 +51,3 @@ PAL_NORETURN void MachSetThreadContext(CONTEXT *lpContext);
 #endif // __cplusplus
 
 #endif /* _MACHEXCEPTION_H_ */
-

--- a/pal/src/exception/machmessage.cpp
+++ b/pal/src/exception/machmessage.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -63,7 +63,7 @@ Abstract:
 MachMessage::MachMessage()
 {
     m_fPortsOwned = false;
-    
+
     ResetMessage();
 }
 
@@ -72,7 +72,7 @@ MachMessage::MachMessage()
 void MachMessage::Receive(mach_port_t hPort)
 {
     kern_return_t machret;
-    
+
     // Erase any stale data.
     ResetMessage();
 
@@ -107,7 +107,7 @@ void MachMessage::Receive(mach_port_t hPort)
     default:
         FATAL_ERROR("Unsupported message type: %u", m_pMessage->header.msgh_id);
     }
-    
+
     m_fPortsOwned = true;
 }
 
@@ -224,7 +224,7 @@ void MachMessage::GetPorts(bool fCalculate, bool fValidThread)
     case SET_THREAD_MESSAGE_ID:
         m_hThread = m_pMessage->data.set_thread.thread;
         break;
-    
+
     case EXCEPTION_RAISE_MESSAGE_ID:
         m_hThread = m_pMessage->data.raise.thread_port.name;
         m_hTask = m_pMessage->data.raise.task_port.name;
@@ -262,7 +262,7 @@ void MachMessage::GetPorts(bool fCalculate, bool fValidThread)
         m_hThread = m_pMessage->data.raise_state_identity_64.thread_port.name;
         m_hTask = m_pMessage->data.raise_state_identity_64.task_port.name;
         break;
-        
+
     default:
         if (fValidThread)
         {
@@ -624,7 +624,7 @@ mach_port_t MachMessage::ForwardNotification(CorUnix::MachExceptionHandler *pHan
 {
     kern_return_t machret;
     mach_port_t hReplyPort;
-    
+
     // Allocate a new port dedicated to receiving the reply for this forward. This will allow us to match the
     // reply to the original request later on.
     machret = mach_port_allocate(mach_task_self(),
@@ -819,14 +819,14 @@ void MachMessage::ResetMessage()
     if (m_fPortsOwned)
     {
         kern_return_t machret;
-        
+
         GetPorts(false /* fCalculate */, false /* fValidThread */);
         if (m_hThread != MACH_PORT_NULL)
         {
             machret = mach_port_deallocate(mach_task_self(), m_hThread);
             MACH_CHECK("mach_port_deallocate(m_hThread)");
         }
-        
+
         if (m_hTask != MACH_PORT_NULL)
         {
             machret = mach_port_deallocate(mach_task_self(), m_hTask);
@@ -934,7 +934,7 @@ void MachMessage::InitFixedFields()
     }
 
     m_pMessage->header.msgh_reserved = 0;
-    
+
     if (m_hTask)
     {
         kern_return_t machret;
@@ -1065,7 +1065,7 @@ thread_act_t MachMessage::GetThreadFromState(thread_state_flavor_t eFlavor, thre
         targetSP = ((x86_thread_state64_t*)pState)->__rsp;
         break;
 #endif // _AMD64_
-        
+
     default:
         FATAL_ERROR("Unhandled thread state flavor: %u", eFlavor);
     }
@@ -1083,7 +1083,7 @@ thread_act_t MachMessage::GetThreadFromState(thread_state_flavor_t eFlavor, thre
     for (mach_msg_type_number_t i = 0; i < cThreads; i++)
     {
         // Get the general register state of each thread.
-#ifdef _X86_        
+#ifdef _X86_
         x86_thread_state32_t sThreadState;
         const thread_state_flavor_t sThreadStateFlavor = x86_THREAD_STATE32;
 #elif defined(_AMD64_)
@@ -1111,7 +1111,7 @@ thread_act_t MachMessage::GetThreadFromState(thread_state_flavor_t eFlavor, thre
 #endif
             {
                 thread_act_t hThread = pThreads[i];
-                
+
                 // Increment the refcount; the thread is a "send" right.
                 machret = mach_port_mod_refs(mach_task_self(), hThread, MACH_PORT_RIGHT_SEND, 1);
                 MACH_CHECK("mach_port_mod_refs()");
@@ -1257,7 +1257,7 @@ void MachMessage::SetThread(thread_act_t hThread)
         FATAL_ERROR("Unsupported message type: %u", m_pMessage->header.msgh_id);
         fSet = false;
     }
-    
+
     if (fSet)
     {
         // Addref the thread port.

--- a/pal/src/exception/machmessage.h
+++ b/pal/src/exception/machmessage.h
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -335,7 +335,7 @@ private:
     //  * fCalculate -- calculate the thread port if the message did not contain it.
     //  * fValidate  -- failfast if the message was not one expected to have a (calculable) thread port.
     void GetPorts(bool fCalculate, bool fValidThread);
-    
+
     // Given a thread's register context, locate and return the Mach port representing that thread. Only the
     // x86_THREAD_STATE and x86_THREAD_STATE32 state flavors are supported.
     thread_act_t GetThreadFromState(thread_state_flavor_t eFlavor, thread_state_t pState);
@@ -377,10 +377,10 @@ private:
 
     // Cached value of GetThread() or MACH_PORT_NULL if that has not been computed yet.
     thread_act_t    m_hThread;
-    
+
     // Cached value of the task port or MACH_PORT_NULL if the message doesn't have one.
     mach_port_t     m_hTask;
-    
+
     // Considered whether we are responsible for the deallocation of the ports in
     // this message. It is true for messages we receive, and false for messages we send.
     bool m_fPortsOwned;

--- a/pal/src/exception/seh-unwind.cpp
+++ b/pal/src/exception/seh-unwind.cpp
@@ -28,17 +28,17 @@ Abstract:
 #include "pal/context.h"
 #include "pal.h"
 #include <dlfcn.h>
-    
+
 #if HAVE_LIBUNWIND_H
 #ifndef __LINUX__
 #define UNW_LOCAL_ONLY
-#endif // !__LINUX__       
+#endif // !__LINUX__
 #include <libunwind.h>
 #ifdef __LINUX__
 #ifdef HAVE_LIBUNWIND_PTRACE
 #include <libunwind-ptrace.h>
 #endif // HAVE_LIBUNWIND_PTRACE
-#endif // __LINUX__    
+#endif // __LINUX__
 #endif // HAVE_LIBUNWIND_H
 
 
@@ -167,7 +167,7 @@ static void GetContextPointer(unw_cursor_t *cursor, unw_context_t *unwContext, i
     if (saveLoc.type == UNW_SLT_MEMORY)
     {
         SIZE_T *pLoc = (SIZE_T *)saveLoc.u.addr;
-        // Filter out fake save locations that point to unwContext 
+        // Filter out fake save locations that point to unwContext
         if ((pLoc < (SIZE_T *)unwContext) || ((SIZE_T *)(unwContext + 1) <= pLoc))
             *contextPointer = (SIZE_T *)saveLoc.u.addr;
     }
@@ -252,7 +252,7 @@ BOOL PAL_VirtualUnwind(CONTEXT *context, KNONVOLATILE_CONTEXT_POINTERS *contextP
 
 #if defined(__APPLE__) || defined(__FreeBSD__) || defined(_ARM64_)
     // OSX and FreeBSD appear to do two different things when unwinding
-    // 1: If it reaches where it cannot unwind anymore, say a 
+    // 1: If it reaches where it cannot unwind anymore, say a
     // managed frame.  It wil return 0, but also update the $pc
     // 2: If it unwinds all the way to _start it will return
     // 0 from the step, but $pc will stay the same.
@@ -330,7 +330,7 @@ static int access_mem(unw_addr_space_t as, unw_word_t addr, unw_word_t *valp, in
     {
         return UNW_ESUCCESS;
     }
-    else 
+    else
     {
         return -UNW_EUNSPEC;
     }
@@ -346,7 +346,7 @@ static int access_reg(unw_addr_space_t as, unw_regnum_t regnum, unw_word_t *valp
 
     CONTEXT *winContext = LibunwindCallbacksInfo.Context;
 
-    switch (regnum) 
+    switch (regnum)
     {
 #if defined(_AMD64_)
         case UNW_REG_IP:       *valp = (unw_word_t) winContext->Rip; break;
@@ -409,28 +409,28 @@ static int resume(unw_addr_space_t as, unw_cursor_t *cp, void *arg)
 static int get_proc_name(unw_addr_space_t as, unw_word_t addr, char *bufp, size_t buf_len, unw_word_t *offp, void *arg)
 {
     ASSERT("Not supposed to be ever called");
-    return -UNW_EINVAL;  
+    return -UNW_EINVAL;
 }
 
-int find_proc_info(unw_addr_space_t as, 
+int find_proc_info(unw_addr_space_t as,
                    unw_word_t ip, unw_proc_info_t *pip,
                    int need_unwind_info, void *arg)
 {
 #ifdef HAVE_LIBUNWIND_PTRACE
-    // UNIXTODO: libunwind RPM package on Fedora/CentOS/RedHat doesn't have libunwind-ptrace.so 
+    // UNIXTODO: libunwind RPM package on Fedora/CentOS/RedHat doesn't have libunwind-ptrace.so
     // and we can't use it from a shared library like libmscordaccore.so.
     // That's why all calls to ptrace parts of libunwind ifdeffed out for now.
     return _UPT_find_proc_info(as, ip, pip, need_unwind_info, arg);
-#else    
+#else
     return -UNW_EINVAL;
-#endif    
+#endif
 }
 
 void put_unwind_info(unw_addr_space_t as, unw_proc_info_t *pip, void *arg)
 {
-#ifdef HAVE_LIBUNWIND_PTRACE    
+#ifdef HAVE_LIBUNWIND_PTRACE
     return _UPT_put_unwind_info(as, pip, arg);
-#endif    
+#endif
 }
 
 static unw_accessors_t unwind_accessors =
@@ -445,20 +445,20 @@ static unw_accessors_t unwind_accessors =
     .get_proc_name = get_proc_name
 };
 
-BOOL PAL_VirtualUnwindOutOfProc(CONTEXT *context, 
-                                KNONVOLATILE_CONTEXT_POINTERS *contextPointers, 
-                                DWORD pid, 
+BOOL PAL_VirtualUnwindOutOfProc(CONTEXT *context,
+                                KNONVOLATILE_CONTEXT_POINTERS *contextPointers,
+                                DWORD pid,
                                 ReadMemoryWordCallback readMemCallback)
 {
-    // This function can be executed only by one thread at a time. 
+    // This function can be executed only by one thread at a time.
     // The reason for this is that we need to pass context and read mem function to libunwind callbacks
-    // but "arg" is already used by the pointer returned from _UPT_create(). 
+    // but "arg" is already used by the pointer returned from _UPT_create().
     // So we resort to using global variables and a lock.
-    struct Lock 
+    struct Lock
     {
         CRITICAL_SECTION cs;
         Lock()
-        {        
+        {
             // ctor of a static variable is a thread-safe way to initialize critical section exactly once (clang,gcc)
             InitializeCriticalSection(&cs);
         }
@@ -477,7 +477,7 @@ BOOL PAL_VirtualUnwindOutOfProc(CONTEXT *context,
             LeaveCriticalSection(cs);
             cs = NULL;
         }
-    };    
+    };
     static Lock lock;
     LockHolder lockHolder(&lock.cs);
 
@@ -492,9 +492,9 @@ BOOL PAL_VirtualUnwindOutOfProc(CONTEXT *context,
     LibunwindCallbacksInfo.readMemCallback = readMemCallback;
     WinContextToUnwindContext(context, &unwContext);
     addrSpace = unw_create_addr_space(&unwind_accessors, 0);
-#ifdef HAVE_LIBUNWIND_PTRACE    
+#ifdef HAVE_LIBUNWIND_PTRACE
     libunwindUptPtr = _UPT_create(pid);
-#endif    
+#endif
     st = unw_init_remote(&cursor, addrSpace, libunwindUptPtr);
     if (st < 0)
     {
@@ -519,22 +519,22 @@ BOOL PAL_VirtualUnwindOutOfProc(CONTEXT *context,
 
 Exit:
 #ifdef HAVE_LIBUNWIND_PTRACE
-    if (libunwindUptPtr != NULL) 
+    if (libunwindUptPtr != NULL)
     {
         _UPT_destroy(libunwindUptPtr);
     }
-#endif    
-    if (addrSpace != 0) 
+#endif
+    if (addrSpace != 0)
     {
         unw_destroy_addr_space(addrSpace);
-    }    
+    }
     return result;
 }
 #else // __LINUX__
 
-BOOL PAL_VirtualUnwindOutOfProc(CONTEXT *context, 
-                                KNONVOLATILE_CONTEXT_POINTERS *contextPointers, 
-                                DWORD pid, 
+BOOL PAL_VirtualUnwindOutOfProc(CONTEXT *context,
+                                KNONVOLATILE_CONTEXT_POINTERS *contextPointers,
+                                DWORD pid,
                                 ReadMemoryWordCallback readMemCallback)
 {
     //UNIXTODO: Implement for Mac flavor of libunwind
@@ -552,18 +552,18 @@ Parameters:
     ExceptionRecord - the Windows exception record to throw
 
 Note:
-    The name of this function and the name of the ExceptionRecord 
+    The name of this function and the name of the ExceptionRecord
     parameter is used in the sos lldb plugin code to read the exception
     record. See coreclr\src\ToolBox\SOS\lldbplugin\debugclient.cpp.
 
     This function must not be inlined or optimized so the below PAL_VirtualUnwind
-    calls end up with RaiseException caller's context and so the above debugger 
+    calls end up with RaiseException caller's context and so the above debugger
     code finds the function and ExceptionRecord parameter.
 --*/
 PAL_NORETURN
 __attribute__((noinline))
 __attribute__((optnone))
-static void 
+static void
 RtlpRaiseException(EXCEPTION_RECORD *ExceptionRecord)
 {
     // Capture the context of RtlpRaiseException.
@@ -572,10 +572,10 @@ RtlpRaiseException(EXCEPTION_RECORD *ExceptionRecord)
     ContextRecord.ContextFlags = CONTEXT_FULL;
     CONTEXT_CaptureContext(&ContextRecord);
 
-    // Find the caller of RtlpRaiseException.  
+    // Find the caller of RtlpRaiseException.
     PAL_VirtualUnwind(&ContextRecord, NULL);
 
-    // The frame we're looking at now is RaiseException. We have to unwind one 
+    // The frame we're looking at now is RaiseException. We have to unwind one
     // level further to get the actual context user code could be resumed at.
     PAL_VirtualUnwind(&ContextRecord, NULL);
 

--- a/pal/src/exception/seh.cpp
+++ b/pal/src/exception/seh.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -74,7 +74,7 @@ Return value :
     TRUE  if SEH support initialization succeeded
     FALSE otherwise
 --*/
-BOOL 
+BOOL
 SEHInitialize (CPalThread *pthrCurrent, DWORD flags)
 {
 #if !HAVE_MACH_EXCEPTIONS
@@ -99,9 +99,9 @@ Parameters :
     None
 
     (no return value)
-    
+
 --*/
-VOID 
+VOID
 SEHCleanup()
 {
     TRACE("Cleaning up SEH\n");
@@ -126,7 +126,7 @@ Return value:
     None
 --*/
 VOID
-PALAPI 
+PALAPI
 PAL_SetHardwareExceptionHandler(
     IN PHARDWARE_EXCEPTION_HANDLER exceptionHandler)
 {
@@ -163,7 +163,7 @@ SEHProcessException(PEXCEPTION_POINTERS pointers)
         }
     }
 
-    TRACE("Unhandled hardware exception %08x at %p\n", 
+    TRACE("Unhandled hardware exception %08x at %p\n",
         pointers->ExceptionRecord->ExceptionCode, pointers->ExceptionRecord->ExceptionAddress);
 }
 
@@ -252,7 +252,7 @@ bool CatchHardwareExceptionHolder::IsEnabled()
 --*/
 
 #ifdef __llvm__
-__thread 
+__thread
 #else // __llvm__
 __declspec(thread)
 #endif // !__llvm__
@@ -275,7 +275,7 @@ NativeExceptionHolderBase::~NativeExceptionHolderBase()
     }
 }
 
-void 
+void
 NativeExceptionHolderBase::Push()
 {
     NativeExceptionHolderBase **head = &t_nativeExceptionHolderHead;
@@ -292,7 +292,7 @@ NativeExceptionHolderBase::FindNextHolder(NativeExceptionHolderBase *currentHold
     while (holder != nullptr)
     {
         if (((void *)holder > stackLowAddress) && ((void *)holder < stackHighAddress))
-        { 
+        {
             return holder;
         }
         // Get next holder

--- a/pal/src/exception/signal.cpp
+++ b/pal/src/exception/signal.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -66,7 +66,7 @@ static void sigsegv_handler(int code, siginfo_t *siginfo, void *context);
 static void sigtrap_handler(int code, siginfo_t *siginfo, void *context);
 static void sigbus_handler(int code, siginfo_t *siginfo, void *context);
 
-static void common_signal_handler(PEXCEPTION_POINTERS pointers, int code, 
+static void common_signal_handler(PEXCEPTION_POINTERS pointers, int code,
                                   native_context_t *ucontext);
 
 static void inject_activation_handler(int code, siginfo_t *siginfo, void *context);
@@ -145,11 +145,11 @@ Parameters :
     None
 
     (no return value)
-    
+
 note :
-reason for this function is that during PAL_Terminate, we reach a point where 
-SEH isn't possible anymore (handle manager is off, etc). Past that point, 
-we can't avoid crashing on a signal     
+reason for this function is that during PAL_Terminate, we reach a point where
+SEH isn't possible anymore (handle manager is off, etc). Past that point,
+we can't avoid crashing on a signal
 --*/
 void SEHCleanupSignals()
 {
@@ -433,8 +433,8 @@ static void inject_activation_handler(int code, siginfo_t *siginfo, void *contex
 
             CONTEXT winContext;
             CONTEXTFromNativeContext(
-                ucontext, 
-                &winContext, 
+                ucontext,
+                &winContext,
                 CONTEXT_CONTROL | CONTEXT_INTEGER | CONTEXT_FLOATING_POINT);
 
             if (g_safeActivationCheckFunction(CONTEXTGetPC(&winContext)))
@@ -456,7 +456,7 @@ Function :
 
 Parameters :
     pThread            - target PAL thread
-    activationFunction - function to call 
+    activationFunction - function to call
 
 (no return value)
 --*/
@@ -466,7 +466,7 @@ PAL_ERROR InjectActivationInternal(CorUnix::CPalThread* pThread)
     if (status != 0)
     {
         // Failure to send the signal is fatal. There are only two cases when sending
-        // the signal can fail. First, if the signal ID is invalid and second, 
+        // the signal can fail. First, if the signal ID is invalid and second,
         // if the thread doesn't exist anymore.
         abort();
     }
@@ -478,7 +478,7 @@ PAL_ERROR InjectActivationInternal(CorUnix::CPalThread* pThread)
 Function :
     SEHSetSafeState
 
-    specify whether the current thread is in a state where exception handling 
+    specify whether the current thread is in a state where exception handling
     of signals can be done safely
 
 Parameters:
@@ -500,7 +500,7 @@ void SEHSetSafeState(CPalThread *pthrCurrent, BOOL state)
 Function :
     SEHGetSafeState
 
-    determine whether the current thread is in a state where exception handling 
+    determine whether the current thread is in a state where exception handling
     of signals can be done safely
 
     (no parameters)
@@ -531,10 +531,10 @@ Parameters :
 
     (no return value)
 Note:
-    the "pointers" parameter should contain a valid exception record pointer, 
-    but the contextrecord pointer will be overwritten.    
+    the "pointers" parameter should contain a valid exception record pointer,
+    but the contextrecord pointer will be overwritten.
 --*/
-static void common_signal_handler(PEXCEPTION_POINTERS pointers, int code, 
+static void common_signal_handler(PEXCEPTION_POINTERS pointers, int code,
                                   native_context_t *ucontext)
 {
     sigset_t signal_set;
@@ -557,7 +557,7 @@ static void common_signal_handler(PEXCEPTION_POINTERS pointers, int code,
     if(-1 == sigprocmask(SIG_UNBLOCK, &signal_set, NULL))
     {
         ASSERT("sigprocmask failed; error is %d (%s)\n", errno, strerror(errno));
-    } 
+    }
 
     SEHProcessException(pointers);
 }
@@ -574,8 +574,8 @@ Parameters :
     previousAction : previous sigaction struct
 
     (no return value)
-    
-note : if sigfunc is NULL, the default signal handler is restored    
+
+note : if sigfunc is NULL, the default signal handler is restored
 --*/
 void handle_signal(int signal_id, SIGFUNC sigfunc, struct sigaction *previousAction)
 {

--- a/pal/src/exception/signal.hpp
+++ b/pal/src/exception/signal.hpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -57,4 +57,3 @@ void SEHCleanupSignals();
 #endif // !HAVE_MACH_EXCEPTIONS
 
 #endif /* _PAL_SIGNAL_HPP_ */
-

--- a/pal/src/file/directory.cpp
+++ b/pal/src/file/directory.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -120,7 +120,7 @@ Parameters:
 
 Return Value:
 
-    BOOL - 
+    BOOL -
         TRUE <=> successful
 
 --*/
@@ -133,7 +133,7 @@ RemoveDirectoryHelper (
 )
 {
     BOOL  bRet = FALSE;
-    *dwLastError = 0; 
+    *dwLastError = 0;
 
     FILEDosToUnixPathA( lpPathName );
     if ( !FILEGetFileNameFromSymLink(lpPathName))
@@ -154,8 +154,8 @@ RemoveDirectoryHelper (
         case ENOENT:
         {
             struct stat stat_data;
-            
-            if ( stat( lpPathName, &stat_data) == 0 && 
+
+            if ( stat( lpPathName, &stat_data) == 0 &&
                  (stat_data.st_mode & S_IFMT) == S_IFREG )
             {
                 /* Not a directory, it is a file. */
@@ -199,13 +199,13 @@ RemoveDirectoryA(
     PathCharString mb_dirPathString;
     size_t length;
     char * mb_dir;
-    
+
     PERF_ENTRY(RemoveDirectoryA);
     ENTRY("RemoveDirectoryA(lpPathName=%p (%s))\n",
           lpPathName,
           lpPathName);
 
-    if (lpPathName == NULL) 
+    if (lpPathName == NULL)
     {
         dwLastError = ERROR_PATH_NOT_FOUND;
         goto done;
@@ -218,7 +218,7 @@ RemoveDirectoryA(
         dwLastError = ERROR_NOT_ENOUGH_MEMORY;
         goto done;
     }
-    
+
     if (strncpy_s (mb_dir, sizeof(char) * (length+1), lpPathName, MAX_LONGPATH) != SAFECRT_SUCCESS)
     {
         mb_dirPathString.CloseBuffer(length);
@@ -264,7 +264,7 @@ RemoveDirectoryW(
           lpPathName?lpPathName:W16_NULLSTRING,
           lpPathName?lpPathName:W16_NULLSTRING);
 
-    if (lpPathName == NULL) 
+    if (lpPathName == NULL)
     {
         dwLastError = ERROR_PATH_NOT_FOUND;
         goto done;
@@ -275,7 +275,7 @@ RemoveDirectoryW(
     if (NULL == mb_dir)
     {
         dwLastError = ERROR_NOT_ENOUGH_MEMORY;
-        goto done;        
+        goto done;
     }
 
     mb_size = WideCharToMultiByte( CP_ACP, 0, lpPathName, -1, mb_dir, length,
@@ -457,7 +457,7 @@ SetCurrentDirectoryW(
     int  size;
     size_t length;
     char * dir;
-    
+
     PERF_ENTRY(SetCurrentDirectoryW);
     ENTRY("SetCurrentDirectoryW(lpPathName=%p (%S))\n",
           lpPathName?lpPathName:W16_NULLSTRING,
@@ -481,11 +481,11 @@ SetCurrentDirectoryW(
         bRet = FALSE;
         goto done;
     }
-    
+
     size = WideCharToMultiByte( CP_ACP, 0, lpPathName, -1, dir, length,
                                 NULL, NULL );
     dirPathString.CloseBuffer(size);
-    
+
     if( size == 0 )
     {
         dwLastError = GetLastError();
@@ -593,7 +593,7 @@ CreateDirectoryA(
     }
     else
     {
-        const char *cwd = PAL__getcwd(NULL, MAX_LONGPATH);        
+        const char *cwd = PAL__getcwd(NULL, MAX_LONGPATH);
         if (NULL == cwd)
         {
             WARN("Getcwd failed with errno=%d [%s]\n", errno, strerror(errno));
@@ -608,7 +608,7 @@ CreateDirectoryA(
 
         PAL_free((char *)cwd);
     }
-    
+
     // Canonicalize the path so we can determine its length.
     FILECanonicalizePath(realPath);
 

--- a/pal/src/file/file.cpp
+++ b/pal/src/file/file.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -99,7 +99,7 @@ FileCleanupRoutine(
     IDataLock *pLocalDataLock = NULL;
 
     palError = pObjectToCleanup->GetProcessLocalData(
-        pThread, 
+        pThread,
         ReadLock,
         &pLocalDataLock,
         reinterpret_cast<void**>(&pLocalData)
@@ -126,10 +126,10 @@ FileCleanupRoutine(
 
 typedef enum
 {
-  PIID_STDIN_HANDLE, 
+  PIID_STDIN_HANDLE,
   PIID_STDOUT_HANDLE,
   PIID_STDERR_HANDLE
-} PROCINFO_ID; 
+} PROCINFO_ID;
 
 #define PAL_LEGAL_FLAGS_ATTRIBS (FILE_ATTRIBUTE_NORMAL| \
                                  FILE_FLAG_SEQUENTIAL_SCAN| \
@@ -139,16 +139,16 @@ typedef enum
                                  FILE_FLAG_BACKUP_SEMANTICS)
 
 /* Static global. The init function must be called
-before any other functions and if it is not successful, 
+before any other functions and if it is not successful,
 no other functions should be done. */
 static HANDLE pStdIn;
 static HANDLE pStdOut;
 static HANDLE pStdErr;
 
 /*++
-Function : 
+Function :
     FILEGetProperNotFoundError
-    
+
 Returns the proper error code, based on the
 Windows behavior.
 
@@ -181,12 +181,12 @@ void FILEGetProperNotFoundError( LPSTR lpPath, LPDWORD lpErrorCode )
     if ( lpLastPathSeparator != NULL )
     {
         *lpLastPathSeparator = '\0';
-        
+
         /* If the last path component is a directory,
            we return file not found. If it's a file or
            doesn't exist, we return path not found. */
-        if ( '\0' == *lpDupedPath || 
-             ( stat( lpDupedPath, &stat_data ) == 0 && 
+        if ( '\0' == *lpDupedPath ||
+             ( stat( lpDupedPath, &stat_data ) == 0 &&
              ( stat_data.st_mode & S_IFMT ) == S_IFDIR ) )
         {
             TRACE( "ERROR_FILE_NOT_FOUND\n" );
@@ -203,7 +203,7 @@ void FILEGetProperNotFoundError( LPSTR lpPath, LPDWORD lpErrorCode )
         TRACE( "ERROR_FILE_NOT_FOUND\n" );
         *lpErrorCode = ERROR_FILE_NOT_FOUND;
     }
-    
+
     InternalFree(lpDupedPath);
     lpDupedPath = NULL;
     TRACE( "FILEGetProperNotFoundError returning TRUE\n" );
@@ -211,9 +211,9 @@ void FILEGetProperNotFoundError( LPSTR lpPath, LPDWORD lpErrorCode )
 }
 
 /*++
-Function : 
+Function :
     FILEGetLastErrorFromErrnoAndFilename
-    
+
 Returns the proper error code for errno, or, if errno is ENOENT,
 based on the Windows behavior for nonexistent filenames.
 
@@ -237,12 +237,12 @@ PAL_ERROR FILEGetLastErrorFromErrnoAndFilename(LPSTR lpPath)
 InternalCanonicalizeRealPath
     Wraps realpath() to hide platform differences. See the man page for
     realpath(3) for details of how realpath() works.
-    
+
     On systems on which realpath() allows the last path component to not
     exist, this is a straight thunk through to realpath(). On other
     systems, we remove the last path component, then call realpath().
 
-    cch is the size of lpBuffer and has to be atleast PATH_MAX (since 
+    cch is the size of lpBuffer and has to be atleast PATH_MAX (since
     realpath() requires the buffer to be atleast PATH_MAX).
 --*/
 PAL_ERROR
@@ -258,7 +258,7 @@ CorUnix::InternalCanonicalizeRealPath(LPCSTR lpUnixPath, LPSTR lpBuffer, DWORD c
     DWORD cchBuffer = 0;
     DWORD cchFilename = 0;
 #endif // !REALPATH_SUPPORTS_NONEXISTENT_FILES
- 
+
     if ( (lpUnixPath == NULL) || (lpBuffer == NULL) || (cch < PATH_MAX) )
     {
         ERROR ("Invalid argument to InternalCanonicalizeRealPath\n");
@@ -319,7 +319,7 @@ CorUnix::InternalCanonicalizeRealPath(LPCSTR lpUnixPath, LPSTR lpBuffer, DWORD c
                  }
             }
 #endif // defined(_AMD64_)
-            
+
             goto LExit;
         }
         lpFilename = lpExistingPath;
@@ -352,7 +352,7 @@ CorUnix::InternalCanonicalizeRealPath(LPCSTR lpUnixPath, LPSTR lpBuffer, DWORD c
         else
 #endif // defined(_AMD64_)
             *pchSeparator = '\0';
-            
+
         lpRealPath = realpath(lpExistingPath, lpBuffer);
         if (lpRealPath == NULL)
         {
@@ -406,7 +406,7 @@ CorUnix::InternalCanonicalizeRealPath(LPCSTR lpUnixPath, LPSTR lpBuffer, DWORD c
     // 2 is for "/" and NULL
     if (cchBuffer + cchFilename + 2 > cch)
     {
-        ERROR ("Provided buffer size (%d) is smaller than the required (%d)\n", 
+        ERROR ("Provided buffer size (%d) is smaller than the required (%d)\n",
                 cch, cchBuffer + cchFilename + 2);
         palError = ERROR_INSUFFICIENT_BUFFER;
         lpRealPath = NULL;
@@ -534,7 +534,7 @@ CorUnix::InternalCreateFile(
 
     // Initialize the path to zeroes...
     ZeroMemory(lpFullUnixPath, cchFullUnixPath);
-    
+
     FILEDosToUnixPathA( lpUnixPath );
 
     // Compute the absolute pathname to the file.  This pathname is used
@@ -552,8 +552,8 @@ CorUnix::InternalCreateFile(
     switch( dwDesiredAccess )
     {
     case 0:
-        /* Device Query Access was requested. let's use open() with 
-           no flags, it's basically the equivalent of O_RDONLY, since 
+        /* Device Query Access was requested. let's use open() with
+           no flags, it's basically the equivalent of O_RDONLY, since
            O_RDONLY is defined as 0x0000 */
         break;
     case( GENERIC_READ ):
@@ -572,7 +572,7 @@ CorUnix::InternalCreateFile(
     }
 
     TRACE("open flags are 0x%lx\n", open_flags);
-    
+
     if ( lpSecurityAttributes )
     {
         if ( lpSecurityAttributes->nLength != sizeof( SECURITY_ATTRIBUTES ) ||
@@ -592,7 +592,7 @@ CorUnix::InternalCreateFile(
         ASSERT("Bad dwFlagsAndAttributes\n");
         palError = ERROR_INVALID_PARAMETER;
         goto done;
-    } 
+    }
     else if (dwFlagsAndAttributes & FILE_FLAG_BACKUP_SEMANTICS)
     {
         /* Override the open flags, and always open as readonly.  This
@@ -631,7 +631,7 @@ CorUnix::InternalCreateFile(
     //
 
     palError = g_pFileLockManager->GetLockControllerForFile(
-        pThread, 
+        pThread,
         lpUnixPath,
         dwDesiredAccess,
         dwShareMode,
@@ -649,7 +649,7 @@ CorUnix::InternalCreateFile(
     */
     switch( dwCreationDisposition )
     {
-    case( CREATE_ALWAYS ):        
+    case( CREATE_ALWAYS ):
         // check whether the file exists
         if ( access( lpUnixPath, F_OK ) == 0 )
         {
@@ -718,10 +718,10 @@ CorUnix::InternalCreateFile(
     // you can atleast implement a lock file using this.
     lock_mode = (dwShareMode == 0 /* FILE_SHARE_NONE */) ? LOCK_EX : LOCK_SH;
 
-    if(flock(filed, lock_mode | LOCK_NB) != 0) 
+    if(flock(filed, lock_mode | LOCK_NB) != 0)
     {
         TRACE("flock() failed; error is %s (%d)\n", strerror(errno), errno);
-        if (errno == EWOULDBLOCK) 
+        if (errno == EWOULDBLOCK)
         {
             palError = ERROR_SHARING_VIOLATION;
         }
@@ -749,7 +749,7 @@ CorUnix::InternalCreateFile(
 #endif
     }
 #endif
-    
+
     /* make file descriptor close-on-exec; inheritable handles will get
       "uncloseonexeced" in CreateProcess if they are actually being inherited*/
     if(-1 == fcntl(filed,F_SETFD,1))
@@ -815,7 +815,7 @@ CorUnix::InternalCreateFile(
     palError = g_pObjectManager->RegisterObject(
         pThread,
         pFileObject,
-        &aotFile, 
+        &aotFile,
         dwDesiredAccess,
         phFile,
         &pRegisteredFile
@@ -869,7 +869,7 @@ done:
     {
         pRegisteredFile->ReleaseReference(pThread);
     }
-    
+
     if (NULL != lpUnixPath)
     {
         InternalFree(lpUnixPath);
@@ -917,9 +917,9 @@ CreateFileA(
 
     PERF_ENTRY(CreateFileA);
     ENTRY("CreateFileA(lpFileName=%p (%s), dwAccess=%#x, dwShareMode=%#x, "
-          "lpSecurityAttr=%p, dwDisposition=%#x, dwFlags=%#x, " 
-          "hTemplateFile=%p )\n",lpFileName?lpFileName:"NULL",lpFileName?lpFileName:"NULL", dwDesiredAccess, 
-          dwShareMode, lpSecurityAttributes, dwCreationDisposition, 
+          "lpSecurityAttr=%p, dwDisposition=%#x, dwFlags=%#x, "
+          "hTemplateFile=%p )\n",lpFileName?lpFileName:"NULL",lpFileName?lpFileName:"NULL", dwDesiredAccess,
+          dwShareMode, lpSecurityAttributes, dwCreationDisposition,
           dwFlagsAndAttributes, hTemplateFile);
 
     pThread = InternalGetCurrentThread();
@@ -995,17 +995,17 @@ CreateFileW(
     {
         length = (PAL_wcslen(lpFileName)+1) * MaxWCharToAcpLengthFactor;
     }
-    
+
     name = namePathString.OpenStringBuffer(length);
     if (NULL == name)
     {
         palError = ERROR_NOT_ENOUGH_MEMORY;
         goto done;
     }
-    
+
     size = WideCharToMultiByte( CP_ACP, 0, lpFileName, -1, name, length,
                                 NULL, NULL );
-    namePathString.CloseBuffer(size);    
+    namePathString.CloseBuffer(size);
 
     if( size == 0 )
     {
@@ -1088,7 +1088,7 @@ CopyFileW(
     {
         length = (PAL_wcslen(lpExistingFileName)+1) * MaxWCharToAcpLengthFactor;
     }
-    
+
     source = sourcePathString.OpenStringBuffer(length);
     if (NULL == source)
     {
@@ -1099,7 +1099,7 @@ CopyFileW(
     src_size = WideCharToMultiByte( CP_ACP, 0, lpExistingFileName, -1, source, length,
                                 NULL, NULL );
     sourcePathString.CloseBuffer(src_size);
-    
+
     if( src_size == 0 )
     {
         DWORD dwLastError = GetLastError();
@@ -1121,7 +1121,7 @@ CopyFileW(
     {
         length = (PAL_wcslen(lpNewFileName)+1) * MaxWCharToAcpLengthFactor;
     }
-    
+
     dest = destPathString.OpenStringBuffer(length);
     if (NULL == dest)
     {
@@ -1131,7 +1131,7 @@ CopyFileW(
     dest_size = WideCharToMultiByte( CP_ACP, 0, lpNewFileName, -1, dest, length,
                                 NULL, NULL );
     destPathString.CloseBuffer(dest_size);
-    
+
     if( dest_size == 0 )
     {
         DWORD dwLastError = GetLastError();
@@ -1194,9 +1194,9 @@ DeleteFileA(
     }
     strcpy_s( lpUnixFileName, lpUnixFileNamePS.GetSizeOf(), lpFileName);
     lpUnixFileNamePS.CloseBuffer(length);
-    
+
     FILEDosToUnixPathA( lpUnixFileName );
-    
+
     if ( !FILEGetFileNameFromSymLink(lpUnixFileName))
     {
         dwLastError = FILEGetLastErrorFromErrnoAndFilename(lpUnixFileName);
@@ -1213,7 +1213,7 @@ DeleteFileA(
 
     // Initialize the path to zeroes...
     ZeroMemory(lpFullUnixFileName, cchFullUnixFileName);
-    
+
     // Compute the absolute pathname to the file.  This pathname is used
     // to determine if two file names represent the same file.
     palError = InternalCanonicalizeRealPath(lpUnixFileName, lpFullUnixFileName, cchFullUnixFileName);
@@ -1235,7 +1235,7 @@ DeleteFileA(
     // Note that there is a window here where a race condition can occur:
     //   the check for the sharing mode and the unlink are two separate actions
     //   (not a single atomic action). So it's possible that between the check
-    //   happening and the unlink happening, the file may have been closed. If 
+    //   happening and the unlink happening, the file may have been closed. If
     //   it is just closed and not re-opened, no problems.
     //   If it is closed and re-opened without any sharing, we should be calling
     //   InternalDelete instead which would have failed.
@@ -1301,12 +1301,12 @@ DeleteFileW(
       lpFileName?lpFileName:W16_NULLSTRING);
 
     pThread = InternalGetCurrentThread();
-    
+
     if (lpFileName != NULL)
     {
         length = (PAL_wcslen(lpFileName)+1) * MaxWCharToAcpLengthFactor;
     }
-    
+
     name = namePS.OpenStringBuffer(length);
     if (NULL == name)
     {
@@ -1317,7 +1317,7 @@ DeleteFileW(
     size = WideCharToMultiByte( CP_ACP, 0, lpFileName, -1, name, length,
                                 NULL, NULL );
     namePS.CloseBuffer(size);
-    
+
     if( size == 0 )
     {
         DWORD dwLastError = GetLastError();
@@ -1446,7 +1446,7 @@ MoveFileExA(
     }
 
     length = strlen(lpExistingFileName);
-    
+
     source = sourcePS.OpenStringBuffer(length);
     if (NULL == source)
     {
@@ -1455,11 +1455,11 @@ MoveFileExA(
     }
     strcpy_s( source, sourcePS.GetSizeOf(), lpExistingFileName);
     sourcePS.CloseBuffer(length);
-    
+
     FILEDosToUnixPathA( source );
 
     length = strlen(lpNewFileName);
-    
+
     dest = destPS.OpenStringBuffer(length);
     if (NULL == dest)
     {
@@ -1468,7 +1468,7 @@ MoveFileExA(
     }
     strcpy_s( dest, destPS.GetSizeOf(), lpNewFileName);
     destPS.CloseBuffer(length);
-    
+
     FILEDosToUnixPathA( dest );
 
     if ( !FILEGetFileNameFromSymLink(source))
@@ -1501,33 +1501,33 @@ MoveFileExA(
         ((errno == ENOTDIR) || (errno == EEXIST)))
     {
         bRet = DeleteFileA( lpNewFileName );
-        
-        if ( bRet ) 
+
+        if ( bRet )
         {
             result = rename( source, dest );
         }
         else
-        { 
+        {
             dwLastError = GetLastError();
         }
-    } 
+    }
 
     if ( result < 0 )
     {
         switch( errno )
         {
         case EXDEV: /* we tried to link across devices */
-        
+
             if ( dwFlags & MOVEFILE_COPY_ALLOWED )
             {
                 BOOL bFailIfExists = !(dwFlags & MOVEFILE_REPLACE_EXISTING);
-            
+
                 /* if CopyFile fails here, so should MoveFailEx */
                 bRet = CopyFileA( lpExistingFileName,
                           lpNewFileName,
                           bFailIfExists );
                 /* CopyFile should set the appropriate error */
-                if ( !bRet ) 
+                if ( !bRet )
                 {
                     dwLastError = GetLastError();
                 }
@@ -1537,8 +1537,8 @@ MoveFileExA(
                     {
                         ERROR("Failed to delete the source file\n");
                         dwLastError = GetLastError();
-                    
-                        /* Delete the destination file if we're unable to delete 
+
+                        /* Delete the destination file if we're unable to delete
                            the source file */
                         if (!DeleteFileA(lpNewFileName))
                         {
@@ -1616,12 +1616,12 @@ MoveFileExW(
           lpNewFileName?lpNewFileName:W16_NULLSTRING, dwFlags);
 
     pThread = InternalGetCurrentThread();
-    
+
     if (lpExistingFileName != NULL)
     {
         length = (PAL_wcslen(lpExistingFileName)+1) * MaxWCharToAcpLengthFactor;
     }
-    
+
     source = sourcePS.OpenStringBuffer(length);
     if (NULL == source)
     {
@@ -1652,7 +1652,7 @@ MoveFileExW(
     {
         length = (PAL_wcslen(lpNewFileName)+1) * MaxWCharToAcpLengthFactor;
     }
-    
+
     dest = destPS.OpenStringBuffer(length);
     if (NULL == dest)
     {
@@ -1662,7 +1662,7 @@ MoveFileExW(
     dest_size = WideCharToMultiByte( CP_ACP, 0, lpNewFileName, -1, dest, length,
                                 NULL, NULL );
     destPS.CloseBuffer(dest_size);
-    
+
     if( dest_size == 0 )
     {
         DWORD dwLastError = GetLastError();
@@ -1736,7 +1736,7 @@ GetFileAttributesA(
     }
 
     length = strlen(lpFileName);
-    
+
     UnixFileName = UnixFileNamePS.OpenStringBuffer(length);
     if (NULL == UnixFileName)
     {
@@ -1745,7 +1745,7 @@ GetFileAttributesA(
     }
     strcpy_s( UnixFileName, UnixFileNamePS.GetSizeOf(), lpFileName );
     UnixFileNamePS.CloseBuffer(length);
-    
+
     FILEDosToUnixPathA( UnixFileName );
 
     if ( stat(UnixFileName, &stat_data) != 0 )
@@ -1760,7 +1760,7 @@ GetFileAttributesA(
     }
     else if ( (stat_data.st_mode & S_IFMT) != S_IFREG )
     {
-        ERROR("Not a regular file or directory, S_IFMT is %#x\n", 
+        ERROR("Not a regular file or directory, S_IFMT is %#x\n",
               stat_data.st_mode & S_IFMT);
         dwLastError = ERROR_ACCESS_DENIED;
         goto done;
@@ -1819,12 +1819,12 @@ GetFileAttributesW(
           lpFileName?lpFileName:W16_NULLSTRING);
 
     pThread = InternalGetCurrentThread();
-    if (lpFileName == NULL) 
+    if (lpFileName == NULL)
     {
         pThread->SetLastError(ERROR_PATH_NOT_FOUND);
         goto done;
     }
-    
+
     length = (PAL_wcslen(lpFileName)+1) * MaxWCharToAcpLengthFactor;
     filename = filenamePS.OpenStringBuffer(length);
     if (NULL == filename)
@@ -1835,7 +1835,7 @@ GetFileAttributesW(
     size = WideCharToMultiByte( CP_ACP, 0, lpFileName, -1, filename, length,
                                 NULL, NULL );
     filenamePS.CloseBuffer(size);
-    
+
     if( size == 0 )
     {
         DWORD dwLastError = GetLastError();
@@ -1904,12 +1904,12 @@ GetFileAttributesExW(
         goto done;
     }
 
-    if (lpFileName == NULL) 
+    if (lpFileName == NULL)
     {
         dwLastError = ERROR_PATH_NOT_FOUND;
         goto done;
     }
-    
+
     length = (PAL_wcslen(lpFileName)+1) * MaxWCharToAcpLengthFactor;
     name = namePS.OpenStringBuffer(length);
     if (NULL == name)
@@ -1920,7 +1920,7 @@ GetFileAttributesExW(
     size = WideCharToMultiByte( CP_ACP, 0, lpFileName, -1, name, length,
                                 NULL, NULL );
     namePS.CloseBuffer(size);
-    
+
     if( size == 0 )
     {
         dwLastError = GetLastError();
@@ -2012,14 +2012,14 @@ SetFileAttributesW(
     ENTRY("SetFileAttributesW(lpFileName=%p (%S), dwFileAttributes=%#x)\n",
         lpFileName?lpFileName:W16_NULLSTRING,
         lpFileName?lpFileName:W16_NULLSTRING, dwFileAttributes);
-    
+
     pThread = InternalGetCurrentThread();
-    if (lpFileName == NULL) 
+    if (lpFileName == NULL)
     {
         dwLastError = ERROR_PATH_NOT_FOUND;
         goto done;
     }
-    
+
     length = (PAL_wcslen(lpFileName)+1) * MaxWCharToAcpLengthFactor;
     name = namePS.OpenStringBuffer(length);
     if (NULL == name)
@@ -2030,7 +2030,7 @@ SetFileAttributesW(
     size = WideCharToMultiByte( CP_ACP, 0, lpFileName, -1, name, length,
                                 NULL, NULL );
     namePS.CloseBuffer(size);
-    
+
     if( size == 0 )
     {
         dwLastError = GetLastError();
@@ -2117,10 +2117,10 @@ CorUnix::InternalWriteFile(
     {
         goto done;
     }
-    
+
     palError = pFileObject->GetProcessLocalData(
         pThread,
-        ReadLock, 
+        ReadLock,
         &pLocalDataLock,
         reinterpret_cast<void**>(&pLocalData)
         );
@@ -2143,7 +2143,7 @@ CorUnix::InternalWriteFile(
     // Inform the lock controller for this file (if any) of our intention
     // to perform a write. (Note that pipes don't have lock controllers.)
     //
-    
+
     if (NULL != pLocalData->pLockController)
     {
         /* Get the current file position to calculate the region to lock */
@@ -2197,7 +2197,7 @@ CorUnix::InternalWriteFile(
     }
 #endif
 
-    res = write( ifd, lpBuffer, nNumberOfBytesToWrite );  
+    res = write( ifd, lpBuffer, nNumberOfBytesToWrite );
     TRACE("write() returns %d\n", res);
 
     if ( res >= 0 )
@@ -2208,9 +2208,9 @@ CorUnix::InternalWriteFile(
     {
         palError = FILEGetLastErrorFromErrno();
     }
-    
+
 done:
-    
+
     if (NULL != pTransactionLock)
     {
         pTransactionLock->ReleaseLock();
@@ -2250,10 +2250,10 @@ WriteFile(
 {
     PAL_ERROR palError;
     CPalThread *pThread;
-    
+
     PERF_ENTRY(WriteFile);
     ENTRY("WriteFile(hFile=%p, lpBuffer=%p, nToWrite=%u, lpWritten=%p, "
-          "lpOverlapped=%p)\n", hFile, lpBuffer, nNumberOfBytesToWrite, 
+          "lpOverlapped=%p)\n", hFile, lpBuffer, nNumberOfBytesToWrite,
           lpNumberOfBytesWritten, lpOverlapped);
 
     pThread = InternalGetCurrentThread();
@@ -2293,7 +2293,7 @@ CorUnix::InternalReadFile(
     IDataLock *pLocalDataLock = NULL;
     IFileTransactionLock *pTransactionLock = NULL;
     int ifd;
-    
+
     LONG readOffsetStartLow = 0, readOffsetStartHigh = 0;
     int res;
 
@@ -2304,7 +2304,7 @@ CorUnix::InternalReadFile(
         // place, per MSDN
         //
 
-        *lpNumberOfBytesRead = 0;        
+        *lpNumberOfBytesRead = 0;
     }
     else
     {
@@ -2347,7 +2347,7 @@ CorUnix::InternalReadFile(
 
     palError = pFileObject->GetProcessLocalData(
         pThread,
-        ReadLock, 
+        ReadLock,
         &pLocalDataLock,
         reinterpret_cast<void**>(&pLocalData)
         );
@@ -2370,7 +2370,7 @@ CorUnix::InternalReadFile(
     // Inform the lock controller for this file (if any) of our intention
     // to perform a read. (Note that pipes don't have lock controllers.)
     //
-    
+
     if (NULL != pLocalData->pLockController)
     {
         /* Get the current file position to calculate the region to lock */
@@ -2433,7 +2433,7 @@ Read:
     {
         palError = FILEGetLastErrorFromErrno();
     }
-    
+
 done:
 
     if (NULL != pTransactionLock)
@@ -2474,11 +2474,11 @@ ReadFile(
 {
     PAL_ERROR palError;
     CPalThread *pThread;
-    
+
     PERF_ENTRY(ReadFile);
     ENTRY("ReadFile(hFile=%p, lpBuffer=%p, nToRead=%u, "
           "lpRead=%p, lpOverlapped=%p)\n",
-          hFile, lpBuffer, nNumberOfBytesToRead, 
+          hFile, lpBuffer, nNumberOfBytesToRead,
           lpNumberOfBytesRead, lpOverlapped);
 
     pThread = InternalGetCurrentThread();
@@ -2530,7 +2530,7 @@ GetStdHandle(
         hRet = pStdOut;
         break;
     case STD_ERROR_HANDLE:
-        hRet = pStdErr; 
+        hRet = pStdErr;
         break;
     default:
         ERROR("nStdHandle is invalid\n");
@@ -2578,7 +2578,7 @@ CorUnix::InternalSetEndOfFile(
 
     palError = pFileObject->GetProcessLocalData(
         pThread,
-        ReadLock, 
+        ReadLock,
         &pLocalDataLock,
         reinterpret_cast<void**>(&pLocalData)
         );
@@ -2594,7 +2594,7 @@ CorUnix::InternalSetEndOfFile(
         palError = ERROR_ACCESS_DENIED;
         goto InternalSetEndOfFileExit;
     }
-    
+
     curr = lseek(pLocalData->unix_fd, 0, SEEK_CUR);
 
     TRACE("current file pointer offset is %u\n", curr);
@@ -2624,7 +2624,7 @@ CorUnix::InternalSetEndOfFile(
     // Perform an additional check to make sure that there's likely to be enough free space to satisfy the
     // request. Do this because it's been observed on Mac OSX that ftruncate can return failure but still
     // extend the file to consume the remainder of free space.
-    // 
+    //
     struct statfs sFileSystemStats;
     off_t cbFreeSpace;
     if (fstatfs(pLocalData->unix_fd, &sFileSystemStats) != 0)
@@ -2632,7 +2632,7 @@ CorUnix::InternalSetEndOfFile(
         ERROR("fstatfs failed\n");
         palError = FILEGetLastErrorFromErrno();
         goto InternalSetEndOfFileExit;
-    } 
+    }
 
     // Free space is free blocks times the size of each block in bytes.
     cbFreeSpace = (off_t)sFileSystemStats.f_bavail * (off_t)sFileSystemStats.f_bsize;
@@ -2745,13 +2745,13 @@ InternalSetFilePointerForUnixFd(
     switch( dwMoveMethod )
     {
     case FILE_BEGIN:
-        seek_whence = SEEK_SET; 
+        seek_whence = SEEK_SET;
         break;
     case FILE_CURRENT:
-        seek_whence = SEEK_CUR; 
+        seek_whence = SEEK_CUR;
         break;
     case FILE_END:
-        seek_whence = SEEK_END; 
+        seek_whence = SEEK_END;
         break;
     default:
         ERROR("dwMoveMethod = %d is invalid\n", dwMoveMethod);
@@ -2760,16 +2760,16 @@ InternalSetFilePointerForUnixFd(
     }
 
     //
-    // According to MSDN, if lpDistanceToMoveHigh is not null, 
-    // lDistanceToMove is treated as unsigned; 
+    // According to MSDN, if lpDistanceToMoveHigh is not null,
+    // lDistanceToMove is treated as unsigned;
     // it is treated as signed otherwise
     //
-    
+
     if ( lpDistanceToMoveHigh )
     {
         /* set the high 32 bits of the offset */
         seek_offset = ((__int64)*lpDistanceToMoveHigh << 32);
-        
+
         /* set the low 32 bits */
         /* cast to unsigned long to avoid sign extension */
         seek_offset |= (ULONG) lDistanceToMove;
@@ -2784,12 +2784,12 @@ InternalSetFilePointerForUnixFd(
     old_offset = lseek(iUnixFd, 0, SEEK_CUR);
     if (old_offset == -1)
     {
-        ERROR("lseek(fd,0,SEEK_CUR) failed errno:%d (%s)\n", 
+        ERROR("lseek(fd,0,SEEK_CUR) failed errno:%d (%s)\n",
               errno, strerror(errno));
         palError = ERROR_ACCESS_DENIED;
         goto done;
     }
-    
+
     // Check to see if we're going to seek to a negative offset.
     // If we're seeking from the beginning or the current mark,
     // this is simple.
@@ -2807,7 +2807,7 @@ InternalSetFilePointerForUnixFd(
         // do that.
         struct stat fileData;
         int result;
-        
+
         result = fstat(iUnixFd, &fileData);
         if (result == -1)
         {
@@ -2843,7 +2843,7 @@ InternalSetFilePointerForUnixFd(
         /* store high-order DWORD */
         if ( lpDistanceToMoveHigh )
             *lpDistanceToMoveHigh = (DWORD)(seek_res >> 32);
-    
+
         /* return low-order DWORD of seek result */
         *lpNewFilePointerLow = (DWORD)seek_res;
     }
@@ -2890,7 +2890,7 @@ CorUnix::InternalSetFilePointer(
 
     palError = pFileObject->GetProcessLocalData(
         pThread,
-        ReadLock, 
+        ReadLock,
         &pLocalDataLock,
         reinterpret_cast<void**>(&pLocalData)
         );
@@ -2907,7 +2907,7 @@ CorUnix::InternalSetFilePointer(
         dwMoveMethod,
         lpNewFilePointerLow
         );
-    
+
 InternalSetFilePointerExit:
 
     if (NULL != pLocalDataLock)
@@ -2962,20 +2962,20 @@ SetFilePointer(
         lNewFilePointerLow = INVALID_SET_FILE_POINTER;
     }
 
-    /* This function must always call SetLastError - even if successful. 
+    /* This function must always call SetLastError - even if successful.
        If we seek to a value greater than 2^32 - 1, we will effectively be
        returning a negative value from this function. Now, let's say that
-       returned value is -1. Furthermore, assume that win32error has been 
-       set before even entering this function. Then, when this function 
-       returns to SetFilePointer in win32native.cs, it will have returned 
+       returned value is -1. Furthermore, assume that win32error has been
+       set before even entering this function. Then, when this function
+       returns to SetFilePointer in win32native.cs, it will have returned
        -1 and win32error will have been set, which will cause an error to be
-       returned. Since -1 may not be an error in this case and since we 
-       can't assume that the win32error is related to SetFilePointer, 
-       we need to always call SetLastError here. That way, if this function 
-       succeeds, SetFilePointer in win32native won't mistakenly determine 
+       returned. Since -1 may not be an error in this case and since we
+       can't assume that the win32error is related to SetFilePointer,
+       we need to always call SetLastError here. That way, if this function
+       succeeds, SetFilePointer in win32native won't mistakenly determine
        that it failed. */
     pThread->SetLastError(palError);
-    
+
     LOGEXIT("SetFilePointer returns DWORD %#x\n", lNewFilePointerLow);
     PERF_EXIT(SetFilePointer);
     return lNewFilePointerLow;
@@ -3001,8 +3001,8 @@ SetFilePointerEx(
 
     PERF_ENTRY(SetFilePointerEx);
     ENTRY("SetFilePointerEx(hFile=%p, liDistanceToMove=0x%llx, "
-           "lpNewFilePointer=%p (0x%llx), dwMoveMethod=0x%x)\n", hFile, 
-           liDistanceToMove.QuadPart, lpNewFilePointer, 
+           "lpNewFilePointer=%p (0x%llx), dwMoveMethod=0x%x)\n", hFile,
+           liDistanceToMove.QuadPart, lpNewFilePointer,
            (lpNewFilePointer) ? (*lpNewFilePointer).QuadPart : 0, dwMoveMethod);
 
     LONG lDistanceToMove;
@@ -3036,7 +3036,7 @@ SetFilePointerEx(
         }
         Ret = TRUE;
     }
-    
+
     LOGEXIT("SetFilePointerEx returns BOOL %d\n", Ret);
     PERF_EXIT(SetFilePointerEx);
     return Ret;
@@ -3079,7 +3079,7 @@ CorUnix::InternalGetFileSize(
 
     palError = pFileObject->GetProcessLocalData(
         pThread,
-        ReadLock, 
+        ReadLock,
         &pLocalDataLock,
         reinterpret_cast<void**>(&pLocalData)
         );
@@ -3097,7 +3097,7 @@ CorUnix::InternalGetFileSize(
     }
 
     *pdwFileSizeLow = (DWORD)stat_data.st_size;
-    
+
     if (NULL != pdwFileSizeHigh)
     {
 #if SIZEOF_OFF_T > 4
@@ -3145,7 +3145,7 @@ GetFileSize(
 
     palError = InternalGetFileSize(
         pThread,
-        hFile, 
+        hFile,
         &dwFileSizeLow,
         lpFileSizeHigh
         );
@@ -3239,10 +3239,10 @@ CorUnix::InternalFlushFileBuffers(
     {
         goto InternalFlushFileBuffersExit;
     }
-    
+
     palError = pFileObject->GetProcessLocalData(
         pThread,
-        ReadLock, 
+        ReadLock,
         &pLocalDataLock,
         reinterpret_cast<void**>(&pLocalData)
         );
@@ -3270,26 +3270,26 @@ CorUnix::InternalFlushFileBuffers(
         if (fsync(pLocalData->unix_fd) == 0)
             break;
 #endif // __APPLE__
-            
+
         switch (errno)
         {
         case EINTR:
             // Execution was interrupted by a signal, so restart.
             TRACE("fsync(%d) was interrupted. Restarting\n", pLocalData->unix_fd);
             break;
-            
+
         default:
             palError = FILEGetLastErrorFromErrno();
             WARN("fsync(%d) failed with error %d\n", pLocalData->unix_fd, errno);
             break;
         }
-    } while (NO_ERROR == palError);    
+    } while (NO_ERROR == palError);
 #else // HAVE_FSYNC
     /* flush all buffers out to disk - there is no way to flush
        an individual file descriptor's buffers out. */
     sync();
 #endif // HAVE_FSYNC else
-    
+
 
 InternalFlushFileBuffersExit:
 
@@ -3374,10 +3374,10 @@ CorUnix::InternalGetFileType(
     {
         goto InternalGetFileTypeExit;
     }
-    
+
     palError = pFileObject->GetProcessLocalData(
         pThread,
-        ReadLock, 
+        ReadLock,
         &pLocalDataLock,
         reinterpret_cast<void**>(&pLocalData)
         );
@@ -3418,7 +3418,7 @@ CorUnix::InternalGetFileType(
     {
         *pdwFileType = FILE_TYPE_UNKNOWN;
     }
-    
+
 
 InternalGetFileTypeExit:
 
@@ -3493,7 +3493,7 @@ GetFileType(
 uUnique is always 0.
  --*/
 const int MAX_PREFIX        = 3;
-const int MAX_SEEDSIZE      = 8; /* length of "unique portion of 
+const int MAX_SEEDSIZE      = 8; /* length of "unique portion of
                                    the string, plus extension(FFFF.TMP). */
 static USHORT uUniqueSeed   = 0;
 static BOOL IsInitialized   = FALSE;
@@ -3513,24 +3513,24 @@ GetTempFileNameA(
     CHAR * file_template;
     PathCharString file_templatePS;
     CHAR    chLastPathNameChar;
- 
+
     HANDLE  hTempFile;
     UINT    uRet = 0;
     DWORD   dwError;
     USHORT  uLoopCounter = 0;
 
     PERF_ENTRY(GetTempFileNameA);
-    ENTRY("GetTempFileNameA(lpPathName=%p (%s), lpPrefixString=%p (%s), uUnique=%u, " 
-          "lpTempFileName=%p)\n",  lpPathName?lpPathName:"NULL",  lpPathName?lpPathName:"NULL", 
-        lpPrefixString?lpPrefixString:"NULL", 
-        lpPrefixString?lpPrefixString:"NULL", uUnique, 
+    ENTRY("GetTempFileNameA(lpPathName=%p (%s), lpPrefixString=%p (%s), uUnique=%u, "
+          "lpTempFileName=%p)\n",  lpPathName?lpPathName:"NULL",  lpPathName?lpPathName:"NULL",
+        lpPrefixString?lpPrefixString:"NULL",
+        lpPrefixString?lpPrefixString:"NULL", uUnique,
         lpTempFileName?lpTempFileName:"NULL");
 
     pThread = InternalGetCurrentThread();
     if ( !IsInitialized )
     {
         uUniqueSeed = (USHORT)( time( NULL ) );
-    
+
         /* On the off chance 0 is returned.
         0 being the error return code.  */
         ENSURE_UNIQUE_NOT_ZERO
@@ -3543,14 +3543,14 @@ GetTempFileNameA(
        goto done;
     }
 
-    if ( NULL == lpTempFileName )  
+    if ( NULL == lpTempFileName )
     {
         ERROR( "lpTempFileName cannot be NULL\n" );
         pThread->SetLastError( ERROR_INVALID_PARAMETER );
         goto done;
     }
 
-    if ( strlen( lpPathName ) + MAX_SEEDSIZE + MAX_PREFIX >= MAX_LONGPATH ) 
+    if ( strlen( lpPathName ) + MAX_SEEDSIZE + MAX_PREFIX >= MAX_LONGPATH )
     {
         WARN( "File names larger than MAX_LONGPATH (%d)!\n", MAX_LONGPATH );
         pThread->SetLastError( ERROR_FILENAME_EXCED_RANGE );
@@ -3573,7 +3573,7 @@ GetTempFileNameA(
     {
         strcat_s( file_template, file_templatePS.GetSizeOf(), "\\" );
     }
-    
+
     if ( lpPrefixString )
     {
         strncat_s( file_template, file_templatePS.GetSizeOf(), lpPrefixString, MAX_PREFIX );
@@ -3594,18 +3594,18 @@ GetTempFileNameA(
     }
     sprintf_s( full_name, full_namePS.GetSizeOf(), file_template, (0 == uUnique) ? uUniqueSeed : uUnique);
     full_namePS.CloseBuffer(length);
-    
-    hTempFile = CreateFileA( full_name, GENERIC_WRITE, 
+
+    hTempFile = CreateFileA( full_name, GENERIC_WRITE,
                              FILE_SHARE_READ, NULL, CREATE_NEW, 0, NULL );
-    
+
     if (uUnique == 0)
     {
         /* The USHORT will overflow back to 0 if we go past
         65536 files, so break the loop after 65536 iterations.
-        If the CreateFile call was not successful within that 
+        If the CreateFile call was not successful within that
         number of iterations, then there are no temp file names
         left for that directory. */
-        while ( ERROR_PATH_NOT_FOUND != GetLastError() && 
+        while ( ERROR_PATH_NOT_FOUND != GetLastError() &&
                 INVALID_HANDLE_VALUE == hTempFile && uLoopCounter < 0xFFFF )
         {
             uUniqueSeed++;
@@ -3613,10 +3613,10 @@ GetTempFileNameA(
 
             pThread->SetLastError( NOERROR );
             sprintf_s( full_name, full_namePS.GetSizeOf(), file_template, uUniqueSeed );
-            hTempFile = CreateFileA( full_name, GENERIC_WRITE, 
+            hTempFile = CreateFileA( full_name, GENERIC_WRITE,
                                     FILE_SHARE_READ, NULL, CREATE_NEW, 0, NULL );
             uLoopCounter++;
-        
+
         }
     }
 
@@ -3640,7 +3640,7 @@ GetTempFileNameA(
         {
             uRet = uUnique;
         }
-        
+
         if ( CloseHandle( hTempFile ) )
         {
             if (strcpy_s( lpTempFileName, MAX_LONGPATH, full_name ) != SAFECRT_SUCCESS)
@@ -3651,7 +3651,7 @@ GetTempFileNameA(
                 uRet = 0;
             }
         }
-        else  
+        else
         {
             ASSERT( "Unable to close the handle %p\n", hTempFile );
             pThread->SetLastError( ERROR_INTERNAL_ERROR );
@@ -3663,10 +3663,10 @@ GetTempFileNameA(
     {
         ERROR( "Unable to create temp file. \n" );
         uRet = 0;
-        
+
         if ( ERROR_PATH_NOT_FOUND == GetLastError() )
         {
-            /* CreateFile failed because it could not 
+            /* CreateFile failed because it could not
             find the path. */
             pThread->SetLastError( ERROR_DIRECTORY );
         } /* else use the lasterror value from CreateFileA */
@@ -3682,9 +3682,9 @@ done:
     LOGEXIT("GetTempFileNameA returns UINT %u\n", uRet);
     PERF_EXIT(GetTempFileNameA);
     return uRet;
-       
+
 }
-        
+
 /*++
 Function:
   GetTempFileNameW
@@ -3735,7 +3735,7 @@ GetTempFileNameW(
     path_size = WideCharToMultiByte( CP_ACP, 0, lpPathName, -1, full_name,
                                      length, NULL, NULL );
     full_namePS.CloseBuffer(path_size);
-                                     
+
     if( path_size == 0 )
     {
         DWORD dwLastError = GetLastError();
@@ -3752,8 +3752,8 @@ GetTempFileNameW(
         uRet = 0;
         goto done;
     }
-    
-    if (lpPrefixString != NULL) 
+
+    if (lpPrefixString != NULL)
     {
         length = (PAL_wcslen(lpPrefixString)+1) * MaxWCharToAcpLengthFactor;
         prefix_string = prefix_stringPS.OpenStringBuffer(length);
@@ -3763,12 +3763,12 @@ GetTempFileNameW(
             uRet = 0;
             goto done;
         }
-        prefix_size = WideCharToMultiByte( CP_ACP, 0, lpPrefixString, -1, 
+        prefix_size = WideCharToMultiByte( CP_ACP, 0, lpPrefixString, -1,
                                            prefix_string,
-                                           MAX_LONGPATH - path_size - MAX_SEEDSIZE, 
+                                           MAX_LONGPATH - path_size - MAX_SEEDSIZE,
                                            NULL, NULL );
         prefix_stringPS.CloseBuffer(prefix_size);
-        
+
         if( prefix_size == 0 )
         {
             DWORD dwLastError = GetLastError();
@@ -3786,7 +3786,7 @@ GetTempFileNameW(
             goto done;
         }
     }
-    
+
     tempfile_name = (char*)InternalMalloc(MAX_LONGPATH);
     if (tempfile_name == NULL)
     {
@@ -3794,13 +3794,13 @@ GetTempFileNameW(
         uRet = 0;
         goto done;
     }
-    
-    uRet = GetTempFileNameA(full_name, 
+
+    uRet = GetTempFileNameA(full_name,
                             (lpPrefixString == NULL) ? NULL : prefix_string,
                             0, tempfile_name);
     if (uRet)
-    {                    
-        path_size = MultiByteToWideChar( CP_ACP, 0, tempfile_name, -1, 
+    {
+        path_size = MultiByteToWideChar( CP_ACP, 0, tempfile_name, -1,
                                            lpTempFileName, MAX_LONGPATH );
 
         InternalFree(tempfile_name);
@@ -3815,7 +3815,7 @@ GetTempFileNameW(
             }
             else
             {
-                ASSERT("MultiByteToWideChar failure! error is %d", dwLastError);     
+                ASSERT("MultiByteToWideChar failure! error is %d", dwLastError);
                 dwLastError = ERROR_INTERNAL_ERROR;
             }
             pThread->SetLastError(dwLastError);
@@ -3842,37 +3842,37 @@ DWORD FILEGetLastErrorFromErrno( void )
     switch(errno)
     {
     case 0:
-        dwRet = ERROR_SUCCESS; 
+        dwRet = ERROR_SUCCESS;
         break;
     case ENAMETOOLONG:
         dwRet = ERROR_FILENAME_EXCED_RANGE;
         break;
     case ENOTDIR:
-        dwRet = ERROR_PATH_NOT_FOUND; 
+        dwRet = ERROR_PATH_NOT_FOUND;
         break;
     case ENOENT:
-        dwRet = ERROR_FILE_NOT_FOUND; 
+        dwRet = ERROR_FILE_NOT_FOUND;
         break;
     case EACCES:
     case EPERM:
     case EROFS:
     case EISDIR:
-        dwRet = ERROR_ACCESS_DENIED; 
+        dwRet = ERROR_ACCESS_DENIED;
         break;
     case EEXIST:
-        dwRet = ERROR_ALREADY_EXISTS; 
+        dwRet = ERROR_ALREADY_EXISTS;
         break;
 #if !defined(_AIX)
     // ENOTEMPTY is the same as EEXIST on AIX. Meaningful when involving directory operations
     case ENOTEMPTY:
-        dwRet = ERROR_DIR_NOT_EMPTY; 
+        dwRet = ERROR_DIR_NOT_EMPTY;
         break;
 #endif
     case EBADF:
-        dwRet = ERROR_INVALID_HANDLE; 
+        dwRet = ERROR_INVALID_HANDLE;
         break;
     case ENOMEM:
-        dwRet = ERROR_NOT_ENOUGH_MEMORY; 
+        dwRet = ERROR_NOT_ENOUGH_MEMORY;
         break;
     case EBUSY:
         dwRet = ERROR_BUSY;
@@ -3941,7 +3941,7 @@ CopyFileA(
     BOOL         bGood = FALSE;
     DWORD        dwSrcFileAttributes;
     struct stat  SrcFileStats;
-    
+
     LPSTR lpUnixPath = NULL;
     const int    buffer_size = 16*1024;
     char        *buffer = (char*)alloca(buffer_size);
@@ -3966,7 +3966,7 @@ CopyFileA(
     {
         dwDestCreationMode = CREATE_ALWAYS;
     }
-    
+
     hSource = CreateFileA( lpExistingFileName,
                GENERIC_READ,
                FILE_SHARE_READ,
@@ -4015,7 +4015,7 @@ CopyFileA(
 
     if ( hDest == INVALID_HANDLE_VALUE )
     {
-        ERROR("CreateFileA failed for %s\n", lpNewFileName);    
+        ERROR("CreateFileA failed for %s\n", lpNewFileName);
         goto done;
     }
 
@@ -4028,8 +4028,8 @@ CopyFileA(
         goto done;
     }
     FILEDosToUnixPathA( lpUnixPath );
-    
- 
+
+
     // We don't set file attributes in CreateFile. The only attribute
     // that is reflected on disk in Unix is read-only, and we set that
     // here.
@@ -4069,10 +4069,10 @@ CopyFileA(
 
         goto done;
     }
-    
+
 done:
 
-    if ( hSource != INVALID_HANDLE_VALUE ) 
+    if ( hSource != INVALID_HANDLE_VALUE )
     {
         CloseHandle( hSource );
     }
@@ -4080,7 +4080,7 @@ done:
     {
         CloseHandle( hDest );
     }
-    if (lpUnixPath) 
+    if (lpUnixPath)
     {
         InternalFree(lpUnixPath);
     }
@@ -4121,8 +4121,8 @@ SetFileAttributesA(
     pThread = InternalGetCurrentThread();
 
     /* Windows behavior for SetFileAttributes is that any valid attributes
-    are set on a file and any invalid attributes are ignored. SetFileAttributes 
-    returns success and does not set an error even if some or all of the 
+    are set on a file and any invalid attributes are ignored. SetFileAttributes
+    returns success and does not set an error even if some or all of the
     attributes are invalid. If all the attributes are invalid, SetFileAttributes
     sets a file's attribute to NORMAL. */
 
@@ -4134,7 +4134,7 @@ SetFileAttributesA(
         WARN("dwFileAttributes(%#x) contains attributes that are either not supported "
             "or cannot be set via SetFileAttributes.\n");
     }
-     
+
     if ( (dwFileAttributes & FILE_ATTRIBUTE_NORMAL) &&
          (dwFileAttributes != FILE_ATTRIBUTE_NORMAL) )
     {
@@ -4157,7 +4157,7 @@ SetFileAttributesA(
     FILEDosToUnixPathA( UnixFileName );
     if ( stat(UnixFileName, &stat_data) != 0 )
     {
-        TRACE("stat failed on %s; errno is %d (%s)\n", 
+        TRACE("stat failed on %s; errno is %d (%s)\n",
              UnixFileName, errno, strerror(errno));
         dwLastError = FILEGetLastErrorFromErrnoAndFilename(UnixFileName);
         goto done;
@@ -4172,7 +4172,7 @@ SetFileAttributesA(
         ERROR("Not a regular file or directory, S_IFMT is %#x\n",
               new_mode & S_IFMT);
         dwLastError = ERROR_ACCESS_DENIED;
-        goto done;    
+        goto done;
     }
 
     /* set or unset the "read-only" attribute */
@@ -4208,7 +4208,7 @@ done:
     {
         pThread->SetLastError(dwLastError);
     }
-    
+
     InternalFree(UnixFileName);
 
     LOGEXIT("SetFileAttributesA returns BOOL %d\n", bRet);
@@ -4233,7 +4233,7 @@ CorUnix::InternalCreatePipe(
     IDataLock *pDataLock = NULL;
     CFileProcessLocalData *pLocalData = NULL;
     CObjectAttributes oaFile(NULL, lpPipeAttributes);
-        
+
     int readWritePipeDes[2] = {-1, -1};
 
     if ((phReadPipe == NULL) || (phWritePipe == NULL))
@@ -4243,7 +4243,7 @@ CorUnix::InternalCreatePipe(
         goto InternalCreatePipeExit;
     }
 
-    if ((lpPipeAttributes == NULL) || 
+    if ((lpPipeAttributes == NULL) ||
         (lpPipeAttributes->bInheritHandle == FALSE) ||
         (lpPipeAttributes->lpSecurityDescriptor != NULL))
     {
@@ -4404,7 +4404,7 @@ CorUnix::InternalCreatePipe(
     //
 
     pWriteFileObject = NULL;
-    
+
 InternalCreatePipeExit:
 
     if (NO_ERROR != palError)
@@ -4522,7 +4522,7 @@ CorUnix::InternalLockFile(
 
     palError = pFileObject->GetProcessLocalData(
         pThread,
-        ReadLock, 
+        ReadLock,
         &pLocalDataLock,
         reinterpret_cast<void**>(&pLocalData)
         );
@@ -4531,7 +4531,7 @@ CorUnix::InternalLockFile(
     {
         goto InternalLockFileExit;
     }
-    
+
     if (NULL != pLocalData->pLockController)
     {
         palError = pLocalData->pLockController->CreateFileLock(
@@ -4549,7 +4549,7 @@ CorUnix::InternalLockFile(
         //
         // This isn't a lockable file (e.g., it may be a pipe)
         //
-        
+
         palError = ERROR_ACCESS_DENIED;
         goto InternalLockFileExit;
     }
@@ -4590,7 +4590,7 @@ LockFile(HANDLE hFile,
 
     PERF_ENTRY(LockFile);
     ENTRY("LockFile(hFile:%p, offsetLow:%u, offsetHigh:%u, nbBytesLow:%u,"
-           " nbBytesHigh:%u\n", hFile, dwFileOffsetLow, dwFileOffsetHigh, 
+           " nbBytesHigh:%u\n", hFile, dwFileOffsetLow, dwFileOffsetHigh,
           nNumberOfBytesToLockLow, nNumberOfBytesToLockHigh);
 
     pThread = InternalGetCurrentThread();
@@ -4651,7 +4651,7 @@ CorUnix::InternalUnlockFile(
 
     palError = pFileObject->GetProcessLocalData(
         pThread,
-        ReadLock, 
+        ReadLock,
         &pLocalDataLock,
         reinterpret_cast<void**>(&pLocalData)
         );
@@ -4660,7 +4660,7 @@ CorUnix::InternalUnlockFile(
     {
         goto InternalUnlockFileExit;
     }
-    
+
     if (NULL != pLocalData->pLockController)
     {
         palError = pLocalData->pLockController->ReleaseFileLock(
@@ -4676,7 +4676,7 @@ CorUnix::InternalUnlockFile(
         //
         // This isn't a lockable file (e.g., it may be a pipe)
         //
-        
+
         palError = ERROR_ACCESS_DENIED;
         goto InternalUnlockFileExit;
     }
@@ -4716,7 +4716,7 @@ UnlockFile(HANDLE hFile,
 
     PERF_ENTRY(UnlockFile);
     ENTRY("UnlockFile(hFile:%p, offsetLow:%u, offsetHigh:%u, nbBytesLow:%u,"
-          "nbBytesHigh:%u\n", hFile, dwFileOffsetLow, dwFileOffsetHigh, 
+          "nbBytesHigh:%u\n", hFile, dwFileOffsetLow, dwFileOffsetHigh,
           nNumberOfBytesToUnlockLow, nNumberOfBytesToUnlockHigh);
 
     pThread = InternalGetCurrentThread();
@@ -4743,7 +4743,7 @@ UnlockFile(HANDLE hFile,
 /*++
 init_std_handle [static]
 
-utility function for FILEInitStdHandles. do the work that is common to all 
+utility function for FILEInitStdHandles. do the work that is common to all
 three standard handles
 
 Parameters:
@@ -4824,7 +4824,7 @@ static HANDLE init_std_handle(HANDLE * pStd, FILE *stream)
     palError = g_pObjectManager->RegisterObject(
         pThread,
         pFileObject,
-        &aotFile, 
+        &aotFile,
         0,
         &hFile,
         &pRegisteredFile
@@ -4956,7 +4956,7 @@ FILEGetFileNameFromSymLink
 
 Input parameters:
 
-source  = path to the file on input, path to the file with all 
+source  = path to the file on input, path to the file with all
           symbolic links traversed on return
 
 Note: Assumes the maximum size of the source is MAX_LONGPATH
@@ -5032,10 +5032,10 @@ GetFileInformationByHandle(
     {
         goto done;
     }
-    
+
     dwLastError = pFileObject->GetProcessLocalData(
         pThread,
-        ReadLock, 
+        ReadLock,
         &pLocalDataLock,
         reinterpret_cast<void**>(&pLocalData)
         );
@@ -5061,7 +5061,7 @@ GetFileInformationByHandle(
     }
     else if ( (stat_data.st_mode & S_IFMT) != S_IFREG )
     {
-        ERROR("Not a regular file or directory, S_IFMT is %#x\n", 
+        ERROR("Not a regular file or directory, S_IFMT is %#x\n",
               stat_data.st_mode & S_IFMT);
         dwLastError = ERROR_ACCESS_DENIED;
         goto done;

--- a/pal/src/file/filetime.cpp
+++ b/pal/src/file/filetime.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -85,11 +85,11 @@ SET_DEFAULT_DEBUG_CHANNEL(FILE);
    89 * 366 + 280 * 365 = 134744 days between epochs. Of course
    60 * 60 * 24 = 86400 seconds per day, so 134744 * 86400 =
    11644473600 = SECS_BETWEEN_1601_AND_1970_EPOCHS.
-   
+
    To 2001:
    Again, both epochs are Gregorian. 2001 - 1601 = 400. Assuming a leap
    year every four years, 400 / 4 = 100. However, 1700, 1800, and 1900
-   were NOT leap years (2000 was because it was divisible by 400), so 
+   were NOT leap years (2000 was because it was divisible by 400), so
    97 leap years, 303 non-leap years.
    97 * 366 + 303 * 365 = 146097 days between epochs. 146097 * 86400 =
    12622780800 = SECS_BETWEEN_1601_AND_2001_EPOCHS.
@@ -122,7 +122,7 @@ CompareFileTime(
     long Ret;
 
     PERF_ENTRY(CompareFileTime);
-    ENTRY("CompareFileTime(lpFileTime1=%p lpFileTime2=%p)\n", 
+    ENTRY("CompareFileTime(lpFileTime1=%p lpFileTime2=%p)\n",
           lpFileTime1, lpFileTime2);
 
     First = ((__int64)lpFileTime1->dwHighDateTime << 32) +
@@ -142,7 +142,7 @@ CompareFileTime(
     {
         Ret = 0;
     }
-    
+
     LOGEXIT("CompareFileTime returns LONG %ld\n", Ret);
     PERF_EXIT(CompareFileTime);
     return Ret;
@@ -176,17 +176,17 @@ SetFileTime(
 
     PERF_ENTRY(SetFileTime);
     ENTRY("SetFileTime(hFile=%p, lpCreationTime=%p, lpLastAccessTime=%p, "
-          "lpLastWriteTime=%p)\n", hFile, lpCreationTime, lpLastAccessTime, 
+          "lpLastWriteTime=%p)\n", hFile, lpCreationTime, lpLastAccessTime,
           lpLastWriteTime);
 
     pThread = InternalGetCurrentThread();
 
     /* validate filetime values */
-    if ( (lpCreationTime && (((UINT64)lpCreationTime->dwHighDateTime   << 32) + 
-          lpCreationTime->dwLowDateTime   >= MAX_FILETIMEVALUE)) ||        
-         (lpLastAccessTime && (((UINT64)lpLastAccessTime->dwHighDateTime << 32) + 
+    if ( (lpCreationTime && (((UINT64)lpCreationTime->dwHighDateTime   << 32) +
+          lpCreationTime->dwLowDateTime   >= MAX_FILETIMEVALUE)) ||
+         (lpLastAccessTime && (((UINT64)lpLastAccessTime->dwHighDateTime << 32) +
           lpLastAccessTime->dwLowDateTime >= MAX_FILETIMEVALUE)) ||
-         (lpLastWriteTime && (((UINT64)lpLastWriteTime->dwHighDateTime  << 32) + 
+         (lpLastWriteTime && (((UINT64)lpLastWriteTime->dwHighDateTime  << 32) +
           lpLastWriteTime->dwLowDateTime  >= MAX_FILETIMEVALUE)))
     {
         pThread->SetLastError(ERROR_INVALID_HANDLE);
@@ -250,7 +250,7 @@ CorUnix::InternalSetFileTime(
 
     palError = pFileObject->GetProcessLocalData(
         pThread,
-        ReadLock, 
+        ReadLock,
         &pLocalDataLock,
         reinterpret_cast<void**>(&pLocalData)
         );
@@ -259,7 +259,7 @@ CorUnix::InternalSetFileTime(
     {
         goto InternalSetFileTimeExit;
     }
-    
+
     if (lpCreationTime)
     {
         palError = ERROR_NOT_SUPPORTED;
@@ -267,7 +267,7 @@ CorUnix::InternalSetFileTime(
     }
 
     if( !lpLastAccessTime && !lpLastWriteTime )
-    { 
+    {
 	// if both pointers are NULL, the function simply returns.
         goto InternalSetFileTimeExit;
     }
@@ -280,7 +280,7 @@ CorUnix::InternalSetFileTime(
           TRACE("pLocalData = [%p], fd = %d\n", pLocalData, fd);
           palError = ERROR_INVALID_HANDLE;
           goto InternalSetFileTimeExit;
-        } 
+        }
 
 	if ( fstat(fd, &stat_buf) != 0 )
     	{
@@ -426,7 +426,7 @@ CorUnix::InternalGetFileTime(
 
     palError = pFileObject->GetProcessLocalData(
         pThread,
-        ReadLock, 
+        ReadLock,
         &pLocalDataLock,
         reinterpret_cast<void**>(&pLocalData)
         );
@@ -508,7 +508,7 @@ GetSystemTimeAsFileTime(
     struct timeval Time;
 
     PERF_ENTRY(GetSystemTimeAsFileTime);
-    ENTRY("GetSystemTimeAsFileTime(lpSystemTimeAsFileTime=%p)\n", 
+    ENTRY("GetSystemTimeAsFileTime(lpSystemTimeAsFileTime=%p)\n",
           lpSystemTimeAsFileTime);
 
     if ( gettimeofday( &Time, NULL ) != 0 )
@@ -537,23 +537,23 @@ Function:
 Convert a CFAbsoluteTime value to a win32 FILETIME structure, as described
 in MSDN documentation. CFAbsoluteTime is the number of seconds elapsed since
 00:00 01 January 2001 UTC (Mac OS X epoch), while FILETIME represents a
-64-bit number of 100-nanosecond intervals that have passed since 00:00 
+64-bit number of 100-nanosecond intervals that have passed since 00:00
 01 January 1601 UTC (win32 epoch).
 --*/
 FILETIME FILECFAbsoluteTimeToFileTime( CFAbsoluteTime sec )
 {
     __int64 Result;
     FILETIME Ret;
-    
+
     Result = ((__int64)sec + SECS_BETWEEN_1601_AND_2001_EPOCHS) * SECS_TO_100NS;
 
     Ret.dwLowDateTime = (DWORD)Result;
     Ret.dwHighDateTime = (DWORD)(Result >> 32);
 
-    TRACE("CFAbsoluteTime = [%9f] converts to Win32 FILETIME = [%#x:%#x]\n", 
+    TRACE("CFAbsoluteTime = [%9f] converts to Win32 FILETIME = [%#x:%#x]\n",
           sec, Ret.dwHighDateTime, Ret.dwLowDateTime);
 
-    return Ret;    
+    return Ret;
 }
 #endif // __APPLE__
 
@@ -563,9 +563,9 @@ Function:
   FILEUnixTimeToFileTime
 
 Convert a time_t value to a win32 FILETIME structure, as described in
-MSDN documentation. time_t is the number of seconds elapsed since 
-00:00 01 January 1970 UTC (Unix epoch), while FILETIME represents a 
-64-bit number of 100-nanosecond intervals that have passed since 00:00 
+MSDN documentation. time_t is the number of seconds elapsed since
+00:00 01 January 1970 UTC (Unix epoch), while FILETIME represents a
+64-bit number of 100-nanosecond intervals that have passed since 00:00
 01 January 1601 UTC (win32 epoch).
 --*/
 FILETIME FILEUnixTimeToFileTime( time_t sec, long nsec )
@@ -579,7 +579,7 @@ FILETIME FILEUnixTimeToFileTime( time_t sec, long nsec )
     Ret.dwLowDateTime = (DWORD)Result;
     Ret.dwHighDateTime = (DWORD)(Result >> 32);
 
-    TRACE("Unix time = [%ld.%09ld] converts to Win32 FILETIME = [%#x:%#x]\n", 
+    TRACE("Unix time = [%ld.%09ld] converts to Win32 FILETIME = [%#x:%#x]\n",
           sec, nsec, Ret.dwHighDateTime, Ret.dwLowDateTime);
 
     return Ret;
@@ -607,7 +607,7 @@ time_t FILEFileTimeToUnixTime( FILETIME FileTime, long *nsec )
     __int64 UnixTime;
 
     /* get the full win32 value, in 100ns */
-    UnixTime = ((__int64)FileTime.dwHighDateTime << 32) + 
+    UnixTime = ((__int64)FileTime.dwHighDateTime << 32) +
         FileTime.dwLowDateTime;
 
     /* convert to the Unix epoch */
@@ -628,7 +628,7 @@ time_t FILEFileTimeToUnixTime( FILETIME FileTime, long *nsec )
         WARN("Resulting value is too big for a time_t value\n");
     }
 
-    TRACE("Win32 FILETIME = [%#x:%#x] converts to Unix time = [%ld.%09ld]\n", 
+    TRACE("Win32 FILETIME = [%#x:%#x] converts to Unix time = [%ld.%09ld]\n",
           FileTime.dwHighDateTime, FileTime.dwLowDateTime ,(long) UnixTime,
           nsec?*nsec:0L);
 
@@ -638,16 +638,16 @@ time_t FILEFileTimeToUnixTime( FILETIME FileTime, long *nsec )
 
 
 /**
-Function 
+Function
 
     FileTimeToSystemTime()
-    
+
     Helper function for FileTimeToDosTime.
     Converts the necessary file time attibutes to system time, for
     easier manipulation in FileTimeToDosTime.
-        
+
 --*/
-BOOL PALAPI FileTimeToSystemTime( CONST FILETIME * lpFileTime, 
+BOOL PALAPI FileTimeToSystemTime( CONST FILETIME * lpFileTime,
                                   LPSYSTEMTIME lpSystemTime )
 {
     UINT64 FileTime = 0;
@@ -663,7 +663,7 @@ BOOL PALAPI FileTimeToSystemTime( CONST FILETIME * lpFileTime,
             SECS_BETWEEN_1601_AND_1970_EPOCHS * SECS_TO_100NS,
             FileTime);
 
-    if (isSafe == true) 
+    if (isSafe == true)
     {
 #if HAVE_GMTIME_R
         struct tm timeBuf;
@@ -671,7 +671,7 @@ BOOL PALAPI FileTimeToSystemTime( CONST FILETIME * lpFileTime,
         /* Convert file time to unix time. */
         if (((INT64)FileTime) < 0)
         {
-            UnixFileTime =  -1 - ( ( -FileTime - 1 ) / 10000000 );            
+            UnixFileTime =  -1 - ( ( -FileTime - 1 ) / 10000000 );
         }
         else
         {
@@ -687,12 +687,12 @@ BOOL PALAPI FileTimeToSystemTime( CONST FILETIME * lpFileTime,
 
         /* Convert unix system time to Windows system time. */
         lpSystemTime->wDay      = UnixSystemTime->tm_mday;
-    
+
         /* Unix time counts January as a 0, under Windows it is 1*/
         lpSystemTime->wMonth    = UnixSystemTime->tm_mon + 1;
         /* Unix time returns the year - 1900, Windows returns the current year*/
         lpSystemTime->wYear     = UnixSystemTime->tm_year + 1900;
-        
+
         lpSystemTime->wSecond   = UnixSystemTime->tm_sec;
         lpSystemTime->wMinute   = UnixSystemTime->tm_min;
         lpSystemTime->wHour     = UnixSystemTime->tm_hour;
@@ -707,16 +707,16 @@ BOOL PALAPI FileTimeToSystemTime( CONST FILETIME * lpFileTime,
 }
 
 
-    
+
 /**
 Function:
     FileTimeToDosDateTime
-    
+
     Notes due to the difference between how BSD and Windows
     calculates time, this function can only repersent dates between
-    1980 and 2037. 2037 is the upperlimit for the BSD time functions( 1900 - 
+    1980 and 2037. 2037 is the upperlimit for the BSD time functions( 1900 -
     2037 range ).
-    
+
 See msdn for more details.
 --*/
 BOOL
@@ -764,7 +764,7 @@ FileTimeToDosDateTime(
 
                 *lpFatTime |= ( ( SysTime.wMinute & 0x3F ) << 5 );
                 *lpFatTime |= ( ( SysTime.wHour & 0x1F ) << 11 );
-                
+
                 bRetVal = TRUE;
             }
             else
@@ -786,4 +786,3 @@ FileTimeToDosDateTime(
     PERF_EXIT(FileTimeToDosDateTime);
     return bRetVal;
 }
-

--- a/pal/src/file/path.cpp
+++ b/pal/src/file/path.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -91,14 +91,14 @@ GetFullPathNameA(
             SetLastError(ERROR_NOT_ENOUGH_MEMORY);
             goto done;
         }
-    }   
+    }
     else
     {
         size_t max_len;
 
         /* allocate memory for full non-canonical path */
         max_len = strlen(lpFileName)+1; /* 1 for the slash to append */
-        max_len += MAX_LONGPATH + 1; 
+        max_len += MAX_LONGPATH + 1;
         lpUnixPath = (LPSTR)PAL_malloc(max_len);
         if(NULL == lpUnixPath)
         {
@@ -107,7 +107,7 @@ GetFullPathNameA(
             SetLastError(ERROR_NOT_ENOUGH_MEMORY);
             goto done;
         }
-        
+
         /* build full path */
         if(!GetCurrentDirectoryA(MAX_LONGPATH + 1, lpUnixPath))
         {
@@ -117,7 +117,7 @@ GetFullPathNameA(
             SetLastError(ERROR_INTERNAL_ERROR);
             goto done;
         }
-        
+
         if (strcat_s(lpUnixPath, max_len, "/") != SAFECRT_SUCCESS)
         {
             ERROR("strcat_s failed!\n");
@@ -135,7 +135,7 @@ GetFullPathNameA(
 
     /* do conversion to Unix path */
     FILEDosToUnixPathA( lpUnixPath );
- 
+
     /* now we can canonicalize this */
     FILECanonicalizePath(lpUnixPath);
 
@@ -165,9 +165,9 @@ GetFullPathNameA(
             nRet = 0;
             goto done;
         }
-        else 
+        else
         {
-            (*lpFilePart)++; 
+            (*lpFilePart)++;
         }
     }
 
@@ -209,14 +209,14 @@ GetFullPathNameW(
     ENTRY("GetFullPathNameW(lpFileName=%p (%S), nBufferLength=%u, lpBuffer=%p"
           ", lpFilePart=%p)\n",
           lpFileName?lpFileName:W16_NULLSTRING,
-          lpFileName?lpFileName:W16_NULLSTRING, nBufferLength, 
+          lpFileName?lpFileName:W16_NULLSTRING, nBufferLength,
           lpBuffer, lpFilePart);
 
     /* Find the number of bytes required to convert lpFileName
        to ANSI. This may be more than MAX_LONGPATH. We try to
        handle that case, since it may be less than MAX_LONGPATH
        WCHARs. */
-    
+
     fileNameLength = WideCharToMultiByte(CP_ACP, 0, lpFileName,
                                          -1, NULL, 0, NULL, NULL);
     if (fileNameLength == 0)
@@ -229,9 +229,9 @@ GetFullPathNameW(
     {
         fileNameA = static_cast<LPSTR>(alloca(fileNameLength));
     }
-    
+
     /* Now convert lpFileName to ANSI. */
-    srcSize = WideCharToMultiByte (CP_ACP, 0, lpFileName, 
+    srcSize = WideCharToMultiByte (CP_ACP, 0, lpFileName,
                                    -1, fileNameA, fileNameLength,
                                    NULL, NULL );
     if( srcSize == 0 )
@@ -248,7 +248,7 @@ GetFullPathNameW(
         SetLastError(ERROR_INVALID_PARAMETER);
         goto done;
     }
-    
+
     bufferASize = MAX_LONGPATH * MaxWCharToAcpLengthRatio;
     bufferA = bufferAPS.OpenStringBuffer(bufferASize);
     if (NULL == bufferA)
@@ -258,14 +258,14 @@ GetFullPathNameW(
     }
     length = GetFullPathNameA(fileNameA, bufferASize, bufferA, &lpFilePartA);
     bufferAPS.CloseBuffer(length);
-    
+
     if (length == 0 || length > bufferASize)
     {
         /* Last error is set by GetFullPathNameA */
         nRet = length;
         goto done;
     }
-    
+
     /* Convert back to Unicode the result */
     nRet = MultiByteToWideChar( CP_ACP, 0, bufferA, -1,
                                 lpBuffer, nBufferLength );
@@ -309,7 +309,7 @@ Function:
 See MSDN doc.
 
 Note:
-  Since short path names are not implemented (nor supported) in the PAL, 
+  Since short path names are not implemented (nor supported) in the PAL,
   this function simply copies the given path into the new buffer.
 
 --*/
@@ -354,7 +354,7 @@ GetLongPathNameW(
         {
             ERROR("Buffer is too small, need %d characters\n", dwPathLen);
             SetLastError( ERROR_INSUFFICIENT_BUFFER );
-        } else 
+        } else
         {
             if ( lpszShortPath != lpszLongPath )
             {
@@ -381,7 +381,7 @@ Function:
 See MSDN doc.
 
 Note:
-  Since short path names are not implemented (nor supported) in the PAL, 
+  Since short path names are not implemented (nor supported) in the PAL,
   this function simply copies the given path into the new buffer.
 
 --*/
@@ -426,7 +426,7 @@ GetShortPathNameW(
         {
             ERROR("Buffer is too small, need %d characters\n", dwPathLen);
             SetLastError( ERROR_INSUFFICIENT_BUFFER );
-        } else 
+        } else
         {
             if ( lpszLongPath != lpszShortPath )
             {
@@ -489,7 +489,7 @@ GetTempPathA(
     dwPathLen = GetEnvironmentVariableA("TMPDIR", lpBuffer, nBufferLength);
     if (dwPathLen > 0)
     {
-        /* The env var existed. dwPathLen will be the length without null termination 
+        /* The env var existed. dwPathLen will be the length without null termination
          * if the entire value was successfully retrieved, or it'll be the length
          * required to store the value with null termination.
          */
@@ -498,7 +498,7 @@ GetTempPathA(
             /* The environment variable fit in the buffer. Make sure it ends with '/'. */
             if (lpBuffer[dwPathLen - 1] != '/')
             {
-                /* If adding the slash would still fit in our provided buffer, do it.  Otherwise, 
+                /* If adding the slash would still fit in our provided buffer, do it.  Otherwise,
                  * let the caller know how much space would be needed.
                  */
                 if (dwPathLen + 2 <= nBufferLength)
@@ -517,7 +517,7 @@ GetTempPathA(
             /* The value is too long for the supplied buffer.  dwPathLen will now be the
              * length required to hold the value, but we don't know whether that value
              * is going to be '/' terminated.  Since we'll need enough space for the '/', and since
-             * a caller would assume that the dwPathLen we return will be sufficient, 
+             * a caller would assume that the dwPathLen we return will be sufficient,
              * we make sure to account for it in dwPathLen even if that means we end up saying
              * one more byte of space is needed than actually is.
              */
@@ -580,7 +580,7 @@ GetTempPathW(
 
     char TempBuffer[nBufferLength > 0 ? nBufferLength : 1];
     DWORD dwRetVal = GetTempPathA( nBufferLength, TempBuffer );
-   
+
     if ( dwRetVal >= nBufferLength )
     {
         ERROR( "lpBuffer was not large enough.\n" )
@@ -590,7 +590,7 @@ GetTempPathW(
     else if ( dwRetVal != 0 )
     {
         /* Convert to wide. */
-        if ( 0 == MultiByteToWideChar( CP_ACP, 0, TempBuffer, -1, 
+        if ( 0 == MultiByteToWideChar( CP_ACP, 0, TempBuffer, -1,
                                        lpBuffer, dwRetVal + 1 ) )
         {
             ASSERT( "An error occurred while converting the string to wide.\n" );
@@ -716,7 +716,7 @@ FILEDosToUnixPathA(
        Truncate at pPointAtDot, unless the dots are path specifiers (. or ..) */
     if (pPointAtDot)
     {
-        /* make sure the trailing dots don't follow a '/', and that they aren't 
+        /* make sure the trailing dots don't follow a '/', and that they aren't
            the only thing in the name */
         if(pPointAtDot != lpPath && *(pPointAtDot-1) != '/')
         {
@@ -754,7 +754,7 @@ FILEDosToUnixPathW(
     if (!lpPath)
     {
         return;
-    }  
+    }
 
     for (p = lpPath; *p; p++)
     {
@@ -833,7 +833,7 @@ FILEDosToUnixPathW(
        Truncate at pPointAtDot, unless the dots are path specifiers (. or ..) */
     if (pPointAtDot)
     {
-        /* make sure the trailing dots don't follow a '/', and that they aren't 
+        /* make sure the trailing dots don't follow a '/', and that they aren't
            the only thing in the name */
         if(pPointAtDot != lpPath && *(pPointAtDot-1) != '/')
         {
@@ -948,18 +948,18 @@ LPCSTR FILEGetFileNameFromFullPathA( LPCSTR lpFullPath )
 
 /*++
 FILECanonicalizePath
-    Removes all instances of '/./', '/../' and '//' from an absolute path. 
-    
+    Removes all instances of '/./', '/../' and '//' from an absolute path.
+
 Parameters:
     LPSTR lpUnixPath : absolute path to modify, in Unix format
 
-(no return value)                                             
- 
+(no return value)
+
 Notes :
 -behavior is undefined if path is not absolute
--the order of steps *is* important: /one/./../two would give /one/two 
+-the order of steps *is* important: /one/./../two would give /one/two
  instead of /two if step 3 was done before step 2
--reason for this function is that GetFullPathName can't use realpath(), since 
+-reason for this function is that GetFullPathName can't use realpath(), since
  realpath() requires the given path to be valid and GetFullPathName does not.
 --*/
 void FILECanonicalizePath(LPSTR lpUnixPath)
@@ -1016,14 +1016,14 @@ void FILECanonicalizePath(LPSTR lpUnixPath)
             memmove(lpUnixPath, lpUnixPath+3,strlen(lpUnixPath+3)+1);
             continue;
         }
-        
-        /* null-terminate the string before the '/../', so that strrchr will 
+
+        /* null-terminate the string before the '/../', so that strrchr will
            start looking right before it */
         *dotdotptr = '\0';
         slashptr = strrchr(lpUnixPath,'/');
         if(NULL == slashptr)
         {
-            /* this happens if this function was called with a relative path. 
+            /* this happens if this function was called with a relative path.
                don't do that.  */
             ASSERT("can't find leading '/' before '/../ sequence\n");
             break;
@@ -1053,7 +1053,7 @@ void FILECanonicalizePath(LPSTR lpUnixPath)
             }
             else
             {
-                *slashptr = '\0';    
+                *slashptr = '\0';
             }
         }
     }
@@ -1116,11 +1116,11 @@ SearchPathA(
     ENTRY("SearchPathA(lpPath=%p (%s), lpFileName=%p (%s), lpExtension=%p, "
           "nBufferLength=%u, lpBuffer=%p, lpFilePart=%p)\n",
       lpPath,
-      lpPath, lpFileName, lpFileName, lpExtension, nBufferLength, lpBuffer, 
+      lpPath, lpFileName, lpFileName, lpExtension, nBufferLength, lpBuffer,
           lpFilePart);
 
     /* validate parameters */
-    
+
     if(NULL == lpPath)
     {
         ASSERT("lpPath may not be NULL\n");
@@ -1142,7 +1142,7 @@ SearchPathA(
 
     FileNameLength = strlen(lpFileName);
 
-    /* special case : if file name contains absolute path, don't search the 
+    /* special case : if file name contains absolute path, don't search the
        provided path */
     if('\\' == lpFileName[0] || '/' == lpFileName[0])
     {
@@ -1162,7 +1162,7 @@ SearchPathA(
         }
         dw = GetFullPathNameA(lpFileName, length+1, CanonicalFullPath, NULL);
         CanonicalFullPathPS.CloseBuffer(dw);
-        
+
         if (length+1 < dw)
         {
             CanonicalFullPath = CanonicalFullPathPS.OpenStringBuffer(dw-1);
@@ -1176,7 +1176,7 @@ SearchPathA(
             CanonicalFullPathPS.CloseBuffer(dw);
         }
 
-        if (dw == 0) 
+        if (dw == 0)
         {
             WARN("couldn't canonicalize path <%s>, error is %#x. failing.\n",
                  lpFileName, GetLastError());
@@ -1194,13 +1194,13 @@ SearchPathA(
     else
     {
         LPCSTR pNextPath;
-        
+
         pNextPath = lpPath;
-    
-        while (*pNextPath) 
+
+        while (*pNextPath)
         {
             pPathStart = pNextPath;
-            
+
             /* get a pointer to the end of the first path in pPathStart */
             pPathEnd = strchr(pPathStart, ':');
             if (!pPathEnd)
@@ -1215,13 +1215,13 @@ SearchPathA(
                 /* point to the next component in the path string */
                 pNextPath = pPathEnd+1;
             }
-    
+
             PathLength = pPathEnd-pPathStart;
-    
-            if (PathLength+FileNameLength+1 >= MAX_LONGPATH) 
+
+            if (PathLength+FileNameLength+1 >= MAX_LONGPATH)
             {
                 /* The path+'/'+file length is too long.  Skip it. */
-                WARN("path component %.*s is too long, skipping it\n", 
+                WARN("path component %.*s is too long, skipping it\n",
                      (int)PathLength, pPathStart);
                 continue;
             }
@@ -1230,8 +1230,8 @@ SearchPathA(
                 /* empty component : there were 2 consecutive ':' */
                 continue;
             }
-    
-            /* Construct a pathname by concatenating one path from lpPath, '/' 
+
+            /* Construct a pathname by concatenating one path from lpPath, '/'
                and lpFileName */
             FullPathLength = PathLength + FileNameLength;
             FullPath = FullPathPS.OpenStringBuffer(FullPathLength+1);
@@ -1250,7 +1250,7 @@ SearchPathA(
                 goto done;
             }
 
-            FullPathPS.CloseBuffer(FullPathLength+1);            
+            FullPathPS.CloseBuffer(FullPathLength+1);
             /* Canonicalize the path to deal with back-to-back '/', etc. */
             length = MAX_LONGPATH;
             CanonicalFullPath = CanonicalFullPathPS.OpenStringBuffer(length);
@@ -1262,7 +1262,7 @@ SearchPathA(
             dw = GetFullPathNameA(FullPath, length+1,
                                   CanonicalFullPath, NULL);
             CanonicalFullPathPS.CloseBuffer(dw);
-            
+
             if (length+1 < dw)
             {
                 CanonicalFullPath = CanonicalFullPathPS.OpenStringBuffer(dw-1);
@@ -1270,15 +1270,15 @@ SearchPathA(
                                       CanonicalFullPath, NULL);
                 CanonicalFullPathPS.CloseBuffer(dw);
             }
-            
-            if (dw == 0) 
+
+            if (dw == 0)
             {
                 /* Call failed - possibly low memory.  Skip the path */
                 WARN("couldn't canonicalize path <%s>, error is %#x. "
                      "skipping it\n", FullPath, GetLastError());
                 continue;
             }
-    
+
             /* see if the file exists */
             if(0 == access(CanonicalFullPath, F_OK))
             {
@@ -1289,7 +1289,7 @@ SearchPathA(
         }
     }
 
-    if (nRet == 0) 
+    if (nRet == 0)
     {
        /* file not found anywhere; say so. in Windows, this always seems to say
           FILE_NOT_FOUND, even if path doesn't exist */
@@ -1297,7 +1297,7 @@ SearchPathA(
     }
     else
     {
-        if (nRet < nBufferLength) 
+        if (nRet < nBufferLength)
         {
             if(NULL == lpBuffer)
             {
@@ -1308,7 +1308,7 @@ SearchPathA(
                 nRet = 0;
                 goto done;
             }
-            
+
             if (strcpy_s(lpBuffer, nBufferLength, CanonicalFullPath) != SAFECRT_SUCCESS)
             {
                 ERROR("strcpy_s failed!\n");
@@ -1333,7 +1333,7 @@ SearchPathA(
         }
         else
         {
-            /* if buffer is too small, report required length, including 
+            /* if buffer is too small, report required length, including
                terminating null */
             nRet++;
         }
@@ -1389,11 +1389,11 @@ SearchPathW(
     ENTRY("SearchPathW(lpPath=%p (%S), lpFileName=%p (%S), lpExtension=%p, "
           "nBufferLength=%u, lpBuffer=%p, lpFilePart=%p)\n",
 	  lpPath,
-	  lpPath, lpFileName, lpFileName, lpExtension, nBufferLength, lpBuffer, 
+	  lpPath, lpFileName, lpFileName, lpExtension, nBufferLength, lpBuffer,
           lpFilePart);
 
     /* validate parameters */
-    
+
     if(NULL == lpPath)
     {
         ASSERT("lpPath may not be NULL\n");
@@ -1411,9 +1411,9 @@ SearchPathW(
         ASSERT("lpExtension must be NULL, is %p instead\n", lpExtension);
         SetLastError(ERROR_INVALID_PARAMETER);
         goto done;
-    }          
+    }
 
-    /* special case : if file name contains absolute path, don't search the 
+    /* special case : if file name contains absolute path, don't search the
        provided path */
     if('\\' == lpFileName[0] || '/' == lpFileName[0])
     {
@@ -1438,8 +1438,8 @@ SearchPathW(
             dw = GetFullPathNameW(lpFileName, dw, CanonicalPath, NULL);
             CanonicalPathPS.CloseBuffer(dw);
         }
-        
-        if (dw == 0) 
+
+        if (dw == 0)
         {
             WARN("couldn't canonicalize path <%S>, error is %#x. failing.\n",
                  lpPath, GetLastError());
@@ -1458,7 +1458,7 @@ SearchPathW(
 	    canonical_size = WideCharToMultiByte(CP_ACP, 0, CanonicalPath, -1,
 			    AnsiPath, CanonicalPathLength, NULL, NULL);
 	    AnsiPathPS.CloseBuffer(canonical_size);
-	    
+
         if(0 == access(AnsiPath, F_OK))
         {
             /* found it */
@@ -1470,13 +1470,13 @@ SearchPathW(
         LPCWSTR pNextPath;
 
         pNextPath = lpPath;
-    
+
         FileNameLength = PAL_wcslen(lpFileName);
 
-        while (*pNextPath) 
+        while (*pNextPath)
         {
             pPathStart = pNextPath;
-    
+
             /* get a pointer to the end of the first path in pPathStart */
             pPathEnd = PAL_wcschr(pPathStart, ':');
             if (!pPathEnd)
@@ -1491,13 +1491,13 @@ SearchPathW(
                 /* point to the next component in the path string */
                 pNextPath = pPathEnd+1;
             }
-    
+
             PathLength = pPathEnd-pPathStart;
-    
-            if (PathLength+FileNameLength+1 >= MAX_LONGPATH) 
+
+            if (PathLength+FileNameLength+1 >= MAX_LONGPATH)
             {
                 /* The path+'/'+file length is too long.  Skip it. */
-                WARN("path component %.*S is too long, skipping it\n", 
+                WARN("path component %.*S is too long, skipping it\n",
                      (int)PathLength, pPathStart);
                 continue;
             }
@@ -1506,8 +1506,8 @@ SearchPathW(
                 /* empty component : there were 2 consecutive ':' */
                 continue;
             }
-    
-            /* Construct a pathname by concatenating one path from lpPath, '/' 
+
+            /* Construct a pathname by concatenating one path from lpPath, '/'
                and lpFileName */
             FullPathLength = PathLength + FileNameLength;
             FullPath = FullPathPS.OpenStringBuffer(FullPathLength+1);
@@ -1519,9 +1519,9 @@ SearchPathW(
             memcpy(FullPath, pPathStart, PathLength*sizeof(WCHAR));
             FullPath[PathLength] = '/';
             PAL_wcscpy(&FullPath[PathLength+1], lpFileName);
-            
+
             FullPathPS.CloseBuffer(FullPathLength+1);
-    
+
             /* Canonicalize the path to deal with back-to-back '/', etc. */
             length = MAX_LONGPATH;
             CanonicalPath = CanonicalPathPS.OpenStringBuffer(length);
@@ -1533,7 +1533,7 @@ SearchPathW(
             dw = GetFullPathNameW(FullPath, length+1,
                                   CanonicalPath, NULL);
             CanonicalPathPS.CloseBuffer(dw);
-            
+
             if (length+1 < dw)
             {
                 CanonicalPath = CanonicalPathPS.OpenStringBuffer(dw-1);
@@ -1545,15 +1545,15 @@ SearchPathW(
                 dw = GetFullPathNameW(FullPath, dw, CanonicalPath, NULL);
                 CanonicalPathPS.CloseBuffer(dw);
             }
-            
-            if (dw == 0) 
+
+            if (dw == 0)
             {
                 /* Call failed - possibly low memory.  Skip the path */
                 WARN("couldn't canonicalize path <%S>, error is %#x. "
                      "skipping it\n", FullPath, GetLastError());
                 continue;
             }
-    
+
             /* see if the file exists */
             CanonicalPathLength = (PAL_wcslen(CanonicalPath)+1) * MaxWCharToAcpLengthRatio;
             AnsiPath = AnsiPathPS.OpenStringBuffer(CanonicalPathLength);
@@ -1565,7 +1565,7 @@ SearchPathW(
             canonical_size = WideCharToMultiByte(CP_ACP, 0, CanonicalPath, -1,
                                 AnsiPath, CanonicalPathLength, NULL, NULL);
             AnsiPathPS.CloseBuffer(canonical_size);
-               
+
             if(0 == access(AnsiPath, F_OK))
             {
                 /* found it */
@@ -1575,7 +1575,7 @@ SearchPathW(
         }
     }
 
-    if (nRet == 0) 
+    if (nRet == 0)
     {
        /* file not found anywhere; say so. in Windows, this always seems to say
           FILE_NOT_FOUND, even if path doesn't exist */
@@ -1583,7 +1583,7 @@ SearchPathW(
     }
     else
     {
-        /* find out the required buffer size, copy path to buffer if it's 
+        /* find out the required buffer size, copy path to buffer if it's
            large enough */
         nRet = PAL_wcslen(CanonicalPath)+1;
         if(nRet <= nBufferLength)
@@ -1599,10 +1599,10 @@ SearchPathW(
             }
             PAL_wcscpy(lpBuffer, CanonicalPath);
 
-            /* don't include the null-terminator in the count if buffer was 
+            /* don't include the null-terminator in the count if buffer was
                large enough */
             nRet--;
-            
+
             if(NULL != lpFilePart)
             {
                 *lpFilePart = PAL_wcsrchr(lpBuffer, '/');

--- a/pal/src/file/shmfilelockmgr.cpp
+++ b/pal/src/file/shmfilelockmgr.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -30,10 +30,10 @@ SET_DEFAULT_DEBUG_CHANNEL(FILE);
 PAL_ERROR
 FILEAddNewLockedRgn(
     SHMFILELOCKS* fileLocks,
-    PVOID pvControllerInstance, 
+    PVOID pvControllerInstance,
     SHMFILELOCKRGNS *insertAfter,
-    UINT64 lockRgnStart, 
-    UINT64 nbBytesToLock, 
+    UINT64 lockRgnStart,
+    UINT64 nbBytesToLock,
     LOCK_TYPE lockType
     );
 
@@ -41,7 +41,7 @@ PAL_ERROR
 FILELockFileRegion(
     SHMPTR shmFileLocks,
     PVOID pvControllerInstance,
-    UINT64 lockRgnStart, 
+    UINT64 lockRgnStart,
     UINT64 nbBytesToLock,
     LOCK_TYPE lockAction
     );
@@ -49,8 +49,8 @@ FILELockFileRegion(
 PAL_ERROR
 FILEUnlockFileRegion(
     SHMPTR shmFileLocks,
-    PVOID pvControllerInstance, 
-    UINT64 unlockRgnStart, 
+    PVOID pvControllerInstance,
+    UINT64 unlockRgnStart,
     UINT64 nbBytesToUnlock,
     LOCK_TYPE unlockType
     );
@@ -78,13 +78,13 @@ FILEGetSHMFileLocks(
 #define IS_LOCK_INTERSECT(LockToTest, lockRgn) \
     (!IS_LOCK_BEFORE(LockToTest, lockRgn) && !IS_LOCK_BEFORE(lockRgn, LockToTest))
 
-/* return TRUE if LockToTest region and lockRgn have the same file pointer and 
+/* return TRUE if LockToTest region and lockRgn have the same file pointer and
    the same process Id, FALSE otherwise */
 #define IS_LOCK_HAVE_SAME_OWNER(LockToTest, lockRgn) \
     (((LockToTest)->pvControllerInstance == (lockRgn)->pvControllerInstance) && \
      ((LockToTest)->processId == (lockRgn)->processId))
 
-/* return TRUE if LockToTest region and lockRgn represent the same lock, 
+/* return TRUE if LockToTest region and lockRgn represent the same lock,
    FALSE otherwise*/
 #define IS_LOCK_EQUAL(LockToTest, lockRgn) \
         (((LockToTest)->processId == (lockRgn)->processId)           && \
@@ -121,7 +121,7 @@ CSharedMemoryFileLockMgr::GetLockControllerForFile(
         palError = ERROR_INTERNAL_ERROR;
         goto GetLockControllerForFileExit;
     }
-        
+
     if(SHARE_MODE_NOT_INITALIZED == fileLocks->share_mode)
     {
         /* this is the first time this file is open */
@@ -135,17 +135,17 @@ CSharedMemoryFileLockMgr::GetLockControllerForFile(
         goto GetLockControllerForFileExit;
     }
     /* check for if the desired access is allowed by the share mode */
-    else if( (dwAccessRights & GENERIC_READ) && 
+    else if( (dwAccessRights & GENERIC_READ) &&
              !(fileLocks->share_mode & FILE_SHARE_READ) )
     {
         palError = ERROR_SHARING_VIOLATION;
-        goto GetLockControllerForFileExit;     
+        goto GetLockControllerForFileExit;
     }
-    else if( (dwAccessRights & GENERIC_WRITE) && 
+    else if( (dwAccessRights & GENERIC_WRITE) &&
              !(fileLocks->share_mode & FILE_SHARE_WRITE) )
     {
         palError = ERROR_SHARING_VIOLATION;
-        goto GetLockControllerForFileExit;     
+        goto GetLockControllerForFileExit;
     }
     /* The case when changing to a conflicting share mode is particular.
        The general rule is: changing from conflicting share mode is invalid
@@ -155,49 +155,49 @@ CSharedMemoryFileLockMgr::GetLockControllerForFile(
        the result is valid. (Please note that FILE_SHARE_READ is ignored
        in this case).
     */
-    else if( (dwShareMode & FILE_SHARE_READ) && 
+    else if( (dwShareMode & FILE_SHARE_READ) &&
              !(dwShareMode & FILE_SHARE_WRITE) &&
              !(fileLocks->share_mode & FILE_SHARE_READ))
-                         
+
     {
         palError = ERROR_SHARING_VIOLATION;
-        goto GetLockControllerForFileExit;     
+        goto GetLockControllerForFileExit;
     }
-    else if( (dwShareMode & FILE_SHARE_WRITE) && 
+    else if( (dwShareMode & FILE_SHARE_WRITE) &&
              !(dwShareMode & FILE_SHARE_READ) &&
              !(fileLocks->share_mode & FILE_SHARE_WRITE))
     {
         palError = ERROR_SHARING_VIOLATION;
-        goto GetLockControllerForFileExit;     
+        goto GetLockControllerForFileExit;
     }
     /* Changing to a less permissive sharing permissions is valid
        if the file handle doesn't have an access right that conflicts with
        the sharing permissions we are trying to set
        (ex: changing from FILE_SHARE_READ|FILE_SHARE_WRITE to FILE_SHARE_WRITE
        isn't valid if the file descriptor still has a GENERIC_READ permission).
-    */     
-    else if( (fileLocks->nbReadAccess) && 
+    */
+    else if( (fileLocks->nbReadAccess) &&
              !(dwShareMode & FILE_SHARE_READ) )
     {
         palError = ERROR_SHARING_VIOLATION;
-        goto GetLockControllerForFileExit;     
+        goto GetLockControllerForFileExit;
     }
-    else if( (fileLocks->nbWriteAccess) && 
+    else if( (fileLocks->nbWriteAccess) &&
              !(dwShareMode & FILE_SHARE_WRITE) )
     {
         palError = ERROR_SHARING_VIOLATION;
-        goto GetLockControllerForFileExit;     
+        goto GetLockControllerForFileExit;
     }
 
-    /* we are trying to change to a less restrictive sharing permission set 
-       keep the current permissions */  
-    if( (dwShareMode & FILE_SHARE_READ) && 
+    /* we are trying to change to a less restrictive sharing permission set
+       keep the current permissions */
+    if( (dwShareMode & FILE_SHARE_READ) &&
               !(fileLocks->share_mode & FILE_SHARE_READ) )
     {
         dwShareMode = fileLocks->share_mode;
     }
 
-    if( (dwShareMode & FILE_SHARE_WRITE) && 
+    if( (dwShareMode & FILE_SHARE_WRITE) &&
               !(fileLocks->share_mode & FILE_SHARE_WRITE) )
     {
         dwShareMode = fileLocks->share_mode;
@@ -222,7 +222,7 @@ CSharedMemoryFileLockMgr::GetLockControllerForFile(
     fileLocks->share_mode = dwShareMode;
     if( dwAccessRights & GENERIC_READ )
     {
-        fileLocks->nbReadAccess++;  
+        fileLocks->nbReadAccess++;
     }
     if( dwAccessRights & GENERIC_WRITE )
     {
@@ -322,13 +322,13 @@ CSharedMemoryFileLockController::GetTransactionLock(
     UINT64 nbBytesToLock;
 
     lockRgnStart  = ((UINT64)dwOffsetHigh) << 32  | dwOffsetLow;
-    nbBytesToLock = ((UINT64)nNumberOfBytesToLockHigh) << 32  | 
+    nbBytesToLock = ((UINT64)nNumberOfBytesToLockHigh) << 32  |
                              nNumberOfBytesToLockLow;
 
     palError = FILELockFileRegion(
         m_shmFileLocks,
         reinterpret_cast<PVOID>(this),
-        lockRgnStart, 
+        lockRgnStart,
         nbBytesToLock,
         RDWR_LOCK_RGN
         );
@@ -337,7 +337,7 @@ CSharedMemoryFileLockController::GetTransactionLock(
     {
         *ppTransactionLock = InternalNew<CSharedMemoryFileTransactionLock>(m_shmFileLocks,
                                                                            reinterpret_cast<PVOID>(this),
-                                                                           lockRgnStart, 
+                                                                           lockRgnStart,
                                                                            nbBytesToLock);
         if (NULL == *ppTransactionLock)
         {
@@ -345,7 +345,7 @@ CSharedMemoryFileLockController::GetTransactionLock(
             FILEUnlockFileRegion(
                 m_shmFileLocks,
                 reinterpret_cast<PVOID>(this),
-                lockRgnStart, 
+                lockRgnStart,
                 nbBytesToLock,
                 RDWR_LOCK_RGN
                 );
@@ -379,13 +379,13 @@ CSharedMemoryFileLockController::CreateFileLock(
     }
 
     lockRgnStart  = ((UINT64)dwOffsetHigh) << 32  | dwOffsetLow;
-    nbBytesToLock = ((UINT64)nNumberOfBytesToLockHigh) << 32  | 
+    nbBytesToLock = ((UINT64)nNumberOfBytesToLockHigh) << 32  |
                              nNumberOfBytesToLockLow;
 
     palError = FILELockFileRegion(
         m_shmFileLocks,
         reinterpret_cast<PVOID>(this),
-        lockRgnStart, 
+        lockRgnStart,
         nbBytesToLock,
         USER_LOCK_RGN
         );
@@ -409,13 +409,13 @@ CSharedMemoryFileLockController::ReleaseFileLock(
     UINT64 nbBytesToUnlock;
 
     unlockRgnStart  = ((UINT64)dwOffsetHigh) << 32  | dwOffsetLow;
-    nbBytesToUnlock = ((UINT64)nNumberOfBytesToUnlockHigh) << 32  | 
+    nbBytesToUnlock = ((UINT64)nNumberOfBytesToUnlockHigh) << 32  |
                              nNumberOfBytesToUnlockLow;
 
     palError = FILEUnlockFileRegion(
         m_shmFileLocks,
         reinterpret_cast<PVOID>(this),
-        unlockRgnStart, 
+        unlockRgnStart,
         nbBytesToUnlock,
         USER_LOCK_RGN
         );
@@ -444,7 +444,7 @@ CSharedMemoryFileTransactionLock::ReleaseLock()
     FILEUnlockFileRegion(
         m_shmFileLocks,
         m_pvControllerInstance,
-        m_lockRgnStart, 
+        m_lockRgnStart,
         m_nbBytesToLock,
         RDWR_LOCK_RGN
         );
@@ -456,25 +456,25 @@ PAL_ERROR
 FILELockFileRegion(
     SHMPTR shmFileLocks,
     PVOID pvControllerInstance,
-    UINT64 lockRgnStart, 
+    UINT64 lockRgnStart,
     UINT64 nbBytesToLock,
     LOCK_TYPE lockAction
     )
 {
     PAL_ERROR palError = NO_ERROR;
-    SHMFILELOCKRGNS *curLock, *prevLock, *insertAfter, 
+    SHMFILELOCKRGNS *curLock, *prevLock, *insertAfter,
                      lockRgn, fakeLock = {0,0,0,0};
     SHMFILELOCKS *fileLocks;
 
     SHMLock();
-    
+
     /* nothing to do if the region to lock is empty */
-    if (nbBytesToLock == 0) 
+    if (nbBytesToLock == 0)
     {
         TRACE("Locking an empty region (%I64d, %I64d)\n", lockRgnStart, nbBytesToLock);
         goto EXIT;
     }
-    
+
     if (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKS, fileLocks, shmFileLocks) == FALSE || fileLocks == NULL)
     {
         ASSERT("Unable to get pointer from shm pointer.\n");
@@ -483,17 +483,17 @@ FILELockFileRegion(
     }
 
     if (fileLocks->fileLockedRgns != 0)
-    {        
+    {
         prevLock = &fakeLock;
-        
-        if (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKRGNS, curLock, fileLocks->fileLockedRgns) 
+
+        if (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKRGNS, curLock, fileLocks->fileLockedRgns)
             == FALSE)
         {
             ASSERT("Unable to get pointer from shm pointer.\n");
             palError = ERROR_INTERNAL_ERROR;
             goto EXIT;
         }
-        
+
         lockRgn.lockRgnStart = lockRgnStart;
         lockRgn.nbBytesLocked = nbBytesToLock;
         lockRgn.pvControllerInstance = pvControllerInstance;
@@ -501,8 +501,8 @@ FILELockFileRegion(
         lockRgn.lockType = lockAction;
 
         while((curLock != NULL) && IS_LOCK_BEFORE(curLock, &lockRgn))
-        {            
-            prevLock = curLock; 
+        {
+            prevLock = curLock;
             if (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKRGNS, curLock, curLock->next) == FALSE)
             {
                 ASSERT("Unable to get pointer from shm pointer.\n");
@@ -510,21 +510,21 @@ FILELockFileRegion(
                 goto EXIT;
             }
         }
-                
+
         while((curLock != NULL) && IS_LOCK_INTERSECT(curLock, &lockRgn))
         {
-            /* we couldn't lock the requested region if it overlap with other 
+            /* we couldn't lock the requested region if it overlap with other
                region locked explicitly (by LockFile call) by other file pointer */
-            if ((lockAction == USER_LOCK_RGN) || 
-                ((curLock->lockType  == USER_LOCK_RGN) && 
+            if ((lockAction == USER_LOCK_RGN) ||
+                ((curLock->lockType  == USER_LOCK_RGN) &&
                  !IS_LOCK_HAVE_SAME_OWNER(curLock, &lockRgn)))
             {
                 WARN("The requested lock region overlaps an existing locked region\n");
                 palError = ERROR_LOCK_VIOLATION;
                 goto EXIT;
             }
-            
-            prevLock = curLock; 
+
+            prevLock = curLock;
             if (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKRGNS, curLock, curLock->next) == FALSE)
             {
                 ASSERT("Unable to get pointer from shm pointer.\n");
@@ -532,24 +532,24 @@ FILELockFileRegion(
                 goto EXIT;
             }
         }
-        
+
         /* save the previous lock in case we need to insert the requested lock */
-        insertAfter = prevLock;         
-                
+        insertAfter = prevLock;
+
         while(((curLock != NULL) && IS_LOCK_INTERSECT(&lockRgn, curLock)))
         {
-            /* we couldn't lock the requested region if it overlap with other region 
+            /* we couldn't lock the requested region if it overlap with other region
                locked explicitly (by LockFile call) by other file pointer */
-            if ((lockAction == USER_LOCK_RGN) || 
-                ((curLock->lockType  == USER_LOCK_RGN) &&  
+            if ((lockAction == USER_LOCK_RGN) ||
+                ((curLock->lockType  == USER_LOCK_RGN) &&
                  !IS_LOCK_HAVE_SAME_OWNER(curLock, &lockRgn)))
             {
                 WARN("The requested lock region overlaps an existing locked region\n");
                 palError = ERROR_LOCK_VIOLATION;
                 goto EXIT;
             }
-            
-            prevLock = curLock; 
+
+            prevLock = curLock;
             if (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKRGNS, curLock, curLock->next) == FALSE)
             {
                 ASSERT("Unable to get pointer from shm pointer.\n");
@@ -557,8 +557,8 @@ FILELockFileRegion(
                 goto EXIT;
             }
         }
-       
-        if (insertAfter == &fakeLock) 
+
+        if (insertAfter == &fakeLock)
         {
             insertAfter = NULL;
         }
@@ -588,13 +588,13 @@ FILELockFileRegion(
             nbBytesToLock,
             lockAction
             );
-        
+
         if (NO_ERROR != palError)
         {
             ERROR("Couldn't add the first file locked region \n");
             goto EXIT;
         }
-    }  
+    }
 
 EXIT:
     SHMRelease();
@@ -605,7 +605,7 @@ PAL_ERROR
 FILEUnlockFileRegion(
     SHMPTR shmFileLocks,
     PVOID pvControllerInstance,
-    UINT64 unlockRgnStart, 
+    UINT64 unlockRgnStart,
     UINT64 nbBytesToUnlock,
     LOCK_TYPE unlockType
     )
@@ -617,16 +617,16 @@ FILEUnlockFileRegion(
 
     SHMLock();
 
-    
+
     /* check if the region to unlock is empty or not */
-    if (nbBytesToUnlock == 0) 
+    if (nbBytesToUnlock == 0)
     {
         palError = ERROR_NOT_LOCKED;
         WARN("Attempt to unlock an empty region\n");
         goto EXIT;
     }
-    
-    if ((SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKS, fileLocks, shmFileLocks) == FALSE) || 
+
+    if ((SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKS, fileLocks, shmFileLocks) == FALSE) ||
         (fileLocks == NULL) ||
         (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKRGNS, curLockRgn, fileLocks->fileLockedRgns) == FALSE))
     {
@@ -634,7 +634,7 @@ FILEUnlockFileRegion(
         palError = ERROR_INTERNAL_ERROR;
         goto EXIT;
     }
-    
+
     unlockRgn.processId = GetCurrentProcessId();
     unlockRgn.pvControllerInstance = pvControllerInstance;
     unlockRgn.lockRgnStart = unlockRgnStart;
@@ -642,10 +642,10 @@ FILEUnlockFileRegion(
     unlockRgn.lockType = unlockType;
 
     shmcurLockRgn = fileLocks->fileLockedRgns;
-    
+
     while((curLockRgn != NULL) && !IS_LOCK_EQUAL(curLockRgn, &unlockRgn))
     {
-        prevLock = curLockRgn; 
+        prevLock = curLockRgn;
         shmcurLockRgn = curLockRgn->next;
         if (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKRGNS, curLockRgn, shmcurLockRgn) == FALSE)
         {
@@ -653,13 +653,13 @@ FILEUnlockFileRegion(
             goto EXIT;
         }
     }
-    
-    if (curLockRgn != NULL) 
+
+    if (curLockRgn != NULL)
     {
-        TRACE("removing the lock region (%I64u, %I64u)\n", 
+        TRACE("removing the lock region (%I64u, %I64u)\n",
                curLockRgn->lockRgnStart, curLockRgn->nbBytesLocked);
 
-        if (prevLock == NULL) 
+        if (prevLock == NULL)
         {
             /* removing the first lock */
             fileLocks->fileLockedRgns = curLockRgn->next;
@@ -677,8 +677,8 @@ FILEUnlockFileRegion(
         palError = ERROR_NOT_LOCKED;
         goto EXIT;
     }
-    
-EXIT:    
+
+EXIT:
     SHMRelease();
     return palError;
 }
@@ -701,7 +701,7 @@ FILEGetSHMFileLocks(
     shmPtrRet = SHMGetInfo(SIID_FILE_LOCKS);
 
     while(shmPtrRet != 0)
-    {        
+    {
         if ( (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKS, filelocksPtr, shmPtrRet) == FALSE) ||
              (SHMPTR_TO_TYPED_PTR_BOOL(char, unix_filename, filelocksPtr->unix_filename) == FALSE))
         {
@@ -716,13 +716,13 @@ FILEGetSHMFileLocks(
             palError = ERROR_INTERNAL_ERROR;
             goto EXIT;
         }
-        
+
         if (strcmp(unix_filename, filename) == 0)
         {
             filelocksPtr->refCount++;
             goto EXIT;
         }
-        
+
         shmPtrRet = filelocksPtr->next;
     }
 
@@ -772,7 +772,7 @@ FILEGetSHMFileLocks(
         palError = ERROR_INTERNAL_ERROR;
         goto CLEANUP2;
     }
-    
+
     if (nextFilelocksPtr != NULL)
     {
         nextFilelocksPtr->prev = shmPtrRet;
@@ -786,24 +786,24 @@ CLEANUP2:
 CLEANUP1:
     SHMfree(shmPtrRet);
     shmPtrRet = 0;
-EXIT:    
+EXIT:
     SHMRelease();
 
     if (NO_ERROR == palError)
     {
         *pshmFileLocks = shmPtrRet;
     }
-    
+
     return palError;
 }
 
 PAL_ERROR
 FILEAddNewLockedRgn(
     SHMFILELOCKS* fileLocks,
-    PVOID pvControllerInstance, 
+    PVOID pvControllerInstance,
     SHMFILELOCKRGNS *insertAfter,
-    UINT64 lockRgnStart, 
-    UINT64 nbBytesToLock, 
+    UINT64 lockRgnStart,
+    UINT64 nbBytesToLock,
     LOCK_TYPE lockType
     )
 {
@@ -818,11 +818,11 @@ FILEAddNewLockedRgn(
     }
 
     SHMLock();
-    
+
     /* Create a new entry for the new locked region */
-    TRACE("Create a new entry for the new lock region (%I64u %I64u)\n", 
+    TRACE("Create a new entry for the new lock region (%I64u %I64u)\n",
           lockRgnStart, nbBytesToLock);
-    
+
     if ((shmNewLockRgn = SHMalloc(sizeof(SHMFILELOCKRGNS))) == SHMNULL)
     {
         ERROR("Can't allocate SHMFILELOCKRGNS structure\n");
@@ -836,13 +836,13 @@ FILEAddNewLockedRgn(
         palError = ERROR_INTERNAL_ERROR;
         goto EXIT;
     }
-    
+
     newLockRgn->processId = GetCurrentProcessId();
     newLockRgn->pvControllerInstance = pvControllerInstance;
     newLockRgn->lockRgnStart = lockRgnStart;
     newLockRgn->nbBytesLocked = nbBytesToLock;
     newLockRgn->lockType = lockType;
-    
+
     /* All locked regions with the same offset should be sorted ascending */
     /* the sort is based on the length of the locked byte range */
     if (insertAfter != NULL)
@@ -863,7 +863,7 @@ FILEAddNewLockedRgn(
             goto EXIT;
         }
     }
-    
+
     while(lockRgnPtr != NULL)
     {
         if ( (lockRgnPtr->lockRgnStart == newLockRgn->lockRgnStart) &&
@@ -881,10 +881,10 @@ FILEAddNewLockedRgn(
 
         break;
     }
-    
+
     if (insertAfter != NULL)
-    {       
-        TRACE("Adding lock after the lock rgn (%I64d %I64d)\n", 
+    {
+        TRACE("Adding lock after the lock rgn (%I64d %I64d)\n",
               insertAfter->lockRgnStart,insertAfter->nbBytesLocked);
         newLockRgn->next = insertAfter->next;
         insertAfter->next = shmNewLockRgn;
@@ -902,9 +902,9 @@ EXIT:
     {
         SHMfree(shmNewLockRgn);
     }
-   
+
     SHMRelease();
-    
+
     return palError;
 }
 
@@ -917,7 +917,7 @@ FILECleanUpLockedRgn(
 {
     SHMFILELOCKRGNS *curLockRgn = NULL, *prevLock = NULL;
     SHMFILELOCKS *fileLocks, *prevFileLocks, *nextFileLocks;
-    SHMPTR shmcurLockRgn;    
+    SHMPTR shmcurLockRgn;
 
     SHMLock();
 
@@ -930,24 +930,24 @@ FILECleanUpLockedRgn(
     if (fileLocks != NULL)
     {
         if(fileLocks->fileLockedRgns !=0)
-        {        
+        {
             shmcurLockRgn = fileLocks->fileLockedRgns;
             if (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKRGNS, curLockRgn, shmcurLockRgn) == FALSE)
             {
                 ASSERT("Unable to get pointer from shm pointer.\n");
                 goto EXIT;
             }
-            
+
             while(curLockRgn != NULL)
             {
-                if ((curLockRgn->pvControllerInstance == pvControllerInstance) && 
+                if ((curLockRgn->pvControllerInstance == pvControllerInstance) &&
                     (curLockRgn->processId == GetCurrentProcessId()))
                 {
                     /* found the locked rgn to remove from SHM */
-                    TRACE("Removing the locked region (%I64u, %I64u) from SMH\n", 
+                    TRACE("Removing the locked region (%I64u, %I64u) from SMH\n",
                           curLockRgn->lockRgnStart, curLockRgn->nbBytesLocked);
-                    
-                    if (prevLock == NULL) 
+
+                    if (prevLock == NULL)
                     {
                         /* removing the first lock */
                         fileLocks->fileLockedRgns = curLockRgn->next;
@@ -972,7 +972,7 @@ FILECleanUpLockedRgn(
                     }
                     continue;
                 }
-                
+
                 prevLock = curLockRgn;
                 shmcurLockRgn = curLockRgn->next;
                 if (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKRGNS, curLockRgn, shmcurLockRgn) == FALSE)
@@ -982,20 +982,20 @@ FILECleanUpLockedRgn(
                 }
             }
         }
-    
+
         if (dwAccessRights & GENERIC_READ)
-        {   
-            fileLocks->nbReadAccess--;      
+        {
+            fileLocks->nbReadAccess--;
         }
         if (dwAccessRights & GENERIC_WRITE)
         {
-            fileLocks->nbWriteAccess--; 
-        }  
+            fileLocks->nbWriteAccess--;
+        }
 
-        /* remove the SHMFILELOCKS structure from SHM if there's no more locked 
-           region left and no more reference to it */        
+        /* remove the SHMFILELOCKS structure from SHM if there's no more locked
+           region left and no more reference to it */
         if ((--(fileLocks->refCount) == 0) && (fileLocks->fileLockedRgns == 0))
-        {            
+        {
             TRACE("Removing the SHMFILELOCKS structure from SHM\n");
 
             if ( (SHMPTR_TO_TYPED_PTR_BOOL(SHMFILELOCKS, prevFileLocks, fileLocks->prev) == FALSE) ||
@@ -1005,7 +1005,7 @@ FILECleanUpLockedRgn(
                 goto EXIT;
             }
 
-            if (prevFileLocks == NULL) 
+            if (prevFileLocks == NULL)
             {
                 /* removing the first lock file*/
                 SHMSetInfo(SIID_FILE_LOCKS, fileLocks->next);
@@ -1025,9 +1025,8 @@ FILECleanUpLockedRgn(
 
             SHMfree(shmFileLocks);
         }
-    }    
+    }
 EXIT:
     SHMRelease();
     return;
 }
-

--- a/pal/src/file/shmfilelockmgr.hpp
+++ b/pal/src/file/shmfilelockmgr.hpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -31,11 +31,11 @@ namespace CorUnix
     typedef struct
     {
         SHMPTR unix_filename;
-        SHMPTR fileLockedRgns;    
+        SHMPTR fileLockedRgns;
         UINT refCount;
         SHMPTR next;
         SHMPTR prev;
-        DWORD  share_mode; /* FILE_SHARE_READ, FILE_SHARE_WRITE, 
+        DWORD  share_mode; /* FILE_SHARE_READ, FILE_SHARE_WRITE,
                               FILE_SHARE_DELETE,  0 ( not shared ) or
                               SHARE_MODE_NOT_INITALIZED */
         int nbReadAccess;  /* used to keep track of the minimal
@@ -46,7 +46,7 @@ namespace CorUnix
     typedef enum
     {
         USER_LOCK_RGN, /* Used only for user locks (LockFile or UnlockFile call) */
-        RDWR_LOCK_RGN  /* Used to distinguish between the user locks and the internal 
+        RDWR_LOCK_RGN  /* Used to distinguish between the user locks and the internal
                           locks made when  reading, writing or truncating file */
     } LOCK_TYPE;
 
@@ -54,17 +54,17 @@ namespace CorUnix
     {
         DWORD processId;
         PVOID pvControllerInstance;
-        UINT64 lockRgnStart; 
+        UINT64 lockRgnStart;
         UINT64 nbBytesLocked;
         LOCK_TYPE lockType;
 
         SHMPTR next;
     } SHMFILELOCKRGNS;
-    
+
     class CSharedMemoryFileLockMgr : public IFileLockManager
     {
     public:
-        
+
         virtual
         PAL_ERROR
         GetLockControllerForFile(
@@ -93,7 +93,7 @@ namespace CorUnix
         virtual ~CSharedMemoryFileLockController()
         {
         };
-        
+
     public:
 
         CSharedMemoryFileLockController(
@@ -148,7 +148,7 @@ namespace CorUnix
     class CSharedMemoryFileTransactionLock : public IFileTransactionLock
     {
         template <class T> friend void InternalDelete(T *p);
-          
+
     private:
 
         SHMPTR m_shmFileLocks;
@@ -159,7 +159,7 @@ namespace CorUnix
         virtual ~CSharedMemoryFileTransactionLock()
         {
         };
-        
+
     public:
 
         CSharedMemoryFileTransactionLock(
@@ -183,4 +183,3 @@ namespace CorUnix
 }
 
 #endif /* _PAL_SHMFILELOCKMGR_H_ */
-

--- a/pal/src/handlemgr/handleapi.cpp
+++ b/pal/src/handlemgr/handleapi.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -65,7 +65,7 @@ DuplicateHandle(
 {
     PAL_ERROR palError;
     CPalThread *pThread;
-    
+
     PERF_ENTRY(DuplicateHandle);
     ENTRY("DuplicateHandle( hSrcProcHandle=%p, hSrcHandle=%p, "
           "hTargetProcHandle=%p, lpTargetHandle=%p, dwAccess=%#x, "
@@ -110,7 +110,7 @@ CorUnix::InternalDuplicateHandle(
 {
     PAL_ERROR palError = NO_ERROR;
     IPalObject *pobjSource = NULL;
-    
+
     DWORD source_process_id;
     DWORD target_process_id;
     DWORD cur_process_id;
@@ -155,7 +155,7 @@ CorUnix::InternalDuplicateHandle(
         palError = ERROR_INVALID_PARAMETER;
         goto InternalDuplicateHandleExit;
     }
-    
+
     if (0 == (dwOptions & DUPLICATE_SAME_ACCESS))
     {
         ASSERT(
@@ -207,7 +207,7 @@ CorUnix::InternalDuplicateHandle(
         {
             ERROR("Unable to get object for source handle %p (%i)\n", hSource, palError);
             goto InternalDuplicateHandleExit;
-        }            
+        }
     }
     else if (hPseudoCurrentProcess == hSource)
     {
@@ -253,7 +253,7 @@ InternalDuplicateHandleExit:
         // MUST be closed, even if an error occurred during the duplication
         // process
         //
-        
+
         TRACE("DuplicateHandle closing source handle %p\n", hSource);
         InternalCloseHandle(pThread, hSource);
     }
@@ -336,4 +336,3 @@ CloseSpecialHandle(
 
     return ERROR_INVALID_HANDLE;
 }
-

--- a/pal/src/handlemgr/handlemgr.cpp
+++ b/pal/src/handlemgr/handlemgr.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -43,7 +43,7 @@ CSimpleHandleManager::Initialize(
     )
 {
     PAL_ERROR palError = NO_ERROR;
-    
+
     InternalInitializeCriticalSection(&m_csLock);
     m_fLockInitialized = TRUE;
 
@@ -52,7 +52,7 @@ CSimpleHandleManager::Initialize(
     /* initialize the handle table - the free list is stored in the 'object'
        field, with the head in the global 'm_hiFreeListStart'. */
     m_dwTableSize = m_dwTableGrowthRate;
-    
+
     m_rghteHandleTable = reinterpret_cast<HANDLE_TABLE_ENTRY*>(InternalMalloc((m_dwTableSize * sizeof(HANDLE_TABLE_ENTRY))));
     if(NULL == m_rghteHandleTable)
     {
@@ -68,14 +68,14 @@ CSimpleHandleManager::Initialize(
     }
 
     m_rghteHandleTable[m_dwTableSize - 1].u.hiNextIndex = (HANDLE_INDEX)-1;
-    
+
     m_hiFreeListStart = 0;
     m_hiFreeListEnd = m_dwTableSize - 1;
 
     TRACE("Handle Manager initialization complete.\n");
 
 InitializeExit:
-    
+
     return palError;
 }
 
@@ -115,7 +115,7 @@ CSimpleHandleManager::AllocateHandle(
         rghteTempTable = reinterpret_cast<HANDLE_TABLE_ENTRY*>(InternalRealloc(
             m_rghteHandleTable,
             (m_dwTableSize + m_dwTableGrowthRate) * sizeof(HANDLE_TABLE_ENTRY)));
-        
+
         if (NULL == rghteTempTable)
         {
             WARN("not enough memory to grow handle table!\n");
@@ -139,7 +139,7 @@ CSimpleHandleManager::AllocateHandle(
         m_dwTableSize += m_dwTableGrowthRate;
         m_rghteHandleTable[m_dwTableSize - 1].u.hiNextIndex = (HANDLE_INDEX)-1;
         m_hiFreeListEnd = m_dwTableSize - 1;
-        
+
     }
 
     /* take the next free handle */
@@ -147,16 +147,16 @@ CSimpleHandleManager::AllocateHandle(
 
     /* remove the handle from the pool */
     m_hiFreeListStart = m_rghteHandleTable[dwIndex].u.hiNextIndex;
-    
+
     /* clear the tail record if this is the last handle slot available */
-    if(m_hiFreeListStart == c_hiInvalid) 
+    if(m_hiFreeListStart == c_hiInvalid)
     {
         m_hiFreeListEnd = c_hiInvalid;
     }
 
     /* save the data associated with the new handle */
     *ph = HandleIndexToHandle(dwIndex);
-    
+
     pObject->AddReference();
     m_rghteHandleTable[dwIndex].u.pObject = pObject;
     m_rghteHandleTable[dwIndex].dwAccessRights = dwAccessRights;
@@ -167,7 +167,7 @@ AllocateHandleExit:
 
     Unlock(pThread);
 
-    return palError;    
+    return palError;
 }
 
 PAL_ERROR
@@ -182,20 +182,20 @@ CSimpleHandleManager::GetObjectFromHandle(
     HANDLE_INDEX hi;
 
     Lock(pThread);
-    
+
     if (!ValidateHandle(h))
     {
         ERROR("Tried to dereference an invalid handle %p\n", h);
         palError = ERROR_INVALID_HANDLE;
         goto GetObjectFromHandleExit;
     }
-    
+
     hi = HandleToHandleIndex(h);
 
     *pdwRightsGranted = m_rghteHandleTable[hi].dwAccessRights;
     *ppObject = m_rghteHandleTable[hi].u.pObject;
     (*ppObject)->AddReference();
-    
+
 GetObjectFromHandleExit:
 
     Unlock(pThread);
@@ -241,11 +241,11 @@ CSimpleHandleManager::FreeHandle(
     {
         m_hiFreeListStart = hi;
     }
-    
+
     m_rghteHandleTable[hi].u.hiNextIndex = c_hiInvalid;
     m_hiFreeListEnd = hi;
 
-FreeHandleExit:    
+FreeHandleExit:
 
     Unlock(pThread);
 
@@ -272,13 +272,13 @@ Return Value :
 bool CSimpleHandleManager::ValidateHandle(HANDLE handle)
 {
     DWORD dwIndex;
-    
+
     if (NULL == m_rghteHandleTable)
     {
         ASSERT("Handle Manager is not initialized!\n");
         return FALSE;
     }
-    
+
     if (handle == INVALID_HANDLE_VALUE || handle == 0)
     {
         TRACE( "INVALID_HANDLE_VALUE or NULL value is not a valid handle.\n" );
@@ -294,7 +294,7 @@ bool CSimpleHandleManager::ValidateHandle(HANDLE handle)
         // (since clients of the handle manager should have already dealt with
         // the specialness of the handle) so we assert here.
         //
-        
+
         ASSERT ("Handle %p is a special handle, returning FALSE.\n", handle);
         return FALSE;
     }
@@ -325,4 +325,3 @@ CorUnix::HandleIsSpecial(
             hPseudoCurrentThread == h ||
             hPseudoGlobalIOCP == h);
 }
-

--- a/pal/src/include/pal/dbgmsg.h
+++ b/pal/src/include/pal/dbgmsg.h
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -121,20 +121,20 @@ Using Debug channels at Run Time
     "stdout" or "stderr". If PAL_API_TRACING is not set, output will go to
     stderr.
 
-    ASSERT() messages cannot be controlled with PAL_DBG_CHANNELS; they can be 
-    globally disabled (in debug builds) by setting the environment variable 
-    PAL_DISABLE_ASSERTS to 1. In release builds, they will always be disabled                    
+    ASSERT() messages cannot be controlled with PAL_DBG_CHANNELS; they can be
+    globally disabled (in debug builds) by setting the environment variable
+    PAL_DISABLE_ASSERTS to 1. In release builds, they will always be disabled
 
-    The environment variable "PAL_API_LEVELS" determines how many levels of 
-    nesting will be allowed in ENTRY calls; if not set, the default is 1; a 
+    The environment variable "PAL_API_LEVELS" determines how many levels of
+    nesting will be allowed in ENTRY calls; if not set, the default is 1; a
     value of 0 will allow infinite nesting, but will not indent the output
 
-    It is possible to disable/enable all channels during the execution of a 
-    process; this involves using a debugger to modify a variable within the 
-    address space of the running process. the variable is named 
-    'dbg_master_switch'; if set to zero, all debug chanels will be closed; if 
+    It is possible to disable/enable all channels during the execution of a
+    process; this involves using a debugger to modify a variable within the
+    address space of the running process. the variable is named
+    'dbg_master_switch'; if set to zero, all debug chanels will be closed; if
     set to nonzero, channels will be open or closed based on PAL_DBG_CHANNELS
-    
+
     Notes :
     If _ENABLE_DEBUG_MESSAGES_ was not defined at build-time, no debug messages
     will be generated.
@@ -145,7 +145,7 @@ Using Debug channels at Run Time
     Normally, if the file specified by PAL_API_TRACING exists, its content will
     be overwritten when a PAL process starts using it. If --enable-appendtraces
     is used, debug output will be appended at the end of the file instead.
-  
+
 
 
  */
@@ -213,8 +213,8 @@ typedef enum
 
 /* extern variables */
 
-// Change W16_NULLSTRING to external variable to avoid multiple warnings showing up in prefast 
-extern LPCWSTR W16_NULLSTRING; 
+// Change W16_NULLSTRING to external variable to avoid multiple warnings showing up in prefast
+extern LPCWSTR W16_NULLSTRING;
 
 extern DWORD dbg_channel_flags[DCI_LAST];
 extern BOOL g_Dbg_asserts_enabled;
@@ -298,7 +298,7 @@ bool DBG_ShouldCheckStackAlignment();
 
 #define LOGEXIT_(x) \
     DBG_PRINTF(DLI_EXIT, DCI_##x,TRUE)
-    
+
 #define DBGOUT \
     DBG_PRINTF(DLI_TRACE,defdbgchan,FALSE)
 
@@ -357,11 +357,11 @@ bool DBG_ShouldCheckStackAlignment();
 #if !defined(_DEBUG)
 
 #define ASSERT(args...)
-#define _ASSERT(expr) 
-#define _ASSERTE(expr) 
-#define _ASSERT_MSG(args...) 
+#define _ASSERT(expr)
+#define _ASSERTE(expr)
+#define _ASSERT_MSG(args...)
 
-#else /* defined(_DEBUG) */ 
+#else /* defined(_DEBUG) */
 
 #define ASSERT(args...)                                                 \
 {                                                                       \
@@ -400,9 +400,9 @@ bool DBG_ShouldCheckStackAlignment();
 #if !defined(_DEBUG)
 
 #define ASSERT(...)
-#define _ASSERT(expr) 
-#define _ASSERTE(expr) 
-#define _ASSERT_MSG(...) 
+#define _ASSERT(expr)
+#define _ASSERTE(expr)
+#define _ASSERT_MSG(...)
 
 #else /* defined(_DEBUG) */
 
@@ -419,7 +419,7 @@ bool DBG_ShouldCheckStackAlignment();
         DebugBreak();                                                   \
     }                                                                   \
 }
-    
+
 #define _ASSERT(expr) do { if (!(expr)) { ASSERT(""); } } while(0)
 #define _ASSERTE(expr) do { if (!(expr)) { ASSERT("Expression: " #expr "\n"); } } while(0)
 #define _ASSERT_MSG(expr, ...) \
@@ -433,9 +433,9 @@ bool DBG_ShouldCheckStackAlignment();
 #endif /* !_DEBUG */
 
 #else /* __STDC_VERSION__ */
-/* Not GNU C, not C99 :  
-   possible work around for the lack of variable-argument macros: 
-   by using 2 function calls; must wrap the whole thing in a critical 
+/* Not GNU C, not C99 :
+   possible work around for the lack of variable-argument macros:
+   by using 2 function calls; must wrap the whole thing in a critical
    section to avoid interleaved output from multiple threads */
 
 #error The compiler is missing support for variable-argument macros.
@@ -518,7 +518,7 @@ Notes :
 
 --*/
 #if __GNUC__ && CHECK_TRACE_SPECIFIERS
-/* if requested, use an __attribute__ feature to ask gcc to check that format 
+/* if requested, use an __attribute__ feature to ask gcc to check that format
    specifiers match their parameters */
 int DBG_printf_gcc(DBG_CHANNEL_ID channel, DBG_LEVEL_ID level, BOOL bHeader,
                    LPCSTR function, LPCSTR file, INT line, LPCSTR format, ...)
@@ -582,12 +582,12 @@ Function :
 
     retrieve current ENTRY nesting level and [optionnally] modify it
 
-Parameters :                                  
+Parameters :
     int new_level : value to which the nesting level must be set, or -1
 
 Return value :
     nesting level at the time the function was called
-    
+
 Notes:
 if new_level is -1, the nesting level will not be modified
 --*/
@@ -623,5 +623,3 @@ void PAL_DisplayDialogFormatted(const char *szTitle, const char *szTextFormat, .
 #endif // __cplusplus
 
 #endif /* _PAL_DBGMSG_H_ */
-
-

--- a/pal/src/include/pal/tls.hpp
+++ b/pal/src/include/pal/tls.hpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -46,7 +46,7 @@ namespace CorUnix
         CThreadTLSInfo()
         {
             ZeroMemory(tlsSlots, sizeof(tlsSlots));
-        };        
+        };
     };
 
     //
@@ -63,4 +63,3 @@ namespace CorUnix
 }
 
 #endif // _PAL_TLS_HPP
-

--- a/pal/src/init/pal.cpp
+++ b/pal/src/init/pal.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -182,7 +182,7 @@ Initialize(
 
     if(NULL == init_critsec)
     {
-        pthread_mutex_lock(&init_critsec_mutex); // prevents race condition of two threads 
+        pthread_mutex_lock(&init_critsec_mutex); // prevents race condition of two threads
                                                  // initializing the critical section.
         if(NULL == init_critsec)
         {
@@ -194,7 +194,7 @@ Initialize(
             if(NULL != InterlockedCompareExchangePointer(&init_critsec, &temp_critsec, NULL))
             {
                 // Another thread got in before us! shouldn't happen, if the PAL
-                // isn't initialized there shouldn't be any other threads 
+                // isn't initialized there shouldn't be any other threads
                 WARN("Another thread initialized the critical section\n");
                 InternalDeleteCriticalSection(&temp_critsec);
             }
@@ -398,7 +398,7 @@ Initialize(
         palError = InitializeProcessCommandLine(
             command_line,
             exe_path);
-        
+
         if (NO_ERROR != palError)
         {
             ERROR("Unable to initialize command line\n");
@@ -410,11 +410,11 @@ Initialize(
 
 #ifdef PAL_PERF
         // Initialize the Profiling structure
-        if(FALSE == PERFInitialize(command_line, exe_path)) 
+        if(FALSE == PERFInitialize(command_line, exe_path))
         {
             ERROR("Performance profiling initial failed\n");
             goto CLEANUP2;
-        }    
+        }
         PERFAllocThreadInfo();
 #endif
 
@@ -497,7 +497,7 @@ Initialize(
         }
 
         TRACE("First-time PAL initialization complete.\n");
-        init_count++;        
+        init_count++;
 
         /* Set LastError to a non-good value - functions within the
            PAL startup may set lasterror to a nonzero value. */
@@ -521,7 +521,7 @@ Initialize(
     }
     goto done;
 
-    /* No cleanup required for CRTInitStdStreams */ 
+    /* No cleanup required for CRTInitStdStreams */
 CLEANUP15:
     FILECleanupStdHandles();
 CLEANUP13:
@@ -550,7 +550,7 @@ CLEANUP0:
     ERROR("PAL_Initialize failed\n");
     SetLastError(palError);
 done:
-#ifdef PAL_PERF 
+#ifdef PAL_PERF
     if( retval == 0)
     {
          PERFEnableProcessProfile();
@@ -599,7 +599,7 @@ Return:
 PAL_ERROR
 PALAPI
 PAL_InitializeChakraCore(const char *szExePath)
-{    
+{
     // Fake up a command line to call PAL initialization with.
     int result = Initialize(1, &szExePath, PAL_INITIALIZE_CHAKRACORE);
     if (result != 0)
@@ -816,7 +816,7 @@ Function:
 Utility function to prepare for shutdown.
 
 --*/
-void 
+void
 PALCommonCleanup()
 {
     static bool cleanupDone = false;
@@ -843,10 +843,10 @@ PALCommonCleanup()
 Function:
   PALShutdown
 
-  sets the PAL's initialization count to zero, so that PALIsInitialized will 
+  sets the PAL's initialization count to zero, so that PALIsInitialized will
   return FALSE. called by PROCCleanupProcess to tell some functions that the
   PAL isn't fully functional, and that they should use an alternate code path
-  
+
 (no parameters, no retun vale)
 --*/
 void PALShutdown()
@@ -857,10 +857,10 @@ void PALShutdown()
 BOOL PALIsShuttingDown()
 {
     /* ROTORTODO: This function may be used to provide a reader/writer-like
-       mechanism (or a ref counting one) to prevent PAL APIs that need to access 
-       PAL runtime data, from working when PAL is shutting down. Each of those API 
+       mechanism (or a ref counting one) to prevent PAL APIs that need to access
+       PAL runtime data, from working when PAL is shutting down. Each of those API
        should acquire a read access while executing. The shutting down code would
-       acquire a write lock, i.e. suspending any new incoming reader, and waiting 
+       acquire a write lock, i.e. suspending any new incoming reader, and waiting
        for the current readers to be done. That would allow us to get rid of the
        dangerous suspend-all-other-threads at shutdown time */
     return shutdown_intent;
@@ -876,7 +876,7 @@ void PALSetShutdownIntent()
 Function:
   PALInitLock
 
-Take the initializaiton critical section (init_critsec). necessary to serialize 
+Take the initializaiton critical section (init_critsec). necessary to serialize
 TerminateProcess along with PAL_Terminate and PAL_Initialize
 
 (no parameters)
@@ -891,10 +891,10 @@ BOOL PALInitLock(void)
     {
         return FALSE;
     }
-    
-    CPalThread * pThread = 
+
+    CPalThread * pThread =
         (PALIsThreadDataInitialized() ? InternalGetCurrentThread() : NULL);
-    
+
     InternalEnterCriticalSection(pThread, init_critsec);
     return TRUE;
 }
@@ -903,7 +903,7 @@ BOOL PALInitLock(void)
 Function:
   PALInitUnlock
 
-Release the initialization critical section (init_critsec). 
+Release the initialization critical section (init_critsec).
 
 (no parameters, no return value)
 --*/
@@ -914,7 +914,7 @@ void PALInitUnlock(void)
         return;
     }
 
-    CPalThread * pThread = 
+    CPalThread * pThread =
         (PALIsThreadDataInitialized() ? InternalGetCurrentThread() : NULL);
 
     InternalLeaveCriticalSection(pThread, init_critsec);
@@ -937,7 +937,7 @@ static BOOL INIT_IncreaseDescriptorLimit(void)
 {
     struct rlimit rlp;
     int result;
-    
+
     result = getrlimit(RLIMIT_NOFILE, &rlp);
     if (result != 0)
     {
@@ -971,7 +971,7 @@ Return value :
     pointer to Unicode command line. This is a buffer allocated with malloc;
     caller is responsible for freeing it with free()
 
-Note : not all peculiarities of Windows command-line processing are supported; 
+Note : not all peculiarities of Windows command-line processing are supported;
 
 -what is supported :
     -arguments with white-space must be double quoted (we'll just double-quote
@@ -979,11 +979,11 @@ Note : not all peculiarities of Windows command-line processing are supported;
     -some characters must be escaped with \ : particularly, the double-quote,
      to avoid confusion with the double-quotes at the start and end of
      arguments, and \ itself, to avoid confusion with escape sequences.
--what is not supported:    
+-what is not supported:
     -under Windows, \\ is interpreted as an escaped \ ONLY if it's followed by
      an escaped double-quote \". \\\" is passed to argv as \", but \\a is
      passed to argv as \\a... there may be other similar cases
-    -there may be other characters which must be escaped 
+    -there may be other characters which must be escaped
 --*/
 static LPWSTR INIT_FormatCommandLine (int argc, const char * const *argv)
 {
@@ -1148,7 +1148,7 @@ static LPWSTR INIT_FindEXEPath(LPCSTR exe_name)
             }
             else
             {
-                if(!MultiByteToWideChar(CP_ACP, 0, real_path, -1, 
+                if(!MultiByteToWideChar(CP_ACP, 0, real_path, -1,
                                         return_value, return_size))
                 {
                     ASSERT("MultiByteToWideChar failure\n");
@@ -1226,7 +1226,7 @@ static LPWSTR INIT_FindEXEPath(LPCSTR exe_name)
             ERROR("Not enough memory!\n");
             break;
         }
-        
+
         if (strcpy_s(full_path, iLength, cur_dir) != SAFECRT_SUCCESS)
         {
             ERROR("strcpy_s failed!\n");
@@ -1338,7 +1338,7 @@ last_resort:
             }
             else
             {
-                if(!MultiByteToWideChar(CP_ACP, 0, real_path, -1, 
+                if(!MultiByteToWideChar(CP_ACP, 0, real_path, -1,
                                         return_value, return_size))
                 {
                     ASSERT("MultiByteToWideChar failure\n");
@@ -1356,7 +1356,7 @@ last_resort:
         {
             ERROR("found %s in current directory, but it isn't executable!\n",
                   exe_name);
-        }                                                                   
+        }
     }
     else
     {
@@ -1394,7 +1394,7 @@ last_resort:
     }
     else
     {
-        if(!MultiByteToWideChar(CP_ACP, 0, exec_path, -1, 
+        if(!MultiByteToWideChar(CP_ACP, 0, exec_path, -1,
                                 return_value, return_size))
         {
             ASSERT("MultiByteToWideChar failure\n");

--- a/pal/src/init/sxs.cpp
+++ b/pal/src/init/sxs.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -56,12 +56,12 @@ PAL_Enter(PAL_Boundary boundary)
     }
     else
     {
-        // If this assert fires, we'll have to pipe this information so that 
-        // CPalThread's RunPostCreateInitializers call to SEHEnable 
+        // If this assert fires, we'll have to pipe this information so that
+        // CPalThread's RunPostCreateInitializers call to SEHEnable
         // can know what direction.
         _ASSERT_MSG(PAL_BoundaryTop == boundary, "How are we entering a PAL "
             "thread for the first time not from the top? (boundary=%u)", boundary);
-            
+
         palError = AllocatePalThread(&pThread);
         if (NO_ERROR != palError)
         {
@@ -78,9 +78,9 @@ Function:
   CreateCurrentThreadData
 
 Abstract:
-  This function is called by the InternalGetOrCreateCurrentThread inlined 
+  This function is called by the InternalGetOrCreateCurrentThread inlined
   function to create the thread data when it is null meaning the thread has
-  never been in this PAL. 
+  never been in this PAL.
 
 Warning:
   If the allocation fails, this function asserts and exits the process.
@@ -121,9 +121,9 @@ AllocatePalThread(CPalThread **ppThread)
         pThread->ReleaseThreadReference();
         goto exit;
     }
-    
-    // Like CreateInitialProcessAndThreadObjects, we do not need this 
-    // thread handle, since we're not returning it to anyone who will 
+
+    // Like CreateInitialProcessAndThreadObjects, we do not need this
+    // thread handle, since we're not returning it to anyone who will
     // possibly release it.
     (void)g_pObjectManager->RevokeHandle(pThread, hThread);
 
@@ -195,7 +195,7 @@ PAL_HasEntered()
     }
 
     LOGEXIT("PAL_HasEntered returned\n");
-    
+
     return pThread->IsInPal();
 }
 
@@ -278,7 +278,7 @@ PALAPI
 PAL_Leave(PAL_Boundary boundary)
 {
     ENTRY("PAL_Leave(boundary=%u)\n", boundary);
-    
+
     CPalThread *pThread = GetCurrentPalThread();
     // We ignore the return code.  This call should only fail on internal
     // error, and we assert at the actual failure.

--- a/pal/src/loader/module.cpp
+++ b/pal/src/loader/module.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -90,7 +90,7 @@ SET_DEFAULT_DEBUG_CHANNEL(LOADER);
 CRITICAL_SECTION module_critsec;
 
 /* always the first, in the in-load-order list */
-MODSTRUCT exe_module; 
+MODSTRUCT exe_module;
 MODSTRUCT *pal_module = nullptr;
 
 char * g_szCoreCLRPath = nullptr;
@@ -157,7 +157,7 @@ LoadLibraryExA(
     IN /*Reserved*/ HANDLE hFile,
     IN DWORD dwFlags)
 {
-    if (dwFlags != 0) 
+    if (dwFlags != 0)
     {
         // UNIXTODO: Implement this!
         ASSERT("Needs Implementation!!!");
@@ -199,7 +199,7 @@ LoadLibraryExA(
     LOGEXIT("LoadLibraryExA returns HMODULE %p\n", hModule);
     PERF_EXIT(LoadLibraryExA);
     return hModule;
-    
+
 }
 
 /*++
@@ -215,13 +215,13 @@ LoadLibraryExW(
     IN /*Reserved*/ HANDLE hFile,
     IN DWORD dwFlags)
 {
-    if (dwFlags != 0) 
+    if (dwFlags != 0)
     {
         // UNIXTODO: Implement this!
         ASSERT("Needs Implementation!!!");
         return nullptr;
     }
-    
+
     CHAR * lpstr;
     INT name_length;
     PathCharString pathstr;
@@ -299,7 +299,7 @@ GetProcAddress(
         SetLastError(ERROR_INVALID_HANDLE);
         goto done;
     }
-    
+
     /* try to assert on attempt to locate symbol by ordinal */
     /* this can't be an exact test for HIWORD((DWORD)lpProcName) == 0
        because of the address range reserved for ordinals contain can
@@ -311,7 +311,7 @@ GetProcAddress(
     }
 
     // Get the symbol's address.
-    
+
     // If we're looking for a symbol inside the PAL, we try the PAL_ variant
     // first because otherwise we run the risk of having the non-PAL_
     // variant preferred over the PAL's implementation.
@@ -420,7 +420,7 @@ FreeLibraryAndExitThread(
     IN DWORD dwExitCode)
 {
     PERF_ENTRY(FreeLibraryAndExitThread);
-    ENTRY("FreeLibraryAndExitThread()\n"); 
+    ENTRY("FreeLibraryAndExitThread()\n");
     FreeLibrary(hLibModule);
     ExitThread(dwExitCode);
     LOGEXIT("FreeLibraryAndExitThread\n");
@@ -547,7 +547,7 @@ GetModuleFileNameW(
         SetLastError(ERROR_INSUFFICIENT_BUFFER);
         goto done;
     }
-    
+
     wcscpy_s(lpFileName, nSize, wide_name);
 
     TRACE("file name of module %p is %S\n", hModule, lpFileName);
@@ -586,7 +586,7 @@ PAL_LoadLibraryDirect(
     {
         goto done;
     }
-    
+
     lpstr = pathstr.OpenStringBuffer((PAL_wcslen(lpLibFileName)+1) * MaxWCharToAcpLength);
     if (nullptr == lpstr)
     {
@@ -773,7 +773,7 @@ Return value:
     TRUE - success
     FALSE - failure (incorrect ptr, etc.)
 --*/
-BOOL 
+BOOL
 PALAPI
 PAL_LOADUnloadPEFile(void * ptr)
 {
@@ -797,7 +797,7 @@ PAL_LOADUnloadPEFile(void * ptr)
 /*++
     PAL_GetSymbolModuleBase
 
-    Get base address of the module containing a given symbol 
+    Get base address of the module containing a given symbol
 
 Parameters:
     void *symbol - address of symbol
@@ -819,18 +819,18 @@ PAL_GetSymbolModuleBase(void *symbol)
         TRACE("Can't get base address. Argument symbol == nullptr\n");
         SetLastError(ERROR_INVALID_DATA);
     }
-    else 
+    else
     {
         Dl_info info;
         if (dladdr(symbol, &info) != 0)
         {
             retval = info.dli_fbase;
         }
-        else 
+        else
         {
             TRACE("Can't get base address of the current module\n");
             SetLastError(ERROR_INVALID_DATA);
-        }        
+        }
     }
 
     LOGEXIT("PAL_GetPalModuleBase returns %p\n", retval);
@@ -909,7 +909,7 @@ BOOL LOADSetExeName(LPWSTR name)
     InternalFree(exe_module.lib_name);
     exe_module.lib_name = name;
 
-    // For platforms where we can't trust the handle to be constant, we need to 
+    // For platforms where we can't trust the handle to be constant, we need to
     // store the inode/device pairs for the modules we just initialized.
 #if RETURNS_NEW_HANDLES_ON_REPEAT_DLOPEN
     {
@@ -927,7 +927,7 @@ BOOL LOADSetExeName(LPWSTR name)
         }
         TRACE("Executable has inode %d and device %d\n", stat_buf.st_ino, stat_buf.st_dev);
 
-        exe_module.inode = stat_buf.st_ino; 
+        exe_module.inode = stat_buf.st_ino;
         exe_module.device = stat_buf.st_dev;
     }
 #endif
@@ -951,13 +951,13 @@ Function :
     Call DllMain for all modules (that have one) with the given "fwReason"
 
 Parameters :
-    DWORD dwReason : parameter to pass down to DllMain, one of DLL_PROCESS_ATTACH, DLL_PROCESS_DETACH, 
+    DWORD dwReason : parameter to pass down to DllMain, one of DLL_PROCESS_ATTACH, DLL_PROCESS_DETACH,
         DLL_THREAD_ATTACH, DLL_THREAD_DETACH
 
     LPVOID lpReserved : parameter to pass down to DllMain
         If dwReason is DLL_PROCESS_ATTACH, lpvReserved is NULL for dynamic loads and non-NULL for static loads.
-        If dwReason is DLL_PROCESS_DETACH, lpvReserved is NULL if DllMain has been called by using FreeLibrary 
-            and non-NULL if DllMain has been called during process termination. 
+        If dwReason is DLL_PROCESS_DETACH, lpvReserved is NULL if DllMain has been called by using FreeLibrary
+            and non-NULL if DllMain has been called during process termination.
 
 (no return value)
 
@@ -970,7 +970,7 @@ void LOADCallDllMain(DWORD dwReason, LPVOID lpReserved)
     MODSTRUCT *module = nullptr;
     BOOL InLoadOrder = TRUE; /* true if in load order, false for reverse */
     CPalThread *pThread;
-    
+
     pThread = InternalGetCurrentThread();
     if (UserCreatedThread != pThread->GetThreadType())
     {
@@ -980,7 +980,7 @@ void LOADCallDllMain(DWORD dwReason, LPVOID lpReserved)
     /* Validate dwReason */
     switch(dwReason)
     {
-    case DLL_PROCESS_ATTACH: 
+    case DLL_PROCESS_ATTACH:
         ASSERT("got called with DLL_PROCESS_ATTACH parameter! Why?\n");
         break;
     case DLL_PROCESS_DETACH:
@@ -1076,7 +1076,7 @@ static BOOL LOADFreeLibrary(MODSTRUCT *module, BOOL fCallDllMain)
     /* Releasing the last reference : call dlclose(), remove module from the
        process-wide module list */
 
-    TRACE("Reference count for module %p (named %S) now 0; destroying module structure\n", 
+    TRACE("Reference count for module %p (named %S) now 0; destroying module structure\n",
         module, MODNAME(module));
 
     /* unlink the module structure from the list */
@@ -1128,13 +1128,13 @@ Function :
 Parameters :
     MODSTRUCT *module : module whose DllMain must be called
 
-    DWORD dwReason : parameter to pass down to DllMain, one of DLL_PROCESS_ATTACH, DLL_PROCESS_DETACH, 
+    DWORD dwReason : parameter to pass down to DllMain, one of DLL_PROCESS_ATTACH, DLL_PROCESS_DETACH,
         DLL_THREAD_ATTACH, DLL_THREAD_DETACH
 
     LPVOID lpvReserved : parameter to pass down to DllMain,
-        If dwReason is DLL_PROCESS_ATTACH, lpvReserved is NULL for dynamic loads and non-NULL for static loads. 
-        If dwReason is DLL_PROCESS_DETACH, lpvReserved is NULL if DllMain has been called by using FreeLibrary 
-            and non-NULL if DllMain has been called during process termination. 
+        If dwReason is DLL_PROCESS_ATTACH, lpvReserved is NULL for dynamic loads and non-NULL for static loads.
+        If dwReason is DLL_PROCESS_DETACH, lpvReserved is NULL if DllMain has been called by using FreeLibrary
+            and non-NULL if DllMain has been called during process termination.
 
 Returns:
     BOOL : DllMain's return value
@@ -1145,7 +1145,7 @@ static BOOL LOADCallDllMainSafe(MODSTRUCT *module, DWORD dwReason, LPVOID lpRese
     /* reset ENTRY nesting level back to zero while inside the callback... */
     int old_level = DBG_change_entrylevel(0);
 #endif /* _ENABLE_DEBUG_MESSAGES_ */
-    
+
     struct Param
     {
         MODSTRUCT *module;
@@ -1161,9 +1161,9 @@ static BOOL LOADCallDllMainSafe(MODSTRUCT *module, DWORD dwReason, LPVOID lpRese
     PAL_TRY(Param *, pParam, &param)
     {
         TRACE("Calling DllMain (%p) for module %S\n",
-              pParam->module->pDllMain, 
+              pParam->module->pDllMain,
               pParam->module->lib_name ? pParam->module->lib_name : W16_NULLSTRING);
-        
+
         {
             // This module may be foreign to our PAL, so leave our PAL.
             // If it depends on us, it will re-enter.
@@ -1263,7 +1263,7 @@ static bool LOADConvertLibraryPathWideStringToMultibyteString(
     size_t length = (PAL_wcslen(wideLibraryPath)+1) * MaxWCharToAcpLength;
     *multibyteLibraryPathLengthRef = WideCharToMultiByte(CP_ACP, 0, wideLibraryPath, -1, multibyteLibraryPath,
                                                         length, nullptr, nullptr);
-    
+
     if (*multibyteLibraryPathLengthRef == 0)
     {
         DWORD dwLastError = GetLastError();
@@ -1303,7 +1303,7 @@ static BOOL LOADValidateModule(MODSTRUCT *module)
 
     /* enumerate through the list of modules to make sure the given handle is
        really a module (HMODULEs are actually MODSTRUCT pointers) */
-    do 
+    do
     {
         if (module == modlist_enum)
         {
@@ -1398,19 +1398,19 @@ Function :
 
 Parameters :
     void *dl_handle :   handle returned by dl_open, goes in MODSTRUCT::dl_handle
-    
-    char *name :        name of new module. after conversion to widechar, 
+
+    char *name :        name of new module. after conversion to widechar,
                         goes in MODSTRUCT::lib_name
-                        
+
 Return value:
     a pointer to a new, initialized MODSTRUCT strucutre, or NULL on failure.
-    
+
 Notes :
     'name' is used to initialize MODSTRUCT::lib_name. The other member is set to NULL
     In case of failure (in malloc or MBToWC), this function sets LastError.
 --*/
 static MODSTRUCT *LOADAllocModule(void *dl_handle, LPCSTR name)
-{   
+{
     MODSTRUCT *module;
     LPWSTR wide_name;
 
@@ -1480,8 +1480,8 @@ static MODSTRUCT *LOADAddModule(void *dl_handle, LPCSTR libraryNameOrPath)
     do
     {
         if (dl_handle == module->dl_handle)
-        {   
-            /* found the handle. increment the refcount and return the 
+        {
+            /* found the handle. increment the refcount and return the
                existing module structure */
             TRACE("Found matching module %p for module name %s\n", module, libraryNameOrPath);
 
@@ -1518,7 +1518,7 @@ static MODSTRUCT *LOADAddModule(void *dl_handle, LPCSTR libraryNameOrPath)
     exe_module.prev = module;
 
 #if RETURNS_NEW_HANDLES_ON_REPEAT_DLOPEN
-    module->inode = stat_buf.st_ino; 
+    module->inode = stat_buf.st_ino;
     module->device = stat_buf.st_dev;
 #endif
 
@@ -1564,7 +1564,7 @@ static HMODULE LOADRegisterLibraryDirect(void *dl_handle, LPCSTR libraryNameOrPa
             else
             {
                 // If the target module doesn't have the PAL_RegisterModule export, then use this PAL's
-                // module handle assuming that the target module is referencing this PAL's exported 
+                // module handle assuming that the target module is referencing this PAL's exported
                 // functions on said handle.
                 module->hinstance = (HINSTANCE)module;
             }
@@ -1685,8 +1685,8 @@ MODSTRUCT *LOADGetPalLibrary()
 {
     if (pal_module == nullptr)
     {
-        // Initialize the pal module (the module containing LOADGetPalLibrary). Assumes that 
-        // the PAL is linked into the coreclr module because we use the module name containing 
+        // Initialize the pal module (the module containing LOADGetPalLibrary). Assumes that
+        // the PAL is linked into the coreclr module because we use the module name containing
         // this function for the coreclr path.
         TRACE("Loading module for PAL library\n");
 
@@ -1708,7 +1708,7 @@ MODSTRUCT *LOADGetPalLibrary()
                 goto exit;
             }
         }
-        
+
         if (strcpy_s(g_szCoreCLRPath, g_cbszCoreCLRPath, info.dli_fname) != SAFECRT_SUCCESS)
         {
             ERROR("LOADGetPalLibrary: strcpy_s failed!");
@@ -1737,7 +1737,7 @@ Return
 extern "C"
 void LockModuleList()
 {
-    CPalThread * pThread = 
+    CPalThread * pThread =
         (PALIsThreadDataInitialized() ? InternalGetCurrentThread() : nullptr);
 
     InternalEnterCriticalSection(pThread, &module_critsec);
@@ -1759,7 +1759,7 @@ Return
 extern "C"
 void UnlockModuleList()
 {
-    CPalThread * pThread = 
+    CPalThread * pThread =
         (PALIsThreadDataInitialized() ? InternalGetCurrentThread() : nullptr);
 
     InternalLeaveCriticalSection(pThread, &module_critsec);

--- a/pal/src/loader/modulename.cpp
+++ b/pal/src/loader/modulename.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -69,7 +69,7 @@ int GetLibRotorNameViaLoadQuery(LPSTR pszBuf)
     }
 
     pThread = InternalGetCurrentThread();
-    // Loop trying to call loadquery with enough memory until either 
+    // Loop trying to call loadquery with enough memory until either
     // 1) we succeed, 2) we run out of memory or 3) loadquery throws
     // an error other than ENOMEM
     while (iLQRetVal != 0)
@@ -99,13 +99,13 @@ int GetLibRotorNameViaLoadQuery(LPSTR pszBuf)
         }
     }
 
-    // We successfully called loadquery, so now see if we can find 
+    // We successfully called loadquery, so now see if we can find
     // librotor_pal.a in the module list
     if (pLoadQueryBuf)
     {
-        pInfo = (struct ld_info *)pLoadQueryBuf;        
+        pInfo = (struct ld_info *)pLoadQueryBuf;
         while (TRUE)
-        {  
+        {
             if (strstr(pInfo->ldinfo_filename, "librotor_pal.a"))
             {
                 UINT cchFileName = strlen(pInfo->ldinfo_filename);
@@ -126,7 +126,7 @@ int GetLibRotorNameViaLoadQuery(LPSTR pszBuf)
             }
             else
             {
-                // The (wacky) design of ld_info is that the value of next is an offset in 
+                // The (wacky) design of ld_info is that the value of next is an offset in
                 // bytes rather than a pointer.  So we need this weird cast to char * to get
                 // the pointer math correct.
                 if (pInfo->ldinfo_next == 0)
@@ -157,7 +157,7 @@ Return value:
 
     NULL if error occurred.
 
-Notes: 
+Notes:
     The string returned by this function is owned by the OS.
     If you need to keep it, strdup() it, because it is unknown how long
     this ptr will point at the string you want (over the lifetime of
@@ -198,11 +198,10 @@ const char *PAL_dladdr(LPVOID ProcAddress)
         /* If we get an error, return NULL */
         return (NULL);
     }
-    else 
+    else
     {
-        /* Return the module name */ 
+        /* Return the module name */
         return dl_info.dli_fname;
     }
 #endif
 }
-

--- a/pal/src/locale/UnicodeData.txt
+++ b/pal/src/locale/UnicodeData.txt
@@ -12856,5 +12856,3 @@ F0000;<Plane 15 Private Use, First>;Co;0;L;;;;;N;;;;;
 FFFFD;<Plane 15 Private Use, Last>;Co;0;L;;;;;N;;;;;
 100000;<Plane 16 Private Use, First>;Co;0;L;;;;;N;;;;;
 10FFFD;<Plane 16 Private Use, Last>;Co;0;L;;;;;N;;;;;
-
-

--- a/pal/src/locale/unicode.cpp
+++ b/pal/src/locale/unicode.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -148,7 +148,7 @@ BOOL GetUnicodeData(INT nUnicodeValue, UnicodeDataRec *pDataRec)
     {
         UnicodeDataRec *dataRec;
         INT nNumOfChars = UNICODE_DATA_SIZE;
-        dataRec = (UnicodeDataRec *) bsearch(&nUnicodeValue, UnicodeData, nNumOfChars, 
+        dataRec = (UnicodeDataRec *) bsearch(&nUnicodeValue, UnicodeData, nNumOfChars,
                        sizeof(UnicodeDataRec), UnicodeDataComp);
         if (dataRec == NULL)
         {
@@ -164,16 +164,16 @@ BOOL GetUnicodeData(INT nUnicodeValue, UnicodeDataRec *pDataRec)
 }
 #endif /* !HAVE_COREFOUNDATION */
 
-/*++ 
+/*++
 Function:
 CODEPAGEGetData
-    
+
     IN UINT CodePage - The code page the caller
     is attempting to retrieve data on.
-    
+
     Returns a pointer to structure, NULL otherwise.
 --*/
-const CP_MAPPING * 
+const CP_MAPPING *
 CODEPAGEGetData( IN UINT CodePage )
 {
     UINT nSize = sizeof( CP_TO_NATIVE_TABLE ) / sizeof( CP_TO_NATIVE_TABLE[ 0 ] );
@@ -193,7 +193,7 @@ CODEPAGEGetData( IN UINT CodePage )
         }
         nIndex++;
     }
-    return NULL;    
+    return NULL;
 }
 
 #if HAVE_COREFOUNDATION
@@ -331,7 +331,7 @@ GetConsoleCP(
     UINT nRet = 0;
     PERF_ENTRY(GetConsoleCP);
     ENTRY("GetConsoleCP()\n");
-     
+
     nRet = GetACP();
 
     LOGEXIT("GetConsoleCP returns UINT %d\n", nRet );
@@ -403,7 +403,7 @@ IsValidCodePage(
         retval = (NULL != CODEPAGEGetData( CodePage ));
         break;
     }
-       
+
     LOGEXIT("IsValidCodePage returns BOOL %d\n",retval);
     PERF_EXIT(IsValidCodePage);
     return retval;
@@ -533,7 +533,7 @@ GetCPInfo(
 {
     const CP_MAPPING * lpStruct = NULL;
     BOOL bRet = FALSE;
-     
+
     PERF_ENTRY(GetCPInfo);
     ENTRY("GetCPInfo(CodePage=%hu, lpCPInfo=%p)\n", CodePage, lpCPInfo);
 
@@ -626,9 +626,9 @@ IsDBCSLeadByteEx(
         {
             goto done;
         }
-         
+
         /*check if the given char is in one of the lead byte ranges*/
-        if( cpinfo.LeadByte[i] <= TestChar && TestChar<= cpinfo.LeadByte[i+1] ) 
+        if( cpinfo.LeadByte[i] <= TestChar && TestChar<= cpinfo.LeadByte[i+1] )
         {
             bRet = TRUE;
             goto done;
@@ -822,14 +822,14 @@ WideCharToMultiByte(
           lpDefaultChar, lpUsedDefaultChar);
 
     if (dwFlags & ~WC_NO_BEST_FIT_CHARS)
-    {  
+    {
         ERROR("dwFlags %d invalid\n", dwFlags);
         SetLastError(ERROR_INVALID_FLAGS);
         goto EXIT;
     }
 
     // No special action is needed for WC_NO_BEST_FIT_CHARS. The default
-    // behavior of this API on Unix is not to find the best fit for a unicode 
+    // behavior of this API on Unix is not to find the best fit for a unicode
     // character that does not map directly into a code point in the given
     // code page. The best fit functionality is not available in wctomb on Unix
     // and is better left unimplemented for security reasons anyway.
@@ -856,7 +856,7 @@ WideCharToMultiByte(
     {
         if (cchWideChar == -1)
         {
-            cchWideChar = PAL_wcslen(lpWideCharStr) + 1; 
+            cchWideChar = PAL_wcslen(lpWideCharStr) + 1;
         }
         retval = UnicodeToUTF8(lpWideCharStr, cchWideChar, lpMultiByteStr, cbMultiByte);
         goto EXIT;
@@ -941,12 +941,12 @@ EXIT:
     /* Flag the cases when WC_NO_BEST_FIT_CHARS was not specified
      * but we found characters that had to be replaced with default
      * characters. Note that Windows would have attempted to find
-     * best fit characters under these conditions and that could pose 
-     * a security risk. 
+     * best fit characters under these conditions and that could pose
+     * a security risk.
      */
     _ASSERT_MSG((dwFlags & WC_NO_BEST_FIT_CHARS) || !usedDefaultChar,
           "WideCharToMultiByte found a string which doesn't round trip: (%p)%S "
-          "and WC_NO_BEST_FIT_CHARS was not specified\n", 
+          "and WC_NO_BEST_FIT_CHARS was not specified\n",
           lpWideCharStr, lpWideCharStr);
 
     LOGEXIT("WideCharToMultiByte returns INT %d\n", retval);
@@ -977,7 +977,7 @@ PAL_GetResourceString(
     // resource. In our case, that will be the English string.
     LPCSTR resourceString = dgettext(lpDomain, lpResourceStr);
 #else // __APPLE__
-    // UNIXTODO: Implement for OSX using the native localization API 
+    // UNIXTODO: Implement for OSX using the native localization API
 
     // This is a temporary solution until we add the real native resource support.
     LPCSTR resourceString = lpResourceStr;

--- a/pal/src/locale/unicode_data.cpp
+++ b/pal/src/locale/unicode_data.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++

--- a/pal/src/locale/utf8.cpp
+++ b/pal/src/locale/utf8.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -129,7 +129,7 @@ int UTF8ToUnicode(
                                 // Error: Buffer too small, we didn't process this character
                                 SetLastError(ERROR_INSUFFICIENT_BUFFER);
                                 return (0);
-                            }                                
+                            }
 
                             lpDestStr[cchWC]   = (WCHAR)
                                                  (((dwUnicodeChar - 0x10000) >> 10) + HIGH_SURROGATE_START);
@@ -148,7 +148,7 @@ int UTF8ToUnicode(
                     {
                         if (cchDest)
                         {
-                            
+
                             if (cchWC >= cchDest)
                             {
                                 // Error: Buffer too small, we didn't process this character
@@ -164,18 +164,18 @@ int UTF8ToUnicode(
                         //
                         cchWC++;
                     }
-                      
+
                 }
 
             }
             else
             {
-                if (bCheckInvalidBytes) 
+                if (bCheckInvalidBytes)
                 {
                     SetLastError(ERROR_NO_UNICODE_TRANSLATION);
                     return (0);
                 }
-                
+
                 // error - not expecting a trail byte. That is, there is a trailing byte without leading byte.
                 bSurrogatePair = FALSE;
             }
@@ -188,7 +188,7 @@ int UTF8ToUnicode(
             if (nTB > 0)
             {
                 // error - A leading byte before the previous sequence is completed.
-                if (bCheckInvalidBytes) 
+                if (bCheckInvalidBytes)
                 {
                     SetLastError(ERROR_NO_UNICODE_TRANSLATION);
                     return (0);
@@ -220,7 +220,7 @@ int UTF8ToUnicode(
 
                 //
                 // Check for non-shortest form.
-                // 
+                //
                 switch (nTB)
                 {
                     case 1:
@@ -245,7 +245,7 @@ int UTF8ToUnicode(
                             }
                         }
                         break;
-                    case 4:                    
+                    case 4:
                         //
                         // This is a surrogate unicode pair
                         //
@@ -253,7 +253,7 @@ int UTF8ToUnicode(
                         {
                             WORD word = (((WORD)*pUTF8) << 8) | *(pUTF8 + 1);
                             // Look ahead to check for non-shortest form.
-                            // 11110XXX 10XXxxxx 10xxxxxx 10xxxxxx                        
+                            // 11110XXX 10XXxxxx 10xxxxxx 10xxxxxx
                             // Check if the 5 X bits are all zero.
                             // 0x0730 == 00000111 00110000
                             if ( (word & 0x0730) == 0 ||
@@ -266,22 +266,22 @@ int UTF8ToUnicode(
                                      // Therefore, if the 21 bit (the most significant bit) is 1, we should verify that the 17 ~ 20
                                      // bit are all zero.
                                      // I.e., in 11110XXX 10XXxxxx 10xxxxxx 10xxxxxx,
-                                     // XXXXX can only be 10000.    
+                                     // XXXXX can only be 10000.
                                      // 0x0330 = 0000 0011 0011 0000
                                     (word & 0x0330) != 0 ) )
                             {
                                 // Not shortest form
                                 nTB = 0;
-                            }                              
+                            }
                             else
-                            { 
+                            {
                                 // A real surrogate pair
                                 bSurrogatePair = TRUE;
                             }
-                        }                        
+                        }
                         break;
-                    default:                    
-                        // 
+                    default:
+                        //
                         // If the bits is greater than 4, this is an invalid
                         // UTF8 lead byte.
                         //
@@ -289,7 +289,7 @@ int UTF8ToUnicode(
                         break;
                 }
 
-                if (nTB != 0) 
+                if (nTB != 0)
                 {
                     //
                     //  Store the value from the first byte and decrement
@@ -297,9 +297,9 @@ int UTF8ToUnicode(
                     //
                     dwUnicodeChar = UTF8;
                     nTB--;
-                } else 
+                } else
                 {
-                    if (bCheckInvalidBytes) 
+                    if (bCheckInvalidBytes)
                     {
                         SetLastError(ERROR_NO_UNICODE_TRANSLATION);
                         return (0);
@@ -310,7 +310,7 @@ int UTF8ToUnicode(
         pUTF8++;
     }
 
-    if ((bCheckInvalidBytes && nTB != 0) || (cchWC == 0)) 
+    if ((bCheckInvalidBytes && nTB != 0) || (cchWC == 0))
     {
         // About (cchWC == 0):
         // Because we now throw away non-shortest form, it is possible that we generate 0 chars.
@@ -457,11 +457,11 @@ int UnicodeToUTF8(
                 //
                 if (cchDest)
                 {
-                    if (cchU8 < cchDest) 
+                    if (cchU8 < cchDest)
                     {
                         lpDestStr[cchU8] = (char)*lpWC;
-                    } 
-                    else 
+                    }
+                    else
                     {
                         //
                         //  Error - buffer too small.

--- a/pal/src/map/common.cpp
+++ b/pal/src/map/common.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -57,7 +57,7 @@ INT W32toUnixAccessControl( IN DWORD flProtect )
     case PAGE_NOACCESS :
         MemAccessControl = PROT_NONE;
         break;
-    
+
     default:
         MemAccessControl = 0;
         ERROR( "Incorrect or no protection flags specified.\n" );

--- a/pal/src/map/common.h
+++ b/pal/src/map/common.h
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -38,7 +38,3 @@ INT W32toUnixAccessControl( IN DWORD flProtect );
 #endif
 
 #endif /* __COMMON_H_ */
-
-
-
-

--- a/pal/src/map/map.cpp
+++ b/pal/src/map/map.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -67,7 +67,7 @@ static DWORD MAPConvertProtectToAccess( DWORD );
 static INT MAPFileMapToMmapFlags( DWORD );
 static DWORD MAPMmapProtToAccessFlags( int prot );
 #if ONE_SHARED_MAPPING_PER_FILEREGION_PER_PROCESS
-static NativeMapHolder * NewNativeMapHolder(CPalThread *pThread, LPVOID address, SIZE_T size, 
+static NativeMapHolder * NewNativeMapHolder(CPalThread *pThread, LPVOID address, SIZE_T size,
                                      SIZE_T offset, long init_ref_count);
 static LONG NativeMapHolderAddRef(NativeMapHolder * thisPMH);
 static LONG NativeMapHolderRelease(CPalThread *pThread, NativeMapHolder * thisPMH);
@@ -161,7 +161,7 @@ FileMappingCleanupRoutine(
         // If we created a temporary file to back this mapping we need
         // to unlink it now
         //
-        
+
         palError = pObjectToCleanup->GetImmutableData(
             reinterpret_cast<void**>(&pImmutableData)
             );
@@ -184,7 +184,7 @@ FileMappingCleanupRoutine(
         // We only need to close the object's descriptor if we're not
         // shutting down
         //
-        
+
         palError = pObjectToCleanup->GetProcessLocalData(
             pThread,
             WriteLock,
@@ -228,7 +228,7 @@ FileMappingInitializationRoutine(
     )
 {
     PAL_ERROR palError = NO_ERROR;
-    
+
     CFileMappingImmutableData *pImmutableData =
         reinterpret_cast<CFileMappingImmutableData *>(pvImmutableData);
     CFileMappingProcessLocalData *pProcessLocalData =
@@ -259,7 +259,7 @@ FileMappingInitializationRoutine(
     }
 #endif
 
-ExitFileMappingInitializationRoutine:    
+ExitFileMappingInitializationRoutine:
 
     return palError;
 }
@@ -290,7 +290,7 @@ CreateFileMappingA(
     PERF_ENTRY(CreateFileMappingA);
     ENTRY("CreateFileMappingA(hFile=%p, lpAttributes=%p, flProtect=%#x, "
           "dwMaxSizeH=%d, dwMaxSizeL=%d, lpName=%p (%s))\n",
-          hFile, lpFileMappingAttributes, flProtect, 
+          hFile, lpFileMappingAttributes, flProtect,
           dwMaximumSizeHigh, dwMaximumSizeLow,
           lpName?lpName:"NULL",
           lpName?lpName:"NULL");
@@ -353,11 +353,11 @@ CreateFileMappingW(
     HANDLE hFileMapping = NULL;
     CPalThread *pThread = NULL;
     PAL_ERROR palError = NO_ERROR;
-    
+
     PERF_ENTRY(CreateFileMappingW);
     ENTRY("CreateFileMappingW(hFile=%p, lpAttributes=%p, flProtect=%#x, "
           "dwMaxSizeH=%u, dwMaxSizeL=%u, lpName=%p (%S))\n",
-          hFile, lpFileMappingAttributes, flProtect, dwMaximumSizeHigh, 
+          hFile, lpFileMappingAttributes, flProtect, dwMaximumSizeHigh,
           dwMaximumSizeLow, lpName?lpName:W16_NULLSTRING, lpName?lpName:W16_NULLSTRING);
 
     pThread = InternalGetCurrentThread();
@@ -409,7 +409,7 @@ CorUnix::InternalCreateFileMapping(
     IPalObject *pFileObject = NULL;
     CFileProcessLocalData *pFileLocalData = NULL;
     IDataLock *pFileLocalDataLock = NULL;
-    
+
     struct stat UnixFileInformation;
     INT UnixFd = -1;
     BOOL bPALCreatedTempFile = FALSE;
@@ -432,13 +432,13 @@ CorUnix::InternalCreateFileMapping(
         palError = ERROR_INVALID_PARAMETER;
         goto ExitInternalCreateFileMapping;
     }
-    
+
     if (PAGE_READWRITE != flProtect
         && PAGE_READONLY != flProtect
         && PAGE_WRITECOPY != flProtect)
     {
         ASSERT( "invalid flProtect %#x, acceptable values are PAGE_READONLY "
-                "(%#x), PAGE_READWRITE (%#x) and PAGE_WRITECOPY (%#x).\n", 
+                "(%#x), PAGE_READWRITE (%#x) and PAGE_WRITECOPY (%#x).\n",
                 flProtect, PAGE_READONLY, PAGE_READWRITE, PAGE_WRITECOPY );
         palError = ERROR_INVALID_PARAMETER;
         goto ExitInternalCreateFileMapping;
@@ -485,7 +485,7 @@ CorUnix::InternalCreateFileMapping(
         // avoid this restriction by always using a temp backing file for
         // anonymous mappings.
         //
-        
+
         /* Anonymous mapped files. */
         if (strcpy_s(pImmutableData->szFileName, sizeof(pImmutableData->szFileName), "/dev/zero") != SAFECRT_SUCCESS)
         {
@@ -532,7 +532,7 @@ CorUnix::InternalCreateFileMapping(
 
             palError = pFileObject->GetProcessLocalData(
                 pThread,
-                ReadLock, 
+                ReadLock,
                 &pFileLocalDataLock,
                 reinterpret_cast<void**>(&pFileLocalData)
                 );
@@ -541,8 +541,8 @@ CorUnix::InternalCreateFileMapping(
             {
                 goto ExitInternalCreateFileMapping;
             }
-        
-            /* We need to check to ensure flProtect jives with 
+
+            /* We need to check to ensure flProtect jives with
                the permission on the file handle */
             if (!MAPIsRequestPermissible(flProtect, pFileLocalData))
             {
@@ -572,7 +572,7 @@ CorUnix::InternalCreateFileMapping(
             // want to consider adding a reference to the PAL's file lock
             // information, though...
             //
-            
+
             UnixFd = dup(pFileLocalData->unix_fd);
             if (-1 == UnixFd)
             {
@@ -584,7 +584,7 @@ CorUnix::InternalCreateFileMapping(
                 }
                 goto ExitInternalCreateFileMapping;
             }
-  
+
             if (strcpy_s(pImmutableData->szFileName, sizeof(pImmutableData->szFileName), pFileLocalData->unix_filename) != SAFECRT_SUCCESS)
             {
                 ERROR( "strcpy_s failed!\n" );
@@ -600,14 +600,14 @@ CorUnix::InternalCreateFileMapping(
             {
                 pFileLocalDataLock->ReleaseLock(pThread, FALSE);
             }
-        } 
-        else 
+        }
+        else
         {
             ASSERT("should not get here\n");
             palError = ERROR_INTERNAL_ERROR;
             goto ExitInternalCreateFileMapping;
         }
-    
+
         if (-1 == fstat(UnixFd, &UnixFileInformation))
         {
             ASSERT("fstat() failed for this reason %s.\n", strerror(errno));
@@ -615,7 +615,7 @@ CorUnix::InternalCreateFileMapping(
             goto ExitInternalCreateFileMapping;
         }
 
-        if ( 0 == UnixFileInformation.st_size && 
+        if ( 0 == UnixFileInformation.st_size &&
              0 == dwMaximumSizeHigh && 0 == dwMaximumSizeLow )
         {
             ERROR( "The file cannot be a zero length file.\n" );
@@ -623,8 +623,8 @@ CorUnix::InternalCreateFileMapping(
             goto ExitInternalCreateFileMapping;
         }
 
-        if ( INVALID_HANDLE_VALUE != hFile && 
-             dwMaximumSizeLow > (DWORD) UnixFileInformation.st_size && 
+        if ( INVALID_HANDLE_VALUE != hFile &&
+             dwMaximumSizeLow > (DWORD) UnixFileInformation.st_size &&
              ( PAGE_READONLY == flProtect || PAGE_WRITECOPY == flProtect ) )
         {
             /* In this situation, Windows returns an error, because the
@@ -633,7 +633,7 @@ CorUnix::InternalCreateFileMapping(
             palError = ERROR_NOT_ENOUGH_MEMORY;
             goto ExitInternalCreateFileMapping;
         }
-      
+
         if ( (DWORD) UnixFileInformation.st_size < dwMaximumSizeLow )
         {
             TRACE( "Growing the size of file on disk to match requested size.\n" );
@@ -648,14 +648,14 @@ CorUnix::InternalCreateFileMapping(
         }
     }
 
-    nFileSize = ( 0 == dwMaximumSizeLow && 0 == dwMaximumSizeHigh ) ? 
+    nFileSize = ( 0 == dwMaximumSizeLow && 0 == dwMaximumSizeHigh ) ?
         UnixFileInformation.st_size : dwMaximumSizeLow;
 
     pImmutableData->MaxSize = nFileSize;
     pImmutableData->flProtect = flProtect;
     pImmutableData->bPALCreatedTempFile = bPALCreatedTempFile;
     pImmutableData->dwDesiredAccessWhenOpened = MAPConvertProtectToAccess(flProtect);
-    
+
 
     //
     // The local data isn't grabbed / modified until here so that we don't
@@ -708,7 +708,7 @@ CorUnix::InternalCreateFileMapping(
     palError = g_pObjectManager->RegisterObject(
         pThread,
         pMapping,
-        &aotFileMapping, 
+        &aotFileMapping,
         flProtect,          // TODO: is flProtect really an access right?
         phMapping,
         &pRegisteredMapping
@@ -723,7 +723,7 @@ CorUnix::InternalCreateFileMapping(
     // object by the same name already existing) the cleanup will take place
     // when that routine releases the reference to pMapping.
     //
-    
+
     pMapping = NULL;
 
 ExitInternalCreateFileMapping:
@@ -824,7 +824,7 @@ OpenFileMappingW(
     HANDLE hFileMapping = NULL;
     PAL_ERROR palError = NO_ERROR;
     CPalThread *pThread = NULL;
-    
+
     PERF_ENTRY(OpenFileMappingW);
     ENTRY("OpenFileMappingW(dwDesiredAccess=%#x, bInheritHandle=%d, lpName=%p (%S)\n",
           dwDesiredAccess, bInheritHandle, lpName?lpName:W16_NULLSTRING, lpName?lpName:W16_NULLSTRING);
@@ -865,9 +865,9 @@ CorUnix::InternalOpenFileMapping(
     IPalObject *pFileMapping = NULL;
     CPalString sObjectName(lpName);
 
-    if ( MAPContainsInvalidFlags( dwDesiredAccess ) ) 
+    if ( MAPContainsInvalidFlags( dwDesiredAccess ) )
     {
-        ASSERT( "dwDesiredAccess can be one or more of FILE_MAP_READ, " 
+        ASSERT( "dwDesiredAccess can be one or more of FILE_MAP_READ, "
                "FILE_MAP_WRITE, FILE_MAP_COPY or FILE_MAP_ALL_ACCESS.\n" );
         palError = ERROR_INVALID_PARAMETER;
         goto ExitInternalOpenFileMapping;
@@ -876,7 +876,7 @@ CorUnix::InternalOpenFileMapping(
     palError = g_pObjectManager->LocateObject(
         pThread,
         &sObjectName,
-        &aotFileMapping, 
+        &aotFileMapping,
         &pFileMapping
         );
 
@@ -905,7 +905,7 @@ ExitInternalOpenFileMapping:
     {
         pFileMapping->ReleaseReference(pThread);
     }
-    
+
     return palError;
 }
 
@@ -926,14 +926,14 @@ Function:
                   Since currently the mappings are supported only at file
                   offset 0, MapViewOfFile will succeed if the new view
                   is equal or smaller of the existing one, and the address
-                  returned will be the same address of the existing 
+                  returned will be the same address of the existing
                   mapping.
-                  Since the underlying mapping is always the same, all 
+                  Since the underlying mapping is always the same, all
                   the shared views of the same file region will share the
-                  same protection, i.e. they will have the largest 
+                  same protection, i.e. they will have the largest
                   protection requested. If any mapping asked for a
-                  read-write access, all the read-only mappings of the 
-                  same region will silently get a read-write access to 
+                  read-write access, all the read-only mappings of the
+                  same region will silently get a read-write access to
                   it.
 
 See MSDN doc.
@@ -1021,7 +1021,7 @@ MapViewOfFileEx(
     else
     {
         // TODO: Figure out if we can support mapping at a specific address on Linux.
-        pThread->SetLastError(ERROR_INVALID_PARAMETER);       
+        pThread->SetLastError(ERROR_INVALID_PARAMETER);
     }
 
     LOGEXIT( "MapViewOfFileEx returning %p.\n", pvMappedBaseAddress );
@@ -1116,7 +1116,7 @@ UnmapViewOfFile(
 {
     PAL_ERROR palError;
     CPalThread *pThread;
-    
+
     PERF_ENTRY(UnmapViewOfFile);
     ENTRY("UnmapViewOfFile(lpBaseAddress=%p)\n", lpBaseAddress);
 
@@ -1128,7 +1128,7 @@ UnmapViewOfFile(
     {
         pThread->SetLastError(palError);
     }
-    
+
     LOGEXIT( "UnmapViewOfFile returning %s.\n", (NO_ERROR == palError) ? "TRUE" : "FALSE" );
     PERF_EXIT(UnmapViewOfFile);
     return (NO_ERROR == palError);
@@ -1207,7 +1207,7 @@ CorUnix::InternalMapViewOfFile(
         ERROR( "Unable to obtain object process local data");
         goto InternalMapViewOfFileExit;
     }
-    
+
     /* If dwNumberOfBytesToMap is 0, we need to map the entire file.
      * mmap doesn't do the same thing as Windows in that case, though,
      * so we use the file size instead. */
@@ -1274,7 +1274,7 @@ CorUnix::InternalMapViewOfFile(
 #if ONE_SHARED_MAPPING_PER_FILEREGION_PER_PROCESS
             if ((MAP_FAILED == pvBaseAddress) && (ENOMEM == errno))
             {
-                /* Search in list of MAPPED_MEMORY_INFO for a shared mapping 
+                /* Search in list of MAPPED_MEMORY_INFO for a shared mapping
                    with the same inode number
                 */
                 TRACE("Mmap() failed with errno=ENOMEM probably for multiple mapping "
@@ -1287,7 +1287,7 @@ CorUnix::InternalMapViewOfFile(
                     dwNumberOfBytesToMap,
                     0
                     );
-                
+
                 if (pReusedMapping)
                 {
                     int ret;
@@ -1304,10 +1304,10 @@ CorUnix::InternalMapViewOfFile(
                                    pReusedMapping->pNMHolder->size,
                                    prot | PROT_CHECK);
                     if (0 != ret)
-                    {               
-                        /* We need to raise the protection to the desired 
+                    {
+                        /* We need to raise the protection to the desired
                            one. That will give write access to any read-only
-                           mapping sharing this native mapping, but there is 
+                           mapping sharing this native mapping, but there is
                            no way around this problem on systems that do not
                            allow more than one mapping per file region, per
                            process */
@@ -1318,7 +1318,7 @@ CorUnix::InternalMapViewOfFile(
                                    prot);
                     }
 
-                    if (ret != 0) 
+                    if (ret != 0)
                     {
                         ERROR( "Failed setting protections on reused mapping\n");
 
@@ -1360,19 +1360,19 @@ CorUnix::InternalMapViewOfFile(
         // list. All other initialization took place in
         // FindSharedMappingReplacement
         //
-        
+
         pvBaseAddress = pReusedMapping->lpAddress;
         pReusedMapping->pFileMapping->AddReference();
         InsertTailList(&MappedViewList, &pReusedMapping->Link);
     }
-    else 
+    else
 #endif // ONE_SHARED_MAPPING_PER_FILEREGION_PER_PROCESS
     {
         //
         // Allocate and fill out a new view structure, and add it to
         // the global list.
         //
-        
+
         PMAPPED_VIEW_LIST pNewView = (PMAPPED_VIEW_LIST)InternalMalloc(sizeof(*pNewView));
         if (NULL != pNewView)
         {
@@ -1387,10 +1387,10 @@ CorUnix::InternalMapViewOfFile(
 #if ONE_SHARED_MAPPING_PER_FILEREGION_PER_PROCESS
             pNewView->MappedFileDevNum = pProcessLocalData->MappedFileDevNum;
             pNewView->MappedFileInodeNum = pProcessLocalData->MappedFileInodeNum;
-            
+
             pNewView->pNMHolder = NewNativeMapHolder(
                 pThread,
-                pvBaseAddress, 
+                pvBaseAddress,
                 dwNumberOfBytesToMap,
                 0,
                 1
@@ -1419,7 +1419,7 @@ CorUnix::InternalMapViewOfFile(
             }
         }
     }
-    
+
     TRACE( "Added %p to the list.\n", pvBaseAddress );
     *ppvBaseAddress = pvBaseAddress;
 
@@ -1462,7 +1462,7 @@ CorUnix::InternalUnmapViewOfFile(
         palError = ERROR_INVALID_HANDLE;
         goto InternalUnmapViewOfFileExit;
     }
-    
+
 #if ONE_SHARED_MAPPING_PER_FILEREGION_PER_PROCESS
     NativeMapHolderRelease(pThread, pView->pNMHolder);
     pView->pNMHolder = NULL;
@@ -1483,7 +1483,7 @@ CorUnix::InternalUnmapViewOfFile(
     RemoveEntryList(&pView->Link);
     pMappingObject = pView->pFileMapping;
     InternalFree(pView);
-    
+
 InternalUnmapViewOfFileExit:
 
     InternalLeaveCriticalSection(pThread, &mapping_critsec);
@@ -1552,7 +1552,7 @@ Function :
     Callers to this function must hold mapping_critsec
 --*/
 static PMAPPED_VIEW_LIST MAPGetViewForAddress( LPCVOID lpAddress )
-{       
+{
     if ( NULL == lpAddress )
     {
         ERROR( "lpAddress cannot be NULL\n" );
@@ -1570,9 +1570,9 @@ static PMAPPED_VIEW_LIST MAPGetViewForAddress( LPCVOID lpAddress )
             return pView;
         }
     }
-            
+
     WARN( "No match found.\n" );
-    
+
     return NULL;
 }
 
@@ -1614,20 +1614,20 @@ static PAL_ERROR MAPDesiredAccessAllowed( DWORD flProtect,
                "view.\n" );
         return ERROR_INVALID_PARAMETER;
     }
-    
+
     /* Check to see we don't confict with the desired access we
     opened the mapping object with. */
     if ( ( dwUserDesiredAccess == FILE_MAP_READ ) &&
-        !( ( dwDesiredAccessWhenOpened == FILE_MAP_READ ) || 
-           ( dwDesiredAccessWhenOpened == FILE_MAP_ALL_ACCESS ) ) ) 
+        !( ( dwDesiredAccessWhenOpened == FILE_MAP_READ ) ||
+           ( dwDesiredAccessWhenOpened == FILE_MAP_ALL_ACCESS ) ) )
     {
         ERROR( "dwDesiredAccess conflict : read access requested, object not "
                "opened with read access.\n" );
         return ERROR_ACCESS_DENIED;
     }
     if ( ( dwUserDesiredAccess & FILE_MAP_WRITE ) &&
-        !( ( dwDesiredAccessWhenOpened == FILE_MAP_WRITE ) || 
-           ( dwDesiredAccessWhenOpened == FILE_MAP_ALL_ACCESS ) ) ) 
+        !( ( dwDesiredAccessWhenOpened == FILE_MAP_WRITE ) ||
+           ( dwDesiredAccessWhenOpened == FILE_MAP_ALL_ACCESS ) ) )
     {
         ERROR( "dwDesiredAccess conflict : write access requested, object not "
                "opened with write access.\n" );
@@ -1676,7 +1676,7 @@ Function :
     MAPConvertAccessToProtect
 
     Converts the FILE_MAP_READ type flags to PAGE_READONLY flags.
-    Currently, this function only deals with the access flags recognized as valid 
+    Currently, this function only deals with the access flags recognized as valid
     by MAPContainsInvalidFlags().
 
 --*/
@@ -1734,7 +1734,7 @@ static INT MAPFileMapToMmapFlags( DWORD flags )
     {
         TRACE( "FILE_MAP_COPY\n");
         return PROT_READ | PROT_WRITE;
-    } 
+    }
 
     ASSERT( "Unknown flag. This line should not have been executed.\n" );
     return -1;
@@ -1781,7 +1781,7 @@ Function :
     MAPGrowLocalFile
 
     Grows the file on disk to match the specified size.
-    
+
 --*/
 static PAL_ERROR MAPGrowLocalFile( INT UnixFD, UINT NewSize )
 {
@@ -1876,7 +1876,7 @@ Function :
     MAPContainsInvalidFlags
 
     Checks that only valid flags are in the parameter.
-    
+
 --*/
 static BOOL MAPContainsInvalidFlags( DWORD flags )
 {
@@ -1895,11 +1895,11 @@ static BOOL MAPContainsInvalidFlags( DWORD flags )
 }
 
 /*++
-Function : 
+Function :
     MAPProtectionToFileOpenFlags
-    
+
     Converts the PAGE_* flags to the O_* flags.
- 
+
     Returns the file open flags.
 --*/
 static INT MAPProtectionToFileOpenFlags( DWORD flProtect )
@@ -1920,23 +1920,23 @@ static INT MAPProtectionToFileOpenFlags( DWORD flProtect )
         ASSERT("unexpected flProtect value %#x\n", flProtect);
         retVal = 0;
         break;
-    }         
+    }
     return retVal;
 }
 
 /*++
 Function :
-    
+
     MAPIsRequestPermissible
-    
+
         DWORD flProtect     - The requested file mapping protection .
         file * pFileStruct  - The file structure containing all the information.
 
 --*/
 static BOOL MAPIsRequestPermissible( DWORD flProtect, CFileProcessLocalData * pFileLocalData )
 {
-    if ( ( (flProtect == PAGE_READONLY || flProtect == PAGE_WRITECOPY) && 
-           (pFileLocalData->open_flags_deviceaccessonly == TRUE || 
+    if ( ( (flProtect == PAGE_READONLY || flProtect == PAGE_WRITECOPY) &&
+           (pFileLocalData->open_flags_deviceaccessonly == TRUE ||
             pFileLocalData->open_flags & O_WRONLY) )
        )
     {
@@ -1950,7 +1950,7 @@ static BOOL MAPIsRequestPermissible( DWORD flProtect, CFileProcessLocalData * pF
     else if ( flProtect == PAGE_READWRITE && !(pFileLocalData->open_flags & O_RDWR) )
     {
         /*
-         * PAGE_READWRITE access to a file needs to be readable and writable 
+         * PAGE_READWRITE access to a file needs to be readable and writable
          */
         return FALSE;
     }
@@ -1967,7 +1967,7 @@ BOOL MAPGetRegionInfo(LPVOID lpAddress,
 {
     BOOL fFound = FALSE;
     CPalThread * pThread = InternalGetCurrentThread();
-    
+
     InternalEnterCriticalSection(pThread, &mapping_critsec);
 
     for(LIST_ENTRY *pLink = MappedViewList.Flink;
@@ -1987,13 +1987,13 @@ BOOL MAPGetRegionInfo(LPVOID lpAddress,
         real_map_sz = pView->NumberOfBytesToMap;
 #endif
 
-        MappedSize = ((real_map_sz-1) & ~VIRTUAL_PAGE_MASK) + VIRTUAL_PAGE_SIZE; 
-        if ( real_map_addr <= lpAddress && 
+        MappedSize = ((real_map_sz-1) & ~VIRTUAL_PAGE_MASK) + VIRTUAL_PAGE_SIZE;
+        if ( real_map_addr <= lpAddress &&
              (VOID *)((UINT_PTR)real_map_addr+MappedSize) > lpAddress )
         {
             if (lpBuffer)
             {
-                SIZE_T regionSize = MappedSize + (UINT_PTR) real_map_addr - 
+                SIZE_T regionSize = MappedSize + (UINT_PTR) real_map_addr -
                        ((UINT_PTR) lpAddress & ~VIRTUAL_PAGE_MASK);
 
                 lpBuffer->BaseAddress = lpAddress;
@@ -2010,7 +2010,7 @@ BOOL MAPGetRegionInfo(LPVOID lpAddress,
     }
 
     InternalLeaveCriticalSection(pThread, &mapping_critsec);
-    
+
     return fFound;
 }
 
@@ -2024,11 +2024,11 @@ static PMAPPED_VIEW_LIST FindSharedMappingReplacement(
     CPalThread *pThread,
     dev_t deviceNum,
     ino_t inodeNum,
-    SIZE_T size, 
+    SIZE_T size,
     SIZE_T offset)
 {
     PMAPPED_VIEW_LIST pNewView = NULL;
-    
+
     if (size == 0)
     {
         ERROR("Mapping size cannot be NULL\n");
@@ -2071,7 +2071,7 @@ static PMAPPED_VIEW_LIST FindSharedMappingReplacement(
 
             if (real_map_offs+real_map_sz >= offset+size)
             {
-                /* The new desired mapping is fully contained in the 
+                /* The new desired mapping is fully contained in the
                    one just found: we can reuse this one */
 
                 pNewView = (PMAPPED_VIEW_LIST)InternalMalloc(sizeof(MAPPED_VIEW_LIST));
@@ -2079,9 +2079,9 @@ static PMAPPED_VIEW_LIST FindSharedMappingReplacement(
                 {
                     memcpy(pNewView, pView, sizeof(*pNewView));
                     NativeMapHolderAddRef(pNewView->pNMHolder);
-                    pNewView->lpAddress = (VOID*)((CHAR*)pNewView->pNMHolder->address + 
+                    pNewView->lpAddress = (VOID*)((CHAR*)pNewView->pNMHolder->address +
                         offset - pNewView->pNMHolder->offset);
-                    pNewView->NumberOfBytesToMap = size; 
+                    pNewView->NumberOfBytesToMap = size;
                 }
                 else
                 {
@@ -2097,20 +2097,20 @@ static PMAPPED_VIEW_LIST FindSharedMappingReplacement(
     return pNewView;
 }
 
-static NativeMapHolder * NewNativeMapHolder(CPalThread *pThread, LPVOID address, SIZE_T size, 
+static NativeMapHolder * NewNativeMapHolder(CPalThread *pThread, LPVOID address, SIZE_T size,
                                      SIZE_T offset, long init_ref_count)
 {
     NativeMapHolder * pThisMapHolder;
-    
+
     if (init_ref_count < 0)
     {
         ASSERT("Negative initial reference count for new map holder\n");
         return NULL;
     }
-	
-    pThisMapHolder = 
+
+    pThisMapHolder =
         (NativeMapHolder *)InternalMalloc(sizeof(NativeMapHolder));
-        
+
     if (pThisMapHolder)
     {
         pThisMapHolder->ref_count = init_ref_count;
@@ -2118,7 +2118,7 @@ static NativeMapHolder * NewNativeMapHolder(CPalThread *pThread, LPVOID address,
         pThisMapHolder->size = size;
         pThisMapHolder->offset = offset;
     }
-    
+
     return pThisMapHolder;
 }
 
@@ -2140,7 +2140,7 @@ static LONG NativeMapHolderRelease(CPalThread *pThread, NativeMapHolder * thisNM
         }
         else
         {
-            TRACE( "Successfully unmapped %p (size=%lu)\n", 
+            TRACE( "Successfully unmapped %p (size=%lu)\n",
                    thisNMH->address, (unsigned long)thisNMH->size);
         }
         InternalFree (thisNMH);
@@ -2148,7 +2148,7 @@ static LONG NativeMapHolderRelease(CPalThread *pThread, NativeMapHolder * thisNM
     else if (ret < 0)
     {
         ASSERT( "Negative reference count for map holder %p"
-                " {address=%p, size=%lu}\n", thisNMH->address, 
+                " {address=%p, size=%lu}\n", thisNMH->address,
                 (unsigned long)thisNMH->size);
     }
 
@@ -2410,8 +2410,8 @@ void * MAPMapPEFile(HANDLE hFile)
 
 #if !defined(_AMD64_)
     loadedBase = mmap((void*)preferredBase, virtualSize, PROT_NONE, MAP_ANON, -1, 0);
-#else // defined(_AMD64_)    
-    // MAC64 requires we pass MAP_SHARED (or MAP_PRIVATE) flags - otherwise, the call is failed. 
+#else // defined(_AMD64_)
+    // MAC64 requires we pass MAP_SHARED (or MAP_PRIVATE) flags - otherwise, the call is failed.
     // Refer to mmap documentation at http://www.manpagez.com/man/2/mmap/ for details.
     loadedBase = mmap((void*)preferredBase, virtualSize, PROT_NONE, MAP_ANON|MAP_PRIVATE, -1, 0);
 #endif // !defined(_AMD64_)

--- a/pal/src/map/virtual.cpp
+++ b/pal/src/map/virtual.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -113,7 +113,7 @@ static ExecutableMemoryAllocator g_executableMemoryAllocator PAL_GLOBAL;
 /*++
 Function:
     VIRTUALInitialize()
-    
+
     Initializes this section's critical section.
 
 Return value:
@@ -174,7 +174,7 @@ void VIRTUALCleanup()
         InternalFree(pTempEntry );
     }
     pVirtualMemory = NULL;
-    
+
 #if MMAP_IGNORES_HINT
     // Clean up the free list.
     pFreeBlock = pFreeMemory;
@@ -188,7 +188,7 @@ void VIRTUALCleanup()
         InternalFree(pTempFreeBlock);
     }
     pFreeMemory = NULL;
-    gBackingBaseAddress = MAP_FAILED;   
+    gBackingBaseAddress = MAP_FAILED;
 #endif  // MMAP_IGNORES_HINT
 
 #if RESERVE_FROM_BACKING_FILE
@@ -245,12 +245,12 @@ static BOOL VIRTUALIsPageCommitted( SIZE_T nBitToRetrieve, CONST PCMI pInformati
         ERROR( "pInformation was NULL!\n" );
         return FALSE;
     }
-    
+
     nByteOffset = nBitToRetrieve / CHAR_BIT;
     nBitOffset = nBitToRetrieve % CHAR_BIT;
 
     byteMask = 1 << nBitOffset;
-    
+
     if ( pInformation->pAllocState[ nByteOffset ] & byteMask )
     {
         return TRUE;
@@ -283,12 +283,12 @@ static BOOL VIRTUALIsPageDirty( SIZE_T nBitToRetrieve, CONST PCMI pInformation )
         ERROR( "pInformation was NULL!\n" );
         return FALSE;
     }
-    
+
     nByteOffset = nBitToRetrieve / CHAR_BIT;
     nBitOffset = nBitToRetrieve % CHAR_BIT;
 
     byteMask = 1 << nBitOffset;
-    
+
     if ( pInformation->pDirtyPages[ nByteOffset ] & byteMask )
     {
         return TRUE;
@@ -304,7 +304,7 @@ static BOOL VIRTUALIsPageDirty( SIZE_T nBitToRetrieve, CONST PCMI pInformation )
  *
  *  VIRTUALGetAllocationType
  *
- *      IN SIZE_T Index - The page within the range to retrieve 
+ *      IN SIZE_T Index - The page within the range to retrieve
  *                      the state for.
  *
  *      IN pInformation - The virtual memory object.
@@ -334,18 +334,18 @@ static INT VIRTUALGetAllocationType( SIZE_T Index, CONST PCMI pInformation )
  *
  *  Returns TRUE on success, FALSE otherwise.
  *  Turn on/off memory staus bits.
- *         
+ *
  */
-static BOOL VIRTUALSetPageBits ( UINT nStatus, SIZE_T nStartingBit, 
+static BOOL VIRTUALSetPageBits ( UINT nStatus, SIZE_T nStartingBit,
                                  SIZE_T nNumberOfBits, BYTE * pBitArray )
 {
-    /* byte masks for optimized modification of partial bytes (changing less 
-       than 8 bits in a single byte). note that bits are treated in little 
-       endian order : value 1 is bit 0; value 128 is bit 7. in the binary 
+    /* byte masks for optimized modification of partial bytes (changing less
+       than 8 bits in a single byte). note that bits are treated in little
+       endian order : value 1 is bit 0; value 128 is bit 7. in the binary
        representations below, bit 0 is on the right */
 
-    /* start masks : for modifying bits >= n while preserving bits < n. 
-       example : if nStartignBit%8 is 3, then bits 0, 1, 2 remain unchanged 
+    /* start masks : for modifying bits >= n while preserving bits < n.
+       example : if nStartignBit%8 is 3, then bits 0, 1, 2 remain unchanged
        while bits 3..7 are changed; startmasks[3] can be used for this.  */
     static const BYTE startmasks[8] = {
       0xff, /* start at 0 : 1111 1111 */
@@ -358,8 +358,8 @@ static BOOL VIRTUALSetPageBits ( UINT nStatus, SIZE_T nStartingBit,
     0x80  /* start at 7 : 1000 0000 */
     };
 
-    /* end masks : for modifying bits <= n while preserving bits > n. 
-       example : if the last bit to change is 5, then bits 6 & 7 stay unchanged 
+    /* end masks : for modifying bits <= n while preserving bits > n.
+       example : if the last bit to change is 5, then bits 6 & 7 stay unchanged
        while bits 1..5 are changed; endmasks[5] can be used for this.  */
     static const BYTE endmasks[8] = {
       0x01, /* end at 0 : 0000 0001 */
@@ -371,14 +371,14 @@ static BOOL VIRTUALSetPageBits ( UINT nStatus, SIZE_T nStartingBit,
       0x7f, /* end at 6 : 0111 1111 */
       0xff  /* end at 7 : 1111 1111 */
     };
-    /* last example : if only the middle of a byte must be changed, both start 
-       and end masks can be combined (bitwise AND) to obtain the correct mask. 
-       if we want to change bits 2 to 4 : 
+    /* last example : if only the middle of a byte must be changed, both start
+       and end masks can be combined (bitwise AND) to obtain the correct mask.
+       if we want to change bits 2 to 4 :
        startmasks[2] : 0xfc   1111 1100  (change 2,3,4,5,6,7)
        endmasks[4]:    0x1f   0001 1111  (change 0,1,2,3,4)
        bitwise AND :   0x1c   0001 1100  (change 2,3,4)
     */
-    
+
     BYTE byte_mask;
     SIZE_T nLastBit;
     SIZE_T nFirstByte;
@@ -386,8 +386,8 @@ static BOOL VIRTUALSetPageBits ( UINT nStatus, SIZE_T nStartingBit,
     SIZE_T nFullBytes;
 
     TRACE( "VIRTUALSetPageBits( nStatus = %d, nStartingBit = %d, "
-           "nNumberOfBits = %d, pBitArray = 0x%p )\n", 
-           nStatus, nStartingBit, nNumberOfBits, pBitArray ); 
+           "nNumberOfBits = %d, pBitArray = 0x%p )\n",
+           nStatus, nStartingBit, nNumberOfBits, pBitArray );
 
     if ( 0 == nNumberOfBits )
     {
@@ -404,7 +404,7 @@ static BOOL VIRTUALSetPageBits ( UINT nStatus, SIZE_T nStartingBit,
     {
         byte_mask = startmasks[nStartingBit % 8];
 
-        /* if 1st byte is the only changing byte, combine endmask to preserve 
+        /* if 1st byte is the only changing byte, combine endmask to preserve
            trailing bits (see 3rd example above) */
         if( nLastByte == nFirstByte)
         {
@@ -414,7 +414,7 @@ static BOOL VIRTUALSetPageBits ( UINT nStatus, SIZE_T nStartingBit,
         /* byte_mask contains 1 for bits to change, 0 for bits to leave alone */
         if(0 == nStatus)
         {
-            /* bits to change must be set to 0 : invert byte_mask (giving 0 for 
+            /* bits to change must be set to 0 : invert byte_mask (giving 0 for
                bits to change), use bitwise AND */
             pBitArray[nFirstByte] &= ~byte_mask;
         }
@@ -449,7 +449,7 @@ static BOOL VIRTUALSetPageBits ( UINT nStatus, SIZE_T nStartingBit,
     /* byte_mask contains 1 for bits to change, 0 for bits to leave alone */
     if(0 == nStatus)
     {
-        /* bits to change must be set to 0 : invert byte_mask (giving 0 for 
+        /* bits to change must be set to 0 : invert byte_mask (giving 0 for
            bits to change), use bitwise AND */
         pBitArray[nLastByte] &= ~byte_mask;
     }
@@ -474,14 +474,14 @@ static BOOL VIRTUALSetPageBits ( UINT nStatus, SIZE_T nStartingBit,
  *
  *  Returns TRUE on success, FALSE otherwise.
  *  Turn bit on to indicate committed, turn bit off to indicate reserved.
- *         
+ *
  */
-static BOOL VIRTUALSetAllocState( UINT nAction, SIZE_T nStartingBit, 
+static BOOL VIRTUALSetAllocState( UINT nAction, SIZE_T nStartingBit,
                            SIZE_T nNumberOfBits, CONST PCMI pInformation )
 {
     TRACE( "VIRTUALSetAllocState( nAction = %d, nStartingBit = %d, "
-           "nNumberOfBits = %d, pStateArray = 0x%p )\n", 
-           nAction, nStartingBit, nNumberOfBits, pInformation ); 
+           "nNumberOfBits = %d, pStateArray = 0x%p )\n",
+           nAction, nStartingBit, nNumberOfBits, pInformation );
 
     if ( !pInformation )
     {
@@ -489,7 +489,7 @@ static BOOL VIRTUALSetAllocState( UINT nAction, SIZE_T nStartingBit,
         return FALSE;
     }
 
-    return VIRTUALSetPageBits((MEM_COMMIT == nAction) ? 1 : 0, nStartingBit, 
+    return VIRTUALSetPageBits((MEM_COMMIT == nAction) ? 1 : 0, nStartingBit,
                               nNumberOfBits, pInformation->pAllocState);
 }
 
@@ -506,14 +506,14 @@ static BOOL VIRTUALSetAllocState( UINT nAction, SIZE_T nStartingBit,
  *
  *  Returns TRUE on success, FALSE otherwise.
  *  Turns bit(s) on/off bit to indicate dirty page(s)
- *         
+ *
  */
-static BOOL VIRTUALSetDirtyPages( UINT nStatus, SIZE_T nStartingBit, 
+static BOOL VIRTUALSetDirtyPages( UINT nStatus, SIZE_T nStartingBit,
                            SIZE_T nNumberOfBits, CONST PCMI pInformation )
 {
     TRACE( "VIRTUALSetDirtyPages( nStatus = %d, nStartingBit = %d, "
-           "nNumberOfBits = %d, pStateArray = 0x%p )\n", 
-           nStatus, nStartingBit, nNumberOfBits, pInformation ); 
+           "nNumberOfBits = %d, pStateArray = 0x%p )\n",
+           nStatus, nStartingBit, nNumberOfBits, pInformation );
 
     if ( !pInformation )
     {
@@ -521,7 +521,7 @@ static BOOL VIRTUALSetDirtyPages( UINT nStatus, SIZE_T nStartingBit,
         return FALSE;
     }
 
-    return VIRTUALSetPageBits(nStatus, nStartingBit, 
+    return VIRTUALSetPageBits(nStatus, nStartingBit,
                               nNumberOfBits, pInformation->pDirtyPages);
 }
 #endif // MMAP_DOESNOT_ALLOW_REMAP
@@ -535,14 +535,14 @@ static BOOL VIRTUALSetDirtyPages( UINT nStatus, SIZE_T nStartingBit,
  *
  *          Returns the PCMI if found, NULL otherwise.
  */
-static PCMI VIRTUALFindRegionInformation( IN UINT_PTR address ) 
+static PCMI VIRTUALFindRegionInformation( IN UINT_PTR address )
 {
     PCMI pEntry = NULL;
-    
+
     TRACE( "VIRTUALFindRegionInformation( %#x )\n", address );
 
     pEntry = pVirtualMemory;
-    
+
     while( pEntry )
     {
         if ( pEntry->startBoundary > address )
@@ -551,11 +551,11 @@ static PCMI VIRTUALFindRegionInformation( IN UINT_PTR address )
             pEntry = NULL;
             break;
         }
-        if ( pEntry->startBoundary + pEntry->memSize > address ) 
+        if ( pEntry->startBoundary + pEntry->memSize > address )
         {
             break;
         }
-        
+
         pEntry = pEntry->pNext;
     }
     return pEntry;
@@ -572,7 +572,7 @@ BOOL VIRTUALOwnedRegion( IN UINT_PTR address )
 {
     PCMI pEntry = NULL;
     CPalThread * pthrCurrent = InternalGetCurrentThread();
-    
+
     InternalEnterCriticalSection(pthrCurrent, &virtual_critsec);
     pEntry = VIRTUALFindRegionInformation( address );
     InternalLeaveCriticalSection(pthrCurrent, &virtual_critsec);
@@ -584,15 +584,15 @@ BOOL VIRTUALOwnedRegion( IN UINT_PTR address )
 Function :
 
     VIRTUALReleaseMemory
-    
+
     Removes a PCMI entry from the list.
-    
+
     Returns true on success. FALSE otherwise.
 --*/
 static BOOL VIRTUALReleaseMemory( PCMI pMemoryToBeReleased )
 {
     BOOL bRetVal = TRUE;
-    
+
     if ( !pMemoryToBeReleased )
     {
         ASSERT( "Invalid pointer.\n" );
@@ -615,7 +615,7 @@ static BOOL VIRTUALReleaseMemory( PCMI pMemoryToBeReleased )
         {
             pMemoryToBeReleased->pLast->pNext = pMemoryToBeReleased->pNext;
         }
-        
+
         if ( pMemoryToBeReleased->pNext )
         {
             pMemoryToBeReleased->pNext->pLast = pMemoryToBeReleased->pLast;
@@ -630,7 +630,7 @@ static BOOL VIRTUALReleaseMemory( PCMI pMemoryToBeReleased )
 
     InternalFree( pMemoryToBeReleased->pAllocState );
     pMemoryToBeReleased->pAllocState = NULL;
-    
+
     InternalFree( pMemoryToBeReleased->pProtectionState );
     pMemoryToBeReleased->pProtectionState = NULL;
 
@@ -646,7 +646,7 @@ static BOOL VIRTUALReleaseMemory( PCMI pMemoryToBeReleased )
 }
 
 /****
- *  VIRTUALConvertWinFlags() - 
+ *  VIRTUALConvertWinFlags() -
  *          Converts win32 protection flags to
  *          internal VIRTUAL flags.
  *
@@ -675,7 +675,7 @@ static BYTE VIRTUALConvertWinFlags( IN DWORD flProtect )
     case PAGE_EXECUTE_READWRITE:
         MemAccessControl = VIRTUAL_EXECUTE_READWRITE;
         break;
-    
+
     default :
         MemAccessControl = 0;
         ERROR( "Incorrect or no protection flags specified.\n" );
@@ -684,7 +684,7 @@ static BYTE VIRTUALConvertWinFlags( IN DWORD flProtect )
     return MemAccessControl;
 }
 /****
- *  VIRTUALConvertVirtualFlags() - 
+ *  VIRTUALConvertVirtualFlags() -
  *              Converts internal virtual protection
  *              flags to their win32 counterparts.
  */
@@ -770,7 +770,7 @@ static void VIRTUALDisplayList( void  )
         count++;
         p = p->pNext;
     }
-    
+
     InternalLeaveCriticalSection(pthrCurrent, &virtual_critsec);
 }
 #endif
@@ -781,7 +781,7 @@ static void VIRTUALDisplayList( void  )
  *      Stores the allocation information in the linked list.
  *      NOTE: The caller must own the critical section.
  */
-static BOOL VIRTUALStoreAllocationInfo( 
+static BOOL VIRTUALStoreAllocationInfo(
             IN UINT_PTR startBoundary,      /* Start of the region. */
             IN SIZE_T memSize,            /* Size of the region. */
             IN DWORD flAllocationType,  /* Allocation Types. */
@@ -798,32 +798,32 @@ static BOOL VIRTUALStoreAllocationInfo(
         bRetVal =  FALSE;
         goto done;
     }
-    
+
     if ( !(pNewEntry = ( PCMI )InternalMalloc( sizeof( *pNewEntry )) ) )
     {
         ERROR( "Unable to allocate memory for the structure.\n");
         bRetVal =  FALSE;
         goto done;
     }
-    
+
     pNewEntry->startBoundary    = startBoundary;
     pNewEntry->memSize          = memSize;
     pNewEntry->allocationType   = flAllocationType;
     pNewEntry->accessProtection = flProtection;
-    
+
     nBufferSize = memSize / VIRTUAL_PAGE_SIZE / CHAR_BIT;
     if ( ( memSize / VIRTUAL_PAGE_SIZE ) % CHAR_BIT != 0 )
     {
         nBufferSize++;
     }
-    
+
     pNewEntry->pAllocState      = (BYTE*)InternalMalloc( nBufferSize  );
     pNewEntry->pProtectionState = (BYTE*)InternalMalloc( (memSize / VIRTUAL_PAGE_SIZE)  );
 #if MMAP_DOESNOT_ALLOW_REMAP
     pNewEntry->pDirtyPages  = (BYTE*)InternalMalloc( nBufferSize );
-#endif // 
+#endif //
 
-    if ( pNewEntry->pAllocState && pNewEntry->pProtectionState 
+    if ( pNewEntry->pAllocState && pNewEntry->pProtectionState
 #if MMAP_DOESNOT_ALLOW_REMAP
         && pNewEntry->pDirtyPages
 #endif // MMAP_DOESNOT_ALLOW_REMAP
@@ -846,39 +846,39 @@ static BOOL VIRTUALStoreAllocationInfo(
 #if MMAP_DOESNOT_ALLOW_REMAP
         if (pNewEntry->pDirtyPages) InternalFree( pNewEntry->pDirtyPages );
         pNewEntry->pDirtyPages = NULL;
-#endif // 
+#endif //
 
         if (pNewEntry->pProtectionState) InternalFree( pNewEntry->pProtectionState );
         pNewEntry->pProtectionState = NULL;
-        
+
         if (pNewEntry->pAllocState) InternalFree( pNewEntry->pAllocState );
         pNewEntry->pAllocState = NULL;
 
         InternalFree( pNewEntry );
         pNewEntry = NULL;
-        
+
         goto done;
     }
-    
+
     pMemInfo = pVirtualMemory;
 
     if ( pMemInfo && pMemInfo->startBoundary < startBoundary )
     {
         /* Look for the correct insert point */
         TRACE( "Looking for the correct insert location.\n");
-        while ( pMemInfo->pNext && ( pMemInfo->pNext->startBoundary < startBoundary ) ) 
+        while ( pMemInfo->pNext && ( pMemInfo->pNext->startBoundary < startBoundary ) )
         {
             pMemInfo = pMemInfo->pNext;
         }
-        
+
         pNewEntry->pNext = pMemInfo->pNext;
         pNewEntry->pLast = pMemInfo;
-        
-        if ( pNewEntry->pNext ) 
+
+        if ( pNewEntry->pNext )
         {
             pNewEntry->pNext->pLast = pNewEntry;
         }
-        
+
         pMemInfo->pNext = pNewEntry;
     }
     else
@@ -887,12 +887,12 @@ static BOOL VIRTUALStoreAllocationInfo(
         /* This is the first entry in the list. */
         pNewEntry->pNext = pMemInfo;
         pNewEntry->pLast = NULL;
-        
-        if ( pNewEntry->pNext ) 
+
+        if ( pNewEntry->pNext )
         {
             pNewEntry->pNext->pLast = pNewEntry;
         }
-        
+
         pVirtualMemory = pNewEntry ;
     }
 done:
@@ -926,7 +926,7 @@ static LPVOID VIRTUALReserveMemory(
     // page-aligned and at multiples of the page size.
     StartBoundary = (UINT_PTR)lpAddress & ~BOUNDARY_64K;
     /* Add the sizes, and round down to the nearest page boundary. */
-    MemSize = ( ((UINT_PTR)lpAddress + dwSize + VIRTUAL_PAGE_MASK) & ~VIRTUAL_PAGE_MASK ) - 
+    MemSize = ( ((UINT_PTR)lpAddress + dwSize + VIRTUAL_PAGE_MASK) & ~VIRTUAL_PAGE_MASK ) -
                StartBoundary;
 
     InternalEnterCriticalSection(pthrCurrent, &virtual_critsec);
@@ -1098,7 +1098,7 @@ static LPVOID VIRTUALCommitMemory(
     {
         StartBoundary = (UINT_PTR)lpAddress & ~VIRTUAL_PAGE_MASK;
         /* Add the sizes, and round down to the nearest page boundary. */
-        MemSize = ( ((UINT_PTR)lpAddress + dwSize + VIRTUAL_PAGE_MASK) & ~VIRTUAL_PAGE_MASK ) - 
+        MemSize = ( ((UINT_PTR)lpAddress + dwSize + VIRTUAL_PAGE_MASK) & ~VIRTUAL_PAGE_MASK ) -
                   StartBoundary;
     }
     else
@@ -1108,25 +1108,25 @@ static LPVOID VIRTUALCommitMemory(
 
     /* See if we have already reserved this memory. */
     pInformation = VIRTUALFindRegionInformation( StartBoundary );
-    
+
     if ( !pInformation )
     {
         /* According to the new MSDN docs, if MEM_COMMIT is specified,
         and the memory is not reserved, you reserve and then commit.
         */
-        LPVOID pReservedMemory = 
-                VIRTUALReserveMemory( pthrCurrent, lpAddress, dwSize, 
+        LPVOID pReservedMemory =
+                VIRTUALReserveMemory( pthrCurrent, lpAddress, dwSize,
                                       flAllocationType, flProtect );
-        
+
         TRACE( "Reserve and commit the memory!\n " );
 
         if ( pReservedMemory )
         {
             /* Re-align the addresses and try again to find the memory. */
             StartBoundary = (UINT_PTR)pReservedMemory & ~VIRTUAL_PAGE_MASK;
-            MemSize = ( ((UINT_PTR)pReservedMemory + dwSize + VIRTUAL_PAGE_MASK) 
+            MemSize = ( ((UINT_PTR)pReservedMemory + dwSize + VIRTUAL_PAGE_MASK)
                         & ~VIRTUAL_PAGE_MASK ) - StartBoundary;
-            
+
             pInformation = VIRTUALFindRegionInformation( StartBoundary );
 
             if ( !pInformation )
@@ -1146,19 +1146,19 @@ static LPVOID VIRTUALCommitMemory(
             goto done;
         }
     }
-               
+
     TRACE( "Committing the memory now..\n");
-    
+
     // Pages that aren't already committed need to be committed. Pages that
     // are committed don't need to be committed, but they might need to have
     // their permissions changed.
     // To get this right, we find runs of pages with similar states and
-    // permissions. If a run is not committed, we commit it and then set 
-    // its permissions. If a run is committed but has different permissions 
-    // from what we're trying to set, we set its permissions. Finally, 
-    // if a run is already committed and has the right permissions, 
+    // permissions. If a run is not committed, we commit it and then set
+    // its permissions. If a run is committed but has different permissions
+    // from what we're trying to set, we set its permissions. Finally,
+    // if a run is already committed and has the right permissions,
     // we don't need to do anything to it.
-    
+
     totalPages = MemSize / VIRTUAL_PAGE_SIZE;
     runStart = (StartBoundary - pInformation->startBoundary) /
                 VIRTUAL_PAGE_SIZE;   // Page index
@@ -1219,7 +1219,7 @@ static LPVOID VIRTUALCommitMemory(
                         // This page is being recommitted after being decommitted,
                         // therefore the memory needs to be cleared
                         memset (temp, 0, VIRTUAL_PAGE_SIZE);
-                    } 
+                    }
 
                     temp += VIRTUAL_PAGE_SIZE;
                 }
@@ -1259,7 +1259,7 @@ static LPVOID VIRTUALCommitMemory(
                 goto error;
             }
         }
-        
+
         runStart = index;
         runLength = 1;
         allocationType = curAllocationType;
@@ -1300,22 +1300,22 @@ Function:
     VIRTUALReserveFromBackingFile
 
     Locates a reserved but unallocated block of memory in the free list.
-    
+
     If addr is not zero, this will only find a block that starts at addr
     and is at least large enough to hold the requested size.
-    
+
     If addr is zero, this finds the first block of memory in the free list
     of the right size.
-    
+
     Once the block is located, it is split if necessary to allocate only
     the requested size. The function then calls mmap() with MAP_FIXED to
     map the located block at its address on an anonymous fd.
-    
+
     This function requires that length be a multiple of the page size. If
     length is not a multiple of the page size, subsequently allocated blocks
     may be allocated on addresses that are not page-size-aligned, which is
     invalid.
-    
+
     Returns the base address of the mapped block, or MAP_FAILED if no
     suitable block exists or mapping fails.
 --*/
@@ -1325,7 +1325,7 @@ static void *VIRTUALReserveFromBackingFile(UINT_PTR addr, size_t length)
     FREE_BLOCK *prev;
     FREE_BLOCK *temp;
     char *returnAddress;
-    
+
     block = NULL;
     prev = NULL;
     for(temp = pFreeMemory; temp != NULL; temp = temp->next)
@@ -1353,7 +1353,7 @@ static void *VIRTUALReserveFromBackingFile(UINT_PTR addr, size_t length)
         // No acceptable page exists.
         return MAP_FAILED;
     }
-    
+
     // Grab the return address before we adjust the free list.
     if (addr == 0)
     {
@@ -1422,7 +1422,7 @@ Function:
 
     Adds the given block to our free list. Coalesces the list if necessary.
     The block should already have been mapped back onto the backing file.
-    
+
     Returns TRUE if the block was added to the free list.
 --*/
 static BOOL VIRTUALAddToFreeList(const PCMI pMemoryToBeReleased)
@@ -1430,8 +1430,8 @@ static BOOL VIRTUALAddToFreeList(const PCMI pMemoryToBeReleased)
     FREE_BLOCK *temp;
     FREE_BLOCK *lastBlock;
     FREE_BLOCK *newBlock;
-    BOOL coalesced; 
-    
+    BOOL coalesced;
+
     lastBlock = NULL;
     for(temp = pFreeMemory; temp != NULL; temp = temp->next)
     {
@@ -1449,11 +1449,11 @@ static BOOL VIRTUALAddToFreeList(const PCMI pMemoryToBeReleased)
         }
         lastBlock = temp;
     }
-    
+
     // Check to see if we're going to coalesce blocks before we
     // allocate anything.
     coalesced = FALSE;
-    
+
     // First, are we coalescing with the next block?
     if (temp != NULL)
     {
@@ -1489,13 +1489,13 @@ static BOOL VIRTUALAddToFreeList(const PCMI pMemoryToBeReleased)
             coalesced = TRUE;
         }
     }
-    
+
     // If we coalesced anything, we're done.
     if (coalesced)
     {
         return TRUE;
     }
-    
+
     // At this point we know we're not coalescing anything and we need
     // a new block.
     newBlock = (FREE_BLOCK *) InternalMalloc(sizeof(FREE_BLOCK));
@@ -1528,10 +1528,10 @@ Function:
     Ensures that we have a set of pages that correspond to a backing file.
     We use the PAL as the backing file merely because we're pretty confident
     it exists.
-    
+
     When the backing file hasn't been created, we create it, mmap pages
     onto it, and create the free list.
-    
+
     Returns TRUE if we could locate our backing file, open it, mmap
     pages onto it, and create the free list. Does nothing if we already
     have a mapping.
@@ -1540,9 +1540,9 @@ static BOOL VIRTUALGetBackingFile(CPalThread *pthrCurrent)
 {
     BOOL result = FALSE;
     char palName[MAX_PATH_FNAME];
-    
+
     InternalEnterCriticalSection(pthrCurrent, &virtual_critsec);
-    
+
     if (gBackingFile != -1)
     {
         result = TRUE;
@@ -1615,7 +1615,7 @@ Function:
 Note:
   MEM_TOP_DOWN, MEM_PHYSICAL, MEM_WRITE_WATCH are not supported.
   Unsupported flags are ignored.
-  
+
   Page size on i386 is set to 4k.
 
 See MSDN doc.
@@ -1663,13 +1663,13 @@ VirtualAlloc(
     {
         WARN( "Ignoring the allocation flag MEM_TOP_DOWN.\n" );
     }
-    
+
 #if RESERVE_FROM_BACKING_FILE
     // Make sure we have memory to map before we try to use it.
     VIRTUALGetBackingFile(pthrCurrent);
 #endif  // RESERVE_FROM_BACKING_FILE
 
-    if ( flAllocationType & MEM_RESERVE ) 
+    if ( flAllocationType & MEM_RESERVE )
     {
         InternalEnterCriticalSection(pthrCurrent, &virtual_critsec);
         pRetVal = VIRTUALReserveMemory( pthrCurrent, lpAddress, dwSize, flAllocationType, flProtect );
@@ -1688,18 +1688,18 @@ VirtualAlloc(
         if ( pRetVal != NULL )
         {
             /* We are reserving and committing. */
-            pRetVal = VIRTUALCommitMemory( pthrCurrent, pRetVal, dwSize, 
-                                    flAllocationType, flProtect );    
+            pRetVal = VIRTUALCommitMemory( pthrCurrent, pRetVal, dwSize,
+                                    flAllocationType, flProtect );
         }
         else
         {
             /* Just a commit. */
-            pRetVal = VIRTUALCommitMemory( pthrCurrent, lpAddress, dwSize, 
+            pRetVal = VIRTUALCommitMemory( pthrCurrent, lpAddress, dwSize,
                                     flAllocationType, flProtect );
         }
         InternalLeaveCriticalSection(pthrCurrent, &virtual_critsec);
-    }                      
-    
+    }
+
 done:
 #if defined _DEBUG
     VIRTUALDisplayList();
@@ -1771,12 +1771,12 @@ VirtualFree(
             bRetVal = FALSE;
             goto VirtualFreeExit;
         }
-        /* 
+        /*
          * A two byte range straddling 2 pages caues both pages to be either
-         * released or decommitted. So round the dwSize up to the next page 
+         * released or decommitted. So round the dwSize up to the next page
          * boundary and round the lpAddress down to the next page boundary.
          */
-        MemSize = (((UINT_PTR)(dwSize) + ((UINT_PTR)(lpAddress) & VIRTUAL_PAGE_MASK) 
+        MemSize = (((UINT_PTR)(dwSize) + ((UINT_PTR)(lpAddress) & VIRTUAL_PAGE_MASK)
                     + VIRTUAL_PAGE_MASK) & ~VIRTUAL_PAGE_MASK);
 
         StartBoundary = (UINT_PTR)lpAddress & ~VIRTUAL_PAGE_MASK;
@@ -1791,11 +1791,11 @@ VirtualFree(
             goto VirtualFreeExit;
         }
 
-        TRACE( "Un-committing the following page(s) %d to %d.\n", 
+        TRACE( "Un-committing the following page(s) %d to %d.\n",
                StartBoundary, MemSize );
 
 #if MMAP_DOESNOT_ALLOW_REMAP
-        // if no double mapping is supported, 
+        // if no double mapping is supported,
         // just mprotect the memory with no access
         if (mprotect((LPVOID)StartBoundary, MemSize, PROT_NONE) == 0)
 #else // MMAP_DOESNOT_ALLOW_REMAP
@@ -1829,16 +1829,16 @@ VirtualFree(
 
             /* We can now commit this memory by calling VirtualAlloc().*/
             index = (StartBoundary - pUnCommittedMem->startBoundary) / VIRTUAL_PAGE_SIZE;
-            
+
             nNumOfPagesToChange = MemSize / VIRTUAL_PAGE_SIZE;
-            VIRTUALSetAllocState( MEM_RESERVE, index, 
-                                  nNumOfPagesToChange, pUnCommittedMem ); 
+            VIRTUALSetAllocState( MEM_RESERVE, index,
+                                  nNumOfPagesToChange, pUnCommittedMem );
 #if MMAP_DOESNOT_ALLOW_REMAP
-            VIRTUALSetDirtyPages( 1, index, 
-                                  nNumOfPagesToChange, pUnCommittedMem ); 
+            VIRTUALSetDirtyPages( 1, index,
+                                  nNumOfPagesToChange, pUnCommittedMem );
 #endif // MMAP_DOESNOT_ALLOW_REMAP
 
-            goto VirtualFreeExit;    
+            goto VirtualFreeExit;
         }
         else
         {
@@ -1848,12 +1848,12 @@ VirtualFree(
             goto VirtualFreeExit;
         }
     }
-    
+
     if ( dwFreeType & MEM_RELEASE )
     {
-        PCMI pMemoryToBeReleased = 
+        PCMI pMemoryToBeReleased =
             VIRTUALFindRegionInformation( (UINT_PTR)lpAddress );
-        
+
         if ( !pMemoryToBeReleased )
         {
             ERROR( "lpAddress must be the base address returned by VirtualAlloc.\n" );
@@ -1869,9 +1869,9 @@ VirtualFree(
             goto VirtualFreeExit;
         }
 
-        TRACE( "Releasing the following memory %d to %d.\n", 
+        TRACE( "Releasing the following memory %d to %d.\n",
                pMemoryToBeReleased->startBoundary, pMemoryToBeReleased->memSize );
-        
+
 #if (MMAP_IGNORES_HINT && !MMAP_DOESNOT_ALLOW_REMAP)
         if (mmap((void *) pMemoryToBeReleased->startBoundary,
                  pMemoryToBeReleased->memSize, PROT_NONE,
@@ -1879,7 +1879,7 @@ VirtualFree(
                  (char *) pMemoryToBeReleased->startBoundary -
                  (char *) gBackingBaseAddress) != MAP_FAILED)
 #else   // MMAP_IGNORES_HINT && !MMAP_DOESNOT_ALLOW_REMAP
-        if ( munmap( (LPVOID)pMemoryToBeReleased->startBoundary, 
+        if ( munmap( (LPVOID)pMemoryToBeReleased->startBoundary,
                      pMemoryToBeReleased->memSize ) == 0 )
 #endif  // MMAP_IGNORES_HINT && !MMAP_DOESNOT_ALLOW_REMAP
         {
@@ -1945,7 +1945,7 @@ VirtualProtect(
 
     pthrCurrent = InternalGetCurrentThread();
     InternalEnterCriticalSection(pthrCurrent, &virtual_critsec);
-    
+
     StartBoundary = (UINT_PTR)lpAddress & ~VIRTUAL_PAGE_MASK;
     MemSize = (((UINT_PTR)(dwSize) + ((UINT_PTR)(lpAddress) & VIRTUAL_PAGE_MASK)
                 + VIRTUAL_PAGE_MASK) & ~VIRTUAL_PAGE_MASK);
@@ -1973,14 +1973,14 @@ VirtualProtect(
         Index = OffSet = StartBoundary - pEntry->startBoundary == 0 ?
              0 : ( StartBoundary - pEntry->startBoundary ) / VIRTUAL_PAGE_SIZE;
         NumberOfPagesToChange = MemSize / VIRTUAL_PAGE_SIZE;
-        
+
         TRACE( "Number of pages to check %d, starting page %d \n",
                NumberOfPagesToChange, Index );
-    
+
         for ( ; Index < NumberOfPagesToChange; Index++  )
         {
             if ( !VIRTUALIsPageCommitted( Index, pEntry ) )
-            {     
+            {
                 ERROR( "You can only change the protection attributes"
                        " on committed memory.\n" )
                 SetLastError( ERROR_INVALID_ADDRESS );
@@ -1989,7 +1989,7 @@ VirtualProtect(
         }
     }
 
-    if ( 0 == mprotect( (LPVOID)StartBoundary, MemSize, 
+    if ( 0 == mprotect( (LPVOID)StartBoundary, MemSize,
                    W32toUnixAccessControl( flNewProtect ) ) )
     {
         /* Reset the access protection. */
@@ -2004,8 +2004,8 @@ VirtualProtect(
         {
             *lpflOldProtect =
                 VIRTUALConvertVirtualFlags( pEntry->pProtectionState[ OffSet ] );
-            
-            memset( pEntry->pProtectionState + OffSet, 
+
+            memset( pEntry->pProtectionState + OffSet,
                     VIRTUALConvertWinFlags( flNewProtect ),
                     NumberOfPagesToChange );
         }
@@ -2123,7 +2123,7 @@ static void VM_ALLOCATE_VirtualQuery(LPCVOID lpAddress, PMEMORY_BASIC_INFORMATIO
 #endif
 
     vm_address = (vm_address_t)lpAddress;
-#ifdef BIT64    
+#ifdef BIT64
     MachRet = vm_region_64(
 #else
     MachRet = vm_region(
@@ -2172,7 +2172,7 @@ static void VM_ALLOCATE_VirtualQuery(LPCVOID lpAddress, PMEMORY_BASIC_INFORMATIO
     }
     else
     {
-        // What should this be?  It's either MEM_MAPPED or MEM_IMAGE, but without an image list, 
+        // What should this be?  It's either MEM_MAPPED or MEM_IMAGE, but without an image list,
         // we can't determine which one it is.
         lpBuffer->Type = MEM_MAPPED;
     }
@@ -2253,10 +2253,10 @@ VirtualQuery(
         /* Can't find a match, or no list present. */
         /* Next, looking for this region in file maps */
         if (!MAPGetRegionInfo((LPVOID)StartBoundary, lpBuffer))
-        { 
+        {
             // When all else fails, call vm_region() if it's available.
 
-            // Initialize the State to be MEM_FREE, in which case AllocationBase, AllocationProtect, 
+            // Initialize the State to be MEM_FREE, in which case AllocationBase, AllocationProtect,
             // Protect, and Type are all undefined.
             lpBuffer->BaseAddress = (LPVOID)StartBoundary;
             lpBuffer->RegionSize = 0;
@@ -2305,7 +2305,7 @@ VirtualQuery(
 ExitVirtualQuery:
 
     InternalLeaveCriticalSection(pthrCurrent, &virtual_critsec);
-    
+
     LOGEXIT( "VirtualQuery returning %d.\n", sizeof( *lpBuffer ) );
     PERF_EXIT(VirtualQuery);
     return sizeof( *lpBuffer );
@@ -2317,8 +2317,8 @@ Function:
 
 See MSDN doc.
 --*/
-UINT 
-PALAPI 
+UINT
+PALAPI
 GetWriteWatch(
   IN DWORD dwFlags,
   IN PVOID lpBaseAddress,
@@ -2341,8 +2341,8 @@ Function:
 
 See MSDN doc.
 --*/
-UINT 
-PALAPI 
+UINT
+PALAPI
 ResetWriteWatch(
   IN LPVOID lpBaseAddress,
   IN SIZE_T dwRegionSize

--- a/pal/src/memory/heap.cpp
+++ b/pal/src/memory/heap.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -48,7 +48,7 @@ SET_DEFAULT_DEBUG_CHANNEL(MEM);
  *
  * We need to know whether an instruction pointer fault is in our executable
  * heap, but the intersection between the HeapX functions on Windows and the
- * malloc_zone functions on Mac OS X are somewhat at odds and we'd have to 
+ * malloc_zone functions on Mac OS X are somewhat at odds and we'd have to
  * implement an unnecessarily complicated HeapWalk. Instead, we cache the only
  * "heap" we create, knowing it's the executable heap, and use that instead
  * with the much simpler malloc_zone_from_ptr.
@@ -71,11 +71,11 @@ RtlMoveMemory(
           IN SIZE_T Length)
 {
     PERF_ENTRY(RtlMoveMemory);
-    ENTRY("RtlMoveMemory(Destination:%p, Source:%p, Length:%d)\n", 
+    ENTRY("RtlMoveMemory(Destination:%p, Source:%p, Length:%d)\n",
           Destination, Source, Length);
-    
+
     memmove(Destination, Source, Length);
-    
+
     LOGEXIT("RtlMoveMemory returning\n");
     PERF_EXIT(RtlMoveMemory);
 }
@@ -95,9 +95,9 @@ RtlZeroMemory(
 {
     PERF_ENTRY(RtlZeroMemory);
     ENTRY("RtlZeroMemory(Destination:%p, Length:%x)\n", Destination, Length);
-    
+
     memset(Destination, 0, Length);
-    
+
     LOGEXIT("RtlZeroMemory returning.\n");
     PERF_EXIT(RtlZeroMemory);
 }
@@ -139,7 +139,7 @@ HeapCreate(
     {
         ret = (HANDLE)malloc_create_zone(dwInitialSize, 0 /* flags */);
     }
-    
+
 #else // __APPLE__
     ret = (HANDLE)DUMMY_HEAP;
 #endif // __APPLE__
@@ -183,7 +183,7 @@ GetProcessHeap(
 #else
     ret = (HANDLE) DUMMY_HEAP;
 #endif
-  
+
     LOGEXIT("GetProcessHeap returning HANDLE %p\n", ret);
     PERF_EXIT(GetProcessHeap);
     return ret;
@@ -282,7 +282,7 @@ HeapFree(
     BOOL bRetVal = FALSE;
 
     PERF_ENTRY(HeapFree);
-    ENTRY("HeapFree (hHeap=%p, dwFlags = %#x, lpMem=%p)\n", 
+    ENTRY("HeapFree (hHeap=%p, dwFlags = %#x, lpMem=%p)\n",
           hHeap, dwFlags, lpMem);
 
 #ifdef __APPLE__

--- a/pal/src/memory/local.cpp
+++ b/pal/src/memory/local.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -48,8 +48,8 @@ AllocFlagsToHeapAllocFlags (IN  UINT  AllocFlags,
     }
     return success;
 }
-        
-    
+
+
 
 /*++
 Function:
@@ -135,7 +135,7 @@ LocalFree(
     {
         bRetVal = TRUE;
     }
-    
+
     LOGEXIT( "LocalFree returning %p.\n", bRetVal == TRUE ? (HLOCAL)NULL : hMem );
     PERF_EXIT(LocalFree);
     return bRetVal == TRUE ? (HLOCAL)NULL : hMem;

--- a/pal/src/misc/dbgmsg.cpp
+++ b/pal/src/misc/dbgmsg.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -42,7 +42,7 @@ Abstract:
 #include <dirent.h>
 #include <dlfcn.h>
 
-/* <stdarg.h> needs to be included after "palinternal.h" to avoid name 
+/* <stdarg.h> needs to be included after "palinternal.h" to avoid name
    collision for va_start and va_end */
 #include <stdarg.h>
 
@@ -66,7 +66,7 @@ static const char FOPEN_FLAGS[] = "wt";
 /* global and static variables */
 
 LPCWSTR W16_NULLSTRING = (LPCWSTR) "N\0U\0L\0L\0\0";
- 
+
 DWORD dbg_channel_flags[DCI_LAST];
 BOOL g_Dbg_asserts_enabled;
 
@@ -131,7 +131,7 @@ static int max_entry_level;
 /* character to use for ENTRY indentation */
 static const char INDENT_CHAR = '.';
 
-static BOOL DBG_get_indent(DBG_LEVEL_ID level, const char *format, 
+static BOOL DBG_get_indent(DBG_LEVEL_ID level, const char *format,
                            char *indent_string);
 
 static CRITICAL_SECTION fprintf_crit_section PAL_GLOBAL;
@@ -161,14 +161,14 @@ BOOL DBG_init_channels(void)
 
     InternalInitializeCriticalSection(&fprintf_crit_section);
 
-    /* output only asserts by default [only affects no-vararg-support case; if 
+    /* output only asserts by default [only affects no-vararg-support case; if
        we have varargs, these flags aren't even checked for ASSERTs] */
     for(i=0;i<DCI_LAST;i++)
         dbg_channel_flags[i]=1<<DLI_ASSERT;
 
     /* parse PAL_DBG_CHANNELS environment variable */
 
-    if (!(env_string = MiscGetenv(ENV_CHANNELS))) 
+    if (!(env_string = MiscGetenv(ENV_CHANNELS)))
     {
         env_pcache = env_workstring = NULL;
     }
@@ -192,13 +192,13 @@ BOOL DBG_init_channels(void)
         {
             entry_ptr++;
         }
-        
+
         /* break if end of string is reached */
         if(*entry_ptr == '\0')
         {
            break;
         }
-        
+
         plus_or_minus=*entry_ptr++;
 
         /* find end of entry; if strchr returns NULL, we have reached the end
@@ -210,7 +210,7 @@ BOOL DBG_init_channels(void)
         {
             *env_workstring++='\0';
         }
-        
+
         /* find period that separates channel name from level name */
         level_ptr=strchr(entry_ptr,'.');
 
@@ -282,7 +282,7 @@ BOOL DBG_init_channels(void)
                 {
                     dbg_channel_flags[i] |= flag_mask; /* OR to open levels*/
                 }
-            } 
+            }
             else
             {
                 for(i=0;i<DCI_LAST;i++)
@@ -340,8 +340,8 @@ BOOL DBG_init_channels(void)
                         "variable!\n", env_string);
             }
         }
-    } 
-    else 
+    }
+    else
     {
         output_file = stderr; /* output to stderr by default */
     }
@@ -358,7 +358,7 @@ BOOL DBG_init_channels(void)
     }
 
     /* select ENTRY level limitation */
-    env_string = MiscGetenv(ENV_ENTRY_LEVELS);    
+    env_string = MiscGetenv(ENV_ENTRY_LEVELS);
     if(env_string)
     {
         max_entry_level = atoi(env_string);
@@ -373,7 +373,7 @@ BOOL DBG_init_channels(void)
     {
         if ((ret = pthread_key_create(&entry_level_key,NULL)) != 0)
         {
-            fprintf(stderr, "ERROR : pthread_key_create() failed error:%d (%s)\n", 
+            fprintf(stderr, "ERROR : pthread_key_create() failed error:%d (%s)\n",
                    ret, strerror(ret));
             DeleteCriticalSection(&fprintf_crit_section);;
             return FALSE;
@@ -397,7 +397,7 @@ void DBG_close_channels()
     {
         if (fclose(output_file) != 0)
         {
-            fprintf(stderr, "ERROR : fclose() failed errno:%d (%s)\n", 
+            fprintf(stderr, "ERROR : fclose() failed errno:%d (%s)\n",
                    errno, strerror(errno));
         }
     }
@@ -500,7 +500,7 @@ int DBG_printf_gcc(DBG_CHANNEL_ID channel, DBG_LEVEL_ID level, BOOL bHeader,
         /* also print file name for ASSERTs, to match Win32 behavior */
         if( DLI_ENTRY == level || DLI_ASSERT == level || DLI_EXIT == level)
         {
-            output_size=snprintf(buffer, DBG_BUFFER_SIZE, 
+            output_size=snprintf(buffer, DBG_BUFFER_SIZE,
                                  "{%p" MODULE_FORMAT "} %-5s [%-7s] at %s.%d: ",
                                  thread_id, MODULE_ID
                                  dbg_level_names[level], dbg_channel_names[channel], file, line);
@@ -512,13 +512,13 @@ int DBG_printf_gcc(DBG_CHANNEL_ID channel, DBG_LEVEL_ID level, BOOL bHeader,
                                  thread_id, MODULE_ID
                                  dbg_level_names[level], dbg_channel_names[channel], function, line);
         }
-        
+
         if(output_size + 1 > DBG_BUFFER_SIZE)
         {
             fprintf(stderr, "ERROR : buffer overflow in DBG_printf_gcc");
             return 1;
         }
-        
+
         buffer_ptr=buffer+output_size;
     }
     else
@@ -549,7 +549,7 @@ int DBG_printf_gcc(DBG_CHANNEL_ID channel, DBG_LEVEL_ID level, BOOL bHeader,
     /* flush the output to file */
     if ( fflush(output_file) != 0 )
     {
-        fprintf(stderr, "ERROR : fflush() failed errno:%d (%s)\n", 
+        fprintf(stderr, "ERROR : fflush() failed errno:%d (%s)\n",
                 errno, strerror(errno));
     }
 
@@ -614,9 +614,9 @@ int DBG_printf_c99(DBG_CHANNEL_ID channel, DBG_LEVEL_ID level, BOOL bHeader,
 
     if(bHeader)
     {
-        output_size=snprintf(buffer, DBG_BUFFER_SIZE, 
+        output_size=snprintf(buffer, DBG_BUFFER_SIZE,
                              "{%p" MODULE_FORMAT "} %-5s [%-7s] at %s.%d: ", thread_id, MODULE_ID
-                             dbg_level_names[level], dbg_channel_names[channel], 
+                             dbg_level_names[level], dbg_channel_names[channel],
                              file, line);
 
         if(output_size + 1 > DBG_BUFFER_SIZE)
@@ -624,7 +624,7 @@ int DBG_printf_c99(DBG_CHANNEL_ID channel, DBG_LEVEL_ID level, BOOL bHeader,
             fprintf(stderr, "ERROR : buffer overflow in DBG_printf_gcc");
             return 1;
         }
-        
+
         buffer_ptr=buffer+output_size;
     }
     else
@@ -634,7 +634,7 @@ int DBG_printf_c99(DBG_CHANNEL_ID channel, DBG_LEVEL_ID level, BOOL bHeader,
     }
 
     va_start(args, format);
-    output_size+=Silent_PAL_vsnprintf(buffer_ptr, DBG_BUFFER_SIZE-output_size, 
+    output_size+=Silent_PAL_vsnprintf(buffer_ptr, DBG_BUFFER_SIZE-output_size,
                                       format, args);
     va_end(args);
 
@@ -656,11 +656,11 @@ int DBG_printf_c99(DBG_CHANNEL_ID channel, DBG_LEVEL_ID level, BOOL bHeader,
         call_count=0;
         if ( fflush(output_file) != 0 )
         {
-            fprintf(stderr, "ERROR : fflush() failed errno:%d (%s)\n", 
+            fprintf(stderr, "ERROR : fflush() failed errno:%d (%s)\n",
                    errno, strerror(errno));
         }
     }
-    
+
     if ( old_errno != errno )
     {
         fprintf( stderr, "ERROR: DBG_printf_c99 changed the errno.\n" );
@@ -676,22 +676,22 @@ Function :
 
     generate an indentation string to be used for message output
 
-Parameters :                                  
+Parameters :
     DBG_LEVEL_ID level  : level of message (DLI_ENTRY, etc)
     const char *format  : printf format string of message
     char *indent_string : destination for indentation string
 
 Return value :
     TRUE if output can proceed, FALSE otherwise
-    
+
 Notes:
-As a side-effect, this function updates the ENTRY nesting level for the current 
-thread : it decrements it if 'format' contains the string 'return', increments 
-it otherwise (but only if 'level' is DLI_ENTRY). The function will return 
+As a side-effect, this function updates the ENTRY nesting level for the current
+thread : it decrements it if 'format' contains the string 'return', increments
+it otherwise (but only if 'level' is DLI_ENTRY). The function will return
 FALSE if the current nesting level is beyond our treshold (max_nesting_level);
 it always returns TRUE for other message levels
 --*/
-static BOOL DBG_get_indent(DBG_LEVEL_ID level, const char *format, 
+static BOOL DBG_get_indent(DBG_LEVEL_ID level, const char *format,
                            char *indent_string)
 {
     int ret;
@@ -769,7 +769,7 @@ Parameters :
 
 Return value :
     nesting level at the time the function was called
-    
+
 Notes:
 if new_level is -1, the nesting level will not be modified
 --*/
@@ -806,28 +806,28 @@ enum CheckAlignmentMode
 {
     // special value to indicate we've not initialized yet
     CheckAlignment_Uninitialized    = -1,
-    
+
     CheckAlignment_Off              = 0,
     CheckAlignment_On               = 1,
-    
+
     CheckAlignment_Default          = CheckAlignment_On
 };
 
 bool DBG_ShouldCheckStackAlignment()
 {
     static CheckAlignmentMode caMode = CheckAlignment_Uninitialized;
-    
+
     if (caMode == CheckAlignment_Uninitialized)
     {
         const char * checkAlignmentSettings = getenv(PAL_CHECK_ALIGNMENT_MODE);
         caMode = checkAlignmentSettings ?
             (CheckAlignmentMode)atoi(checkAlignmentSettings) : CheckAlignment_Default;
     }
-    
+
     return caMode == CheckAlignment_On;
 }
 #endif // _DEBUG && __APPLE__
-    
+
 
 #ifdef __APPLE__
 #include "CoreFoundation/CFUserNotification.h"
@@ -838,10 +838,10 @@ static const char * PAL_DISPLAY_DIALOG PAL_GLOBAL = "PAL_DisplayDialog";
 enum DisplayDialogMode
 {
     DisplayDialog_Uninitialized = -1,
-    
+
     DisplayDialog_Suppress = 0,
     DisplayDialog_Show = 1,
-    
+
     DisplayDialog_Default = DisplayDialog_Suppress,
 };
 
@@ -857,7 +857,7 @@ Function :
 void PAL_DisplayDialog(const char *szTitle, const char *szText)
 {
     static DisplayDialogMode dispDialog = DisplayDialog_Uninitialized;
-    
+
     if (dispDialog == DisplayDialog_Uninitialized)
     {
         const char * displayDialog = getenv(PAL_DISPLAY_DIALOG);
@@ -869,7 +869,7 @@ void PAL_DisplayDialog(const char *szTitle, const char *szText)
             case 0:
                 dispDialog = DisplayDialog_Suppress;
                 break;
-            
+
             case 1:
                 dispDialog = DisplayDialog_Show;
                 break;
@@ -882,7 +882,7 @@ void PAL_DisplayDialog(const char *szTitle, const char *szText)
         }
         else
             dispDialog = DisplayDialog_Default;
-                
+
         if (dispDialog == DisplayDialog_Show)
         {
             // We may not be allowed to show.
@@ -895,10 +895,10 @@ void PAL_DisplayDialog(const char *szTitle, const char *szText)
                 dispDialog = DisplayDialog_Suppress;
         }
     }
-    
+
     if (dispDialog == DisplayDialog_Suppress)
         return;
-        
+
     CFStringRef cfsTitle = CFStringCreateWithCString(kCFAllocatorDefault,
                                                      szTitle,
                                                      kCFStringEncodingUTF8);

--- a/pal/src/misc/environ.cpp
+++ b/pal/src/misc/environ.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -41,12 +41,12 @@ characters.
 
 Parameters
 
-lpName 
-       [in] Pointer to a null-terminated string that specifies the environment variable. 
-lpBuffer 
-       [out] Pointer to a buffer to receive the value of the specified environment variable. 
-nSize 
-       [in] Specifies the size, in TCHARs, of the buffer pointed to by the lpBuffer parameter. 
+lpName
+       [in] Pointer to a null-terminated string that specifies the environment variable.
+lpBuffer
+       [out] Pointer to a buffer to receive the value of the specified environment variable.
+nSize
+       [in] Specifies the size, in TCHARs, of the buffer pointed to by the lpBuffer parameter.
 
 Return Values
 
@@ -76,7 +76,7 @@ GetEnvironmentVariableA(
     ENTRY("GetEnvironmentVariableA(lpName=%p (%s), lpBuffer=%p, nSize=%u)\n",
         lpName?lpName:"NULL",
         lpName?lpName:"NULL", lpBuffer, nSize);
-    
+
     if (lpName == NULL)
     {
         ERROR("lpName is NULL\n");
@@ -90,7 +90,7 @@ GetEnvironmentVariableA(
         SetLastError(ERROR_ENVVAR_NOT_FOUND);
         goto done;
     }
-    
+
     if (strchr(lpName, '=') != NULL)
     {
         // GetEnvironmentVariable doesn't permit '=' in variable names.
@@ -100,7 +100,7 @@ GetEnvironmentVariableA(
     {
         value = MiscGetenv(lpName);
     }
-    
+
     if (value == NULL)
     {
         TRACE("%s is not found\n", lpName);
@@ -112,8 +112,8 @@ GetEnvironmentVariableA(
     {
         strcpy_s(lpBuffer, nSize, value);
         dwRet = strlen(value);
-    } 
-    else 
+    }
+    else
     {
         dwRet = strlen(value)+1;
     }
@@ -149,7 +149,7 @@ GetEnvironmentVariableW(
           lpName?lpName:W16_NULLSTRING,
           lpName?lpName:W16_NULLSTRING, lpBuffer, nSize);
 
-    inBuffSize = WideCharToMultiByte( CP_ACP, 0, lpName, -1, 
+    inBuffSize = WideCharToMultiByte( CP_ACP, 0, lpName, -1,
                                       inBuff, 0, NULL, NULL);
     if ( 0 == inBuffSize )
     {
@@ -165,7 +165,7 @@ GetEnvironmentVariableW(
         SetLastError(ERROR_NOT_ENOUGH_MEMORY);
         goto done;
     }
-    
+
     if (nSize) {
         outBuff = (CHAR *)PAL_malloc(nSize*2);
         if (outBuff == NULL)
@@ -176,7 +176,7 @@ GetEnvironmentVariableW(
         }
     }
 
-    if ( 0 == WideCharToMultiByte( CP_ACP, 0, lpName, -1, inBuff, 
+    if ( 0 == WideCharToMultiByte( CP_ACP, 0, lpName, -1, inBuff,
                                    inBuffSize, NULL, NULL ) )
     {
         ASSERT( "WideCharToMultiByte failed!\n" );
@@ -228,7 +228,7 @@ variable for the current process.
 
 Parameters
 
-lpName 
+lpName
        [in] Pointer to a null-terminated string that specifies the
        environment variable whose value is being set. The operating
        system creates the environment variable if it does not exist
@@ -269,7 +269,7 @@ SetEnvironmentVariableW(
         lpName?lpName:W16_NULLSTRING,
         lpName?lpName:W16_NULLSTRING, lpValue?lpValue:W16_NULLSTRING, lpValue?lpValue:W16_NULLSTRING);
 
-    if ((nameSize = WideCharToMultiByte(CP_ACP, 0, lpName, -1, name, 0, 
+    if ((nameSize = WideCharToMultiByte(CP_ACP, 0, lpName, -1, name, 0,
                                         NULL, NULL)) == 0)
     {
         ERROR("WideCharToMultiByte failed\n");
@@ -284,8 +284,8 @@ SetEnvironmentVariableW(
         SetLastError(ERROR_NOT_ENOUGH_MEMORY);
         goto done;
     }
-    
-    if ( 0 == WideCharToMultiByte(CP_ACP, 0, lpName,  -1, 
+
+    if ( 0 == WideCharToMultiByte(CP_ACP, 0, lpName,  -1,
                                   name,  nameSize, NULL, NULL ) )
     {
         ASSERT( "WideCharToMultiByte returned 0\n" );
@@ -295,7 +295,7 @@ SetEnvironmentVariableW(
 
     if ( NULL != lpValue )
     {
-        if ((valueSize = WideCharToMultiByte(CP_ACP, 0, lpValue, -1, value, 
+        if ((valueSize = WideCharToMultiByte(CP_ACP, 0, lpValue, -1, value,
                                              0, NULL, NULL)) == 0)
         {
             ERROR("WideCharToMultiByte failed\n");
@@ -304,15 +304,15 @@ SetEnvironmentVariableW(
         }
 
         value = (PCHAR)PAL_malloc(sizeof(CHAR)*valueSize);
-        
+
         if ( NULL == value )
         {
             ERROR("malloc failed\n");
             SetLastError(ERROR_NOT_ENOUGH_MEMORY);
             goto done;
         }
-        
-        if ( 0 == WideCharToMultiByte( CP_ACP, 0, lpValue, -1, 
+
+        if ( 0 == WideCharToMultiByte( CP_ACP, 0, lpValue, -1,
                                        value, valueSize, NULL, NULL ) )
         {
             ASSERT("WideCharToMultiByte failed\n");
@@ -320,13 +320,13 @@ SetEnvironmentVariableW(
             goto done;
         }
     }
-    
+
 
     bRet = SetEnvironmentVariableA(name, value);
 done:
     PAL_free(value);
     PAL_free(name);
-    
+
     LOGEXIT("SetEnvironmentVariableW returning BOOL %d\n", bRet);
     PERF_EXIT(SetEnvironmentVariableW);
     return bRet;
@@ -370,7 +370,7 @@ GetEnvironmentStringsW(
     PERF_ENTRY(GetEnvironmentStringsW);
     ENTRY("GetEnvironmentStringsW()\n");
 
-    PALCEnterCriticalSection(&gcsEnvironment);    
+    PALCEnterCriticalSection(&gcsEnvironment);
 
     envNum = 0;
     len    = 0;
@@ -383,7 +383,7 @@ GetEnvironmentStringsW(
     }
 
     wenviron = (WCHAR *)PAL_malloc(sizeof(WCHAR)* (envNum + 1));
-    if (wenviron == NULL) 
+    if (wenviron == NULL)
     {
         ERROR("malloc failed\n");
         SetLastError(ERROR_NOT_ENOUGH_MEMORY);
@@ -400,7 +400,7 @@ GetEnvironmentStringsW(
     }
 
     *tempEnviron = 0; /* Put an extra NULL at the end */
-    
+
  EXIT:
     PALCLeaveCriticalSection(&gcsEnvironment);
 
@@ -428,7 +428,7 @@ GetEnvironmentStringsA(
     PERF_ENTRY(GetEnvironmentStringsA);
     ENTRY("GetEnvironmentStringsA()\n");
 
-    PALCEnterCriticalSection(&gcsEnvironment);    
+    PALCEnterCriticalSection(&gcsEnvironment);
 
     envNum = 0;
     len    = 0;
@@ -459,7 +459,7 @@ GetEnvironmentStringsA(
     }
 
     *tempEnviron = 0; /* Put an extra NULL at the end */
-    
+
  EXIT:
     PALCLeaveCriticalSection(&gcsEnvironment);
 
@@ -479,7 +479,7 @@ Parameters
 
 lpszEnvironmentBlock   [in] Pointer to a block of environment strings. The pointer to
                             the block must be obtained by calling the
-                            GetEnvironmentStrings function. 
+                            GetEnvironmentStrings function.
 
 Return Values
 
@@ -618,15 +618,15 @@ SetEnvironmentVariableA(
             SetLastError(ERROR_NOT_ENOUGH_MEMORY);
             goto done;
         }
-        
+
         sprintf_s(string, iLen, "%s=%s", lpName, lpValue);
         nResult = MiscPutenv(string, FALSE) ? 0 : -1;
 
         PAL_free(string);
         string = NULL;
-        
+
         // If MiscPutenv returns FALSE, it almost certainly failed to
-        // allocate memory.        
+        // allocate memory.
         if(nResult == -1)
         {
             bRet = FALSE;
@@ -637,9 +637,7 @@ SetEnvironmentVariableA(
     }
     bRet = TRUE;
 done:
-    LOGEXIT("SetEnvironmentVariableA returning BOOL %d\n", bRet);    
+    LOGEXIT("SetEnvironmentVariableA returning BOOL %d\n", bRet);
     PERF_EXIT(SetEnvironmentVariableA);
     return bRet;
 }
-
-

--- a/pal/src/misc/error.cpp
+++ b/pal/src/misc/error.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -39,7 +39,7 @@ them.
 Parameters
 
 uMode
-       [in] Specifies the process error mode. This parameter can be one or more of the following values. 
+       [in] Specifies the process error mode. This parameter can be one or more of the following values.
 
         Value                     Action
         0                         Use the system default, which is to display all error dialog boxes.
@@ -50,7 +50,7 @@ uMode
 
 Return Values
 
-The return value is the previous state of the error-mode bit flags. 
+The return value is the previous state of the error-mode bit flags.
 
 --*/
 UINT
@@ -124,4 +124,3 @@ SetLastError(
 {
     CPalThread::SetLastError(dwErrCode);
 }
-

--- a/pal/src/misc/random.cpp
+++ b/pal/src/misc/random.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -38,7 +38,7 @@ BOOL RANDOMInitialize(void)
     {
         return FALSE;
     }
-    
+
     return TRUE;
 }
 

--- a/pal/src/misc/strutil.cpp
+++ b/pal/src/misc/strutil.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -44,7 +44,7 @@ CPalString::CopyString(
     )
 {
     PAL_ERROR palError = NO_ERROR;
-        
+
     _ASSERTE(NULL != psSource);
     _ASSERTE(NULL == m_pwsz);
     _ASSERTE(0 == m_dwStringLength);
@@ -53,7 +53,7 @@ CPalString::CopyString(
     if (0 != psSource->GetStringLength())
     {
         _ASSERTE(psSource->GetMaxLength() > psSource->GetStringLength());
-        
+
         WCHAR *pwsz = reinterpret_cast<WCHAR*>(
             InternalMalloc(psSource->GetMaxLength() * sizeof(WCHAR))
             );

--- a/pal/src/misc/sysinfo.cpp
+++ b/pal/src/misc/sysinfo.cpp
@@ -283,11 +283,11 @@ GlobalMemoryStatusEx(
 #endif // __APPLE__
     }
 
-    // There is no API to get the total virtual address space size on 
-    // Unix, so we use a constant value representing 128TB, which is 
+    // There is no API to get the total virtual address space size on
+    // Unix, so we use a constant value representing 128TB, which is
     // the approximate size of total user virtual address space on
     // the currently supported Unix systems.
-    static const UINT64 _128TB = (1ull << 47); 
+    static const UINT64 _128TB = (1ull << 47);
     lpBuffer->ullTotalVirtual = _128TB;
     lpBuffer->ullAvailVirtual = lpBuffer->ullAvailPhys;
 
@@ -345,4 +345,3 @@ PAL_GetLogicalProcessorCacheSizeFromOS()
 
     return cacheSize;
 }
-

--- a/pal/src/misc/time.cpp
+++ b/pal/src/misc/time.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -75,8 +75,8 @@ time. The system time is expressed in Coordinated Universal Time
 
 Parameters
 
-lpSystemTime 
-       [out] Pointer to a SYSTEMTIME structure to receive the current system date and time. 
+lpSystemTime
+       [out] Pointer to a SYSTEMTIME structure to receive the current system date and time.
 
 Return Values
 
@@ -101,10 +101,10 @@ GetSystemTime(
 
     tt = time(NULL);
 
-    /* We can't get millisecond resolution from time(), so we get it from 
+    /* We can't get millisecond resolution from time(), so we get it from
        gettimeofday() */
     timeofday_retval = gettimeofday(&timeval,NULL);
-    
+
 #if HAVE_GMTIME_R
     utPtr = &ut;
     if (gmtime_r(&tt, utPtr) == NULL)
@@ -134,20 +134,20 @@ GetSystemTime(
     {
         int old_seconds;
         int new_seconds;
-    
+
         lpSystemTime->wMilliseconds = timeval.tv_usec/tccMillieSecondsToMicroSeconds;
-    
+
         old_seconds = utPtr->tm_sec;
         new_seconds = timeval.tv_sec%60;
-   
-        /* just in case we reached the next second in the interval between 
+
+        /* just in case we reached the next second in the interval between
            time() and gettimeofday() */
         if( old_seconds!=new_seconds )
         {
             TRACE("crossed seconds boundary; setting milliseconds to 999\n");
             lpSystemTime->wMilliseconds = 999;
-        }  
-    }                        
+        }
+    }
 EXIT:
     LOGEXIT("GetSystemTime returns void\n");
     PERF_EXIT(GetSystemTime);
@@ -164,7 +164,7 @@ use the GetSystemTimeAdjustment function.
 
 Parameters
 
-This function has no parameters. 
+This function has no parameters.
 
 Return Values
 
@@ -212,7 +212,7 @@ QueryPerformanceCounter(
             retval = FALSE;
             break;
         }
-        lpPerformanceCount->QuadPart = 
+        lpPerformanceCount->QuadPart =
             (LONGLONG)ts.tv_sec * (LONGLONG)tccSecondsToNanoSeconds + (LONGLONG)ts.tv_nsec;
     }
 #elif HAVE_MACH_ABSOLUTE_TIME
@@ -233,22 +233,22 @@ QueryPerformanceCounter(
             retval = FALSE;
             break;
         }
-        lpPerformanceCount->QuadPart = 
+        lpPerformanceCount->QuadPart =
             (LONGLONG)tb.tb_high * (LONGLONG)tccSecondsToNanoSeconds + (LONGLONG)tb.tb_low;
     }
 #else
     {
-        struct timeval tv;    
+        struct timeval tv;
         if (gettimeofday(&tv, NULL) == -1)
         {
             ASSERT("gettimeofday() failed; errno is %d (%s)\n", errno, strerror(errno));
             retval = FALSE;
             break;
         }
-        lpPerformanceCount->QuadPart = 
-            (LONGLONG)tv.tv_sec * (LONGLONG)tccSecondsToMicroSeconds + (LONGLONG)tv.tv_usec;    
+        lpPerformanceCount->QuadPart =
+            (LONGLONG)tv.tv_sec * (LONGLONG)tccSecondsToMicroSeconds + (LONGLONG)tv.tv_usec;
     }
-#endif // HAVE_CLOCK_MONOTONIC 
+#endif // HAVE_CLOCK_MONOTONIC
     while (false);
 
     LOGEXIT("QueryPerformanceCounter\n");
@@ -280,7 +280,7 @@ QueryPerformanceFrequency(
     }
 #else
     lpFrequency->QuadPart = (LONGLONG)tccSecondsToMicroSeconds;
-#endif // HAVE_GETHRTIME || HAVE_READ_REAL_TIME || HAVE_CLOCK_MONOTONIC 
+#endif // HAVE_GETHRTIME || HAVE_READ_REAL_TIME || HAVE_CLOCK_MONOTONIC
     LOGEXIT("QueryPerformanceFrequency\n");
     PERF_EXIT(QueryPerformanceFrequency);
     return retval;
@@ -341,7 +341,7 @@ GetTickCount64()
 
 #if HAVE_CLOCK_MONOTONIC_COARSE || HAVE_CLOCK_MONOTONIC
     {
-        clockid_t clockType = 
+        clockid_t clockType =
 #if HAVE_CLOCK_MONOTONIC_COARSE
             CLOCK_MONOTONIC_COARSE; // good enough resolution, fastest speed
 #else
@@ -382,7 +382,7 @@ GetTickCount64()
     }
 #else
     {
-        struct timeval tv;    
+        struct timeval tv;
         if (gettimeofday(&tv, NULL) == -1)
         {
             ASSERT("gettimeofday() failed; errno is %d (%s)\n", errno, strerror(errno));
@@ -390,8 +390,7 @@ GetTickCount64()
         }
         retval = (tv.tv_sec * tccSecondsToMillieSeconds) + (tv.tv_usec / tccMillieSecondsToMicroSeconds);
     }
-#endif // HAVE_CLOCK_MONOTONIC 
-EXIT:    
+#endif // HAVE_CLOCK_MONOTONIC
+EXIT:
     return retval;
 }
-

--- a/pal/src/misc/utils.cpp
+++ b/pal/src/misc/utils.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -43,16 +43,16 @@ SET_DEFAULT_DEBUG_CHANNEL(MISC);
 Function:
   UTIL_inverse_wcspbrk
 
-  Opposite of wcspbrk : searches a string for the first character NOT in the 
+  Opposite of wcspbrk : searches a string for the first character NOT in the
   given set
 
 Parameters :
     LPWSTR lpwstr :   string to search
     LPCWSTR charset : list of characters to search for
-                                      
+
 Return value :
     pointer to first character of lpwstr that isn't in the set
-    NULL if all characters are in the set                                                                 
+    NULL if all characters are in the set
 --*/
 LPWSTR UTIL_inverse_wcspbrk(LPWSTR lpwstr, LPCWSTR charset)
 {
@@ -63,15 +63,15 @@ LPWSTR UTIL_inverse_wcspbrk(LPWSTR lpwstr, LPCWSTR charset)
             return lpwstr;
         }
         lpwstr++;
-    }                     
+    }
     return NULL;
 }
 
 
 /*++
-Function : 
+Function :
     UTIL_IsReadOnlyBitsSet
-    
+
     Takes a struct stat *
     Returns true if the file is read only,
 --*/
@@ -109,9 +109,9 @@ BOOL UTIL_IsReadOnlyBitsSet( struct stat * stat_data )
 }
 
 /*++
-Function : 
+Function :
     UTIL_IsExecuteBitsSet
-    
+
     Takes a struct stat *
     Returns true if the file is executable,
 --*/
@@ -123,7 +123,7 @@ BOOL UTIL_IsExecuteBitsSet( struct stat * stat_data )
     {
         return FALSE;
     }
-    
+
     /* Check for read permissions. */
     if ( stat_data->st_uid == geteuid() )
     {
@@ -154,19 +154,19 @@ BOOL UTIL_IsExecuteBitsSet( struct stat * stat_data )
 }
 
 /*++
-Function : 
+Function :
     UTIL_WCToMB_Alloc
-    
+
     Converts a wide string to a multibyte string, allocating the required buffer
-    
+
 Parameters :
     LPCWSTR lpWideCharStr : string to convert
     int cchWideChar : number of wide characters to convert
                       (-1 to convert a complete null-termnated string)
-    
+
 Return Value :
-    newly allocated buffer containing the converted string. Conversion is 
-    performed using CP_ACP. Buffer is allocated with malloc(), release it 
+    newly allocated buffer containing the converted string. Conversion is
+    performed using CP_ACP. Buffer is allocated with malloc(), release it
     with free().
     In case if failure, LastError will be set.
 --*/
@@ -176,7 +176,7 @@ LPSTR UTIL_WCToMB_Alloc(LPCWSTR lpWideCharStr, int cchWideChar)
     LPSTR lpMultiByteStr;
 
     /* get required buffer length */
-    length = WideCharToMultiByte(CP_ACP, 0, lpWideCharStr, cchWideChar, 
+    length = WideCharToMultiByte(CP_ACP, 0, lpWideCharStr, cchWideChar,
                                  NULL, 0, NULL, NULL);
     if(0 == length)
     {
@@ -194,7 +194,7 @@ LPSTR UTIL_WCToMB_Alloc(LPCWSTR lpWideCharStr, int cchWideChar)
     }
 
     /* convert into allocated buffer */
-    length = WideCharToMultiByte(CP_ACP, 0, lpWideCharStr, cchWideChar, 
+    length = WideCharToMultiByte(CP_ACP, 0, lpWideCharStr, cchWideChar,
                                  lpMultiByteStr, length, NULL, NULL);
     if(0 == length)
     {
@@ -206,19 +206,19 @@ LPSTR UTIL_WCToMB_Alloc(LPCWSTR lpWideCharStr, int cchWideChar)
 }
 
 /*++
-Function : 
+Function :
     UTIL_MBToWC_Alloc
-    
+
     Converts a multibyte string to a wide string, allocating the required buffer
-    
+
 Parameters :
     LPCSTR lpMultiByteStr : string to convert
     int cbMultiByte : number of bytes to convert
                       (-1 to convert a complete null-termnated string)
-    
+
 Return Value :
-    newly allocated buffer containing the converted string. Conversion is 
-    performed using CP_ACP. Buffer is allocated with malloc(), release it 
+    newly allocated buffer containing the converted string. Conversion is
+    performed using CP_ACP. Buffer is allocated with malloc(), release it
     with free().
     In case if failure, LastError will be set.
 --*/
@@ -254,7 +254,7 @@ LPWSTR UTIL_MBToWC_Alloc(LPCSTR lpMultiByteStr, int cbMultiByte)
     }
 
     /* convert into allocated buffer */
-    length = MultiByteToWideChar(CP_ACP, 0, lpMultiByteStr, cbMultiByte, 
+    length = MultiByteToWideChar(CP_ACP, 0, lpMultiByteStr, cbMultiByte,
                                       lpWideCharStr, length);
     if(0 >= length)
     {
@@ -318,4 +318,3 @@ void UTIL_SetLastErrorFromMach(kern_return_t MachReturn)
     }
 }
 #endif //HAVE_VM_ALLOCATE
-

--- a/pal/src/objmgr/palobjbase.cpp
+++ b/pal/src/objmgr/palobjbase.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -81,7 +81,7 @@ CPalObjectBase::Initialize(
             ERROR("Unable to initialize local data lock!\n");
             goto IntializeExit;
         }
-        
+
         m_pvLocalData = InternalMalloc(m_pot->GetProcessLocalDataSize());
         if (NULL != m_pvLocalData)
         {
@@ -121,7 +121,7 @@ CPalObjectBase::GetObjectType(
 {
     ENTRY("CPalObjectBase::GetObjectType(this = %p)\n", this);
     LOGEXIT("CPalObjectBase::GetObjectType returns %p\n", m_pot);
-    
+
     return m_pot;
 }
 
@@ -139,7 +139,7 @@ CPalObjectBase::GetObjectAttributes(
 {
     ENTRY("CPalObjectBase::GetObjectAttributes(this = %p)\n", this);
     LOGEXIT("CPalObjectBase::GetObjectAttributes returns %p\n", &m_oa);
-    
+
     return &m_oa;
 }
 
@@ -160,13 +160,13 @@ CPalObjectBase::GetImmutableData(
     )
 {
     _ASSERTE(NULL != ppvImmutableData);
-    
+
     ENTRY("CPalObjectBase::GetImmutableData"
         "(this = %p, ppvImmutableData = %p)\n",
         this,
         ppvImmutableData
         );
-    
+
     _ASSERTE(0 < m_pot->GetImmutableDataSize());
 
     *ppvImmutableData = m_pvImmutableData;
@@ -203,7 +203,7 @@ CPalObjectBase::GetProcessLocalData(
     _ASSERTE(ReadLock == eLockRequest || WriteLock == eLockRequest);
     _ASSERTE(NULL != ppDataLock);
     _ASSERTE(NULL != ppvProcessLocalData);
-    
+
     ENTRY("CPalObjectBase::GetProcessLocalData"
         "(this = %p, pthr = %p, eLockRequest = %d, ppDataLock = %p,"
         " ppvProcessLocalData = %p)\n",
@@ -213,14 +213,14 @@ CPalObjectBase::GetProcessLocalData(
         ppDataLock,
         ppvProcessLocalData
         );
-    
+
     _ASSERTE(0 < m_pot->GetProcessLocalDataSize());
 
     m_sdlLocalData.AcquireLock(pthr, ppDataLock);
     *ppvProcessLocalData = m_pvLocalData;
 
     LOGEXIT("CPalObjectBase::GetProcessLocalData returns %d\n", NO_ERROR);
-    
+
     return NO_ERROR;
 }
 
@@ -277,7 +277,7 @@ CPalObjectBase::ReleaseReference(
 
     AcquireObjectDestructionLock(pthr);
 
-    _ASSERTE(m_lRefCount > 0); 
+    _ASSERTE(m_lRefCount > 0);
 
     //
     // Even though object destruction takes place under a lock
@@ -320,7 +320,7 @@ CPalObjectBase::ReleaseReference(
         pthr->ReleaseThreadReference();
     }
     else
-    {       
+    {
         ReleaseObjectDestructionLock(pthr, FALSE);
     }
 
@@ -357,4 +357,3 @@ CPalObjectBase::~CPalObjectBase()
 
     LOGEXIT("CPalObjectBase::~CPalObjectBase\n");
 }
-

--- a/pal/src/objmgr/palobjbase.hpp
+++ b/pal/src/objmgr/palobjbase.hpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -26,7 +26,7 @@ Abstract:
 #include "pal/thread.hpp"
 
 namespace CorUnix
-{   
+{
     class CSimpleDataLock : IDataLock
     {
     private:
@@ -82,13 +82,13 @@ namespace CorUnix
         {
             InternalLeaveCriticalSection(pthr, &m_cs);
         };
-        
+
     };
-    
+
     class CPalObjectBase : public IPalObject
-    { 
+    {
         template <class T> friend void InternalDelete(T *p);
-        
+
     protected:
 
         LONG m_lRefCount;
@@ -146,7 +146,7 @@ namespace CorUnix
         //
         // IPalObject routines
         //
-        
+
         virtual
         CObjectType *
         GetObjectType(
@@ -189,4 +189,3 @@ namespace CorUnix
 }
 
 #endif // _PALOBJBASE_HPP_
-

--- a/pal/src/objmgr/shmobject.cpp
+++ b/pal/src/objmgr/shmobject.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -50,7 +50,7 @@ CSharedMemoryObject::Initialize(
     PAL_ERROR palError = NO_ERROR;
     SHMObjData *psmod = NULL;
 
-    _ASSERTE(NULL != pthr); 
+    _ASSERTE(NULL != pthr);
     _ASSERTE(NULL != poa);
 
     ENTRY("CSharedMemoryObject::Initialize"
@@ -72,7 +72,7 @@ CSharedMemoryObject::Initialize(
     //
 
     if (0 != m_oa.sObjectName.GetStringLength())
-    {   
+    {
         m_ObjectDomain = SharedObject;
 
         palError = AllocateSharedDataItems(&m_shmod, &psmod);
@@ -83,7 +83,7 @@ CSharedMemoryObject::Initialize(
     }
 
     if (0 != m_pot->GetSharedDataSize())
-    {       
+    {
         if (SharedObject == m_ObjectDomain)
         {
             //
@@ -94,7 +94,7 @@ CSharedMemoryObject::Initialize(
                 ASSERT("psmod should not be NULL");
                 palError = ERROR_INTERNAL_ERROR;
                 goto InitializeExit;
-            } 
+            }
 
             m_pvSharedData = SHMPTR_TO_TYPED_PTR(VOID, psmod->shmObjSharedData);
             if (NULL == m_pvSharedData)
@@ -104,7 +104,7 @@ CSharedMemoryObject::Initialize(
                 goto InitializeExit;
             }
         }
-        else 
+        else
         {
             //
             // Initialize the local shared data lock.
@@ -115,8 +115,8 @@ CSharedMemoryObject::Initialize(
             {
                 ERROR("Failure initializing m_sdlSharedData\n");
                 goto InitializeExit;
-            } 
-        
+            }
+
             //
             // Allocate local memory to hold the shared data
             //
@@ -314,7 +314,7 @@ CSharedMemoryObject::AllocateSharedDataItems(
         pshmObjData,
         ppsmod
         );
-        
+
     //
     // We're about to make a number of shared memory allocations,
     // so grab the lock for the entirety of the routine.
@@ -356,7 +356,7 @@ CSharedMemoryObject::AllocateSharedDataItems(
         // The shared copy of the object's immutable data will be initialized
         // by CSharedMemoryObjectManager::RegisterObject or PromoteSharedData
         //
-        
+
         psmod->shmObjImmutableData = SHMalloc(m_pot->GetImmutableDataSize());
         if (SHMNULL == psmod->shmObjImmutableData)
         {
@@ -421,10 +421,10 @@ CSharedMemoryObject::FreeSharedDataAreas(
         );
 
     SHMLock();
-        
+
     psmod = SHMPTR_TO_TYPED_PTR(SHMObjData, shmObjData);
     _ASSERTE(NULL != psmod);
-    
+
     if (SHMNULL != psmod->shmObjImmutableData)
     {
         SHMfree(psmod->shmObjImmutableData);
@@ -439,7 +439,7 @@ CSharedMemoryObject::FreeSharedDataAreas(
     {
         SHMfree(psmod->shmObjName);
     }
-    
+
     SHMfree(shmObjData);
 
     SHMRelease();
@@ -466,22 +466,22 @@ CSharedMemoryObject::PromoteSharedData(
 {
     _ASSERTE(SHMNULL != shmObjData);
     _ASSERTE(NULL != psmod);
-    
+
     ENTRY("CSharedMemoryObject::PromoteSharedData"
         "(this = %p, shmObjData = %p, psmod = %p)\n",
-        this, 
+        this,
         shmObjData,
         psmod);
-    
+
     //
     // psmod has been zero-inited, so we don't need to worry about
     // shmPrevObj, shmNextObj, fAddedToList, shmObjName, dwNameLength,
     // or pvSynchData
     //
-    
+
     psmod->lProcessRefCount = 1;
     psmod->eTypeId = m_pot->GetId();
-    
+
     if (0 != m_pot->GetImmutableDataSize())
     {
         void *pvImmutableData;
@@ -508,7 +508,7 @@ CSharedMemoryObject::PromoteSharedData(
             m_pvSharedData,
             m_pot->GetSharedDataSize()
             );
-        
+
         InternalFree(m_pvSharedData);
         m_pvSharedData = pvSharedData;
     }
@@ -552,7 +552,7 @@ CSharedMemoryObject::EnsureObjectIsShared(
     // Grab the shared memory lock and check if the object is already
     // shared
     //
-    
+
     SHMLock();
 
     if (SharedObject == m_ObjectDomain)
@@ -563,7 +563,7 @@ CSharedMemoryObject::EnsureObjectIsShared(
     //
     // Grab the local shared data lock, if necessary
     //
-    
+
     if (0 != m_pot->GetSharedDataSize())
     {
         m_sdlSharedData.AcquireLock(pthr, &pDataLock);
@@ -597,7 +597,7 @@ EnsureObjectIsSharedExit:
 
     LOGEXIT("CSharedMemoryObject::EnsureObjectIsShared returns %d\n", palError);
 
-    return palError;    
+    return palError;
 }
 
 /*++
@@ -618,7 +618,7 @@ CSharedMemoryObject::CleanupForProcessShutdown(
     bool fCleanupSharedState;
 
     _ASSERTE(NULL != pthr);
-    
+
     ENTRY("CSharedMemoryObject::CleanupForProcessShutdown"
         "(this = %p, pthr = %p)\n",
         this,
@@ -650,7 +650,7 @@ CSharedMemoryObject::CleanupForProcessShutdown(
 
     m_pthrCleanup = pthr;
     pthr->AddThreadReference();
-    
+
     InternalDelete(this);
 
     pthr->ReleaseThreadReference();
@@ -676,13 +676,13 @@ CSharedMemoryObject::AcquireObjectDestructionLock(
     )
 {
     _ASSERTE(NULL != pthr);
-    
+
     ENTRY("CSharedMemoryObject::AcquireObjectDestructionLock"
         "(this = %p, pthr = $p)\n",
         this,
         pthr
         );
-    
+
     InternalEnterCriticalSection(pthr, m_pcsObjListLock);
 
     LOGEXIT("CSharedMemoryObject::AcquireObjectDestructionLock\n");
@@ -717,7 +717,7 @@ CSharedMemoryObject::ReleaseObjectDestructionLock(
         pthr,
         fDestructionPending
         );
-    
+
     if (fDestructionPending)
     {
         RemoveEntryList(&m_le);
@@ -760,16 +760,16 @@ CSharedMemoryObject::DereferenceSharedData()
         );
 
     if (!fSharedDataAlreadDereferenced)
-    {   
+    {
         if (SHMNULL != m_shmod)
         {
             SHMObjData *psmod;
-            
+
             SHMLock();
 
             psmod = SHMPTR_TO_TYPED_PTR(SHMObjData, m_shmod);
             _ASSERTE(NULL != psmod);
-            
+
             psmod->lProcessRefCount -= 1;
             if (0 == psmod->lProcessRefCount)
             {
@@ -814,17 +814,17 @@ CSharedMemoryObject::DereferenceSharedData()
                     {
                         SHMObjData *psmodNext = SHMPTR_TO_TYPED_PTR(SHMObjData, psmod->shmNextObj);
                         _ASSERTE(NULL != psmodNext);
-                        
+
                         psmodNext->shmPrevObj = psmod->shmPrevObj;
                     }
                 }
-#if _DEBUG                
+#if _DEBUG
                 else
                 {
                     _ASSERTE(SHMNULL == psmod->shmPrevObj);
                     _ASSERTE(SHMNULL == psmod->shmNextObj);
                 }
-#endif                
+#endif
             }
 
             SHMRelease();
@@ -835,7 +835,7 @@ CSharedMemoryObject::DereferenceSharedData()
             // If the object is local the shared data needs to be
             // deleted by definition
             //
-            
+
             m_fDeleteSharedData = TRUE;
         }
     }
@@ -861,7 +861,7 @@ Function:
 CSharedMemoryObject::~CSharedMemoryObject()
 {
     ENTRY("CSharedMemoryObject::~CSharedMemoryObject(this = %p)\n", this);
-    
+
     if (!m_fSharedDataDereferenced)
     {
         ASSERT("DereferenceSharedData not called before object destructor -- delete called directly?\n");
@@ -874,7 +874,7 @@ CSharedMemoryObject::~CSharedMemoryObject()
     }
     else if (SHMNULL != m_shmod && m_fDeleteSharedData)
     {
-        FreeSharedDataAreas(m_shmod);        
+        FreeSharedDataAreas(m_shmod);
     }
 
     LOGEXIT("CSharedMemoryObject::~CSharedMemoryObject\n");
@@ -915,12 +915,12 @@ CSharedMemoryObject::GetObjectFromListLink(PLIST_ENTRY ple)
     _ASSERTE(NULL != ple);
 
     ENTRY("CSharedMemoryObject::GetObjectFromListLink(ple = %p)\n", ple);
-    
+
     //
     // Ideally we'd use CONTAINING_RECORD here, but it uses offsetof (see above
     // comment
     //
-    
+
     pshmo = reinterpret_cast<CSharedMemoryObject*>(
         reinterpret_cast<size_t>(ple) - PAL_safe_offsetof(CSharedMemoryObject, m_le)
         );
@@ -973,7 +973,7 @@ CSharedMemoryObject::GetSharedData(
         );
 
     _ASSERTE(0 < m_pot->GetSharedDataSize());
-    
+
     if (ProcessLocalObject == m_ObjectDomain)
     {
         //
@@ -997,7 +997,7 @@ CSharedMemoryObject::GetSharedData(
         // A shared object can never transition back to local,
         // so there's no need to recheck the domain on this path
         //
-        
+
         m_ssmlSharedData.AcquireLock(pthr, &pDataLock);
     }
 
@@ -1005,7 +1005,7 @@ CSharedMemoryObject::GetSharedData(
     *ppvSharedData = m_pvSharedData;
 
     LOGEXIT("CSharedMemoryObject::GetSharedData returns %d\n", NO_ERROR);
-    
+
     return NO_ERROR;
 }
 
@@ -1030,7 +1030,7 @@ CSharedMemoryObject::GetSynchStateController(
 {
     _ASSERTE(NULL != pthr);
     _ASSERTE(NULL != ppStateController);
-    
+
     //
     // This is not a waitable object!
     //
@@ -1060,7 +1060,7 @@ CSharedMemoryObject::GetSynchWaitController(
 {
     _ASSERTE(NULL != pthr);
     _ASSERTE(NULL != ppWaitController);
-    
+
     //
     // This is not a waitable object!!!
     //
@@ -1084,7 +1084,7 @@ CSharedMemoryObject::GetObjectDomain(
 {
     TRACE("CSharedMemoryObject::GetObjectDomain(this = %p)\n", this);
     LOGEXIT("CSharedMemoryObject::GetObjectDomain returns %d\n", m_ObjectDomain);
-    
+
     return m_ObjectDomain;
 }
 
@@ -1105,7 +1105,7 @@ CSharedMemoryObject::GetObjectSynchData(
     )
 {
     _ASSERTE(NULL != ppvSynchData);
-    
+
     //
     // This is not a waitable object!!!
     //
@@ -1163,7 +1163,7 @@ CSharedMemoryWaitableObject::Initialize(
         );
 
     if (NO_ERROR == palError && SharedObject == m_ObjectDomain)
-    {        
+    {
         SHMObjData *pshmod = SHMPTR_TO_TYPED_PTR(SHMObjData, m_shmod);
         _ASSERTE(NULL != pshmod);
 
@@ -1207,7 +1207,7 @@ CSharedMemoryWaitableObject::EnsureObjectIsShared(
         this,
         pthr
         );
-    
+
     //
     // First, grab the process synchronization lock and check
     // if the object is already shared
@@ -1286,7 +1286,7 @@ EnsureObjectIsSharedExitNoSHMLockRelease:
         // need to continue to hold the promotion locks when
         // freeing the allocated data on error
         //
-        
+
         FreeSharedDataAreas(shmObjData);
     }
 
@@ -1310,13 +1310,13 @@ CSharedMemoryWaitableObject::~CSharedMemoryWaitableObject()
         "(this = %p)\n",
         this
         );
-    
+
     if (!m_fSharedDataDereferenced)
     {
         ASSERT("DereferenceSharedData not called before object destructor -- delete called directly?\n");
         DereferenceSharedData();
     }
-    
+
     if (NULL != m_pvSynchData && m_fDeleteSharedData)
     {
         g_pSynchronizationManager->FreeObjectSynchData(
@@ -1365,7 +1365,7 @@ CSharedMemoryWaitableObject::GetSynchStateController(
     //
 
     g_pSynchronizationManager->AcquireProcessLock(pthr);
-    
+
     palError = g_pSynchronizationManager->CreateSynchStateController(
         pthr,
         m_pot,
@@ -1454,19 +1454,18 @@ CSharedMemoryWaitableObject::GetObjectSynchData(
     )
 {
     _ASSERTE(NULL != ppvSynchData);
-    
+
     ENTRY("CSharedMemoryWaitableObject::GetObjectSynchData"
         "(this = %p, ppvSynchData = %p)\n",
         this,
         ppvSynchData
         );
-    
+
     *ppvSynchData = m_pvSynchData;
 
     LOGEXIT("CSharedMemoryWaitableObject::GetObjectSynchData returns %d\n",
         NO_ERROR
         );
-    
+
     return NO_ERROR;
 }
-

--- a/pal/src/objmgr/shmobject.hpp
+++ b/pal/src/objmgr/shmobject.hpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -61,7 +61,7 @@ namespace CorUnix
         SHMPTR shmPrevObj;
         SHMPTR shmNextObj;
         BOOL fAddedToList;
-        
+
         SHMPTR shmObjName;
         SHMPTR shmObjImmutableData;
         SHMPTR shmObjSharedData;
@@ -77,7 +77,7 @@ namespace CorUnix
     class CSharedMemoryObject : public CPalObjectBase
     {
         template <class T> friend void InternalDelete(T *p);
-        
+
     protected:
 
         //
@@ -96,7 +96,7 @@ namespace CorUnix
         // The SHMObjData for this object, protected by the
         // shared memory lock.
         //
-        
+
         SHMPTR m_shmod;
 
         //
@@ -108,14 +108,14 @@ namespace CorUnix
         //
 
         VOID *m_pvSharedData;
-        
+
         CSimpleSharedMemoryLock m_ssmlSharedData;
         CSimpleDataLock m_sdlSharedData;
 
         //
         // Is this object process local or shared?
         //
-        
+
         ObjectDomain m_ObjectDomain;
 
         //
@@ -163,7 +163,7 @@ namespace CorUnix
             CPalThread *pthr,
             bool fDestructionPending
             );
-        
+
         virtual ~CSharedMemoryObject();
 
     public:
@@ -270,7 +270,7 @@ namespace CorUnix
         //
         // IPalObject routines
         //
-        
+
         virtual
         PAL_ERROR
         GetSharedData(
@@ -311,13 +311,13 @@ namespace CorUnix
     class CSharedMemoryWaitableObject : public CSharedMemoryObject
     {
         template <class T> friend void InternalDelete(T *p);
-        
+
     protected:
 
         VOID *m_pvSynchData;
 
         virtual ~CSharedMemoryWaitableObject();
-        
+
     public:
 
         CSharedMemoryWaitableObject(
@@ -389,4 +389,3 @@ namespace CorUnix
 }
 
 #endif // _PAL_SHMOBJECT_HPP
-

--- a/pal/src/objmgr/shmobjectmanager.cpp
+++ b/pal/src/objmgr/shmobjectmanager.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -60,7 +60,7 @@ CSharedMemoryObjectManager::Initialize(
     PAL_ERROR palError = NO_ERROR;
 
     ENTRY("CSharedMemoryObjectManager::Initialize (this=%p)\n", this);
-    
+
     InitializeListHead(&m_leNamedObjects);
     InitializeListHead(&m_leAnonymousObjects);
 
@@ -70,7 +70,7 @@ CSharedMemoryObjectManager::Initialize(
     palError = m_HandleManager.Initialize();
 
     LOGEXIT("CSharedMemoryObjectManager::Initialize returns %d", palError);
-    
+
     return palError;
 }
 
@@ -95,7 +95,7 @@ CSharedMemoryObjectManager::Shutdown(
     CSharedMemoryObject *pshmobj;
 
     _ASSERTE(NULL != pthr);
-    
+
     ENTRY("CSharedMemoryObjectManager::Shutdown (this=%p, pthr=%p)\n",
         this,
         pthr
@@ -122,7 +122,7 @@ CSharedMemoryObjectManager::Shutdown(
     InternalLeaveCriticalSection(pthr, &m_csListLock);
 
     LOGEXIT("CSharedMemoryObjectManager::Shutdown returns %d\n", NO_ERROR);
-    
+
     return NO_ERROR;
 }
 
@@ -263,7 +263,7 @@ CSharedMemoryObjectManager::RegisterObject(
 
     potObj = pobjToRegister->GetObjectType();
     fShared = (SharedObject == pshmobj->GetObjectDomain());
-    
+
     InternalEnterCriticalSection(pthr, &m_csListLock);
 
     if (fShared)
@@ -272,7 +272,7 @@ CSharedMemoryObjectManager::RegisterObject(
         // We only need to acquire the shared memory lock if this
         // object is actually shared.
         //
-        
+
         SHMLock();
     }
 
@@ -285,7 +285,7 @@ CSharedMemoryObjectManager::RegisterObject(
         //
 
         _ASSERTE(fShared);
-        
+
         //
         // Check if an object by this name alredy exists
         //
@@ -308,7 +308,7 @@ CSharedMemoryObjectManager::RegisterObject(
                 pobjExisting,
                 dwRightsRequested,
                 fInherit,
-                NULL, 
+                NULL,
                 pHandle
                 );
 
@@ -356,7 +356,7 @@ CSharedMemoryObjectManager::RegisterObject(
         if (SHMNULL != shmObjectListHead)
         {
             SHMObjData *psmodListHead;
-            
+
             psmodListHead = SHMPTR_TO_TYPED_PTR(SHMObjData, shmObjectListHead);
             if (NULL != psmodListHead)
             {
@@ -411,7 +411,7 @@ CSharedMemoryObjectManager::RegisterObject(
         {
             VOID *pvSharedImmutableData =
                 SHMPTR_TO_TYPED_PTR(VOID, psmod->shmObjImmutableData);
-            
+
             if (NULL != pvSharedImmutableData)
             {
                 CopyMemory(
@@ -444,7 +444,7 @@ CSharedMemoryObjectManager::RegisterObject(
         pobjToRegister,
         dwRightsRequested,
         fInherit,
-        NULL, 
+        NULL,
         pHandle
         );
 
@@ -457,14 +457,14 @@ CSharedMemoryObjectManager::RegisterObject(
         *ppobjRegistered = pobjToRegister;
         pobjToRegister = NULL;
     }
-        
+
 RegisterObjectExit:
 
     if (fShared)
     {
         SHMRelease();
     }
-    
+
     InternalLeaveCriticalSection(pthr, &m_csListLock);
 
     if (NULL != pobjToRegister)
@@ -561,8 +561,8 @@ CSharedMemoryObjectManager::LocateObject(
         //
 
         pobjExisting = static_cast<IPalObject*>(pshmobj);
-        break;        
-    } 
+        break;
+    }
 
     if (NULL != pobjExisting)
     {
@@ -575,7 +575,7 @@ CSharedMemoryObjectManager::LocateObject(
                 ))
         {
             TRACE("Local object exists with compatible type\n");
-            
+
             //
             // Add a reference to the found object
             //
@@ -585,19 +585,19 @@ CSharedMemoryObjectManager::LocateObject(
         }
         else
         {
-            TRACE("Local object exists w/ incompatible type\n");            
+            TRACE("Local object exists w/ incompatible type\n");
             palError = ERROR_INVALID_HANDLE;
         }
-        
+
         goto LocateObjectExit;
     }
 
     //
     // Search the shared memory named object list for a matching object
     //
-    
+
     SHMLock();
-    
+
     shmObjectListEntry = SHMGetInfo(SIID_NAMED_OBJECTS);
     while (SHMNULL != shmObjectListEntry)
     {
@@ -623,7 +623,7 @@ CSharedMemoryObjectManager::LocateObject(
                 {
                     ASSERT("Unable to map psmod->shmObjName\n");
                     break;
-                }                
+                }
             }
 
             shmObjectListEntry = psmod->shmNextObj;
@@ -650,11 +650,11 @@ CSharedMemoryObjectManager::LocateObject(
             palError = ERROR_INVALID_HANDLE;
             goto LocateObjectExitSHMRelease;
         }
-        
+
         //
         // Get the local instance of the CObjectType
         //
-        
+
         CObjectType *pot = CObjectType::GetObjectTypeById(psmod->eTypeId);
         if (NULL == pot)
         {
@@ -663,7 +663,7 @@ CSharedMemoryObjectManager::LocateObject(
         }
 
         TRACE("Remote object exists compatible type -- importing\n");
-        
+
         //
         // Create the local state for the shared object
         //
@@ -679,7 +679,7 @@ CSharedMemoryObjectManager::LocateObject(
             );
 
         if (NO_ERROR == palError)
-        {   
+        {
             *ppobj = static_cast<IPalObject*>(pshmobj);
         }
         else
@@ -687,7 +687,7 @@ CSharedMemoryObjectManager::LocateObject(
             ERROR("Failure initializing object from shared data\n");
             goto LocateObjectExitSHMRelease;
         }
-        
+
     }
     else
     {
@@ -728,7 +728,7 @@ Parameters:
   pNewHandle -- on success, receives the newly allocated handle
 --*/
 
-PAL_ERROR   
+PAL_ERROR
 CSharedMemoryObjectManager::ObtainHandleForObject(
     CPalThread *pthr,
     IPalObject *pobj,
@@ -776,7 +776,7 @@ CSharedMemoryObjectManager::ObtainHandleForObject(
 
     LOGEXIT("CSharedMemoryObjectManager::ObtainHandleForObject return %d\n", palError);
 
-    return palError;    
+    return palError;
 }
 
 /*++
@@ -807,7 +807,7 @@ CSharedMemoryObjectManager::RevokeHandle(
         pthr,
         hHandleToRevoke
         );
-    
+
     palError = m_HandleManager.FreeHandle(pthr, hHandleToRevoke);
 
     LOGEXIT("CSharedMemoryObjectManager::RevokeHandle returns %d\n", palError);
@@ -892,7 +892,7 @@ CSharedMemoryObjectManager::ReferenceObjectByHandle(
         palError
         );
 
-    return palError;    
+    return palError;
 }
 
 /*++
@@ -949,7 +949,7 @@ CSharedMemoryObjectManager::ReferenceMultipleObjectsByHandleArray(
     m_HandleManager.Lock(pthr);
 
     for (dw = 0; dw < dwHandleCount; dw += 1)
-    {        
+    {
         palError = m_HandleManager.GetObjectFromHandle(
             pthr,
             rghHandlesToReference[dw],
@@ -998,7 +998,7 @@ CSharedMemoryObjectManager::ReferenceMultipleObjectsByHandleArray(
         // dw's current value is the failing index, so we want
         // to free from dw - 1.
         //
-        
+
         while (dw > 0)
         {
             rgpobjs[--dw]->ReleaseReference(pthr);
@@ -1110,7 +1110,7 @@ CSharedMemoryObjectManager::ImportSharedObjectIntoProcess(
         fAddRefSharedData,
         ppshmobj
         );
-    
+
     if (CObjectType::WaitableObject == pot->GetSynchronizationSupport())
     {
         pshmobj = InternalNew<CSharedMemoryWaitableObject>(pot,
@@ -1141,7 +1141,7 @@ CSharedMemoryObjectManager::ImportSharedObjectIntoProcess(
             {
                 pleObjectList = &m_leAnonymousObjects;
             }
-            
+
             InsertTailList(pleObjectList, pshmobj->GetObjectListLink());
         }
         else
@@ -1167,7 +1167,7 @@ ImportSharedObjectIntoProcessExit:
 
 static PalObjectTypeId RemotableObjectTypes[] =
     {otiManualResetEvent, otiAutoResetEvent, otiMutex, otiProcess};
-    
+
 static CAllowedObjectTypes aotRemotable PAL_GLOBAL (
     RemotableObjectTypes,
     sizeof(RemotableObjectTypes) / sizeof(RemotableObjectTypes[0])
@@ -1241,7 +1241,7 @@ PAL_LocalHandleToRemote(IN HANDLE hLocal)
     }
 
     SHMLock();
-    
+
     psmod = SHMPTR_TO_TYPED_PTR(SHMObjData, pshmobj->GetShmObjData());
     if (NULL != psmod)
     {
@@ -1250,7 +1250,7 @@ PAL_LocalHandleToRemote(IN HANDLE hLocal)
         // increase the ref count when it converts the remote handle to
         // local.
         //
-        
+
         psmod->lProcessRefCount += 1;
 
         //
@@ -1281,7 +1281,7 @@ PAL_LocalHandleToRemoteExitNoLockRelease:
     {
         pthr->SetLastError(palError);
     }
-    
+
     LOGEXIT("PAL_LocalHandleToRemote returns RHANDLE 0x%lx\n", hRemote);
     PERF_EXIT(PAL_LocalHandleToRemote);
     return hRemote;
@@ -1370,7 +1370,7 @@ CSharedMemoryObjectManager::ConvertRemoteHandleToLocal(
             && reinterpret_cast<SHMPTR>(rhRemote) == pshmobj->GetShmObjData())
         {
             TRACE("Object for remote handle already present in this process\n");
-            
+
             //
             // PAL_LocalHandleToRemote bumped up the process refcount on the
             // object. Since this process already had a reference to the object
@@ -1397,18 +1397,18 @@ CSharedMemoryObjectManager::ConvertRemoteHandleToLocal(
     {
         CObjectType *pot;
         CObjectAttributes oa;
-        
+
         //
         // Get the local instance of the CObjectType
         //
-        
+
         pot = CObjectType::GetObjectTypeById(psmod->eTypeId);
         if (NULL == pot)
         {
             ASSERT("Invalid object type ID in shared memory info\n");
             goto ConvertRemoteHandleToLocalExit;
         }
-        
+
         //
         // Create the local state for the shared object
         //
@@ -1426,7 +1426,7 @@ CSharedMemoryObjectManager::ConvertRemoteHandleToLocal(
         if (NO_ERROR != palError)
         {
             goto ConvertRemoteHandleToLocalExit;
-        }        
+        }
     }
 
     //
@@ -1441,7 +1441,7 @@ CSharedMemoryObjectManager::ConvertRemoteHandleToLocal(
         NULL,
         phLocal
         );
-        
+
 ConvertRemoteHandleToLocalExit:
 
     SHMRelease();
@@ -1496,7 +1496,7 @@ PAL_RemoteHandleToLocal(IN RHANDLE rhRemote)
     {
         pthr->SetLastError(palError);
     }
-    
+
     LOGEXIT("PAL_RemoteHandleToLocal returns HANDLE 0x%lx\n", hLocal);
     PERF_EXIT(PAL_RemoteHandleToLocal);
     return hLocal;
@@ -1548,7 +1548,7 @@ CheckObjectTypeAndRights(
         // This is where the access right check would occur if Win32 object
         // security were supported.
         //
-        
+
         if ((dwRightsRequired & dwRightsGranted) != dwRightsRequired)
         {
             palError = ERROR_ACCESS_DENIED;
@@ -1564,5 +1564,3 @@ CheckObjectTypeAndRights(
 
     return palError;
 }
-    
-

--- a/pal/src/objmgr/shmobjectmanager.hpp
+++ b/pal/src/objmgr/shmobjectmanager.hpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -23,7 +23,7 @@ Abstract:
 
 #include "pal/corunix.hpp"
 #include "pal/handlemgr.hpp"
-#include "pal/list.h"    
+#include "pal/list.h"
 #include "shmobject.hpp"
 
 namespace CorUnix
@@ -36,7 +36,7 @@ namespace CorUnix
         bool m_fListLockInitialized;
         LIST_ENTRY m_leNamedObjects;
         LIST_ENTRY m_leAnonymousObjects;
-        
+
         CSimpleHandleManager m_HandleManager;
 
         PAL_ERROR
@@ -49,7 +49,7 @@ namespace CorUnix
             bool fAddRefSharedData,
             CSharedMemoryObject **ppshmobj
             );
-        
+
     public:
 
         CSharedMemoryObjectManager()
@@ -82,7 +82,7 @@ namespace CorUnix
         //
         // IPalObjectManager routines
         //
-        
+
         virtual
         PAL_ERROR
         AllocateObject(
@@ -103,7 +103,7 @@ namespace CorUnix
             IPalObject **ppobjRegistered
             );
 
-        virtual            
+        virtual
         PAL_ERROR
         LocateObject(
             CPalThread *pthr,
@@ -113,7 +113,7 @@ namespace CorUnix
             );
 
         virtual
-        PAL_ERROR   
+        PAL_ERROR
         ObtainHandleForObject(
             CPalThread *pthr,
             IPalObject *pobj,
@@ -165,4 +165,3 @@ namespace CorUnix
 }
 
 #endif // _PAL_SHMOBJECTMANAGER_HPP_
-

--- a/pal/src/safecrt/cruntime.h
+++ b/pal/src/safecrt/cruntime.h
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /***

--- a/pal/src/safecrt/input.inl
+++ b/pal/src/safecrt/input.inl
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /***
@@ -165,7 +165,7 @@ static int __check_float_string(size_t nFloatStrUsed,
         }
 
         newSize = *pnFloatStrSz * 2 * sizeof(_TCHAR);
-        
+
         if ((*pFloatStr)==floatstring)
         {
             if (((*pFloatStr)=(_TCHAR *)_malloc_crt(newSize))==NULL)
@@ -262,7 +262,7 @@ static int __check_float_string(size_t nFloatStrUsed,
     char *table = AsciiTable;
 #endif  /* ALLOC_TABLE */
 
-#if _INTEGRAL_MAX_BITS >= 64   
+#if _INTEGRAL_MAX_BITS >= 64
     __uint64_t num64 = 0LL;             /* temp for 64-bit integers          */
 #endif  /* _INTEGRAL_MAX_BITS >= 64    */
     void *pointer=NULL;                 /* points to user data receptacle    */
@@ -293,7 +293,7 @@ static int __check_float_string(size_t nFloatStrUsed,
 
     char done_flag;                     /* general purpose loop monitor      */
     char longone;                       /* 0 = SHORT, 1 = LONG, 2 = L_DOUBLE */
-#if _INTEGRAL_MAX_BITS >= 64   
+#if _INTEGRAL_MAX_BITS >= 64
     int integer64;                      /* 1 for 64-bit integer, 0 otherwise */
 #endif  /* _INTEGRAL_MAX_BITS >= 64    */
     signed char widechar;               /* -1 = char, 0 = ????, 1 = wchar_t  */
@@ -360,7 +360,7 @@ static int __check_float_string(size_t nFloatStrUsed,
 
             longone = 1;
 
-#if _INTEGRAL_MAX_BITS >= 64   
+#if _INTEGRAL_MAX_BITS >= 64
             integer64 = 0;
 #endif  /* _INTEGRAL_MAX_BITS >= 64    */
 
@@ -381,7 +381,7 @@ static int __check_float_string(size_t nFloatStrUsed,
                             --widechar;         /* set widechar = -1 */
                             break;
 
-#if _INTEGRAL_MAX_BITS >= 64   
+#if _INTEGRAL_MAX_BITS >= 64
                         case _T('I'):
                             if ( (*(format + 1) == _T('6')) &&
                                  (*(format + 2) == _T('4')) )
@@ -890,7 +890,7 @@ d_incwidth:
                         }
 
 getnum:
-#if _INTEGRAL_MAX_BITS >= 64   
+#if _INTEGRAL_MAX_BITS >= 64
                         if ( integer64 ) {
 
                             while (!done_flag) {
@@ -976,7 +976,7 @@ getnum:
 
                             if (negative)
                                 number = (unsigned long)(-(long)number);
-#if _INTEGRAL_MAX_BITS >= 64   
+#if _INTEGRAL_MAX_BITS >= 64
                         }
 #endif  /* _INTEGRAL_MAX_BITS >= 64    */
                         if (_T('F')==comchr) /* expected ':' in long pointer */
@@ -987,7 +987,7 @@ getnum:
 
                                 ++count;
 assign_num:
-#if _INTEGRAL_MAX_BITS >= 64   
+#if _INTEGRAL_MAX_BITS >= 64
                                 if ( integer64 )
                                     *(__int64 UNALIGNED *)pointer = ( __uint64_t )num64;
                                 else
@@ -1053,7 +1053,7 @@ f_incwidth:
                         decimal = L'.';
                         _MBTOWC(&decimal, _INTRN_LOCALE_CONV(_loc_update)->decimal_point, MB_CUR_MAX);
 #else  /* _UNICODE */
-                       
+
                         decimal=*((_INTRN_LOCALE_CONV(_loc_update))->decimal_point);
 #endif  /* _UNICODE */
 
@@ -1317,4 +1317,3 @@ static int __cdecl _whiteout(int* counter, miniFILE* fileptr)
 }
 
 #endif  /* CPRFLAG */
-

--- a/pal/src/safecrt/internal.h
+++ b/pal/src/safecrt/internal.h
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /***

--- a/pal/src/safecrt/internal_securecrt.h
+++ b/pal/src/safecrt/internal_securecrt.h
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /***
@@ -33,7 +33,7 @@
 #define __in_z
 #define __in
 
-/* 
+/*
  * The original SafeCRT implemention allows runtine control over buffer checking.
  * For now we'll key this off the debug flag.
  */

--- a/pal/src/safecrt/makepath_s.c
+++ b/pal/src/safecrt/makepath_s.c
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /***

--- a/pal/src/safecrt/mbusafecrt.c
+++ b/pal/src/safecrt/mbusafecrt.c
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /***
@@ -134,14 +134,14 @@ int _ungetc_nolock( char inChar, miniFILE* inStream )
 int _ungetwc_nolock( wchar_t inChar, miniFILE* inStream )
 {
     int returnValue = WEOF;
-    
+
     if ( ( size_t )( ( inStream->_ptr ) - ( inStream->_base ) ) >= ( sizeof( wchar_t ) ) )
     {
         inStream->_cnt += sizeof( wchar_t );
         inStream->_ptr -= sizeof( wchar_t );
         returnValue = ( unsigned short )inChar;
     }
-    
+
     return returnValue;
 }
 
@@ -225,10 +225,10 @@ void _safecrt_wfassign(int flag, void* argument, wchar_t* number )
     // without using any system functions. To do this,
     // we'll assume that the numbers are in the 0-9 range and
     // do a simple conversion.
-    
+
     char* numberAsChars = ( char* )number;
     int position = 0;
-    
+
     // do the convert
     while ( number[ position ] != 0 )
     {
@@ -236,7 +236,7 @@ void _safecrt_wfassign(int flag, void* argument, wchar_t* number )
         position++;
     }
     numberAsChars[ position ] = ( char )( number[ position ] & 0x00FF );
-    
+
     // call the normal char version
     _safecrt_fassign( flag, argument, numberAsChars );
 }
@@ -251,5 +251,3 @@ int _minimal_chartowchar( wchar_t* outWChar, const char* inChar )
     *outWChar = ( wchar_t )( ( unsigned short )( ( unsigned char )( *inChar ) ) );
     return 1;
 }
-
-

--- a/pal/src/safecrt/mbusafecrt_internal.h
+++ b/pal/src/safecrt/mbusafecrt_internal.h
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /***

--- a/pal/src/safecrt/memcpy_s.c
+++ b/pal/src/safecrt/memcpy_s.c
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /***

--- a/pal/src/safecrt/memmove_s.c
+++ b/pal/src/safecrt/memmove_s.c
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /***

--- a/pal/src/safecrt/output.inl
+++ b/pal/src/safecrt/output.inl
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /***
@@ -568,7 +568,7 @@ __inline long __cdecl get_long_arg(va_list *pargptr);
 __inline long long __cdecl get_long_long_arg(va_list *pargptr);
 #endif  /* !LONGLONG_IS_INT64 */
 
-#if _INTEGRAL_MAX_BITS >= 64   
+#if _INTEGRAL_MAX_BITS >= 64
 __inline __int64 __cdecl get_int64_arg(va_list *pargptr);
 #endif  /* _INTEGRAL_MAX_BITS >= 64    */
 
@@ -1256,7 +1256,7 @@ int __cdecl _output (
                 /* correct radix, setting text and textlen */
                 /* appropriately. */
 
-#if _INTEGRAL_MAX_BITS >= 64       
+#if _INTEGRAL_MAX_BITS >= 64
                 __uint64_t number;    /* number to convert */
                 int digit;              /* ascii value of digit */
                 __int64 l;              /* temp long value */
@@ -1267,7 +1267,7 @@ int __cdecl _output (
 #endif  /* _INTEGRAL_MAX_BITS >= 64        */
 
                 /* 1. read argument into l, sign extend as needed */
-#if _INTEGRAL_MAX_BITS >= 64       
+#if _INTEGRAL_MAX_BITS >= 64
                 if (flags & FL_I64)
                     l = get_int64_arg(&argptr);
                 else
@@ -1308,7 +1308,7 @@ int __cdecl _output (
                     number = l;
                 }
 
-#if _INTEGRAL_MAX_BITS >= 64       
+#if _INTEGRAL_MAX_BITS >= 64
                 if ( (flags & FL_I64) == 0 && (flags & FL_LONGLONG) == 0 ) {
                     /*
                      * Unless printing a full 64-bit value, insure values
@@ -1358,7 +1358,7 @@ int __cdecl _output (
                     *--sz = '0';
                     ++textlen;      /* add a zero */
                 }
-                
+
                 text.sz = sz;
             }
             break;
@@ -1725,7 +1725,7 @@ __inline long long __cdecl get_long_long_arg (
 }
 #endif  /* !LONGLONG_IS_INT64 */
 
-#if _INTEGRAL_MAX_BITS >= 64   
+#if _INTEGRAL_MAX_BITS >= 64
 __inline __int64 __cdecl get_int64_arg (
     va_list *pargptr
     )
@@ -1739,4 +1739,3 @@ __inline __int64 __cdecl get_int64_arg (
 #endif  /* _UNICODE */
 
 #endif // __GNUC_VA_LIST
-

--- a/pal/src/safecrt/safecrt_input_s.c
+++ b/pal/src/safecrt/safecrt_input_s.c
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /***

--- a/pal/src/safecrt/safecrt_output_l.c
+++ b/pal/src/safecrt/safecrt_output_l.c
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /***
@@ -46,9 +46,9 @@ Buffer size required to be passed to _gcvt, fcvt and other fp conversion routine
 
 //------------------------------------------------------------------------------
 // This code was taken from the 'ouput.c' file located in Visual Studio 8 (i.e. 2005)
-// in the '\Microsoft Visual Studio 8\VC\crt\src' directory. It was moved into 
+// in the '\Microsoft Visual Studio 8\VC\crt\src' directory. It was moved into
 // this file to support only the '_output' function used by _vscprintf() in vsprintf.c
-// UNUSED / NON-RELEVANT PORTIONS OF THE CODE HAVE BEEN REMOVED - do not try and 
+// UNUSED / NON-RELEVANT PORTIONS OF THE CODE HAVE BEEN REMOVED - do not try and
 // use it to generate any other safecrt 'output' functions
 //
 // Noteable modifications
@@ -358,7 +358,7 @@ const char __lookuptable[] = {
 
 #else  /* FORMAT_VALIDATIONS */
 // SNIP -srs 7/3/07
-#error code has been removed 
+#error code has been removed
 #endif  /* FORMAT_VALIDATIONS */
 
 #define FIND_CHAR_CLASS(lookuptbl, c)      \
@@ -430,7 +430,7 @@ __inline long __cdecl get_long_arg(va_list *pargptr);
 __inline long long __cdecl get_long_long_arg(va_list *pargptr);
 #endif  /* !LONGLONG_IS_INT64 */
 
-#if _INTEGRAL_MAX_BITS >= 64   
+#if _INTEGRAL_MAX_BITS >= 64
 __inline __int64 __cdecl get_int64_arg(va_list *pargptr);
 #endif  /* _INTEGRAL_MAX_BITS >= 64    */
 
@@ -1117,7 +1117,7 @@ int __cdecl _output (
                 /* correct radix, setting text and textlen */
                 /* appropriately. */
 
-#if _INTEGRAL_MAX_BITS >= 64       
+#if _INTEGRAL_MAX_BITS >= 64
 //                unsigned __int64 number;    /* number to convert */
                 __uint64_t number;      /* number to convert */
                 int digit;              /* ascii value of digit */
@@ -1129,7 +1129,7 @@ int __cdecl _output (
 #endif  /* _INTEGRAL_MAX_BITS >= 64        */
 
                 /* 1. read argument into l, sign extend as needed */
-#if _INTEGRAL_MAX_BITS >= 64       
+#if _INTEGRAL_MAX_BITS >= 64
                 if (flags & FL_I64)
                     l = get_int64_arg(&argptr);
                 else
@@ -1170,7 +1170,7 @@ int __cdecl _output (
                     number = l;
                 }
 
-#if _INTEGRAL_MAX_BITS >= 64       
+#if _INTEGRAL_MAX_BITS >= 64
                 if ( (flags & FL_I64) == 0 && (flags & FL_LONGLONG) == 0 ) {
                     /*
                      * Unless printing a full 64-bit value, insure values
@@ -1220,7 +1220,7 @@ int __cdecl _output (
                     *--sz = '0';
                     ++textlen;      /* add a zero */
                 }
-                
+
                 text.sz = sz;
             }
             break;
@@ -1587,7 +1587,7 @@ __inline long long __cdecl get_long_long_arg (
 }
 #endif  /* !LONGLONG_IS_INT64 */
 
-#if _INTEGRAL_MAX_BITS >= 64   
+#if _INTEGRAL_MAX_BITS >= 64
 __inline __int64 __cdecl get_int64_arg (
     va_list *pargptr
     )
@@ -1626,4 +1626,3 @@ __inline short __cdecl get_short_arg (
 #endif  /* _UNICODE */
 
 #endif // __GNUC_VA_LIST
-

--- a/pal/src/safecrt/safecrt_output_s.c
+++ b/pal/src/safecrt/safecrt_output_s.c
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /***

--- a/pal/src/safecrt/safecrt_winput_s.c
+++ b/pal/src/safecrt/safecrt_winput_s.c
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /***
@@ -53,4 +53,3 @@ typedef wchar_t         _TUCHAR;
 #define _ungettc_nolock(x,y)    _ungetwc_nolock(x,y)
 
 #include "input.inl"
-

--- a/pal/src/safecrt/safecrt_woutput_s.c
+++ b/pal/src/safecrt/safecrt_woutput_s.c
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /***
@@ -56,4 +56,3 @@ typedef wchar_t     TCHAR;
 #define _T(x)       L##x
 
 #include "output.inl"
-

--- a/pal/src/safecrt/snprintf.c
+++ b/pal/src/safecrt/snprintf.c
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /***

--- a/pal/src/safecrt/splitpath_s.c
+++ b/pal/src/safecrt/splitpath_s.c
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /***

--- a/pal/src/safecrt/sprintf.c
+++ b/pal/src/safecrt/sprintf.c
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /***

--- a/pal/src/safecrt/sscanf.c
+++ b/pal/src/safecrt/sscanf.c
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /***
@@ -247,4 +247,3 @@ int __cdecl _snwscanf_s (
         va_end(arglist);
         return ret;
 }
-

--- a/pal/src/safecrt/strcat_s.c
+++ b/pal/src/safecrt/strcat_s.c
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /***

--- a/pal/src/safecrt/strcpy_s.c
+++ b/pal/src/safecrt/strcpy_s.c
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /***

--- a/pal/src/safecrt/strlen_s.c
+++ b/pal/src/safecrt/strlen_s.c
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /***
@@ -56,4 +56,3 @@ size_t __cdecl strnlen(const char *str, size_t maxsize)
 
     return n;
 }
-

--- a/pal/src/safecrt/strncat_s.c
+++ b/pal/src/safecrt/strncat_s.c
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /***

--- a/pal/src/safecrt/strncpy_s.c
+++ b/pal/src/safecrt/strncpy_s.c
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /***

--- a/pal/src/safecrt/strtok_s.c
+++ b/pal/src/safecrt/strtok_s.c
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /***

--- a/pal/src/safecrt/swprintf.c
+++ b/pal/src/safecrt/swprintf.c
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /***

--- a/pal/src/safecrt/tcscat_s.inl
+++ b/pal/src/safecrt/tcscat_s.inl
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /***
@@ -49,4 +49,3 @@ errno_t __cdecl _FUNC_NAME(_CHAR *_DEST, size_t _SIZE, const _CHAR *_SRC)
     _FILL_STRING(_DEST, _SIZE, _SIZE - available + 1);
     _RETURN_NO_ERROR;
 }
-

--- a/pal/src/safecrt/tcscpy_s.inl
+++ b/pal/src/safecrt/tcscpy_s.inl
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /***
@@ -37,4 +37,3 @@ errno_t __cdecl _FUNC_NAME(_CHAR *_DEST, size_t _SIZE, const _CHAR *_SRC)
     _FILL_STRING(_DEST, _SIZE, _SIZE - available + 1);
     _RETURN_NO_ERROR;
 }
-

--- a/pal/src/safecrt/tcsncat_s.inl
+++ b/pal/src/safecrt/tcsncat_s.inl
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /***
@@ -79,4 +79,3 @@ errno_t __cdecl _FUNC_NAME(_CHAR *_DEST, size_t _SIZE, const _CHAR *_SRC, size_t
     _FILL_STRING(_DEST, _SIZE, _SIZE - available + 1);
     _RETURN_NO_ERROR;
 }
-

--- a/pal/src/safecrt/tcsncpy_s.inl
+++ b/pal/src/safecrt/tcsncpy_s.inl
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /***
@@ -69,4 +69,3 @@ errno_t __cdecl _FUNC_NAME(_CHAR *_DEST, size_t _SIZE, const _CHAR *_SRC, size_t
     _FILL_STRING(_DEST, _SIZE, _SIZE - available + 1);
     _RETURN_NO_ERROR;
 }
-

--- a/pal/src/safecrt/tcstok_s.inl
+++ b/pal/src/safecrt/tcstok_s.inl
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /***

--- a/pal/src/safecrt/tmakepath_s.inl
+++ b/pal/src/safecrt/tmakepath_s.inl
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /***

--- a/pal/src/safecrt/tsplitpath_s.inl
+++ b/pal/src/safecrt/tsplitpath_s.inl
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /***
@@ -28,7 +28,7 @@ errno_t __cdecl _FUNC_NAME(
     int drive_set = 0;
     size_t length = 0;
     int bEinval = 0;
-	
+
     /* validation section */
     if (_Path == NULL)
     {
@@ -139,7 +139,7 @@ errno_t __cdecl _FUNC_NAME(
                 goto error_erange;
             }
             _TCSNCPY_S(_Dir, _DirSize, _Path, length);
-			
+
             // Normalize the path seperator
             int iIndex;
             for(iIndex = 0; iIndex < length; iIndex++)
@@ -185,7 +185,7 @@ errno_t __cdecl _FUNC_NAME(
                 // set length to 1 to get the "." in filename buffer.
                 length = 1;
             }
-			
+
             if (_FilenameSize <= length)
             {
                 goto error_erange;
@@ -201,7 +201,7 @@ errno_t __cdecl _FUNC_NAME(
             // At this time, _Path is pointing to the character after the last slash found.
             // (See comments and code above for clarification).
             //
-            // Returns extension as empty string for strings like "/.". 
+            // Returns extension as empty string for strings like "/.".
             if (dot > _Path)
             {
                 length = (size_t)(tmp - dot);
@@ -209,13 +209,13 @@ errno_t __cdecl _FUNC_NAME(
                 {
                      goto error_erange;
                 }
-                
+
                 /* Since dot pointed to the ".", make sure we actually have an extension
                 like ".cmd" and not just ".", OR
-                
+
                 Confirm that its a string like "/.." - for this, return the
                 second "." in the extension part.
-                
+
                 However, for strings like "/myfile.", return empty string
                 in extension buffer.
                 */

--- a/pal/src/safecrt/vsprintf.c
+++ b/pal/src/safecrt/vsprintf.c
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /***

--- a/pal/src/safecrt/vswprint.c
+++ b/pal/src/safecrt/vswprint.c
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /***

--- a/pal/src/safecrt/wcscat_s.c
+++ b/pal/src/safecrt/wcscat_s.c
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /***

--- a/pal/src/safecrt/wcscpy_s.c
+++ b/pal/src/safecrt/wcscpy_s.c
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /***
@@ -31,4 +31,3 @@
 #define _SRC _Src
 
 #include "tcscpy_s.inl"
-

--- a/pal/src/safecrt/wcslen_s.c
+++ b/pal/src/safecrt/wcslen_s.c
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /***
@@ -56,4 +56,3 @@ size_t __cdecl wcsnlen(const wchar_t *wcs, size_t maxsize)
 
     return n;
 }
-

--- a/pal/src/safecrt/wcsncat_s.c
+++ b/pal/src/safecrt/wcsncat_s.c
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /***
@@ -33,4 +33,3 @@
 #define _COUNT _Count
 
 #include "tcsncat_s.inl"
-

--- a/pal/src/safecrt/wcsncpy_s.c
+++ b/pal/src/safecrt/wcsncpy_s.c
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /***
@@ -32,4 +32,3 @@
 #define _COUNT _Count
 
 #include "tcsncpy_s.inl"
-

--- a/pal/src/safecrt/wcstok_s.c
+++ b/pal/src/safecrt/wcstok_s.c
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /***

--- a/pal/src/safecrt/wmakepath_s.c
+++ b/pal/src/safecrt/wmakepath_s.c
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /***

--- a/pal/src/safecrt/wsplitpath_s.c
+++ b/pal/src/safecrt/wsplitpath_s.c
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /***

--- a/pal/src/safecrt/xtoa_s.c
+++ b/pal/src/safecrt/xtoa_s.c
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /***

--- a/pal/src/safecrt/xtow_s.c
+++ b/pal/src/safecrt/xtow_s.c
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /***

--- a/pal/src/safecrt/xtox_s.inl
+++ b/pal/src/safecrt/xtox_s.inl
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /***

--- a/pal/src/shmemory/shmemory.cpp
+++ b/pal/src/shmemory/shmemory.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -178,7 +178,7 @@ is still alive).
 #if HAVE_YIELD_SYSCALL
 #include <sys/syscall.h>
 #endif  /* HAVE_YIELD_SYSCALL */
-        
+
 SET_DEFAULT_DEBUG_CHANNEL(SHMEM);
 
 /* Macro-definitions **********************************************************/
@@ -347,7 +347,7 @@ memory. Rationale :
  spinlocks, but this would introduce more busy-wait.
 */
 static CRITICAL_SECTION shm_critsec PAL_GLOBAL;
-                        
+
 /* number of segments the current process knows about */
 int shm_numsegments;
 
@@ -360,7 +360,7 @@ SHMLock/SHMRelease pair, this is actually the number of locks held by a single
 thread. */
 static Volatile<LONG> lock_count PAL_GLOBAL;
 
-/* thread ID of thread holding the SHM lock. used for debugging purposes : 
+/* thread ID of thread holding the SHM lock. used for debugging purposes :
    SHMGet/SetInfo will verify that the calling thread holds the lock */
 static Volatile<HANDLE> locking_thread PAL_GLOBAL;
 
@@ -396,7 +396,7 @@ BOOL SHMInitialize(void)
     InternalInitializeCriticalSection(&shm_critsec);
 
     init_waste();
-    
+
         int size;
         SHM_FIRST_HEADER *header;
         SHMPTR pool_start;
@@ -404,7 +404,7 @@ BOOL SHMInitialize(void)
         enum SHM_POOL_SIZES sps;
 
         TRACE("Now initializing global shared memory system\n");
-        
+
         // Not really shared in CoreCLR; we don't try to talk to other CoreCLRs.
         shm_segment_bases[0] = mmap(NULL, segment_size,PROT_READ|PROT_WRITE,
                                     MAP_ANON|MAP_PRIVATE, -1, 0);
@@ -419,17 +419,17 @@ BOOL SHMInitialize(void)
         header = (SHM_FIRST_HEADER *)shm_segment_bases[0].Load();
 
         InterlockedExchange((LONG *)&header->spinlock, 0);
-        
+
 #ifdef TRACK_SHMLOCK_OWNERSHIP
         header->dwHeadCanaries[0] = HeadSignature;
         header->dwHeadCanaries[1] = HeadSignature;
         header->dwTailCanaries[0] = TailSignature;
-        header->dwTailCanaries[1] = TailSignature;        
+        header->dwTailCanaries[1] = TailSignature;
 
         // Check spinlock size
         _ASSERTE(sizeof(DWORD) == sizeof(header->spinlock));
         // Check spinlock alignment
-        _ASSERTE(0 == ((DWORD_PTR)&header->spinlock % (DWORD_PTR)sizeof(void *)));        
+        _ASSERTE(0 == ((DWORD_PTR)&header->spinlock % (DWORD_PTR)sizeof(void *)));
 #endif // TRACK_SHMLOCK_OWNERSHIP
 
 #ifdef TRACK_SHMLOCK_OWNERSHIP
@@ -514,7 +514,7 @@ void SHMCleanup(void)
 
     _ASSERT_MSG(header->spinlock != my_pid,
             "SHMCleanup called while the current process still owns the lock "
-            "[owner thread=%u, current thread: %u]\n", 
+            "[owner thread=%u, current thread: %u]\n",
             locking_thread.Load(), THREADSilentGetCurrentThreadId());
 
     /* Now for the interprocess stuff. */
@@ -525,7 +525,7 @@ void SHMCleanup(void)
     while(shm_numsegments)
     {
         shm_numsegments--;
-        if ( -1 == munmap( shm_segment_bases[ shm_numsegments ], 
+        if ( -1 == munmap( shm_segment_bases[ shm_numsegments ],
                            segment_size ) )
         {
             ASSERT( "munmap() failed; errno is %d (%s).\n",
@@ -632,7 +632,7 @@ SHMPTR SHMalloc(size_t size)
     if(( 0 == header->pools[sps].free_items && 0 != next_free) ||
        ( 0 != header->pools[sps].free_items && 0 == next_free))
     {
-        ASSERT("free block count is %d, but next free block is %#x\n", 
+        ASSERT("free block count is %d, but next free block is %#x\n",
                header->pools[sps].free_items, next_free);
         /* assume all remaining blocks in the pool are corrupt */
         header->pools[sps].first_free = 0;
@@ -771,7 +771,7 @@ int SHMLock(void)
 
     _ASSERTE((0 == lock_count && 0 == locking_thread) ||
              (0 < lock_count && (HANDLE)pthread_self() == locking_thread));
-             
+
     if(lock_count == 0)
     {
         SHM_FIRST_HEADER *header;
@@ -785,12 +785,12 @@ int SHMLock(void)
 
         header = (SHM_FIRST_HEADER *)shm_segment_bases[0].Load();
 
-        // Store the id of the current thread as the (only) one that is 
+        // Store the id of the current thread as the (only) one that is
         // trying to grab the spinlock from the current process
         locking_thread = (HANDLE)pthread_self();
 
         my_pid = gPID;
-        
+
         while(TRUE)
         {
 #ifdef TRACK_SHMLOCK_OWNERSHIP
@@ -812,14 +812,14 @@ int SHMLock(void)
 #ifdef _HPUX_
             //
             // TODO: workaround for VSW # 381564
-            // 
+            //
             if (0 == tmp_pid && my_pid != header->spinlock)
             {
                 ERROR("InterlockedCompareExchange returned the Comperand but "
                       "failed to store the Exchange value to the Destination: "
                       "looping again [my_pid=%u header->spinlock=%u tmp_pid=%u "
-                      "spincount=%d locking_thread=%u]\n", (DWORD)my_pid, 
-                      (DWORD)header->spinlock, (DWORD)tmp_pid, (int)spincount, 
+                      "spincount=%d locking_thread=%u]\n", (DWORD)my_pid,
+                      (DWORD)header->spinlock, (DWORD)tmp_pid, (int)spincount,
                       (HANDLE)locking_thread);
 
                 // Keep looping
@@ -848,14 +848,14 @@ int SHMLock(void)
             }
             else
             {
-                /* another process is holding the lock... we want to yield and 
+                /* another process is holding the lock... we want to yield and
                    give the holder a chance to release the lock
-                   The function sched_yield() only yields to a thread in the 
-                   current process; this doesn't help us much, anddoens't help 
-                   at all if there's only 1 thread. There doesn't seem to be 
-                   any clean way to force a yield to another process, but the 
-                   FreeBSD syscall "yield" does the job. We alternate between 
-                   both methods to give other threads of this process a chance 
+                   The function sched_yield() only yields to a thread in the
+                   current process; this doesn't help us much, anddoens't help
+                   at all if there's only 1 thread. There doesn't seem to be
+                   any clean way to force a yield to another process, but the
+                   FreeBSD syscall "yield" does the job. We alternate between
+                   both methods to give other threads of this process a chance
                    to run while we wait.
                  */
 #if HAVE_YIELD_SYSCALL
@@ -867,8 +867,8 @@ int SHMLock(void)
                 }
                 else
                 {
-                    /* use the syscall first, since we know we'l need to yield 
-                       to another process eventually - the lock can't be held 
+                    /* use the syscall first, since we know we'l need to yield
+                       to another process eventually - the lock can't be held
                        by the current process, thanks to the critical section */
                     syscall(SYS_yield, 0);
                 }
@@ -883,8 +883,8 @@ int SHMLock(void)
             "\n(my_pid = %u) != (header->spinlock = %u)\n"
             "tmp_pid         = %u\n"
             "spincount       = %d\n"
-            "locking_thread  = %u\n", 
-            (DWORD)my_pid, (DWORD)header->spinlock, 
+            "locking_thread  = %u\n",
+            (DWORD)my_pid, (DWORD)header->spinlock,
             (DWORD)tmp_pid,
             (int)spincount,
             (HANDLE)locking_thread);
@@ -896,14 +896,14 @@ int SHMLock(void)
         header->pidtidCurrentOwner.pid = my_pid;
         header->pidtidCurrentOwner.tid = locking_thread;
 
-        ulIdx = header->ulOwnersIdx % (sizeof(header->pidtidOwners) / sizeof(header->pidtidOwners[0])); 
-        
+        ulIdx = header->ulOwnersIdx % (sizeof(header->pidtidOwners) / sizeof(header->pidtidOwners[0]));
+
         header->pidtidOwners[ulIdx].pid = my_pid;
         header->pidtidOwners[ulIdx].tid = locking_thread;
 
         header->ulOwnersIdx += 1;
 #endif // TRACK_SHMLOCK_OWNERSHIP
-        
+
     }
 
     lock_count++;
@@ -948,13 +948,13 @@ int SHMRelease(void)
         TRACE("Releasing first-level SHM lock : resetting spinlock\n");
 
         my_pid = gPID;
-        
+
         header = (SHM_FIRST_HEADER *)shm_segment_bases[0].Load();
 
 #ifdef TRACK_SHMLOCK_OWNERSHIP
         CHECK_CANARIES(header);
         _ASSERTE(0 != my_pid);
-        _ASSERTE(getpid() == my_pid);        
+        _ASSERTE(getpid() == my_pid);
         _ASSERTE(my_pid == header->spinlock);
         _ASSERTE(header->pidtidCurrentOwner.pid == my_pid);
         _ASSERTE(pthread_self() == header->pidtidCurrentOwner.tid);
@@ -967,7 +967,7 @@ int SHMRelease(void)
 
 #ifdef _HPUX_
         //
-        // TODO: workaround for VSW # 381564 
+        // TODO: workaround for VSW # 381564
         //
         do
 #endif // _HPUX_
@@ -1129,7 +1129,7 @@ SHMPTR SHMGetInfo(SHM_INFO_ID element)
         return 0;
     }
 
-    /* verify that this thread holds the SHM lock. No race condition: if the 
+    /* verify that this thread holds the SHM lock. No race condition: if the
        current thread is here, it can't be in SHMLock or SHMUnlock */
     if( (HANDLE)pthread_self() != locking_thread )
     {
@@ -1170,8 +1170,8 @@ BOOL SHMSetInfo(SHM_INFO_ID element, SHMPTR value)
         ASSERT("Invalid SHM info element %d\n", element);
         return FALSE;
     }
-    
-    /* verify that this thread holds the SHM lock. No race condition: if the 
+
+    /* verify that this thread holds the SHM lock. No race condition: if the
        current thread is here, it can't be in SHMLock or SHMUnlock */
     if( (HANDLE)pthread_self() != locking_thread )
     {
@@ -1501,7 +1501,7 @@ SHMPTR SHMStrDup( LPCSTR string )
 
         retVal = SHMalloc( ++length );
 
-        if ( retVal != 0 ) 
+        if ( retVal != 0 )
         {
             LPVOID ptr = SHMPTR_TO_PTR( retVal );
             _ASSERT_MSG(ptr != NULL, "SHMPTR_TO_PTR returned NULL.\n");
@@ -1541,10 +1541,10 @@ SHMPTR SHMWStrDup( LPCWSTR string )
     if ( string )
     {
         length = ( PAL_wcslen( string ) + 1 ) * sizeof( WCHAR );
-        
+
         retVal = SHMalloc( length );
 
-        if ( retVal != 0 ) 
+        if ( retVal != 0 )
         {
             LPVOID ptr = SHMPTR_TO_PTR(retVal);
             _ASSERT_MSG(ptr != NULL, "SHMPTR_TO_PTR returned NULL.\n");
@@ -1593,18 +1593,18 @@ SHMPTR SHMFindNamedObjectByName( LPCWSTR lpName, SHM_NAMED_OBJECTS_ID oid,
         ASSERT("Invalid named object type.\n");
         return 0;
     }
-    
+
     if (pbNameExists == NULL)
     {
         ASSERT("pbNameExists must be non-NULL.\n");
     }
 
     SHMLock();
-    
+
     *pbNameExists = FALSE;
     shmNamedObject = SHMGetInfo( SIID_NAMED_OBJECTS );
-    
-    TRACE( "Entering SHMFindNamedObjectByName looking for %S .\n", 
+
+    TRACE( "Entering SHMFindNamedObjectByName looking for %S .\n",
            lpName?lpName:W16_NULLSTRING );
 
     while ( shmNamedObject )
@@ -1616,13 +1616,13 @@ SHMPTR SHMFindNamedObjectByName( LPCWSTR lpName, SHM_NAMED_OBJECTS_ID oid,
                    "corrupted.\n");
             break;
         }
-        
+
         if ( pNamedObject->ShmObjectName )
         {
             object_name = (LPWSTR)SHMPTR_TO_PTR( pNamedObject->ShmObjectName );
         }
 
-        if ( object_name && 
+        if ( object_name &&
              PAL_wcscmp( lpName, object_name ) == 0 )
         {
             if(oid == pNamedObject->ObjectType)
@@ -1648,7 +1648,7 @@ Exit:
 
 }
 
-/*++ 
+/*++
 SHMRemoveNamedObject
 
 Removes the specified named object from the list
@@ -1665,7 +1665,7 @@ void SHMRemoveNamedObject( SHMPTR shmNamedObject )
     TRACE( "Entered SHMDeleteNamedObject shmNamedObject = %d\n", shmNamedObject );
     SHMLock();
 
-    pshmCurrent = 
+    pshmCurrent =
         (PSHM_NAMED_OBJECTS)SHMPTR_TO_PTR( SHMGetInfo( SIID_NAMED_OBJECTS ) );
     pshmLast = pshmCurrent;
 
@@ -1674,7 +1674,7 @@ void SHMRemoveNamedObject( SHMPTR shmNamedObject )
         if ( pshmCurrent->ShmSelf == shmNamedObject )
         {
             TRACE( "Patching the list.\n" );
-            
+
             /* Patch the list, and delete the object. */
             if ( pshmLast->ShmSelf == pshmCurrent->ShmSelf )
             {
@@ -1690,7 +1690,7 @@ void SHMRemoveNamedObject( SHMPTR shmNamedObject )
                 /* Only one left. */
                 pshmLast->ShmNext = 0;
             }
-            
+
             break;
         }
         else
@@ -1713,18 +1713,18 @@ No return.
 void SHMAddNamedObject( SHMPTR shmNewNamedObject )
 {
     PSHM_NAMED_OBJECTS pshmNew = 0;
-   
+
     pshmNew = (PSHM_NAMED_OBJECTS)SHMPTR_TO_PTR( shmNewNamedObject );
-   
+
     if ( pshmNew == NULL )
     {
         ASSERT( "pshmNew should not be NULL\n" );
     }
- 
+
     SHMLock();
-    
+
     pshmNew->ShmNext = SHMGetInfo( SIID_NAMED_OBJECTS );
-    
+
     if ( !SHMSetInfo( SIID_NAMED_OBJECTS, shmNewNamedObject ) )
     {
         ASSERT( "Unable to add the mapping object to shared memory.\n" );

--- a/pal/src/sync/cs.cpp
+++ b/pal/src/sync/cs.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -27,7 +27,7 @@
 using namespace CorUnix;
 
 //
-// Uncomment the following line to turn CS behavior from 
+// Uncomment the following line to turn CS behavior from
 // unfair to fair lock
 //
 // #define PALCS_TRANSFER_OWNERSHIP_ON_RELEASE
@@ -42,56 +42,56 @@ using namespace CorUnix;
 //
 // Important notes on critical sections layout/semantics on Unix
 //
-// 1) The PAL_CRITICAL_SECTION structure below must match the size of the 
+// 1) The PAL_CRITICAL_SECTION structure below must match the size of the
 //    CRITICAL_SECTION defined in pal.h. Besides the "windows part"
 //    of both the structures must be identical.
-// 2) Both PAL_CRITICAL_SECTION and CRITICAL_SECTION currently do not match 
+// 2) Both PAL_CRITICAL_SECTION and CRITICAL_SECTION currently do not match
 //    the size of the Windows' CRITICAL_SECTION.
-//    - From unmanaged code point of view, one should never make assumptions 
-//      on the size and layout of the CRITICAL_SECTION structure, and anyway 
-//      on Unix PAL's CRITICAL_SECTION extends the  Windows one, so that some 
+//    - From unmanaged code point of view, one should never make assumptions
+//      on the size and layout of the CRITICAL_SECTION structure, and anyway
+//      on Unix PAL's CRITICAL_SECTION extends the  Windows one, so that some
 //      assumptions may still work.
-//    - From managed code point of view, one could try to interop directly 
-//      to unmanaged critical sections APIs (though that would be quite 
-//      meaningless). In order to do that, she would need to define a copy 
-//      of the CRITICAL_SECTION structure in his/her code, and that may lead 
-//      to access random data beyond the structure limit, if that managed 
+//    - From managed code point of view, one could try to interop directly
+//      to unmanaged critical sections APIs (though that would be quite
+//      meaningless). In order to do that, she would need to define a copy
+//      of the CRITICAL_SECTION structure in his/her code, and that may lead
+//      to access random data beyond the structure limit, if that managed
 //      code is compiled on Unix.
-//      In case such scenario should be supported, the  current implementation 
-//      will have to be modified in a way to go back to the original Windows 
-//      CRITICAL_SECTION layout. That would require to dynamically allocate 
-//      the native data and use LockSemaphore as a pointer to it. The current 
-//      solution intentionally avoids that since an effort has been made to 
-//      make CSs objects completely independent from any other PAL subsystem, 
+//      In case such scenario should be supported, the  current implementation
+//      will have to be modified in a way to go back to the original Windows
+//      CRITICAL_SECTION layout. That would require to dynamically allocate
+//      the native data and use LockSemaphore as a pointer to it. The current
+//      solution intentionally avoids that since an effort has been made to
+//      make CSs objects completely independent from any other PAL subsystem,
 //      so that they can be used during initialization and shutdown.
-//      In case the "dynamically allocate native data" solution should be 
-//      implemented, CSs would acquire a dependency on memory allocation and 
-//      thread suspension subsystems, since the first contention on a specific 
+//      In case the "dynamically allocate native data" solution should be
+//      implemented, CSs would acquire a dependency on memory allocation and
+//      thread suspension subsystems, since the first contention on a specific
 //      CS would trigger the native data allocation.
-// 3) The semantics of the LockCount field has not been kept compatible with 
-//    the Windows implementation. 
-//    Both on Windows and Unix the lower bit of LockCount indicates 
-//    whether or not the CS is locked (for both fair and unfair lock 
-//    solution), the second bit indicates whether or not currently there is a 
-//    waiter that has been awakened and that is trying to acquire the CS 
-//    (only unfair lock solution, unused in the fair one); starting from the 
-//    third bit, LockCount represents the number of waiter threads currently 
-//    waiting on the CS. 
-//    Windows, anyway, implements this semantics in negative logic, so that 
-//    an unlocked CS is represented by a LockCount == -1 (i.e. 0xFFFFFFFF, 
+// 3) The semantics of the LockCount field has not been kept compatible with
+//    the Windows implementation.
+//    Both on Windows and Unix the lower bit of LockCount indicates
+//    whether or not the CS is locked (for both fair and unfair lock
+//    solution), the second bit indicates whether or not currently there is a
+//    waiter that has been awakened and that is trying to acquire the CS
+//    (only unfair lock solution, unused in the fair one); starting from the
+//    third bit, LockCount represents the number of waiter threads currently
+//    waiting on the CS.
+//    Windows, anyway, implements this semantics in negative logic, so that
+//    an unlocked CS is represented by a LockCount == -1 (i.e. 0xFFFFFFFF,
 //    all the bits set), while on Unix an unlocked CS has LockCount == 0.
-//    Windows needs to use negative logic to support legacy code bad enough 
-//    to directly access CS's fields making the assumption that 
-//    LockCount == -1 means CS unlocked. Unix will not support that, and 
+//    Windows needs to use negative logic to support legacy code bad enough
+//    to directly access CS's fields making the assumption that
+//    LockCount == -1 means CS unlocked. Unix will not support that, and
 //    it uses positive logic.
-// 4) The CRITICAL_SECTION_DEBUG_INFO layout on Unix is intentionally not 
+// 4) The CRITICAL_SECTION_DEBUG_INFO layout on Unix is intentionally not
 //    compatible with the Windows layout.
-// 5) For legacy code dependencies issues similar to those just described for 
-//    the LockCount field, Windows CS code maintains a per-process list of 
-//    debug info for all the CSs, both on debug and free/retail builds. On 
-//    Unix such a list is maintained only on debug builds, and no debug 
+// 5) For legacy code dependencies issues similar to those just described for
+//    the LockCount field, Windows CS code maintains a per-process list of
+//    debug info for all the CSs, both on debug and free/retail builds. On
+//    Unix such a list is maintained only on debug builds, and no debug
 //    info structure is allocated on free/retail builds
-//   
+//
 
 SET_DEFAULT_DEBUG_CHANNEL(CRITSEC);
 
@@ -117,36 +117,36 @@ SET_DEFAULT_DEBUG_CHANNEL(CRITSEC);
 #define PALCS_GETAWBIT(val)     ((int)(0!=(PALCS_LOCK_AWAKENED_WAITER&val)))
 #define PALCS_GETWCOUNT(val)    (val/PALCS_LOCK_WAITER_INC)
 
-enum PalCsInitState 
-{ 
+enum PalCsInitState
+{
     PalCsNotInitialized,    // Critical section not initialized (InitializedCriticalSection
-                            // has not yet been called, or DeleteCriticalsection has been 
+                            // has not yet been called, or DeleteCriticalsection has been
                             // called).
-    PalCsUserInitialized,   // Critical section initialized from the user point of view, 
+    PalCsUserInitialized,   // Critical section initialized from the user point of view,
                             // i.e. InitializedCriticalSection has been called.
     PalCsFullyInitializing, // A thread found the CS locked, this is the first contention on
                             // this CS, and the thread is initializing the CS's native data.
     PalCsFullyInitialized   // Internal CS's native data has been fully initialized.
 };
 
-enum PalCsWaiterReturnState 
-{ 
-    PalCsReturnWaiterAwakened, 
-    PalCsWaiterDidntWait 
+enum PalCsWaiterReturnState
+{
+    PalCsReturnWaiterAwakened,
+    PalCsWaiterDidntWait
 };
 
 struct _PAL_CRITICAL_SECTION; // fwd declaration
 
-typedef struct _CRITICAL_SECTION_DEBUG_INFO 
+typedef struct _CRITICAL_SECTION_DEBUG_INFO
 {
     LIST_ENTRY Link;
     struct _PAL_CRITICAL_SECTION * pOwnerCS;
     Volatile<ULONG> lAcquireCount;
     Volatile<ULONG> lEnterCount;
-    Volatile<LONG> lContentionCount;    
+    Volatile<LONG> lContentionCount;
 } CRITICAL_SECTION_DEBUG_INFO, *PCRITICAL_SECTION_DEBUG_INFO;
 
-typedef struct _PAL_CRITICAL_SECTION_NATIVE_DATA 
+typedef struct _PAL_CRITICAL_SECTION_NATIVE_DATA
 {
     pthread_mutex_t mutex;
     pthread_cond_t condition;
@@ -164,14 +164,14 @@ typedef struct _PAL_CRITICAL_SECTION {
     // Private Unix part
     BOOL fInternal;
     Volatile<PalCsInitState> cisInitState;
-    PAL_CRITICAL_SECTION_NATIVE_DATA csndNativeData;    
+    PAL_CRITICAL_SECTION_NATIVE_DATA csndNativeData;
 } PAL_CRITICAL_SECTION, *PPAL_CRITICAL_SECTION, *LPPAL_CRITICAL_SECTION;
 
 #ifdef _DEBUG
-namespace CorUnix 
+namespace CorUnix
 {
     PAL_CRITICAL_SECTION g_csPALCSsListLock;
-    LIST_ENTRY g_PALCSList = { &g_PALCSList, &g_PALCSList};    
+    LIST_ENTRY g_PALCSList = { &g_PALCSList, &g_PALCSList};
 }
 #endif // _DEBUG
 
@@ -182,9 +182,9 @@ static SIZE_T ObtainCurrentThreadIdImpl(CPalThread *pCurrentThread, const char *
     if(pCurrentThread)
     {
         threadId = pCurrentThread->GetThreadId();
-        _ASSERTE(threadId == THREADSilentGetCurrentThreadId());            
+        _ASSERTE(threadId == THREADSilentGetCurrentThreadId());
     }
-    else 
+    else
     {
         threadId = THREADSilentGetCurrentThreadId();
         CS_TRACE("Early %s, no pthread data, getting TID internally\n", callingFuncName);
@@ -204,10 +204,10 @@ See MSDN doc.
 void InitializeCriticalSection(LPCRITICAL_SECTION lpCriticalSection)
 {
     PERF_ENTRY(InitializeCriticalSection);
-    ENTRY("InitializeCriticalSection(lpCriticalSection=%p)\n", 
+    ENTRY("InitializeCriticalSection(lpCriticalSection=%p)\n",
           lpCriticalSection);
-    
-    InternalInitializeCriticalSectionAndSpinCount(lpCriticalSection, 
+
+    InternalInitializeCriticalSectionAndSpinCount(lpCriticalSection,
                                                   0, false);
 
     LOGEXIT("InitializeCriticalSection returns void\n");
@@ -246,13 +246,13 @@ BOOL InitializeCriticalSectionAndSpinCount(LPCRITICAL_SECTION lpCriticalSection,
     PERF_ENTRY(InitializeCriticalSectionAndSpinCount);
     ENTRY("InitializeCriticalSectionAndSpinCount(lpCriticalSection=%p, "
           "dwSpinCount=%u)\n", lpCriticalSection, dwSpinCount);
-        
-    InternalInitializeCriticalSectionAndSpinCount(lpCriticalSection, 
+
+    InternalInitializeCriticalSectionAndSpinCount(lpCriticalSection,
                                                   dwSpinCount, false);
-    
+
     LOGEXIT("InitializeCriticalSectionAndSpinCount returns BOOL %d\n",
             bRet);
-    PERF_EXIT(InitializeCriticalSectionAndSpinCount);    
+    PERF_EXIT(InitializeCriticalSectionAndSpinCount);
     return bRet;
 }
 
@@ -285,7 +285,7 @@ void EnterCriticalSection(LPCRITICAL_SECTION lpCriticalSection)
     ENTRY("EnterCriticalSection(lpCriticalSection=%p)\n", lpCriticalSection);
 
     CPalThread * pThread = InternalGetCurrentThread();
-   
+
     InternalEnterCriticalSection(pThread, lpCriticalSection);
 
     LOGEXIT("EnterCriticalSection returns void\n");
@@ -302,10 +302,10 @@ BOOL TryEnterCriticalSection(LPCRITICAL_SECTION lpCriticalSection)
 {
     PERF_ENTRY(TryEnterCriticalSection);
     ENTRY("TryEnterCriticalSection(lpCriticalSection=%p)\n", lpCriticalSection);
-    
+
     CPalThread * pThread = InternalGetCurrentThread();
-   
-    bool fRet = InternalTryEnterCriticalSection(pThread, 
+
+    bool fRet = InternalTryEnterCriticalSection(pThread,
         lpCriticalSection);
 
     LOGEXIT("TryEnterCriticalSection returns bool %d\n", (int)fRet);
@@ -324,9 +324,9 @@ VOID LeaveCriticalSection(LPCRITICAL_SECTION lpCriticalSection)
 {
     PERF_ENTRY(LeaveCriticalSection);
     ENTRY("LeaveCriticalSection(lpCriticalSection=%p)\n", lpCriticalSection);
-    
+
     CPalThread * pThread = InternalGetCurrentThread();
-  
+
     InternalLeaveCriticalSection(pThread, lpCriticalSection);
 
     LOGEXIT("LeaveCriticalSection returns void\n");
@@ -354,15 +354,15 @@ Deletes a critical section
 VOID InternalDeleteCriticalSection(
     PCRITICAL_SECTION pCriticalSection)
 {
-    PAL_CRITICAL_SECTION * pPalCriticalSection = 
+    PAL_CRITICAL_SECTION * pPalCriticalSection =
         reinterpret_cast<PAL_CRITICAL_SECTION*>(pCriticalSection);
-    
+
     _ASSERT_MSG(PalCsUserInitialized == pPalCriticalSection->cisInitState ||
                 PalCsFullyInitialized == pPalCriticalSection->cisInitState,
                 "CS %p is not initialized", pPalCriticalSection);
 
 #ifdef _DEBUG
-    CPalThread * pThread = 
+    CPalThread * pThread =
         (PALIsThreadDataInitialized() ? GetCurrentPalThread() : NULL);
 
     if (0 != pPalCriticalSection->LockCount)
@@ -403,7 +403,7 @@ VOID InternalDeleteCriticalSection(
                 ERROR("Deleting a CS with %d threads waiting on it\n",
                       iWaiterCount);
             }
-            else 
+            else
             {
                 ERROR("Thread tid=%u is deleting a critical section currently not "
                       "owned, but with one waiter awakened\n", tid);
@@ -413,29 +413,29 @@ VOID InternalDeleteCriticalSection(
 
     if (NULL != pPalCriticalSection->DebugInfo)
     {
-        if (pPalCriticalSection != &CorUnix::g_csPALCSsListLock) 
+        if (pPalCriticalSection != &CorUnix::g_csPALCSsListLock)
         {
-            InternalEnterCriticalSection(pThread, 
+            InternalEnterCriticalSection(pThread,
                 reinterpret_cast<CRITICAL_SECTION*>(&g_csPALCSsListLock));
             RemoveEntryList(&pPalCriticalSection->DebugInfo->Link);
-            InternalLeaveCriticalSection(pThread, 
+            InternalLeaveCriticalSection(pThread,
                 reinterpret_cast<CRITICAL_SECTION*>(&g_csPALCSsListLock));
-        } 
-        else 
+        }
+        else
         {
             RemoveEntryList(&pPalCriticalSection->DebugInfo->Link);
         }
-        
+
 #ifdef PAL_TRACK_CRITICAL_SECTIONS_DATA
         LONG lVal, lNewVal;
         Volatile<LONG> * plDest;
 
         // Update delete count
-        InterlockedIncrement(pPalCriticalSection->fInternal ? 
+        InterlockedIncrement(pPalCriticalSection->fInternal ?
             &g_lPALCSInternalDeleteCount : &g_lPALCSDeleteCount);
 
         // Update acquire count
-        plDest = pPalCriticalSection->fInternal ? 
+        plDest = pPalCriticalSection->fInternal ?
             &g_lPALCSInternalAcquireCount : &g_lPALCSAcquireCount;
         do {
             lVal = *plDest;
@@ -444,7 +444,7 @@ VOID InternalDeleteCriticalSection(
         } while (lVal != lNewVal);
 
         // Update enter count
-        plDest = pPalCriticalSection->fInternal ? 
+        plDest = pPalCriticalSection->fInternal ?
             &g_lPALCSInternalEnterCount : &g_lPALCSEnterCount;
         do {
             lVal = *plDest;
@@ -453,7 +453,7 @@ VOID InternalDeleteCriticalSection(
         } while (lVal != lNewVal);
 
         // Update contention count
-        plDest = pPalCriticalSection->fInternal ? 
+        plDest = pPalCriticalSection->fInternal ?
             &g_lPALCSInternalContentionCount : &g_lPALCSContentionCount;
         do {
             lVal = *plDest;
@@ -467,7 +467,7 @@ VOID InternalDeleteCriticalSection(
         pPalCriticalSection->DebugInfo = NULL;
     }
 #endif // _DEBUG
-    
+
     if (PalCsFullyInitialized == pPalCriticalSection->cisInitState)
     {
         int iRet;
@@ -484,7 +484,7 @@ VOID InternalDeleteCriticalSection(
     }
 
     // Reset critical section state
-    pPalCriticalSection->cisInitState = PalCsNotInitialized;        
+    pPalCriticalSection->cisInitState = PalCsNotInitialized;
 }
 
 // The following PALCEnterCriticalSection and PALCLeaveCriticalSection
@@ -501,7 +501,7 @@ which has no knowledge of CPalThread, classes and namespaces.
 --*/
 VOID PALCEnterCriticalSection(CRITICAL_SECTION * pcs)
 {
-    CPalThread * pThread = 
+    CPalThread * pThread =
         (PALIsThreadDataInitialized() ? GetCurrentPalThread() : NULL);
     CorUnix::InternalEnterCriticalSection(pThread, pcs);
 }
@@ -515,15 +515,15 @@ which has no knowledge of CPalThread, classes and namespaces.
 --*/
 VOID PALCLeaveCriticalSection(CRITICAL_SECTION * pcs)
 {
-    CPalThread * pThread = 
+    CPalThread * pThread =
         (PALIsThreadDataInitialized() ? GetCurrentPalThread() : NULL);
-    CorUnix::InternalLeaveCriticalSection(pThread, pcs);    
+    CorUnix::InternalLeaveCriticalSection(pThread, pcs);
 }
 
 namespace CorUnix
 {
     static PalCsWaiterReturnState PALCS_WaitOnCS(
-        PAL_CRITICAL_SECTION * pPalCriticalSection, 
+        PAL_CRITICAL_SECTION * pPalCriticalSection,
         LONG lInc);
     static PAL_ERROR PALCS_DoActualWait(PAL_CRITICAL_SECTION * pPalCriticalSection);
     static PAL_ERROR PALCS_WakeUpWaiter(PAL_CRITICAL_SECTION * pPalCriticalSection);
@@ -531,11 +531,11 @@ namespace CorUnix
 
 #ifdef _DEBUG
     enum CSSubSysInitState
-    { 
+    {
         CSSubSysNotInitialzed,
-        CSSubSysInitializing, 
-        CSSubSysInitialized 
-    }; 
+        CSSubSysInitializing,
+        CSSubSysInitialized
+    };
     static Volatile<CSSubSysInitState> csssInitState = CSSubSysNotInitialzed;
 
 #ifdef PAL_TRACK_CRITICAL_SECTIONS_DATA
@@ -550,7 +550,7 @@ namespace CorUnix
     static Volatile<LONG> g_lPALCSInternalEnterCount      = 0;
     static Volatile<LONG> g_lPALCSInternalContentionCount = 0;
 #endif // PAL_TRACK_CRITICAL_SECTIONS_DATA
-#endif // _DEBUG 
+#endif // _DEBUG
 
 
     /*++
@@ -559,13 +559,13 @@ namespace CorUnix
 
     Initializes CS subsystem
     --*/
-    void CriticalSectionSubSysInitialize()    
-    {            
+    void CriticalSectionSubSysInitialize()
+    {
         static_assert(sizeof(CRITICAL_SECTION) >= sizeof(PAL_CRITICAL_SECTION),
             "PAL fatal internal error: sizeof(CRITICAL_SECTION) is "
             "smaller than sizeof(PAL_CRITICAL_SECTION)");
 
-#ifdef _DEBUG        
+#ifdef _DEBUG
         LONG lRet = InterlockedCompareExchange((LONG *)&csssInitState,
                                                (LONG)CSSubSysInitializing,
                                                (LONG)CSSubSysNotInitialzed);
@@ -586,7 +586,7 @@ namespace CorUnix
                 sched_yield();
             }
         }
-#endif // _DEBUG        
+#endif // _DEBUG
     }
 
     /*++
@@ -603,7 +603,7 @@ namespace CorUnix
         DWORD dwSpinCount,
         bool fInternal)
     {
-        PAL_CRITICAL_SECTION * pPalCriticalSection = 
+        PAL_CRITICAL_SECTION * pPalCriticalSection =
             reinterpret_cast<PAL_CRITICAL_SECTION*>(pCriticalSection);
 
 #ifndef PALCS_TRANSFER_OWNERSHIP_ON_RELEASE
@@ -633,40 +633,40 @@ namespace CorUnix
         pPalCriticalSection->fInternal         = fInternal;
 
 #ifdef _DEBUG
-        CPalThread * pThread = 
+        CPalThread * pThread =
             (PALIsThreadDataInitialized() ? GetCurrentPalThread() : NULL);
 
         pPalCriticalSection->DebugInfo = InternalNew<CRITICAL_SECTION_DEBUG_INFO>();
-        _ASSERT_MSG(NULL != pPalCriticalSection->DebugInfo, 
+        _ASSERT_MSG(NULL != pPalCriticalSection->DebugInfo,
                     "Failed to allocate debug info for new CS\n");
 
-        // Init debug info data 
+        // Init debug info data
         pPalCriticalSection->DebugInfo->lAcquireCount    = 0;
         pPalCriticalSection->DebugInfo->lEnterCount      = 0;
         pPalCriticalSection->DebugInfo->lContentionCount = 0;
         pPalCriticalSection->DebugInfo->pOwnerCS         = pPalCriticalSection;
 
         // Insert debug info struct in global list
-        if (pPalCriticalSection != &g_csPALCSsListLock) 
+        if (pPalCriticalSection != &g_csPALCSsListLock)
         {
-            InternalEnterCriticalSection(pThread, 
+            InternalEnterCriticalSection(pThread,
                 reinterpret_cast<CRITICAL_SECTION*>(&g_csPALCSsListLock));
             InsertTailList(&g_PALCSList, &pPalCriticalSection->DebugInfo->Link);
-            InternalLeaveCriticalSection(pThread, 
+            InternalLeaveCriticalSection(pThread,
                 reinterpret_cast<CRITICAL_SECTION*>(&g_csPALCSsListLock));
-        } 
-        else 
+        }
+        else
         {
             InsertTailList(&g_PALCSList, &pPalCriticalSection->DebugInfo->Link);
         }
-        
+
 #ifdef PAL_TRACK_CRITICAL_SECTIONS_DATA
-        InterlockedIncrement(fInternal ? 
+        InterlockedIncrement(fInternal ?
             &g_lPALCSInternalInitializeCount : &g_lPALCSInitializeCount);
 #endif // PAL_TRACK_CRITICAL_SECTIONS_DATA
 #endif // _DEBUG
 
-        // Set initializazion state 
+        // Set initializazion state
         pPalCriticalSection->cisInitState = PalCsUserInitialized;
 
 #ifdef MUTEX_BASED_CSS
@@ -679,9 +679,9 @@ namespace CorUnix
 
         if (fInit)
         {
-            // Set initializazion state 
+            // Set initializazion state
             pPalCriticalSection->cisInitState = PalCsFullyInitialized;
-        }            
+        }
 #endif // MUTEX_BASED_CSS
     }
 
@@ -697,19 +697,19 @@ namespace CorUnix
         CPalThread * pThread,
         PCRITICAL_SECTION pCriticalSection)
     {
-        PAL_CRITICAL_SECTION * pPalCriticalSection = 
+        PAL_CRITICAL_SECTION * pPalCriticalSection =
             reinterpret_cast<PAL_CRITICAL_SECTION*>(pCriticalSection);
 
         LONG lSpinCount;
         LONG lVal, lNewVal;
         LONG lBitsToChange, lWaitInc;
-        PalCsWaiterReturnState cwrs;    
+        PalCsWaiterReturnState cwrs;
         SIZE_T threadId;
 
         _ASSERTE(PalCsNotInitialized != pPalCriticalSection->cisInitState);
 
         threadId = ObtainCurrentThreadId(pThread);
-        
+
 
         // Check if the current thread already owns the CS
         //
@@ -721,7 +721,7 @@ namespace CorUnix
         // and the second also succeeds, LockCount cannot have changed in the
         // meanwhile, since this is the owning thread and only the owning
         // thread can change the lock bit when the CS is owned.
-        if ((pPalCriticalSection->LockCount & PALCS_LOCK_BIT) && 
+        if ((pPalCriticalSection->LockCount & PALCS_LOCK_BIT) &&
             (pPalCriticalSection->OwningThread == threadId))
         {
             pPalCriticalSection->RecursionCount += 1;
@@ -730,7 +730,7 @@ namespace CorUnix
             {
                 pPalCriticalSection->DebugInfo->lEnterCount += 1;
             }
-#endif // _DEBUG 
+#endif // _DEBUG
             goto IECS_exit;
         }
 
@@ -738,28 +738,28 @@ namespace CorUnix
         lBitsToChange = PALCS_LOCK_BIT;
         lWaitInc = PALCS_LOCK_WAITER_INC;
         lSpinCount = pPalCriticalSection->SpinCount;
-        
+
         while (TRUE)
         {
-            // Either this is an incoming thread, and therefore lBitsToChange 
+            // Either this is an incoming thread, and therefore lBitsToChange
             // is just PALCS_LOCK_BIT, or this is an awakened waiter
-            _ASSERTE(PALCS_LOCK_BIT == lBitsToChange || 
+            _ASSERTE(PALCS_LOCK_BIT == lBitsToChange ||
                      (PALCS_LOCK_BIT | PALCS_LOCK_AWAKENED_WAITER) == lBitsToChange);
 
             // Make sure the waiter increment is in a valid range
-            _ASSERTE(PALCS_LOCK_WAITER_INC == lWaitInc || 
+            _ASSERTE(PALCS_LOCK_WAITER_INC == lWaitInc ||
                      PALCS_LOCK_AWAKENED_WAITER == lWaitInc);
 
             do {
                 lVal = pPalCriticalSection->LockCount;
-                
+
                 while (0 == (lVal & PALCS_LOCK_BIT))
                 {
                     // CS is not locked: try lo lock it
 
-                    // Make sure that whether we are an incoming thread 
+                    // Make sure that whether we are an incoming thread
                     // or the PALCS_LOCK_AWAKENED_WAITER bit is set
-                    _ASSERTE((PALCS_LOCK_BIT == lBitsToChange) || 
+                    _ASSERTE((PALCS_LOCK_BIT == lBitsToChange) ||
                              (PALCS_LOCK_AWAKENED_WAITER & lVal));
 
                     lNewVal = lVal ^ lBitsToChange;
@@ -769,13 +769,13 @@ namespace CorUnix
 
                     CS_TRACE("[ECS %p] Switching from {%d, %d, %d} to "
                         "{%d, %d, %d} ==>\n", pPalCriticalSection,
-                        PALCS_GETWCOUNT(lVal), PALCS_GETAWBIT(lVal), PALCS_GETLBIT(lVal), 
+                        PALCS_GETWCOUNT(lVal), PALCS_GETAWBIT(lVal), PALCS_GETLBIT(lVal),
                         PALCS_GETWCOUNT(lNewVal), PALCS_GETAWBIT(lNewVal), PALCS_GETLBIT(lNewVal));
 
                     // Try to switch the value
-                    lNewVal = InterlockedCompareExchange (&pPalCriticalSection->LockCount, 
+                    lNewVal = InterlockedCompareExchange (&pPalCriticalSection->LockCount,
                                                          lNewVal, lVal);
-                    
+
                     CS_TRACE("[ECS %p] ==> %s LockCount={%d, %d, %d} "
                         "lVal={%d, %d, %d}\n", pPalCriticalSection,
                         (lNewVal == lVal) ? "OK" : "NO",
@@ -783,10 +783,10 @@ namespace CorUnix
                         PALCS_GETAWBIT(pPalCriticalSection->LockCount),
                         PALCS_GETLBIT(pPalCriticalSection->LockCount),
                         PALCS_GETWCOUNT(lVal), PALCS_GETAWBIT(lVal), PALCS_GETLBIT(lVal));
-                    
+
                     if (lNewVal == lVal)
                     {
-                        // CS successfully acquired                        
+                        // CS successfully acquired
                         goto IECS_set_ownership;
                     }
 
@@ -795,29 +795,29 @@ namespace CorUnix
                     lVal = lNewVal;
                 }
 
-                if (0 < lSpinCount) 
+                if (0 < lSpinCount)
                 {
                     sched_yield();
                 }
             } while (0 <= --lSpinCount);
 
             cwrs = PALCS_WaitOnCS(pPalCriticalSection, lWaitInc);
-            
-            if (PalCsReturnWaiterAwakened == cwrs) 
+
+            if (PalCsReturnWaiterAwakened == cwrs)
             {
 #ifdef PALCS_TRANSFER_OWNERSHIP_ON_RELEASE
-                // 
+                //
                 // Fair Critical Sections
                 //
-                // In the fair lock case, when a waiter wakes up the CS 
+                // In the fair lock case, when a waiter wakes up the CS
                 // must be locked (i.e. ownership passed on to the waiter)
                 _ASSERTE(0 != (PALCS_LOCK_BIT & pPalCriticalSection->LockCount));
 
                 // CS successfully acquired
                 goto IECS_set_ownership;
-                
+
 #else // PALCS_TRANSFER_OWNERSHIP_ON_RELEASE
-                // 
+                //
                 // Unfair Critical Sections
                 //
                 _ASSERTE(PALCS_LOCK_AWAKENED_WAITER & pPalCriticalSection->LockCount);
@@ -832,14 +832,14 @@ namespace CorUnix
         // Critical section acquired: set ownership data
         pPalCriticalSection->OwningThread = threadId;
         pPalCriticalSection->RecursionCount = 1;
-#ifdef _DEBUG 
+#ifdef _DEBUG
         if (NULL != pPalCriticalSection->DebugInfo)
         {
             pPalCriticalSection->DebugInfo->lAcquireCount += 1;
             pPalCriticalSection->DebugInfo->lEnterCount += 1;
         }
-#endif // _DEBUG 
-    
+#endif // _DEBUG
+
     IECS_exit:
         return;
     }
@@ -853,7 +853,7 @@ namespace CorUnix
     void InternalLeaveCriticalSection(CPalThread * pThread,
                                       PCRITICAL_SECTION pCriticalSection)
     {
-        PAL_CRITICAL_SECTION * pPalCriticalSection = 
+        PAL_CRITICAL_SECTION * pPalCriticalSection =
             reinterpret_cast<PAL_CRITICAL_SECTION*>(pCriticalSection);
         LONG lVal, lNewVal;
 
@@ -866,10 +866,10 @@ namespace CorUnix
         _ASSERTE(threadId == pPalCriticalSection->OwningThread);
 #endif // _DEBUG
 
-        _ASSERT_MSG(PALCS_LOCK_BIT & pPalCriticalSection->LockCount, 
+        _ASSERT_MSG(PALCS_LOCK_BIT & pPalCriticalSection->LockCount,
                     "Trying to release an unlocked CS\n");
-        _ASSERT_MSG(0 < pPalCriticalSection->RecursionCount, 
-                    "Trying to release an unlocked CS\n");      
+        _ASSERT_MSG(0 < pPalCriticalSection->RecursionCount,
+                    "Trying to release an unlocked CS\n");
 
         if (--pPalCriticalSection->RecursionCount > 0)
         {
@@ -885,38 +885,38 @@ namespace CorUnix
 
         while (true)
         {
-            _ASSERT_MSG(0 != (PALCS_LOCK_BIT & lVal), 
+            _ASSERT_MSG(0 != (PALCS_LOCK_BIT & lVal),
                       "Trying to release an unlocked CS\n");
 
-            // NB: In the fair lock case (PALCS_TRANSFER_OWNERSHIP_ON_RELEASE) the 
+            // NB: In the fair lock case (PALCS_TRANSFER_OWNERSHIP_ON_RELEASE) the
             // PALCS_LOCK_AWAKENED_WAITER bit is not used
             if ( (PALCS_LOCK_BIT == lVal)
 #ifndef PALCS_TRANSFER_OWNERSHIP_ON_RELEASE
                  || (PALCS_LOCK_AWAKENED_WAITER & lVal)
 #endif // !PALCS_TRANSFER_OWNERSHIP_ON_RELEASE
-                ) 
+                )
             {
                 // Whether there are no waiters (PALCS_LOCK_BIT == lVal)
-                // or a waiter has already been awakened, therefore we 
-                // just need to reset the lock bit and return 
+                // or a waiter has already been awakened, therefore we
+                // just need to reset the lock bit and return
                 lNewVal = lVal & ~PALCS_LOCK_BIT;
                 CS_TRACE("[LCS-UN %p] Switching from {%d, %d, %d} to "
                     "{%d, %d, %d} ==>\n", pPalCriticalSection,
                     PALCS_GETWCOUNT(lVal), PALCS_GETAWBIT(lVal), PALCS_GETLBIT(lVal),
                     PALCS_GETWCOUNT(lNewVal), PALCS_GETAWBIT(lNewVal), PALCS_GETLBIT(lNewVal));
 
-                lNewVal = InterlockedCompareExchange(&pPalCriticalSection->LockCount, 
+                lNewVal = InterlockedCompareExchange(&pPalCriticalSection->LockCount,
                                                      lNewVal, lVal);
 
-                CS_TRACE("[LCS-UN %p] ==> %s\n", pPalCriticalSection, 
+                CS_TRACE("[LCS-UN %p] ==> %s\n", pPalCriticalSection,
                                (lNewVal == lVal) ? "OK" : "NO");
 
-                if (lNewVal == lVal) 
+                if (lNewVal == lVal)
                 {
                     goto ILCS_cs_exit;
                 }
-            } 
-            else 
+            }
+            else
             {
                 // There is at least one waiter, we need to wake it up
 
@@ -924,12 +924,12 @@ namespace CorUnix
                 // Fair lock case: passing ownership on to the first waiter.
                 // Here we need only to decrement the waiters count. CS will
                 // remain locked and ownership will be passed to the waiter,
-                // which will take care of setting ownership data as soon as 
+                // which will take care of setting ownership data as soon as
                 // it wakes up
                 lNewVal = lVal - PALCS_LOCK_WAITER_INC;
 #else // PALCS_TRANSFER_OWNERSHIP_ON_RELEASE
-                // Unfair lock case: we need to atomically decrement the waiters 
-                // count (we are about ot wake up one of them), set the 
+                // Unfair lock case: we need to atomically decrement the waiters
+                // count (we are about ot wake up one of them), set the
                 // "waiter awakened" bit and to reset the "CS locked" bit.
                 // Note that, since we know that at this time PALCS_LOCK_BIT
                 // is set and PALCS_LOCK_AWAKENED_WAITER is not set, none of
@@ -938,27 +938,27 @@ namespace CorUnix
                 // PALCS_LOCK_AWAKENED_WAITER will not affect the actual
                 // count of waiters, and the latter will not change the two
                 // former ones
-                lNewVal = lVal - PALCS_LOCK_WAITER_INC + 
+                lNewVal = lVal - PALCS_LOCK_WAITER_INC +
                     PALCS_LOCK_AWAKENED_WAITER - PALCS_LOCK_BIT;
 #endif // PALCS_TRANSFER_OWNERSHIP_ON_RELEASE
-                CS_TRACE("[LCS-CN %p] Switching from {%d, %d, %d} to {%d, %d, %d} ==>\n", 
+                CS_TRACE("[LCS-CN %p] Switching from {%d, %d, %d} to {%d, %d, %d} ==>\n",
                     pPalCriticalSection,
-                    PALCS_GETWCOUNT(lVal), PALCS_GETAWBIT(lVal), PALCS_GETLBIT(lVal), 
+                    PALCS_GETWCOUNT(lVal), PALCS_GETAWBIT(lVal), PALCS_GETLBIT(lVal),
                     PALCS_GETWCOUNT(lNewVal), PALCS_GETAWBIT(lNewVal), PALCS_GETLBIT(lNewVal));
 
                 lNewVal = InterlockedCompareExchange(&pPalCriticalSection->LockCount,
                                                      lNewVal, lVal);
 
-                CS_TRACE("[LCS-CN %p] ==> %s\n", pPalCriticalSection, 
+                CS_TRACE("[LCS-CN %p] ==> %s\n", pPalCriticalSection,
                             (lNewVal == lVal) ? "OK" : "NO");
 
-                if (lNewVal == lVal) 
+                if (lNewVal == lVal)
                 {
                     // Wake up the waiter
                     PALCS_WakeUpWaiter (pPalCriticalSection);
-                    
+
 #ifdef PALCS_TRANSFER_OWNERSHIP_ON_RELEASE
-                    // In the fair lock case, we need to yield here to defeat 
+                    // In the fair lock case, we need to yield here to defeat
                     // the inherently unfair nature of the condition/predicate
                     // construct
                     sched_yield();
@@ -968,14 +968,14 @@ namespace CorUnix
                 }
             }
 
-            // CS unlock failed due to race with another thread trying to 
-            // register as waiter on it. We need to keep on looping. We 
-            // intentionally do not yield here in order to reserve higher 
+            // CS unlock failed due to race with another thread trying to
+            // register as waiter on it. We need to keep on looping. We
+            // intentionally do not yield here in order to reserve higher
             // priority for the releasing thread.
             //
-            // At this point lNewVal contains the latest LockCount value 
-            // retrieved by one of the two InterlockedCompareExchange above; 
-            // we can use this value as expected LockCount for the next loop, 
+            // At this point lNewVal contains the latest LockCount value
+            // retrieved by one of the two InterlockedCompareExchange above;
+            // we can use this value as expected LockCount for the next loop,
             // without the need to fetch it again.
             lVal = lNewVal;
         }
@@ -988,14 +988,14 @@ namespace CorUnix
     Function:
       CorUnix::InternalTryEnterCriticalSection
 
-    Tries to acquire a CS. It returns true on success, false if the CS is 
+    Tries to acquire a CS. It returns true on success, false if the CS is
     locked by another thread
     --*/
     bool InternalTryEnterCriticalSection(
         CPalThread * pThread,
         PCRITICAL_SECTION pCriticalSection)
     {
-        PAL_CRITICAL_SECTION * pPalCriticalSection = 
+        PAL_CRITICAL_SECTION * pPalCriticalSection =
             reinterpret_cast<PAL_CRITICAL_SECTION*>(pCriticalSection);
 
         LONG lNewVal;
@@ -1006,8 +1006,8 @@ namespace CorUnix
 
         threadId = ObtainCurrentThreadId(pThread);
 
-        lNewVal = InterlockedCompareExchange (&pPalCriticalSection->LockCount, 
-                                             (LONG)PALCS_LOCK_BIT, 
+        lNewVal = InterlockedCompareExchange (&pPalCriticalSection->LockCount,
+                                             (LONG)PALCS_LOCK_BIT,
                                              (LONG)PALCS_LOCK_INIT);
         if (lNewVal == PALCS_LOCK_INIT)
         {
@@ -1020,13 +1020,13 @@ namespace CorUnix
                 pPalCriticalSection->DebugInfo->lAcquireCount += 1;
                 pPalCriticalSection->DebugInfo->lEnterCount += 1;
             }
-#endif // _DEBUG 
+#endif // _DEBUG
 
             goto ITECS_exit;
         }
 
         // check if the current thread already owns the criticalSection
-        if ((lNewVal & PALCS_LOCK_BIT) && 
+        if ((lNewVal & PALCS_LOCK_BIT) &&
             (pPalCriticalSection->OwningThread == threadId))
         {
             pPalCriticalSection->RecursionCount += 1;
@@ -1035,14 +1035,14 @@ namespace CorUnix
             {
                 pPalCriticalSection->DebugInfo->lEnterCount += 1;
             }
-#endif // _DEBUG 
+#endif // _DEBUG
 
             goto ITECS_exit;
         }
 
         // Failed to acquire the CS
         fRet = false;
-        
+
     ITECS_exit:
         return fRet;
     }
@@ -1066,7 +1066,7 @@ namespace CorUnix
             goto PCDI_exit;
         }
         if (PalCsUserInitialized == lVal)
-        {            
+        {
             int iRet;
             lNewVal = (LONG)PalCsFullyInitializing;
             lNewVal = InterlockedCompareExchange(
@@ -1075,12 +1075,12 @@ namespace CorUnix
             {
                 if (PalCsFullyInitialized == lNewVal)
                 {
-                    // Another thread did initialize this CS: we can 
+                    // Another thread did initialize this CS: we can
                     // safely return 'true'
                     goto PCDI_exit;
                 }
 
-                // Another thread is still initializing this CS: yield and 
+                // Another thread is still initializing this CS: yield and
                 // spin by returning 'false'
                 sched_yield();
                 fRet = false;
@@ -1094,7 +1094,7 @@ namespace CorUnix
             iRet = pthread_mutex_init(&pPalCriticalSection->csndNativeData.mutex, NULL);
             if (0 != iRet)
             {
-                ASSERT("Failed initializing mutex in CS @ %p [err=%d]\n", 
+                ASSERT("Failed initializing mutex in CS @ %p [err=%d]\n",
                         pPalCriticalSection, iRet);
                 pPalCriticalSection->cisInitState = PalCsUserInitialized;
                 fRet = false;
@@ -1120,7 +1120,7 @@ namespace CorUnix
         }
         else if (PalCsFullyInitializing == lVal)
         {
-            // Another thread is still initializing this CS: yield and 
+            // Another thread is still initializing this CS: yield and
             // spin by returning 'false'
             sched_yield();
             fRet = false;
@@ -1132,7 +1132,7 @@ namespace CorUnix
             fRet = false;
             goto PCDI_exit;
         }
-        
+
     PCDI_exit:
         return fRet;
     }
@@ -1142,9 +1142,9 @@ namespace CorUnix
     Function:
       CorUnix::PALCS_WaitOnCS
 
-    Waits on a CS owned by anothr thread. It returns PalCsReturnWaiterAwakened 
-    if the thread actually waited on the CS and it has been awakened on CS 
-    release. It returns PalCsWaiterDidntWait if another thread is currently 
+    Waits on a CS owned by anothr thread. It returns PalCsReturnWaiterAwakened
+    if the thread actually waited on the CS and it has been awakened on CS
+    release. It returns PalCsWaiterDidntWait if another thread is currently
     fully-initializing the CS and therefore the current thread couldn't wait
     on it
     --*/
@@ -1162,46 +1162,46 @@ namespace CorUnix
             {
                 // The current thread failed the full initialization of the CS,
                 // whether because another thread is race-initializing it, or
-                // there are no enough memory/resources at this time, or 
-                // InitializeCriticalSection has never been called. By 
-                // returning we will cause the thread to spin on CS trying 
+                // there are no enough memory/resources at this time, or
+                // InitializeCriticalSection has never been called. By
+                // returning we will cause the thread to spin on CS trying
                 // again until the CS is initialized
                 return PalCsWaiterDidntWait;
             }
         }
 
         // Make sure we have a valid waiter increment
-        _ASSERTE(PALCS_LOCK_WAITER_INC == lInc || 
+        _ASSERTE(PALCS_LOCK_WAITER_INC == lInc ||
                  PALCS_LOCK_AWAKENED_WAITER == lInc);
-        
+
         do {
             lVal = pPalCriticalSection->LockCount;
 
             // Make sure the waiter increment is compatible with the
             // awakened waiter bit value
-            _ASSERTE(PALCS_LOCK_WAITER_INC == lInc || 
+            _ASSERTE(PALCS_LOCK_WAITER_INC == lInc ||
                      PALCS_LOCK_AWAKENED_WAITER & lVal);
-            
+
             if (0 == (lVal & PALCS_LOCK_BIT))
             {
                 // the CS is no longer locked, let's bail out
                 return PalCsWaiterDidntWait;
             }
-            
-            lNewVal = lVal + lInc; 
 
-            // Make sure that this thread was whether an incoming one or it 
+            lNewVal = lVal + lInc;
+
+            // Make sure that this thread was whether an incoming one or it
             // was an awakened waiter and, in this case, we are now going to
-            // turn off the awakened waiter bit 
-            _ASSERT_MSG(PALCS_LOCK_WAITER_INC == lInc || 
+            // turn off the awakened waiter bit
+            _ASSERT_MSG(PALCS_LOCK_WAITER_INC == lInc ||
                         0 == (PALCS_LOCK_AWAKENED_WAITER & lNewVal));
 
             CS_TRACE("[WCS %p] Switching from {%d, %d, %d} to "
                 "{%d, %d, %d} ==> ", pPalCriticalSection,
                 PALCS_GETWCOUNT(lVal), PALCS_GETAWBIT(lVal), PALCS_GETLBIT(lVal),
                 PALCS_GETWCOUNT(lNewVal), PALCS_GETAWBIT(lNewVal), PALCS_GETLBIT(lNewVal));
-                        
-            lNewVal = InterlockedCompareExchange (&pPalCriticalSection->LockCount, 
+
+            lNewVal = InterlockedCompareExchange (&pPalCriticalSection->LockCount,
                                                   lNewVal, lVal);
 
             CS_TRACE("[WCS %p] ==> %s\n", pPalCriticalSection,
@@ -1214,12 +1214,12 @@ namespace CorUnix
         {
             pPalCriticalSection->DebugInfo->lContentionCount += 1;
         }
-#endif // _DEBUG 
+#endif // _DEBUG
 
         // Do the actual native wait
         palErr = PALCS_DoActualWait(pPalCriticalSection);
         _ASSERT_MSG(NO_ERROR == palErr, "Native CS wait failed\n");
-        
+
         return PalCsReturnWaiterAwakened;
     }
 
@@ -1243,28 +1243,28 @@ namespace CorUnix
             palErr = ERROR_INTERNAL_ERROR;
             goto PCDAW_exit;
         }
-        
+
         CS_TRACE("Actually Going to sleep [CS=%p]\n", pPalCriticalSection);
-        
+
         while (0 == pPalCriticalSection->csndNativeData.iPredicate)
         {
             // Wait on the condition
-            iRet = pthread_cond_wait(&pPalCriticalSection->csndNativeData.condition, 
+            iRet = pthread_cond_wait(&pPalCriticalSection->csndNativeData.condition,
                                      &pPalCriticalSection->csndNativeData.mutex);
-            
+
             CS_TRACE("Got a signal on condition [pred=%d]!\n",
                            pPalCriticalSection->csndNativeData.iPredicate);
             if (0 != iRet)
             {
                 // Failed: unlock the mutex and bail out
-                ASSERT("Failed waiting on condition in CS %p [err=%d]\n", 
+                ASSERT("Failed waiting on condition in CS %p [err=%d]\n",
                        pPalCriticalSection, iRet);
                 pthread_mutex_unlock(&pPalCriticalSection->csndNativeData.mutex);
                 palErr = ERROR_INTERNAL_ERROR;
                 goto PCDAW_exit;
-            }        
+            }
         }
-        
+
         // Reset the predicate
         pPalCriticalSection->csndNativeData.iPredicate = 0;
 
@@ -1275,9 +1275,9 @@ namespace CorUnix
             palErr = ERROR_INTERNAL_ERROR;
             goto PCDAW_exit;
         }
-        
+
     PCDAW_exit:
-        
+
         CS_TRACE("Just woken up [CS=%p]\n", pPalCriticalSection);
 
         return palErr;
@@ -1307,7 +1307,7 @@ namespace CorUnix
 
         // Set the predicate
         pPalCriticalSection->csndNativeData.iPredicate = 1;
-        
+
         CS_TRACE("Signaling condition/predicate [pred=%d]!\n",
                  pPalCriticalSection->csndNativeData.iPredicate);
 
@@ -1315,9 +1315,9 @@ namespace CorUnix
         iRet = pthread_cond_signal(&pPalCriticalSection->csndNativeData.condition);
         if (0 != iRet)
         {
-            // Failed: set palErr, but continue in order to unlock 
+            // Failed: set palErr, but continue in order to unlock
             // the mutex anyway
-            ASSERT("Failed setting condition in CS %p [ret=%d]\n",  
+            ASSERT("Failed setting condition in CS %p [ret=%d]\n",
                    pPalCriticalSection, iRet);
             palErr = ERROR_INTERNAL_ERROR;
         }
@@ -1333,13 +1333,13 @@ namespace CorUnix
     PCWUW_exit:
         return palErr;
     }
-    
+
 #ifdef _DEBUG
     /*++
     Function:
       CorUnix::PALCS_ReportStatisticalData
 
-    Report creation/acquisition/contention statistical data for the all the 
+    Report creation/acquisition/contention statistical data for the all the
     CSs so far existed and no longer existing in the current process
     --*/
     void PALCS_ReportStatisticalData()
@@ -1351,7 +1351,7 @@ namespace CorUnix
 
         // Take the lock for the global list of CS debug infos
         InternalEnterCriticalSection(pThread, (CRITICAL_SECTION*)&g_csPALCSsListLock);
-        
+
         LONG lPALCSInitializeCount         = g_lPALCSInitializeCount;
         LONG lPALCSDeleteCount             = g_lPALCSDeleteCount;
         LONG lPALCSAcquireCount            = g_lPALCSAcquireCount;
@@ -1366,7 +1366,7 @@ namespace CorUnix
         PLIST_ENTRY pItem = g_PALCSList.Flink;
         while (&g_PALCSList != pItem)
         {
-            PCRITICAL_SECTION_DEBUG_INFO pDebugInfo = 
+            PCRITICAL_SECTION_DEBUG_INFO pDebugInfo =
                 (PCRITICAL_SECTION_DEBUG_INFO)pItem;
 
             if (pDebugInfo->pOwnerCS->fInternal)
@@ -1414,7 +1414,7 @@ namespace CorUnix
     Function:
       CorUnix::PALCS_DumpCSList
 
-    Dumps the list of all the CS currently existing in this process. 
+    Dumps the list of all the CS currently existing in this process.
     --*/
     void PALCS_DumpCSList()
     {
@@ -1426,7 +1426,7 @@ namespace CorUnix
         PLIST_ENTRY pItem = g_PALCSList.Flink;
         while (&g_PALCSList != pItem)
         {
-            PCRITICAL_SECTION_DEBUG_INFO pDebugInfo = 
+            PCRITICAL_SECTION_DEBUG_INFO pDebugInfo =
                 (PCRITICAL_SECTION_DEBUG_INFO)pItem;
             PPAL_CRITICAL_SECTION pCS = pDebugInfo->pOwnerCS;
 
@@ -1438,10 +1438,10 @@ namespace CorUnix
                    "\t\tAcquireCount \t= %d\n"
                    "\t\tEnterCount \t= %d\n"
                    "\t\tContentionCount = %d\n",
-                   pDebugInfo->pOwnerCS, pDebugInfo->lAcquireCount.Load(), 
+                   pDebugInfo->pOwnerCS, pDebugInfo->lAcquireCount.Load(),
                    pDebugInfo->lEnterCount.Load(), pDebugInfo->lContentionCount.Load());
             printf("\t}\n");
-              
+
             printf("\tLockCount \t= %#x\n"
                    "\tRecursionCount \t= %d\n"
                    "\tOwningThread \t= %p\n"
@@ -1450,16 +1450,16 @@ namespace CorUnix
                    "\tfInternal \t= %d\n"
                    "\teInitState \t= %u\n"
                    "\tpNativeData \t= %p ->\n",
-                   pCS->LockCount.Load(), pCS->RecursionCount, (void *)pCS->OwningThread, 
-                   pCS->LockSemaphore, (unsigned)pCS->SpinCount, (int)pCS->fInternal, 
+                   pCS->LockCount.Load(), pCS->RecursionCount, (void *)pCS->OwningThread,
+                   pCS->LockSemaphore, (unsigned)pCS->SpinCount, (int)pCS->fInternal,
                    pCS->cisInitState.Load(), &pCS->csndNativeData);
 
             printf("\t{\n\t\t[mutex]\n\t\t[condition]\n"
                    "\t\tPredicate \t= %d\n"
                    "\t}\n}\n",pCS->csndNativeData.iPredicate);
-            
+
             printf("}\n");
-                   
+
             pItem = pItem->Flink;
         }
 
@@ -1488,7 +1488,7 @@ namespace CorUnix
 #endif // MUTEX_BASED_CSS
 
     {
-        PAL_CRITICAL_SECTION * pPalCriticalSection = 
+        PAL_CRITICAL_SECTION * pPalCriticalSection =
             reinterpret_cast<PAL_CRITICAL_SECTION*>(pCriticalSection);
         int iRet;
         SIZE_T threadId;
@@ -1505,7 +1505,7 @@ namespace CorUnix
             return;
         }
 
-        iRet = pthread_mutex_lock(&pPalCriticalSection->csndNativeData.mutex);        
+        iRet = pthread_mutex_lock(&pPalCriticalSection->csndNativeData.mutex);
         _ASSERTE(0 == iRet);
 
         pPalCriticalSection->OwningThread = threadId;
@@ -1527,9 +1527,9 @@ namespace CorUnix
     void MTX_InternalLeaveCriticalSection(
         CPalThread * pThread,
         PCRITICAL_SECTION pCriticalSection)
-#endif // MUTEX_BASED_CSS    
+#endif // MUTEX_BASED_CSS
     {
-        PAL_CRITICAL_SECTION * pPalCriticalSection = 
+        PAL_CRITICAL_SECTION * pPalCriticalSection =
             reinterpret_cast<PAL_CRITICAL_SECTION*>(pCriticalSection);
         int iRet;
 #ifdef _DEBUG
@@ -1542,8 +1542,8 @@ namespace CorUnix
 
         if (0 >= pPalCriticalSection->RecursionCount)
             DebugBreak();
-        
-        _ASSERTE(0 < pPalCriticalSection->RecursionCount);        
+
+        _ASSERTE(0 < pPalCriticalSection->RecursionCount);
 #endif // _DEBUG
 
         if (0 < --pPalCriticalSection->RecursionCount)
@@ -1559,7 +1559,7 @@ namespace CorUnix
     Function:
       CorUnix::InternalTryEnterCriticalSection
 
-    Tries to acquire a CS. It returns true on success, false if the CS is 
+    Tries to acquire a CS. It returns true on success, false if the CS is
     locked by another thread
     --*/
 #ifdef MUTEX_BASED_CSS
@@ -1572,7 +1572,7 @@ namespace CorUnix
         PCRITICAL_SECTION pCriticalSection)
 #endif // MUTEX_BASED_CSS
     {
-        PAL_CRITICAL_SECTION * pPalCriticalSection = 
+        PAL_CRITICAL_SECTION * pPalCriticalSection =
             reinterpret_cast<PAL_CRITICAL_SECTION*>(pCriticalSection);
         bool fRet;
         SIZE_T threadId;

--- a/pal/src/synchmgr/synchmanager.cpp
+++ b/pal/src/synchmgr/synchmanager.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -59,19 +59,19 @@ namespace CorUnix
     {
         TRACE("Verifying WaitingThreadsListNode @ %p\n", this);
         _ASSERT_MSG(HeadSignature == dwDebugHeadSignature,
-                    "WaitingThreadsListNode header signature corruption [p=%p]", 
+                    "WaitingThreadsListNode header signature corruption [p=%p]",
                     this);
         _ASSERT_MSG(TailSignature == dwDebugTailSignature,
-                    "WaitingThreadsListNode trailer signature corruption [p=%p]", 
+                    "WaitingThreadsListNode trailer signature corruption [p=%p]",
                     this);
     }
     void _WaitingThreadsListNode::ValidateEmptyObject()
     {
         _ASSERT_MSG(HeadSignature != dwDebugHeadSignature,
-                    "WaitingThreadsListNode header previously signed [p=%p]", 
+                    "WaitingThreadsListNode header previously signed [p=%p]",
                     this);
         _ASSERT_MSG(TailSignature != dwDebugTailSignature,
-                    "WaitingThreadsListNode trailer previously signed [p=%p]", 
+                    "WaitingThreadsListNode trailer previously signed [p=%p]",
                     this);
     }
     void _WaitingThreadsListNode::InvalidateObject()
@@ -95,7 +95,7 @@ namespace CorUnix
     Creates the Synchronization Manager. It must be called once per process.
     --*/
     IPalSynchronizationManager * CPalSynchMgrController::CreatePalSynchronizationManager()
-    { 
+    {
         return CPalSynchronizationManager::CreatePalSynchronizationManager();
     };
 
@@ -115,7 +115,7 @@ namespace CorUnix
     Method:
       CPalSynchMgrController::PrepareForShutdown
 
-    This method performs the part of Synchronization Manager's shutdown that 
+    This method performs the part of Synchronization Manager's shutdown that
     needs to be carried out when core PAL subsystems are still active
     --*/
     PAL_ERROR CPalSynchMgrController::PrepareForShutdown()
@@ -130,7 +130,7 @@ namespace CorUnix
     //////////////////////////////////
 
     IPalSynchronizationManager * g_pSynchronizationManager = NULL;
-    
+
     CPalSynchronizationManager * CPalSynchronizationManager::s_pObjSynchMgr = NULL;
     Volatile<LONG> CPalSynchronizationManager::s_lInitStatus PAL_GLOBAL = SynchMgrStatusIdle;
     CRITICAL_SECTION CPalSynchronizationManager::s_csSynchProcessLock PAL_GLOBAL;
@@ -157,13 +157,13 @@ namespace CorUnix
 #if HAVE_KQUEUE && !HAVE_BROKEN_FIFO_KEVENT
         m_iKQueue = -1;
         // Initialize data to 0 and flags to EV_EOF
-        EV_SET(&m_keProcessPipeEvent, 0, 0, EV_EOF, 0, 0, 0);        
-#endif // HAVE_KQUEUE            
+        EV_SET(&m_keProcessPipeEvent, 0, 0, EV_EOF, 0, 0, 0);
+#endif // HAVE_KQUEUE
     }
 
     CPalSynchronizationManager::~CPalSynchronizationManager()
     {
-    }        
+    }
 
     /*++
     Method:
@@ -171,8 +171,8 @@ namespace CorUnix
 
     Call by a thread to go to sleep for a wait or a sleep
 
-    NOTE: This methot must must be called without holding any 
-          synchronization lock (as well as other locks) 
+    NOTE: This methot must must be called without holding any
+          synchronization lock (as well as other locks)
     --*/
     PAL_ERROR CPalSynchronizationManager::BlockThread(
         CPalThread *pthrCurrent,
@@ -189,58 +189,58 @@ namespace CorUnix
         DWORD dwSigObjIdx = 0;
         bool fRaceAlerted = false;
         bool fEarlyDeath = false;
-            
+
         pdwWaitState = SharedIDToTypePointer(DWORD,
                 pthrCurrent->synchronizationInfo.m_shridWaitAwakened);
 
         _ASSERT_MSG(NULL != pdwWaitState,
                     "Got NULL pdwWaitState from m_shridWaitAwakened=%p\n",
                     (VOID *)pthrCurrent->synchronizationInfo.m_shridWaitAwakened);
-        
+
         if (fIsSleep)
         {
             // If fIsSleep is true we are being called by Sleep/SleepEx
-            // and we need to switch the wait state to TWS_WAITING or 
+            // and we need to switch the wait state to TWS_WAITING or
             // TWS_ALERTABLE (according to fAlertable)
 
-            if (fAlertable) 
+            if (fAlertable)
             {
-                // If we are in alertable mode we need to grab the lock to 
-                // make sure that no APC is queued right before the 
-                // InterlockedCompareExchange. 
+                // If we are in alertable mode we need to grab the lock to
+                // make sure that no APC is queued right before the
+                // InterlockedCompareExchange.
                 // If there are APCs queued at this time, no native wakeup
                 // will be posted, so we need to skip the native wait
-                
+
                 // Lock
                 AcquireLocalSynchLock(pthrCurrent);
                 AcquireSharedSynchLock(pthrCurrent);
 
                 if (AreAPCsPending(pthrCurrent))
                 {
-                    // APCs have been queued when the thread wait status was 
+                    // APCs have been queued when the thread wait status was
                     // still TWS_ACTIVE, therefore the queueing thread will not
-                    // post any native wakeup: we need to skip the actual 
+                    // post any native wakeup: we need to skip the actual
                     // native wait
                     fRaceAlerted = true;
                 }
-            }                
+            }
 
             if (!fRaceAlerted)
             {
-                // Setting the thread in wait state 
+                // Setting the thread in wait state
                 dwWaitState = (DWORD)(fAlertable ? TWS_ALERTABLE : TWS_WAITING);
 
                 TRACE("Switching my wait state [%p] from TWS_ACTIVE to %u "
-                      "[current *pdwWaitState=%u]\n", 
+                      "[current *pdwWaitState=%u]\n",
                       pdwWaitState, dwWaitState, *pdwWaitState);
 
-                dwWaitState = InterlockedCompareExchange((LONG *)pdwWaitState, 
-                                                         dwWaitState, 
+                dwWaitState = InterlockedCompareExchange((LONG *)pdwWaitState,
+                                                         dwWaitState,
                                                          TWS_ACTIVE);
-                
+
                 if((DWORD)TWS_ACTIVE != dwWaitState)
                 {
-                    if (fAlertable) 
+                    if (fAlertable)
                     {
                         // Unlock
                         ReleaseSharedSynchLock(pthrCurrent);
@@ -248,7 +248,7 @@ namespace CorUnix
                     }
                     if((DWORD)TWS_EARLYDEATH == dwWaitState)
                     {
-                        // Process is terminating, this thread will soon be 
+                        // Process is terminating, this thread will soon be
                         // suspended (by SuspendOtherThreads).
                         WARN("Thread is about to get suspended by "
                              "TerminateProcess\n");
@@ -258,22 +258,22 @@ namespace CorUnix
                     }
                     else
                     {
-                        ASSERT("Unexpected thread wait state %u\n", 
+                        ASSERT("Unexpected thread wait state %u\n",
                                dwWaitState);
                         palErr = ERROR_INTERNAL_ERROR;
                     }
                     goto BT_exit;
                 }
             }
-            
-            if (fAlertable) 
+
+            if (fAlertable)
             {
                 // Unlock
                 ReleaseSharedSynchLock(pthrCurrent);
                 ReleaseLocalSynchLock(pthrCurrent);
             }
         }
-        
+
         if (fRaceAlerted)
         {
             twrWakeupReason = Alerted;
@@ -298,7 +298,7 @@ namespace CorUnix
             TRACE("ThreadNativeWait returned {WakeupReason=%u "
                   "dwSigObjIdx=%u}\n", twrWakeupReason, dwSigObjIdx);
         }
-                
+
         if (WaitTimeout == twrWakeupReason)
         {
             // timeout reached. set wait state back to 'active'
@@ -307,14 +307,14 @@ namespace CorUnix
             TRACE("Current thread awakened for timeout: switching wait "
                   "state [%p] from %u to TWS_ACTIVE [current *pdwWaitState=%u]\n",
                    pdwWaitState, dwWaitState, *pdwWaitState);
-            
+
             DWORD dwOldWaitState = InterlockedCompareExchange(
                                         (LONG *)pdwWaitState,
                                         TWS_ACTIVE, (LONG)dwWaitState);
-            
+
             switch (dwOldWaitState)
             {
-                case TWS_ACTIVE:                        
+                case TWS_ACTIVE:
                     // We were already ACTIVE; someone decided to wake up this
                     // thread sometime between the moment the native wait
                     // timed out and here. Since the signaling side succeeded
@@ -325,8 +325,8 @@ namespace CorUnix
                     // That will also cause this method to report a signal
                     // rather than a timeout.
                     // In the remote signaling scenario, this second wait
-                    // also makes sure that the shared id passed over the 
-                    // process pipe is valid for the entire duration of time 
+                    // also makes sure that the shared id passed over the
+                    // process pipe is valid for the entire duration of time
                     // in which the worker thread deals with it
                     TRACE("Current thread already ACTIVE: a signaling raced "
                           "with the timeout: re-waiting natively to clear the "
@@ -340,7 +340,7 @@ namespace CorUnix
 
                     if (NO_ERROR != palErr)
                     {
-                        ERROR("ThreadNativeWait() failed [palErr=%d]\n", 
+                        ERROR("ThreadNativeWait() failed [palErr=%d]\n",
                               palErr);
                         twrWakeupReason = WaitFailed;
                     }
@@ -351,8 +351,8 @@ namespace CorUnix
                     break;
                 case TWS_EARLYDEATH:
                     // Thread is about to be suspended by TerminateProcess.
-                    // Anyway, if the wait timed out, we still want to 
-                    // (try to) unregister the wait (especially if it 
+                    // Anyway, if the wait timed out, we still want to
+                    // (try to) unregister the wait (especially if it
                     // involves shared objects)
                     WARN("Thread is about to be suspended by "
                          "TerminateProcess\n");
@@ -379,7 +379,7 @@ namespace CorUnix
 
                 TRACE("Current thread awakened for timeout: "
                             "unregistering the wait\n");
-                
+
                 // Local lock
                 AcquireLocalSynchLock(pthrCurrent);
 
@@ -392,7 +392,7 @@ namespace CorUnix
 
                 // Unlock
                 ReleaseLocalSynchLock(pthrCurrent);
-                
+
                 break;
             }
             case WaitSucceeded:
@@ -401,16 +401,16 @@ namespace CorUnix
                 break;
             default:
                 // 'Alerted' and 'WaitFailed' go through this case
-                break;                
+                break;
         }
 
         // Set the returned wakeup reason
         *ptwrWakeupReason = twrWakeupReason;
-                
+
         TRACE("Current thread is now active [WakeupReason=%u SigObjIdx=%u]\n",
               twrWakeupReason, dwSigObjIdx);
 
-        _ASSERT_MSG(TWS_ACTIVE == VolatileLoad(pdwWaitState) || 
+        _ASSERT_MSG(TWS_ACTIVE == VolatileLoad(pdwWaitState) ||
                     TWS_EARLYDEATH == VolatileLoad(pdwWaitState),
                     "Unexpected thread wait state %u\n", VolatileLoad(pdwWaitState));
 
@@ -419,7 +419,7 @@ namespace CorUnix
         {
             ThreadPrepareForShutdown();
         }
-        return palErr;        
+        return palErr;
     }
 
 #if !SYNCHMGR_PIPE_BASED_THREAD_BLOCKING
@@ -432,11 +432,11 @@ namespace CorUnix
     {
         PAL_ERROR palErr = NO_ERROR;
         int iRet, iWaitRet = 0;
-        struct timespec tsAbsTmo;      
+        struct timespec tsAbsTmo;
 
         TRACE("ThreadNativeWait(ptnwdNativeWaitData=%p, dwTimeout=%u, ...)\n",
               ptnwdNativeWaitData, dwTimeout);
-        
+
         if (dwTimeout != INFINITE)
         {
             // Calculate absolute timeout
@@ -445,7 +445,7 @@ namespace CorUnix
             {
                 ERROR("Failed to convert timeout to absolute timeout\n");
                 goto TNW_exit;
-            }            
+            }
         }
 
         // Lock the mutex
@@ -457,9 +457,9 @@ namespace CorUnix
             *ptwrWakeupReason = WaitFailed;
             goto TNW_exit;
         }
-        
-        while (FALSE == ptnwdNativeWaitData->iPred) 
-        {            
+
+        while (FALSE == ptnwdNativeWaitData->iPred)
+        {
             if (INFINITE == dwTimeout)
             {
                 iWaitRet = pthread_cond_wait(&ptnwdNativeWaitData->cond,
@@ -467,44 +467,44 @@ namespace CorUnix
             }
             else
             {
-                iWaitRet = pthread_cond_timedwait(&ptnwdNativeWaitData->cond, 
-                                                  &ptnwdNativeWaitData->mutex, 
+                iWaitRet = pthread_cond_timedwait(&ptnwdNativeWaitData->cond,
+                                                  &ptnwdNativeWaitData->mutex,
                                                   &tsAbsTmo);
             }
 
             if (ETIMEDOUT == iWaitRet)
             {
                 _ASSERT_MSG(INFINITE != dwTimeout,
-                            "Got a ETIMEDOUT despite timeout was INFINITE\n");                    
+                            "Got a ETIMEDOUT despite timeout was INFINITE\n");
                 break;
             }
             else if (0 != iWaitRet)
             {
-                ERROR("pthread_cond_%swait returned %d [errno=%d (%s)]\n", 
-                       (INFINITE == dwTimeout) ? "" : "timed", 
+                ERROR("pthread_cond_%swait returned %d [errno=%d (%s)]\n",
+                       (INFINITE == dwTimeout) ? "" : "timed",
                        iWaitRet, errno, strerror(errno));
                 palErr = ERROR_INTERNAL_ERROR;
                 break;
-            }            
-        } 
+            }
+        }
 
         // Reset the predicate
         if (0 == iWaitRet)
         {
             // We don't want to reset the predicate if pthread_cond_timedwait
-            // timed out racing with a pthread_cond_signal. When 
+            // timed out racing with a pthread_cond_signal. When
             // pthread_cond_timedwait times out, it needs to grab the mutex
-            // before returning. At timeout time, it may happen that the 
+            // before returning. At timeout time, it may happen that the
             // signaling thread just grabbed the mutex, but it hasn't called
             // pthread_cond_signal yet. In this scenario pthread_cond_timedwait
             // will have to wait for the signaling side to release the mutex.
-            // As result it will return with error timeout, but the predicate 
-            // will be set. Since pthread_cond_timedwait timed out, the 
+            // As result it will return with error timeout, but the predicate
+            // will be set. Since pthread_cond_timedwait timed out, the
             // predicate value is intended for the next signal. In case of a
             // object signaling racing with a wait timeout this predicate value
             // will be picked up by the 'second native wait' (see comments in
             // BlockThread).
-            
+
             ptnwdNativeWaitData->iPred = FALSE;
         }
 
@@ -531,10 +531,10 @@ namespace CorUnix
         }
 
     TNW_exit:
-        
-        TRACE("ThreadNativeWait: returning %u [WakeupReason=%u]\n", 
+
+        TRACE("ThreadNativeWait: returning %u [WakeupReason=%u]\n",
               palErr, *ptwrWakeupReason);
-        
+
         return palErr;
     }
 
@@ -551,28 +551,28 @@ namespace CorUnix
         DWORD dwOldTime = GetTickCount();
         int iRet;
         int iPollTmo;
-        int iWaitRet = 0;  
+        int iWaitRet = 0;
         struct pollfd pllfd;
         bool fAgain;
 
         TRACE("ThreadNativeWait(ptnwdNativeWaitData=%p, dwTimeout=%u, ...)\n",
               ptnwdNativeWaitData, dwTimeout);
-        
+
         do
         {
             fAgain = false;
-            
+
             pllfd.fd = ptnwdNativeWaitData->iPipeRd;
             pllfd.events = POLLIN;
             pllfd.revents = 0;
-            iPollTmo = (INFINITE == dwTmo) ? INFTIM : (int)min(INT_MAX,dwTmo);            
+            iPollTmo = (INFINITE == dwTmo) ? INFTIM : (int)min(INT_MAX,dwTmo);
 
             iRet = poll(&pllfd, 1, iPollTmo);
 
             if (1 == iRet &&
                 ((POLLERR | POLLHUP | POLLNVAL) & pllfd.revents))
             {
-                ERROR("Unexpected revents=%x while polling pipe %d\n", 
+                ERROR("Unexpected revents=%x while polling pipe %d\n",
                       pllfd.revents, ptnwdNativeWaitData->iPipeRd);
                 palErr = ERROR_INTERNAL_ERROR;
                 break;
@@ -585,7 +585,7 @@ namespace CorUnix
                     if(EINTR != errno)
                     {
                         // Error
-                        ERROR("Unexpected errno=%d (%s) while polling pipe %d\n", 
+                        ERROR("Unexpected errno=%d (%s) while polling pipe %d\n",
                               errno, strerror(errno), ptnwdNativeWaitData->iPipeRd);
                         palErr = ERROR_INTERNAL_ERROR;
                         break;
@@ -606,7 +606,7 @@ namespace CorUnix
                     else
                     {
                         _ASSERTE(INFINITE != dwTimeout);
-                        *ptwrWakeupReason = WaitTimeout;                        
+                        *ptwrWakeupReason = WaitTimeout;
                     }
                     break;
                 case 1:
@@ -618,27 +618,27 @@ namespace CorUnix
 
                     _ASSERTE(sizeof(c) == iRt);
                     _ASSERTE(c == (char)ptnwdNativeWaitData->twrWakeupReason);
-                    
+
                     *ptwrWakeupReason  = ptnwdNativeWaitData->twrWakeupReason;
                     *pdwSignaledObject = ptnwdNativeWaitData->dwObjectIndex;
                     break;
                 }
                 default:
                     // Error
-                    ERROR("Unexpected return code %d while polling pipe %d\n", 
+                    ERROR("Unexpected return code %d while polling pipe %d\n",
                           iRet, ptnwdNativeWaitData->iPipeRd);
 
                     palErr = ERROR_INTERNAL_ERROR;
                     break;
             }
-                    
+
         } while (fAgain);
 
     TNW_exit:
-        
-        TRACE("ThreadNativeWait: returning %u [WakeupReason=%u]\n", 
+
+        TRACE("ThreadNativeWait: returning %u [WakeupReason=%u]\n",
               palErr, *ptwrWakeupReason);
-        
+
         return palErr;
     }
 
@@ -649,7 +649,7 @@ namespace CorUnix
       CPalSynchronizationManager::AbandonObjectsOwnedByThread
 
     This method is called by a thread at thread-exit time to abandon
-    any currently owned waitable object (mutexes). If pthrTarget is 
+    any currently owned waitable object (mutexes). If pthrTarget is
     different from pthrCurrent, AbandonObjectsOwnedByThread assumes
     to be called whether by TerminateThread or at shutdown time. See
     comments below for more details
@@ -661,7 +661,7 @@ namespace CorUnix
         PAL_ERROR palErr = NO_ERROR;
         OwnedObjectsListNode * poolnItem;
         bool fSharedSynchLock = false;
-        CThreadSynchronizationInfo * pSynchInfo = 
+        CThreadSynchronizationInfo * pSynchInfo =
                     &pthrTarget->synchronizationInfo;
         CPalSynchronizationManager * pSynchManager = GetInstance();
 
@@ -680,8 +680,8 @@ namespace CorUnix
 
             TRACE("Abandoning object with SynchData at %p\n",
                   psdSynchData);
-            
-            if (!fSharedSynchLock && 
+
+            if (!fSharedSynchLock &&
                 (SharedObject == psdSynchData->GetObjectDomain()))
             {
                 AcquireSharedSynchLock(pthrCurrent);
@@ -694,7 +694,7 @@ namespace CorUnix
             // Set abandoned status; in case there is a thread to be released:
             //  - if the thread is local, ReleaseFirstWaiter will reset the
             //    abandoned status
-            //  - if the thread is remote, the remote worker thread will use 
+            //  - if the thread is remote, the remote worker thread will use
             //    the value and reset it
             psdSynchData->SetAbandoned(true);
 
@@ -705,7 +705,7 @@ namespace CorUnix
             psdSynchData->Release(pthrCurrent);
 
             // Return node to the cache
-            pSynchManager->m_cacheOwnedObjectsListNodes.Add(pthrCurrent, 
+            pSynchManager->m_cacheOwnedObjectsListNodes.Add(pthrCurrent,
                                                             poolnItem);
         }
 
@@ -715,34 +715,34 @@ namespace CorUnix
             // at shutdown time, right before the target thread is suspended,
             // or anyway the target thread is being terminated.
             // In this case we switch its wait state to TWS_EARLYDEATH so that,
-            // if the thread is currently waiting/sleeping and it wakes up 
-            // before shutdown code manage to suspend it, it will be rerouted 
+            // if the thread is currently waiting/sleeping and it wakes up
+            // before shutdown code manage to suspend it, it will be rerouted
             // to ThreadPrepareForShutdown (that will be done without holding
             // any internal lock, in a way to accomodate shutdown time thread
-            // suspension). 
-            // At this time we also unregister the wait, so no dummy nodes are 
+            // suspension).
+            // At this time we also unregister the wait, so no dummy nodes are
             // left around on waiting objects.
             // The TWS_EARLYDEATH wait-state will also prevent the thread from
-            // successfully registering for a possible new wait in the same 
+            // successfully registering for a possible new wait in the same
             // time window.
             LONG lTWState;
             DWORD * pdwWaitState;
-            
+
             pdwWaitState = SharedIDToTypePointer(DWORD,
                 pthrTarget->synchronizationInfo.m_shridWaitAwakened);
 
-            lTWState = InterlockedExchange((LONG *)pdwWaitState, 
+            lTWState = InterlockedExchange((LONG *)pdwWaitState,
                                            TWS_EARLYDEATH);
 
-            if ( (((LONG)TWS_WAITING == lTWState) || 
+            if ( (((LONG)TWS_WAITING == lTWState) ||
                   ((LONG)TWS_ALERTABLE == lTWState)) &&
                  (0 < pSynchInfo->m_twiWaitInfo.lObjCount) )
             {
                 // Unregister the wait
                 // Note: UnRegisterWait will take care of grabbing the shared
                 //       synch lock, if needed.
-                UnRegisterWait(pthrCurrent, 
-                               &pSynchInfo->m_twiWaitInfo, 
+                UnRegisterWait(pthrCurrent,
+                               &pSynchInfo->m_twiWaitInfo,
                                fSharedSynchLock);
             }
         }
@@ -776,9 +776,9 @@ namespace CorUnix
                                              rgObjects,
                                              dwObjectCount,
                                              (void **)rgControllers,
-                                             CSynchControllerBase::WaitController);                                                     
-    }                                
-    
+                                             CSynchControllerBase::WaitController);
+    }
+
     /*++
     Method:
       CPalSynchronizationManager::GetSynchStateControllersForObjects
@@ -797,13 +797,13 @@ namespace CorUnix
                                              dwObjectCount,
                                              (void **)rgControllers,
                                              CSynchControllerBase::StateController);
-    }                                
-    
+    }
+
     /*++
     Method:
       CPalSynchronizationManager::GetSynchControllersForObjects
 
-    Internal common implementation for GetSynchWaitControllersForObjects and 
+    Internal common implementation for GetSynchWaitControllersForObjects and
     GetSynchStateControllersForObjects
     --*/
     PAL_ERROR CPalSynchronizationManager::GetSynchControllersForObjects(
@@ -813,17 +813,17 @@ namespace CorUnix
         void ** ppvControllers,
         CSynchControllerBase::ControllerType ctCtrlrType)
     {
-        PAL_ERROR palErr = NO_ERROR;        
+        PAL_ERROR palErr = NO_ERROR;
         unsigned int uIdx, uCount = 0, uSharedObjectCount = 0;
         WaitDomain wdWaitDomain = LocalWait;
-        CObjectType * potObjectType = NULL; 
+        CObjectType * potObjectType = NULL;
         unsigned int uErrCleanupIdxFirstNotInitializedCtrlr = 0;
         unsigned int uErrCleanupIdxLastCtrlr = 0;
         bool fLocalSynchLock = false;
-        union 
-        { 
+        union
+        {
             CSynchWaitController * pWaitCtrlrs[MAXIMUM_WAIT_OBJECTS];
-            CSynchStateController * pStateCtrlrs[MAXIMUM_WAIT_OBJECTS];  
+            CSynchStateController * pStateCtrlrs[MAXIMUM_WAIT_OBJECTS];
         } Ctrlrs;
 
         if ((dwObjectCount <= 0) || (dwObjectCount > MAXIMUM_WAIT_OBJECTS))
@@ -831,30 +831,30 @@ namespace CorUnix
             palErr = ERROR_INVALID_PARAMETER;
             goto GSCFO_exit;
         }
-                
+
         if (CSynchControllerBase::WaitController == ctCtrlrType)
         {
             uCount = (unsigned int)m_cacheWaitCtrlrs.Get(pthrCurrent,
-                                                         dwObjectCount, 
+                                                         dwObjectCount,
                                                          Ctrlrs.pWaitCtrlrs);
         }
         else
         {
-            uCount = (unsigned int)m_cacheStateCtrlrs.Get(pthrCurrent, 
+            uCount = (unsigned int)m_cacheStateCtrlrs.Get(pthrCurrent,
                                                           dwObjectCount,
                                                           Ctrlrs.pStateCtrlrs);
         }
         if (uCount < dwObjectCount)
         {
-            // We got less controllers (uCount) than we asked for (dwObjectCount), 
+            // We got less controllers (uCount) than we asked for (dwObjectCount),
             // probably because of low memory.
             // None of these controllers is initialized, so they must be all
             // returned directly to the cache
             uErrCleanupIdxLastCtrlr = uCount;
-            
+
             palErr = ERROR_NOT_ENOUGH_MEMORY;
             goto GSCFO_error_cleanup;
-        }          
+        }
 
         //
         // We need to acquire the local synch lock before evaluating object
@@ -867,10 +867,10 @@ namespace CorUnix
         {
             if (SharedObject == rgObjects[uIdx]->GetObjectDomain())
             {
-                ++uSharedObjectCount; 
+                ++uSharedObjectCount;
             }
             if (uSharedObjectCount > 0 && uSharedObjectCount <= uIdx)
-            {            
+            {
                 wdWaitDomain = MixedWait;
                 break;
             }
@@ -878,10 +878,10 @@ namespace CorUnix
         if (dwObjectCount == uSharedObjectCount)
         {
             wdWaitDomain = SharedWait;
-        } 
-        
+        }
+
         for (uIdx=0;uIdx<dwObjectCount;uIdx++)
-        {   
+        {
             void * pvSData;
             CSynchData * psdSynchData;
             ObjectDomain odObjectDomain = rgObjects[uIdx]->GetObjectDomain();
@@ -893,13 +893,13 @@ namespace CorUnix
             }
 
             psdSynchData = (SharedObject == odObjectDomain) ? SharedIDToTypePointer(
-                CSynchData, reinterpret_cast<SharedID>(pvSData)) : 
+                CSynchData, reinterpret_cast<SharedID>(pvSData)) :
                 static_cast<CSynchData *>(pvSData);
 
             VALIDATEOBJECT(psdSynchData);
 
             potObjectType = rgObjects[uIdx]->GetObjectType();
-            
+
 
             if (CSynchControllerBase::WaitController == ctCtrlrType)
             {
@@ -933,12 +933,12 @@ namespace CorUnix
                     (void **)&pProcLocData);
                 if (NO_ERROR != palErr)
                 {
-                    // In case of failure here, bail out of the loop, but 
-                    // keep track (by incrementing the counter 'uIdx') of the 
+                    // In case of failure here, bail out of the loop, but
+                    // keep track (by incrementing the counter 'uIdx') of the
                     // fact that this controller has already being initialized
                     // and therefore need to be Release'd rather than just
                     // returned to the cache
-                    uIdx++;                    
+                    uIdx++;
                     break;
                 }
 
@@ -949,12 +949,12 @@ namespace CorUnix
         if (NO_ERROR != palErr)
         {
             // An error occurred while initializing the (uIdx+1)-th controller,
-            // i.e. the one at index uIdx; therefore the first uIdx controllers 
-            // must be Release'd, while the remaining uCount-uIdx must be returned 
+            // i.e. the one at index uIdx; therefore the first uIdx controllers
+            // must be Release'd, while the remaining uCount-uIdx must be returned
             // directly to the cache.
             uErrCleanupIdxFirstNotInitializedCtrlr = uIdx;
             uErrCleanupIdxLastCtrlr = dwObjectCount;
-            
+
             goto GSCFO_error_cleanup;
         }
 
@@ -964,12 +964,12 @@ namespace CorUnix
             for (uIdx=0;uIdx<dwObjectCount;uIdx++)
             {
                 // The multiple cast is NEEDED, though currently it does not
-                // change the value ot the pointer. Anyway, if in the future 
-                // a virtual method should be added to the base class 
-                // CSynchControllerBase, both derived classes would have two 
+                // change the value ot the pointer. Anyway, if in the future
+                // a virtual method should be added to the base class
+                // CSynchControllerBase, both derived classes would have two
                 // virtual tables, therefore a static cast from, for instance,
-                // a CSynchWaitController* to a ISynchWaitController* would 
-                // return the given pointer incremented by the size of a 
+                // a CSynchWaitController* to a ISynchWaitController* would
+                // return the given pointer incremented by the size of a
                 // generic pointer on the specific platform
 
                 ppvControllers[uIdx] = reinterpret_cast<void *>(
@@ -986,8 +986,8 @@ namespace CorUnix
                     static_cast<ISynchStateController *>(Ctrlrs.pStateCtrlrs[uIdx]));
             }
         }
-        
-        // Succeeded: skip error cleanup        
+
+        // Succeeded: skip error cleanup
         goto GSCFO_exit;
 
     GSCFO_error_cleanup:
@@ -1017,15 +1017,15 @@ namespace CorUnix
                 m_cacheStateCtrlrs.Add(pthrCurrent, Ctrlrs.pStateCtrlrs[uIdx]);
             }
         }
-               
+
     GSCFO_exit:
-    
+
         if (fLocalSynchLock)
         {
             ReleaseLocalSynchLock(pthrCurrent);
         }
-        return palErr;        
-    }                                
+        return palErr;
+    }
 
     /*++
     Method:
@@ -1037,14 +1037,14 @@ namespace CorUnix
         CObjectType *potObjectType,
         ObjectDomain odObjectDomain,
         VOID **ppvSynchData)
-    {    
+    {
         PAL_ERROR palErr = NO_ERROR;
         CSynchData * psdSynchData = NULL;
         CPalThread * pthrCurrent = InternalGetCurrentThread();
 
         if (SharedObject == odObjectDomain)
         {
-            SharedID shridSynchData = m_cacheSHRSynchData.Get(pthrCurrent); 
+            SharedID shridSynchData = m_cacheSHRSynchData.Get(pthrCurrent);
             if (NULLSharedID == shridSynchData)
             {
                 ERROR("Unable to allocate shared memory\n");
@@ -1063,28 +1063,28 @@ namespace CorUnix
 
             // Store shared pointer to this object
             psdSynchData->SetSharedThis(shridSynchData);
-            
+
             *ppvSynchData = reinterpret_cast<void *>(shridSynchData);
         }
         else
         {
-            psdSynchData = m_cacheSynchData.Get(pthrCurrent); 
+            psdSynchData = m_cacheSynchData.Get(pthrCurrent);
             if (NULL == psdSynchData)
             {
                 ERROR("Unable to allocate memory\n");
                 palErr = ERROR_NOT_ENOUGH_MEMORY;
                 goto AOSD_exit;
             }
-            
+
             // Initialize waiting list pointers
             psdSynchData->SetWTLHeadPtr(NULL);
             psdSynchData->SetWTLTailPtr(NULL);
 
             // Set shared this pointer to NULL
             psdSynchData->SetSharedThis(NULLSharedID);
-            
+
             *ppvSynchData = static_cast<void *>(psdSynchData);
-        }        
+        }
 
         // Initialize object domain and object type;
         psdSynchData->SetObjectDomain(odObjectDomain);
@@ -1092,8 +1092,8 @@ namespace CorUnix
 
     AOSD_exit:
         return palErr;
-    }                                
-    
+    }
+
     /*++
     Method:
       CPalSynchronizationManager::FreeObjectSynchData
@@ -1101,7 +1101,7 @@ namespace CorUnix
     Called to return a no longer used SynchData to the Synchronization
     Manager. The SynchData may actually survive this call, since it
     is a ref-counted object and at FreeObjectSynchData time it may still
-    be used from withing the Synchronization Manager itself (e.g. the 
+    be used from withing the Synchronization Manager itself (e.g. the
     Worker Thread)
     --*/
     void CPalSynchronizationManager::FreeObjectSynchData(
@@ -1132,7 +1132,7 @@ namespace CorUnix
     FOSD_exit:
         return;
     }
-    
+
     /*++
     Method:
       CPalSynchronizationManager::CreateSynchStateController
@@ -1146,13 +1146,13 @@ namespace CorUnix
         ObjectDomain odObjectDomain,
         ISynchStateController **ppStateController)
     {
-        PAL_ERROR palErr = NO_ERROR;        
+        PAL_ERROR palErr = NO_ERROR;
         CSynchStateController * pCtrlr =  NULL;
         WaitDomain wdWaitDomain = (SharedObject == odObjectDomain) ? SharedWait : LocalWait;
         CSynchData * psdSynchData;
 
         psdSynchData = (SharedObject == odObjectDomain) ? SharedIDToTypePointer(
-            CSynchData, reinterpret_cast<SharedID>(pvSynchData)) : 
+            CSynchData, reinterpret_cast<SharedID>(pvSynchData)) :
             static_cast<CSynchData *>(pvSynchData);
 
         VALIDATEOBJECT(psdSynchData);
@@ -1162,7 +1162,7 @@ namespace CorUnix
         {
             palErr = ERROR_NOT_ENOUGH_MEMORY;
             goto CSSC_exit;
-        }                  
+        }
 
         pCtrlr->Init(pthrCurrent,
                      CSynchControllerBase::StateController,
@@ -1173,15 +1173,15 @@ namespace CorUnix
 
         // Succeeded
         *ppStateController = (ISynchStateController *)pCtrlr;
-        
+
     CSSC_exit:
         if ((NO_ERROR != palErr) && (NULL != pCtrlr))
         {
             m_cacheStateCtrlrs.Add(pthrCurrent, pCtrlr);
         }
-        return palErr;     
+        return palErr;
     }
-    
+
     /*++
     Method:
       CPalSynchronizationManager::CreateSynchWaitController
@@ -1195,24 +1195,24 @@ namespace CorUnix
         ObjectDomain odObjectDomain,
         ISynchWaitController **ppWaitController)
     {
-        PAL_ERROR palErr = NO_ERROR;        
+        PAL_ERROR palErr = NO_ERROR;
         CSynchWaitController * pCtrlr =  NULL;
         WaitDomain wdWaitDomain = (SharedObject == odObjectDomain) ? SharedWait : LocalWait;
         CSynchData * psdSynchData;
 
         psdSynchData = (SharedObject == odObjectDomain) ? SharedIDToTypePointer(
-            CSynchData, reinterpret_cast<SharedID>(pvSynchData)) : 
+            CSynchData, reinterpret_cast<SharedID>(pvSynchData)) :
             static_cast<CSynchData *>(pvSynchData);
 
         VALIDATEOBJECT(psdSynchData);
-            
+
         pCtrlr = m_cacheWaitCtrlrs.Get(pthrCurrent);
         if (NULL == pCtrlr)
         {
             palErr = ERROR_NOT_ENOUGH_MEMORY;
             goto CSWC_exit;
-        }                  
-       
+        }
+
         pCtrlr->Init(pthrCurrent,
                      CSynchControllerBase::WaitController,
                      odObjectDomain,
@@ -1222,7 +1222,7 @@ namespace CorUnix
 
         // Succeeded
         *ppWaitController = (ISynchWaitController *)pCtrlr;
-       
+
     CSWC_exit:
         if ((NO_ERROR != palErr) && (NULL != pCtrlr))
         {
@@ -1247,17 +1247,17 @@ namespace CorUnix
         DWORD dwWaitState;
         DWORD * pdwWaitState;
         ThreadWaitInfo * pTargetTWInfo = GetThreadWaitInfo(pthrTarget);
-        bool fLocalSynchLock = false; 
-        bool fSharedSynchLock = false; 
+        bool fLocalSynchLock = false;
+        bool fSharedSynchLock = false;
         bool fThreadLock = false;
 
         ptainNode = m_cacheThreadApcInfoNodes.Get(pthrCurrent);
         if (NULL == ptainNode)
-        {                           
+        {
             ERROR("No memory for new APCs linked list entry\n");
             palErr = ERROR_NOT_ENOUGH_MEMORY;
             goto QUAPC_exit;
-        }                
+        }
 
         ptainNode->pfnAPC = pfnAPC;
         ptainNode->pAPCData = uptrData;
@@ -1265,13 +1265,13 @@ namespace CorUnix
 
         AcquireLocalSynchLock(pthrCurrent);
         fLocalSynchLock = true;
-        
+
         if (LocalWait != pTargetTWInfo->wdWaitDomain)
         {
             AcquireSharedSynchLock(pthrCurrent);
             fSharedSynchLock = true;
         }
-        
+
         pthrTarget->Lock(pthrCurrent);
         fThreadLock = true;
 
@@ -1295,7 +1295,7 @@ namespace CorUnix
         if (NULL == pthrTarget->apcInfo.m_ptainTail)
         {
             _ASSERT_MSG(NULL == pthrTarget->apcInfo.m_ptainHead,
-                        "Corrupted APC list\n"); 
+                        "Corrupted APC list\n");
 
             pthrTarget->apcInfo.m_ptainHead = ptainNode;
             pthrTarget->apcInfo.m_ptainTail = ptainNode;
@@ -1308,11 +1308,11 @@ namespace CorUnix
 
         // Set ptainNode to NULL so it won't be readded to the cache
         ptainNode = NULL;
-        
-        TRACE("APC %p with parameter %p added to APC queue\n", 
+
+        TRACE("APC %p with parameter %p added to APC queue\n",
              pfnAPC, uptrData);
 
-        dwWaitState = InterlockedCompareExchange((LONG *)pdwWaitState,  
+        dwWaitState = InterlockedCompareExchange((LONG *)pdwWaitState,
                                                  (LONG)TWS_ACTIVE,
                                                  (LONG)TWS_ALERTABLE);
 
@@ -1329,7 +1329,7 @@ namespace CorUnix
             palErr = WakeUpLocalThread(
                 pthrCurrent,
                 pthrTarget,
-                Alerted, 
+                Alerted,
                 0);
 
             if (NO_ERROR != palErr)
@@ -1338,12 +1338,12 @@ namespace CorUnix
                       "APCs [err=%u]\n", pthrTarget->GetThreadId(),
                       palErr);
             }
-        }    
+        }
 
     QUAPC_exit:
         if (fThreadLock)
         {
-            pthrTarget->Unlock(pthrCurrent); 
+            pthrTarget->Unlock(pthrCurrent);
         }
         if (fSharedSynchLock)
         {
@@ -1352,7 +1352,7 @@ namespace CorUnix
         if (fLocalSynchLock)
         {
             ReleaseLocalSynchLock(pthrCurrent);
-        }            
+        }
         if (ptainNode)
         {
             m_cacheThreadApcInfoNodes.Add(pthrCurrent, ptainNode);
@@ -1364,7 +1364,7 @@ namespace CorUnix
     Method:
       CPalSynchronizationManager::AreAPCsPending
 
-    Returns 'true' if there are APCs currently pending for the target 
+    Returns 'true' if there are APCs currently pending for the target
     thread (normally the current one)
     --*/
     bool CPalSynchronizationManager::AreAPCsPending(
@@ -1386,7 +1386,7 @@ namespace CorUnix
         ThreadApcInfoNode * ptainNode, * ptainLocalHead;
         int iAPCsCalled = 0;
 
-        while (TRUE) 
+        while (TRUE)
         {
             // Lock
             pthrCurrent->Lock(pthrCurrent);
@@ -1410,8 +1410,8 @@ namespace CorUnix
                 ptainLocalHead = ptainNode->pNext;
 
 #if _ENABLE_DEBUG_MESSAGES_
-                // reset ENTRY nesting level back to zero while 
-                // inside the callback ... 
+                // reset ENTRY nesting level back to zero while
+                // inside the callback ...
                 int iOldLevel = DBG_change_entrylevel(0);
 #endif /* _ENABLE_DEBUG_MESSAGES_ */
 
@@ -1474,7 +1474,7 @@ namespace CorUnix
     Private method, it is called only by CPalSynchMgrController.
     --*/
     IPalSynchronizationManager * CPalSynchronizationManager::CreatePalSynchronizationManager()
-    { 
+    {
         IPalSynchronizationManager * pRet = NULL;
         if (s_pObjSynchMgr == NULL)
         {
@@ -1500,20 +1500,20 @@ namespace CorUnix
         PAL_ERROR palErr = NO_ERROR;
         LONG lInit;
         CPalSynchronizationManager * pSynchManager = NULL;
-            
-        lInit = InterlockedCompareExchange(&s_lInitStatus, 
-                                           (LONG)SynchMgrStatusInitializing, 
+
+        lInit = InterlockedCompareExchange(&s_lInitStatus,
+                                           (LONG)SynchMgrStatusInitializing,
                                            (LONG)SynchMgrStatusIdle);
         if ((LONG)SynchMgrStatusIdle != lInit)
-        {      
+        {
             ASSERT("Synchronization Manager already being initialized");
             palErr = ERROR_INTERNAL_ERROR;
             goto I_exit;
         }
 
         InternalInitializeCriticalSection(&s_csSynchProcessLock);
-        InternalInitializeCriticalSection(&s_csMonitoredProcessesLock);        
-        
+        InternalInitializeCriticalSection(&s_csMonitoredProcessesLock);
+
         pSynchManager = InternalNew<CPalSynchronizationManager>();
         if (NULL == pSynchManager)
         {
@@ -1535,7 +1535,7 @@ namespace CorUnix
         g_pSynchronizationManager =
             static_cast<IPalSynchronizationManager *>(pSynchManager);
         s_lInitStatus = (LONG)SynchMgrStatusRunning;
-        
+
     I_exit:
         if (NO_ERROR != palErr)
         {
@@ -1572,7 +1572,7 @@ namespace CorUnix
             palErr = ERROR_INTERNAL_ERROR;
             goto SW_exit;
         }
-        
+
         palErr = InternalCreateThread(pthrCurrent,
                                       NULL,
                                       0,
@@ -1588,7 +1588,7 @@ namespace CorUnix
             ERROR("Unable to create worker thread\n");
             goto SW_exit;
         }
-        
+
         palErr = InternalGetThreadDataFromHandle(pthrCurrent,
                                                  hWorkerThread,
                                                  0,
@@ -1598,8 +1598,8 @@ namespace CorUnix
         {
             ERROR("Unable to get worker thread data\n");
             goto SW_exit;
-        }       
-                
+        }
+
     SW_exit:
         if (NULL != hWorkerThread)
         {
@@ -1612,12 +1612,12 @@ namespace CorUnix
     Method:
       CPalSynchronizationManager::PrepareForShutdown
 
-    This method performs the part of Synchronization Manager's shutdown that 
+    This method performs the part of Synchronization Manager's shutdown that
     needs to be carried out when core PAL subsystems are still active.
     Private method, it is called only by CPalSynchMgrController.
     --*/
     PAL_ERROR CPalSynchronizationManager::PrepareForShutdown()
-    {        
+    {
         PAL_ERROR palErr = NO_ERROR;
         LONG lInit;
         CPalSynchronizationManager * pSynchManager = GetInstance();
@@ -1635,16 +1635,16 @@ namespace CorUnix
         struct pollfd pllfd;
 #endif // SYNCHMGR_PIPE_BASED_THREAD_BLOCKING
 
-        lInit = InterlockedCompareExchange(&s_lInitStatus, 
+        lInit = InterlockedCompareExchange(&s_lInitStatus,
             (LONG)SynchMgrStatusShuttingDown, (LONG)SynchMgrStatusRunning);
 
         if ((LONG)SynchMgrStatusRunning != lInit)
         {
             ASSERT("Unexpected initialization status found "
-                   "in PrepareForShutdown [expected=%d current=%d]\n", 
+                   "in PrepareForShutdown [expected=%d current=%d]\n",
                    SynchMgrStatusRunning, lInit);
             // We intentionally not set s_lInitStatus to SynchMgrStatusError
-            // cause this could interfere with a previous thread already 
+            // cause this could interfere with a previous thread already
             // executing shutdown
             palErr = ERROR_INTERNAL_ERROR;
             goto PFS_exit;
@@ -1670,7 +1670,7 @@ namespace CorUnix
             goto PFS_exit;
         }
 
-        ptnwdWorkerThreadNativeData = 
+        ptnwdWorkerThreadNativeData =
             &pSynchManager->m_pthrWorker->synchronizationInfo.m_tnwdNativeData;
 
 #if !SYNCHMGR_PIPE_BASED_THREAD_BLOCKING
@@ -1696,7 +1696,7 @@ namespace CorUnix
             goto PFS_exit;
         }
 
-        while (FALSE == ptnwdWorkerThreadNativeData->iPred) 
+        while (FALSE == ptnwdWorkerThreadNativeData->iPred)
         {
             iRet = pthread_cond_timedwait(&ptnwdWorkerThreadNativeData->cond,
                                           &ptnwdWorkerThreadNativeData->mutex,
@@ -1734,13 +1734,13 @@ namespace CorUnix
         dwTmo = min(WorkerThreadTerminationTimeout, INT_MAX);
 
         do
-        {            
+        {
             fAgain = false;
 
             pllfd.fd = ptnwdWorkerThreadNativeData->iPipeRd;
             pllfd.events = POLLIN;
             pllfd.revents = 0;
-            iPollTmo = dwTmo;        
+            iPollTmo = dwTmo;
 
             iRet = poll(&pllfd, 1, iPollTmo);
 
@@ -1765,38 +1765,38 @@ namespace CorUnix
                         else
                         {
                             ERROR("Too many (%d) consecutive EAGAINs while polling "
-                                  "pipe %d, waiting for worker thread to exit\n", 
+                                  "pipe %d, waiting for worker thread to exit\n",
                                   iEagains, ptnwdWorkerThreadNativeData->iPipeRd);
                             palErr = ERROR_INTERNAL_ERROR;
                         }
                     }
                     else
                     {
-                        ERROR("Unexpected errno=%d (%s) while polling pipe %d\n", 
-                              errno, strerror(errno), 
+                        ERROR("Unexpected errno=%d (%s) while polling pipe %d\n",
+                              errno, strerror(errno),
                               ptnwdWorkerThreadNativeData->iPipeRd);
                         palErr = ERROR_INTERNAL_ERROR;
                     }
                     break;
                 default:
                     // Error
-                    ERROR("Unexpected return code %d while polling pipe %d\n", 
+                    ERROR("Unexpected return code %d while polling pipe %d\n",
                           iRet, ptnwdWorkerThreadNativeData->iPipeRd);
                     palErr = ERROR_INTERNAL_ERROR;
                     break;
             }
         } while (fAgain);
-        
+
 #endif // SYNCHMGR_PIPE_BASED_THREAD_BLOCKING
 
     PFS_exit:
-        if (NO_ERROR == palErr) 
+        if (NO_ERROR == palErr)
         {
             if (NULL != pSynchManager->m_pipoThread)
             {
                 pSynchManager->m_pipoThread->ReleaseReference(pthrCurrent);
 
-                // After this release both m_pipoThread and m_pthrWorker 
+                // After this release both m_pipoThread and m_pthrWorker
                 // are no longer valid
                 pSynchManager->m_pipoThread = NULL;
                 pSynchManager->m_pthrWorker = NULL;
@@ -1805,7 +1805,7 @@ namespace CorUnix
             // Ready for process shutdown
             s_lInitStatus = SynchMgrStatusReadyForProcessShutDown;
         }
-            
+
         return palErr;
     }
 
@@ -1818,14 +1818,14 @@ namespace CorUnix
     DWORD PALAPI CPalSynchronizationManager::WorkerThread(LPVOID pArg)
     {
         PAL_ERROR palErr;
-        bool fShuttingDown = false;        
+        bool fShuttingDown = false;
         bool fWorkerIsDone = false;
         int iPollTimeout = INFTIM;
         SynchWorkerCmd swcCmd;
         ThreadWakeupReason twrWakeUpReason;
         SharedID shridMarshaledData;
         DWORD dwData;
-        CPalSynchronizationManager * pSynchManager = 
+        CPalSynchronizationManager * pSynchManager =
             reinterpret_cast<CPalSynchronizationManager*>(pArg);
         CPalThread * pthrWorker = InternalGetCurrentThread();
 
@@ -1833,19 +1833,19 @@ namespace CorUnix
         {
             LONG lProcessCount;
 
-            palErr = pSynchManager->ReadCmdFromProcessPipe(iPollTimeout, 
+            palErr = pSynchManager->ReadCmdFromProcessPipe(iPollTimeout,
                                                            &swcCmd,
                                                            &shridMarshaledData,
-                                                           &dwData);            
+                                                           &dwData);
             if (NO_ERROR != palErr)
             {
                 ERROR("Received error %x from ReadCmdFromProcessPipe()\n",
-                      palErr);                
+                      palErr);
                 continue;
             }
             switch (swcCmd)
             {
-                case SynchWorkerCmdNop:                    
+                case SynchWorkerCmdNop:
                     TRACE("Synch Worker: received SynchWorkerCmdNop\n");
                     if (fShuttingDown)
                     {
@@ -1855,11 +1855,11 @@ namespace CorUnix
 
                         // Whether WorkerThreadShuttingDownTimeout has elapsed
                         // or the last process with a descriptor opened for
-                        // write on our process pipe, has just closed it, 
-                        // causing an EOF on the read fd (that can happen only 
-                        // at shutdown time since during normal run time we 
+                        // write on our process pipe, has just closed it,
+                        // causing an EOF on the read fd (that can happen only
+                        // at shutdown time since during normal run time we
                         // hold a fd opened for write within this process).
-                        // In both the case it is time to go for the worker 
+                        // In both the case it is time to go for the worker
                         // thread.
                         fWorkerIsDone = true;
                     }
@@ -1889,7 +1889,7 @@ namespace CorUnix
                     AcquireSharedSynchLock(pthrWorker);
                     fSharedSynchLock = true;
 
-                    pWLNode = SharedIDToTypePointer(WaitingThreadsListNode, 
+                    pWLNode = SharedIDToTypePointer(WaitingThreadsListNode,
                                                     shridMarshaledData);
 
                     _ASSERT_MSG(NULL != pWLNode, "Received bad Shared ID %p\n",
@@ -1905,22 +1905,22 @@ namespace CorUnix
 
 
                     // Get the object index
-                    dwObjIndex = pWLNode->dwObjIndex;                    
+                    dwObjIndex = pWLNode->dwObjIndex;
 
-                    // Get the WaitInfo                    
+                    // Get the WaitInfo
                     ptwiWaitInfo = pWLNode->ptwiWaitInfo;
 
                     // Initialize the WakeUpReason to WaitSucceeded
-                    twrWakeUpReason = WaitSucceeded;                              
-                                        
-                    CSynchData * psdSynchData = 
-                        SharedIDToTypePointer(CSynchData, 
+                    twrWakeUpReason = WaitSucceeded;
+
+                    CSynchData * psdSynchData =
+                        SharedIDToTypePointer(CSynchData,
                                               pWLNode->ptrOwnerObjSynchData.shrid);
-                    
+
                     TRACE("Synch Worker: received REMOTE SIGNAL cmd "
                         "[WInfo=%p {Type=%u Domain=%u ObjCount=%d TgtThread=%x} "
                         "SynchData={shriId=%p p=%p} {SigCount=%d IsAbandoned=%d}\n",
-                        ptwiWaitInfo, ptwiWaitInfo->wtWaitType, ptwiWaitInfo->wdWaitDomain, 
+                        ptwiWaitInfo, ptwiWaitInfo->wtWaitType, ptwiWaitInfo->wdWaitDomain,
                         ptwiWaitInfo->lObjCount, ptwiWaitInfo->pthrOwner->GetThreadId(),
                         (VOID *)pWLNode->ptrOwnerObjSynchData.shrid, psdSynchData,
                         psdSynchData->GetSignalCount(), psdSynchData->IsAbandoned());
@@ -1935,7 +1935,7 @@ namespace CorUnix
                         {
                             twrWakeUpReason = MutexAbondoned;
                         }
-                        
+
                         // Acquire ownership
                         palErr = psdSynchData->AssignOwnershipToThread(
                                     pthrWorker,
@@ -1950,16 +1950,16 @@ namespace CorUnix
                     }
 
                     // Unregister the wait
-                    pSynchManager->UnRegisterWait(pthrWorker, 
-                                                  ptwiWaitInfo, 
+                    pSynchManager->UnRegisterWait(pthrWorker,
+                                                  ptwiWaitInfo,
                                                   fSharedSynchLock);
 
                     // pWLNode is no longer valid after UnRegisterWait
                     pWLNode = NULL;
 
                     TRACE("Synch Worker: Waking up local thread %x "
-                          "{WakeUpReason=%u ObjIndex=%u}\n", 
-                          ptwiWaitInfo->pthrOwner->GetThreadId(), 
+                          "{WakeUpReason=%u ObjIndex=%u}\n",
+                          ptwiWaitInfo->pthrOwner->GetThreadId(),
                           twrWakeUpReason, dwObjIndex);
 
                     // Wake up the target thread
@@ -1990,31 +1990,31 @@ namespace CorUnix
                     TRACE("Synch Worker: received "
                           "SynchWorkerCmdDelegatedObjectSignaling\n");
 
-                    psdSynchData = SharedIDToTypePointer(CSynchData, 
-                                                       shridMarshaledData);                    
+                    psdSynchData = SharedIDToTypePointer(CSynchData,
+                                                       shridMarshaledData);
 
                     _ASSERT_MSG(NULL != psdSynchData, "Received bad Shared ID %p\n",
                                 shridMarshaledData);
-                    _ASSERT_MSG(0 < dwData && (DWORD)INT_MAX > dwData, 
+                    _ASSERT_MSG(0 < dwData && (DWORD)INT_MAX > dwData,
                                 "Received remote signaling with invalid signal "
-                                "count\n");                    
-                    
+                                "count\n");
+
                     // Lock
                     AcquireLocalSynchLock(pthrWorker);
-                    AcquireSharedSynchLock(pthrWorker);  
-                    
+                    AcquireSharedSynchLock(pthrWorker);
+
                     TRACE("Synch Worker: received DELEGATED OBJECT SIGNALING "
                         "cmd [SynchData={shriId=%p p=%p} SigCount=%u] [Current obj SigCount=%d "
-                        "IsAbandoned=%d]\n", (VOID *)shridMarshaledData, 
-                        psdSynchData, dwData, psdSynchData->GetSignalCount(), 
+                        "IsAbandoned=%d]\n", (VOID *)shridMarshaledData,
+                        psdSynchData, dwData, psdSynchData->GetSignalCount(),
                         psdSynchData->IsAbandoned());
 
-                    psdSynchData->Signal(pthrWorker, 
-                                       psdSynchData->GetSignalCount() + dwData, 
+                    psdSynchData->Signal(pthrWorker,
+                                       psdSynchData->GetSignalCount() + dwData,
                                        true);
 
                     // Current SynchData has been AddRef'd by remote process in
-                    // order to be marshaled to the current one, therefore at 
+                    // order to be marshaled to the current one, therefore at
                     // this point we need to release it
                     psdSynchData->Release(pthrWorker);
 
@@ -2027,23 +2027,23 @@ namespace CorUnix
                 case SynchWorkerCmdShutdown:
                     TRACE("Synch Worker: received SynchWorkerCmdShutdown\n");
 
-                    // Shutdown the process pipe: this will cause the process 
-                    // pipe to be unlinked and its write-only file descriptor 
+                    // Shutdown the process pipe: this will cause the process
+                    // pipe to be unlinked and its write-only file descriptor
                     // to be closed, so that when the last fd opened for write
-                    // on the fifo (from another process) will be closed, we 
-                    // will receive an EOF on the read end (i.e. poll in 
-                    // ReadBytesFromProcessPipe will return 1 with no data to 
-                    // be read). That will allow the worker thread to process 
-                    // possible commands already successfully written to the 
+                    // on the fifo (from another process) will be closed, we
+                    // will receive an EOF on the read end (i.e. poll in
+                    // ReadBytesFromProcessPipe will return 1 with no data to
+                    // be read). That will allow the worker thread to process
+                    // possible commands already successfully written to the
                     // pipe by some other process, before shutting down.
                     pSynchManager->ShutdownProcessPipe();
 
                     // Shutting down: this will cause the worker thread to
                     // fetch residual cmds from the process pipe until an
-                    // EOF is converted to a SynchWorkerCmdNop or the 
+                    // EOF is converted to a SynchWorkerCmdNop or the
                     // WorkerThreadShuttingDownTimeout has elapsed without
                     // receiving any cmd.
-                    fShuttingDown = true;                    
+                    fShuttingDown = true;
 
                     // Set the timeout to WorkerThreadShuttingDownTimeout
                     iPollTimeout = WorkerThreadShuttingDownTimeout;
@@ -2056,12 +2056,12 @@ namespace CorUnix
         }
 
         int iRet;
-        ThreadNativeWaitData * ptnwdWorkerThreadNativeData = 
+        ThreadNativeWaitData * ptnwdWorkerThreadNativeData =
             &pthrWorker->synchronizationInfo.m_tnwdNativeData;
 
 #if !SYNCHMGR_PIPE_BASED_THREAD_BLOCKING
         // Using the worker thread's predicate/condition/mutex
-        // (that normally are never used) to signal the shutting 
+        // (that normally are never used) to signal the shutting
         // down thread that the worker thread is done
         iRet = pthread_mutex_lock(&ptnwdWorkerThreadNativeData->mutex);
         _ASSERT_MSG(0 == iRet, "Cannot lock mutex [err=%d]\n", iRet);
@@ -2071,29 +2071,29 @@ namespace CorUnix
         iRet = pthread_cond_signal(&ptnwdWorkerThreadNativeData->cond);
         if (0 != iRet)
         {
-            ERROR ("pthread_cond_signal returned %d [errno=%d (%s)]\n", 
+            ERROR ("pthread_cond_signal returned %d [errno=%d (%s)]\n",
                    iRet, errno, strerror(errno));
-        }            
+        }
 
-        iRet = pthread_mutex_unlock(&ptnwdWorkerThreadNativeData->mutex);        
+        iRet = pthread_mutex_unlock(&ptnwdWorkerThreadNativeData->mutex);
         _ASSERT_MSG(0 == iRet, "Cannot lock mutex [err=%d]\n", iRet);
 
 #else // SYNCHMGR_PIPE_BASED_THREAD_BLOCKING
 
-        // Using the worker thread's blocking pipe 
-        // (that normally is never used) to signal the shutting 
+        // Using the worker thread's blocking pipe
+        // (that normally is never used) to signal the shutting
         // down thread that the worker thread is done
         int iEagains = 0;
         char cCode = (char)SynchWorkerCmdNop;
 
         do
         {
-            iRet = write(ptnwdWorkerThreadNativeData->iPipeWr, 
-                         (void *)&cCode, 
+            iRet = write(ptnwdWorkerThreadNativeData->iPipeWr,
+                         (void *)&cCode,
                          sizeof(cCode));
-        } while (-1 == iRet && 
-                 EAGAIN == errno && 
-                 MaxConsecutiveEagains >= ++iEagains && 
+        } while (-1 == iRet &&
+                 EAGAIN == errno &&
+                 MaxConsecutiveEagains >= ++iEagains &&
                  0 == sched_yield());
 
         _ASSERTE(sizeof(cCode) == iRet);
@@ -2110,12 +2110,12 @@ namespace CorUnix
     Method:
       CPalSynchronizationManager::ReadCmdFromProcessPipe
 
-    Reads a worker thread cmd from the process pipe. If there is no data 
-    to be read on the pipe, it blocks until there is data available or the 
+    Reads a worker thread cmd from the process pipe. If there is no data
+    to be read on the pipe, it blocks until there is data available or the
     timeout expires.
     --*/
     PAL_ERROR CPalSynchronizationManager::ReadCmdFromProcessPipe(
-        int iPollTimeout, 
+        int iPollTimeout,
         SynchWorkerCmd * pswcWorkerCmd,
         SharedID * pshridMarshaledData,
         DWORD * pdwData)
@@ -2155,26 +2155,26 @@ namespace CorUnix
                 goto RCFPP_exit;
             }
 
-            _ASSERT_MSG(SynchWorkerCmdNop == swcWorkerCmd || 
-                        SynchWorkerCmdRemoteSignal == swcWorkerCmd || 
-                        SynchWorkerCmdDelegatedObjectSignaling == swcWorkerCmd || 
+            _ASSERT_MSG(SynchWorkerCmdNop == swcWorkerCmd ||
+                        SynchWorkerCmdRemoteSignal == swcWorkerCmd ||
+                        SynchWorkerCmdDelegatedObjectSignaling == swcWorkerCmd ||
                         SynchWorkerCmdShutdown == swcWorkerCmd,
                         "Unknown WrkrCmd=%u\n", swcWorkerCmd);
 
             TRACE("Got cmd %u from process pipe\n", swcWorkerCmd);
         }
 
-        if (SynchWorkerCmdRemoteSignal == swcWorkerCmd || 
+        if (SynchWorkerCmdRemoteSignal == swcWorkerCmd ||
             SynchWorkerCmdDelegatedObjectSignaling == swcWorkerCmd)
         {
             SharedID shridMarshaledId = NULLSharedID;
-            
+
             TRACE("Received %s cmd\n",
                   (swcWorkerCmd == SynchWorkerCmdRemoteSignal) ?
                   "REMOTE SIGNAL" : "DELEGATED OBJECT SIGNALING" );
-            
-            iRet = ReadBytesFromProcessPipe(WorkerCmdCompletionTimeout, 
-                                            (BYTE *)&shridMarshaledId, 
+
+            iRet = ReadBytesFromProcessPipe(WorkerCmdCompletionTimeout,
+                                            (BYTE *)&shridMarshaledId,
                                             sizeof(shridMarshaledId));
             if (sizeof(shridMarshaledId) != iRet)
             {
@@ -2186,7 +2186,7 @@ namespace CorUnix
             }
 
             TRACE("Received marshaled shrid=%p\n", (VOID *)shridMarshaledId);
-                
+
             *pshridMarshaledData = shridMarshaledId;
         }
 
@@ -2194,8 +2194,8 @@ namespace CorUnix
         {
             DWORD dwData;
 
-            iRet = ReadBytesFromProcessPipe(WorkerCmdCompletionTimeout, 
-                                            (BYTE *)&dwData, 
+            iRet = ReadBytesFromProcessPipe(WorkerCmdCompletionTimeout,
+                                            (BYTE *)&dwData,
                                             sizeof(dwData));
             if (sizeof(dwData) != iRet)
             {
@@ -2206,7 +2206,7 @@ namespace CorUnix
                 goto RCFPP_exit;
             }
 
-            TRACE("Received signal count %u\n", dwData);            
+            TRACE("Received signal count %u\n", dwData);
 
             *pdwData = dwData;
         }
@@ -2223,8 +2223,8 @@ namespace CorUnix
     Method:
       CPalSynchronizationManager::ReadBytesFromProcessPipe
 
-    Reads the specified amount ob bytes from the process pipe. If there is 
-    no data to be read on the pipe, it blocks until there is data available 
+    Reads the specified amount ob bytes from the process pipe. If there is
+    no data to be read on the pipe, it blocks until there is data available
     or the timeout expires.
     --*/
     int CPalSynchronizationManager::ReadBytesFromProcessPipe(
@@ -2247,7 +2247,7 @@ namespace CorUnix
 
         _ASSERTE(0 <= iBytes);
 
-        do 
+        do
         {
             while (TRUE)
             {
@@ -2267,7 +2267,7 @@ namespace CorUnix
                 }
                 else
                 {
-                    tv.tv_usec = (iTimeout % tccSecondsToMillieSeconds) * 
+                    tv.tv_usec = (iTimeout % tccSecondsToMillieSeconds) *
                         tccMillieSecondsToMicroSeconds;
                     tv.tv_sec = iTimeout / tccSecondsToMillieSeconds;
                     ptv = &tv;
@@ -2281,15 +2281,15 @@ namespace CorUnix
 #else // HAVE_BROKEN_FIFO_KEVENT
 
                 // Note: FreeBSD needs to use kqueue/kevent support here, since on this
-                // platform the EOF notification on FIFOs is not surfaced through poll, 
+                // platform the EOF notification on FIFOs is not surfaced through poll,
                 // and process pipe shutdown relies on this feature.
-                // If a thread is polling a FIFO or a pipe for POLLIN, when the last 
-                // write descriptor for that pipe is closed, poll() is supposed to 
+                // If a thread is polling a FIFO or a pipe for POLLIN, when the last
+                // write descriptor for that pipe is closed, poll() is supposed to
                 // return with a POLLIN event but no data to be read on the FIFO/pipe,
                 // which means EOF.
-                // On FreeBSD such feature works for pipes but it doesn't for FIFOs. 
+                // On FreeBSD such feature works for pipes but it doesn't for FIFOs.
                 // Using kevent the EOF is instead surfaced correctly.
-                
+
                 if (iBytes > m_keProcessPipeEvent.data)
                 {
                     if (INFTIM == iTimeout)
@@ -2298,7 +2298,7 @@ namespace CorUnix
                     }
                     else
                     {
-                        ts.tv_nsec = (iTimeout % tccSecondsToMillieSeconds) * 
+                        ts.tv_nsec = (iTimeout % tccSecondsToMillieSeconds) *
                             tccMillieSecondsToNanoSeconds;
                         ts.tv_sec = iTimeout / tccSecondsToMillieSeconds;
                         pts = &ts;
@@ -2307,7 +2307,7 @@ namespace CorUnix
                     if (0 != (EV_EOF & m_keProcessPipeEvent.flags))
                     {
                         TRACE("Refreshing kevent settings\n");
-                        EV_SET(&keChanges, m_iProcessPipeRead, EVFILT_READ, 
+                        EV_SET(&keChanges, m_iProcessPipeRead, EVFILT_READ,
                                EV_ADD | EV_CLEAR, 0, 0, 0);
                         iNChanges = 1;
                     }
@@ -2316,12 +2316,12 @@ namespace CorUnix
                         iNChanges = 0;
                     }
 
-                    iRet = kevent(m_iKQueue, &keChanges, iNChanges, 
+                    iRet = kevent(m_iKQueue, &keChanges, iNChanges,
                                   &m_keProcessPipeEvent, 1, pts);
 
                     if (0 < iRet)
                     {
-                        _ASSERTE(1 == iRet);                       
+                        _ASSERTE(1 == iRet);
                         _ASSERTE(EVFILT_READ == m_keProcessPipeEvent.filter);
 
                         if (EV_ERROR & m_keProcessPipeEvent.flags)
@@ -2330,7 +2330,7 @@ namespace CorUnix
                             iRet = -1;
                             iErrno = m_keProcessPipeEvent.data;
                             m_keProcessPipeEvent.data = 0;
-                        }                        
+                        }
                     }
                     else if (0 > iRet)
                     {
@@ -2338,16 +2338,16 @@ namespace CorUnix
                     }
 
                     TRACE("Woken up from kevent() with ret=%d flags=%#x data=%d "
-                          "[iTimeout=%d]\n", iRet, m_keProcessPipeEvent.flags, 
+                          "[iTimeout=%d]\n", iRet, m_keProcessPipeEvent.flags,
                           m_keProcessPipeEvent.data, iTimeout);
                 }
-                else 
+                else
                 {
                     // There is enough data already available in the buffer,
                     // just use that.
                     iRet = 1;
                 }
-                
+
 #endif // HAVE_BROKEN_FIFO_KEVENT
 #else // HAVE_KQUEUE
 
@@ -2355,9 +2355,9 @@ namespace CorUnix
                 Poll.events = POLLIN;
                 Poll.revents = 0;
 
-                iRet = poll(&Poll, 1, iTimeout);            
+                iRet = poll(&Poll, 1, iTimeout);
 
-                TRACE("Woken up from poll() with ret=%d [iTimeout=%d]\n", 
+                TRACE("Woken up from poll() with ret=%d [iTimeout=%d]\n",
                        iRet, iTimeout);
 
                 if (1 == iRet &&
@@ -2392,15 +2392,15 @@ namespace CorUnix
                     if (1 < iRet)
                     {
                         // Unexpected iRet > 1
-                        ASSERT("Unexpected return code %d from blocking poll/kevent call\n", 
+                        ASSERT("Unexpected return code %d from blocking poll/kevent call\n",
                                 iRet);
                         goto RBFPP_exit;
                     }
-                        
+
                     if (EINTR != iErrno)
                     {
                         // Unexpected error
-                        ASSERT("Unexpected error from blocking poll/kevent call: %d (%s)\n", 
+                        ASSERT("Unexpected error from blocking poll/kevent call: %d (%s)\n",
                                iErrno, strerror(iErrno));
                         goto RBFPP_exit;
                     }
@@ -2411,7 +2411,7 @@ namespace CorUnix
                     if (iConsecutiveEintrs >= MaxWorkerConsecutiveEintrs)
                     {
                         if (iTimeout != INFTIM)
-                        {                    
+                        {
                             WARN("Receiving too many EINTRs; converting one of them "
                                  "to a timeout");
                             iRet = 0;
@@ -2431,7 +2431,7 @@ namespace CorUnix
                 // Time out
                 break;
             }
-            else    
+            else
             {
 #if HAVE_KQUEUE && !HAVE_BROKEN_FIFO_KEVENT
                 if (0 != (EV_EOF & m_keProcessPipeEvent.flags) && 0 == m_keProcessPipeEvent.data)
@@ -2446,12 +2446,12 @@ namespace CorUnix
 
                 if (0 == iRet)
                 {
-                    // Poll returned 1 and read returned zero: this is an EOF, 
+                    // Poll returned 1 and read returned zero: this is an EOF,
                     // i.e. no other process has the pipe still open for write
-                    TRACE("Received an EOF on process pipe via poll\n");                   
+                    TRACE("Received an EOF on process pipe via poll\n");
                     goto RBFPP_exit;
-                }                    
-                else if (0 > iRet)            
+                }
+                else if (0 > iRet)
                 {
                     ERROR("Unable to read %d bytes from the the process pipe "
                           "[pipe=%d ret=%d errno=%d (%s)]\n", iBytes - iBytesRead,
@@ -2469,7 +2469,7 @@ namespace CorUnix
                 m_keProcessPipeEvent.data -= iRet;
                 _ASSERTE(0 <= m_keProcessPipeEvent.data);
 #endif // HAVE_KQUEUE
-            }    
+            }
         } while(iBytesRead < iBytes);
 
     RBFPP_exit:
@@ -2491,7 +2491,7 @@ namespace CorUnix
         DWORD dwObjectIndex)
     {
         PAL_ERROR palErr = NO_ERROR;
-        ThreadNativeWaitData * ptnwdNativeWaitData = 
+        ThreadNativeWaitData * ptnwdNativeWaitData =
             pthrTarget->synchronizationInfo.GetNativeData();
 
         TRACE("Waking up a local thread [WakeUpReason=%u ObjectIndex=%u "
@@ -2505,8 +2505,8 @@ namespace CorUnix
 #if SYNCHMGR_SUSPENSION_SAFE_CONDITION_SIGNALING
         if (0 < GetLocalSynchLockCount(pthrCurrent))
         {
-            // Defer the actual thread signaling to right after 
-            // releasing the synch lock(s), so that signaling 
+            // Defer the actual thread signaling to right after
+            // releasing the synch lock(s), so that signaling
             // can happen from a thread-suspension safe area
             palErr = DeferThreadConditionSignaling(pthrCurrent, pthrTarget);
         }
@@ -2514,7 +2514,7 @@ namespace CorUnix
         {
             // Signal the target thread's condition
             palErr = SignalThreadCondition(ptnwdNativeWaitData);
-        }        
+        }
 #else // SYNCHMGR_SUSPENSION_SAFE_CONDITION_SIGNALING
         // Signal the target thread's condition
         palErr = SignalThreadCondition(ptnwdNativeWaitData);
@@ -2540,28 +2540,28 @@ namespace CorUnix
         LONG lCount = pthrCurrent->synchronizationInfo.m_lPendingSignalingCount;
 
         _ASSERTE(pthrTarget != pthrCurrent);
-        
+
         if (CThreadSynchronizationInfo::PendingSignalingsArraySize > lCount)
         {
-            // If there is available room, add the target thread object to 
+            // If there is available room, add the target thread object to
             // the array of pending thread signalings.
             pthrCurrent->synchronizationInfo.m_rgpthrPendingSignalings[lCount] = pthrTarget;
         }
         else
         {
-            // If the array is full, add the target thread object at the end 
+            // If the array is full, add the target thread object at the end
             // of the overflow list
-            DeferredSignalingListNode * pdsln = 
+            DeferredSignalingListNode * pdsln =
                 InternalNew<DeferredSignalingListNode>();
 
             if (pdsln)
             {
                 pdsln->pthrTarget = pthrTarget;
 
-                // Add the note to the end of the list. 
+                // Add the note to the end of the list.
                 // Note: no need to synchronize the access to this list since
                 // it is meant to be accessed only by the owner thread.
-                InsertTailList(&pthrCurrent->synchronizationInfo.m_lePendingSignalingsOverflowList, 
+                InsertTailList(&pthrCurrent->synchronizationInfo.m_lePendingSignalingsOverflowList,
                                &pdsln->Link);
             }
             else
@@ -2575,13 +2575,13 @@ namespace CorUnix
             // Increment the count of pending signalings
             pthrCurrent->synchronizationInfo.m_lPendingSignalingCount += 1;
 
-            // Add a reference to the target CPalThread object; this is 
-            // needed since deferring signaling after releasing the synch 
-            // locks implies accessing the target thread object without 
-            // holding the local synch lock. In rare circumstances, the 
-            // target thread may have already exited while deferred signaling 
-            // takes place, therefore invalidating the thread object. The 
-            // reference added here ensures that the thread object is still 
+            // Add a reference to the target CPalThread object; this is
+            // needed since deferring signaling after releasing the synch
+            // locks implies accessing the target thread object without
+            // holding the local synch lock. In rare circumstances, the
+            // target thread may have already exited while deferred signaling
+            // takes place, therefore invalidating the thread object. The
+            // reference added here ensures that the thread object is still
             // good, even if the target thread has exited.
             pthrTarget->AddThreadReference();
         }
@@ -2600,7 +2600,7 @@ namespace CorUnix
     {
         PAL_ERROR palErr = NO_ERROR;
         int iRet;
-        
+
         // Lock the mutex
         iRet = pthread_mutex_lock(&ptnwdNativeWaitData->mutex);
         if (0 != iRet)
@@ -2618,14 +2618,14 @@ namespace CorUnix
         if (0 != iRet)
         {
             ERROR("Failed to signal condition: pthread_cond_signal "
-                  "returned %d [errno=%d (%s)]\n", iRet, errno, 
+                  "returned %d [errno=%d (%s)]\n", iRet, errno,
                   strerror(errno));
             palErr = ERROR_INTERNAL_ERROR;
             // Continue in order to unlock the mutex anyway
-        }            
+        }
 
         // Unlock the mutex
-        iRet = pthread_mutex_unlock(&ptnwdNativeWaitData->mutex);            
+        iRet = pthread_mutex_unlock(&ptnwdNativeWaitData->mutex);
         if (0 != iRet)
         {
             ERROR("Cannot unlock mutex [err=%d]\n", iRet);
@@ -2656,7 +2656,7 @@ namespace CorUnix
         int iEagains = 0;
         bool fAgain;
         char cCode = (char)twrWakeupReason;
-        ThreadNativeWaitData * ptnwdNativeWaitData = 
+        ThreadNativeWaitData * ptnwdNativeWaitData =
             pthrTarget->synchronizationInfo.GetNativeData();
 
         TRACE("Waking up a local thread [WakeUpReason=%u ObjectIndex=%u "
@@ -2669,12 +2669,12 @@ namespace CorUnix
 
         _ASSERTE(-1 != ptnwdNativeWaitData->iPipeWr);
 
-        do 
+        do
         {
             fAgain = false;
-            
-            iRet = write(ptnwdNativeWaitData->iPipeWr, 
-                         (void *)&cCode, 
+
+            iRet = write(ptnwdNativeWaitData->iPipeWr,
+                         (void *)&cCode,
                          sizeof(cCode));
             switch (iRet)
             {
@@ -2712,11 +2712,11 @@ namespace CorUnix
                     break;
                 default:
                     // unexpected error condition
-                    palErr = ERROR_INTERNAL_ERROR;   
+                    palErr = ERROR_INTERNAL_ERROR;
                     break;
-            }       
+            }
         } while (fAgain);
-        
+
     WUT_exit:
         return palErr;
     }
@@ -2739,22 +2739,22 @@ namespace CorUnix
         PAL_ERROR palErr = NO_ERROR;
         BYTE rgSendBuf[MsgSize];
         BYTE * pbySrc, * pbyDst = rgSendBuf;
-        WaitingThreadsListNode * pWLNode = 
+        WaitingThreadsListNode * pWLNode =
             SharedIDToTypePointer(WaitingThreadsListNode, shridWLNode);
-        
+
         _ASSERT_MSG(gPID != pWLNode->dwProcessId,
                     "WakeUpRemoteThread called on local thread\n");
         _ASSERT_MSG(NULLSharedID != shridWLNode, "NULL shared identifier\n");
-        _ASSERT_MSG(NULL != pWLNode, 
-                    "Bad shared wait list node identifier (%p)\n", 
+        _ASSERT_MSG(NULL != pWLNode,
+                    "Bad shared wait list node identifier (%p)\n",
                     (VOID*)shridWLNode);
-        _ASSERT_MSG(MsgSize <= PIPE_BUF, 
+        _ASSERT_MSG(MsgSize <= PIPE_BUF,
                     "Message too long [MsgSize=%d PIPE_BUF=%d]\n",
                     MsgSize, (int)PIPE_BUF);
 
         TRACE("Waking up remote thread {pid=%x, tid=%x} by sending "
               "cmd=%u and shridWLNode=%p over process pipe\n",
-              pWLNode->dwProcessId, pWLNode->dwThreadId, 
+              pWLNode->dwProcessId, pWLNode->dwThreadId,
               SynchWorkerCmdRemoteSignal, (VOID *)shridWLNode);
 
         // Prepare the message
@@ -2769,7 +2769,7 @@ namespace CorUnix
         _ASSERT_MSG(pbyDst <= rgSendBuf + MsgSize + 1, "Buffer overrun");
 
         // Send the message
-        palErr = SendMsgToRemoteWorker(pWLNode->dwProcessId, rgSendBuf, 
+        palErr = SendMsgToRemoteWorker(pWLNode->dwProcessId, rgSendBuf,
                                        MsgSize);
         if (NO_ERROR != palErr)
         {
@@ -2777,7 +2777,7 @@ namespace CorUnix
                   pWLNode->dwProcessId);
             goto WUT_exit;
         }
-        
+
     WUT_exit:
         return palErr;
     }
@@ -2786,12 +2786,12 @@ namespace CorUnix
     Method:
       CPalSynchronizationManager::DelegateSignalingToRemoteProcess
 
-    This method transfers an object signaling operation to a remote process, 
-    where it will be performed by the worker thread. Such delegation takes 
-    place when the currently processed thread (among those waiting on the 
-    signald object) lives in a different process as the signaling thread, 
-    and it is performing a wait all. In this case generally is not possible 
-    to find out whether or not the wait all is satisfied, therefore the 
+    This method transfers an object signaling operation to a remote process,
+    where it will be performed by the worker thread. Such delegation takes
+    place when the currently processed thread (among those waiting on the
+    signald object) lives in a different process as the signaling thread,
+    and it is performing a wait all. In this case generally is not possible
+    to find out whether or not the wait all is satisfied, therefore the
     signaling operation must be continued in the target process.
     --*/
     PAL_ERROR CPalSynchronizationManager::DelegateSignalingToRemoteProcess(
@@ -2805,22 +2805,22 @@ namespace CorUnix
         BYTE rgSendBuf[MsgSize];
         BYTE * pbySrc, * pbyDst = rgSendBuf;
         DWORD dwSigCount;
-        CSynchData * psdSynchData = 
+        CSynchData * psdSynchData =
             SharedIDToTypePointer(CSynchData, shridSynchData);
-        
+
         _ASSERT_MSG(gPID != dwTargetProcessId,
                     " called on local thread\n");
         _ASSERT_MSG(NULLSharedID != shridSynchData, "NULL shared identifier\n");
-        _ASSERT_MSG(NULL != psdSynchData, 
-                    "Bad shared SynchData identifier (%p)\n", 
+        _ASSERT_MSG(NULL != psdSynchData,
+                    "Bad shared SynchData identifier (%p)\n",
                     (VOID*)shridSynchData);
-        _ASSERT_MSG(MsgSize <= PIPE_BUF, 
+        _ASSERT_MSG(MsgSize <= PIPE_BUF,
                     "Message too long [MsgSize=%d PIPE_BUF=%d]\n",
                     MsgSize, (int)PIPE_BUF);
 
         TRACE("Transfering wait all signaling to remote process pid=%x "
               "by sending cmd=%u and shridSynchData=%p over process pipe\n",
-              dwTargetProcessId, SynchWorkerCmdDelegatedObjectSignaling, 
+              dwTargetProcessId, SynchWorkerCmdDelegatedObjectSignaling,
               (VOID *)shridSynchData);
 
         dwSigCount = psdSynchData->GetSignalCount();
@@ -2831,7 +2831,7 @@ namespace CorUnix
         //
         // Prepare the message
         //
-        
+
         // Cmd
         *pbyDst++ = (BYTE)(SynchWorkerCmdDelegatedObjectSignaling & 0xFF);
 
@@ -2852,7 +2852,7 @@ namespace CorUnix
         _ASSERT_MSG(pbyDst <= rgSendBuf + MsgSize + 1, "Buffer overrun");
 
         // Send the message
-        palErr = SendMsgToRemoteWorker(dwTargetProcessId, rgSendBuf, 
+        palErr = SendMsgToRemoteWorker(dwTargetProcessId, rgSendBuf,
                                        MsgSize);
         if (NO_ERROR != palErr)
         {
@@ -2862,7 +2862,7 @@ namespace CorUnix
             psdSynchData->Release(pthrCurrent);
             goto WUT_exit;
         }
-        
+
     WUT_exit:
         return palErr;
     }
@@ -2881,7 +2881,7 @@ namespace CorUnix
         ASSERT("There should never be a reason to send a message to a remote worker\n");
         return ERROR_INTERNAL_ERROR;
     }
-    
+
     /*++
     Method:
       CPalSynchronizationManager::WakeUpLocalWorkerThread
@@ -2907,24 +2907,24 @@ namespace CorUnix
 
         byCmd = (BYTE)(swcWorkerCmd & 0xFF);
 
-        TRACE("Waking up Synch Worker Thread for %u [byCmd=%u]\n", 
+        TRACE("Waking up Synch Worker Thread for %u [byCmd=%u]\n",
                     swcWorkerCmd, (unsigned int)byCmd);
 
-        // As long as we use pipes and we keep the message size 
+        // As long as we use pipes and we keep the message size
         // within PIPE_BUF, there's no need to lock here, since the
         // write is guaranteed not to be interleaved with/into other
         // writes of PIPE_BUF bytes or less.
         _ASSERT_MSG(sizeof(BYTE) <= PIPE_BUF, "Message too long\n");
-        
+
         iRetryCount = 0;
         do
         {
             sszWritten = write(m_iProcessPipeWrite, &byCmd, sizeof(BYTE));
-        } while (-1 == sszWritten && 
-                 EAGAIN == errno && 
+        } while (-1 == sszWritten &&
+                 EAGAIN == errno &&
                  ++iRetryCount < MaxConsecutiveEagains &&
                  0 == sched_yield());
-        
+
         if (sszWritten != sizeof(BYTE))
         {
             ERROR("Unable to write the the process pipe to wakeup the "
@@ -2957,7 +2957,7 @@ namespace CorUnix
     a thread other than the current one (most of the times the deregistration
     is performed by the signaling thread)
 
-    Note: this method must be called while holding the local process 
+    Note: this method must be called while holding the local process
           synchronization lock.
     --*/
     void CPalSynchronizationManager::UnRegisterWait(
@@ -2973,7 +2973,7 @@ namespace CorUnix
         {
             AcquireSharedSynchLock(pthrCurrent);
             fSharedSynchLock = true;
-        }   
+        }
 
         TRACE("Unregistering wait for thread=%u [ObjCount=%d WaitType=%u WaitDomain=%u]\n",
               ptwiWaitInfo->pthrOwner->GetThreadId(),
@@ -2990,15 +2990,15 @@ namespace CorUnix
             {
                 // Shared object
                 WaitingThreadsListNode * pwtlnItemNext, * pwtlnItemPrev;
-                
-                psdSynchData = SharedIDToTypePointer(CSynchData, 
+
+                psdSynchData = SharedIDToTypePointer(CSynchData,
                     pwtlnItem->ptrOwnerObjSynchData.shrid);
 
                 VALIDATEOBJECT(psdSynchData);
 
-                pwtlnItemNext = SharedIDToTypePointer(WaitingThreadsListNode, 
+                pwtlnItemNext = SharedIDToTypePointer(WaitingThreadsListNode,
                     pwtlnItem->ptrNext.shrid);
-                pwtlnItemPrev = SharedIDToTypePointer(WaitingThreadsListNode, 
+                pwtlnItemPrev = SharedIDToTypePointer(WaitingThreadsListNode,
                     pwtlnItem->ptrPrev.shrid);
                 if (pwtlnItemPrev)
                 {
@@ -3022,7 +3022,7 @@ namespace CorUnix
                 m_cacheSHRWTListNodes.Add(pthrCurrent, pwtlnItem->shridSHRThis);
             }
             else
-            {    
+            {
                 // Local object
                 psdSynchData = pwtlnItem->ptrOwnerObjSynchData.ptr;
 
@@ -3047,7 +3047,7 @@ namespace CorUnix
                     psdSynchData->SetWTLTailPtr(pwtlnItem->ptrPrev.ptr);
                 }
 
-                m_cacheWTListNodes.Add(pthrCurrent, pwtlnItem);                
+                m_cacheWTListNodes.Add(pthrCurrent, pwtlnItem);
             }
 
             // Release the node's refcount on the synch data, and decerement
@@ -3056,7 +3056,7 @@ namespace CorUnix
             psdSynchData->Release(pthrCurrent);
         }
 
-        // Reset wait data in ThreadWaitInfo structure: it is enough 
+        // Reset wait data in ThreadWaitInfo structure: it is enough
         // to reset lObjCount, lSharedObjCount and wdWaitDomain.
         ptwiWaitInfo->lObjCount       = 0;
         ptwiWaitInfo->lSharedObjCount = 0;
@@ -3069,18 +3069,18 @@ namespace CorUnix
         }
         return;
     }
-    
+
     /*++
     Method:
       CPalSynchronizationManager::UnsignalRestOfLocalAwakeningWaitAll
 
-    Unsignals all the objects involved in a wait all, except the target 
+    Unsignals all the objects involved in a wait all, except the target
     one (i.e. psdTgtObjectSynchData)
 
-    Note: this method must be called while holding the synchronization locks 
-          appropriate to all the objects involved in the wait-all. If any 
-          of the objects is shared, the caller must own both local and 
-          shared synch locks; if no shared object is involved in the wait, 
+    Note: this method must be called while holding the synchronization locks
+          appropriate to all the objects involved in the wait-all. If any
+          of the objects is shared, the caller must own both local and
+          shared synch locks; if no shared object is involved in the wait,
           only the local synch lock is needed.
     --*/
     void CPalSynchronizationManager::UnsignalRestOfLocalAwakeningWaitAll(
@@ -3105,7 +3105,7 @@ namespace CorUnix
         _ASSERT_MSG(0 != (WTLN_FLAG_WAIT_ALL & pwtlnNode->dwFlags),
                     "UnsignalRestOfLocalAwakeningWaitAll() called on a normal "
                     "(non wait all) wait");
-            
+
         _ASSERT_MSG(gPID == pwtlnNode->dwProcessId,
                     "UnsignalRestOfLocalAwakeningWaitAll() called on a wait all "
                     "with remote awakening");
@@ -3121,7 +3121,7 @@ namespace CorUnix
 
             if (0 != (WTLN_FLAG_OWNER_OBJECT_IS_SHARED & pwtlnItem->dwFlags))
             {
-                psdSynchDataItem = SharedIDToTypePointer(CSynchData, 
+                psdSynchDataItem = SharedIDToTypePointer(CSynchData,
                     pwtlnItem->ptrOwnerObjSynchData.shrid);
             }
             else
@@ -3134,14 +3134,14 @@ namespace CorUnix
             // Skip originating node
             if (psdTgtObjectSynchData == psdSynchDataItem)
             {
-#ifdef _DEBUG                
+#ifdef _DEBUG
                 bOriginatingNodeFound = true;
 #endif
                 continue;
             }
 
             palErr = psdSynchDataItem->ReleaseWaiterWithoutBlocking(
-                pthrCurrent, 
+                pthrCurrent,
                 pthrTarget);
 
             if (NO_ERROR != palErr)
@@ -3163,15 +3163,15 @@ namespace CorUnix
     Marks all the thread waiting list nodes involved in the the current wait-all
     for "delegated object signaling in progress", so that this wait cannot be
     involved in another delegated object signaling that may happen while the
-    current object singaling is being tranfered to the target process (while 
-    transfering it, synchronization locks are released in this process and later 
-    grabbed again in the target process; in this time window another thread 
+    current object singaling is being tranfered to the target process (while
+    transfering it, synchronization locks are released in this process and later
+    grabbed again in the target process; in this time window another thread
     could signal another object part of the same wait-all. In this case no
     signal delegation must take place.
 
-    Note: this method must be called while holding the synchronization locks 
-          appropriate to the target object described by pwtlnNode (i.e. the 
-          local process synch lock if the target object is local, both local 
+    Note: this method must be called while holding the synchronization locks
+          appropriate to the target object described by pwtlnNode (i.e. the
+          local process synch lock if the target object is local, both local
           and shared one if the object is shared).
     --*/
     void CPalSynchronizationManager::MarkWaitForDelegatedObjectSignalingInProgress(
@@ -3181,7 +3181,7 @@ namespace CorUnix
         int i, iTgtCount;
         ThreadWaitInfo * ptwiWaitInfo = NULL;
         bool fSharedSynchLock = false;
-        bool fTargetObjectIsShared = 
+        bool fTargetObjectIsShared =
             (0 != (WTLN_FLAG_OWNER_OBJECT_IS_SHARED & pwtlnNode->dwFlags));
 
         VALIDATEOBJECT(pwtlnNode);
@@ -3192,12 +3192,12 @@ namespace CorUnix
 
         ptwiWaitInfo = pwtlnNode->ptwiWaitInfo;
 
-        if (!fSharedSynchLock && !fTargetObjectIsShared && 
+        if (!fSharedSynchLock && !fTargetObjectIsShared &&
             LocalWait != ptwiWaitInfo->wdWaitDomain)
         {
             AcquireSharedSynchLock(pthrCurrent);
             fSharedSynchLock = true;
-        }   
+        }
 
         _ASSERT_MSG(MultipleObjectsWaitAll == ptwiWaitInfo->wtWaitType,
                     "MarkWaitForDelegatedObjectSignalingInProgress() called "
@@ -3208,8 +3208,8 @@ namespace CorUnix
         for (i=0; i < iTgtCount; i++)
         {
             VALIDATEOBJECT(ptwiWaitInfo->rgpWTLNodes[i]);
-            
-            ptwiWaitInfo->rgpWTLNodes[i]->dwFlags &= 
+
+            ptwiWaitInfo->rgpWTLNodes[i]->dwFlags &=
                 ~WTLN_FLAG_DELEGATED_OBJECT_SIGNALING_IN_PROGRESS;
         }
 
@@ -3228,12 +3228,12 @@ namespace CorUnix
     Method:
       CPalSynchronizationManager::UnmarkTWListForDelegatedObjectSignalingInProgress
 
-    Resets the "delegated object signaling in progress" flags in all the 
+    Resets the "delegated object signaling in progress" flags in all the
     nodes of the thread waitin list for the target waitable objects (represented
     by its SynchData)
 
-    Note: this method must be called while holding the appropriate 
-          synchronization locks (the local process synch lock if the target 
+    Note: this method must be called while holding the appropriate
+          synchronization locks (the local process synch lock if the target
           object is local, both local and shared one if the object is shared).
     --*/
     void CPalSynchronizationManager::UnmarkTWListForDelegatedObjectSignalingInProgress(
@@ -3245,18 +3245,18 @@ namespace CorUnix
         VALIDATEOBJECT(pTgtObjectSynchData);
 
         pwtlnNode =  fSharedObject ?
-            SharedIDToTypePointer(WaitingThreadsListNode, 
+            SharedIDToTypePointer(WaitingThreadsListNode,
                 pTgtObjectSynchData->GetWTLHeadShmPtr()) :
                 pTgtObjectSynchData->GetWTLHeadPtr();
         while (pwtlnNode)
         {
             VALIDATEOBJECT(pwtlnNode);
-            
+
             pwtlnNode->dwFlags &= ~WTLN_FLAG_DELEGATED_OBJECT_SIGNALING_IN_PROGRESS;
 
-            pwtlnNode = fSharedObject ? 
-                SharedIDToTypePointer(WaitingThreadsListNode, 
-                    pwtlnNode->ptrNext.shrid) : 
+            pwtlnNode = fSharedObject ?
+                SharedIDToTypePointer(WaitingThreadsListNode,
+                    pwtlnNode->ptrNext.shrid) :
                     pwtlnNode->ptrNext.ptr;
         }
     }
@@ -3265,9 +3265,9 @@ namespace CorUnix
     Method:
       CPalSynchronizationManager::RegisterProcessForMonitoring
 
-    Registers the process object represented by the passed psdSynchData and 
+    Registers the process object represented by the passed psdSynchData and
     pProcLocalData. The worker thread will monitor the actual process and,
-    upon process termination, it will set the exit code in pProcLocalData, 
+    upon process termination, it will set the exit code in pProcLocalData,
     and it will signal the process object, by signaling its psdSynchData.
     --*/
     PAL_ERROR CPalSynchronizationManager::RegisterProcessForMonitoring(
@@ -3282,7 +3282,7 @@ namespace CorUnix
 
         VALIDATEOBJECT(psdSynchData);
 
-        InternalEnterCriticalSection(pthrCurrent, 
+        InternalEnterCriticalSection(pthrCurrent,
                                      &s_csMonitoredProcessesLock);
         fMonitoredProcessesLock = true;
 
@@ -3309,7 +3309,7 @@ namespace CorUnix
             if (NULL == pmpln)
             {
                 ERROR("No memory to allocate MonitoredProcessesListNode structure\n");
-                palErr = ERROR_NOT_ENOUGH_MEMORY; 
+                palErr = ERROR_NOT_ENOUGH_MEMORY;
                 goto RPFM_exit;
             }
 
@@ -3321,7 +3321,7 @@ namespace CorUnix
             // Acquire SynchData and AddRef it
             pmpln->psdSynchData = psdSynchData;
             psdSynchData->AddRef();
-            
+
             pmpln->pNext = m_pmplnMonitoredProcesses;
             m_pmplnMonitoredProcesses = pmpln;
             m_lMonitoredProcessesCount++;
@@ -3329,7 +3329,7 @@ namespace CorUnix
             fWakeUpWorker = true;
         }
         // Unlock
-        InternalLeaveCriticalSection(pthrCurrent, 
+        InternalLeaveCriticalSection(pthrCurrent,
                                      &s_csMonitoredProcessesLock);
         fMonitoredProcessesLock = false;
 
@@ -3341,16 +3341,16 @@ namespace CorUnix
             if (NO_ERROR != palErr)
             {
                 ERROR("Failed waking up worker thread for process "
-                      "monitoring registration [errno=%d {%s%}]\n", 
+                      "monitoring registration [errno=%d {%s%}]\n",
                       errno, strerror(errno));
                 palErr = ERROR_INTERNAL_ERROR;
-            } 
+            }
         }
-        
+
     RPFM_exit:
         if (fMonitoredProcessesLock)
         {
-            InternalLeaveCriticalSection(pthrCurrent, 
+            InternalLeaveCriticalSection(pthrCurrent,
                                          &s_csMonitoredProcessesLock);
         }
         return palErr;
@@ -3361,21 +3361,21 @@ namespace CorUnix
       CPalSynchronizationManager::UnRegisterProcessForMonitoring
 
     Unregisters a process object currently monitored by the worker thread
-    (typically called if the wait timed out before the process exited, or 
-    if the wait was a normal (i.e. non wait-all) wait that involved othter 
+    (typically called if the wait timed out before the process exited, or
+    if the wait was a normal (i.e. non wait-all) wait that involved othter
     objects, and another object has been signaled).
     --*/
     PAL_ERROR CPalSynchronizationManager::UnRegisterProcessForMonitoring(
         CPalThread * pthrCurrent,
-        CSynchData *psdSynchData, 
+        CSynchData *psdSynchData,
         DWORD dwPid)
     {
         PAL_ERROR palErr = NO_ERROR;
         MonitoredProcessesListNode * pmpln, * pmplnPrev = NULL;
 
         VALIDATEOBJECT(psdSynchData);
-            
-        InternalEnterCriticalSection(pthrCurrent, 
+
+        InternalEnterCriticalSection(pthrCurrent,
                                      &s_csMonitoredProcessesLock);
 
         pmpln = m_pmplnMonitoredProcesses;
@@ -3406,7 +3406,7 @@ namespace CorUnix
                 }
 
                 m_lMonitoredProcessesCount--;
-                pmpln->psdSynchData->Release(pthrCurrent);                
+                pmpln->psdSynchData->Release(pthrCurrent);
                 InternalDelete(pmpln);
             }
         }
@@ -3415,7 +3415,7 @@ namespace CorUnix
             palErr = ERROR_NOT_FOUND;
         }
 
-        InternalLeaveCriticalSection(pthrCurrent, 
+        InternalLeaveCriticalSection(pthrCurrent,
                                      &s_csMonitoredProcessesLock);
         return palErr;
     }
@@ -3424,8 +3424,8 @@ namespace CorUnix
     Method:
       CPalSynchronizationManager::ThreadPrepareForShutdown
 
-    Used to hijack a thread execution from known spots within the 
-    Synchronization Manager, in case a PAL shutdown is initiaded or the 
+    Used to hijack a thread execution from known spots within the
+    Synchronization Manager, in case a PAL shutdown is initiaded or the
     thread is being terminated by another thread.
     --*/
     void CPalSynchronizationManager::ThreadPrepareForShutdown()
@@ -3439,7 +3439,7 @@ namespace CorUnix
         }
         ASSERT("This code should never be executed\n");
     }
-    
+
     /*++
     Method:
       CPalSynchronizationManager::DoMonitorProcesses
@@ -3452,15 +3452,15 @@ namespace CorUnix
     {
         MonitoredProcessesListNode * pNode, * pPrev = NULL, * pNext;
         LONG lInitialNodeCount;
-        LONG lRemovingCount = 0;        
+        LONG lRemovingCount = 0;
         bool fLocalSynchLock = false;
         bool fSharedSynchLock = false;
         bool fMonitoredProcessesLock = false;
 
-        // Note: we first need to grab the monitored processes lock to walk 
-        //       the list of monitored processes, and then, if there is any 
+        // Note: we first need to grab the monitored processes lock to walk
+        //       the list of monitored processes, and then, if there is any
         //       which exited, to grab the synchronization lock(s) to signal
-        //       the process object. Anyway we cannot grab the synchronization 
+        //       the process object. Anyway we cannot grab the synchronization
         //       lock(s) while holding the monitored processes lock; that
         //       would cause deadlock, since RegisterProcessForMonitoring and
         //       UnRegisterProcessForMonitoring call stacks grab the locks
@@ -3468,33 +3468,33 @@ namespace CorUnix
         //       therefore all the times) would cause unacceptable contention
         //       (process monitoring is done in polling mode).
         //       Therefore we need to remove list nodes for processes that
-        //       exited copying them to the exited array, while holding only 
-        //       the monitored processes lock, and then to signal them from that 
-        //       array holding synch lock(s) and monitored processes lock, 
-        //       acquired in this order. Holding again the monitored processes 
+        //       exited copying them to the exited array, while holding only
+        //       the monitored processes lock, and then to signal them from that
+        //       array holding synch lock(s) and monitored processes lock,
+        //       acquired in this order. Holding again the monitored processes
         //       lock is needed in order to support object promotion.
 
         // Grab the monitored processes lock
-        InternalEnterCriticalSection(pthrCurrent, 
+        InternalEnterCriticalSection(pthrCurrent,
                                      &s_csMonitoredProcessesLock);
         fMonitoredProcessesLock = true;
 
-        lInitialNodeCount = m_lMonitoredProcessesCount;        
-        
+        lInitialNodeCount = m_lMonitoredProcessesCount;
+
         pNode = m_pmplnMonitoredProcesses;
         while (pNode)
         {
             pNext = pNode->pNext;
-            
+
             if (HasProcessExited(pNode->dwPid,
                                  &pNode->dwExitCode,
                                  &pNode->fIsActualExitCode))
             {
                 TRACE("Process %u exited with return code %u\n",
-                      pNode->dwPid, 
+                      pNode->dwPid,
                       pNode->fIsActualExitCode ? "actual" : "guessed",
                       pNode->dwExitCode);
-                                              
+
                 if (NULL != pPrev)
                 {
                     pPrev->pNext = pNext;
@@ -3507,20 +3507,20 @@ namespace CorUnix
 
                 // Insert in the list of nodes for exited processes
                 pNode->pNext = m_pmplnExitedNodes;
-                m_pmplnExitedNodes = pNode;                
+                m_pmplnExitedNodes = pNode;
                 lRemovingCount++;
             }
             else
             {
                 pPrev = pNode;
             }
-            
+
             // Go to the next
             pNode = pNext;
         }
 
         // Release the monitored processes lock
-        InternalLeaveCriticalSection(pthrCurrent, 
+        InternalLeaveCriticalSection(pthrCurrent,
                                      &s_csMonitoredProcessesLock);
         fMonitoredProcessesLock = false;
 
@@ -3531,15 +3531,15 @@ namespace CorUnix
             fLocalSynchLock = true;
 
             // Acquire the monitored processes lock
-            InternalEnterCriticalSection(pthrCurrent, 
+            InternalEnterCriticalSection(pthrCurrent,
                                          &s_csMonitoredProcessesLock);
             fMonitoredProcessesLock = true;
 
             if (!fSharedSynchLock)
             {
                 bool fSharedSynchLockIsNeeded = false;
-                
-                // See if the shared lock is needed 
+
+                // See if the shared lock is needed
                 pNode = m_pmplnExitedNodes;
                 while (pNode)
                 {
@@ -3555,8 +3555,8 @@ namespace CorUnix
                 if (fSharedSynchLockIsNeeded)
                 {
                     // Release the monitored processes lock
-                    InternalLeaveCriticalSection(pthrCurrent, 
-                                                 &s_csMonitoredProcessesLock);                
+                    InternalLeaveCriticalSection(pthrCurrent,
+                                                 &s_csMonitoredProcessesLock);
                     fMonitoredProcessesLock = false;
 
                     // Acquire the shared synch lock
@@ -3564,7 +3564,7 @@ namespace CorUnix
                     fSharedSynchLock = true;
 
                     // Acquire again the monitored processes lock
-                    InternalEnterCriticalSection(pthrCurrent, 
+                    InternalEnterCriticalSection(pthrCurrent,
                                                  &s_csMonitoredProcessesLock);
                     fMonitoredProcessesLock = true;
                 }
@@ -3575,7 +3575,7 @@ namespace CorUnix
 
             // Invalidate the list
             m_pmplnExitedNodes = NULL;
-            
+
             while (pNode)
             {
                 pNext = pNode->pNext;
@@ -3586,7 +3586,7 @@ namespace CorUnix
                 // Store the exit code in the process local data
                 if (pNode->fIsActualExitCode)
                 {
-                    pNode->pProcLocalData->dwExitCode = pNode->dwExitCode; 
+                    pNode->pProcLocalData->dwExitCode = pNode->dwExitCode;
                 }
 
                 // Set process status to PS_DONE
@@ -3595,17 +3595,17 @@ namespace CorUnix
                 // Set signal count
                 pNode->psdSynchData->SetSignalCount(1);
 
-                // Releasing all local waiters 
+                // Releasing all local waiters
                 //
                 // We just called directly in CSynchData::SetSignalCount(), so
                 // we need to take care of waking up waiting threads according
                 // to the Process object semantics (i.e. every thread must be
                 // awakend). Anyway if a process object is shared among two or
-                // more processes and threads from different processes are 
+                // more processes and threads from different processes are
                 // waiting on it, the object will be registered for monitoring
-                // in each of the processes. As result its signal count will 
+                // in each of the processes. As result its signal count will
                 // be set to one more times (which is not a problem, given the
-                // process object semantics) and each worker thread will wake 
+                // process object semantics) and each worker thread will wake
                 // up waiting threads. Therefore we need to make sure that each
                 // worker wakes up only threads in its own process: we do that
                 // by calling ReleaseAllLocalWaiters
@@ -3625,7 +3625,7 @@ namespace CorUnix
         if (fMonitoredProcessesLock)
         {
             // Release the monitored processes lock
-            InternalLeaveCriticalSection(pthrCurrent, 
+            InternalLeaveCriticalSection(pthrCurrent,
                                      &s_csMonitoredProcessesLock);
         }
         if (fSharedSynchLock)
@@ -3641,12 +3641,12 @@ namespace CorUnix
 
         return (lInitialNodeCount - lRemovingCount);
     }
-  
+
     /*++
     Method:
       CPalSynchronizationManager::DiscardMonitoredProcesses
 
-    This method is called at shutdown time to discard all the registration 
+    This method is called at shutdown time to discard all the registration
     for the processes currently monitored by the worker thread.
     This method must be called at shutdown time, otherwise some shared memory
     may be leaked at process shutdown.
@@ -3657,9 +3657,9 @@ namespace CorUnix
         MonitoredProcessesListNode * pNode;
 
         // Grab the monitored processes lock
-        InternalEnterCriticalSection(pthrCurrent, 
+        InternalEnterCriticalSection(pthrCurrent,
                                      &s_csMonitoredProcessesLock);
-        
+
         while (m_pmplnMonitoredProcesses)
         {
             pNode = m_pmplnMonitoredProcesses;
@@ -3669,10 +3669,10 @@ namespace CorUnix
         }
 
         // Release the monitored processes lock
-        InternalLeaveCriticalSection(pthrCurrent, 
+        InternalLeaveCriticalSection(pthrCurrent,
                                      &s_csMonitoredProcessesLock);
     }
-    
+
     /*++
     Method:
       CPalSynchronizationManager::CreateProcessPipe
@@ -3701,7 +3701,7 @@ namespace CorUnix
             ERROR("Failed to create kqueue associated to process pipe\n");
             fRet = false;
             goto CPP_exit;
-        }       
+        }
 #endif // HAVE_KQUEUE
 
     CPP_exit:
@@ -3726,9 +3726,9 @@ namespace CorUnix
             {
                 close(iKq);
             }
-#endif // HAVE_KQUEUE            
-        }              
-        
+#endif // HAVE_KQUEUE
+        }
+
         return fRet;
     }
 
@@ -3753,8 +3753,8 @@ namespace CorUnix
             // Closing the write end of the process pipe. When the last process
             // that still has a open write-fd on this pipe will close it, the
             // worker thread will receive an EOF; the worker thread will wait
-            // for this EOF before shutting down, so to ensure to process any 
-            // possible data already written to the pipe by other processes 
+            // for this EOF before shutting down, so to ensure to process any
+            // possible data already written to the pipe by other processes
             // when the shutdown has been initiated in the current process.
             // Note: no need here to worry about platforms where close(pipe)
             // blocks on outstanding syscalls, since we are the only one using
@@ -3763,11 +3763,11 @@ namespace CorUnix
             if (close(m_iProcessPipeWrite) == -1)
             {
                 ERROR("Unable to close the write end of process pipe\n");
-                palErr = ERROR_INTERNAL_ERROR;                
+                palErr = ERROR_INTERNAL_ERROR;
             }
             m_iProcessPipeWrite = -1;
         }
-        
+
         return palErr;
     }
 
@@ -3817,7 +3817,7 @@ namespace CorUnix
         _ASSERTE(NULL != pthrCurrent);
         _ASSERTE(NULL != pvLocalSynchData);
         _ASSERTE(NULL != ppvSharedSynchData);
-        _ASSERTE(ProcessLocalObject == psdLocal->GetObjectDomain());     
+        _ASSERTE(ProcessLocalObject == psdLocal->GetObjectDomain());
 
 #if _DEBUG
 
@@ -3830,14 +3830,14 @@ namespace CorUnix
         // Allocate shared memory CSynchData and map to local memory
         //
 
-        shridSynchData = m_cacheSHRSynchData.Get(pthrCurrent); 
+        shridSynchData = m_cacheSHRSynchData.Get(pthrCurrent);
         if (NULLSharedID == shridSynchData)
         {
             ERROR("Unable to allocate shared memory\n");
             palError = ERROR_NOT_ENOUGH_MEMORY;
             goto POSD_exit;
         }
-        
+
         psdShared = SharedIDToTypePointer(CSynchData, shridSynchData);
         _ASSERTE(NULL != psdShared);
 
@@ -3857,7 +3857,7 @@ namespace CorUnix
                 palError = ERROR_OUTOFMEMORY;
                 goto POSD_exit;
             }
-            
+
             i = m_cacheSHRWTListNodes.Get(
                     pthrCurrent,
                     ulcWaitingThreads,
@@ -3870,7 +3870,7 @@ namespace CorUnix
                 {
                     m_cacheSHRWTListNodes.Add(pthrCurrent, rgshridWTLNodes[i]);
                 }
-                
+
                 palError = ERROR_OUTOFMEMORY;
                 goto POSD_exit;
             }
@@ -3931,7 +3931,7 @@ namespace CorUnix
 
                 pwtlnNew->shridSHRThis = rgshridWTLNodes[i];
                 pwtlnNew->ptrOwnerObjSynchData.shrid = shridSynchData;
-                
+
                 pwtlnNew->dwThreadId = pwtlnOld->dwThreadId;
                 pwtlnNew->dwProcessId = pwtlnOld->dwProcessId;
                 pwtlnNew->dwObjIndex = pwtlnOld->dwObjIndex;
@@ -3941,10 +3941,10 @@ namespace CorUnix
 
                 psdShared->SharedWaiterEnqueue(rgshridWTLNodes[i]);
                 psdShared->AddRef();
-                
+
                 _ASSERTE(pwtlnOld = pwtlnOld->ptwiWaitInfo->rgpWTLNodes[pwtlnOld->dwObjIndex]);
                 pwtlnNew->ptwiWaitInfo->rgpWTLNodes[pwtlnNew->dwObjIndex] = pwtlnNew;
-                
+
                 pwtlnNew->ptwiWaitInfo->lSharedObjCount += 1;
                 if (pwtlnNew->ptwiWaitInfo->lSharedObjCount
                     == pwtlnNew->ptwiWaitInfo->lObjCount)
@@ -3955,7 +3955,7 @@ namespace CorUnix
                 {
                     _ASSERTE(pwtlnNew->ptwiWaitInfo->lSharedObjCount
                         < pwtlnNew->ptwiWaitInfo->lObjCount);
-                    
+
                     pwtlnNew->ptwiWaitInfo->wdWaitDomain = MixedWait;
                 }
             }
@@ -3983,7 +3983,7 @@ namespace CorUnix
                 //
                 // Copy over other ownership info.
                 //
-                
+
                 psdShared->SetOwner(psdLocal->GetOwnerThread());
                 psdShared->SetOwnershipCount(psdLocal->GetOwnershipCount());
                 _ASSERTE(!psdShared->IsAbandoned());
@@ -4005,7 +4005,7 @@ namespace CorUnix
         if (otiProcess == pot->GetId())
         {
             MonitoredProcessesListNode *pmpn;
-            
+
             pmpn = m_pmplnMonitoredProcesses;
             while (NULL != pmpn)
             {
@@ -4029,7 +4029,7 @@ namespace CorUnix
 
                 pmpn = pmpn->pNext;
             }
-            
+
             InternalLeaveCriticalSection(pthrCurrent, &s_csMonitoredProcessesLock);
         }
 
@@ -4038,7 +4038,7 @@ namespace CorUnix
         //
         // Free the local memory items to caches
         //
-        
+
         if (0 < ulcWaitingThreads)
         {
             WaitingThreadsListNode *pwtln;
@@ -4064,7 +4064,7 @@ namespace CorUnix
         }
 
         return palError;
-    }           
+    }
 
 
     /////////////////////////////
@@ -4094,11 +4094,11 @@ namespace CorUnix
     //  CThreadSynchronizationInfo  //
     //                              //
     //////////////////////////////////
-    
+
     CThreadSynchronizationInfo::CThreadSynchronizationInfo() :
             m_tsThreadState(TS_IDLE),
             m_shridWaitAwakened(NULLSharedID),
-            m_lLocalSynchLockCount(0), 
+            m_lLocalSynchLockCount(0),
             m_lSharedSynchLockCount(0)
     {
         InitializeListHead(&m_leOwnedObjsList);
@@ -4110,7 +4110,7 @@ namespace CorUnix
     }
 
     CThreadSynchronizationInfo::~CThreadSynchronizationInfo()
-    { 
+    {
         if (NULLSharedID != m_shridWaitAwakened)
         {
             RawSharedObjectFree(m_shridWaitAwakened);
@@ -4122,7 +4122,7 @@ namespace CorUnix
 #if !SYNCHMGR_PIPE_BASED_THREAD_BLOCKING && !SYNCHMGR_SUSPENSION_SAFE_CONDITION_SIGNALING
         int iRet;
         iRet = pthread_mutex_lock(&m_tnwdNativeData.mutex);
-        _ASSERT_MSG(0 == iRet, "pthread_mutex_lock failed with error=%d\n", 
+        _ASSERT_MSG(0 == iRet, "pthread_mutex_lock failed with error=%d\n",
                     iRet);
 #endif // !SYNCHMGR_PIPE_BASED_THREAD_BLOCKING && !SYNCHMGR_SUSPENSION_SAFE_CONDITION_SIGNALING
     }
@@ -4132,13 +4132,13 @@ namespace CorUnix
 #if !SYNCHMGR_PIPE_BASED_THREAD_BLOCKING && !SYNCHMGR_SUSPENSION_SAFE_CONDITION_SIGNALING
         int iRet;
         iRet = pthread_mutex_unlock(&m_tnwdNativeData.mutex);
-        _ASSERT_MSG(0 == iRet, "pthread_mutex_unlock failed with error=%d\n", 
+        _ASSERT_MSG(0 == iRet, "pthread_mutex_unlock failed with error=%d\n",
                     iRet);
 #endif // !SYNCHMGR_PIPE_BASED_THREAD_BLOCKING && !SYNCHMGR_SUSPENSION_SAFE_CONDITION_SIGNALING
     }
 
     bool CThreadSynchronizationInfo::TryAcquireNativeWaitLock()
-    {       
+    {
         bool fRet = true;
 #if !SYNCHMGR_PIPE_BASED_THREAD_BLOCKING && !SYNCHMGR_SUSPENSION_SAFE_CONDITION_SIGNALING
         int iRet;
@@ -4148,7 +4148,7 @@ namespace CorUnix
         fRet = (0 == iRet);
 #endif // !SYNCHMGR_PIPE_BASED_THREAD_BLOCKING && !SYNCHMGR_SUSPENSION_SAFE_CONDITION_SIGNALING
         return fRet;
-    }        
+    }
 
 
     /*++
@@ -4162,7 +4162,7 @@ namespace CorUnix
     {
         PAL_ERROR palErr = NO_ERROR;
         DWORD * pdwWaitState = NULL;
-        int iRet;        
+        int iRet;
 #if !SYNCHMGR_PIPE_BASED_THREAD_BLOCKING
         const int MaxUnavailableResourceRetries = 10;
         int iEagains;
@@ -4170,15 +4170,15 @@ namespace CorUnix
         int iPipes[2] = { -1, -1};
 #endif // SYNCHMGR_PIPE_BASED_THREAD_BLOCKING
 
-        m_shridWaitAwakened = RawSharedObjectAlloc(sizeof(DWORD), 
+        m_shridWaitAwakened = RawSharedObjectAlloc(sizeof(DWORD),
                                                    DefaultSharedPool);
         if (NULLSharedID == m_shridWaitAwakened)
         {
             ERROR("Fail allocating thread wait status shared object\n");
-            palErr = ERROR_NOT_ENOUGH_MEMORY; 
+            palErr = ERROR_NOT_ENOUGH_MEMORY;
             goto IPrC_exit;
         }
-        
+
         pdwWaitState = SharedIDToTypePointer(DWORD,
             m_shridWaitAwakened);
 
@@ -4188,7 +4188,7 @@ namespace CorUnix
 
         VolatileStore<DWORD>(pdwWaitState, TWS_ACTIVE);
         m_tsThreadState = TS_STARTING;
-                
+
 #if !SYNCHMGR_PIPE_BASED_THREAD_BLOCKING
 
         iEagains = 0;
@@ -4213,7 +4213,7 @@ namespace CorUnix
             }
             goto IPrC_exit;
         }
-        
+
         iEagains = 0;
     Cond_retry:
         iRet = pthread_cond_init(&m_tnwdNativeData.cond, NULL);
@@ -4248,7 +4248,7 @@ namespace CorUnix
             switch(errno)
             {
                 case EMFILE:
-                case ENFILE:                        
+                case ENFILE:
                     palErr = ERROR_NO_SYSTEM_RESOURCES;
                     break;
                 case EFAULT:
@@ -4262,7 +4262,7 @@ namespace CorUnix
             goto IPrC_exit;
         }
 
-        if (0 != fcntl(iPipes[0], F_SETFL, O_NONBLOCK) || 
+        if (0 != fcntl(iPipes[0], F_SETFL, O_NONBLOCK) ||
             0 != fcntl(iPipes[1], F_SETFL, O_NONBLOCK))
         {
             ERROR("Failed to set thread-blocking pipes to non-blocking mode "
@@ -4332,7 +4332,7 @@ namespace CorUnix
     --*/
     void CThreadSynchronizationInfo::RemoveObjectFromOwnedList(POwnedObjectsListNode pooln)
     {
-        RemoveEntryList(&pooln->Link);       
+        RemoveEntryList(&pooln->Link);
     }
 
     /*++
@@ -4342,7 +4342,7 @@ namespace CorUnix
     Removes the first object from the list of currently owned objects.
     --*/
     POwnedObjectsListNode CThreadSynchronizationInfo::RemoveFirstObjectFromOwnedList()
-    {        
+    {
         OwnedObjectsListNode * poolnItem;
 
         if (IsListEmpty(&m_leOwnedObjsList))
@@ -4356,7 +4356,7 @@ namespace CorUnix
                                           OwnedObjectsListNode,
                                           Link);
         }
-        
+
         return poolnItem;
     }
 
@@ -4376,7 +4376,7 @@ namespace CorUnix
 
         if (0 < m_lPendingSignalingCount)
         {
-            LONG lArrayPendingSignalingCount = 
+            LONG lArrayPendingSignalingCount =
                 min(PendingSignalingsArraySize, m_lPendingSignalingCount);
             LONG lIdx = 0;
             PAL_ERROR palTempErr;
@@ -4401,7 +4401,7 @@ namespace CorUnix
             {
                 PLIST_ENTRY pLink;
                 DeferredSignalingListNode * pdsln;
-                
+
                 while (!IsListEmpty(&m_lePendingSignalingsOverflowList))
                 {
                     // Remove a node from the head of the queue
@@ -4448,7 +4448,7 @@ namespace CorUnix
     Tests whether or not a process has exited
     --*/
     bool CPalSynchronizationManager::HasProcessExited(
-        DWORD dwPid, 
+        DWORD dwPid,
         DWORD * pdwExitCode,
         bool * pfIsActualExitCode)
     {
@@ -4462,7 +4462,7 @@ namespace CorUnix
         {
             /* try to get state of process, using non-blocking call */
             pidWaitRetval = waitpid(dwPid, &iStatus, WNOHANG);
-            
+
             if ((DWORD)pidWaitRetval == dwPid)
             {
                 /* success; get the exit code */
@@ -4489,7 +4489,7 @@ namespace CorUnix
             }
             else
             {
-                // A legitimate cause of failure is EINTR; if this happens we 
+                // A legitimate cause of failure is EINTR; if this happens we
                 // have to try again. A second legitimate cause is ECHILD, which
                 // happens if we're trying to retrieve the status of a currently-
                 // running process that isn't a child of this process.
@@ -4525,7 +4525,7 @@ namespace CorUnix
                 }
                 else
                 {
-                    // Ignoring unexpected waitpid errno and assuming that 
+                    // Ignoring unexpected waitpid errno and assuming that
                     // the process is still running
                     ERROR("waitpid(pid=%u) failed with errno=%d (%s)\n",
                           dwPid, errno, strerror(errno));
@@ -4535,15 +4535,15 @@ namespace CorUnix
             // Break out of the loop in all cases except EINTR.
             break;
         }
-        
+
         return fRet;
     }
-    
+
     /*++
     Method:
       CPalSynchronizationManager::InterlockedAwaken
 
-    Tries to change the target wait status to 'active' in an interlocked fashion 
+    Tries to change the target wait status to 'active' in an interlocked fashion
     --*/
     bool CPalSynchronizationManager::InterlockedAwaken(
         DWORD *pWaitState,
@@ -4565,12 +4565,12 @@ namespace CorUnix
             if(TWS_WAITING == dwPrevState)
             {
                 return true;
-            }               
+            }
         }
         else
         {
             return true;
-        }   
+        }
         return false;
     }
 
@@ -4578,10 +4578,10 @@ namespace CorUnix
     Method:
       CPalSynchronizationManager::GetAbsoluteTimeout
 
-    Converts a relative timeout to an absolute one, reelatively to the 
+    Converts a relative timeout to an absolute one, reelatively to the
     current time.
     --*/
-    PAL_ERROR CPalSynchronizationManager::GetAbsoluteTimeout(DWORD dwTimeout, 
+    PAL_ERROR CPalSynchronizationManager::GetAbsoluteTimeout(DWORD dwTimeout,
                                                  struct timespec * ptsAbsTmo)
     {
         PAL_ERROR palErr = NO_ERROR;
@@ -4589,20 +4589,20 @@ namespace CorUnix
 
 #if HAVE_WORKING_CLOCK_GETTIME
         // Not every platform implements a (working) clock_gettime
-        iRet = clock_gettime(CLOCK_REALTIME, ptsAbsTmo); 
-#elif HAVE_WORKING_GETTIMEOFDAY 
+        iRet = clock_gettime(CLOCK_REALTIME, ptsAbsTmo);
+#elif HAVE_WORKING_GETTIMEOFDAY
         // Not every platform implements a (working) gettimeofday
         struct timeval tv;
         iRet = gettimeofday(&tv, NULL);
         if (0 == iRet)
         {
             ptsAbsTmo->tv_sec  = tv.tv_sec;
-            ptsAbsTmo->tv_nsec = tv.tv_usec * tccMicroSecondsToNanoSeconds; 
+            ptsAbsTmo->tv_nsec = tv.tv_usec * tccMicroSecondsToNanoSeconds;
         }
 #else
         #error "Don't know how to get hi-res current time on this platform"
 #endif // HAVE_WORKING_CLOCK_GETTIME, HAVE_WORKING_GETTIMEOFDAY
-    
+
         if (0 == iRet)
         {
             ptsAbsTmo->tv_sec  += dwTimeout / tccSecondsToMillieSeconds;
@@ -4627,7 +4627,7 @@ namespace CorUnix
         DWORD dwNewTime;
         DWORD dwDeltaTime;
         dwNewTime = GetTickCount();
-        
+
         // check for wrap around
         if(dwNewTime < *pdwOldTime)
         {
@@ -4650,4 +4650,3 @@ namespace CorUnix
 #endif // SYNCHMGR_PIPE_BASED_THREAD_BLOCKING
 
 }
-

--- a/pal/src/synchmgr/synchmanager.hpp
+++ b/pal/src/synchmgr/synchmanager.hpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -12,7 +12,7 @@ Module Name:
     synchmanager.hpp
 
 Abstract:
-    Private header file for synchronization manager and 
+    Private header file for synchronization manager and
     controllers implementation
 
 
@@ -49,17 +49,17 @@ SET_DEFAULT_DEBUG_CHANNEL(SYNC);
 #else
 #define VALIDATEOBJECT(obj)
 #endif
-    
+
 namespace CorUnix
-{          
+{
     const DWORD WTLN_FLAG_OWNER_OBJECT_IS_SHARED                 = 1<<0;
     const DWORD WTLN_FLAG_WAIT_ALL                               = 1<<1;
     const DWORD WTLN_FLAG_DELEGATED_OBJECT_SIGNALING_IN_PROGRESS = 1<<2;
-    
+
 #ifdef SYNCH_OBJECT_VALIDATION
     const DWORD HeadSignature  = 0x48454144;
     const DWORD TailSignature  = 0x5441494C;
-    const DWORD EmptySignature = 0xBAADF00D;    
+    const DWORD EmptySignature = 0xBAADF00D;
 #endif
 
     enum THREAD_WAIT_STATE
@@ -96,8 +96,8 @@ namespace CorUnix
 #endif
         WTLNodeGenrPtr ptrNext;
         WTLNodeGenrPtr ptrPrev;
-        SharedID shridSHRThis;        
-        
+        SharedID shridSHRThis;
+
         // Data
         DWORD dwThreadId;
         DWORD dwProcessId;
@@ -105,9 +105,9 @@ namespace CorUnix
         DWORD dwFlags;
 
         // Pointers to related objects
-        SharedID shridWaitingState; 
+        SharedID shridWaitingState;
         SynchDataGenrPtr ptrOwnerObjSynchData;
-        struct _ThreadWaitInfo * ptwiWaitInfo;  // valid only in the 
+        struct _ThreadWaitInfo * ptwiWaitInfo;  // valid only in the
                                                 // target process
 #ifdef SYNCH_OBJECT_VALIDATION
         _WaitingThreadsListNode();
@@ -136,14 +136,14 @@ namespace CorUnix
     {
         struct _ThreadApcInfoNode * pNext;
         PAPCFUNC pfnAPC;
-        ULONG_PTR pAPCData;        
+        ULONG_PTR pAPCData;
     } ThreadApcInfoNode;
 
     class CPalSynchronizationManager; // fwd declaration
     class CProcProcessLocalData;      // fwd declaration
-    
+
     class CSynchData
-    {        
+    {
 #ifdef SYNCH_OBJECT_VALIDATION
         DWORD m_dwDebugHeadSignature;
 #endif
@@ -154,7 +154,7 @@ namespace CorUnix
         WTLNodeGenrPtr  m_ptrWTLTail;
         ULONG m_ulcWaitingThreads;
         SharedID m_shridThis;
-        ObjectDomain m_odObjectDomain; 
+        ObjectDomain m_odObjectDomain;
         PalObjectTypeId m_otiObjectTypeId;
         LONG  m_lRefCount;
         LONG  m_lSignalCount;
@@ -174,14 +174,14 @@ namespace CorUnix
 #endif
 
     public:
-                
-        CSynchData() 
+
+        CSynchData()
             : m_ulcWaitingThreads(0), m_shridThis(NULLSharedID), m_lRefCount(1),
               m_lSignalCount(0), m_lOwnershipCount(0), m_dwOwnerPid(0),
-              m_dwOwnerTid(0), m_pOwnerThread(NULL), 
+              m_dwOwnerTid(0), m_pOwnerThread(NULL),
               m_poolnOwnedObjectListNode(NULL), m_fAbandoned(false)
-        { 
-            // m_ptrWTLHead, m_ptrWTLTail, m_odObjectDomain 
+        {
+            // m_ptrWTLHead, m_ptrWTLTail, m_odObjectDomain
             // and m_otiObjectTypeId are initialized by
             // CPalSynchronizationManager::AllocateObjectSynchData
 #ifdef SYNCH_STATISTICS
@@ -195,13 +195,13 @@ namespace CorUnix
 #endif
         }
 
-        LONG AddRef() 
-        { 
-            return InterlockedIncrement(&m_lRefCount); 
+        LONG AddRef()
+        {
+            return InterlockedIncrement(&m_lRefCount);
         }
-                 
+
         LONG Release(CPalThread * pthrCurrent);
-        
+
         bool CanWaiterWaitWithoutBlocking(
             CPalThread * pWaiterThread,
             bool * pfAbandoned);
@@ -209,51 +209,51 @@ namespace CorUnix
         PAL_ERROR ReleaseWaiterWithoutBlocking(
             CPalThread * pthrCurrent,
             CPalThread * pthrTarget);
-                   
+
         void WaiterEnqueue(WaitingThreadsListNode * pwtlnNewNode);
         void SharedWaiterEnqueue(SharedID shridNewNode);
- 
+
         // Object Domain accessor methods
-        ObjectDomain GetObjectDomain(void) 
-        { 
-            return m_odObjectDomain; 
-        }        
-        void SetObjectDomain(ObjectDomain odObjectDomain) 
-        { 
-            m_odObjectDomain = odObjectDomain; 
+        ObjectDomain GetObjectDomain(void)
+        {
+            return m_odObjectDomain;
+        }
+        void SetObjectDomain(ObjectDomain odObjectDomain)
+        {
+            m_odObjectDomain = odObjectDomain;
         }
 
         // Object Type accessor methods
-        CObjectType * GetObjectType(void) 
-        { 
+        CObjectType * GetObjectType(void)
+        {
             return CObjectType::GetObjectTypeById(m_otiObjectTypeId);
-        }        
-        PalObjectTypeId GetObjectTypeId(void) 
-        { 
-            return m_otiObjectTypeId;
-        }        
-        void SetObjectType(CObjectType * pot) 
-        { 
-            m_otiObjectTypeId = pot->GetId(); 
         }
-        void SetObjectType(PalObjectTypeId oti) 
-        { 
-            m_otiObjectTypeId = oti; 
+        PalObjectTypeId GetObjectTypeId(void)
+        {
+            return m_otiObjectTypeId;
+        }
+        void SetObjectType(CObjectType * pot)
+        {
+            m_otiObjectTypeId = pot->GetId();
+        }
+        void SetObjectType(PalObjectTypeId oti)
+        {
+            m_otiObjectTypeId = oti;
         }
 
         // Object shared 'this' pointer accessor methods
-        SharedID GetSharedThis (void) 
-        { 
-            return m_shridThis; 
+        SharedID GetSharedThis (void)
+        {
+            return m_shridThis;
         }
-        void SetSharedThis (SharedID shridThis) 
-        { 
-            m_shridThis = shridThis; 
+        void SetSharedThis (SharedID shridThis)
+        {
+            m_shridThis = shridThis;
         }
 
         void Signal(
-            CPalThread * pthrCurrent, 
-            LONG lSignalCount, 
+            CPalThread * pthrCurrent,
+            LONG lSignalCount,
             bool fWorkerThread);
 
         bool ReleaseFirstWaiter(
@@ -268,21 +268,21 @@ namespace CorUnix
             WaitingThreadsListNode * pwtlnNode);
 
         // Object signal count accessor methods
-        LONG GetSignalCount(void) 
+        LONG GetSignalCount(void)
         {
             _ASSERTE(m_lSignalCount >= 0);
-            return m_lSignalCount; 
+            return m_lSignalCount;
         }
-        void SetSignalCount(LONG lSignalCount) 
-        { 
+        void SetSignalCount(LONG lSignalCount)
+        {
             _ASSERTE(m_lSignalCount >= 0);
             _ASSERTE(lSignalCount >= 0);
-            m_lSignalCount = lSignalCount; 
+            m_lSignalCount = lSignalCount;
         }
-        LONG DecrementSignalCount(void) 
+        LONG DecrementSignalCount(void)
         {
             _ASSERTE(m_lSignalCount > 0);
-            return --m_lSignalCount; 
+            return --m_lSignalCount;
         }
 
         // Object ownership accessor methods
@@ -291,17 +291,17 @@ namespace CorUnix
         PAL_ERROR AssignOwnershipToThread(
             CPalThread * pthrCurrent,
             CPalThread * pthrTarget);
-        DWORD GetOwnerProcessID(void) 
-        { 
-            return m_dwOwnerPid; 
+        DWORD GetOwnerProcessID(void)
+        {
+            return m_dwOwnerPid;
         }
-        DWORD GetOwnerThreadID(void) 
-        { 
-            return m_dwOwnerTid; 
+        DWORD GetOwnerThreadID(void)
+        {
+            return m_dwOwnerTid;
         }
-        CPalThread * GetOwnerThread(void) 
-        { 
-            return m_pOwnerThread; 
+        CPalThread * GetOwnerThread(void)
+        {
+            return m_pOwnerThread;
         }
         OwnedObjectsListNode * GetOwnershipListNode(void)
         {
@@ -313,17 +313,17 @@ namespace CorUnix
         }
 
         // Object ownership count accessor methods
-        LONG GetOwnershipCount(void) 
-        { 
-            return m_lOwnershipCount; 
+        LONG GetOwnershipCount(void)
+        {
+            return m_lOwnershipCount;
         }
-        void SetOwnershipCount(LONG lOwnershipCount) 
-        { 
+        void SetOwnershipCount(LONG lOwnershipCount)
+        {
             m_lOwnershipCount = lOwnershipCount;
         }
 
         // Object abandoned flag accessor methods
-        void SetAbandoned(bool fAbandoned) 
+        void SetAbandoned(bool fAbandoned)
                                     { m_fAbandoned = fAbandoned; }
         bool IsAbandoned(void) { return m_fAbandoned; }
 
@@ -362,37 +362,37 @@ namespace CorUnix
         //
         // Wating threads list access methods
         //
-        WaitingThreadsListNode * GetWTLHeadPtr(void) 
-        { 
-            return m_ptrWTLHead.ptr; 
+        WaitingThreadsListNode * GetWTLHeadPtr(void)
+        {
+            return m_ptrWTLHead.ptr;
         }
-        WaitingThreadsListNode * GetWTLTailPtr(void) 
-        { 
-            return m_ptrWTLTail.ptr; 
+        WaitingThreadsListNode * GetWTLTailPtr(void)
+        {
+            return m_ptrWTLTail.ptr;
         }
-        SharedID GetWTLHeadShmPtr(void) 
-        { 
-            return m_ptrWTLHead.shrid; 
+        SharedID GetWTLHeadShmPtr(void)
+        {
+            return m_ptrWTLHead.shrid;
         }
-        SharedID GetWTLTailShmPtr(void) 
-        { 
-            return m_ptrWTLTail.shrid; 
+        SharedID GetWTLTailShmPtr(void)
+        {
+            return m_ptrWTLTail.shrid;
         }
-        void SetWTLHeadPtr(WaitingThreadsListNode * p) 
-        { 
-            m_ptrWTLHead.ptr = p; 
+        void SetWTLHeadPtr(WaitingThreadsListNode * p)
+        {
+            m_ptrWTLHead.ptr = p;
         }
-        void SetWTLTailPtr(WaitingThreadsListNode * p) 
-        { 
-            m_ptrWTLTail.ptr = p; 
+        void SetWTLTailPtr(WaitingThreadsListNode * p)
+        {
+            m_ptrWTLTail.ptr = p;
         }
-        void SetWTLHeadShrPtr(SharedID shrid) 
-        { 
-            m_ptrWTLHead.shrid = shrid; 
+        void SetWTLHeadShrPtr(SharedID shrid)
+        {
+            m_ptrWTLHead.shrid = shrid;
         }
-        void SetWTLTailShrPtr(SharedID shrid) 
-        { 
-            m_ptrWTLTail.shrid = shrid; 
+        void SetWTLTailShrPtr(SharedID shrid)
+        {
+            m_ptrWTLTail.shrid = shrid;
         }
 #ifdef SYNCH_OBJECT_VALIDATION
         ~CSynchData();
@@ -404,13 +404,13 @@ namespace CorUnix
 #endif
     };
 
-    
+
     class CSynchControllerBase
     {
         friend class CPalSynchronizationManager;
 
         // NB: For perforformance purposes this class is supposed
-        //     to have no virtual methods, contructor and 
+        //     to have no virtual methods, contructor and
         //     destructor
     public:
         enum ControllerType { WaitController, StateController };
@@ -422,7 +422,7 @@ namespace CorUnix
         CObjectType * m_potObjectType;
         CSynchData * m_psdSynchData;
         WaitDomain m_wdWaitDomain;
-             
+
         PAL_ERROR Init(
             CPalThread * pthrCurrent,
             ControllerType ctCtrlrType,
@@ -430,39 +430,39 @@ namespace CorUnix
             CObjectType *potObjectType,
             CSynchData * psdSynchData,
             WaitDomain wdWaitDomain);
-        
+
         void Release(void);
 
-        void SetSynchData(CSynchData * psdSynchData) 
-        { 
-            m_psdSynchData = psdSynchData; 
+        void SetSynchData(CSynchData * psdSynchData)
+        {
+            m_psdSynchData = psdSynchData;
         }
-        CSynchData * GetSynchData() 
-        { 
-            return m_psdSynchData; 
+        CSynchData * GetSynchData()
+        {
+            return m_psdSynchData;
         }
     };
-        
-    class CSynchWaitController : public CSynchControllerBase, 
+
+    class CSynchWaitController : public CSynchControllerBase,
                                  public ISynchWaitController
     {
         // Per-object-type specific data
         //
         // Process (otiProcess)
         CProcProcessLocalData * m_pProcLocalData;
-        
+
     public:
         CSynchWaitController() : m_pProcLocalData(NULL) {}
-        
+
         //
         // ISynchWaitController methods
         //
         virtual PAL_ERROR CanThreadWaitWithoutBlocking(
             bool * pfCanWaitWithoutBlocking,
             bool * pfAbandoned);
-        
+
         virtual PAL_ERROR ReleaseWaitingThreadWithoutBlocking(void);
-        
+
         virtual PAL_ERROR RegisterWaitingThread(
             WaitType wtWaitType,
             DWORD dwIndex,
@@ -473,15 +473,15 @@ namespace CorUnix
         CProcProcessLocalData * GetProcessLocalData(void);
 
         void SetProcessLocalData(CProcProcessLocalData * pProcLocalData);
-    };  
+    };
 
-    class CSynchStateController : public CSynchControllerBase, 
+    class CSynchStateController : public CSynchControllerBase,
                                   public ISynchStateController
     {
     public:
         // NB: For perforformance purposes this class is supposed
         //     to have no constructor or destructor
-        
+
         //
         // ISynchStateController methods
         //
@@ -492,8 +492,8 @@ namespace CorUnix
         virtual PAL_ERROR SetOwner(CPalThread *pNewOwningThread);
         virtual PAL_ERROR DecrementOwnershipCount(void);
         virtual void ReleaseController(void);
-    };    
-    
+    };
+
     class CPalSynchronizationManager : public IPalSynchronizationManager
     {
         friend class CPalSynchMgrController;
@@ -512,17 +512,17 @@ namespace CorUnix
 
     private:
         // types
-        enum InitStatus 
-        { 
-            SynchMgrStatusIdle, 
-            SynchMgrStatusInitializing, 
-            SynchMgrStatusRunning, 
+        enum InitStatus
+        {
+            SynchMgrStatusIdle,
+            SynchMgrStatusInitializing,
+            SynchMgrStatusRunning,
             SynchMgrStatusShuttingDown,
             SynchMgrStatusReadyForProcessShutDown,
-            SynchMgrStatusError 
-        };  
-        enum SynchWorkerCmd 
-        { 
+            SynchMgrStatusError
+        };
+        enum SynchWorkerCmd
+        {
             SynchWorkerCmdNop,
             SynchWorkerCmdRemoteSignal,
             SynchWorkerCmdDelegatedObjectSignaling,
@@ -556,12 +556,12 @@ namespace CorUnix
         static const DWORD WorkerThreadTerminationTimeout  = 2000; // ms
 
         // static members
-        static CPalSynchronizationManager * s_pObjSynchMgr;        
+        static CPalSynchronizationManager * s_pObjSynchMgr;
         static Volatile<LONG>               s_lInitStatus;
         static CRITICAL_SECTION             s_csSynchProcessLock;
         static CRITICAL_SECTION             s_csMonitoredProcessesLock;
-        
-        // members        
+
+        // members
         DWORD                           m_dwWorkerThreadTid;
         IPalObject *                    m_pipoThread;
         CPalThread *                    m_pthrWorker;
@@ -609,38 +609,38 @@ namespace CorUnix
         virtual ~CPalSynchronizationManager();
 
         static CPalSynchronizationManager * GetInstance(void)
-        { 
-            // No need here to check for NULL and in case create the 
-            // singleton, since its creation is enforced by the PAL 
+        {
+            // No need here to check for NULL and in case create the
+            // singleton, since its creation is enforced by the PAL
             // initialization code.
-            return s_pObjSynchMgr; 
+            return s_pObjSynchMgr;
         }
-        
+
         //
         // Inline utility methods
         //
         static void AcquireLocalSynchLock(CPalThread * pthrCurrent)
-        { 
+        {
             _ASSERTE(0 <= pthrCurrent->synchronizationInfo.m_lLocalSynchLockCount);
-            
+
             if (1 == ++pthrCurrent->synchronizationInfo.m_lLocalSynchLockCount)
             {
                 InternalEnterCriticalSection(pthrCurrent, &s_csSynchProcessLock);
             }
         }
-        static void ReleaseLocalSynchLock(CPalThread * pthrCurrent) 
+        static void ReleaseLocalSynchLock(CPalThread * pthrCurrent)
         {
             _ASSERTE(0 < pthrCurrent->synchronizationInfo.m_lLocalSynchLockCount);
             if (0 == --pthrCurrent->synchronizationInfo.m_lLocalSynchLockCount)
             {
                 InternalLeaveCriticalSection(pthrCurrent, &s_csSynchProcessLock);
-                
+
 #if SYNCHMGR_SUSPENSION_SAFE_CONDITION_SIGNALING && !SYNCHMGR_PIPE_BASED_THREAD_BLOCKING
                 pthrCurrent->synchronizationInfo.RunDeferredThreadConditionSignalings();
 #endif // SYNCHMGR_SUSPENSION_SAFE_CONDITION_SIGNALING && !SYNCHMGR_PIPE_BASED_THREAD_BLOCKING
             }
         }
-        static LONG ResetLocalSynchLock(CPalThread * pthrCurrent) 
+        static LONG ResetLocalSynchLock(CPalThread * pthrCurrent)
         {
             LONG lRet = pthrCurrent->synchronizationInfo.m_lLocalSynchLockCount;
 
@@ -653,17 +653,17 @@ namespace CorUnix
 #if SYNCHMGR_SUSPENSION_SAFE_CONDITION_SIGNALING && !SYNCHMGR_PIPE_BASED_THREAD_BLOCKING
                 pthrCurrent->synchronizationInfo.RunDeferredThreadConditionSignalings();
 #endif // SYNCHMGR_SUSPENSION_SAFE_CONDITION_SIGNALING && !SYNCHMGR_PIPE_BASED_THREAD_BLOCKING
-            }            
+            }
             return lRet;
         }
-        static LONG GetLocalSynchLockCount(CPalThread * pthrCurrent) 
+        static LONG GetLocalSynchLockCount(CPalThread * pthrCurrent)
         {
             _ASSERTE(0 <= pthrCurrent->synchronizationInfo.m_lLocalSynchLockCount);
             return pthrCurrent->synchronizationInfo.m_lLocalSynchLockCount;
         }
 
         static void AcquireSharedSynchLock(CPalThread * pthrCurrent)
-        {   
+        {
             _ASSERTE(0 <= pthrCurrent->synchronizationInfo.m_lSharedSynchLockCount);
             _ASSERT_MSG(0 < pthrCurrent->synchronizationInfo.m_lLocalSynchLockCount,
                 "The local synch lock should be acquired before grabbing the "
@@ -672,8 +672,8 @@ namespace CorUnix
             {
                 SHMLock();
             }
-        } 
-        static void ReleaseSharedSynchLock(CPalThread * pthrCurrent) 
+        }
+        static void ReleaseSharedSynchLock(CPalThread * pthrCurrent)
         {
             _ASSERTE(0 < pthrCurrent->synchronizationInfo.m_lSharedSynchLockCount);
             if (0 == --pthrCurrent->synchronizationInfo.m_lSharedSynchLockCount)
@@ -681,16 +681,16 @@ namespace CorUnix
                 _ASSERT_MSG(0 < pthrCurrent->synchronizationInfo.m_lLocalSynchLockCount,
                     "Final release of the shared synch lock while not holding the "
                     "local one. Local synch lock should always be acquired first and "
-                    "released last.\n");                
+                    "released last.\n");
                 SHMRelease();
-            }                
+            }
         }
-        static LONG ResetSharedSynchLock(CPalThread * pthrCurrent) 
-        {   
+        static LONG ResetSharedSynchLock(CPalThread * pthrCurrent)
+        {
             LONG lRet = pthrCurrent->synchronizationInfo.m_lSharedSynchLockCount;
 
             _ASSERTE(0 <= lRet);
-            _ASSERTE(0 == lRet || 
+            _ASSERTE(0 == lRet ||
                      0 < pthrCurrent->synchronizationInfo.m_lLocalSynchLockCount);
             if (0 < lRet)
             {
@@ -699,113 +699,113 @@ namespace CorUnix
             }
             return lRet;
         }
-        static LONG GetSharedSynchLockCount(CPalThread * pthrCurrent) 
+        static LONG GetSharedSynchLockCount(CPalThread * pthrCurrent)
         {
             _ASSERTE(0 <= pthrCurrent->synchronizationInfo.m_lSharedSynchLockCount);
-            _ASSERTE(0 == pthrCurrent->synchronizationInfo.m_lSharedSynchLockCount || 
+            _ASSERTE(0 == pthrCurrent->synchronizationInfo.m_lSharedSynchLockCount ||
                      0 < pthrCurrent->synchronizationInfo.m_lLocalSynchLockCount);
             return pthrCurrent->synchronizationInfo.m_lSharedSynchLockCount;
         }
 
         CSynchWaitController * CacheGetWaitCtrlr(CPalThread * pthrCurrent)
-        { 
-            return m_cacheWaitCtrlrs.Get(pthrCurrent); 
+        {
+            return m_cacheWaitCtrlrs.Get(pthrCurrent);
         }
         int CacheGetWaitCtrlr(
-            CPalThread * pthrCurrent, 
-            int n, 
+            CPalThread * pthrCurrent,
+            int n,
             CSynchWaitController * prgCtrlrs[])
-        { 
-            return m_cacheWaitCtrlrs.Get(pthrCurrent, n, prgCtrlrs); 
+        {
+            return m_cacheWaitCtrlrs.Get(pthrCurrent, n, prgCtrlrs);
         }
         void CacheAddWaitCtrlr(
-            CPalThread * pthrCurrent, 
-            CSynchWaitController * pCtrlr) 
-        { 
-            m_cacheWaitCtrlrs.Add(pthrCurrent, pCtrlr); 
-        }            
+            CPalThread * pthrCurrent,
+            CSynchWaitController * pCtrlr)
+        {
+            m_cacheWaitCtrlrs.Add(pthrCurrent, pCtrlr);
+        }
         CSynchStateController * CacheGetStateCtrlr(CPalThread * pthrCurrent)
-        { 
-            return m_cacheStateCtrlrs.Get(pthrCurrent); 
+        {
+            return m_cacheStateCtrlrs.Get(pthrCurrent);
         }
         int CacheGetStateCtrlr(
             CPalThread * pthrCurrent,
-            int n, 
-            CSynchStateController * prgCtrlrs[]) 
-        { 
-            return m_cacheStateCtrlrs.Get(pthrCurrent, n, prgCtrlrs); 
+            int n,
+            CSynchStateController * prgCtrlrs[])
+        {
+            return m_cacheStateCtrlrs.Get(pthrCurrent, n, prgCtrlrs);
         }
         void CacheAddStateCtrlr(
-            CPalThread * pthrCurrent, 
-            CSynchStateController * pCtrlr) 
-        { 
-            m_cacheStateCtrlrs.Add(pthrCurrent, pCtrlr); 
+            CPalThread * pthrCurrent,
+            CSynchStateController * pCtrlr)
+        {
+            m_cacheStateCtrlrs.Add(pthrCurrent, pCtrlr);
         }
 
-        CSynchData * CacheGetLocalSynchData(CPalThread * pthrCurrent)            
-        { 
-            return m_cacheSynchData.Get(pthrCurrent); 
+        CSynchData * CacheGetLocalSynchData(CPalThread * pthrCurrent)
+        {
+            return m_cacheSynchData.Get(pthrCurrent);
         }
         void CacheAddLocalSynchData(
             CPalThread * pthrCurrent,
-            CSynchData * psdSynchData) 
-        { 
-            m_cacheSynchData.Add(pthrCurrent, psdSynchData); 
+            CSynchData * psdSynchData)
+        {
+            m_cacheSynchData.Add(pthrCurrent, psdSynchData);
         }
-        SharedID CacheGetSharedSynchData(CPalThread * pthrCurrent) 
-        { 
-            return m_cacheSHRSynchData.Get(pthrCurrent); 
+        SharedID CacheGetSharedSynchData(CPalThread * pthrCurrent)
+        {
+            return m_cacheSHRSynchData.Get(pthrCurrent);
         }
         void CacheAddSharedSynchData(
             CPalThread * pthrCurrent,
-            SharedID shridSData) 
-        { 
-            m_cacheSHRSynchData.Add(pthrCurrent, shridSData); 
+            SharedID shridSData)
+        {
+            m_cacheSHRSynchData.Add(pthrCurrent, shridSData);
         }
 
         WaitingThreadsListNode * CacheGetLocalWTListNode(
             CPalThread * pthrCurrent)
-        { 
-            return m_cacheWTListNodes.Get(pthrCurrent); 
+        {
+            return m_cacheWTListNodes.Get(pthrCurrent);
         }
         void CacheAddLocalWTListNode(
             CPalThread * pthrCurrent,
             WaitingThreadsListNode * pWTLNode)
-        { 
-            m_cacheWTListNodes.Add(pthrCurrent, pWTLNode); 
+        {
+            m_cacheWTListNodes.Add(pthrCurrent, pWTLNode);
         }
-        SharedID CacheGetSharedWTListNode(CPalThread * pthrCurrent) 
-        { 
-            return m_cacheSHRWTListNodes.Get(pthrCurrent); 
+        SharedID CacheGetSharedWTListNode(CPalThread * pthrCurrent)
+        {
+            return m_cacheSHRWTListNodes.Get(pthrCurrent);
         }
         void CacheAddSharedWTListNode(
             CPalThread * pthrCurrent,
-            SharedID shridWTLNode) 
-        { 
-            m_cacheSHRWTListNodes.Add(pthrCurrent, shridWTLNode); 
+            SharedID shridWTLNode)
+        {
+            m_cacheSHRWTListNodes.Add(pthrCurrent, shridWTLNode);
         }
 
-        ThreadApcInfoNode * CacheGetApcInfoNodes(CPalThread * pthrCurrent) 
-        { 
-            return m_cacheThreadApcInfoNodes.Get(pthrCurrent); 
+        ThreadApcInfoNode * CacheGetApcInfoNodes(CPalThread * pthrCurrent)
+        {
+            return m_cacheThreadApcInfoNodes.Get(pthrCurrent);
         }
         void CacheAddApcInfoNodes(
             CPalThread * pthrCurrent,
-            ThreadApcInfoNode * pNode) 
-        { 
-            m_cacheThreadApcInfoNodes.Add(pthrCurrent, pNode); 
+            ThreadApcInfoNode * pNode)
+        {
+            m_cacheThreadApcInfoNodes.Add(pthrCurrent, pNode);
         }
 
         OwnedObjectsListNode * CacheGetOwnedObjsListNode(
             CPalThread * pthrCurrent)
-        { 
-            return m_cacheOwnedObjectsListNodes.Get(pthrCurrent); 
+        {
+            return m_cacheOwnedObjectsListNodes.Get(pthrCurrent);
         }
         void CacheAddOwnedObjsListNode(
             CPalThread * pthrCurrent,
-            OwnedObjectsListNode * pNode) 
-        { 
-            m_cacheOwnedObjectsListNodes.Add(pthrCurrent, pNode); 
+            OwnedObjectsListNode * pNode)
+        {
+            m_cacheOwnedObjectsListNodes.Add(pthrCurrent, pNode);
         }
 
 
@@ -941,11 +941,11 @@ namespace CorUnix
 
 #ifndef CORECLR
         static bool GetProcessPipeName(
-            LPSTR pDest, 
+            LPSTR pDest,
             int iDestSize,
             DWORD dwPid);
 #endif // !CORECLR
-        
+
         //
         // Non-static helper methods
         //
@@ -956,7 +956,7 @@ namespace CorUnix
 
         PAL_ERROR ReadCmdFromProcessPipe(
             int iPollTimeout,
-            SynchWorkerCmd * pswcWorkerCmd,            
+            SynchWorkerCmd * pswcWorkerCmd,
             SharedID * pshridMarshaledData,
             DWORD * pdwData);
 
@@ -1000,7 +1000,7 @@ namespace CorUnix
         // Utility static methods, no lock required
         //
         static bool HasProcessExited(
-            DWORD dwPid, 
+            DWORD dwPid,
             DWORD * pdwExitCode,
             bool * pfIsActualExitCode);
 
@@ -1009,12 +1009,12 @@ namespace CorUnix
             bool fAlertOnly);
 
         static PAL_ERROR GetAbsoluteTimeout(
-            DWORD dwTimeout, 
+            DWORD dwTimeout,
             struct timespec * ptsAbsTmo);
 
 #if SYNCHMGR_PIPE_BASED_THREAD_BLOCKING
         static void UpdateTimeout(
-            DWORD * pdwOldTime, 
+            DWORD * pdwOldTime,
             DWORD * pdwTimeout);
 #endif
 
@@ -1022,4 +1022,3 @@ namespace CorUnix
 }
 
 #endif // _SINCHMANAGER_HPP_
-

--- a/pal/src/synchmgr/wait.cpp
+++ b/pal/src/synchmgr/wait.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -33,16 +33,16 @@ SET_DEFAULT_DEBUG_CHANNEL(SYNC);
 
 using namespace CorUnix;
 
-static PalObjectTypeId sg_rgWaitObjectsIds[] = 
-    { 
+static PalObjectTypeId sg_rgWaitObjectsIds[] =
+    {
         otiAutoResetEvent,
         otiManualResetEvent,
         otiMutex,
-        otiSemaphore,        
+        otiSemaphore,
         otiProcess,
         otiThread
     };
-static CAllowedObjectTypes sg_aotWaitObject(sg_rgWaitObjectsIds, 
+static CAllowedObjectTypes sg_aotWaitObject(sg_rgWaitObjectsIds,
     sizeof(sg_rgWaitObjectsIds)/sizeof(sg_rgWaitObjectsIds[0]));
 
 /*++
@@ -125,7 +125,7 @@ WaitForMultipleObjects(IN DWORD nCount,
 
     CPalThread * pThread = InternalGetCurrentThread();
 
-    dwRet = InternalWaitForMultipleObjectsEx(pThread, nCount, lpHandles, 
+    dwRet = InternalWaitForMultipleObjectsEx(pThread, nCount, lpHandles,
                                              bWaitAll, dwMilliseconds, FALSE);
 
     LOGEXIT("WaitForMultipleObjects returns DWORD %u\n", dwRet);
@@ -183,7 +183,7 @@ Sleep(IN DWORD dwMilliseconds)
 
     if (NO_ERROR != palErr)
     {
-        ERROR("Sleep(dwMilliseconds=%u) failed [error=%u]\n", 
+        ERROR("Sleep(dwMilliseconds=%u) failed [error=%u]\n",
               dwMilliseconds, palErr);
         pThread->SetLastError(palErr);
     }
@@ -206,7 +206,7 @@ SleepEx(IN DWORD dwMilliseconds,
 {
     DWORD dwRet;
 
-    PERF_ENTRY(SleepEx);    
+    PERF_ENTRY(SleepEx);
     ENTRY("SleepEx(dwMilliseconds=%u, bAlertable=%d)\n", dwMilliseconds, bAlertable);
 
     CPalThread * pThread = InternalGetCurrentThread();
@@ -231,7 +231,7 @@ QueueUserAPC(
     PAPCFUNC pfnAPC,
     HANDLE hThread,
     ULONG_PTR dwData)
-{    
+{
     CPalThread * pCurrentThread = NULL;
     CPalThread * pTargetThread = NULL;
     IPalObject * pTargetThreadObject = NULL;
@@ -239,12 +239,12 @@ QueueUserAPC(
     DWORD dwRet;
 
     PERF_ENTRY(QueueUserAPC);
-    ENTRY("QueueUserAPC(pfnAPC=%p, hThread=%p, dwData=%#x)\n", 
+    ENTRY("QueueUserAPC(pfnAPC=%p, hThread=%p, dwData=%#x)\n",
           pfnAPC, hThread, dwData);
-    
-    /* NOTE: Windows does not check the validity of pfnAPC, even if it is 
-       NULL.  It just does an access violation later on when the APC call 
-       is attempted */                 
+
+    /* NOTE: Windows does not check the validity of pfnAPC, even if it is
+       NULL.  It just does an access violation later on when the APC call
+       is attempted */
 
     pCurrentThread = InternalGetCurrentThread();
 
@@ -258,14 +258,14 @@ QueueUserAPC(
 
     if (NO_ERROR != palErr)
     {
-        ERROR("Unable to obtain thread data for handle %p (error %x)!\n", 
+        ERROR("Unable to obtain thread data for handle %p (error %x)!\n",
                 hThread, palErr);
         goto QueueUserAPC_exit;
     }
-    
 
-    palErr = g_pSynchronizationManager->QueueUserAPC(pCurrentThread, pTargetThread, 
-                                                     pfnAPC, dwData);  
+
+    palErr = g_pSynchronizationManager->QueueUserAPC(pCurrentThread, pTargetThread,
+                                                     pfnAPC, dwData);
 
 QueueUserAPC_exit:
     if (pTargetThreadObject)
@@ -274,7 +274,7 @@ QueueUserAPC_exit:
     }
 
     dwRet = (NO_ERROR == palErr) ? 1 : 0;
-    
+
     LOGEXIT("QueueUserAPC returns DWORD %d\n", dwRet);
     PERF_EXIT(QueueUserAPC);
     return dwRet;
@@ -291,7 +291,7 @@ DWORD CorUnix::InternalWaitForMultipleObjectsEx(
     DWORD dwRet = WAIT_FAILED;
     PAL_ERROR palErr = NO_ERROR;
     int i, iSignaledObjCount, iSignaledObjIndex = -1;
-    bool fWAll = (bool)bWaitAll, fNeedToBlock  = false;    
+    bool fWAll = (bool)bWaitAll, fNeedToBlock  = false;
     bool fAbandoned = false;
     WaitType wtWaitType;
 
@@ -299,12 +299,12 @@ DWORD CorUnix::InternalWaitForMultipleObjectsEx(
     ISynchWaitController  * pISyncStackArray[MAXIMUM_STACK_WAITOBJ_ARRAY_SIZE] = { NULL };
     IPalObject           ** ppIPalObjs = pIPalObjStackArray;
     ISynchWaitController ** ppISyncWaitCtrlrs = pISyncStackArray;
-  
+
     if ((nCount == 0) || (nCount > MAXIMUM_WAIT_OBJECTS))
     {
         ppIPalObjs = NULL;        // make delete at the end safe
-        ppISyncWaitCtrlrs = NULL; // make delete at the end safe       
-        ERROR("Invalid object count=%d [range: 1 to %d]\n", 
+        ppISyncWaitCtrlrs = NULL; // make delete at the end safe
+        ERROR("Invalid object count=%d [range: 1 to %d]\n",
                nCount, MAXIMUM_WAIT_OBJECTS)
         pThread->SetLastError(ERROR_INVALID_PARAMETER);
         goto WFMOExIntExit;
@@ -312,9 +312,9 @@ DWORD CorUnix::InternalWaitForMultipleObjectsEx(
     else if (nCount == 1)
     {
         fWAll = false;  // makes no difference when nCount is 1
-        wtWaitType = SingleObject;                                  
+        wtWaitType = SingleObject;
     }
-    else 
+    else
     {
         wtWaitType = fWAll ? MultipleObjectsWaitAll : MultipleObjectsWaitOne;
         if (nCount > MAXIMUM_STACK_WAITOBJ_ARRAY_SIZE)
@@ -329,9 +329,9 @@ DWORD CorUnix::InternalWaitForMultipleObjectsEx(
             }
         }
     }
-   
+
     palErr = g_pObjectManager->ReferenceMultipleObjectsByHandleArray(pThread,
-                                                                     (VOID **)lpHandles, 
+                                                                     (VOID **)lpHandles,
                                                                      nCount,
                                                                      &sg_aotWaitObject,
                                                                      SYNCHRONIZE,
@@ -368,7 +368,7 @@ DWORD CorUnix::InternalWaitForMultipleObjectsEx(
     }
 
     palErr = g_pSynchronizationManager->GetSynchWaitControllersForObjects(
-        pThread, ppIPalObjs, nCount, ppISyncWaitCtrlrs);    
+        pThread, ppIPalObjs, nCount, ppISyncWaitCtrlrs);
     if (NO_ERROR != palErr)
     {
         ERROR("Unable to obtain ISynchWaitController interface for some or all "
@@ -378,14 +378,14 @@ DWORD CorUnix::InternalWaitForMultipleObjectsEx(
     }
 
     if (bAlertable)
-    {       
+    {
         // First check for pending APC. We need to do that while holding the global
         // synch lock implicitely grabbed by GetSynchWaitControllersForObjects
         if (g_pSynchronizationManager->AreAPCsPending(pThread))
         {
             // If there is any pending APC we need to release the
             // implicit global synch lock before calling into it
-            for (i = 0; (i < (int)nCount) && (NULL != ppISyncWaitCtrlrs[i]); i++)    
+            for (i = 0; (i < (int)nCount) && (NULL != ppISyncWaitCtrlrs[i]); i++)
             {
                 ppISyncWaitCtrlrs[i]->ReleaseController();
                 ppISyncWaitCtrlrs[i] = NULL;
@@ -403,8 +403,8 @@ DWORD CorUnix::InternalWaitForMultipleObjectsEx(
             }
             goto WFMOExIntCleanup;
         }
-    }    
-     
+    }
+
     iSignaledObjCount = 0;
     iSignaledObjIndex = -1;
     for (i=0;i<(int)nCount;i++)
@@ -416,7 +416,7 @@ DWORD CorUnix::InternalWaitForMultipleObjectsEx(
             ERROR("ISynchWaitController::CanThreadWaitWithoutBlocking() failed for "
                   "%d-th object [handle=%p error=%u]\n", i, lpHandles[i], palErr);
             pThread->SetLastError(ERROR_INTERNAL_ERROR);
-            goto WFMOExIntReleaseControllers;            
+            goto WFMOExIntReleaseControllers;
         }
         if (fValue)
         {
@@ -424,16 +424,16 @@ DWORD CorUnix::InternalWaitForMultipleObjectsEx(
             iSignaledObjIndex = i;
             if (!fWAll)
                 break;
-        }                
+        }
     }
 
     fNeedToBlock = (iSignaledObjCount == 0) || (fWAll && (iSignaledObjCount < (int)nCount));
     if (!fNeedToBlock)
     {
         // At least one object signaled, or bWaitAll==TRUE and all object signaled.
-        // No need to wait, let's unsignal the object(s) and return without blocking        
+        // No need to wait, let's unsignal the object(s) and return without blocking
         int iStartIdx, iEndIdx;
-        
+
         if (fWAll)
         {
             iStartIdx = 0;
@@ -444,7 +444,7 @@ DWORD CorUnix::InternalWaitForMultipleObjectsEx(
             iStartIdx = iSignaledObjIndex;
             iEndIdx = iStartIdx + 1;
         }
-        
+
         // Unsignal objects
         if( iStartIdx < 0 )
         {
@@ -457,9 +457,9 @@ DWORD CorUnix::InternalWaitForMultipleObjectsEx(
         {
             palErr = ppISyncWaitCtrlrs[i]->ReleaseWaitingThreadWithoutBlocking();
             if (NO_ERROR != palErr)
-            {     
+            {
                 ERROR("ReleaseWaitingThreadWithoutBlocking() failed for %d-th "
-                      "object [handle=%p error=%u]\n", 
+                      "object [handle=%p error=%u]\n",
                       i, lpHandles[i], palErr);
                 pThread->SetLastError(palErr);
                 goto WFMOExIntReleaseControllers;
@@ -473,29 +473,29 @@ DWORD CorUnix::InternalWaitForMultipleObjectsEx(
         // Not enough objects signaled, but timeout is zero: no actual wait
         dwRet = WAIT_TIMEOUT;
         fNeedToBlock = false;
-    }                
+    }
     else
     {
         // Register the thread for waiting on all objects
         for (i=0;i<(int)nCount;i++)
         {
             palErr = ppISyncWaitCtrlrs[i]->RegisterWaitingThread(
-                                                        wtWaitType, 
+                                                        wtWaitType,
                                                         i,
                                                         (TRUE == bAlertable));
             if (NO_ERROR != palErr)
-            {               
+            {
                 ERROR("RegisterWaitingThread() failed for %d-th object "
                       "[handle=%p error=%u]\n", i, lpHandles[i], palErr);
                 pThread->SetLastError(palErr);
                 goto WFMOExIntReleaseControllers;
             }
-        } 
+        }
     }
 
 WFMOExIntReleaseControllers:
-    // Release all controllers before going to sleep    
-    for (i = 0; i < (int)nCount; i++)    
+    // Release all controllers before going to sleep
+    for (i = 0; i < (int)nCount; i++)
     {
         ppISyncWaitCtrlrs[i]->ReleaseController();
         ppISyncWaitCtrlrs[i] = NULL;
@@ -510,23 +510,23 @@ WFMOExIntReleaseControllers:
         //
         // Going to sleep
         //
-        palErr = g_pSynchronizationManager->BlockThread(pThread, 
-                                                        dwMilliseconds, 
-                                                        (TRUE == bAlertable), 
+        palErr = g_pSynchronizationManager->BlockThread(pThread,
+                                                        dwMilliseconds,
+                                                        (TRUE == bAlertable),
                                                         false,
-                                                        &twrWakeupReason, 
+                                                        &twrWakeupReason,
                                                         (DWORD *)&iSignaledObjIndex);
         //
         // Awakened
         //
         if (NO_ERROR != palErr)
-        {     
+        {
             ERROR("IPalSynchronizationManager::BlockThread failed for thread "
                   "pThread=%p [error=%u]\n", pThread, palErr);
             pThread->SetLastError(palErr);
             goto WFMOExIntCleanup;
         }
-        switch (twrWakeupReason)       
+        switch (twrWakeupReason)
         {
         case WaitSucceeded:
             dwRet = WAIT_OBJECT_0; // offset added later
@@ -536,32 +536,32 @@ WFMOExIntReleaseControllers:
             break;
         case WaitTimeout:
             dwRet = WAIT_TIMEOUT;
-            break;                
+            break;
         case Alerted:
-            _ASSERT_MSG(bAlertable, 
+            _ASSERT_MSG(bAlertable,
                         "Awakened for APC from a non-alertable wait\n");
 
-            dwRet = WAIT_IO_COMPLETION;                
+            dwRet = WAIT_IO_COMPLETION;
             palErr = g_pSynchronizationManager->DispatchPendingAPCs(pThread);
 
-            _ASSERT_MSG(NO_ERROR == palErr, 
+            _ASSERT_MSG(NO_ERROR == palErr,
                         "Awakened for APC, but no APC is pending\n");
             break;
         case WaitFailed:
         default:
             ERROR("Thread %p awakened with some failure\n", pThread);
-            dwRet = WAIT_FAILED;                
+            dwRet = WAIT_FAILED;
             break;
         }
-    }           
-    
+    }
+
     if (!fWAll && ((WAIT_OBJECT_0 == dwRet) || (WAIT_ABANDONED_0 == dwRet)))
     {
         _ASSERT_MSG(0 <= iSignaledObjIndex,
-                    "Failed to identify signaled/abandoned object\n"); 
+                    "Failed to identify signaled/abandoned object\n");
         _ASSERT_MSG(iSignaledObjIndex >= 0 && nCount > static_cast<DWORD>(iSignaledObjIndex),
                     "SignaledObjIndex object out of range "
-                    "[index=%d obj_count=%u\n", 
+                    "[index=%d obj_count=%u\n",
                     iSignaledObjCount, nCount);
 
         if (iSignaledObjIndex < 0)
@@ -579,14 +579,14 @@ WFMOExIntCleanup:
         ppIPalObjs[i]->ReleaseReference(pThread);
         ppIPalObjs[i] = NULL;
     }
-    
+
 WFMOExIntExit:
     if (nCount > MAXIMUM_STACK_WAITOBJ_ARRAY_SIZE)
     {
         InternalDeleteArray(ppIPalObjs);
         InternalDeleteArray(ppISyncWaitCtrlrs);
     }
-    
+
     return dwRet;
 }
 
@@ -605,7 +605,7 @@ PAL_ERROR CorUnix::InternalSleepEx (
     {
         // In this case do not use AreAPCsPending. In fact, since we are
         // not holding the synch lock(s) an APC posting may race with
-        // AreAPCsPending. 
+        // AreAPCsPending.
         palErr = g_pSynchronizationManager->DispatchPendingAPCs(pThread);
         if (NO_ERROR == palErr)
         {
@@ -617,40 +617,40 @@ PAL_ERROR CorUnix::InternalSleepEx (
             // No APC was pending, just continue
             palErr = NO_ERROR;
         }
-    } 
+    }
 
     if (dwMilliseconds > 0)
     {
         ThreadWakeupReason twrWakeupReason;
-                
-        palErr = g_pSynchronizationManager->BlockThread(pThread, 
+
+        palErr = g_pSynchronizationManager->BlockThread(pThread,
                                                         dwMilliseconds,
-                                                        (TRUE == bAlertable), 
+                                                        (TRUE == bAlertable),
                                                         true,
-                                                        &twrWakeupReason, 
-                                                        (DWORD *)&iSignaledObjIndex);        
+                                                        &twrWakeupReason,
+                                                        (DWORD *)&iSignaledObjIndex);
         if (NO_ERROR != palErr)
-        {     
+        {
             ERROR("IPalSynchronizationManager::BlockThread failed for thread "
                   "pThread=%p [error=%u]\n", pThread, palErr);
             goto InternalSleepExExit;
         }
 
-        switch (twrWakeupReason)       
+        switch (twrWakeupReason)
         {
         case WaitSucceeded:
         case WaitTimeout:
-            dwRet = 0; 
-            break;                
+            dwRet = 0;
+            break;
         case Alerted:
-            _ASSERT_MSG(bAlertable, 
+            _ASSERT_MSG(bAlertable,
                         "Awakened for APC from a non-alertable wait\n");
 
-            dwRet = WAIT_IO_COMPLETION;                
+            dwRet = WAIT_IO_COMPLETION;
             palErr = g_pSynchronizationManager->DispatchPendingAPCs(pThread);
 
-            _ASSERT_MSG(NO_ERROR == palErr, 
-                        "Awakened for APC, but no APC is pending\n");            
+            _ASSERT_MSG(NO_ERROR == palErr,
+                        "Awakened for APC, but no APC is pending\n");
             break;
         case MutexAbondoned:
             ASSERT("Thread %p awakened with reason=MutexAbondoned from a "
@@ -662,7 +662,7 @@ PAL_ERROR CorUnix::InternalSleepEx (
             ERROR("Thread %p awakened with some failure\n", pThread);
             palErr = ERROR_INTERNAL_ERROR;
             break;
-        }        
+        }
     }
     else
     {
@@ -674,4 +674,3 @@ PAL_ERROR CorUnix::InternalSleepEx (
 InternalSleepExExit:
     return dwRet;
 }
-

--- a/pal/src/synchobj/mutex.cpp
+++ b/pal/src/synchobj/mutex.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -13,7 +13,7 @@ Module Name:
 
 Abstract:
 
-    Implementation of mutex synchroniztion object as described in 
+    Implementation of mutex synchroniztion object as described in
     the WIN32 API
 
 Revision History:
@@ -79,13 +79,13 @@ CreateMutexA(
     HANDLE hMutex = NULL;
     CPalThread *pthr = NULL;
     PAL_ERROR palError;
-    
+
     PERF_ENTRY(CreateMutexA);
     ENTRY("CreateMutexA(lpMutexAttr=%p, bInitialOwner=%d, lpName=%p (%s)\n",
           lpMutexAttributes, bInitialOwner, lpName, lpName?lpName:"NULL");
 
     pthr = InternalGetCurrentThread();
-    
+
     if (lpName != nullptr)
     {
         ASSERT("lpName: Cross-process named objects are not supported in PAL");
@@ -110,7 +110,7 @@ CreateMutexA(
     //
 
     pthr->SetLastError(palError);
-    
+
     LOGEXIT("CreateMutexA returns HANDLE %p\n", hMutex);
     PERF_EXIT(CreateMutexA);
     return hMutex;
@@ -262,7 +262,7 @@ CorUnix::InternalCreateMutex(
     palError = g_pObjectManager->RegisterObject(
         pthr,
         pobjMutex,
-        &aotMutex, 
+        &aotMutex,
         0, // should be MUTEX_ALL_ACCESS -- currently ignored (no Win32 security)
         phMutex,
         &pobjRegisteredMutex
@@ -273,7 +273,7 @@ CorUnix::InternalCreateMutex(
     // out here to ensure that we don't try to release a reference on
     // it down the line.
     //
-    
+
     pobjMutex = NULL;
 
 InternalCreateMutexExit:
@@ -307,12 +307,12 @@ ReleaseMutex( IN HANDLE hMutex )
 {
     PAL_ERROR palError = NO_ERROR;
     CPalThread *pthr = NULL;
-    
+
     PERF_ENTRY(ReleaseMutex);
     ENTRY("ReleaseMutex(hMutex=%p)\n", hMutex);
 
     pthr = InternalGetCurrentThread();
-    
+
     palError = InternalReleaseMutex(pthr, hMutex);
 
     if (NO_ERROR != palError)
@@ -365,7 +365,7 @@ CorUnix::InternalReleaseMutex(
         ERROR("Unable to obtain object for handle %p (error %d)!\n", hMutex, palError);
         goto InternalReleaseMutexExit;
     }
-    
+
     palError = pobjMutex->GetSynchStateController(
         pthr,
         &pssc
@@ -423,9 +423,9 @@ OpenMutexA (
     HANDLE hMutex = NULL;
     CPalThread *pthr = NULL;
     PAL_ERROR palError;
-    
+
     PERF_ENTRY(OpenMutexA);
-    ENTRY("OpenMutexA(dwDesiredAccess=%#x, bInheritHandle=%d, lpName=%p (%s))\n", 
+    ENTRY("OpenMutexA(dwDesiredAccess=%#x, bInheritHandle=%d, lpName=%p (%s))\n",
           dwDesiredAccess, bInheritHandle, lpName, lpName?lpName:"NULL");
 
     pthr = InternalGetCurrentThread();
@@ -446,7 +446,7 @@ OpenMutexA (
     {
         pthr->SetLastError(palError);
     }
-        
+
     LOGEXIT("OpenMutexA returns HANDLE %p\n", hMutex);
     PERF_EXIT(OpenMutexA);
     return hMutex;
@@ -475,7 +475,7 @@ OpenMutexW(
     CPalThread *pthr = NULL;
 
     PERF_ENTRY(OpenMutexW);
-    ENTRY("OpenMutexW(dwDesiredAccess=%#x, bInheritHandle=%d, lpName=%p (%S))\n", 
+    ENTRY("OpenMutexW(dwDesiredAccess=%#x, bInheritHandle=%d, lpName=%p (%S))\n",
           dwDesiredAccess, bInheritHandle, lpName, lpName?lpName:W16_NULLSTRING);
 
     pthr = InternalGetCurrentThread();
@@ -514,7 +514,7 @@ Note:
 Parameters:
   pthr -- thread data for calling thread
   phEvent -- on success, receives the allocated mutex handle
-  
+
   See MSDN docs on OpenMutex for all other parameters.
 --*/
 
@@ -578,7 +578,7 @@ InternalOpenMutexExit:
     }
 
     LOGEXIT("InternalOpenMutex returns %d\n", palError);
-    
+
     return palError;
 }
 
@@ -603,10 +603,10 @@ void SPINLOCKAcquire (LONG * lock, unsigned int flags)
             nanosleep(&tsSleepTime, NULL);
 #else
             sched_yield();
-#endif 
+#endif
         }
     }
-    
+
 }
 
 void SPINLOCKRelease (LONG * lock)

--- a/pal/src/thread/context.cpp
+++ b/pal/src/thread/context.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -26,7 +26,7 @@ Abstract:
 #include "pal/debug.h"
 #include "pal/thread.hpp"
 
-#include <sys/ptrace.h> 
+#include <sys/ptrace.h>
 #include <errno.h>
 #include <unistd.h>
 
@@ -184,7 +184,7 @@ BOOL CONTEXT_GetRegisters(DWORD processId, LPCONTEXT lpContext)
 #endif  // HAVE_BSD_REGS_T
     BOOL bRet = FALSE;
 
-    if (processId == GetCurrentProcessId()) 
+    if (processId == GetCurrentProcessId())
     {
         CONTEXT_CaptureContext(lpContext);
     }
@@ -217,7 +217,7 @@ BOOL CONTEXT_GetRegisters(DWORD processId, LPCONTEXT lpContext)
 
         CONTEXTFromNativeContext(&registers, lpContext, lpContext->ContextFlags);
     }
-    
+
     bRet = TRUE;
 #if HAVE_BSD_REGS_T
     if (regFd != -1)
@@ -239,7 +239,7 @@ CONTEXT_GetThreadContext(
          DWORD dwProcessId,
          pthread_t self,
          LPCONTEXT lpContext)
-{    
+{
     BOOL ret = FALSE;
 
     if (lpContext == NULL)
@@ -248,11 +248,11 @@ CONTEXT_GetThreadContext(
         SetLastError(ERROR_NOACCESS);
         goto EXIT;
     }
-    
+
     /* How to consider the case when self is different from the current
        thread of its owner process. Machine registers values could be retreived
-       by a ptrace(pid, ...) call or from the "/proc/%pid/reg" file content. 
-       Unfortunately, these two methods only depend on process ID, not on 
+       by a ptrace(pid, ...) call or from the "/proc/%pid/reg" file content.
+       Unfortunately, these two methods only depend on process ID, not on
        thread ID. */
 
     if (dwProcessId == GetCurrentProcessId())
@@ -279,14 +279,14 @@ CONTEXT_GetThreadContext(
 
     }
 
-    if (lpContext->ContextFlags & 
+    if (lpContext->ContextFlags &
         (CONTEXT_CONTROL | CONTEXT_INTEGER))
-    {        
+    {
         if (CONTEXT_GetRegisters(dwProcessId, lpContext) == FALSE)
         {
             SetLastError(ERROR_INTERNAL_ERROR);
             goto EXIT;
-        }  
+        }
     }
 
     ret = TRUE;
@@ -321,13 +321,13 @@ CONTEXT_SetThreadContext(
         SetLastError(ERROR_NOACCESS);
         goto EXIT;
     }
-    
+
     /* How to consider the case when self is different from the current
        thread of its owner process. Machine registers values could be retreived
-       by a ptrace(pid, ...) call or from the "/proc/%pid/reg" file content. 
-       Unfortunately, these two methods only depend on process ID, not on 
+       by a ptrace(pid, ...) call or from the "/proc/%pid/reg" file content.
+       Unfortunately, these two methods only depend on process ID, not on
        thread ID. */
-        
+
     if (dwProcessId == GetCurrentProcessId())
     {
 #ifdef FEATURE_PAL_SXS
@@ -338,10 +338,10 @@ CONTEXT_SetThreadContext(
         SetLastError(ERROR_INVALID_PARAMETER);
         goto EXIT;
     }
-    
-    if (lpContext->ContextFlags  & 
+
+    if (lpContext->ContextFlags  &
         (CONTEXT_CONTROL | CONTEXT_INTEGER))
-    {   
+    {
 #if HAVE_PT_REGS
         if (ptrace((__ptrace_request)PT_GETREGS, dwProcessId, (caddr_t)&ptrace_registers, 0) == -1)
 #elif HAVE_BSD_REGS_T
@@ -373,7 +373,7 @@ CONTEXT_SetThreadContext(
         }
 #undef ASSIGN_REG
 
-#if HAVE_PT_REGS        
+#if HAVE_PT_REGS
         if (ptrace((__ptrace_request)PT_SETREGS, dwProcessId, (caddr_t)&ptrace_registers, 0) == -1)
 #elif HAVE_BSD_REGS_T
         if (ptrace(PT_SETREGS, dwProcessId, (caddr_t)&ptrace_registers, 0) == -1)
@@ -394,7 +394,7 @@ CONTEXT_SetThreadContext(
 /*++
 Function :
     CONTEXTToNativeContext
-    
+
     Converts a CONTEXT record to a native context.
 
 Parameters :
@@ -448,7 +448,7 @@ void CONTEXTToNativeContext(CONST CONTEXT *lpContext, native_context_t *native)
 /*++
 Function :
     CONTEXTFromNativeContext
-    
+
     Converts a native context to a CONTEXT record.
 
 Parameters :
@@ -477,7 +477,7 @@ void CONTEXTFromNativeContext(const native_context_t *native, LPCONTEXT lpContex
         ASSIGN_INTEGER_REGS
     }
 #undef ASSIGN_REG
-    
+
     if ((contextFlags & CONTEXT_FLOATING_POINT) == CONTEXT_FLOATING_POINT)
     {
 #ifdef _AMD64_
@@ -507,7 +507,7 @@ void CONTEXTFromNativeContext(const native_context_t *native, LPCONTEXT lpContex
 /*++
 Function :
     GetNativeContextPC
-    
+
     Returns the program counter from the native context.
 
 Parameters :
@@ -535,7 +535,7 @@ LPVOID GetNativeContextPC(const native_context_t *context)
 /*++
 Function :
     CONTEXTGetExceptionCodeForSignal
-    
+
     Translates signal and context information to a Win32 exception code.
 
 Parameters :
@@ -629,9 +629,9 @@ DWORD CONTEXTGetExceptionCodeForSignal(const siginfo_t *siginfo,
                     return EXCEPTION_SINGLE_STEP;
                 default:
                     // We don't want to use ASSERT here since it raises SIGTRAP and we
-                    // might again end up here resulting in an infinite loop! 
-                    // so, we print out an error message and return 
-                    DBG_PRINTF(DLI_ASSERT, defdbgchan, TRUE) 
+                    // might again end up here resulting in an infinite loop!
+                    // so, we print out an error message and return
+                    DBG_PRINTF(DLI_ASSERT, defdbgchan, TRUE)
                     ("Got unknown SIGTRAP signal (%d) with code %d\n", SIGTRAP, siginfo->si_code);
 
                     return EXCEPTION_ILLEGAL_INSTRUCTION;
@@ -705,7 +705,7 @@ DWORD CONTEXTGetExceptionCodeForSignal(const siginfo_t *siginfo,
     {
         case T_PRIVINFLT : /* privileged instruction */
             TRACE("Trap code T_PRIVINFLT mapped to EXCEPTION_PRIV_INSTRUCTION\n");
-            return EXCEPTION_PRIV_INSTRUCTION; 
+            return EXCEPTION_PRIV_INSTRUCTION;
         case T_BPTFLT :    /* breakpoint instruction */
             TRACE("Trap code T_BPTFLT mapped to EXCEPTION_BREAKPOINT\n");
             return EXCEPTION_BREAKPOINT;
@@ -713,7 +713,7 @@ DWORD CONTEXTGetExceptionCodeForSignal(const siginfo_t *siginfo,
             TRACE("Trap code T_ARITHTRAP maps to floating point exception...\n");
             return 0;      /* let the caller pick an exception code */
 #ifdef T_ASTFLT
-        case T_ASTFLT :    /* system forced exception : ^C, ^\. SIGINT signal 
+        case T_ASTFLT :    /* system forced exception : ^C, ^\. SIGINT signal
                               handler shouldn't be calling this function, since
                               it doesn't need an exception code */
             ASSERT("Trap code T_ASTFLT received, shouldn't get here\n");
@@ -721,7 +721,7 @@ DWORD CONTEXTGetExceptionCodeForSignal(const siginfo_t *siginfo,
 #endif  // T_ASTFLT
         case T_PROTFLT :   /* protection fault */
             TRACE("Trap code T_PROTFLT mapped to EXCEPTION_ACCESS_VIOLATION\n");
-            return EXCEPTION_ACCESS_VIOLATION; 
+            return EXCEPTION_ACCESS_VIOLATION;
         case T_TRCTRAP :   /* debug exception (sic) */
             TRACE("Trap code T_TRCTRAP mapped to EXCEPTION_SINGLE_STEP\n");
             return EXCEPTION_SINGLE_STEP;
@@ -742,31 +742,31 @@ DWORD CONTEXTGetExceptionCodeForSignal(const siginfo_t *siginfo,
             return EXCEPTION_INT_OVERFLOW;
         case T_BOUND :     /* bound instruction fault */
             TRACE("Trap code T_BOUND mapped to EXCEPTION_ARRAY_BOUNDS_EXCEEDED\n");
-            return EXCEPTION_ARRAY_BOUNDS_EXCEEDED; 
+            return EXCEPTION_ARRAY_BOUNDS_EXCEEDED;
         case T_DNA :       /* device not available fault */
             TRACE("Trap code T_DNA mapped to EXCEPTION_ILLEGAL_INSTRUCTION\n");
-            return EXCEPTION_ILLEGAL_INSTRUCTION; 
+            return EXCEPTION_ILLEGAL_INSTRUCTION;
         case T_DOUBLEFLT : /* double fault */
             TRACE("Trap code T_DOUBLEFLT mapped to EXCEPTION_ILLEGAL_INSTRUCTION\n");
-            return EXCEPTION_ILLEGAL_INSTRUCTION; 
+            return EXCEPTION_ILLEGAL_INSTRUCTION;
         case T_FPOPFLT :   /* fp coprocessor operand fetch fault */
             TRACE("Trap code T_FPOPFLT mapped to EXCEPTION_FLT_INVALID_OPERATION\n");
-            return EXCEPTION_FLT_INVALID_OPERATION; 
+            return EXCEPTION_FLT_INVALID_OPERATION;
         case T_TSSFLT :    /* invalid tss fault */
             TRACE("Trap code T_TSSFLT mapped to EXCEPTION_ILLEGAL_INSTRUCTION\n");
-            return EXCEPTION_ILLEGAL_INSTRUCTION; 
+            return EXCEPTION_ILLEGAL_INSTRUCTION;
         case T_SEGNPFLT :  /* segment not present fault */
             TRACE("Trap code T_SEGNPFLT mapped to EXCEPTION_ACCESS_VIOLATION\n");
-            return EXCEPTION_ACCESS_VIOLATION; 
+            return EXCEPTION_ACCESS_VIOLATION;
         case T_STKFLT :    /* stack fault */
             TRACE("Trap code T_STKFLT mapped to EXCEPTION_STACK_OVERFLOW\n");
-            return EXCEPTION_STACK_OVERFLOW; 
+            return EXCEPTION_STACK_OVERFLOW;
         case T_MCHK :      /* machine check trap */
             TRACE("Trap code T_MCHK mapped to EXCEPTION_ILLEGAL_INSTRUCTION\n");
-            return EXCEPTION_ILLEGAL_INSTRUCTION; 
+            return EXCEPTION_ILLEGAL_INSTRUCTION;
         case T_RESERVED :  /* reserved (unknown) */
             TRACE("Trap code T_RESERVED mapped to EXCEPTION_ILLEGAL_INSTRUCTION\n");
-            return EXCEPTION_ILLEGAL_INSTRUCTION; 
+            return EXCEPTION_ILLEGAL_INSTRUCTION;
         default:
             ASSERT("Got unknown trap code %d\n", trap);
             break;
@@ -793,14 +793,14 @@ CONTEXT_GetThreadContextFromPort(
         LPCONTEXT lpContext)
 {
     // Extract the CONTEXT from the Mach thread.
-    
+
     kern_return_t MachRet = KERN_SUCCESS;
     mach_msg_type_number_t StateCount;
     thread_state_flavor_t StateFlavor;
-  
+
     if (lpContext->ContextFlags & (CONTEXT_CONTROL|CONTEXT_INTEGER))
     {
-#ifdef _X86_  
+#ifdef _X86_
         x86_thread_state32_t State;
         StateFlavor = x86_THREAD_STATE32;
 #elif defined(_AMD64_)
@@ -871,7 +871,7 @@ CONTEXT_GetThreadContextFromPort(
 #error Unexpected architecture.
 #endif
     }
-    
+
     if (lpContext->ContextFlags & CONTEXT_ALL_FLOATING) {
 #ifdef _X86_
         x86_float_state32_t State;
@@ -883,7 +883,7 @@ CONTEXT_GetThreadContextFromPort(
 #error Unexpected architecture.
 #endif
         StateCount = sizeof(State) / sizeof(natural_t);
-        
+
         MachRet = thread_get_state(Port,
             StateFlavor,
             (thread_state_t)&State,
@@ -893,7 +893,7 @@ CONTEXT_GetThreadContextFromPort(
             ASSERT("thread_get_state(FLOAT_STATE) failed: %d\n", MachRet);
             goto EXIT;
         }
-        
+
         if (lpContext->ContextFlags & CONTEXT_FLOATING_POINT)
         {
             // Copy the FPRs
@@ -906,7 +906,7 @@ CONTEXT_GetThreadContextFromPort(
             lpContext->FloatSave.DataOffset = State.fpu_dp;
             lpContext->FloatSave.DataSelector = State.fpu_ds;
             lpContext->FloatSave.Cr0NpxState = State.fpu_mxcsr;
-            
+
             // Windows stores the floating point registers in a packed layout (each 10-byte register end to end
             // for a total of 80 bytes). But Mach returns each register in an 16-bit structure (presumably for
             // alignment purposes). So we can't just memcpy the registers over in a single block, we need to copy
@@ -923,14 +923,14 @@ CONTEXT_GetThreadContextFromPort(
             lpContext->FltSave.DataSelector = State.__fpu_ds;
             lpContext->FltSave.MxCsr = State.__fpu_mxcsr;
             lpContext->FltSave.MxCsr_Mask = State.__fpu_mxcsrmask; // note: we don't save the mask for x86
-            
+
             // Windows stores the floating point registers in a packed layout (each 10-byte register end to end
             // for a total of 80 bytes). But Mach returns each register in an 16-bit structure (presumably for
             // alignment purposes). So we can't just memcpy the registers over in a single block, we need to copy
             // them individually.
             for (int i = 0; i < 8; i++)
                 memcpy(&lpContext->FltSave.FloatRegisters[i], (&State.__fpu_stmm0)[i].__mmst_reg, 10);
-            
+
             // AMD64's FLOATING_POINT includes the xmm registers.
             memcpy(&lpContext->Xmm0, &State.__fpu_xmm0, 8 * 16);
 #else
@@ -972,16 +972,16 @@ CONTEXT_GetThreadContext(
         SetLastError(ERROR_NOACCESS);
         goto EXIT;
     }
-    
+
     if (GetCurrentProcessId() == dwProcessId)
     {
         if (self != pthread_self())
         {
-            // the target thread is in the current process, but isn't 
-            // the current one: extract the CONTEXT from the Mach thread.            
+            // the target thread is in the current process, but isn't
+            // the current one: extract the CONTEXT from the Mach thread.
             mach_port_t mptPort;
             mptPort = pthread_mach_thread_np(self);
-   
+
             ret = (CONTEXT_GetThreadContextFromPort(mptPort, lpContext) == KERN_SUCCESS);
         }
         else
@@ -1015,12 +1015,12 @@ CONTEXT_SetThreadContextOnPort(
     mach_msg_type_number_t StateCount;
     thread_state_flavor_t StateFlavor;
 
-    if (lpContext->ContextFlags & (CONTEXT_CONTROL|CONTEXT_INTEGER)) 
+    if (lpContext->ContextFlags & (CONTEXT_CONTROL|CONTEXT_INTEGER))
     {
 #ifdef _X86_
         x86_thread_state32_t State;
         StateFlavor = x86_THREAD_STATE32;
-        
+
         State.eax = lpContext->Eax;
         State.ebx = lpContext->Ebx;
         State.ecx = lpContext->Ecx;
@@ -1084,7 +1084,7 @@ CONTEXT_SetThreadContextOnPort(
 
     if (lpContext->ContextFlags & CONTEXT_ALL_FLOATING)
     {
-        
+
 #ifdef _X86_
         x86_float_state32_t State;
         StateFlavor = x86_FLOAT_STATE32;
@@ -1178,7 +1178,7 @@ CONTEXT_SetThreadContextOnPort(
             ASSERT("thread_set_state(FLOAT_STATE) failed: %d\n", MachRet);
             goto EXIT;
         }
-    }    
+    }
 
 EXIT:
     return MachRet;
@@ -1198,14 +1198,14 @@ CONTEXT_SetThreadContext(
 {
     BOOL ret = FALSE;
 
-    if (lpContext == NULL) 
+    if (lpContext == NULL)
     {
         ERROR("Invalid lpContext parameter value\n");
         SetLastError(ERROR_NOACCESS);
         goto EXIT;
     }
 
-    if (dwProcessId != GetCurrentProcessId()) 
+    if (dwProcessId != GetCurrentProcessId())
     {
         // GetThreadContext() of a thread in another process
         ASSERT("Cross-process GetThreadContext() is not supported\n");
@@ -1221,10 +1221,10 @@ CONTEXT_SetThreadContext(
         mach_port_t mptPort;
 
         mptPort = pthread_mach_thread_np(self);
-    
+
         ret = (CONTEXT_SetThreadContextOnPort(mptPort, lpContext) == KERN_SUCCESS);
-    } 
-    else 
+    }
+    else
     {
         MachSetThreadContext(const_cast<CONTEXT *>(lpContext));
         ASSERT("MachSetThreadContext should never return\n");
@@ -1238,7 +1238,7 @@ EXIT:
 
 /*++
 Function:
-  DBG_FlushInstructionCache: processor-specific portion of 
+  DBG_FlushInstructionCache: processor-specific portion of
   FlushInstructionCache
 
 See MSDN doc.

--- a/pal/src/thread/process.cpp
+++ b/pal/src/thread/process.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -97,7 +97,7 @@ static int s_helperPage[VIRTUAL_PAGE_SIZE / sizeof(int)] __attribute__((aligned(
 
 //
 // Mutex to make the FlushProcessWriteBuffersMutex thread safe
-// 
+//
 pthread_mutex_t flushProcessWriteBuffersMutex PAL_GLOBAL;
 
 CAllowedObjectTypes aotProcess PAL_GLOBAL (otiProcess);
@@ -125,7 +125,7 @@ DWORD g_dwThreadCount;
 LPWSTR g_lpwstrCmdLine = NULL;
 LPWSTR g_lpwstrAppDir = NULL;
 
-// Thread ID of thread that has started the ExitProcess process 
+// Thread ID of thread that has started the ExitProcess process
 Volatile<LONG> terminator PAL_GLOBAL = 0;
 
 // Process ID of this process.
@@ -556,7 +556,7 @@ CorUnix::InternalCreateProcess(
     int iFdOut = -1;
     IPalObject *pobjFileErr = NULL;
     int iFdErr = -1;
-    
+
     pid_t processId;
     char * lpFileName;
     PathCharString lpFileNamePS;
@@ -579,7 +579,7 @@ CorUnix::InternalCreateProcess(
                lpApplicationName);
         palError = ERROR_INVALID_PARAMETER;
         goto InternalCreateProcessExit;
-    } 
+    }
 
     if (0 != (dwCreationFlags & ~(CREATE_SUSPENDED|CREATE_NEW_CONSOLE)))
     {
@@ -685,7 +685,7 @@ CorUnix::InternalCreateProcess(
         palError = ERROR_FILE_NOT_FOUND;
         goto InternalCreateProcessExit;
     }
-    
+
     lpFileNamePS.CloseBuffer(MAX_LONGPATH-1);
     /* check type of file */
     iRet = checkFileType(lpFileName);
@@ -696,7 +696,7 @@ CorUnix::InternalCreateProcess(
             WARN ("File is not valid (%s)", lpFileName);
             palError = ERROR_FILE_NOT_FOUND;
             goto InternalCreateProcessExit;
-            
+
         case FILE_UNIX: /* Unix binary file */
             break;  /* nothing to do */
 
@@ -759,7 +759,7 @@ CorUnix::InternalCreateProcess(
     palError = g_pObjectManager->AllocateObject(
         pThread,
         &otProcess,
-        &oa, 
+        &oa,
         &pobjProcess
         );
 
@@ -801,7 +801,7 @@ CorUnix::InternalCreateProcess(
         &pDummyThread,
         &hDummyThread
         );
-    
+
     if (dwCreationFlags & CREATE_SUSPENDED)
     {
         int pipe_descs[2];
@@ -811,7 +811,7 @@ CorUnix::InternalCreateProcess(
             ERROR("pipe() failed! error is %d (%s)\n", errno, strerror(errno));
             palError = ERROR_NOT_ENOUGH_MEMORY;
             goto InternalCreateProcessExit;
-        }                        
+        }
 
         /* [0] is read end, [1] is write end */
         pDummyThread->suspensionInfo.SetBlockingPipe(pipe_descs[1]);
@@ -846,9 +846,9 @@ CorUnix::InternalCreateProcess(
     if (NO_ERROR != palError)
     {
         ASSERT("Unable to obtain local data for new process object\n");
-        goto InternalCreateProcessExit;    
+        goto InternalCreateProcessExit;
     }
-        
+
 
     /* fork the new process */
     processId = fork();
@@ -866,15 +866,15 @@ CorUnix::InternalCreateProcess(
         goto InternalCreateProcessExit;
     }
 
-    /* From the time the child process begins running, to when it reaches execve, 
+    /* From the time the child process begins running, to when it reaches execve,
     the child process is not a real PAL process and does not own any PAL
-    resources, although it has access to the PAL resources of its parent process. 
-    Thus, while the child process is in this window, it is dangerous for it to affect 
+    resources, although it has access to the PAL resources of its parent process.
+    Thus, while the child process is in this window, it is dangerous for it to affect
     its parent's PAL resources. As a consequence, no PAL code should be used
     in this window; all code should make unix calls. Note the use of _exit
     instead of exit to avoid calling PAL_Terminate and the lack of TRACE's and
     ASSERT's. */
-    
+
     if (processId == 0)  /* child process */
     {
         // At this point, the PAL should be considered uninitialized for this child process.
@@ -883,8 +883,8 @@ CorUnix::InternalCreateProcess(
         // calling PAL functions. Furthermore, nothing should be changing
         // the init_count in the child process at this point since this is the only
         // thread executing.
-        init_count = 0; 
-        
+        init_count = 0;
+
         sigset_t sm;
 
         //
@@ -897,7 +897,7 @@ CorUnix::InternalCreateProcess(
         {
             _exit(EXIT_FAILURE);
         }
-        
+
         if (dwCreationFlags & CREATE_SUSPENDED)
         {
             BYTE resume_code = 0;
@@ -917,7 +917,7 @@ CorUnix::InternalCreateProcess(
                 }
                 else
                 {
-                    /* note : read might return 0 (and return EAGAIN) if the other 
+                    /* note : read might return 0 (and return EAGAIN) if the other
                        end of the pipe gets closed - for example because the parent
                        process dies (very) abruptly */
                     _exit(EXIT_FAILURE);
@@ -960,9 +960,9 @@ CorUnix::InternalCreateProcess(
             if (dup2(iFdErr, STDERR_FILENO) == -1)
             {
                 // Didn't duplicate standard error.
-                _exit(EXIT_FAILURE);            
+                _exit(EXIT_FAILURE);
             }
-            
+
             /* now close the original FDs, we don't need them anymore */
             close(iFdIn);
             close(iFdOut);
@@ -993,17 +993,17 @@ CorUnix::InternalCreateProcess(
     pLocalData->dwProcessId = processId;
     pLocalDataLock->ReleaseLock(pThread, TRUE);
     pLocalDataLock = NULL;
-    
+
     pSharedData->dwProcessId = processId;
     pSharedDataLock->ReleaseLock(pThread, TRUE);
     pSharedDataLock = NULL;
 
-    // 
+    //
     // Release file handle info; we don't need them anymore. Note that
     // this must happen after we've released the data locks, as
     // otherwise a deadlock could result.
     //
-    
+
     if (lpStartupInfo->dwFlags & STARTF_USESTDHANDLES)
     {
         pobjFileIn->ReleaseReference(pThread);
@@ -1063,11 +1063,11 @@ InternalCreateProcessExit:
         InternalFree(EnvironmentArray);
     }
 
-    /* if we still have the file structures at this point, it means we 
-       encountered an error sometime between when we acquired them and when we 
-       fork()ed. We not only have to release them, we have to give them back 
+    /* if we still have the file structures at this point, it means we
+       encountered an error sometime between when we acquired them and when we
+       fork()ed. We not only have to release them, we have to give them back
        their close-on-exec flag */
-    if (NULL != pobjFileIn) 
+    if (NULL != pobjFileIn)
     {
         if(-1 == fcntl(iFdIn, F_SETFD, 1))
         {
@@ -1076,8 +1076,8 @@ InternalCreateProcessExit:
         }
         pobjFileIn->ReleaseReference(pThread);
     }
-    
-    if (NULL != pobjFileOut) 
+
+    if (NULL != pobjFileOut)
     {
         if(-1 == fcntl(iFdOut, F_SETFD, 1))
         {
@@ -1086,8 +1086,8 @@ InternalCreateProcessExit:
         }
         pobjFileOut->ReleaseReference(pThread);
     }
-    
-    if (NULL != pobjFileErr) 
+
+    if (NULL != pobjFileErr)
     {
         if(-1 == fcntl(iFdErr, F_SETFD, 1))
         {
@@ -1144,7 +1144,7 @@ GetExitCodeProcess(
         &ps,
         &dwExitCode
         );
-    
+
     if (NO_ERROR != palError)
     {
         ASSERT("Couldn't get process status information!\n");
@@ -1166,10 +1166,10 @@ done:
     {
         pThread->SetLastError(palError);
     }
-    
+
     LOGEXIT("GetExitCodeProcess returns BOOL %d\n", NO_ERROR == palError);
     PERF_EXIT(GetExitCodeProcess);
-    
+
     return NO_ERROR == palError;
 }
 
@@ -1213,12 +1213,12 @@ ExitProcess(
     }
     else if (0 != old_terminator)
     {
-        /* another thread has already initiated the termination process. we 
-           could just block on the PALInitLock critical section, but then 
+        /* another thread has already initiated the termination process. we
+           could just block on the PALInitLock critical section, but then
            PROCSuspendOtherThreads would hang... so sleep forever here, we're
-           terminating anyway 
+           terminating anyway
 
-           Update: [TODO] PROCSuspendOtherThreads has been removed. Can this 
+           Update: [TODO] PROCSuspendOtherThreads has been removed. Can this
            code be changed? */
         WARN("termination already started from another thread; blocking.\n");
         poll(NULL, 0, INFTIM);
@@ -1237,7 +1237,7 @@ ExitProcess(
     else
     {
         exit(uExitCode);
-        
+
         /* Should not get here, because we terminate the current process */
         ASSERT("exit has returned\n");
     }
@@ -1268,7 +1268,7 @@ TerminateProcess(
     ENTRY("TerminateProcess(hProcess=%p, uExitCode=%u)\n",hProcess, uExitCode );
 
     ret = PROCEndProcess(hProcess, uExitCode, TRUE);
-    
+
     LOGEXIT("TerminateProcess returns BOOL %d\n", ret);
     PERF_EXIT(TerminateProcess);
     return ret;
@@ -1277,7 +1277,7 @@ TerminateProcess(
 /*++
 Function:
   PROCEndProcess
-  
+
   Called from TerminateProcess and ExitProcess. This does the work of
   TerminateProcess, but also takes a flag that determines whether we
   shut down unconditionally. If the flag is set, the PAL will do very
@@ -1299,7 +1299,7 @@ static BOOL PROCEndProcess(HANDLE hProcess, UINT uExitCode, BOOL bTerminateUncon
     {
         if (uExitCode != 0)
             WARN("exit code 0x%x ignored for external process.\n", uExitCode);
-            
+
         if (kill(dwProcessId, SIGKILL) == 0)
         {
             ret = TRUE;
@@ -1336,7 +1336,7 @@ static BOOL PROCEndProcess(HANDLE hProcess, UINT uExitCode, BOOL bTerminateUncon
         }
 
         TerminateCurrentProcessNoExit(bTerminateUnconditionally);
-        
+
         LOGEXIT("PROCEndProcess will not return\n");
 
         // exit() runs atexit handlers possibly registered by foreign code.
@@ -1344,22 +1344,22 @@ static BOOL PROCEndProcess(HANDLE hProcess, UINT uExitCode, BOOL bTerminateUncon
         // registered our own PAL_Terminate with atexit(), the latter will
         // explicitly re-enter us.
         PAL_Leave(PAL_BoundaryBottom);
-        
+
         if (bTerminateUnconditionally)
         {
-            // abort() has the semantics that 
+            // abort() has the semantics that
             // (1) it doesn't run atexit handlers
             // (2) can invoke CrashReporter or produce a coredump,
             // which is appropriate for TerminateProcess calls
-            
+
             // If this turns out to be inappropriate for some case, where we
             // call TerminateProcess vs. ExitProcess, then there needs to be
             // a CLR wrapper for TerminateProcess and some exposure for PAL_abort()
             // to selectively use that in all but those cases.
-            
+
             abort();
         }
-        else    
+        else
             exit(uExitCode);
 
         ASSERT(FALSE); // we shouldn't get here
@@ -1391,7 +1391,7 @@ PAL_SetShutdownCallback(
 /*++
 Function:
   PROCCleanupProcess
-  
+
   Do all cleanup work for TerminateProcess, but don't terminate the process.
   If bTerminateUnconditionally is TRUE, we exit as quickly as possible.
 
@@ -1450,7 +1450,7 @@ GetProcessTimes(
         goto GetProcessTimesExit;
     }
 
-    /* First, we need to actually retrieve the relevant statistics from the 
+    /* First, we need to actually retrieve the relevant statistics from the
        OS */
     if (getrusage (RUSAGE_SELF, &resUsage) == -1)
     {
@@ -1459,7 +1459,7 @@ GetProcessTimes(
         SetLastError(ERROR_INTERNAL_ERROR);
         goto GetProcessTimesExit;
     }
-    
+
     TRACE ("getrusage User: %ld sec,%ld microsec. Kernel: %ld sec,%ld"
            " microsec\n",
            resUsage.ru_utime.tv_sec, resUsage.ru_utime.tv_usec,
@@ -1486,7 +1486,7 @@ GetProcessTimes(
         lpKernelTime->dwLowDateTime = (DWORD)calcTime;
         lpKernelTime->dwHighDateTime = (DWORD)(calcTime >> 32);
     }
-    
+
     retval = TRUE;
 
 
@@ -1498,7 +1498,7 @@ GetProcessTimesExit:
 
 #define FILETIME_TO_ULONGLONG(f) \
     (((ULONGLONG)(f).dwHighDateTime << 32) | ((ULONGLONG)(f).dwLowDateTime))
-    
+
 /*++
 Function:
   PAL_GetCPUBusyTime
@@ -1636,7 +1636,7 @@ GetCommandLineW(
           g_lpwstrCmdLine,
           lpwstr);
     PERF_EXIT(GetCommandLineW);
-    
+
     return lpwstr;
 }
 
@@ -1741,7 +1741,7 @@ OpenProcess(
     //
     // TODO: check to see if the process actually exists?
     //
-    
+
 OpenProcessExit:
 
     if (NULL != pobjProcess)
@@ -1775,10 +1775,10 @@ Return
   TRUE if it succeeded, FALSE otherwise
 
 Notes
-  This API is tricky because the module handles are never closed/freed so there can't be any 
-  allocations for the module handle or name strings, etc. The "handles" are actually the base 
-  addresses of the modules. The module handles should only be used by GetModuleFileNameExW 
-  below. 
+  This API is tricky because the module handles are never closed/freed so there can't be any
+  allocations for the module handle or name strings, etc. The "handles" are actually the base
+  addresses of the modules. The module handles should only be used by GetModuleFileNameExW
+  below.
 --*/
 BOOL
 PALAPI
@@ -1830,7 +1830,7 @@ EnumProcessModules(
 Function:
   GetModuleFileNameExW
 
-  Used only with module handles returned from EnumProcessModule (for dbgshim). 
+  Used only with module handles returned from EnumProcessModule (for dbgshim).
 
 --*/
 DWORD
@@ -2015,7 +2015,7 @@ CreateProcessModules(
 
 #elif defined(HAVE_PROCFS_CTL)
 
-        // Here we read /proc/<pid>/maps file in order to parse it and figure out what it says 
+        // Here we read /proc/<pid>/maps file in order to parse it and figure out what it says
         // about a library we are looking for. This file looks something like this:
         //
         // [address]      [perms] [offset] [dev] [inode]     [pathname] - HEADER is not preset in an actual file
@@ -2030,14 +2030,14 @@ CreateProcessModules(
         // 35b1fb0000-35b1fb2000 rw-p 001b0000 08:02 135870  /usr/lib64/libc-2.15.so
 
         // Making something like: /proc/123/maps
-        char mapFileName[100]; 
+        char mapFileName[100];
 
         INDEBUG(int chars = )
         snprintf(mapFileName, sizeof(mapFileName), "/proc/%d/maps", dwProcessId);
         _ASSERTE(chars > 0 && chars <= sizeof(mapFileName));
 
         FILE *mapsFile = fopen(mapFileName, "r");
-        if (mapsFile == NULL) 
+        if (mapsFile == NULL)
         {
             SetLastError(ERROR_INVALID_HANDLE);
             return NULL;
@@ -2048,8 +2048,8 @@ CreateProcessModules(
         int count = 0;
         ssize_t read;
 
-        // Reading maps file line by line 
-        while ((read = getline(&line, &lineLen, mapsFile)) != -1) 
+        // Reading maps file line by line
+        while ((read = getline(&line, &lineLen, mapsFile)) != -1)
         {
             void *startAddress, *endAddress, *offset;
             int devHi, devLo, inode;
@@ -2186,14 +2186,14 @@ Function:
 
 See MSDN doc.
 --*/
-VOID 
-PALAPI 
+VOID
+PALAPI
 FlushProcessWriteBuffers()
-{   
+{
     int status = pthread_mutex_lock(&flushProcessWriteBuffersMutex);
     FATAL_ASSERT(status == 0, "Failed to lock the flushProcessWriteBuffersMutex lock");
 
-    // Changing a helper memory page protection from read / write to no access 
+    // Changing a helper memory page protection from read / write to no access
     // causes the OS to issue IPI to flush TLBs on all processors. This also
     // results in flushing the processor buffers.
     status = mprotect(s_helperPage, VIRTUAL_PAGE_SIZE, PROT_READ | PROT_WRITE);
@@ -2230,7 +2230,7 @@ PROCGetProcessIDFromHandle(
     PAL_ERROR palError;
     IPalObject *pobjProcess = NULL;
     CPalThread *pThread = InternalGetCurrentThread();
-    
+
     DWORD dwProcessId = 0;
 
     if (hPseudoCurrentProcess == hProcess)
@@ -2238,7 +2238,7 @@ PROCGetProcessIDFromHandle(
         dwProcessId = gPID;
         goto PROCGetProcessIDFromHandleExit;
     }
-    
+
 
     palError = g_pObjectManager->ReferenceObjectByHandle(
         pThread,
@@ -2264,8 +2264,8 @@ PROCGetProcessIDFromHandle(
         {
             dwProcessId = pLocalData->dwProcessId;
             pDataLock->ReleaseLock(pThread, FALSE);
-        }        
-        
+        }
+
         pobjProcess->ReleaseReference(pThread);
     }
 
@@ -2281,7 +2281,7 @@ CorUnix::InitializeProcessData(
 {
     PAL_ERROR palError = NO_ERROR;
     bool fLockInitialized = FALSE;
-    
+
     pGThreadList = NULL;
     g_dwThreadCount = 0;
 
@@ -2309,7 +2309,7 @@ Abstract
 Parameter
     lpwstrCmdLine
     lpwstrFullPath
- 
+
 Return
     PAL_ERROR
 
@@ -2377,7 +2377,7 @@ Abstract
 
 Parameter
   pThread - the initial thread
- 
+
 Return
   PAL_ERROR
 --*/
@@ -2415,7 +2415,7 @@ CorUnix::CreateInitialProcessAndThreadObjects(
     //
     // Create and initialize process object
     //
-    
+
     palError = g_pObjectManager->AllocateObject(
         pThread,
         &otProcess,
@@ -2431,7 +2431,7 @@ CorUnix::CreateInitialProcessAndThreadObjects(
 
     palError = pobjProcess->GetProcessLocalData(
         pThread,
-        WriteLock, 
+        WriteLock,
         &pDataLock,
         reinterpret_cast<void **>(&pLocalData)
         );
@@ -2447,7 +2447,7 @@ CorUnix::CreateInitialProcessAndThreadObjects(
     pDataLock->ReleaseLock(pThread, TRUE);
 
     palError = pobjProcess->GetSharedData(
-        pThread, 
+        pThread,
         WriteLock,
         &pDataLock,
         reinterpret_cast<void **>(&pSharedData)
@@ -2522,10 +2522,10 @@ PROCCleanupInitialProcess(VOID)
     CPalThread *pThread = InternalGetCurrentThread();
 
     InternalEnterCriticalSection(pThread, &g_csProcess);
-    
+
     /* Free the application directory */
     InternalFree(g_lpwstrAppDir);
-    
+
     /* Free the stored command line */
     InternalFree(g_lpwstrCmdLine);
 
@@ -2535,7 +2535,7 @@ PROCCleanupInitialProcess(VOID)
     // Object manager shutdown will handle freeing the underlying
     // thread and process data
     //
-    
+
 }
 
 /*++
@@ -2555,7 +2555,7 @@ CorUnix::PROCAddThread(
     CPalThread *pTargetThread
     )
 {
-    /* protect the access of the thread list with critical section for 
+    /* protect the access of the thread list with critical section for
        mutithreading access */
     InternalEnterCriticalSection(pCurrentThread, &g_csProcess);
 
@@ -2590,7 +2590,7 @@ CorUnix::PROCRemoveThread(
 {
     CPalThread *curThread, *prevThread;
 
-    /* protect the access of the thread list with critical section for 
+    /* protect the access of the thread list with critical section for
        mutithreading access */
     InternalEnterCriticalSection(pCurrentThread, &g_csProcess);
 
@@ -2607,7 +2607,7 @@ CorUnix::PROCRemoveThread(
     if (curThread == pTargetThread)
     {
         pGThreadList =  curThread->GetNext();
-        TRACE("Thread 0x%p (id %#x) removed from the process thread list\n", 
+        TRACE("Thread 0x%p (id %#x) removed from the process thread list\n",
             pTargetThread, pTargetThread->GetThreadId());
         goto EXIT;
     }
@@ -2675,7 +2675,7 @@ VOID
 PROCProcessLock(
     VOID)
 {
-    CPalThread * pThread = 
+    CPalThread * pThread =
         (PALIsThreadDataInitialized() ? InternalGetCurrentThread() : NULL);
 
     InternalEnterCriticalSection(pThread, &g_csProcess);
@@ -2699,10 +2699,10 @@ VOID
 PROCProcessUnlock(
     VOID)
 {
-    CPalThread * pThread = 
+    CPalThread * pThread =
         (PALIsThreadDataInitialized() ? InternalGetCurrentThread() : NULL);
 
-    InternalLeaveCriticalSection(pThread, &g_csProcess);    
+    InternalLeaveCriticalSection(pThread, &g_csProcess);
 }
 
 #if USE_SYSV_SEMAPHORES
@@ -2733,7 +2733,7 @@ PROCCleanupThreadSemIds(void)
     }
 
     PROCProcessUnlock();
-    
+
 }
 #endif // USE_SYSV_SEMAPHORES
 
@@ -2769,8 +2769,8 @@ CorUnix::TerminateCurrentProcessNoExit(BOOL bTerminateUnconditionally)
             could just block on the PALInitLock critical section, but then
             PROCSuspendOtherThreads would hang... so sleep forever here, we're
             terminating anyway
- 
-            Update: [TODO] PROCSuspendOtherThreads has been removed. Can this 
+
+            Update: [TODO] PROCSuspendOtherThreads has been removed. Can this
             code be changed? */
 
          /* note that if *this* thread has already started the termination
@@ -2828,10 +2828,10 @@ PROCGetProcessStatus(
     int status;
 
     //
-    // First, check if we already know the status of this process. This will be 
+    // First, check if we already know the status of this process. This will be
     // the case if this function has already been called for the same process.
     //
-    
+
     palError = g_pObjectManager->ReferenceObjectByHandle(
         pThread,
         hProcess,
@@ -2839,7 +2839,7 @@ PROCGetProcessStatus(
         0,
         &pobjProcess
         );
-    
+
     if (NO_ERROR != palError)
     {
         goto PROCGetProcessStatusExit;
@@ -2851,23 +2851,23 @@ PROCGetProcessStatus(
         &pDataLock,
         reinterpret_cast<void **>(&pLocalData)
         );
-    
+
     if (PS_DONE == pLocalData->ps)
     {
         TRACE("We already called waitpid() on process ID %#x; process has "
-              "terminated, exit code is %d\n", 
+              "terminated, exit code is %d\n",
               pLocalData->dwProcessId, pLocalData->dwExitCode);
-        
+
         *pps = pLocalData->ps;
         *pdwExitCode = pLocalData->dwExitCode;
 
         pDataLock->ReleaseLock(pThread, FALSE);
-        
+
         goto PROCGetProcessStatusExit;
     }
 
-    /* By using waitpid(), we can even retrieve the exit code of a non-PAL 
-       process. However, note that waitpid() can only provide the low 8 bits 
+    /* By using waitpid(), we can even retrieve the exit code of a non-PAL
+       process. However, note that waitpid() can only provide the low 8 bits
        of the exit code. This is all that is required for the PAL spec. */
     TRACE("Looking for status of process; trying wait()");
 
@@ -2875,7 +2875,7 @@ PROCGetProcessStatus(
     {
         /* try to get state of process, using non-blocking call */
         wait_retval = waitpid(pLocalData->dwProcessId, &status, WNOHANG);
-        
+
         if ( wait_retval == (pid_t) pLocalData->dwProcessId )
         {
             /* success; get the exit code */
@@ -2901,10 +2901,10 @@ PROCGetProcessStatus(
         }
         else if (-1 == wait_retval)
         {
-            // This might happen if waitpid() had already been called, but 
-            // this shouldn't happen - we call waitpid once, store the 
+            // This might happen if waitpid() had already been called, but
+            // this shouldn't happen - we call waitpid once, store the
             // result, and use that afterwards.
-            // One legitimate cause of failure is EINTR; if this happens we 
+            // One legitimate cause of failure is EINTR; if this happens we
             // have to try again. A second legitimate cause is ECHILD, which
             // happens if we're trying to retrieve the status of a currently-
             // running process that isn't a child of this process.
@@ -2942,7 +2942,7 @@ PROCGetProcessStatus(
             }
             else
             {
-                // Ignoring unexpected waitpid errno and assuming that 
+                // Ignoring unexpected waitpid errno and assuming that
                 // the process is still running
                 ERROR("waitpid(pid=%u) failed with unexpected errno=%d (%s)\n",
                       pLocalData->dwProcessId, errno, strerror(errno));
@@ -2966,10 +2966,10 @@ PROCGetProcessStatus(
         pLocalData->ps = PS_DONE;
         pLocalData->dwExitCode = *pdwExitCode;
     }
-    
-    TRACE( "State of process 0x%08x : %d (exit code %d)\n", 
+
+    TRACE( "State of process 0x%08x : %d (exit code %d)\n",
            pLocalData->dwProcessId, *pps, *pdwExitCode );
-    
+
     pDataLock->ReleaseLock(pThread, TRUE);
 
 PROCGetProcessStatusExit:
@@ -2978,7 +2978,7 @@ PROCGetProcessStatusExit:
     {
         pobjProcess->ReleaseReference(pThread);
     }
-    
+
     return palError;
 }
 
@@ -3028,14 +3028,14 @@ void PROCDumpThreadList()
     while (NULL != pThread)
     {
         TRACE ("    {pThr=0x%p tid=%#x lwpid=%#x state=%d finsusp=%d}\n",
-               pThread, (int)pThread->GetThreadId(), (int)pThread->GetLwpId(), 
+               pThread, (int)pThread->GetThreadId(), (int)pThread->GetLwpId(),
                (int)pThread->synchronizationInfo.GetThreadState(),
                (int)pThread->suspensionInfo.GetSuspendedForShutdown());
 
         pThread = pThread->GetNext();
     }
     TRACE ("Threads:}\n");
-    
+
     PROCProcessUnlock();
 }
 #endif
@@ -3314,45 +3314,45 @@ isManagedExecutable(LPSTR lpFileName)
     HANDLE hFile = INVALID_HANDLE_VALUE;
     DWORD cbRead;
     IMAGE_DOS_HEADER        dosheader;
-    IMAGE_NT_HEADERS32      NtHeaders; 
+    IMAGE_NT_HEADERS32      NtHeaders;
     BOOL ret = 0;
 
-    /* then check if it is a PE/COFF file */ 
+    /* then check if it is a PE/COFF file */
     if((hFile = CreateFileA(lpFileName, GENERIC_READ, FILE_SHARE_READ, NULL,
                             OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN,
                             NULL)) == INVALID_HANDLE_VALUE)
-    {        
+    {
           goto isManagedExecutableExit;
     }
-      
-    /* Open the file and read the IMAGE_DOS_HEADER structure */ 
+
+    /* Open the file and read the IMAGE_DOS_HEADER structure */
     if(!ReadFile(hFile, &dosheader, sizeof(IMAGE_DOS_HEADER), &cbRead, NULL) || cbRead != sizeof(IMAGE_DOS_HEADER) )
       goto isManagedExecutableExit;
-       
+
     /* check the DOS headers */
-    if ( (dosheader.e_magic != VAL16(IMAGE_DOS_SIGNATURE)) || (VAL32(dosheader.e_lfanew) <= 0) ) 
-      goto isManagedExecutableExit;         
- 
+    if ( (dosheader.e_magic != VAL16(IMAGE_DOS_SIGNATURE)) || (VAL32(dosheader.e_lfanew) <= 0) )
+      goto isManagedExecutableExit;
+
     /* Advance the file pointer to File address of new exe header */
     if( SetFilePointer(hFile, VAL32(dosheader.e_lfanew), NULL, FILE_BEGIN) == 0xffffffff)
       goto isManagedExecutableExit;
-            
+
     if( !ReadFile(hFile, &NtHeaders , sizeof(IMAGE_NT_HEADERS32), &cbRead, NULL) || cbRead != sizeof(IMAGE_NT_HEADERS32) )
       goto isManagedExecutableExit;
-   
-    /* check the NT headers */   
+
+    /* check the NT headers */
     if ((NtHeaders.Signature != VAL32(IMAGE_NT_SIGNATURE)) ||
         (NtHeaders.FileHeader.SizeOfOptionalHeader != VAL16(IMAGE_SIZEOF_NT_OPTIONAL32_HEADER)) ||
         (NtHeaders.OptionalHeader.Magic != VAL16(IMAGE_NT_OPTIONAL_HDR32_MAGIC)))
         goto isManagedExecutableExit;
-     
+
     /* Check that the virtual address of IMAGE_DIRECTORY_ENTRY_COMHEADER is non-null */
     if ( NtHeaders.OptionalHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_COM_DESCRIPTOR].VirtualAddress == 0 )
         goto isManagedExecutableExit;
-  
+
     /* The file is a managed executable */
     ret =  1;
-     
+
  isManagedExecutableExit:
     /* Close the file handle if we opened it */
     if ( hFile != INVALID_HANDLE_VALUE )
@@ -3380,7 +3380,7 @@ Return:
 static
 int
 checkFileType( char *lpFileName)
-{ 
+{
     struct stat stat_data;
 
     /* check if the file exist */
@@ -3388,7 +3388,7 @@ checkFileType( char *lpFileName)
     {
         return FILE_ERROR;
     }
-    
+
     if( isManagedExecutable(lpFileName) )
     {
         return FILE_PE;
@@ -3435,17 +3435,17 @@ Parameters:
 Return:
     the number of arguments
 
-note: this doesn't yet match precisely the behavior of Windows, but should be 
+note: this doesn't yet match precisely the behavior of Windows, but should be
 sufficient.
 what's here:
 1) stripping nonquoted whitespace
-2) handling of quoted parameters and quoted "parts" of parameters, removal of 
+2) handling of quoted parameters and quoted "parts" of parameters, removal of
    doublequotes (<aaaa"b bbb b"ccc> becomes <aaaab bbb bccc>)
 3) \" as an escaped doublequote, both within doublequoted sequences and out
 what's known missing :
-1) \\ as an escaped backslash, but only if the string of '\' 
-   is followed by a " (escaped or not)                                       
-2) "alternate" escape sequence : double-doublequote within a double-quoted 
+1) \\ as an escaped backslash, but only if the string of '\'
+   is followed by a " (escaped or not)
+2) "alternate" escape sequence : double-doublequote within a double-quoted
     argument (<"aaa a""aa aaa">) expands to a single-doublequote(<aaa a"aa aaa>)
 note that there may be other special cases
 --*/
@@ -3517,7 +3517,7 @@ buildArgv(
 
         /* let's skip the first argument in the command line */
 
-        /* strip leading whitespace; function returns NULL if there's only 
+        /* strip leading whitespace; function returns NULL if there's only
            whitespace, so the if statement below will work correctly */
         lpCommandLine = UTIL_inverse_wcspbrk((LPWSTR)lpCommandLine, W16_WHITESPACE);
 
@@ -3536,14 +3536,14 @@ buildArgv(
                 }
                 else if('"' == *lpCommandLine)
                 {
-                    /* got a dquote; skip over it if it's escaped; make sure we 
-                       don't try to look before the first character in the 
+                    /* got a dquote; skip over it if it's escaped; make sure we
+                       don't try to look before the first character in the
                        string */
                     if(lpCommandLine > stringstart && '\\' == lpCommandLine[-1])
                     {
                         lpCommandLine++;
                         continue;
-                    } 
+                    }
 
                     /* found beginning of dquoted sequence, run to the end */
                     /* don't stop if we hit an escaped dquote */
@@ -3560,9 +3560,9 @@ buildArgv(
                         {
                             /* dquote is not escaped, dquoted sequence is over*/
                             break;
-                        } 
+                        }
                         lpCommandLine++;
-                    }   
+                    }
                     if(NULL == lpCommandLine || '\0' == *lpCommandLine)
                     {
                         /* no terminating dquote */
@@ -3596,11 +3596,11 @@ buildArgv(
 
     pChar = lpAsciiCmdLine;
 
-    /* loops through all the arguments, to find out how many arguments there 
+    /* loops through all the arguments, to find out how many arguments there
        are; while looping replace whitespace by \0 */
 
     /* skip leading whitespace (and replace by '\0') */
-    /* note : there shouldn't be any, command starts either with PE loader name 
+    /* note : there shouldn't be any, command starts either with PE loader name
        or computed application path, but this won't hurt */
     while (*pChar)
     {
@@ -3621,14 +3621,14 @@ buildArgv(
         {
             if('"' == *pChar)
             {
-                /* skip over dquote if it's escaped; make sure we don't try to 
+                /* skip over dquote if it's escaped; make sure we don't try to
                    look before the start of the string for the \ */
                 if(pChar > lpAsciiCmdLine && '\\' == pChar[-1])
                 {
                     pChar++;
                     continue;
                 }
-                
+
                 /* found leading dquote : look for ending dquote */
                 pChar++;
                 while (*pChar)
@@ -3636,17 +3636,17 @@ buildArgv(
                     pChar = strchr(pChar,'"');
                     if(NULL == pChar)
                     {
-                        /* no ending dquote found : argument extends to the end 
+                        /* no ending dquote found : argument extends to the end
                            of the string*/
                         break;
                     }
                     if('\\' != pChar[-1])
                     {
-                        /* found a dquote, and it's not escaped : quoted 
+                        /* found a dquote, and it's not escaped : quoted
                            sequence is over*/
                         break;
-                    }      
-                    /* found a dquote, but it was escaped : skip over it, keep 
+                    }
+                    /* found a dquote, but it was escaped : skip over it, keep
                        looking */
                     pChar++;
                 }
@@ -3663,7 +3663,7 @@ buildArgv(
             /* reached the end of the string : we're done */
             break;
         }
-        /* reached end of arg; replace trailing whitespace by '\0', to split 
+        /* reached end of arg; replace trailing whitespace by '\0', to split
            arguments into separate strings */
         while (isspace((unsigned char) *pChar))
         {
@@ -3684,7 +3684,7 @@ buildArgv(
     lppTemp = lppArgv;
 
     /* at this point all parameters are separated by NULL
-       we need to fill the array of arguments; we must also remove all dquotes 
+       we need to fill the array of arguments; we must also remove all dquotes
        from arguments (new process shouldn't see them) */
     for (i = *pnArg, pChar = lpAsciiCmdLine; i; i--)
     {
@@ -3703,7 +3703,7 @@ buildArgv(
             /* copy character if it's not a dquote */
             if('"' != *pChar)
             {
-                /* if it's the \ of an escaped dquote, skip over it, we'll 
+                /* if it's the \ of an escaped dquote, skip over it, we'll
                    copy the " instead */
                 if( '\\' == pChar[0] && '"' == pChar[1] )
                 {
@@ -3771,7 +3771,7 @@ getPath(
 
             TRACE("file %s exists\n", lpFileName);
             return TRUE;
-        } 
+        }
         else
         {
             TRACE("file %s doesn't exist.\n", lpFileName);
@@ -3856,14 +3856,14 @@ getPath(
         {
             lpNext++;
         }
-        
+
         /* search for ':' */
         lpCurrent = strchr(lpNext, ':');
         if (lpCurrent)
         {
             *lpCurrent++ = '\0';
         }
-        
+
         nextLen = strlen(lpNext);
         slashLen = (lpNext[nextLen-1] == '/') ? 0:1;
 
@@ -3882,7 +3882,7 @@ getPath(
         {
             strcat_s (lpPathFileName, iLen, "/");
         }
-        
+
         strcat_s (lpPathFileName, iLen, lpFileName);
 
         if (access (lpPathFileName, F_OK) == 0)
@@ -3904,7 +3904,7 @@ getPath(
 /*++
 Function:
   PROCThreadFromMachPort
-  
+
   Given a Mach thread port, return the CPalThread associated with it.
 
 Return
@@ -3925,7 +3925,7 @@ CorUnix::CPalThread *PROCThreadFromMachPort(mach_port_t hTargetThread)
 
         pThread = pThread->GetNext();
     }
-    
+
     PROCProcessUnlock();
 
     return pThread;
@@ -3945,4 +3945,3 @@ CorUnix::CProcProcessLocalData::~CProcProcessLocalData()
         DestroyProcessModules(pProcessModules);
     }
 }
-        

--- a/pal/src/thread/procprivate.hpp
+++ b/pal/src/thread/procprivate.hpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -14,7 +14,7 @@ Module Name:
 Abstract:
 
     Private process structures and routines
-    
+
 Revision History:
 
 
@@ -75,5 +75,3 @@ namespace CorUnix
 }
 
 #endif //_PAL_PROCPRIVATE_HPP_
-
-

--- a/pal/src/thread/thread.cpp
+++ b/pal/src/thread/thread.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -70,7 +70,7 @@ SET_DEFAULT_DEBUG_CHANNEL(THREAD);
 // is zero. This value can be set by setting the
 // environment variable PAL_THREAD_DEFAULT_STACK_SIZE
 // (the value should be in bytes and in hex).
-DWORD CPalThread::s_dwDefaultThreadStackSize = 256*1024; 
+DWORD CPalThread::s_dwDefaultThreadStackSize = 256*1024;
 
 /* list of free CPalThread objects */
 static Volatile<CPalThread*> free_threads_list PAL_GLOBAL = NULL;
@@ -79,7 +79,7 @@ static Volatile<CPalThread*> free_threads_list PAL_GLOBAL = NULL;
 /* NOTE: can't use a CRITICAL_SECTION here (see comment in FreeTHREAD) */
 int free_threads_spinlock = 0;
 
-/* lock to access iEndingThreads counter, condition variable to signal shutdown 
+/* lock to access iEndingThreads counter, condition variable to signal shutdown
 thread when any remaining threads have died, and count of exiting threads that
 can't be suspended. */
 pthread_mutex_t ptmEndThread PAL_GLOBAL;
@@ -108,12 +108,12 @@ ThreadInitializationRoutine(
     void *pProcessLocalData
     );
 
-void 
+void
 IncrementEndingThreadCount(
     void
     );
 
-void 
+void
 DecrementEndingThreadCount(
     void
     );
@@ -159,10 +159,10 @@ static void InternalEndCurrentThreadWrapper(void *arg)
     // actually is the current PAL thread, put it back in TLS temporarily.
     pthread_setspecific(thObjKey, pThread);
     (void)PAL_Enter(PAL_BoundaryTop);
-    
+
     /* Call entry point functions of every attached modules to
        indicate the thread is exiting */
-    /* note : no need to enter a critical section for serialization, the loader 
+    /* note : no need to enter a critical section for serialization, the loader
        will lock its own critical section */
     LOADCallDllMain(DLL_THREAD_DETACH, NULL);
 
@@ -210,7 +210,7 @@ Function:
 
 Abstract:
     Allocate CPalThread instance
-  
+
 Return:
     The fresh thread structure, NULL otherwise
 --*/
@@ -248,7 +248,7 @@ Function:
 
 Abstract:
     Free THREAD structure
-  
+
 --*/
 static void FreeTHREAD(CPalThread *pThread)
 {
@@ -263,15 +263,15 @@ static void FreeTHREAD(CPalThread *pThread)
     // check against pThread->dwGuard when getting the current thread's data.
     memset((void*)pThread, 0xcc, sizeof(*pThread));
 #endif
-    
-    // We SHOULD be doing the following, but it causes massive problems. See the 
+
+    // We SHOULD be doing the following, but it causes massive problems. See the
     // comment below.
     //pthread_setspecific(thObjKey, NULL); // Make sure any TLS entry is removed.
 
     //
-    // Never actually free the THREAD structure to make the TLS lookaside cache work. 
-    // THREAD* for terminated thread can be stuck in the lookaside cache code for an 
-    // arbitrary amount of time. The unused THREAD* structures has to remain in a 
+    // Never actually free the THREAD structure to make the TLS lookaside cache work.
+    // THREAD* for terminated thread can be stuck in the lookaside cache code for an
+    // arbitrary amount of time. The unused THREAD* structures has to remain in a
     // valid memory and thus can't be returned to the heap.
     //
     // TODO: is this really true? Why would the entry remain in the cache for
@@ -279,12 +279,12 @@ static void FreeTHREAD(CPalThread *pThread)
     //
 
     /* NOTE: can't use a CRITICAL_SECTION here: EnterCriticalSection(&cs,TRUE) and
-       LeaveCriticalSection(&cs,TRUE) need to access the thread private data 
-       stored in the very THREAD structure that we just destroyed. Entering and 
+       LeaveCriticalSection(&cs,TRUE) need to access the thread private data
+       stored in the very THREAD structure that we just destroyed. Entering and
        leaving the critical section with internal==FALSE leads to possible hangs
-       in the PROCSuspendOtherThreads logic, at shutdown time 
+       in the PROCSuspendOtherThreads logic, at shutdown time
 
-       Update: [TODO] PROCSuspendOtherThreads has been removed. Can this 
+       Update: [TODO] PROCSuspendOtherThreads has been removed. Can this
        code be changed?*/
 
     /* Get the lock */
@@ -304,7 +304,7 @@ Function:
 
 returns the process owner ID of the indicated hThread
 --*/
-DWORD 
+DWORD
 THREADGetThreadProcessId(
     HANDLE hThread
     // UNIXTODO Should take pThread parameter here (modify callers)
@@ -314,7 +314,7 @@ THREADGetThreadProcessId(
     CPalThread *pTargetThread;
     IPalObject *pobjThread = NULL;
     PAL_ERROR palError = NO_ERROR;
-    
+
     DWORD dwProcessId = 0;
 
     pThread = InternalGetCurrentThread();
@@ -348,7 +348,7 @@ THREADGetThreadProcessId(
         ERROR("Couldn't retreive the hThread:%p pid owner !\n", hThread);
     }
 
-    
+
     return dwProcessId;
 }
 
@@ -373,12 +373,12 @@ GetCurrentThreadId(
     // with calling InternalGetCurrentThread (i.e., is our lookaside
     // cache faster on average than pthread_self?)
     //
-    
+
     dwThreadId = (DWORD)THREADSilentGetCurrentThreadId();
-    
-    LOGEXIT("GetCurrentThreadId returns DWORD %#x\n", dwThreadId);    
+
+    LOGEXIT("GetCurrentThreadId returns DWORD %#x\n", dwThreadId);
     PERF_EXIT(GetCurrentThreadId);
-    
+
     return dwThreadId;
 }
 
@@ -397,7 +397,7 @@ PAL_GetCurrentThread(
 {
     PERF_ENTRY(GetCurrentThread);
     ENTRY("GetCurrentThread()\n");
-    
+
     LOGEXIT("GetCurrentThread returns HANDLE %p\n", hPseudoCurrentThread);
     PERF_EXIT(GetCurrentThread);
 
@@ -421,7 +421,7 @@ SwitchToThread(
     PERF_ENTRY(SwitchToThread);
     ENTRY("SwitchToThread(VOID)\n");
 
-    /* sched_yield yields to another thread in the current process. This implementation 
+    /* sched_yield yields to another thread in the current process. This implementation
        won't work well for cross-process synchronization. */
     ret = (sched_yield() == 0);
 
@@ -454,7 +454,7 @@ CreateThread(
     PAL_ERROR palError;
     CPalThread *pThread;
     HANDLE hNewThread = NULL;
-    
+
     PERF_ENTRY(CreateThread);
     ENTRY("CreateThread(lpThreadAttr=%p, dwStackSize=%u, lpStartAddress=%p, "
           "lpParameter=%p, dwFlags=%#x, lpThreadId=%#x)\n",
@@ -478,7 +478,7 @@ CreateThread(
     if (NO_ERROR != palError)
     {
         pThread->SetLastError(palError);
-    }    
+    }
 
     LOGEXIT("CreateThread returns HANDLE %p\n", hNewThread);
     PERF_EXIT(CreateThread);
@@ -505,7 +505,7 @@ CorUnix::InternalCreateThread(
     bool fAttributesInitialized = FALSE;
     bool fThreadDataAddedToProcessList = FALSE;
     HANDLE hNewThread = NULL;
-    
+
     pthread_t pthread;
     pthread_attr_t pthreadAttr;
     size_t pthreadStackSize;
@@ -528,7 +528,7 @@ CorUnix::InternalCreateThread(
         // which could occur if a DllMain PROCESS_DETACH handler tried to
         // create a new thread for some odd reason).
         //
-        
+
         ERROR("process is terminating, can't create new thread.\n");
 
         if (pThread->GetThreadId() != static_cast<DWORD>(terminator))
@@ -544,7 +544,7 @@ CorUnix::InternalCreateThread(
             //
             // This is the shutdown thread, so just return an error
             //
-            
+
             palError = ERROR_PROCESS_ABORTED;
             goto EXIT;
         }
@@ -554,15 +554,15 @@ CorUnix::InternalCreateThread(
 
     if (lpThreadAttributes != NULL)
     {
-        ASSERT("lpThreadAttributes parameter must be NULL (%p)\n", 
+        ASSERT("lpThreadAttributes parameter must be NULL (%p)\n",
                lpThreadAttributes);
         palError = ERROR_INVALID_PARAMETER;
         goto EXIT;
     }
-    
+
     // Ignore the STACK_SIZE_PARAM_IS_A_RESERVATION flag
     dwCreationFlags &= ~STACK_SIZE_PARAM_IS_A_RESERVATION;
-    
+
     if ((dwCreationFlags != 0) && (dwCreationFlags != CREATE_SUSPENDED))
     {
         ASSERT("dwCreationFlags parameter is invalid (%#x)\n", dwCreationFlags);
@@ -596,7 +596,7 @@ CorUnix::InternalCreateThread(
     {
         ERROR("couldn't initialize pthread attributes\n");
         palError = ERROR_INTERNAL_ERROR;
-        goto EXIT;        
+        goto EXIT;
     }
 
     fAttributesInitialized = TRUE;
@@ -606,7 +606,7 @@ CorUnix::InternalCreateThread(
     {
         ERROR("couldn't set thread stack size\n");
         palError = ERROR_INTERNAL_ERROR;
-        goto EXIT;        
+        goto EXIT;
     }
 
     TRACE("default pthread stack size is %d, caller requested %d (default is %d)\n",
@@ -622,7 +622,7 @@ CorUnix::InternalCreateThread(
         WARN("default stack size is reported as %d, but PTHREAD_STACK_MIN is "
              "%d\n", pthreadStackSize, PTHREAD_STACK_MIN);
     }
-    
+
     if (pthreadStackSize < dwStackSize)
     {
         TRACE("setting thread stack size to %d\n", dwStackSize);
@@ -669,10 +669,10 @@ CorUnix::InternalCreateThread(
     // Add the thread to the process list
     //
 
-    // 
+    //
     // We use the process lock to ensure that we're not interrupted
     // during the creation process. After adding the CPalThread reference
-    // to the process list, we want to make sure the actual thread has been 
+    // to the process list, we want to make sure the actual thread has been
     // started. Otherwise, there's a window where the thread can be found
     // in the process list but doesn't yet exist in the system.
     //
@@ -710,7 +710,7 @@ CorUnix::InternalCreateThread(
         palError = ERROR_NOT_ENOUGH_MEMORY;
         goto EXIT;
     }
-       
+
     //
     // Wait for the new thread to finish its initial startup tasks
     // (i.e., the ones that might fail)
@@ -722,7 +722,7 @@ CorUnix::InternalCreateThread(
         // the thread's ID in the out params
         //
         *phThread = hNewThread;
-        
+
         if (NULL != lpThreadId)
         {
             *lpThreadId = pNewThread->GetThreadId();
@@ -765,7 +765,7 @@ EXIT:
         {
             PROCRemoveThread(pThread, pNewThread);
         }
-        // 
+        //
         // Once we remove the thread from the process list, we can call
         // PROCProcessUnlock.
         //
@@ -796,7 +796,7 @@ ExitThread(
        IN DWORD dwExitCode)
 {
     CPalThread *pThread;
-      
+
     ENTRY("ExitThread(dwExitCode=%u)\n", dwExitCode);
     PERF_ENTRY_ONLY(ExitThread);
 
@@ -813,7 +813,7 @@ ExitThread(
 
     /* kill the thread (itself), resulting in a call to InternalEndCurrentThread */
     pthread_exit(NULL);
-    
+
     ASSERT("pthread_exit should not return!\n");
     for (;;);
 }
@@ -887,7 +887,7 @@ done:
 
     LOGEXIT("GetExitCodeThread returns BOOL %d\n", NO_ERROR == palError);
     PERF_EXIT(GetExitCodeThread);
-    
+
     return NO_ERROR == palError;
 }
 
@@ -907,7 +907,7 @@ CorUnix::InternalEndCurrentThread(
 {
     PAL_ERROR palError = NO_ERROR;
     ISynchStateController *pSynchStateController = NULL;
-    
+
 #ifdef PAL_PERF
     PERFDisableThreadProfile(UserCreatedThread != pThread->GetThreadType());
 #endif
@@ -927,7 +927,7 @@ CorUnix::InternalEndCurrentThread(
     }
 
     //
-    // Need to synchronize setting the thread state to TS_DONE since 
+    // Need to synchronize setting the thread state to TS_DONE since
     // this is checked for in InternalSuspendThreadFromData.
     // TODO: Is this still needed after removing InternalSuspendThreadFromData?
     //
@@ -991,10 +991,10 @@ CorUnix::InternalEndCurrentThread(
 
         pThread->GetThreadObject()->ReleaseReference(pThread);
 
-        /* Remove thread for the thread list of the process 
+        /* Remove thread for the thread list of the process
            (don't do if this is the last thread -> gets handled by
             TerminateProcess->PROCCleanupProcess->PROCTerminateOtherThreads) */
-        
+
         PROCRemoveThread(pThread, pThread);
 
 #ifdef FEATURE_PAL_SXS
@@ -1002,8 +1002,8 @@ CorUnix::InternalEndCurrentThread(
         SEHDisable(pThread);
         PAL_Leave(PAL_BoundaryTop);
 #endif // FEATURE_PAL_SXS
-        
-        
+
+
         //
         // Now release our reference to the thread data. We cannot touch
         // it after this point
@@ -1011,7 +1011,7 @@ CorUnix::InternalEndCurrentThread(
 
         pThread->ReleaseThreadReference();
         DecrementEndingThreadCount();
-        
+
     }
 }
 
@@ -1029,7 +1029,7 @@ GetThreadPriority(
     CPalThread *pThread;
     PAL_ERROR palError;
     int iPriority = THREAD_PRIORITY_ERROR_RETURN;
-    
+
     PERF_ENTRY(GetThreadPriority);
     ENTRY("GetThreadPriority(hThread=%p)\n", hThread);
 
@@ -1048,7 +1048,7 @@ GetThreadPriority(
 
     LOGEXIT("GetThreadPriorityExit returns int %d\n", iPriority);
     PERF_EXIT(GetThreadPriority);
-    
+
     return iPriority;
 }
 
@@ -1062,7 +1062,7 @@ CorUnix::InternalGetThreadPriority(
     PAL_ERROR palError = NO_ERROR;
     CPalThread *pTargetThread;
     IPalObject *pobjThread = NULL;
-    
+
     palError = InternalGetThreadDataFromHandle(
         pThread,
         hThread,
@@ -1075,7 +1075,7 @@ CorUnix::InternalGetThreadPriority(
     {
         goto InternalGetThreadPriorityExit;
     }
-    
+
     pTargetThread->Lock(pThread);
 
     *piPriority = pTargetThread->GetThreadPriority();
@@ -1107,7 +1107,7 @@ SetThreadPriority(
 {
     CPalThread *pThread;
     PAL_ERROR palError = NO_ERROR;
-    
+
     PERF_ENTRY(SetThreadPriority);
     ENTRY("SetThreadPriority(hThread=%p, nPriority=%#x)\n", hThread, nPriority);
 
@@ -1126,7 +1126,7 @@ SetThreadPriority(
 
     LOGEXIT("SetThreadPriority returns BOOL %d\n", NO_ERROR == palError);
     PERF_EXIT(SetThreadPriority);
-    
+
     return NO_ERROR == palError;
 }
 
@@ -1140,7 +1140,7 @@ CorUnix::InternalSetThreadPriority(
     PAL_ERROR palError = NO_ERROR;
     CPalThread *pTargetThread = NULL;
     IPalObject *pobjThread = NULL;
-    
+
     int policy;
     struct sched_param schedParam;
     int max_priority;
@@ -1160,7 +1160,7 @@ CorUnix::InternalSetThreadPriority(
     {
         goto InternalSetThreadPriorityExit;
     }
-        
+
     pTargetThread->Lock(pThread);
 
     /* validate the requested priority */
@@ -1174,12 +1174,12 @@ CorUnix::InternalSetThreadPriority(
     case THREAD_PRIORITY_ABOVE_NORMAL:  /* fall through */
     case THREAD_PRIORITY_NORMAL:        /* fall through */
     case THREAD_PRIORITY_BELOW_NORMAL:  /* fall through */
-    case THREAD_PRIORITY_LOWEST:        
+    case THREAD_PRIORITY_LOWEST:
 #if PAL_IGNORE_NORMAL_THREAD_PRIORITY
         /* We aren't going to set the thread priority. Just record what it is,
            and exit */
         pTargetThread->m_iThreadPriority = iNewPriority;
-        goto InternalSetThreadPriorityExit;        
+        goto InternalSetThreadPriorityExit;
 #endif
         break;
 
@@ -1187,22 +1187,22 @@ CorUnix::InternalSetThreadPriority(
         ASSERT("Priority %d not supported\n", iNewPriority);
         palError = ERROR_INVALID_PARAMETER;
         goto InternalSetThreadPriorityExit;
-    }  
+    }
 
     /* check if the thread is still running */
     if (TS_DONE == pTargetThread->synchronizationInfo.GetThreadState())
     {
-        /* the thread has exited, set the priority in the thread structure 
+        /* the thread has exited, set the priority in the thread structure
            and exit */
         pTargetThread->m_iThreadPriority = iNewPriority;
-        goto InternalSetThreadPriorityExit;        
+        goto InternalSetThreadPriorityExit;
     }
 
-    /* get the previous thread schedule parameters.  We need to know the 
+    /* get the previous thread schedule parameters.  We need to know the
        scheduling policy to determine the priority range */
     if (pthread_getschedparam(
             pTargetThread->GetPThreadSelf(),
-            &policy, 
+            &policy,
             &schedParam
             ) != 0)
     {
@@ -1216,7 +1216,7 @@ CorUnix::InternalSetThreadPriority(
     min_priority = sched_get_priority_min(policy);
     if( -1 == max_priority || -1 == min_priority)
     {
-        ASSERT("sched_get_priority_min/max failed; error is %d (%s)\n", 
+        ASSERT("sched_get_priority_min/max failed; error is %d (%s)\n",
                errno, strerror(errno));
         palError = ERROR_INTERNAL_ERROR;
         goto InternalSetThreadPriorityExit;
@@ -1226,28 +1226,28 @@ CorUnix::InternalSetThreadPriority(
     min_priority = PAL_THREAD_PRIORITY_MIN;
 #endif
 
-    TRACE("Pthread priorities for policy %d must be in the range %d to %d\n", 
+    TRACE("Pthread priorities for policy %d must be in the range %d to %d\n",
           policy, min_priority, max_priority);
 
     /* explanation for fancy maths below :
-       POSIX doesn't specify the range of thread priorities that can be used 
+       POSIX doesn't specify the range of thread priorities that can be used
        with pthread_setschedparam. Instead, one must use sched_get_priority_min
        and sched_get_priority_max to obtain the lower and upper bounds of this
-       range. Since the PAL also uses a range of values (from Idle [-15] to 
-       Time Critical [+15]), we have to do a mapping from a known range to an 
-       unknown (at compilation) range. 
+       range. Since the PAL also uses a range of values (from Idle [-15] to
+       Time Critical [+15]), we have to do a mapping from a known range to an
+       unknown (at compilation) range.
        We do this by :
-       -substracting the minimal PAL priority from the desired priority. this 
+       -substracting the minimal PAL priority from the desired priority. this
         gives a value between 0 and the PAL priority range
-       -dividing this value by the PAL priority range. this allows us to 
+       -dividing this value by the PAL priority range. this allows us to
         express the desired priority as a floating-point value between 0 and 1
-       -multiplying this value by the PTHREAD priority range. This gives a 
+       -multiplying this value by the PTHREAD priority range. This gives a
         value between 0 and the PTHREAD priority range
-       -adding the minimal PTHREAD priority range. This will give us a value 
-        between the minimal and maximla pthread priority, which should be 
-        equivalent to the original PAL value. 
-        
-        example : suppose a pthread range 100 to 200, and a desired priority 
+       -adding the minimal PTHREAD priority range. This will give us a value
+        between the minimal and maximla pthread priority, which should be
+        equivalent to the original PAL value.
+
+        example : suppose a pthread range 100 to 200, and a desired priority
                   of 0 (halfway between PAL minimum and maximum)
             0 - (IDLE [-15]) = 15
             15 / (TIMECRITICAL[15] - IDLE[-15]) = 0.5
@@ -1260,7 +1260,7 @@ CorUnix::InternalSetThreadPriority(
     posix_priority += min_priority;
 
     schedParam.sched_priority = (int)posix_priority;
-    
+
     TRACE("PAL priority %d is mapped to pthread priority %d\n",
           iNewPriority, schedParam.sched_priority);
 
@@ -1280,12 +1280,12 @@ CorUnix::InternalSetThreadPriority(
             goto InternalSetThreadPriorityExit;
         }
 #endif
-        
+
         ASSERT("Unable to set thread priority (errno %d)\n", errno);
         palError = ERROR_INTERNAL_ERROR;
         goto InternalSetThreadPriorityExit;
     }
-    
+
     pTargetThread->m_iThreadPriority = iNewPriority;
 
 InternalSetThreadPriorityExit:
@@ -1300,7 +1300,7 @@ InternalSetThreadPriorityExit:
         pobjThread->ReleaseReference(pThread);
     }
 
-    return palError;    
+    return palError;
 }
 
 BOOL
@@ -1331,25 +1331,25 @@ CorUnix::GetThreadTimesInternal(
         &pthrTarget,
         &pobjThread
         );
-    
+
     if (palError != NO_ERROR)
     {
         ASSERT("Unable to get thread data from handle %p"
               "thread\n", hThread);
         SetLastError(ERROR_INTERNAL_ERROR);
         goto SetTimesToZero;
-    }   
+    }
 
     pthrTarget->Lock(pthrCurrent);
-    
+
     mach_port_t mhThread;
     mhThread = pthread_mach_thread_np(pthrTarget->GetPThreadSelf());
-    
+
     kern_return_t status;
     status = thread_info(
-        mhThread, 
-        THREAD_BASIC_INFO, 
-        (thread_info_t)&resUsage, 
+        mhThread,
+        THREAD_BASIC_INFO,
+        (thread_info_t)&resUsage,
         &resUsage_count);
 
     pthrTarget->Unlock(pthrCurrent);
@@ -1403,7 +1403,7 @@ CorUnix::GetThreadTimesInternal(
               "thread\n", hThread);
         SetLastError(ERROR_INTERNAL_ERROR);
         goto SetTimesToZero;
-    }   
+    }
 
     pTargetThread->Lock(pThread);
 
@@ -1431,7 +1431,7 @@ CorUnix::GetThreadTimesInternal(
     calcTime += (__int64) ts.tv_nsec;
     lpUserTime->dwLowDateTime = (DWORD)calcTime;
     lpUserTime->dwHighDateTime = (DWORD)(calcTime >> 32);
-    
+
     /* Set kernel time to zero, for now */
     lpKernelTime->dwLowDateTime = 0;
     lpKernelTime->dwHighDateTime = 0;
@@ -1442,7 +1442,7 @@ CorUnix::GetThreadTimesInternal(
 #endif //HAVE_MACH_THREADS
 
 SetTimesToZero:
-    
+
     lpUserTime->dwLowDateTime = 0;
     lpUserTime->dwHighDateTime = 0;
     lpKernelTime->dwLowDateTime = 0;
@@ -1510,13 +1510,13 @@ GetThreadTimes(
         lpCreationTime->dwLowDateTime = 0;
         lpCreationTime->dwHighDateTime = 0;
     }
-    
+
     if (lpExitTime)
     {
         lpExitTime->dwLowDateTime = 0;
         lpExitTime->dwHighDateTime = 0;
     }
-    
+
     LOGEXIT("GetThreadTimes returns BOOL %d\n", retval);
     PERF_EXIT(GetThreadTimes);
     return (retval);
@@ -1603,7 +1603,7 @@ CPalThread::ThreadEntry(
     if (UserCreatedThread == pThread->GetThreadType())
     {
         /* Inform all loaded modules that a thread has been created */
-        /* note : no need to take a critical section to serialize here; the loader 
+        /* note : no need to take a critical section to serialize here; the loader
            will take the module critical section */
         LOADCallDllMain(DLL_THREAD_ATTACH, NULL);
     }
@@ -1622,7 +1622,7 @@ CPalThread::ThreadEntry(
     TRACE("Thread exited (%u)\n", retValue);
     ExitThread(retValue);
 
-    /* Note: never get here */ 
+    /* Note: never get here */
     ASSERT("ExitThread failed!\n");
     for (;;);
 
@@ -1631,15 +1631,15 @@ fail:
     //
     // Notify InternalCreateThread that a failure occurred
     //
-    
+
     if (NULL != pThread)
     {
         pThread->synchronizationInfo.SetThreadState(TS_FAILED);
         pThread->SetStartStatus(FALSE);
     }
 
-    /* do not call ExitThread : we don't want to call DllMain(), and the thread 
-       isn't in a clean state (e.g. lpThread isn't in TLS). the cleanup work 
+    /* do not call ExitThread : we don't want to call DllMain(), and the thread
+       isn't in a clean state (e.g. lpThread isn't in TLS). the cleanup work
        above should release all resources */
     return NULL;
 }
@@ -1675,7 +1675,7 @@ CorUnix::InitializeGlobalThreadData(
     //
     // Initialize the thread suspension signal sets.
     //
-    
+
     CThreadSuspensionInfo::InitializeSignalSets();
 #endif // !HAVE_MACH_EXCEPTIONS
 
@@ -1691,7 +1691,7 @@ Abstract:
     Create the CPalThread for the startup thread
     or another external thread entering the PAL
     for the first time
-  
+
 Parameters:
     ppThread - on success, receives the CPalThread
 
@@ -1706,7 +1706,7 @@ CorUnix::CreateThreadData(
 {
     PAL_ERROR palError = NO_ERROR;
     CPalThread *pThread = NULL;
-    
+
     /* Create the thread object */
     pThread = AllocTHREAD();
 
@@ -1745,7 +1745,7 @@ CorUnix::CreateThreadData(
     }
 
     *ppThread = pThread;
-    
+
 CreateThreadDataExit:
 
     if (NO_ERROR != palError)
@@ -1766,7 +1766,7 @@ Function:
 Abstract:
     Creates the IPalObject for a thread, storing
     the reference in the CPalThread
-  
+
 Parameters:
     pThread - the thread data for the creating thread
     pNewThread - the thread data for the thread being initialized
@@ -1813,7 +1813,7 @@ CorUnix::CreateThreadObject(
 
     palError = pobjThread->GetProcessLocalData(
         pThread,
-        WriteLock, 
+        WriteLock,
         &pDataLock,
         reinterpret_cast<void **>(&pLocalData)
         );
@@ -1839,7 +1839,7 @@ CorUnix::CreateThreadObject(
         &hThread,
         &pobjRegisteredThread
         );
-        
+
     //
     // pobjThread is invalidated by the call to RegisterObject, so NULL
     // it out here to prevent it from being released
@@ -1884,13 +1884,13 @@ CreateThreadObjectExit:
         if (!fThreadDataStoredInObject)
         {
             //
-            // The CPalThread for the new thread was never stored in 
+            // The CPalThread for the new thread was never stored in
             // an IPalObject instance, so we need to release the initial
             // reference here. (If it has been stored it will get freed in
             // the owning object's cleanup routine)
             //
 
-            pNewThread->ReleaseThreadReference();            
+            pNewThread->ReleaseThreadReference();
         }
     }
 
@@ -1974,7 +1974,7 @@ CorUnix::InternalCreateDummyThread(
     // pobjThread is invalidated by the above call, so NULL
     // it out here
     //
-    
+
     pobjThread = NULL;
 
     if (NO_ERROR != palError)
@@ -2061,7 +2061,7 @@ CorUnix::InternalGetThreadDataFromHandle(
                 // Transfer object reference to out param
                 //
 
-                *ppobjThread = pobj;                
+                *ppobjThread = pobj;
             }
             else
             {
@@ -2168,10 +2168,10 @@ CPalThread::~CPalThread()
     if (m_fStartItemsInitialized)
     {
         int iError;
-        
+
         iError = pthread_cond_destroy(&m_startCond);
         _ASSERTE(0 == iError);
-        
+
         iError = pthread_mutex_destroy(&m_startMutex);
         _ASSERTE(0 == iError);
     }
@@ -2196,7 +2196,7 @@ CPalThread::ReleaseThreadReference(
     {
         FreeTHREAD(this);
     }
-    
+
 }
 
 PAL_ERROR
@@ -2277,7 +2277,7 @@ CPalThread::SetStartStatus(
     //
     // This routine may get called from CPalThread::ThreadEntry
     //
-    // If we've reached this point there are no further thread 
+    // If we've reached this point there are no further thread
     // suspensions that happen at creation time, so reset
     // m_bCreateSuspended
     //
@@ -2348,12 +2348,12 @@ to control a global counter that indicates if any threads are about to die.
 Once a thread's state is set to TS_DONE, it cannot be suspended. However,
 the dying thread can still access PAL resources, which is dangerous if the
 thread dies during PAL cleanup. To avoid this, the shutdown thread calls
-WaitForEndingThreads after suspending all other threads. WaitForEndingThreads 
-uses a condition variable along with the global counter to wait for remaining 
-PAL threads to die before proceeding with cleanup. As threads die, they 
+WaitForEndingThreads after suspending all other threads. WaitForEndingThreads
+uses a condition variable along with the global counter to wait for remaining
+PAL threads to die before proceeding with cleanup. As threads die, they
 decrement the counter and signal the condition variable. */
 
-void 
+void
 IncrementEndingThreadCount(
     void
     )
@@ -2369,7 +2369,7 @@ IncrementEndingThreadCount(
     _ASSERT_MSG(iError == 0, "pthread_mutex_unlock returned %d\n", iError);
 }
 
-void 
+void
 DecrementEndingThreadCount(
     void
     )
@@ -2392,7 +2392,7 @@ DecrementEndingThreadCount(
     _ASSERT_MSG(iError == 0, "pthread_mutex_unlock returned %d\n", iError);
 }
 
-void 
+void
 WaitForEndingThreads(
     void
     )
@@ -2405,7 +2405,7 @@ WaitForEndingThreads(
     while (iEndingThreads > 0)
     {
         iError = pthread_cond_wait(&ptcEndThread, &ptmEndThread);
-        _ASSERT_MSG(iError == 0, "pthread_cond_wait returned %d\n", iError);  
+        _ASSERT_MSG(iError == 0, "pthread_cond_wait returned %d\n", iError);
     }
 
     iError = pthread_mutex_unlock(&ptmEndThread);
@@ -2433,7 +2433,7 @@ CorUnix::InitializeEndingThreadsData(
         // Don't bother checking the return value of pthread_mutex_destroy
         // since PAL initialization will now fail.
         //
-        
+
         pthread_mutex_destroy(&ptmEndThread);
         goto InitializeEndingThreadsDataExit;
     }
@@ -2457,14 +2457,14 @@ ThreadCleanupRoutine(
     CPalThread *pThreadToCleanup = NULL;
     IDataLock *pDataLock = NULL;
     PAL_ERROR palError = NO_ERROR;
-        
+
     //
     // Free the CPalThread data for the passed in thread
     //
 
     palError = pObjectToCleanup->GetProcessLocalData(
         pThread,
-        WriteLock, 
+        WriteLock,
         &pDataLock,
         reinterpret_cast<void**>(&pThreadData)
         );
@@ -2480,7 +2480,7 @@ ThreadCleanupRoutine(
         // for the thread data to be available while the rest of the
         // object cleanup takes place).
         //
-        
+
         pThreadToCleanup = pThreadData->pThread;
         pThreadData->pThread = NULL;
         pDataLock->ReleaseLock(pThread, TRUE);
@@ -2490,7 +2490,7 @@ ThreadCleanupRoutine(
     {
         ASSERT("Unable to obtain thread data");
     }
-    
+
 }
 
 PAL_ERROR

--- a/pal/src/thread/threadsusp.cpp
+++ b/pal/src/thread/threadsusp.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 
@@ -39,13 +39,13 @@ Revision History:
 
 #if defined(_AIX)
 // AIX requires explicit definition of the union semun (see semctl man page)
-union semun 
+union semun
 {
     int val;
     struct semid_ds * buf;
     unsigned short * array;
 };
-#endif 
+#endif
 
 using namespace CorUnix;
 
@@ -56,7 +56,7 @@ SET_DEFAULT_DEBUG_CHANNEL(THREAD);
    in suspended state in order to resume it. */
 CONST BYTE WAKEUPCODE=0x2A;
 
-// #define USE_GLOBAL_LOCK_FOR_SUSPENSION // Uncomment this define to use the global suspension lock. 
+// #define USE_GLOBAL_LOCK_FOR_SUSPENSION // Uncomment this define to use the global suspension lock.
 /* The global suspension lock can be used in place of each thread having its own
 suspension mutex or spinlock. The downside is that it restricts us to only
 performing one suspension or resumption in the PAL at a time. */
@@ -101,7 +101,7 @@ CThreadSuspensionInfo::InternalSuspendNewThreadFromData(
 
     BYTE resume_code = 0;
     ssize_t read_ret;
-    
+
     // Block until ResumeThread writes something to the pipe
     while ((read_ret = read(pipe_descs[0], &resume_code, sizeof(resume_code))) != sizeof(resume_code))
     {
@@ -167,7 +167,7 @@ ResumeThread(
     }
     else
     {
-        _ASSERT_MSG(dwSuspendCount != static_cast<DWORD>(-1), "InternalResumeThread returned success but dwSuspendCount did not change.\n");   
+        _ASSERT_MSG(dwSuspendCount != static_cast<DWORD>(-1), "InternalResumeThread returned success but dwSuspendCount did not change.\n");
     }
 
     LOGEXIT("ResumeThread returns DWORD %u\n", dwSuspendCount);
@@ -179,7 +179,7 @@ ResumeThread(
 Function:
   InternalResumeThread
 
-InternalResumeThread converts the handle of the target thread to a 
+InternalResumeThread converts the handle of the target thread to a
 CPalThread, and passes both the resumer and target thread references
 to InternalResumeThreadFromData. A reference to the suspend count from
 the resumption attempt is passed back to the caller of this function.
@@ -227,11 +227,11 @@ Function:
 InternalResumeThreadFromData resumes the target thread. First, the suspension
 mutexes of the threads are acquired. Next, there's a check to ensure that the
 target thread was actually suspended. Finally, the resume attempt is made
-and the suspension mutexes are released. The suspend count of the 
+and the suspension mutexes are released. The suspend count of the
 target thread is passed back to the caller of this function.
 
 Note that ReleaseSuspensionLock(s) is called before hitting ASSERTs in error
-paths. Currently, this seems unnecessary since asserting within 
+paths. Currently, this seems unnecessary since asserting within
 InternalResumeThreadFromData will not cause cleanup to occur. However,
 this may change since it would be preferable to perform cleanup. Thus, calls
 to release suspension locks remain in the error paths.
@@ -257,8 +257,8 @@ CThreadSuspensionInfo::InternalResumeThreadFromData(
     // Acquire suspension mutex
     AcquireSuspensionLocks(pthrResumer, pthrTarget);
 
-    // Check target thread's state to ensure it hasn't died. 
-    // Setting a thread's state to TS_DONE is protected by the 
+    // Check target thread's state to ensure it hasn't died.
+    // Setting a thread's state to TS_DONE is protected by the
     // target's suspension mutex.
     if (pthrTarget->synchronizationInfo.GetThreadState() == TS_DONE)
     {
@@ -281,7 +281,7 @@ CThreadSuspensionInfo::InternalResumeThreadFromData(
     // If there is a blocking pipe on this thread, resume it by writing the wake up code to that pipe.
     if (-1 != pthrTarget->suspensionInfo.GetBlockingPipe())
     {
-        // If write() is interrupted by a signal before writing data, 
+        // If write() is interrupted by a signal before writing data,
         // it returns -1 and sets errno to EINTR. In this case, we
         // attempt the write() again.
         writeAgain:
@@ -290,7 +290,7 @@ CThreadSuspensionInfo::InternalResumeThreadFromData(
         // The size of WAKEUPCODE is 1 byte. If write returns 0, we'll treat it as an error.
         if (sizeof(WAKEUPCODE) != nWrittenBytes)
         {
-            // If we are here during process creation, this is most likely caused by the target 
+            // If we are here during process creation, this is most likely caused by the target
             // process dying before reaching this point and thus breaking the pipe.
             if (nWrittenBytes == -1 && EPIPE == errno)
             {
@@ -316,7 +316,7 @@ CThreadSuspensionInfo::InternalResumeThreadFromData(
 
         // Reset blocking pipe to -1 since we're done using it.
         pthrTarget->suspensionInfo.SetBlockingPipe(-1);
-        
+
         ReleaseSuspensionLocks(pthrResumer, pthrTarget);
         goto InternalResumeThreadFromDataExit;
     }
@@ -341,14 +341,14 @@ Function:
   TryAcquireSuspensionLock
 
 TryAcquireSuspensionLock is a utility function that tries to acquire a thread's
-suspension mutex or spinlock. If it succeeds, the function returns TRUE. 
+suspension mutex or spinlock. If it succeeds, the function returns TRUE.
 Otherwise, it returns FALSE. This function is used in AcquireSuspensionLocks.
 Note that the global lock cannot be acquired in this function since it makes
 no sense to do so. A thread holding the global lock is the only thread that
 can perform suspend or resume operations so it doesn't need to acquire
 a second lock.
 --*/
-BOOL 
+BOOL
 CThreadSuspensionInfo::TryAcquireSuspensionLock(
     CPalThread* pthrTarget
     )
@@ -373,12 +373,12 @@ CThreadSuspensionInfo::TryAcquireSuspensionLock(
 Function:
   AcquireSuspensionLock
 
-AcquireSuspensionLock acquires a thread's suspension mutex or spinlock. 
-If USE_GLOBAL_LOCK_FOR_SUSPENSION is defined, it will acquire the global lock. 
+AcquireSuspensionLock acquires a thread's suspension mutex or spinlock.
+If USE_GLOBAL_LOCK_FOR_SUSPENSION is defined, it will acquire the global lock.
 A thread in this function blocks until it acquires
 its lock, unlike in TryAcquireSuspensionLock.
 --*/
-void 
+void
 CThreadSuspensionInfo::AcquireSuspensionLock(
     CPalThread* pthrCurrent
     )
@@ -409,10 +409,10 @@ Function:
   ReleaseSuspensionLock
 
 ReleaseSuspensionLock is a function that releases a thread's suspension mutex
-or spinlock. If USE_GLOBAL_LOCK_FOR_SUSPENSION is defined, 
+or spinlock. If USE_GLOBAL_LOCK_FOR_SUSPENSION is defined,
 it will release the global lock.
 --*/
-void 
+void
 CThreadSuspensionInfo::ReleaseSuspensionLock(
     CPalThread* pthrCurrent
     )
@@ -423,17 +423,17 @@ CThreadSuspensionInfo::ReleaseSuspensionLock(
 }
 #else // USE_GLOBAL_LOCK_FOR_SUSPENSION
 {
-    #if DEADLOCK_WHEN_THREAD_IS_SUSPENDED_WHILE_BLOCKED_ON_MUTEX 
+    #if DEADLOCK_WHEN_THREAD_IS_SUSPENDED_WHILE_BLOCKED_ON_MUTEX
     {
         SPINLOCKRelease(&pthrCurrent->suspensionInfo.m_nSpinlock);
     }
-    #else // DEADLOCK_WHEN_THREAD_IS_SUSPENDED_WHILE_BLOCKED_ON_MUTEX 
+    #else // DEADLOCK_WHEN_THREAD_IS_SUSPENDED_WHILE_BLOCKED_ON_MUTEX
     {
         INDEBUG(int iPthreadError = )
         pthread_mutex_unlock(&pthrCurrent->suspensionInfo.m_ptmSuspmutex);
         _ASSERT_MSG(iPthreadError == 0, "pthread_mutex_unlock returned %d\n", iPthreadError);
     }
-    #endif // DEADLOCK_WHEN_THREAD_IS_SUSPENDED_WHILE_BLOCKED_ON_MUTEX 
+    #endif // DEADLOCK_WHEN_THREAD_IS_SUSPENDED_WHILE_BLOCKED_ON_MUTEX
 }
 #endif // USE_GLOBAL_LOCK_FOR_SUSPENSION
 }
@@ -443,18 +443,18 @@ Function:
   AcquireSuspensionLocks
 
 AcquireSuspensionLocks is used to acquire the suspension locks
-of a suspender (or resumer) and target thread. The thread will 
+of a suspender (or resumer) and target thread. The thread will
 perform a blocking call to acquire its own suspension lock
-and will then try to acquire the target thread's lock without blocking. 
-If it fails to acquire the target's lock, it releases its own lock 
-and the thread will try to acquire both locks again. The key 
+and will then try to acquire the target thread's lock without blocking.
+If it fails to acquire the target's lock, it releases its own lock
+and the thread will try to acquire both locks again. The key
 is that both locks must be acquired together.
 
 Originally, only blocking calls were used to acquire the suspender
 and the target lock. However, this was problematic since a thread
 could acquire its own lock and then block on acquiring the target
 lock. In the meantime, the target could have already acquired its
-own lock and be attempting to suspend the suspender thread. This 
+own lock and be attempting to suspend the suspender thread. This
 clearly causes deadlock. A second approach used locking hierarchies,
 where locks were acquired use thread id ordering. This was better but
 suffered from the scenario where thread A acquires thread B's
@@ -463,13 +463,13 @@ suspension mutex and its own. Thus, thread A is suspended while
 holding thread B's mutex. This is problematic if thread C now wants
 to suspend thread B. The issue here is that a thread can be
 suspended while holding someone else's mutex but not holding its own.
-In the end, the correct approach is to always acquire your suspension 
-mutex first. This prevents you from being suspended while holding the 
-target's mutex. Then, attempt to acquire the target's mutex. If the mutex 
-cannot be acquired, release your own and try again. This all or nothing 
+In the end, the correct approach is to always acquire your suspension
+mutex first. This prevents you from being suspended while holding the
+target's mutex. Then, attempt to acquire the target's mutex. If the mutex
+cannot be acquired, release your own and try again. This all or nothing
 approach is the safest and avoids nasty race conditions.
 
-If USE_GLOBAL_LOCK_FOR_SUSPENSION is defined, the calling thread 
+If USE_GLOBAL_LOCK_FOR_SUSPENSION is defined, the calling thread
 will acquire the global lock when possible.
 --*/
 VOID
@@ -490,36 +490,36 @@ CThreadSuspensionInfo::AcquireSuspensionLocks(
         if (!TryAcquireSuspensionLock(pthrTarget))
         {
             // pthread_mutex_trylock returned EBUSY so release the first lock and try again.
-            ReleaseSuspensionLock(pthrSuspender);           
+            ReleaseSuspensionLock(pthrSuspender);
             fReacquire = TRUE;
             sched_yield();
         }
     } while (fReacquire);
 #endif // USE_GLOBAL_LOCK_FOR_SUSPENSION
 
-    // Whenever the native implementation for the wait subsystem's thread 
-    // blocking requires a lock as protection (as pthread conditions do with 
-    // the associated mutex), we need to grab that lock to prevent the target 
+    // Whenever the native implementation for the wait subsystem's thread
+    // blocking requires a lock as protection (as pthread conditions do with
+    // the associated mutex), we need to grab that lock to prevent the target
     // thread from being suspended while holding the lock.
-    // Failing to do so can lead to a multiple threads deadlocking such as the 
+    // Failing to do so can lead to a multiple threads deadlocking such as the
     // one described in VSW 363793.
-    // In general, in similar scenarios, we need to grab the protecting lock 
-    // every time suspension safety/unsafety is unbalanced on the two sides 
-    // using the same condition (or any other native blocking support which 
-    // needs an associated native lock), i.e. when either the signaling 
-    // thread(s) is(are) signaling from an unsafe area and the waiting 
+    // In general, in similar scenarios, we need to grab the protecting lock
+    // every time suspension safety/unsafety is unbalanced on the two sides
+    // using the same condition (or any other native blocking support which
+    // needs an associated native lock), i.e. when either the signaling
+    // thread(s) is(are) signaling from an unsafe area and the waiting
     // thread(s) is(are) waiting from a safe one, or vice versa (the scenario
-    // described in VSW 363793 is a good example of the first type of 
+    // described in VSW 363793 is a good example of the first type of
     // unbalanced suspension safety/unsafety).
-    // Instead, whenever signaling and waiting sides are both marked safe or 
-    // unsafe, the deadlock cannot take place since either the suspending 
-    // thread will suspend them anyway (regardless of the native lock), or it 
+    // Instead, whenever signaling and waiting sides are both marked safe or
+    // unsafe, the deadlock cannot take place since either the suspending
+    // thread will suspend them anyway (regardless of the native lock), or it
     // won't suspend any of them, since they are both marked unsafe.
-    // Such a balanced scenario applies, for instance, to critical sections 
+    // Such a balanced scenario applies, for instance, to critical sections
     // where depending on whether the target CS is internal or not, both the
-    // signaling and the waiting side will access the mutex/condition from 
+    // signaling and the waiting side will access the mutex/condition from
     // respectively an unsafe or safe region.
-    
+
     pthrTarget->AcquireNativeWaitLock();
 }
 
@@ -539,7 +539,7 @@ CThreadSuspensionInfo::ReleaseSuspensionLocks(
     CPalThread *pthrTarget
     )
 {
-    // See comment in AcquireSuspensionLocks    
+    // See comment in AcquireSuspensionLocks
     pthrTarget->ReleaseNativeWaitLock();
 
 #ifdef USE_GLOBAL_LOCK_FOR_SUSPENSION
@@ -611,7 +611,7 @@ Function:
   WaitOnSuspendSemaphore
 
 WaitOnSuspendSemaphore is a utility function for a thread
-to wait on its POSIX or SysV suspension semaphore. 
+to wait on its POSIX or SysV suspension semaphore.
 --*/
 void
 CThreadSuspensionInfo::WaitOnSuspendSemaphore()
@@ -774,13 +774,13 @@ CThreadSuspensionInfo::WaitOnResumeSemaphore()
 /*++
 Function:
   InitializeSignalSets
-  
+
 InitializeSignalSets initializes the signal masks used for thread
 suspension operations. Each thread's signal mask is initially set
 to smDefaultMask in InitializePreCreate. This mask blocks SIGUSR2,
 and SIGUSR1 if suspension using signals is off. This mask
 also blocks common signals so they will be handled by the PAL's
-signal handling thread. 
+signal handling thread.
 --*/
 VOID
 CThreadSuspensionInfo::InitializeSignalSets()
@@ -788,9 +788,9 @@ CThreadSuspensionInfo::InitializeSignalSets()
     sigemptyset(&smDefaultmask);
 
 #ifndef DO_NOT_USE_SIGNAL_HANDLING_THREAD
-    // The default signal mask masks all common signals except those that represent 
+    // The default signal mask masks all common signals except those that represent
     // synchronous exceptions in the PAL or are used by the system (e.g. SIGPROF on BSD).
-    // Note that SIGPROF is used by the BSD thread scheduler and masking it caused a 
+    // Note that SIGPROF is used by the BSD thread scheduler and masking it caused a
     // significant reduction in performance.
     sigaddset(&smDefaultmask, SIGHUP);
     sigaddset(&smDefaultmask, SIGABRT);
@@ -848,9 +848,9 @@ CThreadSuspensionInfo::InitializeSuspensionLock()
 Function:
   InitializePreCreate
 
-InitializePreCreate initializes the semaphores and signal masks used 
-for thread suspension. At the end, it sets the calling thread's 
-signal mask to the default signal mask. 
+InitializePreCreate initializes the semaphores and signal masks used
+for thread suspension. At the end, it sets the calling thread's
+signal mask to the default signal mask.
 --*/
 PAL_ERROR
 CThreadSuspensionInfo::InitializePreCreate()
@@ -868,7 +868,7 @@ CThreadSuspensionInfo::InitializePreCreate()
 #endif  // SEM_INIT_MODIFIES_ERRNO
 
     // initialize suspension semaphore
-    iError = sem_init(&m_semSusp, 0, 0);  
+    iError = sem_init(&m_semSusp, 0, 0);
 
 #if SEM_INIT_MODIFIES_ERRNO
     if (iError == 0)
@@ -917,7 +917,7 @@ CThreadSuspensionInfo::InitializePreCreate()
         ASSERT("semget for suspension sem id returned -1 and set errno to %d (%s)\n", errno, strerror(errno));
         goto InitializePreCreateExit;
     }
-    
+
     m_nSemrespid = semget(IPC_PRIVATE, 1, IPC_CREAT | 0666);
     if (m_nSemrespid == -1)
     {
@@ -946,7 +946,7 @@ CThreadSuspensionInfo::InitializePreCreate()
         ASSERT("semctl for resumption sem id returned -1 and set errno to %d (%s)\n", errno, strerror(errno));
         goto InitializePreCreateExit;
     }
-    
+
     // initialize suspend semaphore
     m_sbSemwait.sem_num = 0;
     m_sbSemwait.sem_op = -1;
@@ -955,7 +955,7 @@ CThreadSuspensionInfo::InitializePreCreate()
     // initialize resume semaphore
     m_sbSempost.sem_num = 0;
     m_sbSempost.sem_op = 1;
-    m_sbSempost.sem_flg = 0;    
+    m_sbSempost.sem_flg = 0;
 #elif USE_PTHREAD_CONDVARS
     iError = pthread_cond_init(&m_condSusp, NULL);
     if (iError != 0)
@@ -991,14 +991,14 @@ CThreadSuspensionInfo::InitializePreCreate()
 #if !HAVE_MACH_EXCEPTIONS
     // This signal mask blocks SIGUSR2 when signal suspension is turned on
     // (SIGUSR2 must be blocked for signal suspension), and masks other signals
-    // when the signal waiting thread is turned on. We must use SIG_SETMASK 
+    // when the signal waiting thread is turned on. We must use SIG_SETMASK
     // so all threads start with the same signal mask. Otherwise, issues can arise.
-    // For example, on BSD using suspension with signals, the control handler 
-    // routine thread, spawned from the signal handling thread, inherits the 
+    // For example, on BSD using suspension with signals, the control handler
+    // routine thread, spawned from the signal handling thread, inherits the
     // signal handling thread's mask which blocks SIGUSR1. Thus, the
-    // control handler routine thread cannot be suspended. Using SETMASK 
+    // control handler routine thread cannot be suspended. Using SETMASK
     // ensures that SIGUSR1 is not blocked.
-    
+
     iError = pthread_sigmask(SIG_SETMASK, &smDefaultmask, NULL);
     if (iError != 0)
     {
@@ -1009,7 +1009,7 @@ CThreadSuspensionInfo::InitializePreCreate()
 
     // Initialization was successful.
     palError = NO_ERROR;
-    
+
 InitializePreCreateExit:
 
     if (NO_ERROR == palError && 0 != iError)
@@ -1081,11 +1081,11 @@ CThreadSuspensionInfo::~CThreadSuspensionInfo()
 /*++
 Function:
   DestroySemaphoreIds
-  
+
 DestroySemaphoreIds is called from the CThreadSuspensionInfo destructor and
 from PROCCleanupThreadSemIds. If a thread exits before shutdown or is suspended
-during shutdown, its destructor will be invoked and the semaphore ids destroyed. 
-In assert or exceptions situations that are suspension unsafe, 
+during shutdown, its destructor will be invoked and the semaphore ids destroyed.
+In assert or exceptions situations that are suspension unsafe,
 PROCCleanupThreadSemIds is called, which uses DestroySemaphoreIds.
 --*/
 void

--- a/pal/src/thread/tls.cpp
+++ b/pal/src/thread/tls.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -67,9 +67,9 @@ TlsAlloc(
     /* Yes, this could be ever so slightly improved. It's not
        likely to be called enough to matter, though, so we won't
        optimize here until or unless we need to. */
-       
+
     PROCProcessLock();
-    
+
     for(i = 0; i < sizeof(sTlsSlotFields) * 8; i++)
     {
         if ((sTlsSlotFields & ((unsigned __int64) 1 << i)) == 0)
@@ -87,7 +87,7 @@ TlsAlloc(
     {
         dwIndex = i;
     }
-    
+
     PROCProcessUnlock();
 
     LOGEXIT("TlsAlloc returns DWORD %u\n", dwIndex);
@@ -108,10 +108,10 @@ TlsGetValue(
         IN DWORD dwTlsIndex)
 {
     CPalThread *pThread;
-    
+
     PERF_ENTRY(TlsGetValue);
     ENTRY("TlsGetValue()\n");
-    
+
     if (dwTlsIndex == (DWORD) -1 || dwTlsIndex >= TLS_SLOT_SIZE)
     {
         SetLastError(ERROR_INVALID_PARAMETER);
@@ -123,10 +123,10 @@ TlsGetValue(
     /* From MSDN : "The TlsGetValue function calls SetLastError to clear a
        thread's last error when it succeeds." */
     pThread->SetLastError(NO_ERROR);
-    
+
     LOGEXIT("TlsGetValue \n" );
     PERF_EXIT(TlsGetValue);
-    
+
     return pThread->tlsInfo.tlsSlots[dwTlsIndex];
 }
 
@@ -157,7 +157,7 @@ TlsSetValue(
     pThread = InternalGetCurrentThread();
     pThread->tlsInfo.tlsSlots[dwTlsIndex] = lpTlsValue;
     bRet = TRUE;
-    
+
 EXIT:
     LOGEXIT("TlsSetValue returns BOOL %d\n", bRet);
     PERF_EXIT(TlsSetValue);
@@ -181,7 +181,7 @@ TlsFree(
     PERF_ENTRY(TlsFree);
     ENTRY("TlsFree(dwTlsIndex=%u)\n", dwTlsIndex);
 
-    
+
     if (dwTlsIndex == (DWORD) -1 || dwTlsIndex >= TLS_SLOT_SIZE)
     {
         SetLastError(ERROR_INVALID_PARAMETER);
@@ -193,13 +193,13 @@ TlsFree(
     PROCProcessLock();
 
     /* Reset all threads' values to zero for this index. */
-    for(pThread = pGThreadList; 
+    for(pThread = pGThreadList;
         pThread != NULL; pThread = pThread->GetNext())
     {
         pThread->tlsInfo.tlsSlots[dwTlsIndex] = 0;
     }
     sTlsSlotFields &= ~((unsigned __int64) 1 << dwTlsIndex);
-    
+
     PROCProcessUnlock();
 
     LOGEXIT("TlsFree returns BOOL TRUE\n");
@@ -215,7 +215,7 @@ CThreadTLSInfo::InitializePostCreate(
     )
 {
     PAL_ERROR palError = NO_ERROR;
-    
+
     if (pthread_setspecific(thObjKey, reinterpret_cast<void*>(pThread)))
     {
         ASSERT("Unable to set the thread object key's value\n");
@@ -224,4 +224,3 @@ CThreadTLSInfo::InitializePostCreate(
 
     return palError;
 }
-


### PR DESCRIPTION
This PR cleans up the files under `pal` from extra spaces and tabs. In summary, this is a one time 
(hopefully) mechanical change.

I’m also interested with extending CI to prevent extra spaces, tabs and bad styling.