### PR TITLE
PRE bookkeeping fix

### DIFF
--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -584,7 +584,7 @@ GlobOpt::OptBlock(BasicBlock *block)
         Assert(!TrackHoistableFields() || !HasHoistableFields(&this->blockData));
         if (!DoFieldCopyProp() && !DoFieldRefOpts())
         {
-            this->blockData.liveFields->ClearAll();
+            this->KillAllFields(blockData.liveFields);
         }
     }
 

--- a/lib/Backend/GlobOptFields.cpp
+++ b/lib/Backend/GlobOptFields.cpp
@@ -310,7 +310,10 @@ GlobOpt::KillLiveFields(StackSym * stackSym, BVSparse<JitArenaAllocator> * bv)
         bv->Clear(propertySym->m_id);
         if (this->IsLoopPrePass())
         {
-            this->rootLoopPrePass->fieldKilled->Set(propertySym->m_id);
+            for (Loop * loop = this->rootLoopPrePass; loop != nullptr; loop = loop->parent)
+            {
+                loop->fieldKilled->Set(propertySym->m_id);
+            }
         }
         else if (bv->IsEmpty())
         {
@@ -339,7 +342,10 @@ void GlobOpt::KillLiveFields(BVSparse<JitArenaAllocator> *const propertyEquivSet
 
         if (this->IsLoopPrePass())
         {
-            this->rootLoopPrePass->fieldKilled->Or(propertyEquivSet);
+            for (Loop * loop = this->rootLoopPrePass; loop != nullptr; loop = loop->parent)
+            {
+                loop->fieldKilled->Or(propertyEquivSet);
+            }
         }
     }
 }
@@ -382,7 +388,10 @@ GlobOpt::KillAllFields(BVSparse<JitArenaAllocator> * bv)
     bv->ClearAll();
     if (this->IsLoopPrePass())
     {
-        this->rootLoopPrePass->allFieldsKilled = true;
+        for (Loop * loop = this->rootLoopPrePass; loop != nullptr; loop = loop->parent)
+        {
+            loop->allFieldsKilled = true;
+        }
     }
 }
 


### PR DESCRIPTION
When we clear out live fields on discovering that implicit calls prevent loop optimization, we leave the same syms in the loop's initialValueFieldMap, resulting in later asserts. Two things: should use the KillAllFields API to clear out the live fields BV, and that API should walk the loop hierarchy setting the allFieldsKilled bits.