### PR TITLE
Enable @@toStringTag by default

### DIFF
--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -533,7 +533,7 @@ PHASE(All)
 #endif
 #define DEFAULT_CONFIG_ES6ToPrimitive          (false)
 #define DEFAULT_CONFIG_ES6ToLength             (false)
-#define DEFAULT_CONFIG_ES6ToStringTag          (false)
+#define DEFAULT_CONFIG_ES6ToStringTag          (true)
 #define DEFAULT_CONFIG_ES6Unicode              (true)
 #define DEFAULT_CONFIG_ES6UnicodeVerbose       (true)
 #define DEFAULT_CONFIG_ES6Unscopables          (true)

--- a/lib/Runtime/Library/JavascriptObject.cpp
+++ b/lib/Runtime/Library/JavascriptObject.cpp
@@ -384,8 +384,7 @@ namespace Js
         Var tag = JavascriptOperators::GetProperty(thisArgAsObject, PropertyIds::_symbolToStringTag, scriptContext); // Let tag be the result of Get(O, @@toStringTag).
 
         // 17. Return the String that is the result of concatenating "[object ", tag, and "]". 
-        if (tag != nullptr && JavascriptString::Is(tag))
-        {
+        auto buildToString = [&scriptContext](Var tag) {
             JavascriptString *tagStr = JavascriptString::FromVar(tag);
 
             CompoundString::Builder<32> stringBuilder(scriptContext);
@@ -396,6 +395,10 @@ namespace Js
             stringBuilder.AppendChars(_u(']'));
 
             return stringBuilder.ToString();
+        };
+        if (tag != nullptr && JavascriptString::Is(tag))
+        {
+            return buildToString(tag);
         }
 
         // If we don't have a tag or it's not a string, use the 'built in tag'.
@@ -460,14 +463,7 @@ namespace Js
         {
             if (thisArgAsObject->IsExternal())
             {
-                CompoundString::Builder<32> stringBuilder(scriptContext);
-
-                stringBuilder.AppendChars(_u("[object "));
-
-                stringBuilder.AppendChars(thisArgAsObject->GetClassName(scriptContext));
-                stringBuilder.AppendChars(_u(']'));
-
-                return stringBuilder.ToString();
+                builtInTag = buildToString(thisArgAsObject->GetClassName(scriptContext));
             }
             else
             {
@@ -480,226 +476,6 @@ namespace Js
         Assert(builtInTag != nullptr);
 
         return builtInTag;
-    }
-
-    // This is the previous implementation of @@toStringTag, which is used in some cases even when the feature is disabled.
-    // Leaving this here for now due to the fragility.
-    // TODO(tcare): Remove when @@toStringTag is enabled by default.
-    JavascriptString* JavascriptObject::ToStringTagHelperOld(Var thisArg, ScriptContext* scriptContext, TypeId type)
-    {
-        JavascriptString* tag = nullptr;
-        bool addTilde = true;
-        bool isES6ToStringTagEnabled = scriptContext->GetConfig()->IsES6ToStringTagEnabled();
-        JavascriptLibrary* library = scriptContext->GetLibrary();
-
-        if (isES6ToStringTagEnabled && RecyclableObject::Is(thisArg))
-        {
-            RecyclableObject* thisArgObject = RecyclableObject::FromVar(thisArg);
-
-            if (JavascriptOperators::HasProperty(thisArgObject, PropertyIds::_symbolToStringTag)) // Let hasTag be the result of HasProperty(O, @@toStringTag).
-            {
-                Var tagVar;
-
-                try
-                {
-                    tagVar = JavascriptOperators::GetProperty(thisArgObject, PropertyIds::_symbolToStringTag, scriptContext); // Let tag be the result of Get(O, @@toStringTag).
-                }
-                catch (JavascriptExceptionObject*)
-                {
-                    // tag = "???"
-                    return library->CreateStringFromCppLiteral(_u("[object ???]")); // If tag is an abrupt completion, let tag be NormalCompletion("???").
-                }
-
-                if (!JavascriptString::Is(tagVar))
-                {
-                    // tag = "???"
-                    return library->CreateStringFromCppLiteral(_u("[object ???]")); // If Type(tag) is not String, let tag be "???".
-                }
-
-                tag = JavascriptString::FromVar(tagVar);
-            }
-        }
-
-
-        // If tag is any of "Arguments", "Array", "Boolean", "Date", "Error", "Function", "Number", "RegExp", or "String" and
-        // SameValue(tag, builtinTag) is false, then let tag be the string value "~" concatenated with the current value of tag.
-        switch (type)
-        {
-        case TypeIds_Arguments:
-            if (!isES6ToStringTagEnabled || tag == nullptr || wcscmp(tag->UnsafeGetBuffer(), _u("Arguments")) == 0)
-            {
-                return library->CreateStringFromCppLiteral(_u("[object Arguments]"));
-            }
-            break;
-        case TypeIds_Array:
-        case TypeIds_ES5Array:
-        case TypeIds_NativeIntArray:
-#if ENABLE_COPYONACCESS_ARRAY
-        case TypeIds_CopyOnAccessNativeIntArray:
-#endif
-        case TypeIds_NativeFloatArray:
-            if (!isES6ToStringTagEnabled || tag == nullptr || wcscmp(tag->UnsafeGetBuffer(), _u("Array")) == 0)
-            {
-                return library->CreateStringFromCppLiteral(_u("[object Array]"));
-            }
-            break;
-        case TypeIds_Boolean:
-        case TypeIds_BooleanObject:
-            if (!isES6ToStringTagEnabled || tag == nullptr || wcscmp(tag->UnsafeGetBuffer(), _u("Boolean")) == 0)
-            {
-                return library->CreateStringFromCppLiteral(_u("[object Boolean]"));
-            }
-            break;
-        case TypeIds_DataView:
-            if (!isES6ToStringTagEnabled || tag == nullptr || wcscmp(tag->UnsafeGetBuffer(), _u("DataView")) == 0)
-            {
-                return library->CreateStringFromCppLiteral(_u("[object DataView]"));
-            }
-            break;
-        case TypeIds_Date:
-        case TypeIds_WinRTDate:
-            if (!isES6ToStringTagEnabled || tag == nullptr || wcscmp(tag->UnsafeGetBuffer(), _u("Date")) == 0)
-            {
-                return library->CreateStringFromCppLiteral(_u("[object Date]"));
-            }
-            break;
-        case TypeIds_Error:
-            if (!isES6ToStringTagEnabled || tag == nullptr || wcscmp(tag->UnsafeGetBuffer(), _u("Error")) == 0)
-            {
-                return library->CreateStringFromCppLiteral(_u("[object Error]"));
-            }
-            break;
-
-        case TypeIds_Function:
-            if (!isES6ToStringTagEnabled || tag == nullptr || wcscmp(tag->UnsafeGetBuffer(), _u("Function")) == 0)
-            {
-                return library->CreateStringFromCppLiteral(_u("[object Function]"));
-            }
-            break;
-        case TypeIds_Number:
-        case TypeIds_Int64Number:
-        case TypeIds_UInt64Number:
-        case TypeIds_Integer:
-        case TypeIds_NumberObject:
-            if (!isES6ToStringTagEnabled || tag == nullptr || wcscmp(tag->UnsafeGetBuffer(), _u("Number")) == 0)
-            {
-                return library->CreateStringFromCppLiteral(_u("[object Number]"));
-            }
-            break;
-        case TypeIds_Promise:
-            if (!isES6ToStringTagEnabled || tag == nullptr || wcscmp(tag->UnsafeGetBuffer(), _u("Promise")) == 0)
-            {
-                return library->CreateStringFromCppLiteral(_u("[object Promise]"));
-            }
-            break;
-        case TypeIds_SIMDObject:
-            if (!isES6ToStringTagEnabled || tag == nullptr || wcscmp(tag->UnsafeGetBuffer(), _u("SIMD")) == 0)
-            {
-                return library->CreateStringFromCppLiteral(_u("[object SIMD]"));
-            }
-            break;
-
-        case TypeIds_RegEx:
-            if (!isES6ToStringTagEnabled || tag == nullptr || wcscmp(tag->UnsafeGetBuffer(), _u("RegExp")) == 0)
-            {
-                return library->CreateStringFromCppLiteral(_u("[object RegExp]"));
-            }
-            break;
-
-        case TypeIds_String:
-        case TypeIds_StringObject:
-            if (!isES6ToStringTagEnabled || tag == nullptr || wcscmp(tag->UnsafeGetBuffer(), _u("String")) == 0)
-            {
-                return library->CreateStringFromCppLiteral(_u("[object String]"));
-            }
-            break;
-
-        case TypeIds_ModuleNamespace:
-            if (!isES6ToStringTagEnabled || tag == nullptr || wcscmp(tag->UnsafeGetBuffer(), _u("Module")) == 0)
-            {
-                return library->CreateStringFromCppLiteral(_u("[object Module]"));
-            }
-            break;
-
-        case TypeIds_Proxy:
-            if (JavascriptOperators::IsArray(thisArg))
-            {
-                if (!isES6ToStringTagEnabled || tag == nullptr || wcscmp(tag->UnsafeGetBuffer(), _u("Array")) == 0)
-                {
-                    return library->CreateStringFromCppLiteral(_u("[object Array]"));
-                }
-            }
-            //otherwise, fall though
-        case TypeIds_Object:
-        default:
-            if (tag == nullptr)
-            {
-                // Else, let builtinTag be "Object".
-                // If hasTag is false, then let tag be builtinTag.
-                return library->GetObjectDisplayString(); // "[object Object]"
-            }
-            addTilde = false;
-            break;
-        }
-
-        Assert(tag != nullptr);
-        Assert(isES6ToStringTagEnabled);
-
-        CompoundString::Builder<32> stringBuilder(scriptContext);
-
-        if (addTilde)
-            stringBuilder.AppendChars(_u("[object ~"));
-        else
-            stringBuilder.AppendChars(_u("[object "));
-
-        stringBuilder.AppendChars(tag);
-        stringBuilder.AppendChars(_u(']'));
-
-        return stringBuilder.ToString();
-    }
-
-    Var JavascriptObject::LegacyToStringHelper(ScriptContext* scriptContext, TypeId type)
-    {
-        JavascriptLibrary* library = scriptContext->GetLibrary();
-        switch (type)
-        {
-        case TypeIds_ArrayBuffer:
-            return library->CreateStringFromCppLiteral(_u("[object ArrayBuffer]"));
-        case TypeIds_Int8Array:
-            return library->CreateStringFromCppLiteral(_u("[object Int8Array]"));
-        case TypeIds_Uint8Array:
-            return library->CreateStringFromCppLiteral(_u("[object Uint8Array]"));
-        case TypeIds_Uint8ClampedArray:
-            return library->CreateStringFromCppLiteral(_u("[object Uint8ClampedArray]"));
-        case TypeIds_Int16Array:
-            return library->CreateStringFromCppLiteral(_u("[object Int16Array]"));
-        case TypeIds_Uint16Array:
-            return library->CreateStringFromCppLiteral(_u("[object Uint16Array]"));
-        case TypeIds_Int32Array:
-            return library->CreateStringFromCppLiteral(_u("[object Int32Array]"));
-        case TypeIds_Uint32Array:
-            return library->CreateStringFromCppLiteral(_u("[object Uint32Array]"));
-        case TypeIds_Float32Array:
-            return library->CreateStringFromCppLiteral(_u("[object Float32Array]"));
-        case TypeIds_Float64Array:
-            return library->CreateStringFromCppLiteral(_u("[object Float64Array]"));
-        case TypeIds_Symbol:
-        case TypeIds_SymbolObject:
-            return library->CreateStringFromCppLiteral(_u("[object Symbol]"));
-        case TypeIds_Map:
-            return library->CreateStringFromCppLiteral(_u("[object Map]"));
-        case TypeIds_Set:
-            return library->CreateStringFromCppLiteral(_u("[object Set]"));
-        case TypeIds_WeakMap:
-            return library->CreateStringFromCppLiteral(_u("[object WeakMap]"));
-        case TypeIds_WeakSet:
-            return library->CreateStringFromCppLiteral(_u("[object WeakSet]"));
-        case TypeIds_Generator:
-            return library->CreateStringFromCppLiteral(_u("[object Generator]"));
-        default:
-            AssertMsg(false, "We should never be here");
-            return library->GetUndefined();
-        }
     }
 
     Var JavascriptObject::ToStringHelper(Var thisArg, ScriptContext* scriptContext)
@@ -726,146 +502,18 @@ namespace Js
         }
 
         // Dispatch to @@toStringTag implementation.
-        if (scriptContext->GetConfig()->IsES6ToStringTagEnabled())
+        if (type >= TypeIds_TypedArrayMin && type <= TypeIds_TypedArrayMax && !scriptContext->GetThreadContext()->IsScriptActive())
         {
-            if (type >= TypeIds_TypedArrayMin && type <= TypeIds_TypedArrayMax && !scriptContext->GetThreadContext()->IsScriptActive())
-            {
-                // Use external call for typedarray in the debugger.
-                Var toStringValue = nullptr;
-                BEGIN_JS_RUNTIME_CALL_EX(scriptContext, false);
-                toStringValue = ToStringTagHelper(thisArg, scriptContext, type);
-                END_JS_RUNTIME_CALL(scriptContext);
-                return toStringValue;
-            }
-
-            // By this point, we should be in the correct context, but the thisArg may still need to be marshalled (for to the implicit ToObject conversion call.)
-            return ToStringTagHelper(CrossSite::MarshalVar(scriptContext, thisArg), scriptContext, type);
+            // Use external call for typedarray in the debugger.
+            Var toStringValue = nullptr;
+            BEGIN_JS_RUNTIME_CALL_EX(scriptContext, false);
+            toStringValue = ToStringTagHelper(thisArg, scriptContext, type);
+            END_JS_RUNTIME_CALL(scriptContext);
+            return toStringValue;
         }
 
-        // The following uses the told hybrid legacy/@@toStringTag implementation,
-        // and will be removed when the new implementation is on by default.
-        JavascriptLibrary *library = scriptContext->GetLibrary();
-        switch (type)
-        {
-        case TypeIds_Undefined:
-            return library->CreateStringFromCppLiteral(_u("[object Undefined]"));
-        case TypeIds_Null:
-            return library->CreateStringFromCppLiteral(_u("[object Null]"));
-        case TypeIds_Enumerator:
-        case TypeIds_Proxy:
-        case TypeIds_Object:
-            if (scriptContext->GetConfig()->IsES6ToStringTagEnabled())
-            {
-                // Math, Object and JSON handled by toStringTag now,
-                return ToStringTagHelperOld(thisArg, scriptContext, type);
-            }
-
-            if (thisArg == scriptContext->GetLibrary()->GetMathObject())
-            {
-                return library->CreateStringFromCppLiteral(_u("[object Math]"));
-            }
-            else if (thisArg == library->GetJSONObject())
-            {
-                return library->CreateStringFromCppLiteral(_u("[object JSON]"));
-            }
-
-        default:
-        {
-            RecyclableObject* obj = RecyclableObject::FromVar(thisArg);
-            if (!obj->CanHaveInterceptors())
-            {
-                //this will handle printing Object for non interceptor cases
-                return library->GetObjectDisplayString();
-            }
-            // otherwise, fall through.
-            RecyclableObject* recyclableObject = Js::RecyclableObject::FromVar(thisArg);
-
-            JavascriptString* name = scriptContext->GetLibrary()->CreateStringFromCppLiteral(_u("[object "));
-            name = JavascriptString::Concat(name, recyclableObject->GetClassName(scriptContext));
-            name = JavascriptString::Concat(name, scriptContext->GetLibrary()->CreateStringFromCppLiteral(_u("]")));
-            return name;
-        }
-
-        case TypeIds_HostObject:
-            AssertMsg(false, "Host object should never be here");
-            return library->GetUndefined();
-
-        case TypeIds_StringIterator:
-        case TypeIds_ArrayIterator:
-        case TypeIds_MapIterator:
-        case TypeIds_SetIterator:
-        case TypeIds_DataView:
-        case TypeIds_Promise:
-        case TypeIds_Boolean:
-        case TypeIds_BooleanObject:
-        case TypeIds_Date:
-        case TypeIds_WinRTDate:
-        case TypeIds_Error:
-        case TypeIds_Number:
-        case TypeIds_Int64Number:
-        case TypeIds_UInt64Number:
-        case TypeIds_Integer:
-        case TypeIds_NumberObject:
-        case TypeIds_SIMDObject:
-        case TypeIds_RegEx:
-        case TypeIds_Array:
-        case TypeIds_ES5Array:
-        case TypeIds_NativeIntArray:
-#if ENABLE_COPYONACCESS_ARRAY
-        case TypeIds_CopyOnAccessNativeIntArray:
-#endif
-        case TypeIds_NativeFloatArray:
-        case TypeIds_Function:
-        case TypeIds_String:
-        case TypeIds_StringObject:
-        case TypeIds_Arguments:
-            return ToStringTagHelperOld(thisArg, scriptContext, type);
-
-        case TypeIds_GlobalObject:
-        {
-            GlobalObject* globalObject = static_cast<Js::GlobalObject*>(thisArg);
-            AssertMsg(globalObject == thisArg, "Should be the global object");
-
-            Var toThis = globalObject->ToThis();
-            if (toThis == globalObject)
-            {
-                return library->GetObjectDisplayString();
-            }
-            else
-            {
-                return ToStringTagHelperOld(toThis, scriptContext, type);
-            }
-        }
-        case TypeIds_HostDispatch:
-        {
-            RecyclableObject* hostDispatchObject = RecyclableObject::FromVar(thisArg);
-            DynamicObject* remoteObject = hostDispatchObject->GetRemoteObject();
-            if (remoteObject)
-            {
-                return ToStringTagHelperOld(remoteObject, scriptContext, type);
-            }
-            return library->GetObjectDisplayString();
-        }
-
-        case TypeIds_ArrayBuffer:
-        case TypeIds_Int8Array:
-        case TypeIds_Uint8Array:
-        case TypeIds_Uint8ClampedArray:
-        case TypeIds_Int16Array:
-        case TypeIds_Uint16Array:
-        case TypeIds_Int32Array:
-        case TypeIds_Uint32Array:
-        case TypeIds_Float32Array:
-        case TypeIds_Float64Array:
-        case TypeIds_Symbol:
-        case TypeIds_SymbolObject:
-        case TypeIds_Map:
-        case TypeIds_Set:
-        case TypeIds_WeakMap:
-        case TypeIds_WeakSet:
-        case TypeIds_Generator:
-            return LegacyToStringHelper(scriptContext, type);
-        }
+        // By this point, we should be in the correct context, but the thisArg may still need to be marshalled (for to the implicit ToObject conversion call.)
+        return ToStringTagHelper(CrossSite::MarshalVar(scriptContext, thisArg), scriptContext, type);
     }
 
     // -----------------------------------------------------------

--- a/lib/Runtime/Library/JavascriptObject.cpp
+++ b/lib/Runtime/Library/JavascriptObject.cpp
@@ -457,8 +457,24 @@ namespace Js
 
             // 14. Else, let builtinTag be "Object".
         default:
-            builtInTag = library->GetObjectDisplayString(); // [object Object]
+        {
+            if (thisArgAsObject->IsExternal())
+            {
+                CompoundString::Builder<32> stringBuilder(scriptContext);
+
+                stringBuilder.AppendChars(_u("[object "));
+
+                stringBuilder.AppendChars(thisArgAsObject->GetClassName(scriptContext));
+                stringBuilder.AppendChars(_u(']'));
+
+                return stringBuilder.ToString();
+            }
+            else
+            {
+                builtInTag = library->GetObjectDisplayString(); // [object Object]
+            }
             break;
+        }
         }
 
         Assert(builtInTag != nullptr);

--- a/lib/Runtime/Library/JavascriptObject.h
+++ b/lib/Runtime/Library/JavascriptObject.h
@@ -107,9 +107,7 @@ namespace Js
 
         static BOOL DefineOwnPropertyHelper(RecyclableObject* obj, PropertyId propId, const PropertyDescriptor& descriptor, ScriptContext* scriptContext, bool throwOnError = true);
         static Var ToStringHelper(Var thisArg, ScriptContext* scriptContext);
-        static Var LegacyToStringHelper(ScriptContext* scriptContext, TypeId type);
         static JavascriptString* ToStringTagHelper(Var thisArg, ScriptContext* scriptContext, TypeId type);
-        static JavascriptString* ToStringTagHelperOld(Var thisArg, ScriptContext* scriptContext, TypeId type);
 
     private:
         static void AssignForGenericObjects(RecyclableObject* from, RecyclableObject* to, ScriptContext* scriptContext);

--- a/test/es6/ES6TypedArrayExtensions.js
+++ b/test/es6/ES6TypedArrayExtensions.js
@@ -456,21 +456,18 @@ var tests = [
             var typedArrayPrototype = Int8Array.prototype.__proto__;
             var descriptor = Object.getOwnPropertyDescriptor(typedArrayPrototype, Symbol.toStringTag);
 
-            assert.throws(function () { typedArrayPrototype.length; }, TypeError, "%TypedArrayPrototype%[@@toStringTag] throws TypeError if called with no parameter", "'this' is not a typed array object");
-            assert.throws(function () { descriptor.get(); }, TypeError, "%TypedArrayPrototype%[@@toStringTag] throws TypeError if called with no parameter", "'this' is not a typed array object");
-            assert.throws(function () { descriptor.get.call(); }, TypeError, "%TypedArrayPrototype%[@@toStringTag] throws TypeError if called with no parameter", "'this' is not a typed array object");
-            assert.throws(function () { descriptor.get.call(undefined); }, TypeError, "%TypedArrayPrototype%[@@toStringTag] throws TypeError if called with no parameter", "'this' is not a typed array object");
-            assert.throws(function () { descriptor.get.call([1,2,3]); }, TypeError, "%TypedArrayPrototype%[@@toStringTag] throws TypeError if called with a non-TypedArray parameter", "'this' is not a typed array object");
+            assert.throws(function () { typedArrayPrototype.length; }, TypeError, "%TypedArrayPrototype%[length] throws TypeError if called with no parameter", "'this' is not a typed array object");
+            assert.areEqual(undefined, descriptor.get.call(), "%TypedArrayPrototype%[@@toStringTag] returns undefined if called with no parameter");
 
-            assert.areEqual('Int8Array', new Int8Array(10)[Symbol.toStringTag], "new Int8Array()[@@toStringTag] === 'Int8Array'");
-            assert.areEqual('Uint8Array', new Uint8Array(10)[Symbol.toStringTag], "new Uint8Array()[@@toStringTag] === 'Uint8Array'");
+            assert.areEqual('Int8Array',         new Int8Array(10)[Symbol.toStringTag],         "new Int8Array()[@@toStringTag] === 'Int8Array'");
+            assert.areEqual('Uint8Array',        new Uint8Array(10)[Symbol.toStringTag],        "new Uint8Array()[@@toStringTag] === 'Uint8Array'");
             assert.areEqual('Uint8ClampedArray', new Uint8ClampedArray(10)[Symbol.toStringTag], "new Uint8ClampedArray()[@@toStringTag] === 'Uint8ClampedArray'");
-            assert.areEqual('Int16Array', new Int16Array(10)[Symbol.toStringTag], "new Int16Array()[@@toStringTag] === 'Int16Array'");
-            assert.areEqual('Uint16Array', new Uint16Array(10)[Symbol.toStringTag], "new Uint16Array()[@@toStringTag] === 'Uint16Array'");
-            assert.areEqual('Int32Array', new Int32Array(10)[Symbol.toStringTag], "new Int32Array()[@@toStringTag] === 'Int32Array'");
-            assert.areEqual('Uint32Array', new Uint32Array(10)[Symbol.toStringTag], "new Uint32Array()[@@toStringTag] === 'Uint32Array'");
-            assert.areEqual('Float32Array', new Float32Array(10)[Symbol.toStringTag], "new Float32Array()[@@toStringTag] === 'Float32Array'");
-            assert.areEqual('Float64Array', new Float64Array(10)[Symbol.toStringTag], "new Float64Array()[@@toStringTag] === 'Float64Array'");
+            assert.areEqual('Int16Array',        new Int16Array(10)[Symbol.toStringTag],        "new Int16Array()[@@toStringTag] === 'Int16Array'");
+            assert.areEqual('Uint16Array',       new Uint16Array(10)[Symbol.toStringTag],       "new Uint16Array()[@@toStringTag] === 'Uint16Array'");
+            assert.areEqual('Int32Array',        new Int32Array(10)[Symbol.toStringTag],        "new Int32Array()[@@toStringTag] === 'Int32Array'");
+            assert.areEqual('Uint32Array',       new Uint32Array(10)[Symbol.toStringTag],       "new Uint32Array()[@@toStringTag] === 'Uint32Array'");
+            assert.areEqual('Float32Array',      new Float32Array(10)[Symbol.toStringTag],      "new Float32Array()[@@toStringTag] === 'Float32Array'");
+            assert.areEqual('Float64Array',      new Float64Array(10)[Symbol.toStringTag],      "new Float64Array()[@@toStringTag] === 'Float64Array'");
         }
     },
     {

--- a/test/es6/es6_stable.baseline
+++ b/test/es6/es6_stable.baseline
@@ -59,8 +59,8 @@ FLAG ES6 = 1 - setting child flag ES6ToPrimitive = 0
 FLAG ES6ToPrimitive = 0
 FLAG ES6 = 1 - setting child flag ES6ToLength = 0
 FLAG ES6ToLength = 0
-FLAG ES6 = 1 - setting child flag ES6ToStringTag = 0
-FLAG ES6ToStringTag = 0
+FLAG ES6 = 1 - setting child flag ES6ToStringTag = 1
+FLAG ES6ToStringTag = 1
 FLAG ES6 = 1 - setting child flag ES6Unicode = 1
 FLAG ES6Unicode = 1
 FLAG ES6 = 1 - setting child flag ES6UnicodeVerbose = 1

--- a/test/es6/es6_stable.enable_disable.baseline
+++ b/test/es6/es6_stable.enable_disable.baseline
@@ -59,8 +59,8 @@ FLAG ES6 = 1 - setting child flag ES6ToPrimitive = 0
 FLAG ES6ToPrimitive = 0
 FLAG ES6 = 1 - setting child flag ES6ToLength = 0
 FLAG ES6ToLength = 0
-FLAG ES6 = 1 - setting child flag ES6ToStringTag = 0
-FLAG ES6ToStringTag = 0
+FLAG ES6 = 1 - setting child flag ES6ToStringTag = 1
+FLAG ES6ToStringTag = 1
 FLAG ES6 = 1 - setting child flag ES6Unicode = 1
 FLAG ES6Unicode = 1
 FLAG ES6 = 1 - setting child flag ES6UnicodeVerbose = 1

--- a/test/es6/proxytest9.baseline
+++ b/test/es6/proxytest9.baseline
@@ -120,4 +120,5 @@ foo called
 42
 expected :method  is called on a revoked Proxy object
 expected :method get is called on a revoked Proxy object
+expected :method toObject is called on a revoked Proxy object
 expected :method construct is called on a revoked Proxy object

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -73,7 +73,7 @@
   <test>
     <default>
       <files>toPrimitive.js</files>
-      <compile-flags>-es6regexsymbols -es6toprimitive -es6hasInstance -es6isconcatspreadable -es6tostringtag -es6functionname -args summary -endargs</compile-flags>
+      <compile-flags>-es6regexsymbols -es6toprimitive -es6hasInstance -es6isconcatspreadable -es6functionname -args summary -endargs</compile-flags>
     </default>
   </test>
   <test>
@@ -104,7 +104,7 @@
   <test>
     <default>
       <files>toStringTag.js</files>
-      <compile-flags>-es6tostringtag -args summary -endargs</compile-flags>
+      <compile-flags>-args summary -endargs</compile-flags>
       <tags>exclude_dynapogo</tags>
     </default>
   </test>
@@ -420,7 +420,7 @@
   <test>
     <default>
       <files>ES6TypedArrayExtensions.js</files>
-      <compile-flags> -es6tostringtag -ES6ObjectLiterals -ES6Species -args summary -endargs</compile-flags>
+      <compile-flags>-ES6ObjectLiterals -ES6Species -args summary -endargs</compile-flags>
       <tags>Slow</tags>
     </default>
   </test>
@@ -445,7 +445,7 @@
   <test>
     <default>
       <files>ES6Symbol.js</files>
-      <compile-flags>-ES6ObjectLiterals -es6toprimitive -es6isConcatSpreadable -es6tostringtag -ES6Species -ES6HasInstance -ES6RegExSymbols -args summary -endargs</compile-flags>
+      <compile-flags>-ES6ObjectLiterals -es6toprimitive -es6isConcatSpreadable -ES6Species -ES6HasInstance -ES6RegExSymbols -args summary -endargs</compile-flags>
     </default>
   </test>
   <test>
@@ -458,7 +458,7 @@
   <test>
     <default>
       <files>ES6Promise.js</files>
-      <compile-flags> -ES6 -ES6Promise -es6tostringtag -ES6Species -args summary -endargs</compile-flags>
+      <compile-flags> -ES6 -ES6Promise -ES6Species -args summary -endargs</compile-flags>
     </default>
   </test>
   <test>
@@ -661,7 +661,7 @@
   <test>
     <default>
       <files>ES6Iterators-apis.js</files>
-      <compile-flags>-ES6 -es6tostringtag -Intl- -args summary -endargs</compile-flags>
+      <compile-flags>-ES6 -Intl- -args summary -endargs</compile-flags>
     </default>
   </test>
   <test>
@@ -798,7 +798,7 @@
   <test>
     <default>
       <files>generators-apis.js</files>
-      <compile-flags>-ES6Generators -es6tostringtag -JitES6Generators -args summary -endargs</compile-flags>
+      <compile-flags>-ES6Generators -JitES6Generators -args summary -endargs</compile-flags>
       <tags>exclude_arm</tags>
     </default>
   </test>

--- a/test/es7/rlexe.xml
+++ b/test/es7/rlexe.xml
@@ -35,7 +35,7 @@
   <test>
     <default>
       <files>asyncawait-apis.js</files>
-      <compile-flags>-es7asyncawait -es6tostringtag -args summary -endargs</compile-flags>
+      <compile-flags>-es7asyncawait -args summary -endargs</compile-flags>
     </default>
   </test>
   <test>

--- a/test/typedarray/arraybufferType.baseline
+++ b/test/typedarray/arraybufferType.baseline
@@ -1,7 +1,7 @@
-[object Object]
-[object Object]
+[object ArrayBuffer]
+[object ArrayBuffer]
 20
-[object Object]
+[object ArrayBuffer]
 aaa = 20
 foo = 20
 bar = 42


### PR DESCRIPTION
- Enabled @@toStringTag by default. Updated baselines.
- Removed the legacy helpers. We only have one special case now; any external object that would have resulted in [object Object] under new rules reverts back to the class name. This retains compat with both DOM and WinRT.
- Fixed the coverage for proxy which was outdated.
- Fixed OS 8331493, a nightly test that was failing.