### PR TITLE
Simd.js fixes for Tvs Bugs/Warnings

### DIFF
--- a/lib/Runtime/Library/JavascriptSimdBool16x8.cpp
+++ b/lib/Runtime/Library/JavascriptSimdBool16x8.cpp
@@ -6,6 +6,8 @@
 
 namespace Js
 {
+    const char16 JavascriptSIMDBool16x8::TypeName[] = _u("SIMD.Bool16x8");
+
     JavascriptSIMDBool16x8::JavascriptSIMDBool16x8(StaticType *type) : JavascriptSIMDType(type)
     {
         Assert(type->GetTypeId() == TypeIds_SIMDBool16x8);
@@ -44,11 +46,9 @@ namespace Js
         return JavascriptSIMDBool16x8::New(&value, requestContext);
     }
 
-    const char16* JavascriptSIMDBool16x8::GetFullBuiltinName(char16** aBuffer, const char16* name)
+    const char16* JavascriptSIMDBool16x8::GetTypeName()
     {
-        Assert(aBuffer && *aBuffer);
-        swprintf_s(*aBuffer, SIMD_STRING_BUFFER_MAX, _u("SIMD.Bool16x8.%s"), name);
-        return *aBuffer;
+        return JavascriptSIMDBool16x8::TypeName;
     }
 
     Var JavascriptSIMDBool16x8::Copy(ScriptContext* requestContext)

--- a/lib/Runtime/Library/JavascriptSimdBool16x8.h
+++ b/lib/Runtime/Library/JavascriptSimdBool16x8.h
@@ -10,7 +10,7 @@ namespace Js
     {
     private:
         DEFINE_VTABLE_CTOR(JavascriptSIMDBool16x8, JavascriptSIMDType);
-
+        static const char16 TypeName[];
     public:
         class EntryInfo
         {
@@ -29,7 +29,6 @@ namespace Js
         static JavascriptSIMDBool16x8* New(SIMDValue *val, ScriptContext* requestContext);
         static bool Is(Var instance);
         static JavascriptSIMDBool16x8* FromVar(Var aValue);
-        static const char16* GetFullBuiltinName(char16** aBuffer, const char16* name);
         static size_t GetOffsetOfValue() { return offsetof(JavascriptSIMDBool16x8, value); }
         static Var CallToLocaleString(RecyclableObject&, ScriptContext&, SIMDValue, const Var, uint, CallInfo) 
         { 
@@ -46,6 +45,7 @@ namespace Js
         }
         virtual RecyclableObject * CloneToScriptContext(ScriptContext* requestContext) override;
 
+        static const char16* GetTypeName();
         __inline SIMDValue GetValue() { return value; }
         Var  Copy(ScriptContext* requestContext);
     };

--- a/lib/Runtime/Library/JavascriptSimdBool32x4.cpp
+++ b/lib/Runtime/Library/JavascriptSimdBool32x4.cpp
@@ -6,6 +6,7 @@
 
 namespace Js
 {
+    const char16 JavascriptSIMDBool32x4::TypeName[] = _u("SIMD.Bool32x4");
 
     JavascriptSIMDBool32x4::JavascriptSIMDBool32x4(StaticType *type) : JavascriptSIMDType(type)
     {
@@ -40,11 +41,9 @@ namespace Js
         return reinterpret_cast<JavascriptSIMDBool32x4 *>(aValue);
     }
 
-    const char16* JavascriptSIMDBool32x4::GetFullBuiltinName(char16** aBuffer, const char16* name)
+    const char16* JavascriptSIMDBool32x4::GetTypeName()
     {
-        Assert(aBuffer && *aBuffer);
-        swprintf_s(*aBuffer, SIMD_STRING_BUFFER_MAX, _u("SIMD.Bool32x4.%s"), name);
-        return *aBuffer;
+        return JavascriptSIMDBool32x4::TypeName;
     }
 
     Var JavascriptSIMDBool32x4::Copy(ScriptContext* requestContext)

--- a/lib/Runtime/Library/JavascriptSimdBool32x4.h
+++ b/lib/Runtime/Library/JavascriptSimdBool32x4.h
@@ -10,6 +10,7 @@ namespace Js
     {
     private:
         DEFINE_VTABLE_CTOR(JavascriptSIMDBool32x4, JavascriptSIMDType);
+        static const char16 TypeName[];
     public:
         class EntryInfo
         {
@@ -22,7 +23,6 @@ namespace Js
 
         static bool Is(Var instance);
         static JavascriptSIMDBool32x4* FromVar(Var aValue);
-        static const char16* GetFullBuiltinName(char16** aBuffer, const char16* name);
         static JavascriptSIMDBool32x4* AllocUninitialized(ScriptContext* requestContext);
         static JavascriptSIMDBool32x4* New(SIMDValue *val, ScriptContext* requestContext);
         static size_t GetOffsetOfValue() { return offsetof(JavascriptSIMDBool32x4, value); }
@@ -41,6 +41,8 @@ namespace Js
         JavascriptSIMDBool32x4(SIMDValue *val, StaticType *type);
 
         Var Copy(ScriptContext* requestContext);
+
+        static const char16* GetTypeName();
         __inline SIMDValue GetValue() { return value; }
         virtual RecyclableObject* CloneToScriptContext(ScriptContext* requestContext) override;
 

--- a/lib/Runtime/Library/JavascriptSimdBool8x16.cpp
+++ b/lib/Runtime/Library/JavascriptSimdBool8x16.cpp
@@ -9,6 +9,8 @@
 
 namespace Js
 {
+    const char16 JavascriptSIMDBool8x16::TypeName[] = _u("SIMD.Bool8x16");
+
     JavascriptSIMDBool8x16::JavascriptSIMDBool8x16(StaticType *type) : JavascriptSIMDType(type)
     {
         Assert(type->GetTypeId() == TypeIds_SIMDBool8x16);
@@ -47,11 +49,9 @@ namespace Js
         return JavascriptSIMDBool8x16::New(&value, requestContext);
     }
 
-    const char16* JavascriptSIMDBool8x16::GetFullBuiltinName(char16** aBuffer, const char16* name)
+    const char16* JavascriptSIMDBool8x16::GetTypeName()
     {
-        Assert(aBuffer && *aBuffer);
-        swprintf_s(*aBuffer, SIMD_STRING_BUFFER_MAX, _u("SIMD.Bool8x16.%s"), name);
-        return *aBuffer;
+        return JavascriptSIMDBool8x16::TypeName;
     }
 
     Var JavascriptSIMDBool8x16::Copy(ScriptContext* requestContext)

--- a/lib/Runtime/Library/JavascriptSimdBool8x16.h
+++ b/lib/Runtime/Library/JavascriptSimdBool8x16.h
@@ -10,7 +10,7 @@ namespace Js
     {
     private:
         DEFINE_VTABLE_CTOR(JavascriptSIMDBool8x16, JavascriptSIMDType);
-
+        static const char16 TypeName[];
     public:
         class EntryInfo
         {
@@ -27,7 +27,6 @@ namespace Js
         static JavascriptSIMDBool8x16* New(SIMDValue *val, ScriptContext* requestContext);
         static bool Is(Var instance);
         static JavascriptSIMDBool8x16* FromVar(Var aValue);
-        static const char16* GetFullBuiltinName(char16** aBuffer, const char16* name);
         static size_t GetOffsetOfValue() { return offsetof(JavascriptSIMDBool8x16, value); }
         static Var CallToLocaleString(RecyclableObject&, ScriptContext&, SIMDValue, const Var, uint, CallInfo)
         {
@@ -37,6 +36,7 @@ namespace Js
 
         virtual RecyclableObject * CloneToScriptContext(ScriptContext* requestContext) override;
 
+        static const char16* GetTypeName();
         __inline SIMDValue GetValue() { return value; }
 
         static void ToStringBuffer(SIMDValue& value, __out_ecount(countBuffer) char16* stringBuffer, size_t countBuffer, ScriptContext* scriptContext = nullptr)

--- a/lib/Runtime/Library/JavascriptSimdFloat32x4.cpp
+++ b/lib/Runtime/Library/JavascriptSimdFloat32x4.cpp
@@ -6,6 +6,8 @@
 
 namespace Js
 {
+    const char16 JavascriptSIMDFloat32x4::TypeName[] = _u("SIMD.Float32x4");
+
     JavascriptSIMDFloat32x4::JavascriptSIMDFloat32x4(StaticType *type) : JavascriptSIMDType(type)
     {
         Assert(type->GetTypeId() == TypeIds_SIMDFloat32x4);
@@ -57,11 +59,9 @@ namespace Js
         swprintf_s(stringBuffer, countBuffer, _u("SIMD.Float32x4(%s, %s, %s, %s)"), f0, f1, f2, f3);
     }
 
-    const char16* JavascriptSIMDFloat32x4::GetFullBuiltinName(char16** aBuffer, const char16* name)
+    const char16* JavascriptSIMDFloat32x4::GetTypeName()
     {
-        Assert(aBuffer && *aBuffer);
-        swprintf_s(*aBuffer, SIMD_STRING_BUFFER_MAX, _u("SIMD.Float32x4.%s"), name);
-        return *aBuffer;
+        return JavascriptSIMDFloat32x4::TypeName;
     }
 
     RecyclableObject * JavascriptSIMDFloat32x4::CloneToScriptContext(ScriptContext* requestContext)

--- a/lib/Runtime/Library/JavascriptSimdFloat32x4.h
+++ b/lib/Runtime/Library/JavascriptSimdFloat32x4.h
@@ -13,7 +13,7 @@ namespace Js
     {
     private:
         DEFINE_VTABLE_CTOR(JavascriptSIMDFloat32x4, JavascriptSIMDType);
-
+        static const char16 TypeName[];
     public:
         class EntryInfo
         {
@@ -31,7 +31,6 @@ namespace Js
         static JavascriptSIMDFloat32x4* New(SIMDValue *val, ScriptContext* requestContext);
         static bool Is(Var instance);
         static JavascriptSIMDFloat32x4* FromVar(Var aValue);
-        static const char16* GetFullBuiltinName(char16** aBuffer, const char16* name);
         static JavascriptSIMDFloat32x4* FromFloat64x2(JavascriptSIMDFloat64x2 *instance, ScriptContext* requestContext);
         static JavascriptSIMDFloat32x4* FromInt32x4(JavascriptSIMDInt32x4   *instance, ScriptContext* requestContext);
         static Var CallToLocaleString(RecyclableObject& obj, ScriptContext& requestContext, SIMDValue simdValue,
@@ -39,6 +38,7 @@ namespace Js
         static void ToStringBuffer(SIMDValue& value, __out_ecount(countBuffer) char16* stringBuffer, size_t countBuffer,
             ScriptContext* scriptContext);
 
+        static const char16* GetTypeName();
         __inline SIMDValue GetValue() { return value; }
         virtual RecyclableObject * CloneToScriptContext(ScriptContext* requestContext) override;
 

--- a/lib/Runtime/Library/JavascriptSimdInt16x8.cpp
+++ b/lib/Runtime/Library/JavascriptSimdInt16x8.cpp
@@ -9,6 +9,13 @@
 
 namespace Js
 {
+    const char16 JavascriptSIMDInt16x8::TypeName[] = _u("SIMD.Int16x8");
+
+    JavascriptSIMDInt16x8::JavascriptSIMDInt16x8(StaticType *type) : JavascriptSIMDType(type)
+    {
+        Assert(type->GetTypeId() == TypeIds_SIMDInt16x8);
+    }
+
     JavascriptSIMDInt16x8::JavascriptSIMDInt16x8(SIMDValue *val, StaticType *type) : JavascriptSIMDType(val, type)
     {
         Assert(type->GetTypeId() == TypeIds_SIMDInt16x8);
@@ -45,11 +52,9 @@ namespace Js
         return JavascriptSIMDInt16x8::New(&value, requestContext);
     }
 
-    const char16* JavascriptSIMDInt16x8::GetFullBuiltinName(char16** aBuffer, const char16* name)
+    const char16* JavascriptSIMDInt16x8::GetTypeName()
     {
-        Assert(aBuffer && *aBuffer);
-        swprintf_s(*aBuffer, SIMD_STRING_BUFFER_MAX, _u("SIMD.Int16x8.%s"), name);
-        return *aBuffer;
+        return JavascriptSIMDInt16x8::TypeName;
     }
 
     Var JavascriptSIMDInt16x8::Copy(ScriptContext* requestContext)

--- a/lib/Runtime/Library/JavascriptSimdInt16x8.h
+++ b/lib/Runtime/Library/JavascriptSimdInt16x8.h
@@ -15,7 +15,7 @@ namespace Js
     {
     private:
         DEFINE_VTABLE_CTOR(JavascriptSIMDInt16x8, JavascriptSIMDType);
-
+        static const char16 TypeName[];
     public:
         class EntryInfo
         {
@@ -27,15 +27,16 @@ namespace Js
             static FunctionInfo Bool;
         };
 
+        JavascriptSIMDInt16x8(StaticType *type);
         JavascriptSIMDInt16x8(SIMDValue *val, StaticType *type);
         static JavascriptSIMDInt16x8* New(SIMDValue *val, ScriptContext* requestContext);
         static bool Is(Var instance);
         static JavascriptSIMDInt16x8* FromVar(Var aValue);
-        static const char16* GetFullBuiltinName(char16** aBuffer, const char16* name);
         static Var CallToLocaleString(RecyclableObject& obj, ScriptContext& requestContext, SIMDValue simdValue, const Var* args, uint numArgs, CallInfo callInfo);
 
         virtual RecyclableObject * CloneToScriptContext(ScriptContext* requestContext) override;
 
+        static const char16* GetTypeName();
         __inline SIMDValue GetValue() { return value; }
 
         static void ToStringBuffer(SIMDValue& value, __out_ecount(countBuffer) char16* stringBuffer, size_t countBuffer, ScriptContext* scriptContext = nullptr)

--- a/lib/Runtime/Library/JavascriptSimdInt32x4.cpp
+++ b/lib/Runtime/Library/JavascriptSimdInt32x4.cpp
@@ -6,6 +6,8 @@
 
 namespace Js
 {
+    const char16 JavascriptSIMDInt32x4::TypeName[] = _u("SIMD.Int32x4");
+
     JavascriptSIMDInt32x4::JavascriptSIMDInt32x4(StaticType *type) : JavascriptSIMDType(type)
     {
         Assert(type->GetTypeId() == TypeIds_SIMDInt32x4);
@@ -55,11 +57,9 @@ namespace Js
         return false;
     }
 
-    const char16* JavascriptSIMDInt32x4::GetFullBuiltinName(char16** aBuffer, const char16* name)
+    const char16* JavascriptSIMDInt32x4::GetTypeName()
     {
-        Assert(aBuffer && *aBuffer);
-        swprintf_s(*aBuffer, SIMD_STRING_BUFFER_MAX, _u("SIMD.Int32x4.%s"), name);
-        return *aBuffer;
+        return JavascriptSIMDInt32x4::TypeName;
     }
 
     Var JavascriptSIMDInt32x4::Copy(ScriptContext* requestContext)

--- a/lib/Runtime/Library/JavascriptSimdInt32x4.h
+++ b/lib/Runtime/Library/JavascriptSimdInt32x4.h
@@ -12,7 +12,7 @@ namespace Js
     {
     private:
         DEFINE_VTABLE_CTOR(JavascriptSIMDInt32x4, JavascriptSIMDType);
-
+        static const char16 TypeName[];
     public:
         class EntryInfo
         {
@@ -31,7 +31,6 @@ namespace Js
         static JavascriptSIMDInt32x4* New(SIMDValue *val, ScriptContext* requestContext);
         static bool Is(Var instance);
         static JavascriptSIMDInt32x4* FromVar(Var aValue);
-        static const char16* GetFullBuiltinName(char16** aBuffer, const char16* name);
 
         static JavascriptSIMDInt32x4* FromBool(SIMDValue *val, ScriptContext* requestContext);
         static JavascriptSIMDInt32x4* FromFloat64x2(JavascriptSIMDFloat64x2 *instance, ScriptContext* requestContext);
@@ -42,6 +41,7 @@ namespace Js
         {
             swprintf_s(stringBuffer, countBuffer, _u("SIMD.Int32x4(%d, %d, %d, %d)"), value.i32[SIMD_X], value.i32[SIMD_Y], value.i32[SIMD_Z], value.i32[SIMD_W]);
         }
+        static const char16* GetTypeName();
         __inline SIMDValue GetValue() { return value; }
 
         virtual RecyclableObject * CloneToScriptContext(ScriptContext* requestContext) override;

--- a/lib/Runtime/Library/JavascriptSimdInt8x16.cpp
+++ b/lib/Runtime/Library/JavascriptSimdInt8x16.cpp
@@ -6,7 +6,14 @@
 
 namespace Js
 {
-    JavascriptSIMDInt8x16::JavascriptSIMDInt8x16(SIMDValue *val, StaticType *type) : JavascriptSIMDType(type), value(*val)
+    const char16 JavascriptSIMDInt8x16::TypeName[] = _u("SIMD.Int8x16");
+
+    JavascriptSIMDInt8x16::JavascriptSIMDInt8x16(StaticType *type) : JavascriptSIMDType(type)
+    {
+        Assert(type->GetTypeId() == TypeIds_SIMDInt8x16);
+    }
+
+    JavascriptSIMDInt8x16::JavascriptSIMDInt8x16(SIMDValue *val, StaticType *type) : JavascriptSIMDType(val, type)
     {
         Assert(type->GetTypeId() == TypeIds_SIMDInt8x16);
     }
@@ -42,11 +49,9 @@ namespace Js
         return JavascriptSIMDInt8x16::New(&value, requestContext);
     }
 
-    const char16* JavascriptSIMDInt8x16::GetFullBuiltinName(char16** aBuffer, const char16* name)
+    const char16* JavascriptSIMDInt8x16::GetTypeName()
     {
-        Assert(aBuffer && *aBuffer);
-        swprintf_s(*aBuffer, SIMD_STRING_BUFFER_MAX, _u("SIMD.Int8x16.%s"), name);
-        return *aBuffer;
+        return JavascriptSIMDInt8x16::TypeName;
     }
 
     Var JavascriptSIMDInt8x16::Copy(ScriptContext* requestContext)

--- a/lib/Runtime/Library/JavascriptSimdInt8x16.h
+++ b/lib/Runtime/Library/JavascriptSimdInt8x16.h
@@ -13,10 +13,8 @@ namespace Js
     class JavascriptSIMDInt8x16 sealed : public JavascriptSIMDType
     {
     private:
-        SIMDValue value;
-
         DEFINE_VTABLE_CTOR(JavascriptSIMDInt8x16, JavascriptSIMDType);
-
+        static const char16 TypeName[];
     public:
         class EntryInfo
         {
@@ -26,12 +24,11 @@ namespace Js
             static FunctionInfo ValueOf;
             static FunctionInfo SymbolToPrimitive;
         };
-
+        JavascriptSIMDInt8x16(StaticType *type);
         JavascriptSIMDInt8x16(SIMDValue *val, StaticType *type);
         static JavascriptSIMDInt8x16* New(SIMDValue *val, ScriptContext* requestContext);
         static bool Is(Var instance);
         static JavascriptSIMDInt8x16* FromVar(Var aValue);
-        static const char16* GetFullBuiltinName(char16** aBuffer, const char16* name);
         static Var CallToLocaleString(RecyclableObject& obj, ScriptContext& requestContext, SIMDValue simdValue, const Var* args, uint numArgs, CallInfo callInfo);
 
         static void ToStringBuffer(SIMDValue& value, __out_ecount(countBuffer) char16* stringBuffer, size_t countBuffer, ScriptContext* scriptContext = nullptr)
@@ -43,6 +40,7 @@ namespace Js
 
         virtual RecyclableObject * CloneToScriptContext(ScriptContext* requestContext) override;
 
+        static const char16* GetTypeName();
         __inline SIMDValue GetValue() { return value; }
         Var  Copy(ScriptContext* requestContext);
     };

--- a/lib/Runtime/Library/JavascriptSimdType.cpp
+++ b/lib/Runtime/Library/JavascriptSimdType.cpp
@@ -26,9 +26,9 @@ namespace Js
 
         if (args.Info.Count == 0 || !SIMDType::Is(args[0]))
         {
-            char16 buffer[512] = _u("");
-            char16* bufferPtr = buffer;
-            JavascriptError::ThrowTypeError(scriptContext, JSERR_This_NeedSimd, SIMDType::GetFullBuiltinName(&bufferPtr, _u("toString()")));
+            char16 buffer[SIMD_STRING_BUFFER_MAX] = _u("");
+            swprintf_s(buffer, SIMD_STRING_BUFFER_MAX, _u("%s.toString()"), SIMDType::GetTypeName());
+            JavascriptError::ThrowTypeError(scriptContext, JSERR_This_NeedSimd, buffer);
         }
 
         JavascriptSIMDType* instance = SIMDType::FromVar(args[0]);
@@ -46,21 +46,22 @@ namespace Js
         AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
         Assert(!(callInfo.Flags & CallFlags_New));
 
-        char16 buffer[512] = _u("");
-        char16* bufferPtr = buffer;
-
         if (args.Info.Count == 0 || !SIMDType::Is(args[0]))
         {
-            JavascriptError::ThrowTypeError(scriptContext, JSERR_This_NeedSimd, SIMDType::GetFullBuiltinName(&bufferPtr, _u("toLocaleString"))); //todo
+            char16 buffer[SIMD_STRING_BUFFER_MAX] = _u("");
+            swprintf_s(buffer, SIMD_STRING_BUFFER_MAX, _u("%s.toLocaleString()"), SIMDType::GetTypeName());
+            JavascriptError::ThrowTypeError(scriptContext, JSERR_This_NeedSimd, buffer);
         }
 
         //SPEC: The meanings of the optional parameters to this method are defined in the ECMA - 402 specification; 
         //implementations that do not include ECMA - 402 support must not use those parameter positions for anything else.
         //args[1] and args[2] are optional reserved parameters.
         RecyclableObject *obj = nullptr;
-        if (!JavascriptConversion::ToObject(args[0], scriptContext, &obj))  //Is this needed?
+        if (!JavascriptConversion::ToObject(args[0], scriptContext, &obj))
         {
-            JavascriptError::ThrowTypeError(scriptContext, JSERR_This_NeedSimd, SIMDType::GetFullBuiltinName(&bufferPtr, _u("toLocaleString")));
+            char16 buffer[SIMD_STRING_BUFFER_MAX] = _u("");
+            swprintf_s(buffer, SIMD_STRING_BUFFER_MAX, _u("%s.toLocaleString()"), SIMDType::GetTypeName());
+            JavascriptError::ThrowTypeError(scriptContext, JSERR_This_NeedSimd, buffer);
         }
 
         if (JavascriptSIMDBool32x4::Is(args[0]) || JavascriptSIMDBool16x8::Is(args[0]) || JavascriptSIMDBool8x16::Is(args[0]))
@@ -108,9 +109,9 @@ namespace Js
                 }
             }
         }
-        char16 buffer[512] = _u("");
-        char16* bufferPtr = buffer;
-        JavascriptError::ThrowTypeError(scriptContext, JSERR_FunctionArgument_Invalid, SIMDType::GetFullBuiltinName(&bufferPtr, _u("[Symbol.toPrimitive]"))); //todo
+        char16 buffer[SIMD_STRING_BUFFER_MAX] = _u("");
+        swprintf_s(buffer, SIMD_STRING_BUFFER_MAX, _u("%s.[Symbol.toPrimitive]"), SIMDType::GetTypeName());
+        JavascriptError::ThrowTypeError(scriptContext, JSERR_FunctionArgument_Invalid, buffer);
     }
 
     template<typename SIMDType>
@@ -132,9 +133,9 @@ namespace Js
         {
             return SIMDType::FromVar((JavascriptSIMDObject::FromVar(args[0]))->GetValue());
         }
-        char16 buffer[512] = _u("");
-        char16* bufferPtr = buffer;
-        JavascriptError::ThrowTypeError(scriptContext, JSERR_SIMDConversion, SIMDType::GetFullBuiltinName(&bufferPtr, _u("valueOf")));
+        char16 buffer[SIMD_STRING_BUFFER_MAX] = _u("");
+        swprintf_s(buffer, SIMD_STRING_BUFFER_MAX, _u("%s.valueOf()"), SIMDType::GetTypeName());
+        JavascriptError::ThrowTypeError(scriptContext, JSERR_SIMDConversion, buffer);
     }
     // End Entry Points
 

--- a/lib/Runtime/Library/JavascriptSimdUint16x8.cpp
+++ b/lib/Runtime/Library/JavascriptSimdUint16x8.cpp
@@ -7,6 +7,13 @@
 
 namespace Js
 {
+    const char16 JavascriptSIMDUint16x8::TypeName[] = _u("SIMD.Uint16x8");
+
+    JavascriptSIMDUint16x8::JavascriptSIMDUint16x8(StaticType *type) : JavascriptSIMDType(type)
+    {
+        Assert(type->GetTypeId() == TypeIds_SIMDUint16x8);
+    }
+
     JavascriptSIMDUint16x8::JavascriptSIMDUint16x8(SIMDValue *val, StaticType *type) : JavascriptSIMDType(val, type)
     {
         Assert(type->GetTypeId() == TypeIds_SIMDUint16x8);
@@ -43,11 +50,9 @@ namespace Js
         return JavascriptSIMDUint16x8::New(&value, requestContext);
     }
 
-    const char16* JavascriptSIMDUint16x8::GetFullBuiltinName(char16** aBuffer, const char16* name)
+    const char16* JavascriptSIMDUint16x8::GetTypeName()
     {
-        Assert(aBuffer && *aBuffer);
-        swprintf_s(*aBuffer, SIMD_STRING_BUFFER_MAX, _u("SIMD.Uint16x8.%s"), name);
-        return *aBuffer;
+        return JavascriptSIMDUint16x8::TypeName;
     }
 
     Var JavascriptSIMDUint16x8::Copy(ScriptContext* requestContext)

--- a/lib/Runtime/Library/JavascriptSimdUint16x8.h
+++ b/lib/Runtime/Library/JavascriptSimdUint16x8.h
@@ -11,6 +11,7 @@ namespace Js
     {
     private:
         DEFINE_VTABLE_CTOR(JavascriptSIMDUint16x8, JavascriptSIMDType);
+        static const char16 TypeName[];
     public:
         class EntryInfo
         {
@@ -21,11 +22,11 @@ namespace Js
             static FunctionInfo SymbolToPrimitive;
         };
 
+        JavascriptSIMDUint16x8(StaticType *type);
         JavascriptSIMDUint16x8(SIMDValue *val, StaticType *type);
         static JavascriptSIMDUint16x8* New(SIMDValue *val, ScriptContext* requestContext);
         static bool Is(Var instance);
         static JavascriptSIMDUint16x8* FromVar(Var aValue);
-        static const char16* GetFullBuiltinName(char16** aBuffer, const char16* name);
         static Var CallToLocaleString(RecyclableObject& obj, ScriptContext& requestContext, SIMDValue simdValue, const Var* args, uint numArgs, CallInfo callInfo);
 
         static void ToStringBuffer(SIMDValue& value, __out_ecount(countBuffer) char16* stringBuffer, size_t countBuffer, ScriptContext* scriptContext = nullptr)
@@ -34,6 +35,7 @@ namespace Js
                 value.u16[0], value.u16[1], value.u16[2], value.u16[3], value.u16[4], value.u16[5], value.u16[6], value.u16[7]);
         }
 
+        static const char16* GetTypeName();
         __inline SIMDValue GetValue() { return value; }
         virtual RecyclableObject * CloneToScriptContext(ScriptContext* requestContext) override;
 

--- a/lib/Runtime/Library/JavascriptSimdUint32x4.cpp
+++ b/lib/Runtime/Library/JavascriptSimdUint32x4.cpp
@@ -6,6 +6,8 @@
 
 namespace Js
 {
+    const char16 JavascriptSIMDUint32x4::TypeName[] = _u("SIMD.Uint32x4");
+
     JavascriptSIMDUint32x4::JavascriptSIMDUint32x4(StaticType *type) : JavascriptSIMDType(type)
     {
         Assert(type->GetTypeId() == TypeIds_SIMDUint32x4);
@@ -52,11 +54,9 @@ namespace Js
         return JavascriptSIMDUint32x4::New(&value, requestContext);
     }
 
-    const char16* JavascriptSIMDUint32x4::GetFullBuiltinName(char16** aBuffer, const char16* name)
+    const char16* JavascriptSIMDUint32x4::GetTypeName()
     {
-        Assert(aBuffer && *aBuffer);
-        swprintf_s(*aBuffer, SIMD_STRING_BUFFER_MAX, _u("SIMD.Uint32x4.%s"), name);
-        return *aBuffer;
+        return JavascriptSIMDUint32x4::TypeName;
     }
 
     Var JavascriptSIMDUint32x4::Copy(ScriptContext* requestContext)

--- a/lib/Runtime/Library/JavascriptSimdUint32x4.h
+++ b/lib/Runtime/Library/JavascriptSimdUint32x4.h
@@ -12,7 +12,7 @@ namespace Js
     {
     private:
         DEFINE_VTABLE_CTOR(JavascriptSIMDUint32x4, JavascriptSIMDType);
-
+        static const char16 TypeName[];
     public:
         class EntryInfo
         {
@@ -29,7 +29,6 @@ namespace Js
 
         static JavascriptSIMDUint32x4* AllocUninitialized(ScriptContext* requestContext);
         static JavascriptSIMDUint32x4* New(SIMDValue *val, ScriptContext* requestContext);
-        static const char16* GetFullBuiltinName(char16** aBuffer, const char16* name);
         static bool Is(Var instance);
         static JavascriptSIMDUint32x4* FromVar(Var aValue);
         static JavascriptSIMDUint32x4* FromFloat32x4(JavascriptSIMDFloat32x4   *instance, ScriptContext* requestContext);
@@ -40,7 +39,7 @@ namespace Js
         {
             swprintf_s(stringBuffer, countBuffer, _u("SIMD.Uint32x4(%u, %u, %u, %u)"), value.u32[SIMD_X], value.u32[SIMD_Y], value.u32[SIMD_Z], value.u32[SIMD_W]);
         }
-
+        static const char16* GetTypeName();
         __inline SIMDValue GetValue() { return value; }
 
         virtual RecyclableObject * CloneToScriptContext(ScriptContext* requestContext) override;

--- a/lib/Runtime/Library/JavascriptSimdUint8x16.cpp
+++ b/lib/Runtime/Library/JavascriptSimdUint8x16.cpp
@@ -7,6 +7,13 @@
 
 namespace Js
 {
+    const char16 JavascriptSIMDUint8x16::TypeName[] = _u("SIMD.Uint8x16");
+
+    JavascriptSIMDUint8x16::JavascriptSIMDUint8x16(StaticType *type) : JavascriptSIMDType(type)
+    {
+        Assert(type->GetTypeId() == TypeIds_SIMDUint8x16);
+    }
+
     JavascriptSIMDUint8x16::JavascriptSIMDUint8x16(SIMDValue *val, StaticType *type) : JavascriptSIMDType(val, type)
     {
         Assert(type->GetTypeId() == TypeIds_SIMDUint8x16);
@@ -43,11 +50,9 @@ namespace Js
         return JavascriptSIMDUint8x16::New(&value, requestContext);
     }
 
-    const char16* JavascriptSIMDUint8x16::GetFullBuiltinName(char16** aBuffer, const char16* name)
+    const char16* JavascriptSIMDUint8x16::GetTypeName()
     {
-        Assert(aBuffer && *aBuffer);
-        swprintf_s(*aBuffer, SIMD_STRING_BUFFER_MAX, _u("SIMD.Uint8x16.%s"), name);
-        return *aBuffer;
+        return JavascriptSIMDUint8x16::TypeName;
     }
 
     Var JavascriptSIMDUint8x16::Copy(ScriptContext* requestContext)

--- a/lib/Runtime/Library/JavascriptSimdUint8x16.h
+++ b/lib/Runtime/Library/JavascriptSimdUint8x16.h
@@ -11,6 +11,7 @@ namespace Js
     {
     private:
         DEFINE_VTABLE_CTOR(JavascriptSIMDUint8x16, JavascriptSIMDType);
+        static const char16 TypeName[];
     public:
         class EntryInfo
         {
@@ -21,11 +22,11 @@ namespace Js
             static FunctionInfo SymbolToPrimitive;
         };
 
+        JavascriptSIMDUint8x16(StaticType *type);
         JavascriptSIMDUint8x16(SIMDValue *val, StaticType *type);
         static JavascriptSIMDUint8x16* New(SIMDValue *val, ScriptContext* requestContext);
         static bool Is(Var instance);
         static JavascriptSIMDUint8x16* FromVar(Var aValue);
-        static const char16* GetFullBuiltinName(char16** aBuffer, const char16* name);
         static Var CallToLocaleString(RecyclableObject& obj, ScriptContext& requestContext, SIMDValue simdValue, const Var* args, uint numArgs, CallInfo callInfo);
 
         static void ToStringBuffer(SIMDValue& value, __out_ecount(countBuffer) char16* stringBuffer, size_t countBuffer, ScriptContext* scriptContext = nullptr)
@@ -38,6 +39,7 @@ namespace Js
         virtual RecyclableObject * CloneToScriptContext(ScriptContext* requestContext) override;
 
         __inline SIMDValue GetValue() { return value; }
+        static const char16* GetTypeName();
         Var  Copy(ScriptContext* requestContext);
     };
 }


### PR DESCRIPTION
Refactored code to avoid passing pointers to string buffers as function
arguments while generating simd.js type error messages.

Fixes the following Tvs warnings:
7242752
7243156
7243327
7243735
7243803
7244175
7244414
7244451
7245068
7245507

Note: Please note that we are unable to run the 'oacr' tool because of a
permission issue with the sd enlistments. So we couldn't validate that
this fix has addressed all the 'oacr' warnings in simd.js.
