### PR TITLE
MemCopy btree array source not long enough

### DIFF
--- a/lib/Runtime/Library/JavascriptArray.inl
+++ b/lib/Runtime/Library/JavascriptArray.inl
@@ -953,10 +953,11 @@ SECOND_PASS:
             for (uint i = 0; i < length; i++)
             {
                 T val;
-                if (fromArray->DirectGetItemAt(fromStartIndex + i, &val))
+                if (!fromArray->DirectGetItemAt(fromStartIndex + i, &val))
                 {
-                    DirectSetItem_Full(toStartIndex + i, val);
+                    return false;
                 }
+                DirectSetItem_Full(toStartIndex + i, val);
             }
             return true;
         }


### PR DESCRIPTION
When doing a memcopy with a btree, bailout if we fail to get the value of the source array (source not long enough)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/921)
<!-- Reviewable:end -->
