### PR TITLE
Fixing a debug unittest break.

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -10182,7 +10182,7 @@ void Emit(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator, FuncInfo *func
     case knopAsgLsh:
     case knopAsgRsh:
     case knopAsgRs2:
-        STARTSTATEMENET_IFTOPLEVEL(isTopLevel, pnode);
+        byteCodeGenerator->StartStatement(pnode);
         // Assign a register for the result only if the result is used or the LHS can't be assigned to
         // (i.e., is a constant).
         if (pnode->isUsed || fReturnValue || funcInfo->RegIsConst(pnode->sxBin.pnode1->location))
@@ -10211,7 +10211,7 @@ void Emit(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator, FuncInfo *func
         }
         funcInfo->ReleaseLoad(pnode->sxBin.pnode1);
 
-        ENDSTATEMENET_IFTOPLEVEL(isTopLevel, pnode);
+        byteCodeGenerator->EndStatement(pnode);
         break;
 
     // General nodes.


### PR DESCRIPTION
My adding of StartStatement and EndStatement with top level broke one test as I have changed to check isTopLevel for knopAsgAdd. Reverted that. As the for-loop incrementer will not be top level.
