### PR TITLE
Update @@toStringTag ES6 compliance

### DIFF
--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -1911,6 +1911,10 @@ namespace Js
 
         if (scriptContext->GetConfig()->IsES6ToStringTagEnabled())
         {
+            // ES2017 22.2.3.32 get %TypedArray%.prototype[@@toStringTag]
+            // %TypedArray%.prototype[@@toStringTag] is an accessor property whose set accessor function is undefined.
+            // This property has the attributes { [[Enumerable]]: false, [[Configurable]]: true }.
+            // The initial value of the name property of this function is "get [Symbol.toStringTag]".
             library->AddAccessorsToLibraryObjectWithName(typedarrayPrototype, PropertyIds::_symbolToStringTag,
                 PropertyIds::_RuntimeFunctionNameId_toStringTag, &TypedArrayBase::EntryInfo::GetterSymbolToStringTag, nullptr);
         }
@@ -2125,7 +2129,6 @@ namespace Js
             library->AddFunctionToLibraryObject(booleanPrototype, PropertyIds::valueOf, &JavascriptBoolean::EntryInfo::ValueOf, 0));
         scriptContext->SetBuiltInLibraryFunction(JavascriptBoolean::EntryInfo::ToString.GetOriginalEntryPoint(),
             library->AddFunctionToLibraryObject(booleanPrototype, PropertyIds::toString, &JavascriptBoolean::EntryInfo::ToString, 0));
-
         booleanPrototype->SetHasNoEnumerableProperties(true);
     }
 

--- a/lib/Runtime/Library/JavascriptObject.h
+++ b/lib/Runtime/Library/JavascriptObject.h
@@ -109,6 +109,7 @@ namespace Js
         static Var ToStringHelper(Var thisArg, ScriptContext* scriptContext);
         static Var LegacyToStringHelper(ScriptContext* scriptContext, TypeId type);
         static JavascriptString* ToStringTagHelper(Var thisArg, ScriptContext* scriptContext, TypeId type);
+        static JavascriptString* ToStringTagHelperOld(Var thisArg, ScriptContext* scriptContext, TypeId type);
 
     private:
         static void AssignForGenericObjects(RecyclableObject* from, RecyclableObject* to, ScriptContext* scriptContext);

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -101,15 +101,13 @@
       <tags>BugFix</tags>
     </default>
   </test>
-  <!-- OS BUG 7117880
   <test>
     <default>
       <files>toStringTag.js</files>
-      <compile-flags> -nonative -es6classes -es6generators -es6tostringtag -args summary -endargs</compile-flags>
+      <compile-flags>-es6tostringtag -args summary -endargs</compile-flags>
       <tags>exclude_dynapogo</tags>
     </default>
   </test>
-  -->
   <test>
     <default>
       <files>proto_basic.js</files>

--- a/test/es6/toStringTag.js
+++ b/test/es6/toStringTag.js
@@ -5,299 +5,204 @@
 
 WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
 
-//TODO remove -nonative & exclude_dynapogo when Ian has generator native code support & Taylor has subclassable native support remove -nonnative and native code test exclusions
+var primitives = [
+    { tag: "Undefined",         instance: undefined },
+    { tag: "Null",              instance: null }
+];
+
+var explicitTagExoticBuiltIns = [
+    { tag: "Math",              instance: Math,                                  prototype: Math },
+    { tag: "JSON",              instance: JSON,                                  prototype: JSON }
+];
+
+var explicitTagExtensibleBuiltIns = [
+    { tag: "Map",               instance: new Map(),                             prototype: Map.prototype },
+    { tag: "Set",               instance: new Set(),                             prototype: Set.prototype },
+    { tag: "WeakMap",           instance: new WeakMap(),                         prototype: WeakMap.prototype },
+    { tag: "WeakSet",           instance: new WeakSet(),                         prototype: WeakSet.prototype },
+    { tag: "ArrayBuffer",       instance: new ArrayBuffer(),                     prototype: ArrayBuffer.prototype },
+    { tag: "DataView",          instance: new DataView(new ArrayBuffer()),       prototype: DataView.prototype }
+];
+
+var explicitTagOtherBuiltIns = [
+    { tag: "Promise",           instance: new Promise(() => {}),                 prototype: Promise.prototype },
+    { tag: "GeneratorFunction", instance: function* () { },                      prototype: Object.getPrototypeOf(function* () { }) },
+    { tag: "Generator",         instance: (function* () { })(),                  prototype: Object.getPrototypeOf((function* () { }).prototype) },
+    { tag: "String Iterator",   instance: ""[Symbol.iterator](),                 prototype: Object.getPrototypeOf(""[Symbol.iterator]()) },
+    { tag: "Array Iterator",    instance: [][Symbol.iterator](),                 prototype: Object.getPrototypeOf([][Symbol.iterator]()) },
+    { tag: "Map Iterator",      instance: (new Map())[Symbol.iterator](),        prototype: Object.getPrototypeOf((new Map())[Symbol.iterator]()) },
+    { tag: "Set Iterator",      instance: (new Set())[Symbol.iterator](),        prototype: Object.getPrototypeOf((new Set())[Symbol.iterator]()) }
+];
+
+var explicitTagBuiltIns = [...explicitTagExoticBuiltIns, ...explicitTagExtensibleBuiltIns, ...explicitTagOtherBuiltIns];
+
+// 22.2 TypedArray Objects Table 50: The TypedArray Constructors
+var explicitTagTypedArrayBuiltIns = [
+    { tag: 'Int8Array',         instance: new Int8Array(),                       prototype: Object.getPrototypeOf(Int8Array).prototype },
+    { tag: 'Uint8Array',        instance: new Uint8Array(),                      prototype: Object.getPrototypeOf(Uint8Array).prototype },
+    { tag: 'Uint8ClampedArray', instance: new Uint8ClampedArray(),               prototype: Object.getPrototypeOf(Uint8ClampedArray).prototype },
+    { tag: 'Int16Array',        instance: new Int16Array(),                      prototype: Object.getPrototypeOf(Int16Array).prototype },
+    { tag: 'Uint16Array',       instance: new Uint16Array(),                     prototype: Object.getPrototypeOf(Uint16Array).prototype },
+    { tag: 'Int32Array',        instance: new Int32Array(),                      prototype: Object.getPrototypeOf(Int32Array).prototype },
+    { tag: 'Uint32Array',       instance: new Uint32Array(),                     prototype: Object.getPrototypeOf(Uint32Array).prototype },
+    { tag: 'Float32Array',      instance: new Float32Array(),                    prototype: Object.getPrototypeOf(Float32Array).prototype },
+    { tag: 'Float64Array',      instance: new Float64Array(),                    prototype: Object.getPrototypeOf(Float64Array).prototype }
+];
+
+// A subset of builtins use the presence of an internal slot rather than a default @@toStringTag value.
+// ES2017 19.1.3.6 Object.                                                       prototype.toString ( )
+// 5. If isArray is true, let builtinTag be "Array".
+// ...
+// 14. Else, let builtinTag be "Object"
+var internalSlotBuiltIns = [
+    { tag: "Array",             instance: [],                                    prototype: Array.prototype },
+    { tag: "String",            instance: "",                                    prototype: String.prototype },
+    { tag: "Function",          instance: function () {},                        prototype: Function.prototype },
+    { tag: "Error",             instance: new Error(),                           prototype: Error.prototype },
+    { tag: "Boolean",           instance: true,                                  prototype: Boolean.prototype },
+    { tag: "Number",            instance: 1,                                     prototype: Number.prototype },
+    { tag: "Date",              instance: new Date(),                            prototype: Date.prototype },
+    { tag: "RegExp",            instance: /a/,                                   prototype: RegExp.prototype },
+    { tag: "Object",            instance: {},                                    prototype: Object.prototype },
+];
+
+var argumentsInternalSlotBuiltIn =
+    { tag: "Arguments",         instance: (function () { return arguments; })(), prototype: (function () { return arguments; })() }
+
 var tests = [
    {
-       name: "tag string check for typed arrays, iterators, generators, and Promise",
+       name: "Built-in prototype @@toStringTag properties",
        body: function () {
-            assert.areEqual("Symbol", Symbol.prototype [Symbol.toStringTag], "check String is Symbol");
+            assert.areEqual("Symbol", Symbol.prototype[Symbol.toStringTag], "check String is Symbol");
             var o  = Object.getOwnPropertyDescriptor(Symbol.prototype, Symbol.toStringTag);
-            assert.isFalse(o.writable,     "Symbol @@toStringTag  is not writable");
+            assert.isFalse(o.writable,     "Symbol @@toStringTag is not writable");
             assert.isFalse(o.enumerable,   "Symbol @@toStringTag is not enumerable");
             assert.isTrue(o.configurable,  "Symbol @@toStringTag is configurable");
 
-            var o  = Object.getOwnPropertyDescriptor(Symbol, "toStringTag");
-            assert.isFalse(o.writable,     "@@toStringTag is not writable");
-            assert.isFalse(o.enumerable,   "@@toStringTag is not enumerable");
-            assert.isFalse(o.configurable, "@@toStringTag is not configurable");
+            function checkBuiltInPrototype(builtInName, prototype) {
+                // @@toStringTag default value
+                assert.areEqual(builtInName, prototype[Symbol.toStringTag], builtInName + "[Symbol.toStringTag] defaults to '" + builtInName + "'");
+                assert.areEqual("string", typeof prototype[Symbol.toStringTag], builtInName + "[Symbol.toStringTag] is a String")
 
-            assert.areEqual("String Iterator", ""[Symbol.iterator]()[Symbol.toStringTag], "check String is String Iterator");
-            assert.areEqual("Array Iterator", [][Symbol.iterator]()[Symbol.toStringTag], "check String is Array Iterator");
-            assert.areEqual("Map Iterator", (new Map())[Symbol.iterator]()[Symbol.toStringTag], "check String is Map Iterator");
-            assert.areEqual("Set Iterator", (new Set())[Symbol.iterator]()[Symbol.toStringTag], "check String is Set Iterator");
+                // @@toStringTag property descriptor
+                var o  = Object.getOwnPropertyDescriptor(prototype, Symbol.toStringTag);
+                assert.isFalse(o.writable,     builtInName + "[@@toStringTag] is not writable");
+                assert.isFalse(o.enumerable,   builtInName + "[@@toStringTag] is not enumerable");
+                assert.isTrue(o.configurable,  builtInName + "[@@toStringTag] is configurable");
+            }
 
-            function* gf() { };
-            assert.areEqual("GeneratorFunction", gf[Symbol.toStringTag], "check String is GeneratorFunction");
-            var o  = Object.getOwnPropertyDescriptor(gf.__proto__, Symbol.toStringTag);
-            assert.isFalse(o.writable,     "Generator function @@toStringTag is not writable");
-            assert.isFalse(o.enumerable,   "Generator function @@toStringTag is not enumerable");
-            assert.isTrue(o.configurable,  "Generator function @@toStringTag is configurable");
-
-            var gen = gf();
-            assert.areEqual("Generator", gen[Symbol.toStringTag], "check String is Generator");
-            var o  = Object.getOwnPropertyDescriptor(gen.__proto__.__proto__, Symbol.toStringTag);
-            assert.isFalse(o.writable,     "Generator @@toStringTag is not writable");
-            assert.isFalse(o.enumerable,   "Generator @@toStringTag is not enumerable");
-            assert.isTrue(o.configurable,  "Generator @@toStringTag is not configurable");
-            assert.areEqual("Generator",  o.value, "Should be the Same as gen[Symbol.toStringTag], ie Generator");
-
-            assert.areEqual("Promise", Promise.prototype[Symbol.toStringTag], "check String is Promise");
-            var o  = Object.getOwnPropertyDescriptor(Promise.prototype, Symbol.toStringTag);
-            assert.isFalse(o.writable,     "Promise @@toStringTag is not writable");
-            assert.isFalse(o.enumerable,   "Promise @@toStringTag is not enumerable");
-            assert.isTrue(o.configurable,  "Promise @@toStringTag is configurable");
+            // The following built-ins have an explicit @@toStringTag property on their prototype
+            for (var { tag, prototype } of explicitTagBuiltIns) {
+                checkBuiltInPrototype(tag, prototype);
+            }
        }
     },
     {
-       name: "tag string check for Everything else",
+        name: "Built-ins with no @@toStringTag property that have a default tag",
+        body: function () {
+            // Verify there is no @@toStringTag property.
+            for (var { tag, prototype } of [...internalSlotBuiltIns, argumentsInternalSlotBuiltIn]) {
+                assert.isFalse(prototype.hasOwnProperty(Symbol.toStringTag), tag + " does not have a @@toStringTag property");
+            }
+        }
+    },
+    {
+        name: "Default @@toStringTag built ins",
+        body: function () {
+            for (var { tag, instance } of [...primitives, ...explicitTagBuiltIns, ...explicitTagTypedArrayBuiltIns, ...internalSlotBuiltIns, argumentsInternalSlotBuiltIn]) {
+                assert.areEqual("[object "+ tag + "]", Object.prototype.toString.call(instance), tag + " toString uses default tag");
+            }
+        }
+    },
+    {
+        name: "Proxy forwarding behavior",
+        body: function () {
+            for (var { tag, instance } of explicitTagBuiltIns) {
+                assert.areEqual("[object " + tag + "]", Object.prototype.toString.call(new Proxy(instance, {})),                "Proxy toString should have tag Object");
+                assert.areEqual("[object " + tag + "]", Object.prototype.toString.call(new Proxy(new Proxy(instance, {}), {})), "Chained proxy toString should have tag Object");
+            }
+        }
+    },
+    {
+       name: "Subclass @@toStringTag override of internal slot based default tag",
        body: function () {
-            assert.areEqual("Math", Math[Symbol.toStringTag], "check String is Math");
-            var o  = Object.getOwnPropertyDescriptor(Math, Symbol.toStringTag);
-            assert.isFalse(o.writable,     "Math @@toStringTag is not writable");
-            assert.isFalse(o.enumerable,   "Math @@toStringTag is not enumerable");
-            assert.isTrue(o.configurable,  "Math @@toStringTag is configurable");
+           function testSubclassedBuiltInOverride(builtInName, instance) {
+               var c = class extends eval(builtInName) {};
+               assert.areEqual("[object " + builtInName + "]", Object.prototype.toString.call(new c), builtInName + " subclass toString uses default internal slot based tag before overriding");
 
-            assert.areEqual("JSON", JSON[Symbol.toStringTag], "check String is JSON");
-            var o  = Object.getOwnPropertyDescriptor(JSON, Symbol.toStringTag);
-            assert.isFalse(o.writable,     "JSON @@toStringTag is not writable");
-            assert.isFalse(o.enumerable,   "JSON @@toStringTag is not enumerable");
-            assert.isTrue(o.configurable,  "JSON @@toStringTag is configurable");
+               var instance = new c();
 
-            assert.areEqual("Map", (new Map())[Symbol.toStringTag], "check String is Map");
-            var o  = Object.getOwnPropertyDescriptor(Map.prototype, Symbol.toStringTag);
-            assert.isFalse(o.writable,     "Map @@toStringTag is not writable");
-            assert.isFalse(o.enumerable,   "Map @@toStringTag is not enumerable");
-            assert.isTrue(o.configurable,  "Map @@toStringTag is configurable");
+               var newName = builtInName + "Override";
+               c[Symbol.toStringTag] = newName;
+               assert.areEqual("[object " + newName + "]",     Object.prototype.toString.call(c),        builtInName + " toString uses overridden @@toStringTag after assignment");
+               assert.areEqual("[object " + builtInName + "]", Object.prototype.toString.call(instance), builtInName + " instance created before override does not pick up overridden class @@toStringTag");
 
-            assert.areEqual("WeakMap", (new WeakMap())[Symbol.toStringTag], "check String is WeakMap");
-            var o  = Object.getOwnPropertyDescriptor(WeakMap.prototype, Symbol.toStringTag);
-            assert.isFalse(o.writable,     "WeakMap @@toStringTag is not writable");
-            assert.isFalse(o.enumerable,   "WeakMap @@toStringTag is not enumerable");
-            assert.isTrue(o.configurable,  "WeakMap @@toStringTag is configurable");
+               var newInstanceName = builtInName + "Instance";
+               instance[Symbol.toStringTag] = newInstanceName;
+               assert.areEqual("[object " + newInstanceName + "]", Object.prototype.toString.call(instance), builtInName + " instance picks up @@toStringTag over the internal slot based default tag");
+           }
 
-            assert.areEqual("Set", (new Set())[Symbol.toStringTag], "check String is Set");
-            var o  = Object.getOwnPropertyDescriptor(Set.prototype, Symbol.toStringTag);
-            assert.isFalse(o.writable,     "Set @@toStringTag is not writable");
-            assert.isFalse(o.enumerable,   "Set @@toStringTag is not enumerable");
-            assert.isTrue(o.configurable,  "Set @@toStringTag is configurable");
-
-            assert.areEqual("WeakSet", (new WeakSet())[Symbol.toStringTag], "check String is WeakSet");
-            var o  = Object.getOwnPropertyDescriptor(WeakSet.prototype, Symbol.toStringTag);
-            assert.isFalse(o.writable,     "WeakSet @@toStringTag is not writable");
-            assert.isFalse(o.enumerable,   "WeakSet @@toStringTag is not enumerable");
-            assert.isTrue(o.configurable,  "WeakSet @@toStringTag is configurable");
-
-            assert.areEqual("ArrayBuffer", (new ArrayBuffer())[Symbol.toStringTag], "check String is ArrayBuffer");
-            assert.areEqual("DataView", (new DataView(new ArrayBuffer()))[Symbol.toStringTag], "check String is DataView");
+           for (var { tag, instance } of internalSlotBuiltIns) {
+               testSubclassedBuiltInOverride(tag, instance);
+           }
        }
     },
     {
-       name: "toString test for Symbol, Generators, Promises, Sets, & maps",
-       body: function () {
-            assert.areEqual("[object DataView]", Object.prototype.toString.call(new DataView((new ArrayBuffer()))), "toString should have tag DataView");
-            assert.areEqual("[object ArrayBuffer]", Object.prototype.toString.call(new ArrayBuffer()), "toString should have tag ArrayBuffer");
-            assert.areEqual("[object WeakSet]", Object.prototype.toString.call(new WeakSet()), "toString should have tag WeakSet");
-            assert.areEqual("[object Set]", Object.prototype.toString.call(new Set()), "toString should have tag Set");
-            assert.areEqual("[object WeakMap]", Object.prototype.toString.call(new WeakMap()), "toString should have tag WeakMap");
-            assert.areEqual("[object JSON]", Object.prototype.toString.call(JSON), "toString should have tag JSON");
-            assert.areEqual("[object Math]", Object.prototype.toString.call(Math), "toString should have tag Math");
-            //assert.areEqual("[object Object]", Object.prototype.toString.call(new Proxy(new Array(), {})), "Proxy toString should have tag Object"); //TODO enable when Taylor fixes Proxy subclassable bug
+        name: "TypedArray @@toStringTag behavior",
+        body: function () {
+            function checkGetterOnPrototype(builtInName, prototype) {
+                // This property has the attributes { [[Enumerable]]: false, [[Configurable]]: true }.
+                var o = Object.getOwnPropertyDescriptor(prototype, Symbol.toStringTag);
+                assert.isFalse(o.enumerable,  builtInName + " symbol @@toStringTag is not enumerable");
+                assert.isTrue(o.configurable, builtInName + " symbol @@toStringTag is configurable");
+                assert.areEqual("function", typeof o.get, builtInName + " @@toStringtag is a getter function");
+            }
 
-            function* gf() { };
-            var gen = gf();
-            assert.areEqual("[object ~GeneratorFunction]", Object.prototype.toString.call(gf), "toString should have tag ~GeneratorFunction b/c it is a subset of Function");
-            assert.areEqual("[object Generator]", Object.prototype.toString.call(gen), "toString should have tag Generator");
-            assert.areEqual("[object Promise]", Object.prototype.toString.call(new Promise(() => {})), "toString should have tag Promise");
-            assert.areEqual("[object String Iterator]", Object.prototype.toString.call(""[Symbol.iterator]()), "toString should have tag String Iterator");
-            assert.areEqual("[object Array Iterator]", Object.prototype.toString.call([][Symbol.iterator]()), "toString should have tag Array Iterator");
-            assert.areEqual("[object Map Iterator]", Object.prototype.toString.call((new Map())[Symbol.iterator]()), "toString should have tag Map Iterator");
-            assert.areEqual("[object Set Iterator]", Object.prototype.toString.call((new Set())[Symbol.iterator]()), "toString should have tag Set Iterator");
-       }
+            for (var { tag, prototype } of explicitTagTypedArrayBuiltIns) {
+                checkGetterOnPrototype(tag, prototype);
+            }
+        }
     },
-    /* Subclassing disabled in Windows10 enable once we have full support for classes.
     {
-       name: "sub class Array.toString",
+       name: "Invalid @@toStringtag (non-String coercible)",
        body: function () {
-            class MyArray extends Array {
-                constructor() {
-                   super();
+            function testBuiltIn(builtInName) {
+                var c, i;
+                if (builtInName == "DataView") {
+                    c = class extends DataView {};
+                    i = new c(new ArrayBuffer());
+                } else {
+                    c = class extends eval(builtInName) {};
+                    i = new c();
                 }
-            }
-            MyArray.prototype[Symbol.toStringTag] = "MyArray";
+                i[Symbol.toStringTag] = null;
 
-            var m = new MyArray();
-            assert.areEqual("[object Array]", Object.prototype.toString.call(new Array()), "toString should have tag Array");
-            assert.areEqual("[object ~MyArray]", Object.prototype.toString.call(m), "toString should have tag ~MyArray");
+                assert.areEqual("[object " + builtInName + "]", Object.prototype.toString.call(i), builtInName + " defaults to internal slot based tag when @@toStringTag override is not string coercible");
+            }
+
+            for (var { tag } of [...explicitTagExtensibleBuiltIns, ...explicitTagTypedArrayBuiltIns, ...internalSlotBuiltIns]) {
+                testBuiltIn(tag);
+            }
        }
     },
     {
-       name: "sub class Boolean.toString",
-       body: function () {
-            class MyBoolean extends Boolean {
-                constructor() {
-                   super();
+        name: "@@toStringTag lookup does not use HasProperty",
+        body: function() {
+             var proxy = new Proxy({ [Symbol.toStringTag] : "Proxied" }, {
+                // Previous versions of the spec called HasProperty
+                has: function (target, key) {
+                    assert.fail("Object.prototype.toString should not call HasProperty");
                 }
-            }
-            MyBoolean.prototype[Symbol.toStringTag] = "MyBoolean";
-
-            var m = new MyBoolean();
-            assert.areEqual("[object Boolean]", Object.prototype.toString.call(new Boolean()), "toString should have tag Boolean");
-            assert.areEqual("[object ~MyBoolean]", Object.prototype.toString.call(m), "toString should have tag ~MyBoolean");
-       }
+            });
+            assert.areEqual("[object Proxied]", Object.prototype.toString.call(proxy), "Proxied @@toStringTag passes through value without calling HasProperty");
+        }
     },
     {
-       name: "sub class Date.toString",
-       body: function () {
-            class MyDate extends Date {
-                constructor() {
-                   super();
-                }
-            }
-            MyDate.prototype[Symbol.toStringTag] = "MyDate";
-
-            var m = new MyDate();
-            assert.areEqual("[object Date]", Object.prototype.toString.call(new Date()), "toString should have tag Date");
-            assert.areEqual("[object ~MyDate]", Object.prototype.toString.call(m), "toString should have tag ~MyDate");
-       }
-    },
-    {
-       name: "sub class Error.toString",
-       body: function () {
-            class MyError extends Error {
-                constructor() {
-                   super();
-                }
-            }
-            MyError.prototype[Symbol.toStringTag] = "MyError";
-
-            var m = new MyError();
-            assert.areEqual("[object Error]", Object.prototype.toString.call(new Error()), "toString should have tag Error");
-            assert.areEqual("[object ~MyError]", Object.prototype.toString.call(m), "toString should have tag ~MyError");
-       }
-    },
-    {
-       name: "sub class Function.toString",
-       body: function () {
-            class MyFunction extends Function {
-                constructor() {
-                   super();
-                }
-            }
-            MyFunction[Symbol.toStringTag] = "MyFunction";
-
-            assert.areEqual("[object Function]", Object.prototype.toString.call(Function), "toString should have tag Function");
-            assert.areEqual("[object ~MyFunction]", Object.prototype.toString.call(MyFunction), "toString should have tag ~MyFunction");
-       }
-    },
-    {
-       name: "sub class Number.toString",
-       body: function () {
-            class MyNumber extends Number {
-                constructor() {
-                   super();
-                }
-            }
-            MyNumber.prototype[Symbol.toStringTag] = "MyNumber";
-
-            var m = new MyNumber();
-            assert.areEqual("[object Number]", Object.prototype.toString.call(new Number()), "toString should have tag Number");
-            assert.areEqual("[object ~MyNumber]", Object.prototype.toString.call(m), "toString should have tag ~MyNumber");
-       }
-    },
-    {
-       name: "sub class RegExp.toString",
-       body: function () {
-            class MyRegExp extends RegExp {
-                constructor() {
-                   super();
-                }
-            }
-            MyRegExp.prototype[Symbol.toStringTag] = "MyRegExp";
-
-            var m = new MyRegExp();
-            assert.areEqual("[object RegExp]", Object.prototype.toString.call(new RegExp()), "toString should have tag RegExp");
-            assert.areEqual("[object ~MyRegExp]", Object.prototype.toString.call(m), "toString should have tag ~MyRegExp");
-       }
-    },
-    {
-       name: "sub class String.toString",
-       body: function () {
-            class MyString extends String {
-                constructor() {
-                   super();
-                }
-            }
-
-            MyString.prototype[Symbol.toStringTag] = "MyString";
-
-            var m = new MyString();
-            assert.areEqual("[object String]", Object.prototype.toString.call(new String()), "toString should have tag String");
-            assert.areEqual("[object ~MyString]", Object.prototype.toString.call(m, "toString should have tag ~MyString"));
-       }
-    },
-    {
-       name: "sub class String.toString with bad tag",
-       body: function () {
-            class MyString extends String {
-                constructor() {
-                   super();
-                }
-            }
-            MyString.prototype[Symbol.toStringTag] = {};
-
-            var m = new MyString();
-            assert.areEqual("[object String]", Object.prototype.toString.call(new String()), "toString should have tag String");
-            assert.areEqual("[object ???]", Object.prototype.toString.call(m), "toString should have tag ???");
-       }
-    },
-        {
-       name: "classes with no tag & tag on instance tests",
-       body: function () {
-            class MyString extends String {
-                constructor() {
-                   super();
-                }
-            }
-
-            var m = new MyString();
-            assert.areEqual("[object String]", Object.prototype.toString.call(new String()), "toString should have tag String");
-            assert.areEqual("[object String]", Object.prototype.toString.call(m), "MyString's toString should have tag String");
-
-            class MyClass {
-                constructor() { }
-            }
-
-            var m = new MyClass();
-            var m2 = new MyClass();
-            assert.areEqual("[object Object]", Object.prototype.toString.call(m), "toString should have tag Object");
-
-            m2[Symbol.toStringTag] = "MyClassInstance";
-            assert.areEqual("[object MyClassInstance]", Object.prototype.toString.call(m2), "toString should have tag MyClassInstance");
-            assert.areEqual("[object Object]", Object.prototype.toString.call(m), "toString should have tag Object m2 only changed instance tag");
-
-            MyClass.prototype[Symbol.toStringTag] = "MyClass";
-            assert.areEqual("[object MyClassInstance]", Object.prototype.toString.call(m2), "toString should have tag MyClassInstance because MyClass is higher in the prototype chain");
-            assert.areEqual("[object MyClass]", Object.prototype.toString.call(m), "toString should have tag MyClass because prototype tag changed");
-       }
-    },
-    */
-    {
-       name: "throws test case",
-       body: function () {
-            var a = {};
-            a[Symbol.toStringTag] = "aObject";
-            assert.areEqual("aObject", a[Symbol.toStringTag], "check Tag is aObject");
-
-            assert.areEqual("[object aObject]", Object.prototype.toString.call(a), "check toString has tag aObject");
-            Object.defineProperty(a, Symbol.toStringTag, {get : function() { throw 10;}});
-
-            try {
-                a[Symbol.toStringTag];
-            } catch(e) {
-                assert.areEqual("[object ???]", Object.prototype.toString.call(a), "JS exceptions should have tag ???");
-            }
-            assert.areEqual("[object ???]", Object.prototype.toString.call(a), "JS exceptions should have tag ??? regardless of try catch");
-       }
+        name: "@@toStringTag properties with side effects",
+        body: function () {
+            var tagThrows = { get [Symbol.toStringTag]() { throw new Error(); } };
+            assert.throws(function () { Object.prototype.toString.call(tagThrows) }, Error, "@@toStringTag throws as a side effect");
+        }
     },
     {
         name: "VSO OS Bug 1160433: embedded null characters in toStringTag property value",
@@ -308,7 +213,7 @@ var tests = [
 
             assert.areEqual("[object before\0after]", o.toString(), "ToString implementation handles embedded null characters in @@toStringTag property value");
         }
-    },
+    }
 ];
 
 testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });


### PR DESCRIPTION
Our current implementation of @@toStringTag is based on an old spec
revision from 2015. This change updates the implementation to conform to
the current spec.

The current behavior for handling legacy and toStringTag feature switching
is fragile, and I decided to leave the majority of it in and rename
ToStringTagHelper to ToStringTagHelperOld. The legacy code relies on the
helper, and will call it even when the @@toStringTag feature is disabled.

Other changes of note:
- Slightly tweaked the ordering of ToStringHelper so we can take advantage
  of the existing HostDispatch and TypedArray Debugger handling behavior
  while still retaining legacy codepaths.
- TypedArray toString handler spec update is also guarded by a flag.
- Overhauled the tests for @@toStringTag, adding a lot more type coverage.

When the feature is turned on by default, we can remove the legacy
codepaths for simplicity.
