### PR TITLE
OS4927797: TypeofElem fastpath mishandling out-of-range scenario

### DIFF
--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -2458,8 +2458,11 @@ CommonNumber:
             Var member;
 
             // If the item is found in the array own body, then it is a number
-            if (JavascriptOperators::GetOwnItem(object, index, &member, scriptContext))
+            if (JavascriptOperators::GetOwnItem(object, index, &member, scriptContext)
+                && !JavascriptOperators::IsUndefined(member))
+            {
                 return TRUE;
+            }
         }
         return FALSE;
     }

--- a/test/typedarray/rlexe.xml
+++ b/test/typedarray/rlexe.xml
@@ -321,4 +321,11 @@ Below test fails with difference in space. Investigate the cause and re-enable t
       <compile-flags>-mic:1 -off:simplejit -off:JITLoopBody -mmoc:0</compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>typedarray_bugfixes.js</files>
+      <compile-flags>-Off:Deferparse -args summary -endargs</compile-flags>
+      <tags>BugFix</tags>
+    </default>
+  </test>
 </regress-exe>

--- a/test/typedarray/typedarray_bugfixes.js
+++ b/test/typedarray/typedarray_bugfixes.js
@@ -1,0 +1,25 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+
+var tests = [
+  {
+    name: "OS4927797: TypeofElem fastpath mishandling out-of-range scenario",
+    body: function () {
+        assert.areEqual("undefined", typeof new Int8Array()[NaN & 0XF], "TypeofElem should return 'undefined' for out-of-range situation in Int8Array");
+        assert.areEqual("undefined", typeof new Uint8Array()[NaN & 0XF], "TypeofElem should return 'undefined' for out-of-range situation in Uint8Array");
+        assert.areEqual("undefined", typeof new Uint8ClampedArray()[NaN & 0XF], "TypeofElem should return 'undefined' for out-of-range situation in Uint8ClampedArray");
+        assert.areEqual("undefined", typeof new Int16Array()[NaN & 0XF], "TypeofElem should return 'undefined' for out-of-range situation in Int16Array");
+        assert.areEqual("undefined", typeof new Uint16Array()[NaN & 0XF], "TypeofElem should return 'undefined' for out-of-range situation in Uint16Array");
+        assert.areEqual("undefined", typeof new Int32Array()[NaN & 0XF], "TypeofElem should return 'undefined' for out-of-range situation in Int32Array");
+        assert.areEqual("undefined", typeof new Uint32Array()[NaN & 0XF], "TypeofElem should return 'undefined' for out-of-range situation in Uint32Array");
+        assert.areEqual("undefined", typeof new Float32Array()[NaN & 0XF], "TypeofElem should return 'undefined' for out-of-range situation in Float32Array");
+        assert.areEqual("undefined", typeof new Float64Array()[NaN & 0XF], "TypeofElem should return 'undefined' for out-of-range situation in Float64Array");
+    }
+  },
+];
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });


### PR DESCRIPTION
Fastpaths for opcode 'TypeofElem' mistakenly return 'number' for certain out-of-range situations.
Fix by adding check 'undefined' for return values in the fastpaths.
