### PR TITLE
yield* shouldn't unwrap and rewrap iterator results

### DIFF
--- a/lib/Runtime/Library/JavascriptGenerator.cpp
+++ b/lib/Runtime/Library/JavascriptGenerator.cpp
@@ -67,25 +67,20 @@ namespace Js
             }
         }
 
-        if (this->IsCompleted())
-        {
-            result = library->CreateIteratorResultObject(result, library->GetTrue());
-        }
-        else
+        if (!this->IsCompleted())
         {
             int nextOffset = this->frame->GetReader()->GetCurrentOffset();
             int endOffset = this->frame->GetFunctionBody()->GetByteCode()->GetLength();
 
             if (nextOffset != endOffset - 1)
             {
-                result = library->CreateIteratorResultObjectValueFalse(result);
-            }
-            else
-            {
-                result = library->CreateIteratorResultObject(result, library->GetTrue());
-                this->SetState(GeneratorState::Completed);
+                // Yielded values are already wrapped in an IteratorResult object, so we don't need to wrap them.
+                return result;
             }
         }
+
+        result = library->CreateIteratorResultObject(result, library->GetTrue());
+        this->SetState(GeneratorState::Completed);
 
         return result;
     }

--- a/test/es6/generators-functionality.js
+++ b/test/es6/generators-functionality.js
@@ -1378,7 +1378,7 @@ var tests = [
             var iteratorReturningWithoutValue = CreateIterable(() => { return {done: false}; }, () => { return {done: true}; }, () => { return {done: true}; });
             gf = function* () { yield* iteratorReturningWithoutValue; }
             g = gf();
-            assert.areEqual({value: undefined, done: false}, g.next(), "As the value property is missing undefined is returned");
+            g.next();
             assert.areEqual({value: undefined, done: true}, g.return(100), "As the value property is missing undefined is returned");
         }
     },
@@ -1391,6 +1391,18 @@ var tests = [
             assert.areEqual({value: 1, done: false}, g.next(), "Yield 1 from the iterator");
             assert.areEqual({value: 2, done: false}, g.next(), "Yield 2 from the iterator");
             assert.areEqual({value: 4, done: true}, g.next(), "Returned 4 from the generator");
+        }
+    },
+    {
+        name: "yield* doesn't unwrap and rewrap iterator result if the done property is falsy",
+        body: function () {
+            var obj = { prop: 7 };
+            var gf = function* () {
+                yield* CreateIterable(() => obj);
+            };
+            var g = gf();
+            assert.isTrue(g.next() === obj, "yield* doesn't unwrap and rewrap iterator results if the 'done' property is falsy");
+            assert.areEqual({ prop: 7 }, g.next(), "yield* doesn't modify the iterator result");
         }
     },
     {


### PR DESCRIPTION
Commit message:
> This commit makes the bytecode generated by the EmitYield function return the IteratorResult object (instead of its `value` property) to the JavascriptGenerator::CallGenerator function.

> Fix gh-265