### PR TITLE
update interpreter to use SSE2 div when possible

### DIFF
--- a/lib/Runtime/Math/JavascriptMath.inl
+++ b/lib/Runtime/Math/JavascriptMath.inl
@@ -2,6 +2,9 @@
 // Copyright (C) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
+
+#include "RuntimeMathPch.h"
+
 namespace Js
 {
 #ifdef SSE2MATH
@@ -222,8 +225,17 @@ namespace Js
 
         __inline Var JavascriptMath::Divide(Var aLeft, Var aRight, ScriptContext* scriptContext)
         {
-            // The TaggedInt,TaggedInt case is handled within Divide_Full
-            return Divide_Full(aLeft, aRight,scriptContext);
+#if defined(_M_IX86) && !defined(SSE2MATH)
+            if (AutoSystemInfo::Data.SSE2Available())
+            {
+                return SSE2::JavascriptMath::Divide_Full(aLeft, aRight, scriptContext);
+            }
+            else
+#endif
+            {
+                // The TaggedInt,TaggedInt case is handled within Divide_Full
+                return Divide_Full(aLeft, aRight, scriptContext);
+            }
         }
 
         __inline double JavascriptMath::Divide_Helper(Var aLeft, Var aRight, ScriptContext* scriptContext)

--- a/lib/Runtime/Math/JavascriptMath.inl
+++ b/lib/Runtime/Math/JavascriptMath.inl
@@ -201,10 +201,23 @@ namespace Js
 
         __inline Var JavascriptMath::Multiply(Var aLeft, Var aRight, ScriptContext* scriptContext)
         {
-            return
-                TaggedInt::IsPair(aLeft,aRight) ?
-                TaggedInt::Multiply(aLeft, aRight, scriptContext) :
-                Multiply_Full(aLeft, aRight, scriptContext);
+            if (TaggedInt::IsPair(aLeft, aRight))
+            {
+                return TaggedInt::Multiply(aLeft, aRight, scriptContext);
+            }
+            else
+            {
+#if defined(_M_IX86) && !defined(SSE2MATH)
+                if (AutoSystemInfo::Data.SSE2Available())
+                {
+                    return SSE2::JavascriptMath::Multiply_Full(aLeft, aRight, scriptContext);
+                }
+                else
+#endif
+                {
+                    return Multiply_Full(aLeft, aRight, scriptContext);
+                }
+            }
         }
 
         __inline Var JavascriptMath::Exponentiation(Var aLeft, Var aRight, ScriptContext* scriptContext)


### PR DESCRIPTION
In investigating a difference between JIT and interpreter, I found that interpreter is using x87 for dividing, which is significantly slower than sse2 div, and may not give same result.
To help bring consistency between JIT and interpreter, and to benefit from SSE2, I have added a path to do SSE2 div in the interpreter where possible.

With this, I'm seeing a couple small but consistent perf wins on x86: 3% improvement in Kraken crypto-aes, and 100% (1 ms to 0ms) in sunspider crypto-sha1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/686)
<!-- Reviewable:end -->
