### PR TITLE
Fastpath for hasOwnProperty == true.

### DIFF
--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -1454,21 +1454,32 @@ if (!sourceList)
         return NULL;
     }
 
-
-    PropertyString* ScriptContext::GetPropertyString(PropertyId propertyId)
+    PropertyString* ScriptContext::TryGetPropertyString(PropertyId propertyId)
     {
         PropertyStringCacheMap* propertyStringMap = this->GetLibrary()->EnsurePropertyStringMap();
 
-        PropertyString *string;
         RecyclerWeakReference<PropertyString>* stringReference;
         if (propertyStringMap->TryGetValue(propertyId, &stringReference))
         {
-            string = stringReference->Get();
+            PropertyString *string = stringReference->Get();
             if (string != nullptr)
             {
                 return string;
             }
         }
+
+        return nullptr;
+    }
+
+    PropertyString* ScriptContext::GetPropertyString(PropertyId propertyId)
+    {
+        PropertyString *string = TryGetPropertyString(propertyId);
+        if (string != nullptr)
+        {
+            return string;
+        }
+
+        PropertyStringCacheMap* propertyStringMap = this->GetLibrary()->EnsurePropertyStringMap();
 
         const Js::PropertyRecord* propertyName = this->GetPropertyName(propertyId);
         string = this->GetLibrary()->CreatePropertyString(propertyName);

--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -1337,6 +1337,7 @@ private:
         void SetDisposeDisposeByFaultInjectionEventHandler(EventHandler eventHandler);
 #endif
         EnumeratedObjectCache* GetEnumeratedObjectCache() { return &(cache->enumObjCache); }
+        PropertyString* TryGetPropertyString(PropertyId propertyId);
         PropertyString* GetPropertyString(PropertyId propertyId);
         void InvalidatePropertyStringCache(PropertyId propertyId, Type* type);
         JavascriptString* GetIntegerString(Var aValue);

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -1075,10 +1075,9 @@ CommonNumber:
 
     BOOL JavascriptOperators::HasOwnProperty(Var instance, PropertyId propertyId, ScriptContext *requestContext)
     {
-        BOOL result;
         if (TaggedNumber::Is(instance))
         {
-            result = false;
+            return FALSE;
         }
         else
         {
@@ -1091,10 +1090,22 @@ CommonNumber:
             }
             else
             {
+                PropertyString *propString = requestContext->TryGetPropertyString(propertyId);
+                if (propString != nullptr)
+                {
+                    const PropertyCache *propCache = propString->GetPropertyCache();
+                    if (object->GetType() == propCache->type)
+                    {
+                        // The type cached for the property was the same as the type of this object
+                        // (i.e. obj in obj.hasOwnProperty), so we know the answer is "true".
+                        Assert(TRUE == (object && object->HasOwnProperty(propertyId))); // sanity check on the fastpath result
+                        return TRUE;
+                    }
+                }
+
                 return object && object->HasOwnProperty(propertyId);
             }
         }
-        return result;
     }
 
     BOOL JavascriptOperators::GetOwnAccessors(Var instance, PropertyId propertyId, Var* getter, Var* setter, ScriptContext * requestContext)


### PR DESCRIPTION
Adds a fastpath for the case when `Object.hasOwnProperty` returns `true` (meaning the property was found on the current object).

This optimization was inspired by the observation that a very common pattern to use `Object.hasOwnProperty` in the following manner:

```
for (var x in obj) {
    if (obj.hasOwnProperty(x)) {
        // do something
    }
}
```

From our observations, most instances of these patterns are used with shallow objects (objects with most of their enumerable properties on the object itself, rather than in the prototype chain), so most of the time, `Object.hasOwnProperty` would return true when invoked via the above pattern. Additionally, we have already created a property cache containing the type that a property was enumerated from, so we can use that information to trivially know whether the `this` parameter of `hasOwnProperty` was the same object on which we looked up that property, and if so, we know the answer is `true`.