### PR TITLE
Adding back the flag for enabling opHelper checks only on jshost and ch hosts

### DIFF
--- a/bin/ch/ChakraRtInterface.h
+++ b/bin/ch/ChakraRtInterface.h
@@ -136,6 +136,9 @@ public:
     static HRESULT SetCheckMemoryLeakFlag(bool flag) { return CHECKED_CALL(SetCheckMemoryLeakFlag, flag); }
     static HRESULT SetEnableCheckMemoryLeakOutput(bool flag) { return CHECKED_CALL(SetEnableCheckMemoryLeakOutput, flag); }
 #endif
+#ifdef DEBUG
+    static HRESULT SetCheckOpHelpersFlag(bool flag) { return CHECKED_CALL(SetCheckOpHelpersFlag, flag); }
+#endif
 
     static HRESULT GetCrashOnExceptionFlag(bool * flag)
     {

--- a/bin/ch/ch.cpp
+++ b/bin/ch/ch.cpp
@@ -378,6 +378,10 @@ HRESULT ExecuteTest(LPCWSTR fileName)
     JsContextRef context = JS_INVALID_REFERENCE;
     IfJsErrorFailLog(ChakraRTInterface::JsCreateContext(runtime, &context));
     IfJsErrorFailLog(ChakraRTInterface::JsSetCurrentContext(context));
+    
+#ifdef DEBUG
+    ChakraRTInterface::SetCheckOpHelpersFlag(true);
+#endif
 
     if (!WScriptJsrt::Initialize())
     {

--- a/lib/Backend/DbCheckPostLower.cpp
+++ b/lib/Backend/DbCheckPostLower.cpp
@@ -9,7 +9,7 @@
 void
 DbCheckPostLower::Check()
 {
-    bool doOpHelperCheck = !this->func->isPostLayout;
+    bool doOpHelperCheck = Js::Configuration::Global.flags.CheckOpHelpers && !this->func->isPostLayout;
     bool isInHelperBlock = false;
 
     FOREACH_INSTR_IN_FUNC_EDITING(instr, instrNext, this->func)

--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -783,6 +783,7 @@ FLAGNR(Boolean, CheckEmitBufferPermissions, "Check JIT code buffers at commit an
 FLAGR (Boolean, CheckMemoryLeak       , "Check for heap memory leak", false)
 FLAGR (String,  DumpOnLeak            , "Create a dump on failed memory leak check", nullptr)
 #endif
+FLAGNR(Boolean, CheckOpHelpers        , "Verify opHelper labels in the JIT are set properly", false)
 FLAGNR(Boolean, CloneInlinedPolymorphicCaches, "Clones polymorphic inline caches in inlined functions", DEFAULT_CONFIG_CloneInlinedPolymorphicCaches)
 FLAGNR(Boolean, ConcurrentRuntime     , "Enable Concurrent GC and background JIT when creating runtime", DEFAULT_CONFIG_ConcurrentRuntime)
 FLAGNR(Boolean, Console               , "Create console window in GUI app", false)


### PR DESCRIPTION
OpHelper Checks will be disabled on WebCrawler runs. These asserts do not seem make enough sense when they come from the crawler runs - as reverse engineering the scenario seems pretty tough.
These asserts in DbCheckPostLowerer do not imply that there is a functional bug - it will indicate more of a code layout issue.
With Louis' advice, these checks are enabled only on jshost and ch hosts.