### PR TITLE
cross-platform: fix build break

### DIFF
--- a/bin/ch/WScriptJsrt.cpp
+++ b/bin/ch/WScriptJsrt.cpp
@@ -3,7 +3,6 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "stdafx.h"
-#include <string>
 
 MessageQueue* WScriptJsrt::messageQueue = nullptr;
 std::map<std::string, JsModuleRecord>  WScriptJsrt::moduleRecordMap;
@@ -1046,4 +1045,3 @@ JsErrorCode WScriptJsrt::NotifyModuleReadyCallback(_In_opt_ JsModuleRecord refer
     }
     return JsNoError;
 }
-

--- a/bin/ch/stdafx.h
+++ b/bin/ch/stdafx.h
@@ -26,6 +26,7 @@
 #define ENABLE_TEST_HOOKS 1
 #include "CommonDefines.h"
 #include <map>
+#include <string>
 
 #ifdef _WIN32
 #include <windows.h>


### PR DESCRIPTION
include  `<string>` before PAL header file on non `_WIN32`