### PR TITLE
remove assert against asm.js code in strict mode

### DIFF
--- a/lib/Runtime/Language/AsmJsModule.cpp
+++ b/lib/Runtime/Language/AsmJsModule.cpp
@@ -603,7 +603,6 @@ namespace Js
         FunctionBody * funcBody;
         ParseNodePtr parseTree;
 
-        Assert(!deferParseFunction->GetIsStrictMode());
         CompileScriptException se;
         funcBody = deferParseFunction->ParseAsmJs(&ps, &se, &parseTree);
 


### PR DESCRIPTION
There is no reason you can't use asm.js under strict mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/582)
<!-- Reviewable:end -->
