### PR TITLE
Change how PAL file I/O functions treat symbolic links

### DIFF
--- a/pal/src/cruntime/filecrt.cpp
+++ b/pal/src/cruntime/filecrt.cpp
@@ -333,34 +333,6 @@ PAL_unlink(const char *szPath)
 
 
 /*++
-InternalDeleteFile
-
-Wrapper that does the same thing as unlink, except that
-it uses the SYS_Delete system call present on Apple instead of unlink.
-
-Input parameters:
-
-szPath = a symbolic link or a hard link to a file
-
-Return value:
-    Returns 0 on success and -1 on failure
---*/
-int
-CorUnix::InternalDeleteFile(
-    const char *szPath
-    )
-{
-    int nRet = -1;
-#if defined(__APPLE__) && defined(SYS_delete)
-    nRet = syscall(SYS_delete, szPath);
-#else
-    nRet = unlink(szPath);
-#endif // defined(__APPLE__) && defined(SYS_delete)
-    return nRet;
-}
-
-
-/*++
 PAL_rename
 
 Wrapper function for rename.

--- a/pal/src/file/directory.cpp
+++ b/pal/src/file/directory.cpp
@@ -136,11 +136,6 @@ RemoveDirectoryHelper (
     *dwLastError = 0; 
 
     FILEDosToUnixPathA( lpPathName );
-    if ( !FILEGetFileNameFromSymLink(lpPathName))
-    {
-        FILEGetProperNotFoundError( lpPathName, dwLastError );
-        goto done;
-    }
 
     if ( rmdir(lpPathName) != 0 )
     {
@@ -179,7 +174,6 @@ RemoveDirectoryHelper (
         bRet = TRUE;
     }
 
-done:
     return bRet;
 }
 

--- a/pal/src/include/pal/file.h
+++ b/pal/src/include/pal/file.h
@@ -159,21 +159,6 @@ Close promary handles for stdin, stdout and stderr
 void FILECleanupStdHandles(void);
 
 /*++
-FILEGetFileNameFromSymLink
-
-Input paramters:
-
-source  = path to the file on input, path to the file with all 
-          symbolic links traversed on return
-
-Note: Assumes the maximum size of the source is MAX_LONGPATH
-
-Return value:
-    TRUE on success, FALSE on failure
---*/
-BOOL FILEGetFileNameFromSymLink(char *source);
-
-/*++
 
 Function : 
     FILEGetProperNotFoundError

--- a/pal/src/include/pal/file.hpp
+++ b/pal/src/include/pal/file.hpp
@@ -195,15 +195,6 @@ namespace CorUnix
         );
 
     /*++
-    InternalDeleteFile
-    Wraps SYS_delete
-    --*/
-    int 
-    InternalDeleteFile(
-        const char *szPath
-        );
-
-    /*++
     InternalFgets
     Wraps fgets
     --*/
@@ -357,21 +348,6 @@ Close primary handles for stdin, stdout and stderr
 (no parameters, no return value)
 --*/
 void FILECleanupStdHandles(void);
-
-/*++
-FILEGetFileNameFromSymLink
-
-Input paramters:
-
-source  = path to the file on input, path to the file with all 
-          symbolic links traversed on return
-
-Note: Assumes the maximum size of the source is MAX_LONGPATH
-
-Return value:
-    TRUE on success, FALSE on failure
---*/
-BOOL FILEGetFileNameFromSymLink(char *source);
 
 /*++
 


### PR DESCRIPTION
Synchronize changes made by @adityamandaleeka in https://github.com/dotnet/coreclr/pull/4922

Fixes build on macOS Sierra:
`ChakraCore/pal/src/cruntime/filecrt.cpp:355:12: error: 'syscall' is deprecated: first deprecated in macOS 10.12 - syscall(2) is unsupported; please switch to a supported interface. For SYS_kdebug_trace use kdebug_signpost(). [-Werror,-Wdeprecated-declarations]`