### PR TITLE
Rejit and rethunk issues

### DIFF
--- a/lib/Backend/BailOut.cpp
+++ b/lib/Backend/BailOut.cpp
@@ -2154,6 +2154,8 @@ void BailOutRecord::ScheduleFunctionCodeGen(Js::ScriptFunction * function, Js::S
         }
 
         Assert(!(rejitReason != RejitReason::None && reThunk));
+
+        profileInfo->IncRejitCount();
     }
 
     if(PHASE_FORCE(Js::ReJITPhase, executeFunction) && rejitReason == RejitReason::None)

--- a/lib/Backend/BailOut.cpp
+++ b/lib/Backend/BailOut.cpp
@@ -1050,6 +1050,15 @@ Js::Var BailOutRecord::BailOut(BailOutRecord const * bailOutRecord)
 #endif
 
     Js::JavascriptCallStackLayout *const layout = bailOutRecord->GetStackLayout();
+    Js::ScriptFunction * function = (Js::ScriptFunction *)layout->functionObject;
+
+    if (bailOutRecord->bailOutKind == IR::BailOutOnImplicitCalls)
+    {
+        function->GetScriptContext()->GetThreadContext()->CheckAndResetImplicitCallAccessorFlag();
+    }
+
+    Js::ImplicitCallFlags savedImplicitCallFlags = function->GetScriptContext()->GetThreadContext()->GetImplicitCallFlags();
+
     if(bailOutRecord->globalBailOutRecordTable->isLoopBody)
     {
         if (bailOutRecord->globalBailOutRecordTable->isInlinedFunction)
@@ -1060,9 +1069,9 @@ Js::Var BailOutRecord::BailOut(BailOutRecord const * bailOutRecord)
     }
     if(bailOutRecord->globalBailOutRecordTable->isInlinedFunction)
     {
-        return BailOutInlined(layout, bailOutRecord, _ReturnAddress());
+        return BailOutInlined(layout, bailOutRecord, _ReturnAddress(), savedImplicitCallFlags);
     }
-    return BailOutFromFunction(layout, bailOutRecord, _ReturnAddress(), argoutRestoreAddr);
+    return BailOutFromFunction(layout, bailOutRecord, _ReturnAddress(), argoutRestoreAddr, savedImplicitCallFlags);
 }
 
 uint32
@@ -1073,18 +1082,18 @@ BailOutRecord::BailOutFromLoopBody(Js::JavascriptCallStackLayout * layout, BailO
 }
 
 Js::Var
-BailOutRecord::BailOutFromFunction(Js::JavascriptCallStackLayout * layout, BailOutRecord const * bailOutRecord, void * returnAddress, void * argoutRestoreAddress)
+BailOutRecord::BailOutFromFunction(Js::JavascriptCallStackLayout * layout, BailOutRecord const * bailOutRecord, void * returnAddress, void * argoutRestoreAddress, Js::ImplicitCallFlags savedImplicitCallFlags)
 {
     Assert(bailOutRecord->parent == nullptr);
 
-    return BailOutCommon(layout, bailOutRecord, bailOutRecord->bailOutOffset, returnAddress, bailOutRecord->bailOutKind, nullptr, nullptr, argoutRestoreAddress);
+    return BailOutCommon(layout, bailOutRecord, bailOutRecord->bailOutOffset, returnAddress, bailOutRecord->bailOutKind, savedImplicitCallFlags, nullptr, nullptr, argoutRestoreAddress);
 }
 
 Js::Var
-BailOutRecord::BailOutInlined(Js::JavascriptCallStackLayout * layout, BailOutRecord const * bailOutRecord, void * returnAddress)
+BailOutRecord::BailOutInlined(Js::JavascriptCallStackLayout * layout, BailOutRecord const * bailOutRecord, void * returnAddress, Js::ImplicitCallFlags savedImplicitCallFlags)
 {
     Assert(bailOutRecord->parent != nullptr);
-    return BailOutInlinedCommon(layout, bailOutRecord, bailOutRecord->bailOutOffset, returnAddress, bailOutRecord->bailOutKind);
+    return BailOutInlinedCommon(layout, bailOutRecord, bailOutRecord->bailOutOffset, returnAddress, bailOutRecord->bailOutKind, savedImplicitCallFlags);
 }
 
 uint32
@@ -1109,7 +1118,7 @@ BailOutRecord::BailOutCommonNoCodeGen(Js::JavascriptCallStackLayout * layout, Ba
 
 Js::Var
 BailOutRecord::BailOutCommon(Js::JavascriptCallStackLayout * layout, BailOutRecord const * bailOutRecord,
-uint32 bailOutOffset, void * returnAddress, IR::BailOutKind bailOutKind, Js::Var branchValue, BailOutReturnValue * bailOutReturnValue, void * argoutRestoreAddress)
+uint32 bailOutOffset, void * returnAddress, IR::BailOutKind bailOutKind, Js::ImplicitCallFlags savedImplicitCallFlags, Js::Var branchValue, BailOutReturnValue * bailOutReturnValue, void * argoutRestoreAddress)
 {
     // Do not remove the following code.
     // Need to capture the int registers on stack as threadContext->bailOutRegisterSaveSpace is allocated from ThreadAlloc and is not scanned by recycler.
@@ -1119,13 +1128,13 @@ uint32 bailOutOffset, void * returnAddress, IR::BailOutKind bailOutKind, Js::Var
         sizeof(registerSaves));
 
     Js::Var result = BailOutCommonNoCodeGen(layout, bailOutRecord, bailOutOffset, returnAddress, bailOutKind, branchValue, nullptr, bailOutReturnValue, argoutRestoreAddress);
-    ScheduleFunctionCodeGen(Js::ScriptFunction::FromVar(layout->functionObject), nullptr, bailOutRecord, bailOutKind, returnAddress);
+    ScheduleFunctionCodeGen(Js::ScriptFunction::FromVar(layout->functionObject), nullptr, bailOutRecord, bailOutKind, savedImplicitCallFlags, returnAddress);
     return result;
 }
 
 Js::Var
 BailOutRecord::BailOutInlinedCommon(Js::JavascriptCallStackLayout * layout, BailOutRecord const * bailOutRecord, uint32 bailOutOffset,
-    void * returnAddress, IR::BailOutKind bailOutKind, Js::Var branchValue)
+    void * returnAddress, IR::BailOutKind bailOutKind, Js::ImplicitCallFlags savedImplicitCallFlags, Js::Var branchValue)
 {
     Assert(bailOutRecord->parent != nullptr);
 
@@ -1140,7 +1149,7 @@ BailOutRecord::BailOutInlinedCommon(Js::JavascriptCallStackLayout * layout, Bail
     BailOutInlinedHelper(layout, currentBailOutRecord, bailOutOffset, returnAddress, bailOutKind, registerSaves, &bailOutReturnValue, &innerMostInlinee, false, branchValue);
     Js::Var result = BailOutCommonNoCodeGen(layout, currentBailOutRecord, currentBailOutRecord->bailOutOffset, returnAddress, bailOutKind, branchValue,
         registerSaves, &bailOutReturnValue);
-    ScheduleFunctionCodeGen(Js::ScriptFunction::FromVar(layout->functionObject), innerMostInlinee, currentBailOutRecord, bailOutKind, returnAddress);
+    ScheduleFunctionCodeGen(Js::ScriptFunction::FromVar(layout->functionObject), innerMostInlinee, currentBailOutRecord, bailOutKind, savedImplicitCallFlags, returnAddress);
     return result;
 }
 
@@ -1704,7 +1713,7 @@ BailOutRecord::BailOutHelper(Js::JavascriptCallStackLayout * layout, Js::ScriptF
 // we "rethunk" the bailing out function rather that incurring a rejit.
 
 void BailOutRecord::ScheduleFunctionCodeGen(Js::ScriptFunction * function, Js::ScriptFunction * innerMostInlinee,
-    BailOutRecord const * bailOutRecord, IR::BailOutKind bailOutKind, void * returnAddress)
+    BailOutRecord const * bailOutRecord, IR::BailOutKind bailOutKind, Js::ImplicitCallFlags savedImplicitCallFlags, void * returnAddress)
 {
     if (bailOutKind == IR::BailOnSimpleJitToFullJitLoopBody ||
         bailOutKind == IR::BailOutForGeneratorYield ||
@@ -1865,10 +1874,11 @@ void BailOutRecord::ScheduleFunctionCodeGen(Js::ScriptFunction * function, Js::S
                 // Check if the implicit call flags in the profile have changed since we last JITed this
                 // function body. If so, and they indicate an implicit call of some sort occurred
                 // then we need to reJIT.
-                if (executeFunction->GetSavedImplicitCallsFlags() == Js::ImplicitCall_None ||
-                    executeFunction->GetSavedImplicitCallsFlags() == Js::ImplicitCall_HasNoInfo)
+                if ((executeFunction->GetSavedImplicitCallsFlags() & savedImplicitCallFlags) == Js::ImplicitCall_None)
                 {
-                    profileInfo->RecordImplicitCallFlags(executeFunction->GetScriptContext()->GetThreadContext()->GetImplicitCallFlags());
+                    profileInfo->RecordImplicitCallFlags(savedImplicitCallFlags);
+                    Assert(!profileInfo->IsLoopImplicitCallInfoDisabled());
+                    profileInfo->DisableLoopImplicitCallInfo();
                     rejitReason = RejitReason::ImplicitCallFlagsChanged;
                 }
                 else
@@ -1894,7 +1904,17 @@ void BailOutRecord::ScheduleFunctionCodeGen(Js::ScriptFunction * function, Js::S
                 break;
 
             case IR::BailOutOnNotNativeArray:
-                rejitReason = RejitReason::ExpectingNativeArray;
+
+                // REVIEW: We have an issue with array profile info.  The info on the type of array we have won't 
+                //         get fixed by rejitting.  For now, just give up after 50 rejits.
+                if (profileInfo->GetRejitCount() >= 50)
+                {
+                    reThunk = true;
+                }
+                else
+                {
+                    rejitReason = RejitReason::ExpectingNativeArray;
+                }
                 break;
 
             case IR::BailOutConvertedNativeArray:
@@ -2095,7 +2115,7 @@ void BailOutRecord::ScheduleFunctionCodeGen(Js::ScriptFunction * function, Js::S
                         Output::Flush();
                     }
 #endif
-                    if (state <= executeFunction->GetSavedPolymorphicCacheState())
+                    if (state <= executeFunction->GetSavedPolymorphicCacheState() && executeFunction->GetDefaultEntryPointInfo()->address != function->GetEntryPoint())
                     {
                         reThunk = true;
                     }
@@ -2110,7 +2130,7 @@ void BailOutRecord::ScheduleFunctionCodeGen(Js::ScriptFunction * function, Js::S
 
             case IR::BailOutFailedEquivalentTypeCheck:
             case IR::BailOutFailedEquivalentFixedFieldTypeCheck:
-                if (profileInfo->IsEquivalentObjTypeSpecDisabled())
+                if (profileInfo->IsEquivalentObjTypeSpecDisabled() && executeFunction->GetDefaultEntryPointInfo()->address != function->GetEntryPoint())
                 {
                     reThunk = true;
                 }
@@ -2154,13 +2174,26 @@ void BailOutRecord::ScheduleFunctionCodeGen(Js::ScriptFunction * function, Js::S
         }
 
         Assert(!(rejitReason != RejitReason::None && reThunk));
-
-        profileInfo->IncRejitCount();
     }
 
     if(PHASE_FORCE(Js::ReJITPhase, executeFunction) && rejitReason == RejitReason::None)
     {
         rejitReason = RejitReason::Forced;
+    }
+
+    // REVIEW: Temporary fix for RS1.  Disable Rejiting if it looks like it is not fixing the problem.
+    //         For RS2, turn this into an assert and let's fix all these issues.
+    if (!reThunk && rejitReason != RejitReason::None)
+    {
+        if (executeFunction->GetDynamicProfileInfo()->GetRejitCount() >= 100)
+        {
+            reThunk = true;
+            rejitReason = RejitReason::None;
+        }
+        else
+        {
+            executeFunction->GetDynamicProfileInfo()->IncRejitCount();
+        }
     }
 
     REJIT_KIND_TESTTRACE(bailOutKind, _u("Bailout from function: function: %s, bailOutKindName: (%S), bailOutCount: %d, callCount: %d, reJitReason: %S, reThunk: %s\r\n"),
@@ -2583,6 +2616,15 @@ Js::Var BranchBailOutRecord::BailOut(BranchBailOutRecord const * bailOutRecord, 
 #endif
 
     Js::JavascriptCallStackLayout *const layout = bailOutRecord->GetStackLayout();
+    Js::ScriptFunction * function = (Js::ScriptFunction *)layout->functionObject;
+
+    if (bailOutRecord->bailOutKind == IR::BailOutOnImplicitCalls)
+    {
+        function->GetScriptContext()->GetThreadContext()->CheckAndResetImplicitCallAccessorFlag();
+    }
+
+    Js::ImplicitCallFlags savedImplicitCallFlags = function->GetScriptContext()->GetThreadContext()->GetImplicitCallFlags();
+
     if(bailOutRecord->globalBailOutRecordTable->isLoopBody)
     {
         if (bailOutRecord->globalBailOutRecordTable->isInlinedFunction)
@@ -2593,13 +2635,13 @@ Js::Var BranchBailOutRecord::BailOut(BranchBailOutRecord const * bailOutRecord, 
     }
     if(bailOutRecord->globalBailOutRecordTable->isInlinedFunction)
     {
-        return BailOutInlined(layout, bailOutRecord, cond, _ReturnAddress());
+        return BailOutInlined(layout, bailOutRecord, cond, _ReturnAddress(), savedImplicitCallFlags);
     }
-    return BailOutFromFunction(layout, bailOutRecord, cond, _ReturnAddress(), argoutRestoreAddr);
+    return BailOutFromFunction(layout, bailOutRecord, cond, _ReturnAddress(), argoutRestoreAddr, savedImplicitCallFlags);
 }
 
 Js::Var
-BranchBailOutRecord::BailOutFromFunction(Js::JavascriptCallStackLayout * layout, BranchBailOutRecord const * bailOutRecord, BOOL cond, void * returnAddress, void * argoutRestoreAddress)
+BranchBailOutRecord::BailOutFromFunction(Js::JavascriptCallStackLayout * layout, BranchBailOutRecord const * bailOutRecord, BOOL cond, void * returnAddress, void * argoutRestoreAddress, Js::ImplicitCallFlags savedImplicitCallFlags)
 {
     Assert(bailOutRecord->parent == nullptr);
     uint32 bailOutOffset = cond? bailOutRecord->bailOutOffset : bailOutRecord->falseBailOutOffset;
@@ -2609,7 +2651,7 @@ BranchBailOutRecord::BailOutFromFunction(Js::JavascriptCallStackLayout * layout,
         Js::ScriptContext *scriptContext = layout->functionObject->GetScriptContext();
         branchValue = (cond ? scriptContext->GetLibrary()->GetTrue() : scriptContext->GetLibrary()->GetFalse());
     }
-    return __super::BailOutCommon(layout, bailOutRecord, bailOutOffset, returnAddress, bailOutRecord->bailOutKind,  branchValue, nullptr, argoutRestoreAddress);
+    return __super::BailOutCommon(layout, bailOutRecord, bailOutOffset, returnAddress, bailOutRecord->bailOutKind, savedImplicitCallFlags, branchValue, nullptr, argoutRestoreAddress);
 }
 
 uint32
@@ -2627,7 +2669,7 @@ BranchBailOutRecord::BailOutFromLoopBody(Js::JavascriptCallStackLayout * layout,
 }
 
 Js::Var
-BranchBailOutRecord::BailOutInlined(Js::JavascriptCallStackLayout * layout, BranchBailOutRecord const * bailOutRecord, BOOL cond, void * returnAddress)
+BranchBailOutRecord::BailOutInlined(Js::JavascriptCallStackLayout * layout, BranchBailOutRecord const * bailOutRecord, BOOL cond, void * returnAddress, Js::ImplicitCallFlags savedImplicitCallFlags)
 {
     Assert(bailOutRecord->parent != nullptr);
     uint32 bailOutOffset = cond? bailOutRecord->bailOutOffset : bailOutRecord->falseBailOutOffset;
@@ -2637,7 +2679,7 @@ BranchBailOutRecord::BailOutInlined(Js::JavascriptCallStackLayout * layout, Bran
         Js::ScriptContext *scriptContext = layout->functionObject->GetScriptContext();
         branchValue = (cond ? scriptContext->GetLibrary()->GetTrue() : scriptContext->GetLibrary()->GetFalse());
     }
-    return __super::BailOutInlinedCommon(layout, bailOutRecord, bailOutOffset, returnAddress, bailOutRecord->bailOutKind, branchValue);
+    return __super::BailOutInlinedCommon(layout, bailOutRecord, bailOutOffset, returnAddress, bailOutRecord->bailOutKind, savedImplicitCallFlags, branchValue);
 }
 
 uint32

--- a/lib/Backend/BailOut.h
+++ b/lib/Backend/BailOut.h
@@ -166,10 +166,10 @@ class BailOutRecord
 public:
     BailOutRecord(uint32 bailOutOffset, uint bailOutCacheIndex, IR::BailOutKind kind, Func *bailOutFunc);
     static Js::Var BailOut(BailOutRecord const * bailOutRecord);
-    static Js::Var BailOutFromFunction(Js::JavascriptCallStackLayout * layout, BailOutRecord const * bailOutRecord, void * returnAddress, void * argoutRestoreAddress);
+    static Js::Var BailOutFromFunction(Js::JavascriptCallStackLayout * layout, BailOutRecord const * bailOutRecord, void * returnAddress, void * argoutRestoreAddress, Js::ImplicitCallFlags savedImplicitCallFlags);
     static uint32 BailOutFromLoopBody(Js::JavascriptCallStackLayout * layout, BailOutRecord const * bailOutRecord);
 
-    static Js::Var BailOutInlined(Js::JavascriptCallStackLayout * layout, BailOutRecord const * bailOutRecord, void * returnAddress);
+    static Js::Var BailOutInlined(Js::JavascriptCallStackLayout * layout, BailOutRecord const * bailOutRecord, void * returnAddress, Js::ImplicitCallFlags savedImplicitCallFlags);
     static uint32 BailOutFromLoopBodyInlined(Js::JavascriptCallStackLayout * layout, BailOutRecord const * bailOutRecord, void * returnAddress);
 
     static Js::Var BailOutForElidedYield(void * framePointer);
@@ -217,9 +217,9 @@ protected:
         uint32 bailOutOffset, void * returnAddress, IR::BailOutKind bailOutKind, Js::Var branchValue = nullptr, Js::Var * registerSaves = nullptr,
         BailOutReturnValue * returnValue = nullptr, void * argoutRestoreAddress = nullptr);
     static Js::Var BailOutCommon(Js::JavascriptCallStackLayout * layout, BailOutRecord const * bailOutRecord,
-        uint32 bailOutOffset, void * returnAddress, IR::BailOutKind bailOutKind, Js::Var branchValue = nullptr, BailOutReturnValue * returnValue = nullptr, void * argoutRestoreAddress = nullptr);
+        uint32 bailOutOffset, void * returnAddress, IR::BailOutKind bailOutKind, Js::ImplicitCallFlags savedImplicitCallFlags, Js::Var branchValue = nullptr, BailOutReturnValue * returnValue = nullptr, void * argoutRestoreAddress = nullptr);
     static Js::Var BailOutInlinedCommon(Js::JavascriptCallStackLayout * layout, BailOutRecord const * bailOutRecord,
-        uint32 bailOutOffset, void * returnAddress, IR::BailOutKind bailOutKind, Js::Var branchValue = nullptr);
+        uint32 bailOutOffset, void * returnAddress, IR::BailOutKind bailOutKind, Js::ImplicitCallFlags savedImplicitCallFlags, Js::Var branchValue = nullptr);
     static uint32 BailOutFromLoopBodyCommon(Js::JavascriptCallStackLayout * layout, BailOutRecord const * bailOutRecord,
         uint32 bailOutOffset, IR::BailOutKind bailOutKind, Js::Var branchValue = nullptr);
     static uint32 BailOutFromLoopBodyInlinedCommon(Js::JavascriptCallStackLayout * layout, BailOutRecord const * bailOutRecord,
@@ -235,7 +235,7 @@ protected:
 
     static void UpdatePolymorphicFieldAccess(Js::JavascriptFunction *  function, BailOutRecord const * bailOutRecord);
 
-    static void ScheduleFunctionCodeGen(Js::ScriptFunction * function, Js::ScriptFunction * innerMostInlinee, BailOutRecord const * bailOutRecord, IR::BailOutKind bailOutKind, void * returnAddress);
+    static void ScheduleFunctionCodeGen(Js::ScriptFunction * function, Js::ScriptFunction * innerMostInlinee, BailOutRecord const * bailOutRecord, IR::BailOutKind bailOutKind, Js::ImplicitCallFlags savedImplicitCallFlags, void * returnAddress);
     static void ScheduleLoopBodyCodeGen(Js::ScriptFunction * function, Js::ScriptFunction * innerMostInlinee, BailOutRecord const * bailOutRecord, IR::BailOutKind bailOutKind);
 
     void RestoreValues(IR::BailOutKind bailOutKind, Js::JavascriptCallStackLayout * layout, Js::InterpreterStackFrame * newInstance, Js::ScriptContext * scriptContext,
@@ -337,10 +337,10 @@ public:
     BranchBailOutRecord(uint32 trueBailOutOffset, uint32 falseBailOutOffset, Js::RegSlot resultByteCodeReg, IR::BailOutKind kind, Func *bailOutFunc);
 
     static Js::Var BailOut(BranchBailOutRecord const * bailOutRecord, BOOL cond);
-    static Js::Var BailOutFromFunction(Js::JavascriptCallStackLayout * layout, BranchBailOutRecord const * bailOutRecord, BOOL cond, void * returnAddress, void * argoutRestoreAddress);
+    static Js::Var BailOutFromFunction(Js::JavascriptCallStackLayout * layout, BranchBailOutRecord const * bailOutRecord, BOOL cond, void * returnAddress, void * argoutRestoreAddress, Js::ImplicitCallFlags savedImplicitCallFlags);
     static uint32 BailOutFromLoopBody(Js::JavascriptCallStackLayout * layout, BranchBailOutRecord const * bailOutRecord, BOOL cond);
 
-    static Js::Var BailOutInlined(Js::JavascriptCallStackLayout * layout, BranchBailOutRecord const * bailOutRecord, BOOL cond, void * returnAddress);
+    static Js::Var BailOutInlined(Js::JavascriptCallStackLayout * layout, BranchBailOutRecord const * bailOutRecord, BOOL cond, void * returnAddress, Js::ImplicitCallFlags savedImplicitCallFlags);
     static uint32 BailOutFromLoopBodyInlined(Js::JavascriptCallStackLayout * layout, BranchBailOutRecord const * bailOutRecord, BOOL cond, void * returnAddress);
 private:
     uint falseBailOutOffset;

--- a/lib/Backend/FlowGraph.cpp
+++ b/lib/Backend/FlowGraph.cpp
@@ -761,6 +761,10 @@ FlowGraph::BuildLoop(BasicBlock *headBlock, BasicBlock *tailBlock, Loop *parentL
     if (firstInstr->IsProfiledLabelInstr())
     {
         loop->SetImplicitCallFlags(firstInstr->AsProfiledLabelInstr()->loopImplicitCallFlags);
+        if (this->func->GetProfileInfo()->IsLoopImplicitCallInfoDisabled())
+        {
+            loop->SetImplicitCallFlags(this->func->GetProfileInfo()->GetImplicitCallFlags());
+        }
         loop->SetLoopFlags(firstInstr->AsProfiledLabelInstr()->loopFlags);
     }
     else

--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -568,7 +568,7 @@ PHASE(All)
 #define DEFAULT_CONFIG_SkipFuncCountForBailOnNoProfile (0) //Initial Number of functions in a func body to be skipped from forcibly inserting BailOnNoProfile.
 #endif
 #define DEFAULT_CONFIG_BailOnNoProfileLimit    200      // The limit of bailout on no profile info before triggering a rejit
-#define DEFAULT_CONFIG_BailOnNoProfileRejitLimit (-1)   // The limit of bailout on no profile info before disable all the no profile bailouts
+#define DEFAULT_CONFIG_BailOnNoProfileRejitLimit (50)   // The limit of bailout on no profile info before disable all the no profile bailouts
 #define DEFAULT_CONFIG_CallsToBailoutsRatioForRejit 5   // Ratio of function calls to bailouts on a single bailout record
                                                         // above which a rejit is considered
 #define DEFAULT_CONFIG_MinBailOutsBeforeRejit 2         // Minimum number of bailouts for a single bailout record after which a rejit is considered

--- a/lib/Runtime/Language/DynamicProfileInfo.cpp
+++ b/lib/Runtime/Language/DynamicProfileInfo.cpp
@@ -187,6 +187,8 @@ namespace Js
         {
             returnTypeInfo[i] = ValueType::Uninitialized;
         }
+
+        this->rejitCount = 0;
 #if DBG
         for (ProfileId i = 0; i < functionBody->GetProfiledArrayCallSiteCount(); ++i)
         {

--- a/lib/Runtime/Language/DynamicProfileInfo.h
+++ b/lib/Runtime/Language/DynamicProfileInfo.h
@@ -507,6 +507,7 @@ namespace Js
 
 #if DBG
         bool persistsAcrossScriptContexts;
+        uint16 rejitCount;
 #endif
         static JavascriptMethod EnsureDynamicProfileInfo(Js::ScriptFunction * function);
 #if DBG_DUMP
@@ -780,6 +781,9 @@ namespace Js
         void DisableObjTypeSpecInJitLoopBody() { this->bits.disableObjTypeSpec_jitLoopBody = true; }
 
         static bool IsCallSiteNoInfo(Js::LocalFunctionId functionId) { return functionId == CallSiteNoInfo; }
+#if DBG
+        void IncRejitCount() { this->rejitCount++;  Assert(this->rejitCount < 100); }
+#endif
 #if DBG_DUMP
         void Dump(FunctionBody* functionBody, ArenaAllocator * dynamicProfileInfoAllocator = nullptr);
 #endif

--- a/lib/Runtime/Language/DynamicProfileInfo.h
+++ b/lib/Runtime/Language/DynamicProfileInfo.h
@@ -498,16 +498,17 @@ namespace Js
             bool disableSwitchOpt : 1;
             bool disableEquivalentObjTypeSpec : 1;
             bool disableObjTypeSpec_jitLoopBody : 1;
+            bool disableLoopImplicitCallInfo : 1;
         } bits;
 
         uint32 m_recursiveInlineInfo; // Bit is set for each callsites where the function is called recursively
-        BYTE currentInlinerVersion; // Used to detect when inlining profile changes
         uint32 polymorphicCacheState;
+        uint16 rejitCount;
+        BYTE currentInlinerVersion; // Used to detect when inlining profile changes
         bool hasFunctionBody;
 
 #if DBG
         bool persistsAcrossScriptContexts;
-        uint16 rejitCount;
 #endif
         static JavascriptMethod EnsureDynamicProfileInfo(Js::ScriptFunction * function);
 #if DBG_DUMP
@@ -642,6 +643,8 @@ namespace Js
         void DisableFloatTypeSpec() { this->bits.disableFloatTypeSpec = true; }
         bool IsCheckThisDisabled() const { return this->bits.disableCheckThis; }
         void DisableCheckThis() { this->bits.disableCheckThis = true; }
+        bool IsLoopImplicitCallInfoDisabled() const { return this->bits.disableLoopImplicitCallInfo; }
+        void DisableLoopImplicitCallInfo() { this->bits.disableLoopImplicitCallInfo = true; }
 
         bool IsArrayCheckHoistDisabled(const bool isJitLoopBody) const
         {
@@ -781,9 +784,9 @@ namespace Js
         void DisableObjTypeSpecInJitLoopBody() { this->bits.disableObjTypeSpec_jitLoopBody = true; }
 
         static bool IsCallSiteNoInfo(Js::LocalFunctionId functionId) { return functionId == CallSiteNoInfo; }
-#if DBG
-        void IncRejitCount() { this->rejitCount++;  Assert(this->rejitCount < 100); }
-#endif
+        int IncRejitCount() { return this->rejitCount++; }
+        int GetRejitCount() { return this->rejitCount; }
+
 #if DBG_DUMP
         void Dump(FunctionBody* functionBody, ArenaAllocator * dynamicProfileInfoAllocator = nullptr);
 #endif

--- a/lib/Runtime/Language/ReadOnlyDynamicProfileInfo.h
+++ b/lib/Runtime/Language/ReadOnlyDynamicProfileInfo.h
@@ -48,6 +48,7 @@ namespace Js
             isSwitchOptDisabled(false),
             isEquivalentObjTypeSpecDisabled(false),
             isObjTypeSpecDisabled_jitLoopBody(false),
+            isLoopImplicitCallInfoDisabled(false),
             ldElemInfo(nullptr),
             stElemInfo(nullptr)
         {
@@ -85,6 +86,7 @@ namespace Js
             this->isSwitchOptDisabled = profileInfo->IsSwitchOptDisabled();
             this->isEquivalentObjTypeSpecDisabled = profileInfo->IsEquivalentObjTypeSpecDisabled();
             this->isObjTypeSpecDisabled_jitLoopBody = profileInfo->IsObjTypeSpecDisabledInJitLoopBody();
+            this->isLoopImplicitCallInfoDisabled = profileInfo->IsLoopImplicitCallInfoDisabled();
         }
 
         void OnBackgroundAllocatorReset()
@@ -340,6 +342,12 @@ namespace Js
             return this->isNoProfileBailoutsDisabled;
         }
 
+        bool IsLoopImplicitCallInfoDisabled() const
+        {
+            return this->isLoopImplicitCallInfoDisabled;
+        }
+
+
     private:
         const DynamicProfileInfo * profileInfo;
         ArenaAllocator *const backgroundAllocator; // null if the work item is being jitted in the foreground
@@ -375,6 +383,7 @@ namespace Js
         bool isSwitchOptDisabled : 1;
         bool isEquivalentObjTypeSpecDisabled : 1;
         bool isObjTypeSpecDisabled_jitLoopBody : 1;
+        bool isLoopImplicitCallInfoDisabled : 1;
         const LdElemInfo *ldElemInfo;
         const StElemInfo *stElemInfo;
 


### PR DESCRIPTION
Fix a few rejits and rethunk issues: 
o  give up on bailOnNoProfile after 50 rejits (we can get in these situation on paths that always throw an exception) 
o  give up on bailOnNotNativeArray after 50 rejits (bailout does not fix the profile info for array types...) 
o  give up in general after 100 rejits...  Just Rethunk. 
o  for bailOnFailedFixedFieldType, the polymorphic cache state isn't affected if we just invalidated the guard.  Check if we are rethunking to the same JITed code, and rejit instead. 
o  for post-op bailOnImplicitCalls, the implicitCallFlags were not propagated correctly.  I've made a temporary fix to conservatively propagate it.

These were hitting on mobile.nytimes.com

For RS2, we should cleanup some of these with better fixes...
