### PR TITLE
Undo defer parse mode issue with formals

### DIFF
--- a/test/es6/default-splitscope-undodeferparse.js
+++ b/test/es6/default-splitscope-undodeferparse.js
@@ -1,0 +1,64 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function foo1(a, b) {
+    if (b != 10) {
+        print("FAILED")
+    } else {
+        print("PASSED");
+    }
+    if (eval('b') != 10) {
+        print("FAILED")
+    } else {
+        print("PASSED");
+    }
+    var b = 1;
+    if (b != 1) {
+        print("FAILED")
+    } else {
+        print("PASSED");
+    }
+}
+foo1(undefined, 10);
+
+function foo2(a, b = 10) {
+    if (b != 10) {
+        print("FAILED")
+    } else {
+        print("PASSED");
+    }
+    if (eval('b') != 10) {
+        print("FAILED")
+    } else {
+        print("PASSED");
+    }
+    var b = 1;
+    if (b != 1) {
+        print("FAILED")
+    } else {
+        print("PASSED");
+    }
+}
+foo2();
+
+function foo3(a = 10, b = function () { return a; }) {
+    if (b() != 10) {
+        print("FAILED")
+    } else {
+        print("PASSED");
+    }
+    if (eval('b()') != 10) {
+        print("FAILED")
+    } else {
+        print("PASSED");
+    }
+    var a = 1;
+    if (b() != 10) {
+        print("FAILED")
+    } else {
+        print("PASSED");
+    }
+}
+foo3();

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -732,6 +732,12 @@
   </test>
   <test>
     <default>
+      <files>default-splitscope-undodeferparse.js</files>
+      <compile-flags>-forceundodefer -ES6DefaultArgsSplitScope</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>rest.js</files>
       <compile-flags>-ES6Rest -ES6ObjectLiterals -ES6Spread -ES6DefaultArgs -ES6Classes -args summary -endargs</compile-flags>
     </default>


### PR DESCRIPTION
In undo defer parse mode we reconstruct the pid ref stack for the formals.
With my last change to insert a new reference for each param symbol in the
body I missed making change in the undo defer parse mode. This change adds
the code to do that for both split scope and non-split scope.
