### PR TITLE
xplat: fix some clang undefined sanitizer issues

### DIFF
--- a/lib/Common/Codex/Utf8Codex.cpp
+++ b/lib/Common/Codex/Utf8Codex.cpp
@@ -37,7 +37,7 @@ namespace utf8
 
     inline bool ShouldFastPath(LPCUTF8 pb, LPCOLESTR pch)
     {
-        return (reinterpret_cast<size_t>(pb) & mAlignmentMask) == 0 || (reinterpret_cast<size_t>(pch) & mAlignmentMask) == 0;
+        return (reinterpret_cast<size_t>(pb) & mAlignmentMask) == 0 && (reinterpret_cast<size_t>(pch) & mAlignmentMask) == 0;
     }
 
     inline size_t EncodedBytes(char16 prefix)
@@ -336,14 +336,14 @@ LFourByte:
         uint32 codepoint = 0x10000 + ((highTen << 10) | lowTen);
 
         // This is the maximum valid unicode codepoint
-        // This should be ensured anyway since you can't encode a value higher 
+        // This should be ensured anyway since you can't encode a value higher
         // than this as a surrogate pair, so we assert this here
         CodexAssert(codepoint <= 0x10FFFF);
 
         // Now we need to encode the code point into utf-8
         // Codepoints in the range that gets encoded into a surrogate pair
         // gets encoded into 4 bytes under utf8
-        // Since the codepoint can be represented by 21 bits, the encoding 
+        // Since the codepoint can be represented by 21 bits, the encoding
         // does the following: first 3 bits in the first byte, the next 6 in the
         // second, the next six in the third, and the last six in the 4th byte
         *ptr++ = static_cast<utf8char_t>(codepoint >> 18) | 0xF0;
@@ -506,8 +506,8 @@ LSlowPath:
             while (cch-- > 0)
             {
                 // We increment the source pointer here since at least one utf16 code unit is read here
-                // If the code unit turns out to be the high surrogate in a surrogate pair, then 
-                // EncodeTrueUtf8 will consume the low surrogate code unit too by decrementing cch 
+                // If the code unit turns out to be the high surrogate in a surrogate pair, then
+                // EncodeTrueUtf8 will consume the low surrogate code unit too by decrementing cch
                 // and incrementing source
                 dest = EncodeTrueUtf8(*source++, &source, &cch, dest);
                 if (ShouldFastPath(dest, source)) goto LFastPath;

--- a/lib/Common/Memory/HeapBlock.cpp
+++ b/lib/Common/Memory/HeapBlock.cpp
@@ -8,7 +8,7 @@ template <typename TBlockAttributes>
 SmallNormalHeapBlockT<TBlockAttributes> *
 HeapBlock::AsNormalBlock()
 {
-    Assert(this == nullptr || IsAnyNormalBlock());
+    Assert(IsAnyNormalBlock());
     return static_cast<SmallNormalHeapBlockT<TBlockAttributes> *>(this);
 }
 
@@ -16,7 +16,7 @@ template <typename TBlockAttributes>
 SmallLeafHeapBlockT<TBlockAttributes> *
 HeapBlock::AsLeafBlock()
 {
-    Assert(this == nullptr || IsLeafBlock());
+    Assert(IsLeafBlock());
     return static_cast<SmallLeafHeapBlockT<TBlockAttributes> *>(this);
 }
 
@@ -24,7 +24,7 @@ template <typename TBlockAttributes>
 SmallFinalizableHeapBlockT<TBlockAttributes> *
 HeapBlock::AsFinalizableBlock()
 {
-    Assert(this == nullptr || IsAnyFinalizableBlock());
+    Assert(IsAnyFinalizableBlock());
     return static_cast<SmallFinalizableHeapBlockT<TBlockAttributes> *>(this);
 }
 
@@ -33,7 +33,7 @@ template <typename TBlockAttributes>
 SmallNormalWithBarrierHeapBlockT<TBlockAttributes> *
 HeapBlock::AsNormalWriteBarrierBlock()
 {
-    Assert(this == nullptr || IsNormalWriteBarrierBlock());
+    Assert(IsNormalWriteBarrierBlock());
     return static_cast<SmallNormalWithBarrierHeapBlockT<TBlockAttributes> *>(this);
 }
 
@@ -41,7 +41,7 @@ template <typename TBlockAttributes>
 SmallFinalizableWithBarrierHeapBlockT<TBlockAttributes> *
 HeapBlock::AsFinalizableWriteBarrierBlock()
 {
-    Assert(this == nullptr || IsFinalizableWriteBarrierBlock());
+    Assert(IsFinalizableWriteBarrierBlock());
     return static_cast<SmallFinalizableWithBarrierHeapBlockT<TBlockAttributes> *>(this);
 }
 #endif

--- a/lib/Common/Memory/HeapBlock.h
+++ b/lib/Common/Memory/HeapBlock.h
@@ -446,10 +446,10 @@ public:
 
     void ProtectUnusablePages() {}
     void RestoreUnusablePages() {}
-    
-    uint GetUnusablePageCount() 
+
+    uint GetUnusablePageCount()
     {
-        return 0; 
+        return 0;
     }
 
 #ifdef RECYCLER_WRITE_BARRIER

--- a/lib/Common/Memory/PageAllocator.h
+++ b/lib/Common/Memory/PageAllocator.h
@@ -442,8 +442,8 @@ public:
     uint GetMaxAllocPageCount();
 
     //VirtualAllocator APIs
-    TVirtualAlloc * GetVirtualAllocator() { return virtualAllocator; }
-    bool IsPreReservedPageAllocator() { return virtualAllocator != nullptr; }
+    TVirtualAlloc * GetVirtualAllocator() { Assert(virtualAllocator != nullptr); return virtualAllocator; }
+    bool IsPreReservedPageAllocator();
 
 
     PageAllocation * AllocPagesForBytes(DECLSPEC_GUARD_OVERFLOW size_t requestedBytes);
@@ -517,6 +517,8 @@ public:
     char16 const * debugName;
 #endif
 protected:
+    void InitVirtualAllocator(TVirtualAlloc * virtualAllocator);
+
     SegmentBase<TVirtualAlloc> * AllocSegment(DECLSPEC_GUARD_OVERFLOW size_t pageCount);
     void ReleaseSegment(SegmentBase<TVirtualAlloc> * segment);
 
@@ -596,7 +598,9 @@ protected:
     bool disableAllocationOutOfMemory;
     bool excludeGuardPages;
     AllocationPolicyManager * policyManager;
+private:
     TVirtualAlloc * virtualAllocator;
+protected:
 
 #ifndef JD_PRIVATE
     Js::ConfigFlagsTable& pageAllocatorFlagTable;

--- a/lib/Common/Memory/SmallFinalizableHeapBlock.h
+++ b/lib/Common/Memory/SmallFinalizableHeapBlock.h
@@ -23,7 +23,11 @@ public:
     static SmallFinalizableHeapBlockT * New(HeapBucketT<SmallFinalizableHeapBlockT> * bucket);
     static void Delete(SmallFinalizableHeapBlockT * block);
 
-    SmallFinalizableHeapBlockT * GetNextBlock() const { return SmallHeapBlockT<TBlockAttributes>::GetNextBlock()->template AsFinalizableBlock<TBlockAttributes>(); }
+    SmallFinalizableHeapBlockT * GetNextBlock() const
+    {
+        HeapBlock* block = SmallHeapBlockT<TBlockAttributes>::GetNextBlock();
+        return block ? block->template AsFinalizableBlock<TBlockAttributes>() : nullptr;
+    }
     void SetNextBlock(SmallFinalizableHeapBlockT * next) { Base::SetNextBlock(next); }
 
     void ProcessMarkedObject(void* candidate, MarkContext * markContext);
@@ -140,7 +144,11 @@ public:
     static SmallFinalizableWithBarrierHeapBlockT * New(HeapBucketT<SmallFinalizableWithBarrierHeapBlockT> * bucket);
     static void Delete(SmallFinalizableWithBarrierHeapBlockT * block);
 
-    SmallFinalizableWithBarrierHeapBlockT * GetNextBlock() const { return ((SmallHeapBlock*) this)->GetNextBlock()->AsFinalizableWriteBarrierBlock<TBlockAttributes>(); }
+    SmallFinalizableWithBarrierHeapBlockT * GetNextBlock() const
+    {
+        HeapBlock* block = SmallHeapBlockT<TBlockAttributes>::GetNextBlock();
+        return block ? block->template AsFinalizableWriteBarrierBlock<TBlockAttributes>() : nullptr;
+    }
 
     virtual bool FindHeapObject(void* objectAddress, Recycler * recycler, FindHeapObjectFlags flags, RecyclerHeapObjectInfo& heapObject) override sealed
     {

--- a/lib/Common/Memory/SmallLeafHeapBlock.h
+++ b/lib/Common/Memory/SmallLeafHeapBlock.h
@@ -15,7 +15,11 @@ public:
     static const ObjectInfoBits RequiredAttributes = LeafBit;
     typedef TBlockAttributes HeapBlockAttributes;
 
-    SmallLeafHeapBlockT * GetNextBlock() const { return Base::GetNextBlock()->template AsLeafBlock<TBlockAttributes>(); }
+    SmallLeafHeapBlockT * GetNextBlock() const
+    {
+        HeapBlock* block = Base::GetNextBlock();
+        return block ? block->template AsLeafBlock<TBlockAttributes>() : nullptr;
+    }
     void SetNextBlock(SmallLeafHeapBlockT * next) { Base::SetNextBlock(next); }
 
     void ScanNewImplicitRoots(Recycler * recycler);

--- a/lib/Common/Memory/SmallNormalHeapBlock.h
+++ b/lib/Common/Memory/SmallNormalHeapBlock.h
@@ -21,7 +21,11 @@ public:
     static SmallNormalHeapBlockT * New(HeapBucketT<SmallNormalHeapBlockT> * bucket);
     static void Delete(SmallNormalHeapBlockT * block);
 
-    SmallNormalHeapBlockT * GetNextBlock() const { return Base::GetNextBlock()->template AsNormalBlock<TBlockAttributes>(); }
+    SmallNormalHeapBlockT * GetNextBlock() const
+    {
+        HeapBlock* block = Base::GetNextBlock();
+        return block ? block->template AsNormalBlock<TBlockAttributes>() : nullptr;
+    }
     void SetNextBlock(SmallNormalHeapBlockT * next) { Base::SetNextBlock(next); }
 
     void ScanInitialImplicitRoots(Recycler * recycler);
@@ -66,7 +70,11 @@ public:
     static SmallNormalWithBarrierHeapBlockT * New(HeapBucketT<SmallNormalWithBarrierHeapBlockT> * bucket);
     static void Delete(SmallNormalWithBarrierHeapBlockT * heapBlock);
 
-    SmallNormalWithBarrierHeapBlockT * GetNextBlock() const { return ((SmallHeapBlock*) this)->GetNextBlock()->AsNormalWriteBarrierBlock<TBlockAttributes>(); }
+    SmallNormalWithBarrierHeapBlockT * GetNextBlock() const
+    {
+        HeapBlock* block = SmallHeapBlockT<TBlockAttributes>::GetNextBlock();
+        return block ? block->template AsNormalWriteBarrierBlock<TBlockAttributes>() : nullptr;
+    }
 
     virtual bool FindHeapObject(void* objectAddress, Recycler * recycler, FindHeapObjectFlags flags, RecyclerHeapObjectInfo& heapObject) override sealed
     {

--- a/lib/Common/Memory/VirtualAllocWrapper.h
+++ b/lib/Common/Memory/VirtualAllocWrapper.h
@@ -18,6 +18,10 @@ class VirtualAllocWrapper
 public:
     LPVOID  Alloc(LPVOID lpAddress, DECLSPEC_GUARD_OVERFLOW size_t dwSize, DWORD allocationType, DWORD protectFlags, bool isCustomHeapAllocation = false, HANDLE process = GetCurrentProcess());
     BOOL    Free(LPVOID lpAddress, size_t dwSize, DWORD dwFreeType, HANDLE process = GetCurrentProcess());
+
+    static VirtualAllocWrapper Instance;  // single instance
+private:
+    VirtualAllocWrapper() {}
 };
 
 /*

--- a/lib/Parser/Alloc.cpp
+++ b/lib/Parser/Alloc.cpp
@@ -10,7 +10,7 @@
 #define DEBUG_TRASHMEM
 #endif //DEBUG
 
-#if _WIN64
+#if TARGET_64
 struct __ALIGN_FOO__ {
     int w1;
     double dbl;
@@ -19,7 +19,7 @@ struct __ALIGN_FOO__ {
 #else
 // Force check for 4 byte alignment to support Win98/ME
 #define ALIGN_FULL 4
-#endif // _WIN64
+#endif  // TARGET_64
 
 #define AlignFull(VALUE) (~(~((VALUE) + (ALIGN_FULL-1)) | (ALIGN_FULL-1)))
 

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -69,7 +69,7 @@ namespace Js
 
     // FunctionProxy methods
     FunctionProxy::FunctionProxy(JavascriptMethod entryPoint, Attributes attributes, LocalFunctionId functionId, ScriptContext* scriptContext, Utf8SourceInfo* utf8SourceInfo, uint functionNumber):
-        FunctionInfo(entryPoint, attributes, functionId, (FunctionBody*) this),
+        FunctionInfo(entryPoint, attributes, functionId, this),
         m_isTopLevel(false),
         m_isPublicLibraryCode(false),
         m_scriptContext(scriptContext),

--- a/lib/Runtime/Base/FunctionInfo.cpp
+++ b/lib/Runtime/Base/FunctionInfo.cpp
@@ -6,7 +6,7 @@
 
 namespace Js
 {
-    FunctionInfo::FunctionInfo(JavascriptMethod entryPoint, Attributes attributes, LocalFunctionId functionId, FunctionBody* functionBodyImpl)
+    FunctionInfo::FunctionInfo(JavascriptMethod entryPoint, Attributes attributes, LocalFunctionId functionId, FunctionProxy* functionBodyImpl)
         : originalEntryPoint(entryPoint), attributes(attributes), functionBodyImpl(functionBodyImpl), functionId(functionId)
     {
 #if !DYNAMIC_INTERPRETER_THUNK

--- a/lib/Runtime/Base/FunctionInfo.h
+++ b/lib/Runtime/Base/FunctionInfo.h
@@ -22,7 +22,7 @@ namespace Js
             ErrorOnNew                     = 0x00001,
             SkipDefaultNewObject           = 0x00002,
             DoNotProfile                   = 0x00004,
-            HasNoSideEffect                = 0x00008, // calling function doesn’t cause an implicit flags to be set,
+            HasNoSideEffect                = 0x00008, // calling function doesn't cause an implicit flags to be set,
                                                       // the callee will detect and set implicit flags on its individual operations
             NeedCrossSiteSecurityCheck     = 0x00010,
             DeferredDeserialize            = 0x00020, // The function represents something that needs to be deserialized on use
@@ -39,7 +39,7 @@ namespace Js
             Module                         = 0x20000, // The function is the function body wrapper for a module
             EnclosedByGlobalFunc           = 0x40000,
         };
-        FunctionInfo(JavascriptMethod entryPoint, Attributes attributes = None, LocalFunctionId functionId = Js::Constants::NoFunctionId, FunctionBody* functionBodyImpl = NULL);
+        FunctionInfo(JavascriptMethod entryPoint, Attributes attributes = None, LocalFunctionId functionId = Js::Constants::NoFunctionId, FunctionProxy* functionBodyImpl = NULL);
 
         static DWORD GetFunctionBodyImplOffset() { return offsetof(FunctionInfo, functionBodyImpl); }
         static DWORD GetAttributesOffset() { return offsetof(FunctionInfo, attributes); }

--- a/lib/Runtime/Library/JavascriptExternalFunction.h
+++ b/lib/Runtime/Library/JavascriptExternalFunction.h
@@ -8,7 +8,7 @@ typedef HRESULT(__cdecl *InitializeMethod)(Js::Var instance);
 
 namespace Js
 {
-    typedef Var (__stdcall *StdCallJavascriptMethod)(RecyclableObject *callee, bool isConstructCall, Var *args, USHORT cargs, void *callbackState);
+    typedef Var (__stdcall *StdCallJavascriptMethod)(Var callee, bool isConstructCall, Var *args, USHORT cargs, void *callbackState);
     typedef int JavascriptTypeId;
 
     class JavascriptExternalFunction : public RuntimeFunction

--- a/lib/Runtime/Types/PathTypeHandler.cpp
+++ b/lib/Runtime/Types/PathTypeHandler.cpp
@@ -1465,7 +1465,7 @@ namespace Js
                     oldTypeToPromotedTypeMap = RecyclerNew(instance->GetRecycler(), TypeTransitionMap, instance->GetRecycler(), 2);
                     newPrototype->SetInternalProperty(Js::InternalPropertyIds::TypeOfPrototypeObjectDictionary, (Var)oldTypeToPromotedTypeMap, PropertyOperationFlags::PropertyOperation_Force, nullptr);
                 }
-                
+
                 // oldType is kind of weakReference here
                 oldTypeToPromotedTypeMap->Item(reinterpret_cast<uintptr_t>(oldType), cachedDynamicType);
 
@@ -1482,7 +1482,7 @@ namespace Js
                         Output::Print(_u("TypeSharing: Updating prototype object's DictionarySlot cache in __proto__.\n"));
 #if DBG
                     }
-#endif 
+#endif
                     Output::Flush();
                 }
 
@@ -1725,7 +1725,7 @@ namespace Js
 
         bool populateInlineCache = true;
 
-        PathTypeHandler* newTypeHandler = (PathTypeHandler*)instance->GetTypeHandler();
+        PathTypeHandlerBase* newTypeHandler = (PathTypeHandlerBase*)instance->GetTypeHandler();
 
         if (slotIndex >= newTypeHandler->typePath->GetMaxInitializedLength())
         {

--- a/lib/Runtime/Types/TypePath.cpp
+++ b/lib/Runtime/Types/TypePath.cpp
@@ -16,7 +16,7 @@ namespace Js {
     {
         Assert(size <= MaxPathTypeHandlerLength);
         size = max(size, InitialTypePathSize);
-        
+
 
         if (PHASE_OFF1(Js::TypePathDynamicSizePhase))
         {
@@ -51,8 +51,9 @@ namespace Js {
            return Constants::NoSlot;
         }
         PropertyIndex propIndex = Constants::NoSlot;
-        if (this->GetData()->map.TryGetValue(propId, &propIndex, assignments)) {
-           if (propIndex<typePathLength) {
+        if (this->GetData()->map.TryGetValue(propId, &propIndex,
+                static_cast<const PropertyRecord **>(assignments))) {
+            if (propIndex<typePathLength) {
                 return propIndex;
             }
         }


### PR DESCRIPTION
Utf8Codex.cpp, Alloc.cpp, TypePath.h: fix data alignment.

HeapBlock: refactor to remove "this == nullptr" scenario.

PreReservedPageAllocator: refactor to use a single instance for
VirtualAllocWrapper and remove "this == nullptr" scenario.

Others: fix bad casts.
