### PR TITLE
Fixing an issue with symbol capturing in function defined in catch block's param

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -8876,6 +8876,31 @@ ParseNodePtr Parser::ParseCatch()
 
         pnodeCatchScope = StartParseBlock<buildAST>(PnodeBlockType::Regular, isPattern ? ScopeType_CatchParamPattern : ScopeType_Catch);
 
+        if (buildAST)
+        {
+            // Add this catch to the current scope list.
+
+            if (m_ppnodeExprScope)
+            {
+                Assert(*m_ppnodeExprScope == nullptr);
+                *m_ppnodeExprScope = pnode;
+                m_ppnodeExprScope = &pnode->sxCatch.pnodeNext;
+            }
+            else
+            {
+                Assert(m_ppnodeScope);
+                Assert(*m_ppnodeScope == nullptr);
+                *m_ppnodeScope = pnode;
+                m_ppnodeScope = &pnode->sxCatch.pnodeNext;
+            }
+
+            // Keep a list of function expressions (not declarations) at this scope.
+
+            ppnodeExprScopeSave = m_ppnodeExprScope;
+            m_ppnodeExprScope = &pnode->sxCatch.pnodeScopes;
+            pnode->sxCatch.pnodeScopes = nullptr;
+        }
+
         if (isPattern)
         {
             ParseNodePtr pnodePattern = ParseDestructuredLiteral<buildAST>(tkLET, true /*isDecl*/, true /*topLevel*/, DIC_ForceErrorOnInitializer);
@@ -8928,31 +8953,6 @@ ParseNodePtr Parser::ParseCatch()
             }
 
             m_pscan->Scan();
-        }
-
-        if (buildAST)
-        {
-            // Add this catch to the current scope list.
-
-            if (m_ppnodeExprScope)
-            {
-                Assert(*m_ppnodeExprScope == nullptr);
-                *m_ppnodeExprScope = pnode;
-                m_ppnodeExprScope = &pnode->sxCatch.pnodeNext;
-            }
-            else
-            {
-                Assert(m_ppnodeScope);
-                Assert(*m_ppnodeScope == nullptr);
-                *m_ppnodeScope = pnode;
-                m_ppnodeScope = &pnode->sxCatch.pnodeNext;
-            }
-
-            // Keep a list of function expressions (not declarations) at this scope.
-
-            ppnodeExprScopeSave = m_ppnodeExprScope;
-            m_ppnodeExprScope = &pnode->sxCatch.pnodeScopes;
-            pnode->sxCatch.pnodeScopes = nullptr;
         }
 
         charcount_t ichLim;

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -3117,14 +3117,24 @@ void VisitNestedScopes(ParseNode* pnodeScopeList, ParseNode* pnodeParent, ByteCo
         {
             PreVisitCatch(pnodeScope, byteCodeGenerator);
 
-            Visit(pnodeScope->sxCatch.pnodeParam, byteCodeGenerator, prefix, postfix);
             if (pnodeScope->sxCatch.pnodeParam->nop == knopParamPattern)
             {
+                Parser::MapBindIdentifier(pnodeScope->sxCatch.pnodeParam->sxParamPattern.pnode1, [byteCodeGenerator](ParseNodePtr pnode)
+                {
+                    Assert(pnode->nop == knopLetDecl);
+                    pnode->sxVar.sym->SetLocation(byteCodeGenerator->NextVarRegister());
+                });
+
                 if (pnodeScope->sxCatch.pnodeParam->sxParamPattern.location == Js::Constants::NoRegister)
                 {
                     pnodeScope->sxCatch.pnodeParam->sxParamPattern.location = byteCodeGenerator->NextVarRegister();
                 }
             }
+            else
+            {
+                Visit(pnodeScope->sxCatch.pnodeParam, byteCodeGenerator, prefix, postfix);
+            }
+
             bool isMergedScope;
             pnodeParent->sxFnc.funcInfo->OnStartVisitScope(pnodeScope->sxCatch.scope, &isMergedScope);
             VisitNestedScopes(pnodeScope->sxCatch.pnodeScopes, pnodeParent, byteCodeGenerator, prefix, postfix, pIndex);

--- a/test/es6/destructuring_catch.js
+++ b/test/es6/destructuring_catch.js
@@ -55,7 +55,7 @@ var tests = [
   },
   {
     name: "Destructuring on catch param - basic functionality",
-    body : function () {
+    body: function () {
         try {
             throw [1];
         }
@@ -81,7 +81,7 @@ var tests = [
    },
   {
     name: "Destructuring on catch param - initializer",
-    body : function () {
+    body: function () {
         try {
             throw [];
         }
@@ -189,6 +189,164 @@ var tests = [
             }
         })();
      }
+   },
+   {
+        name: "Function definitions in catch's parameter",
+        body: function () {
+            (function() {
+                try {
+                    var c = 10;
+                    throw ['inside'];
+                } catch ([x, y = function() { return c; }]) {
+                    assert.areEqual(y(), 10, "Function should be able to capture symbols from try's body properly");
+                    assert.areEqual(x, 'inside', "Function should be able to capture symbols from try's body properly");
+                } 
+            })();
+
+            (function() {
+                try {
+                    throw [];
+                } catch ([x = 10, y = function() { return x; }]) {
+                    assert.areEqual(y(), 10, "Function should be able to capture symbols from catch's param");
+                } 
+            })();
+
+            (function() {
+                try {
+                    throw [];
+                } catch ([x = 10, y = function() { return x; }]) {
+                    eval("");
+                    assert.areEqual(y(), 10, "Function should be able to capture symbols from catch's param");
+                } 
+            })();
+
+            (function() {
+                try {
+                    throw {};
+                } catch ({x = 10, y = function() { return x; }}) {
+                    assert.areEqual(y(), 10, "Function should be able to capture symbols from catch's param");
+                } 
+            })();
+
+            (function() {
+                try {
+                    throw ['inside', {}];
+                } catch ([x = 10, { y = function() { return x; } }]) {
+                    eval("");
+                    assert.areEqual(y(), 'inside', "Function should be able to capture symbols from catch's param");
+                } 
+            })();
+
+            (function() {
+                try {
+                    throw ['inside', {}];
+                } catch ([x, { y = () => arguments[0] }]) {
+                    assert.areEqual(y(), 10, "Function should be able to capture the arguments symbol from the parent function");
+                    assert.areEqual(x, 'inside', "Function should be able to capture symbols from try's body properly");
+                } 
+            })(10);
+
+            (function(a = 1, b = () => a) {
+                try {
+                    throw [];
+                } catch ([x = 10, y = function() { return b; }]) {
+                    assert.areEqual(y()(), 1, "Function should be able to capture formals from a split scoped function");
+                } 
+            })();
+
+            (function () {
+                var z = 100;
+                (function() {
+                    try {
+                        throw [];
+                    } catch ([x = 10,  y = () => x + z]) {
+                        assert.areEqual(y(), 110, "Function should be able to capture symbols from outer functions");
+                    } 
+                })();
+            })();
+
+            (function () {
+                var z = 100;
+                (function() {
+                    try {
+                        throw [];
+                    } catch ([x = z = 10,  y = () => x]) {
+                        assert.areEqual(y(), 10, "Function should be able to capture symbols from outer functions");
+                        assert.areEqual(z, 10, "Variable from the outer function is updated during the param initialization");
+                    } 
+                })();
+            })();
+
+            (function () {
+                var a = 100;
+                (function() {
+                    var b = 200;
+                    try {
+                        throw [];
+                    } catch ([x = () => y, y = 10,  z = () => a]) {
+                        c = () => x() + z() + b;
+                        assert.areEqual(c(), 310, "Variable from all three levels are accessible");
+                    } 
+                })();
+            })();
+
+            (function () {
+                var a = 100;
+                (function() {
+                    var b = 200;
+                    try {
+                        throw [];
+                    } catch ([x = () => y, y = 10,  z = () => a]) {
+                        c = () => x() + z() + b;
+                        assert.areEqual(c(), 310, "Variable from all three levels are accessible with eval in catch's body");
+                        eval("");
+                    } 
+                })();
+            })();
+
+            (function () {
+                try {
+                    var c = 10;
+                    throw [ ];
+                } catch ([x = 1, y = function() { eval(""); return c + x; }]) {
+                    assert.areEqual(y(), 11, "Function should be able to capture symbols from outer functions even with eval in the body");
+                }
+            })();
+
+            (function () {
+                try {
+                    eval("");
+                    var c = 10;
+                    throw [ ];
+                } catch ([x = 1, y = function() { return c + x; }]) {
+                    assert.areEqual(y(), 11, "Function should be able to capture symbols from outer functions even with eval in the try block");
+                }
+            })();
+
+            (function () {
+                try {
+                    var c = 10;
+                    throw {x : 'inside', y: []};
+                } catch ({x, y: [y = function(a = 10, b = () => a) { return b; }]}) {
+                    assert.areEqual(y()(), 10, "Function should be able to capture symbols from outer functions even if it has split scope");
+                }
+            })();
+
+            (function () {
+                var f = function foo(a) {
+                    try {
+                        if (!a) {
+                            return foo(1);
+                        }
+                        var c = 10;
+                        throw [ ];
+                    } catch ([y = function() { return c + a; }]) {
+                        assert.areEqual(y(), 11, "Function should be able to capture symbols from outer functions when inside a named function expression");
+                    }
+                };
+                f();
+            })();
+        }
    }
 ];
 


### PR DESCRIPTION
Fixing an issue with symbol capturing in function defined in catch block's
param

When catch block's param has a function definition, its node should be added to the list after the catch block. Right now we were adding the catch block to the list only after the params are parsed. Also during the visit the pnodescopes should be visited separate, not along with the params.
