### PR TITLE
Param debug scope metadata.

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -2926,7 +2926,7 @@ void ByteCodeGenerator::EmitDefaultArgs(FuncInfo *funcInfo, ParseNode *pnode)
         MapFormalsWithoutRest(pnode, emitDefaultArg);
     }
 
-    if (ShouldTrackDebuggerMetadata() && m_writer.GetCurrentOffset() > beginOffset)
+    if (m_writer.GetCurrentOffset() > beginOffset)
     {
         PopulateFormalsScope(beginOffset, funcInfo, pnode);
     }


### PR DESCRIPTION
The debugger scopes are created in the non-debug mode as well. Removed the only-debug-mode check for creating debug scope for parameters.
