### PR TITLE
cross-platform: use ICU libs from target --icu path instead

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,26 @@ function(clr_unknown_arch)
     endif()
 endfunction()
 
+if(ICU_INCLUDE_PATH)
+  set(ICU_CC_PATH "${ICU_INCLUDE_PATH}/../lib/")
+  find_library(ICUUC icuuc PATHS ${ICU_CC_PATH} NO_DEFAULT_PATH)
+  find_library(ICU18 icui18n PATHS ${ICU_CC_PATH} NO_DEFAULT_PATH)
+  find_library(ICUDATA icudata PATHS ${ICU_CC_PATH} NO_DEFAULT_PATH)
+  if(ICUUC)
+    message("found libraries on ${ICU_CC_PATH}")
+    set(ICULIB
+      ${ICUUC}
+      ${ICU18}
+      ${ICUDATA}
+      )
+  endif()
+endif()
+
 if(CMAKE_SYSTEM_NAME STREQUAL Linux)
+    if(NOT ICULIB)
+      set(ICULIB "icuuc")
+    endif()
+
     set(CLR_CMAKE_PLATFORM_UNIX 1)
     if(CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64)
         set(CLR_CMAKE_PLATFORM_UNIX_TARGET_AMD64 1)
@@ -21,8 +40,15 @@ if(CMAKE_SYSTEM_NAME STREQUAL Linux)
 elseif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
     add_definitions(
         -DPLATFORM_UNIX
-        -DU_DISABLE_RENAMING=1 #in case we link against to an older binary of icu
     )
+
+    if(NOT ICULIB)
+      set(ICULIB "icucore")
+      add_definitions(
+        -DU_DISABLE_RENAMING=1 #in case we link against to an older binary of icu
+        )
+      message("using ICU from system default: ${ICULIB}")
+    endif()
 
     set(CLR_CMAKE_PLATFORM_UNIX 1)
     if(CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64)

--- a/bin/ChakraCore/CMakeLists.txt
+++ b/bin/ChakraCore/CMakeLists.txt
@@ -3,7 +3,7 @@ add_library (ChakraCore SHARED
   ConfigParserExternals.cpp
   TestHooks.cpp
 )
-  
+
 target_include_directories (
   ChakraCore PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}
@@ -45,17 +45,8 @@ set(lib_target "${lib_target}"
   pthread
   stdc++
   dl
+  ${ICULIB}
   )
-
-if(CMAKE_SYSTEM_NAME STREQUAL Linux)
-  set(lib_target "${lib_target}"
-    icuuc
-    )
-elseif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
-  set(lib_target "${lib_target}"
-    icucore
-    )
-endif() # Linux ?
 
 if(CMAKE_SYSTEM_NAME STREQUAL Linux)
   set(lib_target "${lib_target}"
@@ -72,7 +63,7 @@ if(NOT CC_XCODE_PROJECT)
   if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
     set(CC_LIB_EXT "dylib")
   endif()
-  
+
   add_custom_command(TARGET ChakraCore POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
     "${CHAKRACORE_BINARY_DIR}/bin/ChakraCore/libChakraCore.${CC_LIB_EXT}"

--- a/bin/ch/CMakeLists.txt
+++ b/bin/ch/CMakeLists.txt
@@ -59,12 +59,12 @@ if(STATIC_LIBRARY)
 
   if(CMAKE_SYSTEM_NAME STREQUAL Linux)
     set(lib_target "${lib_target}"
-      icuuc
+      ${ICULIB}
       unwind-x86_64
       )
   elseif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
     set(lib_target "${lib_target}"
-      icucore
+      ${ICULIB}
       "-framework CoreFoundation"
       "-framework Security"
       # set stack size to 64Mb for stack tests


### PR DESCRIPTION
Searches for the libs from custom ICU path