### PR TITLE
should only do debug reparse if we are actually reparsing

### DIFF
--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -1656,10 +1656,7 @@ namespace Js
         Recycler* recycler = this->m_scriptContext->GetRecycler();
         propertyRecordList = RecyclerNew(recycler, Js::PropertyRecordList, recycler);
 
-        bool isDebugReparse = m_scriptContext->IsScriptContextInSourceRundownOrDebugMode() && !this->GetUtf8SourceInfo()->GetIsLibraryCode();
-        bool isAsmJsReparse = false;
-        bool isReparse = isDebugReparse;
-
+        bool isDebugOrAsmJsReparse = false;
         FunctionBody* funcBody = nullptr;
 
         // If m_hasBeenParsed = true, one of the following things happened things happened:
@@ -1737,11 +1734,14 @@ namespace Js
         }
         else
         {
-            isAsmJsReparse = m_isAsmjsMode && !isDebugReparse;
-            isReparse |= isAsmJsReparse;
+            bool isDebugReparse = m_scriptContext->IsScriptContextInSourceRundownOrDebugMode() && !this->GetUtf8SourceInfo()->GetIsLibraryCode();
+            bool isAsmJsReparse = m_isAsmjsMode && !isDebugReparse;
+
+            isDebugOrAsmJsReparse = isAsmJsReparse || isDebugReparse;
+
             funcBody = this->GetFunctionBody();
 
-            if (isReparse)
+            if (isDebugOrAsmJsReparse)
             {
     #if ENABLE_DEBUG_CONFIG_OPTIONS
                 char16 debugStringBuffer[MAX_FUNCTION_BODY_DEBUG_STRING_SIZE];
@@ -1772,7 +1772,7 @@ namespace Js
             Assert(!funcBody->HasExecutionDynamicProfileInfo());
 #endif
             // In debug or asm.js mode, the scriptlet will be asked to recompile again.
-            AssertMsg(isReparse || funcBody->GetGrfscr() & fscrGlobalCode || CONFIG_FLAG(DeferNested), "Deferred parsing of non-global procedure?");
+            AssertMsg(isDebugOrAsmJsReparse || funcBody->GetGrfscr() & fscrGlobalCode || CONFIG_FLAG(DeferNested), "Deferred parsing of non-global procedure?");
 
             HRESULT hr = NO_ERROR;
             HRESULT hrParser = NO_ERROR;
@@ -1802,12 +1802,12 @@ namespace Js
                     // (not a function declaration statement).
                     grfscr |= fscrDeferredFncExpression;
                 }
-                if (!CONFIG_FLAG(DeferNested) || isDebugReparse || isAsmJsReparse)
+                if (!CONFIG_FLAG(DeferNested) || isDebugOrAsmJsReparse)
                 {
                     grfscr &= ~fscrDeferFncParse; // Disable deferred parsing if not DeferNested, or doing a debug/asm.js re-parse
                 }
 
-                if (isReparse)
+                if (isDebugOrAsmJsReparse)
                 {
                     grfscr |= fscrNoAsmJs; // Disable asm.js when debugging or if linking failed
                 }
@@ -1822,7 +1822,7 @@ namespace Js
                     hrParser = ps.ParseSourceWithOffset(&parseTree, pszStart, offset, length, charOffset, isCesu8, grfscr, &se,
                         &nextFunctionId, funcBody->GetRelativeLineNumber(), funcBody->GetSourceContextInfo(),
                         funcBody);
-                    Assert(FAILED(hrParser) || nextFunctionId == funcBody->deferredParseNextFunctionId || isReparse || isByteCodeDeserialization);
+                    Assert(FAILED(hrParser) || nextFunctionId == funcBody->deferredParseNextFunctionId || isDebugOrAsmJsReparse || isByteCodeDeserialization);
 
                     if (FAILED(hrParser))
                     {
@@ -1834,7 +1834,7 @@ namespace Js
                         TRACE_BYTECODE(_u("\nDeferred parse %s\n"), funcBody->GetDisplayName());
                         Js::AutoDynamicCodeReference dynamicFunctionReference(m_scriptContext);
 
-                        bool forceNoNative = isReparse ? this->GetScriptContext()->IsInterpreted() : false;
+                        bool forceNoNative = isDebugOrAsmJsReparse ? this->GetScriptContext()->IsInterpreted() : false;
                         hrParseCodeGen = GenerateByteCode(parseTree, grfscr, m_scriptContext,
                             funcBody->GetParseableFunctionInfoRef(), funcBody->GetSourceIndex(),
                             forceNoNative, &ps, &se, funcBody->GetScopeInfo(), functionRef);


### PR DESCRIPTION
In some cases this was causing us to disable asm.js even in SourceRundown mode, because we were incorrectly identifying the function as being debug reparsed, when it was really just being defer parsed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/753)
<!-- Reviewable:end -->
