### PR TITLE
Clear disable implicit call flag when dispatching exception to debugger

### DIFF
--- a/lib/Runtime/Language/JavascriptExceptionOperators.cpp
+++ b/lib/Runtime/Language/JavascriptExceptionOperators.cpp
@@ -839,11 +839,6 @@ namespace Js
                 WalkStackForExceptionContext(*scriptContext, exceptionContext, thrownObject, StackCrawlLimitOnThrow(thrownObject, *scriptContext), returnAddress, /*isThrownException=*/ true, resetStack);
                 exceptionObject->FillError(exceptionContext, scriptContext);
                 AddStackTraceToObject(thrownObject, exceptionContext.GetStackTrace(), *scriptContext, /*isThrownException=*/ true, resetStack);
-
-                if (considerPassingToDebugger)
-                {
-                    DispatchExceptionToDebugger(exceptionObject, scriptContext);
-                }
             }
             Assert(!scriptContext ||
                    // If we disabled implicit calls and we did record an implicit call, do not throw.
@@ -856,6 +851,10 @@ namespace Js
                    !scriptContext->GetThreadContext()->IsDisableImplicitException()
             );
             scriptContext->GetThreadContext()->ClearDisableImplicitFlags();
+            if (fillExceptionContext && considerPassingToDebugger)
+            {
+                DispatchExceptionToDebugger(exceptionObject, scriptContext);
+            }
        }
 
         if (exceptionObject->IsPendingExceptionObject())


### PR DESCRIPTION
When dispatching the exception to the debugger, make sure we call `ClearDisableImplicitFlags()`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/792)
<!-- Reviewable:end -->
