### PR TITLE
Address perf regression from TypedArray constructor change related to iterable object

### DIFF
--- a/lib/Runtime/Library/JavascriptLibrary.h
+++ b/lib/Runtime/Library/JavascriptLibrary.h
@@ -620,7 +620,7 @@ namespace Js
         JavascriptFunction* GetSetConstructor() const {return  setConstructor; }
         JavascriptFunction* GetSymbolConstructor() const {return symbolConstructor; }
         JavascriptFunction* GetEvalFunctionObject() { return evalFunctionObject; }
-        JavascriptFunction* GetArrayPrototypeValuesFunction() { return arrayPrototypeValuesFunction; }
+        JavascriptFunction* GetArrayPrototypeValuesFunction() { return EnsureArrayPrototypeValuesFunction(); }
         DynamicObject* GetMathObject() const {return mathObject; }
         DynamicObject* GetJSONObject() const {return JSONObject; }
         DynamicObject* GetReflectObject() const { return reflectObject; }

--- a/lib/Runtime/Library/TypedArray.cpp
+++ b/lib/Runtime/Library/TypedArray.cpp
@@ -143,7 +143,11 @@ namespace Js
             {
                 if (JavascriptOperators::IsObject(firstArgument))
                 {
-                    if (JavascriptOperators::IsIterable(RecyclableObject::FromVar(firstArgument), scriptContext))
+                    Var iterator = JavascriptOperators::GetProperty(RecyclableObject::FromVar(firstArgument), PropertyIds::_symbolIterator, scriptContext);
+
+                    if (!JavascriptOperators::IsUndefinedObject(iterator) &&
+                        (iterator != scriptContext->GetLibrary()->GetArrayPrototypeValuesFunction() ||
+                        !JavascriptArray::Is(firstArgument)))
                     {
                         return CreateNewInstanceFromIterableObj(RecyclableObject::FromVar(firstArgument), scriptContext, elementSize, pfnCreateTypedArray);
                     }

--- a/test/typedarray/TypedArrayBuiltins.js
+++ b/test/typedarray/TypedArrayBuiltins.js
@@ -83,6 +83,35 @@ var tests = [
                 assert.areEqual(2, arr[1], "TypedArray " + t + " created from iterable has element #1 == 2");
                 assert.areEqual(3, arr[2], "TypedArray " + t + " created from iterable has element #2 == 3");
             }
+
+            for(var t of TypedArray) {
+                var a = [1,2,3,4];
+                a[Symbol.iterator] = getIterableObj([99,0])[Symbol.iterator];
+                var arr = new this[t](a);
+                assert.areEqual(1, arr.length, "TypedArray " + t + " created from array with user-defined iterator has length == 1");
+                assert.areEqual(99, arr[0], "TypedArray " + t + " created from array with user-defined iterator has element #0 == 99");
+            }
+
+            function testTypedArrayConstructorWithIterableArray(t) {
+                Array.prototype[Symbol.iterator] = getIterableObj([99,0])[Symbol.iterator];
+                var arr = new this[t](a);
+                assert.areEqual(1, arr.length, "TypedArray " + t + " created from array with Array.prototype overridden has length == 1");
+                assert.areEqual(99, arr[0], "TypedArray " + t + " created from array with Array.prototype overriden has element #0 == 99");
+            }
+
+            var builtinArrayPrototypeIteratorDesc = Object.getOwnPropertyDescriptor(Array.prototype, Symbol.iterator);
+            var a = [1,2,3,4];
+            Object.defineProperty(Array.prototype, Symbol.iterator, {enumerable: false, configurable: true, writable: true});
+            testTypedArrayConstructorWithIterableArray('Int8Array');
+            testTypedArrayConstructorWithIterableArray('Uint8Array');
+            testTypedArrayConstructorWithIterableArray('Uint8ClampedArray');
+            testTypedArrayConstructorWithIterableArray('Int16Array');
+            testTypedArrayConstructorWithIterableArray('Uint16Array');
+            testTypedArrayConstructorWithIterableArray('Int32Array');
+            testTypedArrayConstructorWithIterableArray('Uint32Array');
+            testTypedArrayConstructorWithIterableArray('Float32Array');
+            testTypedArrayConstructorWithIterableArray('Float64Array');
+            Object.defineProperty(Array.prototype, Symbol.iterator, builtinArrayPrototypeIteratorDesc);
         }
     }
 ];


### PR DESCRIPTION
Recent TypedArray constructor change to support iterable object as input had unintentionally
shadowed codepaths constructing a TypedArray from an array (iterable object), causing perf regression.

Fix by adding stricter checks to keep arrays out of the new codepath designed specifically for iterable object. This is done by retrieving `[Symbol.iterator]` property of the object and checking if it is not the built-in Array.prototype[Symbol.iterator], or if the object is not an array but still has an iterator (not `undefined`). Only if these conditions are met would the object be used as an iterable for constructing the `TypedArray`. Otherwise it will go down the existing codepaths for array or error-throwing.


