### PR TITLE
xplat: simulate load resource string

### DIFF
--- a/lib/Parser/errstr.cpp
+++ b/lib/Parser/errstr.cpp
@@ -123,6 +123,7 @@ BSTR BstrGetResourceString(long isz)
 {
     // NOTE - isz is expected to be HRESULT
 
+#ifdef _WIN32
     OLECHAR szT[1024];
 
     if (!FGetResourceString(isz, szT,
@@ -130,6 +131,17 @@ BSTR BstrGetResourceString(long isz)
     {
         return NULL;
     }
+#else
+    const char16* LoadResourceStr(UINT id);
+
+    UINT id = (WORD)isz;
+    const char16* szT = LoadResourceStr(id);
+    if (!szT)
+    {
+        return NULL;
+    }
+
+#endif
 
     return SysAllocString(szT);
 }

--- a/lib/Parser/rterror.cpp
+++ b/lib/Parser/rterror.cpp
@@ -27,3 +27,78 @@ C_ASSERT(JSPUBLICERR_CantExecute == _HRESULT_TYPEDEF_(0x89020001L));
 #include "rterrors.h"
 #undef  RT_PUBLICERROR_MSG
 #undef  RT_ERROR_MSG
+
+//------------------------------------------------------------------------------
+// xplat: simulate resource strings
+#ifndef _WIN32
+#include <rterrors_limits.h>
+
+struct _ResourceStr
+{
+    UINT id;
+    const char16* str;
+};
+
+static _ResourceStr s_resourceStrs[] =
+{
+    //
+    // Copy from jserr.gen
+    //
+#define RT_ERROR_MSG(name, errnum, str1, str2, jst, errorNumSource) \
+    { errnum, _u(str2) },
+#define RT_PUBLICERROR_MSG(name, errnum, str1, str2, jst, errorNumSource) \
+    { errnum + RTERROR_PUBLIC_RESOURCEOFFSET, _u(str2) },
+#include <rterrors.h>
+#undef RT_PUBLICERROR_MSG
+#undef RT_ERROR_MSG
+
+#define RT_ERROR_MSG(name, errnum, str1, str2, jst, errorNumSource) \
+    { errnum + RTERROR_STRINGFORMAT_OFFSET, _u(str1) },
+#define RT_PUBLICERROR_MSG(name, errnum, str1, str2, jst, errorNumSource) \
+    { errnum + RTERROR_STRINGFORMAT_OFFSET + RTERROR_PUBLIC_RESOURCEOFFSET, \
+      _u(str1) },
+#include <rterrors.h>
+#undef RT_PUBLICERROR_MSG
+#undef RT_ERROR_MSG
+
+#define LSC_ERROR_MSG(errnum, name, str) \
+    { errnum, _u(str) },
+#include <perrors.h>
+#undef LSC_ERROR_MSG
+
+    { IDS_COMPILATION_ERROR_SOURCE, _u("JavaScript compilation error") },
+    { IDS_RUNTIME_ERROR_SOURCE,     _u("JavaScript runtime error") },
+    { IDS_UNKNOWN_RUNTIME_ERROR,    _u("Unknown runtime error") },
+
+    { IDS_INFINITY,                 _u("Infinity") },
+    { IDS_MINUSINFINITY,            _u("-Infinity") }
+};
+
+static int compare_ResourceStr(const void* a, const void* b)
+{
+    UINT id1 = reinterpret_cast<const _ResourceStr*>(a)->id;
+    UINT id2 = reinterpret_cast<const _ResourceStr*>(b)->id;
+    return id1 - id2;
+}
+
+static bool s_resourceStrsSorted = false;
+
+const char16* LoadResourceStr(UINT id)
+{
+    if (!s_resourceStrsSorted)
+    {
+        qsort(s_resourceStrs,
+            _countof(s_resourceStrs), sizeof(s_resourceStrs[0]),
+            compare_ResourceStr);
+        s_resourceStrsSorted = true;
+    }
+
+    _ResourceStr key = { id, nullptr };
+    const void* p = bsearch(&key,
+        s_resourceStrs, _countof(s_resourceStrs), sizeof(s_resourceStrs[0]),
+        compare_ResourceStr);
+
+    return p ? reinterpret_cast<const _ResourceStr*>(p)->str : nullptr;
+}
+
+#endif


### PR DESCRIPTION
ChakraCore runtime error message strings are loaded from resources on
Windows. On xplat, store the strings in a static string table and simulate
load resource string.

This enables runtime error messages.
