### PR TITLE
cross-platform: Fix global initialisation ordering issues on OSX

### DIFF
--- a/bin/ch/ch.cpp
+++ b/bin/ch/ch.cpp
@@ -561,8 +561,6 @@ int _cdecl wmain(int argc, __in_ecount(argc) LPWSTR argv[])
 #ifndef _WIN32
 int main(int argc, char** argv)
 {
-    PAL_InitializeChakraCore(argc, argv);
-
     // Ignoring mem-alloc failures here as this is
     // simply a test tool. We can add more error checking
     // here later if desired.

--- a/lib/Common/Core/SysInfo.cpp
+++ b/lib/Common/Core/SysInfo.cpp
@@ -29,6 +29,7 @@
 EXTERN_C IMAGE_DOS_HEADER __ImageBase;
 #endif
 
+#ifdef CHAKRA_STATIC_LIBRARY
 static int AutoSystemInfoInitializer_counter;
 static typename std::aligned_storage<sizeof(AutoSystemInfo), alignof(AutoSystemInfo)>::type AutoSystemInfoInitializer_buffer;
 AutoSystemInfo &AutoSystemInfo::Data = reinterpret_cast<AutoSystemInfo&>(AutoSystemInfoInitializer_buffer);
@@ -44,6 +45,9 @@ AutoSystemInfoInitializer::~AutoSystemInfoInitializer() {
     (&AutoSystemInfo::Data)->~AutoSystemInfo();
   }
 }
+#else
+AutoSystemInfo AutoSystemInfo::Data INIT_PRIORITY(300);
+#endif
 
 #if DBG
 bool

--- a/lib/Common/Core/SysInfo.h
+++ b/lib/Common/Core/SysInfo.h
@@ -6,11 +6,17 @@
 // Automatic system info getter at startup
 //----------------------------------------------------------------------------
 
+static struct AutoSystemInfoInitializer {
+  AutoSystemInfoInitializer();
+  ~AutoSystemInfoInitializer();
+} autoSystemInfoInitializer;
+
 class AutoSystemInfo : public SYSTEM_INFO
 {
     friend void ChakraBinaryAutoSystemInfoInit(AutoSystemInfo *);  // The hosting DLL provides the implementation of this function.
+    friend AutoSystemInfoInitializer;
 public:
-    static AutoSystemInfo Data;
+    static AutoSystemInfo &Data;
     uint GetAllocationGranularityPageCount() const;
     uint GetAllocationGranularityPageSize() const;
 

--- a/lib/Common/Core/SysInfo.h
+++ b/lib/Common/Core/SysInfo.h
@@ -6,17 +6,23 @@
 // Automatic system info getter at startup
 //----------------------------------------------------------------------------
 
+#ifdef CHAKRA_STATIC_LIBRARY
 static struct AutoSystemInfoInitializer {
   AutoSystemInfoInitializer();
   ~AutoSystemInfoInitializer();
 } autoSystemInfoInitializer;
+#endif
 
 class AutoSystemInfo : public SYSTEM_INFO
 {
     friend void ChakraBinaryAutoSystemInfoInit(AutoSystemInfo *);  // The hosting DLL provides the implementation of this function.
-    friend AutoSystemInfoInitializer;
 public:
+#ifdef CHAKRA_STATIC_LIBRARY
+    friend AutoSystemInfoInitializer;
     static AutoSystemInfo &Data;
+#else
+    static AutoSystemInfo Data;
+#endif
     uint GetAllocationGranularityPageCount() const;
     uint GetAllocationGranularityPageSize() const;
 

--- a/lib/Jsrt/JsrtHelper.cpp
+++ b/lib/Jsrt/JsrtHelper.cpp
@@ -93,10 +93,6 @@ void JsrtCallbackState::ObjectBeforeCallectCallbackWrapper(JsObjectBeforeCollect
 
     // Attention: shared library is handled under (see ChakraCore/ChakraCoreDllFunc.cpp)
     // todo: consolidate similar parts from shared and static library initialization
-#ifndef _WIN32
-        PAL_InitializeChakraCore(0, NULL);
-#endif
-
         HMODULE mod = GetModuleHandleW(NULL);
 
         if (!ThreadContextTLSEntry::InitializeProcess() || !JsrtContext::Initialize())

--- a/pal/src/file/file.cpp
+++ b/pal/src/file/file.cpp
@@ -64,7 +64,8 @@ FileCleanupRoutine(
     bool fCleanupSharedState
     );
 
-CObjectType CorUnix::otFile PAL_GLOBAL (
+static CObjectType *GetOtFile() {
+  static CObjectType *otFile = new CObjectType(
                 otiFile,
                 FileCleanupRoutine,
                 NULL,   // No initialization routine
@@ -81,6 +82,8 @@ CObjectType CorUnix::otFile PAL_GLOBAL (
                 CObjectType::ThreadReleaseNotApplicable,
                 CObjectType::OwnershipNotApplicable
                 );
+  return otFile;
+}
 
 CAllowedObjectTypes CorUnix::aotFile PAL_GLOBAL (otiFile);
 static CSharedMemoryFileLockMgr _FileLockManager PAL_GLOBAL;
@@ -762,7 +765,7 @@ CorUnix::InternalCreateFile(
 
     palError = g_pObjectManager->AllocateObject(
         pThread,
-        &otFile,
+        GetOtFile(),
         &oaFile,
         &pFileObject
         );
@@ -4282,7 +4285,7 @@ CorUnix::InternalCreatePipe(
 
     palError = g_pObjectManager->AllocateObject(
         pThread,
-        &otFile,
+        GetOtFile(),
         &oaFile,
         &pReadFileObject
         );
@@ -4325,7 +4328,7 @@ CorUnix::InternalCreatePipe(
 
     palError = g_pObjectManager->AllocateObject(
         pThread,
-        &otFile,
+        GetOtFile(),
         &oaFile,
         &pWriteFileObject
         );
@@ -4778,7 +4781,7 @@ static HANDLE init_std_handle(HANDLE * pStd, FILE *stream)
 
     palError = g_pObjectManager->AllocateObject(
         pThread,
-        &otFile,
+        GetOtFile(),
         &oa,
         &pFileObject
         );

--- a/pal/src/include/pal/file.hpp
+++ b/pal/src/include/pal/file.hpp
@@ -32,7 +32,6 @@ Revision History:
 
 namespace CorUnix
 {
-    extern CObjectType otFile;
     extern CAllowedObjectTypes aotFile;
 
     class CFileProcessLocalData

--- a/pal/src/include/pal/procobj.hpp
+++ b/pal/src/include/pal/procobj.hpp
@@ -25,8 +25,6 @@ Abstract:
 
 namespace CorUnix
 {
-    extern CObjectType otProcess;
-
     typedef enum
     {
         PS_IDLE,

--- a/pal/src/include/pal/thread.hpp
+++ b/pal/src/include/pal/thread.hpp
@@ -782,8 +782,6 @@ namespace CorUnix
     public:
         CPalThread *pThread;
     };
-
-    extern CObjectType otThread;
 }
 
 BOOL

--- a/pal/src/thread/process.cpp
+++ b/pal/src/thread/process.cpp
@@ -72,7 +72,8 @@ ProcessInitializationRoutine(
     void *pProcessLocalData
     );
 
-CObjectType CorUnix::otProcess PAL_GLOBAL (
+static CObjectType *GetOtProcess() {
+  static CObjectType *otProcess = new CObjectType(
                 otiProcess,
                 ProcessCleanupRoutine,
                 ProcessInitializationRoutine,
@@ -89,6 +90,8 @@ CObjectType CorUnix::otProcess PAL_GLOBAL (
                 CObjectType::ThreadReleaseHasNoSideEffects,
                 CObjectType::NoOwner
                 );
+  return otProcess;
+}
 
 //
 // Helper memory page used by the FlushProcessWriteBuffers
@@ -758,7 +761,7 @@ CorUnix::InternalCreateProcess(
 
     palError = g_pObjectManager->AllocateObject(
         pThread,
-        &otProcess,
+        GetOtProcess(),
         &oa, 
         &pobjProcess
         );
@@ -1682,7 +1685,7 @@ OpenProcess(
 
     palError = g_pObjectManager->AllocateObject(
         pThread,
-        &otProcess,
+        GetOtProcess(),
         &oa,
         &pobjProcess
         );
@@ -2418,7 +2421,7 @@ CorUnix::CreateInitialProcessAndThreadObjects(
     
     palError = g_pObjectManager->AllocateObject(
         pThread,
-        &otProcess,
+        GetOtProcess(),
         &oa,
         &pobjProcess
         );

--- a/pal/src/thread/thread.cpp
+++ b/pal/src/thread/thread.cpp
@@ -118,7 +118,8 @@ DecrementEndingThreadCount(
     void
     );
 
-CObjectType CorUnix::otThread PAL_GLOBAL (
+static CObjectType *GetOtThread() {
+  static CObjectType *otThread = new CObjectType(
                 otiThread,
                 ThreadCleanupRoutine,
                 ThreadInitializationRoutine,
@@ -135,6 +136,8 @@ CObjectType CorUnix::otThread PAL_GLOBAL (
                 CObjectType::ThreadReleaseHasNoSideEffects,
                 CObjectType::NoOwner
                 );
+  return otThread;
+}
 
 CAllowedObjectTypes aotThread PAL_GLOBAL (otiThread);
 
@@ -1845,7 +1848,7 @@ CorUnix::CreateThreadObject(
 
     palError = g_pObjectManager->AllocateObject(
         pThread,
-        &otThread,
+        GetOtThread(),
         &oa,
         &pobjThread
         );
@@ -1983,7 +1986,7 @@ CorUnix::InternalCreateDummyThread(
 
     palError = g_pObjectManager->AllocateObject(
         pThread,
-        &otThread,
+        GetOtThread(),
         &oa,
         &pobjThread
         );


### PR DESCRIPTION
Neither `init_sec` nor `init_priority` work on Darwin (`init_priority` only works within the compilation unit), so Chakra was crashing due to out of order initialisation.

This diff uses construct on first use for `PAL` and a nifty counter for `AutoSystemInfo` to ensure the initialisation order.

I've also removed the calls to `PAL_InitializeChakraCore`. which I'm not very sure about, but they seemed redundant, since `Initialize` will already be called by `AutoSystemInfo`, and the second call crashing due to the assertion on `pal/src/loader/module.cpp`:

```
BOOL LOADInitializeModules()
{
    _ASSERTE(exe_module.prev == nullptr);
```

With these changes I managed to compile and execute Chakra on OSX, using the following build command:

```
./build.sh --icu=/usr/local/opt/icu4c/include --debug --jobs=4 --static
```