### PR TITLE
split ChakraCoreVersion.h file

### DIFF
--- a/lib/Common/ChakraCoreVersion.h
+++ b/lib/Common/ChakraCoreVersion.h
@@ -1,0 +1,15 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+#pragma once
+
+#define CHAKRA_CORE_MAJOR_VERSION 1
+#define CHAKRA_CORE_MINOR_VERSION 2
+#define CHAKRA_CORE_VERSION_RELEASE 0
+#define CHAKRA_CORE_VERSION_PRERELEASE 0
+#define CHAKRA_CORE_VERSION_RELEASE_QFE 0
+
+#define CHAKRA_VERSION_RELEASE 0
+
+// NOTE: need to update the GUID in ByteCodeCacheReleaseFileVersion.h as well

--- a/lib/Common/CommonDefines.h
+++ b/lib/Common/CommonDefines.h
@@ -6,19 +6,7 @@
 
 #include "TargetVer.h"
 #include "Warnings.h"
-
-//----------------------------------------------------------------------------------------------------
-// Chakra Core version
-//----------------------------------------------------------------------------------------------------
-#define CHAKRA_CORE_MAJOR_VERSION 1
-#define CHAKRA_CORE_MINOR_VERSION 2
-#define CHAKRA_CORE_VERSION_RELEASE 0
-#define CHAKRA_CORE_VERSION_PRERELEASE 0
-#define CHAKRA_CORE_VERSION_RELEASE_QFE 0
-
-#define CHAKRA_VERSION_RELEASE 0
-
-// NOTE: need to update the GUID in ByteCodeCacheReleaseFileVersion.h as well
+#include "ChakraCoreVersion.h"
 
 //----------------------------------------------------------------------------------------------------
 // Default debug/fretest/release flags values


### PR DESCRIPTION
Split version defs out from `CommonDefines.h` into a separate file.
Hosts that statically link to ChakraCore can then access ChakraCore
version info by `#include` this file at build time.
