### PR TITLE
Debugging: Multiple context stack should be in order and sorted by return address.

### DIFF
--- a/lib/Jsrt/JsrtDebugManager.cpp
+++ b/lib/Jsrt/JsrtDebugManager.cpp
@@ -19,7 +19,6 @@ JsrtDebugManager::JsrtDebugManager(ThreadContext* threadContext) :
     resumeAction(BREAKRESUMEACTION_CONTINUE),
     debugObjectArena(nullptr),
     debuggerObjectsManager(nullptr),
-    callBackDepth(0),
     debugDocumentManager(nullptr),
     stackFrames(nullptr),
     breakOnExceptionAttributes(JsDiagBreakOnExceptionAttributeUncaught)
@@ -335,26 +334,20 @@ void JsrtDebugManager::CallDebugEventCallback(JsDiagDebugEvent debugEvent, Js::D
         AutoClear(JsrtDebugManager* jsrtDebug, void* dispatchHaltFrameAddress)
         {
             this->jsrtDebugManager = jsrtDebug;
-            jsrtDebugManager->callBackDepth++;
             this->jsrtDebugManager->GetThreadContext()->GetDebugManager()->SetDispatchHaltFrameAddress(dispatchHaltFrameAddress);
         }
 
         ~AutoClear()
         {
-            jsrtDebugManager->callBackDepth--;
-
-            if (jsrtDebugManager->callBackDepth == 0)
+            if (jsrtDebugManager->debuggerObjectsManager != nullptr)
             {
-                if (jsrtDebugManager->debuggerObjectsManager != nullptr)
-                {
-                    jsrtDebugManager->GetDebuggerObjectsManager()->ClearAll();
-                }
+                jsrtDebugManager->GetDebuggerObjectsManager()->ClearAll();
+            }
 
-                if (jsrtDebugManager->stackFrames != nullptr)
-                {
-                    Adelete(jsrtDebugManager->GetDebugObjectArena(), jsrtDebugManager->stackFrames);
-                    jsrtDebugManager->stackFrames = nullptr;
-                }
+            if (jsrtDebugManager->stackFrames != nullptr)
+            {
+                Adelete(jsrtDebugManager->GetDebugObjectArena(), jsrtDebugManager->stackFrames);
+                jsrtDebugManager->stackFrames = nullptr;
             }
             this->jsrtDebugManager->GetThreadContext()->GetDebugManager()->SetDispatchHaltFrameAddress(nullptr);
             this->jsrtDebugManager = nullptr;

--- a/lib/Jsrt/JsrtDebugManager.h
+++ b/lib/Jsrt/JsrtDebugManager.h
@@ -63,7 +63,6 @@ private:
     BREAKRESUMEACTION resumeAction;
     ArenaAllocator* debugObjectArena;
     JsrtDebuggerObjectsManager* debuggerObjectsManager;
-    uint callBackDepth;
     JsrtDebugDocumentManager* debugDocumentManager;
     JsrtDebugStackFrames* stackFrames;
     JsDiagBreakOnExceptionAttributes breakOnExceptionAttributes;

--- a/lib/Runtime/Debug/ProbeContainer.h
+++ b/lib/Runtime/Debug/ProbeContainer.h
@@ -63,7 +63,7 @@ namespace Js
         JsUtil::List<DWORD_PTR, ArenaAllocator> *registeredFuncContextList;
         JsUtil::List<const Js::PropertyRecord*> *pinnedPropertyRecords;
 
-        void UpdateFramePointers(bool fMatchWithCurrentScriptContext);
+        void UpdateFramePointers(bool fMatchWithCurrentScriptContext, DWORD_PTR dispatchHaltFrameAddress = 0);
         bool InitializeLocation(InterpreterHaltState* pHaltState, bool fMatchWithCurrentScriptContext = true);
         void DestroyLocation();
 
@@ -91,7 +91,7 @@ namespace Js
         void Initialize(ScriptContext* pScriptContext);
         void Close();
 
-        WeakDiagStack* GetFramePointers();
+        WeakDiagStack* GetFramePointers(DWORD_PTR dispatchHaltFrameAddress = 0);
 
         // A break engine responsible for breaking at iniline statement and error statement.
         void InitializeInlineBreakEngine(HaltCallback* pProbe);

--- a/test/Debugger/MultipleContextStack.js
+++ b/test/Debugger/MultipleContextStack.js
@@ -1,0 +1,53 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+// ScriptFunc1()
+// ScriptFunc2()
+// Script1Func1()
+// Script1Func2()
+// Script2Func1()
+// Script2Func2()
+// ScriptFunc3()
+// Script1Func3()
+// Script2Func3()
+
+var script1 = WScript.LoadScript("\
+  var scriptFunc2; \
+  var scriptFunc3; \
+  function Script1Func1() { scriptFunc2(); } \
+  function Script1Func2() { Script1Func1(); } \
+  function Script1Func3() { scriptFunc3(); } \
+  function setFunc2(func) { scriptFunc2 = func; } \
+  function setFunc3(func) { scriptFunc3 = func; }",
+  "samethread", "Script1.js");
+  
+var script2 = WScript.LoadScript(" \
+  var script1Func2; \
+  var script1Func3; \
+  function Script2Func1() { script1Func2(); } \
+  function Script2Func2() { Script2Func1(); } \
+  function Script2Func3() { script1Func3(); } \
+  function setFunc2(func) { script1Func2 = func; } \
+  function setFunc3(func) { script1Func3 = func; }",
+  "samethread", "Script2.js");
+  
+function Func2() {
+  Func1();
+}
+
+function Func3() {
+  script2.Script2Func2();
+}
+
+function Func1() {
+  var x = 1; /**bp:stack();locals(1);**/;
+}
+
+script2.setFunc2(script1.Script1Func2);
+script1.setFunc2(Func2);
+script1.setFunc3(Func3);
+script2.setFunc3(script1.Script1Func3);
+script2.Script2Func3();
+WScript.Echo("pass");

--- a/test/Debugger/MultipleContextStack.js.dbg.baseline
+++ b/test/Debugger/MultipleContextStack.js.dbg.baseline
@@ -1,0 +1,94 @@
+[
+  {
+    "callStack": [
+      {
+        "line": 44,
+        "column": 2,
+        "sourceText": "var x = 1",
+        "function": "Func1"
+      },
+      {
+        "line": 36,
+        "column": 2,
+        "sourceText": "Func1()",
+        "function": "Func2"
+      },
+      {
+        "line": 0,
+        "column": 66,
+        "sourceText": "scriptFunc2()",
+        "function": "Script1Func1"
+      },
+      {
+        "line": 0,
+        "column": 111,
+        "sourceText": "Script1Func1()",
+        "function": "Script1Func2"
+      },
+      {
+        "line": 0,
+        "column": 69,
+        "sourceText": "script1Func2()",
+        "function": "Script2Func1"
+      },
+      {
+        "line": 0,
+        "column": 115,
+        "sourceText": "Script2Func1()",
+        "function": "Script2Func2"
+      },
+      {
+        "line": 40,
+        "column": 2,
+        "sourceText": "script2.Script2Func2()",
+        "function": "Func3"
+      },
+      {
+        "line": 0,
+        "column": 157,
+        "sourceText": "scriptFunc3()",
+        "function": "Script1Func3"
+      },
+      {
+        "line": 0,
+        "column": 161,
+        "sourceText": "script1Func3()",
+        "function": "Script2Func3"
+      },
+      {
+        "line": 51,
+        "column": 0,
+        "sourceText": "script2.Script2Func3()",
+        "function": "Global code"
+      }
+    ]
+  },
+  {
+    "this": {
+      "telemetryLog": "function <large string>",
+      "Func2": "function <large string>",
+      "Func3": "function <large string>",
+      "Func1": "function <large string>",
+      "script1": "Object {...}",
+      "script2": "Object {...}"
+    },
+    "arguments": {
+      "#__proto__": "Object {...}",
+      "length": "number 0",
+      "callee": "function <large string>",
+      "Symbol.iterator": "function <large string>"
+    },
+    "locals": {
+      "x": "undefined undefined"
+    },
+    "globals": {
+      "WScript": "Object {...}",
+      "print": "function print",
+      "Func2": "function <large string>",
+      "Func3": "function <large string>",
+      "Func1": "function <large string>",
+      "script1": "Object {...}",
+      "script2": "Object {...}"
+    }
+  }
+]

--- a/test/Debugger/rlexe.xml
+++ b/test/Debugger/rlexe.xml
@@ -48,4 +48,10 @@
       <files>JsrtDebugUtilsAddPropertyType.js</files>
     </default>
   </test>
+  <test>
+    <default>
+      <compile-flags>-debuglaunch -dbgbaseline:MultipleContextStack.js.dbg.baseline</compile-flags>
+      <files>MultipleContextStack.js</files>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
When getting frame pointers only create DiagFrame for frames which are
below dispatch address.
