### PR TITLE
[Updated] #110 Convert rlexe.xml tags to use new build architecture and type terms 

### DIFF
--- a/test/Array/rlexe.xml
+++ b/test/Array/rlexe.xml
@@ -30,7 +30,7 @@
     <default>
       <compile-flags>-args summary -endargs -ForceArrayBTree -recyclerStress</compile-flags>
       <files>SpliceBtreeMemoryCorruption.js</files>
-      <tags>exclude_fre,Slow</tags>
+      <tags>exclude_test,Slow</tags>
     </default>
   </test>
   <test>
@@ -123,7 +123,7 @@
       <compile-flags>-arrayValidate</compile-flags>
       <files>array_ctr.js</files>
       <baseline>array_ctr.baseline</baseline>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -265,7 +265,7 @@
     <default>
       <files>toString.js</files>
       <compile-flags>-ForceES5Array</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
       <baseline>toString.baseline</baseline>
     </default>
   </test>
@@ -279,7 +279,7 @@
     <default>
       <files>toLocaleString.js</files>
       <compile-flags>-ForceES5Array</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
       <baseline>toLocaleString.baseline</baseline>
     </default>
   </test>
@@ -325,7 +325,7 @@
       <files>array_sort3.js</files>
       <baseline>array_sort3.baseline</baseline>
       <compile-flags>-arrayValidate</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -345,7 +345,7 @@
       <compile-flags>-arrayValidate</compile-flags>
       <files>array_splice.js</files>
       <baseline>array_splice.baseline</baseline>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -427,7 +427,7 @@
       <compile-flags>-recyclerStress</compile-flags>
       <files>array_literal.js</files>
       <baseline>array_literal.baseline</baseline>
-      <tags>exclude_fre,Slow</tags>
+      <tags>exclude_test,Slow</tags>
     </default>
   </test>
   <test>

--- a/test/AsmJs/rlexe.xml
+++ b/test/AsmJs/rlexe.xml
@@ -190,7 +190,7 @@
     <default>
       <files>ArrayView.js</files>
       <baseline>ArrayView.baseline</baseline>
-      <tags>exclude_amd64</tags>
+      <tags>exclude_x64</tags>
       <compile-flags>-testtrace:asmjs -simdjs -oopjit- -on:asmjsjittemplate -off:fulljit</compile-flags>
     </default>
   </test>
@@ -198,7 +198,7 @@
     <default>
       <files>BasicBranching.js</files>
       <baseline>BasicBranching.baseline</baseline>
-      <tags>exclude_amd64</tags>
+      <tags>exclude_x64</tags>
       <compile-flags>-testtrace:asmjs -simdjs -oopjit- -on:asmjsjittemplate -off:fulljit</compile-flags>
     </default>
   </test>
@@ -206,7 +206,7 @@
     <default>
       <files>basicComparisonDouble.js</files>
       <baseline>basicComparisonDouble.baseline</baseline>
-      <tags>exclude_amd64</tags>
+      <tags>exclude_x64</tags>
       <compile-flags>-testtrace:asmjs -simdjs -oopjit- -on:asmjsjittemplate -off:fulljit</compile-flags>
     </default>
   </test>
@@ -214,7 +214,7 @@
     <default>
       <files>basicComparisonInt.js</files>
       <baseline>basicComparisonInt.baseline</baseline>
-      <tags>exclude_amd64</tags>
+      <tags>exclude_x64</tags>
       <compile-flags>-testtrace:asmjs -simdjs -oopjit- -on:asmjsjittemplate -off:fulljit</compile-flags>
     </default>
   </test>
@@ -222,7 +222,7 @@
     <default>
       <files>basicComparisonUInt.js</files>
       <baseline>basicComparisonUInt.baseline</baseline>
-      <tags>exclude_amd64</tags>
+      <tags>exclude_x64</tags>
       <compile-flags>-testtrace:asmjs -simdjs -oopjit- -on:asmjsjittemplate -off:fulljit</compile-flags>
     </default>
   </test>
@@ -230,7 +230,7 @@
     <default>
       <files>BasicLooping.js</files>
       <baseline>BasicLooping.baseline</baseline>
-      <tags>exclude_amd64</tags>
+      <tags>exclude_x64</tags>
       <compile-flags>-testtrace:asmjs -simdjs -oopjit- -on:asmjsjittemplate -off:fulljit</compile-flags>
     </default>
   </test>
@@ -238,7 +238,7 @@
     <default>
       <files>basicMath.js</files>
       <baseline>basicMath.baseline</baseline>
-      <tags>exclude_amd64</tags>
+      <tags>exclude_x64</tags>
       <compile-flags>-testtrace:asmjs -simdjs -oopjit- -on:asmjsjittemplate -off:fulljit</compile-flags>
     </default>
   </test>
@@ -246,7 +246,7 @@
     <default>
       <files>basicMathIntSpecific.js</files>
       <baseline>basicMathIntSpecific.baseline</baseline>
-      <tags>exclude_amd64</tags>
+      <tags>exclude_x64</tags>
       <compile-flags>-testtrace:asmjs -simdjs -oopjit- -on:asmjsjittemplate -off:fulljit</compile-flags>
     </default>
   </test>
@@ -254,7 +254,7 @@
     <default>
       <files>basicMathUnary.js</files>
       <baseline>basicMathUnary.baseline</baseline>
-      <tags>exclude_amd64</tags>
+      <tags>exclude_x64</tags>
       <compile-flags>-testtrace:asmjs -simdjs -oopjit- -on:asmjsjittemplate -off:fulljit</compile-flags>
     </default>
   </test>
@@ -262,7 +262,7 @@
     <default>
       <files>BasicSwitch.js</files>
       <baseline>BasicSwitch.baseline</baseline>
-      <tags>exclude_amd64</tags>
+      <tags>exclude_x64</tags>
       <compile-flags>-testtrace:asmjs -simdjs -oopjit- -on:asmjsjittemplate -off:fulljit</compile-flags>
     </default>
   </test>
@@ -270,7 +270,7 @@
     <default>
       <files>CompositionMathUnary.js</files>
       <baseline>CompositionMathUnary.baseline</baseline>
-      <tags>exclude_amd64</tags>
+      <tags>exclude_x64</tags>
       <compile-flags>-testtrace:asmjs -simdjs -oopjit- -on:asmjsjittemplate -off:fulljit</compile-flags>
     </default>
   </test>
@@ -278,7 +278,7 @@
     <default>
       <files>FunctionCalls.js</files>
       <baseline>FunctionCalls.baseline</baseline>
-      <tags>exclude_amd64</tags>
+      <tags>exclude_x64</tags>
       <compile-flags>-testtrace:asmjs -simdjs -oopjit- -on:asmjsjittemplate -off:fulljit</compile-flags>
     </default>
   </test>
@@ -286,7 +286,7 @@
     <default>
       <files>functiontablecalls.js</files>
       <baseline>functiontablecalls.baseline</baseline>
-      <tags>exclude_amd64</tags>
+      <tags>exclude_x64</tags>
       <compile-flags>-testtrace:asmjs -simdjs -oopjit- -on:asmjsjittemplate -off:fulljit</compile-flags>
     </default>
   </test>
@@ -294,7 +294,7 @@
     <default>
       <files>MathBuiltinsCall.js</files>
       <baseline>MathBuiltinsCall.baseline</baseline>
-      <tags>exclude_amd64</tags>
+      <tags>exclude_x64</tags>
       <compile-flags>-testtrace:asmjs -simdjs -oopjit- -on:asmjsjittemplate -off:fulljit</compile-flags>
     </default>
   </test>
@@ -302,7 +302,7 @@
     <default>
       <files>ModuleVarRead.js</files>
       <baseline>ModuleVarRead.baseline</baseline>
-      <tags>exclude_amd64</tags>
+      <tags>exclude_x64</tags>
       <compile-flags>-testtrace:asmjs -simdjs -oopjit- -on:asmjsjittemplate -off:fulljit</compile-flags>
     </default>
   </test>
@@ -310,7 +310,7 @@
     <default>
       <files>ModuleVarWrite.js</files>
       <baseline>ModuleVarWrite.baseline</baseline>
-      <tags>exclude_amd64</tags>
+      <tags>exclude_x64</tags>
       <compile-flags>-testtrace:asmjs -simdjs -oopjit- -on:asmjsjittemplate -off:fulljit</compile-flags>
     </default>
   </test>
@@ -318,7 +318,7 @@
     <default>
       <files>ReadArrayView.js</files>
       <baseline>ReadArrayView.baseline</baseline>
-      <tags>exclude_amd64</tags>
+      <tags>exclude_x64</tags>
       <compile-flags>-testtrace:asmjs -simdjs -oopjit- -on:asmjsjittemplate -off:fulljit</compile-flags>
     </default>
   </test>
@@ -326,7 +326,7 @@
     <default>
       <files>ReadFixOffset.js</files>
       <baseline>ReadFixOffset.baseline</baseline>
-      <tags>exclude_amd64</tags>
+      <tags>exclude_x64</tags>
       <compile-flags>-testtrace:asmjs -simdjs -oopjit- -on:asmjsjittemplate -off:fulljit</compile-flags>
     </default>
   </test>
@@ -334,7 +334,7 @@
     <default>
       <files>WriteArrayView.js</files>
       <baseline>WriteArrayView.baseline</baseline>
-      <tags>exclude_amd64</tags>
+      <tags>exclude_x64</tags>
       <compile-flags>-testtrace:asmjs -simdjs -oopjit- -on:asmjsjittemplate -off:fulljit</compile-flags>
     </default>
   </test>
@@ -342,7 +342,7 @@
     <default>
       <files>WriteFixOffset.js</files>
       <baseline>WriteFixOffset.baseline</baseline>
-      <tags>exclude_amd64</tags>
+      <tags>exclude_x64</tags>
       <compile-flags>-testtrace:asmjs -simdjs -oopjit- -on:asmjsjittemplate -off:fulljit</compile-flags>
     </default>
   </test>
@@ -554,7 +554,7 @@
     <default>
       <files>constTest.js</files>
       <baseline>constTest.baseline</baseline>
-      <tags>exclude_amd64</tags>
+      <tags>exclude_x64</tags>
       <compile-flags>-testtrace:asmjs -simdjs -oopjit- -on:asmjsjittemplate -off:fulljit</compile-flags>
     </default>
   </test>
@@ -695,7 +695,7 @@
     <default>
       <files>unityBug.js</files>
       <baseline>unityBug.baseline</baseline>
-      <tags>exclude_amd64</tags>
+      <tags>exclude_x64</tags>
       <compile-flags>-testtrace:asmjs -simdjs -oopjit- -on:asmjsjittemplate -off:fulljit</compile-flags>
     </default>
   </test>
@@ -732,7 +732,7 @@
     <default>
       <files>clz32.js</files>
       <baseline>clz32.baseline</baseline>
-      <tags>exclude_amd64</tags>
+      <tags>exclude_x64</tags>
       <compile-flags>-testtrace:asmjs -simdjs -oopjit- -on:asmjsjittemplate -off:fulljit</compile-flags>
     </default>
   </test>

--- a/test/Closures/rlexe.xml
+++ b/test/Closures/rlexe.xml
@@ -82,14 +82,14 @@
     <default>
       <files>delaycapture-loopbody.js</files>
       <compile-flags>-lic:1 -off:simplejit -bgjit- -off:stackfunc -InitializeInterpreterSlotsWithInvalidStackVar</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
     <default>
       <files>delaycapture-loopbody2.js</files>
       <compile-flags>-lic:1 -bgjit- -InitializeInterpreterSlotsWithInvalidStackVar</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -97,7 +97,7 @@
       <files>initcachedscope.js</files>
       <compile-flags>-recyclerstress -force:cachedscope</compile-flags>
       <baseline>initcachedscope.baseline</baseline>
-      <tags>exclude_fre,Slow</tags>
+      <tags>exclude_test,Slow</tags>
     </default>
   </test>
   <test>
@@ -126,7 +126,7 @@
       <files>invalcachedscope.js</files>
       <compile-flags>-force:deferparse -Intl-</compile-flags>
       <baseline>invalcachedscope.baseline</baseline>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>

--- a/test/DynamicCode/rlexe.xml
+++ b/test/DynamicCode/rlexe.xml
@@ -2,7 +2,7 @@
 <regress-exe>
   <test>
     <default>
-      <tags>exclude_fre,Slow</tags>
+      <tags>exclude_test,Slow</tags>
       <files>eval-nativecodedata.js</files>
       <compile-flags>-force:fieldhoist</compile-flags>
       <baseline />
@@ -10,14 +10,14 @@
   </test>
   <test>
     <default>
-      <tags>exclude_fre,Slow</tags>
+      <tags>exclude_test,Slow</tags>
       <files>eval-nativenumber.js</files>
       <timeout>300</timeout>
     </default>
   </test>
   <test>
     <default>
-      <tags>exclude_fre,exclude_dynapogo</tags>
+      <tags>exclude_test,exclude_dynapogo</tags>
       <files>eval-nativenumber.js</files>
       <compile-flags>-maxinterpretcount:1 -off:simpleJit</compile-flags>
     </default>

--- a/test/Function/rlexe.xml
+++ b/test/Function/rlexe.xml
@@ -65,7 +65,7 @@
       <files>argumentsLimits.js</files>
       <baseline>argumentsLimits.baseline</baseline>
       <!-- this test takes a long time with dynapogo on chk build -->
-      <tags>exclude_chk</tags>
+      <tags>exclude_debug</tags>
     </default>
   </test>
   <test>
@@ -156,7 +156,7 @@
       <files>deferredParsing.js</files>
       <compile-flags>-force:deferparse</compile-flags>
       <baseline>deferredParsing_3.baseline</baseline>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -164,7 +164,7 @@
       <files>deferredParsing.js</files>
       <compile-flags>-forceUndoDefer</compile-flags>
       <baseline>deferredParsing_3.baseline</baseline>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -172,7 +172,7 @@
       <files>deferredGetterSetter.js</files>
       <compile-flags>-force:deferparse</compile-flags>
       <baseline>deferredGetterSetter.baseline</baseline>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -195,7 +195,7 @@
       <files>deferredWith.js</files>
       <compile-flags>-Force:Deferparse</compile-flags>
       <baseline>deferredWith.v4.baseline</baseline>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -203,7 +203,7 @@
       <files>deferredWith2.js</files>
       <compile-flags>-Force:Deferparse</compile-flags>
       <baseline>deferredWith2.baseline</baseline>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -296,7 +296,7 @@
       <files>FuncBody.bug133933.js</files>
       <baseline>FuncBody.bug133933.baseline</baseline>
       <compile-flags>-trace:FunctionSourceInfoParse -off:deferparse</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo</tags>
+      <tags>exclude_test,exclude_dynapogo</tags>
     </default>
   </test>
   <test>
@@ -325,7 +325,7 @@
       <files>FuncBody.bug231397.js</files>
       <baseline>FuncBody.bug231397.baseline</baseline>
       <compile-flags>-dump:bytecode</compile-flags>
-      <tags>exclude_bytecodelayout,exclude_fre,require_backend</tags>
+      <tags>exclude_bytecodelayout,exclude_test,require_backend</tags>
     </default>
   </test>
   <test>
@@ -381,7 +381,7 @@
     <default>
       <files>StackArgsWithFormals.js</files>
       <compile-flags>-mic:1 -off:simpleJit -trace:stackargformalsopt</compile-flags>
-      <tags>exclude_dynapogo,exclude_ship,exclude_fre,exclude_nonative,require_backend,exclude_forceserialized</tags>
+      <tags>exclude_dynapogo,exclude_ship,exclude_test,exclude_nonative,require_backend,exclude_forceserialized</tags>
       <baseline>StackArgsWithFormals.baseline</baseline>
     </default>
   </test>
@@ -397,7 +397,7 @@
       <files>childCallsEvalJitLoopBody.js</files>
       <baseline />
       <compile-flags>-prejit</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo</tags>
+      <tags>exclude_test,exclude_dynapogo</tags>
     </default>
   </test>
   <test>

--- a/test/GlobalFunctions/rlexe.xml
+++ b/test/GlobalFunctions/rlexe.xml
@@ -76,7 +76,7 @@
       <files>deferunicode.js</files>
       <baseline>deferunicode.baseline</baseline>
       <compile-flags>-force:deferparse</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>

--- a/test/JSON/rlexe.xml
+++ b/test/JSON/rlexe.xml
@@ -19,7 +19,7 @@
       <files>stringify-replacer.js</files>
       <baseline>stringify-replacer.baseline</baseline>
       <compile-flags>-recyclerstress</compile-flags>
-      <tags>exclude_fre,Slow</tags>
+      <tags>exclude_test,Slow</tags>
     </default>
   </test>
   <test>
@@ -27,7 +27,7 @@
       <files>stringify-replacerfunc.js</files>
       <baseline>stringify-replacerfunc.baseline</baseline>
       <compile-flags>-recyclerstress</compile-flags>
-      <tags>exclude_fre,Slow</tags>
+      <tags>exclude_test,Slow</tags>
       <timeout>300</timeout>
     </default>
   </test>
@@ -48,7 +48,7 @@
       <files>simple.withLog.js</files>
       <baseline>simple.withLog.baseline</baseline>
       <compile-flags>-recyclerstress -trace:JSON</compile-flags>
-      <tags>exclude_fre,Slow</tags>
+      <tags>exclude_test,Slow</tags>
     </default>
   </test>
   <test>
@@ -61,7 +61,7 @@
     <default>
       <files>parseWithGc.js</files>
       <compile-flags>-ForceGCAfterJSONParse</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -69,7 +69,7 @@
       <files>jsonCache.js</files>
       <compile-flags>-ForceGCAfterJSONParse</compile-flags>
       <baseline>jsonCache.baseline</baseline>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>

--- a/test/Lib/rlexe.xml
+++ b/test/Lib/rlexe.xml
@@ -68,7 +68,7 @@ Re-enable after 190575 is fixed
    <default>
       <files>profiledataobject.js</files>
       <baseline>profiledataobject.baseline</baseline>
-      <tags>exclude_default,exclude_dynapogo,exclude_amd64,exclude_arm,exclude_ship,require_backend</tags>
+      <tags>exclude_default,exclude_dynapogo,exclude_x64,exclude_arm,exclude_ship,require_backend</tags>
           <compile-flags>-nonative -dynamicprofilecache:profile.dpl.profiledataobject.js</compile-flags>
    </default>
 </test>
@@ -79,7 +79,7 @@ Re-enable after 190575 is fixed
    <default>
       <files>profiledataobject.js</files>
       <baseline>profiledataobject.dynapogo.baseline</baseline>
-      <tags>exclude_default,exclude_interpreted,exclude_amd64,exclude_arm,exclude_ship,require_backend</tags>
+      <tags>exclude_default,exclude_interpreted,exclude_x64,exclude_arm,exclude_ship,require_backend</tags>
           <compile-flags>-nonative -dynamicprofileinput:profile.dpl.profiledataobject.js</compile-flags>
    </default>
 </test>
@@ -112,7 +112,7 @@ Re-enable after 190575 is fixed
    <default>
       <files>profiledataobject.js</files>
       <baseline>profiledataobject.arm.baseline</baseline>
-      <tags>exclude_default,exclude_dynapogo,exclude_x86,exclude_amd64,exclude_ship,require_backend</tags>
+      <tags>exclude_default,exclude_dynapogo,exclude_x86,exclude_x64,exclude_ship,require_backend</tags>
           <compile-flags>-nonative -dynamicprofilecache:profile.dpl.profiledataobject.js</compile-flags>
    </default>
 </test>
@@ -123,7 +123,7 @@ Re-enable after 190575 is fixed
    <default>
       <files>profiledataobject.js</files>
       <baseline>profiledataobject.dynapogo.arm.baseline</baseline>
-      <tags>exclude_default,exclude_interpreted,exclude_x86,exclude_amd64,exclude_ship,require_backend</tags>
+      <tags>exclude_default,exclude_interpreted,exclude_x86,exclude_x64,exclude_ship,require_backend</tags>
           <compile-flags>-nonative -dynamicprofileinput:profile.dpl.profiledataobject.js</compile-flags>
    </default>
 </test>

--- a/test/Miscellaneous/rlexe.xml
+++ b/test/Miscellaneous/rlexe.xml
@@ -10,7 +10,7 @@
     <default>
       <compile-flags>-recyclerVerify</compile-flags>
       <files>longstring.js</files>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>

--- a/test/Object/rlexe.xml
+++ b/test/Object/rlexe.xml
@@ -88,7 +88,7 @@
         <files>toLocaleString.js</files>
         <baseline>toLocaleString.arm.baseline</baseline>
         <compile-flags>-Intl</compile-flags>
-        <tags>exclude_x86,exclude_amd64</tags>
+        <tags>exclude_x86,exclude_x64</tags>
     </default>
 </test>
 <test>
@@ -172,7 +172,7 @@
   <test>
     <default>
       <files>Slow.js</files>
-      <tags>exclude_chk</tags>
+      <tags>exclude_debug</tags>
     </default>
   </test>
   <test>

--- a/test/Optimizer/rlexe.xml
+++ b/test/Optimizer/rlexe.xml
@@ -992,7 +992,7 @@
     <default>
       <files>test141.js</files>
       <compile-flags>-bgJit- -off:simpleJit -fullJitAfter:2 -on:simulatePolyCacheWithOneTypeForFunction:1 -simulatePolyCacheWithOneTypeForInlineCacheIndex:3</compile-flags>
-      <tags>exclude_dynapogo,exclude_fre,exclude_ship</tags>
+      <tags>exclude_dynapogo,exclude_test,exclude_ship</tags>
     </default>
   </test>
   <test>
@@ -1290,7 +1290,7 @@
     <default>
       <files>bailonnoprofile_objtypespecstore.js</files>
       <compile-flags>-recyclerverify:run -off:simplejit -maxinterpretcount:2</compile-flags>
-      <tags>exclude_ship,exclude_fre,exclude_dynapogo</tags>
+      <tags>exclude_ship,exclude_test,exclude_dynapogo</tags>
       <baseline />
     </default>
   </test>

--- a/test/Regex/rlexe.xml
+++ b/test/Regex/rlexe.xml
@@ -153,7 +153,7 @@
       <files>BoiHardFail.js</files>
       <baseline>BoiHardFail.baseline</baseline>
       <compile-flags>-regexDebug</compile-flags>
-      <tags>exclude_fre,exclude_apollo,exclude_serialized</tags>
+      <tags>exclude_test,exclude_apollo,exclude_serialized</tags>
     </default>
   </test>
   <test>

--- a/test/TaggedIntegers/rlexe.xml
+++ b/test/TaggedIntegers/rlexe.xml
@@ -142,7 +142,7 @@
     <default>
       <files>comparison.js</files>
       <baseline>comparison.baseline</baseline>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
       <compile-flags>-off:constprop -off:copyprop -off:constfold -off:typespec</compile-flags>
     </default>
   </test>
@@ -150,7 +150,7 @@
     <default>
       <files>addition.js</files>
       <baseline>addition.baseline</baseline>
-      <tags>exclude_fre,Slow</tags>
+      <tags>exclude_test,Slow</tags>
       <compile-flags>-off:constprop -off:copyprop -off:constfold -off:typespec</compile-flags>
     </default>
   </test>
@@ -158,7 +158,7 @@
     <default>
       <files>subtraction.js</files>
       <baseline>subtraction.baseline</baseline>
-      <tags>exclude_fre,Slow</tags>
+      <tags>exclude_test,Slow</tags>
       <compile-flags>-off:constprop -off:copyprop -off:constfold -off:typespec</compile-flags>
     </default>
   </test>
@@ -166,7 +166,7 @@
     <default>
       <files>multiplication.js</files>
       <baseline>multiplication.baseline</baseline>
-      <tags>exclude_fre,Slow</tags>
+      <tags>exclude_test,Slow</tags>
       <compile-flags>-off:constprop -off:copyprop -off:constfold -off:typespec</compile-flags>
     </default>
   </test>
@@ -174,7 +174,7 @@
     <default>
       <files>divide.js</files>
       <baseline>divide.baseline</baseline>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
       <compile-flags>-off:constprop -off:copyprop -off:constfold -off:typespec</compile-flags>
     </default>
   </test>
@@ -182,7 +182,7 @@
     <default>
       <files>and.js</files>
       <baseline>and.baseline</baseline>
-      <tags>exclude_fre,Slow</tags>
+      <tags>exclude_test,Slow</tags>
       <compile-flags>-off:constprop -off:copyprop -off:constfold -off:typespec</compile-flags>
     </default>
   </test>
@@ -190,7 +190,7 @@
     <default>
       <files>or.js</files>
       <baseline>or.baseline</baseline>
-      <tags>exclude_fre,Slow</tags>
+      <tags>exclude_test,Slow</tags>
       <compile-flags>-off:constprop -off:copyprop -off:constfold -off:typespec</compile-flags>
     </default>
   </test>
@@ -198,7 +198,7 @@
     <default>
       <files>xor.js</files>
       <baseline>xor.baseline</baseline>
-      <tags>exclude_fre,Slow</tags>
+      <tags>exclude_test,Slow</tags>
       <compile-flags>-off:constprop -off:copyprop -off:constfold -off:typespec</compile-flags>
     </default>
   </test>
@@ -206,7 +206,7 @@
     <default>
       <files>not.js</files>
       <baseline>not.baseline</baseline>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
       <compile-flags>-off:constprop -off:copyprop -off:constfold -off:typespec</compile-flags>
     </default>
   </test>
@@ -214,7 +214,7 @@
     <default>
       <files>negate.js</files>
       <baseline>negate.baseline</baseline>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
       <compile-flags>-off:constprop -off:copyprop -off:constfold -off:typespec</compile-flags>
     </default>
   </test>
@@ -222,7 +222,7 @@
     <default>
       <files>signedshiftleft.js</files>
       <baseline>signedshiftleft.baseline</baseline>
-      <tags>exclude_fre,Slow</tags>
+      <tags>exclude_test,Slow</tags>
       <compile-flags>-off:constprop -off:copyprop -off:constfold -off:typespec</compile-flags>
     </default>
   </test>
@@ -230,7 +230,7 @@
     <default>
       <files>signedshiftright.js</files>
       <baseline>signedshiftright.baseline</baseline>
-      <tags>exclude_fre,Slow</tags>
+      <tags>exclude_test,Slow</tags>
       <compile-flags>-off:constprop -off:copyprop -off:constfold -off:typespec</compile-flags>
     </default>
   </test>
@@ -238,7 +238,7 @@
     <default>
       <files>unsignedshiftright.js</files>
       <baseline>unsignedshiftright.baseline</baseline>
-      <tags>exclude_fre,Slow</tags>
+      <tags>exclude_test,Slow</tags>
       <compile-flags>-off:constprop -off:copyprop -off:constfold -off:typespec</compile-flags>
     </default>
   </test>
@@ -246,7 +246,7 @@
     <default>
       <files>modulus.js</files>
       <baseline>modulus.baseline</baseline>
-      <tags>exclude_fre,Slow</tags>
+      <tags>exclude_test,Slow</tags>
       <compile-flags>-off:constprop -off:copyprop -off:constfold -off:typespec</compile-flags>
     </default>
   </test>
@@ -254,7 +254,7 @@
     <default>
       <files>loopbounds.js</files>
       <baseline>loopbounds.baseline</baseline>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
       <compile-flags>-off:constprop -off:copyprop -off:constfold -off:typespec</compile-flags>
     </default>
   </test>
@@ -278,7 +278,7 @@
     <default>
       <files>not_1.js</files>
       <baseline>not_1.baseline</baseline>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
       <compile-flags>-off:constprop -off:copyprop -off:constfold -off:typespec</compile-flags>
     </default>
   </test>
@@ -286,7 +286,7 @@
     <default>
       <files>shift_constants.js</files>
       <baseline>shift_constants.baseline</baseline>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
       <compile-flags>-off:constprop -off:copyprop -off:constfold -off:typespec</compile-flags>
     </default>
   </test>
@@ -294,7 +294,7 @@
     <default>
       <files>loops.js</files>
       <baseline>loops.baseline</baseline>
-      <tags>exclude_fre,Slow</tags>
+      <tags>exclude_test,Slow</tags>
       <compile-flags>-off:constprop -off:copyprop -off:constfold -off:typespec</compile-flags>
     </default>
   </test>
@@ -302,7 +302,7 @@
     <default>
       <files>predecrement.js</files>
       <baseline>predecrement.baseline</baseline>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
       <compile-flags>-off:constprop -off:copyprop -off:constfold -off:typespec</compile-flags>
     </default>
   </test>
@@ -310,7 +310,7 @@
     <default>
       <files>preincrement.js</files>
       <baseline>preincrement.baseline</baseline>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
       <compile-flags>-off:constprop -off:copyprop -off:constfold -off:typespec</compile-flags>
     </default>
   </test>

--- a/test/UnifiedRegex/rlexe.xml
+++ b/test/UnifiedRegex/rlexe.xml
@@ -129,7 +129,7 @@
     <default>
       <files>WOOB1138949.js</files>
       <baseline>WOOB1138949.baseline</baseline>
-      <tags>exclude_chk,Slow</tags>
+      <tags>exclude_debug,Slow</tags>
     </default>
   </test>
   <test>

--- a/test/bailout/rlexe.xml
+++ b/test/bailout/rlexe.xml
@@ -10,7 +10,7 @@
     <default>
       <files>bailout.js</files>
       <compile-flags>-dynamicprofilecache:profile.dpl.bailout.js</compile-flags>
-      <tags>exclude_dynapogo,exclude_fre</tags>
+      <tags>exclude_dynapogo,exclude_test</tags>
       <baseline>bailout.baseline</baseline>
     </default>
   </test>
@@ -18,7 +18,7 @@
     <default>
       <files>bailout.js</files>
       <compile-flags>-off:typespec -bailout:5 -dynamicprofileinput:profile.dpl.bailout.js</compile-flags>
-      <tags>exclude_interpreted,exclude_fre</tags>
+      <tags>exclude_interpreted,exclude_test</tags>
       <baseline>bailout.baseline</baseline>
     </default>
   </test>
@@ -26,7 +26,7 @@
     <default>
       <files>bailout.js</files>
       <compile-flags>-bailout:10 -dynamicprofileinput:profile.dpl.bailout.js</compile-flags>
-      <tags>exclude_interpreted,exclude_fre</tags>
+      <tags>exclude_interpreted,exclude_test</tags>
       <baseline>bailout.baseline</baseline>
     </default>
   </test>
@@ -34,7 +34,7 @@
     <default>
       <files>bailout2.js</files>
       <compile-flags>-bailout:7</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
       <baseline>bailout2.baseline</baseline>
     </default>
   </test>
@@ -42,7 +42,7 @@
     <default>
       <files>bailout3.js</files>
       <compile-flags>-bailout:6 -off:typespec</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
       <baseline>bailout3.baseline</baseline>
     </default>
   </test>
@@ -50,7 +50,7 @@
     <default>
       <files>bailout4.js</files>
       <compile-flags>-bailout:6 -off:typespec</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
       <baseline>bailout4.baseline</baseline>
     </default>
   </test>
@@ -58,7 +58,7 @@
     <default>
       <files>bailout5.js</files>
       <compile-flags>-bailout:9 -off:typespec</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
       <baseline>bailout5.baseline</baseline>
     </default>
   </test>
@@ -66,14 +66,14 @@
     <default>
       <files>bailout6.js</files>
       <compile-flags>-bailoutateverybytecode</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
     <default>
       <files>bailout7.js</files>
       <compile-flags>-bailoutbytecode:742 -off:deferparse</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
       <baseline>bailout7.baseline</baseline>
     </default>
   </test>
@@ -81,28 +81,28 @@
     <default>
       <files>bailout_loopbodystart.js</files>
       <compile-flags>-dynamicprofilecache:profile.dpl.bailout_loopbodystart.js</compile-flags>
-      <tags>exclude_dynapogo,exclude_fre</tags>
+      <tags>exclude_dynapogo,exclude_test</tags>
     </default>
   </test>
   <test>
     <default>
       <files>bailout_loopbodystart.js</files>
       <compile-flags>-bailoutbytecode:17 -dynamicprofileinput:profile.dpl.bailout_loopbodystart.js</compile-flags>
-      <tags>exclude_interpreted,exclude_fre</tags>
+      <tags>exclude_interpreted,exclude_test</tags>
     </default>
   </test>
   <test>
     <default>
       <files>bailout_loopbodystart.js</files>
       <compile-flags>-bailoutbytecode:18 -dynamicprofileinput:profile.dpl.bailout_loopbodystart.js</compile-flags>
-      <tags>exclude_interpreted,exclude_fre</tags>
+      <tags>exclude_interpreted,exclude_test</tags>
     </default>
   </test>
   <test>
     <default>
       <files>bailout-eh.js</files>
       <compile-flags>-bailout:6</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
       <baseline>bailout-eh.baseline</baseline>
     </default>
   </test>
@@ -110,7 +110,7 @@
     <default>
       <files>bailout-args.js</files>
       <compile-flags>-bailoutbytecode:1</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
       <baseline>bailout-args.baseline</baseline>
     </default>
   </test>
@@ -126,7 +126,7 @@
     <default>
       <files>bailout-throw.js</files>
       <compile-flags>-bailout:5</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
       <baseline>bailout-throw.baseline</baseline>
     </default>
   </test>
@@ -134,7 +134,7 @@
     <default>
       <files>bailout-floatpref.js</files>
       <compile-flags>-dynamicprofilecache:profile.dpl.bailout-floatpref.js</compile-flags>
-      <tags>exclude_dynapogo,exclude_fre</tags>
+      <tags>exclude_dynapogo,exclude_test</tags>
       <baseline>bailout-floatpref.baseline</baseline>
     </default>
   </test>
@@ -142,7 +142,7 @@
     <default>
       <files>bailout-floatpref.js</files>
       <compile-flags>-bailout:3 -dynamicprofileinput:profile.dpl.bailout-floatpref.js</compile-flags>
-      <tags>exclude_interpreted,exclude_fre</tags>
+      <tags>exclude_interpreted,exclude_test</tags>
       <baseline>bailout-floatpref.baseline</baseline>
     </default>
   </test>
@@ -150,7 +150,7 @@
     <default>
       <files>bailout-floatpref.js</files>
       <compile-flags>-bailoutateverybytecode -dynamicprofileinput:profile.dpl.bailout-floatpref.js</compile-flags>
-      <tags>exclude_interpreted,exclude_fre</tags>
+      <tags>exclude_interpreted,exclude_test</tags>
       <baseline>bailout-floatpref.baseline</baseline>
     </default>
   </test>
@@ -158,7 +158,7 @@
     <default>
       <files>bailout-copyProp1.js</files>
       <compile-flags>-bailout:6</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
       <baseline>bailout-copyProp1.baseline</baseline>
     </default>
   </test>
@@ -180,7 +180,7 @@
     <default>
       <files>bailout-inlined.js</files>
       <compile-flags>-force:inline</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
       <baseline />
     </default>
   </test>

--- a/test/es5/rlexe.xml
+++ b/test/es5/rlexe.xml
@@ -94,7 +94,7 @@
       <compile-flags>-Force:Deferparse</compile-flags>
       <files>ObjLitGetSetParseOnly.js</files>
       <baseline>ObjLitGetSetParseOnlyFdp.baseline</baseline>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -130,7 +130,7 @@
   <test>
     <default>
       <compile-flags>-ForceES5Array</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
       <files>array_length.js</files>
       <baseline>array_length.baseline</baseline>
     </default>
@@ -138,7 +138,7 @@
   <test>
     <default>
       <files>ES5ArrayIndexList.js</files>
-      <tags>exclude_chk,Slow</tags>
+      <tags>exclude_debug,Slow</tags>
       <timeout>900</timeout>
     </default>
   </test>
@@ -263,7 +263,7 @@
       <compile-flags>-Force:Deferparse</compile-flags>
       <files>settersArguments.js</files>
       <baseline>settersArguments.baseline</baseline>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -242,7 +242,7 @@
       <files>blockscope-functionbinding.js</files>
       <compile-flags>-lic:1 -InitializeInterpreterSlotsWithInvalidStackVar</compile-flags>
       <baseline>blockscope-functionbinding.baseline</baseline>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -480,7 +480,7 @@
     <default>
       <files>ES6Symbol_540238.js</files>
       <compile-flags>-RecyclerStress</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -612,7 +612,7 @@
     <default>
       <files>bug620694.js</files>
       <compile-flags>-es6all -recyclerstress</compile-flags>
-      <tags>exclude_fre,Slow</tags>
+      <tags>exclude_test,Slow</tags>
     </default>
   </test>
   <test>
@@ -938,7 +938,7 @@
       <files>blue_641922.js</files>
       <baseline>blue_641922.baseline</baseline>
       <compile-flags> -ES6Rest -RecyclerNoPageReuse -PageHeap:2</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -976,7 +976,7 @@
     <default>
       <files>regex-octoquad.js</files>
       <compile-flags>-RegexOptimize -args summary -endargs</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -1064,7 +1064,7 @@
       <files>ProxyInProxy.js</files>
       <baseline>ProxyInProxy.baseline</baseline>
       <compile-flags> -mic:1 -off:simpleJIT </compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>

--- a/test/runtests.cmd
+++ b/test/runtests.cmd
@@ -334,13 +334,21 @@ goto :main
 
   set _BuildArchMapped=%_BuildArch%
   set _BuildTypeMapped=%_BuildType%
+  :: _NewBuildArchMapped and _NewBuildTypeMapped store new terms of the build and architecture
+  :: _NewBuildArchMapped: x86/x64 _BuildArchMapped:x86/amd64
+  :: _NewBuildTypeMapped: debug/test _BuildTypeMapped:chk/fre
+  set _NewBuildArchMapped=%_BuildArch%
+  set _NewBuildTypeMapped=%_BuildType%
 
   :: Map new build arch and type names to old names until rl test tags are
   :: updated to the new names
   if "%_BuildArchMapped%" == "x64" set _BuildArchMapped=amd64
   if "%_BuildTypeMapped%" == "debug" set _BuildTypeMapped=chk
   if "%_BuildTypeMapped%" == "test" set _BuildTypeMapped=fre
-  if "%_BuildTypeMapped%" == "codecoverage" set _BuildTypeMapped=fre
+  if "%_BuildTypeMapped%" == "codecoverage" (
+    set _BuildTypeMapped=fre
+    set _NewBuildTypeMapped=test
+  )
 
   if "%Disable_JIT%" == "1" (
       set _dynamicprofilecache=
@@ -465,7 +473,9 @@ goto :main
   set _rlArgs=%_rlArgs% -nottags:exclude_%_TESTCONFIG%
   set _rlArgs=%_rlArgs% -nottags:exclude_%TARGET_OS%
   set _rlArgs=%_rlArgs% -nottags:exclude_%_BuildArchMapped%
+  set _rlArgs=%_rlArgs% -nottags:exclude_%_NewBuildArchMapped%
   set _rlArgs=%_rlArgs% -nottags:exclude_%_BuildTypeMapped%
+  set _rlArgs=%_rlArgs% -nottags:exclude_%_NewBuildTypeMapped%
   set _rlArgs=%_rlArgs% %_exclude_serialized%
   set _rlArgs=%_rlArgs% %_exclude_forcedeferparse%
   set _rlArgs=%_rlArgs% %_exclude_nodeferparse%

--- a/test/runtests.py
+++ b/test/runtests.py
@@ -102,7 +102,7 @@ if not os.path.isfile(binary):
 
 # global tags/not_tags
 tags = set(args.tag or [])
-not_tags = set(args.not_tag or []).union(['fail', 'exclude_' + arch])
+not_tags = set(args.not_tag or []).union(['fail', 'exclude_' + arch, 'exclude_' + flavor])
 
 if arch_alias:
     not_tags.add('exclude_' + arch_alias)

--- a/test/stackfunc/rlexe.xml
+++ b/test/stackfunc/rlexe.xml
@@ -5,7 +5,7 @@
       <files>simple_escape.js</files>
       <baseline>simple_escape.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -13,7 +13,7 @@
       <files>simple_stackfunc.js</files>
       <baseline>simple_stackfunc.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simplejit -Off:Deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -21,7 +21,7 @@
       <files>simple_stackfunc.js</files>
       <baseline>simple_stackfunc.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -Off:Deferparse -on:stackfunc -nonative</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo</tags>
+      <tags>exclude_test,exclude_dynapogo</tags>
     </default>
   </test>
   <test>
@@ -29,7 +29,7 @@
       <files>trycatch_stackfunc.js</files>
       <baseline>trycatch_stackfunc.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc -nonative</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo</tags>
+      <tags>exclude_test,exclude_dynapogo</tags>
     </default>
   </test>
   <test>
@@ -37,7 +37,7 @@
       <files>simple_namedstackfunc.js</files>
       <baseline>simple_namedstackfunc.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -45,7 +45,7 @@
       <files>toString_escape.js</files>
       <baseline>toString_escape.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -53,7 +53,7 @@
       <files>chain_assign.js</files>
       <baseline>chain_assign.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -61,7 +61,7 @@
       <files>nested_escape.js</files>
       <baseline>nested_escape.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -69,7 +69,7 @@
       <files>funcname_escape.js</files>
       <baseline>funcname_escape.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -77,7 +77,7 @@
       <files>call_escape.js</files>
       <baseline>call_escape.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -85,7 +85,7 @@
       <files>argout_escape.js</files>
       <baseline>argout_escape.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc -off:disablestackfuncondeferredescape</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -93,7 +93,7 @@
       <files>throw_escape.js</files>
       <baseline>throw_escape.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -101,7 +101,7 @@
       <files>funcname_asg.js</files>
       <baseline>funcname_asg.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -109,7 +109,7 @@
       <files>arrlit_escape.js</files>
       <baseline>arrlit_escape.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -117,7 +117,7 @@
       <files>arrlit_asg_escape.js</files>
       <baseline>arrlit_asg_escape.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -125,7 +125,7 @@
       <files>objlit_escape.js</files>
       <baseline>objlit_escape.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -133,7 +133,7 @@
       <files>formal_asg.js</files>
       <baseline>formal_asg.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -141,7 +141,7 @@
       <files>argument_escape.js</files>
       <baseline>argument_escape.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -149,7 +149,7 @@
       <files>arguments_assignment.js</files>
       <baseline>arguments_assignment.baseline</baseline>
       <compile-flags>-mic:1 -off:simplejit</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -157,7 +157,7 @@
       <files>cross_scope.js</files>
       <baseline>cross_scope.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -165,7 +165,7 @@
       <files>eval_escape.js</files>
       <baseline>eval_escape.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -173,7 +173,7 @@
       <files>child_eval_escape.js</files>
       <baseline>child_eval_escape.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -181,7 +181,7 @@
       <files>with_namedfunc.js</files>
       <baseline>with_namedfunc.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -189,7 +189,7 @@
       <files>formal_namedfunc.js</files>
       <baseline>formal_namedfunc.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -197,7 +197,7 @@
       <files>throw_func.js</files>
       <baseline>throw_func.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -205,7 +205,7 @@
       <files>glo_asg.js</files>
       <baseline>glo_asg.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -213,7 +213,7 @@
       <files>multinested_escape.js</files>
       <baseline>multinested_escape.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -221,7 +221,7 @@
       <files>let_stackfunc.js</files>
       <baseline>let_stackfunc.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -off:deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -229,7 +229,7 @@
       <files>let_blockescape.js</files>
       <baseline>let_blockescape.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -off:deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -237,7 +237,7 @@
       <files>simple_escape.js</files>
       <baseline>simple_escape.deferparse.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo</tags>
+      <tags>exclude_test,exclude_dynapogo</tags>
     </default>
   </test>
   <test>
@@ -245,7 +245,7 @@
       <files>simple_stackfunc.js</files>
       <baseline>simple_stackfunc.deferparse.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo</tags>
+      <tags>exclude_test,exclude_dynapogo</tags>
     </default>
   </test>
   <test>
@@ -253,7 +253,7 @@
       <files>simple_namedstackfunc.js</files>
       <baseline>simple_namedstackfunc.deferparse.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo</tags>
+      <tags>exclude_test,exclude_dynapogo</tags>
     </default>
   </test>
   <test>
@@ -261,7 +261,7 @@
       <files>toString_escape.js</files>
       <baseline>toString_escape.deferparse.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo</tags>
+      <tags>exclude_test,exclude_dynapogo</tags>
     </default>
   </test>
   <test>
@@ -269,7 +269,7 @@
       <files>chain_assign.js</files>
       <baseline>chain_assign.deferparse.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo</tags>
+      <tags>exclude_test,exclude_dynapogo</tags>
     </default>
   </test>
   <test>
@@ -277,7 +277,7 @@
       <files>nested_escape.js</files>
       <baseline>nested_escape.deferparse.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo</tags>
+      <tags>exclude_test,exclude_dynapogo</tags>
     </default>
   </test>
   <test>
@@ -285,7 +285,7 @@
       <files>funcname_escape.js</files>
       <baseline>funcname_escape.deferparse.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc -off:disablestackfuncondeferredescape</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo</tags>
+      <tags>exclude_test,exclude_dynapogo</tags>
     </default>
   </test>
   <test>
@@ -294,7 +294,7 @@
       <baseline>call_escape.deferparse.baseline</baseline>
       <!--Top Level function parsing on first call to script is turned off here, as this tests order of functions executed-->
       <compile-flags>-DeferTopLevelTillFirstCall- -testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo</tags>
+      <tags>exclude_test,exclude_dynapogo</tags>
     </default>
   </test>
   <test>
@@ -303,7 +303,7 @@
       <baseline>throw_escape.deferparse.baseline</baseline>
       <!--Top Level function parsing on first call to script is turned off here, as this tests order of functions executed-->
       <compile-flags>-DeferTopLevelTillFirstCall- -testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo</tags>
+      <tags>exclude_test,exclude_dynapogo</tags>
     </default>
   </test>
   <test>
@@ -311,7 +311,7 @@
       <files>funcname_asg.js</files>
       <baseline>funcname_asg.deferparse.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo</tags>
+      <tags>exclude_test,exclude_dynapogo</tags>
     </default>
   </test>
   <test>
@@ -319,7 +319,7 @@
       <files>arrlit_escape.js</files>
       <baseline>arrlit_escape.deferparse.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo</tags>
+      <tags>exclude_test,exclude_dynapogo</tags>
     </default>
   </test>
   <test>
@@ -327,7 +327,7 @@
       <files>arrlit_asg_escape.js</files>
       <baseline>arrlit_asg_escape.deferparse.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo</tags>
+      <tags>exclude_test,exclude_dynapogo</tags>
     </default>
   </test>
   <test>
@@ -335,7 +335,7 @@
       <files>objlit_escape.js</files>
       <baseline>objlit_escape.deferparse.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo</tags>
+      <tags>exclude_test,exclude_dynapogo</tags>
     </default>
   </test>
   <test>
@@ -343,7 +343,7 @@
       <files>formal_asg.js</files>
       <baseline>formal_asg.deferparse.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo</tags>
+      <tags>exclude_test,exclude_dynapogo</tags>
     </default>
   </test>
   <test>
@@ -351,7 +351,7 @@
       <files>argument_escape.js</files>
       <baseline>argument_escape.deferparse.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo</tags>
+      <tags>exclude_test,exclude_dynapogo</tags>
     </default>
   </test>
   <test>
@@ -359,7 +359,7 @@
       <files>cross_scope.js</files>
       <baseline>cross_scope.deferparse.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -off:cachescopeinfonames -on:stackfunc</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo</tags>
+      <tags>exclude_test,exclude_dynapogo</tags>
     </default>
   </test>
   <test>
@@ -367,7 +367,7 @@
       <files>eval_escape.js</files>
       <baseline>eval_escape.deferparse.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo</tags>
+      <tags>exclude_test,exclude_dynapogo</tags>
     </default>
   </test>
   <test>
@@ -375,7 +375,7 @@
       <files>child_eval_escape.js</files>
       <baseline>child_eval_escape.deferparse.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo</tags>
+      <tags>exclude_test,exclude_dynapogo</tags>
     </default>
   </test>
   <test>
@@ -383,7 +383,7 @@
       <files>with_namedfunc.js</files>
       <baseline>with_namedfunc.deferparse.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo</tags>
+      <tags>exclude_test,exclude_dynapogo</tags>
     </default>
   </test>
   <test>
@@ -391,7 +391,7 @@
       <files>formal_namedfunc.js</files>
       <baseline>formal_namedfunc.deferparse.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo</tags>
+      <tags>exclude_test,exclude_dynapogo</tags>
     </default>
   </test>
   <test>
@@ -400,7 +400,7 @@
       <baseline>throw_func.deferparse.baseline</baseline>
       <!--Top Level function parsing on first call to script is turned off here, as this tests order of functions executed-->
       <compile-flags>-DeferTopLevelTillFirstCall- -testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo</tags>
+      <tags>exclude_test,exclude_dynapogo</tags>
     </default>
   </test>
   <test>
@@ -408,7 +408,7 @@
       <files>glo_asg.js</files>
       <baseline>glo_asg.deferparse.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo</tags>
+      <tags>exclude_test,exclude_dynapogo</tags>
     </default>
   </test>
   <test>
@@ -416,7 +416,7 @@
       <files>multinested_escape.js</files>
       <baseline>multinested_escape.deferparse.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -off:cachescopeinfonames -on:stackfunc</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo,exclude_arm</tags>
+      <tags>exclude_test,exclude_dynapogo,exclude_arm</tags>
     </default>
   </test>
   <test>
@@ -424,7 +424,7 @@
       <files>let_stackfunc.js</files>
       <baseline>let_stackfunc.deferparse.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo</tags>
+      <tags>exclude_test,exclude_dynapogo</tags>
     </default>
   </test>
   <test>
@@ -432,7 +432,7 @@
       <files>let_blockescape.js</files>
       <baseline>let_blockescape.deferparse.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo</tags>
+      <tags>exclude_test,exclude_dynapogo</tags>
     </default>
   </test>
   <test>
@@ -440,7 +440,7 @@
       <files>box.js</files>
       <baseline>box.deferparse.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -off:cachescopeinfonames -on:stackfunc</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo,exclude_nonative,exclude_arm</tags>
+      <tags>exclude_test,exclude_dynapogo,exclude_nonative,exclude_arm</tags>
     </default>
   </test>
   <test>
@@ -448,7 +448,7 @@
       <files>box.js</files>
       <baseline>box.deferparse.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -off:cachescopeinfonames -force:inline -on:stackfunc</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo,exclude_nonative,exclude_arm</tags>
+      <tags>exclude_test,exclude_dynapogo,exclude_nonative,exclude_arm</tags>
     </default>
   </test>
   <test>
@@ -456,7 +456,7 @@
       <files>callee_escape.js</files>
       <baseline>callee_escape.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -force:inline -on:stackfunc</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo,exclude_arm</tags>
+      <tags>exclude_test,exclude_dynapogo,exclude_arm</tags>
     </default>
   </test>
   <test>
@@ -464,7 +464,7 @@
       <files>callee_escape2.js</files>
       <baseline>callee_escape2.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -force:inline -on:stackfunc</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo,exclude_arm</tags>
+      <tags>exclude_test,exclude_dynapogo,exclude_arm</tags>
     </default>
   </test>
   <test>
@@ -472,7 +472,7 @@
       <files>callee_escape2.js</files>
       <baseline>callee_escape2.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -force:inline -on:stackfunc</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo,exclude_arm</tags>
+      <tags>exclude_test,exclude_dynapogo,exclude_arm</tags>
     </default>
   </test>
   <test>
@@ -480,7 +480,7 @@
       <files>caller_escape.js</files>
       <baseline>caller_escape.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo,exclude_nonative,exclude_arm</tags>
+      <tags>exclude_test,exclude_dynapogo,exclude_nonative,exclude_arm</tags>
     </default>
   </test>
   <test>
@@ -488,7 +488,7 @@
       <files>singleuse.js</files>
       <baseline>singleuse.deferparse.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo</tags>
+      <tags>exclude_test,exclude_dynapogo</tags>
     </default>
   </test>
   <test>
@@ -496,7 +496,7 @@
       <files>iffuncdecl.js</files>
       <baseline>iffuncdecl.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -on:stackfunc</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo</tags>
+      <tags>exclude_test,exclude_dynapogo</tags>
     </default>
   </test>
   <test>
@@ -504,7 +504,7 @@
       <files>cachescope.js</files>
       <baseline>cachescope.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -on:stackfunc</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo</tags>
+      <tags>exclude_test,exclude_dynapogo</tags>
     </default>
   </test>
   <test>
@@ -512,7 +512,7 @@
       <files>box_callparam.js</files>
       <baseline>box_callparam.deferparse.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -on:stackfunc -force:deferparse -off:cachescopeinfonames -off:disablestackfuncondeferredescape </compile-flags>
-      <tags>exclude_fre,exclude_dynapogo</tags>
+      <tags>exclude_test,exclude_dynapogo</tags>
     </default>
   </test>
   <test>
@@ -520,7 +520,7 @@
       <files>inlinee_box.js</files>
       <baseline>inlinee_box.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -on:stackfunc -force:inline</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo,exclude_nonative,exclude_arm</tags>
+      <tags>exclude_test,exclude_dynapogo,exclude_nonative,exclude_arm</tags>
     </default>
   </test>
   <test>
@@ -528,7 +528,7 @@
       <files>blockscope_funcdecl.js</files>
       <baseline>blockscope_funcdecl.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -on:stackfunc</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo</tags>
+      <tags>exclude_test,exclude_dynapogo</tags>
     </default>
   </test>
   <test>
@@ -536,7 +536,7 @@
       <files>recurse.js</files>
       <baseline>recurse.deferparse.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -on:stackfunc -force:deferparse -off:disablestackfuncondeferredescape</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo</tags>
+      <tags>exclude_test,exclude_dynapogo</tags>
     </default>
   </test>
   <test>
@@ -544,7 +544,7 @@
       <files>jitdefer.js</files>
       <baseline>jitdefer.deferparse.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -on:stackfunc -force:deferparse -off:cachescopeinfonames</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo,exclude_arm,exclude_nonative</tags>
+      <tags>exclude_test,exclude_dynapogo,exclude_arm,exclude_nonative</tags>
     </default>
   </test>
   <test>
@@ -553,7 +553,7 @@
       <baseline>box_bailout.deferparse.baseline</baseline>
       <!--Top Level function parsing on first call to script is turned off here, as this tests order of functions executed-->
       <compile-flags>-DeferTopLevelTillFirstCall- -testtrace:stackfunc -off:simpleJit -on:stackfunc -force:deferparse -off:disablestackfuncondeferredescape</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo,exclude_arm,exclude_nonative</tags>
+      <tags>exclude_test,exclude_dynapogo,exclude_arm,exclude_nonative</tags>
     </default>
   </test>
   <test>
@@ -562,7 +562,7 @@
       <baseline>box_inline_bailout.deferparse.baseline</baseline>
       <!--Top Level function parsing on first call to script is turned off here, as this tests order of functions executed-->
       <compile-flags>-DeferTopLevelTillFirstCall- -testtrace:stackfunc -off:simpleJit -on:stackfunc -force:deferparse -off:disablestackfuncondeferredescape</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo,exclude_arm,exclude_nonative</tags>
+      <tags>exclude_test,exclude_dynapogo,exclude_arm,exclude_nonative</tags>
     </default>
   </test>
   <test>
@@ -570,7 +570,7 @@
       <files>withref_delayobjscope.js</files>
       <baseline>withref_delayobjscope.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -on:stackfunc</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo,exclude_arm</tags>
+      <tags>exclude_test,exclude_dynapogo,exclude_arm</tags>
     </default>
   </test>
   <test>
@@ -578,7 +578,7 @@
       <files>funcexpr.js</files>
       <baseline>funcexpr.deferparse.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -on:stackfunc -force:deferparse -off:disablestackfuncondeferredescape</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo,exclude_arm</tags>
+      <tags>exclude_test,exclude_dynapogo,exclude_arm</tags>
     </default>
   </test>
   <test>
@@ -586,7 +586,7 @@
       <files>funcexpr_2.js</files>
       <baseline>funcexpr_2.deferparse.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -on:stackfunc -force:deferparse -off:disablestackfuncondeferredescape</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo,exclude_arm</tags>
+      <tags>exclude_test,exclude_dynapogo,exclude_arm</tags>
     </default>
   </test>
   <test>
@@ -594,7 +594,7 @@
       <files>funcexpr_2.js</files>
       <baseline>funcexpr_2.deferparse.native.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -on:stackfunc -force:deferparse -forceNative -off:simpleJit -off:disablestackfuncondeferredescape</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo,exclude_arm</tags>
+      <tags>exclude_test,exclude_dynapogo,exclude_arm</tags>
     </default>
   </test>
   <test>
@@ -602,7 +602,7 @@
       <files>with_existing.js</files>
       <baseline>with_existing.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -on:stackfunc</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo,exclude_arm</tags>
+      <tags>exclude_test,exclude_dynapogo,exclude_arm</tags>
     </default>
   </test>
   <test>
@@ -610,7 +610,7 @@
       <files>with_crossscope.js</files>
       <baseline>with_crossscope.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -on:stackfunc</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo,exclude_arm</tags>
+      <tags>exclude_test,exclude_dynapogo,exclude_arm</tags>
     </default>
   </test>
   <test>
@@ -618,7 +618,7 @@
       <files>bug565705.js</files>
       <baseline>bug565705.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:simpleJit -on:stackfunc</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo,exclude_arm</tags>
+      <tags>exclude_test,exclude_dynapogo,exclude_arm</tags>
     </default>
   </test>
   <test>
@@ -626,7 +626,7 @@
       <files>box_postjit.js</files>
       <baseline>box_postjit.deferparse.baseline</baseline>
       <compile-flags>-off:simplejit -mic:1 -off:inline -force:deferparse</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo,exclude_arm</tags>
+      <tags>exclude_test,exclude_dynapogo,exclude_arm</tags>
     </default>
   </test>
   <test>
@@ -634,7 +634,7 @@
       <files>box_jitloopbody.js</files>
       <baseline>box_jitloopbody.baseline</baseline>
       <compile-flags>-forcejitloopbody</compile-flags>
-      <tags>exclude_fre,exclude_arm</tags>
+      <tags>exclude_test,exclude_arm</tags>
     </default>
   </test>
   <test>
@@ -642,14 +642,14 @@
       <files>box_jitloopbody2.js</files>
       <baseline>box_jitloopbody2.baseline</baseline>
       <compile-flags>-forcejitloopbody</compile-flags>
-      <tags>exclude_fre,exclude_arm</tags>
+      <tags>exclude_test,exclude_arm</tags>
     </default>
   </test>
   <test>
     <default>
       <files>box_jitloopbody3.js</files>
       <compile-flags>-forcejitloopbody -force:deferparse -bgjit-</compile-flags>
-      <tags>exclude_fre,exclude_arm</tags>
+      <tags>exclude_test,exclude_arm</tags>
     </default>
   </test>
   <test>
@@ -668,7 +668,7 @@
     <default>
       <files>622043.js</files>
       <compile-flags>-force:deferparse -mic:1 -off:bailonnoprofile -force:inline -off:simplejit</compile-flags>
-      <tags>exclude_dynapogo,exclude_fre</tags>
+      <tags>exclude_dynapogo,exclude_test</tags>
     </default>
   </test>
   <test>
@@ -687,7 +687,7 @@
       <files>box_blockscope.js</files>
       <baseline>box_blockscope.baseline</baseline>
       <compile-flags>-off:simplejit -testtrace:stackfunc</compile-flags>
-      <tags>exclude_fre,exclude_arm,exclude_dynapogo</tags>
+      <tags>exclude_test,exclude_arm,exclude_dynapogo</tags>
     </default>
   </test>
   <test>

--- a/test/strict/rlexe.xml
+++ b/test/strict/rlexe.xml
@@ -86,7 +86,7 @@
     <default>
       <files>evalargs.js</files>
       <compile-flags>-Force:Deferparse</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
       <baseline />
     </default>
   </test>
@@ -197,7 +197,7 @@
       <files>03.assign.js</files>
       <baseline>03.assign_sm.baseline</baseline>
       <compile-flags>-Force:Deferparse -ForceStrictMode</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -211,7 +211,7 @@
       <files>03.assign_sm.js</files>
       <baseline>03.assign_sm.baseline</baseline>
       <compile-flags>-Force:Deferparse</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -255,7 +255,7 @@
       <files>05.arguments.js</files>
       <baseline>05.arguments_sm.baseline</baseline>
       <compile-flags>-Force:Deferparse -ForceStrictMode</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -277,7 +277,7 @@
       <files>05.arguments_sm.js</files>
       <baseline>05.arguments_sm.baseline</baseline>
       <compile-flags>-Force:Deferparse</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -298,7 +298,7 @@
       <files>06.arguments.js</files>
       <baseline>06.arguments_sm.baseline</baseline>
       <compile-flags>-Force:Deferparse -ForceStrictMode</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -306,7 +306,7 @@
       <files>06.arguments.js</files>
       <baseline>06.arguments_sm.baseline</baseline>
       <compile-flags>-force:cachedscope -ForceStrictMode</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -320,7 +320,7 @@
       <files>06.arguments_sm.js</files>
       <baseline>06.arguments_sm.baseline</baseline>
       <compile-flags>-Force:Deferparse</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>
@@ -328,7 +328,7 @@
       <files>06.arguments_sm.js</files>
       <baseline>06.arguments_sm.baseline</baseline>
       <compile-flags>-force:cachedscope</compile-flags>
-      <tags>exclude_fre</tags>
+      <tags>exclude_test</tags>
     </default>
   </test>
   <test>

--- a/test/typedarray/rlexe.xml
+++ b/test/typedarray/rlexe.xml
@@ -137,7 +137,7 @@ Below test fails with difference in space. Investigate the cause and re-enable t
     <default>
         <files>crossthread.js</files>
         <baseline>crossthread_es6.baseline</baseline>
-        <tags>typedarray,exclude_arm,exclude_chk,exclude_apollo</tags>
+        <tags>typedarray,exclude_arm,exclude_debug,exclude_apollo</tags>
     </default>
 </test>
 -->
@@ -219,7 +219,7 @@ Below test fails with difference in space. Investigate the cause and re-enable t
   </test>
   <test>
     <default>
-      <tags>exclude_fre,exclude_dynapogo,typedarray</tags>
+      <tags>exclude_test,exclude_dynapogo,typedarray</tags>
       <compile-flags>-maxinterpretcount:1 -off:simpleJit</compile-flags>
       <files>typedArrayProfile.js</files>
     </default>


### PR DESCRIPTION
Using this PR to replace old one (#991), due to there are so many changes after that change.

Fixes #110
