### PR TITLE
SIMD.js - Fix regalloc to not fold SIMD opnds

### DIFF
--- a/lib/Backend/amd64/EncoderMD.cpp
+++ b/lib/Backend/amd64/EncoderMD.cpp
@@ -1772,6 +1772,12 @@ bool EncoderMD::TryFold(IR::Instr *instr, IR::RegOpnd *regOpnd)
     IR::Opnd *src1 = instr->GetSrc1();
     IR::Opnd *src2 = instr->GetSrc2();
 
+    if (IRType_IsSimd128(regOpnd->GetType()))
+    {
+        // No folding for SIMD values. Alignment is not guaranteed.
+        return false;
+    }
+
     switch (GetInstrForm(instr))
     {
     case FORM_MOV:

--- a/lib/Backend/i386/EncoderMD.cpp
+++ b/lib/Backend/i386/EncoderMD.cpp
@@ -1606,7 +1606,12 @@ bool EncoderMD::TryFold(IR::Instr *instr, IR::RegOpnd *regOpnd)
 {
     IR::Opnd *src1 = instr->GetSrc1();
     IR::Opnd *src2 = instr->GetSrc2();
-
+    
+    if (IRType_IsSimd128(regOpnd->GetType()))
+    {
+        // No folding for SIMD values. Alignment is not guaranteed.
+        return false;
+    }
     switch(GetInstrForm(instr))
     {
     case FORM_MOV:


### PR DESCRIPTION
Fixed RegAlloc to not use SIMD opnds from memory if lifetime is spilled. Fixes #695