### PR TITLE
Fixing an assert on double to string coversion

### DIFF
--- a/lib/Common/Common/NumberUtilities_strtod.cpp
+++ b/lib/Common/Common/NumberUtilities_strtod.cpp
@@ -2316,7 +2316,6 @@ int Js::NumberUtilities::FDblToStr(double dbl, Js::NumberUtilities::FormatType f
             //Either session pointer is null or session is in compat mode switch to compat handling
             if ((wExp10 + nDigits) > 0)
             {
-                AnalysisAssert(wExp10 + nDigits + 1 <= kcbMaxRgb);
                 wExp10 += RoundTo(rgb, pbLim, wExp10 + nDigits, rgbAdj, &pbLimAdj);
             }
             else

--- a/test/Number/dbltoFixed.js
+++ b/test/Number/dbltoFixed.js
@@ -1,0 +1,8 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+x = -6.628293671040776e+100;
+x.toFixed(this);
+print("Pass");

--- a/test/Number/rlexe.xml
+++ b/test/Number/rlexe.xml
@@ -48,4 +48,10 @@
       <compile-flags>-args summary -endargs</compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>dbltoFixed.js</files>
+      <tags>BugFix</tags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
The assert is an overzealous assert as the exponent can be higher then
number of digits can be. Removed that assert.
