### PR TITLE
remove special handling for atan2 from Js::Math::atan2

### DIFF
--- a/test/Math/atan2.js
+++ b/test/Math/atan2.js
@@ -27,6 +27,7 @@ check(-(Math.PI) / 2, -3, -0);
 
 check(0, 3, +Infinity);
 check((Math.PI), 3, -Infinity);
+check((-Math.PI), -3, -Infinity);
 
 check(-0, -3, +Infinity);
 
@@ -35,6 +36,10 @@ check(-(Math.PI) / 2, -Infinity, 3);
 check((Math.PI) / 2, +Infinity, -3);
 check(-(Math.PI) / 2, -Infinity, -3);
 
+check(Math.PI / 4, +Infinity, +Infinity);
+check(3 * Math.PI / 4, +Infinity, -Infinity);
+check(-Math.PI / 4, -Infinity, +Infinity);
+check(-3 * Math.PI / 4, -Infinity, -Infinity);
 
 check((Math.PI) / 4, 5, 5.0);
 


### PR DESCRIPTION
Using different methods for calculating atan2 was causing differences in result between JIT and interpreter for some inputs. Because it was unclear that the interpreter special handling of certain values is necessary, I removed the special cases and simply call the C++ library functions (as we do with all the other Math builtins).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/593)
<!-- Reviewable:end -->
