### PR TITLE
Change JavascriptConversion::ToPropertyKey to have no return value.

### DIFF
--- a/lib/Runtime/Language/JavascriptConversion.cpp
+++ b/lib/Runtime/Language/JavascriptConversion.cpp
@@ -295,7 +295,7 @@ CommonNumber:
     // ToPropertyKey() takes a value and converts it to a property key
     // Implementation of ES6 7.1.14
     //----------------------------------------------------------------------------
-    BOOL JavascriptConversion::ToPropertyKey(Var argument, ScriptContext* scriptContext, const PropertyRecord** propertyRecord)
+    void JavascriptConversion::ToPropertyKey(Var argument, ScriptContext* scriptContext, const PropertyRecord** propertyRecord)
     {
         Var key = JavascriptConversion::ToPrimitive(argument, JavascriptHint::HintString, scriptContext);
 
@@ -319,8 +319,6 @@ CommonNumber:
                 scriptContext->GetOrAddPropertyRecord(propName->GetString(), propName->GetLength(), propertyRecord);
             }
         }
-
-        return TRUE;
     }
 
     //----------------------------------------------------------------------------

--- a/lib/Runtime/Language/JavascriptConversion.h
+++ b/lib/Runtime/Language/JavascriptConversion.h
@@ -14,7 +14,7 @@ namespace Js {
         static Var ToPrimitive(Var aValue, JavascriptHint hint, ScriptContext * scriptContext);
         static BOOL CanonicalNumericIndexString(Var aValue, double *indexValue, ScriptContext * scriptContext);
 
-        static BOOL ToPropertyKey(Var argument, ScriptContext* scriptContext, const PropertyRecord** propertyRecord);
+        static void ToPropertyKey(Var argument, ScriptContext* scriptContext, const PropertyRecord** propertyRecord);
 
         static JavascriptString* ToString(Var aValue, ScriptContext* scriptContext);
         static JavascriptString* ToLocaleString(Var aValue, ScriptContext* scriptContext);

--- a/lib/Runtime/Library/JavascriptObject.cpp
+++ b/lib/Runtime/Library/JavascriptObject.cpp
@@ -1265,10 +1265,10 @@ namespace Js
 
             PropertyDescriptor propertyDescriptor;
 
-            BOOL propertyKeyResult = JavascriptConversion::ToPropertyKey(nextKey, scriptContext, &propertyRecord);
-            Assert(propertyKeyResult);
+            JavascriptConversion::ToPropertyKey(nextKey, scriptContext, &propertyRecord);
             propertyId = propertyRecord->GetPropertyId();
             Assert(propertyId != Constants::NoProperty);
+
             if (JavascriptOperators::GetOwnPropertyDescriptor(object, propertyId, scriptContext, &propertyDescriptor))
             {
                 if (propertyDescriptor.IsEnumerable())


### PR DESCRIPTION
Fixes #1251 

It turned out the *only* place the return value of ToPropertyKey was used (that I could find) was where I saw it in #1202. I changed the function signature to void, and removed the variable and the assert in that one place it was used. 