### PR TITLE
Restore the 'dev12 tests' trigger. The requirement of the word 'tests' serves as a disambiguator and calling out 'dev12' is more natural than 'legacy'.

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -148,7 +148,7 @@ CreateBuildTasks('Windows 7', 'daily_dev12', ' msbuild12', ' -win7',
     /* nonDefaultTaskSetup */ { newJob, isPR, config ->
         DailyBuildTaskSetup(newJob, isPR,
             "Windows 7 ${config}",
-            'legacy\\s+tests')})
+            '(dev12|legacy)\\s+tests')})
 
 // build and test on the usual configuration (VS 2015) with -includeSlow
 CreateBuildTasks('Windows_NT', 'daily_slow', null, ' -includeSlow', null,


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/581)
<!-- Reviewable:end -->
