### PR TITLE
Added SAL notation for `MoveAndGetNext`

### DIFF
--- a/lib/Runtime/Base/CrossSiteEnumerator.h
+++ b/lib/Runtime/Base/CrossSiteEnumerator.h
@@ -29,7 +29,7 @@ namespace Js
 
     public:
         virtual void Reset() override;
-        virtual Var MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
+        virtual Var MoveAndGetNext(_Out_ PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
         virtual BOOL IsCrossSiteEnumerator() override
         {
             return true;
@@ -44,7 +44,7 @@ namespace Js
     }
 
     template <typename T>
-    Var CrossSiteEnumerator<T>::MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes)
+    Var CrossSiteEnumerator<T>::MoveAndGetNext(_Out_ PropertyId& propertyId, PropertyAttributes* attributes)
     {
         Var result = __super::MoveAndGetNext(propertyId, attributes);
         if (result)

--- a/lib/Runtime/Debug/DiagObjectModel.cpp
+++ b/lib/Runtime/Debug/DiagObjectModel.cpp
@@ -2376,7 +2376,7 @@ namespace Js
                             JavascriptEnumerator* enumerator;
                             if (object->GetEnumerator(true/*enumNonEnumable*/, (Var*)&enumerator, scriptContext, false/*preferSnapshotSyntax*/, true/*enumSymbols*/))
                             {
-                                Js::PropertyId propertyId;
+                                Js::PropertyId propertyId = Constants::NoProperty;
                                 Var obj;
 
                                 while ((obj = enumerator->MoveAndGetNext(propertyId)) != nullptr)

--- a/lib/Runtime/Language/ModuleNamespaceEnumerator.cpp
+++ b/lib/Runtime/Language/ModuleNamespaceEnumerator.cpp
@@ -56,8 +56,9 @@ namespace Js
     }
 
     // enumeration order: symbol first; local exports next; nonlocal exports last.
-    Var ModuleNamespaceEnumerator::MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes)
+    Var ModuleNamespaceEnumerator::MoveAndGetNext(_Out_ PropertyId& propertyId, PropertyAttributes* attributes)
     {
+        propertyId = Constants::NoProperty;
         Var undefined = GetLibrary()->GetUndefined();
         Var result = undefined;
         if (attributes != nullptr)

--- a/lib/Runtime/Language/ModuleNamespaceEnumerator.h
+++ b/lib/Runtime/Language/ModuleNamespaceEnumerator.h
@@ -17,7 +17,7 @@ namespace Js
         static ModuleNamespaceEnumerator* New(ModuleNamespace* nsObject, ScriptContext* scriptContext, bool enumNonEnumerable, bool enumSymbols = false);
         BOOL Init();
         virtual void Reset() override;
-        virtual Var MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
+        virtual Var MoveAndGetNext(_Out_ PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
         virtual Var GetCurrentValue() { Assert(false); return nullptr; }
 
     private:

--- a/lib/Runtime/Library/ArgumentsObjectEnumerator.cpp
+++ b/lib/Runtime/Library/ArgumentsObjectEnumerator.cpp
@@ -15,7 +15,7 @@ namespace Js
         Reset();
     }
 
-    Var ArgumentsObjectEnumerator::MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes)
+    Var ArgumentsObjectEnumerator::MoveAndGetNext(_Out_ PropertyId& propertyId, PropertyAttributes* attributes)
     {
         if (!doneFormalArgs)
         {
@@ -51,7 +51,7 @@ namespace Js
         this->Reset();
     }
 
-    Var ES5ArgumentsObjectEnumerator::MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes)
+    Var ES5ArgumentsObjectEnumerator::MoveAndGetNext(_Out_ PropertyId& propertyId, PropertyAttributes* attributes)
     {
         // Formals:
         // - deleted => not in objectArray && not connected -- do not enum, do not advance

--- a/lib/Runtime/Library/ArgumentsObjectEnumerator.h
+++ b/lib/Runtime/Library/ArgumentsObjectEnumerator.h
@@ -23,7 +23,7 @@ namespace Js
     public:
         ArgumentsObjectEnumerator(ArgumentsObject* argumentsObject, ScriptContext* requestcontext, BOOL enumNonEnumerable, bool enumSymbols = false);
         virtual void Reset() override;
-        virtual Var MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
+        virtual Var MoveAndGetNext(_Out_ PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
     };
 
     class ES5ArgumentsObjectEnumerator : public ArgumentsObjectEnumerator
@@ -35,7 +35,7 @@ namespace Js
     public:
         ES5ArgumentsObjectEnumerator(ArgumentsObject* argumentsObject, ScriptContext* requestcontext, BOOL enumNonEnumerable, bool enumSymbols = false);
         virtual void Reset() override;
-        virtual Var MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
+        virtual Var MoveAndGetNext(_Out_ PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
     private:
         uint enumeratedFormalsInObjectArrayCount;  // The number of enumerated formals for far.
     };

--- a/lib/Runtime/Library/ES5ArrayEnumerator.cpp
+++ b/lib/Runtime/Library/ES5ArrayEnumerator.cpp
@@ -17,7 +17,7 @@ namespace Js
         Reset();
     }
 
-    Var ES5ArrayEnumerator::MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes)
+    Var ES5ArrayEnumerator::MoveAndGetNext(_Out_ PropertyId& propertyId, PropertyAttributes* attributes)
     {
         propertyId = Constants::NoProperty;
 

--- a/lib/Runtime/Library/ES5ArrayEnumerator.h
+++ b/lib/Runtime/Library/ES5ArrayEnumerator.h
@@ -25,6 +25,6 @@ namespace Js
     public:
         ES5ArrayEnumerator(Var originalInstance, ES5Array* arrayObject, ScriptContext* scriptContext, BOOL enumNonEnumerable, bool enumSymbols = false);
         virtual void Reset() override;
-        virtual Var MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
+        virtual Var MoveAndGetNext(_Out_ PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
     };
 }

--- a/lib/Runtime/Library/ForInObjectEnumerator.cpp
+++ b/lib/Runtime/Library/ForInObjectEnumerator.cpp
@@ -154,7 +154,7 @@ namespace Js
         return currentIndex != NULL;
     }
 
-    Var ForInObjectEnumerator::MoveAndGetNext(PropertyId& propertyId)
+    Var ForInObjectEnumerator::MoveAndGetNext(_Out_ PropertyId& propertyId)
     {
         JavascriptEnumerator *pEnumerator = currentEnumerator;
         PropertyRecord const * propRecord;

--- a/lib/Runtime/Library/ForInObjectEnumerator.h
+++ b/lib/Runtime/Library/ForInObjectEnumerator.h
@@ -39,7 +39,7 @@ namespace Js
         Var GetCurrentIndex();        
         BOOL MoveNext();
         void Reset();
-        Var MoveAndGetNext(PropertyId& propertyId);
+        Var MoveAndGetNext(_Out_ PropertyId& propertyId);
 
         static uint32 GetOffsetOfCurrentEnumerator() { return offsetof(ForInObjectEnumerator, currentEnumerator); }
         static uint32 GetOffsetOfFirstPrototype() { return offsetof(ForInObjectEnumerator, firstPrototype); }
@@ -57,7 +57,7 @@ namespace Js
         }
 
         virtual void Reset() override { forInObjectEnumerator.Reset(); }
-        virtual Var MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr)
+        virtual Var MoveAndGetNext(_Out_ PropertyId& propertyId, PropertyAttributes* attributes = nullptr)
         {
             return forInObjectEnumerator.MoveAndGetNext(propertyId);
         }

--- a/lib/Runtime/Library/IteratorObjectEnumerator.cpp
+++ b/lib/Runtime/Library/IteratorObjectEnumerator.cpp
@@ -20,8 +20,9 @@ namespace Js
         iteratorObject = RecyclableObject::FromVar(iterator);
     }
 
-    Var IteratorObjectEnumerator::MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes)
+    Var IteratorObjectEnumerator::MoveAndGetNext(_Out_ PropertyId& propertyId, PropertyAttributes* attributes)
     {
+        propertyId = Constants::NoProperty;
         ScriptContext* scriptContext = GetScriptContext();
         if (JavascriptOperators::IteratorStepAndValue(iteratorObject, scriptContext, &value))
         {

--- a/lib/Runtime/Library/IteratorObjectEnumerator.h
+++ b/lib/Runtime/Library/IteratorObjectEnumerator.h
@@ -10,7 +10,7 @@ namespace Js
     {
     public:
         static Var Create(ScriptContext* scriptContext, Var iteratorObject);
-        virtual Var MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr);
+        virtual Var MoveAndGetNext(_Out_ PropertyId& propertyId, PropertyAttributes* attributes = nullptr);
         virtual void Reset() override;
     protected:
         IteratorObjectEnumerator(ScriptContext* scriptContext, Var iteratorObject);

--- a/lib/Runtime/Library/JSON.cpp
+++ b/lib/Runtime/Library/JSON.cpp
@@ -574,7 +574,7 @@ namespace JSON
     Js::Var StringifySession::StringifyObject(Js::Var value)
     {
         Js::JavascriptString* propertyName;
-        Js::PropertyId id;
+        Js::PropertyId id = Constants::NoProperty;
         Js::PropertyRecord const * propRecord;
 
         bool isFirstMember = true;

--- a/lib/Runtime/Library/JavascriptArrayEnumerator.cpp
+++ b/lib/Runtime/Library/JavascriptArrayEnumerator.cpp
@@ -13,7 +13,7 @@ namespace Js
         Reset();
     }
 
-    Var JavascriptArrayEnumerator::MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes)
+    Var JavascriptArrayEnumerator::MoveAndGetNext(_Out_ PropertyId& propertyId, PropertyAttributes* attributes)
     {
         // TypedArrayEnumerator follow the same logic but implementation is slightly
         // different as we don't have sparse array in typed array, and typed array

--- a/lib/Runtime/Library/JavascriptArrayEnumerator.h
+++ b/lib/Runtime/Library/JavascriptArrayEnumerator.h
@@ -15,6 +15,6 @@ namespace Js
     public:
         JavascriptArrayEnumerator(JavascriptArray* arrayObject, ScriptContext* scriptContext, BOOL enumNonEnumerable, bool enumSymbols = false);
         virtual void Reset() override;
-        virtual Var MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
+        virtual Var MoveAndGetNext(_Out_ PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
     };
 }

--- a/lib/Runtime/Library/JavascriptArraySnapshotEnumerator.cpp
+++ b/lib/Runtime/Library/JavascriptArraySnapshotEnumerator.cpp
@@ -14,7 +14,7 @@ namespace Js
         Reset();
     }
 
-    Var JavascriptArraySnapshotEnumerator::MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes)
+    Var JavascriptArraySnapshotEnumerator::MoveAndGetNext(_Out_ PropertyId& propertyId, PropertyAttributes* attributes)
     {
         propertyId = Constants::NoProperty;
 

--- a/lib/Runtime/Library/JavascriptArraySnapshotEnumerator.h
+++ b/lib/Runtime/Library/JavascriptArraySnapshotEnumerator.h
@@ -18,6 +18,6 @@ namespace Js
     public:
         JavascriptArraySnapshotEnumerator(JavascriptArray* arrayObject, ScriptContext* scriptContext, BOOL enumNonEnumerable, bool enumSymbols = false);
         virtual void Reset() override;
-        virtual Var MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr);
+        virtual Var MoveAndGetNext(_Out_ PropertyId& propertyId, PropertyAttributes* attributes = nullptr);
     };
 }

--- a/lib/Runtime/Library/JavascriptRegExpEnumerator.cpp
+++ b/lib/Runtime/Library/JavascriptRegExpEnumerator.cpp
@@ -18,7 +18,7 @@ namespace Js
         index = (uint)-1;
     }
 
-    Var JavascriptRegExpEnumerator::MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes)
+    Var JavascriptRegExpEnumerator::MoveAndGetNext(_Out_ PropertyId& propertyId, PropertyAttributes* attributes)
     {
         propertyId = Constants::NoProperty;
         ScriptContext* scriptContext = regExpObject->GetScriptContext();
@@ -53,9 +53,10 @@ namespace Js
         Reset();
     }
 
-    Var JavascriptRegExpObjectEnumerator::MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes)
+    Var JavascriptRegExpObjectEnumerator::MoveAndGetNext(_Out_ PropertyId& propertyId, PropertyAttributes* attributes)
     {
         Var currentIndex;
+        propertyId = Constants::NoProperty;
         if (regExpEnumerator != nullptr)
         {
             currentIndex = regExpEnumerator->MoveAndGetNext(propertyId, attributes);

--- a/lib/Runtime/Library/JavascriptRegExpEnumerator.h
+++ b/lib/Runtime/Library/JavascriptRegExpEnumerator.h
@@ -19,7 +19,7 @@ namespace Js
     public:
         JavascriptRegExpEnumerator(JavascriptRegExpConstructor* regExpObject, ScriptContext * requestContext, BOOL enumNonEnumerable);
         virtual void Reset() override;
-        virtual Var MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
+        virtual Var MoveAndGetNext(_Out_ PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
     };
 
     class JavascriptRegExpObjectEnumerator : public JavascriptEnumerator
@@ -38,6 +38,6 @@ namespace Js
     public:
         JavascriptRegExpObjectEnumerator(JavascriptRegExpConstructor* regExpObject, ScriptContext * requestContext, BOOL enumNonEnumerable, bool enumSymbols);
         virtual void Reset() override;
-        virtual Var MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
+        virtual Var MoveAndGetNext(_Out_ PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
     };
 }

--- a/lib/Runtime/Library/JavascriptStringEnumerator.cpp
+++ b/lib/Runtime/Library/JavascriptStringEnumerator.cpp
@@ -19,7 +19,7 @@ namespace Js
     }
 
 
-    Var JavascriptStringEnumerator::MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes)
+    Var JavascriptStringEnumerator::MoveAndGetNext(_Out_ PropertyId& propertyId, PropertyAttributes* attributes)
     {
         propertyId = Constants::NoProperty;
         if (++index < stringObject->GetLengthAsSignedInt())
@@ -50,9 +50,10 @@ namespace Js
         Reset();
     }
 
-    Var JavascriptStringObjectEnumerator::MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes)
+    Var JavascriptStringObjectEnumerator::MoveAndGetNext(_Out_ PropertyId& propertyId, PropertyAttributes* attributes)
     {
         Var currentIndex;
+        propertyId = Constants::NoProperty;
         if (stringEnumerator != nullptr)
         {
             currentIndex = stringEnumerator->MoveAndGetNext(propertyId, attributes);

--- a/lib/Runtime/Library/JavascriptStringEnumerator.h
+++ b/lib/Runtime/Library/JavascriptStringEnumerator.h
@@ -18,7 +18,7 @@ namespace Js
     public:
         JavascriptStringEnumerator(JavascriptString* stringObject, ScriptContext * requestContext);
         virtual void Reset() override;
-        virtual Var MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
+        virtual Var MoveAndGetNext(_Out_ PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
     };
 
     class JavascriptStringObjectEnumerator : public JavascriptEnumerator
@@ -37,6 +37,6 @@ namespace Js
     public:
         JavascriptStringObjectEnumerator(JavascriptStringObject* stringObject, ScriptContext * requestContext, BOOL enumNonEnumerable, bool enumSymbols = false);
         virtual void Reset() override;
-        virtual Var MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
+        virtual Var MoveAndGetNext(_Out_ PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
     };
 }

--- a/lib/Runtime/Library/NullEnumerator.cpp
+++ b/lib/Runtime/Library/NullEnumerator.cpp
@@ -14,6 +14,7 @@ namespace Js
 
     Var NullEnumerator::MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes)
     {
+        propertyId = Constants::NoProperty;
         return nullptr;
     }
 };

--- a/lib/Runtime/Library/TypedArrayEnumerator.cpp
+++ b/lib/Runtime/Library/TypedArrayEnumerator.cpp
@@ -15,7 +15,7 @@ namespace Js
             Reset();
         }
 
-    Var TypedArrayEnumerator::MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes)
+    Var TypedArrayEnumerator::MoveAndGetNext(_Out_ PropertyId& propertyId, PropertyAttributes* attributes)
     {
         // TypedArrayEnumerator follows the same logic in JavascriptArrayEnumerator,
         // but the implementation is slightly different as we don't have sparse array

--- a/lib/Runtime/Library/TypedArrayEnumerator.h
+++ b/lib/Runtime/Library/TypedArrayEnumerator.h
@@ -23,7 +23,7 @@ namespace Js
 
     public:
         TypedArrayEnumerator(BOOL enumNonEnumerable, TypedArrayBase* typeArrayBase, ScriptContext* scriptContext, bool enumSymbols = false);
-        virtual Var MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
+        virtual Var MoveAndGetNext(_Out_ PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
         virtual void Reset() override;
     };
 }

--- a/lib/Runtime/Types/DynamicObjectEnumerator.cpp
+++ b/lib/Runtime/Types/DynamicObjectEnumerator.cpp
@@ -53,8 +53,9 @@ namespace Js
     }
 
     template <typename T, bool enumNonEnumerable, bool enumSymbols, bool snapShotSemantics>
-    Var DynamicObjectEnumerator<T, enumNonEnumerable, enumSymbols, snapShotSemantics>::MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes)
+    Var DynamicObjectEnumerator<T, enumNonEnumerable, enumSymbols, snapShotSemantics>::MoveAndGetNext(_Out_ PropertyId& propertyId, PropertyAttributes* attributes)
     {
+        propertyId = Constants::NoProperty;
         if (arrayEnumerator)
         {
             Var currentIndex = arrayEnumerator->MoveAndGetNext(propertyId, attributes);

--- a/lib/Runtime/Types/DynamicObjectEnumerator.h
+++ b/lib/Runtime/Types/DynamicObjectEnumerator.h
@@ -36,7 +36,7 @@ namespace Js
     public:
         virtual void Reset() override;
         virtual uint32 GetCurrentItemIndex() override;
-        virtual Var MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
+        virtual Var MoveAndGetNext(_Out_ PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
 
         static uint32 GetOffsetOfObject() { return offsetof(DynamicObjectEnumerator, object); }
         static uint32 GetOffsetOfArrayEnumerator() { return offsetof(DynamicObjectEnumerator, arrayEnumerator); }

--- a/lib/Runtime/Types/DynamicObjectSnapshotEnumerator.cpp
+++ b/lib/Runtime/Types/DynamicObjectSnapshotEnumerator.cpp
@@ -15,8 +15,9 @@ namespace Js
     }
 
     template <typename T, bool enumNonEnumerable, bool enumSymbols>
-    Var DynamicObjectSnapshotEnumerator<T, enumNonEnumerable, enumSymbols>::MoveAndGetNextFromArray(PropertyId& propertyId, PropertyAttributes* attributes)
+    Var DynamicObjectSnapshotEnumerator<T, enumNonEnumerable, enumSymbols>::MoveAndGetNextFromArray(_Out_ PropertyId& propertyId, PropertyAttributes* attributes)
     {
+        propertyId = Constants::NoProperty;
         if (this->arrayEnumerator)
         {
             Var currentIndex = this->arrayEnumerator->MoveAndGetNext(propertyId, attributes);
@@ -52,7 +53,7 @@ namespace Js
     }
 
     template <typename T, bool enumNonEnumerable, bool enumSymbols>
-    Var DynamicObjectSnapshotEnumerator<T, enumNonEnumerable, enumSymbols>::MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes)
+    Var DynamicObjectSnapshotEnumerator<T, enumNonEnumerable, enumSymbols>::MoveAndGetNext(_Out_ PropertyId& propertyId, PropertyAttributes* attributes)
     {
         Var currentIndex = MoveAndGetNextFromArray(propertyId, attributes);
         return (currentIndex != nullptr)? currentIndex :

--- a/lib/Runtime/Types/DynamicObjectSnapshotEnumerator.h
+++ b/lib/Runtime/Types/DynamicObjectSnapshotEnumerator.h
@@ -21,7 +21,7 @@ namespace Js
         DEFINE_VTABLE_CTOR(DynamicObjectSnapshotEnumerator, Base);
         DEFINE_MARSHAL_ENUMERATOR_TO_SCRIPT_CONTEXT(DynamicObjectSnapshotEnumerator);
 
-        Var MoveAndGetNextFromArray(PropertyId& propertyId, PropertyAttributes* attributes);
+        Var MoveAndGetNextFromArray(_Out_ PropertyId& propertyId, PropertyAttributes* attributes);
         JavascriptString * MoveAndGetNextFromObject(T& index, PropertyId& propertyId, PropertyAttributes* attributes);
 
         DynamicObjectSnapshotEnumerator() { /* Do nothing, needed by the vtable ctor for ForInObjectEnumeratorWrapper */ }
@@ -31,7 +31,7 @@ namespace Js
         static JavascriptEnumerator* New(ScriptContext* scriptContext, DynamicObject* object);
 
         virtual void Reset() override;
-        virtual Var MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
+        virtual Var MoveAndGetNext(_Out_ PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
     };
 
 } // namespace Js

--- a/lib/Runtime/Types/DynamicObjectSnapshotEnumeratorWPCache.cpp
+++ b/lib/Runtime/Types/DynamicObjectSnapshotEnumeratorWPCache.cpp
@@ -57,8 +57,9 @@ namespace Js
 
     template <typename T, bool enumNonEnumerable, bool enumSymbols>
     JavascriptString *
-        DynamicObjectSnapshotEnumeratorWPCache<T, enumNonEnumerable, enumSymbols>::MoveAndGetNextFromObjectWPCache(T& index, PropertyId& propertyId, PropertyAttributes* attributes)
+        DynamicObjectSnapshotEnumeratorWPCache<T, enumNonEnumerable, enumSymbols>::MoveAndGetNextFromObjectWPCache(T& index, _Out_ PropertyId& propertyId, PropertyAttributes* attributes)
     {
+        propertyId = Constants::NoProperty;
         if (this->initialType != this->object->GetDynamicType())
         {
             if (this->IsCrossSiteEnumerator())
@@ -158,7 +159,7 @@ namespace Js
     }
 
     template <typename T, bool enumNonEnumerable, bool enumSymbols>
-    Var DynamicObjectSnapshotEnumeratorWPCache<T, enumNonEnumerable, enumSymbols>::MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes)
+    Var DynamicObjectSnapshotEnumeratorWPCache<T, enumNonEnumerable, enumSymbols>::MoveAndGetNext(_Out_ PropertyId& propertyId, PropertyAttributes* attributes)
     {
         Var currentIndex = this->MoveAndGetNextFromArray(propertyId, attributes);
 

--- a/lib/Runtime/Types/DynamicObjectSnapshotEnumeratorWPCache.h
+++ b/lib/Runtime/Types/DynamicObjectSnapshotEnumeratorWPCache.h
@@ -29,7 +29,7 @@ namespace Js
         {
         }
 
-        JavascriptString * MoveAndGetNextFromObjectWPCache(T& index, PropertyId& propertyId, PropertyAttributes* attributes);
+        JavascriptString * MoveAndGetNextFromObjectWPCache(T& index, _Out_ PropertyId& propertyId, PropertyAttributes* attributes);
 
         struct CachedData
         {
@@ -51,7 +51,7 @@ namespace Js
     public:
         static JavascriptEnumerator* New(ScriptContext* scriptContext, DynamicObject* object);
         virtual void Reset() override;
-        virtual Var MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
+        virtual Var MoveAndGetNext(_Out_ PropertyId& propertyId, PropertyAttributes* attributes = nullptr) override;
 
         static uint32 GetOffsetOfInitialType() { return offsetof(DynamicObjectSnapshotEnumeratorWPCache, initialType); }
         static uint32 GetOffsetOfEnumeratedCount() { return offsetof(DynamicObjectSnapshotEnumeratorWPCache, enumeratedCount); }

--- a/lib/Runtime/Types/JavascriptEnumerator.h
+++ b/lib/Runtime/Types/JavascriptEnumerator.h
@@ -38,7 +38,7 @@ namespace Js {
         // If that code is added in this base class use JavaScriptRegExpEnumerator.h/cpp
         // as a reference and then remove it. If you have already made the edits before
         // seeing this comment please just consolidate the changes.
-        virtual Var MoveAndGetNext(PropertyId& propertyId, PropertyAttributes* attributes = nullptr) = 0;
+        virtual Var MoveAndGetNext(_Out_ PropertyId& propertyId, PropertyAttributes* attributes = nullptr) = 0;
 
         virtual BOOL IsCrossSiteEnumerator()
         {


### PR DESCRIPTION
Noticed a bug in `JSON.cpp` that was using `MoveAndGetNext` API to
retrieve `propertyId` which was uninitialized. Further we were hitting assert
when we check if `IsActivePropertyId` because propertyId contents are garbage.

Added SAL notation to `MoveAndGetNext` and also added initialization of propertyId
to `Constants::NoProperty` wherever necessary.
