### PR TITLE
xplat: fix minor jsrt header issues

### DIFF
--- a/lib/Jsrt/ChakraCommon.h
+++ b/lib/Jsrt/ChakraCommon.h
@@ -48,6 +48,7 @@ typedef BYTE* ChakraBytePtr;
 #define _Pre_writable_byte_size_(byteLength)
 #define _Outptr_result_buffer_(byteLength)
 #define _Outptr_result_bytebuffer_(byteLength)
+#define _Outptr_result_maybenull_
 #define _Outptr_result_z_
 #define _Ret_maybenull_
 #define _Out_writes_(size)
@@ -70,6 +71,16 @@ typedef BYTE* ChakraBytePtr;
 #include <stdint.h>  // for uintptr_t
 typedef uintptr_t ChakraCookie;
 typedef unsigned char* ChakraBytePtr;
+
+// xplat-todo: try reduce usage of following types
+#if !defined(__MSTYPES_DEFINED)
+typedef uint32_t UINT32;
+typedef int64_t INT64;
+typedef void* HANDLE;
+typedef unsigned char BYTE;
+typedef UINT32 DWORD;
+#endif
+
 #endif //  defined(_WIN32) && defined(_MSC_VER)
 
     /// <summary>

--- a/lib/Jsrt/ChakraCore.h
+++ b/lib/Jsrt/ChakraCore.h
@@ -110,7 +110,7 @@ CHAKRA_API
 JsParseModuleSource(
     _In_ JsModuleRecord requestModule,
     _In_ JsSourceContext sourceContext,
-    _In_ byte* script,
+    _In_ BYTE* script,
     _In_ unsigned int scriptLength,
     _In_ JsParseModuleSourceFlags sourceFlag,
     _Outptr_result_maybenull_ JsValueRef* exceptionValueRef);

--- a/lib/Jsrt/ChakraDebug.h
+++ b/lib/Jsrt/ChakraDebug.h
@@ -22,14 +22,6 @@
 
 #include "ChakraCommon.h"
 
-#if (!defined(_WIN32) || !defined(_MSC_VER)) && !defined(__MSTYPES_DEFINED)
-typedef uint32_t UINT32;
-typedef int64_t INT64;
-typedef void* HANDLE;
-typedef unsigned char BYTE;
-typedef UINT32 DWORD;
-#endif
-
     /// <summary>
     ///     Debug events reported from ChakraCore engine.
     /// </summary>


### PR DESCRIPTION
Recent updates added usages to `_Outptr_result_maybenull_` and `byte`
which are unavailable to external hosts.
