### PR TITLE
use large heap block for all pageheap allocation

### DIFF
--- a/lib/Common/Exceptions/ReportError.h
+++ b/lib/Common/Exceptions/ReportError.h
@@ -18,7 +18,8 @@ enum ErrorReason
     Fatal_Version_Inconsistency = 10,
     MarkStack_OUTOFMEMORY = 11,
     EnterScript_FromDOM_NoScriptScope = 12,
-    Fatal_FailedToBox_OUTOFMEMORY = 13
+    Fatal_FailedToBox_OUTOFMEMORY = 13,
+    Fatal_Recycler_MemoryCorruption = 14
 };
 
 extern "C" void ReportFatalException(

--- a/lib/Common/Memory/HeapBucket.cpp
+++ b/lib/Common/Memory/HeapBucket.cpp
@@ -224,10 +224,7 @@ HeapBucketT<TBlockType>::IntegrateBlock(char * blockAddress, PageSegment * segme
     }
 
     // TODO: Consider supporting guard pages for this codepath
-#ifdef RECYCLER_PAGE_HEAP
-    heapBlock->ClearPageHeap();
-#endif
-    if (!heapBlock->SetPage<false>(blockAddress, segment, recycler))
+    if (!heapBlock->SetPage(blockAddress, segment, recycler))
     {
         FreeHeapBlock(heapBlock);
         return false;
@@ -362,13 +359,16 @@ HeapBucketT<TBlockType>::TryAllocFromNewHeapBlock(Recycler * recycler, TBlockAll
     Assert((attributes & InternalObjectInfoBitMask) == attributes);
 
 #ifdef RECYCLER_PAGE_HEAP
-    if (IsPageHeapEnabled())
+    if (IsPageHeapEnabled(attributes))
     {
-        return this->PageHeapAlloc(recycler, sizeCat, attributes, this->heapInfo->pageHeapMode, true);
+        if ((attributes & TrackBit) != TrackBit) // LargeHeapBlock does not support TrackBit today
+        {
+            return this->PageHeapAlloc(recycler, sizeCat, attributes, this->heapInfo->pageHeapMode, true);
+        }
     }
 #endif
 
-    TBlockType * heapBlock = CreateHeapBlock<false>(recycler);
+    TBlockType * heapBlock = CreateHeapBlock(recycler);
     if (heapBlock == nullptr)
     {
         return nullptr;
@@ -388,92 +388,7 @@ char *
 HeapBucketT<TBlockType>::PageHeapAlloc(Recycler * recycler, size_t sizeCat, ObjectInfoBits attributes, PageHeapMode mode, bool nothrow)
 {
     AllocationVerboseTrace(recycler->GetRecyclerFlagsTable(), _u("In PageHeapAlloc [Size: 0x%x, Attributes: 0x%x]\n"), sizeCat, attributes);
-
-    Assert(sizeCat == this->sizeCat);
-    char * memBlock = nullptr;
-    TBlockAllocatorType* allocator = &this->allocatorHead;
-
-    memBlock = allocator->PageHeapAlloc(recycler, sizeCat, attributes, mode);
-    if (memBlock == nullptr)
-    {
-        TBlockType* heapBlock = nullptr;
-
-        allocator->Clear();
-
-        {
-            AUTO_NO_EXCEPTION_REGION;
-
-            heapBlock = CreateHeapBlock<true>(recycler);
-        }
-
-        if (heapBlock != nullptr)
-        {
-            // new heap block added, allocate from that.
-            allocator->SetNew(heapBlock);
-            memBlock = allocator->PageHeapAlloc(recycler, sizeCat, attributes, mode);
-            Assert(memBlock != nullptr || IS_FAULTINJECT_NO_THROW_ON);
-        }
-
-        if (memBlock == nullptr)
-        {
-            recycler->CollectNow<CollectNowForceInThread>();
-            memBlock = allocator->PageHeapAlloc(recycler, sizeCat, attributes, mode);
-
-            if (memBlock == nullptr)
-            {
-                // Although we collected in thread, PostCollectCallback may
-                // allocate memory and populated the allocator again, let's clear it again
-                allocator->Clear();
-
-                TBlockType* heapBlock = nullptr;
-
-                {
-                    AUTO_NO_EXCEPTION_REGION;
-
-                    heapBlock = CreateHeapBlock<true>(recycler);
-                }
-
-                if (heapBlock != nullptr)
-                {
-                    // new heap block added, allocate from that.
-                    allocator->SetNew(heapBlock);
-                    memBlock = allocator->PageHeapAlloc(recycler, sizeCat, attributes, mode);
-                    Assert(memBlock != nullptr || IS_FAULTINJECT_NO_THROW_ON);
-                }
-
-                if (memBlock == nullptr)
-                {
-                    // If nothrow is false, that means throwing is allowed
-                    // Since we have no more memory to allocate here, throw an OOM exception
-                    // If nothrow is true, then simply return null
-                    if (nothrow == false)
-                    {
-                        recycler->OutOfMemory();
-                    }
-                    else
-                    {
-                        return nullptr;
-                    }
-                }
-            }
-        }
-    }
-
-    Assert(memBlock != nullptr);
-#ifdef RECYCLER_ZERO_MEM_CHECK
-    if ((attributes & ObjectInfoBits::LeafBit) == 0
-#ifdef RECYCLER_WRITE_BARRIER_ALLOC_THREAD_PAGE
-        && ((attributes & ObjectInfoBits::WithBarrierBit) == 0)
-#endif
-        )
-    {
-        // Skip the first and the last pointer objects- the first may have next pointer for the free list
-        // the last might have the old size of the object if this was allocated from an explicit free list
-        recycler->VerifyZeroFill(memBlock + sizeof(FreeObject), sizeCat - (2 * sizeof(FreeObject)));
-    }
-#endif
-
-    return memBlock;
+    return heapInfo->largeObjectBucket.PageHeapAlloc(recycler, sizeCat, attributes, mode, nothrow);
 }
 #endif
 
@@ -585,7 +500,6 @@ HeapBucketT<TBlockType>::GetUnusedHeapBlock()
 }
 
 template <typename TBlockType>
-template<bool pageheap>
 TBlockType *
 HeapBucketT<TBlockType>::CreateHeapBlock(Recycler * recycler)
 {
@@ -598,14 +512,7 @@ HeapBucketT<TBlockType>::CreateHeapBlock(Recycler * recycler)
         return nullptr;
     }
 
-#ifdef RECYCLER_PAGE_HEAP
-    if (pageheap)
-    {
-        heapBlock->EnablePageHeap();
-    }
-#endif
-
-    if (!heapBlock->ReassignPages<pageheap>(recycler))
+    if (!heapBlock->ReassignPages(recycler))
     {
         FreeHeapBlock(heapBlock);
         return nullptr;
@@ -814,21 +721,7 @@ HeapBucketT<TBlockType>::DoPartialReuseSweep(Recycler * recycler)
 }
 #endif
 
-template void HeapBucketT<SmallLeafHeapBlock>::SweepHeapBlockList<true>(RecyclerSweep&, SmallLeafHeapBlock *, bool);
-template void HeapBucketT<SmallLeafHeapBlock>::SweepHeapBlockList<false>(RecyclerSweep&, SmallLeafHeapBlock *, bool);
-template void HeapBucketT<SmallNormalHeapBlock>::SweepHeapBlockList<true>(RecyclerSweep&, SmallNormalHeapBlock *, bool);
-template void HeapBucketT<SmallNormalHeapBlock>::SweepHeapBlockList<false>(RecyclerSweep&, SmallNormalHeapBlock *, bool);
-template void HeapBucketT<SmallFinalizableHeapBlock>::SweepHeapBlockList<true>(RecyclerSweep&, SmallFinalizableHeapBlock *, bool);
-template void HeapBucketT<SmallFinalizableHeapBlock>::SweepHeapBlockList<false>(RecyclerSweep&, SmallFinalizableHeapBlock *, bool);
-#ifdef RECYCLER_WRITE_BARRIER
-template void HeapBucketT<SmallNormalWithBarrierHeapBlock>::SweepHeapBlockList<true>(RecyclerSweep&, SmallNormalWithBarrierHeapBlock *, bool);
-template void HeapBucketT<SmallNormalWithBarrierHeapBlock>::SweepHeapBlockList<false>(RecyclerSweep&, SmallNormalWithBarrierHeapBlock *, bool);
-template void HeapBucketT<SmallFinalizableWithBarrierHeapBlock>::SweepHeapBlockList<true>(RecyclerSweep&, SmallFinalizableWithBarrierHeapBlock *, bool);
-template void HeapBucketT<SmallFinalizableWithBarrierHeapBlock>::SweepHeapBlockList<false>(RecyclerSweep&, SmallFinalizableWithBarrierHeapBlock *, bool);
-#endif
-
 template <typename TBlockType>
-template <bool pageheap>
 void
 HeapBucketT<TBlockType>::SweepHeapBlockList(RecyclerSweep& recyclerSweep, TBlockType * heapBlockList, bool allocable)
 {
@@ -868,7 +761,7 @@ HeapBucketT<TBlockType>::SweepHeapBlockList(RecyclerSweep& recyclerSweep, TBlock
         // The whole list need to be consistent
         DebugOnly(VerifyBlockConsistencyInList(heapBlock, recyclerSweep));
 
-        SweepState state = heapBlock->Sweep<pageheap>(recyclerSweep, queuePendingSweep, allocable);
+        SweepState state = heapBlock->Sweep(recyclerSweep, queuePendingSweep, allocable);
 
         DebugOnly(VerifyBlockConsistencyInList(heapBlock, recyclerSweep, state));
 
@@ -956,14 +849,14 @@ HeapBucketT<TBlockType>::SweepHeapBlockList(RecyclerSweep& recyclerSweep, TBlock
 #endif
                 // CONCURRENT-TODO: We will zero heap block even if the number free page pool exceed
                 // the maximum and will get decommitted anyway
-                recyclerSweep.QueueEmptyHeapBlock<TBlockType, pageheap>(this, heapBlock);
+                recyclerSweep.QueueEmptyHeapBlock<TBlockType>(this, heapBlock);
                 RECYCLER_STATS_INC(recycler, numZeroedOutSmallBlocks);
             }
             else
 #endif
             {
                 // Just free the page in thread (and zero the page)
-                heapBlock->ReleasePagesSweep<pageheap>(recycler);
+                heapBlock->ReleasePagesSweep(recycler);
                 FreeHeapBlock(heapBlock);
                 RECYCLER_SLOW_CHECK(this->heapBlockCount--);
             }
@@ -975,7 +868,6 @@ HeapBucketT<TBlockType>::SweepHeapBlockList(RecyclerSweep& recyclerSweep, TBlock
 }
 
 template <typename TBlockType>
-template <bool pageheap>
 void
 HeapBucketT<TBlockType>::SweepBucket(RecyclerSweep& recyclerSweep)
 {
@@ -1023,7 +915,7 @@ HeapBucketT<TBlockType>::SweepBucket(RecyclerSweep& recyclerSweep)
     TBlockType * currentHeapBlockList = heapBlockList;
     this->heapBlockList = nullptr;
     this->fullBlockList = nullptr;
-    this->SweepHeapBlockList<pageheap>(recyclerSweep, currentHeapBlockList, true);
+    this->SweepHeapBlockList(recyclerSweep, currentHeapBlockList, true);
 
 #if DBG
     if (TBlockType::HeapBlockAttributes::IsSmallBlock)
@@ -1040,7 +932,7 @@ HeapBucketT<TBlockType>::SweepBucket(RecyclerSweep& recyclerSweep)
     }
 #endif
 
-    this->SweepHeapBlockList<pageheap>(recyclerSweep, currentFullBlockList, false);
+    this->SweepHeapBlockList(recyclerSweep, currentFullBlockList, false);
 
     // We shouldn't have allocate from any block yet
     Assert(this->nextAllocableBlockHead == nullptr);
@@ -1129,32 +1021,6 @@ HeapBucketT<TBlockType>::SetupBackgroundSweep(RecyclerSweep& recyclerSweep)
     Assert(recyclerSweep.GetPendingSweepBlockList(this) == nullptr);
 
     this->StopAllocationBeforeSweep();
-}
-#endif
-
-#ifdef RECYCLER_PAGE_HEAP
-template <typename TBlockType>
-void
-HeapBucketT<TBlockType>::PageHeapCheckSweepLists(RecyclerSweep& recyclerSweep)
-{
-#if DBG
-    if (IsPageHeapEnabled())
-    {
-        // in page heap mode. both the heapBlockList and pendingSweepList should not contain page heap block
-        // Since all block should be "empty" if there are swept object.
-        // But the list might not be Null because page heap is not enabled for integrated page heapblock
-        HeapBlockList::ForEach(this->heapBlockList, [](TBlockType * heapBlock)
-        {
-            Assert(!heapBlock->InPageHeapMode());
-        });
-#if ENABLE_CONCURRENT_GC
-        HeapBlockList::ForEach(recyclerSweep.GetPendingSweepBlockList(this), [](TBlockType * heapBlock)
-        {
-            Assert(!heapBlock->InPageHeapMode());
-        });
-#endif
-    }
-#endif
 }
 #endif
 
@@ -1391,40 +1257,26 @@ HeapBucketGroup<TBlockAttributes>::ScanNewImplicitRoots(Recycler * recycler)
     finalizableHeapBucket.ScanNewImplicitRoots(recycler);
 }
 
-// TODO: Fix template args
-template void HeapBucketGroup<SmallAllocationBlockAttributes>::Sweep<true>(RecyclerSweep& recyclerSweep);
-template void HeapBucketGroup<SmallAllocationBlockAttributes>::Sweep<false>(RecyclerSweep& recyclerSweep);
-template void HeapBucketGroup<MediumAllocationBlockAttributes>::Sweep<true>(RecyclerSweep& recyclerSweep);
-template void HeapBucketGroup<MediumAllocationBlockAttributes>::Sweep<false>(RecyclerSweep& recyclerSweep);
-
 template <class TBlockAttributes>
-template<bool pageheap>
 void
 HeapBucketGroup<TBlockAttributes>::Sweep(RecyclerSweep& recyclerSweep)
 {
-    heapBucket.Sweep<pageheap>(recyclerSweep);
-    leafHeapBucket.Sweep<pageheap>(recyclerSweep);
+    heapBucket.Sweep(recyclerSweep);
+    leafHeapBucket.Sweep(recyclerSweep);
 #ifdef RECYCLER_WRITE_BARRIER
-    smallNormalWithBarrierHeapBucket.Sweep<pageheap>(recyclerSweep);
+    smallNormalWithBarrierHeapBucket.Sweep(recyclerSweep);
 #endif
 }
-
-
-template void HeapBucketGroup<SmallAllocationBlockAttributes>::SweepFinalizableObjects<true>(RecyclerSweep& recyclerSweep);
-template void HeapBucketGroup<SmallAllocationBlockAttributes>::SweepFinalizableObjects<false>(RecyclerSweep& recyclerSweep);
-template void HeapBucketGroup<MediumAllocationBlockAttributes>::SweepFinalizableObjects<true>(RecyclerSweep& recyclerSweep);
-template void HeapBucketGroup<MediumAllocationBlockAttributes>::SweepFinalizableObjects<false>(RecyclerSweep& recyclerSweep);
 
 // Sweep finalizable objects first to ensure that if they reference any other
 // objects in the finalizer - they are valid
 template <class TBlockAttributes>
-template<bool pageheap>
 void
 HeapBucketGroup<TBlockAttributes>::SweepFinalizableObjects(RecyclerSweep& recyclerSweep)
 {
-    finalizableHeapBucket.Sweep<pageheap>(recyclerSweep);
+    finalizableHeapBucket.Sweep(recyclerSweep);
 #ifdef RECYCLER_WRITE_BARRIER
-    smallFinalizableWithBarrierHeapBucket.Sweep<pageheap>(recyclerSweep);
+    smallFinalizableWithBarrierHeapBucket.Sweep(recyclerSweep);
 #endif
 }
 
@@ -1514,15 +1366,6 @@ template <class TBlockAttributes>
 void
 HeapBucketGroup<TBlockAttributes>::SweepPartialReusePages(RecyclerSweep& recyclerSweep)
 {
-#if DBG && defined(RECYCLER_PAGE_HEAP)
-    this->heapBucket.PageHeapCheckSweepLists(recyclerSweep);
-#ifdef RECYCLER_WRITE_BARRIER
-    this->smallNormalWithBarrierHeapBucket.PageHeapCheckSweepLists(recyclerSweep);
-    this->smallFinalizableWithBarrierHeapBucket.PageHeapCheckSweepLists(recyclerSweep);
-#endif
-    this->finalizableHeapBucket.PageHeapCheckSweepLists(recyclerSweep);
-#endif
-
     // Leaf heap bucket are always reused for allocation and can be done on the concurrent thread
     // WriteBarrier-TODO: Do the same for write barrier buckets
     heapBucket.SweepPartialReusePages(recyclerSweep);
@@ -1673,30 +1516,3 @@ HeapBucketGroup<TBlockAttributes>::AllocatorsAreEmpty()
 template class HeapBucketGroup<SmallAllocationBlockAttributes>;
 template class HeapBucketGroup<MediumAllocationBlockAttributes>;
 
-
-template void HeapBucketT<SmallFinalizableHeapBlock>::SweepBucket<true>(RecyclerSweep&);
-template void HeapBucketT<SmallFinalizableHeapBlock>::SweepBucket<false>(RecyclerSweep&);
-template void HeapBucketT<SmallNormalHeapBlock>::SweepBucket<true>(RecyclerSweep&);
-template void HeapBucketT<SmallNormalHeapBlock>::SweepBucket<false>(RecyclerSweep&);
-template void HeapBucketT<SmallLeafHeapBlock>::SweepBucket<true>(RecyclerSweep&);
-template void HeapBucketT<SmallLeafHeapBlock>::SweepBucket<false>(RecyclerSweep&);
-#ifdef RECYCLER_WRITE_BARRIER
-template void HeapBucketT<SmallFinalizableWithBarrierHeapBlock>::SweepBucket<true>(RecyclerSweep&);
-template void HeapBucketT<SmallFinalizableWithBarrierHeapBlock>::SweepBucket<false>(RecyclerSweep&);
-template void HeapBucketT<SmallNormalWithBarrierHeapBlock>::SweepBucket<true>(RecyclerSweep&);
-template void HeapBucketT<SmallNormalWithBarrierHeapBlock>::SweepBucket<false>(RecyclerSweep&);
-#endif
-
-template void HeapBucketT<MediumFinalizableHeapBlock>::SweepBucket<true>(RecyclerSweep&);
-template void HeapBucketT<MediumFinalizableHeapBlock>::SweepBucket<false>(RecyclerSweep&);
-
-template void HeapBucketT<MediumNormalHeapBlock>::SweepBucket<true>(RecyclerSweep&);
-template void HeapBucketT<MediumNormalHeapBlock>::SweepBucket<false>(RecyclerSweep&);
-template void HeapBucketT<MediumLeafHeapBlock>::SweepBucket<true>(RecyclerSweep&);
-template void HeapBucketT<MediumLeafHeapBlock>::SweepBucket<false>(RecyclerSweep&);
-#ifdef RECYCLER_WRITE_BARRIER
-template void HeapBucketT<MediumFinalizableWithBarrierHeapBlock>::SweepBucket<true>(RecyclerSweep&);
-template void HeapBucketT<MediumFinalizableWithBarrierHeapBlock>::SweepBucket<false>(RecyclerSweep&);
-template void HeapBucketT<MediumNormalWithBarrierHeapBlock>::SweepBucket<true>(RecyclerSweep&);
-template void HeapBucketT<MediumNormalWithBarrierHeapBlock>::SweepBucket<false>(RecyclerSweep&);
-#endif

--- a/lib/Common/Memory/HeapBucket.h
+++ b/lib/Common/Memory/HeapBucket.h
@@ -124,15 +124,15 @@ public:
     bool IntegrateBlock(char * blockAddress, PageSegment * segment, Recycler * recycler);
 
     template <ObjectInfoBits attributes, bool nothrow>
-    __inline char * RealAlloc(Recycler * recycler, size_t sizeCat);
+    __inline char * RealAlloc(Recycler * recycler, size_t sizeCat, size_t size);
 
 #ifdef RECYCLER_PAGE_HEAP
-    char * PageHeapAlloc(Recycler * recycler, size_t sizeCat, ObjectInfoBits attributes, PageHeapMode mode, bool nothrow);
+    char * PageHeapAlloc(Recycler * recycler, size_t sizeCat, size_t size, ObjectInfoBits attributes, PageHeapMode mode, bool nothrow);
 #endif
 
     void ExplicitFree(void* object, size_t sizeCat);
 
-    char * SnailAlloc(Recycler * recycler, TBlockAllocatorType * allocator, size_t sizeCat, ObjectInfoBits attributes, bool nothrow);
+    char * SnailAlloc(Recycler * recycler, TBlockAllocatorType * allocator, size_t sizeCat, size_t size, ObjectInfoBits attributes, bool nothrow);
 
     void ResetMarks(ResetMarkFlags flags);
     void ScanNewImplicitRoots(Recycler * recycler);
@@ -176,7 +176,7 @@ protected:
     template <class Fn> void ForEachAllocator(Fn fn);
 
     // Allocations
-    char * TryAllocFromNewHeapBlock(Recycler * recycler, TBlockAllocatorType * allocator, size_t sizeCat, ObjectInfoBits attributes);
+    char * TryAllocFromNewHeapBlock(Recycler * recycler, TBlockAllocatorType * allocator, size_t sizeCat, size_t size, ObjectInfoBits attributes);
     char * TryAlloc(Recycler * recycler, TBlockAllocatorType * allocator, size_t sizeCat, ObjectInfoBits attributes);
     TBlockType * CreateHeapBlock(Recycler * recycler);
     TBlockType * GetUnusedHeapBlock();

--- a/lib/Common/Memory/HeapBucket.inl
+++ b/lib/Common/Memory/HeapBucket.inl
@@ -18,14 +18,6 @@ HeapBucketT<TBlockType>::RealAlloc(Recycler * recycler, size_t sizeCat)
         memBlock = SnailAlloc(recycler, &allocatorHead, sizeCat, attributes, nothrow);
         Assert(memBlock != nullptr || nothrow);
     }
-    else
-    {
-#ifdef RECYCLER_PAGE_HEAP
-        Assert(allocatorHead.heapBlock == nullptr || !allocatorHead.heapBlock->InPageHeapMode());
-#else
-        Assert(allocatorHead.heapBlock == nullptr);
-#endif
-    }
 
     // If this API is called and throwing is not allowed,
     // check if we actually allocated a block before verifying

--- a/lib/Common/Memory/HeapBucket.inl
+++ b/lib/Common/Memory/HeapBucket.inl
@@ -7,7 +7,7 @@
 template <typename TBlockType>
 template <ObjectInfoBits attributes, bool nothrow>
 __inline char *
-HeapBucketT<TBlockType>::RealAlloc(Recycler * recycler, size_t sizeCat)
+HeapBucketT<TBlockType>::RealAlloc(Recycler * recycler, size_t sizeCat, size_t size)
 {
     Assert(sizeCat == this->sizeCat);
 
@@ -15,7 +15,7 @@ HeapBucketT<TBlockType>::RealAlloc(Recycler * recycler, size_t sizeCat)
 
     if (memBlock == nullptr)
     {
-        memBlock = SnailAlloc(recycler, &allocatorHead, sizeCat, attributes, nothrow);
+        memBlock = SnailAlloc(recycler, &allocatorHead, sizeCat, size, attributes, nothrow);
         Assert(memBlock != nullptr || nothrow);
     }
 
@@ -38,9 +38,17 @@ HeapBucketT<TBlockType>::RealAlloc(Recycler * recycler, size_t sizeCat)
 #endif
         )
     {
-        // Skip the first and the last pointer objects- the first may have next pointer for the free list
-        // the last might have the old size of the object if this was allocated from an explicit free list
-        recycler->VerifyZeroFill(memBlock + sizeof(FreeObject), sizeCat - (2 * sizeof(FreeObject)));
+        if (this->IsPageHeapEnabled(attributes))
+        {
+            // in page heap there's no free list, and using size instead of sizeCat
+            recycler->VerifyZeroFill(memBlock, size);
+        }
+        else
+        {
+            // Skip the first and the last pointer objects- the first may have next pointer for the free list
+            // the last might have the old size of the object if this was allocated from an explicit free list
+            recycler->VerifyZeroFill(memBlock + sizeof(FreeObject), sizeCat - (2 * sizeof(FreeObject)));
+        }
     }
 #endif
 

--- a/lib/Common/Memory/HeapInfo.cpp
+++ b/lib/Common/Memory/HeapInfo.cpp
@@ -12,7 +12,7 @@
 #error "Platform is not handled"
 #endif
 
-template __forceinline char* HeapInfo::RealAlloc<NoBit, false>(Recycler * recycler, size_t sizeCat);
+template __forceinline char* HeapInfo::RealAlloc<NoBit, false>(Recycler * recycler, size_t sizeCat, size_t size);
 
 HeapInfo::ValidPointersMap<SmallAllocationBlockAttributes>  HeapInfo::smallAllocValidPointersMap;
 HeapInfo::ValidPointersMap<MediumAllocationBlockAttributes> HeapInfo::mediumAllocValidPointersMap;

--- a/lib/Common/Memory/HeapInfo.cpp
+++ b/lib/Common/Memory/HeapInfo.cpp
@@ -638,8 +638,7 @@ bool HeapInfo::IsPageHeapEnabledForBlock(const size_t objectSize)
         }
         else
         {
-            // Page heap is enabled for large heap by default if page heap mode is on
-            return true;
+            return ((byte)this->pageHeapBlockType & (byte)PageHeapBlockTypeFilter::PageHeapBlockTypeFilterLarge) != 0;
         }
     }
     return false;

--- a/lib/Common/Memory/HeapInfo.h
+++ b/lib/Common/Memory/HeapInfo.h
@@ -171,8 +171,7 @@ private:
     template <ObjectInfoBits attributes>
     typename SmallHeapBlockType<attributes, SmallAllocationBlockAttributes>::BucketType& GetBucket(size_t sizeCat);
 
-    template<bool pageheap>
-    void Sweep(RecyclerSweep& recyclerSweep, bool concurrent);
+    void SweepBuckets(RecyclerSweep& recyclerSweep, bool concurrent);
 
 #ifdef BUCKETIZE_MEDIUM_ALLOCATIONS
 #if SMALLBLOCK_MEDIUM_ALLOC
@@ -268,7 +267,6 @@ private:
     }
 #endif
  
-    template<bool pageheap>
     void SweepSmallNonFinalizable(RecyclerSweep& recyclerSweep);
     void SweepLargeNonFinalizable(RecyclerSweep& recyclerSweep);
 

--- a/lib/Common/Memory/HeapInfo.h
+++ b/lib/Common/Memory/HeapInfo.h
@@ -34,6 +34,11 @@ public:
     void EnumerateObjects(ObjectInfoBits infoBits, void(*CallBackFunction)(void * address, size_t size));
 #ifdef RECYCLER_PAGE_HEAP
     bool IsPageHeapEnabled() const{ return isPageHeapEnabled; }
+    static size_t RoundObjectSize(size_t objectSize) 
+    {
+        // triming off the tail part which is not a pointer
+        return objectSize - (objectSize % sizeof(void*)); 
+    }
 
     template <typename TBlockAttributes>
     bool IsPageHeapEnabledForBlock(const size_t objectSize);

--- a/lib/Common/Memory/LargeHeapBlock.cpp
+++ b/lib/Common/Memory/LargeHeapBlock.cpp
@@ -927,7 +927,21 @@ LargeHeapBlock::ScanInitialImplicitRoots(Recycler * recycler)
 
         // TODO: Assume scan interior?
         DUMP_IMPLICIT_ROOT(recycler, objectAddress);
-        recycler->ScanObjectInlineInterior((void **)objectAddress, header->objectSize);
+
+        if (this->InPageHeapMode())
+        {
+            size_t objectSize = header->objectSize;
+            // trim off the trailing part which is not a pointer
+            objectSize = objectSize - (objectSize % sizeof(void*));
+            if (objectSize > 0) // otherwize the object total size is less than a pointer size
+            {
+                recycler->ScanObjectInlineInterior((void **)objectAddress, objectSize);
+            }
+        }
+        else
+        {
+            recycler->ScanObjectInlineInterior((void **)objectAddress, header->objectSize);
+        }
     }
 }
 
@@ -970,8 +984,21 @@ LargeHeapBlock::ScanNewImplicitRoots(Recycler * recycler)
                 continue;
             }
 
-            // TODO: Assume scan interior
-            recycler->ScanObjectInlineInterior((void **)objectAddress, header->objectSize);
+            if (this->InPageHeapMode())
+            {
+                size_t objectSize = header->objectSize;
+                // trim off the trailing part which is not a pointer
+                objectSize = objectSize - (objectSize % sizeof(void*));
+                if (objectSize > 0) // otherwize the object total size is less than a pointer size
+                {
+                    recycler->ScanObjectInlineInterior((void **)objectAddress, objectSize);
+                }
+            }
+            else
+            {
+                // TODO: Assume scan interior
+                recycler->ScanObjectInlineInterior((void **)objectAddress, header->objectSize);
+            }
         }
     }
 }

--- a/lib/Common/Memory/LargeHeapBlock.h
+++ b/lib/Common/Memory/LargeHeapBlock.h
@@ -29,11 +29,11 @@ private:
 #endif
 
 public:
-    bool markOnOOMRescan;
+    bool markOnOOMRescan:1;
+    bool isExplicitFreed:1;
+    bool isPageHeapAlloc:1;
 #if DBG
-    bool isExplicitFreed;
-#else
-    unsigned char unused3;
+    bool isPageHeapFillVerified:1;
 #endif
 
     UINT_PAD_64BIT(unused4);
@@ -123,17 +123,17 @@ public:
     void PartialTransferSweptObjects();
     void FinishPartialCollect(Recycler * recycler);
 #endif
-    template<bool pageheap>
+#ifdef RECYCLER_PAGE_HEAP
+    void VerifyPageHeapPattern();
+#endif
     void ReleasePages(Recycler * recycler);
-    template<bool pageheap>
     void ReleasePagesSweep(Recycler * recycler);
     void ReleasePagesShutdown(Recycler * recycler);
     void ResetMarks(ResetMarkFlags flags, Recycler* recycler);
     void ScanInitialImplicitRoots(Recycler * recycler);
     void ScanNewImplicitRoots(Recycler * recycler);
-    template<bool pageheap>
     SweepState Sweep(RecyclerSweep& recyclerSweep, bool queuePendingSweep);
-    template <bool pageheap, SweepMode mode>
+    template <SweepMode mode>
     void SweepObjects(Recycler * recycler);
     bool TransferSweptObjects();
     void DisposeObjects(Recycler * recycler);
@@ -142,9 +142,6 @@ public:
 
     char* GetBeginAddress() const { return address; }
     char* GetEndAddress() const { return addressEnd; }
-#ifdef RECYCLER_PAGE_HEAP
-    void SetEndAllocAddress(__in char* endAllocAddress) { allocAddressEnd = endAllocAddress; }
-#endif
 
     char * Alloc(size_t size, ObjectInfoBits attributes);
     char * TryAllocFromFreeList(size_t size, ObjectInfoBits attributes);
@@ -257,6 +254,18 @@ private:
     uint finalizeCount;
 
     bool isInPendingDisposeList;
+
+#ifdef RECYCLER_PAGE_HEAP
+    PageHeapMode pageHeapMode;
+    char* guardPageAddress;
+    StackBackTrace* pageHeapAllocStack;
+    StackBackTrace* pageHeapFreeStack;
+
+public:
+    __inline bool InPageHeapMode() const { return pageHeapMode != PageHeapMode::PageHeapModeOff; }
+    void CapturePageHeapAllocStack();
+    void CapturePageHeapFreeStack();
+#endif
 
 #if DBG
     bool hasDisposeBeenCalled;

--- a/lib/Common/Memory/LargeHeapBlock.h
+++ b/lib/Common/Memory/LargeHeapBlock.h
@@ -30,9 +30,8 @@ private:
 
 public:
     bool markOnOOMRescan:1;
-    bool isExplicitFreed:1;
-    bool isPageHeapAlloc:1;
 #if DBG
+    bool isExplicitFreed:1;
     bool isPageHeapFillVerified:1;
 #endif
 
@@ -53,7 +52,11 @@ public:
     void SetAttributes(uint cookie, unsigned char attributes);
     unsigned char GetAttributes(uint cookie);
 };
-
+#if defined(_M_X64_OR_ARM64)
+static_assert(sizeof(LargeObjectHeader) == 0x20, "Incorrect LargeObjectHeader size");
+#else
+static_assert(sizeof(LargeObjectHeader) == 0x10, "Incorrect LargeObjectHeader size");
+#endif
 class LargeHeapBlock;
 class LargeHeapBucket;
 
@@ -265,6 +268,7 @@ public:
     __inline bool InPageHeapMode() const { return pageHeapMode != PageHeapMode::PageHeapModeOff; }
     void CapturePageHeapAllocStack();
     void CapturePageHeapFreeStack();
+    const StackBackTrace* s_StackTraceAllocFailed = (StackBackTrace*)1;
 #endif
 
 #if DBG

--- a/lib/Common/Memory/LargeHeapBucket.cpp
+++ b/lib/Common/Memory/LargeHeapBucket.cpp
@@ -40,7 +40,7 @@ LargeHeapBucket::TryAllocFromNewHeapBlock(Recycler * recycler, size_t sizeCat, O
     Assert((attributes & InternalObjectInfoBitMask) == attributes);
 
 #ifdef RECYCLER_PAGE_HEAP
-    if (IsPageHeapEnabled())
+    if (IsPageHeapEnabled(attributes))
     {
         return this->PageHeapAlloc(recycler, sizeCat, attributes, this->heapInfo->pageHeapMode, true);
     }
@@ -113,7 +113,7 @@ LargeHeapBucket::PageHeapAlloc(Recycler * recycler, size_t size, ObjectInfoBits 
     size_t sizeCat = HeapInfo::GetAlignedSizeNoCheck(size);
 
     Segment * segment;
-    size_t pageCount = LargeHeapBlock::GetPagesNeeded(size, this->supportFreeList);
+    size_t pageCount = LargeHeapBlock::GetPagesNeeded(size, false);
     if (pageCount == 0)
     {
         if (nothrow == false)
@@ -126,9 +126,9 @@ LargeHeapBucket::PageHeapAlloc(Recycler * recycler, size_t size, ObjectInfoBits 
         return nullptr;
     }
 
-    size_t actualPageCount = pageCount + 1; // for page heap
-
-    char * baseAddress = recycler->GetRecyclerLargeBlockPageAllocator()->Alloc(&actualPageCount, &segment);
+    size_t actualPageCount = pageCount + 1; // 1 for guard page
+    auto pageAllocator = recycler->GetRecyclerLargeBlockPageAllocator();
+    char * baseAddress = pageAllocator->Alloc(&actualPageCount, &segment);
     if (baseAddress == nullptr)
     {
         return nullptr;
@@ -136,7 +136,6 @@ LargeHeapBucket::PageHeapAlloc(Recycler * recycler, size_t size, ObjectInfoBits 
 
     char* address = nullptr;
     char* guardPageAddress = nullptr;
-    DWORD guardPageOldProtectFlags = PAGE_NOACCESS;
 
     if (heapInfo->pageHeapMode == PageHeapMode::PageHeapModeBlockStart)
     {
@@ -153,71 +152,46 @@ LargeHeapBucket::PageHeapAlloc(Recycler * recycler, size_t size, ObjectInfoBits 
         AnalysisAssert(false);
     }
 
-    if (::VirtualProtect(static_cast<LPVOID>(guardPageAddress), AutoSystemInfo::PageSize, PAGE_NOACCESS, &guardPageOldProtectFlags) == FALSE)
-    {
-        AssertMsg(false, "Unable to set permission for guard page.");
-        return nullptr;
-    }
-
-#ifdef RECYCLER_ZERO_MEM_CHECK
-    recycler->VerifyZeroFill(address, pageCount * AutoSystemInfo::PageSize);
-#endif
-
     LargeHeapBlock * heapBlock = LargeHeapBlock::New(address, pageCount, segment, 1, nullptr);
     if (!heapBlock)
     {
-        recycler->GetRecyclerLargeBlockPageAllocator()->SuspendIdleDecommit();
-        recycler->GetRecyclerLargeBlockPageAllocator()->Release(address, actualPageCount, segment);
-        recycler->GetRecyclerLargeBlockPageAllocator()->ResumeIdleDecommit();
+        pageAllocator->SuspendIdleDecommit();
+        pageAllocator->Release(baseAddress, actualPageCount, segment);
+        pageAllocator->ResumeIdleDecommit();
         return nullptr;
     }
-    heapBlock->actualPageCount = actualPageCount;
-    heapBlock->guardPageAddress = guardPageAddress;
-    heapBlock->guardPageOldProtectFlags = guardPageOldProtectFlags;
-    heapBlock->pageHeapMode = heapInfo->pageHeapMode;
-
-    if (heapBlock->pageHeapMode == PageHeapMode::PageHeapModeBlockEnd)
-    {
-        // TODO: pad the address to close-most to the guard page to increase the chance to hit guard page when overflow
-        // some Mark code need to be updated to support this
-        // heapBlock->SetEndAllocAddress(address
-        //    + AutoSystemInfo::PageSize - (((AllocSizeMath::Add(sizeCat, sizeof(LargeObjectHeader)) - 1) % AutoSystemInfo::PageSize) / HeapInfo::ObjectGranularity + 1) * HeapInfo::ObjectGranularity);
-    }
-
-#if DBG
-    LargeAllocationVerboseTrace(recycler->GetRecyclerFlagsTable(), _u("Allocated new large heap block 0x%p for sizeCat 0x%x\n"), heapBlock, sizeCat);
-#endif
-
-#ifdef ENABLE_JS_ETW
-#if ENABLE_DEBUG_CONFIG_OPTIONS
-    if (segment->GetPageCount() > recycler->GetRecyclerLargeBlockPageAllocator()->GetMaxAllocPageCount())
-    {
-        EventWriteJSCRIPT_INTERNAL_RECYCLER_EXTRALARGE_OBJECT_ALLOC(size);
-    }
-#endif
-#endif
-
-#if ENABLE_PARTIAL_GC
-    recycler->autoHeap.uncollectedNewPageCount += pageCount;
-#endif
-
-    RECYCLER_SLOW_CHECK(this->heapInfo->heapBlockCount[HeapBlock::HeapBlockType::LargeBlockType]++);
 
     heapBlock->heapInfo = this->heapInfo;
-
-    Assert(recycler->collectionState != CollectionStateMark);
+    heapBlock->actualPageCount = actualPageCount;
+    heapBlock->guardPageAddress = guardPageAddress;
+    heapBlock->pageHeapMode = heapInfo->pageHeapMode;
 
     if (!recycler->heapBlockMap.SetHeapBlock(address, pageCount, heapBlock, HeapBlock::HeapBlockType::LargeBlockType, 0))
     {
-        recycler->GetRecyclerLargeBlockPageAllocator()->SuspendIdleDecommit();
-        heapBlock->ReleasePages<true>(recycler);
-        recycler->GetRecyclerLargeBlockPageAllocator()->ResumeIdleDecommit();
+        pageAllocator->SuspendIdleDecommit();
+        heapBlock->ReleasePages(recycler);
+        pageAllocator->ResumeIdleDecommit();
         LargeHeapBlock::Delete(heapBlock);
-        RECYCLER_SLOW_CHECK(this->heapInfo->heapBlockCount[HeapBlock::HeapBlockType::LargeBlockType]--);
         return nullptr;
     }
 
     heapBlock->ResetMarks(ResetMarkFlags_None, recycler);
+
+    char * memBlock = heapBlock->Alloc(sizeCat, attributes);
+    Assert(memBlock != nullptr);
+
+    // fill pattern
+    memset(heapBlock->allocAddressEnd, 0xF0, heapBlock->addressEnd - heapBlock->allocAddressEnd);
+    LargeObjectHeader* header = (LargeObjectHeader*)address;
+    header->isPageHeapAlloc = true;
+
+#pragma prefast(suppress:6250, "This method decommits memory")
+    if (::VirtualFree(guardPageAddress, AutoSystemInfo::PageSize, MEM_DECOMMIT) == FALSE)
+    {
+        AssertMsg(false, "Unable to decommit guard page.");
+        ReportFatalException(NULL, E_FAIL, Fatal_Internal_Error, 2);
+        return nullptr;
+    }
 
     if (this->largePageHeapBlockList)
     {
@@ -228,10 +202,14 @@ LargeHeapBucket::PageHeapAlloc(Recycler * recycler, size_t size, ObjectInfoBits 
         this->largePageHeapBlockList = heapBlock;
     }
 
+#if ENABLE_PARTIAL_GC
+    recycler->autoHeap.uncollectedNewPageCount += pageCount;
+#endif
+
+    RECYCLER_SLOW_CHECK(this->heapInfo->heapBlockCount[HeapBlock::HeapBlockType::LargeBlockType]++);
     RECYCLER_PERF_COUNTER_ADD(FreeObjectSize, heapBlock->GetPageCount() * AutoSystemInfo::PageSize);
 
-    char * memBlock = heapBlock->Alloc(sizeCat, attributes);
-    Assert(memBlock != nullptr);
+
     if (recycler->ShouldCapturePageHeapAllocStack())
     {
         heapBlock->CapturePageHeapAllocStack();
@@ -306,7 +284,7 @@ LargeHeapBucket::AddLargeHeapBlock(size_t size, bool nothrow)
     if (!recycler->heapBlockMap.SetHeapBlock(address, pageCount, heapBlock, HeapBlock::HeapBlockType::LargeBlockType, 0))
     {
         recycler->GetRecyclerLargeBlockPageAllocator()->SuspendIdleDecommit();
-        heapBlock->ReleasePages<false>(recycler);
+        heapBlock->ReleasePages(recycler);
         recycler->GetRecyclerLargeBlockPageAllocator()->ResumeIdleDecommit();
         LargeHeapBlock::Delete(heapBlock);
         RECYCLER_SLOW_CHECK(this->heapInfo->heapBlockCount[HeapBlock::HeapBlockType::LargeBlockType]--);
@@ -531,10 +509,7 @@ LargeHeapBucket::ScanNewImplicitRoots(Recycler * recycler)
 // Sweep
 //=====================================================================================================
 #pragma region Sweep
-template void LargeHeapBucket::Sweep<true>(RecyclerSweep& recyclerSweep);
-template void LargeHeapBucket::Sweep<false>(RecyclerSweep& recyclerSweep);
 
-template<bool pageheap>
 void
 LargeHeapBucket::Sweep(RecyclerSweep& recyclerSweep)
 {
@@ -569,15 +544,14 @@ LargeHeapBucket::Sweep(RecyclerSweep& recyclerSweep)
 #if ENABLE_CONCURRENT_GC
     Assert(this->pendingSweepLargeBlockList == nullptr);
 #endif
-    SweepLargeHeapBlockList<pageheap>(recyclerSweep, currentLargeObjectBlocks);
+    SweepLargeHeapBlockList(recyclerSweep, currentLargeObjectBlocks);
 #ifdef RECYCLER_PAGE_HEAP
-    SweepLargeHeapBlockList<pageheap>(recyclerSweep, currentLargePageHeapObjectBlocks);
+    SweepLargeHeapBlockList(recyclerSweep, currentLargePageHeapObjectBlocks);
 #endif
-    SweepLargeHeapBlockList<pageheap>(recyclerSweep, currentFullLargeObjectBlocks);
-    SweepLargeHeapBlockList<pageheap>(recyclerSweep, currentDisposeLargeBlockList);
+    SweepLargeHeapBlockList(recyclerSweep, currentFullLargeObjectBlocks);
+    SweepLargeHeapBlockList(recyclerSweep, currentDisposeLargeBlockList);
 }
 
-template<bool pageheap>
 void
 LargeHeapBucket::SweepLargeHeapBlockList(RecyclerSweep& recyclerSweep, LargeHeapBlock * heapBlockList)
 {
@@ -587,7 +561,7 @@ LargeHeapBucket::SweepLargeHeapBlockList(RecyclerSweep& recyclerSweep, LargeHeap
         this->UnregisterFreeList(heapBlock->GetFreeList());
 
         // CONCURRENT-TODO: Allow large block to be sweep in the background
-        SweepState state = heapBlock->Sweep<pageheap>(recyclerSweep, false);
+        SweepState state = heapBlock->Sweep(recyclerSweep, false);
 
         // If the block is already in the pending dispose list (re-entrant GC scenario), do nothing, leave it there
         if (heapBlock->IsInPendingDisposeList()) return;
@@ -595,7 +569,7 @@ LargeHeapBucket::SweepLargeHeapBlockList(RecyclerSweep& recyclerSweep, LargeHeap
         switch (state)
         {
         case SweepStateEmpty:
-            heapBlock->ReleasePagesSweep<pageheap>(recycler);
+            heapBlock->ReleasePagesSweep(recycler);
             LargeHeapBlock::Delete(heapBlock);
             RECYCLER_SLOW_CHECK(this->heapInfo->heapBlockCount[HeapBlock::HeapBlockType::LargeBlockType]--);
             break;
@@ -775,7 +749,7 @@ LargeHeapBucket::SweepPendingObjects(RecyclerSweep& recyclerSweep)
             HeapBlockList::ForEach(this->pendingSweepLargeBlockList, [recycler](LargeHeapBlock * heapBlock)
             {
                 // Page heap blocks are never swept concurrently
-                heapBlock->SweepObjects<false, SweepMode_ConcurrentPartial>(recycler);
+                heapBlock->SweepObjects<SweepMode_ConcurrentPartial>(recycler);
             });
         }
         else
@@ -784,7 +758,7 @@ LargeHeapBucket::SweepPendingObjects(RecyclerSweep& recyclerSweep)
             HeapBlockList::ForEach(this->pendingSweepLargeBlockList, [recycler](LargeHeapBlock * heapBlock)
             {
                 // Page heap blocks are never swept concurrently
-                heapBlock->SweepObjects<false, SweepMode_Concurrent>(recycler);
+                heapBlock->SweepObjects<SweepMode_Concurrent>(recycler);
             });
         }
     }

--- a/lib/Common/Memory/LargeHeapBucket.h
+++ b/lib/Common/Memory/LargeHeapBucket.h
@@ -51,7 +51,6 @@ public:
     void ScanInitialImplicitRoots(Recycler * recycler);
     void ScanNewImplicitRoots(Recycler * recycler);
 
-    template<bool pageheap>
     void Sweep(RecyclerSweep& recyclerSweep);
     void ReinsertLargeHeapBlock(LargeHeapBlock * heapBlock);
 
@@ -103,7 +102,6 @@ private:
     template <class Fn> void ForEachLargeHeapBlock(Fn fn);
     template <class Fn> void ForEachEditingLargeHeapBlock(Fn fn);
     void Finalize(Recycler* recycler, LargeHeapBlock* heapBlock);
-    template<bool pageheap>
     void SweepLargeHeapBlockList(RecyclerSweep& recyclerSweep, LargeHeapBlock * heapBlockList);
 
     void ConstructFreelist(LargeHeapBlock * heapBlock);

--- a/lib/Common/Memory/LargeHeapBucket.h
+++ b/lib/Common/Memory/LargeHeapBucket.h
@@ -43,7 +43,7 @@ public:
     template <ObjectInfoBits attributes, bool nothrow>
     char* Alloc(Recycler * recycler, size_t sizeCat);
 #ifdef RECYCLER_PAGE_HEAP
-    char *PageHeapAlloc(Recycler * recycler, size_t sizeCat, ObjectInfoBits attributes, PageHeapMode mode, bool nothrow);
+    char *PageHeapAlloc(Recycler * recycler, size_t sizeCat, size_t size, ObjectInfoBits attributes, PageHeapMode mode, bool nothrow);
 #endif
     void ExplicitFree(void * object, size_t sizeCat);
 
@@ -93,9 +93,9 @@ public:
 #endif
 
 private:
-    char * SnailAlloc(Recycler * recycler, size_t sizeCat, ObjectInfoBits attributes, bool nothrow);
+    char * SnailAlloc(Recycler * recycler, size_t sizeCat, size_t size, ObjectInfoBits attributes, bool nothrow);
     char * TryAlloc(Recycler * recycler, size_t sizeCat, ObjectInfoBits attributes);
-    char * TryAllocFromNewHeapBlock(Recycler * recycler, size_t sizeCat, ObjectInfoBits attributes, bool nothrow);
+    char * TryAllocFromNewHeapBlock(Recycler * recycler, size_t sizeCat, size_t size, ObjectInfoBits attributes, bool nothrow);
     char * TryAllocFromFreeList(Recycler * recycler, size_t sizeCat, ObjectInfoBits attributes);
     char * TryAllocFromExplicitFreeList(Recycler * recycler, size_t sizeCat, ObjectInfoBits attributes);
 

--- a/lib/Common/Memory/LargeHeapBucket.inl
+++ b/lib/Common/Memory/LargeHeapBucket.inl
@@ -58,7 +58,7 @@ LargeHeapBucket::Alloc(Recycler * recycler, size_t sizeCat)
     else
     {
 #ifdef RECYCLER_PAGE_HEAP
-        Assert(!IsPageHeapEnabled());
+        Assert(!IsPageHeapEnabled(attributes));
 #endif
     }
 

--- a/lib/Common/Memory/PageAllocator.cpp
+++ b/lib/Common/Memory/PageAllocator.cpp
@@ -222,25 +222,8 @@ PageSegmentBase<T>::Prime()
 
 template<typename T>
 bool
-PageSegmentBase<T>::IsAllocationPageAligned(__in char* address, size_t pageCount, PageHeapMode pageHeapFlags)
+PageSegmentBase<T>::IsAllocationPageAligned(__in char* address, size_t pageCount)
 {
-#ifdef RECYCLER_PAGE_HEAP
-    if (pageHeapFlags != PageHeapMode::PageHeapModeOff)
-    {
-        // In PageHeap mode, we should ensure that if the guard page
-        // is in the front, the page after the guard page is aligned
-        if ((pageHeapFlags == PageHeapMode::PageHeapModeBlockStart))
-        {
-            address += AutoSystemInfo::PageSize;
-        }
-
-        // We don't care about whether the guard pages themselves are aligned
-        // or fit in the chunk, so don't count the guard page for the purposes
-        // of alignment
-        pageCount--;
-    }
-#endif
-
     // Require that allocations are aligned at a boundary
     // corresponding to the page count
     // REVIEW: This might actually lead to additional address space fragmentation
@@ -260,7 +243,7 @@ PageSegmentBase<T>::IsAllocationPageAligned(__in char* address, size_t pageCount
 template<typename T>
 template <bool notPageAligned>
 char *
-PageSegmentBase<T>::AllocPages(uint pageCount, PageHeapMode pageHeapFlags)
+PageSegmentBase<T>::AllocPages(uint pageCount)
 {
     Assert(freePageCount != 0);
     Assert(freePageCount == (uint)this->GetCountOfFreePages());
@@ -287,7 +270,7 @@ PageSegmentBase<T>::AllocPages(uint pageCount, PageHeapMode pageHeapFlags)
 
             if (pageCount > 1 && !notPageAligned)
             {
-                if (!IsAllocationPageAligned(allocAddress, pageCount, pageHeapFlags))
+                if (!IsAllocationPageAligned(allocAddress, pageCount))
                 {
                     index = this->freePages.GetNextBit(index + 1);
                     continue;
@@ -316,7 +299,7 @@ PageSegmentBase<T>::AllocPages(uint pageCount, PageHeapMode pageHeapFlags)
 template<typename TVirtualAlloc>
 template<typename T, bool notPageAligned>
 char *
-PageSegmentBase<TVirtualAlloc>::AllocDecommitPages(uint pageCount, T freePages, T decommitPages, PageHeapMode pageHeapFlags)
+PageSegmentBase<TVirtualAlloc>::AllocDecommitPages(uint pageCount, T freePages, T decommitPages)
 {
     Assert(freePageCount == (uint)this->GetCountOfFreePages());
     Assert(decommitPageCount ==  (uint)this->GetCountOfDecommitPages());
@@ -347,7 +330,7 @@ PageSegmentBase<TVirtualAlloc>::AllocDecommitPages(uint pageCount, T freePages, 
 
             if (!notPageAligned)
             {
-                if (!IsAllocationPageAligned(pages, pageCount, pageHeapFlags))
+                if (!IsAllocationPageAligned(pages, pageCount))
                 {
                     index = freeAndDecommitPages.GetNextBit(index + 1);
                     continue;
@@ -476,6 +459,25 @@ PageSegmentBase<T>::DecommitPages(__in void * address, uint pageCount)
     }
 
     Assert(decommitPageCount == (uint)this->GetCountOfDecommitPages());
+}
+
+template<typename T>
+void
+PageSegmentBase<T>::PartialDecommitPages(__in void * address, size_t totalPageCount, __in void* addressToDecommit, size_t pageCountToDecommit)
+{
+
+    Assert(address >= this->address);
+    Assert(totalPageCount <= allocator->maxAllocPageCount);
+    Assert(((uint)(((char *)address) - this->address)) <= (allocator->maxAllocPageCount - totalPageCount) * AutoSystemInfo::PageSize);
+
+    Assert(!IsFreeOrDecommitted(address, (uint)totalPageCount));
+    uint base = this->GetBitRangeBase(address);
+
+    this->SetRangeInDecommitPagesBitVector(base, (uint)totalPageCount);
+    this->decommitPageCount += (uint)totalPageCount;
+    GetAllocator()->GetVirtualAllocator()->Free(addressToDecommit, pageCountToDecommit * AutoSystemInfo::PageSize, MEM_DECOMMIT);
+
+    Assert(this->decommitPageCount == (uint)this->GetCountOfDecommitPages());
 }
 
 template<typename T>
@@ -825,7 +827,7 @@ PageAllocatorBase<T>::TryAllocFromZeroPagesList(uint pageCount, PageSegmentBase<
 
 template<typename T>
 char *
-PageAllocatorBase<T>::TryAllocFromZeroPages(uint pageCount, PageSegmentBase<T> ** pageSegment, PageHeapMode pageHeapFlags)
+PageAllocatorBase<T>::TryAllocFromZeroPages(uint pageCount, PageSegmentBase<T> ** pageSegment)
 {
     if (backgroundPageQueue != nullptr) 
     {
@@ -844,7 +846,7 @@ PageAllocatorBase<T>::TryAllocFromZeroPages(uint pageCount, PageSegmentBase<T> *
 template<typename T>
 template <bool notPageAligned>
 char *
-PageAllocatorBase<T>::TryAllocFreePages(uint pageCount, PageSegmentBase<T> ** pageSegment, PageHeapMode pageHeapFlags)
+PageAllocatorBase<T>::TryAllocFreePages(uint pageCount, PageSegmentBase<T> ** pageSegment)
 {
     Assert(!HasMultiThreadAccess());
     char* pages = nullptr;
@@ -858,7 +860,7 @@ PageAllocatorBase<T>::TryAllocFreePages(uint pageCount, PageSegmentBase<T> ** pa
         {
             PageSegmentBase<T> * freeSegment = &i.Data();
 
-            pages = freeSegment->AllocPages<notPageAligned>(pageCount, pageHeapFlags);
+            pages = freeSegment->AllocPages<notPageAligned>(pageCount);
             if (pages != nullptr)
             {
                 LogAllocPages(pageCount);
@@ -879,7 +881,7 @@ PageAllocatorBase<T>::TryAllocFreePages(uint pageCount, PageSegmentBase<T> ** pa
         }
     }
 
-    pages = TryAllocFromZeroPages(pageCount, pageSegment, pageHeapFlags);
+    pages = TryAllocFromZeroPages(pageCount, pageSegment);
 
     return pages;
 }
@@ -940,7 +942,7 @@ PageAllocatorBase<T>::FillFreePages(__in void * address, uint pageCount)
 template<typename T>
 template <bool notPageAligned>
 char *
-PageAllocatorBase<T>::TryAllocDecommittedPages(uint pageCount, PageSegmentBase<T> ** pageSegment, PageHeapMode pageHeapFlags)
+PageAllocatorBase<T>::TryAllocDecommittedPages(uint pageCount, PageSegmentBase<T> ** pageSegment)
 {
     Assert(!HasMultiThreadAccess());
 
@@ -951,7 +953,7 @@ PageAllocatorBase<T>::TryAllocDecommittedPages(uint pageCount, PageSegmentBase<T
         PageSegmentBase<T> * freeSegment = &i.Data();
         uint oldFreePageCount = freeSegment->GetFreePageCount();
         uint oldDecommitPageCount = freeSegment->GetDecommitPageCount();
-        char * pages = freeSegment->DoAllocDecommitPages<notPageAligned>(pageCount, pageHeapFlags);
+        char * pages = freeSegment->DoAllocDecommitPages<notPageAligned>(pageCount);
         if (pages != nullptr)
         {
             this->freePageCount = this->freePageCount - oldFreePageCount + freeSegment->GetFreePageCount();
@@ -1091,7 +1093,7 @@ PageAllocatorBase<T>::AllocInternal(size_t * pageCount, SegmentBase<T> ** segmen
         if (doPageAlign)
         {
             // TODO: Remove this entire codepath since doPageAlign is not being used anymore
-            addr = this->AllocPagesPageAligned((uint)*pageCount, &pageSegment, PageHeapMode::PageHeapModeOff);
+            addr = this->AllocPagesPageAligned((uint)*pageCount, &pageSegment);
         }
         else
         {
@@ -1149,15 +1151,15 @@ PageAllocatorBase<PreReservedVirtualAllocWrapper>::AllocPages(uint pageCount, Pa
 
 template<typename T>
 char *
-PageAllocatorBase<T>::AllocPagesPageAligned(uint pageCount, PageSegmentBase<T> ** pageSegment, PageHeapMode pageHeapFlags)
+PageAllocatorBase<T>::AllocPagesPageAligned(uint pageCount, PageSegmentBase<T> ** pageSegment)
 {
-    return AllocPagesInternal<false /* noPageAligned */>(pageCount, pageSegment, pageHeapFlags);
+    return AllocPagesInternal<false /* noPageAligned */>(pageCount, pageSegment);
 }
 
 template<typename T>
 template <bool notPageAligned>
 char *
-PageAllocatorBase<T>::AllocPagesInternal(uint pageCount, PageSegmentBase<T> ** pageSegment, PageHeapMode pageHeapModeFlags)
+PageAllocatorBase<T>::AllocPagesInternal(uint pageCount, PageSegmentBase<T> ** pageSegment)
 {
     Assert(!isClosed);
     ASSERT_THREAD();
@@ -1166,14 +1168,19 @@ PageAllocatorBase<T>::AllocPagesInternal(uint pageCount, PageSegmentBase<T> ** p
     this->isUsed = true;
 
     SuspendIdleDecommit();
-    char * allocation = TryAllocFreePages<notPageAligned>(pageCount, pageSegment, pageHeapModeFlags);
+    char * allocation = TryAllocFreePages<notPageAligned>(pageCount, pageSegment);
     if (allocation == nullptr)
     {
-        allocation = SnailAllocPages<notPageAligned>(pageCount, pageSegment, pageHeapModeFlags);
+        allocation = SnailAllocPages<notPageAligned>(pageCount, pageSegment);
     }
     ResumeIdleDecommit();
 
     PageTracking::ReportAllocation((PageAllocator*)this, allocation, AutoSystemInfo::PageSize * pageCount);
+
+    if (!notPageAligned) 
+    {
+        Assert(PageSegmentBase<T>::IsAllocationPageAligned(allocation, pageCount));
+    } 
 
     return allocation;
 }
@@ -1198,7 +1205,7 @@ PageAllocatorBase<T>::OnAllocFromNewSegment(uint pageCount, __in void* pages, Se
 template<typename T>
 template <bool notPageAligned>
 char *
-PageAllocatorBase<T>::SnailAllocPages(uint pageCount, PageSegmentBase<T> ** pageSegment, PageHeapMode pageHeapFlags)
+PageAllocatorBase<T>::SnailAllocPages(uint pageCount, PageSegmentBase<T> ** pageSegment)
 {
     Assert(!HasMultiThreadAccess());
 
@@ -1209,14 +1216,14 @@ PageAllocatorBase<T>::SnailAllocPages(uint pageCount, PageSegmentBase<T> ** page
     {
         newSegment = &emptySegments.Head();
 
-        if (!notPageAligned && !PageSegmentBase<T>::IsAllocationPageAligned(newSegment->GetAddress(), pageCount, pageHeapFlags))
+        if (!notPageAligned && !PageSegmentBase<T>::IsAllocationPageAligned(newSegment->GetAddress(), pageCount))
         {
             newSegment = nullptr;
 
             // Scan through the empty segments for a segment that can fit this allocation
             FOREACH_DLISTBASE_ENTRY_EDITING(PageSegmentBase<T>, emptySegment, &this->emptySegments, iter)
             {
-                if (PageSegmentBase<T>::IsAllocationPageAligned(emptySegment.GetAddress(), pageCount, pageHeapFlags))
+                if (PageSegmentBase<T>::IsAllocationPageAligned(emptySegment.GetAddress(), pageCount))
                 {
                     iter.MoveCurrentTo(&this->emptySegments);
                     newSegment = &emptySegment;
@@ -1228,7 +1235,7 @@ PageAllocatorBase<T>::SnailAllocPages(uint pageCount, PageSegmentBase<T> ** page
 
         if (newSegment != nullptr)
         {
-            pages = newSegment->AllocPages<notPageAligned>(pageCount, pageHeapFlags);
+            pages = newSegment->AllocPages<notPageAligned>(pageCount);
             if (pages != nullptr)
             {
                 OnAllocFromNewSegment(pageCount, pages, newSegment);
@@ -1238,7 +1245,7 @@ PageAllocatorBase<T>::SnailAllocPages(uint pageCount, PageSegmentBase<T> ** page
         }
     }
 
-    pages = TryAllocDecommittedPages<notPageAligned>(pageCount, pageSegment, pageHeapFlags);
+    pages = TryAllocDecommittedPages<notPageAligned>(pageCount, pageSegment);
     if (pages != nullptr)
     {
         // TryAllocDecommittedPages may give out a mix of free pages and decommitted pages.
@@ -1260,7 +1267,7 @@ PageAllocatorBase<T>::SnailAllocPages(uint pageCount, PageSegmentBase<T> ** page
             return nullptr;
         }
 
-        pages = decommitSegment->DoAllocDecommitPages<notPageAligned>(pageCount, pageHeapFlags);
+        pages = decommitSegment->DoAllocDecommitPages<notPageAligned>(pageCount);
         if (pages != nullptr)
         {
 #if DBG_DUMP
@@ -1288,7 +1295,7 @@ PageAllocatorBase<T>::SnailAllocPages(uint pageCount, PageSegmentBase<T> ** page
         return nullptr;
     }
 
-    pages = newSegment->AllocPages<notPageAligned>(pageCount, pageHeapFlags);
+    pages = newSegment->AllocPages<notPageAligned>(pageCount);
     if (notPageAligned)
     {
         // REVIEW: Is this true for single-chunk allocations too? Are new segments guaranteed to
@@ -1383,6 +1390,37 @@ PageAllocatorBase<T>::AddFreePageCount(uint pageCount)
     // so that we don't have to update it on every page allocation.
     UpdateMinFreePageCount();
     this->freePageCount += pageCount;
+}
+
+template<typename T>
+void
+PageAllocatorBase<T>::PartialDecommitPages(__in void * address, size_t pageCountTotal, __in void* decommitAddress, size_t pageCountToDecommit, __in void * segmentParam)
+{
+    // TODO: use a specialized PageHeapPageAllocator to simplify the page allocating logic for pageheap
+    if (pageCountTotal > this->maxAllocPageCount) 
+    {
+        SegmentBase<T> * segment = (SegmentBase<T>*) segmentParam;
+        PageTracking::ReportFree((PageAllocator*)this, segment->GetAddress(), AutoSystemInfo::PageSize * segment->GetPageCount());
+        LogFreePages(segment->GetPageCount());
+        LogFreeSegment(segment);
+
+        // when deleteing segement, it call VirtualFree with MEM_RELEASE, so it should be OK
+        // even we have partial decommited pages in the segment
+        largeSegments.RemoveElement(&NoThrowNoMemProtectHeapAllocator::Instance, segment);
+    }
+    else 
+    {
+        PageSegmentBase<T> * pageSegment = (PageSegmentBase<T>*) segmentParam;
+        DListBase<PageSegmentBase<T>> * fromSegmentList = GetSegmentList(pageSegment);
+
+        pageSegment->PartialDecommitPages(address, pageCountTotal, decommitAddress, pageCountToDecommit);
+        LogFreePages(pageCountTotal);
+        LogDecommitPages(pageCountTotal);
+#if DBG_DUMP
+        this->decommitPageCount += pageCountTotal;
+#endif
+        TransferSegment(pageSegment, fromSegmentList);
+    }
 }
 
 template<typename T>
@@ -2610,9 +2648,9 @@ void PageSegmentBase<T>::SetBitInDecommitPagesBitVector(uint index)
 
 template<typename T>
 template <bool noPageAligned>
-char * PageSegmentBase<T>::DoAllocDecommitPages(uint pageCount, PageHeapMode pageHeapFlags)
+char * PageSegmentBase<T>::DoAllocDecommitPages(uint pageCount)
 {
-    return this->AllocDecommitPages<PageSegmentBase<T>::PageBitVector, noPageAligned>(pageCount, this->freePages, this->decommitPages, pageHeapFlags);
+    return this->AllocDecommitPages<PageSegmentBase<T>::PageBitVector, noPageAligned>(pageCount, this->freePages, this->decommitPages);
 }
 
 template<typename T>

--- a/lib/Common/Memory/PageAllocator.h
+++ b/lib/Common/Memory/PageAllocator.h
@@ -210,17 +210,18 @@ public:
     uint GetFreePageCount() const { return freePageCount; }
     uint GetDecommitPageCount() const { return decommitPageCount; }
 
-    static bool IsAllocationPageAligned(__in char* address, size_t pageCount, PageHeapMode pageHeapFlags);
+    static bool IsAllocationPageAligned(__in char* address, size_t pageCount);
 
     template <typename T, bool notPageAligned>
-    char * AllocDecommitPages(uint pageCount, T freePages, T decommitPages, PageHeapMode pageHeapFlags);
+    char * AllocDecommitPages(uint pageCount, T freePages, T decommitPages);
 
     template <bool notPageAligned>
-    char * AllocPages(uint pageCount, PageHeapMode pageHeapFlags);
+    char * AllocPages(uint pageCount);
 
     void ReleasePages(__in void * address, uint pageCount);
     template <bool onlyUpdateState>
     void DecommitPages(__in void * address, uint pageCount);
+    void PartialDecommitPages(__in void * address, size_t totalPageCount, __in void* addressToDecommit, size_t pageCountToDecommit);
 
     uint GetCountOfFreePages() const;
     uint GetNextBitInFreePagesBitVector(uint index) const;
@@ -239,7 +240,7 @@ public:
     void ClearRangeInDecommitPagesBitVector(uint index, uint pageCount);
 
     template <bool notPageAligned>
-    char * DoAllocDecommitPages(uint pageCount, PageHeapMode pageHeapFlags);
+    char * DoAllocDecommitPages(uint pageCount);
     uint GetMaxPageCount();
 
     size_t DecommitFreePages(size_t pageToDecommit);
@@ -425,8 +426,9 @@ public:
     void Release(void * address, size_t pageCount, void * segment);
 
     char * AllocPages(uint pageCount, PageSegmentBase<TVirtualAlloc> ** pageSegment);
-    char * AllocPagesPageAligned(uint pageCount, PageSegmentBase<TVirtualAlloc> ** pageSegment, PageHeapMode pageHeapFlags);
+    char * AllocPagesPageAligned(uint pageCount, PageSegmentBase<TVirtualAlloc> ** pageSegment);
 
+    void PartialDecommitPages(__in void * address, size_t pageCountTotal, __in void* decommitAddress, size_t pageCountToDecommit,  __in void * pageSegment);
     void ReleasePages(__in void * address, uint pageCount, __in void * pageSegment);
     void BackgroundReleasePages(void * address, uint pageCount, PageSegmentBase<TVirtualAlloc> * pageSegment);
 
@@ -486,16 +488,16 @@ protected:
     char * AllocInternal(size_t * pageCount, SegmentBase<TVirtualAlloc> ** segment);
 
     template <bool notPageAligned>
-    char * SnailAllocPages(uint pageCount, PageSegmentBase<TVirtualAlloc> ** pageSegment, PageHeapMode pageHeapFlags);
+    char * SnailAllocPages(uint pageCount, PageSegmentBase<TVirtualAlloc> ** pageSegment);
     void OnAllocFromNewSegment(uint pageCount, __in void* pages, SegmentBase<TVirtualAlloc>* segment);
 
     template <bool notPageAligned>
-    char * TryAllocFreePages(uint pageCount, PageSegmentBase<TVirtualAlloc> ** pageSegment, PageHeapMode pageHeapFlags);
+    char * TryAllocFreePages(uint pageCount, PageSegmentBase<TVirtualAlloc> ** pageSegment);
     char * TryAllocFromZeroPagesList(uint pageCount, PageSegmentBase<TVirtualAlloc> ** pageSegment, SLIST_HEADER& zeroPagesList, bool isPendingZeroList);
-    char * TryAllocFromZeroPages(uint pageCount, PageSegmentBase<TVirtualAlloc> ** pageSegment, PageHeapMode pageHeapFlags);
+    char * TryAllocFromZeroPages(uint pageCount, PageSegmentBase<TVirtualAlloc> ** pageSegment);
 
     template <bool notPageAligned>
-    char * TryAllocDecommittedPages(uint pageCount, PageSegmentBase<TVirtualAlloc> ** pageSegment, PageHeapMode pageHeapFlags);
+    char * TryAllocDecommittedPages(uint pageCount, PageSegmentBase<TVirtualAlloc> ** pageSegment);
 
     DListBase<PageSegmentBase<TVirtualAlloc>> * GetSegmentList(PageSegmentBase<TVirtualAlloc> * segment);
     void TransferSegment(PageSegmentBase<TVirtualAlloc> * segment, DListBase<PageSegmentBase<TVirtualAlloc>> * fromSegmentList);
@@ -611,7 +613,7 @@ private:
     void QueuePages(void * address, uint pageCount, PageSegmentBase<TVirtualAlloc> * pageSegment);
 
     template <bool notPageAligned>
-    char* AllocPagesInternal(uint pageCount, PageSegmentBase<TVirtualAlloc> ** pageSegment, PageHeapMode pageHeapModeFlags = PageHeapMode::PageHeapModeOff);
+    char* AllocPagesInternal(uint pageCount, PageSegmentBase<TVirtualAlloc> ** pageSegment);
 
 #ifdef PROFILE_MEM
     PageMemoryData * memoryData;

--- a/lib/Common/Memory/Recycler.cpp
+++ b/lib/Common/Memory/Recycler.cpp
@@ -1198,11 +1198,11 @@ Recycler::TryLargeAlloc(HeapInfo * heap, size_t size, ObjectInfoBits attributes,
     {
         if (heap->largeObjectBucket.IsPageHeapEnabled(attributes))
         {
-            memBlock = heap->largeObjectBucket.PageHeapAlloc(this, size, (ObjectInfoBits)attributes, autoHeap.pageHeapMode, nothrow);
+            memBlock = heap->largeObjectBucket.PageHeapAlloc(this, sizeCat, size, (ObjectInfoBits)attributes, autoHeap.pageHeapMode, nothrow);
             if (memBlock != nullptr)
             {
 #ifdef RECYCLER_ZERO_MEM_CHECK
-                VerifyZeroFill(memBlock, sizeCat);
+                VerifyZeroFill(memBlock, size);
 #endif
                 return memBlock;
             }

--- a/lib/Common/Memory/Recycler.cpp
+++ b/lib/Common/Memory/Recycler.cpp
@@ -1091,17 +1091,14 @@ bool Recycler::ExplicitFreeInternal(void* buffer, size_t size, size_t sizeCat)
 
     Assert(heapBlock != nullptr);
 #ifdef RECYCLER_PAGE_HEAP
-    if (this->IsPageHeapEnabled() )
+    if (this->IsPageHeapEnabled() && this->ShouldCapturePageHeapFreeStack())
     {
-        if (this->ShouldCapturePageHeapFreeStack())
+        if (heapBlock->IsLargeHeapBlock())
         {
-            if (heapBlock->IsLargeHeapBlock())
+            LargeHeapBlock* largeHeapBlock = (LargeHeapBlock*)heapBlock;
+            if (largeHeapBlock->InPageHeapMode())
             {
-                LargeHeapBlock* largeHeapBlock = (LargeHeapBlock*)heapBlock;
-                if (largeHeapBlock->InPageHeapMode())
-                {
-                    largeHeapBlock->CapturePageHeapFreeStack();
-                }
+                largeHeapBlock->CapturePageHeapFreeStack();
             }
         }
 

--- a/lib/Common/Memory/Recycler.h
+++ b/lib/Common/Memory/Recycler.h
@@ -1502,7 +1502,7 @@ private:
     template <typename SmallHeapBlockAllocatorType>
     void RemoveSmallAllocator(SmallHeapBlockAllocatorType * allocator, size_t sizeCat);
     template <ObjectInfoBits attributes, typename SmallHeapBlockAllocatorType>
-    char * SmallAllocatorAlloc(SmallHeapBlockAllocatorType * allocator, size_t sizeCat);
+    char * SmallAllocatorAlloc(SmallHeapBlockAllocatorType * allocator, size_t sizeCat, size_t size);
 
     // Allocation
     template <ObjectInfoBits attributes, bool nothrow>
@@ -2205,9 +2205,9 @@ Recycler::RemoveSmallAllocator(SmallHeapBlockAllocatorType * allocator, size_t s
 
 template <ObjectInfoBits attributes, typename SmallHeapBlockAllocatorType>
 char *
-Recycler::SmallAllocatorAlloc(SmallHeapBlockAllocatorType * allocator, size_t sizeCat)
+Recycler::SmallAllocatorAlloc(SmallHeapBlockAllocatorType * allocator, size_t sizeCat, size_t size)
 {
-    return autoHeap.SmallAllocatorAlloc<attributes>(this, allocator, sizeCat);
+    return autoHeap.SmallAllocatorAlloc<attributes>(this, allocator, sizeCat, size);
 }
 
 // Dummy recycler allocator policy classes to choose the allocation function

--- a/lib/Common/Memory/Recycler.h
+++ b/lib/Common/Memory/Recycler.h
@@ -739,6 +739,8 @@ private:
     HeapInfo autoHeap;
 #ifdef RECYCLER_PAGE_HEAP
     __inline bool IsPageHeapEnabled() const { return isPageHeapEnabled; }
+    template<ObjectInfoBits attributes>
+    bool IsPageHeapEnabled(size_t size);
     __inline bool ShouldCapturePageHeapAllocStack() const { return capturePageHeapAllocStack; }
     bool isPageHeapEnabled;
     bool capturePageHeapAllocStack;
@@ -1527,7 +1529,8 @@ private:
         return AllocWithAttributes<WeakReferenceEntryBits, /* nothrow = */ false>(size);
     }
 #if DBG
-    void VerifyPageHeapFillAfterAlloc(char* memBlock);
+    template <ObjectInfoBits attributes>
+    void VerifyPageHeapFillAfterAlloc(char* memBlock, size_t size);
 #endif
 
     bool NeedDisposeTimed()
@@ -2025,7 +2028,7 @@ public:
 #ifdef RECYCLER_PAGE_HEAP
     bool IsPageHeapAlloc() 
     {
-        return isUsingLargeHeapBlock && m_largeHeapBlockHeader->isPageHeapAlloc;
+        return isUsingLargeHeapBlock && ((LargeHeapBlock*)m_heapBlock)->InPageHeapMode();
     }
 #endif
 

--- a/lib/Common/Memory/Recycler.inl
+++ b/lib/Common/Memory/Recycler.inl
@@ -191,6 +191,10 @@ Recycler::AllocWithAttributesInlined(size_t size)
         }
     }
 #endif
+
+#if DBG
+    VerifyPageHeapFillAfterAlloc(memBlock);
+#endif
     return memBlock;
 }
 
@@ -233,6 +237,10 @@ Recycler::AllocZeroWithAttributesInlined(size_t size)
         // which store the next pointer for the free list.  Just zero that one out
         ((FreeObject *)obj)->ZeroNext();
     }
+
+#if DBG
+    VerifyPageHeapFillAfterAlloc(obj);
+#endif
     return obj;
 }
 
@@ -433,7 +441,7 @@ Recycler::AddMark(void * candidate, size_t byteCount) throw()
 }
 
 
-template <bool pageheap, typename T>
+template <typename T>
 void
 Recycler::NotifyFree(T * heapBlock)
 {
@@ -445,7 +453,7 @@ Recycler::NotifyFree(T * heapBlock)
         this->isForceSweeping = true;
         heapBlock->isForceSweeping = true;
 #endif
-        heapBlock->SweepObjects<pageheap, SweepMode_InThread>(this);
+        heapBlock->SweepObjects<SweepMode_InThread>(this);
 #if DBG || defined(RECYCLER_STATS)
         heapBlock->isForceSweeping = false;
         this->isForceSweeping = false;

--- a/lib/Common/Memory/Recycler.inl
+++ b/lib/Common/Memory/Recycler.inl
@@ -233,9 +233,17 @@ Recycler::AllocZeroWithAttributesInlined(size_t size)
     }
     else
     {
-        // All recycler memory are allocated with zero except for the first word,
-        // which store the next pointer for the free list.  Just zero that one out
-        ((FreeObject *)obj)->ZeroNext();
+        if (IsPageHeapEnabled())
+        {
+            // don't corrupt the page heap filled pattern
+            memset((void*)obj, 0, min(size, sizeof(void*)));
+        }
+        else
+        {
+            // All recycler memory are allocated with zero except for the first word,
+            // which store the next pointer for the free list.  Just zero that one out
+            ((FreeObject *)obj)->ZeroNext();
+        }
     }
 
 #if DBG
@@ -256,13 +264,13 @@ Recycler::RealAllocFromBucket(HeapInfo* heap, size_t size)
     if (isSmallAlloc)
     {
         sizeCat = (uint)HeapInfo::GetAlignedSizeNoCheck(size);
-        memBlock = heap->RealAlloc<attributes, nothrow>(this, sizeCat);
+        memBlock = heap->RealAlloc<attributes, nothrow>(this, sizeCat, size);
     }
 #ifdef BUCKETIZE_MEDIUM_ALLOCATIONS
     else
     {
         sizeCat = (uint)HeapInfo::GetMediumObjectAlignedSizeNoCheck(size);
-        memBlock = heap->MediumAlloc<attributes, nothrow>(this, sizeCat);
+        memBlock = heap->MediumAlloc<attributes, nothrow>(this, sizeCat, size);
     }
 #endif
 
@@ -288,7 +296,27 @@ Recycler::RealAllocFromBucket(HeapInfo* heap, size_t size)
 #endif
         )
     {
-        VerifyZeroFill(memBlock + sizeof(FreeObject), sizeCat - (2 * sizeof(FreeObject)));
+        // TODO: looks the check has been done already
+
+        bool isPageHeapAlloc = false;
+        if (isSmallAlloc)
+        {
+            isPageHeapAlloc = heap->GetBucket<(ObjectInfoBits)(attributes & GetBlockTypeBitMask)>(sizeCat).IsPageHeapEnabled(attributes);
+        }
+#ifdef BUCKETIZE_MEDIUM_ALLOCATIONS
+        else
+        {
+            isPageHeapAlloc = heap->GetMediumBucket<(ObjectInfoBits)(attributes & GetBlockTypeBitMask)>(sizeCat).IsPageHeapEnabled(attributes);
+        }
+#endif
+        if (isPageHeapAlloc)
+        {
+            VerifyZeroFill(memBlock, size);
+        }
+        else
+        {
+            VerifyZeroFill(memBlock + sizeof(FreeObject), sizeCat - (2 * sizeof(FreeObject)));
+        }
     }
 #endif
 #ifdef PROFILE_MEM

--- a/lib/Common/Memory/RecyclerFastAllocator.h
+++ b/lib/Common/Memory/RecyclerFastAllocator.h
@@ -72,6 +72,12 @@ public:
 #ifdef RECYCLER_MEMORY_VERIFY
         recycler->FillCheckPad(memBlock, sizeof(T), sizeCat);
 #endif
+#if DBG
+        if (recycler->IsPageHeapEnabled())
+        {
+            recycler->VerifyPageHeapFillAfterAlloc(memBlock);
+        }
+#endif
         return memBlock;
     };
     static uint32 GetEndAddressOffset()

--- a/lib/Common/Memory/RecyclerFastAllocator.h
+++ b/lib/Common/Memory/RecyclerFastAllocator.h
@@ -53,7 +53,7 @@ public:
 
         if (memBlock == nullptr)
         {
-            memBlock = recycler->SmallAllocatorAlloc<attributes>(&allocator, sizeCat);
+            memBlock = recycler->SmallAllocatorAlloc<attributes>(&allocator, sizeCat, size);
             Assert(memBlock != nullptr);
         }
 

--- a/lib/Common/Memory/RecyclerFastAllocator.h
+++ b/lib/Common/Memory/RecyclerFastAllocator.h
@@ -75,7 +75,7 @@ public:
 #if DBG
         if (recycler->IsPageHeapEnabled())
         {
-            recycler->VerifyPageHeapFillAfterAlloc(memBlock);
+            recycler->VerifyPageHeapFillAfterAlloc<attributes>(memBlock, size);
         }
 #endif
         return memBlock;

--- a/lib/Common/Memory/RecyclerSweep.cpp
+++ b/lib/Common/Memory/RecyclerSweep.cpp
@@ -269,16 +269,8 @@ RecyclerSweep::BackgroundSweep()
 {
     this->BeginBackground(forceForeground);
 
-    if (GetRecycler()->IsPageHeapEnabled())
-    {
-        // Finish the concurrent part of the first pass
-        this->recycler->autoHeap.SweepSmallNonFinalizable<true>(*this);
-    }
-    else
-    {
-        // Finish the concurrent part of the first pass
-        this->recycler->autoHeap.SweepSmallNonFinalizable<false>(*this);
-    }
+    // Finish the concurrent part of the first pass
+    this->recycler->autoHeap.SweepSmallNonFinalizable(*this);
 
     // Finish the rest of the sweep
     this->FinishSweep();

--- a/lib/Common/Memory/RecyclerSweep.h
+++ b/lib/Common/Memory/RecyclerSweep.h
@@ -33,7 +33,7 @@ public:
     template <typename TBlockType>
     TBlockType *& GetPendingSweepBlockList(HeapBucketT<TBlockType> const * heapBucket);
     bool HasPendingEmptyBlocks() const;
-    template <typename TBlockType, bool pageheap> void QueueEmptyHeapBlock(HeapBucketT<TBlockType> const *heapBucket, TBlockType * heapBlock);
+    template <typename TBlockType> void QueueEmptyHeapBlock(HeapBucketT<TBlockType> const *heapBucket, TBlockType * heapBlock);
     template <typename TBlockType> void TransferPendingEmptyHeapBlocks(HeapBucketT<TBlockType> * heapBucket);
 
     void BackgroundSweep();
@@ -192,13 +192,13 @@ RecyclerSweep::GetPendingSweepBlockList(HeapBucketT<TBlockType> const * heapBuck
 
 #if ENABLE_CONCURRENT_GC
 
-template <typename TBlockType, bool pageheap>
+template <typename TBlockType>
 void
 RecyclerSweep::QueueEmptyHeapBlock(HeapBucketT<TBlockType> const *heapBucket, TBlockType * heapBlock)
 {
     auto& bucketData = this->GetBucketData(heapBucket);
     Assert(heapBlock->heapBucket == heapBucket);
-    heapBlock->BackgroundReleasePagesSweep<pageheap>(recycler);
+    heapBlock->BackgroundReleasePagesSweep(recycler);
     TBlockType * list = bucketData.pendingEmptyBlockList;
     if (list == nullptr)
     {

--- a/lib/Common/Memory/RecyclerWeakReference.h
+++ b/lib/Common/Memory/RecyclerWeakReference.h
@@ -37,7 +37,7 @@ protected:
 
     char* strongRef;
     HeapBlock * strongRefHeapBlock;
-    SmallHeapBlock * weakRefHeapBlock;
+    HeapBlock * weakRefHeapBlock;
     RecyclerWeakReferenceBase* next;
 #if DBG
     type_info const * typeInfo;
@@ -347,8 +347,8 @@ private:
         Assert(entry->strongRefHeapBlock != nullptr);
 
         HeapBlock * weakRefHeapBlock = recycler->FindHeapBlock(entry);
-        Assert(!weakRefHeapBlock->IsLargeHeapBlock());
-        entry->weakRefHeapBlock = (SmallHeapBlock *)weakRefHeapBlock;
+        Assert(!weakRefHeapBlock->IsLargeHeapBlock() || ((LargeHeapBlock*)weakRefHeapBlock)->InPageHeapMode());
+        entry->weakRefHeapBlock = weakRefHeapBlock;
 
 #ifdef RECYCLER_TRACE_WEAKREF
         Output::Print(_u("Add 0x%08x to bucket %d\n"), entry, targetBucket);

--- a/lib/Common/Memory/SmallBlockDeclarations.inl
+++ b/lib/Common/Memory/SmallBlockDeclarations.inl
@@ -7,20 +7,11 @@
 #error Need to define block type attributes before including this file
 #endif
 
-template void SmallHeapBlockT<TBlockTypeAttributes>::ReleasePages<true>(Recycler * recycler);
-template void SmallHeapBlockT<TBlockTypeAttributes>::ReleasePages<false>(Recycler * recycler);
-template void SmallHeapBlockT<TBlockTypeAttributes>::BackgroundReleasePagesSweep<true>(Recycler* recycler);
-template void SmallHeapBlockT<TBlockTypeAttributes>::BackgroundReleasePagesSweep<false>(Recycler* recycler);
-template void SmallHeapBlockT<TBlockTypeAttributes>::ReleasePagesSweep<true>(Recycler * recycler);
-template void SmallHeapBlockT<TBlockTypeAttributes>::ReleasePagesSweep<false>(Recycler * recycler);
-template BOOL SmallHeapBlockT<TBlockTypeAttributes>::ReassignPages<true>(Recycler * recycler);
-template BOOL SmallHeapBlockT<TBlockTypeAttributes>::ReassignPages<false>(Recycler * recycler);
-template BOOL SmallHeapBlockT<TBlockTypeAttributes>::SetPage<true>(__in_ecount_pagesize char * baseAddress, PageSegment * pageSegment, Recycler * recycler);
-template BOOL SmallHeapBlockT<TBlockTypeAttributes>::SetPage<false>(__in_ecount_pagesize char * baseAddress, PageSegment * pageSegment, Recycler * recycler);
-template const uint SmallHeapBlockT<TBlockTypeAttributes>::GetPageHeapModePageCount<true>() const;
-template const uint SmallHeapBlockT<TBlockTypeAttributes>::GetPageHeapModePageCount<false>() const;
-template SweepState SmallHeapBlockT<TBlockTypeAttributes>::Sweep<true>(RecyclerSweep& recyclerSweep, bool queuePendingSweep, bool allocable, ushort finalizeCount, bool hasPendingDispose);
-template SweepState SmallHeapBlockT<TBlockTypeAttributes>::Sweep<false>(RecyclerSweep& recyclerSweep, bool queuePendingSweep, bool allocable, ushort finalizeCount, bool hasPendingDispose);
+template void SmallHeapBlockT<TBlockTypeAttributes>::ReleasePages(Recycler * recycler);
+template void SmallHeapBlockT<TBlockTypeAttributes>::BackgroundReleasePagesSweep(Recycler* recycler);
+template void SmallHeapBlockT<TBlockTypeAttributes>::ReleasePagesSweep(Recycler * recycler);
+template BOOL SmallHeapBlockT<TBlockTypeAttributes>::ReassignPages(Recycler * recycler);
+template SweepState SmallHeapBlockT<TBlockTypeAttributes>::Sweep(RecyclerSweep& recyclerSweep, bool queuePendingSweep, bool allocable, ushort finalizeCount, bool hasPendingDispose);
 
 template SmallNormalHeapBlockT<TBlockTypeAttributes>* HeapBlock::AsNormalBlock<TBlockTypeAttributes>();
 template SmallLeafHeapBlockT<TBlockTypeAttributes>* HeapBlock::AsLeafBlock<TBlockTypeAttributes>();
@@ -51,8 +42,7 @@ template bool SmallHeapBlockT<TBlockTypeAttributes>::GetFreeObjectListOnAllocato
 // template const SmallHeapBlockT<TBlockTypeAttributes>::SmallHeapBlockBitVector * HeapInfo::ValidPointersMap<TBlockTypeAttributes>::GetInvalidBitVector(uint index) const;
 
 // Explicit instantiate all the sweep mode
-template void SmallHeapBlockT<TBlockTypeAttributes>::SweepObjects<true, SweepMode_InThread>(Recycler * recycler);
-template void SmallHeapBlockT<TBlockTypeAttributes>::SweepObjects<false, SweepMode_InThread>(Recycler * recycler);
+template void SmallHeapBlockT<TBlockTypeAttributes>::SweepObjects<SweepMode_InThread>(Recycler * recycler);
 #if ENABLE_CONCURRENT_GC
 template <>
 template <>
@@ -63,7 +53,7 @@ SmallHeapBlockT<TBlockTypeAttributes>::SweepObject<SweepMode_Concurrent>(Recycle
     EnqueueProcessedObject(&freeObjectList, addr, i);
 }
 // Explicit instantiate all the sweep mode
-template void SmallHeapBlockT<TBlockTypeAttributes>::SweepObjects<false, SweepMode_Concurrent>(Recycler * recycler);
+template void SmallHeapBlockT<TBlockTypeAttributes>::SweepObjects<SweepMode_Concurrent>(Recycler * recycler);
 #if ENABLE_PARTIAL_GC
 template <>
 template <>
@@ -83,7 +73,7 @@ SmallHeapBlockT<TBlockTypeAttributes>::SweepObject<SweepMode_ConcurrentPartial>(
 }
 
 // Explicit instantiate all the sweep mode
-template void SmallHeapBlockT<TBlockTypeAttributes>::SweepObjects<false, SweepMode_ConcurrentPartial>(Recycler * recycler);
+template void SmallHeapBlockT<TBlockTypeAttributes>::SweepObjects<SweepMode_ConcurrentPartial>(Recycler * recycler);
 #endif
 #endif
 

--- a/lib/Common/Memory/SmallFinalizableHeapBlock.cpp
+++ b/lib/Common/Memory/SmallFinalizableHeapBlock.cpp
@@ -229,13 +229,10 @@ SmallFinalizableHeapBlockT<TBlockAttributes>::RescanTrackedObject(FinalizableObj
 }
 #endif
 
-template SweepState SmallFinalizableHeapBlockT<SmallAllocationBlockAttributes>::Sweep<true>(RecyclerSweep& recyclerSweep, bool queuePendingSweep, bool allocable);
-template SweepState SmallFinalizableHeapBlockT<SmallAllocationBlockAttributes>::Sweep<false>(RecyclerSweep& recyclerSweep, bool queuePendingSweep, bool allocable);
-template SweepState SmallFinalizableHeapBlockT<MediumAllocationBlockAttributes>::Sweep<true>(RecyclerSweep& recyclerSweep, bool queuePendingSweep, bool allocable);
-template SweepState SmallFinalizableHeapBlockT<MediumAllocationBlockAttributes>::Sweep<false>(RecyclerSweep& recyclerSweep, bool queuePendingSweep, bool allocable);
+template SweepState SmallFinalizableHeapBlockT<SmallAllocationBlockAttributes>::Sweep(RecyclerSweep& recyclerSweep, bool queuePendingSweep, bool allocable);
+template SweepState SmallFinalizableHeapBlockT<MediumAllocationBlockAttributes>::Sweep(RecyclerSweep& recyclerSweep, bool queuePendingSweep, bool allocable);
 
 template <class TBlockAttributes>
-template<bool pageheap>
 SweepState
 SmallFinalizableHeapBlockT<TBlockAttributes>::Sweep(RecyclerSweep& recyclerSweep, bool queuePendingSweep, bool allocable)
 {
@@ -245,7 +242,7 @@ SmallFinalizableHeapBlockT<TBlockAttributes>::Sweep(RecyclerSweep& recyclerSweep
     // If there are finalizable objects in this heap block, they need to be swept
     // in-thread and not in the concurrent thread, so don't queue pending sweep
 
-    return SmallNormalHeapBlockT<TBlockAttributes>::Sweep<pageheap>(recyclerSweep, false, allocable, this->finalizeCount, HasAnyDisposeObjects());
+    return SmallNormalHeapBlockT<TBlockAttributes>::Sweep(recyclerSweep, false, allocable, this->finalizeCount, HasAnyDisposeObjects());
 }
 
 template <class TBlockAttributes>

--- a/lib/Common/Memory/SmallFinalizableHeapBlock.h
+++ b/lib/Common/Memory/SmallFinalizableHeapBlock.h
@@ -32,7 +32,6 @@ public:
     static bool RescanObject(SmallFinalizableHeapBlockT<TBlockAttributes> * block, __in_ecount(localObjectSize) char * objectAddress, uint localObjectSize, uint objectIndex, Recycler * recycler);
     bool RescanTrackedObject(FinalizableObject * object, uint objectIndex,  Recycler * recycler);
 #endif
-    template<bool pageheap>
     SweepState Sweep(RecyclerSweep& sweepeData, bool queuePendingSweep, bool allocable);
     void DisposeObjects();
     void TransferDisposedObjects();

--- a/lib/Common/Memory/SmallFinalizableHeapBucket.h
+++ b/lib/Common/Memory/SmallFinalizableHeapBucket.h
@@ -30,7 +30,6 @@ protected:
     friend class HeapBucketGroup;
 
     void ResetMarks(ResetMarkFlags flags);
-    template<bool pageheap>
     void Sweep(RecyclerSweep& recyclerSweep);
 #if DBG || defined(RECYCLER_SLOW_CHECK_ENABLED)
     size_t GetNonEmptyHeapBlockCount(bool checkCount) const;
@@ -206,7 +205,6 @@ public:
     void ScanInitialImplicitRoots(Recycler * recycler);
     void ScanNewImplicitRoots(Recycler * recycler);
 
-    template<bool pageheap>
     void Sweep(RecyclerSweep& recyclerSweep);
     uint Rescan(Recycler * recycler, RescanFlags flags);
 #if ENABLE_CONCURRENT_GC
@@ -221,7 +219,6 @@ public:
     void SetupBackgroundSweep(RecyclerSweep& recyclerSweep);
     void TransferPendingEmptyHeapBlocks(RecyclerSweep& recyclerSweep);
 #endif
-    template<bool pageheap>
     void SweepFinalizableObjects(RecyclerSweep& recyclerSweep);
     void DisposeObjects();
     void TransferDisposedObjects();

--- a/lib/Common/Memory/SmallHeapBlockAllocator.cpp
+++ b/lib/Common/Memory/SmallHeapBlockAllocator.cpp
@@ -209,11 +209,7 @@ SmallHeapBlockAllocator<TBlockType>::TrackNativeAllocatedObjects()
 
     if (lastNonNativeBumpAllocatedBlock == nullptr)
     {
-#ifdef RECYCLER_PAGE_HEAP
-        Assert((char *)this->freeObjectList == this->heapBlock->GetAddress() || ((SmallHeapBlock*) this->heapBlock)->InPageHeapMode());
-#else
         Assert((char *)this->freeObjectList == this->heapBlock->GetAddress());
-#endif
         return;
     }
 

--- a/lib/Common/Memory/SmallLeafHeapBucket.cpp
+++ b/lib/Common/Memory/SmallLeafHeapBucket.cpp
@@ -4,17 +4,11 @@
 //-------------------------------------------------------------------------------------------------------
 #include "CommonMemoryPch.h"
 
-template void SmallLeafHeapBucketT<SmallAllocationBlockAttributes>::Sweep<true>(RecyclerSweep& recyclerSweep);
-template void SmallLeafHeapBucketT<SmallAllocationBlockAttributes>::Sweep<false>(RecyclerSweep& recyclerSweep);
-template void SmallLeafHeapBucketT<MediumAllocationBlockAttributes>::Sweep<true>(RecyclerSweep& recyclerSweep);
-template void SmallLeafHeapBucketT<MediumAllocationBlockAttributes>::Sweep<false>(RecyclerSweep& recyclerSweep);
-
 template <typename TBlockAttributes>
-template<bool pageheap>
 void
 SmallLeafHeapBucketT<TBlockAttributes>::Sweep(RecyclerSweep& recyclerSweep)
 {
-    BaseT::SweepBucket<pageheap>(recyclerSweep, [](RecyclerSweep& recyclerSweep){});
+    BaseT::SweepBucket(recyclerSweep, [](RecyclerSweep& recyclerSweep){});
 }
 
 #if DBG || defined(RECYCLER_SLOW_CHECK_ENABLED)

--- a/lib/Common/Memory/SmallLeafHeapBucket.h
+++ b/lib/Common/Memory/SmallLeafHeapBucket.h
@@ -13,7 +13,6 @@ protected:
     template <class TBlockAttributes>
     friend class HeapBucketGroup;
 
-    template<bool pageheap>
     void Sweep(RecyclerSweep& recyclerSweep);
 
 #if DBG || defined(RECYCLER_SLOW_CHECK_ENABLED)

--- a/lib/Common/Memory/SmallNormalHeapBucket.cpp
+++ b/lib/Common/Memory/SmallNormalHeapBucket.cpp
@@ -227,7 +227,7 @@ SmallNormalHeapBucketBase<TBlockType>::SweepPendingObjects(RecyclerSweep& recycl
                 // The sweepable objects will be collected in a future Sweep.
 
                 // Note, page heap blocks are never swept concurrently
-                heapBlock->SweepObjects<false, SweepMode_ConcurrentPartial>(recycler);
+                heapBlock->SweepObjects<SweepMode_ConcurrentPartial>(recycler);
 
                 // page heap mode should never reach here, so don't check pageheap enabled or not
                 if (heapBlock->HasFreeObject<false>())
@@ -272,7 +272,7 @@ SmallNormalHeapBucketBase<TBlockType>::SweepPendingObjects(Recycler * recycler, 
     HeapBlockList::ForEach(list, [recycler, &tail](TBlockType * heapBlock)
     {
         // Note, page heap blocks are never swept concurrently
-        heapBlock->SweepObjects<false, mode>(recycler);
+        heapBlock->SweepObjects<mode>(recycler);
         tail = heapBlock;
     });
     return tail;
@@ -356,7 +356,7 @@ SmallNormalHeapBucketBase<TBlockType>::SweepPartialReusePages(RecyclerSweep& rec
                 Assert(!heapBlock->IsAnyFinalizableBlock());
 
                 // Page heap blocks are never swept concurrently
-                heapBlock->SweepObjects<false, SweepMode_InThread>(recycler);
+                heapBlock->SweepObjects<SweepMode_InThread>(recycler);
 
                 // This block has been counted as concurrently swept, and now we changed our mind
                 // and sweep it in thread. Remove the count
@@ -554,7 +554,6 @@ SmallNormalHeapBucketBase<TBlockType>::VerifyMark()
 #endif // ENABLE_PARTIAL_GC
 
 template <typename TBlockType>
-template<bool pageheap>
 void
 SmallNormalHeapBucketBase<TBlockType>::Sweep(RecyclerSweep& recyclerSweep)
 {
@@ -571,7 +570,7 @@ SmallNormalHeapBucketBase<TBlockType>::Sweep(RecyclerSweep& recyclerSweep)
     this->SweepVerifyPartialBlocks(recycler, this->partialHeapBlockList);
 #endif
 #endif
-    BaseT::SweepBucket<pageheap>(recyclerSweep, [](RecyclerSweep& recyclerSweep){});
+    BaseT::SweepBucket(recyclerSweep, [](RecyclerSweep& recyclerSweep){});
 }
 
 template class SmallNormalHeapBucketBase<SmallNormalHeapBlock>;
@@ -589,15 +588,12 @@ template class SmallNormalHeapBucketBase<MediumFinalizableHeapBlock>;
 template class SmallNormalHeapBucketBase<SmallFinalizableWithBarrierHeapBlock>;
 template class SmallNormalHeapBucketBase<MediumFinalizableWithBarrierHeapBlock>;
 #endif
-
-template void SmallNormalHeapBucketBase<SmallNormalHeapBlock>::Sweep<true>(RecyclerSweep& recyclerSweep);
-template void SmallNormalHeapBucketBase<SmallNormalHeapBlock>::Sweep<false>(RecyclerSweep& recyclerSweep);
-template void SmallNormalHeapBucketBase<MediumNormalHeapBlock>::Sweep<true>(RecyclerSweep& recyclerSweep);
-template void SmallNormalHeapBucketBase<MediumNormalHeapBlock>::Sweep<false>(RecyclerSweep& recyclerSweep);
+   
+template void SmallNormalHeapBucketBase<SmallNormalHeapBlock>::Sweep(RecyclerSweep& recyclerSweep);
+template void SmallNormalHeapBucketBase<MediumNormalHeapBlock>::Sweep(RecyclerSweep& recyclerSweep);
 
 #ifdef RECYCLER_WRITE_BARRIER
-template void SmallNormalHeapBucketBase<SmallNormalWithBarrierHeapBlock>::Sweep<true>(RecyclerSweep& recyclerSweep);
-template void SmallNormalHeapBucketBase<SmallNormalWithBarrierHeapBlock>::Sweep<false>(RecyclerSweep& recyclerSweep);
-template void SmallNormalHeapBucketBase<MediumNormalWithBarrierHeapBlock>::Sweep<true>(RecyclerSweep& recyclerSweep);
-template void SmallNormalHeapBucketBase<MediumNormalWithBarrierHeapBlock>::Sweep<false>(RecyclerSweep& recyclerSweep);
+template void SmallNormalHeapBucketBase<SmallNormalWithBarrierHeapBlock>::Sweep(RecyclerSweep& recyclerSweep);
+template void SmallNormalHeapBucketBase<MediumNormalWithBarrierHeapBlock>::Sweep(RecyclerSweep& recyclerSweep);
 #endif
+

--- a/lib/Common/Memory/SmallNormalHeapBucket.h
+++ b/lib/Common/Memory/SmallNormalHeapBucket.h
@@ -39,7 +39,6 @@ protected:
     template <SweepMode mode>
     static TBlockType * SweepPendingObjects(Recycler * recycler, TBlockType * list);
 #endif
-    template<bool pageheap>
     void Sweep(RecyclerSweep& recyclerSweep);
 #if ENABLE_PARTIAL_GC
     ~SmallNormalHeapBucketBase();


### PR DESCRIPTION
- remove the pageheap implementation in small and medium block
- fix couple issues in large heap pageheap implementation (OOM while allocating LargeHeapBlock or adding to heapBlockMap)
- decommit guard page instead of setting to NOACCESS to save memory.
- implement pattern check for corruption
- TrackBit is not supported by LargeHeapBlock today, so disable pageheap for such allocation
- added assert on non-alignment page allocated for recycler, this is found by page heap run
