### PR TITLE
JSRT context lifetime management change

### DIFF
--- a/lib/Parser/RegexPattern.cpp
+++ b/lib/Parser/RegexPattern.cpp
@@ -34,7 +34,8 @@ namespace UnifiedRegex
             return;
 
 #if DBG
-        if(!isLiteral && !scriptContext->IsClosed())
+        // In JSRT, we might not have a chance to close at finalize time.
+        if(!isLiteral && !scriptContext->IsClosed() && !scriptContext->GetThreadContext()->IsJSRT())
         {
             const auto source = GetSource();
             RegexPattern *p;

--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -81,6 +81,7 @@ namespace Js
         sourceSize(0),
         deferredBody(false),
         isScriptContextActuallyClosed(false),
+        isFinalized(false),
         isInvalidatedForHostObjects(false),
         fastDOMenabled(false),
         directHostTypeId(TypeIds_GlobalObject),
@@ -359,6 +360,7 @@ namespace Js
 
     ScriptContext::~ScriptContext()
     {
+        Assert(isFinalized);
         // Take etw rundown lock on this thread context. We are going to change/destroy this scriptContext.
         AutoCriticalSection autocs(GetThreadContext()->GetEtwRundownCriticalSection());
 
@@ -377,6 +379,7 @@ namespace Js
             // clear out all inline caches to remove our proto inline caches from the thread context
             threadContext->ClearInlineCaches();
 
+            ClearInlineCaches();
             Assert(!this->hasProtoOrStoreFieldInlineCache);
         }
 
@@ -384,10 +387,9 @@ namespace Js
         {
             // clear out all inline caches to remove our proto inline caches from the thread context
             threadContext->ClearIsInstInlineCaches();
+            ClearIsInstInlineCaches();
             Assert(!this->hasIsInstInlineCache);
         }
-
-        threadContext->UnregisterScriptContext(this);
 
         // Only call RemoveFromPendingClose if we are in a pending close state.
         if (isClosed && !isScriptContextActuallyClosed)
@@ -1445,6 +1447,7 @@ if (!sourceList)
 
     void ScriptContext::InvalidatePropertyStringCache(PropertyId propertyId, Type* type)
     {
+        Assert(!isFinalized);
         PropertyStringCacheMap* propertyStringMap = this->javascriptLibrary->GetPropertyStringMap();
         if (propertyStringMap != nullptr)
         {
@@ -4161,7 +4164,10 @@ void ScriptContext::RegisterPrototypeChainEnsuredToHaveOnlyWritableDataPropertie
     void ScriptContext::ClearPrototypeChainEnsuredToHaveOnlyWritableDataPropertiesCaches()
     {
         Assert(registeredPrototypeChainEnsuredToHaveOnlyWritableDataPropertiesScriptContext != nullptr);
-        javascriptLibrary->NoPrototypeChainsAreEnsuredToHaveOnlyWritableDataProperties();
+        if (!isFinalized)
+        {
+            javascriptLibrary->NoPrototypeChainsAreEnsuredToHaveOnlyWritableDataProperties();
+        }
 
         // Caller will unregister the script context from the thread context
         registeredPrototypeChainEnsuredToHaveOnlyWritableDataPropertiesScriptContext = nullptr;

--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -753,6 +753,7 @@ private:
         // We could delay the actual close after callRootLevel is 0.
         // this is to indicate the actual close is called once only.
         bool isScriptContextActuallyClosed;
+        bool isFinalized;
 #if DBG
         bool isInitialized;
         bool isCloningGlobal;
@@ -852,6 +853,8 @@ private:
         DaylightTimeHelper *GetDaylightTimeHelper() { return &daylightTimeHelper; }
 
         bool IsClosed() const { return isClosed; }
+        bool IsFinalized() const { return isFinalized; }
+        void SetIsFinalized() { isFinalized = true; }
         bool IsActuallyClosed() const { return isScriptContextActuallyClosed; }
 #if ENABLE_NATIVE_CODEGEN
         bool IsClosedNativeCodeGenerator() const

--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -1071,6 +1071,8 @@ namespace Js
             // Clear the weak reference dictionary so we don't need to clean them
             // during PostCollectCallBack before Dispose deleting the script context.
             scriptContext->ResetWeakReferenceDictionaryList();
+            scriptContext->SetIsFinalized();
+            scriptContext->GetThreadContext()->UnregisterScriptContext(scriptContext);
         }
     }
 


### PR DESCRIPTION
 In JSRT we are using JSRTContext to control the lifetime of all the recycler objects in the scriptcontext.  Due to GC object finalize and sweep behavior, so non-finalizable object could be swept potentially before  some finalizer function access those fields. The change is to remove the codepath where we touch those  non-finalizable fields in javascriptlibrary in finalizer functions.