### PR TITLE
Array.filter slate bug

### DIFF
--- a/lib/Runtime/Library/JavascriptArray.cpp
+++ b/lib/Runtime/Library/JavascriptArray.cpp
@@ -9125,21 +9125,17 @@ Case0:
                     if (newArr)
                     {
                         newArr->DirectSetItemAt(i, element);
-                        ++i;
                     }
                     else
                     {
                         JavascriptArray::SetArrayLikeObjects(RecyclableObject::FromVar(newObj), i, element);
-                        ++i;
                     }
+                    ++i;
                 }
             }
         }
         else
         {
-            // If source was not an array object, we will always return an array object
-            Assert(newArr);
-
             for (BigIndex k = 0u; k < length; ++k)
             {
                 if (!JavascriptOperators::HasItem(dynamicObject, k.IsSmallIndex() ? k.GetSmallIndex() : k.GetBigIndex()))
@@ -9155,7 +9151,14 @@ Case0:
 
                 if (JavascriptConversion::ToBoolean(selected, scriptContext))
                 {
-                    newArr->DirectSetItemAt(i, element);
+                    if (newArr)
+                    {
+                        newArr->DirectSetItemAt(i, element);
+                    }
+                    else
+                    {
+                        JavascriptArray::SetArrayLikeObjects(RecyclableObject::FromVar(newObj), i, element);
+                    }
                     ++i;
                 }
             }

--- a/test/es6/ES6ArrayUseConstructor.js
+++ b/test/es6/ES6ArrayUseConstructor.js
@@ -338,6 +338,21 @@ var tests = [
             assert.areEqual(3, out.length, "Array.prototype.splice sets the length property of returned object when constructor is %Array% of a different script context");
         }
     },
+    {
+        name: "ArraySpeciesCreate test through Array.prototype.filter - ES5 arrays",
+        body: function () {
+           
+
+            var arr = ['a','b','c'];
+            Object.defineProperty(arr, "3", { get : function () { return 0xff;}, set: function() { }}); //Create an ES5 array 
+            Object.defineProperty(Array, Symbol.species, {enumerable: false, configurable: true, writable: true, value: Object});
+            
+            var out  = Array.prototype.filter.call(arr, function() { return true; });
+            assert.isFalse(Array.isArray(out), "Return from Array.prototype.filter should be an object when constructor has [@@species] == Object on an ES5 array");
+            assert.areEqual('a', out[0], "Array.prototype.filter output Object should have correct first index value when constructor has [@@species] == Object on an ES5 array");
+            assert.areEqual(255, out[3], "Array.prototype.fitler output Object should have correct last index value when constructor has [@@species] == Object on an ES5 array");            
+        }
+    },
 ];
 
 testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });


### PR DESCRIPTION
Fixes subtle bug in Array.prototype.filter when Symbol.species is specified. Fixes OS bug [6030663](https://microsoft.visualstudio.com/web/wi.aspx?pcguid=cb55739e-4afe-46a3-970f-1b49d8ee7564&id=6030663). Exposed by stress runs. 