### PR TITLE
clean ast to use more standard encoding

### DIFF
--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -1870,7 +1870,7 @@ namespace Js
                 {
                     PropertyRecord const * propertyRecord = nullptr;
                     GetOrAddPropertyRecord(L"memory", lstrlen(L"memory"), &propertyRecord);
-                    JavascriptOperators::OP_SetProperty(exportObj, propertyRecord->GetPropertyId(), *heap, this);
+                    JavascriptOperators::OP_SetProperty(exportsNamespace, propertyRecord->GetPropertyId(), *heap, this);
                 }
             }
             else

--- a/lib/WasmReader/WasmBinaryOpCodes.h
+++ b/lib/WasmReader/WasmBinaryOpCodes.h
@@ -28,7 +28,6 @@
 #define WASM_SIMPLE_OPCODE(opname, opcode, token, sig) WASM_OPCODE(opname, opcode, token, sig)
 #endif
 
-
 // built-in opcode signatures
 //              id, retType, arg0, arg1, arg2
 WASM_SIGNATURE(I_II,    3,   WasmTypes::bAstI32, WasmTypes::bAstI32, WasmTypes::bAstI32)
@@ -85,9 +84,10 @@ WASM_MISC_OPCODE(GetGlobal,      0x10,        LIMIT,             Limit)
 WASM_MISC_OPCODE(SetGlobal,      0x11,        LIMIT,             Limit)
 WASM_MISC_OPCODE(Call,           0x12,        CALL,              Limit)
 WASM_MISC_OPCODE(CallIndirect,   0x13,        CALL_INDIRECT,     Limit)
+WASM_MISC_OPCODE(CallImport,     0x1f,        CALL,              Limit)
 
 // Load memory expressions.
-// TODO: Map to node ops
+// TODO: Map to node
 WASM_MEM_OPCODE(I32LoadMem8S,    0x20,        LOAD8S_I32,       I_I)
 WASM_MEM_OPCODE(I32LoadMem8U,    0x21,        LOAD8U_I32,       I_I)
 WASM_MEM_OPCODE(I32LoadMem16S,   0x22,        LOAD16S_I32,      I_I)
@@ -245,4 +245,3 @@ WASM_SIMPLE_OPCODE(I64ReinterpretF64,   0xb5, LIMIT,            L_D)
 #undef WASM_CTRL_OPCODE
 #undef WASM_OPCODE
 #undef WASM_SIGNATURE
-

--- a/lib/WasmReader/WasmBinaryReader.cpp
+++ b/lib/WasmReader/WasmBinaryReader.cpp
@@ -335,7 +335,7 @@ WasmBinaryReader::ASTNode()
     }
 
     WasmBinOp op = (WasmBinOp)*m_pc++;
-    m_funcState.count++;
+    ++m_funcState.count;
     switch (op)
     {
     case wbBlock:
@@ -343,6 +343,7 @@ WasmBinaryReader::ASTNode()
         BlockNode();
         break;
     case wbCall:
+    case wbCallImport:
         CallNode();
         break;
     case wbBr:
@@ -350,17 +351,13 @@ WasmBinaryReader::ASTNode()
         BrNode();
         break;
     case wbBrTable:
-        TableSwitchNode();
+        BrTableNode();
         break;
     case wbReturn:
         // Watch out for optional implicit block
         // (non-void return expression)
         if (!EndOfFunc())
             m_currentNode.opt.exists = true;
-        break;
-    case wbI8Const:
-        m_currentNode.cnst.i32 = ReadConst<INT8>();
-        m_funcState.count += sizeof(INT8);
         break;
     case wbI32Const:
         ConstNode<WasmTypes::bAstI32>();
@@ -423,9 +420,9 @@ WasmBinaryReader::CallNode()
     UINT length = 0;
     UINT32 funcNum = LEB128(length);
     m_funcState.count += length;
-    if (funcNum >= m_moduleInfo->GetSignatureCount())
+    if (funcNum >= m_moduleInfo->GetFunctionCount())
     {
-        ThrowDecodingError(L"Function signature is out of bound");
+        ThrowDecodingError(L"Function is out of bound");
     }
     m_currentNode.var.num = funcNum;
 }
@@ -442,6 +439,9 @@ WasmBinaryReader::BlockNode()
 void
 WasmBinaryReader::BrNode()
 {
+    ReadConst<uint8>(); // arity, ignored for now
+    m_funcState.count++;
+
     UINT len = 0;
     m_currentNode.br.depth = LEB128(len);
     m_funcState.count += len;
@@ -450,38 +450,33 @@ WasmBinaryReader::BrNode()
 }
 
 void
-WasmBinaryReader::TableSwitchNode()
+WasmBinaryReader::BrTableNode()
 {
     UINT len = 0;
-    m_currentNode.tableswitch.numCases = LEB128(len);
+    m_currentNode.brTable.numTargets = LEB128(len);
     m_funcState.count += len;
-    m_currentNode.tableswitch.numEntries = LEB128(len);
-    m_funcState.count += len;
-    m_currentNode.tableswitch.jumpTable = AnewArray(&m_alloc, UINT16, m_currentNode.tableswitch.numEntries);
-    // TODO tableswitch to BR_TABLE
-    for (UINT32 i = 0; i < m_currentNode.tableswitch.numEntries; i++)
+    m_currentNode.brTable.targetTable = AnewArray(&m_alloc, UINT32, m_currentNode.brTable.numTargets);
+
+    for (UINT32 i = 0; i < m_currentNode.brTable.numTargets; i++)
     {
-        m_currentNode.tableswitch.jumpTable[i] = ReadConst<UINT16>();
-        m_funcState.count += sizeof(UINT16);
+        m_currentNode.brTable.targetTable[i] = ReadConst<uint32>();
+        m_funcState.count += sizeof(uint32);
     }
+    m_currentNode.brTable.defaultTarget = ReadConst<uint32>();
+    m_funcState.count += sizeof(uint32);
 }
 
 WasmOp
 WasmBinaryReader::MemNode(WasmBinOp op)
 {
-    // Read memory access byte
-    m_currentNode.mem.alignment = ReadConst<UINT8>();
-    m_funcState.count++;
-    // If offset bit is set, read memory_offset
-    if (m_currentNode.mem.alignment & 0x08)
-    {
-        UINT length = 0;
-        m_currentNode.mem.offset = LEB128(length);
-        m_funcState.count += length;
-    }
-    else {
-        m_currentNode.mem.offset = 0;
-    }
+    uint len = 0;
+
+    LEB128(len); // flags (unused)
+    m_funcState.count += len;
+
+    m_currentNode.mem.offset = LEB128(len);
+    m_funcState.count += len;
+
     return GetWasmToken(op);
 }
 
@@ -624,7 +619,6 @@ void WasmBinaryReader::ReadExportTable()
 void
 WasmBinaryReader::FunctionBodyHeader()
 {
-    UINT32 i32Count = 0, i64Count = 0, f32Count = 0, f64Count = 0;
     UINT len = 0;
 
     m_funcInfo = m_moduleInfo->GetFunSig(m_moduleState.count);
@@ -636,53 +630,22 @@ WasmBinaryReader::FunctionBodyHeader()
     CheckBytesLeft(m_funcState.size);
 
     UINT32 entryCount = LEB128(len);
-    m_funcState.size += len;
+    m_funcState.count += len;
 
     // locals
     for (UINT32 i = 0; i < entryCount; i++)
     {
         UINT32 count = LEB128(len);
-        m_funcState.size += len;
+        m_funcState.count += len;
         UINT8 type = ReadConst<UINT8>();
-        m_funcState.size++;
-
-        switch (type)
+        m_funcState.count++;
+        if (type >= Wasm::WasmTypes::Limit || type == Wasm::WasmTypes::Void)
         {
-        case Wasm::WasmTypes::I32:
-            i32Count += count;
-            break;
-        case Wasm::WasmTypes::I64:
-            i64Count += count;
-            break;
-        case Wasm::WasmTypes::F32:
-            f32Count += count;
-            break;
-        case Wasm::WasmTypes::F64:
-            f64Count += count;
-            break;
-        default:
-            ThrowDecodingError(L"Unexpected local type");
+            ThrowDecodingError(L"Invalid local type");
         }
+        m_funcInfo->AddLocal((Wasm::WasmTypes::WasmType)type, count);
+        TRACE_WASM_DECODER(L"Function body header: type = %u, count = %u", type, count);
     }
-
-    for (UINT32 i = 0; i < i32Count; i++)
-    {
-        m_funcInfo->AddLocal(Wasm::WasmTypes::I32);
-    }
-    for (UINT32 i = 0; i < i64Count; i++)
-    {
-        m_funcInfo->AddLocal(Wasm::WasmTypes::I64);
-    }
-    for (UINT32 i = 0; i < f32Count; i++)
-    {
-        m_funcInfo->AddLocal(Wasm::WasmTypes::F32);
-    }
-    for (UINT32 i = 0; i < f64Count; i++)
-    {
-        m_funcInfo->AddLocal(Wasm::WasmTypes::F64);
-    }
-
-    TRACE_WASM_DECODER(L"Function body header: i32 = %u, i64 = %u, f32 = %u, f64 = %u", i32Count, i64Count, f32Count, f64Count);
 }
 
 wchar_t* WasmBinaryReader::ReadInlineName(uint32& length, uint32& nameLength)

--- a/lib/WasmReader/WasmBinaryReader.h
+++ b/lib/WasmReader/WasmBinaryReader.h
@@ -109,7 +109,7 @@ namespace Wasm
             void CallNode();
             void BlockNode();
             void BrNode();
-            void TableSwitchNode();
+            void BrTableNode();
             WasmOp MemNode(WasmBinOp op);
             void VarNode();
             template <WasmTypes::LocalType type> void ConstNode();

--- a/lib/WasmReader/WasmByteCodeGenerator.cpp
+++ b/lib/WasmReader/WasmByteCodeGenerator.cpp
@@ -151,8 +151,7 @@ WasmBytecodeGenerator::GenerateFunction()
     while ((op = m_reader->ReadExpr()) != wnLIMIT)
     {
         exprInfo = EmitExpr(op);
-        // REVIEW: should this be Assert or throw if false, or does this even hold?
-        // Assert(exprInfo.type == WasmTypes::Void);
+        ReleaseLocation(&exprInfo);
     }
 
     // Functions are like blocks. Emit implicit return of last stmt/expr, unless it is a return or end of file (sexpr).
@@ -289,9 +288,31 @@ WasmBytecodeGenerator::EnregisterLocals()
     }
 }
 
+void
+WasmBytecodeGenerator::PrintOpName(WasmOp op)
+{
+#define MakeWide(x) L##x
+    switch (op)
+    {
+#define WASM_KEYWORD(token, name) \
+    case wn##token: \
+        Output::Print(MakeWide(#token ## "\r\n")); \
+        break;
+#include "WasmKeywords.h"
+    }
+#undef MakeWide
+}
+
 EmitInfo
 WasmBytecodeGenerator::EmitExpr(WasmOp op)
 {
+#if DBG_DUMP
+    if (PHASE_TRACE(Js::WasmReaderPhase, m_func->body))
+    {
+        PrintOpName(op);
+    }
+#endif
+
     switch (op)
     {
     case wnGETLOCAL:
@@ -373,29 +394,31 @@ WasmBytecodeGenerator::EmitGetLocal()
 EmitInfo
 WasmBytecodeGenerator::EmitSetLocal()
 {
-    if (m_funcInfo->GetLocalCount() < m_reader->m_currentNode.var.num)
+    uint localNum = m_reader->m_currentNode.var.num;
+    if (localNum >= m_funcInfo->GetLocalCount())
     {
-        throw WasmCompilationException(L"%u is not a valid local", m_reader->m_currentNode.var.num);
+        throw WasmCompilationException(L"%u is not a valid local", localNum);
     }
 
-    WasmLocal local = m_locals[m_reader->m_currentNode.var.num];
+    WasmLocal local = m_locals[localNum];
 
     Js::OpCodeAsmJs op = GetLoadOp(local.type);
     WasmRegisterSpace * regSpace = GetRegisterSpace(local.type);
-
     EmitInfo info = EmitExpr(m_reader->ReadExpr());
 
     if (info.type != local.type)
     {
-        throw WasmCompilationException(L"TypeError in setlocal for %u", m_reader->m_currentNode.var.num);
+        throw WasmCompilationException(L"TypeError in setlocal for %u", localNum);
     }
 
     m_writer.AsmReg2(op, local.location, info.location);
 
     regSpace->ReleaseLocation(&info);
 
-    // REVIEW: should this produce result of setlocal? currently produces void
-    return EmitInfo();
+    Js::RegSlot tmp = regSpace->AcquireTmpRegister();
+    m_writer.AsmReg2(op, tmp, local.location);
+
+    return EmitInfo(tmp, local.type);
 }
 
 template<WasmTypes::WasmType type>
@@ -441,6 +464,7 @@ WasmBytecodeGenerator::EmitBlock()
         {
             op = m_reader->ReadFromBlock();
             EmitInfo info = EmitExpr(op);
+            ReleaseLocation(&info);
         }
     }
     else
@@ -453,8 +477,7 @@ WasmBytecodeGenerator::EmitBlock()
         do
         {
             EmitInfo info = EmitExpr(op);
-            // REVIEW: should this be Assert or throw if false, or does this even hold?
-            Assert(info.type == WasmTypes::Void);
+            ReleaseLocation(&info);
             op = m_reader->ReadFromBlock();
         } while (op != wnLIMIT);
     }
@@ -471,6 +494,10 @@ WasmBytecodeGenerator::EmitLoop()
     Js::ByteCodeLabel loopHeaderLabel = m_writer.DefineLabel();
     m_labels->Push(loopHeaderLabel);
     m_writer.MarkAsmJsLabel(loopHeaderLabel);
+
+    Js::ByteCodeLabel loopTailLabel = m_writer.DefineLabel();
+    m_labels->Push(loopTailLabel);
+
     if (m_reader->IsBinaryReader())
     {
         UINT blockCount = m_reader->m_currentNode.block.count;
@@ -482,8 +509,11 @@ WasmBytecodeGenerator::EmitLoop()
         {
             op = m_reader->ReadFromBlock();
             EmitInfo info = EmitExpr(op);
+            ReleaseLocation(&info);
         }
     }
+    m_writer.MarkAsmJsLabel(loopTailLabel);
+    m_labels->Pop();
     m_labels->Pop();
     return EmitInfo();
 }
@@ -501,14 +531,12 @@ WasmBytecodeGenerator::EmitCall()
     if (wasmOp == wnCALL)
     {
         funcNum = m_reader->m_currentNode.var.num;
-        if (funcNum >= m_module->functions->Count())
+        if (funcNum >= m_module->info->GetFunctionCount())
         {
-            // TODO: implement forward calls
-            AssertMsg(UNREACHED, "Forward calls currently unsupported");
+            throw WasmCompilationException(L"Call is to unknown function");
         }
-        WasmFunction * callee = m_module->functions->GetBuffer()[funcNum];
-        calleeSignature = callee->wasmInfo->GetSignature();
-        imported = callee->wasmInfo->Imported();
+        calleeSignature = m_module->info->GetFunSig(funcNum)->GetSignature();
+        imported = m_module->info->GetFunSig(funcNum)->Imported();
     }
     else
     {
@@ -651,30 +679,32 @@ WasmBytecodeGenerator::EmitCall()
     // emit result coercion
     EmitInfo retInfo;
     retInfo.type = calleeSignature->GetResultType();
-    Js::OpCodeAsmJs convertOp = Js::OpCodeAsmJs::Nop;
-    switch (retInfo.type)
+    if (retInfo.type != WasmTypes::Void)
     {
-    case WasmTypes::F32:
-        Assert(!imported);
-        retInfo.location = m_f32RegSlots->AcquireTmpRegister();
-        convertOp = Js::OpCodeAsmJs::I_Conv_VTF;
-        break;
-    case WasmTypes::F64:
-        retInfo.location = m_f64RegSlots->AcquireTmpRegister();
-        convertOp = imported ? Js::OpCodeAsmJs::Conv_VTF : Js::OpCodeAsmJs::I_Conv_VTF;
-        break;
-    case WasmTypes::I32:
-        retInfo.location = m_i32RegSlots->AcquireTmpRegister();
-        convertOp = imported ? Js::OpCodeAsmJs::Conv_VTI : Js::OpCodeAsmJs::I_Conv_VTI;
-        break;
-    case WasmTypes::I64:
-        Assert(UNREACHED);
-        break;
-    default:
-        Assume(UNREACHED);
+        Js::OpCodeAsmJs convertOp = Js::OpCodeAsmJs::Nop;
+        switch (retInfo.type)
+        {
+        case WasmTypes::F32:
+            Assert(!imported);
+            retInfo.location = m_f32RegSlots->AcquireTmpRegister();
+            convertOp = Js::OpCodeAsmJs::I_Conv_VTF;
+            break;
+        case WasmTypes::F64:
+            retInfo.location = m_f64RegSlots->AcquireTmpRegister();
+            convertOp = imported ? Js::OpCodeAsmJs::Conv_VTF : Js::OpCodeAsmJs::I_Conv_VTF;
+            break;
+        case WasmTypes::I32:
+            retInfo.location = m_i32RegSlots->AcquireTmpRegister();
+            convertOp = imported ? Js::OpCodeAsmJs::Conv_VTI : Js::OpCodeAsmJs::I_Conv_VTI;
+            break;
+        case WasmTypes::I64:
+            Assert(UNREACHED);
+            break;
+        default:
+            Assume(UNREACHED);
+        }
+        m_writer.AsmReg2(convertOp, retInfo.location, 0);
     }
-    m_writer.AsmReg2(convertOp, retInfo.location, 0);
-
 
     // track stack requirements for out params
 
@@ -774,35 +804,50 @@ WasmBytecodeGenerator::EmitIfElseExpr()
 
     EmitInfo falseExpr = EmitExpr(m_reader->ReadExpr());
 
-    if (falseExpr.type != trueExpr.type)
+    EmitInfo retInfo;
+    if (falseExpr.type == WasmTypes::Void)
+    {
+        if (trueExpr.type != WasmTypes::Void)
+        {
+            GetRegisterSpace(trueExpr.type)->ReleaseLocation(&trueExpr);
+        }
+    }
+    else if (trueExpr.type == WasmTypes::Void)
+    {
+        GetRegisterSpace(falseExpr.type)->ReleaseLocation(&falseExpr);
+    }
+    else if (falseExpr.type != trueExpr.type)
     {
         throw WasmCompilationException(L"If/Else branches must have same result type");
     }
-
-    // we will use result info true expr as our result info
-    // review: how will this work with break? must we store this location?
-    if (falseExpr.type != WasmTypes::Void && falseExpr.location != trueExpr.location)
+    else
     {
-        Js::OpCodeAsmJs op = Js::OpCodeAsmJs::Nop;
-        switch (falseExpr.type)
+        // we will use result info true expr as our result info
+        // review: how will this work with break? must we store this location?
+        if (falseExpr.location != trueExpr.location)
         {
-        case WasmTypes::F32:
-            op = Js::OpCodeAsmJs::Ld_Flt;
-            break;
-        case WasmTypes::F64:
-            op = Js::OpCodeAsmJs::Ld_Db;
-            break;
-        case WasmTypes::I32:
-            op = Js::OpCodeAsmJs::Ld_Int;
-            break;
-        case WasmTypes::I64:
-            AssertMsg(UNREACHED, "NYI");
-            break;
-        default:
-            Assume(UNREACHED);
+            Js::OpCodeAsmJs op = Js::OpCodeAsmJs::Nop;
+            switch (falseExpr.type)
+            {
+            case WasmTypes::F32:
+                op = Js::OpCodeAsmJs::Ld_Flt;
+                break;
+            case WasmTypes::F64:
+                op = Js::OpCodeAsmJs::Ld_Db;
+                break;
+            case WasmTypes::I32:
+                op = Js::OpCodeAsmJs::Ld_Int;
+                break;
+            case WasmTypes::I64:
+                AssertMsg(UNREACHED, "NYI");
+                break;
+            default:
+                Assume(UNREACHED);
+            }
+            m_writer.AsmReg2(op, trueExpr.location, falseExpr.location);
+            GetRegisterSpace(falseExpr.type)->ReleaseLocation(&falseExpr);
         }
-        m_writer.AsmReg2(op, trueExpr.location, falseExpr.location);
-        GetRegisterSpace(falseExpr.type)->ReleaseLocation(&falseExpr);
+        retInfo = trueExpr;
     }
 
     m_writer.MarkAsmJsLabel(endLabel);
@@ -810,59 +855,49 @@ WasmBytecodeGenerator::EmitIfElseExpr()
     Assert(m_nestedIfLevel > 0);
     --m_nestedIfLevel;
 
-    return trueExpr;
+    return retInfo;
 }
 
 EmitInfo
 WasmBytecodeGenerator::EmitBrTable()
 {
-    Js::ByteCodeLabel defaultLabel = m_writer.DefineLabel();
-    Js::ByteCodeLabel breakLabel = m_writer.DefineLabel();
-    uint numEntries = m_reader->m_currentNode.tableswitch.numEntries;
-    uint numCases = m_reader->m_currentNode.tableswitch.numCases;
-    UINT16* jumpTable = m_reader->m_currentNode.tableswitch.jumpTable;
-    Js::ByteCodeLabel* labels = AnewArray(&m_alloc, Js::ByteCodeLabel, numEntries);
+    const uint numTargets = m_reader->m_currentNode.brTable.numTargets;
+    const UINT* targetTable = m_reader->m_currentNode.brTable.targetTable;
+    const UINT defaultEntry = m_reader->m_currentNode.brTable.defaultTarget;
 
-    Assert((numCases == numEntries) || (numCases + 1 == numEntries));
-
-    m_labels->Push(breakLabel);
     // Compile scrutinee
     WasmOp op = m_reader->ReadFromBlock();
     EmitInfo scrutineeInfo = EmitExpr(op);
 
+    Js::ByteCodeLabel fallthroughLabel = m_writer.DefineLabel();
+    
     WasmRegisterSpace* regSpace = GetRegisterSpace(WasmTypes::I32);
     Js::RegSlot scrutineeVal = regSpace->AcquireTmpRegister();
     m_writer.AsmReg2(Js::OpCodeAsmJs::BeginSwitch_Int, scrutineeVal, scrutineeInfo.location);
     // Compile cases
-    for (uint i = 0; i < numEntries; i++)
+    for (uint i = 0; i < numTargets; i++)
     {
+        uint target = targetTable[i];
         Js::RegSlot caseLoc = regSpace->AcquireTmpRegister();
-        m_writer.AsmInt1Const1(Js::OpCodeAsmJs::Ld_IntConst, caseLoc, jumpTable[i]);
-        Js::ByteCodeLabel label;
-        if (i == numEntries - 1) {
-            label = defaultLabel;
+        m_writer.AsmInt1Const1(Js::OpCodeAsmJs::Ld_IntConst, caseLoc, target);
+        Js::ByteCodeLabel targetLabel;
+        if (target == 0)
+        {
+            targetLabel = fallthroughLabel;
         }
         else
         {
-            label = m_writer.DefineLabel();
+            targetLabel = GetLabel(target);
         }
-        labels[i] = label;
-
-        m_writer.AsmBrReg2(Js::OpCodeAsmJs::Case_Int, label, scrutineeVal, caseLoc);
+        m_writer.AsmBrReg2(Js::OpCodeAsmJs::Case_Int, targetLabel, scrutineeVal, caseLoc);
         regSpace->ReleaseTmpRegister(caseLoc);
     }
     regSpace->ReleaseTmpRegister(scrutineeVal);
-    m_writer.AsmBr(defaultLabel, Js::OpCodeAsmJs::EndSwitch_Int);
 
-    for (uint i = 0; i < numEntries; i++)
-    {
-        m_writer.MarkAsmJsLabel(labels[i]);
-        WasmOp op = m_reader->ReadFromBlock();
-        EmitInfo info = EmitExpr(op);
-    }
+    m_writer.AsmBr(defaultEntry, Js::OpCodeAsmJs::EndSwitch_Int);
 
-    m_labels->Pop();
-    m_writer.MarkAsmJsLabel(breakLabel);
+    m_writer.MarkAsmJsLabel(fallthroughLabel);
+
     return EmitInfo();
 }
 
@@ -877,7 +912,7 @@ WasmBytecodeGenerator::EmitBinExpr()
     {
         throw WasmCompilationException(L"Invalid type for LHS");
     }
-    if (rhsType != lhs.type)
+    if (rhsType != rhs.type)
     {
         throw WasmCompilationException(L"Invalid type for RHS");
     }
@@ -943,7 +978,7 @@ EmitInfo
 WasmBytecodeGenerator::EmitMemStore()
 {
     // TODO (michhol): combine with MemRead
-    Js::RegSlot indexReg = GetRegisterSpace(WasmTypes::I32)->AcquireTmpRegister();
+    Js::RegSlot indexReg = m_i32RegSlots->AcquireTmpRegister();
     // TODO: emit less bytecode with expr + 0
     m_writer.AsmInt1Const1(Js::OpCodeAsmJs::Ld_IntConst, indexReg, m_reader->m_currentNode.mem.offset);
 
@@ -955,16 +990,22 @@ WasmBytecodeGenerator::EmitMemStore()
     }
 
     m_writer.AsmReg3(Js::OpCodeAsmJs::Add_Int, indexReg, exprInfo.location, indexReg);
-    GetRegisterSpace(WasmTypes::I32)->ReleaseLocation(&exprInfo);
+    m_i32RegSlots->ReleaseLocation(&exprInfo);
 
     EmitInfo rhsInfo = EmitExpr(m_reader->ReadExpr());
+    if (rhsInfo.type != type)
+    {
+        throw WasmCompilationException(L"Invalid type for store op");
+    }
 
     m_writer.AsmTypedArr(Js::OpCodeAsmJs::StArr, rhsInfo.location, indexReg, GetViewType(wasmOp));
+    ReleaseLocation(&rhsInfo);
+    m_i32RegSlots->ReleaseTmpRegister(indexReg);
 
-    GetRegisterSpace(rhsInfo.type)->ReleaseLocation(&rhsInfo);
-    GetRegisterSpace(WasmTypes::I32)->ReleaseTmpRegister(indexReg);
+    Js::RegSlot retLoc = GetRegisterSpace(rhsInfo.type)->AcquireTmpRegister();
+    m_writer.AsmReg2(GetLoadOp(rhsInfo.type), retLoc, rhsInfo.location);
 
-    return EmitInfo();
+    return EmitInfo(retLoc, rhsInfo.type);
 }
 
 template<typename T>
@@ -1088,8 +1129,8 @@ template<WasmOp wasmOp>
 EmitInfo
 WasmBytecodeGenerator::EmitBr()
 {
-    UINT depth = m_reader->m_currentNode.br.depth;
-    Assert(depth < m_labels->Count());
+    UINT depth = m_reader->m_currentNode.br.depth + 1;
+    Assert(depth <= m_labels->Count());
 
     EmitInfo conditionInfo;
     if (wasmOp == WasmOp::wnBR_IF)
@@ -1107,12 +1148,7 @@ WasmBytecodeGenerator::EmitBr()
         EmitInfo info = EmitExpr(m_reader->ReadFromBlock());
     }
 
-    SListCounted<Js::ByteCodeLabel>::Iterator itr(m_labels);
-    itr.Next();
-    for (UINT i = 0; i < depth; i++) {
-        itr.Next();
-    }
-    Js::ByteCodeLabel target = itr.Data();
+    Js::ByteCodeLabel target = GetLabel(depth);
     if (wasmOp == WasmOp::wnBR)
     {
         m_writer.AsmBr(target);
@@ -1227,6 +1263,29 @@ WasmBytecodeGenerator::GetViewType(WasmOp op)
         Assert(UNREACHED);
         return Js::ArrayBufferView::ViewType::TYPE_INVALID;
     }
+}
+
+
+void
+WasmBytecodeGenerator::ReleaseLocation(EmitInfo * info)
+{
+    if (info->type != WasmTypes::Void)
+    {
+        Assert(info->type < WasmTypes::Limit);
+        GetRegisterSpace(info->type)->ReleaseLocation(info);
+    }
+}
+
+Js::ByteCodeLabel
+WasmBytecodeGenerator::GetLabel(uint depth)
+{
+    Assert(depth != 0);
+    SListCounted<Js::ByteCodeLabel>::Iterator itr(m_labels);
+    for (UINT i = 0; i < depth; ++i)
+    {
+        itr.Next();
+    }
+    return itr.Data();
 }
 
 WasmRegisterSpace *

--- a/lib/WasmReader/WasmByteCodeGenerator.h
+++ b/lib/WasmReader/WasmByteCodeGenerator.h
@@ -108,6 +108,7 @@ namespace Wasm
         EmitInfo EmitSetLocal();
         EmitInfo EmitReturnExpr(EmitInfo *lastStmtExprInfo = nullptr);
         EmitInfo EmitSelect();
+        void PrintOpName(WasmOp op);
 
         template<WasmOp wasmOp>
         EmitInfo EmitBr();
@@ -128,6 +129,9 @@ namespace Wasm
         EmitInfo EmitConst();
 
         void EnregisterLocals();
+        void ReleaseLocation(EmitInfo * info);
+
+        Js::ByteCodeLabel GetLabel(uint depth);
 
         void ReadParams(WasmNode * paramExpr);
         void ReadResult(WasmNode * paramExpr);

--- a/lib/WasmReader/WasmFunctionInfo.cpp
+++ b/lib/WasmReader/WasmFunctionInfo.cpp
@@ -23,9 +23,12 @@ WasmFunctionInfo::WasmFunctionInfo(ArenaAllocator * alloc)
 }
 
 void
-WasmFunctionInfo::AddLocal(WasmTypes::WasmType type)
+WasmFunctionInfo::AddLocal(WasmTypes::WasmType type, uint count)
 {
-    m_locals->Add(type);
+    for (uint i = 0; i < count; ++i)
+    {
+        m_locals->Add(type);
+    }
 }
 
 template<>

--- a/lib/WasmReader/WasmFunctionInfo.h
+++ b/lib/WasmReader/WasmFunctionInfo.h
@@ -12,7 +12,7 @@ namespace Wasm
     public:
         WasmFunctionInfo(ArenaAllocator * alloc);
 
-        void AddLocal(WasmTypes::WasmType type);
+        void AddLocal(WasmTypes::WasmType type, uint count = 1);
         template <typename T> void AddConst(T constVal, Js::RegSlot reg);
 
         WasmTypes::WasmType GetLocal(uint index) const;

--- a/lib/WasmReader/WasmParseTree.h
+++ b/lib/WasmReader/WasmParseTree.h
@@ -74,11 +74,11 @@ namespace Wasm
         bool hasSubExpr;
     };
 
-    struct WasmTableSwitchNode
+    struct WasmBrTableNode
     {
-        uint32 numCases;
-        uint32 numEntries;
-        UINT16* jumpTable;
+        uint32 numTargets;
+        uint32* targetTable;
+        uint32 defaultTarget;
     };
 
     struct WasmNode
@@ -92,7 +92,7 @@ namespace Wasm
             WasmOptionalNode opt;
             WasmBlockNode block;
             WasmBrNode br;
-            WasmTableSwitchNode tableswitch;
+            WasmBrTableNode brTable;
             WasmMemOpNode mem;
         };
     };


### PR DESCRIPTION
There were a number of places in ast which we were not decoding in same was as spidermonkey, now most of these inconsistencies should be resolved.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/492)
<!-- Reviewable:end -->
