### PR TITLE
Do not reuse by resetting the JavascriptStaticEnumerator in the ForInObjectEnumerator

### DIFF
--- a/lib/Runtime/Library/ForInObjectEnumerator.cpp
+++ b/lib/Runtime/Library/ForInObjectEnumerator.cpp
@@ -37,7 +37,6 @@ namespace Js
             enumerator.Clear();
             this->object = nullptr;
             this->baseObject = nullptr;
-            this->baseObjectType = nullptr;
             this->firstPrototype = nullptr;
             return;
         }
@@ -45,23 +44,9 @@ namespace Js
         Assert(JavascriptOperators::GetTypeId(currentObject) != TypeIds_Null
             && JavascriptOperators::GetTypeId(currentObject) != TypeIds_Undefined);
 
-        if (this->object == currentObject &&
-            this->baseObjectType == currentObject->GetType())
-        {
-            // We can re-use the enumerator, only if the 'object' and type from the previous enumeration
-            // remains the same. If the previous enumeration involved prototype enumeration
-            // 'object' and 'currentEnumerator' would represent the prototype. Hence,
-            // we cannot re-use it. Null objects are always equal, therefore, the enumerator cannot
-            // be re-used.
-            enumerator.Reset();
-        }
-        else
-        {
-            this->baseObjectType = currentObject->GetType();
-            this->object = currentObject;
+        this->object = currentObject;
 
-            InitializeCurrentEnumerator();
-        }
+        InitializeCurrentEnumerator();
 
         this->baseObject = currentObject;
         firstPrototype = GetFirstPrototypeWithEnumerableProperties(object);

--- a/lib/Runtime/Library/ForInObjectEnumerator.h
+++ b/lib/Runtime/Library/ForInObjectEnumerator.h
@@ -15,7 +15,6 @@ namespace Js
         BVSparse<Recycler>* propertyIds;
         RecyclableObject *firstPrototype;
         Var currentIndex;
-        Type* baseObjectType;
         SListBase<Js::PropertyRecord const *> newPropertyStrings;
         ScriptContext * scriptContext;
         bool enumSymbols;


### PR DESCRIPTION
Even if the type match, the object may have change to have array index, producing wrong result.
Since we now have an instance of the DynamicObjectPropertyEnumerator in the JavascriptStaticEnumerator already, reset doesn't really gain us much.  So just remove it.
