### PR TITLE
Get X86_test config running

### DIFF
--- a/lib/WasmReader/WasmByteCodeGenerator.cpp
+++ b/lib/WasmReader/WasmByteCodeGenerator.cpp
@@ -302,6 +302,14 @@ WasmBytecodeGenerator::GenerateFunction()
     info->SetFloatConstCount(ReservedRegisterCount);
     info->SetDoubleConstCount(ReservedRegisterCount);
 
+    int nbConst =
+        ((info->GetDoubleConstCount() + 1) * sizeof(double)) // space required
+        + (int)((info->GetFloatConstCount() + 1)* sizeof(float) + 0.5 /*ceil*/)
+        + (int)((info->GetIntConstCount() + 1) * sizeof(int) + 0.5/*ceil*/) //
+        + Js::AsmJsFunctionMemory::RequiredVarConstants;
+
+    m_func->body->CheckAndSetConstantCount(nbConst);
+
     info->SetReturnType(GetAsmJsReturnType(m_funcInfo->GetResultType()));
 
     // REVIEW: overflow checks?

--- a/lib/WasmReader/WasmReaderPch.h
+++ b/lib/WasmReader/WasmReaderPch.h
@@ -10,5 +10,10 @@
 // Parser Includes
 #include "WasmReader.h"
 
+#ifdef ENABLE_WASM
+// AsmJsFunctionMemory::RequiredVarConstants
+#include "../Language/AsmJsModule.h"
+#endif
+
 // Runtime includes
 #include "../Runtime/runtime.h"


### PR DESCRIPTION
Moving wasm heap initialization before GenerateFunction() gets maic:0 working for X86_test. Previously, the heap was initialized too late.