### PR TITLE
Reducing lambda usage to improve code coverage attribution

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -17,12 +17,38 @@ bool IsCallOfConstants(ParseNode *pnode)
 template <class PrefixFn, class PostfixFn>
 void Visit(ParseNode *pnode, ByteCodeGenerator* byteCodeGenerator, PrefixFn prefix, PostfixFn postfix, ParseNode * pnodeParent = nullptr);
 
+//the only point of this type (as opposed to using a lambda) is to provide a named type in code coverage
+template <typename TContext> class ParseNodeVisitor
+{
+    TContext* m_context;
+    void(*m_fn)(ParseNode* pnode, ByteCodeGenerator* byteCodeGenerator, TContext* context);
+public:
+
+    ParseNodeVisitor(TContext* ctx, void(*prefixParam)(ParseNode* pnode, ByteCodeGenerator* byteCodeGenerator, TContext* context)) :
+        m_context(ctx), m_fn(prefixParam)
+    {
+    }
+
+    void operator () (ParseNode* pnode, ByteCodeGenerator* byteCodeGenerator)
+    {
+        if (m_fn)
+        {
+            m_fn(pnode, byteCodeGenerator, m_context);
+        }
+    }
+};
+
 template<class TContext>
 void VisitIndirect(ParseNode* pnode, ByteCodeGenerator* byteCodeGenerator, TContext* context,
     void (*prefix)(ParseNode* pnode, ByteCodeGenerator* byteCodeGenerator, TContext* context),
-    void (*postfix)(ParseNode* pnode, ByteCodeGenerator* byteCodeGenerator, TContext* context),
-    ParseNode *pnodeParent = nullptr)
+    void (*postfix)(ParseNode* pnode, ByteCodeGenerator* byteCodeGenerator, TContext* context))
 {
+    ParseNodeVisitor<TContext> prefixHelper(context, prefix);
+    ParseNodeVisitor<TContext> postfixHelper(context, postfix);
+
+    Visit(pnode, byteCodeGenerator, prefixHelper, postfixHelper, nullptr);
+
+    /*
     Visit(pnode, byteCodeGenerator,
         [context, prefix](ParseNode * pnode, ByteCodeGenerator * byteCodeGenerator)
         {
@@ -34,7 +60,8 @@ void VisitIndirect(ParseNode* pnode, ByteCodeGenerator* byteCodeGenerator, TCont
             {
                 postfix(pnode, byteCodeGenerator, context);
             }
-        }, pnodeParent);
+        }, nullptr);
+        */
 }
 
 template <class PrefixFn, class PostfixFn>

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -47,21 +47,6 @@ void VisitIndirect(ParseNode* pnode, ByteCodeGenerator* byteCodeGenerator, TCont
     ParseNodeVisitor<TContext> postfixHelper(context, postfix);
 
     Visit(pnode, byteCodeGenerator, prefixHelper, postfixHelper, nullptr);
-
-    /*
-    Visit(pnode, byteCodeGenerator,
-        [context, prefix](ParseNode * pnode, ByteCodeGenerator * byteCodeGenerator)
-        {
-            prefix(pnode, byteCodeGenerator, context);
-        },
-        [context, postfix](ParseNode * pnode, ByteCodeGenerator * byteCodeGenerator)
-        {
-            if (postfix)
-            {
-                postfix(pnode, byteCodeGenerator, context);
-            }
-        }, nullptr);
-        */
 }
 
 template <class PrefixFn, class PostfixFn>

--- a/lib/Runtime/Language/InterpreterStackFrame.h
+++ b/lib/Runtime/Language/InterpreterStackFrame.h
@@ -322,6 +322,31 @@ namespace Js
         Var ProcessProfiled();
         Var ProcessUnprofiled();
 
+        const byte* ProcessProfiledExtendedOpCodePrefix(const byte* ip);
+        const byte* ProcessUnprofiledExtendedOpCodePrefix(const byte* ip);
+        const byte* ProcessWithDebuggingExtendedOpCodePrefix(const byte* ip);
+        const byte* ProcessAsmJsExtendedOpCodePrefix(const byte* ip);
+
+        const byte* ProcessProfiledMediumLayoutPrefix(const byte* ip, Var&);
+        const byte* ProcessUnprofiledMediumLayoutPrefix(const byte* ip, Var&);
+        const byte* ProcessWithDebuggingMediumLayoutPrefix(const byte* ip, Var&);
+        const byte* ProcessAsmJsMediumLayoutPrefix(const byte* ip, Var&);
+
+        const byte* ProcessProfiledExtendedMediumLayoutPrefix(const byte* ip);
+        const byte* ProcessUnprofiledExtendedMediumLayoutPrefix(const byte* ip);
+        const byte* ProcessWithDebuggingExtendedMediumLayoutPrefix(const byte* ip);
+        const byte* ProcessAsmJsExtendedMediumLayoutPrefix(const byte* ip);
+
+        const byte* ProcessProfiledLargeLayoutPrefix(const byte* ip, Var&);
+        const byte* ProcessUnprofiledLargeLayoutPrefix(const byte* ip, Var&);
+        const byte* ProcessWithDebuggingLargeLayoutPrefix(const byte* ip, Var&);
+        const byte* ProcessAsmJsLargeLayoutPrefix(const byte* ip, Var&);
+
+        const byte* ProcessProfiledExtendedLargeLayoutPrefix(const byte* ip);
+        const byte* ProcessUnprofiledExtendedLargeLayoutPrefix(const byte* ip);
+        const byte* ProcessWithDebuggingExtendedLargeLayoutPrefix(const byte* ip);
+        const byte* ProcessAsmJsExtendedLargeLayoutPrefix(const byte* ip);
+
         Var ProcessWithDebugging();
         Var DebugProcess();
 


### PR DESCRIPTION
The least covered methods at present are lambdas or template functions parameterized by lambdas. Replace those lambdas with nominal methods to make it easier to locate the source referred to in the code coverage report.