### PR TITLE
xplat: build lib/Runtime/Language, lib/Runtime/Math

### DIFF
--- a/lib/Common/CommonPal.h
+++ b/lib/Common/CommonPal.h
@@ -31,7 +31,6 @@ typedef wchar_t char16;
 #else // !_WIN32
 
 #define USING_PAL_STDLIB 1
-
 #include "inc/pal.h"
 #include "inc/rt/palrt.h"
 #include "inc/rt/no_sal2.h"
@@ -296,8 +295,9 @@ BOOL WINAPI GetModuleHandleEx(
 // and then use the stack size to calculate the stack base
 int GetCurrentThreadStackBounds(char** stackBase, char** stackEnd);
 
-// xplat-todo: cryptographically secure PRNG?
 errno_t rand_s(unsigned int* randomValue);
+errno_t __cdecl _ultow_s(unsigned _Value, WCHAR *_Dst, size_t _SizeInWords, int _Radix);
+errno_t __cdecl _ui64tow_s(unsigned __int64 _Value, WCHAR *_Dst, size_t _SizeInWords, int _Radix);
 
 #define MAXUINT32   ((uint32_t)~((uint32_t)0))
 #define MAXINT32    ((int32_t)(MAXUINT32 >> 1))
@@ -335,6 +335,13 @@ errno_t rand_s(unsigned int* randomValue);
 #define _NOEXCEPT_ throw()
 #else
 #define _NOEXCEPT_ noexcept
+#endif
+
+#ifdef _MSC_VER
+extern "C" PVOID _ReturnAddress(VOID);
+#pragma intrinsic(_ReturnAddress)
+#else
+#define _ReturnAddress() __builtin_return_address(0)
 #endif
 
 // xplat-todo: can we get rid of this for clang?

--- a/lib/Common/Memory/RecyclerFastAllocator.h
+++ b/lib/Common/Memory/RecyclerFastAllocator.h
@@ -49,7 +49,7 @@ public:
 #endif
         size_t sizeCat = GetAlignedAllocSize();
         Assert(HeapInfo::IsSmallObject(sizeCat));
-        char * memBlock = allocator.InlinedAlloc<(ObjectInfoBits)(attributes & InternalObjectInfoBitMask)>(recycler, sizeCat);
+        char * memBlock = allocator.template InlinedAlloc<(ObjectInfoBits)(attributes & InternalObjectInfoBitMask)>(recycler, sizeCat);
 
         if (memBlock == nullptr)
         {

--- a/lib/Runtime/Base/CMakeLists.txt
+++ b/lib/Runtime/Base/CMakeLists.txt
@@ -1,6 +1,3 @@
-# xplat-todo: This is a skeleton make file and not used in build yet.
-# Please add this to build and fix issues.
-
 add_library (Chakra.Runtime.Base
     CallInfo.cpp
     CharStringCache.cpp

--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -741,8 +741,8 @@ private:
 #ifdef ENABLE_GLOBALIZATION
         TIME_ZONE_INFORMATION timeZoneInfo;
         uint lastTimeZoneUpdateTickCount;
-        DaylightTimeHelper daylightTimeHelper;
 #endif // ENABLE_GLOBALIZATION
+        DaylightTimeHelper daylightTimeHelper;
 
         HostScriptContext * hostScriptContext;
         HaltCallback* scriptEngineHaltCallback;
@@ -860,9 +860,7 @@ private:
         bool isRootTrackerScriptContext;
 #endif
 
-#ifdef ENABLE_GLOBALIZATION
         DaylightTimeHelper *GetDaylightTimeHelper() { return &daylightTimeHelper; }
-#endif // ENABLE_GLOBALIZATION
 
         bool IsClosed() const { return isClosed; }
         bool IsActuallyClosed() const { return isScriptContextActuallyClosed; }

--- a/lib/Runtime/ByteCode/CMakeLists.txt
+++ b/lib/Runtime/ByteCode/CMakeLists.txt
@@ -1,6 +1,3 @@
-# xplat-todo: This is a skeleton make file and not used in build yet.
-# Please add this to build and fix issues.
-
 add_library (Chakra.Runtime.ByteCode
     AsmJsByteCodeDumper.cpp
     AsmJsByteCodeWriter.cpp

--- a/lib/Runtime/CMakeLists.txt
+++ b/lib/Runtime/CMakeLists.txt
@@ -11,3 +11,4 @@ include_directories(
 add_subdirectory (Base)
 add_subdirectory (ByteCode)
 add_subdirectory (Language)
+add_subdirectory (Math)

--- a/lib/Runtime/CMakeLists.txt
+++ b/lib/Runtime/CMakeLists.txt
@@ -10,3 +10,4 @@ include_directories(
 
 add_subdirectory (Base)
 add_subdirectory (ByteCode)
+add_subdirectory (Language)

--- a/lib/Runtime/Language/CMakeLists.txt
+++ b/lib/Runtime/Language/CMakeLists.txt
@@ -1,6 +1,3 @@
-# xplat-todo: This is a skeleton make file and not used in build yet.
-# Please add this to build and fix issues.
-
 add_library (Chakra.Runtime.Language
     AsmJs.cpp
     AsmJsByteCodeGenerator.cpp
@@ -31,39 +28,43 @@ add_library (Chakra.Runtime.Language
     ReadOnlyDynamicProfileInfo.cpp
     RuntimeLanguagePch.cpp
     SimdBool16x8Operation.cpp
-    SimdBool16x8OperationX86X64.cpp
+    # SimdBool16x8OperationX86X64.cpp
     SimdBool32x4Operation.cpp
-    SimdBool32x4OperationX86X64.cpp
+    # SimdBool32x4OperationX86X64.cpp
     SimdBool8x16Operation.cpp
-    SimdBool8x16OperationX86X64.cpp
+    # SimdBool8x16OperationX86X64.cpp
     SimdFloat32x4Operation.cpp
-    SimdFloat32x4OperationX86X64.cpp
+    # SimdFloat32x4OperationX86X64.cpp
     SimdFloat64x2Operation.cpp
-    SimdFloat64x2OperationX86X64.cpp
+    # SimdFloat64x2OperationX86X64.cpp
     SimdInt16x8Operation.cpp
-    SimdInt16x8OperationX86X64.cpp
+    # SimdInt16x8OperationX86X64.cpp
     SimdInt32x4Operation.cpp
-    SimdInt32x4OperationX86X64.cpp
+    # SimdInt32x4OperationX86X64.cpp
     SimdInt8x16Operation.cpp
-    SimdInt8x16OperationX86X64.cpp
+    # SimdInt8x16OperationX86X64.cpp
     SimdUint16x8Operation.cpp
-    SimdUint16x8OperationX86X64.cpp
+    # SimdUint16x8OperationX86X64.cpp
     SimdUint32x4Operation.cpp
-    SimdUint32x4OperationX86X64.cpp
+    # SimdUint32x4OperationX86X64.cpp
     SimdUint8x16Operation.cpp
-    SimdUint8x16OperationX86X64.cpp
-    SimdUtils.cpp
+    # SimdUint8x16OperationX86X64.cpp
+    # SimdUtils.cpp
     SourceDynamicProfileManager.cpp
     SourceTextModuleRecord.cpp
     StackTraceArguments.cpp
     TaggedInt.cpp
     ValueType.cpp
-    amd64\AsmJsJitTemplate.cpp
-    amd64\StackFrame.cpp
-    arm64\StackFrame.cpp
-    arm\StackFrame.cpp
-    i386\AsmJsJitTemplate.cpp
-    i386\StackFrame.cpp
+    amd64/AsmJsJitTemplate.cpp
+    # amd64/StackFrame.cpp
+    # arm64/StackFrame.cpp
+    # arm/StackFrame.cpp
+    # i386/AsmJsJitTemplate.cpp
+    # i386/StackFrame.cpp
+    )
+
+include_directories (
+    ../Math
     )
 
 target_include_directories (

--- a/lib/Runtime/Language/CacheOperators.inl
+++ b/lib/Runtime/Language/CacheOperators.inl
@@ -435,7 +435,7 @@ namespace Js
             // polymorphic inline cache. Once resized, bailouts would populate only the new set of caches and full JIT would
             // continue to use to old set of caches.
             Assert(!info->AllowResizingPolymorphicInlineCache() || info->GetFunctionBody());
-            if((includeTypePropertyCache && !createTypePropertyCache || info->AllowResizingPolymorphicInlineCache()) &&
+            if(((includeTypePropertyCache && !createTypePropertyCache) || info->AllowResizingPolymorphicInlineCache()) &&
                 polymorphicInlineCache->HasDifferentType<IsAccessor>(isProto, type, typeWithoutProperty))
             {
                 if(info->AllowResizingPolymorphicInlineCache() && polymorphicInlineCache->CanAllocateBigger())

--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -1833,7 +1833,7 @@ namespace Js
                 // Allocate invalidVar on GC instead of stack since this InterpreterStackFrame will out live the current real frame
                 Js::RecyclableObject* invalidVar = (Js::RecyclableObject*)RecyclerNewPlusLeaf(functionScriptContext->GetRecycler(), sizeof(Js::RecyclableObject), Var);
                 AnalysisAssert(invalidVar);
-                memset(invalidVar, 0xFE, sizeof(Js::RecyclableObject));
+                memset(reinterpret_cast<void*>(invalidVar), 0xFE, sizeof(Js::RecyclableObject));
                 newInstance = setup.InitializeAllocation(allocation, executeFunction->GetHasImplicitArgIns(), doProfile, loopHeaderArray, stackAddr, invalidVar);
 #else
                 newInstance = setup.InitializeAllocation(allocation, executeFunction->GetHasImplicitArgIns(), doProfile, loopHeaderArray, stackAddr);
@@ -1894,7 +1894,7 @@ namespace Js
 
 #if DBG
             Js::RecyclableObject * invalidStackVar = (Js::RecyclableObject*)_alloca(sizeof(Js::RecyclableObject));
-            memset(invalidStackVar, 0xFE, sizeof(Js::RecyclableObject));
+            memset(reinterpret_cast<void*>(invalidStackVar), 0xFE, sizeof(Js::RecyclableObject));
             newInstance = setup.InitializeAllocation(allocation, executeFunction->GetHasImplicitArgIns() && !isAsmJs, doProfile, loopHeaderArray, stackAddr, invalidStackVar);
 #else
             newInstance = setup.InitializeAllocation(allocation, executeFunction->GetHasImplicitArgIns() && !isAsmJs, doProfile, loopHeaderArray, stackAddr);
@@ -2769,7 +2769,7 @@ namespace Js
         Output::Print(_u("\n"));
     }
 
-#ifndef TEMP_DISABLE_ASMJS 
+#ifndef TEMP_DISABLE_ASMJS
     // Function memory allocation should be done the same way as
     // T AsmJsCommunEntryPoint(Js::ScriptFunction* func, ...)  (AsmJSJitTemplate.cpp)
     // update any changes there
@@ -3718,7 +3718,7 @@ namespace Js
         {
             flags |= CallFlags_NotUsed;
             Arguments args(CallInfo((CallFlags)flags, playout->ArgCount), m_outParams);
-            AssertMsg(args.Info.Flags == flags, "Flags don't fit into the CallInfo field?");
+            AssertMsg(static_cast<unsigned>(args.Info.Flags) == flags, "Flags don't fit into the CallInfo field?");
             if (spreadIndices != nullptr)
             {
                 JavascriptFunction::CallSpreadFunction(function, function->GetEntryPoint(), args, spreadIndices);
@@ -3732,7 +3732,7 @@ namespace Js
         {
             flags |= CallFlags_Value;
             Arguments args(CallInfo((CallFlags)flags, playout->ArgCount), m_outParams);
-            AssertMsg(args.Info.Flags == flags, "Flags don't fit into the CallInfo field?");
+            AssertMsg(static_cast<unsigned>(args.Info.Flags) == flags, "Flags don't fit into the CallInfo field?");
             if (spreadIndices != nullptr)
             {
                 SetReg((RegSlot)playout->Return, JavascriptFunction::CallSpreadFunction(function, function->GetEntryPoint(), args, spreadIndices));
@@ -5298,21 +5298,17 @@ namespace Js
 
         Assert(VirtualTableInfo<JavascriptArray>::HasVirtualTable(array));
         SparseArraySegment<Var>* lastUsedSeg = (SparseArraySegment<Var>*)array->GetLastUsedSegment();
-        if (index < lastUsedSeg->left)
+        if (index >= lastUsedSeg->left)
         {
-            goto helper;
+            uint32 index2 = index - lastUsedSeg->left;
+            if (index2 < lastUsedSeg->size)
+            {
+                // Successful fastpath
+                array->DirectSetItemInLastUsedSegmentAt(index2, value);
+                return;
+            }
         }
 
-        uint32 index2 = index - lastUsedSeg->left;
-
-        if (index2 < lastUsedSeg->size)
-        {
-            // Successful fastpath
-            array->DirectSetItemInLastUsedSegmentAt(index2, value);
-            return;
-        }
-
-    helper:
         ScriptContext* scriptContext = array->GetScriptContext();
         JavascriptOperators::SetItem(array, array, index, value, scriptContext);
     }
@@ -7588,7 +7584,7 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
         values[5] = (int16) GetRegRawInt(playout->I6);
         values[6] = (int16) GetRegRawInt(playout->I7);
         values[7] = (int16) GetRegRawInt(playout->I8);
-        
+
         AsmJsSIMDValue result = SIMDInt16x8Operation::OpInt16x8(values);
         SetRegRawSimd(playout->I8_0, result);
     }
@@ -7621,7 +7617,7 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
     template <class T>
     void InterpreterStackFrame::OP_SimdUint16x8(const unaligned T* playout)
     {
-        
+
         uint16 values[8];
         values[0] = (uint16) GetRegRawInt(playout->I1);
         values[1] = (uint16) GetRegRawInt(playout->I2);
@@ -7631,7 +7627,7 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
         values[5] = (uint16) GetRegRawInt(playout->I6);
         values[6] = (uint16) GetRegRawInt(playout->I7);
         values[7] = (uint16) GetRegRawInt(playout->I8);
-        
+
         AsmJsSIMDValue result = SIMDUint16x8Operation::OpUint16x8(values);
         SetRegRawSimd(playout->U8_0, result);
     }
@@ -7686,7 +7682,7 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
         values[5] = GetRegRawInt(playout->I6) ? true : false;
         values[6] = GetRegRawInt(playout->I7) ? true : false;
         values[7] = GetRegRawInt(playout->I8) ? true : false;
-        
+
         AsmJsSIMDValue result = SIMDBool16x8Operation::OpBool16x8(values);
         SetRegRawSimd(playout->B8_0, result);
     }
@@ -7711,7 +7707,7 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
         values[13] = GetRegRawInt(playout->I14) ? true : false;
         values[14] = GetRegRawInt(playout->I15) ? true : false;
         values[15] = GetRegRawInt(playout->I16) ? true : false;
-        
+
         AsmJsSIMDValue result = SIMDBool8x16Operation::OpBool8x16(values);
         SetRegRawSimd(playout->B16_0, result);
     }
@@ -8334,7 +8330,7 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
         return JavascriptOperators::OP_ResumeYield(yieldData, iterator);
     }
 
-    void* InterpreterStackFrame::operator new(size_t byteSize, void* previousAllocation)
+    void* InterpreterStackFrame::operator new(size_t byteSize, void* previousAllocation) throw()
     {
         //
         // Placement 'new' is used by InterpreterStackFrame to initialize the C++ object on the RcInterpreter's
@@ -8350,7 +8346,7 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
         return previousAllocation;
     }
 
-    void __cdecl InterpreterStackFrame::operator delete(void * allocationToFree, void * previousAllocation)
+    void __cdecl InterpreterStackFrame::operator delete(void * allocationToFree, void * previousAllocation) throw()
     {
         AssertMsg(allocationToFree == previousAllocation, "Memory locations should match");
         AssertMsg(false, "This function should never actually be called");

--- a/lib/Runtime/Language/JavascriptConversion.cpp
+++ b/lib/Runtime/Language/JavascriptConversion.cpp
@@ -9,9 +9,6 @@
 #include "Library/DateImplementation.h"
 #include "Library/JavascriptDate.h"
 
-extern "C" PVOID _ReturnAddress(VOID);
-#pragma intrinsic(_ReturnAddress)
-
 namespace Js
 {
     static const double k_2to16 = 65536.0;

--- a/lib/Runtime/Language/JavascriptExceptionOperators.cpp
+++ b/lib/Runtime/Language/JavascriptExceptionOperators.cpp
@@ -3,7 +3,6 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "RuntimeLanguagePch.h"
-#include "shlwapi.h"
 #include "Language/InterpreterStackFrame.h"
 
 #ifdef _M_IX86

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -20,7 +20,7 @@
 #include "Library/ES5Array.h"
 
 #ifndef SCRIPT_DIRECT_TYPE
-typedef enum JsNativeValueType
+typedef enum JsNativeValueType: int
 {
     JsInt8Type,
     JsUint8Type,
@@ -743,7 +743,7 @@ namespace Js
                 aLeft = JavascriptConversion::ToPrimitive(aLeft, JavascriptHint::HintNumber, scriptContext);
             }
             //BugFix: When @@ToPrimitive of an object is overridden with a function that returns null/undefined
-            //this helper will fall into a inescapable goto loop as the checks for null/undefined were outside of the path 
+            //this helper will fall into a inescapable goto loop as the checks for null/undefined were outside of the path
             return RelationalComparisonHelper(aLeft, aRight, scriptContext, leftFirst, undefinedAs);
         }
 
@@ -6791,7 +6791,7 @@ CommonNumber:
 
     Var* JavascriptOperators::OP_NewScopeSlotsWithoutPropIds(unsigned int count, int scopeIndex, ScriptContext *scriptContext, FunctionBody *functionBody)
     {
-        DebuggerScope* scope = Constants::FunctionBodyUnavailable;
+        DebuggerScope* scope = reinterpret_cast<DebuggerScope*>(Constants::FunctionBodyUnavailable);
         if (scopeIndex != DebuggerScope::InvalidScopeIndex)
         {
             AssertMsg(functionBody->GetScopeObjectChain(), "A scope chain should always be created when there are new scope slots for blocks.");

--- a/lib/Runtime/Language/StackTraceArguments.cpp
+++ b/lib/Runtime/Language/StackTraceArguments.cpp
@@ -3,7 +3,6 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "RuntimeLanguagePch.h"
-#include "shlwapi.h"
 
 namespace Js {
 

--- a/lib/Runtime/Language/TaggedInt.cpp
+++ b/lib/Runtime/Language/TaggedInt.cpp
@@ -59,7 +59,8 @@ namespace Js
         //
 
 #if INT32VAR
-        __try
+        // 0x80000000 / -1 (or %) will trigger an integer overflow exception
+        if (nLeft != INT_MIN || nRight != -1)
         {
 #endif
             if ((nLeft % nRight) == 0)
@@ -75,9 +76,6 @@ namespace Js
             }
 #if INT32VAR
         }
-        // 0x80000000 / -1 will trigger an integer overflow exception
-        __except(GetExceptionCode() == STATUS_INTEGER_OVERFLOW)
-        {}
 #endif
         //
         // Fallback to creating a floating-point number to preserve the fractional portion.
@@ -111,15 +109,15 @@ namespace Js
         }
         int result;
 #if INT32VAR
-        __try
+        // 0x80000000 / -1 (or %) will trigger an integer overflow exception
+        if (nLeft != INT_MIN || nRight != -1)
         {
 #endif
             result = nLeft % nRight;
 
 #if INT32VAR
         }
-        // 0x80000000 / -1 will trigger an integer overflow exception
-        __except(GetExceptionCode() == STATUS_INTEGER_OVERFLOW)
+        else
         {
             int64 left64 = nLeft;
             int64 right64 = nRight;
@@ -196,7 +194,7 @@ namespace Js
         __int64 int64Result = (__int64)nLeft * (__int64)nRight;
         nResult = (int)int64Result;
 
-        if (((int64Result >> 32) == 0 && (nResult > 0 || nResult == 0 && nLeft+nRight >= 0))
+        if (((int64Result >> 32) == 0 && (nResult > 0 || (nResult == 0 && nLeft+nRight >= 0)))
             || ((int64Result >> 32) == -1 && nResult < 0))
         {
             return JavascriptNumber::ToVar(nResult,scriptContext);
@@ -224,7 +222,7 @@ namespace Js
         nResult = (int)int64Result;
 
         if (((int64Result >> 32) == 0 && nResult > 0)
-            || (int64Result >> 32) == -1 && nResult < 0)
+            || ((int64Result >> 32) == -1 && nResult < 0))
         {
             if (!TaggedInt::IsOverflow(nResult))
             {

--- a/lib/Runtime/Language/ValueType.cpp
+++ b/lib/Runtime/Language/ValueType.cpp
@@ -555,7 +555,7 @@ bool ValueType::IsLikelyArray() const
 
 bool ValueType::IsNotArray() const
 {
-    return IsNotObject() || IsObject() && GetObjectType() > ObjectType::Object && GetObjectType() != ObjectType::Array;
+    return IsNotObject() || (IsObject() && GetObjectType() > ObjectType::Object && GetObjectType() != ObjectType::Array);
 }
 
 bool ValueType::IsArrayOrObjectWithArray() const
@@ -572,7 +572,7 @@ bool ValueType::IsNotArrayOrObjectWithArray() const
 {
     return
         IsNotObject() ||
-        IsObject() && GetObjectType() != ObjectType::ObjectWithArray && GetObjectType() != ObjectType::Array;
+        (IsObject() && GetObjectType() != ObjectType::ObjectWithArray && GetObjectType() != ObjectType::Array);
 }
 
 bool ValueType::IsNativeArray() const
@@ -591,7 +591,7 @@ bool ValueType::IsNotNativeArray() const
         IsNotObject() ||
         (
             IsObject() &&
-            (GetObjectType() != ObjectType::ObjectWithArray && GetObjectType() != ObjectType::Array || HasVarElements())
+            ((GetObjectType() != ObjectType::ObjectWithArray && GetObjectType() != ObjectType::Array) || HasVarElements())
         );
 }
 
@@ -947,7 +947,7 @@ bool ValueType::IsSubsetOf(
         // type is considered to be a subset of the indefinite value type because neither will participate in type
         // specialization.
         if(other.IsUnknownNumber() &&
-            (isAggressiveIntTypeSpecEnabled && IsLikelyInt() || isFloatSpecEnabled && IsLikelyFloat()))
+            ((isAggressiveIntTypeSpecEnabled && IsLikelyInt()) || (isFloatSpecEnabled && IsLikelyFloat())))
         {
             return true;
         }
@@ -967,12 +967,12 @@ bool ValueType::IsSubsetOf(
         return
             (!_this.OneOn(Bits::Likely) || _other.OneOn(Bits::Likely)) &&
             (
-                (
+                ((
                     _this.IsTaggedInt() ||
-                    _this.IsLikelyTaggedInt() && !_other.IsTaggedInt() ||
-                    _this.IsLikelyInt() && !_other.IsLikelyTaggedInt()
-                ) && !_other.IsLikelyFloat() ||
-                _this.IsLikelyFloat() && !_other.IsLikelyInt() ||
+                    (_this.IsLikelyTaggedInt() && !_other.IsTaggedInt()) ||
+                    (_this.IsLikelyInt() && !_other.IsLikelyTaggedInt())
+                ) && !_other.IsLikelyFloat()) ||
+                (_this.IsLikelyFloat() && !_other.IsLikelyInt()) ||
                 _other.IsLikelyUnknownNumber()
             );
     }
@@ -983,7 +983,7 @@ bool ValueType::IsSubsetOf(
     if(OneOn(Bits::Object))
     {
         if(!other.OneOn(Bits::Object))
-            return other.OneOn(Bits::PrimitiveOrObject) || !other.IsDefinite() && other.CanMergeToObject();
+            return other.OneOn(Bits::PrimitiveOrObject) || (!other.IsDefinite() && other.CanMergeToObject());
     }
     else
     {
@@ -995,8 +995,8 @@ bool ValueType::IsSubsetOf(
         return true; // object types other than UninitializedObject are a subset of UninitializedObject regardless of the Likely bit
     if(GetObjectType() != other.GetObjectType())
         return false;
-    if(!OneOn(Bits::Likely) && other.OneOn(Bits::Likely) ||
-        other.GetObjectType() != ObjectType::ObjectWithArray && other.GetObjectType() != ObjectType::Array)
+    if((!OneOn(Bits::Likely) && other.OneOn(Bits::Likely)) ||
+        (other.GetObjectType() != ObjectType::ObjectWithArray && other.GetObjectType() != ObjectType::Array))
     {
         return true;
     }
@@ -1009,7 +1009,7 @@ bool ValueType::IsSubsetOf(
     return
         (HasNoMissingValues() || !other.HasNoMissingValues() || !isArrayMissingValueCheckHoistEnabled) &&
         (
-            (!HasNonInts() || other.HasNonInts()) && (!HasNonFloats() || other.HasNonFloats()) ||
+            ((!HasNonInts() || other.HasNonInts()) && (!HasNonFloats() || other.HasNonFloats())) ||
             !isNativeArrayEnabled
         );
 }
@@ -2169,13 +2169,13 @@ void ValueType::RunUnitTests()
                 {
                     Assert(isSubsetWithTypeSpecEnabled);
                 }
-                else if(!t0.IsDefinite() && t1.IsDefinite() || t0.GetObjectType() != t1.GetObjectType())
+                else if((!t0.IsDefinite() && t1.IsDefinite()) || t0.GetObjectType() != t1.GetObjectType())
                 {
                     Assert(!isSubsetWithTypeSpecEnabled);
                 }
                 else if(
-                    t0.IsDefinite() && !t1.IsDefinite() ||
-                    t0.GetObjectType() != ObjectType::ObjectWithArray && t0.GetObjectType() != ObjectType::Array)
+                    (t0.IsDefinite() && !t1.IsDefinite()) ||
+                    (t0.GetObjectType() != ObjectType::ObjectWithArray && t0.GetObjectType() != ObjectType::Array))
                 {
                     Assert(isSubsetWithTypeSpecEnabled);
                 }

--- a/lib/Runtime/Library/ArgumentsObject.h
+++ b/lib/Runtime/Library/ArgumentsObject.h
@@ -6,7 +6,7 @@
 
 namespace Js
 {
-    class ArgumentsObject abstract : public DynamicObject
+    class ArgumentsObject _ABSTRACT : public DynamicObject
     {
     private:
         static PropertyId specialPropertyIds[];

--- a/lib/Runtime/Library/CompoundString.h
+++ b/lib/Runtime/Library/CompoundString.h
@@ -1287,7 +1287,7 @@ namespace Js
             return;
         }
         AnalysisAssert(convertBuffer == localConvertBuffer);
-        AppendGeneric(localConvertBuffer, appendCharLength, toString, appendChars);
+        AppendGeneric(static_cast<const char16* const>(localConvertBuffer), appendCharLength, toString, appendChars);
     }
 
     template<CharCount AppendCharLengthPlusOne>

--- a/lib/Runtime/Library/DateImplementation.cpp
+++ b/lib/Runtime/Library/DateImplementation.cpp
@@ -1004,7 +1004,7 @@ Error:
         return true;
     }
 
-    boolean DateImplementation::UtcTimeFromStrCore(
+    bool DateImplementation::UtcTimeFromStrCore(
         __in_ecount_z(ulength) const char16 *psz,
         unsigned int ulength,
         double &retVal,

--- a/lib/Runtime/Library/DateImplementation.h
+++ b/lib/Runtime/Library/DateImplementation.h
@@ -79,16 +79,18 @@ namespace Js {
             bool fDst;
         };
 
+#ifdef ENABLE_GLOBALIZATION
         template <class ScriptContext>
         static long GetDaylightBias(const TIME_ZONE_INFORMATION *const pTz, const ScriptContext *const scriptContext);
         template <class ScriptContext>
         static long GetStandardBias(const TIME_ZONE_INFORMATION *const pTz, const ScriptContext *const scriptContext);
+#endif
 
         template <class ScriptContext>
         static double GetTvLcl(double tv, ScriptContext * scriptContext, TZD *ptzd = nullptr);
         template <class ScriptContext>
         static double GetTvUtc(double tv, ScriptContext * scriptContext);
-        static boolean UtcTimeFromStrCore(
+        static bool UtcTimeFromStrCore(
             __in_ecount_z(ulength) const char16 *psz,
             unsigned int ulength,
             double &retVal,
@@ -295,6 +297,7 @@ namespace Js {
         friend HiResTimer;
     };
 
+#ifdef ENABLE_GLOBALIZATION
     ///
     /// Gets the daylight bias to use, in minutes. (Shared with hybrid debugging, which may use a fake scriptContext.)
     ///
@@ -316,6 +319,7 @@ namespace Js {
         Assert(scriptContext);
         return pTz->StandardBias;
     }
+#endif
 
     ///
     /// Use tv as the UTC time and return the corresponding local time. (Shared with hybrid debugging, which may use a fake scriptContext.)

--- a/lib/Runtime/Math/JavascriptMath.cpp
+++ b/lib/Runtime/Math/JavascriptMath.cpp
@@ -95,26 +95,26 @@ namespace Js
 
         Var JavascriptMath::And_Full(Var aLeft, Var aRight, ScriptContext* scriptContext)
         {
-            int32 and = And_Helper(aLeft, aRight, scriptContext);
-            return JavascriptNumber::ToVar(and, scriptContext);
+            int32 value = And_Helper(aLeft, aRight, scriptContext);
+            return JavascriptNumber::ToVar(value, scriptContext);
         }
 
         Var JavascriptMath::And_InPlace(Var aLeft, Var aRight, ScriptContext* scriptContext, JavascriptNumber* result)
         {
-            int32 and = And_Helper(aLeft, aRight, scriptContext);
-            return JavascriptNumber::ToVarInPlace(and, scriptContext, result);
+            int32 value = And_Helper(aLeft, aRight, scriptContext);
+            return JavascriptNumber::ToVarInPlace(value, scriptContext, result);
         }
 
         Var JavascriptMath::Or_Full(Var aLeft, Var aRight, ScriptContext* scriptContext)
         {
-            int32 or = Or_Helper(aLeft, aRight, scriptContext);
-            return JavascriptNumber::ToVar(or, scriptContext);
+            int32 value = Or_Helper(aLeft, aRight, scriptContext);
+            return JavascriptNumber::ToVar(value, scriptContext);
         }
 
         Var JavascriptMath::Or_InPlace(Var aLeft, Var aRight, ScriptContext* scriptContext, JavascriptNumber* result)
         {
-            int32 or = Or_Helper(aLeft, aRight, scriptContext);
-            return JavascriptNumber::ToVarInPlace(or, scriptContext, result);
+            int32 value = Or_Helper(aLeft, aRight, scriptContext);
+            return JavascriptNumber::ToVarInPlace(value, scriptContext, result);
         }
 
         Var JavascriptMath::Xor_Full(Var aLeft, Var aRight, ScriptContext* scriptContext)

--- a/pal/inc/pal_mstypes.h
+++ b/pal/inc/pal_mstypes.h
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -187,21 +187,21 @@ extern "C" {
 // LLP64 => longs = 32 bits, long long = 64 bits)
 //
 // To handle this difference, we #define long to be int (and thus 32 bits) when
-// compiling those files.  (See the bottom of this file or search for 
-// #define long to see where we do this.)  
+// compiling those files.  (See the bottom of this file or search for
+// #define long to see where we do this.)
 //
-// But this fix is more complicated than it seems, because we also use the 
+// But this fix is more complicated than it seems, because we also use the
 // preprocessor to #define __int64 to long for LP64 architectures (__int64
-// isn't a builtin in gcc).   We don't want __int64 to be an int (by cascading 
-// macro rules).  So we play this little trick below where we add 
-// __cppmungestrip before "long", which is what we're really #defining __int64 
-// to.  The preprocessor sees __cppmungestriplong as something different than 
-// long, so it doesn't replace it with int.  The during the cppmunge phase, we 
+// isn't a builtin in gcc).   We don't want __int64 to be an int (by cascading
+// macro rules).  So we play this little trick below where we add
+// __cppmungestrip before "long", which is what we're really #defining __int64
+// to.  The preprocessor sees __cppmungestriplong as something different than
+// long, so it doesn't replace it with int.  The during the cppmunge phase, we
 // remove the __cppmungestrip part, leaving long for the compiler to see.
 //
-// Note that we can't just use a typedef to define __int64 as long before 
-// #defining long because typedefed types can't be signedness-agnostic (i.e. 
-// they must be either signed or unsigned) and we want to be able to use 
+// Note that we can't just use a typedef to define __int64 as long before
+// #defining long because typedefed types can't be signedness-agnostic (i.e.
+// they must be either signed or unsigned) and we want to be able to use
 // __int64 as though it were intrinsic
 
 #ifdef BIT64
@@ -228,7 +228,7 @@ typedef __int16 int16_t;
 typedef unsigned __int16 uint16_t;
 typedef __int8 int8_t;
 #define __int8_t_defined
-    
+
 typedef unsigned __int8 uint8_t;
 #endif // PAL_IMPLEMENTATION
 
@@ -617,7 +617,7 @@ typedef char16_t WCHAR;
 #else // !PAL_STDCPP_COMPAT
 
 typedef wchar_t WCHAR;
-#if defined(__LINUX__) 
+#if defined(__LINUX__)
 #ifdef BIT64
 typedef long int intptr_t;
 typedef unsigned long int uintptr_t;
@@ -693,6 +693,15 @@ typedef LONG HRESULT;
 typedef LONG NTSTATUS;
 
 typedef union _LARGE_INTEGER {
+    struct {
+#if BIGENDIAN
+        LONG HighPart;
+        DWORD LowPart;
+#else
+        DWORD LowPart;
+        LONG HighPart;
+#endif
+    };
     struct {
 #if BIGENDIAN
         LONG HighPart;


### PR DESCRIPTION
Notable changes:
- InterpreterStackFrame.cpp: refactor code to get rid of a "goto", which
  was illegal as it skipped other variable initialization.
- TaggedInt.cpp: replaced __try/__except with explict test to deal with a
  floating point exception case.
- JavascriptMath.cpp: "and", "or" are reserved keywords and not allowed
  for variable names.
- pal_mstypes.h: LARGE_INTEGER should have an unnamed union member.

To be addressed:
- implement _ultow_s, _ui64tow_s
- design/implement xplat stack walker (RtlVirtualUnwind, ...)
- Simd only partially builds. The rest needs lots of functions declared in
  emmintrin.h/xmmintrin.h. But PAL conflicts with it. We have been copying
  some functions by hand into palrt.h, but that seems not maintainable.
