### PR TITLE
Fix optimized element access that incorrectly reports that the instance has no such property

### DIFF
--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -289,6 +289,7 @@ PHASE(All)
             PHASE(ObjectHeaderInliningForConstructors)
             PHASE(ObjectHeaderInliningForObjectLiterals)
             PHASE(ObjectHeaderInliningForEmptyObjects)
+        PHASE(OptUnknownElementName)
 #if DBG_DUMP
         PHASE(TypePropertyCache)
         PHASE(InlineSlots)

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -76,10 +76,8 @@ namespace Js
         }
     }
 
-    IndexType GetIndexType(Var indexVar, ScriptContext* scriptContext, uint32* index, PropertyRecord const ** propertyRecord, JavascriptString ** propertyNameString, bool createIfNotFound, bool preferJavascriptStringOverPropertyRecord)
+    IndexType GetIndexTypeFromPrimitive(Var indexVar, ScriptContext* scriptContext, uint32* index, PropertyRecord const ** propertyRecord, JavascriptString ** propertyNameString, bool createIfNotFound, bool preferJavascriptStringOverPropertyRecord)
     {
-        indexVar = JavascriptConversion::ToPrimitive(indexVar, JavascriptHint::HintString, scriptContext);
-
         // CONSIDER: Only OP_SetElementI and OP_GetElementI use and take advantage of the
         // IndexType_JavascriptString result. Consider modifying other callers of GetIndexType to take
         // advantage of non-interned property strings where appropriate.
@@ -142,7 +140,18 @@ namespace Js
         }
     }
 
-    IndexType GetIndexType(Var indexVar, ScriptContext* scriptContext, uint32* index, PropertyRecord const ** propertyRecord, bool createIfNotFound)
+    IndexType GetIndexTypeFromPrimitive(Var indexVar, ScriptContext* scriptContext, uint32* index, PropertyRecord const ** propertyRecord, bool createIfNotFound)
+    {
+        return GetIndexTypeFromPrimitive(indexVar, scriptContext, index, propertyRecord, nullptr, createIfNotFound, false);
+    }
+
+    IndexType GetIndexType(Var& indexVar, ScriptContext* scriptContext, uint32* index, PropertyRecord const ** propertyRecord, JavascriptString ** propertyNameString, bool createIfNotFound, bool preferJavascriptStringOverPropertyRecord)
+    {
+        indexVar = JavascriptConversion::ToPrimitive(indexVar, JavascriptHint::HintString, scriptContext);
+        return GetIndexTypeFromPrimitive(indexVar, scriptContext, index, propertyRecord, propertyNameString, createIfNotFound, preferJavascriptStringOverPropertyRecord);
+    }
+
+    IndexType GetIndexType(Var& indexVar, ScriptContext* scriptContext, uint32* index, PropertyRecord const ** propertyRecord, bool createIfNotFound)
     {
         return GetIndexType(indexVar, scriptContext, index, propertyRecord, nullptr, createIfNotFound, false);
     }
@@ -434,11 +443,10 @@ namespace Js
         try
         {
             Js::JavascriptExceptionOperators::AutoCatchHandlerExists autoCatchHandlerExists(scriptContext);
+            IndexType indexType = GetIndexType(index, scriptContext, &indexVal, &propertyRecord, false);
 
             // For JS Objects, don't create the propertyId if not already added
-            bool createIfNotFound = !IsJsNativeObject(object) ||
-                (DynamicType::Is(object->GetTypeId()) && static_cast<DynamicObject*>(object)->GetTypeHandler()->IsStringTypeHandler()) || JavascriptProxy::Is(object);
-            if (GetIndexType(index, scriptContext, &indexVal, &propertyRecord, createIfNotFound) == IndexType_Number)
+            if (indexType == IndexType_Number)
             {
                 // In edge mode, we don't need to worry about the special "unknown" behavior. If the item is not available from Get,
                 // just return undefined.
@@ -450,26 +458,35 @@ namespace Js
                     return scriptContext->GetLibrary()->GetUndefinedDisplayString();
                 }
             }
-            else if (propertyRecord == nullptr)
-            {
-                Assert(IsJsNativeObject(object));
-
-#if DBG
-                JavascriptString* indexStr = JavascriptConversion::ToString(index, scriptContext);
-                PropertyRecord const * debugPropertyRecord;
-                scriptContext->GetOrAddPropertyRecord(indexStr->GetString(), indexStr->GetLength(), &debugPropertyRecord);
-                AssertMsg(!JavascriptOperators::GetProperty(instance, object, debugPropertyRecord->GetPropertyId(), &member, scriptContext), "how did this property come? See OS Bug 2727708 if you see this come from the web");
-#endif
-
-                // If the instance doesn't have the property, typeof result is "undefined".
-                threadContext->CheckAndResetImplicitCallAccessorFlag();
-                threadContext->AddImplicitCallFlags(savedImplicitCallFlags);
-                return scriptContext->GetLibrary()->GetUndefinedDisplayString();
-            }
             else
             {
-                if (!JavascriptOperators::GetProperty(instance, object, propertyRecord->GetPropertyId(), &member, scriptContext))
+                Assert(indexType == IndexType_PropertyId);
+                if (propertyRecord == nullptr && !JavascriptOperators::CanShortcutOnUnknownPropertyName(object))
                 {
+                    indexType = GetIndexTypeFromPrimitive(index, scriptContext, &indexVal, &propertyRecord, true);
+                    Assert(indexType == IndexType_PropertyId);
+                    Assert(propertyRecord != nullptr);
+                }
+
+                if (propertyRecord != nullptr)
+                {
+                    if (!JavascriptOperators::GetProperty(instance, object, propertyRecord->GetPropertyId(), &member, scriptContext))
+                    {
+                        // If the instance doesn't have the property, typeof result is "undefined".
+                        threadContext->CheckAndResetImplicitCallAccessorFlag();
+                        threadContext->AddImplicitCallFlags(savedImplicitCallFlags);
+                        return scriptContext->GetLibrary()->GetUndefinedDisplayString();
+                    }
+                }
+                else
+                {
+#if DBG
+                    JavascriptString* indexStr = JavascriptConversion::ToString(index, scriptContext);
+                    PropertyRecord const * debugPropertyRecord;
+                    scriptContext->GetOrAddPropertyRecord(indexStr->GetString(), indexStr->GetLength(), &debugPropertyRecord);
+                    AssertMsg(!JavascriptOperators::GetProperty(instance, object, debugPropertyRecord->GetPropertyId(), &member, scriptContext), "how did this property come? See OS Bug 2727708 if you see this come from the web");
+#endif
+
                     // If the instance doesn't have the property, typeof result is "undefined".
                     threadContext->CheckAndResetImplicitCallAccessorFlag();
                     threadContext->AddImplicitCallFlags(savedImplicitCallFlags);
@@ -3118,29 +3135,37 @@ CommonNumber:
 
         uint32 indexVal;
         PropertyRecord const * propertyRecord;
-        bool createIfNotFound = (DynamicType::Is(object->GetTypeId()) &&
-            static_cast<DynamicObject*>(object)->GetTypeHandler()->IsStringTypeHandler()) ||
-            JavascriptProxy::Is(object);
-        if (GetIndexType(index, scriptContext, &indexVal, &propertyRecord, createIfNotFound) == IndexType_Number)
+        IndexType indexType = GetIndexType(index, scriptContext, &indexVal, &propertyRecord, false);
+
+        if (indexType == IndexType_Number)
         {
             return HasItem(object, indexVal);
         }
-        else if (propertyRecord == nullptr)
-        {
-            Assert(IsJsNativeObject(object));
-
-#if DBG
-            JavascriptString* indexStr = JavascriptConversion::ToString(index, scriptContext);
-            PropertyRecord const * debugPropertyRecord;
-            scriptContext->GetOrAddPropertyRecord(indexStr->GetString(), indexStr->GetLength(), &debugPropertyRecord);
-            AssertMsg(!JavascriptOperators::HasProperty(object, debugPropertyRecord->GetPropertyId()), "how did this property come? See OS Bug 2727708 if you see this come from the web");
-#endif
-
-            return FALSE;
-        }
         else
         {
-            return HasProperty(object, propertyRecord->GetPropertyId());
+            Assert(indexType == IndexType_PropertyId);
+            if (propertyRecord == nullptr && !JavascriptOperators::CanShortcutOnUnknownPropertyName(object))
+            {
+                indexType = GetIndexTypeFromPrimitive(index, scriptContext, &indexVal, &propertyRecord, true);
+                Assert(indexType == IndexType_PropertyId);
+                Assert(propertyRecord != nullptr);
+            }
+
+            if (propertyRecord != nullptr)
+            {
+                return HasProperty(object, propertyRecord->GetPropertyId());
+            }
+            else
+            {
+#if DBG
+                JavascriptString* indexStr = JavascriptConversion::ToString(index, scriptContext);
+                PropertyRecord const * debugPropertyRecord;
+                scriptContext->GetOrAddPropertyRecord(indexStr->GetString(), indexStr->GetLength(), &debugPropertyRecord);
+                AssertMsg(!JavascriptOperators::HasProperty(object, debugPropertyRecord->GetPropertyId()), "how did this property come? See OS Bug 2727708 if you see this come from the web");
+#endif
+
+                return FALSE;
+            }
         }
     }
 
@@ -3700,9 +3725,7 @@ CommonNumber:
         JavascriptString * propertyNameString;
         Var value;
 
-        bool createIfNotFound = !IsJsNativeObject(object);
-
-        IndexType indexType = GetIndexType(index, scriptContext, &indexVal, &propertyRecord, &propertyNameString, createIfNotFound, true);
+        IndexType indexType = GetIndexType(index, scriptContext, &indexVal, &propertyRecord, &propertyNameString, false, true);
 
         if (indexType == IndexType_Number)
         {
@@ -3720,15 +3743,30 @@ CommonNumber:
         }
         else
         {
-            // We called GetIndexType with preferJavascriptString as true, so we mush have a propertyRecord
             Assert(indexType == IndexType_PropertyId);
-
-            Assert(propertyRecord);
-
-            if (JavascriptOperators::GetPropertyWPCache(receiver, object, propertyRecord->GetPropertyId(), &value, scriptContext, nullptr))
+            if (propertyRecord == nullptr && !JavascriptOperators::CanShortcutOnUnknownPropertyName(object))
             {
-                return value;
+                indexType = GetIndexTypeFromPrimitive(index, scriptContext, &indexVal, &propertyRecord, &propertyNameString, true, true);
+                Assert(indexType == IndexType_PropertyId);
+                Assert(propertyRecord != nullptr);
             }
+
+            if (propertyRecord != nullptr)
+            {
+                if (JavascriptOperators::GetPropertyWPCache(receiver, object, propertyRecord->GetPropertyId(), &value, scriptContext, nullptr))
+                {
+                    return value;
+                }
+            }
+#if DBG
+            else
+            {
+                JavascriptString* indexStr = JavascriptConversion::ToString(index, scriptContext);
+                PropertyRecord const * debugPropertyRecord;
+                scriptContext->GetOrAddPropertyRecord(indexStr->GetString(), indexStr->GetLength(), &debugPropertyRecord);
+                AssertMsg(!JavascriptOperators::GetProperty(receiver, object, debugPropertyRecord->GetPropertyId(), &value, scriptContext), "how did this property come? See OS Bug 2727708 if you see this come from the web");
+            }
+#endif
         }
 
         return scriptContext->GetMissingItemResult();
@@ -3911,15 +3949,23 @@ CommonNumber:
         PropertyRecord const * propertyRecord;
         Var value = NULL;
         BOOL hasProperty = FALSE;
-        bool createIfNotFound = !IsJsNativeObject(object) ||
-            (DynamicType::Is(object->GetTypeId()) && static_cast<DynamicObject*>(object)->GetTypeHandler()->IsStringTypeHandler()) || JavascriptProxy::Is(object);
+        IndexType indexType = GetIndexType(index, scriptContext, &indexVal, &propertyRecord, false);
 
-        if (GetIndexType(index, scriptContext, &indexVal, &propertyRecord, createIfNotFound) == IndexType_Number)
+        if (indexType == IndexType_Number)
         {
             hasProperty = JavascriptOperators::GetItemReference(instance, object, indexVal, &value, scriptContext);
         }
         else
         {
+            Assert(indexType == IndexType_PropertyId);
+
+            if (propertyRecord == nullptr && !JavascriptOperators::CanShortcutOnUnknownPropertyName(object))
+            {
+                indexType = GetIndexTypeFromPrimitive(index, scriptContext, &indexVal, &propertyRecord, true);
+                Assert(indexType == IndexType_PropertyId);
+                Assert(propertyRecord != nullptr);
+            }
+
             if (propertyRecord != nullptr)
             {
                 hasProperty = JavascriptOperators::GetPropertyReference(instance, object, propertyRecord->GetPropertyId(), &value, scriptContext, NULL);
@@ -3927,7 +3973,6 @@ CommonNumber:
 #if DBG
             else
             {
-                Assert(IsJsNativeObject(object));
                 JavascriptString* indexStr = JavascriptConversion::ToString(index, scriptContext);
                 PropertyRecord const * debugPropertyRecord;
                 scriptContext->GetOrAddPropertyRecord(indexStr->GetString(), indexStr->GetLength(), &debugPropertyRecord);
@@ -4765,24 +4810,30 @@ CommonNumber:
         uint32 indexVal;
         PropertyRecord const * propertyRecord;
         BOOL result = TRUE;
+        IndexType indexType = GetIndexType(index, scriptContext, &indexVal, &propertyRecord, false);
 
-        bool createIfNotFound = !IsJsNativeObject(object) ||
-            (DynamicType::Is(object->GetTypeId()) && static_cast<DynamicObject*>(object)->GetTypeHandler()->IsStringTypeHandler()) || JavascriptProxy::Is(object);
-
-        if (GetIndexType(index, scriptContext, &indexVal, &propertyRecord, createIfNotFound) == IndexType_Number)
+        if (indexType == IndexType_Number)
         {
             result = JavascriptOperators::DeleteItem(object, indexVal, propertyOperationFlags);
         }
         else
         {
-            if (propertyRecord)
+            Assert(indexType == IndexType_PropertyId);
+
+            if (propertyRecord == nullptr && !JavascriptOperators::CanShortcutOnUnknownPropertyName(object))
+            {
+                indexType = GetIndexTypeFromPrimitive(index, scriptContext, &indexVal, &propertyRecord, true);
+                Assert(indexType == IndexType_PropertyId);
+                Assert(propertyRecord != nullptr);
+            }
+
+            if (propertyRecord != nullptr)
             {
                 result = JavascriptOperators::DeleteProperty(object, propertyRecord->GetPropertyId(), propertyOperationFlags);
             }
 #if DBG
             else
             {
-                Assert(IsJsNativeObject(object));
                 JavascriptString* indexStr = JavascriptConversion::ToString(index, scriptContext);
                 PropertyRecord const * debugPropertyRecord;
                 scriptContext->GetOrAddPropertyRecord(indexStr->GetString(), indexStr->GetLength(), &debugPropertyRecord);
@@ -4975,6 +5026,50 @@ CommonNumber:
             default:
                 return false;
         }
+    }
+
+    bool JavascriptOperators::CanShortcutOnUnknownPropertyName(RecyclableObject *instance)
+    {
+        if (!CanShortcutInstanceOnUnknownPropertyName(instance))
+        {
+            return false;
+        }
+        return CanShortcutPrototypeChainOnUnknownPropertyName(instance->GetPrototype());
+    }
+
+    bool JavascriptOperators::CanShortcutInstanceOnUnknownPropertyName(RecyclableObject *instance)
+    {
+        if (PHASE_OFF1(Js::OptUnknownElementNamePhase))
+        {
+            return false;
+        }
+
+        if (JavascriptProxy::Is(instance) || instance->IsExternal())
+        {
+            return false;
+        }
+        if (DynamicType::Is(instance->GetTypeId()) && 
+            static_cast<DynamicObject*>(instance)->GetTypeHandler()->IsStringTypeHandler())
+        {
+            return false;
+        }
+        return !(instance->HasDeferredTypeHandler() &&
+                 JavascriptFunction::Is(instance) && 
+                 JavascriptFunction::FromVar(instance)->IsExternalFunction());
+    }
+
+    bool JavascriptOperators::CanShortcutPrototypeChainOnUnknownPropertyName(RecyclableObject *prototype)
+    {
+        Assert(prototype);
+
+        for (; prototype->GetTypeId() != TypeIds_Null; prototype = prototype->GetPrototype())
+        {
+            if (!CanShortcutInstanceOnUnknownPropertyName(prototype))
+            {
+                return false;
+            }
+        }       
+        return true;
     }
 
     RecyclableObject* JavascriptOperators::GetPrototype(RecyclableObject* instance)

--- a/lib/Runtime/Language/JavascriptOperators.h
+++ b/lib/Runtime/Language/JavascriptOperators.h
@@ -215,6 +215,10 @@ namespace Js
         static BOOL IsAnyNumberValue(Var instance);
         static BOOL IsClassConstructor(Var instance);
 
+        static bool CanShortcutOnUnknownPropertyName(RecyclableObject * instance);
+        static bool CanShortcutInstanceOnUnknownPropertyName(RecyclableObject *instance);
+        static bool CanShortcutPrototypeChainOnUnknownPropertyName(RecyclableObject *instance);
+
         static BOOL HasOwnItem(RecyclableObject* instance, uint32 index);
         static BOOL HasItem(RecyclableObject* instance, uint32 index);
         static BOOL HasItem(RecyclableObject* instance, uint64 index);


### PR DESCRIPTION
Reimplement shortcut in element access on unknown property name. The optimization requires a prototype chain walk to confirm that the property being looked for can't be found on an object such as a CEO that may use names unknown to the JS engine, or that, like a proxy, may require that the lookup be done regardless. For now the prototype walk is done on every attempted access where no property record exists for the index name. This could be optimized with a scheme similar to the one we use for non-writable properties in the prototype chain, but I'd like to see a needful use case before I saddle us with another registration mechanism. Benchmarks are flat.