### PR TITLE
Disable switch opts upon loop body rejit

### DIFF
--- a/lib/Backend/BailOut.cpp
+++ b/lib/Backend/BailOut.cpp
@@ -2295,10 +2295,12 @@ void BailOutRecord::ScheduleLoopBodyCodeGen(Js::ScriptFunction * function, Js::S
                 break;
 
             case IR::BailOutExpectingInteger:
+                profileInfo->DisableSwitchOpt();
                 rejitReason = RejitReason::DisableSwitchOptExpectingInteger;
                 break;
 
             case IR::BailOutExpectingString:
+                profileInfo->DisableSwitchOpt();
                 rejitReason = RejitReason::DisableSwitchOptExpectingString;
                 break;
 

--- a/lib/Backend/BailOut.cpp
+++ b/lib/Backend/BailOut.cpp
@@ -1984,13 +1984,27 @@ void BailOutRecord::ScheduleFunctionCodeGen(Js::ScriptFunction * function, Js::S
                 break;
 
             case IR::BailOutExpectingInteger:
-                profileInfo->DisableSwitchOpt();
-                rejitReason = RejitReason::DisableSwitchOptExpectingInteger;
+                if (profileInfo->IsSwitchOptDisabled())
+                {
+                    reThunk = true;
+                }
+                else
+                {
+                    profileInfo->DisableSwitchOpt();
+                    rejitReason = RejitReason::DisableSwitchOptExpectingInteger;
+                }
                 break;
 
             case IR::BailOutExpectingString:
-                profileInfo->DisableSwitchOpt();
-                rejitReason = RejitReason::DisableSwitchOptExpectingString;
+                if (profileInfo->IsSwitchOptDisabled())
+                {
+                    reThunk = true;
+                }
+                else
+                {
+                    profileInfo->DisableSwitchOpt();
+                    rejitReason = RejitReason::DisableSwitchOptExpectingString;
+                }
                 break;
 
             case IR::BailOutOnFailedPolymorphicInlineTypeCheck:
@@ -2296,11 +2310,13 @@ void BailOutRecord::ScheduleLoopBodyCodeGen(Js::ScriptFunction * function, Js::S
 
             case IR::BailOutExpectingInteger:
                 profileInfo->DisableSwitchOpt();
+                executeFunction->SetDontRethunkAfterBailout();
                 rejitReason = RejitReason::DisableSwitchOptExpectingInteger;
                 break;
 
             case IR::BailOutExpectingString:
                 profileInfo->DisableSwitchOpt();
+                executeFunction->SetDontRethunkAfterBailout();
                 rejitReason = RejitReason::DisableSwitchOptExpectingString;
                 break;
 

--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -567,7 +567,7 @@ PHASE(All)
 #endif
 #define DEFAULT_CONFIG_BailOnNoProfileLimit    200      // The limit of bailout on no profile info before triggering a rejit
 #define DEFAULT_CONFIG_BailOnNoProfileRejitLimit (-1)   // The limit of bailout on no profile info before disable all the no profile bailouts
-#define DEFAULT_CONFIG_RejitRatioLimit 5                // Ratio of function calls to bailouts on a single bailout record
+#define DEFAULT_CONFIG_CallsToBailoutsRatioForRejit 5   // Ratio of function calls to bailouts on a single bailout record
                                                         // above which a rejit is considered
 #define DEFAULT_CONFIG_MinBailOutsBeforeRejit 2         // Minimum number of bailouts for a single bailout record after which a rejit is considered
 #define DEFAULT_CONFIG_RejitMaxBailOutCount 500         // Maximum number of bailouts for a single bailout record after which rejit is forced.
@@ -1127,7 +1127,7 @@ FLAGNR(Boolean, ProfileBailOutRecordMemory, "Profile bailout record memory stati
 #endif
 
 FLAGNR(Number,  RejitMaxBailOutCount, "Maximum number of bailouts for a bailout record after which rejit is forced", DEFAULT_CONFIG_RejitMaxBailOutCount)
-FLAGNR(Number,  RejitRatioLimit,     "Rejit ratio (Percentage of bailouts per function after which rejit is queued)", DEFAULT_CONFIG_RejitRatioLimit)
+FLAGNR(Number,  CallsToBailoutsRatioForRejit, "Ratio of function calls to bailouts on a single bailout record above which a rejit is considered", DEFAULT_CONFIG_CallsToBailoutsRatioForRejit)
 FLAGNR(Number,  MinBailOutsBeforeRejit, "Minimum number of bailouts for a single bailout record after which a rejit is considered", DEFAULT_CONFIG_MinBailOutsBeforeRejit)
 
 FLAGNR(Boolean, LibraryStackFrame           , "Display library stack frame", DEFAULT_CONFIG_LibraryStackFrame)

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -941,7 +941,7 @@ namespace Js
     public:
         static const uint8 GetDecrCallCountPerBailout()
         {
-            return (100 / (uint8)CONFIG_FLAG(RejitRatioLimit)) + 1;
+            return (100 / (uint8)CONFIG_FLAG(CallsToBailoutsRatioForRejit)) + 1;
         }
 
         FunctionEntryPointInfo(FunctionProxy * functionInfo, void * address, ThreadContext* context, void* validationCookie);


### PR DESCRIPTION
Disable switch opts when we rejit a loop body owing to a switch opts bailout (We already do this for function rejits).

Also, rename RejitRatioLimit to the more accurate CallsToBailoutsRatioForRejit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/895)
<!-- Reviewable:end -->
