### PR TITLE
Bug 7877542: Simplify EntryNormalize for IsNormalizedString case to avoid LiteralString not allowed assert.

### DIFF
--- a/lib/Runtime/Library/JavascriptString.cpp
+++ b/lib/Runtime/Library/JavascriptString.cpp
@@ -1444,9 +1444,8 @@ case_2:
 
         if (UnicodeText::IsNormalizedString(form, pThis->GetSz(), pThis->GetLength()))
         {
-            return JavascriptString::NewWithSz(pThis->GetSz(), scriptContext);
+            return pThis;
         }
-
 
         BEGIN_TEMP_ALLOCATOR(tempAllocator, scriptContext, _u("normalize"));
 

--- a/test/es6/normalizeProp.baseline
+++ b/test/es6/normalizeProp.baseline
@@ -1,0 +1,3 @@
+blah
+hello
+PASS

--- a/test/es6/normalizeProp.js
+++ b/test/es6/normalizeProp.js
@@ -1,0 +1,17 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+var o = { blah: "abc" }
+Object.defineProperty(o, 'hello', {
+    get: function() { return 42; },
+    set: function() { },
+    enumerable: true
+})
+
+for (var p in o) {
+    print(p.normalize())
+}
+
+print("PASS")

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -497,6 +497,12 @@
   </test>
   <test>
     <default>
+      <files>normalizeProp.js</files>
+      <baseline>normalizeProp.baseline</baseline>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>unicode_escape_sequences.js</files>
       <baseline>unicode_escape_sequences.baseline</baseline>
       <compile-flags> -ES6Unicode -ES6RegExSticky</compile-flags>


### PR DESCRIPTION
pThis is a propertyString. We can't use the buffer to create the same string if the propertyString's buffer is from a PropertyRecord, which would result in am interior pointer.

Since we are just returning the same string in this case, we should just return pThis.

Fixes Bug [7877542](https://microsoft.visualstudio.com/defaultcollection/web/wi.aspx?pcguid=cb55739e-4afe-46a3-970f-1b49d8ee7564&id=7877542)
