### PR TITLE
explicitly copy profile data for background in-proc jit

### DIFF
--- a/lib/Backend/FunctionJITTimeInfo.cpp
+++ b/lib/Backend/FunctionJITTimeInfo.cpp
@@ -18,7 +18,8 @@ FunctionJITTimeInfo::BuildJITTimeData(
     __in const Js::FunctionCodeGenJitTimeData * codeGenData,
     __in_opt const Js::FunctionCodeGenRuntimeData * runtimeData,
     __out FunctionJITTimeDataIDL * jitData,
-    bool isInlinee)
+    bool isInlinee,
+    bool isForegroundJIT)
 {
     jitData->bodyData = codeGenData->GetJITBody();
     jitData->functionInfoAddr = (intptr_t)codeGenData->GetFunctionInfo();
@@ -38,7 +39,7 @@ FunctionJITTimeInfo::BuildJITTimeData(
         {
             Assert(jitData->bodyData != nullptr);
             ProfileDataIDL * profileData = AnewStruct(alloc, ProfileDataIDL);
-            JITTimeProfileInfo::InitializeJITProfileData(functionBody->GetAnyDynamicProfileInfo(), functionBody, profileData);
+            JITTimeProfileInfo::InitializeJITProfileData(alloc, functionBody->GetAnyDynamicProfileInfo(), functionBody, profileData, isForegroundJIT);
 
             jitData->bodyData->profileData = profileData;
 
@@ -76,7 +77,7 @@ FunctionJITTimeInfo::BuildJITTimeData(
                         inlineeRuntimeData = isInlinee ? runtimeData->GetInlineeForTargetInlinee(i, inlinee) : functionBody->GetInlineeCodeGenRuntimeDataForTargetInlinee(i, inlinee);
                     }
                     jitData->inlinees[i] = AnewStructZ(alloc, FunctionJITTimeDataIDL);
-                    BuildJITTimeData(alloc, inlineeJITData, inlineeRuntimeData, jitData->inlinees[i], true);
+                    BuildJITTimeData(alloc, inlineeJITData, inlineeRuntimeData, jitData->inlinees[i], true, isForegroundJIT);
                 }
             }
         }
@@ -112,7 +113,7 @@ FunctionJITTimeInfo::BuildJITTimeData(
                 if (inlineeJITData != nullptr)
                 {
                     jitData->ldFldInlinees[i] = AnewStructZ(alloc, FunctionJITTimeDataIDL);
-                    BuildJITTimeData(alloc, inlineeJITData, inlineeRuntimeData, jitData->ldFldInlinees[i]);
+                    BuildJITTimeData(alloc, inlineeJITData, inlineeRuntimeData, jitData->ldFldInlinees[i], true, isForegroundJIT);
                 }
             }
         }
@@ -136,7 +137,7 @@ FunctionJITTimeInfo::BuildJITTimeData(
             {
                 nextRuntimeData = runtimeData->GetNextForTarget(nextJITData->GetFunctionInfo()->GetFunctionBody());
             }
-            BuildJITTimeData(alloc, nextJITData, nextRuntimeData, jitData->next);
+            BuildJITTimeData(alloc, nextJITData, nextRuntimeData, jitData->next, true, isForegroundJIT);
         }
     }
 }

--- a/lib/Backend/FunctionJITTimeInfo.h
+++ b/lib/Backend/FunctionJITTimeInfo.h
@@ -14,7 +14,8 @@ public:
         __in const Js::FunctionCodeGenJitTimeData * codeGenData,
         __in_opt const Js::FunctionCodeGenRuntimeData * runtimeData,
         __out FunctionJITTimeDataIDL * jitData,
-        bool isInlinee = true);
+        bool isInlinee,
+        bool isForegroundJIT);
 
     uint GetInlineeCount() const;
     bool IsLdFldInlineePresent() const;

--- a/lib/Backend/JITTimeProfileInfo.h
+++ b/lib/Backend/JITTimeProfileInfo.h
@@ -11,9 +11,11 @@ public:
     JITTimeProfileInfo(ProfileDataIDL * profileData);
 
     static void InitializeJITProfileData(
+        __in ArenaAllocator * alloc,
         __in Js::DynamicProfileInfo * profileInfo,
         __in Js::FunctionBody *functionBody,
-        __out ProfileDataIDL * data);
+        __out ProfileDataIDL * data,
+        bool isForegroundJIT);
 
     const Js::LdElemInfo * GetLdElemInfo(Js::ProfileId ldElemId) const;
     const Js::StElemInfo * GetStElemInfo(Js::ProfileId stElemId) const;

--- a/lib/Backend/NativeCodeGenerator.cpp
+++ b/lib/Backend/NativeCodeGenerator.cpp
@@ -868,7 +868,7 @@ NativeCodeGenerator::CodeGen(PageAllocator * pageAllocator, CodeGenWorkItem* wor
 
     auto& jitData = workItem->GetJITData()->jitData;
     jitData = AnewStructZ(&alloc, FunctionJITTimeDataIDL);
-    FunctionJITTimeInfo::BuildJITTimeData(&alloc, workItem->RecyclableData()->JitTimeData(), nullptr, workItem->GetJITData()->jitData, false);
+    FunctionJITTimeInfo::BuildJITTimeData(&alloc, workItem->RecyclableData()->JitTimeData(), nullptr, workItem->GetJITData()->jitData, false, foreground);
 
     Js::EntryPointInfo * epInfo = workItem->GetEntryPoint();
     if (workItem->Type() == JsFunctionType)


### PR DESCRIPTION
I changed how the profile data is passed for OOP JIT (which will be copied via RPC), however I didn't consider in-proc JIT at the time. This adds back code to copy ld/st elem info for in-proc background jit.