### PR TITLE
Fix for an issue with split scope in dead store optimization

### DIFF
--- a/lib/Backend/BackwardPass.cpp
+++ b/lib/Backend/BackwardPass.cpp
@@ -6075,10 +6075,12 @@ BackwardPass::ProcessDef(IR::Opnd * opnd)
         {
             if (propertySym->m_fieldKind == PropertyKindLocalSlots || propertySym->m_fieldKind == PropertyKindSlots)
             {
-                isUsed = !block->slotDeadStoreCandidates->TestAndSet(propertySym->m_id);
+                BOOLEAN isPropertySymUsed = !block->slotDeadStoreCandidates->TestAndSet(propertySym->m_id);
                 // we should not do any dead slots in asmjs loop body
-                Assert(!(this->func->GetJnFunction()->GetIsAsmJsFunction() && this->func->IsLoopBody() && !isUsed));
-                Assert(isUsed || !block->upwardExposedUses->Test(propertySym->m_id));
+                Assert(!(this->func->GetJnFunction()->GetIsAsmJsFunction() && this->func->IsLoopBody() && !isPropertySymUsed));
+                Assert(isPropertySymUsed || !block->upwardExposedUses->Test(propertySym->m_id));
+
+                isUsed = isPropertySymUsed || block->upwardExposedUses->Test(propertySym->m_stackSym->m_id);
             }
         }
 

--- a/test/es6/default-splitscope.js
+++ b/test/es6/default-splitscope.js
@@ -78,6 +78,17 @@ var tests = [
         };
 
         assert.areEqual('string2', f8('string1', undefined, 'string2'), "Function returns the third argument properly");
+        
+        function f9() {
+            var f10 = function (a = function () { c; }, b, c) {
+                assert.areEqual(1, c, "Third argument is properly populated");
+                arguments;
+                function f11() {};
+            };
+            f10(undefined, undefined, 1);
+        }
+        f9();
+        f9();
     } 
  }, 
  { 


### PR DESCRIPTION
Storing the arg in for the parameter and the copy logic of initial value
of the param to the corresponding symbol in the body was happening in the
same block. During dead store check were were only checking the property
sym for usage. So the initial store was getting removed. This fix adds
usage check for the stack sym too.
