### PR TITLE
MemSet incorrect copy for native float array with -1

### DIFF
--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -21446,7 +21446,7 @@ GlobOpt::EmitMemop(Loop * loop, LoopCount *loopCount, const MemOpEmitData* emitD
                 case TyInt16:
                 case TyInt32:
                 case TyInt64:
-                    _snwprintf_s(constBuf, constBufSize, sizeof(IntConstType) == 8 ? _u("lld%") : _u("%d"), candidate->constant.u.intConst.value);
+                    _snwprintf_s(constBuf, constBufSize, sizeof(IntConstType) == 8 ? _u("%lld") : _u("%d"), candidate->constant.u.intConst.value);
                     break;
                 case TyFloat32:
                 case TyFloat64:

--- a/lib/Runtime/Library/JavascriptArray.cpp
+++ b/lib/Runtime/Library/JavascriptArray.cpp
@@ -3956,6 +3956,62 @@ namespace Js
         return -1;
     }
 
+    template<typename T>
+    bool AreAllBytesEqual(T value)
+    {
+        byte* bValue = (byte*)&value;
+        byte firstByte = *bValue++;
+        for (int i = 1; i < sizeof(T); ++i)
+        {
+            if (*bValue++ != firstByte)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    template<>
+    void JavascriptArray::CopyValueToSegmentBuferNoCheck(double* buffer, uint32 length, double value)
+    {
+        if (JavascriptNumber::IsZero(value) && !JavascriptNumber::IsNegZero(value))
+        {
+            memset(buffer, 0, sizeof(double) * length);
+        }
+        else
+        {
+            for (uint32 i = 0; i < length; i++)
+            {
+                buffer[i] = value;
+            }
+        }
+    }
+
+    template<>
+    void JavascriptArray::CopyValueToSegmentBuferNoCheck(int32* buffer, uint32 length, int32 value)
+    {
+        if (value == 0 || AreAllBytesEqual(value))
+        {
+            memset(buffer, *(byte*)&value, sizeof(int32)* length);
+        }
+        else
+        {
+            for (uint32 i = 0; i < length; i++)
+            {
+                buffer[i] = value;
+            }
+        }
+    }
+
+    template<>
+    void JavascriptArray::CopyValueToSegmentBuferNoCheck(Js::Var* buffer, uint32 length, Js::Var value)
+    {
+        for (uint32 i = 0; i < length; i++)
+        {
+            buffer[i] = value;
+        }
+    }
+
     int32 JavascriptNativeIntArray::HeadSegmentIndexOfHelper(Var search, uint32 &fromIndex, uint32 toIndex, bool includesAlgorithm,  ScriptContext * scriptContext)
     {
         // We proceed largely in the same manner as in JavascriptArray's version of this method (see comments there for more information),

--- a/lib/Runtime/Library/JavascriptArray.h
+++ b/lib/Runtime/Library/JavascriptArray.h
@@ -169,6 +169,7 @@ namespace Js
 #if ENABLE_PROFILE_INFO
         template<typename T> inline void DirectProfiledSetItemInHeadSegmentAt(const uint32 offset, const T newValue, StElemInfo *const stElemInfo);
 #endif
+        template<typename T> static void CopyValueToSegmentBuferNoCheck(T* buffer, uint32 length, T value);
         template<typename T> void DirectSetItem_Full(uint32 itemIndex, T newValue);
         template<typename T> SparseArraySegment<T>* PrepareSegmentForMemOp(uint32 startIndex, uint32 length);
         template<typename T> bool DirectSetItemAtRange(uint32 startIndex, uint32 length, T newValue);

--- a/lib/Runtime/Library/JavascriptArray.inl
+++ b/lib/Runtime/Library/JavascriptArray.inl
@@ -1073,17 +1073,6 @@ SECOND_PASS:
             SetHasNoMissingValues(true);
 
             CopyValueToSegmentBuferNoCheck(((Js::SparseArraySegment<T>*)current)->elements, length, newValue);
-            if (newValue == (T)0 || newValue == (T)(-1))
-            {
-                memset(((Js::SparseArraySegment<T>*)current)->elements, ((int)(intptr_t)newValue), sizeof(T)* length);
-            }
-            else
-            {
-                for (uint32 i = 0; i < length; i++)
-                {
-                    ((Js::SparseArraySegment<T>*)current)->elements[i] = newValue;
-                }
-            }
             this->SetLastUsedSegment(current);
         }
         else

--- a/lib/Runtime/Library/JavascriptArray.inl
+++ b/lib/Runtime/Library/JavascriptArray.inl
@@ -1014,6 +1014,7 @@ SECOND_PASS:
 #endif
         return true;
     }
+
     template<typename T>
     bool JavascriptArray::DirectSetItemAtRange(uint32 startIndex, uint32 length, T newValue)
     {
@@ -1033,18 +1034,7 @@ SECOND_PASS:
 
         if (startIndex == 0 && head != EmptySegment && length < head->size)
         {
-            if (newValue == (T)0 || newValue == (T)(-1))
-            {
-                memset(((Js::SparseArraySegment<T>*)head)->elements, ((int)(intptr_t)newValue), sizeof(T)* length);
-            }
-            else
-            {
-                Js::SparseArraySegment<T>* headSegment = ((Js::SparseArraySegment<T>*)head);
-                for (uint32 i = 0; i < length; i++)
-                {
-                    headSegment->elements[i] = newValue;
-                }
-            }
+            CopyValueToSegmentBuferNoCheck(((Js::SparseArraySegment<T>*)head)->elements, length, newValue);
 
             if (length > this->length)
             {
@@ -1082,6 +1072,7 @@ SECOND_PASS:
 
             SetHasNoMissingValues(true);
 
+            CopyValueToSegmentBuferNoCheck(((Js::SparseArraySegment<T>*)current)->elements, length, newValue);
             if (newValue == (T)0 || newValue == (T)(-1))
             {
                 memset(((Js::SparseArraySegment<T>*)current)->elements, ((int)(intptr_t)newValue), sizeof(T)* length);
@@ -1116,17 +1107,9 @@ SECOND_PASS:
         {
             return false;
         }
-        if (newValue == (T)0 || newValue == (T)(-1))
-        {
-            memset((((Js::SparseArraySegment<T>*)current)->elements + (startIndex - current->left)), ((int)(intptr_t)newValue), sizeof(T)* length);
-        }
-        else
-        {
-            for (uint32 i = 0; i < length; i++)
-            {
-                ((Js::SparseArraySegment<T>*)current)->elements[startIndex - current->left + i] = newValue;
-            }
-        }
+        Assert(current->left + current->length >= startIndex + length);
+        T* segmentCopyStart = current->elements + (startIndex - current->left);
+        CopyValueToSegmentBuferNoCheck(segmentCopyStart, length, newValue);
         this->SetLastUsedSegment(current);
 #if DBG
         if (Js::Configuration::Global.flags.MemOpMissingValueValidate)


### PR DESCRIPTION
We used to check if the memset value is -1 to determine if we can do a byte level memset. 
This was valid ints but not for floats. 
Changed the check to really see if the bytes are all the same.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/1361)
<!-- Reviewable:end -->
