### PR TITLE
Enabling eval in default param initializers

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -5054,9 +5054,27 @@ bool Parser::ParseFncDeclHelper(ParseNodePtr pnodeFnc, ParseNodePtr pnodeFncPare
             {
                 OUTPUT_TRACE_DEBUGONLY(Js::ParsePhase, _u("The param and body scope of the function %s cannot be merged\n"), pnodeFnc->sxFnc.pnodeName ? pnodeFnc->sxFnc.pnodeName->sxVar.pid->Psz() : _u("Anonymous function"));
                 // Add a new symbol reference for each formal in the param scope to the body scope.
-                paramScope->ForEachSymbol([this](Symbol* param) {
+                // While inserting symbols into the symbol list we always insert at the front, so while traversing the list we will be visiting the last added
+                // formals first. Normal insertion of those into the body will reverse the order of symbols, which will eventually result in different order
+                // for scope slots allocation for the corresponding symbol in both param and body scope. Inserting them in the opposite order will help us
+                // have the same sequence for scope slots allocation in both scopes. This makes it easy to read the bytecode and may help in some optimization
+                // later.
+                paramScope->ForEachSymbol([this, pnodeFnc](Symbol* param) {
                     OUTPUT_TRACE_DEBUGONLY(Js::ParsePhase, _u("Creating a duplicate symbol for the parameter %s in the body scope\n"), param->GetPid()->Psz());
-                    ParseNodePtr paramNode = this->CreateVarDeclNode(param->GetPid(), STVariable, false, nullptr, false);
+
+                    ParseNodePtr paramNode = nullptr;
+                    if (this->m_ppnodeVar != &pnodeFnc->sxFnc.pnodeVars)
+                    {
+                        ParseNodePtr *const ppnodeVarSave = m_ppnodeVar;
+                        m_ppnodeVar = &pnodeFnc->sxFnc.pnodeVars;
+                        paramNode = this->CreateVarDeclNode(param->GetPid(), STVariable, false, nullptr, false);
+                        m_ppnodeVar = ppnodeVarSave;
+                    }
+                    else
+                    {
+                        paramNode = this->CreateVarDeclNode(param->GetPid(), STVariable, false, nullptr, false);
+                    }
+
                     Assert(paramNode && paramNode->sxVar.sym->GetScope()->GetScopeType() == ScopeType_FunctionBody);
                     paramNode->sxVar.sym->SetHasInit(true);
                 });
@@ -6156,10 +6174,17 @@ void Parser::ParseFncFormals(ParseNodePtr pnodeFnc, ushort flags)
             Error(ERRnoRparen);
         }
 
-        if ((this->GetCurrentFunctionNode()->sxFnc.CallsEval() || this->GetCurrentFunctionNode()->sxFnc.ChildCallsEval())
-            && !m_scriptContext->GetConfig()->IsES6DefaultArgsSplitScopeEnabled())
+        if (this->GetCurrentFunctionNode()->sxFnc.CallsEval() || this->GetCurrentFunctionNode()->sxFnc.ChildCallsEval())
         {
-            Error(ERREvalNotSupportedInParamScope);
+            if (!m_scriptContext->GetConfig()->IsES6DefaultArgsSplitScopeEnabled())
+            {
+                Error(ERREvalNotSupportedInParamScope);
+            }
+            else
+            {
+                Assert(pnodeFnc->sxFnc.HasNonSimpleParameterList());
+                pnodeFnc->sxFnc.pnodeScopes->sxBlock.scope->SetCannotMergeWithBodyScope();
+            }
         }
     }
     Assert(m_token.tk == tkRParen);

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -2942,6 +2942,11 @@ void VisitNestedScopes(ParseNode* pnodeScopeList, ParseNode* pnodeParent, ByteCo
 
     for (pnodeScope = pnodeScopeList; pnodeScope;)
     {
+        if (breakOnBodyScope && pnodeScope == pnodeParent->sxFnc.pnodeBodyScope)
+        {
+            break;
+        }
+
         switch (pnodeScope->nop)
         {
         case knopFncDecl:
@@ -3161,11 +3166,6 @@ void VisitNestedScopes(ParseNode* pnodeScopeList, ParseNode* pnodeParent, ByteCo
         default:
             AssertMsg(false, "Unexpected opcode in tree of scopes");
             return;
-        }
-
-        if (breakOnBodyScope && pnodeScope == pnodeParent->sxFnc.pnodeBodyScope)
-        {
-            break;
         }
     }
 }


### PR DESCRIPTION
This change list is to enable eval in default params. The change will be
still under the experimental flag, not enabled by default. When eval
occurs in the param scope the cannot merge flag is set for the param
scope thus avoiding merging of param and body scope.
