### PR TITLE
Add a case for NetBSD in LOADLoadLibrary()

### DIFF
--- a/pal/src/loader/module.cpp
+++ b/pal/src/loader/module.cpp
@@ -1595,8 +1595,10 @@ static HMODULE LOADLoadLibrary(LPCSTR shortAsciiName, BOOL fDynamic)
         shortAsciiName = "libc.dylib";
 #elif defined(__FreeBSD__)
         shortAsciiName = FREEBSD_LIBC;
-#else
+#elif defined(LIBC_SO)
         shortAsciiName = LIBC_SO;
+#else
+        shortAsciiName = "libc.so";
 #endif
     }
 


### PR DESCRIPTION
The proper solution for NetBSD is to reuse libc.so as shortAsciiName.

The same solution should be promoted for FreeBSD.