### PR TITLE
Wasm: sym lifetime on select

### DIFF
--- a/lib/WasmReader/WasmByteCodeGenerator.cpp
+++ b/lib/WasmReader/WasmByteCodeGenerator.cpp
@@ -1157,11 +1157,15 @@ WasmBytecodeGenerator::EmitSelect()
     m_writer.AsmBrReg1(Js::OpCodeAsmJs::BrFalse_Int, falseLabel, conditionInfo.location);
     ReleaseLocation(&conditionInfo);
 
+    EmitInfo falseInfo = PopEvalStack();
+    EmitInfo trueInfo = PopEvalStack();
+
+    // Refresh the lifetime of the true location
+    m_writer.AsmReg2(GetLoadOp(trueInfo.type), trueInfo.location, trueInfo.location);
+
     m_writer.AsmBr(doneLabel);
     m_writer.MarkAsmJsLabel(falseLabel);
 
-    EmitInfo falseInfo = PopEvalStack();
-    EmitInfo trueInfo = PopEvalStack();
     if (trueInfo.type != falseInfo.type)
     {
         throw WasmCompilationException(_u("select operands must both have same type"));


### PR DESCRIPTION
On select refresh true's location before doing a def.
If the tmp of true has been used for something else then the select, then the resulting IR will create a new symbol for the move false => true. Which will result in an uninitialized symbol.
By doing an extra load, the IR will still create a new symbol, but the new one will be defined on all paths.