### PR TITLE
Kill 'caller' fields when entering and leaving an inlinee

### DIFF
--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -274,7 +274,8 @@ GlobOpt::Optimize()
     if (!func->DoGlobOpt())
     {
         this->lengthEquivBv = nullptr;
-        argumentsEquivBv = nullptr;
+        this->argumentsEquivBv = nullptr;
+        this->callerEquivBv = nullptr;
 
         // Still need to run the dead store phase to calculate the live reg on back edge
         this->BackwardPass(Js::DeadStorePhase);
@@ -284,7 +285,8 @@ GlobOpt::Optimize()
 
     {
         this->lengthEquivBv = this->func->m_symTable->m_propertyEquivBvMap->Lookup(Js::PropertyIds::length, nullptr); // Used to kill live "length" properties
-        argumentsEquivBv = func->m_symTable->m_propertyEquivBvMap->Lookup(Js::PropertyIds::arguments, nullptr); // Used to kill live "arguments" properties
+        this->argumentsEquivBv = func->m_symTable->m_propertyEquivBvMap->Lookup(Js::PropertyIds::arguments, nullptr); // Used to kill live "arguments" properties
+        this->callerEquivBv = func->m_symTable->m_propertyEquivBvMap->Lookup(Js::PropertyIds::caller, nullptr); // Used to kill live "caller" properties
 
         // The backward phase needs the glob opt's allocator to allocate the propertyTypeValueMap
         // in GlobOpt::EnsurePropertyTypeValue and ranges of instructions where int overflow may be ignored.

--- a/lib/Backend/GlobOpt.h
+++ b/lib/Backend/GlobOpt.h
@@ -1206,6 +1206,7 @@ private:
 
     BVSparse<JitArenaAllocator> *  lengthEquivBv;
     BVSparse<JitArenaAllocator> *  argumentsEquivBv;
+    BVSparse<JitArenaAllocator> *  callerEquivBv;
 
     GlobOptBlockData            blockData;
 

--- a/lib/Backend/GlobOptFields.cpp
+++ b/lib/Backend/GlobOptFields.cpp
@@ -539,9 +539,10 @@ GlobOpt::ProcessFieldKills(IR::Instr *instr, BVSparse<JitArenaAllocator> *bv, bo
     case Js::OpCode::InlineeEnd:
         Assert(!instr->UsesAllFields());
 
-        // Kill all live 'arguments' fields, as 'inlineeFunction.arguments' cannot be copy-propped across different instances of
-        // the same inlined function.
+        // Kill all live 'arguments' and 'caller' fields, as 'inlineeFunction.arguments' and 'inlineeFunction.caller' 
+        // cannot be copy-propped across different instances of the same inlined function.
         KillLiveFields(argumentsEquivBv, bv);
+        KillLiveFields(callerEquivBv, bv);
         break;
 
     case Js::OpCode::CallDirect:

--- a/test/Optimizer/copyprop.baseline
+++ b/test/Optimizer/copyprop.baseline
@@ -1,2 +1,8 @@
 startvalue: 0
 d = -9
+function v9() {
+  return func3();
+}
+function v9() {
+  return func3();
+}

--- a/test/Optimizer/copyprop.js
+++ b/test/Optimizer/copyprop.js
@@ -78,3 +78,18 @@ testcycle2();
 // run JITted code
 testcycle2();
 
+var func3 = function () {
+  return func3.caller;
+}
+
+function v9() {
+  return func3();
+}
+function v14() {
+  func3(1);
+  var v15 = v9();
+  WScript.Echo(v15);
+}
+v14();
+v14();
+


### PR DESCRIPTION
Function.caller should only be copy-propped when it is invoked from the same call chain. As such, it cannot be copy-propped from a parent function into an inlinee or from an inlinee to outside the inlinee.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/1016)
<!-- Reviewable:end -->
