### PR TITLE
Intl: removed invalid assert

### DIFF
--- a/lib/Runtime/Base/WindowsGlobalizationAdapter.cpp
+++ b/lib/Runtime/Base/WindowsGlobalizationAdapter.cpp
@@ -385,7 +385,6 @@ namespace Js
 
         // Construct HSTRING of timeZoneId passed
         IfFailThrowHr(GetWindowsGlobalizationLibrary(scriptContext)->WindowsCreateStringReference(timeZoneId, static_cast<UINT32>(wcslen(timeZoneId)), &timeZoneHeader, &timeZone));
-        Assert(timeZone);
 
         // The warning is timeZone could be '0'. This is valid scenario and in that case, ChangeTimeZone() would
         // return error HR in which case we will throw.


### PR DESCRIPTION
`WindowsCreateStringReference` sets string as null if length of input string is 0.
Removed the assert where we were checking that output string should never be null.

Fixes: (7953593)[https://microsoft.visualstudio.com//defaultcollection/OS/_workItems?_a=edit&id=7953593&triage=true]