### PR TITLE
CodePageAllocator::AllocPages should pass thru the page count instead of have fix 1 page.o

### DIFF
--- a/lib/Common/Memory/CustomHeap.h
+++ b/lib/Common/Memory/CustomHeap.h
@@ -191,13 +191,13 @@ public:
         return address;
     }
 
-    char * AllocPages(size_t pages, void ** pageSegment, bool canAllocInPreReservedHeapPageSegment, bool isAnyJittedCode, bool * isAllJITCodeInPreReservedRegion)
+    char * AllocPages(uint pages, void ** pageSegment, bool canAllocInPreReservedHeapPageSegment, bool isAnyJittedCode, bool * isAllJITCodeInPreReservedRegion)
     {
         Assert(this->cs.IsLocked());
         char * address = nullptr;
         if (canAllocInPreReservedHeapPageSegment)
         {
-            address = this->preReservedHeapPageAllocator.AllocPages(1, (PageSegmentBase<PreReservedVirtualAllocWrapper>**)pageSegment);
+            address = this->preReservedHeapPageAllocator.AllocPages(pages, (PageSegmentBase<PreReservedVirtualAllocWrapper>**)pageSegment);
 
             if (address == nullptr)
             {
@@ -211,7 +211,7 @@ public:
             {
                 *isAllJITCodeInPreReservedRegion = false;
             }
-            address = this->pageAllocator.AllocPages(1, (PageSegmentBase<VirtualAllocWrapper>**)pageSegment);
+            address = this->pageAllocator.AllocPages(pages, (PageSegmentBase<VirtualAllocWrapper>**)pageSegment);
         }
         else
         {


### PR DESCRIPTION
During refactoring the page count of 1 was copy and paste there.  Since the caller only call with value 1 currently, it doesn't cause any functional issue.  But the request size should be honor when the API is used with different page count in the future.
