### PR TITLE
MSFT 8152328 module initialization assert when one of the dependent was parsed earlier.

### DIFF
--- a/lib/Runtime/Language/SourceTextModuleRecord.cpp
+++ b/lib/Runtime/Language/SourceTextModuleRecord.cpp
@@ -39,7 +39,7 @@ namespace Js
         isRootModule(false),
         hadNotifyHostReady(false),
         localExportSlots(nullptr),
-        numUnParsedChildrenModule(0),
+        numUnInitializedChildrenModule(0),
         moduleId(InvalidModuleIndex),
         localSlotCount(InvalidSlotCount),
         localExportCount(0)
@@ -197,7 +197,7 @@ namespace Js
     {
         HRESULT hr = NO_ERROR;
 
-        if (numUnParsedChildrenModule == 0)
+        if (numUnInitializedChildrenModule == 0)
         {
             NotifyParentsAsNeeded();
         
@@ -239,11 +239,11 @@ namespace Js
         }
         else
         {
-            if (numUnParsedChildrenModule == 0)
+            if (numUnInitializedChildrenModule == 0)
             {
                 return NOERROR; // this is only in case of recursive module reference. Let the higher stack frame handle this module.
             }
-            numUnParsedChildrenModule--;
+            numUnInitializedChildrenModule--;
 
             hr = PrepareForModuleDeclarationInitialization();
         }
@@ -577,9 +577,9 @@ namespace Js
                         moduleRecord->parentModuleList = RecyclerNew(recycler, ModuleRecordList, recycler);
                     }
                     moduleRecord->parentModuleList->Add(this);
-                    if (!moduleRecord->WasParsed())
+                    if (!moduleRecord->WasDeclarationInitialized())
                     {
-                        numUnParsedChildrenModule++;
+                        numUnInitializedChildrenModule++;
                     }
                 }
                 return false;

--- a/lib/Runtime/Language/SourceTextModuleRecord.h
+++ b/lib/Runtime/Language/SourceTextModuleRecord.h
@@ -126,7 +126,7 @@ namespace Js
         LocalExportMap* localExportMapByExportName;  // from propertyId to index map: for bytecode gen.
         LocalExportMap* localExportMapByLocalName;  // from propertyId to index map: for bytecode gen.
         LocalExportIndexList* localExportIndexList; // from index to propertyId: for typehandler.
-        uint numUnParsedChildrenModule;
+        uint numUnInitializedChildrenModule;
         ExportedNames* exportedNames;
         ResolvedExportMap* resolvedExportMap;
 


### PR DESCRIPTION
Dependent module record notify the parent module that is is ready during DeclarationInitialization. We should
count the number of unfinished dependent module as those that are not done with DeclarationInitialization not Parse.
The test will be ported to core after we fix up ch test harness.
