### PR TITLE
SIMD.js: Restrict simd args and returns from Asm.js functions to signed

### DIFF
--- a/lib/Runtime/Language/AsmJsByteCodeGenerator.cpp
+++ b/lib/Runtime/Language/AsmJsByteCodeGenerator.cpp
@@ -883,7 +883,6 @@ namespace Js
                 retType = AsmJsRetType::Float64x2;
             }
 #endif // 0
-
             else if (info.type.isSubType(AsmJsType::Int16x8))
             {
                 CheckNodeLocation(info, AsmJsSIMDValue);
@@ -899,30 +898,6 @@ namespace Js
                 mFunction->ReleaseLocation<AsmJsSIMDValue>(&info);
                 emitInfo.type = AsmJsType::Int8x16;
                 retType = AsmJsRetType::Int8x16;
-            }
-            else if (info.type.isSubType(AsmJsType::Uint32x4))
-            {
-                CheckNodeLocation(info, AsmJsSIMDValue);
-                mWriter.Conv(OpCodeAsmJs::Simd128_Return_U4, 0, info.location);
-                mFunction->ReleaseLocation<AsmJsSIMDValue>(&info);
-                emitInfo.type = AsmJsType::Uint32x4;
-                retType = AsmJsRetType::Uint32x4;
-            }
-            else if (info.type.isSubType(AsmJsType::Uint16x8))
-            {
-                CheckNodeLocation(info, AsmJsSIMDValue);
-                mWriter.Conv(OpCodeAsmJs::Simd128_Return_U8, 0, info.location);
-                mFunction->ReleaseLocation<AsmJsSIMDValue>(&info);
-                emitInfo.type = AsmJsType::Uint16x8;
-                retType = AsmJsRetType::Uint16x8;
-            }
-            else if (info.type.isSubType(AsmJsType::Uint8x16))
-            {
-                CheckNodeLocation(info, AsmJsSIMDValue);
-                mWriter.Conv(OpCodeAsmJs::Simd128_Return_U16, 0, info.location);
-                mFunction->ReleaseLocation<AsmJsSIMDValue>(&info);
-                emitInfo.type = AsmJsType::Uint8x16;
-                retType = AsmJsRetType::Uint8x16;
             }
             else
             {
@@ -1197,16 +1172,7 @@ namespace Js
                     case AsmJsType::Int8x16:
                          opcode = OpCodeAsmJs::Simd128_I_ArgOut_I16;
                         break;
-                    case AsmJsType::Uint32x4:
-                        opcode = OpCodeAsmJs::Simd128_I_ArgOut_U4;
-                        break;
-                    case AsmJsType::Uint16x8:
-                        opcode = OpCodeAsmJs::Simd128_I_ArgOut_U8;
-                        break;
-                    case AsmJsType::Uint8x16:
-                        opcode = OpCodeAsmJs::Simd128_I_ArgOut_U16;
-                        break;
-                     case AsmJsType::Bool32x4:
+                    case AsmJsType::Bool32x4:
                         opcode = OpCodeAsmJs::Simd128_I_ArgOut_B4;
                         break;
                     case AsmJsType::Bool16x8:
@@ -1215,6 +1181,11 @@ namespace Js
                     case AsmJsType::Bool8x16:
                         opcode = OpCodeAsmJs::Simd128_I_ArgOut_B16;
                         break;
+                    case AsmJsType::Uint32x4:
+                    case AsmJsType::Uint16x8:
+                    case AsmJsType::Uint8x16:
+                        //In Asm.js unsigned SIMD types are not allowed as function arguments or return values.
+                        throw AsmJsCompilationException(_u("Function %s doesn't support argument of type %s. Argument must be of signed type."), funcName->Psz(), argInfo.type.toChars());
                     default:
                         Assert(UNREACHED);
                     }

--- a/lib/Runtime/Language/AsmJsModule.cpp
+++ b/lib/Runtime/Language/AsmJsModule.cpp
@@ -780,6 +780,10 @@ namespace Js
                     {
                        return Fail(rhs, _u("Invalid SIMD argument type check. E.g. expected x = f4check(x)"));
                     }
+                    if (simdFunc->IsUnsignedTypeCheck())
+                    {
+                        return Fail(rhs, _u("Invalid SIMD argument type. Expecting Signed arguments."));
+                    }
                     var->SetVarType(simdFunc->GetTypeCheckVarType());
                     // We don't set SIMD args reg location here. We defer that after all function locals are processed.
                     // This allows us to capture all SIMD constants from locals initializations, add them to the register space before we assign registers to args and locals.

--- a/lib/Runtime/Language/AsmJsTypes.cpp
+++ b/lib/Runtime/Language/AsmJsTypes.cpp
@@ -1258,6 +1258,13 @@ namespace Js
                mBuiltIn == AsmJsSIMDBuiltin_bool8x16_check;
     }
 
+    bool AsmJsSIMDFunction::IsUnsignedTypeCheck()
+    {
+        return mBuiltIn == AsmJsSIMDBuiltin_uint32x4_check ||
+               mBuiltIn == AsmJsSIMDBuiltin_uint16x8_check ||
+               mBuiltIn == AsmJsSIMDBuiltin_uint8x16_check;
+    }
+
     AsmJsVarType AsmJsSIMDFunction::GetTypeCheckVarType()
     {
         Assert(this->IsTypeCheck());

--- a/lib/Runtime/Language/AsmJsTypes.h
+++ b/lib/Runtime/Language/AsmJsTypes.h
@@ -1169,6 +1169,7 @@ namespace Js
         bool IsConstructor();
         bool IsConstructor(uint argCount);
         bool IsTypeCheck();  // e.g. float32x4(x)
+        bool IsUnsignedTypeCheck();
         bool IsInt32x4Func()  { return mBuiltIn >  AsmJsSIMDBuiltinFunction::AsmJsSIMDBuiltin_Int32x4_Start   && mBuiltIn < AsmJsSIMDBuiltinFunction::AsmJsSIMDBuiltin_Int32x4_End;   }
         bool IsBool32x4Func() { return mBuiltIn >= AsmJsSIMDBuiltinFunction::AsmJsSIMDBuiltin_Bool32x4_Start  && mBuiltIn < AsmJsSIMDBuiltinFunction::AsmJsSIMDBuiltin_Bool32x4_End;  }
         bool IsBool16x8Func() { return mBuiltIn >= AsmJsSIMDBuiltinFunction::AsmJsSIMDBuiltin_Bool16x8_Start  && mBuiltIn < AsmJsSIMDBuiltinFunction::AsmJsSIMDBuiltin_Bool16x8_End;  }

--- a/test/SIMD.int16x8.asmjs/testMisc2.js
+++ b/test/SIMD.int16x8.asmjs/testMisc2.js
@@ -5,34 +5,14 @@
 this.WScript.LoadScriptFile("..\\UnitTestFramework\\SimdJsHelpers.js");
 function asmModule(stdlib, imports, buffer) {
     "use asm";
-    /*
+    
     var i4 = stdlib.SIMD.Int32x4;
     var i4check = i4.check;
-    var i4splat = i4.splat;
-    
-    var i4fromFloat32x4 = i4.fromFloat32x4;
-    var i4fromFloat32x4Bits = i4.fromFloat32x4Bits;
-    //var i4abs = i4.abs;
-    var i4neg = i4.neg;
-    var i4add = i4.add;
-    var i4sub = i4.sub;
-    var i4mul = i4.mul;
-    //var i4swizzle = i4.swizzle;
-    //var i4shuffle = i4.shuffle;
-    var i4lessThan = i4.lessThan;
-    var i4equal = i4.equal;
-    var i4greaterThan = i4.greaterThan;
-    var i4select = i4.select;
-    var i4and = i4.and;
-    var i4or = i4.or;
-    var i4xor = i4.xor;
-    var i4not = i4.not;
-    //var i4shiftLeftByScalar = i4.shiftLeftByScalar;
-    //var i4shiftRightByScalar = i4.shiftRightByScalar;
-    //var i4shiftRightArithmeticByScalar = i4.shiftRightArithmeticByScalar;
-    */
+    var i4fromU4Bits = i4.fromUint32x4Bits;
+
     var i8 = stdlib.SIMD.Int16x8;
     var i8check = i8.check;
+    var i8fromU8Bits = i8.fromUint16x8Bits;
     var i8extractLane = i8.extractLane;
     var i8replaceLane = i8.replaceLane;
     var i8swizzle = i8.swizzle;
@@ -40,6 +20,9 @@ function asmModule(stdlib, imports, buffer) {
     var i8load = i8.load;
     var i8store = i8.store;
 
+    var i16 = stdlib.SIMD.Int8x16;
+    var i16check = i16.check;
+    var i16fromU16Bits = i16.fromUint8x16Bits;
     var u16 = stdlib.SIMD.Uint8x16;
     var u16check = u16.check;
     var u16extractLane = u16.extractLane;
@@ -188,7 +171,7 @@ function asmModule(stdlib, imports, buffer) {
             
             loopIndex = (loopIndex + 1) | 0;
         }
-        return u8check(x);
+        return i8check(i8fromU8Bits(x));
     }
     
     
@@ -206,7 +189,7 @@ function asmModule(stdlib, imports, buffer) {
             
             loopIndex = (loopIndex + 1) | 0;
         }
-        return u4check(x);
+        return i4check(i4fromU4Bits(x));
     }
     
     function func5(a, b)
@@ -224,7 +207,7 @@ function asmModule(stdlib, imports, buffer) {
             
             loopIndex = (loopIndex + 1) | 0;
         }
-        return u16check(x);
+        return i16check(i16fromU16Bits(x));
     }
     
     
@@ -303,7 +286,7 @@ function asmModule(stdlib, imports, buffer) {
             loopIndex = (loopIndex + 1) | 0;
         }
         
-        return u4check(x);
+        return i4check(i4fromU4Bits(x));
     }
     
     function func9(a, b)
@@ -339,7 +322,7 @@ function asmModule(stdlib, imports, buffer) {
             loopIndex = (loopIndex + 1) | 0;
         }
         
-        return u8check(z);
+        return i8check(i8fromU8Bits(z));
     }
     
     function func11(a, b)
@@ -357,7 +340,7 @@ function asmModule(stdlib, imports, buffer) {
             loopIndex = (loopIndex + 1) | 0;
         }
         
-        return u16check(w);
+        return i16check(i16fromU16Bits(w));
     }
     
     function func12(a, b)
@@ -376,7 +359,7 @@ function asmModule(stdlib, imports, buffer) {
             loopIndex = (loopIndex + 1) | 0;
         }
         
-        return u4check(x);
+        return i4check(i4fromU4Bits(x));
     }
     
     
@@ -412,7 +395,7 @@ function asmModule(stdlib, imports, buffer) {
             z = u8swizzle(z, 7, 6, 5, 4, 3, 2, 1, 0);
             loopIndex = (loopIndex + 1) | 0;
         }
-        return u8check(z);
+        return i8check(i8fromU8Bits(z));
     }
     
     function func15(a, b)
@@ -431,7 +414,7 @@ function asmModule(stdlib, imports, buffer) {
             
             loopIndex = (loopIndex + 1) | 0;
         }
-        return u16check(w);
+        return i16check(i16fromU16Bits(w));
     }
     
     function func16(a, b)
@@ -451,7 +434,7 @@ function asmModule(stdlib, imports, buffer) {
             loopIndex = (loopIndex + 1) | 0;
         }
         
-        return u4check(x);
+        return i4check(i4fromU4Bits(x));
     }
     
     
@@ -489,7 +472,7 @@ function asmModule(stdlib, imports, buffer) {
             z = u8shuffle(z, z2, 15, 14, 13, 12, 7, 6, 5, 4);
             loopIndex = (loopIndex + 1) | 0;
         }
-        return u8check(z);
+        return i8check(i8fromU8Bits(z));
     }
     
     function func19(a, b)
@@ -509,7 +492,7 @@ function asmModule(stdlib, imports, buffer) {
             
             loopIndex = (loopIndex + 1) | 0;
         }
-        return u16check(w);
+        return i16check(i16fromU16Bits(w));
     }
     
     function func20()
@@ -538,7 +521,7 @@ function asmModule(stdlib, imports, buffer) {
             
             index = (index + 16 ) | 0;
         }
-        return u4check(x);
+        return i4check(i4fromU4Bits(x));
     }
     
     function func21()
@@ -592,7 +575,7 @@ function asmModule(stdlib, imports, buffer) {
             z = u8load(Float32Heap, index >> 2);
             index = (index + 16 ) | 0;
         }
-        return u8check(z);
+        return i8check(i8fromU8Bits(z));
     }
     
     function func23()
@@ -618,7 +601,7 @@ function asmModule(stdlib, imports, buffer) {
             w = u16load(Float32Heap, index >> 2);
             index = (index + 16 ) | 0;
         }
-        return u16check(w);
+        return i16check(i16fromU16Bits(w));
     }
     
     function func24()
@@ -645,7 +628,7 @@ function asmModule(stdlib, imports, buffer) {
             x = u4load1(Float32Heap, index >> 2);
             index = (index + 16 ) | 0;
         }
-        return u4check(x);
+        return i4check(i4fromU4Bits(x));
     }
     
     function func25()
@@ -672,7 +655,7 @@ function asmModule(stdlib, imports, buffer) {
             x = u4load2(Float32Heap, index >> 2);
             index = (index + 16 ) | 0;
         }
-        return u4check(x);
+        return i4check(i4fromU4Bits(x));
     }
     
     function func26()
@@ -699,7 +682,7 @@ function asmModule(stdlib, imports, buffer) {
             x = u4load3(Float32Heap, index >> 2);
             index = (index + 16 ) | 0;
         }
-        return u4check(x);
+        return i4check(i4fromU4Bits(x));
     }
     
     
@@ -833,8 +816,9 @@ var ret20 = m.func20(s1, s2);
 
 // loads/stores
 var Int32Heap = new Int32Array(buffer);
+ret20 = SIMD.Uint32x4.fromInt32x4Bits(ret20);
 //printSimdBaseline(ret20, "SIMD.Uint32x4", "ret20", "func20");
-equalSimd([4294967295, 4294967294, 4294967293, 4294967292], ret20, SIMD.Uint32x4, "func20")
+equalSimd([4294967295, 4294967294, 4294967293, 4294967292], ret20 , SIMD.Uint32x4, "func20")
 
 for (i = 25; i < 25 + 4 * 3; i += 4)
 {
@@ -861,7 +845,7 @@ for (i = 25; i < 25 + 4 * 3; i += 4)
 var ret22 = m.func22(s1, s2);
 var ret22 = m.func22(s1, s2);
 var ret22 = m.func22(s1, s2);
-
+ret22 = SIMD.Uint16x8.fromInt16x8Bits(ret22);
 //printSimdBaseline(ret22, "SIMD.Uint16x8", "ret22", "func22");
 equalSimd([65436, 65336, 65236, 65136, 65036, 64936, 64836, 64736], ret22, SIMD.Uint16x8, "func22")
 
@@ -877,6 +861,8 @@ var ret23 = m.func23(s1, s2);
 var ret23 = m.func23(s1, s2);
 
 //printSimdBaseline(ret23, "SIMD.Uint8x16", "ret23", "func23");
+
+ret23 = SIMD.Uint8x16.fromInt8x16Bits(ret23);
 equalSimd([24, 48, 72, 96, 120, 144, 168, 192, 24, 48, 72, 96, 120, 144, 168, 192], ret23, SIMD.Uint8x16, "func23")
 
 for (i = 25; i < 25 + 4 * 3; i += 4)
@@ -889,6 +875,7 @@ for (i = 25; i < 25 + 4 * 3; i += 4)
 var ret24 = m.func24(s1, s2);
 var ret24 = m.func24(s1, s2);
 var ret24 = m.func24(s1, s2);
+ret24 = SIMD.Uint32x4.fromInt32x4Bits(ret24);
 //printSimdBaseline(ret24, "SIMD.Uint32x4", "ret24", "func24");
 equalSimd([4294967295, 0, 0, 0], ret24, SIMD.Uint32x4, "func24")
 
@@ -902,6 +889,8 @@ for (i = 25; i < 25 + 4 * 3; i += 4)
 var ret25 = m.func25(s1, s2);
 var ret25 = m.func25(s1, s2);
 var ret25 = m.func25(s1, s2);
+
+ret25 = SIMD.Uint32x4.fromInt32x4Bits(ret25);
 //printSimdBaseline(ret25, "SIMD.Uint32x4", "ret25", "func25");
 equalSimd([4294967295, 4294967294, 0, 0], ret25, SIMD.Uint32x4, "func25")
 
@@ -915,6 +904,7 @@ for (i = 25; i < 25 + 4 * 3; i += 4)
 var ret26 = m.func26(s1, s2);
 var ret26 = m.func26(s1, s2);
 var ret26 = m.func26(s1, s2);
+ret26 = SIMD.Uint32x4.fromInt32x4Bits(ret26);
 //printSimdBaseline(ret26, "SIMD.Uint32x4", "ret26", "func26");
 equalSimd([4294967295, 4294967294, 4294967293, 0], ret26, SIMD.Uint32x4, "func26")
 
@@ -960,23 +950,37 @@ printSimdBaseline(ret26, "SIMD.Uint8x16", "ret26", "func26");
 */
 equalSimd([2, -3, 4, 5, 6, -7, 8, 9], ret1, SIMD.Int16x8, "func1")
 equalSimd([2, 4, 13, 5, 15, 7, 17, 9], ret2, SIMD.Int16x8, "func2")
+ret3 = SIMD.Uint16x8.fromInt16x8Bits(ret3);
 equalSimd([0, 65535, 2, 3, 65535, 5, 65436, 0], ret3, SIMD.Uint16x8, "func3")
+ret4 = SIMD.Uint32x4.fromInt32x4Bits(ret4);
 equalSimd([0, 4294967295, 2, 4294967295], ret4, SIMD.Uint32x4, "func4");
+ret5 = SIMD.Uint8x16.fromInt8x16Bits(ret5);
 equalSimd([0, 255, 2, 3, 255, 5, 156, 0, 1, 255, 3, 4, 156, 7, 156, 0], ret5, SIMD.Uint8x16, "func5")
+
 equal(3975, ret6);
 equal(524216, ret7);
+
+ret8 = SIMD.Uint32x4.fromInt32x4Bits(ret8);
 equalSimd([4294967295, 4294967294, 4294967293, 4294967292], ret8, SIMD.Uint32x4, "func8")
 equalSimd([-1, -2, -3, -4, -5, -6, -7, -8], ret9, SIMD.Int16x8, "func9")
+ret10 = SIMD.Uint16x8.fromInt16x8Bits(ret10);
 equalSimd([65535, 65534, 65533, 65532, 65531, 65530, 65529, 65528], ret10, SIMD.Uint16x8, "func10")
+ret11 = SIMD.Uint8x16.fromInt8x16Bits(ret11);
 equalSimd([255, 254, 253, 252, 251, 250, 249, 248, 255, 254, 253, 252, 251, 250, 249, 248], ret11, SIMD.Uint8x16, "func11")
-
+ret12 = SIMD.Uint32x4.fromInt32x4Bits(ret12);
 equalSimd([4294967292, 4294967293, 4294967294, 4294967295], ret12, SIMD.Uint32x4, "func12")
 equalSimd([-4, -3, -2, -1, -8, -7, -6, -5], ret13, SIMD.Int16x8, "func13")
+
+ret14 = SIMD.Uint16x8.fromInt16x8Bits(ret14);
 equalSimd([65528, 65529, 65530, 65531, 65532, 65533, 65534, 65535], ret14, SIMD.Uint16x8, "func14")
+ret15 = SIMD.Uint8x16.fromInt8x16Bits(ret15);
 equalSimd([248, 249, 250, 251, 252, 253, 254, 255, 248, 249, 250, 251, 252, 253, 254, 255], ret15, SIMD.Uint8x16, "func15")
+ret16 = SIMD.Uint32x4.fromInt32x4Bits(ret16);
 equalSimd([4294966896, 4294966996, 4294967292, 4294967294], ret16, SIMD.Uint32x4, "func16")
 equalSimd([-800, -700, -600, -500, -8, -7, -6, -5], ret17, SIMD.Int16x8, "func17")
+ret18 = SIMD.Uint16x8.fromInt16x8Bits(ret18);
 equalSimd([64736, 64836, 64936, 65036, 65528, 65529, 65530, 65531], ret18, SIMD.Uint16x8, "func18")
+ret19 = SIMD.Uint8x16.fromInt8x16Bits(ret19);
 equalSimd([248, 249, 250, 251, 252, 253, 254, 255, 224, 68, 168, 12, 252, 253, 254, 255], ret19, SIMD.Uint8x16, "func19")
 
 

--- a/test/SIMD.uint16x8.asmjs/rlexe.xml
+++ b/test/SIMD.uint16x8.asmjs/rlexe.xml
@@ -41,6 +41,22 @@
   </test>
   <test>
     <default>
+      <files>testFail.js</files>
+      <baseline>testFail.baseline</baseline>
+      <tags>exclude_dynapogo,exclude_ship</tags>
+      <compile-flags>-off:deferparse -testtrace:asmjs -simdjs -bgjit- -maic:1</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
+      <files>testFail_1.js</files>
+      <baseline>testFail_1.baseline</baseline>
+      <tags>exclude_dynapogo,exclude_ship</tags>
+      <compile-flags>-off:deferparse -testtrace:asmjs -simdjs -bgjit- -maic:1</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>testComparison.js</files>
       <baseline>asmjs.baseline</baseline>
       <tags>exclude_dynapogo,exclude_ship</tags>

--- a/test/SIMD.uint16x8.asmjs/testAddSub.js
+++ b/test/SIMD.uint16x8.asmjs/testAddSub.js
@@ -15,6 +15,11 @@ function asmModule(stdlib, imports) {
     var ui8g1 = ui8(10, 1073, 107, 1082, 10402, 12332, 311, 650);      
     var ui8g2 = ui8(353216, 492529, 1128, 1085, 3692, 3937, 9755, 2638);     
 
+    var i8 = stdlib.SIMD.Int16x8;
+    var i8check = i8.check;
+    var i8fu8 = i8.fromUint16x8Bits;
+    var u8fi8 = ui8.fromInt16x8Bits;
+
     var loopCOUNT = 3;
 
     function testAddLocal()
@@ -29,7 +34,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui8check(result);
+        return i8check(i8fu8(result));
     }
     
     function testSubLocal()
@@ -44,7 +49,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui8check(result);
+        return i8check(i8fu8(result));
     }
 
     function testAddGlobal()
@@ -57,7 +62,7 @@ function asmModule(stdlib, imports) {
         loopIndex = (loopIndex + 1) | 0;
     }
 
-        return ui8check(result);
+        return i8check(i8fu8(result));
     }
     
     function testSubGlobal()
@@ -70,7 +75,7 @@ function asmModule(stdlib, imports) {
         loopIndex = (loopIndex + 1) | 0;
     }
 
-        return ui8check(result);
+        return i8check(i8fu8(result));
     }
     
     function testAddGlobalImport()
@@ -84,7 +89,7 @@ function asmModule(stdlib, imports) {
         loopIndex = (loopIndex + 1) | 0;
     }
 
-        return ui8check(result);
+        return i8check(i8fu8(result));
     }
     
     function testSubGlobalImport()
@@ -97,7 +102,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui8check(result);
+        return i8check(i8fu8(result));
     }
     
     return { testAddLocal: testAddLocal, testSubLocal: testSubLocal, testAddGlobal: testAddGlobal, testSubGlobal: testSubGlobal, testAddGlobalImport: testAddGlobalImport, testSubGlobalImport: testSubGlobalImport };
@@ -105,10 +110,17 @@ function asmModule(stdlib, imports) {
 
 var m = asmModule(this, {g1:SIMD.Uint16x8(100, 1073741824, 1028, 102, 3883, 38, 92929, 1442)});
 
-equalSimd([8516, 5545, 6362, 3299, 17908, 3818, 11182, 9901], m.testAddLocal(), SIMD.Uint16x8, "Func1");
-equalSimd([1550, 1257, 60504, 3169, 49524, 1850, 4314, 55685], m.testSubLocal(), SIMD.Uint16x8, "Func2");
-equalSimd([25546, 34850, 1235, 2167, 14094, 16269, 10066, 3288], m.testAddGlobal(), SIMD.Uint16x8, "Func3");
-equalSimd([40010, 32832, 64515, 65533, 6710, 8395, 56092, 63548], m.testSubGlobal(), SIMD.Uint16x8, "Func4");
-equalSimd([5133, 3401, 1693, 3336, 4831, 2872, 35141, 1467], m.testAddGlobalImport(), SIMD.Uint16x8, "Func5");
-equalSimd([60603, 62135, 363, 62404, 2935, 62740, 19645, 1417], m.testSubGlobalImport(), SIMD.Uint16x8, "Func6");
+var ret1 = SIMD.Uint16x8.fromInt16x8Bits(m.testAddLocal());
+var ret2 = SIMD.Uint16x8.fromInt16x8Bits(m.testSubLocal());
+var ret3 = SIMD.Uint16x8.fromInt16x8Bits(m.testAddGlobal());
+var ret4 = SIMD.Uint16x8.fromInt16x8Bits(m.testSubGlobal());
+var ret5 = SIMD.Uint16x8.fromInt16x8Bits(m.testAddGlobalImport());
+var ret6 = SIMD.Uint16x8.fromInt16x8Bits(m.testSubGlobalImport());
+
+equalSimd([8516, 5545, 6362, 3299, 17908, 3818, 11182, 9901], ret1, SIMD.Uint16x8, "Func1");
+equalSimd([1550, 1257, 60504, 3169, 49524, 1850, 4314, 55685],ret2, SIMD.Uint16x8, "Func2");
+equalSimd([25546, 34850, 1235, 2167, 14094, 16269, 10066, 3288], ret3, SIMD.Uint16x8, "Func3");
+equalSimd([40010, 32832, 64515, 65533, 6710, 8395, 56092, 63548],ret4, SIMD.Uint16x8, "Func4");
+equalSimd([5133, 3401, 1693, 3336, 4831, 2872, 35141, 1467], ret5, SIMD.Uint16x8, "Func5");
+equalSimd([60603, 62135, 363, 62404, 2935, 62740, 19645, 1417], ret6, SIMD.Uint16x8, "Func6");
 print("PASS");

--- a/test/SIMD.uint16x8.asmjs/testAddSubSaturate.js
+++ b/test/SIMD.uint16x8.asmjs/testAddSubSaturate.js
@@ -16,7 +16,12 @@ function asmModule(stdlib, imports) {
     var ui8g2 = ui8(353216, 492529, 1128, 1085, 3692, 3937, 9755, 2638);     
 
     var loopCOUNT = 3;
-
+    
+    var i8 = stdlib.SIMD.Int16x8;
+    var i8check = i8.check;
+    var i8fu8 = i8.fromUint16x8Bits;
+    var u8fi8 = ui8.fromInt16x8Bits;
+    
     function testAddSaturateLocal()
     {
         var a = ui8(50000, 65535, 0, 65535, 1, 1, 1, 1);
@@ -29,7 +34,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui8check(result);
+        return i8check(i8fu8(result));
     }
     
     function testSubSaturateLocal()
@@ -44,7 +49,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui8check(result);
+        return i8check(i8fu8(result));
     }
 
     function testAddSaturateGlobal()
@@ -57,7 +62,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui8check(result);
+        return i8check(i8fu8(result));
     }
     
     function testSubSaturateGlobal()
@@ -70,7 +75,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui8check(result);
+        return i8check(i8fu8(result));
     }
     
     function testAddSaturateGlobalImport()
@@ -84,7 +89,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui8check(result);
+        return i8check(i8fu8(result));
     }
     
     function testSubSaturateGlobalImport()
@@ -98,7 +103,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui8check(result);
+        return i8check(i8fu8(result));
     }
     
     return { testAddSaturateLocal: testAddSaturateLocal, testSubSaturateLocal: testSubSaturateLocal, testAddSaturateGlobal: testAddSaturateGlobal, testSubSaturateGlobal: testSubSaturateGlobal, testAddSaturateGlobalImport: testAddSaturateGlobalImport, testSubSaturateGlobalImport: testSubSaturateGlobalImport };
@@ -106,10 +111,18 @@ function asmModule(stdlib, imports) {
 
 var m = asmModule(this, {g1:SIMD.Uint16x8(20000, 1073741824, 1028, 102, 3883, 38, 92929, 1442)});
 
-equalSimd([65535, 65535, 65535, 65535, 2, 2, 2, 2], m.testAddSaturateLocal(), SIMD.Uint16x8, "Func1");
-equalSimd([0, 1257, 0, 3169, 0, 1850, 4314, 0], m.testSubSaturateLocal(), SIMD.Uint16x8, "Func2");
-equalSimd([25536, 33777, 1128, 1085, 50564, 19353, 36938, 51684], m.testAddSaturateGlobal(), SIMD.Uint16x8, "Func3");
-equalSimd([0, 0, 0, 0, 43180, 11479, 17428, 46408], m.testSubSaturateGlobal(), SIMD.Uint16x8, "Func4");
-equalSimd([65535, 3401, 1693, 3336, 4831, 2872, 35141, 1467], m.testAddSaturateGlobalImport(), SIMD.Uint16x8, "Func5");
-equalSimd([0, 0, 363, 0, 2935, 0, 19645, 1417], m.testSubSaturateGlobalImport(), SIMD.Uint16x8, "Func6");
+var ret1 = SIMD.Uint16x8.fromInt16x8Bits(m.testAddSaturateLocal());
+var ret2 = SIMD.Uint16x8.fromInt16x8Bits(m.testSubSaturateLocal());
+var ret3 = SIMD.Uint16x8.fromInt16x8Bits(m.testAddSaturateGlobal());
+var ret4 = SIMD.Uint16x8.fromInt16x8Bits(m.testSubSaturateGlobal());
+var ret5 = SIMD.Uint16x8.fromInt16x8Bits(m.testAddSaturateGlobalImport());
+var ret6 = SIMD.Uint16x8.fromInt16x8Bits(m.testSubSaturateGlobalImport());
+
+
+equalSimd([65535, 65535, 65535, 65535, 2, 2, 2, 2], ret1, SIMD.Uint16x8, "Func1");
+equalSimd([0, 1257, 0, 3169, 0, 1850, 4314, 0], ret2, SIMD.Uint16x8, "Func2");
+equalSimd([25536, 33777, 1128, 1085, 50564, 19353, 36938, 51684], ret3, SIMD.Uint16x8, "Func3");
+equalSimd([0, 0, 0, 0, 43180, 11479, 17428, 46408], ret4, SIMD.Uint16x8, "Func4");
+equalSimd([65535, 3401, 1693, 3336, 4831, 2872, 35141, 1467], ret5, SIMD.Uint16x8, "Func5");
+equalSimd([0, 0, 363, 0, 2935, 0, 19645, 1417], ret6, SIMD.Uint16x8, "Func6");
 print("PASS");

--- a/test/SIMD.uint16x8.asmjs/testBitwise.js
+++ b/test/SIMD.uint16x8.asmjs/testBitwise.js
@@ -25,6 +25,10 @@ function asmModule(stdlib, imports) {
 
     var gval = 1234;
     var gval2 = 1234.0;
+    
+    var i8 = stdlib.SIMD.Int16x8;
+    var i8check = i8.check;
+    var i8fu8 = i8.fromUint16x8Bits;
 
     var loopCOUNT = 3;
 
@@ -47,7 +51,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui8check(d);
+        return i8check(i8fu8(d));
     }
     
     function func2()
@@ -68,7 +72,7 @@ function asmModule(stdlib, imports) {
             
         }
 
-        return ui8check(d);
+        return i8check(i8fu8(d));
     }
 
     function func3()
@@ -91,7 +95,7 @@ function asmModule(stdlib, imports) {
         }
         while ( (loopIndex | 0) > 0);
 
-        return ui8check(ui8g1);
+        return i8check(i8fu8(ui8g1));
     }
     
     
@@ -100,7 +104,11 @@ function asmModule(stdlib, imports) {
 
 var m = asmModule(this, {g1:SIMD.Uint16x8(1065353216, 1073741824, 1077936128, 1082130432, 383829393, 39283838, 92929, 109483922)});
 
-equalSimd([1, 1, 1, 1, 1, 1, 1, 1], m.func1(), SIMD.Uint16x8, "Func1");
-equalSimd([5034, 3402, 666, 32235, 49710, 25421, 21839, 40334], m.func2(), SIMD.Uint16x8, "Func2");
-equalSimd([38447, 12338, 45765, 33301, 20955, 3307, 13096, 11408], m.func3(), SIMD.Uint16x8, "Func3");
+var ret1 = SIMD.Uint16x8.fromInt16x8Bits(m.func1());
+var ret2 = SIMD.Uint16x8.fromInt16x8Bits(m.func2());
+var ret3 = SIMD.Uint16x8.fromInt16x8Bits(m.func3());
+
+equalSimd([1, 1, 1, 1, 1, 1, 1, 1], ret1, SIMD.Uint16x8, "Func1");
+equalSimd([5034, 3402, 666, 32235, 49710, 25421, 21839, 40334], ret2, SIMD.Uint16x8, "Func2");
+equalSimd([38447, 12338, 45765, 33301, 20955, 3307, 13096, 11408], ret3, SIMD.Uint16x8, "Func3");
 print("PASS");

--- a/test/SIMD.uint16x8.asmjs/testCalls.js
+++ b/test/SIMD.uint16x8.asmjs/testCalls.js
@@ -82,14 +82,22 @@ function asmModule(stdlib, imports) {
     var gval = 1234;
     var gval2 = 1234.0;
 
-
-    
     var loopCOUNT = 3;
+    var i8 = stdlib.SIMD.Int16x8;
+    var i8check = i8.check;
+    var i8fromU8bits = i8.fromUint16x8Bits;
+
+    var u8fromI8bits = u8.fromInt16x8Bits;
+    
+    var i16 = stdlib.SIMD.Int8x16;
+    var i16check = i16.check;
+    var i16fromU16bits = i16.fromUint8x16Bits;
+    var u16fromI16bits = u16.fromInt8x16Bits;
 
     function func1(a, b)
     {
-        a = u8check(a);
-        b = u8check(b);
+        a = i8check(a);
+        b = i8check(b);
         var x = u8(-1, -2, -3, -4, -5, -6, -7, -8);;
 
         var loopIndex = 0;
@@ -101,42 +109,41 @@ function asmModule(stdlib, imports) {
         }
         x = globImportU8;
         g2 = x;
-
-        return u8check(x);
+        return i8check(i8fromU8bits(x));
     }
     
     function func2(a, b, c, d)
     {
-        a = u8check(a);
-        b = u8check(b);
-        c = u8check(c);
-        d = u8check(d);
+        a = i8check(a);
+        b = i8check(b);
+        c = i8check(c);
+        d = i8check(d);
         var x = u8(-1, -2, -3, -4, -5, -6, -7, -8);
         var y = u8(1, 2, 3, 4, 5, 6, 7, 8);
         var loopIndex = 0;
         for (loopIndex = 0; (loopIndex | 0) < (loopCOUNT | 0) ; loopIndex = (loopIndex + 1) | 0)
         {
 
-            x = u8check(func1(a, b));
-            y = u8check(func1(c, d));
+            x = u8fromI8bits(i8check(func1(a, b)));
+            y = u8fromI8bits(i8check(func1(c, d)));
             
 
         }
 
-        //return u8check(u8add(x,y));
-        return u8check(x);
+        //return i8check(u8add(x,y));
+        return i8check(i8fromU8bits(x));
     }
 
     function func3(a, b, c, d, e, f, g, h)
     {
-        a = u8check(a);
-        b = u8check(b);
-        c = u8check(c);
-        d = u8check(d);
-        e = u8check(e);
-        f = u8check(f);
-        g = u8check(g);
-        h = u8check(h);        
+        a = i8check(a);
+        b = i8check(b);
+        c = i8check(c);
+        d = i8check(d);
+        e = i8check(e);
+        f = i8check(f);
+        g = i8check(g);
+        h = i8check(h);        
         
         var x = u8(-1, -2, -3, -4, -5, -6, -7, -8);
         var y = u8(1, 2, 3, 4, 5, 6, 7, 8);
@@ -144,13 +151,13 @@ function asmModule(stdlib, imports) {
         for (loopIndex = 0; (loopIndex | 0) < (loopCOUNT | 0) ; loopIndex = (loopIndex + 1) | 0)
         {
 
-            x = u8check(func2(a, b, c, d));
-            y = u8check(func2(e, f, g, h));
+            x = u8fromI8bits(i8check(func2(a, b, c, d)));
+            y = u8fromI8bits(i8check(func2(e, f, g, h)));
             
         }
 
-        //return u8check(u8add(x,y));
-        return u8check(x);
+        //return i8check(u8add(x,y));
+        return i8check(i8fromU8bits(x));
     }
 
     function func4() { //Testing for a bug while returning SIMD values from a loop
@@ -160,7 +167,7 @@ function asmModule(stdlib, imports) {
         for (i = 0; (i | 0) < 1000; i = (i + 1)|0) {
             //value1 = u8add(value1, u8splat(1));
             if ((i | 0) == 300) {
-                return u8check(value1);
+                return i8check(i8fromU8bits(value1));
             }
         }
     }
@@ -185,22 +192,22 @@ function asmModule(stdlib, imports) {
 
     function fctest(a)
     {
-        a = u16check(a);
+        a = i16check(a);
         return a;
     }
     function fcBug_1()
     {
         var x = u8(1, 2, 3, 4, 5, 6, 7, 8);
         var k = u16(1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
-        k = u16check(fctest(k));
-        return u8check(x);
+        k = u16fromI16bits(i16check(fctest(i16fromU16bits(k))));
+        return i8check(i8fromU8bits(x));
     }
     function fcBug_2()
     {
         var x = u8(1, 2, 3, 4, 5, 6, 7, 8);
         var k = u16(1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
-        x = u8check(fcBug_1());
-        return u16check(k);
+        x = u8fromI8bits(i8check(fcBug_1()));
+        return i16check(i16fromU16bits(k));
     }
 
     return {func1:func1, func2:func2, func3:func3, func4:func4, func5:fcBug_1, func6:fcBug_2};
@@ -217,12 +224,16 @@ var s6 = SIMD.Uint16x8(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
 var s7 = SIMD.Uint16x8(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
 var s8 = SIMD.Uint16x8(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0);
 
-var ret1 = m.func1(s1, s2);
-var ret2 = m.func2(s1, s2, s3, s4);
-var ret3 = m.func3(s1, s2, s3, s4, s5, s6, s7, s8);
-var ret4 = m.func4();
-var ret5 = m.func5();
-var ret6 = m.func6();
+var i8fromU8 = SIMD.Int16x8.fromUint16x8Bits;
+var u8fromI8 = SIMD.Uint16x8.fromInt16x8Bits;
+
+var ret1 = u8fromI8(m.func1(i8fromU8(s1), i8fromU8(s2)));
+var ret2 = u8fromI8(m.func2(i8fromU8(s1), i8fromU8(s2), i8fromU8(s3), i8fromU8(s4)));
+var ret3 = u8fromI8(m.func3(i8fromU8(s1), i8fromU8(s2), i8fromU8(s3), i8fromU8(s4), 
+i8fromU8(s5), i8fromU8(s6), i8fromU8(s7), i8fromU8(s8)));
+var ret4 = u8fromI8(m.func4());
+var ret5 = u8fromI8(m.func5());
+var ret6 = SIMD.Uint8x16.fromInt8x16Bits(m.func6());
 
 equalSimd([0, 0, 0, 0, 0, 0, 0, 0], ret1, SIMD.Uint16x8, "func1")
 equalSimd([0, 0, 0, 0, 0, 0, 0, 0], ret2, SIMD.Uint16x8, "func2")

--- a/test/SIMD.uint16x8.asmjs/testComparisonSelect.js
+++ b/test/SIMD.uint16x8.asmjs/testComparisonSelect.js
@@ -23,6 +23,10 @@ function asmModule(stdlib, imports) {
     var ui8g2 = ui8(353216, 492529, 1128, 1085, 3692, 3937, 9755, 2638);          // global var initialized
 
     var loopCOUNT = 5;
+
+    var i8 = stdlib.SIMD.Int16x8;
+    var i8check = i8.check;
+    var i8fu8 = i8.fromUint16x8Bits;
     function testLessThan()
     {
         var b = ui8(5033, 3401, 665, 32234, 948, 2834, 7748, 25);
@@ -39,7 +43,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui8check(d);
+        return i8check(i8fu8(d));
     }
 
     function testLessThanOrEqual()
@@ -58,7 +62,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui8check(d);
+        return i8check(i8fu8(d));
     }
 
     function testGreaterThan()
@@ -77,7 +81,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui8check(d);
+        return i8check(i8fu8(d));
     }
 
     function testGreaterThanOrEqual()
@@ -96,7 +100,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui8check(d);
+        return i8check(i8fu8(d));
     }
 
     function testEqual()
@@ -115,7 +119,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui8check(d);
+        return i8check(i8fu8(d));
     }
 
     function testNotEqual()
@@ -134,7 +138,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui8check(d);
+        return i8check(i8fu8(d));
     }
 
     return { testLessThan: testLessThan, testLessThanOrEqual: testLessThanOrEqual, testGreaterThan: testGreaterThan, testGreaterThanOrEqual: testGreaterThanOrEqual, testEqual: testEqual, testNotEqual: testNotEqual };
@@ -142,12 +146,20 @@ function asmModule(stdlib, imports) {
 
 var m = asmModule(this, { g1: SIMD.Uint16x8(106533216, 1073741824, 1077936128, 1082130432, 383829393, 39283838, 92929, 109483922)});
 
-equalSimd([5033, 3401, 665, 32234, 948, 984, 3434, 25], m.testLessThan(), SIMD.Uint16x8, "Func1");
-equalSimd([5033, 3401, 665, 32234, 948, 984, 3434, 25], m.testLessThanOrEqual(), SIMD.Uint16x8, "Func2");
-equalSimd([34183, 15736, 45149, 65534, 22118, 2834, 7748, 9876], m.testGreaterThan(), SIMD.Uint16x8, "Func3");
-equalSimd([34183, 15736, 45149, 65534, 22118, 2834, 7748, 9876], m.testGreaterThanOrEqual(), SIMD.Uint16x8, "Func4");
-equalSimd([34183, 15736, 45149, 65534, 22118, 984, 3434, 9876], m.testEqual(), SIMD.Uint16x8, "Func5");
-equalSimd([5033, 3401, 665, 32234, 948, 2834, 7748, 25], m.testNotEqual(), SIMD.Uint16x8, "Func6");
+var ret1 = SIMD.Uint16x8.fromInt16x8Bits( m.testLessThan());
+var ret2 = SIMD.Uint16x8.fromInt16x8Bits( m.testLessThanOrEqual());
+var ret3 = SIMD.Uint16x8.fromInt16x8Bits( m.testGreaterThan());
+var ret4 = SIMD.Uint16x8.fromInt16x8Bits( m.testGreaterThanOrEqual());
+var ret5 = SIMD.Uint16x8.fromInt16x8Bits( m.testEqual());
+var ret6 = SIMD.Uint16x8.fromInt16x8Bits( m.testNotEqual());
+
+
+equalSimd([5033, 3401, 665, 32234, 948, 984, 3434, 25], ret1, SIMD.Uint16x8, "Func1");
+equalSimd([5033, 3401, 665, 32234, 948, 984, 3434, 25], ret2, SIMD.Uint16x8, "Func2");
+equalSimd([34183, 15736, 45149, 65534, 22118, 2834, 7748, 9876], ret3, SIMD.Uint16x8, "Func3");
+equalSimd([34183, 15736, 45149, 65534, 22118, 2834, 7748, 9876], ret4, SIMD.Uint16x8, "Func4");
+equalSimd([34183, 15736, 45149, 65534, 22118, 984, 3434, 9876], ret5, SIMD.Uint16x8, "Func5");
+equalSimd([5033, 3401, 665, 32234, 948, 2834, 7748, 25], ret6, SIMD.Uint16x8, "Func6");
 
 print("PASS");
 

--- a/test/SIMD.uint16x8.asmjs/testConstructorLanes.js
+++ b/test/SIMD.uint16x8.asmjs/testConstructorLanes.js
@@ -16,6 +16,10 @@ function asmModule(stdlib, imports) {
 
     var vectorLength = 8;
 
+    var i8 = stdlib.SIMD.Int16x8;
+    var i8check = i8.check;
+    var i8fu8 = i8.fromUint16x8Bits;
+
     var loopCOUNT = 3;
 
     function testLocal() {
@@ -58,7 +62,7 @@ function asmModule(stdlib, imports) {
 
             loopIndex = (loopIndex + 1) | 0;
         }
-        return ui8check(result);
+        return i8check(i8fu8(result));
 }
     
         function testGlobal() {
@@ -101,7 +105,7 @@ function asmModule(stdlib, imports) {
                 loopIndex = (loopIndex + 1) | 0;
             }
 
-            return ui8check(result);
+            return i8check(i8fu8(result));
         }
 
         function testGlobalImport() {
@@ -144,7 +148,7 @@ function asmModule(stdlib, imports) {
                 loopIndex = (loopIndex + 1) | 0;
             }
 
-            return ui8check(result);
+            return i8check(i8fu8(result));
         }
         
         return { testLocal: testLocal, testGlobal: testGlobal, testGlobalImport: testGlobalImport };
@@ -152,8 +156,12 @@ function asmModule(stdlib, imports) {
 
     var m = asmModule(this, { g1: SIMD.Uint16x8(65535, 1000, 3092, -65535, 0, -39283838, 0, -838) });
 
-    equalSimd([65535, 1, 0, 0, 0, 0, 57599, 27009], m.testLocal(), SIMD.Uint16x8, "testLocal");
-    equalSimd([106, 0, 10, 65535, 3192, 32, 19, 5], m.testGlobal(), SIMD.Uint16x8, "testGlobal");
-    equalSimd([65535, 1000, 3092, 1, 0, 37762, 0, 64698], m.testGlobalImport(), SIMD.Uint16x8, "testGlobalImport");
+    var ret1 = SIMD.Uint16x8.fromInt16x8Bits(m.testLocal());
+    var ret2 = SIMD.Uint16x8.fromInt16x8Bits(m.testGlobal());
+    var ret3 = SIMD.Uint16x8.fromInt16x8Bits(m.testGlobalImport());
+
+    equalSimd([65535, 1, 0, 0, 0, 0, 57599, 27009], ret1, SIMD.Uint16x8, "testLocal");
+    equalSimd([106, 0, 10, 65535, 3192, 32, 19, 5], ret2, SIMD.Uint16x8, "testGlobal");
+    equalSimd([65535, 1000, 3092, 1, 0, 37762, 0, 64698], ret3, SIMD.Uint16x8, "testGlobalImport");
 
     print("PASS");

--- a/test/SIMD.uint16x8.asmjs/testConversion-2.js
+++ b/test/SIMD.uint16x8.asmjs/testConversion-2.js
@@ -32,7 +32,10 @@ function asmModule(stdlib, imports) {
     var globImportI4 = i4check(imports.g2);       // global var import
     var g1 = f4(5033.2,3401.0,665.34,32234.1);          // global var initialized
     var g2 = i4(1065353216, 1073741824,1077936128, 1082130432);          // global var initialized
- 
+
+    var i8check = i8.check;
+    var i8fu8 = i8.fromUint16x8Bits;
+    
     var loopCOUNT = 3;
 
     function conv1()
@@ -47,7 +50,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui8check(x);
+        return i8check(i8fu8(x));
     }
     
     function conv2()
@@ -58,7 +61,7 @@ function asmModule(stdlib, imports) {
         {
             x = ui8fromInt32x4Bits(globImportI4);
         }
-        return ui8check(x);
+        return i8check(i8fu8(x));
     }
 
     function conv3()
@@ -75,7 +78,7 @@ function asmModule(stdlib, imports) {
         }
         while ( (loopIndex | 0) > 0);
 
-        return ui8check(x);
+        return i8check(i8fu8(x));
     }
 
     function conv4()
@@ -90,7 +93,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui8check(x);
+        return i8check(i8fu8(x));
     }
 
     function conv5()
@@ -102,7 +105,7 @@ function asmModule(stdlib, imports) {
         {
             x = ui8fromInt8x16Bits(m);
         }
-        return ui8check(x);
+        return i8check(i8fu8(x));
     }
     
     function conv6()
@@ -114,7 +117,7 @@ function asmModule(stdlib, imports) {
         {
             x = ui8fromUint8x16Bits(m);
         }
-        return ui8check(x);
+        return i8check(i8fu8(x));
     }
 
     
@@ -155,12 +158,19 @@ printSimdBaseline(m.func4(), "SIMD.Uint16x8", "m.func4()", "Func4");
 printSimdBaseline(m.func5(), "SIMD.Uint16x8", "m.func5()", "Func5");
 printSimdBaseline(m.func6(), "SIMD.Uint16x8", "m.func6()", "Func6");*/
 
-equalSimd([18842, 17821, 36864, 17748, 21955, 17446, 54323, 18171], m.func1(), SIMD.Uint16x8, "Func1");
-equalSimd([0, 49280, 0, 49152, 0, 49088, 0, 49024], m.func2(), SIMD.Uint16x8, "Func2");
-equalSimd([1, 0, 2, 0, 3, 0, 4, 0], m.func3(), SIMD.Uint16x8, "Func3");
-equalSimd([1, 2, 3, 4, 5, 6, 7, 8], m.func4(), SIMD.Uint16x8, "Func4");
-equalSimd([43690, 43690, 43690, 43690, 43690, 43690, 43690, 43690], m.func5(), SIMD.Uint16x8, "Func5");
-equalSimd([21845, 21845, 21845, 21845, 21845, 21845, 21845, 21845], m.func6(), SIMD.Uint16x8, "Func6");
+var ret1 = SIMD.Uint16x8.fromInt16x8Bits(m.func1());
+var ret2 = SIMD.Uint16x8.fromInt16x8Bits(m.func2());
+var ret3 = SIMD.Uint16x8.fromInt16x8Bits(m.func3());
+var ret4 = SIMD.Uint16x8.fromInt16x8Bits(m.func4());
+var ret5 = SIMD.Uint16x8.fromInt16x8Bits(m.func5());
+var ret6 = SIMD.Uint16x8.fromInt16x8Bits(m.func6());
+
+equalSimd([18842, 17821, 36864, 17748, 21955, 17446, 54323, 18171], ret1, SIMD.Uint16x8, "Func1");
+equalSimd([0, 49280, 0, 49152, 0, 49088, 0, 49024], ret2, SIMD.Uint16x8, "Func2");
+equalSimd([1, 0, 2, 0, 3, 0, 4, 0], ret3, SIMD.Uint16x8, "Func3");
+equalSimd([1, 2, 3, 4, 5, 6, 7, 8], ret4, SIMD.Uint16x8, "Func4");
+equalSimd([43690, 43690, 43690, 43690, 43690, 43690, 43690, 43690], ret5, SIMD.Uint16x8, "Func5");
+equalSimd([21845, 21845, 21845, 21845, 21845, 21845, 21845, 21845], ret6, SIMD.Uint16x8, "Func6");
 
 
 print("PASS");

--- a/test/SIMD.uint16x8.asmjs/testConversion.js
+++ b/test/SIMD.uint16x8.asmjs/testConversion.js
@@ -22,6 +22,8 @@ function asmModule(stdlib, imports) {
     var f4check = f4.check;
 
     var i8 = stdlib.SIMD.Int16x8;
+    var i8check = i8.check;
+    var i8fromU8bits = i8.fromUint16x8Bits;
     var i16 = stdlib.SIMD.Int8x16;
     var ui16 = stdlib.SIMD.Uint8x16;
     var ui4 = stdlib.SIMD.Uint32x4;
@@ -32,7 +34,7 @@ function asmModule(stdlib, imports) {
     var globImportI4 = i4check(imports.g2);       // global var import
     var g1 = f4(5033.2,3401.0,665.34,32234.1);          // global var initialized
     var g2 = i4(1065353216, 1073741824,1077936128, 1082130432);          // global var initialized
- 
+
     var loopCOUNT = 3;
 
     function conv1()
@@ -47,7 +49,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui8check(x);
+        return i8check(i8fromU8bits(x));
     }
     
     function conv2()
@@ -58,7 +60,7 @@ function asmModule(stdlib, imports) {
         {
             x = ui8fromInt32x4Bits(globImportI4);
         }
-        return ui8check(x);
+        return i8check(i8fromU8bits(x));
     }
 
     function conv3()
@@ -75,7 +77,7 @@ function asmModule(stdlib, imports) {
         }
         while ( (loopIndex | 0) > 0);
 
-        return ui8check(x);
+        return i8check(i8fromU8bits(x));
     }
 
     function conv4()
@@ -90,7 +92,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui8check(x);
+        return i8check(i8fromU8bits(x));
     }
     function conv5()
     {
@@ -101,7 +103,7 @@ function asmModule(stdlib, imports) {
         {
             x = ui8fromInt8x16Bits(m);
         }
-        return ui8check(x);
+        return i8check(i8fromU8bits(x));
     }
    
     function conv6()
@@ -113,7 +115,7 @@ function asmModule(stdlib, imports) {
         {
             x = ui8fromUint8x16Bits(m);
         }
-        return ui8check(x);
+        return i8check(i8fromU8bits(x));
     }
 
     return {
@@ -128,19 +130,26 @@ function asmModule(stdlib, imports) {
 
 var m = asmModule(this, {g1:SIMD.Uint16x8(0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55, 0x55), g2:SIMD.Int32x4(-1065353216, -1073741824,-1077936128, -1082130432)});
 
-// printSimdBaseline(m.func1(), "SIMD.Uint16x8", "m.func1())", "Func1");
-// printSimdBaseline(m.func2(), "SIMD.Uint16x8", "m.func2()", "Func2");
-// printSimdBaseline(m.func3(), "SIMD.Uint16x8", "m.func3()", "Func3");
-// printSimdBaseline(m.func4(), "SIMD.Uint16x8", "m.func4()", "Func4");
-// printSimdBaseline(m.func5(), "SIMD.Uint16x8", "m.func5()", "Func5");
-// printSimdBaseline(m.func6(), "SIMD.Uint16x8", "m.func6()", "Func6");
+var ret1 = SIMD.Uint16x8.fromInt16x8Bits(m.func1());
+var ret2 = SIMD.Uint16x8.fromInt16x8Bits(m.func2());
+var ret3 = SIMD.Uint16x8.fromInt16x8Bits(m.func3());
+var ret4 = SIMD.Uint16x8.fromInt16x8Bits(m.func4());
+var ret5 = SIMD.Uint16x8.fromInt16x8Bits(m.func5());
+var ret6 = SIMD.Uint16x8.fromInt16x8Bits(m.func6());
 
-equalSimd([18842, 17821, 36864, 17748, 21955, 17446, 54323, 18171], m.func1(), SIMD.Uint16x8, "Func1");
-equalSimd([0, 49280, 0, 49152, 0, 49088, 0, 49024], m.func2(), SIMD.Uint16x8, "Func2")
-equalSimd([1, 0, 2, 0, 3, 0, 4, 0], m.func3(), SIMD.Uint16x8, "Func3")
-equalSimd([1, 2, 3, 4, 5, 6, 7, 8], m.func4(), SIMD.Uint16x8, "Func4")
-equalSimd([43690, 43690, 43690, 43690, 43690, 43690, 43690, 43690], m.func5(), SIMD.Uint16x8, "Func5")
-equalSimd([21845, 21845, 21845, 21845, 21845, 21845, 21845, 21845], m.func6(), SIMD.Uint16x8, "Func6")
+// printSimdBaseline(ret1, "SIMD.Uint16x8", "m.func1())", "Func1");
+// printSimdBaseline(ret2, "SIMD.Uint16x8", "m.func2()", "Func2");
+// printSimdBaseline(ret3, "SIMD.Uint16x8", "m.func3()", "Func3");
+// printSimdBaseline(ret4, "SIMD.Uint16x8", "m.func4()", "Func4");
+// printSimdBaseline(ret5, "SIMD.Uint16x8", "m.func5()", "Func5");
+// printSimdBaseline(ret6, "SIMD.Uint16x8", "m.func6()", "Func6");
+
+equalSimd([18842, 17821, 36864, 17748, 21955, 17446, 54323, 18171], ret1, SIMD.Uint16x8, "Func1");
+equalSimd([0, 49280, 0, 49152, 0, 49088, 0, 49024], ret2, SIMD.Uint16x8, "Func2")
+equalSimd([1, 0, 2, 0, 3, 0, 4, 0], ret3, SIMD.Uint16x8, "Func3")
+equalSimd([1, 2, 3, 4, 5, 6, 7, 8], ret4, SIMD.Uint16x8, "Func4")
+equalSimd([43690, 43690, 43690, 43690, 43690, 43690, 43690, 43690], ret5, SIMD.Uint16x8, "Func5")
+equalSimd([21845, 21845, 21845, 21845, 21845, 21845, 21845, 21845], ret6, SIMD.Uint16x8, "Func6")
 
 
 print("PASS");

--- a/test/SIMD.uint16x8.asmjs/testFail.baseline
+++ b/test/SIMD.uint16x8.asmjs/testFail.baseline
@@ -1,0 +1,6 @@
+
+testFail.js(10, 5)
+	Asm.js Compilation Error function : module0::foo
+	Expression for return must be subtype of Signed, Double, or Float
+
+Asm.js compilation failed.

--- a/test/SIMD.uint16x8.asmjs/testFail.js
+++ b/test/SIMD.uint16x8.asmjs/testFail.js
@@ -1,0 +1,16 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function module0(stdlib) {
+    "use asm"
+    var u8 = stdlib.SIMD.Uint16x8;
+    var u8check = u8.check;
+    function foo() {
+        var abc = u8(1,1,1,1,1,1,1,1);
+        return u8check(abc);
+    }
+    return { foo:foo }
+}
+var c = module0(this);

--- a/test/SIMD.uint16x8.asmjs/testFail_1.baseline
+++ b/test/SIMD.uint16x8.asmjs/testFail_1.baseline
@@ -1,0 +1,2 @@
+Invalid SIMD argument type. Expecting Signed arguments.
+Asm.js compilation failed.

--- a/test/SIMD.uint16x8.asmjs/testFail_1.js
+++ b/test/SIMD.uint16x8.asmjs/testFail_1.js
@@ -1,0 +1,17 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function module0(stdlib) {
+    "use asm"
+    var u8 = stdlib.SIMD.Uint16x8;
+    var u8check = u8.check;
+
+    function foo(abc) {
+        abc = u8check(abc);
+        return ;
+    }
+    return { foo:foo }
+}
+var c = module0(this);

--- a/test/SIMD.uint16x8.asmjs/testLoadStore.js
+++ b/test/SIMD.uint16x8.asmjs/testLoadStore.js
@@ -20,6 +20,10 @@ function asmModule(stdlib, imports, buffer) {
 
     var loopCOUNT = 3;
 
+    var i8 = stdlib.SIMD.Int16x8;
+    var i8check = i8.check;
+    var i8fu8 = i8.fromUint16x8Bits;
+
     var Int8Heap = new stdlib.Int8Array (buffer);    
     var Uint8Heap = new stdlib.Uint8Array (buffer);    
 
@@ -51,7 +55,7 @@ function asmModule(stdlib, imports, buffer) {
             t0 = ui8add(t0, y);
             index = (index + 16 ) | 0;
         }
-        return ui8check(t0);
+        return i8check(i8fu8(t0));
     }
 
     function func1()
@@ -75,7 +79,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui8add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui8check(y);
+        return i8check(i8fu8(y));
     }
 
     function func1OOB_1()
@@ -102,7 +106,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui8add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui8check(y);
+        return i8check(i8fu8(y));
     }
     
     function func1OOB_2()
@@ -129,7 +133,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui8add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui8check(y);
+        return i8check(i8fu8(y));
     }
 
     function func2()
@@ -153,7 +157,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui8add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui8check(y);
+        return i8check(i8fu8(y));
     }
 
     function func2OOB_1()
@@ -180,7 +184,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui8add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui8check(y);
+        return i8check(i8fu8(y));
     }
 
     function func2OOB_2()
@@ -230,7 +234,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui8add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui8check(y);
+        return i8check(i8fu8(y));
     }
 
     function func3OOB_1()
@@ -257,7 +261,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui8add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui8check(y);
+        return i8check(i8fu8(y));
     }
 
     function func3OOB_2()
@@ -284,7 +288,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui8add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui8check(y);
+        return i8check(i8fu8(y));
     }
 
     function func4()
@@ -308,7 +312,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui8add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui8check(y);
+        return i8check(i8fu8(y));
     }
 
     function func4OOB_1()
@@ -335,7 +339,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui8add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui8check(y);
+        return i8check(i8fu8(y));
     }
 
     function func4OOB_2()
@@ -362,7 +366,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui8add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui8check(y);
+        return i8check(i8fu8(y));
     }
 
     function func5()
@@ -386,7 +390,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui8add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui8check(y);
+        return i8check(i8fu8(y));
     }
 
     function func5OOB_1()
@@ -412,7 +416,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui8add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui8check(y);
+        return i8check(i8fu8(y));
     }
 
     function func5OOB_2()
@@ -439,7 +443,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui8add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui8check(y);
+        return i8check(i8fu8(y));
     }
 
     function func6()
@@ -463,7 +467,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui8add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui8check(y);
+        return i8check(i8fu8(y));
     }
 
     function func6OOB_1()
@@ -490,7 +494,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui8add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui8check(y);
+        return i8check(i8fu8(y));
     }
 
     function func6OOB_2()
@@ -517,7 +521,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui8add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui8check(y);
+        return i8check(i8fu8(y));
     }
 
     // TODO: Test conversion of returned value
@@ -569,36 +573,36 @@ var m = asmModule(this, {g1:SIMD.Uint16x8(13216, 1024, 28, 108, 55, 65535, 992, 
 
 var ret;
 
-ret = m.func0();
+ret = SIMD.Uint16x8.fromInt16x8Bits(m.func0());
 equalSimd([4, 8, 12, 16, 20, 24, 28, 32], ret, SIMD.Uint16x8, "Test Load Store");
 
 
-ret = m.func1();
+ret = SIMD.Uint16x8.fromInt16x8Bits(m.func1());
 //print("func1");
 equalSimd([10, 20, 30, 40, 50, 60, 70, 80], ret, SIMD.Uint16x8, "Test Load Store");
 
 
-ret = m.func2();
+ret = SIMD.Uint16x8.fromInt16x8Bits(m.func2());
 //print("func3");
 equalSimd([10, 20, 30, 40, 50, 60, 70, 80], ret, SIMD.Uint16x8, "Test Load Store");
 
 
-ret = m.func3();
+ret = SIMD.Uint16x8.fromInt16x8Bits(m.func3());
 //print("func3");
 equalSimd([10, 20, 30, 40, 50, 60, 70, 80], ret, SIMD.Uint16x8, "Test Load Store");
 
 
-ret = m.func4();
+ret = SIMD.Uint16x8.fromInt16x8Bits(m.func4());
 //print("func4");
 equalSimd([10, 20, 30, 40, 50, 60, 70, 80], ret, SIMD.Uint16x8, "Test Load Store");
 
 
-ret = m.func5();
+ret = SIMD.Uint16x8.fromInt16x8Bits(m.func5());
 //print("func5");
 equalSimd([10, 20, 30, 40, 50, 60, 70, 80], ret, SIMD.Uint16x8, "Test Load Store");
 
 
-ret = m.func6();
+ret = SIMD.Uint16x8.fromInt16x8Bits(m.func6());
 //print("func6");
 equalSimd([10, 20, 30, 40, 50, 60, 70, 80], ret, SIMD.Uint16x8, "Test Load Store");
 
@@ -618,7 +622,7 @@ for (var i = 0; i < funcOOB1.length; i ++)
 {
     try
     {
-        ret = funcOOB1[i]();
+        ret = SIMD.Uint16x8.fromInt16x8Bits(funcOOB1[i]());
         //print("func" + (i+1) + "OOB_1");
         equalSimd(RESULTS[i], ret, SIMD.Uint16x8, "Test Load Store");
 
@@ -636,7 +640,7 @@ for (var i = 0; i < funcOOB2.length; i ++)
     //print("func" + (i+1) + "OOB_2");
     try
     {
-        ret = funcOOB2[i]();
+        ret = SIMD.Uint16x8.fromInt16x8Bits(funcOOB2[i]());
         print("Wrong");
         
     } catch(e)

--- a/test/SIMD.uint16x8.asmjs/testMinMax.js
+++ b/test/SIMD.uint16x8.asmjs/testMinMax.js
@@ -17,6 +17,9 @@ function asmModule(stdlib, imports) {
     var ui8g2 = ui8(353, 4929, 1128, 0, 3692, 3937, 9755, 2638);          
 
     var loopCOUNT = 3;
+    var i8 = stdlib.SIMD.Int16x8;
+    var i8check = i8.check;
+    var i8fu8 = i8.fromUint16x8Bits;
 
     function testMinLocal()
     {
@@ -30,7 +33,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui8check(result);
+        return i8check(i8fu8(result));
     }
     
     function testMaxLocal()
@@ -45,7 +48,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui8check(result);
+        return i8check(i8fu8(result));
     }
 
     function testMinGlobal()
@@ -58,7 +61,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui8check(result);
+        return i8check(i8fu8(result));
     }
 
     function testMaxGlobal()
@@ -71,7 +74,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui8check(result);
+        return i8check(i8fu8(result));
     }
 
     function testMinGlobalImport()
@@ -85,7 +88,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui8check(result);
+        return i8check(i8fu8(result));
     }
 
     function testMaxGlobalImport()
@@ -99,7 +102,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui8check(result);
+        return i8check(i8fu8(result));
     }
     
     return { testMinLocal: testMinLocal, testMaxLocal: testMaxLocal, testMinGlobal: testMinGlobal, testMaxGlobal: testMaxGlobal, testMinGlobalImport: testMinGlobalImport, testMaxGlobalImport: testMaxGlobalImport };
@@ -107,10 +110,17 @@ function asmModule(stdlib, imports) {
 
 var m = asmModule(this, {g1:SIMD.Uint16x8(50, 1000, 3092, 3393, 0, 39283838, 0, 838)});
 
-equalSimd([4999, 3401, 0, 1000, 948, 2834, 0, 0], m.testMinLocal(), SIMD.Uint16x8, "testMinLocal");
-equalSimd([5000, 3401, 665, 3224, 1000, 9299, 7748, 25], m.testMaxLocal(), SIMD.Uint16x8, "testMaxLocal");
-equalSimd([106, 0, 10, 0, 3192, 32, 19, 5], m.testMinGlobal(), SIMD.Uint16x8, "testMinGlobal");
-equalSimd([353, 4929, 1128, 1082, 3692, 3937, 9755, 2638], m.testMaxGlobal(), SIMD.Uint16x8, "testMaxGlobal");
-equalSimd([50, 1000, 665, 3224, 0, 2834, 0, 25], m.testMinGlobalImport(), SIMD.Uint16x8, "testMinGlobalImport");
-equalSimd([5033, 3401, 3092, 3393, 948, 27774, 7748, 838], m.testMaxGlobalImport(), SIMD.Uint16x8, "testMaxGlobalImport");
+var ret1 = SIMD.Uint16x8.fromInt16x8Bits(m.testMinLocal());
+var ret2 = SIMD.Uint16x8.fromInt16x8Bits(m.testMaxLocal());
+var ret3 = SIMD.Uint16x8.fromInt16x8Bits(m.testMinGlobal());
+var ret4 = SIMD.Uint16x8.fromInt16x8Bits(m.testMaxGlobal());
+var ret5 = SIMD.Uint16x8.fromInt16x8Bits(m.testMinGlobalImport());
+var ret6 = SIMD.Uint16x8.fromInt16x8Bits(m.testMaxGlobalImport());
+
+equalSimd([4999, 3401, 0, 1000, 948, 2834, 0, 0], ret1, SIMD.Uint16x8, "testMinLocal");
+equalSimd([5000, 3401, 665, 3224, 1000, 9299, 7748, 25], ret2, SIMD.Uint16x8, "testMaxLocal");
+equalSimd([106, 0, 10, 0, 3192, 32, 19, 5], ret3, SIMD.Uint16x8, "testMinGlobal");
+equalSimd([353, 4929, 1128, 1082, 3692, 3937, 9755, 2638], ret4, SIMD.Uint16x8, "testMaxGlobal");
+equalSimd([50, 1000, 665, 3224, 0, 2834, 0, 25], ret5, SIMD.Uint16x8, "testMinGlobalImport");
+equalSimd([5033, 3401, 3092, 3393, 948, 27774, 7748, 838], ret6, SIMD.Uint16x8, "testMaxGlobalImport");
 print("PASS");

--- a/test/SIMD.uint16x8.asmjs/testMisc.js
+++ b/test/SIMD.uint16x8.asmjs/testMisc.js
@@ -68,14 +68,8 @@ var i4 = stdlib.SIMD.Int32x4;
     var u8store             = u8.store              ;
     var u8fromFloat32x4Bits = u8.fromFloat32x4Bits  ;
     var u8fromInt32x4Bits   = u8.fromInt32x4Bits    ;
-    var u8fromInt16x8Bits  = u8.fromInt16x8Bits   ;
     var u8fromUint32x4Bits  = u8.fromUint32x4Bits   ;
     var u8fromUint8x16Bits  = u8.fromUint8x16Bits   ;
-
-    
-   
-    
-
 
     var f4 = stdlib.SIMD.Float32x4;  
     var f4check = f4.check;
@@ -143,6 +137,9 @@ var i4 = stdlib.SIMD.Int32x4;
     
     var loopCOUNT = 3;
 
+    var u8fi8 = u8.fromInt16x8Bits;
+    var i8fu8 = i8.fromUint16x8Bits;
+
     function func1()
     {
         var x = u8(-1, -2, -3, -4, -5, -6, -7, -8);;
@@ -179,7 +176,7 @@ var i4 = stdlib.SIMD.Int32x4;
     
     function func2(a)
     {
-        a = u8check(a);
+        a = i8check(a);
         var x = u8(0, 0, 0, 0, 0, 0, 0, 0);
         var loopIndex = 0;
         var loopCOUNT = 3;
@@ -187,16 +184,16 @@ var i4 = stdlib.SIMD.Int32x4;
         while ( (loopIndex|0) < (loopCOUNT|0)) {
 
             x = u8swizzle(x, 1, 2, 3, 4, 0, 7, 7, 7);
-            x = u8shuffle(a, x, 0, 1, 10, 11, 2, 3, 12, 13);
+            x = u8shuffle(u8fi8(a), x, 0, 1, 10, 11, 2, 3, 12, 13);
             loopIndex = (loopIndex + 1) | 0;
         }
         
-        return u8check(x);
+        return i8check(i8fu8(x));
     }
     
     function func3(a)
     {
-        a = u8check(a);
+        a = i8check(a);
         var x = u8(0, 0, 0, 0, 0, 0, 0, 0);
         var y = u8(0, 0, 0, 0, 0, 0, 0, 0);
         var loopIndex = 0;
@@ -212,17 +209,17 @@ var i4 = stdlib.SIMD.Int32x4;
             loopIndex = (loopIndex + 1) | 0;
         }
         
-        return u8check(y);
+        return i8check(i8fu8(y));
     }
     
     
     function func4(a, b, c, d, e)
     {
-        a = u8check(a);
-        b = u8check(b);
-        c = u8check(c);
-        d = u8check(d);
-        e = u8check(e);
+        a = i8check(a);
+        b = i8check(b);
+        c = i8check(c);
+        d = i8check(d);
+        e = i8check(e);
         var x = u8(0, 0, 0, 0, 0, 0, 0, 0);
         var y = u8(0, 0, 0, 0, 0, 0, 0, 0);
         var loopIndex = 0;
@@ -230,24 +227,24 @@ var i4 = stdlib.SIMD.Int32x4;
         
         
         while ( (loopIndex|0) < (loopCOUNT|0)) {
-            x = u8and(a, b);
-            x = u8or(x, d);
-            x = u8xor(x, e);
+            x = u8and(u8fi8(a), u8fi8(b));
+            x = u8or(x, u8fi8(d));
+            x = u8xor(x, u8fi8(e));
             x = u8not(x);
             
             loopIndex = (loopIndex + 1) | 0;
         }
         
-        return u8check(x);
+        return i8check(i8fu8(x));
     }
     
     function func5(a, b, c, d, e)
     {
-        a = u8check(a);
-        b = u8check(b);
-        c = u8check(c);
-        d = u8check(d);
-        e = u8check(e);
+        a = i8check(a);
+        b = i8check(b);
+        c = i8check(c);
+        d = i8check(d);
+        e = i8check(e);
         var x = u8(0, 0, 0, 0, 0, 0, 0, 0);
         var y = u8(0, 0, 0, 0, 0, 0, 0, 0);
         var loopIndex = 0;
@@ -255,23 +252,23 @@ var i4 = stdlib.SIMD.Int32x4;
         
         
         while ( (loopIndex|0) < (loopCOUNT|0)) {
-            x = u8add(a, b);
-            x = u8sub(x, d);
-            x = u8mul(x, e);
+            x = u8add(u8fi8(a), u8fi8(b));
+            x = u8sub(x, u8fi8(d));
+            x = u8mul(x, u8fi8(e));
             
             loopIndex = (loopIndex + 1) | 0;
         }
         
-        return u8check(x);
+        return i8check(i8fu8(x));
     }
     
     function func6(a, b, c, d, e)
     {
-        a = u8check(a);
-        b = u8check(b);
-        c = u8check(c);
-        d = u8check(d);
-        e = u8check(e);
+        a = i8check(a);
+        b = i8check(b);
+        c = i8check(c);
+        d = i8check(d);
+        e = i8check(e);
         var x = u8(0, 0, 0, 0, 0, 0, 0, 0);
         var y = u8(0, 0, 0, 0, 0, 0, 0, 0);
         var loopIndex = 0;
@@ -279,8 +276,8 @@ var i4 = stdlib.SIMD.Int32x4;
         
         
         while ( (loopIndex|0) < (loopCOUNT|0)) {
-            x = u8min(x, b);
-            y = u8max(y, d);
+            x = u8min(x, u8fi8(b));
+            y = u8max(y, u8fi8(d));
             x = u8shiftLeftByScalar(x, loopIndex>>>0);
             y = u8shiftRightByScalar(y, loopIndex>>>0);
             
@@ -288,7 +285,7 @@ var i4 = stdlib.SIMD.Int32x4;
         }
         x = u8addSaturate(x, x);
         x = u8subSaturate(x, y);
-        return u8check(x);
+        return i8check(i8fu8(x));
     }
     
     
@@ -316,7 +313,7 @@ var i4 = stdlib.SIMD.Int32x4;
             y = u8add(y, t);
             index = (index + 16 ) | 0;
         }
-        return u8check(y);
+        return i8check(i8fu8(y));
     }
     
     function func8()
@@ -339,11 +336,11 @@ var i4 = stdlib.SIMD.Int32x4;
         {
             x = u8add(x, u8fromFloat32x4Bits(v_f4));
             x = u8add(x, u8fromInt32x4Bits(v_i4));
-            x = u8add(x, u8fromInt16x8Bits(v_i8));
+            x = u8add(x, u8fi8(v_i8));
             x = u8add(x, u8fromUint32x4Bits(v_u4));
             x = u8add(x, u8fromUint8x16Bits(v_u16));
         }
-        return u8check(x);
+        return i8check(i8fu8(x));
     }
 
     function bug1() //simd tmp reg reuse.
@@ -353,7 +350,7 @@ var i4 = stdlib.SIMD.Int32x4;
         u8add(x,x);
         return i4check(a);
     }
-    
+
     return {func1:func1, func2: func2, func3:func3, func4:func4,
             func5: func5, func6:func6, func7:func7, func8:func8, bug1:bug1};
 }
@@ -361,39 +358,40 @@ var i4 = stdlib.SIMD.Int32x4;
 var buffer = new ArrayBuffer(0x10000);
 var m = asmModule(this, {g1:SIMD.Float32x4(90934.2,123.9,419.39,449.0), g2:SIMD.Int32x4(-1065353216, -1073741824,-1077936128, -1082130432)}, buffer);
 
-
+var u8fi8 = SIMD.Uint16x8.fromInt16x8Bits;
+var i8fu8 = SIMD.Int16x8.fromUint16x8Bits;
 
 var v1 = SIMD.Uint16x8(1, 2, 3, 4, 5, 6, 7, 8);
 var v2 = SIMD.Uint16x8(134, 211, -333, 422, -165, 999996, 0xffff, 0xf0f0);
 var v3 = SIMD.Uint16x8(0xcccc, -211, 189, 422, -165, -999996, 0xffff, 0xf0f0);
 var ret1 = m.func1();
 
-var ret2 = m.func2(v1);
+var ret2 = u8fi8(m.func2(i8fu8(v1)));
 //printSimdBaseline(ret2, "SIMD.Uint16x8", "ret2", "func2");
 
 
-var ret3 = m.func3(v1);
+var ret3 = u8fi8(m.func3(i8fu8(v1)));
 //printSimdBaseline(ret3, "SIMD.Uint16x8", "ret3", "func3");
 
 
-var ret4 = m.func4(v1, v2, v3, v1, v2);
+var ret4 = u8fi8(m.func4(i8fu8(v1), i8fu8(v2), i8fu8(v3), i8fu8(v1), i8fu8(v2)));
 //printSimdBaseline(ret4, "SIMD.Uint16x8", "ret4", "func4");
 
 
-var ret5 = m.func5(v1, v2, v3, v1, v2);
+var ret5 = u8fi8(m.func5(i8fu8(v1), i8fu8(v2), i8fu8(v3), i8fu8(v1), i8fu8(v2)));
 //printSimdBaseline(ret5, "SIMD.Uint16x8", "ret5", "func5");
 
 
 
-var ret6 = m.func6(v1, v2, v3, v1, v2);
+var ret6 = u8fi8(m.func6(i8fu8(v1), i8fu8(v2), i8fu8(v3), i8fu8(v1), i8fu8(v2)));
 //printSimdBaseline(ret6, "SIMD.Uint16x8", "ret6", "func6");
 
 
-var ret7 = m.func7(v1, v2, v3, v1, v2);
+var ret7 = u8fi8(m.func7(i8fu8(v1), i8fu8(v2), i8fu8(v3), i8fu8(v1), i8fu8(v2)));
 //printSimdBaseline(ret7, "SIMD.Uint16x8", "ret7", "func7");
 
 
-var ret8 = m.func8(v1, v2, v3, v1, v2);
+var ret8 = u8fi8(m.func8(i8fu8(v1), i8fu8(v2), i8fu8(v3), i8fu8(v1), i8fu8(v2)));
 //printSimdBaseline(ret8, "SIMD.Uint16x8", "ret8", "func8");
 
 var ret9 = m.bug1();

--- a/test/SIMD.uint16x8.asmjs/testMul.js
+++ b/test/SIMD.uint16x8.asmjs/testMul.js
@@ -17,6 +17,10 @@ function asmModule(stdlib, imports) {
 
     var loopCOUNT = 3;
 
+    var i8 = stdlib.SIMD.Int16x8;
+    var i8check = i8.check;
+    var i8fu8 = i8.fromUint16x8Bits;
+
     function testMulLocal()
     {
         var a = ui8(5, 10, 15, 20, 25, 30, 35, 40);
@@ -29,7 +33,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui8check(result);
+        return i8check(i8fu8(result));
     }
     function testMulGlobal()
     {    
@@ -41,7 +45,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui8check(result);
+        return i8check(i8fu8(result));
     }
 
     function testMulGlobalImport()
@@ -55,7 +59,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui8check(result);
+        return i8check(i8fu8(result));
     }
     
     return {testMulLocal:testMulLocal, testMulGlobal:testMulGlobal, testMulGlobalImport:testMulGlobalImport};
@@ -63,7 +67,11 @@ function asmModule(stdlib, imports) {
 
 var m = asmModule(this, { g1: SIMD.Uint16x8(5, 10, 15, 20, 25, 30, 35, 40) });
 
-equalSimd([10, 20, 30, 40, 50, 60, 70, 80], m.testMulLocal(), SIMD.Uint16x8, "Test Mul");
-equalSimd([65000, 24464, 30030, 12330, 10, 210, 3000, 45450], m.testMulGlobal(), SIMD.Uint16x8, "Test Mul");
-equalSimd([10, 20, 30, 40, 50, 60, 70, 80], m.testMulGlobalImport(), SIMD.Uint16x8, "Test Mul");
+var ret1 = SIMD.Uint16x8.fromInt16x8Bits(m.testMulLocal());
+var ret2 = SIMD.Uint16x8.fromInt16x8Bits(m.testMulGlobal());
+var ret3 = SIMD.Uint16x8.fromInt16x8Bits(m.testMulGlobalImport());
+
+equalSimd([10, 20, 30, 40, 50, 60, 70, 80], ret1, SIMD.Uint16x8, "Test Mul");
+equalSimd([65000, 24464, 30030, 12330, 10, 210, 3000, 45450], ret2, SIMD.Uint16x8, "Test Mul");
+equalSimd([10, 20, 30, 40, 50, 60, 70, 80], ret3, SIMD.Uint16x8, "Test Mul");
 print("PASS");

--- a/test/SIMD.uint16x8.asmjs/testShift.js
+++ b/test/SIMD.uint16x8.asmjs/testShift.js
@@ -17,6 +17,10 @@ function asmModule(stdlib, imports) {
 
     var loopCOUNT = 8;
 
+    var i8 = stdlib.SIMD.Int16x8;
+    var i8check = i8.check;
+    var i8fu8 = i8.fromUint16x8Bits;
+
     function testShiftLeftScalarLocal()
     {
         var a = ui8(5000, 3401, 665, 3224, 948, 2834, 7748, 25);
@@ -27,7 +31,7 @@ function asmModule(stdlib, imports) {
             a = ui8shiftLeftByScalar(a, 1);
         }
 
-        return ui8check(a);
+        return i8check(i8fu8(a));
     }
     
     function testShiftRightScalarLocal()
@@ -39,7 +43,7 @@ function asmModule(stdlib, imports) {
             a = ui8shiftRightByScalar(a, 1);
         }
 
-        return ui8check(a);
+        return i8check(i8fu8(a));
     }
 
     function testShiftLeftScalarGlobal()
@@ -49,7 +53,7 @@ function asmModule(stdlib, imports) {
         for (loopIndex = 0; (loopIndex | 0) < (loopCOUNT | 0) ; loopIndex = (loopIndex + 1) | 0) {
             ui8g1 = ui8shiftLeftByScalar(ui8g1, 1);
         }
-        return ui8check(ui8g1);
+        return i8check(i8fu8(ui8g1));
     }
 
     function testShiftRightScalarGlobal()
@@ -59,7 +63,7 @@ function asmModule(stdlib, imports) {
         for (loopIndex = 0; (loopIndex | 0) < (loopCOUNT | 0) ; loopIndex = (loopIndex + 1) | 0) {
             ui8g1 = ui8shiftRightByScalar(ui8g1, 1);
         }
-        return ui8check(ui8g1);
+        return i8check(i8fu8(ui8g1));
     }
 
     function testShiftLeftScalarGlobalImport()
@@ -69,7 +73,7 @@ function asmModule(stdlib, imports) {
         for (loopIndex = 0; (loopIndex | 0) < (loopCOUNT | 0) ; loopIndex = (loopIndex + 1) | 0) {
             globImportui8 = ui8shiftLeftByScalar(globImportui8, 1);
         }
-        return ui8check(globImportui8);
+        return i8check(i8fu8(globImportui8));
     }
 
     function testShiftRightScalarGlobalImport()
@@ -79,7 +83,7 @@ function asmModule(stdlib, imports) {
         for (loopIndex = 0; (loopIndex | 0) < (loopCOUNT | 0) ; loopIndex = (loopIndex + 1) | 0) {
             globImportui8 = ui8shiftRightByScalar(globImportui8, 1);
         }
-        return ui8check(globImportui8);
+        return i8check(i8fu8(globImportui8));
     }
 
     function testShiftLeftScalarLocal1()
@@ -93,7 +97,7 @@ function asmModule(stdlib, imports) {
             a = ui8shiftLeftByScalar(a, 17);
         }
 
-        return ui8check(a);
+        return i8check(i8fu8(a));
     }
     
     function testShiftRightScalarLocal1()
@@ -106,7 +110,7 @@ function asmModule(stdlib, imports) {
             a = ui8shiftRightByScalar(a, 17);
         }
 
-        return ui8check(a);
+        return i8check(i8fu8(a));
     }
 
     function testShiftLeftScalarGlobal1()
@@ -117,7 +121,7 @@ function asmModule(stdlib, imports) {
             ui8g1 = ui8shiftLeftByScalar(ui8g1, 16);
             ui8g1 = ui8shiftLeftByScalar(ui8g1, 17);
         }
-        return ui8check(ui8g1);
+        return i8check(i8fu8(ui8g1));
     }
 
     function testShiftRightScalarGlobal1()
@@ -128,7 +132,7 @@ function asmModule(stdlib, imports) {
             ui8g1 = ui8shiftRightByScalar(ui8g1, 16);
             ui8g1 = ui8shiftRightByScalar(ui8g1, 17);
         }
-        return ui8check(ui8g1);
+        return i8check(i8fu8(ui8g1));
     }
 
     function testShiftLeftScalarGlobalImport1()
@@ -139,7 +143,7 @@ function asmModule(stdlib, imports) {
             globImportui8 = ui8shiftLeftByScalar(globImportui8, 16);
             globImportui8 = ui8shiftLeftByScalar(globImportui8, 17);
         }
-        return ui8check(globImportui8);
+        return i8check(i8fu8(globImportui8));
     }
 
     function testShiftRightScalarGlobalImport1()
@@ -150,7 +154,7 @@ function asmModule(stdlib, imports) {
             globImportui8 = ui8shiftRightByScalar(globImportui8, 16);
             globImportui8 = ui8shiftRightByScalar(globImportui8, 17);
         }
-        return ui8check(globImportui8);
+        return i8check(i8fu8(globImportui8));
     }
 
     return {
@@ -163,18 +167,32 @@ function asmModule(stdlib, imports) {
 
 var m = asmModule(this, {g1:SIMD.Uint16x8(50, 1000, 3092, 3393, 0, 39283838, 0, 838)});
 
-equalSimd([34816, 18688, 39168, 38912, 46080, 4608, 17408, 6400], m.testShiftLeftScalarLocal(), SIMD.Uint16x8, "testShift1");
-equalSimd([19, 13, 2, 12, 3, 11, 30, 0], m.testShiftRightScalarLocal(), SIMD.Uint16x8, "testShift2");
-equalSimd([27136, 0, 65280, 14848, 30720, 8192, 4864, 1280], m.testShiftLeftScalarGlobal(), SIMD.Uint16x8, "testShift3");
-equalSimd([106, 0, 255, 58, 120, 32, 19, 5], m.testShiftRightScalarGlobal(), SIMD.Uint16x8, "testShift4");
-equalSimd([12800, 59392, 5120, 16640, 0, 32256, 0, 17920], m.testShiftLeftScalarGlobalImport(), SIMD.Uint16x8, "testShift5");
-equalSimd([50, 232, 20, 65, 0, 126, 0, 70], m.testShiftRightScalarGlobalImport(), SIMD.Uint16x8, "testShift");
+var ret1 = SIMD.Uint16x8.fromInt16x8Bits(m.testShiftLeftScalarLocal());
+var ret2 = SIMD.Uint16x8.fromInt16x8Bits(m.testShiftRightScalarLocal());
+var ret3 = SIMD.Uint16x8.fromInt16x8Bits(m.testShiftLeftScalarGlobal());
+var ret4 = SIMD.Uint16x8.fromInt16x8Bits(m.testShiftRightScalarGlobal());
+var ret5 = SIMD.Uint16x8.fromInt16x8Bits(m.testShiftLeftScalarGlobalImport());
+var ret6 = SIMD.Uint16x8.fromInt16x8Bits(m.testShiftRightScalarGlobalImport());
 
-equalSimd([34816, 18688, 39168, 38912, 46080, 4608, 17408, 6400], m.testShiftLeftScalarLocal1(), SIMD.Uint16x8, "testShift1_1");
-equalSimd([19, 13, 2, 12, 3, 11, 30, 0], m.testShiftRightScalarLocal1(), SIMD.Uint16x8, "testShift2_1");
-equalSimd([27136, 0, 65280, 14848, 30720, 8192, 4864, 1280], m.testShiftLeftScalarGlobal1(), SIMD.Uint16x8, "testShift3_1");
-equalSimd([106, 0, 255, 58, 120, 32, 19, 5], m.testShiftRightScalarGlobal1(), SIMD.Uint16x8, "testShift4_1");
-equalSimd([12800, 59392, 5120, 16640, 0, 32256, 0, 17920], m.testShiftLeftScalarGlobalImport1(), SIMD.Uint16x8, "testShift5_1");
-equalSimd([50, 232, 20, 65, 0, 126, 0, 70], m.testShiftRightScalarGlobalImport1(), SIMD.Uint16x8, "testShift_1");
+equalSimd([34816, 18688, 39168, 38912, 46080, 4608, 17408, 6400], ret1, SIMD.Uint16x8, "testShift1");
+equalSimd([19, 13, 2, 12, 3, 11, 30, 0], ret2, SIMD.Uint16x8, "testShift2");
+equalSimd([27136, 0, 65280, 14848, 30720, 8192, 4864, 1280],ret3, SIMD.Uint16x8, "testShift3");
+equalSimd([106, 0, 255, 58, 120, 32, 19, 5], ret4, SIMD.Uint16x8, "testShift4");
+equalSimd([12800, 59392, 5120, 16640, 0, 32256, 0, 17920], ret5, SIMD.Uint16x8, "testShift5");
+equalSimd([50, 232, 20, 65, 0, 126, 0, 70], ret6, SIMD.Uint16x8, "testShift");
+
+var ret7 = SIMD.Uint16x8.fromInt16x8Bits(m.testShiftLeftScalarLocal1());
+var ret8 = SIMD.Uint16x8.fromInt16x8Bits(m.testShiftRightScalarLocal1());
+var ret9 = SIMD.Uint16x8.fromInt16x8Bits(m.testShiftLeftScalarGlobal1());
+var ret10 = SIMD.Uint16x8.fromInt16x8Bits(m.testShiftRightScalarGlobal1());
+var ret11 = SIMD.Uint16x8.fromInt16x8Bits(m.testShiftLeftScalarGlobalImport1());
+var ret12 = SIMD.Uint16x8.fromInt16x8Bits(m.testShiftRightScalarGlobalImport1());
+
+equalSimd([34816, 18688, 39168, 38912, 46080, 4608, 17408, 6400], ret7, SIMD.Uint16x8, "testShift1_1");
+equalSimd([19, 13, 2, 12, 3, 11, 30, 0], ret2, SIMD.Uint16x8, "testShift2_1");
+equalSimd([27136, 0, 65280, 14848, 30720, 8192, 4864, 1280], ret3, SIMD.Uint16x8, "testShift3_1");
+equalSimd([106, 0, 255, 58, 120, 32, 19, 5], ret4, SIMD.Uint16x8, "testShift4_1");
+equalSimd([12800, 59392, 5120, 16640, 0, 32256, 0, 17920], ret5, SIMD.Uint16x8, "testShift5_1");
+equalSimd([50, 232, 20, 65, 0, 126, 0, 70], ret6, SIMD.Uint16x8, "testShift_1");
 
 print("PASS");

--- a/test/SIMD.uint16x8.asmjs/testShuffle.js
+++ b/test/SIMD.uint16x8.asmjs/testShuffle.js
@@ -19,6 +19,10 @@ function asmModule(stdlib, imports) {
 
     var loopCOUNT = 3;
 
+    var i8 = stdlib.SIMD.Int16x8;
+    var i8check = i8.check;
+    var i8fu8 = i8.fromUint16x8Bits;
+
     function testShuffleLocal() {
         var a = ui8(5033, 3401, 665, 3234, 948, 2834, 7748, 25);
         var b = ui8(3483, 2144, 5697, 65, 1000000, 984, 3434, 9876);
@@ -30,7 +34,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui8check(result);
+        return i8check(i8fu8(result));
     }
 
     function testShuffleGlobal() {
@@ -42,7 +46,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui8check(result);
+        return i8check(i8fu8(result));
     }
 
     function testShuffleGlobalImport() {
@@ -55,7 +59,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui8check(result);
+        return i8check(i8fu8(result));
     }
     
     function testShuffleFunc() {
@@ -68,7 +72,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui8check(result);
+        return i8check(i8fu8(result));
     }
 
     return { testShuffleLocal: testShuffleLocal, testShuffleGlobal: testShuffleGlobal, testShuffleGlobalImport: testShuffleGlobalImport, testShuffleFunc: testShuffleFunc };
@@ -76,10 +80,15 @@ function asmModule(stdlib, imports) {
 
 var m = asmModule(this, { g1: SIMD.Uint16x8(50, 1000, 3092, 3393, Infinity, 39238, NaN, 838) });
 
-equalSimd([5033, 3401, 948, 2834, 3483, 3234, 665, 7748], m.testShuffleLocal(), SIMD.Uint16x8, "");
-equalSimd([10, 1073, 10402, 12332, 35316, 1082, 107, 311], m.testShuffleGlobal(), SIMD.Uint16x8, "");
-equalSimd([5033, 3401, 948, 2834, 50, 3234, 665, 7748], m.testShuffleGlobalImport(), SIMD.Uint16x8, "");
-equalSimd([5043, 4474, 11350, 15166, 50330, 4316, 772, 8059], m.testShuffleFunc(), SIMD.Uint16x8, "");
+var ret1 = SIMD.Uint16x8.fromInt16x8Bits(m.testShuffleLocal());
+var ret2 = SIMD.Uint16x8.fromInt16x8Bits(m.testShuffleGlobal());
+var ret3 = SIMD.Uint16x8.fromInt16x8Bits(m.testShuffleGlobalImport());
+var ret4 = SIMD.Uint16x8.fromInt16x8Bits(m.testShuffleFunc());
+
+equalSimd([5033, 3401, 948, 2834, 3483, 3234, 665, 7748], ret1, SIMD.Uint16x8, "");
+equalSimd([10, 1073, 10402, 12332, 35316, 1082, 107, 311], ret2, SIMD.Uint16x8, "");
+equalSimd([5033, 3401, 948, 2834, 50, 3234, 665, 7748], ret3, SIMD.Uint16x8, "");
+equalSimd([5043, 4474, 11350, 15166, 50330, 4316, 772, 8059], ret4, SIMD.Uint16x8, "");
 
 print("PASS");
 

--- a/test/SIMD.uint16x8.asmjs/testSplat.js
+++ b/test/SIMD.uint16x8.asmjs/testSplat.js
@@ -14,6 +14,10 @@ function asmModule(stdlib, imports) {
 
     var loopCOUNT = 3;
 
+    var i8 = stdlib.SIMD.Int16x8;
+    var i8check = i8.check;
+    var i8fu8 = i8.fromUint16x8Bits;
+
     function splat1()
     {
         var a = ui8(0, 0, 0, 0, 0, 0, 0, 0);
@@ -23,7 +27,7 @@ function asmModule(stdlib, imports) {
             a = ui8splat(65535);
             loopIndex = (loopIndex + 1) | 0;
         }   
-        return ui8check(a);
+        return i8check(i8fu8(a));
     }
     
     function splat2()
@@ -36,7 +40,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui8check(a);
+        return i8check(i8fu8(a));
     }
 
     function splat3()
@@ -49,7 +53,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui8check(a);
+        return i8check(i8fu8(a));
     }
     
     function value()
@@ -68,9 +72,9 @@ function asmModule(stdlib, imports) {
 
 var m = asmModule(this, {g1:SIMD.Uint16x8(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)});
 
-var ret1 = m.func1();
-var ret2 = m.func2();
-var ret3 = m.func3();
+var ret1 = SIMD.Uint16x8.fromInt16x8Bits(m.func1());
+var ret2 = SIMD.Uint16x8.fromInt16x8Bits(m.func2());
+var ret3 = SIMD.Uint16x8.fromInt16x8Bits(m.func3());
 
 equalSimd([65535, 65535, 65535, 65535, 65535, 65535, 65535, 65535], ret1, SIMD.Uint16x8, "");
 equalSimd([4951, 4951, 4951, 4951, 4951, 4951, 4951, 4951], ret2, SIMD.Uint16x8, "");

--- a/test/SIMD.uint16x8.asmjs/testSwizzle.js
+++ b/test/SIMD.uint16x8.asmjs/testSwizzle.js
@@ -6,62 +6,66 @@ this.WScript.LoadScriptFile("..\\UnitTestFramework\\SimdJsHelpers.js");
 function asmModule(stdlib, imports) {
     "use asm";
 
-    var i16 = stdlib.SIMD.Uint16x8;
-    var i16check = i16.check;
-    var i16swizzle = i16.swizzle;
-    var i16add = i16.add;
-    var i16mul = i16.mul;
+    var u8 = stdlib.SIMD.Uint16x8;
+    var u8check = u8.check;
+    var u8swizzle = u8.swizzle;
+    var u8add = u8.add;
+    var u8mul = u8.mul;
 
-    var globImporti16 = i16check(imports.g1);
+    var globImportu8 = u8check(imports.g1);
 
-    var i16g1 = i16(1, 2, 3, 4, 5, 6, 7, 8);
+    var u8g1 = u8(1, 2, 3, 4, 5, 6, 7, 8);
 
     var loopCOUNT = 3;
 
+    var i8 = stdlib.SIMD.Int16x8
+    var i8check = i8.check;
+    var i8fu8 = i8.fromUint16x8Bits;
+
     function testswizzleLocal() {
-        var a = i16(1, 2, 3, 4, 5, 6, 7, 8);
-        var result = i16(0, 0, 0, 0, 0, 0, 0, 0);
+        var a = u8(1, 2, 3, 4, 5, 6, 7, 8);
+        var result = u8(0, 0, 0, 0, 0, 0, 0, 0);
         var loopIndex = 0;
 
         while ((loopIndex | 0) < (loopCOUNT | 0)) {
-            result = i16swizzle(a, 0, 1, 4, 5, 7, 4, 2, 3);
+            result = u8swizzle(a, 0, 1, 4, 5, 7, 4, 2, 3);
             loopIndex = (loopIndex + 1) | 0;
         }   
-        return i16check(result);
+        return i8check(i8fu8(result));
     }
 
     function testswizzleGlobal() {
-        var result = i16(0, 0, 0, 0, 0, 0, 0, 0);
+        var result = u8(0, 0, 0, 0, 0, 0, 0, 0);
         var loopIndex = 0;
 
         while ((loopIndex | 0) < (loopCOUNT | 0)) {
-            result = i16swizzle(i16g1, 0, 1, 4, 5, 7, 4, 2, 3);
+            result = u8swizzle(u8g1, 0, 1, 4, 5, 7, 4, 2, 3);
             loopIndex = (loopIndex + 1) | 0;
         }
-        return i16check(result);
+        return i8check(i8fu8(result));
     }
 
     function testswizzleGlobalImport() {
-        var result = i16(0, 0, 0, 0, 0, 0, 0, 0);
+        var result = u8(0, 0, 0, 0, 0, 0, 0, 0);
         var loopIndex = 0;
 
         while ((loopIndex | 0) < (loopCOUNT | 0)) {
-            result = i16swizzle(globImporti16, 0, 1, 4, 5, 7, 4, 2, 3);
+            result = u8swizzle(globImportu8, 0, 1, 4, 5, 7, 4, 2, 3);
             loopIndex = (loopIndex + 1) | 0;
         }
-        return i16check(result);
+        return i8check(i8fu8(result));
     }
 
     function testswizzleFunc() {
-        var a = i16(1, 2, 3, 4, 5, 6, 7, 8);
-        var result = i16(0, 0, 0, 0, 0, 0, 0, 0);
+        var a = u8(1, 2, 3, 4, 5, 6, 7, 8);
+        var result = u8(0, 0, 0, 0, 0, 0, 0, 0);
         var loopIndex = 0;
 
         while ((loopIndex | 0) < (loopCOUNT | 0)) {
-            result = i16swizzle(i16add(a, i16g1), 0, 1, 4, 5, 7, 4, 2, 3);
+            result = u8swizzle(u8add(a, u8g1), 0, 1, 4, 5, 7, 4, 2, 3);
             loopIndex = (loopIndex + 1) | 0;
         }
-        return i16check(result);
+        return i8check(i8fu8(result));
     }
 
     return { testswizzleLocal: testswizzleLocal, testswizzleGlobal: testswizzleGlobal, testswizzleGlobalImport: testswizzleGlobalImport, testswizzleFunc: testswizzleFunc };
@@ -69,10 +73,15 @@ function asmModule(stdlib, imports) {
 
 var m = asmModule(this, { g1: SIMD.Uint16x8(50, 1000, 3092, 3393, 8838, 63838, NaN, 838) });
 
-equalSimd([1, 2, 5, 6, 8, 5, 3, 4], m.testswizzleLocal(), SIMD.Uint16x8, "");
-equalSimd([1, 2, 5, 6, 8, 5, 3, 4], m.testswizzleGlobal(), SIMD.Uint16x8, "");
-equalSimd([50, 1000, 8838, 63838, 838, 8838, 3092, 3393], m.testswizzleGlobalImport(), SIMD.Uint16x8, "");
-equalSimd([2, 4, 10, 12, 16, 10, 6, 8], m.testswizzleFunc(), SIMD.Uint16x8, "");
+var ret1 = SIMD.Uint16x8.fromInt16x8Bits(m.testswizzleLocal());
+var ret2 = SIMD.Uint16x8.fromInt16x8Bits(m.testswizzleGlobal());
+var ret3 = SIMD.Uint16x8.fromInt16x8Bits(m.testswizzleGlobalImport());
+var ret4 = SIMD.Uint16x8.fromInt16x8Bits(m.testswizzleFunc());
+
+equalSimd([1, 2, 5, 6, 8, 5, 3, 4], ret1, SIMD.Uint16x8, "");
+equalSimd([1, 2, 5, 6, 8, 5, 3, 4], ret2, SIMD.Uint16x8, "");
+equalSimd([50, 1000, 8838, 63838, 838, 8838, 3092, 3393], ret3, SIMD.Uint16x8, "");
+equalSimd([2, 4, 10, 12, 16, 10, 6, 8], ret4, SIMD.Uint16x8, "");
 print("PASS");
 
 

--- a/test/SIMD.uint32x4.asmjs/rlexe.xml
+++ b/test/SIMD.uint32x4.asmjs/rlexe.xml
@@ -49,6 +49,22 @@
   </test>
   <test>
     <default>
+      <files>testFail.js</files>
+      <baseline>testFail.baseline</baseline>
+      <tags>exclude_dynapogo,exclude_ship</tags>
+      <compile-flags>-off:deferparse -testtrace:asmjs -simdjs -bgjit- -maic:1</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
+      <files>testFail_1.js</files>
+      <baseline>testFail_1.baseline</baseline>
+      <tags>exclude_dynapogo,exclude_ship</tags>
+      <compile-flags>-off:deferparse -testtrace:asmjs -simdjs -bgjit- -maic:1</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>testComparison.js</files>
       <baseline>asmjs.baseline</baseline>
       <tags>exclude_dynapogo,exclude_ship</tags>

--- a/test/SIMD.uint32x4.asmjs/testAddSub.js
+++ b/test/SIMD.uint32x4.asmjs/testAddSub.js
@@ -16,6 +16,9 @@ function asmModule(stdlib, imports) {
     var ui4g2 = ui4(6531634, 74182444, 779364128, 821730432);
 
     var loopCOUNT = 3;
+    var i4 = stdlib.SIMD.Int32x4;
+    var i4check = i4.check;
+    var i4fu4 = i4.fromUint32x4Bits;
 
     function testAddLocal()
     {
@@ -29,7 +32,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui4check(result);
+        return i4check(i4fu4(result));
     }
     
     function testSubLocal()
@@ -44,7 +47,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui4check(result);
+        return i4check(i4fu4(result));
     }
 
     function testAddGlobal()
@@ -57,7 +60,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui4check(result);
+        return i4check(i4fu4(result));
     }
     
     function testSubGlobal()
@@ -70,7 +73,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui4check(result);
+        return i4check(i4fu4(result));
     }
     
     function testAddGlobalImport()
@@ -84,7 +87,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui4check(result);
+        return i4check(i4fu4(result));
     }
     
     function testSubGlobalImport()
@@ -98,7 +101,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui4check(result);
+        return i4check(i4fu4(result));
     }
     
     return { testAddLocal: testAddLocal, testSubLocal: testSubLocal, testAddGlobal: testAddGlobal, testSubGlobal: testSubGlobal, testAddGlobalImport: testAddGlobalImport, testSubGlobalImport: testSubGlobalImport };
@@ -106,10 +109,17 @@ function asmModule(stdlib, imports) {
 
 var m = asmModule(this, {g1:SIMD.Uint32x4(100, 1073741824, 1028, 102)});
 
-equalSimd([107861105, 23697240, 918264761, 1009503884], m.testAddLocal(), SIMD.Uint32x4, "Func1");
-equalSimd([4204083159, 4280967752, 3436654413, 3304451156], m.testSubLocal(), SIMD.Uint32x4, "Func2");
-equalSimd([1071884850, 1147924268, 1857300256, 1903860864], m.testAddGlobal(), SIMD.Uint32x4, "Func3");
-equalSimd([1058821582, 999559380, 298572000, 260400000], m.testSubGlobal(), SIMD.Uint32x4, "Func4");
-equalSimd([8488584, 1078590672, 29976967, 9493974], m.testAddGlobalImport(), SIMD.Uint32x4, "Func5");
-equalSimd([4286478912, 1068892976, 4264992385, 4285473526], m.testSubGlobalImport(), SIMD.Uint32x4, "Func6");
+var ret1 = SIMD.Uint32x4.fromInt32x4Bits(m.testAddLocal());
+var ret2 = SIMD.Uint32x4.fromInt32x4Bits(m.testSubLocal());
+var ret3 = SIMD.Uint32x4.fromInt32x4Bits(m.testAddGlobal());
+var ret4 = SIMD.Uint32x4.fromInt32x4Bits(m.testSubGlobal());
+var ret5 = SIMD.Uint32x4.fromInt32x4Bits(m.testAddGlobalImport());
+var ret6 = SIMD.Uint32x4.fromInt32x4Bits(m.testSubGlobalImport());
+
+equalSimd([107861105, 23697240, 918264761, 1009503884], ret1, SIMD.Uint32x4, "Func1");
+equalSimd([4204083159, 4280967752, 3436654413, 3304451156], ret2, SIMD.Uint32x4, "Func2");
+equalSimd([1071884850, 1147924268, 1857300256, 1903860864], ret3, SIMD.Uint32x4, "Func3");
+equalSimd([1058821582, 999559380, 298572000, 260400000], ret4, SIMD.Uint32x4, "Func4");
+equalSimd([8488584, 1078590672, 29976967, 9493974], ret5, SIMD.Uint32x4, "Func5");
+equalSimd([4286478912, 1068892976, 4264992385, 4285473526], ret6, SIMD.Uint32x4, "Func6");
 print("PASS");

--- a/test/SIMD.uint32x4.asmjs/testBitwise.js
+++ b/test/SIMD.uint32x4.asmjs/testBitwise.js
@@ -30,6 +30,10 @@ function asmModule(stdlib, imports) {
     var gval2 = 1234.0;
 
     var loopCOUNT = 3;
+    
+    var i4 = stdlib.SIMD.Int32x4;
+    var i4check = i4.check;
+    var i4fu4 = i4.fromUint32x4Bits;
 
     function func1()
     {
@@ -50,7 +54,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui4check(d);
+        return i4check(i4fu4(d));
     }
     
     function func2()
@@ -71,7 +75,7 @@ function asmModule(stdlib, imports) {
             
         }
 
-        return ui4check(d);
+        return i4check(i4fu4(d));
     }
 
     function func3()
@@ -94,7 +98,7 @@ function asmModule(stdlib, imports) {
         }
         while ( (loopIndex | 0) > 0);
 
-        return ui4check(ui4g1);
+        return i4check(i4fu4(ui4g1));
     }
     
     
@@ -103,7 +107,12 @@ function asmModule(stdlib, imports) {
 
 var m = asmModule(this, { g1: SIMD.Uint32x4(100, 1073741824, 1028, 102) });
 
-equalSimd([1, 1, 1, 1], m.func1(), SIMD.Uint32x4, "Func1");
-equalSimd([8488513, 1078590673, 29974920, 9493783], m.func2(), SIMD.Uint32x4, "Func2");
-equalSimd([91080810, 22439513, 893080502, 990522477], m.func3(), SIMD.Uint32x4, "Func3");
+var ret1 = SIMD.Uint32x4.fromInt32x4Bits(m.func1());
+var ret2 = SIMD.Uint32x4.fromInt32x4Bits(m.func2());
+var ret3 = SIMD.Uint32x4.fromInt32x4Bits(m.func3());
+
+
+equalSimd([1, 1, 1, 1], ret1, SIMD.Uint32x4, "Func1");
+equalSimd([8488513, 1078590673, 29974920, 9493783], ret2, SIMD.Uint32x4, "Func2");
+equalSimd([91080810, 22439513, 893080502, 990522477], ret3, SIMD.Uint32x4, "Func3");
 print("PASS");

--- a/test/SIMD.uint32x4.asmjs/testCalls.js
+++ b/test/SIMD.uint32x4.asmjs/testCalls.js
@@ -81,13 +81,14 @@ function asmModule(stdlib, imports) {
     var gval2 = 1234.0;
 
 
-    
+    var i4fu4 = i4.fromUint32x4Bits;
+    var u4fi4 = u4.fromInt32x4Bits;
     var loopCOUNT = 3;
 
     function func1(a, b)
     {
-        a = u4check(a);
-        b = u4check(b);
+        a = i4check(a);
+        b = i4check(b);
         var x = u4(-1, -2, -3, -4);;
 
         var loopIndex = 0;
@@ -100,41 +101,38 @@ function asmModule(stdlib, imports) {
         x = globImportU4;
         g2 = x;
 
-        return u4check(x);
+        return i4check(i4fu4(x));
     }
     
     function func2(a, b, c, d)
     {
-        a = u4check(a);
-        b = u4check(b);
-        c = u4check(c);
-        d = u4check(d);
+        a = i4check(a);
+        b = i4check(b);
+        c = i4check(c);
+        d = i4check(d);
         var x = u4(-1, -2, -3, -4);
         var y = u4(1, 2, 3, 4);
         var loopIndex = 0;
         for (loopIndex = 0; (loopIndex | 0) < (loopCOUNT | 0) ; loopIndex = (loopIndex + 1) | 0)
         {
-
-            x = u4check(func1(a, b));
-            y = u4check(func1(c, d));
-            
-
+            x = u4fi4(i4check(func1(a, b)));
+            y = u4fi4(i4check(func1(c, d)));
         }
 
-        //return u4check(i8add(x,y));
-        return u4check(x);
+        //return i4check(i8add(x,y));
+        return i4check(i4fu4(x));
     }
 
     function func3(a, b, c, d, e, f, g, h)
     {
-        a = u4check(a);
-        b = u4check(b);
-        c = u4check(c);
-        d = u4check(d);
-        e = u4check(e);
-        f = u4check(f);
-        g = u4check(g);
-        h = u4check(h);        
+        a = i4check(a);
+        b = i4check(b);
+        c = i4check(c);
+        d = i4check(d);
+        e = i4check(e);
+        f = i4check(f);
+        g = i4check(g);
+        h = i4check(h);        
         
         var x = u4(-1, -2, -3, -4);
         var y = u4(1, 2, 3, 4);
@@ -142,13 +140,13 @@ function asmModule(stdlib, imports) {
         for (loopIndex = 0; (loopIndex | 0) < (loopCOUNT | 0) ; loopIndex = (loopIndex + 1) | 0)
         {
 
-            x = u4check(func2(a, b, c, d));
-            y = u4check(func2(e, f, g, h));
+            x = u4fi4(i4check(func2(a, b, c, d)))
+            y = u4fi4(i4check(func2(e, f, g, h)));
             
         }
 
-        //return u4check(i8add(x,y));
-        return u4check(x);
+        //return i4check(i8add(x,y));
+        return i4check(i4fu4(x));
     }
 
     function func4() { //Testing for a bug while returning SIMD values from a loop
@@ -158,7 +156,7 @@ function asmModule(stdlib, imports) {
         for (i = 0; (i | 0) < 1000; i = (i + 1)|0) {
             //value1 = i8add(value1, i8splat(1));
             if ((i | 0) == 300) {
-                return u4check(value1);
+                return i4check(i4fu4(value1));
             }
         }
     }
@@ -183,14 +181,14 @@ function asmModule(stdlib, imports) {
 
     function fctest(a)
     {
-        a = u4check(a);
+        a = i4check(a);
         return a;
     }
     function fcBug_1()
     {
         var x = i4(1, 2, 3, 4);
         var k = u4(1, 2, 3, 4);
-        k = u4check(fctest(k));
+        k = u4fi4(i4check(fctest(i4fu4(k))));
         return i4check(x);
     }
     function fcBug_2()
@@ -198,7 +196,7 @@ function asmModule(stdlib, imports) {
         var x = i4(1, 2, 3, 4);
         var k = u4(1, 2, 3, 4);
         x = i4check(fcBug_1());
-        return u4check(k);
+        return i4check(i4fu4(k));
     }
 
     return {func1:func1, func2:func2, func3:func3, func4:func4, func5:fcBug_1, func6:fcBug_2};
@@ -215,12 +213,14 @@ var s6 = SIMD.Uint32x4(1.0, -2.0, 3.0, 4.0);
 var s7 = SIMD.Uint32x4(1.0, 2.0, -3.0, 4.0);
 var s8 = SIMD.Uint32x4(1.0, 2.0, 3.0, -4.0);
 
-var ret1 = m.func1(s1, s2);
-var ret2 = m.func2(s1, s2, s3, s4);
-var ret3 = m.func3(s1, s2, s3, s4, s5, s6, s7, s8);
-var ret4 = m.func4();
+var i4fu4 = SIMD.Int32x4.fromUint32x4Bits;
+var u4fi4 = SIMD.Uint32x4.fromInt32x4Bits;
+var ret1 = u4fi4(m.func1(i4fu4(s1), i4fu4(s2)));
+var ret2 = u4fi4(m.func2(i4fu4(s1), i4fu4(s2), i4fu4(s3), i4fu4(s4)));
+var ret3 = u4fi4(m.func3(i4fu4(s1), i4fu4(s2), i4fu4(s3), i4fu4(s4), i4fu4(s5), i4fu4(s6), i4fu4(s7), i4fu4(s8)));
+var ret4 = u4fi4(m.func4());
 var ret5 = m.func5();
-var ret6 = m.func6();
+var ret6 = u4fi4(m.func6());
 
 /*
 printSimdBaseline(ret1, "SIMD.Uint32x4", "ret1", "func1");

--- a/test/SIMD.uint32x4.asmjs/testComparisonSelect.js
+++ b/test/SIMD.uint32x4.asmjs/testComparisonSelect.js
@@ -23,6 +23,10 @@ function asmModule(stdlib, imports) {
     var ui4g2 = ui4(6531634, 74182444, 779364128, 821730432);
 
     var loopCOUNT = 5;
+    
+    var i4 = stdlib.SIMD.Int32x4;
+    var i4check = i4.check;
+    var i4fu4 = i4.fromUint32x4Bits;
 
     function testLessThan()
     {
@@ -40,7 +44,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui4check(d);
+        return i4check(i4fu4(d));
     }
 
     function testLessThanOrEqual()
@@ -59,7 +63,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui4check(d);
+        return i4check(i4fu4(d));
     }
 
     function testGreaterThan()
@@ -78,7 +82,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui4check(d);
+        return i4check(i4fu4(d));
     }
 
     function testGreaterThanOrEqual()
@@ -97,7 +101,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui4check(d);
+        return i4check(i4fu4(d));
     }
 
     function testEqual()
@@ -116,7 +120,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui4check(d);
+        return i4check(i4fu4(d));
     }
 
     function testNotEqual()
@@ -135,7 +139,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui4check(d);
+        return i4check(i4fu4(d));
     }
 
     return { testLessThan: testLessThan, testLessThanOrEqual: testLessThanOrEqual, testGreaterThan: testGreaterThan, testGreaterThanOrEqual: testGreaterThanOrEqual, testEqual: testEqual, testNotEqual: testNotEqual };
@@ -143,12 +147,19 @@ function asmModule(stdlib, imports) {
 
 var m = asmModule(this, { g1: SIMD.Uint32x4(100, 1073741824, 1028, 102) });
 
-equalSimd([99371, 4848848, 29975939, 100012], m.testLessThan(), SIMD.Uint32x4, "Func1");
-equalSimd([8488484, 4848848, 29975939, 9493872], m.testLessThanOrEqual(), SIMD.Uint32x4, "Func2");
-equalSimd([99372621, 18848392, 888288822, 1000010012], m.testGreaterThan(), SIMD.Uint32x4, "Func3");
-equalSimd([99372621, 18848392, 888288822, 1000010012], m.testGreaterThanOrEqual(), SIMD.Uint32x4, "Func4");
-equalSimd([99372621, 18848392, 888288822, 1000010012], m.testEqual(), SIMD.Uint32x4, "Func5");
-equalSimd([8488484, 4848848, 29975939, 9493872], m.testNotEqual(), SIMD.Uint32x4, "Func6");
+var ret1 = SIMD.Uint32x4.fromInt32x4Bits(m.testLessThan());
+var ret2 = SIMD.Uint32x4.fromInt32x4Bits(m.testLessThanOrEqual());
+var ret3 = SIMD.Uint32x4.fromInt32x4Bits(m.testGreaterThan());
+var ret4 = SIMD.Uint32x4.fromInt32x4Bits(m.testGreaterThanOrEqual());
+var ret5 = SIMD.Uint32x4.fromInt32x4Bits(m.testEqual());
+var ret6 = SIMD.Uint32x4.fromInt32x4Bits(m.testNotEqual());
+
+equalSimd([99371, 4848848, 29975939, 100012], ret1, SIMD.Uint32x4, "Func1");
+equalSimd([8488484, 4848848, 29975939, 9493872], ret2, SIMD.Uint32x4, "Func2");
+equalSimd([99372621, 18848392, 888288822, 1000010012], ret3, SIMD.Uint32x4, "Func3");
+equalSimd([99372621, 18848392, 888288822, 1000010012], ret4, SIMD.Uint32x4, "Func4");
+equalSimd([99372621, 18848392, 888288822, 1000010012], ret5, SIMD.Uint32x4, "Func5");
+equalSimd([8488484, 4848848, 29975939, 9493872], ret6, SIMD.Uint32x4, "Func6");
 
 print("PASS");
 

--- a/test/SIMD.uint32x4.asmjs/testConstructorLanes.js
+++ b/test/SIMD.uint32x4.asmjs/testConstructorLanes.js
@@ -17,6 +17,10 @@ function asmModule(stdlib, imports) {
     var vectorLength = 8;
 
     var loopCOUNT = 3;
+       
+    var i4 = stdlib.SIMD.Int32x4;
+    var i4check = i4.check;
+    var i4fu4 = i4.fromUint32x4Bits;
 
     function testLocal() {
         var a = ui4(8488484, 4848848, 29975939, 9493872);
@@ -46,7 +50,7 @@ function asmModule(stdlib, imports) {
 
             loopIndex = (loopIndex + 1) | 0;
         }
-        return ui4check(result);
+        return i4check(i4fu4(result));
     }
     
         function testGlobal() {
@@ -77,7 +81,7 @@ function asmModule(stdlib, imports) {
                 loopIndex = (loopIndex + 1) | 0;
             }
 
-            return ui4check(result);
+        return i4check(i4fu4(result));
         }
 
         function testGlobalImport() {
@@ -108,16 +112,20 @@ function asmModule(stdlib, imports) {
                 loopIndex = (loopIndex + 1) | 0;
             }
 
-            return ui4check(result);
+        return i4check(i4fu4(result));
         }
         
         return { testLocal: testLocal, testGlobal: testGlobal, testGlobalImport: testGlobalImport };
     }
 
     var m = asmModule(this, { g1: SIMD.Uint32x4(100, 1073741824, 1028, 102) });
+    
+    var ret1 = SIMD.Uint32x4.fromInt32x4Bits(m.testLocal());
+    var ret2 = SIMD.Uint32x4.fromInt32x4Bits(m.testGlobal());
+    var ret3 = SIMD.Uint32x4.fromInt32x4Bits(m.testGlobalImport());
 
-    equalSimd([8488484, 4848848, 29975939, 9493872], m.testLocal(), SIMD.Uint32x4, "testLocal");
-    equalSimd([1065353216, 1073741824, 1077936128, 1082130432], m.testGlobal(), SIMD.Uint32x4, "testGlobal");
-    equalSimd([100, 1073741824, 1028, 102], m.testGlobalImport(), SIMD.Uint32x4, "testGlobalImport");
+    equalSimd([8488484, 4848848, 29975939, 9493872], ret1, SIMD.Uint32x4, "testLocal");
+    equalSimd([1065353216, 1073741824, 1077936128, 1082130432], ret2, SIMD.Uint32x4, "testGlobal");
+    equalSimd([100, 1073741824, 1028, 102], ret3, SIMD.Uint32x4, "testGlobalImport");
 
     print("PASS");

--- a/test/SIMD.uint32x4.asmjs/testConversion-2.js
+++ b/test/SIMD.uint32x4.asmjs/testConversion-2.js
@@ -28,8 +28,6 @@ function asmModule(stdlib, imports) {
     var i16 = stdlib.SIMD.Int8x16;
     var u16 = stdlib.SIMD.Uint8x16;
     
-    
-    
     var fround = stdlib.Math.fround;
 
     var globImporti168 = ui4check(imports.g1);       // global var import
@@ -37,6 +35,8 @@ function asmModule(stdlib, imports) {
     var g1 = f4(5033.2,3401.0,665.34,32234.1);          // global var initialized
     var g2 = i4(1065353216, 1073741824,1077936128, 1082130432);          // global var initialized
     var loopCOUNT = 3;
+    
+    var i4fu4 = i4.fromUint32x4Bits;
 
     function conv1()
     {
@@ -49,7 +49,7 @@ function asmModule(stdlib, imports) {
 
             loopIndex = (loopIndex + 1) | 0;
         }
-        return ui4check(x);
+        return i4check(i4fu4(x));
     }
     
     function conv2()
@@ -60,7 +60,7 @@ function asmModule(stdlib, imports) {
         {
             x = ui4fromInt32x4Bits(globImportI4);
         }
-        return ui4check(x);
+        return i4check(i4fu4(x));
     }
 
     function conv3()
@@ -77,7 +77,7 @@ function asmModule(stdlib, imports) {
         }
         while ( (loopIndex | 0) > 0);
        
-        return ui4check(x);
+        return i4check(i4fu4(x));
     }
 
     function conv4()
@@ -92,7 +92,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
        
-        return ui4check(x);
+        return i4check(i4fu4(x));
     }
 
     function conv5()
@@ -104,7 +104,7 @@ function asmModule(stdlib, imports) {
         {
             x = ui4fromInt8x16Bits(m);
         }
-        return ui4check(x);
+        return i4check(i4fu4(x));
     }
     
     function conv6()
@@ -116,7 +116,7 @@ function asmModule(stdlib, imports) {
         {
             x = ui4fromUint8x16Bits(m);
         }
-        return ui4check(x);
+        return i4check(i4fu4(x));
     }
 
     function conv7()
@@ -132,7 +132,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui4check(x);
+        return i4check(i4fu4(x));
     }
     
     function conv8()
@@ -145,7 +145,7 @@ function asmModule(stdlib, imports) {
             x = ui4fromInt16x8Bits(m);
         }
 
-        return ui4check(x);
+        return i4check(i4fu4(x));
     }
     // TODO: Test conversion of returned value
     function value()
@@ -187,12 +187,20 @@ printSimdBaseline(m.func5(), "SIMD.Uint32x4", "m.func5()", "Func5");
 //printSimdBaseline(m.func6(), "SIMD.Uint32x4", "m.func6()", "Func6");  //need to check exception is thrown
 printSimdBaseline(m.func7(), "SIMD.Uint32x4", "m.func7()", "Func7");
 printSimdBaseline(m.func8(), "SIMD.Uint32x4", "m.func8()", "Func8");*/
-equalSimd([1167935898, 1163169792, 1143363011, 1190908979], m.func1(), SIMD.Uint32x4, "Func1");
-equalSimd([3229614080, 3221225472, 3217031168, 3212836864], m.func2(), SIMD.Uint32x4, "Func2");
-equalSimd([1, 2, 3, 4], m.func3(), SIMD.Uint32x4, "Func3");
-equalSimd([2863311530, 2863311530, 2863311530, 2863311530], m.func5(), SIMD.Uint32x4, "Func5");
-equalSimd([1034, 22342, 1233, 40443], m.func7(), SIMD.Uint32x4, "Func7");
-equalSimd([11141290, 11141290, 11141290, 11141290], m.func8(), SIMD.Uint32x4, "Func8");
+
+var ret1 = SIMD.Uint32x4.fromInt32x4Bits(m.func1());
+var ret2 = SIMD.Uint32x4.fromInt32x4Bits(m.func2());
+var ret3 = SIMD.Uint32x4.fromInt32x4Bits(m.func3());
+var ret5 = SIMD.Uint32x4.fromInt32x4Bits(m.func5());
+var ret7 = SIMD.Uint32x4.fromInt32x4Bits(m.func7());
+var ret8 = SIMD.Uint32x4.fromInt32x4Bits(m.func8());
+
+equalSimd([1167935898, 1163169792, 1143363011, 1190908979], ret1, SIMD.Uint32x4, "Func1");
+equalSimd([3229614080, 3221225472, 3217031168, 3212836864], ret2, SIMD.Uint32x4, "Func2");
+equalSimd([1, 2, 3, 4], ret3, SIMD.Uint32x4, "Func3");
+equalSimd([2863311530, 2863311530, 2863311530, 2863311530], ret5, SIMD.Uint32x4, "Func5");
+equalSimd([1034, 22342, 1233, 40443], ret7, SIMD.Uint32x4, "Func7");
+equalSimd([11141290, 11141290, 11141290, 11141290], ret8, SIMD.Uint32x4, "Func8");
 
 
 print("PASS");

--- a/test/SIMD.uint32x4.asmjs/testConversion.js
+++ b/test/SIMD.uint32x4.asmjs/testConversion.js
@@ -7,18 +7,16 @@ function asmModule(stdlib, imports) {
     "use asm";
     
     var ui4 = stdlib.SIMD.Uint32x4;
-    var ui4check = ui4.check;
+    var u4check = ui4.check;
     var ui4splat = ui4.splat;
     var ui4fromFloat32x4 = ui4.fromFloat32x4;
     var ui4fromFloat32x4Bits = ui4.fromFloat32x4Bits;
-    var ui4fromInt32x4Bits = ui4.fromInt32x4Bits;
     var ui4fromInt16x8Bits = ui4.fromInt16x8Bits;
     var ui4fromUint16x8Bits = ui4.fromUint16x8Bits;
     var ui4fromInt8x16Bits = ui4.fromInt8x16Bits;
     var ui4fromUint8x16Bits = ui4.fromUint8x16Bits;;
     
     var i4 = stdlib.SIMD.Int32x4;
-    var i4check = i4.check;
     var f4 = stdlib.SIMD.Float32x4;  
     var f4check = f4.check;
 
@@ -28,12 +26,16 @@ function asmModule(stdlib, imports) {
     var ui16 = stdlib.SIMD.Uint8x16;
     
     var fround = stdlib.Math.fround;
-
-    var globImporti168 = ui4check(imports.g1);       // global var import
+    var i4check = i4.check;
+    var globImporti168 = u4check(imports.g1);       // global var import
     var globImportI4 = i4check(imports.g2);       // global var import
     var g1 = f4(5033.2,3401.0,665.34,32234.1);          // global var initialized
     var g2 = i4(1065353216, 1073741824,1077936128, 1082130432);          // global var initialized
     var loopCOUNT = 3;
+
+
+    var i4fu4 = i4.fromUint32x4Bits;
+    var u4fi4 = ui4.fromInt32x4Bits;
 
     function conv1()
     {
@@ -46,7 +48,7 @@ function asmModule(stdlib, imports) {
 
             loopIndex = (loopIndex + 1) | 0;
         }
-        return ui4check(x);
+        return i4check(i4fu4(x));
     }
     
     function conv2()
@@ -55,9 +57,9 @@ function asmModule(stdlib, imports) {
         var loopIndex = 0;
         for (loopIndex = 0; (loopIndex | 0) < (loopCOUNT | 0) ; loopIndex = (loopIndex + 1) | 0)
         {
-            x = ui4fromInt32x4Bits(globImportI4);
+            x = u4fi4(globImportI4);
         }
-        return ui4check(x);
+        return i4check(i4fu4(x));
     }
 
     function conv3()
@@ -68,13 +70,13 @@ function asmModule(stdlib, imports) {
         loopIndex = loopCOUNT | 0;
         do {
 
-            x = ui4fromInt32x4Bits(y);
+            x = u4fi4(y);
 
             loopIndex = (loopIndex - 1) | 0;
         }
         while ( (loopIndex | 0) > 0);
        
-        return ui4check(x);
+        return i4check(i4fu4(x));
     }
 
     function conv4()
@@ -89,7 +91,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
         
-        return ui4check(x);
+        return i4check(i4fu4(x));
     }
 
     function conv5()
@@ -101,7 +103,7 @@ function asmModule(stdlib, imports) {
         {
             x = ui4fromInt8x16Bits(m);
         }
-        return ui4check(x);
+        return i4check(i4fu4(x));
     }
     
     function conv6()
@@ -113,7 +115,7 @@ function asmModule(stdlib, imports) {
         {
             x = ui4fromUint8x16Bits(m);
         }
-        return ui4check(x);
+        return i4check(i4fu4(x));
     }
 
     function conv7(v)
@@ -130,7 +132,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui4check(x);
+        return i4check(i4fu4(x));
     }
     
     function conv8()
@@ -143,7 +145,7 @@ function asmModule(stdlib, imports) {
             x = ui4fromInt16x8Bits(m);
         }
 
-        return ui4check(x);
+        return i4check(i4fu4(x));
     }
     // TODO: Test conversion of returned value
     function value()
@@ -187,14 +189,23 @@ var m = asmModule(this, {g1:SIMD.Uint32x4(0x55, 0x55, 0x55, 0x55), g2:SIMD.Int32
 // printSimdBaseline(m.func8(), "SIMD.Uint32x4", "m.func8()", "Func8"); 
 
 
-equalSimd([1167935898, 1163169792, 1143363011, 1190908979], m.func1(), SIMD.Uint32x4, "Func1")
-equalSimd([3229614080, 3221225472, 3217031168, 3212836864], m.func2(), SIMD.Uint32x4, "Func2")
-equalSimd([1, 2, 3, 4], m.func3(), SIMD.Uint32x4, "Func3")
-equalSimd([0, 0, 0, 0], m.func4(), SIMD.Uint32x4, "Func4")
-equalSimd([2863311530, 2863311530, 2863311530, 2863311530], m.func5(), SIMD.Uint32x4, "Func5")
-equalSimd([1431655765, 1431655765, 1431655765, 1431655765], m.func6(), SIMD.Uint32x4, "Func6")
-equalSimd([0, 1, 2, 5], m.func7(SIMD.Float32x4(0.5,1.4,2.4,5.5)), SIMD.Uint32x4, "Func7")
-equalSimd([11141290, 11141290, 11141290, 11141290], m.func8(), SIMD.Uint32x4, "Func8")
+var ret1 = SIMD.Uint32x4.fromInt32x4Bits(m.func1());
+var ret2 = SIMD.Uint32x4.fromInt32x4Bits(m.func2());
+var ret3 = SIMD.Uint32x4.fromInt32x4Bits(m.func3());
+var ret4 = SIMD.Uint32x4.fromInt32x4Bits(m.func4());
+var ret5 = SIMD.Uint32x4.fromInt32x4Bits(m.func5());
+var ret6 = SIMD.Uint32x4.fromInt32x4Bits(m.func6());
+var ret7 = SIMD.Uint32x4.fromInt32x4Bits(m.func7(SIMD.Float32x4(0.5,1.4,2.4,5.5)));
+var ret8 = SIMD.Uint32x4.fromInt32x4Bits(m.func8());
+
+equalSimd([1167935898, 1163169792, 1143363011, 1190908979], ret1, SIMD.Uint32x4, "Func1")
+equalSimd([3229614080, 3221225472, 3217031168, 3212836864],ret2, SIMD.Uint32x4, "Func2")
+equalSimd([1, 2, 3, 4], ret3, SIMD.Uint32x4, "Func3")
+equalSimd([0, 0, 0, 0], ret4, SIMD.Uint32x4, "Func4")
+equalSimd([2863311530, 2863311530, 2863311530, 2863311530], ret5, SIMD.Uint32x4, "Func5")
+equalSimd([1431655765, 1431655765, 1431655765, 1431655765], ret6, SIMD.Uint32x4, "Func6")
+equalSimd([0, 1, 2, 5], ret7, SIMD.Uint32x4, "Func7")
+equalSimd([11141290, 11141290, 11141290, 11141290], ret8, SIMD.Uint32x4, "Func8")
 
 
 // passing:
@@ -203,9 +214,14 @@ equalSimd([11141290, 11141290, 11141290, 11141290], m.func8(), SIMD.Uint32x4, "F
 //printSimdBaseline(m.func7(SIMD.Float32x4(0.5,0x80000000,0x100000000 - 0x81 /*2^32 - (2^7 + 1) rounded to 2^32 - 2^8*/ ,0)), "SIMD.Uint32x4", "m.func7(SIMD.Float32x4(0.5,0x80000000,0x100000000 - 0x81 /*2^32 - (2^7 + 1) rounded to 2^32 - 2^8*/ ,0))", "Func7_2");
 //printSimdBaseline(m.func7(SIMD.Float32x4(-0.0, -0.0, -0.0, -0.0)), "SIMD.Uint32x4", "m.func7(SIMD.Float32x4(-0.0, -0.0, -0.0, -0.0))", "Func7_3");
 
-equalSimd([0, 1, 2, 5], m.func7(SIMD.Float32x4(0.5,1.4,2.4,5.5)), SIMD.Uint32x4, "Func7_1")
-equalSimd([0, 2147483648, 4294967040, 0], m.func7(SIMD.Float32x4(0.5,0x80000000,0x100000000 - 0x81 /*2^32 - (2^7 + 1) rounded to 2^32 - 2^8*/ ,0)), SIMD.Uint32x4, "Func7_2")
-equalSimd([0, 0, 0, 0], m.func7(SIMD.Float32x4(-0.0, -0.0, -0.0, -0.0)), SIMD.Uint32x4, "Func7_3")
+var ret7 = SIMD.Uint32x4.fromInt32x4Bits(m.func7(SIMD.Float32x4(0.5,1.4,2.4,5.5)));
+var ret8 = SIMD.Uint32x4.fromInt32x4Bits(m.func7(SIMD.Float32x4(0.5,0x80000000,0x100000000 - 0x81 /*2^32 - (2^7 + 1) rounded to 2^32 - 2^8*/ ,0)));
+var ret9 = SIMD.Uint32x4.fromInt32x4Bits(m.func7(SIMD.Float32x4(-0.0, -0.0, -0.0, -0.0)));
+
+
+equalSimd([0, 1, 2, 5], ret7, SIMD.Uint32x4, "Func7_1")
+equalSimd([0, 2147483648, 4294967040, 0], ret8, SIMD.Uint32x4, "Func7_2")
+equalSimd([0, 0, 0, 0], ret9, SIMD.Uint32x4, "Func7_3")
 
 // throwing
 try 
@@ -246,7 +262,7 @@ try
 
 
 
-
-equalSimd([11141290, 11141290, 11141290, 11141290], m.func8(), SIMD.Uint32x4, "Func8")
+var ret = SIMD.Uint32x4.fromInt32x4Bits(m.func8());
+equalSimd([11141290, 11141290, 11141290, 11141290], ret, SIMD.Uint32x4, "Func8")
 
 print("PASS");

--- a/test/SIMD.uint32x4.asmjs/testFail.baseline
+++ b/test/SIMD.uint32x4.asmjs/testFail.baseline
@@ -1,0 +1,6 @@
+
+testFail.js(10, 5)
+	Asm.js Compilation Error function : module0::foo
+	Expression for return must be subtype of Signed, Double, or Float
+
+Asm.js compilation failed.

--- a/test/SIMD.uint32x4.asmjs/testFail.js
+++ b/test/SIMD.uint32x4.asmjs/testFail.js
@@ -1,0 +1,16 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function module0(stdlib) {
+    "use asm"
+    var u4 = stdlib.SIMD.Uint32x4;
+    var u4check = u4.check;
+    function foo() {
+        var abc = u4(1,1,1,1);
+        return u4check(abc);
+    }
+    return { foo:foo }
+}
+var c = module0(this);

--- a/test/SIMD.uint32x4.asmjs/testFail_1.baseline
+++ b/test/SIMD.uint32x4.asmjs/testFail_1.baseline
@@ -1,0 +1,2 @@
+Invalid SIMD argument type. Expecting Signed arguments.
+Asm.js compilation failed.

--- a/test/SIMD.uint32x4.asmjs/testFail_1.js
+++ b/test/SIMD.uint32x4.asmjs/testFail_1.js
@@ -1,0 +1,17 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function module0(stdlib) {
+    "use asm"
+    var u4 = stdlib.SIMD.Uint32x4;
+    var u4check = u4.check;
+
+    function foo(abc) {
+        abc = u4check(abc);
+        return ;
+    }
+    return { foo:foo }
+}
+var c = module0(this);

--- a/test/SIMD.uint32x4.asmjs/testLoadStore.js
+++ b/test/SIMD.uint32x4.asmjs/testLoadStore.js
@@ -27,6 +27,10 @@ function asmModule(stdlib, imports, buffer) {
     var gval2 = 1234.0;
 
     var loopCOUNT = 5;
+    
+    var i4 = stdlib.SIMD.Int32x4;
+    var i4check = i4.check;
+    var i4fu4 = i4.fromUint32x4Bits;
 
     var Int8Heap = new stdlib.Int8Array (buffer);    
     var Uint8Heap = new stdlib.Uint8Array (buffer);    
@@ -82,7 +86,7 @@ function asmModule(stdlib, imports, buffer) {
             t0 = ui4add(t0, ui4add(t1, ui4add(t2, t3)));
             index = (index + 16 ) | 0;
         }
-        return ui4check(t0);
+        return i4check(i4fu4(t0));
     }
 
     function func1()
@@ -106,7 +110,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui4add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui4check(y);
+        return i4check(i4fu4(y));
     }
 
     function func1OOB_1()
@@ -133,7 +137,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui4add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui4check(y);
+        return i4check(i4fu4(y));
     }
     
     function func1OOB_2()
@@ -160,7 +164,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui4add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui4check(y);
+        return i4check(i4fu4(y));
     }
 
     function func2()
@@ -184,7 +188,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui4add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui4check(y);
+        return i4check(i4fu4(y));
     }
 
     function func2OOB_1()
@@ -211,7 +215,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui4add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui4check(y);
+        return i4check(i4fu4(y));
     }
 
     function func2OOB_2()
@@ -261,7 +265,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui4add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui4check(y);
+        return i4check(i4fu4(y));
     }
 
     function func3OOB_1()
@@ -288,7 +292,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui4add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui4check(y);
+        return i4check(i4fu4(y));
     }
 
     function func3OOB_2()
@@ -315,7 +319,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui4add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui4check(y);
+        return i4check(i4fu4(y));
     }
 
     function func4()
@@ -339,7 +343,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui4add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui4check(y);
+        return i4check(i4fu4(y));
     }
 
     function func4OOB_1()
@@ -366,7 +370,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui4add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui4check(y);
+        return i4check(i4fu4(y));
     }
 
     function func4OOB_2()
@@ -393,7 +397,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui4add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui4check(y);
+        return i4check(i4fu4(y));
     }
 
     function func5()
@@ -417,7 +421,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui4add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui4check(y);
+        return i4check(i4fu4(y));
     }
 
     function func5OOB_1()
@@ -443,7 +447,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui4add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui4check(y);
+        return i4check(i4fu4(y));
     }
 
     function func5OOB_2()
@@ -470,7 +474,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui4add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui4check(y);
+        return i4check(i4fu4(y));
     }
 
     function func6()
@@ -494,7 +498,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui4add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui4check(y);
+        return i4check(i4fu4(y));
     }
 
     function func6OOB_1()
@@ -521,7 +525,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui4add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui4check(y);
+        return i4check(i4fu4(y));
     }
 
     function func6OOB_2()
@@ -548,7 +552,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui4add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui4check(y);
+        return i4check(i4fu4(y));
     }
 
     // TODO: Test conversion of returned value
@@ -601,30 +605,30 @@ var m = asmModule(this, {g1: SIMD.Uint32x4(1065353216, 1073741824, 1077936128, 1
 var ret;
 
 
-ret = m.func0();
+ret = SIMD.Uint32x4.fromInt32x4Bits(m.func0());
 equalSimd([16, 32, 48, 64], ret, SIMD.Uint32x4, "Test Load Store0");
 
-ret = m.func1();
+ret = SIMD.Uint32x4.fromInt32x4Bits(m.func1());
 equalSimd([10, 20, 30, 40], ret, SIMD.Uint32x4, "Test Load Store1");
 
 
-ret = m.func2();
+ret = SIMD.Uint32x4.fromInt32x4Bits(m.func2());
 equalSimd([10, 20, 30, 0], ret, SIMD.Uint32x4, "Test Load Store2");
 
 
-ret = m.func3();
+ret = SIMD.Uint32x4.fromInt32x4Bits(m.func3());
 equalSimd([10, 20, 0, 0], ret, SIMD.Uint32x4, "Test Load Store3");
 
 
-ret = m.func4();
+ret = SIMD.Uint32x4.fromInt32x4Bits(m.func4());
 equalSimd([10, 0, 0, 0], ret, SIMD.Uint32x4, "Test Load Store4");
 
 
-ret = m.func5();
+ret = SIMD.Uint32x4.fromInt32x4Bits(m.func5());
 equalSimd([10, 20, 30, 40], ret, SIMD.Uint32x4, "Test Load Store5");
 
 
-ret = m.func6();
+ret = SIMD.Uint32x4.fromInt32x4Bits(m.func6());
 equalSimd([10, 20, 30, 40], ret, SIMD.Uint32x4, "Test Load Store6");
 
 
@@ -643,7 +647,7 @@ for (var i = 0; i < funcOOB1.length; i ++)
 {
     try
     {
-        ret = funcOOB1[i]();
+        ret = SIMD.Uint32x4.fromInt32x4Bits(funcOOB1[i]());
         //print("func" + (i+1) + "OOB_1");
         equalSimd(RESULTS[i], ret, SIMD.Uint32x4, "Test Load Store");
 
@@ -661,7 +665,7 @@ for (var i = 0; i < funcOOB2.length; i ++)
     //print("func" + (i+1) + "OOB_2");
     try
     {
-        ret = funcOOB2[i]();
+        ret = SIMD.Uint32x4.fromInt32x4Bits(funcOOB2[i]());
         print("Wrong");
         
     } catch(e)

--- a/test/SIMD.uint32x4.asmjs/testMinMax.js
+++ b/test/SIMD.uint32x4.asmjs/testMinMax.js
@@ -17,6 +17,10 @@ function asmModule(stdlib, imports) {
     var ui4g2 = ui4(6531634, 74182444, 779364128, 821730432);
 
     var loopCOUNT = 3;
+        
+    var i4 = stdlib.SIMD.Int32x4;
+    var i4check = i4.check;
+    var i4fu4 = i4.fromUint32x4Bits;
 
     function testMinLocal()
     {
@@ -30,7 +34,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui4check(result);
+        return i4check(i4fu4(result));
     }
     
     function testMaxLocal()
@@ -45,7 +49,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui4check(result);
+        return i4check(i4fu4(result));
     }
 
     function testMinGlobal()
@@ -58,7 +62,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui4check(result);
+        return i4check(i4fu4(result));
     }
 
     function testMaxGlobal()
@@ -71,7 +75,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui4check(result);
+        return i4check(i4fu4(result));
     }
 
     function testMinGlobalImport()
@@ -85,7 +89,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui4check(result);
+        return i4check(i4fu4(result));
     }
 
     function testMaxGlobalImport()
@@ -99,7 +103,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui4check(result);
+        return i4check(i4fu4(result));
     }
     
     return { testMinLocal: testMinLocal, testMaxLocal: testMaxLocal, testMinGlobal: testMinGlobal, testMaxGlobal: testMaxGlobal, testMinGlobalImport: testMinGlobalImport, testMaxGlobalImport: testMaxGlobalImport };
@@ -107,10 +111,17 @@ function asmModule(stdlib, imports) {
 
 var m = asmModule(this, { g1: SIMD.Uint32x4(100, 1073741824, 1028, 102) });
 
-equalSimd([8488484, 4848848, 29975939, 9493872], m.testMinLocal(), SIMD.Uint32x4, "testMinLocal");
-equalSimd([99372621, 18848392, 888288822, 1000010012], m.testMaxLocal(), SIMD.Uint32x4, "testMaxLocal");
-equalSimd([6531634, 74182444, 779364128, 821730432], m.testMinGlobal(), SIMD.Uint32x4, "testMinGlobal");
-equalSimd([1065353216, 1073741824, 1077936128, 1082130432], m.testMaxGlobal(), SIMD.Uint32x4, "testMaxGlobal");
-equalSimd([100, 4848848, 1028, 102], m.testMinGlobalImport(), SIMD.Uint32x4, "testMinGlobalImport");
-equalSimd([8488484, 1073741824, 29975939, 9493872], m.testMaxGlobalImport(), SIMD.Uint32x4, "testMaxGlobalImport");
+var ret1 = SIMD.Uint32x4.fromInt32x4Bits(m.testMinLocal());
+var ret2 = SIMD.Uint32x4.fromInt32x4Bits(m.testMaxLocal());
+var ret3 = SIMD.Uint32x4.fromInt32x4Bits(m.testMinGlobal());
+var ret4 = SIMD.Uint32x4.fromInt32x4Bits(m.testMaxGlobal());
+var ret5 = SIMD.Uint32x4.fromInt32x4Bits(m.testMinGlobalImport());
+var ret6 = SIMD.Uint32x4.fromInt32x4Bits(m.testMaxGlobalImport());
+
+equalSimd([8488484, 4848848, 29975939, 9493872], ret1, SIMD.Uint32x4, "testMinLocal");
+equalSimd([99372621, 18848392, 888288822, 1000010012], ret2, SIMD.Uint32x4, "testMaxLocal");
+equalSimd([6531634, 74182444, 779364128, 821730432], ret3, SIMD.Uint32x4, "testMinGlobal");
+equalSimd([1065353216, 1073741824, 1077936128, 1082130432], ret4, SIMD.Uint32x4, "testMaxGlobal");
+equalSimd([100, 4848848, 1028, 102], ret5, SIMD.Uint32x4, "testMinGlobalImport");
+equalSimd([8488484, 1073741824, 29975939, 9493872], ret6, SIMD.Uint32x4, "testMaxGlobalImport");
 print("PASS");

--- a/test/SIMD.uint32x4.asmjs/testMisc.js
+++ b/test/SIMD.uint32x4.asmjs/testMisc.js
@@ -62,7 +62,6 @@ function asmModule(stdlib, imports,buffer) {
     var u4store2             = u4.store2              ;
     var u4store3             = u4.store3              ;
     var u4fromFloat32x4Bits = u4.fromFloat32x4Bits  ;
-    var u4fromInt32x4Bits   = u4.fromInt32x4Bits    ;
     var u4fromInt16x8Bits  = u4.fromInt16x8Bits   ;
     var u4fromUint16x8Bits  = u4.fromUint16x8Bits   ;
     var u4fromUint8x16Bits  = u4.fromUint8x16Bits   ;
@@ -143,6 +142,8 @@ function asmModule(stdlib, imports,buffer) {
     var Float32Heap = new stdlib.Float32Array(buffer);
     
     var loopCOUNT = 3;
+    var i4fu4 = i4.fromUint32x4Bits;
+    var u4fi4 = u4.fromInt32x4Bits;
 
     function func1()
     {
@@ -163,15 +164,13 @@ function asmModule(stdlib, imports,buffer) {
             y = u4extractLane(x, 3);
             s = ( s + y ) | 0;
             loopIndex = (loopIndex + 1) | 0;
-            
         }
-        
         return s | 0;
     }
-    
+
     function func2(a)
     {
-        a = u4check(a);
+        a = i4check(a);
         var x = u4(0, 0, 0, 0);
         var loopIndex = 0;
         var loopCOUNT = 3;
@@ -179,16 +178,16 @@ function asmModule(stdlib, imports,buffer) {
         while ( (loopIndex|0) < (loopCOUNT|0)) {
 
             x = u4swizzle(x, 3, 2, 1, 0);
-            x = u4shuffle(a, x, 0, 1, 7, 6);
+            x = u4shuffle(u4fi4(a), x, 0, 1, 7, 6);
             loopIndex = (loopIndex + 1) | 0;
         }
         
-        return u4check(x);
+        return i4check(i4fu4(x));
     }
     
     function func3(a)
     {
-        a = u4check(a);
+        a = i4check(a);
         var x = u4(0, 0, 0, 0);
         var y = u4(0, 0, 0, 0);
         var loopIndex = 0;
@@ -204,17 +203,17 @@ function asmModule(stdlib, imports,buffer) {
             loopIndex = (loopIndex + 1) | 0;
         }
         
-        return u4check(y);
+        return i4check(i4fu4(y));
     }
     
     
     function func4(a, b, c, d, e)
     {
-        a = u4check(a);
-        b = u4check(b);
-        c = u4check(c);
-        d = u4check(d);
-        e = u4check(e);
+        a = i4check(a);
+        b = i4check(b);
+        c = i4check(c);
+        d = i4check(d);
+        e = i4check(e);
         var x = u4(0, 0, 0, 0);
         var y = u4(0, 0, 0, 0);
         var loopIndex = 0;
@@ -222,24 +221,24 @@ function asmModule(stdlib, imports,buffer) {
         
         
         while ( (loopIndex|0) < (loopCOUNT|0)) {
-            x = u4and(a, b);
-            x = u4or(x, d);
-            x = u4xor(x, e);
+            x = u4and(u4fi4(a), u4fi4(b));
+            x = u4or(x, u4fi4(d));
+            x = u4xor(x, u4fi4(e));
             x = u4not(x);
             
             loopIndex = (loopIndex + 1) | 0;
         }
         
-        return u4check(x);
+        return i4check(i4fu4(x));
     }
     
     function func5(a, b, c, d, e)
     {
-        a = u4check(a);
-        b = u4check(b);
-        c = u4check(c);
-        d = u4check(d);
-        e = u4check(e);
+        a = i4check(a);
+        b = i4check(b);
+        c = i4check(c);
+        d = i4check(d);
+        e = i4check(e);
         var x = u4(0, 0, 0, 0);
         var y = u4(0, 0, 0, 0);
         var loopIndex = 0;
@@ -247,24 +246,24 @@ function asmModule(stdlib, imports,buffer) {
         
         
         while ( (loopIndex|0) < (loopCOUNT|0)) {
-            x = u4add(a, b);
-            x = u4sub(x, d);
-            x = u4mul(x, e);
+            x = u4add(u4fi4(a), u4fi4(b));
+            x = u4sub(x, u4fi4(d));
+            x = u4mul(x, u4fi4(e));
             
             
             loopIndex = (loopIndex + 1) | 0;
         }
         
-        return u4check(x);
+        return i4check(i4fu4(x));
     }
-    
+
     function func6(a, b, c, d, e)
     {
-        a = u4check(a);
-        b = u4check(b);
-        c = u4check(c);
-        d = u4check(d);
-        e = u4check(e);
+        a = i4check(a);
+        b = i4check(b);
+        c = i4check(c);
+        d = i4check(d);
+        e = i4check(e);
         var x = u4(0, 0, 0, 0);
         var y = u4(0, 0, 0, 0);
         var loopIndex = 0;
@@ -272,19 +271,17 @@ function asmModule(stdlib, imports,buffer) {
         
         
         while ( (loopIndex|0) < (loopCOUNT|0)) {
-            x = u4min(x, b);
-            y = u4max(y, d);
+            x = u4min(x, u4fi4(b));
+            y = u4max(y, u4fi4(d));
             x = u4shiftLeftByScalar(x, loopIndex>>>0);
             y = u4shiftRightByScalar(y, loopIndex>>>0);
             
             loopIndex = (loopIndex + 1) | 0;
         }
         
-        return u4check(x);
+        return i4check(i4fu4(x));
     }
-    
-    
-    
+
     function func7()
     {
         var loopIndex = 0;
@@ -359,7 +356,7 @@ function asmModule(stdlib, imports,buffer) {
         }
         
         x = u4add(x, y);
-        return u4check(y);
+        return i4check(i4fu4(y));
     }
 
     function bug1() //simd tmp reg reuse.
@@ -389,13 +386,13 @@ function asmModule(stdlib, imports,buffer) {
         for (loopIndex = 0; (loopIndex | 0) < (size | 0) ; loopIndex = (loopIndex + 1) | 0)
         {
             x = u4add(x, u4fromFloat32x4Bits(v_f4));
-            x = u4add(x, u4fromInt32x4Bits(v_i4));
+            x = u4add(x, u4fi4(v_i4));
             x = u4add(x, u4fromInt16x8Bits(v_i8));
             x = u4add(x, u4fromUint16x8Bits(v_u8));
             x = u4add(x, u4fromUint8x16Bits(v_u16));
         }
 
-        return u4check(x);
+        return i4check(i4fu4(x));
     }
 
     return {func1:func1, func2: func2, func3:func3, func4:func4, 
@@ -406,32 +403,33 @@ function asmModule(stdlib, imports,buffer) {
 var buffer = new ArrayBuffer(0x10000);
 var m = asmModule(this, {g1:SIMD.Float32x4(90934.2,123.9,419.39,449.0), g2:SIMD.Int32x4(-1065353216, -1073741824,-1077936128, -1082130432)}, buffer);
 
-
+var i4fu4 = SIMD.Int32x4.fromUint32x4Bits;
+var u4fi4 = SIMD.Uint32x4.fromInt32x4Bits;
 
 var v1 = SIMD.Uint32x4(1, 2, 3, 4 );
 var v2 = SIMD.Uint32x4(134, 211, 0xffff, 0xf0f0);
 var v3 = SIMD.Uint32x4(0xcccc, -999996, 0xffff, 0xf0f0);
 var ret1 = m.func1();
 
-var ret2 = m.func2(v1);
+var ret2 = u4fi4(m.func2(i4fu4(v1)));
 //printSimdBaseline(ret2, "SIMD.Uint32x4", "ret2", "func2");
 
-var ret3 = m.func3(v1);
+var ret3 = u4fi4(m.func3(i4fu4(v1)));
 //printSimdBaseline(ret3, "SIMD.Uint32x4", "ret3", "func3");
 
-var ret4 = m.func4(v1, v2, v3, v1, v2);
+var ret4 = u4fi4(m.func4(i4fu4(v1), i4fu4(v2), i4fu4(v3), i4fu4(v1), i4fu4(v2)));
 //printSimdBaseline(ret4, "SIMD.Uint32x4", "ret4", "func4");
 
-var ret5 = m.func5(v1, v2, v3, v1, v2);
+var ret5 = u4fi4(m.func5(i4fu4(v1), i4fu4(v2), i4fu4(v3), i4fu4(v1), i4fu4(v2)));
 //printSimdBaseline(ret5, "SIMD.Uint32x4", "ret5", "func5");
 
-var ret6 = m.func6(v1, v2, v3, v1, v2);
+var ret6 = u4fi4(m.func6(i4fu4(v1), i4fu4(v2), i4fu4(v3), i4fu4(v1), i4fu4(v2)));
 //printSimdBaseline(ret6, "SIMD.Uint32x4", "ret6", "func6");
 
-var ret7 = m.func7(v1, v2, v3, v1, v2);
+var ret7 = u4fi4(m.func7(i4fu4(v1), i4fu4(v2), i4fu4(v3), i4fu4(v1), i4fu4(v2)));
 //printSimdBaseline(ret7, "SIMD.Uint32x4", "ret7", "func7");
 
-var ret8 = m.func8(v1, v2, v3, v1, v2);
+var ret8 = u4fi4(m.func8(i4fu4(v1), i4fu4(v2), i4fu4(v3), i4fu4(v1), i4fu4(v2)));
 //printSimdBaseline(ret8, "SIMD.Uint32x4", "ret8", "func8");
 
 var ret9 = m.bug1();

--- a/test/SIMD.uint32x4.asmjs/testMul.js
+++ b/test/SIMD.uint32x4.asmjs/testMul.js
@@ -16,6 +16,10 @@ function asmModule(stdlib, imports) {
     var ui4g2 = ui4(6531634, 74182444, 779364128, 821730432);
 
     var loopCOUNT = 3;
+     
+    var i4 = stdlib.SIMD.Int32x4;
+    var i4check = i4.check;
+    var i4fu4 = i4.fromUint32x4Bits;
 
     function testMulLocal()
     {
@@ -29,7 +33,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui4check(result);
+        return i4check(i4fu4(result));
     }
     function testMulGlobal()
     {    
@@ -41,7 +45,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui4check(result);
+        return i4check(i4fu4(result));
     }
 
     function testMulGlobalImport()
@@ -55,7 +59,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui4check(result);
+        return i4check(i4fu4(result));
     }
     
     return {testMulLocal:testMulLocal, testMulGlobal:testMulGlobal, testMulGlobalImport:testMulGlobalImport};
@@ -63,7 +67,11 @@ function asmModule(stdlib, imports) {
 
 var m = asmModule(this, { g1: SIMD.Uint32x4(100, 1073741824, 1028, 102) });
 
-equalSimd([4211364052, 378760832, 1840974754, 1974380608], m.testMulLocal(), SIMD.Uint32x4, "Test Mul");
-equalSimd([1728053248, 0, 3355443200, 1073741824], m.testMulGlobal(), SIMD.Uint32x4, "Test Mul");
-equalSimd([848848400, 0, 750494220, 968374944], m.testMulGlobalImport(), SIMD.Uint32x4, "Test Mul");
+var ret1 = SIMD.Uint32x4.fromInt32x4Bits(m.testMulLocal());
+var ret2 = SIMD.Uint32x4.fromInt32x4Bits(m.testMulGlobal());
+var ret3 = SIMD.Uint32x4.fromInt32x4Bits(m.testMulGlobalImport());
+
+equalSimd([4211364052, 378760832, 1840974754, 1974380608], ret1, SIMD.Uint32x4, "Test Mul");
+equalSimd([1728053248, 0, 3355443200, 1073741824], ret2, SIMD.Uint32x4, "Test Mul");
+equalSimd([848848400, 0, 750494220, 968374944], ret3, SIMD.Uint32x4, "Test Mul");
 print("PASS");

--- a/test/SIMD.uint32x4.asmjs/testShift.js
+++ b/test/SIMD.uint32x4.asmjs/testShift.js
@@ -17,6 +17,10 @@ function asmModule(stdlib, imports) {
     var ui4g2 = ui4(6531634, 74182444, 779364128, 821730432);
 
     var loopCOUNT = 16;
+     
+    var i4 = stdlib.SIMD.Int32x4;
+    var i4check = i4.check;
+    var i4fu4 = i4.fromUint32x4Bits;
 
     function testShiftLeftScalarLocal()
     {
@@ -28,7 +32,7 @@ function asmModule(stdlib, imports) {
             a = ui4shiftLeftByScalar(a, 1);
         }
 
-        return ui4check(a);
+        return i4check(i4fu4(a));
     }
     
     function testShiftRightScalarLocal()
@@ -40,7 +44,7 @@ function asmModule(stdlib, imports) {
             a = ui4shiftRightByScalar(a, 1);
         }
 
-        return ui4check(a);
+        return i4check(i4fu4(a));
     }
 
     function testShiftLeftScalarGlobal()
@@ -50,7 +54,7 @@ function asmModule(stdlib, imports) {
         for (loopIndex = 0; (loopIndex | 0) < (loopCOUNT | 0) ; loopIndex = (loopIndex + 1) | 0) {
             ui4g1 = ui4shiftLeftByScalar(ui4g1, 1);
         }
-        return ui4check(ui4g1);
+        return i4check(i4fu4(ui4g1));
     }
 
     function testShiftRightScalarGlobal()
@@ -60,7 +64,7 @@ function asmModule(stdlib, imports) {
         for (loopIndex = 0; (loopIndex | 0) < (loopCOUNT | 0) ; loopIndex = (loopIndex + 1) | 0) {
             ui4g1 = ui4shiftRightByScalar(ui4g1, 1);
         }
-        return ui4check(ui4g1);
+        return i4check(i4fu4(ui4g1));
     }
 
     function testShiftLeftScalarGlobalImport()
@@ -70,7 +74,7 @@ function asmModule(stdlib, imports) {
         for (loopIndex = 0; (loopIndex | 0) < (loopCOUNT | 0) ; loopIndex = (loopIndex + 1) | 0) {
             globImportui4 = ui4shiftLeftByScalar(globImportui4, 1);
         }
-        return ui4check(globImportui4);
+        return i4check(i4fu4(globImportui4));
     }
 
     function testShiftRightScalarGlobalImport()
@@ -80,7 +84,7 @@ function asmModule(stdlib, imports) {
         for (loopIndex = 0; (loopIndex | 0) < (loopCOUNT | 0) ; loopIndex = (loopIndex + 1) | 0) {
             globImportui4 = ui4shiftRightByScalar(globImportui4, 1);
         }
-        return ui4check(globImportui4);
+        return i4check(i4fu4(globImportui4));
     }
 
     function testShiftLeftScalarLocal1()
@@ -94,7 +98,7 @@ function asmModule(stdlib, imports) {
             a = ui4shiftLeftByScalar(a, 33);
         }
 
-        return ui4check(a);
+        return i4check(i4fu4(a));
     }
     
     function testShiftRightScalarLocal1()
@@ -107,7 +111,7 @@ function asmModule(stdlib, imports) {
             a = ui4shiftRightByScalar(a, 33);
         }
 
-        return ui4check(a);
+        return i4check(i4fu4(a));
     }
 
     function testShiftLeftScalarGlobal1()
@@ -118,7 +122,7 @@ function asmModule(stdlib, imports) {
             ui4g1 = ui4shiftLeftByScalar(ui4g1, 32);
             ui4g1 = ui4shiftLeftByScalar(ui4g1, 33);
         }
-        return ui4check(ui4g1);
+        return i4check(i4fu4(ui4g1));
     }
 
     function testShiftRightScalarGlobal1()
@@ -129,7 +133,7 @@ function asmModule(stdlib, imports) {
             ui4g1 = ui4shiftRightByScalar(ui4g1, 32);
             ui4g1 = ui4shiftRightByScalar(ui4g1, 33);
         }
-        return ui4check(ui4g1);
+        return i4check(i4fu4(ui4g1));
     }
 
     function testShiftLeftScalarGlobalImport1()
@@ -140,7 +144,7 @@ function asmModule(stdlib, imports) {
             globImportui4 = ui4shiftLeftByScalar(globImportui4, 32);
             globImportui4 = ui4shiftLeftByScalar(globImportui4, 33);
         }
-        return ui4check(globImportui4);
+        return i4check(i4fu4(globImportui4));
     }
 
     function testShiftRightScalarGlobalImport1()
@@ -151,7 +155,7 @@ function asmModule(stdlib, imports) {
             globImportui4 = ui4shiftRightByScalar(globImportui4, 32);
             globImportui4 = ui4shiftRightByScalar(globImportui4, 33);
         }
-        return ui4check(globImportui4);
+        return i4check(i4fu4(globImportui4));
     }
 
     return {
@@ -164,18 +168,34 @@ function asmModule(stdlib, imports) {
 
 var m = asmModule(this, { g1: SIMD.Uint32x4(100, 1073741824, 1028, 102) });
 
-equalSimd([2250506240, 4241489920, 1703084032, 3715104768], m.testShiftLeftScalarLocal(), SIMD.Uint32x4, "testShift1");
-equalSimd([129, 73, 457, 144], m.testShiftRightScalarLocal(), SIMD.Uint32x4, "testShift2");
-equalSimd([520093696, 0, 0, 0], m.testShiftLeftScalarGlobal(), SIMD.Uint32x4, "testShift3");
-equalSimd([7936, 0, 0, 0], m.testShiftRightScalarGlobal(), SIMD.Uint32x4, "testShift4");
-equalSimd([6553600, 0, 67371008, 6684672], m.testShiftLeftScalarGlobalImport(), SIMD.Uint32x4, "testShift5");
-equalSimd([100, 0, 1028, 102], m.testShiftRightScalarGlobalImport(), SIMD.Uint32x4, "testShift6");
+var ret1 = SIMD.Uint32x4.fromInt32x4Bits(m.testShiftLeftScalarLocal());
+var ret2 = SIMD.Uint32x4.fromInt32x4Bits(m.testShiftRightScalarLocal());
+var ret3 = SIMD.Uint32x4.fromInt32x4Bits(m.testShiftLeftScalarGlobal());
+var ret4 = SIMD.Uint32x4.fromInt32x4Bits(m.testShiftRightScalarGlobal());
+var ret5 = SIMD.Uint32x4.fromInt32x4Bits(m.testShiftLeftScalarGlobalImport());
+var ret6 = SIMD.Uint32x4.fromInt32x4Bits(m.testShiftRightScalarGlobalImport());
 
-equalSimd([2250506240, 4241489920, 1703084032, 3715104768], m.testShiftLeftScalarLocal1(), SIMD.Uint32x4, "testShift1_1");
-equalSimd([129, 73, 457, 144], m.testShiftRightScalarLocal1(), SIMD.Uint32x4, "testShift2_1");
-equalSimd([520093696, 0, 0, 0], m.testShiftLeftScalarGlobal1(), SIMD.Uint32x4, "testShift3_1");
-equalSimd([7936, 0, 0, 0], m.testShiftRightScalarGlobal1(), SIMD.Uint32x4, "testShift4_1");
-equalSimd([6553600, 0, 67371008, 6684672], m.testShiftLeftScalarGlobalImport1(), SIMD.Uint32x4, "testShift5_1");
-equalSimd([100, 0, 1028, 102], m.testShiftRightScalarGlobalImport1(), SIMD.Uint32x4, "testShift6_1");
+var ret7 = SIMD.Uint32x4.fromInt32x4Bits(m.testShiftLeftScalarLocal1());
+var ret8 = SIMD.Uint32x4.fromInt32x4Bits(m.testShiftRightScalarLocal1());
+var ret9 = SIMD.Uint32x4.fromInt32x4Bits(m.testShiftLeftScalarGlobal1());
+var ret10 = SIMD.Uint32x4.fromInt32x4Bits(m.testShiftRightScalarGlobal1());
+var ret11 = SIMD.Uint32x4.fromInt32x4Bits(m.testShiftLeftScalarGlobalImport1());
+var ret12 = SIMD.Uint32x4.fromInt32x4Bits(m.testShiftRightScalarGlobalImport1());
+
+
+
+equalSimd([2250506240, 4241489920, 1703084032, 3715104768], ret1, SIMD.Uint32x4, "testShift1");
+equalSimd([129, 73, 457, 144], ret2, SIMD.Uint32x4, "testShift2");
+equalSimd([520093696, 0, 0, 0], ret3, SIMD.Uint32x4, "testShift3");
+equalSimd([7936, 0, 0, 0], ret4, SIMD.Uint32x4, "testShift4");
+equalSimd([6553600, 0, 67371008, 6684672], ret5, SIMD.Uint32x4, "testShift5");
+equalSimd([100, 0, 1028, 102], ret6, SIMD.Uint32x4, "testShift6");
+
+equalSimd([2250506240, 4241489920, 1703084032, 3715104768], ret7, SIMD.Uint32x4, "testShift1_1");
+equalSimd([129, 73, 457, 144], ret8, SIMD.Uint32x4, "testShift2_1");
+equalSimd([520093696, 0, 0, 0], ret9, SIMD.Uint32x4, "testShift3_1");
+equalSimd([7936, 0, 0, 0], ret10, SIMD.Uint32x4, "testShift4_1");
+equalSimd([6553600, 0, 67371008, 6684672], ret11, SIMD.Uint32x4, "testShift5_1");
+equalSimd([100, 0, 1028, 102], ret12, SIMD.Uint32x4, "testShift6_1");
 
 print("PASS");

--- a/test/SIMD.uint32x4.asmjs/testShuffle.js
+++ b/test/SIMD.uint32x4.asmjs/testShuffle.js
@@ -19,6 +19,10 @@ function asmModule(stdlib, imports) {
 
     var loopCOUNT = 3;
 
+    var i4 = stdlib.SIMD.Int32x4;
+    var i4check = i4.check;
+    var i4fu4 = i4.fromUint32x4Bits;
+
     function testShuffleLocal() {
         var a = ui4(8488484, 4848848, 29975939, 9493872);
         var b = ui4(99372621, 18848392, 888288822, 1000010012);
@@ -30,7 +34,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui4check(result);
+        return i4check(i4fu4(result));
     }
 
     function testShuffleGlobal() {
@@ -42,7 +46,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui4check(result);
+        return i4check(i4fu4(result));
     }
 
     function testShuffleGlobalImport() {
@@ -55,7 +59,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui4check(result);
+        return i4check(i4fu4(result));
     }
     
     function testShuffleFunc() {
@@ -68,7 +72,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui4check(result);
+        return i4check(i4fu4(result));
     }
 
     return { testShuffleLocal: testShuffleLocal, testShuffleGlobal: testShuffleGlobal, testShuffleGlobalImport: testShuffleGlobalImport, testShuffleFunc: testShuffleFunc };
@@ -76,10 +80,15 @@ function asmModule(stdlib, imports) {
 
 var m = asmModule(this, { g1: SIMD.Uint32x4(100, 1073741824, 1028, 102) });
 
-equalSimd([9493872, 8488484, 29975939, 4848848], m.testShuffleLocal(), SIMD.Uint32x4, "");
-equalSimd([1082130432, 1065353216, 1077936128, 1073741824], m.testShuffleGlobal(), SIMD.Uint32x4, "");
-equalSimd([9493872, 8488484, 29975939, 4848848], m.testShuffleGlobalImport(), SIMD.Uint32x4, "");
-equalSimd([1091624304, 1073841700, 1107912067, 1078590672], m.testShuffleFunc(), SIMD.Uint32x4, "");
+var ret1 = SIMD.Uint32x4.fromInt32x4Bits(m.testShuffleLocal());
+var ret2 = SIMD.Uint32x4.fromInt32x4Bits(m.testShuffleGlobal());
+var ret3 = SIMD.Uint32x4.fromInt32x4Bits(m.testShuffleGlobalImport());
+var ret4 = SIMD.Uint32x4.fromInt32x4Bits(m.testShuffleFunc());
+
+equalSimd([9493872, 8488484, 29975939, 4848848], ret1, SIMD.Uint32x4, "");
+equalSimd([1082130432, 1065353216, 1077936128, 1073741824], ret2, SIMD.Uint32x4, "");
+equalSimd([9493872, 8488484, 29975939, 4848848], ret3, SIMD.Uint32x4, "");
+equalSimd([1091624304, 1073841700, 1107912067, 1078590672], ret4, SIMD.Uint32x4, "");
 
 print("PASS");
 

--- a/test/SIMD.uint32x4.asmjs/testSplat.js
+++ b/test/SIMD.uint32x4.asmjs/testSplat.js
@@ -14,6 +14,10 @@ function asmModule(stdlib, imports) {
 
     var loopCOUNT = 3;
 
+    var i4 = stdlib.SIMD.Int32x4;
+    var i4check = i4.check;
+    var i4fu4 = i4.fromUint32x4Bits;
+
     function splat1()
     {
         var a = ui4(0, 0, 0, 0);
@@ -23,7 +27,7 @@ function asmModule(stdlib, imports) {
             a = ui4splat(4294967295);
             loopIndex = (loopIndex + 1) | 0;
         }   
-        return ui4check(a);
+        return i4check(i4fu4(a));
     }
     
     function splat2()
@@ -36,7 +40,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui4check(a);
+        return i4check(i4fu4(a));
     }
 
     function splat3()
@@ -49,7 +53,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui4check(a);
+        return i4check(i4fu4(a));
     }
     
     function value()
@@ -68,9 +72,9 @@ function asmModule(stdlib, imports) {
 
 var m = asmModule(this, { g1: SIMD.Uint32x4(20, 20, 20, 20) });
 
-var ret1 = m.func1();
-var ret2 = m.func2();
-var ret3 = m.func3();
+var ret1 = SIMD.Uint32x4.fromInt32x4Bits(m.func1());
+var ret2 = SIMD.Uint32x4.fromInt32x4Bits(m.func2());
+var ret3 = SIMD.Uint32x4.fromInt32x4Bits(m.func3());
 
 equalSimd([4294967295, 4294967295, 4294967295, 4294967295], ret1, SIMD.Uint32x4, "");
 equalSimd([4951, 4951, 4951, 4951], ret2, SIMD.Uint32x4, "");

--- a/test/SIMD.uint32x4.asmjs/testSwizzle.js
+++ b/test/SIMD.uint32x4.asmjs/testSwizzle.js
@@ -19,6 +19,11 @@ function asmModule(stdlib, imports) {
 
     var loopCOUNT = 3;
 
+    var i4 = stdlib.SIMD.Int32x4;
+    var i4check = i4.check;
+    var i4fu4 = i4.fromUint32x4Bits;
+    var u4fi4 = ui4.fromInt32x4Bits;
+
     function testswizzleLocal() {
         var a = ui4(8488484, 4848848, 29975939, 9493872);
         var result = ui4(0, 0, 0, 0);
@@ -28,7 +33,7 @@ function asmModule(stdlib, imports) {
             result = ui4swizzle(a, 2, 0, 3, 1);
             loopIndex = (loopIndex + 1) | 0;
         }   
-        return ui4check(result);
+        return i4check(i4fu4(result));
     }
 
     function testswizzleGlobal() {
@@ -39,7 +44,7 @@ function asmModule(stdlib, imports) {
             result = ui4swizzle(ui4g1, 2, 0, 3, 1);
             loopIndex = (loopIndex + 1) | 0;
         }
-        return ui4check(result);
+        return i4check(i4fu4(result));
     }
 
     function testswizzleGlobalImport() {
@@ -50,7 +55,7 @@ function asmModule(stdlib, imports) {
             result = ui4swizzle(globImporti4, 2, 0, 3, 1);
             loopIndex = (loopIndex + 1) | 0;
         }
-        return ui4check(result);
+        return i4check(i4fu4(result));
     }
 
     function testswizzleFunc() {
@@ -62,7 +67,7 @@ function asmModule(stdlib, imports) {
             result = ui4swizzle(ui4add(a, ui4g1), 2, 0, 3, 1);
             loopIndex = (loopIndex + 1) | 0;
         }
-        return ui4check(result);
+        return i4check(i4fu4(result));
     }
 
     return { testswizzleLocal: testswizzleLocal, testswizzleGlobal: testswizzleGlobal, testswizzleGlobalImport: testswizzleGlobalImport, testswizzleFunc: testswizzleFunc };
@@ -70,10 +75,15 @@ function asmModule(stdlib, imports) {
 
 var m = asmModule(this, { g1: SIMD.Uint32x4(50, 1000, 3092, 3393, 8838, 63838, NaN, 838) });
 
-equalSimd([29975939, 8488484, 9493872, 4848848], m.testswizzleLocal(), SIMD.Uint32x4, "");
-equalSimd([1077936128, 1065353216, 1082130432, 1073741824], m.testswizzleGlobal(), SIMD.Uint32x4, "");
-equalSimd([3092, 50, 3393, 1000], m.testswizzleGlobalImport(), SIMD.Uint32x4, "");
-equalSimd([1107912067, 1073841700, 1091624304, 1078590672], m.testswizzleFunc(), SIMD.Uint32x4, "");
+var ret1 = SIMD.Uint32x4.fromInt32x4Bits(m.testswizzleLocal());
+var ret2 = SIMD.Uint32x4.fromInt32x4Bits(m.testswizzleGlobal());
+var ret3 = SIMD.Uint32x4.fromInt32x4Bits(m.testswizzleGlobalImport());
+var ret4 = SIMD.Uint32x4.fromInt32x4Bits(m.testswizzleFunc());
+
+equalSimd([29975939, 8488484, 9493872, 4848848],  ret1, SIMD.Uint32x4, "");
+equalSimd([1077936128, 1065353216, 1082130432, 1073741824], ret2, SIMD.Uint32x4, "");
+equalSimd([3092, 50, 3393, 1000], ret3, SIMD.Uint32x4, "");
+equalSimd([1107912067, 1073841700, 1091624304, 1078590672], ret4, SIMD.Uint32x4, "");
 print("PASS");
 
 

--- a/test/SIMD.uint8x16.asmjs/rlexe.xml
+++ b/test/SIMD.uint8x16.asmjs/rlexe.xml
@@ -24,7 +24,22 @@
       <compile-flags>-on:asmjs -testtrace:asmjs -simdjs -AsmJsStopOnError -on:AsmJsInterpreter -off:fulljit -off:backend</compile-flags>
     </default>
   </test>
-  
+  <test>
+    <default>
+      <files>testFail.js</files>
+      <baseline>testFail.baseline</baseline>
+      <tags>exclude_dynapogo,exclude_ship</tags>
+      <compile-flags>-off:deferparse -testtrace:asmjs -simdjs -bgjit- -maic:1</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
+      <files>testFail_1.js</files>
+      <baseline>testFail_1.baseline</baseline>
+      <tags>exclude_dynapogo,exclude_ship</tags>
+      <compile-flags>-off:deferparse -testtrace:asmjs -simdjs -bgjit- -maic:1</compile-flags>
+    </default>
+  </test>
   <test>
     <default>
       <files>testCalls.js</files>

--- a/test/SIMD.uint8x16.asmjs/testAddSub.js
+++ b/test/SIMD.uint8x16.asmjs/testAddSub.js
@@ -16,6 +16,10 @@ function asmModule(stdlib, imports) {
     var ui16g2 = ui16(256, 255, 128, 127, 0, 0, 1000, 1000, 5, 15, 3, 399, 299, 21, 45, 22);
 
     var loopCOUNT = 3;
+        
+    var i16 = stdlib.SIMD.Int8x16;
+    var i16check = i16.check;
+    var i16fu16 = i16.fromUint8x16Bits;
 
     function testAddLocal()
     {
@@ -29,7 +33,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui16check(result);
+        return i16check(i16fu16(result));
     }
     
     function testSubLocal()
@@ -44,7 +48,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui16check(result);
+        return i16check(i16fu16(result));
     }
 
     function testAddGlobal()
@@ -57,7 +61,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui16check(result);
+        return i16check(i16fu16(result));
     }
     
     function testSubGlobal()
@@ -70,7 +74,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui16check(result);
+        return i16check(i16fu16(result));
     }
     
     function testAddGlobalImport()
@@ -84,7 +88,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui16check(result);
+        return i16check(i16fu16(result));
     }
     
     function testSubGlobalImport()
@@ -98,7 +102,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui16check(result);
+        return i16check(i16fu16(result));
     }
     
     return { testAddLocal: testAddLocal, testSubLocal: testSubLocal, testAddGlobal: testAddGlobal, testSubGlobal: testSubGlobal, testAddGlobalImport: testAddGlobalImport, testSubGlobalImport: testSubGlobalImport };
@@ -106,10 +110,18 @@ function asmModule(stdlib, imports) {
 
 var m = asmModule(this, {g1:SIMD.Uint8x16(100, 65535, 1028, 102, 3883, 38, 52929, 1442, 52, 127, 127, 129, 129, 0, 88, 10234)});
 
-equalSimd([17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17], m.testAddLocal(), SIMD.Uint8x16, "Func1");
-equalSimd([241, 243, 245, 247, 249, 251, 253, 255, 1, 3, 5, 7, 9, 11, 13, 15], m.testSubLocal(), SIMD.Uint8x16, "Func2");
-equalSimd([1, 1, 131, 131, 5, 6, 239, 240, 14, 25, 14, 155, 56, 35, 60, 38], m.testAddGlobal(), SIMD.Uint8x16, "Func3");
-equalSimd([1, 3, 131, 133, 5, 6, 31, 32, 4, 251, 8, 125, 226, 249, 226, 250], m.testSubGlobal(), SIMD.Uint8x16, "Func4");
-equalSimd([101, 1, 7, 106, 48, 44, 200, 170, 61, 137, 138, 141, 142, 14, 103, 10], m.testAddGlobalImport(), SIMD.Uint8x16, "Func5");
-equalSimd([99, 253, 1, 98, 38, 32, 186, 154, 43, 117, 116, 117, 116, 242, 73, 234], m.testSubGlobalImport(), SIMD.Uint8x16, "Func6");
+var ret1 = SIMD.Uint8x16.fromInt8x16Bits(m.testAddLocal());
+var ret2 = SIMD.Uint8x16.fromInt8x16Bits(m.testSubLocal());
+var ret3 = SIMD.Uint8x16.fromInt8x16Bits(m.testAddGlobal());
+var ret4 = SIMD.Uint8x16.fromInt8x16Bits(m.testSubGlobal());
+var ret5 = SIMD.Uint8x16.fromInt8x16Bits(m.testAddGlobalImport());
+var ret6 = SIMD.Uint8x16.fromInt8x16Bits(m.testSubGlobalImport());
+
+
+equalSimd([17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17], ret1, SIMD.Uint8x16, "Func1");
+equalSimd([241, 243, 245, 247, 249, 251, 253, 255, 1, 3, 5, 7, 9, 11, 13, 15], ret2, SIMD.Uint8x16, "Func2");
+equalSimd([1, 1, 131, 131, 5, 6, 239, 240, 14, 25, 14, 155, 56, 35, 60, 38], ret3, SIMD.Uint8x16, "Func3");
+equalSimd([1, 3, 131, 133, 5, 6, 31, 32, 4, 251, 8, 125, 226, 249, 226, 250], ret4, SIMD.Uint8x16, "Func4");
+equalSimd([101, 1, 7, 106, 48, 44, 200, 170, 61, 137, 138, 141, 142, 14, 103, 10], ret5, SIMD.Uint8x16, "Func5");
+equalSimd([99, 253, 1, 98, 38, 32, 186, 154, 43, 117, 116, 117, 116, 242, 73, 234], ret6, SIMD.Uint8x16, "Func6");
 print("PASS");

--- a/test/SIMD.uint8x16.asmjs/testAddSubSaturate.js
+++ b/test/SIMD.uint8x16.asmjs/testAddSubSaturate.js
@@ -16,6 +16,10 @@ function asmModule(stdlib, imports) {
     var ui16g2 = ui16(256, 255, 128, 127, 0, 0, 1000, 1000, 5, 15, 3, 399, 299, 21, 45, 22);
 
     var loopCOUNT = 3;
+    
+    var i16 = stdlib.SIMD.Int8x16;
+    var i16check = i16.check;
+    var i16fu16 = i16.fromUint8x16Bits;
 
     function testAddSaturateLocal()
     {
@@ -29,7 +33,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui16check(result);
+        return i16check(i16fu16(result));
     }
     
     function testSubSaturateLocal()
@@ -44,7 +48,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui16check(result);
+        return i16check(i16fu16(result));
     }
 
     function testAddSaturateGlobal()
@@ -57,7 +61,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui16check(result);
+        return i16check(i16fu16(result));
     }
     
     function testSubSaturateGlobal()
@@ -70,7 +74,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui16check(result);
+        return i16check(i16fu16(result));
     }
     
     function testAddSaturateGlobalImport()
@@ -84,7 +88,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui16check(result);
+        return i16check(i16fu16(result));
     }
     
     function testSubSaturateGlobalImport()
@@ -98,7 +102,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui16check(result);
+        return i16check(i16fu16(result));
     }
     
     return { testAddSaturateLocal: testAddSaturateLocal, testSubSaturateLocal: testSubSaturateLocal, testAddSaturateGlobal: testAddSaturateGlobal, testSubSaturateGlobal: testSubSaturateGlobal, testAddSaturateGlobalImport: testAddSaturateGlobalImport, testSubSaturateGlobalImport: testSubSaturateGlobalImport };
@@ -106,10 +110,17 @@ function asmModule(stdlib, imports) {
 
 var m = asmModule(this, {g1:SIMD.Uint8x16(100, 255, 255, 255, 0, 38, 255, 1442, 52, 127, 254, 256, 129, 0, 88, 100234)});
 
-equalSimd([255, 255, 255, 250, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 255], m.testAddSaturateLocal(), SIMD.Uint8x16, "Func1");
-equalSimd([0, 0, 0, 0, 0, 0, 0, 0, 1, 3, 5, 7, 9, 11, 13, 0], m.testSubSaturateLocal(), SIMD.Uint8x16, "Func2");
-equalSimd([1, 255, 131, 131, 5, 6, 239, 240, 14, 25, 14, 155, 56, 35, 60, 38], m.testAddSaturateGlobal(), SIMD.Uint8x16, "Func3");
-equalSimd([1, 0, 0, 0, 5, 6, 0, 0, 4, 0, 8, 0, 0, 0, 0, 0], m.testSubSaturateGlobal(), SIMD.Uint8x16, "Func4");
-equalSimd([101, 255, 255, 255, 5, 44, 255, 170, 61, 137, 255, 12, 142, 14, 103, 154], m.testAddSaturateGlobalImport(), SIMD.Uint8x16, "Func5");
-equalSimd([99, 253, 252, 251, 0, 32, 248, 154, 43, 117, 243, 0, 116, 0, 73, 122], m.testSubSaturateGlobalImport(), SIMD.Uint8x16, "Func6");
+var ret1 = SIMD.Uint8x16.fromInt8x16Bits(m.testAddSaturateLocal());
+var ret2 = SIMD.Uint8x16.fromInt8x16Bits(m.testSubSaturateLocal());
+var ret3 = SIMD.Uint8x16.fromInt8x16Bits(m.testAddSaturateGlobal());
+var ret4 = SIMD.Uint8x16.fromInt8x16Bits(m.testSubSaturateGlobal());
+var ret5 = SIMD.Uint8x16.fromInt8x16Bits(m.testAddSaturateGlobalImport());
+var ret6 = SIMD.Uint8x16.fromInt8x16Bits(m.testSubSaturateGlobalImport());
+
+equalSimd([255, 255, 255, 250, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 255], ret1, SIMD.Uint8x16, "Func1");
+equalSimd([0, 0, 0, 0, 0, 0, 0, 0, 1, 3, 5, 7, 9, 11, 13, 0], ret2, SIMD.Uint8x16, "Func2");
+equalSimd([1, 255, 131, 131, 5, 6, 239, 240, 14, 25, 14, 155, 56, 35, 60, 38], ret3, SIMD.Uint8x16, "Func3");
+equalSimd([1, 0, 0, 0, 5, 6, 0, 0, 4, 0, 8, 0, 0, 0, 0, 0], ret4, SIMD.Uint8x16, "Func4");
+equalSimd([101, 255, 255, 255, 5, 44, 255, 170, 61, 137, 255, 12, 142, 14, 103, 154], ret5, SIMD.Uint8x16, "Func5");
+equalSimd([99, 253, 252, 251, 0, 32, 248, 154, 43, 117, 243, 0, 116, 0, 73, 122], ret6, SIMD.Uint8x16, "Func6");
 print("PASS");

--- a/test/SIMD.uint8x16.asmjs/testBitwise.js
+++ b/test/SIMD.uint8x16.asmjs/testBitwise.js
@@ -20,6 +20,10 @@ function asmModule(stdlib, imports) {
     var ui16g2 = ui16(256, 255, 128, 127, 0, 0, 1000, 1000, 5, 15, 3, 399, 299, 21, 45, 22);
 
     var loopCOUNT = 3;
+    
+    var i16 = stdlib.SIMD.Int8x16;
+    var i16check = i16.check;
+    var i16fu16 = i16.fromUint8x16Bits;
 
     function testBitwiseOR()
     {
@@ -33,7 +37,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui16check(result);
+        return i16check(i16fu16(result));
     }
     
     function testBitwiseAND()
@@ -48,7 +52,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui16check(result);
+        return i16check(i16fu16(result));
     }
 
     function testBitwiseXOR()
@@ -63,7 +67,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui16check(result);
+        return i16check(i16fu16(result));
     }
     
     function testBitwiseNOT() {
@@ -76,7 +80,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui16check(result);
+        return i16check(i16fu16(result));
     }
     
         
@@ -90,7 +94,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui16check(result);
+        return i16check(i16fu16(result));
     }
     
     return {testBitwiseOR:testBitwiseOR, testBitwiseAND:testBitwiseAND, testBitwiseXOR:testBitwiseXOR, testBitwiseNOT:testBitwiseNOT, testBitwiseNEG:testBitwiseNEG};
@@ -98,10 +102,16 @@ function asmModule(stdlib, imports) {
 
 var m = asmModule(this, { g1: SIMD.Uint8x16(100, -1073741824, -1028, -102, NaN, -38, -92929, Infinity, 52, 127, -127, -129, 129, 0, 88, 100234) });
 
-equalSimd([255, 128, 0, 127, 28, 127, 15, 9, 9, 15, 15, 13, 13, 15, 15, 17], m.testBitwiseOR(), SIMD.Uint8x16, "testBitwiseOR");
-equalSimd([255, 128, 0, 43, 0, 0, 2, 8, 8, 2, 2, 4, 4, 2, 2, 0], m.testBitwiseAND(), SIMD.Uint8x16, "testBitwiseAND");
-equalSimd([0, 127, 255, 212, 128, 127, 13, 1, 1, 13, 13, 9, 9, 13, 13, 17], m.testBitwiseXOR(), SIMD.Uint8x16, "testBitwiseXOR");
-equalSimd([0, 0, 0, 0, 127, 255, 248, 247, 246, 245, 244, 243, 242, 241, 240, 239], m.testBitwiseNOT(), SIMD.Uint8x16, "testBitwiseNOT");
-equalSimd([1, 1, 1, 1, 128, 0, 249, 248, 247, 246, 245, 244, 243, 242, 241, 240], m.testBitwiseNEG(), SIMD.Uint8x16, "testBitwiseNEG");
+var ret1 = SIMD.Uint8x16.fromInt8x16Bits(m.testBitwiseOR());
+var ret2 = SIMD.Uint8x16.fromInt8x16Bits(m.testBitwiseAND());
+var ret3 = SIMD.Uint8x16.fromInt8x16Bits(m.testBitwiseXOR());
+var ret4 = SIMD.Uint8x16.fromInt8x16Bits(m.testBitwiseNOT());
+var ret5 = SIMD.Uint8x16.fromInt8x16Bits(m.testBitwiseNEG());
+
+equalSimd([255, 128, 0, 127, 28, 127, 15, 9, 9, 15, 15, 13, 13, 15, 15, 17], ret1, SIMD.Uint8x16, "testBitwiseOR");
+equalSimd([255, 128, 0, 43, 0, 0, 2, 8, 8, 2, 2, 4, 4, 2, 2, 0], ret2, SIMD.Uint8x16, "testBitwiseAND");
+equalSimd([0, 127, 255, 212, 128, 127, 13, 1, 1, 13, 13, 9, 9, 13, 13, 17], ret3, SIMD.Uint8x16, "testBitwiseXOR");
+equalSimd([0, 0, 0, 0, 127, 255, 248, 247, 246, 245, 244, 243, 242, 241, 240, 239], ret4, SIMD.Uint8x16, "testBitwiseNOT");
+equalSimd([1, 1, 1, 1, 128, 0, 249, 248, 247, 246, 245, 244, 243, 242, 241, 240], ret5, SIMD.Uint8x16, "testBitwiseNEG");
 
 print("PASS");

--- a/test/SIMD.uint8x16.asmjs/testCalls.js
+++ b/test/SIMD.uint8x16.asmjs/testCalls.js
@@ -82,13 +82,16 @@ function asmModule(stdlib, imports) {
     var gval2 = 1234.0;
 
 
-    
+    var i16 = stdlib.SIMD.Int8x16;
+    var i16check = i16.check;
+    var i16fu16 = i16.fromUint8x16Bits;
+    var u16fi16 = u16.fromInt8x16Bits;
     var loopCOUNT = 3;
 
     function func1(a, b)
     {
-        a = u16check(a);
-        b = u16check(b);
+        a = i16check(a);
+        b = i16check(b);
         var x = u16(-1, -2, -3, -4, -5, -6, -7, -8, 1024, 1025, 1026, 1027, -1028, -1029, -1030, -1031);;
 
         var loopIndex = 0;
@@ -100,41 +103,38 @@ function asmModule(stdlib, imports) {
         }
         x = globImportU16;
         g2 = x;
-        return u16check(x);
+        return i16check(i16fu16(x));
     }
     
     function func2(a, b, c, d)
     {
-        a = u16check(a);
-        b = u16check(b);
-        c = u16check(c);
-        d = u16check(d);
+        a = i16check(a);
+        b = i16check(b);
+        c = i16check(c);
+        d = i16check(d);
         var x = u16(-1, -2, -3, -4, -5, -6, -7, -8, 1024, 1025, 1026, 1027, -1028, -1029, -1030, -1031);
         var y = u16(-1, -2, -3, -4, -5, -6, -7, -8, 1024, 1025, 1026, 1027, 1028, 1029, 1030, 1031);
         var loopIndex = 0;
         for (loopIndex = 0; (loopIndex | 0) < (loopCOUNT | 0) ; loopIndex = (loopIndex + 1) | 0)
         {
-
-            x = u16check(func1(a, b));
-            y = u16check(func1(c, d));
-            
-
+            x = u16fi16(i16check(func1(a, b)));
+            y = u16fi16(i16check(func1(c, d)));
         }
 
-        //return u16check(u16add(x,y));
-        return u16check(x);
+        //return i16check(u16add(x,y));
+        return i16check(i16fu16(x));
     }
 
     function func3(a, b, c, d, e, f, g, h)
     {
-        a = u16check(a);
-        b = u16check(b);
-        c = u16check(c);
-        d = u16check(d);
-        e = u16check(e);
-        f = u16check(f);
-        g = u16check(g);
-        h = u16check(h);        
+        a = i16check(a);
+        b = i16check(b);
+        c = i16check(c);
+        d = i16check(d);
+        e = i16check(e);
+        f = i16check(f);
+        g = i16check(g);
+        h = i16check(h);        
         
         var x = u16(-1, -2, -3, -4, -5, -6, -7, -8, 1024, 1025, 1026, 1027, -1028, -1029, -1030, -1031);
         var y = u16(-1, -2, -3, -4, -5, -6, -7, -8, 1024, 1025, 1026, 1027, 1028, 1029, 1030, 1031);
@@ -142,13 +142,13 @@ function asmModule(stdlib, imports) {
         for (loopIndex = 0; (loopIndex | 0) < (loopCOUNT | 0) ; loopIndex = (loopIndex + 1) | 0)
         {
 
-            x = u16check(func2(a, b, c, d));
-            y = u16check(func2(e, f, g, h));
+            x = u16fi16(i16check(func2(a, b, c, d)));
+            y = u16fi16(i16check(func2(e, f, g, h)));
             
         }
 
-        //return u16check(u16add(x,y));
-        return u16check(x);
+        //return i16check(u16add(x,y));
+        return i16check(i16fu16(x));
     }
 
     function func4() { //Testing for a bug while returning SIMD values from a loop
@@ -158,7 +158,7 @@ function asmModule(stdlib, imports) {
         for (i = 0; (i | 0) < 1000; i = (i + 1)|0) {
             //value1 = u16add(value1, u16splat(1));
             if ((i | 0) == 300) {
-                return u16check(value1);
+                return i16check(i16fu16(value1));
             }
         }
     }
@@ -183,14 +183,14 @@ function asmModule(stdlib, imports) {
 
     function fctest(a)
     {
-        a = u16check(a);
+        a = i16check(a);
         return a;
     }
     function fcBug_1()
     {
         var x = f4(-1.0, -2.0, -3.0, -4.0);
         var k = u16(1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
-        k = u16check(fctest(k));
+        k = u16fi16(i16check(fctest(i16fu16(k))));
         return f4check(x);
     }
     function fcBug_2()
@@ -198,7 +198,7 @@ function asmModule(stdlib, imports) {
         var x = f4(-1.0, -2.0, -3.0, -4.0);
         var k = u16(1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
         x = f4check(fcBug_1());
-        return u16check(k);
+        return i16check(i16fu16(k));
     }
 
     return {func1:func1, func2:func2, func3:func3, func4:func4, func5:fcBug_1, func6:fcBug_2};
@@ -217,12 +217,15 @@ var s6 = SIMD.Uint8x16(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 
 var s7 = SIMD.Uint8x16(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0);
 var s8 = SIMD.Uint8x16(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0);
 
-var ret1 = m.func1(s1, s2);
-var ret2 = m.func2(s1, s2, s3, s4);
-var ret3 = m.func3(s1, s2, s3, s4, s5, s6, s7, s8);
-var ret4 = m.func4();
+var i16fu16 = SIMD.Int8x16.fromUint8x16Bits;
+var u16fi16 = SIMD.Uint8x16.fromInt8x16Bits;
+
+var ret1 = u16fi16(m.func1(i16fu16(s1), i16fu16(s2)));
+var ret2 = u16fi16(m.func2(i16fu16(s1), i16fu16(s2), i16fu16(s3), i16fu16(s4)));
+var ret3 = u16fi16(m.func3(i16fu16(s1), i16fu16(s2), i16fu16(s3), i16fu16(s4), i16fu16(s5), i16fu16(s6), i16fu16(s7), i16fu16(s8)));
+var ret4 = u16fi16(m.func4());
 var ret5 = m.func5();
-var ret6 = m.func6();
+var ret6 = u16fi16(m.func6());
 
 
 equalSimd([98, 0, 192, 0, 160, 192, 88, 128, 158, 0, 64, 0, 96, 64, 168, 128], ret1, SIMD.Uint8x16, "func1")

--- a/test/SIMD.uint8x16.asmjs/testComparisonSelect.js
+++ b/test/SIMD.uint8x16.asmjs/testComparisonSelect.js
@@ -24,6 +24,10 @@ function asmModule(stdlib, imports) {
 
     var loopCOUNT = 6;
 
+    var i16 = stdlib.SIMD.Int8x16;
+    var i16check = i16.check;
+    var i16fu16 = i16.fromUint8x16Bits;
+
     function testLessThan() {
         var b = ui16(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
         var c = ui16(16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1);
@@ -38,7 +42,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui16check(d);
+        return i16check(i16fu16(d));
     }
 
     function testLessThanOrEqual() {
@@ -56,7 +60,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui16check(d);
+        return i16check(i16fu16(d));
     }
 
     function testGreaterThan() {
@@ -74,7 +78,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui16check(d);
+        return i16check(i16fu16(d));
     }
 
     function testGreaterThanOrEqual() {
@@ -92,7 +96,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui16check(d);
+        return i16check(i16fu16(d));
     }
 
     function testEqual() {
@@ -110,7 +114,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui16check(d);
+        return i16check(i16fu16(d));
     }
 
     function testNotEqual() {
@@ -128,7 +132,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui16check(d);
+        return i16check(i16fu16(d));
     }
 
     return { testLessThan: testLessThan, testLessThanOrEqual: testLessThanOrEqual, testGreaterThan: testGreaterThan, testGreaterThanOrEqual: testGreaterThanOrEqual, testEqual: testEqual, testNotEqual: testNotEqual };
@@ -136,12 +140,19 @@ function asmModule(stdlib, imports) {
 
 var m = asmModule(this, { g1: SIMD.Uint8x16(100, -1073741824, -1028, -102, 127, -38, -92929, -128, 52, 127, -127, -129, 129, 0, 88, 100234) });
 
-equalSimd([1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1], m.testLessThan(), SIMD.Uint8x16, "Func1");
-equalSimd([1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1], m.testLessThanOrEqual(), SIMD.Uint8x16, "Func2");
-equalSimd([16, 15, 14, 13, 12, 11, 10, 9, 9, 10, 11, 12, 13, 14, 15, 16], m.testGreaterThan(), SIMD.Uint8x16, "Func3");
-equalSimd([16, 15, 14, 13, 12, 11, 10, 9, 9, 10, 11, 12, 13, 14, 15, 16], m.testGreaterThanOrEqual(), SIMD.Uint8x16, "Func4");
-equalSimd([16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1], m.testEqual(), SIMD.Uint8x16, "Func5");
-equalSimd([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16], m.testNotEqual(), SIMD.Uint8x16, "Func6");
+var ret1 = SIMD.Uint8x16.fromInt8x16Bits(m.testLessThan());
+var ret2 = SIMD.Uint8x16.fromInt8x16Bits(m.testLessThanOrEqual());
+var ret3 = SIMD.Uint8x16.fromInt8x16Bits(m.testGreaterThan());
+var ret4 = SIMD.Uint8x16.fromInt8x16Bits(m.testGreaterThanOrEqual());
+var ret5 = SIMD.Uint8x16.fromInt8x16Bits(m.testEqual());
+var ret6 = SIMD.Uint8x16.fromInt8x16Bits(m.testNotEqual());
+
+equalSimd([1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1], ret1, SIMD.Uint8x16, "Func1");
+equalSimd([1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1], ret2, SIMD.Uint8x16, "Func2");
+equalSimd([16, 15, 14, 13, 12, 11, 10, 9, 9, 10, 11, 12, 13, 14, 15, 16], ret3, SIMD.Uint8x16, "Func3");
+equalSimd([16, 15, 14, 13, 12, 11, 10, 9, 9, 10, 11, 12, 13, 14, 15, 16], ret4, SIMD.Uint8x16, "Func4");
+equalSimd([16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1], ret5, SIMD.Uint8x16, "Func5");
+equalSimd([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16], ret6, SIMD.Uint8x16, "Func6");
 
 print("PASS");
 

--- a/test/SIMD.uint8x16.asmjs/testConstructorLanes.js
+++ b/test/SIMD.uint8x16.asmjs/testConstructorLanes.js
@@ -17,6 +17,10 @@ function asmModule(stdlib, imports) {
     var vectorLength = 16;
 
     var loopCOUNT = 3;
+    
+    var i16 = stdlib.SIMD.Int8x16;
+    var i16check = i16.check;
+    var i16fu16 = i16.fromUint8x16Bits;
 
     function testLocal()
     {
@@ -83,7 +87,7 @@ function asmModule(stdlib, imports) {
 
             loopIndex = (loopIndex + 1) | 0;
         }
-        return ui16check(result);
+        return i16check(i16fu16(result));
     }
     
     function testGlobal()
@@ -151,7 +155,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui16check(result);
+        return i16check(i16fu16(result));
     }
 
     function testGlobalImport()
@@ -219,7 +223,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui16check(result);
+        return i16check(i16fu16(result));
     }
     
     return {testLocal:testLocal, testGlobal:testGlobal, testGlobalImport:testGlobalImport};
@@ -227,8 +231,12 @@ function asmModule(stdlib, imports) {
 
 var m = asmModule(this, { g1: SIMD.Uint8x16(-1065353216, -1073741824, -1077936128, -1082130432, -383829393, -39283838, -92929, -109483922, -1065353216, -1073741824, -1077936128, -1082130432, -383829393, -39283838, -92929, -109483922) });
 
-equalSimd([160, 129, 255, 0, 241, 255, 0, 0, 0, 94, 1, 1, 128, 127, 10, 16], m.testLocal(), SIMD.Uint8x16, "testLocal");
-equalSimd([1, 2, 3, 4, 15, 6, 255, 255, 64, 0, 255, 0, 255, 1, 53, 16], m.testGlobal(), SIMD.Uint8x16, "testGlobal");
-equalSimd([0, 0, 0, 0, 111, 130, 255, 110, 0, 0, 0, 0, 111, 130, 255, 110], m.testGlobalImport(), SIMD.Uint8x16, "testGlobalImport");
+var ret1 = SIMD.Uint8x16.fromInt8x16Bits(m.testLocal());
+var ret2 = SIMD.Uint8x16.fromInt8x16Bits(m.testGlobal());
+var ret3 = SIMD.Uint8x16.fromInt8x16Bits(m.testGlobalImport());
+
+equalSimd([160, 129, 255, 0, 241, 255, 0, 0, 0, 94, 1, 1, 128, 127, 10, 16], ret1, SIMD.Uint8x16, "testLocal");
+equalSimd([1, 2, 3, 4, 15, 6, 255, 255, 64, 0, 255, 0, 255, 1, 53, 16], ret2, SIMD.Uint8x16, "testGlobal");
+equalSimd([0, 0, 0, 0, 111, 130, 255, 110, 0, 0, 0, 0, 111, 130, 255, 110], ret3, SIMD.Uint8x16, "testGlobalImport");
 
 print("PASS");

--- a/test/SIMD.uint8x16.asmjs/testConversion-2.js
+++ b/test/SIMD.uint8x16.asmjs/testConversion-2.js
@@ -34,6 +34,9 @@ function asmModule(stdlib, imports) {
     var g2 = i4(1065353216, 1073741824,1077936128, 1082130432);          // global var initialized
     var loopCOUNT = 3;
 
+    var i16check = i16.check;
+    var i16fu16 = i16.fromUint8x16Bits;
+
     function conv1()
     {
         var x = ui16(0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0);
@@ -45,7 +48,7 @@ function asmModule(stdlib, imports) {
 
             loopIndex = (loopIndex + 1) | 0;
         }
-        return ui16check(x);
+        return i16check(i16fu16(x));
     }
     
     function conv2()
@@ -56,7 +59,7 @@ function asmModule(stdlib, imports) {
         {
             x = ui16fromInt32x4Bits(globImportI4);
         }
-        return ui16check(x);
+        return i16check(i16fu16(x));
     }
 
     function conv3()
@@ -73,7 +76,7 @@ function asmModule(stdlib, imports) {
         }
         while ( (loopIndex | 0) > 0);
        
-        return ui16check(x);
+        return i16check(i16fu16(x));
     }
 
     function conv4()
@@ -88,7 +91,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
        
-        return ui16check(x);
+        return i16check(i16fu16(x));
     }
 
     function conv5()
@@ -100,7 +103,7 @@ function asmModule(stdlib, imports) {
         {
             x = ui16fromInt8x16Bits(m);
         }
-        return ui16check(x);
+        return i16check(i16fu16(x));
     }
     
     function conv6()
@@ -113,7 +116,7 @@ function asmModule(stdlib, imports) {
             x = ui16fromInt16x8Bits(m);
         }
 
-        return ui16check(x);
+        return i16check(i16fu16(x));
     }
     // TODO: Test conversion of returned value
     function value()
@@ -152,11 +155,19 @@ printSimdBaseline(m.func4(), "SIMD.Uint8x16", "m.func4()", "Func4");
 printSimdBaseline(m.func5(), "SIMD.Uint8x16", "m.func5()", "Func5");
 printSimdBaseline(m.func6(), "SIMD.Uint8x16", "m.func6()", "Func6");  */
 
-equalSimd([154, 73, 157, 69, 0, 144, 84, 69, 195, 85, 38, 68, 51, 212, 251, 70], m.func1(), SIMD.Uint8x16, "Func1");
-equalSimd([0, 0, 128, 192, 0, 0, 0, 192, 0, 0, 192, 191, 0, 0, 128, 191], m.func2(), SIMD.Uint8x16, "Func2");
-equalSimd([1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 4, 0, 0, 0], m.func3(), SIMD.Uint8x16, "Func3");
-equalSimd([1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0, 7, 0, 8, 0], m.func4(), SIMD.Uint8x16, "Func4");
-equalSimd([170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170], m.func5(), SIMD.Uint8x16, "Func5");
-equalSimd([170, 0, 170, 0, 170, 0, 170, 0, 170, 0, 170, 0, 170, 0, 170, 0], m.func6(), SIMD.Uint8x16, "Func6");
+var ret1 = SIMD.Uint8x16.fromInt8x16Bits(m.func1());
+var ret2 = SIMD.Uint8x16.fromInt8x16Bits(m.func2());
+var ret3 = SIMD.Uint8x16.fromInt8x16Bits(m.func3());
+var ret4 = SIMD.Uint8x16.fromInt8x16Bits(m.func4());
+var ret5 = SIMD.Uint8x16.fromInt8x16Bits(m.func5());
+var ret6 = SIMD.Uint8x16.fromInt8x16Bits(m.func6());
+
+
+equalSimd([154, 73, 157, 69, 0, 144, 84, 69, 195, 85, 38, 68, 51, 212, 251, 70], ret1, SIMD.Uint8x16, "Func1");
+equalSimd([0, 0, 128, 192, 0, 0, 0, 192, 0, 0, 192, 191, 0, 0, 128, 191], ret2, SIMD.Uint8x16, "Func2");
+equalSimd([1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 4, 0, 0, 0], ret3, SIMD.Uint8x16, "Func3");
+equalSimd([1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0, 7, 0, 8, 0], ret4, SIMD.Uint8x16, "Func4");
+equalSimd([170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170], ret5, SIMD.Uint8x16, "Func5");
+equalSimd([170, 0, 170, 0, 170, 0, 170, 0, 170, 0, 170, 0, 170, 0, 170, 0], ret6, SIMD.Uint8x16, "Func6");
 
 print("PASS");

--- a/test/SIMD.uint8x16.asmjs/testConversion.js
+++ b/test/SIMD.uint8x16.asmjs/testConversion.js
@@ -15,7 +15,7 @@ function asmModule(stdlib, imports) {
     var ui16fromUint32x4Bits = ui16.fromUint32x4Bits;
     var ui16fromInt16x8Bits = ui16.fromInt16x8Bits;
     var ui16fromUint16x8Bits = ui16.fromUint16x8Bits;
-    var ui16fromInt8x16Bits = ui16.fromInt8x16Bits;
+    // var ui16fromInt8x16Bits = ui16.fromInt8x16Bits;
      
     var i4 = stdlib.SIMD.Int32x4;
     var i4check = i4.check;
@@ -35,6 +35,10 @@ function asmModule(stdlib, imports) {
     var g2 = i4(1065353216, 1073741824,1077936128, 1082130432);          // global var initialized
     var loopCOUNT = 3;
 
+    var i16check = i16.check;
+    var i16fu16 = i16.fromUint8x16Bits;
+    var u16fi16 = ui16.fromInt8x16Bits;
+
     function conv1()
     {
         var x = ui16(0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0);
@@ -46,7 +50,7 @@ function asmModule(stdlib, imports) {
 
             loopIndex = (loopIndex + 1) | 0;
         }
-        return ui16check(x);
+        return i16check(i16fu16(x));
     }
     
     function conv2()
@@ -57,7 +61,7 @@ function asmModule(stdlib, imports) {
         {
             x = ui16fromInt32x4Bits(globImportI4);
         }
-        return ui16check(x);
+        return i16check(i16fu16(x));
     }
 
     function conv3()
@@ -74,7 +78,7 @@ function asmModule(stdlib, imports) {
         }
         while ( (loopIndex | 0) > 0);
        
-        return ui16check(x);
+        return i16check(i16fu16(x));
     }
 
     function conv4()
@@ -89,7 +93,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
        
-        return ui16check(x);
+        return i16check(i16fu16(x));
     }
 
     function conv5()
@@ -99,9 +103,9 @@ function asmModule(stdlib, imports) {
         var loopIndex = 0;
         for (loopIndex = 0; (loopIndex | 0) < (loopCOUNT | 0) ; loopIndex = (loopIndex + 1) | 0)
         {
-            x = ui16fromInt8x16Bits(m);
+            x = u16fi16(m);
         }
-        return ui16check(x);
+        return i16check(i16fu16(x));
     }
  
     function conv6()
@@ -114,7 +118,7 @@ function asmModule(stdlib, imports) {
             x = ui16fromInt16x8Bits(m);
         }
 
-        return ui16check(x);
+        return i16check(i16fu16(x));
     }
 
 
@@ -137,11 +141,19 @@ var m = asmModule(this, {g1:SIMD.Uint8x16(0x55, 0x55, 0x55, 0x55,0x55, 0x55, 0x5
 // printSimdBaseline(m.func5(), "SIMD.Uint8x16", "m.func5()", "Func5");
 // printSimdBaseline(m.func6(), "SIMD.Uint8x16", "m.func6()", "Func6");  
 
-equalSimd([154, 73, 157, 69, 0, 144, 84, 69, 195, 85, 38, 68, 51, 212, 251, 70], m.func1(), SIMD.Uint8x16, "Func1")
-equalSimd([0, 0, 128, 192, 0, 0, 0, 192, 0, 0, 192, 191, 0, 0, 128, 191], m.func2(), SIMD.Uint8x16, "Func2")
-equalSimd([1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 4, 0, 0, 0], m.func3(), SIMD.Uint8x16, "Func3")
-equalSimd([1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0, 7, 0, 8, 0], m.func4(), SIMD.Uint8x16, "Func4")
-equalSimd([170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170], m.func5(), SIMD.Uint8x16, "Func5")
-equalSimd([170, 0, 170, 0, 170, 0, 170, 0, 170, 0, 170, 0, 170, 0, 170, 0], m.func6(), SIMD.Uint8x16, "Func6")
+var ret1 = SIMD.Uint8x16.fromInt8x16Bits(m.func1());
+var ret2 = SIMD.Uint8x16.fromInt8x16Bits(m.func2());
+var ret3 = SIMD.Uint8x16.fromInt8x16Bits(m.func3());
+var ret4 = SIMD.Uint8x16.fromInt8x16Bits(m.func4());
+var ret5 = SIMD.Uint8x16.fromInt8x16Bits(m.func5());
+var ret6 = SIMD.Uint8x16.fromInt8x16Bits(m.func6());
+
+
+equalSimd([154, 73, 157, 69, 0, 144, 84, 69, 195, 85, 38, 68, 51, 212, 251, 70], ret1, SIMD.Uint8x16, "Func1")
+equalSimd([0, 0, 128, 192, 0, 0, 0, 192, 0, 0, 192, 191, 0, 0, 128, 191], ret2, SIMD.Uint8x16, "Func2")
+equalSimd([1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 4, 0, 0, 0], ret3, SIMD.Uint8x16, "Func3")
+equalSimd([1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0, 7, 0, 8, 0], ret4, SIMD.Uint8x16, "Func4")
+equalSimd([170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170, 170], ret5, SIMD.Uint8x16, "Func5")
+equalSimd([170, 0, 170, 0, 170, 0, 170, 0, 170, 0, 170, 0, 170, 0, 170, 0], ret6, SIMD.Uint8x16, "Func6")
 
 print("PASS");

--- a/test/SIMD.uint8x16.asmjs/testFail.baseline
+++ b/test/SIMD.uint8x16.asmjs/testFail.baseline
@@ -1,0 +1,6 @@
+
+testFail.js(10, 5)
+	Asm.js Compilation Error function : module0::foo
+	Expression for return must be subtype of Signed, Double, or Float
+
+Asm.js compilation failed.

--- a/test/SIMD.uint8x16.asmjs/testFail.js
+++ b/test/SIMD.uint8x16.asmjs/testFail.js
@@ -1,0 +1,16 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function module0(stdlib) {
+    "use asm"
+    var u16 = stdlib.SIMD.Uint8x16;
+    var u16check = u16.check;
+    function foo() {
+        var abc = u16(1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1);
+        return u16check(abc);
+    }
+    return { foo:foo }
+}
+var c = module0(this);

--- a/test/SIMD.uint8x16.asmjs/testFail_1.baseline
+++ b/test/SIMD.uint8x16.asmjs/testFail_1.baseline
@@ -1,0 +1,2 @@
+Invalid SIMD argument type. Expecting Signed arguments.
+Asm.js compilation failed.

--- a/test/SIMD.uint8x16.asmjs/testFail_1.js
+++ b/test/SIMD.uint8x16.asmjs/testFail_1.js
@@ -1,0 +1,17 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function module0(stdlib) {
+    "use asm"
+    var u16 = stdlib.SIMD.Uint8x16;
+    var u16check = u16.check;
+
+    function foo(abc) {
+        abc = u16check(abc);
+        return ;
+    }
+    return { foo:foo }
+}
+var c = module0(this);

--- a/test/SIMD.uint8x16.asmjs/testLoadStore.js
+++ b/test/SIMD.uint8x16.asmjs/testLoadStore.js
@@ -23,6 +23,10 @@ function asmModule(stdlib, imports, buffer) {
     var Int32Heap = new stdlib.Int32Array(buffer);
     var Uint32Heap = new stdlib.Uint32Array(buffer);
     var Float32Heap = new stdlib.Float32Array(buffer);
+    
+    var i16 = stdlib.SIMD.Int8x16;
+    var i16check = i16.check;
+    var i16fu16 = i16.fromUint8x16Bits;    
 
     function func0()
     {
@@ -46,7 +50,7 @@ function asmModule(stdlib, imports, buffer) {
             t0 = ui16add(t0, y);
             index = (index + 16 ) | 0;
         }
-        return ui16check(t0);
+        return i16check(i16fu16(t0));
     }
 
     function func1()
@@ -70,7 +74,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui16add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui16check(y);
+        return i16check(i16fu16(y));
     }
 
     function func1OOB_1()
@@ -97,7 +101,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui16add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui16check(y);
+        return i16check(i16fu16(y));
     }
     
     function func1OOB_2()
@@ -124,7 +128,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui16add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui16check(y);
+        return i16check(i16fu16(y));
     }
 
     function func2()
@@ -148,7 +152,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui16add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui16check(y);
+        return i16check(i16fu16(y));
     }
 
     function func2OOB_1()
@@ -175,7 +179,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui16add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui16check(y);
+        return i16check(i16fu16(y));
     }
 
     function func2OOB_2()
@@ -225,7 +229,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui16add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui16check(y);
+        return i16check(i16fu16(y));
     }
 
     function func3OOB_1()
@@ -252,7 +256,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui16add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui16check(y);
+        return i16check(i16fu16(y));
     }
 
     function func3OOB_2()
@@ -279,7 +283,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui16add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui16check(y);
+        return i16check(i16fu16(y));
     }
 
     function func4()
@@ -303,7 +307,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui16add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui16check(y);
+        return i16check(i16fu16(y));
     }
 
     function func4OOB_1()
@@ -330,7 +334,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui16add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui16check(y);
+        return i16check(i16fu16(y));
     }
 
     function func4OOB_2()
@@ -357,7 +361,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui16add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui16check(y);
+        return i16check(i16fu16(y));
     }
 
     function func5()
@@ -381,7 +385,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui16add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui16check(y);
+        return i16check(i16fu16(y));
     }
 
     function func5OOB_1()
@@ -407,7 +411,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui16add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui16check(y);
+        return i16check(i16fu16(y));
     }
 
     function func5OOB_2()
@@ -434,7 +438,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui16add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui16check(y);
+        return i16check(i16fu16(y));
     }
 
     function func6()
@@ -458,7 +462,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui16add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui16check(y);
+        return i16check(i16fu16(y));
     }
 
     function func6OOB_1()
@@ -485,7 +489,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui16add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui16check(y);
+        return i16check(i16fu16(y));
     }
 
     function func6OOB_2()
@@ -512,7 +516,7 @@ function asmModule(stdlib, imports, buffer) {
             y = ui16add(y, t);
             index = (index + 16 ) | 0;
         }
-        return ui16check(y);
+        return i16check(i16fu16(y));
     }
 
     // TODO: Test conversion of returned value
@@ -564,36 +568,36 @@ var m = asmModule(this, {g1:SIMD.Uint8x16(13216, 1024, 28, 108, 55, 3323, 992, 2
 
 var ret;
 
-ret = m.func0();
+ret = SIMD.Uint8x16.fromInt8x16Bits(m.func0());
 equalSimd([4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60, 64], ret, SIMD.Uint8x16, "Test Load Store");
 
 
-ret = m.func1();
+ret = SIMD.Uint8x16.fromInt8x16Bits(m.func1());
 //print("func1");
 equalSimd([10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160], ret, SIMD.Uint8x16, "Test Load Store");
 
 
-ret = m.func2();
+ret = SIMD.Uint8x16.fromInt8x16Bits(m.func2());
 //print("func3");
 equalSimd([10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160], ret, SIMD.Uint8x16, "Test Load Store");
 
 
-ret = m.func3();
+ret = SIMD.Uint8x16.fromInt8x16Bits(m.func3());
 //print("func3");
 equalSimd([10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160], ret, SIMD.Uint8x16, "Test Load Store");
 
 
-ret = m.func4();
+ret = SIMD.Uint8x16.fromInt8x16Bits(m.func4());
 //print("func4");
 equalSimd([10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160], ret, SIMD.Uint8x16, "Test Load Store");
 
 
-ret = m.func5();
+ret = SIMD.Uint8x16.fromInt8x16Bits(m.func5());
 //print("func5");
 equalSimd([10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160], ret, SIMD.Uint8x16, "Test Load Store");
 
 
-ret = m.func6();
+ret = SIMD.Uint8x16.fromInt8x16Bits(m.func6());
 //print("func6");
 equalSimd([10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160], ret, SIMD.Uint8x16, "Test Load Store");
 //
@@ -612,7 +616,7 @@ for (var i = 0; i < funcOOB1.length; i ++)
 {
     try
     {
-        ret = funcOOB1[i]();
+        ret = SIMD.Uint8x16.fromInt8x16Bits(funcOOB1[i]());
         //print("func" + (i+1) + "OOB_1");
         equalSimd(RESULTS[i], ret, SIMD.Uint8x16, "Test Load Store");
 
@@ -630,7 +634,7 @@ for (var i = 0; i < funcOOB2.length; i ++)
     //print("func" + (i+1) + "OOB_2");
     try
     {
-        ret = funcOOB2[i]();
+        ret = SIMD.Uint8x16.fromInt8x16Bits(funcOOB2[i]());
         print("Wrong");
         
     } catch(e)

--- a/test/SIMD.uint8x16.asmjs/testMinMax.js
+++ b/test/SIMD.uint8x16.asmjs/testMinMax.js
@@ -17,6 +17,10 @@ function asmModule(stdlib, imports) {
     var ui16g2 = ui16(256, 255, 128, 127, 0, 0, 1000, 1000, 5, 15, 3, 399, 299, 21, 45, 22);
 
     var loopCOUNT = 3;
+    
+    var i16 = stdlib.SIMD.Int8x16;
+    var i16check = i16.check;
+    var i16fu16 = i16.fromUint8x16Bits;
 
     function testMinLocal()
     {
@@ -30,7 +34,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui16check(result);
+        return i16check(i16fu16(result));
     }
     
     function testMaxLocal()
@@ -45,7 +49,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui16check(result);
+        return i16check(i16fu16(result));
     }
 
     function testMinGlobal()
@@ -58,7 +62,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui16check(result);
+        return i16check(i16fu16(result));
     }
 
     function testMaxGlobal()
@@ -71,7 +75,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui16check(result);
+        return i16check(i16fu16(result));
     }
 
     function testMinGlobalImport()
@@ -85,7 +89,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui16check(result);
+        return i16check(i16fu16(result));
     }
 
     function testMaxGlobalImport()
@@ -99,7 +103,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui16check(result);
+        return i16check(i16fu16(result));
     }
     
     return { testMinLocal: testMinLocal, testMaxLocal: testMaxLocal, testMinGlobal: testMinGlobal, testMaxGlobal: testMaxGlobal, testMinGlobalImport: testMinGlobalImport, testMaxGlobalImport: testMaxGlobalImport };
@@ -107,10 +111,17 @@ function asmModule(stdlib, imports) {
 
 var m = asmModule(this, { g1: SIMD.Uint8x16(100, 1073741824, 1028, 102, 124, 55, -929, 100, 52, 127, 127, -129, 129, 0, 88, 100234) });
 
-equalSimd([1, 2, 0, 0, 0, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1], m.testMinLocal(), SIMD.Uint8x16, "testMinLocal");
-equalSimd([127, 128, 3, 4, 5, 127, 10, 9, 9, 10, 11, 12, 13, 14, 15, 16], m.testMaxLocal(), SIMD.Uint8x16, "testMaxLocal");
-equalSimd([0, 255, 7, 120, 0, 0, 7, 8, 5, 10, 3, 12, 13, 14, 15, 16], m.testMinGlobal(), SIMD.Uint8x16, "testMinGlobal");
-equalSimd([0, 255, 128, 127, 5, 6, 232, 232, 9, 15, 11, 143, 43, 21, 45, 22], m.testMaxGlobal(), SIMD.Uint8x16, "testMaxGlobal");
-equalSimd([1, 0, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 0, 15, 16], m.testMinGlobalImport(), SIMD.Uint8x16, "testMinGlobalImport");
-equalSimd([100, 2, 4, 102, 124, 55, 95, 100, 52, 127, 127, 127, 129, 14, 88, 138], m.testMaxGlobalImport(), SIMD.Uint8x16, "testMaxGlobalImport");
+var ret1 = SIMD.Uint8x16.fromInt8x16Bits(m.testMinLocal());
+var ret2 = SIMD.Uint8x16.fromInt8x16Bits(m.testMaxLocal());
+var ret3 = SIMD.Uint8x16.fromInt8x16Bits(m.testMinGlobal());
+var ret4 = SIMD.Uint8x16.fromInt8x16Bits(m.testMaxGlobal());
+var ret5 = SIMD.Uint8x16.fromInt8x16Bits(m.testMinGlobalImport());
+var ret6 = SIMD.Uint8x16.fromInt8x16Bits(m.testMaxGlobalImport());
+
+equalSimd([1, 2, 0, 0, 0, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1], ret1, SIMD.Uint8x16, "testMinLocal");
+equalSimd([127, 128, 3, 4, 5, 127, 10, 9, 9, 10, 11, 12, 13, 14, 15, 16], ret2, SIMD.Uint8x16, "testMaxLocal");
+equalSimd([0, 255, 7, 120, 0, 0, 7, 8, 5, 10, 3, 12, 13, 14, 15, 16], ret3, SIMD.Uint8x16, "testMinGlobal");
+equalSimd([0, 255, 128, 127, 5, 6, 232, 232, 9, 15, 11, 143, 43, 21, 45, 22], ret4, SIMD.Uint8x16, "testMaxGlobal");
+equalSimd([1, 0, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 0, 15, 16], ret5, SIMD.Uint8x16, "testMinGlobalImport");
+equalSimd([100, 2, 4, 102, 124, 55, 95, 100, 52, 127, 127, 127, 129, 14, 88, 138], ret6, SIMD.Uint8x16, "testMaxGlobalImport");
 print("PASS");

--- a/test/SIMD.uint8x16.asmjs/testMisc.js
+++ b/test/SIMD.uint8x16.asmjs/testMisc.js
@@ -145,6 +145,11 @@ var i4 = stdlib.SIMD.Int32x4;
     var Float32Heap = new stdlib.Float32Array(buffer);
     
     var loopCOUNT = 3;
+    
+    var i16 = stdlib.SIMD.Int8x16;
+    var i16check = i16.check;
+    var i16fu16 = i16.fromUint8x16Bits;
+    var u16fi16 = u16.fromInt8x16Bits;
 
     function func1()
     {
@@ -199,7 +204,7 @@ var i4 = stdlib.SIMD.Int32x4;
     
     function func2(a)
     {
-        a = u16check(a);
+        a = i16check(a);
         var x = u16(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
         var loopIndex = 0;
         var loopCOUNT = 3;
@@ -207,16 +212,16 @@ var i4 = stdlib.SIMD.Int32x4;
         while ( (loopIndex|0) < (loopCOUNT|0)) {
 
             x = u16swizzle(x, 1, 2, 3, 4, 0, 7, 7, 7, 11, 13, 12, 14, 10, 15, 15, 15);
-            x = u16shuffle(a, x, 0, 1, 10, 11, 2, 3, 12, 13, 20, 21, 31, 3, 22, 0, 18, 31);
+            x = u16shuffle(u16fi16(a), x, 0, 1, 10, 11, 2, 3, 12, 13, 20, 21, 31, 3, 22, 0, 18, 31);
             loopIndex = (loopIndex + 1) | 0;
         }
         
-        return u16check(x);
+        return i16check(i16fu16(x));
     }
     
     function func3(a)
     {
-        a = u16check(a);
+        a = i16check(a);
         var x = u16(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
         var y = u16(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
         var loopIndex = 0;
@@ -232,17 +237,17 @@ var i4 = stdlib.SIMD.Int32x4;
             loopIndex = (loopIndex + 1) | 0;
         }
         
-        return u16check(y);
+        return i16check(i16fu16(y));
     }
     
     
     function func4(a, b, c, d, e)
     {
-        a = u16check(a);
-        b = u16check(b);
-        c = u16check(c);
-        d = u16check(d);
-        e = u16check(e);
+        a = i16check(a);
+        b = i16check(b);
+        c = i16check(c);
+        d = i16check(d);
+        e = i16check(e);
         var x = u16(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
         var y = u16(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
         var loopIndex = 0;
@@ -250,24 +255,24 @@ var i4 = stdlib.SIMD.Int32x4;
         
         
         while ( (loopIndex|0) < (loopCOUNT|0)) {
-            x = u16and(a, b);
-            x = u16or(x, d);
-            x = u16xor(x, e);
+            x = u16and(u16fi16(a), u16fi16(b));
+            x = u16or(x, u16fi16(d));
+            x = u16xor(x, u16fi16(e));
             x = u16not(x);
             
             loopIndex = (loopIndex + 1) | 0;
         }
         
-        return u16check(x);
+        return i16check(i16fu16(x));
     }
     
     function func5(a, b, c, d, e)
     {
-        a = u16check(a);
-        b = u16check(b);
-        c = u16check(c);
-        d = u16check(d);
-        e = u16check(e);
+        a = i16check(a);
+        b = i16check(b);
+        c = i16check(c);
+        d = i16check(d);
+        e = i16check(e);
         var x = u16(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
         var y = u16(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
         var loopIndex = 0;
@@ -275,23 +280,23 @@ var i4 = stdlib.SIMD.Int32x4;
         
         
         while ( (loopIndex|0) < (loopCOUNT|0)) {
-            x = u16add(a, b);
-            x = u16sub(x, d);
-            x = u16mul(x, e);
+            x = u16add(u16fi16(a), u16fi16(b));
+            x = u16sub(x, u16fi16(d));
+            x = u16mul(x, u16fi16(e));
             
             loopIndex = (loopIndex + 1) | 0;
         }
         
-        return u16check(x);
+        return i16check(i16fu16(x));
     }
     
     function func6(a, b, c, d, e)
     {
-        a = u16check(a);
-        b = u16check(b);
-        c = u16check(c);
-        d = u16check(d);
-        e = u16check(e);
+        a = i16check(a);
+        b = i16check(b);
+        c = i16check(c);
+        d = i16check(d);
+        e = i16check(e);
         var x = u16(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
         var y = u16(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
         var loopIndex = 0;
@@ -299,8 +304,8 @@ var i4 = stdlib.SIMD.Int32x4;
         
         
         while ( (loopIndex|0) < (loopCOUNT|0)) {
-            x = u16min(x, b);
-            y = u16max(y, d);
+            x = u16min(x, u16fi16(b));
+            y = u16max(y, u16fi16(d));
             x = u16shiftLeftByScalar(x, loopIndex>>>0);
             y = u16shiftRightByScalar(y, loopIndex>>>0);
             
@@ -308,7 +313,7 @@ var i4 = stdlib.SIMD.Int32x4;
         }
         x = u16addSaturate(x, x);
         x = u16subSaturate(x, y);
-        return u16check(x);
+        return i16check(i16fu16(x));
     }
     
     
@@ -336,7 +341,7 @@ var i4 = stdlib.SIMD.Int32x4;
             y = u16add(y, t);
             index = (index + 16 ) | 0;
         }
-        return u16check(y);
+        return i16check(i16fu16(y));
     }
     
     function func8()
@@ -364,7 +369,7 @@ var i4 = stdlib.SIMD.Int32x4;
             x = u16add(x, u16fromUint16x8Bits(v_u8));
         }
 
-        return u16check(x);
+        return i16check(i16fu16(x));
     }
 
     function bug1() //simd tmp reg reuse.
@@ -383,38 +388,39 @@ var buffer = new ArrayBuffer(0x10000);
 var m = asmModule(this, {g1:SIMD.Float32x4(90934.2,123.9,419.39,449.0), g2:SIMD.Int32x4(-1065353216, -1073741824,-1077936128, -1082130432)}, buffer);
 
 
+var i16fu16 = SIMD.Int8x16.fromUint8x16Bits;
 
 var v1 = SIMD.Uint8x16(1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
 var v2 = SIMD.Uint8x16(134, 211, -333, 422, -165, 999996, 0xffff, 0xf0f0, 134, 211, -333, 422, -165, 999996, 0xffff, 0xf0f0);
 var v3 = SIMD.Uint8x16(0xcccc, -211, 189, 422, -165, -999996, 0xffff, 0xf0f0, 0xcccc, -211, 189, 422, -165, -999996, 0xffff, 0xf0f0);
 var ret1 = m.func1();
 //print (ret1);
-var ret2 = m.func2(v1);
+var ret2 = SIMD.Uint8x16.fromInt8x16Bits(m.func2(i16fu16(v1)));
 //printSimdBaseline(ret2, "SIMD.Uint8x16", "ret2", "func2");
 
 
-var ret3 = m.func3(v1);
+var ret3 = SIMD.Uint8x16.fromInt8x16Bits(m.func3(i16fu16(v1)));
 //printSimdBaseline(ret3, "SIMD.Uint8x16", "ret3", "func3");
 
 
-var ret4 = m.func4(v1, v2, v3, v1, v2);
+var ret4 = SIMD.Uint8x16.fromInt8x16Bits(m.func4(i16fu16(v1), i16fu16(v2), i16fu16(v3), i16fu16(v1), i16fu16(v2)));
 //printSimdBaseline(ret4, "SIMD.Uint8x16", "ret4", "func4");
 
 
-var ret5 = m.func5(v1, v2, v3, v1, v2);
+var ret5 = SIMD.Uint8x16.fromInt8x16Bits(m.func5(i16fu16(v1), i16fu16(v2), i16fu16(v3), i16fu16(v1), i16fu16(v2)));
 //printSimdBaseline(ret5, "SIMD.Uint8x16", "ret5", "func5");
 
 
 
-var ret6 = m.func6(v1, v2, v3, v1, v2);
+var ret6 = SIMD.Uint8x16.fromInt8x16Bits(m.func6(i16fu16(v1), i16fu16(v2), i16fu16(v3), i16fu16(v1), i16fu16(v2)));
 //printSimdBaseline(ret6, "SIMD.Uint8x16", "ret6", "func6");
 
 
-var ret7 = m.func7(v1, v2, v3, v1, v2);
+var ret7 = SIMD.Uint8x16.fromInt8x16Bits(m.func7(i16fu16(v1), i16fu16(v2), i16fu16(v3), i16fu16(v1), i16fu16(v2)));
 //printSimdBaseline(ret7, "SIMD.Uint8x16", "ret7", "func7");
 
 
-var ret8 = m.func8(v1, v2, v3, v1, v2);
+var ret8 = SIMD.Uint8x16.fromInt8x16Bits(m.func8(i16fu16(v1), i16fu16(v2), i16fu16(v3), i16fu16(v1), i16fu16(v2)));
 //printSimdBaseline(ret8, "SIMD.Uint8x16", "ret8", "func8");
 
 var ret9 = m.bug1();

--- a/test/SIMD.uint8x16.asmjs/testMul.js
+++ b/test/SIMD.uint8x16.asmjs/testMul.js
@@ -17,6 +17,10 @@ function asmModule(stdlib, imports) {
 
     var loopCOUNT = 3;
 
+    var i16 = stdlib.SIMD.Int8x16;
+    var i16check = i16.check;
+    var i16fu16 = i16.fromUint8x16Bits;
+
     function testMulLocal()
     {
         var a = ui16(5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80);
@@ -29,7 +33,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui16check(result);
+        return i16check(i16fu16(result));
     }
     function testMulGlobal()
     {    
@@ -41,7 +45,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui16check(result);
+        return i16check(i16fu16(result));
     }
 
     function testMulGlobalImport()
@@ -55,7 +59,7 @@ function asmModule(stdlib, imports) {
             loopIndex = (loopIndex + 1) | 0;
         }
 
-        return ui16check(result);
+        return i16check(i16fu16(result));
     }
     
     return {testMulLocal:testMulLocal, testMulGlobal:testMulGlobal, testMulGlobalImport:testMulGlobalImport};
@@ -63,7 +67,11 @@ function asmModule(stdlib, imports) {
 
 var m = asmModule(this, { g1: SIMD.Uint8x16(5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80) });
 
-equalSimd([10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160], m.testMulLocal(), SIMD.Uint8x16, "Test Neg");
-equalSimd([10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160], m.testMulGlobal(), SIMD.Uint8x16, "Test Neg");
-equalSimd([10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160], m.testMulGlobalImport(), SIMD.Uint8x16, "Test Neg");
+var ret1 = SIMD.Uint8x16.fromInt8x16Bits(m.testMulLocal());
+var ret2 = SIMD.Uint8x16.fromInt8x16Bits(m.testMulGlobal());
+var ret3 = SIMD.Uint8x16.fromInt8x16Bits(m.testMulGlobalImport());
+
+equalSimd([10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160], ret1, SIMD.Uint8x16, "Test Neg");
+equalSimd([10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160], ret2, SIMD.Uint8x16, "Test Neg");
+equalSimd([10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160], ret3, SIMD.Uint8x16, "Test Neg");
 print("PASS");

--- a/test/SIMD.uint8x16.asmjs/testShift.js
+++ b/test/SIMD.uint8x16.asmjs/testShift.js
@@ -17,6 +17,10 @@ function asmModule(stdlib, imports) {
     var ui16g2 = ui16(256, 255, 128, 127, 0, 0, 1000, 1000, 5, 15, 3, 399, 299, 21, 45, 22);
 
     var loopCOUNT = 4;
+    
+    var i16 = stdlib.SIMD.Int8x16;
+    var i16check = i16.check;
+    var i16fu16 = i16.fromUint8x16Bits;
 
     function testShiftLeftScalarLocal()
     {
@@ -28,7 +32,7 @@ function asmModule(stdlib, imports) {
             a = ui16shiftLeftByScalar(a, 1);
         }
 
-        return ui16check(a);
+        return i16check(i16fu16(a));
     }
     
     function testShiftRightScalarLocal()
@@ -40,7 +44,7 @@ function asmModule(stdlib, imports) {
             a = ui16shiftRightByScalar(a, 1);
         }
 
-        return ui16check(a);
+        return i16check(i16fu16(a));
     }
 
     function testShiftLeftScalarGlobal()
@@ -50,7 +54,7 @@ function asmModule(stdlib, imports) {
         for (loopIndex = 0; (loopIndex | 0) < (loopCOUNT | 0) ; loopIndex = (loopIndex + 1) | 0) {
             ui16g1 = ui16shiftLeftByScalar(ui16g1, 1);
         }
-        return ui16check(ui16g1);
+        return i16check(i16fu16(ui16g1));
     }
 
     function testShiftRightScalarGlobal()
@@ -60,7 +64,7 @@ function asmModule(stdlib, imports) {
         for (loopIndex = 0; (loopIndex | 0) < (loopCOUNT | 0) ; loopIndex = (loopIndex + 1) | 0) {
             ui16g1 = ui16shiftRightByScalar(ui16g1, 1);
         }
-        return ui16check(ui16g1);
+        return i16check(i16fu16(ui16g1));
     }
 
     function testShiftLeftScalarGlobalImport()
@@ -70,7 +74,7 @@ function asmModule(stdlib, imports) {
         for (loopIndex = 0; (loopIndex | 0) < (loopCOUNT | 0) ; loopIndex = (loopIndex + 1) | 0) {
             globImportui16 = ui16shiftLeftByScalar(globImportui16, 1);
         }
-        return ui16check(globImportui16);
+        return i16check(i16fu16(globImportui16));
     }
 
     function testShiftRightScalarGlobalImport()
@@ -80,7 +84,7 @@ function asmModule(stdlib, imports) {
         for (loopIndex = 0; (loopIndex | 0) < (loopCOUNT | 0) ; loopIndex = (loopIndex + 1) | 0) {
             globImportui16 = ui16shiftRightByScalar(globImportui16, 1);
         }
-        return ui16check(globImportui16);
+        return i16check(i16fu16(globImportui16));
     }
 
     function testShiftLeftScalarLocal1()
@@ -93,7 +97,7 @@ function asmModule(stdlib, imports) {
             a = ui16shiftLeftByScalar(a, 1);
         }
 
-        return ui16check(a);
+        return i16check(i16fu16(a));
     }
     
     function testShiftRightScalarLocal1()
@@ -106,7 +110,7 @@ function asmModule(stdlib, imports) {
             a = ui16shiftRightByScalar(a, 9);
         }
 
-        return ui16check(a);
+        return i16check(i16fu16(a));
     }
 
     function testShiftLeftScalarGlobal1()
@@ -117,7 +121,7 @@ function asmModule(stdlib, imports) {
             ui16g1 = ui16shiftLeftByScalar(ui16g1, 8);
             ui16g1 = ui16shiftLeftByScalar(ui16g1, 9);
         }
-        return ui16check(ui16g1);
+        return i16check(i16fu16(ui16g1));
     }
 
     function testShiftRightScalarGlobal1()
@@ -128,7 +132,7 @@ function asmModule(stdlib, imports) {
             ui16g1 = ui16shiftRightByScalar(ui16g1, 8);
             ui16g1 = ui16shiftRightByScalar(ui16g1, 9);
         }
-        return ui16check(ui16g1);
+        return i16check(i16fu16(ui16g1));
     }
 
     function testShiftLeftScalarGlobalImport1()
@@ -139,7 +143,7 @@ function asmModule(stdlib, imports) {
             globImportui16 = ui16shiftLeftByScalar(globImportui16, 8);
             globImportui16 = ui16shiftLeftByScalar(globImportui16, 9);
         }
-        return ui16check(globImportui16);
+        return i16check(i16fu16(globImportui16));
     }
 
     function testShiftRightScalarGlobalImport1()
@@ -150,7 +154,7 @@ function asmModule(stdlib, imports) {
             globImportui16 = ui16shiftRightByScalar(globImportui16, 8);
             globImportui16 = ui16shiftRightByScalar(globImportui16, 9);
         }
-        return ui16check(globImportui16);
+        return i16check(i16fu16(globImportui16));
     }
 
     return {
@@ -163,18 +167,33 @@ function asmModule(stdlib, imports) {
 
 var m = asmModule(this, { g1: SIMD.Uint8x16(100, 10824, 1028, 82, 3883, 8, 2929, 1442, 52, 127, 128, 129, 129, 0, 88, 100234) });
 
-equalSimd([128, 128, 0, 0, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 0], m.testShiftLeftScalarLocal(), SIMD.Uint8x16, "func1");
-equalSimd([2, 2, 5, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1], m.testShiftRightScalarLocal(), SIMD.Uint8x16, "func2");
-equalSimd([16, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 0], m.testShiftLeftScalarGlobal(), SIMD.Uint8x16, "func3");
-equalSimd([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0], m.testShiftRightScalarGlobal(), SIMD.Uint8x16, "func4");
-equalSimd([64, 128, 64, 32, 176, 128, 16, 32, 64, 240, 0, 16, 16, 0, 128, 160], m.testShiftLeftScalarGlobalImport(), SIMD.Uint8x16, "func5");
-equalSimd([4, 8, 4, 2, 11, 8, 1, 2, 4, 15, 0, 1, 1, 0, 8, 10], m.testShiftRightScalarGlobalImport(), SIMD.Uint8x16, "func6");
+var ret1 = SIMD.Uint8x16.fromInt8x16Bits(m.testShiftLeftScalarLocal());
+var ret2 = SIMD.Uint8x16.fromInt8x16Bits(m.testShiftRightScalarLocal());
+var ret3 = SIMD.Uint8x16.fromInt8x16Bits(m.testShiftLeftScalarGlobal());
+var ret4 = SIMD.Uint8x16.fromInt8x16Bits(m.testShiftRightScalarGlobal());
+var ret5 = SIMD.Uint8x16.fromInt8x16Bits(m.testShiftLeftScalarGlobalImport());
+var ret6 = SIMD.Uint8x16.fromInt8x16Bits(m.testShiftRightScalarGlobalImport());
+
+var ret7 = SIMD.Uint8x16.fromInt8x16Bits(m.testShiftLeftScalarLocal1());
+var ret8 = SIMD.Uint8x16.fromInt8x16Bits(m.testShiftRightScalarLocal1());
+var ret9 = SIMD.Uint8x16.fromInt8x16Bits(m.testShiftLeftScalarGlobal1());
+var ret10 = SIMD.Uint8x16.fromInt8x16Bits(m.testShiftRightScalarGlobal1());
+var ret11 = SIMD.Uint8x16.fromInt8x16Bits(m.testShiftLeftScalarGlobalImport1());
+var ret12 = SIMD.Uint8x16.fromInt8x16Bits(m.testShiftRightScalarGlobalImport1());
 
 
-equalSimd([128, 128, 0, 0, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 0], m.testShiftLeftScalarLocal1(), SIMD.Uint8x16, "func1_1");
-equalSimd([2, 2, 5, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1], m.testShiftRightScalarLocal1(), SIMD.Uint8x16, "func2_1");
-equalSimd([16, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 0], m.testShiftLeftScalarGlobal1(), SIMD.Uint8x16, "func3_1");
-equalSimd([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0], m.testShiftRightScalarGlobal1(), SIMD.Uint8x16, "func4_1");
-equalSimd([64, 128, 64, 32, 176, 128, 16, 32, 64, 240, 0, 16, 16, 0, 128, 160], m.testShiftLeftScalarGlobalImport1(), SIMD.Uint8x16, "func5_1");
-equalSimd([4, 8, 4, 2, 11, 8, 1, 2, 4, 15, 0, 1, 1, 0, 8, 10], m.testShiftRightScalarGlobalImport1(), SIMD.Uint8x16, "func6_1");
+equalSimd([128, 128, 0, 0, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 0], ret1, SIMD.Uint8x16, "func1");
+equalSimd([2, 2, 5, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1], ret2, SIMD.Uint8x16, "func2");
+equalSimd([16, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 0], ret3, SIMD.Uint8x16, "func3");
+equalSimd([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0], ret4, SIMD.Uint8x16, "func4");
+equalSimd([64, 128, 64, 32, 176, 128, 16, 32, 64, 240, 0, 16, 16, 0, 128, 160], ret5, SIMD.Uint8x16, "func5");
+equalSimd([4, 8, 4, 2, 11, 8, 1, 2, 4, 15, 0, 1, 1, 0, 8, 10], ret6, SIMD.Uint8x16, "func6");
+
+
+equalSimd([128, 128, 0, 0, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 0], ret7, SIMD.Uint8x16, "func1_1");
+equalSimd([2, 2, 5, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1], ret8, SIMD.Uint8x16, "func2_1");
+equalSimd([16, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 0], ret9, SIMD.Uint8x16, "func3_1");
+equalSimd([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0], ret10, SIMD.Uint8x16, "func4_1");
+equalSimd([64, 128, 64, 32, 176, 128, 16, 32, 64, 240, 0, 16, 16, 0, 128, 160], ret11, SIMD.Uint8x16, "func5_1");
+equalSimd([4, 8, 4, 2, 11, 8, 1, 2, 4, 15, 0, 1, 1, 0, 8, 10], ret12, SIMD.Uint8x16, "func6_1");
 print("PASS");

--- a/test/SIMD.uint8x16.asmjs/testShuffle.js
+++ b/test/SIMD.uint8x16.asmjs/testShuffle.js
@@ -16,6 +16,10 @@ function asmModule(stdlib, imports) {
     var ui16g2 = ui16(256, 255, 128, 127, 0, 0, 1000, 1000, 5, 15, 3, 399, 299, 21, 45, 22);
    
     var loopCOUNT = 3;
+        
+    var i16 = stdlib.SIMD.Int8x16;
+    var i16check = i16.check;
+    var i16fu16 = i16.fromUint8x16Bits;
 
     function testShuffleGlobal() {
         var result = ui16(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
@@ -25,7 +29,7 @@ function asmModule(stdlib, imports) {
             result = ui16shuffle(ui16g1, ui16g2, 0, 1, 4, 5, 8, 10, 11, 12, 4, 2, 1, 6, 2, 8, 14, 0);
             loopIndex = (loopIndex + 1) | 0;
         }
-        return ui16check(result);
+        return i16check(i16fu16(result));
     }
     
     function testShuffleLocal() {
@@ -38,7 +42,7 @@ function asmModule(stdlib, imports) {
             result = ui16shuffle(a, b, 0, 1, 4, 5, 8, 10, 11, 12, 4, 2, 1, 6, 2, 8, 14, 0);
             loopIndex = (loopIndex + 1) | 0;
         }
-        return ui16check(result);
+        return i16check(i16fu16(result));
     }
     
     function testShuffleFunc() {
@@ -50,7 +54,7 @@ function asmModule(stdlib, imports) {
             result = ui16shuffle(ui16add(a,ui16g1), ui16mul(a,ui16g1), 0, 1, 4, 5, 8, 10, 11, 12, 4, 2, 1, 6, 2, 8, 14, 0);
             loopIndex = (loopIndex + 1) | 0;
         }
-        return ui16check(result);
+        return i16check(i16fu16(result));
     }
 
     return { testShuffleGlobal:testShuffleGlobal , testShuffleLocal:testShuffleLocal, testShuffleFunc:testShuffleFunc };
@@ -58,9 +62,13 @@ function asmModule(stdlib, imports) {
 
 var m = asmModule(this, { g1: SIMD.Uint8x16(100, -1073741824, -1028, -102, 3883, -38, -92929, 1442, 52, 127, -127, -129, 129, 0, 88, 100234)});
 
-equalSimd([1, 2, 5, 6, 9, 11, 12, 13, 5, 3, 2, 7, 3, 9, 15, 1], m.testShuffleGlobal(), SIMD.Uint8x16, "");
-equalSimd([1, 2, 5, 6, 9, 11, 12, 13, 5, 3, 2, 7, 3, 9, 15, 1], m.testShuffleLocal(), SIMD.Uint8x16, "");
-equalSimd([2, 4, 10, 12, 18, 22, 24, 26, 10, 6, 4, 14, 6, 18, 30, 2], m.testShuffleFunc(), SIMD.Uint8x16, "");
+var ret1 = SIMD.Uint8x16.fromInt8x16Bits(m.testShuffleGlobal());
+var ret2 = SIMD.Uint8x16.fromInt8x16Bits(m.testShuffleLocal());
+var ret3 = SIMD.Uint8x16.fromInt8x16Bits(m.testShuffleFunc());
+
+equalSimd([1, 2, 5, 6, 9, 11, 12, 13, 5, 3, 2, 7, 3, 9, 15, 1], ret1, SIMD.Uint8x16, "");
+equalSimd([1, 2, 5, 6, 9, 11, 12, 13, 5, 3, 2, 7, 3, 9, 15, 1], ret2, SIMD.Uint8x16, "");
+equalSimd([2, 4, 10, 12, 18, 22, 24, 26, 10, 6, 4, 14, 6, 18, 30, 2], ret3, SIMD.Uint8x16, "");
 
 print("PASS");
 

--- a/test/SIMD.uint8x16.asmjs/testSplat.js
+++ b/test/SIMD.uint8x16.asmjs/testSplat.js
@@ -17,6 +17,10 @@ function asmModule(stdlib, imports) {
     var gval = 20;
 
     var loopCOUNT = 3;
+    
+    var i16 = stdlib.SIMD.Int8x16;
+    var i16check = i16.check;
+    var i16fu16 = i16.fromUint8x16Bits;
 
     function splat1()
     {
@@ -27,7 +31,7 @@ function asmModule(stdlib, imports) {
             a = ui16splat(255);
             loopIndex = (loopIndex + 1) | 0;
         }
-        return ui16check(a);
+        return i16check(i16fu16(a));
     }
     
     function splat2()
@@ -39,7 +43,7 @@ function asmModule(stdlib, imports) {
             a = ui16splat(value() | 0);
             loopIndex = (loopIndex + 1) | 0;
         }
-        return ui16check(a);
+        return i16check(i16fu16(a));
     }
 
     function splat3()
@@ -51,7 +55,7 @@ function asmModule(stdlib, imports) {
             a = ui16splat(gval);
             loopIndex = (loopIndex + 1) | 0;
         }
-        return ui16check(a);
+        return i16check(i16fu16(a));
     }
     
     function value()
@@ -70,9 +74,9 @@ function asmModule(stdlib, imports) {
 
 var m = asmModule(this, {g1:SIMD.Uint8x16(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)});
 
-var ret1 = m.func1(SIMD.Uint8x16(1, 2, 3, 4, 5, 6, 7, 8), SIMD.Float32x4(1, 2, 3, 4), SIMD.Float64x2(1, 2, 3, 4));
-var ret2 = m.func2(SIMD.Uint8x16(1, 2, 3, 4, 5, 6, 7, 8), SIMD.Float32x4(1, 2, 3, 4), SIMD.Float64x2(1, 2, 3, 4));
-var ret3 = m.func3(SIMD.Uint8x16(1, 2, 3, 4, 5, 6, 7, 8), SIMD.Float32x4(1, 2, 3, 4), SIMD.Float64x2(1, 2, 3, 4));
+var ret1 = SIMD.Uint8x16.fromInt8x16Bits(m.func1(SIMD.Uint8x16(1, 2, 3, 4, 5, 6, 7, 8), SIMD.Float32x4(1, 2, 3, 4), SIMD.Float64x2(1, 2, 3, 4)));
+var ret2 = SIMD.Uint8x16.fromInt8x16Bits(m.func2(SIMD.Uint8x16(1, 2, 3, 4, 5, 6, 7, 8), SIMD.Float32x4(1, 2, 3, 4), SIMD.Float64x2(1, 2, 3, 4)));
+var ret3 = SIMD.Uint8x16.fromInt8x16Bits(m.func3(SIMD.Uint8x16(1, 2, 3, 4, 5, 6, 7, 8), SIMD.Float32x4(1, 2, 3, 4), SIMD.Float64x2(1, 2, 3, 4)));
 
 equalSimd([255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255], ret1, SIMD.Uint8x16, "");
 equalSimd([87, 87, 87, 87, 87, 87, 87, 87, 87, 87, 87, 87, 87, 87, 87, 87], ret2, SIMD.Uint8x16, "");

--- a/test/SIMD.uint8x16.asmjs/testSwizzle.js
+++ b/test/SIMD.uint8x16.asmjs/testSwizzle.js
@@ -18,6 +18,10 @@ function asmModule(stdlib, imports) {
     var ui16g2 = ui16(256, 255, 128, 127, 0, 0, 1000, 1000, 5, 15, 3, 399, 299, 21, 45, 22);
 
     var loopCOUNT = 3;
+    
+    var i16 = stdlib.SIMD.Int8x16;
+    var i16check = i16.check;
+    var i16fu16 = i16.fromUint8x16Bits;    
 
     function testswizzleLocal() {
         var a = ui16(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
@@ -28,7 +32,7 @@ function asmModule(stdlib, imports) {
             result = ui16swizzle(a, 0, 1, 4, 5, 8, 10, 11, 12, 4, 2, 1, 6, 2, 8, 14, 0);
             loopIndex = (loopIndex + 1) | 0;
         }
-        return ui16check(result);
+        return i16check(i16fu16(result));
     }
     
     function testswizzleGlobal() {
@@ -39,7 +43,7 @@ function asmModule(stdlib, imports) {
             result = ui16swizzle(ui16g1, 0, 1, 4, 5, 8, 10, 11, 12, 4, 2, 1, 6, 2, 8, 14, 0);
             loopIndex = (loopIndex + 1) | 0;
         }
-        return ui16check(result);
+        return i16check(i16fu16(result));
     }
 
     function testswizzleGlobalImport() {
@@ -50,7 +54,7 @@ function asmModule(stdlib, imports) {
             result = ui16swizzle(globImportui16, 0, 1, 4, 5, 8, 10, 11, 12, 4, 2, 1, 6, 2, 8, 14, 0);
             loopIndex = (loopIndex + 1) | 0;
         }
-        return ui16check(result);
+        return i16check(i16fu16(result));
     }
 
     function testswizzleFunc() {
@@ -62,7 +66,7 @@ function asmModule(stdlib, imports) {
             result = ui16swizzle(ui16add(a, ui16g1), 0, 1, 4, 5, 8, 10, 11, 12, 4, 2, 1, 6, 2, 8, 14, 0);
             loopIndex = (loopIndex + 1) | 0;
         }
-        return ui16check(result);
+        return i16check(i16fu16(result));
     }
 
     return { testswizzleLocal: testswizzleLocal, testswizzleGlobal: testswizzleGlobal, testswizzleGlobalImport: testswizzleGlobalImport, testswizzleFunc: testswizzleFunc };
@@ -70,10 +74,16 @@ function asmModule(stdlib, imports) {
 
 var m = asmModule(this, { g1: SIMD.Uint8x16(100, 10824, 1028, 82, 3883, 8, 2929, 1442, 52, 127, 128, 129, 129, 0, 88, 100234) });
 
-equalSimd([1, 2, 5, 6, 9, 11, 12, 13, 5, 3, 2, 7, 3, 9, 15, 1], m.testswizzleLocal(), SIMD.Uint8x16, "");
-equalSimd([1, 2, 5, 6, 9, 11, 12, 13, 5, 3, 2, 7, 3, 9, 15, 1], m.testswizzleGlobal(), SIMD.Uint8x16, "");
-equalSimd([100, 72, 43, 8, 52, 128, 129, 129, 43, 4, 72, 113, 4, 52, 88, 100], m.testswizzleGlobalImport(), SIMD.Uint8x16, "");
-equalSimd([2, 4, 10, 12, 18, 22, 24, 26, 10, 6, 4, 14, 6, 18, 30, 2], m.testswizzleFunc(), SIMD.Uint8x16, "");
+var ret1 = SIMD.Uint8x16.fromInt8x16Bits(m.testswizzleLocal());
+var ret2 = SIMD.Uint8x16.fromInt8x16Bits(m.testswizzleGlobal());
+var ret3 = SIMD.Uint8x16.fromInt8x16Bits(m.testswizzleGlobalImport());
+var ret4 = SIMD.Uint8x16.fromInt8x16Bits(m.testswizzleFunc());
+
+
+equalSimd([1, 2, 5, 6, 9, 11, 12, 13, 5, 3, 2, 7, 3, 9, 15, 1], ret1, SIMD.Uint8x16, "");
+equalSimd([1, 2, 5, 6, 9, 11, 12, 13, 5, 3, 2, 7, 3, 9, 15, 1], ret2, SIMD.Uint8x16, "");
+equalSimd([100, 72, 43, 8, 52, 128, 129, 129, 43, 4, 72, 113, 4, 52, 88, 100], ret3, SIMD.Uint8x16, "");
+equalSimd([2, 4, 10, 12, 18, 22, 24, 26, 10, 6, 4, 14, 6, 18, 30, 2], ret4, SIMD.Uint8x16, "");
 
 print("PASS");
 


### PR DESCRIPTION
Asm.js functions should only allow signed simd values as arguments and
return types.
https://github.com/tc39/ecmascript_simd/issues/307#issuecomment-196969926

Fixes #897 