### PR TITLE
Fix 7019631: Check whether a Proxy object is anywhere in the prototype chain before choosing to do the optimized ToPropertyDescriptor for non-Proxy objects.

### DIFF
--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -8670,6 +8670,7 @@ CommonNumber:
 
         return true;
     }
+
     BOOL JavascriptOperators::ToPropertyDescriptorForProxyObjects(Var propertySpec, PropertyDescriptor* descriptor, ScriptContext* scriptContext)
     {
         if (!JavascriptOperators::IsObject(propertySpec))
@@ -8815,7 +8816,8 @@ CommonNumber:
 
     BOOL JavascriptOperators::ToPropertyDescriptor(Var propertySpec, PropertyDescriptor* descriptor, ScriptContext* scriptContext)
     {
-        if (JavascriptProxy::Is(propertySpec))
+        if (JavascriptProxy::Is(propertySpec) ||
+            JavascriptOperators::CheckIfPrototypeChainContainsProxyObject(RecyclableObject::FromVar(propertySpec)->GetPrototype()))
         {
             if (ToPropertyDescriptorForProxyObjects(propertySpec, descriptor, scriptContext) == FALSE)
             {
@@ -9953,15 +9955,12 @@ CommonNumber:
         return !Equal(aLeft, aRight, scriptContext);
     }
 
-
     // NotStrictEqual() returns whether the two vars have strict equality, as
     // described in (ES3.0: S11.9.5, S11.9.6).
-
     BOOL JavascriptOperators::NotStrictEqual(Var aLeft, Var aRight, ScriptContext* scriptContext)
     {
         return !StrictEqual(aLeft, aRight, scriptContext);
     }
-
 
     bool JavascriptOperators::CheckIfObjectAndPrototypeChainHasOnlyWritableDataProperties(RecyclableObject* object)
     {
@@ -10031,6 +10030,24 @@ CommonNumber:
         }
 
         return true;
+    }
+
+    bool JavascriptOperators::CheckIfPrototypeChainContainsProxyObject(RecyclableObject* prototype)
+    {
+        Assert(JavascriptOperators::IsObjectOrNull(prototype));
+
+        if (prototype->GetTypeId() == TypeIds_Null)
+        {
+            return false;
+        }
+        else if (prototype->GetTypeId() == TypeIds_Proxy)
+        {
+            return true;
+        }
+        else
+        {
+            return CheckIfPrototypeChainContainsProxyObject(prototype->GetPrototype());
+        }
     }
 
     BOOL JavascriptOperators::Equal(Var aLeft, Var aRight, ScriptContext* scriptContext)

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -10032,22 +10032,23 @@ CommonNumber:
         return true;
     }
 
+    // Checks to see if the specified object (which should be a prototype object)
+    // contains a proxy anywhere in the prototype chain.
     bool JavascriptOperators::CheckIfPrototypeChainContainsProxyObject(RecyclableObject* prototype)
     {
         Assert(JavascriptOperators::IsObjectOrNull(prototype));
 
-        if (prototype->GetTypeId() == TypeIds_Null)
+        while (prototype->GetTypeId() != TypeIds_Null)
         {
-            return false;
+            if (prototype->GetTypeId() == TypeIds_Proxy)
+            {
+                return true;
+            }
+
+            prototype = prototype->GetPrototype();
         }
-        else if (prototype->GetTypeId() == TypeIds_Proxy)
-        {
-            return true;
-        }
-        else
-        {
-            return CheckIfPrototypeChainContainsProxyObject(prototype->GetPrototype());
-        }
+
+        return false;
     }
 
     BOOL JavascriptOperators::Equal(Var aLeft, Var aRight, ScriptContext* scriptContext)

--- a/lib/Runtime/Language/JavascriptOperators.h
+++ b/lib/Runtime/Language/JavascriptOperators.h
@@ -538,6 +538,7 @@ namespace Js
         static bool CheckIfObjectAndPrototypeChainHasOnlyWritableDataProperties(RecyclableObject* object);
         static bool CheckIfPrototypeChainHasOnlyWritableDataProperties(RecyclableObject* prototype);
         static bool DoCheckIfPrototypeChainHasOnlyWritableDataProperties(RecyclableObject* prototype);
+        static bool CheckIfPrototypeChainContainsProxyObject(RecyclableObject* prototype);
         static void OP_SetComputedNameVar(Var method, Var computedNameVar);
         static void OP_SetHomeObj(Var method, Var homeObj);
         static Var OP_LdSuper(Var scriptFunction, ScriptContext * scriptContext);

--- a/test/es6/proxyprotobug.baseline
+++ b/test/es6/proxyprotobug.baseline
@@ -1,0 +1,21 @@
+has enumerable
+get enumerable
+has configurable
+get configurable
+has value
+get value
+has writable
+get writable
+has get
+has set
+======================
+has enumerable
+get enumerable
+has configurable
+get configurable
+has value
+get value
+has writable
+get writable
+has get
+has set

--- a/test/es6/proxyprotobug.js
+++ b/test/es6/proxyprotobug.js
@@ -1,0 +1,29 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+var proxyHandler = {
+    has(p, n) {
+        WScript.Echo("has " + n);
+        return !(n === "get" || n === "set");
+    },
+    get(p, n) {
+        WScript.Echo("get " + n);
+        if (n == "get" || n == "set") {
+            return () => 1;
+        } else {
+            return 1;
+        }
+    }
+};
+
+var p = new Proxy({}, proxyHandler);
+var o = {};
+Object.defineProperty(o, "x", p);
+
+WScript.Echo("======================");
+
+var pp = {};
+pp.__proto__ = p;
+Object.defineProperty(o, "y", pp);

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -684,6 +684,12 @@
   </test>
   <test>
     <default>
+      <files>proxyprotobug.js</files>
+      <baseline>proxyprotobug.baseline</baseline>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>proxyenumbug.js</files>
       <compile-flags>-args summary -endargs</compile-flags>
     </default>


### PR DESCRIPTION
See: https://tc39.github.io/ecma262/2016/#sec-topropertydescriptor

---

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/886)
<!-- Reviewable:end -->
