### PR TITLE
Silence Clang 3.9 warnings

### DIFF
--- a/lib/Common/Common/Tick.cpp
+++ b/lib/Common/Common/Tick.cpp
@@ -328,18 +328,18 @@ namespace Js {
         //
         // Ensure we can convert losslessly.
         //
-
+#if DBG
         const int64 lnMinTimeDelta = _I64_MIN / ((int64) 1000000);
         const int64 lnMaxTimeDelta = _I64_MAX / ((int64) 1000000);
         AssertMsg((m_lnDelta <= lnMaxTimeDelta) && (m_lnDelta >= lnMinTimeDelta),
                 "Ensure delta can be converted to microseconds losslessly");
-
+#endif
 
         //
         // Compute the microseconds.
         //
 
-        int64 lnFreq = (int64) Tick::s_luFreq;
+        const int64 lnFreq = (int64) Tick::s_luFreq;
         int64 lnTickDelta = (m_lnDelta * ((int64) 1000000)) / lnFreq;
         return lnTickDelta;
     }

--- a/lib/Runtime/Base/CharStringCache.cpp
+++ b/lib/Runtime/Base/CharStringCache.cpp
@@ -18,7 +18,7 @@ namespace Js
     {
         AssertMsg(JavascriptString::IsASCII7BitChar(c), "GetStringForCharA must be called with ASCII 7bit chars only");
 
-        PropertyString * str = charStringCacheA[c];
+        PropertyString * str = charStringCacheA[(int)c];
         if (str == nullptr)
         {
             PropertyRecord const * propertyRecord;
@@ -26,7 +26,7 @@ namespace Js
             JavascriptLibrary * javascriptLibrary = JavascriptLibrary::FromCharStringCache(this);
             javascriptLibrary->GetScriptContext()->GetOrAddPropertyRecord(&wc, 1, &propertyRecord);
             str = javascriptLibrary->CreatePropertyString(propertyRecord);
-            charStringCacheA[c] = str;
+            charStringCacheA[(int)c] = str;
         }
 
         return str;

--- a/lib/Runtime/Base/ThreadContext.h
+++ b/lib/Runtime/Base/ThreadContext.h
@@ -56,6 +56,8 @@ class InterruptPoller abstract
 public:
     InterruptPoller(ThreadContext *tc);
 
+    virtual ~InterruptPoller() { }
+
     void CheckInterruptPoll();
     void GetStatementCount(ULONG *pluHi, ULONG *pluLo);
     void ResetStatementCount() { lastResetTick = lastPollTick; }

--- a/lib/Runtime/DetachedStateBase.h
+++ b/lib/Runtime/DetachedStateBase.h
@@ -20,6 +20,10 @@ namespace Js
         {
         }
 
+        virtual ~DetachedStateBase()
+        {
+        }
+
         TypeId GetTypeId() { return typeId; }
 
         bool HasBeenClaimed() { return hasBeenClaimed; }


### PR DESCRIPTION
warning: destructor called on ******** that is abstract but has non-virtual destructor [-Wdelete-non-virtual-dtor]
    obj->~T();

and couple of other type related / unused code warnings.

See @jianchun’s review (thanks again!)
https://github.com/obastemur/ChakraCore/commit/c4084f642c0bc658bf349242c7618311fdf525b0 

@curtisman  @jianchun @digitalinfinity any concerns with this targeting
master branch instead of linux?