### PR TITLE
Issue#1586: Out of stack when calling super.<method>.apply

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -10606,7 +10606,15 @@ void Emit(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator, FuncInfo *func
             uint cacheId = funcInfo->FindOrAddInlineCacheId(callObjLocation, propertyId, false, false);
             if (pnode->IsCallApplyTargetLoad())
             {
-                byteCodeGenerator->Writer()->PatchableProperty(Js::OpCode::LdFldForCallApplyTarget, pnode->location, protoLocation, cacheId);
+                if (pnode->sxBin.pnode1->nop == knopSuper)
+                {
+                    Js::RegSlot tmpReg = byteCodeGenerator->EmitLdObjProto(Js::OpCode::LdHomeObjProto, funcInfo->superRegister, funcInfo);
+                    byteCodeGenerator->Writer()->PatchableProperty(Js::OpCode::LdFldForCallApplyTarget, pnode->location, tmpReg, cacheId);
+                }
+                else
+                {
+                    byteCodeGenerator->Writer()->PatchableProperty(Js::OpCode::LdFldForCallApplyTarget, pnode->location, protoLocation, cacheId);
+                }
             }
             else
             {

--- a/test/es6/classes_bugfixes.js
+++ b/test/es6/classes_bugfixes.js
@@ -326,6 +326,30 @@ var tests = [
         new class0("cat", 100, {});
     }
   },
+  {
+    name: "Issue1586: Out of stack for super.<method>.apply and super.<method>.call",
+    body: function () {
+        class A {
+            m() { return 'A'; }
+            m1() { return 'A1'; }
+            static n() { return 'B'; }
+            static n1() { return 'B1'; }
+        }
+
+        class B extends A {
+            m() { return super.m.apply(this); }
+            m1() { return super.m1.call(this); }
+            static n() { return super.n.apply(this); }
+            static n1() { return super.n1.apply(this); }
+        }
+
+        var b = new B();
+        assert.areEqual('A', b.m(), "method.apply()");
+        assert.areEqual('A1', b.m1(), "method.call()");
+        assert.areEqual('B', B.n(), "static method.apply()");
+        assert.areEqual('B1', B.n1(), "static method.call()");
+    }
+  },
 ];
 
 testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });


### PR DESCRIPTION
Bytecode 'LdHomeObjProto' missing for super.\<method\>.apply() calls.
Fix by adding missing bytecode.
