### PR TITLE
Fix AllocationPolicyManager and enable a real memory limit on Posix/Unix

### DIFF
--- a/bin/ch/CMakeLists.txt
+++ b/bin/ch/CMakeLists.txt
@@ -27,6 +27,7 @@ set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fPIE -pie")
 target_link_libraries (ch
   PRIVATE Chakra.Pal
   PRIVATE Chakra.Common.Codex
+  PRIVATE Chakra.Runtime.PlatformAgnostic
   -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/ch.version
   )
 

--- a/bin/ch/ChakraRtInterface.cpp
+++ b/bin/ch/ChakraRtInterface.cpp
@@ -69,6 +69,7 @@ HINSTANCE ChakraRTInterface::LoadChakraDll(ArgInfo* argInfo)
 
     m_jsApiHooks.pfJsrtCreateRuntime = (JsAPIHooks::JsrtCreateRuntimePtr)GetChakraCoreSymbol(library, "JsCreateRuntime");
     m_jsApiHooks.pfJsrtCreateContext = (JsAPIHooks::JsrtCreateContextPtr)GetChakraCoreSymbol(library, "JsCreateContext");
+    m_jsApiHooks.pfJsrtSetRuntimeMemoryLimit = (JsAPIHooks::JsrtSetRuntimeMemoryLimitPtr)GetChakraCoreSymbol(library, "JsSetRuntimeMemoryLimit");
     m_jsApiHooks.pfJsrtSetCurrentContext = (JsAPIHooks::JsrtSetCurrentContextPtr)GetChakraCoreSymbol(library, "JsSetCurrentContext");
     m_jsApiHooks.pfJsrtGetCurrentContext = (JsAPIHooks::JsrtGetCurrentContextPtr)GetChakraCoreSymbol(library, "JsGetCurrentContext");
     m_jsApiHooks.pfJsrtDisposeRuntime = (JsAPIHooks::JsrtDisposeRuntimePtr)GetChakraCoreSymbol(library, "JsDisposeRuntime");

--- a/bin/ch/ChakraRtInterface.h
+++ b/bin/ch/ChakraRtInterface.h
@@ -8,6 +8,7 @@ struct JsAPIHooks
 {
     typedef JsErrorCode (WINAPI *JsrtCreateRuntimePtr)(JsRuntimeAttributes attributes, JsThreadServiceCallback threadService, JsRuntimeHandle *runtime);
     typedef JsErrorCode (WINAPI *JsrtCreateContextPtr)(JsRuntimeHandle runtime, JsContextRef *newContext);
+    typedef JsErrorCode (WINAPI *JsrtSetRuntimeMemoryLimitPtr)(JsRuntimeHandle runtime, size_t memoryLimit);
     typedef JsErrorCode (WINAPI *JsrtSetCurrentContextPtr)(JsContextRef context);
     typedef JsErrorCode (WINAPI *JsrtGetCurrentContextPtr)(JsContextRef* context);
     typedef JsErrorCode (WINAPI *JsrtDisposeRuntimePtr)(JsRuntimeHandle runtime);
@@ -75,6 +76,7 @@ struct JsAPIHooks
 
     JsrtCreateRuntimePtr pfJsrtCreateRuntime;
     JsrtCreateContextPtr pfJsrtCreateContext;
+    JsrtSetRuntimeMemoryLimitPtr pfJsrtSetRuntimeMemoryLimit;
     JsrtSetCurrentContextPtr pfJsrtSetCurrentContext;
     JsrtGetCurrentContextPtr pfJsrtGetCurrentContext;
     JsrtDisposeRuntimePtr pfJsrtDisposeRuntime;
@@ -216,6 +218,7 @@ public:
 
     static JsErrorCode WINAPI JsCreateRuntime(JsRuntimeAttributes attributes, JsThreadServiceCallback threadService, JsRuntimeHandle *runtime) { return m_jsApiHooks.pfJsrtCreateRuntime(attributes, threadService, runtime); }
     static JsErrorCode WINAPI JsCreateContext(JsRuntimeHandle runtime, JsContextRef *newContext) { return m_jsApiHooks.pfJsrtCreateContext(runtime, newContext); }
+    static JsErrorCode WINAPI JsSetRuntimeMemoryLimit(JsRuntimeHandle runtime, size_t memory) { return m_jsApiHooks.pfJsrtSetRuntimeMemoryLimit(runtime, memory); }
     static JsErrorCode WINAPI JsSetCurrentContext(JsContextRef context) { return m_jsApiHooks.pfJsrtSetCurrentContext(context); }
     static JsErrorCode WINAPI JsGetCurrentContext(JsContextRef* context) { return m_jsApiHooks.pfJsrtGetCurrentContext(context); }
     static JsErrorCode WINAPI JsDisposeRuntime(JsRuntimeHandle runtime) { return m_jsApiHooks.pfJsrtDisposeRuntime(runtime); }

--- a/bin/ch/ch.cpp
+++ b/bin/ch/ch.cpp
@@ -261,6 +261,28 @@ Error:
     return hr;
 }
 
+static HRESULT CreateRuntime(JsRuntimeHandle *runtime)
+{
+    HRESULT hr = E_FAIL;
+    IfJsErrorFailLog(ChakraRTInterface::JsCreateRuntime(jsrtAttributes, nullptr, runtime));
+
+#ifndef _WIN32
+    // On Posix, malloc may not return NULL even if there is no
+    // memory left. However, kernel will send SIGKILL to process
+    // in case we use that `not actually available` memory address.
+    // (See posix man malloc and OOM)
+
+    size_t memoryLimit;
+    if (PlatformAgnostic::SystemInfo::GetTotalRam(&memoryLimit))
+    {
+        IfJsErrorFailLog(ChakraRTInterface::JsSetRuntimeMemoryLimit(*runtime, memoryLimit));
+    }
+#endif
+    hr = S_OK;
+Error:
+    return hr;
+}
+
 HRESULT CreateAndRunSerializedScript(const char* fileName, LPCSTR fileContents, char *fullPath)
 {
     HRESULT hr = S_OK;
@@ -272,7 +294,7 @@ HRESULT CreateAndRunSerializedScript(const char* fileName, LPCSTR fileContents, 
 
     // Bytecode buffer is created in one runtime and will be executed on different runtime.
 
-    IfJsErrorFailLog(ChakraRTInterface::JsCreateRuntime(jsrtAttributes, nullptr, &runtime));
+    IfFailGo(CreateRuntime(&runtime));
 
     IfJsErrorFailLog(ChakraRTInterface::JsCreateContext(runtime, &context));
     IfJsErrorFailLog(ChakraRTInterface::JsGetCurrentContext(&current));
@@ -324,7 +346,7 @@ HRESULT ExecuteTest(const char* fileName)
     {
         jsrtAttributes = (JsRuntimeAttributes)(jsrtAttributes | JsRuntimeAttributeSerializeLibraryByteCode);
     }
-    IfJsErrorFailLog(ChakraRTInterface::JsCreateRuntime(jsrtAttributes, nullptr, &runtime));
+    IfFailGo(CreateRuntime(&runtime));
 
     if (HostConfigFlags::flags.DebugLaunch)
     {

--- a/lib/Common/CommonPal.h
+++ b/lib/Common/CommonPal.h
@@ -628,3 +628,4 @@ namespace PlatformAgnostic
 
 #include "PlatformAgnostic/DateTime.h"
 #include "PlatformAgnostic/Numbers.h"
+#include "PlatformAgnostic/SystemInfo.h"

--- a/lib/Common/PlatformAgnostic/SystemInfo.h
+++ b/lib/Common/PlatformAgnostic/SystemInfo.h
@@ -1,0 +1,37 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#ifndef RUNTIME_PLATFORM_AGNOSTIC_COMMON_SYSTEMINFO
+#define RUNTIME_PLATFORM_AGNOSTIC_COMMON_SYSTEMINFO
+
+namespace PlatformAgnostic
+{
+    class SystemInfo
+    {
+
+        class PlatformData
+        {
+            public:
+            size_t totalRam;
+
+            PlatformData();
+        };
+        static PlatformData data;
+    public:
+
+        static bool GetTotalRam(size_t *totalRam)
+        {
+            if (SystemInfo::data.totalRam == 0)
+            {
+                return false;
+            }
+
+            *totalRam = SystemInfo::data.totalRam;
+            return true;
+        }
+    };
+} // namespace PlatformAgnostic
+
+#endif // RUNTIME_PLATFORM_AGNOSTIC_COMMON_SYSTEMINFO

--- a/lib/Runtime/Library/ArrayBuffer.cpp
+++ b/lib/Runtime/Library/ArrayBuffer.cpp
@@ -447,22 +447,33 @@ namespace Js
                 buffer = (BYTE*)allocator(length);
                 if (buffer == nullptr)
                 {
-                    recycler->CollectNow<CollectOnTypedArrayAllocation>();
+                    recycler->ReportExternalMemoryFree(length);
+                }
+            }
+
+            if (buffer == nullptr)
+            {
+                recycler->CollectNow<CollectOnTypedArrayAllocation>();
+
+                if (recycler->ReportExternalMemoryAllocation(length))
+                {
                     buffer = (BYTE*)allocator(length);
                     if (buffer == nullptr)
                     {
                         recycler->ReportExternalMemoryFailure(length);
                     }
                 }
+                else
+                {
+                    JavascriptError::ThrowOutOfMemoryError(GetScriptContext());
+                }
             }
 
-            if (buffer == nullptr)
+            if (buffer != nullptr)
             {
-                JavascriptError::ThrowOutOfMemoryError(GetScriptContext());
+                bufferLength = length;
+                ZeroMemory(buffer, bufferLength);
             }
-
-            bufferLength = length;
-            ZeroMemory(buffer, bufferLength);
         }
     }
 
@@ -854,30 +865,37 @@ namespace Js
             // matching scriptContext might have been deleted and the javascriptLibrary->scriptContext
             // field reset (but javascriptLibrary is still alive).
             // Use the recycler field off library instead of scriptcontext to avoid av.
+
+            // Recycler may not be available at Dispose. We need to
+            // free the memory and report that it has been freed at the same
+            // time. Otherwise, AllocationPolicyManager is unable to provide correct feedback
+#if _WIN64
+            //AsmJS Virtual Free
+            //TOD - see if isBufferCleared need to be added for free too
+            if (IsValidVirtualBufferLength(this->bufferLength) && !isBufferCleared)
+            {
+              LPVOID startBuffer = (LPVOID)((uint64)buffer);
+              BOOL fSuccess = VirtualFree((LPVOID)startBuffer, 0, MEM_RELEASE);
+              Assert(fSuccess);
+              isBufferCleared = true;
+            }
+            else
+            {
+              free(buffer);
+            }
+#else
+            free(buffer);
+#endif
             Recycler* recycler = GetType()->GetLibrary()->GetRecycler();
             recycler->ReportExternalMemoryFree(bufferLength);
+
+            buffer = nullptr;
+            bufferLength = 0;
     }
 
     void JavascriptArrayBuffer::Dispose(bool isShutdown)
     {
-
-#if _WIN64
-        //AsmJS Virtual Free
-        //TOD - see if isBufferCleared need to be added for free too
-        if (IsValidVirtualBufferLength(this->bufferLength) && !isBufferCleared)
-        {
-            LPVOID startBuffer = (LPVOID)((uint64)buffer);
-            BOOL fSuccess = VirtualFree((LPVOID)startBuffer, 0, MEM_RELEASE);
-            Assert(fSuccess);
-            isBufferCleared = true;
-        }
-        else
-        {
-            free(buffer);
-        }
-#else
-        free(buffer);
-#endif
+        /* See JavascriptArrayBuffer::Finalize */
     }
 
     ArrayBuffer * JavascriptArrayBuffer::TransferInternal(uint32 newBufferLength)
@@ -895,7 +913,11 @@ namespace Js
             {
                 if (!recycler->ReportExternalMemoryAllocation(newBufferLength - this->bufferLength))
                 {
-                    JavascriptError::ThrowOutOfMemoryError(GetScriptContext());
+                    recycler->CollectNow<CollectOnTypedArrayAllocation>();
+                    if (!recycler->ReportExternalMemoryAllocation(newBufferLength - this->bufferLength))
+                    {
+                        JavascriptError::ThrowOutOfMemoryError(GetScriptContext());
+                    }
                 }
             }
             // Contracting buffer

--- a/lib/Runtime/PlatformAgnostic/Chakra.Runtime.PlatformAgnostic.vcxproj
+++ b/lib/Runtime/PlatformAgnostic/Chakra.Runtime.PlatformAgnostic.vcxproj
@@ -44,6 +44,7 @@
     <ClCompile Include="Platform\Windows\HiResTimer.cpp" />
     <ClCompile Include="Platform\Windows\UnicodeText.cpp" />
     <ClCompile Include="Platform\Windows\NumbersUtility.cpp" />
+    <ClCompile Include="Platform\Windows\SystemInfo.cpp" />
 
     <ClCompile Include="Platform\Common\UnicodeText.Common.cpp" />
   </ItemGroup>

--- a/lib/Runtime/PlatformAgnostic/Platform/CMakeLists.txt
+++ b/lib/Runtime/PlatformAgnostic/Platform/CMakeLists.txt
@@ -2,13 +2,25 @@ project(CHAKRA_PLATFORM_AGNOSTIC)
 
 check_function_exists(gmtime_r HAVE_GMTIME_R)
 
+if(CMAKE_SYSTEM_NAME STREQUAL Linux)
 add_library (Chakra.Runtime.PlatformAgnostic
   Linux/UnicodeText.ICU.cpp
   Linux/DateTime.cpp
   Linux/HiResTimer.cpp
   Linux/NumbersUtility.cpp
+  Linux/SystemInfo.cpp
   Common/UnicodeText.Common.cpp
   )
+elseif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+add_library (Chakra.Runtime.PlatformAgnostic
+  #Linux/UnicodeText.ICU.cpp
+  #Linux/DateTime.cpp
+  #Linux/HiResTimer.cpp
+  Unix/SystemInfo.cpp
+  Common/UnicodeText.Common.cpp
+  )
+endif()
+
   
 target_include_directories (
     Chakra.Runtime.PlatformAgnostic PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/lib/Runtime/PlatformAgnostic/Platform/Linux/SystemInfo.cpp
+++ b/lib/Runtime/PlatformAgnostic/Platform/Linux/SystemInfo.cpp
@@ -1,0 +1,26 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#include "Common.h"
+#include "ChakraPlatform.h"
+#include <sys/sysinfo.h>
+
+namespace PlatformAgnostic
+{
+    SystemInfo::PlatformData SystemInfo::data;
+
+    SystemInfo::PlatformData::PlatformData()
+    {
+        struct sysinfo systemInfo;
+        if (sysinfo(&systemInfo) == -1)
+        {
+            totalRam = 0;
+        }
+        else
+        {
+            totalRam = systemInfo.totalram;
+        }
+    }
+}

--- a/lib/Runtime/PlatformAgnostic/Platform/Unix/SystemInfo.cpp
+++ b/lib/Runtime/PlatformAgnostic/Platform/Unix/SystemInfo.cpp
@@ -1,0 +1,25 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#include "Common.h"
+#include "ChakraPlatform.h"
+#include <sys/sysctl.h>
+
+namespace PlatformAgnostic
+{
+    SystemInfo::PlatformData SystemInfo::data;
+
+    SystemInfo::PlatformData::PlatformData()
+    {
+        // Get Total Ram
+        int totalRamHW [] = { CTL_HW, HW_MEMSIZE };
+
+        size_t length = sizeof(size_t);
+        if(sysctl(totalRamHW, 2, &totalRam, &length, NULL, 0) == -1)
+        {
+            totalRam = 0;
+        }
+    }
+}

--- a/lib/Runtime/PlatformAgnostic/Platform/Windows/SystemInfo.cpp
+++ b/lib/Runtime/PlatformAgnostic/Platform/Windows/SystemInfo.cpp
@@ -1,0 +1,22 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#include "RuntimePlatformAgnosticPch.h"
+#include "Common.h"
+#include "ChakraPlatform.h"
+
+namespace PlatformAgnostic
+{
+    SystemInfo::PlatformData SystemInfo::data;
+
+    SystemInfo::PlatformData::PlatformData()
+    {
+        ULONGLONG ram;
+        if (GetPhysicallyInstalledSystemMemory(&ram) == TRUE)
+        {
+            totalRam = static_cast<size_t>(ram) * 1024;
+        }
+    }
+}


### PR DESCRIPTION
Story Behind:

 Posix malloc may not return NULL. Instead, process receives an address that is not actually available.
 Finally, kernel sends SIGKILL in case of the process uses that memory space. (see Posix malloc man)

 ArrayBuffer::Finalize was reporting that the external memory is already freed on Finalize.
 However, It wasn't really freed until garbage collection disposes the object behind.

Changes:

 - moved recycler reporting into ArrayBuffer::Dispose (after free call)
 - enabled a real memory limit on Posix/Unix (under ch)
 - Instead of throwing outofmemoryexception straight after `ReportExternalMemoryAllocation`
   initiating a manual garbage collection and trying it again. In case of failure, throwing an
   oom.