### PR TITLE
It is pointless to check program name itself (argv[0]) against flags.

### DIFF
--- a/bin/ch/ch.cpp
+++ b/bin/ch/ch.cpp
@@ -755,8 +755,8 @@ int _cdecl wmain(int argc, __in_ecount(argc) LPWSTR argv[])
     }
 #endif
 
-    int cpos = 0;
-    for(int i = 0; i < argc; ++i)
+    int cpos = 1;
+    for(int i = 1; i < argc; ++i)
     {
         if(wcsstr(argv[i], _u("-TTRecord=")) == argv[i])
         {


### PR DESCRIPTION
AFAIK in every platform first parameter in argv will be program name itself, so it is pointless to check program name itself to flags. 