### PR TITLE
fix validation bug with implicit void returns in asm.js

### DIFF
--- a/lib/Runtime/Language/AsmJsByteCodeGenerator.cpp
+++ b/lib/Runtime/Language/AsmJsByteCodeGenerator.cpp
@@ -469,6 +469,12 @@ namespace Js
             varStmts = ParserWrapper::GetBinaryRight(varStmts);
         }
         Assert(!varStmts->CapturesSyms());
+
+        // if last statement isn't return, type must be void
+        if (varStmts->nop != knopReturn)
+        {
+            mFunction->CheckAndSetReturnType(AsmJsRetType::Void);
+        }
         EmitTopLevelStatement(varStmts);
     }
 

--- a/test/AsmJs/return2.baseline
+++ b/test/AsmJs/return2.baseline
@@ -1,0 +1,7 @@
+
+return2.js(10, 3)
+	Asm.js Compilation Error function : AsmModule::changeType
+	Different return type found for function empty
+
+Asm.js compilation failed.
+undefined

--- a/test/AsmJs/return2.js
+++ b/test/AsmJs/return2.js
@@ -1,0 +1,15 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+let asmModule = (function AsmModule(stdlib) {
+  'use asm';
+  function empty() {
+  }
+  function changeType() {
+    return empty()|0;
+  }
+  return { empty:empty };
+})({});
+print(asmModule.empty());

--- a/test/AsmJs/rlexe.xml
+++ b/test/AsmJs/rlexe.xml
@@ -630,6 +630,13 @@
   </test>
   <test>
     <default>
+      <files>return2.js</files>
+      <baseline>return2.baseline</baseline>
+      <compile-flags>-off:deferparse -testtrace:asmjs -simdjs</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>returndouble.js</files>
       <baseline>returndouble.baseline</baseline>
       <compile-flags>-testtrace:asmjs -simdjs -bgjit- -lic:1</compile-flags>


### PR DESCRIPTION
We weren't failing validation in some cases, which led to functional difference where we should print undefined but return 0 instead.