### PR TITLE
Fix -0 tracking bugs in Add and Sub operations

### DIFF
--- a/lib/Backend/BackwardPass.cpp
+++ b/lib/Backend/BackwardPass.cpp
@@ -5158,15 +5158,34 @@ BackwardPass::TrackIntUsage(IR::Instr *const instr)
                 Assert(instr->GetSrc2()->IsRegOpnd() || instr->GetSrc2()->IsIntConstOpnd());
 
                 if(instr->ignoreNegativeZero ||
-                    !(instr->GetSrc1()->IsRegOpnd() && instr->GetSrc1()->AsRegOpnd()->m_wasNegativeZeroPreventedByBailout) ||
                     instr->GetSrc2()->IsIntConstOpnd() && instr->GetSrc2()->AsIntConstOpnd()->GetValue() != 0)
                 {
                     // At least one of the following is true:
                     //     - -0 does not matter for dst
-                    //     - Src1 is not -0 (regardless of -0 bailout checks), and so this instruction cannot generate -0
                     //     - Src2 is a nonzero int constant, and so this instruction cannot generate -0
                     SetNegativeZeroDoesNotMatterIfLastUse(instr->GetSrc1());
                     SetNegativeZeroDoesNotMatterIfLastUse(instr->GetSrc2());
+                    break;
+                }
+                if (instr->GetSrc1()->IsRegOpnd() && !instr->GetSrc1()->AsRegOpnd()->m_wasNegativeZeroPreventedByBailout)
+                {
+                    // m_wasNegativeZeroPreventedByBailout can only be relied on if src1 was the result of an operation that 
+                    // was int type spec'ed and could have produced negative zero.
+                    // It could be also be the case that src1 was just type spec'ed using a FromVar whose src1 was produced by
+                    // an operation that didn't get int type spec'ed at all. So, m_wasNegativeZeroPreventedByBailout would be false.
+                    // In that case, since we can't say for sure that src1 wouldn't be -0, we can't ignore -0 for src2.
+                    IR::Opnd * src1 = instr->GetSrc1();
+                    IR::Instr * src1DefInstr = this->GetInstrDef(src1->GetStackSym(), instr);
+                    if (src1DefInstr->CouldBeProtectedByNegZeroBailout())
+                    {
+                        SetNegativeZeroDoesNotMatterIfLastUse(instr->GetSrc1());
+                        SetNegativeZeroDoesNotMatterIfLastUse(instr->GetSrc2());
+                    }
+                    else
+                    {
+                        SetNegativeZeroMatters(instr->GetSrc1());
+                        SetNegativeZeroMatters(instr->GetSrc2());
+                    }
                     break;
                 }
                 goto NegativeZero_Sub_Default;
@@ -5198,8 +5217,16 @@ BackwardPass::TrackIntUsage(IR::Instr *const instr)
 
             NegativeZero_Sub_Default:
                 // -0 - 0 == -0. As long as src1 is guaranteed to not be -0, -0 does not matter for src2.
+                // But in the Backward Pass, we can't make that guarantee for src1.
                 SetNegativeZeroMatters(instr->GetSrc1());
-                SetNegativeZeroDoesNotMatterIfLastUse(instr->GetSrc2());
+                if (this->tag == Js::BackwardPhase)
+                {
+                    SetNegativeZeroMatters(instr->GetSrc2());
+                }
+                else 
+                {
+                    SetNegativeZeroDoesNotMatterIfLastUse(instr->GetSrc2());
+                }
                 break;
 
             case Js::OpCode::BrEq_I4:
@@ -7284,6 +7311,28 @@ BackwardPass::RemoveEmptyLoopAfterMemOp(Loop *loop)
     {
         this->func->m_fg->RemoveBlock(tail, nullptr);
     }
+}
+
+IR::Instr*
+BackwardPass::GetInstrDef(StackSym * stackSym, IR::Instr * currentInstr)
+{
+    IR::Instr * instrDef = nullptr;
+    if (stackSym->IsSingleDef())
+    {
+        instrDef = stackSym->GetInstrDef();
+    }
+    else
+    {
+        FOREACH_INSTR_BACKWARD(tmpInstr, currentInstr->m_prev)
+        {
+            if (tmpInstr->GetDst() && stackSym == tmpInstr->GetDst()->GetStackSym())
+            {
+                instrDef = tmpInstr;
+            }
+        }
+        NEXT_INSTR_BACKWARD
+    }
+    return instrDef;
 }
 
 #if DBG_DUMP

--- a/lib/Backend/BackwardPass.cpp
+++ b/lib/Backend/BackwardPass.cpp
@@ -5098,39 +5098,83 @@ BackwardPass::TrackIntUsage(IR::Instr *const instr)
                 break;
 
             case Js::OpCode::Add_I4:
+            {
                 Assert(dstSym);
                 Assert(instr->GetSrc1());
                 Assert(instr->GetSrc1()->IsRegOpnd() || instr->GetSrc1()->IsIntConstOpnd());
                 Assert(instr->GetSrc2());
                 Assert(instr->GetSrc2()->IsRegOpnd() || instr->GetSrc2()->IsIntConstOpnd());
 
-                if(instr->ignoreNegativeZero ||
-                    !(instr->GetSrc1()->IsRegOpnd() && instr->GetSrc1()->AsRegOpnd()->m_wasNegativeZeroPreventedByBailout) ||
-                    !(instr->GetSrc2()->IsRegOpnd() && instr->GetSrc2()->AsRegOpnd()->m_wasNegativeZeroPreventedByBailout))
+                if (instr->ignoreNegativeZero ||
+                    (instr->GetSrc1()->IsConstOpnd() && instr->GetSrc1()->AsIntConstOpnd()->GetValue() != 0) ||
+                    (instr->GetSrc2()->IsConstOpnd() && instr->GetSrc2()->AsIntConstOpnd()->GetValue() != 0))
                 {
-                    // -0 does not matter for dst, or this instruction does not generate -0 since one of the srcs is not -0
-                    // (regardless of -0 bailout checks)
+                    // -0 does not matter for dst, 
+                    // or this instruction does not generate -0 since one of the srcs is not -0
                     SetNegativeZeroDoesNotMatterIfLastUse(instr->GetSrc1());
                     SetNegativeZeroDoesNotMatterIfLastUse(instr->GetSrc2());
                     break;
                 }
 
-                // -0 + -0 == -0. As long as one src is guaranteed to not be -0, -0 does not matter for the other src. Pick a
-                // src for which to ignore negative zero, based on which sym is last-use. If both syms are last-use, src2 is
-                // picked arbitrarily.
-                if(instr->GetSrc2()->IsRegOpnd() &&
-                    !currentBlock->upwardExposedUses->Test(instr->GetSrc2()->AsRegOpnd()->m_sym->m_id))
+                bool canSrc1BeNegativeZero = true;
+                bool canSrc2BeNegativeZero = true;
+                if (instr->GetSrc1()->IsRegOpnd() && !instr->GetSrc1()->AsRegOpnd()->m_wasNegativeZeroPreventedByBailout)
                 {
+                    IR::Opnd * src1 = instr->GetSrc1();
+                    IR::Instr * src1DefInstr = this->GetInstrDef(src1->GetStackSym(), instr);
+                    if (src1DefInstr->CouldBeProtectedByNegZeroBailout())
+                    {
+                        canSrc1BeNegativeZero = false;
+                    }
+                }
+
+                if (canSrc1BeNegativeZero && (instr->GetSrc2()->IsRegOpnd() && !instr->GetSrc2()->AsRegOpnd()->m_wasNegativeZeroPreventedByBailout))
+                {
+                    IR::Opnd * src2 = instr->GetSrc2();
+                    IR::Instr * src2DefInstr = this->GetInstrDef(src2->GetStackSym(), instr);;
+                    if (src2DefInstr->CouldBeProtectedByNegZeroBailout())
+                    {
+                        canSrc2BeNegativeZero = false;
+                    }
+                }
+
+                if (!canSrc1BeNegativeZero || !canSrc2BeNegativeZero)
+                {
+                    // This instruction does not generate -0 since one of the srcs cannot be -0
+                    SetNegativeZeroDoesNotMatterIfLastUse(instr->GetSrc1());
                     SetNegativeZeroDoesNotMatterIfLastUse(instr->GetSrc2());
+                    break;
+                }
+
+                if ((instr->GetSrc1()->IsRegOpnd() && !instr->GetSrc1()->AsRegOpnd()->m_wasNegativeZeroPreventedByBailout) ||
+                    (instr->GetSrc2()->IsRegOpnd() && !instr->GetSrc2()->AsRegOpnd()->m_wasNegativeZeroPreventedByBailout))
+                {
+                    // If we reach here, m_wasNegativeZeroPreventedByBailout being false means that the instruction which
+                    // produced the operand wasn't type-specialized. In this case, we can't ignore -0 for the other operand.
+                    // Since, -0 tracking is only used to get rid of some -0 bailouts, we are fine not ignoring -0 for the operand that
+                    // didn't have m_wasNegativeZeroPreventedByBailout set as it wouldn't have been protected by a -0 bailout anyway.
                     SetNegativeZeroMatters(instr->GetSrc1());
+                    SetNegativeZeroMatters(instr->GetSrc2());
                 }
                 else
                 {
-                    SetNegativeZeroDoesNotMatterIfLastUse(instr->GetSrc1());
-                    SetNegativeZeroMatters(instr->GetSrc2());
+                    // -0 + -0 == -0. As long as one src is guaranteed to not be -0, -0 does not matter for the other src. Pick a
+                    // src for which to ignore negative zero, based on which sym is last-use. If both syms are last-use, src2 is
+                    // picked arbitrarily.
+                    if (instr->GetSrc2()->IsRegOpnd() &&
+                        !currentBlock->upwardExposedUses->Test(instr->GetSrc2()->AsRegOpnd()->m_sym->m_id))
+                    {
+                        SetNegativeZeroDoesNotMatterIfLastUse(instr->GetSrc2());
+                        SetNegativeZeroMatters(instr->GetSrc1());
+                    }
+                    else
+                    {
+                        SetNegativeZeroDoesNotMatterIfLastUse(instr->GetSrc1());
+                        SetNegativeZeroMatters(instr->GetSrc2());
+                    }
                 }
                 break;
-
+            }
             case Js::OpCode::Add_A:
                 Assert(dstSym);
                 Assert(instr->GetSrc1());

--- a/lib/Backend/BackwardPass.h
+++ b/lib/Backend/BackwardPass.h
@@ -47,6 +47,7 @@ private:
     bool ProcessInlineeStart(IR::Instr* instr);
     void ProcessInlineeEnd(IR::Instr* instr);
     void MarkTempProcessInstr(IR::Instr * instr);
+    IR::Instr * GetInstrDef(StackSym * stackSym, IR::Instr * currentInstr);
 
     void RemoveEmptyLoopAfterMemOp(Loop *loop);
     void RemoveEmptyLoops();

--- a/lib/Backend/IR.cpp
+++ b/lib/Backend/IR.cpp
@@ -3262,6 +3262,15 @@ bool Instr::HasAnySideEffects() const
     return false;
 }
 
+bool Instr::CouldBeProtectedByNegZeroBailout() const
+{
+    return
+        this->m_opcode == Js::OpCode::Neg_I4 ||
+        this->m_opcode == Js::OpCode::Mul_I4 ||
+        this->m_opcode == Js::OpCode::Div_I4 ||
+        this->m_opcode == Js::OpCode::Rem_I4;
+}
+
 Js::JavascriptFunction* Instr::GetFixedFunction() const
 {
     Assert(HasFixedFunctionAddressTarget());

--- a/lib/Backend/IR.h
+++ b/lib/Backend/IR.h
@@ -209,6 +209,7 @@ public:
     bool            ShouldCheckForNon32BitOverflow() const;
     bool            HasAnyImplicitCalls() const;
     bool            HasAnySideEffects() const;
+    bool            CouldBeProtectedByNegZeroBailout() const;
 
     IRKind          GetKind() const;
     Opnd *          GetDst() const;


### PR DESCRIPTION
The forward pass sets a bit, m_wasNegativeZeroPreventedByBailout, on an
operand if it was int-type-specialized and was protected by a
BailOutOnNegativeZero (which would happen if there are uses of that
operand downstream in manners which require distinction between -0 and +0
and the forward pass cannot say for sure that the operand can't be -0).
The Deadstore pass then looks at this bit to determine if it can remove
some -0 bailouts.

However, this bit being set to false for an operand doesn't necessarily mean that that
operand cannot be -0 if the operation that produced this operand wasn't type-spec'ed at all.
Negative zero tracking in the deadstore pass wasn't taking this into
account and was getting rid of more -0 bailouts than it should have,
resulting in wrong results.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/576)
<!-- Reviewable:end -->
