### PR TITLE
Fix compact counter in debugging case

### DIFF
--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -4841,6 +4841,8 @@ namespace Js
         char16 debugStringBuffer[MAX_FUNCTION_BODY_DEBUG_STRING_SIZE];
         OUTPUT_VERBOSE_TRACE(Js::DebuggerPhase, _u("Regenerate Due To Debug Mode: function %s (%s) from script context %p\n"),
             this->GetDisplayName(), this->GetDebugNumberSet(debugStringBuffer), m_scriptContext);
+
+        this->counters.bgThreadCallStarted = false; // asuming background jit is stopped and allow the counter setters access again
 #endif
     }
 


### PR DESCRIPTION
In debugging mode function can be reparsed and set the numbers on function body after background code generator has already started. But when reparsing the background jit should have been stopped, so reset bgThreadCallStarted and allow the setter access for reparsing