### PR TITLE
Wasm br/br_table yield 

### DIFF
--- a/lib/WasmReader/WasmBinaryReader.cpp
+++ b/lib/WasmReader/WasmBinaryReader.cpp
@@ -477,16 +477,15 @@ WasmBinaryReader::BrNode()
     m_currentNode.br.arity = ReadConst<uint8>();
     m_funcState.count++;
 
-    if (m_currentNode.br.arity != 0)
+    if (m_currentNode.br.arity > 1)
     {
-        ThrowDecodingError(_u("NYI: br yielding value"));
+        ThrowDecodingError(_u("NYI: br yielding more than 1 value"));
     }
 
     m_currentNode.br.depth = LEB128(len);
     m_funcState.count += len;
 
-    // TODO: binary encoding doesn't yet support br yielding value
-    m_currentNode.br.hasSubExpr = false;
+    m_currentNode.br.hasSubExpr = m_currentNode.br.arity == 1;
 }
 
 void

--- a/lib/WasmReader/WasmBinaryReader.cpp
+++ b/lib/WasmReader/WasmBinaryReader.cpp
@@ -10,6 +10,15 @@
 
 namespace Wasm
 {
+    namespace WasmTypes
+    {
+        bool IsLocalType(WasmTypes::WasmType type) 
+        {
+            // Check if type in range ]Void,Limit[
+            return (uint)(type - 1) < (WasmTypes::Limit - 1);
+        }
+    }
+
 namespace Binary
 {
 
@@ -495,9 +504,9 @@ WasmBinaryReader::BrTableNode()
     m_currentNode.brTable.arity = LEB128(len);
     m_funcState.count += len;
 
-    if (m_currentNode.brTable.arity != 0)
+    if (m_currentNode.brTable.arity > 1)
     {
-        ThrowDecodingError(_u("NYI: br_table yielding value"));
+        ThrowDecodingError(_u("NYI: br_table yielding more than 1 value"));
     }
 
     m_currentNode.brTable.numTargets = LEB128(len);

--- a/lib/WasmReader/WasmByteCodeGenerator.cpp
+++ b/lib/WasmReader/WasmByteCodeGenerator.cpp
@@ -1366,21 +1366,17 @@ WasmBytecodeGenerator::YieldToBlock(uint relativeDepth, EmitInfo expr)
         return;
     }
     
-    // If we already tried to yield no value to this block, ignore the others
+    // If the type differs on any path, do not yield.
+    // This will introduce some dead code on the first paths that tried to Yield a valid type
     if (
         yieldInfo->type == WasmTypes::Void ||
-        expr.type == WasmTypes::Void
+        yieldInfo->type != WasmTypes::Limit && yieldInfo->type != expr.type
     )
     {
         yieldInfo->type = WasmTypes::Void;
         return;
     }
 
-
-    if (yieldInfo->type != WasmTypes::Limit && yieldInfo->type != expr.type)
-    {
-        throw WasmCompilationException(_u("Invalid yield type for block"));
-    }
     yieldInfo->type = expr.type;
     m_writer.AsmReg2(GetLoadOp(expr.type), yieldInfo->yieldLocs[expr.type], expr.location);
 }

--- a/lib/WasmReader/WasmByteCodeGenerator.h
+++ b/lib/WasmReader/WasmByteCodeGenerator.h
@@ -70,7 +70,7 @@ namespace Wasm
     struct BlockYieldInfo
     {
         Js::RegSlot yieldLocs[WasmTypes::Limit];
-        WasmTypes::WasmType type = WasmTypes::Void;
+        WasmTypes::WasmType type = WasmTypes::Limit;
     };
 
     struct BlockInfo

--- a/lib/WasmReader/WasmByteCodeGenerator.h
+++ b/lib/WasmReader/WasmByteCodeGenerator.h
@@ -90,7 +90,8 @@ namespace Wasm
     private:
 
         EmitInfo EmitExpr(WasmOp op);
-        EmitInfo EmitBlock(uint* loopId = nullptr);
+        EmitInfo EmitBlock();
+        EmitInfo EmitBlockCommon();
         EmitInfo EmitLoop();
 
         template<WasmOp wasmOp>

--- a/lib/WasmReader/WasmByteCodeGenerator.h
+++ b/lib/WasmReader/WasmByteCodeGenerator.h
@@ -67,6 +67,18 @@ namespace Wasm
         };
     };
 
+    struct BlockYieldInfo
+    {
+        Js::RegSlot yieldLocs[WasmTypes::Limit];
+        WasmTypes::WasmType type = WasmTypes::Void;
+    };
+
+    struct BlockInfo
+    {
+        BlockYieldInfo* yieldInfo = nullptr;
+        Js::ByteCodeLabel label;
+    };
+
     typedef JsUtil::BaseDictionary<uint, LPCUTF8, ArenaAllocator> WasmExportDictionary;
 
     class WasmBytecodeGenerator
@@ -126,7 +138,11 @@ namespace Wasm
         void EnregisterLocals();
         void ReleaseLocation(EmitInfo * info);
 
-        Js::ByteCodeLabel GetLabel(uint index);
+        EmitInfo PopLabel(Js::ByteCodeLabel labelValidation);
+        void PushLabel(Js::ByteCodeLabel label, bool addBlockYieldInfo = true);
+        void YieldToBlock(uint relativeDepth, EmitInfo expr);
+        BlockInfo GetBlockInfo(uint relativeDepth);
+        Js::ByteCodeLabel GetLabel(uint relativeDepth);
 
         template <typename T>
         Js::RegSlot GetConstReg(T constVal);
@@ -163,8 +179,7 @@ namespace Wasm
         WasmRegisterSpace * m_f32RegSlots;
         WasmRegisterSpace * m_f64RegSlots;
 
-        SListCounted<Js::ByteCodeLabel> * m_labels;
-
+        JsUtil::Stack<BlockInfo> m_blockInfos;
         JsUtil::Stack<EmitInfo> m_evalStack;
     };
 }

--- a/lib/WasmReader/WasmParseTree.h
+++ b/lib/WasmReader/WasmParseTree.h
@@ -15,8 +15,10 @@ namespace Wasm
             Void,
 #define WASM_LOCALTYPE(token, name) token,
 #include "WasmKeywords.h"
-            Limit
+            Limit,
+            Unreachable
         };
+        bool IsLocalType(WasmTypes::WasmType type);
     }
 
     enum WasmOp


### PR DESCRIPTION
Added a landing pad for Wasm loops. Since loops don't loop by default, jump over the pad. Used instead of jumping directly to loop header. This was problematic when nested loops wanted to break to the loop head of an outer loop.

Acquire a tmp register when entering a block. When yielding to a block used the previously save register. This allows br and br_table from anywhere inside the block to yield a value before breaking.
If any path yields a value conflicting type with another path, change the yield type to void and do not use the value (Like the yield never happened).

Introduced the type `unreachable` to differentiate paths that are unreachable. Currently this is used like an `any` type to not change block yield type to void.
For instance `(block (block (br 1 (i32.const 0))`. The second block will have type `unreachable` and the first block will merge `i32` and `unreachable` => `i32`.

There is still some work to do with `unreachable` validate things like `i32.ctz (br 0)`. This is supposed to be valid, but shouldn't produce any bytecode.
See https://github.com/WebAssembly/design/issues/707 for details about this.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/1197)
<!-- Reviewable:end -->
