### PR TITLE
Fix for issue with aux slots reuse in default parameter

### DIFF
--- a/lib/Backend/GlobOptFields.cpp
+++ b/lib/Backend/GlobOptFields.cpp
@@ -434,7 +434,7 @@ GlobOpt::ProcessFieldKills(IR::Instr *instr, BVSparse<JitArenaAllocator> *bv, bo
             else
             {
                 Assert(sym->IsPropertySym());
-                if (instr->m_opcode == Js::OpCode::InitLetFld || instr->m_opcode == Js::OpCode::InitConstFld)
+                if (instr->m_opcode == Js::OpCode::InitLetFld || instr->m_opcode == Js::OpCode::InitConstFld || instr->m_opcode == Js::OpCode::InitFld)
                 {
                     // These can grow the aux slot of the activation object.
                     // We need to kill the slot array sym as well.

--- a/test/es6/default-splitscope.js
+++ b/test/es6/default-splitscope.js
@@ -617,6 +617,15 @@ var tests = [
             return b;   
         }   
         assert.areEqual(400, f3()(), "Function defined in the body scope captures the symbol from the body scope with eval");
+        
+        function f4 (a, b, c = function () { b; }, d = 1) {
+            var e = 10;
+            assert.areEqual(2, arguments[0], "Unmapped arguments value has the expected value in the body");
+            (function () {
+                eval('');
+            }());
+        };
+        f4.call(1, 2);
     }  
   }, 
   { 

--- a/test/es6/default.js
+++ b/test/es6/default.js
@@ -355,6 +355,24 @@ var tests = [
         }
         f3(undefined, undefined, 30);
 
+        function f4 (a, b, c, d = 1) {
+            var e = 10;
+            assert.areEqual(2, arguments[0], "Unmapped arguments value has the expected value in the body");
+            (function () {
+                eval('');
+            }());
+        };
+        f4.call(1, 2);
+        
+        function f5 (a, b, c, d = 1) {
+            var e = 10;
+            var d = 11;
+            assert.areEqual(2, arguments[0], "Unmapped arguments value has the expected value, even with duplicate symbol in the body");
+            (function () {
+                eval('');
+            }());
+        };
+        f5.call(1, 2);
     }
   },
   {


### PR DESCRIPTION
When the function has default parameters we do the LdSlotArr before the body starts. When the body, with eval, has InitFld it can update the size of the slot array thus allocating a new slot array. In this bug, in the body we were still using the old aux slots array. With this fix we kill the slot array when InitFld occurs.
