### PR TITLE
Cleanup empty function and related functions

### DIFF
--- a/lib/Backend/DbCheckPostLower.cpp
+++ b/lib/Backend/DbCheckPostLower.cpp
@@ -176,9 +176,11 @@ DbCheckPostLower::Check()
                     Assert(instr->GetDst()->AsRegOpnd()->GetReg() != RegNOREG);
                 }
                 break;
+            case Js::OpCode::CALL:
+                Assert(!instr->m_func->IsTrueLeaf());
+                break;
             }
 #endif
-            break;
         }
     } NEXT_INSTR_IN_FUNC_EDITING;
 }

--- a/lib/Backend/Encoder.cpp
+++ b/lib/Backend/Encoder.cpp
@@ -642,6 +642,12 @@ Encoder::ShortenBranchesAndLabelAlign(BYTE **codeStart, ptrdiff_t *codeSize)
     BYTE* buffEnd = buffStart + *codeSize;
     ptrdiff_t newCodeSize = *codeSize;
 
+    RelocList* relocList = m_encoderMD.GetRelocList();
+
+    if (relocList == nullptr)
+    {
+        return false;
+    }
 
 #if DBG
     // Sanity check
@@ -661,8 +667,6 @@ Encoder::ShortenBranchesAndLabelAlign(BYTE **codeStart, ptrdiff_t *codeSize)
         , &m_origPragmaInstrToRecordOffset
         , &m_origOffsetBuffer );
 
-    RelocList* relocList = m_encoderMD.GetRelocList();
-    Assert(relocList != nullptr);
     // Here we mark BRs to be shortened and adjust Labels and relocList entries offsets.
     uint32 offsetBuffIndex = 0, pragmaInstToRecordOffsetIndex = 0, inlineeFrameRecordsIndex = 0, inlineeFrameMapIndex = 0;
     int32 totalBytesSaved = 0;

--- a/lib/Backend/Func.cpp
+++ b/lib/Backend/Func.cpp
@@ -79,6 +79,8 @@ Func::Func(JitArenaAllocator *alloc, CodeGenWorkItem* workItem, const Js::Functi
     hasInlinee(false),
     thisOrParentInlinerHasArguments(false),
     hasStackArgs(false),
+    hasImplicitParamLoad(false),
+    hasThrow(false),
     hasNonSimpleParams(false),
     hasUnoptimizedArgumentsAcccess(false),
     hasApplyTargetInlining(false),

--- a/lib/Backend/Func.h
+++ b/lib/Backend/Func.h
@@ -263,6 +263,12 @@ static const unsigned __int64 c_debugFillPattern8 = 0xcececececececece;
         Assert(this->m_jnFunction);     // For now we always have a function body
         return this->m_jnFunction->GetHasFinally();
     }
+    bool HasThis() const
+    {
+        Assert(this->IsTopFunc());
+        Assert(this->m_jnFunction);     // For now we always have a function body
+        return this->m_jnFunction->GetHasThis();
+    }
     Js::ArgSlot GetInParamsCount() const
     {
         Assert(this->IsTopFunc());
@@ -275,7 +281,22 @@ static const unsigned __int64 c_debugFillPattern8 = 0xcececececececece;
         Assert(this->m_jnFunction);     // For now we always have a function body
         return this->m_jnFunction->GetIsGlobalFunc();
     }
-
+    bool IsGeneratorFunc() const
+    {
+        Assert(this->IsTopFunc());
+        Assert(this->m_jnFunction);     // For now we always have a function body
+        return this->m_jnFunction->IsGenerator();
+    }
+    bool IsLambda() const
+    {
+        Assert(this->IsTopFunc());
+        Assert(this->m_jnFunction);     // For now we always have a function body
+        return this->m_jnFunction->IsLambda();
+    }
+    bool IsTrueLeaf() const
+    {
+        return !GetHasCalls() && !GetHasImplicitCalls();
+    }
     RecyclerWeakReference<Js::FunctionBody> *GetWeakFuncRef() const;
     Js::FunctionBody * GetJnFunction() const { return m_jnFunction; }
 
@@ -546,6 +567,8 @@ public:
     bool                hasBailout: 1;
     bool                hasBailoutInEHRegion : 1;
     bool                hasStackArgs: 1;
+    bool                hasImplicitParamLoad : 1; // True if there is a load of CallInfo, FunctionObject
+    bool                hasThrow : 1;
     bool                hasUnoptimizedArgumentsAcccess : 1; // True if there are any arguments access beyond the simple case of this.apply pattern
     bool                m_canDoInlineArgsOpt : 1;
     bool                hasApplyTargetInlining:1;
@@ -628,6 +651,12 @@ public:
                         }
                         return isStackArgsEnabled;
     }
+
+    bool                GetHasImplicitParamLoad() const { return this->hasImplicitParamLoad; }
+    void                SetHasImplicitParamLoad() { this->hasImplicitParamLoad = true; }
+
+    bool                GetHasThrow() const { return this->hasThrow; }
+    void                SetHasThrow() { this->hasThrow = true; }
 
     bool                GetHasUnoptimizedArgumentsAcccess() const { return this->hasUnoptimizedArgumentsAcccess; }
     void                SetHasUnoptimizedArgumentsAccess(bool args)

--- a/lib/Backend/IRBuilder.cpp
+++ b/lib/Backend/IRBuilder.cpp
@@ -1539,6 +1539,8 @@ IRBuilder::BuildReg1(Js::OpCode newOpcode, uint32 offset, Js::RegSlot R0)
 
     case Js::OpCode::Throw:
         {
+            this->m_func->SetHasThrow();
+
             srcOpnd = this->BuildSrcOpnd(srcRegOpnd);
 
             if (this->catchOffsetStack && !this->catchOffsetStack->Empty())
@@ -7137,6 +7139,7 @@ IRBuilder::GenerateLoopBodySlotAccesses(uint offset)
     StackSym *symSrc     = StackSym::NewParamSlotSym(argument + 1, m_func);
     symSrc->m_offset     = (argument + LowererMD::GetFormalParamOffset()) * MachPtr;
     symSrc->m_allocated = true;
+    m_func->SetHasImplicitParamLoad();
     IR::SymOpnd *srcOpnd = IR::SymOpnd::New(symSrc, TyVar, m_func);
 
     StackSym *loopParamSym = m_func->EnsureLoopParamSym();

--- a/lib/Backend/IRBuilderAsmJs.cpp
+++ b/lib/Backend/IRBuilderAsmJs.cpp
@@ -3186,6 +3186,7 @@ IRBuilderAsmJs::GenerateLoopBodySlotAccesses(uint offset)
     StackSym *symSrc = StackSym::NewParamSlotSym(argument + 1, m_func);
     symSrc->m_offset = (argument + LowererMD::GetFormalParamOffset()) * MachPtr;
     symSrc->m_allocated = true;
+    m_func->SetHasImplicitParamLoad();
     IR::SymOpnd *srcOpnd = IR::SymOpnd::New(symSrc, TyMachPtr, m_func);
 
     StackSym *loopParamSym = m_func->EnsureLoopParamSym();

--- a/lib/Backend/Lower.h
+++ b/lib/Backend/Lower.h
@@ -70,6 +70,7 @@ public:
 
     StackSym *      GetTempNumberSym(IR::Opnd * opnd, bool isTempTransferred);
     static bool     HasSideEffects(IR::Instr *instr);
+    static bool     IsArgSaveRequired(Func *func);
 
 #if DBG
     static bool     ValidOpcodeAfterLower(IR::Instr* instr, Func * func);

--- a/lib/Backend/LowerMDShared.cpp
+++ b/lib/Backend/LowerMDShared.cpp
@@ -2060,6 +2060,7 @@ LowererMD::LoadFunctionObjectOpnd(IR::Instr *instr, IR::Opnd *&functionObjOpnd)
         instr->InsertBefore(mov1);
         functionObjOpnd = mov1->GetDst()->AsRegOpnd();
         instrPrev = mov1;
+        instr->m_func->SetHasImplicitParamLoad();
     }
     else
     {
@@ -8050,6 +8051,7 @@ LowererMD::GetImplicitParamSlotSym(Js::ArgSlot argSlot, Func * func)
 
     StackSym * stackSym = StackSym::NewParamSlotSym(argSlot, func);
     func->SetArgOffset(stackSym, (2 + argSlot) * MachPtr);
+    func->SetHasImplicitParamLoad();
     return stackSym;
 }
 
@@ -8783,6 +8785,7 @@ void LowererMD::GenerateFastInlineBuiltInCall(IR::Instr* instr, IR::JnHelperMeth
             IR::Instr *floatCall = IR::Instr::New(Js::OpCode::CALL, floatCallDst, s1, this->m_func);
             instr->InsertBefore(floatCall);
 #endif
+            instr->m_func->SetHasCalls();
             // Save the result.
             instr->m_opcode = Js::OpCode::MOVSD;
             instr->SetSrc1(floatCall->GetDst());

--- a/lib/Backend/amd64/EncoderMD.cpp
+++ b/lib/Backend/amd64/EncoderMD.cpp
@@ -1533,6 +1533,10 @@ EncoderMD::FixMaps(uint32 brOffset, uint32 bytesSaved, uint32 *inlineeFrameRecor
 void
 EncoderMD::ApplyRelocs(size_t codeBufferAddress_)
 {
+    if (m_relocList == nullptr)
+    {
+        return;
+    }
 
     for (int32 i = 0; i < m_relocList->Count(); i++)
     {
@@ -1600,6 +1604,11 @@ void
 EncoderMD::VerifyRelocList(BYTE *buffStart, BYTE *buffEnd)
 {
     BYTE *last_pc = 0, *pc;
+
+    if (m_relocList == nullptr)
+    {
+        return;
+    }
 
     for (int32 i = 0; i < m_relocList->Count(); i ++)
     {

--- a/lib/Backend/arm/LowerMD.cpp
+++ b/lib/Backend/arm/LowerMD.cpp
@@ -243,6 +243,9 @@ LowererMD::LowerCall(IR::Instr * callInstr, Js::ArgSlot argCount)
     IR::Opnd *targetOpnd = callInstr->GetSrc1();
     AssertMsg(targetOpnd, "Call without a target?");
 
+    // This is required here due to calls created during lowering
+    callInstr->m_func->SetHasCalls();
+
     if (targetOpnd->IsRegOpnd())
     {
         // Indirect call
@@ -7788,6 +7791,7 @@ LowererMD::GetImplicitParamSlotSym(Js::ArgSlot argSlot, Func * func)
     // be confused with arg slot number from javascript
     StackSym * stackSym = StackSym::NewParamSlotSym(argSlot, func);
     func->SetArgOffset(stackSym, argSlot * MachPtr);
+    func->SetHasImplicitParamLoad();
     return stackSym;
 }
 

--- a/lib/Backend/i386/LowererMDArch.cpp
+++ b/lib/Backend/i386/LowererMDArch.cpp
@@ -1137,6 +1137,9 @@ LowererMDArch::LowerCall(IR::Instr * callInstr, uint32 argCount, RegNum regNum)
     IR::Instr *retInstr = callInstr;
     callInstr->m_opcode = Js::OpCode::CALL;
 
+    // This is required here due to calls created during lowering
+    callInstr->m_func->SetHasCalls();
+
     if (callInstr->GetDst())
     {
         IR::Opnd *       dstOpnd = callInstr->GetDst();

--- a/lib/Runtime/Base/Constants.h
+++ b/lib/Runtime/Base/Constants.h
@@ -70,6 +70,9 @@ namespace Js
         // Minimum stack required to be able to execute a JITted Javascript function.
         static const unsigned MinStackJIT = 0x930 * WIN64_STACK_FACTOR;
 
+        // Maximum stack space allowed to avoid generating ProbeCurrentStack
+        static const unsigned MaxStackSizeForNoProbe = 0x64;
+
 #if (defined(_M_ARM32_OR_ARM64) || defined(_M_AMD64))
 #if DBG
         static const unsigned MinStackInterpreter = 0x4000; // 16 KB

--- a/lib/Runtime/Language/InterpreterLoop.inl
+++ b/lib/Runtime/Language/InterpreterLoop.inl
@@ -166,7 +166,8 @@ Var Js::InterpreterStackFrame::INTERPRETERLOOPNAME()
     }
 
     Assert(this->returnAddress != nullptr);
-    AssertMsg(m_arguments == NULL || Js::ArgumentsObject::Is(m_arguments), "Bad arguments!");
+    AssertMsg(!this->GetFunctionBody()->GetUsesArgumentsObject() || m_arguments == NULL || Js::ArgumentsObject::Is(m_arguments), "Bad arguments!");
+
     // IP Passing in the interpreter:
     // We keep a local copy of the bytecode's instruction pointer and
     // pass it by reference to the bytecode reader.


### PR DESCRIPTION
This change does the following :
- Eliminates call count profile when there is no bailout

- Eliminates stack probe for leaf functions with small stack footprint

- Eliminates arg saves on stack for a leaf function with no arg usage
