### PR TITLE
avoid ch ENABLE_TEST_HOOKS def side effect

### DIFF
--- a/bin/ch/stdafx.h
+++ b/bin/ch/stdafx.h
@@ -23,7 +23,6 @@
 
 #define WIN32_LEAN_AND_MEAN 1
 
-#define ENABLE_TEST_HOOKS 1
 #include "CommonDefines.h"
 #include <map>
 #include <string>
@@ -137,6 +136,9 @@ do { \
     } \
 } while (0)
 
+#ifndef ENABLE_TEST_HOOKS
+#define ENABLE_TEST_HOOKS
+#endif
 #include "TestHooks.h"
 #include "ChakraRtInterface.h"
 #include "HostConfigFlags.h"

--- a/lib/Common/CommonDefines.h
+++ b/lib/Common/CommonDefines.h
@@ -27,7 +27,6 @@
 #ifdef ENABLE_TEST_HOOKS
 #ifndef ENABLE_DEBUG_CONFIG_OPTIONS
 #define ENABLE_DEBUG_CONFIG_OPTIONS 1
-#define DEBUG_CONFIG_OPTIONS_WERE_DISABLED
 #endif
 #endif
 
@@ -313,10 +312,9 @@
 #define ENABLE_TEST_HOOKS
 #endif
 
-#if !defined(DEBUG_CONFIG_OPTIONS_WERE_DISABLED) || defined(DEBUG)
+////////
 //Time Travel flags
 #define ENABLE_TTD 1
-#endif
 
 #if ENABLE_TTD
 //Enable debugging specific aspects of TTD


### PR DESCRIPTION
Move down ch's ENABLE_TEST_HOOKS def after CommonDefines.h, so that it
does not accidentally turn on ENABLE_DEBUG_CONFIG_OPTIONS for release
build type.
