### PR TITLE
OSX SDK 10.12 build break

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,11 @@ if(CMAKE_SYSTEM_NAME STREQUAL Linux)
     endif()
 
     set(CLR_CMAKE_PLATFORM_LINUX 1)
+    # OSX 10.12 Clang deprecates libstdc++ [See GH #1599]
+    # So, -Werror is linux only for now
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
+        -Werror"
+        )
 elseif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
     add_definitions(
         -DPLATFORM_UNIX
@@ -200,15 +205,6 @@ if(CLR_CMAKE_PLATFORM_XPLAT)
     # do not set to `fvisibility=hidden` as it is going to
     # prevent the required interface is being exported
     # clang by default sets fvisibility=default
-
-if(NOT CC_XCODE_PROJECT)
-    # todo: enable for XCode too
-    # XCode is a bit more strict
-    # keep this until we fix all the warnings there.
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
-        -Werror"
-        )
-endif()
 
     # CXX WARNING FLAGS
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \


### PR DESCRIPTION
Just saw this after updating one of my dev machines.
CC is not compiling on a machine with Xcode 8.0+ installed due to changes to latest clang.

`clang: warning: libstdc++ is deprecated; move to libc++ with a minimum deployment target of OS X 10.9`

This warning breaks the CMake feature detection scripts.
We could update to libc++. However, that would break node-chakracore.

In order not to break node-chakracore builds, I'm turning off the CXX `-werror` for osx until node-chakracore is updated to libc++