### PR TITLE
add missing serialization layouts; disable forceserialized from some UTs

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeSerializer.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeSerializer.cpp
@@ -790,7 +790,7 @@ public:
             opStart = reader.GetIP();
             opStart; // For prefast. It can't figure out that opStart is captured in saveBlock above.
             LayoutSize layoutSize;
-            OpCodeAsmJs op = (OpCodeAsmJs)reader.ReadOp(layoutSize);
+            OpCodeAsmJs op = reader.ReadAsmJsOp(layoutSize);
             if (op == OpCodeAsmJs::EndOfBlock)
             {
                 saveBlock();
@@ -868,13 +868,18 @@ public:
                 DEFAULT_LAYOUT_WITH_ONEBYTE(Float32x4_2);
                 DEFAULT_LAYOUT_WITH_ONEBYTE(Float32x4_3);
                 DEFAULT_LAYOUT_WITH_ONEBYTE(Float32x4_4);
-                DEFAULT_LAYOUT_WITH_ONEBYTE(Bool32x4_1Float32x4_2)
-                DEFAULT_LAYOUT_WITH_ONEBYTE(Float32x4_1Bool32x4_1Float32x4_2)
+                DEFAULT_LAYOUT_WITH_ONEBYTE(Bool32x4_1Float32x4_2);
+                DEFAULT_LAYOUT_WITH_ONEBYTE(Float32x4_1Bool32x4_1Float32x4_2);
                 DEFAULT_LAYOUT_WITH_ONEBYTE(Float32x4_1Float4);
                 DEFAULT_LAYOUT_WITH_ONEBYTE(Float32x4_2Int4);
                 DEFAULT_LAYOUT_WITH_ONEBYTE(Float32x4_3Int4);
                 DEFAULT_LAYOUT_WITH_ONEBYTE(Float32x4_1Float1);
                 DEFAULT_LAYOUT_WITH_ONEBYTE(Float32x4_2Float1);
+                DEFAULT_LAYOUT_WITH_ONEBYTE(Float32x4_1Int16x8_1);
+                DEFAULT_LAYOUT_WITH_ONEBYTE(Float32x4_1Int8x16_1);
+                DEFAULT_LAYOUT_WITH_ONEBYTE(Float32x4_1Uint8x16_1);
+                DEFAULT_LAYOUT_WITH_ONEBYTE(Float32x4_1Uint32x4_1);
+                DEFAULT_LAYOUT_WITH_ONEBYTE(Float32x4_1Uint16x8_1);
                 //DEFAULT_LAYOUT_WITH_ONEBYTE(Float32x4_1Float64x2_1);
                 DEFAULT_LAYOUT_WITH_ONEBYTE(Float32x4_1Int32x4_1);
                 DEFAULT_LAYOUT_WITH_ONEBYTE(Reg1Float32x4_1);
@@ -889,6 +894,11 @@ public:
                 DEFAULT_LAYOUT_WITH_ONEBYTE(Int32x4_3Int4);
                 DEFAULT_LAYOUT_WITH_ONEBYTE(Int32x4_2Int1);
                 DEFAULT_LAYOUT_WITH_ONEBYTE(Int32x4_2Int2);
+                DEFAULT_LAYOUT_WITH_ONEBYTE(Int32x4_1Int8x16_1);
+                DEFAULT_LAYOUT_WITH_ONEBYTE(Int32x4_1Int16x8_1);
+                DEFAULT_LAYOUT_WITH_ONEBYTE(Int32x4_1Uint8x16_1);
+                DEFAULT_LAYOUT_WITH_ONEBYTE(Int32x4_1Uint16x8_1);
+                DEFAULT_LAYOUT_WITH_ONEBYTE(Int32x4_1Uint32x4_1);
                 DEFAULT_LAYOUT_WITH_ONEBYTE(Int1Int32x4_1Int1);
                 DEFAULT_LAYOUT_WITH_ONEBYTE(Float32x4_2Int1Float1);
                 DEFAULT_LAYOUT_WITH_ONEBYTE(Float1Float32x4_1Int1);
@@ -1182,6 +1192,8 @@ public:
                 DEFAULT_LAYOUT_WITH_ONEBYTE(Class);
                 DEFAULT_LAYOUT_WITH_ONEBYTE(ElementU);
                 DEFAULT_LAYOUT_WITH_ONEBYTE(ElementRootU);
+                DEFAULT_LAYOUT_WITH_ONEBYTE(ElementScopedC);
+                DEFAULT_LAYOUT_WITH_ONEBYTE(ElementScopedC2);
                 DEFAULT_LAYOUT(BrProperty);
                 DEFAULT_LAYOUT(BrEnvProperty);
                 DEFAULT_LAYOUT(BrLocalProperty);

--- a/test/Array/rlexe.xml
+++ b/test/Array/rlexe.xml
@@ -18,6 +18,7 @@
       <compile-flags>-Serialized</compile-flags>
       <files>array_init2.js</files>
       <baseline>array_init2.baseline</baseline>
+      <tags>exclude_forceserialized</tags>
     </default>
   </test>
   <test>
@@ -616,7 +617,7 @@
   <test>
     <default>
       <files>CopyOnAccessArray_cache_index_overflow.js</files>
-      <tags>BugFix,require_backend</tags>
+      <tags>BugFix,require_backend,exclude_forceserialized</tags>
       <compile-flags>-force:copyonaccessarray -testtrace:CopyOnAccessArray</compile-flags>
       <baseline>CopyOnAccessArray_cache_index_overflow.baseline</baseline>
     </default>

--- a/test/Closures/rlexe.xml
+++ b/test/Closures/rlexe.xml
@@ -107,6 +107,7 @@
       <compile-flags>-Serialized</compile-flags>
       <files>invalcachedscope.js</files>
       <baseline>invalcachedscope.baseline</baseline>
+      <tags>exclude_forceserialized</tags>
     </default>
   </test>
   <test>

--- a/test/Function/rlexe.xml
+++ b/test/Function/rlexe.xml
@@ -381,7 +381,7 @@
     <default>
       <files>StackArgsWithFormals.js</files>
       <compile-flags>-mic:1 -off:simpleJit -trace:stackargformalsopt</compile-flags>
-      <tags>exclude_dynapogo,exclude_ship,exclude_fre,exclude_nonative,require_backend</tags>
+      <tags>exclude_dynapogo,exclude_ship,exclude_fre,exclude_nonative,require_backend,exclude_forceserialized</tags>
       <baseline>StackArgsWithFormals.baseline</baseline>
     </default>
   </test>

--- a/test/Optimizer/rlexe.xml
+++ b/test/Optimizer/rlexe.xml
@@ -1008,7 +1008,7 @@
       <baseline>test143.baseline</baseline>
       <compile-flags>-bgJit- -off:simpleJit -loopInterpretCount:1 -testTrace:arrayCheckHoist</compile-flags>
       <!-- ch.exe doesn't output entire baseline before exiting; -testTrace flush issue? -->
-      <tags>exclude_dynapogo,exclude_ship</tags>
+      <tags>exclude_dynapogo,exclude_ship,exclude_forceserialized</tags>
     </default>
   </test>
   <test>

--- a/test/UnifiedRegex/rlexe.xml
+++ b/test/UnifiedRegex/rlexe.xml
@@ -143,6 +143,7 @@
       <compile-flags>-Serialized</compile-flags>
       <files>propertyString.js</files>
       <baseline>propertyString.baseline</baseline>
+      <tags>exclude_forceserialized</tags>
     </default>
   </test>
   <test>

--- a/test/es5/rlexe.xml
+++ b/test/es5/rlexe.xml
@@ -159,6 +159,7 @@
       <compile-flags>-Serialized</compile-flags>
       <files>defineProperty.js</files>
       <baseline>defineProperty.baseline</baseline>
+      <tags>exclude_forceserialized</tags>
     </default>
   </test>
   <test>
@@ -172,6 +173,7 @@
       <compile-flags>-Serialized</compile-flags>
       <files>defineIndexProperty.js</files>
       <baseline>defineIndexProperty.baseline</baseline>
+      <tags>exclude_forceserialized</tags>
     </default>
   </test>
   <test>

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -821,7 +821,7 @@
     <default>
       <files>generators-deferred.js</files>
       <compile-flags>-ES6Generators -JitES6Generators -ES6Classes -serialized</compile-flags>
-      <tags>exclude_arm</tags>
+      <tags>exclude_arm,exclude_forceserialized</tags>
     </default>
   </test>
   <test>

--- a/test/fieldopts/rlexe.xml
+++ b/test/fieldopts/rlexe.xml
@@ -203,7 +203,7 @@
       <files>fieldhoist_negzero.js</files>
       <compile-flags>-force:fieldhoist -Serialized</compile-flags>
       <baseline>fieldhoist_negzero.baseline</baseline>
-      <tags>exclude_ship</tags>
+      <tags>exclude_ship,exclude_forceserialized</tags>
     </default>
   </test>
   <test>

--- a/test/runtests.cmd
+++ b/test/runtests.cmd
@@ -431,17 +431,17 @@ goto :main
   )
   if "%_TESTCONFIG%"=="forceserialized" (
     set EXTRA_CC_FLAGS=%EXTRA_CC_FLAGS% -forceserialized
-    set EXTRA_RL_FLAGS=
+    set EXTRA_RL_FLAGS=-nottags:exclude_forceserialized
     set _exclude_serialized=-nottags:exclude_serialized
   )
   if "%_TESTCONFIG%"=="mediumlayout" (
     set EXTRA_CC_FLAGS=%EXTRA_CC_FLAGS% -MediumByteCodeLayout -forceserialized
-    set EXTRA_RL_FLAGS=-nottags:exclude_bytecodelayout
+    set EXTRA_RL_FLAGS=-nottags:exclude_bytecodelayout -nottags:exclude_forceserialized
     set _exclude_serialized=-nottags:exclude_serialized
   )
   if "%_TESTCONFIG%"=="largelayout" (
     set EXTRA_CC_FLAGS=%EXTRA_CC_FLAGS% -LargeByteCodeLayout -forceserialized
-    set EXTRA_RL_FLAGS=-nottags:exclude_bytecodelayout
+    set EXTRA_RL_FLAGS=-nottags:exclude_bytecodelayout -nottags:exclude_forceserialized
     set _exclude_serialized=-nottags:exclude_serialized
   )
 

--- a/test/strict/rlexe.xml
+++ b/test/strict/rlexe.xml
@@ -247,6 +247,7 @@
       <files>05.arguments.js</files>
       <baseline>05.arguments_sm.baseline</baseline>
       <compile-flags>-Serialized -ForceStrictMode</compile-flags>
+      <tags>exclude_forceserialized</tags>
     </default>
   </test>
   <test>
@@ -268,6 +269,7 @@
       <files>05.arguments_sm.js</files>
       <baseline>05.arguments_sm.baseline</baseline>
       <compile-flags>-Serialized</compile-flags>
+      <tags>exclude_forceserialized</tags>
     </default>
   </test>
   <test>


### PR DESCRIPTION
There were some bytecode layouts missing serialization code. This change adds them.

Additionally, there are some unittests which give different output when -forceserialized flag is used, so I have disabled them for these configurations. These were all files which already had -serialized flag or a -trace flag.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/1323)
<!-- Reviewable:end -->
