### PR TITLE
Stack nested functions in jitted loop bodies

### DIFF
--- a/lib/Backend/Func.cpp
+++ b/lib/Backend/Func.cpp
@@ -147,25 +147,20 @@ Func::Func(JitArenaAllocator *alloc, CodeGenWorkItem* workItem, const Js::Functi
         m_workItem->GetEntryPoint()->SetHasJittedStackClosure();
     }
 
-    if (m_workItem->Type() == JsFunctionType)
+    if (m_workItem->Type() == JsFunctionType &&
+        m_jnFunction->GetDoBackendArgumentsOptimization() && 
+        !m_jnFunction->GetHasTry())
     {
-        if (m_jnFunction->GetDoBackendArgumentsOptimization() && !m_jnFunction->GetHasTry())
-        {
-            // doBackendArgumentsOptimization bit is set when there is no eval inside a function
-            // as determined by the bytecode generator.
-            SetHasStackArgs(true);
-        }
-        if (doStackNestedFunc && m_jnFunction->GetNestedCount() != 0 &&
-            this->GetTopFunc()->m_workItem->Type() != JsLoopBodyWorkItemType) // make sure none of the functions inlined in a jitted loop body allocate nested functions on the stack
-        {
-            Assert(!(this->IsJitInDebugMode() && !m_jnFunction->GetUtf8SourceInfo()->GetIsLibraryCode()));
-            stackNestedFunc = true;
-            this->GetTopFunc()->hasAnyStackNestedFunc = true;
-        }
+        // doBackendArgumentsOptimization bit is set when there is no eval inside a function
+        // as determined by the bytecode generator.
+        SetHasStackArgs(true);
     }
-    else
+    if (doStackNestedFunc && m_jnFunction->GetNestedCount() != 0 &&
+        (this->IsTopFunc() || this->GetTopFunc()->m_workItem->Type() != JsLoopBodyWorkItemType)) // make sure none of the functions inlined in a jitted loop body allocate nested functions on the stack
     {
-        Assert(m_workItem->Type() == JsLoopBodyWorkItemType);
+        Assert(!(this->IsJitInDebugMode() && !m_jnFunction->GetUtf8SourceInfo()->GetIsLibraryCode()));
+        stackNestedFunc = true;
+        this->GetTopFunc()->hasAnyStackNestedFunc = true;
     }
 
     if (m_jnFunction->GetHasOrParentHasArguments() || parentFunc && parentFunc->thisOrParentInlinerHasArguments)

--- a/lib/Backend/IRBuilder.h
+++ b/lib/Backend/IRBuilder.h
@@ -68,6 +68,7 @@ public:
         , catchOffsetStack(nullptr)
         , m_switchAdapter(this)
         , m_switchBuilder(&m_switchAdapter)
+        , m_stackFuncPtrSym(nullptr)
 #if DBG
         , m_callsOnStack(0)
         , m_usedAsTemp(nullptr)
@@ -116,7 +117,7 @@ private:
     BranchReloc *       CreateRelocRecord(IR::BranchInstr * branchInstr, uint32 offset, uint32 targetOffset);
     void                BuildGeneratorPreamble();
     void                BuildConstantLoads();
-    void                BuildImplicitArgIns();
+    void                BuildImplicitArgIns();    
 
 #define LAYOUT_TYPE(layout) \
     void                Build##layout(Js::OpCode newOpcode, uint32 offset);
@@ -287,7 +288,7 @@ private:
     bool                IsLoopBodyReturnIPInstr(IR::Instr * instr) const;
     IR::Opnd *          InsertLoopBodyReturnIPInstr(uint targetOffset, uint offset);
     IR::Instr *         CreateLoopBodyReturnIPInstr(uint targetOffset, uint offset);
-
+    StackSym *          EnsureStackFuncPtrSym();
 
     void                InsertBailOutForDebugger(uint offset, IR::BailOutKind kind, IR::Instr* insertBeforeInstr = nullptr);
     void                InsertBailOnNoProfile(uint offset);
@@ -334,6 +335,7 @@ private:
 #endif
     StackSym *          m_loopBodyRetIPSym;
     StackSym*           m_loopCounterSym;
+    StackSym *          m_stackFuncPtrSym;
     bool                callTreeHasSomeProfileInfo;
 
     // Keep track of how many args we have on the stack whenever

--- a/lib/Backend/Lower.h
+++ b/lib/Backend/Lower.h
@@ -143,7 +143,7 @@ private:
     void            EnsureStackFunctionListStackSym();
     void            EnsureZeroLastStackFunctionNext();
     void            AllocStackClosure();
-    IR::Instr *     GenerateNewStackScFunc(IR::Instr * newScFuncInstr);
+    IR::Instr *     GenerateNewStackScFunc(IR::Instr * newScFuncInstr, IR::RegOpnd ** ppEnvOpnd);
     void            GenerateStackScriptFunctionInit(StackSym * stackSym, Js::FunctionProxyPtrPtr nestedProxy);
     void            GenerateScriptFunctionInit(IR::RegOpnd * regOpnd, IR::Opnd * vtableAddressOpnd,
                         Js::FunctionProxyPtrPtr nestedProxy, IR::Opnd * envOpnd, IR::Instr * insertBeforeInstr, bool isZeroed = false);

--- a/lib/Runtime/ByteCode/OpCodes.h
+++ b/lib/Runtime/ByteCode/OpCodes.h
@@ -522,6 +522,7 @@ MACRO_PROFILED(         NewScFltArray,      Auxiliary,      OpSideEffect|OpTempO
 MACRO_EXTEND_WMS(       InitClass,          Class,          OpSideEffect|OpHasImplicitCall|OpPostOpDbgBailOut)
 
 MACRO_WMS(              NewScFunc,          ElementSlotI1,  OpSideEffect)   // Create new ScriptFunction instance
+MACRO_BACKEND_ONLY(     NewScFuncData,      Reg2,           None)
 MACRO_WMS(              NewScGenFunc,       ElementSlotI1,  OpSideEffect)   // Create new JavascriptGeneratorFunction instance
 MACRO_WMS(              NewStackScFunc,     ElementSlotI1,  OpSideEffect|OpByteCodeOnly)  // Create new ScriptFunction instance
 MACRO_EXTEND_WMS(       NewInnerScFunc,     ElementSlot,    OpSideEffect)   // Create new ScriptFunction instance

--- a/lib/Runtime/Language/InterpreterStackFrame.h
+++ b/lib/Runtime/Language/InterpreterStackFrame.h
@@ -249,6 +249,7 @@ namespace Js
         static uint32 GetOffsetOfArguments() { return offsetof(InterpreterStackFrame, m_arguments); }
         static uint32 GetOffsetOfInParams() { return offsetof(InterpreterStackFrame, m_inParams); }
         static uint32 GetOffsetOfInSlotsCount() { return offsetof(InterpreterStackFrame, m_inSlotsCount); }
+        static uint32 GetOffsetOfStackNestedFunctions() { return offsetof(InterpreterStackFrame, stackNestedFunctions); }
         void PrintStack(const int* const intSrc, const float* const fltSrc, const double* const dblSrc, int intConstCount, int floatConstCount, int doubleConstCount, const char16* state);
 
         static uint32 GetStartLocationOffset() { return offsetof(InterpreterStackFrame, m_reader) + ByteCodeReader::GetStartLocationOffset(); }


### PR DESCRIPTION
Allow jitted loop bodies to make use of stack nested functions if indicated by the byte code. The prologue code will initialize a pointer to the interpreter instance's stack nested functions, and each NewScFunc that allocates on the stack will make use of the pointer. The IRBuilder inserts an instruction that refers to the closure environment and the stack nested function pointer and feeds the NewScFunc instruction, since NewScFunc already takes 2 source operands in some cases.