### PR TITLE
Fix incorrect identifier recording of lambda parameter

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -2878,14 +2878,22 @@ ParseNodePtr Parser::ParseTerm(BOOL fAllowCall,
             }
         }
 
-        ref = this->PushPidRef(pid);
+        // don't create PidRefStack if this id is followed by '=>' because id will be
+        // reparsed as parameter for lambda function
+        if (m_token.tk != tkDArrow)
+        {
+            ref = this->PushPidRef(pid);
+        }
 
         if (buildAST)
         {
             pnode = CreateNameNode(pid);
             pnode->ichMin = ichMin;
             pnode->ichLim = ichLim;
-            pnode->sxPid.SetSymRef(ref);
+            if (m_token.tk != tkDArrow)
+            {
+                pnode->sxPid.SetSymRef(ref);
+            }
         }
         else
         {

--- a/test/es6/lambda2.js
+++ b/test/es6/lambda2.js
@@ -1,0 +1,14 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+{
+  function foo() {
+  }
+  function bar() {
+      foo => 1
+  }
+}
+
+WScript.Echo("PASS");

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -14,6 +14,12 @@
   </test>
   <test>
     <default>
+      <files>lambda2.js</files>
+      <tags>BugFix</tags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>NumericLiteralTest.js</files>
       <compile-flags>-args summary -endargs</compile-flags>
     </default>


### PR DESCRIPTION
Single paramter of lambda function is tried to be parsed as identifier at first and could be added to PidRefStack of an identifier defined in outer scope. This causes non local reference to outer identifer by accident and leads to incorrect bytecode. (StInnerSlot is generated without NewInnerScope which causes access violation when setting the inner scope).