### PR TITLE
xplat: fix empty GetResourceString simulation

### DIFF
--- a/lib/Parser/errstr.cpp
+++ b/lib/Parser/errstr.cpp
@@ -136,7 +136,7 @@ BSTR BstrGetResourceString(int32 isz)
 
     UINT id = (WORD)isz;
     const char16* szT = LoadResourceStr(id);
-    if (!szT)
+    if (!szT || !szT[0])
     {
         return NULL;
     }


### PR DESCRIPTION
On Windows the resource string loading code returns NULL if a resource
string content is empty (""). Simulate the same behavior on xplat.

es6/ES6PromiseAsync.js now passes.
