### PR TITLE
Fixes mismatched hashing of ints versus doubles

### DIFF
--- a/lib/Runtime/Library/SameValueComparer.h
+++ b/lib/Runtime/Library/SameValueComparer.h
@@ -31,39 +31,56 @@ namespace Js
             }
         }
 
+        static hash_t HashDouble(double d)
+        {
+            if (JavascriptNumber::IsNan(d))
+            {
+                return 0;
+            }
+
+            if (zero)
+            {
+                // SameValueZero treats -0 and +0 the same, so normalize to get same hash code
+                if (JavascriptNumber::IsNegZero(d))
+                {
+                    d = 0.0;
+                }
+            }
+
+            __int64 v = *(__int64*)&d;
+            return (uint)v ^ (uint)(v >> 32);
+        }
+
         static hash_t GetHashCode(Var i)
         {
             switch (JavascriptOperators::GetTypeId(i))
             {
             case TypeIds_Integer:
-                return TaggedInt::ToInt32(i);
+                // int32 can be fully represented in a double, so hash it as a double
+                // to ensure that tagged ints hash to the same value as JavascriptNumbers.
+                return HashDouble((double)TaggedInt::ToInt32(i));
 
             case TypeIds_Int64Number:
             case TypeIds_UInt64Number:
                 {
                     __int64 v = JavascriptInt64Number::FromVar(i)->GetValue();
-                    return (uint)v ^ (uint)(v >> 32);
+                    double d = (double) v;
+                    if (v != (__int64) d)
+                    {
+                        // this int64 is too large to represent in a double
+                        // and thus will never be equal to a double so hash it
+                        // as an int64
+                        return (uint)v ^ (uint)(v >> 32);
+                    }
+
+                    // otherwise hash it as a double
+                    return HashDouble(d);
                 }
 
             case TypeIds_Number:
                 {
                     double d = JavascriptNumber::GetValue(i);
-                    if (JavascriptNumber::IsNan(d))
-                    {
-                        return 0;
-                    }
-
-                    if (zero)
-                    {
-                        // SameValueZero treats -0 and +0 the same, so normalize to get same hash code
-                        if (JavascriptNumber::IsNegZero(d))
-                        {
-                            d = 0.0;
-                        }
-                    }
-
-                    __int64 v = *(__int64*)&d;
-                    return (uint)v ^ (uint)(v >> 32);
+                    return HashDouble(d);
                 }
 
             case TypeIds_String:

--- a/test/es6/map_functionality.js
+++ b/test/es6/map_functionality.js
@@ -804,6 +804,21 @@ var tests = [
             });
         }
     },
+
+    {
+        name: "Keys that are int versus double should compare and hash equal (github #390)",
+        body: function() {
+            var map = new Map();
+
+            map.set(1, "test");
+            assert.areEqual("test", map.get(1), "sanity check, map has key-value pair { 1, 'test' }");
+
+            var key = 1.1;
+            key -= 0.1; // key is now 1.0, a double, rather than an int
+
+            assert.areEqual("test", map.get(key), "1.0 should be equal to the key 1 and map to 'test'");
+        }
+    },
 ];
 
 testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/es6/set_functionality.js
+++ b/test/es6/set_functionality.js
@@ -727,6 +727,21 @@ var tests = [
             assert.throws(function () { Array()(func3(...new Set([func3, func3]))) }, TypeError, "Should throw TypeError");
         }
     },
+
+    {
+        name: "Values that are int versus double should compare and hash equal (github #390)",
+        body: function() {
+            var set = new Set();
+
+            set.add(1);
+            assert.isTrue(set.has(1), "sanity check, set has value 1");
+
+            var value = 1.1;
+            value -= 0.1; // value is now 1.0, a double, rather than an int
+
+            assert.isTrue(set.has(value), "1.0 should be equal to the value 1 and set has it");
+        }
+    },
 ];
 
 testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });


### PR DESCRIPTION
`SameValueComparerCommon::GetHashCode` was hashing tagged ints
differently from javascript numbers (doubles).  E.g. 1 would hash
differently from 1.0.  This made Map, Set, WeakMap, and WeakSet lookups
fail when the input key was double and the stored key was int, and vice
versa.

Fixed by hashing integers as doubles so long as those integers fit in a
double.  int64 values that do not fit in a double are hashed as int64
values.

Fixes gh-390