### PR TITLE
Avoid calling ::pow(double, int) in CRT which has a imprecision bug

### DIFF
--- a/lib/Runtime/Library/JavascriptNumber.cpp
+++ b/lib/Runtime/Library/JavascriptNumber.cpp
@@ -220,7 +220,8 @@ namespace Js
             }
         }
 
-        return ::pow(x, y);
+        // always call pow(double, double) in C runtime which has a bug to process pow(double, int).
+        return ::pow(x, static_cast<double>(y));
     }
 
 #if _M_IX86


### PR DESCRIPTION
::pow(double, int) causes significant imprecision for exponents which is not very small. This is fixed in Visual Studio 2015 update 2 but haven't reached us. No side effect of avoid calling it since we optimize integer exponent in our side.