### PR TITLE
MemOp Loop Memory allocation

### DIFF
--- a/lib/Backend/BackwardPass.cpp
+++ b/lib/Backend/BackwardPass.cpp
@@ -451,7 +451,7 @@ BackwardPass::MergeSuccBlocksInfo(BasicBlock * block)
             char16 debugStringBuffer[MAX_FUNCTION_BODY_DEBUG_STRING_SIZE];
 #endif
             // save the byteCodeUpwardExposedUsed from deleting for the block right after the memop loop
-            if (this->tag == Js::DeadStorePhase && !this->IsPrePass() && globOpt->DoMemOp(block->loop) && blockSucc->loop != block->loop)
+            if (this->tag == Js::DeadStorePhase && !this->IsPrePass() && globOpt->HasMemOp(block->loop) && blockSucc->loop != block->loop)
             {
                 Assert(block->loop->memOpInfo->inductionVariablesUsedAfterLoop == nullptr);
                 block->loop->memOpInfo->inductionVariablesUsedAfterLoop = JitAnew(this->tempAlloc, BVSparse<JitArenaAllocator>, this->tempAlloc);
@@ -7124,7 +7124,7 @@ BackwardPass::DoDeadStoreLdStForMemop(IR::Instr *instr)
 
     Loop *loop = this->currentBlock->loop;
 
-    if (globOpt->DoMemOp(loop))
+    if (globOpt->HasMemOp(loop))
     {
         if (instr->m_opcode == Js::OpCode::StElemI_A && instr->GetDst()->IsIndirOpnd())
         {
@@ -7192,7 +7192,7 @@ BackwardPass::RestoreInductionVariableValuesAfterMemOp(Loop *loop)
 bool
 BackwardPass::IsEmptyLoopAfterMemOp(Loop *loop)
 {
-    if (globOpt->DoMemOp(loop))
+    if (globOpt->HasMemOp(loop))
     {
         const auto IsInductionVariableUse = [&](IR::Opnd *opnd) -> bool
         {

--- a/lib/Backend/FlowGraph.cpp
+++ b/lib/Backend/FlowGraph.cpp
@@ -747,6 +747,7 @@ FlowGraph::BuildLoop(BasicBlock *headBlock, BasicBlock *tailBlock, Loop *parentL
     loop->hasDeadStoreCollectionPass = false;
     loop->hasDeadStorePrepass = false;
     loop->memOpInfo = nullptr;
+    loop->doMemOp = true;
 
     NoRecoverMemoryJitArenaAllocator tempAlloc(_u("BE-LoopBuilder"), this->func->m_alloc->GetPageAllocator(), Js::Throw::OutOfMemory);
 
@@ -782,8 +783,10 @@ Loop::MemSetCandidate* Loop::MemOpCandidate::AsMemSet()
     return (Loop::MemSetCandidate*)this;
 }
 
-bool Loop::EnsureMemOpVariablesInitialized()
+void
+Loop::EnsureMemOpVariablesInitialized()
 {
+    Assert(this->doMemOp);
     if (this->memOpInfo == nullptr)
     {
         JitArenaAllocator *allocator = this->GetFunc()->GetTopFunc()->m_fg->alloc;
@@ -793,32 +796,10 @@ bool Loop::EnsureMemOpVariablesInitialized()
         this->memOpInfo->startIndexOpndCache[1] = nullptr;
         this->memOpInfo->startIndexOpndCache[2] = nullptr;
         this->memOpInfo->startIndexOpndCache[3] = nullptr;
-        if (this->GetLoopFlags().isInterpreted && !this->GetLoopFlags().memopMinCountReached)
-        {
-#if DBG_DUMP
-            Func* func = this->GetFunc();
-            if (Js::Configuration::Global.flags.Verbose && PHASE_TRACE(Js::MemOpPhase, func))
-            {
-                char16 debugStringBuffer[MAX_FUNCTION_BODY_DEBUG_STRING_SIZE];
-                Output::Print(_u("MemOp skipped: minimum loop count not reached: Function: %s %s,  Loop: %d\n"),
-                              func->GetJnFunction()->GetDisplayName(),
-                              func->GetJnFunction()->GetDebugNumberSet(debugStringBuffer),
-                              this->GetLoopNumber()
-                              );
-            }
-#endif
-            this->memOpInfo->doMemOp = false;
-            this->memOpInfo->inductionVariableChangeInfoMap = nullptr;
-            this->memOpInfo->inductionVariableOpndPerUnrollMap = nullptr;
-            this->memOpInfo->candidates = nullptr;
-            return false;
-        }
-        this->memOpInfo->doMemOp = true;
         this->memOpInfo->inductionVariableChangeInfoMap = JitAnew(allocator, Loop::InductionVariableChangeInfoMap, allocator);
         this->memOpInfo->inductionVariableOpndPerUnrollMap = JitAnew(allocator, Loop::InductionVariableOpndPerUnrollMap, allocator);
         this->memOpInfo->candidates = JitAnew(allocator, Loop::MemOpList, allocator);
     }
-    return true;
 }
 
 // Walk the basic blocks backwards until we find the loop header.

--- a/lib/Backend/FlowGraph.h
+++ b/lib/Backend/FlowGraph.h
@@ -664,7 +664,6 @@ public:
     typedef struct
     {
         MemOpList *candidates;
-        bool doMemOp : 1;
         BVSparse<JitArenaAllocator> *inductionVariablesUsedAfterLoop;
         InductionVariableChangeInfoMap *inductionVariableChangeInfoMap;
         InductionVariableOpndPerUnrollMap *inductionVariableOpndPerUnrollMap;
@@ -674,6 +673,7 @@ public:
         IR::RegOpnd* startIndexOpndCache[4];
     } MemOpInfo;
 
+    bool doMemOp : 1;
     MemOpInfo *memOpInfo;
 
     struct RegAlloc
@@ -729,7 +729,7 @@ public:
     BasicBlock *        GetHeadBlock() const { Assert(headBlock == blockList.Head()); return headBlock; }
     bool                IsDescendentOrSelf(Loop const * loop) const;
 
-    bool                EnsureMemOpVariablesInitialized();
+    void                EnsureMemOpVariablesInitialized();
 
     Js::ImplicitCallFlags GetImplicitCallFlags();
     void                SetImplicitCallFlags(Js::ImplicitCallFlags flags);

--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -4187,30 +4187,33 @@ GlobOpt::IsAllowedForMemOpt(IR::Instr* instr, bool isMemset, IR::RegOpnd *baseOp
     Assert(iv->IsChangeDeterminate() && iv->IsChangeUnidirectional());
     const IntConstantBounds & bounds = iv->ChangeBounds();
 
-    // Only accept induction variables that increments by 1
-    Loop::InductionVariableChangeInfo inductionVariableChangeInfo = { 0, 0 };
-    inductionVariableChangeInfo = loop->memOpInfo->inductionVariableChangeInfoMap->Lookup(indexSymID, inductionVariableChangeInfo);
-
-    if (
-        (bounds.LowerBound() != 1 && bounds.LowerBound() != -1) ||
-        (bounds.UpperBound() != bounds.LowerBound()) ||
-        inductionVariableChangeInfo.unroll > 1 // Must be 0 (not seen yet) or 1 (already seen)
-    )
+    if (loop->memOpInfo)
     {
-        TRACE_MEMOP_VERBOSE(loop, instr, _u("The index does not change by 1: %d><%d, unroll=%d"), bounds.LowerBound(), bounds.UpperBound(), inductionVariableChangeInfo.unroll);
-        return false;
-    }
+        // Only accept induction variables that increments by 1
+        Loop::InductionVariableChangeInfo inductionVariableChangeInfo = { 0, 0 };
+        inductionVariableChangeInfo = loop->memOpInfo->inductionVariableChangeInfoMap->Lookup(indexSymID, inductionVariableChangeInfo);
 
-    // Check if the index is the same in all MemOp optimization in this loop
-    if (!loop->memOpInfo->candidates->Empty())
-    {
-        Loop::MemOpCandidate* previousCandidate = loop->memOpInfo->candidates->Head();
-
-        // All MemOp operations within the same loop must use the same index
-        if (previousCandidate->index != indexSymID)
+        if (
+            (bounds.LowerBound() != 1 && bounds.LowerBound() != -1) ||
+            (bounds.UpperBound() != bounds.LowerBound()) ||
+            inductionVariableChangeInfo.unroll > 1 // Must be 0 (not seen yet) or 1 (already seen)
+        )
         {
-            TRACE_MEMOP_VERBOSE(loop, instr, _u("The index is not the same as other MemOp in the loop"));
+            TRACE_MEMOP_VERBOSE(loop, instr, _u("The index does not change by 1: %d><%d, unroll=%d"), bounds.LowerBound(), bounds.UpperBound(), inductionVariableChangeInfo.unroll);
             return false;
+        }
+
+        // Check if the index is the same in all MemOp optimization in this loop
+        if (!loop->memOpInfo->candidates->Empty())
+        {
+            Loop::MemOpCandidate* previousCandidate = loop->memOpInfo->candidates->Head();
+
+            // All MemOp operations within the same loop must use the same index
+            if (previousCandidate->index != indexSymID)
+            {
+                TRACE_MEMOP_VERBOSE(loop, instr, _u("The index is not the same as other MemOp in the loop"));
+                return false;
+            }
         }
     }
 
@@ -4235,6 +4238,7 @@ GlobOpt::CollectMemcopyLdElementI(IR::Instr *instr, Loop *loop)
     SymID inductionSymID = GetVarSymID(indexOpnd->GetStackSym());
     Assert(IsSymIDInductionVariable(inductionSymID, loop));
 
+    loop->EnsureMemOpVariablesInitialized();
     bool isIndexPreIncr = loop->memOpInfo->inductionVariableChangeInfoMap->ContainsKey(inductionSymID);
 
     IR::Opnd * dst = instr->GetDst();
@@ -4305,6 +4309,7 @@ GlobOpt::CollectMemsetStElementI(IR::Instr *instr, Loop *loop)
     SymID inductionSymID = GetVarSymID(indexOp->GetStackSym());
     Assert(IsSymIDInductionVariable(inductionSymID, loop));
 
+    loop->EnsureMemOpVariablesInitialized();
     bool isIndexPreIncr = loop->memOpInfo->inductionVariableChangeInfoMap->ContainsKey(inductionSymID);
 
     Loop::MemSetCandidate* memsetInfo = JitAnewStruct(this->func->GetTopFunc()->m_fg->alloc, Loop::MemSetCandidate);
@@ -4320,6 +4325,12 @@ GlobOpt::CollectMemsetStElementI(IR::Instr *instr, Loop *loop)
 
 bool GlobOpt::CollectMemcopyStElementI(IR::Instr *instr, Loop *loop)
 {
+    if (!loop->memOpInfo || loop->memOpInfo->candidates->Empty())
+    {
+        // There is no ldElem matching this stElem
+        return false;
+    }
+
     Assert(instr->GetDst()->IsIndirOpnd());
     IR::IndirOpnd *dst = instr->GetDst()->AsIndirOpnd();
     IR::Opnd *indexOp = dst->GetIndexOpnd();
@@ -4348,11 +4359,6 @@ bool GlobOpt::CollectMemcopyStElementI(IR::Instr *instr, Loop *loop)
     SymID srcSymID = GetVarSymID(src1->GetStackSym());
 
     // Prepare the memcopyCandidate entry
-    if (loop->memOpInfo->candidates->Empty())
-    {
-        // There is no ldElem matching this stElem
-        return false;
-    }
     Loop::MemOpCandidate* previousCandidate = loop->memOpInfo->candidates->Head();
     if (!previousCandidate->IsMemCopy())
     {
@@ -4417,12 +4423,13 @@ GlobOpt::CollectMemOpInfo(IR::Instr *instr, Value *src1Val, Value *src2Val)
         return false;
     }
 
-    if (!loop->EnsureMemOpVariablesInitialized())
+    if (loop->GetLoopFlags().isInterpreted && !loop->GetLoopFlags().memopMinCountReached)
     {
+        TRACE_MEMOP_VERBOSE(loop, instr, _u("minimum loop count not reached"))
+        loop->doMemOp = false;
         return false;
     }
-
-    Assert(loop->memOpInfo->doMemOp);
+    Assert(loop->doMemOp);
 
     bool isIncr = true, isChangedByOne = false;
     switch (instr->m_opcode)
@@ -4431,14 +4438,14 @@ GlobOpt::CollectMemOpInfo(IR::Instr *instr, Value *src1Val, Value *src2Val)
     case Js::OpCode::StElemI_A_Strict:
         if (!CollectMemOpStElementI(instr, loop))
         {
-            loop->memOpInfo->doMemOp = false;
+            loop->doMemOp = false;
             return false;
         }
         break;
     case Js::OpCode::LdElemI_A:
         if (!CollectMemOpLdElementI(instr, loop))
         {
-            loop->memOpInfo->doMemOp = false;
+            loop->doMemOp = false;
             return false;
         }
         break;
@@ -4495,6 +4502,7 @@ MemOpCheckInductionVariable:
                 }
             }
 
+            loop->EnsureMemOpVariablesInitialized();
             if (!isChangedByOne)
             {
                 Loop::InductionVariableChangeInfo inductionVariableChangeInfo = { Js::Constants::InvalidLoopUnrollFactor, 0 };
@@ -4531,12 +4539,12 @@ MemOpCheckInductionVariable:
     default:
         if (IsInstrInvalidForMemOp(instr, loop, src1Val, src2Val))
         {
-            loop->memOpInfo->doMemOp = false;
+            loop->doMemOp = false;
             return false;
         }
 
         // Make sure this instruction doesn't use the memcopy transfer sym before it is checked by StElemI
-        if (!loop->memOpInfo->candidates->Empty())
+        if (loop->memOpInfo && !loop->memOpInfo->candidates->Empty())
         {
             Loop::MemOpCandidate* prevCandidate = loop->memOpInfo->candidates->Head();
             if (prevCandidate->IsMemCopy())
@@ -4546,7 +4554,7 @@ MemOpCheckInductionVariable:
                 {
                     if (instr->FindRegUse(memcopyCandidate->transferSym))
                     {
-                        loop->memOpInfo->doMemOp = false;
+                        loop->doMemOp = false;
                         TRACE_MEMOP_PHASE_VERBOSE(MemCopy, loop, instr, _u("Found illegal use of LdElemI value(s%d)"), GetVarSymID(memcopyCandidate->transferSym));
                         return false;
                     }
@@ -4868,7 +4876,7 @@ GlobOpt::OptInstr(IR::Instr *&instr, bool* isInstrRemoved)
         this->currentBlock->loop && !IsLoopPrePass() &&
         !func->IsJitInDebugMode() &&
         (func->HasProfileInfo() && !func->GetProfileInfo()->IsMemOpDisabled()) &&
-        (!this->currentBlock->loop->memOpInfo || this->currentBlock->loop->memOpInfo->doMemOp))
+        this->currentBlock->loop->doMemOp)
     {
         CollectMemOpInfo(instr, src1Val, src2Val);
     }
@@ -7921,7 +7929,6 @@ GlobOpt::IsPrepassSrcValueInfoPrecise(IR::Opnd *const src, Value *const srcValue
             !Js::TaggedInt::IsOverflow(intConstantValue) &&
             GetTaggedIntConstantStackSym(intConstantValue) == srcSym
         ) ||
-        this->IsDefinedInCurrentLoopIteration(this->currentBlock->loop, srcValue) ||
         !currentBlock->loop->regAlloc.liveOnBackEdgeSyms->Test(srcSym->m_id);
 }
 
@@ -8015,11 +8022,6 @@ GlobOpt::IsSafeToTransferInPrePass(IR::Opnd *src, Value *srcValue)
     if (this->DoFieldHoisting())
     {
         return false;
-    }
-
-    if (this->IsDefinedInCurrentLoopIteration(this->prePassLoop, srcValue))
-    {
-        return true;
     }
 
     if (src->IsRegOpnd())
@@ -20069,12 +20071,6 @@ ValueInfo::GetIntValMinMax(int *pMin, int *pMax, bool doAggressiveIntTypeSpec)
 }
 
 bool
-GlobOpt::IsDefinedInCurrentLoopIteration(Loop *loop, Value *val) const
-{
-     return false;
-}
-
-bool
 GlobOpt::IsPREInstrCandidateLoad(Js::OpCode opcode)
 {
     switch (opcode)
@@ -21317,7 +21313,7 @@ GlobOpt::ProcessMemOp()
 {
     FOREACH_LOOP_IN_FUNC_EDITING(loop, this->func)
     {
-        if (DoMemOp(loop))
+        if (HasMemOp(loop))
         {
             const int candidateCount = loop->memOpInfo->candidates->Count();
             Assert(candidateCount > 0);
@@ -21328,7 +21324,7 @@ GlobOpt::ProcessMemOp()
             if (!loopCount || !(loopCount->LoopCountMinusOneSym() || loopCount->LoopCountMinusOneConstantValue()))
             {
                 TRACE_MEMOP(loop, nullptr, _u("MemOp skipped for no loop count"));
-                loop->memOpInfo->doMemOp = false;
+                loop->doMemOp = false;
                 loop->memOpInfo->candidates->Clear();
                 continue;
             }
@@ -21357,7 +21353,7 @@ GlobOpt::ProcessMemOp()
                 }
 
                 // One of the memop candidates did not validate. Do not emit for this loop.
-                loop->memOpInfo->doMemOp = false;
+                loop->doMemOp = false;
                 loop->memOpInfo->candidates->Clear();
             }
 

--- a/lib/Backend/GlobOpt.h
+++ b/lib/Backend/GlobOpt.h
@@ -1454,7 +1454,7 @@ private:
     IR::Instr*              FindArraySegmentLoadInstr(IR::Instr* instr);
     void                    RemoveMemOpSrcInstr(IR::Instr* memopInstr, IR::Instr* srcInstr, BasicBlock* block);
     void                    GetMemOpSrcInfo(Loop* loop, IR::Instr* instr, IR::RegOpnd*& base, IR::RegOpnd*& index, IRType& arrayType);
-    bool                    DoMemOp(Loop * loop);
+    bool                    HasMemOp(Loop * loop);
 
 private:
     void                    ChangeValueType(BasicBlock *const block, Value *const value, const ValueType newValueType, const bool preserveSubclassInfo, const bool allowIncompatibleType = false) const;
@@ -1803,7 +1803,6 @@ private:
     IR::Instr *             TrackMarkTempObject(IR::Instr * instrStart, IR::Instr * instrEnd);
     void                    TrackTempObjectSyms(IR::Instr * instr, IR::RegOpnd * opnd);
     IR::Instr *             GenerateBailOutMarkTempObjectIfNeeded(IR::Instr * instr, IR::Opnd * opnd, bool isDst);
-    bool                    IsDefinedInCurrentLoopIteration(Loop *loop, Value *val) const;
 
     void                    KillStateForGeneratorYield();
 

--- a/lib/Backend/GlobOptFields.cpp
+++ b/lib/Backend/GlobOptFields.cpp
@@ -262,17 +262,17 @@ GlobOpt::DoFieldPRE(Loop *loop) const
     return DoFieldOpts(loop);
 }
 
-bool GlobOpt::DoMemOp(Loop *loop)
+bool GlobOpt::HasMemOp(Loop *loop)
 {
 #pragma prefast(suppress: 6285, "logical-or of constants is by design")
     return (
         loop &&
+        loop->doMemOp &&
         (
             !PHASE_OFF(Js::MemSetPhase, this->func) ||
             !PHASE_OFF(Js::MemCopyPhase, this->func)
         ) &&
         loop->memOpInfo &&
-        loop->memOpInfo->doMemOp &&
         loop->memOpInfo->candidates &&
         !loop->memOpInfo->candidates->Empty()
     );


### PR DESCRIPTION
Allocate Memop memory only if needed.
I did some tracing on the benchmarks.
Before this change there were over 1000 occurrences of the memop memory to be allocated, but not used.
After this change there were 85 occurrences.

The main reason is that right now any loop with 2 blocks will have all the memop memory info allocated.
The downside of this change is that it adds a boolean to every loops.
I was thinking doing something funky on the pointer instead (like -1 means do not do memop), but I fear this might be confusing just to save 1 boolean.

This is not really fixing a bug, and there doesn't seems to be a perf impact, but I came across this as I was fixing something else and it bugged me.
I think it's worth changing.
Maybe I should target the master branch instead ?

@LouisLaf @pleath @rajatd What do you guys think ?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/1015)
<!-- Reviewable:end -->