### PR TITLE
put asm.js output message behind trace flag

### DIFF
--- a/lib/Runtime/Language/AsmJsTypes.cpp
+++ b/lib/Runtime/Language/AsmJsTypes.cpp
@@ -876,7 +876,10 @@ namespace Js
         AsmJsVarBase* var = FindVar(name);
         if (var)
         {
-            Output::Print(_u("Variable redefinition: %s\n"), name->Psz());
+            if (PHASE_TRACE1(AsmjsPhase))
+            {
+                Output::Print(_u("Variable redefinition: %s\n"), name->Psz());
+            }
             return nullptr;
         }
 


### PR DESCRIPTION
This was causing fuzzers to give error on difference in output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/861)
<!-- Reviewable:end -->
