### PR TITLE
line/column difference on emitting index on boolean expression.

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -8854,8 +8854,8 @@ void EmitBooleanExpression(ParseNode *expr, Js::ByteCodeLabel trueLabel, Js::Byt
         // But in this case, EmitBooleanExpression is just a wrapper around a normal Emit call,
         // and the caller of EmitBooleanExpression expects to be able to release this register.
 
-        // For diagnostics purposes, register the name and dot to the statement list.
-        if (expr->nop == knopName || expr->nop == knopDot)
+        // For diagnostics purposes, register the name/dot/index to the statement list.
+        if (expr->nop == knopName || expr->nop == knopDot || expr->nop == knopIndex)
         {
             byteCodeGenerator->StartStatement(expr);
             Emit(expr, byteCodeGenerator, funcInfo, false);

--- a/test/Error/validate_line_column.baseline
+++ b/test/Error/validate_line_column.baseline
@@ -38,3 +38,7 @@ ReferenceError: 'a' is undefined
 	at Anonymous function (validate_line_column.js:60:5)
 	at foo (validate_line_column.js:10:9)
 	at Global code (validate_line_column.js:58:1)
+ReferenceError: 'unresolved' is undefined
+	at Anonymous function (validate_line_column.js:65:11)
+	at foo (validate_line_column.js:10:9)
+	at Global code (validate_line_column.js:63:1)

--- a/test/Error/validate_line_column.js
+++ b/test/Error/validate_line_column.js
@@ -57,6 +57,12 @@ foo(function() {
 
 foo(function() {
     var k = 1;
-    `${a.b}`;         // Error thrown here.
+    `${a.b}`;         
 });
 
+foo(function() {
+    var k = 1;
+    while(unresolved[0]) {   // Error thrown here.
+        break;
+    }
+});


### PR DESCRIPTION
The index expression was forgotton to have start/end source maps. That causes the error reported on the wrong line/column. Fixed that.
