### PR TITLE
Invertloop issue.

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -11440,11 +11440,18 @@ ParseNode* Parser::CopyPnode(ParseNode *pnode) {
     return pnode;
       //PTNODE(knopFalse      , "false"        ,False   ,None ,fnopLeaf)
   case knopFalse:
-    return CreateNodeT<knopFalse>(pnode->ichMin,pnode->ichLim);
-      break;
+    {
+      ParseNode* ret = CreateNodeT<knopFalse>(pnode->ichMin, pnode->ichLim);
+      ret->location = pnode->location;
+      return ret;
+    }
       //PTNODE(knopTrue       , "true"        ,True    ,None ,fnopLeaf)
   case knopTrue:
-    return CreateNodeT<knopTrue>(pnode->ichMin,pnode->ichLim);
+    {
+        ParseNode* ret = CreateNodeT<knopTrue>(pnode->ichMin, pnode->ichLim);
+        ret->location = pnode->location;
+        return ret;
+    }
       //PTNODE(knopEmpty      , "empty"        ,Empty   ,None ,fnopLeaf)
   case knopEmpty:
     return CreateNodeT<knopEmpty>(pnode->ichMin,pnode->ichLim);
@@ -11574,8 +11581,8 @@ ParseNode* Parser::CopyPnode(ParseNode *pnode) {
       //PTNODE(knopNew        , "new"        ,None    ,Bin  ,fnopBin)
   case knopNew:
   case knopCall:
-    return CreateCallNode(pnode->nop,CopyPnode(pnode->sxBin.pnode1),
-                         CopyPnode(pnode->sxBin.pnode2),pnode->ichMin,pnode->ichLim);
+    return CreateCallNode(pnode->nop,CopyPnode(pnode->sxCall.pnodeTarget),
+                         CopyPnode(pnode->sxCall.pnodeArgs),pnode->ichMin,pnode->ichLim);
       //PTNODE(knopQmark      , "?"            ,None    ,Tri  ,fnopBin)
   case knopQmark:
     return CreateTriNode(pnode->nop,CopyPnode(pnode->sxTri.pnode1),

--- a/test/Bugs/invertloop_bug.js
+++ b/test/Bugs/invertloop_bug.js
@@ -1,0 +1,21 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+// Triggering invertloop codepath and ensuring the copying of nodes happens correctly.
+
+function foo() {
+	for (var a = 0; a < 1; ++a) {
+		for (var b = 0; b < 11; ++b) {
+			(true());
+		}
+	};
+
+};
+
+try {
+    foo();
+} catch(e) {
+    print(e.message === 'Function expected' ? 'pass' : 'fail');
+}

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -324,4 +324,10 @@
       <compile-flags>-simdjs  -asmjs -testtrace:asmjs -asmjsstoponerror</compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>invertloop_bug.js</files>
+      <tags>exclude_dynapogo</tags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
When we invertloop in the bytecode gen time, we didn't copy the call node correctly. That triggerred the assert. Fixed the copynode code for the call node.
