### PR TITLE
Don't do prelowerpeeps for shl/shr across blocks

### DIFF
--- a/lib/Backend/PreLowerPeeps.cpp
+++ b/lib/Backend/PreLowerPeeps.cpp
@@ -71,10 +71,6 @@ IR::Instr *Lowerer::PeepShl(IR::Instr *instrShl)
     {
         return instrShl;
     }
-    if (IR::Instr::FindRegUseInRange(src1->AsRegOpnd()->m_sym, instrDef->m_next, instrShl->m_prev))
-    {
-        return instrShl;
-    }
 
     FOREACH_INSTR_IN_RANGE(instrIter, instrDef->m_next, instrShl->m_prev)
     {
@@ -87,6 +83,11 @@ IR::Instr *Lowerer::PeepShl(IR::Instr *instrShl)
             return instrShl;
         }
         if (instrIter->FindRegUse(src1->AsRegOpnd()->m_sym))
+        {
+            return instrShl;
+        }
+        // if any branch between def-use, don't do peeps on it because branch target might depend on the def
+        if (instrIter->IsBranchInstr())
         {
             return instrShl;
         }


### PR DESCRIPTION
Prelower peeps does below transformation which eliminates t1. But in the case there is branch between t1 and t2, t1 could be live in the branch target then unsafe to remove t1.  This fix disables this peep if branch detected inside, and it is safe to do it inside one block.

t1 = SHR X, cst
...
t2 = SHL t1, cst
->
t2 = AND X, mask