### PR TITLE
Defer LdLen instruction handling until globopt so that we can leave it as LdFld for non-array-like objects.

### DIFF
--- a/lib/Backend/BackwardPass.cpp
+++ b/lib/Backend/BackwardPass.cpp
@@ -2508,12 +2508,18 @@ BackwardPass::ProcessBlock(BasicBlock * block)
         {
             Output::Print(_u(">>>>>>>>>>>>>>>>>>>>>> %s: Instr Start\n"), tag == Js::BackwardPhase? _u("BACKWARD") : _u("DEADSTORE"));
             instr->Dump();
-            Output::SkipToColumn(10);
-            Output::Print(_u("   Exposed Use: "));
-            block->upwardExposedUses->Dump();
-            Output::SkipToColumn(10);
-            Output::Print(_u("Exposed Fields: "));
-            block->upwardExposedFields->Dump();
+            if (block->upwardExposedUses)
+            {
+                Output::SkipToColumn(10);
+                Output::Print(_u("   Exposed Use: "));
+                block->upwardExposedUses->Dump();
+            }
+            if (block->upwardExposedFields)
+            {
+                Output::SkipToColumn(10);
+                Output::Print(_u("Exposed Fields: "));
+                block->upwardExposedFields->Dump();
+            }
             if (block->byteCodeUpwardExposedUsed)
             {
                 Output::SkipToColumn(10);
@@ -2828,12 +2834,18 @@ BackwardPass::ProcessBlock(BasicBlock * block)
         {
             Output::Print(_u("-------------------\n"));
             instr->Dump();
-            Output::SkipToColumn(10);
-            Output::Print(_u("   Exposed Use: "));
-            block->upwardExposedUses->Dump();
-            Output::SkipToColumn(10);
-            Output::Print(_u("Exposed Fields: "));
-            block->upwardExposedFields->Dump();
+            if (block->upwardExposedUses)
+            {
+                Output::SkipToColumn(10);
+                Output::Print(_u("   Exposed Use: "));
+                block->upwardExposedUses->Dump();
+            }
+            if (block->upwardExposedFields)
+            {
+                Output::SkipToColumn(10);
+                Output::Print(_u("Exposed Fields: "));
+                block->upwardExposedFields->Dump();
+            }
             if (block->byteCodeUpwardExposedUsed)
             {
                 Output::SkipToColumn(10);

--- a/lib/Backend/GlobOpt.h
+++ b/lib/Backend/GlobOpt.h
@@ -111,6 +111,7 @@ public:
 
     using ValueType::HasBeenString;
     using ValueType::IsString;
+    using ValueType::HasHadStringTag;
     using ValueType::IsLikelyString;
     using ValueType::IsNotString;
 

--- a/lib/Backend/IRBuilder.cpp
+++ b/lib/Backend/IRBuilder.cpp
@@ -6074,9 +6074,8 @@ IRBuilder::BuildProfiledCallI(Js::OpCode opcode, uint32 offset, Js::RegSlot retu
         newOpcode = opcode;
         Js::OpCodeUtil::ConvertNonCallOpToNonProfiled(newOpcode);
         Assert(newOpcode == Js::OpCode::NewScObject || newOpcode == Js::OpCode::NewScObjectSpread);
-        if (newOpcode == Js::OpCode::NewScObjectSpread || !this->m_func->HasProfileInfo())
+        if (!this->m_func->HasProfileInfo())
         {
-            // Testing required before enabling this for newscobjectspread
             returnType = ValueType::GetObject(ObjectType::UninitializedObject);
         }
         else

--- a/lib/Backend/JITTimeProfileInfo.cpp
+++ b/lib/Backend/JITTimeProfileInfo.cpp
@@ -191,7 +191,7 @@ JITTimeProfileInfo::GetThisInfo() const
 ValueType
 JITTimeProfileInfo::GetReturnType(Js::OpCode opcode, Js::ProfileId callSiteId) const
 {
-    if (opcode < Js::OpCode::ProfiledReturnTypeCallI)
+    if (opcode < Js::OpCode::ProfiledReturnTypeCallI || (opcode > Js::OpCode::ProfiledReturnTypeCallIFlags && opcode < Js::OpCode::ProfiledReturnTypeCallIExtended) || opcode > Js::OpCode::ProfiledReturnTypeCallIExtendedFlags)
     {
         Assert(Js::DynamicProfileInfo::IsProfiledCallOp(opcode));
         Assert(callSiteId < GetProfiledCallSiteCount());

--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -14454,6 +14454,10 @@ Lowerer::GenerateFastElemIIntIndexCommon(
     //      } else {
     //          newLength = index + 1
     //      }
+    //      if(BailOutOnInvalidatedArrayLength) {
+    //          CMP [base + offset(length)], newlength
+    //          JB $helper
+    //      }
     //      MOV [headSegment + offset(length)], newLength       -- update length on chunk
     //      CMP [base  + offset(length)], newLength
     //      JAE $done
@@ -14463,13 +14467,13 @@ Lowerer::GenerateFastElemIIntIndexCommon(
     //          INC newLength
     //          MOV dst, newLength
     //      }
-    //     JMP $done
+    //      JMP $done
     //
-    //     $toNumberHelper: Call HelperOp_ConvNumber_Full
-    //     JMP $done
-    //     $done
+    //      $toNumberHelper: Call HelperOp_ConvNumber_Full
+    //      JMP $done
+    //      $done
     //  } else {la
-    //     JBE $helper
+    //      JBE $helper
     //  }
     // return [headSegment + offset(elements) + index]
 
@@ -14692,7 +14696,7 @@ Lowerer::GenerateFastElemIIntIndexCommon(
 
     const IR::BailOutKind bailOutKind = instr->HasBailOutInfo() ? instr->GetBailOutKind() : IR::BailOutInvalid;
     const bool needBailOutOnInvalidLength = !!(bailOutKind & (IR::BailOutOnInvalidatedArrayHeadSegment));
-    const bool needBailOutToHelper = !!(bailOutKind & (IR::BailOutOnArrayAccessHelperCall | IR::BailOutOnInvalidatedArrayLength));
+    const bool needBailOutToHelper = !!(bailOutKind & (IR::BailOutOnArrayAccessHelperCall));
     const bool needBailOutOnSegmentLengthCompare = needBailOutToHelper || needBailOutOnInvalidLength;
     
     if(indexIsLessThanHeadSegmentLength || needBailOutOnSegmentLengthCompare)
@@ -14961,6 +14965,19 @@ Lowerer::GenerateFastElemIIntIndexCommon(
             autoReuseNewLengthOpnd.Initialize(newLengthOpnd, m_func);
         }
 
+        // This is a common enough case that we want to go through this path instead of the simpler one, since doing it this way is faster for preallocated but un-filled arrays.
+        if (!!(bailOutKind & IR::BailOutOnInvalidatedArrayLength))
+        {
+            // If we'd increase the array length, go to the helper
+            indirOpnd = IR::IndirOpnd::New(arrayOpnd, Js::JavascriptArray::GetOffsetOfLength(), TyUint32, this->m_func);
+            InsertCompareBranch(
+                newLengthOpnd,
+                indirOpnd,
+                Js::OpCode::BrGt_A,
+                true,
+                labelHelper,
+                instr);
+        }
         //      MOV [headSegment + offset(length)], newLength
         indirOpnd = IR::IndirOpnd::New(headSegmentOpnd, offsetof(Js::SparseArraySegmentBase, length), TyUint32, this->m_func);
         InsertMove(indirOpnd, newLengthOpnd, instr);

--- a/lib/Backend/TempTracker.cpp
+++ b/lib/Backend/TempTracker.cpp
@@ -1000,6 +1000,8 @@ ObjectTemp::IsTempUseOpCodeSym(IR::Instr * instr, Js::OpCode opcode, Sym * sym)
     // Special case ArgOut_A which communicate information about CallDirect
     switch (opcode)
     {
+    case Js::OpCode::LdLen_A:
+        return instr->GetSrc1()->AsRegOpnd()->GetStackSym() == sym;
     case Js::OpCode::ArgOut_A:
         return instr->dstIsTempObject;
     case Js::OpCode::LdFld:

--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -10597,36 +10597,29 @@ void Emit(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator, FuncInfo *func
         Js::RegSlot protoLocation = callObjLocation;
         EmitSuperMethodBegin(pnode, byteCodeGenerator, funcInfo);
 
-        if (propertyId == Js::PropertyIds::length)
+        uint cacheId = funcInfo->FindOrAddInlineCacheId(callObjLocation, propertyId, false, false);
+        if (pnode->IsCallApplyTargetLoad())
         {
-            byteCodeGenerator->Writer()->Reg2(Js::OpCode::LdLen_A, pnode->location, protoLocation);
-        }
-        else
-        {
-            uint cacheId = funcInfo->FindOrAddInlineCacheId(callObjLocation, propertyId, false, false);
-            if (pnode->IsCallApplyTargetLoad())
+            if (pnode->sxBin.pnode1->nop == knopSuper)
             {
-                if (pnode->sxBin.pnode1->nop == knopSuper)
-                {
-                    Js::RegSlot tmpReg = byteCodeGenerator->EmitLdObjProto(Js::OpCode::LdHomeObjProto, funcInfo->superRegister, funcInfo);
-                    byteCodeGenerator->Writer()->PatchableProperty(Js::OpCode::LdFldForCallApplyTarget, pnode->location, tmpReg, cacheId);
-                }
-                else
-                {
-                    byteCodeGenerator->Writer()->PatchableProperty(Js::OpCode::LdFldForCallApplyTarget, pnode->location, protoLocation, cacheId);
-                }
+                Js::RegSlot tmpReg = byteCodeGenerator->EmitLdObjProto(Js::OpCode::LdHomeObjProto, funcInfo->superRegister, funcInfo);
+                byteCodeGenerator->Writer()->PatchableProperty(Js::OpCode::LdFldForCallApplyTarget, pnode->location, tmpReg, cacheId);
             }
             else
             {
-                if (pnode->sxBin.pnode1->nop == knopSuper)
-                {
-                    Js::RegSlot tmpReg = byteCodeGenerator->EmitLdObjProto(Js::OpCode::LdHomeObjProto, funcInfo->superRegister, funcInfo);
-                    byteCodeGenerator->Writer()->PatchablePropertyWithThisPtr(Js::OpCode::LdSuperFld, pnode->location, tmpReg, funcInfo->thisPointerRegister, cacheId, isConstructorCall);
-                }
-                else
-                {
-                    byteCodeGenerator->Writer()->PatchableProperty(Js::OpCode::LdFld, pnode->location, callObjLocation, cacheId, isConstructorCall);
-                }
+                byteCodeGenerator->Writer()->PatchableProperty(Js::OpCode::LdFldForCallApplyTarget, pnode->location, protoLocation, cacheId);
+            }
+        }
+        else
+        {
+            if (pnode->sxBin.pnode1->nop == knopSuper)
+            {
+                Js::RegSlot tmpReg = byteCodeGenerator->EmitLdObjProto(Js::OpCode::LdHomeObjProto, funcInfo->superRegister, funcInfo);
+                byteCodeGenerator->Writer()->PatchablePropertyWithThisPtr(Js::OpCode::LdSuperFld, pnode->location, tmpReg, funcInfo->thisPointerRegister, cacheId, isConstructorCall);
+            }
+            else
+            {
+                byteCodeGenerator->Writer()->PatchableProperty(Js::OpCode::LdFld, pnode->location, callObjLocation, cacheId, isConstructorCall);
             }
         }
 

--- a/lib/Runtime/ByteCode/OpCodeUtil.cpp
+++ b/lib/Runtime/ByteCode/OpCodeUtil.cpp
@@ -84,7 +84,7 @@ namespace Js
 
     bool OpCodeUtil::IsProfiledConstructorCall(OpCode op)
     {
-        return op >= Js::OpCode::NewScObject && op <= Js::OpCode::ProfiledNewScObjArraySpread && (OpCodeAttr::IsProfiledOp(op) || OpCodeAttr::IsProfiledOpWithICIndex(op));
+        return ((op >= Js::OpCode::NewScObject && op <= Js::OpCode::ProfiledNewScObjArraySpread) || op == Js::OpCode::ProfiledNewScObjectSpread) && (OpCodeAttr::IsProfiledOp(op) || OpCodeAttr::IsProfiledOpWithICIndex(op));
     }
 
     bool OpCodeUtil::IsProfiledReturnTypeCallOp(OpCode op)

--- a/lib/Runtime/ByteCode/OpCodeUtil.cpp
+++ b/lib/Runtime/ByteCode/OpCodeUtil.cpp
@@ -82,6 +82,11 @@ namespace Js
         return op >= Js::OpCode::ProfiledCallIWithICIndex && op <= Js::OpCode::ProfiledCallIExtendedFlagsWithICIndex;
     }
 
+    bool OpCodeUtil::IsProfiledConstructorCall(OpCode op)
+    {
+        return op >= Js::OpCode::NewScObject && op <= Js::OpCode::ProfiledNewScObjArraySpread && (OpCodeAttr::IsProfiledOp(op) || OpCodeAttr::IsProfiledOpWithICIndex(op));
+    }
+
     bool OpCodeUtil::IsProfiledReturnTypeCallOp(OpCode op)
     {
         return op >= Js::OpCode::ProfiledReturnTypeCallI && op <= Js::OpCode::ProfiledReturnTypeCallIExtendedFlags;

--- a/lib/Runtime/ByteCode/OpCodeUtil.h
+++ b/lib/Runtime/ByteCode/OpCodeUtil.h
@@ -14,6 +14,7 @@ public:
     static bool IsCallOp(OpCode op);
     static bool IsProfiledCallOp(OpCode op);
     static bool IsProfiledCallOpWithICIndex(OpCode op);
+    static bool IsProfiledConstructorCall(OpCode op);
     static bool IsProfiledReturnTypeCallOp(OpCode op);
 
     // OpCode conversion functions

--- a/lib/Runtime/Language/DynamicProfileInfo.cpp
+++ b/lib/Runtime/Language/DynamicProfileInfo.cpp
@@ -1312,7 +1312,7 @@ namespace Js
 
     bool DynamicProfileInfo::IsProfiledCallOp(OpCode op)
     {
-        return Js::OpCodeUtil::IsProfiledCallOp(op) || Js::OpCodeUtil::IsProfiledCallOpWithICIndex(op);
+        return Js::OpCodeUtil::IsProfiledCallOp(op) || Js::OpCodeUtil::IsProfiledCallOpWithICIndex(op) || Js::OpCodeUtil::IsProfiledConstructorCall(op);
     }
 
     bool DynamicProfileInfo::IsProfiledReturnTypeOp(OpCode op)

--- a/lib/Runtime/Language/ProfilingHelpers.cpp
+++ b/lib/Runtime/Language/ProfilingHelpers.cpp
@@ -617,7 +617,8 @@ namespace Js
                 calleeObject->GetTypeId() == TypeIds_Function
                     ? JavascriptFunction::FromVar(calleeObject)->GetFunctionInfo()
                     : nullptr;
-            callerFunctionBody->GetDynamicProfileInfo()->RecordCallSiteInfo(
+            DynamicProfileInfo *profileInfo = callerFunctionBody->GetDynamicProfileInfo();
+            profileInfo->RecordCallSiteInfo(
                 callerFunctionBody,
                 profileId,
                 calleeFunctionInfo,
@@ -625,6 +626,11 @@ namespace Js
                 args.Info.Count,
                 true,
                 inlineCacheIndex);
+            // We need to record information here, most importantly so that we handle array subclass
+            // creation properly, since optimizing those cases is important
+            Var retVal = JavascriptOperators::NewScObject(callee, args, scriptContext, spreadIndices);
+            profileInfo->RecordReturnTypeOnCallSiteInfo(callerFunctionBody, profileId, retVal);
+            return retVal;
         }
 
         return JavascriptOperators::NewScObject(callee, args, scriptContext, spreadIndices);

--- a/lib/Runtime/Language/ValueType.cpp
+++ b/lib/Runtime/Language/ValueType.cpp
@@ -418,6 +418,11 @@ bool ValueType::IsString() const
     return OneOnOthersOff(Bits::String, Bits::CanBeTaggedValue);
 }
 
+bool ValueType::HasHadStringTag() const
+{
+    return !!(bits & Bits::String);
+}
+
 bool ValueType::IsLikelyString() const
 {
     return OneOnOthersOff(Bits::String, Bits::Likely | Bits::CanBeTaggedValue);

--- a/lib/Runtime/Language/ValueType.h
+++ b/lib/Runtime/Language/ValueType.h
@@ -150,7 +150,11 @@ public:
 
     bool HasBeenString() const;
     bool IsString() const;
-    bool HasHadStringTag() const; // Note: this is likely not what you're looking for; this is a short-cut for LdLen optimization.
+    // Note: This function is primarily intended for heuristic purposes. There are some cases
+    // where an object can be either a string or undefined, but we want to emit fast code for
+    // the case where it's a string (since otherwise we lose a lot of perf). This simply says
+    // that there's the possibility that the valuetype being considered is a string.
+    bool HasHadStringTag() const;
     bool IsLikelyString() const;
     bool IsNotString() const;
 

--- a/lib/Runtime/Language/ValueType.h
+++ b/lib/Runtime/Language/ValueType.h
@@ -150,6 +150,7 @@ public:
 
     bool HasBeenString() const;
     bool IsString() const;
+    bool HasHadStringTag() const; // Note: this is likely not what you're looking for; this is a short-cut for LdLen optimization.
     bool IsLikelyString() const;
     bool IsNotString() const;
 


### PR DESCRIPTION
This changset makes us handle situations better where the .length field is used on objects other than arrays/strings/arguments, and makes a few optimizations a little more robust.