### PR TITLE
Makes `await` a FutureReservedWord in Modules only

### DIFF
--- a/lib/Parser/JsScan.js
+++ b/lib/Parser/JsScan.js
@@ -21,7 +21,8 @@ function emitToken(token, d, indent) {
             r += indent + "}\r\n";
             r += indent + "goto LIdentifier;\r\n";
         } else if (token.tk === "tkAWAIT") {
-            r += indent + "if (this->m_fAwaitIsKeyword || !this->m_parser || this->m_parser->IsStrictMode()) {" + "\r\n";
+            // Note: `await` is only a FutureReservedWord when parsing module scripts (when Module is goal symbol of the grammar)
+            r += indent + "if (this->m_fAwaitIsKeyword || this->m_fIsModuleCode) {" + "\r\n";
             r += indent + "    token = " + token.tk + ";\r\n";
             r += indent + "    goto LReserved;\r\n";
             r += indent + "}\r\n";

--- a/lib/Parser/kwd-swtch.h
+++ b/lib/Parser/kwd-swtch.h
@@ -13,7 +13,7 @@
             case 'w':
                 if (p[1] == 'a' && p[2] == 'i' && p[3] == 't' && !IsIdContinueNext(p+4, last)) {
                     p += 4;
-                    if (this->m_fAwaitIsKeyword || !this->m_parser || this->m_parser->IsStrictMode()) {
+                    if (this->m_fAwaitIsKeyword || this->m_fIsModuleCode) {
                         token = tkAWAIT;
                         goto LReserved;
                     }
@@ -512,10 +512,10 @@
         goto LIdentifier;
 
     // characters not in a reserved word
-
-              case 'g': case 'h':           case 'j':
-    case 'k':           case 'm':           case 'o':
-              case 'q':
-    case 'u':                     case 'x':
-    case 'z':
+                                                      
+              case 'g': case 'h':           case 'j': 
+    case 'k':           case 'm':           case 'o': 
+              case 'q':                               
+    case 'u':                     case 'x':           
+    case 'z': 
         goto LIdentifier;

--- a/test/es6/await-futreserved-only-in-modules.js
+++ b/test/es6/await-futreserved-only-in-modules.js
@@ -1,0 +1,35 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+// ES6 spec says that `await` is a FutureReservedWord but only
+// when Module is the goal symbol of the syntatic grammar.
+// That is only when parsing a module script.
+// See http://www.ecma-international.org/ecma-262/6.0/#sec-future-reserved-words
+// or https://tc39.github.io/ecma262/#sec-future-reserved-words
+
+var await = 0; // shouldn't cause syntax error
+if (await !== 0) {
+    print('fail');
+}
+
+function f() {
+    "use strict";
+    var await = 1;
+
+    if (await !== 1) {
+        print('fail');
+    }
+}
+f();
+
+var m = '';
+try {
+    WScript.LoadModule('var await = 0;', 'samethread');
+} catch (e) {
+    m = e.message;
+}
+
+print(m === 'The use of a keyword for an identifier is invalid' ?
+        'pass' : 'fail');

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -1153,4 +1153,11 @@
         <baseline>HTMLComments.baseline</baseline>
     </default>
 </test>
+<test>
+  <default>
+    <files>await-futreserved-only-in-modules.js</files>
+    <compile-flags>-ES6Module</compile-flags>
+    <tags>exclude_dynapogo</tags>
+  </default>
+</test>
 </regress-exe>

--- a/test/es7/asyncawait-syntax.js
+++ b/test/es7/asyncawait-syntax.js
@@ -129,13 +129,6 @@ var tests = [
         }
     },
     {
-        name: "await is a future reserved keyword and recognized in strict mode as an error in non-async functions",
-        body: function () {
-            assert.throws(function () { eval("function f() { 'use strict'; await 10; }"); }, SyntaxError, "await expression not allowed in self-strict non-async function", "'await' expression not allowed in this context");
-            assert.throws(function () { "use strict"; eval("function f() { await 10; }"); }, SyntaxError, "await expression not allowed in parent-strict non-async function", "'await' expression not allowed in this context");
-        }
-    },
-    {
         name: "It is a Syntax Error if FormalParameters Contains AwaitExpression is true",
         body: function () {
             assert.throws(function () { eval("async function af(a, b = await a) { }"); }, SyntaxError, "await expressions not allowed in non-strict async function", "'await' expression not allowed in this context");


### PR DESCRIPTION
Fixes #507 

The ES6 spec states that `await` is a _FutureReservedWord_ but then
refines this and says only when the goal symbol of the syntactic grammar
is _Module_.  Meaning that `await` cannot be used as an identifier in
ES6 modules.  The word is reserved to allow top-level await in modules
as a potential future feature addition to the language.