### PR TITLE
MSFT: 6982641 6982542 6982434 6982395 6982802 7033315

### DIFF
--- a/lib/Common/Core/ConfigParser.cpp
+++ b/lib/Common/Core/ConfigParser.cpp
@@ -369,23 +369,29 @@ void ConfigParser::ProcessConfiguration(HANDLE hmod)
         fd = _open_osfhandle((intptr_t)GetStdHandle(STD_OUTPUT_HANDLE), O_TEXT);
         fp = _wfdopen(fd, _u("w"));
 
-        *stdout = *fp;
-        setvbuf(stdout, nullptr, _IONBF, 0);
-
-        fd = _open_osfhandle((intptr_t)GetStdHandle(STD_ERROR_HANDLE), O_TEXT);
-        fp = _wfdopen(fd, _u("w"));
-
-        *stderr = *fp;
-        setvbuf(stderr, nullptr, _IONBF, 0);
-
-        char16 buffer[_MAX_PATH + 70];
-
-        if (ConfigParserAPI::FillConsoleTitle(buffer, _MAX_PATH + 20, modulename))
+        if (fp != nullptr)
         {
-            SetConsoleTitle(buffer);
-        }
+            *stdout = *fp;
+            setvbuf(stdout, nullptr, _IONBF, 0);
 
-        hasOutput = true;
+            fd = _open_osfhandle((intptr_t)GetStdHandle(STD_ERROR_HANDLE), O_TEXT);
+            fp = _wfdopen(fd, _u("w"));
+
+            if (fp != nullptr)
+            {
+                *stderr = *fp;
+                setvbuf(stderr, nullptr, _IONBF, 0);
+
+                char16 buffer[_MAX_PATH + 70];
+
+                if (ConfigParserAPI::FillConsoleTitle(buffer, _MAX_PATH + 20, modulename))
+                {
+                    SetConsoleTitle(buffer);
+                }
+
+                hasOutput = true;
+            }
+        }
     }
 
     if (Js::Configuration::Global.flags.IsEnabled(Js::OutputFileFlag)

--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -1840,6 +1840,9 @@ ThreadContext::DisposeObjects(Recycler * recycler)
         return;
     }
 
+    // we shouldn't dispose in noscriptscope as it might lead to script execution.
+    Assert(!this->IsNoScriptScope());
+
     if (!this->IsScriptActive())
     {
         __super::DisposeObjects(recycler);

--- a/lib/Runtime/Language/SourceTextModuleRecord.h
+++ b/lib/Runtime/Language/SourceTextModuleRecord.h
@@ -37,7 +37,7 @@ namespace Js
         void Dispose(bool isShutdown) override { return; }
         void Mark(Recycler * recycler) override { return; }
 
-        void ResolveExternalModuleDependencies();
+        HRESULT ResolveExternalModuleDependencies();
 
         void* GetHostDefined() const { return hostDefined; }
         void SetHostDefined(void* hostObj) { hostDefined = hostObj; }


### PR DESCRIPTION
Fix a couple of fault injection failures. We should notify the host if
importing child module failure for some reason, and don't continue down the execution
pipeline.
We should also skip dtor at shutdown time and the allocator might have been gone.
assert dispose when in noscriptscope
don't do console output if console is not supported by the host.
