### PR TITLE
Trivial CallFlags issue in jitted code

### DIFF
--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -21175,7 +21175,10 @@ Lowerer::LowerSpreadCall(IR::Instr *instr, Js::CallFlags callFlags, bool setupPr
     instr->ReplaceSrc2(spreadIndicesInstr->UnlinkSrc2());
 
     // Emit the normal args
-    callFlags = (Js::CallFlags)(callFlags | (instr->GetDst() ? Js::CallFlags_Value : Js::CallFlags_NotUsed));
+    if (!(callFlags & Js::CallFlags_New))
+    {
+        callFlags = (Js::CallFlags)(callFlags | (instr->GetDst() ? Js::CallFlags_Value : Js::CallFlags_NotUsed));
+    }
 
     // Profiled helper call requires three more parameters, ArrayProfileId, profileId, and the frame pointer.
     // This is just following the convention of HelperProfiledNewScObjArray call.


### PR DESCRIPTION
Fix an inconsistency between interpreter and JIT in the passing of call flags. Constructor calls with spread arguments were getting CallFlags_Value in jitted code but not interpreter, which exposed some weirdness in the Error constructor. (Suwei and/or Taylor are looking into that issue.)