### PR TITLE
#535 - Proxy traps not triggered for __lookupGetter and __lookupSetter_

### DIFF
--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -2501,7 +2501,7 @@ CommonNumber:
             {
                 break;
             }
-            object = JavascriptOperators::GetPrototypeNoTrap(object);
+            object = JavascriptOperators::GetPrototype(object);
         }
         return FALSE;
     }

--- a/test/es7/lookupgettersetter.js
+++ b/test/es7/lookupgettersetter.js
@@ -1,0 +1,49 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+
+var tests = [
+    {
+        name: "Object.prototype.__lookupGetter__ -> [[GetOwnProperty]], [[GetPrototypeOf]]",
+        body: function () {
+            assert.isTrue((function()
+            {
+                // Object.prototype.__lookupGetter__ -> [[GetOwnProperty]]
+                // Object.prototype.__lookupGetter__ -> [[GetPrototypeOf]]
+                var gopd = [];
+                var gpo = false;
+                var p = new Proxy({}, 
+                {
+                    getPrototypeOf: function(o) { gpo = true; return Object.getPrototypeOf(o); },
+                    getOwnPropertyDescriptor: function(o, v) { gopd.push(v); return Object.getOwnPropertyDescriptor(o, v); }
+                });
+                Object.prototype.__lookupGetter__.call(p, "foo");
+                return gopd + '' === "foo" && gpo;
+            })());
+        }
+    },
+    {
+        name: "Object.prototype.__lookupSetter__ -> [[GetOwnProperty]], [[GetPrototypeOf]]",
+        body: function () {
+            assert.isTrue((function()
+            {
+                // Object.prototype.__lookupSetter__ -> [[GetOwnProperty]]
+                // Object.prototype.__lookupSetter__ -> [[GetPrototypeOf]]
+                var gopd = [];
+                var gpo = false;
+                var p = new Proxy({}, 
+                {
+                    getPrototypeOf: function(o) { gpo = true; return Object.getPrototypeOf(o); },
+                    getOwnPropertyDescriptor: function(o, v) { gopd.push(v); return Object.getOwnPropertyDescriptor(o, v); }
+                });
+                Object.prototype.__lookupSetter__.call(p, "foo");
+                return gopd + '' === "foo" && gpo;
+            })());
+        }
+    }
+];
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/es7/lookupgettersetter.js
+++ b/test/es7/lookupgettersetter.js
@@ -9,39 +9,37 @@ var tests = [
     {
         name: "Object.prototype.__lookupGetter__ -> [[GetOwnProperty]], [[GetPrototypeOf]]",
         body: function () {
-            assert.isTrue((function()
+            // Object.prototype.__lookupGetter__ -> [[GetOwnProperty]]
+            // Object.prototype.__lookupGetter__ -> [[GetPrototypeOf]]
+            var gopd = [];
+            var gpo = false;
+            var p = new Proxy({}, 
             {
-                // Object.prototype.__lookupGetter__ -> [[GetOwnProperty]]
-                // Object.prototype.__lookupGetter__ -> [[GetPrototypeOf]]
-                var gopd = [];
-                var gpo = false;
-                var p = new Proxy({}, 
-                {
-                    getPrototypeOf: function(o) { gpo = true; return Object.getPrototypeOf(o); },
-                    getOwnPropertyDescriptor: function(o, v) { gopd.push(v); return Object.getOwnPropertyDescriptor(o, v); }
-                });
-                Object.prototype.__lookupGetter__.call(p, "foo");
-                return gopd + '' === "foo" && gpo;
-            })());
+                getPrototypeOf: function(o) { gpo = true; return Object.getPrototypeOf(o); },
+                getOwnPropertyDescriptor: function(o, v) { gopd.push(v); return Object.getOwnPropertyDescriptor(o, v); }
+            });
+            Object.prototype.__lookupGetter__.call(p, "foo");
+            assert.areEqual(1, gopd.length, "getOwnPropertyDescriptor should only be called once");
+            assert.areEqual("foo", gopd[0], "getOwnPropertyDescriptor should be called with foo");
+            assert.isTrue(gpo, "getPrototypeOf should be called");
         }
     },
     {
         name: "Object.prototype.__lookupSetter__ -> [[GetOwnProperty]], [[GetPrototypeOf]]",
         body: function () {
-            assert.isTrue((function()
+            // Object.prototype.__lookupSetter__ -> [[GetOwnProperty]]
+            // Object.prototype.__lookupSetter__ -> [[GetPrototypeOf]]
+            var gopd = [];
+            var gpo = false;
+            var p = new Proxy({}, 
             {
-                // Object.prototype.__lookupSetter__ -> [[GetOwnProperty]]
-                // Object.prototype.__lookupSetter__ -> [[GetPrototypeOf]]
-                var gopd = [];
-                var gpo = false;
-                var p = new Proxy({}, 
-                {
-                    getPrototypeOf: function(o) { gpo = true; return Object.getPrototypeOf(o); },
-                    getOwnPropertyDescriptor: function(o, v) { gopd.push(v); return Object.getOwnPropertyDescriptor(o, v); }
-                });
-                Object.prototype.__lookupSetter__.call(p, "foo");
-                return gopd + '' === "foo" && gpo;
-            })());
+                getPrototypeOf: function(o) { gpo = true; return Object.getPrototypeOf(o); },
+                getOwnPropertyDescriptor: function(o, v) { gopd.push(v); return Object.getOwnPropertyDescriptor(o, v); }
+            });
+            Object.prototype.__lookupSetter__.call(p, "foo");
+            assert.areEqual(1, gopd.length, "getOwnPropertyDescriptor should only be called once");
+            assert.areEqual("foo", gopd[0], "getOwnPropertyDescriptor should be called with foo");
+            assert.isTrue(gpo, "getPrototypeOf should be called");
         }
     }
 ];

--- a/test/es7/rlexe.xml
+++ b/test/es7/rlexe.xml
@@ -65,4 +65,11 @@
       <compile-flags>-args summary -endargs</compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>lookupgettersetter.js</files>
+      <compile-flags>-args summary -endargs</compile-flags>
+      <tags>BugFix</tags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
just need to call GetPrototype instead of GetPrototypeNoTrap in JavascriptOperators::GetAccessors
