### PR TITLE
Experimental: enable x64 nojit configuation to build using clang on windows

### DIFF
--- a/Build/Chakra.Build.Clang.Default.props
+++ b/Build/Chakra.Build.Clang.Default.props
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- Not officially supported! Configuration to build with clang on windows -->
+  <PropertyGroup Condition="'$(Clang)'=='ClangCL'">
+    <PlatformToolset>LLVM-vs2014</PlatformToolset>
+  </PropertyGroup>
+</Project>

--- a/Build/Chakra.Build.Clang.props
+++ b/Build/Chakra.Build.Clang.props
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalOptions>
+        %(AdditionalOptions)
+        -msse4.1
+        -Qunused-arguments
+        -Wno-unknown-pragmas
+        -Wno-writable-strings
+        -Wno-int-to-void-pointer-cast
+        -Wno-unused-parameter
+        -Wno-switch
+        -Wno-sign-compare
+        -Wno-missing-declarations
+        -Wno-missing-braces
+        -Wno-reorder
+        -Wno-pointer-bool-conversion
+        -Wno-delete-non-virtual-dtor
+        -Wno-deprecated-declarations
+        -Wno-missing-field-initializers
+        -Wno-ignored-qualifiers
+        -Wno-mismatched-tags
+        -Wno-invalid-token-paste
+        -Wno-invalid-offsetof
+        -Wno-inconsistent-missing-override
+        -Wno-int-to-pointer-cast
+        -Wno-address-of-temporary
+        -Wno-self-assign
+        -Wno-overloaded-virtual
+        -Wno-tautological-undefined-compare
+        -Wno-char-subscripts
+        -Wno-logical-not-parentheses
+        -Wno-infinite-recursion
+        -Wno-undefined-inline
+        -Wno-format
+        -Wno-unused-variable
+        -Wno-unused-value
+        -Wno-unused-private-field
+        -Wno-enum-compare
+        -Wno-null-conversion
+        -Wno-sizeof-pointer-memaccess
+        -Wno-assume
+        -Wno-invalid-noreturn
+        -Wno-tautological-constant-out-of-range-compare
+        -Wno-c++11-narrowing
+        -Wno-uninitialized
+        -Wno-return-type
+        -Wno-unused-local-typedef
+
+        -Wno-microsoft-enum-value
+        -Wno-microsoft-include
+        -Wno-microsoft-goto
+        -Wno-microsoft-sealed
+        -Wno-microsoft-template
+        -Wno-microsoft-unqualified-friend
+        -Wno-microsoft-extra-qualification
+        -Wno-microsoft-default-arg-redefinition
+        -Wno-microsoft-exception-spec
+        -v
+      </AdditionalOptions>
+      <!-- Clang doesn't support code view information, but will generate line number.  It only support /Z7 generation -->
+      <DebugInformationFormat>OldStyle</DebugInformationFormat>
+      <ProgramDataBaseFileName />
+    </ClCompile>  
+  </ItemDefinitionGroup>
+
+  <Import Project="Chakra.Build.Clang.targets" />
+</Project>

--- a/Build/Chakra.Build.Clang.targets
+++ b/Build/Chakra.Build.Clang.targets
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <BeforeClCompileTargets>
+      $(BeforeClCompileTargets);
+      GenerateClangPrecompileHeader;
+      FixupClangIncludePrecompileHeader;
+    </BeforeClCompileTargets>
+  </PropertyGroup>
+
+  <Target Name="FixupClangIncludePrecompileHeader"
+        Condition="'@(ClCompile)' != ''">
+    <ItemGroup>
+      <ClCompile>
+        <!-- Convert the /Yc /Yu switchs to clang -include-pch -->
+        <AdditionalOptions Condition="'%(ClCompile.PrecompiledHeader)'!='NotUsing'">%(ClCompile.AdditionalOptions) -Xclang -include-pch -Xclang %(ClCompile.PrecompiledHeaderOutputFile)</AdditionalOptions>
+
+        <!-- Clear the precompiled header command from CL.exe so that the PCH doesn't get deleted by the ClCompile Target-->
+        <PrecompiledHeaderOutputFile></PrecompiledHeaderOutputFile>
+        <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      </ClCompile>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="GenerateClangPrecompileHeader" BeforeTargets="ClCompile" Condition="'@(ClCompile)' != ''"
+          DependsOnTargets="SelectClCompile">
+    <CL Condition="'%(ClCompile.PrecompiledHeader)' == 'Create' and '%(ClCompile.ExcludedFromBuild)'!='true' and '%(ClCompile.CompilerIteration)' == ''"
+        BuildingInIDE                      ="$(BuildingInsideVisualStudio)"
+        Sources                            ="@(ClCompile)"
+
+        AdditionalIncludeDirectories       ="%(ClCompile.AdditionalIncludeDirectories)"
+        AdditionalOptions                  ="%(ClCompile.AdditionalOptions) -Xclang -emit-pch -o %(ClCompile.PrecompiledHeaderOutputFile)"
+        AdditionalUsingDirectories         ="%(ClCompile.AdditionalUsingDirectories)"
+        AssemblerListingLocation           ="%(ClCompile.AssemblerListingLocation)"
+        AssemblerOutput                    ="%(ClCompile.AssemblerOutput)"
+        BasicRuntimeChecks                 ="%(ClCompile.BasicRuntimeChecks)"
+        BrowseInformation                  ="%(ClCompile.BrowseInformation)"
+        BrowseInformationFile              ="%(ClCompile.BrowseInformationFile)"
+        BufferSecurityCheck                ="%(ClCompile.BufferSecurityCheck)"
+        CallingConvention                  ="%(ClCompile.CallingConvention)"
+        ControlFlowGuard                   ="%(ClCompile.ControlFlowGuard)"
+        CompileAsManaged                   ="%(ClCompile.CompileAsManaged)"
+        CompileAsWinRT                     ="%(ClCompile.CompileAsWinRT)"
+        CompileAs                          ="%(ClCompile.CompileAs)"
+        DebugInformationFormat             ="%(ClCompile.DebugInformationFormat)"
+        DisableLanguageExtensions          ="%(ClCompile.DisableLanguageExtensions)"
+        DisableSpecificWarnings            ="%(ClCompile.DisableSpecificWarnings)"
+        EnableEnhancedInstructionSet       ="%(ClCompile.EnableEnhancedInstructionSet)"
+        EnableFiberSafeOptimizations       ="%(ClCompile.EnableFiberSafeOptimizations)"
+        EnableParallelCodeGeneration       ="%(ClCompile.EnableParallelCodeGeneration)"
+        EnablePREfast                      ="%(ClCompile.EnablePREfast)"
+        EnforceTypeConversionRules         ="%(ClCompile.EnforceTypeConversionRules)"
+        ErrorReporting                     ="%(ClCompile.ErrorReporting)"
+        ExceptionHandling                  ="%(ClCompile.ExceptionHandling)"
+        ExcludedInputPaths                 ="$(ExcludePath)"
+        ExpandAttributedSource             ="%(ClCompile.ExpandAttributedSource)"
+        FavorSizeOrSpeed                   ="%(ClCompile.FavorSizeOrSpeed)"
+        FloatingPointExceptions            ="%(ClCompile.FloatingPointExceptions)"
+        FloatingPointModel                 ="%(ClCompile.FloatingPointModel)"
+        ForceConformanceInForLoopScope     ="%(ClCompile.ForceConformanceInForLoopScope)"
+        ForcedIncludeFiles                 ="%(ClCompile.ForcedIncludeFiles)"
+        ForcedUsingFiles                   ="%(ClCompile.ForcedUsingFiles)"
+        FunctionLevelLinking               ="%(ClCompile.FunctionLevelLinking)"
+        GenerateXMLDocumentationFiles      ="%(ClCompile.GenerateXMLDocumentationFiles)"
+        IgnoreStandardIncludePath          ="%(ClCompile.IgnoreStandardIncludePath)"
+        InlineFunctionExpansion            ="%(ClCompile.InlineFunctionExpansion)"
+        IntrinsicFunctions                 ="%(ClCompile.IntrinsicFunctions)"
+        MinimalRebuild                     ="%(ClCompile.MinimalRebuild)"
+        MultiProcessorCompilation          ="%(ClCompile.MultiProcessorCompilation)"
+        
+        OmitDefaultLibName                 ="%(ClCompile.OmitDefaultLibName)"
+        OmitFramePointers                  ="%(ClCompile.OmitFramePointers)"
+        OpenMPSupport                      ="%(ClCompile.OpenMPSupport)"
+        Optimization                       ="%(ClCompile.Optimization)"
+        PrecompiledHeader                  ="%(ClCompile.PrecompiledHeader)"
+        PrecompiledHeaderFile              ="%(ClCompile.PrecompiledHeaderFile)"
+        PrecompiledHeaderOutputFile        ="%(ClCompile.PrecompiledHeaderOutputFile)"
+        PREfastAdditionalOptions           ="%(ClCompile.PREfastAdditionalOptions)"
+        PREfastAdditionalPlugins           ="%(ClCompile.PREfastAdditionalPlugins)"
+        PREfastLog                         ="%(ClCompile.PREfastLog)"
+        PreprocessKeepComments             ="%(ClCompile.PreprocessKeepComments)"
+        PreprocessorDefinitions            ="%(ClCompile.PreprocessorDefinitions)"
+        PreprocessSuppressLineNumbers      ="%(ClCompile.PreprocessSuppressLineNumbers)"
+        PreprocessToFile                   ="%(ClCompile.PreprocessToFile)"
+        ProcessorNumber                    ="%(ClCompile.ProcessorNumber)"
+        ProgramDataBaseFileName            ="%(ClCompile.ProgramDataBaseFileName)"
+        RemoveUnreferencedCodeData         ="%(ClCompile.RemoveUnreferencedCodeData)"
+        RuntimeLibrary                     ="%(ClCompile.RuntimeLibrary)"
+        RuntimeTypeInfo                    ="%(ClCompile.RuntimeTypeInfo)"
+        SDLCheck                           ="%(ClCompile.SDLCheck)"
+        ShowIncludes                       ="%(ClCompile.ShowIncludes)"
+        WarningVersion                     ="%(ClCompile.WarningVersion)"
+        SmallerTypeCheck                   ="%(ClCompile.SmallerTypeCheck)"
+        StringPooling                      ="%(ClCompile.StringPooling)"
+        StructMemberAlignment              ="%(ClCompile.StructMemberAlignment)"
+        SuppressStartupBanner              ="%(ClCompile.SuppressStartupBanner)"
+        TreatSpecificWarningsAsErrors      ="%(ClCompile.TreatSpecificWarningsAsErrors)"
+        TreatWarningAsError                ="%(ClCompile.TreatWarningAsError)"
+        TreatWChar_tAsBuiltInType          ="%(ClCompile.TreatWChar_tAsBuiltInType)"
+        UndefineAllPreprocessorDefinitions ="%(ClCompile.UndefineAllPreprocessorDefinitions)"
+        UndefinePreprocessorDefinitions    ="%(ClCompile.UndefinePreprocessorDefinitions)"
+        UseFullPaths                       ="%(ClCompile.UseFullPaths)"
+        UseUnicodeForAssemblerListing      ="%(ClCompile.UseUnicodeForAssemblerListing)"
+        WarningLevel                       ="%(ClCompile.WarningLevel)"
+        WholeProgramOptimization           ="%(ClCompile.WholeProgramOptimization)"
+        WinRTNoStdLib                      ="%(ClCompile.WinRTNoStdLib)"
+        XMLDocumentationFileName           ="%(ClCompile.XMLDocumentationFileName)"
+        CreateHotpatchableImage            ="%(CLCompile.CreateHotpatchableImage)"
+
+        TrackerLogDirectory                ="%(ClCompile.TrackerLogDirectory)"
+
+        TLogReadFiles                      ="@(CLTLogReadFiles)"
+        TLogWriteFiles                     ="@(CLTLogWriteFiles)"
+        ToolExe                            ="$(CLToolExe)"
+        ToolPath                           ="$(CLToolPath)"
+        TrackFileAccess                    ="$(TrackFileAccess)"
+        MinimalRebuildFromTracking         ="%(ClCompile.MinimalRebuildFromTracking)"
+        ToolArchitecture                   ="$(CLToolArchitecture)"
+        TrackerFrameworkPath               ="$(CLTrackerFrameworkPath)"
+        TrackerSdkPath                     ="$(CLTrackerSdkPath)"
+        TrackedInputFilesToIgnore          ="@(ClNoDependencies)"
+        DeleteOutputOnExecute              ="$(CLDeleteOutputOnExecute)"
+
+        AcceptableNonZeroExitCodes         ="%(ClCompile.AcceptableNonZeroExitCodes)"
+        YieldDuringToolExecution           ="$(ClYieldDuringToolExecution)"
+    >
+    </CL>
+  </Target>
+</Project>

--- a/Build/Chakra.Build.Default.props
+++ b/Build/Chakra.Build.Default.props
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="Common.Build.Default.props"/>
+  <Import Condition="'$(Clang)'!=''" Project="Chakra.Build.Clang.Default.props"/>
   <PropertyGroup>
     <WindowsTargetPlatformVersion Condition="'$(Platform)'=='ARM'">10.0.10240.0</WindowsTargetPlatformVersion>
 
     <!-- Always use Platform SDK for core builds -->
-    <EventManifestXmlPath>$(WindowsSDK80Path)Include\um</EventManifestXmlPath>
-
-  </PropertyGroup>
+    <EventManifestXmlPath>$(WindowsSDK80Path)Include\um</EventManifestXmlPath>    
+  </PropertyGroup>    
 </Project>

--- a/Build/Chakra.Build.props
+++ b/Build/Chakra.Build.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="Common.Build.props"/>
+  <Import Project="Common.Build.props"/>  
   <PropertyGroup>
     <Win32_WinNTVersion Condition="'$(NtTargetVersion)'=='$(NtTargetVersion_Win7)'">0x0601</Win32_WinNTVersion>
     <Win32_WinNTVersion Condition="'$(NtTargetVersion)'=='$(NtTargetVersion_Win8)'">0x0602</Win32_WinNTVersion>
@@ -62,4 +62,6 @@
         user32.lib
     </ChakraCommonLinkDependencies>
   </PropertyGroup>
+
+  <Import Condition="'$(Clang)'!=''" Project="Chakra.Build.Clang.props"/>
 </Project>

--- a/Build/Common.Build.Default.props
+++ b/Build/Common.Build.Default.props
@@ -64,6 +64,7 @@
   <PropertyGroup>
     <OutBaseDir Condition="'$(OutBaseDir)'!=''">$(OutBaseDir)\$(SolutionName)</OutBaseDir>
     <OutBaseDir Condition="'$(OutBaseDir)'==''">$(SolutionDir)VcBuild</OutBaseDir>
+    <OutBaseDir Condition="'$(Clang)'!=''">$(OutBaseDir).$(Clang)</OutBaseDir>    
     <OutBaseDir Condition="'$(BuildJIT)'=='false'">$(OutBaseDir).NoJIT</OutBaseDir>
     <IntBaseDir Condition="'$(IntBaseDir)'==''">$(OutBaseDir)</IntBaseDir>
   </PropertyGroup>

--- a/bin/ChakraCore/ChakraCore.vcxproj
+++ b/bin/ChakraCore/ChakraCore.vcxproj
@@ -42,6 +42,7 @@
         <!-- Make sure we linked in our own operator new before we got the CRT -->
         $(IntDir)..\Chakra.Common.Memory\HeapAllocatorOperators.obj;
         kernel32.lib;
+        user32.lib;
         advapi32.lib;
         ole32.lib;
         $(ChakraCommonLinkDependencies)

--- a/bin/ch/Encode.js
+++ b/bin/ch/Encode.js
@@ -30,7 +30,7 @@ if (str.length == 0) {
 }
 
 try {
-    var out = fso.OpenTextFile(output, 2, true, -1);
+    var out = fso.OpenTextFile(output, 2, true, 0);
 }
 catch (e) {
     WScript.Echo("ERROR: unable to open output file " + output);
@@ -50,6 +50,7 @@ function writeChar(c) {
         c = "\\n";
         line = true;
     }
+
 
     out.Write("L'" + c + "'");
     out.Write(",");

--- a/bin/rl/rl.cpp
+++ b/bin/rl/rl.cpp
@@ -352,8 +352,8 @@ char* DiffCompiler = NULL;
 RLMODE Mode = DEFAULT_RLMODE;
 
 char *DCFGfile = NULL;
-char *CFGfile = NULL;
-char *CMDfile = NULL;
+char const *CFGfile = NULL;
+char const *CMDfile = NULL;
 int CFGline;
 
 #define MAX_ALLOWED_THREADS 10 // must be <= MAXIMUM_WAIT_OBJECTS (64)

--- a/lib/Common/Common/Int64Math.cpp
+++ b/lib/Common/Common/Int64Math.cpp
@@ -6,7 +6,7 @@
 #include "Common/Int64Math.h"
 
 #if defined(_M_X64)
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !defined(__clang__)
     #pragma intrinsic(_mul128)
 #else
     static int64 _mul128(const int64 left, const int64 right, int64 *high) noexcept

--- a/lib/Common/Common/NumberUtilities.inl
+++ b/lib/Common/Common/NumberUtilities.inl
@@ -60,7 +60,7 @@ namespace Js
 #endif //!BIG_ENDIAN
     }
 
-#if defined(_M_X64) && defined(_MSC_VER)
+#if defined(_M_X64) && defined(_MSC_VER) && !defined(__clang__)
     NUMBER_UTIL_INLINE INT64 NumberUtilities::TryToInt64(double T1)
     {
         // _mm_cvttsd_si64x will result in 0x8000000000000000 if the value is NaN Inf or Zero, or overflows int64

--- a/lib/Common/Common/NumberUtilities_strtod.cpp
+++ b/lib/Common/Common/NumberUtilities_strtod.cpp
@@ -2,7 +2,7 @@
 // Copyright (C) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
-#include <CommonCommonPch.h>
+#include "CommonCommonPch.h"
 #include "DataStructures/BigInt.h"
 
 namespace Js

--- a/lib/Common/CommonDefines.h
+++ b/lib/Common/CommonDefines.h
@@ -120,8 +120,10 @@
 #define ENABLE_SCRIPT_DEBUGGING
 // dep: IActiveScriptProfilerCallback, IActiveScriptProfilerHeapEnum
 #define ENABLE_SCRIPT_PROFILING
+#ifndef __clang__
 // xplat-todo: change DISABLE_SEH to ENABLE_SEH and move here
 #define ENABLE_SIMDJS
+#endif
 
 #define ENABLE_CUSTOM_ENTROPY
 #endif

--- a/lib/Common/Core/FaultInjection.cpp
+++ b/lib/Common/Core/FaultInjection.cpp
@@ -349,7 +349,7 @@ namespace Js
     const auto& globalFlags = Js::Configuration::Global.flags;
     PVOID FaultInjection::vectoredExceptionHandler = nullptr;
     DWORD FaultInjection::exceptionFilterRemovalLastError = 0;
-    int(*Js::FaultInjection::pfnHandleAV)(int, PEXCEPTION_POINTERS) = nullptr;
+    __declspec(thread) int(*Js::FaultInjection::pfnHandleAV)(int, PEXCEPTION_POINTERS) = nullptr;
     static SymbolInfoPackage sip;
     static ModuleInfo mi;
 

--- a/lib/Common/DataStructures/FixedBitVector.h
+++ b/lib/Common/DataStructures/FixedBitVector.h
@@ -411,19 +411,19 @@ public:
     BOOLEAN TestAndSet(BVIndex i)
     {
         AssertRange(i);
-        return _bittestandset((LONG *)this->data, (LONG) i);
+        return PlatformAgnostic::_BitTestAndSet((LONG *)this->data, (LONG) i);
     }
 
     BOOLEAN TestIntrinsic(BVIndex i) const
     {
         AssertRange(i);
-        return _bittest((LONG *)this->data, (LONG) i);
+        return PlatformAgnostic::_BitTest((LONG *)this->data, (LONG) i);
     }
 
     BOOLEAN TestAndSetInterlocked(BVIndex i)
     {
         AssertRange(i);
-        return _interlockedbittestandset((LONG *)this->data, (LONG) i);
+        return PlatformAgnostic::_InterlockedBitTestAndSet((LONG *)this->data, (LONG) i);
     }
 
     BOOLEAN TestAndClear(BVIndex i)

--- a/lib/Common/Exceptions/Throw.cpp
+++ b/lib/Common/Exceptions/Throw.cpp
@@ -64,7 +64,7 @@ extern "C"{
 
 namespace Js {
 #if defined(GENERATE_DUMP) && defined(STACK_BACK_TRACE)
-    StackBackTrace * Throw::stackBackTrace = nullptr;
+    __declspec(thread) StackBackTrace * Throw::stackBackTrace = nullptr;
 #endif
     void Throw::FatalInternalError()
     {

--- a/lib/Common/Memory/ArenaAllocator.cpp
+++ b/lib/Common/Memory/ArenaAllocator.cpp
@@ -8,13 +8,8 @@
 
 const uint Memory::StandAloneFreeListPolicy::MaxEntriesGrowth;
 
-#ifdef _MSC_VER
-template __forceinline BVSparseNode * BVSparse<JitArenaAllocator>::NodeFromIndex(BVIndex i, BVSparseNode *** prevNextFieldOut, bool create);
-#else
-// Clang/GCC support
 // We need this function to be inlined for perf
-template __attribute__((always_inline)) BVSparseNode * BVSparse<JitArenaAllocator>::NodeFromIndex(BVIndex i, BVSparseNode *** prevNextFieldOut, bool create);
-#endif
+template _ALWAYSINLINE BVSparseNode * BVSparse<JitArenaAllocator>::NodeFromIndex(BVIndex i, BVSparseNode *** prevNextFieldOut, bool create);
 
 ArenaData::ArenaData(PageAllocator * pageAllocator) :
     pageAllocator(pageAllocator),
@@ -455,13 +450,8 @@ ReleaseHeapMemory()
     }
 }
 
-#ifdef _MSC_VER
-template __forceinline char *ArenaAllocatorBase<InPlaceFreeListPolicy, 0, 0, 0>::AllocInternal(size_t requestedBytes);
-template __forceinline char *ArenaAllocatorBase<InPlaceFreeListPolicy, 3, 0, 0>::AllocInternal(size_t requestedBytes);
-#else
-template __attribute__((always_inline)) char *ArenaAllocatorBase<InPlaceFreeListPolicy, 0, 0, 0>::AllocInternal(size_t requestedBytes);
-template __attribute__((always_inline)) char *ArenaAllocatorBase<InPlaceFreeListPolicy, 3, 0, 0>::AllocInternal(size_t requestedBytes);
-#endif
+template _ALWAYSINLINE char *ArenaAllocatorBase<InPlaceFreeListPolicy, 0, 0, 0>::AllocInternal(size_t requestedBytes);
+template _ALWAYSINLINE char *ArenaAllocatorBase<InPlaceFreeListPolicy, 3, 0, 0>::AllocInternal(size_t requestedBytes);
 
 template <class TFreeListPolicy, size_t ObjectAlignmentBitShiftArg, bool RequireObjectAlignment, size_t MaxObjectSize>
 char *

--- a/lib/Common/Memory/AutoPtr.h
+++ b/lib/Common/Memory/AutoPtr.h
@@ -66,7 +66,7 @@ template <typename T>
 class AutoArrayAndItemsPtr : public AutoArrayPtr<T>
 {
 public:
-    AutoArrayAndItemsPtr(T * ptr, size_t elementCount) : AutoArrayPtr(ptr, elementCount) {}
+    AutoArrayAndItemsPtr(T * ptr, size_t elementCount) : AutoArrayPtr<T>(ptr, elementCount) {}
 
     ~AutoArrayAndItemsPtr()
     {
@@ -92,11 +92,11 @@ private:
     }
 };
 
-template  <typename T>
+template <typename T>
 class AutoReleasePtr : public BasePtr<T>
 {
 public:
-    AutoReleasePtr(T * ptr = nullptr) : BasePtr(ptr) {}
+    AutoReleasePtr(T * ptr = nullptr) : BasePtr<T>(ptr) {}
     ~AutoReleasePtr()
     {
         Release();
@@ -112,11 +112,11 @@ public:
     }
 };
 
-template < typename T>
+template <typename T>
 class AutoCOMPtr : public AutoReleasePtr<T>
 {
 public:
-    AutoCOMPtr(T * ptr = nullptr) : AutoReleasePtr(ptr)
+    AutoCOMPtr(T * ptr = nullptr) : AutoReleasePtr<T>(ptr)
     {
         if (ptr != nullptr)
         {

--- a/lib/Common/Memory/Chakra.Common.Memory.vcxproj
+++ b/lib/Common/Memory/Chakra.Common.Memory.vcxproj
@@ -25,6 +25,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>
+        $(MSBuildThisFileDirectory);
         $(MSBuildThisFileDirectory)..;
         %(AdditionalIncludeDirectories)
       </AdditionalIncludeDirectories>

--- a/lib/Common/Memory/HeapBucket.h
+++ b/lib/Common/Memory/HeapBucket.h
@@ -67,10 +67,11 @@ public:
 
     uint GetBucketIndex() const;
     uint GetMediumBucketIndex() const;
-protected:
-    template <typename TBlockType>
-    static void EnumerateObjects(TBlockType * heapBlockList, ObjectInfoBits infoBits, void (*CallBackFunction)(void * address, size_t size));
 
+    template <typename TBlockType>
+    static void EnumerateObjects(TBlockType * heapBlockList, ObjectInfoBits infoBits, void(*CallBackFunction)(void * address, size_t size));
+
+protected:
     HeapInfo * heapInfo;
     uint sizeCat;
 

--- a/lib/Common/Memory/HeapInfo.cpp
+++ b/lib/Common/Memory/HeapInfo.cpp
@@ -12,11 +12,7 @@
 #error "Platform is not handled"
 #endif
 
-#ifdef _MSC_VER
-template __forceinline char* HeapInfo::RealAlloc<NoBit, false>(Recycler * recycler, size_t sizeCat, size_t size);
-#else
-template __attribute__((always_inline)) char* HeapInfo::RealAlloc<NoBit, false>(Recycler * recycler, size_t sizeCat, size_t size);
-#endif
+template _ALWAYSINLINE char* HeapInfo::RealAlloc<NoBit, false>(Recycler * recycler, size_t sizeCat, size_t size);
 
 const uint SmallAllocationBlockAttributes::MaxSmallObjectCount;
 const uint MediumAllocationBlockAttributes::MaxSmallObjectCount;

--- a/lib/Common/Memory/HeapInfo.h
+++ b/lib/Common/Memory/HeapInfo.h
@@ -282,7 +282,7 @@ private:
     {
         // xplat-todo: fix up vpm.64b.h generation to generate correctly
         // templatized code
-#ifdef _WIN32
+#if defined(_MSC_VER) && !defined(__clang__)
 #define USE_STATIC_VPM 1 // Disable to force generation at runtime
 #else
 #define USE_STATIC_VPM 0

--- a/lib/Common/Memory/Recycler.cpp
+++ b/lib/Common/Memory/Recycler.cpp
@@ -117,15 +117,9 @@ DefaultRecyclerCollectionWrapper::DisposeObjects(Recycler * recycler)
 
 static void* GetStackBase();
 
-#ifdef _MSC_VER
-template __forceinline char * Recycler::AllocWithAttributesInlined<NoBit, false>(size_t size);
-template __forceinline char* Recycler::RealAlloc<NoBit, false>(HeapInfo* heap, size_t size);
-template __forceinline _Ret_notnull_ void * __cdecl operator new<Recycler>(size_t byteSize, Recycler * alloc, char * (Recycler::*AllocFunc)(size_t));
-#else
-template __attribute__((always_inline)) char * Recycler::AllocWithAttributesInlined<NoBit, false>(size_t size);
-template __attribute__((always_inline)) char* Recycler::RealAlloc<NoBit, false>(HeapInfo* heap, size_t size);
-template __attribute__((always_inline)) void * __cdecl operator new<Recycler>(size_t byteSize, Recycler * alloc, char * (Recycler::*AllocFunc)(size_t));
-#endif
+template _ALWAYSINLINE char * Recycler::AllocWithAttributesInlined<NoBit, false>(size_t size);
+template _ALWAYSINLINE char* Recycler::RealAlloc<NoBit, false>(HeapInfo* heap, size_t size);
+template _ALWAYSINLINE _Ret_notnull_ void * __cdecl operator new<Recycler>(size_t byteSize, Recycler * alloc, char * (Recycler::*AllocFunc)(size_t));
 
 Recycler::Recycler(AllocationPolicyManager * policyManager, IdleDecommitPageAllocator * pageAllocator, void (*outOfMemoryFunc)(), Js::ConfigFlagsTable& configFlagsTable) :
     collectionState(CollectionStateNotCollecting),

--- a/lib/Common/Memory/Recycler.h
+++ b/lib/Common/Memory/Recycler.h
@@ -569,10 +569,10 @@ public:
 
 private:
     // Static entry point for thread creation
-    static unsigned int StaticThreadProc(LPVOID lpParameter);
+    static unsigned int CALLBACK StaticThreadProc(LPVOID lpParameter);
 
     // Static entry point for thread service usage
-    static void StaticBackgroundWorkCallback(void * callbackData);
+    static void CALLBACK StaticBackgroundWorkCallback(void * callbackData);
 
 private:
     WorkFunc workFunc;
@@ -1697,12 +1697,12 @@ private:
     bool AbortConcurrent(bool restoreState);
     void FinalizeConcurrent(bool restoreState);
 
-    static unsigned int  StaticThreadProc(LPVOID lpParameter);
+    static unsigned int CALLBACK StaticThreadProc(LPVOID lpParameter);
     static int ExceptFilter(LPEXCEPTION_POINTERS pEP);
     DWORD ThreadProc();
 
     void DoBackgroundWork(bool forceForeground = false);
-    static void StaticBackgroundWorkCallback(void * callbackData);
+    static void CALLBACK StaticBackgroundWorkCallback(void * callbackData);
 
     BOOL CollectOnConcurrentThread();
     bool StartConcurrent(CollectionState const state);
@@ -2312,7 +2312,13 @@ template <bool isLeaf>
 class ListTypeAllocatorFunc<Recycler, isLeaf>
 {
 public:
+    typedef char * (Recycler::*AllocFuncType)(size_t);
     typedef bool (Recycler::*FreeFuncType)(void*, size_t);
+
+    static AllocFuncType GetAllocFunc()
+    {
+        return isLeaf ? &Recycler::AllocLeaf : &Recycler::Alloc;
+    }
 
     static FreeFuncType GetFreeFunc()
     {

--- a/lib/Common/Memory/RecyclerPageAllocator.cpp
+++ b/lib/Common/Memory/RecyclerPageAllocator.cpp
@@ -197,7 +197,7 @@ size_t
 RecyclerPageAllocator::GetAllWriteWatchPageCount(DListBase<T> * segmentList)
 {
     size_t totalCount = 0;
-    DListBase<T>::Iterator it(segmentList);
+    _TYPENAME DListBase<T>::Iterator it(segmentList);
     while (it.Next())
     {
         T& segment = it.Data();

--- a/lib/Common/Memory/SmallFinalizableHeapBucket.h
+++ b/lib/Common/Memory/SmallFinalizableHeapBucket.h
@@ -164,39 +164,70 @@ public:
 template <class TBlockAttributes>
 class HeapBucketGroup
 {
-public:
     template <ObjectInfoBits objectAttributes>
-    typename SmallHeapBlockType<objectAttributes, TBlockAttributes>::BucketType& GetBucket()
+    class BucketGetter
     {
-        CompileAssert(objectAttributes & FinalizeBit);
-        return this->finalizableHeapBucket;
-    }
+    public:
+        typedef typename SmallHeapBlockType<objectAttributes, TBlockAttributes>::BucketType BucketType;
+        static BucketType& GetBucket(HeapBucketGroup<TBlockAttributes> * heapBucketGroup)
+        {
+            CompileAssert(objectAttributes & FinalizeBit);
+            return heapBucketGroup->finalizableHeapBucket;
+        }
+    };
 
     template <>
-    typename SmallHeapBlockType<LeafBit, TBlockAttributes>::BucketType& GetBucket<LeafBit>()
+    class BucketGetter<LeafBit>
     {
-        return this->leafHeapBucket;
-    }
+    public:
+        typedef typename SmallHeapBlockType<LeafBit, TBlockAttributes>::BucketType BucketType;
+        static BucketType& GetBucket(HeapBucketGroup<TBlockAttributes> * heapBucketGroup)
+        {            
+            return heapBucketGroup->leafHeapBucket;
+        }
+    };
 
     template <>
-    typename SmallHeapBlockType<NoBit, TBlockAttributes>::BucketType& GetBucket<NoBit>()
+    class BucketGetter<NoBit>
     {
-        return this->heapBucket;
-    }
+    public:
+        typedef typename SmallHeapBlockType<NoBit, TBlockAttributes>::BucketType BucketType;
+        static BucketType& GetBucket(HeapBucketGroup<TBlockAttributes> * heapBucketGroup)
+        {
+            return heapBucketGroup->heapBucket;
+        }
+    };
 
 #ifdef RECYCLER_WRITE_BARRIER
     template <>
-    typename SmallHeapBlockType<WithBarrierBit, TBlockAttributes>::BucketType& GetBucket<WithBarrierBit>()
+    class BucketGetter<WithBarrierBit>
     {
-        return this->smallNormalWithBarrierHeapBucket;
-    }
+    public:
+        typedef typename SmallHeapBlockType<WithBarrierBit, TBlockAttributes>::BucketType BucketType;
+        static BucketType& GetBucket(HeapBucketGroup<TBlockAttributes> * heapBucketGroup)
+        {
+            return heapBucketGroup->smallNormalWithBarrierHeapBucket;
+        }
+    };
 
     template <>
-    typename SmallHeapBlockType<FinalizableWithBarrierBit, TBlockAttributes>::BucketType& GetBucket<FinalizableWithBarrierBit>()
+    class BucketGetter<FinalizableWithBarrierBit>
     {
-        return this->smallFinalizableWithBarrierHeapBucket;
-    }
+    public:
+        typedef typename SmallHeapBlockType<FinalizableWithBarrierBit, TBlockAttributes>::BucketType BucketType;
+        static BucketType& GetBucket(HeapBucketGroup<TBlockAttributes> * heapBucketGroup)
+        {
+            return heapBucketGroup->smallFinalizableWithBarrierHeapBucket;
+        }
+    };
 #endif
+public:
+
+    template <ObjectInfoBits objectAttributes>
+    typename SmallHeapBlockType<objectAttributes, TBlockAttributes>::BucketType& GetBucket()
+    {
+        return BucketGetter<objectAttributes>::GetBucket(this);
+    }
 
     void Initialize(HeapInfo * heapInfo, uint sizeCat);
     void ResetMarks(ResetMarkFlags flags);

--- a/lib/Common/Memory/SmallHeapBlockAllocator.cpp
+++ b/lib/Common/Memory/SmallHeapBlockAllocator.cpp
@@ -256,9 +256,5 @@ namespace Memory
 {
     EXPLICIT_INSTANTIATE_WITH_SMALL_HEAP_BLOCK_TYPE(SmallHeapBlockAllocator)
 
-#ifdef _MSC_VER
-    template __forceinline char* SmallHeapBlockAllocator<SmallNormalHeapBlock>::InlinedAllocImpl</*canFaultInject*/true>(Recycler * recycler, size_t sizeCat, ObjectInfoBits attributes);
-#else
-    template __attribute__((always_inline)) char* SmallHeapBlockAllocator<SmallNormalHeapBlock>::InlinedAllocImpl</*canFaultInject*/true>(Recycler * recycler, size_t sizeCat, ObjectInfoBits attributes);
-#endif
+    template _ALWAYSINLINE char* SmallHeapBlockAllocator<SmallNormalHeapBlock>::InlinedAllocImpl</*canFaultInject*/true>(Recycler * recycler, size_t sizeCat, ObjectInfoBits attributes);
 }

--- a/lib/Parser/rterror.cpp
+++ b/lib/Parser/rterror.cpp
@@ -2,7 +2,7 @@
 // Copyright (C) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
-#include <ParserPch.h>
+#include "ParserPch.h"
 #include "rterror.h"
 
 // PUBLIC ERROR codes

--- a/lib/Runtime/ByteCode/ByteCodeWriter.h
+++ b/lib/Runtime/ByteCode/ByteCodeWriter.h
@@ -106,7 +106,7 @@ namespace Js
             // asm.js encoding
             uint Encode(OpCodeAsmJs op, ByteCodeWriter* writer){ return EncodeT<Js::SmallLayout>(op, writer, /*isPatching*/false); }
             uint Encode(OpCodeAsmJs op, const void * rawData, int byteSize, ByteCodeWriter* writer, bool isPatching = false){ return EncodeT<Js::SmallLayout>(op, rawData, byteSize, writer, isPatching); }
-            template <LayoutSize layoutSize> uint EncodeT(OpCodeAsmJs op, ByteCodeWriter* writer, bool isPatching = false);
+            template <LayoutSize layoutSize> uint EncodeT(OpCodeAsmJs op, ByteCodeWriter* writer, bool isPatching);
             template <> uint EncodeT<SmallLayout>(OpCodeAsmJs op, ByteCodeWriter* writer, bool isPatching);
             template <LayoutSize layoutSize> uint EncodeT(OpCodeAsmJs op, const void * rawData, int byteSize, ByteCodeWriter* writer, bool isPatching = false);
 

--- a/lib/Runtime/Language/Chakra.Runtime.Language.vcxproj
+++ b/lib/Runtime/Language/Chakra.Runtime.Language.vcxproj
@@ -25,6 +25,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>
+        $(MSBuildThisFileDirectory);
         $(MSBuildThisFileDirectory)..;
         $(MSBuildThisFileDirectory)..\..\Common;
         $(MSBuildThisFileDirectory)..\..\Parser;

--- a/lib/Runtime/Library/JavascriptError.cpp
+++ b/lib/Runtime/Library/JavascriptError.cpp
@@ -454,7 +454,7 @@ namespace Js
         pError->SetNotEnumerable(PropertyIds::description);
 
         hr = JavascriptError::GetErrorNumberFromResourceID(hr);
-        JavascriptOperators::InitProperty(pError, PropertyIds::number, JavascriptNumber::ToVar(hr, scriptContext));
+        JavascriptOperators::InitProperty(pError, PropertyIds::number, JavascriptNumber::ToVar((int32)hr, scriptContext));
         pError->SetNotEnumerable(PropertyIds::number);
     }
 

--- a/lib/Runtime/Library/JavascriptErrorDebug.cpp
+++ b/lib/Runtime/Library/JavascriptErrorDebug.cpp
@@ -8,13 +8,17 @@
 #include "errstr.h"
 #include "Library/JavascriptErrorDebug.h"
 
+#if defined(_MSC_VER) && !defined(__clang__)
 // Temporarily undefining "null" (defined in Common.h) to avoid compile errors when importing mscorlib.tlb
 #import <mscorlib.tlb> raw_interfaces_only \
     rename("Assert","CLRAssert") rename("ReportEvent","CLRReportEvent") rename("Debugger","CLRDebugger")
+#endif
 
 namespace Js
 {
+#if defined(_MSC_VER) && !defined(__clang__)
     using namespace mscorlib;
+#endif
 
     __declspec(thread)  char16 JavascriptErrorDebug::msgBuff[512];
 
@@ -235,10 +239,7 @@ namespace Js
         memset(proerrstr, 0, sizeof(*proerrstr));
         *pperrinfo = nullptr;
 
-#ifndef _WIN32
-        // xplat-todo: Find out if we can implement richer error info on Linux
-        return hr;
-#else
+#if defined(_MSC_VER) && !defined(__clang__)
         // GetErrorInfo returns S_FALSE if there is no rich error info
         // and S_OK if there is.
         IErrorInfo * perrinfo;
@@ -368,6 +369,9 @@ namespace Js
             pCLRException->Release();
         }
         *pperrinfo = perrinfo;
+        return hr;
+#else
+        // xplat-todo: Find out if we can implement richer error info on Linux
         return hr;
 #endif
     }


### PR DESCRIPTION
Build x64 no jit configurations using clang on windows.
Disable a bunch of warning,
Fix issue with PCH builds.

Since clang on windows doesn't support /homeparam, any javascript that requires stack walking doesn't work (e.g. exception)