### PR TITLE
Break up TypePath to avoid false reference.

### DIFF
--- a/lib/Runtime/Types/PathTypeHandler.cpp
+++ b/lib/Runtime/Types/PathTypeHandler.cpp
@@ -1346,7 +1346,7 @@ namespace Js
         Assert(IsObjectHeaderInlinedTypeHandler());
 
         // Clone the type Path here to evolve separately
-        uint16 pathLength = typePath->pathLength;
+        uint16 pathLength = typePath->GetPathLength();
         TypePath * clonedPath = TypePath::New(library->GetRecycler(), pathLength);
 
         for (PropertyIndex i = 0; i < pathLength; i++)


### PR DESCRIPTION
TypePath contains a TinyDictionary which use bytes to store the chain in the dictionary.  These bytes may combine to look like a pointer, more likely in 32-bit then 64-bits, causing memory leaks.  Move all the numerical fields from TypePath to a substructure, and allocate that as leaf.

Now that it is allocated separately from TypePath, we can also make TinyDictionary's next array dynamic size depending on the entries necessary to save some memory,
