### PR TITLE
linux: re-enable building lib/Parser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ if(CLR_CMAKE_PLATFORM_UNIX)
     add_definitions(
         -DDISABLE_JIT=1
         )
-      
+
     # xplat-todo: revisit these
     # also, we should change this from add_definitions- the intent of that
     # is to just add -D flags
@@ -105,7 +105,7 @@ if(CMAKE_BUILD_TYPE STREQUAL Debug)
         -DDBG=1
         -DDEBUG=1
         -D_DEBUG=1 # for PAL
-        -DDBG_DUMP=1        
+        -DDBG_DUMP=1
     )
     # xplat-todo: reenable this warning
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-writable-strings")
@@ -132,6 +132,11 @@ include_directories(
     pal/inc
     pal/inc/rt
     )
+
+
+add_subdirectory (pal)
+
+# build the rest with NO_PAL_MINMAX
+add_definitions(-DNO_PAL_MINMAX)
 add_subdirectory (lib)
 add_subdirectory (bin)
-add_subdirectory (pal)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,2 +1,2 @@
 add_subdirectory (Common)
-# add_subdirectory (Parser)
+add_subdirectory (Parser)

--- a/lib/Common/Common.h
+++ b/lib/Common/Common.h
@@ -141,10 +141,12 @@ class AutoExpDummyClass
 {
 };
 
-#ifdef _MSC_VER
 #pragma warning(push)
 #if defined(PROFILE_RECYCLER_ALLOC) || defined(HEAP_TRACK_ALLOC) || defined(ENABLE_DEBUG_CONFIG_OPTIONS)
+#ifdef _MSC_VER
 #include <typeinfo.h>
+#else
+#include <typeinfo>
+#endif
 #endif
 #pragma warning(pop)
-#endif

--- a/lib/Common/Core/CommonMinMax.h
+++ b/lib/Common/Core/CommonMinMax.h
@@ -4,7 +4,6 @@
 //-------------------------------------------------------------------------------------------------------
 #pragma once
 
-#ifndef USING_PAL_MINMAX
 template<class T> inline
 _Post_equal_to_(a < b ? a : b) _Post_satisfies_(return <= a && return <= b)
     const T& min(const T& a, const T& b) { return a < b ? a : b; }
@@ -12,4 +11,3 @@ _Post_equal_to_(a < b ? a : b) _Post_satisfies_(return <= a && return <= b)
 template<class T> inline
 _Post_equal_to_(a > b ? a : b) _Post_satisfies_(return >= a && return >= b)
     const T& max(const T& a, const T& b) { return a > b ? a : b; }
-#endif

--- a/lib/Common/DataStructures/DictionaryEntry.h
+++ b/lib/Common/DataStructures/DictionaryEntry.h
@@ -176,14 +176,14 @@ namespace JsUtil
         template<typename Comparer, typename TLookup>
         __inline bool KeyEquals(TLookup const& otherKey, hash_t otherHashCode)
         {
-            Assert(TAGHASH(Comparer::GetHashCode(Key())) == this->hashCode);
+            Assert(TAGHASH(Comparer::GetHashCode(this->Key())) == this->hashCode);
             return this->hashCode == otherHashCode && Comparer::Equals(this->Key(), otherKey);
         }
 
         template<typename Comparer>
         __inline hash_t GetHashCode()
         {
-            Assert(TAGHASH(Comparer::GetHashCode(Key())) == this->hashCode);
+            Assert(TAGHASH(Comparer::GetHashCode(this->Key())) == this->hashCode);
             return hashCode;
         }
 

--- a/lib/Common/DataStructures/SList.h
+++ b/lib/Common/DataStructures/SList.h
@@ -231,8 +231,8 @@ public:
         NodeBase * UnlinkCurrentNode()
         {
             NodeBase * unlinkedNode = const_cast<NodeBase *>(this->current);
-            Assert(current != nullptr);
-            Assert(!list->IsHead(this->current));
+            Assert(this->current != nullptr);
+            Assert(!this->list->IsHead(this->current));
             Assert(last != nullptr);
 
             const_cast<NodeBase *>(last)->Next() = this->current->Next();

--- a/lib/Common/Memory/RecyclerPointers.h
+++ b/lib/Common/Memory/RecyclerPointers.h
@@ -146,12 +146,6 @@ private:
 };
 }
 
-#if USING_PAL_MINMAX
-#pragma push_macro("min")
-#pragma push_macro("max")
-#undef min
-#undef max
-#endif
 
 template<class T> inline
 const T& min(const T& a, const NoWriteBarrierField<T>& b) { return a < b ? a : b; }
@@ -172,10 +166,6 @@ const T& max(const T& a, const NoWriteBarrierField<T>& b) { return a > b ? a : b
 template<class T> inline
 const T& max(const NoWriteBarrierField<T>& a, const NoWriteBarrierField<T>& b) { return a > b ? a : b; }
 
-#if USING_PAL_MINMAX
-#pragma pop_macro("min")
-#pragma pop_macro("max")
-#endif
 
 // Disallow memcpy, memmove of WriteBarrierPtr
 

--- a/lib/Runtime/Base/CompactCounters.h
+++ b/lib/Runtime/Base/CompactCounters.h
@@ -9,29 +9,32 @@
 
 namespace Js
 {
-    template<class T, typename CountT = T::CounterFields>
+    template<class T, typename CountT = typename T::CounterFields>
     struct CompactCounters
-    {    
+    {
+        // requires an integral type constant to use as array size
+        static const int CountTMax = static_cast<int>(CountT::Max);
+
         struct Fields {
             union {
-                uint8 u8Fields[CountT::Max];
-                int8 i8Fields[CountT::Max];
-                uint16 u16Fields[CountT::Max];
-                int16 i16Fields[CountT::Max];
-                uint32 u32Fields[CountT::Max];
-                int32 i32Fields[CountT::Max];
+                uint8 u8Fields[CountTMax];
+                int8 i8Fields[CountTMax];
+                uint16 u16Fields[CountTMax];
+                int16 i16Fields[CountTMax];
+                uint32 u32Fields[CountTMax];
+                int32 i32Fields[CountTMax];
             };
             Fields() {}
         };
 
         uint8 fieldSize;
 #if DBG
-    
+
         mutable bool bgThreadCallStarted;
         bool isCleaningUp;
-#endif    
+#endif
         WriteBarrierPtr<Fields> fields;
-    
+
         CompactCounters() { }
         CompactCounters(T* host)
             :fieldSize(sizeof(uint8))
@@ -99,7 +102,7 @@ namespace Js
         }
 
         uint32 Set(CountT typeEnum, uint32 val, T* host)
-        {            
+        {
             Assert(bgThreadCallStarted == false || isCleaningUp == true);
 
             uint8 type = static_cast<uint8>(typeEnum);

--- a/lib/Runtime/Base/CrossSiteObject.h
+++ b/lib/Runtime/Base/CrossSiteObject.h
@@ -223,13 +223,13 @@ namespace Js
     template <typename T>
     void CrossSiteObject<T>::RemoveFromPrototype(ScriptContext * requestContext)
     {
-        __super::RemoveFromPrototype(GetScriptContext());
+        __super::RemoveFromPrototype(this->GetScriptContext());
     }
 
     template <typename T>
     void CrossSiteObject<T>::AddToPrototype(ScriptContext * requestContext)
     {
-        __super::AddToPrototype(GetScriptContext());
+        __super::AddToPrototype(this->GetScriptContext());
     }
 
     template <typename T>

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -462,7 +462,7 @@ namespace Js
         typedef JsUtil::List<NativeOffsetInlineeFramePair, HeapAllocator> InlineeFrameMap;
         InlineeFrameMap*  inlineeFrameMap;
 #endif
-#ifdef ENABLE_DEBUG_CONFIG_OPTIONS
+#ifdef STACK_BACK_TRACE
         StackBackTrace*    cleanupStack;
 #endif
 
@@ -496,7 +496,7 @@ namespace Js
         uint32 pendingPolymorphicCacheState;
 #endif
         State state; // Single state member so users can query state w/o a lock
-#if ENABLE_DEBUG_CONFIG_OPTIONS
+#ifdef STACK_BACK_TRACE
         CleanupReason cleanupReason;
 #endif
         BYTE   pendingInlinerVersion;
@@ -522,7 +522,7 @@ namespace Js
             isLoopBody(isLoopBody), hasJittedStackClosure(false), registeredEquivalentTypeCacheRef(nullptr), bailoutRecordMap(nullptr),
 #endif
             library(library), codeSize(0), nativeAddress(nullptr), isAsmJsFunction(false), validationCookie(validationCookie)
-#ifdef ENABLE_DEBUG_CONFIG_OPTIONS
+#ifdef STACK_BACK_TRACE
             , cleanupStack(nullptr)
             , cleanupReason(NotCleanedUp)
 #endif
@@ -636,7 +636,7 @@ namespace Js
             this->state = PendingCleanup;
         }
 
-#if ENABLE_DEBUG_CONFIG_OPTIONS
+#ifdef STACK_BACK_TRACE
         void SetCleanupReason(CleanupReason reason)
         {
             this->cleanupReason = reason;
@@ -1706,7 +1706,7 @@ namespace Js
                 FuncExprScopeRegister                   = 21,
                 FirstTmpRegister                        = 22,
 
-                // Signed integers need keep the sign when promoting 
+                // Signed integers need keep the sign when promoting
                 SignedFieldsStart                       = 23,
                 SerializationIndex                      = 23,
 

--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -1353,6 +1353,7 @@ private:
 #if DBG
         SourceContextInfo const * GetNoContextSourceContextInfo() const { return cache->noContextSourceContextInfo; }
 
+#ifdef ENABLE_SCRIPT_PROFILING
         int GetProfileSession()
         {
             AssertMsg(m_pProfileCallback != nullptr, "Asking for profile session when we aren't in one.");
@@ -1369,6 +1370,7 @@ private:
         {
             AssertMsg(m_pProfileCallback == nullptr, "How to stop when there is still the callback out there");
         }
+#endif // ENABLE_SCRIPT_PROFILING
 
         bool hadProfiled;
         bool HadProfiled() const { return hadProfiled; }

--- a/lib/Runtime/Base/ThreadContext.h
+++ b/lib/Runtime/Base/ThreadContext.h
@@ -588,8 +588,10 @@ private:
     JsUtil::ThreadService threadService;
     uint callRootLevel;
 
+#if ENABLE_BACKGROUND_PAGE_FREEING
     // The thread page allocator is used by the recycler and need the background page queue
     PageAllocator::BackgroundPageQueue backgroundPageQueue;
+#endif
     IdleDecommitPageAllocator pageAllocator;
     Recycler* recycler;
 

--- a/lib/Runtime/Language/JavascriptConversion.inl
+++ b/lib/Runtime/Language/JavascriptConversion.inl
@@ -5,7 +5,9 @@
 #pragma once
 
 #if defined(_M_IX86) || defined(_M_X64)
+#ifdef _WIN32
 #include <emmintrin.h>
+#endif
 #endif
 
 namespace Js {

--- a/lib/Runtime/Language/JavascriptExceptionObject.h
+++ b/lib/Runtime/Language/JavascriptExceptionObject.h
@@ -28,7 +28,7 @@ namespace Js {
             {
                 memset(&exceptionContext, 0, sizeof(exceptionContext));
             }
-#if DBG
+#ifdef STACK_BACK_TRACE
             this->stackBackTrace = nullptr;
 #endif
         }
@@ -51,7 +51,7 @@ namespace Js {
         {
             return &exceptionContext;
         }
-#if DBG
+#ifdef STACK_BACK_TRACE
         void FillStackBackTrace();
 #endif
 
@@ -179,7 +179,7 @@ namespace Js {
         HostWrapperCreateFuncType hostWrapperCreateFunc;
 
         JavascriptExceptionContext exceptionContext;
-#if DBG
+#ifdef STACK_BACK_TRACE
         StackBackTrace * stackBackTrace;
         static const int StackToSkip = 2;
         static const int StackTraceDepth = 30;

--- a/lib/Runtime/Language/ModuleRecordBase.h
+++ b/lib/Runtime/Language/ModuleRecordBase.h
@@ -7,9 +7,10 @@
 namespace Js
 {
     class ModuleRecordBase;
+    class ModuleNamespace;
     typedef SList<PropertyId> ExportedNames;
     typedef SList<ModuleRecordBase*> ExportModuleRecordList;
-    typedef struct ModuleNameRecord
+    struct ModuleNameRecord
     {
         ModuleRecordBase* module;
         PropertyId bindingName;

--- a/lib/Runtime/Library/JavascriptArray.inl
+++ b/lib/Runtime/Library/JavascriptArray.inl
@@ -1209,23 +1209,22 @@ SECOND_PASS:
             {
                 Assert(current == head);
             }
-
+        }
 
 #ifdef VALIDATE_ARRAY
 SECOND_PASS:
-            if (!first_pass)
+        if (!first_pass)
+        {
+            current = (SparseArraySegment<T>*)this->GetBeginLookupSegment(itemIndex, false);
+            // If it doesn't fit in current chunk (watch for overflow), start from beginning as we'll
+            // need the prev
+            if (current->left + current->size > current->left || itemIndex >= current->left + current->size)
             {
-                current = (SparseArraySegment<T>*)this->GetBeginLookupSegment(itemIndex, false);
-                // If it doesn't fit in current chunk (watch for overflow), start from beginning as we'll
-                // need the prev
-                if (current->left + current->size > current->left || itemIndex >= current->left + current->size)
-                {
-                    current = (SparseArraySegment<T>*)head;
-                }
-                prev = nullptr;
+                current = (SparseArraySegment<T>*)head;
             }
-#endif
+            prev = nullptr;
         }
+#endif
 
         uint probeCost = 0;
         while(current != nullptr)

--- a/pal/inc/pal.h
+++ b/pal/inc/pal.h
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -29,7 +29,7 @@ Abstract:
 
     If you want to add a PAL_ wrapper function to a native function in
     here, you also need to edit palinternal.h and win32pal.h.
-    
+
 
 
 --*/
@@ -177,7 +177,7 @@ extern "C" {
 #if defined(_MSC_VER) || defined(__llvm__)
 #define DECLSPEC_ALIGN(x)   __declspec(align(x))
 #else
-#define DECLSPEC_ALIGN(x) 
+#define DECLSPEC_ALIGN(x)
 #endif
 
 #define DECLSPEC_NORETURN   PAL_NORETURN
@@ -333,7 +333,7 @@ PALIMPORT
 BOOL
 PALAPI
 PAL_IsDebuggerPresent();
- 
+
 #define MAXIMUM_SUSPEND_COUNT  MAXCHAR
 
 #define CHAR_BIT      8
@@ -486,7 +486,7 @@ typedef long time_t;
 #define PAL_INITIALIZE                 PAL_INITIALIZE_SYNC_THREAD
 
 // PAL_InitializeDLL() flags - don't start any of the helper threads
-#define PAL_INITIALIZE_DLL             PAL_INITIALIZE_NONE       
+#define PAL_INITIALIZE_DLL             PAL_INITIALIZE_NONE
 
 // PAL_InitializeChakraCore() flags
 #define PAL_INITIALIZE_CHAKRACORE         (PAL_INITIALIZE | PAL_INITIALIZE_EXEC_ALLOCATOR)
@@ -606,7 +606,7 @@ PAL_RegisterModule(
     IN LPCSTR lpLibFileName);
 
 PALIMPORT
-VOID 
+VOID
 PALAPI
 PAL_UnregisterModule(
     IN HINSTANCE hInstance);
@@ -643,7 +643,7 @@ PAL_Random(
 // if an address lies inside CoreCLR or not.
 //
 // This shouldnt be used by any other component that links into the PAL.
-PALIMPORT 
+PALIMPORT
 BOOL
 PALAPI
 PAL_IsIPInCoreCLR(IN PVOID address);
@@ -1066,7 +1066,7 @@ RemoveDirectoryA(
 #define RemoveDirectory RemoveDirectoryA
 #endif
 
-typedef struct _BY_HANDLE_FILE_INFORMATION {  
+typedef struct _BY_HANDLE_FILE_INFORMATION {
     DWORD dwFileAttributes;
     FILETIME ftCreationTime;
     FILETIME ftLastAccessTime;
@@ -3407,7 +3407,7 @@ GetThreadTimes(
         OUT LPFILETIME lpExitTime,
         OUT LPFILETIME lpKernelTime,
         OUT LPFILETIME lpUserTime);
-		
+
 #define TLS_OUT_OF_INDEXES ((DWORD)0xFFFFFFFF)
 
 PALIMPORT
@@ -3460,9 +3460,9 @@ typedef BOOL (*ReadMemoryWordCallback)(SIZE_T address, SIZE_T *value);
 #if defined(_AMD64_) || defined(_ARM_) || defined(_ARM64_)
 PALIMPORT BOOL PALAPI PAL_VirtualUnwind(CONTEXT *context, KNONVOLATILE_CONTEXT_POINTERS *contextPointers);
 
-PALIMPORT BOOL PALAPI PAL_VirtualUnwindOutOfProc(CONTEXT *context, 
-                                                 KNONVOLATILE_CONTEXT_POINTERS *contextPointers, 
-                                                 DWORD pid, 
+PALIMPORT BOOL PALAPI PAL_VirtualUnwindOutOfProc(CONTEXT *context,
+                                                 KNONVOLATILE_CONTEXT_POINTERS *contextPointers,
+                                                 DWORD pid,
                                                  ReadMemoryWordCallback readMemCallback);
 #endif
 
@@ -3490,14 +3490,14 @@ PALIMPORT BOOL PALAPI PAL_VirtualUnwindOutOfProc(CONTEXT *context,
 #define PAL_CS_NATIVE_DATA_SIZE 80
 #elif defined(__LINUX__) && defined(_ARM64_)
 #define PAL_CS_NATIVE_DATA_SIZE 116
-#else 
-#warning 
+#else
+#warning
 #error  PAL_CS_NATIVE_DATA_SIZE is not defined for this architecture
 #endif
-    
+
 #endif // PLATFORM_UNIX
 
-// 
+//
 typedef struct _CRITICAL_SECTION {
     PVOID DebugInfo;
     LONG LockCount;
@@ -3511,10 +3511,10 @@ typedef struct _CRITICAL_SECTION {
     volatile DWORD dwInitState;
     union CSNativeDataStorage
     {
-        BYTE rgNativeDataStorage[PAL_CS_NATIVE_DATA_SIZE]; 
+        BYTE rgNativeDataStorage[PAL_CS_NATIVE_DATA_SIZE];
         VOID * pvAlign; // make sure the storage is machine-pointer-size aligned
-    } csnds;    
-#endif // PLATFORM_UNIX    
+    } csnds;
+#endif // PLATFORM_UNIX
 } CRITICAL_SECTION, *PCRITICAL_SECTION, *LPCRITICAL_SECTION;
 
 PALIMPORT VOID PALAPI EnterCriticalSection(IN OUT LPCRITICAL_SECTION lpCriticalSection);
@@ -3635,7 +3635,7 @@ MapViewOfFileEx(
           IN DWORD dwFileOffsetLow,
           IN SIZE_T dwNumberOfBytesToMap,
           IN LPVOID lpBaseAddress);
-          
+
 PALIMPORT
 BOOL
 PALAPI
@@ -3721,7 +3721,7 @@ Return value:
     TRUE - success
     FALSE - failure (incorrect ptr, etc.)
 --*/
-BOOL 
+BOOL
 PALAPI
 PAL_LOADUnloadPEFile(void * ptr);
 
@@ -3798,7 +3798,7 @@ GetModuleFileNameExW(
 #define GetModuleFileNameEx GetModuleFileNameExW
 #endif
 
-// Get base address of the module containing a given symbol 
+// Get base address of the module containing a given symbol
 PALAPI
 LPCVOID
 PAL_GetSymbolModuleBase(void *symbol);
@@ -3841,7 +3841,7 @@ typedef struct _MEMORYSTATUSEX {
   DWORDLONG ullAvailExtendedVirtual;
 } MEMORYSTATUSEX, *LPMEMORYSTATUSEX;
 
-PALIMPORT 
+PALIMPORT
 BOOL
 PALAPI
 GlobalMemoryStatusEx(
@@ -4018,11 +4018,11 @@ GetStringTypeExW(
 #endif // __APPLE__
 
 
-typedef struct nlsversioninfo { 
-  DWORD     dwNLSVersionInfoSize; 
-  DWORD     dwNLSVersion; 
-  DWORD     dwDefinedVersion; 
-} NLSVERSIONINFO, *LPNLSVERSIONINFO; 
+typedef struct nlsversioninfo {
+  DWORD     dwNLSVersionInfoSize;
+  DWORD     dwNLSVersion;
+  DWORD     dwDefinedVersion;
+} NLSVERSIONINFO, *LPNLSVERSIONINFO;
 
 #define CSTR_LESS_THAN     1
 #define CSTR_EQUAL         2
@@ -4114,7 +4114,7 @@ BOOL
 PALAPI
 IsValidCodePage(
         IN UINT CodePage);
-        
+
 
 #define MB_PRECOMPOSED            0x00000001
 #define MB_ERR_INVALID_CHARS      0x00000008
@@ -4325,7 +4325,7 @@ GetThreadLocale(
 #define LOCALE_SSCRIPTS               0x0000006c    /* Typical scripts in the locale */
 #define LOCALE_SPARENT                0x0000006d    /* Fallback name for resources */
 #define LOCALE_SCONSOLEFALLBACKNAME   0x0000006e    /* Fallback name for within the console */
-#define LOCALE_SLANGDISPLAYNAME       0x0000006f    /* Language Display Name for a language */ 
+#define LOCALE_SLANGDISPLAYNAME       0x0000006f    /* Language Display Name for a language */
 #define LOCALE_IREADINGLAYOUT         0x00000070   // Returns one of the following 4 reading layout values:
                                                    // 0 - Left to right (eg en-US)
                                                    // 1 - Right to left (eg arabic locales)
@@ -4438,36 +4438,36 @@ GetLocaleInfoEx(
 
 
 PALIMPORT
-int 
+int
 PALAPI
 CompareStringOrdinal(
-    IN LPCWSTR lpString1, 
-	IN int cchCount1, 
-	IN LPCWSTR lpString2, 
-	IN int cchCount2, 
+    IN LPCWSTR lpString1,
+	IN int cchCount1,
+	IN LPCWSTR lpString2,
+	IN int cchCount2,
 	IN BOOL bIgnoreCase);
 
-typedef struct _nlsversioninfoex { 
-  DWORD  dwNLSVersionInfoSize; 
-  DWORD  dwNLSVersion; 
-  DWORD  dwDefinedVersion; 
-  DWORD  dwEffectiveId;   
-  GUID  guidCustomVersion; 
-  } NLSVERSIONINFOEX, *LPNLSVERSIONINFOEX; 
+typedef struct _nlsversioninfoex {
+  DWORD  dwNLSVersionInfoSize;
+  DWORD  dwNLSVersion;
+  DWORD  dwDefinedVersion;
+  DWORD  dwEffectiveId;
+  GUID  guidCustomVersion;
+  } NLSVERSIONINFOEX, *LPNLSVERSIONINFOEX;
 
 PALIMPORT
-int 
+int
 PALAPI
 FindNLSStringEx(
-    IN LPCWSTR lpLocaleName, 
-	IN DWORD dwFindNLSStringFlags, 
-	IN LPCWSTR lpStringSource, 
-	IN int cchSource, 
-    IN LPCWSTR lpStringValue, 
-	IN int cchValue, 
-	OUT LPINT pcchFound, 
-	IN LPNLSVERSIONINFOEX lpVersionInformation, 
-	IN LPVOID lpReserved, 
+    IN LPCWSTR lpLocaleName,
+	IN DWORD dwFindNLSStringFlags,
+	IN LPCWSTR lpStringSource,
+	IN int cchSource,
+    IN LPCWSTR lpStringValue,
+	IN int cchValue,
+	OUT LPINT pcchFound,
+	IN LPNLSVERSIONINFOEX lpVersionInformation,
+	IN LPVOID lpReserved,
 	IN LPARAM lParam );
 
 typedef enum {
@@ -4475,13 +4475,13 @@ typedef enum {
 } NLS_FUNCTION;
 
 PALIMPORT
-BOOL 
+BOOL
 PALAPI
 IsNLSDefinedString(
-    IN NLS_FUNCTION Function, 
-	IN DWORD dwFlags, 
-	IN LPNLSVERSIONINFOEX lpVersionInfo, 
-	IN LPCWSTR lpString, 
+    IN NLS_FUNCTION Function,
+	IN DWORD dwFlags,
+	IN LPNLSVERSIONINFOEX lpVersionInfo,
+	IN LPCWSTR lpString,
 	IN int cchStr );
 
 
@@ -4494,7 +4494,7 @@ ResolveLocaleName(
         IN int cchLocaleName );
 
 PALIMPORT
-BOOL 
+BOOL
 PALAPI
 GetThreadPreferredUILanguages(
     IN DWORD  dwFlags,
@@ -4504,10 +4504,10 @@ GetThreadPreferredUILanguages(
 
 
 PALIMPORT
-int 
+int
 PALAPI
 GetSystemDefaultLocaleName(
-    OUT LPWSTR lpLocaleName, 
+    OUT LPWSTR lpLocaleName,
 	IN int cchLocaleName);
 
 #ifdef UNICODE
@@ -4736,8 +4736,8 @@ LCMapStringEx(
     IN int     cchSrc,
     OUT LPWSTR lpDestStr,
     IN int     cchDest,
-    IN LPNLSVERSIONINFO lpVersionInformation, 
-    IN LPVOID lpReserved, 
+    IN LPNLSVERSIONINFO lpVersionInformation,
+    IN LPVOID lpReserved,
     IN LPARAM lParam );
 
 PALIMPORT
@@ -4801,7 +4801,7 @@ PALIMPORT int PALAPI PAL_FormatScientific(LPCWSTR sLocale, LPWSTR pBuffer, SIZE_
 PALIMPORT int PALAPI  PAL_FormatCurrency(LPCWSTR sLocale, LPWSTR pBuffer, SIZE_T cchBuffer, PALNUMBER number, int nMinDigits, int nMaxDigits, int iNegativeFormat, int iPositiveFormat,
                       int iPrimaryGroup, int iSecondaryGroup, LPCWSTR sCurrencyDecimal, LPCWSTR sCurrencyGroup, LPCWSTR sNegative, LPCWSTR sCurrency, LPCWSTR sZero);
 
-PALIMPORT int PALAPI  PAL_FormatPercent(LPCWSTR sLocale, LPWSTR pBuffer, SIZE_T cchBuffer, PALNUMBER number,  int nMinDigits, int nMaxDigits,int iNegativeFormat, int iPositiveFormat, 
+PALIMPORT int PALAPI  PAL_FormatPercent(LPCWSTR sLocale, LPWSTR pBuffer, SIZE_T cchBuffer, PALNUMBER number,  int nMinDigits, int nMaxDigits,int iNegativeFormat, int iPositiveFormat,
                       int iPrimaryGroup, int iSecondaryGroup, LPCWSTR sPercentDecimal, LPCWSTR sPercentGroup, LPCWSTR sNegative, LPCWSTR sPercent, LPCWSTR sZero);
 
 PALIMPORT int PALAPI  PAL_FormatDecimal(LPCWSTR sLocale, LPWSTR pBuffer, SIZE_T cchBuffer, PALNUMBER number, int nMinDigits, int nMaxDigits, int iNegativeFormat,
@@ -4952,7 +4952,7 @@ WriteProcessMemory(IN HANDLE hProcess,
 
 #define EVENT_MODIFY_STATE        (0x0002)
 #define EVENT_ALL_ACCESS          (STANDARD_RIGHTS_REQUIRED | SYNCHRONIZE | \
-                                   0x3) 
+                                   0x3)
 
 #define MUTANT_QUERY_STATE        (0x0001)
 #define MUTANT_ALL_ACCESS         (STANDARD_RIGHTS_REQUIRED | SYNCHRONIZE | \
@@ -4963,18 +4963,18 @@ WriteProcessMemory(IN HANDLE hProcess,
 #define SEMAPHORE_ALL_ACCESS      (STANDARD_RIGHTS_REQUIRED | SYNCHRONIZE | \
                                    0x3)
 
-#define PROCESS_TERMINATE         (0x0001)  
-#define PROCESS_CREATE_THREAD     (0x0002)  
-#define PROCESS_SET_SESSIONID     (0x0004)  
-#define PROCESS_VM_OPERATION      (0x0008)  
-#define PROCESS_VM_READ           (0x0010)  
-#define PROCESS_VM_WRITE          (0x0020)  
-#define PROCESS_DUP_HANDLE        (0x0040)  
-#define PROCESS_CREATE_PROCESS    (0x0080)  
-#define PROCESS_SET_QUOTA         (0x0100)  
-#define PROCESS_SET_INFORMATION   (0x0200)  
-#define PROCESS_QUERY_INFORMATION (0x0400)  
-#define PROCESS_SUSPEND_RESUME    (0x0800)  
+#define PROCESS_TERMINATE         (0x0001)
+#define PROCESS_CREATE_THREAD     (0x0002)
+#define PROCESS_SET_SESSIONID     (0x0004)
+#define PROCESS_VM_OPERATION      (0x0008)
+#define PROCESS_VM_READ           (0x0010)
+#define PROCESS_VM_WRITE          (0x0020)
+#define PROCESS_DUP_HANDLE        (0x0040)
+#define PROCESS_CREATE_PROCESS    (0x0080)
+#define PROCESS_SET_QUOTA         (0x0100)
+#define PROCESS_SET_INFORMATION   (0x0200)
+#define PROCESS_QUERY_INFORMATION (0x0400)
+#define PROCESS_SUSPEND_RESUME    (0x0800)
 #define PROCESS_ALL_ACCESS        (STANDARD_RIGHTS_REQUIRED | SYNCHRONIZE | \
                                    0xFFF)
 
@@ -5340,12 +5340,12 @@ simultaneously.
 
 Parameters
 
-lpAddend 
-[in/out] Pointer to the variable to increment. 
+lpAddend
+[in/out] Pointer to the variable to increment.
 
 Return Values
 
-The return value is the resulting incremented value. 
+The return value is the resulting incremented value.
 
 --*/
 EXTERN_C
@@ -5369,7 +5369,7 @@ InterlockedIncrement16(
 {
     return __sync_add_and_fetch(lpAddend, (SHORT)1);
 }
-    
+
 EXTERN_C
 PALIMPORT
 inline
@@ -5392,8 +5392,8 @@ simultaneously.
 
 Parameters
 
-lpAddend 
-[in/out] Pointer to the variable to decrement. 
+lpAddend
+[in/out] Pointer to the variable to decrement.
 
 Return Values
 
@@ -5432,15 +5432,15 @@ variable simultaneously.
 
 Parameters
 
-Target 
+Target
 [in/out] Pointer to the value to exchange. The function sets
 this variable to Value, and returns its prior value.
-Value 
-[in] Specifies a new value for the variable pointed to by Target. 
+Value
+[in] Specifies a new value for the variable pointed to by Target.
 
 Return Values
 
-The function returns the initial value pointed to by Target. 
+The function returns the initial value pointed to by Target.
 
 --*/
 EXTERN_C
@@ -5595,9 +5595,9 @@ InterlockedAdd(
     IN OUT LONG volatile *Addend,
     IN LONG Value)
 {
-    return InterlockedExchangeAdd(Addend, Value) + Value; 
+    return InterlockedExchangeAdd(Addend, Value) + Value;
 }
-    
+
 EXTERN_C
 PALIMPORT
 inline
@@ -5636,7 +5636,7 @@ InterlockedOr(
 
 #define BITS_IN_BYTE 8
 #define BITS_IN_LONG (sizeof(LONG) * BITS_IN_BYTE)
-  
+
 EXTERN_C
 PALIMPORT
 inline
@@ -5649,7 +5649,7 @@ InterlockedBitTestAndReset(
     // The BitTestAndReset family of functions allow for arbitrary bit
     // indices- so a bit index can be greater than the number of bits in
     // LONG. We need to account for this in all BitTest/BitTestAndSet
-    // related functions.    
+    // related functions.
     volatile LONG* longToTest = Base + (Bit / BITS_IN_LONG);
     LONG bitToTest  = Bit % BITS_IN_LONG;
     return (InterlockedAnd(longToTest, ~(1 << bitToTest)) & (1 << bitToTest)) != 0;
@@ -5668,7 +5668,7 @@ InterlockedBitTestAndSet(
     LONG bitToTest  = Bit % BITS_IN_LONG;
     return (InterlockedOr(longToTest, (1 << bitToTest)) & (1 << bitToTest)) != 0;
 }
-  
+
 EXTERN_C
 PALIMPORT
 inline
@@ -5682,7 +5682,7 @@ BitTest(
     LONG bitToTest  = Bit % BITS_IN_LONG;
     return ((*longToTest) & (1 << bitToTest)) != 0;
 }
-  
+
 EXTERN_C
 PALIMPORT
 inline
@@ -5698,7 +5698,7 @@ BitTestAndSet(
     LONG bitToTest  = Bit % BITS_IN_LONG;
 
     // Save whether the bit was set or not. Then, unconditionally set the
-    // bit. Return whether the bit was set or not.   
+    // bit. Return whether the bit was set or not.
     UCHAR wasBitSet = (((*longToTest) & (1 << bitToTest)) != 0);
     *longToTest = *longToTest | (1 << bitToTest);
     return wasBitSet;
@@ -5758,7 +5758,7 @@ PALIMPORT
 BOOL
 PALAPI
 PAL_HasGetCurrentProcessorNumber();
-    
+
 #define FORMAT_MESSAGE_ALLOCATE_BUFFER 0x00000100
 #define FORMAT_MESSAGE_IGNORE_INSERTS  0x00000200
 #define FORMAT_MESSAGE_FROM_STRING     0x00000400
@@ -5806,23 +5806,23 @@ GetCommandLineW(
 #endif
 
 PALIMPORT
-VOID 
-PALAPI 
+VOID
+PALAPI
 RtlRestoreContext(
   IN PCONTEXT ContextRecord,
   IN PEXCEPTION_RECORD ExceptionRecord
 );
 
 PALIMPORT
-VOID 
-PALAPI 
+VOID
+PALAPI
 RtlCaptureContext(
   OUT PCONTEXT ContextRecord
 );
 
 PALIMPORT
-UINT 
-PALAPI 
+UINT
+PALAPI
 GetWriteWatch(
   IN DWORD dwFlags,
   IN PVOID lpBaseAddress,
@@ -5833,16 +5833,16 @@ GetWriteWatch(
 );
 
 PALIMPORT
-UINT 
-PALAPI 
+UINT
+PALAPI
 ResetWriteWatch(
   IN LPVOID lpBaseAddress,
   IN SIZE_T dwRegionSize
 );
 
 PALIMPORT
-VOID 
-PALAPI 
+VOID
+PALAPI
 FlushProcessWriteBuffers();
 
 typedef void (*PAL_ActivationFunction)(CONTEXT *context);
@@ -6173,7 +6173,7 @@ CoCreateGuid(OUT GUID * pguid);
 #define _wcstoui64    PAL__wcstoui64
 #define _flushall     PAL__flushall
 
-#ifdef _AMD64_ 
+#ifdef _AMD64_
 #define _mm_getcsr    PAL__mm_getcsr
 #define _mm_setcsr    PAL__mm_setcsr
 #endif // _AMD64_
@@ -6358,7 +6358,7 @@ unsigned int __cdecl _rotr(unsigned int value, int shift)
 }
 
 PALIMPORT int __cdecl abs(int);
-PALIMPORT double __cdecl fabs(double); 
+PALIMPORT double __cdecl fabs(double);
 #ifndef PAL_STDCPP_COMPAT
 PALIMPORT LONG __cdecl labs(LONG);
 PALIMPORT double __cdecl fabs(double);
@@ -6433,9 +6433,7 @@ PALIMPORT char * __cdecl _strdup(const char *);
 #define max(a, b) (((a) > (b)) ? (a) : (b))
 #define min(a, b) (((a) < (b)) ? (a) : (b))
 #endif
-    
-#define USING_PAL_MINMAX 1
-    
+
 #endif // !PAL_STDCPP_COMPAT
 
 PALIMPORT PAL_NORETURN void __cdecl exit(int);
@@ -6647,7 +6645,7 @@ typedef enum _PAL_Boundary {
     PAL_BoundaryTop,            // closer to main()
     PAL_BoundaryBottom,         // closer to execution
     PAL_BoundaryEH,             // out-of-band during EH
-    
+
     PAL_BoundaryMax = PAL_BoundaryEH
 } PAL_Boundary;
 
@@ -6756,10 +6754,10 @@ public:
     {
         return m_palError;
     }
-    
+
     void SuppressRelease()
     {
-        // Used to avoid calling PAL_Leave() when 
+        // Used to avoid calling PAL_Leave() when
         // another code path will explicitly do so.
         m_fEntered = FALSE;
     }
@@ -6835,12 +6833,12 @@ public:
 
     PAL_SEHException()
     {
-    }    
+    }
 
     PAL_SEHException(const PAL_SEHException& ex)
     {
         *this = ex;
-    }    
+    }
 
     bool IsFirstPass()
     {
@@ -6856,7 +6854,7 @@ public:
         TargetFrameSp = ex.TargetFrameSp;
 
         return *this;
-    }    
+    }
 };
 
 typedef VOID (PALAPI *PHARDWARE_EXCEPTION_HANDLER)(PAL_SEHException* ex);
@@ -6883,7 +6881,7 @@ public:
 };
 
 //
-// NOTE: Catching hardware exceptions are only enabled in the DAC and SOS 
+// NOTE: Catching hardware exceptions are only enabled in the DAC and SOS
 // builds. A hardware exception in coreclr code will fail fast/terminate
 // the process.
 //
@@ -6898,14 +6896,14 @@ public:
 extern "C++" {
 
 //
-// This is the base class of native exception holder used to provide 
+// This is the base class of native exception holder used to provide
 // the filter function to the exception dispatcher. This allows the
 // filter to be called during the first pass to better emulate SEH
 // the xplat platforms that only have C++ exception support.
 //
 class NativeExceptionHolderBase
 {
-    // Save the address of the holder head so the destructor 
+    // Save the address of the holder head so the destructor
     // doesn't have access the slow (on Linux) TLS value again.
     NativeExceptionHolderBase **m_head;
 
@@ -6934,7 +6932,7 @@ public:
 //
 // This is the second part of the native exception filter holder. It is
 // templated because the lambda used to wrap the exception filter is a
-// unknown type. 
+// unknown type.
 //
 template<class FilterType>
 class NativeExceptionHolder : public NativeExceptionHolderBase
@@ -6995,8 +6993,8 @@ public:
     auto tryBlock = [](__ParamType __paramDef)                                  \
     {
 
-// Start of an exception handler. If an exception raised by the RaiseException 
-// occurs in the try block and the disposition is EXCEPTION_EXECUTE_HANDLER, 
+// Start of an exception handler. If an exception raised by the RaiseException
+// occurs in the try block and the disposition is EXCEPTION_EXECUTE_HANDLER,
 // the handler code is executed. If the disposition is EXCEPTION_CONTINUE_SEARCH,
 // the exception is rethrown. The EXCEPTION_CONTINUE_EXECUTION disposition is
 // not supported.
@@ -7039,7 +7037,7 @@ public:
     };                                  \
     const bool isFinally = true;        \
     auto finallyBlock = [&]()           \
-    {                       
+    {
 
 // End of an except or a finally block.
 #define PAL_ENDTRY                      \
@@ -7105,7 +7103,7 @@ public:
 #endif // __cplusplus
 
 // Platform-specific library naming
-// 
+//
 #ifdef PLATFORM_UNIX
 #ifdef __APPLE__
 #define MAKEDLLNAME_W(name) u"lib" name u".dylib"
@@ -7143,16 +7141,16 @@ public:
 #define PAL_SHLIB_SUFFIX ".so"
 #endif
 
-#define DBG_EXCEPTION_HANDLED            ((DWORD   )0x00010001L)    
-#define DBG_CONTINUE                     ((DWORD   )0x00010002L)    
-#define DBG_EXCEPTION_NOT_HANDLED        ((DWORD   )0x80010001L)    
+#define DBG_EXCEPTION_HANDLED            ((DWORD   )0x00010001L)
+#define DBG_CONTINUE                     ((DWORD   )0x00010002L)
+#define DBG_EXCEPTION_NOT_HANDLED        ((DWORD   )0x80010001L)
 
-#define DBG_TERMINATE_THREAD             ((DWORD   )0x40010003L)    
-#define DBG_TERMINATE_PROCESS            ((DWORD   )0x40010004L)    
-#define DBG_CONTROL_C                    ((DWORD   )0x40010005L)    
-#define DBG_RIPEXCEPTION                 ((DWORD   )0x40010007L)    
-#define DBG_CONTROL_BREAK                ((DWORD   )0x40010008L)    
-#define DBG_COMMAND_EXCEPTION            ((DWORD   )0x40010009L)    
+#define DBG_TERMINATE_THREAD             ((DWORD   )0x40010003L)
+#define DBG_TERMINATE_PROCESS            ((DWORD   )0x40010004L)
+#define DBG_CONTROL_C                    ((DWORD   )0x40010005L)
+#define DBG_RIPEXCEPTION                 ((DWORD   )0x40010007L)
+#define DBG_CONTROL_BREAK                ((DWORD   )0x40010008L)
+#define DBG_COMMAND_EXCEPTION            ((DWORD   )0x40010009L)
 
 #define STATUS_USER_APC                  ((DWORD   )0x000000C0L)
 #define STATUS_GUARD_PAGE_VIOLATION      ((DWORD   )0x80000001L)

--- a/pal/inc/rt/palrt.h
+++ b/pal/inc/rt/palrt.h
@@ -1257,6 +1257,25 @@ typedef union __m128i {
     unsigned __int32    m128i_u32[4];
     unsigned __int64    m128i_u64[2];
 } __m128i;
+
+// from emmintrin.h
+static __inline__ __m128d __attribute__((__always_inline__, __nodebug__))
+_mm_load_sd(double const *__dp)
+{
+  struct __mm_load_sd_struct {
+    double __u;
+  } __attribute__((__packed__, __may_alias__));
+  double __u = ((struct __mm_load_sd_struct*)__dp)->__u;
+  return (__m128d){ __u, 0 };
+}
+
+// from emmintrin.h
+static __inline__ int __attribute__((__always_inline__, __nodebug__))
+_mm_cvtsd_si32(__m128d __a)
+{
+  return __builtin_ia32_cvtsd2si(__a);
+}
+
 #endif
 
 #define PF_COMPARE_EXCHANGE_DOUBLE          2


### PR DESCRIPTION
Re-enable building lib/Parser after completing char16 replacements.

- PAL code depends on min/max macros in pal.h. Other chakracore code uses
  safer template min/max functions. To work around the conflict, reordered
  pal,lib,bin and use NO_PAL_MINMAX for chakracore sources. Removed
  previous USING_PAL_MINMAX hack.

- template struct CompactCounters uses an enum class member as array size,
  which clang rejects as it must be an integral value. Changed the enum
  class to normal enum.

- Corrected some usages of #ifdefs (STACK_BACK_TRACE...)

- Moved a JavascriptArray "goto" target section out of an incorrect scope.
  The original scope has scoped variable initializations and cannot be
  skipped by goto target.

- Added 2 emmintrin.h functions into palrt.h, similar to existing changes.
