### PR TITLE
Enabling async functions by default

### DIFF
--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -565,12 +565,7 @@ PHASE(All)
 #else
     #define DEFAULT_CONFIG_ArrayBufferTransfer     (false)
 #endif
-#ifdef COMPILE_DISABLE_ES7AsyncAwait
-    // If ES7AsyncAwait needs to be disabled by compile flag, DEFAULT_CONFIG_ES7AsyncAwait should be false
-    #define DEFAULT_CONFIG_ES7AsyncAwait           (false)
-#else
-    #define DEFAULT_CONFIG_ES7AsyncAwait           (false)
-#endif
+#define DEFAULT_CONFIG_ES7AsyncAwait           (true)
 #define DEFAULT_CONFIG_ES7ExponentionOperator  (true)
 #define DEFAULT_CONFIG_ES7TrailingComma        (true)
 #define DEFAULT_CONFIG_ES7ValuesEntries        (true)
@@ -943,10 +938,7 @@ FLAGNRC(Boolean, ES6Experimental           , "Enable all experimental features",
 
 FLAGPR           (Boolean, ES6, ES6Species             , "Enable ES6 '@@species' properties and built-in behaviors" , DEFAULT_CONFIG_ES6Species)
 
-#ifndef COMPILE_DISABLE_ES7AsyncAwait
-    #define COMPILE_DISABLE_ES7AsyncAwait 0
-#endif
-FLAGPR_REGOVR_EXP(Boolean, ES6, ES7AsyncAwait          , "Enable ES7 'async' and 'await' keywords"                  , DEFAULT_CONFIG_ES7AsyncAwait)
+FLAGPR           (Boolean, ES6, ES7AsyncAwait          , "Enable ES7 'async' and 'await' keywords"                  , DEFAULT_CONFIG_ES7AsyncAwait)
 FLAGPR           (Boolean, ES6, ES6Classes             , "Enable ES6 'class' and 'extends' keywords"                , DEFAULT_CONFIG_ES6Classes)
 FLAGPR           (Boolean, ES6, ES6DateParseFix        , "Enable ES6 Date.parse fixes"                              , DEFAULT_CONFIG_ES6DateParseFix)
 FLAGPR           (Boolean, ES6, ES6DefaultArgs         , "Enable ES6 Default Arguments"                             , DEFAULT_CONFIG_ES6DefaultArgs)

--- a/test/DebuggerCommon/async.js
+++ b/test/DebuggerCommon/async.js
@@ -1,0 +1,32 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function foo() {
+    return this.x; /**bp:locals(1);stack()**/
+}
+
+async function af1(a) {
+    await a;
+    return await foo.call({ x : 100 }); /**bp:locals();stack()**/
+}
+
+async function af2() {
+    return await af1(10);
+}
+
+var p = af2();/**bp:
+    resume('step_into');stack();
+    resume('step_into');stack();
+    resume('step_into');stack();
+**/
+p.then(result => {
+        if (result === 100) {
+            print("PASS");
+        }
+    },
+    error => {
+        print("Failed : " + error);
+    } 
+);

--- a/test/DebuggerCommon/async.js.dbg.baseline
+++ b/test/DebuggerCommon/async.js.dbg.baseline
@@ -1,0 +1,109 @@
+[
+  {
+    "callStack": [
+      {
+        "line": 15,
+        "column": 4,
+        "sourceText": "return await af1(10)",
+        "function": "af2"
+      },
+      {
+        "line": 18,
+        "column": 0,
+        "sourceText": "var p = af2()",
+        "function": "Global code"
+      }
+    ]
+  },
+  {
+    "callStack": [
+      {
+        "line": 10,
+        "column": 4,
+        "sourceText": "await a",
+        "function": "af1"
+      },
+      {
+        "line": 15,
+        "column": 4,
+        "sourceText": "return await af1(10)",
+        "function": "af2"
+      },
+      {
+        "line": 18,
+        "column": 0,
+        "sourceText": "var p = af2()",
+        "function": "Global code"
+      }
+    ]
+  },
+  {
+    "callStack": [
+      {
+        "line": 15,
+        "column": 4,
+        "sourceText": "return await af1(10)",
+        "function": "af2"
+      },
+      {
+        "line": 18,
+        "column": 0,
+        "sourceText": "var p = af2()",
+        "function": "Global code"
+      }
+    ]
+  },
+  {
+    "this": "Object {...}",
+    "arguments": "Object {...}",
+    "locals": {
+      "a": "number 10"
+    }
+  },
+  {
+    "callStack": [
+      {
+        "line": 11,
+        "column": 4,
+        "sourceText": "return await foo.call({ x : 100 })",
+        "function": "af1"
+      }
+    ]
+  },
+  {
+    "this": {
+      "x": "number 100"
+    },
+    "arguments": {
+      "#__proto__": "Object {...}",
+      "length": "number 0",
+      "callee": "function <large string>",
+      "Symbol.iterator": "function <large string>"
+    },
+    "globals": {
+      "WScript": "Object {...}",
+      "print": "function print",
+      "console": "Object {...}",
+      "foo": "function <large string>",
+      "af1": "function <large string>",
+      "af2": "function <large string>",
+      "p": "Promise [...]"
+    }
+  },
+  {
+    "callStack": [
+      {
+        "line": 6,
+        "column": 4,
+        "sourceText": "return this.x",
+        "function": "foo"
+      },
+      {
+        "line": 11,
+        "column": 4,
+        "sourceText": "return await foo.call({ x : 100 })",
+        "function": "af1"
+      }
+    ]
+  }
+]

--- a/test/DebuggerCommon/async_step_out.js
+++ b/test/DebuggerCommon/async_step_out.js
@@ -1,0 +1,36 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function foo() {
+    return 100;
+}
+
+async function af1(a) {
+    return await foo();
+}
+
+async function af2() {
+    return await af1(10);
+}
+
+var p = 1;/**bp:
+    resume('step_over');
+    resume('step_into');
+    resume('step_into');
+    resume('step_out');stack();
+    resume('step_out');stack();**/
+// If we put the break point in the below line after stepping out from af2 we will execute the same break
+// point again which will add more break points. To avoid this adding the break point to a dummy statement.
+p = af2();
+
+p.then(result => {
+        if (result === 100) {
+            print("PASS");
+        }
+    },
+    error => {
+        print("Failed : " + error);
+    } 
+);

--- a/test/DebuggerCommon/async_step_out.js.dbg.baseline
+++ b/test/DebuggerCommon/async_step_out.js.dbg.baseline
@@ -1,0 +1,28 @@
+[
+  {
+    "callStack": [
+      {
+        "line": 14,
+        "column": 4,
+        "sourceText": "return await af1(10)",
+        "function": "af2"
+      },
+      {
+        "line": 25,
+        "column": 0,
+        "sourceText": "p = af2()",
+        "function": "Global code"
+      }
+    ]
+  },
+  {
+    "callStack": [
+      {
+        "line": 25,
+        "column": 0,
+        "sourceText": "p = af2()",
+        "function": "Global code"
+      }
+    ]
+  }
+]

--- a/test/DebuggerCommon/async_step_over.js
+++ b/test/DebuggerCommon/async_step_over.js
@@ -1,0 +1,42 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function foo() {
+    return 100;
+}
+
+async function af1(a) {
+    return await foo();
+}
+
+async function af2() {
+    return await af1(10);
+}
+
+var p = af2();/**bp:
+    resume('step_into');
+    resume('step_into');
+    resume('step_over');stack();
+**/
+p.then(result => {
+        if (result === 100) {
+            print("PASS");
+        }
+    },
+    error => {
+        print("Failed : " + error);
+    } 
+);
+
+p = af2();/**bp:resume('step_over');stack();**/
+p.then(result => {
+        if (result === 100) {
+            print("PASS");
+        }
+    },
+    error => {
+        print("Failed : " + error);
+    } 
+);

--- a/test/DebuggerCommon/async_step_over.js.dbg.baseline
+++ b/test/DebuggerCommon/async_step_over.js.dbg.baseline
@@ -1,0 +1,28 @@
+[
+  {
+    "callStack": [
+      {
+        "line": 14,
+        "column": 4,
+        "sourceText": "return await af1(10)",
+        "function": "af2"
+      },
+      {
+        "line": 17,
+        "column": 0,
+        "sourceText": "var p = af2()",
+        "function": "Global code"
+      }
+    ]
+  },
+  {
+    "callStack": [
+      {
+        "line": 33,
+        "column": 0,
+        "sourceText": "p.then(result => {\r\n        if (result === 100) {\r\n            print(\"PASS\");\r\n        }\r\n    },\r\n    error => {\r\n        print(\"Failed : \" + error);\r\n    } \r\n)",
+        "function": "Global code"
+      }
+    ]
+  }
+]

--- a/test/DebuggerCommon/rlexe.xml
+++ b/test/DebuggerCommon/rlexe.xml
@@ -1358,6 +1358,24 @@
   </test>
   <test>
     <default>
+      <files>async.js</files>
+      <compile-flags>-debuglaunch -dbgbaseline:async.js.dbg.baseline</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
+      <files>async_step_out.js</files>
+      <compile-flags>-debuglaunch -dbgbaseline:async_step_out.js.dbg.baseline</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
+      <files>async_step_over.js</files>
+      <compile-flags>-debuglaunch -dbgbaseline:async_step_over.js.dbg.baseline</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>TypedArray.js</files>
       <compile-flags>-ES6Species -debuglaunch -dbgbaseline:typedarray.js.dbg.baseline -InspectMaxStringLength:200</compile-flags>
     </default>

--- a/test/es6/es6_stable.baseline
+++ b/test/es6/es6_stable.baseline
@@ -3,8 +3,8 @@ FLAG ES6 = 1 - setting child flag Simdjs = 0
 FLAG Simdjs = 0
 FLAG ES6 = 1 - setting child flag ES6Species = 1
 FLAG ES6Species = 1
-FLAG ES6 = 1 - setting child flag ES7AsyncAwait = 0
-FLAG ES7AsyncAwait = 0
+FLAG ES6 = 1 - setting child flag ES7AsyncAwait = 1
+FLAG ES7AsyncAwait = 1
 FLAG ES6 = 1 - setting child flag ES6Classes = 1
 FLAG ES6Classes = 1
 FLAG ES6 = 1 - setting child flag ES6DateParseFix = 1

--- a/test/es6/es6_stable.enable_disable.baseline
+++ b/test/es6/es6_stable.enable_disable.baseline
@@ -3,8 +3,8 @@ FLAG ES6 = 1 - setting child flag Simdjs = 0
 FLAG Simdjs = 0
 FLAG ES6 = 1 - setting child flag ES6Species = 1
 FLAG ES6Species = 1
-FLAG ES6 = 1 - setting child flag ES7AsyncAwait = 0
-FLAG ES7AsyncAwait = 0
+FLAG ES6 = 1 - setting child flag ES7AsyncAwait = 1
+FLAG ES7AsyncAwait = 1
 FLAG ES6 = 1 - setting child flag ES6Classes = 1
 FLAG ES6Classes = 1
 FLAG ES6 = 1 - setting child flag ES6DateParseFix = 1

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -215,21 +215,20 @@
   <test>
     <default>
       <files>blockscope-functionbinding.js</files>
-      <compile-flags>-ES7AsyncAwait</compile-flags>
       <baseline>blockscope-functionbinding.baseline</baseline>
     </default>
   </test>
   <test>
     <default>
       <files>blockscope-functionbinding.js</files>
-      <compile-flags>-force:deferparse -ES7AsyncAwait</compile-flags>
+      <compile-flags>-force:deferparse</compile-flags>
       <baseline>blockscope-functionbinding.baseline</baseline>
     </default>
   </test>
   <test>
     <default>
       <files>blockscope-functionbinding.js</files>
-      <compile-flags>-lic:1 -InitializeInterpreterSlotsWithInvalidStackVar -ES7AsyncAwait</compile-flags>
+      <compile-flags>-lic:1 -InitializeInterpreterSlotsWithInvalidStackVar</compile-flags>
       <baseline>blockscope-functionbinding.baseline</baseline>
       <tags>exclude_fre</tags>
     </default>
@@ -756,31 +755,31 @@
   <test>
     <default>
       <files>default.js</files>
-      <compile-flags>-force:deferparse -ES6DefaultArgs -ES7AsyncAwait -ES6Generators -args summary -endargs</compile-flags>
+      <compile-flags>-force:deferparse -args summary -endargs</compile-flags>
     </default>
   </test>
   <test>
     <default>
       <files>default.js</files>
-      <compile-flags>-off:deferparse -ES6DefaultArgs -ES7AsyncAwait -ES6Generators -args summary -endargs</compile-flags>
+      <compile-flags>-off:deferparse -args summary -endargs</compile-flags>
     </default>
   </test>
   <test>
     <default>
       <files>default.js</files>
-      <compile-flags>-force:CachedScope -ES6DefaultArgs -ES7AsyncAwait -ES6Generators -args summary -endargs</compile-flags>
+      <compile-flags>-force:CachedScope -args summary -endargs</compile-flags>
     </default>
   </test>
   <test>
     <default>
       <files>default-splitscope.js</files>
-      <compile-flags>-off:deferparse -ES6DefaultArgsSplitScope -ES6Generators -args summary -endargs</compile-flags>
+      <compile-flags>-off:deferparse -ES6DefaultArgsSplitScope -args summary -endargs</compile-flags>
     </default>
   </test>
   <test>
     <default>
       <files>default-splitscope.js</files>
-      <compile-flags>-force:deferparse -ES6DefaultArgsSplitScope -ES6Generators -args summary -endargs</compile-flags>
+      <compile-flags>-force:deferparse -ES6DefaultArgsSplitScope -args summary -endargs</compile-flags>
     </default>
   </test>
   <test>
@@ -1288,7 +1287,7 @@
 <test>
     <default>
         <files>module-functionality.js</files>
-        <compile-flags>-ES6Module  -ES7AsyncAwait -args summary -endargs</compile-flags>
+        <compile-flags>-ES6Module -args summary -endargs</compile-flags>
         <tags>exclude_xplat,exclude_dynapogo</tags>
     </default>
 </test>
@@ -1309,7 +1308,7 @@
 <test>
     <default>
         <files>module-namespace.js</files>
-        <compile-flags>-ES6Module  -ES7AsyncAwait -Es6ToStringTag</compile-flags>
+        <compile-flags>-ES6Module -Es6ToStringTag</compile-flags>
         <baseline>module-namespace.baseline</baseline>
         <tags>exclude_xplat</tags>
     </default>

--- a/test/es7/asyncawait-functionality.baseline
+++ b/test/es7/asyncawait-functionality.baseline
@@ -32,6 +32,7 @@ Executing test #26 - Awaiting a function with multiple awaits
 Executing test #27 - Async function with nested try-catch in the body
 Executing test #28 - Async function with try-catch and try-finally in the body
 Executing test #29 - Async function and with
+Executing test #30 - Async and arguments.callee
 
 Completion Results:
 Test #1 - Success lambda expression with no argument called with result = 'true'
@@ -75,6 +76,7 @@ Test #27 - Success Caught the expected exception inside the inner catch in async
 Test #27 - Success Caught the expected exception inside catch in async body
 Test #28 - Success Caught the expected exception inside the inner catch in async body
 Test #28 - Success finally block is executed in async body
+Test #30 - Success async function and arguments.callee
 Test #6 - Success await in an async function #1 called with result = '-4'
 Test #6 - Success await in an async function #2 called with result = '2'
 Test #6 - Success await in an async function catch a rejected Promise in 'err'. Error = 'Error: My Error'

--- a/test/es7/asyncawait-functionality.js
+++ b/test/es7/asyncawait-functionality.js
@@ -918,6 +918,23 @@ var tests = [
             });
         }
     },
+    {
+        name: "Async and arguments.callee",
+        body: function (index) {
+            async function asyncMethod() {
+                return arguments.callee;
+            }
+            asyncMethod().then(result => {
+                if (result === asyncMethod) {
+                    echo(`Test #${index} - Success async function and arguments.callee`);
+                } else {
+                    echo(`Test #${index} - Failed async function and arguments.callee called with result = '${result}'`);
+                }
+            }, err => {
+                echo(`Test #${index} - Error async function and arguments.callee called with err = ${err}`);
+            });
+        }
+    }
 ];
 
 var index = 1;


### PR DESCRIPTION
Enabling async functions by default. Also added one new test case to
verify the arguments.callee behavior.
