### PR TITLE
Enhance parse-time escape detection

### DIFF
--- a/lib/Parser/Hash.h
+++ b/lib/Parser/Hash.h
@@ -75,14 +75,16 @@ public:
 
 struct PidRefStack
 {
-    PidRefStack() : isAsg(false), isDynamic(false), id(0), funcId(0), sym(nullptr), prev(nullptr), isModuleExport(false) {}
-    PidRefStack(int id, Js::LocalFunctionId funcId) : isAsg(false), isDynamic(false), id(id), funcId(funcId), sym(nullptr), prev(nullptr), isModuleExport(false) {}
+    PidRefStack() : isAsg(false), isDynamic(false), id(0), funcId(0), sym(nullptr), prev(nullptr), isEscape(false), isModuleExport(false) {}
+    PidRefStack(int id, Js::LocalFunctionId funcId) : isAsg(false), isDynamic(false), id(id), funcId(funcId), sym(nullptr), prev(nullptr), isEscape(false), isModuleExport(false) {}
 
     int GetScopeId() const    { return id; }
     Js::LocalFunctionId GetFuncScopeId() const { return funcId; }
     Symbol *GetSym() const    { return sym; }
     void SetSym(Symbol *sym)  { this->sym = sym; }
     bool IsAssignment() const { return isAsg; }
+    bool IsEscape() const { return isEscape; }
+    void SetIsEscape(bool is) { isEscape = is; }
     bool IsDynamicBinding() const { return isDynamic; }
     void SetDynamicBinding()  { isDynamic = true; }
 
@@ -94,6 +96,7 @@ struct PidRefStack
     bool           isAsg;
     bool           isDynamic;
     bool           isModuleExport;
+    bool           isEscape;
     int            id;
     Js::LocalFunctionId funcId;
     Symbol        *sym;

--- a/lib/Parser/Parse.h
+++ b/lib/Parser/Parse.h
@@ -728,6 +728,8 @@ private:
     template<const bool backgroundPidRefs>
     void BindPidRefs(BlockInfoStack *blockInfo, uint maxBlockId = (uint)-1);
     void BindPidRefsInScope(IdentPtr pid, Symbol *sym, int blockId, uint maxBlockId = (uint)-1);
+    void MarkEscapingRef(ParseNodePtr pnode, IdentToken *pToken);
+    void SetNestedFuncEscapes() const;
     void SetSymHasNonLocalReference(Symbol *sym);
     void PushScope(Scope *scope);
     void PopScope(Scope *scope);

--- a/test/stackfunc/rlexe.xml
+++ b/test/stackfunc/rlexe.xml
@@ -84,7 +84,7 @@
     <default>
       <files>argout_escape.js</files>
       <baseline>argout_escape.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc -off:disablestackfuncondeferredescape</compile-flags>
       <tags>exclude_fre</tags>
     </default>
   </test>
@@ -535,7 +535,7 @@
     <default>
       <files>recurse.js</files>
       <baseline>recurse.deferparse.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -on:stackfunc -force:deferparse</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:simpleJit -on:stackfunc -force:deferparse -off:disablestackfuncondeferredescape</compile-flags>
       <tags>exclude_fre,exclude_dynapogo</tags>
     </default>
   </test>
@@ -552,7 +552,7 @@
       <files>box_bailout.js</files>
       <baseline>box_bailout.deferparse.baseline</baseline>
       <!--Top Level function parsing on first call to script is turned off here, as this tests order of functions executed-->
-      <compile-flags>-DeferTopLevelTillFirstCall- -testtrace:stackfunc -off:simpleJit -on:stackfunc -force:deferparse</compile-flags>
+      <compile-flags>-DeferTopLevelTillFirstCall- -testtrace:stackfunc -off:simpleJit -on:stackfunc -force:deferparse -off:disablestackfuncondeferredescape</compile-flags>
       <tags>exclude_fre,exclude_dynapogo,exclude_arm,exclude_nonative</tags>
     </default>
   </test>
@@ -561,7 +561,7 @@
       <files>box_inline_bailout.js</files>
       <baseline>box_inline_bailout.deferparse.baseline</baseline>
       <!--Top Level function parsing on first call to script is turned off here, as this tests order of functions executed-->
-      <compile-flags>-DeferTopLevelTillFirstCall- -testtrace:stackfunc -off:simpleJit -on:stackfunc -force:deferparse</compile-flags>
+      <compile-flags>-DeferTopLevelTillFirstCall- -testtrace:stackfunc -off:simpleJit -on:stackfunc -force:deferparse -off:disablestackfuncondeferredescape</compile-flags>
       <tags>exclude_fre,exclude_dynapogo,exclude_arm,exclude_nonative</tags>
     </default>
   </test>
@@ -585,7 +585,7 @@
     <default>
       <files>funcexpr_2.js</files>
       <baseline>funcexpr_2.deferparse.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -on:stackfunc -force:deferparse</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:simpleJit -on:stackfunc -force:deferparse -off:disablestackfuncondeferredescape</compile-flags>
       <tags>exclude_fre,exclude_dynapogo,exclude_arm</tags>
     </default>
   </test>
@@ -593,7 +593,7 @@
     <default>
       <files>funcexpr_2.js</files>
       <baseline>funcexpr_2.deferparse.native.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -on:stackfunc -force:deferparse -forceNative -off:simpleJit</compile-flags>
+      <compile-flags>-testtrace:stackfunc -on:stackfunc -force:deferparse -forceNative -off:simpleJit -off:disablestackfuncondeferredescape</compile-flags>
       <tags>exclude_fre,exclude_dynapogo,exclude_arm</tags>
     </default>
   </test>


### PR DESCRIPTION
Enhance parse-time escape detection to handle function expression passed as out param and to detect names of functions in escaping patterns as well as function expressions.