### PR TITLE
BUG 8258993: Remove Assert that is causing many hits on the OOM path because of inconsistent finalization flags state.

### DIFF
--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -375,7 +375,6 @@ namespace Js
 
     ScriptContext::~ScriptContext()
     {
-        Assert(isFinalized || !isInitialized);
         // Take etw rundown lock on this thread context. We are going to change/destroy this scriptContext.
         AutoCriticalSection autocs(GetThreadContext()->GetEtwRundownCriticalSection());
 


### PR DESCRIPTION
Reviewed by @yongqu