### PR TITLE
Fix for background call into AuxPtrs to get AsmJsModuleInfo

### DIFF
--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -2263,10 +2263,12 @@ namespace Js
     public:
         static bool IsNewSimpleJit();
         bool DoSimpleJit() const;
+        bool DoSimpleJitWithLock() const;
         bool DoSimpleJitDynamicProfile() const;
 
     private:
         bool DoInterpreterProfile() const;
+        bool DoInterpreterProfileWithLock() const;
         bool DoInterpreterAutoProfile() const;
 
     public:
@@ -2869,6 +2871,7 @@ namespace Js
         AsmJsFunctionInfo* GetAsmJsFunctionInfoWithLock()const { return static_cast<AsmJsFunctionInfo*>(this->GetAuxPtrWithLock(AuxPointerType::AsmJsFunctionInfo)); }
         AsmJsFunctionInfo* AllocateAsmJsFunctionInfo();
         AsmJsModuleInfo* GetAsmJsModuleInfo()const { return static_cast<AsmJsModuleInfo*>(this->GetAuxPtr(AuxPointerType::AsmJsModuleInfo)); }
+        AsmJsModuleInfo* GetAsmJsModuleInfoWithLock()const { return static_cast<AsmJsModuleInfo*>(this->GetAuxPtrWithLock(AuxPointerType::AsmJsModuleInfo)); }
         void ResetAsmJsInfo()
         {
             SetAuxPtr(AuxPointerType::AsmJsFunctionInfo, nullptr);


### PR DESCRIPTION
PR #603 introduced a new background call to get AsmJsModuleInfo, this part need a lock