### PR TITLE
WScript.GetDirectory() & WScript.GetFileName()

### DIFF
--- a/bin/ch/ChakraRtInterface.cpp
+++ b/bin/ch/ChakraRtInterface.cpp
@@ -79,6 +79,8 @@ bool ChakraRTInterface::LoadChakraDll(ArgInfo* argInfo, HINSTANCE *outLibrary)
     m_jsApiHooks.pfJsrtSetRuntimeMemoryLimit = (JsAPIHooks::JsrtSetRuntimeMemoryLimitPtr)GetChakraCoreSymbol(library, "JsSetRuntimeMemoryLimit");
     m_jsApiHooks.pfJsrtSetCurrentContext = (JsAPIHooks::JsrtSetCurrentContextPtr)GetChakraCoreSymbol(library, "JsSetCurrentContext");
     m_jsApiHooks.pfJsrtGetCurrentContext = (JsAPIHooks::JsrtGetCurrentContextPtr)GetChakraCoreSymbol(library, "JsGetCurrentContext");
+    m_jsApiHooks.pfJsrtSetContextData = (JsAPIHooks::JsrtSetContextDataPtr)GetChakraCoreSymbol(library, "JsSetContextData");
+    m_jsApiHooks.pfJsrtGetContextData = (JsAPIHooks::JsrtGetContextDataPtr)GetChakraCoreSymbol(library, "JsGetContextData");
     m_jsApiHooks.pfJsrtDisposeRuntime = (JsAPIHooks::JsrtDisposeRuntimePtr)GetChakraCoreSymbol(library, "JsDisposeRuntime");
     m_jsApiHooks.pfJsrtCreateObject = (JsAPIHooks::JsrtCreateObjectPtr)GetChakraCoreSymbol(library, "JsCreateObject");
     m_jsApiHooks.pfJsrtCreateExternalObject = (JsAPIHooks::JsrtCreateExternalObjectPtr)GetChakraCoreSymbol(library, "JsCreateExternalObject");

--- a/bin/ch/ChakraRtInterface.h
+++ b/bin/ch/ChakraRtInterface.h
@@ -11,6 +11,8 @@ struct JsAPIHooks
     typedef JsErrorCode (WINAPI *JsrtSetRuntimeMemoryLimitPtr)(JsRuntimeHandle runtime, size_t memoryLimit);
     typedef JsErrorCode (WINAPI *JsrtSetCurrentContextPtr)(JsContextRef context);
     typedef JsErrorCode (WINAPI *JsrtGetCurrentContextPtr)(JsContextRef* context);
+    typedef JsErrorCode (WINAPI *JsrtSetContextDataPtr)(JsContextRef context, void* data);
+    typedef JsErrorCode (WINAPI *JsrtGetContextDataPtr)(JsContextRef context, void** data);
     typedef JsErrorCode (WINAPI *JsrtDisposeRuntimePtr)(JsRuntimeHandle runtime);
     typedef JsErrorCode (WINAPI *JsrtCreateObjectPtr)(JsValueRef *object);
     typedef JsErrorCode (WINAPI *JsrtCreateExternalObjectPtr)(void* data, JsFinalizeCallback callback, JsValueRef *object);
@@ -102,6 +104,8 @@ struct JsAPIHooks
     JsrtSetRuntimeMemoryLimitPtr pfJsrtSetRuntimeMemoryLimit;
     JsrtSetCurrentContextPtr pfJsrtSetCurrentContext;
     JsrtGetCurrentContextPtr pfJsrtGetCurrentContext;
+    JsrtSetContextDataPtr pfJsrtSetContextData;
+    JsrtGetContextDataPtr pfJsrtGetContextData;
     JsrtDisposeRuntimePtr pfJsrtDisposeRuntime;
     JsrtCreateObjectPtr pfJsrtCreateObject;
     JsrtCreateExternalObjectPtr pfJsrtCreateExternalObject;
@@ -272,6 +276,8 @@ public:
     static JsErrorCode WINAPI JsSetRuntimeMemoryLimit(JsRuntimeHandle runtime, size_t memory) { return HOOK_JS_API(SetRuntimeMemoryLimit(runtime, memory)); }
     static JsErrorCode WINAPI JsSetCurrentContext(JsContextRef context) { return HOOK_JS_API(SetCurrentContext(context)); }
     static JsErrorCode WINAPI JsGetCurrentContext(JsContextRef* context) { return HOOK_JS_API(GetCurrentContext(context)); }
+    static JsErrorCode WINAPI JsSetContextData(JsContextRef context, void* data) { return HOOK_JS_API(SetContextData(context, data)); }
+    static JsErrorCode WINAPI JsGetContextData(JsContextRef context, void** data) { return HOOK_JS_API(GetContextData(context, data)); }
     static JsErrorCode WINAPI JsDisposeRuntime(JsRuntimeHandle runtime) { return HOOK_JS_API(DisposeRuntime(runtime)); }
     static JsErrorCode WINAPI JsCreateObject(JsValueRef *object) { return HOOK_JS_API(CreateObject(object)); }
     static JsErrorCode WINAPI JsCreateExternalObject(void *data, JsFinalizeCallback callback, JsValueRef *object) { return HOOK_JS_API(CreateExternalObject(data, callback, object)); }

--- a/bin/ch/WScriptJsrt.h
+++ b/bin/ch/WScriptJsrt.h
@@ -8,7 +8,16 @@ class WScriptJsrt
 {
 public:
     static bool Initialize();
-
+    struct ContextData
+    {
+        char* scriptFullPath = nullptr;
+        ContextData(const char* fullPath) {
+            scriptFullPath = _strdup(fullPath);
+        }
+        ~ContextData() {
+            delete[] scriptFullPath;
+        }
+    };
     class CallbackMessage : public MessageBase
     {
         JsValueRef m_function;
@@ -91,6 +100,8 @@ private:
     static bool CreateNamedFunction(const char*, JsNativeFunction callback, JsValueRef* functionVar);
     static JsValueRef __stdcall EchoCallback(JsValueRef callee, bool isConstructCall, JsValueRef *arguments, unsigned short argumentCount, void *callbackState);
     static JsValueRef __stdcall QuitCallback(JsValueRef callee, bool isConstructCall, JsValueRef *arguments, unsigned short argumentCount, void *callbackState);
+    static JsValueRef __stdcall GetDirectoryCallback(JsValueRef callee, bool isConstructCall, JsValueRef *arguments, unsigned short argumentCount, void *callbackState);
+    static JsValueRef __stdcall GetFileNameCallback(JsValueRef callee, bool isConstructCall, JsValueRef *arguments, unsigned short argumentCount, void *callbackState);
     static JsValueRef __stdcall LoadScriptFileCallback(JsValueRef callee, bool isConstructCall, JsValueRef *arguments, unsigned short argumentCount, void *callbackState);
     static JsValueRef __stdcall LoadScriptCallback(JsValueRef callee, bool isConstructCall, JsValueRef *arguments, unsigned short argumentCount, void *callbackState);
     static JsValueRef __stdcall LoadModuleCallback(JsValueRef callee, bool isConstructCall, JsValueRef *arguments, unsigned short argumentCount, void *callbackState);

--- a/test/host/nestedDir/scriptDirFile_4.js
+++ b/test/host/nestedDir/scriptDirFile_4.js
@@ -1,0 +1,6 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+__filename4 = WScript.GetFileName();
+__dirname4 = WScript.GetDirectory();

--- a/test/host/nestedDir/scriptDirFile_5.js
+++ b/test/host/nestedDir/scriptDirFile_5.js
@@ -1,0 +1,6 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+__filename5 = WScript.GetFileName();
+__dirname5 = WScript.GetDirectory();

--- a/test/host/rlexe.xml
+++ b/test/host/rlexe.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<regress-exe>
+  <test>
+    <default>
+      <files>scriptDirFile.js</files>
+    </default>
+  </test>
+</regress-exe>

--- a/test/host/scriptDirFile.js
+++ b/test/host/scriptDirFile.js
@@ -1,0 +1,28 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+const __filename = WScript.GetFileName();
+const __dirname = WScript.GetDirectory();
+const {__filename2, __dirname2} = WScript.LoadScriptFile(`${__dirname}\\scriptDirFile_2.js`, "samethread");
+WScript.LoadScriptFile(`${__dirname}\\scriptDirFile_3.js`, "self");
+const {__filename4, __dirname4} = WScript.LoadScriptFile(`${__dirname}\\nestedDir\\scriptDirFile_4.js`, "samethread");
+WScript.LoadScriptFile(`${__dirname}\\nestedDir\\scriptDirFile_5.js`, "self");
+
+// Because of a limitation in how we load scripts 3 and 5 ("self")
+// From these scripts perspective, WScript.GetFileName() & WScript.GetDirectory()
+// will be equal to the current script's path
+if (
+  __dirname === __dirname2 &&
+  __dirname === __dirname3 &&
+  __dirname === __dirname5 && // This should be different without "self"
+  __filename === __filename3 && // This should be different without "self"
+  __filename === __filename5 && // This should be different without "self"
+  __dirname !== __dirname4 &&
+  __filename !== __filename2 &&
+  __filename !== __filename4
+) {
+  print("PASSED");
+} else {
+  print("FAILED");
+}

--- a/test/host/scriptDirFile_2.js
+++ b/test/host/scriptDirFile_2.js
@@ -1,0 +1,6 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+__filename2 = WScript.GetFileName();
+__dirname2 = WScript.GetDirectory();

--- a/test/host/scriptDirFile_3.js
+++ b/test/host/scriptDirFile_3.js
@@ -1,0 +1,6 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+__filename3 = WScript.GetFileName();
+__dirname3 = WScript.GetDirectory();

--- a/test/rlexedirs.xml
+++ b/test/rlexedirs.xml
@@ -247,6 +247,11 @@
 </dir>
 <dir>
   <default>
+    <files>host</files>
+  </default>
+</dir>
+<dir>
+  <default>
     <files>stackfunc</files>
     <tags>exclude_serialized,require_backend</tags>
   </default>


### PR DESCRIPTION
Add WScript.GetFileName() and WScript.GetDirectory(), similar to __filename and __dirname in node.js.

Too often when trying to debug a file, you end up needing to either move to the script's directory or change your debugger to start in that script's directory.
Currently, there is no way to workaround this problem.

Will be able to do 

```
WScript.LoadScriptFile(WScript.GetDirectory() + "../TestHarness.js"); 
```

Then run that script from anywhere.

Additionally, we could append the script's current directory to `WScript.LoadScriptFile` `read` `readbuffer` if it uses relative paths.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/1399)

<!-- Reviewable:end -->
