### PR TITLE
Correct a flag added recently, fixing formatting of exceptions thrown in catch blocks.

### DIFF
--- a/lib/Runtime/Language/JavascriptExceptionOperators.cpp
+++ b/lib/Runtime/Language/JavascriptExceptionOperators.cpp
@@ -91,7 +91,7 @@ namespace Js
 
         try
         {
-            Js::JavascriptExceptionOperators::AutoCatchHandlerExists autoCatchHandlerExists(scriptContext, true);
+            Js::JavascriptExceptionOperators::AutoCatchHandlerExists autoCatchHandlerExists(scriptContext, false);
             continuation = amd64_CallWithFakeFrame(tryAddr, frame, spillSize, argsSize);
         }
         catch (JavascriptExceptionObject *caughtException)


### PR DESCRIPTION
I recently added a parameter to AutoCatchHandlers to help detection
of whether or not an exception can be caught in user code, to match
the -nonative output better. Unfortunately, I set it incorrectly in
one place; namely, the case where we're in a "catch" statement made
by the user. Flipping the flag the other way fixes the issue.
