### PR TITLE
Remove starting and ending newline character from function display string

### DIFF
--- a/lib/Runtime/Library/JavascriptFunction.cpp
+++ b/lib/Runtime/Library/JavascriptFunction.cpp
@@ -144,9 +144,9 @@ namespace Js
     static char16 const genFuncName[] = _u("function* anonymous");
     static char16 const asyncFuncName[] = _u("async function anonymous");
     static char16 const openFormals[] = _u("(");
-    static char16 const closeFormals[] = _u("\012)");
+    static char16 const closeFormals[] = _u("\n)");
     static char16 const openFuncBody[] = _u(" {");
-    static char16 const closeFuncBody[] = _u("\012}");
+    static char16 const closeFuncBody[] = _u("\n}");
 
     Var JavascriptFunction::NewInstanceHelper(ScriptContext *scriptContext, RecyclableObject* function, CallInfo callInfo, Js::ArgumentReader& args, FunctionKind functionKind /* = FunctionKind::Normal */)
     {

--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -1139,7 +1139,7 @@ namespace Js
         generatorFunctionPrefixString = CreateStringFromCppLiteral(_u("function* "));
         asyncFunctionPrefixString = CreateStringFromCppLiteral(_u("async function "));
         functionDisplayString = CreateStringFromCppLiteral(JS_DISPLAY_STRING_FUNCTION_ANONYMOUS);
-        xDomainFunctionDisplayString = CreateStringFromCppLiteral(_u("function anonymous() {\012    [x-domain code]\012}"));
+        xDomainFunctionDisplayString = CreateStringFromCppLiteral(_u("function anonymous() {\n    [x-domain code]\n}"));
         invalidDateString = CreateStringFromCppLiteral(_u("Invalid Date"));
         objectTypeDisplayString = CreateStringFromCppLiteral(_u("object"));
         functionTypeDisplayString = CreateStringFromCppLiteral(_u("function"));

--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -1139,7 +1139,7 @@ namespace Js
         generatorFunctionPrefixString = CreateStringFromCppLiteral(_u("function* "));
         asyncFunctionPrefixString = CreateStringFromCppLiteral(_u("async function "));
         functionDisplayString = CreateStringFromCppLiteral(JS_DISPLAY_STRING_FUNCTION_ANONYMOUS);
-        xDomainFunctionDisplayString = CreateStringFromCppLiteral(_u("\012function anonymous() {\012    [x-domain code]\012}\012"));
+        xDomainFunctionDisplayString = CreateStringFromCppLiteral(_u("function anonymous() {\012    [x-domain code]\012}"));
         invalidDateString = CreateStringFromCppLiteral(_u("Invalid Date"));
         objectTypeDisplayString = CreateStringFromCppLiteral(_u("object"));
         functionTypeDisplayString = CreateStringFromCppLiteral(_u("function"));

--- a/lib/Runtime/RuntimeCommon.h
+++ b/lib/Runtime/RuntimeCommon.h
@@ -214,7 +214,7 @@ namespace JSON
 #define JS_DISPLAY_STRING_NAN           _u("NaN")
 #define JS_DISPLAY_STRING_DATE          _u("Date")
 #define JS_DISPLAY_STRING_INVALID_DATE  _u("Invalid Date")
-#define JS_DISPLAY_STRING_FUNCTION_ANONYMOUS        _u("function() {\012    [native code]\012}")
+#define JS_DISPLAY_STRING_FUNCTION_ANONYMOUS        _u("function() {\n    [native code]\n}")
 #define JS_DISPLAY_STRING_FUNCTION_HEADER           _u("function ")
 #define JS_DISPLAY_STRING_FUNCTION_BODY             _u("() { [native code] }")
 

--- a/lib/Runtime/RuntimeCommon.h
+++ b/lib/Runtime/RuntimeCommon.h
@@ -214,7 +214,7 @@ namespace JSON
 #define JS_DISPLAY_STRING_NAN           _u("NaN")
 #define JS_DISPLAY_STRING_DATE          _u("Date")
 #define JS_DISPLAY_STRING_INVALID_DATE  _u("Invalid Date")
-#define JS_DISPLAY_STRING_FUNCTION_ANONYMOUS        _u("\012function() {\012    [native code]\012}\012")
+#define JS_DISPLAY_STRING_FUNCTION_ANONYMOUS        _u("function() {\012    [native code]\012}")
 #define JS_DISPLAY_STRING_FUNCTION_HEADER           _u("function ")
 #define JS_DISPLAY_STRING_FUNCTION_BODY             _u("() { [native code] }")
 

--- a/test/Function/prototype.baseline
+++ b/test/Function/prototype.baseline
@@ -1,9 +1,7 @@
 function
-
 function() {
     [native code]
 }
-
 undefined
 undefined
 undefined

--- a/test/Function/typeErrorAccessor.baseline
+++ b/test/Function/typeErrorAccessor.baseline
@@ -6,29 +6,21 @@ undefined
 V:0, W:false, E:false, C:false, get:false, set:false
 ***************** g.caller ***************** 
 [object Object]
-
 function() {
     [native code]
 }
-
-
 function() {
     [native code]
 }
-
 V:undefined, W:undefined, E:false, C:false, get:true, set:true
 ***************** g.arguments ***************** 
 [object Object]
-
 function() {
     [native code]
 }
-
-
 function() {
     [native code]
 }
-
 V:undefined, W:undefined, E:false, C:false, get:true, set:true
 ***************** try to set/get the caller/arguments *****************
 Set caller passed

--- a/test/es6/proto_basic.baseline
+++ b/test/es6/proto_basic.baseline
@@ -1,14 +1,10 @@
 *** Running test #1 (0): Test Object.prototype.__proto__ attributes
-get: 
-function() {
+get: function() {
     [native code]
 }
-
-set: 
-function() {
+set: function() {
     [native code]
 }
-
 enumerable: false
 configurable: true
 PASSED

--- a/test/strict/05.arguments_sm.baseline
+++ b/test/strict/05.arguments_sm.baseline
@@ -1,30 +1,22 @@
 arguments.callee:configurable : false
 arguments.callee:enumerable   : false
 arguments.callee:writable     : undefined
-arguments.callee:getter       : 
-function() {
+arguments.callee:getter       : function() {
     [native code]
 }
-
-arguments.callee:setter       : 
-function() {
+arguments.callee:setter       : function() {
     [native code]
 }
-
 arguments.callee:value        : undefined
 arguments.caller:configurable : false
 arguments.caller:enumerable   : false
 arguments.caller:writable     : undefined
-arguments.caller:getter       : 
-function() {
+arguments.caller:getter       : function() {
     [native code]
 }
-
-arguments.caller:setter       : 
-function() {
+arguments.caller:setter       : function() {
     [native code]
 }
-
 arguments.caller:value        : undefined
 Exception: Accessing the 'caller' property is restricted in this context
 Exception: Accessing the 'caller' property is restricted in this context


### PR DESCRIPTION
Chakra  "\nfunction(){\n  [native code]\n}\n"
Firefox "function (){\n}"
Chrome "function () {}"

For arguments.callee.__proto__.toString() (or any native function toString) Chakra shows form feed character (\012) at begining and end whereas Firefox and Chrome doesn't.

VSCode removes the newline after function but doesn't remove the starting so it shows up in locals display.