### PR TITLE
Minor false positive fixes in ChakraCore

### DIFF
--- a/lib/Backend/NativeCodeData.cpp
+++ b/lib/Backend/NativeCodeData.cpp
@@ -68,6 +68,12 @@ NativeCodeData::Allocator::Alloc(size_t requestSize)
 }
 
 char *
+NativeCodeData::Allocator::AllocLeaf(size_t requestSize)
+{
+    return Alloc(requestSize);
+}
+
+char *
 NativeCodeData::Allocator::AllocZero(size_t requestSize)
 {
     char * data = Alloc(requestSize);

--- a/lib/Backend/NativeCodeData.h
+++ b/lib/Backend/NativeCodeData.h
@@ -38,6 +38,8 @@ public:
 
         char * Alloc(DECLSPEC_GUARD_OVERFLOW size_t requestedBytes);
         char * AllocZero(DECLSPEC_GUARD_OVERFLOW size_t requestedBytes);
+        char * AllocLeaf(__declspec(guard(overflow)) size_t requestedBytes);
+
         NativeCodeData * Finalize();
         void Free(void * buffer, size_t byteSize);
 

--- a/lib/Common/DataStructures/FixedBitVector.h
+++ b/lib/Common/DataStructures/FixedBitVector.h
@@ -147,14 +147,14 @@ template <typename TAllocator>
 BVFixed * BVFixed::New(TAllocator * alloc, BVFixed * initBv)
 {
     BVIndex length = initBv->Length();
-    BVFixed *result = AllocatorNewPlus(TAllocator, alloc, sizeof(BVUnit) * BVFixed::WordCount(length), BVFixed, initBv);
+    BVFixed *result = AllocatorNewPlusLeaf(TAllocator, alloc, sizeof(BVUnit) * BVFixed::WordCount(length), BVFixed, initBv);
     return result;
 }
 
 template <typename TAllocator>
 BVFixed * BVFixed::New(DECLSPEC_GUARD_OVERFLOW BVIndex length, TAllocator * alloc, bool initialSet)
 {
-    BVFixed *result = AllocatorNewPlus(TAllocator, alloc, sizeof(BVUnit) * BVFixed::WordCount(length), BVFixed, length, initialSet);
+    BVFixed *result = AllocatorNewPlusLeaf(TAllocator, alloc, sizeof(BVUnit) * BVFixed::WordCount(length), BVFixed, length, initialSet);
     return result;
 }
 

--- a/lib/Runtime/Base/TempArenaAllocatorObject.cpp
+++ b/lib/Runtime/Base/TempArenaAllocatorObject.cpp
@@ -43,6 +43,31 @@ namespace Js
         Assert(allocator.AllocatedSize() == 0);
     }
 
+    template <bool isGuestArena>
+    void TempArenaAllocatorWrapper<isGuestArena>::AdviseInUse()
+    {
+        if (isGuestArena)
+        {
+            if (externalGuestArenaRef == nullptr)
+            {
+                externalGuestArenaRef = this->recycler->RegisterExternalGuestArena(this->GetAllocator());
+            }
+        }
+    }
+
+    template <bool isGuestArena>
+    void TempArenaAllocatorWrapper<isGuestArena>::AdviseNotInUse()
+    {
+        this->allocator.Reset();
+
+        if (isGuestArena)
+        {
+            Assert(externalGuestArenaRef != nullptr);
+            this->recycler->UnregisterExternalGuestArena(externalGuestArenaRef);
+            externalGuestArenaRef = nullptr;
+        }
+    }
+
     // Explicit instantiation
     template class TempArenaAllocatorWrapper<true>;
     template class TempArenaAllocatorWrapper<false>;

--- a/lib/Runtime/Base/TempArenaAllocatorObject.h
+++ b/lib/Runtime/Base/TempArenaAllocatorObject.h
@@ -18,6 +18,8 @@ namespace Js
 
     public:
 
+        void AdviseInUse();
+        void AdviseNotInUse();
 
         static TempArenaAllocatorWrapper* Create(ThreadContext * threadContext);
 

--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -2142,6 +2142,7 @@ ThreadContext::GetTemporaryGuestAllocator(LPCWSTR name)
     {
         temporaryGuestArenaAllocatorCount--;
         Js::TempGuestArenaAllocatorObject * allocator = recyclableData->temporaryGuestArenaAllocators[temporaryGuestArenaAllocatorCount];
+        allocator->AdviseInUse();
         recyclableData->temporaryGuestArenaAllocators[temporaryGuestArenaAllocatorCount] = nullptr;
         return allocator;
     }
@@ -2154,7 +2155,7 @@ ThreadContext::ReleaseTemporaryGuestAllocator(Js::TempGuestArenaAllocatorObject 
 {
     if (temporaryGuestArenaAllocatorCount < MaxTemporaryArenaAllocators)
     {
-        tempGuestAllocator->GetAllocator()->Reset();
+        tempGuestAllocator->AdviseNotInUse();
         recyclableData->temporaryGuestArenaAllocators[temporaryGuestArenaAllocatorCount] = tempGuestAllocator;
         temporaryGuestArenaAllocatorCount++;
         return;


### PR DESCRIPTION
1. BitVectors were not allocated as leaf, and this could cause the GC to interpret it's contents as pointer references. Switched to leaf
2. Temporary guest-arenas that were being cached could still get scanned, even if they weren't actively being used. Added a mechanism to unregister said arena when it wasn't used.
