### PR TITLE
Rename JsParseScriptWithFlags to JsParseScriptWithAttributes

### DIFF
--- a/lib/Jsrt/ChakraCommon.h
+++ b/lib/Jsrt/ChakraCommon.h
@@ -379,7 +379,7 @@
     } JsMemoryEventType;
 
     /// <summary>
-    ///     Attribute mask for JsParseScriptWithFlags
+    ///     Attribute mask for JsParseScriptWithAttributes
     /// </summary>
     typedef enum _JsParseScriptAttributes {
         /// <summary>
@@ -843,7 +843,7 @@
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
     STDAPI_(JsErrorCode)
-        JsParseScriptWithFlags(
+        JsParseScriptWithAttributes(
             _In_z_ const wchar_t *script,
             _In_ JsSourceContext sourceContext,
             _In_z_ const wchar_t *sourceUrl,

--- a/lib/Jsrt/Jsrt.cpp
+++ b/lib/Jsrt/Jsrt.cpp
@@ -2456,7 +2456,7 @@ STDAPI_(JsErrorCode) JsParseScript(_In_z_ const wchar_t * script, _In_ JsSourceC
     return RunScriptCore(script, sourceContext, sourceUrl, true, JsParseScriptAttributeNone, false, result);
 }
 
-STDAPI_(JsErrorCode) JsParseScriptWithFlags(
+STDAPI_(JsErrorCode) JsParseScriptWithAttributes(
     _In_z_ const wchar_t *script,
     _In_ JsSourceContext sourceContext,
     _In_z_ const wchar_t *sourceUrl,

--- a/lib/Jsrt/JsrtCommonExports.inc
+++ b/lib/Jsrt/JsrtCommonExports.inc
@@ -91,7 +91,7 @@
     JsParseSerializedScriptWithCallback
     JsRunSerializedScriptWithCallback
     JsParseScript
-    JsParseScriptWithFlags
+    JsParseScriptWithAttributes
     JsConstructObject
     JsGetPropertyIdFromName
     JsGetPropertyNameFromId


### PR DESCRIPTION
The API name and the mask passed to API is inconsistent in naming
mask is called JsParseScriptAttributes and API have WithFlags.
Change it to match the mask name.
