### PR TITLE
nativetests: fix static crt build

### DIFF
--- a/bin/NativeTests/NativeTests.vcxproj
+++ b/bin/NativeTests/NativeTests.vcxproj
@@ -27,7 +27,6 @@
           $(ChakraCoreRootDirectory)bin\External;
           %(AdditionalIncludeDirectories)
       </AdditionalIncludeDirectories>
-      <RuntimeLibrary Condition="'$(Configuration)'=='Debug'">MultiThreadedDebugDLL</RuntimeLibrary>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <SmallerTypeCheck>false</SmallerTypeCheck>
       <MinimalRebuild>false</MinimalRebuild>


### PR DESCRIPTION
The ChakraCore solution can be built with static CRT
(`msbuild /p:Runtime=static_library ...`). NativeTests.vcxproj should not
specify its own `RuntimeLibrary` property. Should use imported props.
