### PR TITLE
Simple X64 JIT issue

### DIFF
--- a/lib/Backend/amd64/EncoderMD.cpp
+++ b/lib/Backend/amd64/EncoderMD.cpp
@@ -815,7 +815,7 @@ EncoderMD::Encode(IR::Instr *instr, BYTE *pc, BYTE* beginCodeAddress)
 
             if (opr2->IsImmediateOpnd())
             {
-                Assert(instr->m_opcode == Js::OpCode::MOV);
+                Assert(EncoderMD::IsMOVEncoding(instr));
                 if (instrSize == 8 && !instr->isInlineeEntryInstr && Math::FitsInDWord(opr2->GetImmediateValue()))
                 {
                     // Better off using the C7 encoding as it will sign extend
@@ -1672,7 +1672,7 @@ bool EncoderMD::TryConstFold(IR::Instr *instr, IR::RegOpnd *regOpnd)
 
     bool isNotLargeConstant = Math::FitsInDWord(regOpnd->m_sym->GetLiteralConstValue_PostGlobOpt());
 
-    if (!isNotLargeConstant && (instr->m_opcode != Js::OpCode::MOV || !instr->GetDst()->IsRegOpnd()))
+    if (!isNotLargeConstant && (!EncoderMD::IsMOVEncoding(instr) || !instr->GetDst()->IsRegOpnd()))
     {
         return false;
     }
@@ -1875,6 +1875,11 @@ bool EncoderMD::UsesConditionCode(IR::Instr *instr)
 bool EncoderMD::IsOPEQ(IR::Instr *instr)
 {
     return instr->IsLowered() && (EncoderMD::GetOpdope(instr) & DOPEQ);
+}
+
+bool EncoderMD::IsMOVEncoding(IR::Instr *instr)
+{
+    return instr->IsLowered() && (EncoderMD::GetOpdope(instr) & DMOV);
 }
 
 void EncoderMD::UpdateRelocListWithNewBuffer(RelocList * relocList, BYTE * newBuffer, BYTE * oldBufferStart, BYTE * oldBufferEnd)

--- a/lib/Backend/amd64/EncoderMD.h
+++ b/lib/Backend/amd64/EncoderMD.h
@@ -180,6 +180,7 @@ public:
     static bool     SetsConditionCode(IR::Instr *instr);
     static bool     UsesConditionCode(IR::Instr *instr);
     static bool     IsOPEQ(IR::Instr *instr);
+    static bool     IsMOVEncoding(IR::Instr *instr);
     RelocList*      GetRelocList() const { return m_relocList; }
     int             AppendRelocEntry(RelocType type, void *ptr, IR::LabelInstr *label= nullptr);
     int             FixRelocListEntry(uint32 index, int totalBytesSaved, BYTE *buffStart, BYTE* buffEnd);

--- a/lib/Backend/amd64/MdOpCodes.h
+++ b/lib/Backend/amd64/MdOpCodes.h
@@ -129,8 +129,8 @@ MACRO(MINPS,    Reg2,       None,           RNON,   f(MODRM),   o(MINPS),   DNO1
 
 MACRO(LZCNT,    Reg2,   None,          RNON,   f(MODRM),   o(LZCNT),   DF3|DSETCC|DDST,             OLB_0F)
 
-MACRO(MOV,      Reg2,   None,          R000,   f(MOV),     o(MOV),     DDST,                        OLB_NONE)
-MACRO(MOV_TRUNC,Reg2,   None,          R000,   f(MOV),     o(MOV),     DDST,                        OLB_NONE)// Like a MOV, but MOV ECX, ECX can't be removed (truncation)
+MACRO(MOV,      Reg2,   None,          R000,   f(MOV),     o(MOV),     DDST|DMOV,                   OLB_NONE)
+MACRO(MOV_TRUNC,Reg2,   None,          R000,   f(MOV),     o(MOV),     DDST|DMOV,                   OLB_NONE)// Like a MOV, but MOV ECX, ECX can't be removed (truncation)
 MACRO(MOVD,     Reg2,   None,          RNON,   f(SPECIAL), o(MOVD),    DDST|DNO16|D66,              OLB_0F)
 
 

--- a/lib/Backend/amd64/X64Encode.h
+++ b/lib/Backend/amd64/X64Encode.h
@@ -37,9 +37,10 @@
 #define DDST    0x800    /* get the first operand from the DST list */
 #define DCOMMOP 0x1000   /* opcode is commutative */
 #define D66EX   0x2000   // Optional 0x66 for WNI/MNI 128-bit extended MMX opcodes
-#define DSSE    0x4000  /* Instruction operates on XMM registers but not AVX */
-#define D66     0x100000 // 0x66 0x0F style WNI form (usually 128-bit DP FP)
+#define DSSE    0x4000   /* Instruction operates on XMM registers but not AVX */
 #define DF3     0x8000   /* the 0xF3 0x0F style KNI opcodes */
+#define DMOV    0x10000  /* Instruction is a MOV or a synonym for MOV (e.g., MOV_TRUNC) */
+#define D66     0x100000 // 0x66 0x0F style WNI form (usually 128-bit DP FP)
 #define DF2     0x200000 /* 0xF2 0x0F style WNI form (usually 64-bit DP FP) */
 
 // 2nd 3 bits is options


### PR DESCRIPTION
X64 JIT: Constant prop during register allocation can produce a MOV_TRUNC with an immediate src. The encoder wasn't handling this form, but it's simple to do so.