### PR TITLE
JsDiagGetStackTrace should only give frames which were valid when halt was triggered.

### DIFF
--- a/lib/Jsrt/JsrtDebugManager.h
+++ b/lib/Jsrt/JsrtDebugManager.h
@@ -27,7 +27,7 @@ public:
 
     bool EnableAsyncBreak(Js::ScriptContext* scriptContext);
 
-    void CallDebugEventCallback(JsDiagDebugEvent debugEvent, Js::DynamicObject* eventDataObject, Js::ScriptContext* scriptContext);
+    void CallDebugEventCallback(JsDiagDebugEvent debugEvent, Js::DynamicObject* eventDataObject, Js::ScriptContext* scriptContext, bool isBreak);
     void CallDebugEventCallbackForBreak(JsDiagDebugEvent debugEvent, Js::DynamicObject* eventDataObject, Js::ScriptContext* scriptContext);
 
     Js::JavascriptArray* GetScripts(Js::ScriptContext* scriptContext);
@@ -55,7 +55,7 @@ public:
     JsDiagBreakOnExceptionAttributes GetBreakOnException();
 
     JsDiagDebugEvent GetDebugEventFromStopType(Js::StopType stopType);
-
+    ThreadContext* GetThreadContext() const { return this->threadContext; }
 private:
     ThreadContext* threadContext;
     JsDiagDebugEventCallback debugEventCallback;

--- a/lib/Jsrt/JsrtDebugUtils.cpp
+++ b/lib/Jsrt/JsrtDebugUtils.cpp
@@ -27,9 +27,7 @@ void JsrtDebugUtils::AddFileNameOrScriptTypeToObject(Js::DynamicObject* object, 
 
         Js::FunctionBody* anyFunctionBody = utf8SourceInfo->GetAnyParsedFunction();
 
-        Assert(anyFunctionBody != nullptr);
-
-        LPCWSTR sourceName = anyFunctionBody->GetSourceName();
+        LPCWSTR sourceName = (anyFunctionBody != nullptr) ? anyFunctionBody->GetSourceName() : Js::Constants::UnknownScriptCode;
 
         JsrtDebugUtils::AddPropertyToObject(object, JsrtDebugPropertyId::scriptType, sourceName, wcslen(sourceName), utf8SourceInfo->GetScriptContext());
     }

--- a/lib/Runtime/Debug/DebugManager.cpp
+++ b/lib/Runtime/Debug/DebugManager.cpp
@@ -21,11 +21,11 @@ namespace Js
         jscriptBlockRegistrationCount(0),
         isDebuggerAttaching(false),
         nextBreakPointId(0),
-        localsDisplayFlags(LocalsDisplayFlags_None)
+        localsDisplayFlags(LocalsDisplayFlags_None),
+        dispatchHaltFrameAddress(nullptr)
     {
         Assert(_pThreadContext != nullptr);
 #if DBG
-        dispatchHaltFrameAddress = nullptr;
         // diagnosticPageAllocator may be used in multiple thread, but it's usage is synchronized.
         diagnosticPageAllocator.SetDisableThreadAccessCheck();
         diagnosticPageAllocator.debugName = _u("Diagnostic");

--- a/lib/Runtime/Debug/DebugManager.h
+++ b/lib/Runtime/Debug/DebugManager.h
@@ -33,9 +33,7 @@ namespace Js
         DebuggingFlags debuggingFlags;
         UINT nextBreakPointId;
         DWORD localsDisplayFlags;
-#if DBG
         void * dispatchHaltFrameAddress;
-#endif
     public:
         StepController stepController;
         AsyncBreakController asyncBreakController;
@@ -64,8 +62,9 @@ namespace Js
         FrameDisplay *GetFrameDisplay(ScriptContext* scriptContext, DynamicObject* scopeAtZero, DynamicObject* scopeAtOne);
         void UpdateConsoleScope(DynamicObject* copyFromScope, ScriptContext* scriptContext);
         PageAllocator * GetDiagnosticPageAllocator() { return &this->diagnosticPageAllocator; }
-#if DBG
         void SetDispatchHaltFrameAddress(void * returnAddress) { this->dispatchHaltFrameAddress = returnAddress; }
+        DWORD_PTR GetDispatchHaltFrameAddress() const { return (DWORD_PTR)this->dispatchHaltFrameAddress; }
+#if DBG
         void ValidateDebugAPICall();
 #endif
         void SetDebuggerAttaching(bool attaching) { this->isDebuggerAttaching = attaching; }


### PR DESCRIPTION
JsrtDebugStackFrames::StackFrames should only get frame pointers if the ScriptContext/ProbeContainer had valid stack when halt was triggered. Since user can execute JavaScript code after halt any frames after halt are transient so they should be skipped