### PR TITLE
Assertion: default parameter with class expression

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -3162,16 +3162,20 @@ void VisitNestedScopes(ParseNode* pnodeScopeList, ParseNode* pnodeParent, ByteCo
             break;
 
         case knopBlock:
+        {
             PreVisitBlock(pnodeScope, byteCodeGenerator);
-            pnodeParent->sxFnc.funcInfo->OnStartVisitScope(pnodeScope->sxBlock.scope);
+            bool isMergedScope;
+            pnodeParent->sxFnc.funcInfo->OnStartVisitScope(pnodeScope->sxBlock.scope, &isMergedScope);
             VisitNestedScopes(pnodeScope->sxBlock.pnodeScopes, pnodeParent, byteCodeGenerator, prefix, postfix, pIndex);
-            pnodeParent->sxFnc.funcInfo->OnEndVisitScope(pnodeScope->sxBlock.scope);
+            pnodeParent->sxFnc.funcInfo->OnEndVisitScope(pnodeScope->sxBlock.scope, isMergedScope);
             PostVisitBlock(pnodeScope, byteCodeGenerator);
 
             pnodeScope = pnodeScope->sxBlock.pnodeNext;
             break;
+        }
 
         case knopCatch:
+        {
             PreVisitCatch(pnodeScope, byteCodeGenerator);
 
             Visit(pnodeScope->sxCatch.pnodeParam, byteCodeGenerator, prefix, postfix);
@@ -3182,23 +3186,28 @@ void VisitNestedScopes(ParseNode* pnodeScopeList, ParseNode* pnodeParent, ByteCo
                     pnodeScope->sxCatch.pnodeParam->sxParamPattern.location = byteCodeGenerator->NextVarRegister();
                 }
             }
-            pnodeParent->sxFnc.funcInfo->OnStartVisitScope(pnodeScope->sxCatch.scope);
+            bool isMergedScope;
+            pnodeParent->sxFnc.funcInfo->OnStartVisitScope(pnodeScope->sxCatch.scope, &isMergedScope);
             VisitNestedScopes(pnodeScope->sxCatch.pnodeScopes, pnodeParent, byteCodeGenerator, prefix, postfix, pIndex);
 
-            pnodeParent->sxFnc.funcInfo->OnEndVisitScope(pnodeScope->sxCatch.scope);
+            pnodeParent->sxFnc.funcInfo->OnEndVisitScope(pnodeScope->sxCatch.scope, isMergedScope);
             PostVisitCatch(pnodeScope, byteCodeGenerator);
 
             pnodeScope = pnodeScope->sxCatch.pnodeNext;
             break;
+        }
 
         case knopWith:
+        {
             PreVisitWith(pnodeScope, byteCodeGenerator);
-            pnodeParent->sxFnc.funcInfo->OnStartVisitScope(pnodeScope->sxWith.scope);
+            bool isMergedScope;
+            pnodeParent->sxFnc.funcInfo->OnStartVisitScope(pnodeScope->sxWith.scope, &isMergedScope);
             VisitNestedScopes(pnodeScope->sxWith.pnodeScopes, pnodeParent, byteCodeGenerator, prefix, postfix, pIndex);
-            pnodeParent->sxFnc.funcInfo->OnEndVisitScope(pnodeScope->sxWith.scope);
+            pnodeParent->sxFnc.funcInfo->OnEndVisitScope(pnodeScope->sxWith.scope, isMergedScope);
             PostVisitWith(pnodeScope, byteCodeGenerator);
             pnodeScope = pnodeScope->sxWith.pnodeNext;
             break;
+        }
 
         default:
             AssertMsg(false, "Unexpected opcode in tree of scopes");

--- a/lib/Runtime/ByteCode/FuncInfo.cpp
+++ b/lib/Runtime/ByteCode/FuncInfo.cpp
@@ -427,8 +427,10 @@ void FuncInfo::OnEndVisitFunction(ParseNode *pnodeFnc)
     this->SetCurrentChildFunction(nullptr);
 }
 
-void FuncInfo::OnStartVisitScope(Scope *scope)
+void FuncInfo::OnStartVisitScope(Scope *scope, bool *pisMergedScope)
 {
+    *pisMergedScope = false;
+
     if (scope == nullptr)
     {
         return;
@@ -446,6 +448,7 @@ void FuncInfo::OnStartVisitScope(Scope *scope)
                  && scope->GetScopeType() == ScopeType_Block)
         {
             // If param and body are merged then the class declaration in param scope will have body as the parent
+            *pisMergedScope = true;
             Assert(childScope == scope->GetEnclosingScope()->GetEnclosingScope());
         }
         else
@@ -455,9 +458,10 @@ void FuncInfo::OnStartVisitScope(Scope *scope)
     }
 
     this->SetCurrentChildScope(scope);
+    return;
 }
 
-void FuncInfo::OnEndVisitScope(Scope *scope)
+void FuncInfo::OnEndVisitScope(Scope *scope, bool isMergedScope)
 {
     if (scope == nullptr)
     {
@@ -465,7 +469,7 @@ void FuncInfo::OnEndVisitScope(Scope *scope)
     }
     Assert(this->GetCurrentChildScope() == scope || (scope->GetScopeType() == ScopeType_Parameter && this->GetParamScope() == scope));
 
-    this->SetCurrentChildScope(scope->GetEnclosingScope());
+    this->SetCurrentChildScope(isMergedScope ? scope->GetEnclosingScope()->GetEnclosingScope() : scope->GetEnclosingScope());
 }
 
 CapturedSymMap *FuncInfo::EnsureCapturedSymMap()

--- a/lib/Runtime/ByteCode/FuncInfo.h
+++ b/lib/Runtime/ByteCode/FuncInfo.h
@@ -794,8 +794,8 @@ public:
 
     void OnStartVisitFunction(ParseNode *pnodeFnc);
     void OnEndVisitFunction(ParseNode *pnodeFnc);
-    void OnStartVisitScope(Scope *scope);
-    void OnEndVisitScope(Scope *scope);
+    void OnStartVisitScope(Scope *scope, bool *pisMergedScope);
+    void OnEndVisitScope(Scope *scope, bool isMergedScope = false);
     void AddCapturedSym(Symbol *sym);
     CapturedSymMap *EnsureCapturedSymMap();
 

--- a/test/es6/default.js
+++ b/test/es6/default.js
@@ -245,8 +245,7 @@ var tests = [
         assert.throws(function () { eval('function f(a = 1, b = class c { f() { var a1 = 10; return a; }}) { }') }, SyntaxError, "Class methods that refer to a formal are not allowed in the param scope", "Formals cannot contain functions definitions that reference them");
         assert.throws(function () { eval('function f(a = 1, b = () => { return class c { f() { var a1 = 10; return a; }} }) { }') }, SyntaxError, "Nested class methods that refer to a formal are not allowed in the param scope", "Formals cannot contain functions definitions that reference them");
         
-        // TODO(aneeshd): The additional block created for class seems to have the wrong scope associated with it. Will reenable this once the issue in https://github.com/Microsoft/ChakraCore/issues/299 is fixed.
-        // assert.doesNotThrow(function f(a = 1, b = class c { f() { return 2; }}) { }, "Class methods that do not refer to a formal are allowed in the param scope");
+        assert.doesNotThrow(function f(a = 1, b = class c { f() { return 2; }}) { }, "Class methods that do not refer to a formal are allowed in the param scope");
 
         assert.throws(function () { eval("function f(a = eval('1')) { }") }, SyntaxError, "Eval is not allowed in the parameter scope", "'eval' is not allowed in the default initializer");
         assert.throws(function () { eval("function f(a, b = function () { eval('1'); }) { }") }, SyntaxError, "Evals in child functions are not allowed in the parameter scope", "'eval' is not allowed in the default initializer");


### PR DESCRIPTION
     Test case:  `function foo(a=class { }) { }`
     `Assertion failure: childScope == scope->GetEnclosingScope(), FuncInfo::OnStartVisitScope()`
     When parameter scope is merged with body scope, currentChildScope is pushed twice (vs. once otherwise)
     FuncInfo::OnEndVisitScope(), however, does not pop twice to recover the scope stack, causing the problem.
     Fix by adding a local flag and pop scope stack properly for merged scope case.
     Re-enable test case.