### PR TITLE
xplat: runtests.py improvements

### DIFF
--- a/test/typedarray/rlexe.xml
+++ b/test/typedarray/rlexe.xml
@@ -215,13 +215,13 @@ Below test fails with difference in space. Investigate the cause and re-enable t
   <test>
     <default>
       <files>allocation.js</files>
-      <tags>typedarray,exclude_arm</tags>
+      <tags>typedarray,exclude_arm,xplatslow</tags>
     </default>
   </test>
   <test>
     <default>
       <files>allocation2.js</files>
-      <tags>typedarray,exclude_arm</tags>
+      <tags>typedarray,exclude_arm,xplatslow</tags>
     </default>
   </test>
   <test>


### PR DESCRIPTION
1. Add error handling

 Python multiprocessing parallel processes do not print anything if an
 unhandled exception occurs. This causes the script to "hang" silently.
 Added 2 levels of try/except so that the script no longer hangs on
 exception. Script exceptions and backtraces will be reported and logged.

2. Switch to python3 `bytes` for output/baseline diff

 This has no effect on python 2, but enables the script on python 3.
 Capture output as bytes (subprocess communicate() returned type), load
 baseline files in mode 'rb' and diff `bytes` type directly. This avoids
 issues caused by encoding/end-of-line conversions.

3. Refactor, notably move 'folder' data to an attribute of test so that
we don't need to pass folder around.

4. Add a tag "xplatslow" to 2 tests (temporarily, so can be excluded on
command line: `--not-tag xplatslow`).