### PR TITLE
Wasm nyi & errors

### DIFF
--- a/lib/Parser/rterrors.h
+++ b/lib/Parser/rterrors.h
@@ -275,7 +275,7 @@ RT_ERROR_MSG(JSERR_DeletePropertyWithSuper, 5146, "Unable to delete property '%s
 RT_ERROR_MSG(JSERR_DetachedTypedArray, 5147, "%s: The ArrayBuffer is detached.", "The ArrayBuffer is detached.", kjstTypeError, 0)
 RT_ERROR_MSG(JSERR_AsmJsCompileError, 5148, "%s: Compiling asm.js failed.", "Compiling asm.js failed.", kjstError, 0)
 RT_ERROR_MSG(JSERR_ImmutablePrototypeSlot, 5149, "%s: Can't set the prototype of this object.", "Can't set the prototype of this object.", kjstTypeError, 0)
-RT_ERROR_MSG(JSERR_WasmCompileError, 5150, "Compiling wasm failed:  %s", "Compiling wasm failed.", kjstError, 0)
+RT_ERROR_MSG(JSERR_WasmCompileError, 5150, "Compiling wasm failed: %s", "Compiling wasm failed.", kjstError, 0)
 
 /* Error messages for misbehaved Async Operations for use in Promise.js */
 RT_ERROR_MSG(ASYNCERR_NoErrorInErrorState, 5200, "", "Status is 'error', but getResults did not return an error", kjstError, 0)

--- a/lib/WasmReader/WasmBinaryOpCodes.h
+++ b/lib/WasmReader/WasmBinaryOpCodes.h
@@ -182,8 +182,8 @@ WASM_SIMPLE_OPCODE(F32Neg,              0x7c, NEG_F32,          F_F)
 WASM_SIMPLE_OPCODE(F32CopySign,         0x7d, COPYSIGN_F32,     F_FF)
 WASM_SIMPLE_OPCODE(F32Ceil,             0x7e, CEIL_F32,         F_F)
 WASM_SIMPLE_OPCODE(F32Floor,            0x7f, FLOOR_F32,        F_F)
-WASM_SIMPLE_OPCODE(F32Trunc,            0x80, TRUNC_F32,        F_F)
-WASM_SIMPLE_OPCODE(F32NearestInt,       0x81, NEAREST_F32,      F_F)
+WASM_SIMPLE_OPCODE(F32Trunc,            0x80, NYI,              F_F) //TRUNC_F32
+WASM_SIMPLE_OPCODE(F32NearestInt,       0x81, NYI,              F_F) //NEAREST_F32
 WASM_SIMPLE_OPCODE(F32Sqrt,             0x82, SQRT_F32,         F_F)
 WASM_SIMPLE_OPCODE(F32Eq,               0x83, EQ_F32,           I_FF)
 WASM_SIMPLE_OPCODE(F32Ne,               0x84, NEQ_F32,          I_FF)
@@ -199,11 +199,11 @@ WASM_SIMPLE_OPCODE(F64Min,              0x8d, MIN_F64,          D_DD)
 WASM_SIMPLE_OPCODE(F64Max,              0x8e, MAX_F64,          D_DD)
 WASM_SIMPLE_OPCODE(F64Abs,              0x8f, ABS_F64,          D_D)
 WASM_SIMPLE_OPCODE(F64Neg,              0x90, NEG_F64,          D_D)
-WASM_SIMPLE_OPCODE(F64CopySign,         0x91, COPYSIGN_F64,     D_DD)
+WASM_SIMPLE_OPCODE(F64CopySign,         0x91, NYI,              D_DD) //COPYSIGN_F64
 WASM_SIMPLE_OPCODE(F64Ceil,             0x92, CEIL_F64,         D_D)
 WASM_SIMPLE_OPCODE(F64Floor,            0x93, FLOOR_F64,        D_D)
-WASM_SIMPLE_OPCODE(F64Trunc,            0x94, TRUNC_F64,        D_D)
-WASM_SIMPLE_OPCODE(F64NearestInt,       0x95, NEAREST_F64,      D_D)
+WASM_SIMPLE_OPCODE(F64Trunc,            0x94, NYI,              D_D) //TRUNC_F64
+WASM_SIMPLE_OPCODE(F64NearestInt,       0x95, NYI,              D_D) //NEAREST_F64
 WASM_SIMPLE_OPCODE(F64Sqrt,             0x96, SQRT_F64,         D_D)
 WASM_SIMPLE_OPCODE(F64Eq,               0x97, EQ_F64,           I_DD)
 WASM_SIMPLE_OPCODE(F64Ne,               0x98, NEQ_F64,          I_DD)
@@ -213,8 +213,8 @@ WASM_SIMPLE_OPCODE(F64Gt,               0x9b, GT_F64,           I_DD)
 WASM_SIMPLE_OPCODE(F64Ge,               0x9c, GE_F64,           I_DD)
 WASM_SIMPLE_OPCODE(I32SConvertF32,      0x9d, TRUNC_S_F32_I32,  I_F)
 WASM_SIMPLE_OPCODE(I32SConvertF64,      0x9e, TRUNC_S_F64_I32,  I_D)
-WASM_SIMPLE_OPCODE(I32UConvertF32,      0x9f, TRUNC_U_F32_I32,  I_F)
-WASM_SIMPLE_OPCODE(I32UConvertF64,      0xa0, TRUNC_U_F64_I32,  I_D)
+WASM_SIMPLE_OPCODE(I32UConvertF32,      0x9f, NYI,              I_F) //TRUNC_U_F32_I32
+WASM_SIMPLE_OPCODE(I32UConvertF64,      0xa0, NYI,              I_D) //TRUNC_U_F64_I32
 WASM_SIMPLE_OPCODE(I32ConvertI64,       0xa1, NYI,              I_L)
 WASM_SIMPLE_OPCODE(I64SConvertF32,      0xa2, NYI,              L_F)
 WASM_SIMPLE_OPCODE(I64SConvertF64,      0xa3, NYI,              L_D)
@@ -223,13 +223,13 @@ WASM_SIMPLE_OPCODE(I64UConvertF64,      0xa5, NYI,              L_D)
 WASM_SIMPLE_OPCODE(I64SConvertI32,      0xa6, NYI,              L_I)
 WASM_SIMPLE_OPCODE(I64UConvertI32,      0xa7, NYI,              L_I)
 WASM_SIMPLE_OPCODE(F32SConvertI32,      0xa8, CONVERT_S_I32_F32,F_I)
-WASM_SIMPLE_OPCODE(F32UConvertI32,      0xa9, CONVERT_U_I32_F32,F_I)
+WASM_SIMPLE_OPCODE(F32UConvertI32,      0xa9, NYI,              F_I) //CONVERT_U_I32_F32
 WASM_SIMPLE_OPCODE(F32SConvertI64,      0xaa, NYI,              F_L)
 WASM_SIMPLE_OPCODE(F32UConvertI64,      0xab, NYI,              F_L)
 WASM_SIMPLE_OPCODE(F32ConvertF64,       0xac, DEMOTE_F64_F32,   F_D)
-WASM_SIMPLE_OPCODE(F32ReinterpretI32,   0xad, REINTERPRET_I32_F32, F_I)
+WASM_SIMPLE_OPCODE(F32ReinterpretI32,   0xad, NYI,              F_I) //REINTERPRET_I32_F32
 WASM_SIMPLE_OPCODE(F64SConvertI32,      0xae, CONVERT_S_I32_F64,D_I)
-WASM_SIMPLE_OPCODE(F64UConvertI32,      0xaf, CONVERT_U_I32_F64,D_I)
+WASM_SIMPLE_OPCODE(F64UConvertI32,      0xaf, NYI,              D_I) //CONVERT_U_I32_F64
 WASM_SIMPLE_OPCODE(F64SConvertI64,      0xb0, NYI,              D_L)
 WASM_SIMPLE_OPCODE(F64UConvertI64,      0xb1, NYI,              D_L)
 WASM_SIMPLE_OPCODE(F64ConvertF32,       0xb2, PROMOTE_F32_F64,  D_F)

--- a/lib/WasmReader/WasmBinaryReader.cpp
+++ b/lib/WasmReader/WasmBinaryReader.cpp
@@ -86,8 +86,7 @@ WasmBinaryReader::ThrowDecodingError(const char16* msg, ...)
     va_list argptr;
     va_start(argptr, msg);
     // We need to do a format twice (or concat the 2 strings)
-    WasmCompilationException baseEx(msg, argptr);
-    throw WasmCompilationException(_u("Binary decoding failed:\n  %s"), baseEx.GetErrorMessage());
+    throw WasmCompilationException(msg, argptr);
 }
 
 bool

--- a/lib/WasmReader/WasmBinaryReader.h
+++ b/lib/WasmReader/WasmBinaryReader.h
@@ -99,6 +99,7 @@ namespace Wasm
             WasmOp ReadFromCall();
             WasmOp ReadExpr();
             WasmOp GetLastOp();
+            WasmBinOp GetLastBinOp() const { return m_lastOp; }
 #if DBG_DUMP
             void PrintOps();
 #endif

--- a/lib/WasmReader/WasmByteCodeGenerator.cpp
+++ b/lib/WasmReader/WasmByteCodeGenerator.cpp
@@ -336,10 +336,10 @@ WasmBytecodeGenerator::GenerateFunction()
     {
         if (!PHASE_ON1(Js::WasmLazyTrapPhase))
         {
-            throw WasmCompilationException(_u("%s\n  Function %s"), ex.GetErrorMessage(), functionName);
+            throw WasmCompilationException(_u("function %s: %s"), functionName, ex.GetErrorMessage());
         }
         Assert(m_module->lazyTraps != nullptr);
-        WasmCompilationException* lazyTrap = Anew(&m_alloc, WasmCompilationException, _u("Delayed Wasm trap:\n  %s\n  Function %s"), ex.GetErrorMessage(), functionName);
+        WasmCompilationException* lazyTrap = Anew(&m_alloc, WasmCompilationException, _u("(delayed) function %s: %s"), functionName, ex.GetErrorMessage());
         m_module->lazyTraps[wasmInfo->GetNumber()] = lazyTrap;
     }
     return m_currentFunc;
@@ -479,8 +479,16 @@ WasmBytecodeGenerator::EmitExpr(WasmOp op)
         break;
 #include "WasmKeywords.h"
     case wnNYI:
-        // todo:: add the name of the operator that is NYI
-        throw WasmCompilationException(_u("Operator NYI"));
+        switch (m_reader.GetLastBinOp())
+        {
+#define WASM_OPCODE(opname, opcode, token, sig) \
+    case opcode: \
+        throw WasmCompilationException(_u("Operator " #opname## " NYI"));
+        break;
+#include "WasmBinaryOpcodes.h"
+        default:
+            break;
+        }
     default:
         throw WasmCompilationException(_u("Unknown expression's op 0x%X"), op);
     }
@@ -690,8 +698,10 @@ WasmBytecodeGenerator::EmitCall()
         switch (info.type)
         {
         case WasmTypes::F32:
-            Assert(wasmOp != wnCALL_IMPORT);
-            // REVIEW: support FFI call with f32 params?
+            if (wasmOp == wnCALL_IMPORT) 
+            {
+                throw WasmCompilationException(_u("External calls with float argument NYI"));
+            }
             argOp = Js::OpCodeAsmJs::I_ArgOut_Flt;
             break;
         case WasmTypes::F64:


### PR DESCRIPTION
Mark wasm operators that are not fully working as NYI 
Simplify the Compilation error message format 
Output the name of the operator that is NYI  in the error message

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/1142)
<!-- Reviewable:end -->
