### PR TITLE
Fix bug with handling of OOM while processing jit transfer data

### DIFF
--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -8215,12 +8215,9 @@ namespace Js
         // corresponding fields on the entryPointInfo should be rolled back here.
         this->runtimeTypeRefs = nullptr;
         this->FreePropertyGuards();
-        if (this->equivalentTypeCaches != nullptr)
-        {
-            this->equivalentTypeCacheCount = 0;
-            this->equivalentTypeCaches = nullptr;
-            this->UnregisterEquivalentTypeCaches();
-        }
+        this->equivalentTypeCacheCount = 0;
+        this->equivalentTypeCaches = nullptr;
+        this->UnregisterEquivalentTypeCaches();
 
         this->ResetOnNativeCodeInstallFailure();
     }


### PR DESCRIPTION
We allocate equivalent type caches and register the current entry point info on the thread context as having equivalent type caches. Each of these operations could throw OOM. 
The resetting of entrypoint's state in the OOM handling code should be agnostic of the success or failure of the aforementioned operations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/843)
<!-- Reviewable:end -->
