### PR TITLE
Added console.log to ch.exe as a convenient alias for WScript.Echo

### DIFF
--- a/test/Debugger/JsDiagGetStackProperties.js.dbg.baseline
+++ b/test/Debugger/JsDiagGetStackProperties.js.dbg.baseline
@@ -3,6 +3,7 @@
     "this": "Object {...}",
     "{exception}": "number 1",
     "locals": {
+      "console": "Object {...}",
       "FuncLevel1": "function <large string>",
       "outerFunc1": "function <large string>",
       "globalVar": "undefined undefined"
@@ -12,6 +13,7 @@
     "this": "Object {...}",
     "{exception}": "Error Caught Error",
     "locals": {
+      "console": "Object {...}",
       "FuncLevel1": "function <large string>",
       "outerFunc1": "function <large string>",
       "globalVar": "undefined undefined"
@@ -20,6 +22,7 @@
   {
     "this": {
       "telemetryLog": "function <large string>",
+      "console": "Object {...}",
       "FuncLevel1": "function <large string>",
       "outerFunc1": "function <large string>",
       "globalVar": "Object {...}"
@@ -46,6 +49,7 @@
     "globals": {
       "WScript": "Object {...}",
       "print": "function print",
+      "console": "Object {...}",
       "FuncLevel1": "function <large string>",
       "outerFunc1": "function <large string>",
       "globalVar": "Object {...}"
@@ -54,6 +58,7 @@
   {
     "this": {
       "telemetryLog": "function <large string>",
+      "console": "Object {...}",
       "FuncLevel1": "function <large string>",
       "outerFunc1": "function <large string>",
       "globalVar": "Object {...}"
@@ -101,6 +106,7 @@
     "globals": {
       "WScript": "Object {...}",
       "print": "function print",
+      "console": "Object {...}",
       "FuncLevel1": "function <large string>",
       "outerFunc1": "function <large string>",
       "globalVar": "Object {...}"

--- a/test/Debugger/MultipleContextStack.js.dbg.baseline
+++ b/test/Debugger/MultipleContextStack.js.dbg.baseline
@@ -66,6 +66,7 @@
   {
     "this": {
       "telemetryLog": "function <large string>",
+      "console": "Object {...}",
       "Func2": "function <large string>",
       "Func3": "function <large string>",
       "Func1": "function <large string>",
@@ -84,6 +85,7 @@
     "globals": {
       "WScript": "Object {...}",
       "print": "function print",
+      "console": "Object {...}",
       "Func2": "function <large string>",
       "Func3": "function <large string>",
       "Func1": "function <large string>",

--- a/test/LetConst/p.baseline
+++ b/test/LetConst/p.baseline
@@ -1,8 +1,10 @@
 WScript
 print
+console
 10
 20
 10
 WScript
 print
+console
 a

--- a/test/LetConst/q.baseline
+++ b/test/LetConst/q.baseline
@@ -3,6 +3,7 @@ undefined
 undefined
 WScript
 print
+console
 f
 a
 

--- a/test/typedarray/samethread.js
+++ b/test/typedarray/samethread.js
@@ -3,39 +3,34 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 
-var fileNames= ["dataview.js", "int8array.js", "uint8array.js", "int16array.js", "uint16array.js",
-    "int32array.js", "uint32array.js", "float32array.js", "float64array.js"];
+var fileNames = ["dataview.js", "int8array.js", "uint8array.js", "int16array.js", "uint16array.js",
+  "int32array.js", "uint32array.js", "float32array.js", "float64array.js"];
 
-for (var i = 0; i < fileNames.length; i++)
-{
-   WScript.Echo("testing file " + fileNames[i]);
-   oneFile(fileNames[i]);
+for (var i = 0; i < fileNames.length; i++) {
+  WScript.Echo("testing file " + fileNames[i]);
+  oneFile(fileNames[i]);
 }
 
-function oneFile(fileName)
-{
+function oneFile(fileName) {
   var frame = WScript.LoadScriptFile(fileName, "samethread");
   WScript.Echo("Start same thread different engine test on file " + fileName);
-  for (var i in frame)
-  {
-      if (i == 'WScript' || i == 'SCA' || i == 'ImageData')
-          continue;
+  for (var i in frame) {
+    if (i == 'WScript' || i == 'SCA' || i == 'ImageData' || i == 'console') {
+      continue;
+    }
 
-      WScript.Echo("property of global: " + i);
-      if (typeof frame[i] == "object")
-      {
-         for (var j in frame[i])
-           WScript.Echo("sub object " + j + " in " + i + " is " + frame[i][j]);
+    WScript.Echo("property of global: " + i);
+    if (typeof frame[i] == "object") {
+      for (var j in frame[i]) {
+        WScript.Echo("sub object " + j + " in " + i + " is " + frame[i][j]);
       }
-    try 
-    {
-      if (typeof frame[i] == "function")
-      {
+    }
+    try {
+      if (typeof frame[i] == "function") {
         frame[i]();
       }
     }
-    catch (e)
-    {
+    catch (e) {
       WScript.Echo("exception is " + e.number + e.description);
     }
   }


### PR DESCRIPTION
This enables us to easily run examples written for the web browser that rely on console.log because they will now work in ch.exe without modification.

---

Short of merging this PR, here is a shim to work around this issue:

```js
if (typeof(console) === "undefined" &&
    typeof(WScript) != "undefined" &&
    typeof(WScript.Echo) != "undefined") {
    var console = {
        log: WScript.Echo
    }
}
```

If you include that in a test case (and you assume that you will never have a `console` object that doesn't have the `log` method defined, and you only use the `WScript.Echo` and `console.log` methods in mutually compatible ways) you can reuse the entire text of the test between browser hosts and the `ch.exe` host.