### PR TITLE
cross platform: replace long to int32

### DIFF
--- a/bin/rl/rl.cpp
+++ b/bin/rl/rl.cpp
@@ -964,22 +964,22 @@ FormatString(
       else {
          switch (*++format) {
             case 'd':
-               i += sprintf_s(&buf[i], BUFFER_SIZE + 32 - i, "%d", (long)NumDiffsTotal[RLS_TOTAL]);
+               i += sprintf_s(&buf[i], BUFFER_SIZE + 32 - i, "%d", (int32)NumDiffsTotal[RLS_TOTAL]);
                break;
             case 'f':
-               i += sprintf_s(&buf[i], BUFFER_SIZE + 32 - i, "%d", (long)NumFailuresTotal[RLS_TOTAL]);
+               i += sprintf_s(&buf[i], BUFFER_SIZE + 32 - i, "%d", (int32)NumFailuresTotal[RLS_TOTAL]);
                break;
             case 't':
-               i += sprintf_s(&buf[i], BUFFER_SIZE + 32 - i, "%d", (long)NumVariationsRun[RLS_TOTAL]);
+               i += sprintf_s(&buf[i], BUFFER_SIZE + 32 - i, "%d", (int32)NumVariationsRun[RLS_TOTAL]);
                break;
             case 'T':
-               i += sprintf_s(&buf[i], BUFFER_SIZE + 32 - i, "%d", (long)NumVariationsTotal[RLS_TOTAL]);
+               i += sprintf_s(&buf[i], BUFFER_SIZE + 32 - i, "%d", (int32)NumVariationsTotal[RLS_TOTAL]);
                break;
             case 'p':
-               if ((long)NumVariationsTotal[RLS_TOTAL]) {
+               if ((int32)NumVariationsTotal[RLS_TOTAL]) {
                   i += sprintf_s(&buf[i], BUFFER_SIZE + 32 - i, "%d",
-                     100 * (long)NumVariationsRun[RLS_TOTAL] /
-                     (long)NumVariationsTotal[RLS_TOTAL]);
+                     100 * (int32)NumVariationsRun[RLS_TOTAL] /
+                     (int32)NumVariationsTotal[RLS_TOTAL]);
                }
                else {
                   i += sprintf_s(&buf[i], BUFFER_SIZE + 32 - i, "--");
@@ -3377,7 +3377,7 @@ IsTimeoutStringValid(char *strTimeout) {
    char *end;
    _set_errno(0);
 
-   unsigned long secTimeout = strtoul(strTimeout, &end, 10);
+   uint32 secTimeout = strtoul(strTimeout, &end, 10);
 
    if (errno != 0 || *end != 0) {
       return FALSE;
@@ -4602,9 +4602,9 @@ RegressDirectory(
    if (FBaseDiff && !pDir->IsBaseline())
       pDir->InitStats(0);
 
-   ASSERTNR((long)pDir->NumVariationsRun == 0);
-   ASSERTNR((long)pDir->NumDiffs == 0);
-   ASSERTNR((long)pDir->NumFailures == 0);
+   ASSERTNR((int32)pDir->NumVariationsRun == 0);
+   ASSERTNR((int32)pDir->NumDiffs == 0);
+   ASSERTNR((int32)pDir->NumFailures == 0);
 
    if (!FNoDirName)
       WriteLog("*** %s ***", dir);
@@ -5008,16 +5008,16 @@ main(int argc, char *argv[])
 
    if (FRLFE) {
       if (Mode == RM_EXE) {
-         RLFEAddRoot(RLS_EXE, (long)NumVariationsTotal[RLS_EXE]);
+         RLFEAddRoot(RLS_EXE, (int32)NumVariationsTotal[RLS_EXE]);
       }
       else {
          if (FBaseline)
-            RLFEAddRoot(RLS_BASELINES, (long)NumVariationsTotal[RLS_BASELINES]);
+            RLFEAddRoot(RLS_BASELINES, (int32)NumVariationsTotal[RLS_BASELINES]);
          if (FDiff)
-            RLFEAddRoot(RLS_DIFFS, (long)NumVariationsTotal[RLS_DIFFS]);
+            RLFEAddRoot(RLS_DIFFS, (int32)NumVariationsTotal[RLS_DIFFS]);
       }
 
-      RLFEAddRoot(RLS_TOTAL, (long)NumVariationsTotal[RLS_TOTAL]);
+      RLFEAddRoot(RLS_TOTAL, (int32)NumVariationsTotal[RLS_TOTAL]);
    }
 
    DirectoryQueue.AdjustWaitForThreadCount();
@@ -5073,5 +5073,5 @@ main(int argc, char *argv[])
    // The return code from RL is 0 for complete success, 1 for any failure.
    // Note that diffs don't count as failures.
 
-   return ((long)NumFailuresTotal[RLS_TOTAL] == 0L) ? 0 : 1;
+   return ((int32)NumFailuresTotal[RLS_TOTAL] == 0L) ? 0 : 1;
 }

--- a/bin/rl/rl.h
+++ b/bin/rl/rl.h
@@ -24,6 +24,8 @@
 #pragma warning(disable:4127) // expression is constant, e.g., while(TRUE)
 
 #define LOCAL static
+typedef __int32 int32;
+typedef unsigned __int32 uint32;
 
 #define BUFFER_SIZE 1024
 #define MAXQUEUE    10000
@@ -320,7 +322,7 @@ class COutputBuffer;
 
 class CProtectedLong {
     CRITICAL_SECTION    _cs;
-    long                _value;
+    int32                _value;
 
 public:
 
@@ -334,31 +336,31 @@ public:
         DeleteCriticalSection(&_cs);
     }
 
-    long operator++(int)
+    int32 operator++(int)
     {
         EnterCriticalSection(&_cs);
-        long tmp = _value++;
+        int32 tmp = _value++;
         LeaveCriticalSection(&_cs);
         return tmp;
     }
 
-    long operator--(int)
+    int32 operator--(int)
     {
         EnterCriticalSection(&_cs);
-        long tmp = _value--;
+        int32 tmp = _value--;
         LeaveCriticalSection(&_cs);
         return tmp;
     }
 
-    long operator+=(long incr)
+    int32 operator+=(int32 incr)
     {
         EnterCriticalSection(&_cs);
-        long tmp = (_value += incr);
+        int32 tmp = (_value += incr);
         LeaveCriticalSection(&_cs);
         return tmp;
     }
 
-    long operator=(long val)
+    int32 operator=(int32 val)
     {
         EnterCriticalSection(&_cs);
         _value = val;
@@ -371,7 +373,6 @@ public:
         return _value == rhs._value;
     }
 
-    operator long() { return _value; }
     operator int()  { return _value; }
 };
 
@@ -620,9 +621,9 @@ public:
     void SetDiffFlag() { _isDiffDirectory = true; }
 
     void InitStats(int run);
-    long IncRun(int inc = 1);
-    long IncFailures(int inc = 1);
-    long IncDiffs();
+    int32 IncRun(int inc = 1);
+    int32 IncFailures(int inc = 1);
+    int32 IncDiffs();
 
     // Trigger update of directory state.
     void UpdateState();

--- a/bin/rl/rlmp.cpp
+++ b/bin/rl/rlmp.cpp
@@ -141,21 +141,21 @@ void CDirectory::InitStats(int num)
     NumVariationsRun = NumFailures = NumDiffs = 0;
 }
 
-long CDirectory::IncRun(int inc)
+int32 CDirectory::IncRun(int inc)
 {
     ::NumVariationsRun[RLS_TOTAL] += inc; // overall count
     ::NumVariationsRun[stat] += inc; // mode stat
     return NumVariationsRun += inc; // per directory count
 }
 
-long CDirectory::IncFailures(int inc)
+int32 CDirectory::IncFailures(int inc)
 {
     ::NumFailuresTotal[RLS_TOTAL] += inc; // overall count
     ::NumFailuresTotal[stat] += inc; // mode stat
     return NumFailures += inc; // per directory count
 }
 
-long CDirectory::IncDiffs()
+int32 CDirectory::IncDiffs()
 {
     ::NumDiffsTotal[RLS_TOTAL]++; // overall count
     ::NumDiffsTotal[stat]++; // mode stat

--- a/bin/rl/rlrun.cpp
+++ b/bin/rl/rlrun.cpp
@@ -1282,7 +1282,7 @@ int
     if (strTimeout) {
         char *end;
         _set_errno(0);
-        unsigned long secTimeout = strtoul(strTimeout, &end, 10);
+        uint32 secTimeout = strtoul(strTimeout, &end, 10);
         millisecTimeout = 1000 * secTimeout;
         // Validation has already occurred so this string should
         // parse fine and the value shouldn't overflow the DWORD.

--- a/lib/Backend/arm/EncoderMD.cpp
+++ b/lib/Backend/arm/EncoderMD.cpp
@@ -892,7 +892,7 @@ EncoderMD::GetForm(IR::Instr *instr, int32 size)
     return (form);
 }
 
-bool EncoderMD::EncodeImmediate16(long constant, DWORD * result)
+bool EncoderMD::EncodeImmediate16(int32 constant, DWORD * result)
 {
     if (constant > 0xFFFF)
     {
@@ -909,7 +909,7 @@ bool EncoderMD::EncodeImmediate16(long constant, DWORD * result)
 }
 
 ENCODE_32
-EncoderMD::EncodeT2Immediate12(ENCODE_32 encode, long constant)
+EncoderMD::EncodeT2Immediate12(ENCODE_32 encode, int32 constant)
 {
     Assert((constant & 0xFFFFF000) == 0);
 
@@ -987,7 +987,7 @@ EncoderMD::GenerateEncoding(IR::Instr* instr, IFORM iform, BYTE *pc, int32 size,
     bool fPost;
 
     int done = false;
-    long constant = 0; //UTC IVALTYPE
+    int32 constant = 0; //UTC IVALTYPE
     bool constantValid = false;
     RegNum regNum;
     unsigned int iType = 0, SFlag = 0;
@@ -1438,7 +1438,7 @@ EncoderMD::GenerateEncoding(IR::Instr* instr, IFORM iform, BYTE *pc, int32 size,
                         if (!constant)
                         {
                             BVUnit32 registers = opndRD->AsRegBVOpnd()->GetValue();
-                            unsigned long regenc;
+                            uint32 regenc;
                             BVIndex index = registers.GetNextBit();
 
                             // Note: only the wide encoding distinguishes between

--- a/lib/Backend/arm/EncoderMD.h
+++ b/lib/Backend/arm/EncoderMD.h
@@ -99,7 +99,7 @@ public:
     static bool     CanEncodeModConst12(DWORD constant);
     static bool     CanEncodeLoadStoreOffset(int32 offset) { return IS_CONST_UINT12(offset); }
     static void     BaseAndOffsetFromSym(IR::SymOpnd *symOpnd, RegNum *pBaseReg, int32 *pOffset, Func * func);
-    static bool     EncodeImmediate16(long constant, DWORD * result);
+    static bool     EncodeImmediate16(int32 constant, DWORD * result);
     static ENCODE_32  BranchOffset_T2_24(int x);
     void            EncodeInlineeCallInfo(IR::Instr *instr, uint32 offset);
 private:
@@ -127,7 +127,7 @@ private:
     bool            IsWideMemInstr(IR::Opnd * memOpnd, IR::RegOpnd * regOpnd);
     bool            IsWideAddSub(IR::Instr * instr);
 
-    static ENCODE_32 EncodeT2Immediate12(ENCODE_32 encode, long constant);
+    static ENCODE_32 EncodeT2Immediate12(ENCODE_32 encode, int32 constant);
     static bool     EncodeModConst12(DWORD constant, DWORD * result);
     static ENCODE_32 EncodeT2Offset(ENCODE_32 encode, IR::Instr *instr, int offset, int bitOffset);
 

--- a/lib/Backend/arm64/EncoderMD.cpp
+++ b/lib/Backend/arm64/EncoderMD.cpp
@@ -6,7 +6,7 @@
 #include "ARMEncode.h"
 
 bool
-EncoderMD::EncodeImmediate16(long constant, DWORD * result)
+EncoderMD::EncodeImmediate16(int32 constant, DWORD * result)
 {
     if (constant > 0xFFFF)
     {

--- a/lib/Backend/arm64/EncoderMD.h
+++ b/lib/Backend/arm64/EncoderMD.h
@@ -74,7 +74,7 @@ public:
     static bool     CanEncodeModConst12(DWORD constant) { __debugbreak(); return 0; }
     static bool     CanEncodeLoadStoreOffset(int32 offset) { __debugbreak(); return 0; }
     static void     BaseAndOffsetFromSym(IR::SymOpnd *symOpnd, RegNum *pBaseReg, int32 *pOffset, Func * func) { __debugbreak(); }
-    static bool     EncodeImmediate16(long constant, DWORD * result);
+    static bool     EncodeImmediate16(int32 constant, DWORD * result);
 
     void            EncodeInlineeCallInfo(IR::Instr *instr, uint32 offset) { __debugbreak(); }
 

--- a/lib/Common/Common.h
+++ b/lib/Common/Common.h
@@ -34,7 +34,7 @@ typedef _Return_type_success_(return >= 0) LONG NTSTATUS;
 namespace Js
 {
     typedef int32 PropertyId;
-    typedef unsigned long ModuleID;
+    typedef uint32 ModuleID;
 }
 
 #define IsTrueOrFalse(value)     ((value) ? _u("True") : _u("False"))

--- a/lib/Common/Common/NumberUtilities.cpp
+++ b/lib/Common/Common/NumberUtilities.cpp
@@ -332,15 +332,15 @@ namespace Js
     }
 
 
-    long NumberUtilities::LwFromDblNearest(double dbl)
+    int32 NumberUtilities::LwFromDblNearest(double dbl)
     {
         if (Js::NumberUtilities::IsNan(dbl))
             return 0;
         if (dbl > 0x7FFFFFFFL)
             return 0x7FFFFFFFL;
-        if (dbl < (long)0x80000000L)
-            return (long)0x80000000L;
-        return (long)dbl;
+        if (dbl < (int32)0x80000000L)
+            return (int32)0x80000000L;
+        return (int32)dbl;
     }
 
     uint32 NumberUtilities::LuFromDblNearest(double dbl)
@@ -354,12 +354,12 @@ namespace Js
         return (uint32)dbl;
     }
 
-    BOOL NumberUtilities::FDblIsLong(double dbl, long *plw)
+    BOOL NumberUtilities::FDblIsInt32(double dbl, int32 *plw)
     {
         AssertMem(plw);
         double dblT;
 
-        *plw = (long)dbl;
+        *plw = (int32)dbl;
         dblT = (double)*plw;
         return Js::NumberUtilities::LuHiDbl(dblT) == Js::NumberUtilities::LuHiDbl(dbl) && Js::NumberUtilities::LuLoDbl(dblT) == Js::NumberUtilities::LuLoDbl(dbl);
     }

--- a/lib/Common/Common/NumberUtilities.h
+++ b/lib/Common/Common/NumberUtilities.h
@@ -110,9 +110,9 @@ namespace Js
 
         static bool IsInSupplementaryPlane(codepoint_t codePointValue);
 
-        static long LwFromDblNearest(double dbl);
+        static int32 LwFromDblNearest(double dbl);
         static uint32 LuFromDblNearest(double dbl);
-        static BOOL FDblIsLong(double dbl, long *plw);
+        static BOOL FDblIsInt32(double dbl, int32 *plw);
 
         template<typename EncodedChar>
         static double DblFromHex(const EncodedChar *psz, const EncodedChar **ppchLim);

--- a/lib/Common/Common/NumberUtilities_strtod.cpp
+++ b/lib/Common/Common/NumberUtilities_strtod.cpp
@@ -10,8 +10,8 @@ namespace Js
 static inline BOOL FNzDigit(int ch)
 { return ch >= '1' && ch <= '9'; }
 
-static const long klwMaxExp10 = 310;     // Upper bound on base 10 exponent
-static const long klwMinExp10 = -325;    // Lower bound on base 10 exponent
+static const int32 klwMaxExp10 = 310;     // Upper bound on base 10 exponent
+static const int32 klwMinExp10 = -325;    // Lower bound on base 10 exponent
 static const int kcbMaxRgb = 50;
 static const int kcchMaxSig = 20;        // 20 significant digits. ECMA allows this.
 
@@ -24,7 +24,7 @@ static const double g_rgdblTens[] =
     1e20, 1e21, 1e22, 1e23, 1e24, 1e25, 1e26, 1e27, 1e28
 };
 
-static inline char16 ToDigit(long wVal)
+static inline char16 ToDigit(int32 wVal)
 {
     //return reinterpret_cast<char16>((wVal < 10) ? '0' + (ushort) wVal : 'a' - 10 + (ushort) wVal);
     return (ushort)((wVal < 10) ? '0' + (ushort) wVal : 'a' - 10 + (ushort) wVal);
@@ -83,7 +83,7 @@ struct BIGNUM
 
     // Set the value from decimal digits and decimal exponent
     template <typename EncodedChar>
-    void SetFromRgchExp(const EncodedChar *pch, long cch, long lwExp);
+    void SetFromRgchExp(const EncodedChar *pch, int32 cch, int32 lwExp);
 
     // Multiply by a BIGNUM
     void Mul(const BIGNUM *pnumOp);
@@ -130,7 +130,7 @@ struct BIGNUM
         uint32 luT = (m_luError + 1) >> 1;
 
         if (luT &&
-            !Js::NumberUtilities::AddLu(&m_lu0, (uint32)-(long)luT) &&
+            !Js::NumberUtilities::AddLu(&m_lu0, (uint32)-(int32)luT) &&
             !Js::NumberUtilities::AddLu(&m_lu1, 0xFFFFFFFF))
         {
             Js::NumberUtilities::AddLu(&m_lu2, 0xFFFFFFFF);
@@ -344,7 +344,7 @@ void BIGNUM::MulTenAdd(byte bAdd, uint32 *pluExtra)
 }
 
 template<typename EncodedChar>
-void BIGNUM::SetFromRgchExp(const EncodedChar *prgch, long cch, long lwExp)
+void BIGNUM::SetFromRgchExp(const EncodedChar *prgch, int32 cch, int32 lwExp)
 {
     Assert(cch > 0);
     AssertArrMemR(prgch, cch);
@@ -717,18 +717,18 @@ we adjust it to be exactly half way to the previous representable value
 and re-compare.
 ***************************************************************************/
 template <typename EncodedChar>
-static double AdjustDbl(double dbl, const EncodedChar *prgch, long cch, long lwExp)
+static double AdjustDbl(double dbl, const EncodedChar *prgch, int32 cch, int32 lwExp)
 {
     Js::BigInt biDec, biDbl;
-    long c2Dec, c2Dbl;
-    long c5Dec, c5Dbl;
+    int32 c2Dec, c2Dbl;
+    int32 c5Dec, c5Dbl;
     int wAddHi, wT;
-    long iT;
-    long wExp2;
+    int32 iT;
+    int32 wExp2;
     uint32 rglu[2];
     uint32 luT;
     BOOL f;
-    long clu;
+    int32 clu;
 
     if (!biDec.FInitFromDigits(prgch, cch, &cch))
         goto LFail;
@@ -913,14 +913,14 @@ double Js::NumberUtilities::StrToDbl( const EncodedChar *psz, const EncodedChar 
     // points to the first digit and pchLimDig points just past the last
     // digit. cchDig is the number of digits. pchLimDig - pchMinDig may be
     // cchDig + 1 (if there is a decimal point).
-    long cchDig = 0;
+    int32 cchDig = 0;
     const EncodedChar *pchMinDig = NULL;
     const EncodedChar *pchLimDig = NULL;
 
     int signExp = 1;    // sign of the exponent
     int signMan = 0;    // sign of the mantissa
-    long lwAdj = 0;        // exponent adjustment
-    long lwExp = 0;        // the exponent
+    int32 lwAdj = 0;        // exponent adjustment
+    int32 lwExp = 0;        // the exponent
 
     const EncodedChar *pchSave;
     const EncodedChar *pch = psz;
@@ -1071,7 +1071,7 @@ LEnd:
 
         // Here, we are going to consider that there are only kcchMaxSig digits (effectively the same as replacing excessive
         // digits with a '0' to make them insignificant, as the spec requests). So, the following need to be done:
-        const long numExcessiveDigits = cchDig - kcchMaxSig;
+        const int32 numExcessiveDigits = cchDig - kcchMaxSig;
 
         // Move pchLimDig to the left over numExcessiveDigits digits. Note that it needs to move over digits; the decimal point
         // does not count as a digit. We determine if pchLimDig would jump over the decimal point by using the lwAdj value and
@@ -1191,7 +1191,7 @@ LEnd:
 
     // Convert to a big number.
     Assert(pchLimDig - pchMinDig >= 0 && pchLimDig - pchMinDig <= LONG_MAX);
-    num.SetFromRgchExp(pchMinDig, (long)(pchLimDig - pchMinDig), lwExp);
+    num.SetFromRgchExp(pchMinDig, (int32)(pchLimDig - pchMinDig), lwExp);
 
     // If there is no error in the big number, just convert it to a double.
     if (0 == num.m_luError)
@@ -1199,7 +1199,7 @@ LEnd:
         dbl = num.GetDbl();
 #if DBG
         Assert(pchLimDig - pchMinDig >= 0 && pchLimDig - pchMinDig <= LONG_MAX);
-        dblLo = AdjustDbl(dbl, pchMinDig, (long)(pchLimDig - pchMinDig), lwExp);
+        dblLo = AdjustDbl(dbl, pchMinDig, (int32)(pchLimDig - pchMinDig), lwExp);
         Assert(dbl == dblLo);
 #endif //DBG
         goto LDone;
@@ -1220,7 +1220,7 @@ LEnd:
 #if DBG
         Assert(dbl == num.GetDbl());
         Assert(pchLimDig - pchMinDig >= 0 && pchLimDig - pchMinDig <= LONG_MAX);
-        dblLo = AdjustDbl(dbl, pchMinDig, (long)(pchLimDig - pchMinDig), lwExp);
+        dblLo = AdjustDbl(dbl, pchMinDig, (int32)(pchLimDig - pchMinDig), lwExp);
         Assert(dbl == dblLo || Js::NumberUtilities::IsNan(dblLo));
 #endif //DBG
         goto LDone;
@@ -1232,7 +1232,7 @@ LEnd:
     // x = 1.2345678901234568347913049445e+200;
     //
     Assert(pchLimDig - pchMinDig >= 0 && pchLimDig - pchMinDig <= LONG_MAX);
-    dbl = AdjustDbl(num.GetDbl(), pchMinDig, (long)(pchLimDig - pchMinDig), lwExp);
+    dbl = AdjustDbl(num.GetDbl(), pchMinDig, (int32)(pchLimDig - pchMinDig), lwExp);
 
 LDone:
     // This assert was removed because it would fire on VERY rare occasions. Not

--- a/lib/Common/DataStructures/BigInt.cpp
+++ b/lib/Common/DataStructures/BigInt.cpp
@@ -40,19 +40,19 @@ namespace Js
             free(m_prglu);
     }
 
-    long BigInt::Clu(void)
+    int32 BigInt::Clu(void)
     {
         return m_clu;
     }
 
-    uint32 BigInt::Lu(long ilu)
+    uint32 BigInt::Lu(int32 ilu)
     {
         AssertBi(this);
         Assert(ilu < m_clu);
         return m_prglu[ilu];
     }
 
-    bool BigInt::FResize(long clu)
+    bool BigInt::FResize(int32 clu)
     {
         AssertBiNoVal(this);
 
@@ -79,7 +79,7 @@ namespace Js
         return true;
     }
 
-    bool BigInt::FInitFromRglu(uint32 *prglu, long clu)
+    bool BigInt::FInitFromRglu(uint32 *prglu, int32 clu)
     {
         AssertBi(this);
         Assert(clu >= 0);
@@ -105,7 +105,7 @@ namespace Js
     }
 
     template <typename EncodedChar>
-    bool BigInt::FInitFromDigits(const EncodedChar *prgch, long cch, long *pcchDig)
+    bool BigInt::FInitFromDigits(const EncodedChar *prgch, int32 cch, int32 *pcchDig)
     {
         AssertBi(this);
         Assert(cch >= 0);
@@ -114,7 +114,7 @@ namespace Js
 
         uint32 luAdd;
         uint32 luMul;
-        long clu = (cch + 8) / 9;
+        int32 clu = (cch + 8) / 9;
         const EncodedChar *pchLim = prgch + cch;
 
         if (clu > m_cluMax && !FResize(clu))
@@ -174,13 +174,13 @@ LDone:
         return true;
     }
 
-    bool BigInt::FMulPow5(long c5)
+    bool BigInt::FMulPow5(int32 c5)
     {
         AssertBi(this);
         Assert(c5 >= 0);
 
         const uint32 k5to13 = 1220703125;
-        long clu = (c5 + 12) / 13;
+        int32 clu = (c5 + 12) / 13;
         uint32 luT;
 
         if (0 == m_clu || 0 == c5)
@@ -203,13 +203,13 @@ LDone:
         return true;
     }
 
-    bool BigInt::FShiftLeft(long cbit)
+    bool BigInt::FShiftLeft(int32 cbit)
     {
         AssertBi(this);
         Assert(cbit >= 0);
 
-        long ilu;
-        long clu;
+        int32 ilu;
+        int32 clu;
         uint32 luExtra;
 
         if (0 == cbit || 0 == m_clu)
@@ -243,7 +243,7 @@ LDone:
 
             if (clu > 0)
             {
-                // Shift the ulongs.
+                // Shift the uint32s.
                 memmove(m_prglu + clu, m_prglu, m_clu * sizeof(uint32));
                 memset(m_prglu, 0, clu * sizeof(uint32));
                 m_clu += clu;
@@ -258,7 +258,7 @@ LDone:
         return true;
     }
 
-    void BigInt::ShiftLusRight(long clu)
+    void BigInt::ShiftLusRight(int32 clu)
     {
         AssertBi(this);
         Assert(clu >= 0);
@@ -278,13 +278,13 @@ LDone:
         AssertBi(this);
     }
 
-    void BigInt::ShiftRight(long cbit)
+    void BigInt::ShiftRight(int32 cbit)
     {
         AssertBi(this);
         Assert(cbit >= 0);
 
-        long ilu;
-        long clu = cbit >> 5;
+        int32 ilu;
+        int32 clu = cbit >> 5;
         cbit &= 0x001F;
 
         if (clu > 0)
@@ -317,7 +317,7 @@ LDone:
         AssertBi(this);
         AssertBi(pbi);
 
-        long ilu;
+        int32 ilu;
 
         if (m_clu > pbi->m_clu)
             return 1;
@@ -344,8 +344,8 @@ LDone:
         AssertBi(pbi);
         Assert(this != pbi);
 
-        long cluMax, cluMin;
-        long ilu;
+        int32 cluMax, cluMin;
+        int32 ilu;
         int wCarry;
 
         if ((cluMax = m_clu) < (cluMin = pbi->m_clu))
@@ -397,7 +397,7 @@ LDone:
         AssertBi(pbi);
         Assert(this != pbi);
 
-        long ilu;
+        int32 ilu;
         int wCarry;
         uint32 luT;
 
@@ -449,7 +449,7 @@ LNegative:
         AssertBi(pbi);
         Assert(this != pbi);
 
-        long ilu, clu;
+        int32 ilu, clu;
         int wCarry;
         int wQuo;
         int wT;
@@ -515,7 +515,7 @@ LNegative:
         double dbl;
         uint32 luHi, luLo;
         uint32 lu1, lu2, lu3;
-        long ilu;
+        int32 ilu;
         int cbit;
 
         switch (m_clu)
@@ -591,6 +591,6 @@ LNegative:
         return dbl;
     }
 
-    template bool BigInt::FInitFromDigits<char16>(const char16 *prgch, long cch, long *pcchDig);
-    template bool BigInt::FInitFromDigits<utf8char_t>(const utf8char_t *prgch, long cch, long *pcchDig);
+    template bool BigInt::FInitFromDigits<char16>(const char16 *prgch, int32 cch, int32 *pcchDig);
+    template bool BigInt::FInitFromDigits<utf8char_t>(const utf8char_t *prgch, int32 cch, int32 *pcchDig);
 }

--- a/lib/Common/DataStructures/BigInt.h
+++ b/lib/Common/DataStructures/BigInt.h
@@ -15,13 +15,13 @@ namespace Js
         // Make this big enough that we rarely have to call malloc.
         enum { kcluMaxInit = 30 };
 
-        long m_cluMax;
-        long m_clu;
+        int32 m_cluMax;
+        int32 m_clu;
         uint32 *m_prglu;
         uint32 m_rgluInit[kcluMaxInit];
 
         inline BigInt & operator= (BigInt &bi);
-        bool FResize(long clu);
+        bool FResize(int32 clu);
 
 #if DBG
         #define AssertBi(pbi) Assert(pbi); (pbi)->AssertValid(true);
@@ -36,22 +36,22 @@ namespace Js
         BigInt(void);
         ~BigInt(void);
 
-        bool FInitFromRglu(uint32 *prglu, long clu);
+        bool FInitFromRglu(uint32 *prglu, int32 clu);
         bool FInitFromBigint(BigInt *pbiSrc);
         template <typename EncodedChar>
-        bool FInitFromDigits(const EncodedChar *prgch, long cch, long *pcchDec);
+        bool FInitFromDigits(const EncodedChar *prgch, int32 cch, int32 *pcchDec);
         bool FMulAdd(uint32 luMul, uint32 luAdd);
-        bool FMulPow5(long c5);
-        bool FShiftLeft(long cbit);
-        void ShiftLusRight(long clu);
-        void ShiftRight(long cbit);
+        bool FMulPow5(int32 c5);
+        bool FShiftLeft(int32 cbit);
+        void ShiftLusRight(int32 clu);
+        void ShiftRight(int32 cbit);
         int Compare(BigInt *pbi);
         bool FAdd(BigInt *pbi);
         void Subtract(BigInt *pbi);
         int DivRem(BigInt *pbi);
 
-        long Clu(void);
-        uint32 Lu(long ilu);
+        int32 Clu(void);
+        uint32 Lu(int32 ilu);
         double GetDbl(void);
     };
 }

--- a/lib/Parser/Alloc.cpp
+++ b/lib/Parser/Alloc.cpp
@@ -23,7 +23,7 @@ struct __ALIGN_FOO__ {
 
 #define AlignFull(VALUE) (~(~((VALUE) + (ALIGN_FULL-1)) | (ALIGN_FULL-1)))
 
-NoReleaseAllocator::NoReleaseAllocator(long cbFirst, long cbMax)
+NoReleaseAllocator::NoReleaseAllocator(int32 cbFirst, int32 cbMax)
     : m_pblkList(NULL)
     , m_ibCur(0)
     , m_ibMax(0)
@@ -42,19 +42,19 @@ NoReleaseAllocator::NoReleaseAllocator(long cbFirst, long cbMax)
     Assert((0 < cbMax  ) && (cbMax   < SHRT_MAX));
 }
 
-void * NoReleaseAllocator::Alloc(long cb)
+void * NoReleaseAllocator::Alloc(int32 cb)
 {
     Assert(cb > 0);
     if (cb <= 0)
         return NULL;
 
-    const long kcbHead = AlignFull(sizeof(NoReleaseAllocator::NraBlock));
+    const int32 kcbHead = AlignFull(sizeof(NoReleaseAllocator::NraBlock));
     void * pv;
 
     if (cb > m_ibMax - m_ibCur)
     {
-        long cbBlock;
-        long cbAlloc;
+        int32 cbBlock;
+        int32 cbAlloc;
         NraBlock * pblk;
 
         if (cb >= m_cbMaxBlock)
@@ -144,7 +144,7 @@ void * NoReleaseAllocator::Alloc(long cb)
 #endif //DEBUG
     pv = (byte *)m_pblkList + kcbHead + m_ibCur;
     DEBUG_TRASHMEM(pv, cb);
-    m_ibCur += (long)AlignFull(cb);
+    m_ibCur += (int32)AlignFull(cb);
     Assert(m_ibCur >= 0);
     return pv;
 }

--- a/lib/Parser/Alloc.h
+++ b/lib/Parser/Alloc.h
@@ -10,10 +10,10 @@ NoReleaseAllocator - allocator that never releases until it is destroyed
 class NoReleaseAllocator
 {
 public:
-    NoReleaseAllocator(long cbFirst = 256, long cbMax = 0x4000 /*16K*/);
+    NoReleaseAllocator(int32 cbFirst = 256, int32 cbMax = 0x4000 /*16K*/);
     ~NoReleaseAllocator(void) { FreeAll(); }
 
-    void *Alloc(long cb);
+    void *Alloc(int32 cb);
     void FreeAll();
     void Clear() { FreeAll(); }
 
@@ -24,16 +24,16 @@ private:
         // ... DATA ...
     };
     NraBlock * m_pblkList;
-    long m_ibCur;
-    long m_ibMax;
-    long m_cbMinBlock;
-    long m_cbMaxBlock;
+    int32 m_ibCur;
+    int32 m_ibMax;
+    int32 m_cbMinBlock;
+    int32 m_cbMaxBlock;
 
 #if DEBUG
-    long m_cbTotRequested;    // total bytes requested
-    long m_cbTotAlloced;    // total bytes allocated including headers
-    long m_cblk;            // number of blocks including big blocks
-    long m_cpvBig;            // each generates its own big block
-    long m_cpvSmall;        // put in a common block
+    int32 m_cbTotRequested;    // total bytes requested
+    int32 m_cbTotAlloced;    // total bytes allocated including headers
+    int32 m_cblk;            // number of blocks including big blocks
+    int32 m_cpvBig;            // each generates its own big block
+    int32 m_cpvSmall;        // put in a common block
 #endif //DEBUG
 };

--- a/lib/Parser/Hash.cpp
+++ b/lib/Parser/Hash.cpp
@@ -47,7 +47,7 @@ BOOL HashTbl::Init(uint cidHash)
     // cidHash must be a power of two
     Assert(cidHash > 0 && 0 == (cidHash & (cidHash - 1)));
 
-    long cb;
+    int32 cb;
 
     /* Allocate and clear the hash bucket table */
     m_luMask = cidHash - 1;
@@ -55,7 +55,7 @@ BOOL HashTbl::Init(uint cidHash)
 
     // (Bug 1117873 - Windows OS Bugs)
     // Prefast: Verify that cidHash * sizeof(Ident *) does not cause an integer overflow
-    // NoReleaseAllocator( ) takes long - so check for LONG_MAX
+    // NoReleaseAllocator( ) takes int32 - so check for LONG_MAX
     // Win8 730594 - Use intsafe function to check for overflow.
     uint cbTemp;
     if (FAILED(UIntMult(cidHash, sizeof(Ident *), &cbTemp)) || cbTemp > LONG_MAX)
@@ -86,7 +86,7 @@ void HashTbl::Grow()
     if (FAILED(UIntMult(n_cidHash, sizeof(Ident *), &cbTemp)) || cbTemp > LONG_MAX)
         // It is fine to exit early here, we will just have a potentially densely populated hash table
         return;
-    long cb = cbTemp;
+    int32 cb = cbTemp;
     uint n_luMask = n_cidHash - 1;
 
     IdentPtr *n_prgpidName = (IdentPtr *)m_noReleaseAllocator.Alloc(cb);
@@ -229,7 +229,7 @@ template IdentPtr HashTbl::PidHashNameLen<char>(char const * prgch, uint32 cch);
 template IdentPtr HashTbl::PidHashNameLen<char16>(char16 const * prgch, uint32 cch);
 
 template <typename CharType>
-IdentPtr HashTbl::PidHashNameLenWithHash(_In_reads_(cch) CharType const * prgch, long cch, uint32 luHash)
+IdentPtr HashTbl::PidHashNameLenWithHash(_In_reads_(cch) CharType const * prgch, int32 cch, uint32 luHash)
 {
     Assert(cch >= 0);
     AssertArrMemR(prgch, cch);
@@ -238,7 +238,7 @@ IdentPtr HashTbl::PidHashNameLenWithHash(_In_reads_(cch) CharType const * prgch,
     IdentPtr * ppid;
     IdentPtr pid;
     LONG cb;
-    long bucketCount;
+    int32 bucketCount;
 
 
 #if PROFILE_DICTIONARY
@@ -321,16 +321,16 @@ IdentPtr HashTbl::PidHashNameLenWithHash(_In_reads_(cch) CharType const * prgch,
 template <typename CharType>
 IdentPtr HashTbl::FindExistingPid(
     CharType const * prgch,
-    long cch,
+    int32 cch,
     uint32 luHash,
     IdentPtr **pppInsert,
-    long *pBucketCount
+    int32 *pBucketCount
 #if PROFILE_DICTIONARY
     , int& depth
 #endif
     )
 {
-    long bucketCount;
+    int32 bucketCount;
     IdentPtr pid;
     IdentPtr *ppid = &m_prgpidName[luHash & m_luMask];
 
@@ -362,25 +362,25 @@ IdentPtr HashTbl::FindExistingPid(
 }
 
 template IdentPtr HashTbl::FindExistingPid<utf8char_t>(
-    utf8char_t const * prgch, long cch, uint32 luHash, IdentPtr **pppInsert, long *pBucketCount
+    utf8char_t const * prgch, int32 cch, uint32 luHash, IdentPtr **pppInsert, int32 *pBucketCount
 #if PROFILE_DICTIONARY
     , int& depth
 #endif
     );
 template IdentPtr HashTbl::FindExistingPid<char>(
-    char const * prgch, long cch, uint32 luHash, IdentPtr **pppInsert, long *pBucketCount
+    char const * prgch, int32 cch, uint32 luHash, IdentPtr **pppInsert, int32 *pBucketCount
 #if PROFILE_DICTIONARY
     , int& depth
 #endif
     );
 template IdentPtr HashTbl::FindExistingPid<char16>(
-    char16 const * prgch, long cch, uint32 luHash, IdentPtr **pppInsert, long *pBucketCount
+    char16 const * prgch, int32 cch, uint32 luHash, IdentPtr **pppInsert, int32 *pBucketCount
 #if PROFILE_DICTIONARY
     , int& depth
 #endif
     );
 
-bool HashTbl::Contains(_In_reads_(cch) LPCOLESTR prgch, long cch)
+bool HashTbl::Contains(_In_reads_(cch) LPCOLESTR prgch, int32 cch)
 {
     uint32 luHash = CaseSensitiveComputeHashCch(prgch, cch);
 

--- a/lib/Parser/Hash.h
+++ b/lib/Parser/Hash.h
@@ -21,8 +21,8 @@ typedef StaticSymLen<0> StaticSym;
 /***************************************************************************
 Hashing functions. Definitions in core\hashfunc.cpp.
 ***************************************************************************/
-ULONG CaseSensitiveComputeHashCch(LPCOLESTR prgch, long cch);
-ULONG CaseSensitiveComputeHashCch(LPCUTF8 prgch, long cch);
+ULONG CaseSensitiveComputeHashCch(LPCOLESTR prgch, int32 cch);
+ULONG CaseSensitiveComputeHashCch(LPCUTF8 prgch, int32 cch);
 ULONG CaseInsensitiveComputeHash(LPCOLESTR posz);
 
 enum
@@ -327,16 +327,16 @@ public:
     template <typename CharType>
     IdentPtr PidHashNameLen(CharType const * psz, uint32 cch);
     template <typename CharType>
-    IdentPtr PidHashNameLenWithHash(_In_reads_(cch) CharType const * psz, long cch, uint32 luHash);
+    IdentPtr PidHashNameLenWithHash(_In_reads_(cch) CharType const * psz, int32 cch, uint32 luHash);
 
 
     template <typename CharType>
     inline IdentPtr FindExistingPid(
         CharType const * prgch,
-        long cch,
+        int32 cch,
         uint32 luHash,
         IdentPtr **pppInsert,
-        long *pBucketCount
+        int32 *pBucketCount
 #if PROFILE_DICTIONARY
         , int& depth
 #endif
@@ -346,7 +346,7 @@ public:
     tokens TkFromNameLenColor(_In_reads_(cch) LPCOLESTR prgch, uint32 cch);
     NoReleaseAllocator* GetAllocator() {return &m_noReleaseAllocator;}
 
-    bool Contains(_In_reads_(cch) LPCOLESTR prgch, long cch);
+    bool Contains(_In_reads_(cch) LPCOLESTR prgch, int32 cch);
 private:
 
     NoReleaseAllocator m_noReleaseAllocator;            // to allocate identifiers
@@ -378,15 +378,15 @@ private:
     uint CountAndVerifyItems(IdentPtr *buckets, uint bucketCount, uint mask);
 #endif
 
-    static bool CharsAreEqual(__in_z LPCOLESTR psz1, __in_ecount(cch2) LPCOLESTR psz2, long cch2)
+    static bool CharsAreEqual(__in_z LPCOLESTR psz1, __in_ecount(cch2) LPCOLESTR psz2, int32 cch2)
     {
         return memcmp(psz1, psz2, cch2 * sizeof(OLECHAR)) == 0;
     }
-    static bool CharsAreEqual(__in_z LPCOLESTR psz1, LPCUTF8 psz2, long cch2)
+    static bool CharsAreEqual(__in_z LPCOLESTR psz1, LPCUTF8 psz2, int32 cch2)
     {
         return utf8::CharsAreEqual(psz1, psz2, cch2, utf8::doAllowThreeByteSurrogates);
     }
-    static bool CharsAreEqual(__in_z LPCOLESTR psz1, __in_ecount(cch2) char const * psz2, long cch2)
+    static bool CharsAreEqual(__in_z LPCOLESTR psz1, __in_ecount(cch2) char const * psz2, int32 cch2)
     {
         while (cch2-- > 0)
         {
@@ -395,16 +395,16 @@ private:
         }
         return true;
     }
-    static void CopyString(__in_ecount(cch + 1) LPOLESTR psz1, __in_ecount(cch) LPCOLESTR psz2, long cch)
+    static void CopyString(__in_ecount(cch + 1) LPOLESTR psz1, __in_ecount(cch) LPCOLESTR psz2, int32 cch)
     {
         js_memcpy_s(psz1, cch * sizeof(OLECHAR), psz2, cch * sizeof(OLECHAR));
         psz1[cch] = 0;
     }
-    static void CopyString(__in_ecount(cch + 1) LPOLESTR psz1, LPCUTF8 psz2, long cch)
+    static void CopyString(__in_ecount(cch + 1) LPOLESTR psz1, LPCUTF8 psz2, int32 cch)
     {
         utf8::DecodeIntoAndNullTerminate(psz1, psz2, cch);
     }
-    static void CopyString(__in_ecount(cch + 1) LPOLESTR psz1, __in_ecount(cch) char const * psz2, long cch)
+    static void CopyString(__in_ecount(cch + 1) LPOLESTR psz1, __in_ecount(cch) char const * psz2, int32 cch)
     {
         while (cch-- > 0)
             *(psz1++) = *psz2++;

--- a/lib/Parser/HashFunc.cpp
+++ b/lib/Parser/HashFunc.cpp
@@ -16,7 +16,7 @@
  *  of the hash function so things don't go out of sync.
  */
 
-ULONG CaseSensitiveComputeHashCch(LPCOLESTR prgch, long cch)
+ULONG CaseSensitiveComputeHashCch(LPCOLESTR prgch, int32 cch)
 {
     ULONG luHash = 0;
 
@@ -25,7 +25,7 @@ ULONG CaseSensitiveComputeHashCch(LPCOLESTR prgch, long cch)
     return luHash;
 }
 
-ULONG CaseSensitiveComputeHashCch(LPCUTF8 prgch, long cch)
+ULONG CaseSensitiveComputeHashCch(LPCUTF8 prgch, int32 cch)
 {
     utf8::DecodeOptions options = utf8::doAllowThreeByteSurrogates;
     ULONG luHash = 0;
@@ -35,7 +35,7 @@ ULONG CaseSensitiveComputeHashCch(LPCUTF8 prgch, long cch)
     return luHash;
 }
 
-ULONG CaseSensitiveComputeHashCch(char const * prgch, long cch)
+ULONG CaseSensitiveComputeHashCch(char const * prgch, int32 cch)
 {
     ULONG luHash = 0;
 

--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -967,7 +967,7 @@ void Parser::RestorePidRefForSym(Symbol *sym)
     ref->SetSym(sym);
 }
 
-IdentPtr Parser::GenerateIdentPtr(__ecount(len) char16* name, long len)
+IdentPtr Parser::GenerateIdentPtr(__ecount(len) char16* name, int32 len)
 {
     return m_phtbl->PidHashNameLen(name,len);
 }
@@ -1213,7 +1213,7 @@ ParseNodePtr Parser::CreateStrNode(IdentPtr pid)
     return pnode;
 }
 
-ParseNodePtr Parser::CreateIntNode(long lw)
+ParseNodePtr Parser::CreateIntNode(int32 lw)
 {
     ParseNodePtr pnode = CreateNode(knopInt);
     pnode->sxInt.lw = lw;
@@ -1299,7 +1299,7 @@ ParseNodePtr Parser::CreateStrNodeWithScanner(IdentPtr pid)
     return pnode;
 }
 
-ParseNodePtr Parser::CreateIntNodeWithScanner(long lw)
+ParseNodePtr Parser::CreateIntNodeWithScanner(int32 lw)
 {
     Assert(!this->m_deferringAST);
     ParseNodePtr pnode = CreateNodeWithScanner<knopInt>();
@@ -3381,7 +3381,7 @@ ParseNodePtr Parser::ParsePostfixOperators(
                        !Js::TaggedInt::IsOverflow(uintValue)) // the optimization is not very useful if the number can't be represented as a TaggedInt
                     {
                         // No need to verify that uintValue != JavascriptArray::InvalidIndex since all nonnegative TaggedInts are valid indexes
-                        auto intNode = CreateIntNodeWithScanner(uintValue); // implicit conversion from uint32 to long
+                        auto intNode = CreateIntNodeWithScanner(uintValue); // implicit conversion from uint32 to int32
                         pnode->sxBin.pnode2 = intNode;
                     }
                     // Field optimization (see GlobOpt::KillLiveElems) checks for value being a Number,
@@ -4413,7 +4413,7 @@ ParseNodePtr Parser::ParseFncDecl(ushort flags, LPCOLESTR pNameHint, const bool 
     uint scopeCountNoAstSave = m_scopeCountNoAst;
     m_scopeCountNoAst = 0;
 
-    long* pAstSizeSave = m_pCurrentAstSize;
+    int32* pAstSizeSave = m_pCurrentAstSize;
     bool noStmtContext = false;
 
     if (fDeclaration)
@@ -5590,7 +5590,7 @@ bool Parser::FastScanFormalsAndBody()
                 if (tempCurlyDepth != (uint)-1)
                 {
                     ParseNodePtr pnodeFncSave = m_currentNodeFunc;
-                    long *pastSizeSave = m_pCurrentAstSize;
+                    int32 *pastSizeSave = m_pCurrentAstSize;
                     uint *pnestedCountSave = m_pnestedCount;
                     ParseNodePtr *ppnodeScopeSave = m_ppnodeScope;
                     ParseNodePtr *ppnodeExprScopeSave = m_ppnodeExprScope;
@@ -6268,7 +6268,7 @@ ParseNodePtr Parser::GenerateEmptyConstructor(bool extends)
         pnodeFnc->sxFnc.columnNumber = 0;
     }
 
-    long * pAstSizeSave = m_pCurrentAstSize;
+    int32 * pAstSizeSave = m_pCurrentAstSize;
     m_pCurrentAstSize = &(pnodeFnc->sxFnc.astSize);
 
     // Make this the current function.
@@ -6438,7 +6438,7 @@ void Parser::FinishFncNode(ParseNodePtr pnodeFnc)
 
     ParseNodePtr pnodeFncSave = m_currentNodeFunc;
     uint *pnestedCountSave = m_pnestedCount;
-    long* pAstSizeSave = m_pCurrentAstSize;
+    int32* pAstSizeSave = m_pCurrentAstSize;
 
     m_currentNodeFunc = pnodeFnc;
     m_pCurrentAstSize = & (pnodeFnc->sxFnc.astSize);
@@ -6581,7 +6581,7 @@ void Parser::FinishFncNode(ParseNodePtr pnodeFnc)
 void Parser::FinishFncDecl(ParseNodePtr pnodeFnc, LPCOLESTR pNameHint, ParseNodePtr *lastNodeRef)
 {
     LPCOLESTR name = NULL;
-    JS_ETW(long startAstSize = *m_pCurrentAstSize);
+    JS_ETW(int32 startAstSize = *m_pCurrentAstSize);
     if(IS_JS_ETW(EventEnabledJSCRIPT_PARSE_METHOD_START()) || PHASE_TRACE1(Js::DeferParsePhase))
     {
         name = GetFunctionName(pnodeFnc, pNameHint);
@@ -6620,7 +6620,7 @@ void Parser::FinishFncDecl(ParseNodePtr pnodeFnc, LPCOLESTR pNameHint, ParseNode
     //pnodeFnc->sxFnc.pnodeTmps = *m_ppnodeVar;
 
 #ifdef ENABLE_JS_ETW
-    long astSize = *m_pCurrentAstSize - startAstSize;
+    int32 astSize = *m_pCurrentAstSize - startAstSize;
     EventWriteJSCRIPT_PARSE_METHOD_STOP(m_sourceContextInfo->dwHostSourceContext, GetScriptContext(), pnodeFnc->sxFnc.functionId, astSize, m_parseType, name);
 #endif
 }
@@ -7383,7 +7383,7 @@ void Parser::TransformAsyncFncDeclAST(ParseNodePtr *pnodeBody, bool fLambda)
     uint scopeCountNoAstSave = m_scopeCountNoAst;
     m_scopeCountNoAst = 0;
 
-    long* pAstSizeSave = m_pCurrentAstSize;
+    int32* pAstSizeSave = m_pCurrentAstSize;
 
     pnodeFncSave = m_currentNodeFunc;
     pnodeDeferredFncSave = m_currentNodeDeferredFunc;
@@ -10128,7 +10128,7 @@ LNeedTerminator:
 
             // create a fake name for the catch var.
             const WCHAR *uniqueNameStr = _u("__ehobj");
-            IdentPtr uniqueName = m_phtbl->PidHashNameLen(uniqueNameStr, static_cast<long>(wcslen(uniqueNameStr)));
+            IdentPtr uniqueName = m_phtbl->PidHashNameLen(uniqueNameStr, static_cast<int32>(wcslen(uniqueNameStr)));
 
             pCatch->sxCatch.pnodeParam = CreateNameNode(uniqueName);
 
@@ -10711,7 +10711,7 @@ ParseNodePtr Parser::Parse(LPCUTF8 pszSrc, size_t offset, size_t length, charcou
     m_pscan->Scan();
 
     // Make the main 'knopProg' node
-    long initSize = 0;
+    int32 initSize = 0;
     m_pCurrentAstSize = &initSize;
     pnodeProg = CreateProgNodeWithScanner(isModuleSource);
     pnodeProg->grfpn = PNodeFlags::fpnNone;
@@ -11887,7 +11887,7 @@ void Parser::ParseDestructuredLiteralWithScopeSave(tokens declarationType,
     {
         m_currentNodeDeferredFunc = m_currentNodeFunc;
     }
-    long *pAstSizeSave = m_pCurrentAstSize;
+    int32 *pAstSizeSave = m_pCurrentAstSize;
     uint *pNestedCountSave = m_pnestedCount;
     ParseNodePtr *ppnodeScopeSave = m_ppnodeScope;
     ParseNodePtr *ppnodeExprScopeSave = m_ppnodeExprScope;
@@ -11895,7 +11895,7 @@ void Parser::ParseDestructuredLiteralWithScopeSave(tokens declarationType,
     ParseNodePtr newTempScope = nullptr;
     m_ppnodeScope = &newTempScope;
 
-    long newTempAstSize = 0;
+    int32 newTempAstSize = 0;
     m_pCurrentAstSize = &newTempAstSize;
 
     uint newTempNestedCount = 0;

--- a/lib/Parser/Parse.h
+++ b/lib/Parser/Parse.h
@@ -134,7 +134,7 @@ public:
     static IdentPtr PidFromNode(ParseNodePtr pnode);
 
     ParseNode* CopyPnode(ParseNode* pnode);
-    IdentPtr GenerateIdentPtr(__ecount(len) char16* name,long len);
+    IdentPtr GenerateIdentPtr(__ecount(len) char16* name,int32 len);
 
     ArenaAllocator *GetAllocator() { return &m_nodeAllocator;}
 
@@ -183,7 +183,7 @@ private:
     Core members.
     ***********************************************************************/
     ParseNodeAllocator m_nodeAllocator;
-    long        m_cactIdentToNodeLookup;
+    int32        m_cactIdentToNodeLookup;
     uint32       m_grfscr;
     size_t      m_length;             // source length in characters excluding comments and literals
     size_t      m_originalLength;             // source length in characters excluding comments and literals
@@ -215,8 +215,8 @@ private:
     __declspec(noreturn) void Error(HRESULT hr, charcount_t ichMin, charcount_t ichLim);
     __declspec(noreturn) static void OutOfMemory();
 
-    void GenerateCode(ParseNodePtr pnode, void *pvUser, long cbUser,
-        LPCOLESTR pszSrc, long cchSrc, LPCOLESTR pszTitle);
+    void GenerateCode(ParseNodePtr pnode, void *pvUser, int32 cbUser,
+        LPCOLESTR pszSrc, int32 cchSrc, LPCOLESTR pszTitle);
 
     void EnsureStackAvailable();
 
@@ -284,7 +284,7 @@ public:
 
     ParseNodePtr CreateNode(OpCode nop, charcount_t ichMin);
     ParseNodePtr CreateTriNode(OpCode nop, ParseNodePtr pnode1, ParseNodePtr pnode2, ParseNodePtr pnode3);
-    ParseNodePtr CreateIntNode(long lw);
+    ParseNodePtr CreateIntNode(int32 lw);
     ParseNodePtr CreateStrNode(IdentPtr pid);
 
     ParseNodePtr CreateUniNode(OpCode nop, ParseNodePtr pnodeOp);
@@ -348,7 +348,7 @@ private:
     template <OpCode nop> ParseNodePtr CreateNodeWithScanner();
     template <OpCode nop> ParseNodePtr CreateNodeWithScanner(charcount_t ichMin);
     ParseNodePtr CreateStrNodeWithScanner(IdentPtr pid);
-    ParseNodePtr CreateIntNodeWithScanner(long lw);
+    ParseNodePtr CreateIntNodeWithScanner(int32 lw);
     ParseNodePtr CreateProgNodeWithScanner(bool isModuleSource);
 
     static void InitNode(OpCode nop,ParseNodePtr pnode);
@@ -362,7 +362,7 @@ private:
     ParseNodePtr m_currentNodeProg; // current program
     DeferredFunctionStub *m_currDeferredStub;
     DeferredFunctionStub *m_prevSiblingDeferredStub;
-    long * m_pCurrentAstSize;
+    int32 * m_pCurrentAstSize;
     ParseNodePtr * m_ppnodeScope;  // function list tail
     ParseNodePtr * m_ppnodeExprScope; // function expression list tail
     ParseNodePtr * m_ppnodeVar;  // variable list tail
@@ -506,7 +506,7 @@ private:
         ParseNodePtr *m_ppnodeScopeSave;
         ParseNodePtr *m_ppnodeExprScopeSave;
         charcount_t m_funcInArraySave;
-        long *m_pCurrentAstSizeSave;
+        int32 *m_pCurrentAstSizeSave;
         uint m_funcInArrayDepthSave;
         uint m_nestedCountSave;
 #if DEBUG

--- a/lib/Parser/Scan.cpp
+++ b/lib/Parser/Scan.cpp
@@ -243,11 +243,11 @@ charcount_t Scanner<EncodingPolicy>::LineLength(EncodedCharPtr first, EncodedCha
 }
 
 template <typename EncodingPolicy>
-charcount_t Scanner<EncodingPolicy>::UpdateLine(long &line, EncodedCharPtr start, EncodedCharPtr last, charcount_t ichStart, charcount_t ichEnd)
+charcount_t Scanner<EncodingPolicy>::UpdateLine(int32 &line, EncodedCharPtr start, EncodedCharPtr last, charcount_t ichStart, charcount_t ichEnd)
 {
     EncodedCharPtr p = start;
     charcount_t ich = ichStart;
-    long current = line;
+    int32 current = line;
     charcount_t lastStart = ichStart;
 
     while (ich < ichEnd)
@@ -530,12 +530,12 @@ tokens Scanner<EncodingPolicy>::ScanIdentifierContinue(bool identifyKwds, bool f
         {
             // If there are no escape, that the main scan loop would have found the keyword already
             // So we can just assume it is an ID
-            DebugOnly(long cch = UnescapeToTempBuf(pchMin, p));
+            DebugOnly(int32 cch = UnescapeToTempBuf(pchMin, p));
             DebugOnly(tokens tk = m_phtbl->TkFromNameLen(m_tempChBuf.m_prgch, cch, IsStrictMode()));
             Assert(tk == tkID || (tk == tkYIELD && !m_fYieldIsKeyword) || (tk == tkAWAIT && !m_fAwaitIsKeyword));
             return tkID;
         }
-        long cch = UnescapeToTempBuf(pchMin, p);
+        int32 cch = UnescapeToTempBuf(pchMin, p);
         tokens tk = m_phtbl->TkFromNameLen(m_tempChBuf.m_prgch, cch, IsStrictMode());
         return (!m_fYieldIsKeyword && tk == tkYIELD) || (!m_fAwaitIsKeyword && tk == tkAWAIT) ? tkID : tk;
     }
@@ -545,7 +545,7 @@ tokens Scanner<EncodingPolicy>::ScanIdentifierContinue(bool identifyKwds, bool f
         // We always need to check TkFromNameLenColor because
         // the main Scan switch doesn't detect all non-keyword that needs coloring
         // (e.g. int)
-        long cch = UnescapeToTempBuf(pchMin, p);
+        int32 cch = UnescapeToTempBuf(pchMin, p);
         return m_phtbl->TkFromNameLenColor(m_tempChBuf.m_prgch, cch);
     }
 
@@ -556,11 +556,11 @@ tokens Scanner<EncodingPolicy>::ScanIdentifierContinue(bool identifyKwds, bool f
 
         // If there are no escape, that the main scan loop would have found the keyword already
         // So we can just assume it is an ID
-        DebugOnly(long cch = UnescapeToTempBuf(pchMin, p));
+        DebugOnly(int32 cch = UnescapeToTempBuf(pchMin, p));
         DebugOnly(tokens tk = m_phtbl->TkFromNameLen(m_tempChBuf.m_prgch, cch, IsStrictMode()));
         Assert(tk == tkID || (tk == tkYIELD && !m_fYieldIsKeyword) || (tk == tkAWAIT && !m_fAwaitIsKeyword));
 
-        m_ptoken->SetIdentifier(reinterpret_cast<const char *>(pchMin), (long)(p - pchMin));
+        m_ptoken->SetIdentifier(reinterpret_cast<const char *>(pchMin), (int32)(p - pchMin));
         return tkID;
     }
 
@@ -618,7 +618,7 @@ uint32 Scanner<EncodingPolicy>::UnescapeToTempBuf(EncodedCharPtr p, EncodedCharP
 template <typename EncodingPolicy>
 IdentPtr Scanner<EncodingPolicy>::PidOfIdentiferAt(EncodedCharPtr p, EncodedCharPtr last)
 {
-    long cch = UnescapeToTempBuf(p, last);
+    int32 cch = UnescapeToTempBuf(p, last);
     return m_phtbl->PidHashNameLen(m_tempChBuf.m_prgch, cch);
 }
 
@@ -635,12 +635,12 @@ IdentPtr Scanner<EncodingPolicy>::PidOfIdentiferAt(EncodedCharPtr p, EncodedChar
     else if (EncodingPolicy::MultiUnitEncoding)
     {
         Assert(sizeof(EncodedChar) == 1);
-        return m_phtbl->PidHashNameLen(reinterpret_cast<const char *>(p), (long)(last - p));
+        return m_phtbl->PidHashNameLen(reinterpret_cast<const char *>(p), (int32)(last - p));
     }
     else
     {
         Assert(sizeof(EncodedChar) == 2);
-        return m_phtbl->PidHashNameLen(reinterpret_cast< const char16 * >(p), (long)(last - p));
+        return m_phtbl->PidHashNameLen(reinterpret_cast< const char16 * >(p), (int32)(last - p));
     }
 }
 
@@ -1927,8 +1927,8 @@ LEof:
 
                 p = pchT;
 
-                long value;
-                if (likelyInt && Js::NumberUtilities::FDblIsLong(dbl, &value))
+                int32 value;
+                if (likelyInt && Js::NumberUtilities::FDblIsInt32(dbl, &value))
                 {
                     m_ptoken->SetLong(value);
                     token = tkIntCon;
@@ -2400,14 +2400,14 @@ IdentPtr Scanner<EncodingPolicy>::GetSecondaryBufferAsPid()
 }
 
 template <typename EncodingPolicy>
-LPCOLESTR Scanner<EncodingPolicy>::StringFromLong(long lw)
+LPCOLESTR Scanner<EncodingPolicy>::StringFromLong(int32 lw)
 {
     _ltow_s(lw, m_tempChBuf.m_prgch, m_tempChBuf.m_cchMax, 10);
     return m_tempChBuf.m_prgch;
 }
 
 template <typename EncodingPolicy>
-IdentPtr Scanner<EncodingPolicy>::PidFromLong(long lw)
+IdentPtr Scanner<EncodingPolicy>::PidFromLong(int32 lw)
 {
     return m_phtbl->PidHashName(StringFromLong(lw));
 }
@@ -2500,7 +2500,7 @@ void Scanner<EncodingPolicy>::SeekTo(const RestorePoint& restorePoint, uint *nex
 
 // Called by CompileScriptException::ProcessError to retrieve a BSTR for the line on which an error occurred.
 template<typename EncodingPolicy>
-HRESULT Scanner<EncodingPolicy>::SysAllocErrorLine(long ichMinLine, __out BSTR* pbstrLine)
+HRESULT Scanner<EncodingPolicy>::SysAllocErrorLine(int32 ichMinLine, __out BSTR* pbstrLine)
 {
     if( !pbstrLine )
     {

--- a/lib/Parser/Scan.h
+++ b/lib/Parser/Scan.h
@@ -26,9 +26,9 @@ private:
         {
             IdentPtr pid;
             const char * pchMin;
-            long length;
+            int32 length;
         };
-        long lw;
+        int32 lw;
         struct
         {
             double dbl;
@@ -68,7 +68,7 @@ public:
         return CreateIdentifier(hashTbl);
     }
 
-    long GetLong() const
+    int32 GetLong() const
     {
         Assert(tk == tkIntCon);
         return u.lw;
@@ -115,7 +115,7 @@ public:
 
     // UTF16 Scanner are only for syntax coloring.  Only support
     // defer pid creation for UTF8
-    void SetIdentifier(const char * pchMin, long len)
+    void SetIdentifier(const char * pchMin, int32 len)
     {
         this->u.pid = nullptr;
         this->u.pchMin = pchMin;
@@ -127,7 +127,7 @@ public:
         this->u.pchMin = nullptr;
     }
 
-    void SetLong(long value)
+    void SetLong(int32 value)
     {
         this->u.lw = value;
     }
@@ -293,8 +293,8 @@ typedef UTF8EncodingPolicyBase<false> NotNullTerminatedUTF8EncodingPolicy;
 
 interface IScanner
 {
-    virtual void GetErrorLineInfo(__out long& ichMin, __out long& ichLim, __out long& line, __out long& ichMinLine) = 0;
-    virtual HRESULT SysAllocErrorLine(long ichMinLine, __out BSTR* pbstrLine) = 0;
+    virtual void GetErrorLineInfo(__out int32& ichMin, __out int32& ichLim, __out int32& line, __out int32& ichMinLine) = 0;
+    virtual HRESULT SysAllocErrorLine(int32 ichMinLine, __out BSTR* pbstrLine) = 0;
 };
 
 // Flags that can be provided to the Scan functions.
@@ -406,10 +406,10 @@ public:
     {
         return m_fHadEol;
     }
-    IdentPtr PidFromLong(long lw);
+    IdentPtr PidFromLong(int32 lw);
     IdentPtr PidFromDbl(double dbl);
 
-    LPCOLESTR StringFromLong(long lw);
+    LPCOLESTR StringFromLong(int32 lw);
     LPCOLESTR StringFromDbl(double dbl);
 
     IdentPtr GetSecondaryBufferAsPid();
@@ -538,7 +538,7 @@ public:
     }
 
     // IScanner methods
-    virtual void GetErrorLineInfo(__out long& ichMin, __out long& ichLim, __out long& line, __out long& ichMinLine)
+    virtual void GetErrorLineInfo(__out int32& ichMin, __out int32& ichLim, __out int32& line, __out int32& ichMinLine)
     {
         ichMin = this->IchMinError();
         ichLim = this->IchLimError();
@@ -551,8 +551,8 @@ public:
         }
     }
 
-    virtual HRESULT SysAllocErrorLine(long ichMinLine, __out BSTR* pbstrLine);
-    charcount_t UpdateLine(long &line, EncodedCharPtr start, EncodedCharPtr last, charcount_t ichStart, charcount_t ichEnd);
+    virtual HRESULT SysAllocErrorLine(int32 ichMinLine, __out BSTR* pbstrLine);
+    charcount_t UpdateLine(int32 &line, EncodedCharPtr start, EncodedCharPtr last, charcount_t ichStart, charcount_t ichEnd);
     class TemporaryBuffer
     {
         friend Scanner<EncodingPolicy>;

--- a/lib/Parser/errstr.cpp
+++ b/lib/Parser/errstr.cpp
@@ -112,14 +112,14 @@ LError:
 }
 
 
-BOOL FGetResourceString(long isz, __out_ecount(cchMax) OLECHAR *psz, int cchMax)
+BOOL FGetResourceString(int32 isz, __out_ecount(cchMax) OLECHAR *psz, int cchMax)
 {
     return FGetStringFromLibrary((HINSTANCE)g_hInstance, isz, psz, cchMax);
 }
 
 // Get a bstr version of the error string
 __declspec(noinline) // Don't inline. This function needs 2KB stack.
-BSTR BstrGetResourceString(long isz)
+BSTR BstrGetResourceString(int32 isz)
 {
     // NOTE - isz is expected to be HRESULT
 

--- a/lib/Parser/errstr.h
+++ b/lib/Parser/errstr.h
@@ -4,5 +4,5 @@
 //-------------------------------------------------------------------------------------------------------
 #pragma once
 
-BOOL FGetResourceString(long isz, __out_ecount(cchMax) OLECHAR *psz, int cchMax);
-BSTR BstrGetResourceString(long isz);
+BOOL FGetResourceString(int32 isz, __out_ecount(cchMax) OLECHAR *psz, int cchMax);
+BSTR BstrGetResourceString(int32 isz);

--- a/lib/Parser/ptree.h
+++ b/lib/Parser/ptree.h
@@ -97,7 +97,7 @@ struct PnUniSlot : PnUni
 
 struct PnInt
 {
-    long lw;
+    int32 lw;
 };
 
 struct PnFlt
@@ -233,7 +233,7 @@ struct PnFnc
     uint16 firstDefaultArg; // Position of the first default argument, if any
 
     unsigned int fncFlags;
-    long astSize;
+    int32 astSize;
     size_t cbMin; // Min an Lim UTF8 offsets.
     size_t cbLim;
     ULONG lineNumber;   // Line number relative to the current source buffer of the function declaration.
@@ -245,7 +245,7 @@ struct PnFnc
     RestorePoint *pRestorePoint;
     DeferredFunctionStub *deferredStub;
 
-    static const long MaxStackClosureAST = 800000;
+    static const int32 MaxStackClosureAST = 800000;
 
 private:
     void SetFlags(uint flags, bool set)

--- a/lib/Parser/screrror.cpp
+++ b/lib/Parser/screrror.cpp
@@ -165,7 +165,7 @@ const MHR g_rgmhr[] =
     /*0x80080005*/ MAPHR(CO_E_SERVER_EXEC_FAILURE, VBSERR_CantCreateObject),
 #endif // _WIN32 || _WIN64
 };
-const long kcmhr = sizeof(g_rgmhr) / sizeof(g_rgmhr[0]);
+const int32 kcmhr = sizeof(g_rgmhr) / sizeof(g_rgmhr[0]);
 
 
 HRESULT MapHr(HRESULT hr, ErrorTypeEnum * errorTypeOut)

--- a/lib/Parser/screrror.h
+++ b/lib/Parser/screrror.h
@@ -35,8 +35,8 @@ class ActiveScriptError;
 class ScriptException
 {
 public:
-    long ichMin;
-    long ichLim;
+    int32 ichMin;
+    int32 ichLim;
     EXCEPINFO ei;
 
 public:
@@ -53,8 +53,8 @@ public:
 class CompileScriptException : public ScriptException
 {
 public:
-    long line;       // line number of error (zero based)
-    long ichMinLine; // starting char of the line
+    int32 line;       // line number of error (zero based)
+    int32 ichMinLine; // starting char of the line
     bool hasLineNumberInfo;
     // TODO: if the line contains \0 character the substring following \0 will not be included:
     BSTR bstrLine;   // source line (if available)

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -2751,7 +2751,7 @@ namespace Js
         return FALSE;
     }
 
-    void FunctionBody::FindClosestStatements(long characterOffset, StatementLocation *firstStatementLocation, StatementLocation *secondStatementLocation)
+    void FunctionBody::FindClosestStatements(int32 characterOffset, StatementLocation *firstStatementLocation, StatementLocation *secondStatementLocation)
     {
         auto statementMaps = this->GetStatementMaps();
         if (statementMaps)

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -2891,7 +2891,7 @@ namespace Js
         void ResetByteCodeGenState();
         void ResetByteCodeGenVisitState();
 
-        void FindClosestStatements(long characterOffset, StatementLocation *firstStatementLocation, StatementLocation *secondStatementLocation);
+        void FindClosestStatements(int32 characterOffset, StatementLocation *firstStatementLocation, StatementLocation *secondStatementLocation);
 #if ENABLE_NATIVE_CODEGEN
         const FunctionCodeGenRuntimeData *GetInlineeCodeGenRuntimeData(const ProfileId profiledCallSiteId) const;
         const FunctionCodeGenRuntimeData *GetInlineeCodeGenRuntimeDataForTargetInlinee(const ProfileId profiledCallSiteId, FunctionBody *inlineeFuncBody) const;

--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -240,7 +240,7 @@ namespace Js
         {
             return &projectionConfiguration;
         }
-        void SetHostType(long hostType) { this->HostType = hostType; }
+        void SetHostType(int32 hostType) { this->HostType = hostType; }
         void SetWinRTConstructorAllowed(bool allowed) { this->WinRTConstructorAllowed = allowed; }
         void SetProjectionTargetVersion(DWORD version)
         {
@@ -1058,7 +1058,7 @@ private:
         bool Close(bool inDestructor);
         void MarkForClose();
 #ifdef ENABLE_PROJECTION
-        void SetHostType(long hostType) { config.SetHostType(hostType); }
+        void SetHostType(int32 hostType) { config.SetHostType(hostType); }
         void SetWinRTConstructorAllowed(bool allowed) { config.SetWinRTConstructorAllowed(allowed); }
         void SetProjectionTargetVersion(DWORD version) { config.SetProjectionTargetVersion(version); }
 #endif

--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -1961,7 +1961,7 @@ void ThreadContext::ReleaseDebugManager()
     Assert(crefSContextForDiag > 0);
     Assert(this->debugManager != nullptr);
 
-    long lref = InterlockedDecrement(&crefSContextForDiag);
+    LONG lref = InterlockedDecrement(&crefSContextForDiag);
 
     if (lref == 0)
     {

--- a/lib/Runtime/Base/ThreadContext.h
+++ b/lib/Runtime/Base/ThreadContext.h
@@ -753,7 +753,7 @@ private:
     // Number of script context attached with probe manager.
     // This counter will be used as addref when the script context is created, this way we maintain the life of diagnostic object.
     // Once no script context available , diagnostic will go away.
-    long crefSContextForDiag;
+    LONG crefSContextForDiag;
 
     Entropy entropy;
 

--- a/lib/Runtime/ByteCode/AsmJsByteCodeWriter.cpp
+++ b/lib/Runtime/ByteCode/AsmJsByteCodeWriter.cpp
@@ -67,7 +67,7 @@ namespace Js
         return offset;
     }
 
-    void AsmJsByteCodeWriter::InitData(ArenaAllocator* alloc, long initCodeBufferSize)
+    void AsmJsByteCodeWriter::InitData(ArenaAllocator* alloc, int32 initCodeBufferSize)
     {
         ByteCodeWriter::InitData(alloc, initCodeBufferSize);
 #ifdef BYTECODE_BRANCH_ISLAND

--- a/lib/Runtime/ByteCode/AsmJsByteCodeWriter.h
+++ b/lib/Runtime/ByteCode/AsmJsByteCodeWriter.h
@@ -14,7 +14,7 @@ namespace Js
         using ByteCodeWriter::MarkLabel;
 
     public:
-        void InitData        ( ArenaAllocator* alloc, long initCodeBufferSize );
+        void InitData        ( ArenaAllocator* alloc, int32 initCodeBufferSize );
         void EmptyAsm        ( OpCodeAsmJs op );
         void Conv            ( OpCodeAsmJs op, RegSlot R0, RegSlot R1 );
         void AsmInt1Const1   ( OpCodeAsmJs op, RegSlot R0, int C1 );

--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -2713,7 +2713,7 @@ void ByteCodeGenerator::EmitProgram(ParseNode *pnodeProg)
     this->trackEnvDepth = true;
     AssignPropertyIds(pnodeProg->sxFnc.funcInfo->byteCodeFunction);
 
-    long initSize = this->maxAstSize / AstBytecodeRatioEstimate;
+    int32 initSize = this->maxAstSize / AstBytecodeRatioEstimate;
 
     // Use the temp allocator in bytecode write temp buffer.
     m_writer.InitData(this->alloc, initSize);
@@ -9567,7 +9567,7 @@ void Emit(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator, FuncInfo *func
         funcInfo->AcquireLoc(pnode);
         if (pnode->sxUni.pnode1->nop == knopInt)
         {
-            long value = pnode->sxUni.pnode1->sxInt.lw;
+            int32 value = pnode->sxUni.pnode1->sxInt.lw;
             Js::OpCode op = value ? Js::OpCode::LdFalse : Js::OpCode::LdTrue;
             byteCodeGenerator->Writer()->Reg1(op, pnode->location);
         }

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -1113,7 +1113,7 @@ FuncInfo * ByteCodeGenerator::StartBindGlobalStatements(ParseNode *pnode)
     FuncInfo *funcInfo = Anew(alloc, FuncInfo, Js::Constants::GlobalFunction,
         alloc, nullptr, globalScope, pnode, byteCodeFunction);
 
-    long currentAstSize = pnode->sxFnc.astSize;
+    int32 currentAstSize = pnode->sxFnc.astSize;
     if (currentAstSize > this->maxAstSize)
     {
         this->maxAstSize = currentAstSize;
@@ -1426,7 +1426,7 @@ FuncInfo * ByteCodeGenerator::StartBindFunction(const char16 *name, uint nameLen
         funcInfo->funcExprScope = funcExprScope;
     }
 
-    long currentAstSize = pnode->sxFnc.astSize;
+    int32 currentAstSize = pnode->sxFnc.astSize;
     if (currentAstSize > this->maxAstSize)
     {
         this->maxAstSize = currentAstSize;

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.h
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.h
@@ -3,9 +3,9 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #if defined(_M_ARM32_OR_ARM64) || defined(_M_X64)
-const long AstBytecodeRatioEstimate = 4;
+const int32 AstBytecodeRatioEstimate = 4;
 #else
-const long AstBytecodeRatioEstimate = 5;
+const int32 AstBytecodeRatioEstimate = 5;
 #endif
 
 class ByteCodeGenerator
@@ -26,7 +26,7 @@ private:
     // pointer to the root function wrapper that will be invoked by the caller
     Js::ParseableFunctionInfo * pRootFunc;
 
-    long maxAstSize;
+    int32 maxAstSize;
     uint16 envDepth;
     uint sourceIndex;
     uint dynamicScopeCount;

--- a/lib/Runtime/ByteCode/ByteCodeWriter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeWriter.cpp
@@ -20,7 +20,7 @@ namespace Js
         DebugOnly(isInUse = false);
     }
 
-    void ByteCodeWriter::InitData(ArenaAllocator* alloc, long initCodeBufferSize)
+    void ByteCodeWriter::InitData(ArenaAllocator* alloc, int32 initCodeBufferSize)
     {
         Assert(!isInUse);
         Assert(!isInitialized);
@@ -121,7 +121,7 @@ namespace Js
     ///
     ///----------------------------------------------------------------------------
 #ifdef LOG_BYTECODE_AST_RATIO
-    void ByteCodeWriter::End(long currentAstSize, long maxAstSize)
+    void ByteCodeWriter::End(int32 currentAstSize, int32 maxAstSize)
 #else
     void ByteCodeWriter::End()
 #endif

--- a/lib/Runtime/ByteCode/ByteCodeWriter.h
+++ b/lib/Runtime/ByteCode/ByteCodeWriter.h
@@ -229,10 +229,10 @@ namespace Js
 #endif
 
         void Create();
-        void InitData(ArenaAllocator* alloc, long initCodeBufferSize);
+        void InitData(ArenaAllocator* alloc, int32 initCodeBufferSize);
         void Begin(ByteCodeGenerator* byteCodeGenerator, FunctionBody* functionWrite, ArenaAllocator* alloc, bool doJitLoopBodies, bool hasLoop);
 #ifdef LOG_BYTECODE_AST_RATIO
-        void End(long currentAstSize, long maxAstSize);
+        void End(int32 currentAstSize, int32 maxAstSize);
 #else
         void End();
 #endif

--- a/lib/Runtime/ByteCode/OpCodesAsmJs.h
+++ b/lib/Runtime/ByteCode/OpCodesAsmJs.h
@@ -122,9 +122,9 @@ MACRO_WMS   ( Shr_Int                   , Int3         , None            ) // in
 MACRO_WMS   ( ShrU_Int                  , Int3         , None            ) // int32 Shift '>>>'(unsigned, truncate)
 
 // Unsigned int math
-MACRO_WMS   ( Mul_UInt                  , Int3         , None            ) // unsigned int32 Arithmetic '*'
-MACRO_WMS   ( Div_UInt                  , Int3         , None            ) // unsigned int32 Arithmetic '/'
-MACRO_WMS   ( Rem_UInt                  , Int3         , None            ) // unsigned int32 Arithmetic '%'
+MACRO_WMS   ( Mul_UInt                  , Int3         , None            ) // uint32 Arithmetic '*'
+MACRO_WMS   ( Div_UInt                  , Int3         , None            ) // uint32 Arithmetic '/'
+MACRO_WMS   ( Rem_UInt                  , Int3         , None            ) // uint32 Arithmetic '%'
 
 // Double math
 MACRO_WMS   ( Ld_Db                     , Double2       , None           ) // Sets a double from another double register
@@ -151,10 +151,10 @@ MACRO_WMS   ( CmEq_Int                  , Int3         , None            ) // in
 MACRO_WMS   ( CmNe_Int                  , Int3         , None            ) // int32 Comparison !=
 
 // Unsigned int comparisons
-MACRO_WMS   ( CmLt_UnInt                , Int3         , None            ) // unsigned int32 Comparison <
-MACRO_WMS   ( CmLe_UnInt                , Int3         , None            ) // unsigned int32 Comparison <=
-MACRO_WMS   ( CmGt_UnInt                , Int3         , None            ) // unsigned int32 Comparison >
-MACRO_WMS   ( CmGe_UnInt                , Int3         , None            ) // unsigned int32 Comparison >=
+MACRO_WMS   ( CmLt_UnInt                , Int3         , None            ) // uint32 Comparison <
+MACRO_WMS   ( CmLe_UnInt                , Int3         , None            ) // uint32 Comparison <=
+MACRO_WMS   ( CmGt_UnInt                , Int3         , None            ) // uint32 Comparison >
+MACRO_WMS   ( CmGe_UnInt                , Int3         , None            ) // uint32 Comparison >=
 
 // Double comparisons
 MACRO_WMS   ( CmLt_Db                   , Int1Double2   , None           ) // double Comparison <

--- a/lib/Runtime/Debug/DebugDocument.cpp
+++ b/lib/Runtime/Debug/DebugDocument.cpp
@@ -65,7 +65,7 @@ namespace Js
         return BreakpointProbeList::New(arena);
     }
 
-    HRESULT DebugDocument::SetBreakPoint(long ibos, BREAKPOINT_STATE breakpointState)
+    HRESULT DebugDocument::SetBreakPoint(int32 ibos, BREAKPOINT_STATE breakpointState)
     {
         ScriptContext* scriptContext = this->utf8SourceInfo->GetScriptContext();
 
@@ -158,7 +158,7 @@ namespace Js
         }
     }
 
-    BOOL DebugDocument::GetStatementSpan(long ibos, StatementSpan* pStatement)
+    BOOL DebugDocument::GetStatementSpan(int32 ibos, StatementSpan* pStatement)
     {
         StatementLocation statement;
         if (GetStatementLocation(ibos, &statement))
@@ -170,7 +170,7 @@ namespace Js
         return FALSE;
     }
 
-    FunctionBody * DebugDocument::GetFunctionBodyAt(long ibos)
+    FunctionBody * DebugDocument::GetFunctionBodyAt(int32 ibos)
     {
         StatementLocation location = {};
         if (GetStatementLocation(ibos, &location))
@@ -181,12 +181,12 @@ namespace Js
         return nullptr;
     }
 
-    BOOL DebugDocument::HasLineBreak(long _start, long _end)
+    BOOL DebugDocument::HasLineBreak(int32 _start, int32 _end)
     {
         return this->functionBody->HasLineBreak(_start, _end);
     }
 
-    BOOL DebugDocument::GetStatementLocation(long ibos, StatementLocation* plocation)
+    BOOL DebugDocument::GetStatementLocation(int32 ibos, StatementLocation* plocation)
     {
         if (ibos < 0)
         {

--- a/lib/Runtime/Debug/DebugDocument.h
+++ b/lib/Runtime/Debug/DebugDocument.h
@@ -6,8 +6,8 @@
 
 struct StatementSpan
 {
-    long ich;
-    long cch;
+    int32 ich;
+    int32 cch;
 };
 
 // A Document in Engine means a file, eval code or new function code. For each of these there is a Utf8SourceInfo.
@@ -22,12 +22,12 @@ namespace Js
         ~DebugDocument();
         virtual void CloseDocument();
 
-        HRESULT SetBreakPoint(long ibos, BREAKPOINT_STATE bps);
+        HRESULT SetBreakPoint(int32 ibos, BREAKPOINT_STATE bps);
         void RemoveBreakpointProbe(BreakpointProbe *probe);
         void ClearAllBreakPoints(void);
 
-        BOOL GetStatementSpan(long ibos, StatementSpan* pBos);
-        BOOL GetStatementLocation(long ibos, StatementLocation* plocation);
+        BOOL GetStatementSpan(int32 ibos, StatementSpan* pBos);
+        BOOL GetStatementLocation(int32 ibos, StatementLocation* plocation);
 
         virtual bool HasDocumentText() const
         {
@@ -40,7 +40,7 @@ namespace Js
             return nullptr;
         };
 
-        Js::FunctionBody * GetFunctionBodyAt(long ibos);
+        Js::FunctionBody * GetFunctionBodyAt(int32 ibos);
 
     private:
         Utf8SourceInfo* utf8SourceInfo;
@@ -50,6 +50,6 @@ namespace Js
         BreakpointProbeList* NewBreakpointList(ArenaAllocator* arena);
         BreakpointProbeList* GetBreakpointList();
 
-        BOOL HasLineBreak(long _start, long _end);
+        BOOL HasLineBreak(int32 _start, int32 _end);
     };
 }

--- a/lib/Runtime/Debug/DiagObjectModel.cpp
+++ b/lib/Runtime/Debug/DiagObjectModel.cpp
@@ -1252,7 +1252,7 @@ namespace Js
         }
 
         // In the case of not making groups, all variables will be arranged
-        // as one long list in the locals window.
+        // as one int32 list in the locals window.
         if (!ShouldMakeGroups())
         {
             for (int j = 0; j < pVarWalkers->Count(); j++)
@@ -1922,7 +1922,7 @@ namespace Js
             }
 
             // For fractional values, radix is ignored.
-            long l = (long)value;
+            int32 l = (int32)value;
             bool isZero = JavascriptNumber::IsZero(value - (double)l);
 
             if (radix == 10 || !isZero)
@@ -1944,7 +1944,7 @@ namespace Js
                     if (value < 0)
                     {
                         // On the tools side we show unsigned value.
-                        uint32 ul = (uint32)(long)value; // ARM: casting negative value to uint32 gives 0
+                        uint32 ul = static_cast<uint32>(static_cast<int32>(value)); // ARM: casting negative value to uint32 gives 0
                         value = (double)ul;
                     }
                     valueStr = Js::JavascriptString::Concat(scriptContext->GetLibrary()->CreateStringFromCppLiteral(_u("0x")),

--- a/lib/Runtime/Language/AsmJsByteCodeGenerator.cpp
+++ b/lib/Runtime/Language/AsmJsByteCodeGenerator.cpp
@@ -96,7 +96,7 @@ namespace Js
     {
         mWriter.Create();
 
-        const long astSize = func->GetFncNode()->sxFnc.astSize/AstBytecodeRatioEstimate;
+        const int32 astSize = func->GetFncNode()->sxFnc.astSize/AstBytecodeRatioEstimate;
         // Use the temp allocator in bytecode write temp buffer.
         mWriter.InitData(&mAllocator, astSize);
 
@@ -1547,7 +1547,7 @@ namespace Js
                             // f4shuffle(v1, v2, [0-7], [0-7], [0-7], [0-7])
                             // f4swizzle(v1, [0-3], [0-3], [0-3], [0-3])
                             bool valid = true;
-                            long laneValue = (int) arg->sxInt.lw;
+                            int32 laneValue = (int) arg->sxInt.lw;
                             int argPos = i;
 
                             switch (simdFunc->GetSimdBuiltInFunction())

--- a/lib/Runtime/Language/AsmJsModule.h
+++ b/lib/Runtime/Language/AsmJsModule.h
@@ -190,7 +190,7 @@ namespace Js {
         AsmJsModuleMemory               mModuleMemory;
         AsmJsCompileTime                mCompileTime;
         AsmJsCompileTime                mCompileTimeLastTick;
-        long                            mMaxAstSize;
+        int32                            mMaxAstSize;
         BVStatic<ASMMATH_BUILTIN_SIZE>  mAsmMathBuiltinUsedBV;
         BVStatic<ASMARRAY_BUILTIN_SIZE> mAsmArrayBuiltinUsedBV;
         AsmJsCompileTime                mPhaseCompileTime[AsmJsCompilation::Phases_COUNT];
@@ -234,8 +234,8 @@ namespace Js {
         inline ParseNode *GetModuleFunctionNode() const{return mModuleFunctionNode;}
 
         inline ArenaAllocator* GetAllocator() {return &mAllocator;}
-        inline long GetMaxAstSize() const{return mMaxAstSize;}
-        inline void UpdateMaxAstSize( long val ){mMaxAstSize = val>mMaxAstSize?val:mMaxAstSize;}
+        inline int32 GetMaxAstSize() const{return mMaxAstSize;}
+        inline void UpdateMaxAstSize( int32 val ){mMaxAstSize = val>mMaxAstSize?val:mMaxAstSize;}
 
         //Mutable interface
         inline void InitModuleName( PropertyName name ){mModuleFunctionName = name;}

--- a/lib/Runtime/Language/DynamicProfileStorage.cpp
+++ b/lib/Runtime/Language/DynamicProfileStorage.cpp
@@ -18,7 +18,7 @@ char16 DynamicProfileStorage::catalogFilename[_MAX_PATH];
 CriticalSection DynamicProfileStorage::cs;
 DynamicProfileStorage::InfoMap DynamicProfileStorage::infoMap(&NoCheckHeapAllocator::Instance);
 DWORD DynamicProfileStorage::creationTime = 0;
-long DynamicProfileStorage::lastOffset = 0;
+int32 DynamicProfileStorage::lastOffset = 0;
 DWORD const DynamicProfileStorage::MagicNumber = 20100526;
 DWORD const DynamicProfileStorage::FileFormatVersion = 2;
 DWORD DynamicProfileStorage::nextFileId = 0;
@@ -46,9 +46,9 @@ public:
 
     bool WriteUtf8String(char16 const * str);
 
-    bool Seek(long offset);
+    bool Seek(int32 offset);
     bool SeekToEnd();
-    long Size();
+    int32 Size();
     void Close(bool deleteFile = false);
 
 private:
@@ -92,7 +92,7 @@ template <typename T>
 bool DynamicProfileStorageReaderWriter::ReadArray(T * t, size_t len)
 {
     Assert(file);
-    long pos = ftell(file);
+    int32 pos = ftell(file);
     if (fread(t, sizeof(T), len, file) != len)
     {
         Output::Print(_u("ERROR: DynamicProfileStorage: '%s': File corrupted at %d\n"), filename, pos);
@@ -175,7 +175,7 @@ bool DynamicProfileStorageReaderWriter::WriteUtf8String(char16 const * str)
     return success;
 }
 
-bool DynamicProfileStorageReaderWriter::Seek(long offset)
+bool DynamicProfileStorageReaderWriter::Seek(int32 offset)
 {
     Assert(file);
     return fseek(file, offset, SEEK_SET) == 0;
@@ -187,12 +187,12 @@ bool DynamicProfileStorageReaderWriter::SeekToEnd()
     return fseek(file, 0, SEEK_END) == 0;
 }
 
-long DynamicProfileStorageReaderWriter::Size()
+int32 DynamicProfileStorageReaderWriter::Size()
 {
     Assert(file);
-    long current = ftell(file);
+    int32 current = ftell(file);
     SeekToEnd();
-    long end = ftell(file);
+    int32 end = ftell(file);
     fseek(file, current, SEEK_SET);
     return end;
 }
@@ -235,7 +235,7 @@ char const * DynamicProfileStorage::StorageInfo::ReadRecord() const
         return nullptr;
     }
 
-    long size = reader.Size();
+    int32 size = reader.Size();
     char * record = AllocRecord(size);
     if (record == nullptr)
     {

--- a/lib/Runtime/Language/DynamicProfileStorage.h
+++ b/lib/Runtime/Language/DynamicProfileStorage.h
@@ -51,7 +51,7 @@ private:
     static DWORD const MagicNumber;
     static DWORD const FileFormatVersion;
     static DWORD creationTime;
-    static long lastOffset;
+    static int32 lastOffset;
     static HANDLE mutex;
     static CriticalSection cs;
     static DWORD nextFileId;

--- a/lib/Runtime/Language/JavascriptConversion.cpp
+++ b/lib/Runtime/Language/JavascriptConversion.cpp
@@ -558,7 +558,7 @@ CommonNumber:
         {
             ScriptContext *const scriptContext = recyclableObject->GetScriptContext();
 
-            long hCode;
+            int32 hCode;
 
             switch (hint)
             {

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -8973,7 +8973,7 @@ CommonNumber:
             }
             if (descriptor->WritableSpecified())
             {
-                long hCode = descriptor->IsWritable() ? JSERR_InvalidAttributeTrue : JSERR_InvalidAttributeFalse;
+                int32 hCode = descriptor->IsWritable() ? JSERR_InvalidAttributeTrue : JSERR_InvalidAttributeFalse;
                 JavascriptError::ThrowTypeError(scriptContext, hCode, _u("writable"));
             }
         }
@@ -9113,7 +9113,7 @@ CommonNumber:
         }
     }
 
-    BOOL JavascriptOperators::Reject(bool throwOnError, ScriptContext* scriptContext, long errorCode, PropertyId propertyId)
+    BOOL JavascriptOperators::Reject(bool throwOnError, ScriptContext* scriptContext, int32 errorCode, PropertyId propertyId)
     {
         Assert(scriptContext);
 

--- a/lib/Runtime/Language/JavascriptOperators.h
+++ b/lib/Runtime/Language/JavascriptOperators.h
@@ -28,8 +28,8 @@ namespace Js
         if (errorObject != nullptr && Js::JavascriptError::Is(errorObject)) \
         { \
             HRESULT hr = Js::JavascriptError::GetRuntimeError(Js::RecyclableObject::FromVar(errorObject), nullptr); \
-            if (JavascriptError::GetErrorNumberFromResourceID(JSERR_Property_CannotGet_NullOrUndefined) == (long)hr \
-                || JavascriptError::GetErrorNumberFromResourceID(JSERR_UseBeforeDeclaration) == (long)hr) \
+            if (JavascriptError::GetErrorNumberFromResourceID(JSERR_Property_CannotGet_NullOrUndefined) == (int32)hr \
+                || JavascriptError::GetErrorNumberFromResourceID(JSERR_UseBeforeDeclaration) == (int32)hr) \
             { \
                 if (scriptContext->IsScriptContextInDebugMode()) \
                 { \
@@ -623,7 +623,7 @@ namespace Js
         static Var NewScObjectHostDispatchOrProxy(RecyclableObject * function, ScriptContext * requestContext);
         static Var NewScObjectCommon(RecyclableObject * functionObject, FunctionInfo * functionInfo, ScriptContext * scriptContext, bool isBaseClassConstructorNewScObject = false);
 
-        static BOOL Reject(bool throwOnError, ScriptContext* scriptContext, long errorCode, PropertyId propertyId);
+        static BOOL Reject(bool throwOnError, ScriptContext* scriptContext, int32 errorCode, PropertyId propertyId);
         static bool AreSamePropertyDescriptors(const PropertyDescriptor* x, const PropertyDescriptor* y, ScriptContext* scriptContext);
         static Var CanonicalizeAccessor(Var accessor, ScriptContext* scriptContext);
 

--- a/lib/Runtime/Language/ModuleRecordBase.h
+++ b/lib/Runtime/Language/ModuleRecordBase.h
@@ -21,7 +21,7 @@ namespace Js
     class ModuleRecordBase : public FinalizableObject
     {
     public:
-        const unsigned long ModuleMagicNumber = *(const unsigned long*)"Mode";
+        const uint32 ModuleMagicNumber = *(const uint32*)"Mode";
         ModuleRecordBase(JavascriptLibrary* library) :
             namespaceObject(nullptr), wasEvaluated(false),
             javascriptLibrary(library),  magicNumber(ModuleMagicNumber){};
@@ -40,7 +40,7 @@ namespace Js
         virtual bool IsSourceTextModuleRecord() { return false; }
 
     protected:
-        unsigned long magicNumber;
+        uint32 magicNumber;
         ModuleNamespace* namespaceObject;
         bool wasEvaluated;
         JavascriptLibrary* javascriptLibrary;

--- a/lib/Runtime/Language/SourceTextModuleRecord.cpp
+++ b/lib/Runtime/Language/SourceTextModuleRecord.cpp
@@ -71,7 +71,7 @@ namespace Js
         }
     }
 
-    HRESULT SourceTextModuleRecord::ParseSource(__in_bcount(sourceLength) byte* sourceText, unsigned long sourceLength, SRCINFO * srcInfo, Var* exceptionVar, bool isUtf8)
+    HRESULT SourceTextModuleRecord::ParseSource(__in_bcount(sourceLength) byte* sourceText, uint32 sourceLength, SRCINFO * srcInfo, Var* exceptionVar, bool isUtf8)
     {
         Assert(!wasParsed);
         Assert(parser == nullptr);
@@ -857,7 +857,7 @@ namespace Js
     }
 
 #if DBG
-    void SourceTextModuleRecord::AddParent(SourceTextModuleRecord* parentRecord, LPCWSTR specifier, unsigned long specifierLength)
+    void SourceTextModuleRecord::AddParent(SourceTextModuleRecord* parentRecord, LPCWSTR specifier, uint32 specifierLength)
     {
 
     }

--- a/lib/Runtime/Language/SourceTextModuleRecord.h
+++ b/lib/Runtime/Language/SourceTextModuleRecord.h
@@ -56,7 +56,7 @@ namespace Js
         void SetrequestedModuleList(IdentPtrList* requestModules) { requestedModuleList = requestModules; }
 
         ScriptContext* GetScriptContext() const { return scriptContext; }
-        HRESULT ParseSource(__in_bcount(sourceLength) byte* sourceText, unsigned long sourceLength, SRCINFO * srcInfo, Var* exceptionVar, bool isUtf8);
+        HRESULT ParseSource(__in_bcount(sourceLength) byte* sourceText, uint32 sourceLength, SRCINFO * srcInfo, Var* exceptionVar, bool isUtf8);
         HRESULT OnHostException(void* errorVar);
 
         static SourceTextModuleRecord* FromHost(void* hostModuleRecord)
@@ -75,7 +75,7 @@ namespace Js
 
         SourceTextModuleRecord* GetChildModuleRecord(LPCOLESTR specifier) const;
 #if DBG
-        void AddParent(SourceTextModuleRecord* parentRecord, LPCWSTR specifier, unsigned long specifierLength);
+        void AddParent(SourceTextModuleRecord* parentRecord, LPCWSTR specifier, uint32 specifierLength);
 #endif
 
         Utf8SourceInfo* GetSourceInfo() { return this->pSourceInfo; }

--- a/lib/Runtime/Library/DateImplementation.cpp
+++ b/lib/Runtime/Library/DateImplementation.cpp
@@ -34,7 +34,7 @@ namespace Js {
         const char16 *psz;      // string
         short cch;              // length of string
         short szst;             // type of entry
-        long lwVal;             // value
+        int32 lwVal;             // value
     };
 
     BEGIN_ENUM_BYTE(ParseStringTokenType)
@@ -109,7 +109,7 @@ namespace Js {
 #undef szst
 #undef Szs
     };
-    const long kcszs = sizeof(g_rgszs) / sizeof(SZS);
+    const int32 kcszs = sizeof(g_rgszs) / sizeof(SZS);
 
     // Moved DaylightTimeHelper to common.lib to share with hybrid debugging, but this function depends on runtime.
     bool DaylightTimeHelper::ForceOldDateAPIFlag()
@@ -415,7 +415,7 @@ namespace Js {
             const charcount_t cchWritten = NumberUtilities::UInt16ToString(value, buffer, charCapacity, 2);
             Assert(cchWritten != 0);
         };
-        const auto ConvertLongToString = [](const long value, char16 *const buffer, const CharCount charCapacity)
+        const auto ConvertLongToString = [](const int32 value, char16 *const buffer, const CharCount charCapacity)
         {
             const errno_t err = _ltow_s(value, buffer, charCapacity, 10);
             Assert(err == 0);
@@ -1072,18 +1072,18 @@ Error:
         char16 ch;
         char16 *pszSrc = nullptr;
 
-        const long lwNil = 0x80000000;
-        long cch;
-        long depth;
-        long lwT;
-        long lwYear = lwNil;
-        long lwMonth = lwNil;
-        long lwDate = lwNil;
-        long lwTime = lwNil;
-        long lwZone = lwNil;
-        long lwOffset = lwNil;
+        const int32 lwNil = 0x80000000;
+        int32 cch;
+        int32 depth;
+        int32 lwT;
+        int32 lwYear = lwNil;
+        int32 lwMonth = lwNil;
+        int32 lwDate = lwNil;
+        int32 lwTime = lwNil;
+        int32 lwZone = lwNil;
+        int32 lwOffset = lwNil;
 
-        long ss = ssNil;
+        int32 ss = ssNil;
         const SZS *pszs;
 
         bool fUtc;
@@ -1165,7 +1165,7 @@ Error:
                 for ( ; !FBig(*pch) && (isalpha(*pch) || '.' == *pch); pch++)
                     ;
 
-                cch = (long)(pch - pchBase);
+                cch = (int32)(pch - pchBase);
 
                 if ('.' == pchBase[cch - 1])
                 {
@@ -1199,11 +1199,11 @@ Error:
                         {
                             goto LError;
                         }
-                        lwZone = -(long)(ch - 'a' + (ch < 'j')) * 60;
+                        lwZone = -(int32)(ch - 'a' + (ch < 'j')) * 60;
                     }
                     else if (ch <= 'y')
                     {
-                        lwZone = (long)(ch - 'm') * 60;
+                        lwZone = (int32)(ch - 'm') * 60;
                     }
                     else if (ch == 'z')
                     {

--- a/lib/Runtime/Library/DateImplementation.h
+++ b/lib/Runtime/Library/DateImplementation.h
@@ -81,9 +81,9 @@ namespace Js {
 
 #ifdef ENABLE_GLOBALIZATION
         template <class ScriptContext>
-        static long GetDaylightBias(const TIME_ZONE_INFORMATION *const pTz, const ScriptContext *const scriptContext);
+        static int32 GetDaylightBias(const TIME_ZONE_INFORMATION *const pTz, const ScriptContext *const scriptContext);
         template <class ScriptContext>
-        static long GetStandardBias(const TIME_ZONE_INFORMATION *const pTz, const ScriptContext *const scriptContext);
+        static int32 GetStandardBias(const TIME_ZONE_INFORMATION *const pTz, const ScriptContext *const scriptContext);
 #endif
 
         template <class ScriptContext>
@@ -289,7 +289,7 @@ namespace Js {
         Js::YMD                 m_ymdUtc;
         Js::YMD                 m_ymdLcl;
         TZD                     m_tzd;
-        unsigned long           m_grfval; // Which fields are valid. m_tvUtc is always valid.
+        uint32           m_grfval; // Which fields are valid. m_tvUtc is always valid.
         ScriptContext *         m_scriptContext;
         bool                    m_modified : 1; // Whether SetDateData was called on this class
 
@@ -302,7 +302,7 @@ namespace Js {
     /// Gets the daylight bias to use, in minutes. (Shared with hybrid debugging, which may use a fake scriptContext.)
     ///
     template <class ScriptContext>
-    long DateImplementation::GetDaylightBias(const TIME_ZONE_INFORMATION *const pTz, const ScriptContext *const scriptContext)
+    int32 DateImplementation::GetDaylightBias(const TIME_ZONE_INFORMATION *const pTz, const ScriptContext *const scriptContext)
     {
         Assert(pTz);
         Assert(scriptContext);
@@ -313,7 +313,7 @@ namespace Js {
     /// Gets the standard bias to use, in minutes. (Shared with hybrid debugging, which may use a fake scriptContext.)
     ///
     template <class ScriptContext>
-    long DateImplementation::GetStandardBias(const TIME_ZONE_INFORMATION *const pTz, const ScriptContext *const scriptContext)
+    int32 DateImplementation::GetStandardBias(const TIME_ZONE_INFORMATION *const pTz, const ScriptContext *const scriptContext)
     {
         Assert(pTz);
         Assert(scriptContext);
@@ -448,7 +448,7 @@ namespace Js {
             const charcount_t cchWritten = NumberUtilities::UInt16ToString(value, buffer, charCapacity, 2);
             Assert(cchWritten != 0);
         };
-        const auto ConvertLongToString = [](const long value, char16 *const buffer, const CharCount charCapacity)
+        const auto ConvertLongToString = [](const int32 value, char16 *const buffer, const CharCount charCapacity)
         {
             const errno_t err = _ltow_s(value, buffer, charCapacity, 10);
             Assert(err == 0);

--- a/lib/Runtime/Library/GlobalObject.cpp
+++ b/lib/Runtime/Library/GlobalObject.cpp
@@ -224,7 +224,7 @@ namespace Js
         Js::Var lineNumber = Js::JavascriptNumber::ToVar((int64) lineNum, scriptContext);
         Js::Var colNumber = Js::JavascriptNumber::ToVar((int64) colNum, scriptContext);
         Js::Var functionIdNumberVar = Js::JavascriptNumber::ToVar(functionId, scriptContext);
-        Js::Var utf8SourceInfoVar = Js::JavascriptNumber::ToVar((long) utf8SrcInfo, scriptContext);
+        Js::Var utf8SourceInfoVar = Js::JavascriptNumber::ToVar((int32) utf8SrcInfo, scriptContext);
 
         // assign properties to function info object
         SetProperty(fnInfoObj, _u("filename"), filenameString);
@@ -397,18 +397,18 @@ namespace Js
 
         Js::JavascriptNumber *jsUtf8SourceInfoNumber = NULL;
         Js::JavascriptNumber *jsFunctionIdNumber = NULL;
-        long utf8SourceInfoNumber = 0;  // null
-        long functionIdNumber = -1;  // start with invalid function id
+        int32 utf8SourceInfoNumber = 0;  // null
+        int32 functionIdNumber = -1;  // start with invalid function id
 
         // extract value of jsVarUtf8SourceInfo
         if (Js::TaggedInt::Is(jsVarUtf8SourceInfo))
         {
-            utf8SourceInfoNumber = (long)TaggedInt::ToInt64(jsVarUtf8SourceInfo); // REVIEW: just truncate?
+            utf8SourceInfoNumber = (int32)TaggedInt::ToInt64(jsVarUtf8SourceInfo); // REVIEW: just truncate?
         }
         else if (Js::JavascriptNumber::Is(jsVarUtf8SourceInfo))
         {
             jsUtf8SourceInfoNumber = (Js::JavascriptNumber *)jsVarUtf8SourceInfo;
-            utf8SourceInfoNumber = (long)JavascriptNumber::GetValue(jsUtf8SourceInfoNumber);    // REVIEW: just truncate?
+            utf8SourceInfoNumber = (int32)JavascriptNumber::GetValue(jsUtf8SourceInfoNumber);    // REVIEW: just truncate?
         }
         else
         {
@@ -419,12 +419,12 @@ namespace Js
         // extract value of jsVarFunctionId
         if (Js::TaggedInt::Is(jsVarFunctionId))
         {
-            functionIdNumber = (long)TaggedInt::ToInt64(jsVarFunctionId); // REVIEW: just truncate?
+            functionIdNumber = (int32)TaggedInt::ToInt64(jsVarFunctionId); // REVIEW: just truncate?
         }
         else if (Js::JavascriptNumber::Is(jsVarFunctionId))
         {
             jsFunctionIdNumber = (Js::JavascriptNumber *)jsVarFunctionId;
-            functionIdNumber = (long)JavascriptNumber::GetValue(jsFunctionIdNumber); // REVIEW: just truncate?
+            functionIdNumber = (int32)JavascriptNumber::GetValue(jsFunctionIdNumber); // REVIEW: just truncate?
         }
         else
         {

--- a/lib/Runtime/Library/JavascriptArray.cpp
+++ b/lib/Runtime/Library/JavascriptArray.cpp
@@ -7564,7 +7564,7 @@ Case0:
     {
         uint32 lu, luDig;
 
-        long cch = (long)wcslen(propName);
+        int32 cch = (int32)wcslen(propName);
         char16* pch = const_cast<char16 *>(propName);
 
         lu = *pch - '0';

--- a/lib/Runtime/Library/JavascriptArray.inl
+++ b/lib/Runtime/Library/JavascriptArray.inl
@@ -963,7 +963,7 @@ SECOND_PASS:
 
         const auto isSegmentValid = [length](Js::SparseArraySegment<T>* segment, uint32 startIndex) {
             uint32 end, segmentEnd;
-            // Check the segment is long enough
+            // Check the segment is int32 enough
             return (
                 segment &&
                 !UInt32Math::Add(startIndex, length, &end) &&

--- a/lib/Runtime/Library/JavascriptBoolean.cpp
+++ b/lib/Runtime/Library/JavascriptBoolean.cpp
@@ -126,7 +126,7 @@ namespace Js
         return requestContext->GetLibrary()->GetFalse();
     }
 
-    Var JavascriptBoolean::TryInvokeRemotelyOrThrow(JavascriptMethod entryPoint, ScriptContext * scriptContext, Arguments & args, long errorCode, PCWSTR varName)
+    Var JavascriptBoolean::TryInvokeRemotelyOrThrow(JavascriptMethod entryPoint, ScriptContext * scriptContext, Arguments & args, int32 errorCode, PCWSTR varName)
     {
         if (JavascriptOperators::GetTypeId(args[0]) == TypeIds_HostDispatch)
         {

--- a/lib/Runtime/Library/JavascriptBoolean.h
+++ b/lib/Runtime/Library/JavascriptBoolean.h
@@ -50,6 +50,6 @@ namespace Js
 
     private:
         static BOOL Equals(JavascriptBoolean* left, Var right, BOOL* value, ScriptContext * requestContext);
-        static Var TryInvokeRemotelyOrThrow(JavascriptMethod entryPoint, ScriptContext * scriptContext, Arguments & args, long errorCode, PCWSTR varName);
+        static Var TryInvokeRemotelyOrThrow(JavascriptMethod entryPoint, ScriptContext * scriptContext, Arguments & args, int32 errorCode, PCWSTR varName);
     };
 }

--- a/lib/Runtime/Library/JavascriptError.cpp
+++ b/lib/Runtime/Library/JavascriptError.cpp
@@ -295,7 +295,7 @@ namespace Js
         MapAndThrowError(scriptContext, pError, hr, pei, useErrInfoDescription);
     }
 
-    void __declspec(noreturn) JavascriptError::MapAndThrowError(ScriptContext* scriptContext, JavascriptError *pError, long hCode, EXCEPINFO* pei, bool useErrInfoDescription/* = false*/)
+    void __declspec(noreturn) JavascriptError::MapAndThrowError(ScriptContext* scriptContext, JavascriptError *pError, int32 hCode, EXCEPINFO* pei, bool useErrInfoDescription/* = false*/)
     {
         Assert(pError != nullptr);
 
@@ -348,13 +348,13 @@ namespace Js
         return pError; \
     } \
     \
-    void __declspec(noreturn) JavascriptError::err_method(ScriptContext* scriptContext, long hCode, EXCEPINFO* pei, IErrorInfo* perrinfo, RestrictedErrorStrings * proerrstr, bool useErrInfoDescription) \
+    void __declspec(noreturn) JavascriptError::err_method(ScriptContext* scriptContext, int32 hCode, EXCEPINFO* pei, IErrorInfo* perrinfo, RestrictedErrorStrings * proerrstr, bool useErrInfoDescription) \
     { \
         JavascriptError *pError = create_method(scriptContext, perrinfo, proerrstr); \
         MapAndThrowError(scriptContext, pError, hCode, pei, useErrInfoDescription); \
     } \
     \
-    void __declspec(noreturn) JavascriptError::err_method(ScriptContext* scriptContext, long hCode, PCWSTR varName) \
+    void __declspec(noreturn) JavascriptError::err_method(ScriptContext* scriptContext, int32 hCode, PCWSTR varName) \
     { \
         JavascriptLibrary *library = scriptContext->GetLibrary(); \
         JavascriptError *pError = library->create_method(); \
@@ -362,7 +362,7 @@ namespace Js
         JavascriptExceptionOperators::Throw(pError, scriptContext); \
     } \
     \
-    void __declspec(noreturn) JavascriptError::err_method(ScriptContext* scriptContext, long hCode, JavascriptString* varName) \
+    void __declspec(noreturn) JavascriptError::err_method(ScriptContext* scriptContext, int32 hCode, JavascriptString* varName) \
     { \
         JavascriptLibrary *library = scriptContext->GetLibrary(); \
         JavascriptError *pError = library->create_method(); \
@@ -370,7 +370,7 @@ namespace Js
         JavascriptExceptionOperators::Throw(pError, scriptContext); \
     } \
     \
-    void __declspec(noreturn) JavascriptError::err_method##Var(ScriptContext* scriptContext, long hCode, ...) \
+    void __declspec(noreturn) JavascriptError::err_method##Var(ScriptContext* scriptContext, int32 hCode, ...) \
     { \
         JavascriptLibrary *library = scriptContext->GetLibrary(); \
         JavascriptError *pError = library->create_method(); \
@@ -686,7 +686,7 @@ namespace Js
         JavascriptError::MapAndThrowError(scriptContext, pError, ei.scode, &ei);
     }
 
-    ErrorTypeEnum JavascriptError::MapParseError(long hCode)
+    ErrorTypeEnum JavascriptError::MapParseError(int32 hCode)
     {
         switch (hCode)
         {
@@ -703,7 +703,7 @@ namespace Js
         }
     }
 
-    JavascriptError* JavascriptError::MapParseError(ScriptContext* scriptContext, long hCode)
+    JavascriptError* JavascriptError::MapParseError(ScriptContext* scriptContext, int32 hCode)
     {
         ErrorTypeEnum errorType = JavascriptError::MapParseError(hCode);
         return MapError(scriptContext, errorType);
@@ -805,9 +805,9 @@ namespace Js
 
     // Gets the error number associated with the resource ID for an error message.
     // When 'errorNumSource' is 0 (the default case), the resource ID is used as the error number.
-    long JavascriptError::GetErrorNumberFromResourceID(long resourceId)
+    int32 JavascriptError::GetErrorNumberFromResourceID(int32 resourceId)
     {
-        long result;
+        int32 result;
         switch (resourceId)
         {
     #define RT_ERROR_MSG(name, errnum, str1, str2, jst, errorNumSource) \
@@ -877,7 +877,7 @@ namespace Js
         return jsNewError;
     }
 
-    void JavascriptError::TryThrowTypeError(ScriptContext * checkScriptContext, ScriptContext * scriptContext, long hCode, PCWSTR varName)
+    void JavascriptError::TryThrowTypeError(ScriptContext * checkScriptContext, ScriptContext * scriptContext, int32 hCode, PCWSTR varName)
     {
         // Don't throw if implicit exceptions are disabled
         if (checkScriptContext->GetThreadContext()->RecordImplicitException())

--- a/lib/Runtime/Library/JavascriptError.h
+++ b/lib/Runtime/Library/JavascriptError.h
@@ -81,14 +81,14 @@ namespace Js
 
         static void __declspec(noreturn) MapAndThrowError(ScriptContext* scriptContext, HRESULT hr);
         static void __declspec(noreturn) MapAndThrowError(ScriptContext* scriptContext, HRESULT hr, ErrorTypeEnum errorType, EXCEPINFO *ei, IErrorInfo * perrinfo = nullptr, RestrictedErrorStrings * proerrstr = nullptr, bool useErrInfoDescription = false);
-        static void __declspec(noreturn) MapAndThrowError(ScriptContext* scriptContext, JavascriptError *pError, long hCode, EXCEPINFO* pei, bool useErrInfoDescription = false);
+        static void __declspec(noreturn) MapAndThrowError(ScriptContext* scriptContext, JavascriptError *pError, int32 hCode, EXCEPINFO* pei, bool useErrInfoDescription = false);
         static JavascriptError* MapError(ScriptContext* scriptContext, ErrorTypeEnum errorType, IErrorInfo * perrinfo = nullptr, RestrictedErrorStrings * proerrstr = nullptr);
 
 #define THROW_ERROR_DECL(err_method) \
-        static void __declspec(noreturn) err_method(ScriptContext* scriptContext, long hCode, EXCEPINFO* ei, IErrorInfo* perrinfo = nullptr, RestrictedErrorStrings* proerrstr = nullptr, bool useErrInfoDescription = false); \
-        static void __declspec(noreturn) err_method(ScriptContext* scriptContext, long hCode, PCWSTR varName = nullptr); \
-        static void __declspec(noreturn) err_method(ScriptContext* scriptContext, long hCode, JavascriptString* varName); \
-        static void __declspec(noreturn) err_method##Var(ScriptContext* scriptContext, long hCode, ...);
+        static void __declspec(noreturn) err_method(ScriptContext* scriptContext, int32 hCode, EXCEPINFO* ei, IErrorInfo* perrinfo = nullptr, RestrictedErrorStrings* proerrstr = nullptr, bool useErrInfoDescription = false); \
+        static void __declspec(noreturn) err_method(ScriptContext* scriptContext, int32 hCode, PCWSTR varName = nullptr); \
+        static void __declspec(noreturn) err_method(ScriptContext* scriptContext, int32 hCode, JavascriptString* varName); \
+        static void __declspec(noreturn) err_method##Var(ScriptContext* scriptContext, int32 hCode, ...);
 
         THROW_ERROR_DECL(ThrowError)
         THROW_ERROR_DECL(ThrowEvalError)
@@ -102,8 +102,8 @@ namespace Js
         static void __declspec(noreturn) ThrowDispatchError(ScriptContext* scriptContext, HRESULT hCode, PCWSTR message);
         static void __declspec(noreturn) ThrowOutOfMemoryError(ScriptContext *scriptContext);
         static void __declspec(noreturn) ThrowParserError(ScriptContext* scriptContext, HRESULT hrParser, CompileScriptException* se);
-        static ErrorTypeEnum MapParseError(long hCode);
-        static JavascriptError* MapParseError(ScriptContext* scriptContext, long hCode);
+        static ErrorTypeEnum MapParseError(int32 hCode);
+        static JavascriptError* MapParseError(ScriptContext* scriptContext, int32 hCode);
         static HRESULT GetRuntimeError(RecyclableObject* errorObject, __out_opt LPCWSTR * pMessage);
         static HRESULT GetRuntimeErrorWithScriptEnter(RecyclableObject* errorObject, __out_opt LPCWSTR * pMessage);
         static void __declspec(noreturn) ThrowStackOverflowError(ScriptContext *scriptContext, PVOID returnAddress = nullptr);
@@ -137,11 +137,11 @@ namespace Js
 
         static DWORD GetAdjustedResourceStringHr(DWORD hr, bool isFormatString);
 
-        static long GetErrorNumberFromResourceID(long resourceId);
+        static int32 GetErrorNumberFromResourceID(int32 resourceId);
 
         JavascriptError* CreateNewErrorOfSameType(JavascriptLibrary* targetJavascriptLibrary);
         JavascriptError* CloneErrorMsgAndNumber(JavascriptLibrary* targetJavascriptLibrary);
-        static void TryThrowTypeError(ScriptContext * checkScriptContext, ScriptContext * scriptContext, long hCode, PCWSTR varName = nullptr);
+        static void TryThrowTypeError(ScriptContext * checkScriptContext, ScriptContext * scriptContext, int32 hCode, PCWSTR varName = nullptr);
         static JavascriptError* CreateFromCompileScriptException(ScriptContext* scriptContext, CompileScriptException* cse);
 
     private:

--- a/lib/Runtime/Library/JavascriptErrorDebug.h
+++ b/lib/Runtime/Library/JavascriptErrorDebug.h
@@ -44,7 +44,7 @@ namespace Js
         static void ClearErrorInfo(ScriptContext* scriptContext);
 #endif
 
-        static void SetErrorMessage(JavascriptError *pError, long errCode, PCWSTR varDescription, ScriptContext* scriptContext);
+        static void SetErrorMessage(JavascriptError *pError, HRESULT errCode, PCWSTR varDescription, ScriptContext* scriptContext);
 
         void SetRestrictedErrorStrings(RestrictedErrorStrings * proerrstr)
         {

--- a/lib/Runtime/Library/JavascriptExternalFunction.cpp
+++ b/lib/Runtime/Library/JavascriptExternalFunction.cpp
@@ -289,7 +289,7 @@ namespace Js
         Assert(scriptContext->GetThreadContext()->IsScriptActive());
 
         // Make sure the callee knows we are a wrapped function thunk
-        args.Info.Flags = (Js::CallFlags) (((long) args.Info.Flags) | CallFlags_Wrapped);
+        args.Info.Flags = (Js::CallFlags) (((int32) args.Info.Flags) | CallFlags_Wrapped);
 
         // don't need to leave script here, ExternalFunctionThunk will
         Assert(externalFunction->wrappedMethod->GetFunctionInfo()->GetOriginalEntryPoint() == JavascriptExternalFunction::ExternalFunctionThunk);

--- a/lib/Runtime/Library/JavascriptObject.cpp
+++ b/lib/Runtime/Library/JavascriptObject.cpp
@@ -857,7 +857,7 @@ namespace Js
         // 1. Let O be RequireObjectCoercible(O).
         // 2. ReturnIfAbrupt(O).
         // 3. If Type(proto) is neither Object or Null, then throw a TypeError exception.
-        long errCode = NOERROR;
+        int32 errCode = NOERROR;
 
         if (args.Info.Count < 2 || !JavascriptConversion::CheckObjectCoercible(args[1], scriptContext))
         {

--- a/lib/Runtime/Library/JavascriptString.cpp
+++ b/lib/Runtime/Library/JavascriptString.cpp
@@ -2878,7 +2878,7 @@ case_2:
     bool JavascriptString::ToDouble(double * result)
     {
         const char16* pch;
-        long len = this->m_charLength;
+        int32 len = this->m_charLength;
         if (0 == len)
         {
             *result = 0;
@@ -3301,7 +3301,7 @@ case_2:
 
         const char16 searchLast = searchStr[searchLen-1];
 
-        unsigned long lMatchedJump = searchLen;
+        uint32 lMatchedJump = searchLen;
         if (jmpTable[searchLast].shift > 0)
         {
             lMatchedJump = jmpTable[searchLast].shift;
@@ -3345,7 +3345,7 @@ case_2:
     int JavascriptString::LastIndexOfUsingJmpTable(JmpTable jmpTable, const char16* inputStr, int len, const char16* searchStr, int searchLen, int position)
     {
         const char16 searchFirst = searchStr[0];
-        unsigned long lMatchedJump = searchLen;
+        uint32 lMatchedJump = searchLen;
         if (jmpTable[searchFirst].shift > 0)
         {
             lMatchedJump = jmpTable[searchFirst].shift;
@@ -3395,7 +3395,7 @@ case_2:
             {
                 if ( jmpTable[c].shift == 0 )
                 {
-                    jmpTable[c].shift = (unsigned long)(searchStr + searchLen - 1 - p2);
+                    jmpTable[c].shift = (uint32)(searchStr + searchLen - 1 - p2);
                 }
             }
             else
@@ -3424,7 +3424,7 @@ case_2:
             {
                 if ( jmpTable[c].shift == 0 )
                 {
-                    jmpTable[c].shift = (unsigned long)(p2 - searchStr);
+                    jmpTable[c].shift = (uint32)(p2 - searchStr);
                 }
             }
             else

--- a/lib/Runtime/Library/JavascriptString.h
+++ b/lib/Runtime/Library/JavascriptString.h
@@ -8,7 +8,7 @@ namespace Js
 {
     typedef struct
     {
-        unsigned long shift;
+        uint32 shift;
     } Boyer_Moore_Jump;
 
     // Boyer Moore table for only the first character in the search string.

--- a/lib/Runtime/Library/JavascriptSymbol.cpp
+++ b/lib/Runtime/Library/JavascriptSymbol.cpp
@@ -214,7 +214,7 @@ namespace Js
         return requestContext->GetLibrary()->CreateSymbol(this->GetValue());
     }
 
-    Var JavascriptSymbol::TryInvokeRemotelyOrThrow(JavascriptMethod entryPoint, ScriptContext * scriptContext, Arguments & args, long errorCode, PCWSTR varName)
+    Var JavascriptSymbol::TryInvokeRemotelyOrThrow(JavascriptMethod entryPoint, ScriptContext * scriptContext, Arguments & args, int32 errorCode, PCWSTR varName)
     {
         if (JavascriptOperators::GetTypeId(args[0]) == TypeIds_HostDispatch)
         {

--- a/lib/Runtime/Library/JavascriptSymbol.h
+++ b/lib/Runtime/Library/JavascriptSymbol.h
@@ -55,6 +55,6 @@ namespace Js
 
     private:
         static BOOL Equals(JavascriptSymbol* left, Var right, BOOL* value, ScriptContext * requestContext);
-        static Var TryInvokeRemotelyOrThrow(JavascriptMethod entryPoint, ScriptContext * scriptContext, Arguments & args, long errorCode, PCWSTR varName);
+        static Var TryInvokeRemotelyOrThrow(JavascriptMethod entryPoint, ScriptContext * scriptContext, Arguments & args, int32 errorCode, PCWSTR varName);
     };
 }

--- a/lib/Runtime/Library/ThrowErrorObject.cpp
+++ b/lib/Runtime/Library/ThrowErrorObject.cpp
@@ -59,7 +59,7 @@ namespace Js
         return static_cast<ThrowErrorObject*>(RecyclableObject::FromVar(aValue));
     }
 
-    RecyclableObject* ThrowErrorObject::CreateThrowErrorObject(CreateErrorFunc createError, ScriptContext* scriptContext, long hCode, PCWSTR varName)
+    RecyclableObject* ThrowErrorObject::CreateThrowErrorObject(CreateErrorFunc createError, ScriptContext* scriptContext, int32 hCode, PCWSTR varName)
     {
         JavascriptLibrary* library = scriptContext->GetLibrary();
         JavascriptError *pError = (library->*createError)();
@@ -67,12 +67,12 @@ namespace Js
         return library->CreateThrowErrorObject(pError);
     }
 
-    RecyclableObject* ThrowErrorObject::CreateThrowTypeErrorObject(ScriptContext* scriptContext, long hCode, PCWSTR varName)
+    RecyclableObject* ThrowErrorObject::CreateThrowTypeErrorObject(ScriptContext* scriptContext, int32 hCode, PCWSTR varName)
     {
         return CreateThrowErrorObject(&JavascriptLibrary::CreateTypeError, scriptContext, hCode, varName);
     }
 
-    RecyclableObject* ThrowErrorObject::CreateThrowTypeErrorObject(ScriptContext* scriptContext, long hCode, JavascriptString* varName)
+    RecyclableObject* ThrowErrorObject::CreateThrowTypeErrorObject(ScriptContext* scriptContext, int32 hCode, JavascriptString* varName)
     {
         return CreateThrowTypeErrorObject(scriptContext, hCode, varName->GetSz());
     }

--- a/lib/Runtime/Library/ThrowErrorObject.h
+++ b/lib/Runtime/Library/ThrowErrorObject.h
@@ -25,11 +25,11 @@ namespace Js
         static bool Is(Var aValue);
         static ThrowErrorObject* FromVar(Var aValue);
 
-        static RecyclableObject* CreateThrowTypeErrorObject(ScriptContext* scriptContext, long hCode, PCWSTR varName);
-        static RecyclableObject* CreateThrowTypeErrorObject(ScriptContext* scriptContext, long hCode, JavascriptString* varName);
+        static RecyclableObject* CreateThrowTypeErrorObject(ScriptContext* scriptContext, int32 hCode, PCWSTR varName);
+        static RecyclableObject* CreateThrowTypeErrorObject(ScriptContext* scriptContext, int32 hCode, JavascriptString* varName);
 
     private:
         typedef JavascriptError* (JavascriptLibrary::*CreateErrorFunc)();
-        static RecyclableObject* CreateThrowErrorObject(CreateErrorFunc createError, ScriptContext* scriptContext, long hCode, PCWSTR varName);
+        static RecyclableObject* CreateThrowErrorObject(CreateErrorFunc createError, ScriptContext* scriptContext, int32 hCode, PCWSTR varName);
     };
 }

--- a/lib/Runtime/Library/TypedArray.cpp
+++ b/lib/Runtime/Library/TypedArray.cpp
@@ -429,7 +429,7 @@ namespace Js
             else if (ArrayBuffer::Is(firstArgument))
             {
                 // Constructor(ArrayBuffer buffer,
-                //  optional unsigned long byteOffset, optional unsigned long length)
+                //  optional uint32 byteOffset, optional uint32 length)
                 arrayBuffer = ArrayBuffer::FromVar(firstArgument);
                 if (arrayBuffer->IsDetached())
                 {

--- a/lib/Runtime/Library/UriHelper.cpp
+++ b/lib/Runtime/Library/UriHelper.cpp
@@ -101,7 +101,7 @@ namespace Js
     // array 'bUTF8'. uLen is the number of characters in the UTF-8 encoding.
     // This routine assumes that a valid UTF-8 encoding of a character is passed in
     // and does no error checking.
-    unsigned long UriHelper::FromUTF8( BYTE bUTF8[MaxUTF8Len], uint32 uLen )
+    uint32 UriHelper::FromUTF8( BYTE bUTF8[MaxUTF8Len], uint32 uLen )
     {
         Assert( 1 <= uLen && uLen <= MaxUTF8Len );
         if( uLen == 1 )

--- a/lib/Runtime/Library/UriHelper.h
+++ b/lib/Runtime/Library/UriHelper.h
@@ -81,7 +81,7 @@ namespace Js
 
         static const uint32 MaxUTF8Len = 4;
         static uint32 ToUTF8( uint32 uVal, BYTE bUTF8[MaxUTF8Len]);
-        static unsigned long FromUTF8( BYTE bUTF8[MaxUTF8Len], uint32 uLen );
+        static uint32 FromUTF8( BYTE bUTF8[MaxUTF8Len], uint32 uLen );
         static Var Encode(__in_ecount(len) const char16* psz, uint32 len, unsigned char unescapedFlags, ScriptContext* scriptContext );
 
     private:


### PR DESCRIPTION
This PR replaces most of the `long` usage to `int32`. On some places `long`
type is kept as is or replaced to `LONG`.