### PR TITLE
[OS5427497] Parser mistakes 'new.target' as in global function under -forceundodefer

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -10473,7 +10473,13 @@ void Parser::FinishDeferredFunction(ParseNodePtr pnodeScopeList)
             pnodeFnc->sxFnc.pnodeVars = nullptr;
             m_ppnodeVar = &pnodeFnc->sxFnc.pnodeVars;
 
+            Assert(m_currentNodeNonLambdaFunc == nullptr);
+            m_currentNodeNonLambdaFunc = pnodeFnc;
+
             this->FinishFncNode(pnodeFnc);
+
+            Assert(pnodeFnc == m_currentNodeNonLambdaFunc);
+            m_currentNodeNonLambdaFunc = nullptr;
 
             m_ppnodeExprScope = ppnodeExprScopeSave;
 

--- a/test/es6/ES6NewTarget_bugfixes.js
+++ b/test/es6/ES6NewTarget_bugfixes.js
@@ -19,6 +19,12 @@ var tests = [
         // Failure: (i >= 0 && i < symbolCount)
     }
   },
+  {
+    name: "OS5427497: Parser mistakes 'new.target' as in global function under -forceundodefer",
+    body: function () {
+        new.target;  // bug repro: SyntaxError: Invalid use of the 'new.target' keyword
+    }
+  },
 ];
 
 testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -1059,6 +1059,13 @@
       <tags>BugFix</tags>
     </default>
 </test>
+<test>
+    <default>
+      <files>ES6NewTarget_bugfixes.js</files>
+      <compile-flags>-ES6Classes -forceundodefer -args summary -endargs</compile-flags>
+      <tags>BugFix</tags>
+    </default>
+</test>
 
 <test>
     <default>


### PR DESCRIPTION
Global function is not allowed to have 'new.target' expression. Detection of being in the global function
depends on m_currentNodeNonLamdaFunc being nullptr for the global function and pointing to an actual
function pnode otherwise. During undo of deferred parsing, however, m_currentNodeNonLambdaFunc is not
properly set to a function pnode, causing parser to mistake 'new.target' as if it is in the global function.
Fix by assigning m_currentNodeNonLambdaFunc to pnodeFnc.
