### PR TITLE
Load params from registers when possible

### DIFF
--- a/lib/Backend/LinearScan.h
+++ b/lib/Backend/LinearScan.h
@@ -104,7 +104,6 @@ public:
         totalOpHelperFullVisitedLength(0), curLoop(NULL), currentBlock(nullptr), currentRegion(nullptr), m_bailOutRecordCount(0),
         globalBailOutRecordTables(nullptr), lastUpdatedRowIndices(nullptr)
     {
-        linearScanMD.Init(this);
     }
 
     void                RegAlloc();

--- a/lib/Backend/LowerMDShared.cpp
+++ b/lib/Backend/LowerMDShared.cpp
@@ -7979,7 +7979,7 @@ LowererMD::GetImplicitParamSlotSym(Js::ArgSlot argSlot, Func * func)
     // Stack looks like (EBP chain)+0, (return addr)+4, (function object)+8, (arg count)+12, (this)+16, actual args
     // Pass in the EBP+8 to start at the function object, the start of the implicit param slots
 
-    StackSym * stackSym = StackSym::NewParamSlotSym(argSlot, func);
+    StackSym * stackSym = StackSym::NewImplicitParamSym(argSlot, func);
     func->SetArgOffset(stackSym, (2 + argSlot) * MachPtr);
     func->SetHasImplicitParamLoad();
     return stackSym;

--- a/lib/Backend/SccLiveness.cpp
+++ b/lib/Backend/SccLiveness.cpp
@@ -374,6 +374,39 @@ SCCLiveness::ProcessSrc(IR::Opnd *src, IR::Instr *instr)
             }
         }
     }
+    else if (!this->lastCall && src->IsSymOpnd() && src->AsSymOpnd()->m_sym->AsStackSym()->IsParamSlotSym())
+    {
+		IR::SymOpnd *symOpnd = src->AsSymOpnd();
+		RegNum reg = LinearScanMD::GetParamReg(symOpnd, this->func);
+
+		if (reg != RegNOREG && !PHASE_OFF(Js::LivenessPhase, this->func))
+		{
+			StackSym *stackSym = symOpnd->m_sym->AsStackSym();
+			Lifetime *lifetime = stackSym->scratch.linearScan.lifetime;
+
+			if (lifetime == nullptr)
+			{
+				lifetime = this->InsertLifetime(stackSym, reg, this->func->m_headInstr->m_next);
+				lifetime->region = this->curRegion;
+				lifetime->isFloat = symOpnd->IsFloat();
+				lifetime->isSimd128F4 = symOpnd->IsSimd128F4();
+				lifetime->isSimd128I4 = symOpnd->IsSimd128I4();
+				lifetime->isSimd128I8 = symOpnd->IsSimd128I8();
+				lifetime->isSimd128I16 = symOpnd->IsSimd128I16();
+				lifetime->isSimd128U4 = symOpnd->IsSimd128U4();
+				lifetime->isSimd128U8 = symOpnd->IsSimd128U8();
+				lifetime->isSimd128U16 = symOpnd->IsSimd128U16();
+				lifetime->isSimd128B4 = symOpnd->IsSimd128B4();
+				lifetime->isSimd128B8 = symOpnd->IsSimd128B8();
+				lifetime->isSimd128B16 = symOpnd->IsSimd128B16();
+				lifetime->isSimd128D2 = symOpnd->IsSimd128D2();
+			}
+
+			IR::RegOpnd * newRegOpnd = IR::RegOpnd::New(stackSym, reg, symOpnd->GetType(), this->func);
+			instr->ReplaceSrc(symOpnd, newRegOpnd);
+			this->ProcessRegUse(newRegOpnd, instr);
+		}
+    }
 }
 
 // SCCLiveness::ProcessDst

--- a/lib/Backend/Sym.h
+++ b/lib/Backend/Sym.h
@@ -91,6 +91,7 @@ public:
     static StackSym * NewArgSlotRegSym(Js::ArgSlot argSlotNum, Func * func, IRType = TyVar);
     static StackSym * NewParamSlotSym(Js::ArgSlot argSlotNum, Func * func);
     static StackSym * NewParamSlotSym(Js::ArgSlot argSlotNum, Func * func, IRType type);
+	static StackSym *NewImplicitParamSym(Js::ArgSlot paramSlotNum, Func * func);
     static StackSym * New(SymID id, IRType type, Js::RegSlot byteCodeRegSlot, Func *func);
     static StackSym * New(IRType type, Func *func);
     static StackSym * New(Func *func);
@@ -98,7 +99,8 @@ public:
 
     IRType          GetType() const { return this->m_type; }
     bool            IsArgSlotSym() const;
-    bool            IsParamSlotSym() const;
+	bool            IsParamSlotSym() const;
+	bool            IsImplicitParamSym() const { return this->m_isImplicitParamSym; }
     bool            IsAllocated() const;
     int32           GetIntConstValue() const;
     Js::Var         GetFloatConstValueAsVar_PostGlobOpt() const;
@@ -162,11 +164,11 @@ public:
     bool            IsTempReg(Func *const func) const;
     bool            IsFromByteCodeConstantTable() const { return m_isFromByteCodeConstantTable; }
     void            SetIsFromByteCodeConstantTable() { this->m_isFromByteCodeConstantTable = true; }
-    Js::ArgSlot     GetArgSlotNum() const { Assert(HasArgSlotNum()); return m_argSlotNum; }
-    bool            HasArgSlotNum() const { return m_argSlotNum != 0; }
+    Js::ArgSlot     GetArgSlotNum() const { Assert(HasArgSlotNum()); return m_slotNum; }
+    bool            HasArgSlotNum() const { return !!(m_isArgSlotSym | m_isArgSlotRegSym); }
     void            IncrementArgSlotNum();
     void            DecrementArgSlotNum();
-    Js::ArgSlot     GetParamSlotNum() const { Assert(IsParamSlotSym()); return m_paramSlotNum; }
+    Js::ArgSlot     GetParamSlotNum() const { Assert(IsParamSlotSym()); return m_slotNum; }
 
     IR::Instr *     GetInstrDef() const { return this->IsSingleDef() ? this->m_instrDef : nullptr; }
 
@@ -186,11 +188,10 @@ private:
     void            VerifyConstFlags() const;
 #endif
 private:
-    Js::ArgSlot     m_argSlotNum;
-    Js::ArgSlot     m_paramSlotNum;
+    Js::ArgSlot     m_slotNum;
 public:
     uint8           m_isSingleDef:1;            // the symbol only has a single definition in the IR
-    uint8           m_isNotInt:1;
+	uint8           m_isNotInt:1;
     uint8           m_isSafeThis : 1;
     uint8           m_isConst : 1;              // single def and it is a constant
     uint8           m_isIntConst : 1;           // a constant and it's value is an Int32
@@ -209,7 +210,10 @@ public:
     uint8           m_isFromByteCodeConstantTable:1;
     uint8           m_mayNotBeTempLastUse:1;
     uint8           m_isArgSlotSym: 1;        // When set this implies an argument stack slot with no lifetime for register allocation
-    uint8           m_isBailOutReferenced: 1;        // argument sym referenced by bailout
+	uint8           m_isArgSlotRegSym : 1;
+	uint8           m_isParamSym : 1;
+	uint8           m_isImplicitParamSym : 1;
+	uint8           m_isBailOutReferenced: 1;        // argument sym referenced by bailout
     uint8           m_isArgCaptured: 1;       // True if there is a ByteCodeArgOutCapture for this symbol
     uint8           m_nonEscapingArgObjAlias : 1;
     uint8           m_isCatchObjectSym : 1;   // a catch object sym (used while jitting loop bodies)

--- a/lib/Backend/Sym.h
+++ b/lib/Backend/Sym.h
@@ -164,11 +164,11 @@ public:
     bool            IsTempReg(Func *const func) const;
     bool            IsFromByteCodeConstantTable() const { return m_isFromByteCodeConstantTable; }
     void            SetIsFromByteCodeConstantTable() { this->m_isFromByteCodeConstantTable = true; }
-    Js::ArgSlot     GetArgSlotNum() const { Assert(HasArgSlotNum() && m_slotNum); return m_slotNum; }
+    Js::ArgSlot     GetArgSlotNum() const { Assert(HasArgSlotNum()); return m_slotNum; }
     bool            HasArgSlotNum() const { return !!(m_isArgSlotSym | m_isArgSlotRegSym); }
     void            IncrementArgSlotNum();
     void            DecrementArgSlotNum();
-    Js::ArgSlot     GetParamSlotNum() const { Assert(IsParamSlotSym() && m_slotNum); return m_slotNum; }
+    Js::ArgSlot     GetParamSlotNum() const { Assert(IsParamSlotSym()); return m_slotNum; }
 
     IR::Instr *     GetInstrDef() const { return this->IsSingleDef() ? this->m_instrDef : nullptr; }
 

--- a/lib/Backend/Sym.h
+++ b/lib/Backend/Sym.h
@@ -164,11 +164,11 @@ public:
     bool            IsTempReg(Func *const func) const;
     bool            IsFromByteCodeConstantTable() const { return m_isFromByteCodeConstantTable; }
     void            SetIsFromByteCodeConstantTable() { this->m_isFromByteCodeConstantTable = true; }
-    Js::ArgSlot     GetArgSlotNum() const { Assert(HasArgSlotNum()); return m_slotNum; }
+    Js::ArgSlot     GetArgSlotNum() const { Assert(HasArgSlotNum() && m_slotNum); return m_slotNum; }
     bool            HasArgSlotNum() const { return !!(m_isArgSlotSym | m_isArgSlotRegSym); }
     void            IncrementArgSlotNum();
     void            DecrementArgSlotNum();
-    Js::ArgSlot     GetParamSlotNum() const { Assert(IsParamSlotSym()); return m_slotNum; }
+    Js::ArgSlot     GetParamSlotNum() const { Assert(IsParamSlotSym() && m_slotNum); return m_slotNum; }
 
     IR::Instr *     GetInstrDef() const { return this->IsSingleDef() ? this->m_instrDef : nullptr; }
 

--- a/lib/Backend/Sym.inl
+++ b/lib/Backend/Sym.inl
@@ -72,7 +72,7 @@ StackSym::IsArgSlotSym() const
 {
     if(m_isArgSlotSym)
     {
-        Assert(this->m_argSlotNum != 0);
+        Assert(this->m_slotNum != 0);
     }
     return m_isArgSlotSym;
 }
@@ -86,7 +86,7 @@ StackSym::IsArgSlotSym() const
 inline bool
 StackSym::IsParamSlotSym() const
 {
-    return m_paramSlotNum != InvalidSlot;
+	return m_isParamSym;
 }
 
 ///----------------------------------------------------------------------------

--- a/lib/Backend/Sym.inl
+++ b/lib/Backend/Sym.inl
@@ -86,6 +86,7 @@ StackSym::IsArgSlotSym() const
 inline bool
 StackSym::IsParamSlotSym() const
 {
+	Assert(!m_isParamSym || m_slotNum);
 	return m_isParamSym;
 }
 

--- a/lib/Backend/Sym.inl
+++ b/lib/Backend/Sym.inl
@@ -86,7 +86,6 @@ StackSym::IsArgSlotSym() const
 inline bool
 StackSym::IsParamSlotSym() const
 {
-	Assert(!m_isParamSym || m_slotNum);
 	return m_isParamSym;
 }
 

--- a/lib/Backend/SymTable.cpp
+++ b/lib/Backend/SymTable.cpp
@@ -243,6 +243,23 @@ SymTable::GetArgSlotSym(Js::ArgSlot argSlotNum)
     return argSym;
 }
 
+StackSym *          
+SymTable::GetImplicitParam(Js::ArgSlot paramSlotNum)
+{
+	Assert(paramSlotNum - 1 <= this->k_maxImplicitParamSlot);
+
+	if (this->m_implicitParams[paramSlotNum - 1])
+	{
+		return this->m_implicitParams[paramSlotNum - 1];
+	}
+	StackSym *implicitParamSym = StackSym::NewParamSlotSym(paramSlotNum, this->m_func, TyVar);
+	implicitParamSym->m_isImplicitParamSym = true;
+
+	this->m_implicitParams[paramSlotNum - 1] = implicitParamSym;
+
+	return implicitParamSym;
+}
+
 ///----------------------------------------------------------------------------
 ///
 /// SymTable::GetMaxSymID

--- a/lib/Backend/SymTable.cpp
+++ b/lib/Backend/SymTable.cpp
@@ -246,7 +246,7 @@ SymTable::GetArgSlotSym(Js::ArgSlot argSlotNum)
 StackSym *          
 SymTable::GetImplicitParam(Js::ArgSlot paramSlotNum)
 {
-	Assert(paramSlotNum - 1 <= this->k_maxImplicitParamSlot);
+	Assert(paramSlotNum - 1 < this->k_maxImplicitParamSlot);
 
 	if (this->m_implicitParams[paramSlotNum - 1])
 	{

--- a/lib/Backend/SymTable.h
+++ b/lib/Backend/SymTable.h
@@ -9,21 +9,25 @@ class SymTable
     typedef JsUtil::Pair<SymID, Js::PropertyId> SymIdPropIdPair;
     typedef JsUtil::BaseDictionary<SymIdPropIdPair, PropertySym *, JitArenaAllocator, PrimeSizePolicy> PropertyMap;
     typedef JsUtil::BaseDictionary<Js::PropertyId, BVSparse<JitArenaAllocator> *, JitArenaAllocator, PowerOf2SizePolicy> PropertyEquivBvMap;
-public:
-    static const int    k_symTableSize = 8192;
-    Sym *               m_table[k_symTableSize];
-    PropertyMap *       m_propertyMap;
-    PropertyEquivBvMap *m_propertyEquivBvMap;
 
 private:
+	static const int    k_symTableSize = 8192;
+	static const int    k_maxImplicitParamSlot = 4;
+    Sym *               m_table[k_symTableSize];
+	StackSym *          m_implicitParams[k_maxImplicitParamSlot];
+    PropertyMap *       m_propertyMap;
     Func *              m_func;
     SymID               m_currentID;
     SymID               m_IDAdjustment;
 
 public:
+	PropertyEquivBvMap *m_propertyEquivBvMap;
+
+public:
     SymTable() : m_currentID(0), m_func(nullptr), m_IDAdjustment(0)
     {
-        memset(m_table, 0, sizeof(m_table));
+		memset(m_table, 0, sizeof(m_table));
+		memset(m_implicitParams, 0, sizeof(m_implicitParams));
     }
 
 
@@ -37,6 +41,7 @@ public:
     void                IncreaseStartingID(SymID IDIncrease);
     SymID               NewID();
     StackSym *          GetArgSlotSym(Js::ArgSlot argSlotNum);
+	StackSym *          GetImplicitParam(Js::ArgSlot paramSlotNum);
     SymID               GetMaxSymID() const;
     void                ClearStackSymScratch();
     void                SetIDAdjustment() { m_IDAdjustment = m_currentID;}

--- a/lib/Backend/amd64/LinearScanMD.cpp
+++ b/lib/Backend/amd64/LinearScanMD.cpp
@@ -513,11 +513,11 @@ RegNum LinearScanMD::GetParamReg(IR::SymOpnd *symOpnd, Func *func)
 		{
 			switch (paramSym->GetParamSlotNum())
 			{
-			case 2:
-				reg = RegRCX;
-				break;
 			case 1:
 				reg = RegRDX;
+				break;
+			case 2:
+				reg = RegRCX;
 				break;
 			}
 		}

--- a/lib/Backend/amd64/LinearScanMD.cpp
+++ b/lib/Backend/amd64/LinearScanMD.cpp
@@ -464,9 +464,6 @@ RegNum LinearScanMD::GetParamReg(IR::SymOpnd *symOpnd, Func *func)
 		{
 			switch (paramSym->GetParamSlotNum())
 			{
-			case 10000:
-				reg = RegXMM0;
-				break;
 			case 1:
 				reg = RegXMM1;
 				break;

--- a/lib/Backend/amd64/LinearScanMD.cpp
+++ b/lib/Backend/amd64/LinearScanMD.cpp
@@ -450,3 +450,93 @@ RegNum LinearScanMD::GetRegisterFromSaveIndex(uint offset)
 {
     return (RegNum)(offset >= RegXMM0 ? (offset - RegXMM0) / (sizeof(SIMDValue) / sizeof(Js::Var)) + RegXMM0 : offset);
 }
+
+RegNum LinearScanMD::GetParamReg(IR::SymOpnd *symOpnd, Func *func)
+{
+	RegNum reg = RegNOREG;
+	StackSym *paramSym = symOpnd->m_sym->AsStackSym();
+
+	if (func->GetJnFunction()->GetIsAsmjsMode() && !func->IsLoopBody())
+	{
+		// Asm.js function only have 1 implicit param as they have no CallInfo, and they have float/SIMD params.
+		// Asm.js loop bodies however are called like normal JS functions.
+		if (IRType_IsFloat(symOpnd->GetType()) || IRType_IsSimd(symOpnd->GetType()))
+		{
+			switch (paramSym->GetParamSlotNum())
+			{
+			case 10000:
+				reg = RegXMM0;
+				break;
+			case 1:
+				reg = RegXMM1;
+				break;
+			case 2:
+				reg = RegXMM2;
+				break;
+			case 3:
+				reg = RegXMM3;
+				break;
+			}
+		}
+		else
+		{
+			if (paramSym->IsImplicitParamSym())
+			{
+				switch (paramSym->GetParamSlotNum())
+				{
+				case 1:
+					reg = RegRCX;
+					break;
+				default:
+					Assert(UNREACHED);
+				}
+			}
+			else
+			{
+				switch (paramSym->GetParamSlotNum())
+				{
+				case 1:
+					reg = RegRDX;
+					break;
+				case 2:
+					reg = RegR8;
+					break;
+				case 3:
+					reg = RegR9;
+					break;
+				}
+			}
+		}
+	}
+	else // Non-Asm.js
+	{
+		Assert(symOpnd->GetType() == TyVar || IRType_IsNativeInt(symOpnd->GetType()));
+
+		if (paramSym->IsImplicitParamSym())
+		{
+			switch (paramSym->GetParamSlotNum())
+			{
+			case 2:
+				reg = RegRCX;
+				break;
+			case 1:
+				reg = RegRDX;
+				break;
+			}
+		}
+		else
+		{
+			switch (paramSym->GetParamSlotNum())
+			{
+			case 1:
+				reg = RegR8;
+				break;
+			case 2:
+				reg = RegR9;
+				break;
+			}
+		}
+	}
+
+	return reg;
+}

--- a/lib/Backend/amd64/LinearScanMD.h
+++ b/lib/Backend/amd64/LinearScanMD.h
@@ -44,6 +44,7 @@ private:
 public:
     static void SaveAllRegistersAndBailOut(BailOutRecord *const bailOutRecord);
     static void SaveAllRegistersAndBranchBailOut(BranchBailOutRecord *const bailOutRecord, const BOOL condition);
+	static RegNum GetParamReg(IR::SymOpnd *symOpnd, Func *func);
 
     static uint GetRegisterSaveSlotCount() {
         return RegisterSaveSlotCount;

--- a/lib/Backend/arm/LinearScanMD.cpp
+++ b/lib/Backend/arm/LinearScanMD.cpp
@@ -346,3 +346,9 @@ RegNum LinearScanMD::GetRegisterFromSaveIndex(uint offset)
 {
     return (RegNum)(offset >= RegD0 ? (offset - RegD0) / 2  + RegD0 : offset);
 }
+
+RegNum LinearScanMD::GetParamReg(IR::SymOpnd *symOpnd, Func *func)
+{
+	/* TODO - Add ARM32 support according to register calling convention */
+	return RegNOREG;
+}

--- a/lib/Backend/arm/LinearScanMD.h
+++ b/lib/Backend/arm/LinearScanMD.h
@@ -45,6 +45,7 @@ private:
 public:
     static void SaveAllRegistersAndBailOut(BailOutRecord *const bailOutRecord);
     static void SaveAllRegistersAndBranchBailOut(BranchBailOutRecord *const bailOutRecord, const BOOL condition);
+	static RegNum GetParamReg(IR::SymOpnd *symOpnd, Func *func);
 
     bool        IsAllocatable(RegNum reg, Func *func) const;
     static uint GetRegisterSaveSlotCount() {

--- a/lib/Backend/arm/LowerMD.cpp
+++ b/lib/Backend/arm/LowerMD.cpp
@@ -7691,7 +7691,7 @@ LowererMD::GetImplicitParamSlotSym(Js::ArgSlot argSlot, Func * func)
     // For ARM, offset for implicit params always start at 0
     // TODO: Consider not to use the argSlot number for the param slot sym, which can
     // be confused with arg slot number from javascript
-    StackSym * stackSym = StackSym::NewParamSlotSym(argSlot, func);
+    StackSym * stackSym = StackSym::NewImplicitParamSym(argSlot, func);
     func->SetArgOffset(stackSym, argSlot * MachPtr);
     func->SetHasImplicitParamLoad();
     return stackSym;

--- a/lib/Backend/arm64/LinearScanMD.h
+++ b/lib/Backend/arm64/LinearScanMD.h
@@ -38,6 +38,7 @@ public:
 public:
     static void SaveAllRegistersAndBailOut(BailOutRecord *const bailOutRecord) { __debugbreak(); }
     static void SaveAllRegistersAndBranchBailOut(BranchBailOutRecord *const bailOutRecord, const BOOL condition) { __debugbreak(); }
+	static RegNum GetParamReg(IR::SymOpnd *symOpnd, Func *func) { /* TODO */ return RegNOREG; }
 
     bool        IsAllocatable(RegNum reg, Func *func) const { __debugbreak(); return 0; }
     static uint GetRegisterSaveSlotCount() {

--- a/lib/Backend/i386/LinearScanMD.cpp
+++ b/lib/Backend/i386/LinearScanMD.cpp
@@ -530,3 +530,8 @@ RegNum LinearScanMD::GetRegisterFromSaveIndex(uint offset)
 {
     return (RegNum)(offset >= RegXMM0 ? (offset - RegXMM0) / (sizeof(SIMDValue) / sizeof(Js::Var)) + RegXMM0 : offset);
 }
+
+RegNum LinearScanMD::GetParamReg(IR::SymOpnd *symOpnd, Func *func)
+{
+	return RegNOREG;
+}

--- a/lib/Backend/i386/LinearScanMD.h
+++ b/lib/Backend/i386/LinearScanMD.h
@@ -43,6 +43,7 @@ public:
     static void SaveAllRegistersNoSse2AndBailOut(BailOutRecord *const bailOutRecord);
     static void SaveAllRegistersAndBranchBailOut(BranchBailOutRecord *const bailOutRecord, const BOOL condition);
     static void SaveAllRegistersNoSse2AndBranchBailOut(BranchBailOutRecord *const bailOutRecord, const BOOL condition);
+	static RegNum GetParamReg(IR::SymOpnd *symOpnd, Func *func);
 
 public:
     static uint GetRegisterSaveSlotCount() {

--- a/lib/Runtime/Library/MathLibrary.cpp
+++ b/lib/Runtime/Library/MathLibrary.cpp
@@ -356,10 +356,9 @@ namespace Js
 #if defined(_M_IX86) || defined(_M_X64)
             if (AutoSystemInfo::Data.SSE4_1Available())
             {
-                __m128d input, output;
+				__m128d input, output;
                 input = _mm_load_sd(&x);
-#pragma prefast(suppress:6001, "Signature of _mm_ceil_sd intrinsic confuses prefast, output in the parameter list is not used, it is the dst of the intrinsic")
-                output = _mm_ceil_sd(output, input);
+                output = _mm_ceil_sd(input, input);
                 int intResult = _mm_cvtsd_si32(output);
 
                 if (TaggedInt::IsOverflow(intResult) || intResult == 0 || intResult == 0x80000000)
@@ -567,8 +566,7 @@ namespace Js
             }
             else
             {
-#pragma prefast(suppress:6001, "Signature of _mm_floor_sd intrinsic confuses prefast, output in the parameter list is not used, it is the dst of the intrinsic")
-                output = _mm_floor_sd(output, input);
+                output = _mm_floor_sd(input, input);
             }
             intResult = _mm_cvttsd_si32(output);
 


### PR DESCRIPTION
Load ArgIns from registers if the param was passed in registers (x64 only).  Cleanup implicitParams in the process.
