### PR TITLE
Fix some tabs and trailing whitespace that has creeped in; add Tab Check

### DIFF
--- a/jenkins/check_tabs.sh
+++ b/jenkins/check_tabs.sh
@@ -1,0 +1,39 @@
+#-------------------------------------------------------------------------------------------------------
+# Copyright (C) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+#-------------------------------------------------------------------------------------------------------
+
+# Need to make sure that the reference to origin/master is available.
+# We know that HEAD is checked out so that the tests on that source can be run.
+
+# configure the sh environment to run scripts from the bin dir in case that's missing
+ls &> /dev/null # checking for ls script on the path
+if [ $? -ne 0 ]; then
+    PATH=/bin:/usr/bin:$PATH
+fi
+
+ERRFILE=check_tabs.sh.err
+rm -f $ERRFILE
+
+# git diff --name-only `git merge-base origin/master HEAD` HEAD | xargs grep -P -l "\t" > /dev/nul
+
+git diff --name-only `git merge-base origin/master HEAD` HEAD |
+    xargs grep -P -l "\t" |
+    grep -v -E '^pal/' |
+    grep -v -E '\.sln$' |
+    grep -v -E '\.js$' |
+    grep -v -E '\.baseline$' |
+    grep -v -E 'bin/External/.*$' |
+    xargs -I % sh -c 'echo --- IN FILE % ---; git blame HEAD -- % | grep -P "(\t|--- IN FILE)"' > check_tabs.sh.err
+
+if [ -s $ERRFILE ]; then # if file exists and is non-empty then there were errors
+    >&2 echo "--------------" # leading >&2 means echo to stderr
+    >&2 echo "--- ERRORS ---"
+    >&2 echo ""
+
+    cat $ERRFILE 1>&2 # send output to stderr so it can be redirected as error if desired
+
+    exit 1
+else
+    echo "--- NO PROBLEMS DETECTED ---"
+fi

--- a/lib/Parser/CharSet.cpp
+++ b/lib/Parser/CharSet.cpp
@@ -1874,7 +1874,7 @@ namespace UnifiedRegex
     // defined constant and complains. So skip the declaration if we're compiling
     // with VS2013 or below.
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
-	const int  CharSetNode::directBits;
+    const int  CharSetNode::directBits;
     const uint CharSetNode::directSize;
     const uint CharSetNode::innerMask;
     const int  CharSetNode::bitsPerLeafLevel;

--- a/lib/Runtime/Base/jitprofiling.cpp
+++ b/lib/Runtime/Base/jitprofiling.cpp
@@ -24,9 +24,9 @@ static const char rcsid[] = "\n@(#) $Revision: 463960 $\n";
 
 #ifndef NEW_DLL_ENVIRONMENT_VAR
 #if ITT_ARCH==ITT_ARCH_IA32
-#define NEW_DLL_ENVIRONMENT_VAR	        "INTEL_JIT_PROFILER32"
+#define NEW_DLL_ENVIRONMENT_VAR         "INTEL_JIT_PROFILER32"
 #else
-#define NEW_DLL_ENVIRONMENT_VAR	        "INTEL_JIT_PROFILER64"
+#define NEW_DLL_ENVIRONMENT_VAR         "INTEL_JIT_PROFILER64"
 #endif
 #endif /* NEW_DLL_ENVIRONMENT_VAR */
 

--- a/lib/Runtime/Language/JavascriptStackWalker.h
+++ b/lib/Runtime/Language/JavascriptStackWalker.h
@@ -338,7 +338,7 @@ namespace Js
         bool TryGetByteCodeOffsetOfInlinee(Js::JavascriptFunction* function, uint loopNum, DWORD_PTR pCodeAddr, Js::FunctionBody** inlinee, uint32& offset, bool useInternalFrameInfo) const;
         uint GetLoopNumber(bool& usedInternalFrameInfo) const;
         bool InlinedFramesBeingWalked() const;
-		bool HasInlinedFramesOnStack() const;
+        bool HasInlinedFramesOnStack() const;
         bool PreviousInterpreterFrameIsFromBailout() const;
         InternalFrameInfo lastInternalFrameInfo;
 #endif

--- a/lib/Runtime/Library/ArgumentsObject.h
+++ b/lib/Runtime/Library/ArgumentsObject.h
@@ -119,10 +119,10 @@ namespace Js
 
         ES5HeapArgumentsObject* ConvertToUnmappedArgumentsObject(bool overwriteArgsUsingFrameObject = true);
         const ActivationObject* const GetFrameObject() { return frameObject; }
-		void SetFrameObject(ActivationObject * value) 
-        { 
+        void SetFrameObject(ActivationObject * value)
+        {
             AssertMsg(frameObject == nullptr, "Setting the frame object again?");
-            frameObject = value; 
+            frameObject = value;
         }
 
     private:

--- a/netci.groovy
+++ b/netci.groovy
@@ -254,8 +254,9 @@ if (!branch.endsWith('-ci')) {
 // CODE STYLE TASKS
 // ----------------
 
-CreateStyleCheckTasks('./jenkins/check_eol.sh', 'ubuntu_check_eol', 'EOL Check')
 CreateStyleCheckTasks('./jenkins/check_copyright.sh', 'ubuntu_check_copyright', 'Copyright Check')
+CreateStyleCheckTasks('./jenkins/check_eol.sh', 'ubuntu_check_eol', 'EOL Check')
+CreateStyleCheckTasks('./jenkins/check_tabs.sh', 'ubuntu_check_tabs', 'Tab Check')
 
 // --------------
 // XPLAT BRANCHES


### PR DESCRIPTION
Add a new Jenkins task to detect when tabs are introduced into the source code.

There are very few instances of tabs being introduced (always unintentionally in the case of C++ source) and it seems to bother enough people that it would be nice to detect it before it is checked in.