### PR TITLE
fix segment IsInPreReservedHeapPageAllocator regression

### DIFF
--- a/lib/Common/Memory/CustomHeap.h
+++ b/lib/Common/Memory/CustomHeap.h
@@ -152,7 +152,7 @@ public:
     {
         // Simple immutable data access, no need for lock
         Assert(segment);
-        return (((Segment*)(segment))->IsInPreReservedHeapPageAllocator());
+        return reinterpret_cast<SegmentBaseCommon*>(segment)->IsInPreReservedHeapPageAllocator();
     }
 
     bool IsInNonPreReservedPageAllocator(__in void *address)


### PR DESCRIPTION
My recent change breaks segment->IsInPreReservedHeapPageAllocator check
(when CFG is enabled). Refactor related SegmentBase/PageAllocatorBase
to move relevant data to super classes so that we can perform the check on
super class similar to before.
