### PR TITLE
Fix crash when tracing EquivObjTypeSpec

### DIFF
--- a/lib/Runtime/Types/NullTypeHandler.cpp
+++ b/lib/Runtime/Types/NullTypeHandler.cpp
@@ -58,6 +58,7 @@ namespace Js
             const EquivalentPropertyEntry* refInfo = &properties[pi];
             if (!this->NullTypeHandlerBase::IsObjTypeSpecEquivalent(type, refInfo))
             {
+                failedPropertyIndex = pi;
                 return false;
             }
         }


### PR DESCRIPTION
failedPropertyIndex is uninitialized in NullTypeHandler. it is used for tracing EquivObjTypeSpec, and causes a crash

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/1277)
<!-- Reviewable:end -->
