### PR TITLE
Statically link C++ Runtime into ChakraCore.dll.

### DIFF
--- a/Build/Chakra.Build.Default.props
+++ b/Build/Chakra.Build.Default.props
@@ -7,5 +7,8 @@
     <!-- Always use Platform SDK for core builds -->
     <EventManifestXmlPath>$(WindowsSDK80Path)Include\um</EventManifestXmlPath>
 
+    <!-- Unless indicated otherwise, statically link the C++ Runtime into ChakraCore.dll -->
+    <RuntimeLib Condition="'$(RuntimeLib)'==''">static_library</RuntimeLib>
+
   </PropertyGroup>
 </Project>

--- a/bin/ch/WScriptJsrt.cpp
+++ b/bin/ch/WScriptJsrt.cpp
@@ -65,6 +65,7 @@ JsValueRef __stdcall WScriptJsrt::EchoCallback(JsValueRef callee, bool isConstru
     }
 
     wprintf(L"\n");
+    fflush(stdout);
 
     JsValueRef undefinedValue;
     if (ChakraRTInterface::JsGetUndefinedValue(&undefinedValue) == JsNoError)

--- a/lib/Common/Core/Output.cpp
+++ b/lib/Common/Core/Output.cpp
@@ -52,6 +52,7 @@ Output::VerboseNote(const char16 * format, ...)
         va_list argptr;
         va_start(argptr, format);
         size_t size = vfwprintf(stdout, format, argptr);
+        fflush(stdout);
         va_end(argptr);
         return size;
     }
@@ -344,10 +345,7 @@ Output::PrintBuffer(const char16 * buf, size_t size)
         }
     }
 
-    if (IsDebuggerPresent())
-    {
-        Output::Flush();
-    }
+    Output::Flush();
 
     return size;
 }


### PR DESCRIPTION
(Request from TypeScript team.)

This enables us to support running applications developed against
ChakraCore.dll even if the C++ Runtime is not installed on the machine.

Add this to Build/Chakra.Build.Default.props to set the flag for the entire
build. If the user wishes to dynamically link the C++ Runtime, build with e.g.

msbuild ... "/p:RuntimeLib=dynamic_library"

(or any other value for RuntimeLib) to disable the static linking.

Confirmed that ch.exe is now able to run a hello.js file on a machine without
the C++ Runtime installed. (Dynamically linked ChakraCore.dll fails on the same
machine complaining of missing DLLs.)

Note:
* Increases x64_debug ChakraCore.dll size by about 1MB.
* Increases x64_release ChakraCore.dll size by about 100KB.
* Increases x64_release_pogo ChakraCore.dll size by about 150KB.
