### PR TITLE
Reenable warning C4463, C4311, C4499 and C4091

### DIFF
--- a/Build/Chakra.Build.props
+++ b/Build/Chakra.Build.props
@@ -30,8 +30,7 @@
         4456;     <!-- declaration of '' hides previous local declaration -->
         4457;     <!-- declaration of '' hides function parameter -->
         4458;     <!-- declaration of '' hides class member -->
-        4838;     <!-- conversion from 'unsigned int' to 'int requires a narrowing conversion -->        
-        4463;     <!-- overflow; assigning 1 to bit-field that can only hold values from -1 to 0 -->
+        4838;     <!-- conversion from 'unsigned int' to 'int requires a narrowing conversion -->
         4312;     <!-- 'type cast': conversion from '' to '' of greater size -->
       </DisableSpecificWarnings>
       <!-- Use the debug CRT in debug build -->

--- a/Build/Chakra.Build.props
+++ b/Build/Chakra.Build.props
@@ -30,8 +30,7 @@
         4456;     <!-- declaration of '' hides previous local declaration -->
         4457;     <!-- declaration of '' hides function parameter -->
         4458;     <!-- declaration of '' hides class member -->
-        4838;     <!-- conversion from 'unsigned int' to 'int requires a narrowing conversion -->
-        4499;     <!-- explicit specialization cannot have a storage class (ignored) -->
+        4838;     <!-- conversion from 'unsigned int' to 'int requires a narrowing conversion -->        
         4463;     <!-- overflow; assigning 1 to bit-field that can only hold values from -1 to 0 -->
         4311;     <!-- 'type cast': pointer truncation from '' to '' -->
         4312;     <!-- 'type cast': conversion from '' to '' of greater size -->

--- a/Build/Chakra.Build.props
+++ b/Build/Chakra.Build.props
@@ -32,7 +32,6 @@
         4458;     <!-- declaration of '' hides class member -->
         4838;     <!-- conversion from 'unsigned int' to 'int requires a narrowing conversion -->        
         4463;     <!-- overflow; assigning 1 to bit-field that can only hold values from -1 to 0 -->
-        4311;     <!-- 'type cast': pointer truncation from '' to '' -->
         4312;     <!-- 'type cast': conversion from '' to '' of greater size -->
       </DisableSpecificWarnings>
       <!-- Use the debug CRT in debug build -->

--- a/Build/Chakra.Build.props
+++ b/Build/Chakra.Build.props
@@ -30,7 +30,6 @@
         4456;     <!-- declaration of '' hides previous local declaration -->
         4457;     <!-- declaration of '' hides function parameter -->
         4458;     <!-- declaration of '' hides class member -->
-        4091;     <!-- '': ignore on left of 'type' when no variable is declared -->
         4838;     <!-- conversion from 'unsigned int' to 'int requires a narrowing conversion -->
         4499;     <!-- explicit specialization cannot have a storage class (ignored) -->
         4463;     <!-- overflow; assigning 1 to bit-field that can only hold values from -1 to 0 -->

--- a/bin/rl/rlfeint.h
+++ b/bin/rl/rlfeint.h
@@ -36,7 +36,7 @@ enum RLFE_COMMAND {
 #ifndef _RL_STATS_DEFINED
 #define _RL_STATS_DEFINED
 // Statistics index.
-typedef enum RL_STATS {
+enum RL_STATS {
     RLS_TOTAL = 0, // overall stats
     RLS_EXE, // should == RLS_TOTAL at this time
     RLS_BASELINES, // baseline stats (== total if !FBaseDiff)

--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -3695,17 +3695,17 @@ Lowerer::GenerateArrayInfoIsNativeFloatAndNotIntArrayTest(IR::Instr *instr, Js::
 template <typename ArrayType>
 static IR::JnHelperMethod GetArrayAllocMemHelper();
 template <>
-static IR::JnHelperMethod GetArrayAllocMemHelper<Js::JavascriptArray>()
+IR::JnHelperMethod GetArrayAllocMemHelper<Js::JavascriptArray>()
 {
     return IR::HelperAllocMemForJavascriptArray;
 }
 template <>
-static IR::JnHelperMethod GetArrayAllocMemHelper<Js::JavascriptNativeIntArray>()
+IR::JnHelperMethod GetArrayAllocMemHelper<Js::JavascriptNativeIntArray>()
 {
     return IR::HelperAllocMemForJavascriptNativeIntArray;
 }
 template <>
-static IR::JnHelperMethod GetArrayAllocMemHelper<Js::JavascriptNativeFloatArray>()
+IR::JnHelperMethod GetArrayAllocMemHelper<Js::JavascriptNativeFloatArray>()
 {
     return IR::HelperAllocMemForJavascriptNativeFloatArray;
 }

--- a/lib/Common/Memory/Recycler.cpp
+++ b/lib/Common/Memory/Recycler.cpp
@@ -3871,10 +3871,10 @@ Recycler::IsReentrantState() const
 
 #ifdef ENABLE_JS_ETW
 template <Js::Phase phase> static ETWEventGCActivationKind GetETWEventGCActivationKind();
-template <> static ETWEventGCActivationKind GetETWEventGCActivationKind<Js::GarbageCollectPhase>() { return ETWEvent_GarbageCollect; }
-template <> static ETWEventGCActivationKind GetETWEventGCActivationKind<Js::ThreadCollectPhase>() { return ETWEvent_ThreadCollect; }
-template <> static ETWEventGCActivationKind GetETWEventGCActivationKind<Js::ConcurrentCollectPhase>() { return ETWEvent_ConcurrentCollect; }
-template <> static ETWEventGCActivationKind GetETWEventGCActivationKind<Js::PartialCollectPhase>() { return ETWEvent_PartialCollect; }
+template <> ETWEventGCActivationKind GetETWEventGCActivationKind<Js::GarbageCollectPhase>() { return ETWEvent_GarbageCollect; }
+template <> ETWEventGCActivationKind GetETWEventGCActivationKind<Js::ThreadCollectPhase>() { return ETWEvent_ThreadCollect; }
+template <> ETWEventGCActivationKind GetETWEventGCActivationKind<Js::ConcurrentCollectPhase>() { return ETWEvent_ConcurrentCollect; }
+template <> ETWEventGCActivationKind GetETWEventGCActivationKind<Js::PartialCollectPhase>() { return ETWEvent_PartialCollect; }
 #endif
 
 template <Js::Phase phase>

--- a/lib/Parser/Scan.h
+++ b/lib/Parser/Scan.h
@@ -667,7 +667,7 @@ private:
     BOOL m_doubleQuoteOnLastTkStrCon :1;
     bool m_OctOrLeadingZeroOnLastTKNumber :1;
     BOOL m_fSyntaxColor : 1;            // whether we're just syntax coloring
-    BOOL m_EscapeOnLastTkStrCon:1;
+    bool m_EscapeOnLastTkStrCon:1;
     BOOL m_fNextStringTemplateIsTagged:1;   // the next string template scanned has a tag (must create raw strings)
     BYTE m_DeferredParseFlags:2;            // suppressStrPid and suppressIdPid
     charcount_t m_ichCheck;             // character at which completion is to be computed.

--- a/lib/Parser/TextbookBoyerMoore.cpp
+++ b/lib/Parser/TextbookBoyerMoore.cpp
@@ -146,13 +146,13 @@ namespace UnifiedRegex
     static bool MatchPatternAt(uint inputChar, char16 const * pat, CharCount index);
 
     template <>
-    static bool MatchPatternAt<1, 1>(uint inputChar, char16  const* pat, CharCount index)
+    bool MatchPatternAt<1, 1>(uint inputChar, char16  const* pat, CharCount index)
     {
         return inputChar == pat[index];
     }
 
     template <>
-    static bool MatchPatternAt<CaseInsensitive::EquivClassSize, CaseInsensitive::EquivClassSize>(uint inputChar, char16 const * pat, CharCount index)
+    bool MatchPatternAt<CaseInsensitive::EquivClassSize, CaseInsensitive::EquivClassSize>(uint inputChar, char16 const * pat, CharCount index)
     {
         CompileAssert(CaseInsensitive::EquivClassSize == 4);
         return inputChar == pat[index * CaseInsensitive::EquivClassSize]
@@ -162,7 +162,7 @@ namespace UnifiedRegex
     }
 
     template <>
-    static bool MatchPatternAt<CaseInsensitive::EquivClassSize, 1>(uint inputChar, char16 const * pat, CharCount index)
+    bool MatchPatternAt<CaseInsensitive::EquivClassSize, 1>(uint inputChar, char16 const * pat, CharCount index)
     {
         CompileAssert(CaseInsensitive::EquivClassSize == 4);
         return inputChar == pat[index * 4];

--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -263,19 +263,19 @@ namespace Js
 
     struct ScriptEntryExitRecord
     {
-        BOOL hasCaller : 1;
-        BOOL hasReentered : 1;
+        bool hasCaller : 1;
+        bool hasReentered : 1;
 #if DBG_DUMP
-        BOOL isCallRoot : 1;
+        bool isCallRoot : 1;
 #endif
 #if DBG || defined(PROFILE_EXEC)
-        BOOL leaveForHost : 1;
+        bool leaveForHost : 1;
 #endif
 #if DBG
-        BOOL leaveForAsyncHostOperation : 1;
+        bool leaveForAsyncHostOperation : 1;
 #endif
 #ifdef CHECK_STACKWALK_EXCEPTION
-        BOOL ignoreStackWalkException: 1;
+        bool ignoreStackWalkException: 1;
 #endif
         Js::ImplicitCallFlags savedImplicitCallFlags;
 

--- a/lib/Runtime/Base/ScriptMemoryDumper.h
+++ b/lib/Runtime/Base/ScriptMemoryDumper.h
@@ -8,7 +8,7 @@
 class ScriptMemoryDumper
 {
 public:
-    typedef struct HeapStats
+    struct HeapStats
     {
         size_t pageCount;
         uint32 objectSize;

--- a/lib/Runtime/Language/InlineCache.h
+++ b/lib/Runtime/Language/InlineCache.h
@@ -574,12 +574,12 @@ namespace Js
     {
         friend class JavascriptFunction;
 
-        typedef struct GuardStruct
+        struct GuardStruct
         {
             CtorCacheGuardValues value;
         };
 
-        typedef struct ContentStruct
+        struct ContentStruct
         {
             DynamicType* type;
             ScriptContext* scriptContext;

--- a/lib/Runtime/Language/ModuleRecordBase.h
+++ b/lib/Runtime/Language/ModuleRecordBase.h
@@ -9,7 +9,7 @@ namespace Js
     class ModuleRecordBase;
     typedef SList<PropertyId> ExportedNames; 
     typedef SList<ModuleRecordBase*> ExportModuleRecordList;
-    typedef struct ModuleNameRecord
+    struct ModuleNameRecord
     {
         ModuleRecordBase* module;
         PropertyId bindingName;

--- a/lib/Runtime/Language/StackTraceArguments.h
+++ b/lib/Runtime/Language/StackTraceArguments.h
@@ -14,7 +14,7 @@ namespace Js {
         static JavascriptString *TypeCodeToTypeName(unsigned typeCode, ScriptContext *scriptContext);
 
         // We use 3 bits to store the value type. If we add another type, we need to use more bits.
-        static enum valueTypes
+        enum valueTypes
         {
             nullValue = 0,
             undefinedValue = 1,

--- a/lib/Runtime/Library/JavascriptProxy.h
+++ b/lib/Runtime/Library/JavascriptProxy.h
@@ -37,13 +37,13 @@ namespace Js
             SetPropertyWPCacheKind,
         } SetPropertyTrapKind;
 
-        typedef enum KeysTrapKind {
+        enum KeysTrapKind {
             GetOwnPropertyNamesKind,
             GetOwnPropertySymbolKind,
             KeysKind
         };
 
-        typedef enum IntegrityLevel {
+        enum IntegrityLevel {
             IntegrityLevel_sealed,
             IntegrityLevel_frozen
         };


### PR DESCRIPTION
Fix and reenable these warnings:
C4091 - ignore on left of '<type>' when no variable is declared
C4311 - 'type cast': pointer truncation from '' to ''
C4463  - overflow; assigning 1 to bit-field that can only hold values from -1 to 0
C4499 - explicit specialization cannot have a storage class (ignored)
