### PR TITLE
xplat: fix rlexe.xml filename case

### DIFF
--- a/test/Array/rlexe.xml
+++ b/test/Array/rlexe.xml
@@ -373,8 +373,8 @@
   </test>
   <test>
     <default>
-      <files>array_lastIndexOf.js</files>
-      <baseline>array_lastIndexOf.baseline</baseline>
+      <files>array_lastindexof.js</files>
+      <baseline>array_lastindexof.baseline</baseline>
     </default>
   </test>
   <test>
@@ -593,8 +593,8 @@
   </test>
   <test>
     <default>
-      <files>newFromArgs.js</files>
-      <baseline>newFromArgs.baseline</baseline>
+      <files>newfromargs.js</files>
+      <baseline>newfromargs.baseline</baseline>
     </default>
   </test>
   <test>

--- a/test/Basics/rlexe.xml
+++ b/test/Basics/rlexe.xml
@@ -221,15 +221,15 @@
   </test>
   <test>
     <default>
-      <files>Switch.js</files>
-      <baseline>Switch.baseline</baseline>
+      <files>switch.js</files>
+      <baseline>switch.baseline</baseline>
       <compile-flags>-Intl-</compile-flags>
     </default>
   </test>
   <test>
     <default>
       <files>Switch2.js</files>
-      <baseline>Switch2.baseline</baseline>
+      <baseline>switch2.baseline</baseline>
       <compile-flags>-Intl-</compile-flags>
     </default>
   </test>
@@ -288,8 +288,8 @@
   </test>
   <test>
     <default>
-      <files>Witheval.js</files>
-      <baseline>Witheval.baseline</baseline>
+      <files>witheval.js</files>
+      <baseline>witheval.baseline</baseline>
       <compile-flags>-Intl-</compile-flags>
     </default>
   </test>
@@ -321,8 +321,8 @@
   </test>
   <test>
     <default>
-      <files>ScopedAccessors.js</files>
-      <baseline>ScopedAccessors.baseline</baseline>
+      <files>scopedaccessors.js</files>
+      <baseline>scopedaccessors.baseline</baseline>
     </default>
   </test>
   <test>

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -254,7 +254,7 @@
   </test>
   <test>
     <default>
-      <files>bug_resetisdead.js</files>
+      <files>Bug_resetisdead.js</files>
       <compile-flags>-on:prelowererpeeps</compile-flags>
     </default>
   </test>

--- a/test/ControlFlow/rlexe.xml
+++ b/test/ControlFlow/rlexe.xml
@@ -87,7 +87,7 @@
   <test>
     <default>
       <files>forInArrayAdd.js</files>
-      <baseline>forInArrayAddv3.baseline</baseline>
+      <baseline>forinArrayAddv3.baseline</baseline>
     </default>
   </test>
   <test>

--- a/test/Conversions/rlexe.xml
+++ b/test/Conversions/rlexe.xml
@@ -2,20 +2,20 @@
 <regress-exe>
   <test>
     <default>
-      <files>ToInt32.js</files>
+      <files>toint32.js</files>
       <baseline>ToInt32.baseline</baseline>
     </default>
   </test>
   <test>
     <default>
-      <files>ToInt32_2.js</files>
-      <baseline>ToInt32_2.3.baseline</baseline>
+      <files>toint32_2.js</files>
+      <baseline>toint32_2.3.baseline</baseline>
     </default>
   </test>
   <test>
     <default>
-      <files>Touint32.js</files>
-      <baseline>Touint32.baseline</baseline>
+      <files>touint32.js</files>
+      <baseline>ToUInt32.baseline</baseline>
     </default>
   </test>
   <test>

--- a/test/Date/rlexe.xml
+++ b/test/Date/rlexe.xml
@@ -48,8 +48,8 @@
   </test>
   <test>
     <default>
-      <files>DateUTC.js</files>
-      <baseline>DateUTC.baseline</baseline>
+      <files>dateutc.js</files>
+      <baseline>dateutc.baseline</baseline>
     </default>
   </test>
   <test>

--- a/test/Error/rlexe.xml
+++ b/test/Error/rlexe.xml
@@ -22,20 +22,20 @@
   </test>
   <test>
     <default>
-      <files>OutOfMem.js</files>
-      <baseline>OutOfMem.baseline</baseline>
+      <files>outofmem.js</files>
+      <baseline>outofmem.baseline</baseline>
     </default>
   </test>
   <test>
     <default>
-      <files>Stack.js</files>
-      <baseline>Stack.baseline</baseline>
+      <files>stack.js</files>
+      <baseline>stack.baseline</baseline>
     </default>
   </test>
   <test>
     <default>
-      <files>Stack2.js</files>
-      <baseline>Stack2.baseline</baseline>
+      <files>stack2.js</files>
+      <baseline>stack2.baseline</baseline>
     </default>
   </test>
   <test>

--- a/test/InlineCaches/rlexe.xml
+++ b/test/InlineCaches/rlexe.xml
@@ -51,13 +51,13 @@
   </test>
   <test>
     <default>
-      <files>Getter_sideeffect.js</files>
+      <files>getter_sideeffect.js</files>
     </default>
   </test>
   <test>
     <default>
-      <files>PrototypeChainModifications.js</files>
-      <baseline>PrototypeChainModifications.baseline</baseline>
+      <files>prototypeChainModifications.js</files>
+      <baseline>prototypeChainModifications.baseline</baseline>
     </default>
   </test>
   <test>

--- a/test/JSON/rlexe.xml
+++ b/test/JSON/rlexe.xml
@@ -59,7 +59,7 @@
   </test>
   <test>
     <default>
-      <files>parseWithGC.js</files>
+      <files>parseWithGc.js</files>
       <compile-flags>-ForceGCAfterJSONParse</compile-flags>
       <tags>exclude_fre</tags>
     </default>

--- a/test/Lib/rlexe.xml
+++ b/test/Lib/rlexe.xml
@@ -33,7 +33,7 @@
   </test>
   <test>
     <default>
-      <files>toString.js</files>
+      <files>tostring.js</files>
       <baseline>toString.baseline</baseline>
     </default>
   </test>

--- a/test/Prototypes/rlexe.xml
+++ b/test/Prototypes/rlexe.xml
@@ -2,14 +2,14 @@
 <regress-exe>
   <test>
     <default>
-      <files>prototype.js</files>
-      <baseline>prototype.baseline</baseline>
+      <files>Prototype.js</files>
+      <baseline>Prototype.baseline</baseline>
     </default>
   </test>
   <test>
     <default>
-      <files>prototype2.js</files>
-      <baseline>prototype2.baseline</baseline>
+      <files>Prototype2.js</files>
+      <baseline>Prototype2.baseline</baseline>
     </default>
   </test>
   <test>

--- a/test/Regex/rlexe.xml
+++ b/test/Regex/rlexe.xml
@@ -166,8 +166,8 @@
   </test>
   <test>
     <default>
-      <files>LeadTrail.js</files>
-      <baseline>LeadTrail.baseline</baseline>
+      <files>leadtrail.js</files>
+      <baseline>leadtrail.baseline</baseline>
     </default>
   </test>
   <test>

--- a/test/StackTrace/rlexe.xml
+++ b/test/StackTrace/rlexe.xml
@@ -3,7 +3,7 @@
   <test>
     <default>
       <tags>StackTrace,exclude_ship</tags>
-      <files>simpleThrow.js</files>
+      <files>SimpleThrow.js</files>
       <compile-flags>-ExtendedErrorStackForTestHost -errorStackTrace- -args runTest -endargs</compile-flags>
       <baseline>simpleThrow.js.stackTraceDisabled.baseline</baseline>
     </default>
@@ -27,9 +27,9 @@
   <test>
     <default>
       <tags>StackTrace,exclude_ship</tags>
-      <files>simpleThrow.js</files>
+      <files>SimpleThrow.js</files>
       <compile-flags>-ExtendedErrorStackForTestHost -args runTest -endargs</compile-flags>
-      <baseline>simpleThrow.js.baseline</baseline>
+      <baseline>SimpleThrow.js.baseline</baseline>
     </default>
   </test>
   <test>

--- a/test/Strings/rlexe.xml
+++ b/test/Strings/rlexe.xml
@@ -123,14 +123,14 @@
   </test>
   <test>
     <default>
-      <files>lastIndexOf.js</files>
-      <baseline>lastIndexOf.baseline</baseline>
+      <files>lastindexof.js</files>
+      <baseline>lastindexof.baseline</baseline>
     </default>
   </test>
   <test>
     <default>
-      <files>indexOf.js</files>
-      <baseline>indexOf.baseline</baseline>
+      <files>indexof.js</files>
+      <baseline>indexof.baseline</baseline>
     </default>
   </test>
   <test>

--- a/test/VT_DATE/rlexe.xml
+++ b/test/VT_DATE/rlexe.xml
@@ -2,7 +2,7 @@
 <regress-exe>
   <test>
     <default>
-      <files>getVarDate.js</files>
+      <files>getvardate.js</files>
       <baseline>getVarDate.baseline</baseline>
       <!-- test is timezone-sensitive; remove exclude_jenkins after fix -->
       <tags>exclude_jenkins</tags>

--- a/test/es5/rlexe.xml
+++ b/test/es5/rlexe.xml
@@ -10,8 +10,8 @@
   <test>
     <default>
       <compile-flags>-ES6Unicode-</compile-flags>
-      <files>Lex_U3.js</files>
-      <baseline>Lex_U3.baseline</baseline>
+      <files>Lex_u3.js</files>
+      <baseline>Lex_u3.baseline</baseline>
       <tags>fail_mutators</tags>
     </default>
   </test>
@@ -53,8 +53,8 @@
   </test>
   <test>
     <default>
-      <files>array_reduceRight.js</files>
-      <baseline>array_reduceRight.baseline</baseline>
+      <files>array_reduceright.js</files>
+      <baseline>array_reduceright.baseline</baseline>
     </default>
   </test>
   <test>

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -1082,7 +1082,7 @@
 
   <test>
     <default>
-      <files>bug_OS3198161.js</files>
+      <files>bug_os3198161.js</files>
       <compile-flags>-es6all</compile-flags>
       <tags>BugFix</tags>
     </default>
@@ -1167,7 +1167,7 @@
 </test>
 <test>
     <default>
-        <files>Expo.js</files>
+        <files>expo.js</files>
         <compile-flags>-args summary -endargs -es7exponentiationoperator</compile-flags>
     </default>
 </test>
@@ -1179,9 +1179,9 @@
 </test>
 <test>
     <default>
-        <files>ES6HasInstance.js</files>
+        <files>es6HasInstance.js</files>
         <compile-flags>-es6HasInstance</compile-flags>
-        <baseline>ES6HasInstance.baseline</baseline>
+        <baseline>es6HasInstance.baseline</baseline>
     </default>
 </test>
 <test>

--- a/test/fieldopts/rlexe.xml
+++ b/test/fieldopts/rlexe.xml
@@ -321,9 +321,9 @@
   </test>
   <test>
     <default>
-      <files>checkthis.js</files>
+      <files>CheckThis.js</files>
       <compile-flags>-force:inline -force:checkthis</compile-flags>
-      <baseline>checkthis.baseline</baseline>
+      <baseline>CheckThis.baseline</baseline>
       <tags>exclude_ship</tags>
     </default>
   </test>

--- a/test/typedarray/rlexe.xml
+++ b/test/typedarray/rlexe.xml
@@ -2,14 +2,14 @@
 <regress-exe>
   <test>
     <default>
-      <files>arrayBuffer.js</files>
-      <baseline>arraybuffer.baseline</baseline>
+      <files>arraybuffer.js</files>
+      <baseline>arrayBuffer.baseline</baseline>
       <tags>typedarray</tags>
     </default>
   </test>
   <test>
     <default>
-      <files>arrayBufferType_v5.js</files>
+      <files>arraybufferType_v5.js</files>
       <baseline>arraybufferType_v5.baseline</baseline>
       <tags>typedarray</tags>
       <compile-flags>-ES6- </compile-flags>
@@ -17,7 +17,7 @@
   </test>
   <test>
     <default>
-      <files>arrayBufferType.js</files>
+      <files>arraybufferType.js</files>
       <baseline>arraybufferType.baseline</baseline>
       <tags>typedarray</tags>
       <compile-flags>-ES6TypedArrayExtensions</compile-flags>
@@ -94,8 +94,8 @@
   </test>
   <test>
     <default>
-      <files>DataView.js</files>
-      <baseline>DataView.baseline</baseline>
+      <files>dataview.js</files>
+      <baseline>dataview.baseline</baseline>
       <tags>typedarray</tags>
     </default>
   </test>


### PR DESCRIPTION
Change all file names (files/baseline) in rlexe.xml to match real file
names on disk.
