### PR TITLE
improve changePrototype scenario

### DIFF
--- a/lib/Runtime/Base/ThreadContext.h
+++ b/lib/Runtime/Base/ThreadContext.h
@@ -1298,6 +1298,10 @@ public:
     void InvalidateProtoInlineCaches(Js::PropertyId propertyId);
     void InvalidateStoreFieldInlineCaches(Js::PropertyId propertyId);
     void InvalidateAllProtoInlineCaches();
+#if DBG
+    bool IsObjectRegisteredInProtoInlineCaches(Js::DynamicObject * object);
+    bool IsObjectRegisteredInStoreFieldInlineCaches(Js::DynamicObject * object);
+#endif
     bool AreAllProtoInlineCachesInvalidated();
     void InvalidateAllStoreFieldInlineCaches();
     bool AreAllStoreFieldInlineCachesInvalidated();

--- a/lib/Runtime/Language/InlineCache.h
+++ b/lib/Runtime/Language/InlineCache.h
@@ -143,6 +143,18 @@ namespace Js
             return u.proto.isProto;
         }
 
+        DynamicObject * GetPrototypeObject() const
+        {
+            Assert(IsProto());
+            return u.proto.prototypeObject;
+        }
+
+        DynamicObject * GetAccessorObject() const
+        {
+            Assert(IsAccessor());
+            return u.accessor.object;
+        }
+
         bool IsAccessor() const
         {
             return u.accessor.isAccessor;

--- a/lib/Runtime/Library/JavascriptObject.cpp
+++ b/lib/Runtime/Library/JavascriptObject.cpp
@@ -158,6 +158,7 @@ namespace Js
             CrossSite::ForceCrossSiteThunkOnPrototypeChain(newPrototype);
             return proxy->SetPrototypeTrap(newPrototype, shouldThrow);
         }
+        
         // 2.   Let extensible be the value of the [[Extensible]] internal data property of O.
         // 3.   Let current be the value of the [[Prototype]] internal data property of O.
         // 4.   If SameValue(V, current), then return true.
@@ -205,45 +206,64 @@ namespace Js
         // 7.   Set the value of the [[Prototype]] internal data property of O to V.
         // 8.   Return true.
 
-        // Notify old prototypes that they are being removed from a prototype chain. This triggers invalidating protocache, etc.
-        if (!JavascriptProxy::Is(object))
+        bool isInvalidationOfInlineCacheNeeded = true;
+        DynamicObject * obj = DynamicObject::FromVar(object);
+
+        // If this object was not prototype object, then no need to invalidate inline caches.
+        // Simply assign it a new type so if this object used protoInlineCache in past, it will
+        // be invalidated because of type mismatch and subsequently we will update its protoInlineCache
+        if (!(obj->GetDynamicType()->GetTypeHandler()->GetFlags() & DynamicTypeHandler::IsPrototypeFlag))
         {
+            // If object has locked type, skip changing its type here as it will be changed anyway below
+            // when object gets newPrototype object.
+            if (!obj->HasLockedType())
+            {
+                obj->ChangeType();
+            }
+            Assert(!obj->GetScriptContext()->GetThreadContext()->IsObjectRegisteredInProtoInlineCaches(obj));
+            Assert(!obj->GetScriptContext()->GetThreadContext()->IsObjectRegisteredInStoreFieldInlineCaches(obj));
+            isInvalidationOfInlineCacheNeeded = false;
+        }
+
+        if (isInvalidationOfInlineCacheNeeded)
+        {
+            // Notify old prototypes that they are being removed from a prototype chain. This triggers invalidating protocache, etc.
             JavascriptOperators::MapObjectAndPrototypes<true>(object->GetPrototype(), [=](RecyclableObject* obj)
             {
                 obj->RemoveFromPrototype(scriptContext);
             });
-        }
 
-        // Examine new prototype chain. If it brings in any non-WritableData property, we need to invalidate related caches.
-        bool objectAndPrototypeChainHasOnlyWritableDataProperties =
-            JavascriptOperators::CheckIfObjectAndPrototypeChainHasOnlyWritableDataProperties(newPrototype);
+            // Examine new prototype chain. If it brings in any non-WritableData property, we need to invalidate related caches.
+            bool objectAndPrototypeChainHasOnlyWritableDataProperties =
+                JavascriptOperators::CheckIfObjectAndPrototypeChainHasOnlyWritableDataProperties(newPrototype);
 
-        if (!objectAndPrototypeChainHasOnlyWritableDataProperties
-            || object->GetScriptContext() != newPrototype->GetScriptContext())
-        {
-            // The HaveOnlyWritableDataProperties cache is cleared when a property is added or changed,
-            // but only for types in the same script context. Therefore, if the prototype is in another
-            // context, the object's cache won't be cleared when a property is added or changed on the prototype.
-            // Moreover, an object is added to the cache only when its whole prototype chain is in the same
-            // context.
-            //
-            // Since we don't have a way to find out which objects have a certain object as their prototype,
-            // we clear the cache here instead.
-
-            // Invalidate fast prototype chain writable data test flag
-            object->GetLibrary()->NoPrototypeChainsAreEnsuredToHaveOnlyWritableDataProperties();
-        }
-
-        if (!objectAndPrototypeChainHasOnlyWritableDataProperties)
-        {
-            // Invalidate StoreField/PropertyGuards for any non-WritableData property in the new chain
-            JavascriptOperators::MapObjectAndPrototypes<true>(newPrototype, [=](RecyclableObject* obj)
+            if (!objectAndPrototypeChainHasOnlyWritableDataProperties
+                || object->GetScriptContext() != newPrototype->GetScriptContext())
             {
-                if (!obj->HasOnlyWritableDataProperties())
+                // The HaveOnlyWritableDataProperties cache is cleared when a property is added or changed,
+                // but only for types in the same script context. Therefore, if the prototype is in another
+                // context, the object's cache won't be cleared when a property is added or changed on the prototype.
+                // Moreover, an object is added to the cache only when its whole prototype chain is in the same
+                // context.
+                //
+                // Since we don't have a way to find out which objects have a certain object as their prototype,
+                // we clear the cache here instead.
+
+                // Invalidate fast prototype chain writable data test flag
+                object->GetLibrary()->NoPrototypeChainsAreEnsuredToHaveOnlyWritableDataProperties();
+            }
+
+            if (!objectAndPrototypeChainHasOnlyWritableDataProperties)
+            {
+                // Invalidate StoreField/PropertyGuards for any non-WritableData property in the new chain
+                JavascriptOperators::MapObjectAndPrototypes<true>(newPrototype, [=](RecyclableObject* obj)
                 {
-                    obj->AddToPrototype(scriptContext);
-                }
-            });
+                    if (!obj->HasOnlyWritableDataProperties())
+                    {
+                        obj->AddToPrototype(scriptContext);
+                    }
+                });
+            }
         }
 
         // Set to new prototype


### PR DESCRIPTION
Whenever we change prototype of an object, we invalidate all proto inline caches of all the properties present in all of the object's prototype chain. However this can be avoided if the object is not a prototype of any other object since it would have never got registered in proto inline cache as a prototype object. So, skip invalidation if the object is not a prototype of any object.
The only thing that should be done in that case is to change the type of object so that if it's properties were using proto inline caches, they will be invalidated by type mismatch and we will update their proto inline cache on next property access.

Gives approx. 20% gain in AcmeAir benchmarks of node.

Test: UnitTest pass, Internal test runs in progress.