### PR TITLE
Wasm: brtable entries are LEBs

### DIFF
--- a/lib/WasmReader/WasmBinaryReader.cpp
+++ b/lib/WasmReader/WasmBinaryReader.cpp
@@ -482,11 +482,11 @@ WasmBinaryReader::BrTableNode()
 
     for (UINT32 i = 0; i < m_currentNode.brTable.numTargets; i++)
     {
-        m_currentNode.brTable.targetTable[i] = ReadConst<uint32>();
-        m_funcState.count += sizeof(uint32);
+        m_currentNode.brTable.targetTable[i] = LEB128(len);
+        m_funcState.count += len;
     }
-    m_currentNode.brTable.defaultTarget = ReadConst<uint32>();
-    m_funcState.count += sizeof(uint32);
+    m_currentNode.brTable.defaultTarget = LEB128(len);
+    m_funcState.count += len;
 }
 
 WasmOp


### PR DESCRIPTION
For binary format 0xc, brtable entries are now LEBs. This is consistent with the spec and current design. The spec test binaries need to be updated pending sexpr-wasm update.  