### PR TITLE
Replace AddrOpnd with IntConstOpnd for 64-bit immediates

### DIFF
--- a/lib/Backend/Func.h
+++ b/lib/Backend/Func.h
@@ -897,7 +897,7 @@ public:
     }
 
     IR::Instr * GetFunctionEntryInsertionPoint();
-    IR::IndirOpnd * GetConstantAddressIndirOpnd(intptr_t address, IR::AddrOpndKind kind, IRType type, Js::OpCode loadOpCode);
+    IR::IndirOpnd * GetConstantAddressIndirOpnd(intptr_t address, IR::Opnd *largeConstOpnd, IR::AddrOpndKind kind, IRType type, Js::OpCode loadOpCode);
     void MarkConstantAddressSyms(BVSparse<JitArenaAllocator> * bv);
     void DisableConstandAddressLoadHoist() { canHoistConstantAddressLoad = false; }
 

--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -21452,7 +21452,7 @@ GlobOpt::EmitMemop(Loop * loop, LoopCount *loopCount, const MemOpEmitData* emitD
         }
         else
         {
-            src1 = IR::AddrOpnd::New(candidate->constant.ToVar(localFunc), IR::AddrOpndKindConstant, localFunc);
+            src1 = IR::AddrOpnd::New(candidate->constant.ToVar(localFunc), IR::AddrOpndKindConstantAddress, localFunc);
         }
     }
     else

--- a/lib/Backend/IR.cpp
+++ b/lib/Backend/IR.cpp
@@ -2428,7 +2428,8 @@ Instr::HoistMemRefAddress(MemRefOpnd *const memRefOpnd, const Js::OpCode loadOpC
     intptr_t address = memRefOpnd->GetMemLoc();
     IR::AddrOpndKind kind = memRefOpnd->GetAddrKind();
     Func *const func = m_func;
-    IR::IndirOpnd * indirOpnd = func->GetTopFunc()->GetConstantAddressIndirOpnd(address, kind, memRefOpnd->GetType(), loadOpCode);
+    IR::AddrOpnd * addrOpnd = IR::AddrOpnd::New(address, kind, this->m_func, true);
+    IR::IndirOpnd * indirOpnd = func->GetTopFunc()->GetConstantAddressIndirOpnd(address, addrOpnd, kind, memRefOpnd->GetType(), loadOpCode);
 
     if (indirOpnd == nullptr)
     {

--- a/lib/Backend/IRBuilder.cpp
+++ b/lib/Backend/IRBuilder.cpp
@@ -3812,7 +3812,7 @@ IRBuilder::BuildElementSlotI2(Js::OpCode newOpcode, uint32 offset, Js::RegSlot r
         case Js::OpCode::StModuleSlot:
         {
             Js::Var* moduleExportVarArrayAddr = Js::JavascriptOperators::OP_GetModuleExportSlotArrayAddress(slotId1, slotId2, m_func->GetScriptContextInfo());
-            IR::AddrOpnd* addrOpnd = IR::AddrOpnd::New(moduleExportVarArrayAddr, IR::AddrOpndKindConstant, m_func, true);
+            IR::AddrOpnd* addrOpnd = IR::AddrOpnd::New(moduleExportVarArrayAddr, IR::AddrOpndKindConstantAddress, m_func, true);
             regOpnd = IR::RegOpnd::New(TyVar, m_func);
             instr = IR::Instr::New(Js::OpCode::Ld_A, regOpnd, addrOpnd, m_func);
             this->AddInstr(instr, offset);

--- a/lib/Backend/Inline.cpp
+++ b/lib/Backend/Inline.cpp
@@ -4927,7 +4927,7 @@ Inline::SetupInlineeFrame(Func *inlinee, IR::Instr *inlineeStart, Js::ArgSlot ac
     };
 
     IR::Opnd *srcs[Js::Constants::InlineeMetaArgCount] = {
-        IR::AddrOpnd::New((Js::Var)actualCount, IR::AddrOpndKindConstant, inlinee, true /*dontEncode*/),
+        IR::IntConstOpnd::New(actualCount, TyInt16, inlinee, true /*dontEncode*/),
 
         /*
          * Don't initialize this slot with the function object yet. In compat mode we evaluate

--- a/lib/Backend/LowerMDShared.cpp
+++ b/lib/Backend/LowerMDShared.cpp
@@ -1289,7 +1289,7 @@ LowererMD::Legalize(IR::Instr *const instr, bool fPostRegAlloc)
 {
     Assert(instr);
     Assert(!instr->isInlineeEntryInstr
-        || (instr->m_opcode == Js::OpCode::MOV && instr->GetSrc1()->IsAddrOpnd()));
+        || (instr->m_opcode == Js::OpCode::MOV && instr->GetSrc1()->IsIntConstOpnd()));
 
     switch(instr->m_opcode)
     {
@@ -1879,6 +1879,26 @@ void LowererMD::LegalizeDst(IR::Instr *const instr, const uint forms)
     }
 }
 
+bool LowererMD::HoistLargeConstant(IR::IndirOpnd *indirOpnd, IR::Opnd *src, IR::Instr *instr) {
+        if (indirOpnd != nullptr)
+        {
+            if (indirOpnd->GetOffset() == 0)
+            {
+                instr->ReplaceSrc(src, indirOpnd->GetBaseOpnd());
+            }
+            else
+            {
+                // Hoist the address load as LEA [reg + offset]
+                // with the reg = MOV <some address within 32-bit range at the start of the function
+                IR::RegOpnd * regOpnd = IR::RegOpnd::New(TyMachPtr, instr->m_func);
+                Lowerer::InsertLea(regOpnd, indirOpnd, instr);
+                instr->ReplaceSrc(src, regOpnd);
+            }
+            return true;
+        }
+        return false;
+}
+
 template <bool verify>
 void LowererMD::LegalizeSrc(IR::Instr *const instr, IR::Opnd *src, const uint forms)
 {
@@ -1895,13 +1915,39 @@ void LowererMD::LegalizeSrc(IR::Instr *const instr, IR::Opnd *src, const uint fo
             return;
 
         case IR::OpndKindIntConst:
-            Assert(!instr->isInlineeEntryInstr);
-            if(forms & L_Imm32)
+            if(forms & L_Ptr)
             {
                 return;
             }
+#ifdef _M_X64
+            {
+                IR::IntConstOpnd * intOpnd = src->AsIntConstOpnd();
+                if ((forms & L_Imm32) && ((TySize[intOpnd->GetType()] != 8) ||
+                    (!instr->isInlineeEntryInstr && Math::FitsInDWord(intOpnd->GetValue()))))
+                {
+                    // the constant fits in 32-bit, no need to hoist
+                    return;
+                }
+                if (verify)
+                {
+                    AssertMsg(false, "Missing legalization");
+                    return;
+                }
+                // The actual value for inlinee entry instr isn't determined until encoder
+                // So it need to be hoisted conventionally.
+                if (!instr->isInlineeEntryInstr)
+                {
+                    Assert(forms & L_Reg);
+                    IR::IntConstOpnd * newIntOpnd = IR::IntConstOpnd::New(intOpnd->GetValue(), intOpnd->GetType(), instr->m_func, true);
+                    IR::IndirOpnd * indirOpnd = instr->m_func->GetTopFunc()->GetConstantAddressIndirOpnd(intOpnd->GetValue(), newIntOpnd, IR::AddrOpndKindConstantAddress, TyMachPtr, Js::OpCode::MOV);
+                    if (HoistLargeConstant(indirOpnd, src, instr))
+                    {
+                        return;
+                    }
+                }
+            }
+#endif
             break;
-
         case IR::OpndKindFloatConst:
             break; // assume for now that it always needs to be hoisted
 
@@ -1925,29 +1971,14 @@ void LowererMD::LegalizeSrc(IR::Instr *const instr, IR::Opnd *src, const uint fo
                     return;
                 }
 
-                // The actual value for inlinee entry instr isn't determined until encoder
-                // So it need to be hoisted conventionally.
-                if (!instr->isInlineeEntryInstr)
+                Assert(!instr->isInlineeEntryInstr);
+                Assert(forms & L_Reg);
+                // TODO: michhol, remove cast after making m_address intptr
+                IR::AddrOpnd * newAddrOpnd = IR::AddrOpnd::New(addrOpnd->m_address, addrOpnd->GetAddrOpndKind(), instr->m_func, true);
+                IR::IndirOpnd * indirOpnd = instr->m_func->GetTopFunc()->GetConstantAddressIndirOpnd((intptr_t)addrOpnd->m_address, newAddrOpnd, addrOpnd->GetAddrOpndKind(), TyMachPtr, Js::OpCode::MOV);
+                if (HoistLargeConstant(indirOpnd, src, instr))
                 {
-                    Assert(forms & L_Reg);
-                    // TODO: michhol, remove cast after making m_address intptr
-                    IR::IndirOpnd * indirOpnd = instr->m_func->GetTopFunc()->GetConstantAddressIndirOpnd((intptr_t)addrOpnd->m_address, addrOpnd->GetAddrOpndKind(), TyMachPtr, Js::OpCode::MOV);
-                    if (indirOpnd != nullptr)
-                    {
-                        if (indirOpnd->GetOffset() == 0)
-                        {
-                            instr->ReplaceSrc(src, indirOpnd->GetBaseOpnd());
-                        }
-                        else
-                        {
-                            // Hoist the address load as LEA [reg + offset]
-                            // with the reg = MOV <some address within 32-bit range at the start of the function
-                            IR::RegOpnd * regOpnd = IR::RegOpnd::New(TyMachPtr, instr->m_func);
-                            Lowerer::InsertLea(regOpnd, indirOpnd, instr);
-                            instr->ReplaceSrc(src, regOpnd);
-                        }
-                        return;
-                    }
+                    return;
                 }
             }
 #endif
@@ -4503,7 +4534,7 @@ LowererMD::GenerateLoadPolymorphicInlineCacheSlot(IR::Instr * instrLdSt, IR::Reg
     Assert(rightShiftAmount > leftShiftAmount);
     instr = IR::Instr::New(Js::OpCode::SHR, opndOffset, opndOffset, IR::IntConstOpnd::New(rightShiftAmount - leftShiftAmount, TyUint8, instrLdSt->m_func, true), instrLdSt->m_func);
     instrLdSt->InsertBefore(instr);
-    instr = IR::Instr::New(Js::OpCode::AND, opndOffset, opndOffset, IR::AddrOpnd::New((void*)((__int64)(polymorphicInlineCacheSize - 1) << leftShiftAmount), IR::AddrOpndKindConstant, instrLdSt->m_func, true), instrLdSt->m_func);
+    instr = IR::Instr::New(Js::OpCode::AND, opndOffset, opndOffset, IR::IntConstOpnd::New(((__int64)(polymorphicInlineCacheSize - 1) << leftShiftAmount), TyMachReg, instrLdSt->m_func, true), instrLdSt->m_func);
     instrLdSt->InsertBefore(instr);
 
     // LEA inlineCache, [inlineCache + r1]
@@ -5488,7 +5519,7 @@ LowererMD::GenerateFastAbs(IR::Opnd *dst, IR::Opnd *src, IR::Instr *callInstr, I
 
         // Unconditionally set the sign bit. This will get XORd away when we remove the tag.
         // dst64 = OR 0x8000000000000000
-        insertInstr->InsertBefore(IR::Instr::New(Js::OpCode::OR, dst, dst, IR::AddrOpnd::New((void *)MachSignBit, IR::AddrOpndKindConstant, this->m_func), this->m_func));
+        insertInstr->InsertBefore(IR::Instr::New(Js::OpCode::OR, dst, dst, IR::IntConstOpnd::New(MachSignBit, TyMachReg, this->m_func), this->m_func));
 #endif
     }
     else if(!isInt)
@@ -7687,7 +7718,7 @@ void LowererMD::ConvertFloatToInt32(IR::Opnd* intOpnd, IR::Opnd* floatOpnd, IR::
         // CMP dst, 0x80000000 {0x8000000000000000 on x64}    -- Check for overflow
         instr = IR::Instr::New(Js::OpCode::CMP, this->m_func);
         instr->SetSrc1(dstOpnd);
-        instr->SetSrc2(IR::AddrOpnd::New((Js::Var)MachSignBit, IR::AddrOpndKindConstant, this->m_func, true));
+        instr->SetSrc2(IR::IntConstOpnd::New(MachSignBit, TyMachReg, this->m_func, true));
         instInsert->InsertBefore(instr);
         Legalize(instr);
 

--- a/lib/Backend/LowerMDShared.h
+++ b/lib/Backend/LowerMDShared.h
@@ -118,6 +118,7 @@ private:
             static void     LegalizeSrc(IR::Instr *const instr, IR::Opnd *src, const uint forms);
             template <bool verify = false>
             static void     MakeDstEquSrc1(IR::Instr *const instr);
+            static bool     HoistLargeConstant(IR::IndirOpnd *indirOpnd, IR::Opnd *src, IR::Instr *instr);
 public:
             IR::Instr *     GenerateSmIntPairTest(IR::Instr * instrInsert, IR::Opnd * opndSrc1, IR::Opnd * opndSrc2, IR::LabelInstr * labelFail);
             void            GenerateSmIntTest(IR::Opnd *opndSrc, IR::Instr *instrInsert, IR::LabelInstr *labelHelper, IR::Instr **instrFirst = nullptr, bool fContinueLabel = false);

--- a/lib/Backend/Opnd.cpp
+++ b/lib/Backend/Opnd.cpp
@@ -1990,7 +1990,7 @@ AddrOpnd::NewFromNumberVar(double value, Func *func, bool dontEncode /* = false 
 AddrOpnd *
 AddrOpnd::NewNull(Func *func)
 {
-    return AddrOpnd::New((Js::Var)0, AddrOpndKindConstant, func, true);
+    return AddrOpnd::New((Js::Var)0, AddrOpndKindConstantAddress, func, true);
 }
 
 ///----------------------------------------------------------------------------
@@ -3161,7 +3161,7 @@ Opnd::GetAddrDescription(__out_ecount(count) char16 *const description, const si
     {
         switch (addressKind)
         {
-        case IR::AddrOpndKindConstant:
+        case IR::AddrOpndKindConstantAddress:
         {
 #ifdef _M_X64_OR_ARM64
             char16 const * format = _u("0x%012I64X");

--- a/lib/Backend/Opnd.h
+++ b/lib/Backend/Opnd.h
@@ -41,9 +41,8 @@ enum OpndKind : BYTE {
 enum AddrOpndKind : BYTE {
     // The following address kinds are safe for relocatable JIT and regular
     // JIT
-    AddrOpndKindConstant,
+    AddrOpndKindConstantAddress,
     AddrOpndKindConstantVar, // a constant var value (null or tagged int)
-
     // NOTE: None of the following address kinds should be generated directly
     // or you WILL break relocatable JIT code. Each kind has a helper that
     // will generate correct code for relocatable code & non-relocatable code.

--- a/lib/Backend/Security.cpp
+++ b/lib/Backend/Security.cpp
@@ -426,7 +426,7 @@ Security::EncodeAddress(IR::Instr *instr, IR::Opnd *opnd, size_t value, IR::RegO
     instrNew = LowererMD::CreateAssign(regOpnd, opnd, instr);
 
     size_t cookie = (size_t)Math::Rand();
-    IR::AddrOpnd *cookieOpnd = IR::AddrOpnd::New((Js::Var)cookie, IR::AddrOpndKindConstant, instr->m_func);
+    IR::IntConstOpnd *cookieOpnd = IR::IntConstOpnd::New(cookie, TyMachReg, instr->m_func);
     instrNew = IR::Instr::New(Js::OpCode::XOR, regOpnd, regOpnd, cookieOpnd, instr->m_func);
     instr->InsertBefore(instrNew);
     LowererMD::Legalize(instrNew);

--- a/lib/Backend/amd64/EncoderMD.cpp
+++ b/lib/Backend/amd64/EncoderMD.cpp
@@ -1657,17 +1657,17 @@ void
 EncoderMD::EncodeInlineeCallInfo(IR::Instr *instr, uint32 codeOffset)
 {
     Assert(instr->GetSrc1() &&
-        instr->GetSrc1()->IsAddrOpnd() &&
-        (instr->GetSrc1()->AsAddrOpnd()->m_address == (Js::Var)((size_t)instr->GetSrc1()->AsAddrOpnd()->m_address & 0xF)));
-    Js::Var inlineeCallInfo = 0;
+        instr->GetSrc1()->IsIntConstOpnd() &&
+        (instr->GetSrc1()->AsIntConstOpnd()->GetValue() == (instr->GetSrc1()->AsIntConstOpnd()->GetValue() & 0xF)));
+    intptr_t inlineeCallInfo = 0;
     // 60 (AMD64) bits on the InlineeCallInfo to store the
     // offset of the start of the inlinee. We shouldn't have gotten here with more arguments
     // than can fit in as many bits.
     const bool encodeResult = Js::InlineeCallInfo::Encode(inlineeCallInfo,
-        ::Math::PointerCastToIntegral<uint32>(instr->GetSrc1()->AsAddrOpnd()->m_address), codeOffset);
+        instr->GetSrc1()->AsIntConstOpnd()->GetValue(), codeOffset);
     Assert(encodeResult);
 
-    instr->GetSrc1()->AsAddrOpnd()->m_address = inlineeCallInfo;
+    instr->GetSrc1()->AsIntConstOpnd()->SetValue(inlineeCallInfo);
 }
 
 bool EncoderMD::TryConstFold(IR::Instr *instr, IR::RegOpnd *regOpnd)

--- a/lib/Backend/amd64/LowererMDArch.cpp
+++ b/lib/Backend/amd64/LowererMDArch.cpp
@@ -1800,7 +1800,7 @@ LowererMDArch::GeneratePrologueStackProbe(IR::Instr *entryInstr, IntConstType fr
         }
 
         instr = IR::Instr::New(Js::OpCode::ADD, stackLimitOpnd, stackLimitOpnd,
-                               IR::AddrOpnd::New((void*)frameSize, IR::AddrOpndKindConstant, this->m_func), this->m_func);
+                               IR::IntConstOpnd::New(frameSize, TyMachReg, this->m_func), this->m_func);
         insertInstr->InsertBefore(instr);
 
         if (doInterruptProbe)
@@ -1814,7 +1814,7 @@ LowererMDArch::GeneratePrologueStackProbe(IR::Instr *entryInstr, IntConstType fr
     {
         // TODO: michhol, check this math
         size_t scriptStackLimit = m_func->GetThreadContextInfo()->GetScriptStackLimit();
-        this->lowererMD->CreateAssign(stackLimitOpnd, IR::AddrOpnd::New((void *)(frameSize + scriptStackLimit), IR::AddrOpndKindConstant, this->m_func), insertInstr);
+        this->lowererMD->CreateAssign(stackLimitOpnd, IR::IntConstOpnd::New((frameSize + scriptStackLimit), TyMachReg, this->m_func), insertInstr);
     }
 
     // CMP rsp, rax
@@ -1858,7 +1858,7 @@ LowererMDArch::GeneratePrologueStackProbe(IR::Instr *entryInstr, IntConstType fr
         // MOV RegArg0, frameSize
         this->lowererMD->CreateAssign(
             IR::RegOpnd::New(nullptr, RegArg0, TyMachReg, this->m_func),
-            IR::AddrOpnd::New((void*)frameSize, IR::AddrOpndKindConstant, this->m_func), insertInstr);
+            IR::IntConstOpnd::New(frameSize, TyMachReg, this->m_func), insertInstr);
 
         // MOV rax, ThreadContext::ProbeCurrentStack
         target = IR::RegOpnd::New(nullptr, RegRAX, TyMachReg, m_func);
@@ -2706,8 +2706,8 @@ LowererMDArch::LoadCheckedFloat(IR::RegOpnd *opndOrig, IR::RegOpnd *opndFloat, I
     IR::Instr   *xorTag      = IR::Instr::New(Js::OpCode::XOR,
                                               s2,
                                               s2,
-                                              IR::AddrOpnd::New((Js::Var)Js::FloatTag_Value,
-                                                                IR::AddrOpndKindConstantVar,
+                                              IR::IntConstOpnd::New(Js::FloatTag_Value,
+                                                                TyMachReg,
                                                                 this->m_func,
                                                                 /* dontEncode = */ true),
                                               this->m_func);

--- a/lib/Backend/arm/EncoderMD.cpp
+++ b/lib/Backend/arm/EncoderMD.cpp
@@ -1918,7 +1918,7 @@ EncoderMD::Encode(IR::Instr *instr, BYTE *pc, BYTE* beginCodeAddress)
         {
             if (instr->isInlineeEntryInstr)
             {
-                Js::Var inlineeCallInfo = 0;
+                intptr_t inlineeCallInfo = 0;
                 const bool encodeResult = Js::InlineeCallInfo::Encode(inlineeCallInfo, instr->AsLabelInstr()->GetOffset(), m_pc - m_encoder->m_encodeBuffer);
                 Assert(encodeResult);
                 //We are re-using offset to save the inlineeCallInfo which will be patched in ApplyRelocs

--- a/lib/Backend/i386/EncoderMD.cpp
+++ b/lib/Backend/i386/EncoderMD.cpp
@@ -1503,17 +1503,17 @@ EncoderMD::EncodeInlineeCallInfo(IR::Instr *instr, uint32 codeOffset)
             instr->GetDst()->AsSymOpnd()->m_sym->AsStackSym()->m_isInlinedArgSlot);
 
     Assert(instr->GetSrc1() &&
-        instr->GetSrc1()->IsAddrOpnd() &&
-        (instr->GetSrc1()->AsAddrOpnd()->m_address == (Js::Var)((size_t)instr->GetSrc1()->AsAddrOpnd()->m_address & 0xF)));
+        instr->GetSrc1()->IsIntConstOpnd() &&
+        (instr->GetSrc1()->AsIntConstOpnd()->GetValue() == (instr->GetSrc1()->AsIntConstOpnd()->GetValue() & 0xF)));
 
-    Js::Var inlineeCallInfo = 0;
+    intptr_t inlineeCallInfo = 0;
     // 28 (x86) bits on the InlineeCallInfo to store the
     // offset of the start of the inlinee. We shouldn't have gotten here with more arguments
     // than can fit in as many bits.
-    const bool encodeResult = Js::InlineeCallInfo::Encode(inlineeCallInfo, (uint32)instr->GetSrc1()->AsAddrOpnd()->m_address, codeOffset);
+    const bool encodeResult = Js::InlineeCallInfo::Encode(inlineeCallInfo, (uint32)instr->GetSrc1()->AsIntConstOpnd()->GetValue(), codeOffset);
     Assert(encodeResult);
 
-    instr->GetSrc1()->AsAddrOpnd()->m_address = inlineeCallInfo;
+    instr->GetSrc1()->AsIntConstOpnd()->SetValue(inlineeCallInfo);
 }
 
 bool EncoderMD::TryConstFold(IR::Instr *instr, IR::RegOpnd *regOpnd)

--- a/lib/Backend/i386/LowererMDArch.cpp
+++ b/lib/Backend/i386/LowererMDArch.cpp
@@ -1710,7 +1710,7 @@ LowererMDArch::GeneratePrologueStackProbe(IR::Instr *entryInstr, size_t frameSiz
         this->lowererMD->CreateAssign(stackLimitOpnd, memOpnd, insertInstr);
 
         instr = IR::Instr::New(Js::OpCode::ADD, stackLimitOpnd, stackLimitOpnd,
-                               IR::AddrOpnd::New((void*)frameSize, IR::AddrOpndKindConstant, this->m_func), this->m_func);
+                               IR::IntConstOpnd::New(frameSize, TyMachReg, this->m_func), this->m_func);
         insertInstr->InsertBefore(instr);
 
         if (doInterruptProbe)
@@ -1724,7 +1724,7 @@ LowererMDArch::GeneratePrologueStackProbe(IR::Instr *entryInstr, size_t frameSiz
     {
         // The incremented stack limit is a compile-time constant.
         size_t scriptStackLimit = (size_t)m_func->GetThreadContextInfo()->GetScriptStackLimit();
-        stackLimitOpnd = IR::AddrOpnd::New((void *)(frameSize + scriptStackLimit), IR::AddrOpndKindDynamicMisc, this->m_func);
+        stackLimitOpnd = IR::IntConstOpnd::New((frameSize + scriptStackLimit), TyMachReg, this->m_func);
     }
 
     IR::LabelInstr *doneLabel = IR::LabelInstr::New(Js::OpCode::Label, this->m_func, false);
@@ -1748,7 +1748,7 @@ LowererMDArch::GeneratePrologueStackProbe(IR::Instr *entryInstr, size_t frameSiz
     // Load the arguments to the probe helper and do the call.
     lowererMD->m_lowerer->LoadScriptContext(insertInstr);
     this->lowererMD->LoadHelperArgument(
-        insertInstr, IR::AddrOpnd::New((void*)frameSize, IR::AddrOpndKindConstant, this->m_func));
+        insertInstr, IR::IntConstOpnd::New(frameSize, TyMachReg, this->m_func));
 
     instr = IR::Instr::New(Js::OpCode::Call, this->m_func);
     instr->SetSrc1(IR::HelperCallOpnd::New(IR::HelperProbeCurrentStack2, this->m_func));

--- a/lib/Runtime/Base/CallInfo.h
+++ b/lib/Runtime/Base/CallInfo.h
@@ -81,7 +81,7 @@ namespace Js
         size_t InlineeStartOffset: sizeof(void*) * CHAR_BIT - 4;
         static size_t const MaxInlineeArgoutCount = 0xF;
 
-        static bool Encode(Js::Var &callInfo, size_t count, size_t offset)
+        static bool Encode(intptr_t &callInfo, size_t count, size_t offset)
         {
             const size_t offsetMask = (~(size_t)0) >> 4;
             const size_t countMask  = 0x0000000F;
@@ -95,7 +95,7 @@ namespace Js
                 return false;
             }
 
-            callInfo = (Js::Var)((offset << 4) | count);
+            callInfo = (offset << 4) | count;
 
             return true;
         }


### PR DESCRIPTION
AddrOpnd was used with AddrOpndKindConstant for 64bit immediates, and then
legalized. Replace all such uses with IntConstOpnd, and add code in
legalizer to handle them.
