### PR TITLE
Fix for issues with default parameters in async functions

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -7558,6 +7558,10 @@ void Parser::TransformAsyncFncDeclAST(ParseNodePtr *pnodeBody, bool fLambda)
     {
         GetCurrentFunctionNode()->sxFnc.SetUsesArguments();
     }
+    if (pnodeFncGenerator->sxFnc.CallsEval() || pnodeFncGenerator->sxFnc.ChildCallsEval())
+    {
+        GetCurrentFunctionNode()->sxFnc.SetChildCallsEval();
+    }
     lastNodeRef = NULL;
 }
 

--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -1767,6 +1767,7 @@ void ByteCodeGenerator::InitScopeSlotArray(FuncInfo * funcInfo)
     uint scopeSlotCount = funcInfo->bodyScope->GetScopeSlotCount();
     Assert(funcInfo->paramScope == nullptr || funcInfo->paramScope->GetScopeSlotCount() == 0 || !funcInfo->paramScope->GetCanMergeWithBodyScope());
     uint scopeSlotCountForParamScope = funcInfo->paramScope != nullptr ? funcInfo->paramScope->GetScopeSlotCount() : 0;
+
     if (scopeSlotCount == 0 && scopeSlotCountForParamScope == 0)
     {
         return;

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -1410,6 +1410,13 @@ FuncInfo * ByteCodeGenerator::StartBindFunction(const char16 *name, uint nameLen
         paramScope->SetMustInstantiate(true);
     }
 
+    if (pnode->sxFnc.IsAsync())
+    {
+        // For async methods we use the same parameter symbols in the inner function too.
+        // So mark them as having non local reference here.
+        funcInfo->paramScope->ForceAllSymbolNonLocalReference(this);
+    }
+
     PushFuncInfo(_u("StartBindFunction"), funcInfo);
 
     if (funcExprScope)

--- a/test/es6/default.js
+++ b/test/es6/default.js
@@ -245,6 +245,8 @@ var tests = [
         assert.throws(function () { eval("function f(a, b = function () { eval('1'); }) { }") }, SyntaxError, "Evals in child functions are not allowed in the parameter scope", "'eval' is not allowed in the default initializer");
         assert.throws(function () { eval("function f(a, b = function () { function f() { eval('1'); } }) { }") }, SyntaxError, "Evals in nested child functions are not allowed in the parameter scope", "'eval' is not allowed in the default initializer");
         assert.throws(function () { eval("function f(a, b = eval('a')) { }") }, SyntaxError, "Eval is not allowed in the parameter scope", "'eval' is not allowed in the default initializer");
+        assert.throws(function () { eval("async function f(a = eval('b')) { }"); }, SyntaxError, "Eval is not allowed in the param scope of async functions", "'eval' is not allowed in the default initializer");
+        assert.throws(function () { eval("function f(a = async function(y) { eval('b'); }) { }"); }, SyntaxError, "Eval is not allowed in the param scope of nested async functions", "'eval' is not allowed in the default initializer");
         
         assert.doesNotThrow(function (a = eval) { }, "An assignment of eval does not cause syntax error");
         assert.doesNotThrow(function (a = eval()) { }, "If no arguments are passed to eval then it won't cause syntax error");

--- a/test/es7/asyncawait-functionality.baseline
+++ b/test/es7/asyncawait-functionality.baseline
@@ -17,6 +17,9 @@ Executing test #11 - local variables with same names as formal parameters have p
 Executing test #12 - this value in async functions behaves like it does in normal functions
 Executing test #13 - arguments value in async functions behaves like it does in normal functions
 Executing test #14 - super value in async methods behaves like it does in normal methods
+Executing test #15 - Async function with formal captured in a lambda
+Executing test #16 - Async function with formal captured in a nested function
+Executing test #17 - Async function with formal captured in eval
 
 Completion Results:
 Test #1 - Success lambda expression with no argument called with result = 'true'
@@ -48,6 +51,9 @@ Test #12 - Success this value set to 5
 Test #12 - Success this value set to { af: af, b: "abc" }
 Test #13 - Success result is 'ab' from arguments 'a' + 'b'
 Test #14 - Success result is 'base derived' from derived method call
+Test #15 - Success lambda returns 1 when no arguments passed
+Test #16 - Success nested function returns 1 when no arguments passed
+Test #17 - Success eval returns 1 when no arguments passed
 Test #6 - Success await in an async function #1 called with result = '-4'
 Test #6 - Success await in an async function #2 called with result = '2'
 Test #6 - Success await in an async function catch a rejected Promise in 'err'. Error = 'Error: My Error'

--- a/test/es7/asyncawait-functionality.js
+++ b/test/es7/asyncawait-functionality.js
@@ -615,6 +615,66 @@ var tests = [
             });
         }
     },
+    {
+        name:"Async function with formal captured in a lambda",
+        body: function (index) {
+            async function af(d = 1) {
+                return () => d;
+            }
+
+            af().then(result => {
+                if (result() === 1) {
+                    print(`Test #${index} - Success lambda returns 1 when no arguments passed`);
+                } else {
+                    print(`Test #${index} - Failure result is not 1, result = '${result()}'`);
+                }
+            }, err => {
+                print(`Test #${index} - Error err = ${err}`);
+            }).catch(err => {
+                print(`Test #${index} - Catch err = ${err}`);
+            });  
+        }
+    },
+    {
+        name:"Async function with formal captured in a nested function",
+        body: function (index) {
+            async function af(d = 1) {
+                return function () { return d; };
+            }
+
+            af().then(result => {
+                if (result() === 1) {
+                    print(`Test #${index} - Success nested function returns 1 when no arguments passed`);
+                } else {
+                    print(`Test #${index} - Failure result is not 1, result = '${result()}'`);
+                }
+            }, err => {
+                print(`Test #${index} - Error err = ${err}`);
+            }).catch(err => {
+                print(`Test #${index} - Catch err = ${err}`);
+            });  
+        }
+    },
+    {
+        name:"Async function with formal captured in eval",
+        body: function (index) {
+            async function af(d = 1) {
+                return eval("d");
+            }
+
+            af().then(result => {
+                if (result === 1) {
+                    print(`Test #${index} - Success eval returns 1 when no arguments passed`);
+                } else {
+                    print(`Test #${index} - Failure result is not 1, result = '${result}'`);
+                }
+            }, err => {
+                print(`Test #${index} - Error err = ${err}`);
+            }).catch(err => {
+                print(`Test #${index} - Catch err = ${err}`);
+            });  
+        }
+    },
 ];
 
 var index = 1;


### PR DESCRIPTION
This changelist fixes two issues
1. When the inner function of an async function was calling eval we were
not marking the parent function as ChildCallsEval causing SyntaxError
related to eval being missed.
2. The parameters of async function were not marked as
hasNonLocalReference, so when the parameter is referenced inside the body
wrong environment index calculation was happening.