### PR TITLE
Fix memory leak around inlineCache invalidationList

### DIFF
--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -7170,13 +7170,11 @@ namespace Js
             }
         }
 
-        if (!IsScriptContextShutdown)
+        if (unregisteredInlineCacheCount > 0)
         {
+            AssertMsg(!IsScriptContextShutdown, "Unregistration of inlineCache should only be done if this is not scriptContext shutdown.");
             ThreadContext* threadContext = this->m_scriptContext->GetThreadContext();
-            if (unregisteredInlineCacheCount > 0)
-            {
-                threadContext->NotifyInlineCacheBatchUnregistered(unregisteredInlineCacheCount);
-            }
+            threadContext->NotifyInlineCacheBatchUnregistered(unregisteredInlineCacheCount);
         }
 
         while (this->GetPolymorphicInlineCachesHead())

--- a/lib/Runtime/Base/ThreadContext.h
+++ b/lib/Runtime/Base/ThreadContext.h
@@ -718,6 +718,9 @@ private:
 
     uint registeredInlineCacheCount;
     uint unregisteredInlineCacheCount;
+#if DBG
+    uint totalUnregisteredCacheCount;
+#endif
 
     typedef JsUtil::BaseDictionary<Js::Var, Js::IsInstInlineCache*, ArenaAllocator> IsInstInlineCacheListMapByFunction;
     IsInstInlineCacheListMapByFunction isInstInlineCacheByFunction;

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -9374,6 +9374,8 @@ CommonNumber:
             return;
         }
 
+        uint unregisteredInlineCacheCount = 0;
+
         Assert(inlineCaches && size > 0);
 
         // If we're not shutting down (as in closing the script context), we need to remove our inline caches from
@@ -9390,7 +9392,10 @@ CommonNumber:
         {
             for (int i = 0; i < size; i++)
             {
-                inlineCaches[i].RemoveFromInvalidationList();
+                if (inlineCaches[i].RemoveFromInvalidationList())
+                {
+                    unregisteredInlineCacheCount++;
+                }
             }
 
             AllocatorDeleteArray(InlineCacheAllocator, functionBody->GetScriptContext()->GetInlineCacheAllocator(), size, inlineCaches);
@@ -9426,6 +9431,10 @@ CommonNumber:
         prev = next = nullptr;
         inlineCaches = nullptr;
         size = 0;
+        if (unregisteredInlineCacheCount > 0)
+        {
+            functionBody->GetScriptContext()->GetThreadContext()->NotifyInlineCacheBatchUnregistered(unregisteredInlineCacheCount);
+        }
     }
 
     JavascriptString * JavascriptOperators::Concat3(Var aLeft, Var aCenter, Var aRight, ScriptContext * scriptContext)

--- a/lib/Runtime/Library/ScriptFunction.cpp
+++ b/lib/Runtime/Library/ScriptFunction.cpp
@@ -753,8 +753,9 @@ namespace Js
                 }
             }
 
-            if (!isShutdown && unregisteredInlineCacheCount > 0 && !scriptContext->IsClosed())
+            if (unregisteredInlineCacheCount > 0)
             {
+                AssertMsg(!isShutdown && !scriptContext->IsClosed(), "Unregistration of inlineCache should only be done if this is not shutdown or scriptContext closing.");
                 scriptContext->GetThreadContext()->NotifyInlineCacheBatchUnregistered(unregisteredInlineCacheCount);
             }
         }


### PR DESCRIPTION
When inlineCaches are created, they are registered in `threadContext` in an invalidation list and maintained using `registeredInlineCacheCount` in `threadContext`. When these caches are removed from invalidation list, we record that number as well using `unregisteredInlineCacheCount` in `threadContext`. If the ratio of `registeredInlineCacheCount` to `unregisteredInlineCacheCount` is less than 4, we perform compaction of the invalidation list by deleting `unregisteredInlineCacheCount` nodes from the list that doesn't hold inlineCache and return their memory back to the arena. 

* Ideally, `unregisteredInlineCacheCount` should always match no. of inlineCaches that were removed from invalidation list (aka `cachesRemoved`). However today, `cachesRemoved > unregisteredInlineCacheCount` most of the time. Because of this, we were not returning `cachesRemoved - unregisteredInlineCacheCount` nodes of invalidation list back to arena and the memory taken up by these nodes kept piling leading to memory leak. The reason for `cachesRemoved > unregisteredInlineCacheCount` was because there were couple of places where we were not recording the removal of inlineCaches in `unregisteredInlineCacheCount`. Also, we didn't update `unregisteredInlineCacheCount` when we bulk deleted the invalidation list. Fixing these 2 places, the `cachesRemoved == unregisteredInlineCacheCount` holds true.

* `registeredInlineCacheCount` was updated (reduced that count) when we bulk delete entire invalidation lists. However we never updated (again reduced that count) when we performed compaction of invalidation list. Because of this, `registeredInlineCacheCount` kept growing and it became harder and harder to meet the condition of compaction. This leads to nodes having invalid inline cache still holding memory causing leak.

Also did minor code cleanup and added asserts.