### PR TITLE
Fix OS 4721262: FailFast when JsAddRef fails in CallbackMessage ctor.

### DIFF
--- a/bin/ch/WScriptJsrt.cpp
+++ b/bin/ch/WScriptJsrt.cpp
@@ -606,7 +606,12 @@ void WScriptJsrt::AddMessageQueue(MessageQueue *_messageQueue)
 
 WScriptJsrt::CallbackMessage::CallbackMessage(unsigned int time, JsValueRef function) : MessageBase(time), m_function(function)
 {
-    ChakraRTInterface::JsAddRef(m_function, nullptr);
+    JsErrorCode error = ChakraRTInterface::JsAddRef(m_function, nullptr);
+    if (error != JsNoError)
+    {
+        AssertMsg(false, "FATAL ERROR: ChakraRTInterface::JsAddRef failed in WScriptJsrt::CallbackMessage::`ctor`.");
+        RaiseFailFastException(NULL, NULL, 0);
+    }
 }
 
 WScriptJsrt::CallbackMessage::~CallbackMessage()


### PR DESCRIPTION
Allowing the code to continue after a failed JsAddRef will cause corruption of the datastructure which will cause issues later, notable during the dtor when it looks for the Ref which should have been added and should exist.

When OOM occurs and this call fails, we should terminate the process because the OOM is not recoverable in this case. Assert in debug builds and raise the FailFast error in any case.
