### PR TITLE
get rid of jscript9lock check in chakracore

### DIFF
--- a/bin/ChakraCore/ChakraCoreDllFunc.cpp
+++ b/bin/ChakraCore/ChakraCoreDllFunc.cpp
@@ -51,11 +51,6 @@ static BOOL AttachProcess(HANDLE hmod)
     ThreadContext::GlobalInitialize();
 
     char16 *engine = szChakraCoreLock;
-    if (::FindAtom(szJScript9Lock) != 0)
-    {
-        AssertMsg(FALSE, "Expecting to load chakracore.dll but process already loaded jscript9.dll");
-        Binary_Inconsistency_fatal_error();
-    }
     if (::FindAtom(szChakraLock) != 0)
     {
         AssertMsg(FALSE, "Expecting to load chakracore.dll but process already loaded chakra.dll");


### PR DESCRIPTION
There is valid scenario where jscript9.dll and chakracore.dll can be loaded in the same
process. The chance of misuse of jscript9+chakracore scenario should be really rare. Let's
remove the lock and see if there is any strange combined usage.
