### PR TITLE
OS 7249217: Rest is able to be in a slot in arguments optimization case

### DIFF
--- a/lib/Runtime/ByteCode/Symbol.cpp
+++ b/lib/Runtime/ByteCode/Symbol.cpp
@@ -72,11 +72,7 @@ bool Symbol::IsInSlot(FuncInfo *funcInfo, bool ensureSlotAlloc)
     }
     if (funcInfo->GetHasHeapArguments() && this->GetIsFormal() && ByteCodeGenerator::NeedScopeObjectForArguments(funcInfo, funcInfo->root))
     {
-        // Rest is a special case - it will be in a register.
-        if (funcInfo->root->sxFnc.pnodeRest != this->decl)
-        {
-            return true;
-        }
+        return true;
     }
     if (this->GetIsGlobalCatch())
     {

--- a/test/es6/rest.js
+++ b/test/es6/rest.js
@@ -361,6 +361,21 @@ var tests = [
         }));
       }
     }
+  },
+  {
+    name: "OS 7249217: Rest is able to be in a slot in arguments optimization case",
+    body: function () {
+      function foo(...argArr9) {
+        var protoObj0 = {};
+        with (protoObj0) {
+          arguments;
+          var f = function () { assert.areEqual([1,2,3], argArr9, "Arguments scope object optimization allows rest to function correctly inside with"); };
+          f();
+        }
+        assert.areEqual([1,2,3], argArr9, "Arguments scope object optimization allows rest to function correctly");
+      }
+      foo(1,2,3);
+    }
   }
 ];
 


### PR DESCRIPTION
We hit an assert with rest in a case where we trigger an arguments scope object optimization. In the case where we don't actually need to create a scope object, rest was hard coded to not be in a slot. This was based on an assumption from a very long time ago; since then rest is no different to other formals when determining whether it is in a slot. I removed the special casing and added the test.
