### PR TITLE
allow native code bump alloc for arm

### DIFF
--- a/lib/Backend/arm/LowerMD.cpp
+++ b/lib/Backend/arm/LowerMD.cpp
@@ -6423,7 +6423,7 @@ LowererMD::GenerateFastRecyclerAlloc(size_t allocSize, IR::RegOpnd* newObjDst, I
     uint32 freeListOffset;
     size_t alignedSize = HeapInfo::GetAlignedSizeNoCheck(allocSize);
 
-    bool allowNativeCodeBumpAllocation = false; // TODO: pass through RPC
+    bool allowNativeCodeBumpAllocation = scriptContext->GetRecyclerAllowNativeCodeBumpAllocation();
     Recycler::GetNormalHeapBlockAllocatorInfoForNativeAllocation((void*)scriptContext->GetRecyclerAddr(), alignedSize,
         allocatorAddress, endAddressOffset, freeListOffset,
         allowNativeCodeBumpAllocation, this->m_func->IsOOPJIT());


### PR DESCRIPTION
I disabled this for OOP JIT, but never re-enabled for arm after we added support.