### PR TITLE
Fixing a potential OOM point

### DIFF
--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -4810,18 +4810,23 @@ namespace Js
         // For Intl builtins, we need to make sure the Intl object has been initialized before fetching the
         // builtins from the EngineInterfaceObject. This is because the builtins are actually created via
         // Intl.js and are registered into the EngineInterfaceObject as part of Intl object initialization.
+        JavascriptExceptionObject * caughtExceptionObject = nullptr;
         try
         {
             this->IntlObject->GetTypeHandler()->EnsureObjectReady(this->IntlObject);
-        } catch (JavascriptExceptionObject *e)
+        } 
+        catch (JavascriptExceptionObject *e)
         {
-            // Propagate the OOM and SOE exceptions only
-            if (e == ThreadContext::GetContextForCurrentThread()->GetPendingOOMErrorObject() ||
-                e == ThreadContext::GetContextForCurrentThread()->GetPendingSOErrorObject())
-            {
-                e = e->CloneIfStaticExceptionObject(scriptContext);
-                throw e;
-            }
+            caughtExceptionObject = e;
+        }
+
+        // Propagate the OOM and SOE exceptions only
+        if (caughtExceptionObject != nullptr &&
+            (caughtExceptionObject == ThreadContext::GetContextForCurrentThread()->GetPendingOOMErrorObject() ||
+            caughtExceptionObject == ThreadContext::GetContextForCurrentThread()->GetPendingSOErrorObject()))
+        {
+            caughtExceptionObject = caughtExceptionObject->CloneIfStaticExceptionObject(scriptContext);
+            throw caughtExceptionObject;
         }
     }
 


### PR DESCRIPTION
I stumbled across this piece of code while inestigating another issue. We are calling CloneIfStaticExceptionObject inside a catch. This could potentially throw OOM if the caught exception was an out of memory exception. Changing the code here to conform to the pattern used at other places - save the exception object in a local and take action on that local outside the catch. This reduces the chances of an OOM being thrown as the stack would have been unwound when we get outside the catch block.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/728)
<!-- Reviewable:end -->
