### PR TITLE
Align Function(..).toString output with F.p.toString proposal (fixes #971)

### DIFF
--- a/lib/Runtime/Library/JavascriptFunction.cpp
+++ b/lib/Runtime/Library/JavascriptFunction.cpp
@@ -139,7 +139,10 @@ namespace Js
     static char16 const funcName[] = _u("function anonymous");
     static char16 const genFuncName[] = _u("function* anonymous");
     static char16 const asyncFuncName[] = _u("async function anonymous");
-    static char16 const bracket[] = _u(" {\012");
+    static char16 const openFormals[] = _u("(");
+    static char16 const closeFormals[] = _u("\012)");
+    static char16 const openFuncBody[] = _u(" {");
+    static char16 const closeFuncBody[] = _u("\012}");
 
     Var JavascriptFunction::NewInstanceHelper(ScriptContext *scriptContext, RecyclableObject* function, CallInfo callInfo, Js::ArgumentReader& args, FunctionKind functionKind /* = FunctionKind::Normal */)
     {
@@ -157,7 +160,7 @@ namespace Js
         JavascriptString* separator = library->GetCommaDisplayString();
 
         // Gather all the formals into a string like (fml1, fml2, fml3)
-        JavascriptString *formals = library->CreateStringFromCppLiteral(_u("("));
+        JavascriptString *formals = library->CreateStringFromCppLiteral(openFormals);
         for (uint i = 1; i < args.Info.Count - 1; ++i)
         {
             if (i != 1)
@@ -166,8 +169,7 @@ namespace Js
             }
             formals = JavascriptString::Concat(formals, JavascriptConversion::ToString(args.Values[i], scriptContext));
         }
-        formals = JavascriptString::Concat(formals, library->CreateStringFromCppLiteral(_u(")")));
-
+        formals = JavascriptString::Concat(formals, library->CreateStringFromCppLiteral(closeFormals));
         // Function body, last argument to Function(...)
         JavascriptString *fnBody = NULL;
         if (args.Info.Count > 1)
@@ -176,7 +178,12 @@ namespace Js
         }
 
         // Create a string representing the anonymous function
-        Assert(CountNewlines(funcName) + CountNewlines(bracket) == numberLinesPrependedToAnonymousFunction); // Be sure to add exactly one line to anonymous function
+        Assert(
+            CountNewlines(funcName) +
+            CountNewlines(openFormals) +
+            CountNewlines(closeFormals) +
+            CountNewlines(openFuncBody)
+            == numberLinesPrependedToAnonymousFunction); // Be sure to add exactly one line to anonymous function
 
         JavascriptString *bs = functionKind == FunctionKind::Async ?
             library->CreateStringFromCppLiteral(asyncFuncName) :
@@ -184,14 +191,13 @@ namespace Js
             library->CreateStringFromCppLiteral(genFuncName) :
             library->CreateStringFromCppLiteral(funcName);
         bs = JavascriptString::Concat(bs, formals);
-        bs = JavascriptString::Concat(bs, library->CreateStringFromCppLiteral(bracket));
+        bs = JavascriptString::Concat(bs, library->CreateStringFromCppLiteral(openFuncBody));
         if (fnBody != NULL)
         {
             bs = JavascriptString::Concat(bs, fnBody);
         }
 
-        bs = JavascriptString::Concat(bs, library->CreateStringFromCppLiteral(_u("\012}")));
-
+        bs = JavascriptString::Concat(bs, library->CreateStringFromCppLiteral(closeFuncBody));
         // Bug 1105479. Get the module id from the caller
         ModuleID moduleID = kmodGlobal;
 

--- a/test/Lib/noargs_2.baseline
+++ b/test/Lib/noargs_2.baseline
@@ -10,8 +10,8 @@ encodeURI = undefined
 decodeURIComponent = undefined
 encodeURIComponent = undefined
 Object = [object Object]
-Function = function anonymous() {
-
+Function = function anonymous(
+) {
 }
 Array = 
 String = 

--- a/test/StackTrace/FunctionName.js.baseline
+++ b/test/StackTrace/FunctionName.js.baseline
@@ -1,7 +1,7 @@
 Error: My Error!
 	at foo (functionname.js:24:9)
 	at func (functionname.js:28:9)
-	at Function code (Function code:1:1)
+	at Function code (Function code:1:4)
 	at eval code (eval code:1:1)
 	at Anonymous function (functionname.js:35:13)
 	at bar (functionname.js:34:10)

--- a/test/StackTrace/dynamic.js.baseline
+++ b/test/StackTrace/dynamic.js.baseline
@@ -1,6 +1,6 @@
 Error: This is my error
-	at foo (Function code:1:17)
-	at Function code (Function code:1:56)
+	at foo (Function code:1:20)
+	at Function code (Function code:1:59)
 	at Anonymous function (dynamic.js:27:13)
 	at runtest (dynamic.js:25:10)
 	at Global code (dynamic.js:38:1)

--- a/test/es6/generators-functionality.js
+++ b/test/es6/generators-functionality.js
@@ -556,7 +556,7 @@ var tests = [
 
             var g = gf();
 
-            assert.areEqual("function* anonymous() {\nyield 1; return 0;\n}", gf.toString(), "toString of GeneratorFunction constructed function is named anonymous");
+            assert.areEqual("function* anonymous(\n) {yield 1; return 0;\n}", gf.toString(), "toString of GeneratorFunction constructed function is named anonymous");
 
             assert.areEqual({ value: 1, done: false }, g.next(), "gf is a generator function whose body yield's 1 then returns 0");
             assert.areEqual({ value: 0, done: true }, g.next(), "gf is a generator function whose body yield's 1 then returns 0");
@@ -564,7 +564,7 @@ var tests = [
             gf = new GeneratorFunction('a', 'b', 'c', 'yield a; yield b; yield c;');
             g = gf(1, 2, 3);
 
-            assert.areEqual("function* anonymous(a,b,c) {\nyield a; yield b; yield c;\n}", gf.toString(), "toString of GeneratorFunction constructed function is named anonymous with specified parameters");
+            assert.areEqual("function* anonymous(a,b,c\n) {yield a; yield b; yield c;\n}", gf.toString(), "toString of GeneratorFunction constructed function is named anonymous with specified parameters");
 
             assert.areEqual({ value: 1, done: false }, g.next(), "gf is a generator function that takes three parameters and yields each of them in turn");
             assert.areEqual({ value: 2, done: false }, g.next(), "gf is a generator function that takes three parameters and yields each of them in turn");

--- a/test/es7/asyncawait-apis.js
+++ b/test/es7/asyncawait-apis.js
@@ -172,10 +172,10 @@ var tests = [
             assert.areEqual(asyncFunctionPrototype, Object.getPrototypeOf(af), "Async function created by %AsyncFunction% should have the same prototype as syntax declared async functions");
 
             assert.areEqual("anonymous", af.name, "AsyncFunction constructed async function's name is 'anonymous'");
-            assert.areEqual("async function anonymous() {\nreturn await 1;\n}", af.toString(), "toString of AsyncFunction constructed function is named 'anonymous'");
+            assert.areEqual("async function anonymous(\n) {return await 1;\n}", af.toString(), "toString of AsyncFunction constructed function is named 'anonymous'");
 
             af = new AsyncFunction('a', 'b', 'c', 'await a; await b; await c;');
-            assert.areEqual("async function anonymous(a,b,c) {\nawait a; await b; await c;\n}", af.toString(), "toString of AsyncFunction constructed function is named 'anonymous' with specified parameters");
+            assert.areEqual("async function anonymous(a,b,c\n) {await a; await b; await c;\n}", af.toString(), "toString of AsyncFunction constructed function is named 'anonymous' with specified parameters");
 
             // Cannot verify behavior of async functions in conjunction with UnitTestFramework.js
             // due to callback nature of their execution. Instead, verification of behavior is


### PR DESCRIPTION
This fix for #971 also aligns our toString output in this particular case with the [upcoming spec](https://tc39.github.io/Function-prototype-toString-revision/#sec-createdynamicfunction). Unit tests pass as well as a few more test262 tests related to the toString output of Function and %GeneratorFunction%.