### PR TITLE
Old issue in forward pass objtypespec analysis

### DIFF
--- a/lib/Backend/GlobOptFields.cpp
+++ b/lib/Backend/GlobOptFields.cpp
@@ -2495,7 +2495,12 @@ GlobOpt::ProcessPropOpInTypeCheckSeq(IR::Instr* instr, IR::PropertySymOpnd *opnd
                 opnd->SetCheckedTypeSetIndex(checkedTypeSetIndex);
             }
         }
-        else if (opnd->IsMono() || (valueInfo->GetJsTypeSet() && IsSubsetOf(opndTypeSet, valueInfo->GetJsTypeSet())))
+        else if (valueInfo->GetJsTypeSet() &&
+                 (opnd->IsMono() ? 
+                      valueInfo->GetJsTypeSet()->Contains(opnd->GetFirstEquivalentType()) : 
+                      IsSubsetOf(opndTypeSet, valueInfo->GetJsTypeSet())
+                 )
+            )
         {
             // We have an equivalent type check upstream, but we require a tighter type check at this point.
             // We can't treat the operand as "checked", but check for equivalence with the tighter set and update the

--- a/test/fieldopts/fixedfieldmonocheck5.js
+++ b/test/fieldopts/fixedfieldmonocheck5.js
@@ -1,0 +1,44 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+var shouldBailout = false;
+function test0() {
+    var obj0 = {};
+    var protoObj0 = {};
+    var func0 = function () {
+        ({
+            prop0: typeof Error ? Error : Object,
+            prop5: (shouldBailout ? (Object.defineProperty(this, 'prop5', {
+                set: function () {
+                },
+                configurable: true
+            })) : -216, shouldBailout ? (Object.defineProperty(this, 'prop5', {
+                set: function () {
+                }
+            })) : -216)
+        });
+    };
+    var func1 = function () {
+        return func0(func0()) < protoObj0 >= 0 ? func0(func0()) : 0;
+    };
+    var func2 = function () {
+    };
+    var func4 = function () {
+        return func1();
+    };
+    obj0.method0 = func4;
+    obj0.method1 = obj0.method0;
+    function func7() {
+        func2(func0());
+    }
+    func2(func0());
+    obj0.method1();
+    var uniqobj0 = func7();
+}
+test0();
+shouldBailout = true;
+test0();
+
+WScript.Echo('pass');

--- a/test/fieldopts/rlexe.xml
+++ b/test/fieldopts/rlexe.xml
@@ -859,4 +859,10 @@
       <files>fixedfieldmonocheck4.js</files>
     </default>
   </test>
+  <test>
+    <default>
+      <files>fixedfieldmonocheck5.js</files>
+      <compile-flags>-maxinterpretcount:2 -maxsimplejitruncount:6</compile-flags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
Old issue in forward pass objtypespec analysis exposed by recent backward pass fixes. If we have a monomorphic check upstream and reach a point where a monorphic check expects a different type, we can't replace the checked type in the value info. We have to indicate a type mismatch.