### PR TITLE
Simple fix to stack closures in jitted loop bodies

### DIFF
--- a/lib/Runtime/Library/StackScriptFunction.h
+++ b/lib/Runtime/Library/StackScriptFunction.h
@@ -58,7 +58,7 @@ namespace Js
             Var * BoxScopeSlots(Var * scopeSlots, uint count);
             bool NeedBoxFrame(FunctionBody * functionBody);
             bool NeedBoxScriptFunction(ScriptFunction * scriptFunction);
-            ScriptFunction * BoxStackFunction(StackScriptFunction * scriptFunction);
+            ScriptFunction * BoxStackFunction(ScriptFunction * scriptFunction);
             FrameDisplay * BoxFrameDisplay(FrameDisplay * frameDisplay);
             FrameDisplay * GetFrameDisplayFromNativeFrame(JavascriptStackWalker const& walker, FunctionBody * callerFunctionBody);
             Var * GetScopeSlotsFromNativeFrame(JavascriptStackWalker const& walker, FunctionBody * callerFunctionBody);

--- a/test/stackfunc/box_jitloopbody3.js
+++ b/test/stackfunc/box_jitloopbody3.js
@@ -1,0 +1,33 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+var obj1 = {};
+var func2 = function () {
+    function v1() {
+        arguments;
+    }
+    for (var v4 = 0; v4 < 2; v4++) {
+        v1();
+        function v5() {
+            if (v4 < 10) {
+                return;
+            }
+            for (; ; __loopvar6) {
+            }
+        }
+        function v8() {
+            return v5();
+        }
+        function v9() {
+            return v8();
+        }
+        v9();
+    }
+};
+obj1.method0 = func2;
+(function () {
+})(obj1.method0());
+
+WScript.Echo('pass');

--- a/test/stackfunc/rlexe.xml
+++ b/test/stackfunc/rlexe.xml
@@ -647,6 +647,13 @@
   </test>
   <test>
     <default>
+      <files>box_jitloopbody3.js</files>
+      <compile-flags>-forcejitloopbody -force:deferparse -bgjit-</compile-flags>
+      <tags>exclude_fre,exclude_arm</tags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>602481.js</files>
       <tags>exclude_dynapogo</tags>
     </default>


### PR DESCRIPTION
In jitted loop bodies, we may have stack-allocated closures but not create stack-allocated functions inside block scopes. Let BoxScopeSlots call BoxStackFunction for functions not on stack to make sure that any stack closures get boxed.