### PR TITLE
fix compact counter on detecting background access

### DIFF
--- a/lib/Backend/NativeCodeGenerator.cpp
+++ b/lib/Backend/NativeCodeGenerator.cpp
@@ -1362,6 +1362,10 @@ NativeCodeGenerator::Process(JsUtil::Job *const job, JsUtil::ParallelThreadData 
 
     CodeGenWorkItem *const codeGenWork = static_cast<CodeGenWorkItem *>(job);
 
+#if DBG
+    Js::FunctionBody::AutoResetThreadState autoSet(codeGenWork->GetFunctionBody());
+#endif
+
     switch (codeGenWork->Type())
     {
     case JsLoopBodyWorkItemType:
@@ -1499,6 +1503,10 @@ NativeCodeGenerator::JobProcessed(JsUtil::Job *const job, const bool succeeded)
     Assert(job);
 
     CodeGenWorkItem *workItem = static_cast<CodeGenWorkItem *>(job);
+
+#if DBG
+    Js::FunctionBody::AutoResetThreadState autoReset(workItem->GetFunctionBody());
+#endif
 
     class AutoCleanup
     {

--- a/lib/Runtime/Base/CompactCounters.h
+++ b/lib/Runtime/Base/CompactCounters.h
@@ -26,8 +26,6 @@ namespace Js
 
         uint8 fieldSize;
 #if DBG
-
-        mutable bool bgThreadCallStarted;
         bool isCleaningUp;
 #endif
         WriteBarrierPtr<Fields> fields;
@@ -36,7 +34,7 @@ namespace Js
         CompactCounters(T* host)
             :fieldSize(0)
 #if DBG
-            , bgThreadCallStarted(false), isCleaningUp(false)
+            , isCleaningUp(false)
 #endif
         {
             AllocCounters<uint8>(host);
@@ -44,12 +42,6 @@ namespace Js
 
         uint32 Get(CountT typeEnum) const
         {
-#if DBG
-            if (!bgThreadCallStarted && ThreadContext::GetContextForCurrentThread() == nullptr)
-            {
-                bgThreadCallStarted = true;
-            }
-#endif
             uint8 type = static_cast<uint8>(typeEnum);
             uint8 localFieldSize = fieldSize;
             uint32 value = 0;
@@ -75,12 +67,6 @@ namespace Js
 
         int32 GetSigned(CountT typeEnum) const
         {
-#if DBG
-            if (!bgThreadCallStarted && ThreadContext::GetContextForCurrentThread() == nullptr)
-            {
-                bgThreadCallStarted = true;
-            }
-#endif
 
             uint8 type = static_cast<uint8>(typeEnum);
             uint8 localFieldSize = fieldSize;
@@ -106,7 +92,7 @@ namespace Js
 
         uint32 Set(CountT typeEnum, uint32 val, T* host)
         {
-            Assert(bgThreadCallStarted == false || isCleaningUp == true);
+            Assert(host->bgThreadRank == 0 || isCleaningUp == true);
 
             uint8 type = static_cast<uint8>(typeEnum);
             if (fieldSize == 1)
@@ -146,7 +132,7 @@ namespace Js
 
         int32 SetSigned(CountT typeEnum, int32 val, T* host)
         {
-            Assert(bgThreadCallStarted == false || isCleaningUp == true);
+            Assert(host->bgThreadRank == 0 || isCleaningUp == true);
 
             uint8 type = static_cast<uint8>(typeEnum);
             if (fieldSize == 1)
@@ -186,7 +172,7 @@ namespace Js
 
         uint32 Increase(CountT typeEnum, T* host)
         {
-            Assert(bgThreadCallStarted == false);
+            Assert(host->bgThreadRank == 0);
 
             uint8 type = static_cast<uint8>(typeEnum);
             if (fieldSize == 1)

--- a/lib/Runtime/Base/EtwTrace.cpp
+++ b/lib/Runtime/Base/EtwTrace.cpp
@@ -179,6 +179,10 @@ void EtwTrace::PerformRundown(bool start)
 
             scriptContext->MapFunction([&start] (FunctionBody* body)
             {
+#if DBG
+                Js::FunctionBody::AutoResetThreadState autoReset(body);
+#endif
+
                 if(body->HasInterpreterThunkGenerated())
                 {
                     if(start)

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -1720,26 +1720,24 @@ namespace Js
             typedef CompactCounters<FunctionBody> CounterT;
             CounterT counters;
 
-            uint32 GetCountField(FunctionBody::CounterFields fieldEnum) const
+            uint32 GetCountField(FunctionBody::CounterFields fieldEnum) const;
+            uint32 SetCountField(FunctionBody::CounterFields fieldEnum, uint32 val);
+            uint32 IncreaseCountField(FunctionBody::CounterFields fieldEnum);
+            int32 GetCountFieldSigned(FunctionBody::CounterFields fieldEnum) const;
+            int32 SetCountFieldSigned(FunctionBody::CounterFields fieldEnum, int32 val);
+#if DBG
+            struct AutoResetThreadState
             {
-                return counters.Get(fieldEnum);
-            }
-            uint32 SetCountField(FunctionBody::CounterFields fieldEnum, uint32 val)
-            {
-                return counters.Set(fieldEnum, val, this);
-            }
-            uint32 IncreaseCountField(FunctionBody::CounterFields fieldEnum)
-            {
-                return counters.Increase(fieldEnum, this);
-            }
-            int32 GetCountFieldSigned(FunctionBody::CounterFields fieldEnum) const
-            {
-                return counters.GetSigned(fieldEnum);
-            }
-            int32 SetCountFieldSigned(FunctionBody::CounterFields fieldEnum, int32 val)
-            {
-                return counters.SetSigned(fieldEnum, val, this);
-            }
+                Js::FunctionBody* functionBody;
+                bool foreground;
+                bool alreadyInBackground;
+                AutoResetThreadState(Js::FunctionBody* fb);
+                ~AutoResetThreadState();
+            };
+            void EnterBackgroundCall();
+            void LeaveBackgroundCall();
+            volatile uint bgThreadRank;
+#endif
 
             struct StatementMap
             {


### PR DESCRIPTION
previously we assume that we don't change these counters after jit begins. however if there's prejit, we mark the counters has been accessed from background thread already and does not allow update, and then with force searialize bytecode, it is updating the counter (searialize ID).

fixing this by block the counter updating only when there's background thread JIT is ongoing, and unblock when the JIT completed
