### PR TITLE
Fixing stack pointer when destructuring at call expression.

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -11470,6 +11470,9 @@ void Emit(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator, FuncInfo *func
             byteCodeGenerator->Writer()->Br(Js::OpCode::TryFinally, finallyLabel);
         }
 
+        // Increasing the stack as we will be storing the additional values when we enter try..finally.
+        funcInfo->StartRecordingOutArgs(1);
+
         Emit(pnodeTry->sxTry.pnodeBody, byteCodeGenerator, funcInfo, fReturnValue);
         funcInfo->ReleaseLoc(pnodeTry->sxTry.pnodeBody);
 
@@ -11504,6 +11507,8 @@ void Emit(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator, FuncInfo *func
             funcInfo->ReleaseTmpRegister(regOffset);
             funcInfo->ReleaseTmpRegister(regException);
         }
+
+        funcInfo->EndRecordingOutArgs(1);
 
         byteCodeGenerator->Writer()->RecordCrossFrameEntryExitRecord(false);
 

--- a/lib/Runtime/Language/InterpreterStackFrame.h
+++ b/lib/Runtime/Language/InterpreterStackFrame.h
@@ -78,6 +78,7 @@ namespace Js
         Var* m_inParams;                // Range of 'in' parameters
         Var* m_outParams;               // Range of 'out' parameters (offset in m_localSlots)
         Var* m_outSp;                   // Stack pointer for next outparam
+        Var* m_outSpCached;             // Stack pointer for caching previos SP (in order to assist in try..finally)
         Var  m_arguments;               // Dedicated location for this frame's arguments object
         StackScriptFunction * stackNestedFunctions;
         FrameDisplay * localFrameDisplay;
@@ -167,6 +168,8 @@ namespace Js
         void SetOut(ArgSlot_OneByte outRegisterID, Var bValue);
         void PushOut(Var aValue);
         void PopOut(ArgSlot argCount);
+        void CacheSp();
+        void RestoreSp();
 
         FrameDisplay * GetLocalFrameDisplay() const;
         FrameDisplay * GetFrameDisplayForNestedFunc() const;


### PR DESCRIPTION
The destructuring pattern is wrapped around try..finally, as it has to do iteratorclose when the pattern exhaust. However that pattern can appear at call expression. The finally block resetOut the stack pointer. This created the problem as we were middle of the call expression and the stack pointer (m_outSp and m_outParams) got reseted. In order to fix that we need to cache the m_outSp when we enter the try and restore that when we enter the finally block. We need to restore the m_outParams as well - so we are storing that information in the stack itself. There is no problem in the JIT (or bailout code path) so no fix required.
Added the tests for more clarity.
