### PR TITLE
Trivial save-scope-info assert fix

### DIFF
--- a/lib/Runtime/ByteCode/ScopeInfo.cpp
+++ b/lib/Runtime/ByteCode/ScopeInfo.cpp
@@ -226,7 +226,8 @@ namespace Js
                     {
                         Assert(currentScope->GetEnclosingScope() == funcInfo->GetFuncExprScope() &&
                             currentScope->GetEnclosingScope()->GetEnclosingScope() ==
-                            (parentFunc->IsGlobalFunction() ? parentFunc->GetGlobalEvalBlockScope() : parentFunc->GetBodyScope()));
+                            (parentFunc->IsGlobalFunction() && parentFunc->GetGlobalEvalBlockScope()->GetMustInstantiate() ? 
+                             parentFunc->GetGlobalEvalBlockScope() : parentFunc->GetBodyScope()));
                     }
                 }
                 else


### PR DESCRIPTION
Let an assert in saving scope info handle the case where the global eval block scope exists but is empty.