### PR TITLE
Passing binary location to native test script.

### DIFF
--- a/test/jenkins.testall.cmd
+++ b/test/jenkins.testall.cmd
@@ -89,7 +89,7 @@ set _HadFailures=0
 :: ============================================================================
 :runNativeTests
 
-  call :do %_TestDir%\runnativetests.cmd -%1 > %_LogDir%\nativetests.log 2>&1
+  call :do %_TestDir%\runnativetests.cmd -%1 -binDir %_BinDir% > %_LogDir%\nativetests.log 2>&1
 
   if ERRORLEVEL 1 set _HadFailures=1
 

--- a/test/jenkins.testone.cmd
+++ b/test/jenkins.testone.cmd
@@ -85,7 +85,7 @@ set _HadFailures=0
 :: ============================================================================
 :runNativeTests
 
-  call :do %_TestDir%\runnativetests.cmd -%1 > %_LogDir%\nativetests.log 2>&1
+  call :do %_TestDir%\runnativetests.cmd -%1 -binDir %_BinDir% > %_LogDir%\nativetests.log 2>&1
 
   if ERRORLEVEL 1 set _HadFailures=1
 


### PR DESCRIPTION
jenkins script has already determined if it is meant for noJit, so it will pass appropriate location to inner script.

Fixes #1266 