### PR TITLE
cross-platform: Improve O1+ stack probing for test builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,12 +106,16 @@ if(CLR_CMAKE_PLATFORM_UNIX)
         # -Wno-switch # switch values not handled
 
     # CXX COMPILER FLAGS
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
-        -fdelayed-template-parsing"
-    )
 
+    # xplat-todo for release build
+    # -fno-inline.... -> -mno-omit.... are needed for more accurate stack inf.
+    # Release Builds: Not sure if this has to be as strict as the debug/test?
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
-        -fno-omit-frame-pointer"
+        -fdelayed-template-parsing\
+        -fno-inline-functions\
+        -fno-omit-frame-pointer\
+        -fno-optimize-sibling-calls\
+        -mno-omit-leaf-frame-pointer" # this is for compat reasons. i.e. It is a noop with gcc
     )
   
     # CXX / CC COMPILER FLAGS

--- a/lib/Backend/GlobOpt.h
+++ b/lib/Backend/GlobOpt.h
@@ -309,7 +309,7 @@ public:
     Value *     Copy(JitArenaAllocator * allocator, ValueNumber newValueNumber) { return Value::New(allocator, newValueNumber, this->ShareValueInfo()); }
 
 #if DBG_DUMP
-    __declspec(noinline) void Dump() const { Output::Print(_u("0x%X  ValueNumber: %3d,  -> "), this, this->valueNumber);  this->valueInfo->Dump(); }
+    _NOINLINE void Dump() const { Output::Print(_u("0x%X  ValueNumber: %3d,  -> "), this, this->valueNumber);  this->valueInfo->Dump(); }
 #endif
 };
 

--- a/lib/Backend/JnHelperMethod.cpp
+++ b/lib/Backend/JnHelperMethod.cpp
@@ -166,7 +166,7 @@ GetMethodAddress(IR::HelperCallOpnd* opnd)
 // Import function ptr require dynamic initialization, and cause the table to be in read-write memory.
 // Additionally, all function ptrs are automatically marked as safe CFG addresses by the compiler.
 // __declspec(guard(ignore)) can be used on methods to have the compiler not mark these as valid CFG targets.
-DECLSPEC_GUARDIGNORE __declspec(noinline) void * const GetNonTableMethodAddress(JnHelperMethod helperMethod)
+DECLSPEC_GUARDIGNORE _NOINLINE void * const GetNonTableMethodAddress(JnHelperMethod helperMethod)
 {
     switch (helperMethod)
     {

--- a/lib/Common/CommonPal.h
+++ b/lib/Common/CommonPal.h
@@ -4,11 +4,27 @@
 //-------------------------------------------------------------------------------------------------------
 #pragma once
 
+#define __MAKE_WARNING__(X) "This compiler does not support '" ## X ## "'"
 // Define _ALWAYSINLINE for template that want to always inline, but doesn't allow inline linkage in clang
 #if defined(__GNUC__) || defined(__clang__)
-#define _ALWAYSINLINE __attribute__((always_inline))
-#else
-#define _ALWAYSINLINE __forceinline
+    #if __has_attribute(always_inline)
+        #define _ALWAYSINLINE __attribute__((always_inline))
+        #define __forceinline inline _ALWAYSINLINE
+    #else // No always_inline support
+        #pragma message __MAKE_WARNING__("always_inline")
+        #define _ALWAYSINLINE inline
+        #define __forceinline _ALWAYSINLINE
+    #endif
+    #if __has_attribute(noinline)
+        #define _NOINLINE __attribute__((noinline))
+    #else // No noinline support
+        #pragma message __MAKE_WARNING__("noinline")
+        #define _NOINLINE
+    #endif
+#else // Windows
+    #define _ALWAYSINLINE __forceinline
+    #define _NOINLINE __declspec(noinline)
+    #define __forceinline inline
 #endif
 
 #ifdef _WIN32
@@ -57,12 +73,6 @@ __forceinline void  __int2c()
 #include "inc/rt/palrt.h"
 #include "inc/rt/no_sal2.h"
 #include "inc/rt/oaidl.h"
-
-#if defined(__GNUC__) || defined(__clang__)
-#define __forceinline inline __attribute__((always_inline))
-#else
-#define __forceinline inline
-#endif
 
 typedef char16_t char16;
 #define _u(s) u##s

--- a/lib/Common/Core/FaultInjection.cpp
+++ b/lib/Common/Core/FaultInjection.cpp
@@ -109,7 +109,7 @@ namespace Js
 
 #if _M_X64
     // for amd64 jit frame, RtlCaptureStackBackTrace stops walking after hitting jit frame on amd64
-    __declspec(noinline)
+    _NOINLINE
         WORD StackTrace64(_In_ DWORD FramesToSkip,
         _In_ DWORD FramesToCapture,
         _Out_writes_to_(FramesToCapture, return) PVOID * BackTrace,
@@ -936,7 +936,7 @@ namespace Js
     // !list -t jscript9test!Js::FaultInjection::InjectionRecord.next -e -x "dps @$extret @$extret+0x128" poi(@@c++(&jscript9test!Js::FaultInjection::Global.InjectionFirstRecord))
     // to rebuild the stack (locals are available)
     // .cxr @@C++(&jscript9test!Js::FaultInjection::Global.InjectionFirstRecord->Context)
-    __declspec(noinline) void FaultInjection::dumpCurrentStackData(LPCWSTR name /*= nullptr*/, size_t size /*= 0*/)
+    _NOINLINE void FaultInjection::dumpCurrentStackData(LPCWSTR name /*= nullptr*/, size_t size /*= 0*/)
     {
 
 #if !defined(_M_ARM32_OR_ARM64)

--- a/lib/Common/Core/StackBackTrace.h
+++ b/lib/Common/Core/StackBackTrace.h
@@ -9,10 +9,10 @@ class StackBackTrace
 {
 public:
     static const ULONG DefaultFramesToCapture = 30;
-    template <typename TAllocator> __declspec(noinline)
+    template <typename TAllocator> _NOINLINE
         static StackBackTrace * Capture(TAllocator * alloc, ULONG framesToSkip = 0, ULONG framesToCapture = DefaultFramesToCapture);
 
-    template <typename TAllocator> __declspec(noinline)
+    template <typename TAllocator> _NOINLINE
         static StackBackTrace * Create(TAllocator * alloc, ULONG framesToCaptureLater = DefaultFramesToCapture);
     size_t Print();
     template<typename Fn>void Map(Fn fn);   // The Fn is expected to be: void Fn(void*).
@@ -24,8 +24,8 @@ private:
     // We want to skip at lease the StackBackTrace::Capture and the constructor frames
     static const ULONG BaseFramesToSkip = 2;
 
-    __declspec(noinline) StackBackTrace(ULONG framesToSkip, ULONG framesToCapture);
-    __declspec(noinline) StackBackTrace(ULONG framesToCapture);
+    _NOINLINE StackBackTrace(ULONG framesToSkip, ULONG framesToCapture);
+    _NOINLINE StackBackTrace(ULONG framesToCapture);
 
     ULONG requestedFramesToCapture;
     ULONG framesCount;

--- a/lib/Common/DataStructures/StringBuilder.h
+++ b/lib/Common/DataStructures/StringBuilder.h
@@ -103,7 +103,7 @@ namespace Js
             return newChunk;
         }
 
-        __declspec(noinline) void ExtendBuffer(charcount_t newLength)
+        _NOINLINE void ExtendBuffer(charcount_t newLength)
         {
             Data *newChunk;
 

--- a/lib/Common/Exceptions/ReportError.cpp
+++ b/lib/Common/Exceptions/ReportError.cpp
@@ -39,34 +39,34 @@ void ReportFatalException(
 
 // Disable optimization make sure all the frames are still available in Dr. Watson bug reports.
 #pragma optimize("", off)
-__declspec(noinline) void JavascriptDispatch_OOM_fatal_error(
+_NOINLINE void JavascriptDispatch_OOM_fatal_error(
     __in ULONG_PTR context)
 {
     int scenario = 1;
     ReportFatalException(context, E_OUTOFMEMORY, JavascriptDispatch_OUTOFMEMORY, scenario);
 };
 
-__declspec(noinline) void CustomHeap_BadPageState_fatal_error(
+_NOINLINE void CustomHeap_BadPageState_fatal_error(
     __in ULONG_PTR context)
 {
     int scenario = 1;
     ReportFatalException(context, E_UNEXPECTED, CustomHeap_MEMORYCORRUPTION, scenario);
 };
 
-__declspec(noinline) void MarkStack_OOM_fatal_error()
+_NOINLINE void MarkStack_OOM_fatal_error()
 {
     int scenario = 1;
     ReportFatalException(NULL, E_OUTOFMEMORY, MarkStack_OUTOFMEMORY, scenario);
 };
 
-__declspec(noinline) void Amd64StackWalkerOutOfContexts_fatal_error(
+_NOINLINE void Amd64StackWalkerOutOfContexts_fatal_error(
     __in ULONG_PTR context)
 {
     int scenario = 1;
     ReportFatalException(context, E_UNEXPECTED, Fatal_Amd64StackWalkerOutOfContexts, scenario);
 }
 
-__declspec(noinline) void FailedToBox_OOM_fatal_error(
+_NOINLINE void FailedToBox_OOM_fatal_error(
     __in ULONG_PTR context)
 {
     int scenario = 1;
@@ -74,33 +74,33 @@ __declspec(noinline) void FailedToBox_OOM_fatal_error(
 }
 
 #if defined(RECYCLER_WRITE_BARRIER) && defined(_M_X64_OR_ARM64)
-__declspec(noinline) void X64WriteBarrier_OOM_fatal_error()
+_NOINLINE void X64WriteBarrier_OOM_fatal_error()
 {
     int scenario = 3;
     ReportFatalException(NULL, E_OUTOFMEMORY, WriteBarrier_OUTOFMEMORY, scenario);
 }
 #endif
 
-__declspec(noinline) void DebugHeap_OOM_fatal_error()
+_NOINLINE void DebugHeap_OOM_fatal_error()
 {
     int scenario = 3;
     ReportFatalException(NULL, E_OUTOFMEMORY, Fatal_Debug_Heap_OUTOFMEMORY, scenario);
 }
 
-__declspec(noinline) void Binary_Inconsistency_fatal_error()
+_NOINLINE void Binary_Inconsistency_fatal_error()
 {
     int scenario = 4;
     ReportFatalException(NULL, E_UNEXPECTED, Fatal_Binary_Inconsistency, scenario);
 }
 
-__declspec(noinline) void Version_Inconsistency_fatal_error()
+_NOINLINE void Version_Inconsistency_fatal_error()
 {
     int scenario = 4;
     ReportFatalException(NULL, E_UNEXPECTED, Fatal_Version_Inconsistency, scenario);
 }
 
 #ifdef LARGEHEAPBLOCK_ENCODING
-__declspec(noinline) void LargeHeapBlock_Metadata_Corrupted(
+_NOINLINE void LargeHeapBlock_Metadata_Corrupted(
     __in ULONG_PTR context, __in unsigned char calculatedChecksum)
 {
     int scenario = calculatedChecksum; /* For debugging purpose if checksum mismatch happen*/
@@ -108,25 +108,25 @@ __declspec(noinline) void LargeHeapBlock_Metadata_Corrupted(
 };
 #endif
 
-__declspec(noinline) void FromDOM_NoScriptScope_fatal_error()
+_NOINLINE void FromDOM_NoScriptScope_fatal_error()
 {
     int scenario = 5;
     ReportFatalException(NULL, E_UNEXPECTED, EnterScript_FromDOM_NoScriptScope, scenario);
 }
 
-__declspec(noinline) void Debugger_AttachDetach_fatal_error()
+_NOINLINE void Debugger_AttachDetach_fatal_error()
 {
     int scenario = 5;
     ReportFatalException(NULL, E_UNEXPECTED, Fatal_Debugger_AttachDetach_Failure, scenario);
 }
 
-__declspec(noinline) void EntryExitRecord_Corrupted_fatal_error()
+_NOINLINE void EntryExitRecord_Corrupted_fatal_error()
 {
     int scenario = 6;
     ReportFatalException(NULL, E_UNEXPECTED, Fatal_EntryExitRecordCorruption, scenario);
 }
 
-__declspec(noinline) void UnexpectedExceptionHandling_fatal_error(EXCEPTION_POINTERS * originalException)
+_NOINLINE void UnexpectedExceptionHandling_fatal_error(EXCEPTION_POINTERS * originalException)
 {
     int scenario = 7;
     ReportFatalException(NULL, E_UNEXPECTED, Fatal_UnexpectedExceptionHandling, scenario);

--- a/lib/Common/Memory/EtwMemoryTracking.cpp
+++ b/lib/Common/Memory/EtwMemoryTracking.cpp
@@ -18,7 +18,7 @@ enum ArenaType: unsigned short
 class EtwMemoryEvents
 {
 public:
-    __declspec(noinline) static void ReportAllocation(void *arena, void *address, size_t size)
+    _NOINLINE static void ReportAllocation(void *arena, void *address, size_t size)
     {
         allocCount++;
         if (allocCount == 7500)
@@ -30,28 +30,28 @@ public:
         EventWriteJSCRIPT_INTERNAL_ALLOCATOR_ALLOC(arena, address, size);
     }
 
-    __declspec(noinline) static void ReportFree(void *arena, void *address, size_t size)
+    _NOINLINE static void ReportFree(void *arena, void *address, size_t size)
     {
         EventWriteJSCRIPT_INTERNAL_ALLOCATOR_FREE(arena, address, size);
     }
 
-    __declspec(noinline) static void ReportReallocation(void *arena, void *address, size_t existingSize, size_t newSize)
+    _NOINLINE static void ReportReallocation(void *arena, void *address, size_t existingSize, size_t newSize)
     {
         EventWriteJSCRIPT_INTERNAL_ALLOCATOR_FREE(arena, address, existingSize);
         EventWriteJSCRIPT_INTERNAL_ALLOCATOR_ALLOC(arena, address, newSize);
     }
 
-    __declspec(noinline) static void ReportArenaCreated(void *arena, ArenaType arenaType)
+    _NOINLINE static void ReportArenaCreated(void *arena, ArenaType arenaType)
     {
         EventWriteJSCRIPT_INTERNAL_ALLOCATOR_CREATE(arena, arenaType);
     }
 
-    __declspec(noinline) static void ReportArenaDestroyed(void *arena)
+    _NOINLINE static void ReportArenaDestroyed(void *arena)
     {
         EventWriteJSCRIPT_INTERNAL_ALLOCATOR_DESTROY(arena);
     }
 
-    __declspec(noinline) static void ReportFreeAll(void *arena, ArenaType arenaType)
+    _NOINLINE static void ReportFreeAll(void *arena, ArenaType arenaType)
     {
         EventWriteJSCRIPT_INTERNAL_ALLOCATOR_DESTROY(arena);
         EventWriteJSCRIPT_INTERNAL_ALLOCATOR_CREATE(arena, arenaType);
@@ -72,37 +72,37 @@ void ArenaMemoryTracking::Activate()
 {
 }
 
-__declspec(noinline) void ArenaMemoryTracking::ArenaCreated(Allocator *arena, __in LPCWSTR name)
+_NOINLINE void ArenaMemoryTracking::ArenaCreated(Allocator *arena, __in LPCWSTR name)
 {
     DISTINGUISH_FUNCTION(Arena);
     EtwMemoryEvents::ReportArenaCreated(arena, ArenaTypeArena);
 }
 
-__declspec(noinline) void ArenaMemoryTracking::ArenaDestroyed(Allocator *arena)
+_NOINLINE void ArenaMemoryTracking::ArenaDestroyed(Allocator *arena)
 {
     DISTINGUISH_FUNCTION(Arena);
     EtwMemoryEvents::ReportArenaDestroyed(arena);
 }
 
-__declspec(noinline) void ArenaMemoryTracking::ReportAllocation(Allocator *arena, void *address, size_t size)
+_NOINLINE void ArenaMemoryTracking::ReportAllocation(Allocator *arena, void *address, size_t size)
 {
     DISTINGUISH_FUNCTION(Arena);
     EtwMemoryEvents::ReportAllocation(arena, address, size);
 }
 
-__declspec(noinline) void ArenaMemoryTracking::ReportReallocation(Allocator *arena, void *address, size_t existingSize, size_t newSize)
+_NOINLINE void ArenaMemoryTracking::ReportReallocation(Allocator *arena, void *address, size_t existingSize, size_t newSize)
 {
     DISTINGUISH_FUNCTION(Arena);
     EtwMemoryEvents::ReportReallocation(arena, address, existingSize, newSize);
 }
 
-__declspec(noinline) void ArenaMemoryTracking::ReportFree(Allocator *arena, void *address, size_t size)
+_NOINLINE void ArenaMemoryTracking::ReportFree(Allocator *arena, void *address, size_t size)
 {
     DISTINGUISH_FUNCTION(Arena);
     EtwMemoryEvents::ReportFree(arena, address, size);
 }
 
-__declspec(noinline) void ArenaMemoryTracking::ReportFreeAll(Allocator *arena)
+_NOINLINE void ArenaMemoryTracking::ReportFreeAll(Allocator *arena)
 {
     DISTINGUISH_FUNCTION(Arena);
     EtwMemoryEvents::ReportFreeAll(arena, ArenaTypeArena);
@@ -120,25 +120,25 @@ bool RecyclerMemoryTracking::IsActive()
 }
 
 // The external reporting for the recycler uses the MemspectMemoryTracker
-__declspec(noinline) void RecyclerMemoryTracking::ReportRecyclerCreate(Recycler * recycler)
+_NOINLINE void RecyclerMemoryTracking::ReportRecyclerCreate(Recycler * recycler)
 {
     DISTINGUISH_FUNCTION(Recycler);
     EtwMemoryEvents::ReportArenaCreated(recycler, ArenaTypeRecycler);
 }
 
-__declspec(noinline) void RecyclerMemoryTracking::ReportRecyclerDestroy(Recycler * recycler)
+_NOINLINE void RecyclerMemoryTracking::ReportRecyclerDestroy(Recycler * recycler)
 {
     DISTINGUISH_FUNCTION(Recycler);
     EtwMemoryEvents::ReportArenaDestroyed(recycler);
 }
 
-__declspec(noinline) void RecyclerMemoryTracking::ReportAllocation(Recycler * recycler, __in void *address, size_t size)
+_NOINLINE void RecyclerMemoryTracking::ReportAllocation(Recycler * recycler, __in void *address, size_t size)
 {
     DISTINGUISH_FUNCTION(Recycler);
     EtwMemoryEvents::ReportAllocation(recycler, address, size);
 }
 
-__declspec(noinline) void RecyclerMemoryTracking::ReportFree(Recycler * recycler, __in void *address, size_t size)
+_NOINLINE void RecyclerMemoryTracking::ReportFree(Recycler * recycler, __in void *address, size_t size)
 {
     DISTINGUISH_FUNCTION(Recycler);
     EtwMemoryEvents::ReportFree(recycler, address, size);

--- a/lib/Common/Memory/LargeHeapBlock.cpp
+++ b/lib/Common/Memory/LargeHeapBlock.cpp
@@ -299,7 +299,7 @@ LargeHeapBlock::ReleasePagesSweep(Recycler * recycler)
 }
 
 #ifdef RECYCLER_PAGE_HEAP
-__declspec(noinline)
+_NOINLINE
 void LargeHeapBlock::VerifyPageHeapPattern()
 {
     Assert(InPageHeapMode());
@@ -556,7 +556,7 @@ LargeHeapBlock::Alloc(size_t size, ObjectInfoBits attributes)
     return allocObject;
 }
 
-__declspec(noinline)
+_NOINLINE
 void
 LargeHeapBlock::Mark(void* objectAddress, MarkContext * markContext)
 {

--- a/lib/Common/Memory/SmallFinalizableHeapBlock.cpp
+++ b/lib/Common/Memory/SmallFinalizableHeapBlock.cpp
@@ -104,7 +104,7 @@ SmallFinalizableHeapBlockT<TBlockAttributes>::SetAttributes(void * address, unsi
 }
 
 template <class TBlockAttributes>
-__declspec(noinline)
+_NOINLINE
 void
 SmallFinalizableHeapBlockT<TBlockAttributes>::ProcessMarkedObject(void* objectAddress, MarkContext * markContext)
 {

--- a/lib/Parser/errstr.cpp
+++ b/lib/Parser/errstr.cpp
@@ -118,7 +118,7 @@ BOOL FGetResourceString(int32 isz, __out_ecount(cchMax) OLECHAR *psz, int cchMax
 }
 
 // Get a bstr version of the error string
-__declspec(noinline) // Don't inline. This function needs 2KB stack.
+_NOINLINE // Don't inline. This function needs 2KB stack.
 BSTR BstrGetResourceString(int32 isz)
 {
     // NOTE - isz is expected to be HRESULT

--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -57,7 +57,7 @@ void (*InitializeAdditionalProperties)(ThreadContext *threadContext) = DefaultIn
 // To make sure the marker function doesn't get inlined, optimized away, or merged with other functions we disable optimization.
 // If this method ends up causing a perf problem in the future, we should replace it with asm versions which should be lighter.
 #pragma optimize("g", off)
-__declspec(noinline) extern "C" void* MarkerForExternalDebugStep()
+_NOINLINE extern "C" void* MarkerForExternalDebugStep()
 {
     // We need to return something here to prevent this function from being merged with other empty functions by the linker.
     static int __dummy;
@@ -1454,7 +1454,7 @@ ThreadContext::SetStackLimitForCurrentThread(PBYTE limit)
     this->stackLimitForCurrentThread = limit;
 }
 
-__declspec(noinline) //Win8 947081: might use wrong _AddressOfReturnAddress() if this and caller are inlined
+_NOINLINE //Win8 947081: might use wrong _AddressOfReturnAddress() if this and caller are inlined
 bool
 ThreadContext::IsStackAvailable(size_t size)
 {
@@ -1490,7 +1490,7 @@ ThreadContext::IsStackAvailable(size_t size)
     return false;
 }
 
-__declspec(noinline) //Win8 947081: might use wrong _AddressOfReturnAddress() if this and caller are inlined
+_NOINLINE //Win8 947081: might use wrong _AddressOfReturnAddress() if this and caller are inlined
 bool
 ThreadContext::IsStackAvailableNoThrow(size_t size)
 {

--- a/lib/Runtime/Base/ThreadContext.h
+++ b/lib/Runtime/Base/ThreadContext.h
@@ -1317,8 +1317,8 @@ public:
     }
 
     static BOOLEAN IsOnStack(void const *ptr);
-    __declspec(noinline) bool IsStackAvailable(size_t size);
-    __declspec(noinline) bool IsStackAvailableNoThrow(size_t size = Js::Constants::MinStackDefault);
+    _NOINLINE bool IsStackAvailable(size_t size);
+    _NOINLINE bool IsStackAvailableNoThrow(size_t size = Js::Constants::MinStackDefault);
     static bool IsCurrentStackAvailable(size_t size);
     void ProbeStackNoDispose(size_t size, Js::ScriptContext *scriptContext, PVOID returnAddress = nullptr);
     void ProbeStack(size_t size, Js::ScriptContext *scriptContext, PVOID returnAddress = nullptr);

--- a/lib/Runtime/ByteCode/ByteCodeWriter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeWriter.cpp
@@ -3295,7 +3295,7 @@ StoreCommon:
     }
 
     /// Requires buffer extension.
-    __declspec(noinline) void ByteCodeWriter::Data::SlowWrite(__in_bcount(byteSize) const void* data, __in uint byteSize)
+    _NOINLINE void ByteCodeWriter::Data::SlowWrite(__in_bcount(byteSize) const void* data, __in uint byteSize)
     {
         AssertMsg(byteSize > current->RemainingBytes(), "We should not need an extension if there is enough space in the current chunk");
         uint bytesLeftToWrite = byteSize;

--- a/lib/Runtime/ByteCode/ByteCodeWriter.h
+++ b/lib/Runtime/ByteCode/ByteCodeWriter.h
@@ -74,7 +74,7 @@ namespace Js
             bool fixedGrowthPolicy;
 
             inline uint Write(__in_bcount(byteSize) const void* data, __in uint byteSize);
-            __declspec(noinline) void SlowWrite(__in_bcount(byteSize) const void* data, __in uint byteSize);
+            _NOINLINE void SlowWrite(__in_bcount(byteSize) const void* data, __in uint byteSize);
             void AddChunk(uint byteSize);
 
         public:

--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -2204,7 +2204,7 @@ namespace Js
         m_outSp        = m_outParams;
     }
 
-    __declspec(noinline)
+    _NOINLINE
     Var InterpreterStackFrame::DebugProcessThunk(void* returnAddress, void* addressOfReturnAddress)
     {
         PushPopFrameHelper pushPopFrameHelper(this, returnAddress, addressOfReturnAddress);
@@ -2317,7 +2317,7 @@ namespace Js
     }
 #endif
 
-    __declspec(noinline)
+    _NOINLINE
     Var InterpreterStackFrame::ProcessThunk(void* address, void* addressOfReturnAddress)
     {
         PushPopFrameHelper pushPopFrameHelper(this, address, addressOfReturnAddress);
@@ -3311,7 +3311,7 @@ namespace Js
     }
 
     template <class T>
-    __declspec(noinline) void InterpreterStackFrame::OP_GetMethodProperty_NoFastPath(Var instance, unaligned T *playout)
+    _NOINLINE void InterpreterStackFrame::OP_GetMethodProperty_NoFastPath(Var instance, unaligned T *playout)
     {
         PropertyId propertyId = GetPropertyIdFromCacheId(playout->inlineCacheIndex);
 
@@ -3357,7 +3357,7 @@ namespace Js
     }
 
     template <class T>
-    __declspec(noinline) void InterpreterStackFrame::OP_GetRootMethodProperty_NoFastPath(unaligned T *playout)
+    _NOINLINE void InterpreterStackFrame::OP_GetRootMethodProperty_NoFastPath(unaligned T *playout)
     {
         PropertyId propertyId = GetPropertyIdFromCacheId(playout->inlineCacheIndex);
 
@@ -3421,7 +3421,7 @@ namespace Js
     }
 
     template <class T>
-    __declspec(noinline) void InterpreterStackFrame::OP_GetMethodPropertyScoped_NoFastPath(unaligned T *playout)
+    _NOINLINE void InterpreterStackFrame::OP_GetMethodPropertyScoped_NoFastPath(unaligned T *playout)
     {
         PropertyId propertyId = GetPropertyIdFromCacheId(playout->inlineCacheIndex);
         Js::Var instance = GetReg(playout->Instance);
@@ -3855,7 +3855,7 @@ namespace Js
     }
 
     template <class T>
-    __declspec(noinline) void InterpreterStackFrame::OP_GetRootProperty_NoFastPath(unaligned T* playout)
+    _NOINLINE void InterpreterStackFrame::OP_GetRootProperty_NoFastPath(unaligned T* playout)
     {
         PropertyId propertyId = GetPropertyIdFromCacheId(playout->inlineCacheIndex);
         Var rootInstance = this->GetRootObject();
@@ -4065,7 +4065,7 @@ namespace Js
     }
 
     template <class T>
-    __declspec(noinline) void InterpreterStackFrame::OP_GetProperty_NoFastPath(Var instance, unaligned T* playout)
+    _NOINLINE void InterpreterStackFrame::OP_GetProperty_NoFastPath(Var instance, unaligned T* playout)
     {
         PropertyId propertyId = GetPropertyIdFromCacheId(playout->inlineCacheIndex);
 
@@ -4231,7 +4231,7 @@ namespace Js
 
 
     template <typename T>
-    __declspec(noinline) void InterpreterStackFrame::OP_GetPropertyScoped_NoFastPath(const unaligned OpLayoutT_ElementP<T>* playout)
+    _NOINLINE void InterpreterStackFrame::OP_GetPropertyScoped_NoFastPath(const unaligned OpLayoutT_ElementP<T>* playout)
     {
         // Implicit root object as default instance
         Var defaultInstance = GetReg(Js::FunctionBody::RootObjectRegSlot);
@@ -4286,7 +4286,7 @@ namespace Js
     }
 
     template <class T>
-    __declspec(noinline) void InterpreterStackFrame::OP_SetPropertyScoped_NoFastPath(unaligned T* playout, PropertyOperationFlags flags)
+    _NOINLINE void InterpreterStackFrame::OP_SetPropertyScoped_NoFastPath(unaligned T* playout, PropertyOperationFlags flags)
     {
         // Implicit root object as default instance
         Var defaultInstance = GetReg(Js::FunctionBody::RootObjectRegSlot);
@@ -4371,7 +4371,7 @@ namespace Js
     }
 
     template <class T>
-    __declspec(noinline) void InterpreterStackFrame::DoSetProperty_NoFastPath(unaligned T* playout, Var instance, PropertyOperationFlags flags)
+    _NOINLINE void InterpreterStackFrame::DoSetProperty_NoFastPath(unaligned T* playout, Var instance, PropertyOperationFlags flags)
     {
 #if ENABLE_COPYONACCESS_ARRAY
         JavascriptLibrary::CheckAndConvertCopyOnAccessNativeIntArray<Var>(instance);
@@ -4402,7 +4402,7 @@ namespace Js
     }
 
     template <class T>
-    __declspec(noinline) void InterpreterStackFrame::DoSetSuperProperty_NoFastPath(unaligned T* playout, Var instance, PropertyOperationFlags flags)
+    _NOINLINE void InterpreterStackFrame::DoSetSuperProperty_NoFastPath(unaligned T* playout, Var instance, PropertyOperationFlags flags)
     {
 #if ENABLE_COPYONACCESS_ARRAY
         JavascriptLibrary::CheckAndConvertCopyOnAccessNativeIntArray<Var>(instance);
@@ -4630,7 +4630,7 @@ namespace Js
     }
 
     template <class T>
-    __declspec(noinline) void InterpreterStackFrame::DoInitProperty_NoFastPath(unaligned T* playout, Var instance)
+    _NOINLINE void InterpreterStackFrame::DoInitProperty_NoFastPath(unaligned T* playout, Var instance)
     {
         JavascriptOperators::PatchInitValue<false>(
             GetFunctionBody(),

--- a/lib/Runtime/Language/InterpreterStackFrame.h
+++ b/lib/Runtime/Language/InterpreterStackFrame.h
@@ -270,7 +270,7 @@ namespace Js
         static int GetAsmJsArgSize(AsmJsCallStackLayout * stack);
         static int GetDynamicRetType(AsmJsCallStackLayout * stack);
         static DWORD GetAsmIntDbValOffSet(AsmJsCallStackLayout * stack);
-        __declspec(noinline)   static int  AsmJsInterpreter(AsmJsCallStackLayout * stack);
+        _NOINLINE   static int  AsmJsInterpreter(AsmJsCallStackLayout * stack);
 #elif _M_X64
         template <typename T>
         static T AsmJsInterpreter(AsmJsCallStackLayout* layout);
@@ -290,9 +290,9 @@ namespace Js
 
 #if DYNAMIC_INTERPRETER_THUNK
         static Var DelayDynamicInterpreterThunk(RecyclableObject* function, CallInfo callInfo, ...);
-        __declspec(noinline) static Var InterpreterThunk(JavascriptCallStackLayout* layout);
+        _NOINLINE static Var InterpreterThunk(JavascriptCallStackLayout* layout);
 #else
-        __declspec(noinline) static Var InterpreterThunk(RecyclableObject* function, CallInfo callInfo, ...);
+        _NOINLINE static Var InterpreterThunk(RecyclableObject* function, CallInfo callInfo, ...);
 #endif
         static Var InterpreterHelper(ScriptFunction* function, ArgumentReader args, void* returnAddress, void* addressOfReturnAddress, const bool isAsmJs = false);
     private:
@@ -310,8 +310,8 @@ namespace Js
         void __cdecl operator delete(void* allocationToFree, void* previousAllocation) throw();
 
 
-        __declspec(noinline) Var ProcessThunk(void* returnAddress, void* addressOfReturnAddress);
-        __declspec(noinline) Var DebugProcessThunk(void* returnAddress, void* addressOfReturnAddress);
+        _NOINLINE Var ProcessThunk(void* returnAddress, void* addressOfReturnAddress);
+        _NOINLINE Var DebugProcessThunk(void* returnAddress, void* addressOfReturnAddress);
 
         void AlignMemoryForAsmJs();
 

--- a/lib/Runtime/Language/JavascriptStackWalker.cpp
+++ b/lib/Runtime/Language/JavascriptStackWalker.cpp
@@ -536,7 +536,7 @@ namespace Js
 #endif
 
     // Note: noinline is to make sure that when we unwind to the unwindToAddress, there is at least one frame to unwind.
-    __declspec(noinline)
+    _NOINLINE
     JavascriptStackWalker::JavascriptStackWalker(ScriptContext * scriptContext, bool useEERContext, PVOID returnAddress, bool _forceFullWalk /*=false*/) :
         inlinedFrameCallInfo(CallFlags_None, 0), shouldDetectPartiallyInitializedInterpreterFrame(true), forceFullWalk(_forceFullWalk),
         previousInterpreterFrameIsFromBailout(false), ehFramesBeingWalkedFromBailout(false)

--- a/lib/Runtime/Language/JavascriptStackWalker.h
+++ b/lib/Runtime/Language/JavascriptStackWalker.h
@@ -234,10 +234,10 @@ namespace Js
         bool IsCurrentPhysicalFrameForLoopBody() const;
 
         // noinline, we want to use own stack frame.
-        static __declspec(noinline) BOOL GetCaller(JavascriptFunction** ppFunc, ScriptContext* scriptContext);
-        static __declspec(noinline) BOOL GetCaller(JavascriptFunction** ppFunc, uint32* byteCodeOffset, ScriptContext* scriptContext);
-        static __declspec(noinline) bool GetThis(Var* pThis, int moduleId, ScriptContext* scriptContext);
-        static __declspec(noinline) bool GetThis(Var* pThis, int moduleId, JavascriptFunction* func, ScriptContext* scriptContext);
+        static _NOINLINE BOOL GetCaller(JavascriptFunction** ppFunc, ScriptContext* scriptContext);
+        static _NOINLINE BOOL GetCaller(JavascriptFunction** ppFunc, uint32* byteCodeOffset, ScriptContext* scriptContext);
+        static _NOINLINE bool GetThis(Var* pThis, int moduleId, ScriptContext* scriptContext);
+        static _NOINLINE bool GetThis(Var* pThis, int moduleId, JavascriptFunction* func, ScriptContext* scriptContext);
 
         static bool IsDisplayCaller(JavascriptFunction* func);
         bool GetDisplayCaller(JavascriptFunction ** ppFunc);

--- a/lib/Runtime/Language/TaggedInt.cpp
+++ b/lib/Runtime/Language/TaggedInt.cpp
@@ -20,14 +20,14 @@ namespace Js
     }
 
     // Explicitly marking noinline and stdcall since this is called from inline asm
-    __declspec(noinline) Var __stdcall TaggedInt::OverflowHelper(int overflowValue, ScriptContext* scriptContext)
+    _NOINLINE Var __stdcall TaggedInt::OverflowHelper(int overflowValue, ScriptContext* scriptContext)
     {
         Assert( IsOverflow(overflowValue) );
         return JavascriptNumber::NewInlined(static_cast<double>(overflowValue), scriptContext);
     }
 
     // noinline since it's a rare edge case and we don't want to bloat mainline code
-    __declspec(noinline) Var TaggedInt::DivideByZero(int nLeft, ScriptContext* scriptContext)
+    _NOINLINE Var TaggedInt::DivideByZero(int nLeft, ScriptContext* scriptContext)
     {
         if (nLeft == 0)
         {
@@ -491,7 +491,7 @@ LblDone:
     }
 
     // Explicitly marking noinline and stdcall since this is called from inline asm
-    __declspec(noinline) Var __stdcall TaggedInt::IncrementOverflowHelper(ScriptContext* scriptContext)
+    _NOINLINE Var __stdcall TaggedInt::IncrementOverflowHelper(ScriptContext* scriptContext)
     {
         return JavascriptNumber::New( k_nMaxValue + 1.0, scriptContext );
     }
@@ -535,7 +535,7 @@ LblDone:
     }
 
     // Explicitly marking noinline and stdcall since this is called from inline asm
-    __declspec(noinline) Var __stdcall TaggedInt::DecrementUnderflowHelper(ScriptContext* scriptContext)
+    _NOINLINE Var __stdcall TaggedInt::DecrementUnderflowHelper(ScriptContext* scriptContext)
     {
         return JavascriptNumber::New( k_nMinValue - 1.0, scriptContext );
     }

--- a/lib/Runtime/Library/JavascriptFunction.h
+++ b/lib/Runtime/Library/JavascriptFunction.h
@@ -31,7 +31,7 @@ namespace Js
 
     private:
          // noinline, we want to use own stack frame.
-        __declspec(noinline) JavascriptFunction* FindCaller(BOOL* foundThis, JavascriptFunction* nullValue, ScriptContext* requestContext);
+        _NOINLINE JavascriptFunction* FindCaller(BOOL* foundThis, JavascriptFunction* nullValue, ScriptContext* requestContext);
 
         BOOL GetCallerProperty(Var originalInstance, Var* value, ScriptContext* requestContext);
         BOOL GetArgumentsProperty(Var originalInstance, Var* value, ScriptContext* requestContext);

--- a/pal/inc/pal_mstypes.h
+++ b/pal/inc/pal_mstypes.h
@@ -92,12 +92,6 @@ extern "C" {
 #define __inline        inline
 #endif
 
-#if defined(__clang__) || defined(__GNUC__)
-#define __forceinline   __attribute__((always_inline))
-#elif !defined(_MSC_VER)
-#define __forceinline   inline
-#endif
-
 #endif // !_MSC_VER
 
 #ifdef _MSC_VER

--- a/test/Error/stack.js
+++ b/test/Error/stack.js
@@ -56,17 +56,17 @@ catch (e) {
 print("testing stack overflow handling with finally block");
 try
 {
-function stackOverFlowFinally() {
-    try {
-        stackOverFlowFinally();
-        while (true) {
+    function stackOverFlowFinally() {
+        try {
+            stackOverFlowFinally();
+            while (true) {
+            }
+        }
+        finally {
+            DoSomething();
         }
     }
-    finally {
-       DoSomething();
-    }
-}
-   stackOverFlowFinally();
+    stackOverFlowFinally();
 }
 catch(e) {
     printError(e);
@@ -78,19 +78,19 @@ function DoSomething()
 
 try
 {
-   var count = 10000;
+    var count = 20000; // Keep this unrealistic number as we do not
+                       // limit stack memory to a particular capacity
 
-   var a = {};
-   var b = a;
+    var a = {};
+    var b = a;
 
-   for (var i = 0; i < count; i++)
-   {
-    a.x = {};
-    a = a.x;
-   }
-   eval("JSON.stringify(b)");
+    for (var i = 0; i < count; i++)
+    {
+        a.x = {};
+        a = a.x;
+    }
+    eval("JSON.stringify(b)");
 }
 catch(e) {
     printError(e);
 }
-


### PR DESCRIPTION
(Test/Debug Builds) keep Clang from:
- Inlining functions those are not assigned for..
- Optimizing sibling calls (tail call elimination)

Besides:
- Remove `__forceinline` from PAL / use it from CommonPal
- Replace `__declspec(noinline)` with new macro `_NOINLINE` and use attribute on xplat instead
- Make Error/stack.js pushing harder with stack limits