### PR TITLE
Fix build break in VS2013

### DIFF
--- a/lib/Common/Codex/Utf8Codex.cpp
+++ b/lib/Common/Codex/Utf8Codex.cpp
@@ -9,6 +9,16 @@
 #define _Analysis_assume_(expr)
 #endif
 
+#ifdef _MSC_VER
+//=============================
+// Disabled Warnings
+//=============================
+
+#pragma warning(push)
+
+#pragma warning(disable: 4127)  // constant expression for template parameter
+#endif
+
 extern void CodexAssert(bool condition);
 
 namespace utf8
@@ -611,3 +621,7 @@ LSlowPath:
     }
 
 } // namespace utf8
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif


### PR DESCRIPTION
Disable a warning in VS2013 in Utf8Codex.cpp (it's disabled through the rest of the project anyway, but Codex doesn't use the header that disables those warnings so explicitly disable for Utf8Codex too)