### PR TITLE
Should throw error on initializer for shorthand of object literals

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -10127,6 +10127,11 @@ LNeedTerminator:
         break;
     }
 
+    if (m_hasDeferredShorthandInitError)
+    {
+        Error(ERRnoColon);
+    }
+
     if (buildAST)
     {
         // All non expression statements excluded from the "this.x" optimization

--- a/test/es6/destructuring_obj.js
+++ b/test/es6/destructuring_obj.js
@@ -206,6 +206,9 @@ var tests = [
             ({x:{a1 = 2}} = {x:{}});
             assert.areEqual(a1, 2);
         }
+        
+        assert.throws(function () { eval("var a = 1; switch(true) {  case {a = 1} : break; };"); }, SyntaxError, "Object literal on case has initializer is not valid syntax", "Expected ':'");
+       
     }
   },
   {


### PR DESCRIPTION
{x = 1} is not allowed for object literals but allowed for pattern. We have delayed that error. In obscure cases, though got the delayed-error but didn't raise them. Fixed that by raising it and added a test for clarity.
