### PR TITLE
MSFT: 7429352 JSRT context leak regression fix

### DIFF
--- a/lib/Jsrt/Core/JsrtContextCore.cpp
+++ b/lib/Jsrt/Core/JsrtContextCore.cpp
@@ -33,22 +33,22 @@ JsrtContextCore::JsrtContextCore(JsrtRuntime * runtime) :
 /* static */
 JsrtContextCore *JsrtContextCore::New(JsrtRuntime * runtime)
 {
-    return RecyclerNewFinalizedLeaf(runtime->GetThreadContext()->EnsureRecycler(), JsrtContextCore, runtime);
+    return RecyclerNewFinalized(runtime->GetThreadContext()->EnsureRecycler(), JsrtContextCore, runtime);
 }
 
 void JsrtContextCore::Dispose(bool isShutdown)
 {
-    if (nullptr != this->GetScriptContext())
+    if (nullptr != this->GetJavascriptLibrary())
     {
-        this->GetScriptContext()->MarkForClose();
-        this->SetScriptContext(nullptr);
+        this->GetJavascriptLibrary()->GetScriptContext()->MarkForClose();
+        this->SetJavascriptLibrary(nullptr);
         Unlink();
     }
 }
 
 Js::ScriptContext* JsrtContextCore::EnsureScriptContext()
 {
-    Assert(this->GetScriptContext() == nullptr);
+    Assert(this->GetJavascriptLibrary() == nullptr);
 
     ThreadContext* localThreadContext = this->GetRuntime()->GetThreadContext();
 
@@ -59,7 +59,7 @@ Js::ScriptContext* JsrtContextCore::EnsureScriptContext()
     hostContext = HeapNew(ChakraCoreHostScriptContext, newScriptContext);
     newScriptContext->SetHostScriptContext(hostContext);
 
-    this->SetScriptContext(newScriptContext.Detach());
+    this->SetJavascriptLibrary(newScriptContext.Detach()->GetLibrary());
 
     Js::JavascriptLibrary *library = this->GetScriptContext()->GetLibrary();
     Assert(library != nullptr);

--- a/lib/Jsrt/JsrtContext.cpp
+++ b/lib/Jsrt/JsrtContext.cpp
@@ -9,19 +9,19 @@
 DWORD JsrtContext::s_tlsSlot = TLS_OUT_OF_INDEXES;
 
 JsrtContext::JsrtContext(JsrtRuntime * runtime) :
-    runtime(runtime), scriptContext(nullptr)
+    runtime(runtime), javascriptLibrary(nullptr)
 {
 }
 
-void JsrtContext::SetScriptContext(Js::ScriptContext * scriptContext)
+void JsrtContext::SetJavascriptLibrary(Js::JavascriptLibrary * library)
 {
-    this->scriptContext = scriptContext;
+    this->javascriptLibrary = library;
 }
 
 void JsrtContext::PinCurrentJsrtContext()
 {
-    Assert(this->scriptContext);
-    this->scriptContext->GetLibrary()->PinJsrtContextObject(this);
+    Assert(this->javascriptLibrary);
+    this->javascriptLibrary->PinJsrtContextObject(this);
 }
 
 void JsrtContext::Link()

--- a/lib/Jsrt/JsrtContext.h
+++ b/lib/Jsrt/JsrtContext.h
@@ -6,12 +6,45 @@
 
 #include "JsrtRuntime.h"
 
+// This class abstract a pointer value with its last 2 bits set to avoid conservative GC tracking.
+template <class T>
+class GC_MARKED_OBJECT
+{
+public:
+    operator T*()          const { return GetPointerValue(); }
+    bool operator!= (T* p) const { return GetPointerValue() != p; }
+    bool operator== (T* p) const { return GetPointerValue() == p; }
+    T* operator-> ()       const { return GetPointerValue(); }
+    GC_MARKED_OBJECT<T>& operator= (T* inPtr)
+    {
+        SetPointerValue(inPtr);
+        return (*this);
+    }
+    GC_MARKED_OBJECT(T* inPtr) : ptr(inPtr)
+    {
+        SetPointerValue(inPtr);
+    }
+
+    GC_MARKED_OBJECT() : ptr(NULL) {};
+private:
+    T * GetPointerValue() const { return reinterpret_cast<T*>(reinterpret_cast<ULONG_PTR>(ptr) & ~3); }
+    T * SetPointerValue(T* inPtr)
+    {
+        AssertMsg((reinterpret_cast<ULONG_PTR>(inPtr) & 3) == 0, "Invalid pointer value, 2 least significant bits must be zero");
+        ptr = reinterpret_cast<T*>((reinterpret_cast<ULONG_PTR>(inPtr) | 3));
+        return ptr;
+    }
+
+    T* ptr;
+};
+
 class JsrtContext : public FinalizableObject
 {
 public:
     static JsrtContext *New(JsrtRuntime * runtime);
 
-    Js::ScriptContext * GetScriptContext() const { return this->scriptContext; }
+    Js::ScriptContext * GetScriptContext() const { return this->javascriptLibrary->scriptContext; }
+    Js::JavascriptLibrary* GetJavascriptLibrary() const { return this->javascriptLibrary; }
     JsrtRuntime * GetRuntime() const { return this->runtime; }
     void* GetExternalData() const { return this->externalData; }
     void SetExternalData(void * data) { this->externalData = data; }
@@ -31,14 +64,15 @@ protected:
     JsrtContext(JsrtRuntime * runtime);
     void Link();
     void Unlink();
-    void SetScriptContext(Js::ScriptContext * scriptContext);
+    void SetJavascriptLibrary(Js::JavascriptLibrary * library);
     void PinCurrentJsrtContext();
 private:
     static DWORD s_tlsSlot;
-    Js::ScriptContext * scriptContext;
+    Js::JavascriptLibrary * javascriptLibrary;
+
     JsrtRuntime * runtime;
-    void * externalData = nullptr;
-    JsrtContext * previous;
-    JsrtContext * next;
+    GC_MARKED_OBJECT<void> externalData = nullptr;
+    GC_MARKED_OBJECT<JsrtContext> previous;
+    GC_MARKED_OBJECT<JsrtContext> next;
 };
 

--- a/lib/Jsrt/JsrtContext.h
+++ b/lib/Jsrt/JsrtContext.h
@@ -71,7 +71,7 @@ private:
     Js::JavascriptLibrary * javascriptLibrary;
 
     JsrtRuntime * runtime;
-    GC_MARKED_OBJECT<void> externalData = nullptr;
+    void* externalData = nullptr;
     GC_MARKED_OBJECT<JsrtContext> previous;
     GC_MARKED_OBJECT<JsrtContext> next;
 };

--- a/lib/Jsrt/JsrtExternalObject.cpp
+++ b/lib/Jsrt/JsrtExternalObject.cpp
@@ -13,7 +13,7 @@ JsrtExternalType::JsrtExternalType(Js::ScriptContext* scriptContext, JsFinalizeC
         Js::TypeIds_Object,
         scriptContext->GetLibrary()->GetObjectPrototype(),
         nullptr,
-        Js::SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, 0, 0, true, true),
+        Js::SimplePathTypeHandler::New(scriptContext, scriptContext->GetLibrary()->GetRootPath(), 0, 0, 0, true, true),
         true,
         true)
         , jsFinalizeCallback(finalizeCallback)

--- a/lib/Parser/RegexPattern.cpp
+++ b/lib/Parser/RegexPattern.cpp
@@ -41,7 +41,7 @@ namespace UnifiedRegex
             Assert(
                 !GetScriptContext()->GetDynamicRegexMap()->TryGetValue(
                     RegexKey(source.GetBuffer(), source.GetLength(), GetFlags()),
-                    &p) ||
+                    &p) || ( source.GetLength() == 0 ) ||
                 p != this);
         }
 #endif

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -1308,7 +1308,7 @@ FuncInfo * ByteCodeGenerator::StartBindFunction(const char16 *name, uint nameLen
         }
 
         // In either case register the function reference
-        scriptContext->RegisterDynamicFunctionReference(parseableFunctionInfo);
+        scriptContext->GetLibrary()->RegisterDynamicFunctionReference(parseableFunctionInfo);
 
 #if DBG
         parseableFunctionInfo->deferredParseNextFunctionId = pnode->sxFnc.deferredParseNextFunctionId;
@@ -5255,7 +5255,7 @@ Js::FunctionBody * ByteCodeGenerator::MakeGlobalFunctionBody(ParseNode *pnode)
             );
 
     func->SetIsGlobalFunc(true);
-    scriptContext->RegisterDynamicFunctionReference(func);
+    scriptContext->GetLibrary()->RegisterDynamicFunctionReference(func);
     LEAVE_PINNED_SCOPE();
 
     return func;

--- a/lib/Runtime/Library/GlobalObject.cpp
+++ b/lib/Runtime/Library/GlobalObject.cpp
@@ -44,6 +44,7 @@ namespace Js
         JavascriptLibrary* localLibrary = RecyclerNewFinalized(scriptContext->GetRecycler(), JavascriptLibrary, this);
         scriptContext->SetLibrary(localLibrary);
         type->javascriptLibrary = localLibrary;
+        scriptContext->InitializeCache();
         localLibrary->Initialize(scriptContext, this);
         library = localLibrary;
     }

--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -126,6 +126,7 @@ namespace Js
         Type* tempType = StaticType::New(scriptContext, TypeIds_Null, nullptr, nullptr);
         nullValue = RecyclerNew(recycler, RecyclableObject, tempType);
         nullValue->GetType()->SetHasSpecialPrototype(true);
+        this->rootPath = TypePath::New(recycler);
 
         ArrayBuffer* baseArrayBuffer;
 
@@ -152,7 +153,7 @@ namespace Js
                     DeferredTypeHandler<InitializeArrayBufferPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
                 arrayBufferType = DynamicType::New(scriptContext, TypeIds_ArrayBuffer, arrayBufferPrototype, nullptr,
-                    SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, 0, 0, true, true), true, true);
+                    SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
 
                 dataViewPrototype = DynamicObject::New(recycler,
                     DynamicType::New(scriptContext, TypeIds_Object, objectPrototype, nullptr,
@@ -222,7 +223,7 @@ namespace Js
                     DeferredTypeHandler<InitializeArrayBufferPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
                 arrayBufferType = DynamicType::New(scriptContext, TypeIds_ArrayBuffer, arrayBufferPrototype, nullptr,
-                    SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, 0, 0, true, true), true, true);
+                    SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
 
                 tempDynamicType = DynamicType::New(scriptContext, TypeIds_Int8Array, objectPrototype, nullptr,
                     DeferredTypeHandler<InitializeInt8ArrayPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance());
@@ -540,65 +541,65 @@ namespace Js
         heapArgumentsType = DynamicType::New(scriptContext, TypeIds_Arguments, objectPrototype, nullptr,
             SimpleDictionaryTypeHandler::New(scriptContext, HeapArgumentsPropertyDescriptors, _countof(HeapArgumentsPropertyDescriptors), 0, 0, true, true), true, true);
         activationObjectType = DynamicType::New(scriptContext, TypeIds_ActivationObject, nullValue, nullptr,
-            SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, 0, 0, true, true), true, true);
+            SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
         arrayType = DynamicType::New(scriptContext, TypeIds_Array, arrayPrototype, nullptr,
-            SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, 0, 0, true, true), true, true);
+            SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
         nativeIntArrayType = DynamicType::New(scriptContext, TypeIds_NativeIntArray, arrayPrototype, nullptr,
-            SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, 0, 0, true, true), true, true);
+            SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
 #if ENABLE_COPYONACCESS_ARRAY
         copyOnAccessNativeIntArrayType = DynamicType::New(scriptContext, TypeIds_CopyOnAccessNativeIntArray, arrayPrototype, nullptr,
-            SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, 0, 0, true, true), true, true);
+            SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
 #endif
         nativeFloatArrayType = DynamicType::New(scriptContext, TypeIds_NativeFloatArray, arrayPrototype, nullptr,
-            SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, 0, 0, true, true), true, true);
+            SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
 
         arrayBufferType = DynamicType::New(scriptContext, TypeIds_ArrayBuffer, arrayBufferPrototype, nullptr,
-            SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, 0, 0, true, true), true, true);
+            SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
         dataViewType = DynamicType::New(scriptContext, TypeIds_DataView, dataViewPrototype, nullptr,
-            SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, 0, 0, true, true), true, true);
+            SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
 
         int8ArrayType = DynamicType::New(scriptContext, TypeIds_Int8Array, Int8ArrayPrototype, nullptr,
-            SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, 0, 0, true, true), true, true);
+            SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
 
         uint8ArrayType = DynamicType::New(scriptContext, TypeIds_Uint8Array, Uint8ArrayPrototype, nullptr,
-            SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, 0, 0, true, true), true, true);
+            SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
         uint8ClampedArrayType = DynamicType::New(scriptContext, TypeIds_Uint8ClampedArray, Uint8ClampedArrayPrototype, nullptr,
-            SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, 0, 0, true, true), true, true);
+            SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
         int16ArrayType = DynamicType::New(scriptContext, TypeIds_Int16Array, Int16ArrayPrototype, nullptr,
-            SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, 0, 0, true, true), true, true);
+            SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
         uint16ArrayType = DynamicType::New(scriptContext, TypeIds_Uint16Array, Uint16ArrayPrototype, nullptr,
-            SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, 0, 0, true, true), true, true);
+            SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
         int32ArrayType = DynamicType::New(scriptContext, TypeIds_Int32Array, Int32ArrayPrototype, nullptr,
-            SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, 0, 0, true, true), true, true);
+            SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
         uint32ArrayType = DynamicType::New(scriptContext, TypeIds_Uint32Array, Uint32ArrayPrototype, nullptr,
-            SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, 0, 0, true, true), true, true);
+            SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
         float32ArrayType = DynamicType::New(scriptContext, TypeIds_Float32Array, Float32ArrayPrototype, nullptr,
-            SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, 0, 0, true, true), true, true);
+            SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
         float64ArrayType = DynamicType::New(scriptContext, TypeIds_Float64Array, Float64ArrayPrototype, nullptr,
-            SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, 0, 0, true, true), true, true);
+            SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
         int64ArrayType = DynamicType::New(scriptContext, TypeIds_Int64Array, Int64ArrayPrototype, nullptr,
-            SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, 0, 0, true, true), true, true);
+            SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
         uint64ArrayType = DynamicType::New(scriptContext, TypeIds_Uint64Array, Uint64ArrayPrototype, nullptr,
-            SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, 0, 0, true, true), true, true);
+            SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
         boolArrayType = DynamicType::New(scriptContext, TypeIds_BoolArray, BoolArrayPrototype, nullptr,
-            SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, 0, 0, true, true), true, true);
+            SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
         charArrayType = DynamicType::New(scriptContext, TypeIds_CharArray, CharArrayPrototype, nullptr,
-            SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, 0, 0, true, true), true, true);
+            SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
 
         errorType = DynamicType::New(scriptContext, TypeIds_Error, errorPrototype, nullptr,
-            SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, 0, 0, true, true), true, true);
+            SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
         evalErrorType = DynamicType::New(scriptContext, TypeIds_Error, evalErrorPrototype, nullptr,
-            SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, 0, 0, true, true), true, true);
+            SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
         rangeErrorType = DynamicType::New(scriptContext, TypeIds_Error, rangeErrorPrototype, nullptr,
-            SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, 0, 0, true, true), true, true);
+            SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
         referenceErrorType = DynamicType::New(scriptContext, TypeIds_Error, referenceErrorPrototype, nullptr,
-            SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, 0, 0, true, true), true, true);
+            SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
         syntaxErrorType = DynamicType::New(scriptContext, TypeIds_Error, syntaxErrorPrototype, nullptr,
-            SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, 0, 0, true, true), true, true);
+            SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
         typeErrorType = DynamicType::New(scriptContext, TypeIds_Error, typeErrorPrototype, nullptr,
-            SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, 0, 0, true, true), true, true);
+            SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
         uriErrorType = DynamicType::New(scriptContext, TypeIds_Error, uriErrorPrototype, nullptr,
-            SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, 0, 0, true, true), true, true);
+            SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
 
         withType    = nullptr;
         proxyType   = nullptr;
@@ -632,7 +633,7 @@ namespace Js
 
             javascriptEnumeratorIteratorType = DynamicType::New(scriptContext, TypeIds_JavascriptEnumeratorIterator, javascriptEnumeratorIteratorPrototype, nullptr,
 
-                SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, 0, 0, true, true), true, true);
+                SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
         }
 
         if (config->IsES6PromiseEnabled())
@@ -642,7 +643,7 @@ namespace Js
 
         // Initialize Date types
         dateType = DynamicType::New(scriptContext, TypeIds_Date, datePrototype, nullptr,
-            SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, 0, 0, true, true), true, true);
+            SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
         variantDateType = StaticType::New(scriptContext, TypeIds_VariantDate, nullValue, nullptr);
 
         anonymousFunctionTypeHandler = NullTypeHandler<false>::GetDefaultInstance();
@@ -683,7 +684,7 @@ namespace Js
         else
         {
             boundFunctionType = DynamicType::New(scriptContext, TypeIds_Function, functionPrototype, BoundFunction::NewInstance,
-                SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, 0, 0, true, true), true, true);
+                SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
         }
         crossSiteDeferredPrototypeFunctionType = CreateDeferredPrototypeFunctionTypeNoProfileThunk(
             scriptContext->CurrentCrossSiteThunk, true /*isShared*/);
@@ -736,7 +737,7 @@ namespace Js
             SimplePathTypeHandler * typeHandler =
                 SimplePathTypeHandler::New(
                     scriptContext,
-                    scriptContext->GetRootPath(),
+                    this->GetRootPath(),
                     0,
                     i * InlineSlotCountIncrement,
                     sizeof(DynamicObject),
@@ -750,7 +751,7 @@ namespace Js
             SimplePathTypeHandler * typeHandler =
                 SimplePathTypeHandler::New(
                     scriptContext,
-                    scriptContext->GetRootPath(),
+                    this->GetRootPath(),
                     0,
                     DynamicTypeHandler::GetObjectHeaderInlinableSlotCapacity() + i * InlineSlotCountIncrement,
                     DynamicTypeHandler::GetOffsetOfObjectHeaderInlineSlots(),
@@ -776,16 +777,16 @@ namespace Js
         throwErrorObjectType = StaticType::New(scriptContext, TypeIds_Undefined, nullValue, ThrowErrorObject::DefaultEntryPoint);
 
         mapType = DynamicType::New(scriptContext, TypeIds_Map, mapPrototype, nullptr,
-            SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, 0, 0, true, true), true, true);
+            SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
 
         setType = DynamicType::New(scriptContext, TypeIds_Set, setPrototype, nullptr,
-            SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, 0, 0, true, true), true, true);
+            SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
 
         weakMapType = DynamicType::New(scriptContext, TypeIds_WeakMap, weakMapPrototype, nullptr,
-            SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, 0, 0, true, true), true, true);
+            SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
 
         weakSetType = DynamicType::New(scriptContext, TypeIds_WeakSet, weakSetPrototype, nullptr,
-            SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, 0, 0, true, true), true, true);
+            SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
 
         TypePath *const iteratorResultPath = TypePath::New(recycler);
         iteratorResultPath->Add(BuiltInPropertyRecords::value);
@@ -794,13 +795,13 @@ namespace Js
             SimplePathTypeHandler::New(scriptContext, iteratorResultPath, iteratorResultPath->GetPathLength(), 2, sizeof(DynamicObject), true, true), true, true);
 
         arrayIteratorType = DynamicType::New(scriptContext, TypeIds_ArrayIterator, arrayIteratorPrototype, nullptr,
-            SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, 0, 0, true, true), true, true);
+            SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
         mapIteratorType = DynamicType::New(scriptContext, TypeIds_MapIterator, mapIteratorPrototype, nullptr,
-            SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, 0, 0, true, true), true, true);
+            SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
         setIteratorType = DynamicType::New(scriptContext, TypeIds_SetIterator, setIteratorPrototype, nullptr,
-            SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, 0, 0, true, true), true, true);
+            SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
         stringIteratorType = DynamicType::New(scriptContext, TypeIds_StringIterator, stringIteratorPrototype, nullptr,
-            SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, 0, 0, true, true), true, true);
+            SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
 
         if (config->IsES6GeneratorsEnabled())
         {
@@ -812,10 +813,10 @@ namespace Js
 
 #ifdef ENABLE_DEBUG_CONFIG_OPTIONS
         debugDisposableObjectType = DynamicType::New(scriptContext, TypeIds_Object, objectPrototype, nullptr,
-            SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, 0, 0, true, true), true, true);
+            SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
 
         debugFuncExecutorInDisposeObjectType = DynamicType::New(scriptContext, TypeIds_Object, objectPrototype, nullptr,
-            SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, 0, 0, true, true), true, true);
+            SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
 #endif
     }
 
@@ -2583,7 +2584,7 @@ namespace Js
         }
 
         SimplePathTypeHandler *typeHandler =
-            SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, 0, 0, true, true);
+            SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true);
         // See JavascriptRegExp::IsWritable for property writability
         if (!scriptConfig->IsES6RegExPrototypePropertiesEnabled())
         {
@@ -6016,7 +6017,7 @@ namespace Js
             }
         }
 
-        SimplePathTypeHandler* typeHandler = SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, requestedInlineSlotCapacity, offsetOfInlineSlots, true, true);
+        SimplePathTypeHandler* typeHandler = SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, requestedInlineSlotCapacity, offsetOfInlineSlots, true, true);
         dynamicType = DynamicType::New(scriptContext, typeId, prototype, RecyclableObject::DefaultEntryPoint, typeHandler, true, true);
 
         if (useCache)
@@ -6030,7 +6031,7 @@ namespace Js
     DynamicType* JavascriptLibrary::CreateObjectTypeNoCache(RecyclableObject* prototype, Js::TypeId typeId)
     {
         return DynamicType::New(scriptContext, typeId, prototype, RecyclableObject::DefaultEntryPoint,
-            SimplePathTypeHandler::New(scriptContext, scriptContext->GetRootPath(), 0, 0, 0, true, true), true, true);
+            SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
     }
 
     DynamicType* JavascriptLibrary::CreateObjectType(RecyclableObject* prototype, uint16 requestedInlineSlotCapacity)
@@ -6445,6 +6446,68 @@ namespace Js
         }
         return moduleRecordList->Item(moduleId);
     }
+
+    void JavascriptLibrary::BindReference(void * addr)
+    {
+        // The last void* is the linklist connecting to next block. 
+        if (bindRefChunkCurrent == bindRefChunkEnd)
+        {
+            void** tmpBindRefChunk = RecyclerNewArrayZ(recycler, void *, HeapConstants::ObjectGranularity / sizeof(void *));
+            // reserve the last void* as the linklist node.
+            bindRefChunkEnd = tmpBindRefChunk + (HeapConstants::ObjectGranularity / sizeof(void *) -1 );
+            if (bindRefChunkBegin == nullptr)
+            {
+                bindRefChunkCurrent = tmpBindRefChunk;
+                bindRefChunkBegin = bindRefChunkCurrent;
+            }
+            else
+            {
+                *bindRefChunkCurrent = tmpBindRefChunk;
+                bindRefChunkCurrent = tmpBindRefChunk;
+            }
+        }
+        Assert((bindRefChunkCurrent+1) <= bindRefChunkEnd);
+        *bindRefChunkCurrent = addr;
+        bindRefChunkCurrent++;
+    }
+
+    void JavascriptLibrary::CleanupForClose()
+    {
+        bindRefChunkCurrent = nullptr;
+        bindRefChunkEnd = nullptr;
+        scriptContextCache = nullptr;
+    }
+
+    void JavascriptLibrary::BeginDynamicFunctionReferences()
+    {
+        if (this->dynamicFunctionReference == nullptr)
+        {
+            this->dynamicFunctionReference = RecyclerNew(this->recycler, FunctionReferenceList, this->recycler);
+            this->BindReference(this->dynamicFunctionReference);
+            this->dynamicFunctionReferenceDepth = 0;
+        }
+
+        this->dynamicFunctionReferenceDepth++;
+    }
+
+    void JavascriptLibrary::EndDynamicFunctionReferences()
+    {
+        Assert(this->dynamicFunctionReference != nullptr);
+
+        this->dynamicFunctionReferenceDepth--;
+
+        if (this->dynamicFunctionReferenceDepth == 0)
+        {
+            this->dynamicFunctionReference->Clear();
+        }
+    }
+
+    void JavascriptLibrary::RegisterDynamicFunctionReference(FunctionProxy* func)
+    {
+        Assert(this->dynamicFunctionReferenceDepth > 0);
+        this->dynamicFunctionReference->Push(func);
+    }
+
 
     // Register for profiler
 #define DEFINE_OBJECT_NAME(object) const char16 *pwszObjectName = _u(#object);

--- a/lib/Runtime/Library/JavascriptLibrary.h
+++ b/lib/Runtime/Library/JavascriptLibrary.h
@@ -415,6 +415,15 @@ namespace Js
         PromiseContinuationCallback nativeHostPromiseContinuationFunction;
         void *nativeHostPromiseContinuationFunctionState;
 
+        typedef SList<Js::FunctionProxy*, Recycler> FunctionReferenceList;
+
+        void * bindRefChunkBegin;
+        void ** bindRefChunkCurrent;
+        void ** bindRefChunkEnd;
+        TypePath* rootPath;         // this should be in library instead of ScriptContext::Cache
+        void* scriptContextCache;   // forward declaration for point to ScriptContext::Cache such that we don't need to hard pin it.
+        FunctionReferenceList* dynamicFunctionReference;
+        uint dynamicFunctionReferenceDepth;
         FinalizableObject* jsrtContextObject;
 
         typedef JsUtil::BaseHashSet<RecyclerWeakReference<RecyclableObject>*, Recycler, PowerOf2SizePolicy, RecyclerWeakReference<RecyclableObject>*, StringTemplateCallsiteObjectComparer> StringTemplateCallsiteObjectList;
@@ -508,6 +517,7 @@ namespace Js
                               identityFunction(nullptr),
                               throwerFunction(nullptr),
                               jsrtContextObject(nullptr),
+                              scriptContextCache(nullptr),
                               externalLibraryList(nullptr),
                               cachedForInEnumerator(nullptr),
 #if ENABLE_COPYONACCESS_ARRAY
@@ -517,7 +527,12 @@ namespace Js
                               isLibraryReadyForHybridDebugging(false),
                               referencedPropertyRecords(nullptr),
                               stringTemplateCallsiteObjectList(nullptr),
-                              moduleRecordList(nullptr)
+                              moduleRecordList(nullptr),
+                              rootPath(nullptr),
+                              bindRefChunkBegin(nullptr),
+                              bindRefChunkCurrent(nullptr),
+                              bindRefChunkEnd(nullptr),
+                              dynamicFunctionReference(nullptr)
         {
             globalObject = globalObject;
         }
@@ -762,6 +777,13 @@ namespace Js
         int GetRegexGlobalGetterSlotIndex() const { return regexGlobalGetterSlotIndex;  }
         int GetRegexStickyGetterSlotIndex() const { return regexStickyGetterSlotIndex;  }
         int GetRegexUnicodeGetterSlotIndex() const { return regexUnicodeGetterSlotIndex;  }
+
+        TypePath* GetRootPath() const { return rootPath; }
+        void BindReference(void * addr);
+        void CleanupForClose();
+        void BeginDynamicFunctionReferences();
+        void EndDynamicFunctionReferences();
+        void RegisterDynamicFunctionReference(FunctionProxy* func);
 
         void SetDebugObjectNonUserAccessor(FunctionInfo *funcGetter, FunctionInfo *funcSetter);
 


### PR DESCRIPTION
We start supporting cross-context scenarios in JSRT in chakracore. However we are having
leaks in different scenarios due to pinned object. This change cleans up some basic leak scenarios.
We might need to have more cleanup in the future to make sure that there is only one
root for a JSRTContext or script context.

One major leak source is the guest arena in ScriptContext. objects allocated in the guestArena are
hard pinned till the scriptcontext is closed. We need to move objects off the guestArena:
    scriptContext::Cache. it's allocated using normal RecyclerNew, linked in the JavascriptLibrary, and
keep the reference in scriptcontext to minimize the code change.
    BuiltInFunctionMap. We might need to have a full cleanup of BindReference, but for now we just move
out the builtInFunctionMap to JavascripLibrary.
    Convert ScriptContext::BindReference to use linklist in JavascriptLibrary
    Allocate JSRTContext using RecyclerNew (no more leaf); have JSRTContext have a different reference to
JavascriptLibrary to keep it alive, and masked out other fields for potential false reference.
