### PR TITLE
xplat: re-enable GetThreadId assert in Recycler.cpp

### DIFF
--- a/lib/Common/Memory/Recycler.cpp
+++ b/lib/Common/Memory/Recycler.cpp
@@ -1095,14 +1095,10 @@ bool Recycler::ExplicitFreeInternal(void* buffer, size_t size, size_t sizeCat)
 
 #if DBG || defined(RECYCLER_MEMORY_VERIFY) || defined(RECYCLER_PAGE_HEAP)
 
-    // xplat-todo: reenable this Assert once GetThreadId is implemented on
-    // non-Win32 platforms
-#ifdef _WIN32
     // Either the mainThreadHandle is null (we're not thread bound)
     // or we should be calling this function on the main script thread
     Assert(this->mainThreadHandle == NULL ||
         ::GetCurrentThreadId() == ::GetThreadId(this->mainThreadHandle));
-#endif
 
     HeapBlock* heapBlock = this->FindHeapBlock(buffer);
 

--- a/pal/inc/pal.h
+++ b/pal/inc/pal.h
@@ -1739,6 +1739,12 @@ PALAPI
 GetCurrentThreadId(
            VOID);
 
+PALIMPORT
+DWORD
+PALAPI
+GetThreadId(
+    HANDLE hThread);
+
 // To work around multiply-defined symbols in the Carbon framework.
 #define GetCurrentThread PAL_GetCurrentThread
 PALIMPORT

--- a/pal/src/thread/thread.cpp
+++ b/pal/src/thread/thread.cpp
@@ -354,6 +354,54 @@ THREADGetThreadProcessId(
 
 /*++
 Function:
+  GetThreadId
+
+See MSDN doc.
+--*/
+DWORD
+PALAPI
+GetThreadId(
+    HANDLE hThread
+    // UNIXTODO Should take pThread parameter here (modify callers)
+    )
+{
+    DWORD dwThreadId = 0;
+    CPalThread *pThread;
+    PAL_ERROR palError = NO_ERROR;
+    IPalObject *pobjThread = 0;
+
+    // TODO: not sure if this could be done in a more efficient way.
+    PERF_ENTRY(GetThreadId);
+    ENTRY("GetThreadId()\n");
+
+    pThread = InternalGetCurrentThread();
+
+    palError = InternalGetThreadDataFromHandle(
+        pThread,
+        hThread,
+        0,
+        0,
+        &pobjThread
+        );
+
+    if (NO_ERROR != palError)
+    {
+        dwThreadId = (DWORD)pThread->GetThreadId();
+    }
+
+    if (NULL != pobjThread)
+    {
+        pobjThread->ReleaseReference(pThread);
+    }
+
+    LOGEXIT("GetThreadId returns DWORD %#x\n", dwThreadId);
+    PERF_EXIT(GetThreadId);
+
+    return dwThreadId;
+}
+
+/*++
+Function:
   GetCurrentThreadId
 
 See MSDN doc.


### PR DESCRIPTION
The method is implemented for Linux and POSIX/pthread now.