### PR TITLE
cross platform: support amd64 on *nix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL Linux)
     endif()
     set(CLR_CMAKE_PLATFORM_LINUX 1)
 elseif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
-    add_definitions(-D_TARGET_MAC64)
     add_definitions(-DPLATFORM_UNIX)
 
     set(CLR_CMAKE_PLATFORM_UNIX 1)
@@ -34,14 +33,15 @@ else()
 endif()
 
 if(CLR_CMAKE_PLATFORM_UNIX_TARGET_AMD64)
-  set(CLR_CMAKE_PLATFORM_ARCH_AMD64 1)
+    add_definitions(-D_M_X64_OR_ARM64)
+    set(CLR_CMAKE_PLATFORM_ARCH_AMD64 1)
 endif()
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL AppleClang
     OR CMAKE_CXX_COMPILER_ID STREQUAL Clang
     OR CMAKE_CXX_COMPILER_ID STREQUAL GNU)
-  # Color diagnostics for g++ and clang++
-  add_definitions("-fdiagnostics-color=always")
+    # Color diagnostics for g++ and clang++
+    add_definitions("-fdiagnostics-color=always")
 endif()
 
 if(CLR_CMAKE_PLATFORM_UNIX)

--- a/lib/Common/BackendApi.h
+++ b/lib/Common/BackendApi.h
@@ -19,7 +19,9 @@
 #define ProfileEntryThunk Js::ScriptContext::DebugProfileProbeThunk
 
 #define DefaultDeferredParsingThunk Js::JavascriptFunction::DeferredParsingThunk
+#ifdef ENABLE_SCRIPT_PROFILING
 #define ProfileDeferredParsingThunk Js::ScriptContext::ProfileModeDeferredParsingThunk
+#endif
 
 #define DefaultDeferredDeserializeThunk Js::JavascriptFunction::DeferredDeserializeThunk
 #define ProfileDeferredDeserializeThunk Js::ScriptContext::ProfileModeDeferredDeserializeThunk

--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -3399,6 +3399,7 @@ namespace Js
         {
             return ProfileDeferredParsingThunk;
         }
+
         if (entryPoint == DefaultDeferredDeserializeThunk || entryPoint == ProfileDeferredDeserializeThunk)
         {
             return ProfileDeferredDeserializeThunk;

--- a/lib/Runtime/Language/CMakeLists.txt
+++ b/lib/Runtime/Language/CMakeLists.txt
@@ -1,3 +1,9 @@
+if(CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64 OR CMAKE_SYSTEM_PROCESSOR STREQUAL amd64)
+    set( ARCH_CHAKRA_RUNTIME_LANGUAGE
+        amd64/JavascriptOperatorsA.S
+        )
+endif()
+
 add_library (Chakra.Runtime.Language STATIC
     AsmJs.cpp
     AsmJsByteCodeGenerator.cpp
@@ -61,7 +67,7 @@ add_library (Chakra.Runtime.Language STATIC
     # arm/StackFrame.cpp
     # i386/AsmJsJitTemplate.cpp
     # i386/StackFrame.cpp
-    amd64/JavascriptOperatorsA.S
+    ${ARCH_CHAKRA_RUNTIME_LANGUAGE}
     )
 
 include_directories (

--- a/lib/Runtime/Library/JavascriptFunction.cpp
+++ b/lib/Runtime/Library/JavascriptFunction.cpp
@@ -1472,7 +1472,7 @@ LABEL1:
 #ifdef ENABLE_SCRIPT_PROFILING
         Assert(directEntryPoint != DefaultDeferredParsingThunk
             && directEntryPoint != ProfileDeferredParsingThunk);
-#else
+#else // !ENABLE_SCRIPT_PROFILING
         Assert(directEntryPoint != DefaultDeferredParsingThunk);
 #endif
         return (*functionRef)->UpdateUndeferredBody(funcBody);

--- a/pal/inc/rt/palrt.h
+++ b/pal/inc/rt/palrt.h
@@ -1571,14 +1571,14 @@ typedef OUT_OF_PROCESS_FUNCTION_TABLE_CALLBACK *POUT_OF_PROCESS_FUNCTION_TABLE_C
 
 #if defined(FEATURE_PAL_SXS)
 
-// #if !defined(_TARGET_MAC64)
+// #if !defined(__APPLE__)
 // typedef LONG (*PEXCEPTION_ROUTINE)(
     // IN PEXCEPTION_POINTERS pExceptionPointers,
     // IN LPVOID lpvParam);
 
 // #define DISPATCHER_CONTEXT    LPVOID
 
-// #else // defined(_TARGET_MAC64)
+// #else // defined(__APPLE__)
 
 //
 // Define unwind history table structure.
@@ -1663,7 +1663,7 @@ typedef struct _DISPATCHER_CONTEXT {
 
 #endif
 
-// #endif // !defined(_TARGET_MAC64)
+// #endif // !defined(__APPLE__)
 
 typedef DISPATCHER_CONTEXT *PDISPATCHER_CONTEXT;
 

--- a/pal/src/CMakeLists.txt
+++ b/pal/src/CMakeLists.txt
@@ -34,7 +34,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL Linux)
 endif(CMAKE_SYSTEM_NAME STREQUAL Linux)
 
 if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
-  add_definitions(-D_TARGET_MAC64)
   set(PLATFORM_SOURCES
     arch/i386/activationhandlerwrapper.S
     arch/i386/context.S

--- a/pal/src/misc/sysinfo.cpp
+++ b/pal/src/misc/sysinfo.cpp
@@ -46,12 +46,12 @@ Revision History:
 #include <mach/vm_param.h>
 #endif  // HAVE_MACH_VM_PARAM_H
 
-#if defined(_TARGET_MAC64)
+#if defined(__APPLE__)
 #include <mach/vm_statistics.h>
 #include <mach/mach_types.h>
 #include <mach/mach_init.h>
 #include <mach/mach_host.h>
-#endif // defined(_TARGET_MAC64)
+#endif // defined(__APPLE__)
 
 // On some platforms sys/user.h ends up defining _DEBUG; if so
 // remove the definition before including the header and put

--- a/pal/src/thread/thread.cpp
+++ b/pal/src/thread/thread.cpp
@@ -2514,7 +2514,7 @@ CPalThread::GetStackBase()
 
     if (m_stackBase == NULL)
     {
-#ifdef _TARGET_MAC64
+#ifdef __APPLE__
         // This is a Mac specific method
         m_stackBase = pthread_get_stackaddr_np(pthread_self());
 #else
@@ -2559,7 +2559,7 @@ CPalThread::GetStackLimit()
 
     if (m_stackLimit == NULL)
     {
-#ifdef _TARGET_MAC64
+#ifdef __APPLE__
         // This is a Mac specific method
         m_stackLimit = ((BYTE *)pthread_get_stackaddr_np(pthread_self()) -
                        pthread_get_stacksize_np(pthread_self()));
@@ -2788,7 +2788,7 @@ int CorUnix::CThreadMachExceptionHandlers::GetIndexOfHandler(exception_mask_t bm
 
 void GetCurrentThreadStackLimits(ULONG_PTR* lowLimit, ULONG_PTR* highLimit)
 {
-#ifdef _TARGET_MAC64
+#ifdef __APPLE__
     // This is a Mac specific method
     *highLimit = (ULONG_PTR)pthread_get_stackaddr_np(pthread_self());
     *lowLimit = (ULONG_PTR)(highLimit - pthread_get_stacksize_np(pthread_self()));


### PR DESCRIPTION
Currently *nix binary contains a portion of code from x86 specific implementation. This, 
generates an unstable behavior / crashes.

 - `_M_X64_OR_ARM64` is a Windows specific and a widely used macro
definition in ChakraCore. Define it for appropriate *nix platforms

 - Replace `_TARGET_MAC64` to `__APPLE__`

 - ~~Implement `amd64_Thunks.S`~~
 
- Profiling related code temporarily disabled for *nix builds