### PR TITLE
Fix a few module linking issues

### DIFF
--- a/lib/Parser/Parse.h
+++ b/lib/Parser/Parse.h
@@ -516,26 +516,24 @@ private:
 
 public:
     IdentPtrList* GetRequestedModulesList();
-    ModuleImportEntryList* GetModuleImportEntryList();
-    ModuleExportEntryList* GetModuleLocalExportEntryList();
-    ModuleExportEntryList* GetModuleIndirectExportEntryList();
-    ModuleExportEntryList* GetModuleStarExportEntryList();
+    ModuleImportOrExportEntryList* GetModuleImportEntryList();
+    ModuleImportOrExportEntryList* GetModuleLocalExportEntryList();
+    ModuleImportOrExportEntryList* GetModuleIndirectExportEntryList();
+    ModuleImportOrExportEntryList* GetModuleStarExportEntryList();
 
 protected:
     IdentPtrList* EnsureRequestedModulesList();
-    ModuleImportEntryList* EnsureModuleImportEntryList();
-    ModuleExportEntryList* EnsureModuleLocalExportEntryList();
-    ModuleExportEntryList* EnsureModuleIndirectExportEntryList();
-    ModuleExportEntryList* EnsureModuleStarExportEntryList();
+    ModuleImportOrExportEntryList* EnsureModuleImportEntryList();
+    ModuleImportOrExportEntryList* EnsureModuleLocalExportEntryList();
+    ModuleImportOrExportEntryList* EnsureModuleIndirectExportEntryList();
+    ModuleImportOrExportEntryList* EnsureModuleStarExportEntryList();
 
     void AddModuleSpecifier(IdentPtr moduleRequest);
-    void AddModuleImportEntry(ModuleImportEntryList* importEntryList, IdentPtr importName, IdentPtr localName, IdentPtr moduleRequest, ParseNodePtr declNode);
-    void AddModuleExportEntry(ModuleExportEntryList* exportEntryList, ModuleExportEntry* exportEntry);
-    void AddModuleExportEntry(ModuleExportEntryList* exportEntryList, IdentPtr importName, IdentPtr localName, IdentPtr exportName, IdentPtr moduleRequest);
+    ModuleImportOrExportEntry* AddModuleImportOrExportEntry(ModuleImportOrExportEntryList* importOrExportEntryList, IdentPtr importName, IdentPtr localName, IdentPtr exportName, IdentPtr moduleRequest);
+    ModuleImportOrExportEntry* AddModuleImportOrExportEntry(ModuleImportOrExportEntryList* importOrExportEntryList, ModuleImportOrExportEntry* importOrExportEntry);
     void AddModuleLocalExportEntry(ParseNodePtr varDeclNode);
-    void CheckForDuplicateExportEntry(ModuleExportEntryList* exportEntryList, IdentPtr exportName);
+    void CheckForDuplicateExportEntry(ModuleImportOrExportEntryList* exportEntryList, IdentPtr exportName);
 
-    Js::PropertyId EnsurePropertyId(IdentPtr pid);
     ParseNodePtr CreateModuleImportDeclNode(IdentPtr localName);
     void MarkIdentifierReferenceIsModuleExport(IdentPtr localName);
 
@@ -816,12 +814,12 @@ private:
     bool IsImportOrExportStatementValidHere();
 
     template<bool buildAST> ParseNodePtr ParseImportDeclaration();
-    template<bool buildAST> void ParseImportClause(ModuleImportEntryList* importEntryList, bool parsingAfterComma = false);
+    template<bool buildAST> void ParseImportClause(ModuleImportOrExportEntryList* importEntryList, bool parsingAfterComma = false);
 
     template<bool buildAST> ParseNodePtr ParseExportDeclaration();
     template<bool buildAST> ParseNodePtr ParseDefaultExportClause();
 
-    template<bool buildAST> void ParseNamedImportOrExportClause(ModuleImportEntryList* importEntryList, ModuleExportEntryList* exportEntryList, bool isExportClause);
+    template<bool buildAST> void ParseNamedImportOrExportClause(ModuleImportOrExportEntryList* importOrExportEntryList, bool isExportClause);
     template<bool buildAST> IdentPtr ParseImportOrExportFromClause(bool throwIfNotFound);
 
     BOOL NodeIsIdent(ParseNodePtr pnode, IdentPtr pid);

--- a/lib/Parser/ParserCommon.h
+++ b/lib/Parser/ParserCommon.h
@@ -36,18 +36,8 @@ typedef ParseNode *ParseNodePtr;
 
 struct Ident;
 typedef Ident *IdentPtr;
-class Symbol;
 
-struct ModuleImportEntry
-{
-    IdentPtr moduleRequest;
-    IdentPtr importName;
-    IdentPtr localName;
-
-    ParseNodePtr varDecl;
-};
-
-struct ModuleExportEntry
+struct ModuleImportOrExportEntry
 {
     IdentPtr moduleRequest;
     IdentPtr importName;
@@ -55,8 +45,7 @@ struct ModuleExportEntry
     IdentPtr exportName;
 };
 
-typedef SList<ModuleImportEntry, ArenaAllocator> ModuleImportEntryList;
-typedef SList<ModuleExportEntry, ArenaAllocator> ModuleExportEntryList;
+typedef SList<ModuleImportOrExportEntry, ArenaAllocator> ModuleImportOrExportEntryList;
 typedef SList<IdentPtr, ArenaAllocator> IdentPtrList;
 
 //

--- a/lib/Parser/ptree.h
+++ b/lib/Parser/ptree.h
@@ -401,10 +401,10 @@ struct PnProg : PnFnc
 
 struct PnModule : PnProg
 {
-    ModuleExportEntryList* localExportEntries;
-    ModuleExportEntryList* indirectExportEntries;
-    ModuleExportEntryList* starExportEntries;
-    ModuleImportEntryList* importEntries;
+    ModuleImportOrExportEntryList* localExportEntries;
+    ModuleImportOrExportEntryList* indirectExportEntries;
+    ModuleImportOrExportEntryList* starExportEntries;
+    ModuleImportOrExportEntryList* importEntries;
     IdentPtrList* requestedModules;
 };
 

--- a/lib/Parser/rterrors.h
+++ b/lib/Parser/rterrors.h
@@ -337,9 +337,10 @@ RT_ERROR_MSG(JSERR_RegExpExecInvalidReturnType, 5641, "%s: Return value of RegEx
 
 RT_ERROR_MSG(JSERR_ProxyTrapReturnedFalse, 5642, "Proxy trap `%s` returned false", "Proxy trap returned false", kjstTypeError, 0)
 RT_ERROR_MSG(JSERR_ModuleResolveExport, 5643, "Module export %s cannot be resolved", "Module export cannot be resolved", kjstSyntaxError, 0)
-RT_ERROR_MSG(JSERR_TooManyImportExprots, 5644, "Module has too many import/export definitions", "Module has too many import/export definitions", kjstRangeError, 0)
-RT_ERROR_MSG(JSERR_CannotResolveModule, 5645, "HostResolveImportedModule failed to resolve module with specifier %s", "HostResolveImportedModule failed to resolve module", kjstReferenceError, 0)
-RT_ERROR_MSG(JSERR_ResolveExportFailed, 5646, "Resolve export %s failed due to circular reference or resolved exports", "Resolve export failed due to circular reference or resolved exports", kjstSyntaxError, 0)
+RT_ERROR_MSG(JSERR_ModuleResolveImport, 5644, "Module import %s cannot be resolved", "Module import cannot be resolved", kjstSyntaxError, 0)
+RT_ERROR_MSG(JSERR_TooManyImportExports, 5645, "Module has too many import/export definitions", "Module has too many import/export definitions", kjstRangeError, 0)
+RT_ERROR_MSG(JSERR_CannotResolveModule, 5646, "HostResolveImportedModule failed to resolve module with specifier %s", "HostResolveImportedModule failed to resolve module", kjstReferenceError, 0)
+RT_ERROR_MSG(JSERR_ResolveExportFailed, 5647, "Resolve export %s failed due to circular reference or resolved exports", "Resolve export failed due to circular reference or resolved exports", kjstSyntaxError, 0)
 
-RT_ERROR_MSG(JSERR_ObjectCoercible, 5647, "", "Cannot convert null or undefined to object", kjstTypeError, 0)
-RT_ERROR_MSG(JSERR_SIMDConversion, 5648, "%s: cannot be converted to a number", "Cannot be converted to a number", kjstTypeError, 0)
+RT_ERROR_MSG(JSERR_ObjectCoercible, 5648, "", "Cannot convert null or undefined to object", kjstTypeError, 0)
+RT_ERROR_MSG(JSERR_SIMDConversion, 5649, "%s: cannot be converted to a number", "Cannot be converted to a number", kjstTypeError, 0)

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.h
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.h
@@ -232,10 +232,9 @@ public:
     void EndEmitWith(ParseNode *pnodeWith);
     void EnsureFncScopeSlots(ParseNode *pnode, FuncInfo *funcInfo);
     void EnsureLetConstScopeSlots(ParseNode *pnodeBlock, FuncInfo *funcInfo);
-    void EnsureImportBindingScopeSlots(ParseNode* pnode, FuncInfo* funcInfo);
-    void EnsureExportBindingScopeSlots(ParseNode* pnode, FuncInfo* funcInfo);
-    void EnsureSymbolModuleSlots(Symbol* sym, FuncInfo* funcInfo, IdentPtr exportName = nullptr, IdentPtr moduleSpecifier = nullptr);
+    bool EnsureSymbolModuleSlots(Symbol* sym, FuncInfo* funcInfo);
     void EmitAssignmentToDefaultModuleExport(ParseNode* pnode, FuncInfo* funcInfo);
+    void EmitModuleExportAccess(Symbol* sym, Js::OpCode opcode, Js::RegSlot location, FuncInfo* funcInfo);
 
     void PushScope(Scope *innerScope);
     void PopScope();

--- a/lib/Runtime/ByteCode/Symbol.h
+++ b/lib/Runtime/ByteCode/Symbol.h
@@ -43,6 +43,7 @@ private:
     BYTE hasVisitedCapturingFunc : 1;
     BYTE isTrackedForDebugger : 1; // Whether the sym is tracked for debugger scope. This is fine because a sym can only be added to (not more than) one scope.
     BYTE isModuleExportStorage : 1; // If true, this symbol should be stored in the global scope export storage array.
+    BYTE isModuleImport : 1; // If true, this symbol is the local name of a module import statement
 
     // These are get and set a lot, don't put it in bit fields, we are exceeding the number of bits anyway
     bool hasFuncAssignment;
@@ -76,6 +77,7 @@ public:
         isNonSimpleParameter(false),
         assignmentState(NotAssigned),
         isModuleExportStorage(false),
+        isModuleImport(false),
         moduleIndex(Js::Constants::NoProperty)
     {
         SetSymbolType(symbolType);
@@ -154,6 +156,16 @@ public:
     bool GetIsModuleExportStorage() const
     {
         return isModuleExportStorage;
+    }
+
+    void SetIsModuleImport(bool is)
+    {
+        isModuleImport = is;
+    }
+
+    bool GetIsModuleImport() const
+    {
+        return isModuleImport;
     }
 
     void SetModuleIndex(Js::PropertyId index)

--- a/lib/Runtime/Language/SourceTextModuleRecord.h
+++ b/lib/Runtime/Language/SourceTextModuleRecord.h
@@ -20,16 +20,17 @@ namespace Js
 
         SourceTextModuleRecord(ScriptContext* scriptContext);
         IdentPtrList* GetRequestedModuleList() const { return requestedModuleList; }
-        ModuleImportEntryList* GetImportEntryList() const { return importRecordList; }
-        ModuleExportEntryList* GetLocalExportEntryList() const { return localExportRecordList; }
-        ModuleExportEntryList* GetIndirectExportEntryList() const { return indirectExportRecordList; }
-        ModuleExportEntryList* GetStarExportRecordList() const { return starExportRecordList; }
+        ModuleImportOrExportEntryList* GetImportEntryList() const { return importRecordList; }
+        ModuleImportOrExportEntryList* GetLocalExportEntryList() const { return localExportRecordList; }
+        ModuleImportOrExportEntryList* GetIndirectExportEntryList() const { return indirectExportRecordList; }
+        ModuleImportOrExportEntryList* GetStarExportRecordList() const { return starExportRecordList; }
         virtual ExportedNames* GetExportedNames(ExportModuleRecordList* exportStarSet) override;
         virtual bool IsSourceTextModuleRecord() override { return true; } // we don't really have other kind of modulerecord at this time.
 
         // return false when "ambiguous". 
         // otherwise nullptr means "null" where we have circular reference/cannot resolve.
         bool ResolveExport(PropertyId exportName, ResolveSet* resolveSet, ExportModuleRecordList* exportStarSet, ModuleNameRecord** exportRecord) override;
+        bool ResolveImport(PropertyId localName, ModuleNameRecord** importRecord);
         void ModuleDeclarationInstantiation() override;
         Var ModuleEvaluation() override;
 
@@ -48,10 +49,10 @@ namespace Js
         void SetWasDeclarationInitialized() { wasDeclarationInitialized = true; }
         void SetIsRootModule() { isRootModule = true; }
 
-        void SetImportRecordList(ModuleImportEntryList* importList) { importRecordList = importList; }
-        void SetLocalExportRecordList(ModuleExportEntryList* localExports) { localExportRecordList = localExports; }
-        void SetIndirectExportRecordList(ModuleExportEntryList* indirectExports) { indirectExportRecordList = indirectExports; }
-        void SetStarExportRecordList(ModuleExportEntryList* starExports) { starExportRecordList = starExports; }
+        void SetImportRecordList(ModuleImportOrExportEntryList* importList) { importRecordList = importList; }
+        void SetLocalExportRecordList(ModuleImportOrExportEntryList* localExports) { localExportRecordList = localExports; }
+        void SetIndirectExportRecordList(ModuleImportOrExportEntryList* indirectExports) { indirectExportRecordList = indirectExports; }
+        void SetStarExportRecordList(ModuleImportOrExportEntryList* starExports) { starExportRecordList = starExports; }
         void SetrequestedModuleList(IdentPtrList* requestModules) { requestedModuleList = requestModules; }
 
         ScriptContext* GetScriptContext() const { return scriptContext; }
@@ -93,10 +94,10 @@ namespace Js
         Parser* parser;  // we'll need to keep the parser around till we are done with bytecode gen.
         ScriptContext* scriptContext;
         IdentPtrList* requestedModuleList;
-        ModuleImportEntryList* importRecordList;
-        ModuleExportEntryList* localExportRecordList;
-        ModuleExportEntryList* indirectExportRecordList;
-        ModuleExportEntryList* starExportRecordList;
+        ModuleImportOrExportEntryList* importRecordList;
+        ModuleImportOrExportEntryList* localExportRecordList;
+        ModuleImportOrExportEntryList* indirectExportRecordList;
+        ModuleImportOrExportEntryList* starExportRecordList;
         ChildModuleRecordSet* childrenModuleSet;
         ModuleRecordList* parentModuleList;
         LocalExportMap* localExportMapByExportName;  // from propertyId to index map: for bytecode gen.
@@ -123,6 +124,7 @@ namespace Js
         HRESULT OnChildModuleReady(SourceTextModuleRecord* childModule, Var errorObj);
         void NotifyParentsAsNeeded();
         void CleanupBeforeExecution();
+        void InitializeLocalImports();
         void InitializeLocalExports();
         void InitializeIndirectExports();
         PropertyId EnsurePropertyIdForIdentifier(IdentPtr pid);


### PR DESCRIPTION
Fix module cyclic dependencies

Make import and export link errors into syntax errors instead of runtime
errors.

Enable re-export of a locally-bound import. This is re-export without an
"export ... from ..." statement. Instead we allow an import to be
re-exported implicitly. Looks like "import { foo } from 'm'; export { foo
};"

Also fixed a few cases where accessing module exports via slots was
failing. One case here was typeof which has a special case for loading the
target of the typeof statement.

Fix spelling mistake in error code name
