### PR TITLE
MemOp Loop Memory allocation

### DIFF
--- a/lib/Backend/BackwardPass.cpp
+++ b/lib/Backend/BackwardPass.cpp
@@ -444,7 +444,7 @@ BackwardPass::MergeSuccBlocksInfo(BasicBlock * block)
             char16 debugStringBuffer[MAX_FUNCTION_BODY_DEBUG_STRING_SIZE];
 #endif
             // save the byteCodeUpwardExposedUsed from deleting for the block right after the memop loop
-            if (this->tag == Js::DeadStorePhase && !this->IsPrePass() && globOpt->DoMemOp(block->loop) && blockSucc->loop != block->loop)
+            if (this->tag == Js::DeadStorePhase && !this->IsPrePass() && globOpt->HasMemOp(block->loop) && blockSucc->loop != block->loop)
             {
                 Assert(block->loop->memOpInfo->inductionVariablesUsedAfterLoop == nullptr);
                 block->loop->memOpInfo->inductionVariablesUsedAfterLoop = JitAnew(this->tempAlloc, BVSparse<JitArenaAllocator>, this->tempAlloc);
@@ -7117,7 +7117,7 @@ BackwardPass::DoDeadStoreLdStForMemop(IR::Instr *instr)
 
     Loop *loop = this->currentBlock->loop;
 
-    if (globOpt->DoMemOp(loop))
+    if (globOpt->HasMemOp(loop))
     {
         if (instr->m_opcode == Js::OpCode::StElemI_A && instr->GetDst()->IsIndirOpnd())
         {
@@ -7185,7 +7185,7 @@ BackwardPass::RestoreInductionVariableValuesAfterMemOp(Loop *loop)
 bool
 BackwardPass::IsEmptyLoopAfterMemOp(Loop *loop)
 {
-    if (globOpt->DoMemOp(loop))
+    if (globOpt->HasMemOp(loop))
     {
         const auto IsInductionVariableUse = [&](IR::Opnd *opnd) -> bool
         {

--- a/lib/Backend/FlowGraph.cpp
+++ b/lib/Backend/FlowGraph.cpp
@@ -747,6 +747,7 @@ FlowGraph::BuildLoop(BasicBlock *headBlock, BasicBlock *tailBlock, Loop *parentL
     loop->hasDeadStoreCollectionPass = false;
     loop->hasDeadStorePrepass = false;
     loop->memOpInfo = nullptr;
+    loop->doMemOp = true;
 
     NoRecoverMemoryJitArenaAllocator tempAlloc(_u("BE-LoopBuilder"), this->func->m_alloc->GetPageAllocator(), Js::Throw::OutOfMemory);
 
@@ -782,8 +783,10 @@ Loop::MemSetCandidate* Loop::MemOpCandidate::AsMemSet()
     return (Loop::MemSetCandidate*)this;
 }
 
-bool Loop::EnsureMemOpVariablesInitialized()
+void
+Loop::EnsureMemOpVariablesInitialized()
 {
+    Assert(this->doMemOp);
     if (this->memOpInfo == nullptr)
     {
         JitArenaAllocator *allocator = this->GetFunc()->GetTopFunc()->m_fg->alloc;
@@ -793,32 +796,10 @@ bool Loop::EnsureMemOpVariablesInitialized()
         this->memOpInfo->startIndexOpndCache[1] = nullptr;
         this->memOpInfo->startIndexOpndCache[2] = nullptr;
         this->memOpInfo->startIndexOpndCache[3] = nullptr;
-        if (this->GetLoopFlags().isInterpreted && !this->GetLoopFlags().memopMinCountReached)
-        {
-#if DBG_DUMP
-            Func* func = this->GetFunc();
-            if (Js::Configuration::Global.flags.Verbose && PHASE_TRACE(Js::MemOpPhase, func))
-            {
-                char16 debugStringBuffer[MAX_FUNCTION_BODY_DEBUG_STRING_SIZE];
-                Output::Print(_u("MemOp skipped: minimum loop count not reached: Function: %s %s,  Loop: %d\n"),
-                              func->GetJnFunction()->GetDisplayName(),
-                              func->GetJnFunction()->GetDebugNumberSet(debugStringBuffer),
-                              this->GetLoopNumber()
-                              );
-            }
-#endif
-            this->memOpInfo->doMemOp = false;
-            this->memOpInfo->inductionVariableChangeInfoMap = nullptr;
-            this->memOpInfo->inductionVariableOpndPerUnrollMap = nullptr;
-            this->memOpInfo->candidates = nullptr;
-            return false;
-        }
-        this->memOpInfo->doMemOp = true;
         this->memOpInfo->inductionVariableChangeInfoMap = JitAnew(allocator, Loop::InductionVariableChangeInfoMap, allocator);
         this->memOpInfo->inductionVariableOpndPerUnrollMap = JitAnew(allocator, Loop::InductionVariableOpndPerUnrollMap, allocator);
         this->memOpInfo->candidates = JitAnew(allocator, Loop::MemOpList, allocator);
     }
-    return true;
 }
 
 // Walk the basic blocks backwards until we find the loop header.

--- a/lib/Backend/FlowGraph.h
+++ b/lib/Backend/FlowGraph.h
@@ -664,7 +664,6 @@ public:
     typedef struct
     {
         MemOpList *candidates;
-        bool doMemOp : 1;
         BVSparse<JitArenaAllocator> *inductionVariablesUsedAfterLoop;
         InductionVariableChangeInfoMap *inductionVariableChangeInfoMap;
         InductionVariableOpndPerUnrollMap *inductionVariableOpndPerUnrollMap;
@@ -674,6 +673,7 @@ public:
         IR::RegOpnd* startIndexOpndCache[4];
     } MemOpInfo;
 
+    bool doMemOp : 1;
     MemOpInfo *memOpInfo;
 
     struct RegAlloc
@@ -729,7 +729,7 @@ public:
     BasicBlock *        GetHeadBlock() const { Assert(headBlock == blockList.Head()); return headBlock; }
     bool                IsDescendentOrSelf(Loop const * loop) const;
 
-    bool                EnsureMemOpVariablesInitialized();
+    void                EnsureMemOpVariablesInitialized();
 
     Js::ImplicitCallFlags GetImplicitCallFlags();
     void                SetImplicitCallFlags(Js::ImplicitCallFlags flags);

--- a/lib/Backend/GlobOpt.h
+++ b/lib/Backend/GlobOpt.h
@@ -1456,7 +1456,7 @@ private:
     IR::Instr*              FindArraySegmentLoadInstr(IR::Instr* instr);
     void                    RemoveMemOpSrcInstr(IR::Instr* memopInstr, IR::Instr* srcInstr, BasicBlock* block);
     void                    GetMemOpSrcInfo(Loop* loop, IR::Instr* instr, IR::RegOpnd*& base, IR::RegOpnd*& index, IRType& arrayType);
-    bool                    DoMemOp(Loop * loop);
+    bool                    HasMemOp(Loop * loop);
 
 private:
     void                    ChangeValueType(BasicBlock *const block, Value *const value, const ValueType newValueType, const bool preserveSubclassInfo, const bool allowIncompatibleType = false) const;
@@ -1806,7 +1806,6 @@ private:
     IR::Instr *             TrackMarkTempObject(IR::Instr * instrStart, IR::Instr * instrEnd);
     void                    TrackTempObjectSyms(IR::Instr * instr, IR::RegOpnd * opnd);
     IR::Instr *             GenerateBailOutMarkTempObjectIfNeeded(IR::Instr * instr, IR::Opnd * opnd, bool isDst);
-    bool                    IsDefinedInCurrentLoopIteration(Loop *loop, Value *val) const;
 
     void                    KillStateForGeneratorYield();
 

--- a/lib/Backend/GlobOptFields.cpp
+++ b/lib/Backend/GlobOptFields.cpp
@@ -262,17 +262,17 @@ GlobOpt::DoFieldPRE(Loop *loop) const
     return DoFieldOpts(loop);
 }
 
-bool GlobOpt::DoMemOp(Loop *loop)
+bool GlobOpt::HasMemOp(Loop *loop)
 {
 #pragma prefast(suppress: 6285, "logical-or of constants is by design")
     return (
         loop &&
+        loop->doMemOp &&
         (
             !PHASE_OFF(Js::MemSetPhase, this->func) ||
             !PHASE_OFF(Js::MemCopyPhase, this->func)
         ) &&
         loop->memOpInfo &&
-        loop->memOpInfo->doMemOp &&
         loop->memOpInfo->candidates &&
         !loop->memOpInfo->candidates->Empty()
     );


### PR DESCRIPTION
Closes #1015 (retarget changes to master)

Allocate Memop memory only if needed.
I did some tracing on the benchmarks.
Before this change there were over 1000 occurrences of the memop memory to be allocated, but not used.
After this change there were 85 occurrences.

The main reason is that right now any loop with 2 blocks will have all the memop memory info allocated.
The downside of this change is that it adds a boolean to every loops.
I was thinking doing something funky on the pointer instead (like -1 means do not do memop), but I fear this might be confusing just to save 1 boolean.

This is not really fixing a bug, and there doesn't seems to be a perf impact, but I came across this as I was fixing something else and it bugged me.
I think it's worth changing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/1092)
<!-- Reviewable:end -->
