### PR TITLE
Add strong return types to some internal property enumerating functions

### DIFF
--- a/lib/Runtime/Debug/TTActionEvents.cpp
+++ b/lib/Runtime/Debug/TTActionEvents.cpp
@@ -338,7 +338,7 @@ namespace TTD
             const JsRTVarsArgumentAction* action = GetInlineEventDataAs<JsRTVarsArgumentAction, EventKind::GetOwnPropertyNamesInfoActionTag>(evt);
             Js::Var var = InflateVarInReplay(ctx, action->Var1);
 
-            Js::Var res = Js::JavascriptOperators::GetOwnPropertyNames(var, ctx);
+            Js::JavascriptArray* res = Js::JavascriptOperators::GetOwnPropertyNames(var, ctx);
 
             JsRTActionHandleResultForReplay<JsRTVarsArgumentAction, EventKind::GetOwnPropertyNamesInfoActionTag>(ctx, evt, res);
         }
@@ -348,7 +348,7 @@ namespace TTD
             const JsRTVarsArgumentAction* action = GetInlineEventDataAs<JsRTVarsArgumentAction, EventKind::GetOwnPropertySymbolsInfoActionTag>(evt);
             Js::Var var = InflateVarInReplay(ctx, action->Var1);
 
-            Js::Var res = Js::JavascriptOperators::GetOwnPropertySymbols(var, ctx);
+            Js::JavascriptArray* res = Js::JavascriptOperators::GetOwnPropertySymbols(var, ctx);
 
             JsRTActionHandleResultForReplay<JsRTVarsArgumentAction, EventKind::GetOwnPropertySymbolsInfoActionTag>(ctx, evt, res);
         }

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -1112,7 +1112,7 @@ CommonNumber:
         return result;
     }
 
-    Var JavascriptOperators::GetOwnPropertyNames(Var instance, ScriptContext *scriptContext)
+    JavascriptArray* JavascriptOperators::GetOwnPropertyNames(Var instance, ScriptContext *scriptContext)
     {
         RecyclableObject *object = RecyclableObject::FromVar(ToObject(instance, scriptContext));
 
@@ -1125,7 +1125,7 @@ CommonNumber:
         return JavascriptObject::CreateOwnStringPropertiesHelper(object, scriptContext);
     }
 
-    Var JavascriptOperators::GetOwnPropertySymbols(Var instance, ScriptContext *scriptContext)
+    JavascriptArray* JavascriptOperators::GetOwnPropertySymbols(Var instance, ScriptContext *scriptContext)
     {
         RecyclableObject *object = RecyclableObject::FromVar(ToObject(instance, scriptContext));
         CHAKRATEL_LANGSTATS_INC_BUILTINCOUNT(GetOwnPropertySymbolsCount);
@@ -1139,7 +1139,7 @@ CommonNumber:
         return JavascriptObject::CreateOwnSymbolPropertiesHelper(object, scriptContext);
     }
 
-    Var JavascriptOperators::GetOwnPropertyKeys(Var instance, ScriptContext* scriptContext)
+    JavascriptArray* JavascriptOperators::GetOwnPropertyKeys(Var instance, ScriptContext* scriptContext)
     {
         RecyclableObject *object = RecyclableObject::FromVar(ToObject(instance, scriptContext));
 
@@ -1152,26 +1152,15 @@ CommonNumber:
         return JavascriptObject::CreateOwnStringSymbolPropertiesHelper(object, scriptContext);
     }
 
-    Var JavascriptOperators::GetOwnEnumerablePropertyNames(Var instance, ScriptContext* scriptContext)
+    JavascriptArray* JavascriptOperators::GetOwnEnumerablePropertyNames(Var instance, ScriptContext* scriptContext)
     {
         RecyclableObject *object = RecyclableObject::FromVar(ToObject(instance, scriptContext));
 
         if (JavascriptProxy::Is(instance))
         {
             JavascriptProxy* proxy = JavascriptProxy::FromVar(instance);
-            Var result = proxy->PropertyKeysTrap(JavascriptProxy::KeysTrapKind::GetOwnPropertyNamesKind);
-
-            AssertMsg(JavascriptArray::Is(result), "PropertyKeysTrap should return JavascriptArray.");
-            JavascriptArray* proxyResult;
+            JavascriptArray* proxyResult = proxy->PropertyKeysTrap(JavascriptProxy::KeysTrapKind::GetOwnPropertyNamesKind);
             JavascriptArray* proxyResultToReturn = scriptContext->GetLibrary()->CreateArray(0);
-            if (JavascriptArray::Is(result))
-            {
-                proxyResult = JavascriptArray::FromVar(result);
-            }
-            else
-            {
-                return proxyResultToReturn;
-            }
 
             // filter enumerable keys
             uint32 resultLength = proxyResult->GetLength();
@@ -1199,7 +1188,7 @@ CommonNumber:
         return JavascriptObject::CreateOwnEnumerableStringPropertiesHelper(object, scriptContext);
     }
 
-    Var JavascriptOperators::GetOwnEnumerablePropertyNamesSymbols(Var instance, ScriptContext* scriptContext)
+    JavascriptArray* JavascriptOperators::GetOwnEnumerablePropertyNamesSymbols(Var instance, ScriptContext* scriptContext)
     {
         RecyclableObject *object = RecyclableObject::FromVar(ToObject(instance, scriptContext));
 

--- a/lib/Runtime/Language/JavascriptOperators.h
+++ b/lib/Runtime/Language/JavascriptOperators.h
@@ -151,13 +151,13 @@ namespace Js
         static void OP_EnsureNoRootProperty(Var instance, PropertyId propertyId);
         static void OP_EnsureNoRootRedeclProperty(Var instance, PropertyId propertyId);
         static void OP_ScopedEnsureNoRedeclProperty(FrameDisplay *pDisplay, PropertyId propertyId, Var instanceDefault);
-        static Var  GetOwnPropertyNames(Var instance, ScriptContext *scriptContext);
-        static Var  GetOwnPropertySymbols(Var instance, ScriptContext *scriptContext);
-        static Var  GetOwnPropertyKeys(Var instance, ScriptContext *scriptContext);
+        static JavascriptArray*  GetOwnPropertyNames(Var instance, ScriptContext *scriptContext);
+        static JavascriptArray*  GetOwnPropertySymbols(Var instance, ScriptContext *scriptContext);
+        static JavascriptArray*  GetOwnPropertyKeys(Var instance, ScriptContext *scriptContext);
 
 
-        static Var  GetOwnEnumerablePropertyNames(Var instance, ScriptContext *scriptContext);
-        static Var  GetOwnEnumerablePropertyNamesSymbols(Var instance, ScriptContext *scriptContext);
+        static JavascriptArray*  GetOwnEnumerablePropertyNames(Var instance, ScriptContext *scriptContext);
+        static JavascriptArray*  GetOwnEnumerablePropertyNamesSymbols(Var instance, ScriptContext *scriptContext);
 
         static BOOL GetOwnPropertyDescriptor(RecyclableObject* obj, PropertyId propertyId, ScriptContext* scriptContext, PropertyDescriptor* propertyDescriptor);
         static BOOL GetOwnPropertyDescriptor(RecyclableObject* obj, JavascriptString* propertyKey, ScriptContext* scriptContext, PropertyDescriptor* propertyDescriptor);

--- a/lib/Runtime/Library/JSON.cpp
+++ b/lib/Runtime/Library/JSON.cpp
@@ -603,17 +603,7 @@ namespace JSON
             if (JavascriptProxy::Is(object))
             {
                 JavascriptProxy* proxyObject = JavascriptProxy::FromVar(object);
-                Var propertyKeysTrapResult = proxyObject->PropertyKeysTrap(JavascriptProxy::KeysTrapKind::GetOwnPropertyNamesKind);
-
-                AssertMsg(JavascriptArray::Is(propertyKeysTrapResult), "PropertyKeysTrap should return JavascriptArray.");
-                JavascriptArray* proxyResult;
-                if (JavascriptArray::Is(propertyKeysTrapResult))
-                {
-                    proxyResult = JavascriptArray::FromVar(propertyKeysTrapResult);
-                } else
-                {
-                    proxyResult = scriptContext->GetLibrary()->CreateArray(0);
-                }
+                JavascriptArray* proxyResult = proxyObject->PropertyKeysTrap(JavascriptProxy::KeysTrapKind::GetOwnPropertyNamesKind);
 
                 // filter enumerable keys
                 uint32 resultLength = proxyResult->GetLength();

--- a/lib/Runtime/Library/JavascriptObject.cpp
+++ b/lib/Runtime/Library/JavascriptObject.cpp
@@ -868,25 +868,15 @@ namespace Js
             }
         }
 
-        Var ownPropertyKeys = JavascriptOperators::GetOwnPropertyKeys(obj, scriptContext);
-        Assert(JavascriptArray::Is(ownPropertyKeys));
-
-        if (!JavascriptArray::Is(ownPropertyKeys))
-        {
-            ownPropertyKeys = scriptContext->GetLibrary()->CreateArray(0);
-        }
-
-
-        JavascriptArray *ownPropsArray = JavascriptArray::FromVar(ownPropertyKeys);
-
-        RecyclableObject* resultObj = scriptContext->GetLibrary()->CreateObject(true, (Js::PropertyIndex) ownPropsArray->GetLength());
+        JavascriptArray* ownPropertyKeys = JavascriptOperators::GetOwnPropertyKeys(obj, scriptContext);
+        RecyclableObject* resultObj = scriptContext->GetLibrary()->CreateObject(true, (Js::PropertyIndex) ownPropertyKeys->GetLength());
         
         PropertyDescriptor propDesc;
         Var propKey = nullptr;
 
-        for (uint i = 0; i < ownPropsArray->GetLength(); i++)
+        for (uint i = 0; i < ownPropertyKeys->GetLength(); i++)
         {
-            BOOL getPropResult = ownPropsArray->DirectGetItemAt(i, &propKey);
+            BOOL getPropResult = ownPropertyKeys->DirectGetItemAt(i, &propKey);
             Assert(getPropResult);
 
             if (!getPropResult)
@@ -1242,17 +1232,7 @@ namespace Js
         Assert(scriptContext != nullptr);
         JavascriptArray* valuesArray = scriptContext->GetLibrary()->CreateArray(0);
 
-        Var ownKeysVar = JavascriptOperators::GetOwnPropertyNames(object, scriptContext);
-        JavascriptArray* ownKeysResult = nullptr;
-        if (JavascriptArray::Is(ownKeysVar))
-        {
-            ownKeysResult = JavascriptArray::FromVar(ownKeysVar);
-        }
-        else
-        {
-            return valuesArray;
-        }
-
+        JavascriptArray* ownKeysResult = JavascriptOperators::GetOwnPropertyNames(object, scriptContext);
         uint32 length = ownKeysResult->GetLength();
 
         Var nextKey;
@@ -1322,33 +1302,33 @@ namespace Js
         return GetValuesOrEntries(object, false /*valuesToReturn*/, scriptContext);
     }
 
-    Var JavascriptObject::CreateOwnSymbolPropertiesHelper(RecyclableObject* object, ScriptContext* scriptContext)
+    JavascriptArray* JavascriptObject::CreateOwnSymbolPropertiesHelper(RecyclableObject* object, ScriptContext* scriptContext)
     {
         return CreateKeysHelper(object, scriptContext, TRUE, true /*includeSymbolsOnly */, false, true /*includeSpecialProperties*/);
     }
 
-    Var JavascriptObject::CreateOwnStringPropertiesHelper(RecyclableObject* object, ScriptContext* scriptContext)
+    JavascriptArray* JavascriptObject::CreateOwnStringPropertiesHelper(RecyclableObject* object, ScriptContext* scriptContext)
     {
         return CreateKeysHelper(object, scriptContext, TRUE, false, true /*includeStringsOnly*/, true /*includeSpecialProperties*/);
     }
 
-    Var JavascriptObject::CreateOwnStringSymbolPropertiesHelper(RecyclableObject* object, ScriptContext* scriptContext)
+    JavascriptArray* JavascriptObject::CreateOwnStringSymbolPropertiesHelper(RecyclableObject* object, ScriptContext* scriptContext)
     {
         return CreateKeysHelper(object, scriptContext, TRUE, true/*includeSymbolsOnly*/, true /*includeStringsOnly*/, true /*includeSpecialProperties*/);
     }
 
-    Var JavascriptObject::CreateOwnEnumerableStringPropertiesHelper(RecyclableObject* object, ScriptContext* scriptContext)
+    JavascriptArray* JavascriptObject::CreateOwnEnumerableStringPropertiesHelper(RecyclableObject* object, ScriptContext* scriptContext)
     {
         return CreateKeysHelper(object, scriptContext, FALSE, false, true/*includeStringsOnly*/, false);
     }
 
-    Var JavascriptObject::CreateOwnEnumerableStringSymbolPropertiesHelper(RecyclableObject* object, ScriptContext* scriptContext)
+    JavascriptArray* JavascriptObject::CreateOwnEnumerableStringSymbolPropertiesHelper(RecyclableObject* object, ScriptContext* scriptContext)
     {
         return CreateKeysHelper(object, scriptContext, FALSE, true/*includeSymbolsOnly*/, true/*includeStringsOnly*/, false);
     }
 
     // 9.1.12 [[OwnPropertyKeys]] () in RC#4 dated April 3rd 2015.
-    Var JavascriptObject::CreateKeysHelper(RecyclableObject* object, ScriptContext* scriptContext, BOOL includeNonEnumerable, bool includeSymbolProperties, bool includeStringProperties, bool includeSpecialProperties)
+    JavascriptArray* JavascriptObject::CreateKeysHelper(RecyclableObject* object, ScriptContext* scriptContext, BOOL includeNonEnumerable, bool includeSymbolProperties, bool includeStringProperties, bool includeSpecialProperties)
     {
         //1. Let keys be a new empty List.
         //2. For each own property key P of O that is an integer index, in ascending numeric index order
@@ -1786,17 +1766,8 @@ namespace Js
 
     void JavascriptObject::AssignForProxyObjects(RecyclableObject* from, RecyclableObject* to, ScriptContext* scriptContext)
     {
-        Var keysResult = JavascriptOperators::GetOwnEnumerablePropertyNamesSymbols(from, scriptContext);
-        JavascriptArray *keys;
+         JavascriptArray *keys = JavascriptOperators::GetOwnEnumerablePropertyNamesSymbols(from, scriptContext);
 
-        if (JavascriptArray::Is(keysResult))
-        {
-            keys = JavascriptArray::FromVar(keysResult);
-        }
-        else
-        {
-            return;
-        }
         //      c. Repeat for each element nextKey of keys in List order,
         //          i. Let desc be from.[[GetOwnProperty]](nextKey).
         //          ii. ReturnIfAbrupt(desc).
@@ -2010,16 +1981,7 @@ namespace Js
         //3.  Let keys be props.[[OwnPropertyKeys]]().
         //4.  ReturnIfAbrupt(keys).
         //5.  Let descriptors be an empty List.
-        JavascriptArray* keys;
-        Var ownKeysResult = JavascriptOperators::GetOwnEnumerablePropertyNamesSymbols(props, scriptContext);
-        if (JavascriptArray::Is(ownKeysResult))
-        {
-            keys = JavascriptArray::FromVar(ownKeysResult);
-        }
-        else
-        {
-            return object;
-        }
+        JavascriptArray* keys = JavascriptOperators::GetOwnEnumerablePropertyNamesSymbols(props, scriptContext);
         uint32 length = keys->GetLength();
 
         ENTER_PINNED_SCOPE(DescriptorMap, descriptors);

--- a/lib/Runtime/Library/JavascriptObject.h
+++ b/lib/Runtime/Library/JavascriptObject.h
@@ -87,11 +87,11 @@ namespace Js
         static Var GetPrototypeOf(RecyclableObject* obj, ScriptContext* scriptContext);
         static BOOL ChangePrototype(RecyclableObject* object, RecyclableObject* newPrototype, bool validate, ScriptContext* scriptContext);
 
-        static Var CreateOwnSymbolPropertiesHelper(RecyclableObject* object, ScriptContext* scriptContext);
-        static Var CreateOwnStringPropertiesHelper(RecyclableObject* object, ScriptContext* scriptContext);
-        static Var CreateOwnStringSymbolPropertiesHelper(RecyclableObject* object, ScriptContext* scriptContext);
-        static Var CreateOwnEnumerableStringPropertiesHelper(RecyclableObject* object, ScriptContext* scriptContext);
-        static Var CreateOwnEnumerableStringSymbolPropertiesHelper(RecyclableObject* object, ScriptContext* scriptContext);
+        static JavascriptArray* CreateOwnSymbolPropertiesHelper(RecyclableObject* object, ScriptContext* scriptContext);
+        static JavascriptArray* CreateOwnStringPropertiesHelper(RecyclableObject* object, ScriptContext* scriptContext);
+        static JavascriptArray* CreateOwnStringSymbolPropertiesHelper(RecyclableObject* object, ScriptContext* scriptContext);
+        static JavascriptArray* CreateOwnEnumerableStringPropertiesHelper(RecyclableObject* object, ScriptContext* scriptContext);
+        static JavascriptArray* CreateOwnEnumerableStringSymbolPropertiesHelper(RecyclableObject* object, ScriptContext* scriptContext);
 
         static Var GetOwnPropertyDescriptorHelper(RecyclableObject* obj, Var propertyKey, ScriptContext* scriptContext);
         static BOOL GetOwnPropertyDescriptorHelper(RecyclableObject* obj, PropertyId propertyId, ScriptContext* scriptContext, PropertyDescriptor& propertyDescriptor);
@@ -113,7 +113,7 @@ namespace Js
     private:
         static void AssignForGenericObjects(RecyclableObject* from, RecyclableObject* to, ScriptContext* scriptContext);
         static void AssignForProxyObjects(RecyclableObject* from, RecyclableObject* to, ScriptContext* scriptContext);
-        static Var CreateKeysHelper(RecyclableObject* object, ScriptContext* scriptContext, BOOL enumNonEnumerable, bool includeSymbolProperties, bool includeStringProperties, bool includeSpecialProperties);
+        static JavascriptArray* CreateKeysHelper(RecyclableObject* object, ScriptContext* scriptContext, BOOL enumNonEnumerable, bool includeSymbolProperties, bool includeStringProperties, bool includeSpecialProperties);
 
         static void ModifyGetterSetterFuncName(const PropertyRecord * propertyRecord, const PropertyDescriptor& descriptor, ScriptContext* scriptContext);
         static char16 * ConstructName(const PropertyRecord * propertyRecord, const char16 * getOrSetStr, ScriptContext* scriptContext);

--- a/lib/Runtime/Library/JavascriptProxy.cpp
+++ b/lib/Runtime/Library/JavascriptProxy.cpp
@@ -1142,8 +1142,7 @@ namespace Js
         //7. Let keys be O.[[OwnPropertyKeys]]().
         //8. ReturnIfAbrupt(keys).
         Assert(JavascriptProxy::Is(obj));
-        Var resultVar = JavascriptOperators::GetOwnPropertyKeys(obj, scriptContext);
-        Assert(JavascriptArray::Is(resultVar));
+        JavascriptArray* resultArray = JavascriptOperators::GetOwnPropertyKeys(obj, scriptContext);
 
         //9. Repeat for each element k of keys,
         //      a. Let currentDesc be O.[[GetOwnProperty]](k).
@@ -1152,7 +1151,6 @@ namespace Js
         //          i. If currentDesc.[[Configurable]] is true, return false.
         //          ii. If level is "frozen" and IsDataDescriptor(currentDesc) is true, then
         //              1. If currentDesc.[[Writable]] is true, return false.
-        JavascriptArray* resultArray = JavascriptArray::FromVar(resultVar);
         Var itemVar;
         bool writable = false;
         bool configurable = false;
@@ -1199,10 +1197,7 @@ namespace Js
 
         //6. Let keys be O.[[OwnPropertyKeys]]().
         //7. ReturnIfAbrupt(keys).
-        Var resultVar = JavascriptOperators::GetOwnPropertyKeys(obj, scriptContext);
-        Assert(JavascriptArray::Is(resultVar));
-
-        JavascriptArray* resultArray = JavascriptArray::FromVar(resultVar);
+        JavascriptArray* resultArray = JavascriptOperators::GetOwnPropertyKeys(obj, scriptContext);
 
         const PropertyRecord* propertyRecord;        
         if (integrityLevel == IntegrityLevel::IntegrityLevel_sealed)
@@ -2061,7 +2056,7 @@ namespace Js
         return trapResult;
     }
 
-    Var JavascriptProxy::PropertyKeysTrap(KeysTrapKind keysTrapKind)
+    JavascriptArray* JavascriptProxy::PropertyKeysTrap(KeysTrapKind keysTrapKind)
     {
         PROBE_STACK(GetScriptContext(), Js::Constants::MinStackDefault);
 
@@ -2094,32 +2089,23 @@ namespace Js
         Assert(!GetScriptContext()->IsHeapEnumInProgress());
 
         JavascriptArray *targetKeys;
-        Var targetResult;
 
         if (nullptr == ownKeysMethod)
         {
             switch (keysTrapKind)
             {
                 case GetOwnPropertyNamesKind:
-                    targetResult = JavascriptOperators::GetOwnPropertyNames(this->target, scriptContext);
+                    targetKeys = JavascriptOperators::GetOwnPropertyNames(this->target, scriptContext);
                     break;
                 case GetOwnPropertySymbolKind:
-                    targetResult = JavascriptOperators::GetOwnPropertySymbols(this->target, scriptContext);
+                    targetKeys = JavascriptOperators::GetOwnPropertySymbols(this->target, scriptContext);
                     break;
                 case KeysKind:
-                    targetResult = JavascriptOperators::GetOwnPropertyKeys(this->target, scriptContext);
+                    targetKeys = JavascriptOperators::GetOwnPropertyKeys(this->target, scriptContext);
                     break;
                 default:
                     AssertMsg(false, "Invalid KeysTrapKind.");
                     return scriptContext->GetLibrary()->CreateArray(0);
-            }
-            if (JavascriptArray::Is(targetResult))
-            {
-                targetKeys = JavascriptArray::FromVar(targetResult);
-            }
-            else
-            {
-                targetKeys = scriptContext->GetLibrary()->CreateArray(0);
             }
             return targetKeys;
         }
@@ -2149,15 +2135,7 @@ namespace Js
 
         BOOL isTargetExtensible = target->IsExtensible();
 
-        targetResult = JavascriptOperators::GetOwnPropertyKeys(this->target, scriptContext);
-        if (JavascriptArray::Is(targetResult))
-        {
-            targetKeys = JavascriptArray::FromVar(targetResult);
-        }
-        else
-        {
-            targetKeys = scriptContext->GetLibrary()->CreateArray(0);
-        }
+        targetKeys = JavascriptOperators::GetOwnPropertyKeys(this->target, scriptContext);
 
         //15. Assert: targetKeys is a List containing only String and Symbol values.
         //16. Let targetConfigurableKeys be an empty List.

--- a/lib/Runtime/Library/JavascriptProxy.h
+++ b/lib/Runtime/Library/JavascriptProxy.h
@@ -155,7 +155,7 @@ namespace Js
 
         void PropertyIdFromInt(uint32 index, PropertyRecord const** propertyRecord);
 
-        Var PropertyKeysTrap(KeysTrapKind keysTrapKind);
+        JavascriptArray* PropertyKeysTrap(KeysTrapKind keysTrapKind);
 
         template <class Fn>
         void GetOwnPropertyKeysHelper(ScriptContext* scriptContext, RecyclableObject* trapResultArray, uint32 len, JavascriptArray* trapResult,


### PR DESCRIPTION
Fixes #1252 

This adds strong return types (specifically, `JavascriptArray*`) to the following functions:

In JavascriptOperators:
1. `JavascriptOperators::GetOwnPropertyNames`
2. `JavascriptOperators::GetOwnPropertySymbols`
3. `JavascriptOperators::GetOwnPropertyKeys`
4. `JavascriptOperators::GetOwnEnumerablePropertyNames`
5. `JavascriptOperators::GetOwnEnumerablePropertyNamesSymbols`

The first 3 were mentioned in #1252, and 4 and 5 had essentially the same structure - all 5 just returned one of either JavascriptProxy::PropertyKeysTrap or one of the \*PropertiesHelper functions on JavascriptObject (listed below), so I went ahead and gave *all* of them a strong return type, as well.

In JavascriptObject (changed because the above all return the result of one of these):

1. `JavascriptObject::CreateOwnSymbolPropertiesHelper`
2. `JavascriptObject::CreateOwnStringPropertiesHelper`
3. `JavascriptObject::CreateOwnStringSymbolPropertiesHelper`
4. `JavascriptObject::CreateOwnEnumerableStringPropertiesHelper`
5. `JavascriptObject::CreateOwnEnumerableStringSymbolPropertiesHelper`
6. `JavascriptObject::CreateKeysHelper`

The first 5 all return the result of 6). 

I had to update the signature of `JavascriptProxy::PropertyKeysTrap` to return `JavascriptArray*`, as well. This seemed correct, because a). most uses of it were followed by an assert that the result was a JavascriptArray, anyway, and b). [MDN says ](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/ownKeys) the result of the ownKeys trap *must* be an array. 

The rest of the changes are removing asserts and simplifying and/or removing any code that checked the type of the result of calls to any of the above functions. 