### PR TITLE
Dont attempt to get profiled iterations of a functionbody if it's bytecode hasn't been generated yet.

### DIFF
--- a/lib/Runtime/Language/FunctionCodeGenJitTimeData.cpp
+++ b/lib/Runtime/Language/FunctionCodeGenJitTimeData.cpp
@@ -812,7 +812,7 @@ namespace Js
 #ifdef FIELD_ACCESS_STATS
         inlineCacheStats(nullptr),
 #endif
-        profiledIterations(GetFunctionBody() ? GetFunctionBody()->GetProfiledIterations() : 0),
+        profiledIterations(GetFunctionBody() && GetFunctionBody()->GetByteCode() ? GetFunctionBody()->GetProfiledIterations() : 0),
         next(0)
     {
     }


### PR DESCRIPTION
A number of conditions required to be met for this issue to repro:
1. A callee at a polymorphic callsite was defer-parsed.
2. Upon undeferring, its bytecode generation failed.
3. While gathering codegen data for the parent function, we recorded that the said callee cannot be inlined but we still needed to save the info that we will need to emit a call to this function when we inline the rest of the calls at this callsite. We try to save the number of profiled iterations for the callee on the info that we collect for it - that's when we assert that execution mode and limits have not been initialized (because the bytecode wasn't generated)

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/777)
<!-- Reviewable:end -->
