### PR TITLE
Simd.js:Enforce simd value coercion in asmjs return

### DIFF
--- a/lib/Runtime/Language/AsmJsByteCodeGenerator.h
+++ b/lib/Runtime/Language/AsmJsByteCodeGenerator.h
@@ -114,6 +114,9 @@ namespace Js
         void StartStatement(ParseNode* pnode);
         void EndStatement(ParseNode* pnode);
 
+        template<class NodeType>
+        AsmJsRetType::Which EmitReturnForType(EmitExpressionInfo& info, EmitExpressionInfo& emitInfo, OpCodeAsmJs opCode, AsmJsType asmType);
+
         // Emits the bytecode to load from the module
         // dst is the location of the variable in the function
         // index is the location of the target in the module's table
@@ -147,6 +150,8 @@ namespace Js
         {
             return mFunction->GetFuncBody()->GetScriptContext()->GetConfig()->IsSimdjsEnabled();
         }
+
+        bool IsSimdCheckCall(const ParseNode* pnode) const;
         // try to reuse a tmp register or acquire a new one
         // also takes care of releasing tmp register
         template<typename T>

--- a/test/SIMD.bool16x8.asmjs/rlexe.xml
+++ b/test/SIMD.bool16x8.asmjs/rlexe.xml
@@ -32,6 +32,14 @@
       <compile-flags>-bgjit- -on:asmjs -testtrace:asmjs -simdjs -AsmJsStopOnError -maic:0</compile-flags>
     </default>
   </test>
+   <test>
+    <default>
+      <files>testCheck.js</files>
+      <baseline>testCheck.baseline</baseline>
+      <tags>exclude_dynapogo,exclude_ship</tags>
+      <compile-flags>-off:deferparse -testtrace:asmjs -simdjs -bgjit- -maic:1</compile-flags>
+    </default>
+  </test>
   <test>
     <default>
       <files>testBitwise.js</files>

--- a/test/SIMD.bool16x8.asmjs/testCheck.baseline
+++ b/test/SIMD.bool16x8.asmjs/testCheck.baseline
@@ -1,0 +1,7 @@
+Successfully compiled asm.js code
+
+testCheck.js(25, 9)
+	Asm.js Compilation Error function : module::foo
+	Expression for returning simd values must be coerced using check()
+
+Asm.js compilation failed.

--- a/test/SIMD.bool16x8.asmjs/testCheck.js
+++ b/test/SIMD.bool16x8.asmjs/testCheck.js
@@ -1,0 +1,29 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function module0(stdlib) {
+    "use asm"
+    var b8 = stdlib.SIMD.Bool16x8;
+    var b8and = b8.and;
+    var b8check = b8.check;
+    function foo() {
+        var abc = b8(1,1,1,1,1,1,1,1);
+        return b8check(b8and(abc, abc));
+    }
+    return { foo:foo }
+}
+var c = module0(this);
+
+function module(stdlib) {
+    "use asm"
+    var b8 = stdlib.SIMD.Bool16x8;
+    var b8and = b8.and;
+    function foo() {
+        var abc = b8(1,1,1,1,1,1,1,1);
+        return b8and(abc, abc);
+    }
+    return { foo:foo }
+}
+var c = module(this);

--- a/test/SIMD.bool32x4.asmjs/rlexe.xml
+++ b/test/SIMD.bool32x4.asmjs/rlexe.xml
@@ -32,6 +32,14 @@
       <compile-flags>-bgjit- -on:asmjs -testtrace:asmjs -simdjs -AsmJsStopOnError -maic:0</compile-flags>
     </default>
   </test>
+     <test>
+    <default>
+      <files>testCheck.js</files>
+      <baseline>testCheck.baseline</baseline>
+      <tags>exclude_dynapogo,exclude_ship</tags>
+      <compile-flags>-off:deferparse -testtrace:asmjs -simdjs -bgjit- -maic:1</compile-flags>
+    </default>
+  </test>
   <test>
     <default>
       <files>testBitwise.js</files>

--- a/test/SIMD.bool32x4.asmjs/testCheck.baseline
+++ b/test/SIMD.bool32x4.asmjs/testCheck.baseline
@@ -1,0 +1,7 @@
+Successfully compiled asm.js code
+
+testCheck.js(25, 9)
+	Asm.js Compilation Error function : module::foo
+	Expression for returning simd values must be coerced using check()
+
+Asm.js compilation failed.

--- a/test/SIMD.bool32x4.asmjs/testCheck.js
+++ b/test/SIMD.bool32x4.asmjs/testCheck.js
@@ -1,0 +1,29 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function module0(stdlib) {
+    "use asm"
+    var b = stdlib.SIMD.Bool32x4;
+    var band = b.and;
+    var bcheck = b.check;
+    function foo() {
+        var abc = b(1,1,1,1);
+        return bcheck(band(abc, abc));
+    }
+    return { foo:foo }
+}
+var c = module0(this);
+
+function module(stdlib) {
+    "use asm"
+    var b = stdlib.SIMD.Bool32x4;
+    var band = b.and;
+    function foo() {
+        var abc = b(1,1,1,1);
+        return band(abc, abc);
+    }
+    return { foo:foo }
+}
+var c = module(this);

--- a/test/SIMD.bool8x16.asmjs/rlexe.xml
+++ b/test/SIMD.bool8x16.asmjs/rlexe.xml
@@ -34,6 +34,14 @@
   </test>
   <test>
     <default>
+      <files>testCheck.js</files>
+      <baseline>testCheck.baseline</baseline>
+      <tags>exclude_dynapogo,exclude_ship</tags>
+      <compile-flags>-off:deferparse -testtrace:asmjs -simdjs -bgjit- -maic:1</compile-flags>
+  </default>
+  </test>
+  <test>
+    <default>
       <files>testBitwise.js</files>
       <baseline>asmjs.baseline</baseline>
       <tags>exclude_dynapogo,exclude_ship</tags>

--- a/test/SIMD.bool8x16.asmjs/testCheck.baseline
+++ b/test/SIMD.bool8x16.asmjs/testCheck.baseline
@@ -1,0 +1,7 @@
+Successfully compiled asm.js code
+
+testCheck.js(25, 9)
+	Asm.js Compilation Error function : module::foo
+	Expression for returning simd values must be coerced using check()
+
+Asm.js compilation failed.

--- a/test/SIMD.bool8x16.asmjs/testCheck.js
+++ b/test/SIMD.bool8x16.asmjs/testCheck.js
@@ -1,0 +1,29 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function module0(stdlib) {
+    "use asm"
+    var b = stdlib.SIMD.Bool8x16;
+    var band = b.and;
+    var bcheck = b.check;
+    function foo() {
+        var abc = b(1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1);
+        return bcheck(band(abc, abc));
+    }
+    return { foo:foo }
+}
+var c = module0(this);
+
+function module(stdlib) {
+    "use asm"
+    var b = stdlib.SIMD.Bool8x16;
+    var band = b.and;
+    function foo() {
+        var abc = b(1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1);
+        return band(abc, abc);
+    }
+    return { foo:foo }
+}
+var c = module(this);

--- a/test/SIMD.float32x4.asmjs/rlexe.xml
+++ b/test/SIMD.float32x4.asmjs/rlexe.xml
@@ -38,7 +38,14 @@
       <compile-flags>-bgjit- -simdjs -asmjs- -simd128typespec  -off:simplejit -mic:1 -lic:1</compile-flags>
     </default>
   </test>
-
+ <test>
+    <default>
+      <files>testCheck.js</files>
+      <baseline>testCheck.baseline</baseline>
+      <tags>exclude_dynapogo,exclude_ship</tags>
+      <compile-flags>-off:deferparse -testtrace:asmjs -simdjs -bgjit- -maic:1</compile-flags>
+    </default>
+  </test>
   <test>
     <default>
       <files>testAddSub.js</files>

--- a/test/SIMD.float32x4.asmjs/testCheck.baseline
+++ b/test/SIMD.float32x4.asmjs/testCheck.baseline
@@ -1,0 +1,7 @@
+Successfully compiled asm.js code
+
+testCheck.js(25, 9)
+	Asm.js Compilation Error function : module::foo
+	Expression for returning simd values must be coerced using check()
+
+Asm.js compilation failed.

--- a/test/SIMD.float32x4.asmjs/testCheck.js
+++ b/test/SIMD.float32x4.asmjs/testCheck.js
@@ -1,0 +1,29 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function module0(stdlib) {
+    "use asm"
+    var b = stdlib.SIMD.Float32x4;
+    var badd = b.add;
+    var bcheck = b.check;
+    function foo() {
+        var abc = b(1.0,1.0,1.0,1.0);
+        return bcheck(badd(abc, abc));
+    }
+    return { foo:foo }
+}
+var c = module0(this);
+
+function module(stdlib) {
+    "use asm"
+    var b = stdlib.SIMD.Float32x4;
+    var badd = b.add;
+    function foo() {
+        var abc = b(1.0,1.0,1.0,1.0);
+        return badd(abc, abc);
+    }
+    return { foo:foo }
+}
+var c = module(this);

--- a/test/SIMD.float32x4.asmjs/testLoadStore-2.js
+++ b/test/SIMD.float32x4.asmjs/testLoadStore-2.js
@@ -118,49 +118,49 @@ function asmModule(stdlib, imports, buffer) {
     {
         idx = idx|0;
         idx = idx<<2;
-        return f4load(Float32Heap, (idx>>2));
+        return f4check(f4load(Float32Heap, (idx>>2)));
     }
     
     function storeUI32(value, idx)
     { value= f4check(value); idx = idx|0; idx = idx<<2;
     f4store(Uint32Heap, (idx>>2), value);}
     function loadUI32(idx)
-    { idx = idx|0; idx = idx<<2; return f4load(Uint32Heap, (idx>>2)); }
+    { idx = idx|0; idx = idx<<2; return f4check(f4load(Uint32Heap, (idx>>2))); }
 
     function storeI32(value, idx)
     { value= f4check(value); idx = idx|0; idx = idx<<2;
     f4store(Int32Heap, (idx>>2), value);}
     function loadI32(idx)
-    { idx = idx|0; idx = idx<<2; return f4load(Int32Heap, (idx>>2)); }
+    { idx = idx|0; idx = idx<<2; return f4check(f4load(Int32Heap, (idx>>2))); }
 
     function storeI16(value, idx)
     { value= f4check(value); idx = idx|0; idx = idx<<1;
     f4store(Int16Heap, (idx>>1), value);}
     function loadI16(idx)
-    { idx = idx|0; idx = idx<<1; return f4load(Int16Heap, (idx>>1)); }
+    { idx = idx|0; idx = idx<<1; return f4check(f4load(Int16Heap, (idx>>1))); }
 
     function storeUI16(value, idx)
     { value= f4check(value); idx = idx|0; idx = idx<<1;
     f4store(Uint16Heap, (idx>>1), value);}
     function loadUI16(idx)
-    { idx = idx|0; idx = idx<<1; return f4load(Uint16Heap, (idx>>1)); }
+    { idx = idx|0; idx = idx<<1; return f4check(f4load(Uint16Heap, (idx>>1))); }
 
     function storeI8(value, idx)
     { value= f4check(value); idx = idx|0; idx = idx<<0;
     f4store(Int8Heap, (idx>>0), value);}
     function loadI8(idx)
-    { idx = idx|0; idx = idx<<0; return f4load(Int8Heap, (idx>>0)); }
+    { idx = idx|0; idx = idx<<0; return f4check(f4load(Int8Heap, (idx>>0))); }
 
     function storeUI8(value, idx)
     { value= f4check(value); idx = idx|0; idx = idx<<0;
     f4store(Uint8Heap, (idx>>0), value);}
     function loadUI8(idx)
-    { idx = idx|0; idx = idx<<0; return f4load(Uint8Heap, (idx>>0)); }
+    { idx = idx|0; idx = idx<<0; return f4check(f4load(Uint8Heap, (idx>>0))); }
 
     function loadStoreIndex1()
     {
         f4store(Float32Heap, 0, f4(-1.0,-2.0,3.1,-4.0));
-        return f4load(Float32Heap, 0);
+        return f4check(f4load(Float32Heap, 0));
     }
 
     function store_1(functionPicker) //Function picker to pick store1/store2/store3/store
@@ -196,7 +196,7 @@ function asmModule(stdlib, imports, buffer) {
             loopIndex = (loopIndex + 1)|0;
         }
 
-        return f4load(Float32Heap, 0);
+        return f4check(f4load(Float32Heap, 0));
 
     }
     function store_2(functionPicker)
@@ -231,7 +231,7 @@ function asmModule(stdlib, imports, buffer) {
                 v0 = f4add(v0, f4(1.0,1.0,1.0,1.0));
             }
         }
-        return f4load(Float32Heap, 8);
+        return f4check(f4load(Float32Heap, 8));
     }
     
     function store_3(functionPicker)
@@ -268,7 +268,7 @@ function asmModule(stdlib, imports, buffer) {
             loopIndex = (loopIndex - 1) | 0;
         }
         while ( (loopIndex | 0) > 0);
-        return f4load(Float32Heap, 8);
+        return f4check(f4load(Float32Heap, 8));
     }
 
     function store_1_Int8(length)
@@ -289,7 +289,7 @@ function asmModule(stdlib, imports, buffer) {
             loopIndex = (loopIndex + 1)|0;
         }
         //Expects the heap to be: 0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3...15,15,15,15,0,0,0,0...
-        return f4load(Float32Heap, 2);
+        return f4check(f4load(Float32Heap, 2));
     }
 
     function store_1_Uint8(length)
@@ -310,7 +310,7 @@ function asmModule(stdlib, imports, buffer) {
             loopIndex = (loopIndex + 1)|0;
         }
         //Expects the heap to be: 0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3...15,15,15,15,0,0,0,0...
-        return f4load(Float32Heap, 2);
+        return f4check(f4load(Float32Heap, 2));
     }
     
     function store_1_Int16(length)
@@ -331,7 +331,7 @@ function asmModule(stdlib, imports, buffer) {
             loopIndex = (loopIndex + 1)|0;
         }
         //Expects the heap to be: 0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3...15,15,15,15,0,0,0,0...
-        return f4load(Float32Heap, 2);
+        return f4check(f4load(Float32Heap, 2));
     }
     function store_1_Uint16(length)
     {
@@ -351,7 +351,7 @@ function asmModule(stdlib, imports, buffer) {
             loopIndex = (loopIndex + 1)|0;
         }
         //Expects the heap to be: 0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3...15,15,15,15,0,0,0,0...
-        return f4load(Float32Heap, 2);
+        return f4check(f4load(Float32Heap, 2));
     }
     
     function store_1_Int32(length)
@@ -372,7 +372,7 @@ function asmModule(stdlib, imports, buffer) {
             loopIndex = (loopIndex + 1)|0;
         }
         //Expects the heap to be: 0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3...15,15,15,15,0,0,0,0...
-        return f4load(Float32Heap, 2);
+        return f4check(f4load(Float32Heap, 2));
     }
     function store_1_Uint32(length)
     {
@@ -392,7 +392,7 @@ function asmModule(stdlib, imports, buffer) {
             loopIndex = (loopIndex + 1)|0;
         }
         //Expects the heap to be: 0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3...15,15,15,15,0,0,0,0...
-        return f4load(Float32Heap, 2);
+        return f4check(f4load(Float32Heap, 2));
     }
 
     ////////////////////////////Load////////////////////////////
@@ -430,7 +430,7 @@ function asmModule(stdlib, imports, buffer) {
             }
             loopIndex = (loopIndex + 1) | 0;
         }
-        return v;
+        return f4check(v);
     }
 
     function load_2(functionPicker)
@@ -467,7 +467,7 @@ function asmModule(stdlib, imports, buffer) {
                 }
             }
         }
-        return v;
+        return f4check(v);
     }
 
     function load_3(functionPicker)
@@ -505,7 +505,7 @@ function asmModule(stdlib, imports, buffer) {
             loopIndex = (loopIndex - 1) | 0;
         }
         while ( (loopIndex | 0) > 0);
-        return v;
+        return f4check(v);
     } 
     function load_1_Int8(length)
     {
@@ -522,7 +522,7 @@ function asmModule(stdlib, imports, buffer) {
             }
             loopIndex = (loopIndex + 1) | 0;
         }
-        return v;
+        return f4check(v);
     }
     function load_1_Uint8(length)
     {
@@ -539,7 +539,7 @@ function asmModule(stdlib, imports, buffer) {
             }
             loopIndex = (loopIndex + 1) | 0;
         }
-        return v;
+        return f4check(v);
     }
 
     function load_1_Int16(length)
@@ -557,7 +557,7 @@ function asmModule(stdlib, imports, buffer) {
             }
             loopIndex = (loopIndex + 1) | 0;
         }
-        return v;
+        return f4check(v);
     }
 
     function load_1_Uint16(length)
@@ -575,7 +575,7 @@ function asmModule(stdlib, imports, buffer) {
             }
             loopIndex = (loopIndex + 1) | 0;
         }
-        return v;
+        return f4check(v);
     }
 
     function load_1_Int32(length)
@@ -593,7 +593,7 @@ function asmModule(stdlib, imports, buffer) {
             }
             loopIndex = (loopIndex + 1) | 0;
         }
-        return v;
+        return f4check(v);
     }
     function load_1_Uint32(length)
     {
@@ -610,7 +610,7 @@ function asmModule(stdlib, imports, buffer) {
             }
             loopIndex = (loopIndex + 1) | 0;
         }
-        return v;
+        return f4check(v);
     }
 
     return {store1:store_1

--- a/test/SIMD.float32x4.asmjs/testResizeLoadStore-2.js
+++ b/test/SIMD.float32x4.asmjs/testResizeLoadStore-2.js
@@ -133,50 +133,50 @@ function asmModule(stdlib, imports, buffer) {
     {
         idx = idx|0;
         idx = idx<<2;
-        return f4load(Float32Heap, (idx>>2));
+        return f4check(f4load(Float32Heap, (idx>>2)));
     }
     
     function storeUI32(value, idx) 
     { value= f4check(value); idx = idx|0; idx = idx<<2; 
     f4store(Uint32Heap, (idx>>2), value);}
     function loadUI32(idx) 
-    { idx = idx|0; idx = idx<<2; return f4load(Uint32Heap, (idx>>2)); }
+    { idx = idx|0; idx = idx<<2; return f4check(f4load(Uint32Heap, (idx>>2))); }
     
     function storeI32(value, idx) 
     { value= f4check(value); idx = idx|0; idx = idx<<2; 
     f4store(Int32Heap, (idx>>2), value);}
     function loadI32(idx) 
-    { idx = idx|0; idx = idx<<2; return f4load(Int32Heap, (idx>>2)); }
+    { idx = idx|0; idx = idx<<2; return f4check(f4load(Int32Heap, (idx>>2))); }
     
     function storeI16(value, idx) 
     { value= f4check(value); idx = idx|0; idx = idx<<1; 
     f4store(Int16Heap, (idx>>1), value);}
     function loadI16(idx) 
-    { idx = idx|0; idx = idx<<1; return f4load(Int16Heap, (idx>>1)); }
+    { idx = idx|0; idx = idx<<1; return f4check(f4load(Int16Heap, (idx>>1))); }
 
     function storeUI16(value, idx) 
     { value= f4check(value); idx = idx|0; idx = idx<<1; 
     f4store(Uint16Heap, (idx>>1), value);}
     function loadUI16(idx) 
-    { idx = idx|0; idx = idx<<1; return f4load(Uint16Heap, (idx>>1)); }
+    { idx = idx|0; idx = idx<<1; return f4check(f4load(Uint16Heap, (idx>>1))); }
 
     function storeI8(value, idx) 
     { value= f4check(value); idx = idx|0; idx = idx<<0; 
     f4store(Int8Heap, (idx>>0), value);}
     function loadI8(idx) 
-    { idx = idx|0; idx = idx<<0; return f4load(Int8Heap, (idx>>0)); }
+    { idx = idx|0; idx = idx<<0; return f4check(f4load(Int8Heap, (idx>>0))); }
 
     function storeUI8(value, idx) 
     { value= f4check(value); idx = idx|0; idx = idx<<0; 
     f4store(Uint8Heap, (idx>>0), value);}
     function loadUI8(idx) 
-    { idx = idx|0; idx = idx<<0; return f4load(Uint8Heap, (idx>>0)); }
+    { idx = idx|0; idx = idx<<0; return f4check(f4load(Uint8Heap, (idx>>0))); }
     
     
     function loadStoreIndex1()
     {
         f4store(Float32Heap, 0, f4(-1.0,-2.0,3.1,-4.0)); 
-        return f4load(Float32Heap, 0);
+        return f4check(f4load(Float32Heap, 0));
     }
     
     
@@ -213,7 +213,7 @@ function asmModule(stdlib, imports, buffer) {
             loopIndex = (loopIndex + 1)|0;
         }
         //Expects the heap to be: 0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3...15,15,15,15,0,0,0,0...
-        return f4load(Float32Heap, 0);
+        return f4check(f4load(Float32Heap, 0));
         //Alternate validation
         // for(idx = 0; idx << 2 < end << 2; idx = (idx + 4 << 2)|0)
         // {
@@ -252,7 +252,7 @@ function asmModule(stdlib, imports, buffer) {
                 v0 = f4add(v0, f4(1.0,1.0,1.0,1.0));
             }
         }
-        return f4load(Float32Heap, 8);
+        return f4check(f4load(Float32Heap, 8));
     } 
     function store_3(functionPicker)
     {
@@ -288,7 +288,7 @@ function asmModule(stdlib, imports, buffer) {
             loopIndex = (loopIndex - 1) | 0;
         }
         while ( (loopIndex | 0) > 0);
-        return f4load(Float32Heap, 8);
+        return f4check(f4load(Float32Heap, 8));
     } 
     function store_1_Int8(length) 
     {
@@ -308,7 +308,7 @@ function asmModule(stdlib, imports, buffer) {
             loopIndex = (loopIndex + 1)|0;
         }
         //Expects the heap to be: 0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3...15,15,15,15,0,0,0,0...
-        return f4load(Float32Heap, 2);
+        return f4check(f4load(Float32Heap, 2));
     }
     function store_1_Uint8(length) 
     {
@@ -328,7 +328,7 @@ function asmModule(stdlib, imports, buffer) {
             loopIndex = (loopIndex + 1)|0;
         }
         //Expects the heap to be: 0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3...15,15,15,15,0,0,0,0...
-        return f4load(Float32Heap, 2);
+        return f4check(f4load(Float32Heap, 2));
     }
     function store_1_Int16(length) 
     {
@@ -348,7 +348,7 @@ function asmModule(stdlib, imports, buffer) {
             loopIndex = (loopIndex + 1)|0;
         }
         //Expects the heap to be: 0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3...15,15,15,15,0,0,0,0...
-        return f4load(Float32Heap, 2);
+        return f4check(f4load(Float32Heap, 2));
     }	
     function store_1_Uint16(length) 
     {
@@ -368,7 +368,7 @@ function asmModule(stdlib, imports, buffer) {
             loopIndex = (loopIndex + 1)|0;
         }
         //Expects the heap to be: 0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3...15,15,15,15,0,0,0,0...
-        return f4load(Float32Heap, 2);
+        return f4check(f4load(Float32Heap, 2));
     }	
     function store_1_Int32(length) 
     {
@@ -388,7 +388,7 @@ function asmModule(stdlib, imports, buffer) {
             loopIndex = (loopIndex + 1)|0;
         }
         //Expects the heap to be: 0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3...15,15,15,15,0,0,0,0...
-        return f4load(Float32Heap, 2);
+        return f4check(f4load(Float32Heap, 2));
     }	
     function store_1_Uint32(length) 
     {
@@ -408,7 +408,7 @@ function asmModule(stdlib, imports, buffer) {
             loopIndex = (loopIndex + 1)|0;
         }
         //Expects the heap to be: 0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3...15,15,15,15,0,0,0,0...
-        return f4load(Float32Heap, 2);
+        return f4check(f4load(Float32Heap, 2));
     }
     
     ////////////////////////////Load////////////////////////////
@@ -447,7 +447,7 @@ function asmModule(stdlib, imports, buffer) {
             }
             loopIndex = (loopIndex + 1) | 0;
         }
-        return v;
+        return f4check(v);
     }
      
     function load_2(functionPicker)
@@ -484,7 +484,7 @@ function asmModule(stdlib, imports, buffer) {
                 }
             }
         }
-        return v;
+        return f4check(v);
     }
 
     function load_3(functionPicker)
@@ -522,7 +522,7 @@ function asmModule(stdlib, imports, buffer) {
             loopIndex = (loopIndex - 1) | 0;
         }
         while ( (loopIndex | 0) > 0);
-        return v;
+        return f4check(v);
     } 
     function load_1_Int8(length)
     {
@@ -539,7 +539,7 @@ function asmModule(stdlib, imports, buffer) {
             }
             loopIndex = (loopIndex + 1) | 0;
         }
-        return v;
+        return f4check(v);
     }
     function load_1_Uint8(length)
     {
@@ -556,7 +556,7 @@ function asmModule(stdlib, imports, buffer) {
             }
             loopIndex = (loopIndex + 1) | 0;
         }
-        return v;
+        return f4check(v);
     }
     function load_1_Int16(length)
     {
@@ -573,7 +573,7 @@ function asmModule(stdlib, imports, buffer) {
             }
             loopIndex = (loopIndex + 1) | 0;
         }
-        return v;
+        return f4check(v);
     }
     function load_1_Uint16(length)
     {
@@ -590,7 +590,7 @@ function asmModule(stdlib, imports, buffer) {
             }
             loopIndex = (loopIndex + 1) | 0;
         }
-        return v;
+        return f4check(v);
     }
     function load_1_Int32(length)
     {
@@ -607,7 +607,7 @@ function asmModule(stdlib, imports, buffer) {
             }
             loopIndex = (loopIndex + 1) | 0;
         }
-        return v;
+        return f4check(v);
     }
     function load_1_Uint32(length)
     {
@@ -624,7 +624,7 @@ function asmModule(stdlib, imports, buffer) {
             }
             loopIndex = (loopIndex + 1) | 0;
         }
-        return v;
+        return f4check(v);
     }	
     
     return {

--- a/test/SIMD.float32x4.asmjs/testResizeLoadStore.js
+++ b/test/SIMD.float32x4.asmjs/testResizeLoadStore.js
@@ -23,7 +23,7 @@ var m = function(stdlib,imports,buffer){
         return true 
     }
     function store(value, loc) { value=f4check(value); loc = loc|0; loc = loc<<2; f4store(f32, loc>>2, value);  }
-    function load(loc) {loc = loc|0; loc = loc<<2; return f4load(f32, loc>>2);  }
+    function load(loc) {loc = loc|0; loc = loc<<2; return f4check(f4load(f32, loc>>2));  }
     
     return { load:load
             ,store:store

--- a/test/SIMD.int16x8.asmjs/rlexe.xml
+++ b/test/SIMD.int16x8.asmjs/rlexe.xml
@@ -24,7 +24,14 @@
       <compile-flags>-on:asmjs -testtrace:asmjs -simdjs -AsmJsStopOnError -on:AsmJsInterpreter -off:fulljit -off:backend</compile-flags>
     </default>
   </test>
-  
+  <test>
+    <default>
+      <files>testCheck.js</files>
+      <baseline>testCheck.baseline</baseline>
+      <tags>exclude_dynapogo,exclude_ship</tags>
+      <compile-flags>-off:deferparse -testtrace:asmjs -simdjs -bgjit- -maic:1</compile-flags>
+    </default>
+  </test>
   <test>
     <default>
       <files>testCalls.js</files>

--- a/test/SIMD.int16x8.asmjs/testCheck.baseline
+++ b/test/SIMD.int16x8.asmjs/testCheck.baseline
@@ -1,0 +1,7 @@
+Successfully compiled asm.js code
+
+testCheck.js(25, 9)
+	Asm.js Compilation Error function : module::foo
+	Expression for returning simd values must be coerced using check()
+
+Asm.js compilation failed.

--- a/test/SIMD.int16x8.asmjs/testCheck.js
+++ b/test/SIMD.int16x8.asmjs/testCheck.js
@@ -1,0 +1,29 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function module0(stdlib) {
+    "use asm"
+    var b = stdlib.SIMD.Int16x8;
+    var band = b.and;
+    var bcheck = b.check;
+    function foo() {
+        var abc = b(1,1,1,1,1,1,1,1);
+        return bcheck(band(abc, abc));
+    }
+    return { foo:foo }
+}
+var c = module0(this);
+
+function module(stdlib) {
+    "use asm"
+    var b = stdlib.SIMD.Int16x8;
+    var band = b.and;
+    function foo() {
+        var abc = b(1,1,1,1,1,1,1,1);
+        return band(abc, abc);
+    }
+    return { foo:foo }
+}
+var c = module(this);

--- a/test/SIMD.int32x4.asmjs/rlexe.xml
+++ b/test/SIMD.int32x4.asmjs/rlexe.xml
@@ -26,6 +26,14 @@
   </test>
   <test>
     <default>
+      <files>testCheck.js</files>
+      <baseline>testCheck.baseline</baseline>
+      <tags>exclude_dynapogo,exclude_ship</tags>
+      <compile-flags>-off:deferparse -testtrace:asmjs -simdjs -bgjit- -maic:1</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>testAddSub.js</files>
       <tags>exclude_dynapogo,exclude_ship</tags>
       <compile-flags>-bgjit- -simdjs -asmjs- -simd128typespec  -on:simplejit -mic:1 -lic:1</compile-flags>

--- a/test/SIMD.int32x4.asmjs/testCheck.baseline
+++ b/test/SIMD.int32x4.asmjs/testCheck.baseline
@@ -1,0 +1,7 @@
+Successfully compiled asm.js code
+
+testCheck.js(25, 9)
+	Asm.js Compilation Error function : module::foo
+	Expression for returning simd values must be coerced using check()
+
+Asm.js compilation failed.

--- a/test/SIMD.int32x4.asmjs/testCheck.js
+++ b/test/SIMD.int32x4.asmjs/testCheck.js
@@ -1,0 +1,29 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function module0(stdlib) {
+    "use asm"
+    var b = stdlib.SIMD.Int32x4;
+    var band = b.and;
+    var bcheck = b.check;
+    function foo() {
+        var abc = b(1,1,1,1);
+        return bcheck(band(abc, abc));
+    }
+    return { foo:foo }
+}
+var c = module0(this);
+
+function module(stdlib) {
+    "use asm"
+    var b = stdlib.SIMD.Int32x4;
+    var band = b.and;
+    function foo() {
+        var abc = b(1,1,1,1);
+        return band(abc, abc);
+    }
+    return { foo:foo }
+}
+var c = module(this);

--- a/test/SIMD.int32x4.asmjs/testLoadStore-2.js
+++ b/test/SIMD.int32x4.asmjs/testLoadStore-2.js
@@ -119,49 +119,49 @@ function asmModule(stdlib, imports, buffer) {
     {
         idx = idx|0;
         idx = idx<<2;
-        return i4load(Float32Heap, (idx>>2));
+        return i4check(i4load(Float32Heap, (idx>>2)));
     }
     
     function storeUI32(value, idx) 
     { value= i4check(value); idx = idx|0; idx = idx<<2; 
     i4store(Uint32Heap, (idx>>2), value);}
     function loadUI32(idx) 
-    { idx = idx|0; idx = idx<<2; return i4load(Uint32Heap, (idx>>2)); }
+    { idx = idx|0; idx = idx<<2; return i4check(i4load(Uint32Heap, (idx>>2))); }
     
     function storeI32(value, idx) 
     { value= i4check(value); idx = idx|0; idx = idx<<2; 
     i4store(Int32Heap, (idx>>2), value);}
     function loadI32(idx) 
-    { idx = idx|0; idx = idx<<2; return i4load(Int32Heap, (idx>>2)); }
+    { idx = idx|0; idx = idx<<2; return i4check(i4load(Int32Heap, (idx>>2))); }
     
     function storeI16(value, idx) 
     { value= i4check(value); idx = idx|0; idx = idx<<1; 
     i4store(Int16Heap, (idx>>1), value);}
     function loadI16(idx) 
-    { idx = idx|0; idx = idx<<1; return i4load(Int16Heap, (idx>>1)); }
+    { idx = idx|0; idx = idx<<1; return i4check(i4load(Int16Heap, (idx>>1))); }
 
     function storeUI16(value, idx) 
     { value= i4check(value); idx = idx|0; idx = idx<<1; 
     i4store(Uint16Heap, (idx>>1), value);}
     function loadUI16(idx) 
-    { idx = idx|0; idx = idx<<1; return i4load(Uint16Heap, (idx>>1)); }
+    { idx = idx|0; idx = idx<<1; return i4check(i4load(Uint16Heap, (idx>>1))); }
 
     function storeI8(value, idx) 
     { value= i4check(value); idx = idx|0; idx = idx<<0; 
     i4store(Int8Heap, (idx>>0), value);}
     function loadI8(idx) 
-    { idx = idx|0; idx = idx<<0; return i4load(Int8Heap, (idx>>0)); }
+    { idx = idx|0; idx = idx<<0; return i4check(i4load(Int8Heap, (idx>>0))); }
 
     function storeUI8(value, idx) 
     { value= i4check(value); idx = idx|0; idx = idx<<0; 
     i4store(Uint8Heap, (idx>>0), value);}
     function loadUI8(idx) 
-    { idx = idx|0; idx = idx<<0; return i4load(Uint8Heap, (idx>>0)); }
+    { idx = idx|0; idx = idx<<0; return i4check(i4load(Uint8Heap, (idx>>0))); }
     
     function loadStoreIndex1()
     {
         i4store(Float32Heap, 0, i4(-1,-2,3,-4)); 
-        return i4load(Float32Heap, 0);
+        return i4check(i4load(Float32Heap, 0));
     }
     
     function store_1(functionPicker) //Function picker to pick store1/store2/store3/store
@@ -197,7 +197,7 @@ function asmModule(stdlib, imports, buffer) {
             loopIndex = (loopIndex + 1)|0;
         }
 
-        return i4load(Float32Heap, 0);
+        return i4check(i4load(Float32Heap, 0));
 
     }        
      function store_2(functionPicker)
@@ -231,7 +231,7 @@ function asmModule(stdlib, imports, buffer) {
                 v0 = i4add(v0, i4(1, 1, 1, 1));
             }
         }
-        return i4load(Float32Heap, 8);
+        return i4check(i4load(Float32Heap, 8));
     } 
     function store_3(functionPicker)
     {
@@ -267,7 +267,7 @@ function asmModule(stdlib, imports, buffer) {
             loopIndex = (loopIndex - 1) | 0;
         }
         while ( (loopIndex | 0) > 0);
-        return i4load(Float32Heap, 8);
+        return i4check(i4load(Float32Heap, 8));
     } 
     function store_1_Int8(length) 
     {
@@ -287,7 +287,7 @@ function asmModule(stdlib, imports, buffer) {
             loopIndex = (loopIndex + 1)|0;
         }
         //Expects the heap to be: 0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3...15,15,15,15,0,0,0,0...
-        return i4load(Float32Heap, 2);
+        return i4check(i4load(Float32Heap, 2));
     }
     function store_1_Uint8(length) 
     {
@@ -307,7 +307,7 @@ function asmModule(stdlib, imports, buffer) {
             loopIndex = (loopIndex + 1)|0;
         }
         //Expects the heap to be: 0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3...15,15,15,15,0,0,0,0...
-        return i4load(Float32Heap, 2);
+        return i4check(i4load(Float32Heap, 2));
     }
     function store_1_Int16(length) 
     {
@@ -327,7 +327,7 @@ function asmModule(stdlib, imports, buffer) {
             loopIndex = (loopIndex + 1)|0;
         }
         //Expects the heap to be: 0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3...15,15,15,15,0,0,0,0...
-        return i4load(Float32Heap, 2);
+        return i4check(i4load(Float32Heap, 2));
     }    
     function store_1_Uint16(length) 
     {
@@ -347,7 +347,7 @@ function asmModule(stdlib, imports, buffer) {
             loopIndex = (loopIndex + 1)|0;
         }
         //Expects the heap to be: 0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3...15,15,15,15,0,0,0,0...
-        return i4load(Float32Heap, 2);
+        return i4check(i4load(Float32Heap, 2));
     }    
     function store_1_Int32(length) 
     {
@@ -367,7 +367,7 @@ function asmModule(stdlib, imports, buffer) {
             loopIndex = (loopIndex + 1)|0;
         }
         //Expects the heap to be: 0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3...15,15,15,15,0,0,0,0...
-        return i4load(Float32Heap, 2);
+        return i4check(i4load(Float32Heap, 2));
     }    
     function store_1_Uint32(length) 
     {
@@ -387,7 +387,7 @@ function asmModule(stdlib, imports, buffer) {
             loopIndex = (loopIndex + 1)|0;
         }
         //Expects the heap to be: 0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3...15,15,15,15,0,0,0,0...
-        return i4load(Float32Heap, 2);
+        return i4check(i4load(Float32Heap, 2));
     }
     
     ////////////////////////////Load////////////////////////////
@@ -426,7 +426,7 @@ function asmModule(stdlib, imports, buffer) {
             }
             loopIndex = (loopIndex + 1) | 0;
         }
-        return v;
+        return i4check(v);
     }
      
     function load_2(functionPicker)
@@ -463,7 +463,7 @@ function asmModule(stdlib, imports, buffer) {
                 }
             }
         }
-        return v;
+        return i4check(v);
     }
 
     function load_3(functionPicker)
@@ -501,7 +501,7 @@ function asmModule(stdlib, imports, buffer) {
             loopIndex = (loopIndex - 1) | 0;
         }
         while ( (loopIndex | 0) > 0);
-        return v;
+        return i4check(v);
     } 
     function load_1_Int8(length)
     {
@@ -518,7 +518,7 @@ function asmModule(stdlib, imports, buffer) {
             }
             loopIndex = (loopIndex + 1) | 0;
         }
-        return v;
+        return i4check(v);
     }
     function load_1_Uint8(length)
     {
@@ -535,7 +535,7 @@ function asmModule(stdlib, imports, buffer) {
             }
             loopIndex = (loopIndex + 1) | 0;
         }
-        return v;
+        return i4check(v);
     }
     function load_1_Int16(length)
     {
@@ -552,7 +552,7 @@ function asmModule(stdlib, imports, buffer) {
             }
             loopIndex = (loopIndex + 1) | 0;
         }
-        return v;
+        return i4check(v);
     }
     function load_1_Uint16(length)
     {
@@ -569,7 +569,7 @@ function asmModule(stdlib, imports, buffer) {
             }
             loopIndex = (loopIndex + 1) | 0;
         }
-        return v;
+        return i4check(v);
     }
     function load_1_Int32(length)
     {
@@ -586,7 +586,7 @@ function asmModule(stdlib, imports, buffer) {
             }
             loopIndex = (loopIndex + 1) | 0;
         }
-        return v;
+        return i4check(v);
     }
     function load_1_Uint32(length)
     {
@@ -603,7 +603,7 @@ function asmModule(stdlib, imports, buffer) {
             }
             loopIndex = (loopIndex + 1) | 0;
         }
-        return v;
+        return i4check(v);
     }    
     
     return {store1:store_1

--- a/test/SIMD.int32x4.asmjs/testResizeLoadStore-2.js
+++ b/test/SIMD.int32x4.asmjs/testResizeLoadStore-2.js
@@ -145,50 +145,50 @@ function asmModule(stdlib, imports, buffer) {
     {
         idx = idx|0;
         idx = idx<<2;
-        return i4load(Float32Heap, (idx>>2));
+        return i4check(i4load(Float32Heap, (idx>>2)));
     }
     
     function storeUI32(value, idx) 
     { value= i4check(value); idx = idx|0; idx = idx<<2; 
     i4store(Uint32Heap, (idx>>2), value);}
     function loadUI32(idx) 
-    { idx = idx|0; idx = idx<<2; return i4load(Uint32Heap, (idx>>2)); }
+    { idx = idx|0; idx = idx<<2; return i4check(i4load(Uint32Heap, (idx>>2))); }
     
     function storeI32(value, idx) 
     { value= i4check(value); idx = idx|0; idx = idx<<2; 
     i4store(Int32Heap, (idx>>2), value);}
     function loadI32(idx) 
-    { idx = idx|0; idx = idx<<2; return i4load(Int32Heap, (idx>>2)); }
+    { idx = idx|0; idx = idx<<2; return i4check(i4load(Int32Heap, (idx>>2))); }
     
     function storeI16(value, idx) 
     { value= i4check(value); idx = idx|0; idx = idx<<1; 
     i4store(Int16Heap, (idx>>1), value);}
     function loadI16(idx) 
-    { idx = idx|0; idx = idx<<1; return i4load(Int16Heap, (idx>>1)); }
+    { idx = idx|0; idx = idx<<1; return i4check(i4load(Int16Heap, (idx>>1))); }
 
     function storeUI16(value, idx) 
     { value= i4check(value); idx = idx|0; idx = idx<<1; 
     i4store(Uint16Heap, (idx>>1), value);}
     function loadUI16(idx) 
-    { idx = idx|0; idx = idx<<1; return i4load(Uint16Heap, (idx>>1)); }
+    { idx = idx|0; idx = idx<<1; return i4check(i4load(Uint16Heap, (idx>>1))); }
 
     function storeI8(value, idx) 
     { value= i4check(value); idx = idx|0; idx = idx<<0; 
     i4store(Int8Heap, (idx>>0), value);}
     function loadI8(idx) 
-    { idx = idx|0; idx = idx<<0; return i4load(Int8Heap, (idx>>0)); }
+    { idx = idx|0; idx = idx<<0; return i4check(i4load(Int8Heap, (idx>>0))); }
 
     function storeUI8(value, idx) 
     { value= i4check(value); idx = idx|0; idx = idx<<0; 
     i4store(Uint8Heap, (idx>>0), value);}
     function loadUI8(idx) 
-    { idx = idx|0; idx = idx<<0; return i4load(Uint8Heap, (idx>>0)); }
+    { idx = idx|0; idx = idx<<0; return i4check(i4load(Uint8Heap, (idx>>0))); }
     
     
     function loadStoreIndex1()
     {
         i4store(Float32Heap, 0, i4(-1,-2,3,-4)); 
-        return i4load(Float32Heap, 0);
+        return i4check(i4load(Float32Heap, 0));
     }
     
     
@@ -225,7 +225,7 @@ function asmModule(stdlib, imports, buffer) {
             loopIndex = (loopIndex + 1)|0;
         }
         //Expects the heap to be: 0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3...15,15,15,15,0,0,0,0...
-        return i4load(Float32Heap, 0);
+        return i4check(i4load(Float32Heap, 0));
         //Alternate validation
         // for(idx = 0; idx << 2 < end << 2; idx = (idx + 4 << 2)|0)
         // {
@@ -264,7 +264,7 @@ function asmModule(stdlib, imports, buffer) {
                 v0 = i4add(v0, i4(1,1,1,1));
             }
         }
-        return i4load(Float32Heap, 8);
+        return i4check(i4load(Float32Heap, 8));
     } 
     function store_3(functionPicker)
     {
@@ -300,7 +300,7 @@ function asmModule(stdlib, imports, buffer) {
             loopIndex = (loopIndex - 1) | 0;
         }
         while ( (loopIndex | 0) > 0);
-        return i4load(Float32Heap, 8);
+        return i4check(i4load(Float32Heap, 8));
     } 
     function store_1_Int8(length) 
     {
@@ -320,7 +320,7 @@ function asmModule(stdlib, imports, buffer) {
             loopIndex = (loopIndex + 1)|0;
         }
         //Expects the heap to be: 0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3...15,15,15,15,0,0,0,0...
-        return i4load(Float32Heap, 2);
+        return i4check(i4load(Float32Heap, 2));
     }
     function store_1_Uint8(length) 
     {
@@ -340,7 +340,7 @@ function asmModule(stdlib, imports, buffer) {
             loopIndex = (loopIndex + 1)|0;
         }
         //Expects the heap to be: 0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3...15,15,15,15,0,0,0,0...
-        return i4load(Float32Heap, 2);
+        return i4check(i4load(Float32Heap, 2));
     }
     function store_1_Int16(length) 
     {
@@ -360,7 +360,7 @@ function asmModule(stdlib, imports, buffer) {
             loopIndex = (loopIndex + 1)|0;
         }
         //Expects the heap to be: 0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3...15,15,15,15,0,0,0,0...
-        return i4load(Float32Heap, 2);
+        return i4check(i4load(Float32Heap, 2));
     }    
     function store_1_Uint16(length) 
     {
@@ -380,7 +380,7 @@ function asmModule(stdlib, imports, buffer) {
             loopIndex = (loopIndex + 1)|0;
         }
         //Expects the heap to be: 0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3...15,15,15,15,0,0,0,0...
-        return i4load(Float32Heap, 2);
+        return i4check(i4load(Float32Heap, 2));
     }    
     function store_1_Int32(length) 
     {
@@ -400,7 +400,7 @@ function asmModule(stdlib, imports, buffer) {
             loopIndex = (loopIndex + 1)|0;
         }
         //Expects the heap to be: 0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3...15,15,15,15,0,0,0,0...
-        return i4load(Float32Heap, 2);
+        return i4check(i4load(Float32Heap, 2));
     }    
     function store_1_Uint32(length) 
     {
@@ -420,7 +420,7 @@ function asmModule(stdlib, imports, buffer) {
             loopIndex = (loopIndex + 1)|0;
         }
         //Expects the heap to be: 0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3...15,15,15,15,0,0,0,0...
-        return i4load(Float32Heap, 2);
+        return i4check(i4load(Float32Heap, 2))  ;
     }
     
     ////////////////////////////Load////////////////////////////
@@ -459,7 +459,7 @@ function asmModule(stdlib, imports, buffer) {
             }
             loopIndex = (loopIndex + 1) | 0;
         }
-        return v;
+        return i4check(v);
     }
      
     function load_2(functionPicker)
@@ -496,7 +496,7 @@ function asmModule(stdlib, imports, buffer) {
                 }
             }
         }
-        return v;
+        return i4check(v);
     }
 
     function load_3(functionPicker)
@@ -534,7 +534,7 @@ function asmModule(stdlib, imports, buffer) {
             loopIndex = (loopIndex - 1) | 0;
         }
         while ( (loopIndex | 0) > 0);
-        return v;
+        return i4check(v);
     } 
     function load_1_Int8(length)
     {
@@ -551,7 +551,7 @@ function asmModule(stdlib, imports, buffer) {
             }
             loopIndex = (loopIndex + 1) | 0;
         }
-        return v;
+        return i4check(v);
     }
     function load_1_Uint8(length)
     {
@@ -568,7 +568,7 @@ function asmModule(stdlib, imports, buffer) {
             }
             loopIndex = (loopIndex + 1) | 0;
         }
-        return v;
+        return i4check(v);
     }
     function load_1_Int16(length)
     {
@@ -585,7 +585,7 @@ function asmModule(stdlib, imports, buffer) {
             }
             loopIndex = (loopIndex + 1) | 0;
         }
-        return v;
+        return i4check(v);
     }
     function load_1_Uint16(length)
     {
@@ -602,7 +602,7 @@ function asmModule(stdlib, imports, buffer) {
             }
             loopIndex = (loopIndex + 1) | 0;
         }
-        return v;
+        return i4check(v);
     }
     function load_1_Int32(length)
     {
@@ -619,7 +619,7 @@ function asmModule(stdlib, imports, buffer) {
             }
             loopIndex = (loopIndex + 1) | 0;
         }
-        return v;
+        return i4check(v);
     }
     function load_1_Uint32(length)
     {
@@ -636,7 +636,7 @@ function asmModule(stdlib, imports, buffer) {
             }
             loopIndex = (loopIndex + 1) | 0;
         }
-        return v;
+        return i4check(v);
     }    
     
     return {

--- a/test/SIMD.int32x4.asmjs/testResizeLoadStore.js
+++ b/test/SIMD.int32x4.asmjs/testResizeLoadStore.js
@@ -26,7 +26,7 @@ var m = function(stdlib,imports,buffer){
         return true 
     }
     function store(value, loc) { value=i4check(value); loc = loc|0; loc = loc<<2; i4store(i32, loc>>2, value);  }
-    function load(loc) {loc = loc|0; loc = loc<<2; return i4load(i32, loc>>2);  }
+    function load(loc) {loc = loc|0; loc = loc<<2; return i4check(i4load(i32, loc>>2));  }
     
     return { load:load
             ,store:store

--- a/test/SIMD.int8x16.asmjs/rlexe.xml
+++ b/test/SIMD.int8x16.asmjs/rlexe.xml
@@ -24,7 +24,14 @@
       <compile-flags>-on:asmjs -testtrace:asmjs -simdjs -AsmJsStopOnError -on:AsmJsInterpreter -off:fulljit -off:backend</compile-flags>
     </default>
   </test>
-  
+  <test>
+    <default>
+      <files>testCheck.js</files>
+      <baseline>testCheck.baseline</baseline>
+      <tags>exclude_dynapogo,exclude_ship</tags>
+      <compile-flags>-off:deferparse -testtrace:asmjs -simdjs -bgjit- -maic:1</compile-flags>
+    </default>
+  </test>
   <test>
     <default>
       <files>testCalls.js</files>

--- a/test/SIMD.int8x16.asmjs/testCheck.baseline
+++ b/test/SIMD.int8x16.asmjs/testCheck.baseline
@@ -1,0 +1,7 @@
+Successfully compiled asm.js code
+
+testCheck.js(25, 9)
+	Asm.js Compilation Error function : module::foo
+	Expression for returning simd values must be coerced using check()
+
+Asm.js compilation failed.

--- a/test/SIMD.int8x16.asmjs/testCheck.js
+++ b/test/SIMD.int8x16.asmjs/testCheck.js
@@ -1,0 +1,29 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function module0(stdlib) {
+    "use asm"
+    var b = stdlib.SIMD.Int8x16;
+    var band = b.and;
+    var bcheck = b.check;
+    function foo() {
+        var abc = b(1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1);
+        return bcheck(band(abc, abc));
+    }
+    return { foo:foo }
+}
+var c = module0(this);
+
+function module(stdlib) {
+    "use asm"
+    var b = stdlib.SIMD.Int8x16;
+    var band = b.and;
+    function foo() {
+        var abc = b(1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1);
+        return band(abc, abc);
+    }
+    return { foo:foo }
+}
+var c = module(this);

--- a/test/SIMD.uint16x8.asmjs/rlexe.xml
+++ b/test/SIMD.uint16x8.asmjs/rlexe.xml
@@ -24,7 +24,14 @@
       <compile-flags>-on:asmjs -testtrace:asmjs -simdjs -AsmJsStopOnError -on:AsmJsInterpreter -off:fulljit -off:backend</compile-flags>
     </default>
   </test>
-  
+  <test>
+    <default>
+      <files>testCheck.js</files>
+      <baseline>testCheck.baseline</baseline>
+      <tags>exclude_dynapogo,exclude_ship</tags>
+      <compile-flags>-off:deferparse -testtrace:asmjs -simdjs -bgjit- -maic:1</compile-flags>
+    </default>
+  </test>
   <test>
     <default>
       <files>testCalls.js</files>

--- a/test/SIMD.uint16x8.asmjs/testCheck.baseline
+++ b/test/SIMD.uint16x8.asmjs/testCheck.baseline
@@ -1,0 +1,7 @@
+Successfully compiled asm.js code
+
+testCheck.js(25, 9)
+	Asm.js Compilation Error function : module::foo
+	Expression for returning simd values must be coerced using check()
+
+Asm.js compilation failed.

--- a/test/SIMD.uint16x8.asmjs/testCheck.js
+++ b/test/SIMD.uint16x8.asmjs/testCheck.js
@@ -1,0 +1,29 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function module0(stdlib) {
+    "use asm"
+    var b = stdlib.SIMD.Uint16x8;
+    var band = b.and;
+    var bcheck = b.check;
+    function foo() {
+        var abc = b(1,1,1,1,1,1,1,1);
+        return bcheck(band(abc, abc));
+    }
+    return { foo:foo }
+}
+var c = module0(this);
+
+function module(stdlib) {
+    "use asm"
+    var b = stdlib.SIMD.Uint16x8;
+    var band = b.and;
+    function foo() {
+        var abc = b(1,1,1,1,1,1,1,1);
+        return band(abc, abc);
+    }
+    return { foo:foo }
+}
+var c = module(this);

--- a/test/SIMD.uint32x4.asmjs/rlexe.xml
+++ b/test/SIMD.uint32x4.asmjs/rlexe.xml
@@ -24,7 +24,14 @@
       <compile-flags>-on:asmjs -testtrace:asmjs -simdjs -AsmJsStopOnError -on:AsmJsInterpreter -off:fulljit -off:backend</compile-flags>
     </default>
   </test>
-  
+  <test>
+    <default>
+      <files>testCheck.js</files>
+      <baseline>testCheck.baseline</baseline>
+      <tags>exclude_dynapogo,exclude_ship</tags>
+      <compile-flags>-off:deferparse -testtrace:asmjs -simdjs -bgjit- -maic:1</compile-flags>
+    </default>
+  </test>
   <test>
     <default>
       <files>testCalls.js</files>

--- a/test/SIMD.uint32x4.asmjs/testCheck.baseline
+++ b/test/SIMD.uint32x4.asmjs/testCheck.baseline
@@ -1,0 +1,7 @@
+Successfully compiled asm.js code
+
+testCheck.js(25, 9)
+	Asm.js Compilation Error function : module::foo
+	Expression for returning simd values must be coerced using check()
+
+Asm.js compilation failed.

--- a/test/SIMD.uint32x4.asmjs/testCheck.js
+++ b/test/SIMD.uint32x4.asmjs/testCheck.js
@@ -1,0 +1,29 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function module0(stdlib) {
+    "use asm"
+    var b = stdlib.SIMD.Uint32x4;
+    var band = b.and;
+    var bcheck = b.check;
+    function foo() {
+        var abc = b(1,1,1,1);
+        return bcheck(band(abc, abc));
+    }
+    return { foo:foo }
+}
+var c = module0(this);
+
+function module(stdlib) {
+    "use asm"
+    var b = stdlib.SIMD.Uint32x4;
+    var band = b.and;
+    function foo() {
+        var abc = b(1,1,1,1);
+        return band(abc, abc);
+    }
+    return { foo:foo }
+}
+var c = module(this);

--- a/test/SIMD.uint8x16.asmjs/rlexe.xml
+++ b/test/SIMD.uint8x16.asmjs/rlexe.xml
@@ -24,7 +24,14 @@
       <compile-flags>-on:asmjs -testtrace:asmjs -simdjs -AsmJsStopOnError -on:AsmJsInterpreter -off:fulljit -off:backend</compile-flags>
     </default>
   </test>
-  
+  <test>
+    <default>
+      <files>testCheck.js</files>
+      <baseline>testCheck.baseline</baseline>
+      <tags>exclude_dynapogo,exclude_ship</tags>
+      <compile-flags>-off:deferparse -testtrace:asmjs -simdjs -bgjit- -maic:1</compile-flags>
+    </default>
+  </test>
   <test>
     <default>
       <files>testCalls.js</files>

--- a/test/SIMD.uint8x16.asmjs/testCheck.baseline
+++ b/test/SIMD.uint8x16.asmjs/testCheck.baseline
@@ -1,0 +1,7 @@
+Successfully compiled asm.js code
+
+testCheck.js(25, 9)
+	Asm.js Compilation Error function : module::foo
+	Expression for returning simd values must be coerced using check()
+
+Asm.js compilation failed.

--- a/test/SIMD.uint8x16.asmjs/testCheck.js
+++ b/test/SIMD.uint8x16.asmjs/testCheck.js
@@ -1,0 +1,29 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function module0(stdlib) {
+    "use asm"
+    var b = stdlib.SIMD.Uint8x16;
+    var band = b.and;
+    var bcheck = b.check;
+    function foo() {
+        var abc = b(1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1);
+        return bcheck(band(abc, abc));
+    }
+    return { foo:foo }
+}
+var c = module0(this);
+
+function module(stdlib) {
+    "use asm"
+    var b = stdlib.SIMD.Uint8x16;
+    var band = b.and;
+    function foo() {
+        var abc = b(1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1);
+        return band(abc, abc);
+    }
+    return { foo:foo }
+}
+var c = module(this);

--- a/test/SIMD.workloads.asmjs/testScale.js
+++ b/test/SIMD.workloads.asmjs/testScale.js
@@ -118,7 +118,7 @@ function asmModule(stdlib, imports, buffer) {
          f4store(Uint8Heap, (idx + 5)|0, f4(9.0,8.0,10.1, -22.121));
          //return f4load(Uint8Heap, (idx + 5)|0);
          f4store(Uint8Heap, (idx + 0)|0, f4load(Uint8Heap, (idx + 5)|0));
-         return f4load(Uint8Heap, (idx + 0)|0);
+         return f4check(f4load(Uint8Heap, (idx + 0)|0));
     }
 
     function scale(fromIdx, toIdx)


### PR DESCRIPTION
Simd values needs to be coreced using the check() builtin before returning
from asmjs functions.

Fixes #827 