### PR TITLE
Bug fix in memory profiler

### DIFF
--- a/lib/Common/Core/ProfileMemory.cpp
+++ b/lib/Common/Core/ProfileMemory.cpp
@@ -322,7 +322,7 @@ int MemoryProfiler::CreateArenaUsageSummary(ArenaAllocator * alloc, bool liveOnl
         {
             if (data == nullptr)
             {
-                summaries[i] = nullptr;
+                summaries[j] = nullptr;
                 continue;
             }
             localSummary = AnewStructZ(alloc, ArenaMemoryDataSummary);
@@ -343,7 +343,7 @@ int MemoryProfiler::CreateArenaUsageSummary(ArenaAllocator * alloc, bool liveOnl
         {
             localSummary->arenaCount = localSummary->outstandingCount;
         }
-        summaries[i] = localSummary;
+        summaries[j] = localSummary;
     }
 
     return count;


### PR DESCRIPTION
Noticed that we were never printing summary of individual arenas because
of oversight in index variable used to track summaries.