### PR TITLE
fix page alignment when allocating from pending zero list 

### DIFF
--- a/lib/Common/Memory/HeapBlock.cpp
+++ b/lib/Common/Memory/HeapBlock.cpp
@@ -350,7 +350,9 @@ SmallHeapBlockT<TBlockAttributes>::ReassignPages(Recycler * recycler)
     const PageHeapMode pageHeapModeLocal = PageHeapModeOff;
 #endif
 
-    char * address = this->GetPageAllocator(recycler)->AllocPagesPageAligned(this->GetPageHeapModePageCount<pageheap>(), &segment, pageHeapModeLocal);
+    auto pageAllocator = this->GetPageAllocator(recycler);
+    uint pagecount = this->GetPageHeapModePageCount<pageheap>();
+    char * address = pageAllocator->AllocPagesPageAligned(pagecount, &segment, pageHeapModeLocal);
 
     if (address == NULL)
     {
@@ -441,8 +443,10 @@ SmallHeapBlockT<TBlockAttributes>::SetPage(__in_ecount_pagesize char * baseAddre
     }
 #endif
 
+#if DBG
     uint l2Id = HeapBlockMap32::GetLevel2Id(address);
     Assert(l2Id + (TBlockAttributes::PageCount - 1) < 256);
+#endif
 
     this->segment = pageSegment;
     this->address = address;

--- a/lib/Common/Memory/PageAllocator.h
+++ b/lib/Common/Memory/PageAllocator.h
@@ -491,7 +491,7 @@ protected:
 
     template <bool notPageAligned>
     char * TryAllocFreePages(uint pageCount, PageSegmentBase<TVirtualAlloc> ** pageSegment, PageHeapMode pageHeapFlags);
-    char * TryAllocFromZeroPagesList(uint pageCount, PageSegmentBase<TVirtualAlloc> ** pageSegment, SLIST_HEADER& zeroPagesList, bool isPendingZeroList);
+    char * TryAllocFromZeroPagesList(uint pageCount, PageSegmentBase<TVirtualAlloc> ** pageSegment, SLIST_HEADER& zeroPagesList, bool isPendingZeroList, PageHeapMode pageHeapFlags);
     char * TryAllocFromZeroPages(uint pageCount, PageSegmentBase<TVirtualAlloc> ** pageSegment, PageHeapMode pageHeapFlags);
 
     template <bool notPageAligned>


### PR DESCRIPTION
Previous while allocating pages from pending zero list, didn't check the page alignment. with page heap it's very easy to hit such issue because in page heap we alloc extra guard page.