### PR TITLE
Returning nullptr in preReserved Virtual Alloc on low virtual memory(OOM)

### DIFF
--- a/lib/Common/Memory/VirtualAllocWrapper.cpp
+++ b/lib/Common/Memory/VirtualAllocWrapper.cpp
@@ -319,9 +319,11 @@ LPVOID PreReservedVirtualAllocWrapper::Alloc(LPVOID lpAddress, size_t dwSize, DW
 
                 allocatedAddress = (char *)VirtualAlloc(addressToReserve, dwSize, MEM_COMMIT, allocProtectFlags);
 
-                AssertMsg(allocatedAddress != nullptr, "If no space to allocate, then how did we fetch this address from the tracking bit vector?");
-                VirtualProtect(allocatedAddress, dwSize, protectFlags, &oldProtect);
-                AssertMsg(oldProtect == (PAGE_EXECUTE_READWRITE), "CFG Bitmap gets allocated and bits will be set to invalid only upon passing these flags.");
+                if (allocatedAddress != nullptr)
+                {
+                    VirtualProtect(allocatedAddress, dwSize, protectFlags, &oldProtect);
+                    AssertMsg(oldProtect == (PAGE_EXECUTE_READWRITE), "CFG Bitmap gets allocated and bits will be set to invalid only upon passing these flags.");
+                }
             }
             else
 #endif


### PR DESCRIPTION
We are currently asserting when we can't allocate any more memory from the
pre-reserved region due to low virtual memory on the system.
We have hit low virtual memory limits on web crawler runs.
We should ideally return nullptr, and the call site will take care of reporting the OOM failure.
