### PR TITLE
xplat: some JSRT fixes

### DIFF
--- a/bin/ch/ChakraRtInterface.h
+++ b/bin/ch/ChakraRtInterface.h
@@ -71,8 +71,8 @@ struct JsAPIHooks
     typedef JsErrorCode(WINAPI *JsrtRunModuleUtf8Ptr)(const char *script, JsSourceContext sourceContext, const char *sourceUrl, JsValueRef *result);
     typedef JsErrorCode(WINAPI *JsrtStringFreePtr)(const char *stringValue);
 
-    typedef JsErrorCode(WINAPI *JsrtTTDCreateRecordRuntimePtr)(JsRuntimeAttributes attributes, char* infoUri, charcount_t infoUriCount, UINT32 snapInterval, UINT32 snapHistoryLength, JsThreadServiceCallback threadService, JsRuntimeHandle *runtime);
-    typedef JsErrorCode(WINAPI *JsrtTTDCreateDebugRuntimePtr)(JsRuntimeAttributes attributes, char* infoUri, charcount_t infoUriCount, JsThreadServiceCallback threadService, JsRuntimeHandle *runtime);
+    typedef JsErrorCode(WINAPI *JsrtTTDCreateRecordRuntimePtr)(JsRuntimeAttributes attributes, char* infoUri, size_t infoUriCount, UINT32 snapInterval, UINT32 snapHistoryLength, JsThreadServiceCallback threadService, JsRuntimeHandle *runtime);
+    typedef JsErrorCode(WINAPI *JsrtTTDCreateDebugRuntimePtr)(JsRuntimeAttributes attributes, char* infoUri, size_t infoUriCount, JsThreadServiceCallback threadService, JsRuntimeHandle *runtime);
     typedef JsErrorCode(WINAPI *JsrtTTDCreateContextPtr)(JsRuntimeHandle runtime, JsContextRef *newContext);
     typedef JsErrorCode(WINAPI *JsrtTTDRunScriptPtr)(INT64 hostCallbackId, const char *script, JsSourceContext sourceContext, const char *sourceUrl, JsValueRef* result);
     typedef JsErrorCode(WINAPI *JsrtTTDCallFunctionPtr)(INT64 hostCallbackId, JsValueRef function, JsValueRef* arguments, unsigned short argumentCount, JsValueRef *result);
@@ -332,8 +332,8 @@ public:
     static JsErrorCode WINAPI JsRunModuleUtf8(const char *script, JsSourceContext sourceContext, const char *sourceUrl, JsValueRef *result) { return HOOK_JS_API(ExperimentalApiRunModuleUtf8(script, sourceContext, sourceUrl, result)); }
     static JsErrorCode WINAPI JsPointerToStringUtf8(const char *stringValue, size_t length, JsValueRef *value) { return HOOK_JS_API(PointerToStringUtf8(stringValue, length, value)); }
     static JsErrorCode WINAPI JsStringFree(char *stringValue) { return HOOK_JS_API(StringFree(stringValue)); }
-    static JsErrorCode WINAPI JsTTDCreateRecordRuntime(JsRuntimeAttributes attributes, char* infoUri, charcount_t infoUriCount, UINT32 snapInterval, UINT32 snapHistoryLength, JsThreadServiceCallback threadService, JsRuntimeHandle *runtime) { return HOOK_JS_API(TTDCreateRecordRuntime(attributes, infoUri, infoUriCount, snapInterval, snapHistoryLength, threadService, runtime)); }
-    static JsErrorCode WINAPI JsTTDCreateDebugRuntime(JsRuntimeAttributes attributes, char* infoUri, charcount_t infoUriCount, JsThreadServiceCallback threadService, JsRuntimeHandle *runtime) { return HOOK_JS_API(TTDCreateDebugRuntime(attributes, infoUri, infoUriCount, threadService, runtime)); }
+    static JsErrorCode WINAPI JsTTDCreateRecordRuntime(JsRuntimeAttributes attributes, char* infoUri, size_t infoUriCount, UINT32 snapInterval, UINT32 snapHistoryLength, JsThreadServiceCallback threadService, JsRuntimeHandle *runtime) { return HOOK_JS_API(TTDCreateRecordRuntime(attributes, infoUri, infoUriCount, snapInterval, snapHistoryLength, threadService, runtime)); }
+    static JsErrorCode WINAPI JsTTDCreateDebugRuntime(JsRuntimeAttributes attributes, char* infoUri, size_t infoUriCount, JsThreadServiceCallback threadService, JsRuntimeHandle *runtime) { return HOOK_JS_API(TTDCreateDebugRuntime(attributes, infoUri, infoUriCount, threadService, runtime)); }
     static JsErrorCode WINAPI JsTTDCreateContext(JsRuntimeHandle runtime, JsContextRef *newContext) { return HOOK_JS_API(TTDCreateContext(runtime, newContext)); }
     static JsErrorCode WINAPI JsTTDRunScript(INT64 hostCallbackId, const char* script, DWORD_PTR sourceContext, const char* sourceUrl, JsValueRef* result) { return HOOK_JS_API(TTDRunScript(hostCallbackId, script, sourceContext, sourceUrl, result)); }
     static JsErrorCode WINAPI JsTTDCallFunction(INT64 hostCallbackId, JsValueRef function, JsValueRef* arguments, unsigned short argumentCount, JsValueRef *result) { return HOOK_JS_API(TTDCallFunction(hostCallbackId, function, arguments, argumentCount, result)); }

--- a/lib/Jsrt/ChakraCommon.h
+++ b/lib/Jsrt/ChakraCommon.h
@@ -50,6 +50,7 @@ typedef BYTE* ChakraBytePtr;
 #define _Outptr_result_bytebuffer_(byteLength)
 #define _Outptr_result_z_
 #define _Ret_maybenull_
+#define _Out_writes_(size)
 #define _Out_writes_to_opt_(byteLength, byteLength2)
 
 // Header macros
@@ -60,11 +61,13 @@ typedef BYTE* ChakraBytePtr;
 #endif // __i386__
 
 #ifdef __cplusplus
-#define CHAKRA_API extern "C" JsErrorCode 
+#define CHAKRA_API extern "C" JsErrorCode
 #else
 #define CHAKRA_API JsErrorCode
 #endif
 
+#include <stddef.h>  // for size_t
+#include <stdint.h>  // for uintptr_t
 typedef uintptr_t ChakraCookie;
 typedef unsigned char* ChakraBytePtr;
 #endif //  defined(_WIN32) && defined(_MSC_VER)
@@ -72,7 +75,7 @@ typedef unsigned char* ChakraBytePtr;
     /// <summary>
     ///     An error code returned from a Chakra hosting API.
     /// </summary>
-    typedef _Return_type_success_(return == 0) enum _JsErrorCode 
+    typedef _Return_type_success_(return == 0) enum _JsErrorCode
     {
         /// <summary>
         ///     Success error code.
@@ -476,7 +479,7 @@ typedef unsigned char* ChakraBytePtr;
         /// </summary>
         JsPropertyIdTypeSymbol
     } JsPropertyIdType;
- 
+
     /// <summary>
     ///     The JavaScript type of a JsValueRef.
     /// </summary>
@@ -535,7 +538,7 @@ typedef unsigned char* ChakraBytePtr;
         /// </summary>
         JsDataView = 12,
     } JsValueType;
- 
+
     /// <summary>
     ///     User implemented callback routine for memory allocation events
     /// </summary>
@@ -1285,8 +1288,8 @@ typedef unsigned char* ChakraBytePtr;
         JsStringToPointerUtf8Copy(
             _In_ JsValueRef value,
             _Outptr_result_buffer_(*stringLength) char **stringValue,
-            _Out_ size_t *stringLength); 
-    
+            _Out_ size_t *stringLength);
+
     /// <summary>
     ///     Gets the symbol associated with the property ID.
     /// </summary>
@@ -2634,7 +2637,7 @@ typedef unsigned char* ChakraBytePtr;
     CHAKRA_API
         JsStringFree(
             _In_ char* stringValue);
-            
+
 #ifdef _WIN32
 #include "ChakraCommonWindows.h"
 #endif // _WIN32

--- a/lib/Jsrt/ChakraDebug.h
+++ b/lib/Jsrt/ChakraDebug.h
@@ -22,6 +22,14 @@
 
 #include "ChakraCommon.h"
 
+#if !defined(_WIN32) || !defined(_MSC_VER)
+typedef uint32_t UINT32;
+typedef int64_t INT64;
+typedef void* HANDLE;
+typedef unsigned char BYTE;
+typedef UINT32 DWORD;
+#endif
+
     /// <summary>
     ///     Debug events reported from ChakraCore engine.
     /// </summary>
@@ -629,25 +637,25 @@
     /////////////////////
     /// <summary>
     ///     TTD API -- may change in future versions:
-    ///     Given the uri location specified for the TTD output data, which may be relative or contain other implcit information, 
-    ///     convert it into a fully normalized location descriptor. This fully resolved location will be passed to the later callbacks 
+    ///     Given the uri location specified for the TTD output data, which may be relative or contain other implcit information,
+    ///     convert it into a fully normalized location descriptor. This fully resolved location will be passed to the later callbacks
     ///     such as JsTTDInitializeForWriteLogStreamCallback, JsTTDGetLogStreamCallback, and JsTTDGetSnapshotStreamCallback.
     /// </summary>
     /// <param name="uri">The uri the user provided for the output location of the TTD data.</param>
     /// <param name="fullTTDUri">The fully resolved location for the TTD data output.</param>
-    typedef void (CALLBACK *JsTTDInitializeUriCallback)(_In_z_ const wchar_t* uri, _Out_ wchar_t** fullTTDUri);
+    typedef void (CHAKRA_CALLBACK *JsTTDInitializeUriCallback)(_In_z_ const wchar_t* uri, _Out_ wchar_t** fullTTDUri);
 
     /// <summary>
     ///     TTD API -- may change in future versions:
-    ///     Ensure that the location specified for outputting the TTD data is clean. Specifically, ensure that any previous TTD 
+    ///     Ensure that the location specified for outputting the TTD data is clean. Specifically, ensure that any previous TTD
     ///     in the location has been removed.
     /// </summary>
     /// <param name="fullTTDUri">The fully resolved location for the TTD data output as provied by JsTTDInitializeUriCallback.</param>
-    typedef void (CALLBACK *JsTTDInitializeForWriteLogStreamCallback)(_In_z_ const wchar_t* uri);
+    typedef void (CHAKRA_CALLBACK *JsTTDInitializeForWriteLogStreamCallback)(_In_z_ const wchar_t* uri);
 
     /// <summary>
     ///     TTD API -- may change in future versions:
-    ///     Construct a HANDLE that will be used to read/write the event log portion of the TTD data based on the uri 
+    ///     Construct a HANDLE that will be used to read/write the event log portion of the TTD data based on the uri
     ///     provided by JsTTDInitializeUriCallback.
     /// </summary>
     /// <remarks>
@@ -657,7 +665,7 @@
     /// <param name="read">If the handle should be opened for reading.</param>
     /// <param name="write">If the handle should be opened for writing.</param>
     /// <returns>A HANDLE opened in read/write mode as specified.</returns>
-    typedef HANDLE(CALLBACK *JsTTDGetLogStreamCallback)(_In_z_ const wchar_t* uri, _In_ bool read, _In_ bool write);
+    typedef HANDLE (CHAKRA_CALLBACK *JsTTDGetLogStreamCallback)(_In_z_ const wchar_t* uri, _In_ bool read, _In_ bool write);
 
     /// <summary>
     ///     TTD API -- may change in future versions:
@@ -671,7 +679,7 @@
     /// <param name="read">If the handle should be opened for reading.</param>
     /// <param name="write">If the handle should be opened for writing.</param>
     /// <returns>A HANDLE opened in read/write mode as specified.</returns>
-    typedef HANDLE(CALLBACK *JsTTDGetSnapshotStreamCallback)(_In_z_ const wchar_t* uri, _In_z_ const wchar_t* snapId, _In_ bool read, _In_ bool write);
+    typedef HANDLE (CHAKRA_CALLBACK *JsTTDGetSnapshotStreamCallback)(_In_z_ const wchar_t* uri, _In_z_ const wchar_t* snapId, _In_ bool read, _In_ bool write);
 
     /// <summary>
     ///     TTD API -- may change in future versions:
@@ -686,7 +694,7 @@
     /// <param name="read">If the handle should be opened for reading.</param>
     /// <param name="write">If the handle should be opened for writing.</param>
     /// <returns>A HANDLE opened in read/write mode as specified.</returns>
-    typedef HANDLE(CALLBACK *JsTTDGetSrcCodeStreamCallback)(_In_z_ const wchar_t* uri, _In_z_ const wchar_t* bodyCtrId, _In_z_ const wchar_t* srcFileName, _In_ bool read, _In_ bool write);
+    typedef HANDLE (CHAKRA_CALLBACK *JsTTDGetSrcCodeStreamCallback)(_In_z_ const wchar_t* uri, _In_z_ const wchar_t* bodyCtrId, _In_z_ const wchar_t* srcFileName, _In_ bool read, _In_ bool write);
 
     /// <summary>
     ///     TTD API -- may change in future versions:
@@ -697,7 +705,7 @@
     /// <param name="size">The max number of bytes that should be read.</param>
     /// <param name="readCount">The actual number of bytes read and placed in the buffer.</param>
     /// <returns>true if the read was successful false otherwise.</returns>
-    typedef bool(CALLBACK *JsTTDReadBytesFromStreamCallback)(_In_ HANDLE handle, _Out_writes_(size) BYTE* buff, _In_ DWORD size, _Out_ DWORD* readCount);
+    typedef bool (CHAKRA_CALLBACK *JsTTDReadBytesFromStreamCallback)(_In_ HANDLE handle, _Out_writes_(size) BYTE* buff, _In_ DWORD size, _Out_ DWORD* readCount);
 
     /// <summary>
     ///     TTD API -- may change in future versions:
@@ -708,7 +716,7 @@
     /// <param name="size">The max number of bytes that should be written.</param>
     /// <param name="readCount">The actual number of bytes written to the HANDLE.</param>
     /// <returns>true if the write was successful false otherwise.</returns>
-    typedef bool(CALLBACK *JsTTDWriteBytesToStreamCallback)(_In_ HANDLE handle, _In_reads_(size) BYTE* buff, _In_ DWORD size, _Out_ DWORD* writtenCount);
+    typedef bool (CHAKRA_CALLBACK *JsTTDWriteBytesToStreamCallback)(_In_ HANDLE handle, _In_reads_(size) BYTE* buff, _In_ DWORD size, _Out_ DWORD* writtenCount);
 
     /// <summary>
     ///     TTD API -- may change in future versions:
@@ -720,7 +728,7 @@
     /// <param name="handle">The HANDLE to close.</param>
     /// <param name="read">If the handle was opened for reading.</param>
     /// <param name="write">If the handle was opened for writing.</param>
-    typedef void (CALLBACK *JsTTDFlushAndCloseStreamCallback)(_In_ HANDLE handle, _In_ bool read, _In_ bool write);
+    typedef void (CHAKRA_CALLBACK *JsTTDFlushAndCloseStreamCallback)(_In_ HANDLE handle, _In_ bool read, _In_ bool write);
 
     /// <summary>
     ///     TTD API -- may change in future versions:
@@ -742,7 +750,7 @@
         JsTTDCreateRecordRuntime(
             _In_ JsRuntimeAttributes attributes,
             _In_z_ char* infoUri,
-            _In_ charcount_t infoUriCount,
+            _In_ size_t infoUriCount,
             _In_ UINT32 snapInterval,
             _In_ UINT32 snapHistoryLength,
             _In_opt_ JsThreadServiceCallback threadService,
@@ -766,7 +774,7 @@
         JsTTDCreateDebugRuntime(
             _In_ JsRuntimeAttributes attributes,
             _In_z_ char* infoUri,
-            _In_ charcount_t infoUriCount,
+            _In_ size_t infoUriCount,
             _In_opt_ JsThreadServiceCallback threadService,
             _Out_ JsRuntimeHandle *runtime);
 
@@ -815,7 +823,7 @@
     /// </summary>
     /// <remarks>
     ///     <para>
-    ///         Requires thisArg as first argument of arguments. 
+    ///         Requires thisArg as first argument of arguments.
     ///         Requires an active script context.
     ///     </para>
     /// </remarks>

--- a/lib/Jsrt/Jsrt.cpp
+++ b/lib/Jsrt/Jsrt.cpp
@@ -27,18 +27,18 @@
 #if !ENABLE_TTD
 #define PERFORM_JSRT_TTD_RECORD_ACTION_CHECK(CTX) false
 
-#define PERFORM_JSRT_TTD_RECORD_ACTION_NORESULT(CTX, ACTION_CODE) 
-#define PERFORM_JSRT_TTD_RECORD_ACTION_WRESULT(CTX, ACTION_CODE) 
-#define PERFORM_JSRT_TTD_RECORD_ACTION_PROCESS_RESULT(RESULT) 
+#define PERFORM_JSRT_TTD_RECORD_ACTION_NORESULT(CTX, ACTION_CODE)
+#define PERFORM_JSRT_TTD_RECORD_ACTION_WRESULT(CTX, ACTION_CODE)
+#define PERFORM_JSRT_TTD_RECORD_ACTION_PROCESS_RESULT(RESULT)
 
 //TODO: find and replace all of the occourences of this in jsrt.cpp
-#define PERFORM_JSRT_TTD_RECORD_ACTION_NOT_IMPLEMENTED(CTX) 
+#define PERFORM_JSRT_TTD_RECORD_ACTION_NOT_IMPLEMENTED(CTX)
 #endif
 
 struct CodexHeapAllocatorInterface
 {
 public:
-    static void* allocate(size_t size) 
+    static void* allocate(size_t size)
     {
         return HeapNewArray(char, size);
     }
@@ -101,7 +101,7 @@ JsErrorCode CheckContext(JsrtContext *currentContext, bool verifyRuntimeState, b
 /////////////////////
 
 //A create runtime function that we can funnel to for regular and record or debug aware creation
-JsErrorCode CreateRuntimeCore(_In_ JsRuntimeAttributes attributes, _In_opt_ char* optRecordUri, charcount_t optRecordUriCount, _In_opt_ char* optDebugUri, charcount_t optDebugUriCount, _In_ UINT32 snapInterval, _In_ UINT32 snapHistoryLength, _In_opt_ JsThreadServiceCallback threadService, _Out_ JsRuntimeHandle *runtimeHandle)
+JsErrorCode CreateRuntimeCore(_In_ JsRuntimeAttributes attributes, _In_opt_ char* optRecordUri, size_t optRecordUriCount, _In_opt_ char* optDebugUri, size_t optDebugUriCount, _In_ UINT32 snapInterval, _In_ UINT32 snapHistoryLength, _In_opt_ JsThreadServiceCallback threadService, _Out_ JsRuntimeHandle *runtimeHandle)
 {
     VALIDATE_ENTER_CURRENT_THREAD();
 
@@ -2774,7 +2774,7 @@ CHAKRA_API JsGetPropertyNameFromId(_In_ JsPropertyIdRef propertyId, _Outptr_resu
 CHAKRA_API JsGetPropertyNameFromIdUtf8Copy(_In_ JsPropertyIdRef propertyId, _Outptr_result_z_ char **name)
 {
     const wchar_t *wname = nullptr;
- 
+
     JsErrorCode err = JsGetPropertyNameFromId(propertyId, &wname);
 
     if (err == JsNoError)
@@ -3444,8 +3444,8 @@ CHAKRA_API JsStringFree(_In_ char* stringValue)
 
 /////////////////////
 
-CHAKRA_API JsTTDCreateRecordRuntime(_In_ JsRuntimeAttributes attributes, _In_z_ char* infoUri, _In_ charcount_t infoUriCount,
-    _In_ UINT32 snapInterval, _In_ UINT32 snapHistoryLength, 
+CHAKRA_API JsTTDCreateRecordRuntime(_In_ JsRuntimeAttributes attributes, _In_z_ char* infoUri, _In_ size_t infoUriCount,
+    _In_ UINT32 snapInterval, _In_ UINT32 snapHistoryLength,
     _In_opt_ JsThreadServiceCallback threadService, _Out_ JsRuntimeHandle *runtime)
 {
 #if !ENABLE_TTD
@@ -3455,7 +3455,7 @@ CHAKRA_API JsTTDCreateRecordRuntime(_In_ JsRuntimeAttributes attributes, _In_z_ 
 #endif
 }
 
-CHAKRA_API JsTTDCreateDebugRuntime(_In_ JsRuntimeAttributes attributes, _In_z_ char* infoUri, _In_ charcount_t infoUriCount,
+CHAKRA_API JsTTDCreateDebugRuntime(_In_ JsRuntimeAttributes attributes, _In_z_ char* infoUri, _In_ size_t infoUriCount,
     _In_opt_ JsThreadServiceCallback threadService, _Out_ JsRuntimeHandle *runtime)
 {
 #if !ENABLE_TTD
@@ -3474,7 +3474,7 @@ CHAKRA_API JsTTDCreateContext(_In_ JsRuntimeHandle runtime, _Out_ JsContextRef *
 #endif
 }
 
-CHAKRA_API JsTTDRunScript(_In_ INT64 hostCallbackId, _In_z_ const char *script, _In_ JsSourceContext sourceContext, 
+CHAKRA_API JsTTDRunScript(_In_ INT64 hostCallbackId, _In_z_ const char *script, _In_ JsSourceContext sourceContext,
     _In_z_ const char *sourceUrl, _Out_ JsValueRef *result)
 {
 #if !ENABLE_TTD
@@ -3484,7 +3484,7 @@ CHAKRA_API JsTTDRunScript(_In_ INT64 hostCallbackId, _In_z_ const char *script, 
 #endif
 }
 
-CHAKRA_API JsTTDCallFunction(_In_ INT64 hostCallbackId, _In_ JsValueRef function, 
+CHAKRA_API JsTTDCallFunction(_In_ INT64 hostCallbackId, _In_ JsValueRef function,
     _In_reads_(argumentCount) JsValueRef *arguments, _In_ unsigned short argumentCount, _Out_opt_ JsValueRef *result)
 {
 #if !ENABLE_TTD
@@ -3494,9 +3494,9 @@ CHAKRA_API JsTTDCallFunction(_In_ INT64 hostCallbackId, _In_ JsValueRef function
 #endif
 }
 
-CHAKRA_API JsTTDSetIOCallbacks(_In_ JsRuntimeHandle runtime, 
-    _In_ JsTTDInitializeUriCallback ttdInitializeUriFunction, _In_ JsTTDInitializeForWriteLogStreamCallback writeInitializeFunction, 
-    _In_ JsTTDGetLogStreamCallback getLogStreamInfo, _In_ JsTTDGetSnapshotStreamCallback getSnapshotStreamInfo, _In_ JsTTDGetSrcCodeStreamCallback getSrcCodeStreamInfo, 
+CHAKRA_API JsTTDSetIOCallbacks(_In_ JsRuntimeHandle runtime,
+    _In_ JsTTDInitializeUriCallback ttdInitializeUriFunction, _In_ JsTTDInitializeForWriteLogStreamCallback writeInitializeFunction,
+    _In_ JsTTDGetLogStreamCallback getLogStreamInfo, _In_ JsTTDGetSnapshotStreamCallback getSnapshotStreamInfo, _In_ JsTTDGetSrcCodeStreamCallback getSrcCodeStreamInfo,
     _In_ JsTTDReadBytesFromStreamCallback readBytesFromStream, _In_ JsTTDWriteBytesToStreamCallback writeBytesToStream, _In_ JsTTDFlushAndCloseStreamCallback flushAndCloseStream)
 {
 #if !ENABLE_TTD
@@ -3504,8 +3504,8 @@ CHAKRA_API JsTTDSetIOCallbacks(_In_ JsRuntimeHandle runtime,
 #else
     ThreadContext* threadContext = JsrtRuntime::FromHandle(runtime)->GetThreadContext();
 
-    if (ttdInitializeUriFunction == nullptr || writeInitializeFunction == nullptr 
-        || getLogStreamInfo == nullptr || getSnapshotStreamInfo == nullptr || getSrcCodeStreamInfo == nullptr 
+    if (ttdInitializeUriFunction == nullptr || writeInitializeFunction == nullptr
+        || getLogStreamInfo == nullptr || getSnapshotStreamInfo == nullptr || getSrcCodeStreamInfo == nullptr
         || readBytesFromStream == nullptr || writeBytesToStream == nullptr || flushAndCloseStream == nullptr)
     {
         return JsErrorNullArgument;
@@ -3704,7 +3704,7 @@ CHAKRA_API JsTTDReStartTimeTravelAfterRuntimeOperation()
 #endif
 }
 
-CHAKRA_API JsTTDNotifyHostCallbackCreatedOrCanceled(_In_ bool isCreated, _In_ bool isCancel, _In_ bool isRepeating, 
+CHAKRA_API JsTTDNotifyHostCallbackCreatedOrCanceled(_In_ bool isCreated, _In_ bool isCancel, _In_ bool isRepeating,
     _In_ JsValueRef function, _In_ INT64 callbackId)
 {
 #if !ENABLE_TTD

--- a/lib/Jsrt/JsrtCommonExports.inc
+++ b/lib/Jsrt/JsrtCommonExports.inc
@@ -111,6 +111,7 @@
     JsGetPropertyIdFromNameUtf8
     JsStringFree
     JsDiagEvaluateUtf8
+    JsParseScriptUtf8
     JsParseScriptWithAttributesUtf8
     JsStringToPointerUtf8Copy
     JsPointerToStringUtf8

--- a/lib/Jsrt/JsrtHelper.cpp
+++ b/lib/Jsrt/JsrtHelper.cpp
@@ -89,7 +89,9 @@ void JsrtCallbackState::ObjectBeforeCallectCallbackWrapper(JsObjectBeforeCollect
         pthread_key_create(&s_threadLocalDummy, DISPOSE_CHAKRA_CORE_THREAD);
 #endif
 
-#if defined(CHAKRA_STATIC_LIBRARY)
+// xplat-todo: Oguz: revert " || !defined(_WIN32)". This was supposed for
+// static lib only. Temporary workaround for shared lib.
+#if defined(CHAKRA_STATIC_LIBRARY) || !defined(_WIN32)
 
     // Attention: shared library is handled under (see ChakraCore/ChakraCoreDllFunc.cpp)
     // todo: consolidate similar parts from shared and static library initialization

--- a/test/Function/rlexe.xml
+++ b/test/Function/rlexe.xml
@@ -381,7 +381,7 @@
     <default>
       <files>StackArgsWithFormals.js</files>
       <compile-flags>-mic:1 -off:simpleJit -trace:stackargformalsopt</compile-flags>
-      <tags>exclude_dynapogo,exclude_ship, exclude_fre</tags>
+      <tags>exclude_dynapogo,exclude_ship, exclude_fre,require_backend</tags>
       <baseline>StackArgsWithFormals.baseline</baseline>
     </default>
   </test>

--- a/test/runtests.py
+++ b/test/runtests.py
@@ -121,6 +121,11 @@ tags = lower_set(tags)
 not_tags = lower_set(not_tags)
 not_compile_flags = lower_set(not_compile_flags)
 
+# split tags text into tags set
+_empty_set = set()
+def split_tags(text):
+    return set(x.strip() for x in text.lower().split(',')) if text \
+            else _empty_set
 
 class LogFile(object):
     def __init__(self, log_file_path = None):
@@ -228,8 +233,6 @@ class TestResult(PassFailCount):
 #   interpreted: -maxInterpretCount:1 -maxSimpleJitRunCount:1 -bgjit-
 #   dynapogo: -forceNative -off:simpleJit -bgJitDelay:0
 class TestVariant(object):
-    _empty_set = set()
-
     def __init__(self, name, compile_flags=[]):
         self.name = name
         self.compile_flags = \
@@ -246,8 +249,7 @@ class TestVariant(object):
 
     # check if this test variant should run a given test
     def _should_test(self, test):
-        tags = test.get('tags')
-        tags = set(tags.lower().split(',')) if tags else self._empty_set
+        tags = split_tags(test.get('tags'))
         if not tags.isdisjoint(self.not_tags):
             return False
         if self.tags and not self.tags.issubset(tags):
@@ -458,8 +460,6 @@ def run_one(data):
 
 # record folder/tags info from test_root/rlexedirs.xml
 class FolderTags(object):
-    _empty_set = set()
-
     def __init__(self):
         xmlpath = os.path.join(test_root, 'rlexedirs.xml')
         try:
@@ -474,8 +474,7 @@ class FolderTags(object):
             key = d.find('files').text.lower() # avoid case mismatch
             tags = d.find('tags')
             self._folder_tags[key] = \
-                set(tags.text.lower().split(',')) if tags != None \
-                    else self._empty_set
+                split_tags(tags.text) if tags != None else _empty_set
 
     # check if should test a given folder
     def should_test(self, folder):


### PR DESCRIPTION
- Add std includes to make "ChakraCore.h" self-contained (otherwise
  missing defitions for `size_t`, `uintptr_t`).
- Fix ChakraDebug.h to work on xplat.
  - `charcount_t` type isn't available in JSRT. Changed to `size_t`.
  - Add `_Out_writes_` definition.
  - Add a bunch of Windows types.
- Add missing JsParseScriptUtf8 export def.
- Fix non-Win32 shared library InitProcess.
