### PR TITLE
cross platform: Change default timeout to 120 secs

### DIFF
--- a/test/Array/array_slice.js
+++ b/test/Array/array_slice.js
@@ -17,7 +17,7 @@ WScript.Echo(x.slice(-12, -9));
 WScript.Echo(x.slice(-12, -15));
 
 
-var large = new Array(1000000);
+var large = new Array(1e6);
 for (var i = 0; i < large.length; i++)
 {
     large[i] = 0;
@@ -26,6 +26,3 @@ for (var i = 0; i < large.length; i++)
 s = large.slice(0, large.length - 1);
 
 WScript.Echo(s.length);
-
-
-

--- a/test/runtests.py
+++ b/test/runtests.py
@@ -50,8 +50,8 @@ parser.add_argument('--tag', nargs='*',
                     help='select tests with given tags')
 parser.add_argument('--not-tag', nargs='*',
                     help='exclude tests with given tags')
-parser.add_argument('--timeout', type=int, default=60,
-                    help='test timeout (default 60 seconds)')
+parser.add_argument('--timeout', type=int, default=120,
+                    help='test timeout (default 120 seconds)')
 parser.add_argument('-l', '--logfile', metavar='logfile', help='file to log results to', default=None)
 parser.add_argument('--x86', action='store_true', help='use x86 build')
 parser.add_argument('--x64', action='store_true', help='use x64 build')


### PR DESCRIPTION
CI / Debug build tests fail due to timeout.
Array/array_slice.js test actually takes 14 seconds to complete
on an empty macbook-pro with Quad 2.9 Ghz i7 cores on it.
Previous 60 seconds timeout may not cover some tests on CI VM / Debug build.

Fixes #1406 