### PR TITLE
Set Release and Pre-Release macros to 0 in master.

### DIFF
--- a/lib/Common/CommonDefines.h
+++ b/lib/Common/CommonDefines.h
@@ -12,11 +12,11 @@
 //----------------------------------------------------------------------------------------------------
 #define CHAKRA_CORE_MAJOR_VERSION 1
 #define CHAKRA_CORE_MINOR_VERSION 2
-#define CHAKRA_CORE_VERSION_RELEASE 1
-#define CHAKRA_CORE_VERSION_PRERELEASE 1
+#define CHAKRA_CORE_VERSION_RELEASE 0
+#define CHAKRA_CORE_VERSION_PRERELEASE 0
 #define CHAKRA_CORE_VERSION_RELEASE_QFE 0
 
-#define CHAKRA_VERSION_RELEASE 1
+#define CHAKRA_VERSION_RELEASE 0
 
 // NOTE: need to update the GUID in ByteCodeCacheReleaseFileVersion.h as well
 


### PR DESCRIPTION
Set CHAKRA_CORE_VERSION_RELEASE, CHAKRA_CORE_VERSION_PRERELEASE, and CHAKRA_VERSION_RELEASE to 0.

We do not need to update the GUID because by making these changes we are switching from release configuration to engineering configuration by making these changes. See ByteCodeSerializer.cpp for details on this.

This will also enable the logic which allows the build number to be formatted into the x and y fields of the file version format 1.2.x.y.
