### PR TITLE
CheckFixedFld/CheckObjType fix

### DIFF
--- a/test/fieldopts/fixedfieldmonocheck6.js
+++ b/test/fieldopts/fixedfieldmonocheck6.js
@@ -1,0 +1,36 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+var shouldBailout = false;
+function makeArrayLength() {
+}
+var obj0 = {};
+var obj1 = {};
+var arrObj0 = {};
+var func0 = function () {
+};
+var func2 = function () {
+};
+var func4 = function () {
+};
+obj0.method0 = func0;
+obj0.method1 = func2;
+obj1.method0 = obj0;
+obj1.method1 = func0;
+var ary = Array();
+var i32 = new Int32Array(256);
+var IntArr0 = [];
+var e = -2;
+protoObj0 = Object.create(obj0);
+Object.create(obj1);
+arrObj0.prop4 = e * (ary.unshift() + obj1.method1.call());
+for (var _strvar16 of i32) {
+    _strvar16 >>>= false ? func4() : func4(+obj1.method1.call(protoObj0));
+    IntArr0[function () {
+    } instanceof (typeof obj0.method1 ? obj0.method1 : Object)];
+    obj1.length = makeArrayLength((shouldBailout ? obj0.method0 = obj0.method1 : 1, obj0.method0()));
+}
+
+WScript.Echo('pass');

--- a/test/fieldopts/rlexe.xml
+++ b/test/fieldopts/rlexe.xml
@@ -865,4 +865,9 @@
       <compile-flags>-maxinterpretcount:2 -maxsimplejitruncount:6</compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>fixedfieldmonocheck6.js</files>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
Even in cases where there's another type check upstream (so the operand is marked type-available) we may do a monomorphic type check on the spot (e.g., fixed field check). So instead of checking type-available to see whether we need to push a monomorphic guard type up past a given instruction, look to see whether the instruction has a type check bailout.