### PR TITLE
Change LICENSE.txt to use (C) instead of (c) to unify with source code headers.

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,7 +1,7 @@
 ChakraCore
 The MIT License (MIT)
 
-Copyright (c) Microsoft Corporation
+Copyright (C) Microsoft Corporation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Also has the benefit of better conforming with Microsoft recommendation and common practice.

https://en.wikipedia.org/wiki/Copyright_symbol#Digital_representation

> Because the © symbol has long been unavailable on typewriters and ASCII-based computer systems, it has been common to approximate this symbol with the characters (C).