### PR TITLE
Allow Asm.js type coercions on simd builtin ret values

### DIFF
--- a/lib/Runtime/Language/AsmJsByteCodeGenerator.h
+++ b/lib/Runtime/Language/AsmJsByteCodeGenerator.h
@@ -137,6 +137,7 @@ namespace Js
         void LoadSimd(RegSlot dst, RegSlot src, AsmJsVarType type);
 
         bool IsFRound(AsmJsMathFunction* sym);
+        bool IsValidSimdFcnRetType(AsmJsSIMDFunction& simdFunction, const AsmJsRetType& expectedType, const AsmJsRetType& retType);
         /// TODO:: Finish removing references to old bytecode generator
         ByteCodeGenerator* GetOldByteCodeGenerator() const
         {

--- a/test/SIMD.bool16x8.asmjs/rlexe.xml
+++ b/test/SIMD.bool16x8.asmjs/rlexe.xml
@@ -101,4 +101,12 @@
       <compile-flags>-bgjit- -simdjs -simd128typespec -asmjs- -off:simplejit -mic:1</compile-flags>
     </default>
   </test>
+  <test>
+     <default>
+        <files>testBug1.js</files>
+        <baseline>testBug1.baseline</baseline>
+        <tags>exclude_dynapogo,exclude_ship</tags>
+        <compile-flags>-off:deferparse -testtrace:asmjs -simdjs -bgjit- -maic:1</compile-flags>
+     </default>
+   </test>
 </regress-exe>

--- a/test/SIMD.bool16x8.asmjs/testBug1.baseline
+++ b/test/SIMD.bool16x8.asmjs/testBug1.baseline
@@ -1,0 +1,6 @@
+
+testBug1.js(11, 5)
+	Asm.js Compilation Error function : asmModule::testBug
+	SIMD builtin function returns wrong type
+
+Asm.js compilation failed.

--- a/test/SIMD.bool16x8.asmjs/testBug1.js
+++ b/test/SIMD.bool16x8.asmjs/testBug1.js
@@ -1,0 +1,21 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft Corporation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+function asmModule(stdlib, imports) {
+    "use asm";
+
+    var b8 = stdlib.SIMD.Bool16x8;
+    var b8extractLane = b8.extractLane;
+    var fround = stdlib.Math.fround;
+    function testBug()
+    {
+        var a = b8(1, 0, 1, 0, 1, 0, 1, 0);
+        var result = fround(0);
+        result = fround(b8extractLane(a,0));
+        return;
+    }
+    return {testBug:testBug};
+}
+
+var m = asmModule(this, {g1:SIMD.Bool16x8(1, 1, 1, 1, 1, 1, 1, 1)});

--- a/test/SIMD.bool16x8.asmjs/testConstructor.js
+++ b/test/SIMD.bool16x8.asmjs/testConstructor.js
@@ -84,6 +84,13 @@ function asmModule(stdlib, imports) {
         return b8check(result);
     }
 
+    //Validation will fail with the bug
+    function retValueCoercionBug()
+    {
+        var ret1 = 0;
+        var a = b8(1,2,3,4,5,6,7,8);
+        ret1 = (b8extractLane(a, 0))|0;
+    }
     return {testConstructor:testConstructor,
     testSplat:testSplat,
     testLaneAccess: testLaneAccess};

--- a/test/SIMD.bool32x4.asmjs/rlexe.xml
+++ b/test/SIMD.bool32x4.asmjs/rlexe.xml
@@ -101,4 +101,12 @@
       <compile-flags>-bgjit- -simdjs -simd128typespec -asmjs- -off:simplejit -mic:1</compile-flags>
     </default>
   </test>
+  <test>
+     <default>
+        <files>testBug1.js</files>
+        <baseline>testBug1.baseline</baseline>
+        <tags>exclude_dynapogo,exclude_ship</tags>
+        <compile-flags>-off:deferparse -testtrace:asmjs -simdjs -bgjit- -maic:1</compile-flags>
+     </default>
+   </test>
 </regress-exe>

--- a/test/SIMD.bool32x4.asmjs/testBug1.baseline
+++ b/test/SIMD.bool32x4.asmjs/testBug1.baseline
@@ -1,0 +1,6 @@
+
+testBug1.js(11, 5)
+	Asm.js Compilation Error function : asmModule::testBug
+	SIMD builtin function returns wrong type
+
+Asm.js compilation failed.

--- a/test/SIMD.bool32x4.asmjs/testBug1.js
+++ b/test/SIMD.bool32x4.asmjs/testBug1.js
@@ -1,0 +1,21 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft Corporation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+function asmModule(stdlib, imports) {
+    "use asm";
+
+    var b = stdlib.SIMD.Bool32x4;
+    var bextractLane = b.extractLane;
+    var fround = stdlib.Math.fround;
+    function testBug()
+    {
+        var a = b(1, 0, 1, 0);
+        var result = fround(0);
+        result = fround(bextractLane(a,0));
+        return;
+    }
+    return {testBug:testBug};
+}
+
+var m = asmModule(this, {g1:SIMD.Bool16x8(1, 1, 1, 1, 1, 1, 1, 1)});

--- a/test/SIMD.bool32x4.asmjs/testConstructor.js
+++ b/test/SIMD.bool32x4.asmjs/testConstructor.js
@@ -73,6 +73,14 @@ function asmModule(stdlib, imports) {
         return b4check(result);
     }
 
+    //Validation will fail with the bug
+    function retValueCoercionBug()
+    {
+        var ret1 = 0;
+        var a = b4(1,2,3,4);
+        ret1 = (b4extractLane(a, 0))|0;
+    }
+
     return {testConstructor:testConstructor,
     testSplat:testSplat,
     testLaneAccess: testLaneAccess};

--- a/test/SIMD.bool32x4.asmjs/testNeg1.js
+++ b/test/SIMD.bool32x4.asmjs/testNeg1.js
@@ -1,0 +1,20 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft Corporation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+function asmModule(stdlib, imports) {
+    "use asm";
+
+    var b8 = stdlib.SIMD.Bool16x8;
+    var b8extractLane = b8.extractLane;
+    function testNeg()
+    {
+        var a = b8(1, 0, 1, 0, 1, 0, 1, 0);
+        var result = 0.0;
+        result = +(b8extractLane(a,0));
+        return;
+    }
+    return {testNeg:testNeg};
+}
+
+var m = asmModule(this, {g1:SIMD.Bool16x8(1, 1, 1, 1, 1, 1, 1, 1)});

--- a/test/SIMD.bool8x16.asmjs/rlexe.xml
+++ b/test/SIMD.bool8x16.asmjs/rlexe.xml
@@ -125,5 +125,13 @@
       <tags>exclude_dynapogo,exclude_ship</tags>
       <compile-flags>-bgjit- -asmjs -testtrace:asmjs -simdjs -AsmJsStopOnError -maic:0 -mic:0</compile-flags>
     </default>
-  </test>  
+  </test>
+    <test>
+     <default>
+        <files>testBug1.js</files>
+        <baseline>testBug1.baseline</baseline>
+        <tags>exclude_dynapogo,exclude_ship</tags>
+        <compile-flags>-off:deferparse -testtrace:asmjs -simdjs -bgjit- -maic:1</compile-flags>
+     </default>
+   </test>
 </regress-exe>

--- a/test/SIMD.bool8x16.asmjs/testBug1.baseline
+++ b/test/SIMD.bool8x16.asmjs/testBug1.baseline
@@ -1,0 +1,6 @@
+
+testBug1.js(11, 5)
+	Asm.js Compilation Error function : asmModule::testBug
+	SIMD builtin function returns wrong type
+
+Asm.js compilation failed.

--- a/test/SIMD.bool8x16.asmjs/testBug1.js
+++ b/test/SIMD.bool8x16.asmjs/testBug1.js
@@ -1,0 +1,21 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft Corporation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+function asmModule(stdlib, imports) {
+    "use asm";
+
+    var b = stdlib.SIMD.Bool8x16;
+    var bextractLane = b.extractLane;
+    var fround = stdlib.Math.fround;
+    function testBug()
+    {
+        var a = b(1, 0, 1, 0,1, 0, 1, 0,1, 0, 1, 0,1, 0, 1, 0);
+        var result = fround(0);
+        result = fround(bextractLane(a,0));
+        return;
+    }
+    return {testBug:testBug};
+}
+
+var m = asmModule(this, {g1:SIMD.Bool16x8(1, 1, 1, 1, 1, 1, 1, 1)});

--- a/test/SIMD.bool8x16.asmjs/testConstructor.js
+++ b/test/SIMD.bool8x16.asmjs/testConstructor.js
@@ -109,6 +109,14 @@ function asmModule(stdlib, imports) {
         return b16check(result);
     }
 
+    //Validation will fail with the bug
+    function retValueCoercionBug()
+    {
+        var ret1 = 0;
+        var a = b16(1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8);
+        ret1 = (b16extractLane(a, 0))|0;
+    }
+
     return {testConstructor:testConstructor,
     testSplat:testSplat,
     testLaneAccess: testLaneAccess};

--- a/test/SIMD.float32x4.asmjs/rlexe.xml
+++ b/test/SIMD.float32x4.asmjs/rlexe.xml
@@ -942,4 +942,12 @@
             <compile-flags>-bgjit- -simdjs -simd128typespec -asmjs- -off:simplejit -mic:1</compile-flags>
         </default>
     </test>
+    <test>
+     <default>
+        <files>testBug1.js</files>
+        <baseline>testBug1.baseline</baseline>
+        <tags>exclude_dynapogo,exclude_ship</tags>
+        <compile-flags>-off:deferparse -testtrace:asmjs -simdjs -bgjit- -maic:1</compile-flags>
+     </default>
+   </test>
 </regress-exe>

--- a/test/SIMD.float32x4.asmjs/testBug1.baseline
+++ b/test/SIMD.float32x4.asmjs/testBug1.baseline
@@ -1,0 +1,6 @@
+
+testBug1.js(11, 5)
+	Asm.js Compilation Error function : asmModule::testBug
+	SIMD builtin function returns wrong type
+
+Asm.js compilation failed.

--- a/test/SIMD.float32x4.asmjs/testBug1.js
+++ b/test/SIMD.float32x4.asmjs/testBug1.js
@@ -1,0 +1,21 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft Corporation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+function asmModule(stdlib, imports) {
+    "use asm";
+
+    var b = stdlib.SIMD.Float32x4;
+    var bextractLane = b.extractLane;
+    var fround = stdlib.Math.fround;
+    function testBug()
+    {
+        var a = b(1.0, 0.0, 1.0, 0.0);
+        var result = 0;
+        result = bextractLane(a,0)|0;
+        return;
+    }
+    return {testBug:testBug};
+}
+
+var m = asmModule(this, {g1:SIMD.Bool16x8(1, 1, 1, 1, 1, 1, 1, 1)});

--- a/test/SIMD.float32x4.asmjs/testCalls.js
+++ b/test/SIMD.float32x4.asmjs/testCalls.js
@@ -53,7 +53,7 @@ function asmModule(stdlib, imports) {
     var f4xor = f4.xor;
     var f4not = f4.not;
 
-    
+    var f4extractLane = f4.extractLane;
 
     var fround = stdlib.Math.fround;
 
@@ -185,6 +185,16 @@ function asmModule(stdlib, imports) {
         var k = i4(-1, -2, -3, -4);
         x = f4check(fcBug_1());
         return i4check(k);
+    }
+
+    //Validation will fail with the bug
+    function retValueCoercionBug()
+    {
+        var ret = 0.0;
+        var ret1 = fround(0);
+        var a = f4(1.0, 2.0, 3.0, 4.0);
+        ret = +f4extractLane(a, 0);
+        ret1 = fround(f4extractLane(a, 0));
     }
 
     return {func1:func1, func2:func2, func3:func3, func4:func4, fcBug1:fcBug_1, fcBug2:fcBug_2};

--- a/test/SIMD.int16x8.asmjs/rlexe.xml
+++ b/test/SIMD.int16x8.asmjs/rlexe.xml
@@ -742,5 +742,12 @@
       <compile-flags>-bgjit- -simdjs -simd128typespec -asmjs- -off:simplejit -mic:1</compile-flags>
   </default>
   </test>  
-  
+  <test>
+     <default>
+        <files>testBug1.js</files>
+        <baseline>testBug1.baseline</baseline>
+        <tags>exclude_dynapogo,exclude_ship</tags>
+        <compile-flags>-off:deferparse -testtrace:asmjs -simdjs -bgjit- -maic:1</compile-flags>
+     </default>
+   </test>
 </regress-exe>

--- a/test/SIMD.int16x8.asmjs/testBug1.baseline
+++ b/test/SIMD.int16x8.asmjs/testBug1.baseline
@@ -1,0 +1,6 @@
+
+testBug1.js(11, 5)
+	Asm.js Compilation Error function : asmModule::testBug
+	SIMD builtin function returns wrong type
+
+Asm.js compilation failed.

--- a/test/SIMD.int16x8.asmjs/testBug1.js
+++ b/test/SIMD.int16x8.asmjs/testBug1.js
@@ -1,0 +1,21 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft Corporation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+function asmModule(stdlib, imports) {
+    "use asm";
+
+    var b8 = stdlib.SIMD.Int16x8;
+    var b8extractLane = b8.extractLane;
+    var fround = stdlib.Math.fround;
+    function testBug()
+    {
+        var a = b8(1, 0, 1, 0, 1, 0, 1, 0);
+        var result = fround(0);
+        result = fround(b8extractLane(a,0));
+        return;
+    }
+    return {testBug:testBug};
+}
+
+var m = asmModule(this, {g1:SIMD.Bool16x8(1, 1, 1, 1, 1, 1, 1, 1)});

--- a/test/SIMD.int16x8.asmjs/testCalls.js
+++ b/test/SIMD.int16x8.asmjs/testCalls.js
@@ -37,7 +37,7 @@ function asmModule(stdlib, imports) {
     var f4 = stdlib.SIMD.Float32x4;  
     var f4check = f4.check;
     var f4splat = f4.splat;
-    
+    var i8extractLane = i8.extractLane;
     var f4fromInt32x4 = f4.fromInt32x4;
     var f4fromInt32x4Bits = f4.fromInt32x4Bits;
     var f4abs = f4.abs;
@@ -198,6 +198,16 @@ function asmModule(stdlib, imports) {
         var k = i8(1, 2, 3, 4, 5, 6, 7, 8);
         x = i4check(fcBug_1());
         return i8check(k);
+    }
+
+    //Validation will fail with the bug
+    function retValueCoercionBug()
+    {
+        var ret = 0.0;
+        var ret1 = 0;
+        var a = i8(1,2,3,4,5,6,7,8);
+        ret = +i8extractLane(a, 0);
+        ret1 = (i8extractLane(a, 0))|0;
     }
 
     return {func1:func1, func2:func2, func3:func3, func4:func4, fcBug_2:fcBug_2, fcBug_1:fcBug_1/*, func5:func5, func6:func6*/};

--- a/test/SIMD.int32x4.asmjs/rlexe.xml
+++ b/test/SIMD.int32x4.asmjs/rlexe.xml
@@ -765,4 +765,12 @@
       <compile-flags>-bgjit- -simdjs -simd128typespec -off:simplejit -mic:1</compile-flags>
       </default>
   </test>
+  <test>
+     <default>
+        <files>testBug1.js</files>
+        <baseline>testBug1.baseline</baseline>
+        <tags>exclude_dynapogo,exclude_ship</tags>
+        <compile-flags>-off:deferparse -testtrace:asmjs -simdjs -bgjit- -maic:1</compile-flags>
+     </default>
+   </test>
 </regress-exe>

--- a/test/SIMD.int32x4.asmjs/testBug1.baseline
+++ b/test/SIMD.int32x4.asmjs/testBug1.baseline
@@ -1,0 +1,6 @@
+
+testBug1.js(11, 5)
+	Asm.js Compilation Error function : asmModule::testBug
+	SIMD builtin function returns wrong type
+
+Asm.js compilation failed.

--- a/test/SIMD.int32x4.asmjs/testBug1.js
+++ b/test/SIMD.int32x4.asmjs/testBug1.js
@@ -1,0 +1,21 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft Corporation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+function asmModule(stdlib, imports) {
+    "use asm";
+
+    var b = stdlib.SIMD.Int32x4;
+    var bextractLane = b.extractLane;
+    var fround = stdlib.Math.fround;
+    function testBug()
+    {
+        var a = b(1, 0, 1, 0);
+        var result = fround(0);
+        result = fround(bextractLane(a,0));
+        return;
+    }
+    return {testBug:testBug};
+}
+
+var m = asmModule(this, {g1:SIMD.Bool16x8(1, 1, 1, 1, 1, 1, 1, 1)});

--- a/test/SIMD.int32x4.asmjs/testCalls.js
+++ b/test/SIMD.int32x4.asmjs/testCalls.js
@@ -28,6 +28,7 @@ function asmModule(stdlib, imports) {
     var i4or = i4.or;
     var i4xor = i4.xor;
     var i4not = i4.not;
+    var i4extractLane = i4.extractLane;
     //var i4shiftLeftByScalar = i4.shiftLeftByScalar;
     //var i4shiftRightByScalar = i4.shiftRightByScalar;
     //var i4shiftRightArithmeticByScalar = i4.shiftRightArithmeticByScalar;
@@ -195,6 +196,16 @@ function asmModule(stdlib, imports) {
         var k = i16(1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
         x = i4check(fcBug_1());
         return i16check(k);
+    }
+
+    //Validation will fail with the bug
+    function retValueCoercionBug()
+    {
+        var ret = 0.0;
+        var ret1 = 0;
+        var a = i4(1, 2, 3, 4);
+        ret = +i4extractLane(a, 0);
+        ret1 = (i4extractLane(a, 0))|0;
     }
 
     return {func1:func1, func2:func2, func3:func3, func4:func4, fcBug_2:fcBug_2, fcBug_1:fcBug_1};

--- a/test/SIMD.int8x16.asmjs/testBug1.baseline
+++ b/test/SIMD.int8x16.asmjs/testBug1.baseline
@@ -1,0 +1,6 @@
+
+testBug1.js(11, 5)
+	Asm.js Compilation Error function : asmModule::testBug
+	SIMD builtin function returns wrong type
+
+Asm.js compilation failed.

--- a/test/SIMD.int8x16.asmjs/testBug1.js
+++ b/test/SIMD.int8x16.asmjs/testBug1.js
@@ -1,0 +1,21 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft Corporation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+function asmModule(stdlib, imports) {
+    "use asm";
+
+    var b8 = stdlib.SIMD.Int16x8;
+    var b8extractLane = b8.extractLane;
+    var fround = stdlib.Math.fround;
+    function testBug()
+    {
+        var a = b8(1, 0, 1, 0, 1, 0, 1, 0);
+        var result = fround(0);
+        result = fround(b8extractLane(a,0));
+        return;
+    }
+    return {testBug:testBug};
+}
+
+var m = asmModule(this, {g1:SIMD.Bool16x8(1, 1, 1, 1, 1, 1, 1, 1)});

--- a/test/SIMD.int8x16.asmjs/testCalls.js
+++ b/test/SIMD.int8x16.asmjs/testCalls.js
@@ -67,7 +67,7 @@ function asmModule(stdlib, imports) {
     var f4xor = f4.xor;
     var f4not = f4.not;
 
-    
+    var i16extractLane = i16.extractLane;
 
     var fround = stdlib.Math.fround;
 
@@ -198,6 +198,16 @@ function asmModule(stdlib, imports) {
         var k = i16(1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
         x = f4check(fcBug_1());
         return i16check(k);
+    }
+
+    //Validation will fail with the bug
+    function retValueCoercionBug()
+    {
+        var ret = 0.0;
+        var ret1 = 0;
+        var a = i16(1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4);
+        ret = +i16extractLane(a, 0);
+        ret1 = (i16extractLane(a, 0))|0;
     }
 
     return {func1:func1, func2:func2, func3:func3, func4:func4, func5:fcBug_1, func6:fcBug_2};

--- a/test/SIMD.uint16x8.asmjs/rlexe.xml
+++ b/test/SIMD.uint16x8.asmjs/rlexe.xml
@@ -677,5 +677,13 @@
       <tags>exclude_dynapogo,exclude_ship</tags>
       <compile-flags>-bgjit- -simdjs -simd128typespec -asmjs- -off:simplejit -mic:1</compile-flags>
   </default>
-  </test>  
+  </test>
+  <test>
+     <default>
+        <files>testBug1.js</files>
+        <baseline>testBug1.baseline</baseline>
+        <tags>exclude_dynapogo,exclude_ship</tags>
+        <compile-flags>-off:deferparse -testtrace:asmjs -simdjs -bgjit- -maic:1</compile-flags>
+     </default>
+   </test>
 </regress-exe>

--- a/test/SIMD.uint16x8.asmjs/testBug1.baseline
+++ b/test/SIMD.uint16x8.asmjs/testBug1.baseline
@@ -1,0 +1,6 @@
+
+testBug1.js(11, 5)
+	Asm.js Compilation Error function : asmModule::testBug
+	SIMD builtin function returns wrong type
+
+Asm.js compilation failed.

--- a/test/SIMD.uint16x8.asmjs/testBug1.js
+++ b/test/SIMD.uint16x8.asmjs/testBug1.js
@@ -1,0 +1,21 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft Corporation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+function asmModule(stdlib, imports) {
+    "use asm";
+
+    var b8 = stdlib.SIMD.Uint16x8;
+    var b8extractLane = b8.extractLane;
+    var fround = stdlib.Math.fround;
+    function testBug()
+    {
+        var a = b8(1, 0, 1, 0, 1, 0, 1, 0);
+        var result = fround(0);
+        result = fround(b8extractLane(a,0));
+        return;
+    }
+    return {testBug:testBug};
+}
+
+var m = asmModule(this, {g1:SIMD.Bool16x8(1, 1, 1, 1, 1, 1, 1, 1)});

--- a/test/SIMD.uint16x8.asmjs/testCalls.js
+++ b/test/SIMD.uint16x8.asmjs/testCalls.js
@@ -88,7 +88,7 @@ function asmModule(stdlib, imports) {
     var i8fromU8bits = i8.fromUint16x8Bits;
 
     var u8fromI8bits = u8.fromInt16x8Bits;
-    
+    var u8extractLane = u8.extractLane;
     var i16 = stdlib.SIMD.Int8x16;
     var i16check = i16.check;
     var i16fromU16bits = i16.fromUint8x16Bits;
@@ -208,6 +208,16 @@ function asmModule(stdlib, imports) {
         var k = u16(1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
         x = u8fromI8bits(i8check(fcBug_1()));
         return i16check(i16fromU16bits(k));
+    }
+
+    //Validation will fail with the bug
+    function retValueCoercionBug()
+    {
+        var ret = 0.0;
+        var ret1 = 0;
+        var a = u8(1,2,3,4,5,6,7,8);
+        ret = +u8extractLane(a, 0);
+        ret1 = (u8extractLane(a, 0))|0;
     }
 
     return {func1:func1, func2:func2, func3:func3, func4:func4, func5:fcBug_1, func6:fcBug_2};

--- a/test/SIMD.uint32x4.asmjs/rlexe.xml
+++ b/test/SIMD.uint32x4.asmjs/rlexe.xml
@@ -56,6 +56,14 @@
     </default>
   </test>
   <test>
+     <default>
+        <files>testBug1.js</files>
+        <baseline>testBug1.baseline</baseline>
+        <tags>exclude_dynapogo,exclude_ship</tags>
+        <compile-flags>-off:deferparse -testtrace:asmjs -simdjs -bgjit- -maic:1</compile-flags>
+     </default>
+   </test>
+  <test>
     <default>
       <files>testFail_1.js</files>
       <baseline>testFail_1.baseline</baseline>

--- a/test/SIMD.uint32x4.asmjs/testBug1.baseline
+++ b/test/SIMD.uint32x4.asmjs/testBug1.baseline
@@ -1,0 +1,6 @@
+
+testBug1.js(11, 5)
+	Asm.js Compilation Error function : asmModule::testBug
+	SIMD builtin function returns wrong type
+
+Asm.js compilation failed.

--- a/test/SIMD.uint32x4.asmjs/testBug1.js
+++ b/test/SIMD.uint32x4.asmjs/testBug1.js
@@ -1,0 +1,21 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft Corporation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+function asmModule(stdlib, imports) {
+    "use asm";
+
+    var b = stdlib.SIMD.Uint32x4;
+    var bextractLane = b.extractLane;
+    var fround = stdlib.Math.fround;
+    function testBug()
+    {
+        var a = b(1, 0, 1, 0);
+        var result = fround(0);
+        result = fround(bextractLane(a,0));
+        return;
+    }
+    return {testBug:testBug};
+}
+
+var m = asmModule(this, {g1:SIMD.Bool16x8(1, 1, 1, 1, 1, 1, 1, 1)});

--- a/test/SIMD.uint32x4.asmjs/testCalls.js
+++ b/test/SIMD.uint32x4.asmjs/testCalls.js
@@ -33,6 +33,7 @@ function asmModule(stdlib, imports) {
     var u4 = stdlib.SIMD.Uint32x4;
     var u4check = u4.check;
 
+    var u4extractLane = u4.extractLane;
     var f4 = stdlib.SIMD.Float32x4;  
     var f4check = f4.check;
     var f4splat = f4.splat;
@@ -197,6 +198,16 @@ function asmModule(stdlib, imports) {
         var k = u4(1, 2, 3, 4);
         x = i4check(fcBug_1());
         return i4check(i4fu4(k));
+    }
+
+    //Validation will fail with the bug
+    function retValueCoercionBug()
+    {
+        var ret = 0.0;
+        var ret1 = 0;
+        var a = u4(1, 2, 3, 4);
+        ret = +u4extractLane(a, 0);
+        ret1 = (u4extractLane(a, 0))|0;
     }
 
     return {func1:func1, func2:func2, func3:func3, func4:func4, func5:fcBug_1, func6:fcBug_2};

--- a/test/SIMD.uint8x16.asmjs/rlexe.xml
+++ b/test/SIMD.uint8x16.asmjs/rlexe.xml
@@ -41,6 +41,14 @@
     </default>
   </test>
   <test>
+     <default>
+        <files>testBug1.js</files>
+        <baseline>testBug1.baseline</baseline>
+        <tags>exclude_dynapogo,exclude_ship</tags>
+        <compile-flags>-off:deferparse -testtrace:asmjs -simdjs -bgjit- -maic:1</compile-flags>
+     </default>
+   </test>
+  <test>
     <default>
       <files>testCalls.js</files>
       <tags>exclude_dynapogo,exclude_ship</tags>

--- a/test/SIMD.uint8x16.asmjs/testBug1.baseline
+++ b/test/SIMD.uint8x16.asmjs/testBug1.baseline
@@ -1,0 +1,6 @@
+
+testBug1.js(11, 5)
+	Asm.js Compilation Error function : asmModule::testBug
+	SIMD builtin function returns wrong type
+
+Asm.js compilation failed.

--- a/test/SIMD.uint8x16.asmjs/testBug1.js
+++ b/test/SIMD.uint8x16.asmjs/testBug1.js
@@ -1,0 +1,21 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft Corporation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+function asmModule(stdlib, imports) {
+    "use asm";
+
+    var b8 = stdlib.SIMD.Uint16x8;
+    var b8extractLane = b8.extractLane;
+    var fround = stdlib.Math.fround;
+    function testBug()
+    {
+        var a = b8(1, 0, 1, 0, 1, 0, 1, 0);
+        var result = fround(0);
+        result = fround(b8extractLane(a,0));
+        return;
+    }
+    return {testBug:testBug};
+}
+
+var m = asmModule(this, {g1:SIMD.Bool16x8(1, 1, 1, 1, 1, 1, 1, 1)});

--- a/test/SIMD.uint8x16.asmjs/testCalls.js
+++ b/test/SIMD.uint8x16.asmjs/testCalls.js
@@ -35,6 +35,8 @@ function asmModule(stdlib, imports) {
     var u16 = stdlib.SIMD.Uint8x16;
     var u16check = u16.check;
 
+    var u16extractLane = u16.extractLane;
+
     var f4 = stdlib.SIMD.Float32x4;  
     var f4check = f4.check;
     var f4splat = f4.splat;
@@ -199,6 +201,16 @@ function asmModule(stdlib, imports) {
         var k = u16(1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8);
         x = f4check(fcBug_1());
         return i16check(i16fu16(k));
+    }
+
+    //Validation will fail with the bug
+    function retValueCoercionBug()
+    {
+        var ret = 0.0;
+        var ret1 = 0;
+        var a = u16(1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4);
+        ret = +u16extractLane(a, 0);
+        ret1 = (u16extractLane(a, 0))|0;
     }
 
     return {func1:func1, func2:func2, func3:func3, func4:func4, func5:fcBug_1, func6:fcBug_2};


### PR DESCRIPTION
Allow simd builtin function return values to be coereced
to asm.js types as allowed by the spec.
http://asmjs.org/spec/latest/#unary-operators

Adding positive and negative tests.

Fixes #933 