### PR TITLE
use large heap block for all pageheap allocation

### DIFF
--- a/lib/Common/Exceptions/ReportError.h
+++ b/lib/Common/Exceptions/ReportError.h
@@ -18,7 +18,8 @@ enum ErrorReason
     Fatal_Version_Inconsistency = 10,
     MarkStack_OUTOFMEMORY = 11,
     EnterScript_FromDOM_NoScriptScope = 12,
-    Fatal_FailedToBox_OUTOFMEMORY = 13
+    Fatal_FailedToBox_OUTOFMEMORY = 13,
+    Fatal_Recycler_MemoryCorruption = 14
 };
 
 extern "C" void ReportFatalException(

--- a/lib/Common/Memory/HeapBlock.cpp
+++ b/lib/Common/Memory/HeapBlock.cpp
@@ -54,53 +54,6 @@ HeapBlock::SetNeedOOMRescan(Recycler * recycler)
     recycler->SetNeedOOMRescan();
 }
 
-#ifdef RECYCLER_PAGE_HEAP
-void
-HeapBlock::CapturePageHeapAllocStack()
-{
-    if (this->InPageHeapMode()) // pageheap can be enabled only for some of the buckets
-    {
-
-        // These asserts are true because explicit free is disallowed in
-        // page heap mode. If they weren't, we'd have to modify the asserts
-        Assert(this->pageHeapFreeStack == nullptr);
-        Assert(this->pageHeapAllocStack == nullptr);
-
-        // Note: NoCheckHeapAllocator will fail fast if we can't allocate the stack to capture
-        // REVIEW: Should we have a flag to configure the number of frames captured?
-        if (pageHeapAllocStack != nullptr)
-        {
-            this->pageHeapAllocStack->Capture(Recycler::s_numFramesToSkipForPageHeapAlloc);
-        }
-        else
-        {
-            this->pageHeapAllocStack = StackBackTrace::Capture(&NoCheckHeapAllocator::Instance, Recycler::s_numFramesToSkipForPageHeapAlloc, Recycler::s_numFramesToCaptureForPageHeap);
-        }
-    }
-}
-
-void
-HeapBlock::CapturePageHeapFreeStack()
-{
-    if (this->InPageHeapMode()) // pageheap can be enabled only for some of the buckets
-    {
-        // These asserts are true because explicit free is disallowed in
-        // page heap mode. If they weren't, we'd have to modify the asserts
-        Assert(this->pageHeapFreeStack == nullptr);
-        Assert(this->pageHeapAllocStack != nullptr);
-
-        if (this->pageHeapFreeStack != nullptr)
-        {
-            this->pageHeapFreeStack->Capture(Recycler::s_numFramesToSkipForPageHeapFree);
-        }
-        else
-        {
-            this->pageHeapFreeStack = StackBackTrace::Capture(&NoCheckHeapAllocator::Instance, Recycler::s_numFramesToSkipForPageHeapFree, Recycler::s_numFramesToCaptureForPageHeap);
-        }
-    }
-}
-#endif
-
 //========================================================================================================
 // SmallHeapBlock
 //========================================================================================================
@@ -179,22 +132,6 @@ SmallHeapBlockT<TBlockAttributes>::~SmallHeapBlockT()
     heapBucket->heapInfo->heapBlockCount[this->GetHeapBlockType()]--;
     heapBucket->heapBlockCount--;
 #endif
-
-#ifdef RECYCLER_PAGE_HEAP
-    if (this->pageHeapAllocStack != nullptr)
-    {
-        this->pageHeapAllocStack->Delete(&NoCheckHeapAllocator::Instance);
-        this->pageHeapAllocStack = nullptr;
-    }
-
-    // REVIEW: This means that the old free stack is lost when we get free the heap block
-    // Is this okay? Should we delay freeing heap blocks till process/thread shutdown time?
-    if (this->pageHeapFreeStack != nullptr)
-    {
-        this->pageHeapFreeStack->Delete(&NoCheckHeapAllocator::Instance);
-        this->pageHeapFreeStack = nullptr;
-    }
-#endif
 }
 
 template <class TBlockAttributes>
@@ -209,25 +146,6 @@ uint
 SmallHeapBlockT<MediumAllocationBlockAttributes>::GetObjectBitDeltaForBucketIndex(uint bucketIndex)
 {
     return HeapInfo::GetObjectSizeForBucketIndex<MediumAllocationBlockAttributes>(bucketIndex) / HeapConstants::ObjectGranularity;
-}
-
-// TODO: consider remove and merge with GetPageCount
-template <class TBlockAttributes>
-template<bool pageheap>
-const uint
-SmallHeapBlockT<TBlockAttributes>::GetPageHeapModePageCount() const
-{
-#ifdef RECYCLER_PAGE_HEAP
-    if (pageheap)
-    {
-        if (InPageHeapMode())
-        {
-            return TBlockAttributes::PageCount + 1;
-        }
-    }
-#endif
-
-    return TBlockAttributes::PageCount;
 }
 
 template <class TBlockAttributes>
@@ -277,25 +195,6 @@ SmallHeapBlockT<TBlockAttributes>::GetExpectedSweepObjectCount() const
     return GetExpectedFreeObjectCount() - freeCount;
 }
 
-#ifdef RECYCLER_PAGE_HEAP
-template <class TBlockAttributes>
-void
-SmallHeapBlockT<TBlockAttributes>::EnablePageHeap()
-{
-    if (this->heapBucket->IsPageHeapEnabled())
-    {
-        this->pageHeapMode = this->heapBucket->heapInfo->pageHeapMode;
-    }
-}
-
-template <class TBlockAttributes>
-void
-SmallHeapBlockT<TBlockAttributes>::ClearPageHeap()
-{
-    this->pageHeapMode = PageHeapMode::PageHeapModeOff;
-}
-#endif
-
 template <class TBlockAttributes>
 void
 SmallHeapBlockT<TBlockAttributes>::Init(ushort objectSize, ushort objectCount)
@@ -320,26 +219,9 @@ SmallHeapBlockT<TBlockAttributes>::Init(ushort objectSize, ushort objectCount)
     Assert(!this->isInAllocator);
     Assert(!this->isClearedFromAllocator);
     Assert(!this->isIntegratedBlock);
-
-#ifdef RECYCLER_PAGE_HEAP
-    if (this->pageHeapAllocStack != nullptr)
-    {
-        this->pageHeapAllocStack->Delete(&NoCheckHeapAllocator::Instance);
-        this->pageHeapAllocStack = nullptr;
-    }
-
-    // REVIEW: This means that the old free stack is lost when we get reuse the heap block
-    // Is this okay? Should we never reuse heap blocks in page heap mode?
-    if (this->pageHeapFreeStack != nullptr)
-    {
-        this->pageHeapFreeStack->Delete(&NoCheckHeapAllocator::Instance);
-        this->pageHeapFreeStack = nullptr;
-    }
-#endif
 }
 
 template <class TBlockAttributes>
-template<bool pageheap>
 BOOL
 SmallHeapBlockT<TBlockAttributes>::ReassignPages(Recycler * recycler)
 {
@@ -347,13 +229,10 @@ SmallHeapBlockT<TBlockAttributes>::ReassignPages(Recycler * recycler)
     Assert(this->segment == nullptr);
 
     PageSegment * segment;
-#ifdef RECYCLER_PAGE_HEAP
-    const PageHeapMode pageHeapModeLocal = this->pageHeapMode;
-#else
-    const PageHeapMode pageHeapModeLocal = PageHeapModeOff;
-#endif
 
-    char * address = this->GetPageAllocator(recycler)->AllocPagesPageAligned(this->GetPageHeapModePageCount<pageheap>(), &segment, pageHeapModeLocal);
+    auto pageAllocator = this->GetPageAllocator(recycler);
+    uint pagecount = this->GetPageCount();
+    char * address = pageAllocator->AllocPagesPageAligned(pagecount, &segment);
 
     if (address == NULL)
     {
@@ -370,14 +249,14 @@ SmallHeapBlockT<TBlockAttributes>::ReassignPages(Recycler * recycler)
 #endif
         )
     {
-        recycler->VerifyZeroFill(address, AutoSystemInfo::PageSize * this->GetPageHeapModePageCount<pageheap>());
+        recycler->VerifyZeroFill(address, AutoSystemInfo::PageSize * this->GetPageCount());
     }
 #endif
 
-    if (!this->SetPage<pageheap>(address, segment, recycler))
+    if (!this->SetPage(address, segment, recycler))
     {
         this->GetPageAllocator(recycler)->SuspendIdleDecommit();
-        this->ReleasePages<pageheap>(recycler);
+        this->ReleasePages(recycler);
         this->GetPageAllocator(recycler)->ResumeIdleDecommit();
         return FALSE;
     }
@@ -387,65 +266,13 @@ SmallHeapBlockT<TBlockAttributes>::ReassignPages(Recycler * recycler)
     return TRUE;
 }
 
-#ifdef RECYCLER_PAGE_HEAP
 template <class TBlockAttributes>
-void
-SmallHeapBlockT<TBlockAttributes>::ClearPageHeapState()
-{
-    // If this page has a guard page associated with it,
-    // restore its access protections
-    if (this->guardPageAddress != nullptr)
-    {
-        Assert(this->InPageHeapMode());
-        DWORD oldProtectFlags = 0;
-
-        BOOL ret = ::VirtualProtect(static_cast<LPVOID>(this->guardPageAddress), AutoSystemInfo::PageSize, this->guardPageOldProtectFlags, &oldProtectFlags);
-
-        Assert(ret == TRUE);
-        Assert(oldProtectFlags == PAGE_NOACCESS);
-    }
-}
-#endif
-
-template <class TBlockAttributes>
-template<bool pageheap>
 BOOL
 SmallHeapBlockT<TBlockAttributes>::SetPage(__in_ecount_pagesize char * baseAddress, PageSegment * pageSegment, Recycler * recycler)
 {
     char* address = baseAddress;
 
-#ifdef RECYCLER_PAGE_HEAP
-    if (pageheap)
-    {
-        if (InPageHeapMode())
-        {
-            uint pageCount = this->GetPageHeapModePageCount<true>();
-            Assert(pageCount == TBlockAttributes::PageCount + 1 || (!this->InPageHeapMode() && pageCount == TBlockAttributes::PageCount));
-
-            if (this->pageHeapMode == PageHeapMode::PageHeapModeBlockStart)
-            {
-                address = baseAddress + AutoSystemInfo::PageSize;
-                this->guardPageAddress = baseAddress;
-            }
-            else if (this->pageHeapMode == PageHeapMode::PageHeapModeBlockEnd)
-            {
-                address = baseAddress;
-                this->guardPageAddress = baseAddress + (TBlockAttributes::PageCount * AutoSystemInfo::PageSize);
-            }
-
-            if (this->guardPageAddress != nullptr)
-            {
-                if (::VirtualProtect(static_cast<LPVOID>(this->guardPageAddress), AutoSystemInfo::PageSize, PAGE_NOACCESS, &guardPageOldProtectFlags) == FALSE)
-                {
-                    return FALSE;
-                }
-            }
-        }
-    }
-#endif
-
-    uint l2Id = HeapBlockMap32::GetLevel2Id(address);
-    Assert(l2Id + (TBlockAttributes::PageCount - 1) < 256);
+    Assert(HeapBlockMap32::GetLevel2Id(address) + (TBlockAttributes::PageCount - 1) < 256);
 
     this->segment = pageSegment;
     this->address = address;
@@ -491,7 +318,6 @@ SmallHeapBlockT<TBlockAttributes>::SetPage(__in_ecount_pagesize char * baseAddre
 }
 
 template <class TBlockAttributes>
-template<bool pageheap>
 void
 SmallHeapBlockT<TBlockAttributes>::ReleasePages(Recycler * recycler)
 {
@@ -508,31 +334,11 @@ SmallHeapBlockT<TBlockAttributes>::ReleasePages(Recycler * recycler)
 
     char* address = this->address;
 
-#ifdef RECYCLER_PAGE_HEAP
-    if (pageheap)
-    {
-        if (InPageHeapMode())
-        {
-            ClearPageHeapState();
-
-            if (guardPageAddress != nullptr)
-            {
-                if (this->pageHeapMode == PageHeapMode::PageHeapModeBlockStart)
-                {
-                    address = guardPageAddress;
-                }
-
-                guardPageAddress = nullptr;
-            }
-        }
-    }
-#endif
-
 #ifdef RECYCLER_FREE_MEM_FILL
-    memset(address, DbgMemFill, AutoSystemInfo::PageSize * this->GetPageHeapModePageCount<pageheap>());
+    memset(address, DbgMemFill, AutoSystemInfo::PageSize * this->GetPageCount());
 #endif
 
-    this->GetPageAllocator(recycler)->ReleasePages(address, this->GetPageHeapModePageCount<pageheap>(), this->GetPageSegment());
+    this->GetPageAllocator(recycler)->ReleasePages(address, this->GetPageCount(), this->GetPageSegment());
 
     this->segment = nullptr;
     this->address = nullptr;
@@ -540,32 +346,13 @@ SmallHeapBlockT<TBlockAttributes>::ReleasePages(Recycler * recycler)
 }
 
 template <class TBlockAttributes>
-template<bool pageheap>
 void
 SmallHeapBlockT<TBlockAttributes>::BackgroundReleasePagesSweep(Recycler* recycler)
 {
     recycler->heapBlockMap.ClearHeapBlock(address, this->GetPageCount());
     char* address = this->address;
-#ifdef RECYCLER_PAGE_HEAP
-    if (pageheap)
-    {
-        if (InPageHeapMode())
-        {
-            ClearPageHeapState();
-            if (guardPageAddress != nullptr)
-            {
-                if (this->pageHeapMode == PageHeapMode::PageHeapModeBlockStart)
-                {
-                    address = guardPageAddress;
-                }
 
-                guardPageAddress = nullptr;
-            }
-        }
-    }
-#endif
-
-    this->GetPageAllocator(recycler)->BackgroundReleasePages(address, this->GetPageHeapModePageCount<pageheap>(), this->GetPageSegment());
+    this->GetPageAllocator(recycler)->BackgroundReleasePages(address, this->GetPageCount(), this->GetPageSegment());
 
     this->address = nullptr;
     this->segment = nullptr;
@@ -581,10 +368,6 @@ SmallHeapBlockT<TBlockAttributes>::ReleasePagesShutdown(Recycler * recycler)
     {
         RecyclerVerboseTrace(recycler->GetRecyclerFlagsTable(), _u("Releasing leaf block pages at address 0x%p\n"), address);
     }
-
-#ifdef RECYCLER_PAGE_HEAP
-    ClearPageHeapState();
-#endif
 
     RemoveFromHeapBlockMap(recycler);
 
@@ -603,12 +386,11 @@ SmallHeapBlockT<TBlockAttributes>::RemoveFromHeapBlockMap(Recycler* recycler)
 }
 
 template <class TBlockAttributes>
-template<bool pageheap>
 void
 SmallHeapBlockT<TBlockAttributes>::ReleasePagesSweep(Recycler * recycler)
 {
     RemoveFromHeapBlockMap(recycler);
-    ReleasePages<pageheap>(recycler);
+    ReleasePages(recycler);
 }
 
 template <class TBlockAttributes>
@@ -637,21 +419,6 @@ SmallHeapBlockT<TBlockAttributes>::Reset()
 #if DBG
     this->isClearedFromAllocator = false;
     this->isIntegratedBlock = false;
-#endif
-
-#ifdef RECYCLER_PAGE_HEAP
-    if (this->pageHeapFreeStack != nullptr)
-    {
-        this->pageHeapFreeStack->Delete(&NoCheckHeapAllocator::Instance);
-        this->pageHeapFreeStack = nullptr;
-    }
-
-    if (this->pageHeapAllocStack != nullptr)
-    {
-        this->pageHeapAllocStack->Delete(&NoCheckHeapAllocator::Instance);
-        this->pageHeapAllocStack = nullptr;
-    }
-
 #endif
 
     // There is no page associated with this heap block,
@@ -949,24 +716,6 @@ SmallHeapBlockT<TBlockAttributes>::ClearExplicitFreeBitForObject(void* objectAdd
 
 #endif
 
-#ifdef RECYCLER_PAGE_HEAP
-template <class TBlockAttributes>
-void
-SmallHeapBlockT<TBlockAttributes>::VerifyPageHeapAllocation(_In_ char* allocation, PageHeapMode mode)
-{
-    if (mode == PageHeapMode::PageHeapModeBlockStart)
-    {
-        Assert(allocation == this->address);
-    }
-    else
-    {
-        Assert(mode == PageHeapMode::PageHeapModeBlockEnd);
-        char* lastObjectAddress = this->GetAddress() + ((this->GetObjectCount() - 1) * this->objectSize);
-        Assert(lastObjectAddress <= this->GetEndAddress() - this->objectSize);
-    }
-}
-#endif
-
 #ifdef RECYCLER_VERIFY_MARK
 
 template <class TBlockAttributes>
@@ -1085,11 +834,6 @@ SmallHeapBlockT<TBlockAttributes>::DoPartialReusePage(RecyclerSweep const& recyc
 {
     // Partial GC page reuse heuristic
 
-#ifdef RECYCLER_PAGE_HEAP
-    // we should not get here in page heap mode.
-    Assert(!this->InPageHeapMode());
-#endif
-
     Assert(recyclerSweep.InPartialCollectMode());
     expectFreeByteCount = GetExpectedFreeBytes();
     // PartialCollectSmallHeapBlockReuseMinFreeBytes is calculated by dwPageSize* efficacy. If efficacy is
@@ -1168,48 +912,11 @@ SmallHeapBlockT<TBlockAttributes>::AdjustPartialUncollectedAllocBytes(RecyclerSw
 }
 #endif
 
-#ifdef RECYCLER_PAGE_HEAP
 template <class TBlockAttributes>
-char *
-SmallHeapBlockT<TBlockAttributes>::GetPageHeapObjectAddress()
-{
-    Assert(InPageHeapMode());
-
-    if (this->pageHeapMode == PageHeapMode::PageHeapModeBlockStart)
-    {
-        return this->address;
-    }
-    else if (this->pageHeapMode == PageHeapMode::PageHeapModeBlockEnd)
-    {
-        return this->address + (this->objectCount - 1) * objectSize;
-    }
-    else
-    {
-        AssertMsg(false, "Unknown PageHeapMode");
-        return nullptr;
-    }
-}
-#endif
-
-template <class TBlockAttributes>
-template <bool pageheap>
 uint
 SmallHeapBlockT<TBlockAttributes>::GetMarkCountForSweep()
 {
     Assert(IsFreeBitsValid());
-
-    // Determine the number of marked, non-free objects in the block.
-
-#ifdef RECYCLER_PAGE_HEAP
-    if (pageheap && InPageHeapMode())
-    {
-        uint bitIndex = this->GetAddressBitIndex(this->GetPageHeapObjectAddress());
-        bool marked = (this->GetMarkedBitVector()->Test(bitIndex) && !this->GetFreeBitVector()->Test(bitIndex));
-        return marked ? 1 : 0;
-    }
-
-    Assert(!InPageHeapMode());
-#endif
 
     // Make a local copy of mark bits, so we don't modify the actual mark bits.
     SmallHeapBlockBitVector temp;
@@ -1228,7 +935,6 @@ SmallHeapBlockT<TBlockAttributes>::GetMarkCountForSweep()
 }
 
 template <class TBlockAttributes>
-template <bool pageheap>
 SweepState
 SmallHeapBlockT<TBlockAttributes>::Sweep(RecyclerSweep& recyclerSweep, bool queuePendingSweep, bool allocable, ushort finalizeCount, bool hasPendingDispose)
 {
@@ -1262,7 +968,7 @@ SmallHeapBlockT<TBlockAttributes>::Sweep(RecyclerSweep& recyclerSweep, bool queu
     Assert(this->freeCount == this->GetFreeBitVector()->Count());
     RECYCLER_SLOW_CHECK(CheckFreeBitVector(true));
 
-    const uint localMarkCount = this->GetMarkCountForSweep<pageheap>();
+    const uint localMarkCount = this->GetMarkCountForSweep();
     this->markCount = (ushort)localMarkCount;
     Assert(markCount <= objectCount - this->freeCount);
 
@@ -1288,32 +994,12 @@ SmallHeapBlockT<TBlockAttributes>::Sweep(RecyclerSweep& recyclerSweep, bool queu
     const bool isAllFreed = (finalizeCount == 0 && noRealObjectsMarked && !hasPendingDispose);
     if (isAllFreed)
     {
-        recycler->NotifyFree<pageheap>(this);
+        recycler->NotifyFree(this);
 
         Assert(!this->HasPendingDisposeObjects());
 
-#ifdef RECYCLER_PAGE_HEAP
-        if (pageheap)
-        {
-            if (InPageHeapMode())
-            {
-                PageHeapVerboseTrace(recycler->GetRecyclerFlagsTable(), _u("Heap block 0x%p is empty\n"), this);
-            }
-        }
-#endif
-
         return SweepStateEmpty;
     }
-
-#ifdef RECYCLER_PAGE_HEAP
-    if (pageheap)
-    {
-        if (InPageHeapMode())
-        {
-            PageHeapVerboseTrace(recycler->GetRecyclerFlagsTable(), _u("Heap block 0x%p is not empty, local mark count is %d, expected sweep count is %d\n"), this, localMarkCount, expectSweepCount);
-        }
-    }
-#endif
 
     RECYCLER_STATS_ADD(recycler, heapBlockFreeByteCount[this->GetHeapBlockType()], expectFreeCount * this->objectSize);
 
@@ -1330,22 +1016,6 @@ SmallHeapBlockT<TBlockAttributes>::Sweep(RecyclerSweep& recyclerSweep, bool queu
         // nothing has been freed
         return (this->freeCount == 0) ? SweepStateFull : state;
     }
-
-#ifdef RECYCLER_PAGE_HEAP
-    if (pageheap)
-    {
-        if (InPageHeapMode())
-        {
-            // If a real object (either the one at the beginning of the page or at
-            // the end of the page) was marked, then this block is full
-            if (noRealObjectsMarked == false)
-            {
-                Assert(localMarkCount == 1);
-                return SweepStateFull;
-            }
-        }
-    }
-#endif
 
     RECYCLER_STATS_INC(recycler, heapBlockSweptCount[this->GetHeapBlockType()]);
 
@@ -1375,7 +1045,7 @@ SmallHeapBlockT<TBlockAttributes>::Sweep(RecyclerSweep& recyclerSweep, bool queu
     Assert(!recyclerSweep.IsBackground());
 #endif
 
-    SweepObjects<pageheap, SweepMode_InThread>(recycler);
+    SweepObjects<SweepMode_InThread>(recycler);
     if (HasPendingDisposeObjects())
     {
         Assert(finalizeCount != 0);
@@ -1404,7 +1074,7 @@ SmallHeapBlockT<TBlockAttributes>::GetMarkCountOnHeapBlockMap() const
 #endif
 
 template <class TBlockAttributes>
-template <bool pageheap, SweepMode mode>
+template <SweepMode mode>
 void
 SmallHeapBlockT<TBlockAttributes>::SweepObjects(Recycler * recycler)
 {
@@ -1416,147 +1086,94 @@ SmallHeapBlockT<TBlockAttributes>::SweepObjects(Recycler * recycler)
 #endif
     Assert(this->IsFreeBitsValid());
     Assert(this->markCount != 0 || this->isForceSweeping || this->IsAnyFinalizableBlock());
-    Assert(this->markCount == this->GetMarkCountForSweep<pageheap>());
+    Assert(this->markCount == this->GetMarkCountForSweep());
 
     DebugOnly(VerifyMarkBitVector());
 
     SmallHeapBlockBitVector * marked = this->GetMarkedBitVector();
 
-#ifdef RECYCLER_PAGE_HEAP
-    if (pageheap && this->InPageHeapMode())
+    DebugOnly(const uint expectedSweepCount = objectCount - freeCount - markCount);
+    Assert(expectedSweepCount != 0 || this->isForceSweeping);
+    DebugOnly(uint sweepCount = 0);
+
+    const uint localSize = objectSize;
+    const uint localObjectCount = objectCount;
+    const char* objectAddress = address;
+    uint objectBitDelta = this->GetObjectBitDelta();
+
+    for (uint objectIndex = 0, bitIndex = 0; objectIndex < localObjectCount; objectIndex++, bitIndex += objectBitDelta)
     {
-        // Page heap blocks are always swept in thread.
-        Assert(mode == SweepMode_InThread);
+        Assert(IsValidBitIndex(bitIndex));
+
+        RECYCLER_STATS_ADD(recycler, objectSweepScanCount, !isForceSweeping);
+        if (!marked->Test(bitIndex))
+        {
+            if (!this->GetFreeBitVector()->Test(bitIndex))
+            {
+                Assert((this->ObjectInfo(objectIndex) & ImplicitRootBit) == 0);
+                FreeObject* addr = (FreeObject*)objectAddress;
+
+#if ENABLE_PARTIAL_GC && ENABLE_CONCURRENT_GC
+                if (mode != SweepMode_ConcurrentPartial)
+#endif
+                {
+                    // Don't call NotifyFree if we are doing a partial sweep.
+                    // Since we are not actually collecting the object, we will do the NotifyFree later
+                    // when the object is actually collected in a future Sweep.
+                    recycler->NotifyFree((char *)addr, this->objectSize);
+                }
+#if DBG
+                sweepCount++;
+#endif
+                SweepObject<mode>(recycler, objectIndex, addr);
+            }
+        }
+
+#if DBG
+        if (marked->Test(bitIndex))
+        {
+            Assert((ObjectInfo(objectIndex) & NewTrackBit) == 0);
+        }
+#endif
+
+        objectAddress += localSize;
+    }
+
+    Assert(sweepCount == expectedSweepCount);
 #if ENABLE_CONCURRENT_GC
-        Assert(!this->isPendingConcurrentSweep);
+    this->isPendingConcurrentSweep = false;
 #endif
 
-        char * objectAddress = this->GetPageHeapObjectAddress();
-        uint bitIndex = this->GetAddressBitIndex(objectAddress);
-        uint objectIndex = this->GetAddressIndex(objectAddress);
+#if ENABLE_PARTIAL_GC && ENABLE_CONCURRENT_GC
+    if (mode == SweepMode_ConcurrentPartial)
+    {
+        Assert(recycler->inPartialCollectMode);
 
-        // We know that the object is not live, or we wouldn't be here.
-        Assert(this->markCount == 0);
-
-        // However, it's possible that the PageHeap object is already free.
-        // This can happen when the block was in PendingDispose state, and then
-        // we did the dispose and freed the object in TransferDisposeObjects.
-        // So check for this.
-        if (this->GetFreeBitVector()->Test(bitIndex))
-        {
-            Assert(this->IsAnyFinalizableBlock());
-            Assert(this->freeCount == 1);
-        }
-        else
-        {
-            Assert(!marked->Test(bitIndex));
-            Assert((this->ObjectInfo(objectIndex) & ImplicitRootBit) == 0);
-            FreeObject* addr = (FreeObject*)objectAddress;
-
-            recycler->NotifyFree((char *)addr, this->objectSize);
-            SweepObject<SweepMode_InThread>(recycler, objectIndex, addr);
-
-            // Update the free bit vector
-            Assert(this->freeCount == 0);
-            this->GetFreeBitVector()->Set(bitIndex);
-#if ENABLE_PARTIAL_GC
-            this->oldFreeCount = this->lastFreeCount = this->freeCount = 1;
-#else
-            this->lastFreeCount = this->freeCount = 1;
-#endif
-            this->lastFreeObjectHead = this->freeObjectList;
-        }
+        // We didn't actually collect anything, so the free bit vector should still be valid.
+        Assert(IsFreeBitsValid());
     }
     else
 #endif
     {
-#ifdef RECYCLER_PAGE_HEAP
-        Assert(!this->InPageHeapMode());
-#endif
-
-        DebugOnly(const uint expectedSweepCount = objectCount - freeCount - markCount);
-        Assert(expectedSweepCount != 0 || this->isForceSweeping);
-        DebugOnly(uint sweepCount = 0);
-
-        const uint localSize = objectSize;
-        const uint localObjectCount = objectCount;
-        const char* objectAddress = address;
-        uint objectBitDelta = this->GetObjectBitDelta();
-
-        for (uint objectIndex = 0, bitIndex = 0; objectIndex < localObjectCount; objectIndex++, bitIndex += objectBitDelta)
-        {
-            Assert(IsValidBitIndex(bitIndex));
-
-            RECYCLER_STATS_ADD(recycler, objectSweepScanCount, !isForceSweeping);
-            if (!marked->Test(bitIndex))
-            {
-                if (!this->GetFreeBitVector()->Test(bitIndex))
-                {
-                    Assert((this->ObjectInfo(objectIndex) & ImplicitRootBit) == 0);
-                    FreeObject* addr = (FreeObject*)objectAddress;
-
-#if ENABLE_PARTIAL_GC && ENABLE_CONCURRENT_GC
-                    if (mode != SweepMode_ConcurrentPartial)
-#endif
-                    {
-                        // Don't call NotifyFree if we are doing a partial sweep.
-                        // Since we are not actually collecting the object, we will do the NotifyFree later
-                        // when the object is actually collected in a future Sweep.
-                        recycler->NotifyFree((char *)addr, this->objectSize);
-                    }
-#if DBG
-                    sweepCount++;
-#endif
-                    SweepObject<mode>(recycler, objectIndex, addr);
-                }
-            }
-
-#if DBG
-            if (marked->Test(bitIndex))
-            {
-                Assert((ObjectInfo(objectIndex) & NewTrackBit) == 0);
-            }
-#endif
-
-            objectAddress += localSize;
-        }
-
-        Assert(sweepCount == expectedSweepCount);
-#if ENABLE_CONCURRENT_GC
-        this->isPendingConcurrentSweep = false;
-#endif
-
-#if ENABLE_PARTIAL_GC && ENABLE_CONCURRENT_GC
-        if (mode == SweepMode_ConcurrentPartial)
-        {
-            Assert(recycler->inPartialCollectMode);
-
-            // We didn't actually collect anything, so the free bit vector should still be valid.
-            Assert(IsFreeBitsValid());
-        }
-        else
-#endif
-        {
-            // Update the free bit vector
-            // Need to update even if there are not swept object because finalizable object are
-            // consider freed but not on the free list.
-            ushort currentFreeCount = GetExpectedFreeObjectCount();
-            this->GetFreeBitVector()->OrComplimented(marked);
-            this->GetFreeBitVector()->Minus(this->GetInvalidBitVector());
+        // Update the free bit vector
+        // Need to update even if there are not swept object because finalizable object are
+        // consider freed but not on the free list.
+        ushort currentFreeCount = GetExpectedFreeObjectCount();
+        this->GetFreeBitVector()->OrComplimented(marked);
+        this->GetFreeBitVector()->Minus(this->GetInvalidBitVector());
 #if ENABLE_PARTIAL_GC
-            this->oldFreeCount = this->lastFreeCount = this->freeCount = currentFreeCount;
+        this->oldFreeCount = this->lastFreeCount = this->freeCount = currentFreeCount;
 #else
-            this->lastFreeCount = this->freeCount = currentFreeCount;
+        this->lastFreeCount = this->freeCount = currentFreeCount;
 #endif
 
-            this->lastFreeObjectHead = this->freeObjectList;
-        }
+        this->lastFreeObjectHead = this->freeObjectList;
     }
 
     RECYCLER_SLOW_CHECK(CheckFreeBitVector(true));
 
     // The count of marked, non-free objects should still be the same
-    Assert(this->markCount == this->GetMarkCountForSweep<pageheap>());
+    Assert(this->markCount == this->GetMarkCountForSweep());
 }
 
 template <class TBlockAttributes>

--- a/lib/Common/Memory/HeapBucket.cpp
+++ b/lib/Common/Memory/HeapBucket.cpp
@@ -224,10 +224,7 @@ HeapBucketT<TBlockType>::IntegrateBlock(char * blockAddress, PageSegment * segme
     }
 
     // TODO: Consider supporting guard pages for this codepath
-#ifdef RECYCLER_PAGE_HEAP
-    heapBlock->ClearPageHeap();
-#endif
-    if (!heapBlock->SetPage<false>(blockAddress, segment, recycler))
+    if (!heapBlock->SetPage(blockAddress, segment, recycler))
     {
         FreeHeapBlock(heapBlock);
         return false;
@@ -364,11 +361,14 @@ HeapBucketT<TBlockType>::TryAllocFromNewHeapBlock(Recycler * recycler, TBlockAll
 #ifdef RECYCLER_PAGE_HEAP
     if (IsPageHeapEnabled())
     {
-        return this->PageHeapAlloc(recycler, sizeCat, attributes, this->heapInfo->pageHeapMode, true);
+        if ((attributes & TrackBit) != TrackBit) // LargeHeapBlock does not support TrackBit today
+        {
+            return this->PageHeapAlloc(recycler, sizeCat, attributes, this->heapInfo->pageHeapMode, true);
+        }
     }
 #endif
 
-    TBlockType * heapBlock = CreateHeapBlock<false>(recycler);
+    TBlockType * heapBlock = CreateHeapBlock(recycler);
     if (heapBlock == nullptr)
     {
         return nullptr;
@@ -388,92 +388,7 @@ char *
 HeapBucketT<TBlockType>::PageHeapAlloc(Recycler * recycler, size_t sizeCat, ObjectInfoBits attributes, PageHeapMode mode, bool nothrow)
 {
     AllocationVerboseTrace(recycler->GetRecyclerFlagsTable(), _u("In PageHeapAlloc [Size: 0x%x, Attributes: 0x%x]\n"), sizeCat, attributes);
-
-    Assert(sizeCat == this->sizeCat);
-    char * memBlock = nullptr;
-    TBlockAllocatorType* allocator = &this->allocatorHead;
-
-    memBlock = allocator->PageHeapAlloc(recycler, sizeCat, attributes, mode);
-    if (memBlock == nullptr)
-    {
-        TBlockType* heapBlock = nullptr;
-
-        allocator->Clear();
-
-        {
-            AUTO_NO_EXCEPTION_REGION;
-
-            heapBlock = CreateHeapBlock<true>(recycler);
-        }
-
-        if (heapBlock != nullptr)
-        {
-            // new heap block added, allocate from that.
-            allocator->SetNew(heapBlock);
-            memBlock = allocator->PageHeapAlloc(recycler, sizeCat, attributes, mode);
-            Assert(memBlock != nullptr || IS_FAULTINJECT_NO_THROW_ON);
-        }
-
-        if (memBlock == nullptr)
-        {
-            recycler->CollectNow<CollectNowForceInThread>();
-            memBlock = allocator->PageHeapAlloc(recycler, sizeCat, attributes, mode);
-
-            if (memBlock == nullptr)
-            {
-                // Although we collected in thread, PostCollectCallback may
-                // allocate memory and populated the allocator again, let's clear it again
-                allocator->Clear();
-
-                TBlockType* heapBlock = nullptr;
-
-                {
-                    AUTO_NO_EXCEPTION_REGION;
-
-                    heapBlock = CreateHeapBlock<true>(recycler);
-                }
-
-                if (heapBlock != nullptr)
-                {
-                    // new heap block added, allocate from that.
-                    allocator->SetNew(heapBlock);
-                    memBlock = allocator->PageHeapAlloc(recycler, sizeCat, attributes, mode);
-                    Assert(memBlock != nullptr || IS_FAULTINJECT_NO_THROW_ON);
-                }
-
-                if (memBlock == nullptr)
-                {
-                    // If nothrow is false, that means throwing is allowed
-                    // Since we have no more memory to allocate here, throw an OOM exception
-                    // If nothrow is true, then simply return null
-                    if (nothrow == false)
-                    {
-                        recycler->OutOfMemory();
-                    }
-                    else
-                    {
-                        return nullptr;
-                    }
-                }
-            }
-        }
-    }
-
-    Assert(memBlock != nullptr);
-#ifdef RECYCLER_ZERO_MEM_CHECK
-    if ((attributes & ObjectInfoBits::LeafBit) == 0
-#ifdef RECYCLER_WRITE_BARRIER_ALLOC_THREAD_PAGE
-        && ((attributes & ObjectInfoBits::WithBarrierBit) == 0)
-#endif
-        )
-    {
-        // Skip the first and the last pointer objects- the first may have next pointer for the free list
-        // the last might have the old size of the object if this was allocated from an explicit free list
-        recycler->VerifyZeroFill(memBlock + sizeof(FreeObject), sizeCat - (2 * sizeof(FreeObject)));
-    }
-#endif
-
-    return memBlock;
+    return heapInfo->largeObjectBucket.PageHeapAlloc(recycler, sizeCat, attributes, mode, nothrow);
 }
 #endif
 
@@ -585,7 +500,6 @@ HeapBucketT<TBlockType>::GetUnusedHeapBlock()
 }
 
 template <typename TBlockType>
-template<bool pageheap>
 TBlockType *
 HeapBucketT<TBlockType>::CreateHeapBlock(Recycler * recycler)
 {
@@ -598,14 +512,7 @@ HeapBucketT<TBlockType>::CreateHeapBlock(Recycler * recycler)
         return nullptr;
     }
 
-#ifdef RECYCLER_PAGE_HEAP
-    if (pageheap)
-    {
-        heapBlock->EnablePageHeap();
-    }
-#endif
-
-    if (!heapBlock->ReassignPages<pageheap>(recycler))
+    if (!heapBlock->ReassignPages(recycler))
     {
         FreeHeapBlock(heapBlock);
         return nullptr;
@@ -814,21 +721,7 @@ HeapBucketT<TBlockType>::DoPartialReuseSweep(Recycler * recycler)
 }
 #endif
 
-template void HeapBucketT<SmallLeafHeapBlock>::SweepHeapBlockList<true>(RecyclerSweep&, SmallLeafHeapBlock *, bool);
-template void HeapBucketT<SmallLeafHeapBlock>::SweepHeapBlockList<false>(RecyclerSweep&, SmallLeafHeapBlock *, bool);
-template void HeapBucketT<SmallNormalHeapBlock>::SweepHeapBlockList<true>(RecyclerSweep&, SmallNormalHeapBlock *, bool);
-template void HeapBucketT<SmallNormalHeapBlock>::SweepHeapBlockList<false>(RecyclerSweep&, SmallNormalHeapBlock *, bool);
-template void HeapBucketT<SmallFinalizableHeapBlock>::SweepHeapBlockList<true>(RecyclerSweep&, SmallFinalizableHeapBlock *, bool);
-template void HeapBucketT<SmallFinalizableHeapBlock>::SweepHeapBlockList<false>(RecyclerSweep&, SmallFinalizableHeapBlock *, bool);
-#ifdef RECYCLER_WRITE_BARRIER
-template void HeapBucketT<SmallNormalWithBarrierHeapBlock>::SweepHeapBlockList<true>(RecyclerSweep&, SmallNormalWithBarrierHeapBlock *, bool);
-template void HeapBucketT<SmallNormalWithBarrierHeapBlock>::SweepHeapBlockList<false>(RecyclerSweep&, SmallNormalWithBarrierHeapBlock *, bool);
-template void HeapBucketT<SmallFinalizableWithBarrierHeapBlock>::SweepHeapBlockList<true>(RecyclerSweep&, SmallFinalizableWithBarrierHeapBlock *, bool);
-template void HeapBucketT<SmallFinalizableWithBarrierHeapBlock>::SweepHeapBlockList<false>(RecyclerSweep&, SmallFinalizableWithBarrierHeapBlock *, bool);
-#endif
-
 template <typename TBlockType>
-template <bool pageheap>
 void
 HeapBucketT<TBlockType>::SweepHeapBlockList(RecyclerSweep& recyclerSweep, TBlockType * heapBlockList, bool allocable)
 {
@@ -868,7 +761,7 @@ HeapBucketT<TBlockType>::SweepHeapBlockList(RecyclerSweep& recyclerSweep, TBlock
         // The whole list need to be consistent
         DebugOnly(VerifyBlockConsistencyInList(heapBlock, recyclerSweep));
 
-        SweepState state = heapBlock->Sweep<pageheap>(recyclerSweep, queuePendingSweep, allocable);
+        SweepState state = heapBlock->Sweep(recyclerSweep, queuePendingSweep, allocable);
 
         DebugOnly(VerifyBlockConsistencyInList(heapBlock, recyclerSweep, state));
 
@@ -956,14 +849,14 @@ HeapBucketT<TBlockType>::SweepHeapBlockList(RecyclerSweep& recyclerSweep, TBlock
 #endif
                 // CONCURRENT-TODO: We will zero heap block even if the number free page pool exceed
                 // the maximum and will get decommitted anyway
-                recyclerSweep.QueueEmptyHeapBlock<TBlockType, pageheap>(this, heapBlock);
+                recyclerSweep.QueueEmptyHeapBlock<TBlockType>(this, heapBlock);
                 RECYCLER_STATS_INC(recycler, numZeroedOutSmallBlocks);
             }
             else
 #endif
             {
                 // Just free the page in thread (and zero the page)
-                heapBlock->ReleasePagesSweep<pageheap>(recycler);
+                heapBlock->ReleasePagesSweep(recycler);
                 FreeHeapBlock(heapBlock);
                 RECYCLER_SLOW_CHECK(this->heapBlockCount--);
             }
@@ -975,7 +868,6 @@ HeapBucketT<TBlockType>::SweepHeapBlockList(RecyclerSweep& recyclerSweep, TBlock
 }
 
 template <typename TBlockType>
-template <bool pageheap>
 void
 HeapBucketT<TBlockType>::SweepBucket(RecyclerSweep& recyclerSweep)
 {
@@ -1023,7 +915,7 @@ HeapBucketT<TBlockType>::SweepBucket(RecyclerSweep& recyclerSweep)
     TBlockType * currentHeapBlockList = heapBlockList;
     this->heapBlockList = nullptr;
     this->fullBlockList = nullptr;
-    this->SweepHeapBlockList<pageheap>(recyclerSweep, currentHeapBlockList, true);
+    this->SweepHeapBlockList(recyclerSweep, currentHeapBlockList, true);
 
 #if DBG
     if (TBlockType::HeapBlockAttributes::IsSmallBlock)
@@ -1040,7 +932,7 @@ HeapBucketT<TBlockType>::SweepBucket(RecyclerSweep& recyclerSweep)
     }
 #endif
 
-    this->SweepHeapBlockList<pageheap>(recyclerSweep, currentFullBlockList, false);
+    this->SweepHeapBlockList(recyclerSweep, currentFullBlockList, false);
 
     // We shouldn't have allocate from any block yet
     Assert(this->nextAllocableBlockHead == nullptr);
@@ -1129,32 +1021,6 @@ HeapBucketT<TBlockType>::SetupBackgroundSweep(RecyclerSweep& recyclerSweep)
     Assert(recyclerSweep.GetPendingSweepBlockList(this) == nullptr);
 
     this->StopAllocationBeforeSweep();
-}
-#endif
-
-#ifdef RECYCLER_PAGE_HEAP
-template <typename TBlockType>
-void
-HeapBucketT<TBlockType>::PageHeapCheckSweepLists(RecyclerSweep& recyclerSweep)
-{
-#if DBG
-    if (IsPageHeapEnabled())
-    {
-        // in page heap mode. both the heapBlockList and pendingSweepList should not contain page heap block
-        // Since all block should be "empty" if there are swept object.
-        // But the list might not be Null because page heap is not enabled for integrated page heapblock
-        HeapBlockList::ForEach(this->heapBlockList, [](TBlockType * heapBlock)
-        {
-            Assert(!heapBlock->InPageHeapMode());
-        });
-#if ENABLE_CONCURRENT_GC
-        HeapBlockList::ForEach(recyclerSweep.GetPendingSweepBlockList(this), [](TBlockType * heapBlock)
-        {
-            Assert(!heapBlock->InPageHeapMode());
-        });
-#endif
-    }
-#endif
 }
 #endif
 
@@ -1391,40 +1257,26 @@ HeapBucketGroup<TBlockAttributes>::ScanNewImplicitRoots(Recycler * recycler)
     finalizableHeapBucket.ScanNewImplicitRoots(recycler);
 }
 
-// TODO: Fix template args
-template void HeapBucketGroup<SmallAllocationBlockAttributes>::Sweep<true>(RecyclerSweep& recyclerSweep);
-template void HeapBucketGroup<SmallAllocationBlockAttributes>::Sweep<false>(RecyclerSweep& recyclerSweep);
-template void HeapBucketGroup<MediumAllocationBlockAttributes>::Sweep<true>(RecyclerSweep& recyclerSweep);
-template void HeapBucketGroup<MediumAllocationBlockAttributes>::Sweep<false>(RecyclerSweep& recyclerSweep);
-
 template <class TBlockAttributes>
-template<bool pageheap>
 void
 HeapBucketGroup<TBlockAttributes>::Sweep(RecyclerSweep& recyclerSweep)
 {
-    heapBucket.Sweep<pageheap>(recyclerSweep);
-    leafHeapBucket.Sweep<pageheap>(recyclerSweep);
+    heapBucket.Sweep(recyclerSweep);
+    leafHeapBucket.Sweep(recyclerSweep);
 #ifdef RECYCLER_WRITE_BARRIER
-    smallNormalWithBarrierHeapBucket.Sweep<pageheap>(recyclerSweep);
+    smallNormalWithBarrierHeapBucket.Sweep(recyclerSweep);
 #endif
 }
-
-
-template void HeapBucketGroup<SmallAllocationBlockAttributes>::SweepFinalizableObjects<true>(RecyclerSweep& recyclerSweep);
-template void HeapBucketGroup<SmallAllocationBlockAttributes>::SweepFinalizableObjects<false>(RecyclerSweep& recyclerSweep);
-template void HeapBucketGroup<MediumAllocationBlockAttributes>::SweepFinalizableObjects<true>(RecyclerSweep& recyclerSweep);
-template void HeapBucketGroup<MediumAllocationBlockAttributes>::SweepFinalizableObjects<false>(RecyclerSweep& recyclerSweep);
 
 // Sweep finalizable objects first to ensure that if they reference any other
 // objects in the finalizer - they are valid
 template <class TBlockAttributes>
-template<bool pageheap>
 void
 HeapBucketGroup<TBlockAttributes>::SweepFinalizableObjects(RecyclerSweep& recyclerSweep)
 {
-    finalizableHeapBucket.Sweep<pageheap>(recyclerSweep);
+    finalizableHeapBucket.Sweep(recyclerSweep);
 #ifdef RECYCLER_WRITE_BARRIER
-    smallFinalizableWithBarrierHeapBucket.Sweep<pageheap>(recyclerSweep);
+    smallFinalizableWithBarrierHeapBucket.Sweep(recyclerSweep);
 #endif
 }
 
@@ -1514,15 +1366,6 @@ template <class TBlockAttributes>
 void
 HeapBucketGroup<TBlockAttributes>::SweepPartialReusePages(RecyclerSweep& recyclerSweep)
 {
-#if DBG && defined(RECYCLER_PAGE_HEAP)
-    this->heapBucket.PageHeapCheckSweepLists(recyclerSweep);
-#ifdef RECYCLER_WRITE_BARRIER
-    this->smallNormalWithBarrierHeapBucket.PageHeapCheckSweepLists(recyclerSweep);
-    this->smallFinalizableWithBarrierHeapBucket.PageHeapCheckSweepLists(recyclerSweep);
-#endif
-    this->finalizableHeapBucket.PageHeapCheckSweepLists(recyclerSweep);
-#endif
-
     // Leaf heap bucket are always reused for allocation and can be done on the concurrent thread
     // WriteBarrier-TODO: Do the same for write barrier buckets
     heapBucket.SweepPartialReusePages(recyclerSweep);
@@ -1673,30 +1516,3 @@ HeapBucketGroup<TBlockAttributes>::AllocatorsAreEmpty()
 template class HeapBucketGroup<SmallAllocationBlockAttributes>;
 template class HeapBucketGroup<MediumAllocationBlockAttributes>;
 
-
-template void HeapBucketT<SmallFinalizableHeapBlock>::SweepBucket<true>(RecyclerSweep&);
-template void HeapBucketT<SmallFinalizableHeapBlock>::SweepBucket<false>(RecyclerSweep&);
-template void HeapBucketT<SmallNormalHeapBlock>::SweepBucket<true>(RecyclerSweep&);
-template void HeapBucketT<SmallNormalHeapBlock>::SweepBucket<false>(RecyclerSweep&);
-template void HeapBucketT<SmallLeafHeapBlock>::SweepBucket<true>(RecyclerSweep&);
-template void HeapBucketT<SmallLeafHeapBlock>::SweepBucket<false>(RecyclerSweep&);
-#ifdef RECYCLER_WRITE_BARRIER
-template void HeapBucketT<SmallFinalizableWithBarrierHeapBlock>::SweepBucket<true>(RecyclerSweep&);
-template void HeapBucketT<SmallFinalizableWithBarrierHeapBlock>::SweepBucket<false>(RecyclerSweep&);
-template void HeapBucketT<SmallNormalWithBarrierHeapBlock>::SweepBucket<true>(RecyclerSweep&);
-template void HeapBucketT<SmallNormalWithBarrierHeapBlock>::SweepBucket<false>(RecyclerSweep&);
-#endif
-
-template void HeapBucketT<MediumFinalizableHeapBlock>::SweepBucket<true>(RecyclerSweep&);
-template void HeapBucketT<MediumFinalizableHeapBlock>::SweepBucket<false>(RecyclerSweep&);
-
-template void HeapBucketT<MediumNormalHeapBlock>::SweepBucket<true>(RecyclerSweep&);
-template void HeapBucketT<MediumNormalHeapBlock>::SweepBucket<false>(RecyclerSweep&);
-template void HeapBucketT<MediumLeafHeapBlock>::SweepBucket<true>(RecyclerSweep&);
-template void HeapBucketT<MediumLeafHeapBlock>::SweepBucket<false>(RecyclerSweep&);
-#ifdef RECYCLER_WRITE_BARRIER
-template void HeapBucketT<MediumFinalizableWithBarrierHeapBlock>::SweepBucket<true>(RecyclerSweep&);
-template void HeapBucketT<MediumFinalizableWithBarrierHeapBlock>::SweepBucket<false>(RecyclerSweep&);
-template void HeapBucketT<MediumNormalWithBarrierHeapBlock>::SweepBucket<true>(RecyclerSweep&);
-template void HeapBucketT<MediumNormalWithBarrierHeapBlock>::SweepBucket<false>(RecyclerSweep&);
-#endif

--- a/lib/Common/Memory/HeapBucket.h
+++ b/lib/Common/Memory/HeapBucket.h
@@ -123,7 +123,6 @@ public:
 
 #ifdef RECYCLER_PAGE_HEAP
     char * PageHeapAlloc(Recycler * recycler, size_t sizeCat, ObjectInfoBits attributes, PageHeapMode mode, bool nothrow);
-    void PageHeapCheckSweepLists(RecyclerSweep& recyclerSweep);
 #endif
 
     void ExplicitFree(void* object, size_t sizeCat);
@@ -174,16 +173,14 @@ protected:
     // Allocations
     char * TryAllocFromNewHeapBlock(Recycler * recycler, TBlockAllocatorType * allocator, size_t sizeCat, ObjectInfoBits attributes);
     char * TryAlloc(Recycler * recycler, TBlockAllocatorType * allocator, size_t sizeCat, ObjectInfoBits attributes);
-    template<bool pageheap>
     TBlockType * CreateHeapBlock(Recycler * recycler);
     TBlockType * GetUnusedHeapBlock();
 
     void FreeHeapBlock(TBlockType * heapBlock);
 
     // GC
-    template<bool pageheap>
     void SweepBucket(RecyclerSweep& recyclerSweep);
-    template <bool pageheap, typename Fn>
+    template <typename Fn>
     void SweepBucket(RecyclerSweep& recyclerSweep, Fn sweepFn);
 
     void StopAllocationBeforeSweep();
@@ -191,7 +188,6 @@ protected:
 #if DBG
     bool IsAllocationStopped() const;
 #endif
-    template<bool pageheap>
     void SweepHeapBlockList(RecyclerSweep& recyclerSweep, TBlockType * heapBlockList, bool allocable);
 #if ENABLE_PARTIAL_GC
     bool DoQueuePendingSweep(Recycler * recycler);
@@ -263,11 +259,11 @@ HeapBucket::EnumerateObjects(TBlockType * heapBlockList, ObjectInfoBits infoBits
 
 
 template <typename TBlockType>
-template <bool pageheap, typename Fn>
+template <typename Fn>
 void
 HeapBucketT<TBlockType>::SweepBucket(RecyclerSweep& recyclerSweep, Fn sweepFn)
 {
-    this->SweepBucket<pageheap>(recyclerSweep);
+    this->SweepBucket(recyclerSweep);
 
     // Continue to sweep other list from derived class
     sweepFn(recyclerSweep);

--- a/lib/Common/Memory/HeapBucket.inl
+++ b/lib/Common/Memory/HeapBucket.inl
@@ -18,14 +18,6 @@ HeapBucketT<TBlockType>::RealAlloc(Recycler * recycler, size_t sizeCat)
         memBlock = SnailAlloc(recycler, &allocatorHead, sizeCat, attributes, nothrow);
         Assert(memBlock != nullptr || nothrow);
     }
-    else
-    {
-#ifdef RECYCLER_PAGE_HEAP
-        Assert(allocatorHead.heapBlock == nullptr || !allocatorHead.heapBlock->InPageHeapMode());
-#else
-        Assert(allocatorHead.heapBlock == nullptr);
-#endif
-    }
 
     // If this API is called and throwing is not allowed,
     // check if we actually allocated a block before verifying

--- a/lib/Common/Memory/HeapInfo.h
+++ b/lib/Common/Memory/HeapInfo.h
@@ -171,8 +171,7 @@ private:
     template <ObjectInfoBits attributes>
     typename SmallHeapBlockType<attributes, SmallAllocationBlockAttributes>::BucketType& GetBucket(size_t sizeCat);
 
-    template<bool pageheap>
-    void Sweep(RecyclerSweep& recyclerSweep, bool concurrent);
+    void SweepBuckets(RecyclerSweep& recyclerSweep, bool concurrent);
 
 #ifdef BUCKETIZE_MEDIUM_ALLOCATIONS
 #if SMALLBLOCK_MEDIUM_ALLOC
@@ -268,7 +267,6 @@ private:
     }
 #endif
  
-    template<bool pageheap>
     void SweepSmallNonFinalizable(RecyclerSweep& recyclerSweep);
     void SweepLargeNonFinalizable(RecyclerSweep& recyclerSweep);
 

--- a/lib/Common/Memory/LargeHeapBlock.h
+++ b/lib/Common/Memory/LargeHeapBlock.h
@@ -123,17 +123,14 @@ public:
     void PartialTransferSweptObjects();
     void FinishPartialCollect(Recycler * recycler);
 #endif
-    template<bool pageheap>
     void ReleasePages(Recycler * recycler);
-    template<bool pageheap>
     void ReleasePagesSweep(Recycler * recycler);
     void ReleasePagesShutdown(Recycler * recycler);
     void ResetMarks(ResetMarkFlags flags, Recycler* recycler);
     void ScanInitialImplicitRoots(Recycler * recycler);
     void ScanNewImplicitRoots(Recycler * recycler);
-    template<bool pageheap>
     SweepState Sweep(RecyclerSweep& recyclerSweep, bool queuePendingSweep);
-    template <bool pageheap, SweepMode mode>
+    template <SweepMode mode>
     void SweepObjects(Recycler * recycler);
     bool TransferSweptObjects();
     void DisposeObjects(Recycler * recycler);
@@ -142,9 +139,6 @@ public:
 
     char* GetBeginAddress() const { return address; }
     char* GetEndAddress() const { return addressEnd; }
-#ifdef RECYCLER_PAGE_HEAP
-    void SetEndAllocAddress(__in char* endAllocAddress) { allocAddressEnd = endAllocAddress; }
-#endif
 
     char * Alloc(size_t size, ObjectInfoBits attributes);
     char * TryAllocFromFreeList(size_t size, ObjectInfoBits attributes);
@@ -257,6 +251,18 @@ private:
     uint finalizeCount;
 
     bool isInPendingDisposeList;
+
+#ifdef RECYCLER_PAGE_HEAP
+    PageHeapMode pageHeapMode;
+    char* guardPageAddress;
+    StackBackTrace* pageHeapAllocStack;
+    StackBackTrace* pageHeapFreeStack;
+
+public:
+    __inline bool InPageHeapMode() const { return pageHeapMode != PageHeapMode::PageHeapModeOff; }
+    void CapturePageHeapAllocStack();
+    void CapturePageHeapFreeStack();
+#endif
 
 #if DBG
     bool hasDisposeBeenCalled;

--- a/lib/Common/Memory/LargeHeapBucket.cpp
+++ b/lib/Common/Memory/LargeHeapBucket.cpp
@@ -126,9 +126,11 @@ LargeHeapBucket::PageHeapAlloc(Recycler * recycler, size_t size, ObjectInfoBits 
         return nullptr;
     }
 
-    size_t actualPageCount = pageCount + 1; // for page heap
+    size_t actualPageCount = pageCount + 1; // 1 for guard page
 
-    char * baseAddress = recycler->GetRecyclerLargeBlockPageAllocator()->Alloc(&actualPageCount, &segment);
+    auto pageAllocator = recycler->GetRecyclerLargeBlockPageAllocator();
+
+    char * baseAddress = pageAllocator->Alloc(&actualPageCount, &segment);
     if (baseAddress == nullptr)
     {
         return nullptr;
@@ -136,7 +138,6 @@ LargeHeapBucket::PageHeapAlloc(Recycler * recycler, size_t size, ObjectInfoBits 
 
     char* address = nullptr;
     char* guardPageAddress = nullptr;
-    DWORD guardPageOldProtectFlags = PAGE_NOACCESS;
 
     if (heapInfo->pageHeapMode == PageHeapMode::PageHeapModeBlockStart)
     {
@@ -153,70 +154,38 @@ LargeHeapBucket::PageHeapAlloc(Recycler * recycler, size_t size, ObjectInfoBits 
         AnalysisAssert(false);
     }
 
-    if (::VirtualProtect(static_cast<LPVOID>(guardPageAddress), AutoSystemInfo::PageSize, PAGE_NOACCESS, &guardPageOldProtectFlags) == FALSE)
-    {
-        AssertMsg(false, "Unable to set permission for guard page.");
-        return nullptr;
-    }
-
-#ifdef RECYCLER_ZERO_MEM_CHECK
-    recycler->VerifyZeroFill(address, pageCount * AutoSystemInfo::PageSize);
-#endif
-
     LargeHeapBlock * heapBlock = LargeHeapBlock::New(address, pageCount, segment, 1, nullptr);
     if (!heapBlock)
     {
-        recycler->GetRecyclerLargeBlockPageAllocator()->SuspendIdleDecommit();
-        recycler->GetRecyclerLargeBlockPageAllocator()->Release(address, actualPageCount, segment);
-        recycler->GetRecyclerLargeBlockPageAllocator()->ResumeIdleDecommit();
+        pageAllocator->SuspendIdleDecommit();
+        pageAllocator->Release(baseAddress, actualPageCount, segment);
+        pageAllocator->ResumeIdleDecommit();
         return nullptr;
     }
-    heapBlock->actualPageCount = actualPageCount;
-    heapBlock->guardPageAddress = guardPageAddress;
-    heapBlock->guardPageOldProtectFlags = guardPageOldProtectFlags;
-    heapBlock->pageHeapMode = heapInfo->pageHeapMode;
-
-    if (heapBlock->pageHeapMode == PageHeapMode::PageHeapModeBlockEnd)
-    {
-        // TODO: pad the address to close-most to the guard page to increase the chance to hit guard page when overflow
-        // some Mark code need to be updated to support this
-        // heapBlock->SetEndAllocAddress(address
-        //    + AutoSystemInfo::PageSize - (((AllocSizeMath::Add(sizeCat, sizeof(LargeObjectHeader)) - 1) % AutoSystemInfo::PageSize) / HeapInfo::ObjectGranularity + 1) * HeapInfo::ObjectGranularity);
-    }
-
-#if DBG
-    LargeAllocationVerboseTrace(recycler->GetRecyclerFlagsTable(), _u("Allocated new large heap block 0x%p for sizeCat 0x%x\n"), heapBlock, sizeCat);
-#endif
-
-#ifdef ENABLE_JS_ETW
-#if ENABLE_DEBUG_CONFIG_OPTIONS
-    if (segment->GetPageCount() > recycler->GetRecyclerLargeBlockPageAllocator()->GetMaxAllocPageCount())
-    {
-        EventWriteJSCRIPT_INTERNAL_RECYCLER_EXTRALARGE_OBJECT_ALLOC(size);
-    }
-#endif
-#endif
-
-#if ENABLE_PARTIAL_GC
-    recycler->autoHeap.uncollectedNewPageCount += pageCount;
-#endif
-
-    RECYCLER_SLOW_CHECK(this->heapInfo->heapBlockCount[HeapBlock::HeapBlockType::LargeBlockType]++);
 
     heapBlock->heapInfo = this->heapInfo;
 
-    Assert(recycler->collectionState != CollectionStateMark);
-
     if (!recycler->heapBlockMap.SetHeapBlock(address, pageCount, heapBlock, HeapBlock::HeapBlockType::LargeBlockType, 0))
     {
-        recycler->GetRecyclerLargeBlockPageAllocator()->SuspendIdleDecommit();
-        heapBlock->ReleasePages<true>(recycler);
-        recycler->GetRecyclerLargeBlockPageAllocator()->ResumeIdleDecommit();
+        pageAllocator->SuspendIdleDecommit();
+        pageAllocator->Release(baseAddress, actualPageCount, segment);
+        pageAllocator->ResumeIdleDecommit();
         LargeHeapBlock::Delete(heapBlock);
         RECYCLER_SLOW_CHECK(this->heapInfo->heapBlockCount[HeapBlock::HeapBlockType::LargeBlockType]--);
         return nullptr;
     }
 
+#pragma prefast(suppress:6250, "This method decommits memory")
+    if (::VirtualFree(guardPageAddress, AutoSystemInfo::PageSize, MEM_DECOMMIT) == FALSE)
+    {
+        AssertMsg(false, "Unable to decommit guard page.");
+        ReportFatalException(NULL, E_FAIL, Fatal_Internal_Error, 2);
+        return nullptr;
+    }
+
+    heapBlock->actualPageCount = actualPageCount;
+    heapBlock->guardPageAddress = guardPageAddress;
+    heapBlock->pageHeapMode = heapInfo->pageHeapMode;
     heapBlock->ResetMarks(ResetMarkFlags_None, recycler);
 
     if (this->largePageHeapBlockList)
@@ -228,10 +197,20 @@ LargeHeapBucket::PageHeapAlloc(Recycler * recycler, size_t size, ObjectInfoBits 
         this->largePageHeapBlockList = heapBlock;
     }
 
+#if ENABLE_PARTIAL_GC
+    recycler->autoHeap.uncollectedNewPageCount += pageCount;
+#endif
+
+    RECYCLER_SLOW_CHECK(this->heapInfo->heapBlockCount[HeapBlock::HeapBlockType::LargeBlockType]++);
     RECYCLER_PERF_COUNTER_ADD(FreeObjectSize, heapBlock->GetPageCount() * AutoSystemInfo::PageSize);
 
     char * memBlock = heapBlock->Alloc(sizeCat, attributes);
     Assert(memBlock != nullptr);
+
+    // fill pattern
+    // TODO: use real size instead of sizeCat
+    memset(heapBlock->allocAddressEnd, 0xF0, heapBlock->addressEnd - heapBlock->allocAddressEnd);
+
     if (recycler->ShouldCapturePageHeapAllocStack())
     {
         heapBlock->CapturePageHeapAllocStack();
@@ -306,7 +285,7 @@ LargeHeapBucket::AddLargeHeapBlock(size_t size, bool nothrow)
     if (!recycler->heapBlockMap.SetHeapBlock(address, pageCount, heapBlock, HeapBlock::HeapBlockType::LargeBlockType, 0))
     {
         recycler->GetRecyclerLargeBlockPageAllocator()->SuspendIdleDecommit();
-        heapBlock->ReleasePages<false>(recycler);
+        heapBlock->ReleasePages(recycler);
         recycler->GetRecyclerLargeBlockPageAllocator()->ResumeIdleDecommit();
         LargeHeapBlock::Delete(heapBlock);
         RECYCLER_SLOW_CHECK(this->heapInfo->heapBlockCount[HeapBlock::HeapBlockType::LargeBlockType]--);
@@ -531,10 +510,7 @@ LargeHeapBucket::ScanNewImplicitRoots(Recycler * recycler)
 // Sweep
 //=====================================================================================================
 #pragma region Sweep
-template void LargeHeapBucket::Sweep<true>(RecyclerSweep& recyclerSweep);
-template void LargeHeapBucket::Sweep<false>(RecyclerSweep& recyclerSweep);
 
-template<bool pageheap>
 void
 LargeHeapBucket::Sweep(RecyclerSweep& recyclerSweep)
 {
@@ -569,15 +545,14 @@ LargeHeapBucket::Sweep(RecyclerSweep& recyclerSweep)
 #if ENABLE_CONCURRENT_GC
     Assert(this->pendingSweepLargeBlockList == nullptr);
 #endif
-    SweepLargeHeapBlockList<pageheap>(recyclerSweep, currentLargeObjectBlocks);
+    SweepLargeHeapBlockList(recyclerSweep, currentLargeObjectBlocks);
 #ifdef RECYCLER_PAGE_HEAP
-    SweepLargeHeapBlockList<pageheap>(recyclerSweep, currentLargePageHeapObjectBlocks);
+    SweepLargeHeapBlockList(recyclerSweep, currentLargePageHeapObjectBlocks);
 #endif
-    SweepLargeHeapBlockList<pageheap>(recyclerSweep, currentFullLargeObjectBlocks);
-    SweepLargeHeapBlockList<pageheap>(recyclerSweep, currentDisposeLargeBlockList);
+    SweepLargeHeapBlockList(recyclerSweep, currentFullLargeObjectBlocks);
+    SweepLargeHeapBlockList(recyclerSweep, currentDisposeLargeBlockList);
 }
 
-template<bool pageheap>
 void
 LargeHeapBucket::SweepLargeHeapBlockList(RecyclerSweep& recyclerSweep, LargeHeapBlock * heapBlockList)
 {
@@ -587,7 +562,7 @@ LargeHeapBucket::SweepLargeHeapBlockList(RecyclerSweep& recyclerSweep, LargeHeap
         this->UnregisterFreeList(heapBlock->GetFreeList());
 
         // CONCURRENT-TODO: Allow large block to be sweep in the background
-        SweepState state = heapBlock->Sweep<pageheap>(recyclerSweep, false);
+        SweepState state = heapBlock->Sweep(recyclerSweep, false);
 
         // If the block is already in the pending dispose list (re-entrant GC scenario), do nothing, leave it there
         if (heapBlock->IsInPendingDisposeList()) return;
@@ -595,7 +570,7 @@ LargeHeapBucket::SweepLargeHeapBlockList(RecyclerSweep& recyclerSweep, LargeHeap
         switch (state)
         {
         case SweepStateEmpty:
-            heapBlock->ReleasePagesSweep<pageheap>(recycler);
+            heapBlock->ReleasePagesSweep(recycler);
             LargeHeapBlock::Delete(heapBlock);
             RECYCLER_SLOW_CHECK(this->heapInfo->heapBlockCount[HeapBlock::HeapBlockType::LargeBlockType]--);
             break;
@@ -775,7 +750,7 @@ LargeHeapBucket::SweepPendingObjects(RecyclerSweep& recyclerSweep)
             HeapBlockList::ForEach(this->pendingSweepLargeBlockList, [recycler](LargeHeapBlock * heapBlock)
             {
                 // Page heap blocks are never swept concurrently
-                heapBlock->SweepObjects<false, SweepMode_ConcurrentPartial>(recycler);
+                heapBlock->SweepObjects<SweepMode_ConcurrentPartial>(recycler);
             });
         }
         else
@@ -784,7 +759,7 @@ LargeHeapBucket::SweepPendingObjects(RecyclerSweep& recyclerSweep)
             HeapBlockList::ForEach(this->pendingSweepLargeBlockList, [recycler](LargeHeapBlock * heapBlock)
             {
                 // Page heap blocks are never swept concurrently
-                heapBlock->SweepObjects<false, SweepMode_Concurrent>(recycler);
+                heapBlock->SweepObjects<SweepMode_Concurrent>(recycler);
             });
         }
     }

--- a/lib/Common/Memory/LargeHeapBucket.h
+++ b/lib/Common/Memory/LargeHeapBucket.h
@@ -51,7 +51,6 @@ public:
     void ScanInitialImplicitRoots(Recycler * recycler);
     void ScanNewImplicitRoots(Recycler * recycler);
 
-    template<bool pageheap>
     void Sweep(RecyclerSweep& recyclerSweep);
     void ReinsertLargeHeapBlock(LargeHeapBlock * heapBlock);
 
@@ -103,7 +102,6 @@ private:
     template <class Fn> void ForEachLargeHeapBlock(Fn fn);
     template <class Fn> void ForEachEditingLargeHeapBlock(Fn fn);
     void Finalize(Recycler* recycler, LargeHeapBlock* heapBlock);
-    template<bool pageheap>
     void SweepLargeHeapBlockList(RecyclerSweep& recyclerSweep, LargeHeapBlock * heapBlockList);
 
     void ConstructFreelist(LargeHeapBlock * heapBlock);

--- a/lib/Common/Memory/PageAllocator.cpp
+++ b/lib/Common/Memory/PageAllocator.cpp
@@ -222,25 +222,8 @@ PageSegmentBase<T>::Prime()
 
 template<typename T>
 bool
-PageSegmentBase<T>::IsAllocationPageAligned(__in char* address, size_t pageCount, PageHeapMode pageHeapFlags)
+PageSegmentBase<T>::IsAllocationPageAligned(__in char* address, size_t pageCount)
 {
-#ifdef RECYCLER_PAGE_HEAP
-    if (pageHeapFlags != PageHeapMode::PageHeapModeOff)
-    {
-        // In PageHeap mode, we should ensure that if the guard page
-        // is in the front, the page after the guard page is aligned
-        if ((pageHeapFlags == PageHeapMode::PageHeapModeBlockStart))
-        {
-            address += AutoSystemInfo::PageSize;
-        }
-
-        // We don't care about whether the guard pages themselves are aligned
-        // or fit in the chunk, so don't count the guard page for the purposes
-        // of alignment
-        pageCount--;
-    }
-#endif
-
     // Require that allocations are aligned at a boundary
     // corresponding to the page count
     // REVIEW: This might actually lead to additional address space fragmentation
@@ -260,7 +243,7 @@ PageSegmentBase<T>::IsAllocationPageAligned(__in char* address, size_t pageCount
 template<typename T>
 template <bool notPageAligned>
 char *
-PageSegmentBase<T>::AllocPages(uint pageCount, PageHeapMode pageHeapFlags)
+PageSegmentBase<T>::AllocPages(uint pageCount)
 {
     Assert(freePageCount != 0);
     Assert(freePageCount == (uint)this->GetCountOfFreePages());
@@ -287,7 +270,7 @@ PageSegmentBase<T>::AllocPages(uint pageCount, PageHeapMode pageHeapFlags)
 
             if (pageCount > 1 && !notPageAligned)
             {
-                if (!IsAllocationPageAligned(allocAddress, pageCount, pageHeapFlags))
+                if (!IsAllocationPageAligned(allocAddress, pageCount))
                 {
                     index = this->freePages.GetNextBit(index + 1);
                     continue;
@@ -316,7 +299,7 @@ PageSegmentBase<T>::AllocPages(uint pageCount, PageHeapMode pageHeapFlags)
 template<typename TVirtualAlloc>
 template<typename T, bool notPageAligned>
 char *
-PageSegmentBase<TVirtualAlloc>::AllocDecommitPages(uint pageCount, T freePages, T decommitPages, PageHeapMode pageHeapFlags)
+PageSegmentBase<TVirtualAlloc>::AllocDecommitPages(uint pageCount, T freePages, T decommitPages)
 {
     Assert(freePageCount == (uint)this->GetCountOfFreePages());
     Assert(decommitPageCount ==  (uint)this->GetCountOfDecommitPages());
@@ -347,7 +330,7 @@ PageSegmentBase<TVirtualAlloc>::AllocDecommitPages(uint pageCount, T freePages, 
 
             if (!notPageAligned)
             {
-                if (!IsAllocationPageAligned(pages, pageCount, pageHeapFlags))
+                if (!IsAllocationPageAligned(pages, pageCount))
                 {
                     index = freeAndDecommitPages.GetNextBit(index + 1);
                     continue;
@@ -825,7 +808,7 @@ PageAllocatorBase<T>::TryAllocFromZeroPagesList(uint pageCount, PageSegmentBase<
 
 template<typename T>
 char *
-PageAllocatorBase<T>::TryAllocFromZeroPages(uint pageCount, PageSegmentBase<T> ** pageSegment, PageHeapMode pageHeapFlags)
+PageAllocatorBase<T>::TryAllocFromZeroPages(uint pageCount, PageSegmentBase<T> ** pageSegment)
 {
     if (backgroundPageQueue != nullptr) 
     {
@@ -844,7 +827,7 @@ PageAllocatorBase<T>::TryAllocFromZeroPages(uint pageCount, PageSegmentBase<T> *
 template<typename T>
 template <bool notPageAligned>
 char *
-PageAllocatorBase<T>::TryAllocFreePages(uint pageCount, PageSegmentBase<T> ** pageSegment, PageHeapMode pageHeapFlags)
+PageAllocatorBase<T>::TryAllocFreePages(uint pageCount, PageSegmentBase<T> ** pageSegment)
 {
     Assert(!HasMultiThreadAccess());
     char* pages = nullptr;
@@ -858,7 +841,7 @@ PageAllocatorBase<T>::TryAllocFreePages(uint pageCount, PageSegmentBase<T> ** pa
         {
             PageSegmentBase<T> * freeSegment = &i.Data();
 
-            pages = freeSegment->AllocPages<notPageAligned>(pageCount, pageHeapFlags);
+            pages = freeSegment->AllocPages<notPageAligned>(pageCount);
             if (pages != nullptr)
             {
                 LogAllocPages(pageCount);
@@ -879,7 +862,7 @@ PageAllocatorBase<T>::TryAllocFreePages(uint pageCount, PageSegmentBase<T> ** pa
         }
     }
 
-    pages = TryAllocFromZeroPages(pageCount, pageSegment, pageHeapFlags);
+    pages = TryAllocFromZeroPages(pageCount, pageSegment);
 
     return pages;
 }
@@ -940,7 +923,7 @@ PageAllocatorBase<T>::FillFreePages(__in void * address, uint pageCount)
 template<typename T>
 template <bool notPageAligned>
 char *
-PageAllocatorBase<T>::TryAllocDecommittedPages(uint pageCount, PageSegmentBase<T> ** pageSegment, PageHeapMode pageHeapFlags)
+PageAllocatorBase<T>::TryAllocDecommittedPages(uint pageCount, PageSegmentBase<T> ** pageSegment)
 {
     Assert(!HasMultiThreadAccess());
 
@@ -951,7 +934,7 @@ PageAllocatorBase<T>::TryAllocDecommittedPages(uint pageCount, PageSegmentBase<T
         PageSegmentBase<T> * freeSegment = &i.Data();
         uint oldFreePageCount = freeSegment->GetFreePageCount();
         uint oldDecommitPageCount = freeSegment->GetDecommitPageCount();
-        char * pages = freeSegment->DoAllocDecommitPages<notPageAligned>(pageCount, pageHeapFlags);
+        char * pages = freeSegment->DoAllocDecommitPages<notPageAligned>(pageCount);
         if (pages != nullptr)
         {
             this->freePageCount = this->freePageCount - oldFreePageCount + freeSegment->GetFreePageCount();
@@ -1091,7 +1074,7 @@ PageAllocatorBase<T>::AllocInternal(size_t * pageCount, SegmentBase<T> ** segmen
         if (doPageAlign)
         {
             // TODO: Remove this entire codepath since doPageAlign is not being used anymore
-            addr = this->AllocPagesPageAligned((uint)*pageCount, &pageSegment, PageHeapMode::PageHeapModeOff);
+            addr = this->AllocPagesPageAligned((uint)*pageCount, &pageSegment);
         }
         else
         {
@@ -1149,15 +1132,15 @@ PageAllocatorBase<PreReservedVirtualAllocWrapper>::AllocPages(uint pageCount, Pa
 
 template<typename T>
 char *
-PageAllocatorBase<T>::AllocPagesPageAligned(uint pageCount, PageSegmentBase<T> ** pageSegment, PageHeapMode pageHeapFlags)
+PageAllocatorBase<T>::AllocPagesPageAligned(uint pageCount, PageSegmentBase<T> ** pageSegment)
 {
-    return AllocPagesInternal<false /* noPageAligned */>(pageCount, pageSegment, pageHeapFlags);
+    return AllocPagesInternal<false /* noPageAligned */>(pageCount, pageSegment);
 }
 
 template<typename T>
 template <bool notPageAligned>
 char *
-PageAllocatorBase<T>::AllocPagesInternal(uint pageCount, PageSegmentBase<T> ** pageSegment, PageHeapMode pageHeapModeFlags)
+PageAllocatorBase<T>::AllocPagesInternal(uint pageCount, PageSegmentBase<T> ** pageSegment)
 {
     Assert(!isClosed);
     ASSERT_THREAD();
@@ -1166,14 +1149,19 @@ PageAllocatorBase<T>::AllocPagesInternal(uint pageCount, PageSegmentBase<T> ** p
     this->isUsed = true;
 
     SuspendIdleDecommit();
-    char * allocation = TryAllocFreePages<notPageAligned>(pageCount, pageSegment, pageHeapModeFlags);
+    char * allocation = TryAllocFreePages<notPageAligned>(pageCount, pageSegment);
     if (allocation == nullptr)
     {
-        allocation = SnailAllocPages<notPageAligned>(pageCount, pageSegment, pageHeapModeFlags);
+        allocation = SnailAllocPages<notPageAligned>(pageCount, pageSegment);
     }
     ResumeIdleDecommit();
 
     PageTracking::ReportAllocation((PageAllocator*)this, allocation, AutoSystemInfo::PageSize * pageCount);
+
+    if (!notPageAligned) 
+    {
+        Assert(PageSegmentBase<T>::IsAllocationPageAligned(allocation, pageCount));
+    } 
 
     return allocation;
 }
@@ -1198,7 +1186,7 @@ PageAllocatorBase<T>::OnAllocFromNewSegment(uint pageCount, __in void* pages, Se
 template<typename T>
 template <bool notPageAligned>
 char *
-PageAllocatorBase<T>::SnailAllocPages(uint pageCount, PageSegmentBase<T> ** pageSegment, PageHeapMode pageHeapFlags)
+PageAllocatorBase<T>::SnailAllocPages(uint pageCount, PageSegmentBase<T> ** pageSegment)
 {
     Assert(!HasMultiThreadAccess());
 
@@ -1209,14 +1197,14 @@ PageAllocatorBase<T>::SnailAllocPages(uint pageCount, PageSegmentBase<T> ** page
     {
         newSegment = &emptySegments.Head();
 
-        if (!notPageAligned && !PageSegmentBase<T>::IsAllocationPageAligned(newSegment->GetAddress(), pageCount, pageHeapFlags))
+        if (!notPageAligned && !PageSegmentBase<T>::IsAllocationPageAligned(newSegment->GetAddress(), pageCount))
         {
             newSegment = nullptr;
 
             // Scan through the empty segments for a segment that can fit this allocation
             FOREACH_DLISTBASE_ENTRY_EDITING(PageSegmentBase<T>, emptySegment, &this->emptySegments, iter)
             {
-                if (PageSegmentBase<T>::IsAllocationPageAligned(emptySegment.GetAddress(), pageCount, pageHeapFlags))
+                if (PageSegmentBase<T>::IsAllocationPageAligned(emptySegment.GetAddress(), pageCount))
                 {
                     iter.MoveCurrentTo(&this->emptySegments);
                     newSegment = &emptySegment;
@@ -1228,7 +1216,7 @@ PageAllocatorBase<T>::SnailAllocPages(uint pageCount, PageSegmentBase<T> ** page
 
         if (newSegment != nullptr)
         {
-            pages = newSegment->AllocPages<notPageAligned>(pageCount, pageHeapFlags);
+            pages = newSegment->AllocPages<notPageAligned>(pageCount);
             if (pages != nullptr)
             {
                 OnAllocFromNewSegment(pageCount, pages, newSegment);
@@ -1238,7 +1226,7 @@ PageAllocatorBase<T>::SnailAllocPages(uint pageCount, PageSegmentBase<T> ** page
         }
     }
 
-    pages = TryAllocDecommittedPages<notPageAligned>(pageCount, pageSegment, pageHeapFlags);
+    pages = TryAllocDecommittedPages<notPageAligned>(pageCount, pageSegment);
     if (pages != nullptr)
     {
         // TryAllocDecommittedPages may give out a mix of free pages and decommitted pages.
@@ -1260,7 +1248,7 @@ PageAllocatorBase<T>::SnailAllocPages(uint pageCount, PageSegmentBase<T> ** page
             return nullptr;
         }
 
-        pages = decommitSegment->DoAllocDecommitPages<notPageAligned>(pageCount, pageHeapFlags);
+        pages = decommitSegment->DoAllocDecommitPages<notPageAligned>(pageCount);
         if (pages != nullptr)
         {
 #if DBG_DUMP
@@ -1288,7 +1276,7 @@ PageAllocatorBase<T>::SnailAllocPages(uint pageCount, PageSegmentBase<T> ** page
         return nullptr;
     }
 
-    pages = newSegment->AllocPages<notPageAligned>(pageCount, pageHeapFlags);
+    pages = newSegment->AllocPages<notPageAligned>(pageCount);
     if (notPageAligned)
     {
         // REVIEW: Is this true for single-chunk allocations too? Are new segments guaranteed to
@@ -2610,9 +2598,9 @@ void PageSegmentBase<T>::SetBitInDecommitPagesBitVector(uint index)
 
 template<typename T>
 template <bool noPageAligned>
-char * PageSegmentBase<T>::DoAllocDecommitPages(uint pageCount, PageHeapMode pageHeapFlags)
+char * PageSegmentBase<T>::DoAllocDecommitPages(uint pageCount)
 {
-    return this->AllocDecommitPages<PageSegmentBase<T>::PageBitVector, noPageAligned>(pageCount, this->freePages, this->decommitPages, pageHeapFlags);
+    return this->AllocDecommitPages<PageSegmentBase<T>::PageBitVector, noPageAligned>(pageCount, this->freePages, this->decommitPages);
 }
 
 template<typename T>

--- a/lib/Common/Memory/PageAllocator.h
+++ b/lib/Common/Memory/PageAllocator.h
@@ -210,13 +210,13 @@ public:
     uint GetFreePageCount() const { return freePageCount; }
     uint GetDecommitPageCount() const { return decommitPageCount; }
 
-    static bool IsAllocationPageAligned(__in char* address, size_t pageCount, PageHeapMode pageHeapFlags);
+    static bool IsAllocationPageAligned(__in char* address, size_t pageCount);
 
     template <typename T, bool notPageAligned>
-    char * AllocDecommitPages(uint pageCount, T freePages, T decommitPages, PageHeapMode pageHeapFlags);
+    char * AllocDecommitPages(uint pageCount, T freePages, T decommitPages);
 
     template <bool notPageAligned>
-    char * AllocPages(uint pageCount, PageHeapMode pageHeapFlags);
+    char * AllocPages(uint pageCount);
 
     void ReleasePages(__in void * address, uint pageCount);
     template <bool onlyUpdateState>
@@ -239,7 +239,7 @@ public:
     void ClearRangeInDecommitPagesBitVector(uint index, uint pageCount);
 
     template <bool notPageAligned>
-    char * DoAllocDecommitPages(uint pageCount, PageHeapMode pageHeapFlags);
+    char * DoAllocDecommitPages(uint pageCount);
     uint GetMaxPageCount();
 
     size_t DecommitFreePages(size_t pageToDecommit);
@@ -425,7 +425,7 @@ public:
     void Release(void * address, size_t pageCount, void * segment);
 
     char * AllocPages(uint pageCount, PageSegmentBase<TVirtualAlloc> ** pageSegment);
-    char * AllocPagesPageAligned(uint pageCount, PageSegmentBase<TVirtualAlloc> ** pageSegment, PageHeapMode pageHeapFlags);
+    char * AllocPagesPageAligned(uint pageCount, PageSegmentBase<TVirtualAlloc> ** pageSegment);
 
     void ReleasePages(__in void * address, uint pageCount, __in void * pageSegment);
     void BackgroundReleasePages(void * address, uint pageCount, PageSegmentBase<TVirtualAlloc> * pageSegment);
@@ -486,16 +486,16 @@ protected:
     char * AllocInternal(size_t * pageCount, SegmentBase<TVirtualAlloc> ** segment);
 
     template <bool notPageAligned>
-    char * SnailAllocPages(uint pageCount, PageSegmentBase<TVirtualAlloc> ** pageSegment, PageHeapMode pageHeapFlags);
+    char * SnailAllocPages(uint pageCount, PageSegmentBase<TVirtualAlloc> ** pageSegment);
     void OnAllocFromNewSegment(uint pageCount, __in void* pages, SegmentBase<TVirtualAlloc>* segment);
 
     template <bool notPageAligned>
-    char * TryAllocFreePages(uint pageCount, PageSegmentBase<TVirtualAlloc> ** pageSegment, PageHeapMode pageHeapFlags);
+    char * TryAllocFreePages(uint pageCount, PageSegmentBase<TVirtualAlloc> ** pageSegment);
     char * TryAllocFromZeroPagesList(uint pageCount, PageSegmentBase<TVirtualAlloc> ** pageSegment, SLIST_HEADER& zeroPagesList, bool isPendingZeroList);
-    char * TryAllocFromZeroPages(uint pageCount, PageSegmentBase<TVirtualAlloc> ** pageSegment, PageHeapMode pageHeapFlags);
+    char * TryAllocFromZeroPages(uint pageCount, PageSegmentBase<TVirtualAlloc> ** pageSegment);
 
     template <bool notPageAligned>
-    char * TryAllocDecommittedPages(uint pageCount, PageSegmentBase<TVirtualAlloc> ** pageSegment, PageHeapMode pageHeapFlags);
+    char * TryAllocDecommittedPages(uint pageCount, PageSegmentBase<TVirtualAlloc> ** pageSegment);
 
     DListBase<PageSegmentBase<TVirtualAlloc>> * GetSegmentList(PageSegmentBase<TVirtualAlloc> * segment);
     void TransferSegment(PageSegmentBase<TVirtualAlloc> * segment, DListBase<PageSegmentBase<TVirtualAlloc>> * fromSegmentList);
@@ -611,7 +611,7 @@ private:
     void QueuePages(void * address, uint pageCount, PageSegmentBase<TVirtualAlloc> * pageSegment);
 
     template <bool notPageAligned>
-    char* AllocPagesInternal(uint pageCount, PageSegmentBase<TVirtualAlloc> ** pageSegment, PageHeapMode pageHeapModeFlags = PageHeapMode::PageHeapModeOff);
+    char* AllocPagesInternal(uint pageCount, PageSegmentBase<TVirtualAlloc> ** pageSegment);
 
 #ifdef PROFILE_MEM
     PageMemoryData * memoryData;

--- a/lib/Common/Memory/Recycler.cpp
+++ b/lib/Common/Memory/Recycler.cpp
@@ -1091,9 +1091,19 @@ bool Recycler::ExplicitFreeInternal(void* buffer, size_t size, size_t sizeCat)
 
     Assert(heapBlock != nullptr);
 #ifdef RECYCLER_PAGE_HEAP
-    if (this->IsPageHeapEnabled() && this->ShouldCapturePageHeapFreeStack())
+    if (this->IsPageHeapEnabled() )
     {
-        heapBlock->CapturePageHeapFreeStack();
+        if (this->ShouldCapturePageHeapFreeStack())
+        {
+            if (heapBlock->IsLargeHeapBlock()) 
+            {
+                LargeHeapBlock* largeHeapBlock = (LargeHeapBlock*)heapBlock;
+                if (largeHeapBlock->InPageHeapMode())
+                {
+                    largeHeapBlock->CapturePageHeapFreeStack();
+                }
+            }
+        }
 
         // Don't do actual explicit free in page heap mode
         return false;

--- a/lib/Common/Memory/Recycler.h
+++ b/lib/Common/Memory/Recycler.h
@@ -1720,7 +1720,7 @@ private:
 
     bool ForceSweepObject();
     void NotifyFree(__in char * address, size_t size);
-    template <bool pageheap, typename T>
+    template <typename T>
     void NotifyFree(T * heapBlock);
 
     void CleanupPendingUnroot();
@@ -2088,8 +2088,9 @@ public:
         if (recycler->ShouldCapturePageHeapFreeStack())
         {
             Assert(recycler->IsPageHeapEnabled());
+            Assert(this->m_heapBlock->IsLargeHeapBlock());
 
-            this->m_heapBlock->CapturePageHeapFreeStack();
+            ((LargeHeapBlock*)this->m_heapBlock)->CapturePageHeapFreeStack();
         }
 #endif
 

--- a/lib/Common/Memory/Recycler.inl
+++ b/lib/Common/Memory/Recycler.inl
@@ -433,7 +433,7 @@ Recycler::AddMark(void * candidate, size_t byteCount) throw()
 }
 
 
-template <bool pageheap, typename T>
+template <typename T>
 void
 Recycler::NotifyFree(T * heapBlock)
 {
@@ -445,7 +445,7 @@ Recycler::NotifyFree(T * heapBlock)
         this->isForceSweeping = true;
         heapBlock->isForceSweeping = true;
 #endif
-        heapBlock->SweepObjects<pageheap, SweepMode_InThread>(this);
+        heapBlock->SweepObjects<SweepMode_InThread>(this);
 #if DBG || defined(RECYCLER_STATS)
         heapBlock->isForceSweeping = false;
         this->isForceSweeping = false;

--- a/lib/Common/Memory/RecyclerSweep.cpp
+++ b/lib/Common/Memory/RecyclerSweep.cpp
@@ -269,16 +269,8 @@ RecyclerSweep::BackgroundSweep()
 {
     this->BeginBackground(forceForeground);
 
-    if (GetRecycler()->IsPageHeapEnabled())
-    {
-        // Finish the concurrent part of the first pass
-        this->recycler->autoHeap.SweepSmallNonFinalizable<true>(*this);
-    }
-    else
-    {
-        // Finish the concurrent part of the first pass
-        this->recycler->autoHeap.SweepSmallNonFinalizable<false>(*this);
-    }
+    // Finish the concurrent part of the first pass
+    this->recycler->autoHeap.SweepSmallNonFinalizable(*this);
 
     // Finish the rest of the sweep
     this->FinishSweep();

--- a/lib/Common/Memory/RecyclerSweep.h
+++ b/lib/Common/Memory/RecyclerSweep.h
@@ -33,7 +33,7 @@ public:
     template <typename TBlockType>
     TBlockType *& GetPendingSweepBlockList(HeapBucketT<TBlockType> const * heapBucket);
     bool HasPendingEmptyBlocks() const;
-    template <typename TBlockType, bool pageheap> void QueueEmptyHeapBlock(HeapBucketT<TBlockType> const *heapBucket, TBlockType * heapBlock);
+    template <typename TBlockType> void QueueEmptyHeapBlock(HeapBucketT<TBlockType> const *heapBucket, TBlockType * heapBlock);
     template <typename TBlockType> void TransferPendingEmptyHeapBlocks(HeapBucketT<TBlockType> * heapBucket);
 
     void BackgroundSweep();
@@ -192,13 +192,13 @@ RecyclerSweep::GetPendingSweepBlockList(HeapBucketT<TBlockType> const * heapBuck
 
 #if ENABLE_CONCURRENT_GC
 
-template <typename TBlockType, bool pageheap>
+template <typename TBlockType>
 void
 RecyclerSweep::QueueEmptyHeapBlock(HeapBucketT<TBlockType> const *heapBucket, TBlockType * heapBlock)
 {
     auto& bucketData = this->GetBucketData(heapBucket);
     Assert(heapBlock->heapBucket == heapBucket);
-    heapBlock->BackgroundReleasePagesSweep<pageheap>(recycler);
+    heapBlock->BackgroundReleasePagesSweep(recycler);
     TBlockType * list = bucketData.pendingEmptyBlockList;
     if (list == nullptr)
     {

--- a/lib/Common/Memory/RecyclerWeakReference.h
+++ b/lib/Common/Memory/RecyclerWeakReference.h
@@ -37,7 +37,7 @@ protected:
 
     char* strongRef;
     HeapBlock * strongRefHeapBlock;
-    SmallHeapBlock * weakRefHeapBlock;
+    HeapBlock * weakRefHeapBlock;
     RecyclerWeakReferenceBase* next;
 #if DBG
     type_info const * typeInfo;
@@ -347,8 +347,8 @@ private:
         Assert(entry->strongRefHeapBlock != nullptr);
 
         HeapBlock * weakRefHeapBlock = recycler->FindHeapBlock(entry);
-        Assert(!weakRefHeapBlock->IsLargeHeapBlock());
-        entry->weakRefHeapBlock = (SmallHeapBlock *)weakRefHeapBlock;
+        Assert(!weakRefHeapBlock->IsLargeHeapBlock() || ((LargeHeapBlock*)weakRefHeapBlock)->InPageHeapMode());
+        entry->weakRefHeapBlock = weakRefHeapBlock;
 
 #ifdef RECYCLER_TRACE_WEAKREF
         Output::Print(_u("Add 0x%08x to bucket %d\n"), entry, targetBucket);

--- a/lib/Common/Memory/SmallBlockDeclarations.inl
+++ b/lib/Common/Memory/SmallBlockDeclarations.inl
@@ -7,20 +7,11 @@
 #error Need to define block type attributes before including this file
 #endif
 
-template void SmallHeapBlockT<TBlockTypeAttributes>::ReleasePages<true>(Recycler * recycler);
-template void SmallHeapBlockT<TBlockTypeAttributes>::ReleasePages<false>(Recycler * recycler);
-template void SmallHeapBlockT<TBlockTypeAttributes>::BackgroundReleasePagesSweep<true>(Recycler* recycler);
-template void SmallHeapBlockT<TBlockTypeAttributes>::BackgroundReleasePagesSweep<false>(Recycler* recycler);
-template void SmallHeapBlockT<TBlockTypeAttributes>::ReleasePagesSweep<true>(Recycler * recycler);
-template void SmallHeapBlockT<TBlockTypeAttributes>::ReleasePagesSweep<false>(Recycler * recycler);
-template BOOL SmallHeapBlockT<TBlockTypeAttributes>::ReassignPages<true>(Recycler * recycler);
-template BOOL SmallHeapBlockT<TBlockTypeAttributes>::ReassignPages<false>(Recycler * recycler);
-template BOOL SmallHeapBlockT<TBlockTypeAttributes>::SetPage<true>(__in_ecount_pagesize char * baseAddress, PageSegment * pageSegment, Recycler * recycler);
-template BOOL SmallHeapBlockT<TBlockTypeAttributes>::SetPage<false>(__in_ecount_pagesize char * baseAddress, PageSegment * pageSegment, Recycler * recycler);
-template const uint SmallHeapBlockT<TBlockTypeAttributes>::GetPageHeapModePageCount<true>() const;
-template const uint SmallHeapBlockT<TBlockTypeAttributes>::GetPageHeapModePageCount<false>() const;
-template SweepState SmallHeapBlockT<TBlockTypeAttributes>::Sweep<true>(RecyclerSweep& recyclerSweep, bool queuePendingSweep, bool allocable, ushort finalizeCount, bool hasPendingDispose);
-template SweepState SmallHeapBlockT<TBlockTypeAttributes>::Sweep<false>(RecyclerSweep& recyclerSweep, bool queuePendingSweep, bool allocable, ushort finalizeCount, bool hasPendingDispose);
+template void SmallHeapBlockT<TBlockTypeAttributes>::ReleasePages(Recycler * recycler);
+template void SmallHeapBlockT<TBlockTypeAttributes>::BackgroundReleasePagesSweep(Recycler* recycler);
+template void SmallHeapBlockT<TBlockTypeAttributes>::ReleasePagesSweep(Recycler * recycler);
+template BOOL SmallHeapBlockT<TBlockTypeAttributes>::ReassignPages(Recycler * recycler);
+template SweepState SmallHeapBlockT<TBlockTypeAttributes>::Sweep(RecyclerSweep& recyclerSweep, bool queuePendingSweep, bool allocable, ushort finalizeCount, bool hasPendingDispose);
 
 template SmallNormalHeapBlockT<TBlockTypeAttributes>* HeapBlock::AsNormalBlock<TBlockTypeAttributes>();
 template SmallLeafHeapBlockT<TBlockTypeAttributes>* HeapBlock::AsLeafBlock<TBlockTypeAttributes>();
@@ -51,8 +42,7 @@ template bool SmallHeapBlockT<TBlockTypeAttributes>::GetFreeObjectListOnAllocato
 // template const SmallHeapBlockT<TBlockTypeAttributes>::SmallHeapBlockBitVector * HeapInfo::ValidPointersMap<TBlockTypeAttributes>::GetInvalidBitVector(uint index) const;
 
 // Explicit instantiate all the sweep mode
-template void SmallHeapBlockT<TBlockTypeAttributes>::SweepObjects<true, SweepMode_InThread>(Recycler * recycler);
-template void SmallHeapBlockT<TBlockTypeAttributes>::SweepObjects<false, SweepMode_InThread>(Recycler * recycler);
+template void SmallHeapBlockT<TBlockTypeAttributes>::SweepObjects<SweepMode_InThread>(Recycler * recycler);
 #if ENABLE_CONCURRENT_GC
 template <>
 template <>
@@ -63,7 +53,7 @@ SmallHeapBlockT<TBlockTypeAttributes>::SweepObject<SweepMode_Concurrent>(Recycle
     EnqueueProcessedObject(&freeObjectList, addr, i);
 }
 // Explicit instantiate all the sweep mode
-template void SmallHeapBlockT<TBlockTypeAttributes>::SweepObjects<false, SweepMode_Concurrent>(Recycler * recycler);
+template void SmallHeapBlockT<TBlockTypeAttributes>::SweepObjects<SweepMode_Concurrent>(Recycler * recycler);
 #if ENABLE_PARTIAL_GC
 template <>
 template <>
@@ -83,7 +73,7 @@ SmallHeapBlockT<TBlockTypeAttributes>::SweepObject<SweepMode_ConcurrentPartial>(
 }
 
 // Explicit instantiate all the sweep mode
-template void SmallHeapBlockT<TBlockTypeAttributes>::SweepObjects<false, SweepMode_ConcurrentPartial>(Recycler * recycler);
+template void SmallHeapBlockT<TBlockTypeAttributes>::SweepObjects<SweepMode_ConcurrentPartial>(Recycler * recycler);
 #endif
 #endif
 

--- a/lib/Common/Memory/SmallFinalizableHeapBlock.cpp
+++ b/lib/Common/Memory/SmallFinalizableHeapBlock.cpp
@@ -229,13 +229,10 @@ SmallFinalizableHeapBlockT<TBlockAttributes>::RescanTrackedObject(FinalizableObj
 }
 #endif
 
-template SweepState SmallFinalizableHeapBlockT<SmallAllocationBlockAttributes>::Sweep<true>(RecyclerSweep& recyclerSweep, bool queuePendingSweep, bool allocable);
-template SweepState SmallFinalizableHeapBlockT<SmallAllocationBlockAttributes>::Sweep<false>(RecyclerSweep& recyclerSweep, bool queuePendingSweep, bool allocable);
-template SweepState SmallFinalizableHeapBlockT<MediumAllocationBlockAttributes>::Sweep<true>(RecyclerSweep& recyclerSweep, bool queuePendingSweep, bool allocable);
-template SweepState SmallFinalizableHeapBlockT<MediumAllocationBlockAttributes>::Sweep<false>(RecyclerSweep& recyclerSweep, bool queuePendingSweep, bool allocable);
+template SweepState SmallFinalizableHeapBlockT<SmallAllocationBlockAttributes>::Sweep(RecyclerSweep& recyclerSweep, bool queuePendingSweep, bool allocable);
+template SweepState SmallFinalizableHeapBlockT<MediumAllocationBlockAttributes>::Sweep(RecyclerSweep& recyclerSweep, bool queuePendingSweep, bool allocable);
 
 template <class TBlockAttributes>
-template<bool pageheap>
 SweepState
 SmallFinalizableHeapBlockT<TBlockAttributes>::Sweep(RecyclerSweep& recyclerSweep, bool queuePendingSweep, bool allocable)
 {
@@ -245,7 +242,7 @@ SmallFinalizableHeapBlockT<TBlockAttributes>::Sweep(RecyclerSweep& recyclerSweep
     // If there are finalizable objects in this heap block, they need to be swept
     // in-thread and not in the concurrent thread, so don't queue pending sweep
 
-    return SmallNormalHeapBlockT<TBlockAttributes>::Sweep<pageheap>(recyclerSweep, false, allocable, this->finalizeCount, HasAnyDisposeObjects());
+    return SmallNormalHeapBlockT<TBlockAttributes>::Sweep(recyclerSweep, false, allocable, this->finalizeCount, HasAnyDisposeObjects());
 }
 
 template <class TBlockAttributes>

--- a/lib/Common/Memory/SmallFinalizableHeapBlock.h
+++ b/lib/Common/Memory/SmallFinalizableHeapBlock.h
@@ -32,7 +32,6 @@ public:
     static bool RescanObject(SmallFinalizableHeapBlockT<TBlockAttributes> * block, __in_ecount(localObjectSize) char * objectAddress, uint localObjectSize, uint objectIndex, Recycler * recycler);
     bool RescanTrackedObject(FinalizableObject * object, uint objectIndex,  Recycler * recycler);
 #endif
-    template<bool pageheap>
     SweepState Sweep(RecyclerSweep& sweepeData, bool queuePendingSweep, bool allocable);
     void DisposeObjects();
     void TransferDisposedObjects();

--- a/lib/Common/Memory/SmallFinalizableHeapBucket.cpp
+++ b/lib/Common/Memory/SmallFinalizableHeapBucket.cpp
@@ -93,21 +93,16 @@ SmallFinalizableHeapBucketBaseT<TBlockType>::AggregateBucketStats(HeapBucketStat
 }
 #endif
 
-template void SmallFinalizableHeapBucketBaseT<SmallFinalizableHeapBlock>::Sweep<true>(RecyclerSweep& recyclerSweep);
-template void SmallFinalizableHeapBucketBaseT<SmallFinalizableHeapBlock>::Sweep<false>(RecyclerSweep& recyclerSweep);
-template void SmallFinalizableHeapBucketBaseT<MediumFinalizableHeapBlock>::Sweep<true>(RecyclerSweep& recyclerSweep);
-template void SmallFinalizableHeapBucketBaseT<MediumFinalizableHeapBlock>::Sweep<false>(RecyclerSweep& recyclerSweep);
+template void SmallFinalizableHeapBucketBaseT<SmallFinalizableHeapBlock>::Sweep(RecyclerSweep& recyclerSweep);
+template void SmallFinalizableHeapBucketBaseT<MediumFinalizableHeapBlock>::Sweep(RecyclerSweep& recyclerSweep);
 
 #ifdef RECYCLER_WRITE_BARRIER
-template void SmallFinalizableHeapBucketBaseT<SmallFinalizableWithBarrierHeapBlock>::Sweep<true>(RecyclerSweep& recyclerSweep);
-template void SmallFinalizableHeapBucketBaseT<SmallFinalizableWithBarrierHeapBlock>::Sweep<false>(RecyclerSweep& recyclerSweep);
-template void SmallFinalizableHeapBucketBaseT<MediumFinalizableWithBarrierHeapBlock>::Sweep<true>(RecyclerSweep& recyclerSweep);
-template void SmallFinalizableHeapBucketBaseT<MediumFinalizableWithBarrierHeapBlock>::Sweep<false>(RecyclerSweep& recyclerSweep);
+template void SmallFinalizableHeapBucketBaseT<SmallFinalizableWithBarrierHeapBlock>::Sweep(RecyclerSweep& recyclerSweep);
+template void SmallFinalizableHeapBucketBaseT<MediumFinalizableWithBarrierHeapBlock>::Sweep(RecyclerSweep& recyclerSweep);
 #endif
 
 
 template<class TBlockType>
-template<bool pageheap>
 void
 SmallFinalizableHeapBucketBaseT<TBlockType>::Sweep(RecyclerSweep& recyclerSweep)
 {
@@ -121,7 +116,7 @@ SmallFinalizableHeapBucketBaseT<TBlockType>::Sweep(RecyclerSweep& recyclerSweep)
     TBlockType * currentDisposeList = pendingDisposeList;
     this->pendingDisposeList = nullptr;
 
-    BaseT::SweepBucket<pageheap>(recyclerSweep, [=](RecyclerSweep& recyclerSweep)
+    BaseT::SweepBucket(recyclerSweep, [=](RecyclerSweep& recyclerSweep)
     {
 #if DBG
         if (TBlockType::HeapBlockAttributes::IsSmallBlock)
@@ -138,7 +133,7 @@ SmallFinalizableHeapBucketBaseT<TBlockType>::Sweep(RecyclerSweep& recyclerSweep)
         }
 #endif
 
-        HeapBucketT<TBlockType>::SweepHeapBlockList<pageheap>(recyclerSweep, currentDisposeList, false);
+        HeapBucketT<TBlockType>::SweepHeapBlockList(recyclerSweep, currentDisposeList, false);
 
 #if DBG || defined(RECYCLER_SLOW_CHECK_ENABLED)
         Assert(this->tempPendingDisposeList == currentDisposeList);

--- a/lib/Common/Memory/SmallFinalizableHeapBucket.h
+++ b/lib/Common/Memory/SmallFinalizableHeapBucket.h
@@ -30,7 +30,6 @@ protected:
     friend class HeapBucketGroup;
 
     void ResetMarks(ResetMarkFlags flags);
-    template<bool pageheap>
     void Sweep(RecyclerSweep& recyclerSweep);
 #if DBG || defined(RECYCLER_SLOW_CHECK_ENABLED)
     size_t GetNonEmptyHeapBlockCount(bool checkCount) const;
@@ -206,7 +205,6 @@ public:
     void ScanInitialImplicitRoots(Recycler * recycler);
     void ScanNewImplicitRoots(Recycler * recycler);
 
-    template<bool pageheap>
     void Sweep(RecyclerSweep& recyclerSweep);
     uint Rescan(Recycler * recycler, RescanFlags flags);
 #if ENABLE_CONCURRENT_GC
@@ -221,7 +219,6 @@ public:
     void SetupBackgroundSweep(RecyclerSweep& recyclerSweep);
     void TransferPendingEmptyHeapBlocks(RecyclerSweep& recyclerSweep);
 #endif
-    template<bool pageheap>
     void SweepFinalizableObjects(RecyclerSweep& recyclerSweep);
     void DisposeObjects();
     void TransferDisposedObjects();

--- a/lib/Common/Memory/SmallHeapBlockAllocator.cpp
+++ b/lib/Common/Memory/SmallHeapBlockAllocator.cpp
@@ -209,11 +209,7 @@ SmallHeapBlockAllocator<TBlockType>::TrackNativeAllocatedObjects()
 
     if (lastNonNativeBumpAllocatedBlock == nullptr)
     {
-#ifdef RECYCLER_PAGE_HEAP
-        Assert((char *)this->freeObjectList == this->heapBlock->GetAddress() || ((SmallHeapBlock*) this->heapBlock)->InPageHeapMode());
-#else
         Assert((char *)this->freeObjectList == this->heapBlock->GetAddress());
-#endif
         return;
     }
 

--- a/lib/Common/Memory/SmallLeafHeapBucket.cpp
+++ b/lib/Common/Memory/SmallLeafHeapBucket.cpp
@@ -4,17 +4,11 @@
 //-------------------------------------------------------------------------------------------------------
 #include "CommonMemoryPch.h"
 
-template void SmallLeafHeapBucketT<SmallAllocationBlockAttributes>::Sweep<true>(RecyclerSweep& recyclerSweep);
-template void SmallLeafHeapBucketT<SmallAllocationBlockAttributes>::Sweep<false>(RecyclerSweep& recyclerSweep);
-template void SmallLeafHeapBucketT<MediumAllocationBlockAttributes>::Sweep<true>(RecyclerSweep& recyclerSweep);
-template void SmallLeafHeapBucketT<MediumAllocationBlockAttributes>::Sweep<false>(RecyclerSweep& recyclerSweep);
-
 template <typename TBlockAttributes>
-template<bool pageheap>
 void
 SmallLeafHeapBucketT<TBlockAttributes>::Sweep(RecyclerSweep& recyclerSweep)
 {
-    BaseT::SweepBucket<pageheap>(recyclerSweep, [](RecyclerSweep& recyclerSweep){});
+    BaseT::SweepBucket(recyclerSweep, [](RecyclerSweep& recyclerSweep){});
 }
 
 #if DBG || defined(RECYCLER_SLOW_CHECK_ENABLED)

--- a/lib/Common/Memory/SmallLeafHeapBucket.h
+++ b/lib/Common/Memory/SmallLeafHeapBucket.h
@@ -13,7 +13,6 @@ protected:
     template <class TBlockAttributes>
     friend class HeapBucketGroup;
 
-    template<bool pageheap>
     void Sweep(RecyclerSweep& recyclerSweep);
 
 #if DBG || defined(RECYCLER_SLOW_CHECK_ENABLED)

--- a/lib/Common/Memory/SmallNormalHeapBucket.cpp
+++ b/lib/Common/Memory/SmallNormalHeapBucket.cpp
@@ -227,7 +227,7 @@ SmallNormalHeapBucketBase<TBlockType>::SweepPendingObjects(RecyclerSweep& recycl
                 // The sweepable objects will be collected in a future Sweep.
 
                 // Note, page heap blocks are never swept concurrently
-                heapBlock->SweepObjects<false, SweepMode_ConcurrentPartial>(recycler);
+                heapBlock->SweepObjects<SweepMode_ConcurrentPartial>(recycler);
 
                 // page heap mode should never reach here, so don't check pageheap enabled or not
                 if (heapBlock->HasFreeObject<false>())
@@ -272,7 +272,7 @@ SmallNormalHeapBucketBase<TBlockType>::SweepPendingObjects(Recycler * recycler, 
     HeapBlockList::ForEach(list, [recycler, &tail](TBlockType * heapBlock)
     {
         // Note, page heap blocks are never swept concurrently
-        heapBlock->SweepObjects<false, mode>(recycler);
+        heapBlock->SweepObjects<mode>(recycler);
         tail = heapBlock;
     });
     return tail;
@@ -356,7 +356,7 @@ SmallNormalHeapBucketBase<TBlockType>::SweepPartialReusePages(RecyclerSweep& rec
                 Assert(!heapBlock->IsAnyFinalizableBlock());
 
                 // Page heap blocks are never swept concurrently
-                heapBlock->SweepObjects<false, SweepMode_InThread>(recycler);
+                heapBlock->SweepObjects<SweepMode_InThread>(recycler);
 
                 // This block has been counted as concurrently swept, and now we changed our mind
                 // and sweep it in thread. Remove the count
@@ -554,7 +554,6 @@ SmallNormalHeapBucketBase<TBlockType>::VerifyMark()
 #endif // ENABLE_PARTIAL_GC
 
 template <typename TBlockType>
-template<bool pageheap>
 void
 SmallNormalHeapBucketBase<TBlockType>::Sweep(RecyclerSweep& recyclerSweep)
 {
@@ -571,7 +570,7 @@ SmallNormalHeapBucketBase<TBlockType>::Sweep(RecyclerSweep& recyclerSweep)
     this->SweepVerifyPartialBlocks(recycler, this->partialHeapBlockList);
 #endif
 #endif
-    BaseT::SweepBucket<pageheap>(recyclerSweep, [](RecyclerSweep& recyclerSweep){});
+    BaseT::SweepBucket(recyclerSweep, [](RecyclerSweep& recyclerSweep){});
 }
 
 template class SmallNormalHeapBucketBase<SmallNormalHeapBlock>;
@@ -589,15 +588,12 @@ template class SmallNormalHeapBucketBase<MediumFinalizableHeapBlock>;
 template class SmallNormalHeapBucketBase<SmallFinalizableWithBarrierHeapBlock>;
 template class SmallNormalHeapBucketBase<MediumFinalizableWithBarrierHeapBlock>;
 #endif
-
-template void SmallNormalHeapBucketBase<SmallNormalHeapBlock>::Sweep<true>(RecyclerSweep& recyclerSweep);
-template void SmallNormalHeapBucketBase<SmallNormalHeapBlock>::Sweep<false>(RecyclerSweep& recyclerSweep);
-template void SmallNormalHeapBucketBase<MediumNormalHeapBlock>::Sweep<true>(RecyclerSweep& recyclerSweep);
-template void SmallNormalHeapBucketBase<MediumNormalHeapBlock>::Sweep<false>(RecyclerSweep& recyclerSweep);
+   
+template void SmallNormalHeapBucketBase<SmallNormalHeapBlock>::Sweep(RecyclerSweep& recyclerSweep);
+template void SmallNormalHeapBucketBase<MediumNormalHeapBlock>::Sweep(RecyclerSweep& recyclerSweep);
 
 #ifdef RECYCLER_WRITE_BARRIER
-template void SmallNormalHeapBucketBase<SmallNormalWithBarrierHeapBlock>::Sweep<true>(RecyclerSweep& recyclerSweep);
-template void SmallNormalHeapBucketBase<SmallNormalWithBarrierHeapBlock>::Sweep<false>(RecyclerSweep& recyclerSweep);
-template void SmallNormalHeapBucketBase<MediumNormalWithBarrierHeapBlock>::Sweep<true>(RecyclerSweep& recyclerSweep);
-template void SmallNormalHeapBucketBase<MediumNormalWithBarrierHeapBlock>::Sweep<false>(RecyclerSweep& recyclerSweep);
+template void SmallNormalHeapBucketBase<SmallNormalWithBarrierHeapBlock>::Sweep(RecyclerSweep& recyclerSweep);
+template void SmallNormalHeapBucketBase<MediumNormalWithBarrierHeapBlock>::Sweep(RecyclerSweep& recyclerSweep);
 #endif
+

--- a/lib/Common/Memory/SmallNormalHeapBucket.h
+++ b/lib/Common/Memory/SmallNormalHeapBucket.h
@@ -39,7 +39,6 @@ protected:
     template <SweepMode mode>
     static TBlockType * SweepPendingObjects(Recycler * recycler, TBlockType * list);
 #endif
-    template<bool pageheap>
     void Sweep(RecyclerSweep& recyclerSweep);
 #if ENABLE_PARTIAL_GC
     ~SmallNormalHeapBucketBase();


### PR DESCRIPTION
- remove the pageheap implementation in small and medium block
- fix couple issues in large heap pageheap implementation (OOM while allocating LargeHeapBlock or adding to heapBlockMap)
- decommit guard page instead of setting to NOACCESS to save memory.
- implement pattern check for corruption
- TrackBit is not supported by LargeHeapBlock today, so disable pageheap for such allocation
- added assert on non-alignment page allocated for recycler, this is found by page heap run
