### PR TITLE
The 'async' function has inner function which has default threw assert.

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -4539,6 +4539,8 @@ ParseNodePtr Parser::ParseFncDecl(ushort flags, LPCOLESTR pNameHint, const bool 
         pnodeFncSave = m_currentNodeFunc;
         m_currentNodeFunc = pnodeFnc;
 
+        Assert(m_currentNodeDeferredFunc == nullptr);
+
         if (!fLambda)
         {
             pnodeFncSaveNonLambda = m_currentNodeNonLambdaFunc;
@@ -7412,8 +7414,6 @@ void Parser::TransformAsyncFncDeclAST(ParseNodePtr *pnodeBody, bool fLambda)
 
     pnodeFncGenerator = CreateAsyncSpawnGenerator();
 
-    m_currentNodeDeferredFunc = pnodeFncGenerator;
-    m_inDeferredNestedFunc = true;
     pstmtSave = m_pstmtCur;
     SetCurrentStatement(nullptr);
 

--- a/test/es7/misc_bugs.js
+++ b/test/es7/misc_bugs.js
@@ -1,0 +1,32 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+
+var tests = [
+    {
+        name: "Inner function of 'async' function has default - should not throw any assert",
+        body: function () {
+            assert.doesNotThrow(function () { eval(`async function f1() {
+                   function foo(a = function() { } ) { }; 
+            }`); });
+
+            assert.doesNotThrow(function () { eval(`var f1 = async ( ) => {
+                   function foo(a = function() { } ) { } };`); });
+                   
+            assert.doesNotThrow(function () { eval(`async function f1() {
+                        function foo() {
+                            async function f2() {
+                                function bar (a = function () {} ) {
+                                }
+                            }
+                        }
+                    }`); });
+        }
+    },
+
+];
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/es7/rlexe.xml
+++ b/test/es7/rlexe.xml
@@ -45,4 +45,18 @@
       <tags>BugFix</tags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>misc_bugs.js</files>
+      <compile-flags>-args summary -endargs</compile-flags>
+      <tags>BugFix</tags>
+    </default>
+  </test>
+  <test>
+    <default>
+      <files>misc_bugs.js</files>
+      <compile-flags>-ForceDeferParse -args summary -endargs</compile-flags>
+      <tags>BugFix</tags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
In the async function transformation we set m_currentNodeDeferredFunc to the current node, which is wrong. This variable should be set if buildAST is false, which is not the case. I have removed that. Also I have put assert at one place where when we use the m_currentNodeFnc, the m_currentNodeDeferredFunc should be null.
found this in internal tool. Added a unittest.
