### PR TITLE
xplat: switch to Utf8 Jsrt, implement -serialize

### DIFF
--- a/bin/ch/ChakraRtInterface.cpp
+++ b/bin/ch/ChakraRtInterface.cpp
@@ -129,6 +129,12 @@ HINSTANCE ChakraRTInterface::LoadChakraDll(ArgInfo* argInfo)
     m_jsApiHooks.pfJsrtDiagGetProperties = (JsAPIHooks::JsrtDiagGetProperties)GetChakraCoreSymbol(library, "JsDiagGetProperties");
     m_jsApiHooks.pfJsrtDiagGetObjectFromHandle = (JsAPIHooks::JsrtDiagGetObjectFromHandle)GetChakraCoreSymbol(library, "JsDiagGetObjectFromHandle");
     m_jsApiHooks.pfJsrtDiagEvaluate = (JsAPIHooks::JsrtDiagEvaluate)GetChakraCoreSymbol(library, "JsDiagEvaluate");
+
+    m_jsApiHooks.pfJsrtRunScriptUtf8 = (JsAPIHooks::JsrtRunScriptUtf8)GetChakraCoreSymbol(library, "JsRunScriptUtf8");
+    m_jsApiHooks.pfJsrtSerializeScriptUtf8 = (JsAPIHooks::JsrtSerializeScriptUtf8)GetChakraCoreSymbol(library, "JsSerializeScriptUtf8");
+    m_jsApiHooks.pfJsrtRunSerializedScriptUtf8 = (JsAPIHooks::JsrtRunSerializedScriptUtf8)GetChakraCoreSymbol(library, "JsRunSerializedScriptUtf8");
+    m_jsApiHooks.pfJsrtRunModuleUtf8 = (JsAPIHooks::JsrtRunModuleUtf8Ptr)GetChakraCoreSymbol(library, "JsExperimentalApiRunModuleUtf8");
+
     return library;
 }
 
@@ -180,7 +186,7 @@ HRESULT ChakraRTInterface::ParseConfigFlags()
         }
         else
         {
-            hr = Helpers::WideStringToNarrowDynamic(fileNameWide, &m_argInfo->filename);
+            hr = WideStringToNarrowDynamic(fileNameWide, &m_argInfo->filename);
             if (FAILED(hr))
             {
                 Assert(hr == E_OUTOFMEMORY);

--- a/bin/ch/ChakraRtInterface.h
+++ b/bin/ch/ChakraRtInterface.h
@@ -67,6 +67,12 @@ struct JsAPIHooks
     typedef JsErrorCode(WINAPI *JsrtDiagGetProperties)(unsigned int objectHandle, unsigned int fromCount, unsigned int totalCount, JsValueRef * propertiesObject);
     typedef JsErrorCode(WINAPI *JsrtDiagGetObjectFromHandle)(unsigned int handle, JsValueRef * handleObject);
     typedef JsErrorCode(WINAPI *JsrtDiagEvaluate)(const wchar_t * expression, unsigned int stackFrameIndex, JsValueRef * evalResult);
+
+    typedef JsErrorCode(WINAPI *JsrtRunScriptUtf8)(const char *script, JsSourceContext sourceContext, const char *sourceUrl, JsValueRef *result);
+    typedef JsErrorCode(WINAPI *JsrtSerializeScriptUtf8)(const char *script, ChakraBytePtr buffer, unsigned int *bufferSize);
+    typedef JsErrorCode(WINAPI *JsrtRunSerializedScriptUtf8)(JsSerializedScriptLoadUtf8SourceCallback scriptLoadCallback, JsSerializedScriptUnloadCallback scriptUnloadCallback, ChakraBytePtr buffer, JsSourceContext sourceContext, const char *sourceUrl, JsValueRef * result);
+    typedef JsErrorCode(WINAPI *JsrtRunModuleUtf8Ptr)(const char *script, JsSourceContext sourceContext, const char *sourceUrl, JsValueRef *result);
+
     JsrtCreateRuntimePtr pfJsrtCreateRuntime;
     JsrtCreateContextPtr pfJsrtCreateContext;
     JsrtSetCurrentContextPtr pfJsrtSetCurrentContext;
@@ -129,6 +135,11 @@ struct JsAPIHooks
     JsrtDiagGetProperties pfJsrtDiagGetProperties;
     JsrtDiagGetObjectFromHandle pfJsrtDiagGetObjectFromHandle;
     JsrtDiagEvaluate pfJsrtDiagEvaluate;
+
+    JsrtRunScriptUtf8 pfJsrtRunScriptUtf8;
+    JsrtSerializeScriptUtf8 pfJsrtSerializeScriptUtf8;
+    JsrtRunSerializedScriptUtf8 pfJsrtRunSerializedScriptUtf8;
+    JsrtRunModuleUtf8Ptr pfJsrtRunModuleUtf8;
 };
 
 class ChakraRTInterface
@@ -272,6 +283,11 @@ public:
         IfJsrtErrorFailLogAndRetErrorCode(ChakraRTInterface::JsStringToPointer(strValue, stringValue, length));
         return JsNoError;
     }
+
+    static JsErrorCode WINAPI JsRunScriptUtf8(const char *script, JsSourceContext sourceContext, const char *sourceUrl, JsValueRef *result) { return m_jsApiHooks.pfJsrtRunScriptUtf8(script, sourceContext, sourceUrl, result); }
+    static JsErrorCode WINAPI JsSerializeScriptUtf8(const char *script, ChakraBytePtr buffer, unsigned int *bufferSize) { return m_jsApiHooks.pfJsrtSerializeScriptUtf8(script, buffer, bufferSize); }
+    static JsErrorCode WINAPI JsRunSerializedScriptUtf8(JsSerializedScriptLoadUtf8SourceCallback scriptLoadCallback, JsSerializedScriptUnloadCallback scriptUnloadCallback, ChakraBytePtr buffer, JsSourceContext sourceContext, const char *sourceUrl, JsValueRef * result) { return m_jsApiHooks.pfJsrtRunSerializedScriptUtf8(scriptLoadCallback, scriptUnloadCallback, buffer, sourceContext, sourceUrl, result); }
+    static JsErrorCode WINAPI JsRunModuleUtf8(const char *script, JsSourceContext sourceContext, const char *sourceUrl, JsValueRef *result) { return m_jsApiHooks.pfJsrtRunModuleUtf8(script, sourceContext, sourceUrl, result); }
 };
 
 class AutoRestoreContext

--- a/bin/ch/Helpers.cpp
+++ b/bin/ch/Helpers.cpp
@@ -3,79 +3,11 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "stdafx.h"
-#include "Codex/Utf8Codex.h"
 
-///
-/// Use the codex library to encode a UTF16 string to UTF8.
-/// The caller is responsible for freeing the memory, which is allocated
-/// using malloc.
-/// The returned string is null terminated.
-///
-HRESULT Helpers::WideStringToNarrowDynamic(LPCWSTR sourceString, LPSTR* destStringPtr)
-{
-    size_t cchSourceString = wcslen(sourceString);
-    
-    if (cchSourceString >= MAXUINT32)
-    {
-        return E_OUTOFMEMORY;
-    }
-
-    size_t cbDestString = (cchSourceString + 1) * 3;
-
-    // Check for overflow- cbDestString should be >= cchSourceString
-    if (cbDestString < cchSourceString)
-    {
-        return E_OUTOFMEMORY;
-    }
-
-    utf8char_t* destString = (utf8char_t*)malloc(cbDestString);
-    if (destString == nullptr)
-    {
-        return E_OUTOFMEMORY;
-    }
-
-    size_t cbDecoded = utf8::EncodeIntoAndNullTerminate(destString, sourceString, (charcount_t) cchSourceString);
-    Assert(cbDecoded <= cbDestString);
-    static_assert(sizeof(utf8char_t) == sizeof(char), "Needs to be valid for cast");
-    *destStringPtr = (char*)destString;
-    return S_OK;
-}
-
-///
-/// Use the codex library to encode a UTF8 string to UTF16.
-/// The caller is responsible for freeing the memory, which is allocated
-/// using malloc.
-/// The returned string is null terminated.
-///
-HRESULT Helpers::NarrowStringToWideDynamic(LPCSTR sourceString, LPWSTR* destStringPtr)
-{
-    size_t cbSourceString = strlen(sourceString);
-    charcount_t cchDestString = utf8::ByteIndexIntoCharacterIndex((LPCUTF8) sourceString, cbSourceString);
-    size_t cbDestString = (cchDestString + 1) * sizeof(WCHAR);
-    
-    // Check for overflow- cbDestString should be >= cchSourceString
-    if (cbDestString < cchDestString)
-    {
-        return E_OUTOFMEMORY;
-    }
-
-    WCHAR* destString = (WCHAR*)malloc(cbDestString);
-    if (destString == nullptr)
-    {
-        return E_OUTOFMEMORY;
-    }
-
-    utf8::DecodeIntoAndNullTerminate(destString, (LPCUTF8) sourceString, cchDestString);
-    static_assert(sizeof(utf8char_t) == sizeof(char), "Needs to be valid for cast");
-    *destStringPtr = destString;
-    return S_OK;
-}
-
-HRESULT Helpers::LoadScriptFromFile(LPCSTR filename, LPCWSTR& contents, bool* isUtf8Out, LPCWSTR* contentsRawOut, UINT* lengthBytesOut, bool printFileOpenError)
+HRESULT Helpers::LoadScriptFromFile(LPCSTR filename, LPCSTR& contents, bool* isUtf8Out /*= nullptr*/, UINT* lengthBytesOut /*= nullptr*/)
 {
     HRESULT hr = S_OK;
-    LPCWSTR contentsRaw = nullptr;
-    byte * pRawBytes = nullptr;
+    BYTE * pRawBytes = nullptr;
     UINT lengthBytes = 0;
     bool isUtf8 = false;
     contents = nullptr;
@@ -87,34 +19,27 @@ HRESULT Helpers::LoadScriptFromFile(LPCSTR filename, LPCWSTR& contents, bool* is
     //
     if (fopen_s(&file, filename, "rb") != 0)
     {
-        if (printFileOpenError)
-        {
 #ifdef _WIN32
-            DWORD lastError = GetLastError();
-            char16 wszBuff[512];
-            fprintf(stderr, "Error in opening file '%s' ", filename);
-            wszBuff[0] = 0;
-            if (FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM,
-                nullptr,
-                lastError,
-                0,
-                wszBuff,
-                _countof(wszBuff),
-                nullptr))
-            {
-                fwprintf(stderr, _u(": %s"), wszBuff);
-            }
-            fwprintf(stderr, _u("\n"));
-#elif defined(_POSIX_VERSION)
-            fprintf(stderr, "Error in opening file: ");
-            perror(filename);
-#endif            
-            IfFailGo(E_FAIL);
-        }
-        else
+        DWORD lastError = GetLastError();
+        char16 wszBuff[512];
+        fprintf(stderr, "Error in opening file '%s' ", filename);
+        wszBuff[0] = 0;
+        if (FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM,
+            nullptr,
+            lastError,
+            0,
+            wszBuff,
+            _countof(wszBuff),
+            nullptr))
         {
-            return E_FAIL;
+            fwprintf(stderr, _u(": %s"), wszBuff);
         }
+        fwprintf(stderr, _u("\n"));
+#elif defined(_POSIX_VERSION)
+        fprintf(stderr, "Error in opening file: ");
+        perror(filename);
+#endif
+        IfFailGo(E_FAIL);
     }
 
     //
@@ -123,8 +48,8 @@ HRESULT Helpers::LoadScriptFromFile(LPCSTR filename, LPCWSTR& contents, bool* is
     fseek(file, 0, SEEK_END);
     lengthBytes = ftell(file);
     fseek(file, 0, SEEK_SET);
-    contentsRaw = (LPCWSTR)HeapAlloc(GetProcessHeap(), 0, lengthBytes + sizeof(WCHAR));
-    if (nullptr == contentsRaw)
+    pRawBytes = (LPBYTE)malloc(lengthBytes + sizeof(WCHAR));
+    if (nullptr == pRawBytes)
     {
         fwprintf(stderr, _u("out of memory"));
         IfFailGo(E_OUTOFMEMORY);
@@ -133,9 +58,9 @@ HRESULT Helpers::LoadScriptFromFile(LPCSTR filename, LPCWSTR& contents, bool* is
     //
     // Read the entire content as a binary block.
     //
-    fread((void*)contentsRaw, sizeof(char), lengthBytes, file);
+    fread(pRawBytes, sizeof(BYTE), lengthBytes, file);
     fclose(file);
-    *(WCHAR*)((byte*)contentsRaw + lengthBytes) = _u('\0'); // Null terminate it. Could be LPCWSTR.
+    *reinterpret_cast<WCHAR*>(pRawBytes + lengthBytes) = 0; // Null terminate it. Could be UTF16
 
     //
     // Read encoding, handling any conversion to Unicode.
@@ -144,62 +69,57 @@ HRESULT Helpers::LoadScriptFromFile(LPCSTR filename, LPCWSTR& contents, bool* is
     // This is not a complete read of the encoding. Some encodings like UTF7, UTF1, EBCDIC, SCSU, BOCU could be
     // wrongly classified as ANSI
     //
-    pRawBytes = (byte*)contentsRaw;
-    if ((0xEF == *pRawBytes && 0xBB == *(pRawBytes + 1) && 0xBF == *(pRawBytes + 2)))
     {
-        isUtf8 = true;
+        LPCWSTR contentsRaw = reinterpret_cast<LPCWSTR>(pRawBytes);
+        if ((0xEF == *pRawBytes && 0xBB == *(pRawBytes + 1) && 0xBF == *(pRawBytes + 2)))
+        {
+            isUtf8 = true;
+        }
+        else if (0xFFFE == *contentsRaw || (0x0000 == *contentsRaw && 0xFEFF == *(contentsRaw + 1)))
+        {
+            // unicode unsupported
+            fwprintf(stderr, _u("unsupported file encoding"));
+            IfFailGo(E_UNEXPECTED);
+        }
+        else if (0xFEFF == *contentsRaw)
+        {
+            // unicode LE
+            isUtf8 = false;
+        }
+        else
+        {
+            // Assume UTF8
+            isUtf8 = true;
+        }
     }
-    else if (0xFFFE == *contentsRaw || (0x0000 == *contentsRaw && 0xFEFF == *(contentsRaw + 1)))
-    {
-        // unicode unsupported
-        fwprintf(stderr, _u("unsupported file encoding"));
-        IfFailGo(E_UNEXPECTED);
-    }
-    else if (0xFEFF == *contentsRaw)
-    {
-        // unicode LE
-        contents = contentsRaw;
-    }
-    else
-    {
-        // Assume UTF8
-        isUtf8 = true;
-    }
-
 
     if (isUtf8)
     {
-        utf8::DecodeOptions decodeOptions = utf8::doAllowInvalidWCHARs;
-
-        UINT cUtf16Chars = utf8::ByteIndexIntoCharacterIndex(pRawBytes, lengthBytes, decodeOptions);
-        contents = (LPCWSTR)HeapAlloc(GetProcessHeap(), 0, (cUtf16Chars + 1) * sizeof(WCHAR));
-        if (nullptr == contents)
-        {
-            fwprintf(stderr, _u("out of memory"));
-            IfFailGo(E_OUTOFMEMORY);
-        }
-
-        utf8::DecodeIntoAndNullTerminate((char16*) contents, pRawBytes, cUtf16Chars, decodeOptions);
+        contents = reinterpret_cast<LPCSTR>(pRawBytes);
+    }
+    else
+    {
+        LPSTR pNarrow = nullptr;
+        IfFailGo(WideStringToNarrowDynamic(reinterpret_cast<LPCWSTR>(pRawBytes), &pNarrow));
+        contents = pNarrow;
     }
 
 Error:
-    if (SUCCEEDED(hr) && isUtf8Out)
+    if (SUCCEEDED(hr))
     {
-        Assert(contentsRawOut);
-        Assert(lengthBytesOut);
-        *isUtf8Out = isUtf8;
-        *contentsRawOut = contentsRaw;
-        *lengthBytesOut = lengthBytes;
-    }
-    else if (contentsRaw && (contentsRaw != contents)) // Otherwise contentsRaw is lost. Free it if it is different to contents.
-    {
-        HeapFree(GetProcessHeap(), 0, (void*)contentsRaw);
+        if (isUtf8Out)
+        {
+            *isUtf8Out = isUtf8;
+        }
+        if (lengthBytesOut)
+        {
+            *lengthBytesOut = lengthBytes;
+        }
     }
 
-    if (contents && FAILED(hr))
+    if (pRawBytes && reinterpret_cast<LPCSTR>(pRawBytes) != contents)
     {
-        HeapFree(GetProcessHeap(), 0, (void*)contents);
-        contents = nullptr;
+        free(pRawBytes);
     }
 
     return hr;

--- a/bin/ch/Helpers.h
+++ b/bin/ch/Helpers.h
@@ -7,10 +7,7 @@
 class Helpers
 {
 public :
-    static HRESULT LoadScriptFromFile(LPCSTR filename, LPCWSTR& contents, bool* isUtf8Out = nullptr, LPCWSTR* contentsRawOut = nullptr, UINT* lengthBytesOut = nullptr, bool printFileOpenError = true);
-
-    static HRESULT WideStringToNarrowDynamic(LPCWSTR sourceString, LPSTR* destStringPtr);
-    static HRESULT NarrowStringToWideDynamic(LPCSTR sourceString, LPWSTR* destStringPtr);
+    static HRESULT LoadScriptFromFile(LPCSTR filename, LPCSTR& contents, bool* isUtf8Out = nullptr, UINT* lengthBytesOut = nullptr);
     static LPCWSTR JsErrorCodeToString(JsErrorCode jsErrorCode);
     static void LogError(__in __nullterminated const char16 *msg, ...);
 };

--- a/bin/ch/WScriptJsrt.h
+++ b/bin/ch/WScriptJsrt.h
@@ -58,7 +58,7 @@ public:
     }
 
     static bool PrintException(LPCSTR fileName, JsErrorCode jsErrorCode);
-    static JsValueRef LoadScript(JsValueRef callee, LPCSTR fileName, LPCWSTR fileContent, LPCWSTR scriptInjectType, bool isSourceModule);
+    static JsValueRef LoadScript(JsValueRef callee, LPCSTR fileName, LPCSTR fileContent, LPCWSTR scriptInjectType, bool isSourceModule);
     static DWORD_PTR GetNextSourceContext();
     static JsValueRef LoadScriptFileHelper(JsValueRef callee, JsValueRef *arguments, unsigned short argumentCount, bool isSourceModule);
     static JsValueRef LoadScriptHelper(JsValueRef callee, bool isConstructCall, JsValueRef *arguments, unsigned short argumentCount, void *callbackState, bool isSourceModule);

--- a/bin/ch/ch.cpp
+++ b/bin/ch/ch.cpp
@@ -63,7 +63,7 @@ void __stdcall PrintUsage()
 
 // On success the param byteCodeBuffer will be allocated in the function.
 // The caller of this function should de-allocate the memory.
-HRESULT GetSerializedBuffer(LPCOLESTR fileContents, __out BYTE **byteCodeBuffer, __out DWORD *byteCodeBufferSize)
+HRESULT GetSerializedBuffer(LPCSTR fileContents, __out BYTE **byteCodeBuffer, __out DWORD *byteCodeBufferSize)
 {
     HRESULT hr = S_OK;
     *byteCodeBuffer = nullptr;
@@ -72,7 +72,7 @@ HRESULT GetSerializedBuffer(LPCOLESTR fileContents, __out BYTE **byteCodeBuffer,
 
     unsigned int bcBufferSize = 0;
     unsigned int newBcBufferSize = 0;
-    IfJsErrorFailLog(ChakraRTInterface::JsSerializeScript(fileContents, bcBuffer, &bcBufferSize));
+    IfJsErrorFailLog(ChakraRTInterface::JsSerializeScriptUtf8(fileContents, bcBuffer, &bcBufferSize));
     // Above call will return the size of the buffer only, once succeed we need to allocate memory of that much and call it again.
     if (bcBufferSize == 0)
     {
@@ -81,7 +81,7 @@ HRESULT GetSerializedBuffer(LPCOLESTR fileContents, __out BYTE **byteCodeBuffer,
     }
     bcBuffer = new BYTE[bcBufferSize];
     newBcBufferSize = bcBufferSize;
-    IfJsErrorFailLog(ChakraRTInterface::JsSerializeScript(fileContents, bcBuffer, &newBcBufferSize));
+    IfJsErrorFailLog(ChakraRTInterface::JsSerializeScriptUtf8(fileContents, bcBuffer, &newBcBufferSize));
     Assert(bcBufferSize == newBcBufferSize);
 
 Error:
@@ -102,12 +102,12 @@ Error:
     return hr;
 }
 
-HRESULT CreateLibraryByteCodeHeader(LPCOLESTR fileContents, BYTE * contentsRaw, DWORD lengthBytes, LPCWSTR bcFullPath, LPCSTR libraryNameNarrow)
+HRESULT CreateLibraryByteCodeHeader(LPCSTR contentsRaw, DWORD lengthBytes, LPCWSTR bcFullPath, LPCSTR libraryNameNarrow)
 {
     HANDLE bcFileHandle = nullptr;
     BYTE *bcBuffer = nullptr;
     DWORD bcBufferSize = 0;
-    HRESULT hr = GetSerializedBuffer(fileContents, &bcBuffer, &bcBufferSize);
+    HRESULT hr = GetSerializedBuffer(contentsRaw, &bcBuffer, &bcBufferSize);
 
     if (FAILED(hr)) return hr;
 
@@ -199,30 +199,45 @@ static void CALLBACK PromiseContinuationCallback(JsValueRef task, void *callback
     messageQueue->InsertSorted(msg);
 }
 
-HRESULT RunScript(const char* fileName, LPCWSTR fileContents, BYTE *bcBuffer, char *fullPath)
+static bool CHAKRA_CALLBACK DummyJsSerializedScriptLoadUtf8Source(_In_ JsSourceContext sourceContext, _Outptr_result_z_ const char** scriptBuffer)
+{
+    // sourceContext is source ptr, see RunScript below
+    *scriptBuffer = reinterpret_cast<const char*>(sourceContext);
+    return true;
+}
+
+static void CHAKRA_CALLBACK DummyJsSerializedScriptUnload(_In_ JsSourceContext sourceContext)
+{
+    // sourceContext is source ptr, see RunScript below
+    // source memory was originally allocated with malloc() in
+    // Helpers::LoadScriptFromFile. No longer needed, free() it.
+    free(reinterpret_cast<void*>(sourceContext));
+}
+
+HRESULT RunScript(const char* fileName, LPCSTR fileContents, BYTE *bcBuffer, char *fullPath)
 {
     HRESULT hr = S_OK;
     MessageQueue * messageQueue = new MessageQueue();
     WScriptJsrt::AddMessageQueue(messageQueue);
-    LPWSTR fullPathWide = nullptr;
 
     IfJsErrorFailLog(ChakraRTInterface::JsSetPromiseContinuationCallback(PromiseContinuationCallback, (void*)messageQueue));
 
     Assert(fileContents != nullptr || bcBuffer != nullptr);
-    // TODO: Remove this code in a future iteration once Utf8 versions of the Jsrt API is implemented
-    IfFailGo(Helpers::NarrowStringToWideDynamic(fullPath, &fullPathWide));
 
     JsErrorCode runScript;
     if (bcBuffer != nullptr)
     {
-        runScript = ChakraRTInterface::JsRunSerializedScript(fileContents, bcBuffer, WScriptJsrt::GetNextSourceContext(), fullPathWide, nullptr /*result*/);
+        runScript = ChakraRTInterface::JsRunSerializedScriptUtf8(
+            DummyJsSerializedScriptLoadUtf8Source, DummyJsSerializedScriptUnload,
+            bcBuffer,
+            reinterpret_cast<JsSourceContext>(fileContents),
+                // Use source ptr as sourceContext
+            fullPath, nullptr /*result*/);
     }
     else
     {
-        runScript = ChakraRTInterface::JsRunScript(fileContents, WScriptJsrt::GetNextSourceContext(), fullPathWide, nullptr /*result*/);
+        runScript = ChakraRTInterface::JsRunScriptUtf8(fileContents, WScriptJsrt::GetNextSourceContext(), fullPath, nullptr /*result*/);
     }
-
-    free(fullPathWide);
 
     if (runScript != JsNoError)
     {
@@ -246,7 +261,7 @@ Error:
     return hr;
 }
 
-HRESULT CreateAndRunSerializedScript(const char* fileName, LPCWSTR fileContents, char *fullPath)
+HRESULT CreateAndRunSerializedScript(const char* fileName, LPCSTR fileContents, char *fullPath)
 {
     HRESULT hr = S_OK;
     JsRuntimeHandle runtime = JS_INVALID_RUNTIME_HANDLE;
@@ -292,10 +307,9 @@ Error:
 HRESULT ExecuteTest(const char* fileName)
 {
     HRESULT hr = S_OK;
-    LPCWSTR fileContents = nullptr;
+    LPCSTR fileContents = nullptr;
     JsRuntimeHandle runtime = JS_INVALID_RUNTIME_HANDLE;
     bool isUtf8 = false;
-    LPCOLESTR contentsRaw = nullptr;
     UINT lengthBytes = 0;
 
     JsContextRef context = JS_INVALID_REFERENCE;
@@ -303,8 +317,7 @@ HRESULT ExecuteTest(const char* fileName)
     char fullPath[_MAX_PATH];
     size_t len = 0;
 
-    hr = Helpers::LoadScriptFromFile(fileName, fileContents, &isUtf8, &contentsRaw, &lengthBytes);
-    contentsRaw; lengthBytes; // Unused for now.
+    hr = Helpers::LoadScriptFromFile(fileName, fileContents, &isUtf8, &lengthBytes);
 
     IfFailGo(hr);
     if (HostConfigFlags::flags.GenerateLibraryByteCodeHeaderIsEnabled)
@@ -354,7 +367,7 @@ HRESULT ExecuteTest(const char* fileName)
                 CHAR ext[_MAX_EXT];
                 _splitpath_s(fullPath, NULL, 0, NULL, 0, libraryName, _countof(libraryName), ext, _countof(ext));
 
-                IfFailGo(CreateLibraryByteCodeHeader(fileContents, (BYTE*)contentsRaw, lengthBytes, HostConfigFlags::flags.GenerateLibraryByteCodeHeader, libraryName));
+                IfFailGo(CreateLibraryByteCodeHeader(fileContents, lengthBytes, HostConfigFlags::flags.GenerateLibraryByteCodeHeader, libraryName));
             }
             else
             {
@@ -471,8 +484,9 @@ int _cdecl wmain(int argc, __in_ecount(argc) LPWSTR argv[])
     ChakraRTInterface::ArgInfo argInfo = { argc, argv, PrintUsage, nullptr };
     HINSTANCE chakraLibrary = ChakraRTInterface::LoadChakraDll(&argInfo);
 
-    if (argInfo.filename == nullptr) {
-        Helpers::WideStringToNarrowDynamic(argv[1], &argInfo.filename);
+    if (argInfo.filename == nullptr)
+    {
+        WideStringToNarrowDynamic(argv[1], &argInfo.filename);
     }
 
     if (chakraLibrary != nullptr)
@@ -515,7 +529,7 @@ int main(int argc, char** argv)
     char16** args = new char16*[argc];
     for (int i = 0; i < argc; i++)
     {
-        Helpers::NarrowStringToWideDynamic(argv[i], &args[i]);
+        NarrowStringToWideDynamic(argv[i], &args[i]);
     }
 
     // Call wmain with a copy of args, as HostConfigFlags may change argv

--- a/bin/ch/stdafx.h
+++ b/bin/ch/stdafx.h
@@ -87,6 +87,9 @@ if (!(exp)) \
 
 typedef void * Var;
 
+#include "Codex/Utf8Helper.h"
+using utf8::NarrowStringToWideDynamic;
+using utf8::WideStringToNarrowDynamic;
 #include "Helpers.h"
 
 #define IfJsErrorFailLog(expr) \

--- a/lib/Common/Codex/Utf8Helper.h
+++ b/lib/Common/Codex/Utf8Helper.h
@@ -1,0 +1,150 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+#pragma once
+#include "Utf8Codex.h"
+
+namespace utf8
+{
+    ///
+    /// Use the codex library to encode a UTF16 string to UTF8.
+    /// The caller is responsible for freeing the memory, which is allocated
+    /// using Allocator.
+    /// The returned string is null terminated.
+    ///
+    template <class Allocator>
+    HRESULT WideStringToNarrow(LPCWSTR sourceString, LPSTR* destStringPtr)
+    {
+        size_t cchSourceString = wcslen(sourceString);
+
+        if (cchSourceString >= MAXUINT32)
+        {
+            return E_OUTOFMEMORY;
+        }
+
+        size_t cbDestString = (cchSourceString + 1) * 3;
+
+        // Check for overflow- cbDestString should be >= cchSourceString
+        if (cbDestString < cchSourceString)
+        {
+            return E_OUTOFMEMORY;
+        }
+
+        utf8char_t* destString = (utf8char_t*)Allocator::allocate(cbDestString);
+        if (destString == nullptr)
+        {
+            return E_OUTOFMEMORY;
+        }
+
+        utf8::EncodeIntoAndNullTerminate(destString, sourceString, (charcount_t) cchSourceString);
+        static_assert(sizeof(utf8char_t) == sizeof(char), "Needs to be valid for cast");
+        *destStringPtr = (char*)destString;
+        return S_OK;
+    }
+
+    ///
+    /// Use the codex library to encode a UTF8 string to UTF16.
+    /// The caller is responsible for freeing the memory, which is allocated
+    /// using Allocator.
+    /// The returned string is null terminated.
+    ///
+    template <class Allocator>
+    HRESULT NarrowStringToWide(LPCSTR sourceString, LPWSTR* destStringPtr)
+    {
+        size_t cbSourceString = strlen(sourceString);
+        charcount_t cchDestString = utf8::ByteIndexIntoCharacterIndex((LPCUTF8) sourceString, cbSourceString);
+        size_t cbDestString = (cchDestString + 1) * sizeof(WCHAR);
+
+        // Check for overflow- cbDestString should be >= cchSourceString
+        if (cbDestString < cchDestString)
+        {
+            return E_OUTOFMEMORY;
+        }
+
+        WCHAR* destString = (WCHAR*)Allocator::allocate(cbDestString);
+        if (destString == nullptr)
+        {
+            return E_OUTOFMEMORY;
+        }
+
+        utf8::DecodeIntoAndNullTerminate(destString, (LPCUTF8) sourceString, cchDestString);
+        static_assert(sizeof(utf8char_t) == sizeof(char), "Needs to be valid for cast");
+        *destStringPtr = destString;
+        return S_OK;
+    }
+
+    class malloc_allocator
+    {
+    public:
+        static void* allocate(size_t size) { return ::malloc(size); }
+        static void free(void* ptr) { ::free(ptr); }
+    };
+
+    inline HRESULT WideStringToNarrowDynamic(LPCWSTR sourceString, LPSTR* destStringPtr)
+    {
+        return WideStringToNarrow<malloc_allocator>(sourceString, destStringPtr);
+    }
+
+    inline HRESULT NarrowStringToWideDynamic(LPCSTR sourceString, LPWSTR* destStringPtr)
+    {
+        return NarrowStringToWide<malloc_allocator>(sourceString, destStringPtr);
+    }
+
+
+    template <class Allocator, class SrcType, class DstType>
+    class NarrowWideStringConverter
+    {
+    public:
+        static HRESULT Convert(SrcType src, DstType* dst);
+    };
+
+    template <class Allocator>
+    class NarrowWideStringConverter<Allocator, LPCSTR, LPWSTR>
+    {
+    public:
+        static HRESULT Convert(LPCSTR sourceString, LPWSTR* destStringPtr)
+        {
+            return NarrowStringToWide<Allocator>(sourceString, destStringPtr);
+        }
+    };
+
+    template <class Allocator>
+    class NarrowWideStringConverter<Allocator, LPCWSTR, LPSTR>
+    {
+    public:
+        static HRESULT Convert(LPCWSTR sourceString, LPSTR* destStringPtr)
+        {
+            return WideStringToNarrow<Allocator>(sourceString, destStringPtr);
+        }
+    };
+
+    template <class Allocator, class SrcType, class DstType>
+    class NarrowWideConverter
+    {
+    private:
+        DstType dst;
+
+    public:
+        NarrowWideConverter(const SrcType& src): dst()
+        {
+            NarrowWideStringConverter<Allocator, SrcType, DstType>::Convert(src, &dst);
+        }
+
+        ~NarrowWideConverter()
+        {
+            if (dst)
+            {
+                Allocator::free(dst);
+            }
+        }
+
+        operator DstType()
+        {
+            return dst;
+        }
+    };
+
+    typedef NarrowWideConverter<malloc_allocator, LPCSTR, LPWSTR> NarrowToWide;
+    typedef NarrowWideConverter<malloc_allocator, LPCWSTR, LPSTR> WideToNarrow;
+}

--- a/lib/Common/Core/SysInfo.cpp
+++ b/lib/Common/Core/SysInfo.cpp
@@ -62,6 +62,8 @@ AutoSystemInfo::Initialize()
     Assert(!initialized);
 #ifndef _WIN32
     PAL_InitializeDLL();
+    majorVersion = CHAKRA_CORE_MAJOR_VERSION;
+    minorVersion = CHAKRA_CORE_MINOR_VERSION;
 #endif
 
     processHandle = GetCurrentProcess();
@@ -87,7 +89,7 @@ AutoSystemInfo::Initialize()
     dllHighAddress = (UINT_PTR)&__ImageBase +
         ((PIMAGE_NT_HEADERS)(((char *)&__ImageBase) + __ImageBase.e_lfanew))->OptionalHeader.SizeOfImage;
 #endif
-    
+
     InitPhysicalProcessorCount();
 #if DBG
     initialized = true;
@@ -102,7 +104,7 @@ AutoSystemInfo::Initialize()
     {
         disableDebugScopeCapture = false;
     }
-    
+
     this->shouldQCMoreFrequently = false;
     this->supportsOnlyMultiThreadedCOM = false;
     this->isLowMemoryDevice = false;

--- a/lib/Jsrt/Jsrt.cpp
+++ b/lib/Jsrt/Jsrt.cpp
@@ -14,6 +14,7 @@
 #include "Library/DataView.h"
 #include "Library/JavascriptSymbol.h"
 #include "Base/ThreadContextTlsEntry.h"
+#include "Codex/Utf8Helper.h"
 
 // Parser Includes
 #include "cmperr.h"     // For ERRnoMemory
@@ -404,7 +405,7 @@ CHAKRA_API JsSetObjectBeforeCollectCallback(_In_ JsRef ref, _In_opt_ void *callb
         {
             ThreadContext* threadContext = static_cast<JsrtContext *>(ref)->GetRuntime()->GetThreadContext();
             Recycler * recycler = threadContext->GetRecycler();
-            recycler->SetObjectBeforeCollectCallback(ref, reinterpret_cast<Recycler::ObjectBeforeCollectCallback>(objectBeforeCollectCallback), callbackState, 
+            recycler->SetObjectBeforeCollectCallback(ref, reinterpret_cast<Recycler::ObjectBeforeCollectCallback>(objectBeforeCollectCallback), callbackState,
                 reinterpret_cast<Recycler::ObjectBeforeCollectCallbackWrapper>(JsrtCallbackState::ObjectBeforeCallectCallbackWrapper), threadContext);
             return JsNoError;
         });
@@ -424,7 +425,7 @@ CHAKRA_API JsSetObjectBeforeCollectCallback(_In_ JsRef ref, _In_opt_ void *callb
                 return JsErrorInvalidArgument;
             }
 
-            recycler->SetObjectBeforeCollectCallback(ref, reinterpret_cast<Recycler::ObjectBeforeCollectCallback>(objectBeforeCollectCallback), callbackState, 
+            recycler->SetObjectBeforeCollectCallback(ref, reinterpret_cast<Recycler::ObjectBeforeCollectCallback>(objectBeforeCollectCallback), callbackState,
                 reinterpret_cast<Recycler::ObjectBeforeCollectCallbackWrapper>(JsrtCallbackState::ObjectBeforeCallectCallbackWrapper), threadContext);
             return JsNoError;
         });
@@ -2382,7 +2383,7 @@ CHAKRA_API JsSetPromiseContinuationCallback(_In_ JsPromiseContinuationCallback p
     /*allowInObjectBeforeCollectCallback*/true);
 }
 
-JsErrorCode RunScriptCore(const wchar_t *script, JsSourceContext sourceContext, const wchar_t *sourceUrl, bool parseOnly, JsParseScriptAttributes parseAttributes, bool isSourceModule, JsValueRef *result)
+JsErrorCode RunScriptCore(const byte *script, size_t cb, LoadScriptFlag loadScriptFlag, JsSourceContext sourceContext, const wchar_t *sourceUrl, bool parseOnly, JsParseScriptAttributes parseAttributes, bool isSourceModule, JsValueRef *result)
 {
     Js::JavascriptFunction *scriptFunction;
     CompileScriptException se;
@@ -2400,20 +2401,20 @@ JsErrorCode RunScriptCore(const wchar_t *script, JsSourceContext sourceContext, 
             sourceContextInfo = scriptContext->CreateSourceContextInfo(sourceContext, sourceUrl, wcslen(sourceUrl), nullptr);
         }
 
+        const int chsize = (loadScriptFlag & LoadScriptFlag_Utf8Source) ? sizeof(utf8char_t) : sizeof(wchar_t);
         SRCINFO si = {
             /* sourceContextInfo   */ sourceContextInfo,
             /* dlnHost             */ 0,
             /* ulColumnHost        */ 0,
             /* lnMinHost           */ 0,
             /* ichMinHost          */ 0,
-            /* ichLimHost          */ static_cast<ULONG>(wcslen(script)), // OK to truncate since this is used to limit sourceText in debugDocument/compilation errors.
+            /* ichLimHost          */ static_cast<ULONG>(cb / chsize), // OK to truncate since this is used to limit sourceText in debugDocument/compilation errors.
             /* ulCharOffset        */ 0,
             /* mod                 */ kmodGlobal,
             /* grfsi               */ 0
         };
 
         Js::Utf8SourceInfo* utf8SourceInfo = nullptr;
-        LoadScriptFlag loadScriptFlag = LoadScriptFlag_None;
         if (result != nullptr)
         {
             loadScriptFlag = (LoadScriptFlag)(loadScriptFlag | LoadScriptFlag_Expression);
@@ -2427,7 +2428,7 @@ JsErrorCode RunScriptCore(const wchar_t *script, JsSourceContext sourceContext, 
         {
             loadScriptFlag = (LoadScriptFlag)(loadScriptFlag | LoadScriptFlag_Module);
         }
-        scriptFunction = scriptContext->LoadScript((const byte*)script, wcslen(script)* sizeof(wchar_t), &si, &se, &utf8SourceInfo, Js::Constants::GlobalCode, loadScriptFlag);
+        scriptFunction = scriptContext->LoadScript(script, cb, &si, &se, &utf8SourceInfo, Js::Constants::GlobalCode, loadScriptFlag);
 
         JsrtContext * context = JsrtContext::GetCurrent();
         context->OnScriptLoad(scriptFunction, utf8SourceInfo, &se);
@@ -2475,6 +2476,22 @@ JsErrorCode RunScriptCore(const wchar_t *script, JsSourceContext sourceContext, 
     });
 }
 
+JsErrorCode RunScriptCore(const char *script, JsSourceContext sourceContext, const char *sourceUrl, bool parseOnly, JsParseScriptAttributes parseAttributes, bool isSourceModule, JsValueRef *result)
+{
+    utf8::NarrowToWide url((LPCSTR)sourceUrl);
+    if (!url)
+    {
+        return JsErrorOutOfMemory;
+    }
+
+    return RunScriptCore(reinterpret_cast<const byte*>(script), strlen(script), LoadScriptFlag_Utf8Source, sourceContext, url, parseOnly, parseAttributes, isSourceModule, result);
+}
+
+JsErrorCode RunScriptCore(const wchar_t *script, JsSourceContext sourceContext, const wchar_t *sourceUrl, bool parseOnly, JsParseScriptAttributes parseAttributes, bool isSourceModule, JsValueRef *result)
+{
+    return RunScriptCore(reinterpret_cast<const byte*>(script), wcslen(script) * sizeof(wchar_t), LoadScriptFlag_None, sourceContext, sourceUrl, parseOnly, parseAttributes, isSourceModule, result);
+}
+
 CHAKRA_API JsParseScript(_In_z_ const wchar_t * script, _In_ JsSourceContext sourceContext, _In_z_ const wchar_t *sourceUrl, _Out_ JsValueRef * result)
 {
     return RunScriptCore(script, sourceContext, sourceUrl, true, JsParseScriptAttributeNone, false, result);
@@ -2500,7 +2517,7 @@ CHAKRA_API JsExperimentalApiRunModule(_In_z_ const wchar_t * script, _In_ JsSour
     return RunScriptCore(script, sourceContext, sourceUrl, false, JsParseScriptAttributeNone, true, result);
 }
 
-JsErrorCode JsSerializeScriptCore(const wchar_t *script, BYTE *functionTable, int functionTableSize, unsigned char *buffer, unsigned int *bufferSize)
+JsErrorCode JsSerializeScriptCore(const byte *script, size_t cb, LoadScriptFlag loadScriptFlag, BYTE *functionTable, int functionTableSize, unsigned char *buffer, unsigned int *bufferSize)
 {
     Js::JavascriptFunction *function;
     CompileScriptException se;
@@ -2523,13 +2540,14 @@ JsErrorCode JsSerializeScriptCore(const wchar_t *script, BYTE *functionTable, in
         SourceContextInfo * sourceContextInfo = scriptContext->GetSourceContextInfo(JS_SOURCE_CONTEXT_NONE, nullptr);
         Assert(sourceContextInfo != nullptr);
 
+        const int chsize = (loadScriptFlag & LoadScriptFlag_Utf8Source) ? sizeof(utf8char_t) : sizeof(wchar_t);
         SRCINFO si = {
             /* sourceContextInfo   */ sourceContextInfo,
             /* dlnHost             */ 0,
             /* ulColumnHost        */ 0,
             /* lnMinHost           */ 0,
             /* ichMinHost          */ 0,
-            /* ichLimHost          */ static_cast<ULONG>(wcslen(script)), // OK to truncate since this is used to limit sourceText in debugDocument/compilation errors.
+            /* ichLimHost          */ static_cast<ULONG>(cb / chsize), // OK to truncate since this is used to limit sourceText in debugDocument/compilation errors.
             /* ulCharOffset        */ 0,
             /* mod                 */ kmodGlobal,
             /* grfsi               */ 0
@@ -2540,7 +2558,7 @@ JsErrorCode JsSerializeScriptCore(const wchar_t *script, BYTE *functionTable, in
 #endif
 
         Js::Utf8SourceInfo* sourceInfo = nullptr;
-        LoadScriptFlag loadScriptFlag = LoadScriptFlag_disableDeferredParse;
+        loadScriptFlag = (LoadScriptFlag)(loadScriptFlag | LoadScriptFlag_disableDeferredParse);
         if (isSerializeByteCodeForLibrary)
         {
             loadScriptFlag = (LoadScriptFlag)(loadScriptFlag | LoadScriptFlag_isByteCodeBufferForLibrary);
@@ -2549,7 +2567,7 @@ JsErrorCode JsSerializeScriptCore(const wchar_t *script, BYTE *functionTable, in
         {
             loadScriptFlag = (LoadScriptFlag)(loadScriptFlag | LoadScriptFlag_Expression);
         }
-        function = scriptContext->LoadScript((const byte*)script, wcslen(script)* sizeof(wchar_t), &si, &se, &sourceInfo, Js::Constants::GlobalCode, loadScriptFlag);
+        function = scriptContext->LoadScript(script, cb, &si, &se, &sourceInfo, Js::Constants::GlobalCode, loadScriptFlag);
         return JsNoError;
     });
 
@@ -2607,13 +2625,16 @@ JsErrorCode JsSerializeScriptCore(const wchar_t *script, BYTE *functionTable, in
 CHAKRA_API JsSerializeScript(_In_z_ const wchar_t *script, _Out_writes_to_opt_(*bufferSize, *bufferSize) unsigned char *buffer,
     _Inout_ unsigned int *bufferSize)
 {
-    return JsSerializeScriptCore(script, nullptr, 0, buffer, bufferSize);
+    return JsSerializeScriptCore((const byte*)script, wcslen(script) * sizeof(wchar_t), LoadScriptFlag_None, nullptr, 0, buffer, bufferSize);
 }
 
 template <typename TLoadCallback, typename TUnloadCallback>
-JsErrorCode RunSerializedScriptCore(const wchar_t *script, TLoadCallback scriptLoadCallback,
-    TUnloadCallback scriptUnloadCallback, unsigned char *buffer, JsSourceContext sourceContext,
-    const wchar_t *sourceUrl, bool parseOnly, JsValueRef *result)
+JsErrorCode RunSerializedScriptCore(
+    LPCUTF8 script,
+    TLoadCallback scriptLoadCallback, TUnloadCallback scriptUnloadCallback,
+    unsigned char *buffer,
+    JsSourceContext sourceContext, const wchar_t *sourceUrl,
+    bool parseOnly, JsValueRef *result)
 {
     Js::JavascriptFunction *function;
     JsErrorCode errorCode = ContextAPINoScriptWrapper([&](Js::ScriptContext *scriptContext) -> JsErrorCode {
@@ -2626,15 +2647,10 @@ JsErrorCode RunSerializedScriptCore(const wchar_t *script, TLoadCallback scriptL
         PARAM_NOT_NULL(sourceUrl);
 
         Js::ISourceHolder *sourceHolder = nullptr;
-        LPUTF8 utf8Source = nullptr;
-        size_t utf8Length = 0;
-        size_t length = 0;
-
         if (script != nullptr)
         {
             Assert(scriptLoadCallback == nullptr);
             Assert(scriptUnloadCallback == nullptr);
-            Js::JsrtSourceHolder<TLoadCallback, TUnloadCallback>::ScriptToUtf8(scriptContext, script, &utf8Source, &utf8Length, &length);
         }
         else
         {
@@ -2663,7 +2679,7 @@ JsErrorCode RunSerializedScriptCore(const wchar_t *script, TLoadCallback scriptL
             /* ulColumnHost        */ 0,
             /* lnMinHost           */ 0,
             /* ichMinHost          */ 0,
-            /* ichLimHost          */ static_cast<ULONG>(length), // OK to truncate since this is used to limit sourceText in debugDocument/compilation errors.
+            /* ichLimHost          */ 0, // xplat-todo: need to compute this?
             /* ulCharOffset        */ 0,
             /* mod                 */ kmodGlobal,
             /* grfsi               */ 0
@@ -2678,9 +2694,9 @@ JsErrorCode RunSerializedScriptCore(const wchar_t *script, TLoadCallback scriptL
 
         hsi = scriptContext->AddHostSrcInfo(&si);
 
-        if (utf8Source != nullptr)
+        if (script != nullptr)
         {
-            hr = Js::ByteCodeSerializer::DeserializeFromBuffer(scriptContext, flags, utf8Source, hsi, buffer, nullptr, &functionBody);
+            hr = Js::ByteCodeSerializer::DeserializeFromBuffer(scriptContext, flags, script, hsi, buffer, nullptr, &functionBody);
         }
         else
         {
@@ -2727,13 +2743,13 @@ JsErrorCode RunSerializedScriptCore(const wchar_t *script, TLoadCallback scriptL
 CHAKRA_API JsParseSerializedScript(_In_z_ const wchar_t * script, _In_ unsigned char *buffer, _In_ JsSourceContext sourceContext,
     _In_z_ const wchar_t *sourceUrl, _Out_ JsValueRef * result)
 {
-    return RunSerializedScriptCore<JsSerializedScriptLoadSourceCallback, JsSerializedScriptUnloadCallback>(script, nullptr, nullptr, buffer, sourceContext, sourceUrl, true, result);
+    return RunSerializedScriptCore<JsSerializedScriptLoadSourceCallback, JsSerializedScriptUnloadCallback>(nullptr/*script*/, nullptr, nullptr, buffer, sourceContext, sourceUrl, true, result);
 }
 
 CHAKRA_API JsRunSerializedScript(_In_z_ const wchar_t * script, _In_ unsigned char *buffer, _In_ JsSourceContext sourceContext,
     _In_z_ const wchar_t *sourceUrl, _Out_ JsValueRef * result)
 {
-    return RunSerializedScriptCore<JsSerializedScriptLoadSourceCallback, JsSerializedScriptUnloadCallback>(script, nullptr, nullptr, buffer, sourceContext, sourceUrl, false, result);
+    return RunSerializedScriptCore<JsSerializedScriptLoadSourceCallback, JsSerializedScriptUnloadCallback>(nullptr/*script*/, nullptr, nullptr, buffer, sourceContext, sourceUrl, false, result);
 }
 
 CHAKRA_API JsParseSerializedScriptWithCallback(_In_ JsSerializedScriptLoadSourceCallback scriptLoadCallback, _In_ JsSerializedScriptUnloadCallback scriptUnloadCallback, _In_ unsigned char *buffer, _In_ JsSourceContext sourceContext, _In_z_ const wchar_t *sourceUrl, _Out_ JsValueRef * result)
@@ -2746,3 +2762,47 @@ CHAKRA_API JsRunSerializedScriptWithCallback(_In_ JsSerializedScriptLoadSourceCa
     return RunSerializedScriptCore<JsSerializedScriptLoadSourceCallback, JsSerializedScriptUnloadCallback>(nullptr, scriptLoadCallback, scriptUnloadCallback, buffer, sourceContext, sourceUrl, false, result);
 }
 #endif // _WIN32
+
+
+CHAKRA_API JsRunScriptUtf8(
+    _In_z_ const char *script,
+    _In_ JsSourceContext sourceContext,
+    _In_z_ const char *sourceUrl,
+    _Out_ JsValueRef *result)
+{
+    return RunScriptCore(script, sourceContext, sourceUrl, false, JsParseScriptAttributeNone, false, result);
+}
+
+CHAKRA_API JsSerializeScriptUtf8(
+    _In_z_ const char *script,
+    _Out_writes_to_opt_(*bufferSize, *bufferSize) ChakraBytePtr buffer,
+    _Inout_ unsigned int *bufferSize)
+{
+    return JsSerializeScriptCore((const byte*)script, strlen(script), LoadScriptFlag_Utf8Source, nullptr, 0, buffer, bufferSize);
+}
+
+CHAKRA_API JsRunSerializedScriptUtf8(
+    _In_ JsSerializedScriptLoadUtf8SourceCallback scriptLoadCallback,
+    _In_ JsSerializedScriptUnloadCallback scriptUnloadCallback,
+    _In_ ChakraBytePtr buffer,
+    _In_ JsSourceContext sourceContext,
+    _In_z_ const char *sourceUrl,
+    _Out_opt_ JsValueRef * result)
+{
+    utf8::NarrowToWide url(sourceUrl);
+    if (!url)
+    {
+        return JsErrorOutOfMemory;
+    }
+
+    return RunSerializedScriptCore(nullptr, scriptLoadCallback, scriptUnloadCallback, buffer, sourceContext, url, false, result);
+}
+
+CHAKRA_API JsExperimentalApiRunModuleUtf8(
+    _In_z_ const char *script,
+    _In_ JsSourceContext sourceContext,
+    _In_z_ const char *sourceUrl,
+    _Out_ JsValueRef *result)
+{
+    return RunScriptCore(script, sourceContext, sourceUrl, false, JsParseScriptAttributeNone, true, result);
+}

--- a/lib/Jsrt/JsrtCommonExports.inc
+++ b/lib/Jsrt/JsrtCommonExports.inc
@@ -104,3 +104,7 @@
     JsGetRuntime
     JsIdle
     JsSetPromiseContinuationCallback
+    JsRunScriptUtf8
+    JsSerializeScriptUtf8
+    JsRunSerializedScriptUtf8
+    JsExperimentalApiRunModuleUtf8

--- a/lib/Jsrt/JsrtSourceHolder.cpp
+++ b/lib/Jsrt/JsrtSourceHolder.cpp
@@ -7,60 +7,105 @@
 
 namespace Js
 {
-    // Helper function for converting a Unicode script to utf8.
-    // If heapAlloc is true the returned buffer must be freed with HeapDelete.
-    // Otherwise scriptContext must be provided and GCed object is
-    // returned.
-    template <typename TLoadCallback, typename TUnloadCallback>
-    void JsrtSourceHolder<TLoadCallback, TUnloadCallback>::ScriptToUtf8(_When_(heapAlloc, _In_opt_) _When_(!heapAlloc, _In_) Js::ScriptContext *scriptContext,
-        _In_z_ const wchar_t *script, _Outptr_result_buffer_(*utf8Length) utf8char_t **utf8Script, _Out_ size_t *utf8Length,
-        _Out_ size_t *scriptLength, _Out_opt_ size_t *utf8AllocLength, _In_ bool heapAlloc)
+    template <typename TLoadCallback>
+    class JsrtSourceHolderPolicy
     {
-        Assert(utf8Script != nullptr);
-        Assert(utf8Length != nullptr);
-        Assert(scriptLength != nullptr);
+    };
 
-        *utf8Script = nullptr;
-        *utf8Length = 0;
-        *scriptLength = 0;
+#ifdef _WIN32  // JsSerializedScriptLoadSourceCallback is WIN32 only
+    template <>
+    class JsrtSourceHolderPolicy<JsSerializedScriptLoadSourceCallback>
+    {
+    public:
+        typedef wchar_t TLoadCharType;
 
-        if (utf8AllocLength != nullptr)
+        // Helper function for converting a Unicode script to utf8.
+        // If heapAlloc is true the returned buffer must be freed with HeapDelete.
+        // Otherwise scriptContext must be provided and GCed object is
+        // returned.
+        static void ScriptToUtf8(_When_(heapAlloc, _In_opt_) _When_(!heapAlloc, _In_) Js::ScriptContext *scriptContext,
+            _In_z_ const wchar_t *script, _Outptr_result_buffer_(*utf8Length) utf8char_t **utf8Script, _Out_ size_t *utf8Length,
+            _Out_ size_t *scriptLength, _Out_opt_ size_t *utf8AllocLength, _In_ bool heapAlloc)
         {
-            *utf8AllocLength = 0;
+            Assert(utf8Script != nullptr);
+            Assert(utf8Length != nullptr);
+            Assert(scriptLength != nullptr);
+
+            *utf8Script = nullptr;
+            *utf8Length = 0;
+            *scriptLength = 0;
+
+            if (utf8AllocLength != nullptr)
+            {
+                *utf8AllocLength = 0;
+            }
+
+            size_t length = wcslen(script);
+            if (length > UINT_MAX)
+            {
+                Js::JavascriptError::ThrowOutOfMemoryError(nullptr);
+            }
+
+            // `length` should not be bigger than MAXLONG
+            // UINT_MAX / 3 < MAXLONG
+            size_t cbUtf8Buffer = ((UINT_MAX / 3) - 1 > length) ? (length + 1) * 3 : UINT_MAX;
+            if (cbUtf8Buffer >= UINT_MAX)
+            {
+                Js::JavascriptError::ThrowOutOfMemoryError(nullptr);
+            }
+
+            if (!heapAlloc)
+            {
+                Assert(scriptContext != nullptr);
+                *utf8Script = RecyclerNewArrayLeaf(scriptContext->GetRecycler(), utf8char_t, cbUtf8Buffer);
+            }
+            else
+            {
+                *utf8Script = HeapNewArray(utf8char_t, cbUtf8Buffer);
+            }
+
+            *utf8Length = utf8::EncodeIntoAndNullTerminate(*utf8Script, script, static_cast<charcount_t>(length));
+            *scriptLength = length;
+
+            if (utf8AllocLength != nullptr)
+            {
+                *utf8AllocLength = cbUtf8Buffer;
+            }
         }
 
-        size_t length = wcslen(script);
-        if (length > UINT_MAX)
+        static void FreeMappedSource(utf8char_t const * source, size_t allocLength)
         {
-            Js::JavascriptError::ThrowOutOfMemoryError(nullptr);
+            HeapDeleteArray(allocLength, source);
+        }
+    };
+#endif  // _WIN32
+
+    template <>
+    class JsrtSourceHolderPolicy<JsSerializedScriptLoadUtf8SourceCallback>
+    {
+    public:
+        typedef char TLoadCharType;
+
+        static void ScriptToUtf8(_When_(heapAlloc, _In_opt_) _When_(!heapAlloc, _In_) Js::ScriptContext *scriptContext,
+            _In_z_ const char *script, _Outptr_result_buffer_(*utf8Length) utf8char_t **utf8Script, _Out_ size_t *utf8Length,
+            _Out_ size_t *scriptLength, _Out_opt_ size_t *utf8AllocLength, _In_ bool heapAlloc)
+        {
+            *utf8Script = (utf8char_t*)script;
+            *utf8Length = strlen(script);
+            *scriptLength = *utf8Length; // xplat-todo: incorrect for utf8
+
+            if (utf8AllocLength)
+            {
+                *utf8AllocLength = *utf8Length; // actually no alloc, should not release
+            }
         }
 
-        // `length` should not be bigger than MAXLONG 
-        // UINT_MAX / 3 < MAXLONG
-        size_t cbUtf8Buffer = ((UINT_MAX / 3) - 1 > length) ? (length + 1) * 3 : UINT_MAX;
-        if (cbUtf8Buffer >= UINT_MAX)
+        static void FreeMappedSource(utf8char_t const * source, size_t allocLength)
         {
-            Js::JavascriptError::ThrowOutOfMemoryError(nullptr);
+            // do nothing, did not allocate for source
         }
+    };
 
-        if (!heapAlloc)
-        {
-            Assert(scriptContext != nullptr);
-            *utf8Script = RecyclerNewArrayLeaf(scriptContext->GetRecycler(), utf8char_t, cbUtf8Buffer);
-        }
-        else
-        {
-            *utf8Script = HeapNewArray(utf8char_t, cbUtf8Buffer);
-        }
-
-        *utf8Length = utf8::EncodeIntoAndNullTerminate(*utf8Script, script, static_cast<charcount_t>(length));
-        *scriptLength = length;
-
-        if (utf8AllocLength != nullptr)
-        {
-            *utf8AllocLength = cbUtf8Buffer;
-        }
-    }
 
     template <typename TLoadCallback, typename TUnloadCallback>
     void JsrtSourceHolder<TLoadCallback, TUnloadCallback>::EnsureSource(MapRequestFor requestedFor, const wchar_t* reasonString)
@@ -73,7 +118,7 @@ namespace Js
         Assert(scriptLoadCallback != nullptr);
         Assert(this->mappedSource == nullptr);
 
-        const wchar_t *source = nullptr;
+        const typename JsrtSourceHolderPolicy<TLoadCallback>::TLoadCharType *source = nullptr;
         size_t sourceLength = 0;
         utf8char_t *utf8Source = nullptr;
         size_t utf8Length = 0;
@@ -85,7 +130,7 @@ namespace Js
             Js::JavascriptError::ThrowOutOfMemoryError(nullptr);
         }
 
-        JsrtSourceHolder<TLoadCallback, TUnloadCallback>::ScriptToUtf8(nullptr, source, &utf8Source, &utf8Length, &sourceLength, &utf8AllocLength, true);
+        JsrtSourceHolderPolicy<TLoadCallback>::ScriptToUtf8(nullptr, source, &utf8Source, &utf8Length, &sourceLength, &utf8AllocLength, true);
 
         this->mappedSource = utf8Source;
         this->mappedSourceByteLength = utf8Length;
@@ -111,7 +156,8 @@ namespace Js
 
         if (this->mappedSource != nullptr)
         {
-            HeapDeleteArray(this->mappedAllocLength, this->mappedSource);
+            JsrtSourceHolderPolicy<TLoadCallback>::FreeMappedSource(
+                this->mappedSource, this->mappedAllocLength);
             this->mappedSource = nullptr;
         }
 
@@ -121,7 +167,10 @@ namespace Js
         sourceContext = NULL;
     }
 
+
 #ifdef _WIN32
 template class JsrtSourceHolder<JsSerializedScriptLoadSourceCallback, JsSerializedScriptUnloadCallback>;
 #endif // _WIN32
+
+template class JsrtSourceHolder<JsSerializedScriptLoadUtf8SourceCallback, JsSerializedScriptUnloadCallback>;
 };

--- a/lib/Jsrt/JsrtSourceHolder.h
+++ b/lib/Jsrt/JsrtSourceHolder.h
@@ -37,12 +37,8 @@ namespace Js
         };
 
         void EnsureSource(MapRequestFor requestedFor, const wchar_t* reasonString);
+
     public:
-
-        static void ScriptToUtf8(_When_(heapAlloc, _In_opt_) _When_(!heapAlloc, _In_) Js::ScriptContext *scriptContext,
-            _In_z_ const wchar_t *script, _Outptr_result_buffer_(*utf8Length) LPUTF8 *utf8Script, _Out_ size_t *utf8Length,
-            _Out_ size_t *scriptLength, _Out_opt_ size_t *utf8AllocLength = NULL, _In_ bool heapAlloc = false);
-
         JsrtSourceHolder(_In_ TLoadCallback scriptLoadCallback,
             _In_ TUnloadCallback scriptUnloadCallback,
             _In_ JsSourceContext sourceContext) :

--- a/lib/Runtime/Library/JavascriptFunction.cpp
+++ b/lib/Runtime/Library/JavascriptFunction.cpp
@@ -1583,12 +1583,8 @@ LABEL1:
     // Library\arm\arm_DeferredParsingThunk.asm
     // Library\arm64\arm64_DeferredParsingThunk.asm
 #else
-    // xplat-todo: Implement defer deserialization for linux
-    Var JavascriptFunction::DeferredDeserializeThunk(RecyclableObject* function, CallInfo callInfo, ...)
-    {
-        Js::Throw::NotImplemented();
-        return nullptr;
-    }
+    // xplat implement in
+    // Library/amd64/JavascriptFunctionA.S
 #endif
 
     Js::JavascriptMethod JavascriptFunction::DeferredDeserialize(ScriptFunction* function)

--- a/lib/Runtime/Library/amd64/JavascriptFunctionA.S
+++ b/lib/Runtime/Library/amd64/JavascriptFunctionA.S
@@ -7,11 +7,14 @@
 #include "unixasmmacros.inc"
 
 .extern _ZN2Js18JavascriptFunction13DeferredParseEPPNS_14ScriptFunctionE
+.extern _ZN2Js18JavascriptFunction19DeferredDeserializeEPNS_14ScriptFunctionE
 
 .global _ZN2Js18JavascriptFunction20DeferredParsingThunkEPNS_16RecyclableObjectENS_8CallInfoEz
+.global _ZN2Js18JavascriptFunction24DeferredDeserializeThunkEPNS_16RecyclableObjectENS_8CallInfoEz
 
 #ifndef __APPLE__
 .type _ZN2Js18JavascriptFunction20DeferredParsingThunkEPNS_16RecyclableObjectENS_8CallInfoEz, @function
+.type _ZN2Js18JavascriptFunction24DeferredDeserializeThunkEPNS_16RecyclableObjectENS_8CallInfoEz, @function
 #endif
 
 //------------------------------------------------------------------------------
@@ -118,6 +121,30 @@ _ZN2Js18JavascriptFunction20DeferredParsingThunkEPNS_16RecyclableObjectENS_8Call
         //
         lea rdi, [rbp + 10h]    // &function, setup by custom calling convention
         call _ZN2Js18JavascriptFunction13DeferredParseEPPNS_14ScriptFunctionE@plt
+
+        pop rsi
+        pop rdi
+        pop rbp
+
+        jmp rax
+
+// Var JavascriptFunction::DeferredDeserializeThunk(
+//              RecyclableObject* function, CallInfo callInfo, ...)
+.align 16
+_ZN2Js18JavascriptFunction24DeferredDeserializeThunkEPNS_16RecyclableObjectENS_8CallInfoEz:
+        push rbp
+        lea  rbp, [rsp]
+
+        // save argument registers used by custom calling convention
+        push rdi
+        push rsi
+
+        // Call
+        //  Js::JavascriptMethod JavascriptFunction::DeferredDeserialize(
+        //                              ScriptFunction* function)
+        //
+        //      RDI == function, setup by custom calling convention
+        call _ZN2Js18JavascriptFunction19DeferredDeserializeEPNS_14ScriptFunctionE@plt
 
         pop rsi
         pop rdi

--- a/test/runtests.py
+++ b/test/runtests.py
@@ -106,10 +106,9 @@ not_tags.add('exclude_nightly' if args.nightly else 'nightly')
 # xplat: temp hard coded to exclude unsupported tests
 if sys.platform != 'win32':
     not_tags.add('exclude_xplat')
-    not_tags.add('exclude_serialized')
     not_tags.add('require_backend')
     not_tags.add('require_debugger')
-not_compile_flags = set(['-serialized', '-simdjs']) \
+not_compile_flags = set(['-simdjs']) \
     if sys.platform != 'win32' else None
 
 class LogFile(object):
@@ -141,7 +140,8 @@ class LogFile(object):
         if not (self.file is None):
             self.file.close()
 
-log_file = LogFile(args.logfile)
+if __name__ == '__main__':
+    log_file = LogFile(args.logfile)
 
 def log_message(msg = ""):
     log_file.log(msg + "\n")


### PR DESCRIPTION
Implement 4 Utf8 variants of Jsrt Apis:
 - JsRunScriptUtf8
 - JsSerializeScriptUtf8
 - JsRunSerializedScriptUtf8
 - JsRunModuleUtf8

Change `ch` to use Utf8 script encoding and use the new Utf8 Jsrt Apis.

Refactor Narrow-Wide string converter and shared with runtime.
Refactor JsrtSourceHolder to support both wchar_t and utf8 loader.

Implement JavascriptFunction::DeferredDeserializeThunk for cross-platform.
Set major/minor version for xplat (needed by `-serialize`).

Turn on `-serialize` tests on cross-platform.
