### PR TITLE
Fix for preventing copy-prop of foo.arguments to support the creation of arguments object during each access.

### DIFF
--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -5690,6 +5690,13 @@ GlobOpt::OptSrc(IR::Opnd *opnd, IR::Instr * *pInstr, Value **indirIndexValRef, I
         }
         originalPropertySym = sym->AsPropertySym();
 
+        //Don't copy-prop for cases like foo.arguments
+        //We need new copies of the arguments object for accesses like foo.arguments - So copy-proping is not allowed.
+        if (instr->m_opcode == Js::OpCode::LdFld && originalPropertySym->m_propertyId == Js::PropertyIds::arguments)
+        {
+            return nullptr;
+        }
+
         Value *const objectValue = FindValue(originalPropertySym->m_stackSym);
         opnd->AsSymOpnd()->SetPropertyOwnerValueType(
             objectValue ? objectValue->GetValueInfo()->Type() : ValueType::Uninitialized);

--- a/lib/Backend/Opnd.h
+++ b/lib/Backend/Opnd.h
@@ -822,14 +822,6 @@ public:
         this->isTypeCheckSeqCandidate = value;
     }
 
-    void SetTypeCheckSeqCandidateIfObjTypeSpecCandidate()
-    {
-        if (IsObjTypeSpecCandidate())
-        {
-            this->isTypeCheckSeqCandidate = true;
-        }
-    }
-
     bool IsTypeCheckOnly() const
     {
         return this->isTypeCheckOnly;

--- a/lib/Runtime/Language/ProfilingHelpers.cpp
+++ b/lib/Runtime/Language/ProfilingHelpers.cpp
@@ -861,12 +861,6 @@ namespace Js
                 }
             }
 
-            if (propertyId == Js::PropertyIds::arguments)
-            {
-                fldInfoFlags = DynamicProfileInfo::MergeFldInfoFlags(fldInfoFlags, FldInfo_FromAccessor);
-                scriptContext->GetThreadContext()->AddImplicitCallFlags(ImplicitCall_Accessor);
-            }
-
             if (!Root && operationInfo.isPolymorphic)
             {
                 fldInfoFlags = DynamicProfileInfo::MergeFldInfoFlags(fldInfoFlags, FldInfo_Polymorphic);


### PR DESCRIPTION
Premise:
foo.arguments should get a new copy of the arguments object everytime it is accessed (this change was in effect from my recent Stack Args change).
We were doing this right only when the instruction is profiled - by adding a ImplicitAccessor flag in the fldInfoFlags.
But this doesn't cover the cases where the instruction is not profiled (as in cases equivalent to forcenative or forcejitloopbody).
The property sym for arguments fld can be copy proped to the subsequent uses of it, which is wrong.

Fix:
Added a direct check in the OptSrc to detect this case and to disable copy prop for this field.

Test: 
Will do a quick perf test and will start other tests.
