### PR TITLE
Fix ES2015 module redeclaration errors and root object pollution

### DIFF
--- a/lib/Parser/Parse.h
+++ b/lib/Parser/Parse.h
@@ -739,11 +739,11 @@ private:
     template<bool buildAST> ParseNodePtr ParseFncDecl(ushort flags, LPCOLESTR pNameHint = NULL, const bool needsPIDOnRCurlyScan = false, bool resetParsingSuperRestrictionState = true, bool fUnaryOrParen = false);
     template<bool buildAST> bool ParseFncNames(ParseNodePtr pnodeFnc, ParseNodePtr pnodeFncParent, ushort flags, ParseNodePtr **pLastNodeRef);
     template<bool buildAST> void ParseFncFormals(ParseNodePtr pnodeFnc, ushort flags);
-    template<bool buildAST> bool ParseFncDeclHelper(ParseNodePtr pnodeFnc, LPCOLESTR pNameHint, ushort flags, bool *pHasName, bool fUnaryOrParen, bool noStmtContext, bool *pNeedScanRCurly);
+    template<bool buildAST> bool ParseFncDeclHelper(ParseNodePtr pnodeFnc, LPCOLESTR pNameHint, ushort flags, bool *pHasName, bool fUnaryOrParen, bool noStmtContext, bool *pNeedScanRCurly, bool skipFormals = false);
     template<bool buildAST> void ParseExpressionLambdaBody(ParseNodePtr pnodeFnc);
     template<bool buildAST> void UpdateCurrentNodeFunc(ParseNodePtr pnodeFnc, bool fLambda);
     bool FncDeclAllowedWithoutContext(ushort flags);
-    void FinishFncDecl(ParseNodePtr pnodeFnc, LPCOLESTR pNameHint, ParseNodePtr *lastNodeRef);
+    void FinishFncDecl(ParseNodePtr pnodeFnc, LPCOLESTR pNameHint, ParseNodePtr *lastNodeRef, bool skipCurlyBraces = false);
     void ParseTopLevelDeferredFunc(ParseNodePtr pnodeFnc, ParseNodePtr pnodeFncParent, LPCOLESTR pNameHint);
     void ParseNestedDeferredFunc(ParseNodePtr pnodeFnc, bool fLambda, bool *pNeedScanRCurly, bool *pStrictModeTurnedOn);
     void CheckStrictFormalParameters();
@@ -756,6 +756,8 @@ private:
     uint CalculateFunctionColumnNumber();
 
     template<bool buildAST> ParseNodePtr GenerateEmptyConstructor(bool extends = false);
+
+    template<bool buildAST> ParseNodePtr GenerateModuleFunctionWrapper();
 
     IdentPtr ParseClassPropertyName(IdentPtr * hint);
     template<bool buildAST> ParseNodePtr ParseClassDecl(BOOL isDeclaration, LPCOLESTR pNameHint, uint32 *pHintLength, uint32 *pShortNameOffset);
@@ -1000,6 +1002,7 @@ private:
         fFncClassMember = 1 << 6,
         fFncGenerator   = 1 << 7,
         fFncAsync       = 1 << 8,
+        fFncModule      = 1 << 9,
     };
 
     //

--- a/lib/Parser/ptree.h
+++ b/lib/Parser/ptree.h
@@ -182,7 +182,7 @@ enum FncFlags
     kFunctionHasNonThisStmt                     = 1 << 7,
     kFunctionStrictMode                         = 1 << 8,
     kFunctionDoesNotEscape                      = 1 << 9, // function is known not to escape its declaring scope
-    kFunctionSubsumed                           = 1 << 10, // function expression is a parameter in a call that has no closing paren and should be treated as a global declaration (only occurs during error correction)
+    kFunctionIsModule                           = 1 << 10, // function is a module body
     kFunctionHasThisStmt                        = 1 << 11, // function has at least one this.assignment and might be a constructor
     kFunctionHasWithStmt                        = 1 << 12, // function (or child) uses with
     kFunctionIsLambda                           = 1 << 13,
@@ -301,7 +301,7 @@ public:
     void SetNameIsHidden(bool set = true) { SetFlags(kFunctionNameIsHidden, set); }
     void SetNested(bool set = true) { SetFlags(kFunctionNested, set); }
     void SetStrictMode(bool set = true) { SetFlags(kFunctionStrictMode, set); }
-    void SetSubsumed(bool set = true) { SetFlags(kFunctionSubsumed, set); }
+    void SetIsModule(bool set = true) { SetFlags(kFunctionIsModule, set); }
     void SetUsesArguments(bool set = true) { SetFlags(kFunctionUsesArguments, set); }
     void SetIsDefaultModuleExport(bool set = true) { SetFlags(kFunctionIsDefaultModuleExport, set); }
 
@@ -334,7 +334,7 @@ public:
     bool IsMethod() const { return HasFlags(kFunctionIsMethod); }
     bool IsNested() const { return HasFlags(kFunctionNested); }
     bool IsStaticMember() const { return HasFlags(kFunctionIsStaticMember); }
-    bool IsSubsumed() const { return HasFlags(kFunctionSubsumed); }
+    bool IsModule() const { return HasFlags(kFunctionIsModule); }
     bool NameIsHidden() const { return HasFlags(kFunctionNameIsHidden); }
     bool UsesArguments() const { return HasFlags(kFunctionUsesArguments); }
     bool IsDefaultModuleExport() const { return HasFlags(kFunctionIsDefaultModuleExport); }

--- a/lib/Runtime/Base/FunctionInfo.h
+++ b/lib/Runtime/Base/FunctionInfo.h
@@ -35,7 +35,8 @@ namespace Js
             CapturesThis                   = 0x02000, // Only lambdas will set this; denotes whether the lambda referred to this, used by debugger
             Generator                      = 0x04000,
             BuiltInInlinableAsLdFldInlinee = 0x08000,
-            Async                          = 0x10000
+            Async                          = 0x10000,
+            Module                         = 0x20000, // The function is the function body wrapper for a module
         };
         FunctionInfo(JavascriptMethod entryPoint, Attributes attributes = None, LocalFunctionId functionId = Js::Constants::NoFunctionId, FunctionBody* functionBodyImpl = NULL);
 
@@ -54,6 +55,7 @@ namespace Js
         bool IsGenerator() const { return ((this->attributes & Generator) != 0); }
         bool IsClassConstructor() const { return ((this->attributes & ClassConstructor) != 0); }
         bool IsClassMethod() const { return ((this->attributes & ClassMethod) != 0); }
+        bool IsModule() const { return ((this->attributes & Module) != 0); }
         bool HasSuperReference() const { return ((this->attributes & SuperReference) != 0); }
 
         BOOL HasBody() const { return functionBodyImpl != NULL; }

--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -1338,16 +1338,9 @@ void ByteCodeGenerator::DefineUserVars(FuncInfo *funcInfo)
                 Assert(sym && !sym->GetIsCatch() && !sym->GetIsBlockVar());
             }
 
-            if (sym->GetSymbolType() == STVariable)
+            if (sym->GetSymbolType() == STVariable && !sym->GetIsModuleExportStorage())
             {
-                if (sym->GetIsModuleExportStorage())
-                {
-                    Js::RegSlot reg = funcInfo->AcquireTmpRegister();
-                    this->m_writer.Reg1(Js::OpCode::LdUndef, reg);
-                    EmitModuleExportAccess(sym, Js::OpCode::StModuleSlot, reg, funcInfo);
-                    funcInfo->ReleaseTmpRegister(reg);
-                }
-                else if (fGlobal)
+                if (fGlobal)
                 {
                     Js::PropertyId propertyId = sym->EnsurePosition(this);
                     // We do need to initialize some globals to avoid JS errors on loading undefined variables.

--- a/lib/Runtime/ByteCode/ScopeInfo.h
+++ b/lib/Runtime/ByteCode/ScopeInfo.h
@@ -15,6 +15,7 @@ namespace Js {
         {
             ByteCodeGenerator* byteCodeGenerator;
             FuncInfo* func;
+            int nonScopeSymbolCount;
         };
 
         struct SymbolInfo
@@ -28,6 +29,8 @@ namespace Js {
             bool hasFuncAssignment;
             bool isBlockVariable;
             bool isFuncExpr;
+            bool isModuleExportStorage;
+            bool isModuleImport;
         };
 
     private:
@@ -100,6 +103,20 @@ namespace Js {
             symbols[i].isFuncExpr = is;
         }
 
+        void SetIsModuleExportStorage(int i, bool is)
+        {
+            Assert(!areNamesCached);
+            Assert(i >= 0 && i < symbolCount);
+            symbols[i].isModuleExportStorage = is;
+        }
+
+        void SetIsModuleImport(int i, bool is)
+        {
+            Assert(!areNamesCached);
+            Assert(i >= 0 && i < symbolCount);
+            symbols[i].isModuleImport = is;
+        }
+
         void SetPropertyName(int i, PropertyRecord const* name)
         {
             Assert(!areNamesCached);
@@ -124,6 +141,18 @@ namespace Js {
         {
             Assert(i >= 0 && i < symbolCount);
             return symbols[i].hasFuncAssignment;
+        }
+
+        bool GetIsModuleExportStorage(int i)
+        {
+            Assert(i >= 0 && i < symbolCount);
+            return symbols[i].isModuleExportStorage;
+        }
+
+        bool GetIsModuleImport(int i)
+        {
+            Assert(i >= 0 && i < symbolCount);
+            return symbols[i].isModuleImport;
         }
 
         bool GetIsBlockVariable(int i)

--- a/lib/Runtime/ByteCode/Symbol.cpp
+++ b/lib/Runtime/ByteCode/Symbol.cpp
@@ -66,7 +66,7 @@ bool Symbol::NeedsSlotAlloc(FuncInfo *funcInfo)
 
 bool Symbol::IsInSlot(FuncInfo *funcInfo, bool ensureSlotAlloc)
 {
-    if (this->GetIsGlobal())
+    if (this->GetIsGlobal() || this->GetIsModuleExportStorage())
     {
         return false;
     }


### PR DESCRIPTION
Creates a function body to hold the module statements so var and block-scoped declarations don't leak into the root object. Previously, all modules were global code so declarations would leak between module code via the root object.

This resolves two bugs:
https://microsoft.visualstudio.com/web/wi.aspx?pcguid=cb55739e-4afe-46a3-970f-1b49d8ee7564&id=7657926
https://microsoft.visualstudio.com/web/wi.aspx?pcguid=cb55739e-4afe-46a3-970f-1b49d8ee7564&id=7717411
