### PR TITLE
Remove JavascriptErrorDebug from Linux builds

### DIFF
--- a/lib/Runtime/Library/JavascriptErrorDebug.h
+++ b/lib/Runtime/Library/JavascriptErrorDebug.h
@@ -7,6 +7,9 @@
 namespace Js
 {
     // Specialized Error Object, containing WinRT specific information.
+    // Not applicable for non-Windows platforms
+    // TODO: Move this out of ChakraCore
+#ifdef _WIN32
     class JavascriptErrorDebug : public JavascriptError
     {
     protected:
@@ -90,4 +93,5 @@ namespace Js
         IErrorInfo * pErrorInfo; // reference to the original IErrorInfo object
         static __declspec(thread)  char16 msgBuff[512];
     };
+#endif
 }


### PR DESCRIPTION
This is used only for WinRT errors, so remove use of it on non-Windows builds
