### PR TITLE
Fix encoding int const encoding always as 64-bit. Choose the right cookie according to its type.

### DIFF
--- a/lib/Backend/Security.cpp
+++ b/lib/Backend/Security.cpp
@@ -285,12 +285,7 @@ Security::EncodeOpnd(IR::Instr *instr, IR::Opnd *opnd)
             instr->UnlinkSrc1();
         }
 
-#ifdef _M_X64
-        addrOpnd->SetEncodedValue((Js::Var)this->EncodeAddress(instr, addrOpnd, (size_t)addrOpnd->m_address, &newOpnd), addrOpnd->GetAddrOpndKind());
-#else
-
         addrOpnd->SetEncodedValue((Js::Var)this->EncodeValue(instr, addrOpnd, (IntConstType)addrOpnd->m_address, &newOpnd), addrOpnd->GetAddrOpndKind());
-#endif
     }
     break;
 


### PR DESCRIPTION
Current when int constant is saved in AddrOpnd as AddrOpndConstant.The constant encryption phase creates 64 bits cookie for it even if the source operand is in 32, but it only saves the lower 32-bit to the original operand as encryption result. The extended cookie (64-bit) promotes the CMP instruction to use 64-bit operands, then got incorrect result since because the full 64 bit value cannot be recovered by the lower 32-bit encrypted constant.