### PR TITLE
Delete property optimizations

### DIFF
--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -7972,6 +7972,13 @@ namespace Js
                 (*cache) = (*oldCache);
                 // Set the recycler-allocated cache on the (heap-allocated) guard.
                 (*guard)->SetCache(cache);
+
+                uint i = 0;
+                while((i < EQUIVALENT_TYPE_CACHE_SIZE) && (*cache).types[i] != nullptr)
+                {
+                    (*cache).types[i]->SetHasBeenCached();
+                    i++;
+                }
                 cache++;
             }
         }

--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -1209,7 +1209,7 @@ void ThreadContext::GetOrAddPropertyId(JsUtil::CharacterBuffer<WCHAR> const& pro
 const Js::PropertyRecord *
 ThreadContext::GetOrAddPropertyRecordImpl(JsUtil::CharacterBuffer<char16> propertyName, bool bind)
 {
-    // Make sure the recyclers around so that we can take weak references to the property strings
+    // Make sure the recycler is around so that we can take weak references to the property strings
     EnsureRecycler();
 
     const Js::PropertyRecord * propertyRecord;

--- a/lib/Runtime/Debug/MutationBreakpoint.cpp
+++ b/lib/Runtime/Debug/MutationBreakpoint.cpp
@@ -104,6 +104,18 @@ void Js::MutationBreakpoint::HandleDeleteProperty(ScriptContext *scriptContext, 
     }
 }
 
+void Js::MutationBreakpoint::HandleDeleteProperty(ScriptContext *scriptContext, Var instance, Js::JavascriptString *propertyNameString)
+{
+    PropertyRecord const *propertyRecord = nullptr;
+    DynamicObject *obj = DynamicObject::FromVar(instance);
+    
+    if (JavascriptOperators::ShouldTryDeleteProperty(obj, propertyNameString, &propertyRecord))
+    {
+        Assert(propertyRecord);
+        HandleDeleteProperty(scriptContext, instance, propertyRecord->GetPropertyId());
+    }
+}
+
 bool Js::MutationBreakpoint::DeleteProperty(PropertyRecord *pr)
 {
     Assert(pr != nullptr);

--- a/lib/Runtime/Debug/MutationBreakpoint.h
+++ b/lib/Runtime/Debug/MutationBreakpoint.h
@@ -99,6 +99,7 @@ namespace Js
         // Mutation handlers
         static bool HandleSetProperty(ScriptContext *scriptContext, RecyclableObject *object, PropertyId propertyId, Var newValue);
         static void HandleDeleteProperty(ScriptContext *scriptContext, Var instance, PropertyId propertyId);
+        static void HandleDeleteProperty(ScriptContext *scriptContext, Var instance, JavascriptString *propertyNameString);
 
         static const char16 * GetBreakMutationTypeName(MutationType mutationType);
         static const char16 * GetMutationTypeForConditionalEval(MutationType mutationType);

--- a/lib/Runtime/Language/InlineCache.cpp
+++ b/lib/Runtime/Language/InlineCache.cpp
@@ -54,6 +54,12 @@ namespace Js
         u.local.slotIndex = propertyIndex;
         u.local.requiredAuxSlotCapacity = requiredAuxSlotCapacity;
 
+        type->SetHasBeenCached();
+        if (typeWithoutProperty)
+        {
+            typeWithoutProperty->SetHasBeenCached();
+        }
+
         DebugOnly(VerifyRegistrationForInvalidation(this, requestContext, propertyId));
 
 #if DBG_DUMP
@@ -117,6 +123,8 @@ namespace Js
             u.proto.type = TypeWithAuxSlotTag(type);
         }
 
+        prototypeObjectWithProperty->GetType()->SetHasBeenCached();
+
         DebugOnly(VerifyRegistrationForInvalidation(this, requestContext, propertyId));
         Assert(u.proto.isMissing == (uint16)(u.proto.prototypeObject == requestContext->GetLibrary()->GetMissingPropertyHolder()));
 
@@ -179,6 +187,8 @@ namespace Js
         u.accessor.type = isInlineSlot ? type : TypeWithAuxSlotTag(type);
         u.accessor.slotIndex = propertyIndex;
         u.accessor.object = object;
+
+        type->SetHasBeenCached();
 
         DebugOnly(VerifyRegistrationForInvalidation(this, requestContext, propertyId));
 

--- a/lib/Runtime/Language/JavascriptOperators.h
+++ b/lib/Runtime/Language/JavascriptOperators.h
@@ -196,6 +196,8 @@ namespace Js
         static BOOL SetAccessors(RecyclableObject* instance, PropertyId propertyId, Var getter, Var setter, PropertyOperationFlags flags = PropertyOperation_None);
         static BOOL InitProperty(RecyclableObject* instance, PropertyId propertyId, Var newValue, PropertyOperationFlags flags = PropertyOperation_None);
         static BOOL DeleteProperty(RecyclableObject* instance, PropertyId propertyId, PropertyOperationFlags propertyOperationFlags = PropertyOperation_None);
+        static BOOL DeleteProperty(RecyclableObject* instance, JavascriptString *propertyNameString, PropertyOperationFlags propertyOperationFlags = PropertyOperation_None);
+        static bool ShouldTryDeleteProperty(RecyclableObject* instance, JavascriptString *propertyNameString, PropertyRecord const **pPropertyRecord);
         static BOOL DeletePropertyUnscopables(RecyclableObject* instance, PropertyId propertyId, PropertyOperationFlags propertyOperationFlags = PropertyOperation_None);
         template<bool unscopables>
         static BOOL DeleteProperty_Impl(RecyclableObject* instance, PropertyId propertyId, PropertyOperationFlags propertyOperationFlags = PropertyOperation_None);

--- a/lib/Runtime/Language/ModuleNamespace.cpp
+++ b/lib/Runtime/Language/ModuleNamespace.cpp
@@ -231,8 +231,24 @@ namespace Js
         //Assert: IsPropertyKey(P) is true.
         //Let exports be O.[[Exports]].
         //If P is an element of exports, return false.
-        //Return true.        
+        //Return true.
         return !HasProperty(propertyId);
+    }
+
+    BOOL ModuleNamespace::DeleteProperty(JavascriptString *propertyNameString, PropertyOperationFlags flags)
+    {
+        //Assert: IsPropertyKey(P) is true.
+        //Let exports be O.[[Exports]].
+        //If P is an element of exports, return false.
+        //Return true.
+        PropertyRecord const *propertyRecord = nullptr;
+        if (JavascriptOperators::ShouldTryDeleteProperty(this, propertyNameString, &propertyRecord))
+        {
+            Assert(propertyRecord);
+            return DeleteProperty(propertyRecord->GetPropertyId(), flags);
+        }
+
+        return TRUE;
     }
 
     BOOL ModuleNamespace::GetDiagValueString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext)

--- a/lib/Runtime/Language/ModuleNamespace.h
+++ b/lib/Runtime/Language/ModuleNamespace.h
@@ -50,6 +50,7 @@ namespace Js
         virtual BOOL InitProperty(PropertyId propertyId, Var value, PropertyOperationFlags flags = PropertyOperation_None, PropertyValueInfo* info = nullptr) override { Assert(false); return FALSE; }
         virtual BOOL SetPropertyWithAttributes(PropertyId propertyId, Var value, PropertyAttributes attributes, PropertyValueInfo* info, PropertyOperationFlags flags = PropertyOperation_None, SideEffects possibleSideEffects = SideEffects_Any) override { return false; }
         virtual BOOL DeleteProperty(PropertyId propertyId, PropertyOperationFlags flags) override;
+        virtual BOOL DeleteProperty(JavascriptString *propertyNameString, PropertyOperationFlags flags) override;
         virtual BOOL IsFixedProperty(PropertyId propertyId) override { return false; }
         virtual BOOL HasItem(uint32 index) override { return false; }
         virtual BOOL HasOwnItem(uint32 index) override { return false; }

--- a/lib/Runtime/Library/BoundFunction.cpp
+++ b/lib/Runtime/Library/BoundFunction.cpp
@@ -425,6 +425,17 @@ namespace Js
         return JavascriptFunction::DeleteProperty(propertyId, flags);
     }
 
+    BOOL BoundFunction::DeleteProperty(JavascriptString *propertyNameString, PropertyOperationFlags flags)
+    {
+        JsUtil::CharacterBuffer<WCHAR> propertyName(propertyNameString->GetString(), propertyNameString->GetLength());
+        if (BuiltInPropertyRecords::length.Equals(propertyName))
+        {
+            return false;
+        }
+
+        return JavascriptFunction::DeleteProperty(propertyNameString, flags);
+    }
+
     BOOL BoundFunction::IsWritable(PropertyId propertyId)
     {
         if (propertyId == PropertyIds::length)

--- a/lib/Runtime/Library/BoundFunction.h
+++ b/lib/Runtime/Library/BoundFunction.h
@@ -39,6 +39,7 @@ namespace Js
 
         virtual BOOL InitProperty(PropertyId propertyId, Var value, PropertyOperationFlags flags = PropertyOperation_None, PropertyValueInfo* info = NULL) override;
         virtual BOOL DeleteProperty(PropertyId propertyId, PropertyOperationFlags flags) override;
+        virtual BOOL DeleteProperty(JavascriptString *propertyNameString, PropertyOperationFlags flags) override;
 
         virtual BOOL IsWritable(PropertyId propertyId) override;
         virtual BOOL IsConfigurable(PropertyId propertyId) override;

--- a/lib/Runtime/Library/GlobalObject.cpp
+++ b/lib/Runtime/Library/GlobalObject.cpp
@@ -1576,7 +1576,6 @@ LHexError:
         Assert(!(callInfo.Flags & CallFlags_New));
 
         ScriptContext* scriptContext = function->GetScriptContext();
-
         if (!scriptContext->GetConfig()->IsCollectGarbageEnabled()
 #ifdef ENABLE_PROJECTION
             && scriptContext->GetConfig()->GetHostType() != HostType::HostTypeApplication
@@ -2115,6 +2114,18 @@ LHexError:
         }
 
         // Non-existent property
+        return TRUE;
+    }
+
+    BOOL GlobalObject::DeleteProperty(JavascriptString *propertyNameString, PropertyOperationFlags flags)
+    {
+        PropertyRecord const *propertyRecord = nullptr;
+        if (JavascriptOperators::ShouldTryDeleteProperty(this, propertyNameString, &propertyRecord))
+        {
+            Assert(propertyRecord);
+            return DeleteProperty(propertyRecord->GetPropertyId(), flags);
+        }
+
         return TRUE;
     }
 

--- a/lib/Runtime/Library/GlobalObject.h
+++ b/lib/Runtime/Library/GlobalObject.h
@@ -129,6 +129,7 @@ namespace Js
         virtual BOOL SetProperty(PropertyId propertyId, Var value, PropertyOperationFlags flags, PropertyValueInfo* info) override;
         virtual BOOL SetProperty(JavascriptString* propertyNameString, Var value, PropertyOperationFlags flags, PropertyValueInfo* info) override;
         virtual BOOL DeleteProperty(PropertyId propertyId, PropertyOperationFlags flags) override;
+        virtual BOOL DeleteProperty(JavascriptString *propertyNameString, PropertyOperationFlags flags) override;
         virtual BOOL GetPropertyReference(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;
         virtual BOOL HasItem(uint32 index) override;
         virtual BOOL HasOwnItem(uint32 index) override sealed;

--- a/lib/Runtime/Library/JavascriptArray.cpp
+++ b/lib/Runtime/Library/JavascriptArray.cpp
@@ -11602,6 +11602,16 @@ Case0:
         return DynamicObject::DeleteProperty(propertyId, flags);
     }
 
+    BOOL JavascriptArray::DeleteProperty(JavascriptString *propertyNameString, PropertyOperationFlags flags)
+    {
+        JsUtil::CharacterBuffer<WCHAR> propertyName(propertyNameString->GetString(), propertyNameString->GetLength());
+        if (BuiltInPropertyRecords::length.Equals(propertyName))
+        {
+            return false;
+        }
+        return DynamicObject::DeleteProperty(propertyNameString, flags);
+    }
+
     BOOL JavascriptArray::HasProperty(PropertyId propertyId)
     {
         if (propertyId == PropertyIds::length)

--- a/lib/Runtime/Library/JavascriptArray.h
+++ b/lib/Runtime/Library/JavascriptArray.h
@@ -308,6 +308,7 @@ namespace Js
 
         virtual BOOL HasProperty(PropertyId propertyId) override;
         virtual BOOL DeleteProperty(PropertyId propertyId, PropertyOperationFlags flags) override;
+        virtual BOOL DeleteProperty(JavascriptString *propertyNameString, PropertyOperationFlags flags) override;
         virtual BOOL IsEnumerable(PropertyId propertyId) override;
         virtual BOOL IsConfigurable(PropertyId propertyId) override;
         virtual BOOL SetEnumerable(PropertyId propertyId, BOOL value) override;

--- a/lib/Runtime/Library/JavascriptFunction.h
+++ b/lib/Runtime/Library/JavascriptFunction.h
@@ -180,6 +180,7 @@ namespace Js
         virtual uint GetSpecialPropertyCount() const override;
         virtual PropertyId const * GetSpecialPropertyIds() const override;
         virtual BOOL DeleteProperty(PropertyId propertyId, PropertyOperationFlags flags) override;
+        virtual BOOL DeleteProperty(JavascriptString *propertyNameString, PropertyOperationFlags flags) override;
         virtual BOOL GetDiagValueString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext) override;
         virtual BOOL GetDiagTypeString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext) override;
         virtual Var GetTypeOfString(ScriptContext * requestContext) override;

--- a/lib/Runtime/Library/JavascriptGeneratorFunction.cpp
+++ b/lib/Runtime/Library/JavascriptGeneratorFunction.cpp
@@ -428,6 +428,23 @@ namespace Js
         return JavascriptFunction::DeleteProperty(propertyId, flags);
     }
 
+    BOOL JavascriptGeneratorFunction::DeleteProperty(JavascriptString *propertyNameString, PropertyOperationFlags flags)
+    {
+        JsUtil::CharacterBuffer<WCHAR> propertyName(propertyNameString->GetString(), propertyNameString->GetLength());
+        if (BuiltInPropertyRecords::length.Equals(propertyName))
+        {
+            return false;
+        }
+
+        if (BuiltInPropertyRecords::caller.Equals(propertyName) || BuiltInPropertyRecords::arguments.Equals(propertyName))
+        {
+            // JavascriptFunction has special case for caller and arguments; call DynamicObject:: virtual directly to skip that.
+            return DynamicObject::DeleteProperty(propertyNameString, flags);
+        }
+
+        return JavascriptFunction::DeleteProperty(propertyNameString, flags);
+    }
+
     BOOL JavascriptGeneratorFunction::IsWritable(PropertyId propertyId)
     {
         if (propertyId == PropertyIds::length)

--- a/lib/Runtime/Library/JavascriptGeneratorFunction.h
+++ b/lib/Runtime/Library/JavascriptGeneratorFunction.h
@@ -60,6 +60,7 @@ namespace Js
 
         virtual BOOL InitProperty(PropertyId propertyId, Var value, PropertyOperationFlags flags = PropertyOperation_None, PropertyValueInfo* info = NULL) override;
         virtual BOOL DeleteProperty(PropertyId propertyId, PropertyOperationFlags flags) override;
+        virtual BOOL DeleteProperty(JavascriptString *propertyNameString, PropertyOperationFlags flags) override;
 
         virtual BOOL IsWritable(PropertyId propertyId) override;
         virtual BOOL IsEnumerable(PropertyId propertyId) override;

--- a/lib/Runtime/Library/JavascriptProxy.cpp
+++ b/lib/Runtime/Library/JavascriptProxy.cpp
@@ -776,6 +776,18 @@ namespace Js
         return TRUE;
     }
 
+    BOOL JavascriptProxy::DeleteProperty(JavascriptString *propertyNameString, PropertyOperationFlags flags)
+    {
+        PropertyRecord const *propertyRecord = nullptr;
+        if (JavascriptOperators::ShouldTryDeleteProperty(this, propertyNameString, &propertyRecord))
+        {
+            Assert(propertyRecord);
+            return DeleteProperty(propertyRecord->GetPropertyId(), flags);
+        }
+
+        return TRUE;
+    }
+
     BOOL JavascriptProxy::IsFixedProperty(PropertyId propertyId)
     {
         // TODO: can we add support for fixed property? don't see a clear way to invalidate...

--- a/lib/Runtime/Library/JavascriptProxy.h
+++ b/lib/Runtime/Library/JavascriptProxy.h
@@ -93,6 +93,7 @@ namespace Js
         virtual BOOL InitPropertyScoped(PropertyId propertyId, Var value) override;
         virtual BOOL InitFuncScoped(PropertyId propertyId, Var value) override;
         virtual BOOL DeleteProperty(PropertyId propertyId, PropertyOperationFlags flags) override;
+        virtual BOOL DeleteProperty(JavascriptString *propertyNameString, PropertyOperationFlags flags) override;
         virtual BOOL IsFixedProperty(PropertyId propertyId) override;
         virtual BOOL HasItem(uint32 index) override;
         virtual BOOL HasOwnItem(uint32 index) override;

--- a/lib/Runtime/Library/JavascriptRegExpConstructor.cpp
+++ b/lib/Runtime/Library/JavascriptRegExpConstructor.cpp
@@ -388,6 +388,38 @@ namespace Js
         }
     }
 
+    BOOL JavascriptRegExpConstructor::DeleteProperty(JavascriptString *propertyNameString, PropertyOperationFlags flags)
+    {
+        JsUtil::CharacterBuffer<WCHAR> propertyName(propertyNameString->GetString(), propertyNameString->GetLength());
+        if (BuiltInPropertyRecords::input.Equals(propertyName)
+            || BuiltInPropertyRecords::$_.Equals(propertyName)
+            || BuiltInPropertyRecords::length.Equals(propertyName)
+            || BuiltInPropertyRecords::lastMatch.Equals(propertyName)
+            || BuiltInPropertyRecords::$Ampersand.Equals(propertyName)
+            || BuiltInPropertyRecords::lastParen.Equals(propertyName)
+            || BuiltInPropertyRecords::$Plus.Equals(propertyName)
+            || BuiltInPropertyRecords::leftContext.Equals(propertyName)
+            || BuiltInPropertyRecords::$BackTick.Equals(propertyName)
+            || BuiltInPropertyRecords::rightContext.Equals(propertyName)
+            || BuiltInPropertyRecords::$Tick.Equals(propertyName)
+            || BuiltInPropertyRecords::$1.Equals(propertyName)
+            || BuiltInPropertyRecords::$2.Equals(propertyName)
+            || BuiltInPropertyRecords::$3.Equals(propertyName)
+            || BuiltInPropertyRecords::$4.Equals(propertyName)
+            || BuiltInPropertyRecords::$5.Equals(propertyName)
+            || BuiltInPropertyRecords::$6.Equals(propertyName)
+            || BuiltInPropertyRecords::$7.Equals(propertyName)
+            || BuiltInPropertyRecords::$8.Equals(propertyName)
+            || BuiltInPropertyRecords::$9.Equals(propertyName)
+            || BuiltInPropertyRecords::index.Equals(propertyName))
+        {
+            JavascriptError::ThrowCantDeleteIfStrictMode(flags, GetScriptContext(), propertyNameString->GetString());
+            return false;
+        }
+
+        return JavascriptFunction::DeleteProperty(propertyNameString, flags);
+    }
+
     BOOL JavascriptRegExpConstructor::GetDiagValueString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext)
     {
         stringBuilder->AppendCppLiteral(JS_DIAG_VALUE_JavascriptRegExpConstructor);

--- a/lib/Runtime/Library/JavascriptRegExpConstructor.h
+++ b/lib/Runtime/Library/JavascriptRegExpConstructor.h
@@ -32,6 +32,7 @@ namespace Js
         virtual BOOL SetProperty(JavascriptString* propertyNameString, Var value, PropertyOperationFlags flags, PropertyValueInfo* info) override;
         virtual BOOL InitProperty(PropertyId propertyId, Var value, PropertyOperationFlags flags = PropertyOperation_None, PropertyValueInfo* info = NULL) override;
         virtual BOOL DeleteProperty(PropertyId propertyId, PropertyOperationFlags flags) override;
+        virtual BOOL DeleteProperty(JavascriptString *propertyNameString, PropertyOperationFlags flags) override;
         virtual BOOL GetDiagValueString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext) override;
         virtual BOOL GetDiagTypeString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext) override;
         virtual BOOL IsEnumerable(PropertyId propertyId) override;

--- a/lib/Runtime/Library/JavascriptRegularExpression.h
+++ b/lib/Runtime/Library/JavascriptRegularExpression.h
@@ -189,6 +189,7 @@ namespace Js
         virtual BOOL SetProperty(JavascriptString* propertyNameString, Var value, PropertyOperationFlags flags, PropertyValueInfo* info) override;
         virtual BOOL InitProperty(PropertyId propertyId, Var value, PropertyOperationFlags flags = PropertyOperation_None, PropertyValueInfo* info = NULL) override;
         virtual BOOL DeleteProperty(PropertyId propertyId, PropertyOperationFlags flags) override;
+        virtual BOOL DeleteProperty(JavascriptString *propertyNameString, PropertyOperationFlags flags) override;
         virtual DescriptorFlags GetSetter(PropertyId propertyId, Var* setterValue, PropertyValueInfo* info, ScriptContext* requestContext) override;
         virtual DescriptorFlags GetSetter(JavascriptString* propertyNameString, Var* setterValue, PropertyValueInfo* info, ScriptContext* requestContext) override;
         virtual BOOL GetDiagValueString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext) override;

--- a/lib/Runtime/Library/JavascriptString.cpp
+++ b/lib/Runtime/Library/JavascriptString.cpp
@@ -3841,6 +3841,18 @@ case_2:
         return __super::DeleteProperty(propertyId, propertyOperationFlags);
     }
 
+    BOOL JavascriptString::DeleteProperty(JavascriptString *propertyNameString, PropertyOperationFlags propertyOperationFlags)
+    {
+        JsUtil::CharacterBuffer<WCHAR> propertyName(propertyNameString->GetString(), propertyNameString->GetLength());
+        if (BuiltInPropertyRecords::length.Equals(propertyName))
+        {
+            JavascriptError::ThrowCantDeleteIfStrictMode(propertyOperationFlags, this->GetScriptContext(), propertyNameString->GetString());
+
+            return FALSE;
+        }
+        return __super::DeleteProperty(propertyNameString, propertyOperationFlags);
+    }
+
     BOOL JavascriptString::GetDiagValueString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext)
     {
         stringBuilder->Append(_u('"'));

--- a/lib/Runtime/Library/JavascriptString.h
+++ b/lib/Runtime/Library/JavascriptString.h
@@ -124,7 +124,8 @@ namespace Js
         virtual BOOL GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext) override;
         virtual BOOL HasProperty(PropertyId propertyId) override;
         virtual BOOL IsEnumerable(PropertyId propertyId) override;
-        virtual BOOL DeleteProperty(PropertyId propertyId, PropertyOperationFlags propertyOperationFlags)  override;
+        virtual BOOL DeleteProperty(PropertyId propertyId, PropertyOperationFlags propertyOperationFlags) override;
+        virtual BOOL DeleteProperty(JavascriptString *propertyNameString, PropertyOperationFlags propertyOperationFlags) override;
         virtual BOOL GetProperty(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;
         virtual BOOL GetProperty(Var originalInstance, JavascriptString* propertyNameString, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;
         virtual BOOL GetPropertyReference(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;

--- a/lib/Runtime/Library/JavascriptStringObject.cpp
+++ b/lib/Runtime/Library/JavascriptStringObject.cpp
@@ -331,6 +331,18 @@ namespace Js
         return DynamicObject::DeleteProperty(propertyId, flags);
     }
 
+    BOOL JavascriptStringObject::DeleteProperty(JavascriptString *propertyNameString, PropertyOperationFlags propertyOperationFlags)
+    {
+        JsUtil::CharacterBuffer<WCHAR> propertyName(propertyNameString->GetString(), propertyNameString->GetLength());
+        if (BuiltInPropertyRecords::length.Equals(propertyName))
+        {
+            JavascriptError::ThrowCantDeleteIfStrictMode(propertyOperationFlags, this->GetScriptContext(), propertyNameString->GetString());
+
+            return FALSE;
+        }
+        return DynamicObject::DeleteProperty(propertyNameString, propertyOperationFlags);
+    }
+
     BOOL JavascriptStringObject::HasItem(uint32 index)
     {
         if (this->InternalUnwrap()->HasItem(index))

--- a/lib/Runtime/Library/JavascriptStringObject.h
+++ b/lib/Runtime/Library/JavascriptStringObject.h
@@ -47,6 +47,7 @@ namespace Js
         virtual BOOL SetProperty(PropertyId propertyId, Var value, PropertyOperationFlags flags, PropertyValueInfo* info) override;
         virtual BOOL SetProperty(JavascriptString* propertyNameString, Var value, PropertyOperationFlags flags, PropertyValueInfo* info) override;
         virtual BOOL DeleteProperty(PropertyId propertyId, PropertyOperationFlags flags) override;
+        virtual BOOL DeleteProperty(JavascriptString *propertyNameString, PropertyOperationFlags flags) override;
         virtual DescriptorFlags GetSetter(PropertyId propertyId, Var* setterValue, PropertyValueInfo* info, ScriptContext* requestContext) override;
         virtual DescriptorFlags GetSetter(JavascriptString* propertyNameString, Var* setterValue, PropertyValueInfo* info, ScriptContext* requestContext) override;
         virtual BOOL HasItem(uint32 index) override;

--- a/lib/Runtime/Library/JavascriptVariantDate.cpp
+++ b/lib/Runtime/Library/JavascriptVariantDate.cpp
@@ -121,6 +121,12 @@ namespace Js
         JavascriptError::ThrowTypeError(scriptContext, JSERR_Property_VarDate, scriptContext->GetPropertyName(propertyId)->GetBuffer());
     };
 
+    BOOL JavascriptVariantDate::DeleteProperty(JavascriptString *propertyNameString, Js::PropertyOperationFlags flags)
+    {
+        ScriptContext* scriptContext = this->GetScriptContext();
+        JavascriptError::ThrowTypeError(scriptContext, JSERR_Property_VarDate, propertyNameString->GetString());
+    };
+
     BOOL JavascriptVariantDate::GetItemReference(Js::Var originalInstance, uint32 index, Js::Var* value, Js::ScriptContext * scriptContext)
     {
         JavascriptError::ThrowTypeError(scriptContext, JSERR_Property_VarDate, JavascriptNumber::ToStringRadix10(index, scriptContext)->GetSz());

--- a/lib/Runtime/Library/JavascriptVariantDate.h
+++ b/lib/Runtime/Library/JavascriptVariantDate.h
@@ -42,6 +42,7 @@ namespace Js
         virtual BOOL SetProperty(Js::JavascriptString* propertyNameString, Js::Var value, Js::PropertyOperationFlags flags, Js::PropertyValueInfo* info) override;
         virtual BOOL InitProperty(Js::PropertyId propertyId, Js::Var value, PropertyOperationFlags flags = PropertyOperation_None, Js::PropertyValueInfo* info = NULL) override;
         virtual BOOL DeleteProperty(Js::PropertyId propertyId, Js::PropertyOperationFlags flags) override;
+        virtual BOOL DeleteProperty(JavascriptString *propertyNameString, Js::PropertyOperationFlags flags) override;
         virtual BOOL HasItem(uint32 index) override { return false; }
         virtual BOOL GetItemReference(Js::Var originalInstance, uint32 index, Js::Var* value, Js::ScriptContext * scriptContext) override;
         virtual BOOL GetItem(Js::Var originalInstance, uint32 index, Js::Var* value, Js::ScriptContext * scriptContext) override;

--- a/lib/Runtime/Library/ModuleRoot.cpp
+++ b/lib/Runtime/Library/ModuleRoot.cpp
@@ -380,6 +380,18 @@ namespace Js
         return this->GetLibrary()->GetGlobalObject()->GlobalObject::DeleteProperty(propertyId, flags);
     }
 
+    BOOL ModuleRoot::DeleteProperty(JavascriptString *propertyNameString, PropertyOperationFlags flags)
+    {
+        PropertyRecord const *propertyRecord = nullptr;
+        if (JavascriptOperators::ShouldTryDeleteProperty(this, propertyNameString, &propertyRecord))
+        {
+            Assert(propertyRecord);
+            return DeleteProperty(propertyRecord->GetPropertyId(), flags);
+        }
+
+        return TRUE;
+    }
+
     BOOL ModuleRoot::DeleteRootProperty(PropertyId propertyId, PropertyOperationFlags flags)
     {
         int index = GetRootPropertyIndex(propertyId);

--- a/lib/Runtime/Library/ModuleRoot.h
+++ b/lib/Runtime/Library/ModuleRoot.h
@@ -28,6 +28,7 @@ namespace Js
         virtual BOOL GetProperty(Var originalInstance, JavascriptString* propertyNameString, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;
         virtual BOOL GetAccessors(PropertyId propertyId, Var* getter, Var* setter, ScriptContext * requestContext) override;
         virtual BOOL DeleteProperty(PropertyId propertyId, PropertyOperationFlags flags) override;
+        virtual BOOL DeleteProperty(JavascriptString *propertyNameString, PropertyOperationFlags flags) override;
         virtual BOOL SetProperty(PropertyId propertyId, Var value, PropertyOperationFlags flags, PropertyValueInfo* info) override;
         virtual BOOL SetProperty(JavascriptString* propertyNameString, Var value, PropertyOperationFlags flags, PropertyValueInfo* info) override;
         virtual BOOL SetAccessors(PropertyId propertyId, Var getter, Var setter, PropertyOperationFlags flags) override;

--- a/lib/Runtime/Library/ObjectPrototypeObject.cpp
+++ b/lib/Runtime/Library/ObjectPrototypeObject.cpp
@@ -103,6 +103,19 @@ namespace Js
         return result;
     }
 
+    BOOL ObjectPrototypeObject::DeleteProperty(JavascriptString *propertyNameString, PropertyOperationFlags flags)
+    {
+        const BOOL result = __super::DeleteProperty(propertyNameString, flags);
+
+        JsUtil::CharacterBuffer<WCHAR> propertyName(propertyNameString->GetString(), propertyNameString->GetLength());
+        if (result && BuiltInPropertyRecords::__proto__.Equals(propertyName))
+        {
+            this->__proto__Enabled = false;
+        }
+
+        return result;
+    }
+
     void ObjectPrototypeObject::PostDefineOwnProperty__proto__(RecyclableObject* obj)
     {
         if (obj == this)

--- a/lib/Runtime/Library/ObjectPrototypeObject.h
+++ b/lib/Runtime/Library/ObjectPrototypeObject.h
@@ -32,6 +32,7 @@ namespace Js
         static Var Entry__proto__setter(RecyclableObject* function, CallInfo callInfo, ...);
 
         virtual BOOL DeleteProperty(PropertyId propertyId, PropertyOperationFlags flags) override;
+        virtual BOOL DeleteProperty(JavascriptString *propertyNameString, PropertyOperationFlags flags) override;
 
         // Indicates if __proto__ is enabled currently (note that it can be disabled and re-enabled),
         // only useful for diagnostics to decide displaying __proto__ or [prototype].

--- a/lib/Runtime/Library/PropertyString.cpp
+++ b/lib/Runtime/Library/PropertyString.cpp
@@ -64,6 +64,7 @@ namespace Js
             this->GetScriptContext()->SetHasUsedInlineCache(true);
         }
 
+        type->SetHasBeenCached();
         this->propCache->type = type;
         this->propCache->preventdataSlotIndexFalseRef = 1;
         this->propCache->dataSlotIndex = dataSlotIndex;

--- a/lib/Runtime/Library/TypedArray.cpp
+++ b/lib/Runtime/Library/TypedArray.cpp
@@ -654,7 +654,18 @@ namespace Js
             return false;
         }
         return DynamicObject::DeleteProperty(propertyId, flags);
+    }
 
+    BOOL TypedArrayBase::DeleteProperty(JavascriptString *propertyNameString, PropertyOperationFlags flags)
+    {
+        PropertyRecord const *propertyRecord = nullptr;
+        if (JavascriptOperators::ShouldTryDeleteProperty(this, propertyNameString, &propertyRecord))
+        {
+            Assert(propertyRecord);
+            return DeleteProperty(propertyRecord->GetPropertyId(), flags);
+        }
+
+        return TRUE;
     }
 
     BOOL TypedArrayBase::GetPropertyReference(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext)

--- a/lib/Runtime/Library/TypedArray.h
+++ b/lib/Runtime/Library/TypedArray.h
@@ -110,6 +110,7 @@ namespace Js
         virtual BOOL SetProperty(Js::PropertyId propertyId, Js::Var value, Js::PropertyOperationFlags flags, Js::PropertyValueInfo* info) override;
         virtual BOOL SetProperty(Js::JavascriptString* propertyNameString, Js::Var value, Js::PropertyOperationFlags flags, Js::PropertyValueInfo* info) override;
         virtual BOOL DeleteProperty(Js::PropertyId propertyId, Js::PropertyOperationFlags flags) override;
+        virtual BOOL DeleteProperty(JavascriptString *propertyNameString, Js::PropertyOperationFlags flags) override;
         virtual BOOL GetItemReference(Js::Var originalInstance, uint32 index, Js::Var* value, Js::ScriptContext * requestContext) override;
         virtual BOOL GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext) override;
         virtual JavascriptEnumerator * GetIndexEnumerator(EnumeratorFlags flags, ScriptContext * requestContext) override;

--- a/lib/Runtime/Types/DictionaryTypeHandler.h
+++ b/lib/Runtime/Types/DictionaryTypeHandler.h
@@ -92,6 +92,7 @@ namespace Js
         virtual DescriptorFlags GetSetter(DynamicObject* instance, PropertyId propertyId, Var* setterValue, PropertyValueInfo* info, ScriptContext* requestContext) override;
         virtual DescriptorFlags GetSetter(DynamicObject* instance, JavascriptString* propertyNameString, Var* setterValue, PropertyValueInfo* info, ScriptContext* requestContext) override;
         virtual BOOL DeleteProperty(DynamicObject* instance, PropertyId propertyId, PropertyOperationFlags flags) override;
+        virtual BOOL DeleteProperty(DynamicObject* instance, JavascriptString *propertyNameString, PropertyOperationFlags flags) override;
 
         virtual PropertyIndex GetRootPropertyIndex(PropertyRecord const* propertyRecord) override;
 
@@ -198,7 +199,8 @@ namespace Js
     private:
         void CopySingletonInstance(DynamicObject* instance, DynamicTypeHandler* typeHandler);
 
-        void InvalidateFixedField(DynamicObject* instance, PropertyId propertyId, DictionaryPropertyDescriptor<T>* descriptor);
+        template <typename TPropertyKey>
+        void InvalidateFixedField(DynamicObject* instance, TPropertyKey propertyKey, DictionaryPropertyDescriptor<T>* descriptor);
 
     private:
         void SetNumDeletedProperties(const byte n) {}

--- a/lib/Runtime/Types/DynamicObject.h
+++ b/lib/Runtime/Types/DynamicObject.h
@@ -223,6 +223,7 @@ namespace Js
         virtual BOOL InitProperty(PropertyId propertyId, Var value, PropertyOperationFlags flags = PropertyOperation_None, PropertyValueInfo* info = nullptr) override;
         virtual BOOL SetPropertyWithAttributes(PropertyId propertyId, Var value, PropertyAttributes attributes, PropertyValueInfo* info, PropertyOperationFlags flags = PropertyOperation_None, SideEffects possibleSideEffects = SideEffects_Any) override;
         virtual BOOL DeleteProperty(PropertyId propertyId, PropertyOperationFlags flags) override;
+        virtual BOOL DeleteProperty(JavascriptString *propertyNameString, PropertyOperationFlags flags) override;
         virtual BOOL IsFixedProperty(PropertyId propertyId) override;
         virtual BOOL HasItem(uint32 index) override;
         virtual BOOL HasOwnItem(uint32 index) override;

--- a/lib/Runtime/Types/DynamicType.cpp
+++ b/lib/Runtime/Types/DynamicType.cpp
@@ -198,6 +198,11 @@ namespace Js
         return GetTypeHandler()->DeleteProperty(this, propertyId, flags);
     }
 
+    BOOL DynamicObject::DeleteProperty(JavascriptString *propertyNameString, PropertyOperationFlags flags)
+    {
+        return GetTypeHandler()->DeleteProperty(this, propertyNameString, flags);
+    }
+
     BOOL DynamicObject::IsFixedProperty(PropertyId propertyId)
     {
         Assert(!Js::IsInternalPropertyId(propertyId));

--- a/lib/Runtime/Types/RecyclableObject.cpp
+++ b/lib/Runtime/Types/RecyclableObject.cpp
@@ -387,6 +387,11 @@ namespace Js
         return true;
     }
 
+    BOOL RecyclableObject::DeleteProperty(JavascriptString *propertyNameString, PropertyOperationFlags flags)
+    {
+        return true;
+    }
+
     BOOL RecyclableObject::IsFixedProperty(PropertyId propertyId)
     {
         return false;

--- a/lib/Runtime/Types/RecyclableObject.h
+++ b/lib/Runtime/Types/RecyclableObject.h
@@ -267,6 +267,7 @@ namespace Js {
         virtual BOOL InitPropertyScoped(PropertyId propertyId, Var value);
         virtual BOOL InitFuncScoped(PropertyId propertyId, Var value);
         virtual BOOL DeleteProperty(PropertyId propertyId, PropertyOperationFlags flags);
+        virtual BOOL DeleteProperty(JavascriptString *propertyNameString, PropertyOperationFlags flags);
         virtual BOOL IsFixedProperty(PropertyId propertyId);
         virtual BOOL HasItem(uint32 index);
         virtual BOOL HasOwnItem(uint32 index);

--- a/lib/Runtime/Types/SimpleDictionaryTypeHandler.h
+++ b/lib/Runtime/Types/SimpleDictionaryTypeHandler.h
@@ -133,6 +133,7 @@ namespace Js
         virtual DescriptorFlags GetSetter(DynamicObject* instance, PropertyId propertyId, Var* setterValue, PropertyValueInfo* info, ScriptContext* requestContext) override;
         virtual DescriptorFlags GetSetter(DynamicObject* instance, JavascriptString* propertyNameString, Var* setterValue, PropertyValueInfo* info, ScriptContext* requestContext) override;
         virtual BOOL DeleteProperty(DynamicObject* instance, PropertyId propertyId, PropertyOperationFlags flags) override sealed;
+        virtual BOOL DeleteProperty(DynamicObject* instance, JavascriptString* propertyNameString, PropertyOperationFlags flags) override sealed;
 
         virtual PropertyIndex GetRootPropertyIndex(const PropertyRecord* propertyRecord) override;
 

--- a/lib/Runtime/Types/SpreadArgument.h
+++ b/lib/Runtime/Types/SpreadArgument.h
@@ -33,6 +33,7 @@ namespace Js
         virtual BOOL SetProperty(PropertyId propertyId, Var value, PropertyOperationFlags flags, PropertyValueInfo* info) override { AssertAndFailFast(); return FALSE; };
         virtual BOOL GetProperty(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override { AssertAndFailFast(); return FALSE; };
         virtual BOOL DeleteProperty(PropertyId propertyId, PropertyOperationFlags flags) override{ AssertAndFailFast(); return FALSE;};
+        virtual BOOL DeleteProperty(JavascriptString * propertyNameString, PropertyOperationFlags flags) override { AssertAndFailFast(); return FALSE; };
         virtual BOOL GetPropertyReference(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override { AssertAndFailFast(); return None; };
         virtual BOOL SetProperty(JavascriptString* propertyNameString, Var value, PropertyOperationFlags flags, PropertyValueInfo* info) override { AssertAndFailFast(); return FALSE; };
         virtual BOOL GetProperty(Var originalInstance, JavascriptString* propertyNameString, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override { AssertAndFailFast(); return FALSE; };

--- a/lib/Runtime/Types/Type.cpp
+++ b/lib/Runtime/Types/Type.cpp
@@ -50,6 +50,7 @@ namespace Js
             javascriptLibrary->GetScriptContext()->typeCount[typeId]++;
         }
 #endif
+        flags = flags & TypeFlagMask(~TypeFlagMask_HasBeenCached);
         Assert(! (prototype && CrossSite::NeedMarshalVar(prototype, javascriptLibrary->GetScriptContext())));
 
         // If the type property cache is copied over to this new type, then if a property ID caused the type to be changed for

--- a/lib/Runtime/Types/Type.h
+++ b/lib/Runtime/Types/Type.h
@@ -13,7 +13,8 @@ enum TypeFlagMask : uint8
     TypeFlagMask_External                                                          = 0x08,
     TypeFlagMask_SkipsPrototype                                                    = 0x10,
     TypeFlagMask_CanHaveInterceptors                                               = 0x20,
-    TypeFlagMask_JsrtExternal                                                      = 0x40
+    TypeFlagMask_JsrtExternal                                                      = 0x40,
+    TypeFlagMask_HasBeenCached                                                     = 0x80
 };
 ENUM_CLASS_HELPERS(TypeFlagMask, uint8);
 
@@ -64,6 +65,13 @@ namespace Js
         inline BOOL SkipsPrototype() const { return (this->flags & TypeFlagMask_SkipsPrototype) != 0 ; }
         inline BOOL CanHaveInterceptors() const { return (this->flags & TypeFlagMask_CanHaveInterceptors) != 0; }
         inline BOOL IsFalsy() const { return flags & TypeFlagMask_IsFalsy; }
+        inline BOOL HasBeenCached() const { return flags & TypeFlagMask_HasBeenCached; }
+        inline void SetHasBeenCached()
+        {
+            // Once set, this flag should never be reset.
+            flags |= TypeFlagMask_HasBeenCached;
+        };
+
         void SetIsFalsy(const bool truth);
         void SetHasSpecialPrototype(const bool hasSpecialPrototype);
 

--- a/lib/Runtime/Types/TypeHandler.h
+++ b/lib/Runtime/Types/TypeHandler.h
@@ -423,7 +423,7 @@ namespace Js
         virtual DescriptorFlags GetSetter(DynamicObject* instance, PropertyId propertyId, Var* setterValue, PropertyValueInfo* info, ScriptContext* requestContext);
         virtual DescriptorFlags GetSetter(DynamicObject* instance, JavascriptString* propertyNameString, Var* setterValue, PropertyValueInfo* info, ScriptContext* requestContext);
         virtual BOOL DeleteProperty(DynamicObject* instance, PropertyId propertyId, PropertyOperationFlags flags) = 0;
-
+        virtual BOOL DeleteProperty(DynamicObject* instance, JavascriptString* propertyNameString, PropertyOperationFlags flags);
         // ===================================================================================================================
         // Special versions of the various *Property methods that recognize PropertyLetConstGlobal properties.
         // Only used for GlobalObject and ModuleRoot and so only recognized by SimpleDictionary and Dictionary type handlers.
@@ -586,6 +586,10 @@ namespace Js
 
     protected:
         void SetPropertyUpdateSideEffect(DynamicObject* instance, PropertyId propertyId, Var value, SideEffects possibleSideEffects);
+        void SetPropertyUpdateSideEffect(DynamicObject* instance, JsUtil::CharacterBuffer<WCHAR> const& propertyName, Var value, SideEffects possibleSideEffects);
+        PropertyId TMapKey_GetPropertyId(ScriptContext* scriptContext, const PropertyId key);
+        PropertyId TMapKey_GetPropertyId(ScriptContext* scriptContext, const PropertyRecord* key);
+        PropertyId TMapKey_GetPropertyId(ScriptContext* scriptContext, JavascriptString* key);
         bool VerifyIsExtensible(ScriptContext* scriptContext, bool alwaysThrow);
 
         void SetOffsetOfInlineSlots(const uint16 offsetOfInlineSlots) { this->offsetOfInlineSlots = offsetOfInlineSlots; }


### PR DESCRIPTION
A couple of optimizations for deleting a property on an object.

1. When we delete a property, we change the type of the object to invalidate any caches which may have cached its type. We don't have to change the type if it wasn't cached anywhere.

2. For objects that have SimpleDictionary or Dictionary Type Handlers, we have the capability of looking up a property descriptor from the property name itself. However, currently we first lookup the property record for the property in the property map and use the record to look up the descriptor. Getting rid of the intermediate step of property record lookup if we have the property name (delete obj[prop])