### PR TITLE
Capture bailout symbols incrementally in one block

### DIFF
--- a/lib/Backend/GlobHashTable.h
+++ b/lib/Backend/GlobHashTable.h
@@ -210,6 +210,25 @@ public:
         return NULL;
     }
 
+    HashBucket * GetBucket(uint key)
+    {
+        uint hash = this->Hash(key);
+        // Assumes sorted lists
+        FOREACH_SLISTBASE_ENTRY(HashBucket, bucket, &this->table[hash])
+        {
+            if (Key::Get(bucket.value) <= key)
+            {
+                if (Key::Get(bucket.value) == key)
+                {
+                    return &bucket;
+                }
+                break;
+            }
+        } NEXT_SLISTBASE_ENTRY;
+
+        return nullptr;
+    }
+
     TElement GetAndClear(TData * value)
     {
         uint key = Key::Get(value);

--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -1061,6 +1061,9 @@ GlobOpt::MergePredBlocksValueMaps(BasicBlock *block)
         this->KillAllObjectTypes();
     }
 
+    this->blockData.capturedArgs = JitAnew(this->alloc, BVSparse<JitArenaAllocator>, this->alloc);
+    this->blockData.changedSyms = JitAnew(this->alloc, BVSparse<JitArenaAllocator>, this->alloc);
+
     this->CopyBlockData(&block->globOptData, &this->blockData);
 
     if (this->IsLoopPrePass())
@@ -1509,6 +1512,10 @@ GlobOpt::NulloutBlockData(GlobOptBlockData *data)
 
     data->stackLiteralInitFldDataMap = nullptr;
 
+    data->capturedValues = nullptr;
+    data->capturedArgs = nullptr;
+    data->changedSyms = nullptr;
+
     data->OnDataUnreferenced();
 }
 
@@ -1603,6 +1610,12 @@ GlobOpt::ReuseBlockData(GlobOptBlockData *toData, GlobOptBlockData *fromData)
 
     toData->stackLiteralInitFldDataMap = fromData->stackLiteralInitFldDataMap;
 
+    // toData->capturedValues = fromData->capturedValues;
+    toData->capturedArgs = fromData->capturedArgs;
+    toData->changedSyms = fromData->changedSyms;
+    toData->capturedArgs->ClearAll();
+    toData->changedSyms->ClearAll();
+
     toData->OnDataReused(fromData);
 }
 
@@ -1639,8 +1652,12 @@ GlobOpt::CopyBlockData(GlobOptBlockData *toData, GlobOptBlockData *fromData)
     toData->inlinedArgOutCount = fromData->inlinedArgOutCount;
     toData->hasCSECandidates = fromData->hasCSECandidates;
 
-    toData->stackLiteralInitFldDataMap = fromData->stackLiteralInitFldDataMap;
+    toData->capturedArgs = fromData->capturedArgs;
+    toData->changedSyms = fromData->changedSyms;
+    toData->capturedArgs->ClearAll();
+    toData->changedSyms->ClearAll();
 
+    toData->stackLiteralInitFldDataMap = fromData->stackLiteralInitFldDataMap;
     toData->OnDataReused(fromData);
 }
 
@@ -3188,7 +3205,7 @@ GlobOpt::MergeValues(
     // Set symStore if same on both paths.
     if (toDataValue->GetValueInfo()->GetSymStore() == fromDataValue->GetValueInfo()->GetSymStore())
     {
-        newValueInfo->SetSymStore(toDataValue->GetValueInfo()->GetSymStore());
+        this->SetSymStoreDirect(newValueInfo, toDataValue->GetValueInfo()->GetSymStore());
     }
 
     return newValue;
@@ -5059,6 +5076,14 @@ GlobOpt::OptInstr(IR::Instr *&instr, bool* isInstrRemoved)
         }
     }
 
+    if (instr->HasBailOutInfo() && !this->IsLoopPrePass())
+    {
+        this->currentBlock->globOptData.capturedArgs->ClearAll();
+        this->currentBlock->globOptData.changedSyms->ClearAll();
+        this->currentBlock->globOptData.capturedValues = 
+            this->currentBlock->globOptData.capturedValuesCandicate;
+    }
+
     return instrNext;
 }
 
@@ -5356,7 +5381,7 @@ GlobOpt::OptDst(
                         }
                     }
 
-                    dstVal->GetValueInfo()->SetSymStore(dstVarSym);
+                    this->SetSymStoreDirect(dstVal->GetValueInfo(), dstVarSym);
                 } while(false);
             }
         }
@@ -6365,7 +6390,7 @@ GlobOpt::CopyProp(IR::Opnd *opnd, IR::Instr *instr, Value *val, IR::IndirOpnd *p
 
     if (PHASE_OFF(Js::CopyPropPhase, this->func))
     {
-        valueInfo->SetSymStore(opndSym);
+        this->SetSymStoreDirect(valueInfo, opndSym);
         return opnd;
     }
 
@@ -6389,7 +6414,7 @@ GlobOpt::CopyProp(IR::Opnd *opnd, IR::Instr *instr, Value *val, IR::IndirOpnd *p
             //   fieldHoistSym = Ld_A t1    <- we're looking at t1 now, but want to copy-prop fieldHoistSym forward
             return opnd;
         }
-        valueInfo->SetSymStore(opndSym);
+        this->SetSymStoreDirect(valueInfo, opndSym);
     }
     return opnd;
 }
@@ -7057,10 +7082,23 @@ GlobOpt::SetSymStore(ValueInfo *valueInfo, Sym *sym)
     }
     if (valueInfo->GetSymStore() == nullptr || valueInfo->GetSymStore()->IsPropertySym())
     {
-        valueInfo->SetSymStore(sym);
+        SetSymStoreDirect(valueInfo, sym);
     }
 
     return sym;
+}
+
+void
+GlobOpt::SetSymStoreDirect(ValueInfo * valueInfo, Sym * sym)
+{
+    Sym * prevSymStore = valueInfo->GetSymStore();
+    if (prevSymStore && prevSymStore->IsStackSym() &&
+        prevSymStore->AsStackSym()->HasByteCodeRegSlot() &&
+        this->blockData.changedSyms)
+    {
+        this->blockData.changedSyms->Set(prevSymStore->m_id);
+    }
+    valueInfo->SetSymStore(sym);
 }
 
 void
@@ -7069,8 +7107,9 @@ GlobOpt::SetValue(GlobOptBlockData *blockData, Value *val, Sym * sym)
     ValueInfo *valueInfo = val->GetValueInfo();
 
     sym = this->SetSymStore(valueInfo, sym);
+    bool isStackSym = sym->IsStackSym();
 
-    if (sym->IsStackSym() && sym->AsStackSym()->IsFromByteCodeConstantTable())
+    if (isStackSym && sym->AsStackSym()->IsFromByteCodeConstantTable())
     {
         // Put the constants in a global array. This will minimize the per-block info.
         this->byteCodeConstantValueArray->Set(sym->m_id, val);
@@ -7079,6 +7118,10 @@ GlobOpt::SetValue(GlobOptBlockData *blockData, Value *val, Sym * sym)
     else
     {
         SetValueToHashTable(blockData->symToValueMap, val, sym);
+        if (blockData->changedSyms && isStackSym && sym->AsStackSym()->HasByteCodeRegSlot())
+        {
+            blockData->changedSyms->Set(sym->m_id);
+        }
     }
 }
 
@@ -7344,13 +7387,13 @@ GlobOpt::ValueNumberDst(IR::Instr **pInstr, Value *src1Val, Value *src2Val)
             // Update symStore for field hoisting
             if (loop != nullptr && (dstValueInfo != nullptr))
             {
-                dstValueInfo->SetSymStore(fieldHoistSym);
+                this->SetSymStoreDirect(dstValueInfo, fieldHoistSym);
             }
             // Update symStore if it isn't a stackSym
             if (dstVal && (!dstValueInfo->GetSymStore() || !dstValueInfo->GetSymStore()->IsStackSym()))
             {
                 Assert(dst->IsRegOpnd());
-                dstValueInfo->SetSymStore(dst->AsRegOpnd()->m_sym);
+                this->SetSymStoreDirect(dstValueInfo, dst->AsRegOpnd()->m_sym);
             }
             if (src1Val != dstVal)
             {
@@ -14318,7 +14361,7 @@ GlobOpt::ToTypeSpecUse(IR::Instr *instr, IR::Opnd *opnd, BasicBlock *block, Valu
                 if(!varSym || !IsFloat64TypeSpecialized(varSym, block))
                 {
                     // Clear the symstore to ensure it's set below to this new symbol
-                    val->GetValueInfo()->SetSymStore(nullptr);
+                    this->SetSymStoreDirect(val->GetValueInfo(), nullptr);
                     varSym = StackSym::New(TyVar, instr->m_func);
                     newFloatSym = true;
                 }
@@ -16253,7 +16296,7 @@ GlobOpt::OptArraySrc(IR::Instr * *const instrRef)
 
             // SetValue above would have set the sym store to newLengthSym. This sym won't be used for copy-prop though, so
             // remove it as the sym store.
-            lengthValue->GetValueInfo()->SetSymStore(nullptr);
+            this->SetSymStoreDirect(lengthValue->GetValueInfo(), nullptr);
 
             // length = [array + offsetOf(length)]
             IR::Instr *const loadLength =
@@ -16308,7 +16351,7 @@ GlobOpt::OptArraySrc(IR::Instr * *const instrRef)
                     Assert(!FindValue(block->globOptData.symToValueMap, newLengthSym));
                     Value *const lengthValueCopy = CopyValue(lengthValue, lengthValue->GetValueNumber());
                     SetValue(&block->globOptData, lengthValueCopy, newLengthSym);
-                    lengthValueCopy->GetValueInfo()->SetSymStore(nullptr);
+                    this->SetSymStoreDirect(lengthValueCopy->GetValueInfo(), nullptr);
                 }
             }
             else
@@ -16422,7 +16465,7 @@ GlobOpt::OptArraySrc(IR::Instr * *const instrRef)
 
             // SetValue above would have set the sym store to newHeadSegmentLengthSym. This sym won't be used for copy-prop
             // though, so remove it as the sym store.
-            headSegmentLengthValue->GetValueInfo()->SetSymStore(nullptr);
+            this->SetSymStoreDirect(headSegmentLengthValue->GetValueInfo(), nullptr);
 
             StackSym *const headSegmentSym =
                 isLikelyJsArray
@@ -16480,7 +16523,7 @@ GlobOpt::OptArraySrc(IR::Instr * *const instrRef)
                     Value *const headSegmentLengthValueCopy =
                         CopyValue(headSegmentLengthValue, headSegmentLengthValue->GetValueNumber());
                     SetValue(&block->globOptData, headSegmentLengthValueCopy, newHeadSegmentLengthSym);
-                    headSegmentLengthValueCopy->GetValueInfo()->SetSymStore(nullptr);
+                    this->SetSymStoreDirect(headSegmentLengthValueCopy->GetValueInfo(), nullptr);
                 }
             }
             else
@@ -18869,7 +18912,7 @@ GlobOpt::OptHoistInvariant(
                 // instance, if we're inside a conditioned block, because we don't make the copy sym live and set its value in
                 // all preceding blocks, this sym would not be live after exiting this block, causing this value to not
                 // participate in copy-prop after this block.
-                dstValueInfo->SetSymStore(copyVarSym);
+                this->SetSymStoreDirect(dstValueInfo, copyVarSym);
             }
 
             this->InsertNewValue(&block->globOptData, dstVal, copyReg);
@@ -18897,7 +18940,12 @@ GlobOpt::OptHoistInvariant(
         EnsureBailTarget(loop);
 
         // Copy bailout info of loop top.
-        instr->ReplaceBailOutInfo(loop->bailOutInfo);
+        if (instr->ReplaceBailOutInfo(loop->bailOutInfo))
+        {
+            // if the old bailout is deleted, reset capturedvalues cached in block
+            block->globOptData.capturedValues = nullptr;
+            block->globOptData.capturedValuesCandicate = nullptr;
+        }
     }
 
     if (instr->GetSrc1())
@@ -19335,7 +19383,7 @@ GlobOpt::HoistInvariantValueInfo(
     else
     {
         newValueInfo = invariantValueInfoToHoist->Copy(alloc);
-        newValueInfo->SetSymStore(symStore);
+        this->SetSymStoreDirect(newValueInfo, symStore);
     }
     ChangeValueInfo(targetBlock, valueToUpdate, newValueInfo);
 }

--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -1610,7 +1610,6 @@ GlobOpt::ReuseBlockData(GlobOptBlockData *toData, GlobOptBlockData *fromData)
 
     toData->stackLiteralInitFldDataMap = fromData->stackLiteralInitFldDataMap;
 
-    // toData->capturedValues = fromData->capturedValues;
     toData->capturedArgs = fromData->capturedArgs;
     toData->changedSyms = fromData->changedSyms;
     toData->capturedArgs->ClearAll();

--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -5081,7 +5081,7 @@ GlobOpt::OptInstr(IR::Instr *&instr, bool* isInstrRemoved)
         this->currentBlock->globOptData.capturedArgs->ClearAll();
         this->currentBlock->globOptData.changedSyms->ClearAll();
         this->currentBlock->globOptData.capturedValues = 
-            this->currentBlock->globOptData.capturedValuesCandicate;
+            this->currentBlock->globOptData.capturedValuesCandidate;
     }
 
     return instrNext;
@@ -18944,7 +18944,7 @@ GlobOpt::OptHoistInvariant(
         {
             // if the old bailout is deleted, reset capturedvalues cached in block
             block->globOptData.capturedValues = nullptr;
-            block->globOptData.capturedValuesCandicate = nullptr;
+            block->globOptData.capturedValuesCandidate = nullptr;
         }
     }
 

--- a/lib/Backend/GlobOpt.h
+++ b/lib/Backend/GlobOpt.h
@@ -1647,7 +1647,7 @@ private:
     static void             TrackByteCodeSymUsed(IR::RegOpnd * opnd, BVSparse<JitArenaAllocator> * instrByteCodeStackSymUsed);
     static void             TrackByteCodeSymUsed(StackSym * sym, BVSparse<JitArenaAllocator> * instrByteCodeStackSymUsed);
     void                    CaptureValues(BasicBlock *block, BailOutInfo * bailOutInfo);
-    void                    CaptureValue(BasicBlock *block, StackSym * stackSym, Value * value, BailOutInfo * bailOutInfo);
+    void                    CaptureCopyPropValue(BasicBlock * block, Sym * sym, Value * val, SListBase<CopyPropSyms>::EditingIterator & bailOutCopySymsIter);
     void                    CaptureArguments(BasicBlock *block, BailOutInfo * bailOutInfo, JitArenaAllocator *allocator);
     void                    CaptureByteCodeSymUses(IR::Instr * instr);
     IR::ByteCodeUsesInstr * InsertByteCodeUses(IR::Instr * instr, bool includeDef = false);

--- a/lib/Backend/GlobOpt.h
+++ b/lib/Backend/GlobOpt.h
@@ -957,6 +957,10 @@ public:
         argOutCount(0),
         totalOutParamCount(0),
         callSequence(nullptr),
+        capturedValuesCandicate(nullptr),
+        capturedValues(nullptr),
+        capturedArgs(nullptr),
+        changedSyms(nullptr),
         hasCSECandidates(false),
         curFunc(func),
         hasDataRef(nullptr),
@@ -1006,6 +1010,11 @@ public:
     uint                                    totalOutParamCount;
     SListBase<IR::Opnd *> *                 callSequence;
     StackLiteralInitFldDataMap *            stackLiteralInitFldDataMap;
+
+    CapturedValues *                        capturedValuesCandicate;
+    CapturedValues *                        capturedValues;
+    BVSparse<JitArenaAllocator> *           capturedArgs;
+    BVSparse<JitArenaAllocator> *           changedSyms;
 
     uint                                    inlinedArgOutCount;
 
@@ -1377,6 +1386,7 @@ private:
     StackSym *              GetTaggedIntConstantStackSym(const int32 intConstantValue) const;
     StackSym *              GetOrCreateTaggedIntConstantStackSym(const int32 intConstantValue) const;
     Sym *                   SetSymStore(ValueInfo *valueInfo, Sym *sym);
+    void                    SetSymStoreDirect(ValueInfo *valueInfo, Sym *sym);
     Value *                 InsertNewValue(Value *val, IR::Opnd *opnd);
     Value *                 InsertNewValue(GlobOptBlockData * blockData, Value *val, IR::Opnd *opnd);
     Value *                 SetValue(GlobOptBlockData * blockData, Value *val, IR::Opnd *opnd);

--- a/lib/Backend/GlobOpt.h
+++ b/lib/Backend/GlobOpt.h
@@ -957,7 +957,7 @@ public:
         argOutCount(0),
         totalOutParamCount(0),
         callSequence(nullptr),
-        capturedValuesCandicate(nullptr),
+        capturedValuesCandidate(nullptr),
         capturedValues(nullptr),
         capturedArgs(nullptr),
         changedSyms(nullptr),
@@ -1011,7 +1011,7 @@ public:
     SListBase<IR::Opnd *> *                 callSequence;
     StackLiteralInitFldDataMap *            stackLiteralInitFldDataMap;
 
-    CapturedValues *                        capturedValuesCandicate;
+    CapturedValues *                        capturedValuesCandidate;
     CapturedValues *                        capturedValues;
     BVSparse<JitArenaAllocator> *           capturedArgs;
     BVSparse<JitArenaAllocator> *           changedSyms;

--- a/lib/Backend/GlobOptBailOut.cpp
+++ b/lib/Backend/GlobOptBailOut.cpp
@@ -5,7 +5,7 @@
 #include "Backend.h"
 
 void
-GlobOpt::CaptureValue(BasicBlock *block, StackSym * stackSym, Value * value, BailOutInfo * bailOutInfo)
+GlobOpt::CaptureValues(BasicBlock *block, BailOutInfo * bailOutInfo)
 {
     if (!this->func->DoGlobOptsForGeneratorFunc())
     {
@@ -15,52 +15,258 @@ GlobOpt::CaptureValue(BasicBlock *block, StackSym * stackSym, Value * value, Bai
         return;
     }
 
-    ValueInfo * valueInfo = value->GetValueInfo();
-    Assert(stackSym->HasByteCodeRegSlot() || stackSym->HasArgSlotNum());
-    Assert(!stackSym->IsTypeSpec());
-    int32 intConstantValue;
-    if (valueInfo->TryGetIntConstantValue(&intConstantValue))
+    CapturedValues capturedValues;
+    SListBase<ConstantStackSymValue>::EditingIterator bailOutConstValuesIter(&capturedValues.constantValues);
+    SListBase<CopyPropSyms>::EditingIterator bailOutCopySymsIter(&capturedValues.copyPropSyms);
+
+    bailOutConstValuesIter.Next();
+    bailOutCopySymsIter.Next();
+
+    // tempBv has both changed syms with bytecode reg slot or arg slot
+    BVSparse<JitArenaAllocator> * tempBv = JitAnew(this->tempAlloc, BVSparse<JitArenaAllocator>, this->tempAlloc);
+
+    if (!block->globOptData.capturedValues)
     {
-        BailoutConstantValue constValue;
-        constValue.InitIntConstValue(intConstantValue);
-        bailOutInfo->capturedValues.constantValues.PrependNode(this->func->m_alloc, stackSym, constValue);
-    }
-    else if (valueInfo->IsVarConstant())
-    {
-        BailoutConstantValue constValue;
-        constValue.InitVarConstValue(valueInfo->AsVarConstant()->VarValue());
-        bailOutInfo->capturedValues.constantValues.PrependNode(this->func->m_alloc, stackSym, constValue);
+        // capture bailout values from scratch
+
+        Sym * sym = nullptr;
+        Value * value = nullptr;
+        ValueInfo * valueInfo = nullptr;
+
+        block->globOptData.changedSyms->ClearAll();
+
+        FOREACH_GLOBHASHTABLE_ENTRY(bucket, block->globOptData.symToValueMap)
+        {
+            value = bucket.element;
+            valueInfo = value->GetValueInfo();
+
+            if (valueInfo->GetSymStore() == nullptr && !valueInfo->HasIntConstantValue())
+            {
+                continue;
+            }
+
+            sym = bucket.value;
+            if (sym == nullptr || !sym->IsStackSym() || !(sym->AsStackSym()->HasByteCodeRegSlot()))
+            {
+                continue;
+            }
+            block->globOptData.changedSyms->Set(sym->m_id);
+        }
+        NEXT_GLOBHASHTABLE_ENTRY;
+
+        tempBv->Or(block->globOptData.changedSyms, block->globOptData.capturedArgs);
+
+        FOREACH_BITSET_IN_SPARSEBV(symId, tempBv)
+        {
+            HashBucket<Sym*, Value*> * bucket = block->globOptData.symToValueMap->GetBucket(symId);
+            StackSym * stackSym = bucket->value->AsStackSym();
+            value = block->globOptData.capturedArgs->Test(symId) ? FindValue(stackSym) : bucket->element;
+            valueInfo = value->GetValueInfo();
+
+            int intConstantValue;
+            if (valueInfo->TryGetIntConstantValue(&intConstantValue))
+            {
+                BailoutConstantValue constValue;
+                constValue.InitIntConstValue(intConstantValue);
+                bailOutConstValuesIter.InsertNodeBefore(this->func->m_alloc, stackSym, constValue);
+            }
+            else if (valueInfo->IsVarConstant())
+            {
+                BailoutConstantValue constValue;
+                constValue.InitVarConstValue(valueInfo->AsVarConstant()->VarValue());
+                bailOutConstValuesIter.InsertNodeBefore(this->func->m_alloc, stackSym, constValue);
+            }
+            else
+            {
+                StackSym* copyPropSym = this->GetCopyPropSym(block, stackSym, value);
+                if (copyPropSym)
+                {
+                    bailOutCopySymsIter.InsertNodeBefore(this->func->m_alloc, stackSym, copyPropSym);
+                }
+            }
+        }
+        NEXT_BITSET_IN_SPARSEBV
     }
     else
     {
-        StackSym * copyPropSym = this->GetCopyPropSym(block, stackSym, value);
-        if (copyPropSym)
-        {
-            bailOutInfo->capturedValues.copyPropSyms.PrependNode(this->func->m_alloc, stackSym, copyPropSym);
-        }
-    }
-}
+        // capture bailout values incrementally
 
-void
-GlobOpt::CaptureValues(BasicBlock *block, BailOutInfo * bailOutInfo)
-{
-    FOREACH_GLOBHASHTABLE_ENTRY(bucket, block->globOptData.symToValueMap)
-    {
-        Value* value = bucket.element;
-        ValueInfo * valueInfo = value->GetValueInfo();
+        CapturedValues * currCapturedValues = block->globOptData.capturedValues;
+        SListBase<ConstantStackSymValue>::Iterator iterConst(currCapturedValues ? &currCapturedValues->constantValues : nullptr);
+        SListBase<CopyPropSyms>::Iterator iterCopyPropSym(currCapturedValues ? &currCapturedValues->copyPropSyms : nullptr);
+        bool hasConstValue = currCapturedValues ? iterConst.Next() : false;
+        bool hasCopyPropSym = currCapturedValues ? iterCopyPropSym.Next() : false;
 
-        if (valueInfo->GetSymStore() == nullptr && !valueInfo->HasIntConstantValue())
+        tempBv->Or(block->globOptData.changedSyms, block->globOptData.capturedArgs);
+
+        tempBv->Set(Js::Constants::InvalidSymID);
+
+        FOREACH_BITSET_IN_SPARSEBV(symId, tempBv)
         {
-            continue;
+            Sym * sym = hasConstValue ? iterConst.Data().Key() : nullptr;
+            Value * val = nullptr;
+            HashBucket<Sym *, Value *> * symIdBucket = nullptr;
+            bool symIdHandled = false;
+
+            // copy unchanged sym to new capturedValues
+            while (sym && sym->m_id < symId)
+            {
+                Assert(sym->IsStackSym());
+                if (!sym->AsStackSym()->HasArgSlotNum() || block->globOptData.capturedArgs->Test(sym->m_id))
+                {
+                    bailOutConstValuesIter.InsertNodeBefore(this->func->m_alloc, sym->AsStackSym(), iterConst.Data().Value());
+                }
+
+                hasConstValue = iterConst.Next();
+                sym = hasConstValue ? iterConst.Data().Key() : nullptr;
+            }
+            if (sym && sym->m_id == symId)
+            {
+                hasConstValue = iterConst.Next();
+            }
+            if (symId != Js::Constants::InvalidSymID)
+            {
+                // recapture changed constant sym
+
+                symIdBucket = block->globOptData.symToValueMap->GetBucket(symId);
+                if (symIdBucket == nullptr)
+                {
+                    continue;
+                }
+
+                sym = symIdBucket->value;
+                Assert(sym->IsStackSym() && (sym->AsStackSym()->HasByteCodeRegSlot() || sym->AsStackSym()->HasArgSlotNum()));
+
+                val =  block->globOptData.capturedArgs->Test(symId) ? FindValue(sym) : symIdBucket->element;
+                ValueInfo* valueInfo = val->GetValueInfo();
+
+                if (valueInfo->GetSymStore() != nullptr)
+                {
+                    int32 intConstValue;
+                    BailoutConstantValue constValue;
+
+                    if (valueInfo->TryGetIntConstantValue(&intConstValue))
+                    {
+                        constValue.InitIntConstValue(intConstValue);
+                        bailOutConstValuesIter.InsertNodeBefore(this->func->m_alloc, sym->AsStackSym(), constValue);
+                        symIdHandled = true;
+                    }
+                    else if(valueInfo->IsVarConstant())
+                    {
+                        constValue.InitVarConstValue(valueInfo->AsVarConstant()->VarValue());
+                        bailOutConstValuesIter.InsertNodeBefore(this->func->m_alloc, sym->AsStackSym(), constValue);
+                        symIdHandled = true;
+                    }
+                }
+                else if (!valueInfo->HasIntConstantValue())
+                {
+                    continue;
+                }
+            }
+
+            if (symIdHandled)
+            {
+                continue;
+            }
+
+            sym = hasCopyPropSym ? iterCopyPropSym.Data().Key() : nullptr;
+
+            while (true)
+            {
+                StackSym * copyPropSym = (sym != nullptr) ? iterCopyPropSym.Data().Value() : nullptr;
+                Sym * mergeSym = nullptr;
+                bool mergeSymId = false;
+
+                // copy unchanged copy prop sym
+                if (sym && !tempBv->Test(copyPropSym->m_id) && sym->m_id < symId)
+                {
+                    Assert(sym->IsStackSym());
+
+                    if (!sym->AsStackSym()->HasArgSlotNum() || block->globOptData.capturedArgs->Test(sym->m_id))
+                    {
+                        bailOutCopySymsIter.InsertNodeBefore(this->func->m_alloc, sym->AsStackSym(), copyPropSym);
+                    }
+                }
+                else if (!sym && symId == Js::Constants::InvalidSymID)
+                {
+                    break;
+                }
+                else
+                {
+                    // recapture changed copy prop sym
+
+                    if (!sym || sym->m_id > symId)
+                    {
+                        if (!symIdBucket)
+                        {
+                            symIdBucket = block->globOptData.symToValueMap->GetBucket(symId);
+                            if (symIdBucket == nullptr)
+                            {
+                                break;
+                            }
+                        }
+                        mergeSym = symIdBucket->value;
+                        mergeSymId = true;
+                    }
+                    else
+                    {
+                        if (sym->m_id == symId)
+                        {
+                            mergeSymId = true;
+                        }
+                        mergeSym = sym;
+                    }
+
+                    Assert(mergeSym && mergeSym->IsStackSym());
+
+                    symIdBucket = block->globOptData.symToValueMap->GetBucket(mergeSym->m_id);
+
+                    if (symIdBucket)
+                    {
+                        val = block->globOptData.capturedArgs->Test(mergeSym->m_id) ? FindValue(mergeSym) : symIdBucket->element;
+                        ValueInfo* valueInfo = val->GetValueInfo();
+                        Assert(valueInfo->GetSymStore() != nullptr || valueInfo->HasIntConstantValue());
+
+                        copyPropSym = this->GetCopyPropSym(block, mergeSym, val);
+                        if (copyPropSym)
+                        {
+                            bailOutCopySymsIter.InsertNodeBefore(this->func->m_alloc, mergeSym->AsStackSym(), copyPropSym);
+                        }
+                    }
+                }
+
+                if (hasCopyPropSym && sym->m_id <= symId)
+                {
+                    hasCopyPropSym = iterCopyPropSym.Next();
+                    sym = hasCopyPropSym ? iterCopyPropSym.Data().Key() : nullptr;
+                }
+
+                if (mergeSymId)
+                {
+                    break;
+                }
+            }
         }
-        Sym * sym = bucket.value;
-        if (sym == nullptr || !sym->IsStackSym() || !sym->AsStackSym()->HasByteCodeRegSlot())
-        {
-            continue;
-        }
-        this->CaptureValue(block, sym->AsStackSym(), value, bailOutInfo);
+        NEXT_BITSET_IN_SPARSEBV
     }
-    NEXT_GLOBHASHTABLE_ENTRY;
+
+    JitAdelete(this->tempAlloc, tempBv);
+    block->globOptData.capturedArgs->ClearAll();
+
+    // attach capturedValues to bailOutInfo
+
+    bailOutInfo->capturedValues.constantValues.Clear(this->func->m_alloc);
+    bailOutConstValuesIter.SetNext(&bailOutInfo->capturedValues.constantValues);
+    bailOutInfo->capturedValues.constantValues = capturedValues.constantValues;
+    capturedValues.constantValues.Reset();
+
+    bailOutInfo->capturedValues.copyPropSyms.Clear(this->func->m_alloc);
+    bailOutCopySymsIter.SetNext(&bailOutInfo->capturedValues.copyPropSyms);
+    bailOutInfo->capturedValues.copyPropSyms = capturedValues.copyPropSyms;
+    capturedValues.copyPropSyms.Reset();
+
+    // cache the pointer of current bailout as potential baseline for later bailout in this block
+    block->globOptData.capturedValuesCandicate = &bailOutInfo->capturedValues;
 }
 
 void
@@ -722,10 +928,6 @@ GlobOpt::FillBailOutInfo(BasicBlock *block, BailOutInfo * bailOutInfo)
         }
     }
 
-    // Save the constant values that we know so we can restore them directly.
-    // This allows us to dead store the constant value assign.
-    this->CaptureValues(block, bailOutInfo);
-
     if (TrackArgumentsObject())
     {
         this->CaptureArguments(block, bailOutInfo, this->func->m_alloc);
@@ -769,9 +971,8 @@ GlobOpt::FillBailOutInfo(BasicBlock *block, BailOutInfo * bailOutInfo)
                 else
                 {
                     sym = opnd->GetStackSym();
-                    Value* val = FindValue(sym);
-                    Assert(val);
-                    CaptureValue(block, sym, val, bailOutInfo);
+                    Assert(FindValue(sym));
+                    this->blockData.capturedArgs->Set(sym->m_id);
                 }
 
                 Assert(totalOutParamCount != 0);
@@ -836,6 +1037,10 @@ GlobOpt::FillBailOutInfo(BasicBlock *block, BailOutInfo * bailOutInfo)
         Assert(startCallNumber == 0);
         Assert(currentArgOutCount == 0);
     }
+
+    // Save the constant values that we know so we can restore them directly.
+    // This allows us to dead store the constant value assign.
+    this->CaptureValues(block, bailOutInfo);
 }
 
 IR::ByteCodeUsesInstr *

--- a/lib/Backend/GlobOptBailOut.cpp
+++ b/lib/Backend/GlobOptBailOut.cpp
@@ -106,13 +106,12 @@ GlobOpt::CaptureValues(BasicBlock *block, BailOutInfo * bailOutInfo)
             Sym * sym = hasConstValue ? iterConst.Data().Key() : nullptr;
             Value * val = nullptr;
             HashBucket<Sym *, Value *> * symIdBucket = nullptr;
-            bool symIdHandled = false;
 
             // copy unchanged sym to new capturedValues
             while (sym && sym->m_id < symId)
             {
                 Assert(sym->IsStackSym());
-                if (!sym->AsStackSym()->HasArgSlotNum() || block->globOptData.capturedArgs->Test(sym->m_id))
+                if (!sym->AsStackSym()->HasArgSlotNum())
                 {
                     bailOutConstValuesIter.InsertNodeBefore(this->func->m_alloc, sym->AsStackSym(), iterConst.Data().Value());
                 }
@@ -149,24 +148,21 @@ GlobOpt::CaptureValues(BasicBlock *block, BailOutInfo * bailOutInfo)
                     {
                         constValue.InitIntConstValue(intConstValue);
                         bailOutConstValuesIter.InsertNodeBefore(this->func->m_alloc, sym->AsStackSym(), constValue);
-                        symIdHandled = true;
+
+                        continue;
                     }
                     else if(valueInfo->IsVarConstant())
                     {
                         constValue.InitVarConstValue(valueInfo->AsVarConstant()->VarValue());
                         bailOutConstValuesIter.InsertNodeBefore(this->func->m_alloc, sym->AsStackSym(), constValue);
-                        symIdHandled = true;
+
+                        continue;
                     }
                 }
                 else if (!valueInfo->HasIntConstantValue())
                 {
                     continue;
                 }
-            }
-
-            if (symIdHandled)
-            {
-                continue;
             }
 
             sym = hasCopyPropSym ? iterCopyPropSym.Data().Key() : nullptr;
@@ -178,11 +174,11 @@ GlobOpt::CaptureValues(BasicBlock *block, BailOutInfo * bailOutInfo)
                 bool mergeSymId = false;
 
                 // copy unchanged copy prop sym
-                if (sym && !tempBv->Test(copyPropSym->m_id) && sym->m_id < symId)
+                if (sym && sym->m_id < symId && !tempBv->Test(copyPropSym->m_id))
                 {
                     Assert(sym->IsStackSym());
 
-                    if (!sym->AsStackSym()->HasArgSlotNum() || block->globOptData.capturedArgs->Test(sym->m_id))
+                    if (!sym->AsStackSym()->HasArgSlotNum())
                     {
                         bailOutCopySymsIter.InsertNodeBefore(this->func->m_alloc, sym->AsStackSym(), copyPropSym);
                     }

--- a/lib/Backend/GlobOptBailOut.cpp
+++ b/lib/Backend/GlobOptBailOut.cpp
@@ -266,7 +266,7 @@ GlobOpt::CaptureValues(BasicBlock *block, BailOutInfo * bailOutInfo)
     capturedValues.copyPropSyms.Reset();
 
     // cache the pointer of current bailout as potential baseline for later bailout in this block
-    block->globOptData.capturedValuesCandicate = &bailOutInfo->capturedValues;
+    block->globOptData.capturedValuesCandidate = &bailOutInfo->capturedValues;
 }
 
 void

--- a/lib/Backend/GlobOptFields.cpp
+++ b/lib/Backend/GlobOptFields.cpp
@@ -689,6 +689,7 @@ GlobOpt::PreparePrepassFieldHoisting(Loop * loop)
 
                 // Set object type live on prepass so we can track if it got killed in the loop. (see FinishOptHoistedPropOps)
                 JsTypeValueInfo* typeValueInfo = JsTypeValueInfo::New(this->alloc, nullptr, nullptr);
+                typeValueInfo->SetIsShared();
                 this->SetSymStoreDirect(typeValueInfo, typeSym);
 
                 ValueNumber typeValueNumber = this->NewValueNumber();

--- a/lib/Backend/GlobOptFields.cpp
+++ b/lib/Backend/GlobOptFields.cpp
@@ -2932,7 +2932,6 @@ GlobOpt::SetObjectTypeFromTypeSym(StackSym *typeSym, const Js::Type *type, Js::E
     else
     {
         JsTypeValueInfo* valueInfo = JsTypeValueInfo::New(this->alloc, type, typeSet);
-        valueInfo->SetSymStore(typeSym);
         this->SetSymStoreDirect(valueInfo, typeSym);
         Value* value = NewValue(valueInfo);
         SetValue(blockData, value, typeSym);

--- a/lib/Backend/GlobOptFields.cpp
+++ b/lib/Backend/GlobOptFields.cpp
@@ -689,8 +689,7 @@ GlobOpt::PreparePrepassFieldHoisting(Loop * loop)
 
                 // Set object type live on prepass so we can track if it got killed in the loop. (see FinishOptHoistedPropOps)
                 JsTypeValueInfo* typeValueInfo = JsTypeValueInfo::New(this->alloc, nullptr, nullptr);
-                typeValueInfo->SetSymStore(typeSym);
-                typeValueInfo->SetIsShared();
+                this->SetSymStoreDirect(typeValueInfo, typeSym);
 
                 ValueNumber typeValueNumber = this->NewValueNumber();
                 Value* landingPadTypeValue = NewValue(typeValueNumber, typeValueInfo);
@@ -1198,7 +1197,7 @@ GlobOpt::HoistFieldLoadValue(Loop * loop, Value * newValue, SymID symId, Js::OpC
     else
     {
         this->SetValue(&this->blockData, newValue, newStackSym);
-        newValue->GetValueInfo()->SetSymStore(newStackSym);
+        this->SetSymStoreDirect(newValue->GetValueInfo(), newStackSym);
     }
 
 
@@ -1853,7 +1852,7 @@ GlobOpt::CopyStoreFieldHoistStackSym(IR::Instr * storeFldInstr, PropertySym * sy
 
     Value * dstVal = this->CopyValue(src1Val);
     TrackCopiedValueForKills(dstVal);
-    dstVal->GetValueInfo()->SetSymStore(copySym);
+    this->SetSymStoreDirect(dstVal->GetValueInfo(), copySym);
     this->SetValue(&this->blockData, dstVal, copySym);
 
     // Copy the type specialized sym as well, in case we have a use for them
@@ -2934,6 +2933,7 @@ GlobOpt::SetObjectTypeFromTypeSym(StackSym *typeSym, const Js::Type *type, Js::E
     {
         JsTypeValueInfo* valueInfo = JsTypeValueInfo::New(this->alloc, type, typeSet);
         valueInfo->SetSymStore(typeSym);
+        this->SetSymStoreDirect(valueInfo, typeSym);
         Value* value = NewValue(valueInfo);
         SetValue(blockData, value, typeSym);
     }

--- a/lib/Backend/IR.cpp
+++ b/lib/Backend/IR.cpp
@@ -1045,10 +1045,11 @@ Instr::UnlinkBailOutInfo()
     return bailOutInfo;
 }
 
-void
+bool
 Instr::ReplaceBailOutInfo(BailOutInfo *newBailOutInfo)
 {
     BailOutInfo *oldBailOutInfo;
+    bool deleteOld = false;
 
 #if DBG
     newBailOutInfo->wasCopied = true;
@@ -1080,7 +1081,10 @@ Instr::ReplaceBailOutInfo(BailOutInfo *newBailOutInfo)
         JitArenaAllocator * alloc = this->m_func->m_alloc;
         oldBailOutInfo->Clear(alloc);
         JitAdelete(alloc, oldBailOutInfo);
+        deleteOld = true;
     }
+
+    return deleteOld;
 }
 
 IR::Instr *Instr::ShareBailOut()

--- a/lib/Backend/IR.h
+++ b/lib/Backend/IR.h
@@ -298,7 +298,7 @@ public:
 
     BailOutInfo *   GetBailOutInfo() const;
     BailOutInfo *   UnlinkBailOutInfo();
-    void            ReplaceBailOutInfo(BailOutInfo *newBailOutInfo);
+    bool            ReplaceBailOutInfo(BailOutInfo *newBailOutInfo);
     IR::Instr *     ShareBailOut();
     BailOutKind     GetBailOutKind() const;
     BailOutKind     GetBailOutKindNoBits() const;

--- a/lib/Common/DataStructures/SList.h
+++ b/lib/Common/DataStructures/SList.h
@@ -201,6 +201,22 @@ public:
             return nullptr;
         }
 
+        template <typename TAllocator, typename TParam1, typename TParam2>
+        TData * InsertNodeBefore(TAllocator * allocator, TParam1 param1, TParam2 param2)
+        {
+            Assert(last != nullptr);
+            Node * newNode = AllocatorNew(TAllocator, allocator, Node, param1, param2);
+            if (newNode)
+            {
+                newNode->Next() = last->Next();
+                const_cast<NodeBase *>(last)->Next() = newNode;
+                const_cast<SListBase *>(this->list)->IncrementCount();
+                last = newNode;
+                return &newNode->data;
+            }
+            return nullptr;
+        }
+
         template <typename TAllocator>
         bool InsertBefore(TAllocator * allocator, TData const& data)
         {
@@ -223,6 +239,12 @@ public:
             node->Next() = toList->Next();
             toList->Next() = node;
             toList->IncrementCount();
+        }
+
+        void SetNext(SListBase * newNext)
+        {
+            Assert(last != nullptr);
+            const_cast<NodeBase *>(last)->Next() = newNext;
         }
 
     private:


### PR DESCRIPTION
Capture constant and copy prop symbols for bailout takes lots of time in regexp benchmark from Octane one some low end machine, this change caches the first capture values for bailout, and reuse it when capturing value in the following bailout in the same block.

The new bailout is constructed according to the previous bailout and changed symbol value map since then.