### PR TITLE
Yield keyword usage in default parameter was not handled well in defer parse mode

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -7982,7 +7982,7 @@ ParseNodePtr Parser::ParseExpr(int oplMin,
                 // binding operator, be it unary or binary.
                 Error(ERRsyntax);
             }
-            if (m_currentNodeFunc->sxFnc.IsGenerator()
+            if (GetCurrentFunctionNode()->sxFnc.IsGenerator()
                 && m_currentBlockInfo->pnodeBlock->sxBlock.blockType == PnodeBlockType::Parameter)
             {
                 Error(ERRsyntax);

--- a/test/es6/generators-deferparse.js
+++ b/test/es6/generators-deferparse.js
@@ -1,0 +1,15 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+try {
+    eval("function f1() { class c extends BaseClass { *f3(a = yield) { } } };");
+    WScript.Echo('FAILED');
+} catch (e) {
+    if (e instanceof SyntaxError) {
+        WScript.Echo('PASSED');
+    } else {
+        WScript.Echo('FAILED');
+    }
+}

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -751,6 +751,13 @@
   </test>
   <test>
     <default>
+      <files>generators-deferparse.js</files>
+      <compile-flags>-force:deferparse -ES6Generators -JitES6Generators -ES6Classes -ES6DefaultArgs</compile-flags>
+      <tags>exclude_arm</tags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>generators-apis.js</files>
       <compile-flags>-ES6Generators -es6tostringtag -JitES6Generators -args summary -endargs</compile-flags>
       <tags>exclude_arm</tags>


### PR DESCRIPTION
It is a syntax error to use yield keyword in the default parameter
expression in a generator function. We were using the wrong function node
to check this condition in defer parse mode.
