### PR TITLE
Scope slot positions for destructuring patterns on param.

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -1577,15 +1577,20 @@ void ByteCodeGenerator::EmitScopeObjectInit(FuncInfo *funcInfo)
                     Assert(sym->GetScopeSlot() != Js::Constants::NoProperty && sym->GetScopeSlot() > slot);
                     propIds->elements[slot] = Js::Constants::NoProperty;
                 }
-                slot++;
             }
+            else
+            {
+                // This is for patterns
+                propIds->elements[slot] = Js::Constants::NoProperty;
+            }
+            slot++;
         };
         MapFormalsWithoutRest(pnodeFnc, initArg);
 
-        // initArg assumes the sym is in a slot, but this may not be true for the rest parameter.
+        // If the rest is in the slot - we need to keep that slot.
         if (pnodeFnc->sxFnc.pnodeRest != nullptr && pnodeFnc->sxFnc.pnodeRest->sxVar.sym->IsInSlot(funcInfo))
         {
-            initArg(pnodeFnc->sxFnc.pnodeRest);
+            Symbol::SaveToPropIdArray(pnodeFnc->sxFnc.pnodeRest->sxVar.sym, propIds, this);
         }
     }
     else

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -2724,14 +2724,19 @@ FuncInfo* PostVisitFunction(ParseNode* pnode, ByteCodeGenerator* byteCodeGenerat
                                 top->sameNameArgsPlaceHolderSlotCount++; // Same name args appeared before
                             }
                             sym->SetScopeSlot(i);
-                            i++;
                         }
+                        i++;
                     };
 
-                    // We don't need to process the rest parameter here because it may not need a scope slot.
+                    // We need to include the rest as well -as it will get slot assigned.
                     if (ByteCodeGenerator::NeedScopeObjectForArguments(top, pnode))
                     {
-                        MapFormalsWithoutRest(pnode, setArgScopeSlot);
+                        MapFormals(pnode, setArgScopeSlot);
+                        if (argSym->NeedsSlotAlloc(top))
+                        {
+                            Assert(argSym->GetScopeSlot() == Js::Constants::NoProperty);
+                            argSym->SetScopeSlot(i++);
+                        }
                         MapFormalsFromPattern(pnode, setArgScopeSlot);
                     }
 
@@ -4545,6 +4550,7 @@ void AssignRegisters(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator)
         CheckMaybeEscapedUse(pnode->sxParamPattern.pnode1, byteCodeGenerator);
         break;
 
+    case knopObjectPattern:
     case knopArrayPattern:
         byteCodeGenerator->AssignUndefinedConstRegister();
         CheckMaybeEscapedUse(pnode->sxUni.pnode1, byteCodeGenerator);

--- a/lib/Runtime/ByteCode/Scope.cpp
+++ b/lib/Runtime/ByteCode/Scope.cpp
@@ -130,9 +130,10 @@ void Scope::MergeParamAndBodyScopes(ParseNode *pnodeScope, ByteCodeGenerator *by
 
     // Reassign non-formal slot positions. Formals need to keep their slot positions to ensure
     // the argument object works properly. Other symbols need to be reassigned slot positions.
+    // The sym belonging to arguments will use the same slot.
     paramScope->ForEachSymbol([&](Symbol * sym)
     {
-        if (sym->GetSymbolType() != STFormal && sym->GetScopeSlot() != Js::Constants::NoProperty)
+        if (sym->GetSymbolType() != STFormal && sym->GetScopeSlot() != Js::Constants::NoProperty && !sym->GetIsArguments())
         {
             sym->SetScopeSlot(Js::Constants::NoProperty);
             sym->EnsureScopeSlot(pnodeScope->sxFnc.funcInfo);


### PR DESCRIPTION
We were not assigning the slot position to the destructuring pattern itself. eg funciton foo({}, a), we were not assigning the slot for the pattern, so the 'a' used to get the first slot. This was creating the problem for the arguments object as while creating the arguments object we were having formals count as 2 but only 1 slot assigned so the arguments object to frameObject interaction is messed up. For that reason I have created the slots for the pattern itself.
While doing that I have also made sure the order of assigning slots should be consistent.
such as
1. normal params and patterns
2. rest
3. arguments object
4. Identifiers inside the pattern.

Since I have touched the way 'rest' used to get slots I have added tests for 'rest' as well for validation.
