### PR TITLE
Move api.cpp from Chakra.Common.Common.lib to Chakra.Common.Core.lib

### DIFF
--- a/lib/Common/Common/CMakeLists.txt
+++ b/lib/Common/Common/CMakeLists.txt
@@ -1,5 +1,4 @@
 add_library (Chakra.Common.Common OBJECT
-    Api.cpp
     CfgLogger.cpp
     CommonCommonPch.cpp
     DateUtilities.cpp

--- a/lib/Common/Common/Chakra.Common.Common.vcxproj
+++ b/lib/Common/Common/Chakra.Common.Common.vcxproj
@@ -37,7 +37,6 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="$(MSBuildThisFileDirectory)Api.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)CfgLogger.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)DateUtilities.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)Event.cpp" />

--- a/lib/Common/Core/Api.cpp
+++ b/lib/Common/Core/Api.cpp
@@ -2,7 +2,7 @@
 // Copyright (C) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
-#include "CommonCommonPch.h"
+#include "CommonCorePch.h"
 
 void __stdcall js_memcpy_s(__bcount(sizeInBytes) void *dst, size_t sizeInBytes, __in_bcount(count) const void *src, size_t count)
 {

--- a/lib/Common/Core/CMakeLists.txt
+++ b/lib/Common/Core/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library (Chakra.Common.Core STATIC
+    Api.cpp
     BinaryFeatureControl.cpp
     CmdParser.cpp
     CodexAssert.cpp

--- a/lib/Common/Core/Chakra.Common.Core.vcxproj
+++ b/lib/Common/Core/Chakra.Common.Core.vcxproj
@@ -29,6 +29,7 @@
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="$(MSBuildThisFileDirectory)Api.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)BinaryFeatureControl.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)CmdParser.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)CodexAssert.cpp" />


### PR DESCRIPTION
The functions inside api.cpp (like js_memcpy_s) could be called when Chakra.Common.Common.lib should not be linked, so move it to Chakra.Common.Core.lib.