### PR TITLE
MSFT: 7334254

### DIFF
--- a/lib/Runtime/Language/SourceTextModuleRecord.h
+++ b/lib/Runtime/Language/SourceTextModuleRecord.h
@@ -11,7 +11,7 @@ namespace Js
     typedef JsUtil::BaseDictionary<SourceTextModuleRecord*, SourceTextModuleRecord*, ArenaAllocator, PowerOf2SizePolicy> ParentModuleRecordSet;
     typedef JsUtil::BaseDictionary<PropertyId, uint, ArenaAllocator, PowerOf2SizePolicy> LocalExportMap;
     typedef JsUtil::BaseDictionary<PropertyId, ModuleNameRecord, ArenaAllocator, PowerOf2SizePolicy> ResolvedExportMap;
-    typedef JsUtil::List<PropertyId> LocalExportIndexList;
+    typedef JsUtil::List<PropertyId, ArenaAllocator> LocalExportIndexList;
 
     class SourceTextModuleRecord : public ModuleRecordBase
     {
@@ -108,8 +108,6 @@ namespace Js
         ExportedNames* exportedNames;
         ResolvedExportMap* resolvedExportMap;
 
-        TempArenaAllocatorObject* tempAllocatorObject;
-
         Js::JavascriptFunction* rootFunction;
         void* hostDefined;
         Var errorObject;
@@ -118,7 +116,6 @@ namespace Js
         uint localSlotCount;
         uint moduleId;
 
-        ArenaAllocator* EnsureTempAllocator();
         HRESULT PostParseProcess();
         HRESULT PrepareForModuleDeclarationInitialization();
         void ImportModuleListsFromParser();


### PR DESCRIPTION
I wanted to use recycler temp allocator because we can have shorter lifetime for different objects in
moduleRecord than the scriptContext. At it turned out we need to keep various helper structures alive
longer due to debugger reparsing of source code, and the module will be kept alive by the JavascriptLibrary
anyhow. Recycler tempallocator is not designed to be used for this long period. Change it to use the
general arena allocator.
