### PR TITLE
Memset: Native arrays typecheck and missing item check

### DIFF
--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -4685,7 +4685,13 @@ CommonNumber:
                 }
                 else if (instanceType == TypeIds_NativeIntArray)
                 {
-                    returnValue = JavascriptArray::FromVar(instance)->DirectSetItemAtRange<int32>(start, length, JavascriptConversion::ToInt32(value, scriptContext));
+                    int32 intValue = JavascriptConversion::ToInt32(value, scriptContext);
+                    // Special case for missing item
+                    if (SparseArraySegment<int32>::IsMissingItem(&intValue))
+                    {
+                        return false;
+                    }
+                    returnValue = JavascriptArray::FromVar(instance)->DirectSetItemAtRange<int32>(start, length, intValue);
                 }
                 else
                 {
@@ -4694,7 +4700,14 @@ CommonNumber:
                     {
                         return false;
                     }
-                    returnValue = JavascriptArray::FromVar(instance)->DirectSetItemAtRange<double>(start, length, JavascriptConversion::ToNumber(value, scriptContext));
+
+                    double doubleValue = JavascriptConversion::ToNumber(value, scriptContext);
+                    // Special case for missing item
+                    if (SparseArraySegment<double>::IsMissingItem(&doubleValue))
+                    {
+                        return false;
+                    }
+                    returnValue = JavascriptArray::FromVar(instance)->DirectSetItemAtRange<double>(start, length, doubleValue);
                 }
                 returnValue &= vt == VirtualTableInfoBase::GetVirtualTable(instance);
             }

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -4689,6 +4689,11 @@ CommonNumber:
                 }
                 else
                 {
+                    // For native float arrays, the jit doesn't check the type of the source so we have to do it here
+                    if (!JavascriptNumber::Is(value) && !TaggedNumber::Is(value))
+                    {
+                        return false;
+                    }
                     returnValue = JavascriptArray::FromVar(instance)->DirectSetItemAtRange<double>(start, length, JavascriptConversion::ToNumber(value, scriptContext));
                 }
                 returnValue &= vt == VirtualTableInfoBase::GetVirtualTable(instance);

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -4685,12 +4685,12 @@ CommonNumber:
                 }
                 else if (instanceType == TypeIds_NativeIntArray)
                 {
-                    int32 intValue = JavascriptConversion::ToInt32(value, scriptContext);
-                    // Special case for missing item
-                    if (SparseArraySegment<int32>::IsMissingItem(&intValue))
+                    // Only accept tagged int. Also covers case for MissingItem
+                    if (!TaggedInt::Is(value))
                     {
                         return false;
                     }
+                    int32 intValue = JavascriptConversion::ToInt32(value, scriptContext);
                     returnValue = JavascriptArray::FromVar(instance)->DirectSetItemAtRange<int32>(start, length, intValue);
                 }
                 else


### PR DESCRIPTION
Memset with native float arrays needs to check the type of the source because we can do `nativearray[i] = var` and bailout after the fact if the source was not a float (ie: changes the type of array). 

Since memset will not change the type of the array, it needs to check before hand that the source is actually a float or int and bailout if not.

Additionally, I added a check for `IsMissingItem` for native int and float arrays.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/919)
<!-- Reviewable:end -->
