### PR TITLE
cross platform: enable release binary basic testing

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -133,8 +133,6 @@ def CreateXPlatBuildTasks = { machine, platform, configTag, xplatBranch, nonDefa
                 // params: Project, BaseTaskName, IsPullRequest (appends '_prtest')
                 def jobName = Utilities.getFullJobName(project, config, isPR)
 
-                def testableConfig = buildType in ['debug', 'test']
-
                 def infoScript = "bash jenkins/get_system_info.sh --${platform}"
                 def buildFlag = buildType == "release" ? "" : (buildType == "debug" ? "--debug" : "--test-build")
                 def staticFlag = staticBuild ? "--static" : ""
@@ -147,9 +145,7 @@ def CreateXPlatBuildTasks = { machine, platform, configTag, xplatBranch, nonDefa
                     steps {
                         shell(infoScript)
                         shell(buildScript)
-                        if (testableConfig) {
-                            shell(testScript)
-                        }
+                        shell(testScript)
                     }
                 }
 

--- a/test/runtests.sh
+++ b/test/runtests.sh
@@ -19,6 +19,20 @@ if [[ $build_type != "-d" && $build_type != "-t" ]]; then
     elif [[ -f "$test_path/../BuildLinux/Test/ch" ]]; then
         echo "Warning: Test build was found"
         build_type="-t"
+    elif [[ -f "$test_path/../BuildLinux/Release/ch" ]]; then
+        # TEST flags are not enabled for release build
+        # however we would like to test if the compiled binary
+        # works or not
+        CH="$test_path/../BuildLinux/Release/ch"
+        echo "Warning: Release build was found"
+        RES=$(${CH} $test_path/test/basics/hello.js)
+        if [[ $RES =~ "Error :" ]]; then
+            echo "FAILED"
+            exit 1
+        else
+            echo "PASS"
+            exit 0
+        fi
     else
         echo 'Error: ch not found- exiting'
         exit 1
@@ -29,5 +43,3 @@ fi
 if [[ $? != 0 ]]; then
     exit 1
 fi
-
-


### PR DESCRIPTION
current xplat release binary was broken and CI could not detect that
This PR enables very basic testing to make sure the compiled binary is functioning

/cc @dilijev @digitalinfinity @jianchun 