### PR TITLE
SIMD.js Bugfix: IRBuilder Register allocation in Asm.js

### DIFF
--- a/lib/Backend/IRBuilderAsmJs.h
+++ b/lib/Backend/IRBuilderAsmJs.h
@@ -84,6 +84,7 @@ private:
     Js::RegSlot             GetRegSlotFromSimd128Reg(Js::RegSlot srcSimd128Reg);
     IR::Instr *             AddExtendedArg(IR::RegOpnd *src1, IR::RegOpnd *src2, uint32 offset);
     BOOL                    RegIsSimd128Var(Js::RegSlot reg);
+    bool                    RegIsSimd128ReturnVar(Js::RegSlot reg);
     SymID                   GetMappedTemp(Js::RegSlot reg);
     void                    SetMappedTemp(Js::RegSlot reg, SymID tempId);
     BOOL                    GetTempUsed(Js::RegSlot reg);

--- a/lib/Runtime/ByteCode/AsmJsByteCodeDumper.cpp
+++ b/lib/Runtime/ByteCode/AsmJsByteCodeDumper.cpp
@@ -1092,7 +1092,7 @@ namespace Js
     void AsmJsByteCodeDumper::DumpFloat1Float32x4_1Int1(OpCodeAsmJs op, const unaligned T * data, FunctionBody * dumpFunction, ByteCodeReader& reader)
     {
         DumpFloatReg(data->F0);
-        DumpInt32x4Reg(data->F4_1);
+        DumpFloat32x4Reg(data->F4_1);
         DumpIntReg(data->I2);
     }
 
@@ -1148,28 +1148,28 @@ namespace Js
     void AsmJsByteCodeDumper::DumpInt32x4_1Int16x8_1(OpCodeAsmJs op, const unaligned T * data, FunctionBody * dumpFunction, ByteCodeReader& reader)
     {
         DumpInt32x4Reg(data->I4_0);
-        DumpFloat32x4Reg(data->I8_1);
+        DumpInt16x8Reg(data->I8_1);
     }
 
     template <class T>
     void AsmJsByteCodeDumper::DumpInt32x4_1Uint16x8_1(OpCodeAsmJs op, const unaligned T * data, FunctionBody * dumpFunction, ByteCodeReader& reader)
     {
         DumpInt32x4Reg(data->I4_0);
-        DumpFloat32x4Reg(data->U8_1);
+        DumpUint16x8Reg(data->U8_1);
     }
 
     template <class T>
     void AsmJsByteCodeDumper::DumpInt32x4_1Int8x16_1(OpCodeAsmJs op, const unaligned T * data, FunctionBody * dumpFunction, ByteCodeReader& reader)
     {
         DumpInt32x4Reg(data->I4_0);
-        DumpFloat32x4Reg(data->I16_1);
+        DumpInt8x16Reg(data->I16_1);
     }
 
     template <class T>
     void AsmJsByteCodeDumper::DumpInt32x4_1Uint8x16_1(OpCodeAsmJs op, const unaligned T * data, FunctionBody * dumpFunction, ByteCodeReader& reader)
     {
         DumpInt32x4Reg(data->I4_0);
-        DumpFloat32x4Reg(data->U16_1);
+        DumpUint8x16Reg(data->U16_1);
     }
 
 
@@ -1179,7 +1179,7 @@ namespace Js
     template <class T>
     void AsmJsByteCodeDumper::DumpBool32x4_1Int4(OpCodeAsmJs op, const unaligned T * data, FunctionBody * dumpFunction, ByteCodeReader& reader)
     {
-        DumpInt32x4Reg(data->B4_0);
+        DumpBool32x4Reg(data->B4_0);
         DumpIntReg(data->I1);
         DumpIntReg(data->I2);
         DumpIntReg(data->I3);
@@ -1196,8 +1196,8 @@ namespace Js
     template <class T>
     void AsmJsByteCodeDumper::DumpBool32x4_2Int2(OpCodeAsmJs op, const unaligned T * data, FunctionBody * dumpFunction, ByteCodeReader& reader)
     {
-        DumpInt32x4Reg(data->B4_0);
-        DumpInt32x4Reg(data->B4_1);
+        DumpBool32x4Reg(data->B4_0);
+        DumpBool32x4Reg(data->B4_1);
         DumpIntReg(data->I2);
         DumpIntReg(data->I3);
     }
@@ -1206,7 +1206,7 @@ namespace Js
     void AsmJsByteCodeDumper::DumpInt1Bool32x4_1Int1(OpCodeAsmJs op, const unaligned T * data, FunctionBody * dumpFunction, ByteCodeReader& reader)
     {
         DumpIntReg(data->I0);
-        DumpInt32x4Reg(data->B4_1);
+        DumpBool32x4Reg(data->B4_1);
         DumpIntReg(data->I2);
     }
 
@@ -1229,14 +1229,14 @@ namespace Js
     void AsmJsByteCodeDumper::DumpReg1Bool32x4_1(OpCodeAsmJs op, const unaligned T * data, FunctionBody * dumpFunction, ByteCodeReader& reader)
     {
         DumpReg(data->R0);
-        DumpInt32x4Reg(data->B4_1);
+        DumpBool32x4Reg(data->B4_1);
     }
 
     // Bool16x8
     template <class T>
     void AsmJsByteCodeDumper::DumpBool16x8_1Int8(OpCodeAsmJs op, const unaligned T * data, FunctionBody * dumpFunction, ByteCodeReader& reader)
     {
-        DumpInt32x4Reg(data->B8_0);
+        DumpBool16x8Reg(data->B8_0);
         DumpIntReg(data->I1);
         DumpIntReg(data->I2);
         DumpIntReg(data->I3);
@@ -1251,14 +1251,14 @@ namespace Js
     void AsmJsByteCodeDumper::DumpInt1Bool16x8_1(OpCodeAsmJs op, const unaligned T * data, FunctionBody * dumpFunction, ByteCodeReader& reader)
     {
         DumpIntReg(data->I0);
-        DumpBool8x16Reg(data->B8_1);
+        DumpBool16x8Reg(data->B8_1);
     }
 
     template <class T>
     void AsmJsByteCodeDumper::DumpBool16x8_2Int2(OpCodeAsmJs op, const unaligned T * data, FunctionBody * dumpFunction, ByteCodeReader& reader)
     {
-        DumpInt32x4Reg(data->B8_0);
-        DumpInt32x4Reg(data->B8_1);
+        DumpBool16x8Reg(data->B8_0);
+        DumpBool16x8Reg(data->B8_1);
         DumpIntReg(data->I2);
         DumpIntReg(data->I3);
     }
@@ -1267,7 +1267,7 @@ namespace Js
     void AsmJsByteCodeDumper::DumpInt1Bool16x8_1Int1(OpCodeAsmJs op, const unaligned T * data, FunctionBody * dumpFunction, ByteCodeReader& reader)
     {
         DumpIntReg(data->I0);
-        DumpInt32x4Reg(data->B8_1);
+        DumpBool16x8Reg(data->B8_1);
         DumpIntReg(data->I2);
     }
 
@@ -1275,29 +1275,29 @@ namespace Js
     void AsmJsByteCodeDumper::DumpBool16x8_2(OpCodeAsmJs op, const unaligned T * data, FunctionBody * dumpFunction, ByteCodeReader& reader)
     {
         DumpBool16x8Reg(data->B8_0);
-        DumpBool8x16Reg(data->B8_1);
+        DumpBool16x8Reg(data->B8_1);
     }
 
     template <class T>
     void AsmJsByteCodeDumper::DumpBool16x8_3(OpCodeAsmJs op, const unaligned T * data, FunctionBody * dumpFunction, ByteCodeReader& reader)
     {
         DumpBool16x8Reg(data->B8_0);
-        DumpBool8x16Reg(data->B8_1);
-        DumpBool8x16Reg(data->B8_2);
+        DumpBool16x8Reg(data->B8_1);
+        DumpBool16x8Reg(data->B8_2);
     }
 
     template <class T>
     void AsmJsByteCodeDumper::DumpReg1Bool16x8_1(OpCodeAsmJs op, const unaligned T * data, FunctionBody * dumpFunction, ByteCodeReader& reader)
     {
         DumpReg(data->R0);
-        DumpInt32x4Reg(data->B8_1);
+        DumpBool16x8Reg(data->B8_1);
     }
 
     // Bool8x16
     template <class T>
     void AsmJsByteCodeDumper::DumpBool8x16_1Int16(OpCodeAsmJs op, const unaligned T * data, FunctionBody * dumpFunction, ByteCodeReader& reader)
     {
-        DumpInt32x4Reg(data->B16_0);
+        DumpBool8x16Reg(data->B16_0);
         DumpIntReg(data->I1);
         DumpIntReg(data->I2);
         DumpIntReg(data->I3);
@@ -1326,8 +1326,8 @@ namespace Js
     template <class T>
     void AsmJsByteCodeDumper::DumpBool8x16_2Int2(OpCodeAsmJs op, const unaligned T * data, FunctionBody * dumpFunction, ByteCodeReader& reader)
     {
-        DumpInt32x4Reg(data->B16_0);
-        DumpInt32x4Reg(data->B16_1);
+        DumpBool8x16Reg(data->B16_0);
+        DumpBool8x16Reg(data->B16_1);
         DumpIntReg(data->I2);
         DumpIntReg(data->I3);
     }
@@ -1336,7 +1336,7 @@ namespace Js
     void AsmJsByteCodeDumper::DumpInt1Bool8x16_1Int1(OpCodeAsmJs op, const unaligned T * data, FunctionBody * dumpFunction, ByteCodeReader& reader)
     {
         DumpIntReg(data->I0);
-        DumpInt32x4Reg(data->B16_1);
+        DumpBool8x16Reg(data->B16_1);
         DumpIntReg(data->I2);
     }
 
@@ -1359,7 +1359,7 @@ namespace Js
     void AsmJsByteCodeDumper::DumpReg1Bool8x16_1(OpCodeAsmJs op, const unaligned T * data, FunctionBody * dumpFunction, ByteCodeReader& reader)
     {
         DumpReg(data->R0);
-        DumpInt32x4Reg(data->B16_1);
+        DumpBool8x16Reg(data->B16_1);
     }
 
     // Int8x16
@@ -1373,9 +1373,9 @@ namespace Js
     template <class T>
     void AsmJsByteCodeDumper::DumpInt8x16_3(OpCodeAsmJs op, const unaligned T * data, FunctionBody * dumpFunction, ByteCodeReader& reader)
     {
-        DumpInt32x4Reg(data->I16_0);
-        DumpInt32x4Reg(data->I16_1);
-        DumpInt32x4Reg(data->I16_2);
+        DumpInt8x16Reg(data->I16_0);
+        DumpInt8x16Reg(data->I16_1);
+        DumpInt8x16Reg(data->I16_2);
     }
 
     template <class T>
@@ -1403,9 +1403,9 @@ namespace Js
     template <class T>
     void AsmJsByteCodeDumper::DumpInt8x16_3Int16(OpCodeAsmJs op, const unaligned T * data, FunctionBody * dumpFunction, ByteCodeReader& reader)
     {
-        DumpUint8x16Reg(data->I16_0);
-        DumpUint8x16Reg(data->I16_1);
-        DumpUint8x16Reg(data->I16_2);
+        DumpInt8x16Reg(data->I16_0);
+        DumpInt8x16Reg(data->I16_1);
+        DumpInt8x16Reg(data->I16_2);
         DumpIntReg(data->I3);
         DumpIntReg(data->I4);
         DumpIntReg(data->I5);
@@ -1427,8 +1427,8 @@ namespace Js
     template <class T>
     void AsmJsByteCodeDumper::DumpInt8x16_2Int16(OpCodeAsmJs op, const unaligned T * data, FunctionBody * dumpFunction, ByteCodeReader& reader)
     {
-        DumpUint8x16Reg(data->I16_0);
-        DumpUint8x16Reg(data->I16_1);
+        DumpInt8x16Reg(data->I16_0);
+        DumpInt8x16Reg(data->I16_1);
         DumpIntReg(data->I2);
         DumpIntReg(data->I3);
         DumpIntReg(data->I4);
@@ -1450,18 +1450,18 @@ namespace Js
     template <class T>
     void AsmJsByteCodeDumper::DumpBool8x16_1Int8x16_2(OpCodeAsmJs op, const unaligned T * data, FunctionBody * dumpFunction, ByteCodeReader& reader)
     {
-        DumpBool16x8Reg(data->B16_0);
-        DumpInt16x8Reg(data->I16_1);
-        DumpInt16x8Reg(data->I16_2);
+        DumpBool8x16Reg(data->B16_0);
+        DumpInt8x16Reg(data->I16_1);
+        DumpInt8x16Reg(data->I16_2);
     }
 
     template <class T>
     void AsmJsByteCodeDumper::DumpInt8x16_1Bool8x16_1Int8x16_2(OpCodeAsmJs op, const unaligned T * data, FunctionBody * dumpFunction, ByteCodeReader& reader)
     {
-        DumpInt16x8Reg(data->I16_0);
-        DumpBool16x8Reg(data->B16_1);
-        DumpInt16x8Reg(data->I16_2);
-        DumpInt16x8Reg(data->I16_3);
+        DumpInt8x16Reg(data->I16_0);
+        DumpBool8x16Reg(data->B16_1);
+        DumpInt8x16Reg(data->I16_2);
+        DumpInt8x16Reg(data->I16_3);
     }
 
     template <class T>
@@ -1830,8 +1830,8 @@ namespace Js
     template <class T>
     void AsmJsByteCodeDumper::DumpUint32x4_2(OpCodeAsmJs op, const unaligned T * data, FunctionBody * dumpFunction, ByteCodeReader& reader)
     {
-        DumpInt32x4Reg(data->U4_0);
-        DumpInt32x4Reg(data->U4_1);
+        DumpUint32x4Reg(data->U4_0);
+        DumpUint32x4Reg(data->U4_1);
     }
 
     template <class T>
@@ -2310,7 +2310,7 @@ namespace Js
     template <class T>
     void AsmJsByteCodeDumper::DumpBool32x4_1Int1(OpCodeAsmJs op, const unaligned T * data, FunctionBody * dumpFunction, ByteCodeReader& reader)
     {
-        DumpInt16x8Reg(data->B4_0);
+        DumpBool32x4Reg(data->B4_0);
         DumpIntReg(data->I1);
     }
 
@@ -2318,7 +2318,7 @@ namespace Js
     template <class T>
     void AsmJsByteCodeDumper::DumpBool16x8_1Int1(OpCodeAsmJs op, const unaligned T * data, FunctionBody * dumpFunction, ByteCodeReader& reader)
     {
-        DumpInt16x8Reg(data->B8_0);
+        DumpBool16x8Reg(data->B8_0);
         DumpIntReg(data->I1);
     }
 
@@ -2326,7 +2326,7 @@ namespace Js
     template <class T>
     void AsmJsByteCodeDumper::DumpBool8x16_1Int1(OpCodeAsmJs op, const unaligned T * data, FunctionBody * dumpFunction, ByteCodeReader& reader)
     {
-        DumpInt16x8Reg(data->B16_0);
+        DumpBool8x16Reg(data->B16_0);
         DumpIntReg(data->I1);
     }
     

--- a/test/SIMD.float32x4.asmjs/testCalls.js
+++ b/test/SIMD.float32x4.asmjs/testCalls.js
@@ -67,7 +67,6 @@ function asmModule(stdlib, imports) {
     var gval2 = 1234.0;
 
 
-    
     var loopCOUNT = 3;
 
     function func1(a, i, b, count)
@@ -167,8 +166,28 @@ function asmModule(stdlib, imports) {
 
         return +ret;
     }
-    
-    return {func1:func1, func2:func2, func3:func3, func4:func4, /*func5:func5, func6:func6*/};
+
+    function fctest(a)
+    {
+        a = i4check(a);
+        return a;
+    }
+    function fcBug_1()
+    {
+        var x = f4(-1.0, -2.0, -3.0, -4.0);
+        var k = i4(-1, -2, -3, -4);
+        k = i4check(fctest(k));
+        return f4check(x);
+    }
+    function fcBug_2()
+    {
+        var x = f4(-1.0, -2.0, -3.0, -4.0);
+        var k = i4(-1, -2, -3, -4);
+        x = f4check(fcBug_1());
+        return i4check(k);
+    }
+
+    return {func1:func1, func2:func2, func3:func3, func4:func4, fcBug1:fcBug_1, fcBug2:fcBug_2};
 }
 
 var m = asmModule(this, {g1:SIMD.Float32x4(90934.2,123.9,419.39,449.0), g2:SIMD.Int32x4(-1065353216, -1073741824,-1077936128, -1082130432)});
@@ -194,4 +213,11 @@ equalSimd([8.000000,16.000000,24.000000,32.000000], c, SIMD.Float32x4, "func1");
 
 c = m.func4();
 equalSimd([301.000000,301.000000,301.000000,301.000000], c, SIMD.Float32x4, "func1");
+
+c = m.fcBug1();
+equalSimd([-1, -2, -3, -4], c, SIMD.Float32x4, 'fcBug1');
+
+c = m.fcBug2();
+equalSimd([-1, -2, -3, -4], c, SIMD.Int32x4, 'fcBug2');
+
 WScript.Echo("PASS");

--- a/test/SIMD.float32x4.asmjs/testMisc.js
+++ b/test/SIMD.float32x4.asmjs/testMisc.js
@@ -130,9 +130,16 @@ function asmModule(stdlib, imports) {
 
         return f4check(f4reciprocalSqrtApproximation(b));
     }
-    
-    
-    return {func1:func1, func2:func2};
+
+    function bug1() //simd tmp reg reuse.
+    {
+        var a = i4(1,2,3,4);
+        var x = f4(-1.0, -2.0, -3.0, -4.0);
+        f4add(x,x);
+        return i4check(a);
+    }
+
+    return {func1:func1, func2:func2, bug1:bug1};
 }
 
 var m = asmModule(this, {g1:SIMD.Float32x4(90934.2,123.9,419.39,449.0), g2:SIMD.Int32x4(-1065353216, -1073741824,-1077936128, -1082130432)});
@@ -143,6 +150,9 @@ equalSimd([0.00019868074741680175, 0.00000470933673568652, 0.0015029908390715718
 
 c = m.func2();
 equalSimd([0.01409541629254818, 0.002170100575312972, 0.038768425583839416, 0.003906280267983675], c, SIMD.Float32x4, "func2")
+
+c = m.bug1();
+equalSimd([1,2,3,4], c, SIMD.Int32x4, "bug1")
 
 
 print("PASS");

--- a/test/SIMD.int16x8.asmjs/testCalls.js
+++ b/test/SIMD.int16x8.asmjs/testCalls.js
@@ -5,9 +5,9 @@
 this.WScript.LoadScriptFile("..\\UnitTestFramework\\SimdJsHelpers.js");
 function asmModule(stdlib, imports) {
     "use asm";
-    /*
     var i4 = stdlib.SIMD.Int32x4;
     var i4check = i4.check;
+    /*
     var i4splat = i4.splat;
     
     var i4fromFloat32x4 = i4.fromFloat32x4;
@@ -179,8 +179,28 @@ function asmModule(stdlib, imports) {
 
         return +ret;
     }
-    
-    return {func1:func1, func2:func2, func3:func3, func4:func4/*, func5:func5, func6:func6*/};
+
+    function fctest(a)
+    {
+        a = i8check(a);
+        return a;
+    }
+    function fcBug_1()
+    {
+        var x = i4(-1, -2, -3, -4);
+        var k = i8(1, 2, 3, 4, 5, 6, 7, 8);
+        k = i8check(fctest(k));
+        return i4check(x);
+    }
+    function fcBug_2()
+    {
+        var x = i4(-1, -2, -3, -4);
+        var k = i8(1, 2, 3, 4, 5, 6, 7, 8);
+        x = i4check(fcBug_1());
+        return i8check(k);
+    }
+
+    return {func1:func1, func2:func2, func3:func3, func4:func4, fcBug_2:fcBug_2, fcBug_1:fcBug_1/*, func5:func5, func6:func6*/};
 }
 
 var m = asmModule(this, {g1:SIMD.Float32x4(90934.2,123.9,419.39,449.0), g2:SIMD.Int16x8(-1065353216, -1073741824,-1077936128, -1082130432, -1065353216, -1073741824,-1077936128, -1082130432)});
@@ -198,6 +218,8 @@ var ret1 = m.func1(s1, s2);
 var ret2 = m.func2(s1, s2, s3, s4);
 var ret3 = m.func3(s1, s2, s3, s4, s5, s6, s7, s8);
 var ret4 = m.func4();
+var c1 = m.fcBug_1();
+var c2 = m.fcBug_2();
 
 
 /* printSimdBaseline(ret1, "SIMD.Int16x8", "ret1", "func1");
@@ -209,6 +231,8 @@ equalSimd([0, 0, 0, 0, 0, 0, 0, 0], ret1, SIMD.Int16x8, "func1")
 equalSimd([0, 0, 0, 0, 0, 0, 0, 0], ret2, SIMD.Int16x8, "func2")
 equalSimd([0, 0, 0, 0, 0, 0, 0, 0], ret3, SIMD.Int16x8, "func3")
 equalSimd([-1, -2, -3, -4, -5, -6, -7, -8], ret4, SIMD.Int16x8, "func4")
+equalSimd([-1, -2, -3, -4], c1, SIMD.Int32x4, 'fcBug1');
+equalSimd([1, 2, 3, 4, 5, 6, 7, 8], c2, SIMD.Int16x8, 'fcBug2');
 
 print("PASS");
 

--- a/test/SIMD.int16x8.asmjs/testMisc.js
+++ b/test/SIMD.int16x8.asmjs/testMisc.js
@@ -340,11 +340,19 @@ var i4 = stdlib.SIMD.Int32x4;
             x = i8add(x, i8fromUint16x8Bits(v_u8));
             x = i8add(x, i8fromUint8x16Bits(v_u16));
         }
-
         return i8check(x);
     }
 
-    return {func1:func1, func2: func2, func3:func3, func4:func4, func5: func5, func6:func6, func7:func7, func8:func8};
+    function bug1() //simd tmp reg reuse.
+    {
+        var a = i4(1,2,3,4);
+        var x = i8(-1, -2, -3, -4,-1, -2, -3, -4);
+        i8add(x,x);
+        return i4check(a);
+    }
+
+    return {func1:func1, func2: func2, func3:func3, func4:func4,
+            func5: func5, func6:func6, func7:func7, func8:func8, bug1:bug1};
 }
 
 var buffer = new ArrayBuffer(0x10000);
@@ -386,6 +394,11 @@ equalSimd([10, 20, 30, 40, -10, -20, -30, -40], ret7, SIMD.Int16x8, "func7");
 var ret8 = m.func8(v1, v2, v3, v1, v2);
 //printSimdBaseline(ret8, "SIMD.Int16x8", "ret8", "func8");
 equalSimd([-1159, -23736, 29089, 32006, -10305, 16232, -32693, -28368], ret8, SIMD.Int16x8, "func8")
+
+ret8 = m.bug1();
+//printSimdBaseline(ret8, "SIMD.Int16x8", "ret8", "func8");
+equalSimd([1,2,3,4], ret8, SIMD.Int32x4, "bug1")
+
 
 print("PASS");
 

--- a/test/SIMD.int32x4.asmjs/testCalls.js
+++ b/test/SIMD.int32x4.asmjs/testCalls.js
@@ -31,6 +31,8 @@ function asmModule(stdlib, imports) {
     //var i4shiftLeftByScalar = i4.shiftLeftByScalar;
     //var i4shiftRightByScalar = i4.shiftRightByScalar;
     //var i4shiftRightArithmeticByScalar = i4.shiftRightArithmeticByScalar;
+    var i16 = stdlib.SIMD.Int8x16;
+    var i16check = i16.check;
 
     var f4 = stdlib.SIMD.Float32x4;  
     var f4check = f4.check;
@@ -174,8 +176,28 @@ function asmModule(stdlib, imports) {
 
         return +ret;
     }
-    
-    return {func1:func1, func2:func2, func3:func3, func4:func4/*, func5:func5, func6:func6*/};
+
+    function fctest(a)
+    {
+        a = i16check(a);
+        return a;
+    }
+    function fcBug_1()
+    {
+        var x = i4(-1, -2, -3, -4);
+        var k = i16(1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+        k = i16check(fctest(k));
+        return i4check(x);
+    }
+    function fcBug_2()
+    {
+        var x = i4(-1, -2, -3, -4);
+        var k = i16(1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+        x = i4check(fcBug_1());
+        return i16check(k);
+    }
+
+    return {func1:func1, func2:func2, func3:func3, func4:func4, fcBug_2:fcBug_2, fcBug_1:fcBug_1};
 }
 
 var m = asmModule(this, {g1:SIMD.Float32x4(90934.2,123.9,419.39,449.0), g2:SIMD.Int32x4(-1065353216, -1073741824,-1077936128, -1082130432)});
@@ -193,11 +215,16 @@ var ret1 = m.func1(s1, s2);
 var ret2 = m.func2(s1, s2, s3, s4);
 var ret3 = m.func3(s1, s2, s3, s4, s5, s6, s7, s8);
 var ret4 = m.func4();
+var ret5 = m.fcBug_1();
+var ret6 = m.fcBug_2();
 
 
 equalSimd([2, 4, 6, 8], ret1, SIMD.Int32x4, "TestCalls");
 equalSimd([4, 8, 12, 16], ret2, SIMD.Int32x4, "TestCalls");
 equalSimd([8, 16, 24, 32], ret3, SIMD.Int32x4, "TestCalls");
 equalSimd([301, 301, 301, 301], ret4, SIMD.Int32x4, "TestCalls");
+equalSimd([-1, -2, -3, -4], ret5, SIMD.Int32x4, "testBug1");
+equalSimd([1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8], ret6, SIMD.Int8x16, "testBug1");
+
 print("PASS");
 

--- a/test/SIMD.int32x4.asmjs/testMisc.js
+++ b/test/SIMD.int32x4.asmjs/testMisc.js
@@ -106,15 +106,25 @@ var i4 = stdlib.SIMD.Int32x4;
 
         return i4check(d);
     }
-    
-    
-    
-    return {func1:func1};
+
+    function bug1() //simd tmp reg reuse.
+    {
+        var a = f4(1.0, 2.0, 3.0, 4.0);
+        var x = i4(-1, -2, -3, -4);
+        i4add(x,x);
+        return f4check(a);
+    }
+
+    return {func1:func1, bug1:bug1};
 }
 
 var m = asmModule(this, {g1:SIMD.Float32x4(90934.2,123.9,419.39,449.0), g2:SIMD.Int32x4(-1065353216, -1073741824,-1077936128, -1082130432)});
 var r = m.func1();
 equalSimd([-136732, 424688, -2277748, 131068], r, SIMD.Int32x4, "func1");
 //printSimdBaseline(r, "SIMD.Int32x4", "r", "func1");
+
+var r = m.bug1();
+equalSimd([1.0,2.0,3.0,4.0], r, SIMD.Float32x4, "bug1");
+//printSimdBaseline(r, "SIMD.Float32x4", "r", "bug1");
 
 print("PASS");

--- a/test/SIMD.int8x16.asmjs/testCalls.js
+++ b/test/SIMD.int8x16.asmjs/testCalls.js
@@ -179,8 +179,28 @@ function asmModule(stdlib, imports) {
 
         return +ret;
     }
-    
-    return {func1:func1, func2:func2, func3:func3, func4:func4/*, func5:func5, func6:func6*/};
+
+    function fctest(a)
+    {
+        a = i16check(a);
+        return a;
+    }
+    function fcBug_1()
+    {
+        var x = f4(-1.0, -2.0, -3.0, -4.0);
+        var k = i16(1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+        k = i16check(fctest(k));
+        return f4check(x);
+    }
+    function fcBug_2()
+    {
+        var x = f4(-1.0, -2.0, -3.0, -4.0);
+        var k = i16(1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+        x = f4check(fcBug_1());
+        return i16check(k);
+    }
+
+    return {func1:func1, func2:func2, func3:func3, func4:func4, func5:fcBug_1, func6:fcBug_2};
 }
 
 var m = asmModule(this, {g1:SIMD.Float32x4(90934.2,123.9,419.39,449.0), g2:SIMD.Int8x16(-106535326, -73741824,-10776128, -10130432, -10653536, -10741824,-1077928, -12130432, 106535326, 73741824,10776128, 10130432, 10653536, 10741824,1077928, 12130432)});
@@ -200,12 +220,16 @@ var ret1 = m.func1(s1, s2);
 var ret2 = m.func2(s1, s2, s3, s4);
 var ret3 = m.func3(s1, s2, s3, s4, s5, s6, s7, s8);
 var ret4 = m.func4();
+var ret5 = m.func5();
+var ret6 = m.func6();
 
 
 equalSimd([98, 0, -64, 0, -96, -64, 88, -128, -98, 0, 64, 0, 96, 64, -88, -128], ret1, SIMD.Int8x16, "func1")
 equalSimd([98, 0, -64, 0, -96, -64, 88, -128, -98, 0, 64, 0, 96, 64, -88, -128], ret2, SIMD.Int8x16, "func2")
 equalSimd([98, 0, -64, 0, -96, -64, 88, -128, -98, 0, 64, 0, 96, 64, -88, -128], ret3, SIMD.Int8x16, "func3")
 equalSimd([-1, -2, -3, -4, -5, -6, -7, -8, 0, 1, 2, 3, -4, -5, -6, -7], ret4, SIMD.Int8x16, "func4")
+equalSimd([-1.0, -2.0, -3.0, -4.0], ret5, SIMD.Float32x4, "func5 - Bug1")
+equalSimd([1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8], ret6, SIMD.Int8x16, "func6 - Bug1")
 
 
 // printSimdBaseline(ret1, "SIMD.Int8x16", "ret1", "func1");

--- a/test/SIMD.int8x16.asmjs/testMisc.js
+++ b/test/SIMD.int8x16.asmjs/testMisc.js
@@ -364,7 +364,16 @@ var i4 = stdlib.SIMD.Int32x4;
         return i16check(x);
     }
 
-    return {func1:func1, func2: func2, func3:func3, func4:func4, func5: func5, func6:func6, func7:func7, func8:func8};
+    function bug1() //simd tmp reg reuse.
+    {
+        var a = i4(1,2,3,4);
+        var x = i16(-1, -2, -3, -4,-1, -2, -3, -4, -1, -2, -3, -4,-1, -2, -3, -4);
+        i16add(x,x);
+        return i4check(a);
+    }
+
+    return {func1:func1, func2: func2, func3:func3, func4:func4,
+            func5: func5, func6:func6, func7:func7, func8:func8, bug1:bug1};
 }
 
 var buffer = new ArrayBuffer(0x10000);
@@ -404,7 +413,10 @@ var ret7 = m.func7(v1, v2, v3, v1, v2);
 
 var ret8 = m.func8(v1, v2, v3, v1, v2);
 // printSimdBaseline(ret8, "SIMD.Int8x16", "ret8", "func8");
-// 
+
+var ret9 = m.bug1();
+// printSimdBaseline(ret9, "SIMD.Int32x4", "ret9", "bug1");
+
 equal(-1410, ret1);
 equalSimd([1, 2, 3, 4, 3, 4, 5, 6, 1, 6, 0, 4, 6, 1, 4, 0], ret2, SIMD.Int8x16, "func2")
 equalSimd([0, 1, 1, 1, 3, 3, 3, 3, 1, 3, 1, 1, 0, 0, 0, 0], ret3, SIMD.Int8x16, "func3")
@@ -413,6 +425,7 @@ equalSimd([36, -23, 41, -92, 89, 16, 1, 0, 36, -23, 41, -92, 89, 16, 1, 0], ret5
 equalSimd([47, -128, -107, -128, -5, -6, -23, -128, 47, -128, -107, -128, -5, -6, -23, -128], ret6, SIMD.Int8x16, "func6")
 equalSimd([10, 20, 30, -10, -10, -20, -30, -40, -96, -16, 64, -102, 76, -14, -118, -10], ret7, SIMD.Int8x16, "func7")
 equalSimd([121, -38, -37, 77, 17, -12, 29, -102, -30, -40, -112, -99, 86, -17, -57, -79], ret8, SIMD.Int8x16, "func8")
+equalSimd([1, 2, 3, 4], ret9, SIMD.Int32x4, "bug1")
 
 print("PASS");
 

--- a/test/SIMD.uint16x8.asmjs/testCalls.js
+++ b/test/SIMD.uint16x8.asmjs/testCalls.js
@@ -67,7 +67,8 @@ function asmModule(stdlib, imports) {
     var f4xor = f4.xor;
     var f4not = f4.not;
 
-    
+    var u16 = stdlib.SIMD.Uint8x16;
+    var u16check = u16.check;
 
 
     var fround = stdlib.Math.fround;
@@ -181,8 +182,28 @@ function asmModule(stdlib, imports) {
 
         return +ret;
     }
-    
-    return {func1:func1, func2:func2, func3:func3, func4:func4/*, func5:func5, func6:func6*/};
+
+    function fctest(a)
+    {
+        a = u16check(a);
+        return a;
+    }
+    function fcBug_1()
+    {
+        var x = u8(1, 2, 3, 4, 5, 6, 7, 8);
+        var k = u16(1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+        k = u16check(fctest(k));
+        return u8check(x);
+    }
+    function fcBug_2()
+    {
+        var x = u8(1, 2, 3, 4, 5, 6, 7, 8);
+        var k = u16(1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+        x = u8check(fcBug_1());
+        return u16check(k);
+    }
+
+    return {func1:func1, func2:func2, func3:func3, func4:func4, func5:fcBug_1, func6:fcBug_2};
 }
 
 var m = asmModule(this, {g1:SIMD.Float32x4(90934.2,123.9,419.39,449.0), g2:SIMD.Uint16x8(-1065353216, -1073741824,-1077936128, -1082130432, -1065353216, -1073741824,-1077936128, -1082130432)});
@@ -200,12 +221,15 @@ var ret1 = m.func1(s1, s2);
 var ret2 = m.func2(s1, s2, s3, s4);
 var ret3 = m.func3(s1, s2, s3, s4, s5, s6, s7, s8);
 var ret4 = m.func4();
+var ret5 = m.func5();
+var ret6 = m.func6();
 
 equalSimd([0, 0, 0, 0, 0, 0, 0, 0], ret1, SIMD.Uint16x8, "func1")
 equalSimd([0, 0, 0, 0, 0, 0, 0, 0], ret2, SIMD.Uint16x8, "func2")
 equalSimd([0, 0, 0, 0, 0, 0, 0, 0], ret3, SIMD.Uint16x8, "func3")
 equalSimd([65535, 65534, 65533, 65532, 65531, 65530, 65529, 65528], ret4, SIMD.Uint16x8, "func4")
-
+equalSimd([1, 2, 3, 4, 5, 6, 7, 8], ret5, SIMD.Uint16x8, "func5 - Bug1")
+equalSimd([1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8], ret6, SIMD.Uint8x16, "func6 - Bug1")
 
 /* printSimdBaseline(ret1, "SIMD.Uint16x8", "ret1", "func1");
 printSimdBaseline(ret2, "SIMD.Uint16x8", "ret2", "func2");

--- a/test/SIMD.uint16x8.asmjs/testMisc.js
+++ b/test/SIMD.uint16x8.asmjs/testMisc.js
@@ -343,11 +343,19 @@ var i4 = stdlib.SIMD.Int32x4;
             x = u8add(x, u8fromUint32x4Bits(v_u4));
             x = u8add(x, u8fromUint8x16Bits(v_u16));
         }
-
         return u8check(x);
     }
 
-    return {func1:func1, func2: func2, func3:func3, func4:func4, func5: func5, func6:func6, func7:func7, func8:func8};
+    function bug1() //simd tmp reg reuse.
+    {
+        var a = i4(1,2,3,4);
+        var x = u8(-1, -2, -3, -4,-1, -2, -3, -4);
+        u8add(x,x);
+        return i4check(a);
+    }
+    
+    return {func1:func1, func2: func2, func3:func3, func4:func4,
+            func5: func5, func6:func6, func7:func7, func8:func8, bug1:bug1};
 }
 
 var buffer = new ArrayBuffer(0x10000);
@@ -388,6 +396,9 @@ var ret7 = m.func7(v1, v2, v3, v1, v2);
 var ret8 = m.func8(v1, v2, v3, v1, v2);
 //printSimdBaseline(ret8, "SIMD.Uint16x8", "ret8", "func8");
 
+var ret9 = m.bug1();
+//printSimdBaseline(ret9, "SIMD.Uint16x8", "ret9", "bug1");
+
 equal(627954, ret1);
 equalSimd([1, 2, 3, 3, 3, 4, 1, 0], ret2, SIMD.Uint16x8, "func2")
 equalSimd([200, 2, 2, 2, 2, 2, 2, 2], ret3, SIMD.Uint16x8, "func3")
@@ -396,6 +407,7 @@ equalSimd([17956, 44521, 45353, 47012, 27225, 65040, 1, 57600], ret5, SIMD.Uint1
 equalSimd([0, 0, 0, 0, 0, 0, 0, 0], ret6, SIMD.Uint16x8, "func6")
 equalSimd([10, 20, 30, 40, 65526, 65516, 65506, 65496], ret7, SIMD.Uint16x8, "func7")
 equalSimd([64377, 41800, 29089, 32006, 55231, 16232, 32843, 37168], ret8, SIMD.Uint16x8, "func8")
+equalSimd([1, 2, 3, 4], ret9, SIMD.Int32x4, "bug1")
 
 print("PASS");
 

--- a/test/SIMD.uint32x4.asmjs/testCalls.js
+++ b/test/SIMD.uint32x4.asmjs/testCalls.js
@@ -5,11 +5,10 @@
 this.WScript.LoadScriptFile("..\\UnitTestFramework\\SimdJsHelpers.js");
 function asmModule(stdlib, imports) {
     "use asm";
-    /*
+
     var i4 = stdlib.SIMD.Int32x4;
     var i4check = i4.check;
-    var i4splat = i4.splat;
-    
+    /*
     var i4fromFloat32x4 = i4.fromFloat32x4;
     var i4fromFloat32x4Bits = i4.fromFloat32x4Bits;
     //var i4abs = i4.abs;
@@ -181,8 +180,28 @@ function asmModule(stdlib, imports) {
 
         return +ret;
     }
-    
-    return {func1:func1, func2:func2, func3:func3, func4:func4/*, func5:func5, func6:func6*/};
+
+    function fctest(a)
+    {
+        a = u4check(a);
+        return a;
+    }
+    function fcBug_1()
+    {
+        var x = i4(1, 2, 3, 4);
+        var k = u4(1, 2, 3, 4);
+        k = u4check(fctest(k));
+        return i4check(x);
+    }
+    function fcBug_2()
+    {
+        var x = i4(1, 2, 3, 4);
+        var k = u4(1, 2, 3, 4);
+        x = i4check(fcBug_1());
+        return u4check(k);
+    }
+
+    return {func1:func1, func2:func2, func3:func3, func4:func4, func5:fcBug_1, func6:fcBug_2};
 }
 
 var m = asmModule(this, {g1:SIMD.Float32x4(90934.2,123.9,419.39,449.0), g2:SIMD.Uint32x4(-1065353216, -1073741824,-1077936128, -1082130432)});
@@ -200,6 +219,8 @@ var ret1 = m.func1(s1, s2);
 var ret2 = m.func2(s1, s2, s3, s4);
 var ret3 = m.func3(s1, s2, s3, s4, s5, s6, s7, s8);
 var ret4 = m.func4();
+var ret5 = m.func5();
+var ret6 = m.func6();
 
 /*
 printSimdBaseline(ret1, "SIMD.Uint32x4", "ret1", "func1");
@@ -211,6 +232,8 @@ equalSimd([3229614080, 3221225472, 3217031168, 3212836864], ret1, SIMD.Uint32x4,
 equalSimd([3229614080, 3221225472, 3217031168, 3212836864], ret2, SIMD.Uint32x4, "func2")
 equalSimd([3229614080, 3221225472, 3217031168, 3212836864], ret3, SIMD.Uint32x4, "func3")
 equalSimd([4294967295, 4294967294, 4294967293, 4294967292], ret4, SIMD.Uint32x4, "func4")
+equalSimd([1,2,3,4], ret5, SIMD.Int32x4, "func5 - Bug1")
+equalSimd([1,2,3,4], ret6, SIMD.Uint32x4, "func6 - Bug1")
 
 
 

--- a/test/SIMD.uint32x4.asmjs/testMisc.js
+++ b/test/SIMD.uint32x4.asmjs/testMisc.js
@@ -361,7 +361,15 @@ function asmModule(stdlib, imports,buffer) {
         x = u4add(x, y);
         return u4check(y);
     }
-    
+
+    function bug1() //simd tmp reg reuse.
+    {
+        var a = i4(1,2,3,4);
+        var x = u4(-1, -2, -3, -4);
+        u4add(x,x);
+        return i4check(a);
+    }
+
     function func8()
     {
         var loopIndex = 0;
@@ -390,7 +398,9 @@ function asmModule(stdlib, imports,buffer) {
         return u4check(x);
     }
 
-    return {func1:func1, func2: func2, func3:func3, func4:func4, func5: func5, func6:func6, func7:func7, func8:func8};
+    return {func1:func1, func2: func2, func3:func3, func4:func4, 
+            func5: func5, func6:func6, func7:func7, func8:func8,
+            bug1:bug1};
 }
 
 var buffer = new ArrayBuffer(0x10000);
@@ -424,6 +434,9 @@ var ret7 = m.func7(v1, v2, v3, v1, v2);
 var ret8 = m.func8(v1, v2, v3, v1, v2);
 //printSimdBaseline(ret8, "SIMD.Uint32x4", "ret8", "func8");
 
+var ret9 = m.bug1();
+//printSimdBaseline(ret9, "SIMD.Uint32x4", "ret9", "bug1");
+
 
 equal(-11826, ret1);
 equalSimd([1, 2, 1, 2], ret2, SIMD.Uint32x4, "func2")
@@ -433,6 +446,7 @@ equalSimd([17956, 44521, 4294836225, 3804422400], ret5, SIMD.Uint32x4, "func5")
 equalSimd([0, 0, 0, 0], ret6, SIMD.Uint32x4, "func6")
 equalSimd([40, 60, 4294967236, 4294967256], ret7, SIMD.Uint32x4, "func7")
 equalSimd([2741894009, 2100523531, 3103445833, 2451472428], ret8, SIMD.Uint32x4, "func8")
+equalSimd([1,2,3,4], ret9, SIMD.Int32x4, "bug1")
 
 print("PASS");
 

--- a/test/SIMD.uint8x16.asmjs/testCalls.js
+++ b/test/SIMD.uint8x16.asmjs/testCalls.js
@@ -180,8 +180,28 @@ function asmModule(stdlib, imports) {
 
         return +ret;
     }
-    
-    return {func1:func1, func2:func2, func3:func3, func4:func4/*, func5:func5, func6:func6*/};
+
+    function fctest(a)
+    {
+        a = u16check(a);
+        return a;
+    }
+    function fcBug_1()
+    {
+        var x = f4(-1.0, -2.0, -3.0, -4.0);
+        var k = u16(1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+        k = u16check(fctest(k));
+        return f4check(x);
+    }
+    function fcBug_2()
+    {
+        var x = f4(-1.0, -2.0, -3.0, -4.0);
+        var k = u16(1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
+        x = f4check(fcBug_1());
+        return u16check(k);
+    }
+
+    return {func1:func1, func2:func2, func3:func3, func4:func4, func5:fcBug_1, func6:fcBug_2};
 }
 
 var m = asmModule(this, {g1:SIMD.Float32x4(90934.2,123.9,419.39,449.0), g2:SIMD.Uint8x16(-106535326, -73741824,-10776128, -10130432, -10653536, -10741824,-1077928, -12130432, 106535326, 73741824,10776128, 10130432, 10653536, 10741824,1077928, 12130432)});
@@ -201,12 +221,16 @@ var ret1 = m.func1(s1, s2);
 var ret2 = m.func2(s1, s2, s3, s4);
 var ret3 = m.func3(s1, s2, s3, s4, s5, s6, s7, s8);
 var ret4 = m.func4();
+var ret5 = m.func5();
+var ret6 = m.func6();
 
 
 equalSimd([98, 0, 192, 0, 160, 192, 88, 128, 158, 0, 64, 0, 96, 64, 168, 128], ret1, SIMD.Uint8x16, "func1")
 equalSimd([98, 0, 192, 0, 160, 192, 88, 128, 158, 0, 64, 0, 96, 64, 168, 128], ret2, SIMD.Uint8x16, "func2")
 equalSimd([98, 0, 192, 0, 160, 192, 88, 128, 158, 0, 64, 0, 96, 64, 168, 128], ret3, SIMD.Uint8x16, "func3")
 equalSimd([255, 254, 253, 252, 251, 250, 249, 248, 0, 1, 2, 3, 252, 251, 250, 249], ret4, SIMD.Uint8x16, "func4")
+equalSimd([-1.0, -2.0, -3.0, -4.0], ret5, SIMD.Float32x4, "func5 - Bug1")
+equalSimd([1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8], ret6, SIMD.Uint8x16, "func6 - Bug1")
 
 /*
 printSimdBaseline(ret1, "SIMD.Uint8x16", "ret1", "func1");

--- a/test/SIMD.uint8x16.asmjs/testMisc.js
+++ b/test/SIMD.uint8x16.asmjs/testMisc.js
@@ -367,7 +367,16 @@ var i4 = stdlib.SIMD.Int32x4;
         return u16check(x);
     }
 
-    return {func1:func1, func2: func2, func3:func3, func4:func4, func5: func5, func6:func6, func7:func7, func8:func8};
+    function bug1() //simd tmp reg reuse.
+    {
+        var a = i4(1,2,3,4);
+        var x = u16(-1, -2, -3, -4,-1, -2, -3, -4,-1, -2, -3, -4,-1, -2, -3, -4);
+        u16add(x,x);
+        return i4check(a);
+    }
+
+    return {func1:func1, func2: func2, func3:func3, func4:func4, func5: func5, 
+            func6:func6, func7:func7, func8:func8, bug1:bug1};
 }
 
 var buffer = new ArrayBuffer(0x10000);
@@ -408,6 +417,9 @@ var ret7 = m.func7(v1, v2, v3, v1, v2);
 var ret8 = m.func8(v1, v2, v3, v1, v2);
 //printSimdBaseline(ret8, "SIMD.Uint8x16", "ret8", "func8");
 
+var ret9 = m.bug1();
+//printSimdBaseline(ret9, "SIMD.Int8x16", "ret9", "bug1");
+
 equal(3966, ret1);
 equalSimd([1, 2, 3, 4, 3, 4, 5, 6, 1, 6, 0, 4, 6, 1, 4, 0], ret2, SIMD.Uint8x16, "func2")
 equalSimd([200, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2], ret3, SIMD.Uint8x16, "func3")
@@ -416,7 +428,7 @@ equalSimd([36, 233, 41, 164, 89, 16, 1, 0, 36, 233, 41, 164, 89, 16, 1, 0], ret5
 equalSimd([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], ret6, SIMD.Uint8x16, "func6")
 equalSimd([10, 20, 30, 246, 246, 236, 226, 216, 160, 240, 64, 154, 76, 242, 138, 246], ret7, SIMD.Uint8x16, "func7")
 equalSimd([121, 218, 219, 77, 17, 244, 29, 154, 226, 216, 144, 157, 86, 239, 199, 177], ret8, SIMD.Uint8x16, "func8")
-
+equalSimd([1,2,3,4], ret9, SIMD.Int32x4, "bug1")
 print("PASS");
 
 


### PR DESCRIPTION
1. Type assertion while reusing function retrun registers for SIMD values.
2. Incorrect reuse of unused simd temp registers.
3. Incorrect destination register type for simd conversion operations.


Fixes: #865, #866 and  #867 