### PR TITLE
Wasm register space overflow checks

### DIFF
--- a/lib/Runtime/Language/AsmJsByteCodeGenerator.cpp
+++ b/lib/Runtime/Language/AsmJsByteCodeGenerator.cpp
@@ -186,14 +186,14 @@ namespace Js
     {
         // this value is the number of Var slots needed to allocate all the const
         int nbConst =
-            ((mFunction->GetRegisterSpace<double>().GetConstCount() + 1) * DOUBLE_SLOTS_SPACE) // space required for all double constants + 1 return register reserved
-            + (int)((mFunction->GetRegisterSpace<float>().GetConstCount() + 1)* FLOAT_SLOTS_SPACE + 0.5 /*ceil*/) // space required for all float constants + 1 return register reserved
-            + (int)((mFunction->GetRegisterSpace<int>().GetConstCount() + 1) * INT_SLOTS_SPACE + 0.5/*ceil*/) // space required for all int constants + 1 return register reserved
+            ((mFunction->GetRegisterSpace<double>().GetConstCount() + 1) * WAsmJs::DOUBLE_SLOTS_SPACE) // space required for all double constants + 1 return register reserved
+            + (int)((mFunction->GetRegisterSpace<float>().GetConstCount() + 1) * WAsmJs::FLOAT_SLOTS_SPACE + 0.5 /*ceil*/) // space required for all float constants + 1 return register reserved
+            + (int)((mFunction->GetRegisterSpace<int>().GetConstCount() + 1) * WAsmJs::INT_SLOTS_SPACE + 0.5/*ceil*/) // space required for all int constants + 1 return register reserved
             + AsmJsFunctionMemory::RequiredVarConstants;
 
         if (IsSimdjsEnabled())
         {
-            nbConst += (int)((mFunction->GetRegisterSpace<AsmJsSIMDValue>().GetConstCount() + 1) * SIMD_SLOTS_SPACE); // Return register is already reserved in the register space.
+            nbConst += (int)((mFunction->GetRegisterSpace<AsmJsSIMDValue>().GetConstCount() + 1) * WAsmJs::SIMD_SLOTS_SPACE); // Return register is already reserved in the register space.
         }
 
         byteCodeFunction->CheckAndSetConstantCount(nbConst);
@@ -3373,15 +3373,15 @@ namespace Js
    // int tab = 0;
     void AsmJSByteCodeGenerator::LoadModuleInt( RegSlot dst, RegSlot index )
     {
-        mWriter.AsmSlot(OpCodeAsmJs::LdSlot_Int, dst, AsmJsFunctionMemory::ModuleEnvRegister, index + (int32)(mCompiler->GetIntOffset() / INT_SLOTS_SPACE + 0.5));
+        mWriter.AsmSlot(OpCodeAsmJs::LdSlot_Int, dst, AsmJsFunctionMemory::ModuleEnvRegister, index + (int32)(mCompiler->GetIntOffset() / WAsmJs::INT_SLOTS_SPACE + 0.5));
     }
     void AsmJSByteCodeGenerator::LoadModuleFloat(RegSlot dst, RegSlot index)
     {
-        mWriter.AsmSlot(OpCodeAsmJs::LdSlot_Flt, dst, AsmJsFunctionMemory::ModuleEnvRegister, index + (int32)(mCompiler->GetFloatOffset() / FLOAT_SLOTS_SPACE + 0.5));
+        mWriter.AsmSlot(OpCodeAsmJs::LdSlot_Flt, dst, AsmJsFunctionMemory::ModuleEnvRegister, index + (int32)(mCompiler->GetFloatOffset() / WAsmJs::FLOAT_SLOTS_SPACE + 0.5));
     }
     void AsmJSByteCodeGenerator::LoadModuleDouble( RegSlot dst, RegSlot index )
     {
-        mWriter.AsmSlot(OpCodeAsmJs::LdSlot_Db, dst, AsmJsFunctionMemory::ModuleEnvRegister, index + mCompiler->GetDoubleOffset() / DOUBLE_SLOTS_SPACE);
+        mWriter.AsmSlot(OpCodeAsmJs::LdSlot_Db, dst, AsmJsFunctionMemory::ModuleEnvRegister, index + mCompiler->GetDoubleOffset() / WAsmJs::DOUBLE_SLOTS_SPACE);
     }
 
     void AsmJSByteCodeGenerator::LoadModuleFFI( RegSlot dst, RegSlot index )
@@ -3402,17 +3402,17 @@ namespace Js
 
     void AsmJSByteCodeGenerator::SetModuleInt( Js::RegSlot dst, RegSlot src )
     {
-        mWriter.AsmSlot(OpCodeAsmJs::StSlot_Int, src, AsmJsFunctionMemory::ModuleEnvRegister, dst + (int32)(mCompiler->GetIntOffset() / INT_SLOTS_SPACE + 0.5));
+        mWriter.AsmSlot(OpCodeAsmJs::StSlot_Int, src, AsmJsFunctionMemory::ModuleEnvRegister, dst + (int32)(mCompiler->GetIntOffset() / WAsmJs::INT_SLOTS_SPACE + 0.5));
     }
 
     void AsmJSByteCodeGenerator::SetModuleFloat(Js::RegSlot dst, RegSlot src)
     {
-        mWriter.AsmSlot(OpCodeAsmJs::StSlot_Flt, src, AsmJsFunctionMemory::ModuleEnvRegister, dst + (int32)(mCompiler->GetFloatOffset() / FLOAT_SLOTS_SPACE + 0.5));
+        mWriter.AsmSlot(OpCodeAsmJs::StSlot_Flt, src, AsmJsFunctionMemory::ModuleEnvRegister, dst + (int32)(mCompiler->GetFloatOffset() / WAsmJs::FLOAT_SLOTS_SPACE + 0.5));
     }
 
     void AsmJSByteCodeGenerator::SetModuleDouble( Js::RegSlot dst, RegSlot src )
     {
-        mWriter.AsmSlot(OpCodeAsmJs::StSlot_Db, src, AsmJsFunctionMemory::ModuleEnvRegister, dst + mCompiler->GetDoubleOffset() / DOUBLE_SLOTS_SPACE);
+        mWriter.AsmSlot(OpCodeAsmJs::StSlot_Db, src, AsmJsFunctionMemory::ModuleEnvRegister, dst + mCompiler->GetDoubleOffset() / WAsmJs::DOUBLE_SLOTS_SPACE);
     }
 
     void AsmJSByteCodeGenerator::LoadModuleSimd(RegSlot dst, RegSlot index, AsmJsVarType type)

--- a/lib/Runtime/Language/AsmJsModule.cpp
+++ b/lib/Runtime/Language/AsmJsModule.cpp
@@ -87,14 +87,14 @@ namespace Js
             asmInfo->SetIsHeapBufferConst(!mUsesChangeHeap);
             asmInfo->SetUsesHeapBuffer(mUsesHeapBuffer);
             int varCount = 0;
-            varCount += (int)((intRegisterSpace.GetTotalVarCount() * INT_SLOTS_SPACE) + 0.5);
-            varCount += (int)(floatRegisterSpace.GetTotalVarCount() * FLOAT_SLOTS_SPACE + 0.5);
-            varCount += doubleRegisterSpace.GetTotalVarCount() * DOUBLE_SLOTS_SPACE;
+            varCount += (int)((intRegisterSpace.GetTotalVarCount() * WAsmJs::INT_SLOTS_SPACE) + 0.5);
+            varCount += (int)(floatRegisterSpace.GetTotalVarCount() * WAsmJs::FLOAT_SLOTS_SPACE + 0.5);
+            varCount += doubleRegisterSpace.GetTotalVarCount() * WAsmJs::DOUBLE_SLOTS_SPACE;
 
             if (IsSimdjsEnabled())
             {
                 const auto& simdRegisterSpace = func->GetRegisterSpace<AsmJsSIMDValue>();
-                varCount += (int)((simdRegisterSpace.GetTotalVarCount() + 1) * SIMD_SLOTS_SPACE); /* + 1 to make room for possible alignment of SIMD values*/
+                varCount += (int)((simdRegisterSpace.GetTotalVarCount() + 1) * WAsmJs::SIMD_SLOTS_SPACE); /* + 1 to make room for possible alignment of SIMD values*/
                 // Aligned SIMD values.
                 Assert(asmInfo->GetSimdByteOffset() % sizeof(AsmJsSIMDValue) == 0);
             }
@@ -2401,21 +2401,21 @@ namespace Js
         mModuleMemory.mArrayBufferOffset = AsmJsModuleMemory::MemoryTableBeginOffset;
         mModuleMemory.mStdLibOffset = mModuleMemory.mArrayBufferOffset + 1;
         mModuleMemory.mDoubleOffset = mModuleMemory.mStdLibOffset + 1;
-        mModuleMemory.mFuncOffset = mModuleMemory.mDoubleOffset + (mDoubleVarSpace.GetTotalVarCount() * DOUBLE_SLOTS_SPACE);
+        mModuleMemory.mFuncOffset = mModuleMemory.mDoubleOffset + (mDoubleVarSpace.GetTotalVarCount() * WAsmJs::DOUBLE_SLOTS_SPACE);
         mModuleMemory.mFFIOffset = mModuleMemory.mFuncOffset + mFunctionArray.Count();
         mModuleMemory.mFuncPtrOffset = mModuleMemory.mFFIOffset + mImportFunctions.GetTotalVarCount();
         mModuleMemory.mFloatOffset = mModuleMemory.mFuncPtrOffset + GetFuncPtrTableCount();
-        mModuleMemory.mIntOffset = mModuleMemory.mFloatOffset + (int32)(mFloatVarSpace.GetTotalVarCount() * FLOAT_SLOTS_SPACE + 0.5);
-        mModuleMemory.mMemorySize    = mModuleMemory.mIntOffset + (int32)(mIntVarSpace.GetTotalVarCount() * INT_SLOTS_SPACE + 0.5);
+        mModuleMemory.mIntOffset = mModuleMemory.mFloatOffset + (int32)(mFloatVarSpace.GetTotalVarCount() * WAsmJs::FLOAT_SLOTS_SPACE + 0.5);
+        mModuleMemory.mMemorySize    = mModuleMemory.mIntOffset + (int32)(mIntVarSpace.GetTotalVarCount() * WAsmJs::INT_SLOTS_SPACE + 0.5);
 
         if (IsSimdjsEnabled())
         {
             // mSimdOffset is in SIMDValues, hence aligned
             // mMemorySize is in Vars
-            mModuleMemory.mSimdOffset = (int) ::ceil(mModuleMemory.mMemorySize / SIMD_SLOTS_SPACE);
+            mModuleMemory.mSimdOffset = (int) ::ceil(mModuleMemory.mMemorySize / WAsmJs::SIMD_SLOTS_SPACE);
             if (mSimdVarSpace.GetTotalVarCount())
             {
-                mModuleMemory.mMemorySize = (int)((mModuleMemory.mSimdOffset + mSimdVarSpace.GetTotalVarCount()) * SIMD_SLOTS_SPACE);
+                mModuleMemory.mMemorySize = (int)((mModuleMemory.mSimdOffset + mSimdVarSpace.GetTotalVarCount()) * WAsmJs::SIMD_SLOTS_SPACE);
             }
             
         }

--- a/lib/Runtime/Language/AsmJsUtils.h
+++ b/lib/Runtime/Language/AsmJsUtils.h
@@ -27,11 +27,6 @@
 #define MaybeTodo( expr ) AssertMsg( !(expr), "Unhandled scenario in asm.js" )
 
 namespace Js {
-    static const int DOUBLE_SLOTS_SPACE = (sizeof(double) / sizeof(Var)); // 2 in x86 and 1 in x64
-    static const double FLOAT_SLOTS_SPACE = (sizeof(float) / (double)sizeof(Var)); // 1 in x86 and 0.5 in x64
-    static const double INT_SLOTS_SPACE = ( sizeof( int ) / (double)sizeof( Var ) ); // 1 in x86 and 0.5 in x64
-    static const double SIMD_SLOTS_SPACE = (sizeof(SIMDValue) / sizeof(Var)); // 4 in x86 and 2 in x64
-
     Var AsmJsChangeHeapBuffer(RecyclableObject * function, CallInfo callInfo, ...);
 
 #if _M_X64

--- a/lib/Runtime/Language/Chakra.Runtime.Language.vcxproj
+++ b/lib/Runtime/Language/Chakra.Runtime.Language.vcxproj
@@ -181,6 +181,7 @@
     <ClInclude Include="AsmJs.h" />
     <ClInclude Include="AsmJsByteCodeGenerator.h" />
     <ClInclude Include="AsmJsCodeGenerator.h" />
+    <ClInclude Include="WAsmJsConstants.h" />
     <ClInclude Include="AsmJsEncoder.h">
       <ExcludedFromBuild Condition="'$(Platform)'!='Win32' AND '$(Platform)'!='x64'">true</ExcludedFromBuild>
     </ClInclude>

--- a/lib/Runtime/Language/Chakra.Runtime.Language.vcxproj.filters
+++ b/lib/Runtime/Language/Chakra.Runtime.Language.vcxproj.filters
@@ -60,7 +60,6 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)TaggedInt.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)RuntimeLanguagePch.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)JavascriptNativeOperators.cpp" />
-    <ClCompile Include="SourceTextModuleRecord.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)SimdInt16x8Operation.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)SimdInt16x8OperationX86X64.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)SimdUint32x4Operation.cpp" />
@@ -75,7 +74,8 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)SimdBool16x8OperationX86X64.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)SimdBool8x16Operation.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)SimdBool8x16OperationX86X64.cpp" />
-    <ClCompile Include="ModuleNamespace.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)ModuleNamespace.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)SourceTextModuleRecord.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="AsmJs.h" />
@@ -146,6 +146,8 @@
     <ClInclude Include="SimdBool32x4Operation.h" />
     <ClInclude Include="SimdBool16x8Operation.h" />
     <ClInclude Include="SimdBool8x16Operation.h" />
+    <ClInclude Include="ModuleNamespace.h" />
+    <ClInclude Include="WAsmJsConstants.h" />
   </ItemGroup>
   <ItemGroup>
     <MASM Include="$(MSBuildThisFileDirectory)amd64\amd64_Thunks.asm">

--- a/lib/Runtime/Language/RuntimeLanguagePch.h
+++ b/lib/Runtime/Language/RuntimeLanguagePch.h
@@ -14,6 +14,7 @@
 #include "Language/AsmJsLink.h"
 #include "Language/AsmJsModule.h"
 #include "Language/AsmJs.h"
+#include "Language/WAsmJsConstants.h"
 #ifdef ASMJS_PLAT
 #include "Language/AsmJsJitTemplate.h"
 #include "Language/AsmJsEncoder.h"

--- a/lib/Runtime/Language/WAsmJsConstants.h
+++ b/lib/Runtime/Language/WAsmJsConstants.h
@@ -1,0 +1,18 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+// Portions of this file are copyright 2014 Mozilla Foundation, available under the Apache 2.0 license.
+//-------------------------------------------------------------------------------------------------------
+
+#pragma once
+
+#ifndef TEMP_DISABLE_ASMJS
+
+namespace WAsmJs {
+    static const int DOUBLE_SLOTS_SPACE = (sizeof(double) / sizeof(Js::Var)); // 2 in x86 and 1 in x64
+    static const double FLOAT_SLOTS_SPACE = (sizeof(float) / (double)sizeof(Js::Var)); // 1 in x86 and 0.5 in x64
+    static const double INT_SLOTS_SPACE = (sizeof(int) / (double)sizeof(Js::Var)); // 1 in x86 and 0.5 in x64
+    static const int SIMD_SLOTS_SPACE = (sizeof(SIMDValue) / sizeof(Js::Var)); // 4 in x86 and 2 in x64
+};
+
+#endif

--- a/lib/WasmReader/WasmReaderPch.h
+++ b/lib/WasmReader/WasmReaderPch.h
@@ -13,6 +13,7 @@
 #ifdef ENABLE_WASM
 // AsmJsFunctionMemory::RequiredVarConstants
 #include "../Language/AsmJsModule.h"
+#include "../Language/WAsmJsConstants.h"
 #endif
 
 // Runtime includes


### PR DESCRIPTION
Added some overflow checks for Wasm register space calculations. 
Added a file for constants shared between asmjs and wasm. 
Fix how we calculate constant space in the constant table for wasm.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/1206)
<!-- Reviewable:end -->
