### PR TITLE
Wasm current memory

### DIFF
--- a/lib/Backend/IRBuilderAsmJs.cpp
+++ b/lib/Backend/IRBuilderAsmJs.cpp
@@ -1921,9 +1921,13 @@ IRBuilderAsmJs::BuildAsmReg1(Js::OpCodeAsmJs newOpcode, uint32 offset, Js::RegSl
     {
         Js::RegSlot dstRegSlot = GetRegSlotFromIntReg(dstReg);
         IR::RegOpnd * dstOpnd = BuildDstOpnd(dstRegSlot, TyInt32);
-        Assume(m_asmFuncInfo->UsesHeapBuffer());
-        IR::Instr* instr = IR::Instr::New(Js::OpCode::ShrU_I4, dstOpnd, BuildSrcOpnd(AsmJsRegSlots::LengthReg, TyUint32),
-            IR::IntConstOpnd::New(16, TyUint8, m_func), m_func);
+        IR::IntConstOpnd* constZero = IR::IntConstOpnd::New(0, TyInt32, m_func);
+        IR::IntConstOpnd* constSixteen = IR::IntConstOpnd::New(16, TyUint8, m_func);
+ 	
+        IR::Instr * instr = m_asmFuncInfo->UsesHeapBuffer() ?
+            IR::Instr::New(Js::OpCode::ShrU_I4, dstOpnd, BuildSrcOpnd(AsmJsRegSlots::LengthReg, TyUint32), constSixteen, m_func) :
+            IR::Instr::New(Js::OpCode::Ld_I4, dstOpnd, constZero, m_func);
+
         AddInstr(instr, offset);
     }
 
@@ -2593,12 +2597,6 @@ IRBuilderAsmJs::BuildInt2(Js::OpCodeAsmJs newOpcode, uint32 offset, Js::RegSlot 
 
     case Js::OpCodeAsmJs::Eqz_Int:
         instr = IR::Instr::New(Js::OpCode::CmEq_I4, dstOpnd, srcOpnd, IR::IntConstOpnd::New(0, TyInt32, m_func), m_func);
-        break;
-
-    case Js::OpCodeAsmJs::CurrentMemory_Int:
-        Assume(m_asmFuncInfo->UsesHeapBuffer()); 
-        instr = IR::Instr::New(Js::OpCode::ShrU_I4, dstOpnd, BuildSrcOpnd(AsmJsRegSlots::LengthReg, TyUint32), 
-            IR::IntConstOpnd::New(16, TyUint8, m_func), m_func);
         break;
 
     default:

--- a/lib/Runtime/ByteCode/OpCodesAsmJs.h
+++ b/lib/Runtime/ByteCode/OpCodesAsmJs.h
@@ -230,6 +230,7 @@ MACRO_EXTEND_WMS( Trunc_Flt                  , Float2          , None           
 MACRO_EXTEND_WMS( Nearest_Db                 , Double2         , None            )
 MACRO_EXTEND_WMS( Nearest_Flt                , Float2          , None            )
 MACRO_EXTEND_WMS( PopCnt_Int                 , Int2            , None            ) 
+MACRO_EXTEND_WMS( CurrentMemory_Int          , AsmReg1         , None            )
 
 #define MACRO_SIMD(opcode, asmjsLayout, opCodeAttrAsmJs, OpCodeAttr, ...) MACRO(opcode, asmjsLayout, opCodeAttrAsmJs)
 #define MACRO_SIMD_WMS(opcode, asmjsLayout, opCodeAttrAsmJs, OpCodeAttr, ...) MACRO_WMS(opcode, asmjsLayout, opCodeAttrAsmJs)

--- a/lib/Runtime/Language/InterpreterHandlerAsmJs.inl
+++ b/lib/Runtime/Language/InterpreterHandlerAsmJs.inl
@@ -180,6 +180,7 @@ EXDEF2    (NOPASMJS          , NopEx        , Empty                             
   EXDEF2_WMS( D1toD1Mem      , Trunc_Db         , Wasm::WasmMath::Trunc<double>                      )
   EXDEF2_WMS( D1toD1Mem      , Nearest_Db       , Wasm::WasmMath::Nearest<double>                    )
   EXDEF2_WMS( I1toI1Mem      , PopCnt_Int       , ::Math::PopCnt32                                   )
+  EXDEF2_WMS( VtoI1Mem       , CurrentMemory_Int   , OP_GetMemorySize                                   )
 
   DEF2_WMS( IP_TARG_ASM      , AsmJsLoopBodyStart, OP_ProfiledLoopBodyStart                      )
 

--- a/lib/Runtime/Language/InterpreterProcessOpCodeAsmJs.h
+++ b/lib/Runtime/Language/InterpreterProcessOpCodeAsmJs.h
@@ -66,7 +66,16 @@
 
 #define PROCESS_CUSTOM_ASMJS(name, func, layout) PROCESS_CUSTOM_ASMJS_COMMON(name, func, layout,)
 
+#define PROCESS_VtoI1Mem_COMMON(name, func, suffix) \
+    case OpCodeAsmJs::name: \
+    { \
+        PROCESS_READ_LAYOUT_ASMJS(name, AsmReg1, suffix); \
+        SetRegRawInt(playout->R0, \
+                func()); \
+        break; \
+    }
 
+#define PROCESS_VtoI1Mem(name, func) PROCESS_VtoI1Mem_COMMON(name, func,)
 
 #define PROCESS_I2toI1Mem_COMMON(name, func, suffix) \
     case OpCodeAsmJs::name: \

--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -7655,6 +7655,12 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
         m_localSimdSlots[localRegisterID] = bValue;
     }
 
+    int InterpreterStackFrame::OP_GetMemorySize()
+    {
+        JavascriptArrayBuffer* arr = *(JavascriptArrayBuffer**)GetNonVarReg(AsmJsFunctionMemory::ArrayBufferRegister);
+        return arr->GetByteLength() >> 16;
+    }
+
     template <class T>
     void InterpreterStackFrame::OP_SimdLdArrGeneric(const unaligned T* playout)
     {

--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -7658,7 +7658,7 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
     int InterpreterStackFrame::OP_GetMemorySize()
     {
         JavascriptArrayBuffer* arr = *(JavascriptArrayBuffer**)GetNonVarReg(AsmJsFunctionMemory::ArrayBufferRegister);
-        return arr->GetByteLength() >> 16;
+        return arr ? arr->GetByteLength() >> 16 : 0;
     }
 
     template <class T>

--- a/lib/Runtime/Language/InterpreterStackFrame.h
+++ b/lib/Runtime/Language/InterpreterStackFrame.h
@@ -177,6 +177,7 @@ namespace Js
         void SetClosureInitDone(bool done) { closureInitDone = done; }
 
         void ValidateRegValue(Var value, bool allowStackVar = false, bool allowStackVarOnDisabledStackNestedFunc = true) const;
+        int OP_GetMemorySize();
         void ValidateSetRegValue(Var value, bool allowStackVar = false, bool allowStackVarOnDisabledStackNestedFunc = true) const;
         template <typename RegSlotType> Var GetReg(RegSlotType localRegisterID) const;
         template <typename RegSlotType> void SetReg(RegSlotType localRegisterID, Var bValue);

--- a/lib/WasmReader/WasmBinaryOpCodes.h
+++ b/lib/WasmReader/WasmBinaryOpCodes.h
@@ -125,8 +125,8 @@ WASM_MEMSTORE_OPCODE(F32StoreMem,     0x35,        F_IF, false)
 WASM_MEMSTORE_OPCODE(F64StoreMem,     0x36,        D_ID, false)
 
 // Memory operator
-WASM_MISC_OPCODE(MemorySize,      0x3b,        I_V, true)
-WASM_MISC_OPCODE(GrowMemory,      0x39,        I_I, true)
+WASM_MISC_OPCODE(CurrentMemory,      0x3b,        I_I, false)
+WASM_MISC_OPCODE(GrowMemory,         0x39,        I_I, true)
 
 // Expressions
 WASM_BINARY_OPCODE(I32Add,            0x40, I_II, Add_Int        , false)

--- a/lib/WasmReader/WasmByteCodeGenerator.cpp
+++ b/lib/WasmReader/WasmByteCodeGenerator.cpp
@@ -395,7 +395,7 @@ WasmBytecodeGenerator::GenerateFunction()
     info->SetFloatConstCount(ReservedRegisterCount);
     info->SetDoubleConstCount(ReservedRegisterCount);
 
-    const uint32 nbConst = 
+    const uint32 nbConst =
         ((info->GetDoubleConstCount() + 1) * WAsmJs::DOUBLE_SLOTS_SPACE)
         + (uint32)((info->GetFloatConstCount() + 1) * WAsmJs::FLOAT_SLOTS_SPACE + 0.5 /*ceil*/)
         + (uint32)((info->GetIntConstCount() + 1) * WAsmJs::INT_SLOTS_SPACE + 0.5/*ceil*/)
@@ -764,10 +764,17 @@ WasmBytecodeGenerator::EmitCall()
         throw WasmCompilationException(_u("Mismatch between call signature and arity"));
     }
 
-    int32 argsBytesLeft = argSize;
-    for (int i = calleeSignature->GetParamCount() - 1; i >= 0; --i)
+    //copy args into a list so they could be generated in the right order (FIFO)
+    JsUtil::List<EmitInfo, ArenaAllocator> argsList(&m_alloc);
+    for (int i = 0; i < (int)calleeSignature->GetParamCount(); i++)
     {
-        EmitInfo info = PopEvalStack();
+        argsList.Add(PopEvalStack());
+    }
+
+    int32 argsBytesLeft = 0;
+    for (int i = calleeSignature->GetParamCount() - 1; i >= 0 ; i--)
+    {
+        EmitInfo info = argsList.Item(i);
         if (calleeSignature->GetParam(i) != info.type)
         {
             throw WasmCompilationException(_u("Call argument does not match formal type"));
@@ -799,15 +806,22 @@ WasmBytecodeGenerator::EmitCall()
         default:
             throw WasmCompilationException(_u("Unknown argument type %u"), info.type);
         }
-        argsBytesLeft -= wasmOp == wbCallImport ? sizeof(Js::Var) : calleeSignature->GetParamSize(i);
+        //argSize
+
         if (argsBytesLeft < 0 || (argsBytesLeft % sizeof(Js::Var)) != 0)
         {
             throw WasmCompilationException(_u("Error while emitting call arguments"));
         }
+        argsBytesLeft += wasmOp == wbCallImport ? sizeof(Js::Var) : calleeSignature->GetParamSize(i);
         Js::RegSlot argLoc = argsBytesLeft / sizeof(Js::Var);
 
         m_writer.AsmReg2(argOp, argLoc, info.location);
-        ReleaseLocation(&info);
+    }
+
+    //registers need to be released from higher ordinals to lower
+    for (int i = 0; i < argsList.Count(); i++)
+    {
+        ReleaseLocation(&(argsList.Item(i)));
     }
 
     // emit call
@@ -1285,7 +1299,6 @@ WasmBytecodeGenerator::GetViewType(WasmOp op)
         throw WasmCompilationException(_u("Could not match typed array name"));
     }
 }
-
 
 void
 WasmBytecodeGenerator::ReleaseLocation(EmitInfo * info)

--- a/lib/WasmReader/WasmByteCodeGenerator.cpp
+++ b/lib/WasmReader/WasmByteCodeGenerator.cpp
@@ -558,6 +558,13 @@ WasmBytecodeGenerator::EmitExpr(WasmOp op)
     case wb##opname: \
         info = EmitUnaryExpr<Js::OpCodeAsmJs::##asmjop, WasmSignature##sig>(); \
         break;
+    case wbCurrentMemory:
+        {
+        Js::RegSlot tempReg = m_i32RegSlots.AcquireTmpRegister();
+        m_writer.AsmReg1(Js::OpCodeAsmJs::CurrentMemory_Int, tempReg);
+        info = EmitInfo(tempReg, WasmTypes::I32);
+        }
+        break;
 #include "WasmBinaryOpCodes.h"
     default:
         throw WasmCompilationException(_u("Unknown expression's op 0x%X"), op);

--- a/test/WasmSpec/baselines/memory_trap.baseline
+++ b/test/WasmSpec/baselines/memory_trap.baseline
@@ -1,5 +1,3 @@
-memory_trap.wast:24: $assert_return_0 unexpectedly threw: Error: Compiling wasm failed: function wasm-function[0]: Operator MemorySize NYI
-memory_trap.wast:25: $assert_return_1 unexpectedly threw: Error: Compiling wasm failed: function wasm-function[0]: Operator MemorySize NYI
 memory_trap.wast:26: $assert_trap_2 failed, runtime trap NYI
 memory_trap.wast:27: $assert_trap_3 failed, runtime trap NYI
 memory_trap.wast:28: $assert_trap_4 failed, runtime trap NYI
@@ -11,4 +9,4 @@ memory_trap.wast:33: $assert_trap_9 failed, runtime trap NYI
 memory_trap.wast:34: $assert_trap_10 failed, runtime trap NYI
 memory_trap.wast:35: $assert_trap_11 failed, runtime trap NYI
 memory_trap.wast:36: $assert_trap_12 failed, runtime trap NYI
-0/13 tests passed.
+2/13 tests passed.


### PR DESCRIPTION
This PR  consists of two commits.
* The first one fixes an issue where wasm seems to violate calling conventions for internal asmjs routines  by providing arguments in the **reverse order** (calls to internal asmjs seems to be the only case when it happens). 
* memory_size + test fixes