### PR TITLE
Function.name on the getter/setter on defineProperty.

### DIFF
--- a/lib/Runtime/Library/JavascriptObject.h
+++ b/lib/Runtime/Library/JavascriptObject.h
@@ -115,7 +115,6 @@ namespace Js
 
         static void ModifyGetterSetterFuncName(const PropertyRecord * propertyRecord, const PropertyDescriptor& descriptor, ScriptContext* scriptContext);
         static char16 * ConstructName(const PropertyRecord * propertyRecord, const char16 * getOrSetStr, ScriptContext* scriptContext);
-        static char16 * ConstructAccessorNameES6(const PropertyRecord * propertyRecord, const char16 * getOrSetStr, ScriptContext* scriptContext);
         static Var DefinePropertiesHelper(RecyclableObject* object, RecyclableObject* properties, ScriptContext* scriptContext);
         static Var DefinePropertiesHelperForGenericObjects(RecyclableObject* object, RecyclableObject* properties, ScriptContext* scriptContext);
         static Var DefinePropertiesHelperForProxyObjects(RecyclableObject* object, RecyclableObject* properties, ScriptContext* scriptContext);

--- a/test/StackTrace/StackTraceLimit.baseline
+++ b/test/StackTrace/StackTraceLimit.baseline
@@ -267,10 +267,10 @@ Error: Out of stack space
 
 --Throw new Error() in getter for a number of times
 Error: My error in custom stackTraceLimit getter
-	at get stackTraceLimit (stacktracelimit.js:94:13)
-	at get stackTraceLimit (stacktracelimit.js:94:13)
-	at get stackTraceLimit (stacktracelimit.js:94:13)
-	at get stackTraceLimit (stacktracelimit.js:94:13)
+	at stackTraceLimit.get (stacktracelimit.js:94:13)
+	at stackTraceLimit.get (stacktracelimit.js:94:13)
+	at stackTraceLimit.get (stacktracelimit.js:94:13)
+	at stackTraceLimit.get (stacktracelimit.js:94:13)
 	at throwException (longcallstackthrow.js:33:5)
 	at throwExceptionWithCatch (longcallstackthrow.js:22:9)
 	at Anonymous function (longcallstackthrow.js:45:17)

--- a/test/es6/function.name.js
+++ b/test/es6/function.name.js
@@ -750,6 +750,17 @@ var tests = [
             class C { foo(){} };
             assert.areEqual("foo",(new C).foo.name);
         }
+    },
+	{
+        name: "Getter and setter have correct name in defineProperty",
+        body: function()
+        {
+            var obj = {};
+            Object.defineProperty(obj, 'test', {get : function () {}, set : function () {} });
+            var desc = Object.getOwnPropertyDescriptor(obj, 'test');
+            assert.areEqual("get", desc.get.name);
+            assert.areEqual("set", desc.set.name);
+        }
     }
 
 ];


### PR DESCRIPTION
For getter/setter function in the object literal we were initially giving them get/set name respectively. However if they appear in the defineProperty we were changing them for diagnostics purpose. In the diagnostics side we were expected to give <propname>.get but due to function.name we have changed it to "get <propname>"., which is not needed and not consistent.
This change is removing that and putting the <propname>.get as full name for the current function. The short name will now automatically be given as get/set correctly.
