### PR TITLE
Fix missing capture dest reg for bailout

### DIFF
--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -5176,9 +5176,16 @@ GlobOpt::OptInstr(IR::Instr *&instr, bool* isInstrRemoved)
     {
         GlobOptBlockData * globOptData = &this->currentBlock->globOptData;
         globOptData->changedSyms->ClearAll();
-        globOptData->changedSyms->Or(this->changedSymsAfterIncBailoutCandidate);
 
-        this->changedSymsAfterIncBailoutCandidate->ClearAll();
+        if (!this->changedSymsAfterIncBailoutCandidate->IsEmpty())
+        {
+            // swap changedSyms and changedSymsAfterIncBailoutCandidate
+            // because both are from this->alloc
+            BVSparse<JitArenaAllocator> * tempBvSwap = globOptData->changedSyms;
+            globOptData->changedSyms = this->changedSymsAfterIncBailoutCandidate;
+            this->changedSymsAfterIncBailoutCandidate = tempBvSwap;
+        }
+
         globOptData->capturedValues = globOptData->capturedValuesCandidate;
 
         // null out capturedValuesCandicate to stop tracking symbols change for it

--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -532,7 +532,7 @@ GlobOpt::ForwardPass()
     // Make sure we free most of them.
     Assert(freedCount >= spilledCount);
 
-    JitAdelete(alloc, this->changedSymsAfterIncBailoutCandidate);
+    // this->alloc will be freed right after return, no need to free it here
     this->changedSymsAfterIncBailoutCandidate = nullptr;
 
     END_CODEGEN_PHASE(this->func, Js::ForwardPhase);
@@ -5179,6 +5179,13 @@ GlobOpt::OptInstr(IR::Instr *&instr, bool* isInstrRemoved)
 
         if (!this->changedSymsAfterIncBailoutCandidate->IsEmpty())
         {
+            //
+            // some symbols are changed after the values for current bailout have been
+            // captured (GlobOpt::CapturedValues), need to restore such symbols as changed
+            // for following incremental bailout construction, or we will miss capturing
+            // values for later bailout
+            //
+
             // swap changedSyms and changedSymsAfterIncBailoutCandidate
             // because both are from this->alloc
             BVSparse<JitArenaAllocator> * tempBvSwap = globOptData->changedSyms;

--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -7220,6 +7220,9 @@ GlobOpt::SetSymStoreDirect(ValueInfo * valueInfo, Sym * sym)
 void
 GlobOpt::SetChangedSym(SymID symId)
 {
+    // this->currentBlock might not be the one which contain the changing symId,
+    // like hoisting invariant, but more changed symId is overly conservative and safe.
+    // symId in the hoisted to block is marked as JITOptimizedReg so it does't affect bailout.
     GlobOptBlockData * globOptData = &this->currentBlock->globOptData;
     if (globOptData->changedSyms)
     {

--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -7220,25 +7220,18 @@ GlobOpt::SetSymStoreDirect(ValueInfo * valueInfo, Sym * sym)
 void
 GlobOpt::SetChangedSym(SymID symId)
 {
-    GlobOptBlockData * globOptData = nullptr;
-    if (this->currentBlock->globOptData.changedSyms)
+    GlobOptBlockData * globOptData = &this->currentBlock->globOptData;
+    if (globOptData->changedSyms)
     {
         globOptData = &this->currentBlock->globOptData;
-    }
-    else
-    {
-        Assert(this->blockData.changedSyms != nullptr);
 
-        // blockData has not been copied to globOptData yet, use blockData
-        // to store the changed syms which will be copied to globOptData later
-        globOptData = &this->blockData;
+        globOptData->changedSyms->Set(symId);
+        if (globOptData->capturedValuesCandidate != nullptr)
+        {
+            this->changedSymsAfterIncBailoutCandidate->Set(symId);
+        }
     }
-
-    globOptData->changedSyms->Set(symId);
-    if (globOptData->capturedValuesCandidate != nullptr)
-    {
-        this->changedSymsAfterIncBailoutCandidate->Set(symId);
-    }
+    // else could be hit only in MergeValues and it is handled by MergeCapturedValues
 }
 
 void

--- a/lib/Backend/GlobOpt.h
+++ b/lib/Backend/GlobOpt.h
@@ -955,6 +955,7 @@ public:
         capturedValuesCandidate(nullptr),
         capturedValues(nullptr),
         changedSyms(nullptr),
+        changedSymsAfterIncBailoutCandidate(nullptr),
         hasCSECandidates(false),
         curFunc(func),
         hasDataRef(nullptr),
@@ -1008,6 +1009,7 @@ public:
     CapturedValues *                        capturedValuesCandidate;
     CapturedValues *                        capturedValues;
     BVSparse<JitArenaAllocator> *           changedSyms;
+    BVSparse<JitArenaAllocator> *           changedSymsAfterIncBailoutCandidate;
 
     uint                                    inlinedArgOutCount;
 
@@ -1384,6 +1386,7 @@ private:
     StackSym *              GetOrCreateTaggedIntConstantStackSym(const int32 intConstantValue) const;
     Sym *                   SetSymStore(ValueInfo *valueInfo, Sym *sym);
     void                    SetSymStoreDirect(ValueInfo *valueInfo, Sym *sym);
+    void                    SetChangedSym(SymID symId);
     Value *                 InsertNewValue(Value *val, IR::Opnd *opnd);
     Value *                 InsertNewValue(GlobOptBlockData * blockData, Value *val, IR::Opnd *opnd);
     Value *                 SetValue(GlobOptBlockData * blockData, Value *val, IR::Opnd *opnd);

--- a/lib/Backend/GlobOpt.h
+++ b/lib/Backend/GlobOpt.h
@@ -955,7 +955,6 @@ public:
         capturedValuesCandidate(nullptr),
         capturedValues(nullptr),
         changedSyms(nullptr),
-        changedSymsAfterIncBailoutCandidate(nullptr),
         hasCSECandidates(false),
         curFunc(func),
         hasDataRef(nullptr),
@@ -1009,7 +1008,6 @@ public:
     CapturedValues *                        capturedValuesCandidate;
     CapturedValues *                        capturedValues;
     BVSparse<JitArenaAllocator> *           changedSyms;
-    BVSparse<JitArenaAllocator> *           changedSymsAfterIncBailoutCandidate;
 
     uint                                    inlinedArgOutCount;
 
@@ -1213,6 +1211,8 @@ private:
     BVSparse<JitArenaAllocator> *  callerEquivBv;
 
     GlobOptBlockData            blockData;
+
+    BVSparse<JitArenaAllocator> *   changedSymsAfterIncBailoutCandidate;
 
     JitArenaAllocator *             alloc;
     JitArenaAllocator *             tempAlloc;

--- a/lib/Backend/GlobOptBailOut.cpp
+++ b/lib/Backend/GlobOptBailOut.cpp
@@ -253,7 +253,7 @@ GlobOpt::CaptureValues(BasicBlock *block, BailOutInfo * bailOutInfo)
         block->globOptData.capturedValuesCandidate = &bailOutInfo->capturedValues;
 
         // reset changed syms to track symbols change after the above captured values candidate
-        block->globOptData.changedSymsAfterIncBailoutCandidate->ClearAll();
+        this->changedSymsAfterIncBailoutCandidate->ClearAll();
     }
 }
 

--- a/lib/Backend/GlobOptBailOut.cpp
+++ b/lib/Backend/GlobOptBailOut.cpp
@@ -251,6 +251,9 @@ GlobOpt::CaptureValues(BasicBlock *block, BailOutInfo * bailOutInfo)
     {
         // cache the pointer of current bailout as potential baseline for later bailout in this block
         block->globOptData.capturedValuesCandidate = &bailOutInfo->capturedValues;
+
+        // reset changed syms to track symbols change after the above captured values candidate
+        block->globOptData.changedSymsAfterIncBailoutCandidate->ClearAll();
     }
 }
 
@@ -958,7 +961,7 @@ GlobOpt::FillBailOutInfo(BasicBlock *block, BailOutInfo * bailOutInfo)
                     sym = opnd->GetStackSym();
                     Assert(FindValue(sym));
                     // StackSym args need to be re-captured
-                    this->blockData.changedSyms->Set(sym->m_id);
+                    this->SetChangedSym(sym->m_id);
                 }
 
                 Assert(totalOutParamCount != 0);


### PR DESCRIPTION
When tracking symbols for capturing bailout values incrementally, the dest register for the current instruction might be ignored because the set of changed symbols is cleaned up at the end of OptInstr. The fix captures all the symbols changed after bailout value capture and restore them to changed symbols set when attaching capture values to bailout finally.