### PR TITLE
sectionProcess error handling issue

### DIFF
--- a/lib/WasmReader/WasmByteCodeGenerator.cpp
+++ b/lib/WasmReader/WasmByteCodeGenerator.cpp
@@ -87,7 +87,7 @@ WasmBytecodeGenerator::GenerateModule()
     {
         if (m_reader->ReadNextSection((SectionCode)sectionCode))
         {
-            if (!sectionProcess[sectionCode](this, (SectionCode)sectionCode))
+            if (sectionProcess[sectionCode](this, (SectionCode)sectionCode) == psrInvalid)
             {
                 throw WasmCompilationException(L"Error while reading section %d", sectionCode);
             }


### PR DESCRIPTION
It appears that sectionProcess is testing for a bool instead of
a psr.
