### PR TITLE
cross platform: fix runtest.sh start path and force build flavor

### DIFF
--- a/test/runtests.py
+++ b/test/runtests.py
@@ -70,7 +70,9 @@ arch_alias = 'amd64' if arch == 'x64' else None
 type_flavor = {'chk':'debug', 'test':'test', 'fre':'release'}
 flavor = 'debug' if args.debug else ('test' if args.test else None)
 if flavor == None:
-    flavor = type_flavor[os.environ.get('_BuildType', 'fre')]
+    print("ERROR: Test build target wasn't defined.")
+    print("Try '-t' (test build) or '-d' (debug build).")
+    sys.exit(1)
 flavor_alias = 'chk' if flavor == 'debug' else 'fre'
 
 # binary: full ch path

--- a/test/runtests.sh
+++ b/test/runtests.sh
@@ -3,17 +3,27 @@
 # Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 #-------------------------------------------------------------------------------------------------------
 #
-# todo-CI: REMOVE THIS AFTER ENABLING runtests.py on CI
+# todo-CI: REMOVE THIS AFTER ENABLING runtests.py directly on CI
 
 test_path=`dirname "$0"`
 
-# Only debug jenkins builds support tests currently
-# Todo: Support both debug and test builds
-ch_path="$test_path/../BuildLinux/debug/ch"
-
-if [ ! -f $ch_path ]; then
-    echo 'ch not found- exiting'
-    exit 1
+build_type=$1
+# Accept -d or -t. If none was given (i.e. current CI), 
+# search for the known paths
+if [[ $build_type != "-d" && $build_type != "-t" ]]; then
+    echo "Warning: You haven't provide either '-d' (debug) or '-t' (test)."
+    echo "Warning: Searching for ch.."
+    if [[ -f "$test_path/../BuildLinux/debug/ch" ]]; then
+        echo "Warning: Debug build was found"
+        build_type="-d"
+    elif [[ -f "$test_path/../BuildLinux/test/ch" ]]; then
+        echo "Warning: Test build was found"
+        build_type="-t"
+    else
+        echo 'Error: ch not found- exiting'
+        exit 1
+    fi
 fi
 
-"$test_path/runtests.py" --binary $ch_path Basics/hello.js
+# todo-xpat: Enable others tests 
+"$test_path/runtests.py" $build_type $test_path/Basics/hello.js


### PR DESCRIPTION
Similar to Windows runtests.cmd, runtests.py asks for a build flavor instead of forcing release build.