### PR TITLE
Implement ICU based platform agnostic interface on Linux builds

### DIFF
--- a/lib/Runtime/CMakeLists.txt
+++ b/lib/Runtime/CMakeLists.txt
@@ -2,14 +2,16 @@ project(CHAKRA_RUNTIME)
 
 include_directories(
     $(CHAKRA_RUNTIME_SOURCE_DIR)
-    $(CHAKRA_RUNTIME_SOURCE_DIR)/../Common
-    $(CHAKRA_RUNTIME_SOURCE_DIR)/../Backend
-    $(CHAKRA_RUNTIME_SOURCE_DIR)/../Parser
+    $(CHAKRA_RUNTIME_SOURCE_DIR)../Common
+    $(CHAKRA_RUNTIME_SOURCE_DIR)../Backend
+    $(CHAKRA_RUNTIME_SOURCE_DIR)../Parser
     $(CHAKRA_RUNTIME_SOURCE_DIR)/ByteCode
+    $(CHAKRA_RUNTIME_SOURCE_DIR)/PlatformAgnostic
     $(CHAKRA_RUNTIME_SOURCE_DIR)/Math
     )
 
 add_subdirectory (Base)
+add_subdirectory (PlatformAgnostic)
 add_subdirectory (ByteCode)
 add_subdirectory (Debug)
 add_subdirectory (Language)

--- a/lib/Runtime/Library/JavascriptString.cpp
+++ b/lib/Runtime/Library/JavascriptString.cpp
@@ -2118,7 +2118,8 @@ case_2:
 #if DBG
             DWORD converted =
 #endif
-                CharLowerBuffW(&outChar, 1);
+                PlatformAgnostic::UnicodeText::ChangeStringCaseInPlace(
+                    PlatformAgnostic::UnicodeText::CaseFlags::CaseFlagsLower, &outChar, 1);
 
             Assert(converted == 1);
 
@@ -2181,7 +2182,8 @@ case_2:
 #if DBG
             DWORD converted =
 #endif
-                CharUpperBuffW(&outChar, 1);
+                PlatformAgnostic::UnicodeText::ChangeStringCaseInPlace(
+                    PlatformAgnostic::UnicodeText::CaseFlags::CaseFlagsUpper, &outChar, 1);
 
             Assert(converted == 1);
 
@@ -2212,7 +2214,8 @@ case_2:
 #if DBG
             DWORD converted =
 #endif
-                CharUpperBuffW(outStr, count);
+                PlatformAgnostic::UnicodeText::ChangeStringCaseInPlace(
+                    PlatformAgnostic::UnicodeText::CaseFlags::CaseFlagsUpper, outStr, count);
 
             Assert(converted == count);
         }
@@ -2222,7 +2225,8 @@ case_2:
 #if DBG
             DWORD converted =
 #endif
-                CharLowerBuffW(outStr, count);
+                PlatformAgnostic::UnicodeText::ChangeStringCaseInPlace(
+                    PlatformAgnostic::UnicodeText::CaseFlags::CaseFlagsLower, outStr, count);
 
             Assert(converted == count);
         }
@@ -3261,9 +3265,9 @@ case_2:
         CaseFlags caseFlags = (toUpper ? CaseFlags::CaseFlagsUpper : CaseFlags::CaseFlagsLower);
         const char16* str = pThis->GetString();
         ApiError err = ApiError::NoError;
-        uint32 count = PlatformAgnostic::UnicodeText::ChangeStringLinguisticCase(caseFlags, str, strLength, nullptr, 0, &err);
+        int32 count = PlatformAgnostic::UnicodeText::ChangeStringLinguisticCase(caseFlags, str, strLength, nullptr, 0, &err);
 
-        if (count == 0)
+        if (count <= 0)
         {
             AssertMsg(err != ApiError::NoError, "LCMapString failed");
             Throw::InternalError();
@@ -3274,7 +3278,7 @@ case_2:
 
         int count1 = PlatformAgnostic::UnicodeText::ChangeStringLinguisticCase(caseFlags, str, count, stringBuffer, count, &err);
 
-        if (count1 == 0)
+        if (count1 <= 0)
         {
             AssertMsg(err != ApiError::NoError, "LCMapString failed");
             Throw::InternalError();

--- a/lib/Runtime/PlatformAgnostic/CMakeLists.txt
+++ b/lib/Runtime/PlatformAgnostic/CMakeLists.txt
@@ -1,0 +1,3 @@
+project(CHAKRA_PLATFORM_AGNOSTIC)
+
+add_subdirectory (Platform)

--- a/lib/Runtime/PlatformAgnostic/Chakra.Runtime.PlatformAgnostic.vcxproj
+++ b/lib/Runtime/PlatformAgnostic/Chakra.Runtime.PlatformAgnostic.vcxproj
@@ -41,6 +41,7 @@
     </ClCompile>
     <ClCompile Include="Platform\Linux\UnicodeText.ICU.cpp" />
     <ClCompile Include="Platform\Windows\UnicodeText.cpp" />
+    <ClCompile Include="Platform\Common\UnicodeText.Common.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ChakraPlatform.h" />

--- a/lib/Runtime/PlatformAgnostic/Chakra.Runtime.PlatformAgnostic.vcxproj.filters
+++ b/lib/Runtime/PlatformAgnostic/Chakra.Runtime.PlatformAgnostic.vcxproj.filters
@@ -8,6 +8,7 @@
       <Filter>Platform\Linux</Filter>
     </ClCompile>
     <ClCompile Include="RuntimePlatformAgnosticPch.cpp" />
+    <ClCompile Include="Platform\Common\UnicodeText.Common.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Interfaces">

--- a/lib/Runtime/PlatformAgnostic/Platform/CMakeLists.txt
+++ b/lib/Runtime/PlatformAgnostic/Platform/CMakeLists.txt
@@ -1,0 +1,9 @@
+project(CHAKRA_PLATFORM_AGNOSTIC)
+
+add_library (Chakra.Runtime.PlatformAgnostic
+  Linux/UnicodeText.ICU.cpp
+  Common/UnicodeText.Common.cpp
+  )
+  
+target_include_directories (
+    Chakra.Runtime.PlatformAgnostic PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/lib/Runtime/PlatformAgnostic/Platform/Common/UnicodeText.Common.cpp
+++ b/lib/Runtime/PlatformAgnostic/Platform/Common/UnicodeText.Common.cpp
@@ -1,0 +1,282 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#include "RuntimePlatformAgnosticPch.h"
+#include "UnicodeText.h"
+#include <ctype.h>
+
+namespace PlatformAgnostic
+{
+namespace UnicodeText
+{
+CharacterTypeFlags GetLegacyCharacterTypeFlags(char16 ch)
+{
+    Assert(ch >= 128);
+
+    const char16 lineSeperatorChar = 0x2028;
+    const char16 paraSeperatorChar = 0x2029;
+
+    if (ch == lineSeperatorChar || ch == paraSeperatorChar)
+    {
+        return LineCharGroup;
+    }
+
+    CharacterClassificationType charClass = GetLegacyCharacterClassificationType(ch);
+
+    if (charClass == CharacterClassificationType::Letter)
+    {
+        return LetterCharGroup;
+    }
+    else if (charClass == CharacterClassificationType::DigitOrPunct)
+    {
+        return IdChar;
+    }
+    else if (charClass == CharacterClassificationType::Whitespace)
+    {
+        return SpaceChar;
+    }
+
+    return UnknownChar;
+}
+
+#if !defined(_WIN32) || ENABLE_TEST_PLATFORM_AGNOSTIC
+namespace Internal
+{
+template <typename CharType>
+inline bool isDigit(__in CharType c)
+{
+    return c >= '0' && c <= '9';
+}
+
+template <typename CharType>
+inline int readNumber(__inout CharType* &str)
+{
+    int num = 0;
+
+    // Count digits on each string
+    while (isDigit(*str))
+    {
+        int newNum = (num * 10) + (*str - '0');
+        Assert(newNum > num);
+        if (newNum <= num)
+        {
+            return num;
+        }
+
+        num = newNum;
+
+        str++;
+    }
+
+    return num;
+}
+
+///
+/// Implementation of CompareString(NORM_IGNORECASE | SORT_DIGITSASNUMBERS)
+/// This code is in the common library so that we can unit test it on Windows too
+///
+/// Basic algorithm is as follows:
+/// 
+/// Iterate through both strings
+///  If either current character is not a number, compare the rest of the strings lexically
+///  else if they're both numbers:
+///     Count the leading zeroes in both strings and skip over them
+///     Read the two numbers
+///     If they're not the same, return accordingly
+///     If they are the same, but the leading zeroes are different, return whichever has fewer zeroes as "larger"
+///     Otherwise, they're the same to continue scanning
+///  else they're both not numbers:
+///     Compare lexically till we find a number
+/// The algorithm treats the characters in a case-insensitive manner
+///
+template <typename CharType>
+int LogicalStringCompareImpl(__in const CharType* p1, __in const CharType* p2)
+{
+    Assert(p1 != nullptr);
+    Assert(p2 != nullptr);
+
+    while (*p1 && *p2)
+    {
+        bool isDigit1 = isDigit(*p1);
+        bool isDigit2 = isDigit(*p2);
+
+        if (isDigit1 ^ isDigit2)
+        {
+            // If either character exclusively is not a number, compare just the characters
+            // since that's enough to sort the string
+            CharType c1 = tolower(*p1);
+            CharType c2 = tolower(*p2);
+
+            Assert(c1 != c2);
+
+            if (c1 < c2)
+            {
+                return -1;
+            }
+
+            return 1;
+        }
+        else if (isDigit1 && isDigit2)
+        {
+            // Both current characters are digits, so we'll compare the numbers
+            int numZero1 = 0, numZero2 = 0;
+
+            // Count leading zeroes on each string
+            while (*p1 == '0')
+            {
+                p1++; numZero1++;
+            }
+
+            while (*p2 == '0')
+            {
+                p2++; numZero2++;
+            }
+
+            int num1 = readNumber(p1);
+            int num2 = readNumber(p2);
+
+            if (num1 != num2)
+            {
+                // If the numbers are unequal, just compare the numbers
+                return (num1 > num2) ? 1 : -1;
+            }
+            else if (numZero1 != numZero2)
+            {
+                // The numbers are equal but the number of leading zeroes are not
+                // The one with the fewer number of leading zeroes is considered
+                // "larger" (gets sorted earlier)
+                return (numZero1 < numZero2 ? 1 : -1);
+            }
+            // else both numbers are the same, keep going
+        }
+        else
+        {
+            // Both characters are not digits - scan till we find a
+            // digit in the same position in each string
+            while (*p1 && !isDigit(*p1) && *p2 && !isDigit(*p2))
+            {
+                int c1 = tolower(*p1);
+                int c2 = tolower(*p2);
+
+                if (c1 < c2)
+                {
+                    return -1;
+                }
+                else if (c1 > c2)
+                {
+                    return 1;
+                }
+
+                p1++; p2++;
+            }
+        }
+    }
+
+    if (*p1 == *p2) return 0;
+
+    return ((*p1 > *p2) ? 1 : -1);
+}
+
+template
+int LogicalStringCompareImpl<char16>(__in const char16* str1, __in const char16* str2);
+
+}; // Internal
+#endif // !defined(_WIN32) || ENABLE_TEST_PLATFORM_AGNOSTIC
+}; // UnicodeText
+}; // PlatformAgnostic
+
+// Unnamespaced test code
+#if ENABLE_TEST_PLATFORM_AGNOSTIC
+void LogicalStringCompareTest(const wchar_t* str1, const wchar_t* str2, int expected)
+{
+    int compareStringResult = CompareStringW(LOCALE_USER_DEFAULT, NORM_IGNORECASE | SORT_DIGITSASNUMBERS, str1, -1, str2, -1);
+
+    if (compareStringResult == 0)
+    {
+        printf("ERROR: CompareStringW failed with error: %d\n", ::GetLastError());
+        return;
+    }
+
+    compareStringResult = compareStringResult - CSTR_EQUAL;
+
+    int res = PlatformAgnostic::UnicodeText::Internal::LogicalStringCompareImpl<wchar_t>(str1, str2);
+    bool passed = res == expected;
+
+    if (compareStringResult != expected)
+    {
+        wprintf(L"WARNING: Incorrect expected value: %d, actual: %d\n", expected, compareStringResult);
+    }
+
+    if (passed)
+    {
+        wprintf(L"[%s]\n", L"PASS");
+    }
+    else
+    {
+        wprintf(L"[%s] Expected: %d, Actual: %d)\n", L"FAIL", expected, res);
+    }
+}
+
+void doLogicalStringTests()
+{
+    LogicalStringCompareTest(L"a", L"a", 0);
+    LogicalStringCompareTest(L"a", L"b", -1);
+    LogicalStringCompareTest(L"b", L"a", 1);
+
+    LogicalStringCompareTest(L"a", L"A", 0);
+    LogicalStringCompareTest(L"a", L"B", -1);
+    LogicalStringCompareTest(L"b", L"A", 1);
+
+    LogicalStringCompareTest(L"1", L"2", -1);
+    LogicalStringCompareTest(L"2", L"1", 1);
+
+    LogicalStringCompareTest(L"10", L"01", 1);
+    LogicalStringCompareTest(L"01", L"10", -1);
+
+    LogicalStringCompareTest(L"01", L"1", -1);
+    LogicalStringCompareTest(L"1", L"01", 1);
+
+    LogicalStringCompareTest(L"1a", L"a1", -1);
+    LogicalStringCompareTest(L"aa1", L"a1", 1);
+    LogicalStringCompareTest(L"a1", L"a1", 0);
+    LogicalStringCompareTest(L"a1", L"b1", -1);
+    LogicalStringCompareTest(L"b1", L"a1", 1);
+    LogicalStringCompareTest(L"a1", L"a2", -1);
+    LogicalStringCompareTest(L"a10", L"a2", 1);
+    LogicalStringCompareTest(L"a2", L"a10", -1);
+
+    LogicalStringCompareTest(L"A1", L"a1", 0);
+    LogicalStringCompareTest(L"A1", L"b1", -1);
+    LogicalStringCompareTest(L"B1", L"a1", 1);
+    LogicalStringCompareTest(L"A1", L"a2", -1);
+    LogicalStringCompareTest(L"A10", L"a2", 1);
+    LogicalStringCompareTest(L"A2", L"a10", -1);
+
+    LogicalStringCompareTest(L"123", L"456", -1);
+    LogicalStringCompareTest(L"456", L"123", 1);
+    LogicalStringCompareTest(L"abc123", L"def123", -1);
+    LogicalStringCompareTest(L"abc123", L"abc123", 0);
+    LogicalStringCompareTest(L"abc123", L"abc0123", 1);
+    LogicalStringCompareTest(L"abc123", L"abc124", -1);
+    LogicalStringCompareTest(L"abc124", L"abc123", 1);
+
+    LogicalStringCompareTest(L"abc123def", L"abc123def", 0);
+    LogicalStringCompareTest(L"abc123def", L"abc123eef", -1);
+    LogicalStringCompareTest(L"abc123eef", L"abc123def", 1);
+
+    LogicalStringCompareTest(L"abc1def", L"abc10def", -1);
+    LogicalStringCompareTest(L"abc1def1", L"abc1def12", -1);
+
+    LogicalStringCompareTest(L"2string", L"3string", -1);
+    LogicalStringCompareTest(L"20string", L"3string", 1);
+    LogicalStringCompareTest(L"20string", L"st2ring", -1);
+    LogicalStringCompareTest(L"st3ring", L"st2ring", 1);
+
+    LogicalStringCompareTest(L"2String", L"3string", -1);
+    LogicalStringCompareTest(L"20String", L"3string", 1);
+    LogicalStringCompareTest(L"20sTRing", L"st2ring", -1);
+    LogicalStringCompareTest(L"st3rING", L"st2riNG", 1);
+}
+#endif

--- a/lib/Runtime/PlatformAgnostic/Platform/Linux/UnicodeText.ICU.cpp
+++ b/lib/Runtime/PlatformAgnostic/Platform/Linux/UnicodeText.ICU.cpp
@@ -9,8 +9,10 @@
 // Non-Windows Implementation
 // TODO: Probably should check for something specific to Linux instead of checking for not _WIN32
 #include "UnicodeText.h"
-#include <unicode/utypes.h>
-#include <unicode/unorm2.h>
+
+#include <unicode/uchar.h>
+#include <unicode/ustring.h>
+#include <unicode/normalizer2.h>
 
 namespace PlatformAgnostic
 {
@@ -21,26 +23,26 @@ namespace PlatformAgnostic
 #endif
 
         // Helper ICU conversion facilities
-        static const UNormalizer* TranslateToICUNormalizer(NormalizationForm normalizationForm)
+        static const Normalizer2* TranslateToICUNormalizer(NormalizationForm normalizationForm)
         {
             UErrorCode errorCode = U_ZERO_ERROR;
-            UNormalizer* normalizer = nullptr;
+            const Normalizer2* normalizer;
 
             switch (normalizationForm)
             {
                 case NormalizationForm::C:
-                    normalizer = unorm2_getNFCInstance(errorCode);
+                    normalizer = Normalizer2::getNFCInstance(errorCode);
                 case NormalizationForm::D:
-                    normalizer = unorm2_getNFDInstance(errorCode);
+                    normalizer = Normalizer2::getNFDInstance(errorCode);
                 case NormalizationForm::KC:
-                    normalizer = unorm2_getNFKCInstance(errorCode);
+                    normalizer = Normalizer2::getNFKCInstance(errorCode);
                 case NormalizationForm::KD:
-                    normalizer = unorm2_getNFKDInstance(errorCode);
+                    normalizer = Normalizer2::getNFKDInstance(errorCode);
                 default:
-                    AssertMsg(false, "Unsupported normalization form")
+                    AssertMsg(false, "Unsupported normalization form");
             };
 
-            AssertMsg(U_SUCCESS(errorCode), u_errorName(errorCode));
+            AssertMsg(U_SUCCESS(errorCode), (char*) u_errorName(errorCode));
 
             return normalizer;
         }
@@ -82,17 +84,27 @@ namespace PlatformAgnostic
 
             *pErrorOut = NoError;
 
-            const UNormalizer* normalizer = TranslateToICUNormalizer(normalizationForm);
+            const Normalizer2* normalizer = TranslateToICUNormalizer(normalizationForm);
             Assert(normalizer != nullptr);
 
+            const UnicodeString sourceUniStr((const UChar*) sourceString, sourceLength);
+
             UErrorCode errorCode = U_ZERO_ERROR;
-            int32 normalizedStringLength = unorm2_normalize(normalizer, (const UChar*)sourceString, sourceLength, (UChar*)destString, destLength, &errorCode);
+            const UnicodeString destUniStr = normalizer->normalize(sourceUniStr, errorCode);
 
             if (U_FAILURE(errorCode))
             {
                 *pErrorOut = TranslateUErrorCode(errorCode);
             }
 
+            int32_t normalizedStringLength = destUniStr.length();
+            destUniStr.extract((UChar*) destString, destLength, errorCode);
+            if (U_FAILURE(errorCode))
+            {
+                *pErrorOut = TranslateUErrorCode(errorCode);
+                return -1;
+            }
+            
             return normalizedStringLength;
         }
 
@@ -101,12 +113,172 @@ namespace PlatformAgnostic
             Assert(testString != nullptr);
             UErrorCode errorCode = U_ZERO_ERROR;
 
-            const UNormalizer* normalizer = TranslateToICUNormalizer(normalizationForm);
+            const Normalizer2* normalizer = TranslateToICUNormalizer(normalizationForm);
             Assert(normalizer != nullptr);
-            bool isNormalized = unorm2_isNormalized(normalizer, (const UChar*)testString, testStringLength, &errorCode);
+
+            const UnicodeString testUniStr((const UChar*) testString, testStringLength);
+            bool isNormalized = normalizer->isNormalized(testUniStr, errorCode);
 
             Assert(U_SUCCESS(errorCode));
             return isNormalized;
+        }
+
+        // Since we're using the ICU here, this is trivially true
+        bool IsExternalUnicodeLibraryAvailable()
+        {
+            return true;
+        }
+
+        bool IsWhitespace(codepoint_t ch)
+        {
+            return u_isUWhiteSpace(ch) == 1;
+        }
+
+        bool IsIdStart(codepoint_t ch)
+        {
+            return u_isIDStart(ch);
+        }
+        
+        bool IsIdContinue(codepoint_t ch)
+        {
+            return u_hasBinaryProperty(ch, UCHAR_ID_CONTINUE) == 1;
+        }
+
+        UnicodeGeneralCategoryClass GetGeneralCategoryClass(codepoint_t ch)
+        {
+            int8_t charType = u_charType(ch);
+
+            if (charType == U_LOWERCASE_LETTER ||
+                charType == U_UPPERCASE_LETTER ||
+                charType == U_TITLECASE_LETTER ||
+                charType == U_MODIFIER_LETTER ||
+                charType == U_OTHER_LETTER ||
+                charType == U_LETTER_NUMBER)
+            {
+                return UnicodeGeneralCategoryClass::CategoryClassLetter;
+            }
+
+            if (charType == U_DECIMAL_DIGIT_NUMBER)
+            {
+                return UnicodeGeneralCategoryClass::CategoryClassDigit;
+            }
+
+            if (charType == U_LINE_SEPARATOR)
+            {
+                return UnicodeGeneralCategoryClass::CategoryClassLineSeparator;
+            }
+
+            if (charType == U_PARAGRAPH_SEPARATOR)
+            {
+                return UnicodeGeneralCategoryClass::CategoryClassParagraphSeparator;
+            }
+
+            if (charType == U_SPACE_SEPARATOR)
+            {
+                return UnicodeGeneralCategoryClass::CategoryClassSpaceSeparator;
+            }
+
+            if (charType == U_COMBINING_SPACING_MARK)
+            {
+                return UnicodeGeneralCategoryClass::CategoryClassSpacingCombiningMark;
+            }
+
+            if (charType == U_NON_SPACING_MARK)
+            {
+                return UnicodeGeneralCategoryClass::CategoryClassNonSpacingMark;
+            }
+
+            if (charType == U_CONNECTOR_PUNCTUATION)
+            {
+                return UnicodeGeneralCategoryClass::CategoryClassConnectorPunctuation;
+            }
+            
+            return UnicodeGeneralCategoryClass::CategoryClassOther;
+        }
+
+        // We actually don't care about the legacy behavior on Linux since no one
+        // has a dependency on it. So this actually is different between
+        // Windows and Linux
+        CharacterClassificationType GetLegacyCharacterClassificationType(char16 character)
+        {
+            auto charTypeMask = U_GET_GC_MASK(character);
+
+            if ((charTypeMask & U_GC_L_MASK) != 0)
+            {
+                return CharacterClassificationType::Letter;
+            }
+            
+            if ((charTypeMask & (U_GC_ND_MASK | U_GC_P_MASK)) != 0)
+            {
+                return CharacterClassificationType::DigitOrPunct;
+            }
+
+            // As per http://archives.miloush.net/michkap/archive/2007/06/11/3230072.html
+            //  * C1_SPACE corresponds to the Unicode Zs category.
+            //  * C1_BLANK corresponds to a hardcoded list thats ill-defined.
+            // We'll skip that compatibility here and just check for Zs.
+            if ((charTypeMask & U_GC_ZS_MASK) != 0)
+            {
+                return CharacterClassificationType::Whitespace;
+            }
+            
+            return CharacterClassificationType::Invalid;
+        }
+            
+        int32 ChangeStringLinguisticCase(CaseFlags caseFlags, const char16* sourceString, uint32 sourceLength, char16* destString, uint32 destLength, ApiError* pErrorOut)
+        {
+            int32_t resultStringLength = 0;
+            UErrorCode errorCode = U_ZERO_ERROR;
+
+            static_assert(sizeof(UChar) == sizeof(char16), "Unexpected char type from ICU, function might have to be updated");
+            if (caseFlags == CaseFlagsUpper)
+            {
+                resultStringLength = u_strToUpper((UChar*) destString, destLength,
+                    (UChar*) sourceString, sourceLength, NULL, &errorCode);
+            }
+            else if (caseFlags == CaseFlagsLower)
+            {
+                resultStringLength = u_strToLower((UChar*) destString, destLength,
+                    (UChar*) sourceString, sourceLength, NULL, &errorCode);
+            }
+            else
+            {
+                Assert(false);
+            }
+
+            if (U_FAILURE(errorCode))
+            {
+                *pErrorOut = TranslateUErrorCode(errorCode);
+                return -1;
+            }
+
+            // Todo: check for resultStringLength > destLength
+            // Return insufficient buffer in that case
+            return resultStringLength;
+        }
+
+        uint32 ChangeStringCaseInPlace(CaseFlags caseFlags, char16* stringToChange, uint32 bufferLength)
+        {
+            // Assert pointers
+            Assert(stringToChange != nullptr);
+            ApiError error = NoError;
+
+            if (bufferLength == 0 || stringToChange == nullptr)
+            {
+                return 0;
+            }
+            
+            int32 ret = ChangeStringLinguisticCase(caseFlags, stringToChange, bufferLength, stringToChange, bufferLength, &error);
+
+            // Callers to this function don't expect any errors
+            Assert(error == ApiError::NoError);
+            Assert(ret > 0);
+            return (uint32) ret;
+        }
+
+        int LogicalStringCompare(const char16* string1, const char16* string2)
+        {
+            return PlatformAgnostic::UnicodeText::Internal::LogicalStringCompareImpl<char16>(string1, string2);
         }
     };
 };

--- a/lib/Runtime/PlatformAgnostic/Platform/Windows/UnicodeText.cpp
+++ b/lib/Runtime/PlatformAgnostic/Platform/Windows/UnicodeText.cpp
@@ -240,36 +240,6 @@ namespace PlatformAgnostic
             return CharacterClassificationType::Invalid;
         }
 
-        CharacterTypeFlags GetLegacyCharacterTypeFlags(char16 ch)
-        {
-            Assert(ch >= 128);
-
-            const char16 lineSeperatorChar = 0x2028;
-            const char16 paraSeperatorChar = 0x2029;
-
-            if (ch == lineSeperatorChar || ch == paraSeperatorChar)
-            {
-                return LineCharGroup;
-            }
-
-            CharacterClassificationType charClass = GetLegacyCharacterClassificationType(ch);
-
-            if (charClass == CharacterClassificationType::Letter)
-            {
-                return LetterCharGroup;
-            }
-            else if (charClass == CharacterClassificationType::DigitOrPunct)
-            {
-                return IdChar;
-            }
-            else if (charClass == CharacterClassificationType::Whitespace)
-            {
-                return SpaceChar;
-            }
-
-            return UnknownChar;
-        }
-
         int32 NormalizeString(NormalizationForm normalizationForm, const char16* sourceString, uint32 sourceLength, char16* destString, int32 destLength, ApiError* pErrorOut)
         {
             // Assert pointers
@@ -311,7 +281,7 @@ namespace PlatformAgnostic
             return (::IsNormalizedString(TranslateToWin32NormForm(normalizationForm), (LPCWSTR)testString, testStringLength) == TRUE);
         }
 
-        uint32 ChangeStringLinguisticCase(CaseFlags caseFlags, const char16* sourceString, uint32 sourceLength, char16* destString, uint32 destLength, ApiError* pErrorOut)
+        int32 ChangeStringLinguisticCase(CaseFlags caseFlags, const char16* sourceString, uint32 sourceLength, char16* destString, uint32 destLength, ApiError* pErrorOut)
         {
             // Assert pointers
             Assert(sourceString != nullptr);
@@ -337,7 +307,30 @@ namespace PlatformAgnostic
             Assert(translatedStringLength >= 0);
             return (uint32) translatedStringLength;
         }
+
+        uint32 ChangeStringCaseInPlace(CaseFlags caseFlags, char16* sourceString, uint32 sourceLength)
+        {
+            // Assert pointers
+            Assert(sourceString != nullptr);
+
+            if (sourceLength == 0 || sourceString == nullptr)
+            {
+                return 0;
+            }
+            
+            if (caseFlags == CaseFlagsUpper)
+            {
+                return (uint32) CharUpperBuff(sourceString, sourceLength);
+            }
+            else if (caseFlags == CaseFlagsLower)
+            {
+                return (uint32) CharLowerBuff(sourceString, sourceLength);
+            }
  
+            AssertMsg(false, "Invalid flags passed to ChangeStringCaseInPlace");
+            return 0;
+        }
+
         UnicodeGeneralCategoryClass GetGeneralCategoryClass(codepoint_t codepoint)
         {
             return ExecuteWinGlobApi([&](IUnicodeCharactersStatics* pUnicodeCharStatics) {

--- a/lib/Runtime/PlatformAgnostic/RuntimePlatformAgnosticPch.h
+++ b/lib/Runtime/PlatformAgnostic/RuntimePlatformAgnosticPch.h
@@ -4,8 +4,10 @@
 //-------------------------------------------------------------------------------------------------------
 #pragma once
 
+#ifdef _WIN32
 #include "CommonDefines.h"
 #include "CommonMin.h"
+#endif
 
 #ifdef _MSC_VER
 #pragma warning(push)
@@ -15,6 +17,46 @@
 #pragma warning(pop)
 #endif
 
+// Minimal definitions to use AssertMsg in the PAIL
+#ifndef _WIN32
+#define DbgRaiseAssertionFailure() __builtin_trap()
+#define __analysis_assume(x)
+#define __in
+#define __inout
 
+#ifndef USE_ICU
+#ifndef TRUE
+#define TRUE 1
+#endif
 
+#ifndef FALSE
+#define FALSE 0
+#endif
+#else
+#include <unicode/umachine.h>
+#endif
 
+namespace Js
+{
+class Throw
+{
+public:
+    static bool ReportAssert(char* fileName, unsigned int lineNumber, char* error, char* message);
+    static void LogAssert();
+};
+}
+
+#include <Core/Assertions.h>
+
+namespace PlatformAgnostic
+{
+    namespace UnicodeText
+    {
+         namespace Internal
+         {
+             template <typename CharType>
+             int LogicalStringCompareImpl(const CharType* str1, const CharType* str2);
+         }
+    }
+}
+#endif

--- a/lib/Runtime/PlatformAgnostic/UnicodeText.h
+++ b/lib/Runtime/PlatformAgnostic/UnicodeText.h
@@ -4,7 +4,6 @@
 //-------------------------------------------------------------------------------------------------------
 #pragma once
 
-#include "CommonPal.h"
 #include "Core/CommonTypedefs.h"
 
 namespace PlatformAgnostic
@@ -168,7 +167,22 @@ namespace PlatformAgnostic
         //   length of the translated string in the destination buffer
         //   If the return value is less than or equal to 0, then see the value of pErrorOut to understand the error
         //
-        uint32 ChangeStringLinguisticCase(CaseFlags caseFlags, const char16* sourceString, uint32 sourceLength, char16* destString, uint32 destLength, ApiError* pErrorOut);
+        int32 ChangeStringLinguisticCase(CaseFlags caseFlags, const char16* sourceString, uint32 sourceLength, char16* destString, uint32 destLength, ApiError* pErrorOut);
+
+        // 
+        // Change the case of a string using linguistic rules
+        // The string is changed in place
+        //
+        // Params:
+        //   caseFlags: the case to convert to 
+        //   sourceString: The string to convert
+        //   sourceLength: The number of characters in the source string. This must be provided, the function does not assume null-termination etc. Length should be greater than 0.
+        // 
+        // Return Value:
+        //   length of the translated string in the destination buffer
+        //   If the return value is less than or equal to 0, then see the value of pErrorOut to understand the error
+        //
+        uint32 ChangeStringCaseInPlace(CaseFlags caseFlags, char16* stringToChange, uint32 bufferLength);
 
         //
         // Return the classification type of the character using Unicode 2.0 rules


### PR DESCRIPTION
This change implements the UnicodeText Platform Agnostic interface on Linux builds.
With this change, Linux builds will temporarily have an ICU dependency
(we'll do another change later to make it optional but it shouldn't be too difficult).

Additionally, one new API is introduced to the UnicodeText interface- ChangeStringCaseInPlace.
This is a thin wrapper around CharUpperBuffer/CharLowerBuff on Win32.
On Linux it just falls back to the ICU based function ChangeStringLinguisticCase.

Note that while the ICU functions are generally analogous to their Windows counterparts, they
need not be identical in behavior. This can cause differences between Windows and Linux but we'll
deal with them as we encounter them.

Finally, one additional function was re-implemented for Linux. LogicalStringCompareImpl is a
reimplementation of CompareStringW(NORM_IGNORECASE | SORT_DIGITSASNUMBERS)
