### PR TITLE
IEEE754 Perf Improvement

### DIFF
--- a/test/Number/toString.js
+++ b/test/Number/toString.js
@@ -46,6 +46,14 @@ function runTest(numberToTestAsString)
          !(8.255.toFixed(2) + "" == "8.26") ) {
         throw Error("1.255.toFixed(2) != 1.25 or 8.255.toFixed(2) != 8.26 ??");
     }
+
+    if (-4.223372036854776e+12 + "" != -4.223372036854776e+12.toFixed(3)) {
+        // original number is;
+        // -4223372036854.77587890625
+        // We don't know the 8 after 775
+        // Our default approach is to pick upperBound
+        throw Error("-4.223372036854776e+12 -> -4223372036854.776");
+    }
     writeLine("");
 }
 


### PR DESCRIPTION
We don't know whether BHL or BLH is the correct number
When nDigits is set(>=0), that means the consumer is not
interested with the entire value.
That means, we may not just roundup to the higher bound.
Doing so would break IEEE754
Imagine LowerBound is 4999... while the UpperBoud is 50001..
We need to know where actually the number is instead of picking
either Lower or UpperBoud
In this case, we should skip and fail
and let FDblToRgbPrecise do the math.

Perf Improvement [new]:
Exception for a number that has smaller amount of fractional part
than the number of digits are being asked.