### PR TITLE
cross-platform: Fix GCC lib Fedora X64 compile time issues

### DIFF
--- a/pal/inc/pal.h
+++ b/pal/inc/pal.h
@@ -6411,6 +6411,7 @@ PALIMPORT double __cdecl _copysign(double, double);
 
 #if !defined(PAL_STDCPP_COMPAT) || defined(USING_PAL_STDLIB)
 
+#ifdef PLATFORM_ACCEPTS_ABS_OVERLOAD
 #ifdef __cplusplus
 extern "C++" {
 
@@ -6419,6 +6420,7 @@ inline __int64 abs(__int64 _X) {
 }
 
 }
+#endif
 #endif
 
 PALIMPORT void * __cdecl malloc(size_t);

--- a/pal/src/configure.cmake
+++ b/pal/src/configure.cmake
@@ -102,6 +102,21 @@ check_cxx_symbol_exists(_SC_PHYS_PAGES unistd.h HAVE__SC_PHYS_PAGES)
 check_cxx_symbol_exists(_SC_AVPHYS_PAGES unistd.h HAVE__SC_AVPHYS_PAGES)
 
 check_cxx_source_runs("
+#include <stdlib.h>
+#include <stdio.h>
+
+extern \"C++\" {
+  inline long long abs(long long _X) {
+    return llabs(_X);
+  }
+}
+
+int main(int argc, char **argv) {
+  long long X = 123456789 + argc;
+  printf(\"%lld\", abs(X));
+  exit(0);
+}" PLATFORM_ACCEPTS_ABS_OVERLOAD)
+check_cxx_source_runs("
 #include <sys/param.h>
 #include <stdlib.h>
 

--- a/pal/src/include/pal/palinternal.h
+++ b/pal/src/include/pal/palinternal.h
@@ -677,4 +677,11 @@ inline T* InterlockedCompareExchangePointerT(
 
 #endif // __cplusplus
 
+#ifndef max
+#define max(a,b)            (((a) > (b)) ? (a) : (b))
+#endif
+#ifndef min
+#define min(a,b)            (((a) < (b)) ? (a) : (b))
+#endif
+
 #endif /* _PAL_INTERNAL_H_ */


### PR DESCRIPTION
Fedora x64, we have only 1 failing test at the moment: 'test/Regex/BoiHardFail.js'

Compile steps for Fedora 24

Install dependencies
```
sudo dnf group install -y "Development Tools" "C Development Tools and Libraries"
sudo dnf install -y git cmake clang gcc gcc-c++ kernel-devel python
sudo dnf install -y libuuid-devel lttng-ust-devel.x86_64  libunwind-devel.x86_64 libicu-devel.x86_64
```

Clone && Compile
```
> git clone https://github.com/Microsoft/ChakraCore
> cd ChakraCore
> ./build.sh
```