### PR TITLE
Extend test timeout for allocation*.js and array_slice.js which can run longer on busy or low-resource test VMs.

### DIFF
--- a/test/Array/rlexe.xml
+++ b/test/Array/rlexe.xml
@@ -281,6 +281,7 @@
     <default>
       <files>array_slice.js</files>
       <baseline>array_slice.baseline</baseline>
+      <timeout>300</timeout>
     </default>
   </test>
   <test>

--- a/test/typedarray/rlexe.xml
+++ b/test/typedarray/rlexe.xml
@@ -207,12 +207,14 @@ Below test fails with difference in space. Investigate the cause and re-enable t
     <default>
       <files>allocation.js</files>
       <tags>typedarray,exclude_arm,xplatslow</tags>
+      <timeout>300</timeout>
     </default>
   </test>
   <test>
     <default>
       <files>allocation2.js</files>
       <tags>typedarray,exclude_arm,xplatslow</tags>
+      <timeout>300</timeout>
     </default>
   </test>
   <test>


### PR DESCRIPTION
We've observed them run for around 120 seconds; increasing the timeout to 300 seconds (5 minutes) should more than account for this.

Fixes #1406
Fixes #1417