### PR TITLE
cross platform: fix release/static lib build

### DIFF
--- a/bin/ch/ch.cpp
+++ b/bin/ch/ch.cpp
@@ -521,7 +521,7 @@ int _cdecl wmain(int argc, __in_ecount(argc) LPWSTR argv[])
     HINSTANCE chakraLibrary = nullptr;
     bool success = ChakraRTInterface::LoadChakraDll(&argInfo, &chakraLibrary);
 
-#if defined(CHAKRA_STATIC_LIBRARY)
+#if defined(CHAKRA_STATIC_LIBRARY) && !defined(NDEBUG)
     // handle command line flags
     OnChakraCoreLoaded();
 #endif


### PR DESCRIPTION
At the moment, Release build doesn't have the test hooks are enabled. Although we force define `ENABLE_TEST_HOOKS` from ch/stdafx.h, underlying shared lib doesn't include the tooling for release build. Following the same approach for static builds, fixes release/static library builds on xplat.