### PR TITLE
netci.groovy changes for linux

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -20,13 +20,14 @@ PRINT_USAGE() {
     echo "  build.sh [options]"
     echo ""
     echo "  options:"
-    echo "    --cxx       : Path to Clang++ (see example below)"
-    echo "    --cc        : Path to Clang   (see example below)"
-    echo "    --debug, -d : Debug build (by default Release Build)"
-    echo "    --help, -h  : Show help"
-    echo "    --icu       : Path to ICU include folder (see example below)"
-    echo "    --jobs, -j  : Multicore build (i.e. -j=3 for 3 cores)"
-    echo "    --ninja, -n : Build with ninja instead of make"
+    echo "    --cxx         : Path to Clang++ (see example below)"
+    echo "    --cc          : Path to Clang   (see example below)"
+    echo "    --debug, -d   : Debug build (by default Release Build)"
+    echo "    --help, -h    : Show help"
+    echo "    --icu         : Path to ICU include folder (see example below)"
+    echo "    --jobs, -j    : Multicore build (i.e. -j=3 for 3 cores)"
+    echo "    --ninja, -n   : Build with ninja instead of make"
+    echo "    --verbose, -v : Display verbose output including all options"
     echo ""
     echo "  example:"
     echo "    ./build.sh --cxx=/path/to/clang++ --cc=/path/to/clang -j=2"
@@ -37,6 +38,7 @@ PRINT_USAGE() {
 
 _CXX=""
 _CC=""
+VERBOSE=""
 BUILD_TYPE="Release"
 CMAKE_GEN=
 MAKE=make
@@ -57,6 +59,10 @@ while [[ $# -gt 0 ]]; do
     if [[ "$1" == "--help" || "$1" == "-h" ]]; then
         PRINT_USAGE
         exit
+    fi
+
+    if [[ "$1" == "--verbose" || "$1" == "-v" ]]; then
+        _VERBOSE="verbose"
     fi
 
     if [[ "$1" == "--debug" || "$1" == "-d" ]]; then
@@ -85,6 +91,19 @@ while [[ $# -gt 0 ]]; do
 
     shift
 done
+
+if [[ ${#_VERBOSE} > 0 ]]; then
+    # echo options back to the user
+    echo "Printing command line options back to the user:"
+    echo "_CXX=${_CXX}"
+    echo "_CC=${_CC}"
+    echo "BUILD_TYPE=${BUILD_TYPE}"
+    echo "MULTICORE_BUILD=${MULTICORE_BUILD}"
+    echo "ICU_PATH=${ICU_PATH}"
+    echo "CMAKE_GEN=${CMAKE_GEN}"
+    echo "MAKE=${MAKE}"
+    echo ""
+fi
 
 if [[ ${#_CXX} > 0 && ${#_CC} > 0 ]]; then
     echo "Custom CXX ${_CXX}"

--- a/jenkins/get_system_info.sh
+++ b/jenkins/get_system_info.sh
@@ -1,0 +1,40 @@
+#-------------------------------------------------------------------------------------------------------
+# Copyright (C) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+#-------------------------------------------------------------------------------------------------------
+
+echo
+echo "=================================================="
+echo
+
+echo "Number of processors (nproc):"
+echo
+nproc
+
+echo
+echo "--------------------------------------------------"
+echo
+
+echo "Linux version (lsb_release -a):"
+echo
+lsb_release -a
+
+echo
+echo "--------------------------------------------------"
+echo
+
+echo "Clang version (clang --version):"
+echo
+clang --version
+
+echo
+echo "--------------------------------------------------"
+echo
+
+echo "cmake version (cmake --version):"
+echo
+cmake --version
+
+echo
+echo "=================================================="
+echo

--- a/netci.groovy
+++ b/netci.groovy
@@ -19,7 +19,9 @@ def msbuildTypeMap = [
 // convert `machine` parameter to OS component of PR task name
 def machineTypeToOSTagMap = [
     'Windows 7': 'Windows 7',
-    'Windows_NT': 'Windows'
+    'Windows_NT': 'Windows',
+    'Ubuntu14.04': 'Ubuntu14.04',
+    'Ubuntu16.04': 'Ubuntu'
 ]
 
 def dailyRegex = 'dailies'
@@ -76,20 +78,18 @@ def CreateBuildTasks = { machine, configTag, buildExtra, testExtra, runCodeAnaly
                     }
                 }
 
-                Utilities.setMachineAffinity(newJob, machine, 'latest-or-auto')
-
                 def msbuildType = msbuildTypeMap.get(buildType)
                 def msbuildFlavor = "build_${buildArch}${msbuildType}"
-
                 def archivalString = "test/${msbuildFlavor}.*,test/logs/**"
                 archivalString += analysisConfig ? ',CodeAnalysis.err' : ''
-
                 Utilities.addArchival(newJob, archivalString,
                     '', // no exclusions from archival
                     false, // doNotFailIfNothingArchived=false ~= failIfNothingArchived
                     false) // archiveOnlyIfSuccessful=false ~= archiveAlways
 
+                Utilities.setMachineAffinity(newJob, machine, 'latest-or-auto')
                 Utilities.standardJobSetup(newJob, project, isPR, "*/${branch}")
+
                 if (nonDefaultTaskSetup == null) {
                     if (isPR) {
                         def osTag = machineTypeToOSTagMap.get(machine)
@@ -108,6 +108,59 @@ def CreateBuildTasks = { machine, configTag, buildExtra, testExtra, runCodeAnaly
                     // https://github.com/dotnet/dotnet-ci/blob/master/jobs/data/repolist.txt
                     nonDefaultTaskSetup(newJob, isPR, config)
                 }
+            }
+        }
+    }
+}
+
+def CreateLinuxBuildTasks = { machine, configTag, linuxBranch, nonDefaultTaskSetup ->
+    [true, false].each { isPR ->
+        ['debug', 'release'].each { buildType ->
+            def config = "linux_${buildType}"
+            config = (configTag == null) ? config : "${configTag}_${config}"
+
+            // params: Project, BaseTaskName, IsPullRequest (appends '_prtest')
+            def jobName = Utilities.getFullJobName(project, config, isPR)
+
+            def infoScript = 'jenkins/get_system_info.sh'
+            def debugFlag = buildType == 'debug' ? '--debug' : ''
+            def buildScript = "./build.sh -j=`nproc` ${debugFlag}"
+            def testScript = "test/runtests.sh"
+
+            def newJob = job(jobName) {
+                steps {
+                    shell(infoScript)
+                    shell(buildScript)
+                    shell(testScript)
+                }
+            }
+
+            def archivalString = "BuildLinux/build.log"
+            Utilities.addArchival(newJob, archivalString,
+                '', // no exclusions from archival
+                false, // doNotFailIfNothingArchived=false ~= failIfNothingArchived
+                false) // archiveOnlyIfSuccessful=false ~= archiveAlways
+
+            Utilities.setMachineAffinity(newJob, machine, 'latest-or-auto')
+            Utilities.standardJobSetup(newJob, project, isPR, "*/${branch}")
+
+            if (nonDefaultTaskSetup == null) {
+                if (isPR) {
+                    def osTag = machineTypeToOSTagMap.get(machine)
+                    // Set up checks which apply to PRs targeting any branch
+                    Utilities.addGithubPRTriggerForBranch(newJob, linuxBranch, "${osTag} ${config}")
+                    // To enable PR checks only for specific target branches, use the following instead:
+                    // Utilities.addGithubPRTriggerForBranch(newJob, branch, checkName)
+                } else {
+                    Utilities.addGithubPushTrigger(newJob)
+                }
+            } else {
+                // nonDefaultTaskSetup is e.g. DailyBuildTaskSetup (which sets up daily builds)
+                // These jobs will only be configured for the branch specified below,
+                // which is the name of the branch netci.groovy was processed for.
+                // See list of such branches at:
+                // https://github.com/dotnet/dotnet-ci/blob/master/jobs/data/repolist.txt
+                nonDefaultTaskSetup(newJob, isPR, config)
             }
         }
     }
@@ -188,3 +241,21 @@ CreateBuildTasks('Windows_NT', 'daily_disablejit', '"/p:BuildJIT=false"', '-disa
 
 CreateStyleCheckTasks('./jenkins/check_eol.sh', 'ubuntu_check_eol', 'EOL Check')
 CreateStyleCheckTasks('./jenkins/check_copyright.sh', 'ubuntu_check_copyright', 'Copyright Check')
+
+// -----------------
+// LINUX BUILD TASKS
+// -----------------
+
+if (branch == 'linux') {
+    osString = 'Ubuntu16.04'
+
+    // PR checks
+    CreateLinuxBuildTasks(osString, "ubuntu", branch, null)
+
+    // daily builds
+    CreateLinuxBuildTasks(osString, "daily_ubuntu", branch,
+        /* nonDefaultTaskSetup */ { newJob, isPR, config ->
+            DailyBuildTaskSetup(newJob, isPR,
+                "Ubuntu ${config}",
+                'linux\\s+tests')})
+}


### PR DESCRIPTION
Enable CI and Daily builds of Ubuntu Linux on the `linux` branch.

Builds using `./build.sh` and tests with `./test/runtests.sh`

Archives the `BuildLinux/build.log`