### PR TITLE
Fixing a bug in FreeLoopBodyJobManager::GetJob

### DIFF
--- a/lib/Backend/NativeCodeGenerator.cpp
+++ b/lib/Backend/NativeCodeGenerator.cpp
@@ -2757,7 +2757,9 @@ void NativeCodeGenerator::FreeLoopBodyJobManager::QueueFreeLoopBodyJob(void* cod
 
         {
             AutoOptionalCriticalSection lock(Processor()->GetCriticalSection());
+#if DBG
             this->waitingForStackJob = true;
+#endif
             this->stackJobProcessed = false;
             Processor()->AddJob(&stackJob);
         }

--- a/lib/Backend/NativeCodeGenerator.h
+++ b/lib/Backend/NativeCodeGenerator.h
@@ -212,7 +212,9 @@ private:
             , autoClose(true)
             , isClosed(false)
             , stackJobProcessed(false)
+#if DBG
             , waitingForStackJob(false)
+#endif
         {
             Processor()->AddManager(this);
         }
@@ -240,9 +242,8 @@ private:
 
         FreeLoopBodyJob* GetJob(FreeLoopBodyJob* job)
         {
-            if (this->waitingForStackJob)
+            if (!job->heapAllocated)
             {
-                Assert(job->heapAllocated == false);
                 return this->stackJobProcessed ? nullptr : job;
             }
             else
@@ -284,8 +285,10 @@ private:
             }
             else
             {
+#if DBG
                 Assert(this->waitingForStackJob);
                 this->waitingForStackJob = false;
+#endif
                 this->stackJobProcessed = true;
             }
         }
@@ -297,7 +300,9 @@ private:
         bool autoClose;
         bool isClosed;
         bool stackJobProcessed;
+#if DBG
         bool waitingForStackJob;
+#endif
     };
 
     FreeLoopBodyJobManager freeLoopBodyManager;


### PR DESCRIPTION
`FreeLoopBodyJobManager::GetJob` first checks whether `FreeLoopBodyJobManager::waitingForStackJob` is true, if yes, then it returns the passed in job if `FreeLoopBodyJobManager::stackJobProcessed` is false, otherwise return `nullptr`. If `waitingForStackJob` is false, the method just returns the passed in job. However, waitingForStackJob is set to false in
`FreeLoopBodyJobManager::JobProcessed`, which makes the first check in `GetJob` fail and it returns
the job. We later try to move the job to the beginning of the jobs queue but since the job was already processed, it is not present in the queue.

Fix is to have `GetJob` check for a stack allocated job instead of checking for `waitingForStackJob`.
