### PR TITLE
Profiler for call with flags does not check the call flags to see if the call is a new call

### DIFF
--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -3761,7 +3761,8 @@ namespace Js
         DynamicProfileInfo * dynamicProfileInfo = functionBody->GetDynamicProfileInfo();
         FunctionInfo* functionInfo = function->GetTypeId() == TypeIds_Function?
             JavascriptFunction::FromVar(function)->GetFunctionInfo() : nullptr;
-        dynamicProfileInfo->RecordCallSiteInfo(functionBody, profileId, functionInfo, functionInfo ? static_cast<JavascriptFunction*>(function) : nullptr, playout->ArgCount, false, inlineCacheIndex);
+        bool isConstructorCall = (CallFlags_New & flags) == CallFlags_New;
+        dynamicProfileInfo->RecordCallSiteInfo(functionBody, profileId, functionInfo, functionInfo ? static_cast<JavascriptFunction*>(function) : nullptr, playout->ArgCount, isConstructorCall, inlineCacheIndex);
         OP_CallCommon<T>(playout, function, flags, spreadIndices);
         if (playout->Return != Js::Constants::NoRegister)
         {

--- a/test/es6/classes_bug_OS_7100885.js
+++ b/test/es6/classes_bug_OS_7100885.js
@@ -1,0 +1,20 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+// OS 7100885: With -maxsimplejitruncount:4 -maxinterpretcount:4, crashes due to incorrect profile data
+
+class class2 { }
+for (var i = 0; i < 10; i++) {
+  class class8 extends class2 {
+    constructor() {
+      super();
+      class2 = Boolean;
+    }
+  }
+  new class8()
+  new class8()
+}
+
+print('pass');

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -325,6 +325,13 @@
   </test>
   <test>
     <default>
+      <files>classes_bug_OS_7100885.js</files>
+      <compile-flags>-maxsimplejitruncount:4 -maxinterpretcount:4</compile-flags>
+      <tags>BugFix</tags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>ES6SubclassableBuiltins.js</files>
       <compile-flags>-ES6Classes -ES6Spread -ES6Generators -Off:Deferparse -args summary -endargs</compile-flags>
     </default>


### PR DESCRIPTION
This only really happens when we are doing a super call in a derived class
constructor. That call is using ProfiledCallIFlags opcode to pass the new
flag and new target flags in the call info. When we get to the helper,
OP_ProfileCallCommon, we need to check the flags to see if we have the new
flag and pass that to RecordCallSiteInfo.

Previously we ignored the flags and always passed false for
isConstructorCall. This could lead to an assert as in the attached test
case.
