### PR TITLE
Fix DRT issue related to HostDispatch property access

### DIFF
--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -5044,12 +5044,17 @@ CommonNumber:
             return false;
         }
 
-        if (JavascriptProxy::Is(instance) || instance->IsExternal())
+        TypeId typeId = instance->GetTypeId();
+        if (typeId == TypeIds_Proxy || typeId == TypeIds_HostDispatch)
         {
             return false;
         }
-        if (DynamicType::Is(instance->GetTypeId()) && 
+        if (DynamicType::Is(typeId) && 
             static_cast<DynamicObject*>(instance)->GetTypeHandler()->IsStringTypeHandler())
+        {
+            return false;
+        }
+        if (instance->IsExternal())
         {
             return false;
         }


### PR DESCRIPTION
My cleanup of the shortcut-property-access-on-unknown-property-name optimization relied on IsExternal() to tell us whether an object is eligible. But we must also exclude HostDispatch, which returns false on IsExternal().