### PR TITLE
Fix `toFixed` bug #1511

### DIFF
--- a/lib/Common/Common/NumberUtilities_strtod.cpp
+++ b/lib/Common/Common/NumberUtilities_strtod.cpp
@@ -2199,7 +2199,7 @@ static int RoundTo(byte *pbSrc, byte *pbLim, int nDigits, __out_bcount(nDigits+1
     {
         int i = nDigits;
 
-        if( pbSrc[i] >= 5 )
+        if( pbSrc[i] > 5 )
         {
             // Add 1 to the BCD representation.
             for( i = nDigits - 1; i >= 0; i-- )
@@ -2322,7 +2322,7 @@ int Js::NumberUtilities::FDblToStr(double dbl, Js::NumberUtilities::FormatType f
             else
             {
                 //Special case: When negative power of 10 is more than most significant digit.
-                if( rgb[0] >= 5 )
+                if( rgb[0] > 5 )
                 {
                     rgbAdj[0] = 1;
                     wExp10 += 1;

--- a/test/Number/toString.js
+++ b/test/Number/toString.js
@@ -39,6 +39,11 @@ function runTest(numberToTestAsString)
     writeLine("n.toPrecision(5):  " + n.toPrecision(5));
     writeLine("n.toPrecision(20):  " + n.toPrecision(20));
 
+    // test toFixed toString round formatting
+    if ( !(1.25499999999999989342.toFixed(2) + "" == "1.25") ||
+         !(1.255.toFixed(2) + "" == "1.25") ) {
+        throw Error("1.255.toFixed(2) != 1.25 ??");
+    }
     writeLine("");
 }
 


### PR DESCRIPTION
```
print(1.25499999999999989342.toFixed(2));
print(1.255.toFixed(2));
```

Code above should print 1.25 while it was printing 1.26

Fixes https://github.com/Microsoft/ChakraCore/issues/1511