### PR TITLE
instantiateModule Typed Array

### DIFF
--- a/lib/Runtime/Library/WasmLibrary.cpp
+++ b/lib/Runtime/Library/WasmLibrary.cpp
@@ -19,20 +19,20 @@ namespace Js
 
         if (args.Info.Count < 2)
         {
-            JavascriptError::ThrowTypeError(scriptContext, JSERR_NeedArrayBufferObject, L"[Wasm].instantiateModule(arrayBuffer,)");
+            JavascriptError::ThrowTypeError(scriptContext, JSERR_This_NeedTypedArray, L"[Wasm].instantiateModule(typedArray,)");
         }
         if (args.Info.Count < 3)
         {
             JavascriptError::ThrowTypeError(scriptContext, JSERR_NeedObject, L"[Wasm].instantiateModule(,ffi)");
         }
 
-        if (!Js::ArrayBuffer::Is(args[1]))
+        if (!Js::TypedArrayBase::Is(args[1]))
         {
-            JavascriptError::ThrowTypeError(scriptContext, JSERR_NeedArrayBufferObject, L"[Wasm].instantiateModule(arrayBuffer,)");
+            JavascriptError::ThrowTypeError(scriptContext, JSERR_This_NeedTypedArray, L"[Wasm].instantiateModule(typedArray,)");
         }
-        Js::ArrayBuffer* arrayBuffer = Js::ArrayBuffer::FromVar(args[1]);
-        BYTE* buffer = arrayBuffer->GetBuffer();
-        uint byteLength = arrayBuffer->GetByteLength();
+        Js::TypedArrayBase* array = Js::TypedArrayBase::FromVar(args[1]);
+        BYTE* buffer = array->GetByteBuffer();
+        uint byteLength = array->GetByteLength();
 
         if (!Js::JavascriptObject::Is(args[2]))
         {

--- a/test/wasm/basicBinary.js
+++ b/test/wasm/basicBinary.js
@@ -4,6 +4,7 @@
 //-------------------------------------------------------------------------------------------------------
 
 const blob = WScript.LoadBinaryFile('basic.wasm');
-print(blob.byteLength)
-var a = Wasm.instantiateModule(blob, {});
+print(blob.byteLength);
+const moduleBytesView = new Uint8Array(blob);
+var a = Wasm.instantiateModule(moduleBytesView, {});
 print(a.a(11));


### PR DESCRIPTION
instantiateModule now requires a TypedArray instead of an Array buffer

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/486)
<!-- Reviewable:end -->
