### PR TITLE
Fix for issue when marking a function as eval caller in defer and non-defer cases

### DIFF
--- a/lib/Parser/Parse.h
+++ b/lib/Parser/Parse.h
@@ -482,7 +482,7 @@ private:
 
     void MarkEvalCaller()
     {
-        if (m_currentNodeFunc)
+        if (this->GetCurrentFunctionNode())
         {
             ParseNodePtr pnodeFunc = GetCurrentFunctionNode();
             pnodeFunc->sxFnc.SetCallsEval(true);

--- a/test/es6/default.js
+++ b/test/es6/default.js
@@ -229,6 +229,9 @@ var tests = [
         assert.throws(function () { eval("function f(a, b = function () { eval('1'); }) { }") }, SyntaxError, "Evals in child functions are not allowed in the parameter scope", "'eval' is not allowed in the default initializer");
         assert.throws(function () { eval("function f(a, b = function () { function f() { eval('1'); } }) { }") }, SyntaxError, "Evals in nested child functions are not allowed in the parameter scope", "'eval' is not allowed in the default initializer");
         assert.throws(function () { eval("function f(a, b = eval('a')) { }") }, SyntaxError, "Eval is not allowed in the parameter scope", "'eval' is not allowed in the default initializer");
+        
+        assert.doesNotThrow(function (a = eval) { }, "An assignment of eval does not cause syntax error");
+        assert.doesNotThrow(function (a = eval()) { }, "If no arguments are passed to eval then it won't cause syntax error");
     }
   },
   {

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -677,7 +677,13 @@
   <test>
     <default>
       <files>default.js</files>
-      <compile-flags> -ES6DefaultArgs -ES6Generators -args summary -endargs</compile-flags>
+      <compile-flags>-force:deferparse -ES6DefaultArgs -ES6Generators -args summary -endargs</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
+      <files>default.js</files>
+      <compile-flags>-off:deferparse -ES6DefaultArgs -ES6Generators -args summary -endargs</compile-flags>
     </default>
   </test>
   <test>


### PR DESCRIPTION
Fix for issue when marking a function as eval caller in defer and non-defer cases

In defer parse case when parsing the argument list to a call we were
not returing the argument count. We mark the current function as
CallsEval only if the eval has at least one argument in the call. This
count check was missing in the defer parse case.
