### PR TITLE
X64 call arg MOV 0

### DIFF
--- a/lib/Backend/amd64/LinearScanMD.cpp
+++ b/lib/Backend/amd64/LinearScanMD.cpp
@@ -115,6 +115,8 @@ LinearScanMD::LegalizeConstantUse(IR::Instr * instr, IR::Opnd * opnd)
         // we should hoist it and generate xor reg, reg and MOV dst, reg
         BitVector regsBv;
         regsBv.Copy(this->linearScan->activeRegs);
+        regsBv.Or(this->linearScan->callSetupRegs);
+
         regsBv.ComplimentAll();
         regsBv.And(this->linearScan->int32Regs);
         regsBv.Minus(this->linearScan->tempRegs);       // Avoid tempRegs


### PR DESCRIPTION
When optimizing MOV 0, take into accounts registers used for arguments.
It was possible to reuse a register already used for an argument to do the `XOR reg, reg; MOV arg,reg` optimization.
The result would be to change the value of 1 argument to 0.

This bug is hitting is WebAssembly and probably in asm.js as well.
This can not hit with javascript user code, because it it specific to `MOV arg, 0` pattern and we never have const 0 (at least a tagged int 0 -> 1).
It could have been a problem with helper calls, but I guess we got lucky.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/1183)
<!-- Reviewable:end -->
