### PR TITLE
MSFT: 7562980 field of JavascriptLibrary can be reclaimed too early

### DIFF
--- a/lib/Jsrt/Core/JsrtContextCore.cpp
+++ b/lib/Jsrt/Core/JsrtContextCore.cpp
@@ -63,6 +63,7 @@ Js::ScriptContext* JsrtContextCore::EnsureScriptContext()
 
     Js::JavascriptLibrary *library = this->GetScriptContext()->GetLibrary();
     Assert(library != nullptr);
+    localThreadContext->GetRecycler()->RootRelease(library->GetGlobalObject());
 
     library->GetEvalFunctionObject()->SetEntryPoint(&Js::GlobalObject::EntryEval);
     library->GetFunctionConstructor()->SetEntryPoint(&Js::JavascriptFunction::NewInstance);

--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -1215,10 +1215,7 @@ if (!sourceList)
     void ScriptContext::InitializeGlobalObject()
     {
         GlobalObject * localGlobalObject = GlobalObject::New(this);
-        if (!GetThreadContext()->IsJSRT())
-        {
-            GetRecycler()->RootAddRef(localGlobalObject);
-        }
+        GetRecycler()->RootAddRef(localGlobalObject);
 
         // Assigned the global Object after we have successfully AddRef (in case of OOM)
         globalObject = localGlobalObject;


### PR DESCRIPTION
At this time, the life time of JavascriptLibrary/ScriptContext etc. is controlled
by JsrtContext only. However, there are multiple allocation points during JsrtContext
initialization path. JavascriptLibrary could be reclaimed half way during initialization as
nothing pins it. Change the globalObject pin/unpin sequence. We'll still pin the GO thus
JavascriptLibrary during initialization, but unpin it right after initialization.
