### PR TITLE
cross-platform: va_end may not be no-op

### DIFF
--- a/lib/Common/Core/Output.cpp
+++ b/lib/Common/Core/Output.cpp
@@ -74,6 +74,7 @@ Output::Trace(Js::Phase phase, const char16 *form, ...)
         va_list argptr;
         va_start(argptr, form);
         retValue += Output::VTrace(_u("%s: "), Js::PhaseNames[static_cast<int>(phase)], form, argptr);
+        va_end(argptr);
     }
 
     return retValue;
@@ -89,6 +90,7 @@ Output::Trace2(Js::Phase phase, const char16 *form, ...)
         va_list argptr;
         va_start(argptr, form);
         retValue += Output::VPrint(form, argptr);
+        va_end(argptr);
     }
 
     return retValue;
@@ -106,6 +108,7 @@ Output::TraceWithPrefix(Js::Phase phase, const char16 prefix[], const char16 *fo
         WCHAR prefixValue[512];
         _snwprintf_s(prefixValue, _countof(prefixValue), _TRUNCATE, _u("%s: %s: "), Js::PhaseNames[static_cast<int>(phase)], prefix);
         retValue += Output::VTrace(_u("%s"), prefixValue, form, argptr);
+        va_end(argptr);
     }
 
     return retValue;
@@ -122,6 +125,7 @@ Output::TraceWithFlush(Js::Phase phase, const char16 *form, ...)
         va_start(argptr, form);
         retValue += Output::VTrace(_u("%s:"), Js::PhaseNames[static_cast<int>(phase)], form, argptr);
         Output::Flush();
+        va_end(argptr);
     }
 
     return retValue;
@@ -138,6 +142,7 @@ Output::TraceWithFlush(Js::Flag flag, const char16 *form, ...)
         va_start(argptr, form);
         retValue += Output::VTrace(_u("[-%s]::"), Js::FlagNames[static_cast<int>(flag)], form, argptr);
         Output::Flush();
+        va_end(argptr);
     }
 
     return retValue;
@@ -214,7 +219,9 @@ Output::TraceStats(Js::Phase phase, const char16 *form, ...)
     {
         va_list argptr;
         va_start(argptr, form);
-        return Output::VPrint(form, argptr);
+        size_t ret_val = Output::VPrint(form, argptr);
+        va_end(argptr);
+        return ret_val;
     }
     return 0;
 }
@@ -235,7 +242,9 @@ Output::Print(const char16 *form, ...)
 {
     va_list argptr;
     va_start(argptr, form);
-    return Output::VPrint(form, argptr);
+    size_t ret_val = Output::VPrint(form, argptr);
+    va_end(argptr);
+    return ret_val;
 }
 
 size_t __cdecl
@@ -244,7 +253,9 @@ Output::Print(int column, const char16 *form, ...)
     Output::SkipToColumn(column);
     va_list argptr;
     va_start(argptr, form);
-    return Output::VPrint(form, argptr);
+    size_t ret_val = Output::VPrint(form, argptr);
+    va_end(argptr);
+    return ret_val;
 }
 
 size_t __cdecl

--- a/lib/Common/Core/Output.h
+++ b/lib/Common/Core/Output.h
@@ -89,6 +89,7 @@ public:
             retValue = Output::Print(_u("%s:"), Js::PhaseNames[static_cast<int>(phase)]);
             retValue += Output::VPrint(form, argptr);
             retValue += Output::Print(_u("%s"), callback());
+            va_end(argptr);
         }
 
         return retValue;

--- a/lib/Parser/DebugWriter.cpp
+++ b/lib/Parser/DebugWriter.cpp
@@ -14,30 +14,28 @@ namespace UnifiedRegex
     {
     }
 
+#define PRINT_DEBUG_WRITER()                                        \
+    va_list argptr;                                                 \
+    va_start(argptr, form);                                         \
+    int len = _vsnwprintf_s(buf, bufLen, _TRUNCATE, form, argptr);  \
+    if (len < 0 || len >= bufLen - 1)                               \
+        Output::Print(_u("<not enough buffer space to format>"));   \
+    else                                                            \
+    {                                                               \
+        if (len > 0)                                                \
+            CheckForNewline();                                      \
+        Output::Print(_u("%s"), buf);                               \
+    }                                                               \
+    va_end(argptr)
+
     void __cdecl DebugWriter::Print(const Char *form, ...)
     {
-        va_list argptr;
-        va_start(argptr, form);
-        int len = _vsnwprintf_s(buf, bufLen, _TRUNCATE, form, argptr);
-        if (len < 0)
-            Output::Print(_u("<not enough buffer space to format>"));
-        else
-        {
-            if (len > 0)
-                CheckForNewline();
-            Output::Print(_u("%s"), buf);
-        }
+        PRINT_DEBUG_WRITER();
     }
 
     void __cdecl DebugWriter::PrintEOL(const Char *form, ...)
     {
-        va_list argptr;
-        va_start(argptr, form);
-        int len = _vsnwprintf_s(buf, bufLen, _TRUNCATE, form, argptr);
-        Assert(len >= 0 && len < bufLen - 1);
-        if (len > 0)
-            CheckForNewline();
-        Output::Print(_u("%s"), buf);
+        PRINT_DEBUG_WRITER();
         EOL();
     }
 


### PR DESCRIPTION
Standard requires a call to va_end due to its undefined behavior.