### PR TITLE
MSFT: 7363961 Array.prototype.concat doesn't check if a Proxy is revoked when the Proxy is "this"

### DIFF
--- a/lib/Runtime/Debug/DiagObjectModel.cpp
+++ b/lib/Runtime/Debug/DiagObjectModel.cpp
@@ -3622,6 +3622,10 @@ namespace Js
     BOOL RecyclableProxyObjectWalker::Get(int i, ResolvedObject* pResolvedObject)
     {
         JavascriptProxy* proxy = JavascriptProxy::FromVar(instance);
+        if (proxy->GetTarget() == nullptr || proxy->GetHandler() == nullptr)
+        {
+            return FALSE;
+        }
         if (i == 0)
         {
             pResolvedObject->name = _u("[target]");

--- a/lib/Runtime/Library/JavascriptObject.cpp
+++ b/lib/Runtime/Library/JavascriptObject.cpp
@@ -474,7 +474,7 @@ namespace Js
                 break;
 
             case TypeIds_Proxy:
-                if (JavascriptOperators::IsArray(JavascriptProxy::FromVar(thisArg)->GetTarget()))
+                if (JavascriptOperators::IsArray(thisArg))
                 {
                     if (!isES6ToStringTagEnabled || tag == nullptr || wcscmp(tag->UnsafeGetBuffer(), _u("Array")) == 0)
                     {

--- a/lib/Runtime/Library/JavascriptProxy.cpp
+++ b/lib/Runtime/Library/JavascriptProxy.cpp
@@ -12,6 +12,25 @@ namespace Js
         return JavascriptOperators::GetTypeId(obj) == TypeIds_Proxy;
     }
 
+    RecyclableObject* JavascriptProxy::GetTarget()
+    {
+        if (target == nullptr)
+        {
+            JavascriptError::ThrowTypeError(GetScriptContext(), JSERR_ErrorOnRevokedProxy, _u(""));
+        }
+        return target;
+    }
+
+    RecyclableObject* JavascriptProxy::GetHandler()
+    {
+        if (handler == nullptr)
+        {
+            JavascriptError::ThrowTypeError(GetScriptContext(), JSERR_ErrorOnRevokedProxy, _u(""));
+        }
+        return handler;
+    }
+
+
     Var JavascriptProxy::NewInstance(RecyclableObject* function, CallInfo callInfo, ...)
     {
         PROBE_STACK(function->GetScriptContext(), Js::Constants::MinStackDefault);
@@ -59,7 +78,7 @@ namespace Js
 #endif
         if (JavascriptProxy::Is(target))
         {
-            if (JavascriptProxy::FromVar(target)->GetTarget() == nullptr)
+            if (JavascriptProxy::FromVar(target)->target == nullptr)
             {
                 JavascriptError::ThrowTypeError(scriptContext, JSERR_InvalidProxyArgument, _u("target"));
             }
@@ -72,7 +91,7 @@ namespace Js
         handler = DynamicObject::FromVar(args[2]);
         if (JavascriptProxy::Is(handler))
         {
-            if (JavascriptProxy::FromVar(handler)->GetHandler() == nullptr)
+            if (JavascriptProxy::FromVar(handler)->handler == nullptr)
             {
                 JavascriptError::ThrowTypeError(scriptContext, JSERR_InvalidProxyArgument, _u("handler"));
             }

--- a/lib/Runtime/Library/JavascriptProxy.h
+++ b/lib/Runtime/Library/JavascriptProxy.h
@@ -52,9 +52,13 @@ namespace Js
         JavascriptProxy(DynamicType * type, ScriptContext * scriptContext, RecyclableObject* target, RecyclableObject* handler);
         static BOOL Is(Var obj);
         static JavascriptProxy* FromVar(Var obj) { Assert(Is(obj)); return static_cast<JavascriptProxy*>(obj); }
-        RecyclableObject* GetTarget() const { return target; }
-        RecyclableObject* GetHandler() const { return handler; }
-
+#ifndef IsJsDiag
+        RecyclableObject* GetTarget();
+        RecyclableObject* GetHandler();
+#else
+        RecyclableObject* GetTarget() { return target; }
+        RecyclableObject* GetHandler() { return handler; }
+#endif
         static Var NewInstance(RecyclableObject* function, CallInfo callInfo, ...);
         static Var EntryRevocable(RecyclableObject* function, CallInfo callInfo, ...);
         static Var EntryRevoke(RecyclableObject* function, CallInfo callInfo, ...);

--- a/test/es6/proxytest9.baseline
+++ b/test/es6/proxytest9.baseline
@@ -118,3 +118,6 @@ getTrap, property : foo123
 foo called
 43
 42
+expected :method  is called on a revoked Proxy object
+expected :method get is called on a revoked Proxy object
+expected :method construct is called on a revoked Proxy object

--- a/test/es6/proxytest9.js
+++ b/test/es6/proxytest9.js
@@ -532,6 +532,36 @@ function test29() {
     }  
 }
 
+function test30() {
+    var o = Proxy.revocable([], {});
+    o.revoke();
+    try {
+        Array.prototype.concat.call(o.proxy);
+    } catch(e) {
+        print('expected :' + e.message);
+    }
+    
+    try {
+        Array.prototype.join.call(o.proxy, o.proxy);
+    } catch(e) {
+        print('expected :' + e.message);
+    }
+
+    try {
+        Object.prototype.toString.call(o.proxy);
+    } catch(e) {
+        print('expected :' + e.message);
+    }
+
+    try {
+        function foo() {return this;}
+        var p = Proxy.revocable(foo, {});
+        p.revoke();
+        var pp = new p.proxy();
+    } catch(e) {
+        print('expected :' + e.message);
+    }
+}
 test0();
 test1();
 test2();
@@ -562,3 +592,4 @@ test26();
 test27();
 test28();
 test29();
+test30();


### PR DESCRIPTION
There are places we directly access proxy's target & potentially handler after the proxy is revoked.
At check when non-proxy code access the handler & target, throw if proxy was revoked already.
