### PR TITLE
Bug fixes

### DIFF
--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -6476,7 +6476,7 @@ GlobOpt::CopyPropReplaceOpnd(IR::Instr * instr, IR::Opnd * opnd, StackSym * copy
                 // We're creating a copy of this operand to be reused in the same spot in the flow, so we can copy all
                 // flow sensitive fields.  However, we will do only a type check here (no property access) and only for
                 // the sake of downstream instructions, so the flags pertaining to this property access are irrelevant.
-                IR::PropertySymOpnd* checkObjTypeOpnd = propertySymOpnd->CopyForTypeCheckOnly(instr->m_func);
+                IR::PropertySymOpnd* checkObjTypeOpnd = CreateOpndForTypeCheckOnly(propertySymOpnd, instr->m_func);
                 IR::Instr* checkObjTypeInstr = IR::Instr::New(Js::OpCode::CheckObjType, instr->m_func);
                 checkObjTypeInstr->SetSrc1(checkObjTypeOpnd);
                 checkObjTypeInstr->SetByteCodeOffset(instr);

--- a/lib/Backend/GlobOpt.h
+++ b/lib/Backend/GlobOpt.h
@@ -1316,6 +1316,7 @@ private:
     bool                    OptTagChecks(IR::Instr *instr);
     void                    TryOptimizeInstrWithFixedDataProperty(IR::Instr * * const pInstr);
     bool                    CheckIfPropOpEmitsTypeCheck(IR::Instr *instr, IR::PropertySymOpnd *opnd);
+    IR::PropertySymOpnd *   CreateOpndForTypeCheckOnly(IR::PropertySymOpnd* opnd, Func* func);
     bool                    FinishOptPropOp(IR::Instr *instr, IR::PropertySymOpnd *opnd, BasicBlock* block = nullptr, bool updateExistingValue = false, bool* emitsTypeCheckOut = nullptr, bool* changesTypeValueOut = nullptr);
     void                    FinishOptHoistedPropOps(Loop * loop);
     IR::Instr *             SetTypeCheckBailOut(IR::Opnd *opnd, IR::Instr *instr, BailOutInfo *bailOutInfo);

--- a/lib/Backend/Inline.cpp
+++ b/lib/Backend/Inline.cpp
@@ -3730,7 +3730,7 @@ Inline::InlineScriptFunction(IR::Instr *callInstr, const Js::FunctionCodeGenJitT
                          this->topFunc->GetCodeGenProfiler(),
                          this->topFunc->IsBackgroundJIT(),
                          callInstr->m_func,
-                         callInstr->m_next->GetByteCodeOffset(),
+                         callInstr->GetNextRealInstr()->GetByteCodeOffset(),
                          returnRegSlot,
                          isCtor,
                          callSiteId,

--- a/lib/Backend/Opnd.cpp
+++ b/lib/Backend/Opnd.cpp
@@ -788,32 +788,6 @@ PropertySymOpnd::CopyWithoutFlowSensitiveInfo(Func *func)
 }
 
 PropertySymOpnd *
-PropertySymOpnd::CopyForTypeCheckOnly(Func *func)
-{
-    Assert(!IsRootObjectNonConfigurableFieldLoad());
-    PropertySymOpnd *newOpnd = CopyCommon(func);
-
-    newOpnd->objTypeSpecFldInfo = this->objTypeSpecFldInfo;
-    newOpnd->usesAuxSlot = usesAuxSlot;
-    newOpnd->slotIndex = slotIndex;
-
-    newOpnd->objTypeSpecFlags = this->objTypeSpecFlags;
-    // If we're turning the instruction owning this operand into a CheckObjType, we will do a type check here
-    // only for the sake of downstream instructions, so the flags pertaining to this property access are
-    // irrelevant, because we don't do a property access here.
-    newOpnd->SetTypeCheckOnly(true);
-    newOpnd->usesFixedValue = false;
-
-    newOpnd->finalType = this->finalType;
-    newOpnd->guardedPropOps = this->guardedPropOps != nullptr ? this->guardedPropOps->CopyNew() : nullptr;
-    newOpnd->writeGuards = this->writeGuards != nullptr ? this->writeGuards->CopyNew() : nullptr;
-
-    newOpnd->SetIsJITOptimizedReg(this->GetIsJITOptimizedReg());
-
-    return newOpnd;
-}
-
-PropertySymOpnd *
 PropertySymOpnd::CopyInternalSub(Func *func)
 {
     Assert(m_kind == OpndKindSym && this->IsPropertySymOpnd());

--- a/lib/Backend/Opnd.h
+++ b/lib/Backend/Opnd.h
@@ -495,7 +495,6 @@ public:
 public:
     PropertySymOpnd * CopyCommon(Func *func);
     PropertySymOpnd * CopyWithoutFlowSensitiveInfo(Func *func);
-    PropertySymOpnd * CopyForTypeCheckOnly(Func *func);
     PropertySymOpnd * CopyInternalSub(Func *func);
     PropertySymOpnd * CloneDefInternalSub(Func *func);
     PropertySymOpnd * CloneUseInternalSub(Func *func);

--- a/lib/Runtime/Library/StackScriptFunction.cpp
+++ b/lib/Runtime/Library/StackScriptFunction.cpp
@@ -240,7 +240,7 @@ namespace Js
                         this->UpdateFrameDisplay(stackFunction);
                     }
 
-                    if (walker.IsBailedOutFromInlinee())
+                    if (walker.IsBailedOutFromInlinee() && !walker.IsCurrentPhysicalFrameForLoopBody())
                     {
                         // this is the interpret frame from bailing out of inline frame
                         // Just mark we have inlinee to box so we will walk the native frame's list when we get there.
@@ -266,7 +266,7 @@ namespace Js
                 }
                 else
                 {
-                    if (walker.IsInlineFrame())
+                    if (walker.IsInlineFrame() && !walker.IsCurrentPhysicalFrameForLoopBody())
                     {
                         // We may have function that are not in slots.  So we have to walk the stack function list of the inliner
                         // to box all the needed function to catch those

--- a/test/inlining/inliningInLoopBody.js
+++ b/test/inlining/inliningInLoopBody.js
@@ -1,0 +1,40 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+var __counter = 0;
+function test0() {
+  __counter++;
+  var obj0 = {};
+  var protoObj0 = {};
+  var obj1 = {};
+  var func0 = function () {
+  };
+  var func4 = function () {
+    return func4.caller;
+  };
+  obj0.method1 = func0;
+  obj1.method0 = func4;
+  Object.prototype.method0 = obj0.method1;
+  var ary = Array();
+  ary[0] = 41697303.1;
+  var protoObj1 = Object(obj1);
+  for (var _strvar35 in ary) {
+    function v18() {
+      for (var v21 = 0; v21 < 3; v21++) {
+        (function () {
+          var uniqobj8 = [
+            protoObj1,
+            protoObj0
+          ];
+          uniqobj8[__counter % uniqobj8.length].method0();
+        }());
+      }
+    }
+    v18();
+  }
+}
+test0();
+test0();
+WScript.Echo("Passed");

--- a/test/inlining/rlexe.xml
+++ b/test/inlining/rlexe.xml
@@ -238,4 +238,10 @@
       <files>missingInlineeEnd.js</files>
     </default>
   </test>
+  <test>
+    <default>
+      <files>inliningInLoopBody.js</files>
+      <compile-flags>-loopinterpretcount:1 -bgjit- -force:inline</compile-flags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
1. Inlinees in a loop body frame need not marked as candidates for boxing as we wouldn't have allocated nested functions on the stack for a jitted loop body frame (both for loop body and inlinees in it)

2. CheckObjType instruction shouldn't add a bytecode use of the symbol whose type it is checking. For this purpose, I'm marking the source operand as jit-optimized.

3. Bailout offset on InlineeEnd should be that of the next real instruction after the call to the inlinee.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/1295)
<!-- Reviewable:end -->
