### PR TITLE
Make yield* forward .next() argument to iterable's .next() call

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -3968,7 +3968,7 @@ void ByteCodeGenerator::EnsureSymbolModuleSlots(Symbol* sym, FuncInfo* funcInfo,
         Js::SourceTextModuleRecord* childModuleRecord = moduleRecord->GetChildModuleRecord(moduleSpecifier->Psz());
 
         AssertMsg(childModuleRecord != nullptr, "We somehow tried to resolve an import from a module we didn't resolve.");
-        
+
         Js::ModuleNameRecord* moduleNameRecord = nullptr;
         if (!childModuleRecord->ResolveExport(exportNameId, nullptr, nullptr, &moduleNameRecord) ||
             moduleNameRecord == nullptr)
@@ -4018,7 +4018,7 @@ void ByteCodeGenerator::EnsureImportBindingScopeSlots(ParseNode* pnode, FuncInfo
 
     pnode->sxModule.importEntries->Map([this, funcInfo](ModuleImportEntry& importEntry) {
         Symbol* sym = importEntry.varDecl->sxVar.sym;
-        
+
         Assert(sym->GetIsModuleExportStorage());
         Assert(importEntry.moduleRequest != nullptr);
 
@@ -6992,7 +6992,7 @@ void EmitMethodFld(ParseNode *pnode, Js::RegSlot callObjLocation, Js::PropertyId
     bool isRoot = pnode->nop == knopName && (pnode->sxPid.sym == nullptr || pnode->sxPid.sym->GetIsGlobal());
     bool isScoped = (byteCodeGenerator->GetFlags() & fscrEval) != 0 ||
         (isRoot && callObjLocation != ByteCodeGenerator::RootObjectRegister);
-    
+
     EmitMethodFld(isRoot, isScoped, pnode->location, callObjLocation, propertyId, byteCodeGenerator, funcInfo, registerCacheIdForCall);
 }
 
@@ -9149,14 +9149,14 @@ void EmitYieldStar(ParseNode* yieldStarNode, ByteCodeGenerator* byteCodeGenerato
 
     EmitGetIterator(iteratorLocation, yieldStarNode->sxUni.pnode1->location, byteCodeGenerator, funcInfo);
 
+    // Get a temporary to hold the input for the next() calls.  Initialize it to undefined for the first call.
+    Js::RegSlot nextInputLocation = funcInfo->AcquireTmpRegister();
+    byteCodeGenerator->Writer()->Reg2(Js::OpCode::Ld_A, nextInputLocation, funcInfo->undefinedConstantRegister);
+
     uint loopId = byteCodeGenerator->Writer()->EnterLoop(loopEntrance);
     // since a yield* doesn't have a user defined body, we cannot return from this loop
     // which means we don't need to support EmitJumpCleanup() and there do not need to
     // remember the loopId like the loop statements do.
-
-    // Get a temporary to hold the input for the next() calls.  Initialize it to undefined for the first call.
-    Js::RegSlot nextInputLocation = funcInfo->AcquireTmpRegister();
-    byteCodeGenerator->Writer()->Reg2(Js::OpCode::Ld_A, nextInputLocation, funcInfo->undefinedConstantRegister);
 
     // Call the iterator's next()
     EmitIteratorNext(yieldStarNode->location, iteratorLocation, nextInputLocation, byteCodeGenerator, funcInfo);

--- a/test/es6/generators-functionality.js
+++ b/test/es6/generators-functionality.js
@@ -1425,6 +1425,21 @@ var tests = [
         }
     },
     {
+        name: "yield* forwards .next() parameter to iterable's .next() call",
+        body: function () {
+            function* inner() {
+                assert.areEqual(yield, "a");
+            }
+            function* outer() {
+                yield* inner();
+            }
+
+            var it = outer();
+            it.next();
+            it.next("a");
+        }
+    },
+    {
         name: "Testing 'super' reference inside a generator function",
         body: function () {
             class BASE {


### PR DESCRIPTION
The argument of the first `.next()` was mistakenly initialized inside the `yield*`'s loop, so the correct argument was always overwritten. Move the initialization to `undefined` outside of the loop to fix gh-510