### PR TITLE
cross platform: Fix file descriptor leak on PAL_IsDebuggerPresent

### DIFF
--- a/pal/src/init/pal.cpp
+++ b/pal/src/init/pal.cpp
@@ -662,6 +662,8 @@ PAL_IsDebuggerPresent()
         }
     }
 
+    close(status_fd);
+
     return debugger_present;
 #elif defined(__APPLE__)
     struct kinfo_proc info = {};


### PR DESCRIPTION
Also submitted a PR to coreclr to fix the same issue there. See https://github.com/dotnet/coreclr/pull/6958
This PR fixes the Regex/BoiHardFail.js on Fedora. See #1334 
Now we have all the tests are passing on Fedora