### PR TITLE
Make -0 output "-0" when doing toString()

### DIFF
--- a/lib/Runtime/Library/JavascriptNumber.cpp
+++ b/lib/Runtime/Library/JavascriptNumber.cpp
@@ -891,6 +891,11 @@ namespace Js
             return nanF;
         }
 
+        if (IsNegZero(value))
+        {
+            return scriptContext->GetLibrary()->CreateStringFromCppLiteral(_u("-0"));
+        }
+
         if (IsZero(value))
         {
             return scriptContext->GetLibrary()->GetCharStringCache().GetStringForCharA('0');


### PR DESCRIPTION
As I was doing some work related to `-0` I realized that we do the following
```
-0..toString() === "0"
0..toString() === "0"
```

Which is very confusing and different than what the other browsers do.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/1390)
<!-- Reviewable:end -->
