### PR TITLE
Fixing an issue with class definition in the param scope

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -3536,7 +3536,7 @@ void ByteCodeGenerator::MapReferencedPropertyIds(FuncInfo * funcInfo)
 #endif
 }
 
-void ByteCodeGenerator::EmitScopeList(ParseNode *pnode, bool breakOnNonFunc)
+void ByteCodeGenerator::EmitScopeList(ParseNode *pnode, ParseNode *breakOnBodyScopeNode)
 {
     while (pnode)
     {
@@ -3581,7 +3581,7 @@ void ByteCodeGenerator::EmitScopeList(ParseNode *pnode, bool breakOnNonFunc)
 
                     // While emitting the functions we have to stop when we see the body scope block.
                     // Otherwise functions defined in the body scope will not be able to get the right references.
-                    this->EmitScopeList(paramBlock->sxBlock.pnodeScopes, true);
+                    this->EmitScopeList(paramBlock->sxBlock.pnodeScopes, pnode->sxFnc.pnodeBodyScope);
                     Assert(this->GetCurrentScope() == paramScope);
                 }
 
@@ -3641,7 +3641,7 @@ void ByteCodeGenerator::EmitScopeList(ParseNode *pnode, bool breakOnNonFunc)
             break;
         }
 
-        if (breakOnNonFunc && pnode && pnode->nop != knopFncDecl)
+        if (breakOnBodyScopeNode != nullptr && breakOnBodyScopeNode == pnode)
         {
             break;
         }

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -3024,7 +3024,7 @@ void AddFunctionsToScope(ParseNodePtr scope, ByteCodeGenerator * byteCodeGenerat
 
 template <class PrefixFn, class PostfixFn>
 void VisitNestedScopes(ParseNode* pnodeScopeList, ParseNode* pnodeParent, ByteCodeGenerator* byteCodeGenerator,
-    PrefixFn prefix, PostfixFn postfix, uint *pIndex, bool breakOnNonFnc = false)
+    PrefixFn prefix, PostfixFn postfix, uint *pIndex, bool breakOnBodyScope = false)
 {
     // Visit all scopes nested in this scope before visiting this function's statements. This way we have all the
     // attributes of all the inner functions before we assign registers within this function.
@@ -3251,7 +3251,7 @@ void VisitNestedScopes(ParseNode* pnodeScopeList, ParseNode* pnodeParent, ByteCo
             return;
         }
 
-        if (breakOnNonFnc && pnodeScope->nop != knopFncDecl)
+        if (breakOnBodyScope && pnodeScope == pnodeParent->sxFnc.pnodeBodyScope)
         {
             break;
         }

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.h
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.h
@@ -284,7 +284,7 @@ public:
 
     void DefineLabels(FuncInfo *funcInfo);
     void EmitProgram(ParseNode *pnodeProg);
-    void EmitScopeList(ParseNode *pnode, bool breakOnNonFunc = false);
+    void EmitScopeList(ParseNode *pnode, ParseNode *breakOnBodyScopeNode = nullptr);
     void EmitDefaultArgs(FuncInfo *funcInfo, ParseNode *pnode);
     void EmitOneFunction(ParseNode *pnode);
     void EmitGlobalFncDeclInit(Js::RegSlot rhsLocation, Js::PropertyId propertyId, FuncInfo * funcInfo);

--- a/test/es6/default-splitscope.js
+++ b/test/es6/default-splitscope.js
@@ -250,7 +250,7 @@ var tests = [
     } 
   },
   { 
-    name: "Split parameter scope in class methods", 
+    name: "Split parameter scope and class", 
     body: function () { 
         class c { 
             f(a = 10, d, b = function () { return a; }, c) { 
@@ -315,7 +315,53 @@ var tests = [
                 return y; 
             } 
         } 
-        assert.areEqual(10, (new c4()).f({})(), "The method defined as the default destructured value of the parameter should capture the formal from the param scope"); 
+        assert.areEqual(10, (new c4()).f({})(), "The method defined as the default destructured value of the parameter should capture the formal from the param scope");
+        
+        function f3(a = 10, d, b = (function () { return a; }, class { method1() { return a; } }), c) { 
+            var a = 20; 
+            assert.areEqual(10, (new b()).method1(), "Class method defined within the param scope should capture the formal from the param scope"); 
+            return b; 
+        } 
+        result = f3(); 
+        assert.areEqual(10, (new result()).method1(), "Methods defined in a class defined, after another function definition, in the param scope should capture the formals form that param scope itself"); 
+        
+        function f4(a = 10, d, b = (function () { return a; }, class {}, class { method1() { return a; } }), c) { 
+            var a = 20; 
+            return b; 
+        } 
+        result = f4(); 
+        assert.areEqual(10, (new result()).method1(), "Methods defined in a class defined, after another class definition, in the param scope should capture the formals form that param scope itself");
+         
+        function f5(a = 10, d, b = (function () { return a; }, class {}, function () {}, class { method1() { return a; } }), c) { 
+            var a = 20; 
+            return b; 
+        } 
+        result = f5(); 
+        assert.areEqual(10, (new result()).method1(), "Methods defined in a class defined, after a function and class, in the param scope should capture the formals form that param scope itself");
+        
+        function f6(a = 10, d, b = (function () { return a; }, class {}, function (a, b = () => a) {}, class { method1() { return a; } }), c) { 
+            var a = 20; 
+            return b; 
+        } 
+        result = f6(); 
+        assert.areEqual(10, (new result()).method1(), "Methods defined in a class defined, after a split scope function, in the param scope should capture the formals form that param scope itself");
+        
+        function f7(a = 10, d, b = (function () { return a; }, class c1 { method1() { return a; } }), c) { 
+            var a = 20; 
+            assert.areEqual(10, (new b()).method1(), "Class method defined within the param scope should capture the formal from the param scope"); 
+            return b; 
+        } 
+        result = f7(); 
+        assert.areEqual(10, (new result()).method1(), "Methods defined in a class with name defined, after another function definition, in the param scope should capture the formals form that param scope itself");
+        
+        function f8(a = 10, d, b = class c1 { method1() { return a; } }, c = (function () { return a; }, class c2 extends b { method2() { return a * a; } })) { 
+            var a = 20; 
+            assert.areEqual(10, (new b()).method1(), "Class method defined within the param scope should capture the formal from the param scope"); 
+            return c; 
+        } 
+        result = f8(); 
+        assert.areEqual(10, (new result()).method1(), "Methods defined in a class extending another class defined, after another function definition, in the param scope should capture the formals form that param scope itself");
+        assert.areEqual(100, (new result()).method2(), "Method in the derived class returns the right value");
     } 
   },
   { 


### PR DESCRIPTION
When visiting the pnodescopes I had a check to avoid visiting the body scope as part of the param scope. The condition I was using for the check does not seem to cover all scenarios. This changelist fixes that issue.
