### PR TITLE
Tweaking rejit heuristics

### DIFF
--- a/lib/Backend/BailOut.h
+++ b/lib/Backend/BailOut.h
@@ -237,7 +237,7 @@ protected:
 
     static void ScheduleFunctionCodeGen(Js::ScriptFunction * function, Js::ScriptFunction * innerMostInlinee, BailOutRecord const * bailOutRecord, IR::BailOutKind bailOutKind, void * returnAddress);
     static void ScheduleLoopBodyCodeGen(Js::ScriptFunction * function, Js::ScriptFunction * innerMostInlinee, BailOutRecord const * bailOutRecord, IR::BailOutKind bailOutKind);
-
+    static void CheckPreemptiveRejit(Js::FunctionBody* executeFunction, IR::BailOutKind bailOutKind, BailOutRecord* bailoutRecord, uint8& callsOrIterationsCount, int loopNumber);
     void RestoreValues(IR::BailOutKind bailOutKind, Js::JavascriptCallStackLayout * layout, Js::InterpreterStackFrame * newInstance, Js::ScriptContext * scriptContext,
         bool fromLoopBody, Js::Var * registerSaves, BailOutReturnValue * returnValue, Js::Var* pArgumentsObject, Js::Var branchValue = nullptr, void* returnAddress = nullptr, bool useStartCall = true, void * argoutRestoreAddress = nullptr) const;
     void RestoreValues(IR::BailOutKind bailOutKind, Js::JavascriptCallStackLayout * layout, uint count, __in_ecount_opt(count) int * offsets, int argOutSlotId,

--- a/lib/Backend/Func.cpp
+++ b/lib/Backend/Func.cpp
@@ -1275,6 +1275,16 @@ Func::GetCallsCountAddress() const
     return functionCodeGen->GetFunctionBody()->GetCallsCountAddress(functionCodeGen->GetEntryPoint());
 }
 
+uint *
+Func::GetJittedLoopIterationsSinceLastBailoutAddress() const
+{
+    Assert(this->m_workItem->Type() == JsLoopBodyWorkItemType);
+
+    JsLoopBodyCodeGen * loopBodyCodeGen = static_cast<JsLoopBodyCodeGen *>(this->m_workItem);
+
+    return loopBodyCodeGen->GetFunctionBody()->GetJittedLoopIterationsSinceLastBailoutAddress(loopBodyCodeGen->GetEntryPoint());
+}
+
 RecyclerWeakReference<Js::FunctionBody> *
 Func::GetWeakFuncRef() const
 {

--- a/lib/Backend/Func.h
+++ b/lib/Backend/Func.h
@@ -273,6 +273,7 @@ static const unsigned __int64 c_debugFillPattern8 = 0xcececececececece;
     void SetLocalFrameDisplaySym(StackSym *sym) { m_localFrameDisplaySym = sym; }
 
     uint8 *GetCallsCountAddress() const;
+    uint *GetJittedLoopIterationsSinceLastBailoutAddress() const;
 
     void EnsurePinnedTypeRefs();
     void PinTypeRef(void* typeRef);

--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -2392,12 +2392,18 @@ Lowerer::LowerRange(IR::Instr *instrStart, IR::Instr *instrEnd, bool defaultDoFa
             break;
 
         case Js::OpCode::IncrLoopBodyCount:
+        {
             Assert(this->m_func->IsLoopBody());
             instr->m_opcode = Js::OpCode::Add_I4;
             instr->SetSrc2(IR::IntConstOpnd::New(1, TyUint32, this->m_func));
             this->m_lowererMD.EmitInt4Instr(instr);
-            break;
 
+            // Update the jittedLoopIterations field on the entryPointInfo
+            IR::MemRefOpnd *iterationsAddressOpnd = IR::MemRefOpnd::New(this->m_func->GetJittedLoopIterationsSinceLastBailoutAddress(), TyUint32, this->m_func);
+            m_lowererMD.CreateAssign(iterationsAddressOpnd, instr->GetDst(), instr);
+
+            break;
+        }
 #if !FLOATVAR
         case Js::OpCode::StSlotBoxTemp:
             this->LowerStSlotBoxTemp(instr);

--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -569,7 +569,7 @@ PHASE(All)
 #endif
 #define DEFAULT_CONFIG_BailOnNoProfileLimit    200      // The limit of bailout on no profile info before triggering a rejit
 #define DEFAULT_CONFIG_BailOnNoProfileRejitLimit (-1)   // The limit of bailout on no profile info before disable all the no profile bailouts
-#define DEFAULT_CONFIG_CallsToBailoutsRatioForRejit 20   // Ratio of function calls to bailouts above which a rejit is considered
+#define DEFAULT_CONFIG_CallsToBailoutsRatioForRejit 10   // Ratio of function calls to bailouts above which a rejit is considered
 #define DEFAULT_CONFIG_LoopIterationsToBailoutsRatioForRejit 50 // Ratio of loop iteration count to bailouts above which a rejit of the loop body is considered
 #define DEFAULT_CONFIG_MinBailOutsBeforeRejit 2         // Minimum number of bailouts for a single bailout record after which a rejit is considered
 #define DEFAULT_CONFIG_MinBailOutsBeforeRejitForLoops 2         // Minimum number of bailouts for a single bailout record after which a rejit is considered

--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -569,9 +569,10 @@ PHASE(All)
 #endif
 #define DEFAULT_CONFIG_BailOnNoProfileLimit    200      // The limit of bailout on no profile info before triggering a rejit
 #define DEFAULT_CONFIG_BailOnNoProfileRejitLimit (-1)   // The limit of bailout on no profile info before disable all the no profile bailouts
-#define DEFAULT_CONFIG_CallsToBailoutsRatioForRejit 5   // Ratio of function calls to bailouts on a single bailout record
-                                                        // above which a rejit is considered
+#define DEFAULT_CONFIG_CallsToBailoutsRatioForRejit 20   // Ratio of function calls to bailouts above which a rejit is considered
+#define DEFAULT_CONFIG_LoopIterationsToBailoutsRatioForRejit 50 // Ratio of loop iteration count to bailouts above which a rejit of the loop body is considered
 #define DEFAULT_CONFIG_MinBailOutsBeforeRejit 2         // Minimum number of bailouts for a single bailout record after which a rejit is considered
+#define DEFAULT_CONFIG_MinBailOutsBeforeRejitForLoops 2         // Minimum number of bailouts for a single bailout record after which a rejit is considered
 #define DEFAULT_CONFIG_RejitMaxBailOutCount 500         // Maximum number of bailouts for a single bailout record after which rejit is forced.
 
 
@@ -1130,9 +1131,10 @@ FLAGNR(Boolean, ProfileBailOutRecordMemory, "Profile bailout record memory stati
 #endif
 
 FLAGNR(Number,  RejitMaxBailOutCount, "Maximum number of bailouts for a bailout record after which rejit is forced", DEFAULT_CONFIG_RejitMaxBailOutCount)
-FLAGNR(Number,  CallsToBailoutsRatioForRejit, "Ratio of function calls to bailouts on a single bailout record above which a rejit is considered", DEFAULT_CONFIG_CallsToBailoutsRatioForRejit)
+FLAGNR(Number,  CallsToBailoutsRatioForRejit, "Ratio of function calls to bailouts above which a rejit is considered", DEFAULT_CONFIG_CallsToBailoutsRatioForRejit)
+FLAGNR(Number,  LoopIterationsToBailoutsRatioForRejit, "Ratio of loop iteration count to bailouts above which a rejit of the loop body is considered", DEFAULT_CONFIG_LoopIterationsToBailoutsRatioForRejit)
 FLAGNR(Number,  MinBailOutsBeforeRejit, "Minimum number of bailouts for a single bailout record after which a rejit is considered", DEFAULT_CONFIG_MinBailOutsBeforeRejit)
-
+FLAGNR(Number,  MinBailOutsBeforeRejitForLoops, "Minimum number of bailouts for a single bailout record after which a rejit is considered", DEFAULT_CONFIG_MinBailOutsBeforeRejitForLoops)
 FLAGNR(Boolean, LibraryStackFrame           , "Display library stack frame", DEFAULT_CONFIG_LibraryStackFrame)
 FLAGNR(Boolean, LibraryStackFrameDebugger   , "Assume debugger support for library stack frame", DEFAULT_CONFIG_LibraryStackFrameDebugger)
 #ifdef RECYCLER_STRESS

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -3217,6 +3217,14 @@ namespace Js
         Assert(((LoopEntryPointInfo*) entryPointInfo)->loopHeader == loopHeader);
         Assert(entryPointInfo->address == nullptr);
         entryPointInfo->address = (void*)entryPoint;
+
+        ((Js::LoopEntryPointInfo*)entryPointInfo)->totalJittedLoopIterations = 
+            static_cast<uint8>(
+                min(
+                    static_cast<uint>(static_cast<uint8>(CONFIG_FLAG(MinBailOutsBeforeRejitForLoops))) *
+                    (Js::LoopEntryPointInfo::GetDecrLoopCountPerBailout() - 1),
+                    0xffu));
+
         // reset the counter to 1 less than the threshold for TJLoopBody
         if (loopHeader->GetCurrentEntryPointInfo()->GetIsAsmJSFunction())
         {

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -938,11 +938,6 @@ namespace Js
         FunctionEntryPointInfo* mOldFunctionEntryPointInfo; // strong ref to oldEntryPointInfo(Int or TJ) in asm to ensure we don't collect it before JIT is completed
         bool       mIsTemplatizedJitMode; // true only if in TJ mode, used only for debugging
     public:
-        static const uint8 GetDecrCallCountPerBailout()
-        {
-            return (100 / (uint8)CONFIG_FLAG(CallsToBailoutsRatioForRejit)) + 1;
-        }
-
         FunctionEntryPointInfo(FunctionProxy * functionInfo, void * address, ThreadContext* context, void* validationCookie);
 
 #ifndef TEMP_DISABLE_ASMJS
@@ -964,6 +959,10 @@ namespace Js
         virtual void Expire() override;
         virtual void EnterExpirableCollectMode() override;
         virtual void ResetOnNativeCodeInstallFailure() override;
+        static const uint8 GetDecrCallCountPerBailout()
+        {
+            return (uint8)CONFIG_FLAG(CallsToBailoutsRatioForRejit) + 1;
+        }
 #endif
 
         virtual void OnCleanup(bool isShutdown) override;
@@ -980,8 +979,10 @@ namespace Js
     {
     public:
         LoopHeader* loopHeader;
+        uint jittedLoopIterationsSinceLastBailout; // number of times the loop iterated in the jitted code before bailing out 
+        uint totalJittedLoopIterations; // total number of times the loop has iterated in the jitted code for this entry point for a particular invocation of the loop
         LoopEntryPointInfo(LoopHeader* loopHeader, Js::JavascriptLibrary* library, void* validationCookie) :
-            loopHeader(loopHeader), mIsTemplatizedJitMode(false),EntryPointInfo(nullptr, library, validationCookie, /*threadContext*/ nullptr, /*isLoopBody*/ true)
+            loopHeader(loopHeader), jittedLoopIterationsSinceLastBailout(0), totalJittedLoopIterations(0), mIsTemplatizedJitMode(false),EntryPointInfo(nullptr, library, validationCookie, /*threadContext*/ nullptr, /*isLoopBody*/ true)
 
 #ifdef BGJIT_STATS
             ,used(false)
@@ -994,6 +995,10 @@ namespace Js
 
 #if ENABLE_NATIVE_CODEGEN
         virtual void ResetOnNativeCodeInstallFailure() override;
+        static const uint8 GetDecrLoopCountPerBailout()
+        {
+            return (uint8)CONFIG_FLAG(LoopIterationsToBailoutsRatioForRejit) + 1;
+        }
 #endif
 
 #ifndef TEMP_DISABLE_ASMJS
@@ -1060,7 +1065,7 @@ namespace Js
         static const uint GetOffsetOfProfiledLoopCounter() { return offsetof(LoopHeader, profiledLoopCounter); }
         static const uint GetOffsetOfInterpretCount() { return offsetof(LoopHeader, interpretCount); }
 
-                bool Contains(Js::LoopHeader * loopHeader) const
+        bool Contains(Js::LoopHeader * loopHeader) const
         {
             return (this->startOffset <= loopHeader->startOffset && loopHeader->endOffset <= this->endOffset);
         }
@@ -2198,6 +2203,12 @@ namespace Js
         {
             FunctionEntryPointInfo* entryPoint = (FunctionEntryPointInfo*) info;
             return &entryPoint->callsCount;
+        }
+
+        uint *GetJittedLoopIterationsSinceLastBailoutAddress(EntryPointInfo* info) const
+        {
+            LoopEntryPointInfo* entryPoint = (LoopEntryPointInfo*)info;
+            return &entryPoint->jittedLoopIterationsSinceLastBailout;
         }
 
         FunctionEntryPointInfo* GetDefaultFunctionEntryPointInfo() const;

--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -5879,6 +5879,18 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
                 {
                     this->CheckIfLoopIsHot(loopHeader->profiledLoopCounter);
                 }
+
+                if (newOffset >= loopHeader->endOffset)
+                {
+                    // Reset the totalJittedLoopIterations for the next invocation of this loop entry point
+                    entryPointInfo->totalJittedLoopIterations =
+                        static_cast<uint8>(
+                            min(
+                                static_cast<uint>(static_cast<uint8>(CONFIG_FLAG(MinBailOutsBeforeRejit))) *
+                                (Js::LoopEntryPointInfo::GetDecrLoopCountPerBailout() - 1),
+                                entryPointInfo->totalJittedLoopIterations));
+                    entryPointInfo->jittedLoopIterationsSinceLastBailout = 0;
+                }
                 m_reader.SetCurrentOffset(newOffset);
             }
 

--- a/test/Operators/modopt.baseline
+++ b/test/Operators/modopt.baseline
@@ -1,10 +1,10 @@
 0
-Bailout from function: function: modByNeg, bailOutKindName: (BailOnModByPowerOf2), bailOutCount: 1, callCount: 20, reJitReason: None, reThunk: false
+Bailout from function: function: modByNeg, bailOutKindName: (BailOnModByPowerOf2), bailOutCount: 1, callCount: 10, reJitReason: None, reThunk: false
 2
 32
-Bailout from function: function: modByNonPowerOf2, bailOutKindName: (BailOnModByPowerOf2), bailOutCount: 1, callCount: 20, reJitReason: None, reThunk: false
+Bailout from function: function: modByNonPowerOf2, bailOutKindName: (BailOnModByPowerOf2), bailOutCount: 1, callCount: 10, reJitReason: None, reThunk: false
 9
 4
-Bailout from function: function: modOfNeg, bailOutKindName: (BailOnModByPowerOf2), bailOutCount: 1, callCount: 20, reJitReason: None, reThunk: false
+Bailout from function: function: modOfNeg, bailOutKindName: (BailOnModByPowerOf2), bailOutCount: 1, callCount: 10, reJitReason: None, reThunk: false
 -12
 Bailout from function: function: modByNeg, bailOutKindName: (BailOnModByPowerOf2), bailOutCount: 2, callCount: 0, reJitReason: ModByPowerOf2, reThunk: false


### PR DESCRIPTION
Our current threshold of call-count-to-bailout-count ratio beyond which a rejit is triggered, is 20. Also, we don’t have such a ratio for loop bodies, we just rejit after the second bailout for the same bailout record. I had been looking into tuning the ratio for function rejits and also to make loop body rejits heuristics based instead of a hard bailout limit of 2. 

Making rejits less aggressive should generally help with CPU time for websites. However, making them too conservative starts to show regressions on benchmarks due to increased number of bailouts. From my experiments, sweet spot for call-count to bailout-count ration for rejit seems to 10.

_Loop body rejits:_
1. Implemented a counter for loop bodies to keep track of how many iterations we run in the jitted code before bailing out of a jitted loop body. Then, I use the ratio of jitted-iterations-count to bailout-count to trigger a rejit. Settling on a value of 50 as the threshold for this ratio.
2. Ported some preemptive rejit strategies that we use for functions, to the loop body rejitting code.
