### PR TITLE
remove useless template specialization for BVSparse::QueueInFreeList

### DIFF
--- a/lib/Backend/BackwardPass.cpp
+++ b/lib/Backend/BackwardPass.cpp
@@ -2,13 +2,6 @@
 // Copyright (C) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
-class JitArenaAllocator;
-template <>
-void
-BVSparse<JitArenaAllocator>::QueueInFreeList(BVSparseNode *curNode)
-{
-    AllocatorDeleteInline(JitArenaAllocator, this->alloc, curNode);
-}
 
 #include "Backend.h"
 


### PR DESCRIPTION
this code is not compiled since it's in front of the pch including header
