### PR TITLE
Update the yield* implementation to match the spec

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -9223,17 +9223,13 @@ void EmitYieldStar(ParseNode* yieldStarNode, ByteCodeGenerator* byteCodeGenerato
 
     EmitGetIterator(iteratorLocation, yieldStarNode->sxUni.pnode1->location, byteCodeGenerator, funcInfo);
 
-    // Get a temporary to hold the input for the next() calls.  Initialize it to undefined for the first call.
-    Js::RegSlot nextInputLocation = funcInfo->AcquireTmpRegister();
-    byteCodeGenerator->Writer()->Reg2(Js::OpCode::Ld_A, nextInputLocation, funcInfo->undefinedConstantRegister);
+    // Call the iterator's next()
+    EmitIteratorNext(yieldStarNode->location, iteratorLocation, funcInfo->undefinedConstantRegister, byteCodeGenerator, funcInfo);
 
     uint loopId = byteCodeGenerator->Writer()->EnterLoop(loopEntrance);
     // since a yield* doesn't have a user defined body, we cannot return from this loop
     // which means we don't need to support EmitJumpCleanup() and there do not need to
     // remember the loopId like the loop statements do.
-
-    // Call the iterator's next()
-    EmitIteratorNext(yieldStarNode->location, iteratorLocation, nextInputLocation, byteCodeGenerator, funcInfo);
 
     Js::RegSlot doneLocation = funcInfo->AcquireTmpRegister();
     EmitIteratorComplete(doneLocation, yieldStarNode->location, byteCodeGenerator, funcInfo);
@@ -9242,9 +9238,8 @@ void EmitYieldStar(ParseNode* yieldStarNode, ByteCodeGenerator* byteCodeGenerato
     byteCodeGenerator->Writer()->BrReg1(Js::OpCode::BrTrue_A, continuePastLoop, doneLocation);
     funcInfo->ReleaseTmpRegister(doneLocation);
 
-    EmitYield(yieldStarNode->location, nextInputLocation, byteCodeGenerator, funcInfo, iteratorLocation);
+    EmitYield(yieldStarNode->location, yieldStarNode->location, byteCodeGenerator, funcInfo, iteratorLocation);
 
-    funcInfo->ReleaseTmpRegister(nextInputLocation);
     funcInfo->ReleaseTmpRegister(iteratorLocation);
 
     byteCodeGenerator->Writer()->Br(loopEntrance);

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -743,7 +743,7 @@ namespace Js
                 aLeft = JavascriptConversion::ToPrimitive(aLeft, JavascriptHint::HintNumber, scriptContext);
             }
             //BugFix: When @@ToPrimitive of an object is overridden with a function that returns null/undefined
-            //this helper will fall into a inescapable goto loop as the checks for null/undefined were outside of the path 
+            //this helper will fall into a inescapable goto loop as the checks for null/undefined were outside of the path
             return RelationalComparisonHelper(aLeft, aRight, scriptContext, leftFirst, undefinedAs);
         }
 
@@ -9386,80 +9386,116 @@ CommonNumber:
 
     Var JavascriptOperators::OP_ResumeYield(ResumeYieldData* yieldData, RecyclableObject* iterator)
     {
+        bool isNext = yieldData->exceptionObj == nullptr;
+        bool isThrow = !isNext && !yieldData->exceptionObj->IsGeneratorReturnException();
+
+        if (iterator != nullptr) // yield*
+        {
+            ScriptContext* scriptContext = iterator->GetScriptContext();
+            PropertyId propertyId = isNext ? PropertyIds::next : isThrow ? PropertyIds::throw_ : PropertyIds::return_;
+            Var prop = JavascriptOperators::GetProperty(iterator, propertyId, scriptContext);
+
+            if (!isNext && JavascriptOperators::IsUndefinedOrNull(prop))
+            {
+                if (isThrow)
+                {
+                    // 5.b.iii.2
+                    // NOTE: If iterator does not have a throw method, this throw is going to terminate the yield* loop.
+                    // But first we need to give iterator a chance to clean up.
+
+                    prop = JavascriptOperators::GetProperty(iterator, PropertyIds::return_, scriptContext);
+                    if (!JavascriptOperators::IsUndefinedOrNull(prop))
+                    {
+                        if (!JavascriptConversion::IsCallable(prop))
+                        {
+                            JavascriptError::ThrowTypeError(scriptContext, JSERR_Property_NeedFunction, _u("return"));
+                        }
+
+                        RecyclableObject* method = RecyclableObject::FromVar(prop);
+                        Var args[] = { iterator, yieldData->data };
+                        CallInfo callInfo(CallFlags_Value, _countof(args));
+                        Var result = JavascriptFunction::CallFunction<true>(method, method->GetEntryPoint(), Arguments(callInfo, args));
+
+                        if (!JavascriptOperators::IsObject(result))
+                        {
+                            JavascriptError::ThrowTypeError(scriptContext, JSERR_NeedObject);
+                        }
+                    }
+
+                    // 5.b.iii.3
+                    // NOTE: The next step throws a TypeError to indicate that there was a yield* protocol violation:
+                    // iterator does not have a throw method.
+                    JavascriptError::ThrowTypeError(scriptContext, JSERR_Property_NeedFunction, _u("throw"));
+                }
+
+                // Do not use ThrowExceptionObject for return() API exceptions since these exceptions are not real exceptions
+                throw yieldData->exceptionObj;
+            }
+
+            if (!JavascriptConversion::IsCallable(prop))
+            {
+                JavascriptError::ThrowTypeError(scriptContext, JSERR_Property_NeedFunction, isNext ? _u("next") : isThrow ? _u("throw") : _u("return"));
+            }
+
+            RecyclableObject* method = RecyclableObject::FromVar(prop);
+            Var args[] = { iterator, yieldData->data };
+            CallInfo callInfo(CallFlags_Value, _countof(args));
+            Var result = JavascriptFunction::CallFunction<true>(method, method->GetEntryPoint(), Arguments(callInfo, args));
+
+            if (!JavascriptOperators::IsObject(result))
+            {
+                JavascriptError::ThrowTypeError(scriptContext, JSERR_NeedObject);
+            }
+
+            if (isThrow || isNext)
+            {
+                // 5.b.ii.2
+                // NOTE: Exceptions from the inner iterator throw method are propagated.
+                // Normal completions from an inner throw method are processed similarly to an inner next.
+                return result;
+            }
+
+            RecyclableObject* obj = RecyclableObject::FromVar(result);
+            Var done = JavascriptOperators::GetProperty(obj, PropertyIds::done, scriptContext);
+            if (done == iterator->GetLibrary()->GetTrue())
+            {
+                Var value = JavascriptOperators::GetProperty(obj, PropertyIds::value, scriptContext);
+                yieldData->exceptionObj->SetThrownObject(value);
+                // Do not use ThrowExceptionObject for return() API exceptions since these exceptions are not real exceptions
+                throw yieldData->exceptionObj;
+            }
+            return result;
+        }
+
         // CONSIDER: Fast path this early out return path in JITed code before helper call to avoid the helper call overhead in the common case e.g. next() calls.
-        if (yieldData->exceptionObj == nullptr)
+        if (isNext)
         {
             return yieldData->data;
         }
 
-        ScriptContext* scriptContext = yieldData->exceptionObj->GetScriptContext();
-        bool isReturn = yieldData->exceptionObj->IsGeneratorReturnException();
-
-        if (iterator != nullptr)
-        {
-            PropertyId propertyId = isReturn ? PropertyIds::return_ : PropertyIds::throw_;
-            Var prop = nullptr;
-            Var args[] = { iterator, yieldData->data };
-            CallInfo callInfo(CallFlags_Value, _countof(args));
-
-            if (JavascriptOperators::GetProperty(iterator, iterator, propertyId, &prop, iterator->GetScriptContext())
-                    && prop != iterator->GetLibrary()->GetUndefined())
-            {
-                RecyclableObject* method = RecyclableObject::FromVar(prop);
-
-                Var result = JavascriptFunction::CallFunction<true>(method, method->GetEntryPoint(), Arguments(callInfo, args));
-
-                if (isReturn)
-                {
-                    if (!JavascriptOperators::IsObject(result))
-                    {
-                        JavascriptError::ThrowTypeError(scriptContext, JSERR_NeedObject);
-                    }
-
-                    Var value = JavascriptOperators::GetProperty(RecyclableObject::FromVar(result), PropertyIds::value, scriptContext);
-                    // CONSIDER: Using an exception to carry the return value and force finally code to execute is a bit of a janky
-                    // solution since we have to override the value here in the case of yield* expressions.  It works but is there
-                    // a more elegant way?
-                    //
-                    // Instead what if ResumeYield was a "set Dst then optionally branch" opcode, that could also throw? Then we could
-                    // avoid using a special exception entirely with byte code something like this:
-                    //
-                    // ;; Ry is the yieldData
-                    //
-                    // ResumeYield Rx Ry $returnPathLabel
-                    // ... code like normal
-                    // $returnPathLabel:
-                    // Ld_A R0 Rx
-                    // Br $exitFinallyAndReturn
-                    //
-                    // This would probably give better performance for the common case of calling next() on generators since we wouldn't
-                    // have to wrap the call to the generator code in a try catch.
-                    yieldData->exceptionObj->SetThrownObject(value);
-                }
-            }
-            else if (!isReturn)
-            {
-                // Throw is called on yield* but the iterator does not have a throw method. This is a protocol violation.
-                // So we have to call IteratorClose().
-                if (JavascriptOperators::GetProperty(iterator, iterator, PropertyIds::return_, &prop, iterator->GetScriptContext())
-                        && prop != iterator->GetLibrary()->GetUndefined())
-                {
-                    // As per the spec we ignore the inner result after checking whether it is a valid object
-                    RecyclableObject* method = RecyclableObject::FromVar(prop);
-                    Var result = JavascriptFunction::CallFunction<true>(method, method->GetEntryPoint(), Arguments(callInfo, args));
-                    if (!JavascriptOperators::IsObject(result))
-                    {
-                        JavascriptError::ThrowTypeError(scriptContext, JSERR_NeedObject);
-                    }
-                }
-            }
-        }
-
-        if (!isReturn)
+        if (isThrow)
         {
             // Use ThrowExceptionObject() to get debugger support for breaking on throw
-            JavascriptExceptionOperators::ThrowExceptionObject(yieldData->exceptionObj, scriptContext, true);
+            JavascriptExceptionOperators::ThrowExceptionObject(yieldData->exceptionObj, yieldData->exceptionObj->GetScriptContext(), true);
         }
+
+        // CONSIDER: Using an exception to carry the return value and force finally code to execute is a bit of a janky
+        // solution since we have to override the value here in the case of yield* expressions.  It works but is there
+        // a more elegant way?
+        //
+        // Instead what if ResumeYield was a "set Dst then optionally branch" opcode, that could also throw? Then we could
+        // avoid using a special exception entirely with byte code something like this:
+        //
+        // ;; Ry is the yieldData
+        //
+        // ResumeYield Rx Ry $returnPathLabel
+        // ... code like normal
+        // $returnPathLabel:
+        // Ld_A R0 Rx
+        // Br $exitFinallyAndReturn
+        //
+        // This would probably give better performance for the common case of calling next() on generators since we wouldn't
+        // have to wrap the call to the generator code in a try catch.
 
         // Do not use ThrowExceptionObject for return() API exceptions since these exceptions are not real exceptions
         throw yieldData->exceptionObj;


### PR DESCRIPTION
1. If the iterator's `.return()` method returns an object whose `done` property is `false`, do not terminate the yield*'s loop.
2. If the iterator's `.throw()` method doesn't throw, return the value it returned instead of throwing an exception

Fixes gh-139, fixes gh-137