### PR TITLE
Fix assertion in EntryPointInfo expiring

### DIFF
--- a/lib/Backend/NativeCodeGenerator.cpp
+++ b/lib/Backend/NativeCodeGenerator.cpp
@@ -1392,12 +1392,18 @@ NativeCodeGenerator::Process(JsUtil::Job *const job, JsUtil::ParallelThreadData 
             CodeGen(pageAllocator, codeGenWork, foreground);
             return true;
         }
+#if ENABLE_DEBUG_CONFIG_OPTIONS
+        job->failureReason = Job::FailureReason::ExceedJITLimit;
+#endif
         return false;
     }
 
     default:
         Assume(UNREACHED);
     }
+#if ENABLE_DEBUG_CONFIG_OPTIONS
+    job->failureReason = Job::FailureReason::Unknown;
+#endif
     return false;
 }
 
@@ -1558,9 +1564,11 @@ NativeCodeGenerator::JobProcessed(JsUtil::Job *const job, const bool succeeded)
 #if ENABLE_DEBUG_CONFIG_OPTIONS
                 switch (job->failureReason)
                 {
-                case Job::FailureReason::OOM: entryPointInfo->SetCleanupReason(Js::EntryPointInfo::CodeGenFailedOOM); break;
-                case Job::FailureReason::StackOverflow: entryPointInfo->SetCleanupReason(Js::EntryPointInfo::CodeGenFailedStackOverflow); break;
-                case Job::FailureReason::Aborted: entryPointInfo->SetCleanupReason(Js::EntryPointInfo::CodeGenFailedAborted); break;
+                case Job::FailureReason::OOM: entryPointInfo->SetCleanupReason(Js::EntryPointInfo::CleanupReason::CodeGenFailedOOM); break;
+                case Job::FailureReason::StackOverflow: entryPointInfo->SetCleanupReason(Js::EntryPointInfo::CleanupReason::CodeGenFailedStackOverflow); break;
+                case Job::FailureReason::Aborted: entryPointInfo->SetCleanupReason(Js::EntryPointInfo::CleanupReason::CodeGenFailedAborted); break;
+                case Job::FailureReason::ExceedJITLimit: entryPointInfo->SetCleanupReason(Js::EntryPointInfo::CleanupReason::CodeGenFailedExceedJITLimit); break;
+                case Job::FailureReason::Unknown: entryPointInfo->SetCleanupReason(Js::EntryPointInfo::CleanupReason::CodeGenFailedUnknown); break;
                 default: Assert(job->failureReason == Job::FailureReason::NotFailed);
                 }
 #endif

--- a/lib/Common/Common/Jobs.h
+++ b/lib/Common/Common/Jobs.h
@@ -53,7 +53,9 @@ namespace JsUtil
             NotFailed,
             OOM,
             StackOverflow,
-            Aborted
+            Aborted,
+            ExceedJITLimit,
+            Unknown
         };
         FailureReason failureReason;
 #endif

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -9207,7 +9207,9 @@ namespace Js
                 }
                 else
                 {
-                    Assert((DWORD_PTR)functionType->GetEntryPoint() != this->GetNativeAddress());
+                    Assert(functionType->GetEntryPointInfo()->IsFunctionEntryPointInfo());                    
+                    Assert(((FunctionEntryPointInfo*)functionType->GetEntryPointInfo())->IsCleanedUp() 
+                        || (DWORD_PTR)functionType->GetEntryPoint() != this->GetNativeAddress());
                 }
             });
 

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -474,6 +474,8 @@ namespace Js
             CodeGenFailedOOM,
             CodeGenFailedStackOverflow,
             CodeGenFailedAborted,
+            CodeGenFailedExceedJITLimit,
+            CodeGenFailedUnknown,
             NativeCodeInstallFailure,
             CleanUpForFinalize
         };


### PR DESCRIPTION
Previously when fixing a bug that when codegen failed, entryPointInfo is cleanedup with wrong(previously jitted code/thunk) address and causes the jit code freed prematurely.
I added the assert to capture we should not be expiring the entryPointInfo which has the address still installed on the functionType.
Here's another situation that the entryPointInfo on deferredPrototypeType (which is same as the default m_defaultEntryPointInfo) is already cleanedup due to some other reason (most likely hit the JitLimit, added Unknown to capture other cases). In this situation the Assertion can be wrong.
