### PR TITLE
xplat: fix direct entryPoint calling convention

### DIFF
--- a/lib/Runtime/Base/CallInfo.h
+++ b/lib/Runtime/Base/CallInfo.h
@@ -29,7 +29,7 @@ namespace Js
          * to pass this object by reference. Interpreter stack setup code expects
          * CallInfo to be passed by value.
          */
-        CallInfo(ushort count)
+        explicit CallInfo(ushort count)
             : Flags(CallFlags_None)
             , Count(count)
 #ifdef _WIN64
@@ -62,6 +62,12 @@ namespace Js
         unsigned unused : 32;
 #endif
 
+#if DBG
+        bool operator==(CallInfo other) const
+        {
+            return this->Count == other.Count && this->Flags == other.Flags;
+        }
+#endif
     public:
         static const ushort ksizeofCount;
         static const ushort ksizeofCallFlags;

--- a/lib/Runtime/Language/JavascriptConversion.cpp
+++ b/lib/Runtime/Language/JavascriptConversion.cpp
@@ -524,7 +524,7 @@ CommonNumber:
                 Assert(!ThreadContext::IsOnStack(recyclableObject));
 
                 // Let result be the result of calling the[[Call]] internal method of exoticToPrim, with input as thisArgument and(hint) as argumentsList.
-                return  exoticToPrim->GetEntryPoint()(exoticToPrim, CallInfo(CallFlags_Value, 2), recyclableObject, hintString);
+                return CALL_FUNCTION(exoticToPrim, CallInfo(CallFlags_Value, 2), recyclableObject, hintString);
             });
 
             Assert(!CrossSite::NeedMarshalVar(result, requestContext));
@@ -691,7 +691,7 @@ CommonNumber:
                 return JavascriptString::FromVar(simdObject->ToString(scriptContext));
             }
 #endif
-            
+
             case TypeIds_GlobalObject:
                 aValue = static_cast<Js::GlobalObject*>(aValue)->ToThis();
                 // fall through
@@ -754,7 +754,7 @@ CommonNumber:
                 if (JavascriptConversion::IsCallable(value))
                 {
                     RecyclableObject* toLocaleStringFunction = RecyclableObject::FromVar(value);
-                    Var aResult = toLocaleStringFunction->GetEntryPoint()(toLocaleStringFunction, 1, aValue);
+                    Var aResult = CALL_FUNCTION(toLocaleStringFunction, CallInfo(1), aValue);
                     if (JavascriptString::Is(aResult))
                     {
                         return JavascriptString::FromVar(aResult);
@@ -848,7 +848,7 @@ CommonNumber:
             return true;
         }
 #endif
-        
+
         default:
             {
                 AssertMsg(JavascriptOperators::IsObject(aValue), "bad type object in conversion ToBoolean");
@@ -958,7 +958,7 @@ CommonNumber:
             case TypeIds_SIMDUint8x16:
                 JavascriptError::ThrowError(scriptContext, JSERR_NeedNumber);
 #endif
-                
+
             default:
                 {
                     AssertMsg(JavascriptOperators::IsObject(aValue), "bad type object in conversion ToInteger");
@@ -1027,7 +1027,7 @@ CommonNumber:
             case TypeIds_SIMDUint8x16:
                 JavascriptError::ThrowError(scriptContext, JSERR_NeedNumber);
 #endif
-                
+
             default:
                 {
                     AssertMsg(JavascriptOperators::IsObject(aValue), "bad type object in conversion ToInteger");
@@ -1129,7 +1129,7 @@ CommonNumber:
         case TypeIds_SIMDUint8x16:
             JavascriptError::ThrowError(scriptContext, JSERR_NeedNumber);
 #endif
-            
+
         default:
             AssertMsg(JavascriptOperators::IsObject(aValue), "bad type object in conversion ToInteger32");
             aValue = ToPrimitive(aValue, JavascriptHint::HintNumber, scriptContext);
@@ -1244,7 +1244,7 @@ CommonNumber:
             case TypeIds_SIMDUint8x16:
                 JavascriptError::ThrowError(scriptContext, JSERR_NeedNumber);
 #endif
-                
+
             default:
                 {
                     AssertMsg(JavascriptOperators::IsObject(aValue), "bad type object in conversion ToInteger32");
@@ -1395,7 +1395,7 @@ CommonNumber:
             case TypeIds_SIMDUint8x16:
                 JavascriptError::ThrowError(scriptContext, JSERR_NeedNumber);
 #endif
-                
+
             default:
                 {
                     AssertMsg(JavascriptOperators::IsObject(aValue), "bad type object in conversion ToUInt32");
@@ -1484,7 +1484,7 @@ CommonNumber:
             case TypeIds_SIMDUint8x16:
                 JavascriptError::ThrowError(scriptContext, JSERR_NeedNumber);
 #endif
-                
+
             default:
                 {
                     AssertMsg(JavascriptOperators::IsObject(aValue), "bad type object in conversion ToUIn16");

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -582,7 +582,7 @@ namespace Js
             return StrictEqualSIMD(aLeft, aRight, requestContext);
         }
 #endif
-        
+
         if (RecyclableObject::FromVar(aLeft)->Equals(aRight, &result, requestContext))
         {
             return result;
@@ -1382,7 +1382,7 @@ CommonNumber:
             return aRight;
         }
 
-        Var iteratorVar = function->GetEntryPoint()(function, CallInfo(Js::CallFlags_Value, 1), aRight);
+        Var iteratorVar = CALL_FUNCTION(function, CallInfo(Js::CallFlags_Value, 1), aRight);
 
         if (!JavascriptOperators::IsObject(iteratorVar))
         {
@@ -5801,7 +5801,7 @@ CommonNumber:
             JavascriptOperators::NewScObjectCommon(object, functionInfo, requestContext) :
             JavascriptOperators::NewScObjectHostDispatchOrProxy(object, requestContext);
 
-        Var returnVar = object->GetEntryPoint()(object, CallInfo(CallFlags_New, 1), newObject);
+        Var returnVar = CALL_FUNCTION(object, CallInfo(CallFlags_New, 1), newObject);
         if (JavascriptOperators::IsObject(returnVar))
         {
             newObject = returnVar;
@@ -9268,12 +9268,7 @@ CommonNumber:
             Var thisVar = RootToThisObject(object, scriptContext);
 
             RecyclableObject* marshalledFunction = RecyclableObject::FromVar(CrossSite::MarshalVar(requestContext, function));
-#ifdef _WIN32
-            Var result = marshalledFunction->GetEntryPoint()(function, CallInfo(flags, 1), thisVar);
-#else
-            Var result = JavascriptFunction::CallFunction<false>(
-                    function, marshalledFunction->GetEntryPoint(), Arguments(CallInfo(flags, 1), &thisVar));
-#endif
+            Var result = CALL_ENTRYPOINT(marshalledFunction->GetEntryPoint(), function, CallInfo(flags, 1), thisVar);
             result = CrossSite::MarshalVar(requestContext, result);
 
             return result;
@@ -9315,13 +9310,7 @@ CommonNumber:
                 marshalledFunction = RecyclableObject::FromVar(CrossSite::MarshalVar(requestContext, function));
             }
 
-#ifdef _WIN32
-            Var result = marshalledFunction->GetEntryPoint()(function, CallInfo(flags, 2), thisVar, putValue);
-#else
-            Var args[] = { thisVar, putValue };
-            Var result = JavascriptFunction::CallFunction<false>(
-                    function, marshalledFunction->GetEntryPoint(), Arguments(CallInfo(flags, 2), args));
-#endif
+            Var result = CALL_ENTRYPOINT(marshalledFunction->GetEntryPoint(), function, CallInfo(flags, 2), thisVar, putValue);
             Assert(result);
             return nullptr;
         });
@@ -9691,7 +9680,7 @@ CommonNumber:
 
         try
         {
-            executor->GetEntryPoint()(executor, CallInfo(CallFlags_Value, 3), library->GetUndefined(), resolve, reject);
+            CALL_FUNCTION(executor, CallInfo(CallFlags_Value, 3), library->GetUndefined(), resolve, reject);
         }
         catch (JavascriptExceptionObject* ex)
         {
@@ -10442,7 +10431,7 @@ CommonNumber:
             return nullptr;
         }
 
-        Var iterator = function->GetEntryPoint()(function, CallInfo(Js::CallFlags_Value, 1), instance);
+        Var iterator = CALL_FUNCTION(function, CallInfo(Js::CallFlags_Value, 1), instance);
 
         if (!JavascriptOperators::IsObject(iterator))
         {

--- a/lib/Runtime/Library/GlobalObject.cpp
+++ b/lib/Runtime/Library/GlobalObject.cpp
@@ -701,7 +701,7 @@ namespace Js
             // Executing the eval causes the scope chain to escape.
             pfuncScript->InvalidateCachedScopeChain();
         }
-        Var varResult = pfuncScript->GetEntryPoint()(pfuncScript, CallInfo(CallFlags_Eval, 1), varThis);
+        Var varResult = CALL_FUNCTION(pfuncScript, CallInfo(CallFlags_Eval, 1), varThis);
         pfuncScript->SetEnvironment(nullptr);
         return varResult;
     }

--- a/lib/Runtime/Library/JavascriptArray.cpp
+++ b/lib/Runtime/Library/JavascriptArray.cpp
@@ -6016,11 +6016,11 @@ Case0:
             {
                 Var leftVar = CrossSite::MarshalVar(scriptContext, *(Var*)aRef);
                 Var rightVar = CrossSite::MarshalVar(scriptContext, *(Var*)bRef);
-                retVal = compFn->GetEntryPoint()(compFn, CallInfo(flags, 3), undefined, leftVar, rightVar);
+                retVal = CALL_FUNCTION(compFn, CallInfo(flags, 3), undefined, leftVar, rightVar);
             }
             else
             {
-                retVal = compFn->GetEntryPoint()(compFn, CallInfo(flags, 3), undefined, *(Var*)aRef, *(Var*)bRef);
+                retVal = CALL_FUNCTION(compFn, CallInfo(flags, 3), undefined, *(Var*)aRef, *(Var*)bRef);
             }
 
             if (TaggedInt::Is(retVal))
@@ -7540,7 +7540,7 @@ Case0:
 
                 // The correct flag value is CallFlags_Value but we pass CallFlags_None in compat modes
                 CallFlags flags = CallFlags_Value;
-                return func->GetEntryPoint()(func, CallInfo(flags, 1), obj);
+                return CALL_FUNCTION(func, CallInfo(flags, 1), obj);
             });
 
             if(!result)
@@ -7555,7 +7555,7 @@ Case0:
         else
         {
             // call built-in Object.prototype.toString
-            return JavascriptObject::EntryToString(function, 1, obj);
+            return CALL_ENTRYPOINT(JavascriptObject::EntryToString, function, CallInfo(1), obj);
         }
     }
 
@@ -7630,7 +7630,7 @@ Case0:
         }
 #else
         // xplat-todo: Support locale-specific seperator
-        return scriptContext->GetLibrary()->GetCommaSpaceDisplayString();        
+        return scriptContext->GetLibrary()->GetCommaSpaceDisplayString();
 #endif
     }
 
@@ -7809,7 +7809,7 @@ Case0:
 
                 Var index = JavascriptNumber::ToVar(k, scriptContext);
 
-                testResult = callBackFn->GetEntryPoint()(callBackFn, CallInfo(flags, 4), thisArg,
+                testResult = CALL_FUNCTION(callBackFn, CallInfo(flags, 4), thisArg,
                     element,
                     index,
                     pArr);
@@ -7828,7 +7828,7 @@ Case0:
 
                 Var index = JavascriptNumber::ToVar(k, scriptContext);
 
-                testResult = callBackFn->GetEntryPoint()(callBackFn, CallInfo(flags, 4), thisArg,
+                testResult = CALL_FUNCTION(callBackFn, CallInfo(flags, 4), thisArg,
                     element,
                     index,
                     typedArrayBase);
@@ -7847,7 +7847,7 @@ Case0:
                 JavascriptOperators::GetItem(obj, k, &element, scriptContext);
                 Var index = JavascriptNumber::ToVar(k, scriptContext);
 
-                testResult = callBackFn->GetEntryPoint()(callBackFn, CallInfo(flags, 4), thisArg,
+                testResult = CALL_FUNCTION(callBackFn, CallInfo(flags, 4), thisArg,
                     element,
                     index,
                     obj);
@@ -8106,7 +8106,7 @@ Case0:
                     continue;
                 }
 
-                testResult = callBackFn->GetEntryPoint()(callBackFn, CallInfo(flags, 4), thisArg,
+                testResult = CALL_FUNCTION(callBackFn, CallInfo(flags, 4), thisArg,
                     element,
                     JavascriptNumber::ToVar(k, scriptContext),
                     pArr);
@@ -8130,7 +8130,7 @@ Case0:
 
                 element = typedArrayBase->DirectGetItem(k);
 
-                testResult = callBackFn->GetEntryPoint()(callBackFn, CallInfo(flags, 4), thisArg,
+                testResult = CALL_FUNCTION(callBackFn, CallInfo(flags, 4), thisArg,
                     element,
                     JavascriptNumber::ToVar(k, scriptContext),
                     typedArrayBase);
@@ -8153,7 +8153,7 @@ Case0:
                 BOOL getResult = JavascriptOperators::GetItem(obj, k, &element, scriptContext);
                 Assert(getResult);
 
-                testResult = callBackFn->GetEntryPoint()(callBackFn, CallInfo(flags, 4), thisArg,
+                testResult = CALL_FUNCTION(callBackFn, CallInfo(flags, 4), thisArg,
                     element,
                     JavascriptNumber::ToVar(k, scriptContext),
                     obj);
@@ -8279,7 +8279,7 @@ Case0:
                     continue;
                 }
 
-                testResult = callBackFn->GetEntryPoint()(callBackFn, CallInfo(flags, 4), thisArg,
+                testResult = CALL_FUNCTION(callBackFn, CallInfo(flags, 4), thisArg,
                     element,
                     JavascriptNumber::ToVar(k, scriptContext),
                     pArr);
@@ -8306,7 +8306,7 @@ Case0:
 
                 element = typedArrayBase->DirectGetItem(k);
 
-                testResult = callBackFn->GetEntryPoint()(callBackFn, CallInfo(flags, 4), thisArg,
+                testResult = CALL_FUNCTION(callBackFn, CallInfo(flags, 4), thisArg,
                     element,
                     JavascriptNumber::ToVar(k, scriptContext),
                     typedArrayBase);
@@ -8327,7 +8327,7 @@ Case0:
                 }
                 BOOL getResult = JavascriptOperators::GetItem(obj, k, &element, scriptContext);
                 Assert(getResult);
-                testResult = callBackFn->GetEntryPoint()(callBackFn, CallInfo(flags, 4), thisArg,
+                testResult = CALL_FUNCTION(callBackFn, CallInfo(flags, 4), thisArg,
                     element,
                     JavascriptNumber::ToVar(k, scriptContext),
                     obj);
@@ -8425,7 +8425,7 @@ Case0:
 
         auto fn32 = [dynamicObject, callBackFn, flags, thisArg, scriptContext](uint32 k, Var element)
         {
-            callBackFn->GetEntryPoint()(callBackFn, CallInfo(flags, 4), thisArg,
+            CALL_FUNCTION(callBackFn, CallInfo(flags, 4), thisArg,
                 element,
                 JavascriptNumber::ToVar(k, scriptContext),
                 dynamicObject);
@@ -8433,7 +8433,7 @@ Case0:
 
         auto fn64 = [dynamicObject, callBackFn, flags, thisArg, scriptContext](uint64 k, Var element)
         {
-            callBackFn->GetEntryPoint()(callBackFn, CallInfo(flags, 4), thisArg,
+            CALL_FUNCTION(callBackFn, CallInfo(flags, 4), thisArg,
                 element,
                 JavascriptNumber::ToVar(k, scriptContext),
                 dynamicObject);
@@ -8916,7 +8916,7 @@ Case0:
                     continue;
                 }
 
-                mappedValue = callBackFn->GetEntryPoint()(callBackFn, callBackFnInfo, thisArg,
+                mappedValue = CALL_FUNCTION(callBackFn, callBackFnInfo, thisArg,
                     element,
                     JavascriptNumber::ToVar(k, scriptContext),
                     pArr);
@@ -8956,7 +8956,7 @@ Case0:
                 }
 
                 element = typedArrayBase->DirectGetItem(k);
-                mappedValue = callBackFn->GetEntryPoint()(callBackFn, callBackFnInfo, thisArg,
+                mappedValue = CALL_FUNCTION(callBackFn, callBackFnInfo, thisArg,
                     element,
                     JavascriptNumber::ToVar(k, scriptContext),
                     obj);
@@ -8988,7 +8988,7 @@ Case0:
 
                 BOOL getResult = JavascriptOperators::GetItem(obj, k, &element, scriptContext);
                 Assert(getResult);
-                mappedValue = callBackFn->GetEntryPoint()(callBackFn, callBackFnInfo, thisArg,
+                mappedValue = CALL_FUNCTION(callBackFn, callBackFnInfo, thisArg,
                     element,
                     JavascriptNumber::ToVar(k, scriptContext),
                     obj);
@@ -9121,7 +9121,7 @@ Case0:
                     continue;
                 }
 
-                selected = callBackFn->GetEntryPoint()(callBackFn, CallInfo(flags, 4), thisArg,
+                selected = CALL_FUNCTION(callBackFn, CallInfo(flags, 4), thisArg,
                                                                 element,
                                                                 JavascriptNumber::ToVar(k, scriptContext),
                                                                 pArr);
@@ -9151,7 +9151,7 @@ Case0:
                 }
                 BOOL getResult = JavascriptOperators::GetItem(dynamicObject, k.IsSmallIndex() ? k.GetSmallIndex() : k.GetBigIndex(), &element, scriptContext);
                 Assert(getResult);
-                selected = callBackFn->GetEntryPoint()(callBackFn, CallInfo(flags, 4), thisArg,
+                selected = CALL_FUNCTION(callBackFn, CallInfo(flags, 4), thisArg,
                                                                 element,
                                                                 JavascriptNumber::ToVar(k.IsSmallIndex() ? k.GetSmallIndex() : k.GetBigIndex(), scriptContext),
                                                                 dynamicObject);
@@ -9339,7 +9339,7 @@ Case0:
                     continue;
                 }
 
-                accumulator = callBackFn->GetEntryPoint()(callBackFn, CallInfo(flags, 5), undefinedValue,
+                accumulator = CALL_FUNCTION(callBackFn, CallInfo(flags, 5), undefinedValue,
                     accumulator,
                     element,
                     JavascriptNumber::ToVar(k, scriptContext),
@@ -9358,7 +9358,7 @@ Case0:
 
                 element = typedArrayBase->DirectGetItem((uint32)k);
 
-                accumulator = callBackFn->GetEntryPoint()(callBackFn, CallInfo(flags, 5), undefinedValue,
+                accumulator = CALL_FUNCTION(callBackFn, CallInfo(flags, 5), undefinedValue,
                     accumulator,
                     element,
                     JavascriptNumber::ToVar(k, scriptContext),
@@ -9376,7 +9376,7 @@ Case0:
                 BOOL getResult = JavascriptOperators::GetItem(obj, k, &element, scriptContext);
                 Assert(getResult);
 
-                accumulator = callBackFn->GetEntryPoint()(callBackFn, CallInfo(flags, 5), undefinedValue,
+                accumulator = CALL_FUNCTION(callBackFn, CallInfo(flags, 5), undefinedValue,
                     accumulator,
                     element,
                     JavascriptNumber::ToVar(k, scriptContext),
@@ -9549,7 +9549,7 @@ Case0:
                     continue;
                 }
 
-                accumulator = callBackFn->GetEntryPoint()(callBackFn, CallInfo(flags, 5), undefinedValue,
+                accumulator = CALL_FUNCTION(callBackFn, CallInfo(flags, 5), undefinedValue,
                     accumulator,
                     element,
                     JavascriptNumber::ToVar(index, scriptContext),
@@ -9569,7 +9569,7 @@ Case0:
 
                 element = typedArrayBase->DirectGetItem((uint32)index);
 
-                accumulator = callBackFn->GetEntryPoint()(callBackFn, CallInfo(flags, 5), undefinedValue,
+                accumulator = CALL_FUNCTION(callBackFn, CallInfo(flags, 5), undefinedValue,
                     accumulator,
                     element,
                     JavascriptNumber::ToVar(index, scriptContext),
@@ -9588,7 +9588,7 @@ Case0:
 
                 BOOL getResult = JavascriptOperators::GetItem(obj, index, &element, scriptContext);
                 Assert(getResult);
-                accumulator = callBackFn->GetEntryPoint()(callBackFn, CallInfo(flags, 5), undefinedValue,
+                accumulator = CALL_FUNCTION(callBackFn, CallInfo(flags, 5), undefinedValue,
                     accumulator,
                     element,
                     JavascriptNumber::ToVar(index, scriptContext),

--- a/lib/Runtime/Library/JavascriptDate.cpp
+++ b/lib/Runtime/Library/JavascriptDate.cpp
@@ -1282,7 +1282,7 @@ namespace Js
             JavascriptError::ThrowTypeError(scriptContext, JSERR_Property_NeedFunction, scriptContext->GetPropertyName(PropertyIds::toISOString)->GetBuffer());
         }
         RecyclableObject* toISOFunc = RecyclableObject::FromVar(toISO);
-        return toISOFunc->GetEntryPoint()(toISOFunc, 1, thisObj);
+        return CALL_FUNCTION(toISOFunc, CallInfo(1), thisObj);
     }
 
     Var JavascriptDate::EntryToLocaleDateString(RecyclableObject* function, CallInfo callInfo, ...)

--- a/lib/Runtime/Library/JavascriptFunction.cpp
+++ b/lib/Runtime/Library/JavascriptFunction.cpp
@@ -2453,7 +2453,7 @@ LABEL1:
             if (scriptContext->GetThreadContext()->RecordImplicitException())
             {
                 JavascriptFunction* accessor = requestContext->GetLibrary()->GetThrowTypeErrorCallerAccessorFunction();
-                *value = accessor->GetEntryPoint()(accessor, 1, originalInstance);
+                *value = CALL_FUNCTION(accessor, CallInfo(1), originalInstance);
             }
             return true;
         }
@@ -2528,7 +2528,7 @@ LABEL1:
             if (scriptContext->GetThreadContext()->RecordImplicitException())
             {
                 JavascriptFunction* accessor = requestContext->GetLibrary()->GetThrowTypeErrorArgumentsAccessorFunction();
-                *value = accessor->GetEntryPoint()(accessor, 1, originalInstance);
+                *value = CALL_FUNCTION(accessor, CallInfo(1), originalInstance);
             }
             return true;
         }

--- a/lib/Runtime/Library/JavascriptMap.cpp
+++ b/lib/Runtime/Library/JavascriptMap.cpp
@@ -112,7 +112,7 @@ namespace Js
                 }
 
                 // CONSIDER: if adder is the default built-in, fast path it and skip the JS call?
-                adder->GetEntryPoint()(adder, CallInfo(CallFlags_Value, 3), mapObject, key, value);
+                CALL_FUNCTION(adder, CallInfo(CallFlags_Value, 3), mapObject, key, value);
             }
         }
 
@@ -191,7 +191,7 @@ namespace Js
             Var key = iterator.Current().Key();
             Var value = iterator.Current().Value();
 
-            callBackFn->GetEntryPoint()(callBackFn, CallInfo(CallFlags_Value, 4), thisArg, value, key, map);
+            CALL_FUNCTION(callBackFn, CallInfo(CallFlags_Value, 4), thisArg, value, key, map);
         }
 
         return scriptContext->GetLibrary()->GetUndefined();

--- a/lib/Runtime/Library/JavascriptObject.cpp
+++ b/lib/Runtime/Library/JavascriptObject.cpp
@@ -321,7 +321,7 @@ namespace Js
         }
 
         RecyclableObject* toStringFunc = RecyclableObject::FromVar(toStringVar);
-        return toStringFunc->GetEntryPoint()(toStringFunc, CallInfo(CallFlags_Value, 1), thisValue);
+        return CALL_FUNCTION(toStringFunc, CallInfo(CallFlags_Value, 1), thisValue);
     }
 
     Var JavascriptObject::EntryToString(RecyclableObject* function, CallInfo callInfo, ...)

--- a/lib/Runtime/Library/JavascriptRegularExpression.cpp
+++ b/lib/Runtime/Library/JavascriptRegularExpression.cpp
@@ -861,7 +861,7 @@ namespace Js
         if (JavascriptConversion::IsCallable(exec))
         {
             RecyclableObject* execFn = RecyclableObject::FromVar(exec);
-            Var result = execFn->GetEntryPoint()(execFn, CallInfo(CallFlags_Value, 2), thisObj, string);
+            Var result = CALL_FUNCTION(execFn, CallInfo(CallFlags_Value, 2), thisObj, string);
 
             if (!JavascriptOperators::IsObjectOrNull(result))
             {

--- a/lib/Runtime/Library/JavascriptSet.cpp
+++ b/lib/Runtime/Library/JavascriptSet.cpp
@@ -92,7 +92,7 @@ namespace Js
 
             while (JavascriptOperators::IteratorStepAndValue(iter, scriptContext, &nextItem))
             {
-                adder->GetEntryPoint()(adder, CallInfo(CallFlags_Value, 2), setObject, nextItem);
+                CALL_FUNCTION(adder, CallInfo(CallFlags_Value, 2), setObject, nextItem);
             }
         }
 
@@ -198,7 +198,7 @@ namespace Js
         {
             Var value = iterator.Current();
 
-            callBackFn->GetEntryPoint()(callBackFn, CallInfo(CallFlags_Value, 4), thisArg, value, value, args[0]);
+            CALL_FUNCTION(callBackFn, CallInfo(CallFlags_Value, 4), thisArg, value, value, args[0]);
         }
 
         return scriptContext->GetLibrary()->GetUndefined();

--- a/lib/Runtime/Library/JavascriptString.cpp
+++ b/lib/Runtime/Library/JavascriptString.cpp
@@ -1743,7 +1743,7 @@ case_2:
     Var JavascriptString::CallRegExFunction<1>(RecyclableObject* fnObj, Var regExp, Arguments& args)
     {
         // args[0]: String
-        return fnObj->GetEntryPoint()(fnObj, CallInfo(CallFlags_Value, 2), regExp, args[0]);
+        return CALL_FUNCTION(fnObj, CallInfo(CallFlags_Value, 2), regExp, args[0]);
     }
 
     template<>
@@ -1758,7 +1758,7 @@ case_2:
             return CallRegExFunction<1>(fnObj, regExp, args);
         }
 
-        return fnObj->GetEntryPoint()(fnObj, CallInfo(CallFlags_Value, 3), regExp, args[0], args[2]);
+        return CALL_FUNCTION(fnObj, CallInfo(CallFlags_Value, 3), regExp, args[0], args[2]);
     }
 
     Var JavascriptString::EntrySlice(RecyclableObject* function, CallInfo callInfo, ...)

--- a/lib/Runtime/Library/JavascriptWeakMap.cpp
+++ b/lib/Runtime/Library/JavascriptWeakMap.cpp
@@ -127,7 +127,7 @@ namespace Js
                     value = undefined;
                 }
 
-                adder->GetEntryPoint()(adder, CallInfo(CallFlags_Value, 3), weakMapObject, key, value);
+                CALL_FUNCTION(adder, CallInfo(CallFlags_Value, 3), weakMapObject, key, value);
             }
         }
 

--- a/lib/Runtime/Library/JavascriptWeakSet.cpp
+++ b/lib/Runtime/Library/JavascriptWeakSet.cpp
@@ -71,7 +71,7 @@ namespace Js
 
             while (JavascriptOperators::IteratorStepAndValue(iter, scriptContext, &nextItem))
             {
-                adder->GetEntryPoint()(adder, CallInfo(CallFlags_Value, 2), weakSetObject, nextItem);
+                CALL_FUNCTION(adder, CallInfo(CallFlags_Value, 2), weakSetObject, nextItem);
             }
         }
 

--- a/lib/Runtime/Library/RegexHelper.cpp
+++ b/lib/Runtime/Library/RegexHelper.cpp
@@ -1398,7 +1398,7 @@ namespace Js
         if (indexMatched != CharCountFlag)
         {
             Var pThis = scriptContext->GetLibrary()->GetUndefined();
-            JavascriptString* replace = JavascriptConversion::ToString(replacefn->GetEntryPoint()(replacefn, 4, pThis, match, JavascriptNumber::ToVar((int)indexMatched, scriptContext), input), scriptContext);
+            JavascriptString* replace = JavascriptConversion::ToString(CALL_FUNCTION(replacefn, CallInfo(4), pThis, match, JavascriptNumber::ToVar((int)indexMatched, scriptContext), input), scriptContext);
             const char16* inputStr = input->GetString();
             const char16* prefixStr = inputStr;
             CharCount prefixLength = indexMatched;

--- a/lib/Runtime/Library/TypedArray.cpp
+++ b/lib/Runtime/Library/TypedArray.cpp
@@ -451,7 +451,7 @@ namespace Js
                         (iteratorFn != scriptContext->GetLibrary()->GetArrayPrototypeValuesFunction() ||
                             !JavascriptArray::Is(firstArgument) || JavascriptLibrary::ArrayIteratorPrototypeHasUserDefinedNext(scriptContext)))
                     {
-                        Var iterator = iteratorFn->GetEntryPoint()(iteratorFn, CallInfo(Js::CallFlags_Value, 1), RecyclableObject::FromVar(firstArgument));
+                        Var iterator = CALL_FUNCTION(iteratorFn, CallInfo(Js::CallFlags_Value, 1), RecyclableObject::FromVar(firstArgument));
 
                         if (!JavascriptOperators::IsObject(iterator))
                         {
@@ -2059,7 +2059,7 @@ namespace Js
                 // We know that the TypedArray.HasItem will be true because k < length and we can skip the check in the TypedArray version of filter.
                 element = typedArrayBase->DirectGetItem(k);
 
-                selected = callBackFn->GetEntryPoint()(callBackFn, CallInfo(flags, 4), thisArg,
+                selected = CALL_FUNCTION(callBackFn, CallInfo(flags, 4), thisArg,
                     element,
                     JavascriptNumber::ToVar(k, scriptContext),
                     typedArrayBase);
@@ -2208,7 +2208,7 @@ namespace Js
 
             element = typedArrayBase->DirectGetItem(k);
 
-            callBackFn->GetEntryPoint()(callBackFn, CallInfo(flags, 4), thisArg,
+            CALL_FUNCTION(callBackFn, CallInfo(flags, 4), thisArg,
                 element,
                 JavascriptNumber::ToVar(k, scriptContext),
                 typedArrayBase);
@@ -2614,7 +2614,7 @@ namespace Js
             ScriptContext* scriptContext = compFn->GetScriptContext();
             Var undefined = scriptContext->GetLibrary()->GetUndefined();
             double dblResult;
-            Var retVal = compFn->GetEntryPoint()(compFn, CallInfo(CallFlags_Value, 3),
+            Var retVal = CALL_FUNCTION(compFn, CallInfo(CallFlags_Value, 3),
                 undefined,
                 JavascriptNumber::ToVarWithCheck((double)x, scriptContext),
                 JavascriptNumber::ToVarWithCheck((double)y, scriptContext));

--- a/lib/Runtime/Types/DynamicType.cpp
+++ b/lib/Runtime/Types/DynamicType.cpp
@@ -298,9 +298,9 @@ namespace Js
             {
                 // Stack object should have a pre-op bail on implicit call.  We shouldn't see them here.
                 Assert(!ThreadContext::IsOnStack(this) || threadContext->HasNoSideEffect(toStringFunction));
-                return toStringFunction->GetEntryPoint()(toStringFunction, CallInfo(CallFlags_Value, 1), this);
+                return CALL_FUNCTION(toStringFunction, CallInfo(CallFlags_Value, 1), this);
             });
- 
+
             if (!aResult)
             {
                 // There was an implicit call and implicit calls are disabled. This would typically cause a bailout.


### PR DESCRIPTION
For cross-plat we required custom calling convention on JavascriptMethods.
This change replaces all direct entryPoint calls with macros. On non-Win32,
the macros expand to call with extra parameters to meet the custom calling
convention.
