### PR TITLE
LEB128 and Function/Body Split

### DIFF
--- a/lib/WasmReader/ModuleInfo.cpp
+++ b/lib/WasmReader/ModuleInfo.cpp
@@ -107,6 +107,25 @@ ModuleInfo::GetFunctionCount() const
     return m_funcCount;
 }
 
+uint32
+ModuleInfo::AddFunSig(WasmFunctionInfo* funsig)
+{
+    uint32 id = m_funsigs->Count();
+    funsig->SetNumber(id);
+    m_funsigs->Add(funsig);
+    return id;
+}
+
+WasmFunctionInfo*
+ModuleInfo::GetFunSig(uint index) const
+{
+    if (index >= m_funsigs->Count())
+    {
+        return nullptr;
+    }
+    return m_funsigs->GetBuffer()[index];
+}
+
 } // namespace Wasm
 
 #endif // ENABLE_WASM

--- a/lib/WasmReader/ModuleInfo.h
+++ b/lib/WasmReader/ModuleInfo.h
@@ -39,12 +39,17 @@ public:
     void SetFunctionCount(uint count);
     uint GetFunctionCount() const;
 
+    uint32 AddFunSig(WasmFunctionInfo* funsig);
+    WasmFunctionInfo * GetFunSig(uint index) const;
+
 private:
     typedef JsUtil::GrowingArray<WasmSignature*, ArenaAllocator> WasmSignatureArray;
     typedef JsUtil::GrowingArray<uint32, ArenaAllocator> WasmIndirectFuncArray;
+    typedef JsUtil::GrowingArray<WasmFunctionInfo*, ArenaAllocator> WasmFuncSigArray;
 
     WasmSignatureArray * m_signatures;
     WasmIndirectFuncArray * m_indirectfuncs;
+    WasmFuncSigArray * m_funsigs;
 
     uint m_funcCount;
     ArenaAllocator * m_alloc;

--- a/lib/WasmReader/WasmBinaryReader.h
+++ b/lib/WasmReader/WasmBinaryReader.h
@@ -69,7 +69,7 @@ namespace Wasm
             bSectInvalid        = -1,
             bSectMemory         = 0x00,
             bSectSignatures     = 0x01,
-            bSectFunctions      = 0x02,
+            bSectFunSigs        = 0x02,
             bSectGlobals        = 0x03,
             bSectDataSegments   = 0x04,
             bSectIndirectFunctionTable = 0x05,
@@ -77,6 +77,7 @@ namespace Wasm
             bSectStartFunction  = 0x07,
             bSectImportTable    = 0x08,
             bSectExportTable    = 0x09,
+            bSectFunBodies      = 0x0A,
             bSectLimit
         };
 
@@ -104,9 +105,9 @@ namespace Wasm
             struct ReaderState
             {
                 SectionCode secId;
-                UINT count;         // current entry
-                UINT size;          // number of entries
-
+                UINT32 count;         // current entry
+                UINT32 size;          // number of entries
+                UINT32 byteLen;       // byte length of section excluding the LEB128 length field
             };
 
             void ResetModuleData();
@@ -126,13 +127,13 @@ namespace Wasm
             void ReadMemorySection();
             void Signature();
             void FunctionHeader();
+            void FunctionBodyHeader();
             const char* Name(UINT32 offset, UINT &length);
             UINT32 Offset();
-            UINT LEB128(UINT &length);
+            UINT LEB128(UINT &length, bool sgn = false);
+            INT SLEB128(UINT &length);
             template <typename T> T ReadConst();
             SectionCode SectionHeader();
-
-
 
             void CheckBytesLeft(UINT bytesNeeded);
             bool EndOfFunc();

--- a/lib/WasmReader/WasmByteCodeGenerator.cpp
+++ b/lib/WasmReader/WasmByteCodeGenerator.cpp
@@ -1065,7 +1065,7 @@ template<WasmOp wasmOp>
 EmitInfo
 WasmBytecodeGenerator::EmitBr()
 {
-    uint8 depth = m_reader->m_currentNode.br.depth;
+    UINT depth = m_reader->m_currentNode.br.depth;
     Assert(depth < m_labels->Count());
 
     EmitInfo conditionInfo;
@@ -1086,7 +1086,7 @@ WasmBytecodeGenerator::EmitBr()
 
     SListCounted<Js::ByteCodeLabel>::Iterator itr(m_labels);
     itr.Next();
-    for (int i = 0; i < depth; i++) {
+    for (UINT i = 0; i < depth; i++) {
         itr.Next();
     }
     Js::ByteCodeLabel target = itr.Data();

--- a/lib/WasmReader/WasmParseTree.h
+++ b/lib/WasmReader/WasmParseTree.h
@@ -59,7 +59,7 @@ namespace Wasm
 
     struct WasmBlockNode
     {
-        UINT8 count;
+        uint32 count;
     };
 
     struct WasmMemOpNode
@@ -70,14 +70,14 @@ namespace Wasm
 
     struct WasmBrNode
     {
-        UINT8 depth;
+        uint32 depth;
         bool hasSubExpr;
     };
 
     struct WasmTableSwitchNode
     {
-        UINT16 numCases;
-        UINT16 numEntries;
+        uint32 numCases;
+        uint32 numEntries;
         UINT16* jumpTable;
     };
 


### PR DESCRIPTION
- Added decoding of signed LEB128
- Using LEB128 for counts, indices, and offsets in several places
- Splitting up function declaration (function header)
  and function body
