### PR TITLE
MSFT: 5470396 sourceList entry needs to be guarded against etw rundown

### DIFF
--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -1964,8 +1964,12 @@ namespace Js
 
         RecyclerWeakReference<Utf8SourceInfo>* sourceWeakRef = this->GetRecycler()->CreateWeakReferenceHandle<Utf8SourceInfo>(sourceInfo);
         sourceInfo->SetIsCesu8(isCesu8);
-
-        return sourceList->SetAtFirstFreeSpot(sourceWeakRef);
+        {
+            // We can be compiling new source code while rundown thread is reading from the list, causing AV on the reader thread
+            // lock the list during write as well.
+            AutoCriticalSection autocs(GetThreadContext()->GetEtwRundownCriticalSection());
+            return sourceList->SetAtFirstFreeSpot(sourceWeakRef);
+        }
     }
 
     void ScriptContext::CloneSources(ScriptContext* sourceContext)


### PR DESCRIPTION
We can be compiling new source code while rundown thread is reading from the list, causing AV on the reader thread
lock the list during write when new code is compiled. The lock should be mostly noop as the rundown open happen
during debugger dynamic attach & etw data collection start after the script is running. Don't see ieperf difference.
