### PR TITLE
Do not recompile a RegExp pattern before calling "exec" from Symbol methods

### DIFF
--- a/lib/Runtime/Library/JavascriptRegularExpression.cpp
+++ b/lib/Runtime/Library/JavascriptRegularExpression.cpp
@@ -870,21 +870,6 @@ namespace Js
 
     Var JavascriptRegExp::CallExec(RecyclableObject* thisObj, JavascriptString* string, PCWSTR varName, ScriptContext* scriptContext)
     {
-        JavascriptRegExp* regExObj = nullptr;
-
-        // TODO: The built-in "exec" in ES6 is supposed to access the RegExp flags. Since the flags
-        // can be overridden and return a different value than what's passed to the constructor,
-        // the pattern needs to be recompiled. However, the way the observability check is currently
-        // implemented, it reduces the perf quite a lot.
-        //
-        // Therefore, we recompile the pattern here before calling "exec" for the time being, but
-        // this will be moved to "exec".
-        if (JavascriptRegExp::Is(thisObj))
-        {
-            regExObj = JavascriptRegExp::FromVar(thisObj);
-            regExObj->RecompilePatternForExecIfNeeded(scriptContext);
-        }
-
         Var exec = JavascriptOperators::GetProperty(thisObj, PropertyIds::exec, scriptContext);
         if (JavascriptConversion::IsCallable(exec))
         {
@@ -899,10 +884,7 @@ namespace Js
             return result;
         }
 
-        if (regExObj == nullptr)
-        {
-            regExObj = ToRegExp(thisObj, varName, scriptContext);
-        }
+        JavascriptRegExp* regExObj = ToRegExp(thisObj, varName, scriptContext);
         return RegexHelper::RegexExec(scriptContext, regExObj, string, false);
     }
 

--- a/lib/Runtime/Library/JavascriptRegularExpression.h
+++ b/lib/Runtime/Library/JavascriptRegularExpression.h
@@ -68,11 +68,9 @@ namespace Js
         static bool HasObservableExec(DynamicObject* regexPrototype);
         static bool HasObservableFlags(DynamicObject* regexPrototype);
         static bool HasObservableGlobalFlag(DynamicObject* regexPrototype);
-        static bool HasObservableStickyFlag(DynamicObject* regexPrototype);
         static bool HasObservableUnicodeFlag(DynamicObject* regexPrototype);
 
         static Var CallExec(RecyclableObject* thisObj, JavascriptString* string, PCWSTR varName, ScriptContext* scriptContext);
-        void RecompilePatternForExecIfNeeded(ScriptContext* scriptContext);
         UnifiedRegex::RegexFlags SetRegexFlag(PropertyId propertyId, UnifiedRegex::RegexFlags flags, UnifiedRegex::RegexFlags flag, ScriptContext* scriptContext);
 
         // For boxing stack instance

--- a/lib/Runtime/Library/RegexHelper.cpp
+++ b/lib/Runtime/Library/RegexHelper.cpp
@@ -377,7 +377,6 @@ namespace Js
         return !JavascriptRegExp::HasOriginalRegExType(instance)
             || JavascriptRegExp::HasObservableExec(regexPrototype)
             || JavascriptRegExp::HasObservableGlobalFlag(regexPrototype)
-            || JavascriptRegExp::HasObservableStickyFlag(regexPrototype)
             || JavascriptRegExp::HasObservableUnicodeFlag(regexPrototype);
     }
 
@@ -648,9 +647,7 @@ namespace Js
     {
         DynamicObject* regexPrototype = scriptContext->GetLibrary()->GetRegExpPrototype();
         return !JavascriptRegExp::HasOriginalRegExType(instance)
-            || JavascriptRegExp::HasObservableExec(regexPrototype)
-            || JavascriptRegExp::HasObservableGlobalFlag(regexPrototype)
-            || JavascriptRegExp::HasObservableStickyFlag(regexPrototype);
+            || JavascriptRegExp::HasObservableExec(regexPrototype);
     }
 
     Var RegexHelper::RegexEs6TestImpl(ScriptContext* scriptContext, RecyclableObject* thisObj, JavascriptString *input)
@@ -837,8 +834,7 @@ namespace Js
         return !JavascriptRegExp::HasOriginalRegExType(instance)
             || JavascriptRegExp::HasObservableUnicodeFlag(regexPrototype)
             || JavascriptRegExp::HasObservableExec(regexPrototype)
-            || JavascriptRegExp::HasObservableGlobalFlag(regexPrototype)
-            || JavascriptRegExp::HasObservableStickyFlag(regexPrototype);
+            || JavascriptRegExp::HasObservableGlobalFlag(regexPrototype);
     }
 
     Var RegexHelper::RegexEs6ReplaceImpl(ScriptContext* scriptContext, RecyclableObject* thisObj, JavascriptString* input, JavascriptString* replace, bool noResult)
@@ -1505,9 +1501,7 @@ namespace Js
         return !JavascriptRegExp::HasOriginalRegExType(instance)
             || JavascriptRegExp::HasObservableConstructor(regexPrototype)
             || JavascriptRegExp::HasObservableFlags(regexPrototype)
-            || JavascriptRegExp::HasObservableExec(regexPrototype)
-            || JavascriptRegExp::HasObservableGlobalFlag(regexPrototype)
-            || JavascriptRegExp::HasObservableStickyFlag(regexPrototype);
+            || JavascriptRegExp::HasObservableExec(regexPrototype);
     }
 
     Var RegexHelper::RegexEs6SplitImpl(ScriptContext* scriptContext, RecyclableObject* thisObj, JavascriptString* input, CharCount limit, bool noResult, void *const stackAllocationPointer)

--- a/test/es6/regex-symbols.js
+++ b/test/es6/regex-symbols.js
@@ -519,7 +519,7 @@ var tests = [
     {
         name: "RegExp.prototype[@@replace] should 'Get' 'global' when it is overridden",
         body: function () {
-            var re = /a-/;
+            var re = /a-/g;
             re.lastIndex = 1; // Will be reset to 0 by RegExp.prototype[@@replace]
             var string = "a-a-ba-";
             var replace = "*";
@@ -540,7 +540,7 @@ var tests = [
     {
         name: "RegExp.prototype[@@replace] should coerce a missing 'global' to 'false'",
         body: function () {
-            var re = /a-/g;
+            var re = /a-/;
             re.lastIndex = 1; // RegExpBuiltinExec will ignore this and start from 0
             var string = "a-a-ba-";
             var replace = "*";
@@ -924,7 +924,7 @@ var tests = [
     {
         name: "RegExp.prototype[@@match] should 'Get' 'global' when it is overridden",
         body: function () {
-            var re = /a-/;
+            var re = /a-/g;
             re.lastIndex = 1; // Will be reset to 0 by RegExp.prototype[@@match]
 
             var calledGlobal = false;
@@ -946,45 +946,11 @@ var tests = [
     {
         name: "RegExp.prototype[@@match] should coerce a missing 'global' to 'false'",
         body: function () {
-            var re = /a-/g;
+            var re = /a-/;
             re.lastIndex = 1; // RegExpBuiltinExec will ignore this and start from 0
 
             var result;
             helpers.withPropertyDeleted(RegExp.prototype, "global", function () {
-                result = re[Symbol.match]("a-a-ba-");
-            });
-
-            assert.areEqual(1, result.length, "result.length");
-            assert.areEqual("a-", result[0], "result[0]");
-        }
-    },
-    {
-        name: "RegExp.prototype[@@match] should 'Get' 'sticky' when it is overridden",
-        body: function () {
-            var re = /a-/;
-            re.lastIndex = 1; // Will be kept at 1
-
-            var calledSticky = false;
-            var getSticky = function () {
-                calledSticky = true;
-                return true;
-            };
-            Object.defineProperty(re, "sticky", {get: getSticky});
-
-            var result = re[Symbol.match]("a-a-ba-");
-
-            assert.isTrue(calledSticky, "'sticky' getter is called");
-            assert.areEqual(null, result, "result");
-        }
-    },
-    {
-        name: "RegExp.prototype[@@match] should coerce a missing 'sticky' to 'false'",
-        body: function () {
-            var re = /a-/y;
-            re.lastIndex = 1; // RegExpBuiltinExec will ignore this and start from 0
-
-            var result;
-            helpers.withPropertyDeleted(RegExp.prototype, "sticky", function () {
                 result = re[Symbol.match]("a-a-ba-");
             });
 


### PR DESCRIPTION
RegExpBuiltinExec in the spec has been updated to infer "global" and
"sticky" using [[OriginalFlags]] instead of "Get"ting them via their
respective properties.

The "exec" implementation in our codebase wasn't previously updated to
use the properties due to perf concerns, so it already uses [[OriginalFlags]].
However, we used to recompile the RegExp pattern before calling "exec"
from Symbol methods (e.g., RegExp.prototype[@@match]), so this change
removes that recompilation.

Fixes #759.
