### PR TITLE
Caching the arguments type for strict mode on the library

### DIFF
--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -6893,7 +6893,7 @@ CommonNumber:
     HeapArgumentsObject *JavascriptOperators::CreateHeapArguments(JavascriptFunction *funcCallee, uint32 actualsCount, uint32 formalsCount, Var frameObj, ScriptContext* scriptContext)
     {
         JavascriptLibrary *library = scriptContext->GetLibrary();
-        HeapArgumentsObject *argsObj = library->CreateHeapArguments(frameObj, formalsCount);
+        HeapArgumentsObject *argsObj = library->CreateHeapArguments(frameObj, formalsCount, !!funcCallee->IsStrictMode());
 
         //
         // Set the number of arguments of Arguments Object
@@ -6904,27 +6904,12 @@ CommonNumber:
         JavascriptOperators::SetProperty(argsObj, argsObj, PropertyIds::_symbolIterator, library->GetArrayPrototypeValuesFunction(), scriptContext);
         if (funcCallee->IsStrictMode())
         {
-            PropertyDescriptor propertyDescriptorCaller;
-            JavascriptFunction* callerAccessor = library->GetThrowTypeErrorCallerAccessorFunction();
-
-            propertyDescriptorCaller.SetGetter(callerAccessor);
-            propertyDescriptorCaller.SetSetter(callerAccessor);
-            propertyDescriptorCaller.SetEnumerable(false);
-            propertyDescriptorCaller.SetConfigurable(false);
-
+            JavascriptFunction* callerAccessor = library->GetThrowTypeErrorCallerAccessorFunction();            
             argsObj->SetAccessors(PropertyIds::caller, callerAccessor, callerAccessor, PropertyOperation_NonFixedValue);
-            JavascriptOperators::SetAttributes(argsObj, PropertyIds::caller, propertyDescriptorCaller, false);
 
-            PropertyDescriptor propertyDescriptorCallee;
             JavascriptFunction* calleeAccessor = library->GetThrowTypeErrorCalleeAccessorFunction();
-
-            propertyDescriptorCallee.SetGetter(calleeAccessor);
-            propertyDescriptorCallee.SetSetter(calleeAccessor);
-            propertyDescriptorCallee.SetEnumerable(false);
-            propertyDescriptorCallee.SetConfigurable(false);
-
             argsObj->SetAccessors(PropertyIds::callee, calleeAccessor, calleeAccessor, PropertyOperation_NonFixedValue);
-            JavascriptOperators::SetAttributes(argsObj, PropertyIds::callee, propertyDescriptorCallee, false);
+
         }
         else
         {

--- a/lib/Runtime/Library/JavascriptLibrary.h
+++ b/lib/Runtime/Library/JavascriptLibrary.h
@@ -185,6 +185,7 @@ namespace Js
         DynamicType * generatorConstructorPrototypeObjectType;
         DynamicType * constructorPrototypeObjectType;
         DynamicType * heapArgumentsType;
+        DynamicType * heapArgumentsTypeStrictMode;
         DynamicType * activationObjectType;
         DynamicType * arrayType;
         DynamicType * nativeIntArrayType;
@@ -836,7 +837,7 @@ namespace Js
         FinalizableObject* GetPinnedJsrtContextObject();
         void EnqueueTask(Var taskVar);
 
-        HeapArgumentsObject* CreateHeapArguments(Var frameObj, uint formalCount);
+        HeapArgumentsObject* CreateHeapArguments(Var frameObj, uint formalCount, bool isStrictMode = false);
         JavascriptArray* CreateArray();
         JavascriptArray* CreateArray(uint32 length);
         JavascriptArray *CreateArrayOnStack(void *const stackAllocationPointer);

--- a/lib/Runtime/Types/DictionaryTypeHandler.cpp
+++ b/lib/Runtime/Types/DictionaryTypeHandler.cpp
@@ -13,6 +13,19 @@ namespace Js
     }
 
     template <typename T>
+    DictionaryTypeHandlerBase<T>* DictionaryTypeHandlerBase<T>::CreateTypeHandlerForArgumentsInStrictMode(Recycler * recycler, ScriptContext * scriptContext)
+    {
+        DictionaryTypeHandlerBase<T> * dictTypeHandler = New(recycler, 8, 0, 0);
+        
+        dictTypeHandler->Add(scriptContext->GetPropertyName(Js::PropertyIds::caller), PropertyWritable, scriptContext);
+        dictTypeHandler->Add(scriptContext->GetPropertyName(Js::PropertyIds::callee), PropertyWritable, scriptContext);
+        dictTypeHandler->Add(scriptContext->GetPropertyName(Js::PropertyIds::length), PropertyBuiltInMethodDefaults, scriptContext);
+        dictTypeHandler->Add(scriptContext->GetPropertyName(Js::PropertyIds::_symbolIterator), PropertyBuiltInMethodDefaults, scriptContext);
+
+        return dictTypeHandler;
+    }
+
+    template <typename T>
     DictionaryTypeHandlerBase<T>::DictionaryTypeHandlerBase(Recycler* recycler) :
         DynamicTypeHandler(1),
         nextPropertyIndex(0),
@@ -354,7 +367,6 @@ namespace Js
 
     template <typename T>
     void DictionaryTypeHandlerBase<T>::Add(
-
         const PropertyRecord* propertyId,
         PropertyAttributes attributes,
         bool isInitialized, bool isFixed, bool usedAsFixed,
@@ -369,6 +381,7 @@ namespace Js
         descriptor.IsInitialized = isInitialized;
         descriptor.IsFixed = isFixed;
         descriptor.UsedAsFixed = usedAsFixed;
+
         propertyMap->Add(propertyId, descriptor);
 
         if (!(attributes & PropertyWritable))

--- a/lib/Runtime/Types/DictionaryTypeHandler.h
+++ b/lib/Runtime/Types/DictionaryTypeHandler.h
@@ -60,6 +60,8 @@ namespace Js
         // Create a new type handler for a future DynamicObject. This is for public usage. "initialCapacity" indicates desired slotCapacity, subject to alignment round up.
         static DictionaryTypeHandlerBase* New(Recycler * recycler, int initialCapacity, uint16 inlineSlotCapacity, uint16 offsetOfInlineSlots);
 
+        static DictionaryTypeHandlerBase* CreateTypeHandlerForArgumentsInStrictMode(Recycler * recycler, ScriptContext * scriptContext);
+
         BOOL IsBigDictionaryTypeHandler();
 
         virtual BOOL IsLockable() const override { return false; }


### PR DESCRIPTION
**Premise:**
For strict mode, we start with a simple dictionary type for arguments object and transition to dictionary type upon adding setter/getter. This is costly.

**Fix:**
We, now, cache the dictionary type with accessors on the javascript library - so that we don't want to do the transition everytime.

_This improves the strict mode with arguments by 40% on micro benchmarks_. Note that this will be evident only when stack arg optimization is disabled (because with optimization - we will not be creating the heap arguments object in the first place).

**Perf tests:**
Surprisingly, this code change didn't show up evidently in Speedometer - especially given the fact that there are some functions that have unoptimized heap arguments object.
I am yet to try with acme-benchmark.

**IE PerfLab: (Few overall improvements in Elapsed/CPU Time)**
http://ieperf-web-01/perfresults/Comparison?testRunId=423952&baseRunId=423947&lab=IEPERF&getRelatedRunData=false&priorities=0,1&categories=failures,warnings,improvements,no-change&search=

**Note:**
_SetAccessor API is still hot as most of the time is spent in GetPropertyName()_ -> which looks up the propertyRecord from the Dictionary. I kinda gave up at this point on further making strict mode scenario faster as the returns wasn't really fruitful. Let me know if someone has any thoughts on this. 