### PR TITLE
cross-platform: fix AutoSystemInfo Initialization

### DIFF
--- a/lib/Common/Core/SysInfo.h
+++ b/lib/Common/Core/SysInfo.h
@@ -11,6 +11,7 @@ class AutoSystemInfo : public SYSTEM_INFO
     friend void ChakraBinaryAutoSystemInfoInit(AutoSystemInfo *);  // The hosting DLL provides the implementation of this function.
 public:
     static AutoSystemInfo Data;
+
     uint GetAllocationGranularityPageCount() const;
     uint GetAllocationGranularityPageSize() const;
 
@@ -70,10 +71,11 @@ public:
     UINT_PTR dllLoadAddress;
     UINT_PTR dllHighAddress;
 #endif
-    
+
 private:
-    AutoSystemInfo() : majorVersion(0), minorVersion(0), buildDateHash(0), buildTimeHash(0) { Initialize(); }
-    void Initialize();
+    AutoSystemInfo() : majorVersion(0), minorVersion(0), buildDateHash(0), buildTimeHash(0) { }
+    static void InitializeOnDemand();
+    bool Initialize();
     bool isWindows8OrGreater;
     uint allocationGranularityPageCount;
     HANDLE processHandle;
@@ -123,4 +125,3 @@ public:
 CompileAssert(AutoSystemInfo::PageSize == 4096);
 #define __in_ecount_pagesize __in_ecount(4096)
 #define __in_ecount_twopagesize __in_ecount(8192)
-


### PR DESCRIPTION
AutoSystemInfo class was being initialized before its cross dependencies are able to initialize.

This is a compiler/linker dependent issue, requires that AutoSystemInfo is initialized
at the end of the initializion phase.

Although the problem at hand  was not necessarily requiring a thread safe solution, the one proposed here (static function type of initializer) is thread safe and incredibly liteweight. It does the job by
passing the first `__cxx_global_var_init` (or similar) phase for its host module.