### PR TITLE
fix xProc number allocator

### DIFF
--- a/lib/Backend/CodeGenNumberAllocator.cpp
+++ b/lib/Backend/CodeGenNumberAllocator.cpp
@@ -290,16 +290,12 @@ CodeGenNumberAllocator::Finalize()
     return finalizedChunk;
 }
 
-/* static */
-uint
-XProcNumberPageSegmentImpl::GetSizeCat()
-{
-    return (uint)HeapInfo::GetAlignedSizeNoCheck(sizeof(Js::JavascriptNumber));
-}
+uint XProcNumberPageSegmentImpl::sizeCat = sizeof(Js::JavascriptNumber);
 
-
-Js::JavascriptNumber* XProcNumberPageSegmentImpl::AllocateNumber(HANDLE hProcess, double value, Js::StaticType* numberTypeStatic, void* javascriptNumberVtbl)
+Js::JavascriptNumber* XProcNumberPageSegmentImpl::AllocateNumber(Func* func, double value)
 {
+    HANDLE hProcess = func->GetThreadContextInfo()->GetProcessHandle();
+
     XProcNumberPageSegmentImpl* tail = this;
 
     if (this->pageAddress != 0)
@@ -309,31 +305,46 @@ Js::JavascriptNumber* XProcNumberPageSegmentImpl::AllocateNumber(HANDLE hProcess
             tail = (XProcNumberPageSegmentImpl*)tail->nextSegment;
         }
 
-        if (tail->pageAddress + tail->committedEnd - tail->allocEndAddress >= GetSizeCat())
+        if (tail->pageAddress + tail->committedEnd - tail->allocEndAddress >= sizeCat)
         {
             auto number = tail->allocEndAddress;
-            tail->allocEndAddress += GetSizeCat();
+            tail->allocEndAddress += sizeCat;
 
-            Js::JavascriptNumber localNumber(value, numberTypeStatic
 #if DBG
-                , true
+            Js::JavascriptNumber localNumber(value, (Js::StaticType*)func->GetScriptContextInfo()->GetNumberTypeStaticAddr(), true);
+#else
+            Js::JavascriptNumber localNumber(value, (Js::StaticType*)func->GetScriptContextInfo()->GetNumberTypeStaticAddr());
 #endif
-            );
+            Js::JavascriptNumber* pLocalNumber = &localNumber;
 
+#ifdef RECYCLER_MEMORY_VERIFY
+            if (func->GetScriptContextInfo()->IsRecyclerVerifyEnabled())
+            {
+                pLocalNumber = (Js::JavascriptNumber*)alloca(sizeCat);                
+                memset(pLocalNumber, Recycler::VerifyMemFill, sizeCat);
+                Recycler::FillPadNoCheck(pLocalNumber, sizeof(Js::JavascriptNumber), sizeCat, false);
+                pLocalNumber = new (pLocalNumber) Js::JavascriptNumber(localNumber);
+            }
+#endif
             // change vtable to the remote one
-            *(void**)&localNumber = javascriptNumberVtbl;
+            *(void**)pLocalNumber = (void*)func->GetScriptContextInfo()->GetVTableAddress(VTableValue::VtableJavascriptNumber);
 
             // initialize number by WriteProcessMemory
             SIZE_T bytesWritten;
-            WriteProcessMemory(hProcess, (void*)number, &localNumber, sizeof(localNumber), &bytesWritten);
+            if (!WriteProcessMemory(hProcess, (void*)number, pLocalNumber, sizeCat, &bytesWritten)
+                || bytesWritten != sizeCat)
+            {
+                Output::Print(_u("FATAL ERROR: WriteProcessMemory failed, GLE: %d\n"), GetLastError());
+                Js::Throw::FatalInternalError(); // TODO: don't bring down whole server process, but pass the last error to main process
+            }
 
             return (Js::JavascriptNumber*) number;
         }
 
         // alloc blocks
-        if ((void*)tail->committedEnd < tail->GetEndAddress())
+        if (tail->GetCommitEndAddress() < tail->GetEndAddress())
         {
-            Assert((unsigned int)((char*)tail->GetEndAddress() - (char*)tail->committedEnd) >= BlockSize);
+            Assert((unsigned int)((char*)tail->GetEndAddress() - (char*)tail->GetCommitEndAddress()) >= BlockSize);
             // TODO: implement guard pages (still necessary for OOP JIT?)
             auto ret = ::VirtualAllocEx(hProcess, tail->GetCommitEndAddress(), BlockSize, MEM_COMMIT, PAGE_READWRITE);
             if (!ret)
@@ -341,7 +352,7 @@ Js::JavascriptNumber* XProcNumberPageSegmentImpl::AllocateNumber(HANDLE hProcess
                 Js::Throw::OutOfMemory();
             }
             tail->committedEnd += BlockSize;
-            return AllocateNumber(hProcess, value, numberTypeStatic, javascriptNumberVtbl);
+            return AllocateNumber(func, value);
         }
     }
 
@@ -354,12 +365,11 @@ Js::JavascriptNumber* XProcNumberPageSegmentImpl::AllocateNumber(HANDLE hProcess
 
     if (tail->pageAddress == 0)
     {
-        tail = new (tail) XProcNumberPageSegmentImpl();
         tail->pageAddress = (intptr_t)pages;
         tail->allocStartAddress = this->pageAddress;
         tail->allocEndAddress = this->pageAddress;
         tail->nextSegment = nullptr;
-        return AllocateNumber(hProcess, value, numberTypeStatic, javascriptNumberVtbl);
+        return AllocateNumber(func, value);
     }
     else
     {
@@ -370,15 +380,37 @@ Js::JavascriptNumber* XProcNumberPageSegmentImpl::AllocateNumber(HANDLE hProcess
         }
         seg = new (seg) XProcNumberPageSegmentImpl();
         tail->nextSegment = seg;
-        return seg->AllocateNumber(hProcess, value, numberTypeStatic, javascriptNumberVtbl);
+        return seg->AllocateNumber(func, value);
     }
 }
 
 
 XProcNumberPageSegmentImpl::XProcNumberPageSegmentImpl()
 {
-    this->blockIntegratedSize = 0;
-    this->pageSegment = 0;
+    memset(this, 0, sizeof(XProcNumberPageSegment));
+}
+
+void XProcNumberPageSegmentImpl::Initialize(bool recyclerVerifyEnabled, uint recyclerVerifyPad)
+{
+    size_t allocSize = sizeof(Js::JavascriptNumber) + Js::Configuration::Global.flags.NumberAllocPlusSize;
+#ifdef RECYCLER_MEMORY_VERIFY
+    // TODO: share same pad size with main process
+    if (recyclerVerifyEnabled)
+    {
+        size_t padAllocSize = AllocSizeMath::Add(sizeof(Js::JavascriptNumber) + sizeof(size_t), recyclerVerifyPad);
+        allocSize = padAllocSize < allocSize ? allocSize : padAllocSize;
+    }
+#endif    
+
+    allocSize = (uint)HeapInfo::GetAlignedSizeNoCheck(allocSize);
+
+    if (BlockSize%allocSize != 0)
+    {
+        // align allocation sizeCat to be 2^n to make integration easier
+        allocSize = BlockSize / (1 << (Math::Log2(BlockSize / allocSize)));
+    }
+
+    sizeCat = allocSize;
 }
 
 Js::JavascriptNumber** ::XProcNumberPageSegmentManager::RegisterSegments(XProcNumberPageSegment* segments)
@@ -390,7 +422,7 @@ Js::JavascriptNumber** ::XProcNumberPageSegmentManager::RegisterSegments(XProcNu
     size_t totalCount = 0;
     while (temp)
     {
-        totalCount += (temp->allocEndAddress - temp->allocStartAddress) / XProcNumberPageSegmentImpl::GetSizeCat();
+        totalCount += (temp->allocEndAddress - temp->allocStartAddress) / XProcNumberPageSegmentImpl::sizeCat;
         temp = (XProcNumberPageSegmentImpl*)temp->nextSegment;
     }
 
@@ -400,17 +432,14 @@ Js::JavascriptNumber** ::XProcNumberPageSegmentManager::RegisterSegments(XProcNu
     int count = 0;
     while (temp)
     {
-        auto start = temp->allocStartAddress;
-        while (start < temp->allocEndAddress)
+        while (temp->allocStartAddress < temp->allocEndAddress)
         {
-            numbers[count] = (Js::JavascriptNumber*)start;
+            numbers[count] = (Js::JavascriptNumber*)temp->allocStartAddress;
             count++;
-            start += XProcNumberPageSegmentImpl::GetSizeCat();
+            temp->allocStartAddress += XProcNumberPageSegmentImpl::sizeCat;
         }
         temp = (XProcNumberPageSegmentImpl*)temp->nextSegment;
     }
-
-
 
     AutoCriticalSection autoCS(&cs);
     if (this->segmentsList == nullptr)
@@ -430,15 +459,9 @@ Js::JavascriptNumber** ::XProcNumberPageSegmentManager::RegisterSegments(XProcNu
     return numbers;
 }
 
-void XProcNumberPageSegmentManager::GetFreeSegment(XProcNumberPageSegment * seg)
+XProcNumberPageSegment * XProcNumberPageSegmentManager::GetFreeSegment(Memory::ArenaAllocator* alloc)
 {
     AutoCriticalSection autoCS(&cs);
-
-    if (segmentsList == nullptr)
-    {
-        new (seg) XProcNumberPageSegmentImpl();
-        return;
-    }
 
     auto temp = segmentsList;
     auto prev = &segmentsList;
@@ -449,13 +472,17 @@ void XProcNumberPageSegmentManager::GetFreeSegment(XProcNumberPageSegment * seg)
             *prev = (XProcNumberPageSegmentImpl*)temp->nextSegment;
 
             // remove from the list
-            memcpy(seg, temp, sizeof(XProcNumberPageSegment));
+            XProcNumberPageSegment * seg = (XProcNumberPageSegment *)AnewStructZ(alloc, XProcNumberPageSegmentImpl);
+            temp->nextSegment = 0;
+            memcpy(seg, temp, sizeof(XProcNumberPageSegment));            
             midl_user_free(temp);
-            return;
+            return seg;
         }
         prev = (XProcNumberPageSegmentImpl**)&temp->nextSegment;
         temp = (XProcNumberPageSegmentImpl*)temp->nextSegment;
     }
+
+    return nullptr;
 }
 
 void XProcNumberPageSegmentManager::Integrate()
@@ -466,34 +493,56 @@ void XProcNumberPageSegmentManager::Integrate()
     auto prev = &this->segmentsList;
     while (temp)
     {
-        if (temp->pageSegment == 0)
+        if((uintptr_t)temp->allocEndAddress - (uintptr_t)temp->pageAddress > temp->blockIntegratedSize + XProcNumberPageSegmentImpl::BlockSize)
         {
-            auto leafPageAllocator = recycler->GetRecyclerLeafPageAllocator();
-            DListBase<PageSegment> segmentList;
-            temp->pageSegment = (intptr_t)leafPageAllocator->AllocPageSegment(segmentList, leafPageAllocator,
-                (void*)temp->pageAddress, XProcNumberPageSegmentImpl::PageCount, temp->committedEnd / AutoSystemInfo::PageSize);
-            leafPageAllocator->IntegrateSegments(segmentList, 1, XProcNumberPageSegmentImpl::PageCount);
-
-            this->integratedSegmentCount++;
-        }
-
-        unsigned int minIntegrateSize = XProcNumberPageSegmentImpl::BlockSize;
-        for (; temp->pageAddress + temp->blockIntegratedSize + minIntegrateSize < (unsigned int)temp->allocEndAddress;
-            temp->blockIntegratedSize += minIntegrateSize)
-        {
-            TRACK_ALLOC_INFO(recycler, Js::JavascriptNumber, Recycler, 0, (size_t)-1);
-
-            if (!recycler->IntegrateBlock<LeafBit>((char*)temp->pageAddress + temp->blockIntegratedSize,
-                (PageSegment*)temp->pageSegment, XProcNumberPageSegmentImpl::GetSizeCat(), sizeof(Js::JavascriptNumber)))
+            if (temp->pageSegment == 0)
             {
-                Js::Throw::OutOfMemory();
+                auto leafPageAllocator = recycler->GetRecyclerLeafPageAllocator();
+                DListBase<PageSegment> segmentList;
+                temp->pageSegment = (intptr_t)leafPageAllocator->AllocPageSegment(segmentList, leafPageAllocator,
+                    (void*)temp->pageAddress, XProcNumberPageSegmentImpl::PageCount, temp->committedEnd / AutoSystemInfo::PageSize);
+
+                if (temp->pageSegment)
+                {
+                    leafPageAllocator->IntegrateSegments(segmentList, 1, XProcNumberPageSegmentImpl::PageCount);
+                    this->integratedSegmentCount++;
+                }
+            }
+
+            if (temp->pageSegment)
+            {
+                unsigned int minIntegrateSize = XProcNumberPageSegmentImpl::BlockSize;
+                for (; temp->pageAddress + temp->blockIntegratedSize + minIntegrateSize < (unsigned int)temp->allocEndAddress;
+                    temp->blockIntegratedSize += minIntegrateSize)
+                {
+                    TRACK_ALLOC_INFO(recycler, Js::JavascriptNumber, Recycler, 0, (size_t)-1);
+
+                    if (!recycler->IntegrateBlock<LeafBit>((char*)temp->pageAddress + temp->blockIntegratedSize,
+                        (PageSegment*)temp->pageSegment, XProcNumberPageSegmentImpl::sizeCat, sizeof(Js::JavascriptNumber)))
+                    {
+                        Js::Throw::OutOfMemory();
+                    }
+                }
+
+                if ((uintptr_t)temp->allocEndAddress + XProcNumberPageSegmentImpl::sizeCat 
+                    > (uintptr_t)temp->pageAddress + XProcNumberPageSegmentImpl::PageCount*AutoSystemInfo::PageSize)
+                {
+                    *prev = (XProcNumberPageSegmentImpl*)temp->nextSegment;
+                    midl_user_free(temp);
+                    temp = *prev;
+                    continue;
+                }
             }
         }
 
-        *prev = (XProcNumberPageSegmentImpl*)temp->nextSegment;
-        midl_user_free(temp);
-        temp = *prev;
+        temp = (XProcNumberPageSegmentImpl*)temp->nextSegment;
     }
+}
+
+XProcNumberPageSegmentManager::XProcNumberPageSegmentManager(Recycler* recycler)
+    :segmentsList(nullptr), recycler(recycler), integratedSegmentCount(0)
+{
+    XProcNumberPageSegmentImpl::Initialize(recycler->VerifyEnabled() == TRUE, recycler->GetVerifyPad());
 }
 
 XProcNumberPageSegmentManager::~XProcNumberPageSegmentManager()

--- a/lib/Backend/CodeGenNumberAllocator.h
+++ b/lib/Backend/CodeGenNumberAllocator.h
@@ -4,6 +4,7 @@
 //-------------------------------------------------------------------------------------------------------
 #pragma once
 
+#if !FLOATVAR
 /****************************************************************************
  * CodeGenNumberThreadAllocator
  *
@@ -185,4 +186,4 @@ struct XProcNumberPageSegmentManager
 
     void Integrate();
 };
-
+#endif

--- a/lib/Backend/CodeGenNumberAllocator.h
+++ b/lib/Backend/CodeGenNumberAllocator.h
@@ -157,14 +157,15 @@ namespace Js
 struct XProcNumberPageSegmentImpl : public XProcNumberPageSegment
 {
     XProcNumberPageSegmentImpl();
-    Js::JavascriptNumber* AllocateNumber(HANDLE hProcess, double value, Js::StaticType* numberTypeStatic, void* javascriptNumberVtbl);
+    Js::JavascriptNumber* AllocateNumber(Func* func, double value);
     unsigned int GetTotalSize() { return PageCount * AutoSystemInfo::PageSize; }
     void* GetEndAddress() { return (void*)(this->pageAddress + PageCount * AutoSystemInfo::PageSize); }
     void* GetCommitEndAddress() { return (void*)(this->pageAddress + this->committedEnd); }
 
     static const uint BlockSize = SmallAllocationBlockAttributes::PageCount*AutoSystemInfo::PageSize;
     static const uint PageCount = Memory::IdleDecommitPageAllocator::DefaultMaxAllocPageCount;
-    static uint GetSizeCat();
+    static uint sizeCat;
+    static void Initialize(bool recyclerVerifyEnabled, uint recyclerVerifyPad);
 };
 
 static_assert(sizeof(XProcNumberPageSegmentImpl) == sizeof(XProcNumberPageSegment), "should not have data member in XProcNumberPageSegmentImpl");
@@ -175,14 +176,11 @@ struct XProcNumberPageSegmentManager
     XProcNumberPageSegmentImpl* segmentsList;
     Recycler* recycler;
     unsigned int integratedSegmentCount;
-    XProcNumberPageSegmentManager(Recycler* recycler)
-        :segmentsList(nullptr), recycler(recycler), integratedSegmentCount(0)
-    {
-    }
+    XProcNumberPageSegmentManager(Recycler* recycler);
 
     ~XProcNumberPageSegmentManager();
 
-    void GetFreeSegment(XProcNumberPageSegment * seg);
+    XProcNumberPageSegment * GetFreeSegment(Memory::ArenaAllocator* alloc);
     Js::JavascriptNumber** RegisterSegments(XProcNumberPageSegment* segments);
 
     void Integrate();

--- a/lib/Backend/Func.cpp
+++ b/lib/Backend/Func.cpp
@@ -16,7 +16,9 @@ Func::Func(JitArenaAllocator *alloc, JITTimeWorkItem * workItem,
     Js::EntryPointInfo* epInfo,
     const FunctionJITRuntimeInfo *const runtimeInfo,
     JITTimePolymorphicInlineCacheInfo * const polymorphicInlineCacheInfo, CodeGenAllocators *const codeGenAllocators,
+#if !FLOATVAR
     CodeGenNumberAllocator * numberAllocator,
+#endif
     Js::ScriptContextProfiler *const codeGenProfiler, const bool isBackgroundJIT, Func * parentFunc,
     uint postCallByteCodeOffset, Js::RegSlot returnValueRegSlot, const bool isInlinedConstructor,
     Js::ProfileId callSiteIdInParentFunc, bool isGetterSetter) :
@@ -95,7 +97,9 @@ Func::Func(JitArenaAllocator *alloc, JITTimeWorkItem * workItem,
     hasImplicitCalls(false),
     hasTempObjectProducingInstr(false),
     isInlinedConstructor(isInlinedConstructor),
+#if !FLOATVAR
     numberAllocator(numberAllocator),
+#endif
     loopCount(0),
     callSiteIdInParentFunc(callSiteIdInParentFunc),
     isGetterSetter(isGetterSetter),
@@ -266,7 +270,9 @@ Func::Codegen(JitArenaAllocator *alloc, JITTimeWorkItem * workItem,
     Js::EntryPointInfo* epInfo, // for in-proc jit only
     const FunctionJITRuntimeInfo *const runtimeInfo,
     JITTimePolymorphicInlineCacheInfo * const polymorphicInlineCacheInfo, CodeGenAllocators *const codeGenAllocators,
+#if !FLOATVAR
     CodeGenNumberAllocator * numberAllocator,
+#endif
     Js::ScriptContextProfiler *const codeGenProfiler, const bool isBackgroundJIT)
 {
     bool rejit;
@@ -274,7 +280,10 @@ Func::Codegen(JitArenaAllocator *alloc, JITTimeWorkItem * workItem,
     {
         Func func(alloc, workItem, threadContextInfo,
             scriptContextInfo, outputData, epInfo, runtimeInfo,
-            polymorphicInlineCacheInfo, codeGenAllocators, numberAllocator,
+            polymorphicInlineCacheInfo, codeGenAllocators, 
+#if !FLOATVAR
+            numberAllocator,
+#endif
             codeGenProfiler, isBackgroundJIT);
         try
         {
@@ -1802,7 +1811,7 @@ Func::AllocateNumber(double value)
 {
     Js::Var number = nullptr;
 #if FLOATVAR
-    number = Js::JavascriptNumber::NewCodeGenInstance(GetNumberAllocator(), (double)value, nullptr);
+    number = Js::JavascriptNumber::NewCodeGenInstance((double)value, nullptr);
 #else
     if (!IsOOPJIT()) // in-proc jit
     {

--- a/lib/Backend/Func.cpp
+++ b/lib/Backend/Func.cpp
@@ -1810,10 +1810,7 @@ Func::AllocateNumber(double value)
     }
     else // OOP JIT
     {
-        number = GetXProcNumberAllocator()->AllocateNumber(this->GetThreadContextInfo()->GetProcessHandle(),
-            value,
-            (Js::StaticType*)this->GetScriptContextInfo()->GetNumberTypeStaticAddr(),
-            (void*)this->GetScriptContextInfo()->GetVTableAddress(VTableValue::VtableJavascriptNumber));
+        number = GetXProcNumberAllocator()->AllocateNumber(this, value);
     }
 #endif
 

--- a/lib/Backend/Func.h
+++ b/lib/Backend/Func.h
@@ -132,6 +132,15 @@ public:
     }
     XProcNumberPageSegmentImpl* GetXProcNumberAllocator()
     {
+        if (this->GetJITOutput()->GetOutputData()->numberPageSegments == nullptr)
+        {
+            XProcNumberPageSegmentImpl* seg = (XProcNumberPageSegmentImpl*)midl_user_allocate(sizeof(XProcNumberPageSegment));
+            if (seg == nullptr)
+            {
+                Js::Throw::OutOfMemory();
+            }
+            this->GetJITOutput()->GetOutputData()->numberPageSegments = new (seg) XProcNumberPageSegmentImpl();
+        }
         return (XProcNumberPageSegmentImpl*)this->GetJITOutput()->GetOutputData()->numberPageSegments;
     }
 

--- a/lib/Backend/Func.h
+++ b/lib/Backend/Func.h
@@ -104,7 +104,9 @@ public:
         Js::EntryPointInfo* epInfo,
         const FunctionJITRuntimeInfo *const runtimeInfo,
         JITTimePolymorphicInlineCacheInfo * const polymorphicInlineCacheInfo, CodeGenAllocators *const codeGenAllocators,
+#if !FLOATVAR
         CodeGenNumberAllocator * numberAllocator,
+#endif
         Js::ScriptContextProfiler *const codeGenProfiler, const bool isBackgroundJIT, Func * parentFunc = nullptr,
         uint postCallByteCodeOffset = Js::Constants::NoByteCodeOffset,
         Js::RegSlot returnValueRegSlot = Js::Constants::NoRegister, const bool isInlinedConstructor = false,
@@ -122,14 +124,18 @@ public:
     {
         return &this->GetTopFunc()->transferDataAllocator;
     }
+#if !FLOATVAR
     CodeGenNumberAllocator * GetNumberAllocator()
     {
         return this->numberAllocator;
     }
+#endif
     EmitBufferManager<CriticalSection> *GetEmitBufferManager() const
     {
         return &this->m_codeGenAllocators->emitBufferManager;
     }
+
+#if !FLOATVAR
     XProcNumberPageSegmentImpl* GetXProcNumberAllocator()
     {
         if (this->GetJITOutput()->GetOutputData()->numberPageSegments == nullptr)
@@ -143,6 +149,7 @@ public:
         }
         return (XProcNumberPageSegmentImpl*)this->GetJITOutput()->GetOutputData()->numberPageSegments;
     }
+#endif
 
     Js::ScriptContextProfiler *GetCodeGenProfiler() const
     {
@@ -252,7 +259,9 @@ public:
         Js::EntryPointInfo* epInfo, // for in-proc jit only
         const FunctionJITRuntimeInfo *const runtimeInfo,
         JITTimePolymorphicInlineCacheInfo * const polymorphicInlineCacheInfo, CodeGenAllocators *const codeGenAllocators,
+#if !FLOATVAR
         CodeGenNumberAllocator * numberAllocator,
+#endif
         Js::ScriptContextProfiler *const codeGenProfiler, const bool isBackgroundJIT);
 
     int32 StackAllocate(int size);
@@ -955,7 +964,9 @@ private:
     InstrMap *          m_cloneMap;
     NativeCodeData::Allocator       nativeCodeDataAllocator;
     NativeCodeData::Allocator       transferDataAllocator;
+#if !FLOATVAR
     CodeGenNumberAllocator *        numberAllocator;
+#endif
     int32           m_localVarSlotsOffset;
     int32           m_hasLocalVarChangedOffset;    // Offset on stack of 1 byte which indicates if any local var has changed.
     CodeGenAllocators *const m_codeGenAllocators;

--- a/lib/Backend/Inline.cpp
+++ b/lib/Backend/Inline.cpp
@@ -1175,6 +1175,7 @@ Inline::BuildInlinee(JITTimeFunctionBody* funcBody, const FunctionJITTimeInfo * 
     JITTimeWorkItem * jitWorkItem = JitAnew(this->topFunc->m_alloc, JITTimeWorkItem, workItemData);
 
     JITTimePolymorphicInlineCacheInfo * entryPointPolymorphicInlineCacheInfo = this->topFunc->GetWorkItem()->GetInlineePolymorphicInlineCacheInfo(funcBody->GetAddr());
+#if !FLOATVAR
     Func * inlinee = JitAnew(this->topFunc->m_alloc,
                             Func,
                             this->topFunc->m_alloc,
@@ -1195,6 +1196,27 @@ Inline::BuildInlinee(JITTimeFunctionBody* funcBody, const FunctionJITTimeInfo * 
                             false,
                             callSiteId,
                             false);
+#else
+        Func * inlinee = JitAnew(this->topFunc->m_alloc,
+                            Func,
+                            this->topFunc->m_alloc,
+                            jitWorkItem,
+                            this->topFunc->GetThreadContextInfo(),
+                            this->topFunc->GetScriptContextInfo(),
+                            this->topFunc->GetJITOutput()->GetOutputData(),
+                            nullptr,
+                            inlineeRuntimeData,
+                            entryPointPolymorphicInlineCacheInfo,
+                            this->topFunc->GetCodeGenAllocators(),
+                            this->topFunc->GetCodeGenProfiler(),
+                            this->topFunc->IsBackgroundJIT(),
+                            callInstr->m_func,
+                            callInstr->m_next->GetByteCodeOffset(),
+                            returnRegSlot,
+                            false,
+                            callSiteId,
+                            false);
+#endif
 
     BuildIRForInlinee(inlinee, funcBody, callInstr, false, recursiveInlineDepth);
     return inlinee;
@@ -2602,6 +2624,7 @@ Inline::InlineCallApplyTarget_Shared(IR::Instr *callInstr, StackSym* originalCal
     JITTimeWorkItem * jitWorkItem = JitAnew(this->topFunc->m_alloc, JITTimeWorkItem, workItemData);
 
     JITTimePolymorphicInlineCacheInfo * entryPointPolymorphicInlineCacheInfo = inlineeData->HasBody() ? this->topFunc->GetWorkItem()->GetInlineePolymorphicInlineCacheInfo(inlineeData->GetBody()->GetAddr()) : nullptr;
+#if !FLOATVAR
     Func * inlinee = JitAnew(this->topFunc->m_alloc,
         Func,
         this->topFunc->m_alloc,
@@ -2622,6 +2645,27 @@ Inline::InlineCallApplyTarget_Shared(IR::Instr *callInstr, StackSym* originalCal
         false,
         callSiteId,
         false);
+#else
+    Func * inlinee = JitAnew(this->topFunc->m_alloc,
+        Func,
+        this->topFunc->m_alloc,
+        jitWorkItem,
+        this->topFunc->GetThreadContextInfo(),
+        this->topFunc->GetScriptContextInfo(),
+        this->topFunc->GetJITOutput()->GetOutputData(),
+        nullptr,
+        callInstr->m_func->GetWorkItem()->GetJITTimeInfo()->GetLdFldInlineeRuntimeData(inlineCacheIndex),
+        entryPointPolymorphicInlineCacheInfo,
+        this->topFunc->GetCodeGenAllocators(),
+        this->topFunc->GetCodeGenProfiler(),
+        this->topFunc->IsBackgroundJIT(),
+        callInstr->m_func,
+        callInstr->m_next->GetByteCodeOffset(),
+        returnRegSlot,
+        false,
+        callSiteId,
+        false);
+#endif
 
     // instrNext
     IR::Instr* instrNext = callInstr->m_next;
@@ -3343,6 +3387,7 @@ Inline::InlineGetterSetterFunction(IR::Instr *accessorInstr, const FunctionJITTi
     JITTimeWorkItem * jitWorkItem = JitAnew(this->topFunc->m_alloc, JITTimeWorkItem, workItemData);
 
     JITTimePolymorphicInlineCacheInfo * entryPointPolymorphicInlineCacheInfo = this->topFunc->GetWorkItem()->GetInlineePolymorphicInlineCacheInfo(funcBody->GetAddr());
+#if !FLOATVAR
     Func * inlinee = JitAnew(this->topFunc->m_alloc,
         Func,
         this->topFunc->m_alloc,
@@ -3363,6 +3408,27 @@ Inline::InlineGetterSetterFunction(IR::Instr *accessorInstr, const FunctionJITTi
         false,
         UINT16_MAX,
         true);
+#else
+    Func * inlinee = JitAnew(this->topFunc->m_alloc,
+        Func,
+        this->topFunc->m_alloc,
+        jitWorkItem,
+        this->topFunc->GetThreadContextInfo(),
+        this->topFunc->GetScriptContextInfo(),
+        this->topFunc->GetJITOutput()->GetOutputData(),
+        nullptr,
+        accessorInstr->m_func->GetWorkItem()->GetJITTimeInfo()->GetLdFldInlineeRuntimeData(inlineCacheIndex),
+        entryPointPolymorphicInlineCacheInfo,
+        this->topFunc->GetCodeGenAllocators(),
+        this->topFunc->GetCodeGenProfiler(),
+        this->topFunc->IsBackgroundJIT(),
+        accessorInstr->m_func,
+        accessorInstr->m_next->GetByteCodeOffset(),
+        returnRegSlot,
+        false,
+        UINT16_MAX,
+        true);
+#endif
 
     // funcBody->GetInParamsCount() can be greater than one even if it is all undefined. Example defineProperty(a,"foo", {get:function(a,b,c){}});
 
@@ -3657,6 +3723,7 @@ Inline::InlineScriptFunction(IR::Instr *callInstr, const FunctionJITTimeInfo *co
 
 
     JITTimePolymorphicInlineCacheInfo * entryPointPolymorphicInlineCacheInfo = this->topFunc->GetWorkItem()->GetInlineePolymorphicInlineCacheInfo(funcBody->GetAddr());
+#if !FLOATVAR
     Func * inlinee = JitAnew(this->topFunc->m_alloc,
         Func,
         this->topFunc->m_alloc,
@@ -3677,6 +3744,27 @@ Inline::InlineScriptFunction(IR::Instr *callInstr, const FunctionJITTimeInfo *co
         isCtor,
         callSiteId,
         false);
+#else
+    Func * inlinee = JitAnew(this->topFunc->m_alloc,
+        Func,
+        this->topFunc->m_alloc,
+        jitWorkItem,
+        this->topFunc->GetThreadContextInfo(),
+        this->topFunc->GetScriptContextInfo(),
+        this->topFunc->GetJITOutput()->GetOutputData(),
+        nullptr,
+        funcCaller->GetWorkItem()->GetJITTimeInfo()->GetInlineeForTargetInlineeRuntimeData(profileId, funcBody->GetAddr()),
+        entryPointPolymorphicInlineCacheInfo,
+        this->topFunc->GetCodeGenAllocators(),
+        this->topFunc->GetCodeGenProfiler(),
+        this->topFunc->IsBackgroundJIT(),
+        callInstr->m_func,
+        callInstr->GetNextRealInstr()->GetByteCodeOffset(),
+        returnRegSlot,
+        isCtor,
+        callSiteId,
+        false);
+#endif
 
     return InlineFunctionCommon(callInstr, originalCallTargetStackSym, inlineeData, inlinee, instrNext, returnValueOpnd, inlineBailoutChecksBeforeInstr, symCallerThis, recursiveInlineDepth, safeThis);
 }

--- a/lib/Backend/NativeCodeGenerator.cpp
+++ b/lib/Backend/NativeCodeGenerator.cpp
@@ -885,8 +885,7 @@ NativeCodeGenerator::CodeGen(PageAllocator * pageAllocator, CodeGenWorkItem* wor
     jitData->sharedPropertyGuards = epInfo->GetSharedPropertyGuardsWithLock(&alloc, jitData->sharedPropGuardCount);
 
     JITOutputIDL jitWriteData = {0};
-    workItem->GetJITData()->xProcNumberPageSegment = AnewStructZ(&alloc, XProcNumberPageSegment);
-    threadContext->GetXProcNumberPageSegmentManager()->GetFreeSegment(workItem->GetJITData()->xProcNumberPageSegment);
+    workItem->GetJITData()->xProcNumberPageSegment = threadContext->GetXProcNumberPageSegmentManager()->GetFreeSegment(&alloc);
 
     LARGE_INTEGER start_time = { 0 };
     NativeCodeGenerator::LogCodeGenStart(workItem, &start_time);

--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -1438,6 +1438,9 @@ FLAGNR(Boolean, ZeroMemoryWithNonTemporalStore, "Zero free memory with non-tempo
 FLAGNR(Number,  MaxMarkStackPageCount , "Restrict recycler mark stack size (in pages)", -1)
 FLAGNR(Number,  MaxTrackedObjectListCount,  "Restrict recycler tracked object count during GC", -1)
 
+// make the recycler page integration path easier to hit
+FLAGNR(Number, NumberAllocPlusSize, "Additional bytes to allocate with JavascriptNumber from number allocator (0~496)", 0)
+
 #if DBG
 FLAGNR(Boolean, InitializeInterpreterSlotsWithInvalidStackVar, "Enable the initialization of the interpreter local slots with invalid stack vars", false)
 #endif

--- a/lib/Common/Memory/Recycler.cpp
+++ b/lib/Common/Memory/Recycler.cpp
@@ -6965,15 +6965,21 @@ Recycler::FillCheckPad(void * address, size_t size, size_t alignedAllocSize, boo
         // Actually this is filling the non-pad to zero
         VerifyCheckFill(addressToVerify, sizeToVerify - sizeof(size_t));
 
-        // Ignore the first word
-        if (!objectAlreadyInitialized && size > sizeof(FreeObject))
-        {
-            memset((char *)address + sizeof(FreeObject), 0, size - sizeof(FreeObject));
-        }
-
-        // write the pad size at the end;
-        *(size_t *)((char *)address + alignedAllocSize - sizeof(size_t)) = alignedAllocSize - size;
+        FillPadNoCheck(address, size, alignedAllocSize, objectAlreadyInitialized);
     }
+}
+
+void 
+Recycler::FillPadNoCheck(void * address, size_t size, size_t alignedAllocSize, bool objectAlreadyInitialized)
+{
+    // Ignore the first word
+    if (!objectAlreadyInitialized && size > sizeof(FreeObject))
+    {
+        memset((char *)address + sizeof(FreeObject), 0, size - sizeof(FreeObject));
+    }
+
+    // write the pad size at the end;
+    *(size_t *)((char *)address + alignedAllocSize - sizeof(size_t)) = alignedAllocSize - size;
 }
 
 void Recycler::Verify(Js::Phase phase)

--- a/lib/Common/Memory/Recycler.h
+++ b/lib/Common/Memory/Recycler.h
@@ -1448,6 +1448,7 @@ public:
     {
         FillCheckPad(address, size, alignedAllocSize, false);
     }
+    static void FillPadNoCheck(void * address, size_t size, size_t alignedAllocSize, bool objectAlreadyInitialized);
 
     void VerifyCheckPad(void * address, size_t size);
     void VerifyCheckPadExplicitFreeList(void * address, size_t size);

--- a/lib/JITServer/JITServer.cpp
+++ b/lib/JITServer/JITServer.cpp
@@ -255,9 +255,10 @@ ServerInitializeScriptContext(
     ServerScriptContext * contextInfo = HeapNew(ServerScriptContext, scriptContextData);
     *scriptContextInfoAddress = (intptr_t)EncodePointer(contextInfo);
 
+#if !FLOATVAR
     // TODO: should move this to ServerInitializeThreadContext, also for the fields in IDL
     XProcNumberPageSegmentImpl::Initialize(contextInfo->IsRecyclerVerifyEnabled(), contextInfo->GetRecyclerVerifyPad());
-
+#endif
     return S_OK;
 }
 
@@ -446,7 +447,9 @@ ServerRemoteCodeGen(
             nullptr,
             jitWorkItem->GetPolymorphicInlineCacheInfo(),
             threadContextInfo->GetCodeGenAllocators(),
-            nullptr,
+#if !FLOATVAR
+            nullptr, // number allocator
+#endif
             profiler,
             true);
     }

--- a/lib/JITServer/JITServer.cpp
+++ b/lib/JITServer/JITServer.cpp
@@ -135,6 +135,7 @@ ServerInitializeThreadContext(
 
     *threadContextRoot = (intptr_t)EncodePointer(contextInfo);
     *prereservedRegionAddr = (intptr_t)contextInfo->GetPreReservedVirtualAllocator()->EnsurePreReservedRegion();
+   
     return S_OK;
 }
 
@@ -253,6 +254,10 @@ ServerInitializeScriptContext(
 
     ServerScriptContext * contextInfo = HeapNew(ServerScriptContext, scriptContextData);
     *scriptContextInfoAddress = (intptr_t)EncodePointer(contextInfo);
+
+    // TODO: should move this to ServerInitializeThreadContext, also for the fields in IDL
+    XProcNumberPageSegmentImpl::Initialize(contextInfo->IsRecyclerVerifyEnabled(), contextInfo->GetRecyclerVerifyPad());
+
     return S_OK;
 }
 
@@ -414,19 +419,20 @@ ServerRemoteCodeGen(
         profiler->Initialize(threadContextInfo->GetPageAllocator(), nullptr);
     }
 #endif
-
-    jitData->numberPageSegments = (XProcNumberPageSegment*)midl_user_allocate(sizeof(XProcNumberPageSegment));
-    if (!jitData->numberPageSegments)
+    if (jitWorkItem->GetWorkItemData()->xProcNumberPageSegment)
     {
-        scriptContextInfo->EndJIT();
-        threadContextInfo->EndJIT();
+        jitData->numberPageSegments = (XProcNumberPageSegment*)midl_user_allocate(sizeof(XProcNumberPageSegment));
+        if (!jitData->numberPageSegments)
+        {
+            scriptContextInfo->EndJIT();
+            threadContextInfo->EndJIT();
 
-        return E_OUTOFMEMORY;
+            return E_OUTOFMEMORY;
+        }
+        __analysis_assume(jitData->numberPageSegments);
+
+        memcpy_s(jitData->numberPageSegments, sizeof(XProcNumberPageSegment), jitWorkItem->GetWorkItemData()->xProcNumberPageSegment, sizeof(XProcNumberPageSegment));
     }
-    __analysis_assume(jitData->numberPageSegments);
-
-    memcpy_s(jitData->numberPageSegments, sizeof(XProcNumberPageSegment), jitWorkItem->GetWorkItemData()->xProcNumberPageSegment, sizeof(XProcNumberPageSegment));
-
     HRESULT hr = S_OK;
     try
     {

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -7788,6 +7788,7 @@ namespace Js
     {
         ProcessJitTransferData();
         
+#if !FLOATVAR
         if (this->numberPageSegments)
         {
             auto numberArray = this->GetScriptContext()->GetThreadContext()
@@ -7795,6 +7796,7 @@ namespace Js
             this->SetNumberArray(numberArray);
             this->numberPageSegments = nullptr;
         }
+#endif
     }
 
     void EntryPointInfo::ProcessJitTransferData()

--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -165,10 +165,12 @@ ThreadContext::ThreadContext(AllocationPolicyManager * allocationPolicyManager, 
     caseInvariantPropertySet(nullptr),
     entryPointToBuiltInOperationIdCache(&threadAlloc, 0),
 #if ENABLE_NATIVE_CODEGEN
+#if !FLOATVAR
     codeGenNumberThreadAllocator(nullptr),
+    xProcNumberPageSegmentManager(nullptr),
+#endif
     m_pendingJITProperties(nullptr),
     m_reclaimedJITProperties(nullptr),
-    xProcNumberPageSegmentManager(nullptr),
 #if DYNAMIC_INTERPRETER_THUNK || defined(ASMJS_PLAT)
     thunkPageAllocators(allocationPolicyManager, /* allocXData */ false, /* virtualAllocator */ nullptr, GetCurrentProcess()),
 #endif
@@ -517,6 +519,7 @@ ThreadContext::~ThreadContext()
 #endif
 #endif
 #if ENABLE_NATIVE_CODEGEN
+#if !FLOATVAR
         if (this->codeGenNumberThreadAllocator)
         {
             HeapDelete(this->codeGenNumberThreadAllocator);
@@ -527,6 +530,7 @@ ThreadContext::~ThreadContext()
             HeapDelete(this->xProcNumberPageSegmentManager);
             this->xProcNumberPageSegmentManager = nullptr;
         }
+#endif
 #endif
 
         Assert(this->debugManager == nullptr);
@@ -2534,6 +2538,7 @@ ThreadContext::PreCollectionCallBack(CollectionFlags flags)
     {
         // Integrate allocated pages from background JIT threads
 #if ENABLE_NATIVE_CODEGEN
+#if !FLOATVAR
         if (codeGenNumberThreadAllocator)
         {
             codeGenNumberThreadAllocator->Integrate();
@@ -2542,6 +2547,7 @@ ThreadContext::PreCollectionCallBack(CollectionFlags flags)
         {
             this->xProcNumberPageSegmentManager->Integrate();
         }
+#endif
 #endif
     }
 

--- a/lib/Runtime/Base/ThreadContext.h
+++ b/lib/Runtime/Base/ThreadContext.h
@@ -710,8 +710,10 @@ private:
 #if ENABLE_NATIVE_CODEGEN
     JsUtil::JobProcessor *jobProcessor;
     Js::Var * bailOutRegisterSaveSpace;
+#if !FLOATVAR
     CodeGenNumberThreadAllocator * codeGenNumberThreadAllocator;
     XProcNumberPageSegmentManager * xProcNumberPageSegmentManager;
+#endif
 #if DYNAMIC_INTERPRETER_THUNK || defined(ASMJS_PLAT)
     CustomHeap::CodePageAllocators thunkPageAllocators;
 #endif
@@ -1229,6 +1231,7 @@ public:
     JsUtil::JobProcessor *GetJobProcessor();
     Js::Var * GetBailOutRegisterSaveSpace() const { return bailOutRegisterSaveSpace; }
     virtual intptr_t GetBailOutRegisterSaveSpaceAddr() const override { return (intptr_t)bailOutRegisterSaveSpace; }
+#if !FLOATVAR
     CodeGenNumberThreadAllocator * GetCodeGenNumberThreadAllocator() const
     {
         return codeGenNumberThreadAllocator;
@@ -1237,6 +1240,7 @@ public:
     {
         return this->xProcNumberPageSegmentManager;
     }
+#endif
 #endif
     void ResetFunctionCount() { Assert(this->GetScriptSiteHolderCount() == 0); this->functionCount = 0; }
     void PushEntryExitRecord(Js::ScriptEntryExitRecord *);

--- a/lib/Runtime/Library/JavascriptLibrary.h
+++ b/lib/Runtime/Library/JavascriptLibrary.h
@@ -986,7 +986,9 @@ namespace Js
         JavascriptExternalFunction* CreateWrappedExternalFunction(JavascriptExternalFunction* wrappedFunction);
 
 #if ENABLE_NATIVE_CODEGEN
+#if !FLOATVAR
         JavascriptNumber* CreateCodeGenNumber(CodeGenNumberAllocator *alloc, double value);
+#endif
 #endif
 
         DynamicObject* CreateGeneratorConstructorPrototypeObject();

--- a/lib/Runtime/Library/JavascriptNumber.h
+++ b/lib/Runtime/Library/JavascriptNumber.h
@@ -122,7 +122,11 @@ namespace Js
         static JavascriptNumber* InPlaceNew(double value, ScriptContext* scriptContext, JavascriptNumber* result);
 
 #if ENABLE_NATIVE_CODEGEN
+#if FLOATVAR
+        static Var NewCodeGenInstance(double value, ScriptContext* scriptContext);
+#else
         static Var NewCodeGenInstance(CodeGenNumberAllocator *alloc, double value, ScriptContext* scriptContext);
+#endif
 #endif
 
         inline static bool IsSpecial(double value, uint64 nSpecial) { return NumberUtilities::IsSpecial(value, nSpecial); }

--- a/lib/Runtime/Library/JavascriptNumber.inl
+++ b/lib/Runtime/Library/JavascriptNumber.inl
@@ -139,7 +139,7 @@ namespace Js
     }
 
 #if ENABLE_NATIVE_CODEGEN
-    inline Var JavascriptNumber::NewCodeGenInstance(CodeGenNumberAllocator *alloc, double value, ScriptContext* scriptContext)
+    inline Var JavascriptNumber::NewCodeGenInstance(double value, ScriptContext* scriptContext)
     {
         return ToVar(value);
     }


### PR DESCRIPTION
- some fix needed because of the IDL adjustment(numberSegment changing to pointer and Arena allocated)
- delay allocate the segment only when necessary(when there's number need to be allocated in JIT time)
- added test switch to make the integration and segment full code path easier to test in oop JIT (currently 0x20 pages hold 0x2000 numbers which is extremely hard to fullfil the segment)
- make recycler memory verify work for cross process number allocator