### PR TITLE
Update arguments count for an inlinee at InlineeStart instead of InlineeEnd

### DIFF
--- a/lib/Backend/GlobOptBailOut.cpp
+++ b/lib/Backend/GlobOptBailOut.cpp
@@ -331,6 +331,7 @@ GlobOpt::TrackCalls(IR::Instr * instr)
         this->blockData.curFunc = instr->m_func;
         this->currentBlock->globOptData.curFunc = instr->m_func;
 
+        this->func->UpdateMaxInlineeArgOutCount(this->currentBlock->globOptData.inlinedArgOutCount);
         this->EndTrackCall(instr);
 
         if (DoInlineArgsOpt(instr->m_func))
@@ -358,14 +359,6 @@ GlobOpt::TrackCalls(IR::Instr * instr)
         this->isCallHelper = false;
         break;
 
-    case Js::OpCode::BailOnNoProfile:
-    case Js::OpCode::InlineThrow:
-    case Js::OpCode::InlineRuntimeTypeError:
-    case Js::OpCode::InlineRuntimeReferenceError:
-        //We are not going to see an inlinee end
-        this->func->UpdateMaxInlineeArgOutCount(this->currentBlock->globOptData.inlinedArgOutCount);
-        break;
-
     case Js::OpCode::InlineeEnd:
         if (instr->m_func->m_hasInlineArgsOpt)
         {
@@ -374,7 +367,6 @@ GlobOpt::TrackCalls(IR::Instr * instr)
         EndTrackingOfArgObjSymsForInlinee();
 
         Assert(this->currentBlock->globOptData.inlinedArgOutCount >= instr->GetArgOutCount(/*getInterpreterArgOutCount*/ false));
-        this->func->UpdateMaxInlineeArgOutCount(this->currentBlock->globOptData.inlinedArgOutCount);
         this->currentBlock->globOptData.inlinedArgOutCount -= instr->GetArgOutCount(/*getInterpreterArgOutCount*/ false);
         break;
 

--- a/test/inlining/missingInlineeEnd.js
+++ b/test/inlining/missingInlineeEnd.js
@@ -1,0 +1,24 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function bar() {
+  foo();
+}
+function foo() {
+  for (v8; 10; 0) {
+  }
+}
+
+try{
+  bar()
+}catch(ex){
+}
+
+try{
+  bar()
+}catch(ex){
+}
+
+WScript.Echo("Passed");

--- a/test/inlining/rlexe.xml
+++ b/test/inlining/rlexe.xml
@@ -233,4 +233,9 @@
       <baseline>stackTrace.baseline</baseline>
     </default>
   </test>
+  <test>
+    <default>
+      <files>missingInlineeEnd.js</files>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
We currently do this when we see InlineeEnd, and have special cases for
opcodes (such as InlineThrow, InlineRuntimeError) which may make
InlineeEnd unreachable. Updating the maxInlineeArgoutCount on the func
upon seeing an InlineeStart is safer and more sustainable. We wouldn't
have to keep adding cases in which InlineeEnd might get removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/788)
<!-- Reviewable:end -->
