### PR TITLE
fix oop jit bugs with reclaimed property records

### DIFF
--- a/lib/Backend/NativeCodeGenerator.cpp
+++ b/lib/Backend/NativeCodeGenerator.cpp
@@ -1992,6 +1992,87 @@ NativeCodeGenerator::JobProcessed(JsUtil::Job *const job, const bool succeeded)
     }
 }
 
+void
+NativeCodeGenerator::UpdateJITState()
+{
+    if (JITManager::GetJITManager()->IsOOPJITEnabled())
+    {
+        // ensure jit contexts have been set up
+        if (!scriptContext->GetRemoteScriptAddr())
+        {
+            scriptContext->InitializeRemoteScriptContext();
+        }
+
+        bool allowPrereserveAlloc = true;
+#if !_M_X64_OR_ARM64
+        if (this->scriptContext->webWorkerId != Js::Constants::NonWebWorkerContextId)
+        {
+            allowPrereserveAlloc = false;
+        }
+#endif
+#ifndef _CONTROL_FLOW_GUARD
+        allowPrereserveAlloc = false;
+#endif
+        scriptContext->GetThreadContext()->EnsureJITThreadContext(allowPrereserveAlloc);
+
+        // update all property records on server that have been changed since last jit
+        ThreadContext::PropertyMap * pendingProps = scriptContext->GetThreadContext()->GetPendingJITProperties();
+        PropertyRecordIDL ** newPropArray = nullptr;
+        uint newCount = 0;
+        if (pendingProps->Count() > 0)
+        {
+            newCount = (uint)pendingProps->Count();
+            newPropArray = HeapNewArray(PropertyRecordIDL*, newCount);
+            uint index = 0;
+            auto iter = pendingProps->GetIteratorWithRemovalSupport();
+            while (iter.IsValid())
+            {
+                newPropArray[index++] = (PropertyRecordIDL*)iter.CurrentValue();
+                iter.RemoveCurrent();
+                iter.MoveNext();
+            }
+            Assert(index == newCount);
+        }
+
+        ThreadContext::PropertyList * reclaimedProps = scriptContext->GetThreadContext()->GetReclaimedJITProperties();
+        int * reclaimedPropArray = nullptr;
+        uint reclaimedCount = 0;
+        if (reclaimedProps->Count() > 0)
+        {
+            reclaimedCount = (uint)reclaimedProps->Count();
+            reclaimedPropArray = HeapNewArray(int, reclaimedCount);
+            uint index = 0;
+            while (!reclaimedProps->Empty())
+            {
+                reclaimedPropArray[index++] = (int)reclaimedProps->Pop();
+            }
+            Assert(index == reclaimedCount);
+        }
+
+        if (newCount > 0 || reclaimedCount > 0)
+        {
+            UpdatedPropertysIDL props = {0};
+            props.reclaimedPropertyCount = reclaimedCount;
+            props.reclaimedPropertyIdArray = reclaimedPropArray;
+            props.newRecordCount = newCount;
+            props.newRecordArray = newPropArray;
+            HRESULT hr = JITManager::GetJITManager()->UpdatePropertyRecordMap(scriptContext->GetThreadContext()->GetRemoteThreadContextAddr(), &props);
+            if (hr != S_OK)
+            {
+                Js::Throw::FatalInternalError();
+            }
+            if (newPropArray)
+            {
+                HeapDeleteArray(newCount, newPropArray);
+            }
+            if (reclaimedPropArray)
+            {
+                HeapDeleteArray(reclaimedCount, reclaimedPropArray);
+            }
+        }
+    }
+}
+
 JsUtil::Job *
 NativeCodeGenerator::GetJobToProcessProactively()
 {
@@ -2881,49 +2962,7 @@ NativeCodeGenerator::GatherCodeGenData(Js::FunctionBody *const topFunctionBody, 
     } autoProfile(foregroundCodeGenProfiler);
 #endif
 
-    if (JITManager::GetJITManager()->IsOOPJITEnabled() )
-    {
-        // ensure jit contexts have been set up
-        if (!scriptContext->GetRemoteScriptAddr())
-        {
-            scriptContext->InitializeRemoteScriptContext();
-        }
-
-        bool allowPrereserveAlloc = true;
-#if !_M_X64_OR_ARM64
-        if (this->scriptContext->webWorkerId != Js::Constants::NonWebWorkerContextId)
-        {
-            allowPrereserveAlloc = false;
-        }
-#endif
-#ifndef _CONTROL_FLOW_GUARD
-        allowPrereserveAlloc = false;
-#endif
-        scriptContext->GetThreadContext()->EnsureJITThreadContext(allowPrereserveAlloc);
-
-        // batch send all new property records
-        ThreadContext::PropertyMap * pendingProps = scriptContext->GetThreadContext()->GetPendingJITProperties();
-        if (pendingProps->Count() > 0)
-        {
-            uint count = (uint)pendingProps->Count();
-            PropertyRecordIDL ** propArray = HeapNewArray(PropertyRecordIDL*, count);
-            uint index = 0;
-            auto iter = pendingProps->GetIteratorWithRemovalSupport();
-            while (iter.IsValid())
-            {
-                propArray[index++] = (PropertyRecordIDL*)iter.CurrentValue();
-                iter.RemoveCurrent();
-                iter.MoveNext();
-            }
-            Assert(index == count);
-            HRESULT hr = JITManager::GetJITManager()->AddPropertyRecordArray(scriptContext->GetThreadContext()->GetRemoteThreadContextAddr(), count, (PropertyRecordIDL**)propArray);
-            if (hr != S_OK)
-            {
-                Js::Throw::FatalInternalError();
-            }
-            HeapDeleteArray(count, propArray);
-        }
-    }
+    UpdateJITState();
 
     const auto recycler = scriptContext->GetRecycler();
     {

--- a/lib/Backend/NativeCodeGenerator.h
+++ b/lib/Backend/NativeCodeGenerator.h
@@ -77,6 +77,7 @@ private:
     JsUtil::Job *GetJobToProcessProactively();
     void AddToJitQueue(CodeGenWorkItem *const codeGenWorkItem, bool prioritize, bool lock, void* function = nullptr);
     void RemoveProactiveJobs();
+    void UpdateJITState();
     static void LogCodeGenStart(CodeGenWorkItem * workItem, LARGE_INTEGER * start_time);
     static void LogCodeGenDone(CodeGenWorkItem * workItem, LARGE_INTEGER * start_time);
     typedef SListCounted<Js::ObjTypeSpecFldInfo*, ArenaAllocator> ObjTypeSpecFldInfoList;

--- a/lib/Backend/ServerThreadContext.cpp
+++ b/lib/Backend/ServerThreadContext.cpp
@@ -224,6 +224,15 @@ ServerThreadContext::AddToPropertyMap(const Js::PropertyRecord * origRecord)
     }
     record->pid = origRecord->pid;
 
+    const Js::PropertyRecord * oldRecord = nullptr;
+    if (m_propertyMap->TryGetValue(origRecord->GetPropertyId(), &oldRecord))
+    {
+        // if there was reclaimed property that had its pid reused, delete the old property record
+        m_propertyMap->Remove(oldRecord);
+        size_t oldLength = oldRecord->byteCount + sizeof(char16) + (oldRecord->isNumeric ? sizeof(uint32) : 0);
+        HeapDeletePlus(oldLength, const_cast<Js::PropertyRecord*>(oldRecord));
+    }
+
     m_propertyMap->Add(record);
 
     PropertyRecordTrace(_u("Added JIT property '%s' at 0x%08x, pid = %d\n"), record->GetBuffer(), record, record->pid);

--- a/lib/Backend/ServerThreadContext.cpp
+++ b/lib/Backend/ServerThreadContext.cpp
@@ -206,6 +206,27 @@ ServerThreadContext::GetPropertyRecord(Js::PropertyId propertyId)
 }
 
 void
+ServerThreadContext::RemoveFromPropertyMap(Js::PropertyId reclaimedId)
+{
+    const Js::PropertyRecord * oldRecord = nullptr;
+    if (m_propertyMap->TryGetValue(reclaimedId, &oldRecord))
+    {
+        // if there was reclaimed property that had its pid reused, delete the old property record
+        m_propertyMap->Remove(oldRecord);
+
+        PropertyRecordTrace(_u("Reclaimed JIT property '%s' at 0x%08x, pid = %d\n"), oldRecord->GetBuffer(), oldRecord, oldRecord->pid);
+
+        size_t oldLength = oldRecord->byteCount + sizeof(char16) + (oldRecord->isNumeric ? sizeof(uint32) : 0);
+        HeapDeletePlus(oldLength, const_cast<Js::PropertyRecord*>(oldRecord));
+    }
+    else
+    {
+        // we should only ever ask to reclaim properties which were previously added to the jit map
+        Assert(UNREACHED);
+    }
+}
+
+void
 ServerThreadContext::AddToPropertyMap(const Js::PropertyRecord * origRecord)
 {
     size_t allocLength = origRecord->byteCount + sizeof(char16) + (origRecord->isNumeric ? sizeof(uint32) : 0);
@@ -225,9 +246,10 @@ ServerThreadContext::AddToPropertyMap(const Js::PropertyRecord * origRecord)
     record->pid = origRecord->pid;
 
     const Js::PropertyRecord * oldRecord = nullptr;
+
+    // this should only happen if there was reclaimed property that we failed to add to reclaimed list due to a prior oom
     if (m_propertyMap->TryGetValue(origRecord->GetPropertyId(), &oldRecord))
     {
-        // if there was reclaimed property that had its pid reused, delete the old property record
         m_propertyMap->Remove(oldRecord);
         size_t oldLength = oldRecord->byteCount + sizeof(char16) + (oldRecord->isNumeric ? sizeof(uint32) : 0);
         HeapDeletePlus(oldLength, const_cast<Js::PropertyRecord*>(oldRecord));

--- a/lib/Backend/ServerThreadContext.h
+++ b/lib/Backend/ServerThreadContext.h
@@ -42,6 +42,7 @@ public:
     AllocationPolicyManager * GetAllocationPolicyManager();
     CustomHeap::CodePageAllocators * GetCodePageAllocators();
     PageAllocator* GetPageAllocator();
+    void RemoveFromPropertyMap(Js::PropertyId reclaimedId);
     void AddToPropertyMap(const Js::PropertyRecord * propertyRecord);
     void SetWellKnownHostTypeId(Js::TypeId typeId) { this->wellKnownHostTypeHTMLAllCollectionTypeId = typeId; }
 private:

--- a/lib/JITClient/JITManager.cpp
+++ b/lib/JITClient/JITManager.cpp
@@ -420,17 +420,16 @@ JITManager::SetWellKnownHostTypeId(
 }
 
 HRESULT
-JITManager::AddPropertyRecordArray(
+JITManager::UpdatePropertyRecordMap(
     __in intptr_t threadContextInfoAddress,
-    __in uint count,
-    __in PropertyRecordIDL ** propertyRecordArray)
+    __in UpdatedPropertysIDL * updatedProps)
 {
     Assert(IsOOPJITEnabled());
 
     HRESULT hr = E_FAIL;
     RpcTryExcept
     {
-        hr = ClientAddPropertyRecordArray(m_rpcBindingHandle, threadContextInfoAddress, count, propertyRecordArray);
+        hr = ClientUpdatePropertyRecordMap(m_rpcBindingHandle, threadContextInfoAddress, updatedProps);
     }
         RpcExcept(RpcExceptionFilter(RpcExceptionCode()))
     {

--- a/lib/JITClient/JITManager.h
+++ b/lib/JITClient/JITManager.h
@@ -26,10 +26,9 @@ public:
     HRESULT CleanupThreadContext(
         __in intptr_t threadContextInfoAddress);
 
-    HRESULT AddPropertyRecordArray(
+    HRESULT UpdatePropertyRecordMap(
         __in intptr_t threadContextInfoAddress,
-        __in unsigned int count,
-        __in PropertyRecordIDL ** propertyRecordArray);
+        __in UpdatedPropertysIDL * updatedProps);
 
     HRESULT AddDOMFastPathHelper(
         __in intptr_t scriptContextInfoAddress,

--- a/lib/JITIDL/ChakraJIT.idl
+++ b/lib/JITIDL/ChakraJIT.idl
@@ -27,11 +27,10 @@ interface IChakraJIT
         [in] handle_t binding,
         [in] CHAKRA_PTR threadContextInfoAddress);
 
-    HRESULT AddPropertyRecordArray(
+    HRESULT UpdatePropertyRecordMap(
         [in] handle_t binding,
         [in] CHAKRA_PTR threadContextInfoAddress,
-        [in] unsigned int count,
-        [in, size_is(count)] PropertyRecordIDL ** propertyRecord);
+        [in] UpdatedPropertysIDL * updatedProps);
 
     HRESULT AddDOMFastPathHelper(
         [in] handle_t binding,

--- a/lib/JITIDL/JITTypes.h
+++ b/lib/JITIDL/JITTypes.h
@@ -801,3 +801,11 @@ typedef struct JITOutputIDL
     X86_PAD4(1)
     __int64 startTime;
 } JITOutputIDL;
+
+typedef struct UpdatedPropertysIDL
+{
+    unsigned int reclaimedPropertyCount;
+    unsigned int newRecordCount;
+    [size_is(reclaimedPropertyCount)] int * reclaimedPropertyIdArray;
+    [size_is(newRecordCount)] PropertyRecordIDL ** newRecordArray;
+} UpdatedPropertysIDL;

--- a/lib/JITServer/JITServer.cpp
+++ b/lib/JITServer/JITServer.cpp
@@ -158,23 +158,28 @@ ServerCleanupThreadContext(
 }
 
 HRESULT
-ServerAddPropertyRecordArray(
+ServerUpdatePropertyRecordMap(
     /* [in] */ handle_t binding,
-    /* [in] */ intptr_t threadContextRoot,
-    /* [in] */ uint count,
-    /* [in] */ __RPC__in_ecount_full(count) PropertyRecordIDL ** propertyRecordArray)
+    /* [in] */ intptr_t threadContextInfoAddress,
+    /* [in] */ __RPC__in UpdatedPropertysIDL * updatedProps)
 {
     AUTO_NESTED_HANDLED_EXCEPTION_TYPE(static_cast<ExceptionType>(ExceptionType_OutOfMemory | ExceptionType_StackOverflow));
 
-    ServerThreadContext * threadContextInfo = (ServerThreadContext*)DecodePointer((void*)threadContextRoot);
+    ServerThreadContext * threadContextInfo = (ServerThreadContext*)DecodePointer((void*)threadContextInfoAddress);
 
     if (threadContextInfo == nullptr)
     {
         return RPC_S_INVALID_ARG;
     }
-    for (uint i = 0; i < count; ++i)
+
+    for (uint i = 0; i < updatedProps->reclaimedPropertyCount; ++i)
     {
-        threadContextInfo->AddToPropertyMap((Js::PropertyRecord *)propertyRecordArray[i]);
+        threadContextInfo->RemoveFromPropertyMap((Js::PropertyId)updatedProps->reclaimedPropertyIdArray[i]);
+    }
+
+    for (uint i = 0; i < updatedProps->newRecordCount; ++i)
+    {
+        threadContextInfo->AddToPropertyMap((Js::PropertyRecord *)updatedProps->newRecordArray[i]);
     }
 
     return S_OK;

--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -167,6 +167,7 @@ ThreadContext::ThreadContext(AllocationPolicyManager * allocationPolicyManager, 
 #if ENABLE_NATIVE_CODEGEN
     codeGenNumberThreadAllocator(nullptr),
     m_pendingJITProperties(nullptr),
+    m_reclaimedJITProperties(nullptr),
     xProcNumberPageSegmentManager(nullptr),
 #if DYNAMIC_INTERPRETER_THUNK || defined(ASMJS_PLAT)
     thunkPageAllocators(allocationPolicyManager, /* allocXData */ false, /* virtualAllocator */ nullptr, GetCurrentProcess()),
@@ -489,6 +490,11 @@ ThreadContext::~ThreadContext()
         {
             HeapDelete(this->m_pendingJITProperties);
             this->m_pendingJITProperties = nullptr;
+        }
+        if (this->m_reclaimedJITProperties != nullptr)
+        {
+            HeapDelete(this->m_reclaimedJITProperties);
+            this->m_reclaimedJITProperties = nullptr;
         }
 #endif
         // Unpin the memory for leak report so we don't report this as a leak.
@@ -919,9 +925,6 @@ void ThreadContext::InitializePropertyMaps()
     try
     {
         this->propertyMap = HeapNew(PropertyMap, &HeapAllocator::Instance, TotalNumberOfBuiltInProperties + 700);
-#if ENABLE_NATIVE_CODEGEN
-        this->m_pendingJITProperties = HeapNew(PropertyMap, &HeapAllocator::Instance, TotalNumberOfBuiltInProperties + 700);
-#endif
         this->recyclableData->boundPropertyStrings = RecyclerNew(this->recycler, JsUtil::List<Js::PropertyRecord const*>, this->recycler);
 
         memset(propertyNamesDirect, 0, 128*sizeof(Js::PropertyRecord *));
@@ -929,20 +932,6 @@ void ThreadContext::InitializePropertyMaps()
         Js::JavascriptLibrary::InitializeProperties(this);
         InitializeAdditionalProperties(this);
 
-#if ENABLE_NATIVE_CODEGEN
-        if (propertyMap->Count() > 0)
-        {
-            uint count = (uint)propertyMap->Count();
-            PropertyRecordIDL ** propArray = HeapNewArray(PropertyRecordIDL*, count);
-            auto iter = propertyMap->GetIterator();
-            while (iter.IsValid())
-            {
-                m_pendingJITProperties->Add(iter.CurrentValue());
-                iter.MoveNext();
-            }
-            HeapDeleteArray(count, propArray);
-        }
-#endif
         //Js::JavascriptLibrary::InitializeDOMProperties(this);
     }
     catch(...)
@@ -961,6 +950,11 @@ void ThreadContext::InitializePropertyMaps()
         {
             HeapDelete(this->m_pendingJITProperties);
             this->m_pendingJITProperties = nullptr;
+        }
+        if (this->m_reclaimedJITProperties != nullptr)
+        {
+            HeapDelete(this->m_reclaimedJITProperties);
+            this->m_reclaimedJITProperties = nullptr;
         }
 #endif
 
@@ -1119,9 +1113,11 @@ ThreadContext::AddPropertyRecordInternal(const Js::PropertyRecord * propertyReco
     propertyMap->Add(propertyRecord);
 
 #if ENABLE_NATIVE_CODEGEN
-    if (JITManager::GetJITManager()->IsOOPJITEnabled())
+    if (m_pendingJITProperties)
     {
+        Assert(m_reclaimedJITProperties);
         m_pendingJITProperties->Add(propertyRecord);
+        m_reclaimedJITProperties->Remove(propertyRecord->GetPropertyId());
     }
 #endif
 
@@ -1278,7 +1274,11 @@ void ThreadContext::InvalidatePropertyRecord(const Js::PropertyRecord * property
 {
     InternalInvalidateProtoTypePropertyCaches(propertyRecord->GetPropertyId());     // use the internal version so we don't check for active property id
 #if ENABLE_NATIVE_CODEGEN
-    m_pendingJITProperties->Remove(propertyRecord);
+    if (m_pendingJITProperties && !m_pendingJITProperties->Remove(propertyRecord))
+    {
+        // if it wasn't pending, that means it was already sent to the jit, so add to list that jit needs to reclaim
+        m_reclaimedJITProperties->PrependNoThrow(&HeapAllocator::Instance, propertyRecord->GetPropertyId());
+    }
 #endif
     this->propertyMap->Remove(propertyRecord);
     PropertyRecordTrace(_u("Reclaimed property '%s' at 0x%08x, pid = %d\n"),
@@ -1989,6 +1989,9 @@ ThreadContext::EnsureJITThreadContext(bool allowPrereserveAlloc)
 #if _M_IX86 || _M_AMD64
     contextData.simdTempAreaBaseAddr = (intptr_t)GetSimdTempArea();
 #endif
+
+    m_reclaimedJITProperties = HeapNew(PropertyList, &HeapAllocator::Instance);
+    m_pendingJITProperties = propertyMap->Clone();
 
     JITManager::GetJITManager()->InitializeThreadContext(&contextData, &m_remoteThreadContextInfo, &m_prereservedRegionAddr);
 }

--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -920,7 +920,7 @@ void ThreadContext::InitializePropertyMaps()
     {
         this->propertyMap = HeapNew(PropertyMap, &HeapAllocator::Instance, TotalNumberOfBuiltInProperties + 700);
 #if ENABLE_NATIVE_CODEGEN
-        this->m_pendingJITProperties = HeapNew(PropertyList, &HeapAllocator::Instance);
+        this->m_pendingJITProperties = HeapNew(PropertyMap, &HeapAllocator::Instance, TotalNumberOfBuiltInProperties + 700);
 #endif
         this->recyclableData->boundPropertyStrings = RecyclerNew(this->recycler, JsUtil::List<Js::PropertyRecord const*>, this->recycler);
 
@@ -1277,9 +1277,10 @@ bool ThreadContext::IsActivePropertyId(Js::PropertyId pid)
 void ThreadContext::InvalidatePropertyRecord(const Js::PropertyRecord * propertyRecord)
 {
     InternalInvalidateProtoTypePropertyCaches(propertyRecord->GetPropertyId());     // use the internal version so we don't check for active property id
-
+#if ENABLE_NATIVE_CODEGEN
+    m_pendingJITProperties->Remove(propertyRecord);
+#endif
     this->propertyMap->Remove(propertyRecord);
-
     PropertyRecordTrace(_u("Reclaimed property '%s' at 0x%08x, pid = %d\n"),
         propertyRecord->GetBuffer(), propertyRecord, propertyRecord->GetPropertyId());
 }

--- a/lib/Runtime/Base/ThreadContext.h
+++ b/lib/Runtime/Base/ThreadContext.h
@@ -530,16 +530,15 @@ public:
     typedef JsUtil::BaseDictionary<Js::PropertyId, TypeHashSet *, Recycler, PowerOf2SizePolicy> PropertyIdToTypeHashSetDictionary;
     typedef JsUtil::WeaklyReferencedKeyDictionary<const Js::PropertyRecord, PropertyGuardEntry*, Js::PropertyRecordPointerComparer> PropertyGuardDictionary;
 
-    typedef JsUtil::List<const Js::PropertyRecord *, HeapAllocator> PropertyList;
 private:
     intptr_t m_remoteThreadContextInfo;
     intptr_t m_prereservedRegionAddr;
 
 #if ENABLE_NATIVE_CODEGEN
-    PropertyList * m_pendingJITProperties;
+    PropertyMap * m_pendingJITProperties;
 public:
 
-    PropertyList * GetPendingJITProperties() const
+    PropertyMap * GetPendingJITProperties() const
     {
         return m_pendingJITProperties;
     }

--- a/lib/Runtime/Base/ThreadContext.h
+++ b/lib/Runtime/Base/ThreadContext.h
@@ -524,6 +524,8 @@ public:
         Js::PropertyRecordStringHashComparer, JsUtil::SimpleHashedEntry, JsUtil::AsymetricResizeLock> PropertyMap;
     PropertyMap * propertyMap;
 
+    typedef SListCounted<Js::PropertyId, HeapAllocator> PropertyList;
+
     typedef JsUtil::BaseHashSet<Js::CaseInvariantPropertyListWithHashCode*, Recycler, PowerOf2SizePolicy, Js::CaseInvariantPropertyListWithHashCode*, JsUtil::NoCaseComparer, JsUtil::SimpleDictionaryEntry>
         PropertyNoCaseSetType;
     typedef JsUtil::WeaklyReferencedKeyDictionary<Js::Type, bool> TypeHashSet;
@@ -536,7 +538,13 @@ private:
 
 #if ENABLE_NATIVE_CODEGEN
     PropertyMap * m_pendingJITProperties;
+    PropertyList  * m_reclaimedJITProperties;
 public:
+
+    PropertyList * GetReclaimedJITProperties() const
+    {
+        return m_reclaimedJITProperties;
+    }
 
     PropertyMap * GetPendingJITProperties() const
     {


### PR DESCRIPTION
when property records were reclaimed we should remove them from list of pending jit property records.
when reclaimed property later has pid reused, we should first delete the old record on the server map before adding new one.