### PR TITLE
OS:7112681 Promise callback handler code is not marked as being handled

### DIFF
--- a/lib/Runtime/Library/JavascriptPromise.h
+++ b/lib/Runtime/Library/JavascriptPromise.h
@@ -356,7 +356,6 @@ namespace Js
 
         static JavascriptPromiseCapability* NewPromiseCapability(Var constructor, ScriptContext* scriptContext);
         static JavascriptPromiseCapability* CreatePromiseCapabilityRecord(RecyclableObject* constructor, ScriptContext* scriptContext);
-        static bool UpdatePromiseFromPotentialThenable(Var resolution, JavascriptPromiseCapability* promiseCapability, ScriptContext* scriptContext);
         static Var TriggerPromiseReactions(JavascriptPromiseReactionList* reactions, Var resolution, ScriptContext* scriptContext);
         static void EnqueuePromiseReactionTask(JavascriptPromiseReaction* reaction, Var resolution, ScriptContext* scriptContext);
 


### PR DESCRIPTION
If that code throws, the exception gets propagated back to the host via ReportError which prints it into the console in Edge. We can fix this by setting a flag before calling into the callback code which indicates that the exception should be treated as handled and not handed back to the host. Also removes one dead function from JavascriptPromise.
