### PR TITLE
Improve the perf of Array#filter a little bit by using specialized versions of GetItem

### DIFF
--- a/lib/Runtime/Library/JavascriptArray.cpp
+++ b/lib/Runtime/Library/JavascriptArray.cpp
@@ -8996,13 +8996,9 @@ Case0:
             JavascriptError::ThrowTypeError(scriptContext, JSERR_This_NullOrUndefined, _u("Array.prototype.filter"));
         }
 
-        RecyclableObject* newObj = nullptr;
-        JavascriptArray* newArr = nullptr;
         BigIndex length;
         JavascriptArray* pArr = nullptr;
         RecyclableObject* dynamicObject = nullptr;
-        RecyclableObject* callBackFn = nullptr;
-        Var thisArg = nullptr;
 
         if (JavascriptArray::Is(args[0]) && !JavascriptArray::FromVar(args[0])->IsCrossSiteObject())
         {
@@ -9036,11 +9032,23 @@ Case0:
             length = pArr->length;
         }
 
+        if (length.IsSmallIndex())
+        {
+            return JavascriptArray::FilterHelper(pArr, dynamicObject, length.GetSmallIndex(), args, scriptContext);
+        }
+        return JavascriptArray::FilterHelper(pArr, dynamicObject, length.GetBigIndex(), args, scriptContext);
+    }
+
+    template <typename T>
+    Var JavascriptArray::FilterHelper(JavascriptArray* pArr, RecyclableObject* obj, T length, Arguments& args, ScriptContext* scriptContext)
+    {
         if (args.Info.Count < 2 || !JavascriptConversion::IsCallable(args[1]))
         {
             JavascriptError::ThrowTypeError(scriptContext, JSERR_FunctionArgument_NeedFunction, _u("Array.prototype.filter"));
         }
-        callBackFn = RecyclableObject::FromVar(args[1]);
+
+        RecyclableObject* callBackFn = RecyclableObject::FromVar(args[1]);
+        Var thisArg = nullptr;
 
         if (args.Info.Count > 2)
         {
@@ -9052,7 +9060,8 @@ Case0:
         }
 
         // If the source object is an Array exotic object we should try to load the constructor property and use it to construct the return object.
-        newObj = ArraySpeciesCreate(dynamicObject, 0, scriptContext);
+        RecyclableObject* newObj = ArraySpeciesCreate(obj, 0, scriptContext);
+        JavascriptArray* newArr = nullptr;
 
         if (newObj == nullptr)
         {
@@ -9069,28 +9078,25 @@ Case0:
             }
         }
 
-        // The correct flag value is CallFlags_Value but we pass CallFlags_None in compat modes
-        CallFlags flags = CallFlags_Value;
         Var element = nullptr;
         Var selected = nullptr;
-        BigIndex i = 0u;
 
         if (pArr)
         {
-            uint32 arrayLength = length.IsUint32Max() ? MaxArrayLength : length.GetSmallIndex();
+            Assert(length <= MaxArrayLength);
+            uint32 i = 0;
 
-            // If source was an array object, the return object might be any random object
-            for (uint32 k = 0; k < arrayLength; k++)
+            for (uint32 k = 0; k < length; k++)
             {
                 if (!pArr->DirectGetItemAtFull(k, &element))
                 {
                     continue;
                 }
 
-                selected = callBackFn->GetEntryPoint()(callBackFn, CallInfo(flags, 4), thisArg,
-                                                                element,
-                                                                JavascriptNumber::ToVar(k, scriptContext),
-                                                                pArr);
+                selected = callBackFn->GetEntryPoint()(callBackFn, CallInfo(CallFlags_Value, 4), thisArg,
+                    element,
+                    JavascriptNumber::ToVar(k, scriptContext),
+                    pArr);
 
                 if (JavascriptConversion::ToBoolean(selected, scriptContext))
                 {
@@ -9101,7 +9107,7 @@ Case0:
                     }
                     else
                     {
-                        JavascriptArray::SetArrayLikeObjects(RecyclableObject::FromVar(newObj), i, element);
+                        JavascriptArray::SetArrayLikeObjects(newObj, i, element);
                     }
                     ++i;
                 }
@@ -9109,15 +9115,17 @@ Case0:
         }
         else
         {
-            for (BigIndex k = 0u; k < length; ++k)
+            BigIndex i = 0u;
+
+            for (T k = 0; k < length; k++)
             {
-                if (JavascriptOperators::HasItem(dynamicObject, k.IsSmallIndex() ? k.GetSmallIndex() : k.GetBigIndex()))
+                if (JavascriptOperators::HasItem(obj, k))
                 {
-                    element = JavascriptOperators::GetItem(dynamicObject, k.IsSmallIndex() ? k.GetSmallIndex() : k.GetBigIndex(), scriptContext);
-                    selected = callBackFn->GetEntryPoint()(callBackFn, CallInfo(flags, 4), thisArg,
+                    element = JavascriptOperators::GetItem(obj, k, scriptContext);
+                    selected = callBackFn->GetEntryPoint()(callBackFn, CallInfo(CallFlags_Value, 4), thisArg,
                         element,
-                        JavascriptNumber::ToVar(k.IsSmallIndex() ? k.GetSmallIndex() : k.GetBigIndex(), scriptContext),
-                        dynamicObject);
+                        JavascriptNumber::ToVar(k, scriptContext),
+                        obj);
 
                     if (JavascriptConversion::ToBoolean(selected, scriptContext))
                     {
@@ -9127,7 +9135,7 @@ Case0:
                         }
                         else
                         {
-                            JavascriptArray::SetArrayLikeObjects(RecyclableObject::FromVar(newObj), i, element);
+                            JavascriptArray::SetArrayLikeObjects(newObj, i, element);
                         }
                         ++i;
                     }
@@ -9183,7 +9191,6 @@ Case0:
             if (scriptContext->GetConfig()->IsES6ToLengthEnabled())
             {
                 length = (uint64) JavascriptConversion::ToLength(JavascriptOperators::OP_GetLength(obj, scriptContext), scriptContext);
-
             }
             else
             {

--- a/lib/Runtime/Library/JavascriptArray.h
+++ b/lib/Runtime/Library/JavascriptArray.h
@@ -467,6 +467,8 @@ namespace Js
         static Var FindHelper(JavascriptArray* pArr, Js::TypedArrayBase* typedArrayBase, RecyclableObject* obj, int64 length, Arguments& args, ScriptContext* scriptContext);
         template <typename T = uint32>
         static Var ReduceHelper(JavascriptArray* pArr, Js::TypedArrayBase* typedArrayBase, RecyclableObject* obj, T length, Arguments& args, ScriptContext* scriptContext);
+        template <typename T>
+        static Var FilterHelper(JavascriptArray* pArr, RecyclableObject* obj, T length, Arguments& args, ScriptContext* scriptContext);
         template <typename T = uint32>
         static Var ReduceRightHelper(JavascriptArray* pArr, Js::TypedArrayBase* typedArrayBase, RecyclableObject* obj, T length, Arguments& args, ScriptContext* scriptContext);
         static Var OfHelper(bool isTypedArrayEntryPoint, Arguments& args, ScriptContext* scriptContext);


### PR DESCRIPTION
We were always going into the uint64 path for these helpers due to the way the logic of EntryFilter was written. Made a fix by factoring-out the bulk of this function into a templated version. 