### PR TITLE
Fix for pid ref stack issue in split scope when a lambda shadows a param

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -2677,7 +2677,11 @@ FuncInfo* PostVisitFunction(ParseNode* pnode, ByteCodeGenerator* byteCodeGenerat
                 top->GetChildCallsEval() ||
                 (top->GetHasArguments() && ByteCodeGenerator::NeedScopeObjectForArguments(top, pnode) && pnode->sxFnc.pnodeParams != nullptr) ||
                 top->GetHasLocalInClosure() ||
-                top->funcExprScope && top->funcExprScope->GetMustInstantiate())
+                top->funcExprScope && top->funcExprScope->GetMustInstantiate() ||
+                // When we have split scope normally either eval will be present or the GetHasLocalInClosure will be true as one of the formal is
+                // captured. But when we force split scope or split scope happens due to some other reasons we have to make sure we allocate frame
+                // slot register here.
+                (top->paramScope != nullptr && !top->paramScope->GetCanMergeWithBodyScope()))
             {
                 if (!top->GetCallsEval())
                 {

--- a/test/es6/default-splitscope.js
+++ b/test/es6/default-splitscope.js
@@ -89,6 +89,13 @@ var tests = [
         }
         f9();
         f9();
+        
+        function f12() {
+            var result = ((a = (w = a => a * a) => w) => a)()()(10); 
+            
+            assert.areEqual(100, result, "The inner lambda function properly maps to the right symbol for a");
+        };
+        f12();
     } 
  }, 
  { 


### PR DESCRIPTION
When a lambda in the param scope has a parameter that shadows a parameter in the parent function an additional pid ref is inserted into the ref stack as we parse the arguments list of lambda initially as an expression. This causes the parent function to be marked as split scope and the symbol requires scope slots. But as there is no non-local reference a slot register was not getting allocated for the function. The fix is to assign frame slots register when the function has split scope.
