### PR TITLE
fix page alignment when allocating from pending zero list

### DIFF
--- a/lib/Common/Memory/HeapBlock.cpp
+++ b/lib/Common/Memory/HeapBlock.cpp
@@ -58,42 +58,45 @@ HeapBlock::SetNeedOOMRescan(Recycler * recycler)
 void
 HeapBlock::CapturePageHeapAllocStack()
 {
-    Assert(this->InPageHeapMode());
-
-    // These asserts are true because explicit free is disallowed in
-    // page heap mode. If they weren't, we'd have to modify the asserts
-    Assert(this->pageHeapFreeStack == nullptr);
-    Assert(this->pageHeapAllocStack == nullptr);
-
-    // Note: NoCheckHeapAllocator will fail fast if we can't allocate the stack to capture
-    // REVIEW: Should we have a flag to configure the number of frames captured?
-    if (pageHeapAllocStack != nullptr)
+    if (this->InPageHeapMode()) // pageheap can be enabled only for some of the buckets
     {
-        this->pageHeapAllocStack->Capture(Recycler::s_numFramesToSkipForPageHeapAlloc);
-    }
-    else
-    {
-        this->pageHeapAllocStack = StackBackTrace::Capture(&NoCheckHeapAllocator::Instance, Recycler::s_numFramesToSkipForPageHeapAlloc, Recycler::s_numFramesToCaptureForPageHeap);
+
+        // These asserts are true because explicit free is disallowed in
+        // page heap mode. If they weren't, we'd have to modify the asserts
+        Assert(this->pageHeapFreeStack == nullptr);
+        Assert(this->pageHeapAllocStack == nullptr);
+
+        // Note: NoCheckHeapAllocator will fail fast if we can't allocate the stack to capture
+        // REVIEW: Should we have a flag to configure the number of frames captured?
+        if (pageHeapAllocStack != nullptr)
+        {
+            this->pageHeapAllocStack->Capture(Recycler::s_numFramesToSkipForPageHeapAlloc);
+        }
+        else
+        {
+            this->pageHeapAllocStack = StackBackTrace::Capture(&NoCheckHeapAllocator::Instance, Recycler::s_numFramesToSkipForPageHeapAlloc, Recycler::s_numFramesToCaptureForPageHeap);
+        }
     }
 }
 
 void
 HeapBlock::CapturePageHeapFreeStack()
 {
-    Assert(this->InPageHeapMode());
-
-    // These asserts are true because explicit free is disallowed in
-    // page heap mode. If they weren't, we'd have to modify the asserts
-    Assert(this->pageHeapFreeStack == nullptr);
-    Assert(this->pageHeapAllocStack != nullptr);
-
-    if (this->pageHeapFreeStack != nullptr)
+    if (this->InPageHeapMode()) // pageheap can be enabled only for some of the buckets
     {
-        this->pageHeapFreeStack->Capture(Recycler::s_numFramesToSkipForPageHeapFree);
-    }
-    else
-    {
-        this->pageHeapFreeStack = StackBackTrace::Capture(&NoCheckHeapAllocator::Instance, Recycler::s_numFramesToSkipForPageHeapFree, Recycler::s_numFramesToCaptureForPageHeap);
+        // These asserts are true because explicit free is disallowed in
+        // page heap mode. If they weren't, we'd have to modify the asserts
+        Assert(this->pageHeapFreeStack == nullptr);
+        Assert(this->pageHeapAllocStack != nullptr);
+
+        if (this->pageHeapFreeStack != nullptr)
+        {
+            this->pageHeapFreeStack->Capture(Recycler::s_numFramesToSkipForPageHeapFree);
+        }
+        else
+        {
+            this->pageHeapFreeStack = StackBackTrace::Capture(&NoCheckHeapAllocator::Instance, Recycler::s_numFramesToSkipForPageHeapFree, Recycler::s_numFramesToCaptureForPageHeap);
+        }
     }
 }
 #endif

--- a/lib/Common/Memory/HeapBlock.cpp
+++ b/lib/Common/Memory/HeapBlock.cpp
@@ -353,7 +353,9 @@ SmallHeapBlockT<TBlockAttributes>::ReassignPages(Recycler * recycler)
     const PageHeapMode pageHeapModeLocal = PageHeapModeOff;
 #endif
 
-    char * address = this->GetPageAllocator(recycler)->AllocPagesPageAligned(this->GetPageHeapModePageCount<pageheap>(), &segment, pageHeapModeLocal);
+    auto pageAllocator = this->GetPageAllocator(recycler);
+    uint pagecount = this->GetPageHeapModePageCount<pageheap>();
+    char * address = pageAllocator->AllocPagesPageAligned(pagecount, &segment, pageHeapModeLocal);
 
     if (address == NULL)
     {
@@ -444,8 +446,10 @@ SmallHeapBlockT<TBlockAttributes>::SetPage(__in_ecount_pagesize char * baseAddre
     }
 #endif
 
+#if DBG
     uint l2Id = HeapBlockMap32::GetLevel2Id(address);
     Assert(l2Id + (TBlockAttributes::PageCount - 1) < 256);
+#endif
 
     this->segment = pageSegment;
     this->address = address;

--- a/lib/Common/Memory/HeapInfo.cpp
+++ b/lib/Common/Memory/HeapInfo.cpp
@@ -505,10 +505,10 @@ HeapInfo::Initialize(Recycler * recycler
     if (pageheapmode == PageHeapMode::PageHeapModeOff)
     {
 #ifdef ENABLE_DEBUG_CONFIG_OPTIONS
-        isPageHeapEnabled = Js::Configuration::Global.flags.PageHeap != PageHeapMode::PageHeapModeOff;
-        pageheapmode = (PageHeapMode)Js::Configuration::Global.flags.PageHeap;
-        blockTypeFilter = (PageHeapBlockTypeFilter)Js::Configuration::Global.flags.PageHeapBlockType;
-        pBucketNumberRange = &Js::Configuration::Global.flags.PageHeapBucketNumber;
+        isPageHeapEnabled = recycler->GetRecyclerFlagsTable().PageHeap != PageHeapMode::PageHeapModeOff;
+        pageheapmode = (PageHeapMode)recycler->GetRecyclerFlagsTable().PageHeap;
+        blockTypeFilter = (PageHeapBlockTypeFilter)recycler->GetRecyclerFlagsTable().PageHeapBlockType;
+        pBucketNumberRange = &recycler->GetRecyclerFlagsTable().PageHeapBucketNumber;
 #else
         // @TODO in free build, use environment var or other way to enable page heap
         // currently page heap build is enable in free build but has not implemented a way to input the page heap flags.
@@ -528,8 +528,8 @@ HeapInfo::Initialize(Recycler * recycler
         this->captureFreeCallStack = captureFreeCallStack;
 
 #ifdef ENABLE_DEBUG_CONFIG_OPTIONS
-        this->captureAllocCallStack = captureAllocCallStack || Js::Configuration::Global.flags.PageHeapAllocStack;
-        this->captureFreeCallStack = captureFreeCallStack || Js::Configuration::Global.flags.PageHeapFreeStack;
+        this->captureAllocCallStack = captureAllocCallStack || recycler->GetRecyclerFlagsTable().PageHeapAllocStack;
+        this->captureFreeCallStack = captureFreeCallStack || recycler->GetRecyclerFlagsTable().PageHeapFreeStack;
 #endif
     }
 #endif

--- a/lib/Common/Memory/PageAllocator.h
+++ b/lib/Common/Memory/PageAllocator.h
@@ -491,7 +491,7 @@ protected:
 
     template <bool notPageAligned>
     char * TryAllocFreePages(uint pageCount, PageSegmentBase<TVirtualAlloc> ** pageSegment, PageHeapMode pageHeapFlags);
-    char * TryAllocFromZeroPagesList(uint pageCount, PageSegmentBase<TVirtualAlloc> ** pageSegment, SLIST_HEADER& zeroPagesList, bool isPendingZeroList);
+    char * TryAllocFromZeroPagesList(uint pageCount, PageSegmentBase<TVirtualAlloc> ** pageSegment, SLIST_HEADER& zeroPagesList, bool isPendingZeroList, PageHeapMode pageHeapFlags);
     char * TryAllocFromZeroPages(uint pageCount, PageSegmentBase<TVirtualAlloc> ** pageSegment, PageHeapMode pageHeapFlags);
 
     template <bool notPageAligned>


### PR DESCRIPTION
previous while allocating pages from pending zero list, didn't check the page alignment. with page heap it's very easy to hit such issue because in page heap we alloc extra guard page.