### PR TITLE
LdSuperCtor: Update interpreter error message to match JIT

### DIFF
--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -9179,7 +9179,7 @@ CommonNumber:
 
         if (superCtor == nullptr || !IsConstructor(superCtor))
         {
-            JavascriptError::ThrowTypeError(scriptContext, JSERR_NotAConstructor, L"super");
+            JavascriptError::ThrowTypeError(scriptContext, JSERR_NotAConstructor);
         }
 
         return superCtor;


### PR DESCRIPTION
LdSuperCtor: Update interpreter error message to match JIT

TypeError thrown by operator 'LdSuperCtor' differs in Interpreter vs. in JIT.
Change operator code to align the messages.
