### PR TITLE
xplat: re-enable compile assert for BVSparseNode

### DIFF
--- a/lib/Common/DataStructures/SparseBitVector.h
+++ b/lib/Common/DataStructures/SparseBitVector.h
@@ -91,10 +91,7 @@ struct BVSparseNode
 #endif
 };
 
-// xplat-todo: revisit for unix
-#ifdef _WIN32
 CompileAssert(sizeof(BVSparseNode) == 16); // Performance assert, BVSparseNode is heavily used in the backend, do perf measurement before changing this.
-#endif
 
 template <class TAllocator>
 class BVSparse


### PR DESCRIPTION
It's indeed 16 bytes on GNU/Linux 64bit Clang 3.8. Since it seems
important to avoid regressions here we should re-enable it.