### PR TITLE
Fixing a subtle Switch Opt Assert

### DIFF
--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -8988,7 +8988,11 @@ GlobOpt::OptConstFoldUnary(
     case Js::OpCode::Ld_A:
         if (instr->HasBailOutInfo())
         {
-            Assert(instr->GetBailOutKind() == IR::BailOutExpectingInteger);
+            //The profile data for switch expr can be string and in GlobOpt we realize it is an int.
+            if(instr->GetBailOutKind() == IR::BailOutExpectingString)
+            {
+                throw Js::RejitException(RejitReason::DisableSwitchOptExpectingString);
+            }
             instr->ClearBailOutInfo();
         }
         value = intConstantValue;


### PR DESCRIPTION
Issue:
The interpreter profiles the switch expression as a string. But the
globopt sees the value of the expression as an Integer, due to effects
of constant folding and BailOnNoProfile.

Fix:
When such incompatibility is seen, we do a compile time rejit.
This is already done when we have a sym. But we were just asserting for
this in constant folding path.
