### PR TITLE
Fix dev12 build

### DIFF
--- a/lib/Common/Common/NumberUtilities.cpp
+++ b/lib/Common/Common/NumberUtilities.cpp
@@ -9,6 +9,10 @@
 
 namespace Js
 {
+    // The VS2013 linker treats this as a redefinition of an already
+    // defined constant and complains. So skip the declaration if we're compiling
+    // with VS2013 or below.
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
     // Redeclare static constants
     const UINT64 NumberConstantsBase::k_Nan;
     const INT64 NumberUtilitiesBase::Pos_InvalidInt64;
@@ -31,6 +35,7 @@ namespace Js
     const uint32 NumberConstants::k_Float32NegZero;
     const uint32 NumberConstants::k_Float32TwoToFraction;
     const uint32 NumberConstants::k_Float32NegTwoToFraction;
+#endif
 
     const double NumberConstants::MAX_VALUE = *(double*)(&NumberConstants::k_PosMax);
     const double NumberConstants::MIN_VALUE = *(double*)(&NumberConstants::k_PosMin);

--- a/lib/Common/Memory/ArenaAllocator.cpp
+++ b/lib/Common/Memory/ArenaAllocator.cpp
@@ -6,7 +6,12 @@
 
 #define ASSERT_THREAD() AssertMsg(this->pageAllocator->ValidThreadAccess(), "Arena allocation should only be used by a single thread")
 
+// The VS2013 linker treats this as a redefinition of an already
+// defined constant and complains. So skip the declaration if we're compiling
+// with VS2013 or below.
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
 const uint Memory::StandAloneFreeListPolicy::MaxEntriesGrowth;
+#endif
 
 #ifdef _MSC_VER
 template __forceinline BVSparseNode * BVSparse<JitArenaAllocator>::NodeFromIndex(BVIndex i, BVSparseNode *** prevNextFieldOut, bool create);

--- a/lib/Common/Memory/HeapBlockMap.cpp
+++ b/lib/Common/Memory/HeapBlockMap.cpp
@@ -4,8 +4,13 @@
 //-------------------------------------------------------------------------------------------------------
 #include "CommonMemoryPch.h"
 
+// The VS2013 linker treats this as a redefinition of an already
+// defined constant and complains. So skip the declaration if we're compiling
+// with VS2013 or below.
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
 const uint Memory::HeapBlockMap32::L1Count;
 const uint Memory::HeapBlockMap32::L2Count;
+#endif
 
 #if defined(_M_X64_OR_ARM64)
 HeapBlockMap32::HeapBlockMap32(__in char * startAddress) :

--- a/lib/Common/Memory/HeapInfo.cpp
+++ b/lib/Common/Memory/HeapInfo.cpp
@@ -18,8 +18,13 @@ template __forceinline char* HeapInfo::RealAlloc<NoBit, false>(Recycler * recycl
 template __attribute__((always_inline)) char* HeapInfo::RealAlloc<NoBit, false>(Recycler * recycler, size_t sizeCat, size_t size);
 #endif
 
+// The VS2013 linker treats this as a redefinition of an already
+// defined constant and complains. So skip the declaration if we're compiling
+// with VS2013 or below.
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
 const uint SmallAllocationBlockAttributes::MaxSmallObjectCount;
 const uint MediumAllocationBlockAttributes::MaxSmallObjectCount;
+#endif
 
 HeapInfo::ValidPointersMap<SmallAllocationBlockAttributes>  HeapInfo::smallAllocValidPointersMap;
 HeapInfo::ValidPointersMap<MediumAllocationBlockAttributes> HeapInfo::mediumAllocValidPointersMap;

--- a/lib/Parser/CharSet.cpp
+++ b/lib/Parser/CharSet.cpp
@@ -1870,11 +1870,16 @@ namespace UnifiedRegex
     }
 #endif
 
-    const int  CharSetNode::directBits;
+    // The VS2013 linker treats this as a redefinition of an already
+    // defined constant and complains. So skip the declaration if we're compiling
+    // with VS2013 or below.
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+	const int  CharSetNode::directBits;
     const uint CharSetNode::directSize;
     const uint CharSetNode::innerMask;
     const int  CharSetNode::bitsPerLeafLevel;
     const int  CharSetNode::branchingPerLeafLevel;
     const uint CharSetNode::leafMask;
     const uint CharSetNode::levels;
+#endif
 }

--- a/lib/Parser/CharTrie.cpp
+++ b/lib/Parser/CharTrie.cpp
@@ -6,7 +6,12 @@
 
 namespace UnifiedRegex
 {
+    // The VS2013 linker treats this as a redefinition of an already
+    // defined constant and complains. So skip the declaration if we're compiling
+    // with VS2013 or below.
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
     const int CharTrie::initCapacity;
+#endif
 
     // ----------------------------------------------------------------------
     // CharTrie

--- a/lib/Parser/RegexCompileTime.cpp
+++ b/lib/Parser/RegexCompileTime.cpp
@@ -11,7 +11,12 @@ namespace UnifiedRegex
     // Compiler (inlines etc)
     // ----------------------------------------------------------------------
 
+    // The VS2013 linker treats this as a redefinition of an already
+    // defined constant and complains. So skip the declaration if we're compiling
+    // with VS2013 or below.
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
     const CharCount Compiler::initInstBufSize;
+#endif
 
     uint8* Compiler::Emit(size_t size)
     {

--- a/lib/Runtime/Base/Constants.cpp
+++ b/lib/Runtime/Base/Constants.cpp
@@ -6,8 +6,13 @@
 
 using namespace Js;
 
+// The VS2013 linker treats this as a redefinition of an already
+// defined constant and complains. So skip the declaration if we're compiling
+// with VS2013 or below.
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
 const uint Constants::InvalidSourceIndex;
 const RegSlot Constants::NoRegister;
+#endif
 
 const char16 Constants::AnonymousFunction[] = _u("Anonymous function");
 const char16 Constants::Anonymous[] = _u("anonymous");

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -33,7 +33,12 @@
 
 namespace Js
 {
+    // The VS2013 linker treats this as a redefinition of an already
+    // defined constant and complains. So skip the declaration if we're compiling
+    // with VS2013 or below.
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
     uint const ScopeSlots::MaxEncodedSlotCount;
+#endif
 
     CriticalSection FunctionProxy::GlobalLock;
 

--- a/lib/Runtime/Library/ConcatString.cpp
+++ b/lib/Runtime/Library/ConcatString.cpp
@@ -120,7 +120,12 @@ namespace Js
     /////////////////////// ConcatStringBuilder //////////////////////////
 
     // MAX number of slots in one chunk. Until we fit into this, we realloc, otherwise create new chunk.
+    // The VS2013 linker treats this as a redefinition of an already
+    // defined constant and complains. So skip the declaration if we're compiling
+    // with VS2013 or below.
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
     const int ConcatStringBuilder::c_maxChunkSlotCount;
+#endif
 
     ConcatStringBuilder::ConcatStringBuilder(ScriptContext* scriptContext, int initialSlotCount) :
         ConcatStringBase(scriptContext->GetLibrary()->GetStringTypeStatic()),

--- a/lib/Runtime/Library/JavascriptFunction.cpp
+++ b/lib/Runtime/Library/JavascriptFunction.cpp
@@ -22,7 +22,12 @@ extern "C" void __cdecl _alloca_probe_16();
 
 namespace Js
 {
+    // The VS2013 linker treats this as a redefinition of an already
+    // defined constant and complains. So skip the declaration if we're compiling
+    // with VS2013 or below.
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
     const charcount_t JavascriptFunction::DIAG_MAX_FUNCTION_STRING;
+#endif
 
     DEFINE_RECYCLER_TRACKER_PERF_COUNTER(JavascriptFunction);
     JavascriptFunction::JavascriptFunction(DynamicType * type)

--- a/lib/Runtime/Library/JavascriptRegExpConstructor.cpp
+++ b/lib/Runtime/Library/JavascriptRegExpConstructor.cpp
@@ -7,7 +7,12 @@
 
 namespace Js
 {
+    // The VS2013 linker treats this as a redefinition of an already
+    // defined constant and complains. So skip the declaration if we're compiling
+    // with VS2013 or below.
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
     const int JavascriptRegExpConstructor::NumCtorCaptures;
+#endif
 
     JavascriptRegExpConstructor::JavascriptRegExpConstructor(DynamicType * type) :
         RuntimeFunction(type, &JavascriptRegExp::EntryInfo::NewInstance),

--- a/lib/Runtime/Library/ProfileString.cpp
+++ b/lib/Runtime/Library/ProfileString.cpp
@@ -8,7 +8,12 @@
 
 namespace Js
 {
+    // The VS2013 linker treats this as a redefinition of an already
+    // defined constant and complains. So skip the declaration if we're compiling
+    // with VS2013 or below.
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
     const uint StringProfiler::k_MaxConcatLength;
+#endif
 
     StringProfiler::StringProfiler(PageAllocator * pageAllocator)
       : allocator(_u("StringProfiler"), pageAllocator, Throw::OutOfMemory ),

--- a/lib/Runtime/Types/TypePath.cpp
+++ b/lib/Runtime/Types/TypePath.cpp
@@ -5,7 +5,12 @@
 #include "RuntimeTypePch.h"
 
 namespace Js {
+    // The VS2013 linker treats this as a redefinition of an already
+    // defined constant and complains. So skip the declaration if we're compiling
+    // with VS2013 or below.
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
     const uint TypePath::InitialTypePathSize;
+#endif
 
     TypePath* TypePath::New(Recycler* recycler, uint size)
     {


### PR DESCRIPTION
The dev12 toolset was unhappy with the redeclaration of class static
constants, that was done to satisfy clang. Dev12 treats the second
declaration as a second definition and makes the linker unhappy.
Conditionally compiled out the redeclarations on dev12.
