### PR TITLE
Change assigning to const to runtime TypeError

### DIFF
--- a/lib/Parser/Hash.h
+++ b/lib/Parser/Hash.h
@@ -62,32 +62,25 @@ public:
 
 struct PidRefStack
 {
-    PidRefStack() : isAsg(false), isDynamic(false), id(0), span(), sym(nullptr), prev(nullptr), isModuleExport(false) {}
-    PidRefStack(int id) : isAsg(false), isDynamic(false), id(id), span(), sym(nullptr), prev(nullptr), isModuleExport(false) {}
+    PidRefStack() : isDynamic(false), id(0), sym(nullptr), prev(nullptr), isModuleExport(false) {}
+    PidRefStack(int id) : isDynamic(false), id(id), sym(nullptr), prev(nullptr), isModuleExport(false) {}
 
-    charcount_t GetIchMin()   { return span.GetIchMin(); }
-    charcount_t GetIchLim()   { return span.GetIchLim(); }
     int GetScopeId() const    { return id; }
     Symbol *GetSym() const    { return sym; }
     void SetSym(Symbol *sym)  { this->sym = sym; }
-    bool IsAssignment() const { return isAsg; }
     bool IsDynamicBinding() const { return isDynamic; }
     void SetDynamicBinding()  { isDynamic = true; }
     bool IsModuleExport() const { return isModuleExport; }
     void SetModuleExport()    { isModuleExport = true; }
-
-    void TrackAssignment(charcount_t ichMin, charcount_t ichLim);
 
     Symbol **GetSymRef()
     {
         return &sym;
     }
 
-    bool           isAsg;
     bool           isDynamic;
     bool           isModuleExport;
     int            id;
-    Span           span;
     Symbol        *sym;
     PidRefStack   *prev;
 };
@@ -169,18 +162,6 @@ public:
             }
         }
         return nullptr;
-    }
-
-    charcount_t GetTopIchMin() const
-    {
-        Assert(m_pidRefStack);
-        return m_pidRefStack->GetIchMin();
-    }
-
-    charcount_t GetTopIchLim() const
-    {
-        Assert(m_pidRefStack);
-        return m_pidRefStack->GetIchLim();
     }
 
     void PushPidRef(int blockId, PidRefStack *newRef)

--- a/lib/Parser/Parse.h
+++ b/lib/Parser/Parse.h
@@ -198,7 +198,6 @@ private:
     BOOL                m_uncertainStructure;
     bool                m_hasParallelJob;
     bool                m_doingFastScan;
-    Span                m_asgToConst;
     int                 m_nextBlockId;
 
     // RegexPattern objects created for literal regexes are recycler-allocated and need to be kept alive until the function body
@@ -930,7 +929,6 @@ public:
 
 private:
     void DeferOrEmitPotentialSpreadError(ParseNodePtr pnodeT);
-    template<bool buildAST> void TrackAssignment(ParseNodePtr pnodeT, IdentToken* pToken, charcount_t ichMin, charcount_t ichLim);
     PidRefStack* PushPidRef(IdentPtr pid);
     PidRefStack* FindOrAddPidRef(IdentPtr pid, int blockId, int maxScopeId = -1);
     void RemovePrevPidRef(IdentPtr pid, PidRefStack *lastRef);

--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -4734,7 +4734,7 @@ void ByteCodeGenerator::EmitPropStore(Js::RegSlot rhsLocation, Symbol *sym, Iden
     {
         if (!isConstDecl && sym->GetDecl() && sym->GetDecl()->nop == knopConstDecl)
         {
-            this->m_writer.W1(Js::OpCode::RuntimeReferenceError, SCODE_CODE(ERRAssignmentToConst));
+            this->m_writer.W1(Js::OpCode::RuntimeTypeError, SCODE_CODE(ERRAssignmentToConst));
         }
 
         EnsureSymbolModuleSlots(sym, funcInfo);
@@ -4898,7 +4898,7 @@ void ByteCodeGenerator::EmitPropStore(Js::RegSlot rhsLocation, Symbol *sym, Iden
             // This is a case where const reassignment can't be proven statically (e.g., eval, with) so
             // we have to catch it at runtime.
             this->m_writer.W1(
-                Js::OpCode::RuntimeReferenceError, SCODE_CODE(ERRAssignmentToConst));
+                Js::OpCode::RuntimeTypeError, SCODE_CODE(ERRAssignmentToConst));
         }
         // Make sure the property has a slot. This will bump up the size of the slot array if necessary.
         Js::PropertyId slot = sym->EnsureScopeSlot(funcInfo);
@@ -4947,7 +4947,7 @@ void ByteCodeGenerator::EmitPropStore(Js::RegSlot rhsLocation, Symbol *sym, Iden
         {
             // This is a case where const reassignment can't be proven statically (e.g., eval, with) so
             // we have to catch it at runtime.
-            this->m_writer.W1(Js::OpCode::RuntimeReferenceError, SCODE_CODE(ERRAssignmentToConst));
+            this->m_writer.W1(Js::OpCode::RuntimeTypeError, SCODE_CODE(ERRAssignmentToConst));
         }
         if (rhsLocation != sym->GetLocation())
         {

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -2372,7 +2372,7 @@ CommonNumber:
                     Assert((flags & Data) == Data && (flags & Writable) == None);
                     if (flags & Const)
                     {
-                        JavascriptError::ThrowReferenceError(requestContext, ERRAssignmentToConst);
+                        JavascriptError::ThrowTypeError(requestContext, ERRAssignmentToConst);
                     }
 
                     JavascriptError::ThrowCantAssign(propertyOperationFlags, requestContext, propertyId);
@@ -2782,7 +2782,7 @@ CommonNumber:
                     {
                         if (flags & Const)
                         {
-                            JavascriptError::ThrowReferenceError(scriptContext, ERRAssignmentToConst);
+                            JavascriptError::ThrowTypeError(scriptContext, ERRAssignmentToConst);
                         }
 
                         Assert(!isLexicalThisSlotSymbol);

--- a/test/LetConst/AssignmentToConst.baseline
+++ b/test/LetConst/AssignmentToConst.baseline
@@ -1,23 +1,48 @@
-SyntaxError: Assignment to const
-SyntaxError: Assignment to const
-SyntaxError: Assignment to const
-SyntaxError: Assignment to const
-SyntaxError: Assignment to const
-SyntaxError: Assignment to const
-SyntaxError: Assignment to const
-SyntaxError: Assignment to const
-SyntaxError: Assignment to const
-SyntaxError: Assignment to const
-SyntaxError: Assignment to const
-SyntaxError: Assignment to const
-SyntaxError: Assignment to const
-SyntaxError: Assignment to const
-SyntaxError: Assignment to const
-SyntaxError: Assignment to const
-SyntaxError: Assignment to const
+test 1
+TypeError: Assignment to const
+test 2
+TypeError: Assignment to const
+test 3
+TypeError: Assignment to const
+test 4
+TypeError: Assignment to const
+test 5
+TypeError: Assignment to const
+test 6
+TypeError: Assignment to const
+test 7
+TypeError: Assignment to const
+test 8
+TypeError: Assignment to const
+test 9
+TypeError: Assignment to const
+test 10
+TypeError: Assignment to const
+test 11
+TypeError: Assignment to const
+test 12
+TypeError: Assignment to const
+test 13
+TypeError: Assignment to const
+test 14
+TypeError: Assignment to const
+test 15
+TypeError: Assignment to const
+test 16
+TypeError: Assignment to const
+test 17
+TypeError: Assignment to const
+test 18
+passed
+test 19
 ReferenceError: Use before declaration
-SyntaxError: Assignment to const
-SyntaxError: Assignment to const
-SyntaxError: Assignment to const
-SyntaxError: Assignment to const
-SyntaxError: Assignment to const
+test 20
+TypeError: Assignment to const
+test 21
+TypeError: Assignment to const
+test 22
+TypeError: Assignment to const
+test 23
+ReferenceError: Use before declaration
+test 24
+ReferenceError: Use before declaration

--- a/test/LetConst/AssignmentToConst.js
+++ b/test/LetConst/AssignmentToConst.js
@@ -3,29 +3,29 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 
-try { eval("const x = 1; x = 2;"); } catch (e) { WScript.Echo(e); }
-try { eval("const x = 1; x += 2;"); } catch (e) { WScript.Echo(e); }
-try { eval("const x = 1; x -= 2;"); } catch (e) { WScript.Echo(e); }
-try { eval("const x = 1; x *= 2;"); } catch (e) { WScript.Echo(e); }
-try { eval("const x = 1; x /= 2;"); } catch (e) { WScript.Echo(e); }
-try { eval("const x = 1; x &= 2;"); } catch (e) { WScript.Echo(e); }
-try { eval("const x = 1; x |= 2;"); } catch (e) { WScript.Echo(e); }
-try { eval("const x = 1; x ^= 2;"); } catch (e) { WScript.Echo(e); }
-try { eval("const x = 1; x >>= 2;"); } catch (e) { WScript.Echo(e); }
-try { eval("const x = 1; x <<= 2;"); } catch (e) { WScript.Echo(e); }
-try { eval("const x = 1; x >>>= 2;"); } catch (e) { WScript.Echo(e); }
-try { eval("const x = 1; x %= 2;"); } catch (e) { WScript.Echo(e); }
-try { eval("const x = 1; x ++;"); } catch (e) { WScript.Echo(e); }
-try { eval("const x = 1; x --;"); } catch (e) { WScript.Echo(e); }
-try { eval("const x = 1; ++ x;"); } catch (e) { WScript.Echo(e); }
-try { eval("const x = 1; -- x;"); } catch (e) { WScript.Echo(e); }
-try { eval("const x = 1; {x++;}"); } catch (e) { WScript.Echo(e); }
-try { eval("const x = 1; {let x = 2; x++;}"); } catch (e) { WScript.Echo(e); }
-try { eval("const x = 1; {x++; let x = 2;}"); } catch (e) { WScript.Echo(e); }
-try { eval("const x = 1; {let x = 2;} x = 10"); } catch (e) { WScript.Echo(e); }
-try { eval("const x = 1; {const x = 2; x++;}"); } catch (e) { WScript.Echo(e); }
-try { eval("const x = 1; {const x = 2;} x++;"); } catch (e) { WScript.Echo(e); }
-try { eval("x = 1; {let x = 2;} const x = 10;"); } catch (e) { WScript.Echo(e); }
-try { eval("function f() {x = 1; {let x = 2;} const x = 10;} f();"); } catch (e) { WScript.Echo(e); }
+try { eval("WScript.Echo('test 1'); const x = 1; x = 2;"); WScript.Echo("passed"); } catch (e) { WScript.Echo(e); }
+try { eval("WScript.Echo('test 2'); const x = 1; x += 2;"); WScript.Echo("passed"); } catch (e) { WScript.Echo(e); }
+try { eval("WScript.Echo('test 3'); const x = 1; x -= 2;"); WScript.Echo("passed"); } catch (e) { WScript.Echo(e); }
+try { eval("WScript.Echo('test 4'); const x = 1; x *= 2;"); WScript.Echo("passed"); } catch (e) { WScript.Echo(e); }
+try { eval("WScript.Echo('test 5'); const x = 1; x /= 2;"); WScript.Echo("passed"); } catch (e) { WScript.Echo(e); }
+try { eval("WScript.Echo('test 6'); const x = 1; x &= 2;"); WScript.Echo("passed"); } catch (e) { WScript.Echo(e); }
+try { eval("WScript.Echo('test 7'); const x = 1; x |= 2;"); WScript.Echo("passed"); } catch (e) { WScript.Echo(e); }
+try { eval("WScript.Echo('test 8'); const x = 1; x ^= 2;"); WScript.Echo("passed"); } catch (e) { WScript.Echo(e); }
+try { eval("WScript.Echo('test 9'); const x = 1; x >>= 2;"); WScript.Echo("passed"); } catch (e) { WScript.Echo(e); }
+try { eval("WScript.Echo('test 10'); const x = 1; x <<= 2;"); WScript.Echo("passed"); } catch (e) { WScript.Echo(e); }
+try { eval("WScript.Echo('test 11'); const x = 1; x >>>= 2;"); WScript.Echo("passed"); } catch (e) { WScript.Echo(e); }
+try { eval("WScript.Echo('test 12'); const x = 1; x %= 2;"); WScript.Echo("passed"); } catch (e) { WScript.Echo(e); }
+try { eval("WScript.Echo('test 13'); const x = 1; x ++;"); WScript.Echo("passed"); } catch (e) { WScript.Echo(e); }
+try { eval("WScript.Echo('test 14'); const x = 1; x --;"); WScript.Echo("passed"); } catch (e) { WScript.Echo(e); }
+try { eval("WScript.Echo('test 15'); const x = 1; ++ x;"); WScript.Echo("passed"); } catch (e) { WScript.Echo(e); }
+try { eval("WScript.Echo('test 16'); const x = 1; -- x;"); WScript.Echo("passed"); } catch (e) { WScript.Echo(e); }
+try { eval("WScript.Echo('test 17'); const x = 1; {x++;}"); WScript.Echo("passed"); } catch (e) { WScript.Echo(e); }
+try { eval("WScript.Echo('test 18'); const x = 1; {let x = 2; x++;}"); WScript.Echo("passed"); } catch (e) { WScript.Echo(e); }
+try { eval("WScript.Echo('test 19'); const x = 1; {x++; let x = 2;}"); WScript.Echo("passed"); } catch (e) { WScript.Echo(e); }
+try { eval("WScript.Echo('test 20'); const x = 1; {let x = 2;} x = 10"); WScript.Echo("passed"); } catch (e) { WScript.Echo(e); }
+try { eval("WScript.Echo('test 21'); const x = 1; {const x = 2; x++;}"); WScript.Echo("passed"); } catch (e) { WScript.Echo(e); }
+try { eval("WScript.Echo('test 22'); const x = 1; {const x = 2;} x++;"); WScript.Echo("passed"); } catch (e) { WScript.Echo(e); }
+try { eval("WScript.Echo('test 23'); x = 1; {let x = 2;} const x = 10;"); WScript.Echo("passed"); } catch (e) { WScript.Echo(e); }
+try { eval("WScript.Echo('test 24'); function f() {x = 1; {let x = 2;} const x = 10;} f();"); WScript.Echo("passed"); } catch (e) { WScript.Echo(e); }
 
 

--- a/test/LetConst/constreassign1.baseline
+++ b/test/LetConst/constreassign1.baseline
@@ -1,8 +1,8 @@
 3
-ReferenceError: Assignment to const
+TypeError: Assignment to const
 3
-ReferenceError: Assignment to const
-ReferenceError: Assignment to const
+TypeError: Assignment to const
+TypeError: Assignment to const
 3
-ReferenceError: Assignment to const
-ReferenceError: Assignment to const
+TypeError: Assignment to const
+TypeError: Assignment to const

--- a/test/LetConst/constreassign1.js
+++ b/test/LetConst/constreassign1.js
@@ -7,7 +7,7 @@ const a = 1;
 
 with({a:2}) {
     a++;
-    print(a);
+    print(a);  // 3
 }
 
 try {
@@ -17,7 +17,7 @@ try {
     }
 }
 catch(e) {
-    print(e);
+    print(e);  // TypeError: Assignment to const
 }
 
 let foo1 = new Function(
@@ -26,7 +26,7 @@ let foo1 = new Function(
     "    print(a);" +
     "}");
 
-foo1();
+foo1();   // 3
 
 let foo2 = new Function(
     "with({b:2}) {" + 
@@ -38,7 +38,7 @@ try {
     foo2();
 }
 catch(e) {
-    print(e);
+    print(e);  // TypeError: Assignment to const
 }
 
 try {
@@ -47,14 +47,14 @@ try {
     print(a);
 }
 catch(e) {
-    print(e);
+    print(e);  // TypeError: Assignment to const
 }
 
 (function() {
     const a = 1;
     with({a:2}) {
         a++;
-        print(a);
+        print(a);  // 3
     }
 
     try {
@@ -64,7 +64,7 @@ catch(e) {
         }
     }
     catch(e) {
-        print(e);
+        print(e);  // TypeError: Assignment to const
     }
 
     try {
@@ -73,7 +73,7 @@ catch(e) {
         print(a);
     }
     catch(e) {
-        print(e);
+        print(e);  // TypeError: Assignment to const
     }
 })();
 

--- a/test/LetConst/defer2.baseline
+++ b/test/LetConst/defer2.baseline
@@ -1,2 +1,4 @@
-SyntaxError: Assignment to const
-	at code (defer2.js:9:9)
+TypeError: Assignment to const
+	at g() (defer2.js:9:9)
+	at f() (defer2.js:11:5)
+	at Global code (defer2.js:13:1)

--- a/test/LetConst/defer3.baseline
+++ b/test/LetConst/defer3.baseline
@@ -1,14 +1,14 @@
 Syntax check succeeded
 Syntax check succeeded
-SyntaxError: Assignment to const
-SyntaxError: Assignment to const
-SyntaxError: Assignment to const
-SyntaxError: Assignment to const
-Syntax check succeeded
-SyntaxError: Assignment to const
 Syntax check succeeded
 Syntax check succeeded
-SyntaxError: Assignment to const
+Syntax check succeeded
+Syntax check succeeded
+Syntax check succeeded
+Syntax check succeeded
+Syntax check succeeded
+Syntax check succeeded
+Syntax check succeeded
 SyntaxError: Const must be initialized
 SyntaxError: Const must be initialized
 SyntaxError: Const must be initialized

--- a/test/es6/blockscope-functionbinding.baseline
+++ b/test/es6/blockscope-functionbinding.baseline
@@ -166,10 +166,10 @@ function l(one) { }
 function l(two) { }
 function l(two) { }
 outer let l
-ReferenceError: Assignment to const
+TypeError: Assignment to const
 const m
 const m
-ReferenceError: Assignment to const
+TypeError: Assignment to const
 inner const m
 const m
 function m(three) { }
@@ -180,7 +180,7 @@ function n() { }
 function n() { }
 ReferenceError: Use before declaration
 let o
-ReferenceError: Assignment to const
+TypeError: Assignment to const
 const p
 function q() { }
 var q
@@ -247,11 +247,11 @@ function glo_t19_l(two) { }
 function glo_t19_l(two) { }
 outer let glo_t19_l
 undefined
-ReferenceError: Assignment to const
+TypeError: Assignment to const
 const glo_t19_m
 const glo_t19_m
 undefined
-ReferenceError: Assignment to const
+TypeError: Assignment to const
 inner const m
 const glo_t19_m
 undefined
@@ -264,7 +264,7 @@ function glo_t19_n() { }
 function glo_t19_n() { }
 ReferenceError: Use before declaration
 let glo_t19_o
-ReferenceError: Assignment to const
+TypeError: Assignment to const
 const glo_t19_p
 function glo_t19_q() { }
 var glo_t19_q

--- a/test/es6/classes.js
+++ b/test/es6/classes.js
@@ -710,14 +710,14 @@ var tests = [
 
       // Class name is immutable within class body.
       var obj1 = new c();
-      assert.throws(function() { obj1.reassign() }, ReferenceError);
+      assert.throws(function() { obj1.reassign() }, TypeError);
 
       // Class name is also immutable within body of class declaration statement
       class Q extends c {
           reassign() { eval('Q = 0;') }
       };
       var obj2 = new Q();
-      assert.throws(function() { obj2.reassign() }, ReferenceError);
+      assert.throws(function() { obj2.reassign() }, TypeError);
       // Class name binding in enclosing context is mutable
       Q = 0;
       assert.areEqual(Q, 0, "Mutable class declaration binding");
@@ -1125,6 +1125,19 @@ var tests = [
             assert.doesNotThrow(function () { eval("class C { set foo(x) { } }"); }, "Class setter with exactly one parameter is valid syntax", "asdf");
             assert.throws(function () { eval("class C { set foo() { } }"); }, SyntaxError, "Class setter with zero parameters is invalid syntax", "Setter functions must have exactly one parameter");
             assert.throws(function () { eval("class C { set foo(x, y, z) { } }"); }, SyntaxError, "Class setter with more than one parameter is invalid syntax", "Setter functions must have exactly one parameter");
+        }
+    },
+    {
+        name: "class identifier is const binding inside class body",
+        body: function () {
+            assert.throws(function () { class A { constructor() { A = 0; } }; new A(); }, TypeError, "Assignment to class identifier in constructor");
+            assert.throws(function() { new (class A { constructor() { A = 0; }}); }, TypeError, "Assignment to class identifier in constructor");
+            assert.throws(function() { class A { m() { A = 0; } }; new A().m(); }, TypeError, "Assignment to class identifier in method");
+            assert.throws(function() { new (class A { m() { A = 0; } }).m(); }, TypeError, "Assignment to class identifier in method" );
+            assert.throws(function() { class A { get x() { A = 0; } }; new A().x; }, TypeError, "Assignment to class identifier in getter");
+            assert.throws(function() { (new (class A { get x() { A = 0; } })).x; }, TypeError, "Assignment to class identifier in getter");
+            assert.throws(function() { class A { set x(_) { A = 0; } }; new A().x = 15; }, TypeError, "Assignment to class identifier in setter");
+            assert.throws(function() { (new (class A { set x(_) { A = 0; } })).x = 15; }, TypeError, "Assignment to class identifier in setter");
         }
     },
 ];

--- a/test/es6/destructuring_bugs.js
+++ b/test/es6/destructuring_bugs.js
@@ -83,6 +83,14 @@ var tests = [
     }
   },
   {
+    name: "Destructuring bug fix - assign to const",
+    body: function () {
+      assert.throws(function () { const c = 10; ({c} = {c:11}); }, TypeError, "Cannot assign to const", "Assignment to const");
+      assert.throws(function () { eval("const c = 10; ({c} = {c:11});"); }, TypeError, "Cannot assign to const in eval", "Assignment to const");
+      assert.throws(function () { const c = 10; eval("({c} = {c:11});"); }, TypeError, "Cannot assign to const in eval, where const is defined outsdie of eval", "Assignment to const");
+    }
+  },
+  {
     name: "Destructuring bug fix - pattern with rest parameter",
     body: function () {
       assert.doesNotThrow(function () { eval("function foo({a}, ...b) { if (b) { } }; foo({});"); } );

--- a/test/es6/forloops-per-iteration-bindings.js
+++ b/test/es6/forloops-per-iteration-bindings.js
@@ -89,10 +89,13 @@ var tests = [
     {
         name: "const variables in for-in and for-of loops cannot be assigned",
         body: function () {
-            assert.throws(function () { eval("for (const x in { a: 1 }) { x = 1; }"); }, SyntaxError, "assignment to const known at parse time in for-in loop", "Assignment to const");
-            assert.throws(function () { for (const x in { a: 1 }) { eval("x = 1;"); } }, ReferenceError, "assignment to const only known at run time in for-in loop", "Assignment to const");
-            assert.throws(function () { eval("for (const x of [ 0 ]) { x = 1; }"); }, SyntaxError, "assignment to const known at parse time in for-of loop", "Assignment to const");
-            assert.throws(function () { for (const x of [ 0 ]) { eval("x = 1;"); } }, ReferenceError, "assignment to const only known at run time in for-of loop", "Assignment to const");
+            assert.throws(function () { for (const x in { a: 1 }) { x = 1; } }, TypeError, "assignment to const known at parse time in for-in loop", "Assignment to const");
+            assert.throws(function () { for (const x of [ 0 ]) { x = 1; } }, TypeError, "assignment to const known at parse time in for-of loop", "Assignment to const");
+
+            assert.throws(function () { eval("for (const x in { a: 1 }) { x = 1; }"); }, TypeError, "assignment to const known at eval parse time in for-in loop", "Assignment to const");
+            assert.throws(function () { for (const x in { a: 1 }) { eval("x = 1;"); } }, TypeError, "assignment to const only known at run time in for-in loop", "Assignment to const");
+            assert.throws(function () { eval("for (const x of [ 0 ]) { x = 1; }"); }, TypeError, "assignment to const known at eval parse time in for-of loop", "Assignment to const");
+            assert.throws(function () { for (const x of [ 0 ]) { eval("x = 1;"); } }, TypeError, "assignment to const only known at run time in for-of loop", "Assignment to const");
         }
     },
     {
@@ -241,12 +244,16 @@ var tests = [
     {
         name: "for loops allow const loop variables but cannot assign to them anywhere including the increment expression", // so they're kinda useless
         body: function () {
-            assert.throws(function () { eval("for (const x = 0; x++ < 3; ) { }"); }, SyntaxError, "assignment to const known at parse time in the test expression", "Assignment to const");
-            assert.throws(function () { for (const x = 0; eval("x++") < 3; ) { } }, ReferenceError, "assignment to const known at run time in the test expression", "Assignment to const");
-            assert.throws(function () { eval("for (const x = 0; x < 3; x += 1) { }"); }, SyntaxError, "assignment to const known at parse time in the increment expression", "Assignment to const");
-            assert.throws(function () { for (const x = 0; x < 3; eval("x += 1")) { } }, ReferenceError, "assignment to const known at run time in the increment expression", "Assignment to const");
-            assert.throws(function () { eval("for (const x = 0; x < 3; ) { x += 1; }"); }, SyntaxError, "assignment to const known at parse time in the body", "Assignment to const");
-            assert.throws(function () { for (const x = 0; x < 3; ) { eval("x += 1"); } }, ReferenceError, "assignment to const known at run time in the body", "Assignment to const");
+            assert.throws(function () { for (const x = 0; x++ < 3; ) { } }, TypeError, "assignment to const known at parse time in the test expression", "Assignment to const");
+            assert.throws(function () { for (const x = 0; x < 3; x += 1) { } }, TypeError, "assignment to const known at parse time in the increment expression", "Assignment to const");
+            assert.throws(function () { for (const x = 0; x < 3; ) { x += 1; } }, TypeError, "assignment to const known at parse time in the body", "Assignment to const");
+
+            assert.throws(function () { eval("for (const x = 0; x++ < 3; ) { }"); }, TypeError, "assignment to const known at eval parse time in the test expression", "Assignment to const");
+            assert.throws(function () { for (const x = 0; eval("x++") < 3; ) { } }, TypeError, "assignment to const known at run time in the test expression", "Assignment to const");
+            assert.throws(function () { eval("for (const x = 0; x < 3; x += 1) { }"); }, TypeError, "assignment to const known at eval parse time in the increment expression", "Assignment to const");
+            assert.throws(function () { for (const x = 0; x < 3; eval("x += 1")) { } }, TypeError, "assignment to const known at run time in the increment expression", "Assignment to const");
+            assert.throws(function () { eval("for (const x = 0; x < 3; ) { x += 1; }"); }, TypeError, "assignment to const known at eval parse time in the body", "Assignment to const");
+            assert.throws(function () { for (const x = 0; x < 3; ) { eval("x += 1"); } }, TypeError, "assignment to const known at run time in the body", "Assignment to const");
         }
     },
     {

--- a/test/es6/letconst_global_shadowing.baseline
+++ b/test/es6/letconst_global_shadowing.baseline
@@ -67,7 +67,7 @@ this.p
 
 ==== Global properties added after const should not destroy const-ness ====
 
-ReferenceError: Assignment to const
+TypeError: Assignment to const
 const q
 this.q
 


### PR DESCRIPTION
Current ECMA spec spec says assigning to const is runtime TypeError, not early SyntaxError.
Fix by removing assign-to-const checks/throws in parser and changing runtime error type of ERRAssignmentToConst to TypeError.
Update unit test baselines.

Issue explained

Const declarations are created in an environment record via CreateImmutableBinding(name, true).
The second argument means that the binding is made "strict" which is important below.
Assignments to variables are evaluated via PutValue.
E.g. step 1.f for simple assignment in https://tc39.github.io/ecma262/#sec-assignment-operators-runtime-semantics-evaluation
In the case of a variable assignment, PutValue calls into SetMutableBinding on the corresponding environment record.
SetMutableBinding throws if the S parameter is true in step 6.
For const variables this parameter will be true (see CreateImmutableBinding above).
e.g.
`const x=0;`
`foo() { print('foo'); } // 'hello' should be printed`
`x = foo(); // foo() should be called, then TypeError thrown`
`// Instead we threw a SyntaxError during parse.`
