### PR TITLE
Fix missing capture dest reg for bailout

### DIFF
--- a/lib/Backend/GlobOpt.h
+++ b/lib/Backend/GlobOpt.h
@@ -955,6 +955,7 @@ public:
         capturedValuesCandidate(nullptr),
         capturedValues(nullptr),
         changedSyms(nullptr),
+        changedSymsAfterIncBailoutCandidate(nullptr),
         hasCSECandidates(false),
         curFunc(func),
         hasDataRef(nullptr),
@@ -1008,6 +1009,7 @@ public:
     CapturedValues *                        capturedValuesCandidate;
     CapturedValues *                        capturedValues;
     BVSparse<JitArenaAllocator> *           changedSyms;
+    BVSparse<JitArenaAllocator> *           changedSymsAfterIncBailoutCandidate;
 
     uint                                    inlinedArgOutCount;
 
@@ -1384,6 +1386,7 @@ private:
     StackSym *              GetOrCreateTaggedIntConstantStackSym(const int32 intConstantValue) const;
     Sym *                   SetSymStore(ValueInfo *valueInfo, Sym *sym);
     void                    SetSymStoreDirect(ValueInfo *valueInfo, Sym *sym);
+    void                    SetChangedSym(SymID symId);
     Value *                 InsertNewValue(Value *val, IR::Opnd *opnd);
     Value *                 InsertNewValue(GlobOptBlockData * blockData, Value *val, IR::Opnd *opnd);
     Value *                 SetValue(GlobOptBlockData * blockData, Value *val, IR::Opnd *opnd);

--- a/lib/Backend/GlobOptBailOut.cpp
+++ b/lib/Backend/GlobOptBailOut.cpp
@@ -251,6 +251,9 @@ GlobOpt::CaptureValues(BasicBlock *block, BailOutInfo * bailOutInfo)
     {
         // cache the pointer of current bailout as potential baseline for later bailout in this block
         block->globOptData.capturedValuesCandidate = &bailOutInfo->capturedValues;
+
+        // reset changed syms to track symbols change after the above captured values candidate
+        block->globOptData.changedSymsAfterIncBailoutCandidate->ClearAll();
     }
 }
 
@@ -958,7 +961,7 @@ GlobOpt::FillBailOutInfo(BasicBlock *block, BailOutInfo * bailOutInfo)
                     sym = opnd->GetStackSym();
                     Assert(FindValue(sym));
                     // StackSym args need to be re-captured
-                    this->blockData.changedSyms->Set(sym->m_id);
+                    this->SetChangedSym(sym->m_id);
                 }
 
                 Assert(totalOutParamCount != 0);


### PR DESCRIPTION
When tracking symbols for capturing bailout values incrementally, the dest register for the current instruction might be ignored because the set of changed symbols is cleaned up at the end of OptInstr. The fix captures all the symbols changed after bailout value capture and restore them to changed symbols set when attaching capture values to bailout finally.