### PR TITLE
work for iteratorclose

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -12056,6 +12056,13 @@ ParseNodePtr Parser::ParseDestructuredVarDecl(tokens declarationType, bool isDec
     {
         // Go recursively
         pnodeElem = ParseDestructuredLiteral<buildAST>(declarationType, isDecl, false /*topLevel*/, seenRest ? DIC_ShouldNotParseInitializer : DIC_None);
+        if (!isDecl)
+        {
+            BOOL fCanAssign;
+            IdentToken token;
+            // Look for postfix operator
+            pnodeElem = ParsePostfixOperators<buildAST>(pnodeElem, TRUE, FALSE, &fCanAssign, &token);
+        }
     }
     else if (m_token.tk == tkSUPER || m_token.tk == tkID)
     {
@@ -12186,35 +12193,45 @@ ParseNodePtr Parser::ParseDestructuredArrayLiteral(tokens declarationType, bool 
     bool hasMissingValues = false;
     bool seenRest = false;
 
-    while (true)
+    if (m_token.tk != tkRBrack)
     {
-        if (seenRest) // Rest must be in the last position.
+        while (true)
         {
-            Error(ERRDestructRestLast);
-        }
-
-        ParseNodePtr pnodeElem = ParseDestructuredVarDecl<buildAST>(declarationType, isDecl, &seenRest, topLevel);
-        if (buildAST)
-        {
-            if (pnodeElem == nullptr && buildAST)
+            if (seenRest) // Rest must be in the last position.
             {
-                pnodeElem = CreateNodeWithScanner<knopEmpty>();
-                hasMissingValues = true;
+                Error(ERRDestructRestLast);
             }
-            AddToNodeListEscapedUse(&pnodeList, &lastNodeRef, pnodeElem);
-        }
-        count++;
 
-        if (m_token.tk == tkRBrack)
-        {
-            break;
-        }
+            ParseNodePtr pnodeElem = ParseDestructuredVarDecl<buildAST>(declarationType, isDecl, &seenRest, topLevel);
+            if (buildAST)
+            {
+                if (pnodeElem == nullptr && buildAST)
+                {
+                    pnodeElem = CreateNodeWithScanner<knopEmpty>();
+                    hasMissingValues = true;
+                }
+                AddToNodeListEscapedUse(&pnodeList, &lastNodeRef, pnodeElem);
+            }
+            count++;
 
-        if (m_token.tk != tkComma)
-        {
-            Error(ERRDestructNoOper);
+            if (m_token.tk == tkRBrack)
+            {
+                break;
+            }
+
+            if (m_token.tk != tkComma)
+            {
+                Error(ERRDestructNoOper);
+            }
+
+            m_pscan->Scan();
+
+            // break if we have the trailing comma as well, eg. [a,]
+            if (m_token.tk == tkRBrack)
+            {
+                break;
+            }
         }
-        m_pscan->Scan();
     }
 
     if (buildAST)

--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -158,10 +158,10 @@ bool IsArguments(ParseNode *pnode)
             pnode = pnode->sxTri.pnode3;
             break;
 
-        //
-        // Cases where we don't check for "arguments" yet.
-        // Assume that they might have it. Disable the optimization is such scenarios
-        //
+            //
+            // Cases where we don't check for "arguments" yet.
+            // Assume that they might have it. Disable the optimization is such scenarios
+            //
         case knopList:
         case knopObject:
         case knopVarDecl:
@@ -245,7 +245,7 @@ static const Js::OpCode nopToCMOp[knopLim] =
 
 Js::OpCode ByteCodeGenerator::ToChkUndeclOp(Js::OpCode op) const
 {
-    switch(op)
+    switch (op)
     {
     case Js::OpCode::StLocalSlot:
         return Js::OpCode::StLocalSlotChkUndecl;
@@ -2043,12 +2043,12 @@ void ByteCodeGenerator::LoadAllConstants(FuncInfo *funcInfo)
                 {
                     scopeLocation = funcInfo->funcExprScope->GetLocation();
                     this->m_writer.Property(Js::OpCode::StFuncExpr, sym->GetLocation(), scopeLocation,
-                                            funcInfo->FindOrAddReferencedPropertyId(sym->GetPosition()));
+                        funcInfo->FindOrAddReferencedPropertyId(sym->GetPosition()));
                 }
                 else
                 {
                     this->m_writer.ElementU(Js::OpCode::StLocalFuncExpr, sym->GetLocation(),
-                                            funcInfo->FindOrAddReferencedPropertyId(sym->GetPosition()));
+                        funcInfo->FindOrAddReferencedPropertyId(sym->GetPosition()));
                 }
             }
             else if (ShouldTrackDebuggerMetadata())
@@ -2437,10 +2437,10 @@ void ByteCodeGenerator::EmitInternalScopedSlotLoad(FuncInfo *funcInfo, Scope *sc
 
     if (envIndex != -1)
     {
-        this->m_writer.SlotI2(opcode, symbolRegister, envIndex + Js::FrameDisplay::GetOffsetOfScopes()/sizeof(Js::Var), slot, profileId);
+        this->m_writer.SlotI2(opcode, symbolRegister, envIndex + Js::FrameDisplay::GetOffsetOfScopes() / sizeof(Js::Var), slot, profileId);
     }
     else if (scopeLocation != Js::Constants::NoRegister &&
-             (scopeLocation == funcInfo->frameSlotsRegister || scopeLocation == funcInfo->frameObjRegister))
+        (scopeLocation == funcInfo->frameSlotsRegister || scopeLocation == funcInfo->frameObjRegister))
     {
         this->m_writer.SlotI1(opcode, symbolRegister, slot, profileId);
     }
@@ -2478,10 +2478,10 @@ void ByteCodeGenerator::EmitInternalScopedSlotStore(FuncInfo *funcInfo, Js::RegS
 
     if (envIndex != -1)
     {
-        this->m_writer.SlotI2(opcode, symbolRegister, envIndex + Js::FrameDisplay::GetOffsetOfScopes()/sizeof(Js::Var), slot);
+        this->m_writer.SlotI2(opcode, symbolRegister, envIndex + Js::FrameDisplay::GetOffsetOfScopes() / sizeof(Js::Var), slot);
     }
     else if (scopeLocation != Js::Constants::NoRegister &&
-             (scopeLocation == funcInfo->frameSlotsRegister || scopeLocation == funcInfo->frameObjRegister))
+        (scopeLocation == funcInfo->frameSlotsRegister || scopeLocation == funcInfo->frameObjRegister))
     {
         this->m_writer.SlotI1(opcode, symbolRegister, slot);
     }
@@ -3544,7 +3544,7 @@ void ByteCodeGenerator::EmitScopeList(ParseNode *pnode, ParseNode *breakOnBodySc
     {
         switch (pnode->nop)
         {
-            case knopFncDecl:
+        case knopFncDecl:
 #ifndef TEMP_DISABLE_ASMJS
             if (pnode->sxFnc.GetAsmjsMode())
             {
@@ -4444,12 +4444,12 @@ void ByteCodeGenerator::EmitLoadInstance(Symbol *sym, IdentPtr pid, Js::RegSlot 
             this->m_writer.BrEnvProperty(
                 Js::OpCode::BrOnNoEnvProperty, nextLabel,
                 funcInfo->FindOrAddReferencedPropertyId(propertyId),
-                envIndex + Js::FrameDisplay::GetOffsetOfScopes()/sizeof(Js::Var));
+                envIndex + Js::FrameDisplay::GetOffsetOfScopes() / sizeof(Js::Var));
 
             Js::RegSlot tmpReg = funcInfo->AcquireTmpRegister();
 
             this->m_writer.SlotI1(Js::OpCode::LdEnvObj, tmpReg,
-                                  envIndex + Js::FrameDisplay::GetOffsetOfScopes()/sizeof(Js::Var));
+                envIndex + Js::FrameDisplay::GetOffsetOfScopes() / sizeof(Js::Var));
 
             Js::OpCode op = unwrapWithObj ? Js::OpCode::UnwrapWithObj : Js::OpCode::Ld_A;
 
@@ -4464,7 +4464,7 @@ void ByteCodeGenerator::EmitLoadInstance(Symbol *sym, IdentPtr pid, Js::RegSlot 
         else if (scopeLocation != Js::Constants::NoRegister && scopeLocation == funcInfo->frameObjRegister)
         {
             this->m_writer.BrLocalProperty(Js::OpCode::BrOnNoLocalProperty, nextLabel,
-                                           funcInfo->FindOrAddReferencedPropertyId(propertyId));
+                funcInfo->FindOrAddReferencedPropertyId(propertyId));
 
             Assert(!unwrapWithObj);
             this->m_writer.Reg1(Js::OpCode::LdLocalObj, instLocation);
@@ -4476,7 +4476,7 @@ void ByteCodeGenerator::EmitLoadInstance(Symbol *sym, IdentPtr pid, Js::RegSlot 
         else
         {
             this->m_writer.BrProperty(Js::OpCode::BrOnNoProperty, nextLabel, scopeLocation,
-                                      funcInfo->FindOrAddReferencedPropertyId(propertyId));
+                funcInfo->FindOrAddReferencedPropertyId(propertyId));
 
             Js::OpCode op = unwrapWithObj ? Js::OpCode::UnwrapWithObj : Js::OpCode::Ld_A;
             this->m_writer.Reg2(op, instLocation, scopeLocation);
@@ -4544,7 +4544,7 @@ void ByteCodeGenerator::EmitLoadInstance(Symbol *sym, IdentPtr pid, Js::RegSlot 
         if (envIndex != -1)
         {
             this->m_writer.SlotI1(Js::OpCode::LdEnvObj, instLocation,
-                                  envIndex + Js::FrameDisplay::GetOffsetOfScopes()/sizeof(Js::Var));
+                envIndex + Js::FrameDisplay::GetOffsetOfScopes() / sizeof(Js::Var));
         }
         else if (scope->HasInnerScopeIndex())
         {
@@ -4589,7 +4589,7 @@ void ByteCodeGenerator::EmitGlobalFncDeclInit(Js::RegSlot rhsLocation, Js::Prope
         // even if the instance doesn't have the property yet (i.e., collapse the init-to-undef and the store
         // into one operation). See WOOB 1121763 and 1120973.
         this->m_writer.ScopedProperty(Js::OpCode::ScopedInitFunc, rhsLocation,
-                                      funcInfo->FindOrAddReferencedPropertyId(propertyId));
+            funcInfo->FindOrAddReferencedPropertyId(propertyId));
     }
     else
     {
@@ -4685,12 +4685,12 @@ ByteCodeGenerator::GetStSlotOp(Scope *scope, int envIndex, Js::RegSlot scopeLoca
         }
     }
     else if (scopeLocation != Js::Constants::NoRegister &&
-             scopeLocation == funcInfo->frameSlotsRegister)
+        scopeLocation == funcInfo->frameSlotsRegister)
     {
         op = Js::OpCode::StLocalSlot;
     }
     else if (scopeLocation != Js::Constants::NoRegister &&
-             scopeLocation == funcInfo->frameObjRegister)
+        scopeLocation == funcInfo->frameObjRegister)
     {
         op = Js::OpCode::StLocalObjSlot;
     }
@@ -4813,14 +4813,14 @@ void ByteCodeGenerator::EmitPropStore(Js::RegSlot rhsLocation, Symbol *sym, Iden
                 Js::OpCode::BrOnNoEnvProperty,
                 nextLabel,
                 funcInfo->FindOrAddReferencedPropertyId(propertyId),
-                envIndex + Js::FrameDisplay::GetOffsetOfScopes()/sizeof(Js::Var));
+                envIndex + Js::FrameDisplay::GetOffsetOfScopes() / sizeof(Js::Var));
 
             Js::RegSlot instLocation = funcInfo->AcquireTmpRegister();
 
             this->m_writer.SlotI1(
                 Js::OpCode::LdEnvObj,
                 instLocation,
-                envIndex + Js::FrameDisplay::GetOffsetOfScopes()/sizeof(Js::Var));
+                envIndex + Js::FrameDisplay::GetOffsetOfScopes() / sizeof(Js::Var));
 
             if (unwrapWithObj)
             {
@@ -4838,16 +4838,16 @@ void ByteCodeGenerator::EmitPropStore(Js::RegSlot rhsLocation, Symbol *sym, Iden
         else if (scopeLocation != Js::Constants::NoRegister && scopeLocation == funcInfo->frameObjRegister)
         {
             this->m_writer.BrLocalProperty(Js::OpCode::BrOnNoLocalProperty, nextLabel,
-                                           funcInfo->FindOrAddReferencedPropertyId(propertyId));
+                funcInfo->FindOrAddReferencedPropertyId(propertyId));
 
             Assert(!unwrapWithObj);
             this->m_writer.ElementP(Js::OpCode::StLocalFld, rhsLocation,
-                                    funcInfo->FindOrAddInlineCacheId(scopeLocation, propertyId, false, true));
+                funcInfo->FindOrAddInlineCacheId(scopeLocation, propertyId, false, true));
         }
         else
         {
             this->m_writer.BrProperty(Js::OpCode::BrOnNoProperty, nextLabel, scopeLocation,
-                                      funcInfo->FindOrAddReferencedPropertyId(propertyId));
+                funcInfo->FindOrAddReferencedPropertyId(propertyId));
 
             if (unwrapWithObj)
             {
@@ -4942,20 +4942,20 @@ void ByteCodeGenerator::EmitPropStore(Js::RegSlot rhsLocation, Symbol *sym, Iden
         if (envIndex != -1)
         {
             this->m_writer.SlotI2(op, rhsLocation,
-                                  envIndex + Js::FrameDisplay::GetOffsetOfScopes()/sizeof(Js::Var),
-                                  slot + (sym->GetScope()->GetIsObject()? 0 : Js::ScopeSlots::FirstSlotIndex));
+                envIndex + Js::FrameDisplay::GetOffsetOfScopes() / sizeof(Js::Var),
+                slot + (sym->GetScope()->GetIsObject() ? 0 : Js::ScopeSlots::FirstSlotIndex));
         }
         else if (scopeLocation != Js::Constants::NoRegister &&
-                 (scopeLocation == funcInfo->frameSlotsRegister || scopeLocation == funcInfo->frameObjRegister))
+            (scopeLocation == funcInfo->frameSlotsRegister || scopeLocation == funcInfo->frameObjRegister))
         {
             this->m_writer.SlotI1(op, rhsLocation,
-                                  slot + (sym->GetScope()->GetIsObject()? 0 : Js::ScopeSlots::FirstSlotIndex));
+                slot + (sym->GetScope()->GetIsObject() ? 0 : Js::ScopeSlots::FirstSlotIndex));
         }
         else
         {
             Assert(scope->HasInnerScopeIndex());
             this->m_writer.SlotI2(op, rhsLocation, scope->GetInnerScopeIndex(),
-                slot + (sym->GetScope()->GetIsObject()? 0 : Js::ScopeSlots::FirstSlotIndex));
+                slot + (sym->GetScope()->GetIsObject() ? 0 : Js::ScopeSlots::FirstSlotIndex));
         }
 
         if (this->ShouldTrackDebuggerMetadata() && (isLetDecl || isConstDecl))
@@ -5019,12 +5019,12 @@ ByteCodeGenerator::GetLdSlotOp(Scope *scope, int envIndex, Js::RegSlot scopeLoca
         }
     }
     else if (scopeLocation != Js::Constants::NoRegister &&
-             scopeLocation == funcInfo->frameSlotsRegister)
+        scopeLocation == funcInfo->frameSlotsRegister)
     {
         op = Js::OpCode::LdLocalSlot;
     }
     else if (scopeLocation != Js::Constants::NoRegister &&
-             scopeLocation == funcInfo->frameObjRegister)
+        scopeLocation == funcInfo->frameObjRegister)
     {
         op = Js::OpCode::LdLocalObjSlot;
     }
@@ -5104,14 +5104,14 @@ void ByteCodeGenerator::EmitPropLoad(Js::RegSlot lhsLocation, Symbol *sym, Ident
                 Js::OpCode::BrOnNoEnvProperty,
                 nextLabel,
                 funcInfo->FindOrAddReferencedPropertyId(propertyId),
-                envIndex + Js::FrameDisplay::GetOffsetOfScopes()/sizeof(Js::Var));
+                envIndex + Js::FrameDisplay::GetOffsetOfScopes() / sizeof(Js::Var));
 
             Js::RegSlot instLocation = funcInfo->AcquireTmpRegister();
 
             this->m_writer.SlotI1(
                 Js::OpCode::LdEnvObj,
                 instLocation,
-                envIndex + Js::FrameDisplay::GetOffsetOfScopes()/sizeof(Js::Var));
+                envIndex + Js::FrameDisplay::GetOffsetOfScopes() / sizeof(Js::Var));
 
             if (unwrapWithObj)
             {
@@ -5129,16 +5129,16 @@ void ByteCodeGenerator::EmitPropLoad(Js::RegSlot lhsLocation, Symbol *sym, Ident
         else if (scopeLocation != Js::Constants::NoRegister && scopeLocation == funcInfo->frameObjRegister)
         {
             this->m_writer.BrLocalProperty(Js::OpCode::BrOnNoLocalProperty, nextLabel,
-                                           funcInfo->FindOrAddReferencedPropertyId(propertyId));
+                funcInfo->FindOrAddReferencedPropertyId(propertyId));
 
             Assert(!unwrapWithObj);
             this->m_writer.ElementP(Js::OpCode::LdLocalFld, lhsLocation,
-                                    funcInfo->FindOrAddInlineCacheId(scopeLocation, propertyId, false, false));
+                funcInfo->FindOrAddInlineCacheId(scopeLocation, propertyId, false, false));
         }
         else
         {
             this->m_writer.BrProperty(Js::OpCode::BrOnNoProperty, nextLabel, scopeLocation,
-                                      funcInfo->FindOrAddReferencedPropertyId(propertyId));
+                funcInfo->FindOrAddReferencedPropertyId(propertyId));
 
             if (unwrapWithObj)
             {
@@ -5245,10 +5245,10 @@ void ByteCodeGenerator::EmitPropLoad(Js::RegSlot lhsLocation, Symbol *sym, Ident
 
         if (envIndex != -1)
         {
-            this->m_writer.SlotI2(op, lhsLocation, envIndex + Js::FrameDisplay::GetOffsetOfScopes()/sizeof(Js::Var), slot, profileId);
+            this->m_writer.SlotI2(op, lhsLocation, envIndex + Js::FrameDisplay::GetOffsetOfScopes() / sizeof(Js::Var), slot, profileId);
         }
         else if (scopeLocation != Js::Constants::NoRegister &&
-                 (scopeLocation == funcInfo->frameSlotsRegister || scopeLocation == funcInfo->frameObjRegister))
+            (scopeLocation == funcInfo->frameSlotsRegister || scopeLocation == funcInfo->frameObjRegister))
         {
             this->m_writer.SlotI1(op, lhsLocation, slot, profileId);
         }
@@ -5344,14 +5344,14 @@ void ByteCodeGenerator::EmitPropDelete(Js::RegSlot lhsLocation, Symbol *sym, Ide
                 Js::OpCode::BrOnNoEnvProperty,
                 nextLabel,
                 funcInfo->FindOrAddReferencedPropertyId(propertyId),
-                envIndex + Js::FrameDisplay::GetOffsetOfScopes()/sizeof(Js::Var));
+                envIndex + Js::FrameDisplay::GetOffsetOfScopes() / sizeof(Js::Var));
 
             Js::RegSlot instLocation = funcInfo->AcquireTmpRegister();
 
             this->m_writer.SlotI1(
                 Js::OpCode::LdEnvObj,
                 instLocation,
-                envIndex + Js::FrameDisplay::GetOffsetOfScopes()/sizeof(Js::Var));
+                envIndex + Js::FrameDisplay::GetOffsetOfScopes() / sizeof(Js::Var));
 
             if (unwrapWithObj)
             {
@@ -5359,23 +5359,23 @@ void ByteCodeGenerator::EmitPropDelete(Js::RegSlot lhsLocation, Symbol *sym, Ide
             }
 
             this->m_writer.Property(Js::OpCode::DeleteFld, lhsLocation, instLocation,
-                                    funcInfo->FindOrAddReferencedPropertyId(propertyId));
+                funcInfo->FindOrAddReferencedPropertyId(propertyId));
 
             funcInfo->ReleaseTmpRegister(instLocation);
         }
         else if (scopeLocation != Js::Constants::NoRegister && scopeLocation == funcInfo->frameObjRegister)
         {
             this->m_writer.BrLocalProperty(Js::OpCode::BrOnNoLocalProperty, nextLabel,
-                                           funcInfo->FindOrAddReferencedPropertyId(propertyId));
+                funcInfo->FindOrAddReferencedPropertyId(propertyId));
 
             Assert(!unwrapWithObj);
             this->m_writer.ElementU(Js::OpCode::DeleteLocalFld, lhsLocation,
-                                    funcInfo->FindOrAddReferencedPropertyId(propertyId));
+                funcInfo->FindOrAddReferencedPropertyId(propertyId));
         }
         else
         {
             this->m_writer.BrProperty(Js::OpCode::BrOnNoProperty, nextLabel, scopeLocation,
-                                      funcInfo->FindOrAddReferencedPropertyId(propertyId));
+                funcInfo->FindOrAddReferencedPropertyId(propertyId));
 
             Js::RegSlot unwrappedScopeLocation = Js::Constants::NoRegister;
             if (unwrapWithObj)
@@ -5386,7 +5386,7 @@ void ByteCodeGenerator::EmitPropDelete(Js::RegSlot lhsLocation, Symbol *sym, Ide
             }
 
             this->m_writer.Property(Js::OpCode::DeleteFld, lhsLocation, scopeLocation,
-                                    funcInfo->FindOrAddReferencedPropertyId(propertyId));
+                funcInfo->FindOrAddReferencedPropertyId(propertyId));
 
             if (unwrapWithObj)
             {
@@ -5512,14 +5512,14 @@ void ByteCodeGenerator::EmitPropTypeof(Js::RegSlot lhsLocation, Symbol *sym, Ide
         if (envIndex != -1)
         {
             this->m_writer.BrEnvProperty(Js::OpCode::BrOnNoEnvProperty, nextLabel,
-                                         funcInfo->FindOrAddReferencedPropertyId(propertyId),
-                                         envIndex + Js::FrameDisplay::GetOffsetOfScopes()/sizeof(Js::Var));
+                funcInfo->FindOrAddReferencedPropertyId(propertyId),
+                envIndex + Js::FrameDisplay::GetOffsetOfScopes() / sizeof(Js::Var));
 
             Js::RegSlot instLocation = funcInfo->AcquireTmpRegister();
 
             this->m_writer.SlotI1(Js::OpCode::LdEnvObj,
-                                  instLocation,
-                                  envIndex + Js::FrameDisplay::GetOffsetOfScopes()/sizeof(Js::Var));
+                instLocation,
+                envIndex + Js::FrameDisplay::GetOffsetOfScopes() / sizeof(Js::Var));
 
             if (unwrapWithObj)
             {
@@ -5533,7 +5533,7 @@ void ByteCodeGenerator::EmitPropTypeof(Js::RegSlot lhsLocation, Symbol *sym, Ide
         else if (scopeLocation != Js::Constants::NoRegister && scopeLocation == funcInfo->frameObjRegister)
         {
             this->m_writer.BrLocalProperty(Js::OpCode::BrOnNoLocalProperty, nextLabel,
-                                           funcInfo->FindOrAddReferencedPropertyId(propertyId));
+                funcInfo->FindOrAddReferencedPropertyId(propertyId));
 
             Assert(!unwrapWithObj);
             this->EmitTypeOfFld(funcInfo, propertyId, lhsLocation, scopeLocation, Js::OpCode::LdLocalFld);
@@ -5541,7 +5541,7 @@ void ByteCodeGenerator::EmitPropTypeof(Js::RegSlot lhsLocation, Symbol *sym, Ide
         else
         {
             this->m_writer.BrProperty(Js::OpCode::BrOnNoProperty, nextLabel, scopeLocation,
-                                      funcInfo->FindOrAddReferencedPropertyId(propertyId));
+                funcInfo->FindOrAddReferencedPropertyId(propertyId));
 
             Js::RegSlot unwrappedScopeLocation = Js::Constants::NoRegister;
             if (unwrapWithObj)
@@ -5612,10 +5612,10 @@ void ByteCodeGenerator::EmitPropTypeof(Js::RegSlot lhsLocation, Symbol *sym, Ide
 
         if (envIndex != -1)
         {
-            this->m_writer.SlotI2(op, tmpLocation, envIndex + Js::FrameDisplay::GetOffsetOfScopes()/sizeof(Js::Var), slot, profileId);
+            this->m_writer.SlotI2(op, tmpLocation, envIndex + Js::FrameDisplay::GetOffsetOfScopes() / sizeof(Js::Var), slot, profileId);
         }
         else if (scopeLocation != Js::Constants::NoRegister &&
-                 (scopeLocation == funcInfo->frameSlotsRegister || scopeLocation == funcInfo->frameObjRegister))
+            (scopeLocation == funcInfo->frameSlotsRegister || scopeLocation == funcInfo->frameObjRegister))
         {
             this->m_writer.SlotI1(op, tmpLocation, slot, profileId);
         }
@@ -5703,7 +5703,7 @@ void ByteCodeGenerator::EnsureNoRedeclarations(ParseNode *pnodeBlock, FuncInfo *
                 if (!funcInfo->byteCodeFunction->GetIsStrictMode())
                 {
                     this->m_writer.ScopedProperty(Js::OpCode::ScopedEnsureNoRedeclFld, ByteCodeGenerator::RootObjectRegister,
-                                                  funcInfo->FindOrAddReferencedPropertyId(propertyId));
+                        funcInfo->FindOrAddReferencedPropertyId(propertyId));
                 }
             }
             else
@@ -6021,6 +6021,7 @@ void EmitReference(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator, FuncI
 
 void EmitGetIterator(Js::RegSlot iteratorLocation, Js::RegSlot iterableLocation, ByteCodeGenerator* byteCodeGenerator, FuncInfo* funcInfo);
 void EmitIteratorNext(Js::RegSlot itemLocation, Js::RegSlot iteratorLocation, Js::RegSlot nextInputLocation, ByteCodeGenerator* byteCodeGenerator, FuncInfo* funcInfo);
+void EmitIteratorClose(Js::RegSlot iteratorLocation, ByteCodeGenerator* byteCodeGenerator, FuncInfo* funcInfo);
 void EmitIteratorComplete(Js::RegSlot doneLocation, Js::RegSlot iteratorResultLocation, ByteCodeGenerator* byteCodeGenerator, FuncInfo* funcInfo);
 void EmitIteratorValue(Js::RegSlot valueLocation, Js::RegSlot iteratorResultLocation, ByteCodeGenerator* byteCodeGenerator, FuncInfo* funcInfo);
 
@@ -6043,7 +6044,7 @@ void EmitDestructuredElement(ParseNode *elem, Js::RegSlot sourceLocation, ByteCo
     funcInfo->ReleaseReference(elem);
 }
 
-void EmitDestructuredRestArray(ParseNode *elem, Js::RegSlot iteratorLocation, ByteCodeGenerator *byteCodeGenerator, FuncInfo *funcInfo)
+void EmitDestructuredRestArray(ParseNode *elem, Js::RegSlot iteratorLocation, Js::RegSlot shouldCallReturnFunctionLocation, ByteCodeGenerator *byteCodeGenerator, FuncInfo *funcInfo)
 {
     Js::RegSlot restArrayLocation = funcInfo->AcquireTmpRegister();
     byteCodeGenerator->Writer()->Reg1Unsigned1(
@@ -6077,6 +6078,8 @@ void EmitDestructuredRestArray(ParseNode *elem, Js::RegSlot iteratorLocation, By
     Js::RegSlot valueLocation = funcInfo->AcquireTmpRegister();
     EmitIteratorValue(valueLocation, itemLocation, byteCodeGenerator, funcInfo);
 
+    byteCodeGenerator->Writer()->Reg1(Js::OpCode::LdTrue, shouldCallReturnFunctionLocation);
+
     byteCodeGenerator->Writer()->Element(
         ByteCodeGenerator::GetStElemIOpCode(funcInfo),
         valueLocation, restArrayLocation, counterLocation);
@@ -6085,6 +6088,9 @@ void EmitDestructuredRestArray(ParseNode *elem, Js::RegSlot iteratorLocation, By
     funcInfo->ReleaseTmpRegister(itemLocation);
 
     byteCodeGenerator->Writer()->Reg2(Js::OpCode::Incr_A, counterLocation, counterLocation);
+
+    byteCodeGenerator->Writer()->Reg1(Js::OpCode::LdFalse, shouldCallReturnFunctionLocation);
+
     byteCodeGenerator->Writer()->Br(loopTop);
 
     // iteratorDone:
@@ -6094,6 +6100,22 @@ void EmitDestructuredRestArray(ParseNode *elem, Js::RegSlot iteratorLocation, By
     EmitDestructuredElement(restElem, restArrayLocation, byteCodeGenerator, funcInfo);
 
     funcInfo->ReleaseTmpRegister(restArrayLocation);
+}
+
+void EmitDestructuredArray(
+    ParseNode *lhs,
+    Js::RegSlot rhsLocation,
+    ByteCodeGenerator *byteCodeGenerator,
+    FuncInfo *funcInfo);
+
+void EmitIteratorCloseIfNotDone(Js::RegSlot iteratorLocation, Js::RegSlot doneLocation, ByteCodeGenerator* byteCodeGenerator, FuncInfo* funcInfo)
+{
+    Js::ByteCodeLabel skipCloseLabel = byteCodeGenerator->Writer()->DefineLabel();
+    byteCodeGenerator->Writer()->BrReg1(Js::OpCode::BrTrue_A, skipCloseLabel, doneLocation);
+
+    EmitIteratorClose(iteratorLocation, byteCodeGenerator, funcInfo);
+
+    byteCodeGenerator->Writer()->MarkLabel(skipCloseLabel);
 }
 
 /*
@@ -6121,26 +6143,15 @@ void EmitDestructuredRestArray(ParseNode *elem, Js::RegSlot iteratorLocation, By
         value = iterator.next()
         rest.append(value)
 */
-void EmitDestructuredArray(
-    ParseNode *lhs,
-    Js::RegSlot rhsLocation,
+void EmitDestructuredArrayCore(
+    ParseNode *list,
+    Js::RegSlot iteratorLocation,
+    Js::RegSlot shouldCallReturnFunctionLocation,
     ByteCodeGenerator *byteCodeGenerator,
-    FuncInfo *funcInfo)
+    FuncInfo *funcInfo
+    )
 {
-    byteCodeGenerator->StartStatement(lhs);
-    Js::RegSlot iteratorLocation = funcInfo->AcquireTmpRegister();
-
-    EmitGetIterator(iteratorLocation, rhsLocation, byteCodeGenerator, funcInfo);
-
-    Assert(lhs->nop == knopArrayPattern);
-    ParseNode *list = lhs->sxArrLit.pnode1;
-
-    if (list == nullptr)
-    {
-        // No elements to bind or assign.
-        funcInfo->ReleaseTmpRegister(iteratorLocation);
-        return;
-    }
+    Assert(list != nullptr);
 
     ParseNode *elem = nullptr;
     while (list != nullptr)
@@ -6156,10 +6167,8 @@ void EmitDestructuredArray(
             elem = list;
         }
 
-        if (elem->nop == knopEllipsis
-            || (elem->nop == knopEmpty && list->nop == knopEmpty))
+        if (elem->nop == knopEllipsis)
         {
-            // Rest and last empty slot do not require any more processing.
             break;
         }
 
@@ -6181,40 +6190,45 @@ void EmitDestructuredArray(
             break;
         }
 
-
         byteCodeGenerator->StartStatement(elem);
 
+        byteCodeGenerator->Writer()->Reg1(Js::OpCode::LdFalse, shouldCallReturnFunctionLocation);
+
         Js::RegSlot itemLocation = funcInfo->AcquireTmpRegister();
-
         EmitIteratorNext(itemLocation, iteratorLocation, Js::Constants::NoRegister, byteCodeGenerator, funcInfo);
-
-        if (elem->nop == knopEmpty)
-        {
-            // Missing elements only require a next call.
-            funcInfo->ReleaseTmpRegister(itemLocation);
-            if (list->nop == knopList)
-            {
-                list = list->sxBin.pnode2;
-                continue;
-            }
-            else
-            {
-                break;
-            }
-        }
 
         Js::RegSlot doneLocation = funcInfo->AcquireTmpRegister();
         EmitIteratorComplete(doneLocation, itemLocation, byteCodeGenerator, funcInfo);
 
+        if (elem->nop == knopEmpty)
+        {
+            if (list->nop == knopList)
+            {
+                list = list->sxBin.pnode2;
+                funcInfo->ReleaseTmpRegister(doneLocation);
+                funcInfo->ReleaseTmpRegister(itemLocation);
+                continue;
+            }
+            else
+            {
+                Assert(list->nop == knopEmpty);
+                EmitIteratorCloseIfNotDone(iteratorLocation, doneLocation, byteCodeGenerator, funcInfo);
+                funcInfo->ReleaseTmpRegister(doneLocation);
+                funcInfo->ReleaseTmpRegister(itemLocation);
+                break;
+            }
+        }
+
         // If the iterator hasn't completed, skip assigning undefined.
         Js::ByteCodeLabel iteratorAlreadyDone = byteCodeGenerator->Writer()->DefineLabel();
         byteCodeGenerator->Writer()->BrReg1(Js::OpCode::BrTrue_A, iteratorAlreadyDone, doneLocation);
-        funcInfo->ReleaseTmpRegister(doneLocation);
 
         // We're not done with the iterator, so assign the .next() value.
         Js::RegSlot valueLocation = funcInfo->AcquireTmpRegister();
         EmitIteratorValue(valueLocation, itemLocation, byteCodeGenerator, funcInfo);
         Js::ByteCodeLabel beforeDefaultAssign = byteCodeGenerator->Writer()->DefineLabel();
+
+        byteCodeGenerator->Writer()->Reg1(Js::OpCode::LdTrue, shouldCallReturnFunctionLocation);
         byteCodeGenerator->Writer()->Br(beforeDefaultAssign);
 
         // iteratorAlreadyDone:
@@ -6303,7 +6317,15 @@ void EmitDestructuredArray(
             EmitDestructuredValueOrInitializer(elem, valueLocation, init, byteCodeGenerator, funcInfo);
         }
 
+        byteCodeGenerator->Writer()->Reg1(Js::OpCode::LdFalse, shouldCallReturnFunctionLocation);
+
+        if (list->nop != knopList)
+        {
+            EmitIteratorCloseIfNotDone(iteratorLocation, doneLocation, byteCodeGenerator, funcInfo);
+        }
+
         funcInfo->ReleaseTmpRegister(valueLocation);
+        funcInfo->ReleaseTmpRegister(doneLocation);
         funcInfo->ReleaseTmpRegister(itemLocation);
 
         byteCodeGenerator->EndStatement(elem);
@@ -6321,8 +6343,182 @@ void EmitDestructuredArray(
     // If we saw a rest element, emit the rest array.
     if (elem != nullptr && elem->nop == knopEllipsis)
     {
-        EmitDestructuredRestArray(elem, iteratorLocation, byteCodeGenerator, funcInfo);
+        EmitDestructuredRestArray(elem, iteratorLocation, shouldCallReturnFunctionLocation, byteCodeGenerator, funcInfo);
     }
+}
+
+// Generating
+// try {
+//    CallIteratorClose
+// } catch (e) {
+//    do nothing 
+// }
+
+void EmitTryCatchAroundClose(
+    Js::RegSlot iteratorLocation,
+    Js::ByteCodeLabel endLabel,
+    ByteCodeGenerator *byteCodeGenerator,
+    FuncInfo *funcInfo)
+{
+    Js::ByteCodeLabel catchLabel = byteCodeGenerator->Writer()->DefineLabel();
+    byteCodeGenerator->Writer()->Br(Js::OpCode::TryCatch, catchLabel);
+
+    //
+    // There is no need to add TryScopeRecord here as we are going to call 'return' function and there is not yield expression here.
+
+    EmitIteratorClose(iteratorLocation, byteCodeGenerator, funcInfo);
+
+    byteCodeGenerator->Writer()->Empty(Js::OpCode::Leave);
+    byteCodeGenerator->Writer()->Br(endLabel);
+
+    byteCodeGenerator->Writer()->MarkLabel(catchLabel);
+    Js::RegSlot catchParamLocation = funcInfo->AcquireTmpRegister();
+    byteCodeGenerator->Writer()->Reg1(Js::OpCode::Catch, catchParamLocation);
+    funcInfo->ReleaseTmpRegister(catchParamLocation);
+
+    byteCodeGenerator->Writer()->Empty(Js::OpCode::Leave);
+}
+
+struct ByteCodeGenerator::TryScopeRecord : public JsUtil::DoublyLinkedListElement<TryScopeRecord>
+{
+    Js::OpCode op;
+    Js::ByteCodeLabel label;
+    Js::RegSlot reg1;
+    Js::RegSlot reg2;
+
+    TryScopeRecord(Js::OpCode op, Js::ByteCodeLabel label) : op(op), label(label), reg1(Js::Constants::NoRegister), reg2(Js::Constants::NoRegister) { }
+    TryScopeRecord(Js::OpCode op, Js::ByteCodeLabel label, Js::RegSlot r1, Js::RegSlot r2) : op(op), label(label), reg1(r1), reg2(r2) { }
+};
+
+// Generating
+// finally {
+//    if (hasReturnFunction)
+//        EmitTryCatchAroundClose
+// }
+
+void EmitFinallyForClose(
+    Js::RegSlot iteratorLocation,
+    Js::RegSlot returnLocation,
+    Js::RegSlot yieldExceptionLocation,
+    Js::RegSlot yieldOffsetLocation,
+    Js::ByteCodeLabel finallyLabel,
+    ByteCodeGenerator *byteCodeGenerator,
+    FuncInfo *funcInfo)
+{
+    Js::ByteCodeLabel afterFinallyBlockLabel = byteCodeGenerator->Writer()->DefineLabel();
+    byteCodeGenerator->Writer()->Empty(Js::OpCode::Leave);
+
+    byteCodeGenerator->Writer()->RecordCrossFrameEntryExitRecord(false);
+    byteCodeGenerator->Writer()->RecordCrossFrameEntryExitRecord(true);
+
+    byteCodeGenerator->Writer()->Br(afterFinallyBlockLabel);
+    byteCodeGenerator->Writer()->MarkLabel(finallyLabel);
+
+    bool isGenerator = funcInfo->byteCodeFunction->IsGenerator();
+    ByteCodeGenerator::TryScopeRecord tryRecForFinally(Js::OpCode::ResumeFinally, finallyLabel, yieldExceptionLocation, yieldOffsetLocation);
+    if (isGenerator)
+    {
+        byteCodeGenerator->tryScopeRecordsList.LinkToEnd(&tryRecForFinally);
+    }
+
+    Js::ByteCodeLabel skipCallTryCatchLabel = byteCodeGenerator->Writer()->DefineLabel();
+
+    byteCodeGenerator->Writer()->BrReg1(Js::OpCode::BrFalse_A, skipCallTryCatchLabel, returnLocation);
+    EmitTryCatchAroundClose(iteratorLocation, skipCallTryCatchLabel, byteCodeGenerator, funcInfo);
+
+    byteCodeGenerator->Writer()->MarkLabel(skipCallTryCatchLabel);
+
+    if (isGenerator)
+    {
+        byteCodeGenerator->tryScopeRecordsList.UnlinkFromEnd();
+        funcInfo->ReleaseTmpRegister(yieldOffsetLocation);
+        funcInfo->ReleaseTmpRegister(yieldExceptionLocation);
+    }
+
+    byteCodeGenerator->Writer()->RecordCrossFrameEntryExitRecord(false);
+    byteCodeGenerator->Writer()->Empty(Js::OpCode::LeaveNull);
+    byteCodeGenerator->Writer()->MarkLabel(afterFinallyBlockLabel);
+}
+
+// Emit a wrapper try..finaly block around the destructuring elements
+void EmitDestructuredArray(
+    ParseNode *lhs,
+    Js::RegSlot rhsLocation,
+    ByteCodeGenerator *byteCodeGenerator,
+    FuncInfo *funcInfo)
+{
+    byteCodeGenerator->StartStatement(lhs);
+    Js::RegSlot iteratorLocation = funcInfo->AcquireTmpRegister();
+
+    EmitGetIterator(iteratorLocation, rhsLocation, byteCodeGenerator, funcInfo);
+
+    Assert(lhs->nop == knopArrayPattern);
+    ParseNode *list = lhs->sxArrLit.pnode1;
+
+    if (list == nullptr)
+    { // Handline this case ([] = obj);
+        EmitIteratorClose(iteratorLocation, byteCodeGenerator, funcInfo);
+
+        // No elements to bind or assign.
+        funcInfo->ReleaseTmpRegister(iteratorLocation);
+        byteCodeGenerator->EndStatement(lhs);
+        return;
+    }
+
+    // This variable facilitates on when to call the return function (which is Iterator close). When we are emitting bytecode for destructuring element
+    // this variable will be set to true.
+    Js::RegSlot shouldCallReturnFunctionLocation = funcInfo->AcquireTmpRegister();
+    byteCodeGenerator->Writer()->Reg1(Js::OpCode::LdFalse, shouldCallReturnFunctionLocation);
+
+    byteCodeGenerator->SetHasFinally(true);
+    byteCodeGenerator->SetHasTry(true);
+    byteCodeGenerator->TopFuncInfo()->byteCodeFunction->SetDontInline(true);
+
+    Js::RegSlot regException = Js::Constants::NoRegister;
+    Js::RegSlot regOffset = Js::Constants::NoRegister;
+    bool isGenerator = funcInfo->byteCodeFunction->IsGenerator();
+
+    if (isGenerator)
+    {
+        regException = funcInfo->AcquireTmpRegister();
+        regOffset = funcInfo->AcquireTmpRegister();
+    }
+
+    // Insert try node here 
+    Js::ByteCodeLabel finallyLabel = byteCodeGenerator->Writer()->DefineLabel();
+    byteCodeGenerator->Writer()->RecordCrossFrameEntryExitRecord(true);
+
+    //byteCodeGenerator->Writer()->Br(Js::OpCode::TryFinally, finallyLabel);
+    ByteCodeGenerator::TryScopeRecord tryRecForTryFinally(Js::OpCode::TryFinallyWithYield, finallyLabel);
+
+    if (isGenerator)
+    {
+        byteCodeGenerator->Writer()->BrReg2(Js::OpCode::TryFinallyWithYield, finallyLabel, regException, regOffset);
+        tryRecForTryFinally.reg1 = regException;
+        tryRecForTryFinally.reg2 = regOffset;
+        byteCodeGenerator->tryScopeRecordsList.LinkToEnd(&tryRecForTryFinally);
+    }
+    else
+    {
+        byteCodeGenerator->Writer()->Br(Js::OpCode::TryFinally, finallyLabel);
+    }
+
+    EmitDestructuredArrayCore(list, iteratorLocation, shouldCallReturnFunctionLocation, byteCodeGenerator, funcInfo);
+
+    if (isGenerator)
+    {
+        byteCodeGenerator->tryScopeRecordsList.UnlinkFromEnd();
+    }
+
+    EmitFinallyForClose(iteratorLocation,
+        shouldCallReturnFunctionLocation,
+        regException,
+        regOffset,
+        finallyLabel,
+        byteCodeGenerator,
+        funcInfo);
+
+    funcInfo->ReleaseTmpRegister(shouldCallReturnFunctionLocation);
     funcInfo->ReleaseTmpRegister(iteratorLocation);
 
     byteCodeGenerator->EndStatement(lhs);
@@ -6479,7 +6675,7 @@ void EmitAssignment(
 {
     switch (lhs->nop)
     {
-    // assignment to a local or global variable
+        // assignment to a local or global variable
     case knopVarDecl:
     case knopLetDecl:
     case knopConstDecl:
@@ -6582,7 +6778,7 @@ void EmitLoad(
     switch (lhs->nop)
     {
 
-    // load of a local or global variable
+        // load of a local or global variable
     case knopName:
     {
         funcInfo->AcquireLoc(lhs);
@@ -6609,7 +6805,7 @@ void EmitLoad(
             Js::OpCode::LdElemI_A, lhs->location, lhs->sxBin.pnode1->location, lhs->sxBin.pnode2->location);
         break;
 
-    // f(x) +=
+        // f(x) +=
     case knopCall:
         funcInfo->AcquireLoc(lhs);
         EmitReference(lhs, byteCodeGenerator, funcInfo);
@@ -7262,7 +7458,7 @@ void EmitCallTarget(
         }
 
         Emit(pnodeTarget->sxBin.pnode1, byteCodeGenerator, funcInfo, false);
-        Js::PropertyId propertyId = pnodeTarget->sxBin.pnode2->sxPid.PropertyIdFromNameNode();        
+        Js::PropertyId propertyId = pnodeTarget->sxBin.pnode2->sxPid.PropertyIdFromNameNode();
         Js::RegSlot protoLocation = pnodeTarget->sxBin.pnode1->location;
         EmitSuperMethodBegin(pnodeTarget, byteCodeGenerator, funcInfo);
         EmitMethodFld(pnodeTarget, protoLocation, propertyId, byteCodeGenerator, funcInfo);
@@ -7286,7 +7482,7 @@ void EmitCallTarget(
         Emit(pnodeTarget->sxBin.pnode1, byteCodeGenerator, funcInfo, false);
         Emit(pnodeTarget->sxBin.pnode2, byteCodeGenerator, funcInfo, false);
 
-        Js::RegSlot indexLocation = pnodeTarget->sxBin.pnode2->location;        
+        Js::RegSlot indexLocation = pnodeTarget->sxBin.pnode2->location;
         Js::RegSlot protoLocation = pnodeTarget->sxBin.pnode1->location;
         EmitSuperMethodBegin(pnodeTarget, byteCodeGenerator, funcInfo);
         EmitMethodElem(pnodeTarget, protoLocation, indexLocation, byteCodeGenerator);
@@ -8540,6 +8736,36 @@ void EmitIteratorNext(Js::RegSlot itemLocation, Js::RegSlot iteratorLocation, Js
     byteCodeGenerator->Writer()->MarkLabel(skipThrow);
 }
 
+// Generating
+// if (hasReturnFunction) {
+//     value = Call Retrun;
+//     if (value != Object) 
+//        throw TypeError;
+// }
+
+void EmitIteratorClose(Js::RegSlot iteratorLocation, ByteCodeGenerator* byteCodeGenerator, FuncInfo* funcInfo)
+{
+    Js::RegSlot returnLocation = funcInfo->AcquireTmpRegister();
+
+    Js::ByteCodeLabel skipThrow = byteCodeGenerator->Writer()->DefineLabel();
+    Js::ByteCodeLabel noReturn = byteCodeGenerator->Writer()->DefineLabel();
+
+    uint cacheId = funcInfo->FindOrAddInlineCacheId(iteratorLocation, Js::PropertyIds::return_, false, false);
+    byteCodeGenerator->Writer()->PatchableProperty(Js::OpCode::LdFld, returnLocation, iteratorLocation, cacheId);
+
+    byteCodeGenerator->Writer()->BrReg2(Js::OpCode::BrEq_A, noReturn, returnLocation, funcInfo->undefinedConstantRegister);
+
+    EmitInvoke(returnLocation, iteratorLocation, Js::PropertyIds::return_, byteCodeGenerator, funcInfo);
+
+    // throw TypeError if the result is not an Object
+    byteCodeGenerator->Writer()->BrReg1(Js::OpCode::BrOnObject_A, skipThrow, returnLocation);
+    byteCodeGenerator->Writer()->W1(Js::OpCode::RuntimeTypeError, SCODE_CODE(JSERR_NeedObject));
+    byteCodeGenerator->Writer()->MarkLabel(skipThrow);
+    byteCodeGenerator->Writer()->MarkLabel(noReturn);
+
+    funcInfo->ReleaseTmpRegister(returnLocation);
+}
+
 void EmitIteratorComplete(Js::RegSlot doneLocation, Js::RegSlot iteratorResultLocation, ByteCodeGenerator* byteCodeGenerator, FuncInfo* funcInfo)
 {
     // get the iterator result's "done" property
@@ -8555,6 +8781,198 @@ void EmitIteratorValue(Js::RegSlot valueLocation, Js::RegSlot iteratorResultLoca
     // get the iterator result's "value" property
     uint cacheId = funcInfo->FindOrAddInlineCacheId(iteratorResultLocation, Js::PropertyIds::value, false, false);
     byteCodeGenerator->Writer()->PatchableProperty(Js::OpCode::LdFld, valueLocation, iteratorResultLocation, cacheId);
+}
+
+// Generating
+// catch(e) {
+//      if (shouldCallReturn)
+//          CallReturnWhichWrappedByTryCatch
+//      throw e;
+// }
+void EmitTopLevelCatchForOf(Js::ByteCodeLabel catchLabel,
+    Js::RegSlot iteratorLocation,
+    Js::RegSlot shouldCallReturnLocation,
+    Js::RegSlot shouldCallReturnLocationFinally,
+    ByteCodeGenerator *byteCodeGenerator,
+    FuncInfo *funcInfo)
+{
+    Js::ByteCodeLabel afterCatchBlockLabel = byteCodeGenerator->Writer()->DefineLabel();
+    byteCodeGenerator->Writer()->Empty(Js::OpCode::Leave);
+    byteCodeGenerator->Writer()->Br(afterCatchBlockLabel);
+    byteCodeGenerator->Writer()->MarkLabel(catchLabel);
+
+    Js::RegSlot catchParamLocation = funcInfo->AcquireTmpRegister();
+    byteCodeGenerator->Writer()->Reg1(Js::OpCode::Catch, catchParamLocation);
+
+    ByteCodeGenerator::TryScopeRecord tryRecForCatch(Js::OpCode::ResumeCatch, catchLabel);
+    if (funcInfo->byteCodeFunction->IsGenerator())
+    {
+        byteCodeGenerator->tryScopeRecordsList.LinkToEnd(&tryRecForCatch);
+    }
+
+    Js::ByteCodeLabel skipCallCloseLabel = byteCodeGenerator->Writer()->DefineLabel();
+
+    byteCodeGenerator->Writer()->BrReg1(Js::OpCode::BrFalse_A, skipCallCloseLabel, shouldCallReturnLocation);
+    byteCodeGenerator->Writer()->Reg1(Js::OpCode::LdFalse, shouldCallReturnLocationFinally);
+    EmitTryCatchAroundClose(iteratorLocation, skipCallCloseLabel, byteCodeGenerator, funcInfo);
+
+    byteCodeGenerator->Writer()->MarkLabel(skipCallCloseLabel);
+
+    // Rethrow the exception.
+    byteCodeGenerator->Writer()->Reg1(Js::OpCode::Throw, catchParamLocation);
+
+    funcInfo->ReleaseTmpRegister(catchParamLocation);
+
+    if (funcInfo->byteCodeFunction->IsGenerator())
+    {
+        byteCodeGenerator->tryScopeRecordsList.UnlinkFromEnd();
+    }
+
+    byteCodeGenerator->Writer()->Empty(Js::OpCode::Leave);
+    byteCodeGenerator->Writer()->MarkLabel(afterCatchBlockLabel);
+}
+
+// Generating
+// finally {
+//      if (shouldCallReturn)
+//          CallReturn
+// }
+
+void EmitTopLevelFinallyForOf(Js::ByteCodeLabel finallyLabel,
+    Js::RegSlot iteratorLocation,
+    Js::RegSlot shouldCallReturnLocation,
+    Js::RegSlot yieldExceptionLocation,
+    Js::RegSlot yieldOffsetLocation,
+    ByteCodeGenerator *byteCodeGenerator,
+    FuncInfo *funcInfo)
+{
+    bool isGenerator = funcInfo->byteCodeFunction->IsGenerator();
+
+    Js::ByteCodeLabel afterFinallyBlockLabel = byteCodeGenerator->Writer()->DefineLabel();
+    byteCodeGenerator->Writer()->Empty(Js::OpCode::Leave);
+
+    byteCodeGenerator->Writer()->RecordCrossFrameEntryExitRecord(false);
+    byteCodeGenerator->Writer()->RecordCrossFrameEntryExitRecord(true);
+
+    byteCodeGenerator->Writer()->Br(afterFinallyBlockLabel);
+    byteCodeGenerator->Writer()->MarkLabel(finallyLabel);
+
+    ByteCodeGenerator::TryScopeRecord tryRecForFinally(Js::OpCode::ResumeFinally, finallyLabel, yieldExceptionLocation, yieldOffsetLocation);
+    if (isGenerator)
+    {
+        byteCodeGenerator->tryScopeRecordsList.LinkToEnd(&tryRecForFinally);
+    }
+
+    Js::ByteCodeLabel skipCallCloseLabel = byteCodeGenerator->Writer()->DefineLabel();
+
+    byteCodeGenerator->Writer()->BrReg1(Js::OpCode::BrFalse_A, skipCallCloseLabel, shouldCallReturnLocation);
+    EmitIteratorClose(iteratorLocation, byteCodeGenerator, funcInfo);
+
+    byteCodeGenerator->Writer()->MarkLabel(skipCallCloseLabel);
+
+    if (isGenerator)
+    {
+        byteCodeGenerator->tryScopeRecordsList.UnlinkFromEnd();
+        funcInfo->ReleaseTmpRegister(yieldOffsetLocation);
+        funcInfo->ReleaseTmpRegister(yieldExceptionLocation);
+    }
+
+    byteCodeGenerator->Writer()->RecordCrossFrameEntryExitRecord(false);
+    byteCodeGenerator->Writer()->Empty(Js::OpCode::LeaveNull);
+    byteCodeGenerator->Writer()->MarkLabel(afterFinallyBlockLabel);
+}
+
+void EmitForInOfLoopBody(ParseNode *loopNode,
+    Js::ByteCodeLabel loopEntrance,
+    Js::ByteCodeLabel continuePastLoop,
+    ByteCodeGenerator *byteCodeGenerator,
+    FuncInfo *funcInfo,
+    BOOL fReturnValue)
+{
+    if (loopNode->sxForInOrForOf.pnodeLval->nop != knopVarDecl &&
+        loopNode->sxForInOrForOf.pnodeLval->nop != knopLetDecl &&
+        loopNode->sxForInOrForOf.pnodeLval->nop != knopConstDecl)
+    {
+        EmitReference(loopNode->sxForInOrForOf.pnodeLval, byteCodeGenerator, funcInfo);
+    }
+    else
+    {
+        Symbol * sym = loopNode->sxForInOrForOf.pnodeLval->sxVar.sym;
+        sym->SetNeedDeclaration(false);
+    }
+
+    if (byteCodeGenerator->IsES6ForLoopSemanticsEnabled())
+    {
+        BeginEmitBlock(loopNode->sxForInOrForOf.pnodeBlock, byteCodeGenerator, funcInfo);
+    }
+
+    EmitAssignment(nullptr, loopNode->sxForInOrForOf.pnodeLval, loopNode->sxForInOrForOf.itemLocation, byteCodeGenerator, funcInfo);
+
+    // The StartStatement is already done in the caller of this function.
+    byteCodeGenerator->EndStatement(loopNode->sxForInOrForOf.pnodeLval);
+
+    funcInfo->ReleaseReference(loopNode->sxForInOrForOf.pnodeLval);
+
+    Emit(loopNode->sxForInOrForOf.pnodeBody, byteCodeGenerator, funcInfo, fReturnValue);
+    funcInfo->ReleaseLoc(loopNode->sxForInOrForOf.pnodeBody);
+
+    if (byteCodeGenerator->IsES6ForLoopSemanticsEnabled())
+    {
+        EndEmitBlock(loopNode->sxForInOrForOf.pnodeBlock, byteCodeGenerator, funcInfo);
+    }
+
+    funcInfo->ReleaseTmpRegister(loopNode->sxForInOrForOf.itemLocation);
+    if (loopNode->emitLabels)
+    {
+        byteCodeGenerator->Writer()->MarkLabel(loopNode->sxForInOrForOf.continueLabel);
+    }
+    byteCodeGenerator->Writer()->Br(loopEntrance);
+    byteCodeGenerator->Writer()->MarkLabel(continuePastLoop);
+    if (loopNode->emitLabels)
+    {
+        byteCodeGenerator->Writer()->MarkLabel(loopNode->sxForInOrForOf.breakLabel);
+    }
+}
+
+void EmitForIn(ParseNode *loopNode,
+    Js::ByteCodeLabel loopEntrance,
+    Js::ByteCodeLabel continuePastLoop,
+    ByteCodeGenerator *byteCodeGenerator,
+    FuncInfo *funcInfo,
+    BOOL fReturnValue)
+{
+    Assert(loopNode->nop == knopForIn);
+
+    // Grab registers for the enumerator and for the current enumerated item.
+    // The enumerator register will be released after this call returns.
+    loopNode->sxForInOrForOf.itemLocation = funcInfo->AcquireTmpRegister();
+
+    // get enumerator from the collection
+    byteCodeGenerator->Writer()->Reg2(Js::OpCode::GetForInEnumerator, loopNode->location, loopNode->sxForInOrForOf.pnodeObj->location);
+
+    // The StartStatement is already done in the caller of the current function, which is EmitForInOrForOf
+    byteCodeGenerator->EndStatement(loopNode);
+
+    // Need to increment loop count whether we are going into profile or not for HasLoop()
+    uint loopId = byteCodeGenerator->Writer()->EnterLoop(loopEntrance);
+    loopNode->sxForInOrForOf.loopId = loopId;
+
+    // The EndStatement will happen in the EmitForInOfLoopBody function
+    byteCodeGenerator->StartStatement(loopNode->sxForInOrForOf.pnodeLval);
+
+    // branch past loop when GetCurrentAndMoveNext returns nullptr
+    byteCodeGenerator->Writer()->BrReg2(Js::OpCode::BrOnEmpty, continuePastLoop, loopNode->sxForInOrForOf.itemLocation, loopNode->location);
+    
+    EmitForInOfLoopBody(loopNode, loopEntrance, continuePastLoop, byteCodeGenerator, funcInfo, fReturnValue);
+
+    byteCodeGenerator->Writer()->ExitLoop(loopId);
+
+    byteCodeGenerator->Writer()->Reg1(Js::OpCode::ReleaseForInEnumerator, loopNode->location);
+
+    if (!byteCodeGenerator->IsES6ForLoopSemanticsEnabled())
+    {
+        EndEmitBlock(loopNode->sxForInOrForOf.pnodeBlock, byteCodeGenerator, funcInfo);
+    }
 }
 
 void EmitForInOrForOf(ParseNode *loopNode, ByteCodeGenerator *byteCodeGenerator, FuncInfo *funcInfo, BOOL fReturnValue)
@@ -8583,7 +9001,6 @@ void EmitForInOrForOf(ParseNode *loopNode, ByteCodeGenerator *byteCodeGenerator,
     }
     Js::ByteCodeLabel loopEntrance = byteCodeGenerator->Writer()->DefineLabel();
     Js::ByteCodeLabel continuePastLoop = byteCodeGenerator->Writer()->DefineLabel();
-    Js::ByteCodeLabel skipPastLoop = byteCodeGenerator->Writer()->DefineLabel();
 
     if (loopNode->sxForInOrForOf.pnodeLval->nop == knopVarDecl)
     {
@@ -8604,32 +9021,91 @@ void EmitForInOrForOf(ParseNode *loopNode, ByteCodeGenerator *byteCodeGenerator,
         }
     }
 
+    if (isForIn)
+    {
+        EmitForIn(loopNode, loopEntrance, continuePastLoop, byteCodeGenerator, funcInfo, fReturnValue);
+
+        if (!byteCodeGenerator->IsES6ForLoopSemanticsEnabled())
+        {
+            EndEmitBlock(loopNode->sxForInOrForOf.pnodeBlock, byteCodeGenerator, funcInfo);
+        }
+
+        return;
+    }
+
+    Js::RegSlot regException = Js::Constants::NoRegister;
+    Js::RegSlot regOffset = Js::Constants::NoRegister;
+
+    // These two temp variables store the information of return function to be called or not.
+    // one variable is used for catch block and one is used for finally block. These variable will be set to true when we think that return function
+    // to be called on abrupt loop break. 
+    // Why two variables? since these are temps and JIT does like not flow if single variable is used in multiple blocks.
+    Js::RegSlot shouldCallReturnFunctionLocation = funcInfo->AcquireTmpRegister();
+    Js::RegSlot shouldCallReturnFunctionLocationFinally = funcInfo->AcquireTmpRegister();
+
+    bool isGenerator = funcInfo->byteCodeFunction->IsGenerator();
+
+    if (isGenerator)
+    {
+        regException = funcInfo->AcquireTmpRegister();
+        regOffset = funcInfo->AcquireTmpRegister();
+    }
+
     // Grab registers for the enumerator and for the current enumerated item.
     // The enumerator register will be released after this call returns.
     loopNode->sxForInOrForOf.itemLocation = funcInfo->AcquireTmpRegister();
 
-    if (isForIn)
+    Js::ByteCodeLabel skipPastLoop = byteCodeGenerator->Writer()->DefineLabel();
+
+    // We want call profile information on the @@iterator call, so instead of adding a GetForOfIterator bytecode op
+    // to do all the following work in a helper do it explicitly in bytecode so that the @@iterator call is exposed
+    // to the profiler and JIT.
+
+    // If collection is null or undefined, don't enter the loop.
+    byteCodeGenerator->Writer()->BrReg2(Js::OpCode::BrSrEq_A, skipPastLoop, loopNode->sxForInOrForOf.pnodeObj->location, funcInfo->nullConstantRegister);
+    byteCodeGenerator->Writer()->BrReg2(Js::OpCode::BrSrEq_A, skipPastLoop, loopNode->sxForInOrForOf.pnodeObj->location, funcInfo->undefinedConstantRegister);
+
+    byteCodeGenerator->SetHasFinally(true);
+    byteCodeGenerator->SetHasTry(true);
+    byteCodeGenerator->TopFuncInfo()->byteCodeFunction->SetDontInline(true);
+
+    // do a ToObject on the collection
+    Js::RegSlot tmpObj = funcInfo->AcquireTmpRegister();
+    byteCodeGenerator->Writer()->Reg2(Js::OpCode::Conv_Obj, tmpObj, loopNode->sxForInOrForOf.pnodeObj->location);
+
+    EmitGetIterator(loopNode->location, tmpObj, byteCodeGenerator, funcInfo);
+    funcInfo->ReleaseTmpRegister(tmpObj);
+
+    // The whole loop is surrounded with try..catch..finally - in order to capture the abrupt completion.
+    Js::ByteCodeLabel finallyLabel = byteCodeGenerator->Writer()->DefineLabel();
+    Js::ByteCodeLabel catchLabel = byteCodeGenerator->Writer()->DefineLabel();
+    byteCodeGenerator->Writer()->RecordCrossFrameEntryExitRecord(true);
+
+    byteCodeGenerator->Writer()->Reg1(Js::OpCode::LdFalse, shouldCallReturnFunctionLocation);
+    byteCodeGenerator->Writer()->Reg1(Js::OpCode::LdFalse, shouldCallReturnFunctionLocationFinally);
+
+    ByteCodeGenerator::TryScopeRecord tryRecForTryFinally(Js::OpCode::TryFinallyWithYield, finallyLabel);
+
+    if (isGenerator)
     {
-        // get enumerator from the collection
-        byteCodeGenerator->Writer()->Reg2(Js::OpCode::GetForInEnumerator, loopNode->location, loopNode->sxForInOrForOf.pnodeObj->location);
+        byteCodeGenerator->Writer()->BrReg2(Js::OpCode::TryFinallyWithYield, finallyLabel, regException, regOffset);
+        tryRecForTryFinally.reg1 = regException;
+        tryRecForTryFinally.reg2 = regOffset;
+        byteCodeGenerator->tryScopeRecordsList.LinkToEnd(&tryRecForTryFinally);
     }
     else
     {
-        // We want call profile information on the @@iterator call, so instead of adding a GetForOfIterator bytecode op
-        // to do all the following work in a helper do it explicitly in bytecode so that the @@iterator call is exposed
-        // to the profiler and JIT.
-
-        // If collection is null or undefined, don't enter the loop.
-        byteCodeGenerator->Writer()->BrReg2(Js::OpCode::BrSrEq_A, skipPastLoop, loopNode->sxForInOrForOf.pnodeObj->location, funcInfo->nullConstantRegister);
-        byteCodeGenerator->Writer()->BrReg2(Js::OpCode::BrSrEq_A, skipPastLoop, loopNode->sxForInOrForOf.pnodeObj->location, funcInfo->undefinedConstantRegister);
-
-        // do a ToObject on the collection
-        Js::RegSlot tmpObj = funcInfo->AcquireTmpRegister();
-        byteCodeGenerator->Writer()->Reg2(Js::OpCode::Conv_Obj, tmpObj, loopNode->sxForInOrForOf.pnodeObj->location);
-
-        EmitGetIterator(loopNode->location, tmpObj, byteCodeGenerator, funcInfo);
-        funcInfo->ReleaseTmpRegister(tmpObj);
+        byteCodeGenerator->Writer()->Br(Js::OpCode::TryFinally, finallyLabel);
     }
+
+    byteCodeGenerator->Writer()->Br(Js::OpCode::TryCatch, catchLabel);
+
+    ByteCodeGenerator::TryScopeRecord tryRecForTry(Js::OpCode::TryCatch, catchLabel);
+    if (isGenerator)
+    {
+        byteCodeGenerator->tryScopeRecordsList.LinkToEnd(&tryRecForTry);
+    }
+
     byteCodeGenerator->EndStatement(loopNode);
 
     // Need to increment loop count whether we are going into profile or not for HasLoop()
@@ -8638,78 +9114,57 @@ void EmitForInOrForOf(ParseNode *loopNode, ByteCodeGenerator *byteCodeGenerator,
 
     byteCodeGenerator->StartStatement(loopNode->sxForInOrForOf.pnodeLval);
 
-    if (isForIn)
-    {
-        // branch past loop when GetCurrentAndMoveNext returns nullptr
-        byteCodeGenerator->Writer()->BrReg2(Js::OpCode::BrOnEmpty, continuePastLoop, loopNode->sxForInOrForOf.itemLocation, loopNode->location);
-    }
-    else
-    {
-        EmitIteratorNext(loopNode->sxForInOrForOf.itemLocation, loopNode->location, Js::Constants::NoRegister, byteCodeGenerator, funcInfo);
+    byteCodeGenerator->Writer()->Reg1(Js::OpCode::LdFalse, shouldCallReturnFunctionLocation);
+    byteCodeGenerator->Writer()->Reg1(Js::OpCode::LdFalse, shouldCallReturnFunctionLocationFinally);
 
-        Js::RegSlot doneLocation = funcInfo->AcquireTmpRegister();
-        EmitIteratorComplete(doneLocation, loopNode->sxForInOrForOf.itemLocation, byteCodeGenerator, funcInfo);
+    EmitIteratorNext(loopNode->sxForInOrForOf.itemLocation, loopNode->location, Js::Constants::NoRegister, byteCodeGenerator, funcInfo);
 
-        // branch past loop if the result's done property is truthy
-        byteCodeGenerator->Writer()->BrReg1(Js::OpCode::BrTrue_A, continuePastLoop, doneLocation);
-        funcInfo->ReleaseTmpRegister(doneLocation);
+    Js::RegSlot doneLocation = funcInfo->AcquireTmpRegister();
+    EmitIteratorComplete(doneLocation, loopNode->sxForInOrForOf.itemLocation, byteCodeGenerator, funcInfo);
 
-        // otherwise put result's value property in itemLocation
-        EmitIteratorValue(loopNode->sxForInOrForOf.itemLocation, loopNode->sxForInOrForOf.itemLocation, byteCodeGenerator, funcInfo);
-    }
+    // branch past loop if the result's done property is truthy
+    byteCodeGenerator->Writer()->BrReg1(Js::OpCode::BrTrue_A, continuePastLoop, doneLocation);
+    funcInfo->ReleaseTmpRegister(doneLocation);
 
-    if (loopNode->sxForInOrForOf.pnodeLval->nop != knopVarDecl &&
-        loopNode->sxForInOrForOf.pnodeLval->nop != knopLetDecl &&
-        loopNode->sxForInOrForOf.pnodeLval->nop != knopConstDecl)
-    {
-        EmitReference(loopNode->sxForInOrForOf.pnodeLval, byteCodeGenerator, funcInfo);
-    }
-    else
-    {
-        Symbol * sym = loopNode->sxForInOrForOf.pnodeLval->sxVar.sym;
-        sym->SetNeedDeclaration(false);
-    }
+    // otherwise put result's value property in itemLocation
+    EmitIteratorValue(loopNode->sxForInOrForOf.itemLocation, loopNode->sxForInOrForOf.itemLocation, byteCodeGenerator, funcInfo);
 
-    if (byteCodeGenerator->IsES6ForLoopSemanticsEnabled())
-    {
-        BeginEmitBlock(loopNode->sxForInOrForOf.pnodeBlock, byteCodeGenerator, funcInfo);
-    }
+    byteCodeGenerator->Writer()->Reg1(Js::OpCode::LdTrue, shouldCallReturnFunctionLocation);
+    byteCodeGenerator->Writer()->Reg1(Js::OpCode::LdTrue, shouldCallReturnFunctionLocationFinally);
 
-    EmitAssignment(nullptr, loopNode->sxForInOrForOf.pnodeLval, loopNode->sxForInOrForOf.itemLocation, byteCodeGenerator, funcInfo);
+    EmitForInOfLoopBody(loopNode, loopEntrance, continuePastLoop, byteCodeGenerator, funcInfo, fReturnValue);
 
-    byteCodeGenerator->EndStatement(loopNode->sxForInOrForOf.pnodeLval);
-
-    funcInfo->ReleaseReference(loopNode->sxForInOrForOf.pnodeLval);
-
-    Emit(loopNode->sxForInOrForOf.pnodeBody, byteCodeGenerator, funcInfo, fReturnValue);
-    funcInfo->ReleaseLoc(loopNode->sxForInOrForOf.pnodeBody);
-
-    if (byteCodeGenerator->IsES6ForLoopSemanticsEnabled())
-    {
-        EndEmitBlock(loopNode->sxForInOrForOf.pnodeBlock, byteCodeGenerator, funcInfo);
-    }
-
-    funcInfo->ReleaseTmpRegister(loopNode->sxForInOrForOf.itemLocation);
-    if (loopNode->emitLabels)
-    {
-        byteCodeGenerator->Writer()->MarkLabel(loopNode->sxForInOrForOf.continueLabel);
-    }
-    byteCodeGenerator->Writer()->Br(loopEntrance);
-    byteCodeGenerator->Writer()->MarkLabel(continuePastLoop);
-    if (loopNode->emitLabels)
-    {
-        byteCodeGenerator->Writer()->MarkLabel(loopNode->sxForInOrForOf.breakLabel);
-    }
     byteCodeGenerator->Writer()->ExitLoop(loopId);
 
-    if (isForIn)
+    if (isGenerator)
     {
-        byteCodeGenerator->Writer()->Reg1(Js::OpCode::ReleaseForInEnumerator, loopNode->location);
+        byteCodeGenerator->tryScopeRecordsList.UnlinkFromEnd();
     }
-    else
+
+    EmitTopLevelCatchForOf(catchLabel,
+        loopNode->location,
+        shouldCallReturnFunctionLocation,
+        shouldCallReturnFunctionLocationFinally,
+        byteCodeGenerator,
+        funcInfo);
+
+    if (isGenerator)
     {
-        byteCodeGenerator->Writer()->MarkLabel(skipPastLoop);
+        byteCodeGenerator->tryScopeRecordsList.UnlinkFromEnd();
     }
+
+    EmitTopLevelFinallyForOf(finallyLabel,
+        loopNode->location,
+        shouldCallReturnFunctionLocationFinally,
+        regException,
+        regOffset,
+        byteCodeGenerator,
+        funcInfo);
+
+    funcInfo->ReleaseTmpRegister(shouldCallReturnFunctionLocationFinally);
+    funcInfo->ReleaseTmpRegister(shouldCallReturnFunctionLocation);
+
+    byteCodeGenerator->Writer()->MarkLabel(skipPastLoop);
 
     if (!byteCodeGenerator->IsES6ForLoopSemanticsEnabled())
     {
@@ -8749,17 +9204,30 @@ void EmitJumpCleanup(ParseNode *pnode, ParseNode *pnodeTarget, ByteCodeGenerator
             byteCodeGenerator->Writer()->Empty(Js::OpCode::Leave);
             break;
 
-#if ENABLE_PROFILE_INFO
-        case knopWhile:
-        case knopDoWhile:
-        case knopFor:
-        case knopForIn:
         case knopForOf:
+#if ENABLE_PROFILE_INFO
             if (Js::DynamicProfileInfo::EnableImplicitCallFlags(funcInfo->GetParsedFunctionBody()))
             {
                 byteCodeGenerator->Writer()->Unsigned1(Js::OpCode::ProfiledLoopEnd, pnode->sxLoop.loopId);
             }
 #endif
+            // The ForOf loop code is wrapped around try..catch..finally - Forcing couple Leave bytecode over here
+            byteCodeGenerator->Writer()->Empty(Js::OpCode::Leave);
+            byteCodeGenerator->Writer()->Empty(Js::OpCode::Leave);
+            break;
+
+#if ENABLE_PROFILE_INFO
+        case knopWhile:
+        case knopDoWhile:
+        case knopFor:
+        case knopForIn:
+            if (Js::DynamicProfileInfo::EnableImplicitCallFlags(funcInfo->GetParsedFunctionBody()))
+            {
+                byteCodeGenerator->Writer()->Unsigned1(Js::OpCode::ProfiledLoopEnd, pnode->sxLoop.loopId);
+            }
+            break;
+#endif
+
         }
     }
 }
@@ -9030,8 +9498,7 @@ void EmitAdd(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator, FuncInfo *f
                     byteCodeGenerator->Writer()->Reg3B1(
                         Js::OpCode::SetConcatStrMultiItem2, pnode->location, currNode->location, currNode2->location, (uint8)i);
                     i += 2;
-                }
-                while (concatOpnds.Count() > 1);
+                } while (concatOpnds.Count() > 1);
 
                 if (!concatOpnds.Empty())
                 {
@@ -9122,16 +9589,7 @@ void EmitSuperFieldPatch(FuncInfo* funcInfo, ParseNode* pnode, ByteCodeGenerator
     propFuncNode->sxFnc.pnodeName = nullptr;
 }
 
-struct ByteCodeGenerator::TryScopeRecord : public JsUtil::DoublyLinkedListElement<TryScopeRecord>
-{
-    Js::OpCode op;
-    Js::ByteCodeLabel label;
-    Js::RegSlot reg1;
-    Js::RegSlot reg2;
 
-    TryScopeRecord(Js::OpCode op, Js::ByteCodeLabel label) : op(op), label(label), reg1(Js::Constants::NoRegister), reg2(Js::Constants::NoRegister) { }
-    TryScopeRecord(Js::OpCode op, Js::ByteCodeLabel label, Js::RegSlot r1, Js::RegSlot r2) : op(op), label(label), reg1(r1), reg2(r2) { }
-};
 
 void ByteCodeGenerator::EmitLeaveOpCodesBeforeYield()
 {
@@ -9402,15 +9860,15 @@ void Emit(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator, FuncInfo *func
     case knopInt:
         // currently, these are loaded at the top
         break;
-    // PTNODE(knopFlt        , "flt const"    ,None    ,Flt  ,fnopLeaf|fnopConst)
+        // PTNODE(knopFlt        , "flt const"    ,None    ,Flt  ,fnopLeaf|fnopConst)
     case knopFlt:
         // currently, these are loaded at the top
         break;
-    // PTNODE(knopStr        , "str const"    ,None    ,Pid  ,fnopLeaf|fnopConst)
+        // PTNODE(knopStr        , "str const"    ,None    ,Pid  ,fnopLeaf|fnopConst)
     case knopStr:
         // TODO: protocol for combining string constants
         break;
-    // PTNODE(knopRegExp     , "reg expr"    ,None    ,Pid  ,fnopLeaf|fnopConst)
+        // PTNODE(knopRegExp     , "reg expr"    ,None    ,Pid  ,fnopLeaf|fnopConst)
     case knopRegExp:
         funcInfo->GetParsedFunctionBody()->SetLiteralRegex(pnode->sxPid.regexPatternIndex, pnode->sxPid.regexPattern);
         byteCodeGenerator->Writer()->Reg1Unsigned1(Js::OpCode::NewRegEx, funcInfo->AcquireLoc(pnode), pnode->sxPid.regexPatternIndex);
@@ -9420,10 +9878,10 @@ void Emit(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator, FuncInfo *func
         // Try to load 'this' from a scope slot if we are in a derived class constructor with scope slots. Otherwise, this is a nop.
         byteCodeGenerator->EmitScopeSlotLoadThis(funcInfo, funcInfo->thisPointerRegister);
         break;
-    // PTNODE(knopNewTarget      , "new.target"       ,None    , None        , fnopLeaf)
+        // PTNODE(knopNewTarget      , "new.target"       ,None    , None        , fnopLeaf)
     case knopNewTarget:
         break;
-    // PTNODE(knopSuper      , "super"       ,None    , None        , fnopLeaf)
+        // PTNODE(knopSuper      , "super"       ,None    , None        , fnopLeaf)
     case knopSuper:
         if (!funcInfo->IsClassMember())
         {
@@ -9456,19 +9914,19 @@ void Emit(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator, FuncInfo *func
             }
         }
         break;
-    // PTNODE(knopNull       , "null"        ,Null    ,None ,fnopLeaf)
+        // PTNODE(knopNull       , "null"        ,Null    ,None ,fnopLeaf)
     case knopNull:
         // enregistered
         break;
-    // PTNODE(knopFalse      , "false"        ,False   ,None ,fnopLeaf)
+        // PTNODE(knopFalse      , "false"        ,False   ,None ,fnopLeaf)
     case knopFalse:
         // enregistered
         break;
-    // PTNODE(knopTrue       , "true"        ,True    ,None ,fnopLeaf)
+        // PTNODE(knopTrue       , "true"        ,True    ,None ,fnopLeaf)
     case knopTrue:
         // enregistered
         break;
-    // PTNODE(knopEmpty      , "empty"        ,Empty   ,None ,fnopLeaf)
+        // PTNODE(knopEmpty      , "empty"        ,Empty   ,None ,fnopLeaf)
     case knopEmpty:
         break;
         // Unary operators.
@@ -9481,7 +9939,7 @@ void Emit(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator, FuncInfo *func
             Js::OpCode::Not_A, funcInfo->AcquireLoc(pnode), pnode->sxUni.pnode1->location);
         ENDSTATEMENET_IFTOPLEVEL(isTopLevel, pnode);
         break;
-    // PTNODE(knopNeg        , "unary -"    ,Neg     ,Uni  ,fnopUni)
+        // PTNODE(knopNeg        , "unary -"    ,Neg     ,Uni  ,fnopUni)
     case knopNeg:
         STARTSTATEMENET_IFTOPLEVEL(isTopLevel, pnode);
         Emit(pnode->sxUni.pnode1, byteCodeGenerator, funcInfo, false);
@@ -9491,7 +9949,7 @@ void Emit(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator, FuncInfo *func
             Js::OpCode::Neg_A, pnode->location, pnode->sxUni.pnode1->location);
         ENDSTATEMENET_IFTOPLEVEL(isTopLevel, pnode);
         break;
-    // PTNODE(knopPos        , "unary +"    ,Pos     ,Uni  ,fnopUni)
+        // PTNODE(knopPos        , "unary +"    ,Pos     ,Uni  ,fnopUni)
     case knopPos:
         STARTSTATEMENET_IFTOPLEVEL(isTopLevel, pnode);
         Emit(pnode->sxUni.pnode1, byteCodeGenerator, funcInfo, false);
@@ -9500,7 +9958,7 @@ void Emit(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator, FuncInfo *func
             Js::OpCode::Conv_Num, funcInfo->AcquireLoc(pnode), pnode->sxUni.pnode1->location);
         ENDSTATEMENET_IFTOPLEVEL(isTopLevel, pnode);
         break;
-    // PTNODE(knopLogNot     , "!"            ,LogNot  ,Uni  ,fnopUni)
+        // PTNODE(knopLogNot     , "!"            ,LogNot  ,Uni  ,fnopUni)
     case knopLogNot:
     {
         STARTSTATEMENET_IFTOPLEVEL(isTopLevel, pnode);
@@ -9688,20 +10146,20 @@ void Emit(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator, FuncInfo *func
         funcInfo->ReleaseLoc(pnode->sxUni.pnode1);
         byteCodeGenerator->Writer()->Reg1(Js::OpCode::LdUndef, funcInfo->AcquireLoc(pnode));
         break;
-    // PTNODE(knopArray      , "arr cnst"    ,None    ,Uni  ,fnopUni)
+        // PTNODE(knopArray      , "arr cnst"    ,None    ,Uni  ,fnopUni)
     case knopArray:
         STARTSTATEMENET_IFTOPLEVEL(isTopLevel, pnode);
         EmitArrayLiteral(pnode, byteCodeGenerator, funcInfo);
         ENDSTATEMENET_IFTOPLEVEL(isTopLevel, pnode);
         break;
-    // PTNODE(knopObject     , "obj cnst"    ,None    ,Uni  ,fnopUni)
+        // PTNODE(knopObject     , "obj cnst"    ,None    ,Uni  ,fnopUni)
     case knopObject:
         STARTSTATEMENET_IFTOPLEVEL(isTopLevel, pnode);
         funcInfo->AcquireLoc(pnode);
         EmitObjectInitializers(pnode->sxUni.pnode1, pnode->location, byteCodeGenerator, funcInfo);
         ENDSTATEMENET_IFTOPLEVEL(isTopLevel, pnode);
         break;
-    // PTNODE(knopComputedName, "[name]"      ,None    ,Uni  ,fnopUni)
+        // PTNODE(knopComputedName, "[name]"      ,None    ,Uni  ,fnopUni)
     case knopComputedName:
         Emit(pnode->sxUni.pnode1, byteCodeGenerator, funcInfo, false);
         if (pnode->location == Js::Constants::NoRegister)
@@ -9715,7 +10173,7 @@ void Emit(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator, FuncInfo *func
             byteCodeGenerator->Writer()->Reg2(Js::OpCode::Ld_A, pnode->location, pnode->sxUni.pnode1->location);
         }
         break;
-    // Binary and Ternary Operators
+        // Binary and Ternary Operators
     case knopAdd:
         EmitAdd(pnode, byteCodeGenerator, funcInfo);
         break;
@@ -10045,8 +10503,7 @@ void Emit(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator, FuncInfo *func
                 rhsStack.Push(pnode1->sxBin.pnode2);
                 pnode1 = pnode1->sxBin.pnode1;
                 pnode1->isUsed = false;
-            }
-            while (pnode1->nop == knopComma);
+            } while (pnode1->nop == knopComma);
 
             Emit(pnode1, byteCodeGenerator, funcInfo, false);
             if (funcInfo->IsTmpReg(pnode1->location))
@@ -10213,14 +10670,14 @@ void Emit(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator, FuncInfo *func
         byteCodeGenerator->EndStatement(pnode);
         break;
 
-    // General nodes.
-    // PTNODE(knopTempRef      , "temp ref"  ,None   ,Uni ,fnopUni)
+        // General nodes.
+        // PTNODE(knopTempRef      , "temp ref"  ,None   ,Uni ,fnopUni)
     case knopTempRef:
         // TODO: check whether mov is necessary
         funcInfo->AcquireLoc(pnode);
         byteCodeGenerator->Writer()->Reg2(Js::OpCode::Ld_A, pnode->location, pnode->sxUni.pnode1->location);
         break;
-    // PTNODE(knopTemp      , "temp"        ,None   ,None ,fnopLeaf)
+        // PTNODE(knopTemp      , "temp"        ,None   ,None ,fnopLeaf)
     case knopTemp:
         // Emit initialization code
         if (pnode->sxVar.pnodeInit != nullptr)
@@ -10232,7 +10689,7 @@ void Emit(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator, FuncInfo *func
             byteCodeGenerator->EndStatement(pnode);
         }
         break;
-    // PTNODE(knopVarDecl    , "varDcl"    ,None    ,Var  ,fnopNone)
+        // PTNODE(knopVarDecl    , "varDcl"    ,None    ,Var  ,fnopNone)
     case knopVarDecl:
     case knopConstDecl:
     case knopLetDecl:
@@ -10290,7 +10747,7 @@ void Emit(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator, FuncInfo *func
             byteCodeGenerator->DefineOneFunction(pnode, funcInfo, false);
         }
         break;
-    // PTNODE(knopClassDecl, "class"    ,None    ,None ,fnopLeaf)
+        // PTNODE(knopClassDecl, "class"    ,None    ,None ,fnopLeaf)
     case knopClassDecl:
     {
         funcInfo->AcquireLoc(pnode);
@@ -10401,13 +10858,13 @@ void Emit(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator, FuncInfo *func
         byteCodeGenerator->Writer()->Empty(Js::OpCode::Ret);
         byteCodeGenerator->EndStatement(pnode);
         break;
-    // PTNODE(knopDebugger   , "debugger"    ,None    ,None ,fnopNone)
+        // PTNODE(knopDebugger   , "debugger"    ,None    ,None ,fnopNone)
     case knopDebugger:
         byteCodeGenerator->StartStatement(pnode);
         byteCodeGenerator->Writer()->Empty(Js::OpCode::Break);
         byteCodeGenerator->EndStatement(pnode);
         break;
-    // PTNODE(knopFor        , "for"        ,None    ,For  ,fnopBreak|fnopContinue)
+        // PTNODE(knopFor        , "for"        ,None    ,For  ,fnopBreak|fnopContinue)
     case knopFor:
         if (pnode->sxFor.pnodeInverted != nullptr)
         {
@@ -10434,7 +10891,7 @@ void Emit(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator, FuncInfo *func
             EndEmitBlock(pnode->sxFor.pnodeBlock, byteCodeGenerator, funcInfo);
         }
         break;
-    // PTNODE(knopIf         , "if"        ,None    ,If   ,fnopNone)
+        // PTNODE(knopIf         , "if"        ,None    ,If   ,fnopNone)
     case knopIf:
     {
         byteCodeGenerator->StartStatement(pnode);
@@ -10485,7 +10942,7 @@ void Emit(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator, FuncInfo *func
             funcInfo,
             fReturnValue);
         break;
-    // PTNODE(knopDoWhile    , "do-while"    ,None    ,While,fnopBreak|fnopContinue)
+        // PTNODE(knopDoWhile    , "do-while"    ,None    ,While,fnopBreak|fnopContinue)
     case knopDoWhile:
         EmitLoop(pnode,
             pnode->sxWhile.pnodeCond,
@@ -10496,14 +10953,14 @@ void Emit(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator, FuncInfo *func
             fReturnValue,
             true);
         break;
-    // PTNODE(knopForIn      , "for in"    ,None    ,ForIn,fnopBreak|fnopContinue|fnopCleanup)
+        // PTNODE(knopForIn      , "for in"    ,None    ,ForIn,fnopBreak|fnopContinue|fnopCleanup)
     case knopForIn:
         EmitForInOrForOf(pnode, byteCodeGenerator, funcInfo, fReturnValue);
         break;
     case knopForOf:
         EmitForInOrForOf(pnode, byteCodeGenerator, funcInfo, fReturnValue);
         break;
-    // PTNODE(knopReturn     , "return"    ,None    ,Uni  ,fnopNone)
+        // PTNODE(knopReturn     , "return"    ,None    ,Uni  ,fnopNone)
     case knopReturn:
         byteCodeGenerator->StartStatement(pnode);
         if (pnode->sxReturn.pnodeExpr != nullptr)
@@ -10564,7 +11021,7 @@ void Emit(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator, FuncInfo *func
         break;
     case knopLabel:
         break;
-    // PTNODE(knopBlock      , "{}"        ,None    ,Block,fnopNone)
+        // PTNODE(knopBlock      , "{}"        ,None    ,Block,fnopNone)
     case knopBlock:
         if (pnode->sxBlock.pnodeStmt != nullptr)
         {
@@ -10575,7 +11032,7 @@ void Emit(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator, FuncInfo *func
             }
         }
         break;
-    // PTNODE(knopWith       , "with"        ,None    ,With ,fnopCleanup)
+        // PTNODE(knopWith       , "with"        ,None    ,With ,fnopCleanup)
     case knopWith:
     {
         Assert(pnode->sxWith.pnodeObj != nullptr);
@@ -10654,7 +11111,7 @@ void Emit(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator, FuncInfo *func
         byteCodeGenerator->Writer()->Br(pnode->sxJump.pnodeTarget->sxStmt.continueLabel);
         byteCodeGenerator->EndStatement(pnode);
         break;
-    // PTNODE(knopContinue   , "continue"    ,None    ,Jump ,fnopNone)
+        // PTNODE(knopContinue   , "continue"    ,None    ,Jump ,fnopNone)
     case knopSwitch:
     {
         BOOL fHasDefault = false;

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -10444,6 +10444,27 @@ CommonNumber:
         return RecyclableObject::FromVar(iterator);
     }
 
+    void JavascriptOperators::IteratorClose(RecyclableObject* iterator, ScriptContext* scriptContext)
+    {
+        try
+        {
+            Var func = JavascriptOperators::GetProperty(iterator, PropertyIds::return_, scriptContext);
+
+            if (JavascriptConversion::IsCallable(func))
+            {
+                RecyclableObject* callable = RecyclableObject::FromVar(func);
+                Js::Var args[] = { iterator };
+                Js::CallInfo callInfo(Js::CallFlags_Value, _countof(args));
+                JavascriptFunction::CallFunction<true>(callable, callable->GetEntryPoint(), Js::Arguments(callInfo, args));
+            }
+        }
+        catch (JavascriptExceptionObject *)
+        {
+            // We have arrived in this function due to AbruptCompletion (which is an exception), so we don't need to
+            // propagate the exception of calling return function
+        }
+    }
+
     // IteratorNext as described in ES6.0 (draft 22) Section 7.4.2
     RecyclableObject* JavascriptOperators::IteratorNext(RecyclableObject* iterator, ScriptContext* scriptContext, Var value)
     {

--- a/lib/Runtime/Language/JavascriptOperators.h
+++ b/lib/Runtime/Language/JavascriptOperators.h
@@ -408,6 +408,11 @@ namespace Js
         static RecyclableObject* GetIterator(Var instance, ScriptContext* scriptContext, bool optional = false);
         static RecyclableObject* GetIterator(RecyclableObject* instance, ScriptContext* scriptContext, bool optional = false);
         static RecyclableObject* IteratorNext(RecyclableObject* iterator, ScriptContext* scriptContext, Var value = nullptr);
+        static void IteratorClose(RecyclableObject* iterator, ScriptContext* scriptContext);
+
+        template <typename THandler>
+        static void DoIteratorStepAndValue(RecyclableObject* iterator, ScriptContext* scriptContext, THandler handler);
+
         static bool IteratorComplete(RecyclableObject* iterResult, ScriptContext* scriptContext);
         static Var IteratorValue(RecyclableObject* iterResult, ScriptContext* scriptContext);
         static bool IteratorStep(RecyclableObject* iterator, ScriptContext* scriptContext, RecyclableObject** result);

--- a/lib/Runtime/Language/JavascriptOperators.inl
+++ b/lib/Runtime/Language/JavascriptOperators.inl
@@ -31,6 +31,32 @@ namespace Js
         }
     }
 
+    // A helper function which will do the IteratorStep and fetch value - however in the event of an exception it will perform the IteratorClose as well.
+    template <typename THandler>
+    void JavascriptOperators::DoIteratorStepAndValue(RecyclableObject* iterator, ScriptContext* scriptContext, THandler handler)
+    {
+        Var nextItem = nullptr;
+        bool shouldCallReturn = false;
+        try
+        {
+            while (JavascriptOperators::IteratorStepAndValue(iterator, scriptContext, &nextItem))
+            {
+                shouldCallReturn = true;
+                handler(nextItem);
+                shouldCallReturn = false;
+            }
+        }
+        catch (JavascriptExceptionObject * exceptionObj)
+        {
+            if (shouldCallReturn)
+            {
+                // Closing the iterator
+                JavascriptOperators::IteratorClose(iterator, scriptContext);
+            }
+            throw exceptionObj;
+        }
+    }
+
     template <BOOL stopAtProxy, class Func>
     void JavascriptOperators::MapObjectAndPrototypes(RecyclableObject* object, Func func)
     {

--- a/lib/Runtime/Library/JavascriptArray.cpp
+++ b/lib/Runtime/Library/JavascriptArray.cpp
@@ -9647,11 +9647,9 @@ Case0:
                 newObj = newArr;
             }
 
-            Var nextValue;
             uint32 k = 0;
 
-            while (JavascriptOperators::IteratorStepAndValue(iterator, scriptContext, &nextValue))
-            {
+            JavascriptOperators::DoIteratorStepAndValue(iterator, scriptContext, [&](Var nextValue) {
                 if (mapping)
                 {
                     Assert(mapFn != nullptr);
@@ -9672,7 +9670,7 @@ Case0:
                 }
 
                 k++;
-            }
+            });
 
             JavascriptOperators::SetProperty(newObj, newObj, Js::PropertyIds::length, JavascriptNumber::ToVar(k, scriptContext), scriptContext, PropertyOperation_ThrowIfNotExtensible);
         }

--- a/lib/Runtime/Library/JavascriptMap.cpp
+++ b/lib/Runtime/Library/JavascriptMap.cpp
@@ -87,11 +87,9 @@ namespace Js
 
         if (iter != nullptr)
         {
-            Var nextItem;
             Var undefined = library->GetUndefined();
 
-            while (JavascriptOperators::IteratorStepAndValue(iter, scriptContext, &nextItem))
-            {
+            JavascriptOperators::DoIteratorStepAndValue(iter, scriptContext, [&](Var nextItem) {
                 if (!JavascriptOperators::IsObject(nextItem))
                 {
                     JavascriptError::ThrowTypeError(scriptContext, JSERR_NeedObject);
@@ -113,7 +111,7 @@ namespace Js
 
                 // CONSIDER: if adder is the default built-in, fast path it and skip the JS call?
                 CALL_FUNCTION(adder, CallInfo(CallFlags_Value, 3), mapObject, key, value);
-            }
+            });
         }
 
         return isCtorSuperCall ?

--- a/lib/Runtime/Library/JavascriptPromise.cpp
+++ b/lib/Runtime/Library/JavascriptPromise.cpp
@@ -201,15 +201,13 @@ namespace Js
         remainingElementsWrapper->remainingElements = 1;
 
         JavascriptExceptionObject* exception = nullptr;
-
         try
         {
             // 4. Let iterator be GetIterator(iterable).
             RecyclableObject* iterator = JavascriptOperators::GetIterator(iterable, scriptContext);
-            Var next;
             values = library->CreateArray(0);
 
-            while (JavascriptOperators::IteratorStepAndValue(iterator, scriptContext, &next))
+            JavascriptOperators::DoIteratorStepAndValue(iterator, scriptContext, [&](Var next)
             {
                 Var resolveVar = JavascriptOperators::GetProperty(constructorObject, Js::PropertyIds::resolve, scriptContext);
 
@@ -250,7 +248,7 @@ namespace Js
                     promiseCapability->GetReject());
 
                 index++;
-            }
+            });
         }
         catch (JavascriptExceptionObject* e)
         {
@@ -369,9 +367,8 @@ namespace Js
         {
             // 4. Let iterator be GetIterator(iterable).
             RecyclableObject* iterator = JavascriptOperators::GetIterator(iterable, scriptContext);
-            Var next;
 
-            while (JavascriptOperators::IteratorStepAndValue(iterator, scriptContext, &next))
+            JavascriptOperators::DoIteratorStepAndValue(iterator, scriptContext, [&](Var next)
             {
                 Var resolveVar = JavascriptOperators::GetProperty(constructorObject, Js::PropertyIds::resolve, scriptContext);
 
@@ -406,7 +403,8 @@ namespace Js
                     nextPromiseObject,
                     promiseCapability->GetResolve(),
                     promiseCapability->GetReject());
-            }
+
+            });
         }
         catch (JavascriptExceptionObject* e)
         {

--- a/lib/Runtime/Library/JavascriptSet.cpp
+++ b/lib/Runtime/Library/JavascriptSet.cpp
@@ -88,12 +88,9 @@ namespace Js
 
         if (iter != nullptr)
         {
-            Var nextItem;
-
-            while (JavascriptOperators::IteratorStepAndValue(iter, scriptContext, &nextItem))
-            {
+            JavascriptOperators::DoIteratorStepAndValue(iter, scriptContext, [&](Var nextItem) {
                 CALL_FUNCTION(adder, CallInfo(CallFlags_Value, 2), setObject, nextItem);
-            }
+            });
         }
 
         return isCtorSuperCall ?

--- a/lib/Runtime/Library/JavascriptWeakMap.cpp
+++ b/lib/Runtime/Library/JavascriptWeakMap.cpp
@@ -103,11 +103,9 @@ namespace Js
 
         if (iter != nullptr)
         {
-            Var nextItem;
             Var undefined = library->GetUndefined();
 
-            while (JavascriptOperators::IteratorStepAndValue(iter, scriptContext, &nextItem))
-            {
+            JavascriptOperators::DoIteratorStepAndValue(iter, scriptContext, [&](Var nextItem) {
                 if (!JavascriptOperators::IsObject(nextItem))
                 {
                     JavascriptError::ThrowTypeError(scriptContext, JSERR_NeedObject);
@@ -128,7 +126,7 @@ namespace Js
                 }
 
                 CALL_FUNCTION(adder, CallInfo(CallFlags_Value, 3), weakMapObject, key, value);
-            }
+            });
         }
 
         return isCtorSuperCall ?

--- a/lib/Runtime/Library/JavascriptWeakSet.cpp
+++ b/lib/Runtime/Library/JavascriptWeakSet.cpp
@@ -67,12 +67,9 @@ namespace Js
 
         if (iter != nullptr)
         {
-            Var nextItem;
-
-            while (JavascriptOperators::IteratorStepAndValue(iter, scriptContext, &nextItem))
-            {
+            JavascriptOperators::DoIteratorStepAndValue(iter, scriptContext, [&](Var nextItem) {
                 CALL_FUNCTION(adder, CallInfo(CallFlags_Value, 2), weakSetObject, nextItem);
-            }
+            });
         }
 
         return isCtorSuperCall ?

--- a/test/es6/iteratorclose.js
+++ b/test/es6/iteratorclose.js
@@ -1,0 +1,982 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+
+var nextCount = 0;
+var returnCount = 0;
+var value1 = 1;
+var done1 = false;
+var iterable = {};
+var shouldNextThrow = false;
+var shouldReturnThrow = false;
+iterable[Symbol.iterator] = function () {
+    return {
+        next: function() {
+            nextCount++;
+            if (shouldNextThrow) { throw new Error('Exception from next function'); }
+            return {value : value1, done:done1};
+        },
+        return: function (value) {
+            returnCount++;
+            if (shouldReturnThrow) { throw new Error('Exception from return function'); }
+            return {done:true};
+        }
+    };
+};
+
+var obj = {
+  set prop(val) {
+    throw new Error('From setter');
+  }
+};
+
+var tests = [
+    {
+		name : "Destructuring - no .return function defined is a valid scenario",
+		body : function () {
+			var iterable = {};
+			iterable[Symbol.iterator] = function () {
+				return {
+					next : function () {
+						return {
+							value : 10,
+							done : false
+						};
+					}
+				};
+			};
+
+			var [a] = iterable;
+			assert.areEqual(a, 10, "Destructuring declaration calls next on iterator and should get 10");
+            var b;
+            [b] = iterable;
+			assert.areEqual(b, 10, "Destructuring expression calls next on iterator and should get 10");
+		}
+	},
+    {
+		name : "Destructuring - validating that the iterable has .return field but not as a function",
+		body : function () {
+            var returnFnc = undefined;
+            var iterable = {};
+            iterable[Symbol.iterator] = function() {
+              return {
+                next: function() {
+                    return {value:10, done:false};
+                },
+                return: returnFnc
+              };
+            };
+            
+            var a;
+            assert.doesNotThrow(function() {
+                [a] = iterable;
+            }, "iterator has return field which returns 'undefined' and that should not throw");
+            
+            assert.doesNotThrow(function() {
+                returnFnc = null;
+                [a] = iterable;
+            }, "iterator has return field which returns 'null' and that should not throw");
+            
+            assert.throws(function () { returnFnc = {}; [a] = iterable; }, TypeError, 
+                    "return field is not a function and returns other than 'undefined'/'null' should throw Type Error");
+		}
+	},
+    {
+		name : "Destructuring - basic validation with .return function when the pattern is empty or has one element",
+		body : function () {
+            nextCount = 0;
+            returnCount = 0;
+            [] = iterable;
+            assert.areEqual(nextCount, 0, "Empty LHS pattern should not call the next function");
+            assert.areEqual(returnCount, 1, "Evaluation of empty LHS pattern will call return function");
+
+            nextCount = 0;
+            returnCount = 0;
+            var [] = iterable;
+            assert.areEqual(nextCount, 0, "Empty LHS declaration pattern should not call the next function");
+            assert.areEqual(returnCount, 1, "Evaluation of empty LHS declaration pattern call return function");
+            
+            nextCount = 0;
+            returnCount = 0;
+            [,] = iterable;
+            assert.areEqual(nextCount, 1, "Comma operator causes the next to be called");
+            assert.areEqual(returnCount, 1, "Exhausting the LHS pattern (after comma) will call the call return function");
+
+            var a;
+            nextCount = 0;
+            returnCount = 0;
+            [a] = iterable;
+            assert.areEqual(nextCount, 1, "Evaluating destructuring element will call next function");
+            assert.areEqual(returnCount, 1, "Exhausting the LHS pattern (after comma) will call the call return function");
+            
+		}
+	},
+    {
+		name : "Destructuring - validation with .return function with nesting pattern",
+		body : function () {
+            nextCount = 0;
+            returnCount = 0;
+            [[a]] = [iterable];
+            assert.areEqual(nextCount, 1, "Nested array pattern will call next function when 'a' is evauluated");
+            assert.areEqual(returnCount, 1, "When nested array pattern exhausts the return function will be called");
+            
+            nextCount = 0;
+            returnCount = 0;
+            value1 = iterable;
+            [a, [a]] = iterable;
+            
+            assert.areEqual(nextCount, 3, "Recursive iterators on RHS - next function will be called 3 times in order to exhaust elements");
+            assert.areEqual(returnCount, 2, "Recursive iterators on RHS - return function for two nested iterators will be called");
+            value1 = 1; // Reset it back
+
+            nextCount = 0;
+            returnCount = 0;
+            value1 = iterable;
+            var [a, [a]] = iterable;
+            
+            assert.areEqual(nextCount, 3, "Array declaration - Recursive iterators on RHS - next function will be called 3 times in order to exhaust elements");
+            assert.areEqual(returnCount, 2, "Array declaration - Recursive iterators on RHS - return function for two nested iterators will be called");
+            value1 = 1; // Reset it back
+		}
+	},    
+    {
+		name : "Destructuring - change .done to true will not call .return function",
+		body : function () {
+            nextCount = 0;
+            returnCount = 0;
+            done1 = true;
+            var [a] = iterable;
+            
+            assert.areEqual(nextCount, 1, "next function is called to evaluate the element on the LHS");
+            assert.areEqual(returnCount, 0, "'done' is set true on next function call - which will ensure that return function is not called");
+            done1 = false;
+		}
+	},    
+    {
+		name : "Destructuring - validating that exception will call the .return function",
+		body : function () {
+            nextCount = 0;
+            returnCount = 0;
+            assert.throws(function () { [obj.prop] = iterable; }, Error, "Pattern throws error while assigning .value", "From setter");
+            assert.areEqual(returnCount, 1, "Abrupt completion due to exception will call the return function");
+
+            nextCount = 0;
+            returnCount = 0;
+            value1 = iterable;
+            assert.throws(function () { [k, [obj.prop]] = iterable; }, Error, "Nested pattern throws error while assigning .value", "From setter");
+            assert.areEqual(returnCount, 2, "Nested recursive iterators - abrupt completion due to exception will call the return function");
+            value1 = 1;
+
+            nextCount = 0;
+            returnCount = 0;
+            value1 = iterable;
+            assert.throws(function () { [[[[obj.prop]]]] = iterable; }, Error, "Nested pattern throws error while assigning .value", "From setter");
+            assert.areEqual(nextCount, 4, "Nested recursing iterators - 4 times next function called due to 4 level depth of array pattern");
+            assert.areEqual(returnCount, 4, "Nested recursing iterators - 4 times return function called due to abrupt comletion");
+            value1 = 1;
+            
+            done1 = true;
+            nextCount = 0;
+            returnCount = 0;
+            assert.throws(function () { [obj.prop] = iterable; }, Error, "Pattern throws error while assigning .value", "From setter");
+            assert.areEqual(returnCount, 0, "Ensuring that return function is not called when 'done' is set to true during abrupt completion");
+            done1 = false; // Reset it back.
+		}
+	},    
+    {
+		name : "Destructuring - chained iterators will have their .return function called correctly",
+		body : function () {
+            var nextCount1 = 0;
+            var nextCount2 = 0;
+            var returnCount1 = 0;
+            var returnCount2 = 0;
+            
+            var iterable = {};
+            iterable[Symbol.iterator] = function() {
+              return {
+                next: function() {
+                    nextCount1++;
+                  return { value: iterable2, done: false };
+                },
+                return: function() {
+                    returnCount1++;
+                    return {done:true};
+                },
+              };
+            };
+
+            var iterable2 = {};
+            iterable2[Symbol.iterator] = function() {
+              return {
+                next: function() {
+                    nextCount2++;
+                  return { value: [0], done: false };
+                },
+                return: function() {
+                    returnCount2++;
+                    return {done:true};
+                }
+              };
+            };
+
+             nextCount1 = 0;
+             nextCount2 = 0;
+             returnCount1 = 0;
+             returnCount2 = 0;
+             assert.throws(function () {[[obj.prop]] = iterable; }, Error, "Pattern throws error while assigning .value", "From setter");
+             assert.areEqual(nextCount1, 1, "next function for the first iterator is called");
+             assert.areEqual(nextCount2, 1, "next function for the second iterator is called");
+             assert.areEqual(returnCount1, 1, "return function for the second iterator is called" );
+             assert.areEqual(returnCount2, 1, "return function for the first iterator is called");
+		}
+	},    
+    {
+		name : "Destructuring - .return function should not be called when .next function throws",
+		body : function () {
+            shouldNextThrow = true;
+            returnCount = 0;
+            assert.throws(function () { var [a] = iterable; }, Error, "Array declaration - Calling .next throws", "Exception from next function");
+            assert.areEqual(returnCount, 0, "Ensuring that return function is not called in array declaration pattern");
+             
+            assert.throws(function () { [a] = iterable; }, Error, "Array expression - Calling .next throws", "Exception from next function");
+            assert.areEqual(returnCount, 0, "Ensuring that return function is not called in array expression pattern");
+             
+            assert.throws(function () { var [...a] = iterable; }, Error, "Array declaration with rest - Calling .next throws", "Exception from next function");
+            assert.areEqual(returnCount, 0, "Ensuring that return function is not called when evalauting rest in array declaration pattern");
+             
+            assert.throws(function () { [...a] = iterable; }, Error, "Array expression with rest - Calling .next throws", "Exception from next function");
+            assert.areEqual(returnCount, 0, "Ensuring that return function is not called when evaluating rest in array expression pattern");
+             
+            shouldNextThrow = false;
+		}
+	},    
+    {
+		name : "Destructuring - .return function should not be called when fetching .value throws",
+		body : function () {
+            var iterable2 = {};
+            iterable2[Symbol.iterator] = function() {
+              return {
+                next: function() {
+                    return {get value () { throw new Error('Exception while getting value'); }, done:false};
+                },
+                return: function() {
+                    assert.fail('return should not be called');
+                    return {};
+                },
+              };
+            };
+
+            assert.throws(function () { [a] = iterable2; }, Error, "Fetch .value throws", "Exception while getting value");
+		}
+	},    
+    {
+		name : "Destructuring - .return function can also throw",
+		body : function () {
+            shouldReturnThrow = true;
+            assert.throws(function () { [a] = iterable; }, Error, "Calling .return throws", "Exception from return function");
+            shouldReturnThrow = false;
+		}
+	},    
+    {
+		name : "Destructuring - caller and .return function both throw and caller's exception wins",
+		body : function () {
+            shouldReturnThrow = true;
+            returnCount = 0;
+            assert.throws(function () { [obj.prop] = iterable; }, Error, "Setting value will throw", "From setter");
+            assert.areEqual(returnCount, 1, "Ensuring that return function is called");
+            shouldReturnThrow = false;
+		}
+	},    
+    {
+		name : "Destructuring - with generator",
+		body : function () {
+            var finallyCount = 0;
+            function *gf() {
+                try {
+                    yield 1;
+                    assert.fail('should not reach after yield');
+                }
+                finally {
+                    finallyCount++;
+                }
+                assert.fail('should not reach after finally');;
+            }
+            
+            [a] = gf();
+            assert.areEqual(finallyCount, 1, "Exhausting pattern will call return function on generator, which will execute finally block");
+            
+            finallyCount = 0;
+            assert.throws(function () { [obj.prop] = gf(); }, Error, "Assigning value to destructuring element can throw", "From setter");
+            assert.areEqual(finallyCount, 1, "Exception causes to call return function on generator, which will execute finally block");
+            
+            function* gf2() {
+                yield 1;
+                assert.fail('should not reach after yield');
+            }
+            var returnCount = 0;
+            gf2.prototype.return = function() {
+                returnCount++;
+                return {};
+            };
+            [a] = gf2();
+            assert.areEqual(returnCount, 1, "Exhausting pattern will call return function on generator");
+            
+            gf2.prototype.return = function() {
+                returnCount++;
+                throw new Error('Exception from return function');
+            };
+            assert.throws(function () { [a] = gf2(); }, Error, "Return function throws", "Exception from return function");
+            returnCount = 0;
+            assert.throws(function () { [obj.prop] = gf2(); }, Error, "Exception at destructuring element wins", "From setter");
+            assert.areEqual(returnCount, 1, "Exception causes to call return function on generator");
+		}
+	},    
+    {
+		name : "Destructuring - at function parameter",
+		body : function () {
+            nextCount = 0;
+            returnCount = 0;
+            (function([a, b]) {})(iterable);
+            assert.areEqual(nextCount, 2, "next function will be called 2 times to evaluate 2 elements in the pattern");
+            assert.areEqual(returnCount, 1, "return function will be called once the pattern exhausts");
+            
+            shouldReturnThrow = true;
+            assert.throws(function () { (function([a, b]) {})(iterable) }, Error, "Calling return function while at param throws", "Exception from return function");
+            shouldReturnThrow = false;
+		}
+	},
+    {
+		name : "Destructuring - assigning to rest parameter can throw but should not call .return function",
+		body : function () {
+            function* gf() {
+                yield 1;
+                yield 2;
+            }
+            gf.prototype.return = function() {
+                assert.fail('return function should not be called');
+            };
+            
+            assert.throws(function () { [...obj.prop] = gf(); }, Error, "Assigning to rest head can throw", "From setter");
+		}
+	},    
+    {
+		name : "Destructuring - .next throws during rest assignment but it should not call the .return function",
+		body : function () {
+            returnCount = 0;
+            shouldNextThrow = true;
+            assert.throws(function () { var [...a] = iterable; }, Error, "next function throws in the array declaration evaluation", "Exception from next function");
+            assert.throws(function () { [...a] = iterable; }, Error, "next function throws in the array expression evaluation", "Exception from next function");
+            shouldNextThrow = false;
+            assert.areEqual(returnCount, 0, "return function should be called even when the next function throws");
+		}
+	},    
+    {
+		name : "Destructuring - has yield as initializer",
+		body : function () {
+            var returnCalled = 0;
+            function *innerGen () { yield undefined; yield 21; }
+
+            innerGen.prototype.return = function () {
+                returnCalled++;
+                return {};
+            };
+            
+            var x;
+
+            var iter = (function * () {
+                ([x = yield] = innerGen());
+            }());
+
+            iter.next();
+            var iterationResult = iter.next(10);
+            assert.areEqual(x, 10, "calling next with value 10 will assign 'x' to 10");
+            assert.isTrue(iterationResult.done, "iterator is completed as there is nothing more to yield");
+            assert.areEqual(returnCalled, 1, "Destructuring elements exhaust and that should call return function");
+		}
+	},    
+    {
+		name : "For..of - validation of calling .return function on abrupt loop break",
+		body : function () {
+            returnCount = 0;
+            for (i of iterable) {
+                break;
+            }
+            assert.areEqual(returnCount, 1, "return function is called as the loop is abruptly completed due to 'break'");
+
+            returnCount = 0;
+            (function () {
+                for (i of iterable) {
+                    return;
+                }
+            })();
+            assert.areEqual(returnCount, 1, "return function is called as the loop is abruptly completed due to 'return'");
+
+            returnCount = 0;
+            (function () {
+                var loop = true;
+                outer2 : while (loop) {
+                    loop = false;
+                    for (i of iterable) {
+                        continue outer2;
+                    }
+                }
+            })();
+            assert.areEqual(returnCount, 1, "return function is called as the loop is abruptly completed due to 'continue'");
+
+            returnCount = 0;
+            (function () {
+                var loop = true;
+                outer3 : while (loop) {
+                    loop = false;
+                    for (i of iterable) {
+                        break outer3;
+                    }
+                }
+            })();
+            assert.areEqual(returnCount, 1, "return function is called as the loop is abruptly completed due to 'break label'");
+
+            nextCount = 0;
+            returnCount = 0;
+            assert.throws(function () {
+                for (i of iterable) {
+                    (function () {
+                        throw new Error('break loop by causing an exception');
+                    })();
+                }
+            }, Error);
+            assert.areEqual(nextCount, 1, "next function is called once as the loop iterates only once");
+            assert.areEqual(returnCount, 1, "return function is called as the loop is abruptly completed due to an exception");
+            
+		}
+	},
+    {
+		name : "For..of - validation of .return function with nesting pattern",
+		body : function () {
+            
+            nextCount = 0;
+            returnCount = 0;
+            // Creating recursing iterator. the value is another iterator.
+            value1 = iterable;
+            (function() {
+            for (var iter of iterable) {
+                for (var iter2 of iter) {
+                    return;
+                }
+            }
+            })();
+            
+            assert.areEqual(nextCount, 2, "Nested iterators - next function is called 2 times, once for each loop");
+            assert.areEqual(returnCount, 2, "Nested iterators - return function is called 2 times as two loops are abruptly completed due to 'return'");
+            
+            nextCount = 0;
+            returnCount = 0;
+            assert.throws(function() {
+                for (var iter of iterable) {
+                    for (var iter2 of iter) {
+                        throw new Error('error');
+                    }
+                }
+            }, Error);
+            
+            assert.areEqual(nextCount, 2, "Nested iterators - next function is called 2 times, once for each loop");
+            assert.areEqual(returnCount, 2, "Nested iterators - return function is called 2 times as two loops are abruptly completed due to exception");
+		}
+	},    
+    {
+		name : "For..of - change .done to true will not call .return function",
+		body : function () {
+            returnCount = 0;
+            done1 = true;
+            for (var i of iterable) {
+                assert.fail('This will not reach as the .done is marked to true');
+            }
+            
+            assert.areEqual(returnCount, 0, "Loop is completed as .done is set to true, this ensures that return function should not be called");
+            done1 = false;
+		}
+	},    
+    {
+		name : "For..of - validating that causing an exception on assigning value to for..of head  will call .return function",
+		body : function () {
+            returnCount = 0;
+            assert.throws(function () {for (obj.prop of iterable) {
+                assert.fail('Should not reach here as assigning to obj.prop throws');
+            }}, Error, "Assigning to loop head can throw", "From setter");
+            
+            assert.areEqual(returnCount, 1, "Abrupt loop break due to exception in assigning value to head should call return function");
+            
+            returnCount = 0;
+            value1 = iterable;
+            assert.throws(function () {
+                for (var iter1 of iterable) {
+                    for (obj.prop of iter1) {
+                        assert.fail('Should not reach here as assigning to obj.prop throws');
+                    }
+                }
+            }, Error, "Assigning to loop head can throw", "From setter");
+            
+            assert.areEqual(returnCount, 2, "Exception caused in inner loop when assigning value to head should call the return function");
+            value1 = 1;
+		}
+	},    
+    {
+		name : "For..of - .return function should not be called when .next function throws",
+		body : function () {
+            returnCount = 0;
+            shouldNextThrow = true;
+            assert.throws(function () { for (var i of iterable) { } }, Error, "Calling .next throws", "Exception from next function");
+            shouldNextThrow = false;
+            assert.areEqual(returnCount, 0, "Ensuring that exception in next function should not call the return function");
+		}
+	},    
+    {
+		name : "For..of - .return function should not be called when fetching .value throws",
+		body : function () {
+            var iterable2 = {};
+            iterable2[Symbol.iterator] = function() {
+              return {
+                next: function() {
+                    return {get value () { throw new Error('Exception while getting value'); }, done:false};
+                },
+                return: function() {
+                    assert.fail('return should not be called');
+                },
+              };
+            };
+
+            assert.throws(function () { for (var i of iterable2) { } }, Error,
+                ".value causes an exception but that should not call the return function",
+                "Exception while getting value");
+		}
+	},    
+    {
+		name : "For..of - .return function can also throw",
+		body : function () {
+            shouldReturnThrow = true;
+            assert.throws(function () { for (var i of iterable) { break; } }, Error, ".return function throws", "Exception from return function");
+            shouldReturnThrow = false;
+		}
+	},    
+    {
+		name : "For..of - caller and .return function both throw and caller's exception wins",
+		body : function () {
+            shouldReturnThrow = true;
+            returnCount = 0;
+            assert.throws(function () { for (obj.prop of iterable) { break; } }, Error, "Setting value will throw", "From setter");
+            assert.areEqual(returnCount, 1, "Ensuring that abrupt loop completion due to exception will call return function");
+            shouldReturnThrow = false;
+		}
+	},    
+    {
+		name : "For..of - with generator",
+		body : function () {
+            var finallyCount = 0;
+            function *gf() {
+                try {
+                    yield 1;
+                    assert.fail('Should not reach here after yield');
+                }
+                finally {
+                    finallyCount++;
+                }
+                assert.fail('Should not reach here after finally');;
+            }
+            
+            for (var i of gf()) {
+                break;
+            }
+
+            assert.areEqual(finallyCount, 1, "'break' causes the return function called which should execute the finally block");
+            
+            finallyCount = 0;
+            assert.throws(function () { for (obj.prop of gf()) { } }, Error, "Setting value will throw", "From setter");
+            assert.areEqual(finallyCount, 1, "Exception causes the return function called which should execute the finally block");
+            
+            function* gf2() {
+                yield 1;
+                assert.fail('Should not reach here after yield');
+            }
+            var returnCount = 0;
+            gf2.prototype.return = function() {
+                returnCount++;
+                return {};
+            };
+            
+            for (var i of gf2()) {
+                break;
+            }
+
+            assert.areEqual(returnCount, 1, "Loop break due to 'break' should call the return function on the generator");
+            
+            gf2.prototype.return = function() {
+                returnCount++;
+                throw new Error('Exception from return function');
+            };
+            assert.throws(function () { for (i of gf2()) { break; } }, Error, "return function throws", "Exception from return function");
+            returnCount = 0;
+            assert.throws(function () { for (obj.prop of gf2()) { } }, Error, "Exception at destructuring element wins", "From setter");
+            assert.areEqual(returnCount, 1, "Exception in loop should call the return function");
+            
+		}
+	},    
+    {
+		name : "Iterator close with yield *",
+		body : function () {
+            var returnCalled = 0;
+            let innerGen = function*() { yield 1; yield 2 };
+            innerGen.prototype.return = function () {
+                returnCalled++;
+                return {};
+            };
+            
+            function* gf() { yield* innerGen() }
+
+            for (var i of gf()) {
+                break;
+            }
+
+            assert.areEqual(returnCalled, 1, "Loop break due to 'break' should call the return function, yield * should propagate that to inner generator");
+            
+            returnCalled = 0;
+            (function() {
+                for (var i of gf()) {
+                    return;
+                }
+            })();
+            assert.areEqual(returnCalled, 1, "Loop break due to 'return' should call the return function, yield * should propagate that to inner generator");
+            
+            returnCalled = 0;
+            assert.throws(function () { for (var i of gf()) { throw new Error(''); } }, Error);
+            assert.areEqual(returnCalled, 1, "Loop break due to 'throw' should call the return function, yield * should propagate that to inner generator");
+
+            returnCalled = 0;
+            var [x2] = gf();
+            assert.areEqual(returnCalled, 1, "Exhausting destructuring element will call the return function");
+		}
+	},    
+    {
+		name : "Array.from - Iterator closing when mapping function throws",
+		body : function () {
+            var mapFn = function() {
+                throw new Error('');
+            };
+            
+            returnCount = 0;
+            assert.throws(function () { 
+                Array.from(iterable, mapFn);
+            }, Error);
+    
+            assert.areEqual(returnCount, 1, "Exception in mapping function in Array.from should call the return function");
+		}
+	},    
+    {
+		name : "Array.from - .return function should not be called when .next function throws",
+		body : function () {
+            shouldNextThrow = true;
+            returnCount = 0;
+            assert.throws(function () { 
+                Array.from(iterable);
+            }, Error);
+            assert.areEqual(returnCount, 0, "next function causes exception which should not call the return function");
+            shouldNextThrow = false;
+		}
+	},    
+    {
+		name : "Array.from - both mapping function and .return throw but the outer exception wins",
+		body : function () {
+            var mapFn = function() {
+                throw new Error('Exception from map function');
+            };
+            
+            returnCount = 0;
+            shouldReturnThrow = true;
+            assert.throws(function () { 
+                Array.from(iterable, mapFn);
+            }, Error, 'Validate that the exception from return function is skipped', 'Exception from map function');
+    
+            shouldReturnThrow = false;
+            assert.areEqual(returnCount, 1, "return function is called when mapping function throws");
+		}
+	},    
+    {
+		name : "Map - calling .return function in the event of exception",
+		body : function () {
+            returnCount = 0;
+            assert.throws(function () { 
+                new Map(iterable);
+            }, TypeError);
+            assert.areEqual(returnCount, 1, "return function is called when iterator does not return object");
+            
+            Map.prototype.set = function() {
+                throw new Error('');
+            };
+            
+            value1 = [];
+            returnCount = 0;
+            assert.throws(function () { 
+                new Map(iterable);
+            }, Error);
+    
+            assert.areEqual(returnCount, 1, "return function is called when .set function throws");
+            value1 = 1;
+		}
+	},    
+    {
+		name : "Map - .return function should not be called when .next function throws",
+		body : function () {
+            returnCount = 0;
+            shouldNextThrow = true;
+            assert.throws(function () { 
+                new Map(iterable);
+            }, Error);
+    
+            assert.areEqual(returnCount, 0, "next function causes exception which should not call the return function");
+            shouldNextThrow = false;
+		}
+	},    
+    {
+		name : "Map - both .set function and .return throw but the outer exception wins",
+		body : function () {
+            Map.prototype.set = function() {
+                throw new Error('Exception from set function');
+            };
+            
+            value1 = [];
+            returnCount = 0;
+            shouldReturnThrow = true;
+            assert.throws(function () { 
+                new Map(iterable);
+            }, Error, 'Validate that the exception from return function is skipped', 'Exception from set function');
+    
+            shouldReturnThrow = true;
+            value1 = 1;
+            assert.areEqual(returnCount, 1, "return function is called as the set function throws");
+		}
+	},    
+    {
+		name : "WeakMap - calling .return function in the event of exception",
+		body : function () {
+            returnCount = 0;
+            assert.throws(function () { 
+                new WeakMap(iterable);
+            }, TypeError);
+            assert.areEqual(returnCount, 1, "return function is called when iterator does not return object");
+            
+            WeakMap.prototype.set = function() {
+                throw new Error('');
+            };
+            
+            value1 = [];
+            returnCount = 0;
+            assert.throws(function () { 
+                new WeakMap(iterable);
+            }, Error);
+    
+            assert.areEqual(returnCount, 1, "return function is called as the set function throws");
+            value1 = 1;
+		}
+	},    
+    {
+		name : "WeakMap - .return function should not be called when .next function throws",
+		body : function () {
+            returnCount = 0;
+            shouldNextThrow = true;
+            assert.throws(function () { 
+                new WeakMap(iterable);
+            }, Error);
+    
+            assert.areEqual(returnCount, 0, "next function causes exception which should not call the return function");
+            shouldNextThrow = false;
+		}
+	},    
+    {
+		name : "WeakMap - both .set function and .return throw but the outer exception wins",
+		body : function () {
+            WeakMap.prototype.set = function() {
+                throw new Error('Exception from set function');
+            };
+            
+            value1 = [];
+            returnCount = 0;
+            shouldReturnThrow = true;
+            assert.throws(function () { 
+                new WeakMap(iterable);
+            }, Error, 'Validate that the exception from return function is skipped', 'Exception from set function');
+    
+            shouldReturnThrow = true;
+            value1 = 1;
+            assert.areEqual(returnCount, 1, "return function is called as the set function throws");
+		}
+	},    
+    {
+		name : "Set - calling .return function when .add function throws",
+		body : function () {
+            Set.prototype.add = function() {
+                throw new Error('');
+            };
+            
+            returnCount = 0;
+            assert.throws(function () { 
+                new Set(iterable);
+            }, Error);
+    
+            assert.areEqual(returnCount, 1, "return function is called as the add function throws");
+		}
+	},
+    {
+		name : "Set - .return function should not be called when .next function throws",
+		body : function () {
+            returnCount = 0;
+            shouldNextThrow = true;
+            assert.throws(function () { 
+                new Set(iterable);
+            }, Error);
+    
+            assert.areEqual(returnCount, 0, "next function causes exception which should not call the return function");
+            shouldNextThrow = false;
+		}
+	},
+    {
+		name : "Set - both .add function and .return throw but the outer exception wins",
+		body : function () {
+            Set.prototype.add = function() {
+                throw new Error('Exception from add function');
+            };
+            
+            returnCount = 0;
+            shouldReturnThrow = true;
+            assert.throws(function () { 
+                new Set(iterable);
+            }, Error, 'Validate that the exception from return function is skipped', 'Exception from add function');
+    
+            shouldReturnThrow = false;
+            assert.areEqual(returnCount, 1, "return function is called as the add function throws");
+		}
+	},
+    {
+		name : "WeakSet - calling .return function when .add function throws",
+		body : function () {
+            WeakSet.prototype.add = function() {
+                throw new Error('');
+            };
+            
+            returnCount = 0;
+            assert.throws(function () { 
+                new WeakSet(iterable);
+            }, Error);
+    
+            assert.areEqual(returnCount, 1, "return function is called as the add function throws");
+		}
+	},
+    {
+		name : "WeakSet - .return function should not be called when .next function throws",
+		body : function () {
+            returnCount = 0;
+            shouldNextThrow = true;
+            assert.throws(function () { 
+                new WeakSet(iterable);
+            }, Error);
+    
+            assert.areEqual(returnCount, 0, "next function causes exception which should not call the return function");
+            shouldNextThrow = false;
+		}
+	},
+    {
+		name : "WeakSet - both .add function and .return throw but the outer exception wins",
+		body : function () {
+            WeakSet.prototype.add = function() {
+                throw new Error('Exception from add function');
+            };
+            
+            returnCount = 0;
+            shouldReturnThrow = true;
+            assert.throws(function () { 
+                new WeakSet(iterable);
+            }, Error, 'Validate that the exception from return function is skipped', 'Exception from add function');
+    
+            shouldReturnThrow = false;
+            assert.areEqual(returnCount, 1, "return function is called as the add function throws");
+		}
+	},
+    {
+		name : "Promise.all - call .return function when .resolve function throws",
+		body : function () {
+            Promise.resolve = function () {
+                throw new Error('');
+            }
+            returnCount = 0;
+            Promise.all(iterable);
+            assert.areEqual(returnCount, 1, "return function is called as the resolve function throws");
+		}
+	},    
+    {
+		name : "Promise.all - .return function should not be called when .next function throws",
+		body : function () {
+            returnCount = 0;
+            shouldNextThrow = true;
+            Promise.all(iterable);
+            shouldNextThrow = false;
+            assert.areEqual(returnCount, 0, "next function causes exception which should not call the return function");
+		}
+	},    
+    {
+		name : "Promise.all - both .resolve and .return function thrown and outer exception wins",
+		body : function () {
+            Promise.resolve = function () {
+                throw new Error('Exception from resolve function');
+            }
+            returnCount = 0;
+            shouldReturnThrow = true;
+            var p = Promise.all(iterable);
+            shouldReturnThrow = false;
+            assert.areEqual(returnCount, 1, "return function is called as the resolve function throws");
+            p.catch( function (err) {
+                assert.areEqual(err.message, 'Exception from resolve function');
+            });
+		}
+	},    
+    {
+		name : "Promise.race - call .return function when .resolve function throws",
+		body : function () {
+            Promise.resolve = function () {
+                throw new Error('');
+            }
+            returnCount = 0;
+            Promise.race(iterable);
+            assert.areEqual(returnCount, 1, "return function is called as the resolve function throws");
+		}
+	},    
+    {
+		name : "Promise.race - .return function should not be called when .next function throws",
+		body : function () {
+            returnCount = 0;
+            shouldNextThrow = true;
+            Promise.race(iterable);
+            shouldNextThrow = false;
+            assert.areEqual(returnCount, 0, "next function causes exception which should not call the return function");
+		}
+	},    
+    {
+		name : "Promise.race - both .resolve and .return function thrown and outer exception wins",
+		body : function () {
+            Promise.resolve = function () {
+                throw new Error('Exception from resolve function');
+            }
+            returnCount = 0;
+            shouldReturnThrow = true;
+            var p = Promise.race(iterable);
+            shouldReturnThrow = false;
+            assert.areEqual(returnCount, 1, "return function is called as the resolve function throws");
+            p.catch( function (err) {
+                assert.areEqual(err.message, 'Exception from resolve function');
+            });
+		}
+	},    
+];
+
+testRunner.runTests(tests, {
+	verbose : WScript.Arguments[0] != "summary"
+});

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -1236,4 +1236,16 @@
     <tags>exclude_dynapogo</tags>
   </default>
 </test>
+<test>
+  <default>
+    <files>iteratorClose.js</files>
+    <compile-flags>-off:deferparse -args summary -endargs</compile-flags>
+  </default>
+</test>
+<test>
+  <default>
+    <files>iteratorClose.js</files>
+    <compile-flags>-force:deferparse -args summary -endargs</compile-flags>
+  </default>
+</test>
 </regress-exe>


### PR DESCRIPTION
This changeset enables IteratorClose scenario for destructuring, for..of
loop and built-ins (Promise, Array.from, Map, WeakMap, Set and WeakSet).
Closing the iterator means calling the return function of the iterator. The implementation for destructuring and for..of is done in the Bytecode level.
Destructuring : In the array destructuring pattern the try..finally
bytecodes are emitted in order to capture the abrupt completion of the
destructuring elements assignment.
For..of : The loop is surrounded by try..catch..finally. The catch block
is to tackle the abrupt completion due to exception and finally block is
to tackle the scenarios which involves break, return, continue.
Added unittest.
