### PR TITLE
Implement Utf8 Jsrt API

### DIFF
--- a/bin/ch/ChakraRtInterface.cpp
+++ b/bin/ch/ChakraRtInterface.cpp
@@ -84,7 +84,7 @@ bool ChakraRTInterface::LoadChakraDll(ArgInfo* argInfo, HINSTANCE *outLibrary)
     m_jsApiHooks.pfJsrtCreateExternalObject = (JsAPIHooks::JsrtCreateExternalObjectPtr)GetChakraCoreSymbol(library, "JsCreateExternalObject");
     m_jsApiHooks.pfJsrtCreateFunction = (JsAPIHooks::JsrtCreateFunctionPtr)GetChakraCoreSymbol(library, "JsCreateFunction");
     m_jsApiHooks.pfJsrtCreateNamedFunction = (JsAPIHooks::JsCreateNamedFunctionPtr)GetChakraCoreSymbol(library, "JsCreateNamedFunction");
-    m_jsApiHooks.pfJsrtPointerToString = (JsAPIHooks::JsrtPointerToStringPtr)GetChakraCoreSymbol(library, "JsPointerToString");
+    m_jsApiHooks.pfJsrtPointerToStringUtf8 = (JsAPIHooks::JsrtPointerToStringUtf8Ptr)GetChakraCoreSymbol(library, "JsPointerToStringUtf8");
     m_jsApiHooks.pfJsrtSetProperty = (JsAPIHooks::JsrtSetPropertyPtr)GetChakraCoreSymbol(library, "JsSetProperty");
     m_jsApiHooks.pfJsrtGetGlobalObject = (JsAPIHooks::JsrtGetGlobalObjectPtr)GetChakraCoreSymbol(library, "JsGetGlobalObject");
     m_jsApiHooks.pfJsrtGetUndefinedValue = (JsAPIHooks::JsrtGetUndefinedValuePtr)GetChakraCoreSymbol(library, "JsGetUndefinedValue");
@@ -93,13 +93,10 @@ bool ChakraRTInterface::LoadChakraDll(ArgInfo* argInfo, HINSTANCE *outLibrary)
     m_jsApiHooks.pfJsrtConvertValueToString = (JsAPIHooks::JsrtConvertValueToStringPtr)GetChakraCoreSymbol(library, "JsConvertValueToString");
     m_jsApiHooks.pfJsrtConvertValueToNumber = (JsAPIHooks::JsrtConvertValueToNumberPtr)GetChakraCoreSymbol(library, "JsConvertValueToNumber");
     m_jsApiHooks.pfJsrtConvertValueToBoolean = (JsAPIHooks::JsrtConvertValueToBooleanPtr)GetChakraCoreSymbol(library, "JsConvertValueToBoolean");
-    m_jsApiHooks.pfJsrtStringToPointer = (JsAPIHooks::JsrtStringToPointerPtr)GetChakraCoreSymbol(library, "JsStringToPointer");
+    m_jsApiHooks.pfJsrtStringToPointerUtf8Copy = (JsAPIHooks::JsrtStringToPointerUtf8CopyPtr)GetChakraCoreSymbol(library, "JsStringToPointerUtf8Copy");
     m_jsApiHooks.pfJsrtBooleanToBool = (JsAPIHooks::JsrtBooleanToBoolPtr)GetChakraCoreSymbol(library, "JsBooleanToBool");
-    m_jsApiHooks.pfJsrtGetPropertyIdFromName = (JsAPIHooks::JsrtGetPropertyIdFromNamePtr)GetChakraCoreSymbol(library, "JsGetPropertyIdFromName");
     m_jsApiHooks.pfJsrtGetProperty = (JsAPIHooks::JsrtGetPropertyPtr)GetChakraCoreSymbol(library, "JsGetProperty");
     m_jsApiHooks.pfJsrtHasProperty = (JsAPIHooks::JsrtHasPropertyPtr)GetChakraCoreSymbol(library, "JsHasProperty");
-    m_jsApiHooks.pfJsrtRunScript = (JsAPIHooks::JsrtRunScriptPtr)GetChakraCoreSymbol(library, "JsRunScript");
-    m_jsApiHooks.pfJsrtRunModule = (JsAPIHooks::JsrtRunModulePtr)GetChakraCoreSymbol(library, "JsExperimentalApiRunModule");
     m_jsApiHooks.pfJsrtCallFunction = (JsAPIHooks::JsrtCallFunctionPtr)GetChakraCoreSymbol(library, "JsCallFunction");
     m_jsApiHooks.pfJsrtNumberToDouble = (JsAPIHooks::JsrtNumberToDoublePtr)GetChakraCoreSymbol(library, "JsNumberToDouble");
     m_jsApiHooks.pfJsrtNumberToInt = (JsAPIHooks::JsrtNumberToIntPtr)GetChakraCoreSymbol(library, "JsNumberToInt");
@@ -115,11 +112,9 @@ bool ChakraRTInterface::LoadChakraDll(ArgInfo* argInfo, HINSTANCE *outLibrary)
     m_jsApiHooks.pfJsrtAddRef = (JsAPIHooks::JsrtAddRefPtr)GetChakraCoreSymbol(library, "JsAddRef");
     m_jsApiHooks.pfJsrtGetValueType = (JsAPIHooks::JsrtGetValueType)GetChakraCoreSymbol(library, "JsGetValueType");
     m_jsApiHooks.pfJsrtSetIndexedProperty = (JsAPIHooks::JsrtSetIndexedPropertyPtr)GetChakraCoreSymbol(library, "JsSetIndexedProperty");
-    m_jsApiHooks.pfJsrtSerializeScript = (JsAPIHooks::JsrtSerializeScriptPtr)GetChakraCoreSymbol(library, "JsSerializeScript");
-    m_jsApiHooks.pfJsrtRunSerializedScript = (JsAPIHooks::JsrtRunSerializedScriptPtr)GetChakraCoreSymbol(library, "JsRunSerializedScript");
     m_jsApiHooks.pfJsrtSetPromiseContinuationCallback = (JsAPIHooks::JsrtSetPromiseContinuationCallbackPtr)GetChakraCoreSymbol(library, "JsSetPromiseContinuationCallback");
     m_jsApiHooks.pfJsrtGetContextOfObject = (JsAPIHooks::JsrtGetContextOfObject)GetChakraCoreSymbol(library, "JsGetContextOfObject");
-    m_jsApiHooks.pfJsrtParseScriptWithAttributes = (JsAPIHooks::JsrtParseScriptWithAttributes)GetChakraCoreSymbol(library, "JsParseScriptWithAttributes");
+    m_jsApiHooks.pfJsrtParseScriptWithAttributesUtf8 = (JsAPIHooks::JsrtParseScriptWithAttributesUtf8)GetChakraCoreSymbol(library, "JsParseScriptWithAttributesUtf8");
     m_jsApiHooks.pfJsrtDiagStartDebugging = (JsAPIHooks::JsrtDiagStartDebugging)GetChakraCoreSymbol(library, "JsDiagStartDebugging");
     m_jsApiHooks.pfJsrtDiagStopDebugging = (JsAPIHooks::JsrtDiagStopDebugging)GetChakraCoreSymbol(library, "JsDiagStopDebugging");
     m_jsApiHooks.pfJsrtDiagGetSource = (JsAPIHooks::JsrtDiagGetSource)GetChakraCoreSymbol(library, "JsDiagGetSource");
@@ -136,15 +131,13 @@ bool ChakraRTInterface::LoadChakraDll(ArgInfo* argInfo, HINSTANCE *outLibrary)
     m_jsApiHooks.pfJsrtDiagGetStackProperties = (JsAPIHooks::JsrtDiagGetStackProperties)GetChakraCoreSymbol(library, "JsDiagGetStackProperties");
     m_jsApiHooks.pfJsrtDiagGetProperties = (JsAPIHooks::JsrtDiagGetProperties)GetChakraCoreSymbol(library, "JsDiagGetProperties");
     m_jsApiHooks.pfJsrtDiagGetObjectFromHandle = (JsAPIHooks::JsrtDiagGetObjectFromHandle)GetChakraCoreSymbol(library, "JsDiagGetObjectFromHandle");
-
-#ifdef _WIN32
-    m_jsApiHooks.pfJsrtDiagEvaluate = (JsAPIHooks::JsrtDiagEvaluate)GetChakraCoreSymbol(library, "JsDiagEvaluate");
-#endif
-
+    m_jsApiHooks.pfJsrtDiagEvaluateUtf8 = (JsAPIHooks::JsrtDiagEvaluateUtf8)GetChakraCoreSymbol(library, "JsDiagEvaluateUtf8");
     m_jsApiHooks.pfJsrtRunScriptUtf8 = (JsAPIHooks::JsrtRunScriptUtf8)GetChakraCoreSymbol(library, "JsRunScriptUtf8");
     m_jsApiHooks.pfJsrtSerializeScriptUtf8 = (JsAPIHooks::JsrtSerializeScriptUtf8)GetChakraCoreSymbol(library, "JsSerializeScriptUtf8");
     m_jsApiHooks.pfJsrtRunSerializedScriptUtf8 = (JsAPIHooks::JsrtRunSerializedScriptUtf8)GetChakraCoreSymbol(library, "JsRunSerializedScriptUtf8");
     m_jsApiHooks.pfJsrtExperimentalApiRunModuleUtf8 = (JsAPIHooks::JsrtRunModuleUtf8Ptr)GetChakraCoreSymbol(library, "JsExperimentalApiRunModuleUtf8");
+    m_jsApiHooks.pfJsrtGetPropertyIdFromNameUtf8 = (JsAPIHooks::JsrtGetPropertyIdFromNameUtf8Ptr)GetChakraCoreSymbol(library, "JsGetPropertyIdFromNameUtf8");
+    m_jsApiHooks.pfJsrtStringFree = (JsAPIHooks::JsrtStringFreePtr)GetChakraCoreSymbol(library, "JsStringFree");
 #endif
 
     return true;

--- a/bin/ch/ChakraRtInterface.h
+++ b/bin/ch/ChakraRtInterface.h
@@ -16,20 +16,18 @@ struct JsAPIHooks
     typedef JsErrorCode (WINAPI *JsrtCreateExternalObjectPtr)(void* data, JsFinalizeCallback callback, JsValueRef *object);
     typedef JsErrorCode (WINAPI *JsrtCreateFunctionPtr)(JsNativeFunction nativeFunction, void *callbackState, JsValueRef *function);
     typedef JsErrorCode (WINAPI *JsCreateNamedFunctionPtr)(JsValueRef name, JsNativeFunction nativeFunction, void *callbackState, JsValueRef *function);
-    typedef JsErrorCode (WINAPI *JsrtPointerToStringPtr)(const char16 *stringValue, size_t length, JsValueRef *value);
+    typedef JsErrorCode (WINAPI *JsrtPointerToStringUtf8Ptr)(const char *stringValue, size_t length, JsValueRef *value);
     typedef JsErrorCode (WINAPI *JsrtSetPropertyPtr)(JsValueRef object, JsPropertyIdRef property, JsValueRef value, bool useStrictRules);
     typedef JsErrorCode (WINAPI *JsrtGetGlobalObjectPtr)(JsValueRef *globalObject);
     typedef JsErrorCode (WINAPI *JsrtGetUndefinedValuePtr)(JsValueRef *globalObject);
     typedef JsErrorCode (WINAPI *JsrtConvertValueToStringPtr)(JsValueRef value, JsValueRef *stringValue);
     typedef JsErrorCode (WINAPI *JsrtConvertValueToNumberPtr)(JsValueRef value, JsValueRef *numberValue);
     typedef JsErrorCode (WINAPI *JsrtConvertValueToBooleanPtr)(JsValueRef value, JsValueRef *booleanValue);
-    typedef JsErrorCode (WINAPI *JsrtStringToPointerPtr)(JsValueRef value, const char16 **stringValue, size_t *length);
+    typedef JsErrorCode (WINAPI *JsrtStringToPointerUtf8CopyPtr)(JsValueRef value, char **stringValue, size_t *length);
     typedef JsErrorCode (WINAPI *JsrtBooleanToBoolPtr)(JsValueRef value, bool *boolValue);
-    typedef JsErrorCode (WINAPI *JsrtGetPropertyIdFromNamePtr)(const char16 *name, JsPropertyIdRef *propertyId);
+    typedef JsErrorCode (WINAPI *JsrtGetPropertyIdFromNameUtf8Ptr)(const char *name, JsPropertyIdRef *propertyId);
     typedef JsErrorCode (WINAPI *JsrtGetPropertyPtr)(JsValueRef object, JsPropertyIdRef property, JsValueRef* value);
     typedef JsErrorCode (WINAPI *JsrtHasPropertyPtr)(JsValueRef object, JsPropertyIdRef property, bool *hasProperty);
-    typedef JsErrorCode (WINAPI *JsrtRunScriptPtr)(const char16 *script, DWORD_PTR sourceContext, const char16 *sourceUrl, JsValueRef* result);
-    typedef JsErrorCode (WINAPI *JsrtRunModulePtr)(const char16 *script, DWORD_PTR sourceContext, const char16 *sourceUrl, JsValueRef* result);
     typedef JsErrorCode (WINAPI *JsrtCallFunctionPtr)(JsValueRef function, JsValueRef* arguments, unsigned short argumentCount, JsValueRef *result);
     typedef JsErrorCode (WINAPI *JsrtNumberToDoublePtr)(JsValueRef value, double *doubleValue);
     typedef JsErrorCode (WINAPI *JsrtNumberToIntPtr)(JsValueRef value, int *intValue);
@@ -45,12 +43,10 @@ struct JsAPIHooks
     typedef JsErrorCode (WINAPI *JsrtAddRefPtr)(JsRef ref, unsigned int* count);
     typedef JsErrorCode (WINAPI *JsrtGetValueType)(JsValueRef value, JsValueType *type);
     typedef JsErrorCode (WINAPI *JsrtSetIndexedPropertyPtr)(JsValueRef object, JsValueRef index, JsValueRef value);
-    typedef JsErrorCode (WINAPI *JsrtSerializeScriptPtr)(const char16 *script, BYTE *buffer, unsigned int *bufferSize);
-    typedef JsErrorCode (WINAPI *JsrtRunSerializedScriptPtr)(const char16 *script, BYTE *buffer, DWORD_PTR sourceContext, const char16 *sourceUrl, JsValueRef* result);
     typedef JsErrorCode (WINAPI *JsrtSetPromiseContinuationCallbackPtr)(JsPromiseContinuationCallback callback, void *callbackState);
     typedef JsErrorCode (WINAPI *JsrtGetContextOfObject)(JsValueRef object, JsContextRef *callbackState);
 
-    typedef JsErrorCode(WINAPI *JsrtParseScriptWithAttributes)(const wchar_t *script, JsSourceContext sourceContext, const wchar_t *sourceUrl, JsParseScriptAttributes parseAttributes, JsValueRef *result);
+    typedef JsErrorCode(WINAPI *JsrtParseScriptWithAttributesUtf8)(const char *script, JsSourceContext sourceContext, const char *sourceUrl, JsParseScriptAttributes parseAttributes, JsValueRef *result);
     typedef JsErrorCode(WINAPI *JsrtDiagStartDebugging)(JsRuntimeHandle runtimeHandle, JsDiagDebugEventCallback debugEventCallback, void* callbackState);
     typedef JsErrorCode(WINAPI *JsrtDiagStopDebugging)(JsRuntimeHandle runtimeHandle, void** callbackState);
     typedef JsErrorCode(WINAPI *JsrtDiagGetSource)(unsigned int scriptId, JsValueRef *source);
@@ -67,12 +63,13 @@ struct JsAPIHooks
     typedef JsErrorCode(WINAPI *JsrtDiagGetStackProperties)(unsigned int stackFrameIndex, JsValueRef * properties);
     typedef JsErrorCode(WINAPI *JsrtDiagGetProperties)(unsigned int objectHandle, unsigned int fromCount, unsigned int totalCount, JsValueRef * propertiesObject);
     typedef JsErrorCode(WINAPI *JsrtDiagGetObjectFromHandle)(unsigned int handle, JsValueRef * handleObject);
-    typedef JsErrorCode(WINAPI *JsrtDiagEvaluate)(const wchar_t * expression, unsigned int stackFrameIndex, JsValueRef * evalResult);
+    typedef JsErrorCode(WINAPI *JsrtDiagEvaluateUtf8)(const char * expression, unsigned int stackFrameIndex, JsValueRef * evalResult);
 
     typedef JsErrorCode(WINAPI *JsrtRunScriptUtf8)(const char *script, JsSourceContext sourceContext, const char *sourceUrl, JsValueRef *result);
     typedef JsErrorCode(WINAPI *JsrtSerializeScriptUtf8)(const char *script, ChakraBytePtr buffer, unsigned int *bufferSize);
     typedef JsErrorCode(WINAPI *JsrtRunSerializedScriptUtf8)(JsSerializedScriptLoadUtf8SourceCallback scriptLoadCallback, JsSerializedScriptUnloadCallback scriptUnloadCallback, ChakraBytePtr buffer, JsSourceContext sourceContext, const char *sourceUrl, JsValueRef * result);
     typedef JsErrorCode(WINAPI *JsrtRunModuleUtf8Ptr)(const char *script, JsSourceContext sourceContext, const char *sourceUrl, JsValueRef *result);
+    typedef JsErrorCode(WINAPI *JsrtStringFreePtr)(const char *stringValue);
 
     JsrtCreateRuntimePtr pfJsrtCreateRuntime;
     JsrtCreateContextPtr pfJsrtCreateContext;
@@ -84,7 +81,7 @@ struct JsAPIHooks
     JsrtCreateExternalObjectPtr pfJsrtCreateExternalObject;
     JsrtCreateFunctionPtr pfJsrtCreateFunction;
     JsCreateNamedFunctionPtr pfJsrtCreateNamedFunction;
-    JsrtPointerToStringPtr pfJsrtPointerToString;
+    JsrtPointerToStringUtf8Ptr pfJsrtPointerToStringUtf8;
     JsrtSetPropertyPtr pfJsrtSetProperty;
     JsrtGetGlobalObjectPtr pfJsrtGetGlobalObject;
     JsrtGetUndefinedValuePtr pfJsrtGetUndefinedValue;
@@ -93,13 +90,11 @@ struct JsAPIHooks
     JsrtConvertValueToStringPtr pfJsrtConvertValueToString;
     JsrtConvertValueToNumberPtr pfJsrtConvertValueToNumber;
     JsrtConvertValueToBooleanPtr pfJsrtConvertValueToBoolean;
-    JsrtStringToPointerPtr pfJsrtStringToPointer;
+    JsrtStringToPointerUtf8CopyPtr pfJsrtStringToPointerUtf8Copy;
     JsrtBooleanToBoolPtr pfJsrtBooleanToBool;
-    JsrtGetPropertyIdFromNamePtr pfJsrtGetPropertyIdFromName;
+    JsrtGetPropertyIdFromNameUtf8Ptr pfJsrtGetPropertyIdFromNameUtf8;
     JsrtGetPropertyPtr pfJsrtGetProperty;
     JsrtHasPropertyPtr pfJsrtHasProperty;
-    JsrtRunScriptPtr pfJsrtRunScript;
-    JsrtRunModulePtr pfJsrtRunModule;
     JsrtCallFunctionPtr pfJsrtCallFunction;
     JsrtNumberToDoublePtr pfJsrtNumberToDouble;
     JsrtNumberToIntPtr pfJsrtNumberToInt;
@@ -115,11 +110,9 @@ struct JsAPIHooks
     JsrtAddRefPtr pfJsrtAddRef;
     JsrtGetValueType pfJsrtGetValueType;
     JsrtSetIndexedPropertyPtr pfJsrtSetIndexedProperty;
-    JsrtSerializeScriptPtr pfJsrtSerializeScript;
-    JsrtRunSerializedScriptPtr pfJsrtRunSerializedScript;
     JsrtSetPromiseContinuationCallbackPtr pfJsrtSetPromiseContinuationCallback;
     JsrtGetContextOfObject pfJsrtGetContextOfObject;
-    JsrtParseScriptWithAttributes pfJsrtParseScriptWithAttributes;
+    JsrtParseScriptWithAttributesUtf8 pfJsrtParseScriptWithAttributesUtf8;
     JsrtDiagStartDebugging pfJsrtDiagStartDebugging;
     JsrtDiagStopDebugging pfJsrtDiagStopDebugging;
     JsrtDiagGetSource pfJsrtDiagGetSource;
@@ -136,12 +129,13 @@ struct JsAPIHooks
     JsrtDiagGetStackProperties pfJsrtDiagGetStackProperties;
     JsrtDiagGetProperties pfJsrtDiagGetProperties;
     JsrtDiagGetObjectFromHandle pfJsrtDiagGetObjectFromHandle;
-    JsrtDiagEvaluate pfJsrtDiagEvaluate;
+    JsrtDiagEvaluateUtf8 pfJsrtDiagEvaluateUtf8;
 
     JsrtRunScriptUtf8 pfJsrtRunScriptUtf8;
     JsrtSerializeScriptUtf8 pfJsrtSerializeScriptUtf8;
     JsrtRunSerializedScriptUtf8 pfJsrtRunSerializedScriptUtf8;
     JsrtRunModuleUtf8Ptr pfJsrtExperimentalApiRunModuleUtf8;
+    JsrtStringFreePtr pfJsrtStringFree;
 };
 
 class ChakraRTInterface
@@ -231,7 +225,6 @@ public:
     static JsErrorCode WINAPI JsCreateExternalObject(void *data, JsFinalizeCallback callback, JsValueRef *object) { return HOOK_JS_API(CreateExternalObject(data, callback, object)); }
     static JsErrorCode WINAPI JsCreateFunction(JsNativeFunction nativeFunction, void *callbackState, JsValueRef *function) { return HOOK_JS_API(CreateFunction(nativeFunction, callbackState, function)); }
     static JsErrorCode WINAPI JsCreateNamedFunction(JsValueRef name, JsNativeFunction nativeFunction, void *callbackState, JsValueRef *function) { return HOOK_JS_API(CreateNamedFunction(name, nativeFunction, callbackState, function)); }
-    static JsErrorCode WINAPI JsPointerToString(const char16 *stringValue, size_t length, JsValueRef *value) { return HOOK_JS_API(PointerToString(stringValue, length, value)); }
     static JsErrorCode WINAPI JsSetProperty(JsValueRef object, JsPropertyIdRef property, JsValueRef value, bool useStrictRules) { return HOOK_JS_API(SetProperty(object, property, value, useStrictRules)); }
     static JsErrorCode WINAPI JsGetGlobalObject(JsValueRef *globalObject) { return HOOK_JS_API(GetGlobalObject(globalObject)); }
     static JsErrorCode WINAPI JsGetUndefinedValue(JsValueRef *globalObject) { return HOOK_JS_API(GetUndefinedValue(globalObject)); }
@@ -240,13 +233,11 @@ public:
     static JsErrorCode WINAPI JsConvertValueToString(JsValueRef value, JsValueRef *stringValue) { return HOOK_JS_API(ConvertValueToString(value, stringValue)); }
     static JsErrorCode WINAPI JsConvertValueToNumber(JsValueRef value, JsValueRef *numberValue) { return HOOK_JS_API(ConvertValueToNumber(value, numberValue)); }
     static JsErrorCode WINAPI JsConvertValueToBoolean(JsValueRef value, JsValueRef *booleanValue) { return HOOK_JS_API(ConvertValueToBoolean(value, booleanValue)); }
-    static JsErrorCode WINAPI JsStringToPointer(JsValueRef value, const char16 **stringValue, size_t *length) { return HOOK_JS_API(StringToPointer(value, stringValue, length)); }
+    static JsErrorCode WINAPI JsStringToPointerUtf8Copy(JsValueRef value, char **stringValue, size_t *length) { return HOOK_JS_API(StringToPointerUtf8Copy(value, stringValue, length)); }
     static JsErrorCode WINAPI JsBooleanToBool(JsValueRef value, bool* boolValue) { return HOOK_JS_API(BooleanToBool(value, boolValue)); }
-    static JsErrorCode WINAPI JsGetPropertyIdFromName(const char16 *name, JsPropertyIdRef *propertyId) { return HOOK_JS_API(GetPropertyIdFromName(name, propertyId)); }
+    static JsErrorCode WINAPI JsGetPropertyIdFromNameUtf8(const char *name, JsPropertyIdRef *propertyId) { return HOOK_JS_API(GetPropertyIdFromNameUtf8(name, propertyId)); }
     static JsErrorCode WINAPI JsGetProperty(JsValueRef object, JsPropertyIdRef property, JsValueRef* value) { return HOOK_JS_API(GetProperty(object, property, value)); }
     static JsErrorCode WINAPI JsHasProperty(JsValueRef object, JsPropertyIdRef property, bool *hasProperty) { return HOOK_JS_API(HasProperty(object, property, hasProperty)); }
-    static JsErrorCode WINAPI JsRunScript(const char16 *script, DWORD_PTR sourceContext, const char16 *sourceUrl, JsValueRef* result) { return HOOK_JS_API(RunScript(script, sourceContext, sourceUrl, result)); }
-    static JsErrorCode WINAPI JsRunModule(const char16 *script, DWORD_PTR sourceContext, const char16 *sourceUrl, JsValueRef* result) { return m_jsApiHooks.pfJsrtRunModule(script, sourceContext, sourceUrl, result); }
     static JsErrorCode WINAPI JsCallFunction(JsValueRef function, JsValueRef* arguments, unsigned short argumentCount, JsValueRef *result) { return HOOK_JS_API(CallFunction(function, arguments, argumentCount, result)); }
     static JsErrorCode WINAPI JsNumberToDouble(JsValueRef value, double* doubleValue) { return HOOK_JS_API(NumberToDouble(value, doubleValue)); }
     static JsErrorCode WINAPI JsNumberToInt(JsValueRef value, int* intValue) { return HOOK_JS_API(NumberToInt(value, intValue)); }
@@ -262,11 +253,9 @@ public:
     static JsErrorCode WINAPI JsAddRef(JsRef ref, unsigned int* count) { return HOOK_JS_API(AddRef(ref, count)); }
     static JsErrorCode WINAPI JsGetValueType(JsValueRef value, JsValueType *type) { return HOOK_JS_API(GetValueType(value, type)); }
     static JsErrorCode WINAPI JsSetIndexedProperty(JsValueRef object, JsValueRef index, JsValueRef value) { return HOOK_JS_API(SetIndexedProperty(object, index, value)); }
-    static JsErrorCode WINAPI JsSerializeScript(const char16 *script, BYTE *buffer, unsigned int *bufferSize) { return HOOK_JS_API(SerializeScript(script, buffer, bufferSize)); }
-    static JsErrorCode WINAPI JsRunSerializedScript(const char16 *script, BYTE *buffer, DWORD_PTR sourceContext, const char16 *sourceUrl, JsValueRef* result) { return HOOK_JS_API(RunSerializedScript(script, buffer, sourceContext, sourceUrl, result)); }
     static JsErrorCode WINAPI JsSetPromiseContinuationCallback(JsPromiseContinuationCallback callback, void *callbackState) { return HOOK_JS_API(SetPromiseContinuationCallback(callback, callbackState)); }
     static JsErrorCode WINAPI JsGetContextOfObject(JsValueRef object, JsContextRef* context) { return HOOK_JS_API(GetContextOfObject(object, context)); }
-    static JsErrorCode WINAPI JsParseScriptWithAttributes(const wchar_t *script, JsSourceContext sourceContext, const wchar_t *sourceUrl, JsParseScriptAttributes parseAttributes, JsValueRef *result) { return HOOK_JS_API(ParseScriptWithAttributes(script, sourceContext, sourceUrl, parseAttributes, result)); }
+    static JsErrorCode WINAPI JsParseScriptWithAttributesUtf8(const char *script, JsSourceContext sourceContext, const char *sourceUrl, JsParseScriptAttributes parseAttributes, JsValueRef *result) { return HOOK_JS_API(ParseScriptWithAttributesUtf8(script, sourceContext, sourceUrl, parseAttributes, result)); }
     static JsErrorCode WINAPI JsDiagStartDebugging(JsRuntimeHandle runtimeHandle, JsDiagDebugEventCallback debugEventCallback, void* callbackState) { return HOOK_JS_API(DiagStartDebugging(runtimeHandle, debugEventCallback, callbackState)); }
     static JsErrorCode WINAPI JsDiagStopDebugging(JsRuntimeHandle runtimeHandle, void** callbackState) { return HOOK_JS_API(DiagStopDebugging(runtimeHandle, callbackState)); }
     static JsErrorCode WINAPI JsDiagGetSource(unsigned int scriptId, JsValueRef *source) { return HOOK_JS_API(DiagGetSource(scriptId, source)); }
@@ -283,16 +272,13 @@ public:
     static JsErrorCode WINAPI JsDiagGetStackProperties(unsigned int stackFrameIndex, JsValueRef * properties) { return HOOK_JS_API(DiagGetStackProperties(stackFrameIndex, properties)); }
     static JsErrorCode WINAPI JsDiagGetProperties(unsigned int objectHandle, unsigned int fromCount, unsigned int totalCount, JsValueRef * propertiesObject) { return HOOK_JS_API(DiagGetProperties(objectHandle, fromCount, totalCount, propertiesObject)); }
     static JsErrorCode WINAPI JsDiagGetObjectFromHandle(unsigned int handle, JsValueRef * handleObject) { return HOOK_JS_API(DiagGetObjectFromHandle(handle, handleObject)); }
+    static JsErrorCode WINAPI JsDiagEvaluateUtf8(const char * expression, unsigned int stackFrameIndex, JsValueRef * evalResult) { return HOOK_JS_API(DiagEvaluateUtf8(expression, stackFrameIndex, evalResult)); }
 
-#ifdef _WIN32
-    static JsErrorCode WINAPI JsDiagEvaluate(const wchar_t * expression, unsigned int stackFrameIndex, JsValueRef * evalResult) { return HOOK_JS_API(DiagEvaluate(expression, stackFrameIndex, evalResult)); }
-#endif
-
-    static JsErrorCode WINAPI JsValueToWchar(JsValueRef value, const wchar_t **stringValue, size_t *length)
+    static JsErrorCode WINAPI JsValueToCharCopy(JsValueRef value, char **stringValue, size_t *length)
     {
         JsValueRef strValue;
         IfJsrtErrorFailLogAndRetErrorCode(ChakraRTInterface::JsConvertValueToString(value, &strValue));
-        IfJsrtErrorFailLogAndRetErrorCode(ChakraRTInterface::JsStringToPointer(strValue, stringValue, length));
+        IfJsrtErrorFailLogAndRetErrorCode(ChakraRTInterface::JsStringToPointerUtf8Copy(strValue, stringValue, length));
         return JsNoError;
     }
 
@@ -300,6 +286,8 @@ public:
     static JsErrorCode WINAPI JsSerializeScriptUtf8(const char *script, ChakraBytePtr buffer, unsigned int *bufferSize) { return HOOK_JS_API(SerializeScriptUtf8(script, buffer, bufferSize)); }
     static JsErrorCode WINAPI JsRunSerializedScriptUtf8(JsSerializedScriptLoadUtf8SourceCallback scriptLoadCallback, JsSerializedScriptUnloadCallback scriptUnloadCallback, ChakraBytePtr buffer, JsSourceContext sourceContext, const char *sourceUrl, JsValueRef * result) { return HOOK_JS_API(RunSerializedScriptUtf8(scriptLoadCallback, scriptUnloadCallback, buffer, sourceContext, sourceUrl, result)); }
     static JsErrorCode WINAPI JsRunModuleUtf8(const char *script, JsSourceContext sourceContext, const char *sourceUrl, JsValueRef *result) { return HOOK_JS_API(ExperimentalApiRunModuleUtf8(script, sourceContext, sourceUrl, result)); }
+    static JsErrorCode WINAPI JsPointerToStringUtf8(const char *stringValue, size_t length, JsValueRef *value) { return HOOK_JS_API(PointerToStringUtf8(stringValue, length, value)); }
+    static JsErrorCode WINAPI JsStringFree(char *stringValue) { return HOOK_JS_API(StringFree(stringValue)); }
 };
 
 class AutoRestoreContext

--- a/bin/ch/Debugger.h
+++ b/bin/ch/Debugger.h
@@ -5,13 +5,12 @@
 #pragma once
 
 #ifdef _WIN32
-static const WCHAR controllerScript[] = {
+static const char controllerScript[] = {
 #include "DbgController.js.encoded"
-    _u('\0')
+    '\0'
 };
 #else
-// xplat-todo: Need to generate DbgController.js.encoded
-static const WCHAR controllerScript[] = { _u('\0') };
+static const char controllerScript[] = { '\0' };
 #endif
     
 class Debugger
@@ -37,8 +36,8 @@ private:
     bool InstallDebugCallbacks(JsValueRef hostDebugObject);
     bool SetBaseline();
     bool SetInspectMaxStringLength();
-    bool CallFunction(char16 const * functionName, JsValueRef *result, JsValueRef arg1 = JS_INVALID_REFERENCE, JsValueRef arg2 = JS_INVALID_REFERENCE);
-    bool CallFunctionNoResult(char16 const * functionName, JsValueRef arg1 = JS_INVALID_REFERENCE, JsValueRef arg2 = JS_INVALID_REFERENCE);
+    bool CallFunction(char const * functionName, JsValueRef *result, JsValueRef arg1 = JS_INVALID_REFERENCE, JsValueRef arg2 = JS_INVALID_REFERENCE);
+    bool CallFunctionNoResult(char const * functionName, JsValueRef arg1 = JS_INVALID_REFERENCE, JsValueRef arg2 = JS_INVALID_REFERENCE);
 public:
     static void CALLBACK DebugEventHandler(_In_ JsDiagDebugEvent debugEvent, _In_ JsValueRef eventData, _In_opt_ void* callbackState);
     static JsValueRef CALLBACK GetSource(JsValueRef callee, bool isConstructCall, JsValueRef *arguments, unsigned short argumentCount, void *callbackState);

--- a/bin/ch/WScriptJsrt.cpp
+++ b/bin/ch/WScriptJsrt.cpp
@@ -7,6 +7,28 @@
 MessageQueue* WScriptJsrt::messageQueue = nullptr;
 DWORD_PTR WScriptJsrt::sourceContext = 0;
 
+#define ERROR_MESSAGE_TO_STRING(errorCode, errorMessage, errorMessageString)        \
+    JsErrorCode errorCode = JsNoError;                                              \
+    do                                                                              \
+    {                                                                               \
+        const char *outOfMemoryString =                                             \
+                                    "Failed to convert wide string. Out of memory?";\
+                                                                                    \
+        char *errorMessageNarrow;                                                   \
+        if (FAILED(WideStringToNarrowDynamic(errorMessage, &errorMessageNarrow)))   \
+        {                                                                           \
+            errorCode = ChakraRTInterface::JsPointerToStringUtf8(outOfMemoryString, \
+                        strlen(outOfMemoryString), &errorMessageString);            \
+        }                                                                           \
+        else                                                                        \
+        {                                                                           \
+            errorCode = ChakraRTInterface::JsPointerToStringUtf8(errorMessageNarrow,\
+                        strlen(errorMessageNarrow), &errorMessageString);           \
+            free(errorMessageNarrow);                                               \
+        }                                                                           \
+    }                                                                               \
+    while(0)
+
 DWORD_PTR WScriptJsrt::GetNextSourceContext()
 {
     return sourceContext++;
@@ -27,7 +49,15 @@ bool WScriptJsrt::CreateArgumentsObject(JsValueRef *argsObject)
         JsValueRef value;
         JsValueRef index;
 
-        IfJsrtErrorFail(ChakraRTInterface::JsPointerToString(argv[i], wcslen(argv[i]), &value), false);
+        char *argNarrow;
+        if (FAILED(WideStringToNarrowDynamic(argv[i], &argNarrow)))
+        {
+            return false;
+        }
+        JsErrorCode errCode  = ChakraRTInterface::JsPointerToStringUtf8(argNarrow, strlen(argNarrow), &value);
+        free(argNarrow);
+        IfJsrtErrorFail(errCode, false);
+
         IfJsrtErrorFail(ChakraRTInterface::JsDoubleToNumber(i, &index), false);
         IfJsrtErrorFail(ChakraRTInterface::JsSetIndexedProperty(retArr, index, value), false);
     }
@@ -45,16 +75,19 @@ JsValueRef __stdcall WScriptJsrt::EchoCallback(JsValueRef callee, bool isConstru
         JsErrorCode error = ChakraRTInterface::JsConvertValueToString(arguments[i], &strValue);
         if (error == JsNoError)
         {
-            LPCWSTR str = nullptr;
+            AutoString str;
             size_t length;
-            error = ChakraRTInterface::JsStringToPointer(strValue, &str, &length);
+            error = ChakraRTInterface::JsStringToPointerUtf8Copy(strValue, &str, &length);
             if (error == JsNoError)
             {
                 if (i > 1)
                 {
                     wprintf(_u(" "));
                 }
-                wprintf(_u("%ls"), str);
+                LPWSTR wstr = nullptr;
+                NarrowStringToWideDynamic(*str, &wstr);
+                wprintf(_u("%ls"), wstr);
+                free(wstr);
             }
         }
 
@@ -117,31 +150,28 @@ JsValueRef WScriptJsrt::LoadScriptFileHelper(JsValueRef callee, JsValueRef *argu
     else
     {
         LPCSTR fileContent;
-        const wchar_t *fileName;
-        const wchar_t *scriptInjectType = _u("self");
+        AutoString fileName;
+        AutoString scriptInjectType;
         size_t fileNameLength;
         size_t scriptInjectTypeLength;
-        char *fileNameNarrow;
 
-        IfJsrtErrorSetGo(ChakraRTInterface::JsStringToPointer(arguments[1], &fileName, &fileNameLength));
+        IfJsrtErrorSetGo(ChakraRTInterface::JsStringToPointerUtf8Copy(arguments[1], &fileName, &fileNameLength));
 
         if (argumentCount > 2)
         {
-            IfJsrtErrorSetGo(ChakraRTInterface::JsStringToPointer(arguments[2], &scriptInjectType, &scriptInjectTypeLength));
+            IfJsrtErrorSetGo(ChakraRTInterface::JsStringToPointerUtf8Copy(arguments[2], &scriptInjectType, &scriptInjectTypeLength));
         }
 
         if (errorCode == JsNoError)
         {
-            IfFailGo(WideStringToNarrowDynamic(fileName, &fileNameNarrow));
-            hr = Helpers::LoadScriptFromFile(fileNameNarrow, fileContent);
+            hr = Helpers::LoadScriptFromFile(*fileName, fileContent);
             if (FAILED(hr))
             {
                 fwprintf(stderr, _u("Couldn't load file.\n"));
             }
             else
             {
-                returnValue = LoadScript(callee, fileNameNarrow, fileContent, scriptInjectType, isSourceModule);
-                free(fileNameNarrow);
+                returnValue = LoadScript(callee, *fileName, fileContent, *scriptInjectType ? *scriptInjectType : "self", isSourceModule);
             }
         }
     }
@@ -156,7 +186,8 @@ Error:
             errorMessage = ConvertErrorCodeToMessage(errorCode);
         }
 
-        ChakraRTInterface::JsPointerToString(errorMessage, wcslen(errorMessage), &errorMessageString);
+        ERROR_MESSAGE_TO_STRING(errCode, errorMessage, errorMessageString);
+
         ChakraRTInterface::JsCreateError(errorMessageString, &errorObject);
         ChakraRTInterface::JsSetException(errorObject);
     }
@@ -188,38 +219,30 @@ JsValueRef WScriptJsrt::LoadScriptHelper(JsValueRef callee, bool isConstructCall
     }
     else
     {
-        const wchar_t *fileContent;
-        char *fileName = nullptr;
-        const wchar_t *scriptInjectType = _u("self");
+        AutoString fileContent;
+        AutoString fileName;
+        AutoString scriptInjectType;
         size_t fileContentLength;
         size_t scriptInjectTypeLength;
 
-        IfJsrtErrorSetGo(ChakraRTInterface::JsStringToPointer(arguments[1], &fileContent, &fileContentLength));
+        IfJsrtErrorSetGo(ChakraRTInterface::JsStringToPointerUtf8Copy(arguments[1], &fileContent, &fileContentLength));
 
         if (argumentCount > 2)
         {
-            IfJsrtErrorSetGo(ChakraRTInterface::JsStringToPointer(arguments[2], &scriptInjectType, &scriptInjectTypeLength));
+            IfJsrtErrorSetGo(ChakraRTInterface::JsStringToPointerUtf8Copy(arguments[2], &scriptInjectType, &scriptInjectTypeLength));
 
             if (argumentCount > 3)
             {
-                size_t fileNameWideLength = 0;
-                const wchar_t* fileNameWide = nullptr;
-                IfJsrtErrorSetGo(ChakraRTInterface::JsStringToPointer(arguments[3], &fileNameWide, &fileNameWideLength));
-                IfFailGo(WideStringToNarrowDynamic(fileNameWide, &fileName));
+                size_t unused;
+                IfJsrtErrorSetGo(ChakraRTInterface::JsStringToPointerUtf8Copy(arguments[3], &fileName, &unused));
             }
         }
 
-        utf8::WideToNarrow script(fileContent);
-        if (script)
+        if (*fileContent)
         {
             // TODO: This is CESU-8. How to tell the engine?
             // TODO: How to handle this source (script) life time?
-            returnValue = LoadScript(callee, fileName, script, scriptInjectType, isSourceModule);
-        }
-
-        if (fileName)
-        {
-            free(fileName);
+            returnValue = LoadScript(callee, *fileName, *fileContent, *scriptInjectType ? *scriptInjectType : "self", isSourceModule);
         }
     }
 
@@ -233,7 +256,8 @@ Error:
             errorMessage = ConvertErrorCodeToMessage(errorCode);
         }
 
-        ChakraRTInterface::JsPointerToString(errorMessage, wcslen(errorMessage), &errorMessageString);
+        ERROR_MESSAGE_TO_STRING(errCode, errorMessage, errorMessageString);
+
         ChakraRTInterface::JsCreateError(errorMessageString, &errorObject);
         ChakraRTInterface::JsSetException(errorObject);
     }
@@ -241,12 +265,11 @@ Error:
     return returnValue;
 }
 
-JsValueRef WScriptJsrt::LoadScript(JsValueRef callee, LPCSTR fileName, LPCSTR fileContent, LPCWSTR scriptInjectType, bool isSourceModule)
+JsValueRef WScriptJsrt::LoadScript(JsValueRef callee, LPCSTR fileName, LPCSTR fileContent, LPCSTR scriptInjectType, bool isSourceModule)
 {
     HRESULT hr = E_FAIL;
     JsErrorCode errorCode = JsNoError;
     LPCWSTR errorMessage = _u("Internal error.");
-    size_t errorMessageLength = wcslen(errorMessage);
     JsValueRef returnValue = JS_INVALID_REFERENCE;
     JsErrorCode innerErrorCode = JsNoError;
     JsContextRef currentContext = JS_INVALID_REFERENCE;
@@ -278,7 +301,7 @@ JsValueRef WScriptJsrt::LoadScript(JsValueRef callee, LPCSTR fileName, LPCSTR fi
         strcpy_s(fullPathNarrow, "script.js");
     }
 
-    if (wcscmp(scriptInjectType, _u("self")) == 0)
+    if (strcmp(scriptInjectType, "self") == 0)
     {
         JsContextRef calleeContext;
         IfJsrtErrorSetGo(ChakraRTInterface::JsGetContextOfObject(callee, &calleeContext));
@@ -301,7 +324,7 @@ JsValueRef WScriptJsrt::LoadScript(JsValueRef callee, LPCSTR fileName, LPCSTR fi
 
         IfJsrtErrorSetGo(ChakraRTInterface::JsSetCurrentContext(currentContext));
     }
-    else if (wcscmp(scriptInjectType, _u("samethread")) == 0)
+    else if (strcmp(scriptInjectType, "samethread") == 0)
     {
         JsValueRef newContext = JS_INVALID_REFERENCE;
 
@@ -348,14 +371,15 @@ Error:
 
         JsValueRef error = JS_INVALID_REFERENCE;
         JsValueRef messageProperty = JS_INVALID_REFERENCE;
-        errorMessageLength = wcslen(errorMessage);
-        innerErrorCode = ChakraRTInterface::JsPointerToString(errorMessage, errorMessageLength, &messageProperty);
-        if (innerErrorCode == JsNoError)
+
+        ERROR_MESSAGE_TO_STRING(errCode, errorMessage, messageProperty);
+
+        if (errCode == JsNoError)
         {
-            innerErrorCode = ChakraRTInterface::JsCreateError(messageProperty, &error);
-            if (innerErrorCode == JsNoError)
+            errCode = ChakraRTInterface::JsCreateError(messageProperty, &error);
+            if (errCode == JsNoError)
             {
-                innerErrorCode = ChakraRTInterface::JsSetException(error);
+                errCode = ChakraRTInterface::JsSetException(error);
             }
         }
 
@@ -397,7 +421,7 @@ Error:
     JsValueRef errorObject;
     JsValueRef errorMessageString;
 
-    JsErrorCode errorCode = ChakraRTInterface::JsPointerToString(errorMessage, wcslen(errorMessage), &errorMessageString);
+    ERROR_MESSAGE_TO_STRING(errorCode, errorMessage, errorMessageString);
 
     if (errorCode != JsNoError)
     {
@@ -440,7 +464,7 @@ Error:
     JsValueRef errorObject;
     JsValueRef errorMessageString;
 
-    JsErrorCode errorCode = ChakraRTInterface::JsPointerToString(errorMessage, wcslen(errorMessage), &errorMessageString);
+    ERROR_MESSAGE_TO_STRING(errorCode, errorMessage, errorMessageString);
 
     if (errorCode != JsNoError)
     {
@@ -490,7 +514,9 @@ JsValueRef WScriptJsrt::AttachCallback(JsValueRef callee, bool isConstructCall, 
 Error:
     JsValueRef errorObject;
     JsValueRef errorMessageString;
-    JsErrorCode errorCode = ChakraRTInterface::JsPointerToString(errorMessage, wcslen(errorMessage), &errorMessageString);
+
+    ERROR_MESSAGE_TO_STRING(errorCode, errorMessage, errorMessageString);
+
     if (errorCode != JsNoError)
     {
         errorCode = ChakraRTInterface::JsCreateError(errorMessageString, &errorObject);
@@ -531,7 +557,9 @@ JsValueRef WScriptJsrt::DetachCallback(JsValueRef callee, bool isConstructCall, 
 Error:
     JsValueRef errorObject;
     JsValueRef errorMessageString;
-    JsErrorCode errorCode = ChakraRTInterface::JsPointerToString(errorMessage, wcslen(errorMessage), &errorMessageString);
+
+    ERROR_MESSAGE_TO_STRING(errorCode, errorMessage, errorMessageString);
+
     if (errorCode != JsNoError)
     {
         errorCode = ChakraRTInterface::JsCreateError(errorMessageString, &errorObject);
@@ -583,19 +611,19 @@ JsValueRef WScriptJsrt::EmptyCallback(JsValueRef callee, bool isConstructCall, J
     return JS_INVALID_REFERENCE;
 }
 
-bool WScriptJsrt::CreateNamedFunction(const char16* nameString, JsNativeFunction callback, JsValueRef* functionVar)
+bool WScriptJsrt::CreateNamedFunction(const char* nameString, JsNativeFunction callback, JsValueRef* functionVar)
 {
     JsValueRef nameVar;
-    IfJsrtErrorFail(ChakraRTInterface::JsPointerToString(nameString, wcslen(nameString), &nameVar), false);
+    IfJsrtErrorFail(ChakraRTInterface::JsPointerToStringUtf8(nameString, strlen(nameString), &nameVar), false);
     IfJsrtErrorFail(ChakraRTInterface::JsCreateNamedFunction(nameVar, callback, nullptr, functionVar), false);
     return true;
 }
 
-bool WScriptJsrt::InstallObjectsOnObject(JsValueRef object, const char16* name, JsNativeFunction nativeFunction)
+bool WScriptJsrt::InstallObjectsOnObject(JsValueRef object, const char* name, JsNativeFunction nativeFunction)
 {
     JsValueRef propertyValueRef;
     JsPropertyIdRef propertyId;
-    IfJsrtErrorFail(ChakraRTInterface::JsGetPropertyIdFromName(name, &propertyId), false);
+    IfJsrtErrorFail(ChakraRTInterface::JsGetPropertyIdFromNameUtf8(name, &propertyId), false);
     CreateNamedFunction(name, nativeFunction, &propertyValueRef);
     IfJsrtErrorFail(ChakraRTInterface::JsSetProperty(object, propertyId, propertyValueRef, true), false);
     return true;
@@ -607,21 +635,21 @@ bool WScriptJsrt::Initialize()
     JsValueRef wscript;
     IfJsrtErrorFail(ChakraRTInterface::JsCreateObject(&wscript), false);
 
-    IfFalseGo(WScriptJsrt::InstallObjectsOnObject(wscript, _u("Echo"), EchoCallback));
-    IfFalseGo(WScriptJsrt::InstallObjectsOnObject(wscript, _u("Quit"), QuitCallback));
-    IfFalseGo(WScriptJsrt::InstallObjectsOnObject(wscript, _u("LoadScriptFile"), LoadScriptFileCallback));
-    IfFalseGo(WScriptJsrt::InstallObjectsOnObject(wscript, _u("LoadModuleFile"), LoadModuleFileCallback));
-    IfFalseGo(WScriptJsrt::InstallObjectsOnObject(wscript, _u("LoadScript"), LoadScriptCallback));
-    IfFalseGo(WScriptJsrt::InstallObjectsOnObject(wscript, _u("LoadModule"), LoadModuleCallback));
-    IfFalseGo(WScriptJsrt::InstallObjectsOnObject(wscript, _u("SetTimeout"), SetTimeoutCallback));
-    IfFalseGo(WScriptJsrt::InstallObjectsOnObject(wscript, _u("ClearTimeout"), ClearTimeoutCallback));
-    IfFalseGo(WScriptJsrt::InstallObjectsOnObject(wscript, _u("Attach"), AttachCallback));
-    IfFalseGo(WScriptJsrt::InstallObjectsOnObject(wscript, _u("Detach"), DetachCallback));
-    IfFalseGo(WScriptJsrt::InstallObjectsOnObject(wscript, _u("DumpFunctionPosition"), DumpFunctionPositionCallback));
-    IfFalseGo(WScriptJsrt::InstallObjectsOnObject(wscript, _u("RequestAsyncBreak"), RequestAsyncBreakCallback));
+    IfFalseGo(WScriptJsrt::InstallObjectsOnObject(wscript, "Echo", EchoCallback));
+    IfFalseGo(WScriptJsrt::InstallObjectsOnObject(wscript, "Quit", QuitCallback));
+    IfFalseGo(WScriptJsrt::InstallObjectsOnObject(wscript, "LoadScriptFile", LoadScriptFileCallback));
+    IfFalseGo(WScriptJsrt::InstallObjectsOnObject(wscript, "LoadModuleFile", LoadModuleFileCallback));
+    IfFalseGo(WScriptJsrt::InstallObjectsOnObject(wscript, "LoadScript", LoadScriptCallback));
+    IfFalseGo(WScriptJsrt::InstallObjectsOnObject(wscript, "LoadModule", LoadModuleCallback));
+    IfFalseGo(WScriptJsrt::InstallObjectsOnObject(wscript, "SetTimeout", SetTimeoutCallback));
+    IfFalseGo(WScriptJsrt::InstallObjectsOnObject(wscript, "ClearTimeout", ClearTimeoutCallback));
+    IfFalseGo(WScriptJsrt::InstallObjectsOnObject(wscript, "Attach", AttachCallback));
+    IfFalseGo(WScriptJsrt::InstallObjectsOnObject(wscript, "Detach", DetachCallback));
+    IfFalseGo(WScriptJsrt::InstallObjectsOnObject(wscript, "DumpFunctionPosition", DumpFunctionPositionCallback));
+    IfFalseGo(WScriptJsrt::InstallObjectsOnObject(wscript, "RequestAsyncBreak", RequestAsyncBreakCallback));
 
     // ToDo Remove
-    IfFalseGo(WScriptJsrt::InstallObjectsOnObject(wscript, _u("Edit"), EmptyCallback));
+    IfFalseGo(WScriptJsrt::InstallObjectsOnObject(wscript, "Edit", EmptyCallback));
 
     JsValueRef argsObject;
 
@@ -631,16 +659,16 @@ bool WScriptJsrt::Initialize()
     }
 
     JsPropertyIdRef argsName;
-    IfJsrtErrorFail(ChakraRTInterface::JsGetPropertyIdFromName(_u("Arguments"), &argsName), false);
+    IfJsrtErrorFail(ChakraRTInterface::JsGetPropertyIdFromNameUtf8("Arguments", &argsName), false);
     IfJsrtErrorFail(ChakraRTInterface::JsSetProperty(wscript, argsName, argsObject, true), false);
 
     JsPropertyIdRef wscriptName;
-    IfJsrtErrorFail(ChakraRTInterface::JsGetPropertyIdFromName(_u("WScript"), &wscriptName), false);
+    IfJsrtErrorFail(ChakraRTInterface::JsGetPropertyIdFromNameUtf8("WScript", &wscriptName), false);
     JsValueRef global;
     IfJsrtErrorFail(ChakraRTInterface::JsGetGlobalObject(&global), false);
     IfJsrtErrorFail(ChakraRTInterface::JsSetProperty(global, wscriptName, wscript, true), false);
 
-    IfFalseGo(WScriptJsrt::InstallObjectsOnObject(global, _u("print"), EchoCallback));
+    IfFalseGo(WScriptJsrt::InstallObjectsOnObject(global, "print", EchoCallback));
 
 Error:
     return hr == S_OK;
@@ -655,13 +683,15 @@ bool WScriptJsrt::PrintException(LPCSTR fileName, JsErrorCode jsErrorCode)
     {
         if (jsErrorCode == JsErrorCode::JsErrorScriptCompile || jsErrorCode == JsErrorCode::JsErrorScriptException)
         {
-            LPCWSTR errorMessage = nullptr;
+            AutoString errorMessage;
             size_t errorMessageLength = 0;
 
             JsValueRef errorString = JS_INVALID_REFERENCE;
 
             IfJsrtErrorFail(ChakraRTInterface::JsConvertValueToString(exception, &errorString), false);
-            IfJsrtErrorFail(ChakraRTInterface::JsStringToPointer(errorString, &errorMessage, &errorMessageLength), false);
+            IfJsrtErrorFail(ChakraRTInterface::JsStringToPointerUtf8Copy(errorString, &errorMessage, &errorMessageLength), false);
+            AutoWideString wideErrorMessage;
+            NarrowStringToWideDynamic(*errorMessage, &wideErrorMessage);
 
             if (jsErrorCode == JsErrorCode::JsErrorScriptCompile)
             {
@@ -674,28 +704,28 @@ bool WScriptJsrt::PrintException(LPCSTR fileName, JsErrorCode jsErrorCode)
                 int line;
                 int column;
 
-                IfJsrtErrorFail(ChakraRTInterface::JsGetPropertyIdFromName(_u("line"), &linePropertyId), false);
+                IfJsrtErrorFail(ChakraRTInterface::JsGetPropertyIdFromNameUtf8("line", &linePropertyId), false);
                 IfJsrtErrorFail(ChakraRTInterface::JsGetProperty(exception, linePropertyId, &lineProperty), false);
                 IfJsrtErrorFail(ChakraRTInterface::JsNumberToInt(lineProperty, &line), false);
 
-                IfJsrtErrorFail(ChakraRTInterface::JsGetPropertyIdFromName(_u("column"), &columnPropertyId), false);
+                IfJsrtErrorFail(ChakraRTInterface::JsGetPropertyIdFromNameUtf8("column", &columnPropertyId), false);
                 IfJsrtErrorFail(ChakraRTInterface::JsGetProperty(exception, columnPropertyId, &columnProperty), false);
                 IfJsrtErrorFail(ChakraRTInterface::JsNumberToInt(columnProperty, &column), false);
 
                 CHAR shortFileName[_MAX_PATH];
                 CHAR ext[_MAX_EXT];
                 _splitpath_s(fileName, nullptr, 0, nullptr, 0, shortFileName, _countof(shortFileName), ext, _countof(ext));
-                fwprintf(stderr, _u("%ls\n\tat code (%S%S:%d:%d)\n"), errorMessage, shortFileName, ext, (int)line + 1, (int)column + 1);
+                fwprintf(stderr, _u("%ls\n\tat code (%S%S:%d:%d)\n"), *wideErrorMessage, shortFileName, ext, (int)line + 1, (int)column + 1);
             }
             else
             {
                 JsValueType propertyType = JsUndefined;
                 JsPropertyIdRef stackPropertyId = JS_INVALID_REFERENCE;
                 JsValueRef stackProperty = JS_INVALID_REFERENCE;
-                LPCWSTR errorStack = nullptr;
+                AutoString errorStack;
                 size_t errorStackLength = 0;
 
-                JsErrorCode errorCode = ChakraRTInterface::JsGetPropertyIdFromName(_u("stack"), &stackPropertyId);
+                JsErrorCode errorCode = ChakraRTInterface::JsGetPropertyIdFromNameUtf8("stack", &stackPropertyId);
 
                 if (errorCode == JsErrorCode::JsNoError)
                 {
@@ -711,12 +741,14 @@ bool WScriptJsrt::PrintException(LPCSTR fileName, JsErrorCode jsErrorCode)
                     const char *fName = fileName != nullptr ? fileName : "(unknown)";
                     // do not mix char/wchar. print them separately
                     fprintf(stderr, "thrown at %s:\n^\n", fName);
-                    fwprintf(stderr, _u("%ls\n"), errorMessage);
+                    fwprintf(stderr, _u("%ls\n"), *wideErrorMessage);
                 }
                 else
                 {
-                    IfJsrtErrorFail(ChakraRTInterface::JsStringToPointer(stackProperty, &errorStack, &errorStackLength), false);
-                    fwprintf(stderr, _u("%ls\n"), errorStack);
+                    IfJsrtErrorFail(ChakraRTInterface::JsStringToPointerUtf8Copy(stackProperty, &errorStack, &errorStackLength), false);
+                    AutoWideString wideErrorStack;
+                    NarrowStringToWideDynamic(*errorStack, &wideErrorStack);
+                    fwprintf(stderr, _u("%ls\n"), *wideErrorStack);
                 }
             }
         }
@@ -785,14 +817,14 @@ HRESULT WScriptJsrt::CallbackMessage::CallFunction(LPCSTR fileName)
 
     if (type == JsString)
     {
-        LPCWSTR script = nullptr;
+        AutoString script;
         size_t length = 0;
 
         IfJsrtErrorHR(ChakraRTInterface::JsConvertValueToString(m_function, &stringValue));
-        IfJsrtErrorHR(ChakraRTInterface::JsStringToPointer(stringValue, &script, &length));
+        IfJsrtErrorHR(ChakraRTInterface::JsStringToPointerUtf8Copy(stringValue, &script, &length));
 
         // Run the code
-        errorCode = ChakraRTInterface::JsRunScript(script, JS_SOURCE_CONTEXT_NONE, _u("") /*sourceUrl*/, nullptr /*no result needed*/);
+        errorCode = ChakraRTInterface::JsRunScriptUtf8(*script, JS_SOURCE_CONTEXT_NONE, "" /*sourceUrl*/, nullptr /*no result needed*/);
     }
     else
     {

--- a/bin/ch/WScriptJsrt.h
+++ b/bin/ch/WScriptJsrt.h
@@ -58,14 +58,14 @@ public:
     }
 
     static bool PrintException(LPCSTR fileName, JsErrorCode jsErrorCode);
-    static JsValueRef LoadScript(JsValueRef callee, LPCSTR fileName, LPCSTR fileContent, LPCWSTR scriptInjectType, bool isSourceModule);
+    static JsValueRef LoadScript(JsValueRef callee, LPCSTR fileName, LPCSTR fileContent, LPCSTR scriptInjectType, bool isSourceModule);
     static DWORD_PTR GetNextSourceContext();
     static JsValueRef LoadScriptFileHelper(JsValueRef callee, JsValueRef *arguments, unsigned short argumentCount, bool isSourceModule);
     static JsValueRef LoadScriptHelper(JsValueRef callee, bool isConstructCall, JsValueRef *arguments, unsigned short argumentCount, void *callbackState, bool isSourceModule);
-    static bool InstallObjectsOnObject(JsValueRef object, const char16* name, JsNativeFunction nativeFunction);
+    static bool InstallObjectsOnObject(JsValueRef object, const char* name, JsNativeFunction nativeFunction);
 private:
     static bool CreateArgumentsObject(JsValueRef *argsObject);
-    static bool CreateNamedFunction(const char16*, JsNativeFunction callback, JsValueRef* functionVar);
+    static bool CreateNamedFunction(const char*, JsNativeFunction callback, JsValueRef* functionVar);
     static JsValueRef __stdcall EchoCallback(JsValueRef callee, bool isConstructCall, JsValueRef *arguments, unsigned short argumentCount, void *callbackState);
     static JsValueRef __stdcall QuitCallback(JsValueRef callee, bool isConstructCall, JsValueRef *arguments, unsigned short argumentCount, void *callbackState);
     static JsValueRef __stdcall LoadModuleFileCallback(JsValueRef callee, bool isConstructCall, JsValueRef *arguments, unsigned short argumentCount, void *callbackState);

--- a/bin/ch/stdafx.h
+++ b/bin/ch/stdafx.h
@@ -140,3 +140,33 @@ do { \
 #include "MessageQueue.h"
 #include "WScriptJsrt.h"
 #include "Debugger.h"
+
+template<class T, bool JSRTHeap>
+class AutoStringPtr
+{
+    T* data;
+public:
+    AutoStringPtr():data(nullptr) { }
+    ~AutoStringPtr()
+    {
+        if (data == nullptr)
+        {
+            return;
+        }
+
+        if (JSRTHeap)
+        {
+            ChakraRTInterface::JsStringFree((char*)data);
+        }
+        else
+        {
+            free(data);
+        }
+    }
+
+    T* operator*() { return data; }
+    T** operator&()  { return &data; }
+};
+
+typedef AutoStringPtr<char, true> AutoString;
+typedef AutoStringPtr<wchar_t, false> AutoWideString;

--- a/lib/Jsrt/ChakraCommon.h
+++ b/lib/Jsrt/ChakraCommon.h
@@ -596,20 +596,6 @@ typedef unsigned char* ChakraBytePtr;
     /// <param name="callbackState">The data argument to be passed to the callback.</param>
     typedef bool (CHAKRA_CALLBACK *JsThreadServiceCallback)(_In_ JsBackgroundWorkItemCallback callback, _In_opt_ void *callbackState);
 
-#ifdef _WIN32
-    /// <summary>
-    ///     Called by the runtime to load the source code of the serialized script.
-    ///     The caller must keep the script buffer valid until the JsSerializedScriptUnloadCallback.
-    ///     This callback is only supported by the Win32 version of the API
-    /// </summary>
-    /// <param name="sourceContext">The context passed to Js[Parse|Run]SerializedScriptWithCallback</param>
-    /// <param name="scriptBuffer">The script returned.</param>
-    /// <returns>
-    ///     true if the operation succeeded, false otherwise.
-    /// </returns>
-    typedef bool (CHAKRA_CALLBACK * JsSerializedScriptLoadSourceCallback)(_In_ JsSourceContext sourceContext, _Outptr_result_z_ const wchar_t** scriptBuffer);
-#endif // _WIN32
-
     /// <summary>
     ///     Called by the runtime when it is finished with all resources related to the script execution.
     ///     The caller should free the source if loaded, the byte code, and the context at this time.
@@ -1016,359 +1002,6 @@ typedef unsigned char* ChakraBytePtr;
         JsIdle(
             _Out_opt_ unsigned int *nextIdleTick);
 
-#ifdef _WIN32
-#define CSTR_TYPE wchar_t
-#else // !_WIN32
-// non-Windows ChakraCore overrides wchar_t to char16_t
-#define CSTR_TYPE char16_t
-#endif // _WIN32
-
-    /// <summary>
-    ///     Parses a script and returns a function representing the script.
-    /// </summary>
-    /// <remarks>
-    ///     Requires an active script context.
-    /// </remarks>
-    /// <param name="script">The script to parse.</param>
-    /// <param name="sourceContext">
-    ///     A cookie identifying the script that can be used by debuggable script contexts.
-    /// </param>
-    /// <param name="sourceUrl">The location the script came from.</param>
-    /// <param name="result">A function representing the script code.</param>
-    /// <returns>
-    ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
-    /// </returns>
-    CHAKRA_API
-        JsParseScript(
-            _In_z_ const CSTR_TYPE *script,
-            _In_ JsSourceContext sourceContext,
-            _In_z_ const CSTR_TYPE *sourceUrl,
-            _Out_ JsValueRef *result);
-
-    /// <summary>
-    ///     Parses a script and returns a function representing the script.
-    /// </summary>
-    /// <remarks>
-    ///     Requires an active script context.
-    /// </remarks>
-    /// <param name="script">The script to parse.</param>
-    /// <param name="sourceContext">
-    ///     A cookie identifying the script that can be used by debuggable script contexts.
-    /// </param>
-    /// <param name="sourceUrl">The location the script came from.</param>
-    /// <param name="parseAttributes">Attribute mask for parsing the script</param>
-    /// <param name="result">A function representing the script code.</param>
-    /// <returns>
-    ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
-    /// </returns>
-    CHAKRA_API
-        JsParseScriptWithAttributes(
-            _In_z_ const CSTR_TYPE *script,
-            _In_ JsSourceContext sourceContext,
-            _In_z_ const CSTR_TYPE *sourceUrl,
-            _In_ JsParseScriptAttributes parseAttributes,
-            _Out_ JsValueRef *result);
-
-    /// <summary>
-    ///     Executes a script.
-    /// </summary>
-    /// <remarks>
-    ///     Requires an active script context.
-    /// </remarks>
-    /// <param name="script">The script to run.</param>
-    /// <param name="sourceContext">
-    ///     A cookie identifying the script that can be used by debuggable script contexts.
-    /// </param>
-    /// <param name="sourceUrl">The location the script came from.</param>
-    /// <param name="result">The result of the script, if any. This parameter can be null.</param>
-    /// <returns>
-    ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
-    /// </returns>
-    CHAKRA_API
-        JsRunScript(
-            _In_z_ const CSTR_TYPE *script,
-            _In_ JsSourceContext sourceContext,
-            _In_z_ const CSTR_TYPE *sourceUrl,
-            _Out_ JsValueRef *result);
-
-    /// <summary>
-    ///     Executes a module.
-    /// </summary>
-    /// <remarks>
-    ///     Requires an active script context.
-    /// </remarks>
-    /// <param name="script">The module script to parse and execute.</param>
-    /// <param name="sourceContext">
-    ///     A cookie identifying the script that can be used by debuggable script contexts.
-    /// </param>
-    /// <param name="sourceUrl">The location the module script came from.</param>
-    /// <param name="result">The result of executing the module script, if any. This parameter can be null.</param>
-    /// <returns>
-    ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
-    /// </returns>
-    CHAKRA_API
-        JsExperimentalApiRunModule(
-            _In_z_ const CSTR_TYPE *script,
-            _In_ JsSourceContext sourceContext,
-            _In_z_ const CSTR_TYPE *sourceUrl,
-            _Out_ JsValueRef *result);
-
-    /// <summary>
-    ///     Serializes a parsed script to a buffer than can be reused.
-    /// </summary>
-    /// <remarks>
-    ///     <para>
-    ///     <c>JsSerializeScript</c> parses a script and then stores the parsed form of the script in a
-    ///     runtime-independent format. The serialized script then can be deserialized in any
-    ///     runtime without requiring the script to be re-parsed.
-    ///     </para>
-    ///     <para>
-    ///     Requires an active script context.
-    ///     </para>
-    /// </remarks>
-    /// <param name="script">The script to serialize.</param>
-    /// <param name="buffer">The buffer to put the serialized script into. Can be null.</param>
-    /// <param name="bufferSize">
-    ///     On entry, the size of the buffer, in bytes; on exit, the size of the buffer, in bytes,
-    ///     required to hold the serialized script.
-    /// </param>
-    /// <returns>
-    ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
-    /// </returns>
-    CHAKRA_API
-        JsSerializeScript(
-            _In_z_ const CSTR_TYPE *script,
-            _Out_writes_to_opt_(*bufferSize, *bufferSize) BYTE *buffer,
-            _Inout_ unsigned int *bufferSize);
-
-#ifdef _WIN32
-    /// <summary>
-    ///     Parses a serialized script and returns a function representing the script.
-    ///     Provides the ability to lazy load the script source only if/when it is needed.
-    /// </summary>
-    /// <remarks>
-    ///     <para>
-    ///     Requires an active script context.
-    ///     </para>
-    ///     <para>
-    ///     The runtime will hold on to the buffer until all instances of any functions created from
-    ///     the buffer are garbage collected.  It will then call scriptUnloadCallback to inform the
-    ///     caller it is safe to release.
-    ///     </para>
-    /// </remarks>
-    /// <param name="scriptLoadCallback">Callback called when the source code of the script needs to be loaded.</param>
-    /// <param name="scriptUnloadCallback">Callback called when the serialized script and source code are no longer needed.</param>
-    /// <param name="buffer">The serialized script.</param>
-    /// <param name="sourceContext">
-    ///     A cookie identifying the script that can be used by debuggable script contexts.
-    ///     This context will passed into scriptLoadCallback and scriptUnloadCallback.
-    /// </param>
-    /// <param name="sourceUrl">The location the script came from.</param>
-    /// <param name="result">A function representing the script code.</param>
-    /// <returns>
-    ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
-    /// </returns>
-    CHAKRA_API
-        JsParseSerializedScriptWithCallback(
-            _In_ JsSerializedScriptLoadSourceCallback scriptLoadCallback,
-            _In_ JsSerializedScriptUnloadCallback scriptUnloadCallback,
-            _In_ BYTE *buffer,
-            _In_ JsSourceContext sourceContext,
-            _In_z_ const CSTR_TYPE *sourceUrl,
-            _Out_ JsValueRef * result);
-
-    /// <summary>
-    ///     Runs a serialized script.
-    ///     Provides the ability to lazy load the script source only if/when it is needed.
-    /// </summary>
-    /// <remarks>
-    ///     <para>
-    ///     Requires an active script context.
-    ///     </para>
-    ///     <para>
-    ///     The runtime will hold on to the buffer until all instances of any functions created from
-    ///     the buffer are garbage collected.  It will then call scriptUnloadCallback to inform the
-    ///     caller it is safe to release.
-    ///     </para>
-    /// </remarks>
-    /// <param name="scriptLoadCallback">Callback called when the source code of the script needs to be loaded.</param>
-    /// <param name="scriptUnloadCallback">Callback called when the serialized script and source code are no longer needed.</param>
-    /// <param name="buffer">The serialized script.</param>
-    /// <param name="sourceContext">
-    ///     A cookie identifying the script that can be used by debuggable script contexts.
-    ///     This context will passed into scriptLoadCallback and scriptUnloadCallback.
-    /// </param>
-    /// <param name="sourceUrl">The location the script came from.</param>
-    /// <param name="result">
-    ///     The result of running the script, if any. This parameter can be null.
-    /// </param>
-    /// <returns>
-    ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
-    /// </returns>
-    CHAKRA_API
-        JsRunSerializedScriptWithCallback(
-            _In_ JsSerializedScriptLoadSourceCallback scriptLoadCallback,
-            _In_ JsSerializedScriptUnloadCallback scriptUnloadCallback,
-            _In_ BYTE *buffer,
-            _In_ JsSourceContext sourceContext,
-            _In_z_ const CSTR_TYPE *sourceUrl,
-            _Out_opt_ JsValueRef * result);
-#endif
-
-    /// <summary>
-    ///     Parses a serialized script and returns a function representing the script.
-    /// </summary>
-    /// <remarks>
-    ///     <para>
-    ///     Requires an active script context.
-    ///     </para>
-    ///     <para>
-    ///     The runtime will hold on to the buffer until all instances of any functions created from
-    ///     the buffer are garbage collected.
-    ///     </para>
-    /// </remarks>
-    /// <param name="script">The script to parse.</param>
-    /// <param name="buffer">The serialized script.</param>
-    /// <param name="sourceContext">
-    ///     A cookie identifying the script that can be used by debuggable script contexts.
-    /// </param>
-    /// <param name="sourceUrl">The location the script came from.</param>
-    /// <param name="result">A function representing the script code.</param>
-    /// <returns>
-    ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
-    /// </returns>
-    CHAKRA_API
-        JsParseSerializedScript(
-            _In_z_ const CSTR_TYPE *script,
-            _In_ BYTE *buffer,
-            _In_ JsSourceContext sourceContext,
-            _In_z_ const CSTR_TYPE *sourceUrl,
-            _Out_ JsValueRef *result);
-
-    /// <summary>
-    ///     Runs a serialized script.
-    /// </summary>
-    /// <remarks>
-    ///     <para>
-    ///     Requires an active script context.
-    ///     </para>
-    ///     <para>
-    ///     The runtime will hold on to the buffer until all instances of any functions created from
-    ///     the buffer are garbage collected.
-    ///     </para>
-    /// </remarks>
-    /// <param name="script">The source code of the serialized script.</param>
-    /// <param name="buffer">The serialized script.</param>
-    /// <param name="sourceContext">
-    ///     A cookie identifying the script that can be used by debuggable script contexts.
-    /// </param>
-    /// <param name="sourceUrl">The location the script came from.</param>
-    /// <param name="result">
-    ///     The result of running the script, if any. This parameter can be null.
-    /// </param>
-    /// <returns>
-    ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
-    /// </returns>
-    CHAKRA_API
-        JsRunSerializedScript(
-            _In_z_ const CSTR_TYPE *script,
-            _In_ BYTE *buffer,
-            _In_ JsSourceContext sourceContext,
-            _In_z_ const CSTR_TYPE *sourceUrl,
-            _Out_ JsValueRef *result);
-
-    /// <summary>
-    ///     Gets the property ID associated with the name.
-    /// </summary>
-    /// <remarks>
-    ///     <para>
-    ///     Property IDs are specific to a context and cannot be used across contexts.
-    ///     </para>
-    ///     <para>
-    ///     Requires an active script context.
-    ///     </para>
-    /// </remarks>
-    /// <param name="name">
-    ///     The name of the property ID to get or create. The name may consist of only digits.
-    /// </param>
-    /// <param name="propertyId">The property ID in this runtime for the given name.</param>
-    /// <returns>
-    ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
-    /// </returns>
-    CHAKRA_API
-        JsGetPropertyIdFromName(
-            _In_z_ const CSTR_TYPE *name,
-            _Out_ JsPropertyIdRef *propertyId);
-
-    /// <summary>
-    ///     Gets the name associated with the property ID.
-    /// </summary>
-    /// <remarks>
-    ///     <para>
-    ///     Requires an active script context.
-    ///     </para>
-    ///     <para>
-    ///     The returned buffer is valid as long as the runtime is alive and cannot be used
-    ///     once the runtime has been disposed.
-    ///     </para>
-    /// </remarks>
-    /// <param name="propertyId">The property ID to get the name of.</param>
-    /// <param name="name">The name associated with the property ID.</param>
-    /// <returns>
-    ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
-    /// </returns>
-    CHAKRA_API
-        JsGetPropertyNameFromId(
-            _In_ JsPropertyIdRef propertyId,
-            _Outptr_result_z_ const CSTR_TYPE **name);
-
-    /// <summary>
-    ///     Creates a string value from a string pointer.
-    /// </summary>
-    /// <remarks>
-    ///     Requires an active script context.
-    /// </remarks>
-    /// <param name="stringValue">The string pointer to convert to a string value.</param>
-    /// <param name="stringLength">The length of the string to convert.</param>
-    /// <param name="value">The new string value.</param>
-    /// <returns>
-    ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
-    /// </returns>
-    CHAKRA_API
-        JsPointerToString(
-            _In_reads_(stringLength) const CSTR_TYPE *stringValue,
-            _In_ size_t stringLength,
-            _Out_ JsValueRef *value);
-
-    /// <summary>
-    ///     Retrieves the string pointer of a string value.
-    /// </summary>
-    /// <remarks>
-    ///     <para>
-    ///     This function retrieves the string pointer of a string value. It will fail with
-    ///     <c>JsErrorInvalidArgument</c> if the type of the value is not string. The lifetime
-    ///     of the string returned will be the same as the lifetime of the value it came from, however
-    ///     the string pointer is not considered a reference to the value (and so will not keep it
-    ///     from being collected).
-    ///     </para>
-    ///     <para>
-    ///     Requires an active script context.
-    ///     </para>
-    /// </remarks>
-    /// <param name="value">The string value to convert to a string pointer.</param>
-    /// <param name="stringValue">The string pointer.</param>
-    /// <param name="stringLength">The length of the string.</param>
-    /// <returns>
-    ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
-    /// </returns>
-    CHAKRA_API
-        JsStringToPointer(
-            _In_ JsValueRef value,
-            _Outptr_result_buffer_(*stringLength) const CSTR_TYPE **stringValue,
-            _Out_ size_t *stringLength);
-
-#undef CSTR_TYPE
-
     /// <summary>
     ///     Parses a script and returns a function representing the script.
     /// </summary>
@@ -1591,8 +1224,9 @@ typedef unsigned char* ChakraBytePtr;
     ///     Requires an active script context.
     ///     </para>
     ///     <para>
-    ///     The returned buffer is valid as long as the runtime is alive and cannot be used
-    ///     once the runtime has been disposed.
+    ///     Consumer is responsible from calling JsStringFree to free allocated memory.
+    ///
+    ///     Experimental. We may update the name or behavior until it is stable.
     ///     </para>
     /// </remarks>
     /// <param name="propertyId">The property ID to get the name of.</param>
@@ -1601,15 +1235,17 @@ typedef unsigned char* ChakraBytePtr;
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
     CHAKRA_API
-        JsGetPropertyNameFromIdUtf8(
+        JsGetPropertyNameFromIdUtf8Copy(
             _In_ JsPropertyIdRef propertyId,
-            _Outptr_result_z_ const char *name);
+            _Outptr_result_z_ char **name);
 
     /// <summary>
     ///     Creates a string value from a string pointer.
     /// </summary>
     /// <remarks>
     ///     Requires an active script context.
+    ///
+    ///     Experimental. We may update the name or behavior until it is stable.
     /// </remarks>
     /// <param name="stringValue">The string pointer to convert to a string value, encoded as Utf8.</param>
     /// <param name="stringLength">The length of the string to convert.</param>
@@ -1630,9 +1266,10 @@ typedef unsigned char* ChakraBytePtr;
     ///     <para>
     ///     This function retrieves the string pointer of a string value. It will fail with
     ///     <c>JsErrorInvalidArgument</c> if the type of the value is not string. The lifetime
-    ///     of the string returned will be the same as the lifetime of the value it came from, however
-    ///     the string pointer is not considered a reference to the value (and so will not keep it
-    ///     from being collected).
+    ///     of the string returned won't be the same as the lifetime of the value it came from, so
+    ///     the consumer is responsible from calling JsStringFree.
+    ///
+    ///     Experimental. We may update the name or behavior until it is stable.
     ///     </para>
     ///     <para>
     ///     Requires an active script context.
@@ -1645,9 +1282,9 @@ typedef unsigned char* ChakraBytePtr;
     ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
     /// </returns>
     CHAKRA_API
-        JsStringToPointerUtf8(
+        JsStringToPointerUtf8Copy(
             _In_ JsValueRef value,
-            _Outptr_result_buffer_(*stringLength) const char **stringValue,
+            _Outptr_result_buffer_(*stringLength) char **stringValue,
             _Out_ size_t *stringLength); 
     
     /// <summary>
@@ -2981,4 +2618,25 @@ typedef unsigned char* ChakraBytePtr;
         JsSetPromiseContinuationCallback(
             _In_ JsPromiseContinuationCallback promiseContinuationCallback,
             _In_opt_ void *callbackState);
+
+    /// <summary>
+    ///     Free the memory used for Utf8 buffer copy
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///     Experimental. We may update the name or behavior until it is stable.
+    ///     </para>
+    /// </remarks>
+    /// <param name="stringValue">Pointer to string memory.</param>
+    /// <returns>
+    ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
+    /// </returns>
+    CHAKRA_API
+        JsStringFree(
+            _In_ char* stringValue);
+            
+#ifdef _WIN32
+#include "ChakraCommonWindows.h"
+#endif // _WIN32
+
 #endif // _CHAKRACOMMON_H_

--- a/lib/Jsrt/ChakraCommonWindows.h
+++ b/lib/Jsrt/ChakraCommonWindows.h
@@ -1,0 +1,367 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#ifdef _MSC_VER
+#pragma once
+#endif  // _MSC_VER
+
+#ifndef _CHAKRACOMMONWINDOWS_H_
+#define _CHAKRACOMMONWINDOWS_H_
+
+    /// <summary>
+    ///     Called by the runtime to load the source code of the serialized script.
+    ///     The caller must keep the script buffer valid until the JsSerializedScriptUnloadCallback.
+    ///     This callback is only supported by the Win32 version of the API
+    /// </summary>
+    /// <param name="sourceContext">The context passed to Js[Parse|Run]SerializedScriptWithCallback</param>
+    /// <param name="scriptBuffer">The script returned.</param>
+    /// <returns>
+    ///     true if the operation succeeded, false otherwise.
+    /// </returns>
+    typedef bool (CHAKRA_CALLBACK * JsSerializedScriptLoadSourceCallback)(_In_ JsSourceContext sourceContext, _Outptr_result_z_ const wchar_t** scriptBuffer);
+
+    /// <summary>
+    ///     Parses a script and returns a function representing the script.
+    /// </summary>
+    /// <remarks>
+    ///     Requires an active script context.
+    /// </remarks>
+    /// <param name="script">The script to parse.</param>
+    /// <param name="sourceContext">
+    ///     A cookie identifying the script that can be used by debuggable script contexts.
+    /// </param>
+    /// <param name="sourceUrl">The location the script came from.</param>
+    /// <param name="result">A function representing the script code.</param>
+    /// <returns>
+    ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
+    /// </returns>
+    CHAKRA_API
+        JsParseScript(
+            _In_z_ const wchar_t *script,
+            _In_ JsSourceContext sourceContext,
+            _In_z_ const wchar_t *sourceUrl,
+            _Out_ JsValueRef *result);
+
+    /// <summary>
+    ///     Parses a script and returns a function representing the script.
+    /// </summary>
+    /// <remarks>
+    ///     Requires an active script context.
+    /// </remarks>
+    /// <param name="script">The script to parse.</param>
+    /// <param name="sourceContext">
+    ///     A cookie identifying the script that can be used by debuggable script contexts.
+    /// </param>
+    /// <param name="sourceUrl">The location the script came from.</param>
+    /// <param name="parseAttributes">Attribute mask for parsing the script</param>
+    /// <param name="result">A function representing the script code.</param>
+    /// <returns>
+    ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
+    /// </returns>
+    CHAKRA_API
+        JsParseScriptWithAttributes(
+            _In_z_ const wchar_t *script,
+            _In_ JsSourceContext sourceContext,
+            _In_z_ const wchar_t *sourceUrl,
+            _In_ JsParseScriptAttributes parseAttributes,
+            _Out_ JsValueRef *result);
+
+    /// <summary>
+    ///     Executes a script.
+    /// </summary>
+    /// <remarks>
+    ///     Requires an active script context.
+    /// </remarks>
+    /// <param name="script">The script to run.</param>
+    /// <param name="sourceContext">
+    ///     A cookie identifying the script that can be used by debuggable script contexts.
+    /// </param>
+    /// <param name="sourceUrl">The location the script came from.</param>
+    /// <param name="result">The result of the script, if any. This parameter can be null.</param>
+    /// <returns>
+    ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
+    /// </returns>
+    CHAKRA_API
+        JsRunScript(
+            _In_z_ const wchar_t *script,
+            _In_ JsSourceContext sourceContext,
+            _In_z_ const wchar_t *sourceUrl,
+            _Out_ JsValueRef *result);
+
+    /// <summary>
+    ///     Executes a module.
+    /// </summary>
+    /// <remarks>
+    ///     Requires an active script context.
+    /// </remarks>
+    /// <param name="script">The module script to parse and execute.</param>
+    /// <param name="sourceContext">
+    ///     A cookie identifying the script that can be used by debuggable script contexts.
+    /// </param>
+    /// <param name="sourceUrl">The location the module script came from.</param>
+    /// <param name="result">The result of executing the module script, if any. This parameter can be null.</param>
+    /// <returns>
+    ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
+    /// </returns>
+    CHAKRA_API
+        JsExperimentalApiRunModule(
+            _In_z_ const wchar_t *script,
+            _In_ JsSourceContext sourceContext,
+            _In_z_ const wchar_t *sourceUrl,
+            _Out_ JsValueRef *result);
+
+    /// <summary>
+    ///     Serializes a parsed script to a buffer than can be reused.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///     <c>JsSerializeScript</c> parses a script and then stores the parsed form of the script in a
+    ///     runtime-independent format. The serialized script then can be deserialized in any
+    ///     runtime without requiring the script to be re-parsed.
+    ///     </para>
+    ///     <para>
+    ///     Requires an active script context.
+    ///     </para>
+    /// </remarks>
+    /// <param name="script">The script to serialize.</param>
+    /// <param name="buffer">The buffer to put the serialized script into. Can be null.</param>
+    /// <param name="bufferSize">
+    ///     On entry, the size of the buffer, in bytes; on exit, the size of the buffer, in bytes,
+    ///     required to hold the serialized script.
+    /// </param>
+    /// <returns>
+    ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
+    /// </returns>
+    CHAKRA_API
+        JsSerializeScript(
+            _In_z_ const wchar_t *script,
+            _Out_writes_to_opt_(*bufferSize, *bufferSize) BYTE *buffer,
+            _Inout_ unsigned int *bufferSize);
+
+    /// <summary>
+    ///     Parses a serialized script and returns a function representing the script.
+    ///     Provides the ability to lazy load the script source only if/when it is needed.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///     Requires an active script context.
+    ///     </para>
+    ///     <para>
+    ///     The runtime will hold on to the buffer until all instances of any functions created from
+    ///     the buffer are garbage collected.  It will then call scriptUnloadCallback to inform the
+    ///     caller it is safe to release.
+    ///     </para>
+    /// </remarks>
+    /// <param name="scriptLoadCallback">Callback called when the source code of the script needs to be loaded.</param>
+    /// <param name="scriptUnloadCallback">Callback called when the serialized script and source code are no longer needed.</param>
+    /// <param name="buffer">The serialized script.</param>
+    /// <param name="sourceContext">
+    ///     A cookie identifying the script that can be used by debuggable script contexts.
+    ///     This context will passed into scriptLoadCallback and scriptUnloadCallback.
+    /// </param>
+    /// <param name="sourceUrl">The location the script came from.</param>
+    /// <param name="result">A function representing the script code.</param>
+    /// <returns>
+    ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
+    /// </returns>
+    CHAKRA_API
+        JsParseSerializedScriptWithCallback(
+            _In_ JsSerializedScriptLoadSourceCallback scriptLoadCallback,
+            _In_ JsSerializedScriptUnloadCallback scriptUnloadCallback,
+            _In_ BYTE *buffer,
+            _In_ JsSourceContext sourceContext,
+            _In_z_ const wchar_t *sourceUrl,
+            _Out_ JsValueRef * result);
+
+    /// <summary>
+    ///     Runs a serialized script.
+    ///     Provides the ability to lazy load the script source only if/when it is needed.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///     Requires an active script context.
+    ///     </para>
+    ///     <para>
+    ///     The runtime will hold on to the buffer until all instances of any functions created from
+    ///     the buffer are garbage collected.  It will then call scriptUnloadCallback to inform the
+    ///     caller it is safe to release.
+    ///     </para>
+    /// </remarks>
+    /// <param name="scriptLoadCallback">Callback called when the source code of the script needs to be loaded.</param>
+    /// <param name="scriptUnloadCallback">Callback called when the serialized script and source code are no longer needed.</param>
+    /// <param name="buffer">The serialized script.</param>
+    /// <param name="sourceContext">
+    ///     A cookie identifying the script that can be used by debuggable script contexts.
+    ///     This context will passed into scriptLoadCallback and scriptUnloadCallback.
+    /// </param>
+    /// <param name="sourceUrl">The location the script came from.</param>
+    /// <param name="result">
+    ///     The result of running the script, if any. This parameter can be null.
+    /// </param>
+    /// <returns>
+    ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
+    /// </returns>
+    CHAKRA_API
+        JsRunSerializedScriptWithCallback(
+            _In_ JsSerializedScriptLoadSourceCallback scriptLoadCallback,
+            _In_ JsSerializedScriptUnloadCallback scriptUnloadCallback,
+            _In_ BYTE *buffer,
+            _In_ JsSourceContext sourceContext,
+            _In_z_ const wchar_t *sourceUrl,
+            _Out_opt_ JsValueRef * result);
+
+    /// <summary>
+    ///     Parses a serialized script and returns a function representing the script.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///     Requires an active script context.
+    ///     </para>
+    ///     <para>
+    ///     The runtime will hold on to the buffer until all instances of any functions created from
+    ///     the buffer are garbage collected.
+    ///     </para>
+    /// </remarks>
+    /// <param name="script">The script to parse.</param>
+    /// <param name="buffer">The serialized script.</param>
+    /// <param name="sourceContext">
+    ///     A cookie identifying the script that can be used by debuggable script contexts.
+    /// </param>
+    /// <param name="sourceUrl">The location the script came from.</param>
+    /// <param name="result">A function representing the script code.</param>
+    /// <returns>
+    ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
+    /// </returns>
+    CHAKRA_API
+        JsParseSerializedScript(
+            _In_z_ const wchar_t *script,
+            _In_ BYTE *buffer,
+            _In_ JsSourceContext sourceContext,
+            _In_z_ const wchar_t *sourceUrl,
+            _Out_ JsValueRef *result);
+
+    /// <summary>
+    ///     Runs a serialized script.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///     Requires an active script context.
+    ///     </para>
+    ///     <para>
+    ///     The runtime will hold on to the buffer until all instances of any functions created from
+    ///     the buffer are garbage collected.
+    ///     </para>
+    /// </remarks>
+    /// <param name="script">The source code of the serialized script.</param>
+    /// <param name="buffer">The serialized script.</param>
+    /// <param name="sourceContext">
+    ///     A cookie identifying the script that can be used by debuggable script contexts.
+    /// </param>
+    /// <param name="sourceUrl">The location the script came from.</param>
+    /// <param name="result">
+    ///     The result of running the script, if any. This parameter can be null.
+    /// </param>
+    /// <returns>
+    ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
+    /// </returns>
+    CHAKRA_API
+        JsRunSerializedScript(
+            _In_z_ const wchar_t *script,
+            _In_ BYTE *buffer,
+            _In_ JsSourceContext sourceContext,
+            _In_z_ const wchar_t *sourceUrl,
+            _Out_ JsValueRef *result);
+
+    /// <summary>
+    ///     Gets the property ID associated with the name.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///     Property IDs are specific to a context and cannot be used across contexts.
+    ///     </para>
+    ///     <para>
+    ///     Requires an active script context.
+    ///     </para>
+    /// </remarks>
+    /// <param name="name">
+    ///     The name of the property ID to get or create. The name may consist of only digits.
+    /// </param>
+    /// <param name="propertyId">The property ID in this runtime for the given name.</param>
+    /// <returns>
+    ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
+    /// </returns>
+    CHAKRA_API
+        JsGetPropertyIdFromName(
+            _In_z_ const wchar_t *name,
+            _Out_ JsPropertyIdRef *propertyId);
+
+    /// <summary>
+    ///     Gets the name associated with the property ID.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///     Requires an active script context.
+    ///     </para>
+    ///     <para>
+    ///     The returned buffer is valid as long as the runtime is alive and cannot be used
+    ///     once the runtime has been disposed.
+    ///     </para>
+    /// </remarks>
+    /// <param name="propertyId">The property ID to get the name of.</param>
+    /// <param name="name">The name associated with the property ID.</param>
+    /// <returns>
+    ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
+    /// </returns>
+    CHAKRA_API
+        JsGetPropertyNameFromId(
+            _In_ JsPropertyIdRef propertyId,
+            _Outptr_result_z_ const wchar_t **name);
+
+    /// <summary>
+    ///     Creates a string value from a string pointer.
+    /// </summary>
+    /// <remarks>
+    ///     Requires an active script context.
+    /// </remarks>
+    /// <param name="stringValue">The string pointer to convert to a string value.</param>
+    /// <param name="stringLength">The length of the string to convert.</param>
+    /// <param name="value">The new string value.</param>
+    /// <returns>
+    ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
+    /// </returns>
+    CHAKRA_API
+        JsPointerToString(
+            _In_reads_(stringLength) const wchar_t *stringValue,
+            _In_ size_t stringLength,
+            _Out_ JsValueRef *value);
+
+    /// <summary>
+    ///     Retrieves the string pointer of a string value.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///     This function retrieves the string pointer of a string value. It will fail with
+    ///     <c>JsErrorInvalidArgument</c> if the type of the value is not string. The lifetime
+    ///     of the string returned will be the same as the lifetime of the value it came from, however
+    ///     the string pointer is not considered a reference to the value (and so will not keep it
+    ///     from being collected).
+    ///     </para>
+    ///     <para>
+    ///     Requires an active script context.
+    ///     </para>
+    /// </remarks>
+    /// <param name="value">The string value to convert to a string pointer.</param>
+    /// <param name="stringValue">The string pointer.</param>
+    /// <param name="stringLength">The length of the string.</param>
+    /// <returns>
+    ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
+    /// </returns>
+    CHAKRA_API
+        JsStringToPointer(
+            _In_ JsValueRef value,
+            _Outptr_result_buffer_(*stringLength) const wchar_t **stringValue,
+            _Out_ size_t *stringLength);
+
+#endif // _CHAKRACOMMONWINDOWS_H_

--- a/lib/Jsrt/ChakraDebug.h
+++ b/lib/Jsrt/ChakraDebug.h
@@ -581,5 +581,48 @@
             _In_ const wchar_t *expression,
             _In_ unsigned int stackFrameIndex,
             _Out_ JsValueRef *evalResult);
+
 #endif // _WIN32
+
+    /// <summary>
+    ///     Evaluates an expression on given frame.
+    /// </summary>
+    /// <param name="expression">Expression to evaluate.</param>
+    /// <param name="stackFrameIndex">Index of stack frame on which to evaluate the expression.</param>
+    /// <param name="evalResult">Result of evaluation.</param>
+    /// <remarks>
+    ///     <para>
+    ///     evalResult when evaluating 'this' and return is JsNoError
+    ///     {
+    ///         "name" : "this",
+    ///         "type" : "object",
+    ///         "className" : "Object",
+    ///         "display" : "{...}",
+    ///         "propertyAttributes" : 1,
+    ///         "handle" : 18
+    ///     }
+    ///
+    ///     evalResult when evaluating a script which throws JavaScript error and return is JsErrorScriptException
+    ///     {
+    ///         "name" : "a.b.c",
+    ///         "type" : "object",
+    ///         "className" : "Error",
+    ///         "display" : "'a' is undefined",
+    ///         "propertyAttributes" : 1,
+    ///         "handle" : 18
+    ///     }
+    ///     </para>
+    /// </remarks>
+    /// <returns>
+    ///     The code <c>JsNoError</c> if the operation succeeded, evalResult will contain the result
+    ///     The code <c>JsErrorScriptException</c> if evaluate generated a JavaScript exception, evalResult will contain the error details
+    ///     Other error code for invalid parameters or API was not called at break
+    /// </returns>
+    /// <remarks>
+    ///     The current runtime should be in debug state. This API can only be called when runtime is at a break.
+    /// </remarks>
+    CHAKRA_API JsDiagEvaluateUtf8(
+        _In_ const char *expression,
+        _In_ unsigned int stackFrameIndex,
+        _Out_ JsValueRef *evalResult);
 #endif // _CHAKRADEBUG_H_

--- a/lib/Jsrt/JsrtCommonExports.inc
+++ b/lib/Jsrt/JsrtCommonExports.inc
@@ -108,3 +108,10 @@
     JsSerializeScriptUtf8
     JsRunSerializedScriptUtf8
     JsExperimentalApiRunModuleUtf8
+    JsGetPropertyIdFromNameUtf8
+    JsStringFree
+    JsDiagEvaluateUtf8
+    JsParseScriptWithAttributesUtf8
+    JsStringToPointerUtf8Copy
+    JsPointerToStringUtf8
+    JsGetPropertyNameFromIdUtf8Copy

--- a/lib/Jsrt/JsrtDiag.cpp
+++ b/lib/Jsrt/JsrtDiag.cpp
@@ -8,6 +8,7 @@
 #include "RuntimeDebugPch.h"
 #include "ThreadContextTlsEntry.h"
 #include "JsrtDebugUtils.h"
+#include "Codex/Utf8Helper.h"
 
 #define VALIDATE_IS_DEBUGGING(jsrtDebugManager) \
     if (jsrtDebugManager == nullptr || !jsrtDebugManager->IsDebugEventCallbackSet()) \
@@ -625,7 +626,6 @@ CHAKRA_API JsDiagGetObjectFromHandle(
     });
 }
 
-#ifdef _WIN32
 CHAKRA_API JsDiagEvaluate(
     _In_ const wchar_t *expression,
     _In_ unsigned int stackFrameIndex,
@@ -671,4 +671,18 @@ CHAKRA_API JsDiagEvaluate(
 
     }, false /*allowInObjectBeforeCollectCallback*/, true /*scriptExceptionAllowed*/);
 }
-#endif
+
+CHAKRA_API JsDiagEvaluateUtf8(
+    _In_ const char *expression,
+    _In_ unsigned int stackFrameIndex,
+    _Out_ JsValueRef *evalResult)
+{
+    PARAM_NOT_NULL(expression);
+    utf8::NarrowToWide wstr(expression, strlen(expression));
+    if (!wstr)
+    {
+        return JsErrorOutOfMemory;
+    }
+
+    return JsDiagEvaluate(wstr, stackFrameIndex, evalResult);
+}


### PR DESCRIPTION
This PR introduces the new Utf8 API as a cross-platform alternative to current Jsrt.

Embedder note: Utf8 API is not yet in a final shape. Names and behaviors may change over time.

- Implements rememaning Utf8 API
- Updates CH to use only Utf8 API (including Windows)