### PR TITLE
Fix buffer overflow of a global variable

### DIFF
--- a/lib/Runtime/Library/DateImplementation.cpp
+++ b/lib/Runtime/Library/DateImplementation.cpp
@@ -47,7 +47,7 @@ namespace Js {
 
     const static SZS g_rgszs[] =
     {
-#define Szs(sz, val) { _u(sz), sizeof(_u(sz)) - 1, ParseStringTokenType::##szst, val }
+#define Szs(sz, val) { _u(sz), _countof(_u(sz)) - 1, ParseStringTokenType::##szst, val }
 
         // bc and ad
 #undef szst


### PR DESCRIPTION
`memcmp` was reaching beyond the global variable ~~heap~~ buffer.

`cch` does not include `sizeof(char16)` while `pszs->cch` includes that. See https://github.com/Microsoft/ChakraCore/blob/master/lib/Runtime/Library/DateImplementation.cpp#L1199-L1200
