### PR TITLE
cross-platform: protect stack on xplat

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,7 @@ endif()
     # -fno-inline.... -> -mno-omit.... are needed for more accurate stack inf.
     # Release Builds: Not sure if this has to be as strict as the debug/test?
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
+        -fstack-protector\
         -fdelayed-template-parsing\
         -fno-omit-frame-pointer\
         -fno-optimize-sibling-calls\

--- a/lib/Common/CommonPal.h
+++ b/lib/Common/CommonPal.h
@@ -27,8 +27,8 @@
     #define __forceinline inline
 #endif
 
-// Only VC compiler support overflow guard
 #if defined(__GNUC__) || defined(__clang__)
+// We have -fstack-protector added to CMake CXX flags
 #define DECLSPEC_GUARD_OVERFLOW
 #else // Windows
 #define DECLSPEC_GUARD_OVERFLOW __declspec(guard(overflow))


### PR DESCRIPTION
We have `__declspec(guard(overflow))` in place for Windows. Adding `-fstack-protector` flag
for a similar expectation on xplat