### PR TITLE
Deserializing anonymous function

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeSerializer.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeSerializer.cpp
@@ -125,7 +125,7 @@ struct SerializedFieldList {
 #include "SerializableFunctionFields.h"
     bool has_m_lineNumber: 1;
     bool has_m_columnNumber: 1;
-	bool has_m_nestedCount: 1;
+    bool has_m_nestedCount: 1;
 };
 
 C_ASSERT(sizeof(GUID)==sizeof(DWORD)*4);
@@ -204,7 +204,8 @@ enum FunctionFlags
     ffHasReferenceableBuiltInArguments = 0x10000,
     ffIsNamedFunctionExpression        = 0x20000,
     ffIsAsmJsMode                      = 0x40000,
-    ffIsAsmJsFunction                  = 0x80000
+    ffIsAsmJsFunction                  = 0x80000,
+    ffIsAnonymous                      = 0x100000
 };
 
 // Kinds of constant
@@ -2117,7 +2118,11 @@ public:
             Assert(0); // Likely a bug
             return ByteCodeSerializer::CantGenerate;
         }
-        PrependString16(builder, _u("Display Name"), function->m_displayName, (function->m_displayNameLength +1)* sizeof(char16));
+
+        bool isAnonymous = function->GetIsAnonymousFunction();
+        const char16* displayName = isAnonymous ? nullptr : function->GetDisplayName();
+        uint displayNameLength = isAnonymous ? 0 : function->m_displayNameLength;
+        PrependString16(builder, _u("Display Name"), displayName, (displayNameLength + 1)* sizeof(char16));
 
         if (function->m_lineNumber != 0)
         {
@@ -2151,6 +2156,7 @@ public:
             | (function->m_CallsEval ? ffhasSetCallsEval : 0)
             | (function->m_ChildCallsEval ? ffChildCallsEval : 0)
             | (function->m_hasReferenceableBuiltInArguments ? ffHasReferenceableBuiltInArguments : 0)
+            | (isAnonymous ? ffIsAnonymous : 0)
 #ifndef TEMP_DISABLE_ASMJS
             | (function->m_isAsmjsMode ? ffIsAsmJsMode : 0)
             | (function->m_isAsmJsFunction ? ffIsAsmJsFunction : 0)
@@ -3588,11 +3594,13 @@ public:
 
         serialization_alignment SerializedFieldList* definedFields = (serialization_alignment SerializedFieldList*) functionBytes;
 
-        auto displayName = deferDeserializeFunctionInfo != nullptr ?
-            deferDeserializeFunctionInfo->GetDisplayName() :
+        auto displayName = (bitflags & ffIsAnonymous) ? Constants::AnonymousFunction :
+            deferDeserializeFunctionInfo != nullptr ? deferDeserializeFunctionInfo->GetDisplayName() :
             GetString16ById(displayNameId);
 
-        uint displayNameLength = deferDeserializeFunctionInfo ? deferDeserializeFunctionInfo->GetDisplayNameLength() : GetString16LengthById(displayNameId);
+        uint displayNameLength = (bitflags & ffIsAnonymous) ? Constants::AnonymousFunctionLength :
+            deferDeserializeFunctionInfo ? deferDeserializeFunctionInfo->GetDisplayNameLength() : 
+            GetString16LengthById(displayNameId);
         uint displayShortNameOffset = deferDeserializeFunctionInfo ? deferDeserializeFunctionInfo->GetShortDisplayNameOffset() : 0;
         int functionId;
         current = ReadInt32(current, &functionId);


### PR DESCRIPTION
Track anonymous functions bodies when we serialize them in the byte code. Otherwise it's impossible on deserialization to tell the difference between an anonymous function and a function with the name, 'Anonymous function.' The difference determines, for instance, whether instances of the function body have a name property.