### PR TITLE
stop inlining decider selecting asm.js functions with -force:inline

### DIFF
--- a/lib/Backend/InliningDecider.cpp
+++ b/lib/Backend/InliningDecider.cpp
@@ -686,6 +686,11 @@ bool InliningDecider::DeciderInlineIntoInliner(Js::FunctionBody * inlinee, Js::F
         return false;
     }
 
+    if (inlinee->GetIsAsmjsMode() || inliner->GetIsAsmjsMode())
+    {
+        return false;
+    }
+
     if (PHASE_FORCE(Js::InlinePhase, this->topFunc) ||
         PHASE_FORCE(Js::InlinePhase, inliner) ||
         PHASE_FORCE(Js::InlinePhase, inlinee))
@@ -709,11 +714,6 @@ bool InliningDecider::DeciderInlineIntoInliner(Js::FunctionBody * inlinee, Js::F
     if (PHASE_FORCE(Js::InlineAtEveryCallerPhase, inlinee))
     {
         return true;
-    }
-
-    if (inlinee->GetIsAsmjsMode() || inliner->GetIsAsmjsMode())
-    {
-        return false;
     }
 
     uint inlineeByteCodeCount = inlinee->GetByteCodeWithoutLDACount();


### PR DESCRIPTION
This caused issues with oop jit when trying to build inline info for the asm.js closure, which is an invalid scenario