### PR TITLE
Move TEMP up one level

### DIFF
--- a/jenkins/buildone.cmd
+++ b/jenkins/buildone.cmd
@@ -6,8 +6,10 @@
 @echo off
 setlocal
 
-REM set TEMP and TMP to a new temp folder under the WORKSPACE and create it
-set TEMP=%WORKSPACE%\TEMP
+REM set TEMP and TMP to a new temp folder under the parent of WORKSPACE and create it
+pushd %WORKSPACE%\..\
+set TEMP=%CD%\TEMP
+popd
 set TMP=%TEMP%
 REM create the TMP folder if it doesn't exist
 if not exist %TEMP% (


### PR DESCRIPTION
I think this may be a workaround to the XamlTaskFactory and CodeTaskFactory issues.  It appears that the combination of git clean and msbuild has somehow started to cause the TEMP directory to be asynchronously deleted (or at least deleted slower than before).  While msbuild is running, the TEMP dir finishes deletion, and suddenly msbuild fails to create files.  This fix does not fix the underlying issue. It's still unknown what change caused it, but it may be an Azure change.  I can repro outside of Jenkins and on a clean machine without any coreclr build ever done on it.

After making this tweak, a failure that occurred very often was not seen at all.

I am running the new version overnight on the test VM.  If it passes all the way through we should merge this.

/cc @dilijev 