### PR TITLE
cross platform: fix FWrite output buffer size

### DIFF
--- a/pal/src/cruntime/printfcpp.cpp
+++ b/pal/src/cruntime/printfcpp.cpp
@@ -84,7 +84,7 @@ static int Internal_Convertfwrite(CPalThread *pthrCurrent, const void *buffer, s
             InternalFree(newBuff);
             return -1;
         }
-        ret = InternalFwrite(newBuff, 1, count, stream, &iError);
+        ret = InternalFwrite(newBuff, 1, nsize, stream, &iError);
         if (iError != 0)
         {
             ERROR("InternalFwrite did not write the whole buffer. Error is %d\n", iError);


### PR DESCRIPTION
Fixes unicode output to file stream.

```
print("ab\u00A0cd");

before fix : ab c
after fix  : ab cd
```