### PR TITLE
cross-platform: Fix external build break and add native testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,6 @@ install_manifest.txt
 # additional *nix generated files
 *.a
 *.gch
+*.o
 Makefile
 pal/src/config.h
-

--- a/bin/ch/WScriptJsrt.cpp
+++ b/bin/ch/WScriptJsrt.cpp
@@ -18,19 +18,24 @@
 // otherwise, i.e. android system can be marked as posix? etc..
 #ifdef _WIN32
 #define DEST_PLATFORM_TEXT "win32"
-#elif defined(__APPLE__)
+#else // ! _WIN32
+#if defined(__APPLE__)
+#include <mach-o/dyld.h> // _NSGetExecutablePath
 #ifdef __IOS__
 #define DEST_PLATFORM_TEXT "ios"
-#else
+#else // ! iOS
 #define DEST_PLATFORM_TEXT "darwin"
-#endif
+#endif // iOS ?
 #elif defined(__ANDROID__)
+#include <unistd.h> // readlink
 #define DEST_PLATFORM_TEXT "android"
 #elif defined(__linux__)
+#include <unistd.h> // readlink
 #define DEST_PLATFORM_TEXT "posix"
 #elif defined(__FreeBSD__) || defined(__unix__)
 #define DEST_PLATFORM_TEXT "bsd"
-#endif
+#endif // FreeBSD or unix ?
+#endif // _WIN32 ?
 
 MessageQueue* WScriptJsrt::messageQueue = nullptr;
 std::map<std::string, JsModuleRecord>  WScriptJsrt::moduleRecordMap;
@@ -715,9 +720,84 @@ bool WScriptJsrt::InstallObjectsOnObject(JsValueRef object, const char* name, Js
     return true;
 }
 
+#define SET_BINARY_PATH_ERROR_MESSAGE(path, msg) \
+    str_len = (int) strlen(msg);                 \
+    memcpy(path, msg, (size_t)str_len);          \
+    path[str_len] = char(0)
+
+void GetBinaryLocation(char *path, const uint32_t size)
+{
+    AssertMsg(size >= 512 && path != nullptr, "Min path buffer size 512 and path can not be nullptr");
+    AssertMsg(size < INT_MAX, "Isn't it too big for a path buffer?");
+#ifdef _WIN32
+    LPWSTR wpath = (WCHAR*)malloc(sizeof(WCHAR) * size);
+    int str_len;
+    if (!wpath)
+    {
+        SET_BINARY_PATH_ERROR_MESSAGE(path, "GetBinaryLocation: GetModuleFileName has failed. OutOfMemory!");
+        return;
+    }
+    str_len = GetModuleFileNameW(NULL, wpath, size - 1);
+    if (str_len <= 0)
+    {
+        SET_BINARY_PATH_ERROR_MESSAGE(path, "GetBinaryLocation: GetModuleFileName has failed.");
+        free(wpath);
+        return;
+    }
+
+    str_len = WideCharToMultiByte(CP_UTF8, 0, wpath, str_len, path, size, NULL, NULL);
+    free(wpath);
+
+    if (str_len <= 0)
+    {
+        SET_BINARY_PATH_ERROR_MESSAGE(path, "GetBinaryLocation: GetModuleFileName (WideCharToMultiByte) has failed.");
+        return;
+    }
+
+    if ((uint32_t)str_len > size - 1)
+    {
+        str_len = (int) size - 1;
+    }
+    path[str_len] = char(0);
+#elif defined(__APPLE__)
+    uint32_t path_size = size;
+    char *tmp = nullptr;
+    int str_len;
+    if (_NSGetExecutablePath(path, &path_size))
+    {
+        SET_BINARY_PATH_ERROR_MESSAGE(path, "GetBinaryLocation: _NSGetExecutablePath has failed.");
+        return;
+    }
+
+    tmp = (char*)malloc(size);
+    char *result = realpath(path, tmp);
+    str_len = strlen(result);
+    memcpy(path, result, str_len);
+    free(tmp);
+    path[str_len] = char(0);
+#elif defined(__linux__)
+    int str_len = readlink("/proc/self/exe", path, size - 1);
+    if (str_len <= 0)
+    {
+        SET_BINARY_PATH_ERROR_MESSAGE(path, "GetBinaryLocation: /proc/self/exe has failed.");
+        return;
+    }
+    path[str_len] = char(0);
+#else
+#warning "Implement GetBinaryLocation for this platform"
+#endif
+}
+
 bool WScriptJsrt::Initialize()
 {
     HRESULT hr = S_OK;
+    char CH_BINARY_LOCATION[2048];
+#ifdef CHAKRA_STATIC_LIBRARY
+    const char* LINK_TYPE = "static";
+#else
+    const char* LINK_TYPE = "shared";
+#endif
+
     JsValueRef wscript;
     IfJsrtErrorFail(ChakraRTInterface::JsCreateObject(&wscript), false);
 
@@ -746,8 +826,28 @@ bool WScriptJsrt::Initialize()
     JsPropertyIdRef archProperty;
     IfJsrtErrorFail(ChakraRTInterface::JsGetPropertyIdFromNameUtf8("ARCH", &archProperty), false);
     JsValueRef archValue;
-    IfJsrtErrorFail(ChakraRTInterface::JsPointerToStringUtf8(CPU_ARCH_TEXT, strlen(CPU_ARCH_TEXT), &archValue), false);
+    IfJsrtErrorFail(ChakraRTInterface::JsPointerToStringUtf8(CPU_ARCH_TEXT,strlen(CPU_ARCH_TEXT), &archValue), false);
     IfJsrtErrorFail(ChakraRTInterface::JsSetProperty(platformObject, archProperty, archValue, true), false);
+
+    // Set Link Type [static / shared]
+    JsPropertyIdRef linkProperty;
+    IfJsrtErrorFail(ChakraRTInterface::JsGetPropertyIdFromNameUtf8("LINK_TYPE", &linkProperty), false);
+    JsValueRef linkValue;
+    IfJsrtErrorFail(ChakraRTInterface::JsPointerToStringUtf8(LINK_TYPE,strlen(LINK_TYPE), &linkValue), false);
+    IfJsrtErrorFail(ChakraRTInterface::JsSetProperty(platformObject, linkProperty, linkValue, true), false);
+
+    // Set Binary Location
+    JsValueRef binaryPathValue;
+    GetBinaryLocation(CH_BINARY_LOCATION, sizeof(CH_BINARY_LOCATION));
+
+    JsPropertyIdRef binaryPathProperty;
+    IfJsrtErrorFail(ChakraRTInterface::JsGetPropertyIdFromNameUtf8("BINARY_PATH",
+                                                    &binaryPathProperty), false);
+
+    IfJsrtErrorFail(ChakraRTInterface::JsPointerToStringUtf8(CH_BINARY_LOCATION,
+                          strlen(CH_BINARY_LOCATION), &binaryPathValue), false);
+    IfJsrtErrorFail(ChakraRTInterface::JsSetProperty(platformObject, binaryPathProperty,
+                                                  binaryPathValue, true), false);
 
     // Set destination OS
     JsPropertyIdRef osProperty;

--- a/lib/Jsrt/ChakraCommon.h
+++ b/lib/Jsrt/ChakraCommon.h
@@ -84,6 +84,7 @@ typedef uint32_t UINT32;
 typedef int64_t INT64;
 typedef void* HANDLE;
 typedef unsigned char BYTE;
+typedef BYTE byte;
 typedef UINT32 DWORD;
 #endif
 

--- a/test/native-tests/test-static-native/Platform.js
+++ b/test/native-tests/test-static-native/Platform.js
@@ -1,0 +1,54 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+var isWindows = !WScript.Platform || WScript.Platform.OS == 'win32';
+var path_sep = isWindows ? '\\' : '/';
+var isStaticBuild = WScript.Platform && WScript.Platform.LINK_TYPE == 'static';
+
+if (!isStaticBuild) {
+    // test will be ignored
+    print("# IGNORE_THIS_TEST");
+} else {
+    var platform = WScript.Platform.OS;
+    var binaryPath = WScript.Platform.BINARY_PATH;
+    // discard `ch` from path
+    binaryPath = binaryPath.substr(0, binaryPath.lastIndexOf(path_sep));
+    var makefile =
+"IDIR=" + binaryPath + "/../../lib/Jsrt \n\
+\n\
+LIBRARY_PATH=" + binaryPath + "/lib\n\
+PLATFORM=" + platform + "\n\
+LDIR=$(LIBRARY_PATH)/../pal/src/libChakra.Pal.a \
+  $(LIBRARY_PATH)/Common/Core/libChakra.Common.Core.a \
+  $(LIBRARY_PATH)/Jsrt/libChakra.Jsrt.a \n\
+\n\
+ifeq (darwin, ${PLATFORM})\n\
+\tICU4C_LIBRARY_PATH ?= /usr/local/opt/icu4c\n\
+\tCFLAGS=-lstdc++ -std=c++11 -I$(IDIR)\n\
+\tFORCE_STARTS=-Wl,-force_load,\n\
+\tFORCE_ENDS=\n\
+\tLIBS=-framework CoreFoundation -framework Security -lm -ldl -Wno-c++11-compat-deprecated-writable-strings \
+    -Wno-deprecated-declarations -Wno-unknown-warning-option -o sample.o\n\
+\tLDIR+=$(ICU4C_LIBRARY_PATH)/lib/libicudata.a \
+    $(ICU4C_LIBRARY_PATH)/lib/libicuuc.a \
+    $(ICU4C_LIBRARY_PATH)/lib/libicui18n.a\n\
+else\n\
+\tCFLAGS=-lstdc++ -std=c++0x -I$(IDIR)\n\
+\tFORCE_STARTS=-Wl,--whole-archive\n\
+\tFORCE_ENDS=-Wl,--no-whole-archive\n\
+\tLIBS=-pthread -lm -ldl -licuuc -lunwind-x86_64 -Wno-c++11-compat-deprecated-writable-strings \
+    -Wno-deprecated-declarations -Wno-unknown-warning-option -o sample.o\n\
+endif\n\
+\n\
+testmake:\n\
+\t$(CC) sample.cpp $(CFLAGS) $(FORCE_STARTS) $(LDIR) $(FORCE_ENDS) $(LIBS)\n\
+\n\
+.PHONY: clean\n\
+\n\
+clean:\n\
+\trm sample.o\n";
+
+    print(makefile)
+}

--- a/test/native-tests/test-static-native/sample.cpp
+++ b/test/native-tests/test-static-native/sample.cpp
@@ -1,0 +1,50 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#include "ChakraCore.h"
+#include <string>
+#include <iostream>
+
+using namespace std;
+
+int main()
+{
+    JsRuntimeHandle runtime;
+    JsContextRef context;
+    JsValueRef result;
+    unsigned currentSourceContext = 0;
+
+    const char* script = "(()=>{return \'SUCCESS\';})()";
+
+    // Create a runtime.
+    JsCreateRuntime(JsRuntimeAttributeNone, nullptr, &runtime);
+
+    // Create an execution context.
+    JsCreateContext(runtime, &context);
+
+    // Now set the current execution context.
+    JsSetCurrentContext(context);
+
+    // Run the script.
+    JsRunScriptUtf8(script, currentSourceContext++, "", &result);
+
+    // Convert your script result to String in JavaScript; redundant if your script returns a String
+    JsValueRef resultJSString;
+    JsConvertValueToString(result, &resultJSString);
+
+    // Project script result back to C++.
+    char *resultSTR;
+    size_t stringLength;
+    JsStringToPointerUtf8Copy(resultJSString, &resultSTR, &stringLength);
+
+    printf("Result -> %s \n", resultSTR);
+    JsStringFree(resultSTR);
+
+    // Dispose runtime
+    JsSetCurrentContext(JS_INVALID_REFERENCE);
+    JsDisposeRuntime(runtime);
+
+    return 0;
+}

--- a/test/native-tests/test_native.sh
+++ b/test/native-tests/test_native.sh
@@ -1,0 +1,65 @@
+#-------------------------------------------------------------------------------------------------------
+# Copyright (C) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+#-------------------------------------------------------------------------------------------------------
+
+CH_DIR=$1
+RES=
+CC=0
+CXX=0
+
+FIND_CLANG() {
+    for i in 7 8 9
+    do
+        if [[ -f "/usr/bin/clang-3.${i}" ]]; then
+            CC="/usr/bin/clang-3.${i}"
+            CXX="/usr/bin/clang++-3.${i}"
+        fi
+    done
+    if [[ $CC == 0 ]]; then
+        echo "Error: Couldn't find Clang"
+        exit 1
+    fi
+}
+
+SAFE_RUN() {
+    local SF_RETURN_VALUE=$($1 2>&1)
+
+    if [[ $? != 0 ]]; then
+        >&2 echo $SF_RETURN_VALUE
+        exit 1
+    fi
+    echo $SF_RETURN_VALUE
+}
+
+TEST () {
+    if [[ $RES =~ $1 ]]; then
+        echo "${TEST_PATH} : PASS"
+    else
+        echo "${TEST_PATH} FAILED"
+        echo -e "$RES"
+        exit 1
+    fi
+}
+
+RES=$(c++ --version)
+if [[ ! $RES =~ "Apple LLVM" ]]; then
+    FIND_CLANG
+else
+    CC="cc"
+    CXX="c++"
+fi
+
+# test-static-native
+TEST_PATH="test-static-native"
+SAFE_RUN `cd $TEST_PATH; ${CH_DIR} Platform.js > Makefile`
+RES=$(cd $TEST_PATH; cat Makefile)
+if [[ $RES =~ "# IGNORE_THIS_TEST" ]]; then
+    echo "Ignoring $TEST_PATH"
+else
+    SAFE_RUN `cd $TEST_PATH; make CC=${CC} CXX=${CXX}`
+    RES=$(cd $TEST_PATH; ./sample.o)
+    TEST "SUCCESS"
+    SAFE_RUN `rm -rf ./sample.o`
+fi
+SAFE_RUN `rm -rf Makefile`


### PR DESCRIPTION
We've been keep breaking the native sample project.
Fixing the break and adding a native test to make sure we do not break it again

new WScript.Platform members : 'LINK_TYPE' and 'BINARY_PATH'