### PR TITLE
JsRT Debugging: Port 2 commits from master to release/1.3

### DIFF
--- a/lib/Jsrt/JsrtDebuggerObject.cpp
+++ b/lib/Jsrt/JsrtDebuggerObject.cpp
@@ -219,21 +219,15 @@ bool JsrtDebuggerObjectsManager::TryGetDataFromDataToDebuggerObjectsDictionary(v
 JsrtDebuggerStackFrame::JsrtDebuggerStackFrame(JsrtDebuggerObjectsManager * debuggerObjectsManager, Js::DiagStackFrame * stackFrame, uint frameIndex) :
     debuggerObjectsManager(debuggerObjectsManager),
     frameIndex(frameIndex),
-    stackFrame(stackFrame),
-    pObjectModelWalker(nullptr)
+    stackFrame(stackFrame)
 {
     Assert(this->stackFrame != nullptr);
 }
 
 JsrtDebuggerStackFrame::~JsrtDebuggerStackFrame()
 {
+    this->debuggerObjectsManager = nullptr;
     this->stackFrame = nullptr;
-
-    if (this->pObjectModelWalker != nullptr)
-    {
-        HeapDelete(this->pObjectModelWalker);
-        this->pObjectModelWalker = nullptr;
-    }
 }
 
 Js::DynamicObject * JsrtDebuggerStackFrame::GetJSONObject(Js::ScriptContext* scriptContext)
@@ -295,18 +289,13 @@ Js::DynamicObject * JsrtDebuggerStackFrame::GetLocalsObject(Js::ScriptContext* s
 
     Js::DynamicObject* globalsObject = nullptr;
 
-    if (this->pObjectModelWalker != nullptr)
-    {
-        HeapDelete(this->pObjectModelWalker);
-    }
-
     ReferencedArenaAdapter* pRefArena = scriptContext->GetThreadContext()->GetDebugManager()->GetDiagnosticArena();
     Js::IDiagObjectModelDisplay* pLocalsDisplay = Anew(pRefArena->Arena(), Js::LocalsDisplay, this->stackFrame);
-    this->pObjectModelWalker = pLocalsDisplay->CreateWalker();
+    WeakArenaReference<Js::IDiagObjectModelWalkerBase>* objectModelWalker = pLocalsDisplay->CreateWalker();
 
-    if (this->pObjectModelWalker != nullptr)
+    if (objectModelWalker != nullptr)
     {
-        Js::LocalsWalker* localsWalker = (Js::LocalsWalker*)this->pObjectModelWalker->GetStrongReference();
+        Js::LocalsWalker* localsWalker = (Js::LocalsWalker*)objectModelWalker->GetStrongReference();
 
         if (localsWalker != nullptr)
         {
@@ -433,7 +422,8 @@ Js::DynamicObject * JsrtDebuggerStackFrame::GetLocalsObject(Js::ScriptContext* s
                 }
             }
 
-            this->pObjectModelWalker->ReleaseStrongReference();
+            objectModelWalker->ReleaseStrongReference();
+            HeapDelete(objectModelWalker);
         }
 
         Adelete(pRefArena->Arena(), pLocalsDisplay);
@@ -787,10 +777,8 @@ JsrtDebugStackFrames::~JsrtDebugStackFrames()
 {
     if (this->framesDictionary != nullptr)
     {
-        this->framesDictionary->Map([this](uint handle, JsrtDebuggerStackFrame* debuggerStackFrame) {
-            Adelete(this->jsrtDebugManager->GetDebugObjectArena(), debuggerStackFrame);
-        });
-        this->framesDictionary->Clear();
+        this->ClearFrameDictionary();
+        Adelete(this->jsrtDebugManager->GetDebugObjectArena(), this->framesDictionary);
         this->framesDictionary = nullptr;
     }
 }
@@ -826,7 +814,7 @@ Js::JavascriptArray * JsrtDebugStackFrames::StackFrames(Js::ScriptContext * scri
         }
         else
         {
-            this->framesDictionary->Clear();
+            this->ClearFrameDictionary();
         }
 
         typedef JsUtil::List<Js::DiagStackFrame*, ArenaAllocator> DiagStackFrameList;
@@ -898,4 +886,15 @@ Js::DynamicObject * JsrtDebugStackFrames::GetStackFrame(Js::DiagStackFrame * sta
     this->framesDictionary->Add(frameIndex, debuggerStackFrame);
 
     return debuggerStackFrame->GetJSONObject(stackFrame->GetScriptContext());
+}
+
+void JsrtDebugStackFrames::ClearFrameDictionary()
+{
+    if (this->framesDictionary != nullptr)
+    {
+        this->framesDictionary->Map([this](uint handle, JsrtDebuggerStackFrame* debuggerStackFrame) {
+            Adelete(this->jsrtDebugManager->GetDebugObjectArena(), debuggerStackFrame);
+        });
+        this->framesDictionary->Clear();
+    }
 }

--- a/lib/Jsrt/JsrtDebuggerObject.cpp
+++ b/lib/Jsrt/JsrtDebuggerObject.cpp
@@ -494,7 +494,7 @@ bool JsrtDebuggerStackFrame::Evaluate(Js::ScriptContext* scriptContext, const ch
 
         if (resolvedObject.obj != nullptr)
         {
-            resolvedObject.scriptContext = scriptContext;
+            resolvedObject.scriptContext = frameScriptContext;
 
             charcount_t len = Js::JavascriptString::GetBufferLength(source);
             resolvedObject.name = AnewNoThrowArray(this->debuggerObjectsManager->GetDebugObjectArena(), WCHAR, len + 1);

--- a/lib/Jsrt/JsrtDebuggerObject.h
+++ b/lib/Jsrt/JsrtDebuggerObject.h
@@ -126,7 +126,6 @@ public:
 private:
     uint frameIndex;
     Js::DiagStackFrame* stackFrame;
-    WeakArenaReference<Js::IDiagObjectModelWalkerBase>* pObjectModelWalker;
     JsrtDebuggerObjectsManager * debuggerObjectsManager;
 };
 
@@ -143,6 +142,7 @@ private:
 
     typedef JsUtil::BaseDictionary<uint, JsrtDebuggerStackFrame*, ArenaAllocator> FramesDictionary;
     FramesDictionary* framesDictionary;
+    void ClearFrameDictionary();
 };
 
 // Class managing objects we give to debugger, it maintains various mappings


### PR DESCRIPTION
During evaluate resolvedObject scriptcontext should be the frame scriptcontext 6099399320f24b03dc3b3e01bbb49919b3faac85
Fix a memory leak in JsRT debugging where we were not deleting weak ref of locals display 8b0df4d8df7d09699b95dacfdfce82f793c3e664