### PR TITLE
Removed `Output::Print()`

### DIFF
--- a/lib/Common/Memory/Recycler.cpp
+++ b/lib/Common/Memory/Recycler.cpp
@@ -4914,8 +4914,6 @@ Recycler::BackgroundScanStack()
 #ifdef RECYCLER_TRACE
         CUSTOM_PHASE_PRINT_VERBOSE_TRACE1(GetRecyclerFlagsTable(), Js::ScanStackPhase, _u("[%04X] Skipping the stack scan\n"), ::GetCurrentThreadId());
 #endif
-        Output::Print(Js::ScanStackPhase, _u("[%04X] Skipping the stack scan\n"), ::GetCurrentThreadId());
-
         return 0;
     }
 


### PR DESCRIPTION
The trace is only printed if host has `idleGC` implemented, so haven't noticed so far in `ch.exe` but was showing up in node+chakracore after my idleGC changes.

This will fix  https://github.com/nodejs/node-chakracore/issues/115
