### PR TITLE
Zero free memory with non-temporal stores

### DIFF
--- a/bin/GCStress/StubExternalApi.cpp
+++ b/bin/GCStress/StubExternalApi.cpp
@@ -7,30 +7,6 @@
 
 #include "Core/ConfigParser.h"
 
-// TODO: REMOVE
-void js_memcpy_s(__bcount(sizeInBytes) void *dst, size_t sizeInBytes, __in_bcount(count) const void *src, size_t count)
-{
-    Assert((count) <= (sizeInBytes));
-    if ((count) <= (sizeInBytes))
-        memcpy((dst), (src), (count));
-    else
-        ReportFatalException(NULL, E_FAIL, Fatal_Internal_Error, 2);
-}
-
-void js_wmemcpy_s(__ecount(sizeInWords) char16 *dst, size_t sizeInWords, __in_ecount(count) const char16 *src, size_t count)
-{
-    //Multiplication Overflow check
-    Assert(count <= sizeInWords && count <= SIZE_MAX/sizeof(char16));
-    if(!(count <= sizeInWords && count <= SIZE_MAX/sizeof(char16)))
-    {
-        ReportFatalException((ULONG_PTR) NULL, E_FAIL, Fatal_Internal_Error, 2);
-    }
-    else
-    {
-        memcpy(dst, src, count * sizeof(char16));
-    }
-}
-
 bool ConfigParserAPI::FillConsoleTitle(__ecount(cchBufferSize) LPWSTR buffer, size_t cchBufferSize, __in LPWSTR moduleName)
 {
     swprintf_s(buffer, cchBufferSize, _u("Chakra GC: %d - %s"), GetCurrentProcessId(), moduleName);

--- a/lib/Common/Common/Api.cpp
+++ b/lib/Common/Common/Api.cpp
@@ -24,3 +24,25 @@ void __stdcall js_wmemcpy_s(__ecount(sizeInWords) char16 *dst, size_t sizeInWord
 
     memcpy(dst, src, count * sizeof(char16));
 }
+
+#if defined(_M_IX86) || defined(_M_X64)
+
+void __stdcall js_memset_zero_nontemporal(__bcount(sizeInBytes) void *dst, size_t sizeInBytes)
+{
+    if ((sizeInBytes % sizeof(__m128i)) == 0)
+    {
+        size_t writeBytes = 0;
+        __m128i simdZero = _mm_setzero_si128();
+        for (__m128i * p = (__m128i *)dst; writeBytes < sizeInBytes; p += 1, writeBytes += sizeof(__m128i))
+        {
+            _mm_stream_si128(p, simdZero);
+        }
+    }
+    // cannot do non-temporal store directly if set size is not multiple of sizeof(__m128i)
+    else
+    {
+        memset(dst, 0, sizeInBytes);
+    }
+}
+
+#endif

--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -703,6 +703,10 @@ PHASE(All)
 #define DEFAULT_CONFIG_LoopAlignNopLimit (6)
 #endif
 
+#if defined(_M_IX86) || defined(_M_X64)
+#define DEFAULT_CONFIG_ZeroMemoryWithNonTemporalStore (true)
+#endif
+
 #define TraceLevel_Error        (1)
 #define TraceLevel_Warning      (2)
 #define TraceLevel_Info         (3)
@@ -1415,6 +1419,10 @@ FLAGNR(NumberSet, RejitTraceFilter, "Filter the rejit trace messages to specific
 FLAGNR(Number,  MaxBackgroundFinishMarkCount, "Maximum number of background finish mark", 1)
 FLAGNR(Number,  BackgroundFinishMarkWaitTime, "Millisecond to wait for background finish mark", 15)
 FLAGNR(Number,  MinBackgroundRepeatMarkRescanBytes, "Minimum number of bytes rescan to trigger background finish mark",  -1)
+
+#if defined(_M_IX86) || defined(_M_X64)
+FLAGNR(Boolean, ZeroMemoryWithNonTemporalStore, "Zero free memory with non-temporal stores to avoid evicting other content from processor cache", DEFAULT_CONFIG_ZeroMemoryWithNonTemporalStore)
+#endif
 
 // recycler memory restrict test flags
 FLAGNR(Number,  MaxMarkStackPageCount , "Restrict recycler mark stack size (in pages)", -1)

--- a/lib/Common/Core/Api.h
+++ b/lib/Common/Core/Api.h
@@ -8,6 +8,10 @@
 extern void __stdcall js_memcpy_s(__bcount(sizeInBytes) void *dst, size_t sizeInBytes, __in_bcount(count) const void *src, size_t count);
 extern void __stdcall js_wmemcpy_s(__ecount(sizeInWords) char16 *dst, size_t sizeInWords, __in_ecount(count) const char16 *src, size_t count);
 
+#if defined(_M_IX86) || defined(_M_X64)
+extern void __stdcall js_memset_zero_nontemporal(__bcount(sizeInBytes) void *dst, size_t sizeInBytes);
+#endif
+
 // A virtualized thread id. The physical thread on which an instance of the runtime is executed can change but a
 // ThreadContextId should be invariant.
 // Many parts of the runtime expect to only be called by the execution, or "main", thread. Hosts have the prerogative

--- a/lib/Common/Memory/PageAllocator.cpp
+++ b/lib/Common/Memory/PageAllocator.cpp
@@ -936,12 +936,7 @@ PageAllocatorBase<T>::FillFreePages(__in void * address, uint pageCount)
 #if defined(_M_IX86) || defined(_M_X64)
         if (CONFIG_FLAG(ZeroMemoryWithNonTemporalStore))
         {
-            size_t writeBytes = 0;
-            __m128i simdZero = _mm_setzero_si128();
-            for (__m128i * p = (__m128i *)address; writeBytes < pageCount * AutoSystemInfo::PageSize; p += 1, writeBytes += sizeof(__m128i))
-            {
-                _mm_stream_si128(p, simdZero);
-            }
+            js_memset_zero_nontemporal(address, AutoSystemInfo::PageSize * pageCount);
         }
         else
 #endif
@@ -1580,12 +1575,7 @@ PageAllocatorBase<T>::ZeroQueuedPages()
 #if defined(_M_IX86) || defined(_M_X64)
         if (CONFIG_FLAG(ZeroMemoryWithNonTemporalStore))
         {
-            size_t writeBytes = 0;
-            __m128i simdZero = _mm_setzero_si128();
-            for (__m128i * p = (__m128i *)freePageEntry; writeBytes < pageCount * AutoSystemInfo::PageSize; p += 1, writeBytes += sizeof(__m128i))
-            {
-                _mm_stream_si128(p, simdZero);
-            }
+            js_memset_zero_nontemporal(freePageEntry, AutoSystemInfo::PageSize * pageCount);
         }
         else
 #endif

--- a/lib/Common/Memory/PageAllocator.cpp
+++ b/lib/Common/Memory/PageAllocator.cpp
@@ -929,7 +929,25 @@ PageAllocatorBase<T>::FillFreePages(__in void * address, uint pageCount)
 #endif
     if (ZeroPages())
     {
-        memset(address, 0, AutoSystemInfo::PageSize * pageCount);
+        //
+        // Do memset via non-temporal store to avoid evicting existing processor cache.
+        // This helps low-end machines with limited cache size.
+        //
+#if defined(_M_IX86) || defined(_M_X64)
+        if (CONFIG_FLAG(ZeroMemoryWithNonTemporalStore))
+        {
+            size_t writeBytes = 0;
+            __m128i simdZero = _mm_setzero_si128();
+            for (__m128i * p = (__m128i *)address; writeBytes < pageCount * AutoSystemInfo::PageSize; p += 1, writeBytes += sizeof(__m128i))
+            {
+                _mm_stream_si128(p, simdZero);
+            }
+        }
+        else
+#endif
+        {
+            memset(address, 0, AutoSystemInfo::PageSize * pageCount);
+        }
     }
 #endif
 
@@ -1554,15 +1572,26 @@ PageAllocatorBase<T>::ZeroQueuedPages()
         }
         PageSegmentBase<T> * segment = freePageEntry->segment;
         uint pageCount = freePageEntry->pageCount;
-        memset(freePageEntry, 0, pageCount * AutoSystemInfo::PageSize);
 
-        // Expriment code to perform non-temporal write to zero pages instead of memset, the idea is keeping cache untouched.
-        // Haven't observed perf win for low-end machines, just keep it here to be re-used later.
-        // size_t writeBytes = 0;
-        // for (__m128i * p = (__m128i *)freePageEntry; writeBytes < pageCount * AutoSystemInfo::PageSize; p += 1, writeBytes += sizeof(__m128i))
-        // {
-        //     _mm_stream_si128(p, simdZero);
-        // }
+        //
+        // Do memset via non-temporal store to avoid evicting existing processor cache.
+        // This helps low-end machines with limited cache size.
+        //
+#if defined(_M_IX86) || defined(_M_X64)
+        if (CONFIG_FLAG(ZeroMemoryWithNonTemporalStore))
+        {
+            size_t writeBytes = 0;
+            __m128i simdZero = _mm_setzero_si128();
+            for (__m128i * p = (__m128i *)freePageEntry; writeBytes < pageCount * AutoSystemInfo::PageSize; p += 1, writeBytes += sizeof(__m128i))
+            {
+                _mm_stream_si128(p, simdZero);
+            }
+        }
+        else
+#endif
+        {
+            memset(freePageEntry, 0, pageCount * AutoSystemInfo::PageSize);
+        }
 
         QueuePages(freePageEntry, pageCount, segment);
     }


### PR DESCRIPTION
Cache misses looks servere on low-end machine with less processor cache. It is uncessary to zero free memory and load all of them on cache. Changing it to non-temporal store gives ~%5 improvement of Earley-boyer in Octane on some low-end machines.