### PR TITLE
Fix a with-related precise-capture bug

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -5265,10 +5265,11 @@ bool Parser::ParseFncDeclHelper(ParseNodePtr pnodeFnc, LPCOLESTR pNameHint, usho
             m_currentNodeNonLambdaDeferredFunc = pnodeFncSaveNonLambda;
         }
         m_currentNodeDeferredFunc = pnodeFncSave;
-        if (m_currentNodeFunc && pnodeFnc->sxFnc.HasWithStmt())
-        {
-            GetCurrentFunctionNode()->sxFnc.SetHasWithStmt(true);
-        }
+    }
+
+    if (m_currentNodeFunc && pnodeFnc->sxFnc.HasWithStmt())
+    {
+        GetCurrentFunctionNode()->sxFnc.SetHasWithStmt(true);
     }
 
     return true;


### PR DESCRIPTION
Fix a precise-capture bug exposed in the unreleased branch. Also make our conservative with-statement closure-capture code immune to deferred nested functions.
