### PR TITLE
Added assert inside CheckIfTypeIsEquivalent

### DIFF
--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -8208,6 +8208,8 @@ CommonNumber:
             return false;
         }
 
+        AssertMsg(type && type->GetScriptContext(), "type and it's ScriptContext should be valid.");
+
         if (!guard->IsInvalidatedDuringSweep() && guard->GetType()->GetScriptContext() != type->GetScriptContext())
         {
             // For valid guard value, can't cache cross-context objects


### PR DESCRIPTION
In internal test tools, sometimes the `type` passed to `CheckIfTypeIsEquivalent()` is null. This might be an existing issue but now started showing up in `CheckIfTypeIsEquivalent()`
because we resurrect the guard that was set invalid in the past. When that happens, `guard->GetValue() == 0` check will always return false and the type being nullptr would fail later in bailout/helper. However after my change 475df2c988608ecb99987c685c6459090e91c4e8, guard value was reset and now it passed the above mentioned check and blows up when we try to extract scriptContext from type.

To better understand why it is failing in this code path, I have added an assert on `type` as well as guard's type never being nullptr. If we hit this, we could determine if guard was resurrected or not. If not, then this is definitely an existing bug and need investigation. If guard was resurrected means that it is crashing inside CheckIfTypeIsEquivalent() because of side effect of resurrection otherwise it would have crashed later in the flow.

See : https://microsoft.visualstudio.com//defaultcollection/OS/_workItems?_a=edit&id=8301000&triage=true
