### PR TITLE
Fix OS 4721262: Report fatal error when JsAddRef fails in CallbackMessage ctor.

### DIFF
--- a/bin/ch/WScriptJsrt.cpp
+++ b/bin/ch/WScriptJsrt.cpp
@@ -606,7 +606,14 @@ void WScriptJsrt::AddMessageQueue(MessageQueue *_messageQueue)
 
 WScriptJsrt::CallbackMessage::CallbackMessage(unsigned int time, JsValueRef function) : MessageBase(time), m_function(function)
 {
-    ChakraRTInterface::JsAddRef(m_function, nullptr);
+    JsErrorCode error = ChakraRTInterface::JsAddRef(m_function, nullptr);
+    if (error != JsNoError)
+    {
+        // Simply report a fatal error and exit because continuing from this point would result in inconsistent state
+        // and FailFast telemetry would not be useful.
+        wprintf(_u("FATAL ERROR: ChakraRTInterface::JsAddRef failed in WScriptJsrt::CallbackMessage::`ctor`. error=0x%x\n"), error);
+        exit(1);
+    }
 }
 
 WScriptJsrt::CallbackMessage::~CallbackMessage()


### PR DESCRIPTION
Allowing the code to continue after a failed JsAddRef will cause corruption of the datastructure which will cause issues later, notable during the dtor when it looks for the Ref which should have been added and should exist.

When OOM occurs and this call fails, we should terminate the process because the OOM is not recoverable in this case.