### PR TITLE
Fix bad byte code for deferred nested event handlers

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -1702,7 +1702,7 @@ void ByteCodeGenerator::FinalizeRegisters(FuncInfo * funcInfo, Js::FunctionBody 
 {
     if (funcInfo->NeedEnvRegister())
     {
-        bool constReg = !funcInfo->GetIsEventHandler() && funcInfo->IsGlobalFunction() && !(this->flags & fscrEval);
+        bool constReg = !funcInfo->GetIsTopLevelEventHandler() && funcInfo->IsGlobalFunction() && !(this->flags & fscrEval);
         funcInfo->AssignEnvRegister(constReg);
     }
 
@@ -1902,7 +1902,7 @@ void ByteCodeGenerator::LoadAllConstants(FuncInfo *funcInfo)
     if (funcInfo->NeedEnvRegister())
     {
         byteCodeFunction->MapAndSetEnvRegister(funcInfo->GetEnvRegister());
-        if (funcInfo->GetIsEventHandler())
+        if (funcInfo->GetIsTopLevelEventHandler())
         {
             byteCodeFunction->MapAndSetThisRegisterForEventHandler(funcInfo->thisPointerRegister);
             // The environment is the namespace hierarchy starting with "this".

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -752,12 +752,12 @@ void ByteCodeGenerator::SetRootFuncInfo(FuncInfo* func)
 {
     Assert(pRootFunc == nullptr || pRootFunc == func->byteCodeFunction || !IsInNonDebugMode());
 
-    if (this->flags & (fscrImplicitThis | fscrImplicitParents))
+    if ((this->flags & (fscrImplicitThis | fscrImplicitParents)) && !this->HasParentScopeInfo())
     {
         // Mark a top-level event handler, since it will need to construct the "this" pointer's
         // namespace hierarchy to access globals.
         Assert(!func->IsGlobalFunction());
-        func->SetIsEventHandler(true);
+        func->SetIsTopLevelEventHandler(true);
     }
 
     if (pRootFunc)
@@ -2623,7 +2623,7 @@ FuncInfo* PostVisitFunction(ParseNode* pnode, ByteCodeGenerator* byteCodeGenerat
             (byteCodeGenerator->GetFlags() & (fscrImplicitThis | fscrImplicitParents | fscrEval))))))
         {
             byteCodeGenerator->SetNeedEnvRegister();
-            if (top->GetIsEventHandler())
+            if (top->GetIsTopLevelEventHandler())
             {
                 byteCodeGenerator->AssignThisRegister();
             }
@@ -2669,7 +2669,7 @@ FuncInfo* PostVisitFunction(ParseNode* pnode, ByteCodeGenerator* byteCodeGenerat
                     byteCodeGenerator->SetNeedEnvRegister(); // This to ensure that Env should be there when the FrameDisplay register is there.
                     byteCodeGenerator->AssignFrameDisplayRegister();
 
-                    if (top->GetIsEventHandler())
+                    if (top->GetIsTopLevelEventHandler())
                     {
                         byteCodeGenerator->AssignThisRegister();
                     }

--- a/lib/Runtime/ByteCode/FuncInfo.cpp
+++ b/lib/Runtime/ByteCode/FuncInfo.cpp
@@ -52,7 +52,7 @@ FuncInfo::FuncInfo(
     childCallsEval(false),
     hasArguments(false),
     hasHeapArguments(false),
-    isEventHandler(false),
+    isTopLevelEventHandler(false),
     hasLocalInClosure(false),
     hasClosureReference(false),
     hasGlobalReference(false),

--- a/lib/Runtime/ByteCode/FuncInfo.h
+++ b/lib/Runtime/ByteCode/FuncInfo.h
@@ -124,7 +124,7 @@ public:
     uint childCallsEval : 1;
     uint hasArguments : 1;
     uint hasHeapArguments : 1;
-    uint isEventHandler : 1;
+    uint isTopLevelEventHandler : 1;
     uint hasLocalInClosure : 1;
     uint hasClosureReference : 1;
     uint hasGlobalReference : 1;
@@ -315,12 +315,12 @@ public:
         byteCodeFunction->SetDoBackendArgumentsOptimization(optArgInBackend);
     }
 
-    bool GetIsEventHandler() const {
-        return isEventHandler;
+    bool GetIsTopLevelEventHandler() const {
+        return isTopLevelEventHandler;
     }
 
-    void SetIsEventHandler(bool is) {
-        isEventHandler = is;
+    void SetIsTopLevelEventHandler(bool is) {
+        isTopLevelEventHandler = is;
     }
 
     bool GetChildCallsEval() const {


### PR DESCRIPTION
Don't mark a nested function as a top-level event handler, since this can cause us to emit code to build a COM-hierarchy frame display from the this pointer, which should only be done for the function that is called by the host.