### PR TITLE
cross platform: fix platform endianness check

### DIFF
--- a/lib/Common/Common/NumberUtilities.inl
+++ b/lib/Common/Common/NumberUtilities.inl
@@ -7,11 +7,44 @@
 #define NUMBER_UTIL_INLINE
 #endif
 
+#if !defined(__BIG_ENDIAN__) && !defined(__LITTLE_ENDIAN__)
+#if defined(_MSC_VER) // WINDOWS
+
+#ifdef BIG_ENDIAN
+#define __BIG_ENDIAN__
+#else
+#define __LITTLE_ENDIAN__
+#endif
+
+#else // NOT WINDOWS
+
+#ifdef __BYTE_ORDER
+#define X_BYTE_ORDER __BYTE_ORDER
+#define X_LITTLE_ENDIAN __LITTLE_ENDIAN
+#elif defined(BYTE_ORDER)
+#define X_BYTE_ORDER BYTE_ORDER
+#define X_LITTLE_ENDIAN LITTLE_ENDIAN
+#else // BYTE_ORDER not defined
+#error "Endiannes of this platform is undefined"
+#endif // __BYTE_ORDER
+
+#if X_BYTE_ORDER == X_LITTLE_ENDIAN
+#define __LITTLE_ENDIAN__
+#else // X_BYTE_ORDER != X_LITTLE_ENDIAN
+#define __BIG_ENDIAN__
+#endif
+
+#undef X_BYTE_ORDER
+#undef X_LITTLE_ENDIAN
+
+#endif // defined(_MSC_VER)
+#endif // !defined(__BIG_ENDIAN__) && !defined(__LITTLE_ENDIAN__)
+
 namespace Js
 {
     NUMBER_UTIL_INLINE ulong &NumberUtilities::LuHiDbl(double &dbl)
     {
-#ifdef BIG_ENDIAN
+#if defined(__BIG_ENDIAN__)
         return ((ulong *)&dbl)[0];
 #else //!BIG_ENDIAN
         return ((ulong *)&dbl)[1];
@@ -20,7 +53,7 @@ namespace Js
 
     NUMBER_UTIL_INLINE ulong &NumberUtilities::LuLoDbl(double &dbl)
     {
-#ifdef BIG_ENDIAN
+#if defined(__BIG_ENDIAN__)
         return ((ulong *)&dbl)[1];
 #else //!BIG_ENDIAN
         return ((ulong *)&dbl)[0];


### PR DESCRIPTION
By default(mostly), both `BIG_ENDIAN` and `LITTLE_ENDIAN` are defined
on *nix platforms. Unlike Windows, comparing the value of `BYTE_ORDER`
to `BIG_ENDIAN` or `LITTLE_ENDIAN` tells the endianness of the system.

P.S. : I couldn’t see any other usage of `BIG_ENDIAN` definition, otherwise
macro could be located under a common header file.