### PR TITLE
Removes jenkins redirect stub scripts

### DIFF
--- a/jenkins.buildone.cmd
+++ b/jenkins.buildone.cmd
@@ -1,6 +1,0 @@
-::-------------------------------------------------------------------------------------------------------
-:: Copyright (C) Microsoft. All rights reserved.
-:: Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
-::-------------------------------------------------------------------------------------------------------
-
-@call .\jenkins\buildone.cmd %*

--- a/jenkins.check_copyright.sh
+++ b/jenkins.check_copyright.sh
@@ -1,6 +1,0 @@
-#-------------------------------------------------------------------------------------------------------
-# Copyright (C) Microsoft. All rights reserved.
-# Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
-#-------------------------------------------------------------------------------------------------------
-
-./jenkins/check_copyright.sh $*

--- a/jenkins.check_eol.sh
+++ b/jenkins.check_eol.sh
@@ -1,6 +1,0 @@
-#-------------------------------------------------------------------------------------------------------
-# Copyright (C) Microsoft. All rights reserved.
-# Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
-#-------------------------------------------------------------------------------------------------------
-
-./jenkins/check_eol.sh $*

--- a/jenkins.testone.cmd
+++ b/jenkins.testone.cmd
@@ -1,6 +1,0 @@
-::-------------------------------------------------------------------------------------------------------
-:: Copyright (C) Microsoft. All rights reserved.
-:: Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
-::-------------------------------------------------------------------------------------------------------
-
-@call .\jenkins\testone.cmd %*


### PR DESCRIPTION
Follow up to previous commit that move jenkins scripts to the jenkins
subdirectory.  netci.groovy change is compiled and these redirects are
no longer necessary.

Fixes #48 
Fixes #529 