### PR TITLE
BugFix: StackArgs Optimization with formals

### DIFF
--- a/lib/Backend/BackwardPass.cpp
+++ b/lib/Backend/BackwardPass.cpp
@@ -2938,8 +2938,9 @@ BackwardPass::DeadStoreOrChangeInstrForScopeObjRemoval()
 
                         Assert(currFunc->HasStackSymForFormal(value));
                         StackSym * paramStackSym = currFunc->GetStackSymForFormal(value);
-                        instr->ReplaceSrc1(IR::RegOpnd::New(paramStackSym, TyVar, currFunc));
-                        this->currentBlock->upwardExposedUses->Set(paramStackSym->m_id);
+                        IR::RegOpnd * srcOpnd = IR::RegOpnd::New(paramStackSym, TyVar, currFunc);
+                        instr->ReplaceSrc1(srcOpnd);
+                        this->ProcessSymUse(paramStackSym, true, true);
 
                         if (PHASE_VERBOSE_TRACE1(Js::StackArgFormalsOptPhase))
                         {

--- a/test/Function/StackArgsWithFormals.baseline
+++ b/test/Function/StackArgsWithFormals.baseline
@@ -8,4 +8,6 @@ StackArgFormals : inner_test4 (8) :Removing Heap Arguments object creation in Lo
 StackArgFormals : test5 (9) :Removing Heap Arguments object creation in Lowerer. 
 StackArgFormals : test6 (10) :Removing Heap Arguments object creation in Lowerer. 
 StackArgFormals : test7 (11) :Removing Heap Arguments object creation in Lowerer. 
+StackArgFormals : test12_1 (17) :Removing Scope object creation in Deadstore pass. 
+StackArgFormals : test12_1 (17) :Removing Heap Arguments object creation in Lowerer. 
 PASSED

--- a/test/Function/StackArgsWithFormals.js
+++ b/test/Function/StackArgsWithFormals.js
@@ -195,6 +195,19 @@ test11(1,2);
 test11('x','y');
 verify([20,40,20,40], "TEST 11");
 
+
+var obj12 = { method1: function () {} };
+function test12_1(arg1) {
+  this.prop1 = arg1;
+  obj12.method1.apply(obj12, arguments);
+}
+function test12() {
+  new test12_1(-{});
+}
+test12();
+test12();
+verify([], "TEST 12");
+
 if(hasAllPassed)
 {
     print("PASSED");


### PR DESCRIPTION
After we change LdSlot instruction to Ld_A, the sym wasn't calling
ProcessSymUse (in the DeadStore pass).
ProcessSymUse marks the src sym as a nonTemp (which was being missed in
this case - causing a cascade effect with boxing of number)

Test:
UTs pass. Started other harness runs
