### PR TITLE
Add FailFast for SEH handling

### DIFF
--- a/bin/ch/ch.cpp
+++ b/bin/ch/ch.cpp
@@ -109,9 +109,14 @@ int HostExceptionFilter(int exceptionCode, _EXCEPTION_POINTERS *ep)
     }
 
     fwprintf(stderr, _u("FATAL ERROR: %ls failed due to exception code %x\n"), hostName, exceptionCode);
-    fflush(stderr);
 
-    return EXCEPTION_EXECUTE_HANDLER;
+    _flushall();
+
+    // Exception happened, so we probably didn't clean up properly,
+    // Don't exit normally, just terminate
+    TerminateProcess(::GetCurrentProcess(), exceptionCode);
+
+    return EXCEPTION_CONTINUE_SEARCH;
 }
 
 void __stdcall PrintUsageFormat()
@@ -468,11 +473,7 @@ HRESULT ExecuteTestWithMemoryCheck(BSTR fileName)
     }
     __except (HostExceptionFilter(GetExceptionCode(), GetExceptionInformation()))
     {
-        _flushall();
-
-        // Exception happened, so we probably didn't clean up properly,
-        // Don't exit normally, just terminate
-        TerminateProcess(::GetCurrentProcess(), GetExceptionCode());
+        Assert(false);
     }
 
     _flushall();

--- a/lib/Runtime/Library/JavascriptFunction.h
+++ b/lib/Runtime/Library/JavascriptFunction.h
@@ -199,8 +199,12 @@ namespace Js
         static bool IsBuiltinProperty(Var objectWithProperty, PropertyIds propertyId);
 #endif
         private:
-        static int  ResumeForOutOfBoundsArrayRefs(int exceptionCode, PEXCEPTION_POINTERS exceptionInfo);
+            static int CallRootEventFilter(int exceptionCode, PEXCEPTION_POINTERS exceptionInfo);
+#if ENABLE_NATIVE_CODEGEN && defined(_M_X64)
+            static bool ResumeForOutOfBoundsArrayRefs(int exceptionCode, PEXCEPTION_POINTERS exceptionInfo);
+#endif
     };
+#if ENABLE_NATIVE_CODEGEN && defined(_M_X64)
     class ArrayAccessDecoder
     {
     public:
@@ -230,6 +234,7 @@ namespace Js
         };
         static InstructionData CheckValidInstr(BYTE* &pc, PEXCEPTION_POINTERS exceptionInfo, FunctionBody* funcBody);
     };
+#endif
 
     //
     // ---- implementation shared with diagnostics ----


### PR DESCRIPTION
Doing SEH over Chakra frames can cause us to go into a bad state because C++ destructors will not be called.
This change adds code to explicitly FailFast in case a host tries this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/805)
<!-- Reviewable:end -->
