### PR TITLE
Misc minor fixes to Switch Optimization

### DIFF
--- a/lib/Backend/BailOut.cpp
+++ b/lib/Backend/BailOut.cpp
@@ -1984,10 +1984,12 @@ void BailOutRecord::ScheduleFunctionCodeGen(Js::ScriptFunction * function, Js::S
                 break;
 
             case IR::BailOutExpectingInteger:
+                profileInfo->DisableSwitchOpt();
                 rejitReason = RejitReason::DisableSwitchOptExpectingInteger;
                 break;
 
             case IR::BailOutExpectingString:
+                profileInfo->DisableSwitchOpt();
                 rejitReason = RejitReason::DisableSwitchOptExpectingString;
                 break;
 

--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -8993,6 +8993,7 @@ GlobOpt::OptConstFoldUnary(
             {
                 throw Js::RejitException(RejitReason::DisableSwitchOptExpectingString);
             }
+            Assert(instr->GetBailOutKind() == IR::BailOutExpectingInteger);
             instr->ClearBailOutInfo();
         }
         value = intConstantValue;

--- a/lib/Backend/IR.h
+++ b/lib/Backend/IR.h
@@ -53,13 +53,6 @@ public:
         branchTargets->jmpTable = jmpTable;
         return branchTargets;
     }
-
-    static void Delete(JitArenaAllocator * allocator, BranchJumpTableWrapper * branchTargets)
-    {
-        Assert(allocator != nullptr && branchTargets != nullptr);
-        JitAdeleteArray(allocator, branchTargets->tableSize, branchTargets->jmpTable);
-        JitAdelete(allocator, branchTargets);
-    }
 };
 
 namespace IR {


### PR DESCRIPTION
- Disabled Switch optimization upon Rejit.
- Cleaned up an API which is no longer called.
- Added back the Assert in the Ld_A const folding API (It was removed
  earlier as it can have only two BailOutKinds, but it is good to have the
  old assert here.)
