### PR TITLE
Profile a callsite after the call returns

### DIFF
--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -3762,8 +3762,8 @@ namespace Js
         FunctionInfo* functionInfo = function->GetTypeId() == TypeIds_Function?
             JavascriptFunction::FromVar(function)->GetFunctionInfo() : nullptr;
         bool isConstructorCall = (CallFlags_New & flags) == CallFlags_New;
-        dynamicProfileInfo->RecordCallSiteInfo(functionBody, profileId, functionInfo, functionInfo ? static_cast<JavascriptFunction*>(function) : nullptr, playout->ArgCount, isConstructorCall, inlineCacheIndex);
         OP_CallCommon<T>(playout, function, flags, spreadIndices);
+        dynamicProfileInfo->RecordCallSiteInfo(functionBody, profileId, functionInfo, functionInfo ? static_cast<JavascriptFunction*>(function) : nullptr, playout->ArgCount, isConstructorCall, inlineCacheIndex);
         if (playout->Return != Js::Constants::NoRegister)
         {
             dynamicProfileInfo->RecordReturnTypeOnCallSiteInfo(functionBody, profileId, GetReg((RegSlot)playout->Return));


### PR DESCRIPTION
In the interpreter, we profile a call site first and then call the callee. It may happen that the callee was defer-parsed and the its bytecode generation failed due to some reason (OOM?) upon undeferral. Since, the call won't execute any code in this case, we should not record call site information - during work item creation, we would erroneously think that this a potential inlining candidate. Fix is to record the call site info after the call returns

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/771)
<!-- Reviewable:end -->
