### PR TITLE
Module script sources should be visible in the debugger

### DIFF
--- a/lib/Backend/IRBuilder.cpp
+++ b/lib/Backend/IRBuilder.cpp
@@ -3677,7 +3677,7 @@ IRBuilder::BuildElementSlotI2(Js::OpCode newOpcode, uint32 offset, Js::RegSlot r
             instr = IR::Instr::New(Js::OpCode::Ld_A, regOpnd, addrOpnd, m_func);
             this->AddInstr(instr, offset);
 
-            fieldSym = PropertySym::FindOrCreate(regOpnd->m_sym->m_id, slotId2, (uint32)-1, (uint)-1, PropertyKindSlots, m_func);
+            fieldSym = PropertySym::New(regOpnd->m_sym, slotId2, (uint32)-1, (uint)-1, PropertyKindSlots, m_func);
             fieldOpnd = IR::SymOpnd::New(fieldSym, TyVar, m_func);
             
             if (newOpcode == Js::OpCode::LdModuleSlot)

--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -1627,7 +1627,9 @@ namespace Js
             // We do not own the memory passed into DefaultLoadScriptUtf8. We need to save it so we copy the memory.
             if (*ppSourceInfo == nullptr)
             {
-                *ppSourceInfo = Utf8SourceInfo::New(this, script, parser->GetSourceIchLim(), cb, pSrcInfo, isLibraryCode);
+                // the 'length' here is not correct - we will get the length from the parser - however parser hasn't done yet.
+                // Once the parser is done we will update the utf8sourceinfo's lenght correctly with parser's
+                *ppSourceInfo = Utf8SourceInfo::New(this, script, (int)length, cb, pSrcInfo, isLibraryCode);
             }
         }
         //
@@ -1698,6 +1700,8 @@ namespace Js
         }
         else
         {
+            // Update the length.
+            (*ppSourceInfo)->SetCchLength(parser->GetSourceIchLim());
             *sourceIndex = this->SaveSourceNoCopy(*ppSourceInfo, parser->GetSourceIchLim(), /* isCesu8*/ false);
         }
 

--- a/lib/Runtime/Language/SourceTextModuleRecord.h
+++ b/lib/Runtime/Language/SourceTextModuleRecord.h
@@ -56,7 +56,7 @@ namespace Js
         void SetrequestedModuleList(IdentPtrList* requestModules) { requestedModuleList = requestModules; }
 
         ScriptContext* GetScriptContext() const { return scriptContext; }
-        HRESULT ParseSource(__in_bcount(sourceLength) byte* sourceText, unsigned long sourceLength, Var* exceptionVar, bool isUtf8);
+        HRESULT ParseSource(__in_bcount(sourceLength) byte* sourceText, unsigned long sourceLength, SRCINFO * srcInfo, Var* exceptionVar, bool isUtf8);
         HRESULT OnHostException(void* errorVar);
 
         static SourceTextModuleRecord* FromHost(void* hostModuleRecord)
@@ -78,6 +78,8 @@ namespace Js
         void AddParent(SourceTextModuleRecord* parentRecord, LPCWSTR specifier, unsigned long specifierLength);
 #endif
 
+        Utf8SourceInfo* GetSourceInfo() { return this->pSourceInfo; }
+
     private:
         const static uint InvalidModuleIndex = 0xffffffff;
         const static uint InvalidSlotCount = 0xffffffff;
@@ -88,7 +90,6 @@ namespace Js
         bool wasDeclarationInitialized;
         bool isRootModule;
         ParseNodePtr parseTree;
-        SRCINFO srcInfo; 
         Utf8SourceInfo* pSourceInfo;
         uint sourceIndex;
         Parser* parser;  // we'll need to keep the parser around till we are done with bytecode gen.


### PR DESCRIPTION
Scipts within modules were not registered to the debugger. This work enables
them to register them properly. The dwHostSourceContext was already setup
correctly, the work remaining is to create the proper sourceContextInfo
and link them to utf8sourceinfo. As we create the correct
sourceContextInfo the module code exposed the inliner bug (earlier we
were not inlining - after current work we are now) - fixed that as well.

Note : Locals experience is also not optimum for the module - but that
will be tackled in the later stages.
