### PR TITLE
Clean up in BailOnNotStackArgs OpCode Lowering

### DIFF
--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -4180,7 +4180,6 @@ GlobOpt::OptArguments(IR::Instr *instr)
     }
     case Js::OpCode::BailOnNotStackArgs:
     case Js::OpCode::ArgOut_A_FromStackArgs:
-    case Js::OpCode::LdArgumentsFromStack:
     case Js::OpCode::BytecodeArgOutUse:
         break;
 
@@ -18760,9 +18759,13 @@ GlobOpt::OptIsInvariant(
 
     switch(instr->m_opcode)
     {
-
         // Can't legally hoist these
     case Js::OpCode::LdLen_A:
+        return false;
+
+        //Can't Hoist BailOnNotStackArgs, as it is necessary as InlineArgsOptimization relies on this opcode 
+        //to decide whether to throw rejit exception or not.
+    case Js::OpCode::BailOnNotStackArgs:
         return false;
 
         // Usually not worth hoisting these

--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -239,10 +239,6 @@ Lowerer::LowerRange(IR::Instr *instrStart, IR::Instr *instrEnd, bool defaultDoFa
             instrPrev = m_lowererMD.LoadHeapArguments(instr);
             break;
 
-        case Js::OpCode::LdArgumentsFromStack:
-            instrPrev = this->LoadArgumentsFromStack(instr);
-            break;
-
         case Js::OpCode::LdHeapArgsCached:
         case Js::OpCode::LdLetHeapArgsCached:
             m_lowererMD.LoadHeapArgsCached(instr);
@@ -10639,25 +10635,6 @@ Lowerer::LowerCondBranchCheckBailOut(IR::BranchInstr * branchInstr, IR::Instr * 
     return m_lowererMD.LowerCondBranch(branchInstr);
 }
 
-IR::Instr *
-Lowerer::LoadArgumentsFromStack(IR::Instr * instr)
-{
-    IR::Instr * prevInstr = instr->m_prev;
-
-    Assert(instr->GetDst()->IsRegOpnd());
-    if (instr->m_func->IsInlinee())
-    {
-        instr->ReplaceSrc1(instr->m_func->GetInlineeArgumentsObjectSlotOpnd());
-    }
-    else
-    {
-        instr->ReplaceSrc1(this->m_lowererMD.CreateStackArgumentsSlotOpnd());
-    }
-    this->m_lowererMD.ChangeToAssign(instr);
-
-    return prevInstr;
-}
-
 IR::SymOpnd *
 Lowerer::LoadCallInfo(IR::Instr * instrInsert)
 {
@@ -10728,28 +10705,24 @@ Lowerer::LowerBailOnNotStackArgs(IR::Instr * instr)
         instr->InsertAfter(continueLabelInstr);
     }
 
-    IR::LabelInstr * helperLabelInstr = IR::LabelInstr::New(Js::OpCode::Label, m_func, true);
     if (!instr->m_func->IsInlinee())
     {
-        //BailOut if it is not stack args or the number of actuals (except "this" argument) is greater than or equal to 15.
-        IR::Opnd* stackArgs = instr->UnlinkSrc1();
-        InsertCompareBranch(stackArgs, instr->UnlinkSrc2(), Js::OpCode::BrNeq_A, helperLabelInstr, instr);
-
+        //BailOut if the number of actuals (except "this" argument) is greater than or equal to 15.
         IR::RegOpnd* ldLenDstOpnd = IR::RegOpnd::New(TyUint32, instr->m_func);
-        IR::Instr* ldLen = IR::Instr::New(Js::OpCode::LdLen_A, ldLenDstOpnd, stackArgs, instr->m_func);
+        IR::Instr* ldLen = IR::Instr::New(Js::OpCode::LdLen_A, ldLenDstOpnd, instr->m_func);
         ldLenDstOpnd->SetValueType(ValueType::GetTaggedInt()); //LdLen_A works only on stack arguments
         instr->InsertBefore(ldLen);
         this->GenerateFastRealStackArgumentsLdLen(ldLen);
         this->InsertCompareBranch(ldLenDstOpnd, IR::IntConstOpnd::New(Js::InlineeCallInfo::MaxInlineeArgoutCount, TyUint32, m_func, true),  Js::OpCode::BrLt_A, true, continueLabelInstr, instr);
+        this->GenerateBailOut(instr, nullptr, nullptr);
     }
     else
     {
         //For Inlined functions, we are sure actuals can't exceed Js::InlineeCallInfo::MaxInlineeArgoutCount (15).
-        InsertCompareBranch(instr->UnlinkSrc1(), instr->UnlinkSrc2(), Js::OpCode::BrEq_A, continueLabelInstr, instr);
+        //No need to bail out.
+        instr->Remove();
     }
 
-    instr->InsertBefore(helperLabelInstr);
-    this->GenerateBailOut(instr, nullptr, nullptr);
     return prevInstr;
 }
 

--- a/lib/Backend/Lower.h
+++ b/lib/Backend/Lower.h
@@ -422,8 +422,6 @@ private:
     void            LowerInlineeStart(IR::Instr * instr);
     void            LowerInlineeEnd(IR::Instr * instr);
 
-    IR::Instr*      LoadArgumentsFromStack(IR::Instr * instr);
-
     static
     IR::SymOpnd*    LoadCallInfo(IR::Instr * instrInsert);
 

--- a/lib/Runtime/ByteCode/OpCodes.h
+++ b/lib/Runtime/ByteCode/OpCodes.h
@@ -472,7 +472,6 @@ MACRO_BACKEND_ONLY(     StLoopBodyCount,    Reg1,           OpSideEffect)   // f
 
 MACRO_WMS(              LdHeapArguments,    Reg1,           OpSideEffect)   // Load the heap-based "arguments" object
 MACRO_WMS(              LdLetHeapArguments, Reg1,           OpSideEffect)   // Load the heap-based "arguments" object (formals are let-like instead of var-like)
-MACRO_BACKEND_ONLY(     LdArgumentsFromStack,Reg1,          None)           // Load the heap-based "arguments" object even if it is null (Loads from meta arguments location for inlinee as well).
 MACRO_WMS(              LdHeapArgsCached,   Reg1,           OpSideEffect)   // Load the heap-based "arguments" object in a cached scope
 MACRO_EXTEND_WMS(       LdLetHeapArgsCached,Reg1,           OpSideEffect)   // Load the heap-based "arguments" object in a cached scope (formals are let-like instead of var-like)
 MACRO_EXTEND_WMS(       LdStackArgPtr,      Reg1,           OpSideEffect)   // Load the address of the base of the input parameter area


### PR DESCRIPTION
caller.arguments creates a copy of the heap arguments object with the actuals values. So we don't have to TEST for heap arguments object on the stack slot.

Perf test:
No  difference in the benchmarks.
UTs passed.
