### PR TITLE
Add new cross-platform APIs to Jsrt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ Build/VCBuild/
 Build/VCBuild.NoJIT/
 Build/ipch/
 Build/.vs/
+Build/Chakra.Core.VC.db
 build_*.log
 build_*.wrn
 build_*.err

--- a/lib/Jsrt/ChakraCommon.h
+++ b/lib/Jsrt/ChakraCommon.h
@@ -34,7 +34,12 @@
 typedef DWORD_PTR ChakraCookie;
 typedef BYTE* ChakraBytePtr;
 #else // Non-Windows VC++
-#include <cstdint>
+#include <stdint.h>     // Needed for uintptr_t
+#ifndef __cplusplus
+#include <stdbool.h>    // Needed fo bool
+#include <stdio.h>      // for NULL
+#define nullptr NULL
+#endif
 
 // SAL compat
 #define _Return_type_success_(x)
@@ -60,7 +65,11 @@ typedef BYTE* ChakraBytePtr;
 #define CHAKRA_CALLBACK
 #endif // __i386__
 
-#define CHAKRA_API extern "C" JsErrorCode
+#ifdef __cplusplus
+#define CHAKRA_API extern "C" JsErrorCode 
+#else
+#define CHAKRA_API JsErrorCode
+#endif
 
 typedef uintptr_t ChakraCookie;
 typedef unsigned char* ChakraBytePtr;
@@ -69,7 +78,7 @@ typedef unsigned char* ChakraBytePtr;
     /// <summary>
     ///     An error code returned from a Chakra hosting API.
     /// </summary>
-    typedef _Return_type_success_(return == 0) enum _JsErrorCode : unsigned int
+    typedef _Return_type_success_(return == 0) enum _JsErrorCode 
     {
         /// <summary>
         ///     Success error code.
@@ -564,9 +573,11 @@ typedef unsigned char* ChakraBytePtr;
     /// <param name="callbackState">The data argument to be passed to the callback.</param>
     typedef bool (CHAKRA_CALLBACK *JsThreadServiceCallback)(_In_ JsBackgroundWorkItemCallback callback, _In_opt_ void *callbackState);
 
+#ifdef _WIN32
     /// <summary>
     ///     Called by the runtime to load the source code of the serialized script.
     ///     The caller must keep the script buffer valid until the JsSerializedScriptUnloadCallback.
+    ///     This callback is only supported by the Win32 version of the API
     /// </summary>
     /// <param name="sourceContext">The context passed to Js[Parse|Run]SerializedScriptWithCallback</param>
     /// <param name="scriptBuffer">The script returned.</param>
@@ -574,6 +585,7 @@ typedef unsigned char* ChakraBytePtr;
     ///     true if the operation succeeded, false otherwise.
     /// </returns>
     typedef bool (CHAKRA_CALLBACK * JsSerializedScriptLoadSourceCallback)(_In_ JsSourceContext sourceContext, _Outptr_result_z_ const wchar_t** scriptBuffer);
+#endif // _WIN32
 
     /// <summary>
     ///     Called by the runtime when it is finished with all resources related to the script execution.

--- a/lib/Jsrt/ChakraCommon.h
+++ b/lib/Jsrt/ChakraCommon.h
@@ -23,8 +23,49 @@
 #ifndef _CHAKRACOMMON_H_
 #define _CHAKRACOMMON_H_
 
+// Platform specific code
+#if defined(_WIN32) && defined(_MSC_VER)
 #include <oaidl.h>
 
+// Header macros
+#define CHAKRA_CALLBACK CALLBACK
+#define CHAKRA_API STDAPI_(JsErrorCode)
+
+typedef DWORD_PTR ChakraCookie;
+typedef BYTE* ChakraBytePtr;
+#else
+#include <cstdint>
+
+// SAL compat
+#define _Return_type_success_(x)
+#define _In_
+#define _In_z_
+#define _In_opt_
+#define _Inout_
+#define _Out_
+#define _Out_opt_
+#define _In_reads_(x)
+#define _Pre_maybenull_
+#define _Pre_writable_byte_size_(byteLength)
+#define _Outptr_result_buffer_(byteLength)
+#define _Outptr_result_bytebuffer_(byteLength)
+#define _Outptr_result_z_
+#define _Ret_maybenull_
+#define _Out_writes_to_opt_(byteLength, byteLength2)
+
+// Header macros
+// REVIEW: What should we do here??
+#ifdef __i386___
+#define CHAKRA_CALLBACK __attribute__((cdecl))
+#else
+#define CHAKRA_CALLBACK
+#endif
+
+#define CHAKRA_API extern "C" JsErrorCode
+
+typedef uintptr_t ChakraCookie;
+typedef unsigned char* ChakraBytePtr;
+#endif
 
 
     /// <summary>
@@ -210,7 +251,7 @@
     /// <summary>
     ///     An invalid runtime handle.
     /// </summary>
-    const JsRuntimeHandle JS_INVALID_RUNTIME_HANDLE = NULL;
+    const JsRuntimeHandle JS_INVALID_RUNTIME_HANDLE = nullptr;
 
     /// <summary>
     ///     A reference to an object owned by the Chakra garbage collector.
@@ -227,7 +268,7 @@
     /// <summary>
     ///     An invalid reference.
     /// </summary>
-    const JsRef JS_INVALID_REFERENCE = NULL;
+    const JsRef JS_INVALID_REFERENCE = nullptr;
 
     /// <summary>
     ///     A reference to a script context.
@@ -257,7 +298,7 @@
     /// <summary>
     ///     A cookie that identifies a script for debugging purposes.
     /// </summary>
-    typedef DWORD_PTR JsSourceContext;
+    typedef ChakraCookie JsSourceContext;
 
     /// <summary>
     ///     An empty source context.
@@ -408,7 +449,7 @@
     ///     with the allocation. Returning false indicates the allocation request is rejected. The
     ///     return value is ignored for other allocation events.
     /// </returns>
-    typedef bool (CALLBACK * JsMemoryAllocationCallback)(_In_opt_ void *callbackState, _In_ JsMemoryEventType allocationEvent, _In_ size_t allocationSize);
+    typedef bool (CHAKRA_CALLBACK * JsMemoryAllocationCallback)(_In_opt_ void *callbackState, _In_ JsMemoryEventType allocationEvent, _In_ size_t allocationSize);
 
     /// <summary>
     ///     A callback called before collection.
@@ -417,7 +458,7 @@
     ///     Use <c>JsSetBeforeCollectCallback</c> to register this callback.
     /// </remarks>
     /// <param name="callbackState">The state passed to <c>JsSetBeforeCollectCallback</c>.</param>
-    typedef void (CALLBACK *JsBeforeCollectCallback)(_In_opt_ void *callbackState);
+    typedef void (CHAKRA_CALLBACK *JsBeforeCollectCallback)(_In_opt_ void *callbackState);
 
     /// <summary>
     ///     A callback called before collecting an object.
@@ -427,7 +468,7 @@
     /// </remarks>
     /// <param name="ref">The object to be collected.</param>
     /// <param name="callbackState">The state passed to <c>JsSetObjectBeforeCollectCallback</c>.</param>
-    typedef void (CALLBACK *JsObjectBeforeCollectCallback)(_In_ JsRef ref, _In_opt_ void *callbackState);
+    typedef void (CHAKRA_CALLBACK *JsObjectBeforeCollectCallback)(_In_ JsRef ref, _In_opt_ void *callbackState);
 
     /// <summary>
     ///     A background work item callback.
@@ -437,7 +478,7 @@
     ///     invoke the work item callback on the background thread of its choice.
     /// </remarks>
     /// <param name="callbackState">Data argument passed to the thread service.</param>
-    typedef void (CALLBACK *JsBackgroundWorkItemCallback)(_In_opt_ void *callbackState);
+    typedef void (CHAKRA_CALLBACK *JsBackgroundWorkItemCallback)(_In_opt_ void *callbackState);
 
     /// <summary>
     ///     A thread service callback.
@@ -450,7 +491,37 @@
     /// </remarks>
     /// <param name="callback">The callback for the background work item.</param>
     /// <param name="callbackState">The data argument to be passed to the callback.</param>
-    typedef bool (CALLBACK *JsThreadServiceCallback)(_In_ JsBackgroundWorkItemCallback callback, _In_opt_ void *callbackState);
+    typedef bool (CHAKRA_CALLBACK *JsThreadServiceCallback)(_In_ JsBackgroundWorkItemCallback callback, _In_opt_ void *callbackState);
+
+    /// <summary>
+    ///     Called by the runtime to load the source code of the serialized script.
+    ///     The caller must keep the script buffer valid until the JsSerializedScriptUnloadCallback.
+    /// </summary>
+    /// <param name="sourceContext">The context passed to Js[Parse|Run]SerializedScriptWithCallback</param>
+    /// <param name="scriptBuffer">The script returned.</param>
+    /// <returns>
+    ///     true if the operation succeeded, false otherwise.
+    /// </returns>
+    typedef bool (CHAKRA_CALLBACK * JsSerializedScriptLoadSourceCallback)(_In_ JsSourceContext sourceContext, _Outptr_result_z_ const wchar_t** scriptBuffer);
+
+    /// <summary>
+    ///     Called by the runtime when it is finished with all resources related to the script execution.
+    ///     The caller should free the source if loaded, the byte code, and the context at this time.
+    /// </summary>
+    /// <param name="sourceContext">The context passed to Js[Parse|Run]SerializedScriptWithCallback</param>
+    typedef void (CHAKRA_CALLBACK * JsSerializedScriptUnloadCallback)(_In_ JsSourceContext sourceContext);
+
+    /// <summary>
+    ///     Called by the runtime to load the source code of the serialized script.
+    ///     The caller must keep the script buffer valid until the JsSerializedScriptUnloadCallback.
+    /// </summary>
+    /// <param name="sourceContext">The context passed to Js[Parse|Run]SerializedScriptWithCallback</param>
+    /// <param name="scriptBuffer">The script returned, encoded as utf8.</param>
+    /// <returns>
+    ///     true if the operation succeeded, false otherwise.
+    /// </returns>
+    typedef bool (CHAKRA_CALLBACK * JsSerializedScriptLoadUtf8SourceCallback)(_In_ JsSourceContext sourceContext, _Outptr_result_z_ const char** scriptBuffer);
+
 
     /// <summary>
     ///     Creates a new runtime.
@@ -463,7 +534,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsCreateRuntime(
             _In_ JsRuntimeAttributes attributes,
             _In_opt_ JsThreadServiceCallback threadService,
@@ -476,7 +547,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsCollectGarbage(
             _In_ JsRuntimeHandle runtime);
 
@@ -492,7 +563,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsDisposeRuntime(
             _In_ JsRuntimeHandle runtime);
 
@@ -508,7 +579,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsGetRuntimeMemoryUsage(
             _In_ JsRuntimeHandle runtime,
             _Out_ size_t *memoryUsage);
@@ -527,7 +598,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsGetRuntimeMemoryLimit(
             _In_ JsRuntimeHandle runtime,
             _Out_ size_t *memoryLimit);
@@ -555,7 +626,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsSetRuntimeMemoryLimit(
             _In_ JsRuntimeHandle runtime,
             _In_ size_t memoryLimit);
@@ -590,7 +661,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsSetRuntimeMemoryAllocationCallback(
             _In_ JsRuntimeHandle runtime,
             _In_opt_ void *callbackState,
@@ -617,7 +688,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsSetRuntimeBeforeCollectCallback(
             _In_ JsRuntimeHandle runtime,
             _In_opt_ void *callbackState,
@@ -636,7 +707,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsAddRef(
             _In_ JsRef ref,
             _Out_opt_ unsigned int *count);
@@ -652,7 +723,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsRelease(
             _In_ JsRef ref,
             _Out_opt_ unsigned int *count);
@@ -676,7 +747,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsSetObjectBeforeCollectCallback(
             _In_ JsRef ref,
             _In_opt_ void *callbackState,
@@ -694,7 +765,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsCreateContext(
             _In_ JsRuntimeHandle runtime,
             _Out_ JsContextRef *newContext);
@@ -708,7 +779,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsGetCurrentContext(
             _Out_ JsContextRef *currentContext);
 
@@ -719,7 +790,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsSetCurrentContext(
             _In_ JsContextRef context);
 
@@ -731,7 +802,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsGetContextOfObject(
             _In_ JsValueRef object,
             _Out_ JsContextRef *context);
@@ -744,7 +815,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsGetContextData(
             _In_ JsContextRef context,
             _Out_ void **data);
@@ -757,7 +828,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsSetContextData(
             _In_ JsContextRef context,
             _In_ void *data);
@@ -770,7 +841,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsGetRuntime(
             _In_ JsContextRef context,
             _Out_ JsRuntimeHandle *runtime);
@@ -800,10 +871,11 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsIdle(
             _Out_opt_ unsigned int *nextIdleTick);
 
+#ifdef _WIN32
     /// <summary>
     ///     Parses a script and returns a function representing the script.
     /// </summary>
@@ -819,7 +891,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsParseScript(
             _In_z_ const wchar_t *script,
             _In_ JsSourceContext sourceContext,
@@ -842,7 +914,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsParseScriptWithAttributes(
             _In_z_ const wchar_t *script,
             _In_ JsSourceContext sourceContext,
@@ -865,7 +937,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsRunScript(
             _In_z_ const wchar_t *script,
             _In_ JsSourceContext sourceContext,
@@ -887,7 +959,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsExperimentalApiRunModule(
             _In_z_ const wchar_t *script,
             _In_ JsSourceContext sourceContext,
@@ -916,29 +988,11 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsSerializeScript(
             _In_z_ const wchar_t *script,
             _Out_writes_to_opt_(*bufferSize, *bufferSize) BYTE *buffer,
-            _Inout_ unsigned long *bufferSize);
-
-    /// <summary>
-    ///     Called by the runtime to load the source code of the serialized script.
-    ///     The caller must keep the script buffer valid until the JsSerializedScriptUnloadCallback.
-    /// </summary>
-    /// <param name="sourceContext">The context passed to Js[Parse|Run]SerializedScriptWithCallback</param>
-    /// <param name="scriptBuffer">The script returned.</param>
-    /// <returns>
-    ///     true if the operation succeeded, false otherwise.
-    /// </returns>
-    typedef bool (CALLBACK * JsSerializedScriptLoadSourceCallback)(_In_ JsSourceContext sourceContext, _Outptr_result_z_ const wchar_t** scriptBuffer);
-
-    /// <summary>
-    ///     Called by the runtime when it is finished with all resources related to the script execution.
-    ///     The caller should free the source if loaded, the byte code, and the context at this time.
-    /// </summary>
-    /// <param name="sourceContext">The context passed to Js[Parse|Run]SerializedScriptWithCallback</param>
-    typedef void (CALLBACK * JsSerializedScriptUnloadCallback)(_In_ JsSourceContext sourceContext);
+            _Inout_ unsigned int *bufferSize);
 
     /// <summary>
     ///     Parses a serialized script and returns a function representing the script.
@@ -966,7 +1020,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsParseSerializedScriptWithCallback(
             _In_ JsSerializedScriptLoadSourceCallback scriptLoadCallback,
             _In_ JsSerializedScriptUnloadCallback scriptUnloadCallback,
@@ -1003,7 +1057,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsRunSerializedScriptWithCallback(
             _In_ JsSerializedScriptLoadSourceCallback scriptLoadCallback,
             _In_ JsSerializedScriptUnloadCallback scriptUnloadCallback,
@@ -1034,7 +1088,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsParseSerializedScript(
             _In_z_ const wchar_t *script,
             _In_ BYTE *buffer,
@@ -1066,7 +1120,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsRunSerializedScript(
             _In_z_ const wchar_t *script,
             _In_ BYTE *buffer,
@@ -1092,7 +1146,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsGetPropertyIdFromName(
             _In_z_ const wchar_t *name,
             _Out_ JsPropertyIdRef *propertyId);
@@ -1114,10 +1168,247 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsGetPropertyNameFromId(
             _In_ JsPropertyIdRef propertyId,
             _Outptr_result_z_ const wchar_t **name);
+#endif
+
+    /// <summary>
+    ///     Parses a script and returns a function representing the script.
+    /// </summary>
+    /// <remarks>
+    ///     Requires an active script context.
+    /// </remarks>
+    /// <param name="script">The script to parse, encoded as utf8.</param>
+    /// <param name="sourceContext">
+    ///     A cookie identifying the script that can be used by debuggable script contexts.
+    /// </param>
+    /// <param name="sourceUrl">The location the script came from, encoded as utf8.</param>
+    /// <param name="result">A function representing the script code.</param>
+    /// <returns>
+    ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
+    /// </returns>
+    CHAKRA_API
+        JsParseScriptUtf8(
+            _In_z_ const char *script,
+            _In_ JsSourceContext sourceContext,
+            _In_z_ const char *sourceUrl,
+            _Out_ JsValueRef *result);
+
+    /// <summary>
+    ///     Parses a script and returns a function representing the script.
+    /// </summary>
+    /// <remarks>
+    ///     Requires an active script context.
+    /// </remarks>
+    /// <param name="script">The script to parse, encoded as utf8.</param>
+    /// <param name="sourceContext">
+    ///     A cookie identifying the script that can be used by debuggable script contexts.
+    /// </param>
+    /// <param name="sourceUrl">The location the script came from, encoded as utf8.</param>
+    /// <param name="parseAttributes">Attribute mask for parsing the script</param>
+    /// <param name="result">A function representing the script code.</param>
+    /// <returns>
+    ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
+    /// </returns>
+    CHAKRA_API
+        JsParseScriptWithAttributesUtf8(
+            _In_z_ const char *script,
+            _In_ JsSourceContext sourceContext,
+            _In_z_ const char *sourceUrl,
+            _In_ JsParseScriptAttributes parseAttributes,
+            _Out_ JsValueRef *result);
+
+    /// <summary>
+    ///     Executes a script.
+    /// </summary>
+    /// <remarks>
+    ///     Requires an active script context.
+    /// </remarks>
+    /// <param name="script">The script to run, encoded as utf8.</param>
+    /// <param name="sourceContext">
+    ///     A cookie identifying the script that can be used by debuggable script contexts.
+    /// </param>
+    /// <param name="sourceUrl">The location the script came from, encoded as utf8.</param>
+    /// <param name="result">The result of the script, if any. This parameter can be null.</param>
+    /// <returns>
+    ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
+    /// </returns>
+    CHAKRA_API
+        JsRunScriptUtf8(
+            _In_z_ const char *script,
+            _In_ JsSourceContext sourceContext,
+            _In_z_ const char *sourceUrl,
+            _Out_ JsValueRef *result);
+
+    /// <summary>
+    ///     Executes a module.
+    /// </summary>
+    /// <remarks>
+    ///     Requires an active script context.
+    /// </remarks>
+    /// <param name="script">The module script to parse and execute, encoded as utf8.</param>
+    /// <param name="sourceContext">
+    ///     A cookie identifying the script that can be used by debuggable script contexts.
+    /// </param>
+    /// <param name="sourceUrl">The location the module script came from, encoded as utf8.</param>
+    /// <param name="result">The result of executing the module script, if any. This parameter can be null.</param>
+    /// <returns>
+    ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
+    /// </returns>
+    CHAKRA_API
+        JsExperimentalApiRunModuleUtf8(
+            _In_z_ const char *script,
+            _In_ JsSourceContext sourceContext,
+            _In_z_ const char *sourceUrl,
+            _Out_ JsValueRef *result);
+
+    /// <summary>
+    ///     Serializes a parsed script to a buffer than can be reused.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///     <c>JsSerializeScript</c> parses a script and then stores the parsed form of the script in a
+    ///     runtime-independent format. The serialized script then can be deserialized in any
+    ///     runtime without requiring the script to be re-parsed.
+    ///     </para>
+    ///     <para>
+    ///     Requires an active script context.
+    ///     </para>
+    /// </remarks>
+    /// <param name="script">The script to serialize, encoded as utf8.</param>
+    /// <param name="buffer">The buffer to put the serialized script into. Can be null.</param>
+    /// <param name="bufferSize">
+    ///     On entry, the size of the buffer, in bytes; on exit, the size of the buffer, in bytes,
+    ///     required to hold the serialized script.
+    /// </param>
+    /// <returns>
+    ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
+    /// </returns>
+    CHAKRA_API
+        JsSerializeScriptUtf8(
+            _In_z_ const char *script,
+            _Out_writes_to_opt_(*bufferSize, *bufferSize) ChakraBytePtr buffer,
+            _Inout_ unsigned int *bufferSize);
+
+    /// <summary>
+    ///     Parses a serialized script and returns a function representing the script.
+    ///     Provides the ability to lazy load the script source only if/when it is needed.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///     Requires an active script context.
+    ///     </para>
+    ///     <para>
+    ///     The runtime will hold on to the buffer until all instances of any functions created from
+    ///     the buffer are garbage collected.  It will then call scriptUnloadCallback to inform the
+    ///     caller it is safe to release.
+    ///     </para>
+    /// </remarks>
+    /// <param name="scriptLoadCallback">Callback called when the source code of the script needs to be loaded. This is an optional parameter, set to null if not needed.</param>
+    /// <param name="scriptUnloadCallback">Callback called when the serialized script and source code are no longer needed. This is an optional parameter, set to null if not needed.</param>
+    /// <param name="buffer">The serialized script.</param>
+    /// <param name="sourceContext">
+    ///     A cookie identifying the script that can be used by debuggable script contexts.
+    ///     This context will passed into scriptLoadCallback and scriptUnloadCallback.
+    /// </param>
+    /// <param name="sourceUrl">The location the script came from, encoded as utf8.</param>
+    /// <param name="result">A function representing the script code.</param>
+    /// <returns>
+    ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
+    /// </returns>
+    CHAKRA_API
+        JsParseSerializedScriptUtf8(
+            _In_ JsSerializedScriptLoadUtf8SourceCallback scriptLoadCallback,
+            _In_ JsSerializedScriptUnloadCallback scriptUnloadCallback,
+            _In_ ChakraBytePtr buffer,
+            _In_ JsSourceContext sourceContext,
+            _In_z_ const char *sourceUrl,
+            _Out_ JsValueRef * result);
+
+    /// <summary>
+    ///     Runs a serialized script.
+    ///     Provides the ability to lazy load the script source only if/when it is needed.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///     Requires an active script context.
+    ///     </para>
+    ///     <para>
+    ///     The runtime will hold on to the buffer until all instances of any functions created from
+    ///     the buffer are garbage collected.  It will then call scriptUnloadCallback to inform the
+    ///     caller it is safe to release.
+    ///     </para>
+    /// </remarks>
+    /// <param name="scriptLoadCallback">Callback called when the source code of the script needs to be loaded. This is an optional parameter, set to null if not needed.</param>
+    /// <param name="scriptUnloadCallback">Callback called when the serialized script and source code are no longer needed. This is an optional parameter, set to null if not needed.</param>
+    /// <param name="buffer">The serialized script.</param>
+    /// <param name="sourceContext">
+    ///     A cookie identifying the script that can be used by debuggable script contexts.
+    ///     This context will passed into scriptLoadCallback and scriptUnloadCallback.
+    /// </param>
+    /// <param name="sourceUrl">The location the script came from, encoded as utf8.</param>
+    /// <param name="result">
+    ///     The result of running the script, if any. This parameter can be null.
+    /// </param>
+    /// <returns>
+    ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
+    /// </returns>
+    CHAKRA_API
+        JsRunSerializedScriptUtf8(
+            _In_ JsSerializedScriptLoadUtf8SourceCallback scriptLoadCallback,
+            _In_ JsSerializedScriptUnloadCallback scriptUnloadCallback,
+            _In_ ChakraBytePtr buffer,
+            _In_ JsSourceContext sourceContext,
+            _In_z_ const char *sourceUrl,
+            _Out_opt_ JsValueRef * result);
+
+    /// <summary>
+    ///     Gets the property ID associated with the name.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///     Property IDs are specific to a context and cannot be used across contexts.
+    ///     </para>
+    ///     <para>
+    ///     Requires an active script context.
+    ///     </para>
+    /// </remarks>
+    /// <param name="name">
+    ///     The name of the property ID to get or create. The name may consist of only digits.
+    ///     The string is expected to be encoded as utf8.
+    /// </param>
+    /// <param name="propertyId">The property ID in this runtime for the given name.</param>
+    /// <returns>
+    ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
+    /// </returns>
+    CHAKRA_API
+        JsGetPropertyIdFromNameUtf8(
+            _In_z_ const char *name,
+            _Out_ JsPropertyIdRef *propertyId);
+
+    /// <summary>
+    ///     Gets the name associated with the property ID.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///     Requires an active script context.
+    ///     </para>
+    ///     <para>
+    ///     The returned buffer is valid as long as the runtime is alive and cannot be used
+    ///     once the runtime has been disposed.
+    ///     </para>
+    /// </remarks>
+    /// <param name="propertyId">The property ID to get the name of.</param>
+    /// <param name="name">The name associated with the property ID, encoded as utf8.</param>
+    /// <returns>
+    ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
+    /// </returns>
+    CHAKRA_API
+        JsGetPropertyNameFromIdUtf8(
+            _In_ JsPropertyIdRef propertyId,
+            _Outptr_result_z_ const char *name);
 
     /// <summary>
     ///     Gets the symbol associated with the property ID.
@@ -1132,7 +1423,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsGetSymbolFromPropertyId(
             _In_ JsPropertyIdRef propertyId,
             _Out_ JsValueRef *symbol);
@@ -1164,7 +1455,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsGetPropertyIdType(
             _In_ JsPropertyIdRef propertyId,
             _Out_ JsPropertyIdType* propertyIdType);
@@ -1188,7 +1479,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsGetPropertyIdFromSymbol(
             _In_ JsValueRef symbol,
             _Out_ JsPropertyIdRef *propertyId);
@@ -1204,7 +1495,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsCreateSymbol(
             _In_ JsValueRef description,
             _Out_ JsValueRef *result);
@@ -1220,7 +1511,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsGetOwnPropertySymbols(
             _In_ JsValueRef object,
             _Out_ JsValueRef *propertySymbols);
@@ -1235,7 +1526,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsGetUndefinedValue(
             _Out_ JsValueRef *undefinedValue);
 
@@ -1249,7 +1540,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsGetNullValue(
             _Out_ JsValueRef *nullValue);
 
@@ -1263,7 +1554,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsGetTrueValue(
             _Out_ JsValueRef *trueValue);
 
@@ -1277,7 +1568,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsGetFalseValue(
             _Out_ JsValueRef *falseValue);
 
@@ -1292,7 +1583,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsBoolToBoolean(
             _In_ bool value,
             _Out_ JsValueRef *booleanValue);
@@ -1305,7 +1596,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsBooleanToBool(
             _In_ JsValueRef value,
             _Out_ bool *boolValue);
@@ -1321,7 +1612,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsConvertValueToBoolean(
             _In_ JsValueRef value,
             _Out_ JsValueRef *booleanValue);
@@ -1393,7 +1684,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsGetValueType(
             _In_ JsValueRef value,
             _Out_ JsValueType *type);
@@ -1409,7 +1700,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsDoubleToNumber(
             _In_ double doubleValue,
             _Out_ JsValueRef *value);
@@ -1425,7 +1716,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsIntToNumber(
             _In_ int intValue,
             _Out_ JsValueRef *value);
@@ -1442,7 +1733,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsNumberToDouble(
             _In_ JsValueRef value,
             _Out_ double *doubleValue);
@@ -1459,7 +1750,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsNumberToInt(
             _In_ JsValueRef value,
             _Out_ int *intValue);
@@ -1475,7 +1766,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsConvertValueToNumber(
             _In_ JsValueRef value,
             _Out_ JsValueRef *numberValue);
@@ -1488,11 +1779,12 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsGetStringLength(
             _In_ JsValueRef stringValue,
             _Out_ int *length);
 
+#ifdef _WIN32
     /// <summary>
     ///     Creates a string value from a string pointer.
     /// </summary>
@@ -1505,7 +1797,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsPointerToString(
             _In_reads_(stringLength) const wchar_t *stringValue,
             _In_ size_t stringLength,
@@ -1532,10 +1824,56 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsStringToPointer(
             _In_ JsValueRef value,
             _Outptr_result_buffer_(*stringLength) const wchar_t **stringValue,
+            _Out_ size_t *stringLength);
+#endif
+
+    /// <summary>
+    ///     Creates a string value from a string pointer.
+    /// </summary>
+    /// <remarks>
+    ///     Requires an active script context.
+    /// </remarks>
+    /// <param name="stringValue">The string pointer to convert to a string value, encoded as Utf8.</param>
+    /// <param name="stringLength">The length of the string to convert.</param>
+    /// <param name="value">The new string value.</param>
+    /// <returns>
+    ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
+    /// </returns>
+    CHAKRA_API
+        JsPointerToStringUtf8(
+            _In_reads_(stringLength) const char *stringValue,
+            _In_ size_t stringLength,
+            _Out_ JsValueRef *value);
+
+    /// <summary>
+    ///     Retrieves the string pointer of a string value.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///     This function retrieves the string pointer of a string value. It will fail with
+    ///     <c>JsErrorInvalidArgument</c> if the type of the value is not string. The lifetime
+    ///     of the string returned will be the same as the lifetime of the value it came from, however
+    ///     the string pointer is not considered a reference to the value (and so will not keep it
+    ///     from being collected).
+    ///     </para>
+    ///     <para>
+    ///     Requires an active script context.
+    ///     </para>
+    /// </remarks>
+    /// <param name="value">The string value to convert to a string pointer.</param>
+    /// <param name="stringValue">The string pointer, encoded as utf8.</param>
+    /// <param name="stringLength">The length of the string.</param>
+    /// <returns>
+    ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
+    /// </returns>
+    CHAKRA_API
+        JsStringToPointerUtf8(
+            _In_ JsValueRef value,
+            _Outptr_result_buffer_(*stringLength) const char **stringValue,
             _Out_ size_t *stringLength);
 
     /// <summary>
@@ -1549,7 +1887,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsConvertValueToString(
             _In_ JsValueRef value,
             _Out_ JsValueRef *stringValue);
@@ -1564,7 +1902,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsGetGlobalObject(
             _Out_ JsValueRef *globalObject);
 
@@ -1578,7 +1916,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsCreateObject(
             _Out_ JsValueRef *object);
 
@@ -1588,7 +1926,7 @@
     /// <param name="data">
     ///     The external data that was passed in when creating the object being finalized.
     /// </param>
-    typedef void (CALLBACK *JsFinalizeCallback)(_In_opt_ void *data);
+    typedef void (CHAKRA_CALLBACK *JsFinalizeCallback)(_In_opt_ void *data);
 
     /// <summary>
     ///     Creates a new object that stores some external data.
@@ -1604,7 +1942,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsCreateExternalObject(
             _In_opt_ void *data,
             _In_opt_ JsFinalizeCallback finalizeCallback,
@@ -1621,7 +1959,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsConvertValueToObject(
             _In_ JsValueRef value,
             _Out_ JsValueRef *object);
@@ -1637,7 +1975,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsGetPrototype(
             _In_ JsValueRef object,
             _Out_ JsValueRef *prototypeObject);
@@ -1653,7 +1991,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsSetPrototype(
             _In_ JsValueRef object,
             _In_ JsValueRef prototypeObject);
@@ -1670,7 +2008,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsInstanceOf(
             _In_ JsValueRef object,
             _In_ JsValueRef constructor,
@@ -1687,7 +2025,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsGetExtensionAllowed(
             _In_ JsValueRef object,
             _Out_ bool *value);
@@ -1702,7 +2040,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsPreventExtension(
             _In_ JsValueRef object);
 
@@ -1718,7 +2056,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsGetProperty(
             _In_ JsValueRef object,
             _In_ JsPropertyIdRef propertyId,
@@ -1736,7 +2074,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsGetOwnPropertyDescriptor(
             _In_ JsValueRef object,
             _In_ JsPropertyIdRef propertyId,
@@ -1753,7 +2091,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsGetOwnPropertyNames(
             _In_ JsValueRef object,
             _Out_ JsValueRef *propertyNames);
@@ -1771,7 +2109,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsSetProperty(
             _In_ JsValueRef object,
             _In_ JsPropertyIdRef propertyId,
@@ -1790,7 +2128,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsHasProperty(
             _In_ JsValueRef object,
             _In_ JsPropertyIdRef propertyId,
@@ -1809,7 +2147,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsDeleteProperty(
             _In_ JsValueRef object,
             _In_ JsPropertyIdRef propertyId,
@@ -1829,7 +2167,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsDefineProperty(
             _In_ JsValueRef object,
             _In_ JsPropertyIdRef propertyId,
@@ -1848,7 +2186,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsHasIndexedProperty(
             _In_ JsValueRef object,
             _In_ JsValueRef index,
@@ -1866,7 +2204,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsGetIndexedProperty(
             _In_ JsValueRef object,
             _In_ JsValueRef index,
@@ -1884,7 +2222,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsSetIndexedProperty(
             _In_ JsValueRef object,
             _In_ JsValueRef index,
@@ -1901,7 +2239,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsDeleteIndexedProperty(
             _In_ JsValueRef object,
             _In_ JsValueRef index);
@@ -1914,7 +2252,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsHasIndexedPropertiesExternalData(
             _In_ JsValueRef object,
             _Out_ bool* value);
@@ -1929,7 +2267,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsGetIndexedPropertiesExternalData(
             _In_ JsValueRef object,
             _Out_ void** data,
@@ -1950,7 +2288,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsSetIndexedPropertiesToExternalData(
             _In_ JsValueRef object,
             _In_ void* data,
@@ -1974,7 +2312,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsEquals(
             _In_ JsValueRef object1,
             _In_ JsValueRef object2,
@@ -1997,7 +2335,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsStrictEquals(
             _In_ JsValueRef object1,
             _In_ JsValueRef object2,
@@ -2011,7 +2349,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsHasExternalData(
             _In_ JsValueRef object,
             _Out_ bool *value);
@@ -2027,7 +2365,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsGetExternalData(
             _In_ JsValueRef object,
             _Out_ void **externalData);
@@ -2043,7 +2381,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsSetExternalData(
             _In_ JsValueRef object,
             _In_opt_ void *externalData);
@@ -2059,7 +2397,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsCreateArray(
             _In_ unsigned int length,
             _Out_ JsValueRef *result);
@@ -2077,7 +2415,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsCreateArrayBuffer(
             _In_ unsigned int byteLength,
             _Out_ JsValueRef *result);
@@ -2094,7 +2432,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsCreateExternalArrayBuffer(
             _Pre_maybenull_ _Pre_writable_byte_size_(byteLength) void *data,
             _In_ unsigned int byteLength,
@@ -2132,7 +2470,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsCreateTypedArray(
             _In_ JsTypedArrayType arrayType,
             _In_ JsValueRef baseArray,
@@ -2159,7 +2497,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsCreateDataView(
             _In_ JsValueRef arrayBuffer,
             _In_ unsigned int byteOffset,
@@ -2177,7 +2515,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsGetTypedArrayInfo(
             _In_ JsValueRef typedArray,
             _Out_opt_ JsTypedArrayType *arrayType,
@@ -2198,10 +2536,10 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsGetArrayBufferStorage(
             _In_ JsValueRef arrayBuffer,
-            _Outptr_result_bytebuffer_(*bufferLength) BYTE **buffer,
+            _Outptr_result_bytebuffer_(*bufferLength) ChakraBytePtr *buffer,
             _Out_ unsigned int *bufferLength);
 
     /// <summary>
@@ -2221,10 +2559,10 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsGetTypedArrayStorage(
             _In_ JsValueRef typedArray,
-            _Outptr_result_bytebuffer_(*bufferLength) BYTE **buffer,
+            _Outptr_result_bytebuffer_(*bufferLength) ChakraBytePtr *buffer,
             _Out_ unsigned int *bufferLength,
             _Out_opt_ JsTypedArrayType *arrayType,
             _Out_opt_ int *elementSize);
@@ -2242,17 +2580,17 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsGetDataViewStorage(
             _In_ JsValueRef dataView,
-            _Outptr_result_bytebuffer_(*bufferLength) BYTE **buffer,
+            _Outptr_result_bytebuffer_(*bufferLength) ChakraBytePtr *buffer,
             _Out_ unsigned int *bufferLength);
 
     /// <summary>
     ///     Invokes a function.
     /// </summary>
     /// <remarks>
-    ///     Requires thisArg as first argument of arguments. 
+    ///     Requires thisArg as first argument of arguments.
     ///     Requires an active script context.
     /// </remarks>
     /// <param name="function">The function to invoke.</param>
@@ -2262,7 +2600,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsCallFunction(
             _In_ JsValueRef function,
             _In_reads_(argumentCount) JsValueRef *arguments,
@@ -2282,7 +2620,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsConstructObject(
             _In_ JsValueRef function,
             _In_reads_(argumentCount) JsValueRef *arguments,
@@ -2302,7 +2640,7 @@
     ///     The state passed to <c>JsCreateFunction</c>.
     /// </param>
     /// <returns>The result of the call, if any.</returns>
-    typedef _Ret_maybenull_ JsValueRef(CALLBACK * JsNativeFunction)(_In_ JsValueRef callee, _In_ bool isConstructCall, _In_ JsValueRef *arguments, _In_ unsigned short argumentCount, _In_opt_ void *callbackState);
+    typedef _Ret_maybenull_ JsValueRef(CHAKRA_CALLBACK * JsNativeFunction)(_In_ JsValueRef callee, _In_ bool isConstructCall, _In_ JsValueRef *arguments, _In_ unsigned short argumentCount, _In_opt_ void *callbackState);
 
     /// <summary>
     ///     Creates a new JavaScript function.
@@ -2318,7 +2656,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsCreateFunction(
             _In_ JsNativeFunction nativeFunction,
             _In_opt_ void *callbackState,
@@ -2339,7 +2677,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsCreateNamedFunction(
             _In_ JsValueRef name,
             _In_ JsNativeFunction nativeFunction,
@@ -2357,7 +2695,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsCreateError(
             _In_ JsValueRef message,
             _Out_ JsValueRef *error);
@@ -2373,7 +2711,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsCreateRangeError(
             _In_ JsValueRef message,
             _Out_ JsValueRef *error);
@@ -2389,7 +2727,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsCreateReferenceError(
             _In_ JsValueRef message,
             _Out_ JsValueRef *error);
@@ -2405,7 +2743,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsCreateSyntaxError(
             _In_ JsValueRef message,
             _Out_ JsValueRef *error);
@@ -2421,7 +2759,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsCreateTypeError(
             _In_ JsValueRef message,
             _Out_ JsValueRef *error);
@@ -2437,7 +2775,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsCreateURIError(
             _In_ JsValueRef message,
             _Out_ JsValueRef *error);
@@ -2467,7 +2805,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsHasException(
             _Out_ bool *hasException);
 
@@ -2491,7 +2829,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsGetAndClearException(
             _Out_ JsValueRef *exception);
 
@@ -2513,7 +2851,7 @@
     /// <returns>
     ///     JsNoError if the engine was set into an exception state, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsSetException(
             _In_ JsValueRef exception);
 
@@ -2538,7 +2876,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsDisableRuntimeExecution(
             _In_ JsRuntimeHandle runtime);
 
@@ -2553,7 +2891,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsEnableRuntimeExecution(
             _In_ JsRuntimeHandle runtime);
 
@@ -2565,7 +2903,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsIsRuntimeExecutionDisabled(
             _In_ JsRuntimeHandle runtime,
             _Out_ bool *isDisabled);
@@ -2582,7 +2920,7 @@
     /// </remarks>
     /// <param name="task">The task, represented as a JavaScript function.</param>
     /// <param name="callbackState">The data argument to be passed to the callback.</param>
-    typedef void (CALLBACK *JsPromiseContinuationCallback)(_In_ JsValueRef task, _In_opt_ void *callbackState);
+    typedef void (CHAKRA_CALLBACK *JsPromiseContinuationCallback)(_In_ JsValueRef task, _In_opt_ void *callbackState);
 
     /// <summary>
     ///     Sets a promise continuation callback function that is called by the context when a task
@@ -2600,7 +2938,7 @@
     /// <returns>
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
-    STDAPI_(JsErrorCode)
+    CHAKRA_API
         JsSetPromiseContinuationCallback(
             _In_ JsPromiseContinuationCallback promiseContinuationCallback,
             _In_opt_ void *callbackState);

--- a/lib/Jsrt/Jsrt.cpp
+++ b/lib/Jsrt/Jsrt.cpp
@@ -69,7 +69,7 @@ JsErrorCode CheckContext(JsrtContext *currentContext, bool verifyRuntimeState, b
     return JsNoError;
 }
 
-STDAPI_(JsErrorCode) JsCreateRuntime(_In_ JsRuntimeAttributes attributes, _In_opt_ JsThreadServiceCallback threadService, _Out_ JsRuntimeHandle *runtimeHandle)
+CHAKRA_API JsCreateRuntime(_In_ JsRuntimeAttributes attributes, _In_opt_ JsThreadServiceCallback threadService, _Out_ JsRuntimeHandle *runtimeHandle)
 {
     return GlobalAPIWrapper([&] () -> JsErrorCode {
         PARAM_NOT_NULL(runtimeHandle);
@@ -196,19 +196,19 @@ JsErrorCode JsCollectGarbageCommon(JsRuntimeHandle runtimeHandle)
     });
 }
 
-STDAPI_(JsErrorCode) JsCollectGarbage(_In_ JsRuntimeHandle runtimeHandle)
+CHAKRA_API JsCollectGarbage(_In_ JsRuntimeHandle runtimeHandle)
 {
     return JsCollectGarbageCommon<CollectNowExhaustive>(runtimeHandle);
 }
 
 #ifdef ENABLE_DEBUG_CONFIG_OPTIONS
-STDAPI_(JsErrorCode) JsPrivateCollectGarbageSkipStack(_In_ JsRuntimeHandle runtimeHandle)
+CHAKRA_API JsPrivateCollectGarbageSkipStack(_In_ JsRuntimeHandle runtimeHandle)
 {
     return JsCollectGarbageCommon<CollectNowExhaustiveSkipStack>(runtimeHandle);
 }
 #endif
 
-STDAPI_(JsErrorCode) JsDisposeRuntime(_In_ JsRuntimeHandle runtimeHandle)
+CHAKRA_API JsDisposeRuntime(_In_ JsRuntimeHandle runtimeHandle)
 {
     return GlobalAPIWrapper([&] () -> JsErrorCode {
         VALIDATE_INCOMING_RUNTIME_HANDLE(runtimeHandle);
@@ -283,7 +283,7 @@ STDAPI_(JsErrorCode) JsDisposeRuntime(_In_ JsRuntimeHandle runtimeHandle)
     });
 }
 
-STDAPI_(JsErrorCode) JsAddRef(_In_ JsRef ref, _Out_opt_ unsigned int *count)
+CHAKRA_API JsAddRef(_In_ JsRef ref, _Out_opt_ unsigned int *count)
 {
     VALIDATE_JSREF(ref);
     if (count != nullptr)
@@ -333,7 +333,7 @@ STDAPI_(JsErrorCode) JsAddRef(_In_ JsRef ref, _Out_opt_ unsigned int *count)
     }
 }
 
-STDAPI_(JsErrorCode) JsRelease(_In_ JsRef ref, _Out_opt_ unsigned int *count)
+CHAKRA_API JsRelease(_In_ JsRef ref, _Out_opt_ unsigned int *count)
 {
     VALIDATE_JSREF(ref);
     if (count != nullptr)
@@ -382,7 +382,7 @@ STDAPI_(JsErrorCode) JsRelease(_In_ JsRef ref, _Out_opt_ unsigned int *count)
 }
 
 
-STDAPI_(JsErrorCode) JsSetObjectBeforeCollectCallback(_In_ JsRef ref, _In_opt_ void *callbackState, _In_ JsObjectBeforeCollectCallback objectBeforeCollectCallback)
+CHAKRA_API JsSetObjectBeforeCollectCallback(_In_ JsRef ref, _In_opt_ void *callbackState, _In_ JsObjectBeforeCollectCallback objectBeforeCollectCallback)
 {
     VALIDATE_JSREF(ref);
 
@@ -424,7 +424,7 @@ STDAPI_(JsErrorCode) JsSetObjectBeforeCollectCallback(_In_ JsRef ref, _In_opt_ v
     }
 }
 
-STDAPI_(JsErrorCode) JsCreateContext(_In_ JsRuntimeHandle runtimeHandle, _Out_ JsContextRef *newContext)
+CHAKRA_API JsCreateContext(_In_ JsRuntimeHandle runtimeHandle, _Out_ JsContextRef *newContext)
 {
     return GlobalAPIWrapper([&]() -> JsErrorCode {
         PARAM_NOT_NULL(newContext);
@@ -456,7 +456,7 @@ STDAPI_(JsErrorCode) JsCreateContext(_In_ JsRuntimeHandle runtimeHandle, _Out_ J
     });
 }
 
-STDAPI_(JsErrorCode) JsGetCurrentContext(_Out_ JsContextRef *currentContext)
+CHAKRA_API JsGetCurrentContext(_Out_ JsContextRef *currentContext)
 {
     PARAM_NOT_NULL(currentContext);
 
@@ -467,7 +467,7 @@ STDAPI_(JsErrorCode) JsGetCurrentContext(_Out_ JsContextRef *currentContext)
     END_JSRT_NO_EXCEPTION
 }
 
-STDAPI_(JsErrorCode) JsSetCurrentContext(_In_ JsContextRef newContext)
+CHAKRA_API JsSetCurrentContext(_In_ JsContextRef newContext)
 {
     return GlobalAPIWrapper([&] () -> JsErrorCode {
         JsrtContext *currentContext = JsrtContext::GetCurrent();
@@ -491,7 +491,7 @@ STDAPI_(JsErrorCode) JsSetCurrentContext(_In_ JsContextRef newContext)
     });
 }
 
-STDAPI_(JsErrorCode) JsGetContextOfObject(_In_ JsValueRef object, _Out_ JsContextRef *context)
+CHAKRA_API JsGetContextOfObject(_In_ JsValueRef object, _Out_ JsContextRef *context)
 {
     VALIDATE_JSREF(object);
     PARAM_NOT_NULL(context);
@@ -508,7 +508,7 @@ STDAPI_(JsErrorCode) JsGetContextOfObject(_In_ JsValueRef object, _Out_ JsContex
     END_JSRT_NO_EXCEPTION
 }
 
-STDAPI_(JsErrorCode) JsGetContextData(_In_ JsContextRef context, _Out_ void **data)
+CHAKRA_API JsGetContextData(_In_ JsContextRef context, _Out_ void **data)
 {
     VALIDATE_JSREF(context);
     PARAM_NOT_NULL(data);
@@ -525,7 +525,7 @@ STDAPI_(JsErrorCode) JsGetContextData(_In_ JsContextRef context, _Out_ void **da
     END_JSRT_NO_EXCEPTION
 }
 
-STDAPI_(JsErrorCode) JsSetContextData(_In_ JsContextRef context, _In_ void *data)
+CHAKRA_API JsSetContextData(_In_ JsContextRef context, _In_ void *data)
 {
     VALIDATE_JSREF(context);
 
@@ -557,7 +557,7 @@ void HandleScriptCompileError(Js::ScriptContext * scriptContext, CompileScriptEx
     scriptContext->GetThreadContext()->SetRecordedException(exceptionObject);
 }
 
-STDAPI_(JsErrorCode) JsGetUndefinedValue(_Out_ JsValueRef *undefinedValue)
+CHAKRA_API JsGetUndefinedValue(_Out_ JsValueRef *undefinedValue)
 {
     return ContextAPINoScriptWrapper([&] (Js::ScriptContext *scriptContext) -> JsErrorCode {
         PARAM_NOT_NULL(undefinedValue);
@@ -569,7 +569,7 @@ STDAPI_(JsErrorCode) JsGetUndefinedValue(_Out_ JsValueRef *undefinedValue)
     /*allowInObjectBeforeCollectCallback*/true);
 }
 
-STDAPI_(JsErrorCode) JsGetNullValue(_Out_ JsValueRef *nullValue)
+CHAKRA_API JsGetNullValue(_Out_ JsValueRef *nullValue)
 {
     return ContextAPINoScriptWrapper([&] (Js::ScriptContext *scriptContext) -> JsErrorCode {
         PARAM_NOT_NULL(nullValue);
@@ -581,7 +581,7 @@ STDAPI_(JsErrorCode) JsGetNullValue(_Out_ JsValueRef *nullValue)
     /*allowInObjectBeforeCollectCallback*/true);
 }
 
-STDAPI_(JsErrorCode) JsGetTrueValue(_Out_ JsValueRef *trueValue)
+CHAKRA_API JsGetTrueValue(_Out_ JsValueRef *trueValue)
 {
     return ContextAPINoScriptWrapper([&] (Js::ScriptContext *scriptContext) -> JsErrorCode {
         PARAM_NOT_NULL(trueValue);
@@ -593,7 +593,7 @@ STDAPI_(JsErrorCode) JsGetTrueValue(_Out_ JsValueRef *trueValue)
     /*allowInObjectBeforeCollectCallback*/true);
 }
 
-STDAPI_(JsErrorCode) JsGetFalseValue(_Out_ JsValueRef *falseValue)
+CHAKRA_API JsGetFalseValue(_Out_ JsValueRef *falseValue)
 {
     return ContextAPINoScriptWrapper([&] (Js::ScriptContext *scriptContext) -> JsErrorCode {
         PARAM_NOT_NULL(falseValue);
@@ -605,7 +605,7 @@ STDAPI_(JsErrorCode) JsGetFalseValue(_Out_ JsValueRef *falseValue)
     /*allowInObjectBeforeCollectCallback*/true);
 }
 
-STDAPI_(JsErrorCode) JsBoolToBoolean(_In_ bool value, _Out_ JsValueRef *booleanValue)
+CHAKRA_API JsBoolToBoolean(_In_ bool value, _Out_ JsValueRef *booleanValue)
 {
     return ContextAPINoScriptWrapper([&] (Js::ScriptContext *scriptContext) -> JsErrorCode {
         PARAM_NOT_NULL(booleanValue);
@@ -617,7 +617,7 @@ STDAPI_(JsErrorCode) JsBoolToBoolean(_In_ bool value, _Out_ JsValueRef *booleanV
     /*allowInObjectBeforeCollectCallback*/true);
 }
 
-STDAPI_(JsErrorCode) JsBooleanToBool(_In_ JsValueRef value, _Out_ bool *boolValue)
+CHAKRA_API JsBooleanToBool(_In_ JsValueRef value, _Out_ bool *boolValue)
 {
     VALIDATE_JSREF(value);
     PARAM_NOT_NULL(boolValue);
@@ -634,7 +634,7 @@ STDAPI_(JsErrorCode) JsBooleanToBool(_In_ JsValueRef value, _Out_ bool *boolValu
     END_JSRT_NO_EXCEPTION
 }
 
-STDAPI_(JsErrorCode) JsConvertValueToBoolean(_In_ JsValueRef value, _Out_ JsValueRef *result)
+CHAKRA_API JsConvertValueToBoolean(_In_ JsValueRef value, _Out_ JsValueRef *result)
 {
     return ContextAPIWrapper<true>([&] (Js::ScriptContext *scriptContext) -> JsErrorCode {
         VALIDATE_INCOMING_REFERENCE(value, scriptContext);
@@ -653,7 +653,7 @@ STDAPI_(JsErrorCode) JsConvertValueToBoolean(_In_ JsValueRef value, _Out_ JsValu
     });
 }
 
-STDAPI_(JsErrorCode) JsGetValueType(_In_ JsValueRef value, _Out_ JsValueType *type)
+CHAKRA_API JsGetValueType(_In_ JsValueRef value, _Out_ JsValueType *type)
 {
     VALIDATE_JSREF(value);
     PARAM_NOT_NULL(type);
@@ -720,7 +720,7 @@ STDAPI_(JsErrorCode) JsGetValueType(_In_ JsValueRef value, _Out_ JsValueType *ty
     END_JSRT_NO_EXCEPTION
 }
 
-STDAPI_(JsErrorCode) JsDoubleToNumber(_In_ double dbl, _Out_ JsValueRef *asValue)
+CHAKRA_API JsDoubleToNumber(_In_ double dbl, _Out_ JsValueRef *asValue)
 {
     PARAM_NOT_NULL(asValue);
     if (Js::JavascriptNumber::TryToVarFastWithCheck(dbl, asValue)) {
@@ -733,7 +733,7 @@ STDAPI_(JsErrorCode) JsDoubleToNumber(_In_ double dbl, _Out_ JsValueRef *asValue
     });
 }
 
-STDAPI_(JsErrorCode) JsIntToNumber(_In_ int intValue, _Out_ JsValueRef *asValue)
+CHAKRA_API JsIntToNumber(_In_ int intValue, _Out_ JsValueRef *asValue)
 {
     PARAM_NOT_NULL(asValue);
     if (Js::JavascriptNumber::TryToVarFast(intValue, asValue))
@@ -747,7 +747,7 @@ STDAPI_(JsErrorCode) JsIntToNumber(_In_ int intValue, _Out_ JsValueRef *asValue)
     });
 }
 
-STDAPI_(JsErrorCode) JsNumberToDouble(_In_ JsValueRef value, _Out_ double *asDouble)
+CHAKRA_API JsNumberToDouble(_In_ JsValueRef value, _Out_ double *asDouble)
 {
     VALIDATE_JSREF(value);
     PARAM_NOT_NULL(asDouble);
@@ -771,7 +771,7 @@ STDAPI_(JsErrorCode) JsNumberToDouble(_In_ JsValueRef value, _Out_ double *asDou
     END_JSRT_NO_EXCEPTION
 }
 
-STDAPI_(JsErrorCode) JsNumberToInt(_In_ JsValueRef value, _Out_ int *asInt)
+CHAKRA_API JsNumberToInt(_In_ JsValueRef value, _Out_ int *asInt)
 {
     VALIDATE_JSREF(value);
     PARAM_NOT_NULL(asInt);
@@ -795,7 +795,7 @@ STDAPI_(JsErrorCode) JsNumberToInt(_In_ JsValueRef value, _Out_ int *asInt)
     END_JSRT_NO_EXCEPTION
 }
 
-STDAPI_(JsErrorCode) JsConvertValueToNumber(_In_ JsValueRef value, _Out_ JsValueRef *result)
+CHAKRA_API JsConvertValueToNumber(_In_ JsValueRef value, _Out_ JsValueRef *result)
 {
     return ContextAPIWrapper<true>([&] (Js::ScriptContext *scriptContext) -> JsErrorCode {
         VALIDATE_INCOMING_REFERENCE(value, scriptContext);
@@ -806,7 +806,7 @@ STDAPI_(JsErrorCode) JsConvertValueToNumber(_In_ JsValueRef value, _Out_ JsValue
     });
 }
 
-STDAPI_(JsErrorCode) JsGetStringLength(_In_ JsValueRef value, _Out_ int *length)
+CHAKRA_API JsGetStringLength(_In_ JsValueRef value, _Out_ int *length)
 {
     VALIDATE_JSREF(value);
     PARAM_NOT_NULL(length);
@@ -823,7 +823,7 @@ STDAPI_(JsErrorCode) JsGetStringLength(_In_ JsValueRef value, _Out_ int *length)
     END_JSRT_NO_EXCEPTION
 }
 
-STDAPI_(JsErrorCode) JsPointerToString(_In_reads_(stringLength) const wchar_t *stringValue, _In_ size_t stringLength, _Out_ JsValueRef *string)
+CHAKRA_API JsPointerToString(_In_reads_(stringLength) const wchar_t *stringValue, _In_ size_t stringLength, _Out_ JsValueRef *string)
 {
     return ContextAPINoScriptWrapper([&](Js::ScriptContext *scriptContext) -> JsErrorCode {
         PARAM_NOT_NULL(stringValue);
@@ -842,7 +842,7 @@ STDAPI_(JsErrorCode) JsPointerToString(_In_reads_(stringLength) const wchar_t *s
 // TODO: The annotation of stringPtr is wrong.  Need to fix definition in chakrart.h
 // The warning is '*stringPtr' could be '0' : this does not adhere to the specification for the function 'JsStringToPointer'.
 #pragma warning(suppress:6387)
-STDAPI_(JsErrorCode) JsStringToPointer(_In_ JsValueRef stringValue, _Outptr_result_buffer_(*stringLength) const wchar_t **stringPtr, _Out_ size_t *stringLength)
+CHAKRA_API JsStringToPointer(_In_ JsValueRef stringValue, _Outptr_result_buffer_(*stringLength) const wchar_t **stringPtr, _Out_ size_t *stringLength)
 {
     VALIDATE_JSREF(stringValue);
     PARAM_NOT_NULL(stringPtr);
@@ -864,7 +864,7 @@ STDAPI_(JsErrorCode) JsStringToPointer(_In_ JsValueRef stringValue, _Outptr_resu
     });
 }
 
-STDAPI_(JsErrorCode) JsConvertValueToString(_In_ JsValueRef value, _Out_ JsValueRef *result)
+CHAKRA_API JsConvertValueToString(_In_ JsValueRef value, _Out_ JsValueRef *result)
 {
     return ContextAPIWrapper<true>([&] (Js::ScriptContext *scriptContext) -> JsErrorCode {
         VALIDATE_INCOMING_REFERENCE(value, scriptContext);
@@ -876,7 +876,7 @@ STDAPI_(JsErrorCode) JsConvertValueToString(_In_ JsValueRef value, _Out_ JsValue
     });
 }
 
-STDAPI_(JsErrorCode) JsGetGlobalObject(_Out_ JsValueRef *globalObject)
+CHAKRA_API JsGetGlobalObject(_Out_ JsValueRef *globalObject)
 {
     return ContextAPINoScriptWrapper([&](Js::ScriptContext *scriptContext) -> JsErrorCode {
         PARAM_NOT_NULL(globalObject);
@@ -887,7 +887,7 @@ STDAPI_(JsErrorCode) JsGetGlobalObject(_Out_ JsValueRef *globalObject)
     /*allowInObjectBeforeCollectCallback*/true);
 }
 
-STDAPI_(JsErrorCode) JsCreateObject(_Out_ JsValueRef *object)
+CHAKRA_API JsCreateObject(_Out_ JsValueRef *object)
 {
     return ContextAPINoScriptWrapper([&](Js::ScriptContext *scriptContext) -> JsErrorCode {
         PARAM_NOT_NULL(object);
@@ -897,7 +897,7 @@ STDAPI_(JsErrorCode) JsCreateObject(_Out_ JsValueRef *object)
     });
 }
 
-STDAPI_(JsErrorCode) JsCreateExternalObject(_In_opt_ void *data, _In_opt_ JsFinalizeCallback finalizeCallback, _Out_ JsValueRef *object)
+CHAKRA_API JsCreateExternalObject(_In_opt_ void *data, _In_opt_ JsFinalizeCallback finalizeCallback, _Out_ JsValueRef *object)
 {
     return ContextAPINoScriptWrapper([&](Js::ScriptContext *scriptContext) -> JsErrorCode {
         PARAM_NOT_NULL(object);
@@ -907,7 +907,7 @@ STDAPI_(JsErrorCode) JsCreateExternalObject(_In_opt_ void *data, _In_opt_ JsFina
     });
 }
 
-STDAPI_(JsErrorCode) JsConvertValueToObject(_In_ JsValueRef value, _Out_ JsValueRef *result)
+CHAKRA_API JsConvertValueToObject(_In_ JsValueRef value, _Out_ JsValueRef *result)
 {
     return ContextAPIWrapper<true>([&] (Js::ScriptContext *scriptContext) -> JsErrorCode {
         VALIDATE_INCOMING_REFERENCE(value, scriptContext);
@@ -920,7 +920,7 @@ STDAPI_(JsErrorCode) JsConvertValueToObject(_In_ JsValueRef value, _Out_ JsValue
     });
 }
 
-STDAPI_(JsErrorCode) JsGetPrototype(_In_ JsValueRef object, _Out_ JsValueRef *prototypeObject)
+CHAKRA_API JsGetPrototype(_In_ JsValueRef object, _Out_ JsValueRef *prototypeObject)
 {
     return ContextAPIWrapper<true>([&] (Js::ScriptContext *scriptContext) -> JsErrorCode {
         VALIDATE_INCOMING_OBJECT(object, scriptContext);
@@ -933,7 +933,7 @@ STDAPI_(JsErrorCode) JsGetPrototype(_In_ JsValueRef object, _Out_ JsValueRef *pr
     });
 }
 
-STDAPI_(JsErrorCode) JsSetPrototype(_In_ JsValueRef object, _In_ JsValueRef prototypeObject)
+CHAKRA_API JsSetPrototype(_In_ JsValueRef object, _In_ JsValueRef prototypeObject)
 {
     return ContextAPIWrapper<true>([&] (Js::ScriptContext *scriptContext) -> JsErrorCode {
         VALIDATE_INCOMING_OBJECT(object, scriptContext);
@@ -951,7 +951,7 @@ STDAPI_(JsErrorCode) JsSetPrototype(_In_ JsValueRef object, _In_ JsValueRef prot
     });
 }
 
-STDAPI_(JsErrorCode) JsInstanceOf(_In_ JsValueRef object, _In_ JsValueRef constructor, _Out_ bool *result) {
+CHAKRA_API JsInstanceOf(_In_ JsValueRef object, _In_ JsValueRef constructor, _Out_ bool *result) {
     return ContextAPIWrapper<true>([&](Js::ScriptContext *scriptContext) -> JsErrorCode {
         VALIDATE_INCOMING_REFERENCE(object, scriptContext);
         VALIDATE_INCOMING_REFERENCE(constructor, scriptContext);
@@ -963,7 +963,7 @@ STDAPI_(JsErrorCode) JsInstanceOf(_In_ JsValueRef object, _In_ JsValueRef constr
     });
 }
 
-STDAPI_(JsErrorCode) JsGetExtensionAllowed(_In_ JsValueRef object, _Out_ bool *value)
+CHAKRA_API JsGetExtensionAllowed(_In_ JsValueRef object, _Out_ bool *value)
 {
     return ContextAPIWrapper<true>([&] (Js::ScriptContext *scriptContext) -> JsErrorCode {
         VALIDATE_INCOMING_OBJECT(object, scriptContext);
@@ -976,7 +976,7 @@ STDAPI_(JsErrorCode) JsGetExtensionAllowed(_In_ JsValueRef object, _Out_ bool *v
     });
 }
 
-STDAPI_(JsErrorCode) JsPreventExtension(_In_ JsValueRef object)
+CHAKRA_API JsPreventExtension(_In_ JsValueRef object)
 {
     return ContextAPIWrapper<true>([&] (Js::ScriptContext *scriptContext) -> JsErrorCode {
         VALIDATE_INCOMING_OBJECT(object, scriptContext);
@@ -987,7 +987,7 @@ STDAPI_(JsErrorCode) JsPreventExtension(_In_ JsValueRef object)
     });
 }
 
-STDAPI_(JsErrorCode) JsGetProperty(_In_ JsValueRef object, _In_ JsPropertyIdRef propertyId, _Out_ JsValueRef *value)
+CHAKRA_API JsGetProperty(_In_ JsValueRef object, _In_ JsPropertyIdRef propertyId, _Out_ JsValueRef *value)
 {
     return ContextAPIWrapper<true>([&] (Js::ScriptContext *scriptContext) -> JsErrorCode {
         VALIDATE_INCOMING_OBJECT(object, scriptContext);
@@ -1001,7 +1001,7 @@ STDAPI_(JsErrorCode) JsGetProperty(_In_ JsValueRef object, _In_ JsPropertyIdRef 
     });
 }
 
-STDAPI_(JsErrorCode) JsGetOwnPropertyDescriptor(_In_ JsValueRef object, _In_ JsPropertyIdRef propertyId, _Out_ JsValueRef *propertyDescriptor)
+CHAKRA_API JsGetOwnPropertyDescriptor(_In_ JsValueRef object, _In_ JsPropertyIdRef propertyId, _Out_ JsValueRef *propertyDescriptor)
 {
     return ContextAPIWrapper<true>([&] (Js::ScriptContext *scriptContext) -> JsErrorCode {
         VALIDATE_INCOMING_OBJECT(object, scriptContext);
@@ -1023,7 +1023,7 @@ STDAPI_(JsErrorCode) JsGetOwnPropertyDescriptor(_In_ JsValueRef object, _In_ JsP
     });
 }
 
-STDAPI_(JsErrorCode) JsGetOwnPropertyNames(_In_ JsValueRef object, _Out_ JsValueRef *propertyNames)
+CHAKRA_API JsGetOwnPropertyNames(_In_ JsValueRef object, _Out_ JsValueRef *propertyNames)
 {
     return ContextAPIWrapper<true>([&] (Js::ScriptContext *scriptContext) -> JsErrorCode {
         VALIDATE_INCOMING_OBJECT(object, scriptContext);
@@ -1036,7 +1036,7 @@ STDAPI_(JsErrorCode) JsGetOwnPropertyNames(_In_ JsValueRef object, _Out_ JsValue
     });
 }
 
-STDAPI_(JsErrorCode) JsGetOwnPropertySymbols(_In_ JsValueRef object, _Out_ JsValueRef *propertySymbols)
+CHAKRA_API JsGetOwnPropertySymbols(_In_ JsValueRef object, _Out_ JsValueRef *propertySymbols)
 {
     return ContextAPIWrapper<true>([&](Js::ScriptContext *scriptContext) -> JsErrorCode {
         VALIDATE_INCOMING_OBJECT(object, scriptContext);
@@ -1048,7 +1048,7 @@ STDAPI_(JsErrorCode) JsGetOwnPropertySymbols(_In_ JsValueRef object, _Out_ JsVal
     });
 }
 
-STDAPI_(JsErrorCode) JsSetProperty(_In_ JsValueRef object, _In_ JsPropertyIdRef propertyId, _In_ JsValueRef value, _In_ bool useStrictRules)
+CHAKRA_API JsSetProperty(_In_ JsValueRef object, _In_ JsPropertyIdRef propertyId, _In_ JsValueRef value, _In_ bool useStrictRules)
 {
     return ContextAPIWrapper<true>([&] (Js::ScriptContext *scriptContext) -> JsErrorCode {
         VALIDATE_INCOMING_OBJECT(object, scriptContext);
@@ -1062,7 +1062,7 @@ STDAPI_(JsErrorCode) JsSetProperty(_In_ JsValueRef object, _In_ JsPropertyIdRef 
     });
 }
 
-STDAPI_(JsErrorCode) JsHasProperty(_In_ JsValueRef object, _In_ JsPropertyIdRef propertyId, _Out_ bool *hasProperty)
+CHAKRA_API JsHasProperty(_In_ JsValueRef object, _In_ JsPropertyIdRef propertyId, _Out_ bool *hasProperty)
 {
     return ContextAPIWrapper<true>([&] (Js::ScriptContext *scriptContext) -> JsErrorCode {
         VALIDATE_INCOMING_OBJECT(object, scriptContext);
@@ -1076,7 +1076,7 @@ STDAPI_(JsErrorCode) JsHasProperty(_In_ JsValueRef object, _In_ JsPropertyIdRef 
     });
 }
 
-STDAPI_(JsErrorCode) JsDeleteProperty(_In_ JsValueRef object, _In_ JsPropertyIdRef propertyId, _In_ bool useStrictRules, _Out_ JsValueRef *result)
+CHAKRA_API JsDeleteProperty(_In_ JsValueRef object, _In_ JsPropertyIdRef propertyId, _In_ bool useStrictRules, _Out_ JsValueRef *result)
 {
     return ContextAPIWrapper<true>([&] (Js::ScriptContext *scriptContext) -> JsErrorCode {
         VALIDATE_INCOMING_OBJECT(object, scriptContext);
@@ -1091,7 +1091,7 @@ STDAPI_(JsErrorCode) JsDeleteProperty(_In_ JsValueRef object, _In_ JsPropertyIdR
     });
 }
 
-STDAPI_(JsErrorCode) JsDefineProperty(_In_ JsValueRef object, _In_ JsPropertyIdRef propertyId, _In_ JsValueRef propertyDescriptor, _Out_ bool *result)
+CHAKRA_API JsDefineProperty(_In_ JsValueRef object, _In_ JsPropertyIdRef propertyId, _In_ JsValueRef propertyDescriptor, _Out_ bool *result)
 {
     return ContextAPIWrapper<true>([&] (Js::ScriptContext *scriptContext) -> JsErrorCode {
         VALIDATE_INCOMING_OBJECT(object, scriptContext);
@@ -1114,7 +1114,7 @@ STDAPI_(JsErrorCode) JsDefineProperty(_In_ JsValueRef object, _In_ JsPropertyIdR
     });
 }
 
-STDAPI_(JsErrorCode) JsCreateArray(_In_ unsigned int length, _Out_ JsValueRef *result)
+CHAKRA_API JsCreateArray(_In_ unsigned int length, _Out_ JsValueRef *result)
 {
     return ContextAPIWrapper<true>([&] (Js::ScriptContext *scriptContext) -> JsErrorCode {
         PARAM_NOT_NULL(result);
@@ -1126,7 +1126,7 @@ STDAPI_(JsErrorCode) JsCreateArray(_In_ unsigned int length, _Out_ JsValueRef *r
     });
 }
 
-STDAPI_(JsErrorCode) JsCreateArrayBuffer(_In_ unsigned int byteLength, _Out_ JsValueRef *result)
+CHAKRA_API JsCreateArrayBuffer(_In_ unsigned int byteLength, _Out_ JsValueRef *result)
 {
     return ContextAPIWrapper<true>([&](Js::ScriptContext *scriptContext) -> JsErrorCode {
         PARAM_NOT_NULL(result);
@@ -1139,7 +1139,7 @@ STDAPI_(JsErrorCode) JsCreateArrayBuffer(_In_ unsigned int byteLength, _Out_ JsV
     });
 }
 
-STDAPI_(JsErrorCode) JsCreateExternalArrayBuffer(_Pre_maybenull_ _Pre_writable_byte_size_(byteLength) void *data, _In_ unsigned int byteLength,
+CHAKRA_API JsCreateExternalArrayBuffer(_Pre_maybenull_ _Pre_writable_byte_size_(byteLength) void *data, _In_ unsigned int byteLength,
     _In_opt_ JsFinalizeCallback finalizeCallback, _In_opt_ void *callbackState, _Out_ JsValueRef *result)
 {
     return ContextAPIWrapper<true>([&](Js::ScriptContext *scriptContext) -> JsErrorCode {
@@ -1163,7 +1163,7 @@ STDAPI_(JsErrorCode) JsCreateExternalArrayBuffer(_Pre_maybenull_ _Pre_writable_b
     });
 }
 
-STDAPI_(JsErrorCode) JsCreateTypedArray(_In_ JsTypedArrayType arrayType, _In_ JsValueRef baseArray, _In_ unsigned int byteOffset,
+CHAKRA_API JsCreateTypedArray(_In_ JsTypedArrayType arrayType, _In_ JsValueRef baseArray, _In_ unsigned int byteOffset,
     _In_ unsigned int elementLength, _Out_ JsValueRef *result)
 {
     return ContextAPIWrapper<true>([&](Js::ScriptContext *scriptContext) -> JsErrorCode {
@@ -1242,7 +1242,7 @@ STDAPI_(JsErrorCode) JsCreateTypedArray(_In_ JsTypedArrayType arrayType, _In_ Js
     });
 }
 
-STDAPI_(JsErrorCode) JsCreateDataView(_In_ JsValueRef arrayBuffer, _In_ unsigned int byteOffset, _In_ unsigned int byteLength, _Out_ JsValueRef *result)
+CHAKRA_API JsCreateDataView(_In_ JsValueRef arrayBuffer, _In_ unsigned int byteOffset, _In_ unsigned int byteLength, _Out_ JsValueRef *result)
 {
     return ContextAPIWrapper<true>([&](Js::ScriptContext *scriptContext) -> JsErrorCode {
         VALIDATE_INCOMING_REFERENCE(arrayBuffer, scriptContext);
@@ -1277,7 +1277,7 @@ inline JsTypedArrayType GetTypedArrayType(Js::TypeId typeId)
     return static_cast<JsTypedArrayType>(typeId + (JsArrayTypeInt8 - Js::TypeIds_Int8Array));
 }
 
-STDAPI_(JsErrorCode) JsGetTypedArrayInfo(_In_ JsValueRef typedArray, _Out_opt_ JsTypedArrayType *arrayType, _Out_opt_ JsValueRef *arrayBuffer,
+CHAKRA_API JsGetTypedArrayInfo(_In_ JsValueRef typedArray, _Out_opt_ JsTypedArrayType *arrayType, _Out_opt_ JsValueRef *arrayBuffer,
     _Out_opt_ unsigned int *byteOffset, _Out_opt_ unsigned int *byteLength)
 {
     VALIDATE_JSREF(typedArray);
@@ -1311,7 +1311,7 @@ STDAPI_(JsErrorCode) JsGetTypedArrayInfo(_In_ JsValueRef typedArray, _Out_opt_ J
     END_JSRT_NO_EXCEPTION
 }
 
-STDAPI_(JsErrorCode) JsGetArrayBufferStorage(_In_ JsValueRef instance, _Outptr_result_bytebuffer_(*bufferLength) BYTE **buffer,
+CHAKRA_API JsGetArrayBufferStorage(_In_ JsValueRef instance, _Outptr_result_bytebuffer_(*bufferLength) BYTE **buffer,
     _Out_ unsigned int *bufferLength)
 {
     VALIDATE_JSREF(instance);
@@ -1332,7 +1332,7 @@ STDAPI_(JsErrorCode) JsGetArrayBufferStorage(_In_ JsValueRef instance, _Outptr_r
     END_JSRT_NO_EXCEPTION
 }
 
-STDAPI_(JsErrorCode) JsGetTypedArrayStorage(_In_ JsValueRef instance, _Outptr_result_bytebuffer_(*bufferLength) BYTE **buffer,
+CHAKRA_API JsGetTypedArrayStorage(_In_ JsValueRef instance, _Outptr_result_bytebuffer_(*bufferLength) BYTE **buffer,
     _Out_ unsigned int *bufferLength, _Out_opt_ JsTypedArrayType *typedArrayType, _Out_opt_ int *elementSize)
 {
     VALIDATE_JSREF(instance);
@@ -1397,7 +1397,7 @@ STDAPI_(JsErrorCode) JsGetTypedArrayStorage(_In_ JsValueRef instance, _Outptr_re
     END_JSRT_NO_EXCEPTION
 }
 
-STDAPI_(JsErrorCode) JsGetDataViewStorage(_In_ JsValueRef instance, _Outptr_result_bytebuffer_(*bufferLength) BYTE **buffer, _Out_ unsigned int *bufferLength)
+CHAKRA_API JsGetDataViewStorage(_In_ JsValueRef instance, _Outptr_result_bytebuffer_(*bufferLength) BYTE **buffer, _Out_ unsigned int *bufferLength)
 {
     VALIDATE_JSREF(instance);
     PARAM_NOT_NULL(buffer);
@@ -1418,7 +1418,7 @@ STDAPI_(JsErrorCode) JsGetDataViewStorage(_In_ JsValueRef instance, _Outptr_resu
 }
 
 
-STDAPI_(JsErrorCode) JsCreateSymbol(_In_ JsValueRef description, _Out_ JsValueRef *result)
+CHAKRA_API JsCreateSymbol(_In_ JsValueRef description, _Out_ JsValueRef *result)
 {
     return ContextAPIWrapper<true>([&](Js::ScriptContext *scriptContext) -> JsErrorCode {
         PARAM_NOT_NULL(result);
@@ -1442,7 +1442,7 @@ STDAPI_(JsErrorCode) JsCreateSymbol(_In_ JsValueRef description, _Out_ JsValueRe
     });
 }
 
-STDAPI_(JsErrorCode) JsHasIndexedProperty(_In_ JsValueRef object, _In_ JsValueRef index, _Out_ bool *result)
+CHAKRA_API JsHasIndexedProperty(_In_ JsValueRef object, _In_ JsValueRef index, _Out_ bool *result)
 {
     return ContextAPIWrapper<true>([&] (Js::ScriptContext *scriptContext) -> JsErrorCode {
         VALIDATE_INCOMING_OBJECT(object, scriptContext);
@@ -1456,7 +1456,7 @@ STDAPI_(JsErrorCode) JsHasIndexedProperty(_In_ JsValueRef object, _In_ JsValueRe
     });
 }
 
-STDAPI_(JsErrorCode) JsGetIndexedProperty(_In_ JsValueRef object, _In_ JsValueRef index, _Out_ JsValueRef *result)
+CHAKRA_API JsGetIndexedProperty(_In_ JsValueRef object, _In_ JsValueRef index, _Out_ JsValueRef *result)
 {
     return ContextAPIWrapper<true>([&] (Js::ScriptContext *scriptContext) -> JsErrorCode {
         VALIDATE_INCOMING_OBJECT(object, scriptContext);
@@ -1470,7 +1470,7 @@ STDAPI_(JsErrorCode) JsGetIndexedProperty(_In_ JsValueRef object, _In_ JsValueRe
     });
 }
 
-STDAPI_(JsErrorCode) JsSetIndexedProperty(_In_ JsValueRef object, _In_ JsValueRef index, _In_ JsValueRef value)
+CHAKRA_API JsSetIndexedProperty(_In_ JsValueRef object, _In_ JsValueRef index, _In_ JsValueRef value)
 {
     return ContextAPIWrapper<true>([&] (Js::ScriptContext *scriptContext) -> JsErrorCode {
         VALIDATE_INCOMING_OBJECT(object, scriptContext);
@@ -1483,7 +1483,7 @@ STDAPI_(JsErrorCode) JsSetIndexedProperty(_In_ JsValueRef object, _In_ JsValueRe
     });
 }
 
-STDAPI_(JsErrorCode) JsDeleteIndexedProperty(_In_ JsValueRef object, _In_ JsValueRef index)
+CHAKRA_API JsDeleteIndexedProperty(_In_ JsValueRef object, _In_ JsValueRef index)
 {
     return ContextAPIWrapper<true>([&] (Js::ScriptContext *scriptContext) -> JsErrorCode {
         VALIDATE_INCOMING_OBJECT(object, scriptContext);
@@ -1529,7 +1529,7 @@ void GetObjectArrayData(Js::ArrayObject* objectArray, void** data, JsTypedArrayT
     *length = typedArray->GetLength();
 }
 
-STDAPI_(JsErrorCode) JsSetIndexedPropertiesToExternalData(
+CHAKRA_API JsSetIndexedPropertiesToExternalData(
     _In_ JsValueRef object,
     _In_ void* data,
     _In_ JsTypedArrayType arrayType,
@@ -1597,7 +1597,7 @@ STDAPI_(JsErrorCode) JsSetIndexedPropertiesToExternalData(
     });
 }
 
-STDAPI_(JsErrorCode) JsHasIndexedPropertiesExternalData(_In_ JsValueRef object, _Out_ bool *value)
+CHAKRA_API JsHasIndexedPropertiesExternalData(_In_ JsValueRef object, _Out_ bool *value)
 {
     VALIDATE_JSREF(object);
     PARAM_NOT_NULL(value);
@@ -1616,7 +1616,7 @@ STDAPI_(JsErrorCode) JsHasIndexedPropertiesExternalData(_In_ JsValueRef object, 
     END_JSRT_NO_EXCEPTION
 }
 
-STDAPI_(JsErrorCode) JsGetIndexedPropertiesExternalData(
+CHAKRA_API JsGetIndexedPropertiesExternalData(
     _In_ JsValueRef object,
     _Out_ void** buffer,
     _Out_ JsTypedArrayType* arrayType,
@@ -1681,7 +1681,7 @@ STDAPI_(JsErrorCode) JsGetIndexedPropertiesExternalData(
     END_JSRT_NO_EXCEPTION
 }
 
-STDAPI_(JsErrorCode) JsEquals(_In_ JsValueRef object1, _In_ JsValueRef object2, _Out_ bool *result)
+CHAKRA_API JsEquals(_In_ JsValueRef object1, _In_ JsValueRef object2, _Out_ bool *result)
 {
     return ContextAPIWrapper<true>([&] (Js::ScriptContext *scriptContext) -> JsErrorCode {
         VALIDATE_INCOMING_REFERENCE(object1, scriptContext);
@@ -1693,7 +1693,7 @@ STDAPI_(JsErrorCode) JsEquals(_In_ JsValueRef object1, _In_ JsValueRef object2, 
     });
 }
 
-STDAPI_(JsErrorCode) JsStrictEquals(_In_ JsValueRef object1, _In_ JsValueRef object2, _Out_ bool *result)
+CHAKRA_API JsStrictEquals(_In_ JsValueRef object1, _In_ JsValueRef object2, _Out_ bool *result)
 {
     return ContextAPIWrapper<true>([&] (Js::ScriptContext *scriptContext) -> JsErrorCode {
         VALIDATE_INCOMING_REFERENCE(object1, scriptContext);
@@ -1705,7 +1705,7 @@ STDAPI_(JsErrorCode) JsStrictEquals(_In_ JsValueRef object1, _In_ JsValueRef obj
     });
 }
 
-STDAPI_(JsErrorCode) JsHasExternalData(_In_ JsValueRef object, _Out_ bool *value)
+CHAKRA_API JsHasExternalData(_In_ JsValueRef object, _Out_ bool *value)
 {
     VALIDATE_JSREF(object);
     PARAM_NOT_NULL(value);
@@ -1717,7 +1717,7 @@ STDAPI_(JsErrorCode) JsHasExternalData(_In_ JsValueRef object, _Out_ bool *value
     END_JSRT_NO_EXCEPTION
 }
 
-STDAPI_(JsErrorCode) JsGetExternalData(_In_ JsValueRef object, _Out_ void **data)
+CHAKRA_API JsGetExternalData(_In_ JsValueRef object, _Out_ void **data)
 {
     VALIDATE_JSREF(object);
     PARAM_NOT_NULL(data);
@@ -1737,7 +1737,7 @@ STDAPI_(JsErrorCode) JsGetExternalData(_In_ JsValueRef object, _Out_ void **data
     END_JSRT_NO_EXCEPTION
 }
 
-STDAPI_(JsErrorCode) JsSetExternalData(_In_ JsValueRef object, _In_opt_ void *data)
+CHAKRA_API JsSetExternalData(_In_ JsValueRef object, _In_opt_ void *data)
 {
     VALIDATE_JSREF(object);
 
@@ -1755,7 +1755,7 @@ STDAPI_(JsErrorCode) JsSetExternalData(_In_ JsValueRef object, _In_opt_ void *da
     END_JSRT_NO_EXCEPTION
 }
 
-STDAPI_(JsErrorCode) JsCallFunction(_In_ JsValueRef function, _In_reads_(cargs) JsValueRef *args, _In_ ushort cargs, _Out_opt_ JsValueRef *result)
+CHAKRA_API JsCallFunction(_In_ JsValueRef function, _In_reads_(cargs) JsValueRef *args, _In_ ushort cargs, _Out_opt_ JsValueRef *result)
 {
     if (result != nullptr)
     {
@@ -1789,7 +1789,7 @@ STDAPI_(JsErrorCode) JsCallFunction(_In_ JsValueRef function, _In_reads_(cargs) 
     });
 }
 
-STDAPI_(JsErrorCode) JsConstructObject(_In_ JsValueRef function, _In_reads_(cargs) JsValueRef *args, _In_ ushort cargs, _Out_ JsValueRef *result)
+CHAKRA_API JsConstructObject(_In_ JsValueRef function, _In_reads_(cargs) JsValueRef *args, _In_ ushort cargs, _Out_ JsValueRef *result)
 {
     return ContextAPIWrapper<true>([&] (Js::ScriptContext *scriptContext) -> JsErrorCode {
         VALIDATE_INCOMING_FUNCTION(function, scriptContext);
@@ -1816,7 +1816,7 @@ STDAPI_(JsErrorCode) JsConstructObject(_In_ JsValueRef function, _In_reads_(carg
     });
 }
 
-STDAPI_(JsErrorCode) JsCreateFunction(_In_ JsNativeFunction nativeFunction, _In_opt_ void *callbackState, _Out_ JsValueRef *function)
+CHAKRA_API JsCreateFunction(_In_ JsNativeFunction nativeFunction, _In_opt_ void *callbackState, _Out_ JsValueRef *function)
 {
     return ContextAPIWrapper<true>([&] (Js::ScriptContext *scriptContext) -> JsErrorCode {
         PARAM_NOT_NULL(nativeFunction);
@@ -1830,7 +1830,7 @@ STDAPI_(JsErrorCode) JsCreateFunction(_In_ JsNativeFunction nativeFunction, _In_
     });
 }
 
-STDAPI_(JsErrorCode) JsCreateNamedFunction(_In_ JsValueRef name, _In_ JsNativeFunction nativeFunction, _In_opt_ void *callbackState, _Out_ JsValueRef *function)
+CHAKRA_API JsCreateNamedFunction(_In_ JsValueRef name, _In_ JsNativeFunction nativeFunction, _In_opt_ void *callbackState, _Out_ JsValueRef *function)
 {
     return ContextAPIWrapper<true>([&](Js::ScriptContext *scriptContext) -> JsErrorCode {
         VALIDATE_INCOMING_REFERENCE(name, scriptContext);
@@ -1859,7 +1859,7 @@ void SetErrorMessage(Js::ScriptContext *scriptContext, JsValueRef newError, JsVa
     Js::JavascriptOperators::OP_SetProperty(newError, Js::PropertyIds::message, message, scriptContext);
 }
 
-STDAPI_(JsErrorCode) JsCreateError(_In_ JsValueRef message, _Out_ JsValueRef *error)
+CHAKRA_API JsCreateError(_In_ JsValueRef message, _Out_ JsValueRef *error)
 {
     return ContextAPIWrapper<true>([&] (Js::ScriptContext * scriptContext) -> JsErrorCode {
         VALIDATE_INCOMING_REFERENCE(message, scriptContext);
@@ -1874,7 +1874,7 @@ STDAPI_(JsErrorCode) JsCreateError(_In_ JsValueRef message, _Out_ JsValueRef *er
     });
 }
 
-STDAPI_(JsErrorCode) JsCreateRangeError(_In_ JsValueRef message, _Out_ JsValueRef *error)
+CHAKRA_API JsCreateRangeError(_In_ JsValueRef message, _Out_ JsValueRef *error)
 {
     return ContextAPIWrapper<true>([&] (Js::ScriptContext * scriptContext) -> JsErrorCode {
         VALIDATE_INCOMING_REFERENCE(message, scriptContext);
@@ -1891,7 +1891,7 @@ STDAPI_(JsErrorCode) JsCreateRangeError(_In_ JsValueRef message, _Out_ JsValueRe
     });
 }
 
-STDAPI_(JsErrorCode) JsCreateReferenceError(_In_ JsValueRef message, _Out_ JsValueRef *error)
+CHAKRA_API JsCreateReferenceError(_In_ JsValueRef message, _Out_ JsValueRef *error)
 {
     return ContextAPIWrapper<true>([&] (Js::ScriptContext * scriptContext) -> JsErrorCode {
         VALIDATE_INCOMING_REFERENCE(message, scriptContext);
@@ -1908,7 +1908,7 @@ STDAPI_(JsErrorCode) JsCreateReferenceError(_In_ JsValueRef message, _Out_ JsVal
     });
 }
 
-STDAPI_(JsErrorCode) JsCreateSyntaxError(_In_ JsValueRef message, _Out_ JsValueRef *error)
+CHAKRA_API JsCreateSyntaxError(_In_ JsValueRef message, _Out_ JsValueRef *error)
 {
     return ContextAPIWrapper<true>([&] (Js::ScriptContext * scriptContext) -> JsErrorCode {
         VALIDATE_INCOMING_REFERENCE(message, scriptContext);
@@ -1925,7 +1925,7 @@ STDAPI_(JsErrorCode) JsCreateSyntaxError(_In_ JsValueRef message, _Out_ JsValueR
     });
 }
 
-STDAPI_(JsErrorCode) JsCreateTypeError(_In_ JsValueRef message, _Out_ JsValueRef *error)
+CHAKRA_API JsCreateTypeError(_In_ JsValueRef message, _Out_ JsValueRef *error)
 {
     return ContextAPIWrapper<true>([&] (Js::ScriptContext * scriptContext) -> JsErrorCode {
         VALIDATE_INCOMING_REFERENCE(message, scriptContext);
@@ -1942,7 +1942,7 @@ STDAPI_(JsErrorCode) JsCreateTypeError(_In_ JsValueRef message, _Out_ JsValueRef
     });
 }
 
-STDAPI_(JsErrorCode) JsCreateURIError(_In_ JsValueRef message, _Out_ JsValueRef *error)
+CHAKRA_API JsCreateURIError(_In_ JsValueRef message, _Out_ JsValueRef *error)
 {
     return ContextAPIWrapper<true>([&] (Js::ScriptContext * scriptContext) -> JsErrorCode {
         VALIDATE_INCOMING_REFERENCE(message, scriptContext);
@@ -1959,7 +1959,7 @@ STDAPI_(JsErrorCode) JsCreateURIError(_In_ JsValueRef message, _Out_ JsValueRef 
     });
 }
 
-STDAPI_(JsErrorCode) JsHasException(_Out_ bool *hasException)
+CHAKRA_API JsHasException(_Out_ bool *hasException)
 {
     PARAM_NOT_NULL(hasException);
     *hasException = false;
@@ -1993,7 +1993,7 @@ STDAPI_(JsErrorCode) JsHasException(_Out_ bool *hasException)
     return JsNoError;
 }
 
-STDAPI_(JsErrorCode) JsGetAndClearException(_Out_ JsValueRef *exception)
+CHAKRA_API JsGetAndClearException(_Out_ JsValueRef *exception)
 {
     PARAM_NOT_NULL(exception);
     *exception = nullptr;
@@ -2046,7 +2046,7 @@ STDAPI_(JsErrorCode) JsGetAndClearException(_Out_ JsValueRef *exception)
     return JsNoError;
 }
 
-STDAPI_(JsErrorCode) JsSetException(_In_ JsValueRef exception)
+CHAKRA_API JsSetException(_In_ JsValueRef exception)
 {
     return ContextAPINoScriptWrapper([&](Js::ScriptContext* scriptContext) -> JsErrorCode {
         VALIDATE_INCOMING_REFERENCE(exception, scriptContext);
@@ -2064,7 +2064,7 @@ STDAPI_(JsErrorCode) JsSetException(_In_ JsValueRef exception)
     });
 }
 
-STDAPI_(JsErrorCode) JsGetRuntimeMemoryUsage(_In_ JsRuntimeHandle runtimeHandle, _Out_ size_t * memoryUsage)
+CHAKRA_API JsGetRuntimeMemoryUsage(_In_ JsRuntimeHandle runtimeHandle, _Out_ size_t * memoryUsage)
 {
     VALIDATE_INCOMING_RUNTIME_HANDLE(runtimeHandle);
     PARAM_NOT_NULL(memoryUsage);
@@ -2078,7 +2078,7 @@ STDAPI_(JsErrorCode) JsGetRuntimeMemoryUsage(_In_ JsRuntimeHandle runtimeHandle,
     return JsNoError;
 }
 
-STDAPI_(JsErrorCode) JsSetRuntimeMemoryLimit(_In_ JsRuntimeHandle runtimeHandle, _In_ size_t memoryLimit)
+CHAKRA_API JsSetRuntimeMemoryLimit(_In_ JsRuntimeHandle runtimeHandle, _In_ size_t memoryLimit)
 {
     VALIDATE_INCOMING_RUNTIME_HANDLE(runtimeHandle);
 
@@ -2090,7 +2090,7 @@ STDAPI_(JsErrorCode) JsSetRuntimeMemoryLimit(_In_ JsRuntimeHandle runtimeHandle,
     return JsNoError;
 }
 
-STDAPI_(JsErrorCode) JsGetRuntimeMemoryLimit(_In_ JsRuntimeHandle runtimeHandle, _Out_ size_t * memoryLimit)
+CHAKRA_API JsGetRuntimeMemoryLimit(_In_ JsRuntimeHandle runtimeHandle, _Out_ size_t * memoryLimit)
 {
     VALIDATE_INCOMING_RUNTIME_HANDLE(runtimeHandle);
     PARAM_NOT_NULL(memoryLimit);
@@ -2109,7 +2109,7 @@ C_ASSERT(JsMemoryFree == AllocationPolicyManager::MemoryAllocateEvent::MemoryFre
 C_ASSERT(JsMemoryFailure == AllocationPolicyManager::MemoryAllocateEvent::MemoryFailure);
 C_ASSERT(JsMemoryFailure == AllocationPolicyManager::MemoryAllocateEvent::MemoryMax);
 
-STDAPI_(JsErrorCode) JsSetRuntimeMemoryAllocationCallback(_In_ JsRuntimeHandle runtime, _In_opt_ void *callbackState, _In_ JsMemoryAllocationCallback allocationCallback)
+CHAKRA_API JsSetRuntimeMemoryAllocationCallback(_In_ JsRuntimeHandle runtime, _In_opt_ void *callbackState, _In_ JsMemoryAllocationCallback allocationCallback)
 {
     VALIDATE_INCOMING_RUNTIME_HANDLE(runtime);
 
@@ -2121,7 +2121,7 @@ STDAPI_(JsErrorCode) JsSetRuntimeMemoryAllocationCallback(_In_ JsRuntimeHandle r
     return JsNoError;
 }
 
-STDAPI_(JsErrorCode) JsSetRuntimeBeforeCollectCallback(_In_ JsRuntimeHandle runtime, _In_opt_ void *callbackState, _In_ JsBeforeCollectCallback beforeCollectCallback)
+CHAKRA_API JsSetRuntimeBeforeCollectCallback(_In_ JsRuntimeHandle runtime, _In_opt_ void *callbackState, _In_ JsBeforeCollectCallback beforeCollectCallback)
 {
     return GlobalAPIWrapper([&]() -> JsErrorCode {
         VALIDATE_INCOMING_RUNTIME_HANDLE(runtime);
@@ -2131,7 +2131,7 @@ STDAPI_(JsErrorCode) JsSetRuntimeBeforeCollectCallback(_In_ JsRuntimeHandle runt
     });
 }
 
-STDAPI_(JsErrorCode) JsDisableRuntimeExecution(_In_ JsRuntimeHandle runtimeHandle)
+CHAKRA_API JsDisableRuntimeExecution(_In_ JsRuntimeHandle runtimeHandle)
 {
     VALIDATE_INCOMING_RUNTIME_HANDLE(runtimeHandle);
 
@@ -2154,7 +2154,7 @@ STDAPI_(JsErrorCode) JsDisableRuntimeExecution(_In_ JsRuntimeHandle runtimeHandl
     return JsNoError;
 }
 
-STDAPI_(JsErrorCode) JsEnableRuntimeExecution(_In_ JsRuntimeHandle runtimeHandle)
+CHAKRA_API JsEnableRuntimeExecution(_In_ JsRuntimeHandle runtimeHandle)
 {
     return GlobalAPIWrapper([&] () -> JsErrorCode {
         VALIDATE_INCOMING_RUNTIME_HANDLE(runtimeHandle);
@@ -2186,7 +2186,7 @@ STDAPI_(JsErrorCode) JsEnableRuntimeExecution(_In_ JsRuntimeHandle runtimeHandle
     });
 }
 
-STDAPI_(JsErrorCode) JsIsRuntimeExecutionDisabled(_In_ JsRuntimeHandle runtimeHandle, _Out_ bool *isDisabled)
+CHAKRA_API JsIsRuntimeExecutionDisabled(_In_ JsRuntimeHandle runtimeHandle, _Out_ bool *isDisabled)
 {
     VALIDATE_INCOMING_RUNTIME_HANDLE(runtimeHandle);
     PARAM_NOT_NULL(isDisabled);
@@ -2197,7 +2197,7 @@ STDAPI_(JsErrorCode) JsIsRuntimeExecutionDisabled(_In_ JsRuntimeHandle runtimeHa
     return JsNoError;
 }
 
-STDAPI_(JsErrorCode) JsGetPropertyIdFromName(_In_z_ const wchar_t *name, _Out_ JsPropertyIdRef *propertyId)
+CHAKRA_API JsGetPropertyIdFromName(_In_z_ const wchar_t *name, _Out_ JsPropertyIdRef *propertyId)
 {
     return ContextAPINoScriptWrapper([&](Js::ScriptContext * scriptContext) -> JsErrorCode {
         PARAM_NOT_NULL(name);
@@ -2221,7 +2221,7 @@ STDAPI_(JsErrorCode) JsGetPropertyIdFromName(_In_z_ const wchar_t *name, _Out_ J
     });
 }
 
-STDAPI_(JsErrorCode) JsGetPropertyIdFromSymbol(_In_ JsValueRef symbol, _Out_ JsPropertyIdRef *propertyId)
+CHAKRA_API JsGetPropertyIdFromSymbol(_In_ JsValueRef symbol, _Out_ JsPropertyIdRef *propertyId)
 {
     return ContextAPINoScriptWrapper([&](Js::ScriptContext * scriptContext) -> JsErrorCode {
         VALIDATE_INCOMING_REFERENCE(symbol, scriptContext);
@@ -2239,7 +2239,7 @@ STDAPI_(JsErrorCode) JsGetPropertyIdFromSymbol(_In_ JsValueRef symbol, _Out_ JsP
     /*allowInObjectBeforeCollectCallback*/true);
 }
 
-STDAPI_(JsErrorCode) JsGetSymbolFromPropertyId(_In_ JsPropertyIdRef propertyId, _Out_ JsValueRef *symbol)
+CHAKRA_API JsGetSymbolFromPropertyId(_In_ JsPropertyIdRef propertyId, _Out_ JsValueRef *symbol)
 {
     return ContextAPINoScriptWrapper([&](Js::ScriptContext * scriptContext) -> JsErrorCode {
         VALIDATE_INCOMING_PROPERTYID(propertyId);
@@ -2258,7 +2258,7 @@ STDAPI_(JsErrorCode) JsGetSymbolFromPropertyId(_In_ JsPropertyIdRef propertyId, 
 }
 
 #pragma prefast(suppress:6101, "Prefast doesn't see through the lambda")
-STDAPI_(JsErrorCode) JsGetPropertyNameFromId(_In_ JsPropertyIdRef propertyId, _Outptr_result_z_ const wchar_t **name)
+CHAKRA_API JsGetPropertyNameFromId(_In_ JsPropertyIdRef propertyId, _Outptr_result_z_ const wchar_t **name)
 {
     return GlobalAPIWrapper([&]() -> JsErrorCode {
         VALIDATE_INCOMING_PROPERTYID(propertyId);
@@ -2277,7 +2277,7 @@ STDAPI_(JsErrorCode) JsGetPropertyNameFromId(_In_ JsPropertyIdRef propertyId, _O
     });
 }
 
-STDAPI_(JsErrorCode) JsGetPropertyIdType(_In_ JsPropertyIdRef propertyId, _Out_ JsPropertyIdType* propertyIdType)
+CHAKRA_API JsGetPropertyIdType(_In_ JsPropertyIdRef propertyId, _Out_ JsPropertyIdType* propertyIdType)
 {
     return GlobalAPIWrapper([&]() -> JsErrorCode {
         VALIDATE_INCOMING_PROPERTYID(propertyId);
@@ -2297,7 +2297,7 @@ STDAPI_(JsErrorCode) JsGetPropertyIdType(_In_ JsPropertyIdRef propertyId, _Out_ 
 }
 
 
-STDAPI_(JsErrorCode) JsGetRuntime(_In_ JsContextRef context, _Out_ JsRuntimeHandle *runtime)
+CHAKRA_API JsGetRuntime(_In_ JsContextRef context, _Out_ JsRuntimeHandle *runtime)
 {
     VALIDATE_JSREF(context);
     PARAM_NOT_NULL(runtime);
@@ -2313,7 +2313,7 @@ STDAPI_(JsErrorCode) JsGetRuntime(_In_ JsContextRef context, _Out_ JsRuntimeHand
     return JsNoError;
 }
 
-STDAPI_(JsErrorCode) JsIdle(_Out_opt_ unsigned int *nextIdleTick)
+CHAKRA_API JsIdle(_Out_opt_ unsigned int *nextIdleTick)
 {
     PARAM_NOT_NULL(nextIdleTick);
 
@@ -2347,7 +2347,7 @@ STDAPI_(JsErrorCode) JsIdle(_Out_opt_ unsigned int *nextIdleTick)
     });
 }
 
-STDAPI_(JsErrorCode) JsSetPromiseContinuationCallback(_In_ JsPromiseContinuationCallback promiseContinuationCallback, _In_opt_ void *callbackState)
+CHAKRA_API JsSetPromiseContinuationCallback(_In_ JsPromiseContinuationCallback promiseContinuationCallback, _In_opt_ void *callbackState)
 {
     return ContextAPINoScriptWrapper([&](Js::ScriptContext * scriptContext) -> JsErrorCode {
         PARAM_NOT_NULL(promiseContinuationCallback);
@@ -2451,12 +2451,12 @@ JsErrorCode RunScriptCore(const wchar_t *script, JsSourceContext sourceContext, 
     });
 }
 
-STDAPI_(JsErrorCode) JsParseScript(_In_z_ const wchar_t * script, _In_ JsSourceContext sourceContext, _In_z_ const wchar_t *sourceUrl, _Out_ JsValueRef * result)
+CHAKRA_API JsParseScript(_In_z_ const wchar_t * script, _In_ JsSourceContext sourceContext, _In_z_ const wchar_t *sourceUrl, _Out_ JsValueRef * result)
 {
     return RunScriptCore(script, sourceContext, sourceUrl, true, JsParseScriptAttributeNone, false, result);
 }
 
-STDAPI_(JsErrorCode) JsParseScriptWithAttributes(
+CHAKRA_API JsParseScriptWithAttributes(
     _In_z_ const wchar_t *script,
     _In_ JsSourceContext sourceContext,
     _In_z_ const wchar_t *sourceUrl,
@@ -2466,17 +2466,17 @@ STDAPI_(JsErrorCode) JsParseScriptWithAttributes(
     return RunScriptCore(script, sourceContext, sourceUrl, true, parseAttributes, false, result);
 }
 
-STDAPI_(JsErrorCode) JsRunScript(_In_z_ const wchar_t * script, _In_ JsSourceContext sourceContext, _In_z_ const wchar_t *sourceUrl, _Out_ JsValueRef * result)
+CHAKRA_API JsRunScript(_In_z_ const wchar_t * script, _In_ JsSourceContext sourceContext, _In_z_ const wchar_t *sourceUrl, _Out_ JsValueRef * result)
 {
     return RunScriptCore(script, sourceContext, sourceUrl, false, JsParseScriptAttributeNone, false, result);
 }
 
-STDAPI_(JsErrorCode) JsExperimentalApiRunModule(_In_z_ const wchar_t * script, _In_ JsSourceContext sourceContext, _In_z_ const wchar_t *sourceUrl, _Out_ JsValueRef * result)
+CHAKRA_API JsExperimentalApiRunModule(_In_z_ const wchar_t * script, _In_ JsSourceContext sourceContext, _In_z_ const wchar_t *sourceUrl, _Out_ JsValueRef * result)
 {
     return RunScriptCore(script, sourceContext, sourceUrl, false, JsParseScriptAttributeNone, true, result);
 }
 
-JsErrorCode JsSerializeScriptCore(const wchar_t *script, BYTE *functionTable, int functionTableSize, unsigned char *buffer, unsigned long *bufferSize)
+JsErrorCode JsSerializeScriptCore(const wchar_t *script, BYTE *functionTable, int functionTableSize, unsigned char *buffer, unsigned int *bufferSize)
 {
     Js::JavascriptFunction *function;
     CompileScriptException se;
@@ -2562,7 +2562,10 @@ JsErrorCode JsSerializeScriptCore(const wchar_t *script, BYTE *functionTable, in
 #endif
 
         BEGIN_TEMP_ALLOCATOR(tempAllocator, scriptContext, L"ByteCodeSerializer");
-        HRESULT hr = Js::ByteCodeSerializer::SerializeToBuffer(scriptContext, tempAllocator, static_cast<DWORD>(cSourceCodeLength), utf8Code, 0, nullptr, functionBody, functionBody->GetHostSrcInfo(), false, &buffer, bufferSize, dwFlags);
+        // We cast buffer size to DWORD* because on Windows, DWORD = unsigned long = unsigned int
+        // On 64-bit clang on linux, this is not true, unsigned long is larger than unsigned int
+        // However, the PAL defines DWORD for us on linux as unsigned int so the cast is safe here.
+        HRESULT hr = Js::ByteCodeSerializer::SerializeToBuffer(scriptContext, tempAllocator, static_cast<DWORD>(cSourceCodeLength), utf8Code, 0, nullptr, functionBody, functionBody->GetHostSrcInfo(), false, &buffer, (DWORD*) bufferSize, dwFlags);
         END_TEMP_ALLOCATOR(tempAllocator, scriptContext);
 
         if (SUCCEEDED(hr))
@@ -2577,8 +2580,8 @@ JsErrorCode JsSerializeScriptCore(const wchar_t *script, BYTE *functionTable, in
 
 }
 
-STDAPI_(JsErrorCode) JsSerializeScript(_In_z_ const wchar_t *script, _Out_writes_to_opt_(*bufferSize, *bufferSize) unsigned char *buffer,
-    _Inout_ unsigned long *bufferSize)
+CHAKRA_API JsSerializeScript(_In_z_ const wchar_t *script, _Out_writes_to_opt_(*bufferSize, *bufferSize) unsigned char *buffer,
+    _Inout_ unsigned int *bufferSize)
 {
     return JsSerializeScriptCore(script, nullptr, 0, buffer, bufferSize);
 }
@@ -2694,24 +2697,24 @@ JsErrorCode RunSerializedScriptCore(const wchar_t *script, JsSerializedScriptLoa
     });
 }
 
-STDAPI_(JsErrorCode) JsParseSerializedScript(_In_z_ const wchar_t * script, _In_ unsigned char *buffer, _In_ JsSourceContext sourceContext,
+CHAKRA_API JsParseSerializedScript(_In_z_ const wchar_t * script, _In_ unsigned char *buffer, _In_ JsSourceContext sourceContext,
     _In_z_ const wchar_t *sourceUrl, _Out_ JsValueRef * result)
 {
     return RunSerializedScriptCore(script, nullptr, nullptr, buffer, sourceContext, sourceUrl, true, result);
 }
 
-STDAPI_(JsErrorCode) JsRunSerializedScript(_In_z_ const wchar_t * script, _In_ unsigned char *buffer, _In_ JsSourceContext sourceContext,
+CHAKRA_API JsRunSerializedScript(_In_z_ const wchar_t * script, _In_ unsigned char *buffer, _In_ JsSourceContext sourceContext,
     _In_z_ const wchar_t *sourceUrl, _Out_ JsValueRef * result)
 {
     return RunSerializedScriptCore(script, nullptr, nullptr, buffer, sourceContext, sourceUrl, false, result);
 }
 
-STDAPI_(JsErrorCode) JsParseSerializedScriptWithCallback(_In_ JsSerializedScriptLoadSourceCallback scriptLoadCallback, _In_ JsSerializedScriptUnloadCallback scriptUnloadCallback, _In_ unsigned char *buffer, _In_ JsSourceContext sourceContext, _In_z_ const wchar_t *sourceUrl, _Out_ JsValueRef * result)
+CHAKRA_API JsParseSerializedScriptWithCallback(_In_ JsSerializedScriptLoadSourceCallback scriptLoadCallback, _In_ JsSerializedScriptUnloadCallback scriptUnloadCallback, _In_ unsigned char *buffer, _In_ JsSourceContext sourceContext, _In_z_ const wchar_t *sourceUrl, _Out_ JsValueRef * result)
 {
     return RunSerializedScriptCore(nullptr, scriptLoadCallback, scriptUnloadCallback, buffer, sourceContext, sourceUrl, true, result);
 }
 
-STDAPI_(JsErrorCode) JsRunSerializedScriptWithCallback(_In_ JsSerializedScriptLoadSourceCallback scriptLoadCallback, _In_ JsSerializedScriptUnloadCallback scriptUnloadCallback, _In_ unsigned char *buffer, _In_ JsSourceContext sourceContext, _In_z_ const wchar_t *sourceUrl, _Out_opt_ JsValueRef * result)
+CHAKRA_API JsRunSerializedScriptWithCallback(_In_ JsSerializedScriptLoadSourceCallback scriptLoadCallback, _In_ JsSerializedScriptUnloadCallback scriptUnloadCallback, _In_ unsigned char *buffer, _In_ JsSourceContext sourceContext, _In_z_ const wchar_t *sourceUrl, _Out_opt_ JsValueRef * result)
 {
     return RunSerializedScriptCore(nullptr, scriptLoadCallback, scriptUnloadCallback, buffer, sourceContext, sourceUrl, false, result);
 }


### PR DESCRIPTION
This change introduces the cross-platform API shape for JSRT.
It starts with the following assumptions:
-  Changing the definition of existing APIs is ok, as long as the effective shape doesnt change
   (so it's fine to use new macros etc as long as signature/calling convention/linkage etc doesn't change)
-  Existing APIs which take wchar_t* as a parameter will be exposed only on Windows
-  New variants of these APIs that take in UTF-8 strings will be exposed on *all* platforms

Here is a summary of the changes:

New macros introduced:
CHAKRA_CALLBACK - Calling convention attribute of callback functions consumed by jsrt APIs. Used in place of Win32 CALLBACK macro.
CHAKRA_API - Calling convention, linkage and return type of Jsrt APIs (always returns JsErrorCode). Used in place of Win32 STDAPI_ macro.

New types introduced
ChakraCookie - Type of cookies consumed by Jsrt Apis. Used in place of Win32 DWORD_PTR datatype.
JsSerializedScriptLoadUtf8SourceCallback - Callback called to load source code of serialized script encoded as utf8

Following APIs become WIN32 only:
JsParseScript
JsParseScriptWithFlags
JsRunScript
JsExperimentalApiRunModule
JsSerializeScript
JsParseSerializedScriptWithCallback
JsRunSerializedScriptWithCallback
JsParseSerializedScript
JsRunSerializedScript
JsGetPropertyIdFromName
JsGetPropertyNameFromId
JsPointerToString
JsStringToPointer

New APIs introduced (available on all platforms):
JsParseScriptUtf8
JsParseScriptWithAttributesUtf8
JsRunScriptUtf8
JsExperimentalApiRunModuleUtf8
JsRunScriptUtf8
JsExperimentalApiRunModuleUtf8
JsSerializeScriptUtf8
JsParseSerializedScriptUtf8
JsRunSerializedScriptUtf8
JsGetPropertyIdFromNameUtf8
JsGetPropertyNameFromIdUtf8
JsPointerToStringUtf8
JsStringToPointerUtf8

Couple notes:
-      All utf8 strings are passed in as char*
-      All string parameters in the new APIs are utf8 (e.g source, url etc).

