### PR TITLE
Create PlatformAgnostic::Event

### DIFF
--- a/lib/Common/Common.h
+++ b/lib/Common/Common.h
@@ -124,7 +124,6 @@ template<> struct IntMath<int64> { using Type = Int64Math; };
 #include "Core/ProfileMemory.h"
 #include "Core/StackBackTrace.h"
 
-#include "Common/Event.h"
 #include "Common/Jobs.h"
 
 #include "Common/vtregistry.h" // Depends on SimpleHashTable.h

--- a/lib/Common/Common/CMakeLists.txt
+++ b/lib/Common/Common/CMakeLists.txt
@@ -2,7 +2,6 @@ add_library (Chakra.Common.Common OBJECT
     CfgLogger.cpp
     CommonCommonPch.cpp
     DateUtilities.cpp
-    Event.cpp
     Int32Math.cpp
     Int64Math.cpp
     Jobs.cpp

--- a/lib/Common/Common/Chakra.Common.Common.vcxproj
+++ b/lib/Common/Common/Chakra.Common.Common.vcxproj
@@ -39,7 +39,6 @@
   <ItemGroup>
     <ClCompile Include="$(MSBuildThisFileDirectory)CfgLogger.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)DateUtilities.cpp" />
-    <ClCompile Include="$(MSBuildThisFileDirectory)Event.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)Int32Math.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)Int64Math.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)Jobs.cpp" />
@@ -60,7 +59,6 @@
     <ClInclude Include="CommonCommonPch.h" />
     <ClInclude Include="CfgLogger.h" />
     <ClInclude Include="DateUtilities.h" />
-    <ClInclude Include="Event.h" />
     <ClInclude Include="GetCurrentFrameId.h" />
     <ClInclude Include="Int32Math.h" />
     <ClInclude Include="Jobs.h" />

--- a/lib/Common/Common/Jobs.cpp
+++ b/lib/Common/Common/Jobs.cpp
@@ -21,7 +21,6 @@
 #include "DataStructures/DoublyLinkedListElement.inl"
 #include "DataStructures/DoublyLinkedList.inl"
 
-#include "Common/Event.h"
 #include "Common/ThreadService.h"
 #include "Common/Jobs.h"
 #include "Common/Jobs.inl"
@@ -703,7 +702,7 @@ namespace JsUtil
         return WaitWithThread(parallelThreadData, parallelThreadData->threadStartedOrClosing, milliseconds);
     }
 
-    bool BackgroundJobProcessor::WaitWithThread(ParallelThreadData *parallelThreadData, const Event &e, const unsigned int milliseconds)
+    bool BackgroundJobProcessor::WaitWithThread(ParallelThreadData *parallelThreadData, const PlatformAgnostic::Event &e, const unsigned int milliseconds)
     {
         const HANDLE handles[] = { e.Handle(), parallelThreadData->threadHandle };
 

--- a/lib/Common/Common/Jobs.h
+++ b/lib/Common/Common/Jobs.h
@@ -202,11 +202,11 @@ namespace JsUtil
     private:
         Job *jobBeingWaitedUpon;
 #if ENABLE_BACKGROUND_JOB_PROCESSOR
-        Event jobBeingWaitedUponProcessed;
+        PlatformAgnostic::Event jobBeingWaitedUponProcessed;
 #endif
         bool isWaitingForQueuedJobs;
 #if ENABLE_BACKGROUND_JOB_PROCESSOR
-        Event queuedJobsProcessed;
+        PlatformAgnostic::Event queuedJobsProcessed;
 #endif
         
     protected:
@@ -415,7 +415,7 @@ namespace JsUtil
         bool isWaitingForJobs;
         bool canDecommit;
         Job *currentJob;
-        Event threadStartedOrClosing; //This is only used for shutdown scenario to indicate background thread is shutting down or starting
+        PlatformAgnostic::Event threadStartedOrClosing; //This is only used for shutdown scenario to indicate background thread is shutting down or starting
         PageAllocator backgroundPageAllocator;
         ArenaAllocator *threadArena;
         BackgroundJobProcessor *processor;
@@ -447,8 +447,8 @@ namespace JsUtil
     {
     private:
         CriticalSection criticalSection;
-        Event jobReady;                 //This is an auto reset event, only one thread wakes up when the event is signaled.
-        Event wakeAllBackgroundThreads; //This is a manual reset event.
+        PlatformAgnostic::Event jobReady;                 //This is an auto reset event, only one thread wakes up when the event is signaled.
+        PlatformAgnostic::Event wakeAllBackgroundThreads; //This is a manual reset event.
         unsigned int numJobs;
         ThreadContextId threadId;
         ThreadService *threadService;
@@ -467,7 +467,7 @@ namespace JsUtil
 
 
     private:
-        bool WaitWithThread(ParallelThreadData *parallelThreadData, const Event &e, const unsigned int milliseconds = INFINITE);
+        bool WaitWithThread(ParallelThreadData *parallelThreadData, const PlatformAgnostic::Event &e, const unsigned int milliseconds = INFINITE);
 
         bool WaitWithThreadForThreadStartedOrClosingEvent(ParallelThreadData *parallelThreadData, const unsigned int milliseconds = INFINITE);
         void WaitWithAllThreadsForThreadStartedOrClosingEvent();

--- a/lib/Common/CommonPal.h
+++ b/lib/Common/CommonPal.h
@@ -648,6 +648,7 @@ namespace PlatformAgnostic
 };
 
 #include "PlatformAgnostic/DateTime.h"
+#include "PlatformAgnostic/Event.h"
 #include "PlatformAgnostic/Numbers.h"
 #include "PlatformAgnostic/SystemInfo.h"
 #include "PlatformAgnostic/Thread.h"

--- a/lib/Common/Memory/Recycler.h
+++ b/lib/Common/Memory/Recycler.h
@@ -577,8 +577,8 @@ private:
 private:
     WorkFunc workFunc;
     Recycler * recycler;
-    HANDLE concurrentWorkReadyEvent;// main thread uses this event to tell concurrent threads that the work is ready
-    HANDLE concurrentWorkDoneEvent;// concurrent threads use this event to tell main thread that the work allocated is done
+    PlatformAgnostic::Event concurrentWorkReadyEvent;// main thread uses this event to tell concurrent threads that the work is ready
+    PlatformAgnostic::Event concurrentWorkDoneEvent;// concurrent threads use this event to tell main thread that the work allocated is done
     HANDLE concurrentThread;
     bool synchronizeOnStartup;
 };
@@ -921,8 +921,8 @@ private:
     byte backgroundRescanCount;             // for ETW events and stats
     byte backgroundFinishMarkCount;
     size_t backgroundRescanRootBytes;
-    HANDLE concurrentWorkReadyEvent; // main thread uses this event to tell concurrent threads that the work is ready
-    HANDLE concurrentWorkDoneEvent; // concurrent threads use this event to tell main thread that the work allocated is done
+    PlatformAgnostic::Event concurrentWorkReadyEvent; // main thread uses this event to tell concurrent threads that the work is ready
+    PlatformAgnostic::Event concurrentWorkDoneEvent; // concurrent threads use this event to tell main thread that the work allocated is done
     HANDLE concurrentThread;
 
     template <uint parallelId>
@@ -963,7 +963,7 @@ private:
     static const uint tickDiffToNextCollect = 300;
 
 #ifdef IDLE_DECOMMIT_ENABLED
-    HANDLE concurrentIdleDecommitEvent;
+    PlatformAgnostic::Event concurrentIdleDecommitEvent;
     DWORD needIdleDecommitSignal;
 #endif
 

--- a/lib/Common/PlatformAgnostic/Event.h
+++ b/lib/Common/PlatformAgnostic/Event.h
@@ -2,50 +2,48 @@
 // Copyright (C) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
-#pragma once
 
-// xplat-todo: Support this on Linux too, currently tied to CreateEvent API
-#ifdef _WIN32
+#ifndef RUNTIME_PLATFORM_AGNOSTIC_COMMON_EVENT
+#define RUNTIME_PLATFORM_AGNOSTIC_COMMON_EVENT
+
+namespace PlatformAgnostic
+{
 class Event
 {
-private:
-    const HANDLE handle;
-
 public:
-    Event(const bool autoReset, const bool signaled = false);
+    typedef HANDLE EventHandle;
 
 private:
+    EventHandle handle;
+
     Event(const Event &) : handle(0)
     {
     }
 
-    Event &operator =(const Event &)
-    {
-        return *this;
-    }
-
 public:
-    ~Event()
-    {
-        CloseHandle(handle);
-    }
+    Event(const bool autoReset, const bool signaled = false);
 
-public:
-    HANDLE Handle() const
+    EventHandle Handle() const
     {
         return handle;
     }
 
-    void Set() const
+    operator bool() const
     {
-        SetEvent(handle);
+        return handle != nullptr;
     }
 
-    void Reset() const
-    {
-        ResetEvent(handle);
-    }
+    ~Event();
+
+    void Close() const;
+
+    void Set() const;
+
+    void Reset() const;
 
     bool Wait(const unsigned int milliseconds = INFINITE) const;
 };
-#endif
+} // namespace PlatformAgnostic
+
+#endif // RUNTIME_PLATFORM_AGNOSTIC_COMMON_EVENT
+

--- a/lib/Runtime/PlatformAgnostic/Chakra.Runtime.PlatformAgnostic.vcxproj
+++ b/lib/Runtime/PlatformAgnostic/Chakra.Runtime.PlatformAgnostic.vcxproj
@@ -43,6 +43,7 @@
     </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)Platform\Windows\DateTime.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)Platform\Windows\DaylightHelper.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)Platform\Windows\Event.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)Platform\Windows\HiResTimer.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)Platform\Windows\UnicodeText.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)Platform\Windows\NumbersUtility.cpp" />

--- a/lib/Runtime/PlatformAgnostic/Platform/CMakeLists.txt
+++ b/lib/Runtime/PlatformAgnostic/Platform/CMakeLists.txt
@@ -4,6 +4,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL Linux)
 set(PL_SOURCE_FILES
   Linux/UnicodeText.ICU.cpp
   Linux/DateTime.cpp
+  Linux/Event.cpp
   Linux/HiResTimer.cpp
   Linux/NumbersUtility.cpp
   Linux/SystemInfo.cpp
@@ -15,6 +16,7 @@ set(PL_SOURCE_FILES
   # xplat-todo: implement them for unix! or carry them into common
   Linux/UnicodeText.ICU.cpp
   Unix/DateTime.cpp
+  Linux/Event.cpp
   Linux/HiResTimer.cpp
   Linux/NumbersUtility.cpp
   Unix/SystemInfo.cpp

--- a/lib/Runtime/PlatformAgnostic/Platform/Linux/Event.cpp
+++ b/lib/Runtime/PlatformAgnostic/Platform/Linux/Event.cpp
@@ -1,0 +1,33 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+#include "Common.h"
+
+namespace PlatformAgnostic
+{
+
+Event::Event(const bool autoReset, const bool signaled) : handle(nullptr)
+{
+}
+
+bool Event::Wait(const unsigned int milliseconds) const
+{
+}
+
+void Event::Close() const
+{
+}
+
+void Event::Set() const
+{
+}
+
+void Event::Reset() const
+{
+}
+
+Event::~Event()
+{
+}
+} // namespace PlatformAgnostic

--- a/lib/Runtime/PlatformAgnostic/Platform/Windows/Event.cpp
+++ b/lib/Runtime/PlatformAgnostic/Platform/Windows/Event.cpp
@@ -2,10 +2,13 @@
 // Copyright (C) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
-#include "CommonCommonPch.h"
-#include "Common/Event.h"
+#include "RuntimePlatformAgnosticPch.h"
+#include "Common.h"
+#include <process.h>
 
-#ifdef _WIN32
+namespace PlatformAgnostic
+{
+
 Event::Event(const bool autoReset, const bool signaled) : handle(CreateEvent(0, !autoReset, signaled, 0))
 {
     if(!handle)
@@ -19,4 +22,26 @@ bool Event::Wait(const unsigned int milliseconds) const
         Js::Throw::FatalInternalError();
     return result == WAIT_OBJECT_0;
 }
-#endif
+
+void Event::Close() const
+{
+//    CloseHandle(handle);
+}
+
+void Event::Set() const
+{
+    SetEvent(handle);
+}
+
+void Event::Reset() const
+{
+    ResetEvent(handle);
+}
+
+Event::~Event()
+{
+    CloseHandle(handle);
+}
+
+} // namespace PlatformAgnostic
+

--- a/pal/inc/pal.h
+++ b/pal/inc/pal.h
@@ -1632,42 +1632,6 @@ ReleaseSemaphore(
 PALIMPORT
 HANDLE
 PALAPI
-CreateEventA(
-         IN LPSECURITY_ATTRIBUTES lpEventAttributes,
-         IN BOOL bManualReset,
-         IN BOOL bInitialState,
-         IN LPCSTR lpName);
-
-PALIMPORT
-HANDLE
-PALAPI
-CreateEventW(
-         IN LPSECURITY_ATTRIBUTES lpEventAttributes,
-         IN BOOL bManualReset,
-         IN BOOL bInitialState,
-         IN LPCWSTR lpName);
-
-#ifdef UNICODE
-#define CreateEvent CreateEventW
-#else
-#define CreateEvent CreateEventA
-#endif
-
-PALIMPORT
-BOOL
-PALAPI
-SetEvent(
-     IN HANDLE hEvent);
-
-PALIMPORT
-BOOL
-PALAPI
-ResetEvent(
-       IN HANDLE hEvent);
-
-PALIMPORT
-HANDLE
-PALAPI
 OpenEventW(
        IN DWORD dwDesiredAccess,
        IN BOOL bInheritHandle,


### PR DESCRIPTION
Largely based on the existig lib/Common/Common/Event.\* class, but
moved to PlatformAgnostic for a future Linux/Unix version. Changed
Jobs and Recycler to use the new API, and took the opportunity to do
some slight cleanups (e.g. avoid the constant checking of event !=
nullptr, etc.).

Remove the Event API declarations from PAL, since they should be
unused now and were unimplemented anyway.
