### PR TITLE
Harden Promise code against OOM after catching exception

### DIFF
--- a/lib/Runtime/Library/JavascriptPromise.h
+++ b/lib/Runtime/Library/JavascriptPromise.h
@@ -362,6 +362,7 @@ namespace Js
 
         static void InitializePromise(JavascriptPromise* promise, JavascriptPromiseResolveOrRejectFunction** resolve, JavascriptPromiseResolveOrRejectFunction** reject, ScriptContext* scriptContext);
         static Var TryCallResolveOrRejectHandler(Var handler, Var value, ScriptContext* scriptContext);
+        static Var TryRejectWithExceptionObject(JavascriptExceptionObject* exceptionObject, Var handler, ScriptContext* scriptContext);
 
     protected:
         enum PromiseStatus


### PR DESCRIPTION
JavascriptExceptionObject::GetThrownObject returns nullptr if it hits OOM.
We previously did not check for this case which caused assert or AV in
retail builds when a JavascriptError object fails to allocate with OOM.

Made our implementation more robust by catching the case wehre we hit an
OOM and pass undefined to the promise reject handler instead of nullptr in
that case. This avoids potential AV or assert but does ignore the OOM.
