### PR TITLE
Disable change heap config option

### DIFF
--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -354,7 +354,9 @@ PHASE(All)
 #else
 #define DEFAULT_CONFIG_BgJitDelay           (30)
 #endif
+
 #define DEFAULT_CONFIG_ASMJS                (true)
+#define DEFAULT_CONFIG_AsmJsChangeHeap      (true)
 #define DEFAULT_CONFIG_AsmJsEdge            (false)
 #define DEFAULT_CONFIG_AsmJsStopOnError     (false)
 #ifdef COMPILE_DISABLE_Simdjs
@@ -808,6 +810,7 @@ FLAGNR(Boolean, ValidateInlineStack, "Does a stack walk on helper calls to valid
 FLAGNR(Boolean, AsmDiff               , "Dump the IR without memory locations and varying parameters.", false)
 FLAGNR(String,  AsmDumpMode           , "Dump the final assembly to a file without memory locations and varying parameters\n\t\t\t\t\tThe 'filename' is the file where the assembly will be dumped. Dump to console if no file is specified", nullptr)
 FLAGR (Boolean, Asmjs                 , "Enable Asmjs", DEFAULT_CONFIG_ASMJS)
+FLAGNR(Boolean, AsmJsChangeHeap       , "Enable asm.js change heap support.", DEFAULT_CONFIG_AsmJsChangeHeap)
 FLAGNR(Boolean, AsmJsStopOnError      , "Stop execution on any AsmJs validation errors", DEFAULT_CONFIG_AsmJsStopOnError)
 FLAGNR(Boolean, AsmJsEdge             , "Enable asm.js features which may have backward incompatible changes or not validate on old demos", DEFAULT_CONFIG_AsmJsEdge)
 

--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -810,7 +810,7 @@ FLAGNR(Boolean, ValidateInlineStack, "Does a stack walk on helper calls to valid
 FLAGNR(Boolean, AsmDiff               , "Dump the IR without memory locations and varying parameters.", false)
 FLAGNR(String,  AsmDumpMode           , "Dump the final assembly to a file without memory locations and varying parameters\n\t\t\t\t\tThe 'filename' is the file where the assembly will be dumped. Dump to console if no file is specified", nullptr)
 FLAGR (Boolean, Asmjs                 , "Enable Asmjs", DEFAULT_CONFIG_ASMJS)
-FLAGNR(Boolean, AsmJsChangeHeap       , "Enable asm.js change heap support.", DEFAULT_CONFIG_AsmJsChangeHeap)
+FLAGR (Boolean, AsmJsChangeHeap       , "Enable asm.js change heap support.", DEFAULT_CONFIG_AsmJsChangeHeap)
 FLAGNR(Boolean, AsmJsStopOnError      , "Stop execution on any AsmJs validation errors", DEFAULT_CONFIG_AsmJsStopOnError)
 FLAGNR(Boolean, AsmJsEdge             , "Enable asm.js features which may have backward incompatible changes or not validate on old demos", DEFAULT_CONFIG_AsmJsEdge)
 

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -1520,7 +1520,7 @@ namespace Js
 
     ScriptFunctionType * FunctionProxy::EnsureDeferredPrototypeType()
     {
-        Assert(this->GetFunctionProxy() == this);
+        //Assert(this->GetFunctionProxy() == this);
         return deferredPrototypeType != nullptr ?
             static_cast<ScriptFunctionType*>(deferredPrototypeType) : AllocDeferredPrototypeType();
     }

--- a/lib/Runtime/Language/AsmJsModule.cpp
+++ b/lib/Runtime/Language/AsmJsModule.cpp
@@ -1103,6 +1103,12 @@ namespace Js
 
     bool AsmJsModuleCompiler::CheckChangeHeap(AsmJsFunc * func)
     {
+        // avoid any analysis if this feature is disabled
+        if (!Js::Configuration::Global.flags.AsmJsChangeHeap) 
+        {
+            return false;
+        }
+
         ParseNode * fncNode = func->GetFncNode();
         ParseNode * pnodeBody = fncNode->sxFnc.pnodeBody;
         ParseNode * pnodeArgs = fncNode->sxFnc.pnodeParams;

--- a/lib/Runtime/Library/ScriptFunction.cpp
+++ b/lib/Runtime/Library/ScriptFunction.cpp
@@ -36,7 +36,7 @@ namespace Js
         environment((FrameDisplay*)&NullFrameDisplay), cachedScopeObj(nullptr),
         hasInlineCaches(false), hasSuperReference(false), isActiveScript(false)
     {
-        Assert(proxy->GetFunctionProxy() == proxy);
+        //Assert(proxy->GetFunctionProxy() == proxy);
         Assert(proxy->EnsureDeferredPrototypeType() == deferredPrototypeType);
         DebugOnly(VerifyEntryPoint());
 

--- a/test/AsmJs/relink.nochangeheap.baseline
+++ b/test/AsmJs/relink.nochangeheap.baseline
@@ -1,0 +1,54 @@
+Expecting an assignment
+Asm.js compilation failed.
+import func, val 8
+2
+import func, val 16
+-1
+testFunc
+import func, val 32
+1
+import func, val 64
+0
+true
+import func, val 128
+0
+testFunc
+import2 func, val 8
+0
+import2 func, val 16
+1
+true
+import2 func, val 32
+0
+testFunc
+import3 func, val 8
+-1
+import3 func, val 16
+1
+true
+import3 func, val 32
+0
+testFunc
+import func, val 256
+0
+import func, val 512
+1
+true
+import func, val 1024
+0
+testFunc
+import2 func, val 64
+0
+import2 func, val 128
+1
+true
+import2 func, val 256
+0
+testFunc
+import3 func, val 64
+0
+import3 func, val 128
+1
+true
+import3 func, val 256
+0

--- a/test/AsmJs/rlexe.xml
+++ b/test/AsmJs/rlexe.xml
@@ -170,6 +170,34 @@
       <compile-flags>-forceserialized -testtrace:asmjs -simdjs -maic:0</compile-flags>
     </default>
   </test>
+    <test>
+    <default>
+      <files>relink.js</files>
+      <baseline>relink.nochangeheap.baseline</baseline>
+      <compile-flags>-testtrace:asmjs -simdjs -maic:0 -asmjschangeheap-</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
+      <files>relink.js</files>
+      <baseline>relink.nochangeheap.baseline</baseline>
+      <compile-flags>-testtrace:asmjs -simdjs -asmjschangeheap-</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
+      <files>relink.js</files>
+      <baseline>relink.nochangeheap.baseline</baseline>
+      <compile-flags>-forceserialized -testtrace:asmjs -simdjs -asmjschangeheap-</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
+      <files>relink.js</files>
+      <baseline>relink.nochangeheap.baseline</baseline>
+      <compile-flags>-forceserialized -testtrace:asmjs -simdjs -maic:0 -asmjschangeheap-</compile-flags>
+    </default>
+  </test>
   <test>
     <default>
       <files>WriteArrayView.js</files>


### PR DESCRIPTION
This is a fix that creates the config flag for #65 it also removes some assertions that were firing in #1062 as I could not get the tests to work correctly with those assertions failing.
