### PR TITLE
Fix bad catch variable bindings

### DIFF
--- a/lib/Parser/Parse.h
+++ b/lib/Parser/Parse.h
@@ -442,9 +442,29 @@ private:
     BlockInfoStack* GetCurrentBlockInfo();
     BlockInfoStack* GetCurrentFunctionBlockInfo();
     ParseNode *GetCurrentFunctionNode();
-    ParseNode *GetCurrentNonLamdaFunctionNode();
-    bool IsNodeAllowedForDeferParse(OpCode op) {return !this->m_deferringAST ||
-        (op == knopBlock || op == knopVarDecl || op == knopConstDecl || op == knopLetDecl || op == knopFncDecl); }
+    ParseNode *GetCurrentNonLambdaFunctionNode();
+
+    bool IsNodeAllowedInCurrentDeferralState(OpCode op) 
+    {
+        if (!this->m_deferringAST)
+        {
+            return true;
+        }
+        switch(op)
+        {
+            case knopBlock:
+            case knopVarDecl:
+            case knopConstDecl:
+            case knopLetDecl:
+            case knopFncDecl:
+            case knopName:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+
     bool NextTokenConfirmsLetDecl() const { return m_token.tk == tkID || m_token.tk == tkLBrack || m_token.tk == tkLCurly || m_token.IsReservedWord(); }
     bool NextTokenIsPropertyNameStart() const { return m_token.tk == tkID || m_token.tk == tkStrCon || m_token.tk == tkIntCon || m_token.tk == tkFltCon || m_token.tk == tkLBrack || m_token.IsReservedWord(); }
 

--- a/test/EH/capture.js
+++ b/test/EH/capture.js
@@ -50,3 +50,19 @@ function f10(){
     f12();
 };
 f10();
+
+function outer(g) {
+    function inner() {
+        try {
+            throw 1;
+        }
+        catch(g) {
+            if (g !== 1) 
+                WScript.Echo('g === ' + g + ' in catch');
+        }
+    }
+    inner();
+    if (g !== 'g')
+        WScript.Echo('g === ' + g + ' in "inner"');
+}
+outer('g');


### PR DESCRIPTION
Enable binding logic for catch variables under !buildAST. Fixes cases where catch variables in deferred nested functions were mistakenly bound to same-named variables in enclosing functions.