### PR TITLE
Conversion from uint32 to int32 should be marked lossy

### DIFF
--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -10962,7 +10962,14 @@ GlobOpt::TypeSpecializeBinary(IR::Instr **pInstr, Value **pSrc1Val, Value **pSrc
 
             // Try to type specialize to int32
 
-            lossy = false;
+            // If one of the values is a float constant with a value that fits in a uint32 but not an int32, 
+            // and the instruction can ignore int overflow, the source value for the purposes of int specialization 
+            // would have been changed to an int constant value by ignoring overflow. But, the conversion is still lossy.
+            if (!(src1OriginalVal && src1OriginalVal->GetValueInfo()->IsFloatConstant() && src1Val && src1Val->GetValueInfo()->HasIntConstantValue()) &&
+                !(src2OriginalVal && src2OriginalVal->GetValueInfo()->IsFloatConstant() && src2Val && src2Val->GetValueInfo()->HasIntConstantValue()))
+            {
+                lossy = false;
+            }
 
             switch(instr->m_opcode)
             {

--- a/test/Optimizer/LossyLosslessInt32.baseline
+++ b/test/Optimizer/LossyLosslessInt32.baseline
@@ -6,3 +6,6 @@ test3b: valueOf
 test3b: valueOf
 test3b: 2
 test3c: TypeError
+test4
+2147483650
+2147483650

--- a/test/Optimizer/LossyLosslessInt32.js
+++ b/test/Optimizer/LossyLosslessInt32.js
@@ -86,3 +86,27 @@ function safeCall(f) {
         return ex.name;
     }
 }
+
+// Conversions from uint32 to int32 should be treated as lossy
+WScript.Echo("test4");
+function makeArrayLength(x) {
+    print( Math.floor(x));
+  }
+function test4(a) {
+  
+  var func2 = function () {
+  };
+  func2.length = 1;
+  func2.prop4 = 1;
+  var __loopvar2 = 0;
+  while ((func2.prop4+ 2147483650) |1) {
+
+    if (__loopvar2) {
+      break;
+    }
+    __loopvar2 = 2;
+	   makeArrayLength(2147483650);
+  }
+}
+test4();
+test4();

--- a/test/Optimizer/rlexe.xml
+++ b/test/Optimizer/rlexe.xml
@@ -1092,6 +1092,13 @@
       <baseline>LossyLosslessInt32.baseline</baseline>
     </default>
   </test>
+    <test>
+    <default>
+      <files>LossyLosslessInt32.js</files>
+      <compile-flags>-off:simplejit</compile-flags>
+      <baseline>LossyLosslessInt32.baseline</baseline>
+    </default>
+  </test>
   <test>
     <default>
       <files>AggressiveIntTypeSpec.js</files>


### PR DESCRIPTION
If one of the values in a binary operation is a float constant with a value that fits in a uint32 but not an int32, and the instruction can ignore int overflow, the source value for the purposes of int specialization would have been changed to an int constant value by ignoring overflow. But, the conversion is still lossy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/700)
<!-- Reviewable:end -->
