### PR TITLE
Fix an implicit toString of symbol object which should not throw TypeError

### DIFF
--- a/lib/Runtime/Language/JavascriptConversion.cpp
+++ b/lib/Runtime/Language/JavascriptConversion.cpp
@@ -666,6 +666,10 @@ CommonNumber:
 
             case TypeIds_Symbol:
                 return JavascriptSymbol::FromVar(aValue)->ToString(scriptContext);
+
+            case TypeIds_SymbolObject:
+                return JavascriptSymbol::ToString(JavascriptSymbolObject::FromVar(aValue)->GetValue(), scriptContext);
+
             case TypeIds_SIMDBool8x16:
             case TypeIds_SIMDBool16x8:
             case TypeIds_SIMDBool32x4:

--- a/test/es6/OS_5500719.js
+++ b/test/es6/OS_5500719.js
@@ -1,0 +1,3 @@
+c = Object(Symbol());
+var y = { [e = c]:(class {}) };
+print('Pass');

--- a/test/es6/OS_5500719.js
+++ b/test/es6/OS_5500719.js
@@ -1,3 +1,8 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
 c = Object(Symbol());
 var y = { [e = c]:(class {}) };
 print('Pass');

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -1160,4 +1160,11 @@
     <tags>exclude_dynapogo</tags>
   </default>
 </test>
+<test>
+  <default>
+    <files>OS_5500719.js</files>
+    <compile-flags>-forceserialized</compile-flags>
+    <tags>exclude_dynapogo</tags>
+  </default>
+</test>
 </regress-exe>


### PR DESCRIPTION
Force serialize exposed a bug in JavascriptConversion::ToString which throws if it is passed a symbol wrapper object instead of correctly calling Symbol.prototype.toString.