### PR TITLE
fix xdata issues on arm

### DIFF
--- a/lib/Backend/Encoder.cpp
+++ b/lib/Backend/Encoder.cpp
@@ -323,8 +323,6 @@ Encoder::Encode()
         m_func->GetThreadContextInfo()->GetProcessHandle());
 #elif _M_ARM
     m_func->m_unwindInfo.EmitUnwindInfo(m_func->GetJITOutput(), alloc);
-    m_func->GetJITOutput()->SetCodeAddress(m_func->GetJITOutput()->GetCodeAddress() | 0x1); // Set thumb mode
-
     if (m_func->IsOOPJIT())
     {
         size_t allocSize = XDataAllocator::GetAllocSize(alloc->allocation->xdata.pdataCount, alloc->allocation->xdata.xdataSize);
@@ -337,6 +335,8 @@ Encoder::Encode()
         XDataAllocator::Register(&alloc->allocation->xdata, m_func->GetJITOutput()->GetCodeAddress(), m_func->GetJITOutput()->GetCodeSize());
         m_func->GetInProcJITEntryPointInfo()->SetXDataInfo(&alloc->allocation->xdata);
     }
+
+    m_func->GetJITOutput()->SetCodeAddress(m_func->GetJITOutput()->GetCodeAddress() | 0x1); // Set thumb mode
 #endif
     const bool isSimpleJit = m_func->IsSimpleJit();
 

--- a/lib/Backend/NativeCodeGenerator.cpp
+++ b/lib/Backend/NativeCodeGenerator.cpp
@@ -1068,7 +1068,7 @@ NativeCodeGenerator::CodeGen(PageAllocator * pageAllocator, CodeGenWorkItem* wor
 #endif
 
 
-#if defined(_M_ARM32_OR_ARM64)
+#if defined(_M_ARM)
     // for in-proc jit we do registration in encoder
     if (JITManager::GetJITManager()->IsOOPJITEnabled())
     {
@@ -1083,7 +1083,8 @@ NativeCodeGenerator::CodeGen(PageAllocator * pageAllocator, CodeGenWorkItem* wor
         {
             xdataInfo->address = nullptr;
         }
-        XDataAllocator::Register(xdataInfo, jitWriteData.codeAddress, jitWriteData.codeSize);
+        // unmask thumb mode from code address
+        XDataAllocator::Register(xdataInfo, jitWriteData.codeAddress & ~0x1, jitWriteData.codeSize);
         epInfo->SetXDataInfo(xdataInfo);
     }
 #endif

--- a/lib/Backend/NativeCodeGenerator.cpp
+++ b/lib/Backend/NativeCodeGenerator.cpp
@@ -1078,6 +1078,17 @@ NativeCodeGenerator::CodeGen(PageAllocator * pageAllocator, CodeGenWorkItem* wor
         if (jitWriteData.buffer)
         {
             xdataInfo->address = jitWriteData.buffer->data + jitWriteData.xdataOffset;
+            for (ushort i = 0; i < xdataInfo->pdataCount; ++i)
+            {
+                RUNTIME_FUNCTION *function = xdataInfo->GetPdataArray() + i;
+                // if flag is 0, then we have separate .xdata, for which we need to fixup the address
+                if (function->Flag == 0)
+                {
+                    // UnwindData was set on server as the offset from the beginning of xdata buffer
+                    function->UnwindData = (DWORD)(xdataInfo->address + function->UnwindData);
+                    Assert(((DWORD)function->UnwindData & 0x3) == 0); // 4 byte aligned
+                }
+            }
         }
         else
         {

--- a/lib/Backend/arm/UnwindInfoManager.cpp
+++ b/lib/Backend/arm/UnwindInfoManager.cpp
@@ -494,8 +494,10 @@ void UnwindInfoManager::EncodeExpandedUnwindData()
     size_t totalSize = (xDataDwordCount * 4);
 
     size_t xdataFinal = this->jitOutput->RecordUnwindInfo(this->xdataTotal, xData, totalSize, this->alloc->allocation->xdata.address, this->processHandle);
+    // for OOP JIT, we will set UnwindData to be the offset to it. we can fix it up on other side
+    DWORD unwindField = (DWORD)(JITManager::GetJITManager()->IsOOPJITEnabled() ? this->xdataTotal : xdataFinal);
     this->xdataTotal += totalSize;
-    RecordPdataEntry((DWORD)(this->GetFragmentStart() + this->GetPrologOffset()) | 1, (DWORD)xdataFinal);
+    RecordPdataEntry((DWORD)(this->GetFragmentStart() + this->GetPrologOffset()) | 1, unwindField);
 }
 
 DWORD UnwindInfoManager::EmitXdataStackAlloc(BYTE xData[], DWORD byte, DWORD stack)

--- a/lib/JITIDL/JITTypes.h
+++ b/lib/JITIDL/JITTypes.h
@@ -741,9 +741,8 @@ typedef struct  CtorCacheTransferEntryIDL
 typedef struct NativeDataBuffer
 {
     unsigned int len;
-    unsigned int unused;
-    IDL_PAD2(0)
-    IDL_PAD1(1)
+    // pad so that buffer is always 8 byte aligned
+    IDL_PAD4(0)
     IDL_DEF([size_is(len)]) byte data[IDL_DEF(*)];
 } NativeDataBuffer;
 


### PR DESCRIPTION
We were masking the code address for thumb mode before registering the unwind data with the OS, which causes unwinding to fail.

Also, for OOP JIT specifically, when we have expanded unwind data we need to fixup the .xdata pointer. Also fixed an issue I recently introduced which was causing bad alignment for everything in NativeDataBuffer (necessary here as .xdata is required to be 4 byte aligned).