### PR TITLE
Fix trashing scratch register (r12) by the call of chkstk in prolog code

### DIFF
--- a/lib/Backend/arm/LowerMD.cpp
+++ b/lib/Backend/arm/LowerMD.cpp
@@ -1557,7 +1557,7 @@ LowererMD::LowerEntryInstr(IR::EntryInstr * entryInstr)
             insertInstr);
     }
 
-    bool trashScratchRegister = false;
+    bool isScratchRegisterThrashed = false;
 
     uint32 probeSize = stackAdjust;
     RegNum localsReg = this->m_func->GetLocalsPointer();
@@ -1568,7 +1568,7 @@ LowererMD::LowerEntryInstr(IR::EntryInstr * entryInstr)
         uint32 localsSize = this->m_func->m_localStackHeight;
         if (localsSize != 0)
         {
-            trashScratchRegister = GenerateStackAllocation(insertInstr, localsSize, localsSize);
+            isScratchRegisterThrashed = GenerateStackAllocation(insertInstr, localsSize, localsSize);
             stackAdjust -= localsSize;
             if (!IsSmallStack(localsSize))
             {
@@ -1604,7 +1604,7 @@ LowererMD::LowerEntryInstr(IR::EntryInstr * entryInstr)
     // stack limit has a buffer of StackOverflowHandlingBufferPages pages and we are okay here
     if (stackAdjust != 0)
     {
-        trashScratchRegister = GenerateStackAllocation(insertInstr, stackAdjust, probeSize);
+        isScratchRegisterThrashed = GenerateStackAllocation(insertInstr, stackAdjust, probeSize);
     }
 
     //As we have already allocated the stack here, we can safely zero out the inlinee argout slot.
@@ -1613,7 +1613,7 @@ LowererMD::LowerEntryInstr(IR::EntryInstr * entryInstr)
     if (this->m_func->GetMaxInlineeArgOutCount())
     {
         // This is done post prolog. so we don't have to emit unwind data.
-        if (r12Opnd == nullptr || trashScratchRegister)
+        if (r12Opnd == nullptr || isScratchRegisterThrashed)
         {
             r12Opnd = r12Opnd ? r12Opnd : IR::RegOpnd::New(nullptr, SCRATCH_REG, TyMachReg, this->m_func);
             // mov r12, 0

--- a/lib/Backend/arm/LowerMD.cpp
+++ b/lib/Backend/arm/LowerMD.cpp
@@ -1052,7 +1052,7 @@ LowererMD::GenerateStackProbe(IR::Instr *insertInstr, bool afterProlog)
 // Emits the code to allocate 'size' amount of space on stack. for values smaller than PAGE_SIZE
 // this will just emit sub rsp,size otherwise calls _chkstk.
 //
-void
+bool
 LowererMD::GenerateStackAllocation(IR::Instr *instr, uint32 allocSize, uint32 probeSize)
 {
     IR::RegOpnd *       spOpnd         = IR::RegOpnd::New(nullptr, GetRegStackPointer(), TyMachReg, this->m_func);
@@ -1064,7 +1064,7 @@ LowererMD::GenerateStackAllocation(IR::Instr *instr, uint32 allocSize, uint32 pr
         IR::IntConstOpnd *  stackSizeOpnd   = IR::IntConstOpnd::New(allocSize, TyMachReg, this->m_func, true);
         IR::Instr * subInstr = IR::Instr::New(Js::OpCode::SUB, spOpnd, spOpnd, stackSizeOpnd, this->m_func);
         instr->InsertBefore(subInstr);
-        return;
+        return false;
     }
 
     //__chkStk is a leaf function and hence alignment is not required.
@@ -1094,6 +1094,9 @@ LowererMD::GenerateStackAllocation(IR::Instr *instr, uint32 allocSize, uint32 pr
 
     IR::Instr * subInstr = IR::Instr::New(Js::OpCode::SUB, spOpnd, spOpnd, r4Opnd, this->m_func);
     instr->InsertBefore(subInstr);
+
+    // return true to imply scratch register is trashed
+    return true;
 }
 
 void
@@ -1554,6 +1557,8 @@ LowererMD::LowerEntryInstr(IR::EntryInstr * entryInstr)
             insertInstr);
     }
 
+    bool trashScratchRegister = false;
+
     uint32 probeSize = stackAdjust;
     RegNum localsReg = this->m_func->GetLocalsPointer();
     if (localsReg != RegSP)
@@ -1563,7 +1568,7 @@ LowererMD::LowerEntryInstr(IR::EntryInstr * entryInstr)
         uint32 localsSize = this->m_func->m_localStackHeight;
         if (localsSize != 0)
         {
-            GenerateStackAllocation(insertInstr, localsSize, localsSize);
+            trashScratchRegister = GenerateStackAllocation(insertInstr, localsSize, localsSize);
             stackAdjust -= localsSize;
             if (!IsSmallStack(localsSize))
             {
@@ -1599,7 +1604,7 @@ LowererMD::LowerEntryInstr(IR::EntryInstr * entryInstr)
     // stack limit has a buffer of StackOverflowHandlingBufferPages pages and we are okay here
     if (stackAdjust != 0)
     {
-        GenerateStackAllocation(insertInstr, stackAdjust, probeSize);
+        trashScratchRegister = GenerateStackAllocation(insertInstr, stackAdjust, probeSize);
     }
 
     //As we have already allocated the stack here, we can safely zero out the inlinee argout slot.
@@ -1608,9 +1613,9 @@ LowererMD::LowerEntryInstr(IR::EntryInstr * entryInstr)
     if (this->m_func->GetMaxInlineeArgOutCount())
     {
         // This is done post prolog. so we don't have to emit unwind data.
-        if (r12Opnd == nullptr)
+        if (r12Opnd == nullptr || trashScratchRegister)
         {
-            r12Opnd = IR::RegOpnd::New(nullptr, SCRATCH_REG, TyMachReg, this->m_func);
+            r12Opnd = r12Opnd ? r12Opnd : IR::RegOpnd::New(nullptr, SCRATCH_REG, TyMachReg, this->m_func);
             // mov r12, 0
             IR::Instr * instrMov = IR::Instr::New(Js::OpCode::MOV, r12Opnd, IR::IntConstOpnd::New(0, TyMachReg, this->m_func), this->m_func);
             insertInstr->InsertBefore(instrMov);

--- a/lib/Backend/arm/LowerMD.h
+++ b/lib/Backend/arm/LowerMD.h
@@ -217,7 +217,7 @@ public:
             IR::Instr *         LowerEHRegionReturn(IR::Instr * insertBeforeInstr, IR::Opnd * targetOpnd);
             void                FinishArgLowering();
             IR::Opnd *          GetOpndForArgSlot(Js::ArgSlot argSlot, bool isDoubleArgument = false);
-            void                GenerateStackAllocation(IR::Instr *instr, uint32 allocSize, uint32 probeSize);
+            bool                GenerateStackAllocation(IR::Instr *instr, uint32 allocSize, uint32 probeSize);
             void                GenerateStackDeallocation(IR::Instr *instr, uint32 allocSize);
             void                GenerateStackProbe(IR::Instr *instr, bool afterProlog);
             IR::Opnd*           GenerateArgOutForStackArgs(IR::Instr* callInstr, IR::Instr* stackArgsInstr);


### PR DESCRIPTION
When function or loopbody needs chkstk, we utilize scratch register (r12) to call it in prolog. At the end of prolog, we assume scratch register still holds zero and use it to initialize CallInfo in InlineedFrame, then we get corrupted InlineedFrame on the stack. See below snnippet in prolog for details:

$L34123:
    (r12).i32       =  MOV            0 (0x0).i32
$L34124:
    [(sp).i32].i32  =  PUSH           0, 1, 2.i32
    [(sp).i32].i32  =  PUSH           11, 14.i32
    (r11).i32       =  MOV            (sp).i32
    [(sp).i32].i32  =  PUSH           4, 5, 6, 7, 8, 9, 10, 12.i32
    [(sp).i32].i32  =  VPUSH          8, 9, 10, 11, 12, 13, 14, 15.i32
    (r4).i32        =  LDIMM          4037 (0xFC5).i32
    (r12).i32       =  LDIMM          CRT_chkstk.u32
    (r4).i32        =  BLX            (r12).i32
    (sp).i32        =  SUB            (sp).i32, (r4).i32
    iarg65535(s94418)<0>.i32 = STR    (r12).i32