### PR TITLE
If we have no user crash handler we should generate additional info.

### DIFF
--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -6479,7 +6479,7 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
             // mark the stackFrame as 'in try block'
             this->m_flags |= InterpreterStackFrameFlags_WithinTryBlock;
 
-            Js::JavascriptExceptionOperators::AutoCatchHandlerExists autoCatchHandlerExists(scriptContext);
+            Js::JavascriptExceptionOperators::AutoCatchHandlerExists autoCatchHandlerExists(scriptContext, true);
 
             if (this->IsInDebugMode())
             {
@@ -6615,7 +6615,7 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
                     this->ProcessTryCatchBailout(ehBailoutData->child, --tryNestingDepth);
                 }
 
-                Js::JavascriptExceptionOperators::AutoCatchHandlerExists autoCatchHandlerExists(scriptContext);
+                Js::JavascriptExceptionOperators::AutoCatchHandlerExists autoCatchHandlerExists(scriptContext, true);
 
                 if (this->IsInDebugMode())
                 {

--- a/lib/Runtime/Language/JavascriptExceptionOperators.cpp
+++ b/lib/Runtime/Language/JavascriptExceptionOperators.cpp
@@ -17,14 +17,13 @@ namespace Js
     {
         Assert(scriptContext);
 
-        bool fFound = false;
         // If the outer try catch was already in the user code, no need to go any further.
         if (!m_previousCatchHandlerToUserCodeStatus)
         {
             if (!isUserExceptionHandling)
             {
-                fFound = true;
                 m_threadContext->SetIsUserCode(false);
+                return;
             }
             else
             {
@@ -35,17 +34,14 @@ namespace Js
                     if (caller != NULL && (funcBody = caller->GetFunctionBody()) != NULL)
                     {
                         m_threadContext->SetIsUserCode(funcBody->IsNonUserCode() == false);
-                        fFound = true;
+                        return;
                     }
                 }
             }
         }
 
-        if (!fFound)
-        {
-            // If not successfully able to find the caller, set this catch handler belongs to the user code.
-            m_threadContext->SetIsUserCode(true);
-        }
+        // If not successfully able to find the caller, set this catch handler belongs to the user code.
+        m_threadContext->SetIsUserCode(true);
     }
 
     JavascriptExceptionOperators::AutoCatchHandlerExists::AutoCatchHandlerExists(ScriptContext* scriptContext, bool isUserExceptionHandling)

--- a/lib/Runtime/Language/JavascriptExceptionOperators.h
+++ b/lib/Runtime/Language/JavascriptExceptionOperators.h
@@ -36,10 +36,10 @@ namespace Js
             bool m_previousCatchHandlerExists;
             bool m_previousCatchHandlerToUserCodeStatus;
             ThreadContext* m_threadContext;
-            void FetchNonUserCodeStatus(ScriptContext *scriptContext);
+            void FetchNonUserCodeStatus(ScriptContext *scriptContext, bool isUserExecptionHandling);
 
           public:
-            AutoCatchHandlerExists(ScriptContext* scriptContext);
+            AutoCatchHandlerExists(ScriptContext* scriptContext, bool isUserExceptionHandling);
             ~AutoCatchHandlerExists();
         };
 

--- a/lib/Runtime/Language/JavascriptExceptionOperators.h
+++ b/lib/Runtime/Language/JavascriptExceptionOperators.h
@@ -36,7 +36,7 @@ namespace Js
             bool m_previousCatchHandlerExists;
             bool m_previousCatchHandlerToUserCodeStatus;
             ThreadContext* m_threadContext;
-            void FetchNonUserCodeStatus(ScriptContext *scriptContext, bool isUserExecptionHandling);
+            void FetchNonUserCodeStatus(ScriptContext *scriptContext, bool isUserExeceptionHandling);
 
           public:
             AutoCatchHandlerExists(ScriptContext* scriptContext, bool isUserExceptionHandling);

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -353,7 +353,7 @@ namespace Js
         Var value;
         try
         {
-            Js::JavascriptExceptionOperators::AutoCatchHandlerExists autoCatchHandlerExists(scriptContext);
+            Js::JavascriptExceptionOperators::AutoCatchHandlerExists autoCatchHandlerExists(scriptContext, false);
 
             // In edge mode, spec compat is more important than backward compat. Use spec/web behavior here
             if (isRoot
@@ -441,7 +441,7 @@ namespace Js
 
         try
         {
-            Js::JavascriptExceptionOperators::AutoCatchHandlerExists autoCatchHandlerExists(scriptContext);
+            Js::JavascriptExceptionOperators::AutoCatchHandlerExists autoCatchHandlerExists(scriptContext, false);
             IndexType indexType = GetIndexType(index, scriptContext, &indexVal, &propertyRecord, false);
 
             // For JS Objects, don't create the propertyId if not already added

--- a/lib/Runtime/Language/JavascriptOperators.h
+++ b/lib/Runtime/Language/JavascriptOperators.h
@@ -54,7 +54,7 @@ namespace Js
 
 #define BEGIN_TYPEOF_ERROR_HANDLER(scriptContext)  \
     try { \
-    Js::JavascriptExceptionOperators::AutoCatchHandlerExists autoCatchHandlerExists(scriptContext); \
+    Js::JavascriptExceptionOperators::AutoCatchHandlerExists autoCatchHandlerExists(scriptContext, false); \
     class AutoCleanup \
     { \
     private: \

--- a/lib/Runtime/Library/JavascriptPromise.cpp
+++ b/lib/Runtime/Library/JavascriptPromise.cpp
@@ -736,7 +736,7 @@ namespace Js
         JavascriptExceptionObject* exception = nullptr;
 
         {
-            Js::JavascriptExceptionOperators::AutoCatchHandlerExists autoCatchHandlerExists(scriptContext);
+            Js::JavascriptExceptionOperators::AutoCatchHandlerExists autoCatchHandlerExists(scriptContext, false);
             try
             {
                 handlerResult = CALL_FUNCTION(handler, Js::CallInfo(Js::CallFlags::CallFlags_Value, 2),
@@ -810,7 +810,7 @@ namespace Js
         JavascriptExceptionObject* exception = nullptr;
 
         {
-            Js::JavascriptExceptionOperators::AutoCatchHandlerExists autoCatchHandlerExists(scriptContext);
+            Js::JavascriptExceptionOperators::AutoCatchHandlerExists autoCatchHandlerExists(scriptContext, false);
             try
             {
                 return CALL_FUNCTION(thenFunction, Js::CallInfo(Js::CallFlags::CallFlags_Value, 3),

--- a/test/Error/rlexe.xml
+++ b/test/Error/rlexe.xml
@@ -171,4 +171,10 @@
       <compile-flags>-ExtendedErrorStackForTestHost -force:DeferParse</compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>useruncaught.js</files>
+      <baseline>useruncaught.baseline</baseline>
+    </default>
+  </test>
 </regress-exe>

--- a/test/Error/useruncaught.baseline
+++ b/test/Error/useruncaught.baseline
@@ -1,0 +1,3 @@
+TypeError: Unable to get property 'prop5' of undefined or null reference
+	at func12() (useruncaught.js:9:3)
+	at Global code (useruncaught.js:11:1)

--- a/test/Error/useruncaught.js
+++ b/test/Error/useruncaught.js
@@ -1,0 +1,11 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+var arrObj0 = {};
+function func12() {
+  'use strict';
+  arrObj0(arrObj0(typeof this.prop5));
+}
+func12();


### PR DESCRIPTION
The previous way we were doing things, we'd only generate the additional
backtrace information about arguments and the like when an exception was
_totally_ uncaught. This interfered with our implicit autocatchhandlers,
which were added for some instructions. This caused divergences with the
nonative version of the debug output, where we wouldn't add these, which
caused us to only generate the additional backtrace information in a few
of the test configurations, but not all of them. By allowing creation of
the additional backtrace information when we have a catch handler but no
user catch handler, we handle these cases more uniformly.

This does, however, mean that our information on whether or not there is
a user catch handler; the existing code does this to some degree, but it
is polluted by a bunch of implied catch handlers in both interpreter and
in helper code. I added an argument to autocatchhandler to specify if we
can mark a particular instance of the autocatchhandler as user-made; the
values that I've chosen for it (i.e. where it is true) should be checked
and verified. Note that if the argument is true, that only means that it
_can_ be a user catch handler; if it's not in user code (e.g. in chakra-
generated JS) then it still won't be marked as a user catch handler.
