### PR TITLE
xplat: implement custom entropy for GNU/Linux

### DIFF
--- a/lib/Common/CommonDefines.h
+++ b/lib/Common/CommonDefines.h
@@ -124,9 +124,9 @@
 // xplat-todo: change DISABLE_SEH to ENABLE_SEH and move here
 #define ENABLE_SIMDJS
 #endif
+#endif
 
 #define ENABLE_CUSTOM_ENTROPY
-#endif
 
 // GC features
 

--- a/lib/Runtime/Base/CMakeLists.txt
+++ b/lib/Runtime/Base/CMakeLists.txt
@@ -5,7 +5,7 @@ add_library (Chakra.Runtime.Base STATIC
     CrossSite.cpp
     Debug.cpp
     # DelayLoadLibrary.cpp
-    # Entropy.cpp
+    Entropy.cpp
     EtwTrace.cpp
     Exception.cpp
     ExpirableObject.cpp


### PR DESCRIPTION
We'll just use /dev/random since it's not really possible to implement
GetProcessIoCounters in a good way.