### PR TITLE
Assert with Array.prototype.map and ES5Array.

### DIFF
--- a/lib/Runtime/Library/JavascriptArray.cpp
+++ b/lib/Runtime/Library/JavascriptArray.cpp
@@ -8976,9 +8976,6 @@ Case0:
         }
         else
         {
-            // Source was not an array or TypedArray, return object is definitely a JavascriptArray
-            Assert(newArr);
-
             for (uint32 k = 0; k < length; k++)
             {
                 if (!JavascriptOperators::HasItem(obj, k))
@@ -8993,7 +8990,14 @@ Case0:
                     JavascriptNumber::ToVar(k, scriptContext),
                     obj);
 
-                newArr->DirectSetItemAt(k, mappedValue);
+                if (newArr)
+                {
+                    newArr->DirectSetItemAt(k, mappedValue);
+                }
+                else
+                {
+                    JavascriptArray::SetArrayLikeObjects(RecyclableObject::FromVar(newObj), k, mappedValue);
+                }
             }
         }
 

--- a/test/Bugs/bug_es5array.js
+++ b/test/Bugs/bug_es5array.js
@@ -1,0 +1,12 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+var func1 = function() {
+    var ary = new Array(1);
+    ary.map(function(a) { });
+}
+
+func1();
+print("Pass");

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -258,4 +258,10 @@
       <compile-flags>-on:prelowererpeeps</compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>bug_es5array.js</files>
+      <compile-flags>-off:NativeArray -ForceES5Array</compile-flags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
In the EntryMap function, we did not handle the ES5Array correctly, as in the case of ES5Array the newArr will be null. Fixed that as it is done in other APIs.
