### PR TITLE
Fixing scope issues with function expressions with split scope

### DIFF
--- a/lib/Backend/IRBuilder.cpp
+++ b/lib/Backend/IRBuilder.cpp
@@ -6704,13 +6704,21 @@ IRBuilder::BuildEmpty(Js::OpCode newOpcode, uint32 offset)
                     Js::Constants::NoByteCodeOffset);
             }
 
+            IR::RegOpnd* tempRegOpnd = IR::RegOpnd::New(StackSym::New(this->m_func), TyVar, this->m_func);
             this->AddInstr(
                 IR::Instr::New(
                     Js::OpCode::LdFrameDisplay,
-                    this->BuildDstOpnd(this->m_func->GetJnFunction()->GetLocalFrameDisplayRegister()),
+                    tempRegOpnd,
                     this->BuildSrcOpnd(this->m_func->GetJnFunction()->GetLocalClosureRegister()),
                     this->BuildSrcOpnd(this->m_func->GetJnFunction()->GetLocalFrameDisplayRegister()),
-                    m_func),
+                    this->m_func),
+                Js::Constants::NoByteCodeOffset);
+            this->AddInstr(
+                IR::Instr::New(
+                    Js::OpCode::MOV,
+                    this->BuildDstOpnd(this->m_func->GetJnFunction()->GetLocalFrameDisplayRegister()),
+                    tempRegOpnd,
+                    this->m_func),
                 Js::Constants::NoByteCodeOffset);
         }
         break;

--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -3278,9 +3278,9 @@ void ByteCodeGenerator::EmitOneFunction(ParseNode *pnode)
         {
             // Emit bytecode to copy the initial values from param names to their corresponding body bindings.
             // We have to do this after the rest param is marked as false for need declaration.
-            paramScope->ForEachSymbol([this, funcInfo, paramScope, byteCodeFunction](Symbol* param) {
+            paramScope->ForEachSymbol([&](Symbol* param) {
                 Symbol* varSym = funcInfo->GetBodyScope()->FindLocalSymbol(param->GetName());
-                Assert(varSym || param->GetIsArguments());
+                Assert(varSym || param->GetIsArguments() || pnode->sxFnc.pnodeName->sxVar.sym == param);
                 Assert(param->GetIsArguments() || param->IsInSlot(funcInfo));
                 if (varSym && varSym->GetSymbolType() == STVariable && (varSym->IsInSlot(funcInfo) || varSym->GetLocation() != Js::Constants::NoRegister))
                 {
@@ -3570,22 +3570,7 @@ void ByteCodeGenerator::EmitScopeList(ParseNode *pnode, ParseNode *breakOnBodySc
                 this->StartEmitFunction(pnode);
 
                 Scope* paramScope = pnode->sxFnc.funcInfo->GetParamScope();
-                Scope* bodyScope = pnode->sxFnc.funcInfo->GetBodyScope();
 
-                if (paramScope && !paramScope->GetCanMergeWithBodyScope())
-                {
-                    ParseNodePtr paramBlock = pnode->sxFnc.pnodeScopes;
-                    Assert(paramBlock->nop == knopBlock && paramBlock->sxBlock.blockType == Parameter);
-
-                    PushScope(paramScope);
-
-                    // While emitting the functions we have to stop when we see the body scope block.
-                    // Otherwise functions defined in the body scope will not be able to get the right references.
-                    this->EmitScopeList(paramBlock->sxBlock.pnodeScopes, pnode->sxFnc.pnodeBodyScope);
-                    Assert(this->GetCurrentScope() == paramScope);
-                }
-
-                PushScope(bodyScope);
                 // Persist outer func scope info if nested func is deferred
                 if (CONFIG_FLAG(DeferNested))
                 {
@@ -3605,12 +3590,6 @@ void ByteCodeGenerator::EmitScopeList(ParseNode *pnode, ParseNode *breakOnBodySc
 
                 this->EmitOneFunction(pnode);
                 this->EndEmitFunction(pnode);
-
-                if (paramScope && !paramScope->GetCanMergeWithBodyScope())
-                {
-                    Assert(this->GetCurrentScope() == paramScope);
-                    PopScope(); // Pop the param scope
-                }
             }
             pnode = pnode->sxFnc.pnodeNext;
             break;
@@ -3768,7 +3747,14 @@ void ByteCodeGenerator::StartEmitFunction(ParseNode *pnodeFnc)
         else
         {
             Symbol *sym = funcInfo->root->sxFnc.GetFuncSymbol();
-            funcInfo->bodyScope->AddSymbol(sym);
+            if (funcInfo->paramScope->GetCanMergeWithBodyScope())
+            {
+                funcInfo->bodyScope->AddSymbol(sym);
+            }
+            else
+            {
+                funcInfo->paramScope->AddSymbol(sym);
+            }
         }
     }
 
@@ -3802,9 +3788,6 @@ void ByteCodeGenerator::StartEmitFunction(ParseNode *pnodeFnc)
                 paramScope->SetLocation(funcInfo->frameSlotsRegister);
             }
         }
-
-        bodyScope->SetMustInstantiate(funcInfo->frameObjRegister != Js::Constants::NoRegister || funcInfo->frameSlotsRegister != Js::Constants::NoRegister);
-        paramScope->SetMustInstantiate(!paramScope->GetCanMergeWithBodyScope());
 
         if (bodyScope->GetIsObject())
         {
@@ -4016,6 +3999,18 @@ void ByteCodeGenerator::StartEmitFunction(ParseNode *pnodeFnc)
                 this->EnsureLetConstScopeSlots(pnodeFnc->sxFnc.pnodeBodyScope, funcInfo);
             }
         }
+
+        if (!paramScope->GetCanMergeWithBodyScope() && bodyScope->GetScopeSlotCount() == 0 && !bodyScope->GetHasOwnLocalInClosure())
+        {
+            // When we have split scope the body scope may be wrongly marked as must instantiate even though the capture occurred
+            // in param scope. This check is to make sure if no capture occurs in body scope make in not must instantiate.
+            bodyScope->SetMustInstantiate(false);
+        }
+        else
+        {
+            bodyScope->SetMustInstantiate(funcInfo->frameObjRegister != Js::Constants::NoRegister || funcInfo->frameSlotsRegister != Js::Constants::NoRegister);
+        }
+        paramScope->SetMustInstantiate(!paramScope->GetCanMergeWithBodyScope());
     }
     else
     {
@@ -4026,6 +4021,21 @@ void ByteCodeGenerator::StartEmitFunction(ParseNode *pnodeFnc)
             Assert(bodyScope->GetIsObject());
         }
     }
+
+    if (paramScope && !paramScope->GetCanMergeWithBodyScope())
+    {
+        ParseNodePtr paramBlock = pnodeFnc->sxFnc.pnodeScopes;
+        Assert(paramBlock->nop == knopBlock && paramBlock->sxBlock.blockType == Parameter);
+
+        PushScope(paramScope);
+
+        // While emitting the functions we have to stop when we see the body scope block.
+        // Otherwise functions defined in the body scope will not be able to get the right references.
+        this->EmitScopeList(paramBlock->sxBlock.pnodeScopes, pnodeFnc->sxFnc.pnodeBodyScope);
+        Assert(this->GetCurrentScope() == paramScope);
+    }
+
+    PushScope(bodyScope);
 }
 
 void ByteCodeGenerator::EmitModuleExportAccess(Symbol* sym, Js::OpCode opcode, Js::RegSlot location, FuncInfo* funcInfo)
@@ -4150,6 +4160,13 @@ void ByteCodeGenerator::EndEmitFunction(ParseNode *pnodeFnc)
     PopScope(); // function body
 
     FuncInfo *funcInfo = pnodeFnc->sxFnc.funcInfo;
+
+    Scope* paramScope = funcInfo->paramScope;
+    if (paramScope && !paramScope->GetCanMergeWithBodyScope())
+    {
+        Assert(this->GetCurrentScope() == paramScope);
+        PopScope(); // Pop the param scope
+    }
 
     Scope *scope = funcInfo->funcExprScope;
     if (scope && scope->GetMustInstantiate())

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -998,14 +998,9 @@ void ByteCodeGenerator::RestoreScopeInfo(Js::FunctionBody* functionBody)
                 bodyScope = Anew(alloc, Scope, alloc, ScopeType_FunctionBody, true);
             }
         }
+        bodyScope->SetHasOwnLocalInClosure(scopeInfo->GetHasOwnLocalInClosure());
 
         FuncInfo* func = Anew(alloc, FuncInfo, functionBody->GetDisplayName(), alloc, paramScope, bodyScope, nullptr, functionBody);
-
-        if (paramScope != nullptr)
-        {
-            paramScope->SetFunc(func);
-            paramScopeInfo->GetScopeInfo(nullptr, this, func, paramScope);
-        }
 
         if (bodyScope->GetScopeType() == ScopeType_GlobalEvalBlock)
         {
@@ -1032,6 +1027,12 @@ void ByteCodeGenerator::RestoreScopeInfo(Js::FunctionBody* functionBody)
             funcExprScopeInfo->GetScopeInfo(nullptr, this, func, funcExprScope);
         }
 
+        // Restore the param scope after the function expression scope
+        if (paramScope != nullptr)
+        {
+            paramScope->SetFunc(func);
+            paramScopeInfo->GetScopeInfo(nullptr, this, func, paramScope);
+        }
         scopeInfo->GetScopeInfo(nullptr, this, func, bodyScope);
     }
     else

--- a/lib/Runtime/ByteCode/Scope.cpp
+++ b/lib/Runtime/ByteCode/Scope.cpp
@@ -16,6 +16,8 @@ bool Scope::IsBlockScope(FuncInfo *funcInfo)
 
 void Scope::SetHasLocalInClosure(bool has)
 {
+    SetHasOwnLocalInClosure(has);
+
     // (Note: if any catch var is closure-captured, we won't merge the catch scope with the function scope.
     // So don't mark the function scope "has local in closure".)
     bool notCatch = this->scopeType != ScopeType_Catch && this->scopeType != ScopeType_CatchParamPattern;

--- a/lib/Runtime/ByteCode/Scope.h
+++ b/lib/Runtime/ByteCode/Scope.h
@@ -38,6 +38,7 @@ private:
     BYTE hasCrossScopeFuncAssignment : 1;
     BYTE hasDuplicateFormals : 1;
     BYTE canMergeWithBodyScope : 1;
+    BYTE hasLocalInClosure : 1;
 public:
 #if DBG
     BYTE isRestored : 1;
@@ -54,6 +55,7 @@ public:
         hasCrossScopeFuncAssignment(false),
         hasDuplicateFormals(false),
         canMergeWithBodyScope(true),
+        hasLocalInClosure(false),
         location(Js::Constants::NoRegister),
         symbolTable(nullptr),
         m_symList(nullptr),
@@ -294,6 +296,8 @@ public:
     bool GetCanMergeWithBodyScope() const { return canMergeWithBodyScope; }
 
     void SetHasLocalInClosure(bool has);
+    void SetHasOwnLocalInClosure(bool has) { hasLocalInClosure = has; }
+    bool GetHasOwnLocalInClosure() const { return hasLocalInClosure; }
 
     bool HasInnerScopeIndex() const { return innerScopeIndex != (uint)-1; }
     uint GetInnerScopeIndex() const { return innerScopeIndex; }

--- a/lib/Runtime/ByteCode/ScopeInfo.cpp
+++ b/lib/Runtime/ByteCode/ScopeInfo.cpp
@@ -68,6 +68,7 @@ namespace Js
         scopeInfo->isCached = (scope->GetFunc()->GetBodyScope() == scope) && scope->GetFunc()->GetHasCachedScope();
         scopeInfo->isGlobalEval = scope->GetScopeType() == ScopeType_GlobalEvalBlock;
         scopeInfo->canMergeWithBodyScope = scope->GetCanMergeWithBodyScope();
+        scopeInfo->hasLocalInClosure = scope->GetHasOwnLocalInClosure();
 
         TRACE_BYTECODE(_u("\nSave ScopeInfo: %s parent: %s #symbols: %d %s\n"),
             scope->GetFunc()->name, parent->GetDisplayName(), count, scopeInfo->isObject ? _u("isObject") : _u(""));
@@ -206,9 +207,16 @@ namespace Js
 #if DBG
                 if (funcInfo->GetFuncExprScope() && funcInfo->GetFuncExprScope()->GetIsObject())
                 {
-                    Assert(currentScope->GetEnclosingScope() == funcInfo->GetFuncExprScope() &&
-                        currentScope->GetEnclosingScope()->GetEnclosingScope() ==
-                        (parentFunc->IsGlobalFunction() ? parentFunc->GetGlobalEvalBlockScope() : parentFunc->GetBodyScope()));
+                    if (funcInfo->paramScope && !funcInfo->paramScope->GetCanMergeWithBodyScope())
+                    {
+                        Assert(currentScope->GetEnclosingScope()->GetEnclosingScope() == funcInfo->GetFuncExprScope());
+                    }
+                    else
+                    {
+                        Assert(currentScope->GetEnclosingScope() == funcInfo->GetFuncExprScope() &&
+                            currentScope->GetEnclosingScope()->GetEnclosingScope() ==
+                            (parentFunc->IsGlobalFunction() ? parentFunc->GetGlobalEvalBlockScope() : parentFunc->GetBodyScope()));
+                    }
                 }
                 else
                 {
@@ -262,6 +270,7 @@ namespace Js
         {
             scope->SetCannotMergeWithBodyScope();
         }
+        scope->SetHasOwnLocalInClosure(this->hasLocalInClosure);
         if (parser)
         {
             scriptContext = parser->GetScriptContext();

--- a/lib/Runtime/ByteCode/ScopeInfo.h
+++ b/lib/Runtime/ByteCode/ScopeInfo.h
@@ -41,6 +41,7 @@ namespace Js {
         BYTE isGlobalEval : 1;
         BYTE areNamesCached : 1;
         BYTE canMergeWithBodyScope : 1;
+        BYTE hasLocalInClosure : 1;
 
         Scope *scope;
         int scopeId;
@@ -49,7 +50,7 @@ namespace Js {
 
     private:
         ScopeInfo(FunctionBody * parent, int symbolCount)
-            : parent(parent), funcExprScopeInfo(nullptr), paramScopeInfo(nullptr), symbolCount(symbolCount), scope(nullptr), areNamesCached(false), canMergeWithBodyScope(true)
+            : parent(parent), funcExprScopeInfo(nullptr), paramScopeInfo(nullptr), symbolCount(symbolCount), scope(nullptr), areNamesCached(false), canMergeWithBodyScope(true), hasLocalInClosure(false)
         {
         }
 
@@ -191,6 +192,16 @@ namespace Js {
         bool GetCanMergeWithBodyScope() const
         {
             return canMergeWithBodyScope;
+        }
+
+        void SetHasLocalInClosure(bool has)
+        {
+            hasLocalInClosure = has;
+        }
+
+        bool GetHasOwnLocalInClosure() const
+        {
+            return hasLocalInClosure;
         }
 
         static void SaveScopeInfoForDeferParse(ByteCodeGenerator* byteCodeGenerator, FuncInfo* parentFunc, FuncInfo* func);

--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -1407,7 +1407,7 @@ namespace Js
             if (executeFunction->HasScopeObject())
             {
                 Js::RegSlot funcExprScopeReg = executeFunction->GetFuncExprScopeRegister();
-                if (funcExprScopeReg != Constants::NoRegister)
+                if (funcExprScopeReg != Constants::NoRegister && this->paramClosure == nullptr)
                 {
                     // t0 = NewPseudoScope
                     // t1 = LdFrameDisplay t0 env

--- a/test/es6/default-splitscope.js
+++ b/test/es6/default-splitscope.js
@@ -73,7 +73,7 @@ var tests = [
     } 
  }, 
  { 
-    name: "Split parameter scope in function expressions with name", 
+    name: "Split parameter scope and function expressions with name", 
     body: function () { 
         function f1(a = 10, b = function c() { return a; }) { 
             assert.areEqual(10, a, "Initial value of parameter in the body scope of the method should be the same as the one in param scope"); 
@@ -86,7 +86,53 @@ var tests = [
         function f2(a = 10, b = function c(recurse = true) { return recurse ? c(false) : a; }) { 
             return b; 
         } 
-        assert.areEqual(10, f2()(), "Recursive function expression defined in the param scope captures the formals from the param scope not body scope"); 
+        assert.areEqual(10, f2()(), "Recursive function expression defined in the param scope captures the formals from the param scope not body scope");
+        
+        assert.areEqual(10, f2()(), "Recursive function expression defined in the param scope captures the formals from the param scope not body scope");
+
+        var f3 = function f4 (a = function ( ) { b; return f4(20); }, b) {
+            if (a == 20) {
+                return 10;
+            }
+            return a;
+        }
+        assert.areEqual(10, f3()(), "Recursive call to the function from the param scope returns the right value");
+
+        var f5 = function f6 (a = function ( ) { b; return f6; }, b) {
+            if (a == 20) {
+                return 10;
+            }
+            return a;
+        }
+        assert.areEqual(10, f5()()(20), "Recursive call to the function from the param scope returns the right value");
+        
+        var f7 = function f8 (a = function ( ) { b; }, b) {
+            if (a == 20) {
+                return 10;
+            }
+            var a = function () { return f8(20); };
+            return a;
+        }
+        assert.areEqual(10, f7()(), "Recursive call to the function from the body scope returns the right value");
+        
+        var f9 = function f10 (a = function ( ) { b; return f10(20); }, b) {
+            eval("");
+            if (a == 20) {
+                return 10;
+            }
+            return a;
+        }
+        assert.areEqual(10, f9()(), "Recursive call to the function from the param scope returns the right value when eval is there in the body");
+        
+        var f11 = function f12 (a = function ( ) { b; }, b) {
+            eval("");
+            if (a == 20) {
+                return 10;
+            }
+            var a = function () { return f12(20); };
+            return a;
+        }
+        assert.areEqual(10, f11()(), "Recursive call to the function from the body scope returns the right value when eval is there in the body");
     } 
  }, 
  { 


### PR DESCRIPTION
This change fixes multiple issues with using function expression symbols in split scope.

One issue was if the function expression is not captured and has not eval
then we were adding the function expression symbol to body scope. In split
scope case I changed it to add to the param scope. But we don't have to
duplicate the function expression name symbol in the body.

Function expression should be pop out only after taking out the param scope. Another issue was while creating the new frame display during BeginBodyScope we have to skip the function expression.

In split scope the body scope was always getting marked as must
instantiate even though no closure was there in the body scope. I added a
new flag to the scope object to mark whether a closure is there.
