### PR TITLE
Remove assert in stack func boxing

### DIFF
--- a/lib/Runtime/Library/StackScriptFunction.cpp
+++ b/lib/Runtime/Library/StackScriptFunction.cpp
@@ -699,8 +699,6 @@ namespace Js
             return boxedFunction;
         }
 
-        Assert(functionObjectToBox.Contains(stackFunction->GetFunctionProxy()->GetFunctionProxy()));
-
         if (PHASE_TESTTRACE(Js::StackFuncPhase, stackFunction->GetFunctionProxy()))
         {
             char16 debugStringBuffer[MAX_FUNCTION_BODY_DEBUG_STRING_SIZE];


### PR DESCRIPTION
Remove an assert that doesn't hold if a boxable stack function is found in a frame display.