### PR TITLE
Few iterator close issues - array destructuring.

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -12197,11 +12197,6 @@ ParseNodePtr Parser::ParseDestructuredArrayLiteral(tokens declarationType, bool 
     {
         while (true)
         {
-            if (seenRest) // Rest must be in the last position.
-            {
-                Error(ERRDestructRestLast);
-            }
-
             ParseNodePtr pnodeElem = ParseDestructuredVarDecl<buildAST>(declarationType, isDecl, &seenRest, topLevel);
             if (buildAST)
             {
@@ -12222,6 +12217,11 @@ ParseNodePtr Parser::ParseDestructuredArrayLiteral(tokens declarationType, bool 
             if (m_token.tk != tkComma)
             {
                 Error(ERRDestructNoOper);
+            }
+
+            if (seenRest) // Rest must be in the last position.
+            {
+                Error(ERRDestructRestLast);
             }
 
             m_pscan->Scan();

--- a/test/es6/destructuring.js
+++ b/test/es6/destructuring.js
@@ -128,6 +128,8 @@ var tests = [
       assert.throws(function () { eval("const [...a, b] = [];"); },       SyntaxError, "Destructured const array declaration with rest parameter in non-last position throws", "Destructuring rest variables must be in the last position of the expression");
       assert.throws(function () { eval("var a, b; [...a, b] = [];"); },   SyntaxError, "Destructured var array assignment with rest parameter in non-last position throws",    "Destructuring rest variables must be in the last position of the expression");
       assert.throws(function () { eval("let a, b; [...a, b] = [];"); },   SyntaxError, "Destructured let array assignment with rest parameter in non-last position throws",    "Destructuring rest variables must be in the last position of the expression");
+      assert.throws(function () { eval("let [...a,] = [];"); },           SyntaxError, "Destructured array declaration has comma after rest parameter throws",                 "Destructuring rest variables must be in the last position of the expression");
+      assert.throws(function () { eval("let a; [...a,] = [];"); },        SyntaxError, "Destructured array assignment has comma after rest parameter throws",                  "Destructuring rest variables must be in the last position of the expression");
 
       // Default values
       assert.doesNotThrow(function () { eval("var [a = 1] = [];"); },    "Destructured var array declaration with all default values does not throw");


### PR DESCRIPTION
Array destructuring was wrapped with try..finally as it was assumed that we will get abrupt completion due to throw. But 'yield' makes it possible to abrupt completion with 'return'. Fixed that by extend that to try.catch.finally.
Also we were emitting reference of the LHS after emitting of RHS. However that is supposed to happen first. Fixed that by Emit reference of LHS first.
Added unittest.
