### PR TITLE
Fix call syntax after class expression syntax

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -3146,7 +3146,6 @@ LFunction :
     }
 
     case tkCLASS:
-        fAllowCall = FALSE;
         if (m_scriptContext->GetConfig()->IsES6ClassAndExtendsEnabled())
         {
             pnode = ParseClassDecl<buildAST>(FALSE, pNameHint, pHintLength, pShortNameOffset);

--- a/test/es6/classes_bugfixes.js
+++ b/test/es6/classes_bugfixes.js
@@ -7,6 +7,18 @@ WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
 
 var tests = [
   {
+    name: "GitHub ChakraCore #1465 - call syntax is allowed after class expression",
+    body: function () {
+      var s1 = class { }.toString();
+      var s2 = class x { }.toString();
+      var s3 = class x { }.toString(1, 2, 3); // arguments should not affect valid parse
+
+      assert.areEqual("class { }", s1, "Calling toString after a class expression with no name parses and behaves correctly");
+      assert.areEqual("class x { }", s2, "Calling toString after a class expression with a name parses and behaves correctly");
+      assert.areEqual("class x { }", s3, "Calling toString with arguments after a class expression with a name parses and behaves correctly");
+    }
+  },
+  {
     name: "BLUE 540289: AV on deferred parse of first class method",
     body: function () {
       assert.throws(function() { eval("function f() { var o = { \"a\": class { \"b\""); }, SyntaxError);


### PR DESCRIPTION
Call syntax was being disallowed after a call expression.  Appears to be
a mistake, perhaps copy and paste error.  Fix by simply remove line
disallowing call syntax in class expression parsing.

Fixes #1465 