### PR TITLE
Get the last error code immediately after a Windows API call in IntlEngineInterfaceExtensionObject::EntryIntl_CompareString

### DIFF
--- a/lib/Runtime/Library/IntlEngineInterfaceExtensionObject.cpp
+++ b/lib/Runtime/Library/IntlEngineInterfaceExtensionObject.cpp
@@ -1005,6 +1005,7 @@ namespace Js
         }
 
         int compareResult = 0;
+        DWORD lastError = S_OK;
         BEGIN_TEMP_ALLOCATOR(tempAllocator, scriptContext, _u("localeCompare"))
         {
             char16 * aLeft = nullptr;
@@ -1034,6 +1035,12 @@ namespace Js
             }
 
             compareResult = CompareStringEx(givenLocale != nullptr ? givenLocale : defaultLocale, compareFlags, aLeft, size1, aRight, size2, NULL, NULL, 0);
+
+            // Get the last error code so that it won't be affected by END_TEMP_ALLOCATOR.
+            if (compareResult == 0)
+            {
+                lastError = GetLastError();
+            }
         }
         END_TEMP_ALLOCATOR(tempAllocator, scriptContext);
 
@@ -1043,7 +1050,7 @@ namespace Js
             return JavascriptNumber::ToVar(compareResult - 2, scriptContext);//Convert 1,2,3 to -1,0,1
         }
 
-        JavascriptError::MapAndThrowError(scriptContext, HRESULT_FROM_WIN32(GetLastError()));
+        JavascriptError::MapAndThrowError(scriptContext, HRESULT_FROM_WIN32(lastError));
     }
 
     Var IntlEngineInterfaceExtensionObject::EntryIntl_CurrencyDigits(RecyclableObject* function, CallInfo callInfo, ...)


### PR DESCRIPTION
In certain cases, END_TEMP_ALLOCATOR would clear the last error code
after the CompareStringEx call, causing us to hit an assert in
JavascriptError::SetErrorMessage since the function expects a failure.
