### PR TITLE
cross platform: fix conditional behavior for x64 target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL Linux)
     endif()
     set(CLR_CMAKE_PLATFORM_LINUX 1)
 elseif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
-    add_definitions(-D_TARGET_MAC64)
     add_definitions(-DPLATFORM_UNIX)
 
     set(CLR_CMAKE_PLATFORM_UNIX 1)
@@ -35,6 +34,7 @@ endif()
 
 if(CLR_CMAKE_PLATFORM_UNIX_TARGET_AMD64)
   set(CLR_CMAKE_PLATFORM_ARCH_AMD64 1)
+  add_definitions(-D_M_X64_OR_ARM64)
 endif()
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL AppleClang

--- a/pal/inc/rt/palrt.h
+++ b/pal/inc/rt/palrt.h
@@ -1571,14 +1571,14 @@ typedef OUT_OF_PROCESS_FUNCTION_TABLE_CALLBACK *POUT_OF_PROCESS_FUNCTION_TABLE_C
 
 #if defined(FEATURE_PAL_SXS)
 
-// #if !defined(_TARGET_MAC64)
+// #if !defined(__APPLE__)
 // typedef LONG (*PEXCEPTION_ROUTINE)(
     // IN PEXCEPTION_POINTERS pExceptionPointers,
     // IN LPVOID lpvParam);
 
 // #define DISPATCHER_CONTEXT    LPVOID
 
-// #else // defined(_TARGET_MAC64)
+// #else // defined(__APPLE__)
 
 //
 // Define unwind history table structure.
@@ -1663,7 +1663,7 @@ typedef struct _DISPATCHER_CONTEXT {
 
 #endif
 
-// #endif // !defined(_TARGET_MAC64)
+// #endif // !defined(__APPLE__)
 
 typedef DISPATCHER_CONTEXT *PDISPATCHER_CONTEXT;
 

--- a/pal/src/CMakeLists.txt
+++ b/pal/src/CMakeLists.txt
@@ -34,7 +34,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL Linux)
 endif(CMAKE_SYSTEM_NAME STREQUAL Linux)
 
 if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
-  add_definitions(-D_TARGET_MAC64)
   set(PLATFORM_SOURCES
     arch/i386/activationhandlerwrapper.S
     arch/i386/context.S

--- a/pal/src/misc/sysinfo.cpp
+++ b/pal/src/misc/sysinfo.cpp
@@ -46,12 +46,12 @@ Revision History:
 #include <mach/vm_param.h>
 #endif  // HAVE_MACH_VM_PARAM_H
 
-#if defined(_TARGET_MAC64)
+#if defined(__APPLE__)
 #include <mach/vm_statistics.h>
 #include <mach/mach_types.h>
 #include <mach/mach_init.h>
 #include <mach/mach_host.h>
-#endif // defined(_TARGET_MAC64)
+#endif // defined(__APPLE__)
 
 // On some platforms sys/user.h ends up defining _DEBUG; if so
 // remove the definition before including the header and put
@@ -345,4 +345,3 @@ PAL_GetLogicalProcessorCacheSizeFromOS()
 
     return cacheSize;
 }
-

--- a/pal/src/thread/thread.cpp
+++ b/pal/src/thread/thread.cpp
@@ -2514,7 +2514,7 @@ CPalThread::GetStackBase()
 
     if (m_stackBase == NULL)
     {
-#ifdef _TARGET_MAC64
+#ifdef __APPLE__
         // This is a Mac specific method
         m_stackBase = pthread_get_stackaddr_np(pthread_self());
 #else
@@ -2559,7 +2559,7 @@ CPalThread::GetStackLimit()
 
     if (m_stackLimit == NULL)
     {
-#ifdef _TARGET_MAC64
+#ifdef __APPLE__
         // This is a Mac specific method
         m_stackLimit = ((BYTE *)pthread_get_stackaddr_np(pthread_self()) -
                        pthread_get_stacksize_np(pthread_self()));
@@ -2788,7 +2788,7 @@ int CorUnix::CThreadMachExceptionHandlers::GetIndexOfHandler(exception_mask_t bm
 
 void GetCurrentThreadStackLimits(ULONG_PTR* lowLimit, ULONG_PTR* highLimit)
 {
-#ifdef _TARGET_MAC64
+#ifdef __APPLE__
     // This is a Mac specific method
     *highLimit = (ULONG_PTR)pthread_get_stackaddr_np(pthread_self());
     *lowLimit = (ULONG_PTR)(highLimit - pthread_get_stacksize_np(pthread_self()));


### PR DESCRIPTION
 - `_M_X64_OR_ARM64` is a Windows specific and widely used macro
definition in ChakraCore. Define it for appropriate *nix platforms

 - Replace `_TARGET_MAC64` to `__APPLE__`