### PR TITLE
OS8600339:Add EnclosedByGlobalFunc to debug assertion in ByteCodeSerializer.cpp

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeSerializer.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeSerializer.cpp
@@ -2233,8 +2233,9 @@ public:
                   | FunctionInfo::Attributes::CapturesThis
                   | FunctionInfo::Attributes::Generator
                   | FunctionInfo::Attributes::ClassConstructor
-                  | FunctionInfo::Attributes::ClassMethod)) == 0,
-                "Only the ErrorOnNew|SuperReference|Lambda|CapturesThis|Generator|ClassConstructor|Async|ClassMember attributes should be set on a serialized function");
+                  | FunctionInfo::Attributes::ClassMethod
+                  | FunctionInfo::Attributes::EnclosedByGlobalFunc)) == 0,
+                "Only the ErrorOnNew|SuperReference|Lambda|CapturesThis|Generator|ClassConstructor|Async|ClassMember|EnclosedByGlobalFunc attributes should be set on a serialized function");
 
         PrependInt32(builder, _u("Offset Into Source"), sourceDiff);
         if (function->GetNestedCount() > 0)

--- a/test/es6/OS_8600339.js
+++ b/test/es6/OS_8600339.js
@@ -1,0 +1,7 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+e=>0;  // bug repro: assert in ByteCodeSerializer.cpp
+print('Pass');

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -1324,6 +1324,13 @@
 </test>
 <test>
   <default>
+    <files>OS_8600339.js</files>
+    <compile-flags>-forceserialized</compile-flags>
+    <tags>exclude_dynapogo</tags>
+  </default>
+</test>
+<test>
+  <default>
     <files>iteratorclose.js</files>
     <compile-flags>-off:deferparse -args summary -endargs</compile-flags>
   </default>


### PR DESCRIPTION
EnclosedByGlobalFunc is not being recognized by following assertion

        AssertMsg((function->GetAttributes() &
                ~(FunctionInfo::Attributes::ErrorOnNew
                  | FunctionInfo::Attributes::SuperReference
                  | FunctionInfo::Attributes::Lambda
                  | FunctionInfo::Attributes::Async
                  ...

in ByteCodeSerializer.cpp

Fix by adding EnclosedByGlobalFunc to the assertion.
