### PR TITLE
Disable assignment of local registers to delay-captured vars

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -1389,7 +1389,7 @@ void ByteCodeGenerator::DefineUserVars(FuncInfo *funcInfo)
 
                     // Undef-initialize the home location if it is a register (not closure-captured, or else capture
                     // is delayed) or a property of an object.
-                    if ((sym->GetLocation() != Js::Constants::NoRegister && (!sym->GetHasInit() || (sym->NeedsSlotAlloc(funcInfo) && sym->GetHasNonCommittedReference()))) ||
+                    if ((!sym->GetHasInit() && !sym->IsInSlot(funcInfo)) ||
                         (funcInfo->bodyScope->GetIsObject() && !funcInfo->GetHasCachedScope()))
                     {
                         Js::RegSlot reg = sym->GetLocation();

--- a/lib/Runtime/ByteCode/Symbol.cpp
+++ b/lib/Runtime/ByteCode/Symbol.cpp
@@ -93,6 +93,10 @@ bool Symbol::IsInSlot(FuncInfo *funcInfo, bool ensureSlotAlloc)
 
 bool Symbol::GetIsCommittedToSlot() const
 {
+    if (!PHASE_ON1(Js::DelayCapturePhase))
+    {
+        return true;
+    }
     return isCommittedToSlot || this->scope->GetFunc()->GetCallsEval() || this->scope->GetFunc()->GetChildCallsEval();
 }
 


### PR DESCRIPTION
Delay-capture optimization has been effectively disabled by the stable closures change, and assigning local registers to captured vars (as delay-capture needs to do) is causing persistent functional issues. Blocking the assignment of registers in such cases by default to stop the flow of such issues altogether (and restoring the original simple related logic in DefineUserVars). The harder work of re-enabling delay-capture will follow.