### PR TITLE
Declare m_displayShortNameOffset as a serializable field. Fixes #652.

### DIFF
--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -1623,7 +1623,6 @@ namespace Js
         ULONG m_columnNumber;
         WriteBarrierPtr<const char16> m_displayName;  // Optional name
         uint m_displayNameLength;
-        uint m_displayShortNameOffset;
         WriteBarrierPtr<PropertyRecordList> m_boundPropertyRecords;
         WriteBarrierPtr<NestedArray> nestedArray;
 

--- a/lib/Runtime/SerializableFunctionFields.h
+++ b/lib/Runtime/SerializableFunctionFields.h
@@ -30,12 +30,13 @@
 
 #if DEFINE_PARSEABLE_FUNCTION_INFO_FIELDS
 PROTECTED_FIELDS
-    DECLARE_SERIALIZABLE_FIELD(ulong, m_grfscr, ULong);                 // For values, see fscr* values in scrutil.h.
-    DECLARE_SERIALIZABLE_FIELD(ArgSlot, m_inParamCount, ArgSlot);         // Count of 'in' parameters to method
-    DECLARE_SERIALIZABLE_FIELD(ArgSlot, m_reportedInParamCount, ArgSlot); // Count of 'in' parameters to method excluding default and rest
+    DECLARE_SERIALIZABLE_FIELD(ulong, m_grfscr, ULong);                     // For values, see fscr* values in scrutil.h.
+    DECLARE_SERIALIZABLE_FIELD(ArgSlot, m_inParamCount, ArgSlot);           // Count of 'in' parameters to method
+    DECLARE_SERIALIZABLE_FIELD(ArgSlot, m_reportedInParamCount, ArgSlot);   // Count of 'in' parameters to method excluding default and rest
     DECLARE_SERIALIZABLE_FIELD(charcount_t, m_cchStartOffset, CharCount);   // offset in characters from the start of the document.
     DECLARE_SERIALIZABLE_FIELD(charcount_t, m_cchLength, CharCount);        // length of the function in code points (not bytes)
-    DECLARE_SERIALIZABLE_FIELD(uint, m_cbLength, UInt32);              // length of the function in bytes
+    DECLARE_SERIALIZABLE_FIELD(uint, m_cbLength, UInt32);                   // length of the function in bytes
+    DECLARE_SERIALIZABLE_FIELD(uint, m_displayShortNameOffset, UInt32);     // Offset into the display name where the short name is found
 
 PUBLIC_FIELDS
     DECLARE_SERIALIZABLE_FIELD(UINT, scopeSlotArraySize, UInt32);


### PR DESCRIPTION
With -forceserialized, the name of the function was being printed incorrectly because the short name offset was not being serialized.

Marking the offset as serializable fixes the issue.

Fixes #652.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/653)
<!-- Reviewable:end -->
