### PR TITLE
Constrain conv_bool optimization to improve correctness.

### DIFF
--- a/test/Bugs/bug9080773.js
+++ b/test/Bugs/bug9080773.js
@@ -1,0 +1,24 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function func(d0) {
+    i1 = ((d0) == (+((((((0x517ddbc)-(0xc7276b6f)+(-0x8000000))>>>(((0x0)))) >= (0x4866034e))))));
+    return i1 + d0;
+}
+
+var d1 = (1.015625);
+func(d1);
+func(d1);
+
+func(d1);
+func(d1);
+func(d1);
+func(d1);
+
+runningJITtedCode = true;
+func(d1);
+func(d1);
+
+WScript.Echo("PASSED");

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -286,6 +286,12 @@
   </test>
   <test>
     <default>
+      <files>bug9080773.js</files>
+      <compile-flags>-maxinterpretcount:1 -off:simplejit</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>b208_asmjs.js</files>
       <baseline>b208_asmjs.baseline</baseline>
       <tags>exclude_dynapogo,exclude_ship,require_backend</tags>


### PR DESCRIPTION
Due to my recent change to the unsigned compare peep, the conv_bool
optimization was causing instructions to be generated in a way that
the some registers could have two overlapping lifetimes. This fixes
the issue by checking for these ByteCodeUses instructions, and then
placing the conv_bool after them.
