### PR TITLE
Wasm: Compilation exception message bugfix

### DIFF
--- a/lib/Runtime/Library/WasmLibrary.cpp
+++ b/lib/Runtime/Library/WasmLibrary.cpp
@@ -13,7 +13,7 @@ namespace Js
 {
     const unsigned int WasmLibrary::experimentalVersion = Wasm::experimentalVersion;
 
-    char16* lastWasmExceptionMessage = nullptr;
+    char16* WasmLibrary::lastWasmExceptionMessage = nullptr;
 
     Var WasmLibrary::instantiateModule(RecyclableObject* function, CallInfo callInfo, ...)
     {
@@ -168,9 +168,11 @@ namespace Js
             }
 #endif
         }
-        catch (Wasm::WasmCompilationException ex)
+        catch (Wasm::WasmCompilationException& ex)
         {
-            Wasm::WasmCompilationException newEx(_u("function %s: %s"), body->GetDisplayName(), ex.GetErrorMessage());
+            char16* originalMessage = ex.ReleaseErrorMessage();
+            Wasm::WasmCompilationException newEx = Wasm::WasmCompilationException(_u("function %s: %s"), body->GetDisplayName(), originalMessage);
+            SysFreeString(originalMessage);
             if (propagateError)
             {
                 throw newEx;

--- a/lib/Runtime/Library/WasmLibrary.h
+++ b/lib/Runtime/Library/WasmLibrary.h
@@ -48,6 +48,7 @@ namespace Js
             Js::Var ffi,
             Js::Var* start = nullptr
         );
+        static char16* lastWasmExceptionMessage;
 #endif
     };
 }

--- a/lib/WasmReader/WasmByteCodeGenerator.cpp
+++ b/lib/WasmReader/WasmByteCodeGenerator.cpp
@@ -1477,14 +1477,6 @@ WasmCompilationException::FormatError(const char16* _msg, va_list arglist)
     errorMsg = SysAllocString(buf);
 }
 
-WasmCompilationException::~WasmCompilationException()
-{
-    if (errorMsg)
-    {
-        SysFreeString(errorMsg);
-    }
-}
-
 WasmCompilationException::WasmCompilationException(const char16* _msg, ...)
 {
     va_list arglist;

--- a/lib/WasmReader/WasmByteCodeGenerator.h
+++ b/lib/WasmReader/WasmByteCodeGenerator.h
@@ -45,19 +45,8 @@ namespace Wasm
         void FormatError(const char16* _msg, va_list arglist);
         char16* errorMsg;
     public:
-        ~WasmCompilationException();
         WasmCompilationException(const char16* _msg, ...);
         WasmCompilationException(const char16* _msg, va_list arglist);
-
-        void SetErrorMessage(char16* _errorMsg)
-        {
-            errorMsg = _errorMsg;
-        }
-
-        const char16* GetErrorMessage() const
-        {
-            return errorMsg;
-        }
 
         char16* ReleaseErrorMessage()
         {


### PR DESCRIPTION
Fix bug in the Wasm Exception error message memory handling.
The memory for the string was being freed to soon by the destructor of the c++ exception. Which caused the next SysAllocString to allocate a different string at the same pointer of the previous wasm message.
The string's memory needs to be handled manually.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/1447)
<!-- Reviewable:end -->
