### PR TITLE
Debugger support for default parameters

### DIFF
--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -5241,6 +5241,12 @@ namespace Js
         this->scopeProperties->Add(scopeProperty);
     }
 
+    bool DebuggerScope::HasProperty(Js::PropertyId propertyId)
+    {
+        int i = -1;
+        return GetPropertyIndex(propertyId, i);
+    }
+
     bool DebuggerScope::GetPropertyIndex(Js::PropertyId propertyId, int& index)
     {
         if (!this->HasProperties())
@@ -5304,6 +5310,8 @@ namespace Js
             return _u("DiagUnknownScope");
         case DiagExtraScopesType::DiagWithScope:
             return _u("DiagWithScope");
+        case DiagExtraScopesType::DiagParamScope:
+            return _u("DiagParamScope");
         default:
             AssertMsg(false, "Missing a debug scope type.");
             return _u("");
@@ -5667,7 +5675,7 @@ namespace Js
         {
             Js::DebuggerScope *debuggerScope = pScopeChain->Item(i);
             DebuggerScopeProperty debuggerScopeProperty;
-            if (debuggerScope->TryGetProperty(propertyId, location, &debuggerScopeProperty))
+            if (debuggerScope->scopeType != DiagParamScope && debuggerScope->TryGetProperty(propertyId, location, &debuggerScopeProperty))
             {
                 bool isOffsetInScope = debuggerScope->IsOffsetInScope(offset);
 

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -66,6 +66,7 @@ namespace Js
         DiagBlockScopeInSlot,       // Block scope in slot array
         DiagBlockScopeInObject,     // Block scope in activation object
         DiagBlockScopeRangeEnd,     // Used to end a block scope range.
+        DiagParamScope,             // The scope represents symbols at formals
     };
 
     class PropertyGuard
@@ -3452,6 +3453,7 @@ namespace Js
         DebuggerScope * GetSiblingScope(RegSlot location, FunctionBody *functionBody);
         void AddProperty(RegSlot location, Js::PropertyId propertyId, DebuggerScopePropertyFlags flags);
         bool GetPropertyIndex(Js::PropertyId propertyId, int& i);
+        bool HasProperty(Js::PropertyId propertyId);
 
         bool IsOffsetInScope(int offset) const;
         bool Contains(Js::PropertyId propertyId, RegSlot location) const;

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.h
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.h
@@ -366,6 +366,7 @@ public:
     void TrackFunctionDeclarationPropertyForDebugger(Symbol *functionDeclarationSymbol, FuncInfo *funcInfoParent);
     void UpdateDebuggerPropertyInitializationOffset(Js::RegSlot location, Js::PropertyId propertyId, bool shouldConsumeRegister = true);
 
+    void PopulateFormalsScope(uint beginOffset, FuncInfo *funcInfo, ParseNode *pnode);
     FuncInfo *FindEnclosingNonLambda();
 
     bool CanStackNestedFunc(FuncInfo * funcInfo, bool trace = false);

--- a/lib/Runtime/Debug/DiagObjectModel.h
+++ b/lib/Runtime/Debug/DiagObjectModel.h
@@ -200,6 +200,7 @@ namespace Js
 
         bool IsInGroup() const { return (groupType != UIGroupType::UIGroupType_None && groupType != UIGroupType::UIGroupType_InnerScope); }
         bool IsWalkerForCurrentFrame() const { return groupType == UIGroupType::UIGroupType_None; }
+        DebuggerScope * GetScopeWhenHaltAtFormals();
 
         int GetAdjustedByteCodeOffset() const;
 


### PR DESCRIPTION
When we stop at formals (params) location we need to show locals, visible
only at formals scope. For that purpose DebuggerScope is used (with a new
type DiagParamScope). That scope will contain the bytecode range and symbols. With
the help of that scope we will filter variables when we are halted at
formals location.
