### PR TITLE
use target inlinee runtime info when building JIT data

### DIFF
--- a/lib/Runtime/Language/FunctionCodeGenRuntimeData.cpp
+++ b/lib/Runtime/Language/FunctionCodeGenRuntimeData.cpp
@@ -27,6 +27,16 @@ namespace Js
         return &clonedInlineCaches;
     }
 
+    FunctionCodeGenRuntimeData * FunctionCodeGenRuntimeData::GetNextForTarget(FunctionBody *targetFuncBody) const
+    {
+        FunctionCodeGenRuntimeData * next = this->next;
+        if (next->GetFunctionBody() != targetFuncBody)
+        {
+            next = next->next;
+        }
+        return next;
+    }
+
     const FunctionCodeGenRuntimeData *FunctionCodeGenRuntimeData::GetInlinee(const ProfileId profiledCallSiteId) const
     {
         Assert(profiledCallSiteId < functionBody->GetProfiledCallSiteCount());

--- a/lib/Runtime/Language/FunctionCodeGenRuntimeData.h
+++ b/lib/Runtime/Language/FunctionCodeGenRuntimeData.h
@@ -36,6 +36,7 @@ namespace Js
     public:
         FunctionBody *GetFunctionBody() const;
         FunctionCodeGenRuntimeData *GetNext() const { return next; };
+        FunctionCodeGenRuntimeData *GetNextForTarget(FunctionBody *targetFuncBody) const;
         const InlineCachePointerArray<InlineCache> *ClonedInlineCaches() const;
         InlineCachePointerArray<InlineCache> *ClonedInlineCaches();
 


### PR DESCRIPTION
I was assuming that structure of inlinee JIT data and runtime data would be same at codegen time. However, runtime data can become more polymorphic between WI creation and codegen time, so we should select the runtime data corresponding to what we built at WI creation.