### PR TITLE
Disable stack nested functions for split scope

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -1819,6 +1819,17 @@ bool ByteCodeGenerator::CanStackNestedFunc(FuncInfo * funcInfo, bool trace)
         return false;
     }
 
+    if (funcInfo->paramScope && !funcInfo->paramScope->GetCanMergeWithBodyScope())
+    {
+        if (trace)
+        {
+            PHASE_PRINT_TESTTRACE(Js::StackFuncPhase, funcInfo->byteCodeFunction,
+                _u("CanStackNestedFunc: %s (Split Scope)\n"),
+                funcInfo->byteCodeFunction->GetDisplayName());
+        }
+        return false;
+    }
+
     if (trace && funcInfo->byteCodeFunction->GetNestedCount())
     {
         // Only print functions that actually have nested functions, although we will still mark

--- a/test/es6/default-splitscope.js
+++ b/test/es6/default-splitscope.js
@@ -70,6 +70,14 @@ var tests = [
             return b; 
         } 
         assert.areEqual(10, f7().iFnc(), "Function definition inside the object literal should capture the formal from the param scope");
+        
+        var f8 = function (a, b = ((function() { assert.areEqual('string1', a, "First arguemnt receives the right value"); })(), 1), c) {
+            var d = 'string3';
+            (function () { assert.areEqual('string3', d, "Var declaration in the body is initialized properly"); })();
+            return c;
+        };
+
+        assert.areEqual('string2', f8('string1', undefined, 'string2'), "Function returns the third argument properly");
     } 
  }, 
  { 


### PR DESCRIPTION
When we have non-escaping functions in both param and body scope we are
trying to create stack nested functions for them. The problem is we try to
reuse the local frame display. In case of split scope we cannot do that as
both functions should get different frame displays. This changelist
disables stack nested functions inside split scoped functions.
