### PR TITLE
Fix implementation of GET_CURRENT_FRAME_ID on Linux

### DIFF
--- a/lib/Common/Common/GetCurrentFrameId.h
+++ b/lib/Common/Common/GetCurrentFrameId.h
@@ -21,8 +21,13 @@
 #define GET_CURRENT_FRAME_ID(f) \
     __asm { mov f, ebp }
 #elif defined(_M_X64)
+#ifdef _WIN32
 #define GET_CURRENT_FRAME_ID(f) \
     (f = _ReturnAddress())
+#else
+#define GET_CURRENT_FRAME_ID(f) \
+    (f = __builtin_frame_address(0))
+#endif
 #elif defined(_M_ARM)
 // ARM, like x86, uses the frame pointer rather than code address
 #define GET_CURRENT_FRAME_ID(f) \


### PR DESCRIPTION
GET_CURRENT_FRAME_ID is used by the stack walker on Linux to figure out
the start of the frame. However, the implementation was still using the
win32 x64 implementation which use the return address as the frame
id. This broke the stack walker on Linux which is based on the x86
one. Changed the x64 linux implementation to match the x86 implementation.
