### PR TITLE
Destructuring pattern at formals with rest param.

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -2214,8 +2214,6 @@ void AddArgsToScope(ParseNodePtr pnode, ByteCodeGenerator *byteCodeGenerator, bo
     MapFormalsWithoutRest(pnode, addArgToScope);
     byteCodeGenerator->SetNumberOfInArgs(pos);
 
-    MapFormalsFromPattern(pnode, addArgToScope);
-
     if (pnode->sxFnc.pnodeRest != nullptr)
     {
         // The rest parameter will always be in a register, regardless of whether it is in a scope slot.
@@ -2227,6 +2225,8 @@ void AddArgsToScope(ParseNodePtr pnode, ByteCodeGenerator *byteCodeGenerator, bo
 
         assignLocation = assignLocationSave;
     }
+
+    MapFormalsFromPattern(pnode, addArgToScope);
 
     Assert(!assignLocation || byteCodeGenerator->TopFuncInfo()->varRegsCount + 1 == pos);
 }

--- a/test/es6/destructuring_bugs.js
+++ b/test/es6/destructuring_bugs.js
@@ -81,6 +81,13 @@ var tests = [
       assert.doesNotThrow(function () { eval("function foo() { function bar([a], {b, b1}, [c]) { var b1 = 1; } }"); }, "variable 'b1' is not a re-declaration" );
       assert.doesNotThrow(function () { eval("function foo() { ({c}) => { var c = 1; } }"); }, "variable 'c' is not a re-declaration" );
     }
+  },
+  {
+    name: "Destructuring bug fix - pattern with rest parameter",
+    body: function () {
+      assert.doesNotThrow(function () { eval("function foo({a}, ...b) { if (b) { } }; foo({});"); } );
+      assert.doesNotThrow(function () { eval("function foo([], ...b) { if (b) { } }; foo([]);"); });
+    }
   }
 ];
 


### PR DESCRIPTION
We actually assign register to formals of destructuring pattern before than rest param. This makes the rest to fetch value from wrong register. Fixed that by reversing the order.
