### PR TITLE
cross-platform: fix stack related issues on macOS

### DIFF
--- a/bin/ch/CMakeLists.txt
+++ b/bin/ch/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(ch_source_files 
+set(ch_source_files
   ch.cpp
   ChakraRtInterface.cpp
   CodexAssert.cpp
@@ -67,6 +67,8 @@ if(STATIC_LIBRARY)
       icucore
       "-framework CoreFoundation"
       "-framework Security"
+      # set stack size to 64Mb for stack tests
+      -Wl,-stack_size,0x04000000
       )
   endif() # Linux ?
 else() # // !from shared library
@@ -78,7 +80,7 @@ else() # // !from shared library
 endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL Linux)
-  set(lib_target "${lib_target}" 
+  set(lib_target "${lib_target}"
     -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/ch.version
     )
 endif()

--- a/test/Error/stack.js
+++ b/test/Error/stack.js
@@ -78,8 +78,8 @@ function DoSomething()
 
 try
 {
-    var count = 20000; // Keep this unrealistic number as we do not
-                       // limit stack memory to a particular capacity
+    var count = 200000; // Keep this unrealistic number as we do (osx)
+                        // and do not limit stack memory to a particular capacity
 
     var a = {};
     var b = a;


### PR DESCRIPTION
We have all tests are passing for macOS now.

notes on updates:

 ~~Main thread default stack limit is 8MB while `pthread_get_stacksize_np` may return lower value.~~

~~OSX implementation of Pthread stack size is 512KB~~
 - Sets 64MB process stack limit through macOS linker to match our testing needs

edit: removed additional pthread updates. It was kind of a nice to have but at the moment not needed. Going to visit that separately.