### PR TITLE
MSFT: 6646000 Missing cross-site thunk for boundFunction

### DIFF
--- a/lib/Runtime/Library/BoundFunction.cpp
+++ b/lib/Runtime/Library/BoundFunction.cpp
@@ -145,6 +145,7 @@ namespace Js
 
         if (boundFunction->count > 0)
         {
+            BOOL isCrossSiteObject = boundFunction->IsCrossSiteObject();
             // OACR thinks that this can change between here and the check in the for loop below
             const unsigned int argCount = args.Info.Count;
 
@@ -171,9 +172,20 @@ namespace Js
             }
 
             // Copy the bound args
-            for (uint i=0; i<boundFunction->count; i++)
+            if (!isCrossSiteObject)
             {
-                newValues[index++] = boundFunction->boundArgs[i];
+                for (uint i = 0; i < boundFunction->count; i++)
+                {
+                    newValues[index++] = boundFunction->boundArgs[i];
+                }
+            }
+            else
+            {
+                // it is possible that the bound arguments are not marshalled yet.
+                for (uint i = 0; i < boundFunction->count; i++)
+                {
+                    newValues[index++] = CrossSite::MarshalVar(scriptContext, boundFunction->boundArgs[i]);
+                }
             }
 
             // Copy the extra args
@@ -207,6 +219,19 @@ namespace Js
 
         return aReturnValue;
     }
+
+    void BoundFunction::MarshalToScriptContext(Js::ScriptContext * scriptContext)
+    {
+        Assert(this->GetScriptContext() != scriptContext);
+        AssertMsg(VirtualTableInfo<BoundFunction>::HasVirtualTable(this), "Derived class need to define marshal to script context");
+        VirtualTableInfo<Js::CrossSiteObject<BoundFunction>>::SetVirtualTable(this);
+        this->targetFunction = (RecyclableObject*)CrossSite::MarshalVar(scriptContext, this->targetFunction);
+        for (uint i = 0; i < count; i++)
+        {
+            this->boundArgs[i] = CrossSite::MarshalVar(scriptContext, this->boundArgs[i]);
+        }
+    }
+
 
     JavascriptFunction * BoundFunction::GetTargetFunction() const
     {

--- a/lib/Runtime/Library/BoundFunction.cpp
+++ b/lib/Runtime/Library/BoundFunction.cpp
@@ -226,9 +226,10 @@ namespace Js
         AssertMsg(VirtualTableInfo<BoundFunction>::HasVirtualTable(this), "Derived class need to define marshal to script context");
         VirtualTableInfo<Js::CrossSiteObject<BoundFunction>>::SetVirtualTable(this);
         this->targetFunction = (RecyclableObject*)CrossSite::MarshalVar(scriptContext, this->targetFunction);
+        this->boundThis = (RecyclableObject*)CrossSite::MarshalVar(this->GetScriptContext(), this->boundThis);
         for (uint i = 0; i < count; i++)
         {
-            this->boundArgs[i] = CrossSite::MarshalVar(scriptContext, this->boundArgs[i]);
+            this->boundArgs[i] = CrossSite::MarshalVar(this->GetScriptContext(), this->boundArgs[i]);
         }
     }
 

--- a/lib/Runtime/Library/BoundFunction.h
+++ b/lib/Runtime/Library/BoundFunction.h
@@ -10,7 +10,7 @@ namespace Js
     {
     protected:
         DEFINE_VTABLE_CTOR(BoundFunction, JavascriptFunction);
-        DEFINE_MARSHAL_OBJECT_TO_SCRIPT_CONTEXT(BoundFunction);
+        virtual void MarshalToScriptContext(Js::ScriptContext * scriptContext) override;
 
     private:
         bool GetPropertyBuiltIns(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext, BOOL* result);

--- a/test/Function/crosssite_bind_child.js
+++ b/test/Function/crosssite_bind_child.js
@@ -4,6 +4,6 @@
 //-------------------------------------------------------------------------------------------------------
 function setupFunc(inFunc)
 {
-var result = inFunc.bind(inFunc, "one");
-return result;
+    var result = inFunc.bind(inFunc, "one");
+    return result;
 }

--- a/test/Function/crosssite_bind_child.js
+++ b/test/Function/crosssite_bind_child.js
@@ -1,0 +1,9 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+function setupFunc(inFunc)
+{
+var result = inFunc.bind(inFunc, "one");
+return result;
+}

--- a/test/Function/crosssite_bind_main.js
+++ b/test/Function/crosssite_bind_main.js
@@ -1,0 +1,16 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+function mainFunc(inName) {
+  for (i in this) {
+    if (i == inName) {
+       WScript.Echo("PASS");
+    }
+  }
+}
+
+mainFunc.one = 20;
+child = WScript.LoadScriptFile("crosssite_bind_child.js", "samethread");
+childFunc = child.setupFunc(mainFunc);
+childFunc();

--- a/test/Function/rlexe.xml
+++ b/test/Function/rlexe.xml
@@ -400,6 +400,11 @@
   </test>
   <test>
     <default>
+      <files>crosssite_bind_main.js</files>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>failnativecodeinstall.js</files>
       <compile-flags>/maxinterpretcount:2 /lic:1 /bgjit /off:simplejit /on:failnativecodeinstall</compile-flags>
       <tags>exclude_dynapogo,require_backend</tags>


### PR DESCRIPTION
We didn't add cross-site thunk for BoundFunction. Also, the bound arguments
could be from different scriptcontext if the bind happen in a different context and
execution happens in original context. Add the missing cross-site checks
