### PR TITLE
xplat: build lib/Runtime/ByteCode

### DIFF
--- a/lib/Common/CommonPal.h
+++ b/lib/Common/CommonPal.h
@@ -279,6 +279,7 @@ errno_t rand_s(unsigned int* randomValue);
 
 #define MAXUINT32   ((uint32_t)~((uint32_t)0))
 #define MAXINT32    ((int32_t)(MAXUINT32 >> 1))
+#define BYTE_MAX    0xff
 
 #ifdef UNICODE
 #define StringCchPrintf  StringCchPrintfW

--- a/lib/Common/Core/CommonTypedefs.h
+++ b/lib/Common/Core/CommonTypedefs.h
@@ -48,7 +48,7 @@ const CharCountOrFlag CharCountFlag = (CharCountOrFlag)-1;
 
 #define QUOTE(s) #s
 #define STRINGIZE(s) QUOTE(s)
-#define STRINGIZEW(s) TEXT(QUOTE(s))
+#define STRINGIZEW(s) _u(#s)
 
 namespace Js
 {

--- a/lib/Common/DataStructures/BufferBuilder.h
+++ b/lib/Common/DataStructures/BufferBuilder.h
@@ -210,7 +210,7 @@ namespace Js
     struct ConstantSizedBufferBuilderOf : BufferBuilderOf<T, false>
     {
         ConstantSizedBufferBuilderOf(LPCWSTR clue, const T & value)
-        : BufferBuilderOf(clue, value)
+        : BufferBuilderOf<T, false>(clue, value)
         { }
     };
 

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -1398,7 +1398,7 @@ FuncInfo * ByteCodeGenerator::StartBindFunction(const char16 *name, uint nameLen
     if (pnode->sxFnc.CallsEval())
     {
         funcInfo->SetCallsEval(true);
-        
+
         bodyScope->SetIsDynamic(true);
         bodyScope->SetIsObject();
         bodyScope->SetCapturesAll(true);
@@ -2652,7 +2652,7 @@ FuncInfo* PostVisitFunction(ParseNode* pnode, ByteCodeGenerator* byteCodeGenerat
                 top->GetChildCallsEval() ||
                 (top->GetHasArguments() && ByteCodeGenerator::NeedScopeObjectForArguments(top, pnode) && pnode->sxFnc.pnodeParams != nullptr) ||
                 top->GetHasLocalInClosure() ||
-                top->funcExprScope && top->funcExprScope->GetMustInstantiate())
+                (top->funcExprScope && top->funcExprScope->GetMustInstantiate()))
             {
                 if (!top->GetCallsEval())
                 {
@@ -3901,8 +3901,8 @@ bool InvertableBlock(ParseNode* block, Symbol* outerVar, ParseNode* innerLoop, P
             return false;
         }
 
-        if (innerLoop->sxFor.pnodeBody->nop == knopBlock && innerLoop->sxFor.pnodeBody->sxBlock.HasBlockScopedContent()
-            || outerLoop->sxFor.pnodeBody->nop == knopBlock && outerLoop->sxFor.pnodeBody->sxBlock.HasBlockScopedContent())
+        if ((innerLoop->sxFor.pnodeBody->nop == knopBlock && innerLoop->sxFor.pnodeBody->sxBlock.HasBlockScopedContent())
+            || (outerLoop->sxFor.pnodeBody->nop == knopBlock && outerLoop->sxFor.pnodeBody->sxBlock.HasBlockScopedContent()))
         {
             // we can not invert loops if there are block scoped declarations inside
             return false;

--- a/lib/Runtime/ByteCode/ByteCodeSerializer.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeSerializer.cpp
@@ -146,11 +146,12 @@ public:
         : byteCount(byteCount), pv(pv)
     { }
 };
+} // namespace Js
 
 template<>
-struct DefaultComparer<ByteBuffer*>
+struct DefaultComparer<Js::ByteBuffer*>
 {
-    static bool Equals(ByteBuffer const * str1, ByteBuffer const * str2)
+    static bool Equals(Js::ByteBuffer const * str1, Js::ByteBuffer const * str2)
     {
         if (str1->byteCount != str2->byteCount)
         {
@@ -159,12 +160,14 @@ struct DefaultComparer<ByteBuffer*>
         return memcmp(str1->pv, str2->pv, str1->byteCount)==0;
     }
 
-    static hash_t GetHashCode(ByteBuffer const * str)
+    static hash_t GetHashCode(Js::ByteBuffer const * str)
     {
         return JsUtil::CharacterBuffer<char>::StaticGetHashCode(str->s8, str->byteCount);
     }
 };
 
+namespace Js
+{
 struct IndexEntry
 {
     BufferBuilderByte* isPropertyRecord;
@@ -1037,7 +1040,7 @@ public:
                 DEFAULT_LAYOUT_WITH_ONEBYTE(Bool8x16_2);
                 DEFAULT_LAYOUT_WITH_ONEBYTE(Bool8x16_3);
                 DEFAULT_LAYOUT_WITH_ONEBYTE(Reg1Bool8x16_1);
-                
+
                 DEFAULT_LAYOUT_WITH_ONEBYTE(AsmSimdTypedArr);
 
 
@@ -1953,7 +1956,7 @@ public:
     }
 
     template <typename TStructType>
-    uint32 PrependStruct(BufferBuilderList & builder, LPWSTR clue, TStructType * value)
+    uint32 PrependStruct(BufferBuilderList & builder, LPCWSTR clue, TStructType * value)
     {
         auto entry = Anew(alloc, ConstantSizedBufferBuilderOf<TStructType>, clue, *value);
         builder.list = builder.list->Prepend(entry, alloc);
@@ -4336,4 +4339,4 @@ SerializedFuncInfoArray::SerializedFuncInfoArray( uint offset, int count ) :
 
 }
 
-}
+} // namespace Js

--- a/lib/Runtime/ByteCode/ByteCodeWriter.h
+++ b/lib/Runtime/ByteCode/ByteCodeWriter.h
@@ -104,7 +104,7 @@ namespace Js
             template <> uint EncodeT<SmallLayout>(OpCode op, ByteCodeWriter* writer);
             template <LayoutSize layoutSize> uint EncodeT(OpCode op, const void * rawData, int byteSize, ByteCodeWriter* writer);
             // asm.js encoding
-            uint Encode(OpCodeAsmJs op, ByteCodeWriter* writer){ return EncodeT<Js::SmallLayout>(op, writer); }
+            uint Encode(OpCodeAsmJs op, ByteCodeWriter* writer){ return EncodeT<Js::SmallLayout>(op, writer, /*isPatching*/false); }
             uint Encode(OpCodeAsmJs op, const void * rawData, int byteSize, ByteCodeWriter* writer, bool isPatching = false){ return EncodeT<Js::SmallLayout>(op, rawData, byteSize, writer, isPatching); }
             template <LayoutSize layoutSize> uint EncodeT(OpCodeAsmJs op, ByteCodeWriter* writer, bool isPatching = false);
             template <> uint EncodeT<SmallLayout>(OpCodeAsmJs op, ByteCodeWriter* writer, bool isPatching);

--- a/lib/Runtime/ByteCode/Scope.cpp
+++ b/lib/Runtime/ByteCode/Scope.cpp
@@ -19,7 +19,8 @@ void Scope::SetHasLocalInClosure(bool has)
     // (Note: if any catch var is closure-captured, we won't merge the catch scope with the function scope.
     // So don't mark the function scope "has local in closure".)
     bool notCatch = this->scopeType != ScopeType_Catch && this->scopeType != ScopeType_CatchParamPattern;
-    if (has && (this == func->GetBodyScope() || this == func->GetParamScope()) || (GetCanMerge() && notCatch))
+    if ((has && (this == func->GetBodyScope() || this == func->GetParamScope())) ||
+        (GetCanMerge() && notCatch))
     {
         func->SetHasLocalInClosure(true);
     }

--- a/lib/Runtime/CMakeLists.txt
+++ b/lib/Runtime/CMakeLists.txt
@@ -9,3 +9,4 @@ include_directories(
     )
 
 add_subdirectory (Base)
+add_subdirectory (ByteCode)


### PR DESCRIPTION
Moved ```DefaultComparer<ByteBuffer*>``` template specialization to global
scope as ```DefaultComparer``` was declared in global scope.

Added a (default) parameter to ```EncodeT()``` call as otherwise clang
matches it to a different function and failes.

Others are simple changes. All "ByteCode" files build successfully.
