### PR TITLE
Fixing a bug with FreeLoopBodyJobManager

### DIFF
--- a/lib/Backend/NativeCodeGenerator.h
+++ b/lib/Backend/NativeCodeGenerator.h
@@ -285,6 +285,7 @@ private:
             else
             {
                 Assert(this->waitingForStackJob);
+                this->waitingForStackJob = false;
                 this->stackJobProcessed = true;
             }
         }


### PR DESCRIPTION
Need to reset FreeLoopBodyJobManager::waitingForStackJob when stack job is processed.