### PR TITLE
Fix bug with recursive inlining

### DIFF
--- a/lib/Backend/NativeCodeGenerator.cpp
+++ b/lib/Backend/NativeCodeGenerator.cpp
@@ -2289,7 +2289,7 @@ NativeCodeGenerator::GatherCodeGenData(
                     // Share the jitTime data if i) it is a recursive call, ii) jitTimeData is not from a polymorphic chain, and iii) all the call sites are recursive
                     if (functionBody == inlineeFunctionBody   // recursive call
                         && jitTimeData->GetNext() == nullptr        // not from a polymorphic  call site
-                        && profiledCallSiteCount == functionBody->GetNumberOfRecursiveCallSites()) // all the callsites are recursive
+                        && profiledCallSiteCount == functionBody->GetNumberOfRecursiveCallSites() && !inlineGetterSetter) // all the callsites are recursive
                     {
                         jitTimeData->SetupRecursiveInlineeChain(recycler, profiledCallSiteId);
                         inlineeJitTimeData = jitTimeData;
@@ -2422,34 +2422,30 @@ NativeCodeGenerator::GatherCodeGenData(
                 Js::FunctionCodeGenRuntimeData *const inlineeRuntimeData = IsInlinee ? runtimeData->EnsureLdFldInlinee(recycler, inlineCacheIndex, inlineeFunctionBody) :
                     functionBody->EnsureLdFldInlineeCodeGenRuntimeData(recycler, inlineCacheIndex, inlineeFunctionBody);
 
-                    if (inlineeRuntimeData->GetFunctionBody() != inlineeFunctionBody)
-                    {
-                        //There are obscure cases where profileData has not yet seen the polymorphic LdFld but the inlineCache has the newer object from which getter is invoked.
-                        //In this case we don't want to inline that getter. Polymorphic bit will be set later correctly.
-                        //See WinBlue 54540
-                        continue;
-                    }
-
-
-                    if (!isJitTimeDataComputed)
-                    {
-                        Js::FunctionCodeGenJitTimeData *inlineeJitTimeData =  jitTimeData->AddLdFldInlinee(recycler, inlineCacheIndex, inlinee);
-                        GatherCodeGenData<true>(
-                            recycler,
-                            topFunctionBody,
-                            inlineeFunctionBody,
-                            entryPoint,
-                            inliningDecider,
-                            objTypeSpecFldInfoList,
-                            inlineeJitTimeData,
-                            inlineeRuntimeData,
-                            nullptr);
-
-                        AddInlineCacheStats(jitTimeData, inlineeJitTimeData);
-                    }
+                if (inlineeRuntimeData->GetFunctionBody() != inlineeFunctionBody)
+                {
+                    //There are obscure cases where profileData has not yet seen the polymorphic LdFld but the inlineCache has the newer object from which getter is invoked.
+                    //In this case we don't want to inline that getter. Polymorphic bit will be set later correctly.
+                    //See WinBlue 54540
+                    continue;
                 }
+
+                Js::FunctionCodeGenJitTimeData *inlineeJitTimeData =  jitTimeData->AddLdFldInlinee(recycler, inlineCacheIndex, inlinee);
+                GatherCodeGenData<true>(
+                    recycler,
+                    topFunctionBody,
+                    inlineeFunctionBody,
+                    entryPoint,
+                    inliningDecider,
+                    objTypeSpecFldInfoList,
+                    inlineeJitTimeData,
+                    inlineeRuntimeData,
+                    nullptr);
+
+                AddInlineCacheStats(jitTimeData, inlineeJitTimeData);
             }
         }
+    }
 
 #ifdef FIELD_ACCESS_STATS
     if (PHASE_VERBOSE_TRACE(Js::ObjTypeSpecPhase, topFunctionBody) || PHASE_VERBOSE_TRACE(Js::EquivObjTypeSpecPhase, topFunctionBody))


### PR DESCRIPTION
We do recursive inlining only when all the callsites in the function are recursive. But, the checks weren't taking into account the presence of getters and setters which are not exposed as "call" sites. This leads to data about a getter/setter present in the inliner but not in the inlinee version of the recursive function. This causes us to assert when we try to get data for the getter/setter when trying to inline it in the inlinee.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/620)
<!-- Reviewable:end -->
