### PR TITLE
Typespec too aggressive in prepass

### DIFF
--- a/lib/Backend/GlobOptIntBounds.cpp
+++ b/lib/Backend/GlobOptIntBounds.cpp
@@ -1221,9 +1221,9 @@ void GlobOpt::TrackIntSpecializedAddSubConstant(
             // also track that it is equal to (the value of 'b') - 2.
             Value *const value = addSubConstantInfo->SrcValue();
             const ValueInfo *const valueInfo = value->GetValueInfo();
-            Assert(valueInfo->IsInt());
+            Assert(valueInfo->IsLikelyInt());
             IntConstantBounds constantBounds;
-            AssertVerify(valueInfo->TryGetIntConstantBounds(&constantBounds));
+            AssertVerify(valueInfo->TryGetIntConstantBounds(&constantBounds, true));
             IntBounds *const bounds =
                 GetIntBoundsToUpdate(
                     valueInfo,

--- a/test/Optimizer/bug6228026.js
+++ b/test/Optimizer/bug6228026.js
@@ -1,0 +1,22 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function test0() {
+  var IntArr1 = [];
+  e = 0;
+  c = 30;
+  for (var v0 = 0; v0 < 4; ++v0) {
+    e = c * 10;
+    c += 1.1;
+  }
+  IntArr1[e] = 10;
+  return IntArr1.length === 0;
+}
+test0();
+if(!test0()) {
+  print("FAILED");
+} else {
+  print("PASSED");
+}

--- a/test/Optimizer/rlexe.xml
+++ b/test/Optimizer/rlexe.xml
@@ -27,6 +27,12 @@
   </test>
   <test>
     <default>
+      <files>bug6228026.js</files>
+      <compile-flags>-mic:1 -off:simplejit</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>bug469.js</files>
       <compile-flags>-maxinterpretcount:1 -bgjit- -loopinterpretcount:1 -force:fixdataprops -off:aggressiveinttypespec -off:bailonnoprofile</compile-flags>
     </default>


### PR DESCRIPTION
No longer change the value info in Prepass during TypeSpec.
This was leading to some instruction to be typespec'ed too aggressively and thus removing some bailouts.

Perf comparison (with pogo binaires)
```
Octane            Left score        Right score       ∆ Score   ∆ Score %  Comment
----------------  ----------------  ----------------  --------  ---------  --------
Box2d              45262.25 ±0.63%   45372.20 ±0.27%    109.95      0.24%
Code-load          21873.08 ±0.10%   21901.10 ±0.07%     28.02      0.13%
Crypto             34201.92 ±0.62%   34671.90 ±0.28%    469.98      1.37%
Deltablue          26274.60 ±0.39%   26321.70 ±0.26%     47.10      0.18%
Earley-boyer       41517.20 ±0.18%   41470.40 ±0.14%    -46.80     -0.11%
Gbemu              62691.70 ±0.12%   63147.30 ±0.21%    455.60      0.73%  Improved
Mandreel           34027.10 ±0.09%   33979.80 ±0.27%    -47.30     -0.14%
Mandreel latency  123694.62 ±0.33%  122603.33 ±0.35%  -1091.28     -0.88%
Navier-stokes      36757.08 ±0.03%   36632.70 ±0.12%   -124.38     -0.34%
Pdfjs              26641.58 ±0.96%   25988.50 ±0.28%   -653.08     -2.45%
Raytrace           55591.60 ±0.65%   55654.40 ±0.81%     62.80      0.11%
Regexp              6144.60 ±0.52%    6191.00 ±0.18%     46.40      0.76%
Richards           30234.00 ±0.21%   30328.00 ±0.25%     94.00      0.31%
Splay              26369.80 ±0.18%   26639.30 ±0.24%    269.50      1.02%  Improved
Splay latency      46125.15 ±0.40%   46029.92 ±0.68%    -95.24     -0.21%
Typescript         31416.20 ±0.72%   31193.80 ±0.36%   -222.40     -0.71%
Zlib               67404.36 ±0.24%   66917.90 ±0.43%   -486.46     -0.72%
----------------  ----------------  ----------------  --------  ---------  --------
Total              35744.86 ±0.38%   35728.69 ±0.31%    -16.17     -0.05%
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/811)
<!-- Reviewable:end -->
