### PR TITLE
Getter/setter methods defined in object literal should not have 'prototype' property

### DIFF
--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -4962,13 +4962,13 @@ namespace Js
 #if DEBUG
             if (!function->GetFunctionProxy()->GetIsAnonymousFunction())
             {
-                Assert(!function->GetFunctionInfo()->IsLambda() ?
+                Assert(function->GetFunctionInfo()->IsConstructor() ?
                     function->GetDynamicType()->GetTypeHandler() == JavascriptLibrary::GetDeferredPrototypeFunctionTypeHandler(this->GetScriptContext()) :
                     function->GetDynamicType()->GetTypeHandler() == JavascriptLibrary::GetDeferredFunctionTypeHandler());
             }
             else
             {
-                Assert(!function->GetFunctionInfo()->IsLambda() ?
+                Assert(function->GetFunctionInfo()->IsConstructor() ?
                     function->GetDynamicType()->GetTypeHandler() == JavascriptLibrary::GetDeferredAnonymousPrototypeFunctionTypeHandler() :
                     function->GetDynamicType()->GetTypeHandler() == JavascriptLibrary::GetDeferredAnonymousFunctionTypeHandler());
             }

--- a/lib/Runtime/Types/ScriptFunctionType.cpp
+++ b/lib/Runtime/Types/ScriptFunctionType.cpp
@@ -31,7 +31,7 @@ namespace Js
             scriptContext, functionPrototype,
             address,
             proxy->GetDefaultEntryPointInfo(),
-            library->ScriptFunctionTypeHandler(proxy->IsLambda() || proxy->IsAsync() || proxy->IsClassMethod(), proxy->GetIsAnonymousFunction()),
+            library->ScriptFunctionTypeHandler(!proxy->IsConstructor() || proxy->IsAsync() || proxy->IsClassMethod(), proxy->GetIsAnonymousFunction()),
             isShared, isShared);
     }
 };

--- a/test/es6/object_literal_bug.js
+++ b/test/es6/object_literal_bug.js
@@ -37,7 +37,20 @@ var tests = [
             }
         }
     }
-  }
+  },
+  {
+    name: "Getter/setter methods defined in object literal should not have 'prototype' property",
+    body: function () {
+        var o = {
+            get m() {},
+            set m(v) {}
+        };
+        var g = Object.getOwnPropertyDescriptor(o, 'm').get;
+        var s = Object.getOwnPropertyDescriptor(o, 'm').set;
+        assert.areEqual(false, g.hasOwnProperty('prototype'), "Getter method defined in object literal should not have 'prototype' property");
+        assert.areEqual(false, s.hasOwnProperty('prototype'), "Setter method defined in object literal should not have 'prototype' property");
+    }
+  },
 ];
 
 testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });


### PR DESCRIPTION
Fix following bug:
    var o = {get m() {}};
    var f = Object.getOwnPropertyDescriptor(o, 'm').get;
    console.log(f.hasOwnProperty('prototype')); // expected: false, actual: true
