### PR TITLE
TypedArray construction from array with user-defined %ArrayIteratorPrototype%.next

### DIFF
--- a/lib/Runtime/Base/ThreadContext.h
+++ b/lib/Runtime/Base/ThreadContext.h
@@ -387,6 +387,25 @@ public:
     void SetStackProber(StackProber * stackProber);
     PBYTE GetScriptStackLimit() const;
     static DWORD GetStackLimitForCurrentThreadOffset() { return offsetof(ThreadContext, stackLimitForCurrentThread); }
+
+    template <class Fn>
+    Js::ImplicitCallFlags TryWithDisabledImplicitCall(Fn fn)
+    {
+        DisableImplicitFlags prevDisableImplicitFlags = this->GetDisableImplicitFlags();
+        Js::ImplicitCallFlags savedImplicitCallFlags = this->GetImplicitCallFlags();
+
+        this->DisableImplicitCall();
+        this->SetImplicitCallFlags(Js::ImplicitCallFlags::ImplicitCall_None);
+        fn();
+
+        Js::ImplicitCallFlags curImplicitCallFlags = this->GetImplicitCallFlags();
+
+        this->SetDisableImplicitFlags(prevDisableImplicitFlags);
+        this->SetImplicitCallFlags(savedImplicitCallFlags);
+
+        return curImplicitCallFlags;
+    }
+
     void * GetAddressOfStackLimitForCurrentThread()
     {
         FAULTINJECT_SCRIPT_TERMINATION

--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -4434,7 +4434,7 @@ namespace Js
         JavascriptLibrary* library = arrayIteratorPrototype->GetLibrary();
         ScriptContext* scriptContext = library->GetScriptContext();
 
-        library->AddFunctionToLibraryObject(arrayIteratorPrototype, PropertyIds::next, &JavascriptArrayIterator::EntryInfo::Next, 0);
+        library->arrayIteratorPrototypeBuiltinNextFunction = library->AddFunctionToLibraryObject(arrayIteratorPrototype, PropertyIds::next, &JavascriptArrayIterator::EntryInfo::Next, 0);
 
         if (scriptContext->GetConfig()->IsES6ToStringTagEnabled())
         {

--- a/lib/Runtime/Library/JavascriptLibrary.h
+++ b/lib/Runtime/Library/JavascriptLibrary.h
@@ -619,6 +619,7 @@ namespace Js
         JavascriptFunction* GetSymbolConstructor() const {return symbolConstructor; }
         JavascriptFunction* GetEvalFunctionObject() { return evalFunctionObject; }
         JavascriptFunction* GetArrayPrototypeValuesFunction() { return EnsureArrayPrototypeValuesFunction(); }
+        JavascriptFunction* GetArrayIteratorPrototypeBuiltinNextFunction() { return arrayIteratorPrototypeBuiltinNextFunction; }
         DynamicObject* GetMathObject() const {return mathObject; }
         DynamicObject* GetJSONObject() const {return JSONObject; }
         DynamicObject* GetReflectObject() const { return reflectObject; }

--- a/lib/Runtime/Library/JavascriptLibraryBase.h
+++ b/lib/Runtime/Library/JavascriptLibraryBase.h
@@ -182,6 +182,7 @@ namespace Js
         JavascriptFunction* debugObjectDebugModeGetterFunction;
         JavascriptFunction* __proto__getterFunction;
         JavascriptFunction* __proto__setterFunction;
+        JavascriptFunction* arrayIteratorPrototypeBuiltinNextFunction;
         DynamicObject* mathObject;
         // SIMD_JS
         DynamicObject* simdObject;

--- a/lib/Runtime/Library/TypedArray.h
+++ b/lib/Runtime/Library/TypedArray.h
@@ -170,6 +170,7 @@ namespace Js
         static Var CreateNewInstanceFromIterableObj(RecyclableObject *object, ScriptContext *scriptContext, uint32 elementSize, PFNCreateTypedArray pfnCreateTypedArray);
         static Var CreateNewInstance(Arguments& args, ScriptContext* scriptContext, uint32 elementSize, PFNCreateTypedArray pfnCreateTypedArray );
         static int32 ToLengthChecked(Var lengthVar, uint32 elementSize, ScriptContext* scriptContext);
+        static bool ArrayIteratorPrototypeHasUserDefinedNext(ScriptContext *scriptContext);
 
         virtual void* GetCompareElementsFunction() = 0;
 

--- a/test/typedarray/TypedArrayBuiltins.baseline
+++ b/test/typedarray/TypedArrayBuiltins.baseline
@@ -1,5 +1,0 @@
-*** Running test #1 (0): TypedArray builtin properties can't be overwritten, but writing to them does not throw an error
-PASSED
-*** Running test #2 (1): TypedArray constructed out of an iterable object
-PASSED
-Summary of tests: total executed: 2; passed: 2; failed: 0

--- a/test/typedarray/rlexe.xml
+++ b/test/typedarray/rlexe.xml
@@ -26,9 +26,8 @@
   <test>
     <default>
       <files>TypedArrayBuiltins.js</files>
-      <baseline>TypedArrayBuiltins.baseline</baseline>
       <tags>typedarray</tags>
-      <compile-flags>-ES6TypedArrayExtensions</compile-flags>
+      <compile-flags>-ES6TypedArrayExtensions -args summary -endargs</compile-flags>
     </default>
   </test>
   <test>


### PR DESCRIPTION
TypedArray constructor uses the fast path for array on an array even if %ArrayIteratorPrototype%.next
is changed by user code. Correct behavior is to treat it as an iterable object and invoke
TypedArray(object).
Fix by adding extra conditions (essentially testing if %ArrayIteratorPrototype%.next is the built-in version)
under which TypedArray(object) will be used.
Tweak unit test to cover this case.
