### PR TITLE
Add dtor for CapturedValues to make its SListBase members to be exception safe

### DIFF
--- a/lib/Backend/GlobOptBailOut.cpp
+++ b/lib/Backend/GlobOptBailOut.cpp
@@ -240,12 +240,10 @@ GlobOpt::CaptureValues(BasicBlock *block, BailOutInfo * bailOutInfo)
     bailOutInfo->capturedValues.constantValues.Clear(this->func->m_alloc);
     bailOutConstValuesIter.SetNext(&bailOutInfo->capturedValues.constantValues);
     bailOutInfo->capturedValues.constantValues = capturedValues.constantValues;
-    capturedValues.constantValues.Reset();
 
     bailOutInfo->capturedValues.copyPropSyms.Clear(this->func->m_alloc);
     bailOutCopySymsIter.SetNext(&bailOutInfo->capturedValues.copyPropSyms);
     bailOutInfo->capturedValues.copyPropSyms = capturedValues.copyPropSyms;
-    capturedValues.copyPropSyms.Reset();
     
     if (!PHASE_OFF(Js::IncrementalBailoutPhase, func))
     {

--- a/lib/Backend/IR.h
+++ b/lib/Backend/IR.h
@@ -26,6 +26,14 @@ struct CapturedValues
     SListBase<ConstantStackSymValue> constantValues;           // Captured constant values during glob opt
     SListBase<CopyPropSyms> copyPropSyms;                      // Captured copy prop values during glob opt
     BVSparse<JitArenaAllocator> * argObjSyms;                  // Captured arg object symbols during glob opt
+
+    ~CapturedValues()
+    {
+        // Reset SListBase to be exception safe. Captured values are from GlobOpt->func->alloc
+        // in normal case the 2 SListBase are empty so no Clear needed, also no need to Clear in exception case
+        constantValues.Reset();
+        copyPropSyms.Reset();
+    }
 };
 
 class LoweredBasicBlock;


### PR DESCRIPTION
CapturedValues with 2 members of SListBase is used as stack variable in GlobOpt. The dtor of SListBase will complain if exception happened before destructing CapturedValues.  This fix added dtor to CapturedValues to Reset 2 SListBase member before destruct them.