### PR TITLE
Return a value from pre_pgi.cmd to imply check passed

### DIFF
--- a/Build/scripts/pgo/pre_pgi.cmd
+++ b/Build/scripts/pgo/pre_pgi.cmd
@@ -46,7 +46,7 @@ set POGO_TYPE=PGI
 REM Temporary fix around pgo bug, todo:: check if still necessary once toolset is updated
 set _LINK_=/cgthreads:1
 
-goto:eof
+goto:checkpass
 
 :usage
   echo Invalid/missing arguments
@@ -57,3 +57,6 @@ goto:eof
   echo   - binary_path: output path of your binaries
 
 exit /b 1
+
+:checkpass
+exit /b 0


### PR DESCRIPTION
Pre_pgi.cmd doesn't exit with 0 explicitly after all check passed. The caller (pogo.git.bat) will get incorrect %errorlevel% if it was set previously.