### PR TITLE
Cleanup JavascriptEnumerator interface

### DIFF
--- a/lib/Runtime/Base/CrossSiteEnumerator.h
+++ b/lib/Runtime/Base/CrossSiteEnumerator.h
@@ -28,33 +28,14 @@ namespace Js
         DEFINE_VTABLE_CTOR(CrossSiteEnumerator<T>, T);
 
     public:
-        virtual Var GetCurrentIndex() override;
         virtual void Reset() override;
-        virtual BOOL MoveNext(PropertyAttributes* attributes = nullptr) override;
-        virtual Var GetCurrentAndMoveNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
+        virtual Var MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
         virtual BOOL IsCrossSiteEnumerator() override
         {
             return true;
         }
 
     };
-
-    template<typename T>
-    Var CrossSiteEnumerator<T>::GetCurrentIndex()
-    {
-        Var result = __super::GetCurrentIndex();
-        if (result)
-        {
-            result = CrossSite::MarshalVar(this->GetScriptContext(), result);
-        }
-        return result;
-    }
-
-    template <typename T>
-    BOOL CrossSiteEnumerator<T>::MoveNext(PropertyAttributes* attributes)
-    {
-        return __super::MoveNext(attributes);
-    }
 
     template <typename T>
     void CrossSiteEnumerator<T>::Reset()
@@ -63,9 +44,9 @@ namespace Js
     }
 
     template <typename T>
-    Var CrossSiteEnumerator<T>::GetCurrentAndMoveNext(PropertyId& propertyId, PropertyAttributes* attributes)
+    Var CrossSiteEnumerator<T>::MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes)
     {
-        Var result = __super::GetCurrentAndMoveNext(propertyId, attributes);
+        Var result = __super::MoveAndGetNext(propertyId, attributes);
         if (result)
         {
             result = CrossSite::MarshalVar(this->GetScriptContext(), result);

--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -9116,7 +9116,7 @@ void EmitForIn(ParseNode *loopNode,
     // The EndStatement will happen in the EmitForInOfLoopBody function
     byteCodeGenerator->StartStatement(loopNode->sxForInOrForOf.pnodeLval);
 
-    // branch past loop when GetCurrentAndMoveNext returns nullptr
+    // branch past loop when MoveAndGetNext returns nullptr
     byteCodeGenerator->Writer()->BrReg2(Js::OpCode::BrOnEmpty, continuePastLoop, loopNode->sxForInOrForOf.itemLocation, loopNode->location);
     
     EmitForInOfLoopBody(loopNode, loopEntrance, continuePastLoop, byteCodeGenerator, funcInfo, fReturnValue);

--- a/lib/Runtime/Debug/DiagObjectModel.cpp
+++ b/lib/Runtime/Debug/DiagObjectModel.cpp
@@ -2063,7 +2063,8 @@ namespace Js
                         if (object->CanHaveInterceptors())
                         {
                             Js::ForInObjectEnumerator enumerator(object, object->GetScriptContext(), /* enumSymbols */ true);
-                            if (enumerator.MoveNext())
+                            Js::PropertyId propertyId;
+                            if (enumerator.MoveAndGetNext(propertyId))
                             {
                                 enumerator.Clear();
                                 return TRUE;
@@ -2378,7 +2379,7 @@ namespace Js
                                 Js::PropertyId propertyId;
                                 Var obj;
 
-                                while ((obj = enumerator->GetCurrentAndMoveNext(propertyId)) != nullptr)
+                                while ((obj = enumerator->MoveAndGetNext(propertyId)) != nullptr)
                                 {
                                     if (!JavascriptString::Is(obj))
                                     {
@@ -2402,7 +2403,7 @@ namespace Js
                                             propertyId = propertyRecord->GetPropertyId();
                                         }
                                     }
-                                    // GetCurrentAndMoveNext shouldn't return an internal property id
+                                    // MoveAndGetNext shouldn't return an internal property id
                                     Assert(!Js::IsInternalPropertyId(propertyId));
 
                                     uint32 indexVal;

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -5214,7 +5214,7 @@ CommonNumber:
     Var JavascriptOperators::OP_BrOnEmpty(ForInObjectEnumerator * aEnumerator)
     {
         PropertyId id;
-        return aEnumerator->GetCurrentAndMoveNext(id);
+        return aEnumerator->MoveAndGetNext(id);
     }
 
     ForInObjectEnumerator * JavascriptOperators::OP_GetForInEnumerator(Var enumerable, ScriptContext* scriptContext)

--- a/lib/Runtime/Library/ArgumentsObjectEnumerator.h
+++ b/lib/Runtime/Library/ArgumentsObjectEnumerator.h
@@ -22,10 +22,8 @@ namespace Js
 
     public:
         ArgumentsObjectEnumerator(ArgumentsObject* argumentsObject, ScriptContext* requestcontext, BOOL enumNonEnumerable, bool enumSymbols = false);
-        virtual Var GetCurrentIndex() override;        
-        virtual BOOL MoveNext(PropertyAttributes* attributes = nullptr) override;
         virtual void Reset() override;
-        virtual bool GetCurrentPropertyId(PropertyId *propertyId) override;
+        virtual Var MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
     };
 
     class ES5ArgumentsObjectEnumerator : public ArgumentsObjectEnumerator
@@ -36,10 +34,8 @@ namespace Js
 
     public:
         ES5ArgumentsObjectEnumerator(ArgumentsObject* argumentsObject, ScriptContext* requestcontext, BOOL enumNonEnumerable, bool enumSymbols = false);
-
-        virtual BOOL MoveNext(PropertyAttributes* attributes = nullptr) override;
         virtual void Reset() override;
-
+        virtual Var MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
     private:
         uint enumeratedFormalsInObjectArrayCount;  // The number of enumerated formals for far.
     };

--- a/lib/Runtime/Library/ES5ArrayEnumerator.cpp
+++ b/lib/Runtime/Library/ES5ArrayEnumerator.cpp
@@ -17,21 +17,7 @@ namespace Js
         Reset();
     }
 
-    Var ES5ArrayEnumerator::GetCurrentIndex()
-    {
-        if (!doneArray && index != JavascriptArray::InvalidIndex)
-        {
-            return arrayObject->GetScriptContext()->GetIntegerString(index);
-        }
-        else if (!doneObject)
-        {
-            return objectEnumerator->GetCurrentIndex();
-        }
-
-        return GetLibrary()->GetUndefined();
-    }
-
-    Var ES5ArrayEnumerator::GetCurrentAndMoveNext(PropertyId& propertyId, PropertyAttributes* attributes)
+    Var ES5ArrayEnumerator::MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes)
     {
         propertyId = Constants::NoProperty;
 
@@ -77,7 +63,7 @@ namespace Js
         }
         if (!doneObject)
         {
-            Var currentIndex = objectEnumerator->GetCurrentAndMoveNext(propertyId, attributes);
+            Var currentIndex = objectEnumerator->MoveAndGetNext(propertyId, attributes);
             if (currentIndex)
             {
                 return currentIndex;

--- a/lib/Runtime/Library/ES5ArrayEnumerator.h
+++ b/lib/Runtime/Library/ES5ArrayEnumerator.h
@@ -24,8 +24,7 @@ namespace Js
 
     public:
         ES5ArrayEnumerator(Var originalInstance, ES5Array* arrayObject, ScriptContext* scriptContext, BOOL enumNonEnumerable, bool enumSymbols = false);
-        virtual Var GetCurrentIndex() override;
         virtual void Reset() override;
-        virtual Var GetCurrentAndMoveNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
+        virtual Var MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
     };
 }

--- a/lib/Runtime/Library/ForInObjectEnumerator.cpp
+++ b/lib/Runtime/Library/ForInObjectEnumerator.cpp
@@ -136,12 +136,7 @@ namespace Js
 
     Var ForInObjectEnumerator::GetCurrentIndex()
     {
-        if (currentIndex)
-        {
-            return currentIndex;
-        }
-        Assert(currentEnumerator != nullptr);
-        return currentEnumerator->GetCurrentIndex();
+        return currentIndex;
     }
 
     BOOL ForInObjectEnumerator::TestAndSetEnumerated(PropertyId propertyId)
@@ -155,11 +150,11 @@ namespace Js
     BOOL ForInObjectEnumerator::MoveNext()
     {
         PropertyId propertyId;
-        currentIndex = GetCurrentAndMoveNext(propertyId);
+        currentIndex = MoveAndGetNext(propertyId);
         return currentIndex != NULL;
     }
 
-    Var ForInObjectEnumerator::GetCurrentAndMoveNext(PropertyId& propertyId)
+    Var ForInObjectEnumerator::MoveAndGetNext(PropertyId& propertyId)
     {
         JavascriptEnumerator *pEnumerator = currentEnumerator;
         PropertyRecord const * propRecord;
@@ -168,7 +163,7 @@ namespace Js
         while (true)
         {
             propertyId = Constants::NoProperty;
-            currentIndex = pEnumerator->GetCurrentAndMoveNext(propertyId, &attributes);
+            currentIndex = pEnumerator->MoveAndGetNext(propertyId, &attributes);
 #if ENABLE_COPYONACCESS_ARRAY
             JavascriptLibrary::CheckAndConvertCopyOnAccessNativeIntArray<Var>(currentIndex);
 #endif
@@ -177,7 +172,7 @@ namespace Js
                 if (firstPrototype == nullptr)
                 {
                     // We are calculating correct shadowing for non-enumerable properties of the child object, we will receive
-                    // both enumerable and non-enumerable properties from GetCurrentAndMoveNext so we need to check before we simply
+                    // both enumerable and non-enumerable properties from MoveAndGetNext so we need to check before we simply
                     // return here. If this property is non-enumerable we're going to skip it.
                     if (!(attributes & PropertyEnumerable))
                     {

--- a/lib/Runtime/Library/ForInObjectEnumerator.h
+++ b/lib/Runtime/Library/ForInObjectEnumerator.h
@@ -39,7 +39,7 @@ namespace Js
         Var GetCurrentIndex();        
         BOOL MoveNext();
         void Reset();
-        Var GetCurrentAndMoveNext(PropertyId& propertyId);
+        Var MoveAndGetNext(PropertyId& propertyId);
 
         static uint32 GetOffsetOfCurrentEnumerator() { return offsetof(ForInObjectEnumerator, currentEnumerator); }
         static uint32 GetOffsetOfFirstPrototype() { return offsetof(ForInObjectEnumerator, firstPrototype); }
@@ -56,12 +56,10 @@ namespace Js
         {
         }
 
-        virtual Var GetCurrentIndex() override { return forInObjectEnumerator.GetCurrentIndex(); }
-        virtual BOOL MoveNext(PropertyAttributes* attributes = nullptr) override { return forInObjectEnumerator.MoveNext(); }
         virtual void Reset() override { forInObjectEnumerator.Reset(); }
-        virtual Var GetCurrentAndMoveNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr)
+        virtual Var MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr)
         {
-            return forInObjectEnumerator.GetCurrentAndMoveNext(propertyId);
+            return forInObjectEnumerator.MoveAndGetNext(propertyId);
         }
     protected:
         DEFINE_VTABLE_CTOR(ForInObjectEnumeratorWrapper, JavascriptEnumerator);

--- a/lib/Runtime/Library/IteratorObjectEnumerator.cpp
+++ b/lib/Runtime/Library/IteratorObjectEnumerator.cpp
@@ -20,43 +20,17 @@ namespace Js
         iteratorObject = RecyclableObject::FromVar(iterator);
     }
 
-    void IteratorObjectEnumerator::EnsureIterator()
-    {
-        if (value == nullptr)
-        {
-            MoveNext();
-        }
-    }
-
-    Var IteratorObjectEnumerator::GetCurrentIndex()
-    {
-        EnsureIterator();
-        if (done)
-        {
-            return GetScriptContext()->GetLibrary()->GetUndefined();
-        }
-        return value;
-    }
-
-    BOOL IteratorObjectEnumerator::MoveNext(PropertyAttributes* attributes)
+    Var IteratorObjectEnumerator::MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes)
     {
         ScriptContext* scriptContext = GetScriptContext();
-        done = !JavascriptOperators::IteratorStepAndValue(iteratorObject, scriptContext, &value);
-
-        if (attributes != nullptr)
+        if (JavascriptOperators::IteratorStepAndValue(iteratorObject, scriptContext, &value))
         {
-            *attributes = PropertyEnumerable;
-        }
+            if (attributes != nullptr)
+            {
+                *attributes = PropertyEnumerable;
+            }
 
-        return !done;
-    }
-
-    Var IteratorObjectEnumerator::GetCurrentAndMoveNext(PropertyId& propertyId, PropertyAttributes* attributes)
-    {
-        if (MoveNext(attributes))
-        {
-            Var currentIndex = GetCurrentIndex();
-            ScriptContext* scriptContext = GetScriptContext();
+            Var currentIndex = value;
             const PropertyRecord* propertyRecord = nullptr;
             if (!TaggedInt::Is(currentIndex) && JavascriptString::Is(currentIndex) &&
                 VirtualTableInfo<Js::PropertyString>::HasVirtualTable(JavascriptString::FromVar(currentIndex)))

--- a/lib/Runtime/Library/IteratorObjectEnumerator.h
+++ b/lib/Runtime/Library/IteratorObjectEnumerator.h
@@ -10,9 +10,7 @@ namespace Js
     {
     public:
         static Var Create(ScriptContext* scriptContext, Var iteratorObject);
-        virtual Var GetCurrentIndex() override;
-        virtual Var GetCurrentAndMoveNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr);
-        virtual BOOL MoveNext(PropertyAttributes* attributes = nullptr) override;
+        virtual Var MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr);
         virtual void Reset() override;
     protected:
         IteratorObjectEnumerator(ScriptContext* scriptContext, Var iteratorObject);

--- a/lib/Runtime/Library/JSON.cpp
+++ b/lib/Runtime/Library/JSON.cpp
@@ -650,7 +650,7 @@ namespace JSON
                     {
                         Js::Var propertyNameVar;
                         enumerator->Reset();
-                        while ((propertyNameVar = enumerator->GetCurrentAndMoveNext(id)) != NULL)
+                        while ((propertyNameVar = enumerator->MoveAndGetNext(id)) != NULL)
                         {
                             if (!Js::JavascriptOperators::IsUndefinedObject(propertyNameVar, undefined))
                             {
@@ -692,7 +692,7 @@ namespace JSON
                             enumerator->Reset();
                             uint32 index = 0;
                             Js::Var propertyNameVar;
-                            while ((propertyNameVar = enumerator->GetCurrentAndMoveNext(id)) != NULL && index < precisePropertyCount)
+                            while ((propertyNameVar = enumerator->MoveAndGetNext(id)) != NULL && index < precisePropertyCount)
                             {
                                 if (!Js::JavascriptOperators::IsUndefinedObject(propertyNameVar, undefined))
                                 {
@@ -925,7 +925,7 @@ namespace JSON
         Js::Var propertyNameVar;
         Js::PropertyId id;
         enumerator->Reset();
-        while ((propertyNameVar = enumerator->GetCurrentAndMoveNext(id)) != NULL)
+        while ((propertyNameVar = enumerator->MoveAndGetNext(id)) != NULL)
         {
             if (!Js::JavascriptOperators::IsUndefinedObject(propertyNameVar, this->scriptContext->GetLibrary()->GetUndefined()))
             {

--- a/lib/Runtime/Library/JSONParser.cpp
+++ b/lib/Runtime/Library/JSONParser.cpp
@@ -131,16 +131,21 @@ namespace JSON
                 {
                     Js::JavascriptEnumerator* enumerator = static_cast<Js::JavascriptEnumerator*>(enumeratorVar);
                     Js::Var propertyNameVar;
-                    Js::PropertyId idMember;
 
-                    while(enumerator->MoveNext())
+                    while (true)
                     {
-                        propertyNameVar  = enumerator->GetCurrentIndex();
+                        Js::PropertyId idMember = Js::Constants::NoProperty;
+                        propertyNameVar = enumerator->MoveAndGetNext(idMember);
+                        if (propertyNameVar == nullptr)
+                        {
+                            break;
+                        }
+
                         //NOTE: If testing key value call enumerator->GetCurrentValue() to confirm value is correct;
 
-                        AssertMsg(!Js::JavascriptOperators::IsUndefinedObject(propertyNameVar,  undefined) && Js::JavascriptString::Is(propertyNameVar) , "bad enumeration on a JSON Object");
+                        AssertMsg(Js::JavascriptString::Is(propertyNameVar) , "bad enumeration on a JSON Object");
 
-                        if (enumerator->GetCurrentPropertyId(&idMember))
+                        if (idMember != Js::Constants::NoProperty)
                         {
                             Js::Var newElement = Walk(Js::JavascriptString::FromVar(propertyNameVar), idMember, value);
                             if (Js::JavascriptOperators::IsUndefinedObject(newElement, undefined))

--- a/lib/Runtime/Library/JavascriptArrayEnumerator.cpp
+++ b/lib/Runtime/Library/JavascriptArrayEnumerator.cpp
@@ -13,7 +13,7 @@ namespace Js
         Reset();
     }
 
-    Var JavascriptArrayEnumerator::GetCurrentAndMoveNext(PropertyId& propertyId, PropertyAttributes* attributes)
+    Var JavascriptArrayEnumerator::MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes)
     {
         // TypedArrayEnumerator follow the same logic but implementation is slightly
         // different as we don't have sparse array in typed array, and typed array
@@ -46,7 +46,7 @@ namespace Js
         }
         if (!doneObject)
         {
-            Var currentIndex = objectEnumerator->GetCurrentAndMoveNext(propertyId, attributes);
+            Var currentIndex = objectEnumerator->MoveAndGetNext(propertyId, attributes);
             if (currentIndex)
             {
                 return currentIndex;

--- a/lib/Runtime/Library/JavascriptArrayEnumerator.h
+++ b/lib/Runtime/Library/JavascriptArrayEnumerator.h
@@ -15,6 +15,6 @@ namespace Js
     public:
         JavascriptArrayEnumerator(JavascriptArray* arrayObject, ScriptContext* scriptContext, BOOL enumNonEnumerable, bool enumSymbols = false);
         virtual void Reset() override;
-        virtual Var GetCurrentAndMoveNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
+        virtual Var MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
     };
 }

--- a/lib/Runtime/Library/JavascriptArrayEnumeratorBase.cpp
+++ b/lib/Runtime/Library/JavascriptArrayEnumeratorBase.cpp
@@ -14,45 +14,4 @@ namespace Js
         enumSymbols(enumSymbols)
     {
     }
-
-    Var JavascriptArrayEnumeratorBase::GetCurrentIndex()
-    {
-        if (index != JavascriptArray::InvalidIndex && !doneArray)
-        {
-            return arrayObject->GetScriptContext()->GetIntegerString(index);
-        }
-        else if (!doneObject)
-        {
-            return objectEnumerator->GetCurrentIndex();
-        }
-        else
-        {
-            return GetLibrary()->GetUndefined();
-        }
-    }
-
-    BOOL JavascriptArrayEnumeratorBase::MoveNext(PropertyAttributes* attributes)
-    {
-        PropertyId propId;
-        return GetCurrentAndMoveNext(propId, attributes) != nullptr;
-    }
-
-    bool JavascriptArrayEnumeratorBase::GetCurrentPropertyId(PropertyId *pPropertyId)
-    {
-        if (index != JavascriptArray::InvalidIndex && !doneArray)
-        {
-            *pPropertyId = Constants::NoProperty;
-            return false;
-        }
-        else if (!doneObject)
-        {
-            return objectEnumerator->GetCurrentPropertyId(pPropertyId);
-        }
-        else
-        {
-            *pPropertyId = Constants::NoProperty;
-            return false;
-        }
-    }
-
 }

--- a/lib/Runtime/Library/JavascriptArrayEnumeratorBase.h
+++ b/lib/Runtime/Library/JavascriptArrayEnumeratorBase.h
@@ -20,9 +20,6 @@ namespace Js
         DEFINE_VTABLE_CTOR_ABSTRACT(JavascriptArrayEnumeratorBase, JavascriptEnumerator)
 
         JavascriptArrayEnumeratorBase(JavascriptArray* arrayObject, ScriptContext* scriptContext, BOOL enumNonEnumerable, bool enumSymbols = false);
-        virtual Var GetCurrentIndex() override;
-        virtual BOOL MoveNext(PropertyAttributes* attributes = nullptr) override;
         virtual uint32 GetCurrentItemIndex()  override { return index; }
-        virtual bool GetCurrentPropertyId(PropertyId *propertyId) override;
     };
 }

--- a/lib/Runtime/Library/JavascriptArraySnapshotEnumerator.cpp
+++ b/lib/Runtime/Library/JavascriptArraySnapshotEnumerator.cpp
@@ -14,7 +14,7 @@ namespace Js
         Reset();
     }
 
-    Var JavascriptArraySnapshotEnumerator::GetCurrentAndMoveNext(PropertyId& propertyId, PropertyAttributes* attributes)
+    Var JavascriptArraySnapshotEnumerator::MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes)
     {
         propertyId = Constants::NoProperty;
 
@@ -39,7 +39,7 @@ namespace Js
         }
         if (!doneObject)
         {
-            Var currentIndex = objectEnumerator->GetCurrentAndMoveNext(propertyId, attributes);
+            Var currentIndex = objectEnumerator->MoveAndGetNext(propertyId, attributes);
             if (!currentIndex)
             {
                 doneObject = true;

--- a/lib/Runtime/Library/JavascriptArraySnapshotEnumerator.h
+++ b/lib/Runtime/Library/JavascriptArraySnapshotEnumerator.h
@@ -18,6 +18,6 @@ namespace Js
     public:
         JavascriptArraySnapshotEnumerator(JavascriptArray* arrayObject, ScriptContext* scriptContext, BOOL enumNonEnumerable, bool enumSymbols = false);
         virtual void Reset() override;
-        virtual Var GetCurrentAndMoveNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr);
+        virtual Var MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr);
     };
 }

--- a/lib/Runtime/Library/JavascriptEnumeratorIterator.cpp
+++ b/lib/Runtime/Library/JavascriptEnumeratorIterator.cpp
@@ -66,7 +66,7 @@ namespace Js
 
         if (enumerator != nullptr)
         {
-            index = enumerator->GetCurrentAndMoveNext(propertyId);
+            index = enumerator->MoveAndGetNext(propertyId);
             if (index == nullptr)
             {
                 // when done with iterator, cleanup the enumerator to avoid GC pressure.

--- a/lib/Runtime/Library/JavascriptObject.cpp
+++ b/lib/Runtime/Library/JavascriptObject.cpp
@@ -1143,7 +1143,7 @@ namespace Js
         const PropertyRecord* propertyRecord;
         JavascriptSymbol* symbol;
 
-        while ((propertyName = pEnumerator->GetCurrentAndMoveNext(propertyId)) != NULL)
+        while ((propertyName = pEnumerator->MoveAndGetNext(propertyId)) != NULL)
         {
             if (!JavascriptOperators::IsUndefinedObject(propertyName, undefined)) //There are some code paths in which GetCurrentIndex can return undefined
             {
@@ -1521,7 +1521,7 @@ namespace Js
         Var propertyVar = nullptr;
 
         //enumerate through each property of properties and fetch the property descriptor
-        while ((propertyVar = pEnumerator->GetCurrentAndMoveNext(nextKey)) != NULL)
+        while ((propertyVar = pEnumerator->MoveAndGetNext(nextKey)) != NULL)
         {
             if (nextKey == Constants::NoProperty)
             {
@@ -1684,7 +1684,7 @@ namespace Js
         RecyclableObject *undefined = scriptContext->GetLibrary()->GetUndefined();
 
         //enumerate through each property of properties and fetch the property descriptor
-        while ((tempVar = pEnumerator->GetCurrentAndMoveNext(propId)) != NULL)
+        while ((tempVar = pEnumerator->MoveAndGetNext(propId)) != NULL)
         {
             if (propId == Constants::NoProperty) //try current property id query first
             {

--- a/lib/Runtime/Library/JavascriptRegExpEnumerator.cpp
+++ b/lib/Runtime/Library/JavascriptRegExpEnumerator.cpp
@@ -13,44 +13,12 @@ namespace Js
         index = (uint)-1;
     }
 
-    Var JavascriptRegExpEnumerator::GetCurrentIndex()
-    {
-        ScriptContext *scriptContext = regExpObject->GetScriptContext();
-
-        if (index != (uint)-1 && index < regExpObject->GetSpecialEnumerablePropertyCount())
-        {
-            return scriptContext->GetIntegerString(index);
-        }
-        else
-        {
-            return scriptContext->GetLibrary()->GetUndefined();
-        }
-    }
-
-    BOOL JavascriptRegExpEnumerator::MoveNext(PropertyAttributes* attributes)
-    {
-        if (++index < regExpObject->GetSpecialEnumerablePropertyCount())
-        {
-            if (attributes != nullptr)
-            {
-                *attributes = PropertyEnumerable;
-            }
-
-            return true;
-        }
-        else
-        {
-            index = regExpObject->GetSpecialEnumerablePropertyCount();
-            return false;
-        }
-    }
-
     void JavascriptRegExpEnumerator::Reset()
     {
         index = (uint)-1;
     }
 
-    Var JavascriptRegExpEnumerator::GetCurrentAndMoveNext(PropertyId& propertyId, PropertyAttributes* attributes)
+    Var JavascriptRegExpEnumerator::MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes)
     {
         propertyId = Constants::NoProperty;
         ScriptContext* scriptContext = regExpObject->GetScriptContext();
@@ -85,66 +53,12 @@ namespace Js
         Reset();
     }
 
-    Var JavascriptRegExpObjectEnumerator::GetCurrentIndex()
-    {
-        if (regExpEnumerator != nullptr)
-        {
-            return regExpEnumerator->GetCurrentIndex();
-        }
-        else if (objectEnumerator != nullptr)
-        {
-            return objectEnumerator->GetCurrentIndex();
-        }
-        else
-        {
-            return GetLibrary()->GetUndefined();
-        }
-    }
-
-    BOOL JavascriptRegExpObjectEnumerator::MoveNext(PropertyAttributes* attributes)
-    {
-        if (regExpEnumerator != nullptr)
-        {
-            if (regExpEnumerator->MoveNext(attributes))
-            {
-                return true;
-            }
-            regExpEnumerator = nullptr;
-        }
-        if (objectEnumerator != nullptr)
-        {
-            if (objectEnumerator->MoveNext(attributes))
-            {
-                return true;
-            }
-            objectEnumerator = nullptr;
-        }
-        return false;
-    }
-
-    bool JavascriptRegExpObjectEnumerator::GetCurrentPropertyId(PropertyId *pPropertyId)
-    {
-        if (regExpEnumerator != nullptr)
-        {
-            *pPropertyId = Constants::NoProperty;
-            return false;
-        }
-
-        if (objectEnumerator != nullptr)
-        {
-            return objectEnumerator->GetCurrentPropertyId(pPropertyId);
-        }
-
-        *pPropertyId = Constants::NoProperty;
-        return false;
-    }
-
-    Var JavascriptRegExpObjectEnumerator::GetCurrentAndMoveNext(PropertyId& propertyId, PropertyAttributes* attributes)
+    Var JavascriptRegExpObjectEnumerator::MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes)
     {
         Var currentIndex;
         if (regExpEnumerator != nullptr)
         {
-            currentIndex = regExpEnumerator->GetCurrentAndMoveNext(propertyId, attributes);
+            currentIndex = regExpEnumerator->MoveAndGetNext(propertyId, attributes);
             if (currentIndex != nullptr)
             {
                 return currentIndex;
@@ -153,7 +67,7 @@ namespace Js
         }
         if (objectEnumerator != nullptr)
         {
-            currentIndex = objectEnumerator->GetCurrentAndMoveNext(propertyId, attributes);
+            currentIndex = objectEnumerator->MoveAndGetNext(propertyId, attributes);
             if (currentIndex != nullptr)
             {
                 return currentIndex;

--- a/lib/Runtime/Library/JavascriptRegExpEnumerator.h
+++ b/lib/Runtime/Library/JavascriptRegExpEnumerator.h
@@ -18,10 +18,8 @@ namespace Js
 
     public:
         JavascriptRegExpEnumerator(JavascriptRegExpConstructor* regExpObject, ScriptContext * requestContext, BOOL enumNonEnumerable);
-        virtual Var GetCurrentIndex() override;
-        virtual BOOL MoveNext(PropertyAttributes* attributes = nullptr) override;
         virtual void Reset() override;
-        virtual Var GetCurrentAndMoveNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
+        virtual Var MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
     };
 
     class JavascriptRegExpObjectEnumerator : public JavascriptEnumerator
@@ -39,10 +37,7 @@ namespace Js
 
     public:
         JavascriptRegExpObjectEnumerator(JavascriptRegExpConstructor* regExpObject, ScriptContext * requestContext, BOOL enumNonEnumerable, bool enumSymbols);
-        virtual Var GetCurrentIndex() override;        
-        virtual BOOL MoveNext(PropertyAttributes* attributes = nullptr) override;
         virtual void Reset() override;
-        virtual bool GetCurrentPropertyId(PropertyId *propertyId) override;
-        virtual Var GetCurrentAndMoveNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
+        virtual Var MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
     };
 }

--- a/lib/Runtime/Library/JavascriptStringEnumerator.cpp
+++ b/lib/Runtime/Library/JavascriptStringEnumerator.cpp
@@ -13,45 +13,13 @@ namespace Js
     {
     }
 
-    Var JavascriptStringEnumerator::GetCurrentIndex()
-    {
-        ScriptContext *scriptContext = stringObject->GetScriptContext();
-
-        if (index >= 0 && index < stringObject->GetLengthAsSignedInt())
-        {
-            return scriptContext->GetIntegerString(index);
-        }
-        else
-        {
-            return scriptContext->GetLibrary()->GetUndefined();
-        }
-    }
-
-    BOOL JavascriptStringEnumerator::MoveNext(PropertyAttributes* attributes)
-    {
-        if (++index < stringObject->GetLengthAsSignedInt())
-        {
-            if (attributes != nullptr)
-            {
-                *attributes = PropertyEnumerable;
-            }
-
-            return true;
-        }
-        else
-        {
-            index = stringObject->GetLength();
-            return false;
-        }
-    }
-
     void JavascriptStringEnumerator::Reset()
     {
         index = -1;
     }
 
 
-    Var JavascriptStringEnumerator::GetCurrentAndMoveNext(PropertyId& propertyId, PropertyAttributes* attributes)
+    Var JavascriptStringEnumerator::MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes)
     {
         propertyId = Constants::NoProperty;
         if (++index < stringObject->GetLengthAsSignedInt())
@@ -82,64 +50,12 @@ namespace Js
         Reset();
     }
 
-    Var JavascriptStringObjectEnumerator::GetCurrentIndex()
-    {
-        if (stringEnumerator != nullptr)
-        {
-            return stringEnumerator->GetCurrentIndex();
-        }
-        else if (objectEnumerator != nullptr)
-        {
-            return objectEnumerator->GetCurrentIndex();
-        }
-        else
-        {
-            return GetLibrary()->GetUndefined();
-        }
-    }
-
-    BOOL JavascriptStringObjectEnumerator::MoveNext(PropertyAttributes* attributes)
-    {
-        if (stringEnumerator != nullptr)
-        {
-            if (stringEnumerator->MoveNext(attributes))
-            {
-                return true;
-            }
-            stringEnumerator = nullptr;
-        }
-        if (objectEnumerator != nullptr)
-        {
-            if (objectEnumerator->MoveNext(attributes))
-            {
-                return true;
-            }
-            objectEnumerator = nullptr;
-        }
-        return false;
-    }
-
-    bool JavascriptStringObjectEnumerator::GetCurrentPropertyId(PropertyId* propertyId)
-    {
-        if (stringEnumerator != nullptr)
-        {
-            *propertyId = Constants::NoProperty;
-            return false;
-        }
-        if (objectEnumerator != nullptr)
-        {
-            return objectEnumerator->GetCurrentPropertyId(propertyId);
-        }
-        *propertyId = Constants::NoProperty;
-        return false;
-    }
-
-    Var JavascriptStringObjectEnumerator::GetCurrentAndMoveNext(PropertyId& propertyId, PropertyAttributes* attributes)
+    Var JavascriptStringObjectEnumerator::MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes)
     {
         Var currentIndex;
         if (stringEnumerator != nullptr)
         {
-            currentIndex = stringEnumerator->GetCurrentAndMoveNext(propertyId, attributes);
+            currentIndex = stringEnumerator->MoveAndGetNext(propertyId, attributes);
             if (currentIndex != nullptr)
             {
                 return currentIndex;
@@ -148,7 +64,7 @@ namespace Js
         }
         if (objectEnumerator != nullptr)
         {
-            currentIndex = objectEnumerator->GetCurrentAndMoveNext(propertyId, attributes);
+            currentIndex = objectEnumerator->MoveAndGetNext(propertyId, attributes);
             if (currentIndex != nullptr)
             {
                 return currentIndex;

--- a/lib/Runtime/Library/JavascriptStringEnumerator.h
+++ b/lib/Runtime/Library/JavascriptStringEnumerator.h
@@ -17,10 +17,8 @@ namespace Js
 
     public:
         JavascriptStringEnumerator(JavascriptString* stringObject, ScriptContext * requestContext);
-        virtual Var GetCurrentIndex() override;
-        virtual BOOL MoveNext(PropertyAttributes* attributes = nullptr) override;
         virtual void Reset() override;
-        virtual Var GetCurrentAndMoveNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
+        virtual Var MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
     };
 
     class JavascriptStringObjectEnumerator : public JavascriptEnumerator
@@ -38,10 +36,7 @@ namespace Js
 
     public:
         JavascriptStringObjectEnumerator(JavascriptStringObject* stringObject, ScriptContext * requestContext, BOOL enumNonEnumerable, bool enumSymbols = false);
-        virtual Var GetCurrentIndex() override;
-        virtual BOOL MoveNext(PropertyAttributes* attributes = nullptr) override;
         virtual void Reset() override;
-        virtual bool GetCurrentPropertyId(PropertyId *propertyId) override;
-        virtual Var GetCurrentAndMoveNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
+        virtual Var MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
     };
 }

--- a/lib/Runtime/Library/NullEnumerator.cpp
+++ b/lib/Runtime/Library/NullEnumerator.cpp
@@ -8,30 +8,12 @@
 
 namespace Js
 {
-    Var NullEnumerator::GetCurrentIndex()
-    {
-        // This function may be called without calling MoveNext to verify element availability
-        // by JavascriptDispatch::GetNextDispIDWithScriptEnter which call
-        // GetEnumeratorCurrentPropertyId to resume an enumeration
-        return this->GetLibrary()->GetUndefined();
-    }
-
-    BOOL NullEnumerator::MoveNext(PropertyAttributes* attributes)
-    {
-        return FALSE;
-    }
-
     void NullEnumerator::Reset()
     {
     }
 
-    Var NullEnumerator::GetCurrentAndMoveNext(PropertyId& propertyId, PropertyAttributes* attributes)
+    Var NullEnumerator::MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes)
     {
-        return NULL;
-    }
-
-    bool NullEnumerator::GetCurrentPropertyId(PropertyId *propertyId)
-    {
-        return false;
+        return nullptr;
     }
 };

--- a/lib/Runtime/Library/NullEnumerator.h
+++ b/lib/Runtime/Library/NullEnumerator.h
@@ -11,11 +11,8 @@ namespace Js
     class NullEnumerator : public JavascriptEnumerator
     {
     private:
-        virtual Var GetCurrentIndex() override;
-        virtual BOOL MoveNext(PropertyAttributes* attributes = nullptr) override;
         virtual void Reset() override;
-        virtual Var GetCurrentAndMoveNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
-        virtual bool GetCurrentPropertyId(PropertyId *propertyId) override;
+        virtual Var MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
 
     protected:
         DEFINE_VTABLE_CTOR(NullEnumerator, JavascriptEnumerator);

--- a/lib/Runtime/Library/TypedArrayEnumerator.cpp
+++ b/lib/Runtime/Library/TypedArrayEnumerator.cpp
@@ -15,29 +15,7 @@ namespace Js
             Reset();
         }
 
-    Var TypedArrayEnumerator::GetCurrentIndex()
-    {
-        if (index != JavascriptArray::InvalidIndex && !doneArray)
-        {
-            return typedArrayObject->GetScriptContext()->GetIntegerString(index);
-        }
-        else if (!doneObject)
-        {
-            return objectEnumerator->GetCurrentIndex();
-        }
-        else
-        {
-            return typedArrayObject->GetType()->GetLibrary()->GetUndefined();
-        }
-    }
-
-    BOOL TypedArrayEnumerator::MoveNext(PropertyAttributes* attributes)
-    {
-        PropertyId propId;
-        return GetCurrentAndMoveNext(propId, attributes) != nullptr;
-    }
-
-    Var TypedArrayEnumerator::GetCurrentAndMoveNext(PropertyId& propertyId, PropertyAttributes* attributes)
+    Var TypedArrayEnumerator::MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes)
     {
         // TypedArrayEnumerator follows the same logic in JavascriptArrayEnumerator,
         // but the implementation is slightly different as we don't have sparse array
@@ -68,7 +46,7 @@ namespace Js
         }
         if (!doneObject)
         {
-            Var currentIndex = objectEnumerator->GetCurrentAndMoveNext(propertyId, attributes);
+            Var currentIndex = objectEnumerator->MoveAndGetNext(propertyId, attributes);
             if (!currentIndex)
             {
                 doneObject = true;
@@ -86,20 +64,5 @@ namespace Js
         Var enumerator;
         typedArrayObject->DynamicObject::GetEnumerator(enumNonEnumerable, &enumerator, GetScriptContext(), true, enumSymbols);
         objectEnumerator = (JavascriptEnumerator*)enumerator;
-    }
-
-    bool TypedArrayEnumerator::GetCurrentPropertyId(PropertyId* propertyId)
-    {
-        if (!doneArray)
-        {
-            *propertyId = Constants::NoProperty;
-            return false;
-        }
-        if (!doneObject)
-        {
-            return objectEnumerator->GetCurrentPropertyId(propertyId);
-        }
-        *propertyId = Constants::NoProperty;
-        return false;
     }
 }

--- a/lib/Runtime/Library/TypedArrayEnumerator.h
+++ b/lib/Runtime/Library/TypedArrayEnumerator.h
@@ -23,10 +23,7 @@ namespace Js
 
     public:
         TypedArrayEnumerator(BOOL enumNonEnumerable, TypedArrayBase* typeArrayBase, ScriptContext* scriptContext, bool enumSymbols = false);
-        virtual Var GetCurrentIndex() override;
-        virtual Var GetCurrentAndMoveNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
-        virtual BOOL MoveNext(PropertyAttributes* attributes = nullptr) override;
+        virtual Var MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
         virtual void Reset() override;
-        virtual bool GetCurrentPropertyId(PropertyId *propertyId) override;
     };
 }

--- a/lib/Runtime/Types/DynamicObjectEnumerator.cpp
+++ b/lib/Runtime/Types/DynamicObjectEnumerator.cpp
@@ -26,53 +26,6 @@ namespace Js
     }
 
     template <typename T, bool enumNonEnumerable, bool enumSymbols, bool snapShotSemantics>
-    Var DynamicObjectEnumerator<T, enumNonEnumerable, enumSymbols, snapShotSemantics>::GetCurrentIndex()
-    {
-        if (arrayEnumerator)
-        {
-            return arrayEnumerator->GetCurrentIndex();
-        }
-
-        JavascriptString* propertyString = nullptr;
-        PropertyId propertyId = Constants::NoProperty;
-        if (!object->FindNextProperty(objectIndex, &propertyString, &propertyId, nullptr, GetTypeToEnumerate(), !enumNonEnumerable, enumSymbols))
-        {
-            return this->GetLibrary()->GetUndefined();
-        }
-
-        Assert(propertyId == Constants::NoProperty || !Js::IsInternalPropertyId(propertyId));
-
-        return propertyString;
-    }
-
-    template <typename T, bool enumNonEnumerable, bool enumSymbols, bool snapShotSemantics>
-    BOOL DynamicObjectEnumerator<T, enumNonEnumerable, enumSymbols, snapShotSemantics>::MoveNext(PropertyAttributes* attributes)
-    {
-        PropertyId propId;
-        return GetCurrentAndMoveNext(propId, attributes) != NULL;
-    }
-
-    template <typename T, bool enumNonEnumerable, bool enumSymbols, bool snapShotSemantics>
-    bool DynamicObjectEnumerator<T, enumNonEnumerable, enumSymbols, snapShotSemantics>::GetCurrentPropertyId(PropertyId *pPropertyId)
-    {
-        if (arrayEnumerator)
-        {
-            return arrayEnumerator->GetCurrentPropertyId(pPropertyId);
-        }
-        Js::PropertyId propertyId = object->GetPropertyId((T) objectIndex);
-
-        if ((enumNonEnumerable || (propertyId != Constants::NoProperty && object->IsEnumerable(propertyId))))
-        {
-            *pPropertyId = propertyId;
-            return true;
-        }
-        else
-        {
-            return false;
-        }
-    }
-
-    template <typename T, bool enumNonEnumerable, bool enumSymbols, bool snapShotSemantics>
     uint32 DynamicObjectEnumerator<T, enumNonEnumerable, enumSymbols, snapShotSemantics>::GetCurrentItemIndex()
     {
         if (arrayEnumerator)
@@ -100,11 +53,11 @@ namespace Js
     }
 
     template <typename T, bool enumNonEnumerable, bool enumSymbols, bool snapShotSemantics>
-    Var DynamicObjectEnumerator<T, enumNonEnumerable, enumSymbols, snapShotSemantics>::GetCurrentAndMoveNext(PropertyId& propertyId, PropertyAttributes* attributes)
+    Var DynamicObjectEnumerator<T, enumNonEnumerable, enumSymbols, snapShotSemantics>::MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes)
     {
         if (arrayEnumerator)
         {
-            Var currentIndex = arrayEnumerator->GetCurrentAndMoveNext(propertyId, attributes);
+            Var currentIndex = arrayEnumerator->MoveAndGetNext(propertyId, attributes);
             if(currentIndex != NULL)
             {
                 return currentIndex;

--- a/lib/Runtime/Types/DynamicObjectEnumerator.h
+++ b/lib/Runtime/Types/DynamicObjectEnumerator.h
@@ -34,12 +34,9 @@ namespace Js
         DynamicType *GetTypeToEnumerate() const;
 
     public:
-        virtual Var GetCurrentIndex() override;
-        virtual BOOL MoveNext(PropertyAttributes* attributes = nullptr) override;
         virtual void Reset() override;
-        virtual bool GetCurrentPropertyId(PropertyId *propertyId) override;
         virtual uint32 GetCurrentItemIndex() override;
-        virtual Var GetCurrentAndMoveNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
+        virtual Var MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
 
         static uint32 GetOffsetOfObject() { return offsetof(DynamicObjectEnumerator, object); }
         static uint32 GetOffsetOfArrayEnumerator() { return offsetof(DynamicObjectEnumerator, arrayEnumerator); }

--- a/lib/Runtime/Types/DynamicObjectSnapshotEnumerator.cpp
+++ b/lib/Runtime/Types/DynamicObjectSnapshotEnumerator.cpp
@@ -15,11 +15,11 @@ namespace Js
     }
 
     template <typename T, bool enumNonEnumerable, bool enumSymbols>
-    Var DynamicObjectSnapshotEnumerator<T, enumNonEnumerable, enumSymbols>::GetCurrentAndMoveNextFromArray(PropertyId& propertyId, PropertyAttributes* attributes)
+    Var DynamicObjectSnapshotEnumerator<T, enumNonEnumerable, enumSymbols>::MoveAndGetNextFromArray(PropertyId& propertyId, PropertyAttributes* attributes)
     {
         if (this->arrayEnumerator)
         {
-            Var currentIndex = this->arrayEnumerator->GetCurrentAndMoveNext(propertyId, attributes);
+            Var currentIndex = this->arrayEnumerator->MoveAndGetNext(propertyId, attributes);
             if(currentIndex != nullptr)
             {
                 return currentIndex;
@@ -31,7 +31,7 @@ namespace Js
     }
 
     template <typename T, bool enumNonEnumerable, bool enumSymbols>
-    JavascriptString * DynamicObjectSnapshotEnumerator<T, enumNonEnumerable, enumSymbols>::GetCurrentAndMoveNextFromObject(T& index, PropertyId& propertyId, PropertyAttributes* attributes)
+    JavascriptString * DynamicObjectSnapshotEnumerator<T, enumNonEnumerable, enumSymbols>::MoveAndGetNextFromObject(T& index, PropertyId& propertyId, PropertyAttributes* attributes)
     {
         JavascriptString* propertyString = nullptr;
         auto newIndex = this->objectIndex;
@@ -52,11 +52,11 @@ namespace Js
     }
 
     template <typename T, bool enumNonEnumerable, bool enumSymbols>
-    Var DynamicObjectSnapshotEnumerator<T, enumNonEnumerable, enumSymbols>::GetCurrentAndMoveNext(PropertyId& propertyId, PropertyAttributes* attributes)
+    Var DynamicObjectSnapshotEnumerator<T, enumNonEnumerable, enumSymbols>::MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes)
     {
-        Var currentIndex = GetCurrentAndMoveNextFromArray(propertyId, attributes);
+        Var currentIndex = MoveAndGetNextFromArray(propertyId, attributes);
         return (currentIndex != nullptr)? currentIndex :
-            this->GetCurrentAndMoveNextFromObject(this->objectIndex, propertyId, attributes);
+            this->MoveAndGetNextFromObject(this->objectIndex, propertyId, attributes);
     }
 
     template <typename T, bool enumNonEnumerable, bool enumSymbols>

--- a/lib/Runtime/Types/DynamicObjectSnapshotEnumerator.h
+++ b/lib/Runtime/Types/DynamicObjectSnapshotEnumerator.h
@@ -21,8 +21,8 @@ namespace Js
         DEFINE_VTABLE_CTOR(DynamicObjectSnapshotEnumerator, Base);
         DEFINE_MARSHAL_ENUMERATOR_TO_SCRIPT_CONTEXT(DynamicObjectSnapshotEnumerator);
 
-        Var GetCurrentAndMoveNextFromArray(PropertyId& propertyId, PropertyAttributes* attributes);
-        JavascriptString * GetCurrentAndMoveNextFromObject(T& index, PropertyId& propertyId, PropertyAttributes* attributes);
+        Var MoveAndGetNextFromArray(PropertyId& propertyId, PropertyAttributes* attributes);
+        JavascriptString * MoveAndGetNextFromObject(T& index, PropertyId& propertyId, PropertyAttributes* attributes);
 
         DynamicObjectSnapshotEnumerator() { /* Do nothing, needed by the vtable ctor for ForInObjectEnumeratorWrapper */ }
         void Initialize(DynamicObject* object);
@@ -31,7 +31,7 @@ namespace Js
         static JavascriptEnumerator* New(ScriptContext* scriptContext, DynamicObject* object);
 
         virtual void Reset() override;
-        virtual Var GetCurrentAndMoveNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
+        virtual Var MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
     };
 
 } // namespace Js

--- a/lib/Runtime/Types/DynamicObjectSnapshotEnumeratorWPCache.cpp
+++ b/lib/Runtime/Types/DynamicObjectSnapshotEnumeratorWPCache.cpp
@@ -57,7 +57,7 @@ namespace Js
 
     template <typename T, bool enumNonEnumerable, bool enumSymbols>
     JavascriptString *
-        DynamicObjectSnapshotEnumeratorWPCache<T, enumNonEnumerable, enumSymbols>::GetCurrentAndMoveNextFromObjectWPCache(T& index, PropertyId& propertyId, PropertyAttributes* attributes)
+        DynamicObjectSnapshotEnumeratorWPCache<T, enumNonEnumerable, enumSymbols>::MoveAndGetNextFromObjectWPCache(T& index, PropertyId& propertyId, PropertyAttributes* attributes)
     {
         if (this->initialType != this->object->GetDynamicType())
         {
@@ -71,7 +71,7 @@ namespace Js
                 // downgrade back to the normal snapshot enumerator
                 VirtualTableInfo<DynamicObjectSnapshotEnumerator<T, enumNonEnumerable, enumSymbols>>::SetVirtualTable(this);
             }
-            return this->GetCurrentAndMoveNextFromObject(this->objectIndex, propertyId, attributes);
+            return this->MoveAndGetNextFromObject(this->objectIndex, propertyId, attributes);
         }
         Assert(enumeratedCount <= cachedData->cachedCount);
         JavascriptString* propertyStringName;
@@ -84,7 +84,7 @@ namespace Js
 
 #if ENABLE_TTD
             //
-            //TODO: We have code in GetCurrentAndMoveNextFromObject to record replay the order in which properties are enumerated. 
+            //TODO: We have code in MoveAndGetNextFromObject to record replay the order in which properties are enumerated. 
             //      Since caching may happen differently at record/replay time we need to force this to ensure the log/order is consistent.
             //      Later we may want to optimize by lifting the TTD code from the call and explicitly calling it here (but not the rest of the enumeration work).
             //
@@ -92,14 +92,14 @@ namespace Js
             if(actionCtx->ShouldPerformRecordAction() | actionCtx->ShouldPerformDebugAction())
             {
                 PropertyId tempPropertyId;
-                /* JavascriptString * tempPropertyString = */ this->GetCurrentAndMoveNextFromObject(this->objectIndex, tempPropertyId, attributes);
+                /* JavascriptString * tempPropertyString = */ this->MoveAndGetNextFromObject(this->objectIndex, tempPropertyId, attributes);
 
                 Assert(tempPropertyId == propertyId);
                 Assert(this->objectIndex == cachedData->indexes[enumeratedCount]);
             }
 #elif DBG
             PropertyId tempPropertyId;
-            /* JavascriptString * tempPropertyString = */ this->GetCurrentAndMoveNextFromObject(this->objectIndex, tempPropertyId, attributes);
+            /* JavascriptString * tempPropertyString = */ this->MoveAndGetNextFromObject(this->objectIndex, tempPropertyId, attributes);
 
             Assert(tempPropertyId == propertyId);
             Assert(this->objectIndex == cachedData->indexes[enumeratedCount]);
@@ -112,7 +112,7 @@ namespace Js
         }
         else if (!cachedData->completed)
         {
-            propertyStringName = this->GetCurrentAndMoveNextFromObject(this->objectIndex, propertyId, &propertyAttributes);
+            propertyStringName = this->MoveAndGetNextFromObject(this->objectIndex, propertyId, &propertyAttributes);
 
             if (propertyStringName && VirtualTableInfo<PropertyString>::HasVirtualTable(propertyStringName))
             {
@@ -131,7 +131,7 @@ namespace Js
         {
 #if ENABLE_TTD
             //
-            //TODO: We have code in GetCurrentAndMoveNextFromObject to record replay the order in which properties are enumerated. 
+            //TODO: We have code in MoveAndGetNextFromObject to record replay the order in which properties are enumerated. 
             //      Since caching may happen differently at record/replay time we need to force this to ensure the log/order is consistent.
             //      Later we may want to optimize by lifting the TTD code from the call and explicitly calling it here (but not the rest of the enumeration work).
             //
@@ -139,11 +139,11 @@ namespace Js
             if(actionCtx->ShouldPerformRecordAction() | actionCtx->ShouldPerformDebugAction())
             {
                 PropertyId tempPropertyId;
-                /*JavascriptString* tempPropertyStringName =*/ this->GetCurrentAndMoveNextFromObject(this->objectIndex, tempPropertyId, attributes);
+                /*JavascriptString* tempPropertyStringName =*/ this->MoveAndGetNextFromObject(this->objectIndex, tempPropertyId, attributes);
             }
 #elif DBG
             PropertyId tempPropertyId;
-            Assert(this->GetCurrentAndMoveNextFromObject(this->objectIndex, tempPropertyId, attributes) == nullptr);
+            Assert(this->MoveAndGetNextFromObject(this->objectIndex, tempPropertyId, attributes) == nullptr);
 #endif
 
             propertyStringName = nullptr;
@@ -158,13 +158,13 @@ namespace Js
     }
 
     template <typename T, bool enumNonEnumerable, bool enumSymbols>
-    Var DynamicObjectSnapshotEnumeratorWPCache<T, enumNonEnumerable, enumSymbols>::GetCurrentAndMoveNext(PropertyId& propertyId, PropertyAttributes* attributes)
+    Var DynamicObjectSnapshotEnumeratorWPCache<T, enumNonEnumerable, enumSymbols>::MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes)
     {
-        Var currentIndex = this->GetCurrentAndMoveNextFromArray(propertyId, attributes);
+        Var currentIndex = this->MoveAndGetNextFromArray(propertyId, attributes);
 
         if (currentIndex == nullptr)
         {
-            currentIndex = this->GetCurrentAndMoveNextFromObjectWPCache(this->objectIndex, propertyId, attributes);
+            currentIndex = this->MoveAndGetNextFromObjectWPCache(this->objectIndex, propertyId, attributes);
         }
 
         return currentIndex;

--- a/lib/Runtime/Types/DynamicObjectSnapshotEnumeratorWPCache.h
+++ b/lib/Runtime/Types/DynamicObjectSnapshotEnumeratorWPCache.h
@@ -29,7 +29,7 @@ namespace Js
         {
         }
 
-        JavascriptString * GetCurrentAndMoveNextFromObjectWPCache(T& index, PropertyId& propertyId, PropertyAttributes* attributes);
+        JavascriptString * MoveAndGetNextFromObjectWPCache(T& index, PropertyId& propertyId, PropertyAttributes* attributes);
 
         struct CachedData
         {
@@ -51,7 +51,7 @@ namespace Js
     public:
         static JavascriptEnumerator* New(ScriptContext* scriptContext, DynamicObject* object);
         virtual void Reset() override;
-        virtual Var GetCurrentAndMoveNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
+        virtual Var MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
 
         static uint32 GetOffsetOfInitialType() { return offsetof(DynamicObjectSnapshotEnumeratorWPCache, initialType); }
         static uint32 GetOffsetOfEnumeratedCount() { return offsetof(DynamicObjectSnapshotEnumeratorWPCache, enumeratedCount); }

--- a/lib/Runtime/Types/JavascriptEnumerator.h
+++ b/lib/Runtime/Types/JavascriptEnumerator.h
@@ -24,16 +24,6 @@ namespace Js {
         virtual uint32 GetCurrentItemIndex() { return Constants::InvalidSourceIndex; }
 
         //
-        // Returns the current index
-        //
-        virtual Var GetCurrentIndex() = 0;
-
-        //
-        // Moves to next element
-        //
-        virtual BOOL MoveNext(PropertyAttributes* attributes = nullptr) = 0;
-
-        //
         // Sets the enumerator to its initial position
         //
         virtual void Reset() = 0;
@@ -48,22 +38,7 @@ namespace Js {
         // If that code is added in this base class use JavaScriptRegExpEnumerator.h/cpp
         // as a reference and then remove it. If you have already made the edits before
         // seeing this comment please just consolidate the changes.
-        virtual Var GetCurrentAndMoveNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr)
-        {
-            propertyId = Constants::NoProperty;
-            if (MoveNext(attributes))
-            {
-                Var currentIndex = GetCurrentIndex();
-                return currentIndex;
-            }
-            return NULL;
-        }
-
-        virtual bool GetCurrentPropertyId(PropertyId *propertyId)
-        {
-           *propertyId = Constants::NoProperty;
-            return false;
-        };
+        virtual Var MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr) = 0;
 
         virtual BOOL IsCrossSiteEnumerator()
         {


### PR DESCRIPTION
The JavascriptEnumerator function GetCurrentAndMoveNext is misleading because.  Because it move to the next one before return the next element that we moved to. Change to MoveAndGetNext.

Also remove MoveNext/GetCurrentIndex/GetCurrentPropertyId, which is equivalent to GetCurrentAndMoveNext. Move all usage of those API to  MoveAndGetNext.
