### PR TITLE
Fixing OACR warning in CustomHeap. 

### DIFF
--- a/lib/Common/Memory/CustomHeap.cpp
+++ b/lib/Common/Memory/CustomHeap.cpp
@@ -264,7 +264,7 @@ Allocation* Heap::Alloc(size_t bytes, ushort pdataCount, ushort xdataSize, bool 
     } while (true);
 }
 
-BOOL Heap::ProtectAllocationWithExecuteReadWrite(Allocation *allocation, char* addressInPage)
+BOOL Heap::ProtectAllocationWithExecuteReadWrite(Allocation *allocation, __in_opt char* addressInPage)
 {
     DWORD protectFlags = 0;
 
@@ -279,7 +279,7 @@ BOOL Heap::ProtectAllocationWithExecuteReadWrite(Allocation *allocation, char* a
     return this->ProtectAllocation(allocation, protectFlags, PAGE_EXECUTE, addressInPage);
 }
 
-BOOL Heap::ProtectAllocationWithExecuteReadOnly(Allocation *allocation, char* addressInPage)
+BOOL Heap::ProtectAllocationWithExecuteReadOnly(Allocation *allocation, __in_opt char* addressInPage)
 {
     DWORD protectFlags = 0;
     if (AutoSystemInfo::Data.IsCFGEnabled())

--- a/lib/Common/Memory/CustomHeap.h
+++ b/lib/Common/Memory/CustomHeap.h
@@ -418,8 +418,8 @@ public:
     }
 
     BOOL ProtectAllocation(__in Allocation* allocation, DWORD dwVirtualProtectFlags, DWORD desiredOldProtectFlag, __in_opt char* addressInPage = nullptr);
-    BOOL ProtectAllocationWithExecuteReadWrite(Allocation *allocation, char* addressInPage = nullptr);
-    BOOL ProtectAllocationWithExecuteReadOnly(Allocation *allocation, char* addressInPage = nullptr);
+    BOOL ProtectAllocationWithExecuteReadWrite(Allocation *allocation, __in_opt char* addressInPage = nullptr);
+    BOOL ProtectAllocationWithExecuteReadOnly(Allocation *allocation, __in_opt char* addressInPage = nullptr);
 
     ~Heap();
 


### PR DESCRIPTION
Adding SAL annotation to one of the arguments in CustomHeap