### PR TITLE
xplat: turn on and customize PAL_STDCPP_COMPAT mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,28 +59,19 @@ if(CLR_CMAKE_PLATFORM_UNIX)
         add_definitions(-D_M_X64 -D_M_AMD64)
     endif(CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64 OR CMAKE_SYSTEM_PROCESSOR STREQUAL amd64)
 
-    add_definitions("-D__STDC_WANT_LIB_EXT1__=1")
     add_definitions(
         -DUNICODE
         -D_SAFECRT_USE_CPP_OVERLOADS=1
+        -D__STDC_WANT_LIB_EXT1__=1
+        -DDISABLE_JIT=1  # xplat-todo: enable the JIT for Linux
         )
 
-    add_compile_options(-fms-extensions)
-
-    # Disable some warnings
-    add_compile_options(-Wno-tautological-constant-out-of-range-compare)
     set(CMAKE_CXX_STANDARD 11)
 
-    # xplat-todo: enable the JIT for Linux
-    add_definitions(
-        -DDISABLE_JIT=1
-        )
-
-    # xplat-todo: revisit these
-    # also, we should change this from add_definitions- the intent of that
-    # is to just add -D flags
-    add_definitions(
+    add_compile_options(
+        -fms-extensions
         -fdelayed-template-parsing
+        -msse4.1
         -Wno-microsoft
         -Wno-unused-value
         -Wno-int-to-void-pointer-cast
@@ -94,6 +85,7 @@ if(CLR_CMAKE_PLATFORM_UNIX)
         -Wno-format
         -Wno-invalid-noreturn
         -Wno-null-arithmetic
+        -Wno-tautological-constant-out-of-range-compare
         -Wno-tautological-undefined-compare
         -Wno-address-of-temporary  # vtinfo.h, VirtualTableInfo<T>::RegisterVirtualTable
         -Wno-null-conversion # Check shmemory.cpp and cs.cpp here...
@@ -139,7 +131,10 @@ include_directories(
 
 add_subdirectory (pal)
 
-# build the rest with NO_PAL_MINMAX
-add_definitions(-DNO_PAL_MINMAX)
+# build the rest with NO_PAL_MINMAX and PAL_STDCPP_COMPAT
+add_definitions(
+    -DNO_PAL_MINMAX
+    -DPAL_STDCPP_COMPAT
+    )
 add_subdirectory (lib)
 add_subdirectory (bin)

--- a/bin/ChakraCore/CMakeLists.txt
+++ b/bin/ChakraCore/CMakeLists.txt
@@ -1,6 +1,3 @@
-# xplat-todo: This is a skeleton make file and not used in build yet.
-# Please add this to build and fix issues.
-
 add_library (ChakraCore
     ChakraCore.def
     ChakraCoreDLLFunc.cpp

--- a/bin/rl/CMakeLists.txt
+++ b/bin/rl/CMakeLists.txt
@@ -1,6 +1,3 @@
-# xplat-todo: This is a skeleton make file and not used in build yet.
-# Please add this to build and fix issues.
-
 add_library (rl
     rl.cpp
     rlfeint.cpp

--- a/lib/Backend/CMakeLists.txt
+++ b/lib/Backend/CMakeLists.txt
@@ -1,6 +1,3 @@
-# xplat-todo: This is a skeleton make file and not used in build yet.
-# Please add this to build and fix issues.
-
 add_library (Chakra.Backend
     AgenPeeps.cpp
     Backend.cpp

--- a/lib/Common/CommonPal.h
+++ b/lib/Common/CommonPal.h
@@ -31,6 +31,12 @@ typedef wchar_t char16;
 #else // !_WIN32
 
 #define USING_PAL_STDLIB 1
+#ifdef PAL_STDCPP_COMPAT
+#include <math.h>
+#include <time.h>
+#include <smmintrin.h>
+#include <xmmintrin.h>
+#endif
 #include "inc/pal.h"
 #include "inc/rt/palrt.h"
 #include "inc/rt/no_sal2.h"
@@ -39,6 +45,12 @@ typedef wchar_t char16;
 typedef char16_t char16;
 #define _u(s) u##s
 #define INIT_PRIORITY(x) __attribute__((init_priority(x)))
+
+#ifdef PAL_STDCPP_COMPAT
+#define __in
+#define __out
+#define FILE PAL_FILE
+#endif
 
 // xplat-todo: verify below is correct
 #include <cpuid.h>
@@ -354,14 +366,6 @@ extern "C" PVOID _ReturnAddress(VOID);
 #pragma intrinsic(_ReturnAddress)
 #else
 #define _ReturnAddress() __builtin_return_address(0)
-#endif
-
-// xplat-todo: can we get rid of this for clang?
-// Including xmmintrin.h right now creates a ton of
-// compile errors, so temporarily defining this for clang
-// to avoid including that header
-#ifndef _MSC_VER
-#define _MM_HINT_T0 3
 #endif
 
 // xplat-todo: figure out why strsafe.h includes stdio etc

--- a/lib/Common/Memory/CommonMemoryPch.h
+++ b/lib/Common/Memory/CommonMemoryPch.h
@@ -9,14 +9,12 @@
 typedef _Return_type_success_(return >= 0) LONG NTSTATUS;
 #define NT_SUCCESS(Status) (((NTSTATUS)(Status)) >= 0)
 
-#ifndef USING_PAL_STDLIB
 // === C Runtime Header Files ===
 #include <time.h>
 #if defined(_UCRT)
 #include <cmath>
 #else
 #include <math.h>
-#endif
 #endif
 
 // Exceptions

--- a/lib/Jsrt/CMakeLists.txt
+++ b/lib/Jsrt/CMakeLists.txt
@@ -1,6 +1,3 @@
-# xplat-todo: This is a skeleton make file and not used in build yet.
-# Please add this to build and fix issues.
-
 add_library (Chakra.Jsrt
     Jsrt.cpp
     JsrtContext.cpp

--- a/lib/Jsrt/Core/CMakeLists.txt
+++ b/lib/Jsrt/Core/CMakeLists.txt
@@ -1,6 +1,3 @@
-# xplat-todo: This is a skeleton make file and not used in build yet.
-# Please add this to build and fix issues.
-
 add_library (Chakra.Jsrt.Core
     JsrtContextCore.cpp
     )

--- a/lib/Runtime/Debug/CMakeLists.txt
+++ b/lib/Runtime/Debug/CMakeLists.txt
@@ -1,6 +1,3 @@
-# xplat-todo: This is a skeleton make file and not used in build yet.
-# Please add this to build and fix issues.
-
 add_library (Chakra.Runtime.Debug
     BreakpointProbe.cpp
     DebugContext.cpp

--- a/lib/Runtime/Library/CMakeLists.txt
+++ b/lib/Runtime/Library/CMakeLists.txt
@@ -1,6 +1,3 @@
-# xplat-todo: This is a skeleton make file and not used in build yet.
-# Please add this to build and fix issues.
-
 add_library (Chakra.Runtime.Library
     ArgumentsObject.cpp
     ArgumentsObjectEnumerator.cpp
@@ -79,7 +76,7 @@ add_library (Chakra.Runtime.Library
     JavascriptWeakMap.cpp
     JavascriptWeakSet.cpp
     LiteralString.cpp
-    # MathLibrary.cpp
+    MathLibrary.cpp
     ModuleRoot.cpp
     NullEnumerator.cpp
     ObjectPrototypeObject.cpp

--- a/lib/Runtime/Library/CompoundString.cpp
+++ b/lib/Runtime/Library/CompoundString.cpp
@@ -3,7 +3,6 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 // JScriptDiag does not link with Runtime.lib and does not include .cpp files, so this file will be included as a header
-#pragma once
 #include "RuntimeLibraryPch.h"
 
 

--- a/lib/Runtime/Math/CMakeLists.txt
+++ b/lib/Runtime/Math/CMakeLists.txt
@@ -1,6 +1,3 @@
-# xplat-todo: This is a skeleton make file and not used in build yet.
-# Please add this to build and fix issues.
-
 add_library (Chakra.Runtime.Math
     AsmJsMath.cpp
     JavascriptSSE2MathOperators.cpp

--- a/pal/inc/pal.h
+++ b/pal/inc/pal.h
@@ -6080,7 +6080,7 @@ CoCreateGuid(OUT GUID * pguid);
    To avoid name collisions, those functions have been renamed using
    defines */
 #ifdef PLATFORM_UNIX
-#ifndef PAL_STDCPP_COMPAT
+#if !defined(PAL_STDCPP_COMPAT) || defined(USING_PAL_STDLIB)
 #define exit          PAL_exit
 #define atexit        PAL_atexit
 #define printf        PAL_printf
@@ -6394,7 +6394,7 @@ PALIMPORT int __cdecl _finite(double);
 PALIMPORT int __cdecl _isnan(double);
 PALIMPORT double __cdecl _copysign(double, double);
 
-#ifndef PAL_STDCPP_COMPAT
+#if !defined(PAL_STDCPP_COMPAT) || defined(USING_PAL_STDLIB)
 
 #ifdef __cplusplus
 extern "C++" {
@@ -6561,7 +6561,7 @@ PALIMPORT PAL_FILE * __cdecl PAL_get_stdin(int caller);
 PALIMPORT PAL_FILE * __cdecl PAL_get_stderr(int caller);
 PALIMPORT int * __cdecl PAL_errno(int caller);
 
-#ifdef PAL_STDCPP_COMPAT
+#if defined(PAL_STDCPP_COMPAT) && !defined(USING_PAL_STDLIB)
 #define PAL_stdout (PAL_get_stdout(PAL_get_caller))
 #define PAL_stdin  (PAL_get_stdin(PAL_get_caller))
 #define PAL_stderr (PAL_get_stderr(PAL_get_caller))

--- a/pal/inc/rt/palrt.h
+++ b/pal/inc/rt/palrt.h
@@ -1102,7 +1102,7 @@ errno_t __cdecl _ltow_s(long _Value, WCHAR *_Dst, size_t _SizeInWords, int _Radi
 }
 
 #endif
-    
+
 /* _i64tow_s */
 _SAFECRT__EXTERN_C
 errno_t __cdecl _i64tow_s(__int64 _Value, WCHAR *_Dst, size_t _SizeInWords, int _Radix);
@@ -1267,60 +1267,6 @@ typename std::remove_reference<T>::type&& move( T&& t );
 #define __RPC__deref_out_ecount_full_opt(x)
 
 typedef DWORD OLE_COLOR;
-
-#ifndef PAL_STDCPP_COMPAT
-// defined in xmmintrin.h
-typedef float __m128 __attribute__((__vector_size__(16)));
-typedef double __m128d __attribute__((__vector_size__(16)));
-
-// __m128i defined in emmintrin.h
-typedef union __m128i {
-    __int8              m128i_i8[16];
-    __int16             m128i_i16[8];
-    __int32             m128i_i32[4];
-    __int64             m128i_i64[2];
-    unsigned __int8     m128i_u8[16];
-    unsigned __int16    m128i_u16[8];
-    unsigned __int32    m128i_u32[4];
-    unsigned __int64    m128i_u64[2];
-} __m128i;
-
-// from emmintrin.h
-static __inline__ __m128d __attribute__((__always_inline__, __nodebug__))
-_mm_load_sd(double const *__dp)
-{
-  struct __mm_load_sd_struct {
-    double __u;
-  } __attribute__((__packed__, __may_alias__));
-  double __u = ((struct __mm_load_sd_struct*)__dp)->__u;
-  return (__m128d){ __u, 0 };
-}
-
-// from emmintrin.h
-static __inline__ int __attribute__((__always_inline__, __nodebug__))
-_mm_cvtsd_si32(__m128d __a)
-{
-  return __builtin_ia32_cvtsd2si(__a);
-}
-
-// from xmmintrin.h
-static __inline__ __m128 __attribute__((__always_inline__, __nodebug__))
-_mm_loadu_ps(const float *__p)
-{
-  struct __loadu_ps {
-    __m128 __v;
-  } __attribute__((__packed__, __may_alias__));
-  return ((struct __loadu_ps*)__p)->__v;
-}
-
-// from xmmintrin.h
-static __inline__ void __attribute__((__always_inline__, __nodebug__))
-_mm_storeu_ps(float *__p, __m128 __a)
-{
-  __builtin_ia32_storeups(__p, __a);
-}
-
-#endif
 
 #define PF_COMPARE_EXCHANGE_DOUBLE          2
 


### PR DESCRIPTION
We use PAL's stdlib implementations which are incompatible with std headers.
This was a big headache as we couldn't include std headers such as
`<stdio.h>` or `<emmintrin.h>`, directly or indirectly. To work around we
used to copy some declarations directly (into palrt.h or CommonPal.h), till
it no longer worked for some reason (copied declarations dependency?).

This change attemps to turn on `PAL_STDCPP_COMPAT` mode and customize it,
so that we can use PAL and be compatible with std headers.

The primary change is very simple: turn on `PAL_STDCPP_COMPAT` mode, and
in `pal.h` enable some non-STDCPP-COMPAT customizations that we need. (e.g.,
`printf` is defined to `PAL_printf`, thus Chakra code that uses `printf`
are all redirected to call `PAL_printf`.)

With this change we are able to `#include <emmintrin.h>` and build
`Runtime/Library/MathLibrary.cpp` and a list of `Runtime/Language/Simd???`
files.
