### PR TITLE
Simd.js: Truncate F32 before bound check in SIMD.Uint32x4.fromFloat32x4

### DIFF
--- a/lib/Backend/LowerMDSharedSimd128.cpp
+++ b/lib/Backend/LowerMDSharedSimd128.cpp
@@ -2690,12 +2690,12 @@ IR::Instr* LowererMD::Simd128LowerUint32x4FromFloat32x4(IR::Instr *instr)
     two_31_i4_mask = IR::RegOpnd::New(TySimd128I4, m_func);
     tmp = IR::RegOpnd::New(TySimd128F4, m_func);
     tmp2 = IR::RegOpnd::New(TySimd128F4, m_func);
-    // any lanes < 0 ?
-    // CMPLTPS tmp, src, [X86_ALL_ZEROS]
+    // any lanes <= -1.0 ?
+    // CMPLEPS tmp, src, [X86_ALL_FLOAT32_NEG_ONES]
     // MOVMSKPS mask, tmp
     // CMP mask, 0
     // JNE $throwLabel
-    newInstr = IR::Instr::New(Js::OpCode::CMPLTPS, tmp, src, IR::MemRefOpnd::New((void*)&X86_ALL_ZEROS, TySimd128I4, m_func), m_func);
+    newInstr = IR::Instr::New(Js::OpCode::CMPLEPS, tmp, src, IR::MemRefOpnd::New((void*)&X86_ALL_NEG_ONES_F4, TySimd128I4, m_func), m_func);
     instr->InsertBefore(newInstr);
     Legalize(newInstr);
 

--- a/lib/Runtime/Language/SimdUint32x4Operation.cpp
+++ b/lib/Runtime/Language/SimdUint32x4Operation.cpp
@@ -47,11 +47,11 @@ namespace Js
     SIMDValue SIMDUint32x4Operation::OpFromFloat32x4(const SIMDValue& v, bool &throws)
     {
         SIMDValue result = {0};
-        const uint MIN_UINT = 0, MAX_UINT = 0xFFFFFFFF;
+        const int MIN_UINT = -1, MAX_UINT = 0xFFFFFFFF;
 
         for (int i = 0; i < 4; i++)
         {
-            if (v.f32[i] >= MIN_UINT && v.f32[i] <= MAX_UINT)
+            if (v.f32[i] > MIN_UINT && v.f32[i] <= MAX_UINT)
             {
                 result.u32[i] = (unsigned int)(v.f32[i]);
             }

--- a/lib/Runtime/Language/SimdUint32x4OperationX86X64.cpp
+++ b/lib/Runtime/Language/SimdUint32x4OperationX86X64.cpp
@@ -43,8 +43,8 @@ namespace Js
         X86SIMDValue two_31_f4, two_31_i4;
         int mask = 0;
 
-        // any lanes < 0 ?
-        temp.m128_value = _mm_cmplt_ps(v.m128_value, X86_ALL_ZEROS.m128_value);
+        // any lanes <= -1.0 ?
+        temp.m128_value = _mm_cmple_ps(v.m128_value, X86_ALL_NEG_ONES_F4.m128_value);
         mask = _mm_movemask_ps(temp.m128_value);
         // negative value are out of range, caller should throw Range Error
         if (mask)

--- a/lib/Runtime/Language/SimdUtils.h
+++ b/lib/Runtime/Language/SimdUtils.h
@@ -115,6 +115,7 @@ const _x86_SIMDValue X86_ALL_ONES_I4 = { 0x00000001, 0x00000001, 0x00000001, 0x0
 const _x86_SIMDValue X86_ALL_ONES_D2 = { 0x00000000, 0x3ff00000, 0x00000000, 0x3ff00000 }; // {1.0, 1.0}
 
 const _x86_SIMDValue X86_ALL_NEG_ONES = { 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff };
+const _x86_SIMDValue X86_ALL_NEG_ONES_F4 = { 0xBF800000, 0xBF800000, 0xBF800000, 0xBF800000 }; //-1.0, -1.0, -1.0, -1.0
 
 const _x86_SIMDValue X86_ALL_ONES_I8  = { 0x00010001, 0x00010001, 0x00010001, 0x00010001 }; // {1, 1, 1, 1, 1, 1, 1, 1}
 

--- a/test/SIMD.uint32x4.asmjs/testConversion.js
+++ b/test/SIMD.uint32x4.asmjs/testConversion.js
@@ -188,7 +188,6 @@ var m = asmModule(this, {g1:SIMD.Uint32x4(0x55, 0x55, 0x55, 0x55), g2:SIMD.Int32
 // printSimdBaseline(m.func7(SIMD.Float32x4(0.5,1.4,2.4,5.5)), "SIMD.Uint32x4", "m.func7()", "Func7");
 // printSimdBaseline(m.func8(), "SIMD.Uint32x4", "m.func8()", "Func8"); 
 
-
 var ret1 = SIMD.Uint32x4.fromInt32x4Bits(m.func1());
 var ret2 = SIMD.Uint32x4.fromInt32x4Bits(m.func2());
 var ret3 = SIMD.Uint32x4.fromInt32x4Bits(m.func3());
@@ -204,9 +203,16 @@ equalSimd([1, 2, 3, 4], ret3, SIMD.Uint32x4, "Func3")
 equalSimd([0, 0, 0, 0], ret4, SIMD.Uint32x4, "Func4")
 equalSimd([2863311530, 2863311530, 2863311530, 2863311530], ret5, SIMD.Uint32x4, "Func5")
 equalSimd([1431655765, 1431655765, 1431655765, 1431655765], ret6, SIMD.Uint32x4, "Func6")
-equalSimd([0, 1, 2, 5], ret7, SIMD.Uint32x4, "Func7")
-equalSimd([11141290, 11141290, 11141290, 11141290], ret8, SIMD.Uint32x4, "Func8")
 
+equalSimd([0, 1, 2, 5], ret7, SIMD.Uint32x4, "Func7")
+ret7 = SIMD.Uint32x4.fromInt32x4Bits(m.func7(SIMD.Float32x4(0.5,0.0,-.5,-.6)));
+equalSimd([0, 0, 0, 0], ret7, SIMD.Uint32x4, "Func7")
+ret7 = SIMD.Uint32x4.fromInt32x4Bits(m.func7(SIMD.Float32x4(-0.5, 1.0, -0.0, -0.0)));
+equalSimd([0, 1, 0, 0], ret7, SIMD.Uint32x4, "Func7");
+ret7 = SIMD.Uint32x4.fromInt32x4Bits(m.func7(SIMD.Float32x4(0.5,0.0,-.5,-.999)));
+equalSimd([0, 0, 0, 0], ret7, SIMD.Uint32x4, "Func7")
+
+equalSimd([11141290, 11141290, 11141290, 11141290], ret8, SIMD.Uint32x4, "Func8")
 
 // passing:
 
@@ -218,7 +224,6 @@ var ret7 = SIMD.Uint32x4.fromInt32x4Bits(m.func7(SIMD.Float32x4(0.5,1.4,2.4,5.5)
 var ret8 = SIMD.Uint32x4.fromInt32x4Bits(m.func7(SIMD.Float32x4(0.5,0x80000000,0x100000000 - 0x81 /*2^32 - (2^7 + 1) rounded to 2^32 - 2^8*/ ,0)));
 var ret9 = SIMD.Uint32x4.fromInt32x4Bits(m.func7(SIMD.Float32x4(-0.0, -0.0, -0.0, -0.0)));
 
-
 equalSimd([0, 1, 2, 5], ret7, SIMD.Uint32x4, "Func7_1")
 equalSimd([0, 2147483648, 4294967040, 0], ret8, SIMD.Uint32x4, "Func7_2")
 equalSimd([0, 0, 0, 0], ret9, SIMD.Uint32x4, "Func7_3")
@@ -226,20 +231,44 @@ equalSimd([0, 0, 0, 0], ret9, SIMD.Uint32x4, "Func7_3")
 // throwing
 try 
 {
+    m.func7(SIMD.Float32x4(-0.0, -NaN, -0.0, -0.0));
+    print("ERROR Func17_4");
+} catch (e)
+{
+    // PASS
+}
+try 
+{
+    m.func7(SIMD.Float32x4(-0.0, Infinity, -0.0, -0.0));
+    print("ERROR Func17_4");
+} catch (e)
+{
+    // PASS
+}
+try 
+{
+    m.func7(SIMD.Float32x4(-0.0, -Infinity, -0.0, -0.0));
+    print("ERROR Func17_4");
+} catch (e)
+{
+    // PASS
+}
+try 
+{
     m.func7(SIMD.Float32x4(-0.0, NaN, -0.0, -0.0));
     print("ERROR Func17_4");
 } catch (e)
 {
-        // PASS
+    // PASS
 }
 
 try 
 {
-    m.func7(SIMD.Float32x4(-0.5, 1.0, -0.0, -0.0));
+    m.func7(SIMD.Float32x4(-1,0.0,-.5,-.999));
     print("ERROR Func17_5");
 } catch (e)
 {
-        // PASS
+    // PASS
 }
 
 try 
@@ -248,7 +277,7 @@ try
     print("ERROR Func17_6");
 } catch (e)
 {
-        // PASS
+    // PASS
 }
 
 try 
@@ -257,10 +286,8 @@ try
     print("ERROR Func17_8");
 } catch (e)
 {
-        // PASS
+    // PASS
 }
-
-
 
 var ret = SIMD.Uint32x4.fromInt32x4Bits(m.func8());
 equalSimd([11141290, 11141290, 11141290, 11141290], ret, SIMD.Uint32x4, "Func8")


### PR DESCRIPTION
In SIMD.Uint32x4.fromFloat32x4() conversion builtin, f32 values needs
to be truncated before bound check so that only values <= -1.0 will throw
range error.

Fixes #890 