### PR TITLE
Default parameters pid ref stack issue

### DIFF
--- a/lib/Parser/Hash.h
+++ b/lib/Parser/Hash.h
@@ -236,6 +236,7 @@ public:
 
         // Search for the corresponding PidRef, or the position to insert the new PidRef.
         PidRefStack *ref = m_pidRefStack;
+        PidRefStack *prevRef = nullptr;
         while (1)
         {
             // We may already have a ref for this scopeId.
@@ -263,11 +264,21 @@ public:
 
                 if (ref->id < scopeId)
                 {
-                    // Without parameter scope, we would have just pushed the ref instead of inserting.
-                    // We effectively had a false positive match (a parameter scope ref with no sym)
-                    // so we need to push the Pid rather than inserting.
-                    newRef->prev = m_pidRefStack;
-                    m_pidRefStack = newRef;
+                    if (prevRef != nullptr)
+                    {
+                        // Param scope has a reference to the same pid as the one we are inserting into the body.
+                        // There is a another reference (prevRef), probably from an inner block in the body.
+                        // So we should insert the new reference between them.
+                        newRef->prev = prevRef->prev;
+                        prevRef->prev = newRef;
+                    }
+                    else
+                    {
+                        // When we have code like below, prevRef will be null,
+                        // function (a = x) { var x = 1; }
+                        newRef->prev = m_pidRefStack;
+                        m_pidRefStack = newRef;
+                    }
                 }
                 else
                 {
@@ -278,6 +289,7 @@ public:
             }
 
             Assert(ref->prev->id <= ref->id);
+            prevRef = ref;
             ref = ref->prev;
         }
     }

--- a/test/es6/default.js
+++ b/test/es6/default.js
@@ -155,6 +155,17 @@ var tests = [
                     ReferenceError,
                     "Named function expression does not leak name into subsequent default expressions",
                     "'bar' is undefined");
+      function foo6(a = b1) {
+          {
+              function b1() {
+                  return 2;
+              }
+          }
+          assert.areEqual(1, a, "First argument should get the initial value from outer variable");
+          assert.areEqual(2, b1(), "Block scoped function should be visible in the body also");
+      }
+      var b1 = 1;
+      foo6();
     }
   },
   {


### PR DESCRIPTION
Default parameters pid ref stack issue

This is a fix for an assert happening when default param is referencing a
variable from outer scope and there is a function definition with the same
name in a block in the function body.

When we have a function definition in a block we add an additional var
declaration node for the same in the function body for backward
compatibility. When param scope also has a reference to the same name
we were adding this reference to the body scope in the wrong order.
