### PR TITLE
Set debugContext to null before calling close and HeapDelete

### DIFF
--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -670,9 +670,10 @@ namespace Js
             // Guard the closing and deleting of DebugContext as in meantime PDM might
             // call OnBreakFlagChange
             AutoCriticalSection autoDebugContextCloseCS(&debugContextCloseCS);
-            this->debugContext->Close();
-            HeapDelete(this->debugContext);
+            DebugContext* tempDebugContext = this->debugContext;
             this->debugContext = nullptr;
+            tempDebugContext->Close();
+            HeapDelete(tempDebugContext);
         }
 
         // Need to print this out before the native code gen is deleted


### PR DESCRIPTION
In multiple context scenarios (Slate) with chk builds I see debugContext
is not null and is garbage, ScriptContext is in closed state which means
debugContext is in the process of being deleted and has not be set to null.
I can put critical section to the particular AV but it’s better to hold
debugContext in a temporary variable set scriptContext->debugContext to
null and then HeapDelete memory pointed by temporary variable.

I have kept the autoDebugContextCloseCS for PDM case though it should
not be needed (I think so)
