### PR TITLE
Add Walker and Display for Promise objects under debugger locals

### DIFF
--- a/lib/Runtime/Debug/DiagObjectModel.h
+++ b/lib/Runtime/Debug/DiagObjectModel.h
@@ -844,6 +844,7 @@ namespace Js
         RecyclableKeyValueWalker(ScriptContext* scriptContext, Var key, Var value):scriptContext(scriptContext), key(key), value(value) { }
 
         virtual BOOL Get(int i, ResolvedObject* pResolvedObject) override;
+        // Children count is 2 for 'key' and 'value'
         virtual ulong GetChildrenCount() override { return 2; }
         virtual BOOL GetGroupObject(ResolvedObject* pResolvedObject) override { return FALSE; }
     };
@@ -863,6 +864,27 @@ namespace Js
         RecyclableProxyObjectWalker(ScriptContext* pContext, Var instance);
 
         virtual BOOL Get(int i, ResolvedObject* pResolvedObject) override;
+        // Children count is 2 for '[target]' and '[handler]'
+        virtual ulong GetChildrenCount() override { return 2; }
+        virtual BOOL GetGroupObject(ResolvedObject* pResolvedObject) override;
+    };
+
+    class RecyclablePromiseObjectDisplay : public RecyclableObjectDisplay
+    {
+    public:
+        RecyclablePromiseObjectDisplay(ResolvedObject* resolvedObject);
+
+        virtual BOOL HasChildren() override { return TRUE; }
+        virtual WeakArenaReference<IDiagObjectModelWalkerBase>* CreateWalker() override;
+    };
+
+    class RecyclablePromiseObjectWalker : public RecyclableObjectWalker
+    {
+    public:
+        RecyclablePromiseObjectWalker(ScriptContext* pContext, Var instance);
+
+        virtual BOOL Get(int i, ResolvedObject* pResolvedObject) override;
+        // Children count is 2 for '[status]' and '[value]'
         virtual ulong GetChildrenCount() override { return 2; }
         virtual BOOL GetGroupObject(ResolvedObject* pResolvedObject) override;
     };

--- a/lib/Runtime/Library/JavascriptPromise.h
+++ b/lib/Runtime/Library/JavascriptPromise.h
@@ -363,7 +363,6 @@ namespace Js
         static Var TryCallResolveOrRejectHandler(Var handler, Var value, ScriptContext* scriptContext);
         static Var TryRejectWithExceptionObject(JavascriptExceptionObject* exceptionObject, Var handler, ScriptContext* scriptContext);
 
-    protected:
         enum PromiseStatus
         {
             PromiseStatusCode_Undefined,
@@ -372,6 +371,10 @@ namespace Js
             PromiseStatusCode_HasRejection
         };
 
+        PromiseStatus GetStatus() const { return status; }
+        Var GetResult() const { return result; }
+
+    protected:
         PromiseStatus status;
         Var result;
         JavascriptPromiseReactionList* resolveReactions;


### PR DESCRIPTION
Promise objects will now show [Promise] fake node with [status] and
[value] as childrens.

[status] is one of undefined/pending/resolved/rejected
[value] is either undefined or the value display.
