### PR TITLE
Initialize prototype type's defer initialize type handler with the prototype variant.

### DIFF
--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -132,7 +132,7 @@ namespace Js
         // The prototype property of the object prototype is null.
         objectPrototype = ObjectPrototypeObject::New(recycler,
             DynamicType::New(scriptContext, TypeIds_Object, nullValue, nullptr,
-            DeferredTypeHandler<InitializeObjectPrototype>::GetDefaultInstance()));
+            DeferredTypeHandler<InitializeObjectPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
         constructorPrototypeObjectType = DynamicType::New(scriptContext, TypeIds_Object, objectPrototype, nullptr,
             &SharedPrototypeTypeHandler, true, true);
@@ -145,77 +145,77 @@ namespace Js
             {
                 arrayBufferPrototype = DynamicObject::New(recycler,
                     DynamicType::New(scriptContext, TypeIds_Object, objectPrototype, nullptr,
-                    DeferredTypeHandler<InitializeArrayBufferPrototype>::GetDefaultInstance()));
+                    DeferredTypeHandler<InitializeArrayBufferPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
                 arrayBufferType = DynamicType::New(scriptContext, TypeIds_ArrayBuffer, arrayBufferPrototype, nullptr,
                     SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, 0, 0, true, true), true, true);
 
                 dataViewPrototype = DynamicObject::New(recycler,
                     DynamicType::New(scriptContext, TypeIds_Object, objectPrototype, nullptr,
-                    DeferredTypeHandler<InitializeDataViewPrototype>::GetDefaultInstance()));
+                    DeferredTypeHandler<InitializeDataViewPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
                 typedArrayPrototype = DynamicObject::New(recycler,
                     DynamicType::New(scriptContext, TypeIds_Object, objectPrototype, nullptr,
-                    DeferredTypeHandler<InitializeTypedArrayPrototype>::GetDefaultInstance()));
+                    DeferredTypeHandler<InitializeTypedArrayPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
                 Int8ArrayPrototype = DynamicObject::New(recycler,
                     DynamicType::New(scriptContext, TypeIds_Object, typedArrayPrototype, nullptr,
-                    DeferredTypeHandler<InitializeInt8ArrayPrototype>::GetDefaultInstance()));
+                    DeferredTypeHandler<InitializeInt8ArrayPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
                 Uint8ArrayPrototype = DynamicObject::New(recycler,
                     DynamicType::New(scriptContext, TypeIds_Object, typedArrayPrototype, nullptr,
-                    DeferredTypeHandler<InitializeUint8ArrayPrototype>::GetDefaultInstance()));
+                    DeferredTypeHandler<InitializeUint8ArrayPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
                 // If ES6 TypedArrays are enabled, we have Khronos Interop mode enabled
                 Uint8ClampedArrayPrototype = DynamicObject::New(recycler,
                     DynamicType::New(scriptContext, TypeIds_Object, typedArrayPrototype, nullptr,
-                    DeferredTypeHandler<InitializeUint8ClampedArrayPrototype>::GetDefaultInstance()));
+                    DeferredTypeHandler<InitializeUint8ClampedArrayPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
                 Int16ArrayPrototype = DynamicObject::New(recycler,
                     DynamicType::New(scriptContext, TypeIds_Object, typedArrayPrototype, nullptr,
-                    DeferredTypeHandler<InitializeInt16ArrayPrototype>::GetDefaultInstance()));
+                    DeferredTypeHandler<InitializeInt16ArrayPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
                 Uint16ArrayPrototype = DynamicObject::New(recycler,
                     DynamicType::New(scriptContext, TypeIds_Object, typedArrayPrototype, nullptr,
-                    DeferredTypeHandler<InitializeUint16ArrayPrototype>::GetDefaultInstance()));
+                    DeferredTypeHandler<InitializeUint16ArrayPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
                 Int32ArrayPrototype = DynamicObject::New(recycler,
                     DynamicType::New(scriptContext, TypeIds_Object, typedArrayPrototype, nullptr,
-                    DeferredTypeHandler<InitializeInt32ArrayPrototype>::GetDefaultInstance()));
+                    DeferredTypeHandler<InitializeInt32ArrayPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
                 Uint32ArrayPrototype = DynamicObject::New(recycler,
                     DynamicType::New(scriptContext, TypeIds_Object, typedArrayPrototype, nullptr,
-                    DeferredTypeHandler<InitializeUint32ArrayPrototype>::GetDefaultInstance()));
+                    DeferredTypeHandler<InitializeUint32ArrayPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
                 Float32ArrayPrototype = DynamicObject::New(recycler,
                     DynamicType::New(scriptContext, TypeIds_Object, typedArrayPrototype, nullptr,
-                    DeferredTypeHandler<InitializeFloat32ArrayPrototype>::GetDefaultInstance()));
+                    DeferredTypeHandler<InitializeFloat32ArrayPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
                 Float64ArrayPrototype = DynamicObject::New(recycler,
                     DynamicType::New(scriptContext, TypeIds_Object, typedArrayPrototype, nullptr,
-                    DeferredTypeHandler<InitializeFloat64ArrayPrototype>::GetDefaultInstance()));
+                    DeferredTypeHandler<InitializeFloat64ArrayPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
                 Int64ArrayPrototype = DynamicObject::New(recycler,
                     DynamicType::New(scriptContext, TypeIds_Object, typedArrayPrototype, nullptr,
-                    DeferredTypeHandler<InitializeInt64ArrayPrototype>::GetDefaultInstance()));
+                    DeferredTypeHandler<InitializeInt64ArrayPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
                 Uint64ArrayPrototype = DynamicObject::New(recycler,
                     DynamicType::New(scriptContext, TypeIds_Object, typedArrayPrototype, nullptr,
-                    DeferredTypeHandler<InitializeUint64ArrayPrototype>::GetDefaultInstance()));
+                    DeferredTypeHandler<InitializeUint64ArrayPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
                 BoolArrayPrototype = DynamicObject::New(recycler,
                     DynamicType::New(scriptContext, TypeIds_Object, typedArrayPrototype, nullptr,
-                    DeferredTypeHandler<InitializeBoolArrayPrototype>::GetDefaultInstance()));
+                    DeferredTypeHandler<InitializeBoolArrayPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
                 CharArrayPrototype = DynamicObject::New(recycler,
                     DynamicType::New(scriptContext, TypeIds_Object, typedArrayPrototype, nullptr,
-                    DeferredTypeHandler<InitializeCharArrayPrototype>::GetDefaultInstance()));
+                    DeferredTypeHandler<InitializeCharArrayPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
             }
             else
             {
                 arrayBufferPrototype = JavascriptArrayBuffer::Create(0,
                     DynamicType::New(scriptContext, TypeIds_ArrayBuffer, objectPrototype, nullptr,
-                    DeferredTypeHandler<InitializeArrayBufferPrototype>::GetDefaultInstance()));
+                    DeferredTypeHandler<InitializeArrayBufferPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
                 arrayBufferType = DynamicType::New(scriptContext, TypeIds_ArrayBuffer, arrayBufferPrototype, nullptr,
                     SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, 0, 0, true, true), true, true);
@@ -223,71 +223,71 @@ namespace Js
                 baseArrayBuffer = JavascriptArrayBuffer::Create(0, arrayBufferType);
                 Int8ArrayPrototype = RecyclerNew(recycler, Int8Array, baseArrayBuffer, 0, 0,
                     DynamicType::New(scriptContext, TypeIds_Int8Array, objectPrototype, nullptr,
-                    DeferredTypeHandler<InitializeInt8ArrayPrototype>::GetDefaultInstance()));
+                    DeferredTypeHandler<InitializeInt8ArrayPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
                 baseArrayBuffer = JavascriptArrayBuffer::Create(0, arrayBufferType);
                 Uint8ArrayPrototype = RecyclerNew(recycler, Uint8Array, baseArrayBuffer, 0, 0,
                     DynamicType::New(scriptContext, TypeIds_Uint8Array, objectPrototype, nullptr,
-                    DeferredTypeHandler<InitializeUint8ArrayPrototype>::GetDefaultInstance()));
+                    DeferredTypeHandler<InitializeUint8ArrayPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
                 dataViewPrototype = DynamicObject::New(recycler,
                     DynamicType::New(scriptContext, TypeIds_Object, objectPrototype, nullptr,
-                    DeferredTypeHandler<InitializeDataViewPrototype>::GetDefaultInstance()));
+                    DeferredTypeHandler<InitializeDataViewPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
                 baseArrayBuffer = JavascriptArrayBuffer::Create(0, arrayBufferType);
                 Uint8ClampedArrayPrototype = RecyclerNew(recycler, Uint8ClampedArray, baseArrayBuffer, 0, 0,
                     DynamicType::New(scriptContext, TypeIds_Uint8ClampedArray, objectPrototype, nullptr,
-                    DeferredTypeHandler<InitializeUint8ClampedArrayPrototype>::GetDefaultInstance()));
+                    DeferredTypeHandler<InitializeUint8ClampedArrayPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
                 baseArrayBuffer = JavascriptArrayBuffer::Create(0, arrayBufferType);
                 Int16ArrayPrototype = RecyclerNew(recycler, Int16Array, baseArrayBuffer, 0, 0,
                     DynamicType::New(scriptContext, TypeIds_Int16Array, objectPrototype, nullptr,
-                    DeferredTypeHandler<InitializeInt16ArrayPrototype>::GetDefaultInstance()));
+                    DeferredTypeHandler<InitializeInt16ArrayPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
                 baseArrayBuffer = JavascriptArrayBuffer::Create(0, arrayBufferType);
                 Uint16ArrayPrototype = RecyclerNew(recycler, Uint16Array, baseArrayBuffer, 0, 0,
                     DynamicType::New(scriptContext, TypeIds_Uint16Array, objectPrototype, nullptr,
-                    DeferredTypeHandler<InitializeUint16ArrayPrototype>::GetDefaultInstance()));
+                    DeferredTypeHandler<InitializeUint16ArrayPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
                 baseArrayBuffer = JavascriptArrayBuffer::Create(0, arrayBufferType);
                 Int32ArrayPrototype = RecyclerNew(recycler, Int32Array, baseArrayBuffer, 0, 0,
                     DynamicType::New(scriptContext, TypeIds_Int32Array, objectPrototype, nullptr,
-                    DeferredTypeHandler<InitializeInt32ArrayPrototype>::GetDefaultInstance()));
+                    DeferredTypeHandler<InitializeInt32ArrayPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
                 baseArrayBuffer = JavascriptArrayBuffer::Create(0, arrayBufferType);
                 Uint32ArrayPrototype = RecyclerNew(recycler, Uint32Array, baseArrayBuffer, 0, 0,
                     DynamicType::New(scriptContext, TypeIds_Uint32Array, objectPrototype, nullptr,
-                    DeferredTypeHandler<InitializeUint32ArrayPrototype>::GetDefaultInstance()));
+                    DeferredTypeHandler<InitializeUint32ArrayPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
                 baseArrayBuffer = JavascriptArrayBuffer::Create(0, arrayBufferType);
                 Float32ArrayPrototype = RecyclerNew(recycler, Float32Array, baseArrayBuffer, 0, 0,
                     DynamicType::New(scriptContext, TypeIds_Float32Array, objectPrototype, nullptr,
-                    DeferredTypeHandler<InitializeFloat32ArrayPrototype>::GetDefaultInstance()));
+                    DeferredTypeHandler<InitializeFloat32ArrayPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
                 baseArrayBuffer = JavascriptArrayBuffer::Create(0, arrayBufferType);
                 Float64ArrayPrototype = RecyclerNew(recycler, Float64Array, baseArrayBuffer, 0, 0,
                     DynamicType::New(scriptContext, TypeIds_Float64Array, objectPrototype, nullptr,
-                    DeferredTypeHandler<InitializeFloat64ArrayPrototype>::GetDefaultInstance()));
+                    DeferredTypeHandler<InitializeFloat64ArrayPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
                 baseArrayBuffer = JavascriptArrayBuffer::Create(0, arrayBufferType);
                 Int64ArrayPrototype = RecyclerNew(recycler, Int64Array, baseArrayBuffer, 0, 0,
                     DynamicType::New(scriptContext, TypeIds_Int64Array, objectPrototype, nullptr,
-                    DeferredTypeHandler<InitializeInt64ArrayPrototype>::GetDefaultInstance()));
+                    DeferredTypeHandler<InitializeInt64ArrayPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
                 baseArrayBuffer = JavascriptArrayBuffer::Create(0, arrayBufferType);
                 Uint64ArrayPrototype = RecyclerNew(recycler, Uint64Array, baseArrayBuffer, 0, 0,
                     DynamicType::New(scriptContext, TypeIds_Uint64Array, objectPrototype, nullptr,
-                    DeferredTypeHandler<InitializeUint64ArrayPrototype>::GetDefaultInstance()));
+                    DeferredTypeHandler<InitializeUint64ArrayPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
                 baseArrayBuffer = JavascriptArrayBuffer::Create(0, arrayBufferType);
                 BoolArrayPrototype = RecyclerNew(recycler, BoolArray, baseArrayBuffer, 0, 0,
                     DynamicType::New(scriptContext, TypeIds_BoolArray, objectPrototype, nullptr,
-                    DeferredTypeHandler<InitializeBoolArrayPrototype>::GetDefaultInstance()));
+                    DeferredTypeHandler<InitializeBoolArrayPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
                 baseArrayBuffer = JavascriptArrayBuffer::Create(0, arrayBufferType);
                 CharArrayPrototype = RecyclerNew(recycler, CharArray, baseArrayBuffer, 0, 0,
                     DynamicType::New(scriptContext, TypeIds_CharArray, objectPrototype, nullptr,
-                    DeferredTypeHandler<InitializeCharArrayPrototype>::GetDefaultInstance()));
+                    DeferredTypeHandler<InitializeCharArrayPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
             }
         }
         else
@@ -313,67 +313,67 @@ namespace Js
 
         arrayPrototype = JavascriptArray::New<Var, JavascriptArray, 0>(0,
             DynamicType::New(scriptContext, TypeIds_Array, objectPrototype, nullptr,
-            DeferredTypeHandler<InitializeArrayPrototype>::GetDefaultInstance()), recycler);
+            DeferredTypeHandler<InitializeArrayPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()), recycler);
 
         booleanPrototype = RecyclerNew(recycler, JavascriptBooleanObject, nullptr,
             DynamicType::New(scriptContext, TypeIds_BooleanObject, objectPrototype, nullptr,
-            DeferredTypeHandler<InitializeBooleanPrototype>::GetDefaultInstance()));
+            DeferredTypeHandler<InitializeBooleanPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
         numberPrototype = RecyclerNew(recycler, JavascriptNumberObject, TaggedInt::ToVarUnchecked(0),
             DynamicType::New(scriptContext, TypeIds_NumberObject, objectPrototype, nullptr,
-            DeferredTypeHandler<InitializeNumberPrototype>::GetDefaultInstance()));
+            DeferredTypeHandler<InitializeNumberPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
         stringPrototype = RecyclerNew(recycler, JavascriptStringObject, nullptr,
             DynamicType::New(scriptContext, TypeIds_StringObject, objectPrototype, nullptr,
-            DeferredTypeHandler<InitializeStringPrototype>::GetDefaultInstance()));
+            DeferredTypeHandler<InitializeStringPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
         /* Initialize SIMD prototypes*/
         if (GetScriptContext()->GetConfig()->IsSimdjsEnabled())
         {
             simdBool8x16Prototype = RecyclerNew(recycler, JavascriptSIMDObject, nullptr,
                 DynamicType::New(scriptContext, TypeIds_SIMDObject, objectPrototype, nullptr,
-                    DeferredTypeHandler<InitializeSIMDBool8x16Prototype>::GetDefaultInstance()));
+                    DeferredTypeHandler<InitializeSIMDBool8x16Prototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
             simdBool16x8Prototype = RecyclerNew(recycler, JavascriptSIMDObject, nullptr,
                 DynamicType::New(scriptContext, TypeIds_SIMDObject, objectPrototype, nullptr,
-                    DeferredTypeHandler<InitializeSIMDBool16x8Prototype>::GetDefaultInstance()));
+                    DeferredTypeHandler<InitializeSIMDBool16x8Prototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
             simdBool32x4Prototype = RecyclerNew(recycler, JavascriptSIMDObject, nullptr,
                 DynamicType::New(scriptContext, TypeIds_SIMDObject, objectPrototype, nullptr,
-                    DeferredTypeHandler<InitializeSIMDBool32x4Prototype>::GetDefaultInstance()));
+                    DeferredTypeHandler<InitializeSIMDBool32x4Prototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
             simdInt8x16Prototype = RecyclerNew(recycler, JavascriptSIMDObject, nullptr,
                 DynamicType::New(scriptContext, TypeIds_SIMDObject, objectPrototype, nullptr,
-                    DeferredTypeHandler<InitializeSIMDInt8x16Prototype>::GetDefaultInstance()));
+                    DeferredTypeHandler<InitializeSIMDInt8x16Prototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
             simdInt16x8Prototype = RecyclerNew(recycler, JavascriptSIMDObject, nullptr,
                 DynamicType::New(scriptContext, TypeIds_SIMDObject, objectPrototype, nullptr,
-                    DeferredTypeHandler<InitializeSIMDInt16x8Prototype>::GetDefaultInstance()));
+                    DeferredTypeHandler<InitializeSIMDInt16x8Prototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
             simdInt32x4Prototype = RecyclerNew(recycler, JavascriptSIMDObject, nullptr,
                 DynamicType::New(scriptContext, TypeIds_SIMDObject, objectPrototype, nullptr,
-                    DeferredTypeHandler<InitializeSIMDInt32x4Prototype>::GetDefaultInstance()));
+                    DeferredTypeHandler<InitializeSIMDInt32x4Prototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
             simdUint8x16Prototype = RecyclerNew(recycler, JavascriptSIMDObject, nullptr,
                 DynamicType::New(scriptContext, TypeIds_SIMDObject, objectPrototype, nullptr,
-                    DeferredTypeHandler<InitializeSIMDUint8x16Prototype>::GetDefaultInstance()));
+                    DeferredTypeHandler<InitializeSIMDUint8x16Prototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
             simdUint16x8Prototype = RecyclerNew(recycler, JavascriptSIMDObject, nullptr,
                 DynamicType::New(scriptContext, TypeIds_SIMDObject, objectPrototype, nullptr,
-                    DeferredTypeHandler<InitializeSIMDUint16x8Prototype>::GetDefaultInstance()));
+                    DeferredTypeHandler<InitializeSIMDUint16x8Prototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
             simdUint32x4Prototype = RecyclerNew(recycler, JavascriptSIMDObject, nullptr,
                 DynamicType::New(scriptContext, TypeIds_SIMDObject, objectPrototype, nullptr,
-                    DeferredTypeHandler<InitializeSIMDUint32x4Prototype>::GetDefaultInstance()));
+                    DeferredTypeHandler<InitializeSIMDUint32x4Prototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
             simdFloat32x4Prototype = RecyclerNew(recycler, JavascriptSIMDObject, nullptr,
                 DynamicType::New(scriptContext, TypeIds_SIMDObject, objectPrototype, nullptr,
-                    DeferredTypeHandler<InitializeSIMDFloat32x4Prototype>::GetDefaultInstance()));
+                    DeferredTypeHandler<InitializeSIMDFloat32x4Prototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
         }
 
         if (scriptContext->GetConfig()->IsES6PrototypeChain())
         {
             datePrototype = DynamicObject::New(recycler,
                 DynamicType::New(scriptContext, TypeIds_Object, objectPrototype, nullptr,
-                DeferredTypeHandler<InitializeDatePrototype>::GetDefaultInstance()));
+                DeferredTypeHandler<InitializeDatePrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
             regexPrototype = DynamicObject::New(recycler,
                 DynamicType::New(scriptContext, TypeIds_Object, objectPrototype, nullptr,
-                DeferredTypeHandler<InitializeRegexPrototype>::GetDefaultInstance()));
+                DeferredTypeHandler<InitializeRegexPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
         }
         else
         {
@@ -381,80 +381,80 @@ namespace Js
 
             datePrototype = RecyclerNewZ(recycler, JavascriptDate, initDateValue,
                 DynamicType::New(scriptContext, TypeIds_Date, objectPrototype, nullptr,
-                DeferredTypeHandler<InitializeDatePrototype>::GetDefaultInstance()));
+                DeferredTypeHandler<InitializeDatePrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
         }
 
         if (scriptContext->GetConfig()->IsES6PrototypeChain())
         {
             errorPrototype = DynamicObject::New(recycler,
                 DynamicType::New(scriptContext, TypeIds_Object, objectPrototype, nullptr,
-                DeferredTypeHandler<InitializeErrorPrototype>::GetDefaultInstance()));
+                DeferredTypeHandler<InitializeErrorPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
             evalErrorPrototype = DynamicObject::New(recycler,
                 DynamicType::New(scriptContext, TypeIds_Object, errorPrototype, nullptr,
-                DeferredTypeHandler<InitializeEvalErrorPrototype>::GetDefaultInstance()));
+                DeferredTypeHandler<InitializeEvalErrorPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
             rangeErrorPrototype = DynamicObject::New(recycler,
                 DynamicType::New(scriptContext, TypeIds_Object, errorPrototype, nullptr,
-                DeferredTypeHandler<InitializeRangeErrorPrototype>::GetDefaultInstance()));
+                DeferredTypeHandler<InitializeRangeErrorPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
             referenceErrorPrototype = DynamicObject::New(recycler,
                 DynamicType::New(scriptContext, TypeIds_Object, errorPrototype, nullptr,
-                DeferredTypeHandler<InitializeReferenceErrorPrototype>::GetDefaultInstance()));
+                DeferredTypeHandler<InitializeReferenceErrorPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
             syntaxErrorPrototype = DynamicObject::New(recycler,
                 DynamicType::New(scriptContext, TypeIds_Object, errorPrototype, nullptr,
-                DeferredTypeHandler<InitializeSyntaxErrorPrototype>::GetDefaultInstance()));
+                DeferredTypeHandler<InitializeSyntaxErrorPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
             typeErrorPrototype = DynamicObject::New(recycler,
                 DynamicType::New(scriptContext, TypeIds_Object, errorPrototype, nullptr,
-                DeferredTypeHandler<InitializeTypeErrorPrototype>::GetDefaultInstance()));
+                DeferredTypeHandler<InitializeTypeErrorPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
             uriErrorPrototype = DynamicObject::New(recycler,
                 DynamicType::New(scriptContext, TypeIds_Object, errorPrototype, nullptr,
-                DeferredTypeHandler<InitializeURIErrorPrototype>::GetDefaultInstance()));
+                DeferredTypeHandler<InitializeURIErrorPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
         }
         else
         {
             errorPrototype = RecyclerNew(this->GetRecycler(), JavascriptError,
                 DynamicType::New(scriptContext, TypeIds_Error, objectPrototype, nullptr,
-                DeferredTypeHandler<InitializeErrorPrototype>::GetDefaultInstance()),
+                DeferredTypeHandler<InitializeErrorPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()),
                 /*isExternalError*/FALSE, /*isPrototype*/TRUE);
 
             evalErrorPrototype = RecyclerNew(this->GetRecycler(), JavascriptError,
                 DynamicType::New(scriptContext, TypeIds_Error, errorPrototype, nullptr,
-                DeferredTypeHandler<InitializeEvalErrorPrototype>::GetDefaultInstance()),
+                DeferredTypeHandler<InitializeEvalErrorPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()),
                 /*isExternalError*/FALSE, /*isPrototype*/TRUE);
 
             rangeErrorPrototype = RecyclerNew(this->GetRecycler(), JavascriptError,
                 DynamicType::New(scriptContext, TypeIds_Error, errorPrototype, nullptr,
-                DeferredTypeHandler<InitializeRangeErrorPrototype>::GetDefaultInstance()),
+                DeferredTypeHandler<InitializeRangeErrorPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()),
                 /*isExternalError*/FALSE, /*isPrototype*/TRUE);
 
             referenceErrorPrototype = RecyclerNew(this->GetRecycler(), JavascriptError,
                 DynamicType::New(scriptContext, TypeIds_Error, errorPrototype, nullptr,
-                DeferredTypeHandler<InitializeReferenceErrorPrototype>::GetDefaultInstance()),
+                DeferredTypeHandler<InitializeReferenceErrorPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()),
                 /*isExternalError*/FALSE, /*isPrototype*/TRUE);
 
             syntaxErrorPrototype = RecyclerNew(this->GetRecycler(), JavascriptError,
                 DynamicType::New(scriptContext, TypeIds_Error, errorPrototype, nullptr,
-                DeferredTypeHandler<InitializeSyntaxErrorPrototype>::GetDefaultInstance()),
+                DeferredTypeHandler<InitializeSyntaxErrorPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()),
                 /*isExternalError*/FALSE, /*isPrototype*/TRUE);
 
             typeErrorPrototype = RecyclerNew(this->GetRecycler(), JavascriptError,
                 DynamicType::New(scriptContext, TypeIds_Error, errorPrototype, nullptr,
-                DeferredTypeHandler<InitializeTypeErrorPrototype>::GetDefaultInstance()),
+                DeferredTypeHandler<InitializeTypeErrorPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()),
                 /*isExternalError*/FALSE, /*isPrototype*/TRUE);
 
             uriErrorPrototype = RecyclerNew(this->GetRecycler(), JavascriptError,
                 DynamicType::New(scriptContext, TypeIds_Error, errorPrototype, nullptr,
-                DeferredTypeHandler<InitializeURIErrorPrototype>::GetDefaultInstance()),
+                DeferredTypeHandler<InitializeURIErrorPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()),
                 /*isExternalError*/FALSE, /*isPrototype*/TRUE);
         }
 
         functionPrototype = RecyclerNew(recycler, JavascriptFunction,
             DynamicType::New(scriptContext, TypeIds_Function, objectPrototype, JavascriptFunction::PrototypeEntryPoint,
-            DeferredTypeHandler<InitializeFunctionPrototype>::GetDefaultInstance()), &JavascriptFunction::EntryInfo::PrototypeEntryPoint);
+            DeferredTypeHandler<InitializeFunctionPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()), &JavascriptFunction::EntryInfo::PrototypeEntryPoint);
 
         promisePrototype = nullptr;
         javascriptEnumeratorIteratorPrototype = nullptr;
@@ -464,71 +464,71 @@ namespace Js
 
         symbolPrototype = DynamicObject::New(recycler,
             DynamicType::New(scriptContext, TypeIds_Object, objectPrototype, nullptr,
-            DeferredTypeHandler<InitializeSymbolPrototype>::GetDefaultInstance()));
+            DeferredTypeHandler<InitializeSymbolPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
         mapPrototype = DynamicObject::New(recycler,
             DynamicType::New(scriptContext, TypeIds_Object, objectPrototype, nullptr,
-            DeferredTypeHandler<InitializeMapPrototype>::GetDefaultInstance()));
+            DeferredTypeHandler<InitializeMapPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
         setPrototype = DynamicObject::New(recycler,
             DynamicType::New(scriptContext, TypeIds_Object, objectPrototype, nullptr,
-            DeferredTypeHandler<InitializeSetPrototype>::GetDefaultInstance()));
+            DeferredTypeHandler<InitializeSetPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
         weakMapPrototype = DynamicObject::New(recycler,
             DynamicType::New(scriptContext, TypeIds_Object, objectPrototype, nullptr,
-            DeferredTypeHandler<InitializeWeakMapPrototype>::GetDefaultInstance()));
+            DeferredTypeHandler<InitializeWeakMapPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
         weakSetPrototype = DynamicObject::New(recycler,
             DynamicType::New(scriptContext, TypeIds_Object, objectPrototype, nullptr,
-            DeferredTypeHandler<InitializeWeakSetPrototype>::GetDefaultInstance()));
+            DeferredTypeHandler<InitializeWeakSetPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
         iteratorPrototype = DynamicObject::New(recycler,
             DynamicType::New(scriptContext, TypeIds_Object, objectPrototype, nullptr,
-            DeferredTypeHandler<InitializeIteratorPrototype>::GetDefaultInstance()));
+            DeferredTypeHandler<InitializeIteratorPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
         arrayIteratorPrototype = DynamicObject::New(recycler,
             DynamicType::New(scriptContext, TypeIds_Object, iteratorPrototype, nullptr,
-            DeferredTypeHandler<InitializeArrayIteratorPrototype>::GetDefaultInstance()));
+            DeferredTypeHandler<InitializeArrayIteratorPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
         mapIteratorPrototype = DynamicObject::New(recycler,
             DynamicType::New(scriptContext, TypeIds_Object, iteratorPrototype, nullptr,
-            DeferredTypeHandler<InitializeMapIteratorPrototype>::GetDefaultInstance()));
+            DeferredTypeHandler<InitializeMapIteratorPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
         setIteratorPrototype = DynamicObject::New(recycler,
             DynamicType::New(scriptContext, TypeIds_Object, iteratorPrototype, nullptr,
-            DeferredTypeHandler<InitializeSetIteratorPrototype>::GetDefaultInstance()));
+            DeferredTypeHandler<InitializeSetIteratorPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
         stringIteratorPrototype = DynamicObject::New(recycler,
             DynamicType::New(scriptContext, TypeIds_Object, iteratorPrototype, nullptr,
-            DeferredTypeHandler<InitializeStringIteratorPrototype>::GetDefaultInstance()));
+            DeferredTypeHandler<InitializeStringIteratorPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
         if (scriptContext->GetConfig()->IsES6PromiseEnabled())
         {
             promisePrototype = DynamicObject::New(recycler,
                 DynamicType::New(scriptContext, TypeIds_Object, objectPrototype, nullptr,
-                DeferredTypeHandler<InitializePromisePrototype>::GetDefaultInstance()));
+                DeferredTypeHandler<InitializePromisePrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
         }
 
         if (scriptContext->GetConfig()->IsES6ProxyEnabled())
         {
             javascriptEnumeratorIteratorPrototype = DynamicObject::New(recycler,
                 DynamicType::New(scriptContext, TypeIds_Object, iteratorPrototype, nullptr,
-                DeferredTypeHandler<InitializeJavascriptEnumeratorIteratorPrototype>::GetDefaultInstance()));
+                DeferredTypeHandler<InitializeJavascriptEnumeratorIteratorPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
         }
 
         if (scriptContext->GetConfig()->IsES6GeneratorsEnabled())
         {
             generatorFunctionPrototype = DynamicObject::New(recycler,
                 DynamicType::New(scriptContext, TypeIds_Object, functionPrototype, nullptr,
-                DeferredTypeHandler<InitializeGeneratorFunctionPrototype>::GetDefaultInstance()));
+                DeferredTypeHandler<InitializeGeneratorFunctionPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
             generatorPrototype = DynamicObject::New(recycler,
                 DynamicType::New(scriptContext, TypeIds_Object, iteratorPrototype, nullptr,
-                DeferredTypeHandler<InitializeGeneratorPrototype>::GetDefaultInstance()));
+                DeferredTypeHandler<InitializeGeneratorPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
         }
 
         if (scriptContext->GetConfig()->IsES7AsyncAndAwaitEnabled())
         {
             asyncFunctionPrototype = DynamicObject::New(recycler,
                 DynamicType::New(scriptContext, TypeIds_Object, functionPrototype, nullptr,
-                DeferredTypeHandler<InitializeAsyncFunctionPrototype>::GetDefaultInstance()));
+                DeferredTypeHandler<InitializeAsyncFunctionPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
         }
     }
 
@@ -1330,7 +1330,7 @@ namespace Js
             DeferredTypeHandler<InitializeDateConstructor>::GetDefaultInstance());
         AddFunction(globalObject, PropertyIds::Date, dateConstructor);
         functionConstructor = CreateBuiltinConstructor(&JavascriptFunction::EntryInfo::NewInstance,
-            DeferredTypeHandler<InitializeFunctionConstructor>::GetDefaultInstance());
+            DeferredTypeHandler<InitializeFunctionConstructor, DefaultDeferredTypeFilter, true>::GetDefaultInstance());
         AddFunction(globalObject, PropertyIds::Function, functionConstructor);
         mathObject = DynamicObject::New(recycler,
             DynamicType::New(scriptContext, TypeIds_Object, objectPrototype, nullptr,
@@ -1372,7 +1372,7 @@ namespace Js
             if (scriptContext->GetConfig()->IsES6TypedArrayExtensionsEnabled())
             {
                 typedArrayConstructor = CreateBuiltinConstructor(&TypedArrayBase::EntryInfo::NewInstance,
-                    DeferredTypeHandler<InitializeTypedArrayConstructor>::GetDefaultInstance(),
+                    DeferredTypeHandler<InitializeTypedArrayConstructor, DefaultDeferredTypeFilter, true>::GetDefaultInstance(),
                     functionPrototype);
 
                 Int8ArrayConstructor = CreateBuiltinConstructor(&Int8Array::EntryInfo::NewInstance,
@@ -2581,7 +2581,7 @@ namespace Js
         {
             regexPrototype = RecyclerNew(recycler, JavascriptRegExp, emptyRegexPattern,
                 DynamicType::New(scriptContext, TypeIds_RegEx, objectPrototype, nullptr,
-                DeferredTypeHandler<InitializeRegexPrototype>::GetDefaultInstance()));
+                DeferredTypeHandler<InitializeRegexPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
         }
 
         SimplePathTypeHandler *typeHandler =

--- a/lib/Runtime/Library/JavascriptLibrary.h
+++ b/lib/Runtime/Library/JavascriptLibrary.h
@@ -605,7 +605,6 @@ namespace Js
         JavascriptFunction* GetStringConstructor() const {return stringConstructor; }
         JavascriptFunction* GetArrayBufferConstructor() const {return arrayBufferConstructor; }
         JavascriptFunction* GetErrorConstructor() const { return errorConstructor; }
-        JavascriptFunction* GetTypedArrayConstructor() const { return typedArrayConstructor; }
         JavascriptFunction* GetInt8ArrayConstructor() const {return Int8ArrayConstructor; }
         JavascriptFunction* GetUint8ArrayConstructor() const {return Uint8ArrayConstructor; }
         JavascriptFunction* GetInt16ArrayConstructor() const {return Int16ArrayConstructor; }


### PR DESCRIPTION
Avoid the need to switch to the prototype variant when the type that we are create is going to be a prototype anyways.
Reduce binary size and script context initialization costs
