### PR TITLE
Destructuring issue with assignment.

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -6420,7 +6420,7 @@ void EmitDestructuredObjectMember(ParseNodePtr memberNode,
 }
 
 void EmitDestructuredObject(ParseNode *lhs,
-    Js::RegSlot rhsLocation,
+    Js::RegSlot rhsLocationOrig,
     ByteCodeGenerator *byteCodeGenerator,
     FuncInfo *funcInfo)
 {
@@ -6430,6 +6430,8 @@ void EmitDestructuredObject(ParseNode *lhs,
     byteCodeGenerator->StartStatement(lhs);
 
     Js::ByteCodeLabel skipThrow = byteCodeGenerator->Writer()->DefineLabel();
+    Js::RegSlot rhsLocation = funcInfo->AcquireTmpRegister();
+    byteCodeGenerator->Writer()->Reg2(Js::OpCode::Ld_A, rhsLocation, rhsLocationOrig);
     byteCodeGenerator->Writer()->BrReg2(Js::OpCode::BrNeq_A, skipThrow, rhsLocation, funcInfo->undefinedConstantRegister);
     byteCodeGenerator->Writer()->W1(Js::OpCode::RuntimeTypeError, SCODE_CODE(JSERR_ObjectCoercible));
     byteCodeGenerator->Writer()->MarkLabel(skipThrow);
@@ -6448,6 +6450,7 @@ void EmitDestructuredObject(ParseNode *lhs,
         EmitDestructuredObjectMember(current, rhsLocation, byteCodeGenerator, funcInfo);
     }
 
+    funcInfo->ReleaseTmpRegister(rhsLocation);
     byteCodeGenerator->EndStatement(lhs);
 }
 

--- a/test/es6/destructuring_bugs.js
+++ b/test/es6/destructuring_bugs.js
@@ -279,6 +279,15 @@ var tests = [
             assert.areEqual(x6, 11);
         })(1, {x2:2, x3:3}, [4, 5], undefined);
     }
+  },
+  {
+    name: "Object destructuring - changing the RHS when emitting",
+    body: function () {
+        var a = {}, b;
+        ({x:a, y:b = 1} = a);
+        assert.areEqual(a, undefined);
+        assert.areEqual(b, 1);
+    }
   }
 ];
 


### PR DESCRIPTION
We were passing the rhs regslot location while emitting bytecode for the object's member. However if the first member changes the variable which is stored in that rhslocation, then the second member will work on the updated one instead of the original value on the rhs location.
For fixing that we storing the rhslocation to a temp and use that temp for emitting the members of the object pattern.
