### PR TITLE
Remove the registering of scriptContexts those have inlineCaches

### DIFF
--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -118,10 +118,8 @@ namespace Js
 #endif
         inlineCacheAllocator(_u("SC-InlineCache"), threadContext->GetPageAllocator(), Throw::OutOfMemory),
         isInstInlineCacheAllocator(_u("SC-IsInstInlineCache"), threadContext->GetPageAllocator(), Throw::OutOfMemory),
-        hasRegisteredInlineCache(false),
-        hasRegisteredIsInstInlineCache(false),
-        entryInScriptContextWithInlineCachesRegistry(nullptr),
-        entryInScriptContextWithIsInstInlineCachesRegistry(nullptr),
+        hasInlineCache(false),
+        hasIsInstInlineCache(false),
         registeredPrototypeChainEnsuredToHaveOnlyWritableDataPropertiesScriptContext(nullptr),
         cache(nullptr),
         bindRefChunkCurrent(nullptr),
@@ -369,6 +367,28 @@ namespace Js
         // TODO: Can we move this on Close()?
         ClearHostScriptContext();
 
+        if (this->hasInlineCache)
+        {
+            // TODO (PersistentInlineCaches): It really isn't necessary to clear inline caches in all script contexts.
+            // Since this script context is being destroyed, the inline cache arena will also go away and release its
+            // memory back to the page allocator.  Thus, we cannot leave this script context's inline caches on the
+            // thread context's invalidation lists.  However, it should suffice to remove this script context's caches
+            // without touching other script contexts' caches.  We could call some form of RemoveInlineCachesFromInvalidationLists()
+            // on the inline cache allocator, which would walk all inline caches and zap values pointed to by strongRef.
+
+            // clear out all inline caches to remove our proto inline caches from the thread context
+            threadContext->ClearInlineCaches();
+
+            Assert(!this->hasInlineCache);
+        }
+
+        if (this->hasIsInstInlineCache)
+        {
+            // clear out all inline caches to remove our proto inline caches from the thread context
+            threadContext->ClearIsInstInlineCaches();
+            Assert(!this->hasIsInstInlineCache);
+        }
+
         threadContext->UnregisterScriptContext(this);
 
         // Only call RemoveFromPendingClose if we are in a pending close state.
@@ -449,43 +469,6 @@ namespace Js
             this->asmJsCodeGenerator = NULL;
         }
 #endif
-
-        if (this->hasRegisteredInlineCache)
-        {
-            // TODO (PersistentInlineCaches): It really isn't necessary to clear inline caches in all script contexts.
-            // Since this script context is being destroyed, the inline cache arena will also go away and release its
-            // memory back to the page allocator.  Thus, we cannot leave this script context's inline caches on the
-            // thread context's invalidation lists.  However, it should suffice to remove this script context's caches
-            // without touching other script contexts' caches.  We could call some form of RemoveInlineCachesFromInvalidationLists()
-            // on the inline cache allocator, which would walk all inline caches and zap values pointed to by strongRef.
-
-            // clear out all inline caches to remove our proto inline caches from the thread context
-            threadContext->ClearInlineCaches();
-            Assert(!this->hasRegisteredInlineCache);
-            Assert(this->entryInScriptContextWithInlineCachesRegistry == nullptr);
-        }
-        else if (this->entryInScriptContextWithInlineCachesRegistry != nullptr)
-        {
-            // UnregisterInlineCacheScriptContext may throw, set up the correct state first
-            ScriptContext ** entry = this->entryInScriptContextWithInlineCachesRegistry;
-            this->entryInScriptContextWithInlineCachesRegistry = nullptr;
-            threadContext->UnregisterInlineCacheScriptContext(entry);
-        }
-
-        if (this->hasRegisteredIsInstInlineCache)
-        {
-            // clear out all inline caches to remove our proto inline caches from the thread context
-            threadContext->ClearIsInstInlineCaches();
-            Assert(!this->hasRegisteredIsInstInlineCache);
-            Assert(this->entryInScriptContextWithIsInstInlineCachesRegistry == nullptr);
-        }
-        else if (this->entryInScriptContextWithInlineCachesRegistry != nullptr)
-        {
-            // UnregisterInlineCacheScriptContext may throw, set up the correct state first
-            ScriptContext ** entry = this->entryInScriptContextWithInlineCachesRegistry;
-            this->entryInScriptContextWithInlineCachesRegistry = nullptr;
-            threadContext->UnregisterIsInstInlineCacheScriptContext(entry);
-        }
 
         // In case there is something added to the list between close and dtor, just reset the list again
         this->weakReferenceDictionaryList.Reset();
@@ -3985,44 +3968,9 @@ namespace Js
 #endif
     }
 
-    void ScriptContext::RegisterAsScriptContextWithInlineCaches()
-    {
-        if (this->entryInScriptContextWithInlineCachesRegistry == nullptr)
-        {
-            DoRegisterAsScriptContextWithInlineCaches();
-        }
-    }
-
-    void ScriptContext::DoRegisterAsScriptContextWithInlineCaches()
-    {
-        Assert(this->entryInScriptContextWithInlineCachesRegistry == nullptr);
-        // this call may throw OOM
-        this->entryInScriptContextWithInlineCachesRegistry = threadContext->RegisterInlineCacheScriptContext(this);
-    }
-
-    void ScriptContext::RegisterAsScriptContextWithIsInstInlineCaches()
-    {
-        if (this->entryInScriptContextWithIsInstInlineCachesRegistry == nullptr)
-        {
-            DoRegisterAsScriptContextWithIsInstInlineCaches();
-        }
-    }
-
-    bool ScriptContext::IsRegisteredAsScriptContextWithIsInstInlineCaches()
-    {
-        return this->entryInScriptContextWithIsInstInlineCachesRegistry != nullptr;
-    }
-
-    void ScriptContext::DoRegisterAsScriptContextWithIsInstInlineCaches()
-    {
-        Assert(this->entryInScriptContextWithIsInstInlineCachesRegistry == nullptr);
-        // this call may throw OOM
-        this->entryInScriptContextWithIsInstInlineCachesRegistry = threadContext->RegisterIsInstInlineCacheScriptContext(this);
-    }
-
     void ScriptContext::RegisterProtoInlineCache(InlineCache *pCache, PropertyId propId)
     {
-        hasRegisteredInlineCache = true;
+        hasInlineCache = true;
         threadContext->RegisterProtoInlineCache(pCache, propId);
     }
 
@@ -4052,7 +4000,7 @@ namespace Js
 
     void ScriptContext::RegisterStoreFieldInlineCache(InlineCache *pCache, PropertyId propId)
     {
-        hasRegisteredInlineCache = true;
+        hasInlineCache = true;
         threadContext->RegisterStoreFieldInlineCache(pCache, propId);
     }
 
@@ -4072,7 +4020,7 @@ namespace Js
     void ScriptContext::RegisterIsInstInlineCache(Js::IsInstInlineCache * cache, Js::Var function)
     {
         Assert(JavascriptFunction::FromVar(function)->GetScriptContext() == this);
-        hasRegisteredIsInstInlineCache = true;
+        hasIsInstInlineCache = true;
         threadContext->RegisterIsInstInlineCache(cache, function);
     }
 
@@ -4122,10 +4070,11 @@ namespace Js
     {
         // Prevent reentrancy for the following work, which is not required to be done on every call to this function including
         // reentrant calls
-        if (this->isPerformingNonreentrantWork)
+        if (this->isPerformingNonreentrantWork || !this->hasInlineCache)
         {
             return;
         }
+
         class AutoCleanup
         {
         private:
@@ -4186,36 +4135,31 @@ namespace Js
 
 void ScriptContext::ClearInlineCaches()
 {
-    Assert(this->entryInScriptContextWithInlineCachesRegistry != nullptr);
-
-    // For persistent inline caches, we assume here that all thread context's invalidation lists
-    // will be reset, such that all invalidationListSlotPtr will get zeroed.  We will not be zeroing
-    // this field here to preserve the free list, which uses the field to link caches together.
-    GetInlineCacheAllocator()->ZeroAll();
-
-    this->entryInScriptContextWithInlineCachesRegistry = nullptr; // caller will remove us from the thread context
-
-    this->hasRegisteredInlineCache = false;
+    if (this->hasInlineCache)
+    {
+        GetInlineCacheAllocator()->ZeroAll();
+        this->hasInlineCache = false;
+    }
 }
 
 void ScriptContext::ClearIsInstInlineCaches()
 {
-    Assert(entryInScriptContextWithIsInstInlineCachesRegistry != nullptr);
-    GetIsInstInlineCacheAllocator()->ZeroAll();
-
-    this->entryInScriptContextWithIsInstInlineCachesRegistry = nullptr; // caller will remove us from the thread context.
-
-    this->hasRegisteredIsInstInlineCache = false;
+    if (this->hasIsInstInlineCache)
+    {
+        GetIsInstInlineCacheAllocator()->ZeroAll();
+        this->hasIsInstInlineCache = false;
+    }
 }
 
 
 #ifdef PERSISTENT_INLINE_CACHES
 void ScriptContext::ClearInlineCachesWithDeadWeakRefs()
 {
-    // Review: I should be able to assert this here just like in ClearInlineCaches.
-    Assert(this->entryInScriptContextWithInlineCachesRegistry != nullptr);
-    GetInlineCacheAllocator()->ClearCachesWithDeadWeakRefs(this->recycler);
-    Assert(GetInlineCacheAllocator()->HasNoDeadWeakRefs(this->recycler));
+    if (this->hasInlineCache)
+    {
+        GetInlineCacheAllocator()->ClearCachesWithDeadWeakRefs(this->recycler);
+        Assert(GetInlineCacheAllocator()->HasNoDeadWeakRefs(this->recycler));
+    }
 }
 #endif
 

--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -4140,6 +4140,7 @@ void ScriptContext::ClearInlineCaches()
     {
         GetInlineCacheAllocator()->ZeroAll();
         this->hasUsedInlineCache = false;
+        this->hasProtoOrStoreFieldInlineCache = false;
     }
 
     Assert(GetInlineCacheAllocator()->IsAllZero());

--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -755,7 +755,8 @@ private:
         bool isCloningGlobal;
 #endif
         bool fastDOMenabled;
-        bool hasInlineCache;
+        bool hasUsedInlineCache;
+        bool hasProtoOrStoreFieldInlineCache;
         bool hasIsInstInlineCache;
         bool deferredBody;
         bool isPerformingNonreentrantWork;
@@ -854,6 +855,8 @@ private:
             return !nativeCodeGen || ::IsClosedNativeCodeGenerator(nativeCodeGen);
         }
 #endif
+
+        void SetHasUsedInlineCache(bool value) { hasUsedInlineCache = value; }
 
         void SetDirectHostTypeId(TypeId typeId) {directHostTypeId = typeId; }
         TypeId GetDirectHostTypeId() const { return directHostTypeId; }

--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -465,8 +465,6 @@ namespace Js
         JavascriptFunction* GenerateRootFunction(ParseNodePtr parseTree, uint sourceIndex, Parser* parser, ulong grfscr, CompileScriptException * pse, const char16 *rootDisplayName);
 
         typedef void (*EventHandler)(ScriptContext *);
-        ScriptContext ** entryInScriptContextWithInlineCachesRegistry;
-        ScriptContext ** entryInScriptContextWithIsInstInlineCachesRegistry;
         ScriptContext ** registeredPrototypeChainEnsuredToHaveOnlyWritableDataPropertiesScriptContext;
 
         ArenaAllocator generalAllocator;
@@ -757,8 +755,8 @@ private:
         bool isCloningGlobal;
 #endif
         bool fastDOMenabled;
-        bool hasRegisteredInlineCache;
-        bool hasRegisteredIsInstInlineCache;
+        bool hasInlineCache;
+        bool hasIsInstInlineCache;
         bool deferredBody;
         bool isPerformingNonreentrantWork;
         bool isDiagnosticsScriptContext;   // mentions that current script context belongs to the diagnostics OM.
@@ -1272,15 +1270,10 @@ private:
         }
 
     public:
-        void RegisterAsScriptContextWithInlineCaches();
-        void RegisterAsScriptContextWithIsInstInlineCaches();
-        bool IsRegisteredAsScriptContextWithIsInstInlineCaches();
         void FreeLoopBody(void* codeAddress);
         void FreeFunctionEntryPoint(Js::JavascriptMethod method);
 
     private:
-        void DoRegisterAsScriptContextWithInlineCaches();
-        void DoRegisterAsScriptContextWithIsInstInlineCaches();
         uint CloneSource(Utf8SourceInfo* info);
     public:
         void RegisterProtoInlineCache(InlineCache *pCache, PropertyId propId);

--- a/lib/Runtime/Base/ThreadContext.h
+++ b/lib/Runtime/Base/ThreadContext.h
@@ -668,8 +668,6 @@ private:
     ArenaAllocator inlineCacheThreadInfoAllocator;
     ArenaAllocator isInstInlineCacheThreadInfoAllocator;
     ArenaAllocator equivalentTypeCacheInfoAllocator;
-    DListBase<Js::ScriptContext *> inlineCacheScriptContexts;
-    DListBase<Js::ScriptContext *> isInstInlineCacheScriptContexts;
     DListBase<Js::EntryPointInfo *> equivalentTypeCacheEntryPoints;
 
     typedef SList<Js::InlineCache*> InlineCacheList;
@@ -1153,11 +1151,7 @@ public:
     void SetNoScriptScope(bool noScriptScope) { this->noScriptScope = noScriptScope; }
     bool IsNoScriptScope() { return this->noScriptScope; }
 
-    Js::ScriptContext ** RegisterInlineCacheScriptContext(Js::ScriptContext * scriptContext);
-    Js::ScriptContext ** RegisterIsInstInlineCacheScriptContext(Js::ScriptContext * scriptContext);
     Js::EntryPointInfo ** RegisterEquivalentTypeCacheEntryPoint(Js::EntryPointInfo * entryPoint);
-    void UnregisterInlineCacheScriptContext(Js::ScriptContext ** scriptContext);
-    void UnregisterIsInstInlineCacheScriptContext(Js::ScriptContext ** scriptContext);
     void UnregisterEquivalentTypeCacheEntryPoint(Js::EntryPointInfo ** entryPoint);
     void RegisterProtoInlineCache(Js::InlineCache * inlineCache, Js::PropertyId propertyId);
     void RegisterStoreFieldInlineCache(Js::InlineCache * inlineCache, Js::PropertyId propertyId);

--- a/lib/Runtime/Language/InlineCache.cpp
+++ b/lib/Runtime/Language/InlineCache.cpp
@@ -26,6 +26,8 @@ namespace Js
         // We may, however, have a flags cache (setter) change to add property cache.
         Assert(typeWithoutProperty == nullptr || !IsProto());
 
+        requestContext->SetHasUsedInlineCache(true);
+
         // Add cache into a store field cache list if required, but not there yet.
         if (typeWithoutProperty != nullptr && invalidationListSlotPtr == nullptr)
         {
@@ -89,6 +91,8 @@ namespace Js
         // Store field and load field caches are never shared so we should never have an add property cache morphing into a prototype cache.
         Assert(!IsLocal() || u.local.typeWithoutProperty == nullptr);
 
+        requestContext->SetHasUsedInlineCache(true);
+
         // Add cache into a proto cache list if not there yet.
         if (invalidationListSlotPtr == nullptr)
         {
@@ -144,6 +148,8 @@ namespace Js
         // It is possible that prototype is from a different scriptContext than the original instance. We don't want to cache
         // in this case.
         Assert(type->GetScriptContext() == requestContext);
+
+        requestContext->SetHasUsedInlineCache(true);
 
         if (isOnProto && invalidationListSlotPtr == nullptr)
         {

--- a/lib/Runtime/Language/InlineCache.cpp
+++ b/lib/Runtime/Language/InlineCache.cpp
@@ -26,8 +26,6 @@ namespace Js
         // We may, however, have a flags cache (setter) change to add property cache.
         Assert(typeWithoutProperty == nullptr || !IsProto());
 
-        requestContext->RegisterAsScriptContextWithInlineCaches();
-
         // Add cache into a store field cache list if required, but not there yet.
         if (typeWithoutProperty != nullptr && invalidationListSlotPtr == nullptr)
         {
@@ -91,8 +89,6 @@ namespace Js
         // Store field and load field caches are never shared so we should never have an add property cache morphing into a prototype cache.
         Assert(!IsLocal() || u.local.typeWithoutProperty == nullptr);
 
-        requestContext->RegisterAsScriptContextWithInlineCaches();
-
         // Add cache into a proto cache list if not there yet.
         if (invalidationListSlotPtr == nullptr)
         {
@@ -148,8 +144,6 @@ namespace Js
         // It is possible that prototype is from a different scriptContext than the original instance. We don't want to cache
         // in this case.
         Assert(type->GetScriptContext() == requestContext);
-
-        requestContext->RegisterAsScriptContextWithInlineCaches();
 
         if (isOnProto && invalidationListSlotPtr == nullptr)
         {
@@ -1152,7 +1146,6 @@ namespace Js
         // this cache is registered with thread context for invalidation.
         if (this->function == function)
         {
-            Assert(scriptContext->IsRegisteredAsScriptContextWithIsInstInlineCaches());
             Assert(scriptContext->IsIsInstInlineCacheRegistered(this, function));
             this->Set(instanceType, function, result);
         }
@@ -1164,7 +1157,6 @@ namespace Js
                 Clear();
             }
 
-            scriptContext->RegisterAsScriptContextWithIsInstInlineCaches();
             // If the cache's function is not null, the cache must have been registered already.  No need to register again.
             // In fact, ThreadContext::RegisterIsInstInlineCache, would assert if we tried to re-register the same cache (to enforce the invariant above).
             // Review (jedmiad): What happens if we run out of memory inside RegisterIsInstInlieCache?

--- a/lib/Runtime/Library/PropertyString.cpp
+++ b/lib/Runtime/Library/PropertyString.cpp
@@ -53,10 +53,6 @@ namespace Js
     void PropertyString::UpdateCache(Type * type, uint16 dataSlotIndex, bool isInlineSlot, bool isStoreFieldEnabled)
     {
         Assert(type && type->GetScriptContext() == this->GetScriptContext());
-        if (registerScriptContext)
-        {
-            this->GetScriptContext()->RegisterAsScriptContextWithInlineCaches();
-        }
 
         this->propCache->type = type;
         this->propCache->preventdataSlotIndexFalseRef = 1;

--- a/lib/Runtime/Library/PropertyString.cpp
+++ b/lib/Runtime/Library/PropertyString.cpp
@@ -16,7 +16,7 @@ namespace Js
 
     PropertyString* PropertyString::New(StaticType* type, const Js::PropertyRecord* propertyRecord, ArenaAllocator *arena)
     {
-        PropertyString * propertyString = Anew(arena, PropertyString, type, propertyRecord);
+        PropertyString * propertyString = (PropertyString *)Anew(arena, AreanaAllocPropertyString, type, propertyRecord);
         propertyString->propCache = AllocatorNewStructZ(InlineCacheAllocator, type->GetScriptContext()->GetInlineCacheAllocator(), PropertyCache);
         return propertyString;
     }
@@ -54,6 +54,11 @@ namespace Js
     {
         Assert(type && type->GetScriptContext() == this->GetScriptContext());
 
+        if (this->IsAreanaAllocPropertyString())
+        {
+            this->GetScriptContext()->SetHasUsedInlineCache(true);
+        }
+
         this->propCache->type = type;
         this->propCache->preventdataSlotIndexFalseRef = 1;
         this->propCache->dataSlotIndex = dataSlotIndex;
@@ -61,4 +66,8 @@ namespace Js
         this->propCache->isInlineSlot = isInlineSlot;
         this->propCache->isStoreFieldEnabled = isStoreFieldEnabled;
     }
+
+    AreanaAllocPropertyString::AreanaAllocPropertyString(StaticType* type, const Js::PropertyRecord* propertyRecord)
+        :PropertyString(type, propertyRecord)
+    {}
 }

--- a/lib/Runtime/Library/PropertyString.cpp
+++ b/lib/Runtime/Library/PropertyString.cpp
@@ -9,14 +9,14 @@ namespace Js
     DEFINE_RECYCLER_TRACKER_PERF_COUNTER(PropertyString);
     DEFINE_RECYCLER_TRACKER_WEAKREF_PERF_COUNTER(PropertyString);
 
-    PropertyString::PropertyString(StaticType* type, const Js::PropertyRecord* propertyRecord, bool registerScriptContext)
-        : JavascriptString(type, propertyRecord->GetLength(), propertyRecord->GetBuffer()), registerScriptContext(registerScriptContext), m_propertyRecord(propertyRecord)
+    PropertyString::PropertyString(StaticType* type, const Js::PropertyRecord* propertyRecord)
+        : JavascriptString(type, propertyRecord->GetLength(), propertyRecord->GetBuffer()), m_propertyRecord(propertyRecord)
     {
     }
 
     PropertyString* PropertyString::New(StaticType* type, const Js::PropertyRecord* propertyRecord, ArenaAllocator *arena)
     {
-        PropertyString * propertyString = Anew(arena, PropertyString, type, propertyRecord, true);
+        PropertyString * propertyString = Anew(arena, PropertyString, type, propertyRecord);
         propertyString->propCache = AllocatorNewStructZ(InlineCacheAllocator, type->GetScriptContext()->GetInlineCacheAllocator(), PropertyCache);
         return propertyString;
     }
@@ -24,7 +24,7 @@ namespace Js
 
     PropertyString* PropertyString::New(StaticType* type, const Js::PropertyRecord* propertyRecord, Recycler *recycler)
     {
-        PropertyString * propertyString =  RecyclerNewPlusZ(recycler, sizeof(PropertyCache), PropertyString, type, propertyRecord, false);
+        PropertyString * propertyString =  RecyclerNewPlusZ(recycler, sizeof(PropertyCache), PropertyString, type, propertyRecord);
         propertyString->propCache = (PropertyCache*)(propertyString + 1);
         return propertyString;
     }

--- a/lib/Runtime/Library/PropertyString.h
+++ b/lib/Runtime/Library/PropertyString.h
@@ -34,7 +34,7 @@ namespace Js
     CompileAssert(sizeof(PropertyCache) == sizeof(InlineCacheAllocator::CacheLayout));
     CompileAssert(offsetof(PropertyCache, blank) == offsetof(InlineCacheAllocator::CacheLayout, strongRef));
 
-    class PropertyString sealed : public JavascriptString
+    class PropertyString : public JavascriptString
     {
     protected:
         PropertyCache* propCache;
@@ -54,7 +54,17 @@ namespace Js
 
         virtual void const * GetOriginalStringReference() override;
         virtual RecyclableObject * CloneToScriptContext(ScriptContext* requestContext) override;
+        virtual bool IsAreanaAllocPropertyString() { return false; }
 
         static uint32 GetOffsetOfPropertyCache() { return offsetof(PropertyString, propCache); }
+    };
+
+    class AreanaAllocPropertyString sealed : public PropertyString
+    {
+        friend PropertyString;
+    protected:
+        AreanaAllocPropertyString(StaticType* type, const Js::PropertyRecord* propertyRecord);
+    public:
+        virtual bool IsAreanaAllocPropertyString() override { return true; }
     };
 }

--- a/lib/Runtime/Library/PropertyString.h
+++ b/lib/Runtime/Library/PropertyString.h
@@ -38,12 +38,11 @@ namespace Js
     {
     protected:
         PropertyCache* propCache;
-        bool registerScriptContext;
         const Js::PropertyRecord* m_propertyRecord;
         DEFINE_VTABLE_CTOR(PropertyString, JavascriptString);
         DECLARE_CONCRETE_STRING_CLASS;
 
-        PropertyString(StaticType* type, const Js::PropertyRecord* propertyRecord, bool registerScriptContext);
+        PropertyString(StaticType* type, const Js::PropertyRecord* propertyRecord);
     public:
         PropertyCache const * GetPropertyCache() const;
         void ClearPropertyCache();


### PR DESCRIPTION
ThreadContext uses different list to keep tracking of those scriptContexts which have inlineCaches, when adding to this list it can OOM and then causes some of the inlineCaches not be able to cleared up.
Changing the design to not using this kind of registering mechanism, instead just use the flags on scriptContext to determine if there's inlineCaches need to be cleared or not. with this change there should be less work to do while allocating inlineCache, but longer list to walk while shutting down. usually we do not have many scriptContexts (my guess is in most web sites we have less than 100 scriptContexts) so it should not slow down the shutdown process.