### PR TITLE
Memop bailout on negative length

### DIFF
--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -4599,7 +4599,7 @@ CommonNumber:
     {
         if (length <= 0)
         {
-            return true;
+            return false;
         }
 
         TypeId instanceType = JavascriptOperators::GetTypeId(srcInstance);
@@ -4706,7 +4706,7 @@ CommonNumber:
     {
         if (length <= 0)
         {
-            return true;
+            return false;
         }
         TypeId instanceType = JavascriptOperators::GetTypeId(instance);
         BOOL  returnValue = false;

--- a/test/Array/bug8159763.js
+++ b/test/Array/bug8159763.js
@@ -1,0 +1,19 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function test0() {
+  var IntArr0 = [];
+  v5 = IntArr0.length;
+  for (var i = 10; i < v5; i++) {
+    IntArr0[i] = 0.5;
+  }
+  return i;
+}
+test0();
+if (test0() !== 10) {
+  print("FAILED");
+} else {
+  print("PASSED");
+}

--- a/test/Array/rlexe.xml
+++ b/test/Array/rlexe.xml
@@ -639,13 +639,13 @@
         <compile-flags>-mic:1 -off:simplejit -mmoc:0 -off:JITLoopBody</compile-flags>
      </default>
   </test>
-  <!-- 
+  <!--
    <test>
      <default>
         <files>memset_simd.js</files>
         <compile-flags>-mic:1 -off:simplejit -mmoc:0 -off:JITLoopBody -simdjs -simd128typespec</compile-flags>
      </default>
-  </test>  
+  </test>
 -->
   <test>
      <default>
@@ -706,6 +706,12 @@
      <default>
         <files>bug4587739.js</files>
         <compile-flags>-mic:1 -off:simplejit</compile-flags>
+     </default>
+  </test>
+  <test>
+     <default>
+        <files>bug8159763.js</files>
+        <compile-flags>-mic:1 -off:simplejit -mmoc:0 -off:bailonnoprofile</compile-flags>
      </default>
   </test>
 </regress-exe>


### PR DESCRIPTION
Bailout on Memset/Memcopy if the length is <= 0. 
After the memop, we restore the induction variable to its expected value. 
If the memop didn't actually happen we shouldn't modify the induction variable.
This is unlikely to happen since we would normally bailout on no profile and not emit this memop.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/1275)
<!-- Reviewable:end -->
