### PR TITLE
xplat: 2 test changes

### DIFF
--- a/test/rlexedirs.xml
+++ b/test/rlexedirs.xml
@@ -278,24 +278,24 @@
 <dir>
   <default>
     <files>SIMD.float32x4</files>
-    <tags>exclude_arm,exclude_arm64</tags>
+    <tags>exclude_arm,exclude_arm64,require_backend</tags>
   </default>
 </dir>
 <dir>
   <default>
     <files>SIMD.int32x4</files>
-    <tags>exclude_arm,exclude_arm64</tags>
+    <tags>exclude_arm,exclude_arm64,require_backend</tags>
   </default>
 </dir>
 <dir>
   <default>
     <files>SIMD.int8x16</files>
-    <tags>exclude_arm,exclude_arm64</tags>
+    <tags>exclude_arm,exclude_arm64,require_backend</tags>
   </default>
 </dir>
 <dir>
   <default>
-    <files>SIMD.float32x4.asmjs</files>
+    <files>SIMD.float32x4.asmjs,require_backend</files>
     <tags>exclude_arm,exclude_arm64,require_backend</tags>
   </default>
 </dir>
@@ -368,13 +368,13 @@
 <dir>
   <default>
     <files>SIMD.TypeSpec</files>
-    <tags>exclude_serialized,exclude_arm,exclude_arm64</tags>
+    <tags>exclude_serialized,exclude_arm,exclude_arm64,require_backend</tags>
   </default>
 </dir>
 <dir>
   <default>
     <files>Debugger</files>
-    <tags>exclude_serialized,exclude_jshost,exclude_snap</tags>
+    <tags>exclude_serialized,exclude_jshost,exclude_snap,require_debugger</tags>
   </default>
 </dir>
 </regress-exe>


### PR DESCRIPTION
runtests.py: "hide" passed tests on the terminal

```
While running tests we are more interested in failed tests. Printing
passed results on the screen makes it harder to read failed tests.

Change `runtests.py` slightly so that "Pass" tests are still printed on the
terminal, but immediately overwritten by the next result. Now we can still
read test progress but passed tests no longer flush the screen.
```

xplat: exclude more unsupported tests 

```
Exclude more Simd tests (require_backend), Debugger tests (
require_debugger), and apply exclude_chk/exclude_fre.

Exclude tests that require compile-flags: -serialized, -simdjs (neither
implemented yet on cross-platform).
```
