### PR TITLE
Fix for issues with split scope in eval

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -2599,6 +2599,12 @@ FuncInfo* PostVisitFunction(ParseNode* pnode, ByteCodeGenerator* byteCodeGenerat
     {
         // Even if it wasn't determined during visiting this function that we need a scope object, we still have a few conditions that may require one.
         top->bodyScope->SetIsObject();
+        if (!top->paramScope->GetCanMergeWithBodyScope())
+        {
+            // If we have the function inside an eval then access to outer variables should go through scope object.
+            // So we set the body scope as object and we need to set the param scope also as object in case of split scope.
+            top->paramScope->SetIsObject();
+        }
     }
 
     if (pnode->nop == knopProg
@@ -5020,6 +5026,16 @@ void AssignRegisters(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator)
                         }
                     }
                     byteCodeGenerator->AssignRegister(sym);
+                }
+                if (sym->GetScope() == funcInfo->paramScope && !funcInfo->paramScope->GetCanMergeWithBodyScope())
+                {
+                    // We created an equivalent symbol in the body, let us allocate a register for it if necessary,
+                    // because it may not be referenced in the body at all.
+                    Symbol* bodySym = funcInfo->bodyScope->FindLocalSymbol(sym->GetName());
+                    if (!bodySym->IsInSlot(funcInfo))
+                    {
+                        byteCodeGenerator->AssignRegister(bodySym);
+                    }
                 }
             }
             else

--- a/test/es6/default.js
+++ b/test/es6/default.js
@@ -250,6 +250,7 @@ var tests = [
         
         assert.doesNotThrow(function (a = eval) { }, "An assignment of eval does not cause syntax error");
         assert.doesNotThrow(function (a = eval()) { }, "If no arguments are passed to eval then it won't cause syntax error");
+        assert.doesNotThrow(function () { eval("function f( x = function y() { function z() { x; }; }) { }"); }, "Split scope functions inside eval shouldn't throw");
     }
   },
   {


### PR DESCRIPTION
1. When a function is defined inside eval we were only marking body scope
as object. Fixed to mark param scope also as an object.
2. In split scope there can be symbols which were created duping the
formals but are not referenced in the body. We need to allocate registers
for them.
