### PR TITLE
param scope symbols should not go the propIdsForScopeSlotArray container.

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -1809,10 +1809,7 @@ void ByteCodeGenerator::InitScopeSlotArray(FuncInfo * funcInfo)
                 propertyIdsForScopeSlotArray[sym->GetScopeSlot()] = sym->EnsurePosition(funcInfo);
             }
         };
-        if (funcInfo->GetParamScope() != nullptr)
-        {
-            funcInfo->GetParamScope()->ForEachSymbol(setPropIdsForScopeSlotArray);
-        }
+
         funcInfo->GetBodyScope()->ForEachSymbol(setPropIdsForScopeSlotArray);
 
         if (funcInfo->thisScopeSlot != Js::Constants::NoRegister)


### PR DESCRIPTION
This metadata is not required for param-scope symbols.
