### PR TITLE
Fix for CheckFixedFld hoisting bug OS:6773420

### DIFF
--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -6313,11 +6313,11 @@ GlobOpt::CopyPropReplaceOpnd(IR::Instr * instr, IR::Opnd * opnd, StackSym * copy
                     PropertySym * currentPropertySymUse = this->propertySymUse;
                     PropertySym * tempPropertySymUse = NULL;
                     this->byteCodeUses = NULL;
+                    BVSparse<JitArenaAllocator> *tempByteCodeUse = JitAnew(this->tempAlloc, BVSparse<JitArenaAllocator>, this->tempAlloc);
 #if DBG
                     BVSparse<JitArenaAllocator> *currentBytecodeUsesBeforeOpt = this->byteCodeUsesBeforeOpt;
-                    this->byteCodeUsesBeforeOpt = JitAnew(this->tempAlloc, BVSparse<JitArenaAllocator>, this->tempAlloc);
+                    this->byteCodeUsesBeforeOpt = tempByteCodeUse;
 #endif
-                    BVSparse<JitArenaAllocator> *tempByteCodeUse = JitAnew(this->tempAlloc, BVSparse<JitArenaAllocator>, this->tempAlloc);
                     this->propertySymUse = NULL;
                     GlobOpt::TrackByteCodeSymUsed(checkObjTypeInstr, tempByteCodeUse, &tempPropertySymUse);
 

--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -6306,10 +6306,17 @@ GlobOpt::CopyPropReplaceOpnd(IR::Instr * instr, IR::Opnd * opnd, StackSym * copy
 
                 if (this->currentBlock->loop && !this->IsLoopPrePass())
                 {
+                    // Try hoisting this checkObjType.
+                    // But since this isn't the current instr being optimized, we need to play tricks with 
+                    // the byteCodeUse fields...
                     BVSparse<JitArenaAllocator> *currentBytecodeUses = this->byteCodeUses;
                     PropertySym * currentPropertySymUse = this->propertySymUse;
                     PropertySym * tempPropertySymUse = NULL;
                     this->byteCodeUses = NULL;
+#if DBG
+                    BVSparse<JitArenaAllocator> *currentBytecodeUsesBeforeOpt = this->byteCodeUsesBeforeOpt;
+                    this->byteCodeUsesBeforeOpt = JitAnew(this->tempAlloc, BVSparse<JitArenaAllocator>, this->tempAlloc);
+#endif
                     BVSparse<JitArenaAllocator> *tempByteCodeUse = JitAnew(this->tempAlloc, BVSparse<JitArenaAllocator>, this->tempAlloc);
                     this->propertySymUse = NULL;
                     GlobOpt::TrackByteCodeSymUsed(checkObjTypeInstr, tempByteCodeUse, &tempPropertySymUse);
@@ -6318,6 +6325,9 @@ GlobOpt::CopyPropReplaceOpnd(IR::Instr * instr, IR::Opnd * opnd, StackSym * copy
 
                     this->byteCodeUses = currentBytecodeUses;
                     this->propertySymUse = currentPropertySymUse;
+#if DBG
+                    this->byteCodeUsesBeforeOpt = currentBytecodeUsesBeforeOpt;
+#endif
                 }
             }
         }

--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -6303,6 +6303,22 @@ GlobOpt::CopyPropReplaceOpnd(IR::Instr * instr, IR::Opnd * opnd, StackSym * copy
                 Assert(!propertySymOpnd->IsTypeChecked());
                 checkObjTypeInstr = this->SetTypeCheckBailOut(checkObjTypeOpnd, checkObjTypeInstr, nullptr);
                 Assert(checkObjTypeInstr->HasBailOutInfo());
+
+                if (this->currentBlock->loop && !this->IsLoopPrePass())
+                {
+                    BVSparse<JitArenaAllocator> *currentBytecodeUses = this->byteCodeUses;
+                    PropertySym * currentPropertySymUse = this->propertySymUse;
+                    PropertySym * tempPropertySymUse = NULL;
+                    this->byteCodeUses = NULL;
+                    BVSparse<JitArenaAllocator> *tempByteCodeUse = JitAnew(this->tempAlloc, BVSparse<JitArenaAllocator>, this->tempAlloc);
+                    this->propertySymUse = NULL;
+                    GlobOpt::TrackByteCodeSymUsed(checkObjTypeInstr, tempByteCodeUse, &tempPropertySymUse);
+
+                    TryHoistInvariant(checkObjTypeInstr, this->currentBlock, NULL, this->FindValue(copySym), NULL, true);
+
+                    this->byteCodeUses = currentBytecodeUses;
+                    this->propertySymUse = currentPropertySymUse;
+                }
             }
         }
 
@@ -18147,6 +18163,17 @@ GlobOpt::OptIsInvariant(IR::Opnd *src, BasicBlock *block, Loop *loop, Value *src
 
     case IR::OpndKindSym:
         sym = src->AsSymOpnd()->m_sym;
+        if (src->AsSymOpnd()->IsPropertySymOpnd())
+        {
+            if (src->AsSymOpnd()->AsPropertySymOpnd()->IsTypeChecked())
+            {
+                // We do not handle hoisting these yet.  We might be hoisting this across the instr with the type check protecting this one.
+                // And somehow, the dead-store pass now removes the type check on that instr later on...
+                // For CheckFixedFld, there is no benefit hoisting these if they don't have a type check as they won't generate code.
+                return false;
+            }
+        }
+
         break;
 
     case IR::OpndKindHelperCall:

--- a/lib/Runtime/ByteCode/OpCodes.h
+++ b/lib/Runtime/ByteCode/OpCodes.h
@@ -694,7 +694,7 @@ MACRO_BACKEND_ONLY(     InlineRegExpExec,    Empty,          OpSideEffect|OpInli
 MACRO_BACKEND_ONLY(     CallIFixed,          Empty,          OpSideEffect|OpUseAllFields|OpCallInstr|OpInlineCallInstr)
 MACRO_BACKEND_ONLY(     CheckFixedFld,       Empty,          OpFastFldInstr|OpTempObjectSources|OpCanCSE)
 MACRO_BACKEND_ONLY(     CheckPropertyGuardAndLoadType,  Empty,          OpFastFldInstr|OpTempObjectSources|OpDoNotTransfer)
-MACRO_BACKEND_ONLY(     CheckObjType,        Empty,          OpFastFldInstr|OpTempObjectSources)
+MACRO_BACKEND_ONLY(     CheckObjType,        Empty,          OpFastFldInstr|OpTempObjectSources|OpCanCSE)
 MACRO_BACKEND_ONLY(     AdjustObjType,       Empty,          OpSideEffect)
 
 // Edge inline built-ins


### PR DESCRIPTION
Hoist CheckObjType as well since there is a dependency with CheckFixedFld, and
don't hoist propertySym opnd if type is checked.  It break obj type spec and has no benefits.
