### PR TITLE
Fixing UT Failure in DisableJIT

### DIFF
--- a/test/Function/rlexe.xml
+++ b/test/Function/rlexe.xml
@@ -381,7 +381,7 @@
     <default>
       <files>StackArgsWithFormals.js</files>
       <compile-flags>-mic:1 -off:simpleJit -trace:stackargformalsopt</compile-flags>
-      <tags>exclude_dynapogo,exclude_ship, exclude_fre</tags>
+      <tags>exclude_dynapogo,exclude_ship,exclude_fre,exclude_nonative,require_backend</tags>
       <baseline>StackArgsWithFormals.baseline</baseline>
     </default>
   </test>


### PR DESCRIPTION
Disabling nonative mode for the failing UT, which verifies the trace during the optimization in the backend.