### PR TITLE
Reorder the ByteCodeUse and Cm/Br(Sr)?[GL][te] instructions in the unsigned compare peep

### DIFF
--- a/lib/Backend/FlowGraph.cpp
+++ b/lib/Backend/FlowGraph.cpp
@@ -3022,8 +3022,8 @@ bool FlowGraph::UnsignedCmpPeep(IR::Instr *cmpInstr)
     //
     //  t1 = ShrU_A x, 0
     //  t2 = 10;
-    //       ByteCodeUse t1
     //  BrUnGt x, t2, L
+    //       ByteCodeUse t1
     //
     // Hopefully dead-store can get rid of the ShrU
 
@@ -3090,7 +3090,7 @@ bool FlowGraph::UnsignedCmpPeep(IR::Instr *cmpInstr)
     IR::ByteCodeUsesInstr * bytecodeInstr = IR::ByteCodeUsesInstr::New(cmpInstr->m_func);
     bytecodeInstr->SetByteCodeOffset(cmpInstr);
     bytecodeInstr->byteCodeUpwardExposedUsed = Anew(cmpInstr->m_func->m_alloc, BVSparse<JitArenaAllocator>,cmpInstr->m_func->m_alloc);
-    cmpInstr->InsertBefore(bytecodeInstr);
+    cmpInstr->InsertAfter(bytecodeInstr);
 
     if (cmpSrc1 != newSrc1)
     {

--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -10206,7 +10206,7 @@ Lowerer::LowerArgIn(IR::Instr *instrArgIn)
         this->m_lowererMD.ChangeToAssign(instrArgIn);
     }
 
-	JitAdelete(this->m_alloc, formalsBv);
+    JitAdelete(this->m_alloc, formalsBv);
 
     return instrResume;
 }
@@ -10248,8 +10248,8 @@ Lowerer::LoadGeneratorObject(IR::Instr * instrInsert)
     instrInsert->m_func->SetArgOffset(generatorSym, LowererMD::GetFormalParamOffset() * MachPtr);
     IR::SymOpnd * generatorSymOpnd = IR::SymOpnd::New(generatorSym, TyMachPtr, instrInsert->m_func);
     IR::RegOpnd * generatorRegOpnd = IR::RegOpnd::New(TyMachPtr, instrInsert->m_func);
-	instrInsert->m_func->SetHasImplicitParamLoad();
-	return LowererMD::CreateAssign(generatorRegOpnd, generatorSymOpnd, instrInsert);
+    instrInsert->m_func->SetHasImplicitParamLoad();
+    return LowererMD::CreateAssign(generatorRegOpnd, generatorSymOpnd, instrInsert);
 }
 
 IR::Instr *
@@ -10904,7 +10904,7 @@ Lowerer::LoadCallInfo(IR::Instr * instrInsert)
     {
         // Generator function arguments and ArgumentsInfo are not on the stack.  Instead they
         // are accessed off the generator object (which is prm1).
-		IR::Instr *genLoadInstr = LoadGeneratorObject(instrInsert);
+        IR::Instr *genLoadInstr = LoadGeneratorObject(instrInsert);
         IR::RegOpnd * generatorRegOpnd = genLoadInstr->GetDst()->AsRegOpnd();
 
         IR::IndirOpnd * indirOpnd = IR::IndirOpnd::New(generatorRegOpnd, Js::JavascriptGenerator::GetCallInfoOffset(), TyMachPtr, func);


### PR DESCRIPTION
This helps avoid situations in which the arguments to the compare op
would get optimized out too aggressively, and are then unavailable in
exceptional cases.
