### PR TITLE
MSFT: 8158180 CAS:EdgeCrawler: ASSERT:  isFinalized (Chakra!Js::ScriptContext::~ScriptContext+97 [d:\a\_work\19\s\core\lib\runtime\base\scriptcontext.cpp @ 378])

### DIFF
--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -375,7 +375,7 @@ namespace Js
 
     ScriptContext::~ScriptContext()
     {
-        Assert(isFinalized);
+        Assert(isFinalized || !isInitialized);
         // Take etw rundown lock on this thread context. We are going to change/destroy this scriptContext.
         AutoCriticalSection autocs(GetThreadContext()->GetEtwRundownCriticalSection());
 

--- a/lib/Runtime/Library/JavascriptBuiltInFunctionList.h
+++ b/lib/Runtime/Library/JavascriptBuiltInFunctionList.h
@@ -139,6 +139,7 @@ BUILTIN(JavascriptError, ToString, EntryToString, FunctionInfo::ErrorOnNew | Fun
 BUILTIN(JavascriptExternalFunction, ExternalFunctionThunk, ExternalFunctionThunk, FunctionInfo::None)
 BUILTIN(JavascriptExternalFunction, WrappedFunctionThunk, WrappedFunctionThunk, FunctionInfo::None)
 BUILTIN(JavascriptExternalFunction, StdCallExternalFunctionThunk, StdCallExternalFunctionThunk, FunctionInfo::None)
+BUILTIN(JavascriptExternalFunction, DefaultExternalFunctionThunk, DefaultExternalFunctionThunk, FunctionInfo::None)
 BUILTIN(JavascriptFunction, NewInstance, NewInstance, FunctionInfo::SkipDefaultNewObject)
 BUILTIN(JavascriptFunction, PrototypeEntryPoint, PrototypeEntryPoint, FunctionInfo::DoNotProfile | FunctionInfo::ErrorOnNew)
 BUILTIN(JavascriptFunction, Apply, EntryApply, FunctionInfo::ErrorOnNew)

--- a/lib/Runtime/Library/JavascriptExternalFunction.cpp
+++ b/lib/Runtime/Library/JavascriptExternalFunction.cpp
@@ -246,7 +246,10 @@ namespace Js
 #endif
         if (result == nullptr)
         {
+#pragma warning(push)
+#pragma warning(disable:6011) // scriptContext cannot be null here
             result = scriptContext->GetLibrary()->GetUndefined();
+#pragma warning(pop)
         }
         else
         {

--- a/lib/Runtime/Library/JavascriptExternalFunction.cpp
+++ b/lib/Runtime/Library/JavascriptExternalFunction.cpp
@@ -15,35 +15,43 @@ namespace Js
 
     JavascriptExternalFunction::JavascriptExternalFunction(ExternalMethod entryPoint, DynamicType* type)
         : RuntimeFunction(type, &EntryInfo::ExternalFunctionThunk), nativeMethod(entryPoint), signature(nullptr), callbackState(nullptr), initMethod(nullptr),
-        oneBit(1), typeSlots(0), hasAccessors(0), callCount(0), prototypeTypeId(-1), flags(0)
+        oneBit(1), typeSlots(0), hasAccessors(0), prototypeTypeId(-1), flags(0)
     {
         DebugOnly(VerifyEntryPoint());
     }
 
     JavascriptExternalFunction::JavascriptExternalFunction(ExternalMethod entryPoint, DynamicType* type, InitializeMethod method, unsigned short deferredSlotCount, bool accessors)
         : RuntimeFunction(type, &EntryInfo::ExternalFunctionThunk), nativeMethod(entryPoint), signature(nullptr), callbackState(nullptr), initMethod(method),
-        oneBit(1), typeSlots(deferredSlotCount), hasAccessors(accessors), callCount(0), prototypeTypeId(-1), flags(0)
+        oneBit(1), typeSlots(deferredSlotCount), hasAccessors(accessors),prototypeTypeId(-1), flags(0)
     {
         DebugOnly(VerifyEntryPoint());
     }
 
+    JavascriptExternalFunction::JavascriptExternalFunction(DynamicType* type, InitializeMethod method, unsigned short deferredSlotCount, bool accessors)
+        : RuntimeFunction(type, &EntryInfo::DefaultExternalFunctionThunk), nativeMethod(nullptr), signature(nullptr), callbackState(nullptr), initMethod(method),
+        oneBit(1), typeSlots(deferredSlotCount), hasAccessors(accessors), prototypeTypeId(-1), flags(0)
+    {
+        DebugOnly(VerifyEntryPoint());
+    }
+
+
     JavascriptExternalFunction::JavascriptExternalFunction(JavascriptExternalFunction* entryPoint, DynamicType* type)
         : RuntimeFunction(type, &EntryInfo::WrappedFunctionThunk), wrappedMethod(entryPoint), callbackState(nullptr), initMethod(nullptr),
-        oneBit(1), typeSlots(0), hasAccessors(0), callCount(0), prototypeTypeId(-1), flags(0)
+        oneBit(1), typeSlots(0), hasAccessors(0), prototypeTypeId(-1), flags(0)
     {
         DebugOnly(VerifyEntryPoint());
     }
 
     JavascriptExternalFunction::JavascriptExternalFunction(StdCallJavascriptMethod entryPoint, DynamicType* type)
         : RuntimeFunction(type, &EntryInfo::StdCallExternalFunctionThunk), stdCallNativeMethod(entryPoint), signature(nullptr), callbackState(nullptr), initMethod(nullptr),
-        oneBit(1), typeSlots(0), hasAccessors(0), callCount(0), prototypeTypeId(-1), flags(0)
+        oneBit(1), typeSlots(0), hasAccessors(0), prototypeTypeId(-1), flags(0)
     {
         DebugOnly(VerifyEntryPoint());
     }
 
     JavascriptExternalFunction::JavascriptExternalFunction(DynamicType *type)
         : RuntimeFunction(type, &EntryInfo::ExternalFunctionThunk), nativeMethod(nullptr), signature(nullptr), callbackState(nullptr), initMethod(nullptr),
-        oneBit(1), typeSlots(0), hasAccessors(0), callCount(0), prototypeTypeId(-1), flags(0)
+        oneBit(1), typeSlots(0), hasAccessors(0), prototypeTypeId(-1), flags(0)
     {
         DebugOnly(VerifyEntryPoint());
     }
@@ -112,69 +120,6 @@ namespace Js
 
         Js::TypeId typeId = Js::JavascriptOperators::GetTypeId(thisVar);
 
-        this->callCount++;
-        if (IS_JS_ETW(EventEnabledJSCRIPT_HOSTING_EXTERNAL_FUNCTION_CALL_START()))
-        {
-            JavascriptFunction* caller = nullptr;
-
-            // Lot the caller function if the call count of the external function pass certain threshold (randomly pick 256)
-            // we don't want to call stackwalk too often. The threshold can be adjusted as needed.
-            if (callCount >= ETW_MIN_COUNT_FOR_CALLER && ((callCount % ETW_MIN_COUNT_FOR_CALLER) == 0))
-            {
-                Js::JavascriptStackWalker stackWalker(scriptContext);
-                bool foundScriptCaller = false;
-                while(stackWalker.GetCaller(&caller))
-                {
-                    if(caller != nullptr && Js::ScriptFunction::Is(caller))
-                    {
-                        foundScriptCaller = true;
-                        break;
-                    }
-                }
-                if(foundScriptCaller)
-                {
-                    Var sourceString = caller->EnsureSourceString();
-                    Assert(JavascriptString::Is(sourceString));
-                    const char16* callerString = Js::JavascriptString::FromVar(sourceString)->GetSz();
-                    char16* outString = (char16*)callerString;
-                    int length = 0;
-                    if (wcschr(callerString, _u('\n')) != NULL || wcschr(callerString, _u('\n')) != NULL)
-                    {
-                        length = Js::JavascriptString::FromVar(sourceString)->GetLength();
-                        outString = HeapNewArray(char16, length+1);
-                        int j = 0;
-                        for (int i = 0; i < length; i++)
-                        {
-                            if (callerString[i] != _u('\n') && callerString[i] != _u('\r'))
-                            {
-                                outString[j++] = callerString[i];
-                            }
-                        }
-                        outString[j] = _u('\0');
-                    }
-                    JS_ETW(EventWriteJSCRIPT_HOSTING_CALLER_TO_EXTERNAL(scriptContext, this, typeId, outString, callCount));
-                    if (outString != callerString)
-                    {
-                        HeapDeleteArray(length+1, outString);
-                    }
-#if DBG_DUMP
-                    if (Js::Configuration::Global.flags.Trace.IsEnabled(Js::HostPhase))
-                    {
-                        Output::Print(_u("Large number of Call to trampoline: methodAddr= %p, Object typeid= %d, caller method= %s, callcount= %d\n"),
-                            this, typeId, callerString, callCount);
-                    }
-#endif
-                }
-            }
-            JS_ETW(EventWriteJSCRIPT_HOSTING_EXTERNAL_FUNCTION_CALL_START(scriptContext, this, typeId));
-#if DBG_DUMP
-            if (Js::Configuration::Global.flags.Trace.IsEnabled(Js::HostPhase))
-            {
-                Output::Print(_u("Call to trampoline: methodAddr= %p, Object typeid= %d\n"), this, typeId);
-            }
-#endif
-        }
-
         Js::RecyclableObject* directHostObject = nullptr;
         switch(typeId)
         {
@@ -229,36 +174,10 @@ namespace Js
         }
     }
 
-    Var JavascriptExternalFunction::FinishExternalCall(Var result)
-    {
-        ScriptContext * scriptContext = this->type->GetScriptContext();
-
-        if ( NULL == result )
-        {
-            result = scriptContext->GetLibrary()->GetUndefined();
-        }
-        else
-        {
-            result = CrossSite::MarshalVar(scriptContext, result);
-        }
-        if (IS_JS_ETW(EventEnabledJSCRIPT_HOSTING_EXTERNAL_FUNCTION_CALL_STOP()))
-        {
-            JS_ETW(EventWriteJSCRIPT_HOSTING_EXTERNAL_FUNCTION_CALL_STOP(scriptContext, this, 0));
-        }
-        return result;
-    }
-
     Var JavascriptExternalFunction::ExternalFunctionThunk(RecyclableObject* function, CallInfo callInfo, ...)
     {
         RUNTIME_ARGUMENTS(args, callInfo);
         JavascriptExternalFunction* externalFunction = static_cast<JavascriptExternalFunction*>(function);
-
-        // Deferred constructors which are not callable fall back to using the RecyclableObject::DefaultEntryPoint. In order to call
-        // this function we have to be inside script so all this and return before doing any of the external call preparation.
-        if (externalFunction->nativeMethod == Js::RecyclableObject::DefaultExternalEntryPoint)
-        {
-            return Js::RecyclableObject::DefaultExternalEntryPoint(function, callInfo, args.Values);
-        }
 
         ScriptContext * scriptContext = externalFunction->type->GetScriptContext();
 
@@ -325,8 +244,16 @@ namespace Js
         }
         END_LEAVE_SCRIPT_WITH_EXCEPTION(scriptContext);
 #endif
+        if (result == nullptr)
+        {
+            result = scriptContext->GetLibrary()->GetUndefined();
+        }
+        else
+        {
+            result = CrossSite::MarshalVar(scriptContext, result);
+        }
 
-        return externalFunction->FinishExternalCall(result);
+        return result;
     }
 
     Var JavascriptExternalFunction::WrappedFunctionThunk(RecyclableObject* function, CallInfo callInfo, ...)
@@ -344,6 +271,13 @@ namespace Js
         // don't need to leave script here, ExternalFunctionThunk will
         Assert(externalFunction->wrappedMethod->GetFunctionInfo()->GetOriginalEntryPoint() == JavascriptExternalFunction::ExternalFunctionThunk);
         return JavascriptFunction::CallFunction<true>(externalFunction->wrappedMethod, externalFunction->wrappedMethod->GetEntryPoint(), args);
+    }
+
+    Var JavascriptExternalFunction::DefaultExternalFunctionThunk(RecyclableObject* function, CallInfo callInfo, ...)
+    {
+        TypeId typeId = function->GetTypeId();
+        rtErrors err = typeId == TypeIds_Undefined || typeId == TypeIds_Null ? JSERR_NeedObject : JSERR_NeedFunction;
+        JavascriptError::ThrowTypeError(function->GetScriptContext(), err);
     }
 
     Var JavascriptExternalFunction::StdCallExternalFunctionThunk(RecyclableObject* function, CallInfo callInfo, ...)
@@ -430,7 +364,16 @@ namespace Js
             }
         }
 
-        return externalFunction->FinishExternalCall(result);
+        if (result == nullptr)
+        {
+            result = scriptContext->GetLibrary()->GetUndefined();
+        }
+        else
+        {
+            result = CrossSite::MarshalVar(scriptContext, result);
+        }
+
+        return result;
     }
 
     BOOL JavascriptExternalFunction::SetLengthProperty(Var length)

--- a/lib/Runtime/Library/JavascriptExternalFunction.h
+++ b/lib/Runtime/Library/JavascriptExternalFunction.h
@@ -21,6 +21,8 @@ namespace Js
     public:
         JavascriptExternalFunction(ExternalMethod nativeMethod, DynamicType* type);
         JavascriptExternalFunction(ExternalMethod entryPoint, DynamicType* type, InitializeMethod method, unsigned short deferredSlotCount, bool accessors);
+        // this is default external function for DOM constructor that cannot be new'ed.
+        JavascriptExternalFunction(DynamicType* type, InitializeMethod method, unsigned short deferredSlotCount, bool accessors);
         JavascriptExternalFunction(JavascriptExternalFunction* wrappedMethod, DynamicType* type);
         JavascriptExternalFunction(StdCallJavascriptMethod nativeMethod, DynamicType* type);
 
@@ -37,6 +39,7 @@ namespace Js
             static FunctionInfo ExternalFunctionThunk;
             static FunctionInfo WrappedFunctionThunk;
             static FunctionInfo StdCallExternalFunctionThunk;
+            static FunctionInfo DefaultExternalFunctionThunk;
         };
 
         ExternalMethod GetNativeMethod() { return nativeMethod; }
@@ -62,9 +65,7 @@ namespace Js
         unsigned int typeSlots:15;
         // Determines if we need are a dictionary type
         unsigned int hasAccessors:1;
-        // This is used for etw tracking for now; potentially we can use this as heuristic
-        // to determine if when to JIT the method.
-        unsigned int callCount:15;
+        unsigned int unused:15;
 
         JavascriptTypeId prototypeTypeId;
         UINT64 flags;
@@ -72,10 +73,10 @@ namespace Js
         static Var ExternalFunctionThunk(RecyclableObject* function, CallInfo callInfo, ...);
         static Var WrappedFunctionThunk(RecyclableObject* function, CallInfo callInfo, ...);
         static Var StdCallExternalFunctionThunk(RecyclableObject* function, CallInfo callInfo, ...);
+        static Var DefaultExternalFunctionThunk(RecyclableObject* function, CallInfo callInfo, ...);
         static void __cdecl DeferredInitializer(DynamicObject* instance, DeferredTypeHandlerBase* typeHandler, DeferredInitializeMode mode);
 
         void PrepareExternalCall(Arguments * args);
-        Var FinishExternalCall(Var result);
 
 #if ENABLE_TTD
     public:

--- a/lib/Runtime/Library/JavascriptLibrary.h
+++ b/lib/Runtime/Library/JavascriptLibrary.h
@@ -243,6 +243,7 @@ namespace Js
         DynamicType * stdCallFunctionWithDeferredPrototypeType;
         DynamicType * idMappedFunctionWithPrototypeType;
         DynamicType * externalConstructorFunctionWithDeferredPrototypeType;
+        DynamicType * defaultExternalConstructorFunctionWithDeferredPrototypeType;
         DynamicType * boundFunctionType;
         DynamicType * regexConstructorType;
         DynamicType * crossSiteDeferredPrototypeFunctionType;

--- a/lib/Runtime/Types/RecyclableObject.cpp
+++ b/lib/Runtime/Types/RecyclableObject.cpp
@@ -302,14 +302,6 @@ namespace Js
             /* TODO-ERROR: args.Info.Count > 0? args[0] : nullptr); */);
     }
 
-    Var RecyclableObject::DefaultExternalEntryPoint(RecyclableObject* function, CallInfo callInfo, Var* arguments)
-    {
-        TypeId typeId = function->GetTypeId();
-        rtErrors err = typeId == TypeIds_Undefined || typeId == TypeIds_Null ? JSERR_NeedObject : JSERR_NeedFunction;
-        JavascriptError::ThrowTypeError(function->GetScriptContext(), err
-            /* TODO-ERROR: args.Info.Count > 0? args[0] : nullptr); */);
-    }
-
     BOOL RecyclableObject::HasProperty(PropertyId propertyId)
     {
         return false;

--- a/lib/Runtime/Types/RecyclableObject.h
+++ b/lib/Runtime/Types/RecyclableObject.h
@@ -240,7 +240,6 @@ namespace Js {
         // function - however, if it can't be called like a function, it's set to DefaultEntryPoint
         // which will emit an error.
         static Var DefaultEntryPoint(RecyclableObject* function, CallInfo callInfo, ...);
-        static Var DefaultExternalEntryPoint(RecyclableObject* function, CallInfo callInfo, Var* arguments);
 
         virtual PropertyId GetPropertyId(PropertyIndex index) { return Constants::NoProperty; }
         virtual PropertyId GetPropertyId(BigPropertyIndex index) { return Constants::NoProperty; }


### PR DESCRIPTION
Fix an assert. ScriptContext dtor can be called if we failed half way during the intialization.
Some perf improvement for ExternalFunctionThunk as it is the main entrypoint for external function calls.
Get rid of unused ETW code, and move out DefaultEntryPoint check for DOM constructors that cannot be new'ed.
