### PR TITLE
Remove CSE for BailOnNotStackArgs

### DIFF
--- a/lib/Backend/Inline.cpp
+++ b/lib/Backend/Inline.cpp
@@ -2307,7 +2307,7 @@ IR::Instr * Inline::InlineApplyWithArgumentsObject(IR::Instr * callInstr, IR::In
     }
 
     // set src1 to avoid CSE on BailOnNotStackArgs for different arguments object
-    bailOutOnNotStackArgs->SetSrc1(ldHeapArguments->GetDst());
+    bailOutOnNotStackArgs->SetSrc1(ldHeapArguments->GetDst()->Copy(this->topFunc));
     bailOutOnNotStackArgsInsertionPoint->InsertBefore(bailOutOnNotStackArgs);
 
     // If we optimized the call instruction for a fixed function, we must extend the function object's lifetime until after
@@ -2552,7 +2552,7 @@ bool Inline::InlineApplyTarget(IR::Instr *callInstr, const FunctionJITTimeInfo* 
     IR::Instr *  bailOutOnNotStackArgs = IR::BailOutInstr::New(Js::OpCode::BailOnNotStackArgs, IR::BailOutOnInlineFunction,
         callInstr, callInstr->m_func);
     // set src1 to avoid CSE on BailOnNotStackArgs for different arguments object
-    bailOutOnNotStackArgs->SetSrc1(argumentsObjArgOut->GetSrc1());
+    bailOutOnNotStackArgs->SetSrc1(argumentsObjArgOut->GetSrc1()->Copy(this->topFunc));
     argumentsObjArgOut->InsertBefore(bailOutOnNotStackArgs);
 
     IR::Instr* byteCodeArgOutUse = IR::Instr::New(Js::OpCode::BytecodeArgOutUse, callInstr->m_func);

--- a/lib/Backend/Inline.cpp
+++ b/lib/Backend/Inline.cpp
@@ -2306,6 +2306,8 @@ IR::Instr * Inline::InlineApplyWithArgumentsObject(IR::Instr * callInstr, IR::In
         bailOutOnNotStackArgsInsertionPoint = primaryBailoutInstr;
     }
 
+    // set src1 to avoid CSE on BailOnNotStackArgs for different arguments object
+    bailOutOnNotStackArgs->SetSrc1(ldHeapArguments->GetDst());
     bailOutOnNotStackArgsInsertionPoint->InsertBefore(bailOutOnNotStackArgs);
 
     // If we optimized the call instruction for a fixed function, we must extend the function object's lifetime until after
@@ -2549,6 +2551,8 @@ bool Inline::InlineApplyTarget(IR::Instr *callInstr, const FunctionJITTimeInfo* 
 
     IR::Instr *  bailOutOnNotStackArgs = IR::BailOutInstr::New(Js::OpCode::BailOnNotStackArgs, IR::BailOutOnInlineFunction,
         callInstr, callInstr->m_func);
+    // set src1 to avoid CSE on BailOnNotStackArgs for different arguments object
+    bailOutOnNotStackArgs->SetSrc1(argumentsObjArgOut->GetSrc1());
     argumentsObjArgOut->InsertBefore(bailOutOnNotStackArgs);
 
     IR::Instr* byteCodeArgOutUse = IR::Instr::New(Js::OpCode::BytecodeArgOutUse, callInstr->m_func);

--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -12698,6 +12698,11 @@ Lowerer::GenerateBailOut(IR::Instr * instr, IR::BranchInstr * branchInstr, IR::L
     bailOutRecord->bailOutOpcode = bailOutInfo->bailOutOpcode;
 #endif
 
+    if (instr->m_opcode == Js::OpCode::BailOnNotStackArgs && instr->GetSrc1())
+    {
+        // src1 on BailOnNotStackArgs is helping CSE
+        instr->FreeSrc1();
+    }
     // Call the bail out wrapper
     instr->m_opcode = Js::OpCode::Call;
     if(instr->GetDst())

--- a/lib/Runtime/ByteCode/OpCodes.h
+++ b/lib/Runtime/ByteCode/OpCodes.h
@@ -633,7 +633,7 @@ MACRO_BACKEND_ONLY(     BailOut,                     Empty,          OpSideEffec
 MACRO_BACKEND_ONLY(     BailOnEqual,                 Empty,          OpBailOutRec|OpTempNumberSources|OpTempObjectSources|OpCanCSE)
 MACRO_BACKEND_ONLY(     BailOnNotEqual,              Empty,          OpBailOutRec|OpTempNumberSources|OpTempObjectSources|OpCanCSE)
 MACRO_BACKEND_ONLY(     BailOnNegative,              Empty,          OpBailOutRec|OpTempNumberSources|OpTempObjectSources|OpCanCSE)
-MACRO_BACKEND_ONLY(     BailOnNotStackArgs,          Empty,          OpBailOutRec|OpTempNumberSources|OpTempObjectSources|OpCanCSE)    // Bail out if not stack args or actuals exceed InlineeCallInfo::MaxInlineeArgoutCount (15)
+MACRO_BACKEND_ONLY(     BailOnNotStackArgs,          Empty,          OpBailOutRec|OpTempNumberSources|OpTempObjectSources)    // Bail out if not stack args or actuals exceed InlineeCallInfo::MaxInlineeArgoutCount (15). Cannot do CSE in forward pass right now because lowerer depends on it which is in backward order
 MACRO_BACKEND_ONLY(     BailOnNotSpreadable,         Empty,          OpBailOutRec|OpTempNumberSources|OpTempObjectSources|OpCanCSE)
 MACRO_BACKEND_ONLY(     BailOnNotPolymorphicInlinee, Empty,          OpBailOutRec|OpTempNumberSources)
 MACRO_BACKEND_ONLY(     BailTarget,                  Empty,          OpBailOutRec|OpTempNumberSources|OpTempObjectSources)

--- a/lib/Runtime/ByteCode/OpCodes.h
+++ b/lib/Runtime/ByteCode/OpCodes.h
@@ -633,7 +633,7 @@ MACRO_BACKEND_ONLY(     BailOut,                     Empty,          OpSideEffec
 MACRO_BACKEND_ONLY(     BailOnEqual,                 Empty,          OpBailOutRec|OpTempNumberSources|OpTempObjectSources|OpCanCSE)
 MACRO_BACKEND_ONLY(     BailOnNotEqual,              Empty,          OpBailOutRec|OpTempNumberSources|OpTempObjectSources|OpCanCSE)
 MACRO_BACKEND_ONLY(     BailOnNegative,              Empty,          OpBailOutRec|OpTempNumberSources|OpTempObjectSources|OpCanCSE)
-MACRO_BACKEND_ONLY(     BailOnNotStackArgs,          Empty,          OpBailOutRec|OpTempNumberSources|OpTempObjectSources)    // Bail out if not stack args or actuals exceed InlineeCallInfo::MaxInlineeArgoutCount (15). Cannot do CSE in forward pass right now because lowerer depends on it which is in backward order
+MACRO_BACKEND_ONLY(     BailOnNotStackArgs,          Empty,          OpBailOutRec|OpTempNumberSources|OpTempObjectSources|OpCanCSE)    // Bail out if not stack args or actuals exceed InlineeCallInfo::MaxInlineeArgoutCount (15)
 MACRO_BACKEND_ONLY(     BailOnNotSpreadable,         Empty,          OpBailOutRec|OpTempNumberSources|OpTempObjectSources|OpCanCSE)
 MACRO_BACKEND_ONLY(     BailOnNotPolymorphicInlinee, Empty,          OpBailOutRec|OpTempNumberSources)
 MACRO_BACKEND_ONLY(     BailTarget,                  Empty,          OpBailOutRec|OpTempNumberSources|OpTempObjectSources)


### PR DESCRIPTION
Lowerer relies on LoadHeapArguments to be followed by BailOnNotStackArgs to ensure stackargs option is consistent between inliner and inlinee. When the same function inlined twice in the same inliner (because it is called twice in sequence), CSE will eliminate the second BailOnNotStackArgs which breaks the assumption for lowerer. This fix disable CSE for BailOnNotStackArgs like the workaround for hoist case.