### PR TITLE
linux: partially builds lib/Runtime/Base

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,9 @@ if(CLR_CMAKE_PLATFORM_UNIX)
         -Wno-tautological-undefined-compare
         -Wno-address-of-temporary  # vtinfo.h, VirtualTableInfo<T>::RegisterVirtualTable
         -Wno-null-conversion # Check shmemory.cpp and cs.cpp here...
+        -Wno-return-type # switch unreachable code
+        -Wno-switch # switch values not handled
+        -Wno-int-to-pointer-cast
     )
 endif(CLR_CMAKE_PLATFORM_UNIX)
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory (Common)
 add_subdirectory (Parser)
+add_subdirectory (Runtime)

--- a/lib/Common/CommonDefines.h
+++ b/lib/Common/CommonDefines.h
@@ -551,6 +551,12 @@
 #endif
 #endif
 
+// ENABLE_DEBUG_STACK_BACK_TRACE is for capturing stack back trace for debug only.
+// (STACK_BACK_TRACE is enabled on release build, used by RECYCLER_PAGE_HEAP.)
+#if ENABLE_DEBUG_CONFIG_OPTIONS && defined(STACK_BACK_TRACE)
+#define ENABLE_DEBUG_STACK_BACK_TRACE 1
+#endif
+
 #if defined(STACK_BACK_TRACE) || defined(CONTROL_FLOW_GUARD_LOGGER)
 #define DBGHELP_SYMBOL_MANAGER
 #endif

--- a/lib/Common/DataStructures/BaseDictionary.h
+++ b/lib/Common/DataStructures/BaseDictionary.h
@@ -1581,7 +1581,7 @@ namespace JsUtil
 #ifdef DBG
         void Dump()
         {
-            LockPolicy::ReadLock autoLock(syncObj);
+            typename LockPolicy::ReadLock autoLock(syncObj);
 
             __super::Dump();
         }
@@ -1589,7 +1589,7 @@ namespace JsUtil
 
         TAllocator *GetAllocator() const
         {
-            LockPolicy::ReadLock autoLock(syncObj);
+            typename LockPolicy::ReadLock autoLock(syncObj);
 
             return __super::GetAllocator();
         }
@@ -1603,56 +1603,56 @@ namespace JsUtil
 
         inline int Capacity() const
         {
-            LockPolicy::ReadLock autoLock(syncObj);
+            typename LockPolicy::ReadLock autoLock(syncObj);
 
             return __super::Capacity();
         }
 
         TValue Item(const TKey& key)
         {
-            LockPolicy::ReadLock autoLock(syncObj);
+            typename LockPolicy::ReadLock autoLock(syncObj);
 
             return __super::Item(key);
         }
 
         bool IsInAdd()
         {
-            LockPolicy::ReadLock autoLock(syncObj);
+            typename LockPolicy::ReadLock autoLock(syncObj);
 
             return __super::IsInAdd();
         }
 
         int Add(const TKey& key, const TValue& value)
         {
-            LockPolicy::AddRemoveLock autoLock(syncObj);
+            typename LockPolicy::AddRemoveLock autoLock(syncObj);
 
             return __super::Add(key, value);
         }
 
         int AddNew(const TKey& key, const TValue& value)
         {
-            LockPolicy::AddRemoveLock autoLock(syncObj);
+            typename LockPolicy::AddRemoveLock autoLock(syncObj);
 
             return __super::AddNew(key, value);
         }
 
         int Item(const TKey& key, const TValue& value)
         {
-            LockPolicy::AddRemoveLock autoLock(syncObj);
+            typename LockPolicy::AddRemoveLock autoLock(syncObj);
 
             return __super::Item(key, value);
         }
 
         bool Contains(KeyValuePair<TKey, TValue> keyValuePair)
         {
-            LockPolicy::ReadLock autoLock(syncObj);
+            typename LockPolicy::ReadLock autoLock(syncObj);
 
             return __super::Contains(keyValuePair);
         }
 
         bool Remove(KeyValuePair<TKey, TValue> keyValuePair)
         {
-            LockPolicy::AddRemoveLock autoLock(syncObj);
+            typename LockPolicy::AddRemoveLock autoLock(syncObj);
 
             return __super::Remove(keyValuePair);
         }
@@ -1666,14 +1666,14 @@ namespace JsUtil
 
         void Reset()
         {
-            LockPolicy::AddRemoveLock autoLock(syncObj);
+            typename LockPolicy::AddRemoveLock autoLock(syncObj);
 
             return __super::Reset();
         }
 
         bool ContainsKey(const TKey& key)
         {
-            LockPolicy::ReadLock autoLock(syncObj);
+            typename LockPolicy::ReadLock autoLock(syncObj);
 
             return __super::ContainsKey(key);
         }
@@ -1681,14 +1681,14 @@ namespace JsUtil
         template <typename TLookup>
         inline const TValue& LookupWithKey(const TLookup& key, const TValue& defaultValue)
         {
-            LockPolicy::ReadLock autoLock(syncObj);
+            typename LockPolicy::ReadLock autoLock(syncObj);
 
             return __super::LookupWithKey(key, defaultValue);
         }
 
         inline const TValue& Lookup(const TKey& key, const TValue& defaultValue)
         {
-            LockPolicy::ReadLock autoLock(syncObj);
+            typename LockPolicy::ReadLock autoLock(syncObj);
 
             return __super::Lookup(key, defaultValue);
         }
@@ -1696,14 +1696,14 @@ namespace JsUtil
         template <typename TLookup>
         bool TryGetValue(const TLookup& key, TValue* value)
         {
-            LockPolicy::ReadLock autoLock(syncObj);
+            typename LockPolicy::ReadLock autoLock(syncObj);
 
             return __super::TryGetValue(key, value);
         }
 
         bool TryGetValueAndRemove(const TKey& key, TValue* value)
         {
-            LockPolicy::AddRemoveLock autoLock(syncObj);
+            typename LockPolicy::AddRemoveLock autoLock(syncObj);
 
             return __super::TryGetValueAndRemove(key, value);
         }
@@ -1711,7 +1711,7 @@ namespace JsUtil
         template <typename TLookup>
         __inline bool TryGetReference(const TLookup& key, TValue** value)
         {
-            LockPolicy::ReadLock autoLock(syncObj);
+            typename LockPolicy::ReadLock autoLock(syncObj);
 
             return __super::TryGetReference(key, value);
         }
@@ -1719,35 +1719,35 @@ namespace JsUtil
         template <typename TLookup>
         __inline bool TryGetReference(const TLookup& key, TValue** value, int* index)
         {
-            LockPolicy::ReadLock autoLock(syncObj);
+            typename LockPolicy::ReadLock autoLock(syncObj);
 
             return __super::TryGetReference(key, value, index);
         }
 
         const TValue& GetValueAt(const int& index) const
         {
-            LockPolicy::ReadLock autoLock(syncObj);
+            typename LockPolicy::ReadLock autoLock(syncObj);
 
             return __super::GetValueAt(index);
         }
 
         TValue* GetReferenceAt(const int& index)
         {
-            LockPolicy::ReadLock autoLock(syncObj);
+            typename LockPolicy::ReadLock autoLock(syncObj);
 
             return __super::GetReferenceAt(index);
         }
 
         TKey const& GetKeyAt(const int& index)
         {
-            LockPolicy::ReadLock autoLock(syncObj);
+            typename LockPolicy::ReadLock autoLock(syncObj);
 
             return __super::GetKeyAt(index);
         }
 
         bool Remove(const TKey& key)
         {
-            LockPolicy::ReadLock autoLock(syncObj);
+            typename LockPolicy::ReadLock autoLock(syncObj);
 
             return __super::Remove(key);
         }
@@ -1756,7 +1756,7 @@ namespace JsUtil
         void MapReference(Fn fn)
         {
             // TODO: Verify that Map doesn't actually modify the list
-            LockPolicy::ReadLock autoLock(syncObj);
+            typename LockPolicy::ReadLock autoLock(syncObj);
 
             return __super::MapReference(fn);
         }
@@ -1764,7 +1764,7 @@ namespace JsUtil
         template<class Fn>
         bool MapUntilReference(Fn fn) const
         {
-            LockPolicy::ReadLock autoLock(syncObj);
+            typename LockPolicy::ReadLock autoLock(syncObj);
 
             return __super::MapUntilReference(fn);
         }
@@ -1772,7 +1772,7 @@ namespace JsUtil
         template<class Fn>
         void MapAddress(Fn fn) const
         {
-            LockPolicy::ReadLock autoLock(syncObj);
+            typename LockPolicy::ReadLock autoLock(syncObj);
 
             return __super::MapAddress(fn);
         }
@@ -1780,7 +1780,7 @@ namespace JsUtil
         template<class Fn>
         bool MapUntilAddress(Fn fn) const
         {
-            LockPolicy::ReadLock autoLock(syncObj);
+            typename LockPolicy::ReadLock autoLock(syncObj);
 
             return __super::MapUntilAddress(fn);
         }
@@ -1788,7 +1788,7 @@ namespace JsUtil
         template<class Fn>
         void Map(Fn fn) const
         {
-            LockPolicy::ReadLock autoLock(syncObj);
+            typename LockPolicy::ReadLock autoLock(syncObj);
 
             return __super::Map(fn);
         }
@@ -1796,7 +1796,7 @@ namespace JsUtil
         template<class Fn>
         bool MapUntil(Fn fn) const
         {
-            LockPolicy::ReadLock autoLock(syncObj);
+            typename LockPolicy::ReadLock autoLock(syncObj);
 
             return __super::MapUntil(fn);
         }
@@ -1804,7 +1804,7 @@ namespace JsUtil
         template<class Fn>
         void MapAndRemoveIf(Fn fn)
         {
-            LockPolicy::AddRemoveLock autoLock(syncObj);
+            typename LockPolicy::AddRemoveLock autoLock(syncObj);
 
             return __super::MapAndRemoveIf(fn);
         }

--- a/lib/Common/Memory/HeapAllocatorOperators.cpp
+++ b/lib/Common/Memory/HeapAllocatorOperators.cpp
@@ -21,13 +21,13 @@ operator new[](size_t byteSize)
 }
 
 void __cdecl
-operator delete(void * obj) _NOEXCEPT
+operator delete(void * obj) _NOEXCEPT_
 {
     HeapAllocator::Instance.Free(obj, (size_t)-1);
 }
 
 void __cdecl
-operator delete[](void * obj) _NOEXCEPT
+operator delete[](void * obj) _NOEXCEPT_
 {
     HeapAllocator::Instance.Free(obj, (size_t)-1);
 }

--- a/lib/Common/Memory/HeapBlock.h
+++ b/lib/Common/Memory/HeapBlock.h
@@ -290,7 +290,7 @@ protected:
     StackBackTrace* pageHeapAllocStack;
     StackBackTrace* pageHeapFreeStack;
 #endif
-    
+
 public:
     __inline bool InPageHeapMode() const { return pageHeapMode != PageHeapMode::PageHeapModeOff; }
 #ifdef STACK_BACK_TRACE
@@ -398,7 +398,7 @@ template <class TBlockAttributes>
 class SmallHeapBlockT : public HeapBlock
 {
 #ifdef ENABLE_DEBUG_CONFIG_OPTIONS
-    friend class ScriptMemoryDumper;
+    friend class ::ScriptMemoryDumper;
 #endif
 
     template <typename TBlockType>
@@ -626,7 +626,7 @@ public:
     template<bool pageheap>
     void BackgroundReleasePagesSweep(Recycler* recycler);
 #endif
-    
+
     void Reset();
 
     void EnumerateObjects(ObjectInfoBits infoBits, void (*CallBackFunction)(void * address, size_t size));

--- a/lib/Common/Memory/HeapBucket.cpp
+++ b/lib/Common/Memory/HeapBucket.cpp
@@ -506,6 +506,7 @@ HeapBucketT<TBlockType>::SnailAlloc(Recycler * recycler, TBlockAllocatorType * a
     AllocationVerboseTrace(recycler->GetRecyclerFlagsTable(), _u("TryAlloc failed, forced collection on allocation [Collected: %d]\n"), collected);
     if (!collected)
     {
+#if ENABLE_CONCURRENT_GC
         // wait for background sweeping finish if there are too many pages allocated during background sweeping
         if (recycler->IsConcurrentSweepExecutingState() && this->heapInfo->uncollectedNewPageCount > (uint)CONFIG_FLAG(NewPagesCapDuringBGSweeping))
         {
@@ -516,7 +517,7 @@ HeapBucketT<TBlockType>::SnailAlloc(Recycler * recycler, TBlockAllocatorType * a
                 return memBlock;
             }
         }
-
+#endif
         // We didn't collect, try to add a new heap block
         memBlock = TryAllocFromNewHeapBlock(recycler, allocator, sizeCat, attributes);
         if (memBlock != nullptr)

--- a/lib/Common/Memory/HeapBucket.h
+++ b/lib/Common/Memory/HeapBucket.h
@@ -143,7 +143,7 @@ public:
     void SetupBackgroundSweep(RecyclerSweep& recyclerSweep);
 #endif
 #ifdef ENABLE_DEBUG_CONFIG_OPTIONS
-    friend class ScriptMemoryDumper;
+    friend class ::ScriptMemoryDumper;
 #endif
 
     TBlockAllocatorType * GetAllocator() { return &allocatorHead;}

--- a/lib/Common/Memory/HeapInfo.h
+++ b/lib/Common/Memory/HeapInfo.h
@@ -7,7 +7,7 @@ namespace Memory
 class HeapInfo
 {
 #ifdef ENABLE_DEBUG_CONFIG_OPTIONS
-    friend class ScriptMemoryDumper;
+    friend class ::ScriptMemoryDumper;
 #endif
 public:
     HeapInfo();
@@ -260,7 +260,7 @@ private:
         return heapBucket->heapBlockList;
     }
 #endif
- 
+
     template<bool pageheap>
     void SweepSmallNonFinalizable(RecyclerSweep& recyclerSweep);
     void SweepLargeNonFinalizable(RecyclerSweep& recyclerSweep);
@@ -277,14 +277,14 @@ private:
     template <typename TBlockAttributes>
     class ValidPointersMap
     {
-        // xplat-todo: fix up vpm.64b.h generation to generate correctly 
+        // xplat-todo: fix up vpm.64b.h generation to generate correctly
         // templatized code
 #ifdef _WIN32
 #define USE_STATIC_VPM 1 // Disable to force generation at runtime
 #else
 #define USE_STATIC_VPM 0
 #endif
-        
+
     private:
         static const uint rowSize = TBlockAttributes::MaxSmallObjectCount * 2;
         typedef ushort ValidPointersMapRow[rowSize];

--- a/lib/Common/Memory/LargeHeapBlock.h
+++ b/lib/Common/Memory/LargeHeapBlock.h
@@ -269,7 +269,7 @@ private:
     bool hadTrimmed;
 #endif
 #ifdef ENABLE_DEBUG_CONFIG_OPTIONS
-    friend class ScriptMemoryDumper;
+    friend class ::ScriptMemoryDumper;
 #endif
     friend class HeapInfo;
     HeapInfo * heapInfo;

--- a/lib/Common/Memory/LargeHeapBucket.h
+++ b/lib/Common/Memory/LargeHeapBucket.h
@@ -130,7 +130,7 @@ private:
 
     friend class HeapInfo;
     friend class Recycler;
-    friend class ScriptMemoryDumper;
+    friend class ::ScriptMemoryDumper;
 };
 }
 

--- a/lib/Common/Memory/SmallFinalizableHeapBlock.h
+++ b/lib/Common/Memory/SmallFinalizableHeapBlock.h
@@ -120,7 +120,7 @@ protected:
     FreeObject* disposedObjectList;
     FreeObject* disposedObjectListTail;
 
-    friend class ScriptMemoryDumper;
+    friend class ::ScriptMemoryDumper;
 #ifdef RECYCLER_MEMORY_VERIFY
     friend void SmallHeapBlockT<TBlockAttributes>::Verify(bool pendingDispose);
 #endif

--- a/lib/Common/Memory/SmallFinalizableHeapBucket.h
+++ b/lib/Common/Memory/SmallFinalizableHeapBucket.h
@@ -45,7 +45,7 @@ protected:
     void VerifyMark();
 #endif
 #ifdef ENABLE_DEBUG_CONFIG_OPTIONS
-    friend class ScriptMemoryDumper;
+    friend class ::ScriptMemoryDumper;
 #endif
     template <typename TBlockType>
     friend class HeapBucketT;

--- a/lib/Common/Memory/SmallLeafHeapBucket.h
+++ b/lib/Common/Memory/SmallLeafHeapBucket.h
@@ -30,7 +30,7 @@ protected:
     void VerifyMark();
 #endif
 #ifdef ENABLE_DEBUG_CONFIG_OPTIONS
-    friend class ScriptMemoryDumper;
+    friend class ::ScriptMemoryDumper;
 #endif
 };
 

--- a/lib/Common/Memory/SmallNormalHeapBucket.h
+++ b/lib/Common/Memory/SmallNormalHeapBucket.h
@@ -17,7 +17,7 @@ public:
 
     CompileAssert(!BaseT::IsLeafBucket);
 #ifdef ENABLE_DEBUG_CONFIG_OPTIONS
-    friend class ScriptMemoryDumper;
+    friend class ::ScriptMemoryDumper;
 #endif
 
 #ifdef DUMP_FRAGMENTATION_STATS

--- a/lib/Runtime/Base/AuxPtrs.h
+++ b/lib/Runtime/Base/AuxPtrs.h
@@ -7,7 +7,7 @@
 
 namespace Js
 {
-    // Use fixed size structure to save pointers 
+    // Use fixed size structure to save pointers
     // AuxPtrsFix(16 bytes or 32 bytes) layout:
     //                        max count  metadata(init'd type)        pointers array
     //     --------------------------------------------------------------------------------------------------
@@ -28,7 +28,7 @@ namespace Js
         bool Set(FieldsEnum e, void* p);
     };
 
-    // Use flexible size structure to save pointers. when pointer count exceeds AuxPtrsFix<FieldsEnum, 32>::MaxCount, 
+    // Use flexible size structure to save pointers. when pointer count exceeds AuxPtrsFix<FieldsEnum, 32>::MaxCount,
     // it will promote to this structure to save the pointers
     // Layout:
     //     count      array of positions       array of instantiated pointers
@@ -42,7 +42,7 @@ namespace Js
         typedef AuxPtrs<T, FieldsEnum> AuxPtrsT;
         uint8 count;                            // save instantiated pointers count
         uint8 capacity;                         // save number of pointers can be hold in current instance of AuxPtrs
-        uint8 offsets[FieldsEnum::Max];       // save position of each instantiated pointers, if not instantiate, it's invalid
+        uint8 offsets[static_cast<int>(FieldsEnum::Max)];       // save position of each instantiated pointers, if not instantiate, it's invalid
         WriteBarrierPtr<void> ptrs[1];          // instantiated pointer addresses
         AuxPtrs(uint8 capacity, AuxPtrs32* ptr32);  // called when promoting from AuxPtrs32 to AuxPtrs
         AuxPtrs(uint8 capacity, AuxPtrs* ptr);      // called when expanding (i.e. promoting from AuxPtrs to bigger AuxPtrs)

--- a/lib/Runtime/Base/CMakeLists.txt
+++ b/lib/Runtime/Base/CMakeLists.txt
@@ -6,34 +6,34 @@ add_library (Chakra.Runtime.Base
     CharStringCache.cpp
     Constants.cpp
     CrossSite.cpp
-    Debug.cpp
-    DelayLoadLibrary.cpp
-    Entropy.cpp
+    # Debug.cpp
+    # DelayLoadLibrary.cpp
+    # Entropy.cpp
     EtwTrace.cpp
     Exception.cpp
     ExpirableObject.cpp
     FunctionBody.cpp
     FunctionInfo.cpp
-    HiResTimer.cpp
+    # HiResTimer.cpp
     LeaveScriptObject.cpp
     PerfHint.cpp
     PropertyRecord.cpp
     RuntimeBasePch.cpp
-    ScriptContext.cpp
+    # ScriptContext.cpp
     ScriptContextOptimizationOverrideInfo.cpp
     ScriptContextProfiler.cpp
     ScriptMemoryDumper.cpp
     SourceHolder.cpp
-    StackProber.cpp
+    # StackProber.cpp
     TempArenaAllocatorObject.cpp
     TestEtwEventSink.cpp
     ThreadBoundThreadContextManager.cpp
-    ThreadContext.cpp
+    # ThreadContext.cpp
     ThreadContextTlsEntry.cpp
     ThreadServiceWrapperBase.cpp
-    Utf8SourceInfo.cpp
-    WindowsFoundationAdapter.cpp
-    WindowsGlobalizationAdapter.cpp
+    # Utf8SourceInfo.cpp
+    # WindowsFoundationAdapter.cpp
+    # WindowsGlobalizationAdapter.cpp
     )
 
 target_include_directories (

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -73,7 +73,7 @@ namespace Js
 
     inline Recycler* FunctionProxy::GetRecycler() const
     {
-        return m_scriptContext->GetRecycler(); 
+        return m_scriptContext->GetRecycler();
     }
 
     inline void* FunctionProxy::GetAuxPtr(AuxPointerType e) const
@@ -101,7 +101,7 @@ namespace Js
     {
         // On process detach this can be called from another thread but the ThreadContext should be locked
         Assert(ThreadContext::GetContextForCurrentThread() || ThreadContext::GetCriticalSection()->IsLocked());
-        
+
         if (ptr == nullptr && GetAuxPtr(e) == nullptr)
         {
             return;
@@ -587,7 +587,7 @@ namespace Js
     {
         return GetCountFieldSigned(CounterFields::SerializationIndex);
     }
-    void FunctionBody::SetSerializationIndex(int index) 
+    void FunctionBody::SetSerializationIndex(int index)
     {
         SetCountFieldSigned(CounterFields::SerializationIndex, index);
     }
@@ -1043,8 +1043,8 @@ namespace Js
 
     void FunctionProxy::SetReferenceInParentFunction(FunctionProxyPtrPtr reference)
     {
-        // No need to tag the reference because the first field of the nested array 
-        // is count, so the reference here won't be same as address of the parent nested 
+        // No need to tag the reference because the first field of the nested array
+        // is count, so the reference here won't be same as address of the parent nested
         // array (even for index 0)
         this->m_referenceInParentFunction = reference;
     }
@@ -1159,7 +1159,7 @@ namespace Js
 #if ENABLE_NATIVE_CODEGEN
             validationCookie = (void*)scriptContext->GetNativeCodeGenerator();
 #endif
-             
+
             this->m_defaultEntryPointInfo = RecyclerNewFinalized(scriptContext->GetRecycler(),
                 FunctionEntryPointInfo, this, entryPoint, scriptContext->GetThreadContext(), validationCookie);
         }
@@ -1439,7 +1439,7 @@ namespace Js
 
     void ParseableFunctionInfo::ClearNestedFunctionParentFunctionReference()
     {
-        this->ForEachNestedFunc([](FunctionProxy* proxy, uint32 index) 
+        this->ForEachNestedFunc([](FunctionProxy* proxy, uint32 index)
         {
             if (proxy)
             {
@@ -1482,7 +1482,8 @@ namespace Js
     ScriptFunctionType * FunctionProxy::EnsureDeferredPrototypeType()
     {
         Assert(this->GetFunctionProxy() == this);
-        return (deferredPrototypeType != nullptr)? deferredPrototypeType : AllocDeferredPrototypeType();
+        return deferredPrototypeType != nullptr ?
+            static_cast<ScriptFunctionType*>(deferredPrototypeType) : AllocDeferredPrototypeType();
     }
 
     ScriptFunctionType * FunctionProxy::AllocDeferredPrototypeType()
@@ -3430,7 +3431,7 @@ namespace Js
         newFunctionBody->SetReferencedPropertyIdMap(this->GetReferencedPropertyIdMap());
         newFunctionBody->SetPropertyIdsForScopeSlotArray(this->GetPropertyIdsForScopeSlotArray(), this->scopeSlotArraySize);
         newFunctionBody->SetPropertyIdOnRegSlotsContainer(this->GetPropertyIdOnRegSlotsContainer());
-        
+
 
         if (this->byteCodeBlock == nullptr)
         {
@@ -3639,7 +3640,7 @@ namespace Js
         this->SetAuxPtr(AuxPointerType::StackNestedFuncParent, this->GetScriptContext()->GetRecycler()->CreateWeakReferenceHandle(parentFunctionBody));
     }
 
-    FunctionBody * FunctionBody::GetStackNestedFuncParentStrongRef() 
+    FunctionBody * FunctionBody::GetStackNestedFuncParentStrongRef()
     {
         Assert(this->GetStackNestedFuncParent() != nullptr);
         return this->GetStackNestedFuncParent()->Get();
@@ -3734,11 +3735,11 @@ namespace Js
 
         ParseableFunctionInfo* newFunctionInfo = ParseableFunctionInfo::New(scriptContext,
             this->GetNestedCount(),
-            this->GetLocalFunctionId(), 
-            sourceInfo, this->GetDisplayName(), 
+            this->GetLocalFunctionId(),
+            sourceInfo, this->GetDisplayName(),
             this->GetDisplayNameLength(),
-            this->GetShortDisplayNameOffset(), 
-            this->GetBoundPropertyRecords(), 
+            this->GetShortDisplayNameOffset(),
+            this->GetBoundPropertyRecords(),
             this->GetAttributes());
 
         if (this->GetScopeInfo() != nullptr)
@@ -4125,7 +4126,7 @@ namespace Js
         }
     }
 #endif
-    
+
     void FunctionBody::DumpStatementMaps()
     {
         // Source Map to ByteCode
@@ -4525,6 +4526,7 @@ namespace Js
         this->GetPropertyIdOnRegSlotsContainer()->SetFormalArgs(formalArgs);
     }
 
+#ifdef ENABLE_SCRIPT_PROFILING
     HRESULT FunctionBody::RegisterFunction(BOOL fChangeMode, BOOL fOnlyCurrent)
     {
         if (!this->IsFunctionParsed())
@@ -4657,6 +4659,7 @@ namespace Js
 
 #endif //ENABLE_NATIVE_CODEGEN
     }
+#endif // ENABLE_SCRIPT_PROFILING
 
 #if DBG
     void FunctionBody::MustBeInDebugMode()
@@ -6800,7 +6803,7 @@ namespace Js
         const bool doSimpleJit = DoSimpleJit();
         const bool doInterpreterProfile = DoInterpreterProfile();
         const bool fullyScaled =
-            IsNewSimpleJit() && doSimpleJit && ScaleLimit(simpleJitLimit) ||
+            (IsNewSimpleJit() && doSimpleJit && ScaleLimit(simpleJitLimit)) ||
             (
                 doInterpreterProfile
                     ?   DoInterpreterAutoProfile() &&
@@ -6811,9 +6814,9 @@ namespace Js
                 IsNewSimpleJit()
                     ?   doInterpreterProfile &&
                         (ScaleLimit(profilingInterpreter1Limit) || ScaleLimit(profilingInterpreter0Limit))
-                    :   doInterpreterProfile && ScaleLimit(profilingInterpreter0Limit) ||
-                        doSimpleJit && ScaleLimit(simpleJitLimit) ||
-                        doInterpreterProfile && ScaleLimit(profilingInterpreter1Limit)
+                    :   (doInterpreterProfile && ScaleLimit(profilingInterpreter0Limit)) ||
+                        (doSimpleJit && ScaleLimit(simpleJitLimit)) ||
+                        (doInterpreterProfile && ScaleLimit(profilingInterpreter1Limit))
             );
         Assert(fullyScaled);
         Assert(scale == 0);
@@ -6894,12 +6897,12 @@ namespace Js
         VerifyExecutionModeLimits();
 
         if(&limit == profilingInterpreter0Limit.AddressOf() ||
-            !IsNewSimpleJit() && &limit == simpleJitLimit.AddressOf() ||
+            (!IsNewSimpleJit() && &limit == simpleJitLimit.AddressOf()) ||
             &limit == profilingInterpreter1Limit.AddressOf())
         {
             const uint16 newCommittedProfiledIterations = committedProfiledIterations + clampedExecutedIterations;
             committedProfiledIterations =
-                newCommittedProfiledIterations >= committedProfiledIterations ? newCommittedProfiledIterations : MAXUINT16;
+                newCommittedProfiledIterations >= committedProfiledIterations ? newCommittedProfiledIterations : UINT16_MAX;
         }
     }
 
@@ -6917,7 +6920,9 @@ namespace Js
         // Simple JIT counts down and transitions on overflow
         const uint8 callCount = simpleJitEntryPointInfo->callsCount;
         Assert(simpleJitLimit == 0 ? callCount == 0 : simpleJitLimit > callCount);
-        return callCount == 0 ? simpleJitLimit : simpleJitLimit - callCount - 1;
+        return callCount == 0 ?
+            static_cast<uint16>(simpleJitLimit) :
+            static_cast<uint16>(simpleJitLimit) - callCount - 1;
     }
 
     void FunctionBody::ResetSimpleJitLimitAndCallCount()
@@ -6968,11 +6973,11 @@ namespace Js
             {
                 uint32 interpretedCount = GetInterpretedCount();
                 const uint16 clampedInterpretedCount =
-                    interpretedCount <= MAXUINT16
+                    interpretedCount <= UINT16_MAX
                         ? static_cast<uint16>(interpretedCount)
-                        : MAXUINT16;
+                        : UINT16_MAX;
                 const uint16 newProfiledIterations = profiledIterations + clampedInterpretedCount;
-                profiledIterations = newProfiledIterations >= profiledIterations ? newProfiledIterations : MAXUINT16;
+                profiledIterations = newProfiledIterations >= profiledIterations ? newProfiledIterations : UINT16_MAX;
                 break;
             }
 
@@ -6980,7 +6985,7 @@ namespace Js
                 if(!IsNewSimpleJit())
                 {
                     const uint16 newProfiledIterations = profiledIterations + GetSimpleJitExecutedIterations();
-                    profiledIterations = newProfiledIterations >= profiledIterations ? newProfiledIterations : MAXUINT16;
+                    profiledIterations = newProfiledIterations >= profiledIterations ? newProfiledIterations : UINT16_MAX;
                 }
                 break;
         }
@@ -7555,7 +7560,7 @@ namespace Js
                     // isShutdown is false because cleanup is called only in the !isShutdown case
                     entryPoint->Finalize(isShutdown);
 
-#ifdef ENABLE_DEBUG_CONFIG_OPTIONS
+#if ENABLE_DEBUG_STACK_BACK_TRACE
                     // Do this separately since calling EntryPoint::Finalize doesn't capture the stack trace
                     // and in some calls to CleanupRecyclerData, we do want the stack trace captured.
 
@@ -7726,7 +7731,9 @@ namespace Js
 
     void FunctionBody::InitDisableInlineApply()
     {
-        SetDisableInlineApply(this->functionId != Js::Constants::NoFunctionId && PHASE_OFF(Js::InlinePhase, this) || PHASE_OFF(Js::InlineApplyPhase, this));
+        SetDisableInlineApply(
+            (this->functionId != Js::Constants::NoFunctionId && PHASE_OFF(Js::InlinePhase, this)) ||
+            PHASE_OFF(Js::InlineApplyPhase, this));
     }
 
     bool FunctionBody::CheckCalleeContextForInlining(FunctionProxy* calleeFunctionProxy)
@@ -8712,7 +8719,7 @@ namespace Js
     }
 #endif
 
-#ifdef ENABLE_DEBUG_CONFIG_OPTIONS
+#if ENABLE_DEBUG_STACK_BACK_TRACE
     void EntryPointInfo::CaptureCleanupStackTrace()
     {
         if (this->cleanupStack != nullptr)
@@ -8740,7 +8747,7 @@ namespace Js
 
         this->Cleanup(isShutdown, false);
 
-#if DBG
+#if ENABLE_DEBUG_STACK_BACK_TRACE
         if (this->cleanupStack != nullptr)
         {
             this->cleanupStack->Delete(&NoCheckHeapAllocator::Instance);
@@ -8819,11 +8826,12 @@ namespace Js
 #if !DBG
             captureCleanupStack = captureCleanupStack && Js::Configuration::Global.flags.FreTestDiagMode;
 #endif
-
+#if ENABLE_DEBUG_STACK_BACK_TRACE
             if (captureCleanupStack)
             {
                 this->CaptureCleanupStackTrace();
             }
+#endif
 #endif
 
 #if ENABLE_NATIVE_CODEGEN
@@ -9611,7 +9619,7 @@ namespace Js
         return m_hasFuncExprScopeRegister ? GetCountField(CounterFields::FuncExprScopeRegister) : Constants::NoRegister;
     }
 
-    void FunctionBody::SetFirstTmpRegister(RegSlot reg) 
+    void FunctionBody::SetFirstTmpRegister(RegSlot reg)
     {
         if (reg == Constants::NoRegister)
         {

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -463,7 +463,7 @@ namespace Js
         typedef JsUtil::List<NativeOffsetInlineeFramePair, HeapAllocator> InlineeFrameMap;
         InlineeFrameMap*  inlineeFrameMap;
 #endif
-#ifdef STACK_BACK_TRACE
+#if ENABLE_DEBUG_STACK_BACK_TRACE
         StackBackTrace*    cleanupStack;
 #endif
 
@@ -499,7 +499,7 @@ namespace Js
         uint32 pendingPolymorphicCacheState;
 #endif
         State state; // Single state member so users can query state w/o a lock
-#ifdef STACK_BACK_TRACE
+#if ENABLE_DEBUG_CONFIG_OPTIONS
         CleanupReason cleanupReason;
 #endif
         BYTE   pendingInlinerVersion;
@@ -525,8 +525,10 @@ namespace Js
             isLoopBody(isLoopBody), hasJittedStackClosure(false), registeredEquivalentTypeCacheRef(nullptr), bailoutRecordMap(nullptr),
 #endif
             library(library), codeSize(0), nativeAddress(nullptr), isAsmJsFunction(false), validationCookie(validationCookie)
-#ifdef STACK_BACK_TRACE
+#if ENABLE_DEBUG_STACK_BACK_TRACE
             , cleanupStack(nullptr)
+#endif
+#if ENABLE_DEBUG_CONFIG_OPTIONS
             , cleanupReason(NotCleanedUp)
 #endif
 #if DBG_DUMP | defined(VTUNE_PROFILING)
@@ -573,7 +575,7 @@ namespace Js
 
         void Cleanup(bool isShutdown, bool captureCleanupStack);
 
-#ifdef ENABLE_DEBUG_CONFIG_OPTIONS
+#if ENABLE_DEBUG_STACK_BACK_TRACE
         void CaptureCleanupStackTrace();
 #endif
 
@@ -639,7 +641,7 @@ namespace Js
             this->state = PendingCleanup;
         }
 
-#ifdef STACK_BACK_TRACE
+#if ENABLE_DEBUG_CONFIG_OPTIONS
         void SetCleanupReason(CleanupReason reason)
         {
             this->cleanupReason = reason;

--- a/lib/Runtime/Base/LeaveScriptObject.cpp
+++ b/lib/Runtime/Base/LeaveScriptObject.cpp
@@ -27,7 +27,12 @@ namespace Js
         this->doCleanup = doCleanup;
         this->isCallRoot = isCallRoot;
         this->hr = NOERROR;
-        this->hasForcedEnter = scriptContext->GetDebugContext() != nullptr ? scriptContext->GetDebugContext()->GetProbeContainer()->isForcedToEnterScriptStart : false;
+        this->hasForcedEnter =
+#ifdef ENABLE_SCRIPT_DEBUGGING
+         scriptContext->GetDebugContext() != nullptr ?
+            scriptContext->GetDebugContext()->GetProbeContainer()->isForcedToEnterScriptStart :
+#endif
+            false;
 
         // Initialize the entry exit record
         entryExitRecord->returnAddrOfScriptEntryFunction = returnAddress;

--- a/lib/Runtime/Base/RuntimeBasePch.h
+++ b/lib/Runtime/Base/RuntimeBasePch.h
@@ -8,9 +8,11 @@
 
 #include "Runtime.h"
 
+#ifdef ENABLE_SCRIPT_DEBUGGING
 #include "Debug/DebuggingFlags.h"
 #include "Debug/DiagProbe.h"
 #include "Debug/DebugManager.h"
 #include "Debug/ProbeContainer.h"
 #include "Debug/DebugContext.h"
+#endif
 

--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -453,11 +453,9 @@ namespace Js
         AsmJsCodeGenerator* InitAsmJsCodeGenerator();
 #endif
 
-#ifdef ENABLE_SCRIPT_DEBUGGING
         bool IsExceptionWrapperForBuiltInsEnabled();
         static bool IsExceptionWrapperForBuiltInsEnabled(ScriptContext* scriptContext);
         static bool IsExceptionWrapperForHelpersEnabled(ScriptContext* scriptContext);
-#endif
 #ifdef ENABLE_SCRIPT_PROFILING
         bool IsEnumerateNonUserFunctionsOnly() const { return m_enumerateNonUserFunctionsOnly; }
         bool IsTraceDomCall() const { return !!m_fTraceDomCall; }
@@ -1338,17 +1336,23 @@ private:
             return sourceContextInfo == cache->noContextSourceContextInfo;
         }
 
-#ifdef ENABLE_SCRIPT_PROFILING
         BOOL IsProfiling()
         {
+#ifdef ENABLE_SCRIPT_PROFILING
             return (m_pProfileCallback != nullptr);
+#else
+            return FALSE;
+#endif
         }
 
         BOOL IsInProfileCallback()
         {
+#ifdef ENABLE_SCRIPT_PROFILING
             return m_inProfileCallback;
+#else
+            return FALSE;
+#endif
         }
-#endif // ENABLE_SCRIPT_PROFILING
 
 #if DBG
         SourceContextInfo const * GetNoContextSourceContextInfo() const { return cache->noContextSourceContextInfo; }
@@ -1489,6 +1493,14 @@ private:
         void ReleaseDynamicAsmJsInterpreterThunk(BYTE* address, bool addtoFreeList);
 #endif
 
+        static Var DebugProfileProbeThunk(RecyclableObject* function, CallInfo callInfo, ...);
+        static JavascriptMethod ProfileModeDeferredParse(ScriptFunction **function);
+        static Var ProfileModeDeferredParsingThunk(RecyclableObject* function, CallInfo callInfo, ...);
+
+        // Thunks for deferred deserialization of function bodies from the byte code cache
+        static JavascriptMethod ProfileModeDeferredDeserialize(ScriptFunction* function);
+        static Var ProfileModeDeferredDeserializeThunk(RecyclableObject* function, CallInfo callInfo, ...);
+
 #ifdef ENABLE_SCRIPT_PROFILING
         void SetProfileMode(BOOL fSet);
         static JavascriptMethod GetProfileModeThunk(JavascriptMethod entryPoint);
@@ -1497,13 +1509,6 @@ private:
             JavascriptFunction* function,
             PROFILER_TOKEN &scriptId,
             PROFILER_TOKEN &functionId);
-        static Var DebugProfileProbeThunk(RecyclableObject* function, CallInfo callInfo, ...);
-        static JavascriptMethod ProfileModeDeferredParse(ScriptFunction **function);
-        static Var ProfileModeDeferredParsingThunk(RecyclableObject* function, CallInfo callInfo, ...);
-
-        // Thunks for deferred deserialization of function bodies from the byte code cache
-        static JavascriptMethod ProfileModeDeferredDeserialize(ScriptFunction* function);
-        static Var ProfileModeDeferredDeserializeThunk(RecyclableObject* function, CallInfo callInfo, ...);
 
         HRESULT OnScriptCompiled(PROFILER_TOKEN scriptId, PROFILER_SCRIPT_TYPE type, IUnknown *pIDebugDocumentContext);
         HRESULT OnFunctionCompiled(

--- a/lib/Runtime/Base/ScriptMemoryDumper.cpp
+++ b/lib/Runtime/Base/ScriptMemoryDumper.cpp
@@ -127,7 +127,7 @@ void ScriptMemoryDumper::DumpSmallHeapBlock(SmallHeapBlockT<TBlockAttributes>* h
     current.activeObjectCount += heapBlock->objectCount - heapBlock->freeCount;
     if (heapBlock->IsAnyFinalizableBlock())
     {
-        current.finalizeCount += heapBlock->AsFinalizableBlock<TBlockAttributes>()->finalizeCount;
+        current.finalizeCount += heapBlock->template AsFinalizableBlock<TBlockAttributes>()->finalizeCount;
     }
     current.pageCount += heapBlock->GetPageCount();
     current.totalByteCount += heapBlock->GetPageCount() * AutoSystemInfo::PageSize;
@@ -152,7 +152,7 @@ void ScriptMemoryDumper::DumpLargeBucket(LargeHeapBucket* heapBucket)
     DumpLargeHeapBlockList(heapBucket->pendingDisposeLargeBlockList);
 #if ENABLE_CONCURRENT_GC
     DumpLargeHeapBlockList(heapBucket->pendingSweepLargeBlockList);
-#if ENABLE_PARTIAL_GC 
+#if ENABLE_PARTIAL_GC
     DumpLargeHeapBlockList(heapBucket->partialSweptLargeBlockList);
 #endif
 #endif

--- a/lib/Runtime/Base/ScriptMemoryDumper.h
+++ b/lib/Runtime/Base/ScriptMemoryDumper.h
@@ -8,7 +8,7 @@
 class ScriptMemoryDumper
 {
 public:
-    typedef struct HeapStats
+    struct HeapStats
     {
         size_t pageCount;
         uint32 objectSize;

--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -3458,7 +3458,7 @@ BOOL ThreadContext::IsNativeAddress(void * pCodeAddr)
     {
         return TRUE;
     }
-    
+
     if (!this->IsAllJITCodeInPreReservedRegion())
     {
         CustomHeap::CodePageAllocators::AutoLock autoLock(&this->codePageAllocators);

--- a/lib/Runtime/Base/ThreadServiceWrapper.h
+++ b/lib/Runtime/Base/ThreadServiceWrapper.h
@@ -5,7 +5,7 @@
 #pragma once
 // This class is used to communicate between ThreadContext and JavascriptThreadService
 
-class ThreadServiceWrapper abstract
+class ThreadServiceWrapper _ABSTRACT
 {
 public:
     virtual bool ScheduleNextCollectOnExit() = 0;

--- a/lib/Runtime/Base/ThreadServiceWrapperBase.h
+++ b/lib/Runtime/Base/ThreadServiceWrapperBase.h
@@ -64,13 +64,13 @@ private:
 #define IDLE_COLLECT_VERBOSE_TRACE(msg, ...) \
     if (Js::Configuration::Global.flags.Verbose) \
             { \
-        IDLE_COLLECT_TRACE(msg, __VA_ARGS__); \
+        IDLE_COLLECT_TRACE(msg, ##__VA_ARGS__); \
             }
 
 #define IDLE_COLLECT_TRACE(msg, ...) \
     if (Js::Configuration::Global.flags.Trace.IsEnabled(Js::IdleCollectPhase)) \
             {\
-        Output::Print(_u("%04X> ") msg, ::GetCurrentThreadId(), __VA_ARGS__); \
+        Output::Print(_u("%04X> ") msg, ::GetCurrentThreadId(), ##__VA_ARGS__); \
         Output::Flush(); \
             }
 #else

--- a/lib/Runtime/CMakeLists.txt
+++ b/lib/Runtime/CMakeLists.txt
@@ -1,0 +1,11 @@
+project(CHAKRA_RUNTIME)
+
+include_directories(
+    $(CHAKRA_RUNTIME_SOURCE_DIR)
+    $(CHAKRA_RUNTIME_SOURCE_DIR)/../Common
+    $(CHAKRA_RUNTIME_SOURCE_DIR)/../Backend
+    $(CHAKRA_RUNTIME_SOURCE_DIR)/../Parser
+    $(CHAKRA_RUNTIME_SOURCE_DIR)/ByteCode
+    )
+
+add_subdirectory (Base)

--- a/lib/Runtime/Language/InterpreterStackFrame.h
+++ b/lib/Runtime/Language/InterpreterStackFrame.h
@@ -5,8 +5,13 @@
 
 #pragma once
 
+#ifdef _MSC_VER
 extern "C" PVOID _ReturnAddress(VOID);
 #pragma intrinsic(_ReturnAddress)
+#else
+#define _ReturnAddress() __builtin_return_address(0)
+#endif
+
 class BailOutRecord;
 
 extern "C" void __cdecl _alloca_probe_16();

--- a/lib/Runtime/Library/JavascriptProxy.h
+++ b/lib/Runtime/Library/JavascriptProxy.h
@@ -37,13 +37,13 @@ namespace Js
             SetPropertyWPCacheKind,
         } SetPropertyTrapKind;
 
-        typedef enum KeysTrapKind {
+        enum KeysTrapKind {
             GetOwnPropertyNamesKind,
             GetOwnPropertySymbolKind,
             KeysKind
         };
 
-        typedef enum IntegrityLevel {
+        enum IntegrityLevel {
             IntegrityLevel_sealed,
             IntegrityLevel_frozen
         };

--- a/lib/Runtime/Types/PathTypeHandler.h
+++ b/lib/Runtime/Types/PathTypeHandler.h
@@ -6,6 +6,8 @@
 
 namespace Js
 {
+    class SimplePathTypeHandler;
+
     class PathTypeHandlerBase : public DynamicTypeHandler
     {
         friend class DynamicObject;


### PR DESCRIPTION
Remaining files depend on debugging, stack walker, or other unavailable
Windows APIs. To be address later.

Changes are:
- Added templates for a few InterLocked??? functions.
- Changed ```_NOEXCEPT``` to ```_NOEXCEPT_``` (was conflicting on VS 2013).
- "friend class ::ScriptMemoryDumper" needs "::" as the container classes
  are in a different "Memory" namespace.
- AuxPtr.h: added cast to use FieldEnum::Max as array size.
- Changed a __try/__finally to call TryFinally template function
- Standard ```__VA_ARGS__``` requires at least 1 arg. Found a well-known hack to
  work around: ```##__VA_ARGS__```. Verified works on VS 2013/2015, g++, clang.
- Added ENABLE_DEBUG_STACK_BACK_TRACE for capturing stack back traces for
  debugging only. (STACK_BACK_TRACE is defined on release.) Changed
  FunctionBody::cleanupReason under ENABLE_DEBUG_CONFIG_OPTIONS and
  cleanupStack under ENABLE_DEBUG_STACK_BACK_TRACE.
