### PR TITLE
fix debugging asm.js when closure is named function expression

### DIFF
--- a/lib/Runtime/Language/AsmJsTypes.h
+++ b/lib/Runtime/Language/AsmJsTypes.h
@@ -304,7 +304,8 @@ namespace Js
             TypedArrayBuiltinFunction,
             /*SIMDVariable,*/
             SIMDBuiltinFunction,
-            ModuleArgument
+            ModuleArgument,
+            ClosureFunction
         };
     private:
         // name of the symbol, all symbols must have unique names


### PR DESCRIPTION
FunctionBody wants named function to be in slotArray even though it isn't actually closure captured, because of our temporary deferral of inner functions

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/1144)
<!-- Reviewable:end -->
