### PR TITLE
Enhance parse-time escape detection

### DIFF
--- a/lib/Parser/Hash.h
+++ b/lib/Parser/Hash.h
@@ -206,6 +206,22 @@ public:
         return prevRef;
     }
 
+    PidRefStack * TopDecl(int maxBlockId) const
+    {
+        for (PidRefStack *pidRef = m_pidRefStack; pidRef; pidRef = pidRef->prev)
+        {
+            if (pidRef->id > maxBlockId)
+            {
+                continue;
+            }
+            if (pidRef->sym != nullptr)
+            {
+                return pidRef;
+            }
+        }
+        return nullptr;
+    }
+
     PidRefStack * FindOrAddPidRef(ArenaAllocator *alloc, int scopeId, Js::LocalFunctionId funcId)
     {
         // If the stack is empty, or we are pushing to the innermost scope already,

--- a/test/stackfunc/rlexe.xml
+++ b/test/stackfunc/rlexe.xml
@@ -284,7 +284,7 @@
     <default>
       <files>funcname_escape.js</files>
       <baseline>funcname_escape.deferparse.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc -off:disablestackfuncondeferredescape</compile-flags>
       <tags>exclude_fre,exclude_dynapogo</tags>
     </default>
   </test>
@@ -511,7 +511,7 @@
     <default>
       <files>box_callparam.js</files>
       <baseline>box_callparam.deferparse.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -on:stackfunc -force:deferparse -off:cachescopeinfonames </compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:simpleJit -on:stackfunc -force:deferparse -off:cachescopeinfonames -off:disablestackfuncondeferredescape </compile-flags>
       <tags>exclude_fre,exclude_dynapogo</tags>
     </default>
   </test>


### PR DESCRIPTION
Enhance the parse-time escape-detection I added the other day by detecting 'function e(){...}; return e;'.