### PR TITLE
Issue with this object handling in param scope

### DIFF
--- a/lib/Backend/amd64/LowererMDArch.cpp
+++ b/lib/Backend/amd64/LowererMDArch.cpp
@@ -2211,7 +2211,7 @@ LowererMDArch::EmitLoadVar(IR::Instr *instrLoad, bool isFromUint32, bool isHelpe
 void
 LowererMDArch::EmitLoadVar(IR::Instr *instrLoad, bool isFromUint32, bool isHelper)
 {
-    //    MOV e1, e_src1
+    //    MOV_TRUNC e1, e_src1
     //    CMP e1, 0             [uint32]
     //    JLT $Helper           [uint32]  -- overflows?
     //    BTS r1, VarTag_Shift
@@ -2247,10 +2247,11 @@ LowererMDArch::EmitLoadVar(IR::Instr *instrLoad, bool isFromUint32, bool isHelpe
 
     IR::RegOpnd *r1 = IR::RegOpnd::New(TyVar, m_func);
 
-    // e1 = MOV e_src1
+    // e1 = MOV_TRUNC e_src1
+    // (Use MOV_TRUNC here as we rely on the register copy to clear the upper 32 bits.)
     IR::RegOpnd *e1 = r1->Copy(m_func)->AsRegOpnd();
     e1->SetType(TyInt32);
-    instrLoad->InsertBefore(IR::Instr::New(Js::OpCode::MOV,
+    instrLoad->InsertBefore(IR::Instr::New(Js::OpCode::MOV_TRUNC,
         e1,
         src1,
         m_func));

--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -2520,7 +2520,7 @@ void ByteCodeGenerator::GetEnclosingNonLambdaScope(FuncInfo *funcInfo, Scope * &
         {
             envIndex++;
         }
-        if ((scope == scope->GetFunc()->GetBodyScope() && !scope->GetFunc()->IsLambda()) || scope->IsGlobalEvalBlockScope())
+        if (((scope == scope->GetFunc()->GetBodyScope() || scope == scope->GetFunc()->GetParamScope()) && !scope->GetFunc()->IsLambda()) || scope->IsGlobalEvalBlockScope())
         {
             break;
         }
@@ -3895,7 +3895,14 @@ void ByteCodeGenerator::StartEmitFunction(ParseNode *pnodeFnc)
                 MapFormalsFromPattern(pnodeFnc, [&](ParseNode *pnode) { pnode->sxVar.sym->EnsureScopeSlot(funcInfo); });
             }
 
-            this->EnsureSpecialScopeSlots(funcInfo, bodyScope);
+            if (paramScope->GetCanMergeWithBodyScope())
+            {
+                this->EnsureSpecialScopeSlots(funcInfo, bodyScope);
+            }
+            else
+            {
+                this->EnsureSpecialScopeSlots(funcInfo, paramScope);
+            }
 
             auto ensureFncDeclScopeSlots = [&](ParseNode *pnodeScope)
             {
@@ -3951,7 +3958,14 @@ void ByteCodeGenerator::StartEmitFunction(ParseNode *pnodeFnc)
             ParseNode *pnode;
             Symbol *sym;
 
-            this->EnsureSpecialScopeSlots(funcInfo, bodyScope);
+            if (paramScope->GetCanMergeWithBodyScope())
+            {
+                this->EnsureSpecialScopeSlots(funcInfo, bodyScope);
+            }
+            else
+            {
+                this->EnsureSpecialScopeSlots(funcInfo, paramScope);
+            }
 
             pnodeFnc->sxFnc.MapContainerScopes([&](ParseNode *pnodeScope) { this->EnsureFncScopeSlots(pnodeScope, funcInfo); });
 

--- a/lib/Runtime/ByteCode/ByteCodeSerializer.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeSerializer.cpp
@@ -125,7 +125,7 @@ struct SerializedFieldList {
 #include "SerializableFunctionFields.h"
     bool has_m_lineNumber: 1;
     bool has_m_columnNumber: 1;
-	bool has_m_nestedCount: 1;
+    bool has_m_nestedCount: 1;
 };
 
 C_ASSERT(sizeof(GUID)==sizeof(DWORD)*4);
@@ -204,7 +204,8 @@ enum FunctionFlags
     ffHasReferenceableBuiltInArguments = 0x10000,
     ffIsNamedFunctionExpression        = 0x20000,
     ffIsAsmJsMode                      = 0x40000,
-    ffIsAsmJsFunction                  = 0x80000
+    ffIsAsmJsFunction                  = 0x80000,
+    ffIsAnonymous                      = 0x100000
 };
 
 // Kinds of constant
@@ -2117,7 +2118,11 @@ public:
             Assert(0); // Likely a bug
             return ByteCodeSerializer::CantGenerate;
         }
-        PrependString16(builder, _u("Display Name"), function->m_displayName, (function->m_displayNameLength +1)* sizeof(char16));
+
+        bool isAnonymous = function->GetIsAnonymousFunction();
+        const char16* displayName = isAnonymous ? nullptr : function->GetDisplayName();
+        uint displayNameLength = isAnonymous ? 0 : function->m_displayNameLength;
+        PrependString16(builder, _u("Display Name"), displayName, (displayNameLength + 1)* sizeof(char16));
 
         if (function->m_lineNumber != 0)
         {
@@ -2151,6 +2156,7 @@ public:
             | (function->m_CallsEval ? ffhasSetCallsEval : 0)
             | (function->m_ChildCallsEval ? ffChildCallsEval : 0)
             | (function->m_hasReferenceableBuiltInArguments ? ffHasReferenceableBuiltInArguments : 0)
+            | (isAnonymous ? ffIsAnonymous : 0)
 #ifndef TEMP_DISABLE_ASMJS
             | (function->m_isAsmjsMode ? ffIsAsmJsMode : 0)
             | (function->m_isAsmJsFunction ? ffIsAsmJsFunction : 0)
@@ -3588,11 +3594,13 @@ public:
 
         serialization_alignment SerializedFieldList* definedFields = (serialization_alignment SerializedFieldList*) functionBytes;
 
-        auto displayName = deferDeserializeFunctionInfo != nullptr ?
-            deferDeserializeFunctionInfo->GetDisplayName() :
+        auto displayName = (bitflags & ffIsAnonymous) ? Constants::AnonymousFunction :
+            deferDeserializeFunctionInfo != nullptr ? deferDeserializeFunctionInfo->GetDisplayName() :
             GetString16ById(displayNameId);
 
-        uint displayNameLength = deferDeserializeFunctionInfo ? deferDeserializeFunctionInfo->GetDisplayNameLength() : GetString16LengthById(displayNameId);
+        uint displayNameLength = (bitflags & ffIsAnonymous) ? Constants::AnonymousFunctionLength :
+            deferDeserializeFunctionInfo ? deferDeserializeFunctionInfo->GetDisplayNameLength() : 
+            GetString16LengthById(displayNameId);
         uint displayShortNameOffset = deferDeserializeFunctionInfo ? deferDeserializeFunctionInfo->GetShortDisplayNameOffset() : 0;
         int functionId;
         current = ReadInt32(current, &functionId);

--- a/test/Optimizer/ToVari32_x64.js
+++ b/test/Optimizer/ToVari32_x64.js
@@ -1,0 +1,46 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+var shouldBailout = false;
+function test0() {
+    var loopInvariant = shouldBailout ? 12 : 8;
+    var GiantPrintArray = [];
+    var protoObj0 = {};
+    var obj1 = {};
+    var protoObj1 = {};
+    var func4 = function () {
+    };
+    for (var __loopvar0 = loopInvariant; __loopvar0 != loopInvariant + 4; loopInvariant) {
+        var __loopvar1 = loopInvariant;
+        for (var __loopSecondaryVar1_0 = loopInvariant; ; loopInvariant) {
+            while (obj1.prop0) {
+                var __loopvar3 = loopInvariant;
+                do {
+                    var v0 = protoObj1[{}];
+                    protoObj1 = protoObj0;
+                    var uniqobj1 = [obj1];
+                    GiantPrintArray.push(__loopvar0);
+                    func4();
+                    if (__loopvar3 > loopInvariant + 6) {
+                    }
+                    __loopvar3 += 2;
+                } while (protoObj0);
+                GiantPrintArray('arrObj0.prop0 = ' + arrObj0);
+                GiantPrintArray('protoObj1.prop0 = ' + protoObj0);
+            }
+            if (__loopvar1 === loopInvariant) {
+                break;
+            }
+            __loopvar1++;
+        }
+        __loopvar0++;
+    }
+}
+test0();
+test0();
+test0();
+test0();
+
+WScript.Echo('pass');

--- a/test/Optimizer/rlexe.xml
+++ b/test/Optimizer/rlexe.xml
@@ -1321,4 +1321,10 @@
       <baseline>trycatch_assert.baseline</baseline>
     </default>
   </test>
+  <test>
+    <default>
+      <files>ToVarI32_x64.js</files>
+      <compile-flags>-force:rejit -off:ArrayCheckHoist -off:aggressiveinttypespec -off:bailonnoprofile -off:nativearray</compile-flags>
+    </default>
+  </test>
 </regress-exe>

--- a/test/es6/default-splitscope.js
+++ b/test/es6/default-splitscope.js
@@ -207,12 +207,19 @@ var tests = [
         } 
         assert.areEqual(30, f2.call({y : 10}), "Properties are accessed from the right this object"); 
 
-        var thisObj = {x : 1, y: 20};             
-        function f3(b = () => { this.x = 10; return this.y; }) { 
+        var thisObj = {x : 1, y: 20 };
+        function f3(a, b = () => { a; this.x = 10; return this.y; }) {
+            assert.areEqual(1, this.x, "Assignment from the param scope has not happened yet");
+            assert.areEqual(20, this.y, "y property of the this object is not affected");
             return b; 
         } 
         assert.areEqual(20, f3.call(thisObj)(), "Lambda defined in the param scope returns the right property value from thisObj"); 
         assert.areEqual(10, thisObj.x, "Assignment from the param scope method updates thisObj's property"); 
+
+        function f4(a, b = () => { a; return this}) {
+            return b;
+        }
+        assert.areEqual(thisObj, f4.call(thisObj)(), "Lambda defined in the param scope returns the right this object"); 
     } 
   },
   { 


### PR DESCRIPTION
Issue with this object handling in param scope

We were allocating scope slot for this object in the body scope. So when a lamdda tries to access this object it was using the wrong scope slot. Another issue was when we try to find the enclosing non-lambda function from a lambda function we always compare with the body scope. But when the lambda is defined inside the param scope, we have to compare it with the param scope.
