### PR TITLE
Fix missing color for items in BackgroundJobProcessor::DebugThreadNames

### DIFF
--- a/lib/Common/Common/Jobs.cpp
+++ b/lib/Common/Common/Jobs.cpp
@@ -1402,7 +1402,7 @@ namespace JsUtil
         _u("BackgroundJobProcessor thread 5"),
         _u("BackgroundJobProcessor thread 6"),
         _u("BackgroundJobProcessor thread 7"),
-        _u("BackgroundJobProcessor thread 8")
+        _u("BackgroundJobProcessor thread 8"),
         _u("BackgroundJobProcessor thread 9"),
         _u("BackgroundJobProcessor thread 10"),
         _u("BackgroundJobProcessor thread 11"),


### PR DESCRIPTION
The missing colon makes the debug name incorrect after it.