### PR TITLE
Fix PreservedVirtualAllocWrapper and CodeGenAllocators' HeapPageAllocator clean up order.

### DIFF
--- a/lib/Common/Memory/VirtualAllocWrapper.cpp
+++ b/lib/Common/Memory/VirtualAllocWrapper.cpp
@@ -78,8 +78,7 @@ PreReservedVirtualAllocWrapper::PreReservedVirtualAllocWrapper() :
     freeSegments.SetAll();
 }
 
-void
-PreReservedVirtualAllocWrapper::Shutdown()
+PreReservedVirtualAllocWrapper::~PreReservedVirtualAllocWrapper()
 {
     Assert(this);
     if (IsPreReservedRegionPresent())

--- a/lib/Common/Memory/VirtualAllocWrapper.h
+++ b/lib/Common/Memory/VirtualAllocWrapper.h
@@ -40,7 +40,7 @@ public:
 #endif
 public:
     PreReservedVirtualAllocWrapper();
-    void        Shutdown();
+    ~PreReservedVirtualAllocWrapper();
     LPVOID      Alloc(LPVOID lpAddress, size_t dwSize, DWORD allocationType, DWORD protectFlags, bool isCustomHeapAllocation = false);
     BOOL        Free(LPVOID lpAddress, size_t dwSize, DWORD dwFreeType);
 

--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -319,13 +319,6 @@ void ThreadContext::GlobalInitialize()
     }
 }
 
-#if ENABLE_NATIVE_CODEGEN
-void ThreadContext::ReleasePreReservedSegment()
-{
-    preReservedVirtualAllocator.Shutdown();
-}
-#endif
-
 ThreadContext::~ThreadContext()
 {
     {
@@ -500,10 +493,6 @@ ThreadContext::~ThreadContext()
         this->projectionMemoryInformation = nullptr;
     }
 #endif
-#endif
-
-#if ENABLE_NATIVE_CODEGEN
-    ReleasePreReservedSegment();
 #endif
 }
 

--- a/lib/Runtime/Base/ThreadContext.h
+++ b/lib/Runtime/Base/ThreadContext.h
@@ -372,10 +372,6 @@ public:
         WorkerThread(HANDLE handle = nullptr) :threadHandle(handle){};
     };
 
-#if ENABLE_NATIVE_CODEGEN
-    void ReleasePreReservedSegment();
-#endif
-
     void SetCurrentThreadId(DWORD threadId) { this->currentThreadId = threadId; }
     DWORD GetCurrentThreadId() const { return this->currentThreadId; }
     void SetIsThreadBound()


### PR DESCRIPTION
In the ThreadContext dtor sequence, PreservedVirtualAllocWrapper::Shutdown is called explicitly, before the CodeGenAllocators' HeapPageAllocator dtor is called.  The release should be in PreReservedVirtualAllocWrapper dtor instead, which will be the right order.
