### PR TITLE
FreeLoopBodyJobs race condition.

### DIFF
--- a/lib/Backend/NativeCodeGenerator.h
+++ b/lib/Backend/NativeCodeGenerator.h
@@ -211,6 +211,7 @@ private:
             : JsUtil::WaitableJobManager(processor)
             , autoClose(true)
             , isClosed(false)
+            , processed(false)
         {
             Processor()->AddManager(this);
         }
@@ -238,7 +239,7 @@ private:
 
         FreeLoopBodyJob* GetJob(FreeLoopBodyJob* job)
         {
-            return job;
+            return this->processed ? nullptr : job;
         }
 
         bool WasAddedToJobProcessor(JsUtil::Job *const job) const
@@ -268,6 +269,8 @@ private:
         {
             FreeLoopBodyJob* freeLoopBodyJob = static_cast<FreeLoopBodyJob*>(job);
 
+            this->processed = true;
+
             if (freeLoopBodyJob->heapAllocated)
             {
                 HeapDelete(freeLoopBodyJob);
@@ -280,6 +283,7 @@ private:
         NativeCodeGenerator* nativeCodeGen;
         bool autoClose;
         bool isClosed;
+        bool processed;
     };
 
     FreeLoopBodyJobManager freeLoopBodyManager;


### PR DESCRIPTION
FreeLoopBodyJobs also need a processed flag to avoid race conditions.
To free data associated with a JIT loopbody, we create a FreeLoopBodyJob.  If we can't allocate one of these (OOM), we create one on the stack, and wait for it to be processed.
There was a race condition if we processed the job before starting to wait for it...  The 'processed' flag avoids this.
