### PR TITLE
Minor simplification in BindPidRefsInScope

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -1632,23 +1632,8 @@ void Parser::BindPidRefs(BlockInfoStack *blockInfo, uint maxBlockId)
             Assert(pnode);
             switch (pnode->nop)
             {
-            case knopLetDecl:
             case knopVarDecl:
-                pid = pnode->sxVar.pid;
-                if (backgroundPidRef)
-                {
-                    pid = this->m_pscan->m_phtbl->FindExistingPid(pid->Psz(), pid->Cch(), pid->Hash(), nullptr, nullptr
-#if PROFILE_DICTIONARY
-                                                                  , depth
-#endif
-                        );
-                    if (pid == nullptr)
-                    {
-                        break;
-                    }
-                }
-                this->BindPidRefsInScope(pid, sym, blockId, maxBlockId);
-                break;
+            case knopLetDecl:
             case knopConstDecl:
                 pid = pnode->sxVar.pid;
                 if (backgroundPidRef)
@@ -1663,7 +1648,7 @@ void Parser::BindPidRefs(BlockInfoStack *blockInfo, uint maxBlockId)
                         break;
                     }
                 }
-                this->BindConstPidRefsInScope(pid, sym, blockId, maxBlockId);
+                this->BindPidRefsInScope(pid, sym, blockId, maxBlockId);
                 break;
             case knopName:
                 pid = pnode->sxPid.pid;
@@ -1692,17 +1677,6 @@ void Parser::BindPidRefs(BlockInfoStack *blockInfo, uint maxBlockId)
 }
 
 void Parser::BindPidRefsInScope(IdentPtr pid, Symbol *sym, int blockId, uint maxBlockId)
-{
-    this->BindPidRefsInScopeImpl<false>(pid, sym, blockId, maxBlockId);
-}
-
-void Parser::BindConstPidRefsInScope(IdentPtr pid, Symbol *sym, int blockId, uint maxBlockId)
-{
-    this->BindPidRefsInScopeImpl<true>(pid, sym, blockId, maxBlockId);
-}
-
-template<const bool isConstBinding>
-void Parser::BindPidRefsInScopeImpl(IdentPtr pid, Symbol *sym, int blockId, uint maxBlockId)
 {
     PidRefStack *ref, *nextRef, *lastRef = nullptr;
     Assert(sym);

--- a/lib/Parser/Parse.h
+++ b/lib/Parser/Parse.h
@@ -709,9 +709,6 @@ private:
     template<const bool backgroundPidRefs>
     void BindPidRefs(BlockInfoStack *blockInfo, uint maxBlockId = (uint)-1);
     void BindPidRefsInScope(IdentPtr pid, Symbol *sym, int blockId, uint maxBlockId = (uint)-1);
-    void BindConstPidRefsInScope(IdentPtr pid, Symbol *sym, int blockId, uint maxBlockId = (uint)-1);
-    template<const bool constBinding>
-    void BindPidRefsInScopeImpl(IdentPtr pid, Symbol *sym, int blockId, uint maxBlockId = (uint)-1);
     void PushScope(Scope *scope);
     void PopScope(Scope *scope);
 


### PR DESCRIPTION
De-templatize Parser::BindPidRefsInScope now that template parameter is unused. Delete the methods that dispatched to template functions. Merge the knopConstDecl case in Parser::BindPidRefs now that it is identical to knopVarDecl and knopLetDecl.