### PR TITLE
Issue with this object handling in param scope

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -2520,7 +2520,7 @@ void ByteCodeGenerator::GetEnclosingNonLambdaScope(FuncInfo *funcInfo, Scope * &
         {
             envIndex++;
         }
-        if ((scope == scope->GetFunc()->GetBodyScope() && !scope->GetFunc()->IsLambda()) || scope->IsGlobalEvalBlockScope())
+        if (((scope == scope->GetFunc()->GetBodyScope() || scope == scope->GetFunc()->GetParamScope()) && !scope->GetFunc()->IsLambda()) || scope->IsGlobalEvalBlockScope())
         {
             break;
         }
@@ -3890,7 +3890,14 @@ void ByteCodeGenerator::StartEmitFunction(ParseNode *pnodeFnc)
                 MapFormalsFromPattern(pnodeFnc, [&](ParseNode *pnode) { pnode->sxVar.sym->EnsureScopeSlot(funcInfo); });
             }
 
-            this->EnsureSpecialScopeSlots(funcInfo, bodyScope);
+            if (paramScope->GetCanMergeWithBodyScope())
+            {
+                this->EnsureSpecialScopeSlots(funcInfo, bodyScope);
+            }
+            else
+            {
+                this->EnsureSpecialScopeSlots(funcInfo, paramScope);
+            }
 
             auto ensureFncDeclScopeSlots = [&](ParseNode *pnodeScope)
             {
@@ -3946,7 +3953,14 @@ void ByteCodeGenerator::StartEmitFunction(ParseNode *pnodeFnc)
             ParseNode *pnode;
             Symbol *sym;
 
-            this->EnsureSpecialScopeSlots(funcInfo, bodyScope);
+            if (paramScope->GetCanMergeWithBodyScope())
+            {
+                this->EnsureSpecialScopeSlots(funcInfo, bodyScope);
+            }
+            else
+            {
+                this->EnsureSpecialScopeSlots(funcInfo, paramScope);
+            }
 
             pnodeFnc->sxFnc.MapContainerScopes([&](ParseNode *pnodeScope) { this->EnsureFncScopeSlots(pnodeScope, funcInfo); });
 

--- a/test/es6/default-splitscope.js
+++ b/test/es6/default-splitscope.js
@@ -207,12 +207,19 @@ var tests = [
         } 
         assert.areEqual(30, f2.call({y : 10}), "Properties are accessed from the right this object"); 
 
-        var thisObj = {x : 1, y: 20};             
-        function f3(b = () => { this.x = 10; return this.y; }) { 
+        var thisObj = {x : 1, y : 20 };
+        function f3(a, b = () => { a; this.x = 10; return this.y; }) {
+            assert.areEqual(1, this.x, "Assignment from the param scope has not happened yet");
+            assert.areEqual(20, this.y, "y property of the this object is not affected");
             return b; 
         } 
         assert.areEqual(20, f3.call(thisObj)(), "Lambda defined in the param scope returns the right property value from thisObj"); 
         assert.areEqual(10, thisObj.x, "Assignment from the param scope method updates thisObj's property"); 
+
+        function f4(a, b = () => { a; return this; }) {
+            return b;
+        }
+        assert.areEqual(thisObj, f4.call(thisObj)(), "Lambda defined in the param scope returns the right this object"); 
     } 
   },
   { 


### PR DESCRIPTION
We were allocating scope slot for this object in the body scope. So when a lamdda tries to access this object it was using the wrong scope slot. Another issue was when we try to find the enclosing non-lambda function from a lambda function we always compare with the body scope. But when the lambda is defined inside the param scope, we have to compare it with the param scope.
