### PR TITLE
BUG 7853164: Check for nullptr before searching prototype chain; if propertyDescriptor is null then it's prototype will be nullptr.

### DIFF
--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -10171,6 +10171,11 @@ CommonNumber:
     // contains a proxy anywhere in the prototype chain.
     bool JavascriptOperators::CheckIfPrototypeChainContainsProxyObject(RecyclableObject* prototype)
     {
+        if (prototype == nullptr)
+        {
+            return false;
+        }
+
         Assert(JavascriptOperators::IsObjectOrNull(prototype));
 
         while (prototype->GetTypeId() != TypeIds_Null)

--- a/test/es6/nullPropertyDescriptor.js
+++ b/test/es6/nullPropertyDescriptor.js
@@ -1,0 +1,18 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+try {
+    Object.defineProperty({}, "x", null);
+} catch (e) {
+    if (e instanceof TypeError) {
+        if (e.message !== "Invalid descriptor for property 'x'") {
+            print('FAIL');
+        } else {
+            print('PASS');
+        }
+    } else {
+        print('FAIL');
+    }
+}

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -708,6 +708,11 @@
   </test>
   <test>
     <default>
+      <files>nullPropertyDescriptor.js</files>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>object-is.js</files>
       <compile-flags>-args summary -endargs</compile-flags>
     </default>


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/1146)
<!-- Reviewable:end -->
