### PR TITLE
Fix inline cache assert with BoundFunction

### DIFF
--- a/lib/Runtime/Library/BoundFunction.cpp
+++ b/lib/Runtime/Library/BoundFunction.cpp
@@ -35,6 +35,11 @@ namespace Js
         RecyclableObject* proto = JavascriptOperators::GetPrototype(targetFunction);
         if (proto != type->GetPrototype())
         {
+            if (type->GetIsShared())
+            {
+                this->ChangeType();
+                type = this->GetDynamicType();
+            }
             type->SetPrototype(proto);
         }
         // If targetFunction is proxy, need to make sure that traps are called in right order as per 19.2.3.2 in RC#4 dated April 3rd 2015.

--- a/test/Function/bind.baseline
+++ b/test/Function/bind.baseline
@@ -76,6 +76,7 @@ PASS: Construction :30
 PASS: Add Test:50
 PASS: f Test:11
 PASS: Proto Test:true
+PASS: Proto toString Test:[object Function]
 PASS: TestConstruction0 x:0
 PASS: TestConstruction0 y:1
 PASS: TestConstruction1 x:100

--- a/test/Function/bind.js
+++ b/test/Function/bind.js
@@ -187,6 +187,10 @@ function testProto()
     var f2 = new f();
 
     Verify("Proto Test", add.prototype.isPrototypeOf(f2), true);
+
+    // Test toString inline cache behavior when a bound function has a non-typical prototype
+    var a = decodeURIComponent.bind().toString;
+    Verify("Proto toString Test", Function.prototype.bind(), '[object Function]');
 }
 
 function testConstruction1()


### PR DESCRIPTION
When we create a bound function, we set its prototype to match the prototype of the target function. Typically this is the Function prototype. But if it isn't, we can't set the prototype of the new instance without changing the prototype of all the other bound functions that are sharing the type. If the type is shared, and the new prototype doesn't match, create a new type for the new instance.