### PR TITLE
Fixing an assert in GlobOpt::TrackInstrsForScopeObjectRemoval

### DIFF
--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -3880,8 +3880,9 @@ GlobOpt::TrackInstrsForScopeObjectRemoval(IR::Instr * instr)
             //So we don't want to track the stack sym for this argout.- Skipping it here.
             if (instr->m_func->IsInlinedConstructor())
             {
-                Assert(argOutInstr->GetSrc1()->GetStackSym()->GetInstrDef() != nullptr);
-                Assert(argOutInstr->GetSrc1()->GetStackSym()->GetInstrDef()->m_opcode == Js::OpCode::NewScObjectNoCtor);
+                //PRE might introduce a second defintion for the Src1. So assert for the opcode only when it has single definition.
+                Assert(argOutInstr->GetSrc1()->GetStackSym()->GetInstrDef() == nullptr ||
+                    argOutInstr->GetSrc1()->GetStackSym()->GetInstrDef()->m_opcode == Js::OpCode::NewScObjectNoCtor);
                 argOutInstr = argOutInstr->GetSrc2()->GetStackSym()->GetInstrDef();
             }
             if (formalsCount < actualsCount)

--- a/test/Function/StackArgsWithFormals.baseline
+++ b/test/Function/StackArgsWithFormals.baseline
@@ -10,4 +10,6 @@ StackArgFormals : test6 (10) :Removing Heap Arguments object creation in Lowerer
 StackArgFormals : test7 (11) :Removing Heap Arguments object creation in Lowerer. 
 StackArgFormals : test12_1 (17) :Removing Scope object creation in Deadstore pass. 
 StackArgFormals : test12_1 (17) :Removing Heap Arguments object creation in Lowerer. 
+StackArgFormals : test13 (19) :Removing Scope object creation in Deadstore pass. 
+StackArgFormals : test13 (19) :Removing Heap Arguments object creation in Lowerer. 
 PASSED

--- a/test/Function/StackArgsWithFormals.js
+++ b/test/Function/StackArgsWithFormals.js
@@ -208,6 +208,13 @@ test12();
 test12();
 verify([], "TEST 12");
 
+function test13(a) {
+    actuals.push(typeof arguments[1]);
+}
+test13(1,2);
+test13({}, {});
+verify(["number", "object"], "TEST 13");
+
 if(hasAllPassed)
 {
     print("PASSED");


### PR DESCRIPTION
The assert under interest was assuming that the Src1 of ArgOut Instr will
always have a single def, which is false in some cases(the one which I
observed was with PRE introducing extra defintion with this src sym)
