### PR TITLE
SparseBitVector::TestAndClear should not allocate

### DIFF
--- a/lib/Common/DataStructures/SparseBitVector.h
+++ b/lib/Common/DataStructures/SparseBitVector.h
@@ -474,7 +474,11 @@ BOOLEAN
 BVSparse<TAllocator>::TestAndClear(BVIndex i)
 {
     BVSparseNode ** prevNextField;
-    BVSparseNode * current = this->NodeFromIndex(i, &prevNextField);
+    BVSparseNode * current = this->NodeFromIndex(i, &prevNextField, false /* create */);
+    if (current == nullptr)
+    {
+        return false;
+    }
     BVIndex bvIndex = SparseBVUnit::Offset(i);
     BOOLEAN bit = current->data.Test(bvIndex);
     current->data.Clear(bvIndex);


### PR DESCRIPTION
Fix a nit I found yesterday: SparseBitVector::TestAndClear will create a BV node if the BV doesn't have a node that contains the bit we're testing. Changed the API so it doesn't create and instead returns early if it doesn't have the node we're looking for.
