### PR TITLE
Guard deleting of DebugContext in critical section

### DIFF
--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -315,6 +315,9 @@ namespace Js
         intConstPropsOnGlobalObject = Anew(GeneralAllocator(), PropIdSetForConstProp, GeneralAllocator());
         intConstPropsOnGlobalUserObject = Anew(GeneralAllocator(), PropIdSetForConstProp, GeneralAllocator());
 
+        // Initialize the closing critical section which will be deleted when we close DebugContext
+        InitializeCriticalSection(&debugContextCloseCS);
+
         this->debugContext = HeapNew(DebugContext, this);
     }
 
@@ -621,10 +624,18 @@ namespace Js
 
         if (this->debugContext != nullptr)
         {
+            // Guard the closing and deleting of DebugContext as in meantime PDM might
+            // call OnBreakFlagChange
+            EnterCriticalSection(&debugContextCloseCS);
             this->debugContext->Close();
             HeapDelete(this->debugContext);
             this->debugContext = nullptr;
+            LeaveCriticalSection(&debugContextCloseCS);
         }
+
+        // Deleted DebugContext so delete critical section which was initialized
+        // when we created DebugContext in ScriptContext::InitializeAllocations
+        DeleteCriticalSection(&debugContextCloseCS);
 
         // Need to print this out before the native code gen is deleted
         // which will delete the codegenProfiler

--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -833,6 +833,7 @@ private:
         void InternalClose();
 
         DebugContext* debugContext;
+        CRITICAL_SECTION debugContextCloseCS;
 
     public:
         static const int kArrayMatchCh=72;
@@ -889,6 +890,7 @@ private:
 #endif
 
         DebugContext* GetDebugContext() const { return this->debugContext; }
+        CRITICAL_SECTION* GetDebugContextCloseCS() { return &debugContextCloseCS; }
 
         uint callCount;
 

--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -833,7 +833,7 @@ private:
         void InternalClose();
 
         DebugContext* debugContext;
-        CRITICAL_SECTION debugContextCloseCS;
+        CriticalSection debugContextCloseCS;
 
     public:
         static const int kArrayMatchCh=72;
@@ -890,7 +890,7 @@ private:
 #endif
 
         DebugContext* GetDebugContext() const { return this->debugContext; }
-        CRITICAL_SECTION* GetDebugContextCloseCS() { return &debugContextCloseCS; }
+        CriticalSection* GetDebugContextCloseCS() { return &debugContextCloseCS; }
 
         uint callCount;
 


### PR DESCRIPTION
OnBreakFlagChange from PDM can be called while debugcontext is being
deleted, so gaurd the deletion in critical section and if getting critical
section fails during OnBreakFlagChange return error to PDM.
