### PR TITLE
Cap new page count during background sweeping

### DIFF
--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -434,6 +434,7 @@ PHASE(All)
 #endif
 
 #define DEFAULT_CONFIG_LowMemoryCap         (0xB900000) // 185 MB - based on memory cap for process on low-capacity device
+#define DEFAULT_CONFIG_NewPagesCapDuringBGSweeping    (15000)
 
 #define DEFAULT_CONFIG_MaxCodeFill          (500)
 #define DEFAULT_CONFIG_MaxLoopsPerFunction  (10)
@@ -1168,6 +1169,7 @@ FLAGNR(Boolean, RecyclerProtectPagesOnRescan, "Temporarily switch all pages to r
 FLAGNR(Boolean, RecyclerVerifyMark    , "verify concurrent gc", false)
 #endif
 FLAGR (Number,  LowMemoryCap          , "Memory cap indicating a low-memory process", DEFAULT_CONFIG_LowMemoryCap)
+FLAGNR(Number,  NewPagesCapDuringBGSweeping, "New pages count allowed to be allocated during background sweeping", DEFAULT_CONFIG_NewPagesCapDuringBGSweeping)
 #ifdef RUNTIME_DATA_COLLECTION
 FLAGNR(String,  RuntimeDataOutputFile, "Filename to write the dynamic profile info", nullptr)
 #endif


### PR DESCRIPTION
When large amount of short living objects and small amount of long living objects interlaced on the same pages causes very bad fragmentation.
With background sweeping the problem becomes even worse because while background sweeping, the short living objects swept space can't be reused before the whole background sweeping completed. So the interlaced allocation keeps happening on new pages.
So far there's no easy way to totally solve the issue. This change mitigate the issue by setting a limit of new pages allowed during background sweeping, and wait for the background sweeping complete when limit is hit.

simple repro for the fragmentation:
```
var glo = [];
for (var k = 0; k < 258; k++) {
    for (var j = 0; j < 258; j++) {
        var x;
        for (var i = 0; i <1000 ; i++) {
             x = {}; // short living objects
        }
        glo.push({});// long living objects sharing same bucket/pages
    }
}
glo={};
```