### PR TITLE
xplat: enable -test build type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,10 @@ if(CMAKE_BUILD_TYPE STREQUAL Debug)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
         -Wno-writable-strings"
     )
+elseif(CMAKE_BUILD_TYPE STREQUAL Test)
+    add_definitions(
+        -DENABLE_DEBUG_CONFIG_OPTIONS=1
+    )
 endif(CMAKE_BUILD_TYPE STREQUAL Debug)
 
 if(IS_64BIT_BUILD)

--- a/build.sh
+++ b/build.sh
@@ -20,14 +20,15 @@ PRINT_USAGE() {
     echo "  build.sh [options]"
     echo ""
     echo "  options:"
-    echo "    --cxx         : Path to Clang++ (see example below)"
-    echo "    --cc          : Path to Clang   (see example below)"
-    echo "    --debug, -d   : Debug build (by default Release Build)"
-    echo "    --help, -h    : Show help"
-    echo "    --icu         : Path to ICU include folder (see example below)"
-    echo "    --jobs, -j    : Multicore build (i.e. -j=3 for 3 cores)"
-    echo "    --ninja, -n   : Build with ninja instead of make"
-    echo "    --verbose, -v : Display verbose output including all options"
+    echo "    --cxx             : Path to Clang++ (see example below)"
+    echo "    --cc              : Path to Clang   (see example below)"
+    echo "    --debug, -d       : Debug build (by default Release build)"
+    echo "    --help, -h        : Show help"
+    echo "    --icu             : Path to ICU include folder (see example below)"
+    echo "    --jobs, -j        : Multicore build (i.e. -j=3 for 3 cores)"
+    echo "    --ninja, -n       : Build with ninja instead of make"
+    echo "    --test-build, -t  : Test build (by default Release build)"
+    echo "    --verbose, -v     : Display verbose output including all options"
     echo ""
     echo "  example:"
     echo "    ./build.sh --cxx=/path/to/clang++ --cc=/path/to/clang -j=2"
@@ -67,6 +68,10 @@ while [[ $# -gt 0 ]]; do
 
     if [[ "$1" == "--debug" || "$1" == "-d" ]]; then
         BUILD_TYPE="Debug"
+    fi
+
+    if [[ "$1" == "--test-build" || "$1" == "-t" ]]; then
+        BUILD_TYPE="Test"
     fi
 
     if [[ "$1" =~ "-j" ]]; then


### PR DESCRIPTION
Simple changes to enable "test" build type on cross-platform.
