### PR TITLE
Clear the HasOnlyWritableDataProperties cache across script contexts when prototype changes

### DIFF
--- a/lib/Runtime/Library/JavascriptObject.cpp
+++ b/lib/Runtime/Library/JavascriptObject.cpp
@@ -205,11 +205,27 @@ namespace Js
         }
 
         // Examine new prototype chain. If it brings in any non-WritableData property, we need to invalidate related caches.
-        if (!JavascriptOperators::CheckIfObjectAndPrototypeChainHasOnlyWritableDataProperties(newPrototype))
+        bool objectAndPrototypeChainHasOnlyWritableDataProperties =
+            JavascriptOperators::CheckIfObjectAndPrototypeChainHasOnlyWritableDataProperties(newPrototype);
+
+        if (!objectAndPrototypeChainHasOnlyWritableDataProperties
+            || object->GetScriptContext() != newPrototype->GetScriptContext())
         {
+            // The HaveOnlyWritableDataProperties cache is cleared when a property is added or changed,
+            // but only for types in the same script context. Therefore, if the prototype is in another
+            // context, the object's cache won't be cleared when a property is added or changed on the prototype.
+            // Moreover, an object is added to the cache only when its whole prototype chain is in the same
+            // context.
+            //
+            // Since we don't have a way to find out which objects have a certain object as their prototype,
+            // we clear the cache here instead.
+
             // Invalidate fast prototype chain writable data test flag
             object->GetLibrary()->NoPrototypeChainsAreEnsuredToHaveOnlyWritableDataProperties();
+        }
 
+        if (!objectAndPrototypeChainHasOnlyWritableDataProperties)
+        {
             // Invalidate StoreField/PropertyGuards for any non-WritableData property in the new chain
             JavascriptOperators::MapObjectAndPrototypes<true>(newPrototype, [=](RecyclableObject* obj)
             {

--- a/test/Bugs/HasOnlyWritableDataProperties-cross-context.js
+++ b/test/Bugs/HasOnlyWritableDataProperties-cross-context.js
@@ -1,3 +1,8 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
 function f() {
     var obj0 = {};
     obj1 = Object.create(obj0);

--- a/test/Bugs/HasOnlyWritableDataProperties-cross-context.js
+++ b/test/Bugs/HasOnlyWritableDataProperties-cross-context.js
@@ -1,0 +1,13 @@
+function f() {
+    var obj0 = {};
+    obj1 = Object.create(obj0);
+
+    var sc = WScript.LoadScript('function setUp(obj0, obj1) { obj1.foo0 = 1; Object.setPrototypeOf(obj0, {}); Object.defineProperty(Object.getPrototypeOf(obj0), "foo1", {writable: false, value: "bar"}); }', 'samethread');
+    sc.setUp(obj0, obj1);
+
+    obj1.foo2 = 'bar';
+}
+
+f();
+
+WScript.Echo('Pass');

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -270,4 +270,10 @@
       <compile-flags>-ES6FunctionName -args summary -endargs</compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>HasOnlyWritableDataProperties-cross-context.js</files>
+      <compile-flags>-nonative</compile-flags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
Fixes VSO bug #[7003426](https://microsoft.visualstudio.com/web/wi.aspx?pcguid=cb55739e-4afe-46a3-970f-1b49d8ee7564&id=7003426).