### PR TITLE
Only add defined properties to the result of getOwnPropertyDescriptors

### DIFF
--- a/lib/Runtime/Library/JavascriptObject.cpp
+++ b/lib/Runtime/Library/JavascriptObject.cpp
@@ -1006,7 +1006,10 @@ namespace Js
             JavascriptConversion::ToPropertyKey(propKey, scriptContext, &propertyRecord);
 
             Var newDescriptor = JavascriptObject::GetOwnPropertyDescriptorHelper(obj, propKey, scriptContext);
-            resultObj->SetProperty(propertyRecord->GetPropertyId(), newDescriptor, PropertyOperation_None, nullptr);
+            if (!JavascriptOperators::IsUndefined(newDescriptor))
+            {
+                resultObj->SetProperty(propertyRecord->GetPropertyId(), newDescriptor, PropertyOperation_None, nullptr);
+            }
         }
 
         return resultObj;

--- a/test/Object/getOwnPropertyDescriptors.js
+++ b/test/Object/getOwnPropertyDescriptors.js
@@ -153,7 +153,29 @@ var tests = [
 
             verifyObjectDescriptors(desc, allTrueSymbol, allFalseSymbol);
         }
-    }
+    },
+    {
+        name:"For any property, if getOwnPropertyDescriptor(property) is undefined, that property should not be present on the result.",
+        body: function() {
+            // Adapted from: https://github.com/ljharb/test262/blob/c2eaa30b08fb1e041b7297e415b6bad8461f50dc/test/built-ins/Object/getOwnPropertyDescriptors/proxy-undefined-descriptor.js
+            var proxyHandler = {
+              getOwnPropertyDescriptor: function () {},
+            };
+
+            var key = "a";
+            var obj = {};
+            obj[key] = "value";
+
+            var proxy = new Proxy(obj, proxyHandler);
+
+            var descriptor = Object.getOwnPropertyDescriptor(proxy, key);
+            assert.areEqual(undefined, descriptor, "Descriptor matches result of [[GetOwnPropertyDescriptor]] trap");
+
+            var result = Object.getOwnPropertyDescriptors(proxy);
+            assert.isFalse(result.hasOwnProperty(key), "key should not be present in result");
+
+        }
+    },
 ]
 
 testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });


### PR DESCRIPTION
Fixes #1342 

For the tests for this change, I adapted @ljharb's tests from the discussion he linked to in the issue and trimmed it down to test just this change. 