### PR TITLE
Fixing debug-only race condition during RecordNativeCodeSize

### DIFF
--- a/lib/Backend/CodeGenWorkItem.cpp
+++ b/lib/Backend/CodeGenWorkItem.cpp
@@ -206,12 +206,7 @@ void CodeGenWorkItem::RecordNativeCodeSize(Func *func, size_t bytes, ushort pdat
     bool canAllocInPreReservedHeapPageSegment = func->CanAllocInPreReservedHeapPageSegment();
 #endif
     EmitBufferAllocation *allocation = func->GetEmitBufferManager()->AllocateBuffer(bytes, &buffer, pdataCount, xdataSize, canAllocInPreReservedHeapPageSegment, true);
-
-#if DBG
-    MEMORY_BASIC_INFORMATION memBasicInfo;
-    size_t resultBytes = VirtualQuery(allocation->allocation->address, &memBasicInfo, sizeof(memBasicInfo));
-    Assert(resultBytes != 0 && memBasicInfo.Protect == PAGE_EXECUTE);
-#endif
+    Assert(func->GetEmitBufferManager()->IsBufferExecuteReadOnly(allocation));
 
     Assert(allocation != nullptr);
     if (buffer == nullptr)

--- a/lib/Backend/EmitBuffer.cpp
+++ b/lib/Backend/EmitBuffer.cpp
@@ -327,6 +327,17 @@ bool EmitBufferManager<SyncObject>::CheckCommitFaultInjection()
 
 #endif
 
+#if DBG
+template <typename SyncObject>
+bool EmitBufferManager<SyncObject>::IsBufferExecuteReadOnly(EmitBufferAllocation * allocation)
+{
+    AutoRealOrFakeCriticalSection<SyncObject> autoCs(&this->criticalSection);
+    MEMORY_BASIC_INFORMATION memBasicInfo;
+    size_t resultBytes = VirtualQuery(allocation->allocation->address, &memBasicInfo, sizeof(memBasicInfo));
+    return resultBytes != 0 && memBasicInfo.Protect == PAGE_EXECUTE;
+}
+#endif
+
 template <typename SyncObject>
 bool EmitBufferManager<SyncObject>::ProtectBufferWithExecuteReadWriteForInterpreter(EmitBufferAllocation* allocation)
 {

--- a/lib/Backend/EmitBuffer.h
+++ b/lib/Backend/EmitBuffer.h
@@ -55,6 +55,10 @@ public:
     void CheckBufferPermissions(EmitBufferAllocation *allocation);
 #endif
 
+#if DBG
+    bool IsBufferExecuteReadOnly(EmitBufferAllocation * allocation);
+#endif
+
     EmitBufferAllocation * allocations;
 
 private:


### PR DESCRIPTION
The VirtualQuery in CodeGenWorkItem is unprotected without lock. Hence the
assert that is checking for the protect state of the page might not always
be true.

Fix:
Moved the VirtualQuery to EmitBuffer under a lock. This query is still
debug-only.
