### PR TITLE
Fix update of likely int bounds

### DIFF
--- a/lib/Backend/GlobOptIntBounds.cpp
+++ b/lib/Backend/GlobOptIntBounds.cpp
@@ -773,9 +773,10 @@ IntBounds *GlobOpt::GetIntBoundsToUpdate(
             // New relative bounds are not being set, will use IntRangeValueInfo instead
             return nullptr;
         }
+        return IntBounds::New(constantBounds, false, alloc);
     }
 
-    return IntBounds::New(constantBounds, false, alloc);
+    return nullptr;
 }
 
 ValueInfo *GlobOpt::UpdateIntBoundsForEqual(

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -330,4 +330,10 @@
       <tags>exclude_dynapogo</tags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>typespec_bug.js</files>
+      <compile-flags>-maxinterpretcount:1 -maxsimplejitruncount:1 -bgjit-</compile-flags>
+    </default>
+  </test>
 </regress-exe>

--- a/test/Bugs/typespec_bug.js
+++ b/test/Bugs/typespec_bug.js
@@ -1,0 +1,23 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+var f = 2147483647;
+var func1 = function (argMath3) {
+    if ( f < argMath3)
+    {
+        f++;
+    }
+};
+func1(3);
+func1(4);
+func1(4702209150613300000);
+if (f == 2147483648)
+{
+    WScript.Echo("Passed");
+}
+else
+{
+    WScript.Echo("Fail");
+}


### PR DESCRIPTION
The function GlobOpt::GetIntBoundsToUpdate should not return bounds for a
likely int. The bounds returned by this function are adjusted based on
whether the conditional branch was less than, less than equal to, etc.
Updating bound on a likely int, can result in incorrect results for edge
cases.
