### PR TITLE
Fix BoxStackInstance error

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -1389,7 +1389,7 @@ void ByteCodeGenerator::DefineUserVars(FuncInfo *funcInfo)
 
                     // Undef-initialize the home location if it is a register (not closure-captured, or else capture
                     // is delayed) or a property of an object.
-                    if ((!sym->GetHasInit() && (!sym->NeedsSlotAlloc(funcInfo) || sym->GetHasNonCommittedReference())) ||
+                    if ((sym->GetLocation() != Js::Constants::NoRegister && (!sym->GetHasInit() || (sym->NeedsSlotAlloc(funcInfo) && sym->GetHasNonCommittedReference()))) ||
                         (funcInfo->bodyScope->GetIsObject() && !funcInfo->GetHasCachedScope()))
                     {
                         Js::RegSlot reg = sym->GetLocation();

--- a/test/Closures/delaycapture-loopbody2.js
+++ b/test/Closures/delaycapture-loopbody2.js
@@ -1,0 +1,109 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function test0() {
+    var loopInvariant = false ? 7 : 12;
+    var GiantPrintArray = [];
+    function makeArrayLength() {
+    }
+    function leaf() {
+    }
+    var obj0 = {};
+    var protoObj0 = {};
+    var obj1 = {};
+    var arrObj0 = {};
+    var litObj0 = { prop1: 3.14159265358979 };
+    var litObj1 = { prop0: 0 };
+    var func0 = function () {
+    };
+    var func1 = function () {
+    };
+    var func2 = function () {
+        for (; protoObj0.prop0; 2) {
+            ary(851125506.1 !== 2 && 2 < arrObj0.prop2, func0(arguments[2 + 0]), ary.reverse(), typeof ary[((Object.prototype.prop2 !== Object.prototype.length || obj5.prop1 < Object.prototype.length) >= 0 ? Object.prototype.prop2 !== Object.prototype.length || obj5.prop1 < Object.prototype.length : 0) & 15] != 'undefined', ui8[loopInvariant + 1 & 255] * (false ? (Object.defineProperty(obj5, 'prop0', {
+                get: function () {
+                    WScript.Echo();
+                    return 3;
+                },
+                configurable: true
+            }), 4294967297 & 702469842) : 4294967297 & 702469842) + ary.unshift(typeof obj5.prop0 != 'number', -1556722774.9 + Object.prototype.prop2, !221, func0.call(arrObj0, -1556722774.9 + Object.prototype.prop2), Object.prototype.prop2 >>= 33, typeof obj0.prop2 != 'object', -8074665319890990000 && 1413529899.1, obj5.prop1 = obj5.prop0, function () {
+                ;
+            } instanceof (typeof Number == 'function' ? Number : Object), Math.sin(Object.prototype.prop0), -8074665319890990000 && 1413529899.1), typeof protoObj0.length == 'object', arguments[((typeof Object.prototype.prop1-- == 'boolean') >= 0 ? typeof Object.prototype.prop1-- == 'boolean' : 0) & 15]);
+            func0(uic8[1522725379.1]);
+        }
+    };
+    var func3 = function () {
+    };
+    var func4 = function () {
+    };
+    obj0.method0 = func2;
+    obj1.method0 = obj0.method0;
+    var ary = Array(10);
+    var i8 = new Int8Array(256);
+    var i16 = new Int16Array();
+    var i32 = new Int32Array();
+    var ui8 = new Uint8Array();
+    var ui16 = new Uint16Array();
+    var ui32 = new Uint32Array();
+    var f32 = new Float32Array();
+    var f64 = new Float64Array();
+    var uic8 = new Uint8ClampedArray();
+    var IntArr0 = Array(9);
+    var IntArr1 = Array(-1399162652, 173143797, -1810098018, 96552438, 65535, -14752727, 1269200816, 226, -229);
+    var FloatArr0 = [];
+    var VarArr0 = Array();
+    var a = 0;
+    var b = 851125506.1;
+    177;
+    243;
+    var aliasOflitObj0 = litObj0;
+    -137;
+    makeArrayLength(8805654756604090000);
+    -1178371243;
+    190816894 * this;
+    var uniqobj4 = [];
+    do {
+        if (__loopvar0) {
+        }
+        var __loopvar1 = loopInvariant;
+        for (var _strvar0 in i8) {
+            if (4) {
+            }
+            obj1.method0();
+            var __loopvar2 = loopInvariant, __loopSecondaryVar2_0 = loopInvariant;
+            for (; _strvar0 < 3077559403207580000; VarArr0) {
+                if (-2) {
+                    break;
+                }
+                var v1 = shouldBailout;
+                var v2 = true;
+                function v3() {
+                    Math(_strvar0 * __loopvar2);
+                    ({ prop1: FloatArr0 });
+                }
+                v3(5);
+                var __loopvar3 = loopInvariant, __loopSecondaryVar3_0 = loopInvariant;
+                var __loopSecondaryVar4_0 = loopInvariant, __loopSecondaryVar4_1 = loopInvariant;
+
+                var __loopvar5 = loopInvariant - 3;
+                for (var _strvar0 in FloatArr0) {
+                    if (typeof _strvar0 === 'string' && _strvar0.indexOf('method') != -1) {
+                        continue;
+                    }
+                    __loopvar5++;
+                    if (__loopvar5 == loopInvariant + 1) {
+                        break;
+                    }
+                    FloatArr0[_strvar0] = _strvar0;
+                }
+                var id28 = test0.caller >>> uic8[120 & 255];
+            }
+        }
+    } while (false);
+    var __loopvar0 = loopInvariant, __loopSecondaryVar0_0 = loopInvariant, __loopSecondaryVar0_1 = loopInvariant;
+}
+test0();
+
+WScript.Echo('pass');

--- a/test/Closures/rlexe.xml
+++ b/test/Closures/rlexe.xml
@@ -76,6 +76,13 @@
   </test>
   <test>
     <default>
+      <files>delaycapture-loopbody2.js</files>
+      <compile-flags>-lic:1 -bgjit- -InitializeInterpreterSlotsWithInvalidStackVar</compile-flags>
+      <tags>exclude_fre</tags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>initcachedscope.js</files>
       <compile-flags>-recyclerstress -force:cachedscope</compile-flags>
       <baseline>initcachedscope.baseline</baseline>


### PR DESCRIPTION
Similar issue to the missiung-undef-initialization case I fixed last week, this is the case where we have a dominating initialization that nevertheless doesn't write to the variable's register, but a later delay-captured reference does write to the register. Conservatively emitting undef-init now; delay capture needs to be revisited in the wake of the stable closures change.
