### PR TITLE
SIMD.js - Extend GVN ExprHash to 64-bits

### DIFF
--- a/lib/Backend/GlobHashTable.h
+++ b/lib/Backend/GlobHashTable.h
@@ -27,8 +27,8 @@ public:
 class Key
 {
 public:
-    static uint Get(Sym *sym) { return static_cast<uint>(sym->m_id); }
-    static uint Get(ExprHash hash) { return static_cast<uint>(hash); }
+    static uint64 Get(Sym *sym) { return static_cast<uint64>(sym->m_id); }
+    static uint64 Get(ExprHash hash) { return static_cast<uint64>(hash); }
 };
 
 #define FOREACH_GLOBHASHTABLE_ENTRY(bucket, hashTable) \
@@ -82,7 +82,7 @@ public:
 
     TElement * FindOrInsertNew(TData value)
     {
-        uint key = Key::Get(value);
+        uint64 key = Key::Get(value);
         uint hash = this->Hash(key);
 
 #if PROFILE_DICTIONARY
@@ -187,11 +187,11 @@ public:
 
     TElement * Get(TData value)
     {
-        uint key = Key::Get(value);
+        uint64 key = Key::Get(value);
         return Get(key);
     }
 
-    TElement * Get(uint key)
+    TElement * Get(uint64 key)
     {
         uint hash = this->Hash(key);
         // Assumes sorted lists
@@ -433,7 +433,7 @@ protected:
         }
     }
 private:
-    uint         Hash(uint key) { return (key % this->tableSize); }
+    uint         Hash(uint64 key) { return ((uint32)key % this->tableSize); }
 
 #if PROFILE_DICTIONARY
     DictionaryStats *stats;

--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -1532,7 +1532,9 @@ GlobOpt::InitBlockData()
     data->symToValueMap = GlobHashTable::New(alloc, 64);
     data->exprToValueMap = ExprHashTable::New(alloc, 64);
     data->liveFields = JitAnew(alloc, BVSparse<JitArenaAllocator>, alloc);
-    data->liveArrayValues = JitAnew(alloc, BVSparse<JitArenaAllocator>, alloc);
+
+    data->liveArrayValues = JitAnew(alloc, BVSparse64, alloc);
+    
     data->isTempSrc = JitAnew(alloc, BVSparse<JitArenaAllocator>, alloc);
     data->liveVarSyms = JitAnew(alloc, BVSparse<JitArenaAllocator>, alloc);
     data->liveInt32Syms = JitAnew(alloc, BVSparse<JitArenaAllocator>, alloc);
@@ -1685,7 +1687,7 @@ void GlobOpt::CloneBlockData(BasicBlock *const toBlock, GlobOptBlockData *const 
     toData->liveFields = JitAnew(alloc, BVSparse<JitArenaAllocator>, alloc);
     toData->liveFields->Copy(fromData->liveFields);
 
-    toData->liveArrayValues = JitAnew(alloc, BVSparse<JitArenaAllocator>, alloc);
+    toData->liveArrayValues = JitAnew(alloc, BVSparse64, alloc);
     toData->liveArrayValues->Copy(fromData->liveArrayValues);
 
     if (fromData->maybeWrittenTypeSyms)

--- a/lib/Backend/GlobOpt.h
+++ b/lib/Backend/GlobOpt.h
@@ -476,6 +476,7 @@ struct ObjectTypePropertyEntry
 };
 
 typedef JsUtil::BaseDictionary<Js::PropertyId, ObjectTypePropertyEntry, JitArenaAllocator> ObjectTypePropertyMap;
+typedef  BVSparse<JitArenaAllocator, BVIndex64> BVSparse64;
 
 class JsTypeValueInfo : public ValueInfo
 {
@@ -773,14 +774,15 @@ public:
     ValueNumber GetSrc2ValueNumber()    { return this->src2Val; }
     ExprAttributes GetExprAttributes()  { return this->attributes; }
     bool        IsValid()               { return this->opcode != 0; }
-
-    operator    uint()                  { return *(uint*)this; }
+    
+    operator    uint64()                  { return *(uint64*)this; }
+    
 
 private:
-    uint32  opcode: 8;
-    uint32  src1Val: 11;
-    uint32  src2Val: 11;
-    uint32  attributes: 2;
+    uint64  opcode: 10;
+    uint64  src1Val: 26;
+    uint64  src2Val: 26;
+    uint64  attributes: 2;
 };
 
 enum class PathDependentRelationship : uint8
@@ -966,7 +968,7 @@ public:
     GlobHashTable *                         symToValueMap;
     ExprHashTable *                         exprToValueMap;
     BVSparse<JitArenaAllocator> *           liveFields;
-    BVSparse<JitArenaAllocator> *           liveArrayValues;
+    BVSparse<JitArenaAllocator, BVIndex64> * liveArrayValues;
     BVSparse<JitArenaAllocator> *           maybeWrittenTypeSyms;
     BVSparse<JitArenaAllocator> *           isTempSrc;
     BVSparse<JitArenaAllocator> *           liveVarSyms;

--- a/lib/Common/DataStructures/BitVector.h
+++ b/lib/Common/DataStructures/BitVector.h
@@ -7,6 +7,7 @@
 
 
 typedef uint             BVIndex;
+typedef uint64           BVIndex64;
 const BVIndex BVInvalidIndex = (uint)-1;
 
 const int               MachBits = 8;

--- a/lib/Common/DataStructures/SparseBitVector.cpp
+++ b/lib/Common/DataStructures/SparseBitVector.cpp
@@ -4,13 +4,15 @@
 //-------------------------------------------------------------------------------------------------------
 #include "CommonDataStructuresPch.h"
 
-BVSparseNode::BVSparseNode(BVIndex beginIndex, BVSparseNode * nextNode) :
+template <typename TBVIndex>
+BVSparseNode<TBVIndex>::BVSparseNode(TBVIndex beginIndex, BVSparseNode<TBVIndex> * nextNode) :
     startIndex(beginIndex),
     data(0),
     next(nextNode)
 {
 }
-void BVSparseNode::init(BVIndex beginIndex, BVSparseNode * nextNode)
+template <typename TBVIndex>
+void BVSparseNode<TBVIndex>::init(TBVIndex beginIndex, BVSparseNode * nextNode)
 {
     this->startIndex = beginIndex;
     this->data = 0;
@@ -18,7 +20,8 @@ void BVSparseNode::init(BVIndex beginIndex, BVSparseNode * nextNode)
 }
 
 #ifdef _WIN32
-bool BVSparseNode::ToString(
+template <typename TBVIndex>
+bool BVSparseNode<TBVIndex>::ToString(
     __out_ecount(strSize) char *const str,
     const size_t strSize,
     size_t *const writtenLengthRef,
@@ -91,4 +94,8 @@ bool BVSparseNode::ToString(
     }
     return true;
 }
+
+template struct BVSparseNode<BVIndex>;
+template struct BVSparseNode<BVIndex64>;
+
 #endif

--- a/lib/Common/DataStructures/SparseBitVector.cpp
+++ b/lib/Common/DataStructures/SparseBitVector.cpp
@@ -4,6 +4,7 @@
 //-------------------------------------------------------------------------------------------------------
 #include "CommonDataStructuresPch.h"
 
+#ifdef _WIN32
 template <typename TBVIndex>
 BVSparseNode<TBVIndex>::BVSparseNode(TBVIndex beginIndex, BVSparseNode<TBVIndex> * nextNode) :
     startIndex(beginIndex),
@@ -19,7 +20,6 @@ void BVSparseNode<TBVIndex>::init(TBVIndex beginIndex, BVSparseNode * nextNode)
     this->next = nextNode;
 }
 
-#ifdef _WIN32
 template <typename TBVIndex>
 bool BVSparseNode<TBVIndex>::ToString(
     __out_ecount(strSize) char *const str,

--- a/lib/Common/DataStructures/SparseBitVector.cpp
+++ b/lib/Common/DataStructures/SparseBitVector.cpp
@@ -4,7 +4,6 @@
 //-------------------------------------------------------------------------------------------------------
 #include "CommonDataStructuresPch.h"
 
-#ifdef _WIN32
 template <typename TBVIndex>
 BVSparseNode<TBVIndex>::BVSparseNode(TBVIndex beginIndex, BVSparseNode<TBVIndex> * nextNode) :
     startIndex(beginIndex),
@@ -20,6 +19,7 @@ void BVSparseNode<TBVIndex>::init(TBVIndex beginIndex, BVSparseNode * nextNode)
     this->next = nextNode;
 }
 
+#ifdef _WIN32
 template <typename TBVIndex>
 bool BVSparseNode<TBVIndex>::ToString(
     __out_ecount(strSize) char *const str,
@@ -95,7 +95,7 @@ bool BVSparseNode<TBVIndex>::ToString(
     return true;
 }
 
+#endif
 template struct BVSparseNode<BVIndex>;
 template struct BVSparseNode<BVIndex64>;
 
-#endif

--- a/lib/Common/DataStructures/UnitBitVector.h
+++ b/lib/Common/DataStructures/UnitBitVector.h
@@ -14,7 +14,6 @@
         _unit.Clear(index); \
         \
 
-
 #define NEXT_BITSET_IN_UNITBV           }}
 
 // Typedef
@@ -87,7 +86,8 @@ public:
 // Implementation
 private:
 
-    static void AssertRange(BVIndex index)
+    template <typename TBVIndex = BVIndex>
+    static void AssertRange(TBVIndex index)
     {
         AssertMsg(index < BitsPerWord, "index out of bound");
     }
@@ -128,9 +128,9 @@ private:
         bits = ((bits >> 4) & _F1_32) + (bits & _F1_32);
         bits += bits >> 8;
         bits += bits >> 16;
-        return BVIndex(bits & 0xff);
+        return (BVIndex)(bits & 0xff);
     }
-
+    
     static BVIndex CountBit(UnitWord64 bits)
     {
 #if DBG
@@ -227,22 +227,27 @@ public:
     //Initialization is through template specialization
     static const LONG ShiftValue;
 
-    static BVIndex Position(BVIndex index)
+    template <typename TBVIndex = BVIndex>
+    static TBVIndex Position(TBVIndex index)
     {
         return index >> ShiftValue;
     }
 
-    static BVIndex Offset(BVIndex index)
+    // offset only needs to be uint32
+    template <typename TBVIndex = BVIndex>
+    static BVIndex Offset(TBVIndex index)
     {
         return index & BitMask;
     }
 
-    static BVIndex Floor(BVIndex index)
+    template <typename TBVIndex = BVIndex>
+    static TBVIndex Floor(TBVIndex index)
     {
         return index & (~BitMask);
     }
 
-    static T GetTopBitsClear(BVIndex len)
+    template <typename TBVIndex = BVIndex>
+    static T GetTopBitsClear(TBVIndex len)
     {
         return ((T)1 << Offset(len)) - 1;
     }
@@ -258,14 +263,11 @@ public:
         this->word |= (T)1 << index;
     }
 
-
     void Clear(BVIndex index)
     {
         AssertRange(index);
         this->word &= ~((T)1 << index);
     }
-
-
 
     void Complement(BVIndex index)
     {
@@ -282,16 +284,19 @@ public:
     {
         return (this->word & unit.word) != 0;
     }
+    
     BOOLEAN TestRange(const BVIndex index, uint length) const
     {
         T mask = ((T)AllOnesMask) >> (BitsPerWord - length) << index;
         return (this->word & mask) == mask;
     }
+    
     void SetRange(const BVIndex index, uint length)
     {
         T mask = ((T)AllOnesMask) >> (BitsPerWord - length) << index;
         this->word |= mask;
     }
+    
     void ClearRange(const BVIndex index, uint length)
     {
         T mask = ((T)AllOnesMask) >> (BitsPerWord - length) << index;
@@ -310,6 +315,7 @@ public:
             return BVInvalidIndex;
         }
     }
+
     BVIndex GetNextBit(BVIndex index) const
     {
         AssertRange(index);

--- a/lib/Common/Memory/ArenaAllocator.cpp
+++ b/lib/Common/Memory/ArenaAllocator.cpp
@@ -14,7 +14,7 @@ const uint Memory::StandAloneFreeListPolicy::MaxEntriesGrowth;
 #endif
 
 // We need this function to be inlined for perf
-template _ALWAYSINLINE BVSparseNode * BVSparse<JitArenaAllocator>::NodeFromIndex(BVIndex i, BVSparseNode *** prevNextFieldOut, bool create);
+template _ALWAYSINLINE BVSparseNode<> * BVSparse<JitArenaAllocator>::NodeFromIndex(BVIndex i, BVSparseNode<> *** prevNextFieldOut, bool create);
 
 ArenaData::ArenaData(PageAllocator * pageAllocator) :
     pageAllocator(pageAllocator),

--- a/lib/Common/Memory/ArenaAllocator.h
+++ b/lib/Common/Memory/ArenaAllocator.h
@@ -444,7 +444,7 @@ class JitArenaAllocator : public ArenaAllocator
     // Throughput improvement in the backend is substantial with this freeList.
 
 private:
-    BVSparseNode *bvFreeList;
+    BVSparseNode<> *bvFreeList;
 
 public:
 
@@ -456,13 +456,13 @@ public:
     char * Alloc(DECLSPEC_GUARD_OVERFLOW size_t requestedBytes)
     {
         // Fast path
-        if (sizeof(BVSparseNode) == requestedBytes)
+        if (sizeof(BVSparseNode<>) == requestedBytes)
         {
             AssertMsg(Math::Align(requestedBytes, ArenaAllocatorBase::ObjectAlignment) == requestedBytes, "Assert for Perf, T should always be aligned");
             // Fast path for BVSparseNode allocation
             if (bvFreeList)
             {
-                BVSparseNode *node = bvFreeList;
+                BVSparseNode<> *node = bvFreeList;
                 bvFreeList = bvFreeList->next;
                 return (char*)node;
             }
@@ -482,11 +482,11 @@ public:
 
     __forceinline void FreeInline(void * buffer, size_t byteSize)
     {
-        if (sizeof(BVSparseNode) == byteSize)
+        if (sizeof(BVSparseNode<>) == byteSize)
         {
             //FastPath
-            ((BVSparseNode*)buffer)->next = bvFreeList;
-            bvFreeList = (BVSparseNode*)buffer;
+            ((BVSparseNode<>*)buffer)->next = bvFreeList;
+            bvFreeList = (BVSparseNode<>*)buffer;
             return;
         }
         return ArenaAllocator::Free(buffer, byteSize);


### PR DESCRIPTION
1. Extended ExprHash to 64-bits. Changed bit widths to opcode:10, VN1: 26, VN2:26, attr:2
2. Templatized BVSparse to handle 64-bit bitIndex. Needed because liveArrayValues uses ExprHash as a bitIndex

(continuing from PR #459)
