### PR TITLE
Let named function expression be eligible for IIFE heuristic

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -4795,8 +4795,7 @@ bool Parser::ParseFncDeclHelper(ParseNodePtr pnodeFnc, LPCOLESTR pNameHint, usho
     bool parallelJobStarted = false;
     if (buildAST)
     {
-        bool isLikelyModulePattern =
-            !fDeclaration && pnodeFnc && pnodeFnc->sxFnc.pnodeName == nullptr && fUnaryOrParen;
+        bool isLikelyIIFE = !fDeclaration && pnodeFnc && fUnaryOrParen;
 
         BOOL isDeferredFnc = IsDeferredFnc();
         AnalysisAssert(isDeferredFnc || pnodeFnc);
@@ -4806,7 +4805,7 @@ bool Parser::ParseFncDeclHelper(ParseNodePtr pnodeFnc, LPCOLESTR pNameHint, usho
              && (!pnodeFnc->sxFnc.IsNested() || CONFIG_FLAG(DeferNested))
             // Don't defer if this is a function expression not contained in a statement or other expression.
             // Assume it will be called as part of this expression.
-             && (!isLikelyModulePattern || !topLevelStmt || PHASE_FORCE_RAW(Js::DeferParsePhase, m_sourceContextInfo->sourceContextId, pnodeFnc->sxFnc.functionId))
+             && (!isLikelyIIFE || !topLevelStmt || PHASE_FORCE_RAW(Js::DeferParsePhase, m_sourceContextInfo->sourceContextId, pnodeFnc->sxFnc.functionId))
              && !m_InAsmMode
             // Don't defer a module function wrapper because we need to do export resolution at parse time
              && !fModule
@@ -4814,7 +4813,7 @@ bool Parser::ParseFncDeclHelper(ParseNodePtr pnodeFnc, LPCOLESTR pNameHint, usho
 
         if (!fLambda &&
             !isDeferredFnc &&
-            !isLikelyModulePattern &&
+            !isLikelyIIFE &&
             !this->IsBackgroundParser() &&
             !this->m_doingFastScan &&
             !(pnodeFncSave && m_currDeferredStub) &&


### PR DESCRIPTION
Trivial change to our deferred-parsing heuristic for detecting IIFE's: also treat a function expression as an IIFE if it has a name, provided it is preceded by a unary operator or parenthesis. The name consideration dates from legacy mode, in which a function expression's name could be referred to outside the function.