### PR TITLE
FunctionBody: fix compiler error when doing implicit cast

### DIFF
--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -1479,7 +1479,7 @@ namespace Js
         void SetDeferredParsingEntryPoint();
 
         void SetEntryPoint(ProxyEntryPointInfo* entryPoint, Js::JavascriptMethod address) {
-            entryPoint->address = address;
+            entryPoint->address = (void*)address;
         }
 
         bool IsDynamicScript() const;


### PR DESCRIPTION
Clang is not happy about implicit casts to void*:

FunctionBody.h:1482:33: error: assigning to 'void *' from incompatible type 'Js::JavascriptMethod' (aka 'void *(*)(Js::RecyclableObject *, Js::CallInfo, ...)')
            entryPoint->address = address;
                                ^ ~~~~~~~

We only want the address of the function here so this is safe, add a
C-style cast.