### PR TITLE
cross-platform: Fix clang issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,7 @@ if(CLR_CMAKE_PLATFORM_UNIX)
 
     # CXX WARNING FLAGS
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
+        -Werror\
         -Wno-microsoft\
         -Wno-unused-value\
         -Wno-int-to-void-pointer-cast\
@@ -112,7 +113,6 @@ if(CLR_CMAKE_PLATFORM_UNIX)
     # Release Builds: Not sure if this has to be as strict as the debug/test?
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
         -fdelayed-template-parsing\
-        -fno-inline-functions\
         -fno-omit-frame-pointer\
         -fno-optimize-sibling-calls\
         -mno-omit-leaf-frame-pointer" # this is for compat reasons. i.e. It is a noop with gcc

--- a/lib/Runtime/Debug/DiagObjectModel.h
+++ b/lib/Runtime/Debug/DiagObjectModel.h
@@ -88,6 +88,8 @@ namespace Js
         virtual bool IsFake() { return (this->GetTypeAttribute() & DBGPROP_ATTRIB_VALUE_IS_FAKE) == DBGPROP_ATTRIB_VALUE_IS_FAKE; }
         virtual bool IsLiteralProperty() const = 0;
         virtual bool IsSymbolProperty() { return false; }
+
+        virtual ~IDiagObjectModelDisplay() { /* Dummy */ }
     };
 
     //

--- a/lib/Runtime/Library/JavascriptFunction.cpp
+++ b/lib/Runtime/Library/JavascriptFunction.cpp
@@ -2755,7 +2755,7 @@ LABEL1:
 
         BOOL result = DynamicObject::DeleteProperty(propertyId, flags);
 
-        if (result && propertyId == PropertyIds::prototype || propertyId == PropertyIds::_symbolHasInstance)
+        if (result && (propertyId == PropertyIds::prototype || propertyId == PropertyIds::_symbolHasInstance))
         {
             InvalidateConstructorCacheOnPrototypeChange();
             this->GetScriptContext()->GetThreadContext()->InvalidateIsInstInlineCachesForFunction(this);

--- a/lib/Runtime/Library/JavascriptString.cpp
+++ b/lib/Runtime/Library/JavascriptString.cpp
@@ -2220,7 +2220,7 @@ case_2:
                 if (*i >= 'a')
                 {
                     if (*i <= 'z') { break; }
-                    if (*i >= 'ß') { break; }
+                    if (*i >= 223) { break; }
                 }
                 i++;
             }
@@ -2236,10 +2236,10 @@ case_2:
                 if (*i >= 'A')
                 {
                     if (*i <= 'Z') { break; }
-                    if (*i >= 'À')
+                    if (*i >= 192)
                     { 
-                        if (*i < 'ß') { break; }
-                        if (*i >= 'ÿ') { break; }
+                        if (*i < 223) { break; }
+                        if (*i >= 255) { break; }
                     }
                 }
                 i++;

--- a/lib/Runtime/Library/TypedArray.h
+++ b/lib/Runtime/Library/TypedArray.h
@@ -467,26 +467,37 @@ namespace Js
         }
     };
 
-    typedef TypedArray<int8> Int8Array;
-    typedef TypedArray<uint8,false> Uint8Array;
-    typedef TypedArray<uint8,true> Uint8ClampedArray;
-    typedef TypedArray<int16> Int16Array;
-    typedef TypedArray<uint16> Uint16Array;
-    typedef TypedArray<int32> Int32Array;
-    typedef TypedArray<uint32> Uint32Array;
-    typedef TypedArray<float> Float32Array;
-    typedef TypedArray<double> Float64Array;
-    typedef TypedArray<int64> Int64Array;
-    typedef TypedArray<uint64> Uint64Array;
-    typedef TypedArray<bool> BoolArray;
-    typedef TypedArray<int8, false, true> Int8VirtualArray;
-    typedef TypedArray<uint8, false, true> Uint8VirtualArray;
-    typedef TypedArray<uint8, true, true> Uint8ClampedVirtualArray;
-    typedef TypedArray<int16, false, true> Int16VirtualArray;
-    typedef TypedArray<uint16, false, true> Uint16VirtualArray;
-    typedef TypedArray<int32, false, true> Int32VirtualArray;
-    typedef TypedArray<uint32, false, true> Uint32VirtualArray;
-    typedef TypedArray<float, false, true> Float32VirtualArray;
-    typedef TypedArray<double, false, true> Float64VirtualArray;
+#if defined(__clang__)
+// hack for clang message: "...add an explicit instantiation declaration to .."
+#define __EXPLICIT_INSTANTINATE_TA(x) x;\
+            template<> FunctionInfo Js::x::EntryInfo::NewInstance;\
+            template<> FunctionInfo Js::x::EntryInfo::Set;\
+            template<> FunctionInfo Js::x::EntryInfo::Subarray
+#else // MSVC
+#define __EXPLICIT_INSTANTINATE_TA(x) x
+#endif
 
+    typedef TypedArray<int8>        __EXPLICIT_INSTANTINATE_TA(Int8Array);
+    typedef TypedArray<uint8,false> __EXPLICIT_INSTANTINATE_TA(Uint8Array);
+    typedef TypedArray<uint8,true>  __EXPLICIT_INSTANTINATE_TA(Uint8ClampedArray);
+    typedef TypedArray<int16>       __EXPLICIT_INSTANTINATE_TA(Int16Array);
+    typedef TypedArray<uint16>      __EXPLICIT_INSTANTINATE_TA(Uint16Array);
+    typedef TypedArray<int32>       __EXPLICIT_INSTANTINATE_TA(Int32Array);
+    typedef TypedArray<uint32>      __EXPLICIT_INSTANTINATE_TA(Uint32Array);
+    typedef TypedArray<float>       __EXPLICIT_INSTANTINATE_TA(Float32Array);
+    typedef TypedArray<double>      __EXPLICIT_INSTANTINATE_TA(Float64Array);
+    typedef TypedArray<int64>       __EXPLICIT_INSTANTINATE_TA(Int64Array);
+    typedef TypedArray<uint64>      __EXPLICIT_INSTANTINATE_TA(Uint64Array);
+    typedef TypedArray<bool>        __EXPLICIT_INSTANTINATE_TA(BoolArray);
+    typedef TypedArray<int8, false, true>   __EXPLICIT_INSTANTINATE_TA(Int8VirtualArray);
+    typedef TypedArray<uint8, false, true>  __EXPLICIT_INSTANTINATE_TA(Uint8VirtualArray);
+    typedef TypedArray<uint8, true, true>   __EXPLICIT_INSTANTINATE_TA(Uint8ClampedVirtualArray);
+    typedef TypedArray<int16, false, true>  __EXPLICIT_INSTANTINATE_TA(Int16VirtualArray);
+    typedef TypedArray<uint16, false, true> __EXPLICIT_INSTANTINATE_TA(Uint16VirtualArray);
+    typedef TypedArray<int32, false, true>  __EXPLICIT_INSTANTINATE_TA(Int32VirtualArray);
+    typedef TypedArray<uint32, false, true> __EXPLICIT_INSTANTINATE_TA(Uint32VirtualArray);
+    typedef TypedArray<float, false, true>  __EXPLICIT_INSTANTINATE_TA(Float32VirtualArray);
+    typedef TypedArray<double, false, true> __EXPLICIT_INSTANTINATE_TA(Float64VirtualArray);
+
+#undef __EXPLICIT_INSTANTINATE_TA
 }

--- a/lib/Runtime/Types/NullTypeHandler.cpp
+++ b/lib/Runtime/Types/NullTypeHandler.cpp
@@ -332,6 +332,9 @@ namespace Js
     template<bool IsPrototypeTemplate>
     NullTypeHandler<IsPrototypeTemplate> NullTypeHandler<IsPrototypeTemplate>::defaultInstance;
 
+    template<bool IsPrototypeTemplate>
+    NullTypeHandler<IsPrototypeTemplate> * NullTypeHandler<IsPrototypeTemplate>::GetDefaultInstance() { return &defaultInstance; }
+
     template class NullTypeHandler<false>;
     template class NullTypeHandler<true>;
 }

--- a/lib/Runtime/Types/NullTypeHandler.h
+++ b/lib/Runtime/Types/NullTypeHandler.h
@@ -91,6 +91,6 @@ namespace Js
         static NullTypeHandler defaultInstance;
 
     public:
-        static NullTypeHandler * GetDefaultInstance() { return &defaultInstance; }
+        static NullTypeHandler * GetDefaultInstance();
     };
 }

--- a/test/runtests.sh
+++ b/test/runtests.sh
@@ -25,5 +25,4 @@ if [[ $build_type != "-d" && $build_type != "-t" ]]; then
     fi
 fi
 
-# todo-xpat: Enable others tests 
-"$test_path/runtests.py" $build_type $test_path/Basics/hello.js
+"$test_path/runtests.py" $build_type


### PR DESCRIPTION
 - remove `-fno-inline-functions` from build as it breaks CC / Clang3.8+
   ATM we have all the tests are passing. So, we no longer need this compiler
   switch in place.

 - enable `Werror` to prevent commits are breaking clang support

 - enable both debug and test-build tests on CI

 - fix clang 3.8/3.9 template issues