### PR TITLE
Fix for AddrOpnd to IntConstOpnd tests break

### DIFF
--- a/lib/Backend/LowerMDShared.cpp
+++ b/lib/Backend/LowerMDShared.cpp
@@ -1922,11 +1922,15 @@ void LowererMD::LegalizeSrc(IR::Instr *const instr, IR::Opnd *src, const uint fo
 #ifdef _M_X64
             {
                 IR::IntConstOpnd * intOpnd = src->AsIntConstOpnd();
-                if ((forms & L_Imm32) && ((TySize[intOpnd->GetType()] != 8) ||
-                    (!instr->isInlineeEntryInstr && Math::FitsInDWord(intOpnd->GetValue()))))
+                if ((TySize[intOpnd->GetType()] != 8) ||
+                    (!instr->isInlineeEntryInstr && Math::FitsInDWord(intOpnd->GetValue())))
                 {
-                    // the constant fits in 32-bit, no need to hoist
-                    return;
+                    if (forms & L_Imm32)
+                    {
+                        // the constant fits in 32-bit, no need to hoist
+                        return;
+                    }
+                    break;
                 }
                 if (verify)
                 {

--- a/lib/Backend/Opnd.cpp
+++ b/lib/Backend/Opnd.cpp
@@ -2447,6 +2447,7 @@ IndirOpnd::GetOriginalAddress() const
 void
 IndirOpnd::SetAddrKind(IR::AddrOpndKind kind, void * originalAddress)
 {
+    Assert(originalAddress != nullptr);
     this->m_addrKind = kind;
     this->m_originalAddress = originalAddress;
 }


### PR DESCRIPTION
When a IntConstOpnd fits in the opnd field, but the instruction doesnt
accept an int constant as its operand, then the immediate should be
hoisted into a register and then used in the instruction. Fix the conditions so
that this case is handled correctly.
