### PR TITLE
Specialize pow when exponent is small integer

### DIFF
--- a/lib/Runtime/Library/JavascriptNumber.cpp
+++ b/lib/Runtime/Library/JavascriptNumber.cpp
@@ -235,7 +235,35 @@ namespace Js
         }
         else if(TryGetInt32Value(y, &intY))
         {
-            return ::pow(x, intY);
+            // For exponent in [-8, 8], aggregate the product according to binary representation
+            // of exponent. This acceleration may lead to significant deviation for larger exponent
+            if (intY >= -8 && intY <= 8)
+            {
+                uint32 uexp;
+                if (intY >= 0)
+                {
+                    uexp = static_cast<uint32>(intY);
+                }
+                else
+                {
+                    uexp = static_cast<uint32>(-intY);
+                }
+                for (double result = 1.0; ; x *= x)
+                {
+                    if ((uexp & 1) != 0)
+                    {
+                        result *= x;
+                    }
+                    if ((uexp >>= 1) == 0)
+                    {
+                        return (intY < 0 ? (1.0 / result) : result);
+                    }
+                }
+            }
+            else
+            {
+                return ::pow(x, intY);
+            }
         }
 
         return ::pow(x, y);

--- a/lib/Runtime/Library/JavascriptNumber.cpp
+++ b/lib/Runtime/Library/JavascriptNumber.cpp
@@ -239,15 +239,7 @@ namespace Js
             // of exponent. This acceleration may lead to significant deviation for larger exponent
             if (intY >= -8 && intY <= 8)
             {
-                uint32 uexp;
-                if (intY >= 0)
-                {
-                    uexp = static_cast<uint32>(intY);
-                }
-                else
-                {
-                    uexp = static_cast<uint32>(-intY);
-                }
+                uint32 uexp = static_cast<uint32>(intY >= 0 ? intY : -intY);
                 for (double result = 1.0; ; x *= x)
                 {
                     if ((uexp & 1) != 0)


### PR DESCRIPTION
The current CRT in Windows 10 specializes pow(double, int) by breaking the result in to product with power of 2, then aggregation the sub-results. This leads to impricision after many float multiply operations so it was just removed from CRT which will regress Chakra performance when the CRT fix reaches public. This change does the same optimization for smaller integer which improves imaging-darkrom in kraken by 11%.