### PR TITLE
Wrong memop assert

### DIFF
--- a/lib/Runtime/Library/JavascriptArray.inl
+++ b/lib/Runtime/Library/JavascriptArray.inl
@@ -843,7 +843,7 @@ SECOND_PASS:
             if (!endSeg)
             {
                 // end is beyond the length of the array
-                Assert(endIndex == this->length - 1);
+                Assert(endIndex == (current->left + current->length - 1));
                 current->next = nullptr;
             }
             else


### PR DESCRIPTION
Assert in PrepareSegmentForMemop was incorrectly using length to verify that we were at the end of the array.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/1360)
<!-- Reviewable:end -->
