### PR TITLE
Fixing bug when hoisting FromVar from the landing pad of an inner loop

### DIFF
--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -18597,7 +18597,14 @@ GlobOpt::OptHoistInvariant(
                 {
                     instr->GetSrc1()->SetValueType(landingPadSrc1val->GetValueInfo()->Type());
                     EnsureBailTarget(loop);
-                    instr = instr->ConvertToBailOutInstr(instr, bailoutKind);
+                    if (block->IsLandingPad())
+                    {
+                        instr = instr->ConvertToBailOutInstr(instr, bailoutKind, loop->bailOutInfo->bailOutOffset);
+                    }
+                    else
+                    {
+                        instr = instr->ConvertToBailOutInstr(instr, bailoutKind);
+                    }
                 };
 
                 // A definite type in the source position and not a definite type in the destination (landing pad)

--- a/lib/Backend/IR.cpp
+++ b/lib/Backend/IR.cpp
@@ -2942,10 +2942,10 @@ Instr::TransferTo(Instr * instr)
 }
 
 IR::Instr *
-Instr::ConvertToBailOutInstr(IR::Instr * bailOutTarget, IR::BailOutKind kind)
+Instr::ConvertToBailOutInstr(IR::Instr * bailOutTarget, IR::BailOutKind kind, uint32 bailOutOffset)
 {
     Func * func = bailOutTarget->m_func;
-    BailOutInfo * bailOutInfo = JitAnew(func->m_alloc, BailOutInfo, bailOutTarget->GetByteCodeOffset(), func);
+    BailOutInfo * bailOutInfo = JitAnew(func->m_alloc, BailOutInfo, bailOutOffset == Js::Constants::NoByteCodeOffset ? bailOutTarget->GetByteCodeOffset() : bailOutOffset , func);
 #if ENABLE_DEBUG_CONFIG_OPTIONS
     bailOutInfo->bailOutOpcode = this->m_opcode;
 #endif

--- a/lib/Backend/IR.h
+++ b/lib/Backend/IR.h
@@ -250,7 +250,7 @@ public:
     void            TransferDstAttributesTo(Instr * instr);
     IR::Instr *     Copy();
     IR::Instr *     Clone();
-    IR::Instr *     ConvertToBailOutInstr(IR::Instr * bailOutTarget, BailOutKind kind);
+    IR::Instr *     ConvertToBailOutInstr(IR::Instr * bailOutTarget, BailOutKind kind, uint32 bailOutOffset = Js::Constants::NoByteCodeOffset);
     IR::Instr *     ConvertToBailOutInstr(BailOutInfo * bailOutInfo, BailOutKind kind, bool useAuxBailout = false);
     IR::Instr *     GetNextRealInstr() const;
     IR::Instr *     GetNextRealInstrOrLabel() const;


### PR DESCRIPTION
When hoisting a FromVar out of a loop, we check whether it needs a bailout at its hoisted position. If it does and if doesn't already have a bailout, we insert the appropriate bailout on it, and then hoist it. If the FromVar was originally in the landing pad of an inner loop, we have to make sure that the bail out offset of the newly inserted bailout is that of the top of the loop.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/1066)
<!-- Reviewable:end -->
