### PR TITLE
Fix !== codegen for arm when destination operand is same as both source operands

### DIFF
--- a/lib/Backend/arm/LowerMD.cpp
+++ b/lib/Backend/arm/LowerMD.cpp
@@ -3446,7 +3446,7 @@ bool LowererMD::GenerateFastCmXxTaggedInt(IR::Instr *instr)
         LowererMD::CreateAssign(newSrc1, src1, instr);
         src1 = newSrc1;
     }
-    else if (dst->IsEqual(src2))
+    if (dst->IsEqual(src2))
     {
         IR::RegOpnd *newSrc2 = IR::RegOpnd::New(TyMachReg, m_func);
         LowererMD::CreateAssign(newSrc2, src2, instr);


### PR DESCRIPTION
When destination of CmpSrNeq_A is same as both its sources, we need to generate instructions that saves the value of both the sources in newly created Opnds. 
Current codegen did not check the case when destination can be equal to both the sources. This change fixes it.