### PR TITLE
xplat: enable ch [flaglist] and printing assertions

### DIFF
--- a/bin/ChakraCore/ChakraCoreDllFunc.cpp
+++ b/bin/ChakraCore/ChakraCoreDllFunc.cpp
@@ -24,14 +24,6 @@ static ATOM  lockedDll = 0;
 #define EXPORT_FUNC __attribute__ ((visibility ("default")))
 #endif
 
-#ifndef _WIN32
-HANDLE GetModuleHandle(HANDLE hProcess)
-{
-    Assert(hProcess == NULL);
-    return g_hInstance;
-}
-#endif
-
 static BOOL AttachProcess(HANDLE hmod)
 {
     if (!ThreadContextTLSEntry::InitializeProcess() || !JsrtContext::Initialize())
@@ -80,7 +72,7 @@ static BOOL AttachProcess(HANDLE hmod)
     lockedDll = ::AddAtom(engine);
     AssertMsg(lockedDll, "Failed to lock chakracore.dll");
 #endif // _WIN32
-    
+
 #ifdef ENABLE_BASIC_TELEMETRY
     g_TraceLoggingClient = NoCheckHeapNewStruct(TraceLoggingClient);
 #endif
@@ -148,7 +140,7 @@ EXTERN_C BOOL WINAPI DllMain(HINSTANCE hmod, DWORD dwReason, PVOID pvReserved)
         lockedDll = ::DeleteAtom(lockedDll);
         AssertMsg(lockedDll == 0, "Failed to release the lock for chakracore.dll");
 #endif
-        
+
 #ifdef DYNAMIC_PROFILE_STORAGE
         DynamicProfileStorage::Uninitialize();
 #endif

--- a/bin/ch/CMakeLists.txt
+++ b/bin/ch/CMakeLists.txt
@@ -26,6 +26,7 @@ set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fPIE -pie")
 target_link_libraries (ch
   PRIVATE Chakra.Pal
   PRIVATE Chakra.Common.Codex
+  -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/ch.version
   )
 
 # Add a post build event to the ch target

--- a/bin/ch/ch.cpp
+++ b/bin/ch/ch.cpp
@@ -130,9 +130,9 @@ void __stdcall PrintUsageFormat()
 
 void __stdcall PrintUsage()
 {
-#if !defined(DEBUG) || !defined(_WIN32)
+#ifndef DEBUG
     wprintf(_u("\nUsage: %s <source file> %s"), hostName,
-            _u("\n[flaglist] is only supported for debug builds on Windows\n"));
+            _u("\n[flaglist] is not supported for Release mode\n"));
 #else
     PrintUsageFormat();
     wprintf(_u("Try '%s -?' for help\n"), hostName);
@@ -188,7 +188,7 @@ HRESULT CreateLibraryByteCodeHeader(LPCOLESTR fileContents, BYTE * contentsRaw, 
     HRESULT hr = GetSerializedBuffer(fileContents, &bcBuffer, &bcBufferSize);
 
     if (FAILED(hr)) return hr;
-    
+
     bcFileHandle = CreateFile(bcFullPath, GENERIC_WRITE, FILE_SHARE_DELETE, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
     if (bcFileHandle == INVALID_HANDLE_VALUE)
     {
@@ -283,7 +283,7 @@ HRESULT RunScript(const char* fileName, LPCWSTR fileContents, BYTE *bcBuffer, ch
     MessageQueue * messageQueue = new MessageQueue();
     WScriptJsrt::AddMessageQueue(messageQueue);
     LPWSTR fullPathWide = nullptr;
-    
+
     IfJsErrorFailLog(ChakraRTInterface::JsSetPromiseContinuationCallback(PromiseContinuationCallback, (void*)messageQueue));
 
     Assert(fileContents != nullptr || bcBuffer != nullptr);
@@ -489,12 +489,12 @@ HRESULT ExecuteTestWithMemoryCheck(char* fileName)
     {
         Assert(false);
     }
-#else 
+#else
     // REVIEW: Do we need a SEH handler here?
     hr = ExecuteTest(fileName);
     if (FAILED(hr)) exit(0);
 #endif // _WIN32
-    
+
     _flushall();
 #ifdef CHECK_MEMORY_LEAK
     ChakraRTInterface::SetEnableCheckMemoryLeakOutput(true);
@@ -522,11 +522,11 @@ int _cdecl wmain(int argc, __in_ecount(argc) LPWSTR argv[])
     // The following code is present to make sure we don't load
     // jscript9.dll etc with ch. Since that isn't a concern on non-Windows
     // builds, it's safe to conditionally compile it out.
-#ifdef _WIN32    
+#ifdef _WIN32
     ATOM lock = ::AddAtom(szChakraCoreLock);
     AssertMsg(lock, "failed to lock chakracore.dll");
 #endif // _WIN32
-    
+
     HostConfigFlags::HandleArgsFlag(argc, argv);
 
     ChakraRTInterface::ArgInfo argInfo = { argc, argv, PrintUsage, nullptr };
@@ -541,7 +541,7 @@ int _cdecl wmain(int argc, __in_ecount(argc) LPWSTR argv[])
 #ifdef _WIN32
         HANDLE threadHandle;
         threadHandle = reinterpret_cast<HANDLE>(_beginthreadex(0, 0, &StaticThreadProc, &argInfo, STACK_SIZE_PARAM_IS_A_RESERVATION, 0));
-        
+
         if (threadHandle != nullptr)
         {
             DWORD waitResult = WaitForSingleObject(threadHandle, INFINITE);
@@ -567,9 +567,9 @@ int _cdecl wmain(int argc, __in_ecount(argc) LPWSTR argv[])
 int main(int argc, char** argv)
 {
     PAL_InitializeChakraCore(argc, argv);
-        
+
     const char* strProgramFile = argv[0];
-    
+
     // Ignoring mem-alloc failures here as this is
     // simply a test tool. We can add more error checking
     // here later if desired.
@@ -578,7 +578,7 @@ int main(int argc, char** argv)
     {
         Helpers::NarrowStringToWideDynamic(argv[i], &args[i]);
     }
-    
+
     int ret = wmain(argc, args);
 
     for (int i = 0; i < argc; i++)
@@ -586,7 +586,7 @@ int main(int argc, char** argv)
         free(args[i]);
     }
     delete[] args;
-    
+
     PAL_Shutdown();
     return ret;
 }

--- a/bin/ch/ch.version
+++ b/bin/ch/ch.version
@@ -1,0 +1,4 @@
+{
+   global: OnChakraCoreLoadedEntry;
+   local: *;
+};

--- a/jenkins/check_copyright.sh
+++ b/jenkins/check_copyright.sh
@@ -33,7 +33,7 @@ git diff --name-only `git merge-base origin/master HEAD` HEAD |
     grep -v -E '\.inc$' |
     grep -v -E 'test/benchmarks/.*\.js$' |
     grep -v -E 'pal/.*' |
-    grep -v -E 'libChakraCoreLib.version' |
+    grep -v -E 'libChakraCoreLib.version|ch.version' |
     xargs -I % sh -c "echo 'Check Copyright > Checking %'; python jenkins/check_copyright.py % > $ERRFILETEMP || cat $ERRFILETEMP >> $ERRFILE"
 
 if [ -e $ERRFILE ]; then # if error file exists then there were errors

--- a/lib/Common/CommonPal.h
+++ b/lib/Common/CommonPal.h
@@ -533,7 +533,6 @@ STRSAFEAPI StringCchPrintfW(WCHAR* pszDest, size_t cchDest, const WCHAR* pszForm
 #endif
 
 #ifndef _WIN32
-HANDLE GetModuleHandle(HANDLE hProcess);
 __inline
 HRESULT ULongMult(ULONG ulMultiplicand, ULONG ulMultiplier, ULONG* pulResult);
 #endif

--- a/lib/Common/Core/CmdParser.cpp
+++ b/lib/Common/Core/CmdParser.cpp
@@ -590,7 +590,11 @@ int CmdLineArgsParser::Parse(__in LPWSTR oneArg) throw()
                 NextChar();
             }
             //fallthrough
+#ifdef _WIN32
+        // Only support '/' as a command line switch start char on Windows
+        // for legacy reason. Deprecate on xplat, as it starts a path on Unix.
         case '/':
+#endif
             NextChar();
             if('?' == CurChar())
             {

--- a/pal/inc/pal.h
+++ b/pal/inc/pal.h
@@ -691,12 +691,12 @@ CharNextExA(
 #define CharNextEx CharNextExA
 #endif
 
-extern int sprintf_s(char *_Dst, size_t _SizeInBytes, const char *_Format, ...);        
+extern int sprintf_s(char *_Dst, size_t _SizeInBytes, const char *_Format, ...);
 
 typedef int errno_t;
 extern errno_t _ultow_s(unsigned long inValue, WCHAR* outBuffer, size_t inDestBufferSize, int inRadix );
 extern errno_t _ui64tow_s(unsigned long long inValue, WCHAR* outBuffer, size_t inDestBufferSize, int inRadix );
-    
+
 PALIMPORT
 int
 PALAPIV
@@ -3802,6 +3802,17 @@ GetModuleFileNameExW(
 
 #ifdef UNICODE
 #define GetModuleFileNameEx GetModuleFileNameExW
+#endif
+
+PALIMPORT
+HMODULE
+PALAPI
+GetModuleHandleW(
+    IN OPTIONAL LPCWSTR lpModuleName
+);
+
+#ifdef UNICODE
+#define GetModuleHandle GetModuleHandleW
 #endif
 
 // Get base address of the module containing a given symbol

--- a/pal/src/loader/module.cpp
+++ b/pal/src/loader/module.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -90,7 +90,7 @@ SET_DEFAULT_DEBUG_CHANNEL(LOADER);
 CRITICAL_SECTION module_critsec;
 
 /* always the first, in the in-load-order list */
-MODSTRUCT exe_module; 
+MODSTRUCT exe_module;
 MODSTRUCT *pal_module = nullptr;
 
 char * g_szCoreCLRPath = nullptr;
@@ -157,7 +157,7 @@ LoadLibraryExA(
     IN /*Reserved*/ HANDLE hFile,
     IN DWORD dwFlags)
 {
-    if (dwFlags != 0) 
+    if (dwFlags != 0)
     {
         // UNIXTODO: Implement this!
         ASSERT("Needs Implementation!!!");
@@ -199,7 +199,7 @@ LoadLibraryExA(
     LOGEXIT("LoadLibraryExA returns HMODULE %p\n", hModule);
     PERF_EXIT(LoadLibraryExA);
     return hModule;
-    
+
 }
 
 /*++
@@ -215,13 +215,13 @@ LoadLibraryExW(
     IN /*Reserved*/ HANDLE hFile,
     IN DWORD dwFlags)
 {
-    if (dwFlags != 0) 
+    if (dwFlags != 0)
     {
         // UNIXTODO: Implement this!
         ASSERT("Needs Implementation!!!");
         return nullptr;
     }
-    
+
     CHAR * lpstr;
     INT name_length;
     PathCharString pathstr;
@@ -299,7 +299,7 @@ GetProcAddress(
         SetLastError(ERROR_INVALID_HANDLE);
         goto done;
     }
-    
+
     /* try to assert on attempt to locate symbol by ordinal */
     /* this can't be an exact test for HIWORD((DWORD)lpProcName) == 0
        because of the address range reserved for ordinals contain can
@@ -311,7 +311,7 @@ GetProcAddress(
     }
 
     // Get the symbol's address.
-    
+
     // If we're looking for a symbol inside the PAL, we try the PAL_ variant
     // first because otherwise we run the risk of having the non-PAL_
     // variant preferred over the PAL's implementation.
@@ -419,7 +419,7 @@ FreeLibraryAndExitThread(
     IN DWORD dwExitCode)
 {
     PERF_ENTRY(FreeLibraryAndExitThread);
-    ENTRY("FreeLibraryAndExitThread()\n"); 
+    ENTRY("FreeLibraryAndExitThread()\n");
     FreeLibrary(hLibModule);
     ExitThread(dwExitCode);
     LOGEXIT("FreeLibraryAndExitThread\n");
@@ -546,7 +546,7 @@ GetModuleFileNameW(
         SetLastError(ERROR_INSUFFICIENT_BUFFER);
         goto done;
     }
-    
+
     wcscpy_s(lpFileName, nSize, wide_name);
 
     TRACE("file name of module %p is %S\n", hModule, lpFileName);
@@ -556,6 +556,21 @@ done:
     LOGEXIT("GetModuleFileNameW returns DWORD %u\n", retval);
     PERF_EXIT(GetModuleFileNameW);
     return retval;
+}
+
+HMODULE
+PALAPI
+GetModuleHandleW(
+    IN OPTIONAL LPCWSTR lpModuleName)
+{
+    if (lpModuleName)
+    {
+        // UNIXTODO: Implement this!
+        ASSERT("Needs Implementation!!!");
+        return nullptr;
+    }
+
+    return (HMODULE)&exe_module;
 }
 
 /*
@@ -585,7 +600,7 @@ PAL_LoadLibraryDirect(
     {
         goto done;
     }
-    
+
     lpstr = pathstr.OpenStringBuffer((PAL_wcslen(lpLibFileName)+1) * MaxWCharToAcpLength);
     if (nullptr == lpstr)
     {
@@ -772,7 +787,7 @@ Return value:
     TRUE - success
     FALSE - failure (incorrect ptr, etc.)
 --*/
-BOOL 
+BOOL
 PALAPI
 PAL_LOADUnloadPEFile(void * ptr)
 {
@@ -796,7 +811,7 @@ PAL_LOADUnloadPEFile(void * ptr)
 /*++
     PAL_GetSymbolModuleBase
 
-    Get base address of the module containing a given symbol 
+    Get base address of the module containing a given symbol
 
 Parameters:
     void *symbol - address of symbol
@@ -818,18 +833,18 @@ PAL_GetSymbolModuleBase(void *symbol)
         TRACE("Can't get base address. Argument symbol == nullptr\n");
         SetLastError(ERROR_INVALID_DATA);
     }
-    else 
+    else
     {
         Dl_info info;
         if (dladdr(symbol, &info) != 0)
         {
             retval = info.dli_fbase;
         }
-        else 
+        else
         {
             TRACE("Can't get base address of the current module\n");
             SetLastError(ERROR_INVALID_DATA);
-        }        
+        }
     }
 
     LOGEXIT("PAL_GetPalModuleBase returns %p\n", retval);
@@ -908,7 +923,7 @@ BOOL LOADSetExeName(LPWSTR name)
     InternalFree(exe_module.lib_name);
     exe_module.lib_name = name;
 
-    // For platforms where we can't trust the handle to be constant, we need to 
+    // For platforms where we can't trust the handle to be constant, we need to
     // store the inode/device pairs for the modules we just initialized.
 #if RETURNS_NEW_HANDLES_ON_REPEAT_DLOPEN
     {
@@ -926,7 +941,7 @@ BOOL LOADSetExeName(LPWSTR name)
         }
         TRACE("Executable has inode %d and device %d\n", stat_buf.st_ino, stat_buf.st_dev);
 
-        exe_module.inode = stat_buf.st_ino; 
+        exe_module.inode = stat_buf.st_ino;
         exe_module.device = stat_buf.st_dev;
     }
 #endif
@@ -950,13 +965,13 @@ Function :
     Call DllMain for all modules (that have one) with the given "fwReason"
 
 Parameters :
-    DWORD dwReason : parameter to pass down to DllMain, one of DLL_PROCESS_ATTACH, DLL_PROCESS_DETACH, 
+    DWORD dwReason : parameter to pass down to DllMain, one of DLL_PROCESS_ATTACH, DLL_PROCESS_DETACH,
         DLL_THREAD_ATTACH, DLL_THREAD_DETACH
 
     LPVOID lpReserved : parameter to pass down to DllMain
         If dwReason is DLL_PROCESS_ATTACH, lpvReserved is NULL for dynamic loads and non-NULL for static loads.
-        If dwReason is DLL_PROCESS_DETACH, lpvReserved is NULL if DllMain has been called by using FreeLibrary 
-            and non-NULL if DllMain has been called during process termination. 
+        If dwReason is DLL_PROCESS_DETACH, lpvReserved is NULL if DllMain has been called by using FreeLibrary
+            and non-NULL if DllMain has been called during process termination.
 
 (no return value)
 
@@ -969,7 +984,7 @@ void LOADCallDllMain(DWORD dwReason, LPVOID lpReserved)
     MODSTRUCT *module = nullptr;
     BOOL InLoadOrder = TRUE; /* true if in load order, false for reverse */
     CPalThread *pThread;
-    
+
     pThread = InternalGetCurrentThread();
     if (UserCreatedThread != pThread->GetThreadType())
     {
@@ -979,7 +994,7 @@ void LOADCallDllMain(DWORD dwReason, LPVOID lpReserved)
     /* Validate dwReason */
     switch(dwReason)
     {
-    case DLL_PROCESS_ATTACH: 
+    case DLL_PROCESS_ATTACH:
         ASSERT("got called with DLL_PROCESS_ATTACH parameter! Why?\n");
         break;
     case DLL_PROCESS_DETACH:
@@ -1075,7 +1090,7 @@ static BOOL LOADFreeLibrary(MODSTRUCT *module, BOOL fCallDllMain)
     /* Releasing the last reference : call dlclose(), remove module from the
        process-wide module list */
 
-    TRACE("Reference count for module %p (named %S) now 0; destroying module structure\n", 
+    TRACE("Reference count for module %p (named %S) now 0; destroying module structure\n",
         module, MODNAME(module));
 
     /* unlink the module structure from the list */
@@ -1127,13 +1142,13 @@ Function :
 Parameters :
     MODSTRUCT *module : module whose DllMain must be called
 
-    DWORD dwReason : parameter to pass down to DllMain, one of DLL_PROCESS_ATTACH, DLL_PROCESS_DETACH, 
+    DWORD dwReason : parameter to pass down to DllMain, one of DLL_PROCESS_ATTACH, DLL_PROCESS_DETACH,
         DLL_THREAD_ATTACH, DLL_THREAD_DETACH
 
     LPVOID lpvReserved : parameter to pass down to DllMain,
-        If dwReason is DLL_PROCESS_ATTACH, lpvReserved is NULL for dynamic loads and non-NULL for static loads. 
-        If dwReason is DLL_PROCESS_DETACH, lpvReserved is NULL if DllMain has been called by using FreeLibrary 
-            and non-NULL if DllMain has been called during process termination. 
+        If dwReason is DLL_PROCESS_ATTACH, lpvReserved is NULL for dynamic loads and non-NULL for static loads.
+        If dwReason is DLL_PROCESS_DETACH, lpvReserved is NULL if DllMain has been called by using FreeLibrary
+            and non-NULL if DllMain has been called during process termination.
 
 Returns:
     BOOL : DllMain's return value
@@ -1144,7 +1159,7 @@ static BOOL LOADCallDllMainSafe(MODSTRUCT *module, DWORD dwReason, LPVOID lpRese
     /* reset ENTRY nesting level back to zero while inside the callback... */
     int old_level = DBG_change_entrylevel(0);
 #endif /* _ENABLE_DEBUG_MESSAGES_ */
-    
+
     struct Param
     {
         MODSTRUCT *module;
@@ -1160,9 +1175,9 @@ static BOOL LOADCallDllMainSafe(MODSTRUCT *module, DWORD dwReason, LPVOID lpRese
     PAL_TRY(Param *, pParam, &param)
     {
         TRACE("Calling DllMain (%p) for module %S\n",
-              pParam->module->pDllMain, 
+              pParam->module->pDllMain,
               pParam->module->lib_name ? pParam->module->lib_name : W16_NULLSTRING);
-        
+
         {
             // This module may be foreign to our PAL, so leave our PAL.
             // If it depends on us, it will re-enter.
@@ -1262,7 +1277,7 @@ static bool LOADConvertLibraryPathWideStringToMultibyteString(
     size_t length = (PAL_wcslen(wideLibraryPath)+1) * MaxWCharToAcpLength;
     *multibyteLibraryPathLengthRef = WideCharToMultiByte(CP_ACP, 0, wideLibraryPath, -1, multibyteLibraryPath,
                                                         length, nullptr, nullptr);
-    
+
     if (*multibyteLibraryPathLengthRef == 0)
     {
         DWORD dwLastError = GetLastError();
@@ -1302,7 +1317,7 @@ static BOOL LOADValidateModule(MODSTRUCT *module)
 
     /* enumerate through the list of modules to make sure the given handle is
        really a module (HMODULEs are actually MODSTRUCT pointers) */
-    do 
+    do
     {
         if (module == modlist_enum)
         {
@@ -1397,19 +1412,19 @@ Function :
 
 Parameters :
     void *dl_handle :   handle returned by dl_open, goes in MODSTRUCT::dl_handle
-    
-    char *name :        name of new module. after conversion to widechar, 
+
+    char *name :        name of new module. after conversion to widechar,
                         goes in MODSTRUCT::lib_name
-                        
+
 Return value:
     a pointer to a new, initialized MODSTRUCT strucutre, or NULL on failure.
-    
+
 Notes :
     'name' is used to initialize MODSTRUCT::lib_name. The other member is set to NULL
     In case of failure (in malloc or MBToWC), this function sets LastError.
 --*/
 static MODSTRUCT *LOADAllocModule(void *dl_handle, LPCSTR name)
-{   
+{
     MODSTRUCT *module;
     LPWSTR wide_name;
 
@@ -1479,8 +1494,8 @@ static MODSTRUCT *LOADAddModule(void *dl_handle, LPCSTR libraryNameOrPath)
     do
     {
         if (dl_handle == module->dl_handle)
-        {   
-            /* found the handle. increment the refcount and return the 
+        {
+            /* found the handle. increment the refcount and return the
                existing module structure */
             TRACE("Found matching module %p for module name %s\n", module, libraryNameOrPath);
 
@@ -1517,7 +1532,7 @@ static MODSTRUCT *LOADAddModule(void *dl_handle, LPCSTR libraryNameOrPath)
     exe_module.prev = module;
 
 #if RETURNS_NEW_HANDLES_ON_REPEAT_DLOPEN
-    module->inode = stat_buf.st_ino; 
+    module->inode = stat_buf.st_ino;
     module->device = stat_buf.st_dev;
 #endif
 
@@ -1563,7 +1578,7 @@ static HMODULE LOADRegisterLibraryDirect(void *dl_handle, LPCSTR libraryNameOrPa
             else
             {
                 // If the target module doesn't have the PAL_RegisterModule export, then use this PAL's
-                // module handle assuming that the target module is referencing this PAL's exported 
+                // module handle assuming that the target module is referencing this PAL's exported
                 // functions on said handle.
                 module->hinstance = (HINSTANCE)module;
             }
@@ -1684,8 +1699,8 @@ MODSTRUCT *LOADGetPalLibrary()
 {
     if (pal_module == nullptr)
     {
-        // Initialize the pal module (the module containing LOADGetPalLibrary). Assumes that 
-        // the PAL is linked into the coreclr module because we use the module name containing 
+        // Initialize the pal module (the module containing LOADGetPalLibrary). Assumes that
+        // the PAL is linked into the coreclr module because we use the module name containing
         // this function for the coreclr path.
         TRACE("Loading module for PAL library\n");
 
@@ -1707,7 +1722,7 @@ MODSTRUCT *LOADGetPalLibrary()
                 goto exit;
             }
         }
-        
+
         if (strcpy_s(g_szCoreCLRPath, g_cbszCoreCLRPath, info.dli_fname) != SAFECRT_SUCCESS)
         {
             ERROR("LOADGetPalLibrary: strcpy_s failed!");
@@ -1736,7 +1751,7 @@ Return
 extern "C"
 void LockModuleList()
 {
-    CPalThread * pThread = 
+    CPalThread * pThread =
         (PALIsThreadDataInitialized() ? InternalGetCurrentThread() : nullptr);
 
     InternalEnterCriticalSection(pThread, &module_critsec);
@@ -1758,7 +1773,7 @@ Return
 extern "C"
 void UnlockModuleList()
 {
-    CPalThread * pThread = 
+    CPalThread * pThread =
         (PALIsThreadDataInitialized() ? InternalGetCurrentThread() : nullptr);
 
     InternalLeaveCriticalSection(pThread, &module_critsec);


### PR DESCRIPTION
Fix `OnChakraCoreLoadedEntry` export from `ch`.

Fix `GetModuleHandle(nullptr)`. It was returning HMODULE to
"libChakraCore.so". HMODULE to `ch` was expected. Add the implementation
to PAL.

Deprecate `/` as a command line switch start char on xplat. On Unix it
starts a path.

With this change, `ch` now supports [flaglist], and `AssertMsg` starts
to print assertion line/col/message to console (Previously not because
AssertToConsole test hook flag failed to set).
