### PR TITLE
MSFT: 7563889 stress AV when javascriptLibrary is nullptr

### DIFF
--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -670,7 +670,6 @@ namespace Js
             guestArena = nullptr;
         }
         cache = nullptr;
-        javascriptLibrary->CleanupForClose();
 
         builtInLibraryFunctions = nullptr;
 
@@ -683,6 +682,7 @@ namespace Js
         // and InternalClose gets called in the destructor code path
         if (javascriptLibrary != nullptr)
         {
+            javascriptLibrary->CleanupForClose();
             javascriptLibrary->Uninitialize();
         }
 


### PR DESCRIPTION
JavascriptLibrary can null be if the script context initialization threw.
move the cleanup code inside the null check block.
