### PR TITLE
Bug fix when proxy is from different context

### DIFF
--- a/lib/Runtime/Library/JavascriptArray.cpp
+++ b/lib/Runtime/Library/JavascriptArray.cpp
@@ -4252,7 +4252,7 @@ namespace Js
         [&](bool/*hasException*/)
         {
             Var top = scriptContext->PopObject();
-            if (JavascriptProxy::Is(thisArg))
+            if (isProxy)
             {
                 AssertMsg(top == target, "Unmatched operation stack");
             }


### PR DESCRIPTION
We set `target` only if proxy is from same context, but while asserting we were not taking cross-context into account and hitting assert.
