### PR TITLE
Add JIT support to module import and exports

### DIFF
--- a/lib/Backend/IRBuilder.cpp
+++ b/lib/Backend/IRBuilder.cpp
@@ -3662,7 +3662,11 @@ IRBuilder::BuildElementSlotI2(Js::OpCode newOpcode, uint32 offset, Js::RegSlot r
         case Js::OpCode::LdModuleSlot:
         case Js::OpCode::StModuleSlot:
         {
-            Js::Var* moduleExportVarArrayAddr = Js::JavascriptOperators::OP_GetModuleExportSlotArrayAddress(slotId1, m_func->GetScriptContext());
+            if ((uint)slotId1 >= m_func->GetJnFunction()->GetInnerScopeCount())
+            {
+                Js::Throw::FatalInternalError();
+            }
+            Js::Var* moduleExportVarArrayAddr = Js::JavascriptOperators::OP_GetModuleExportSlotArrayAddress(slotId1, slotId2, m_func->GetScriptContext());
             IR::AddrOpnd* addrOpnd = IR::AddrOpnd::New(moduleExportVarArrayAddr, IR::AddrOpndKindConstant, m_func, true);
             regOpnd = IR::RegOpnd::New(TyVar, m_func);
             instr = IR::Instr::New(Js::OpCode::Ld_A, regOpnd, addrOpnd, m_func);

--- a/lib/Backend/IRBuilder.cpp
+++ b/lib/Backend/IRBuilder.cpp
@@ -3662,10 +3662,6 @@ IRBuilder::BuildElementSlotI2(Js::OpCode newOpcode, uint32 offset, Js::RegSlot r
         case Js::OpCode::LdModuleSlot:
         case Js::OpCode::StModuleSlot:
         {
-            if ((uint)slotId1 >= m_func->GetJnFunction()->GetInnerScopeCount())
-            {
-                Js::Throw::FatalInternalError();
-            }
             Js::Var* moduleExportVarArrayAddr = Js::JavascriptOperators::OP_GetModuleExportSlotArrayAddress(slotId1, slotId2, m_func->GetScriptContext());
             IR::AddrOpnd* addrOpnd = IR::AddrOpnd::New(moduleExportVarArrayAddr, IR::AddrOpndKindConstant, m_func, true);
             regOpnd = IR::RegOpnd::New(TyVar, m_func);

--- a/lib/Backend/IRBuilder.cpp
+++ b/lib/Backend/IRBuilder.cpp
@@ -3659,6 +3659,36 @@ IRBuilder::BuildElementSlotI2(Js::OpCode newOpcode, uint32 offset, Js::RegSlot r
 
     switch (newOpcode)
     {
+        case Js::OpCode::LdModuleSlot:
+        case Js::OpCode::StModuleSlot:
+        {
+            Js::Var* moduleExportVarArrayAddr = Js::JavascriptOperators::OP_GetModuleExportSlotArrayAddress(slotId1, m_func->GetScriptContext());
+            IR::AddrOpnd* addrOpnd = IR::AddrOpnd::New(moduleExportVarArrayAddr, IR::AddrOpndKindConstant, m_func, true);
+            regOpnd = IR::RegOpnd::New(TyVar, m_func);
+            instr = IR::Instr::New(Js::OpCode::Ld_A, regOpnd, addrOpnd, m_func);
+            this->AddInstr(instr, offset);
+
+            fieldSym = PropertySym::FindOrCreate(regOpnd->m_sym->m_id, slotId2, (uint32)-1, (uint)-1, PropertyKindSlots, m_func);
+            fieldOpnd = IR::SymOpnd::New(fieldSym, TyVar, m_func);
+            
+            if (newOpcode == Js::OpCode::LdModuleSlot)
+            {
+                newOpcode = Js::OpCode::LdSlot;
+                regOpnd = this->BuildDstOpnd(regSlot);
+                instr = IR::Instr::New(newOpcode, regOpnd, fieldOpnd, m_func);
+            }
+            else
+            {
+                Assert(newOpcode == Js::OpCode::StModuleSlot);
+                newOpcode = Js::OpCode::StSlot;
+                regOpnd = this->BuildSrcOpnd(regSlot);
+                instr = IR::Instr::New(newOpcode, fieldOpnd, regOpnd, m_func);
+            }
+
+            this->AddInstr(instr, offset);
+            break;
+        }
+
         case Js::OpCode::LdEnvSlot:
         case Js::OpCode::LdEnvObjSlot:
         case Js::OpCode::StEnvSlot:

--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -2694,6 +2694,12 @@ void ByteCodeGenerator::EmitProgram(ParseNode *pnodeProg)
 #endif
 
     Assert(pnodeProg && pnodeProg->nop == knopProg);
+
+    if (IsModuleCode())
+    {
+        EnsureImportBindingScopeSlots(pnodeProg, pnodeProg->sxFnc.funcInfo);
+    }
+
     if (this->parentScopeInfo)
     {
         // Scope stack is already set up the way we want it, so don't visit the global scope.
@@ -3136,11 +3142,6 @@ void ByteCodeGenerator::EmitOneFunction(ParseNode *pnode)
         if (funcInfo->IsGlobalFunction())
         {
             EnsureNoRedeclarations(pnode->sxFnc.pnodeScopes, funcInfo);
-        }
-
-        if (IsModuleCode() && funcInfo->IsGlobalFunction() && pnode->nop == knopProg)
-        {
-            EnsureImportBindingScopeSlots(pnode, funcInfo);
         }
 
         ::BeginEmitBlock(pnode->sxFnc.pnodeScopes, this, funcInfo);

--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -7935,39 +7935,12 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
     template <class T>
     Var InterpreterStackFrame::OP_LdModuleSlot(Var instance, const unaligned T* playout)
     {
-        Js::SourceTextModuleRecord* moduleRecord = scriptContext->GetLibrary()->GetModuleRecord(playout->SlotIndex1);
-        Assert(moduleRecord != nullptr);
-
-        Var* moduleRecordSlots = moduleRecord->GetLocalExportSlots();
-        Assert(moduleRecordSlots != nullptr);
-
-        if (moduleRecord->GetLocalExportCount() <= (uint)playout->SlotIndex2)
-        {
-            Js::Throw::FatalInternalError();
-        }
-
-        Var value = moduleRecordSlots[playout->SlotIndex2];
-        Assert(value != nullptr);
-
-        return value;
+        return JavascriptOperators::OP_LdModuleSlot(playout->SlotIndex1, playout->SlotIndex2, scriptContext);
     }
 
     inline void InterpreterStackFrame::OP_StModuleSlot(Var instance, int32 slotIndex1, int32 slotIndex2, Var value)
     {
-        Assert(value != nullptr);
-
-        Js::SourceTextModuleRecord* moduleRecord = scriptContext->GetLibrary()->GetModuleRecord(slotIndex1);
-        Assert(moduleRecord != nullptr);
-
-        Var* moduleRecordSlots = moduleRecord->GetLocalExportSlots();
-        Assert(moduleRecordSlots != nullptr);
-
-        if (moduleRecord->GetLocalExportCount() <= (uint)slotIndex2)
-        {
-            Js::Throw::FatalInternalError();
-        }
-
-        moduleRecordSlots[slotIndex2] = value;
+        JavascriptOperators::OP_StModuleSlot(slotIndex1, slotIndex2, value, scriptContext);
     }
 
 #if ENABLE_PROFILE_INFO

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -6411,26 +6411,24 @@ CommonNumber:
         return propertyId;
     }
 
-    Var* JavascriptOperators::OP_GetModuleExportSlotArrayAddress(uint moduleIndex, ScriptContext* scriptContext)
+    Var* JavascriptOperators::OP_GetModuleExportSlotArrayAddress(uint moduleIndex, uint slotIndex, ScriptContext* scriptContext)
     {
         Js::SourceTextModuleRecord* moduleRecord = scriptContext->GetLibrary()->GetModuleRecord(moduleIndex);
         Assert(moduleRecord != nullptr);
+
+        // Require caller to also provide the intended access slot so we can do bounds check now.
+        if (moduleRecord->GetLocalExportCount() <= slotIndex)
+        {
+            Js::Throw::FatalInternalError();
+        }
 
         return moduleRecord->GetLocalExportSlots();
     }
 
     Var* JavascriptOperators::OP_GetModuleExportSlotAddress(uint moduleIndex, uint slotIndex, ScriptContext* scriptContext)
     {
-        Js::SourceTextModuleRecord* moduleRecord = scriptContext->GetLibrary()->GetModuleRecord(moduleIndex);
-        Assert(moduleRecord != nullptr);
-
-        Var* moduleRecordSlots = OP_GetModuleExportSlotArrayAddress(moduleIndex, scriptContext);
+        Var* moduleRecordSlots = OP_GetModuleExportSlotArrayAddress(moduleIndex, slotIndex, scriptContext);
         Assert(moduleRecordSlots != nullptr);
-
-        if (moduleRecord->GetLocalExportCount() <= slotIndex)
-        {
-            Js::Throw::FatalInternalError();
-        }
 
         return &moduleRecordSlots[slotIndex];
     }

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -6411,6 +6411,50 @@ CommonNumber:
         return propertyId;
     }
 
+    Var* JavascriptOperators::OP_GetModuleExportSlotArrayAddress(uint moduleIndex, ScriptContext* scriptContext)
+    {
+        Js::SourceTextModuleRecord* moduleRecord = scriptContext->GetLibrary()->GetModuleRecord(moduleIndex);
+        Assert(moduleRecord != nullptr);
+
+        return moduleRecord->GetLocalExportSlots();
+    }
+
+    Var* JavascriptOperators::OP_GetModuleExportSlotAddress(uint moduleIndex, uint slotIndex, ScriptContext* scriptContext)
+    {
+        Js::SourceTextModuleRecord* moduleRecord = scriptContext->GetLibrary()->GetModuleRecord(moduleIndex);
+        Assert(moduleRecord != nullptr);
+
+        Var* moduleRecordSlots = OP_GetModuleExportSlotArrayAddress(moduleIndex, scriptContext);
+        Assert(moduleRecordSlots != nullptr);
+
+        if (moduleRecord->GetLocalExportCount() <= slotIndex)
+        {
+            Js::Throw::FatalInternalError();
+        }
+
+        return &moduleRecordSlots[slotIndex];
+    }
+
+    Var JavascriptOperators::OP_LdModuleSlot(uint moduleIndex, uint slotIndex, ScriptContext* scriptContext)
+    {
+        Var* addr = OP_GetModuleExportSlotAddress(moduleIndex, slotIndex, scriptContext);
+
+        Assert(addr != nullptr);
+
+        return *addr;
+    }
+
+    void JavascriptOperators::OP_StModuleSlot(uint moduleIndex, uint slotIndex, Var value, ScriptContext* scriptContext)
+    {
+        Assert(value != nullptr);
+
+        Var* addr = OP_GetModuleExportSlotAddress(moduleIndex, slotIndex, scriptContext);
+
+        Assert(addr != nullptr);
+
+        *addr = value;
+    }
+
     void JavascriptOperators::OP_InitClassMemberSetComputedName(Var object, Var elementName, Var value, ScriptContext* scriptContext, PropertyOperationFlags flags)
     {
         Js::PropertyId propertyId = JavascriptOperators::OP_InitElemSetter(object, elementName, value, scriptContext);

--- a/lib/Runtime/Language/JavascriptOperators.h
+++ b/lib/Runtime/Language/JavascriptOperators.h
@@ -281,6 +281,11 @@ namespace Js
         static void OP_InitClassMemberSet(Var object, PropertyId propertyId, Var setter);
         static void OP_InitClassMemberSetComputedName(Var object, Var elementName, Var getter, ScriptContext* scriptContext, PropertyOperationFlags flags = PropertyOperation_None);
 
+        static Var* OP_GetModuleExportSlotArrayAddress(uint moduleIndex, ScriptContext* scriptContext);
+        static Var* OP_GetModuleExportSlotAddress(uint moduleIndex, uint slotIndex, ScriptContext* scriptContext);
+        static Var OP_LdModuleSlot(uint moduleIndex, uint slotIndex, ScriptContext* scriptContext);
+        static void OP_StModuleSlot(uint moduleIndex, uint slotIndex, Var value, ScriptContext* scriptContext);
+
         static Js::PropertyId GetPropertyId(Var propertyName, ScriptContext* scriptContext);
 
         static BOOL OP_HasItem(Var instance, Var aElementIndex, ScriptContext* scriptContext);

--- a/lib/Runtime/Language/JavascriptOperators.h
+++ b/lib/Runtime/Language/JavascriptOperators.h
@@ -281,7 +281,7 @@ namespace Js
         static void OP_InitClassMemberSet(Var object, PropertyId propertyId, Var setter);
         static void OP_InitClassMemberSetComputedName(Var object, Var elementName, Var getter, ScriptContext* scriptContext, PropertyOperationFlags flags = PropertyOperation_None);
 
-        static Var* OP_GetModuleExportSlotArrayAddress(uint moduleIndex, ScriptContext* scriptContext);
+        static Var* OP_GetModuleExportSlotArrayAddress(uint moduleIndex, uint slotIndex, ScriptContext* scriptContext);
         static Var* OP_GetModuleExportSlotAddress(uint moduleIndex, uint slotIndex, ScriptContext* scriptContext);
         static Var OP_LdModuleSlot(uint moduleIndex, uint slotIndex, ScriptContext* scriptContext);
         static void OP_StModuleSlot(uint moduleIndex, uint slotIndex, Var value, ScriptContext* scriptContext);

--- a/lib/Runtime/Language/SourceTextModuleRecord.cpp
+++ b/lib/Runtime/Language/SourceTextModuleRecord.cpp
@@ -362,6 +362,12 @@ namespace Js
         {
             bool isAmbiguous = false;
             indirectExportRecordList->MapUntil([&](ModuleExportEntry exportEntry) {
+                PropertyId reexportNameId = EnsurePropertyIdForIdentifier(exportEntry.exportName);
+                if (exportName != reexportNameId)
+                {
+                    return false;
+                }
+
                 PropertyId importNameId = EnsurePropertyIdForIdentifier(exportEntry.importName);
                 SourceTextModuleRecord* childModuleRecord = GetChildModuleRecord(exportEntry.moduleRequest->Psz());
                 if (childModuleRecord == nullptr)


### PR DESCRIPTION
Add JIT support to module import and exports

Allow the export-side name to be a reserved word. This is by design and required for syntax such as 'export { foo as default };' Also allow import statements to use reserved words as the IdentifierName used to find the export needed for syntax like 'import { default as foo } from "./module.js"'

Fix an issue where using a value imported from a different module inside a nested function could cause AV

Fix a bug where indirect export resolution only performed resolution against the import identifier instead of the export name