### PR TITLE
Implement Names Section Decoding

### DIFF
--- a/lib/WasmReader/BaseWasmReader.h
+++ b/lib/WasmReader/BaseWasmReader.h
@@ -26,6 +26,21 @@ namespace Wasm
         ModuleInfo * m_moduleInfo;
         WasmModule * m_module;
 
+        // TODO: Move this to somewhere more appropriate and possible make m_alloc part of
+        // BaseWasmReader state.
+        char16* CvtUtf8Str(ArenaAllocator* m_alloc, LPUTF8 name, uint32 nameLen)
+        {
+            utf8::DecodeOptions decodeOptions = utf8::doDefault;
+            charcount_t utf16Len = utf8::ByteIndexIntoCharacterIndex(name, nameLen, decodeOptions);
+            char16* contents = AnewArray(m_alloc, char16, utf16Len + 1);
+            if (contents == nullptr)
+            {
+                Js::Throw::OutOfMemory();
+            }
+            utf8::DecodeIntoAndNullTerminate((char16*)contents, name, utf16Len, decodeOptions);
+            return contents;
+        }
+
     protected:
         WasmFunctionInfo *  m_funcInfo;
     };

--- a/lib/WasmReader/SExprParser.cpp
+++ b/lib/WasmReader/SExprParser.cpp
@@ -274,7 +274,8 @@ SExprParser::ParseFunctionHeader()
     {
         if (type == funcImport)
         {
-            m_funcInfo->SetName(m_token.u.m_sz);
+            uint32 nameLen = (uint32)strlen((const char*)m_token.u.m_sz);
+            m_funcInfo->SetName(CvtUtf8Str(&m_alloc, m_token.u.m_sz, nameLen));
         }
         m_nameToFuncMap->AddNew(m_token.u.m_sz, m_funcNumber);
 

--- a/lib/WasmReader/WasmBinaryReader.h
+++ b/lib/WasmReader/WasmBinaryReader.h
@@ -128,6 +128,8 @@ namespace Wasm
             void ReadDataSegments();
             void ReadImportEntries();
 
+            void ReadNamesSection();
+
             char16* ReadInlineName(uint32& length, uint32& nameLength);
 
             const char* Name(UINT32 offset, UINT &length);

--- a/lib/WasmReader/WasmFunctionInfo.cpp
+++ b/lib/WasmReader/WasmFunctionInfo.cpp
@@ -27,7 +27,7 @@ WasmFunctionInfo::AddLocal(WasmTypes::WasmType type, uint count)
 {
     for (uint i = 0; i < count; ++i)
     {
-        m_locals->Add(type);
+        m_locals->Add(Wasm::Local(type));
     }
 }
 
@@ -68,7 +68,7 @@ WasmFunctionInfo::GetLocal(uint index) const
 {
     if (index < m_locals->Count())
     {
-        return m_locals->GetBuffer()[index];
+        return m_locals->GetBuffer()[index].t;
     }
     return WasmTypes::Limit;
 }
@@ -126,24 +126,24 @@ WasmFunctionInfo::GetParamCount() const
 }
 
 void
-WasmFunctionInfo::SetName(LPCUTF8 name)
+WasmFunctionInfo::SetName(char16* name)
 {
     m_name = name;
 }
 
-LPCUTF8
+char16*
 WasmFunctionInfo::GetName() const
 {
     return m_name;
 }
 
 void
-WasmFunctionInfo::SetModuleName(LPCUTF8 name)
+WasmFunctionInfo::SetModuleName(char16* name)
 {
     m_mod = name;
 }
 
-LPCUTF8
+char16*
 WasmFunctionInfo::GetModuleName() const
 {
     return m_mod;
@@ -166,7 +166,7 @@ WasmFunctionInfo::SetSignature(WasmSignature * signature)
 {
     for (uint32 i = 0; i < signature->GetParamCount(); ++i)
     {
-        m_locals->Add(signature->GetParam(i));
+        m_locals->Add(Wasm::Local(signature->GetParam(i)));
     }
 
     m_signature = signature;
@@ -188,6 +188,20 @@ Js::ByteCodeLabel
 WasmFunctionInfo::GetExitLabel() const
 {
     return m_ExitLabel;
+}
+
+void
+WasmFunctionInfo::SetLocalName(uint i, char16* n)
+{
+    Assert(i < GetLocalCount());
+    m_locals->GetBuffer()[i].name = n;
+}
+
+char16*
+WasmFunctionInfo::GetLocalName(uint i)
+{
+    Assert(i < GetLocalCount());
+    return m_locals->GetBuffer()[i].name;
 }
 
 } // namespace Wasm

--- a/lib/WasmReader/WasmFunctionInfo.h
+++ b/lib/WasmReader/WasmFunctionInfo.h
@@ -23,10 +23,10 @@ namespace Wasm
         uint32 GetLocalCount() const;
         uint32 GetParamCount() const;
 
-        void SetName(LPCUTF8 name);
-        LPCUTF8 GetName() const;
-        void SetModuleName(LPCUTF8 name);
-        LPCUTF8 GetModuleName() const;
+        void SetName(char16* name);
+        char16* GetName() const;
+        void SetModuleName(char16* name);
+        char16* GetModuleName() const;
 
         void SetNumber(UINT32 number);
         UINT32 GetNumber() const;
@@ -35,6 +35,10 @@ namespace Wasm
 
         void SetExitLabel(Js::ByteCodeLabel label);
         Js::ByteCodeLabel GetExitLabel() const;
+
+        void SetLocalName(uint i, char16* n);
+        char16* GetLocalName(uint i);
+
     private:
 
         // TODO: need custom comparator so -0 != 0
@@ -50,8 +54,8 @@ namespace Wasm
         ArenaAllocator * m_alloc;
         WasmSignature * m_signature;
         Js::ByteCodeLabel m_ExitLabel;
-        LPCUTF8 m_name;
-        LPCUTF8 m_mod; // imported module
+        char16* m_name;
+        char16* m_mod; // imported module
         UINT32 m_number;
     };
 

--- a/lib/WasmReader/WasmReader.h
+++ b/lib/WasmReader/WasmReader.h
@@ -54,7 +54,16 @@ namespace Wasm
 
 namespace Wasm
 {
-    typedef JsUtil::GrowingArray<WasmTypes::WasmType, ArenaAllocator> WasmTypeArray;
+    struct Local
+    {
+        WasmTypes::WasmType t;
+        char16* name;
+
+        Local(WasmTypes::WasmType _t) : t(_t), name(nullptr) {}
+        Local() : t(WasmTypes::Limit), name(nullptr) {}
+    };
+
+    typedef JsUtil::GrowingArray<Local, ArenaAllocator> WasmTypeArray;
 }
 
 #include "WasmSignature.h"

--- a/lib/WasmReader/WasmSections.h
+++ b/lib/WasmReader/WasmSections.h
@@ -13,6 +13,6 @@ WASM_SECTION(ExportTable          , "export_table"       , fSectNone  , Function
 WASM_SECTION(StartFunction        , "start_function"     , fSectIgnore, FunctionSignatures)
 WASM_SECTION(FunctionBodies       , "function_bodies"    , fSectNone  , FunctionSignatures)
 WASM_SECTION(DataSegments         , "data_segments"      , fSectNone  , Memory            )
-WASM_SECTION(Names                , "names"              , fSectIgnore, Invalid           )
+WASM_SECTION(Names                , "names"              , fSectNone,   Signatures        )
 
 #undef WASM_SECTION

--- a/lib/WasmReader/WasmSignature.cpp
+++ b/lib/WasmReader/WasmSignature.cpp
@@ -22,7 +22,7 @@ WasmSignature::WasmSignature(ArenaAllocator * alloc) :
 void
 WasmSignature::AddParam(WasmTypes::WasmType type)
 {
-    m_params->Add(type);
+    m_params->Add(Wasm::Local(type));
 }
 
 void
@@ -44,7 +44,7 @@ WasmSignature::GetParam(uint index) const
 {
     if (index < m_params->Count())
     {
-        return m_params->GetBuffer()[index];
+        return m_params->GetBuffer()[index].t;
     }
     return WasmTypes::Limit;
 }


### PR DESCRIPTION
Implemented Names section. This also moves all names include FunctionInfo names to char16* from LPUTF8.  