### PR TITLE
fix bug with trying to use full JS strings from JIT

### DIFF
--- a/lib/Backend/Backend.h
+++ b/lib/Backend/Backend.h
@@ -112,6 +112,7 @@ enum IRDumpFlags
 
 #include "ChakraJIT.h"
 #include "JITTimeProfileInfo.h"
+#include "JITRecyclableObject.h"
 #include "JITTimeFixedField.h"
 #include "JITTimePolymorphicInlineCache.h"
 #include "JITTimePolymorphicInlineCacheInfo.h"

--- a/lib/Backend/CaseNode.cpp
+++ b/lib/Backend/CaseNode.cpp
@@ -32,9 +32,9 @@ DefaultComparer<CaseNode *>::Equals(CaseNode * caseNode1, CaseNode* caseNode2)
     }
     else if(caseNode1->IsSrc2StrConst() && caseNode2->IsSrc2StrConst())
     {
-        Js::JavascriptString * caseVal1 = caseNode1->GetSrc2StringConst();
-        Js::JavascriptString * caseVal2 = caseNode2->GetSrc2StringConst();
-        return Js::JavascriptString::Equals(caseVal1, caseVal2);
+        JITJavascriptString * caseVal1 = caseNode1->GetSrc2StringConst();
+        JITJavascriptString * caseVal2 = caseNode2->GetSrc2StringConst();
+        return JITJavascriptString::Equals(caseVal1, caseVal2);
     }
     else
     {

--- a/lib/Backend/CaseNode.h
+++ b/lib/Backend/CaseNode.h
@@ -31,15 +31,15 @@ public:
         return caseInstr->GetSrc2()->GetStackSym()->GetIntConstValue();
     }
 
-    Js::JavascriptString* GetSrc2StringConstLocal()
+    JITJavascriptString* GetSrc2StringConstLocal()
     {
         AssertMsg(caseInstr->GetSrc2()->GetStackSym()->m_isStrConst,"Source2 operand is not an integer constant");
-        return Js::JavascriptString::FromVar(caseInstr->GetSrc2()->GetStackSym()->GetConstAddress(true));
+        return JITJavascriptString::FromVar(caseInstr->GetSrc2()->GetStackSym()->GetConstAddress(true));
     }
-    Js::JavascriptString* GetSrc2StringConst()
+    JITJavascriptString* GetSrc2StringConst()
     {
         AssertMsg(caseInstr->GetSrc2()->GetStackSym()->m_isStrConst, "Source2 operand is not an integer constant");
-        return static_cast<Js::JavascriptString*>(caseInstr->GetSrc2()->GetStackSym()->GetConstAddress(false));
+        return static_cast<JITJavascriptString*>(caseInstr->GetSrc2()->GetStackSym()->GetConstAddress(false));
     }
 
     bool IsSrc2IntConst()

--- a/lib/Backend/Chakra.Backend.vcxproj
+++ b/lib/Backend/Chakra.Backend.vcxproj
@@ -384,6 +384,7 @@
     <ClInclude Include="IRTypeList.h" />
     <ClInclude Include="JITObjTypeSpecFldInfo.h" />
     <ClInclude Include="JITOutput.h" />
+    <ClInclude Include="JITRecyclableObject.h" />
     <ClInclude Include="JITTimeConstructorCache.h" />
     <ClInclude Include="JITTimeFixedField.h" />
     <ClInclude Include="JITTimeFunctionBody.h" />

--- a/lib/Backend/Chakra.Backend.vcxproj.filters
+++ b/lib/Backend/Chakra.Backend.vcxproj.filters
@@ -125,7 +125,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)JITTypeHandler.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)ServerScriptContext.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)ServerThreadContext.cpp" />
-    <ClCompile Include="JITTimeFixedField.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)JITTimeFixedField.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="AgenPeeps.h" />
@@ -334,6 +334,8 @@
     <ClInclude Include="ServerThreadContext.h" />
     <ClInclude Include="ServerScriptContext.h" />
     <ClInclude Include="JITTimeFixedField.h" />
+    <ClInclude Include="ExternalLowerer.h" />
+    <ClInclude Include="JITRecyclableObject.h" />
   </ItemGroup>
   <ItemGroup>
     <MASM Include="$(MSBuildThisFileDirectory)amd64\LinearScanMdA.asm">

--- a/lib/Backend/GlobOpt.h
+++ b/lib/Backend/GlobOpt.h
@@ -439,18 +439,19 @@ class VarConstantValueInfo : public ValueInfo
 {
 private:
     Js::Var const varValue;
+    Js::Var const localVarValue;
     bool isFunction;
 
 public:
-    VarConstantValueInfo(Js::Var varValue, ValueType valueType, bool isFunction = false)
+    VarConstantValueInfo(Js::Var varValue, ValueType valueType, bool isFunction = false, Js::Var localVarValue = nullptr)
         : ValueInfo(valueType, ValueStructureKind::VarConstant),
-        varValue(varValue), isFunction(isFunction)
+        varValue(varValue), localVarValue(localVarValue), isFunction(isFunction)
     {
     }
 
-    static VarConstantValueInfo *New(JitArenaAllocator *const allocator, Js::Var varValue, ValueType valueType, bool isFunction = false)
+    static VarConstantValueInfo *New(JitArenaAllocator *const allocator, Js::Var varValue, ValueType valueType, bool isFunction = false, Js::Var localVarValue = nullptr)
     {
-        return JitAnew(allocator, VarConstantValueInfo, varValue, valueType, isFunction);
+        return JitAnew(allocator, VarConstantValueInfo, varValue, valueType, isFunction, localVarValue);
     }
 
     VarConstantValueInfo *Copy(JitArenaAllocator *const allocator) const
@@ -459,9 +460,16 @@ public:
     }
 
 public:
-    Js::Var VarValue() const
+    Js::Var VarValue(bool useLocal = false) const
     {
-        return this->varValue;
+        if(useLocal && this->localVarValue)
+        {
+            return this->localVarValue;
+        }
+        else
+        {
+            return this->varValue;
+        }
     }
 
     bool IsFunction() const

--- a/lib/Backend/IR.h
+++ b/lib/Backend/IR.h
@@ -761,7 +761,7 @@ private:
     */
 
 private:
-    typedef Js::JavascriptString* TBranchKey;
+    typedef JITJavascriptString* TBranchKey;
     typedef Js::BranchDictionaryWrapper<TBranchKey> BranchDictionaryWrapper;
     typedef BranchDictionaryWrapper::BranchDictionary BranchDictionary;
     typedef BranchJumpTableWrapper BranchJumpTable;

--- a/lib/Backend/IRBuilder.cpp
+++ b/lib/Backend/IRBuilder.cpp
@@ -1472,15 +1472,8 @@ IRBuilder::BuildConstantLoads()
             if (m_func->IsOOPJIT())
             {
                 // must be either PropertyString or LiteralString
-                Js::JavascriptString * constStr;
-                if (m_func->GetJITFunctionBody()->IsConstRegPropertyString(reg, m_func->GetScriptContextInfo()))
-                {
-                    constStr = m_func->GetJITFunctionBody()->GetConstAsT<Js::PropertyString>(reg);
-                }
-                else
-                {
-                    constStr = m_func->GetJITFunctionBody()->GetConstAsT<Js::LiteralString>(reg);
-                }
+                JITRecyclableObject * jitObj = m_func->GetJITFunctionBody()->GetConstantContent(reg);
+                JITJavascriptString * constStr = JITJavascriptString::FromVar(jitObj);
                 instr = IR::Instr::NewConstantLoad(dstOpnd, varConst, valueType, m_func, constStr);
             }
             else

--- a/lib/Backend/JITRecyclableObject.h
+++ b/lib/Backend/JITRecyclableObject.h
@@ -46,19 +46,13 @@ public:
 
     static JITJavascriptString * JITJavascriptString::FromVar(Js::Var var)
     {
-        JITJavascriptString * jitString = reinterpret_cast<JITJavascriptString*>(var);
-#if DBG
-        Assert(Is(var));
-        Assert(jitString->GetTypeId() == Js::TypeIds_String);
-        if (!JITManager::GetJITManager()->IsOOPJITEnabled())
-        {
-            Js::JavascriptString * fullString = Js::JavascriptString::FromVar(var);
-            // ensure layouts are same
-            Assert(fullString->GetLength() == jitString->GetLength());
-            Assert(wmemcmp(fullString->GetString(), jitString->GetString(), jitString->GetLength()) == 0);
-        }
+#ifdef HAS_CONSTEXPR
+        CompileAssert(offsetof(JITJavascriptString, m_pszValue) == Js::JavascriptString::GetOffsetOfpszValue());
+        CompileAssert(offsetof(JITJavascriptString, m_charLength) == Js::JavascriptString::GetOffsetOfcharLength());
 #endif
-        return jitString;
+        Assert(Is(var));
+
+        return reinterpret_cast<JITJavascriptString*>(var);
     }
 };
 

--- a/lib/Backend/JITRecyclableObject.h
+++ b/lib/Backend/JITRecyclableObject.h
@@ -1,0 +1,84 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#pragma once
+
+class JITRecyclableObject
+{
+private:
+    intptr_t remoteVTable;
+    Js::TypeId * typeId;
+public:
+    Js::TypeId GetTypeId() const
+    {
+        return *typeId;
+    }
+};
+
+class JITJavascriptString : JITRecyclableObject
+{
+private:
+    const char16* m_pszValue;
+    charcount_t m_charLength;
+public:
+    const char16* GetString() const
+    {
+        return m_pszValue;
+    }
+
+    charcount_t GetLength() const
+    {
+        return m_charLength;
+    }
+
+    static bool JITJavascriptString::Equals(Js::Var aLeft, Js::Var aRight)
+    {
+        return Js::JavascriptStringHelpers<JITJavascriptString>::Equals(aLeft, aRight);
+    }
+
+    static bool JITJavascriptString::Is(Js::Var var)
+    {
+        JITRecyclableObject * jitObj = reinterpret_cast<JITRecyclableObject*>(var);
+        return jitObj->GetTypeId() == Js::TypeIds_String;
+    }
+
+    static JITJavascriptString * JITJavascriptString::FromVar(Js::Var var)
+    {
+        JITJavascriptString * jitString = reinterpret_cast<JITJavascriptString*>(var);
+#if DBG
+        Assert(Is(var));
+        Assert(jitString->GetTypeId() == Js::TypeIds_String);
+        if (!JITManager::GetJITManager()->IsOOPJITEnabled())
+        {
+            Js::JavascriptString * fullString = Js::JavascriptString::FromVar(var);
+            // ensure layouts are same
+            Assert(fullString->GetLength() == jitString->GetLength());
+            Assert(wmemcmp(fullString->GetString(), jitString->GetString(), jitString->GetLength()) == 0);
+        }
+#endif
+        return jitString;
+    }
+};
+
+class JITJavascriptNumber : JITRecyclableObject
+{
+private:
+    double value;
+
+};
+
+template <>
+struct DefaultComparer<JITJavascriptString*>
+{
+    inline static bool Equals(JITJavascriptString * x, JITJavascriptString * y)
+    {
+        return Js::JavascriptStringHelpers<JITJavascriptString>::Equals(x, y);
+    }
+
+    inline static uint GetHashCode(JITJavascriptString * pStr)
+    {
+        return JsUtil::CharacterBuffer<char16>::StaticGetHashCode(pStr->GetString(), pStr->GetLength());
+    }
+};

--- a/lib/Backend/JITTimeFunctionBody.cpp
+++ b/lib/Backend/JITTimeFunctionBody.cpp
@@ -49,12 +49,6 @@ JITTimeFunctionBody::InitializeJITFunctionData(
                     }
                     else
                     {
-                        // irbuilder relies on this assertion
-                        Assert(!Js::JavascriptString::Is(varConst)
-                            || VirtualTableInfo<Js::LiteralString>::HasVirtualTable(varConst)
-                            || VirtualTableInfo<Js::PropertyString>::HasVirtualTable(varConst)
-                            || VirtualTableInfo<Js::SingleCharString>::HasVirtualTable(varConst));
-
                         jitBody->constTableContent->content[reg - Js::FunctionBody::FirstRegSlot] = (RecyclableObjectIDL*)varConst;
                     }
                 }
@@ -831,6 +825,19 @@ JITTimeFunctionBody::GetConstantVar(Js::RegSlot location) const
     Assert(location != 0);
 
     return static_cast<intptr_t>(m_bodyData.constTable[location - Js::FunctionBody::FirstRegSlot]);
+}
+
+JITRecyclableObject *
+JITTimeFunctionBody::GetConstantContent(Js::RegSlot location) const
+{
+    Assert(m_bodyData.constTableContent != nullptr);
+    Assert(m_bodyData.constTableContent->content != nullptr);
+    Assert(location < GetConstCount());
+    Assert(location != 0);
+
+    JITRecyclableObject * obj = (JITRecyclableObject *)m_bodyData.constTableContent->content[location - Js::FunctionBody::FirstRegSlot];
+    Assert(obj);
+    return obj;
 }
 
 intptr_t

--- a/lib/Backend/JITTimeFunctionBody.h
+++ b/lib/Backend/JITTimeFunctionBody.h
@@ -9,6 +9,7 @@
 class AsmJsJITInfo;
 class JITTimeProfileInfo;
 class FunctionJITRuntimeInfo;
+class JITRecyclableObject;
 
 class JITTimeFunctionBody
 {
@@ -103,6 +104,8 @@ public:
     void * ReadFromAuxContextData(uint offset) const;
     intptr_t GetNestedFuncRef(uint index) const;
     intptr_t GetConstantVar(Js::RegSlot location) const;
+    JITRecyclableObject * GetConstantContent(Js::RegSlot location) const;
+
     template<class T>
     T* GetConstAsT(Js::RegSlot location) const
     {

--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -20073,7 +20073,7 @@ Lowerer::TryGenerateFastBrOrCmTypeOf(IR::Instr *instr, IR::Instr **prev, bool *p
                 Assert(instrSrc2->m_sym->m_instrDef->GetSrc1()->IsAddrOpnd());
 
                 // We can't optimize non-javascript type strings.
-                Js::JavascriptString *typeNameJsString = Js::JavascriptString::FromVar(instrSrc2->m_sym->m_instrDef->GetSrc1()->AsAddrOpnd()->m_localAddress);
+                JITJavascriptString *typeNameJsString = JITJavascriptString::FromVar(instrSrc2->m_sym->m_instrDef->GetSrc1()->AsAddrOpnd()->m_localAddress);
                 const char16        *typeName         = typeNameJsString->GetString();
 
                 Js::InternalString typeNameString(typeName, typeNameJsString->GetLength());
@@ -21081,11 +21081,9 @@ Lowerer::LowerSetConcatStrMultiItem(IR::Instr * instr)
     IR::IndirOpnd * dstLength = IR::IndirOpnd::New(concatStrOpnd, Js::ConcatStringMulti::GetOffsetOfcharLength(), TyUint32, func);
     IR::Opnd * srcLength;
 
-    // TODO: OOP JIT, String Length
-    if (!func->IsOOPJIT() && CONFIG_FLAG(OOPJITMissingOpts) && srcOpnd->m_sym->m_isStrConst)
+    if (srcOpnd->m_sym->m_isStrConst)
     {
-        srcLength = IR::IntConstOpnd::New(Js::JavascriptString::FromVar(srcOpnd->m_sym->GetConstAddress())->GetLength(),
-            TyUint32, func);
+        srcLength = IR::IntConstOpnd::New(JITJavascriptString::FromVar(srcOpnd->m_sym->GetConstAddress(true))->GetLength(), TyUint32, func);
     }
     else
     {
@@ -22413,7 +22411,7 @@ void Lowerer::GenerateSwitchStringLookup(IR::Instr * instr)
     charcount_t minLength = UINT_MAX;
     charcount_t maxLength = 0;
     BVUnit32 bvLength;
-    instr->AsBranchInstr()->AsMultiBrInstr()->GetBranchDictionary()->dictionary.Map([&](Js::JavascriptString * str, void *)
+    instr->AsBranchInstr()->AsMultiBrInstr()->GetBranchDictionary()->dictionary.Map([&](JITJavascriptString * str, void *)
     {
         charcount_t len = str->GetLength();
         minLength = min(minLength, str->GetLength());

--- a/lib/Backend/SwitchIRBuilder.cpp
+++ b/lib/Backend/SwitchIRBuilder.cpp
@@ -233,7 +233,7 @@ SwitchIRBuilder::OnCase(IR::RegOpnd * src1Opnd, IR::RegOpnd * src2Opnd, uint32 o
     }
 
     if (GlobOpt::IsSwitchOptEnabled(m_func->GetTopFunc()) && src2Opnd->m_sym->m_isStrConst
-        && TestAndAddStringCaseConst(Js::JavascriptString::FromVar(src2Opnd->GetStackSym()->GetConstAddress(true))))
+        && TestAndAddStringCaseConst(JITJavascriptString::FromVar(src2Opnd->GetStackSym()->GetConstAddress(true))))
     {
         // We've already seen a case statement with the same string const value. No need to emit anything for this.
         return;
@@ -770,7 +770,7 @@ SwitchIRBuilder::BuildBailOnNotString()
 ///----------------------------------------------------------------------------
 
 bool
-SwitchIRBuilder::TestAndAddStringCaseConst(Js::JavascriptString * str)
+SwitchIRBuilder::TestAndAddStringCaseConst(JITJavascriptString * str)
 {
     Assert(m_strConstSwitchCases);
 
@@ -825,7 +825,7 @@ SwitchIRBuilder::BuildMultiBrCaseInstrForStrings(uint32 targetOffset)
         generateDictionary = false;
         for (uint i = 0; i < caseCount; i++)
         {
-            Js::JavascriptString * str = m_caseNodes->Item(i)->GetSrc2StringConstLocal();
+            JITJavascriptString * str = m_caseNodes->Item(i)->GetSrc2StringConstLocal();
             Assert(str->GetLength() == 1);
             char16 currChar = str->GetString()[0];
             minChar = min(minChar, currChar);
@@ -846,7 +846,7 @@ SwitchIRBuilder::BuildMultiBrCaseInstrForStrings(uint32 targetOffset)
         //Adding normal cases to the instruction (except the default case, which we do it later)
         for (uint i = 0; i < caseCount; i++)
         {
-            Js::JavascriptString * str = m_caseNodes->Item(i)->GetSrc2StringConstLocal();
+            JITJavascriptString * str = m_caseNodes->Item(i)->GetSrc2StringConstLocal();
             uint32 caseTargetOffset = m_caseNodes->Item(i)->GetTargetOffset();
             multiBranchInstr->AddtoDictionary(caseTargetOffset, str, m_caseNodes->Item(i)->GetSrc2StringConst());
         }
@@ -871,7 +871,7 @@ SwitchIRBuilder::BuildMultiBrCaseInstrForStrings(uint32 targetOffset)
         //Adding normal cases to the instruction (except the default case, which we do it later)
         for (uint i = 0; i < caseCount; i++)
         {
-            Js::JavascriptString * str = m_caseNodes->Item(i)->GetSrc2StringConstLocal();
+            JITJavascriptString * str = m_caseNodes->Item(i)->GetSrc2StringConstLocal();
             Assert(str->GetLength() == 1);
             uint32 caseTargetOffset = m_caseNodes->Item(i)->GetTargetOffset();
             multiBranchInstr->AddtoJumpTable(caseTargetOffset, str->GetString()[0] - minChar);

--- a/lib/Backend/SwitchIRBuilder.h
+++ b/lib/Backend/SwitchIRBuilder.h
@@ -63,7 +63,7 @@ public:
 class SwitchIRBuilder {
 private:
     typedef JsUtil::List<CaseNode*, JitArenaAllocator>              CaseNodeList;
-    typedef JsUtil::List<Js::JavascriptString *, JitArenaAllocator> StrSwitchCaseList;
+    typedef JsUtil::List<JITJavascriptString *, JitArenaAllocator> StrSwitchCaseList;
 
     SwitchAdapter*                  m_adapter;
     Func*                           m_func;
@@ -114,7 +114,7 @@ public:
     void                FixUpMultiBrJumpTable(IR::MultiBranchInstr * multiBranchInstr, uint32 targetOffset);
     void                TryBuildBinaryTreeOrMultiBrForSwitchInts(IR::MultiBranchInstr * &multiBranchInstr, uint32 fallthrOffset,
         int startjmpTableIndex, int endjmpTableIndex, int startBinaryTravIndex, uint32 targetOffset);
-    bool                TestAndAddStringCaseConst(Js::JavascriptString * str);
+    bool                TestAndAddStringCaseConst(JITJavascriptString * str);
     void                BuildBailOnNotInteger();
     void                BuildBailOnNotString();
     IR::MultiBranchInstr * BuildMultiBrCaseInstrForInts(uint32 start, uint32 end, uint32 targetOffset);

--- a/lib/Common/CommonDefines.h
+++ b/lib/Common/CommonDefines.h
@@ -186,6 +186,16 @@
 // Other features
 // #define CHAKRA_CORE_DOWN_COMPAT 1
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1900 )
+#define HAS_CONSTEXPR 1
+#endif
+
+#ifdef HAS_CONSTEXPR
+#define OPT_CONSTEXPR constexpr
+#else
+#define OPT_CONSTEXPR
+#endif
+
 #if defined(ENABLE_DEBUG_CONFIG_OPTIONS) || defined(CHAKRA_CORE_DOWN_COMPAT)
 #define DELAYLOAD_SET_CFG_TARGET 1
 #endif

--- a/lib/Runtime/Library/JavascriptString.cpp
+++ b/lib/Runtime/Library/JavascriptString.cpp
@@ -8,6 +8,10 @@
 #include "Library/EngineInterfaceObject.h"
 #include "Library/IntlEngineInterfaceExtensionObject.h"
 
+#if ENABLE_NATIVE_CODEGEN
+#include "../Backend/JITRecyclableObject.h"
+#endif
+
 namespace Js
 {
     // White Space characters are defined in ES6 Section 11.2
@@ -3002,21 +3006,7 @@ case_2:
 
     bool JavascriptString::Equals(Var aLeft, Var aRight)
     {
-        AssertMsg(JavascriptString::Is(aLeft) && JavascriptString::Is(aRight), "string comparison");
-
-        JavascriptString *leftString  = JavascriptString::FromVar(aLeft);
-        JavascriptString *rightString = JavascriptString::FromVar(aRight);
-
-        if (leftString->GetLength() != rightString->GetLength())
-        {
-            return false;
-        }
-
-        if (wmemcmp(leftString->GetString(), rightString->GetString(), leftString->GetLength()) == 0)
-        {
-            return true;
-        }
-        return false;
+        return JavascriptStringHelpers<JavascriptString>::Equals(aLeft, aRight);
     }
 
     //
@@ -3876,4 +3866,30 @@ case_2:
     {
         return requestContext->GetLibrary()->GetStringTypeDisplayString();
     }
+
+    /* static */
+    template <typename T>
+    bool JavascriptStringHelpers<T>::Equals(Var aLeft, Var aRight)
+    {
+        AssertMsg(T::Is(aLeft) && T::Is(aRight), "string comparison");
+
+        T *leftString = T::FromVar(aLeft);
+        T *rightString = T::FromVar(aRight);
+
+        if (leftString->GetLength() != rightString->GetLength())
+        {
+            return false;
+        }
+
+        if (wmemcmp(leftString->GetString(), rightString->GetString(), leftString->GetLength()) == 0)
+        {
+            return true;
+        }
+        return false;
+    }
+
+#if ENABLE_NATIVE_CODEGEN
+    template bool JavascriptStringHelpers<JITJavascriptString>::Equals(Var aLeft, Var aRight);
+#endif
+
 }

--- a/lib/Runtime/Library/JavascriptString.h
+++ b/lib/Runtime/Library/JavascriptString.h
@@ -401,6 +401,13 @@ namespace Js
         return (str1->GetLength() == str2->GetLength() && !Js::IsInternalPropertyId(str1->GetPropertyId()) &&
             JsUtil::CharacterBuffer<WCHAR>::StaticEquals(str1->GetBuffer(), str2->GetString(), str1->GetLength()));
     }
+
+    template <typename T>
+    class JavascriptStringHelpers
+    {
+    public:
+        static bool Equals(Var aLeft, Var aRight);
+    };
 }
 
 template <>

--- a/lib/Runtime/Library/JavascriptString.h
+++ b/lib/Runtime/Library/JavascriptString.h
@@ -218,12 +218,12 @@ namespace Js
         static JavascriptString* Concat_BothOneChar(JavascriptString * pstLeft, JavascriptString * pstRight);
 
     public:
-        static uint32 GetOffsetOfpszValue()
+        static OPT_CONSTEXPR uint32 GetOffsetOfpszValue()
         {
             return offsetof(JavascriptString, m_pszValue);
         }
 
-        static uint32 GetOffsetOfcharLength()
+        static OPT_CONSTEXPR uint32 GetOffsetOfcharLength()
         {
             return offsetof(JavascriptString, m_charLength);
         }

--- a/lib/Runtime/Runtime.h
+++ b/lib/Runtime/Runtime.h
@@ -53,6 +53,7 @@ class LowererMDArch;
 class ByteCodeGenerator;
 interface IActiveScriptDataCache;
 class ActiveScriptProfilerHeapEnum;
+class JITJavascriptString;
 
 ////////
 


### PR DESCRIPTION
For OOP JIT, we only marshal across the necessary bits we need from RecyclableObjects, in particular for JavascriptStrings we only marshal the typeId, buffer, and length.
We then need to make sure to only use the bits we have available.

There was a place where we do FromVar, which under an assert calls type->CanHaveInterceptors(). And that is data we don't have, so it reads some invalid memory from the RPC buffer.

To make this all much safer (and fix the assert) I have added a new JITJavascriptString class which contains only the fields we have, and replaced all backend string usage with this. This also gave me the opportunity to enable a couple of places where we were being cautious and disabling string optimizations for OOP JIT (these optimizations were pretty minor, so OOP JIT benchmarks are flat).