### PR TITLE
Wasm Block yielding

### DIFF
--- a/lib/WasmReader/WasmBinaryReader.cpp
+++ b/lib/WasmReader/WasmBinaryReader.cpp
@@ -327,15 +327,6 @@ Entry point for decoding a node
 WasmBinOp
 WasmBinaryReader::ASTNode()
 {
-    // [b-gekua] REVIEW: It would be best to figure out how to unify
-    // SExprParser and WasmBinaryReader's interface for those Nodes
-    // that are repeatedly called (scoping construct) such as Blocks and Calls.
-    // SExprParser uses an interface such that ReadFromX() will be
-    // repeatedly called until we reach the end of the scope (at which
-    // point ReadFromX() should return a wnLIMIT to signal this). This
-    // Would eliminate a lot of the special casing in WasmBytecodeGenerator's
-    // EmitX() functions. The gotcha is that this may involve adding
-    // state to WasmBinaryReader to indicate how far in the scope we are.
     if (EndOfFunc())
     {
         // end of AST

--- a/lib/WasmReader/WasmByteCodeGenerator.cpp
+++ b/lib/WasmReader/WasmByteCodeGenerator.cpp
@@ -219,6 +219,11 @@ WasmBytecodeGenerator::GenerateFunction()
                 m_reader.m_currentNode.ret.arity = arity;
                 EmitReturnExpr(&exprInfo);
             }
+            else if (returnType == Wasm::WasmTypes::Void) 
+            {
+                m_reader.m_currentNode.ret.arity = 0;
+                EmitReturnExpr(&exprInfo);
+            }
             ExitEvalStackScope();
         }
         catch (...)

--- a/lib/WasmReader/WasmByteCodeGenerator.h
+++ b/lib/WasmReader/WasmByteCodeGenerator.h
@@ -90,7 +90,7 @@ namespace Wasm
     private:
 
         EmitInfo EmitExpr(WasmOp op);
-        EmitInfo EmitBlock();
+        EmitInfo EmitBlock(uint* loopId = nullptr);
         EmitInfo EmitLoop();
 
         template<WasmOp wasmOp>
@@ -101,8 +101,9 @@ namespace Wasm
         EmitInfo EmitSetLocal();
         EmitInfo EmitReturnExpr(EmitInfo *lastStmtExprInfo = nullptr);
         EmitInfo EmitSelect();
-        void PrintOpName(WasmOp op);
-
+#if DBG_DUMP
+        void PrintOpName(WasmOp op) const;
+#endif
         template<WasmOp wasmOp>
         EmitInfo EmitBr();
 


### PR DESCRIPTION
Closes #1110
Blocks now move the yielded value to a tmp register after releasing all the tmp register used in the block.
Exiting an eval stack now releases the location of tmp registers.
Added some debugging utils

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/1116)
<!-- Reviewable:end -->
