### PR TITLE
WasmCompilationException cleanup for ByteCodeWriter

### DIFF
--- a/lib/WasmReader/WasmByteCodeGenerator.cpp
+++ b/lib/WasmReader/WasmByteCodeGenerator.cpp
@@ -168,10 +168,19 @@ WasmBytecodeGenerator::GenerateFunction()
 
     WasmOp op;
     EmitInfo exprInfo;
-    while ((op = m_reader->ReadExpr()) != wnLIMIT)
+
+    try
     {
-        exprInfo = EmitExpr(op);
-        ReleaseLocation(&exprInfo);
+        while ((op = m_reader->ReadExpr()) != wnLIMIT)
+        {
+            exprInfo = EmitExpr(op);
+            ReleaseLocation(&exprInfo);
+        }
+    }
+    catch (...)
+    {
+        m_writer.Reset();
+        throw;
     }
 
     // Functions are like blocks. Emit implicit return of last stmt/expr, unless it is a return or end of file (sexpr).


### PR DESCRIPTION
When WasmCompilationException is thrown, LoadWasmScript()
can't clean up the bytecodeGen properly without a Reset().
