### PR TITLE
Do not throw implicit exceptions when an implicit call happened

### DIFF
--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -11867,12 +11867,12 @@ Lowerer::SplitBailOnImplicitCall(IR::Instr *& instr)
                 TyInt8,
                 instr);
 
-        // Disable implicit calls since they will be called after bailing out
+        // Disable implicit calls and implicit exceptions since they will be called after bailing out
         disableImplicitCallsInstr =
             IR::Instr::New(
                 Js::OpCode::Ld_A,
                 disableImplicitCallAddress,
-                IR::IntConstOpnd::New(DisableImplicitCallFlag, TyInt8, instr->m_func, true),
+                IR::IntConstOpnd::New(DisableImplicitCallAndExceptionFlag, TyInt8, instr->m_func, true),
                 instr->m_func);
         instr->InsertBefore(disableImplicitCallsInstr);
 

--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -11867,12 +11867,12 @@ Lowerer::SplitBailOnImplicitCall(IR::Instr *& instr)
                 TyInt8,
                 instr);
 
-        // Disable implicit calls and implicit exceptions since they will be called after bailing out
+        // Disable implicit calls since they will be called after bailing out
         disableImplicitCallsInstr =
             IR::Instr::New(
                 Js::OpCode::Ld_A,
                 disableImplicitCallAddress,
-                IR::IntConstOpnd::New(DisableImplicitCallAndExceptionFlag, TyInt8, instr->m_func, true),
+                IR::IntConstOpnd::New(DisableImplicitCallFlag, TyInt8, instr->m_func, true),
                 instr->m_func);
         instr->InsertBefore(disableImplicitCallsInstr);
 

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -2152,8 +2152,8 @@ CommonNumber:
                 {
                     Assert((flags & Data) == Data && (flags & Writable) == None);
 
-                    JavascriptError::ThrowCantAssignIfStrictMode(propertyOperationFlags, requestContext);
                     requestContext->GetThreadContext()->AddImplicitCallFlags(ImplicitCall_NoOpSet);
+                    JavascriptError::ThrowCantAssignIfStrictMode(propertyOperationFlags, requestContext);
                     return FALSE;
                 }
             }

--- a/test/Optimizer/bug5579910.js
+++ b/test/Optimizer/bug5579910.js
@@ -1,0 +1,25 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function test0() {
+  var loopInvariant = 11;
+  var obj0 = {};
+  var arrObj0 = {};
+  var func1 = function (argMath0) {
+    for (var _strvar4 in i32) {
+      loopInvariant;
+      i32[_strvar4] = argMath0;
+    }
+  };
+  var i32 = new Int32Array(256);
+  arrObj0 = new Proxy(arrObj0, Object());
+  func1(arrObj0);
+}
+try {
+  test0();
+  print("PASSED");
+} catch (e) {
+  print("FAILED");
+}

--- a/test/Optimizer/rlexe.xml
+++ b/test/Optimizer/rlexe.xml
@@ -39,6 +39,12 @@
   </test>
   <test>
     <default>
+      <files>bug5579910.js</files>
+      <compile-flags>-bgjit- -mic:1</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>conv_bool.js</files>
     </default>
   </test>


### PR DESCRIPTION
BailOutOnImplicitCallsPreOp means anything unexpected should bailout and try again in the interpreter.
Since this is placed on hoisted instructions, it is possible that we won't actually execute this instruction.
We have to bailout on exception and let the interpreter determine if we actually need to throw or not.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/806)
<!-- Reviewable:end -->
