### PR TITLE
Add a copy of the security notice to CONTRIBUTING.md.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,19 +1,22 @@
-## Contributing Code
+# Contributing Code
 
 ChakraCore accepts bug fix pull requests. For a bug fix PR to be accepted, it must first have a tracking issue that has been marked approved. Your PR should link to the bug you are fixing. If you've submitted a PR for a bug, please post a comment in the bug to avoid duplication of effort.
 
 ChakraCore also accepts new feature pull requests. For a feature-level PR to be accepted, it first needs to have design discussion. Design discussion can take one of two forms a) a feature request in the issue tracker that has been marked as approved or b) the PR must be accompanied by a full design spec and this spec is later approved in the open design discussion. Features are evaluated against their complexity, impact on other features, roadmap alignment, and maintainability.
 
-
 These two blogs posts on contributing code to open source projects are a good reference: [Open Source Contribution Etiquette](http://tirania.org/blog/archive/2010/Dec-31.html) by Miguel de Icaza and [Don't "Push" Your Pull Requests](https://www.igvita.com/2011/12/19/dont-push-your-pull-requests/) by Ilya Grigorik.
 
-### Legal
+## Security
+
+If you believe you have found a security issue in ChakraCore, please share it with us privately following the guidance at the Microsoft [Security TechCenter](https://technet.microsoft.com/en-us/security/ff852094). Reporting it via this channel helps minimize risk to projects built with ChakraCore.
+
+## Legal
 
 You will need to complete a Contributor License Agreement (CLA) before your pull request can be accepted. This agreement testifies that you are granting us permission to use the source code you are submitting, and that this work is being submitted under appropriate license that we can use it.
 
 You can complete the CLA by going through the steps at https://cla.microsoft.com. Once we have received the signed CLA, we'll review the request. You will only need to do this once.
 
-### Housekeeping
+## Housekeeping
 
 Your pull request should:
 * Include a description of what your change intends to do
@@ -29,7 +32,7 @@ Submissions that have met these requirements will be assigned to a ChakraCore te
 
 ChakraCore is an organically grown codebase. The consistency of style reflects this. For the most part, the team follows these [coding conventions](https://github.com/Microsoft/ChakraCore/wiki/Coding-Convention). Contributors should also follow them when making submissions. Otherwise, follow the general coding conventions adhered to in the code surrounding your changes. Pull requests that reformat the code will not be accepted.
 
-### Running the tests
+## Running the tests
 
 The unit tests can be run by following these steps:
 * Choose a build configuration to build and test, e.g. debug and x64.
@@ -49,11 +52,11 @@ For full coverage, please run unit tests against debug and test for both x86 and
 
 `runtests.cmd` looks for the build output in the default build output folder `Build\VcBuild\bin`. If the build output path is changed from this default then use the `-bindir` switch to specify that path.
 
-### Code Flow into Microsoft Edge
+## Code Flow into Microsoft Edge
 
 Changes that make it into our ChakraCore GitHub master branch have a short journey to Chakra.dll. Code flows daily from GitHub to the internal repository from which builds of Chakra.dll are produced and then it flows into Windows and Microsoft Edge. While code flows quickly on this first leg of the journey, code flow from our internal branch to a Windows flighting branch is subject to any number of delays. So it is difficult to predict when your change in our GitHub repo will make it into a particular Windows flight.
 
-### Issue Labels
+## Issue Labels
 
  - [`Accepting PRs`](https://github.com/Microsoft/ChakraCore/labels/Accepting%20PRs): these issues are specifically well suited for outside contributors.
  - [`Your first PR`](https://github.com/Microsoft/ChakraCore/labels/Your%20first%20PR): these issues are small and appropriate for people who wish to familiarize themselves with GitHub pull requests and/or ChakraCore's contributor guidelines, build process, and running tests.  We're here to help you get started in open source.


### PR DESCRIPTION
This notice was in the README but not in CONTRIBUTING. @digitalinfinity and I think it is better to be redundant on this one as it is so important, and people opening issues or PRs may be more likely to see it if it is in the link pointed to in the banner that pops up when issues and PRs are opened.