### PR TITLE
fix compact counter on detecting background access

### DIFF
--- a/lib/Backend/NativeCodeGenerator.cpp
+++ b/lib/Backend/NativeCodeGenerator.cpp
@@ -796,10 +796,6 @@ NativeCodeGenerator::CodeGen(PageAllocator * pageAllocator, CodeGenWorkItem* wor
         PROBE_STACK(scriptContext, Js::Constants::MinStackJITCompile);
     }
 
-#if DBG
-    Js::FunctionBody::AutoResetThreadState autoReset(workItem->GetFunctionBody());
-#endif
-
 #if ENABLE_DEBUG_CONFIG_OPTIONS
     if (!foreground && Js::Configuration::Global.flags.IsEnabled(Js::InduceCodeGenFailureFlag))
     {
@@ -1366,6 +1362,10 @@ NativeCodeGenerator::Process(JsUtil::Job *const job, JsUtil::ParallelThreadData 
 
     CodeGenWorkItem *const codeGenWork = static_cast<CodeGenWorkItem *>(job);
 
+#if DBG
+    Js::FunctionBody::AutoResetThreadState autoSet(codeGenWork->GetFunctionBody());
+#endif
+
     switch (codeGenWork->Type())
     {
     case JsLoopBodyWorkItemType:
@@ -1503,6 +1503,10 @@ NativeCodeGenerator::JobProcessed(JsUtil::Job *const job, const bool succeeded)
     Assert(job);
 
     CodeGenWorkItem *workItem = static_cast<CodeGenWorkItem *>(job);
+
+#if DBG
+    Js::FunctionBody::AutoResetThreadState autoReset(workItem->GetFunctionBody());
+#endif
 
     class AutoCleanup
     {

--- a/lib/Backend/NativeCodeGenerator.cpp
+++ b/lib/Backend/NativeCodeGenerator.cpp
@@ -796,6 +796,10 @@ NativeCodeGenerator::CodeGen(PageAllocator * pageAllocator, CodeGenWorkItem* wor
         PROBE_STACK(scriptContext, Js::Constants::MinStackJITCompile);
     }
 
+#if DBG
+    Js::FunctionBody::AutoResetThreadState autoReset(workItem->GetFunctionBody());
+#endif
+
 #if ENABLE_DEBUG_CONFIG_OPTIONS
     if (!foreground && Js::Configuration::Global.flags.IsEnabled(Js::InduceCodeGenFailureFlag))
     {

--- a/lib/Runtime/Base/CompactCounters.h
+++ b/lib/Runtime/Base/CompactCounters.h
@@ -45,9 +45,9 @@ namespace Js
         uint32 Get(CountT typeEnum) const
         {
 #if DBG
-            if (!bgThreadCallStarted && ThreadContext::GetContextForCurrentThread() == nullptr)
+            if (ThreadContext::GetContextForCurrentThread() == nullptr)
             {
-                bgThreadCallStarted = true;
+                Assert(bgThreadCallStarted == true);
             }
 #endif
             uint8 type = static_cast<uint8>(typeEnum);
@@ -76,9 +76,9 @@ namespace Js
         int32 GetSigned(CountT typeEnum) const
         {
 #if DBG
-            if (!bgThreadCallStarted && ThreadContext::GetContextForCurrentThread() == nullptr)
+            if (ThreadContext::GetContextForCurrentThread() == nullptr)
             {
-                bgThreadCallStarted = true;
+                Assert(bgThreadCallStarted == true);
             }
 #endif
 

--- a/lib/Runtime/Base/EtwTrace.cpp
+++ b/lib/Runtime/Base/EtwTrace.cpp
@@ -179,6 +179,10 @@ void EtwTrace::PerformRundown(bool start)
 
             scriptContext->MapFunction([&start] (FunctionBody* body)
             {
+#if DBG
+                Js::FunctionBody::AutoResetThreadState autoReset(body);
+#endif
+
                 if(body->HasInterpreterThunkGenerated())
                 {
                     if(start)

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -409,6 +409,24 @@ namespace Js
 #endif
     }
 
+#if DBG
+    FunctionBody::AutoResetThreadState::AutoResetThreadState(Js::FunctionBody* fb)
+        :functionBody(fb), foreground(ThreadContext::GetContextForCurrentThread() != nullptr)
+    {
+        if (!foreground)
+        {
+            alreadyInBackground = functionBody->EnterBackgroundCall();
+        }
+    }
+    FunctionBody::AutoResetThreadState::~AutoResetThreadState()
+    {
+        if (!foreground && !alreadyInBackground)
+        {
+            functionBody->LeaveBackgroundCall();
+        }
+    }
+#endif
+
 
     FunctionBody::FunctionBody(ScriptContext* scriptContext, const char16* displayName, uint displayNameLength, uint displayShortNameOffset, uint nestedCount,
         Utf8SourceInfo* utf8SourceInfo, uint uFunctionNumber, uint uScriptId,

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -1740,6 +1740,26 @@ namespace Js
             {
                 return counters.SetSigned(fieldEnum, val, this);
             }
+#if DBG
+            struct AutoResetThreadState
+            {
+                Js::FunctionBody* functionBody;
+                bool foreground;
+                bool alreadyInBackground;
+                AutoResetThreadState(Js::FunctionBody* fb);
+                ~AutoResetThreadState();
+            };
+            bool EnterBackgroundCall()
+            {
+                bool oldValue = counters.bgThreadCallStarted;
+                counters.bgThreadCallStarted = true;
+                return oldValue;
+            }
+            void LeaveBackgroundCall()
+            {
+                counters.bgThreadCallStarted = false;
+            }
+#endif
 
             struct StatementMap
             {


### PR DESCRIPTION
previously we assume that we don't change these counters after jit begins. however if there's prejit, we mark the counters has been accessed from background thread already and does not allow update, and then with force searialize bytecode, it is updating the counter (searialize ID).

fixing this by block the counter updating only when there's background thread JIT is ongoing, and unblock when the JIT completed
