### PR TITLE
tell legalize we're post-reg alloc on LinearScanMD::InsertLea for arm

### DIFF
--- a/lib/Backend/LinearScan.cpp
+++ b/lib/Backend/LinearScan.cpp
@@ -4970,7 +4970,7 @@ IR::Instr* LinearScan::InsertLea(IR::RegOpnd *dst, IR::Opnd *src, IR::Instr *con
 {
     IR::Instr *instrPrev = insertBeforeInstr->m_prev;
 
-    IR::Instr *instrRet = Lowerer::InsertLea(dst, src, insertBeforeInstr);
+    IR::Instr *instrRet = Lowerer::InsertLea(dst, src, insertBeforeInstr, true);
 
     for (IR::Instr *instr = instrPrev->m_next; instr != insertBeforeInstr; instr = instr->m_next)
     {

--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -14085,7 +14085,7 @@ IR::Instr *Lowerer::InsertSub(
     return instr;
 }
 
-IR::Instr *Lowerer::InsertLea(IR::RegOpnd *const dst, IR::Opnd *const src, IR::Instr *const insertBeforeInstr)
+IR::Instr *Lowerer::InsertLea(IR::RegOpnd *const dst, IR::Opnd *const src, IR::Instr *const insertBeforeInstr, bool postRegAlloc)
 {
     Assert(dst);
     Assert(src);
@@ -14097,7 +14097,7 @@ IR::Instr *Lowerer::InsertLea(IR::RegOpnd *const dst, IR::Opnd *const src, IR::I
     IR::Instr *const instr = IR::Instr::New(Js::OpCode::LEA, dst, src, func);
 
     insertBeforeInstr->InsertBefore(instr);
-    return LowererMD::ChangeToLea(instr);
+    return LowererMD::ChangeToLea(instr, postRegAlloc);
 }
 
 #if _M_X64

--- a/lib/Backend/Lower.h
+++ b/lib/Backend/Lower.h
@@ -316,7 +316,7 @@ public:
     static IR::BranchInstr *    InsertTestBranch(IR::Opnd *const testSrc1, IR::Opnd *const testSrc2, const Js::OpCode branchOpCode, const bool isUnsigned, IR::LabelInstr *const target, IR::Instr *const insertBeforeInstr);
     static IR::Instr *          InsertAdd(const bool needFlags, IR::Opnd *const dst, IR::Opnd *src1, IR::Opnd *src2, IR::Instr *const insertBeforeInstr);
     static IR::Instr *          InsertSub(const bool needFlags, IR::Opnd *const dst, IR::Opnd *src1, IR::Opnd *src2, IR::Instr *const insertBeforeInstr);
-    static IR::Instr *          InsertLea(IR::RegOpnd *const dst, IR::Opnd *const src, IR::Instr *const insertBeforeInstr);
+    static IR::Instr *          InsertLea(IR::RegOpnd *const dst, IR::Opnd *const src, IR::Instr *const insertBeforeInstr, bool postRegAlloc = false);
     static IR::Instr *          InsertXor(IR::Opnd *const dst, IR::Opnd *const src1, IR::Opnd *const src2, IR::Instr *const insertBeforeInstr);
     static IR::Instr *          InsertAnd(IR::Opnd *const dst, IR::Opnd *const src1, IR::Opnd *const src2, IR::Instr *const insertBeforeInstr);
     static IR::Instr *          InsertOr(IR::Opnd *const dst, IR::Opnd *const src1, IR::Opnd *const src2, IR::Instr *const insertBeforeInstr);

--- a/lib/Backend/LowerMDShared.cpp
+++ b/lib/Backend/LowerMDShared.cpp
@@ -750,7 +750,7 @@ LowererMD::ChangeToAssign(IR::Instr * instr, IRType type)
 ///----------------------------------------------------------------------------
 
 IR::Instr *
-LowererMD::ChangeToLea(IR::Instr * instr)
+LowererMD::ChangeToLea(IR::Instr * instr, bool postRegAlloc)
 {
     Assert(instr);
     Assert(instr->GetDst());

--- a/lib/Backend/LowerMDShared.h
+++ b/lib/Backend/LowerMDShared.h
@@ -86,7 +86,7 @@ public:
 
     static  IR::Instr *     ChangeToAssign(IR::Instr * instr);
     static  IR::Instr *     ChangeToAssign(IR::Instr * instr, IRType type);
-    static  IR::Instr *     ChangeToLea(IR::Instr *const instr);
+    static  IR::Instr *     ChangeToLea(IR::Instr *const instr, bool postRegAlloc = false);
     static  void            ImmedSrcToReg(IR::Instr * instr, IR::Opnd * newOpnd, int srcNum);
 
             IR::Instr *     LoadInputParamCount(IR::Instr * instr, int adjust = 0, bool needFlags = false);

--- a/lib/Backend/arm/LowerMD.cpp
+++ b/lib/Backend/arm/LowerMD.cpp
@@ -2530,7 +2530,7 @@ LowererMD::ChangeToWriteBarrierAssign(IR::Instr * assignInstr)
 ///----------------------------------------------------------------------------
 
 IR::Instr *
-LowererMD::ChangeToLea(IR::Instr * instr)
+LowererMD::ChangeToLea(IR::Instr * instr, bool postRegAlloc)
 {
     Assert(instr);
     Assert(instr->GetDst());
@@ -2540,7 +2540,7 @@ LowererMD::ChangeToLea(IR::Instr * instr)
     Assert(!instr->GetSrc2());
 
     instr->m_opcode = Js::OpCode::LEA;
-    Legalize(instr);
+    Legalize(instr, postRegAlloc);
     return instr;
 }
 

--- a/lib/Backend/arm/LowerMD.h
+++ b/lib/Backend/arm/LowerMD.h
@@ -71,7 +71,7 @@ public:
     static  IR::Instr *     CreateAssign(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsertPt);
     static  IR::Instr *     ChangeToAssign(IR::Instr * instr);
     static  IR::Instr *     ChangeToAssign(IR::Instr * instr, IRType type);
-    static  IR::Instr *     ChangeToLea(IR::Instr *const instr);
+    static  IR::Instr *     ChangeToLea(IR::Instr *const instr, bool postRegAlloc = false);
     static  IR::Instr *     ForceDstToReg(IR::Instr *instr);
     static  void            ImmedSrcToReg(IR::Instr * instr, IR::Opnd * newOpnd, int srcNum);
 

--- a/lib/Backend/arm64/LowerMD.h
+++ b/lib/Backend/arm64/LowerMD.h
@@ -66,7 +66,7 @@ public:
     static  IR::Instr *     CreateAssign(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsertPt) { __debugbreak(); return 0; }
     static  IR::Instr *     ChangeToAssign(IR::Instr * instr) { __debugbreak(); return 0; }
     static  IR::Instr *     ChangeToAssign(IR::Instr * instr, IRType type) { __debugbreak(); return 0; }
-    static  IR::Instr *     ChangeToLea(IR::Instr *const instr) { __debugbreak(); return 0; }
+    static  IR::Instr *     ChangeToLea(IR::Instr *const instr, bool postRegAlloc = false) { __debugbreak(); return 0; }
     static  IR::Instr *     ForceDstToReg(IR::Instr *instr) { __debugbreak(); return 0; }
     static  void            ImmedSrcToReg(IR::Instr * instr, IR::Opnd * newOpnd, int srcNum) { __debugbreak(); }
 


### PR DESCRIPTION
Sometimes offset would be hoisted into generic reg opnd (now it will be hoisted into scratch reg)