### PR TITLE
Bug fix to not remove GetNewScObject in the loop prepass

### DIFF
--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -4954,7 +4954,7 @@ GlobOpt::OptInstr(IR::Instr *&instr, bool* isInstrRemoved)
         this->currentBlock->RemoveInstr(instr);
         return instrNext;
     }
-    else if (instr->m_opcode == Js::OpCode::GetNewScObject && src1Val->GetValueInfo()->IsPrimitive())
+    else if (instr->m_opcode == Js::OpCode::GetNewScObject && !this->IsLoopPrePass() && src1Val->GetValueInfo()->IsPrimitive())
     {
         // Constructor returned (src1) a primitive value, so fold this into "dst = Ld_A src2", where src2 is the new object that
         // was passed into the constructor as its 'this' parameter


### PR DESCRIPTION
We should wait for the main pass of a loop to make changes to the IR based on value types of operands. In this case GetNewScObject instruction was being removed in the prepass and this led to functional differences from nonative runs.