### PR TITLE
remove verbase etw in hot codepath

### DIFF
--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -1629,8 +1629,6 @@ ThreadContext::LeaveScriptStart(void * frameAddress)
     }
 #endif
 
-    JS_ETW(EventWriteJSCRIPT_CALL_OUT_START(this,0));
-
     Js::ScriptEntryExitRecord * entryExitRecord = this->GetScriptEntryExit();
 
     AssertMsg(entryExitRecord && entryExitRecord->frameIdOfScriptExitFunction == nullptr,
@@ -1689,7 +1687,6 @@ ThreadContext::LeaveScriptEnd(void * frameAddress)
     }
 #endif
 
-    JS_ETW(EventWriteJSCRIPT_CALL_OUT_STOP(this,0));
     Js::ScriptEntryExitRecord * entryExitRecord = this->GetScriptEntryExit();
 
     AssertMsg(entryExitRecord && entryExitRecord->frameIdOfScriptExitFunction,


### PR DESCRIPTION
These two etw check shows up in some trace. We should avoid perf impact in hot codepath here.