### PR TITLE
OS:6523257: Enable CollectGarbage functionality for WWA and Webview.

### DIFF
--- a/lib/Runtime/Library/GlobalObject.cpp
+++ b/lib/Runtime/Library/GlobalObject.cpp
@@ -1523,7 +1523,6 @@ LHexError:
         }
 #endif
 
-
 #if DBG
         // Clear 1K of stack to avoid false positive in debug build.
         // Because we don't debug build don't stack pack
@@ -1533,9 +1532,17 @@ LHexError:
 
         ScriptContext* scriptContext = function->GetScriptContext();
 
-        if (!scriptContext->GetConfig()->IsCollectGarbageEnabled())
+        if (!scriptContext->GetConfig()->IsCollectGarbageEnabled()
+#ifdef ENABLE_PROJECTION
+            && scriptContext->GetConfig()->GetHostType() != HostType::HostTypeApplication
+            && scriptContext->GetConfig()->GetHostType() != HostType::HostTypeWebview
+#endif
+            )
         {
-            //We expose the CollectGarbage API with flag for compat reasons. Though we don't trigger GC if CollectGarbage key is not present.
+            // We expose the CollectGarbage API with flag for compat reasons.
+            // If CollectGarbage key is not enabled, and if the HostType is neither
+            // HostType::HostTypeApplication nor HostType::HostTypeWebview,
+            // then we do not trigger collection.
             return scriptContext->GetLibrary()->GetUndefined();
         }
 

--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -1264,7 +1264,12 @@ namespace Js
         AddFunctionToLibraryObject(globalObject, PropertyIds::escape, &GlobalObject::EntryInfo::Escape, 1);
         AddFunctionToLibraryObject(globalObject, PropertyIds::unescape, &GlobalObject::EntryInfo::UnEscape, 1);
 
-        if (scriptContext->GetConfig()->SupportsCollectGarbage())
+        if (scriptContext->GetConfig()->SupportsCollectGarbage()
+#ifdef ENABLE_PROJECTION
+            || scriptContext->GetConfig()->GetHostType() == HostType::HostTypeApplication
+            || scriptContext->GetConfig()->GetHostType() == HostType::HostTypeWebview
+#endif
+            )
         {
             AddFunctionToLibraryObject(globalObject, PropertyIds::CollectGarbage, &GlobalObject::EntryInfo::CollectGarbage, 0);
         }


### PR DESCRIPTION
During testing, I temporarily introduced some output into the function after it would have done nothing and returned if it were disabled.

The function now performs GC for WWA and Webview host types (2 and 3 respectively), and does nothing for HostType 1 (Browser). Default is HostType:1 (Browser). Applies to both internal test harness and hosting. ch.exe always acts as a Browser host.

As before, function is always present on the GlobalObject for legacy reasons (in all binaries and hosts), even if it is set to do nothing.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/595)
<!-- Reviewable:end -->
