### PR TITLE
Adding typeof support to enable Stack arg optimization

### DIFF
--- a/lib/Backend/BackwardPass.h
+++ b/lib/Backend/BackwardPass.h
@@ -27,6 +27,7 @@ private:
     bool IsFormalParamSym(Func * func, Sym * sym) const;
     bool CanDeadStoreInstrForScopeObjRemoval(Sym *sym = nullptr) const;
     void TraceDeadStoreOfInstrsForScopeObjectRemoval();
+    IR::Instr * TryChangeInstrForStackArgOpt();
     void InsertArgInsForFormals();
     void ProcessBailOnStackArgsOutOfActualsRange();
     bool DeadStoreOrChangeInstrForScopeObjRemoval();

--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -4023,6 +4023,7 @@ GlobOpt::OptArguments(IR::Instr *instr)
     switch(instr->m_opcode)
     {
     case Js::OpCode::LdElemI_A:
+    case Js::OpCode::TypeofElem:
     {
         Assert(src1->IsIndirOpnd());
         IR::RegOpnd *indexOpnd = src1->AsIndirOpnd()->GetIndexOpnd();
@@ -4800,7 +4801,8 @@ GlobOpt::OptInstr(IR::Instr *&instr, bool* isInstrRemoved)
     this->OptArguments(instr);
 
     //StackArguments Optimization - We bail out if the index is out of range of actuals.
-    if (instr->m_opcode == Js::OpCode::LdElemI_A && instr->DoStackArgsOpt(this->func) && !this->IsLoopPrePass())
+    if ((instr->m_opcode == Js::OpCode::LdElemI_A || instr->m_opcode == Js::OpCode::TypeofElem) && 
+        instr->DoStackArgsOpt(this->func) && !this->IsLoopPrePass())
     {
         GenerateBailAtOperation(&instr, IR::BailOnStackArgsOutOfActualsRange);
     }


### PR DESCRIPTION
**Premise:**

acme-benchmark uses arguments[i] with typeof keyword. We do not currently do Stack Arguments optimization for this scenario.

**Change:**

Added support in the Globopt to enable Stack arg optimization when the
function body has typeof keyword.

**Details:**

We optimistically insert (BailOnStackArgsOutOfActualsRange) for
TypeOfElem, if it is a candidate for optimization.
We decide during DeadStore phase, whether this bail out is required or not
and then change the instr accordingly(as shown below).

**After GlobOpt Phase:**
_Before:_
dst = TypeOfElem arguments[i]

_With this pack:_
tmpdst = LdElemI_A arguments[i] <(BailOnStackArgsOutOfActualsRange)>
dst = TypeOf tmpdst.

**Perf:**
This will help _acme-benchmark by 3%_ as pointed out by Kunal.
Yet to run other tests.
