### PR TITLE
Fix incorrect error when calling non-existent symbol property

### DIFF
--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -4024,7 +4024,15 @@ CommonNumber:
 
         if (!hasProperty)
         {
-            JavascriptString* varName = JavascriptConversion::ToString(index, scriptContext);
+            JavascriptString* varName = nullptr;
+            if (indexType == IndexType_PropertyId && propertyRecord != nullptr && propertyRecord->IsSymbol())
+            {
+                varName = JavascriptSymbol::ToString(propertyRecord, scriptContext);
+            }
+            else
+            {
+                varName = JavascriptConversion::ToString(index, scriptContext);
+            }
 
             // ES5 11.2.3 #2: We evaluate the call target but don't throw yet if target member is missing. We need to evaluate argList
             // first (#3). Postpone throwing error to invoke time.

--- a/test/es6/ES6Symbol.js
+++ b/test/es6/ES6Symbol.js
@@ -961,7 +961,17 @@ var tests = [
             assert.areEqual('Symbol()', Symbol(undefined).toString(), 'Symbol(undefined).toString() === "Symbol()"');
             assert.areEqual('Symbol()', Symbol("").toString(), 'Symbol("").toString() === "Symbol()"');
         }
-    }
+    },
+    {
+        name: 'Calling symbol property on object that does not exist should give appropriate error',
+        body: function () {
+            // https://github.com/microsoft/ChakraCore/issues/1409
+            var o = Object.create(null);
+            assert.throws(function () { o[Symbol()](); }, TypeError, "Calling non-existent symbol property with no description fails", "Object doesn't support property or method 'Symbol()'");
+            assert.throws(function () { o[Symbol('foo')](); }, TypeError, "Calling non-existent symbol property with description fails", "Object doesn't support property or method 'Symbol(foo)'");
+            assert.throws(function () { o[Symbol.iterator](); }, TypeError, "Calling non-existent built-in symbol property with description fails", "Object doesn't support property or method 'Symbol(Symbol.iterator)'");
+        }
+    },
 ];
 
 testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });


### PR DESCRIPTION
We threw 'Object does not support ToString' when trying to call a symbol
property on an object when that property didn't exist.  This happened
because we try to do a toString conversion on the index var for the
error message string, but Symbol objects do not support toString via
JavascriptConversion::ToString().

Fix it by special casing symbol properties and directly calling the
static JavascriptSymbol::ToString method to get a useful string.

Fixes #1409
