### PR TITLE
cross platform: add edge date cases support

### DIFF
--- a/lib/Common/PlatformAgnostic/DateTime.h
+++ b/lib/Common/PlatformAgnostic/DateTime.h
@@ -29,8 +29,12 @@ namespace DateTime
     {
         UtilityPlatformData data;
     public:
-        const WCHAR *GetStandardName(size_t *nameLength);
-        const WCHAR *GetDaylightName(size_t *nameLength);
+        const WCHAR *GetStandardName(size_t *nameLength,
+                                     // xplat implementation needs an actual
+                                     // date for the zone abbr.
+                                     const DateTime::YMD *ymd = NULL);
+        const WCHAR *GetDaylightName(size_t *nameLength,
+                                     const DateTime::YMD *ymd = NULL);
     };
 
     // Decomposed date (Year-Month-Date).

--- a/lib/Common/PlatformAgnostic/DateTimeInternal.h
+++ b/lib/Common/PlatformAgnostic/DateTimeInternal.h
@@ -84,16 +84,12 @@ namespace DateTime
 
     typedef void* DaylightTimeHelperPlatformData;
 
-    class UtilityPlatformData
+    #define __CC_PA_TIMEZONE_ABVR_NAME_LENGTH 32
+    struct UtilityPlatformData
     {
-    public:
-        WCHAR standardZoneName[32];
-        size_t standardZoneNameLength;
-        uint32 lastTimeZoneUpdateTickCount;
-
-        void UpdateTimeZoneInfo();
-
-        UtilityPlatformData(): lastTimeZoneUpdateTickCount(0) { }
+        // cache always the last date's zone
+        WCHAR standardName[__CC_PA_TIMEZONE_ABVR_NAME_LENGTH];
+        size_t standardNameLength;
     };
 
     class HiresTimerPlatformData

--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -745,14 +745,14 @@ private:
         DateTime::Utility dateTimeUtility;
 
 public:
-        inline const WCHAR *const GetStandardName(size_t *nameLength)
+        inline const WCHAR *const GetStandardName(size_t *nameLength, DateTime::YMD *ymd = NULL)
         {
-            return dateTimeUtility.GetStandardName(nameLength);
+            return dateTimeUtility.GetStandardName(nameLength, ymd);
         }
 
-        inline const WCHAR *const GetDaylightName(size_t *nameLength)
+        inline const WCHAR *const GetDaylightName(size_t *nameLength, DateTime::YMD *ymd = NULL)
         {
-            return dateTimeUtility.GetDaylightName(nameLength);
+            return dateTimeUtility.GetDaylightName(nameLength, ymd);
         }
 
 private:

--- a/lib/Runtime/Library/DateImplementation.h
+++ b/lib/Runtime/Library/DateImplementation.h
@@ -476,13 +476,13 @@ namespace Js {
             if (ptzd->fDst == false)
             {
                 size_t nameLength;
-                const WCHAR *const standardName = scriptContext->GetStandardName(&nameLength);
+                const WCHAR *const standardName = scriptContext->GetStandardName(&nameLength, pymd);
                 bs->AppendChars(standardName, static_cast<CharCount>(nameLength));
             }
             else
             {
                 size_t nameLength;
-                const WCHAR *const daylightName = scriptContext->GetDaylightName(&nameLength);
+                const WCHAR *const daylightName = scriptContext->GetDaylightName(&nameLength, pymd);
                 bs->AppendChars(daylightName, static_cast<CharCount>(nameLength));
             }
 

--- a/lib/Runtime/PlatformAgnostic/Platform/Windows/DateTime.cpp
+++ b/lib/Runtime/PlatformAgnostic/Platform/Windows/DateTime.cpp
@@ -58,14 +58,14 @@ namespace DateTime
         }
     }
 
-    const WCHAR *Utility::GetStandardName(size_t *nameLength)
+    const WCHAR *Utility::GetStandardName(size_t *nameLength, const DateTime::YMD *_ /*caution! can be NULL. not used for Windows*/)
     {
         data.UpdateTimeZoneInfo();
         *nameLength = wcslen(data.timeZoneInfo.StandardName);
         return data.timeZoneInfo.StandardName;
     }
 
-    const WCHAR *Utility::GetDaylightName(size_t *nameLength)
+    const WCHAR *Utility::GetDaylightName(size_t *nameLength, const DateTime::YMD *_/*caution! can be NULL. not used for Windows*/)
     {
         data.UpdateTimeZoneInfo();
         *nameLength = wcslen(data.timeZoneInfo.DaylightName);

--- a/test/Date/DateParse2.js
+++ b/test/Date/DateParse2.js
@@ -50,6 +50,11 @@ testParseDate("Tue Feb 02 2012 01:02:03 GMT+0430 (prisec@)");
 testParseDate("Tue Feb 2 01:02:03 PST 2013 B.C.");
 testParseDate("Thu Feb 2 01:02:03 PST 2012");
 
+function CUT_NAME(str) {
+    return str.replace("(PST)", "(Pacific Standard Time)")
+              .replace("(PDT)", "(Pacific Daylight Time)");
+}
+
 function testDate(date) {
     testParseDate(date.toString());
 }
@@ -84,7 +89,7 @@ function testParseDateCore(d) {
 
 function myPrint(str) {
     if (WScript.Echo !== undefined) {
-        WScript.Echo(str);
+        WScript.Echo(CUT_NAME(str));
     }
     else {
         throw "no print!";

--- a/test/Date/formatting.js
+++ b/test/Date/formatting.js
@@ -3,15 +3,20 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 
+function CUT_NAME(str) {
+    return str.replace("(PST)", "(Pacific Standard Time)")
+              .replace("(PDT)", "(Pacific Daylight Time)");
+}
+
 for (var i = 0; i < 4 * 60; i++) {
     var d = new Date(2012, 2, 11, 0, i, 0);
-    WScript.Echo(d.toString());
+    WScript.Echo(CUT_NAME(d.toString()));
 }
 for (var i = 0; i < 4 * 60; i++) {
     var d = new Date(2012, 10, 4, 0, i, 0);
-    WScript.Echo(d.toString());
+    WScript.Echo(CUT_NAME(d.toString()));
 }
 
 // BLUE: 538457
 var bug538457 = new Date(1383672529000000);
-WScript.Echo(bug538457.toString());
+WScript.Echo(CUT_NAME(bug538457.toString()));

--- a/test/Date/rlexe.xml
+++ b/test/Date/rlexe.xml
@@ -65,7 +65,7 @@
       <baseline>Conversions.win8.baseline</baseline>
       <compile-flags>-Intl-</compile-flags>
       <!-- test is timezone-sensitive; remove exclude_jenkins after fix -->
-      <tags>exclude_win7,exclude_winBlue,exclude_snap,exclude_jenkins</tags>
+      <tags>exclude_win7,exclude_winBlue,exclude_snap,exclude_jenkins,exclude_xplat</tags>
     </default>
   </test>
   <test>
@@ -74,7 +74,7 @@
       <baseline>Conversions.baseline</baseline>
       <compile-flags>-Intl-</compile-flags>
       <!-- test is timezone-sensitive; remove exclude_jenkins after fix -->
-      <tags>exclude_win7,exclude_win8,exclude_snap,exclude_jenkins</tags>
+      <tags>exclude_win7,exclude_win8,exclude_snap,exclude_jenkins,exclude_xplat</tags>
     </default>
   </test>
   <test>

--- a/test/runtests.py
+++ b/test/runtests.py
@@ -91,6 +91,7 @@ if not os.path.isfile(binary):
 # global tags/not_tags
 tags = set(args.tag or [])
 not_tags = set(args.not_tag or []).union(['fail', 'exclude_' + arch])
+
 if arch_alias:
     not_tags.add('exclude_' + arch_alias)
 if flavor_alias:
@@ -104,6 +105,7 @@ not_tags.add('exclude_nightly' if args.nightly else 'nightly')
 
 # xplat: temp hard coded to exclude unsupported tests
 if sys.platform != 'win32':
+    not_tags.add('exclude_xplat')
     not_tags.add('exclude_serialized')
     not_tags.add('require_backend')
     not_tags.add('require_debugger')


### PR DESCRIPTION
This PR improves xplat date implementation with edge cases support.
Now test cases for Date passes on Ubuntu / Debian

 - tested against VSOFull and its test cases
 - no perf difference on Windows measured

Update:

Some details on what's been done with this update.

  - Linux implementation no longer converts from Windows SYSTEMTIME.
    ChakraCore's internal YMD structure was a good fit between tm and
    SYSTEMTIME. Besides, new implementation spends less time there.

  - Now xplat handles out of range year cases ( <1900 or > 2100) and
    Feb28/29 + 1 (see test file under Date)

  - ChakraCore's common date utilities consider the start year is epoch.
    Besides, system time and clock is based on epoch too. However, the C
    api that calculates the time zone offset, and DST in case of leap year
    depends on broken-out time starting from 1900.
    We handle the leap year differences.

  - On xplat we need exact date to grab right tm_zone information instead
    of caching approach on Windows. Windows API can bring back both DTS and
    STD abbrv with a single call.