### PR TITLE
Fix bug in assert in AddShadowedData()

### DIFF
--- a/lib/Runtime/Types/DictionaryPropertyDescriptor.h
+++ b/lib/Runtime/Types/DictionaryPropertyDescriptor.h
@@ -164,6 +164,7 @@ namespace Js
         {
             this->Getter = nextPropertyIndex++;
         }
+        this->Attributes |= PropertyLetConstGlobal;
         Assert(GetDataPropertyIndex<false>() != NoSlots);
     }
 

--- a/lib/Runtime/Types/DictionaryTypeHandler.cpp
+++ b/lib/Runtime/Types/DictionaryTypeHandler.cpp
@@ -1706,16 +1706,16 @@ namespace Js
             {
                 bool addingLetConstGlobal = (attributes & PropertyLetConstGlobal) != 0;
 
-                descriptor->AddShadowedData(nextPropertyIndex, addingLetConstGlobal);
-
                 if (addingLetConstGlobal)
                 {
-                    descriptor->Attributes = descriptor->Attributes | (attributes & PropertyNoRedecl) | PropertyLetConstGlobal;
+                    descriptor->Attributes = descriptor->Attributes | (attributes & PropertyNoRedecl);
                 }
                 else
                 {
-                    descriptor->Attributes = attributes | (descriptor->Attributes & PropertyNoRedecl) | PropertyLetConstGlobal;
+                    descriptor->Attributes = attributes | (descriptor->Attributes & PropertyNoRedecl);
                 }
+
+                descriptor->AddShadowedData(nextPropertyIndex, addingLetConstGlobal);
 
                 if (this->GetSlotCapacity() <= nextPropertyIndex)
                 {


### PR DESCRIPTION
DictionaryPropertyDescriptor<>::AddShadowedData() has an assert at the
end to verify the data property index is correct after the shadowing.
However GetDataPropertyIndex<>() relies on the PropertyLetConstGlobal
attribute being set on the Attributes field in order to return correct
results and this was being set after the call to AddShadowedData.

Fixed by moving the attribute flag set into AddShadowedData before the
assertion.

Found by internal web crawler, VSO bug [8482800](https://microsoft.visualstudio.com/OS/_workitems?id=8482800).