### PR TITLE
OOP JIT server side error handling

### DIFF
--- a/lib/Backend/CodeGenNumberAllocator.cpp
+++ b/lib/Backend/CodeGenNumberAllocator.cpp
@@ -333,6 +333,7 @@ Js::JavascriptNumber* XProcNumberPageSegmentImpl::AllocateNumber(Func* func, dou
             if (!WriteProcessMemory(hProcess, (void*)number, pLocalNumber, sizeCat, &bytesWritten)
                 || bytesWritten != sizeCat)
             {
+                Js::Throw::CheckAndThrowJITOperationFailed();
                 Output::Print(_u("FATAL ERROR: WriteProcessMemory failed, GLE: %d\n"), GetLastError());
                 Js::Throw::FatalInternalError(); // TODO: don't bring down whole server process, but pass the last error to main process
             }

--- a/lib/Backend/CodeGenNumberAllocator.cpp
+++ b/lib/Backend/CodeGenNumberAllocator.cpp
@@ -334,7 +334,6 @@ Js::JavascriptNumber* XProcNumberPageSegmentImpl::AllocateNumber(Func* func, dou
                 || bytesWritten != sizeCat)
             {
                 Js::Throw::CheckAndThrowJITOperationFailed();
-                Output::Print(_u("FATAL ERROR: WriteProcessMemory failed, GLE: %d\n"), GetLastError());
                 Js::Throw::FatalInternalError(); // TODO: don't bring down whole server process, but pass the last error to main process
             }
 

--- a/lib/Backend/CodeGenWorkItem.cpp
+++ b/lib/Backend/CodeGenWorkItem.cpp
@@ -20,7 +20,6 @@ CodeGenWorkItem::CodeGenWorkItem(
     , isAllocationCommitted(false)
     , queuedFullJitWorkItem(nullptr)
     , allocation(nullptr)
-    , codeGenResult(0)
 #ifdef IR_VIEWER
     , isRejitIRViewerFunction(false)
     , irViewerOutput(nullptr)

--- a/lib/Backend/CodeGenWorkItem.h
+++ b/lib/Backend/CodeGenWorkItem.h
@@ -24,9 +24,6 @@ protected:
     ptrdiff_t codeSize;
 
 public:
-    HRESULT codeGenResult;
-
-public:
     virtual uint GetByteCodeCount() const = 0;
     virtual size_t GetDisplayName(_Out_writes_opt_z_(sizeInChars) WCHAR* displayName, _In_ size_t sizeInChars) = 0;
     virtual void GetEntryPointAddress(void** entrypoint, ptrdiff_t *size) = 0;

--- a/lib/Backend/EmitBuffer.cpp
+++ b/lib/Backend/EmitBuffer.cpp
@@ -290,6 +290,13 @@ EmitBufferAllocation* EmitBufferManager<SyncObject>::AllocateBuffer(__in size_t 
 #if DBG
     MEMORY_BASIC_INFORMATION memBasicInfo;
     size_t resultBytes = VirtualQueryEx(this->processHandle, allocation->allocation->address, &memBasicInfo, sizeof(memBasicInfo));
+    if (resultBytes == 0) 
+    {
+        if (this->processHandle != GetCurrentProcess())
+        {
+            Js::Throw::CheckAndThrowJITOperationFailed();
+        }
+    }
     Assert(resultBytes != 0 && memBasicInfo.Protect == PAGE_EXECUTE);
 #endif
 

--- a/lib/Backend/NativeCodeGenerator.cpp
+++ b/lib/Backend/NativeCodeGenerator.cpp
@@ -2007,12 +2007,6 @@ NativeCodeGenerator::UpdateJITState()
 {
     if (JITManager::GetJITManager()->IsOOPJITEnabled())
     {
-        // ensure jit contexts have been set up
-        if (!scriptContext->GetRemoteScriptAddr())
-        {
-            scriptContext->InitializeRemoteScriptContext();
-        }
-
         // update all property records on server that have been changed since last jit
         ThreadContext::PropertyMap * pendingProps = scriptContext->GetThreadContext()->GetPendingJITProperties();
         PropertyRecordIDL ** newPropArray = nullptr;

--- a/lib/Backend/NativeCodeGenerator.cpp
+++ b/lib/Backend/NativeCodeGenerator.cpp
@@ -896,7 +896,6 @@ NativeCodeGenerator::CodeGen(PageAllocator * pageAllocator, CodeGenWorkItem* wor
     {
         HRESULT hr = JITManager::GetJITManager()->RemoteCodeGenCall(
             workItem->GetJITData(),
-            scriptContext->GetThreadContext()->GetRemoteThreadContextAddr(),
             scriptContext->GetRemoteScriptAddr(),
             &jitWriteData);
         JITManager::HandleServerCallResult(hr);

--- a/lib/Backend/NativeCodeGenerator.cpp
+++ b/lib/Backend/NativeCodeGenerator.cpp
@@ -2007,6 +2007,12 @@ NativeCodeGenerator::UpdateJITState()
 {
     if (JITManager::GetJITManager()->IsOOPJITEnabled())
     {
+        // TODO: OOP JIT, move server calls to background thread to reduce foreground thread delay
+        if (!scriptContext->GetRemoteScriptAddr())
+        {
+            return;
+        }
+
         // update all property records on server that have been changed since last jit
         ThreadContext::PropertyMap * pendingProps = scriptContext->GetThreadContext()->GetPendingJITProperties();
         PropertyRecordIDL ** newPropArray = nullptr;

--- a/lib/Backend/ServerScriptContext.cpp
+++ b/lib/Backend/ServerScriptContext.cpp
@@ -14,7 +14,8 @@ ServerScriptContext::ServerScriptContext(ScriptContextDataIDL * contextData, Ser
 #ifdef PROFILE_EXEC
     m_codeGenProfiler(nullptr),
 #endif
-    m_refCount(0)
+    m_refCount(0),
+    m_isClosed(false)
 {
 #ifdef PROFILE_EXEC
     if (Js::Configuration::Global.flags.IsEnabled(Js::ProfileFlag))

--- a/lib/Backend/ServerScriptContext.cpp
+++ b/lib/Backend/ServerScriptContext.cpp
@@ -5,16 +5,16 @@
 
 #include "Backend.h"
 
-ServerScriptContext::ServerScriptContext(ScriptContextDataIDL * contextData) :
+ServerScriptContext::ServerScriptContext(ScriptContextDataIDL * contextData, ServerThreadContext* threadContextInfo) :
     m_contextData(*contextData),
+    threadContextInfo(threadContextInfo),
     m_isPRNGSeeded(false),
-    m_isClosed(false),
     m_domFastPathHelperMap(nullptr),
     m_moduleRecords(&HeapAllocator::Instance),
 #ifdef PROFILE_EXEC
     m_codeGenProfiler(nullptr),
 #endif
-    m_activeJITCount(0)
+    m_refCount(0)
 {
 #ifdef PROFILE_EXEC
     if (Js::Configuration::Global.flags.IsEnabled(Js::ProfileFlag))
@@ -279,21 +279,19 @@ ServerScriptContext::Close()
 }
 
 void
-ServerScriptContext::BeginJIT()
+ServerScriptContext::AddRef()
 {
-    InterlockedExchangeAdd(&m_activeJITCount, 1u);
+    InterlockedExchangeAdd(&m_refCount, 1u);
 }
 
 void
-ServerScriptContext::EndJIT()
+ServerScriptContext::Release()
 {
-    InterlockedExchangeSubtract(&m_activeJITCount, 1u);
-}
-
-bool
-ServerScriptContext::IsJITActive()
-{
-    return m_activeJITCount != 0;
+    InterlockedExchangeSubtract(&m_refCount, 1u);
+    if (m_isClosed && m_refCount == 0)
+    {
+        HeapDelete(this);
+    }
 }
 
 Js::Var*
@@ -328,3 +326,4 @@ ServerScriptContext::GetCodeGenProfiler() const
     return nullptr;
 #endif
 }
+

--- a/lib/Backend/ServerScriptContext.h
+++ b/lib/Backend/ServerScriptContext.h
@@ -8,7 +8,7 @@
 class ServerScriptContext : public ScriptContextInfo
 {
 public:
-    ServerScriptContext(ScriptContextDataIDL * contextData);
+    ServerScriptContext(ScriptContextDataIDL * contextData, ServerThreadContext* threadContextInfo);
     ~ServerScriptContext();
     virtual intptr_t GetNullAddr() const override;
     virtual intptr_t GetUndefinedAddr() const override;
@@ -62,11 +62,12 @@ public:
     void AddModuleRecordInfo(unsigned int moduleId, __int64 localExportSlotsAddr);
 
     Js::ScriptContextProfiler *  GetCodeGenProfiler() const;
+    ServerThreadContext* GetThreadContext() { return threadContextInfo; }
 
     void Close();
-    void BeginJIT();
-    void EndJIT();
-    bool IsJITActive();
+    void AddRef();
+    void Release();
+
 private:
     JITDOMFastPathHelperMap * m_domFastPathHelperMap;
 #ifdef PROFILE_EXEC
@@ -74,7 +75,9 @@ private:
 #endif
 
     ScriptContextDataIDL m_contextData;
-    uint m_activeJITCount;
+
+    ServerThreadContext* threadContextInfo;
+    uint m_refCount;
 
     bool m_isPRNGSeeded;
     bool m_isClosed;

--- a/lib/Backend/ServerThreadContext.cpp
+++ b/lib/Backend/ServerThreadContext.cpp
@@ -22,7 +22,9 @@ ServerThreadContext::ServerThreadContext(ThreadContextDataIDL * data) :
 #endif
     m_jitCRTBaseAddress((intptr_t)GetModuleHandle(UCrtC99MathApis::LibraryName))
 {
+#if ENABLE_OOP_NATIVE_CODEGEN
     m_pid = GetProcessId((HANDLE)data->processHandle);
+#endif
 
 #if !_M_X64_OR_ARM64 && _CONTROL_FLOW_GUARD
     m_codeGenAlloc.canCreatePreReservedSegment = data->allowPrereserveAlloc != FALSE;

--- a/lib/Backend/ServerThreadContext.cpp
+++ b/lib/Backend/ServerThreadContext.cpp
@@ -22,6 +22,8 @@ ServerThreadContext::ServerThreadContext(ThreadContextDataIDL * data) :
 #endif
     m_jitCRTBaseAddress((intptr_t)GetModuleHandle(UCrtC99MathApis::LibraryName))
 {
+    m_pid = GetProcessId((HANDLE)data->processHandle);
+
 #if !_M_X64_OR_ARM64 && _CONTROL_FLOW_GUARD
     m_codeGenAlloc.canCreatePreReservedSegment = data->allowPrereserveAlloc != FALSE;
 #endif

--- a/lib/Backend/ServerThreadContext.cpp
+++ b/lib/Backend/ServerThreadContext.cpp
@@ -260,3 +260,20 @@ ServerThreadContext::AddToPropertyMap(const Js::PropertyRecord * origRecord)
 
     PropertyRecordTrace(_u("Added JIT property '%s' at 0x%08x, pid = %d\n"), record->GetBuffer(), record, record->pid);
 }
+
+void ServerThreadContext::AddRef()
+{
+    InterlockedExchangeAdd(&m_refCount, (uint)1);
+}
+void ServerThreadContext::Release()
+{
+    InterlockedExchangeSubtract(&m_refCount, (uint)1);
+    if (m_isClosed && m_refCount == 0)
+    {
+        HeapDelete(this);
+    }
+}
+void ServerThreadContext::Close()
+{
+    this->m_isClosed = true;
+}

--- a/lib/Backend/ServerThreadContext.cpp
+++ b/lib/Backend/ServerThreadContext.cpp
@@ -7,6 +7,7 @@
 
 ServerThreadContext::ServerThreadContext(ThreadContextDataIDL * data) :
     m_threadContextData(*data),
+    m_refCount(0),
     m_policyManager(true),
     m_propertyMap(nullptr),
     m_pageAllocs(&HeapAllocator::Instance),

--- a/lib/Backend/ServerThreadContext.h
+++ b/lib/Backend/ServerThreadContext.h
@@ -65,6 +65,8 @@ private:
     CodeGenAllocators m_codeGenAlloc;
 
     ThreadContextDataIDL m_threadContextData;
+
+    DWORD m_pid; //save client process id for easier diagnose
     
     intptr_t m_jitChakraBaseAddress;
     intptr_t m_jitCRTBaseAddress;

--- a/lib/Backend/ServerThreadContext.h
+++ b/lib/Backend/ServerThreadContext.h
@@ -45,6 +45,11 @@ public:
     void RemoveFromPropertyMap(Js::PropertyId reclaimedId);
     void AddToPropertyMap(const Js::PropertyRecord * propertyRecord);
     void SetWellKnownHostTypeId(Js::TypeId typeId) { this->wellKnownHostTypeHTMLAllCollectionTypeId = typeId; }
+
+    void AddRef();
+    void Release();
+    void Close();    
+
 private:
     intptr_t GetRuntimeChakraBaseAddress() const;
     intptr_t GetRuntimeCRTBaseAddress() const;
@@ -60,8 +65,9 @@ private:
     CodeGenAllocators m_codeGenAlloc;
 
     ThreadContextDataIDL m_threadContextData;
-
-    ThreadContext * m_threadContext;
+    
     intptr_t m_jitChakraBaseAddress;
     intptr_t m_jitCRTBaseAddress;
+    uint m_refCount;
+
 };

--- a/lib/Common/Common.h
+++ b/lib/Common/Common.h
@@ -83,6 +83,7 @@ template<> struct IntMath<int64> { using Type = Int64Math; };
 #include "Exceptions/StackOverflowException.h"
 #include "Exceptions/NotImplementedException.h"
 #include "Exceptions/AsmJsParseException.h"
+#include "Exceptions/JITOperationFailedException.h"
 
 #include "Memory/AutoPtr.h"
 #include "Memory/AutoAllocatorObjectPtr.h"

--- a/lib/Common/Common/Jobs.cpp
+++ b/lib/Common/Common/Jobs.cpp
@@ -14,6 +14,7 @@
 #include "Exceptions/OperationAbortedException.h"
 #include "Exceptions/OutOfMemoryException.h"
 #include "Exceptions/StackOverflowException.h"
+#include "Exceptions/JITOperationFailedException.h"
 
 #include "TemplateParameter.h"
 #include "DataStructures/DoublyLinkedListElement.h"
@@ -1002,6 +1003,14 @@ namespace JsUtil
             // context is closed while the job is being processed in the background
 #if ENABLE_DEBUG_CONFIG_OPTIONS
             job->failureReason = Job::FailureReason::Aborted;
+#endif
+        }
+        catch (Js::JITOperationFailedException)
+        {
+            // This can happen for any reason a job needs to be aborted while executing, like for instance, if the script
+            // context is closed while the job is being processed in the background
+#if ENABLE_DEBUG_CONFIG_OPTIONS
+            job->failureReason = Job::FailureReason::Unknown;
 #endif
         }
 

--- a/lib/Common/Exceptions/Chakra.Common.Exceptions.vcxproj
+++ b/lib/Common/Exceptions/Chakra.Common.Exceptions.vcxproj
@@ -47,6 +47,7 @@
     <ClInclude Include="ExceptionCheck.h" />
     <ClInclude Include="InScriptExceptionBase.h" />
     <ClInclude Include="InternalErrorException.h" />
+    <ClInclude Include="JITOperationFailedException.h" />
     <ClInclude Include="NotImplementedException.h" />
     <ClInclude Include="OperationAbortedException.h" />
     <ClInclude Include="OutOfMemoryException.h" />

--- a/lib/Common/Exceptions/JITOperationFailedException.h
+++ b/lib/Common/Exceptions/JITOperationFailedException.h
@@ -2,13 +2,17 @@
 // Copyright (C) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
-
 #pragma once
 
-#include "Common.h"
+namespace Js {
 
-#include "ChakraJIT.h"
+    class JITOperationFailedException : public ExceptionBase
+    {
+    public:
+        JITOperationFailedException(DWORD lastError)
+            :LastError(lastError)
+        {}
+        DWORD LastError;
+    };
 
-#include "Runtime.h"
-#include "Backend.h"
-#include "JITServer.h"
+} // namespace Js

--- a/lib/Common/Exceptions/JITOperationFailedException.h
+++ b/lib/Common/Exceptions/JITOperationFailedException.h
@@ -2,6 +2,7 @@
 // Copyright (C) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
+
 #pragma once
 
 namespace Js {

--- a/lib/Common/Exceptions/Throw.cpp
+++ b/lib/Common/Exceptions/Throw.cpp
@@ -18,6 +18,7 @@
 #include "InternalErrorException.h"
 #include "OutOfMemoryException.h"
 #include "NotImplementedException.h"
+#include "JITOperationFailedException.h"
 
 // Header files required before including ConfigFlagsTable.h
 
@@ -119,6 +120,30 @@ namespace Js {
             AssertMsg(false, "We shouldn't be here");
         }
         throw StackOverflowException();
+    }
+
+    void Throw::JITOperationFailed(DWORD lastError)
+    {
+#ifdef ENABLE_DEBUG_CONFIG_OPTIONS
+        if (CONFIG_FLAG(PrintSystemException))
+        {
+            Output::Print(_u("SystemException: JITOperationFailed\n"));
+            Output::Flush();
+        }
+#endif
+        throw JITOperationFailedException(lastError);
+    }
+
+    void Throw::CheckAndThrowJITOperationFailed()
+    {
+        DWORD lastError = GetLastError();
+        // currently this is used for virtual memory(Virtual*Ex) operations only
+        // which 0 indicate succeed
+        if (lastError != 0) 
+        {
+            Throw::JITOperationFailed(lastError);
+        }
+        
     }
 
     void Throw::NotImplemented()

--- a/lib/Common/Exceptions/Throw.h
+++ b/lib/Common/Exceptions/Throw.h
@@ -21,6 +21,9 @@ namespace Js {
         static void __declspec(noreturn) InternalError();
         static void __declspec(noreturn) FatalInternalError();
         static void __declspec(noreturn) FatalProjectionError();
+        static void __declspec(noreturn) JITOperationFailed(DWORD lastError);
+
+        static void CheckAndThrowJITOperationFailed();
 
         static void CheckAndThrowOutOfMemory(BOOLEAN status);
 

--- a/lib/Common/Memory/CommonMemoryPch.h
+++ b/lib/Common/Memory/CommonMemoryPch.h
@@ -20,6 +20,7 @@ typedef _Return_type_success_(return >= 0) LONG NTSTATUS;
 // Exceptions
 #include "Exceptions/ExceptionBase.h"
 #include "Exceptions/OutOfMemoryException.h"
+#include "Exceptions/JITOperationFailedException.h"
 
 // Other Memory headers
 #include "Memory/LeakReport.h"

--- a/lib/Common/Memory/CustomHeap.cpp
+++ b/lib/Common/Memory/CustomHeap.cpp
@@ -223,7 +223,11 @@ Allocation* Heap::Alloc(size_t bytes, ushort pdataCount, ushort xdataSize, bool 
         {
             MEMORY_BASIC_INFORMATION memBasicInfo;
             size_t resultBytes = VirtualQueryEx(this->processHandle, allocation->address, &memBasicInfo, sizeof(memBasicInfo));
-            Assert(resultBytes != 0 && memBasicInfo.Protect == PAGE_EXECUTE);
+            if (resultBytes == 0)
+            {
+                Js::Throw::CheckAndThrowJITOperationFailed();
+            }
+            Assert(memBasicInfo.Protect == PAGE_EXECUTE);
         }
 #endif
         return allocation;
@@ -254,7 +258,11 @@ Allocation* Heap::Alloc(size_t bytes, ushort pdataCount, ushort xdataSize, bool 
 #if defined(DBG)
         MEMORY_BASIC_INFORMATION memBasicInfo;
         size_t resultBytes = VirtualQueryEx(this->processHandle, page->address, &memBasicInfo, sizeof(memBasicInfo));
-        Assert(resultBytes != 0 && memBasicInfo.Protect == PAGE_EXECUTE);
+        if (resultBytes == 0)
+        {
+            Js::Throw::CheckAndThrowJITOperationFailed();
+        }
+        Assert(memBasicInfo.Protect == PAGE_EXECUTE);
 #endif
 
         Allocation* allocation = nullptr;

--- a/lib/Common/Memory/CustomHeap.cpp
+++ b/lib/Common/Memory/CustomHeap.cpp
@@ -1069,6 +1069,7 @@ void FillDebugBreak(_In_ BYTE* buffer, __in size_t byteCount, HANDLE processHand
     {
         if (!WriteProcessMemory(processHandle, buffer, writeBuffer, byteCount, NULL))
         {
+            Js::Throw::CheckAndThrowJITOperationFailed();
             Js::Throw::FatalInternalError();
         }
         HeapDeleteArray(byteCount, writeBuffer);

--- a/lib/Common/Memory/MemUtils.cpp
+++ b/lib/Common/Memory/MemUtils.cpp
@@ -25,7 +25,6 @@ Memory::ChakraMemSet(_In_ void *dst, int val, size_t sizeInBytes, HANDLE process
         if (!WriteProcessMemory(processHandle, dst, writeBuffer, sizeInBytes, NULL))
         {
             Js::Throw::CheckAndThrowJITOperationFailed();
-            // if it's not E_ACCESSDENIED
             Js::Throw::FatalInternalError();
         }
         HeapDeleteArray(sizeInBytes, writeBuffer);
@@ -49,7 +48,6 @@ Memory::ChakraMemCopy(_In_ void *dst, size_t sizeInBytes, _In_reads_bytes_(count
     {
         if (!WriteProcessMemory(processHandle, dst, src, count, NULL))
         {
-            Output::Print(_u("FATAL ERROR: WriteProcessMemory failed, GLE: %d\n"), GetLastError());
             Js::Throw::CheckAndThrowJITOperationFailed();
             Js::Throw::FatalInternalError();
         }

--- a/lib/Common/Memory/MemUtils.cpp
+++ b/lib/Common/Memory/MemUtils.cpp
@@ -24,6 +24,8 @@ Memory::ChakraMemSet(_In_ void *dst, int val, size_t sizeInBytes, HANDLE process
     {
         if (!WriteProcessMemory(processHandle, dst, writeBuffer, sizeInBytes, NULL))
         {
+            Js::Throw::CheckAndThrowJITOperationFailed();
+            // if it's not E_ACCESSDENIED
             Js::Throw::FatalInternalError();
         }
         HeapDeleteArray(sizeInBytes, writeBuffer);
@@ -48,6 +50,7 @@ Memory::ChakraMemCopy(_In_ void *dst, size_t sizeInBytes, _In_reads_bytes_(count
         if (!WriteProcessMemory(processHandle, dst, src, count, NULL))
         {
             Output::Print(_u("FATAL ERROR: WriteProcessMemory failed, GLE: %d\n"), GetLastError());
+            Js::Throw::CheckAndThrowJITOperationFailed();
             Js::Throw::FatalInternalError();
         }
     }

--- a/lib/Common/Memory/PageAllocator.cpp
+++ b/lib/Common/Memory/PageAllocator.cpp
@@ -933,6 +933,7 @@ PageAllocatorBase<T>::FillAllocPages(__in void * address, uint pageCount)
         readBuffer = HeapNewArray(byte, bufferSize);
         if (!ReadProcessMemory(this->processHandle, address, readBuffer, bufferSize, NULL))
         {
+            Js::Throw::CheckAndThrowJITOperationFailed();
             Js::Throw::InternalError();
         }
     }

--- a/lib/Common/Memory/PageAllocator.cpp
+++ b/lib/Common/Memory/PageAllocator.cpp
@@ -210,7 +210,11 @@ PageSegmentBase<T>::Initialize(DWORD allocFlags, bool excludeGuardPages)
         {
             DWORD oldProtect;
             BOOL vpresult = VirtualProtectEx(this->allocator->processHandle, this->address, this->GetAvailablePageCount() * AutoSystemInfo::PageSize, PAGE_NOACCESS, &oldProtect);
-            Assert(vpresult && oldProtect == PAGE_READWRITE);
+            if (vpresult == FALSE)
+            {
+                Js::Throw::CheckAndThrowJITOperationFailed();
+            }
+            Assert(oldProtect == PAGE_READWRITE);
         }
         return true;
     }
@@ -294,6 +298,10 @@ PageSegmentBase<T>::AllocPages(uint pageCount)
 #ifdef PAGEALLOCATOR_PROTECT_FREEPAGE
                 DWORD oldProtect;
                 BOOL vpresult = VirtualProtectEx(this->allocator->processHandle, allocAddress, pageCount * AutoSystemInfo::PageSize, PAGE_READWRITE, &oldProtect);
+                if (vpresult == FALSE)
+                {
+                    Js::Throw::CheckAndThrowJITOperationFailed();
+                }
                 Assert(vpresult && oldProtect == PAGE_NOACCESS);
 #endif
             return allocAddress;
@@ -394,6 +402,10 @@ PageSegmentBase<T>::ReleasePages(__in void * address, uint pageCount)
 #ifdef PAGEALLOCATOR_PROTECT_FREEPAGE
     DWORD oldProtect;
     BOOL vpresult = VirtualProtectEx(this->allocator->processHandle, address, pageCount * AutoSystemInfo::PageSize, PAGE_NOACCESS, &oldProtect);
+    if (vpresult == FALSE)
+    {
+        Js::Throw::CheckAndThrowJITOperationFailed();
+    }
     Assert(vpresult && oldProtect == PAGE_READWRITE);
 #endif
 
@@ -2370,6 +2382,7 @@ HeapPageAllocator<T>::ProtectPages(__in char* address, size_t pageCount, __in vo
         || address < segment->GetAddress()
         || ((uint)(((char *)address) - segment->GetAddress()) > (segment->GetPageCount() - pageCount) * AutoSystemInfo::PageSize))
     {
+        // OOPJIT TODO: don't bring down the whole JIT process
         CustomHeap_BadPageState_fatal_error((ULONG_PTR)this);
         return FALSE;
     }
@@ -2378,6 +2391,13 @@ HeapPageAllocator<T>::ProtectPages(__in char* address, size_t pageCount, __in vo
 
     // check old protection on all pages about to change, ensure the fidelity
     size_t bytes = VirtualQueryEx(this->processHandle, address, &memBasicInfo, sizeof(memBasicInfo));
+    if (bytes == 0)
+    {
+        if (this->processHandle != GetCurrentProcess())
+        {
+            Js::Throw::CheckAndThrowJITOperationFailed();
+        }
+    }
     if (bytes == 0
         || memBasicInfo.RegionSize < pageCount * AutoSystemInfo::PageSize
         || desiredOldProtectFlag != memBasicInfo.Protect)
@@ -2392,6 +2412,7 @@ HeapPageAllocator<T>::ProtectPages(__in char* address, size_t pageCount, __in vo
         (dwVirtualProtectFlags & (PAGE_EXECUTE | PAGE_EXECUTE_READ | PAGE_EXECUTE_READWRITE)) &&
         ((dwVirtualProtectFlags & PAGE_TARGETS_NO_UPDATE) == 0))
     {
+        // OOPJIT TODO: don't bring down the whole JIT process
         CustomHeap_BadPageState_fatal_error((ULONG_PTR)this);
         return FALSE;
     }

--- a/lib/Common/Memory/VirtualAllocWrapper.cpp
+++ b/lib/Common/Memory/VirtualAllocWrapper.cpp
@@ -54,9 +54,16 @@ LPVOID VirtualAllocWrapper::Alloc(LPVOID lpAddress, size_t dwSize, DWORD allocat
         if ((allocationType & MEM_COMMIT) == MEM_COMMIT) // The access protection value can be set only on committed pages.
         {
             BOOL result = VirtualProtectEx(process, address, dwSize, protectFlags, &oldProtectFlags);
-            if (result == FALSE && process != GetCurrentProcess())
+            if (result == FALSE)
             {
-                Js::Throw::CheckAndThrowJITOperationFailed();
+                if (process != GetCurrentProcess())
+                {
+                    Js::Throw::CheckAndThrowJITOperationFailed();
+                }
+                else
+                {
+                    CustomHeap_BadPageState_fatal_error((ULONG_PTR)this);
+                }
             }
         }
     }

--- a/lib/Common/Memory/VirtualAllocWrapper.cpp
+++ b/lib/Common/Memory/VirtualAllocWrapper.cpp
@@ -44,13 +44,27 @@ LPVOID VirtualAllocWrapper::Alloc(LPVOID lpAddress, size_t dwSize, DWORD allocat
         {
             allocProtectFlags = PAGE_EXECUTE_READWRITE;
         }
+
         address = VirtualAllocEx(process, lpAddress, dwSize, allocationType, allocProtectFlags);
-        VirtualProtectEx(process, address, dwSize, protectFlags, &oldProtectFlags);
+        if (address == nullptr && process != GetCurrentProcess())
+        {
+            Js::Throw::CheckAndThrowJITOperationFailed();
+        }
+
+        BOOL result = VirtualProtectEx(process, address, dwSize, protectFlags, &oldProtectFlags);
+        if (result == FALSE && process != GetCurrentProcess())
+        {
+            Js::Throw::CheckAndThrowJITOperationFailed();
+        }
     }
     else
 #endif
     {
         address = VirtualAllocEx(process, lpAddress, dwSize, allocationType, protectFlags);
+        if (address == nullptr && process != GetCurrentProcess())
+        {
+            Js::Throw::CheckAndThrowJITOperationFailed();
+        }
     }
 
     return address;
@@ -62,7 +76,12 @@ BOOL VirtualAllocWrapper::Free(LPVOID lpAddress, size_t dwSize, DWORD dwFreeType
     AnalysisAssert(dwFreeType == MEM_RELEASE || dwFreeType == MEM_DECOMMIT);
     size_t bytes = (dwFreeType == MEM_RELEASE)? 0 : dwSize;
 #pragma warning(suppress: 28160) // Calling VirtualFreeEx without the MEM_RELEASE flag frees memory but not address descriptors (VADs)
-    return VirtualFreeEx(process, lpAddress, bytes, dwFreeType);
+    BOOL ret = VirtualFreeEx(process, lpAddress, bytes, dwFreeType);
+    if (ret == FALSE && process != GetCurrentProcess())
+    {
+        // OOP JIT TODO: check if we need to cleanup the context related to this content process
+    }
+    return ret;
 }
 
 /*
@@ -88,9 +107,9 @@ PreReservedVirtualAllocWrapper::~PreReservedVirtualAllocWrapper()
         BOOL success = VirtualFreeEx(processHandle, preReservedStartAddress, 0, MEM_RELEASE);
         PreReservedHeapTrace(_u("MEM_RELEASE the PreReservedSegment. Start Address: 0x%p, Size: 0x%x * 0x%x bytes"), preReservedStartAddress, PreReservedAllocationSegmentCount,
             AutoSystemInfo::Data.GetAllocationGranularityPageSize());
-        if (!success)
+        if (!success && this->processHandle != GetCurrentProcess())
         {
-            Assert(false);
+            // OOP JIT TODO: check if we need to cleanup the context related to this content process
         }
 
 #if !_M_X64_OR_ARM64 && _CONTROL_FLOW_GUARD
@@ -119,10 +138,14 @@ PreReservedVirtualAllocWrapper::IsInRange(void * address)
     //Check if the region is in MEM_COMMIT state.
     MEMORY_BASIC_INFORMATION memBasicInfo;
     size_t bytes = VirtualQueryEx(processHandle, address, &memBasicInfo, sizeof(memBasicInfo));
-    if (bytes == 0 || memBasicInfo.State != MEM_COMMIT)
+    if (bytes == 0)
     {
-        AssertMsg(false, "Memory not committed? Checking for uncommitted address region?");
+        if (this->processHandle != GetCurrentProcess())
+        {
+            Js::Throw::CheckAndThrowJITOperationFailed();
+        }
     }
+    AssertMsg(memBasicInfo.State == MEM_COMMIT, "Memory not committed? Checking for uncommitted address region?");
 #endif
     return result;
 }
@@ -291,6 +314,13 @@ LPVOID PreReservedVirtualAllocWrapper::Alloc(LPVOID lpAddress, size_t dwSize, DW
             //Check if the region is not already in MEM_COMMIT state.
             MEMORY_BASIC_INFORMATION memBasicInfo;
             size_t bytes = VirtualQueryEx(processHandle, addressToReserve, &memBasicInfo, sizeof(memBasicInfo));
+            if (bytes == 0)
+            {
+                if (this->processHandle != GetCurrentProcess())
+                {
+                    Js::Throw::CheckAndThrowJITOperationFailed();
+                }
+            }
             if (bytes == 0
                 || memBasicInfo.RegionSize < requestedNumOfSegments * AutoSystemInfo::Data.GetAllocationGranularityPageSize()
                 || memBasicInfo.State == MEM_COMMIT
@@ -345,7 +375,11 @@ LPVOID PreReservedVirtualAllocWrapper::Alloc(LPVOID lpAddress, size_t dwSize, DW
 
                 if (allocatedAddress != nullptr)
                 {
-                    VirtualProtectEx(processHandle, allocatedAddress, dwSize, protectFlags, &oldProtect);
+                    BOOL result = VirtualProtectEx(processHandle, allocatedAddress, dwSize, protectFlags, &oldProtect);
+                    if (result == FALSE && this->processHandle != GetCurrentProcess())
+                    {
+                        Js::Throw::CheckAndThrowJITOperationFailed();
+                    }
                     AssertMsg(oldProtect == (PAGE_EXECUTE_READWRITE), "CFG Bitmap gets allocated and bits will be set to invalid only upon passing these flags.");
                 }
             }
@@ -353,6 +387,10 @@ LPVOID PreReservedVirtualAllocWrapper::Alloc(LPVOID lpAddress, size_t dwSize, DW
 #endif
             {
                 allocatedAddress = (char *)VirtualAllocEx(processHandle, addressToReserve, dwSize, MEM_COMMIT, protectFlags);
+                if (allocatedAddress == nullptr && this->processHandle != GetCurrentProcess())
+                {
+                    Js::Throw::CheckAndThrowJITOperationFailed();
+                }
             }
         }
         else
@@ -425,6 +463,12 @@ PreReservedVirtualAllocWrapper::Free(LPVOID lpAddress, size_t dwSize, DWORD dwFr
             freeSegments.SetRange(freeSegmentsBVIndex, static_cast<uint>(requestedNumOfSegments));
             PreReservedHeapTrace(_u("MEM_RELEASE: Address: 0x%p of size: 0x%x * 0x%x bytes\n"), lpAddress, requestedNumOfSegments, AutoSystemInfo::Data.GetAllocationGranularityPageSize());
         }
+
+        if (success == FALSE && process != GetCurrentProcess())
+        {
+            // OOP JIT TODO: check if we need to cleanup the context related to this content process
+        }
+
         return success;
     }
 }

--- a/lib/JITClient/JITManager.cpp
+++ b/lib/JITClient/JITManager.cpp
@@ -548,7 +548,6 @@ JITManager::IsNativeAddr(
 HRESULT
 JITManager::RemoteCodeGenCall(
     __in CodeGenWorkItemIDL *workItemData,
-    __in intptr_t threadContextInfoAddress,
     __in intptr_t scriptContextInfoAddress,
     __out JITOutputIDL *jitData)
 {
@@ -557,7 +556,7 @@ JITManager::RemoteCodeGenCall(
     HRESULT hr = E_FAIL;
     RpcTryExcept
     {
-        hr = ClientRemoteCodeGen(m_rpcBindingHandle, threadContextInfoAddress, scriptContextInfoAddress, workItemData, jitData);
+        hr = ClientRemoteCodeGen(m_rpcBindingHandle, scriptContextInfoAddress, workItemData, jitData);
     }
         RpcExcept(RpcExceptionFilter(RpcExceptionCode()))
     {

--- a/lib/JITClient/JITManager.cpp
+++ b/lib/JITClient/JITManager.cpp
@@ -443,6 +443,7 @@ JITManager::UpdatePropertyRecordMap(
 HRESULT
 JITManager::InitializeScriptContext(
     __in ScriptContextDataIDL * data,
+    __in intptr_t threadContextInfoAddress,
     __out intptr_t * scriptContextInfoAddress)
 {
     Assert(IsOOPJITEnabled());
@@ -450,7 +451,7 @@ JITManager::InitializeScriptContext(
     HRESULT hr = E_FAIL;
     RpcTryExcept
     {
-        hr = ClientInitializeScriptContext(m_rpcBindingHandle, data, scriptContextInfoAddress);
+        hr = ClientInitializeScriptContext(m_rpcBindingHandle, data, threadContextInfoAddress, scriptContextInfoAddress);
     }
         RpcExcept(RpcExceptionFilter(RpcExceptionCode()))
     {

--- a/lib/JITClient/JITManager.h
+++ b/lib/JITClient/JITManager.h
@@ -81,6 +81,7 @@ public:
 
 
     static JITManager * GetJITManager();
+    static void HandleServerCallResult(HRESULT hr);
 private:
     JITManager();
     ~JITManager();

--- a/lib/JITClient/JITManager.h
+++ b/lib/JITClient/JITManager.h
@@ -73,7 +73,6 @@ public:
 
     HRESULT RemoteCodeGenCall(
         __in CodeGenWorkItemIDL *workItemData,
-        __in intptr_t threadContextInfoAddress,
         __in intptr_t scriptContextInfoAddress,
         __out JITOutputIDL *jitData);
 

--- a/lib/JITClient/JITManager.h
+++ b/lib/JITClient/JITManager.h
@@ -47,6 +47,7 @@ public:
 
     HRESULT InitializeScriptContext(
         __in ScriptContextDataIDL * data,
+        __in  intptr_t threadContextInfoAddress,
         __out intptr_t *scriptContextInfoAddress);
 
     HRESULT CleanupProcess();
@@ -78,6 +79,7 @@ public:
 
     HRESULT Shutdown();
 
+
     static JITManager * GetJITManager();
 private:
     JITManager();
@@ -96,6 +98,7 @@ private:
     bool m_isJITServer;
 
     static JITManager s_jitManager;
+
 };
 
 #else  // !ENABLE_OOP_NATIVE_CODEGEN
@@ -148,6 +151,7 @@ public:
 
     HRESULT InitializeScriptContext(
         __in ScriptContextDataIDL * data,
+        __in intptr_t threadContextInfoAddress,
         __out intptr_t *scriptContextInfoAddress)
         { Assert(false); return E_FAIL; }
 

--- a/lib/JITClient/JITManager.h
+++ b/lib/JITClient/JITManager.h
@@ -184,7 +184,6 @@ public:
 
     HRESULT RemoteCodeGenCall(
         __in CodeGenWorkItemIDL *workItemData,
-        __in intptr_t threadContextInfoAddress,
         __in intptr_t scriptContextInfoAddress,
         __out JITOutputIDL *jitData)
         { Assert(false); return E_FAIL; }
@@ -194,6 +193,7 @@ public:
 
     static JITManager * GetJITManager()
         { return &s_jitManager; }
+    static void HandleServerCallResult(HRESULT hr);
 
 private:
     static JITManager s_jitManager;

--- a/lib/JITIDL/ChakraJIT.idl
+++ b/lib/JITIDL/ChakraJIT.idl
@@ -52,6 +52,7 @@ interface IChakraJIT
     HRESULT InitializeScriptContext(
         [in] handle_t binding,
         [in] ScriptContextDataIDL * scriptContextData,
+        [in] CHAKRA_PTR threadContextInfoAddress,
         [out] CHAKRA_PTR * scriptContextInfoAddress);
 
     HRESULT CloseScriptContext(

--- a/lib/JITIDL/ChakraJIT.idl
+++ b/lib/JITIDL/ChakraJIT.idl
@@ -81,7 +81,6 @@ interface IChakraJIT
 
     HRESULT RemoteCodeGen(
         [in] handle_t binding,
-        [in] CHAKRA_PTR threadContextInfoAddress,
         [in] CHAKRA_PTR scriptContextInfoAddress,
         [in] CodeGenWorkItemIDL * workItemData,
         [out] JITOutputIDL * jitData);

--- a/lib/JITServer/Chakra.JITServer.vcxproj
+++ b/lib/JITServer/Chakra.JITServer.vcxproj
@@ -28,6 +28,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)JITServer.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="JITServer.h" />
     <ClInclude Include="JITServerPch.h" />
   </ItemGroup>
   <ItemGroup>

--- a/lib/JITServer/Chakra.JITServer.vcxproj.filters
+++ b/lib/JITServer/Chakra.JITServer.vcxproj.filters
@@ -1,11 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <ClCompile Include="JITServerPch.cpp" />
-    <ClCompile Include="JITServerStub.c" />
-    <ClCompile Include="JITServer.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)JITServerStub.c" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)JITServerPch.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)JITServer.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="JITServerPch.h" />
+    <ClInclude Include="JITServer.h" />
   </ItemGroup>
 </Project>

--- a/lib/JITServer/JITServer.cpp
+++ b/lib/JITServer/JITServer.cpp
@@ -297,7 +297,7 @@ HRESULT
 ServerInitializeScriptContext(
     /* [in] */ handle_t binding,
     /* [in] */ __RPC__in ScriptContextDataIDL * scriptContextData,
-    /* [in] */ __RPC__in intptr_t threadContextInfoAddress,
+    /* [in] */ intptr_t threadContextInfoAddress,
     /* [out] */ __RPC__out intptr_t * scriptContextInfoAddress)
 {
     AUTO_NESTED_HANDLED_EXCEPTION_TYPE(static_cast<ExceptionType>(ExceptionType_OutOfMemory | ExceptionType_StackOverflow));
@@ -494,6 +494,13 @@ ServerRemoteCodeGen(
     UNREFERENCED_PARAMETER(binding);
     AUTO_NESTED_HANDLED_EXCEPTION_TYPE(static_cast<ExceptionType>(ExceptionType_OutOfMemory | ExceptionType_StackOverflow));
 
+    LARGE_INTEGER start_time = { 0 };
+    if (PHASE_TRACE1(Js::BackEndPhase))
+    {
+        QueryPerformanceCounter(&start_time);
+    }
+    memset(jitData, 0, sizeof(JITOutputIDL));
+
     ServerThreadContext * threadContextInfo = (ServerThreadContext*)DecodePointer((void*)threadContextInfoAddress);
     ServerScriptContext * scriptContextInfo = (ServerScriptContext*)DecodePointer((void*)scriptContextInfoAddress);
 
@@ -517,13 +524,6 @@ ServerRemoteCodeGen(
 
     return ServerCallWrapper(threadContextInfo, [&]() ->HRESULT
     {
-        LARGE_INTEGER start_time = { 0 };
-        if (PHASE_TRACE1(Js::BackEndPhase))
-        {
-            QueryPerformanceCounter(&start_time);
-        }
-        memset(jitData, 0, sizeof(JITOutputIDL));
-
         NoRecoverMemoryJitArenaAllocator jitArena(L"JITArena", threadContextInfo->GetPageAllocator(), Js::Throw::OutOfMemory);
         JITTimeWorkItem * jitWorkItem = Anew(&jitArena, JITTimeWorkItem, workItemData);
 

--- a/lib/JITServer/JITServer.h
+++ b/lib/JITServer/JITServer.h
@@ -1,4 +1,3 @@
-
 //-------------------------------------------------------------------------------------------------------
 // Copyright (C) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.

--- a/lib/JITServer/JITServer.h
+++ b/lib/JITServer/JITServer.h
@@ -1,0 +1,43 @@
+
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+class ServerContextManager
+{
+public:
+    static void RegisterThreadContext(ServerThreadContext* threadContext);
+    static void UnRegisterThreadContext(ServerThreadContext* threadContext);
+    static bool IsThreadContextAlive(ServerThreadContext* threadContext);
+
+    static void RegisterScriptContext(ServerScriptContext* scriptContext);
+    static void UnRegisterScriptContext(ServerScriptContext* scriptContext);    
+    static bool IsScriptContextAlive(ServerScriptContext* scriptContext);
+private:
+    static JsUtil::BaseHashSet<ServerThreadContext*, HeapAllocator> threadContexts;
+    static JsUtil::BaseHashSet<ServerScriptContext*, HeapAllocator> scriptContexts;
+    static CriticalSection cs;
+};
+
+template<class T>
+struct AutoReleaseContext
+{
+    AutoReleaseContext(T* context)
+        :context(context)
+    {
+        context->AddRef();
+    }
+
+    ~AutoReleaseContext()
+    {
+        context->Release();
+    }
+
+    T* context;
+};
+
+template<typename Fn>
+HRESULT ServerCallWrapper(ServerThreadContext* threadContextInfo, Fn fn);
+template<typename Fn>
+HRESULT ServerCallWrapper(ServerScriptContext* scriptContextInfo, Fn fn);

--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -4508,7 +4508,8 @@ void ScriptContext::RegisterPrototypeChainEnsuredToHaveOnlyWritableDataPropertie
 #endif
         this->GetThreadContext()->EnsureJITThreadContext(allowPrereserveAlloc);
 
-        JITManager::GetJITManager()->InitializeScriptContext(&contextData, this->GetThreadContext()->GetRemoteThreadContextAddr(), &m_remoteScriptContextAddr);
+        HRESULT hr = JITManager::GetJITManager()->InitializeScriptContext(&contextData, this->GetThreadContext()->GetRemoteThreadContextAddr(), &m_remoteScriptContextAddr);
+        JITManager::HandleServerCallResult(hr);
     }
 #endif
 

--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -4495,7 +4495,20 @@ void ScriptContext::RegisterPrototypeChainEnsuredToHaveOnlyWritableDataPropertie
         {
             contextData.vtableAddresses[i] = vtblAddresses[i];
         }
-        JITManager::GetJITManager()->InitializeScriptContext(&contextData, &m_remoteScriptContextAddr);
+
+        bool allowPrereserveAlloc = true;
+#if !_M_X64_OR_ARM64
+        if (this->webWorkerId != Js::Constants::NonWebWorkerContextId)
+        {
+            allowPrereserveAlloc = false;
+        }
+#endif
+#ifndef _CONTROL_FLOW_GUARD
+        allowPrereserveAlloc = false;
+#endif
+        this->GetThreadContext()->EnsureJITThreadContext(allowPrereserveAlloc);
+
+        JITManager::GetJITManager()->InitializeScriptContext(&contextData, this->GetThreadContext()->GetRemoteThreadContextAddr(), &m_remoteScriptContextAddr);
     }
 #endif
 

--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -915,10 +915,12 @@ private:
 
         intptr_t GetRemoteScriptAddr() 
         {
+#if ENABLE_OOP_NATIVE_CODEGEN
             if (!m_remoteScriptContextAddr)
             {
                 InitializeRemoteScriptContext();
             }
+#endif
             return m_remoteScriptContextAddr; 
         }
 

--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -913,7 +913,14 @@ private:
         void SetDirectHostTypeId(TypeId typeId) {directHostTypeId = typeId; }
         TypeId GetDirectHostTypeId() const { return directHostTypeId; }
 
-        intptr_t GetRemoteScriptAddr() { return m_remoteScriptContextAddr; }
+        intptr_t GetRemoteScriptAddr() 
+        {
+            if (!m_remoteScriptContextAddr)
+            {
+                InitializeRemoteScriptContext();
+            }
+            return m_remoteScriptContextAddr; 
+        }
 
         char16 const * GetUrl() const { return url; }
         void SetUrl(BSTR bstr);

--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -2008,7 +2008,8 @@ ThreadContext::EnsureJITThreadContext(bool allowPrereserveAlloc)
     m_reclaimedJITProperties = HeapNew(PropertyList, &HeapAllocator::Instance);
     m_pendingJITProperties = propertyMap->Clone();
 
-    JITManager::GetJITManager()->InitializeThreadContext(&contextData, &m_remoteThreadContextInfo, &m_prereservedRegionAddr);
+    HRESULT hr = JITManager::GetJITManager()->InitializeThreadContext(&contextData, &m_remoteThreadContextInfo, &m_prereservedRegionAddr);
+    JITManager::HandleServerCallResult(hr);
 }
 #endif
 

--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -2249,7 +2249,8 @@ void ThreadContext::SetWellKnownHostTypeId(WellKnownHostType wellKnownType, Js::
 #if ENABLE_NATIVE_CODEGEN
         if (this->m_remoteThreadContextInfo != 0)
         {
-            JITManager::GetJITManager()->SetWellKnownHostTypeId(this->m_remoteThreadContextInfo, (int)typeId);
+            HRESULT hr = JITManager::GetJITManager()->SetWellKnownHostTypeId(this->m_remoteThreadContextInfo, (int)typeId);
+            JITManager::HandleServerCallResult(hr);
         }
 #endif
     }
@@ -3874,11 +3875,9 @@ BOOL ThreadContext::IsNativeAddress(void * pCodeAddr)
             return false;
         }
         HRESULT hr = JITManager::GetJITManager()->IsNativeAddr(this->m_remoteThreadContextInfo, (intptr_t)pCodeAddr, &result);
-        if (FAILED(hr))
-        {
-            // TODO: OOP JIT, what to do in failure case?
-            Js::Throw::FatalInternalError();
-        }
+
+        // TODO: OOP JIT, can we throw here?
+        JITManager::HandleServerCallResult(hr);
         return result;
     }
     else

--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -1979,6 +1979,7 @@ ThreadContext::EnsureJITThreadContext(bool allowPrereserveAlloc)
     {
         return;
     }
+
     ThreadContextDataIDL contextData;
     contextData.processHandle = (intptr_t)JITManager::GetJITManager()->GetJITTargetHandle();
 

--- a/lib/Runtime/Base/ThreadContext.h
+++ b/lib/Runtime/Base/ThreadContext.h
@@ -554,8 +554,9 @@ public:
     static void SetJITConnectionInfo(HANDLE processHandle, void* serverSecurityDescriptor, UUID connectionId);
     void EnsureJITThreadContext(bool allowPrereserveAlloc);
 
-    intptr_t GetRemoteThreadContextAddr() const
+    intptr_t GetRemoteThreadContextAddr()
     {
+        Assert(m_remoteThreadContextInfo);
         return m_remoteThreadContextInfo;
     }
 #endif

--- a/lib/Runtime/Base/ThreadContextInfo.cpp
+++ b/lib/Runtime/Base/ThreadContextInfo.cpp
@@ -12,7 +12,8 @@
 
 ThreadContextInfo::ThreadContextInfo() :
     m_isAllJITCodeInPreReservedRegion(true),
-    wellKnownHostTypeHTMLAllCollectionTypeId(Js::TypeIds_Undefined)
+    wellKnownHostTypeHTMLAllCollectionTypeId(Js::TypeIds_Undefined), 
+    m_isClosed(false)
 {
 }
 

--- a/lib/Runtime/Base/ThreadContextInfo.cpp
+++ b/lib/Runtime/Base/ThreadContextInfo.cpp
@@ -12,8 +12,7 @@
 
 ThreadContextInfo::ThreadContextInfo() :
     m_isAllJITCodeInPreReservedRegion(true),
-    wellKnownHostTypeHTMLAllCollectionTypeId(Js::TypeIds_Undefined),
-    m_activeJITCount(0)
+    wellKnownHostTypeHTMLAllCollectionTypeId(Js::TypeIds_Undefined)
 {
 }
 
@@ -411,24 +410,11 @@ ThreadContextInfo::SetValidCallTargetForCFG(PVOID callTargetAddress, bool isSetV
 #endif // _CONTROL_FLOW_GUARD
 }
 
-void
-ThreadContextInfo::BeginJIT()
+bool 
+ThreadContextInfo::IsClosed()
 {
-    InterlockedExchangeAdd(&m_activeJITCount, (uint)1);
+    return m_isClosed;
 }
-
-void
-ThreadContextInfo::EndJIT()
-{
-    InterlockedExchangeSubtract(&m_activeJITCount, (uint)1);
-}
-
-bool
-ThreadContextInfo::IsJITActive()
-{
-    return m_activeJITCount != 0;
-}
-
 
 intptr_t SHIFT_ADDR(const ThreadContextInfo*const context, intptr_t address)
 {

--- a/lib/Runtime/Base/ThreadContextInfo.h
+++ b/lib/Runtime/Base/ThreadContextInfo.h
@@ -100,9 +100,8 @@ public:
     bool CanBeFalsy(Js::TypeId typeId) { return typeId == this->wellKnownHostTypeHTMLAllCollectionTypeId; }
 
     bool IsCFGEnabled();
-    void BeginJIT();
-    void EndJIT();
-    bool IsJITActive();
+    bool IsClosed();
+    
 
 #if defined(ENABLE_GLOBALIZATION) && defined(_CONTROL_FLOW_GUARD)
     Js::DelayLoadWinCoreMemory * GetWinCoreMemoryLibrary();
@@ -113,10 +112,9 @@ public:
 #endif
 protected:
     Js::TypeId wellKnownHostTypeHTMLAllCollectionTypeId;
-private:
 
-    uint m_activeJITCount;
     bool m_isAllJITCodeInPreReservedRegion;
+    bool m_isClosed;
 
 };
 

--- a/lib/Runtime/Language/SourceTextModuleRecord.cpp
+++ b/lib/Runtime/Language/SourceTextModuleRecord.cpp
@@ -841,10 +841,6 @@ namespace Js
 #if ENABLE_NATIVE_CODEGEN
             if (JITManager::GetJITManager()->IsOOPJITEnabled())
             {
-                if (!scriptContext->GetRemoteScriptAddr())
-                {
-                    scriptContext->InitializeRemoteScriptContext();
-                }
                 HRESULT hr = JITManager::GetJITManager()->AddModuleRecordInfo(
                     scriptContext->GetRemoteScriptAddr(),
                     this->GetModuleId(),

--- a/lib/Runtime/Language/SourceTextModuleRecord.cpp
+++ b/lib/Runtime/Language/SourceTextModuleRecord.cpp
@@ -845,10 +845,11 @@ namespace Js
                 {
                     scriptContext->InitializeRemoteScriptContext();
                 }
-                JITManager::GetJITManager()->AddModuleRecordInfo(
+                HRESULT hr = JITManager::GetJITManager()->AddModuleRecordInfo(
                     scriptContext->GetRemoteScriptAddr(),
                     this->GetModuleId(),
                     (intptr_t)this->GetLocalExportSlots());
+                JITManager::HandleServerCallResult(hr);
             }
 #endif
         }

--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -6588,11 +6588,8 @@ namespace Js
 #if ENABLE_NATIVE_CODEGEN
         if (JITManager::GetJITManager()->IsOOPJITEnabled())
         {
-            if (!GetScriptContext()->GetRemoteScriptAddr())
-            {
-                GetScriptContext()->InitializeRemoteScriptContext();
-            }
-            JITManager::GetJITManager()->SetIsPRNGSeeded(GetScriptContext()->GetRemoteScriptAddr(), val);
+            HRESULT hr = JITManager::GetJITManager()->SetIsPRNGSeeded(GetScriptContext()->GetRemoteScriptAddr(), val);
+            JITManager::HandleServerCallResult(hr);
         }
 #endif
     }


### PR DESCRIPTION
adding a new type of exception to indicate system call failed(mostly because content process is terminated/crash and VM is deleted, the JIT server is still trying to do the VM operations, which fails)
wrap all server call in exception handling
make relationship between scriptcontext and threadcontext in server side