### PR TITLE
Simd.js: Fix for Tvs warnings

### DIFF
--- a/lib/Backend/IRBuilderAsmJs.cpp
+++ b/lib/Backend/IRBuilderAsmJs.cpp
@@ -7386,7 +7386,7 @@ void IRBuilderAsmJs::BuildSimd_1Ints(Js::OpCodeAsmJs newOpcode, uint32 offset, I
     srcOpnds[0]->SetValueType(ValueType::GetInt(false));
     instr = AddExtendedArg(srcOpnds[0], nullptr, offset);
     // reset of args
-    for (uint i = 1; i < LANES; i++)
+    for (uint i = 1; i < LANES && i < 16; i++)
     {
         srcOpnds[i] = BuildSrcOpnd(srcRegSlots[i], TyInt32);
         srcOpnds[i]->SetValueType(ValueType::GetInt(false));

--- a/lib/Backend/LowerMDSharedSimd128.cpp
+++ b/lib/Backend/LowerMDSharedSimd128.cpp
@@ -422,7 +422,7 @@ IR::Instr* LowererMD::Simd128LowerConstructor_8(IR::Instr *instr)
     dst = args->Pop();
 
     uint i = 0;
-    while (!args->Empty())
+    while (!args->Empty() && i < 8)
     {
         srcs[i] = args->Pop();
         // src's might have been constant prop'ed. Enregister them if so.
@@ -461,7 +461,7 @@ IR::Instr* LowererMD::Simd128LowerConstructor_16(IR::Instr *instr)
     dst = args->Pop();
 
     uint i = 0;
-    while (!args->Empty())
+    while (!args->Empty() && i < 16)
     {
         srcs[i] = args->Pop();
         // src's might have been constant prop'ed. Enregister them if so.
@@ -1713,13 +1713,13 @@ IR::Instr* LowererMD::Simd128LowerShuffle_4(IR::Instr* instr)
             // compute re-arrangement mask
             for (uint8 i = 0, j1 = 0, j2 = 2; i < 4; i++)
             {
-                if (lanesSrc[i] == 1)
+                if (lanesSrc[i] == 1 && j1 < 4)
                 {
                     ordLanes[j1] = lanes[i];
                     reArrLanes[i] = j1;
                     j1++;
                 }
-                else
+                else if(j2 < 4)
                 {
                     Assert(lanesSrc[i] == 2);
                     ordLanes[j2] = lanes[i];


### PR DESCRIPTION
Fixing buffer overflow warnings from Lowerer and IRBuilderAsmJs.

Fixes the following work items:
7198772, 7199415, 7197278, 7196675
