### PR TITLE
cross-platform: Make amd64 asm files compile on OSX

### DIFF
--- a/lib/Runtime/Language/amd64/JavascriptOperatorsA.S
+++ b/lib/Runtime/Language/amd64/JavascriptOperatorsA.S
@@ -3,25 +3,26 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 .intel_syntax noprefix
+#include "unixasmmacros.inc"
 
-.global amd64_CallWithFakeFrame
-.global amd64_ReturnFromCallWithFakeFrame
+.global C_FUNC(amd64_CallWithFakeFrame)
+.global C_FUNC(amd64_ReturnFromCallWithFakeFrame)
 
         // r8       = arg0.
         // rcx      = args size.
         // rdx      = spill size.
         // rsi      = original frame pointer.
         // rdi      = target.
-.align 16
+.balign 16
 .text
-amd64_CallWithFakeFrame:        
+C_FUNC(amd64_CallWithFakeFrame):
         // xplat-todo: need to have an equivalent function to __chkstk that we can
         // call here to verify that we have enough stack space
 
         // The stack walker uses this marker to skip this frame.
         // Note that we use rip-relative addressing here since this
         // library is shared and therefore the code has to be position independent
-        lea rax, [rip+amd64_ReturnFromCallWithFakeFrame]
+        lea rax, [rip+C_FUNC(amd64_ReturnFromCallWithFakeFrame)]
         mov [rsp+8h], rax
 
         mov rax, [rsp + 28h]
@@ -59,8 +60,8 @@ amd64_CallWithFakeFrame:
 
         // rcx = args size.
         // rdx = spill size.
-.align 16
-amd64_ReturnFromCallWithFakeFrame:      
+.balign 16
+C_FUNC(amd64_ReturnFromCallWithFakeFrame):
         add  rsp, rcx
 
         pop  rbx

--- a/lib/Runtime/Library/amd64/JavascriptFunctionA.S
+++ b/lib/Runtime/Library/amd64/JavascriptFunctionA.S
@@ -6,11 +6,11 @@
 .intel_syntax noprefix
 #include "unixasmmacros.inc"
 
-.extern _ZN2Js18JavascriptFunction13DeferredParseEPPNS_14ScriptFunctionE
-.extern _ZN2Js18JavascriptFunction19DeferredDeserializeEPNS_14ScriptFunctionE
+.extern C_FUNC(_ZN2Js18JavascriptFunction13DeferredParseEPPNS_14ScriptFunctionE)
+.extern C_FUNC(_ZN2Js18JavascriptFunction19DeferredDeserializeEPNS_14ScriptFunctionE)
 
-.global _ZN2Js18JavascriptFunction20DeferredParsingThunkEPNS_16RecyclableObjectENS_8CallInfoEz
-.global _ZN2Js18JavascriptFunction24DeferredDeserializeThunkEPNS_16RecyclableObjectENS_8CallInfoEz
+.global C_FUNC(_ZN2Js18JavascriptFunction20DeferredParsingThunkEPNS_16RecyclableObjectENS_8CallInfoEz)
+.global C_FUNC(_ZN2Js18JavascriptFunction24DeferredDeserializeThunkEPNS_16RecyclableObjectENS_8CallInfoEz)
 
 #ifndef __APPLE__
 .type _ZN2Js18JavascriptFunction20DeferredParsingThunkEPNS_16RecyclableObjectENS_8CallInfoEz, @function
@@ -107,8 +107,8 @@ NESTED_END amd64_CallFunction, _TEXT
 
 
 // extrn ?DeferredParse@JavascriptFunction@Js@@SAP6APEAXPEAVRecyclableObject@2@UCallInfo@2@ZZPEAPEAVScriptFunction@2@@Z : PROC
-.align 16
-_ZN2Js18JavascriptFunction20DeferredParsingThunkEPNS_16RecyclableObjectENS_8CallInfoEz:
+.balign 16
+C_FUNC(_ZN2Js18JavascriptFunction20DeferredParsingThunkEPNS_16RecyclableObjectENS_8CallInfoEz):
         push rbp
         lea  rbp, [rsp]
 
@@ -120,7 +120,7 @@ _ZN2Js18JavascriptFunction20DeferredParsingThunkEPNS_16RecyclableObjectENS_8Call
         //  JavascriptMethod JavascriptFunction::DeferredParse(ScriptFunction**)
         //
         lea rdi, [rbp + 10h]    // &function, setup by custom calling convention
-        call _ZN2Js18JavascriptFunction13DeferredParseEPPNS_14ScriptFunctionE@plt
+        call C_PLTFUNC(_ZN2Js18JavascriptFunction13DeferredParseEPPNS_14ScriptFunctionE)
 
         pop rsi
         pop rdi
@@ -130,8 +130,8 @@ _ZN2Js18JavascriptFunction20DeferredParsingThunkEPNS_16RecyclableObjectENS_8Call
 
 // Var JavascriptFunction::DeferredDeserializeThunk(
 //              RecyclableObject* function, CallInfo callInfo, ...)
-.align 16
-_ZN2Js18JavascriptFunction24DeferredDeserializeThunkEPNS_16RecyclableObjectENS_8CallInfoEz:
+.balign 16
+C_FUNC(_ZN2Js18JavascriptFunction24DeferredDeserializeThunkEPNS_16RecyclableObjectENS_8CallInfoEz):
         push rbp
         lea  rbp, [rsp]
 
@@ -144,7 +144,7 @@ _ZN2Js18JavascriptFunction24DeferredDeserializeThunkEPNS_16RecyclableObjectENS_8
         //                              ScriptFunction* function)
         //
         //      RDI == function, setup by custom calling convention
-        call _ZN2Js18JavascriptFunction19DeferredDeserializeEPNS_14ScriptFunctionE@plt
+        call C_PLTFUNC(_ZN2Js18JavascriptFunction19DeferredDeserializeEPNS_14ScriptFunctionE)
 
         pop rsi
         pop rdi


### PR DESCRIPTION
The assembly files fail to assemble due to unsupported `@plt` modifier and fail to link on OS X due to missing label prefix on function names.