### PR TITLE
StElemI Fast path with InvalidatedArrayLength bailout

### DIFF
--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -13970,7 +13970,7 @@ void Lowerer::InsertFloatCheckForZeroOrNanBranch(
 
 IR::IndirOpnd *
 Lowerer::GenerateFastElemICommon(
-    IR::Instr * ldElem,
+    IR::Instr * instr,
     bool isStore,
     IR::IndirOpnd * indirOpnd,
     IR::LabelInstr * labelHelper,
@@ -14013,7 +14013,7 @@ Lowerer::GenerateFastElemICommon(
                 // If profile data says that it's a typed array - do not generate the property string fast path as the src. could be a temp and that would cause a bug.
                 *pIsTypedArrayElement = false;
                 *pIsStringIndex = true;
-                return m_lowererMD.GenerateFastElemIStringIndexCommon(ldElem, isStore, indirOpnd, labelHelper);
+                return m_lowererMD.GenerateFastElemIStringIndexCommon(instr, isStore, indirOpnd, labelHelper);
             }
             else
             {
@@ -14024,7 +14024,7 @@ Lowerer::GenerateFastElemICommon(
     }
     return
         GenerateFastElemIIntIndexCommon(
-            ldElem,
+            instr,
             isStore,
             indirOpnd,
             labelHelper,
@@ -14041,7 +14041,7 @@ Lowerer::GenerateFastElemICommon(
 
 IR::IndirOpnd *
 Lowerer::GenerateFastElemIIntIndexCommon(
-    IR::Instr * ldElem,
+    IR::Instr * instr,
     bool isStore,
     IR::IndirOpnd * indirOpnd,
     IR::LabelInstr * labelHelper,
@@ -14152,14 +14152,14 @@ Lowerer::GenerateFastElemIIntIndexCommon(
     IRType elementType = TyIllegal;
     IR::Opnd * element = nullptr;
 
-    if(ldElem->m_opcode == Js::OpCode::InlineArrayPush)
+    if(instr->m_opcode == Js::OpCode::InlineArrayPush)
     {
-        element = ldElem->GetSrc2();
+        element = instr->GetSrc2();
         elementType = element->GetType();
     }
-    else if(isStore && ldElem->GetSrc1())
+    else if(isStore && instr->GetSrc1())
     {
-        element = ldElem->GetSrc1();
+        element = instr->GetSrc1();
         elementType = element->GetType();
     }
 
@@ -14180,7 +14180,7 @@ Lowerer::GenerateFastElemIIntIndexCommon(
     bool indexIsLessThanHeadSegmentLength = false;
     if(!baseValueType.IsAnyOptimizedArray())
     {
-        arrayOpnd = GenerateArrayTest(baseOpnd, labelCantUseArray, labelCantUseArray, ldElem, true, isStore);
+        arrayOpnd = GenerateArrayTest(baseOpnd, labelCantUseArray, labelCantUseArray, instr, true, isStore);
     }
     else
     {
@@ -14220,7 +14220,7 @@ Lowerer::GenerateFastElemIIntIndexCommon(
         {
             return;
         }
-        arrayOpnd = LoadObjectArray(arrayOpnd, ldElem);
+        arrayOpnd = LoadObjectArray(arrayOpnd, instr);
         autoReuseArrayOpnd.Initialize(arrayOpnd, m_func);
     };
 
@@ -14240,7 +14240,7 @@ Lowerer::GenerateFastElemIIntIndexCommon(
             ),
             labelCantUseArray,
             labelHelper,
-            ldElem);
+            instr);
     }
     const IR::AutoReuseOpnd autoReuseIndexValueOpnd(indexValueOpnd, m_func);
 
@@ -14262,11 +14262,11 @@ Lowerer::GenerateFastElemIIntIndexCommon(
             //  CMP index, headSegmentLength  -- upper bound check
             if(!invertBoundCheckComparison)
             {
-                InsertCompare(indexValueOpnd, headSegmentLengthOpnd, ldElem);
+                InsertCompare(indexValueOpnd, headSegmentLengthOpnd, instr);
             }
             else
             {
-                InsertCompare(headSegmentLengthOpnd, indexValueOpnd, ldElem);
+                InsertCompare(headSegmentLengthOpnd, indexValueOpnd, instr);
             }
         }
     }
@@ -14278,15 +14278,15 @@ Lowerer::GenerateFastElemIIntIndexCommon(
             baseValueType.IsLikelyNativeIntArray() &&
             (!element->IsIntConstOpnd() || Js::SparseArraySegment<int32>::GetMissingItem() == element->AsIntConstOpnd()->AsInt32()))
         {
-            Assert(ldElem->m_opcode != Js::OpCode::InlineArrayPush || bailOutLabelInstr);
+            Assert(instr->m_opcode != Js::OpCode::InlineArrayPush || bailOutLabelInstr);
 
             // Check for a write of the MissingItem value.
             InsertCompareBranch(
                 element,
                 GetMissingItemOpnd(elementType, m_func),
                 Js::OpCode::BrEq_A,
-                ldElem->m_opcode == Js::OpCode::InlineArrayPush ? bailOutLabelInstr : labelCantUseArray,
-                ldElem,
+                instr->m_opcode == Js::OpCode::InlineArrayPush ? bailOutLabelInstr : labelCantUseArray,
+                instr,
                 true);
         }
 
@@ -14298,7 +14298,7 @@ Lowerer::GenerateFastElemIIntIndexCommon(
             indirOpnd = IR::IndirOpnd::New(arrayOpnd, Js::JavascriptArray::GetOffsetOfHead(), TyMachPtr, this->m_func);
             headSegmentOpnd = IR::RegOpnd::New(TyMachPtr, this->m_func);
             autoReuseHeadSegmentOpnd.Initialize(headSegmentOpnd, m_func);
-            InsertMove(headSegmentOpnd, indirOpnd, ldElem);
+            InsertMove(headSegmentOpnd, indirOpnd, instr);
         }
 
         if(doUpperBoundCheck)
@@ -14314,23 +14314,26 @@ Lowerer::GenerateFastElemIIntIndexCommon(
             //  CMP index, headSegmentLength  -- upper bound check
             if(!invertBoundCheckComparison)
             {
-                InsertCompare(indexValueOpnd, headSegmentLengthOpnd, ldElem);
+                InsertCompare(indexValueOpnd, headSegmentLengthOpnd, instr);
             }
             else
             {
-                InsertCompare(headSegmentLengthOpnd, indexValueOpnd, ldElem);
+                InsertCompare(headSegmentLengthOpnd, indexValueOpnd, instr);
             }
         }
     }
 
-    const IR::BailOutKind bailOutKind = ldElem->HasBailOutInfo() ? ldElem->GetBailOutKind() : IR::BailOutInvalid;
-    if(indexIsLessThanHeadSegmentLength ||
-        bailOutKind & (IR::BailOutOnArrayAccessHelperCall | IR::BailOutOnInvalidatedArrayHeadSegment))
+    const IR::BailOutKind bailOutKind = instr->HasBailOutInfo() ? instr->GetBailOutKind() : IR::BailOutInvalid;
+    const bool needBailOutOnInvalidLength = !!(bailOutKind & (IR::BailOutOnInvalidatedArrayHeadSegment));
+    const bool needBailOutToHelper = !!(bailOutKind & (IR::BailOutOnArrayAccessHelperCall | IR::BailOutOnInvalidatedArrayLength));
+    const bool needBailOutOnSegmentLengthCompare = needBailOutToHelper || needBailOutOnInvalidLength;
+    
+    if(indexIsLessThanHeadSegmentLength || needBailOutOnSegmentLengthCompare)
     {
-        if(bailOutKind & (IR::BailOutOnArrayAccessHelperCall | IR::BailOutOnInvalidatedArrayHeadSegment))
+        if (needBailOutOnSegmentLengthCompare)
         {
             // The bailout must be pre-op because it will not have completed the operation
-            Assert(ldElem->GetBailOutInfo()->bailOutOffset == ldElem->GetByteCodeOffset());
+            Assert(instr->GetBailOutInfo()->bailOutOffset == instr->GetByteCodeOffset());
 
             // Verify other bailouts these can be combined with
             Assert(
@@ -14342,11 +14345,12 @@ Lowerer::GenerateFastElemIIntIndexCommon(
                         IR::BailOutOnInvalidatedArrayHeadSegment |
                         IR::BailOutOnInvalidatedArrayLength |
                         IR::BailOutConventionalNativeArrayAccessOnly |
+                        IR::BailOutOnMissingValue |
                         (bailOutKind & IR::BailOutOnArrayAccessHelperCall ? IR::BailOutInvalid : IR::BailOutConvertedNativeArray)
-                    )
-                ));
+                        )
+                    ));
 
-            if(bailOutKind & IR::BailOutOnArrayAccessHelperCall)
+            if (bailOutKind & IR::BailOutOnArrayAccessHelperCall)
             {
                 // Omit the helper call and generate a bailout instead
                 Assert(emitBailoutRef);
@@ -14354,38 +14358,37 @@ Lowerer::GenerateFastElemIIntIndexCommon(
             }
         }
 
-        if(indexIsLessThanHeadSegmentLength)
+        if (indexIsLessThanHeadSegmentLength)
         {
             Assert(!(bailOutKind & IR::BailOutOnInvalidatedArrayHeadSegment));
         }
         else
         {
             IR::LabelInstr *bailOutLabel;
-            if(bailOutKind & IR::BailOutOnInvalidatedArrayHeadSegment)
+            if (needBailOutOnInvalidLength)
             {
                 Assert(isStore);
-
                 // Lower a separate (but shared) bailout for this case, and preserve the bailout kind in the instruction if the
                 // helper call is going to be generated, because the bailout kind needs to be lowered again and differently in the
                 // helper call path.
                 //
                 // Generate:
-                //     (LdElem)
+                //     (instr)
                 //     jmp $continue
                 //   $bailOut:
                 //     Bail out with IR::BailOutOnInvalidatedArrayHeadSegment
                 //   $continue:
                 LowerOneBailOutKind(
-                    ldElem,
+                    instr,
                     IR::BailOutOnInvalidatedArrayHeadSegment,
                     false,
                     !(bailOutKind & IR::BailOutOnArrayAccessHelperCall));
-                bailOutLabel = ldElem->GetOrCreateContinueLabel(true);
+                bailOutLabel = instr->GetOrCreateContinueLabel(true);
                 InsertBranch(Js::OpCode::Br, labelFallthrough, bailOutLabel);
             }
             else
             {
-                Assert(bailOutKind & IR::BailOutOnArrayAccessHelperCall);
+                Assert(needBailOutToHelper);
                 bailOutLabel = labelHelper;
             }
 
@@ -14396,7 +14399,7 @@ Lowerer::GenerateFastElemIIntIndexCommon(
                 !invertBoundCheckComparison ? Js::OpCode::BrGe_A : Js::OpCode::BrLe_A,
                 true /* isUnsigned */,
                 bailOutLabel,
-                ldElem);
+                instr);
         }
     }
     else if (isStore && !baseValueType.IsLikelyTypedArray()) //  #if (opcode == StElemI_A)
@@ -14404,7 +14407,7 @@ Lowerer::GenerateFastElemIIntIndexCommon(
         IR::LabelInstr *labelDone = IR::LabelInstr::New(Js::OpCode::Label, this->m_func);
         IR::LabelInstr *labelSegmentLengthIncreased = nullptr;
 
-        const bool isPush = ldElem->m_opcode != Js::OpCode::StElemI_A && ldElem->m_opcode != Js::OpCode::StElemI_A_Strict;
+        const bool isPush = instr->m_opcode != Js::OpCode::StElemI_A && instr->m_opcode != Js::OpCode::StElemI_A_Strict;
 
         // Put the head segment size check and length updates in a helper block since they're not the common path for StElem.
         // For push, that is the common path so keep it in a non-helper block.
@@ -14415,8 +14418,8 @@ Lowerer::GenerateFastElemIIntIndexCommon(
             if(pLabelSegmentLengthIncreased &&
                 !(
                     baseValueType.IsArrayOrObjectWithArray() && baseValueType.HasNoMissingValues() ||
-                    (ldElem->m_opcode == Js::OpCode::StElemI_A || ldElem->m_opcode == Js::OpCode::StElemI_A_Strict) &&
-                        ldElem->IsProfiledInstr() && !ldElem->AsProfiledInstr()->u.stElemInfo->LikelyFillsMissingValue()
+                    (instr->m_opcode == Js::OpCode::StElemI_A || instr->m_opcode == Js::OpCode::StElemI_A_Strict) &&
+                        instr->IsProfiledInstr() && !instr->AsProfiledInstr()->u.stElemInfo->LikelyFillsMissingValue()
                 ))
             {
                 // For arrays that are not guaranteed to have no missing values, before storing to an element where
@@ -14437,12 +14440,12 @@ Lowerer::GenerateFastElemIIntIndexCommon(
                 !invertBoundCheckComparison ? Js::OpCode::BrLt_A : Js::OpCode::BrGt_A,
                 true /* isUnsigned */,
                 labelDone,
-                ldElem);
+                instr);
         }
 
         if(isInHelperBlock)
         {
-            InsertLabel(true /* isHelper */, ldElem);
+            InsertLabel(true /* isHelper */, instr);
         }
 
         EnsureObjectArrayLoaded();
@@ -14451,14 +14454,14 @@ Lowerer::GenerateFastElemIIntIndexCommon(
         {
             if(checkArrayLengthOverflow)
             {
-                if(ldElem->HasBailOutInfo() && ldElem->GetBailOutKind() & IR::BailOutOnMissingValue)
+                if(instr->HasBailOutInfo() && instr->GetBailOutKind() & IR::BailOutOnMissingValue)
                 {
                     // Need to bail out if this store would create a missing value. The store would cause a missing value to be
                     // created if (index > length && index < size). If (index >= size) we would go to helper anyway, and the bailout
                     // handling for this is done after the helper call, so just go to helper if (index > length).
                     //
                     // jne  $helper // branch for (cmp index, headSegmentLength)
-                    InsertBranch(Js::OpCode::BrNeq_A, labelHelper, ldElem);
+                    InsertBranch(Js::OpCode::BrNeq_A, labelHelper, instr);
                 }
                 else
                 {
@@ -14475,8 +14478,8 @@ Lowerer::GenerateFastElemIIntIndexCommon(
                     //     and  [array + offsetOf(objectArrayOrFlags)], ~Js::DynamicObjectFlags::HasNoMissingValues
                     // indexLessThanSize:
 
-                    IR::LabelInstr *const indexGreaterThanLengthLabel = InsertLabel(true /* isHelper */, ldElem);
-                    IR::LabelInstr *const indexLessThanSizeLabel = InsertLabel(isInHelperBlock, ldElem);
+                    IR::LabelInstr *const indexGreaterThanLengthLabel = InsertLabel(true /* isHelper */, instr);
+                    IR::LabelInstr *const indexLessThanSizeLabel = InsertLabel(isInHelperBlock, instr);
 
                     //     jne  indexGreaterThanLength // branch for (cmp index, headSegmentLength)
                     //     cmp  index, [headSegment + offset(size)]
@@ -14526,12 +14529,12 @@ Lowerer::GenerateFastElemIIntIndexCommon(
             //      CMP index, [headSegment + offset(size)]
             //      JAE $helper
             indirOpnd = IR::IndirOpnd::New(headSegmentOpnd, offsetof(Js::SparseArraySegmentBase, size), TyUint32, this->m_func);
-            InsertCompareBranch(indexValueOpnd, indirOpnd, Js::OpCode::BrGe_A, true /* isUnsigned */, labelHelper, ldElem);
+            InsertCompareBranch(indexValueOpnd, indirOpnd, Js::OpCode::BrGe_A, true /* isUnsigned */, labelHelper, instr);
         } while(false);
 
         if(isPush)
         {
-            IR::LabelInstr *const updateLengthLabel = InsertLabel(isInHelperBlock, ldElem);
+            IR::LabelInstr *const updateLengthLabel = InsertLabel(isInHelperBlock, instr);
 
             if(!doUpperBoundCheck && !headSegmentLengthOpnd)
             {
@@ -14573,7 +14576,7 @@ Lowerer::GenerateFastElemIIntIndexCommon(
         {
             // We didn't emit an array check, but if we are going to grow the array
             // We need to go to helper if there is an ES5 array/objectarray used as prototype
-            GenerateIsEnabledArraySetElementFastPathCheck(labelHelper, ldElem);
+            GenerateIsEnabledArraySetElementFastPathCheck(labelHelper, instr);
         }
 
         IR::Opnd *newLengthOpnd;
@@ -14583,7 +14586,7 @@ Lowerer::GenerateFastElemIIntIndexCommon(
             //      LEA newLength, [index + 1]
             newLengthOpnd = IR::RegOpnd::New(TyUint32, this->m_func);
             autoReuseNewLengthOpnd.Initialize(newLengthOpnd, m_func);
-            InsertAdd(false /* needFlags */, newLengthOpnd, indexValueOpnd, IR::IntConstOpnd::New(1, TyUint32, m_func), ldElem);
+            InsertAdd(false /* needFlags */, newLengthOpnd, indexValueOpnd, IR::IntConstOpnd::New(1, TyUint32, m_func), instr);
         }
         else
         {
@@ -14593,7 +14596,7 @@ Lowerer::GenerateFastElemIIntIndexCommon(
 
         //      MOV [headSegment + offset(length)], newLength
         indirOpnd = IR::IndirOpnd::New(headSegmentOpnd, offsetof(Js::SparseArraySegmentBase, length), TyUint32, this->m_func);
-        InsertMove(indirOpnd, newLengthOpnd, ldElem);
+        InsertMove(indirOpnd, newLengthOpnd, instr);
 
         if (checkArrayLengthOverflow)
         {
@@ -14607,17 +14610,17 @@ Lowerer::GenerateFastElemIIntIndexCommon(
                 Js::OpCode::BrLe_A,
                 true /* isUnsigned */,
                 labelSegmentLengthIncreased,
-                ldElem);
+                instr);
 
             if(!isInHelperBlock)
             {
-                InsertLabel(true /* isHelper */, ldElem);
+                InsertLabel(true /* isHelper */, instr);
             }
         }
 
         //      MOV [base + offset(length)], newLength
         indirOpnd = IR::IndirOpnd::New(arrayOpnd, Js::JavascriptArray::GetOffsetOfLength(), TyUint32, this->m_func);
-        InsertMove(indirOpnd, newLengthOpnd, ldElem);
+        InsertMove(indirOpnd, newLengthOpnd, instr);
 
         if(returnLength)
         {
@@ -14628,20 +14631,20 @@ Lowerer::GenerateFastElemIIntIndexCommon(
 
             //      SHL newLength, AtomTag
             //      INC newLength
-            this->m_lowererMD.GenerateInt32ToVarConversion(newLengthOpnd, ldElem);
+            this->m_lowererMD.GenerateInt32ToVarConversion(newLengthOpnd, instr);
 
             //      MOV dst, newLength
-            InsertMove(ldElem->GetDst(), newLengthOpnd, ldElem);
+            InsertMove(instr->GetDst(), newLengthOpnd, instr);
         }
 
         if(labelSegmentLengthIncreased && labelSegmentLengthIncreased != labelDone)
         {
             // labelSegmentLengthIncreased:
-            ldElem->InsertBefore(labelSegmentLengthIncreased);
+            instr->InsertBefore(labelSegmentLengthIncreased);
         }
 
         //     $done
-        ldElem->InsertBefore(labelDone);
+        instr->InsertBefore(labelDone);
     }
     else //  #else
     {
@@ -14656,20 +14659,20 @@ Lowerer::GenerateFastElemIIntIndexCommon(
                     !invertBoundCheckComparison ? Js::OpCode::BrLt_A : Js::OpCode::BrGt_A,
                     true /* isUnsigned */,
                     labelInlineSet,
-                    ldElem);
+                    instr);
 
                 // For typed array, call ToNumber before we fallThrough.
-                if (ldElem->GetSrc1()->GetType() == TyVar && !ldElem->GetSrc1()->GetValueType().IsPrimitive())
+                if (instr->GetSrc1()->GetType() == TyVar && !instr->GetSrc1()->GetValueType().IsPrimitive())
                 {
                     IR::Instr *toNumberInstr = IR::Instr::New(Js::OpCode::Call, this->m_func);
-                    toNumberInstr->SetSrc1(ldElem->GetSrc1());
-                    ldElem->InsertBefore(toNumberInstr);
+                    toNumberInstr->SetSrc1(instr->GetSrc1());
+                    instr->InsertBefore(toNumberInstr);
 
                     LowerUnaryHelperMem(toNumberInstr, IR::HelperOp_ConvNumber_Full);
                 }
-                InsertBranch(Js::OpCode::Br, labelFallthrough, ldElem);  //Jump to fallThrough
+                InsertBranch(Js::OpCode::Br, labelFallthrough, instr);  //Jump to fallThrough
 
-                ldElem->InsertBefore(labelInlineSet);
+                instr->InsertBefore(labelInlineSet);
             }
             else
             {
@@ -14678,13 +14681,13 @@ Lowerer::GenerateFastElemIIntIndexCommon(
                     !invertBoundCheckComparison ? Js::OpCode::BrGe_A : Js::OpCode::BrLe_A,
                     true /* isUnsigned */,
                     labelHelper,
-                    ldElem);
+                    instr);
             }
         }
 
         EnsureObjectArrayLoaded();
 
-        if (ldElem->m_opcode == Js::OpCode::InlineArrayPop)
+        if (instr->m_opcode == Js::OpCode::InlineArrayPop)
         {
             Assert(!baseValueType.IsLikelyTypedArray());
             Assert(bailOutLabelInstr);
@@ -14704,7 +14707,7 @@ Lowerer::GenerateFastElemIIntIndexCommon(
             }
 
             IR::Opnd * tmpDst = nullptr;
-            IR::Opnd * dst = ldElem->GetDst();
+            IR::Opnd * dst = instr->GetDst();
             //Pop might not have a dst, if not don't worry about returning the last element. But we still have to
             // worry about gaps, because these force us to access the prototype chain, which may have side-effects.
             if (dst || !baseValueType.HasNoMissingValues())
@@ -14720,7 +14723,7 @@ Lowerer::GenerateFastElemIIntIndexCommon(
                 }
 
                 //  MOV dst, [head + offset]
-                InsertMove(dst, indirOpnd, ldElem);
+                InsertMove(dst, indirOpnd, instr);
 
                 //If the array has missing values, check for one
                 if (!baseValueType.HasNoMissingValues())
@@ -14730,12 +14733,12 @@ Lowerer::GenerateFastElemIIntIndexCommon(
                         GetMissingItemOpnd(indirType, m_func),
                         Js::OpCode::BrEq_A,
                         bailOutLabelInstr,
-                        ldElem,
+                        instr,
                         true);
                 }
             }
             //  MOV [head + offset], missing
-            InsertMove(indirOpnd, GetMissingItemOpnd(indirType, m_func), ldElem);
+            InsertMove(indirOpnd, GetMissingItemOpnd(indirType, m_func), instr);
 
             IR::Opnd *newLengthOpnd;
             IR::AutoReuseOpnd autoReuseNewLengthOpnd;
@@ -14754,17 +14757,17 @@ Lowerer::GenerateFastElemIIntIndexCommon(
             //update segment length and array length
             //      MOV [headSegment + offset(length)], newLength
             IR::IndirOpnd *lengthIndirOpnd = IR::IndirOpnd::New(headSegmentOpnd, offsetof(Js::SparseArraySegmentBase, length), TyUint32, this->m_func);
-            InsertMove(lengthIndirOpnd, newLengthOpnd, ldElem);
+            InsertMove(lengthIndirOpnd, newLengthOpnd, instr);
 
             //      MOV [base + offset(length)], newLength
             lengthIndirOpnd = IR::IndirOpnd::New(arrayOpnd, Js::JavascriptArray::GetOffsetOfLength(), TyUint32, this->m_func);
-            InsertMove(lengthIndirOpnd, newLengthOpnd, ldElem);
+            InsertMove(lengthIndirOpnd, newLengthOpnd, instr);
 
             if (tmpDst)
             {
                 // The array opnd and the destination is the same, need to move the value in the tmp dst
                 // to the actual dst
-                InsertMove(ldElem->GetDst(), tmpDst, ldElem);
+                InsertMove(instr->GetDst(), tmpDst, instr);
             }
 
             return indirOpnd;
@@ -14781,7 +14784,7 @@ Lowerer::GenerateFastElemIIntIndexCommon(
             indirOpnd = IR::IndirOpnd::New(arrayOpnd, bufferOffset, TyMachPtr, this->m_func);
             headSegmentOpnd = IR::RegOpnd::New(TyMachPtr, this->m_func);
             autoReuseHeadSegmentOpnd.Initialize(headSegmentOpnd, m_func);
-            InsertMove(headSegmentOpnd, indirOpnd, ldElem);
+            InsertMove(headSegmentOpnd, indirOpnd, instr);
         }
 
         //  indirOpnd = [headSegment + index]

--- a/test/Array/bug6268659.js
+++ b/test/Array/bug6268659.js
@@ -1,0 +1,21 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+var func0 = function () {
+  for (var _strvar0 in ary) {
+    ary[1] = 0;
+    if (ary.length > 1) {
+      break;
+    }
+    --a;
+  }
+};
+var a = 1;
+var ary = [,,0];
+func0();
+ary = [,0];
+ary.shift();
+func0();
+print(a === 1 ? "PASSED" : "FAILED");

--- a/test/Array/rlexe.xml
+++ b/test/Array/rlexe.xml
@@ -61,6 +61,13 @@
   </test>
   <test>
     <default>
+      <files>bug6268659.js</files>
+      <compile-flags>-mic:1 -off:simplejit</compile-flags>
+      <tags>BugFix</tags>
+    </default>
+  </test>
+  <test>
+    <default>
       <compile-flags>-ForceArrayBTree</compile-flags>
       <files>ArrayBtreeBadCodeGen.js</files>
       <baseline>ArrayBtreeBadCodeGen.baseline</baseline>


### PR DESCRIPTION
The StElemI fast was ignoring the InvalidatedArrayLength bailout.
This change adds a verifies that the array length assumption is still valid and go to helper if not

It adds the first 2 instructions in the following lowered code where `1` in `CMP            s19.u32, 1 (0x1).u32` is the head segment bounds (ran using the added unittest).
```
 GLOBOPT INSTR:     [s6[Array][seg: s18][segLen: s19][>].var!+1].var = StElemI_A  0x00000001.var #001d  Bailout: #001d (BailOutOnImplicitCallsPreOp | BailOutOnInvalidatedArrayLength)


                       CMP            s19.u32, 1 (0x1).u32                    #
                       JBE            $L13                                    #
                       CMP            [s18.u32+20].var, 0x80000002.u32        #
                       JEQ            $L13                                    #
    [s18.u32+20].var = MOV            0x00000001.var                          #
                       JMP            $L12                                    #
$L13: [helper]                                                                #
                       PUSH           s6[Array][seg: s18][segLen: s19][>].var #
    s23(eax).u32    =  CALL           Array_Jit_GetArrayLength.u32            #
    s22.u32         =  MOV            s23(eax).u32                            #
                       PUSH           0 (0x0).i32                             #
                       PUSH           0xXXXXXXXX (ScriptContext).u32          #
                       PUSH           0x00000001.var                          #
                       PUSH           0x00000003.var                          #
                       PUSH           s6[Array][seg: s18][segLen: s19][>].var! #
    [0xXXXXXXXX (&ImplicitCallFlags)].u8 = MOV  1 (0x1).i8                    #
    [0xXXXXXXXX (&DisableImplicitCallFlags)].i8 = MOV  1 (0x1).i8             #
                       CALL           Op_SetElementI.u32                      #001d
    [0xXXXXXXXX (&DisableImplicitCallFlags)].i8 = MOV  0 (0x0).i8             #
                       CMP            [0xXXXXXXXX (&ImplicitCallFlags)].u8, 1 (0x1).i8 #
                       JEQ            $L17                                    #
$L18: [helper]                                                                #
    [0xXXXXXXXX (&BailOutKind)].u32 = MOV  5 (0x5).u32                        #
                       JMP            $L15                                    #
$L17: [helper]                                                                #
                       PUSH           s6[Array][seg: s18][segLen: s19][>].var #
                       PUSH           s22.u32                                 #
    s25(eax).u8     =  CALL           Array_Jit_OperationInvalidatedArrayLength.u32 #
    s24.u8          =  MOV            s25(eax).u8                             #
                       TEST           s24.u8, s24.u8                          #
                       JEQ            $L14                                    #
$L16: [helper]                                                                #
    [0xXXXXXXXX (&BailOutKind)].u32 = MOV  262144 (0x40000).u32               #
                       JMP            $L15                                    #
$L15: [helper]                                                                #
                       CALL           SaveAllRegistersAndBailOut.u32          #001d  Bailout: #001d (BailOutShared)
                       JMP            $L11                                    #
$L14: [helper]                                                                #
$L12:                                                                         #
```

Perf comparison (using pgo binaries)
```
Octane            Left score        Right score       ∆ Score  ∆ Score %  Comment
----------------  ----------------  ----------------  -------  ---------  --------
Box2d              45511.18 ±0.06%   45702.24 ±0.24%   191.05      0.42%
Code-load          21755.90 ±0.13%   21771.80 ±0.29%    15.90      0.07%
Crypto             34798.80 ±0.23%   34730.82 ±0.09%   -67.98     -0.20%
Deltablue          26570.30 ±0.35%   26334.31 ±0.30%  -235.99     -0.89%
Earley-boyer       41226.33 ±0.23%   40930.20 ±0.32%  -296.13     -0.72%
Gbemu              62391.77 ±0.06%   62760.10 ±0.11%   368.33      0.59%  Improved
Mandreel           34023.00 ±0.04%   34066.44 ±0.11%    43.44      0.13%
Mandreel latency  123778.80 ±0.23%  123447.78 ±0.29%  -331.02     -0.27%
Navier-stokes      36588.90 ±0.18%   36673.70 ±0.10%    84.80      0.23%
Pdfjs              25950.50 ±0.30%   26004.70 ±0.24%    54.20      0.21%
Raytrace           56779.20 ±0.25%   56604.90 ±0.83%  -174.30     -0.31%
Regexp              6161.00 ±0.47%    6135.27 ±0.37%   -25.73     -0.42%
Richards           29961.80 ±0.39%   30213.70 ±0.10%   251.90      0.84%
Splay              26685.27 ±0.33%   26783.53 ±0.29%    98.26      0.37%
Splay latency      46631.86 ±0.35%   46534.15 ±0.44%   -97.71     -0.21%
Typescript         31457.75 ±0.76%   31530.08 ±0.94%    72.33      0.23%
Zlib               67508.50 ±0.11%   67255.87 ±0.31%  -252.63     -0.37%
----------------  ----------------  ----------------  -------  ---------  --------
Total              35801.50 ±0.26%   35795.09 ±0.32%    -6.41     -0.02%
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/802)
<!-- Reviewable:end -->