### PR TITLE
Fix #36: class name in extends clause should be ReferenceError (use before declaration).

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -6885,20 +6885,6 @@ ParseNodePtr Parser::ParseClassDecl(BOOL isDeclaration, LPCOLESTR pNameHint, uin
     BOOL strictSave = m_fUseStrictMode;
     m_fUseStrictMode = TRUE;
 
-    if (m_token.tk == tkEXTENDS)
-    {
-        m_pscan->Scan();
-        pnodeExtends = ParseExpr<buildAST>();
-        hasExtends = true;
-    }
-
-    if (m_token.tk != tkLCurly)
-    {
-        Error(ERRnoLcurly);
-    }
-
-    OUTPUT_TRACE_DEBUGONLY(Js::ES6VerboseFlag, _u("Parsing class (%s) : %s\n"), GetParseType(), name ? name->Psz() : _u("anonymous class"));
-
     ParseNodePtr pnodeDeclName = nullptr;
     if (isDeclaration)
     {
@@ -6919,6 +6905,20 @@ ParseNodePtr Parser::ParseClassDecl(BOOL isDeclaration, LPCOLESTR pNameHint, uin
     {
         pnodeName = CreateBlockScopedDeclNode(name, knopConstDecl);
     }
+
+    if (m_token.tk == tkEXTENDS)
+    {
+        m_pscan->Scan();
+        pnodeExtends = ParseExpr<buildAST>();
+        hasExtends = true;
+    }
+
+    if (m_token.tk != tkLCurly)
+    {
+        Error(ERRnoLcurly);
+    }
+
+    OUTPUT_TRACE_DEBUGONLY(Js::ES6VerboseFlag, _u("Parsing class (%s) : %s\n"), GetParseType(), name ? name->Psz() : _u("anonymous class"));
 
     RestorePoint beginClass;
     m_pscan->Capture(&beginClass);

--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -10814,6 +10814,11 @@ void Emit(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator, FuncInfo *func
     {
         funcInfo->AcquireLoc(pnode);
 
+        Assert(pnode->sxClass.pnodeConstructor);
+        pnode->sxClass.pnodeConstructor->location = pnode->location;
+
+        BeginEmitBlock(pnode->sxClass.pnodeBlock, byteCodeGenerator, funcInfo);
+
         // Extends
         if (pnode->sxClass.pnodeExtends)
         {
@@ -10821,11 +10826,6 @@ void Emit(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator, FuncInfo *func
             // defer and nondefer parse modes.
             Emit(pnode->sxClass.pnodeExtends, byteCodeGenerator, funcInfo, false);
         }
-
-        Assert(pnode->sxClass.pnodeConstructor);
-        pnode->sxClass.pnodeConstructor->location = pnode->location;
-
-        BeginEmitBlock(pnode->sxClass.pnodeBlock, byteCodeGenerator, funcInfo);
 
         // Constructor
         Emit(pnode->sxClass.pnodeConstructor, byteCodeGenerator, funcInfo, false);

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -286,11 +286,13 @@ void Visit(ParseNode *pnode, ByteCodeGenerator* byteCodeGenerator, PrefixFn pref
     }
     case knopClassDecl:
     {
-        // Visit the extends expression first, since it's bound outside the scope containing the class name.
-        Visit(pnode->sxClass.pnodeExtends, byteCodeGenerator, prefix, postfix);
         Visit(pnode->sxClass.pnodeDeclName, byteCodeGenerator, prefix, postfix);
         // Now visit the class name and methods.
         BeginVisitBlock(pnode->sxClass.pnodeBlock, byteCodeGenerator);
+        // The extends clause is bound to the scope which contains the class name
+        // (and the class name identifier is in a TDZ when the extends clause is evaluated).
+        // See ES 2017 14.5.13 Runtime Semantics: ClassDefinitionEvaluation.
+        Visit(pnode->sxClass.pnodeExtends, byteCodeGenerator, prefix, postfix);
         Visit(pnode->sxClass.pnodeName, byteCodeGenerator, prefix, postfix);
         Visit(pnode->sxClass.pnodeStaticMembers, byteCodeGenerator, prefix, postfix);
         Visit(pnode->sxClass.pnodeConstructor, byteCodeGenerator, prefix, postfix);


### PR DESCRIPTION
Previously would be TypeError or ReferenceError with a different message in many cases.

The spec changed at some point to make it so that the name of the class should effectively live in a temporary deadzone when the extends clause expression is being evaluated, but we were treating it as part of the scope in which the class statement or expression is being evaluated, which means that it could be undefined (in the case of `var x = (class x extends x`)) or not defined (in the case of `let x = (class x extends x)`), and similar behavior. In the case of `let x = ...` we would emit the correct error

`eval('x')` and other expressions using eval in the extends clause should also have the same semantics for binding `x` as long as we have the scopes organized correctly.

What this essentially meant was that we needed to move the parsing of the extends clause inside the class declaration's scope, and update the bytecode generator to reflect the new semantics.

Added a variety of tests to capture different cases to cover all the possibilities that produced different error cases. Also fixed up some tests that were no longer valid under the new semantics.

Thanks @ianwjhalliday for helping me understand the parser and bytecode semantics.
Thanks @bterlson for helping me understand the spec semantics.

Fixes #36.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/1233)
<!-- Reviewable:end -->
