### PR TITLE
Unify error handling for arguments, caller and callee accessor functions

### DIFF
--- a/lib/Parser/rterrors.h
+++ b/lib/Parser/rterrors.h
@@ -154,7 +154,7 @@ RT_ERROR_MSG(JSERR_CyclicProtoValue, 5040, "", "Cyclic __proto__ value", kjstErr
 RT_ERROR_MSG(JSERR_CantDeleteExpr, 5041, "Calling delete on '%s' is not allowed in strict mode", "Object member not configurable", kjstTypeError, 0) // string 4
 RT_ERROR_MSG(JSERR_RefErrorUndefVariable, 5042, "", "Variable undefined in strict mode",  kjstReferenceError, 0) // string 10
 RT_ERROR_MSG(JSERR_AccessRestrictedProperty, 5043, "", "'arguments', 'callee' and 'caller' are restricted function properties and cannot be accessed in this context", kjstTypeError, 0)
-//RT_ERROR_MSG(JSERR_AccessCallee, 5044, "", "Accessing the 'callee' property of an arguments object is not allowed in strict mode", kjstTypeError, 0) // string 2
+// 5044 - Removed
 RT_ERROR_MSG(JSERR_CantAssignToReadOnly, 5045, "", "Assignment to read-only properties is not allowed in strict mode", kjstTypeError, 0) // string 5
 RT_ERROR_MSG(JSERR_NonExtensibleObject, 5046, "", "Cannot create property for a non-extensible object", kjstTypeError, 0) // string 6
 
@@ -213,9 +213,7 @@ RT_ERROR_MSG(JSERR_InvalidPropertySignature, 5092, "The property '%s' has an inv
 
 RT_ERROR_MSG(JSERR_InvalidRTCPropertyValueIn, 5093, "The runtimeclass %s that has Windows.Foundation.IPropertyValue as default interface is not supported as an input parameter type", "invalid input parameter type", kjstTypeError, 0)
 RT_ERROR_MSG(JSERR_RTCInvalidRTCPropertyValueOut, 5094, "The object with interface Windows.Foundation.IPropertyValue that has runtimeclass name %s is not supported as an output parameter", "invalid output parameter", kjstTypeError, 0)
-
-//RT_ERROR_MSG(JSERR_AccessArgumentsRestricted, 5095, "", "Accessing the 'arguments' property is restricted in this context", kjstTypeError, 0)
-
+// 5095 - Removed
 RT_ERROR_MSG(JSERR_This_NeedInspectableObject, 5096, "%s: 'this' is not an Inspectable Object", "Inspectable Object expected", kjstTypeError, JSERR_NeedObject) // {Locked="\'this\'"}
 
 RT_ERROR_MSG(JSERR_FunctionArgument_NeedWinRTChar, 5097, "%s: could not convert argument to type 'char'", "Could not convert argument to type 'char'", kjstTypeError, 0)

--- a/lib/Parser/rterrors.h
+++ b/lib/Parser/rterrors.h
@@ -153,8 +153,8 @@ RT_ERROR_MSG(JSERR_CyclicProtoValue, 5040, "", "Cyclic __proto__ value", kjstErr
 
 RT_ERROR_MSG(JSERR_CantDeleteExpr, 5041, "Calling delete on '%s' is not allowed in strict mode", "Object member not configurable", kjstTypeError, 0) // string 4
 RT_ERROR_MSG(JSERR_RefErrorUndefVariable, 5042, "", "Variable undefined in strict mode",  kjstReferenceError, 0) // string 10
-RT_ERROR_MSG(JSERR_AccessCallerRestricted, 5043, "", "Accessing the 'caller' property is restricted in this context", kjstTypeError, 0)
-RT_ERROR_MSG(JSERR_AccessCallee, 5044, "", "Accessing the 'callee' property of an arguments object is not allowed in strict mode", kjstTypeError, 0) // string 2
+RT_ERROR_MSG(JSERR_AccessRestrictedProperty, 5043, "", "'arguments', 'callee' and 'caller' are restricted function properties and cannot be accessed in this context", kjstTypeError, 0)
+//RT_ERROR_MSG(JSERR_AccessCallee, 5044, "", "Accessing the 'callee' property of an arguments object is not allowed in strict mode", kjstTypeError, 0) // string 2
 RT_ERROR_MSG(JSERR_CantAssignToReadOnly, 5045, "", "Assignment to read-only properties is not allowed in strict mode", kjstTypeError, 0) // string 5
 RT_ERROR_MSG(JSERR_NonExtensibleObject, 5046, "", "Cannot create property for a non-extensible object", kjstTypeError, 0) // string 6
 
@@ -214,7 +214,7 @@ RT_ERROR_MSG(JSERR_InvalidPropertySignature, 5092, "The property '%s' has an inv
 RT_ERROR_MSG(JSERR_InvalidRTCPropertyValueIn, 5093, "The runtimeclass %s that has Windows.Foundation.IPropertyValue as default interface is not supported as an input parameter type", "invalid input parameter type", kjstTypeError, 0)
 RT_ERROR_MSG(JSERR_RTCInvalidRTCPropertyValueOut, 5094, "The object with interface Windows.Foundation.IPropertyValue that has runtimeclass name %s is not supported as an output parameter", "invalid output parameter", kjstTypeError, 0)
 
-RT_ERROR_MSG(JSERR_AccessArgumentsRestricted, 5095, "", "Accessing the 'arguments' property is restricted in this context", kjstTypeError, 0)
+//RT_ERROR_MSG(JSERR_AccessArgumentsRestricted, 5095, "", "Accessing the 'arguments' property is restricted in this context", kjstTypeError, 0)
 
 RT_ERROR_MSG(JSERR_This_NeedInspectableObject, 5096, "%s: 'this' is not an Inspectable Object", "Inspectable Object expected", kjstTypeError, JSERR_NeedObject) // {Locked="\'this\'"}
 

--- a/lib/Runtime/Debug/TTRuntmeInfoTracker.cpp
+++ b/lib/Runtime/Debug/TTRuntmeInfoTracker.cpp
@@ -490,10 +490,7 @@ namespace TTD
         this->EnqueueRootPathObject(_u("_defaultAccessor"), ctx->GetLibrary()->GetDefaultAccessorFunction());
 
         this->EnqueueRootPathObject(_u("_stackTraceAccessor"), ctx->GetLibrary()->GetStackTraceAccessorFunction());
-        this->EnqueueRootPathObject(_u("_throwTypeErrorAccessor"), ctx->GetLibrary()->GetThrowTypeErrorAccessorFunction());
-        this->EnqueueRootPathObject(_u("_throwTypeErrorCallerAccessor"), ctx->GetLibrary()->GetThrowTypeErrorCallerAccessorFunction());
-        this->EnqueueRootPathObject(_u("_throwTypeErrorCalleeAccessor"), ctx->GetLibrary()->GetThrowTypeErrorCalleeAccessorFunction());
-        this->EnqueueRootPathObject(_u("_throwTypeErrorArgumentsAccessor"), ctx->GetLibrary()->GetThrowTypeErrorArgumentsAccessorFunction());
+        this->EnqueueRootPathObject(_u("_throwTypeErrorRestrictedPropertyAccessor"), ctx->GetLibrary()->GetThrowTypeErrorRestrictedPropertyAccessorFunction());
 
         //DEBUG
         uint32 counter = 0;

--- a/lib/Runtime/Language/JavascriptConversion.cpp
+++ b/lib/Runtime/Language/JavascriptConversion.cpp
@@ -216,16 +216,7 @@ CommonNumber:
                 }
             }
             return false;
-        case TypeIds_Function:
-            switch (rightType)
-            {
-            case TypeIds_Function:
-                if (JavascriptFunction::FromVar(aLeft)->IsThrowTypeErrorFunction() &&
-                    JavascriptFunction::FromVar(aRight)->IsThrowTypeErrorFunction())
-                {
-                    return true;
-                }
-            }
+        default:
             break;
         }
         return aLeft == aRight;

--- a/lib/Runtime/Language/JavascriptExceptionOperators.cpp
+++ b/lib/Runtime/Language/JavascriptExceptionOperators.cpp
@@ -1032,27 +1032,10 @@ namespace Js
         JavascriptError::ThrowReferenceError(scriptContext, MAKE_HR(messageId));
     }
 
-    Var JavascriptExceptionOperators::ThrowTypeErrorAccessor(RecyclableObject* function, CallInfo callInfo, ...)
+    // Throw type error on access 'arguments', 'callee' or 'caller' when in a restricted context
+    Var JavascriptExceptionOperators::ThrowTypeErrorRestrictedPropertyAccessor(RecyclableObject* function, CallInfo callInfo, ...)
     {
-        JavascriptError::ThrowTypeError(function->GetScriptContext(), VBSERR_ActionNotSupported);
-    }
-
-    // Throw type error on access caller when in a restricted context
-    Var JavascriptExceptionOperators::ThrowTypeErrorCallerAccessor(RecyclableObject* function, CallInfo callInfo, ...)
-    {
-        JavascriptError::ThrowTypeError(function->GetScriptContext(), JSERR_AccessCallerRestricted);
-    }
-
-    // Throw type error on access on callee when strict mode
-    Var JavascriptExceptionOperators::ThrowTypeErrorCalleeAccessor(RecyclableObject* function, CallInfo callInfo, ...)
-    {
-        JavascriptError::ThrowTypeError(function->GetScriptContext(), JSERR_AccessCallee);
-    }
-
-    // Throw type error on access arguments when in a restricted context
-    Var JavascriptExceptionOperators::ThrowTypeErrorArgumentsAccessor(RecyclableObject* function, CallInfo callInfo, ...)
-    {
-        JavascriptError::ThrowTypeError(function->GetScriptContext(), JSERR_AccessArgumentsRestricted);
+        JavascriptError::ThrowTypeError(function->GetScriptContext(), JSERR_AccessRestrictedProperty);
     }
 
     Var JavascriptExceptionOperators::StackTraceAccessor(RecyclableObject* function, CallInfo callInfo, ...)

--- a/lib/Runtime/Language/JavascriptExceptionOperators.h
+++ b/lib/Runtime/Language/JavascriptExceptionOperators.h
@@ -70,10 +70,7 @@ namespace Js
         static void __declspec(noreturn) ThrowStackOverflow(ScriptContext* scriptContext, PVOID returnAddress);
 
         static uint64 GetStackTraceLimit(Var thrownObject, ScriptContext* scriptContext);
-        static Var ThrowTypeErrorAccessor(RecyclableObject* function, CallInfo callInfo, ...);
-        static Var ThrowTypeErrorCallerAccessor(RecyclableObject* function, CallInfo callInfo, ...);
-        static Var ThrowTypeErrorCalleeAccessor(RecyclableObject* function, CallInfo callInfo, ...);
-        static Var ThrowTypeErrorArgumentsAccessor(RecyclableObject* function, CallInfo callInfo, ...);
+        static Var ThrowTypeErrorRestrictedPropertyAccessor(RecyclableObject* function, CallInfo callInfo, ...);
         static Var StackTraceAccessor(RecyclableObject* function, CallInfo callInfo, ...);
         static void WalkStackForExceptionContext(ScriptContext& scriptContext, JavascriptExceptionContext& exceptionContext, Var thrownObject, uint64 stackCrawlLimit, PVOID returnAddress, bool isThrownException = true, bool resetSatck = false);
         static void AddStackTraceToObject(Var obj, JavascriptExceptionContext::StackTrace* stackTrace, ScriptContext& scriptContext, bool isThrownException = true, bool resetSatck = false);
@@ -82,13 +79,10 @@ namespace Js
         class EntryInfo
         {
         public:
-            static FunctionInfo ThrowTypeErrorAccessor;
             static FunctionInfo StackTraceAccessor;
 
             // For strict mode
-            static FunctionInfo ThrowTypeErrorCallerAccessor;
-            static FunctionInfo ThrowTypeErrorCalleeAccessor;
-            static FunctionInfo ThrowTypeErrorArgumentsAccessor;
+            static FunctionInfo ThrowTypeErrorRestrictedPropertyAccessor;
         };
 
       private:

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -1016,19 +1016,6 @@ CommonNumber:
             }
             break;
 
-        case TypeIds_Function:
-            if (rightType == TypeIds_Function)
-            {
-                // In ES5 in certain cases (ES5 10.6.14(strict), 13.2.19(strict), 15.3.4.5.20-21) we return a function that throws type error.
-                // For different scenarios we return different instances of the function, which differ by exception/error message.
-                // According to ES5, this is the same [[ThrowTypeError]] (thrower) internal function, thus they should be equal.
-                if (JavascriptFunction::FromVar(aLeft)->IsThrowTypeErrorFunction() &&
-                    JavascriptFunction::FromVar(aRight)->IsThrowTypeErrorFunction())
-                {
-                    return true;
-                }
-            }
-            break;
 #ifdef ENABLE_SIMDJS
         case TypeIds_SIMDBool8x16:
         case TypeIds_SIMDInt8x16:
@@ -6904,11 +6891,10 @@ CommonNumber:
         JavascriptOperators::SetProperty(argsObj, argsObj, PropertyIds::_symbolIterator, library->GetArrayPrototypeValuesFunction(), scriptContext);
         if (funcCallee->IsStrictMode())
         {
-            JavascriptFunction* callerAccessor = library->GetThrowTypeErrorCallerAccessorFunction();            
-            argsObj->SetAccessors(PropertyIds::caller, callerAccessor, callerAccessor, PropertyOperation_NonFixedValue);
+            JavascriptFunction* restrictedPropertyAccessor = library->GetThrowTypeErrorRestrictedPropertyAccessorFunction();
+            argsObj->SetAccessors(PropertyIds::caller, restrictedPropertyAccessor, restrictedPropertyAccessor, PropertyOperation_NonFixedValue);
 
-            JavascriptFunction* calleeAccessor = library->GetThrowTypeErrorCalleeAccessorFunction();
-            argsObj->SetAccessors(PropertyIds::callee, calleeAccessor, calleeAccessor, PropertyOperation_NonFixedValue);
+            argsObj->SetAccessors(PropertyIds::callee, restrictedPropertyAccessor, restrictedPropertyAccessor, PropertyOperation_NonFixedValue);
 
         }
         else

--- a/lib/Runtime/Library/JavascriptBuiltInFunctionList.h
+++ b/lib/Runtime/Library/JavascriptBuiltInFunctionList.h
@@ -8,10 +8,7 @@
 #endif
 
 BUILTIN(JavascriptExceptionOperators, StackTraceAccessor, StackTraceAccessor, FunctionInfo::DoNotProfile)
-BUILTIN(JavascriptExceptionOperators, ThrowTypeErrorAccessor, ThrowTypeErrorAccessor, FunctionInfo::DoNotProfile)
-BUILTIN(JavascriptExceptionOperators, ThrowTypeErrorCallerAccessor, ThrowTypeErrorCallerAccessor, FunctionInfo::DoNotProfile)
-BUILTIN(JavascriptExceptionOperators, ThrowTypeErrorCalleeAccessor, ThrowTypeErrorCalleeAccessor, FunctionInfo::DoNotProfile)
-BUILTIN(JavascriptExceptionOperators, ThrowTypeErrorArgumentsAccessor, ThrowTypeErrorArgumentsAccessor, FunctionInfo::DoNotProfile)
+BUILTIN(JavascriptExceptionOperators, ThrowTypeErrorRestrictedPropertyAccessor, ThrowTypeErrorRestrictedPropertyAccessor, FunctionInfo::DoNotProfile)
 BUILTIN(JavascriptOperators, DefaultAccessor, DefaultAccessor, FunctionInfo::DoNotProfile)
 BUILTIN(GlobalObject, Eval, EntryEval, FunctionInfo::ErrorOnNew)
 BUILTIN(GlobalObject, ParseInt, EntryParseInt, FunctionInfo::ErrorOnNew)

--- a/lib/Runtime/Library/JavascriptFunction.cpp
+++ b/lib/Runtime/Library/JavascriptFunction.cpp
@@ -371,18 +371,6 @@ namespace Js
         return library->GetUndefined();
     }
 
-    BOOL JavascriptFunction::IsThrowTypeErrorFunction()
-    {
-        ScriptContext* scriptContext = this->GetScriptContext();
-        Assert(scriptContext);
-
-        return
-            this == scriptContext->GetLibrary()->GetThrowTypeErrorAccessorFunction() ||
-            this == scriptContext->GetLibrary()->GetThrowTypeErrorCalleeAccessorFunction() ||
-            this == scriptContext->GetLibrary()->GetThrowTypeErrorCallerAccessorFunction() ||
-            this == scriptContext->GetLibrary()->GetThrowTypeErrorArgumentsAccessorFunction();
-    }
-
     enum : unsigned { STACK_ARGS_ALLOCA_THRESHOLD = 8 }; // Number of stack args we allow before using _alloca
 
     // ES5 15.3.4.3
@@ -2255,17 +2243,10 @@ LABEL1:
             switch (propertyId)
             {
             case PropertyIds::caller:
-                if (this->GetEntryPoint() == JavascriptFunction::PrototypeEntryPoint)
-                {
-                    *setter = *getter = requestContext->GetLibrary()->GetThrowTypeErrorCallerAccessorFunction();
-                    return true;
-                }
-                break;
-
             case PropertyIds::arguments:
                 if (this->GetEntryPoint() == JavascriptFunction::PrototypeEntryPoint)
                 {
-                    *setter = *getter = requestContext->GetLibrary()->GetThrowTypeErrorArgumentsAccessorFunction();
+                    *setter = *getter = requestContext->GetLibrary()->GetThrowTypeErrorRestrictedPropertyAccessorFunction();
                     return true;
                 }
                 break;
@@ -2309,27 +2290,12 @@ LABEL1:
         switch (propertyId)
         {
         case PropertyIds::caller:
-            if (this->HasRestrictedProperties()) {
-                PropertyValueInfo::SetNoCache(info, this);
-                if (this->GetEntryPoint() == JavascriptFunction::PrototypeEntryPoint)
-                {
-                    *setterValue = requestContext->GetLibrary()->GetThrowTypeErrorCallerAccessorFunction();
-                    *descriptorFlags = Accessor;
-                }
-                else
-                {
-                    *descriptorFlags = Data;
-                }
-                return true;
-            }
-            break;
-
         case PropertyIds::arguments:
             if (this->HasRestrictedProperties()) {
                 PropertyValueInfo::SetNoCache(info, this);
                 if (this->GetEntryPoint() == JavascriptFunction::PrototypeEntryPoint)
                 {
-                    *setterValue = requestContext->GetLibrary()->GetThrowTypeErrorArgumentsAccessorFunction();
+                    *setterValue = requestContext->GetLibrary()->GetThrowTypeErrorRestrictedPropertyAccessorFunction();
                     *descriptorFlags = Accessor;
                 }
                 else
@@ -2507,7 +2473,7 @@ LABEL1:
         {
             if (scriptContext->GetThreadContext()->RecordImplicitException())
             {
-                JavascriptFunction* accessor = requestContext->GetLibrary()->GetThrowTypeErrorCallerAccessorFunction();
+                JavascriptFunction* accessor = requestContext->GetLibrary()->GetThrowTypeErrorRestrictedPropertyAccessorFunction();
                 *value = CALL_FUNCTION(accessor, CallInfo(1), originalInstance);
             }
             return true;
@@ -2562,7 +2528,7 @@ LABEL1:
                 // Note that for caller coming from remote context (see the check right above) we can't call IsStrictMode()
                 // unless CheckCrossDomainScriptContext succeeds. If it fails we don't know whether caller is strict mode
                 // function or not and throw if it's not, so just return Null.
-                JavascriptError::ThrowTypeError(scriptContext, JSERR_AccessCallerRestricted);
+                JavascriptError::ThrowTypeError(scriptContext, JSERR_AccessRestrictedProperty);
             }
         }
 
@@ -2582,7 +2548,7 @@ LABEL1:
         {
             if (scriptContext->GetThreadContext()->RecordImplicitException())
             {
-                JavascriptFunction* accessor = requestContext->GetLibrary()->GetThrowTypeErrorArgumentsAccessorFunction();
+                JavascriptFunction* accessor = requestContext->GetLibrary()->GetThrowTypeErrorRestrictedPropertyAccessorFunction();
                 *value = CALL_FUNCTION(accessor, CallInfo(1), originalInstance);
             }
             return true;

--- a/lib/Runtime/Library/JavascriptFunction.h
+++ b/lib/Runtime/Library/JavascriptFunction.h
@@ -191,8 +191,6 @@ namespace Js
         virtual bool IsBoundFunction() const { return false; }
         virtual bool IsGeneratorFunction() const { return false; }
 
-        BOOL IsThrowTypeErrorFunction();
-
         void SetEntryPoint(JavascriptMethod method);
 #if DBG
         void VerifyEntryPoint();

--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -1107,17 +1107,8 @@ namespace Js
             stackTraceAccessorFunction->SetPropertyWithAttributes(PropertyIds::length, TaggedInt::ToVarUnchecked(0), PropertyNone, nullptr);
         }
 
-        throwTypeErrorAccessorFunction = CreateNonProfiledFunction(&JavascriptExceptionOperators::EntryInfo::ThrowTypeErrorAccessor);
-        throwTypeErrorAccessorFunction->SetPropertyWithAttributes(PropertyIds::length, TaggedInt::ToVarUnchecked(0), PropertyNone, nullptr);
-
-        throwTypeErrorCallerAccessorFunction = CreateNonProfiledFunction(&JavascriptExceptionOperators::EntryInfo::ThrowTypeErrorCallerAccessor);
-        throwTypeErrorCallerAccessorFunction->SetPropertyWithAttributes(PropertyIds::length, TaggedInt::ToVarUnchecked(0), PropertyNone, nullptr);
-
-        throwTypeErrorCalleeAccessorFunction = CreateNonProfiledFunction(&JavascriptExceptionOperators::EntryInfo::ThrowTypeErrorCalleeAccessor);
-        throwTypeErrorCalleeAccessorFunction->SetPropertyWithAttributes(PropertyIds::length, TaggedInt::ToVarUnchecked(0), PropertyNone, nullptr);
-
-        throwTypeErrorArgumentsAccessorFunction = CreateNonProfiledFunction(&JavascriptExceptionOperators::EntryInfo::ThrowTypeErrorArgumentsAccessor);
-        throwTypeErrorArgumentsAccessorFunction->SetPropertyWithAttributes(PropertyIds::length, TaggedInt::ToVarUnchecked(0), PropertyNone, nullptr);
+        throwTypeErrorRestrictedPropertyAccessorFunction = CreateNonProfiledFunction(&JavascriptExceptionOperators::EntryInfo::ThrowTypeErrorRestrictedPropertyAccessor);
+        throwTypeErrorRestrictedPropertyAccessorFunction->SetPropertyWithAttributes(PropertyIds::length, TaggedInt::ToVarUnchecked(0), PropertyNone, nullptr);
 
         __proto__getterFunction = CreateNonProfiledFunction(&ObjectPrototypeObject::EntryInfo::__proto__getter);
         __proto__getterFunction->SetPropertyWithAttributes(PropertyIds::length, TaggedInt::ToVarUnchecked(0), PropertyNone, nullptr);

--- a/lib/Runtime/Library/JavascriptLibrary.h
+++ b/lib/Runtime/Library/JavascriptLibrary.h
@@ -775,10 +775,7 @@ namespace Js
         DynamicType * GetListIteratorType() const { return listIteratorType; }
         JavascriptFunction* GetDefaultAccessorFunction() const { return defaultAccessorFunction; }
         JavascriptFunction* GetStackTraceAccessorFunction() const { return stackTraceAccessorFunction; }
-        JavascriptFunction* GetThrowTypeErrorAccessorFunction() const { return throwTypeErrorAccessorFunction; }
-        JavascriptFunction* GetThrowTypeErrorCallerAccessorFunction() const { return throwTypeErrorCallerAccessorFunction; }
-        JavascriptFunction* GetThrowTypeErrorCalleeAccessorFunction() const { return throwTypeErrorCalleeAccessorFunction; }
-        JavascriptFunction* GetThrowTypeErrorArgumentsAccessorFunction() const { return throwTypeErrorArgumentsAccessorFunction; }
+        JavascriptFunction* GetThrowTypeErrorRestrictedPropertyAccessorFunction() const { return throwTypeErrorRestrictedPropertyAccessorFunction; }
         JavascriptFunction* Get__proto__getterFunction() const { return __proto__getterFunction; }
         JavascriptFunction* Get__proto__setterFunction() const { return __proto__setterFunction; }
 

--- a/lib/Runtime/Library/JavascriptLibraryBase.h
+++ b/lib/Runtime/Library/JavascriptLibraryBase.h
@@ -173,10 +173,7 @@ namespace Js
 
         JavascriptFunction* defaultAccessorFunction;
         JavascriptFunction* stackTraceAccessorFunction;
-        JavascriptFunction* throwTypeErrorAccessorFunction;
-        JavascriptFunction* throwTypeErrorCallerAccessorFunction;
-        JavascriptFunction* throwTypeErrorCalleeAccessorFunction;
-        JavascriptFunction* throwTypeErrorArgumentsAccessorFunction;
+        JavascriptFunction* throwTypeErrorRestrictedPropertyAccessorFunction;
         JavascriptFunction* debugObjectNonUserGetterFunction;
         JavascriptFunction* debugObjectNonUserSetterFunction;
         JavascriptFunction* debugObjectDebugModeGetterFunction;

--- a/lib/Runtime/Types/RecyclableObject.cpp
+++ b/lib/Runtime/Types/RecyclableObject.cpp
@@ -680,14 +680,6 @@ namespace Js
         case TypeIds_Function:
             if (rightType == TypeIds_Function)
             {
-                // In ES5 in certain cases (ES5 10.6.14(strict), 13.2.19(strict), 15.3.4.5.20-21) we return a function that throws type error.
-                // For different scenarios we return different instances of the function, which differ by exception/error message.
-                // According to ES5, this is the same [[ThrowTypeError]] (thrower) internal function, thus they should be equal.
-                if (JavascriptFunction::FromVar(aLeft)->IsThrowTypeErrorFunction() &&
-                    JavascriptFunction::FromVar(aRight)->IsThrowTypeErrorFunction())
-                {
-                    goto ReturnTrue;
-                }
                 goto ReturnFalse;
             }
             // Fall through to do normal object comparison on function object.

--- a/test/es6/ES6RestrictedProperties.js
+++ b/test/es6/ES6RestrictedProperties.js
@@ -65,17 +65,17 @@ function verifyDoesNotHaveRestrictedOwnProperties(obj, name) {
     assert.areEqual(undefined, Object.getOwnPropertyDescriptor(obj, 'arguments'), name + " does not have 'arguments' own property");
     assert.isFalse(obj.propertyIsEnumerable('arguments'), name + " says 'arguments' property is not enumerable");
 
-    assert.throws(function() { obj.caller; }, TypeError, name + " throws on access to 'caller' property", "Accessing the 'caller' property is restricted in this context");
-    assert.throws(function() { obj.arguments; }, TypeError, name + " throws on access to 'arguments' property", "Accessing the 'arguments' property is restricted in this context");
+    assert.throws(function() { obj.caller; }, TypeError, name + " throws on access to 'caller' property", "'arguments', 'callee' and 'caller' are restricted function properties and cannot be accessed in this context");
+    assert.throws(function() { obj.arguments; }, TypeError, name + " throws on access to 'arguments' property", "'arguments', 'callee' and 'caller' are restricted function properties and cannot be accessed in this context");
 
-    assert.throws(function() { 'use strict'; obj.caller; }, TypeError, name + " throws on access to 'caller' property in strict mode", "Accessing the 'caller' property is restricted in this context");
-    assert.throws(function() { 'use strict'; obj.arguments; }, TypeError, name + " throws on access to 'arguments' property in strict mode", "Accessing the 'arguments' property is restricted in this context");
+    assert.throws(function() { 'use strict'; obj.caller; }, TypeError, name + " throws on access to 'caller' property in strict mode", "'arguments', 'callee' and 'caller' are restricted function properties and cannot be accessed in this context");
+    assert.throws(function() { 'use strict'; obj.arguments; }, TypeError, name + " throws on access to 'arguments' property in strict mode", "'arguments', 'callee' and 'caller' are restricted function properties and cannot be accessed in this context");
 
-    assert.throws(function() { obj.caller = 'something'; }, TypeError, name + " throws trying to assign to 'caller' property", "Accessing the 'caller' property is restricted in this context");
-    assert.throws(function() { obj.arguments = 'something'; }, TypeError, name + " throws trying to assign to 'arguments' property", "Accessing the 'arguments' property is restricted in this context");
+    assert.throws(function() { obj.caller = 'something'; }, TypeError, name + " throws trying to assign to 'caller' property", "'arguments', 'callee' and 'caller' are restricted function properties and cannot be accessed in this context");
+    assert.throws(function() { obj.arguments = 'something'; }, TypeError, name + " throws trying to assign to 'arguments' property", "'arguments', 'callee' and 'caller' are restricted function properties and cannot be accessed in this context");
 
-    assert.throws(function() { 'use strict'; obj.caller = 'something'; }, TypeError, name + " throws trying to assign to 'caller' property in strict mode", "Accessing the 'caller' property is restricted in this context");
-    assert.throws(function() { 'use strict'; obj.arguments = 'something'; }, TypeError, name + " throws trying to assign to 'arguments' property in strict mode", "Accessing the 'arguments' property is restricted in this context");
+    assert.throws(function() { 'use strict'; obj.caller = 'something'; }, TypeError, name + " throws trying to assign to 'caller' property in strict mode", "'arguments', 'callee' and 'caller' are restricted function properties and cannot be accessed in this context");
+    assert.throws(function() { 'use strict'; obj.arguments = 'something'; }, TypeError, name + " throws trying to assign to 'arguments' property in strict mode", "'arguments', 'callee' and 'caller' are restricted function properties and cannot be accessed in this context");
 
     assert.isTrue(delete obj.arguments, name + " allows deleting own property named 'arguments' if that property doesn't exist");
     assert.doesNotThrow(function() { Object.defineProperty(obj, 'arguments', { value: 123, writable: true, enumerable: true, configurable: true }); }, name + " doesn't have own 'arguments' property");
@@ -151,11 +151,11 @@ var tests = [
             assert.areNotEqual(-1, names.findIndex((e) => { return e === 'arguments'; }), "Function.prototype has 'arguments' own property");
             assert.areNotEqual(-1, names.findIndex((e) => { return e === 'caller'; }), "Function.prototype has 'caller' own property");
 
-            assert.throws(function() { obj.caller; }, TypeError, "Function.prototype throws on access to 'caller' property", "Accessing the 'caller' property is restricted in this context");
-            assert.throws(function() { obj.arguments; }, TypeError, "Function.prototype throws on access to 'arguments' property", "Accessing the 'arguments' property is restricted in this context");
+            assert.throws(function() { obj.caller; }, TypeError, "Function.prototype throws on access to 'caller' property", "'arguments', 'callee' and 'caller' are restricted function properties and cannot be accessed in this context");
+            assert.throws(function() { obj.arguments; }, TypeError, "Function.prototype throws on access to 'arguments' property", "'arguments', 'callee' and 'caller' are restricted function properties and cannot be accessed in this context");
 
-            assert.throws(function() { obj.caller = 'something'; }, TypeError, "Function.prototype throws trying to assign to 'caller' property", "Accessing the 'caller' property is restricted in this context");
-            assert.throws(function() { obj.arguments = 'something'; }, TypeError, "Function.prototype throws trying to assign to 'arguments' property", "Accessing the 'arguments' property is restricted in this context");
+            assert.throws(function() { obj.caller = 'something'; }, TypeError, "Function.prototype throws trying to assign to 'caller' property", "'arguments', 'callee' and 'caller' are restricted function properties and cannot be accessed in this context");
+            assert.throws(function() { obj.arguments = 'something'; }, TypeError, "Function.prototype throws trying to assign to 'arguments' property", "'arguments', 'callee' and 'caller' are restricted function properties and cannot be accessed in this context");
 
             // TODO: These descriptors should have configurable set to true so remaining asserts in this test should actually succeed
             assert.throws(function() { Object.defineProperty(obj, 'arguments', { value: 123 }); }, TypeError, "Function.prototype has 'arguments' property as non-configurable", "Cannot redefine non-configurable property 'arguments'");
@@ -247,7 +247,7 @@ var tests = [
             assert.areEqual('["caller","length","name","prototype"]', JSON.stringify(Object.getOwnPropertyNames(obj).sort()), "Class does not have 'caller' and 'arguments' own properties");
 
             assert.areEqual(42, obj.caller(), "Accessing the 'caller' property is not restricted");
-            assert.throws(function() { obj.arguments; }, TypeError, "Class throws on access to 'arguments' property", "Accessing the 'arguments' property is restricted in this context");
+            assert.throws(function() { obj.arguments; }, TypeError, "Class throws on access to 'arguments' property", "'arguments', 'callee' and 'caller' are restricted function properties and cannot be accessed in this context");
         }
     },
     {
@@ -264,7 +264,7 @@ var tests = [
             assert.areEqual('{"enumerable":false,"configurable":true}', JSON.stringify(Object.getOwnPropertyDescriptor(obj, 'arguments')), "Class has 'arguments' own property");
             assert.areEqual('["arguments","length","name","prototype"]', JSON.stringify(Object.getOwnPropertyNames(obj).sort()), "Class has 'arguments' own property, no 'caller' own property");
 
-            assert.throws(function() { obj.caller; }, TypeError, "Class method throws on access to 'caller' property", "Accessing the 'caller' property is restricted in this context");
+            assert.throws(function() { obj.caller; }, TypeError, "Class method throws on access to 'caller' property", "'arguments', 'callee' and 'caller' are restricted function properties and cannot be accessed in this context");
             assert.areEqual(42, obj.arguments, "Accessing the 'arguments' property is not restricted");
         }
     },
@@ -284,8 +284,8 @@ var tests = [
             assert.areEqual(undefined, JSON.stringify(Object.getOwnPropertyDescriptor(obj, 'arguments')), "Class has 'arguments' own property");
             assert.areEqual('["length","name","prototype"]', JSON.stringify(Object.getOwnPropertyNames(obj).sort()), "Class has 'arguments' own property, no 'caller' own property");
 
-            assert.throws(function() { obj.caller; }, TypeError, "Class method throws on access to 'caller' property", "Accessing the 'caller' property is restricted in this context");
-            assert.throws(function() { obj.arguments; }, TypeError, "Class method throws on access to 'arguments' property", "Accessing the 'arguments' property is restricted in this context");
+            assert.throws(function() { obj.caller; }, TypeError, "Class method throws on access to 'caller' property", "'arguments', 'callee' and 'caller' are restricted function properties and cannot be accessed in this context");
+            assert.throws(function() { obj.arguments; }, TypeError, "Class method throws on access to 'arguments' property", "'arguments', 'callee' and 'caller' are restricted function properties and cannot be accessed in this context");
 
             var a = new A();
 

--- a/test/es6/classes.js
+++ b/test/es6/classes.js
@@ -949,8 +949,8 @@ var tests = [
         name: "Extends expression of a class declaration or expression is strict mode",
         body: function() {
             var BadClass = class extends function() { arguments.caller; } {};
-            assert.throws(function() { Object.getPrototypeOf(BadClass).arguments; }, TypeError, "The extends expression of a class expression should be parsed in strict mode", "Accessing the 'arguments' property is restricted in this context");
-            assert.throws(function() { new BadClass(); }, TypeError, "New'ing a class with a parent constructor that throws in strict mode, should throw", "Accessing the 'caller' property is restricted in this context");
+            assert.throws(function() { Object.getPrototypeOf(BadClass).arguments; }, TypeError, "The extends expression of a class expression should be parsed in strict mode", "'arguments', 'callee' and 'caller' are restricted function properties and cannot be accessed in this context");
+            assert.throws(function() { new BadClass(); }, TypeError, "New'ing a class with a parent constructor that throws in strict mode, should throw", "'arguments', 'callee' and 'caller' are restricted function properties and cannot be accessed in this context");
 
             assert.throws(function() { eval('class WorseClass extends (function foo() { with ({}); return foo; }()) {};'); }, SyntaxError, "The extends expression of a class decl should be parsed in strict mode", "'with' statements are not allowed in strict mode");
         }

--- a/test/strict/05.arguments_sm.baseline
+++ b/test/strict/05.arguments_sm.baseline
@@ -18,7 +18,7 @@ arguments.caller:setter       : function() {
     [native code]
 }
 arguments.caller:value        : undefined
-Exception: Accessing the 'caller' property is restricted in this context
-Exception: Accessing the 'caller' property is restricted in this context
-Exception: Accessing the 'callee' property of an arguments object is not allowed in strict mode
-Exception: Accessing the 'callee' property of an arguments object is not allowed in strict mode
+Exception: 'arguments', 'callee' and 'caller' are restricted function properties and cannot be accessed in this context
+Exception: 'arguments', 'callee' and 'caller' are restricted function properties and cannot be accessed in this context
+Exception: 'arguments', 'callee' and 'caller' are restricted function properties and cannot be accessed in this context
+Exception: 'arguments', 'callee' and 'caller' are restricted function properties and cannot be accessed in this context

--- a/test/strict/22.callerCalleeArguments_sm.baseline
+++ b/test/strict/22.callerCalleeArguments_sm.baseline
@@ -17,40 +17,40 @@ var foo = function(){"use strict";};(function(){"use strict";echo("hasOwnPropert
 hasOwnProperty(arguments): false
 
 (function(){"use strict";arguments.caller;})();
-TypeError: Accessing the 'caller' property is restricted in this context
+TypeError: 'arguments', 'callee' and 'caller' are restricted function properties and cannot be accessed in this context
 
 var foo = function(){"use strict";};(function(){foo.caller;})();
-TypeError: Accessing the 'caller' property is restricted in this context
+TypeError: 'arguments', 'callee' and 'caller' are restricted function properties and cannot be accessed in this context
 
 var foo = function(){"use strict";};(function(){"use strict";foo.caller;})();
-TypeError: Accessing the 'caller' property is restricted in this context
+TypeError: 'arguments', 'callee' and 'caller' are restricted function properties and cannot be accessed in this context
 
 (function(){"use strict";arguments.callee;})();
-TypeError: Accessing the 'callee' property of an arguments object is not allowed in strict mode
+TypeError: 'arguments', 'callee' and 'caller' are restricted function properties and cannot be accessed in this context
 
 var foo = function(){"use strict";};(function(){foo.arguments;})();
-TypeError: Accessing the 'arguments' property is restricted in this context
+TypeError: 'arguments', 'callee' and 'caller' are restricted function properties and cannot be accessed in this context
 
 var foo = function(){"use strict";};(function(){"use strict";foo.arguments;})();
-TypeError: Accessing the 'arguments' property is restricted in this context
+TypeError: 'arguments', 'callee' and 'caller' are restricted function properties and cannot be accessed in this context
 
 (function(){"use strict";arguments.caller = 0;})();
-TypeError: Accessing the 'caller' property is restricted in this context
+TypeError: 'arguments', 'callee' and 'caller' are restricted function properties and cannot be accessed in this context
 
 var foo = function(){"use strict";};(function(){foo.caller = 0;})();
-TypeError: Accessing the 'caller' property is restricted in this context
+TypeError: 'arguments', 'callee' and 'caller' are restricted function properties and cannot be accessed in this context
 
 var foo = function(){"use strict";};(function(){"use strict";foo.caller = 0;})();
-TypeError: Accessing the 'caller' property is restricted in this context
+TypeError: 'arguments', 'callee' and 'caller' are restricted function properties and cannot be accessed in this context
 
 (function(){"use strict";arguments.callee = 0;})();
-TypeError: Accessing the 'callee' property of an arguments object is not allowed in strict mode
+TypeError: 'arguments', 'callee' and 'caller' are restricted function properties and cannot be accessed in this context
 
 var foo = function(){"use strict";};(function(){foo.arguments = 0;})();
-TypeError: Accessing the 'arguments' property is restricted in this context
+TypeError: 'arguments', 'callee' and 'caller' are restricted function properties and cannot be accessed in this context
 
 var foo = function(){"use strict";};(function(){"use strict";foo.arguments = 0;})();
-TypeError: Accessing the 'arguments' property is restricted in this context
+TypeError: 'arguments', 'callee' and 'caller' are restricted function properties and cannot be accessed in this context
 
 (function(){"use strict";Object.defineProperty(arguments, "caller", {value: 0});})();
 TypeError: Cannot redefine non-configurable property 'caller'
@@ -67,8 +67,8 @@ var foo = function(){"use strict";};(function(){Object.defineProperty(foo, "argu
 var foo = function(){"use strict";};(function(){"use strict";Object.defineProperty(foo, "arguments", {value: 0});})();
 
 (function(){"use strict";var descriptor = Object.getOwnPropertyDescriptor(arguments, "caller");if(descriptor.hasOwnProperty("get")) safeCall(descriptor.get);if(descriptor.hasOwnProperty("set")) safeCall(descriptor.set);})();
-TypeError: Accessing the 'caller' property is restricted in this context
-TypeError: Accessing the 'caller' property is restricted in this context
+TypeError: 'arguments', 'callee' and 'caller' are restricted function properties and cannot be accessed in this context
+TypeError: 'arguments', 'callee' and 'caller' are restricted function properties and cannot be accessed in this context
 
 var foo = function(){"use strict";};(function(){var descriptor = Object.getOwnPropertyDescriptor(foo, "caller");if(descriptor.hasOwnProperty("get")) safeCall(descriptor.get);if(descriptor.hasOwnProperty("set")) safeCall(descriptor.set);})();
 TypeError: Unable to get property 'hasOwnProperty' of undefined or null reference
@@ -77,8 +77,8 @@ var foo = function(){"use strict";};(function(){"use strict";var descriptor = Ob
 TypeError: Unable to get property 'hasOwnProperty' of undefined or null reference
 
 (function(){"use strict";var descriptor = Object.getOwnPropertyDescriptor(arguments, "callee");if(descriptor.hasOwnProperty("get")) safeCall(descriptor.get);if(descriptor.hasOwnProperty("set")) safeCall(descriptor.set);})();
-TypeError: Accessing the 'callee' property of an arguments object is not allowed in strict mode
-TypeError: Accessing the 'callee' property of an arguments object is not allowed in strict mode
+TypeError: 'arguments', 'callee' and 'caller' are restricted function properties and cannot be accessed in this context
+TypeError: 'arguments', 'callee' and 'caller' are restricted function properties and cannot be accessed in this context
 
 var foo = function(){"use strict";};(function(){var descriptor = Object.getOwnPropertyDescriptor(foo, "arguments");if(descriptor.hasOwnProperty("get")) safeCall(descriptor.get);if(descriptor.hasOwnProperty("set")) safeCall(descriptor.set);})();
 TypeError: Unable to get property 'hasOwnProperty' of undefined or null reference


### PR DESCRIPTION
Accessing arguments, caller and callee accessor returns different functions differing in error message. Spec says they should be treated as same for == and ===, so we had special handling in interpreter. Handling the same case in JIT is overkill. So I unified all the three functions into one and made the error message same.