### PR TITLE
Fix exception path when excpeption is thrown while processing jit transfer data

### DIFF
--- a/lib/Backend/Backend.cpp
+++ b/lib/Backend/Backend.cpp
@@ -106,6 +106,18 @@ CheckCodeGenFunction GetCheckCodeGenFunction(Js::JavascriptMethod codeAddress)
     return NativeCodeGenerator::GetCheckCodeGenFunction(codeAddress);
 }
 
+Js::JavascriptMethod GetCheckCodeGenThunk()
+{
+    return NativeCodeGenerator::CheckCodeGenThunk;
+}
+
+#ifdef ASMJS_PLAT
+Js::JavascriptMethod GetCheckAsmJsCodeGenThunk()
+{
+    return NativeCodeGenerator::CheckAsmJsCodeGenThunk;
+}
+#endif
+
 uint GetBailOutRegisterSaveSlotCount()
 {
     // REVIEW: not all registers are used, we are allocating more space then necessary.

--- a/lib/Common/BackendApi.h
+++ b/lib/Common/BackendApi.h
@@ -73,6 +73,10 @@ BOOL IsIntermediateCodeGenThunk(Js::JavascriptMethod codeAddress);
 BOOL IsAsmJsCodeGenThunk(Js::JavascriptMethod codeAddress);
 typedef Js::JavascriptMethod (*CheckCodeGenFunction)(Js::ScriptFunction * function);
 CheckCodeGenFunction GetCheckCodeGenFunction(Js::JavascriptMethod codeAddress);
+Js::JavascriptMethod GetCheckCodeGenThunk();
+#ifdef ASMJS_PLAT
+Js::JavascriptMethod GetCheckAsmJsCodeGenThunk();
+#endif
 
 uint GetBailOutRegisterSaveSlotCount();
 uint GetBailOutReserveSlotCount();

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -568,7 +568,7 @@ namespace Js
         FieldAccessStats* EnsureFieldAccessStats(Recycler* recycler);
 #endif
 
-        void  PinTypeRefs(ScriptContext* scriptContext);
+        void PinTypeRefs(ScriptContext* scriptContext);
         void InstallGuards(ScriptContext* scriptContext);
 #endif
 
@@ -843,8 +843,9 @@ namespace Js
 
         void EnsureIsReadyToCall();
         void ProcessJitTransferData();
-        void ResetOnNativeCodeInstallFailure();
-        virtual void OnNativeCodeInstallFailure() = 0;
+        void ResetOnLazyBailoutFailure();
+        void OnNativeCodeInstallFailure();
+        virtual void ResetOnNativeCodeInstallFailure() = 0;
 
         Js::PropertyGuard* RegisterSharedPropertyGuard(Js::PropertyId propertyId, ScriptContext* scriptContext);
         bool HasSharedPropertyGuards() { return this->sharedPropertyGuards != nullptr; }
@@ -963,7 +964,7 @@ namespace Js
         virtual void Invalidate(bool prolongEntryPoint) override;
         virtual void Expire() override;
         virtual void EnterExpirableCollectMode() override;
-        virtual void OnNativeCodeInstallFailure() override;
+        virtual void ResetOnNativeCodeInstallFailure() override;
 #endif
 
         virtual void OnCleanup(bool isShutdown) override;
@@ -993,7 +994,7 @@ namespace Js
         virtual void OnCleanup(bool isShutdown) override;
 
 #if ENABLE_NATIVE_CODEGEN
-        virtual void OnNativeCodeInstallFailure() override;
+        virtual void ResetOnNativeCodeInstallFailure() override;
 #endif
 
 #ifndef TEMP_DISABLE_ASMJS


### PR DESCRIPTION
After generating the jitted code for a function, we pin type references and install property guards on the entryPointInfo. If either one of these throws (OOM/SO, for example), we execute an object destructor that calls a function that allocates a new entryPointInfo. This is a problem if we were throwing an OOM exception. Apart from exceptions, this function can be called when we lazily bailout - in that case, it is ok to create a new entry point info and generate jitted code for it. In fact, we have to do this, otherwise we'll keep bailing out. For OOM scenarios, we dont really have to create a new default entry point info- we could just change the entry point to CheckCodeGenThunk. If the exception was caught and the function was called again, it'll re-use the jitted code and attempt to pin type refs and install property guards again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/763)
<!-- Reviewable:end -->
