### PR TITLE
Abstract usage of _beginthreadex in PlatformAgnostic class

### DIFF
--- a/lib/Common/Common/Jobs.cpp
+++ b/lib/Common/Common/Jobs.cpp
@@ -531,7 +531,7 @@ namespace JsUtil
 
             this->parallelThreadData[i]->processor = this;
             // Make sure to create the thread suspended so the thread handle can be assigned before the thread starts running
-            this->parallelThreadData[i]->threadHandle = reinterpret_cast<HANDLE>(_beginthreadex(0, 0, &StaticThreadProc, this->parallelThreadData[i], CREATE_SUSPENDED, 0));
+            this->parallelThreadData[i]->threadHandle = reinterpret_cast<HANDLE>(PlatformAgnostic::Thread::Create(0, &StaticThreadProc, this->parallelThreadData[i], PlatformAgnostic::Thread::ThreadInitCreateSuspended));
             if (!this->parallelThreadData[i]->threadHandle)
             {
                 HeapDelete(parallelThreadData[i]);

--- a/lib/Common/CommonPal.h
+++ b/lib/Common/CommonPal.h
@@ -391,15 +391,7 @@ inline __int64 _abs64(__int64 n)
     return n < 0 ? -n : n;
 }
 
-// xplat-todo: implement these for JIT and Concurrent/Partial GC
-uintptr_t _beginthreadex(
-   void *security,
-   unsigned stack_size,
-   unsigned ( __stdcall *start_address )( void * ),
-   void *arglist,
-   unsigned initflag,
-   unsigned *thrdaddr);
-
+// xplat-todo: implement this for JIT and Concurrent/Partial GC
 BOOL WINAPI GetModuleHandleEx(
   _In_     DWORD   dwFlags,
   _In_opt_ LPCTSTR lpModuleName,
@@ -658,3 +650,4 @@ namespace PlatformAgnostic
 #include "PlatformAgnostic/DateTime.h"
 #include "PlatformAgnostic/Numbers.h"
 #include "PlatformAgnostic/SystemInfo.h"
+#include "PlatformAgnostic/Thread.h"

--- a/lib/Common/Memory/Recycler.cpp
+++ b/lib/Common/Memory/Recycler.cpp
@@ -4635,7 +4635,7 @@ Recycler::EnableConcurrent(JsUtil::ThreadService *threadService, bool startAllTh
 
         if (startConcurrentThread)
         {
-            HANDLE concurrentThread = (HANDLE)_beginthreadex(NULL, Recycler::ConcurrentThreadStackSize, &Recycler::StaticThreadProc, this, STACK_SIZE_PARAM_IS_A_RESERVATION, NULL);
+            HANDLE concurrentThread = (HANDLE)PlatformAgnostic::Thread::Create(Recycler::ConcurrentThreadStackSize, &Recycler::StaticThreadProc, this, PlatformAgnostic::Thread::ThreadInitStackSizeParamIsAReservation);
             if (concurrentThread != nullptr)
             {
                 // Wait for recycler thread to initialize
@@ -6069,7 +6069,7 @@ RecyclerParallelThread::EnableConcurrent(bool waitForThread)
         return false;
     }
 
-    this->concurrentThread = (HANDLE)_beginthreadex(NULL, Recycler::ConcurrentThreadStackSize, &RecyclerParallelThread::StaticThreadProc, this, STACK_SIZE_PARAM_IS_A_RESERVATION, NULL);
+    this->concurrentThread = (HANDLE)PlatformAgnostic::Thread::Create(Recycler::ConcurrentThreadStackSize, &RecyclerParallelThread::StaticThreadProc, this, PlatformAgnostic::Thread::ThreadInitStackSizeParamIsAReservation);
 
     if (this->concurrentThread != nullptr && waitForThread)
     {

--- a/lib/Common/PlatformAgnostic/Thread.h
+++ b/lib/Common/PlatformAgnostic/Thread.h
@@ -1,0 +1,30 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#ifndef RUNTIME_PLATFORM_AGNOSTIC_COMMON_THREAD
+#define RUNTIME_PLATFORM_AGNOSTIC_COMMON_THREAD
+
+namespace PlatformAgnostic
+{
+class Thread
+{
+    public:
+
+    enum ThreadInitFlag {
+        ThreadInitRunImmediately,
+        ThreadInitCreateSuspended,
+        ThreadInitStackSizeParamIsAReservation
+    };
+
+    typedef uintptr_t ThreadHandle;
+
+    static ThreadHandle Create(unsigned int stack_size,
+                               unsigned int ( *start_address )( void * ),
+                               void* arg_list,
+                               ThreadInitFlag init_flag);
+};
+} // namespace PlatformAgnostic
+
+#endif // RUNTIME_PLATFORM_AGNOSTIC_COMMON_THREAD

--- a/lib/Runtime/PlatformAgnostic/Chakra.Runtime.PlatformAgnostic.vcxproj
+++ b/lib/Runtime/PlatformAgnostic/Chakra.Runtime.PlatformAgnostic.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Condition="'$(ChakraBuildPathImported)'!='true'" Project="$(SolutionDir)Chakra.Build.Paths.props" />
   <Import Project="$(BuildConfigPropsPath)Chakra.Build.ProjectConfiguration.props" />
@@ -45,6 +45,7 @@
     <ClCompile Include="Platform\Windows\UnicodeText.cpp" />
     <ClCompile Include="Platform\Windows\NumbersUtility.cpp" />
     <ClCompile Include="Platform\Windows\SystemInfo.cpp" />
+    <ClCompile Include="Platform\Windows\Thread.cpp" />
 
     <ClCompile Include="Platform\Common\UnicodeText.Common.cpp" />
   </ItemGroup>

--- a/lib/Runtime/PlatformAgnostic/Platform/CMakeLists.txt
+++ b/lib/Runtime/PlatformAgnostic/Platform/CMakeLists.txt
@@ -7,6 +7,7 @@ set(PL_SOURCE_FILES
   Linux/HiResTimer.cpp
   Linux/NumbersUtility.cpp
   Linux/SystemInfo.cpp
+  Linux/Thread.cpp
   Common/UnicodeText.Common.cpp
   )
 elseif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
@@ -17,6 +18,7 @@ set(PL_SOURCE_FILES
   Linux/HiResTimer.cpp
   Linux/NumbersUtility.cpp
   Unix/SystemInfo.cpp
+  Linux/Thread.cpp
   Common/UnicodeText.Common.cpp
   )
 endif()

--- a/lib/Runtime/PlatformAgnostic/Platform/Linux/Thread.cpp
+++ b/lib/Runtime/PlatformAgnostic/Platform/Linux/Thread.cpp
@@ -1,0 +1,37 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#include "RuntimePlatformAgnosticPch.h"
+#include "CommonPal.h"
+
+#include <stdint.h>
+
+namespace PlatformAgnostic
+{
+    Thread::ThreadHandle Thread::Create(unsigned stack_size,
+                                        unsigned ( *start_address )( void * ),
+                                        void* arg_list,
+                                        ThreadInitFlag init_flag)
+    {
+        unsigned int flag = 0;
+
+        switch (init_flag)
+        {
+        case ThreadInitRunImmediately:
+            flag = 0;
+            break;
+        case ThreadInitCreateSuspended:
+            flag = CREATE_SUSPENDED;
+            break;
+        case ThreadInitStackSizeParamIsAReservation:
+            flag = STACK_SIZE_PARAM_IS_A_RESERVATION;
+            break;
+        default:
+            Assert(false);
+        }
+
+        return reinterpret_cast<ThreadHandle>(CreateThread(0, stack_size, start_address, arg_list, flag, 0));
+    }
+} // namespace PlatformAgnostic

--- a/lib/Runtime/PlatformAgnostic/Platform/Windows/Thread.cpp
+++ b/lib/Runtime/PlatformAgnostic/Platform/Windows/Thread.cpp
@@ -1,0 +1,36 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#include "RuntimePlatformAgnosticPch.h"
+#include "Common.h"
+#include <process.h>
+
+namespace PlatformAgnostic
+{
+    Thread::ThreadHandle Thread::Create(unsigned stack_size,
+                                        unsigned ( __stdcall *start_address )( void * ),
+                                        void* arg_list,
+                                        ThreadInitFlag init_flag)
+    {
+        unsigned int flag = 0;
+
+        switch (init_flag)
+        {
+        case ThreadInitRunImmediately:
+            flag = 0;
+            break;
+        case ThreadInitCreateSuspended:
+            flag = CREATE_SUSPENDED;
+            break;
+        case ThreadInitStackSizeParamIsAReservation:
+            flag = STACK_SIZE_PARAM_IS_A_RESERVATION;
+            break;
+        default:
+            Assert(false);
+        }
+
+        return _beginthreadex(nullptr, stack_size, start_address, arg_list, flag, nullptr);
+    }
+} // namespace PlatformAgnostic


### PR DESCRIPTION
PlatformAgnostic::Threads::Utility::BeginThread exports the
functionality we use consistently in Chakra. In particular the
"security" and "thread address" parameters are missing. See MSDN for
details.

The Windows implementation just calls _beginthreadex. On Linux we use
PAL's CreateThread, but in the future we would like to use pthread
directly. Future patches will enable the functionality on !Windows,
for now it remains disabled.