### PR TITLE
cross-platform: Fix some missing and duplicate symbols on OSX

### DIFF
--- a/bin/ChakraCore/CMakeLists.txt
+++ b/bin/ChakraCore/CMakeLists.txt
@@ -103,6 +103,7 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
       stdc++
       dl
       icucore
+      -Wl,-all_load
     #   -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/libChakraCoreLib.version
     )
     #

--- a/pal/src/CMakeLists.txt
+++ b/pal/src/CMakeLists.txt
@@ -159,14 +159,14 @@ set(SOURCES
   thread/tls.cpp
 )
 
-add_library(Chakra.Pal
-  STATIC
-  ${SOURCES}
-  ${PLATFORM_SOURCES}
-  ${ARCH_SOURCES}
-)
-
 if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  add_library(Chakra.Pal
+    SHARED
+    ${SOURCES}
+    ${PLATFORM_SOURCES}
+    ${ARCH_SOURCES}
+  )
+
   target_link_libraries(Chakra.Pal
     pthread
     dl
@@ -176,6 +176,13 @@ if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
 endif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
 
 if(CMAKE_SYSTEM_NAME STREQUAL Linux)
+  add_library(Chakra.Pal
+    STATIC
+    ${SOURCES}
+    ${PLATFORM_SOURCES}
+    ${ARCH_SOURCES}
+  )
+
   if(PAL_CMAKE_PLATFORM_ARCH_AMD64)
     target_link_libraries(Chakra.Pal
       unwind-x86_64


### PR DESCRIPTION
The `Chakra.Pal` library was being linked into both `ch` and `libChakraCore`, and `libChakraCore` wasn't exporting any of the `JSRT` symbols.

There are still runtime issues though, the one I'm looking at right now is `RecyclerWriteBarrierManager` is being initialised before `AutoSystemInfo`.