### PR TITLE
Function.name issue when the LHS is not identifier ref.

### DIFF
--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -1912,6 +1912,9 @@ namespace Js
 
         if (fParsed == TRUE)
         {
+            // Restore if the function has nameIdentifier reference, as that name on the left side will not be parsed again while deferparse.
+            funcBody->SetIsNameIdentifierRef(this->GetIsNameIdentifierRef());
+
             this->UpdateFunctionBodyImpl(funcBody);
             this->m_hasBeenParsed = true;
         }

--- a/test/es6/function.name.js
+++ b/test/es6/function.name.js
@@ -761,6 +761,17 @@ var tests = [
             assert.areEqual("get", desc.get.name);
             assert.areEqual("set", desc.set.name);
         }
+    },
+	{
+        name: "Function name will be set only when LHS is identifier reference.",
+        body: function()
+        {
+            var obj = {};
+            obj.foo = function() {
+                assert.areEqual(obj.foo.name, "");
+            }
+            obj.foo();
+        }
     }
 
 ];

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -90,6 +90,12 @@
   </test>
   <test>
     <default>
+      <files>function.name.js</files>
+      <compile-flags>-ES6Generators -es6toprimitive -ES6Classes -es6functionnamefull -force:deferparse -args summary -endargs</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>superDotOSBug3930962.js</files>
       <compile-flags>-args summary -endargs</compile-flags>
       <tags>BugFix</tags>


### PR DESCRIPTION
The variable isNameIdentifierRef is used to guide the logic to give the function.name. That flag will be set when the LHS is reference identifier (say foo = function() {}), that works correct in the no-deferparse case. For example foo.bar =function() {}, the variable isNameIdentifier should be false. Which works correct till the function is deferred. However when we undefer that function, we parse the function after assignment (foo.bar information is lost). in that case the isNameIdentifier was not set correctly. Fixed that by setting back that flag to new function body from the old parseablefunctioninfo, after the parsing is done.
UT passed. Added one test.
