### PR TITLE
Few destructuring fixes

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -187,6 +187,9 @@ bool IsArguments(ParseNode *pnode)
         case knopTry:
         case knopTryCatch:
         case knopTryFinally:
+        case knopArrayPattern:
+        case knopObjectPattern:
+        case knopParamPattern:
             return true;
 
         default:

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -2711,7 +2711,7 @@ FuncInfo* PostVisitFunction(ParseNode* pnode, ByteCodeGenerator* byteCodeGenerat
                 if (argSym)
                 {
                     Assert(top->bodyScope->GetScopeSlotCount() == 0);
-                    Assert(top->sameNameArgsPlaceHolderSlotCount == 0);
+                    Assert(top->argsPlaceHolderSlotCount == 0);
                     byteCodeGenerator->AssignRegister(argSym);
                     uint i = 0;
                     auto setArgScopeSlot = [&](ParseNode *pnodeArg)
@@ -2721,9 +2721,13 @@ FuncInfo* PostVisitFunction(ParseNode* pnode, ByteCodeGenerator* byteCodeGenerat
                             Symbol* sym = pnodeArg->sxVar.sym;
                             if (sym->GetScopeSlot() != Js::Constants::NoProperty)
                             {
-                                top->sameNameArgsPlaceHolderSlotCount++; // Same name args appeared before
+                                top->argsPlaceHolderSlotCount++; // Same name args appeared before
                             }
                             sym->SetScopeSlot(i);
+                        }
+                        else if (pnodeArg->nop == knopParamPattern)
+                        {
+                            top->argsPlaceHolderSlotCount++;
                         }
                         i++;
                     };

--- a/lib/Runtime/ByteCode/FuncInfo.cpp
+++ b/lib/Runtime/ByteCode/FuncInfo.cpp
@@ -71,7 +71,7 @@ FuncInfo::FuncInfo(
     inlineCacheMap(nullptr),
     slotProfileIdMap(alloc),
     localPropIdOffset(-1),
-    sameNameArgsPlaceHolderSlotCount(0),
+    argsPlaceHolderSlotCount(0),
     thisScopeSlot(Js::Constants::NoProperty),
     superScopeSlot(Js::Constants::NoProperty),
     superCtorScopeSlot(Js::Constants::NoProperty),

--- a/lib/Runtime/ByteCode/FuncInfo.h
+++ b/lib/Runtime/ByteCode/FuncInfo.h
@@ -115,7 +115,7 @@ public:
     Js::RegSlot yieldRegister;
     Js::RegSlot firstTmpReg;
     Js::RegSlot curTmpReg;
-    int sameNameArgsPlaceHolderSlotCount; // count of place holder slots for same name args
+    int argsPlaceHolderSlotCount;   // count of place holder slots for same name args and destructuring patterns
     int localPropIdOffset;
     Js::RegSlot firstThunkArgReg;
     short thunkArgCount;

--- a/lib/Runtime/ByteCode/ScopeInfo.cpp
+++ b/lib/Runtime/ByteCode/ScopeInfo.cpp
@@ -54,8 +54,8 @@ namespace Js
     {
         int count = scope->Count();
 
-        // Add same name args place holder slot counts
-        AddSlotCount(count, scope->GetFunc()->sameNameArgsPlaceHolderSlotCount);
+        // Add argsPlaceHolder which includes same name args and destructuring patterns on parameters
+        AddSlotCount(count, scope->GetFunc()->argsPlaceHolderSlotCount);
         AddSlotCount(count, scope->GetFunc()->thisScopeSlot != Js::Constants::NoRegister ? 1 : 0);
         AddSlotCount(count, scope->GetFunc()->newTargetScopeSlot != Js::Constants::NoRegister ? 1 : 0);
 

--- a/test/es6/destructuring_bugs.js
+++ b/test/es6/destructuring_bugs.js
@@ -288,6 +288,30 @@ var tests = [
         assert.areEqual(a, undefined);
         assert.areEqual(b, 1);
     }
+  },
+  {
+    name: "Destructuring - Empty object pattern inside call node is a valid syntax",
+    body: function () {
+        function f() {
+            ({} = []).Symbol.interator();
+            eval("");
+        };
+    }
+  },
+  {
+    name: "Destructuring - Place holder slots for pattern are accounted when undeferred.",
+    body: function () {
+        function foo({a}) {
+            function x() {}
+            eval('');
+        }
+        foo({});
+        function foo1(...[b]) {
+            function x() {}
+            eval('');
+        }
+        foo1([]);
+    }
   }
 ];
 


### PR DESCRIPTION
The IsArgument optimization code did not handle the pattern nodes. Added
'cases' for those nop. This happens when we try to find out the
'arguments' usage from a parse node. Here in this case we have an empty pattern and this leads to the assert.
We have place holder slots for destructuring patterns - however when we
generate the scopeinfo for deferred function we didn't account that piece
of information. Fixed that by using the same counter (earlier used for same name args place holder) and increment that for destructuring patterns.
Added unittest for those.
