### PR TITLE
cross-platform: Improve compiler options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,6 +208,8 @@ if(CLR_CMAKE_PLATFORM_XPLAT)
 
     # CXX WARNING FLAGS
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
+        -Wno-system-headers\
+        -Wc++11-narrowing\
         -Wno-ignored-attributes\
         -Wno-deprecated-declarations\
         -Wno-parentheses-equality\
@@ -240,6 +242,9 @@ if(CLR_CMAKE_PLATFORM_XPLAT)
         # -Wno-return-type # switch unreachable code
         # -Wno-switch # switch values not handled
 
+    add_compile_options(-fexceptions)
+    add_compile_options(-fstack-protector-all)
+
     # xplat-todo for release build
     # -fno-inline.... -> -mno-omit.... are needed for more accurate stack inf.
     # Release Builds: Not sure if this has to be as strict as the debug/test?
@@ -258,6 +263,7 @@ if(CLR_CMAKE_PLATFORM_XPLAT)
 endif(CLR_CMAKE_PLATFORM_XPLAT)
 
 if(CMAKE_BUILD_TYPE STREQUAL Debug)
+    add_compile_options(-gdwarf-4) # This is actually a GCC option (Clang translates this to -g ?)
     add_definitions(
         -DDBG=1
         -DDEBUG=1

--- a/lib/Runtime/Language/SimdUtils.h
+++ b/lib/Runtime/Language/SimdUtils.h
@@ -104,6 +104,7 @@ struct _x86_SIMDValue
 
 #pragma warning(push)
 #pragma warning(disable:4838) // conversion from 'unsigned int' to 'int32' requires a narrowing conversion
+CLANG_WNO_BEGIN("-Wc++11-narrowing")
 
 // These global values are 16-byte aligned.
 const _x86_SIMDValue X86_ABS_MASK_F4 = { 0x7fffffff, 0x7fffffff, 0x7fffffff, 0x7fffffff };
@@ -141,8 +142,7 @@ const _x86_SIMDValue X86_4LANES_MASKS[]     = {{ 0xffffffff, 0x00000000, 0x00000
                                                { 0x00000000, 0xffffffff, 0x00000000, 0x00000000 },
                                                { 0x00000000, 0x00000000, 0xffffffff, 0x00000000 },
                                                { 0x00000000, 0x00000000, 0x00000000, 0xffffffff }};
-
-
+CLANG_WNO_END // -Wc++11-narrowing
 #pragma warning(pop)
 
 #if ENABLE_NATIVE_CODEGEN && defined(ENABLE_SIMDJS)

--- a/pal/CMakeLists.txt
+++ b/pal/CMakeLists.txt
@@ -5,8 +5,4 @@ project(COREPAL)
 include_directories(${COREPAL_SOURCE_DIR}/inc)
 include_directories(${COREPAL_SOURCE_DIR}/src)
 
-add_compile_options(-gdwarf-3)
-add_compile_options(-fexceptions)
-add_compile_options(-fstack-protector-all)
-
 add_subdirectory(src)


### PR DESCRIPTION
- make PAL specific flags project wide (i.e. fstack-protector-all)
- force Wc++11-narrowing (similar to VC++)
- disable warning reporting from system headers -wsystem-headers [node-chakracore issue]
- set -gdwarf-4 instead of gdwarf-3 as it is the currently supported version on GCC targets
- set -gdwarf-4 only for debug builds
