### PR TITLE
Fix for cleanup of empty functions in presence of -bailoutoneveryline and related flags

### DIFF
--- a/lib/Backend/BackwardPass.cpp
+++ b/lib/Backend/BackwardPass.cpp
@@ -2756,6 +2756,11 @@ BackwardPass::ProcessBlock(BasicBlock * block)
                     }
                     break;
                 }
+                case Js::OpCode::Throw:
+                case Js::OpCode::EHThrow:
+                case Js::OpCode::InlineThrow:
+                    this->func->SetHasThrow();
+                    break;
             }
         }
 

--- a/lib/Backend/IRBuilder.cpp
+++ b/lib/Backend/IRBuilder.cpp
@@ -1539,8 +1539,6 @@ IRBuilder::BuildReg1(Js::OpCode newOpcode, uint32 offset, Js::RegSlot R0)
 
     case Js::OpCode::Throw:
         {
-            this->m_func->SetHasThrow();
-
             srcOpnd = this->BuildSrcOpnd(srcRegOpnd);
 
             if (this->catchOffsetStack && !this->catchOffsetStack->Empty())

--- a/lib/Backend/amd64/LowererMDArch.cpp
+++ b/lib/Backend/amd64/LowererMDArch.cpp
@@ -1486,7 +1486,14 @@ LowererMDArch::LowerEntryInstr(IR::EntryInstr * entryInstr)
     if (this->m_func->HasArgumentSlot() && (this->m_func->IsStackArgsEnabled() ||
         this->m_func->IsJitInDebugMode() ||
         // disabling apply inlining leads to explicit load from the zero-inited slot
-        this->m_func->GetJnFunction()->IsInlineApplyDisabled()))
+        this->m_func->GetJnFunction()->IsInlineApplyDisabled())
+#ifdef BAILOUT_INJECTION
+        || Js::Configuration::Global.flags.IsEnabled(Js::BailOutFlag)
+        || Js::Configuration::Global.flags.IsEnabled(Js::BailOutAtEveryLineFlag)
+        || Js::Configuration::Global.flags.IsEnabled(Js::BailOutAtEveryByteCodeFlag)
+        || Js::Configuration::Global.flags.IsEnabled(Js::BailOutByteCodeFlag)
+#endif
+        )
     {
         // TODO: Support mov [rbp - n], IMM64
         raxOpnd = IR::RegOpnd::New(nullptr, RegRAX, TyUint32, this->m_func);


### PR DESCRIPTION
Flag -bailoutateveryline injects bailout code at every line. On a bailout, we assert if there is an argument object used in the function body, it should be either zero initialized or valid. We eliminate zero initialization of arg object when stack args is enabled because it is initialized again. But in the presence of bailout injection flag, we bailout much before the argument object is initialized. So in the presence of this flag, we should not eliminate zero initialization.