### PR TITLE
cross-platform: Enable non-ICU toLocateString

### DIFF
--- a/lib/Common/DataStructures/Comparer.h
+++ b/lib/Common/DataStructures/Comparer.h
@@ -155,9 +155,10 @@ struct StringComparer
         return hash;
     }
 
-    static int Compare(T str1, T str2)
+    inline static int Compare(T str1, T str2)
     {
-        return ::wcscmp(str1, str2);
+        const int result = ::wcscmp(str1, str2);
+        return result > 0 ? 1 : result == 0 ? 0 : -1;
     }
 };
 

--- a/lib/Runtime/Library/JavascriptString.cpp
+++ b/lib/Runtime/Library/JavascriptString.cpp
@@ -1339,6 +1339,9 @@ case_2:
         const char16* pThatStr = pThat->GetString();
         int thatStrCount = pThat->GetLength();
 
+        // xplat-todo: doing a locale-insensitive compare here
+        // but need to move locale-specific string comparison to
+        // platform agnostic interface
 #ifdef ENABLE_GLOBALIZATION
         LCID lcid = GetUserDefaultLCID();
         int result = CompareStringW(lcid, NULL, pThisStr, thisStrCount, pThatStr, thatStrCount );
@@ -1350,12 +1353,10 @@ case_2:
                 VBSERR_InternalError /* TODO-ERROR: _u("Failed compare operation")*/ );
         }
         return JavascriptNumber::ToVar(result-2, scriptContext);
-#else
-        // xplat-todo: doing a locale-insensitive compare here
-        // but need to move locale-specific string comparison to
-        // platform agnostic interface
-        AssertMsg(false, "toLocaleString is not yet implemented on linux");
-        return JavascriptNumber::ToVar(wcscmp(pThisStr, pThatStr), scriptContext);
+#else // !ENABLE_GLOBALIZATION
+        // no ICU / or external support for localization. Use c-lib
+        const int result = wcscmp(pThisStr, pThatStr);
+        return JavascriptNumber::ToVar(result > 0 ? 1 : result == 0 ? 0 : -1, scriptContext);
 #endif
     }
 


### PR DESCRIPTION
`wcscmp` produces positive or negative results based on the inputs. However we expect -1, 0, +1

Also, normalized another usage of `wcscmp` although no consumer found for `Compare`.