### PR TITLE
xplat: enhance runtests.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.opendb
 *.user
 *.i
+*.pyc
 .vscode/
 Build/VCBuild/
 Build/VCBuild.NoJIT/

--- a/bin/ch/ch.cpp
+++ b/bin/ch/ch.cpp
@@ -392,7 +392,7 @@ HRESULT ExecuteTest(const char* fileName)
 
     IfJsErrorFailLog(ChakraRTInterface::JsCreateContext(runtime, &context));
     IfJsErrorFailLog(ChakraRTInterface::JsSetCurrentContext(context));
-    
+
 #ifdef DEBUG
     ChakraRTInterface::SetCheckOpHelpersFlag(true);
 #endif
@@ -583,7 +583,11 @@ int main(int argc, char** argv)
         Helpers::NarrowStringToWideDynamic(argv[i], &args[i]);
     }
 
-    int ret = wmain(argc, args);
+    // Call wmain with a copy of args, as HostConfigFlags may change argv
+    char16** argsCopy = new char16*[argc];
+    memcpy(argsCopy, args, sizeof(args[0]) * argc);
+    int ret = wmain(argc, argsCopy);
+    delete[] argsCopy;
 
     for (int i = 0; i < argc; i++)
     {

--- a/test/runtests.py
+++ b/test/runtests.py
@@ -4,6 +4,10 @@
 # Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 #-------------------------------------------------------------------------------------------------------
 
+from __future__ import print_function
+from datetime import datetime
+from multiprocessing import Pool, Manager
+from threading import Timer
 import sys
 import os
 import subprocess as SP
@@ -34,6 +38,18 @@ parser.add_argument('-b', '--binary', metavar='bin', help='ch full path')
 parser.add_argument('-d', '--debug', action='store_true',
                     help='use debug build');
 parser.add_argument('-t', '--test', action='store_true', help='use test build')
+parser.add_argument('--include-slow', action='store_true',
+                    help='include slow tests')
+parser.add_argument('--only-slow', action='store_true',
+                    help='run only slow tests')
+parser.add_argument('--nightly', action='store_true',
+                    help='run as nightly tests')
+parser.add_argument('--tag', nargs='*',
+                    help='select tests with given tags')
+parser.add_argument('--not-tag', nargs='*',
+                    help='exclude tests with given tags')
+parser.add_argument('--timeout', type=int, default=60,
+                    help='test timeout (default 60 seconds)')
 parser.add_argument('--x86', action='store_true', help='use x86 build')
 parser.add_argument('--x64', action='store_true', help='use x64 build')
 args = parser.parse_args()
@@ -65,6 +81,20 @@ if not os.path.isfile(binary):
     print('{} not found. Did you run ./build.sh already?'.format(binary))
     sys.exit(1)
 
+# global tags/not_tags
+tags = set(args.tag or [])
+not_tags = set(args.not_tag or []).union(['fail'])
+if args.only_slow:
+    tags.add('Slow')
+elif not args.include_slow:
+    not_tags.add('Slow')
+
+not_tags.add('exclude_nightly' if args.nightly else 'nightly')
+
+# xplat: temp hard coded to exclude tag 'require_backend'
+if sys.platform != 'win32':
+    not_tags.add('require_backend')
+
 # records pass_count/fail_count
 class PassFailCount(object):
     def __init__(self):
@@ -73,6 +103,9 @@ class PassFailCount(object):
 
     def __str__(self):
         return 'passed {}, failed {}'.format(self.pass_count, self.fail_count)
+
+    def total_count(self):
+        return self.pass_count + self.fail_count
 
 # records total and individual folder's pass_count/fail_count
 class TestResult(PassFailCount):
@@ -87,9 +120,8 @@ class TestResult(PassFailCount):
             self.folders[folder] = r
         return r
 
-    def log(self, filename=None, folder=None, fail=False):
-        if not folder:
-            folder = os.path.basename(os.path.dirname(filename))
+    def log(self, filename, fail=False):
+        folder = os.path.basename(os.path.dirname(filename))
         r = self._get_folder_result(folder)
         if fail:
             r.fail_count += 1
@@ -98,87 +130,241 @@ class TestResult(PassFailCount):
             r.pass_count += 1
             self.pass_count += 1
 
-test_result = TestResult()
+# test variants:
+#   interpreted: -maxInterpretCount:1 -maxSimpleJitRunCount:1 -bgjit-
+#   dynapogo: -forceNative -off:simpleJit -bgJitDelay:0
+class TestVariant(object):
+    MSG_PRINT = 0
+    MSG_TEST_RESULT = 1
+    _empty_set = set()
 
+    def __init__(self, name, compile_flags=[]):
+        self.name = name
+        self.compile_flags = \
+            ['-WERExceptionSupport', '-ExtendedErrorStackForTestHost'] + compile_flags
+        self.tags = tags.copy()
+        self.not_tags = not_tags.union(
+            ['{}_{}'.format(x, name) for x in 'fails','excludes'])
 
-def show_failed(filename, output, exit_code, expected_output):
-    print("\nFailed -> {}".format(filename))
-    if expected_output == None:
-        print("\nOutput:")
+        self.msg_queue = Manager().Queue() # messages from multi processes
+        self.test_result = TestResult()
+
+    # check if this test variant should run a given test
+    def _should_test(self, test):
+        tags = test.get('tags')
+        tags = set(tags.split(',')) if tags else self._empty_set
+        if not tags.isdisjoint(self.not_tags):
+            return False
+        if self.tags and not self.tags.issubset(tags):
+            return False
+        return True
+
+    # queue a test result from multi-process runs
+    def _log_result(self, filename, fail=False):
+        self.msg_queue.put((self.MSG_TEST_RESULT, filename, fail))
+
+    # queue output from multiprocessing runs
+    def _print(self, line):
+        self.msg_queue.put((self.MSG_PRINT, line))
+
+    # (on main process) process one queued message
+    def _process_msg(self, msg):
+        if msg[0] == self.MSG_TEST_RESULT:
+            tmp,filename,fail = msg
+            self.test_result.log(filename, fail=fail)
+        elif msg[0] == self.MSG_PRINT:
+            print(msg[1])
+        else:
+            print('ERROR: invalid msg! {}'.format(msg))
+            sys.exit(-1)
+
+    # (on main process) wait and process one queued message
+    def _process_one_msg(self):
+        self._process_msg(self.msg_queue.get())
+
+    # log a failed test with details
+    def _show_failed(self, flags, filename,
+                    output, exit_code, elapsed_time,
+                    expected_output=None, timedout=False):
+        self._print('[{}] Failed -> {}'.format(elapsed_time, filename))
+        if timedout:
+            self._print('ERROR: Test timed out!')
+        self._print('{} {} {}'.format(binary, ' '.join(flags), filename));
+        if expected_output == None or timedout:
+            self._print("\nOutput:")
+            self._print("----------------------------")
+            self._print(output)
+            self._print("----------------------------")
+        else:
+            lst_output = output.split('\n')
+            lst_expected = expected_output.split('\n')
+            ln = min(len(lst_output), len(lst_expected))
+            for i in range(0, ln):
+                if lst_output[i] != lst_expected[i]:
+                    self._print("Output: (at line " + str(i) + ")")
+                    self._print("----------------------------")
+                    self._print(lst_output[i])
+                    self._print("----------------------------")
+                    self._print("Expected Output:")
+                    self._print("----------------------------")
+                    self._print(lst_expected[i])
+                    self._print("----------------------------")
+                    break
+
+        self._print("exit code: {}".format(exit_code))
+        self._log_result(filename, fail=True)
+
+    # temp: try find real file name on hard drive if case mismatch
+    def _check_file(self, folder, filename):
+        path = os.path.join(folder, filename)
+        if os.path.isfile(path):
+            return path     # file exists on disk
+
+        filename_lower = filename.lower()
+        files = os.listdir(folder)
+        for i in range(len(files)):
+            if files[i].lower() == filename_lower:
+                self._print('\nWARNING: {} should be {}\n'.format(
+                    path, files[i]))
+                return os.path.join(folder, files[i])
+
+        # cann't find the file, just return the path and let it error out
+        return path
+
+    # run one test under this variant
+    def test_one(self, folder, test):
+        js_file = self._check_file(folder, test['files'])
+        js_output = ""
+
+        working_path = os.path.dirname(js_file)
+        file_name = os.path.basename(js_file)
+
+        flags = test.get('compile-flags')
+        flags = self.compile_flags + (flags.split() if flags else [])
+        cmd = [binary] + flags + [file_name]
+
+        proc = SP.Popen(cmd, stdout=SP.PIPE, stderr=SP.STDOUT, cwd=working_path)
+        timeout_data = [proc, False]
+        def timeout_func(timeout_data):
+            timeout_data[0].kill()
+            timeout_data[1] = True
+        timeout = args.timeout # or specific test timeout override
+        timer = Timer(timeout, timeout_func, [timeout_data])
+        start_time = datetime.now()
+        try:
+            timer.start()
+            js_output = proc.communicate()[0].replace('\r','')
+            exit_code = proc.wait()
+        finally:
+            timer.cancel()
+        elapsed_time = (datetime.now() - start_time).total_seconds()
+
+        # shared _show_failed args
+        fail_args = { 'flags': flags, 'filename': js_file,
+                    'output': js_output, 'exit_code': exit_code,
+                    'elapsed_time': elapsed_time };
+
+        # check timed out
+        if (timeout_data[1]):
+            return self._show_failed(timedout=True, **fail_args)
+
+        # check ch failed
+        if exit_code != 0:
+            return self._show_failed(**fail_args)
+
+        # check output
+        if 'baseline' not in test:
+            # output lines must be 'pass' or 'passed' or empty
+            lines = (line.lower() for line in js_output.split('\n'))
+            if any(line != '' and line != 'pass' and line != 'passed'
+                    for line in lines):
+                return self._show_failed(**fail_args)
+        else:
+            baseline = test.get('baseline')
+            if baseline:
+                # perform baseline comparison
+                baseline = self._check_file(working_path, baseline)
+                expected_output = None
+                with open(baseline, 'r') as bs_file:
+                    baseline_output = bs_file.read()
+
+                # Cleanup carriage return
+                # todo: remove carriage return at the end of the line
+                #       or better fix ch to output same on all platforms
+                expected_output = re.sub('[\r]+\n', '\n', baseline_output)
+
+                # todo: implement wild cards support
+                if expected_output != js_output:
+                    return self._show_failed(
+                        expected_output=expected_output, **fail_args)
+
+        # passed
+        self._print('[{}] Passed -> {}'.format(elapsed_time, js_file))
+        self._log_result(js_file)
+
+    # run tests under this variant, using given multiprocessing Pool
+    def run(self, tests, pool):
+        print('\n############# Starting {} variant #############'.format(
+            self.name))
+        if self.tags:
+            print('  tags: {}'.format(self.tags))
+        for x in self.not_tags:
+            print('  exclude: {}'.format(x))
+        print()
+
+        # filter tests to run
+        tests = [x for x in tests if self._should_test(x[1])]
+
+        # run tests in parallel
+        result = pool.map_async(run_one,
+                    [(self,folder,test) for folder,test in tests])
+        while self.test_result.total_count() != len(tests):
+            self._process_one_msg()
+
+    # print test result summary
+    def print_summary(self):
+        print('\n######## Logs for {} variant ########'.format(self.name))
+        for folder, result in sorted(self.test_result.folders.items()):
+            print('{}: {}'.format(folder, result))
         print("----------------------------")
-        print(output)
-        print("----------------------------")
-    else:
-        lst_output = output.split('\n')
-        lst_expected = expected_output.split('\n')
-        ln = min(len(lst_output), len(lst_expected))
-        for i in range(0, ln):
-            if lst_output[i] != lst_expected[i]:
-                print("Output: (at line " + str(i) + ")")
-                print("----------------------------")
-                print(lst_output[i])
-                print("----------------------------")
-                print("Expected Output:")
-                print("----------------------------")
-                print(lst_expected[i])
-                print("----------------------------")
-                break
+        print('Total: {}'.format(self.test_result))
 
-    print("exit code: {}".format(exit_code))
-    test_result.log(filename, fail=True)
+# global run one test function for multiprocessing, used by TestVariant
+def run_one(data):
+    variant, folder, test = data
+    variant.test_one(folder, test)
 
-def test_path(path):
-    if os.path.isfile(path):
-        folder, file = os.path.dirname(path), os.path.basename(path)
-    else:
-        folder, file = path, None
 
-    tests = load_tests(folder, file)
-    if len(tests) == 0:
-        return
+# record folder/tags info from test_root/rlexedirs.xml
+class FolderTags(object):
+    _empty_set = set()
 
-    print("Testing -> " + os.path.basename(folder))
-    for test in tests:
-        test_one(folder, test)
+    def __init__(self):
+        xmlpath = os.path.join(test_root, 'rlexedirs.xml')
+        try:
+            xml = ET.parse(xmlpath).getroot()
+        except IOError:
+            print('ERROR: failed to read {}'.format(xmlpath))
+            exit(-1)
 
-def test_one(folder, test):
-    js_file = os.path.join(folder, test['files'])
-    js_output = ""
+        self._folder_tags = {}
+        for x in xml:
+            d = x.find('default')
+            key = d.find('files').text.lower() # avoid case mismatch
+            tags = d.find('tags')
+            self._folder_tags[key] = \
+                set(tags.text.split(',')) if tags != None else self._empty_set
 
-    flags = test.get('compile-flags')
+    # check if should test a given folder
+    def should_test(self, folder):
+        key = os.path.basename(os.path.normpath(folder)).lower()
+        ftags = self._folder_tags.get(key)
 
-    working_path = os.path.dirname(js_file)
-    file_name = os.path.basename(js_file)
+        # folder listed in rlexedirs.xml and not exlucded by global not_tags
+        return ftags != None and ftags.isdisjoint(not_tags)
 
-    cmd = [binary, '-WERExceptionSupport', '-ExtendedErrorStackForTestHost'] \
-          + (flags.split() if flags else []) \
-          + [file_name]
 
-    p = SP.Popen(cmd, stdout=SP.PIPE, stderr=SP.STDOUT, cwd=working_path)
-    js_output = p.communicate()[0].replace('\r','')
-    exit_code = p.wait()
-
-    if exit_code != 0:
-        return show_failed(js_file, js_output, exit_code, None)
-    else: #compare outputs
-        baseline = os.path.splitext(js_file)[0] + '.baseline'
-        if os.path.isfile(baseline):
-            expected_output = None
-            with open(baseline, 'r') as bs_file:
-                baseline_output = bs_file.read()
-
-            # Cleanup carriage return
-            # todo: remove carriage return at the end of the line
-            #       or better fix ch to output same on all platforms
-            expected_output = re.sub('[\r]+\n', '\n', baseline_output)
-
-            # todo: implement wild cards support
-            if expected_output != js_output:
-                return show_failed(js_file, js_output, exit_code, expected_output)
-
-    print("\tPassed -> " + os.path.basename(js_file))
-    test_result.log(folder=folder)
-
+# load all tests in folder using rlexe.xml file
 def load_tests(folder, file):
     try:
         xmlpath = os.path.join(folder, 'rlexe.xml')
@@ -186,18 +372,18 @@ def load_tests(folder, file):
     except IOError:
         return []
 
+    def load_test(testXml):
+        test = dict()
+        for c in testXml.find('default'):
+            test[c.tag] = c.text
+        return test
+
     tests = [load_test(x) for x in xml]
     if file != None:
-        tests = [x for x in tests if x['files'] == file]
+        tests = [x for x in tests if x.get('files') == file]
         if len(tests) == 0 and is_jsfile(file):
-            tests = [{'files':file}]
+            tests = [{'files':file, 'baseline':''}]
     return tests
-
-def load_test(testXml):
-    test = dict()
-    for c in testXml.find('default'):
-        test[c.tag] = c.text
-    return test
 
 def is_jsfile(path):
     return os.path.splitext(path)[1] == '.js'
@@ -205,19 +391,41 @@ def is_jsfile(path):
 def main():
     # By default run all tests
     if len(args.folders) == 0:
-        args.folders = [os.path.join(test_root, x)
-                        for x in sorted(os.listdir(test_root))]
+        files = (os.path.join(test_root, x) for x in os.listdir(test_root))
+        args.folders = [f for f in sorted(files) if not os.path.isfile(f)]
 
-    for folder in args.folders:
-        test_path(folder)
+    # load all tests
+    tests = []
+    folder_tags = FolderTags()
+    for path in args.folders:
+        if os.path.isfile(path):
+            folder, file = os.path.dirname(path), os.path.basename(path)
+        else:
+            folder, file = path, None
+        if folder_tags.should_test(folder):
+            tests += ((folder,test) for test in load_tests(folder, file))
 
-    print('\n')
-    print('============================')
-    for folder, result in sorted(test_result.folders.items()):
-        print('{}: {}'.format(folder, result))
-    print('============================')
-    print('Total: {}'.format(test_result))
-    print('Success!' if test_result.fail_count == 0 else 'Failed!')
+    # test variants
+    variants = [
+        TestVariant('interpreted', [
+            '-maxInterpretCount:1', '-maxSimpleJitRunCount:1', '-bgjit-'])
+    ]
+
+    # run each variant
+    pool = Pool() # Use a multiprocessing process Pool
+    start_time = datetime.now()
+    for variant in variants:
+        variant.run(tests, pool)
+    elapsed_time = datetime.now() - start_time
+
+    # print summary
+    for variant in variants:
+        variant.print_summary()
+
+    print()
+    failed = any(variant.test_result.fail_count > 0 for variant in variants)
+    print('[{}] {}'.format(
+        str(elapsed_time), 'Success!' if not failed else 'Failed!'))
     return 0
 
 if __name__ == '__main__':


### PR DESCRIPTION
Run tests in parallel.
Support tags, not_tags (excludes).
Support `pass` baselines.
Support test time out.
Support test variants, currently only interpreted.

Print elapsed time for each test and entire run.

Load and filter test folders with test_root/rlexedirs.xml.

Temporary: Find and use correct filename on disk if rlexe.xml filename
case mismatches. Print a warning.