### PR TITLE
Destructuring pattern at param has arguments as declaration.

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -6027,6 +6027,10 @@ void Parser::ParseFncFormals(ParseNodePtr pnodeFnc, ushort flags)
                         Assert(lexNode->IsVarLetOrConst());
                         UpdateOrCheckForDuplicateInFormals(lexNode->sxVar.pid, &formals);
                         lexNode->sxVar.sym->SetSymbolType(STFormal);
+                        if (m_currentNodeFunc != nullptr && lexNode->sxVar.pid == wellKnownPropertyPids.arguments)
+                        {
+                            m_currentNodeFunc->grfpn |= PNodeFlags::fpnArguments_overriddenByDecl;
+                        }
                     }
 
                     m_ppnodeVar = ppnodeVarSave;

--- a/test/es6/destructuring_bugs.js
+++ b/test/es6/destructuring_bugs.js
@@ -105,6 +105,14 @@ var tests = [
       assert.throws(function () { eval("var {x :  , y} = {};"); }, SyntaxError);
       assert.throws(function () { eval("({x : , y} = {});"); }, SyntaxError);
     }
+  },
+  {
+    name: "Destructuring pattern at param has arguments as declaration",
+    body: function () {
+      assert.doesNotThrow(function () { eval("function foo([arguments]) { arguments; }; foo([1]);"); });
+      assert.doesNotThrow(function () { eval("function foo({arguments}) { arguments; }; foo({arguments:1});"); });
+      assert.doesNotThrow(function () { eval("function foo({x:{arguments}}) { arguments; }; foo({x:{arguments:1}});"); });
+    }
   }
 ];
 


### PR DESCRIPTION
This was producing assert while generating bytecode since the 'arguments' is not marked as declaration. Fixed that by setting the flag as the arguments is overridden. Added unittest.
