### PR TITLE
xplat: keep uncaught exception object alive

### DIFF
--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -1449,6 +1449,9 @@ ThreadContext::EnterScriptStart(Js::ScriptEntryExitRecord * record, bool doClean
     Assert(recycler->IsReentrantState());
     JS_ETW(EventWriteJSCRIPT_RUN_START(this,0));
 
+    // On enter script we should be out of throw-catch, safe to clear TempUncaughtException
+    this->ClearTempUncaughtException();
+
     // Increment the callRootLevel early so that Dispose ran during FinishConcurrent will not close the current scriptContext
     uint oldCallRootLevel = this->callRootLevel++;
 

--- a/lib/Runtime/Base/ThreadContext.h
+++ b/lib/Runtime/Base/ThreadContext.h
@@ -603,6 +603,9 @@ private:
 
         Js::JavascriptExceptionObject* unhandledExceptionObject;
 
+        // Used to temporarily keep throwing exception object alive (thrown but not yet caught)
+        Js::JavascriptExceptionObject* tempUncaughtException;
+
         // Contains types that have property caches that need to be tracked, as the caches may need to be cleared. Types that
         // contain a property cache for a property that is on a prototype object will be tracked in this map since those caches
         // need to be cleared if for instance, the property is deleted from the prototype object.
@@ -1402,6 +1405,16 @@ public:
     void ResetHasUnhandledException() {hasUnhandledException = FALSE; }
     void SetUnhandledExceptionObject(Js::JavascriptExceptionObject* exceptionObject) {recyclableData->unhandledExceptionObject  = exceptionObject; }
     Js::JavascriptExceptionObject* GetUnhandledExceptionObject() const  { return recyclableData->unhandledExceptionObject; };
+
+    // To temporarily keep throwing exception object alive (thrown but not yet caught)
+    void SaveTempUncaughtException(Js::JavascriptExceptionObject* exceptionObject)
+    {
+        // WIN32 doesn't need this because the exception object pointer is on stack
+#ifndef _WIN32
+        recyclableData->tempUncaughtException = exceptionObject;
+#endif
+    }
+    void ClearTempUncaughtException() { SaveTempUncaughtException(nullptr); }
 
     bool HasCatchHandler() const { return hasCatchHandler; }
     void SetHasCatchHandler(bool hasCatchHandler) { this->hasCatchHandler = hasCatchHandler; }

--- a/lib/Runtime/Language/JavascriptExceptionObject.cpp
+++ b/lib/Runtime/Language/JavascriptExceptionObject.cpp
@@ -66,6 +66,10 @@ namespace Js
             threadContext->ClearPendingSOError();
         }
 
+        // We will very likely throw the cloned exception object. SaveTempUncaughtException
+        // just in case we will and won't need to do this at every throw spot.
+        threadContext->SaveTempUncaughtException(exceptionObject);
+
         return exceptionObject;
     }
 


### PR DESCRIPTION
On xplat when throwing a JS exception, the exception object pointer
is not on stack and could be collected by GC prematually (triggered
by destructors). Manually track it in threadContext data temporarily.
