### PR TITLE
delete the right indexed property

### DIFF
--- a/lib/Runtime/Types/SimpleDictionaryTypeHandler.cpp
+++ b/lib/Runtime/Types/SimpleDictionaryTypeHandler.cpp
@@ -1638,7 +1638,7 @@ namespace Js
             // Check for a numeric propertyRecord only if objectArray available
             if (instance->HasObjectArray() && propertyRecord->IsNumeric())
             {
-                return SimpleDictionaryTypeHandlerBase<TPropertyIndex, TMapKey, IsNotExtensibleSupported>::DeleteItem(instance, propertyRecord->IsNumeric(), propertyOperationFlags);
+                return SimpleDictionaryTypeHandlerBase<TPropertyIndex, TMapKey, IsNotExtensibleSupported>::DeleteItem(instance, propertyRecord->GetNumericValue(), propertyOperationFlags);
             }
         }
         else


### PR DESCRIPTION
In one delete property code path "propertyRecord->IsNumeric()" (bool) is
passed for "uint32 index" parameter. Don't know why the compiler doesn't
complain about it. So if it is run we always delete property "1".

Seems the bug can only be hit through JSRT and also requires the object to
use SimpleDictionaryTypeHandler.
