### PR TITLE
[wasm] Fixed return type check bug

### DIFF
--- a/lib/WasmReader/WasmByteCodeGenerator.cpp
+++ b/lib/WasmReader/WasmByteCodeGenerator.cpp
@@ -1068,6 +1068,7 @@ WasmBytecodeGenerator::GetConstReg(T constVal)
 EmitInfo
 WasmBytecodeGenerator::EmitReturnExpr(EmitInfo *lastStmtExprInfo)
 {
+    EmitInfo retExprInfo;
     if (m_funcInfo->GetResultType() == WasmTypes::Void)
     {
         // TODO (michhol): consider moving off explicit 0 for return reg
@@ -1075,7 +1076,6 @@ WasmBytecodeGenerator::EmitReturnExpr(EmitInfo *lastStmtExprInfo)
     }
     else
     {
-        EmitInfo retExprInfo;
         if (lastStmtExprInfo)
         {
             retExprInfo = *lastStmtExprInfo;
@@ -1107,14 +1107,9 @@ WasmBytecodeGenerator::EmitReturnExpr(EmitInfo *lastStmtExprInfo)
         }
 
         m_writer.Conv(retOp, 0, retExprInfo.location);
-        if (!lastStmtExprInfo)
-        {
-            ReleaseLocation(&retExprInfo);
-        }
     }
     m_writer.AsmBr(m_funcInfo->GetExitLabel());
-
-    return EmitInfo();
+    return retExprInfo;
 }
 
 EmitInfo

--- a/test/wasm/ret.js
+++ b/test/wasm/ret.js
@@ -1,0 +1,9 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft Corporation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+const blob = WScript.LoadBinaryFile('ret.wasm');
+const moduleBytesView = new Uint8Array(blob);
+var a = Wasm.instantiateModule(moduleBytesView, {}).exports;
+print(a.foo()) // == 2

--- a/test/wasm/ret.wast
+++ b/test/wasm/ret.wast
@@ -1,0 +1,10 @@
+;;-------------------------------------------------------------------------------------------------------
+;; Copyright (C) Microsoft Corporation and contributors. All rights reserved.
+;; Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+;;-------------------------------------------------------------------------------------------------------
+
+(module
+  (func  (result i32)
+    (if (i32.const 1) (return (i32.const 2)) (return (i32.const 3))))
+  (export "foo" 0)
+)


### PR DESCRIPTION
Previously, the type of the return was not passed up.
This precluded expressions with returns in the body.
