### PR TITLE
fix oop jit issue with LdThis loading wrong global object

### DIFF
--- a/lib/Backend/NativeCodeGenerator.cpp
+++ b/lib/Backend/NativeCodeGenerator.cpp
@@ -908,6 +908,7 @@ NativeCodeGenerator::CodeGen(PageAllocator * pageAllocator, CodeGenWorkItem* wor
 
         JITTimeWorkItem * jitWorkItem = Anew(&jitArena, JITTimeWorkItem, workItem->GetJITData());
 
+        workItem->GetJITData()->globalThisAddr = (intptr_t)scriptContext->GetLibrary()->GetGlobalObject()->ToThis();
 #if !FLOATVAR
         CodeGenNumberAllocator* pNumberAllocator = nullptr;
 

--- a/lib/Backend/ServerScriptContext.cpp
+++ b/lib/Backend/ServerScriptContext.cpp
@@ -11,6 +11,7 @@ ServerScriptContext::ServerScriptContext(ScriptContextDataIDL * contextData, Ser
     m_isPRNGSeeded(false),
     m_domFastPathHelperMap(nullptr),
     m_moduleRecords(&HeapAllocator::Instance),
+    m_globalThisAddr(0),
 #ifdef PROFILE_EXEC
     m_codeGenProfiler(nullptr),
 #endif
@@ -183,7 +184,15 @@ ServerScriptContext::GetGlobalObjectAddr() const
 intptr_t
 ServerScriptContext::GetGlobalObjectThisAddr() const
 {
-    return m_contextData.globalObjectThisAddr;
+    return m_globalThisAddr;
+}
+
+void
+ServerScriptContext::UpdateGlobalObjectThisAddr(intptr_t globalThis)
+{
+    // this should stay constant once context initialization is complete
+    Assert(!m_globalThisAddr || m_globalThisAddr == globalThis);
+    m_globalThisAddr = globalThis;
 }
 
 intptr_t

--- a/lib/Backend/ServerScriptContext.h
+++ b/lib/Backend/ServerScriptContext.h
@@ -60,6 +60,7 @@ public:
 
     void SetIsPRNGSeeded(bool value);
     void AddModuleRecordInfo(unsigned int moduleId, __int64 localExportSlotsAddr);
+    void UpdateGlobalObjectThisAddr(intptr_t globalThis);
 
     Js::ScriptContextProfiler *  GetCodeGenProfiler() const;
     ServerThreadContext* GetThreadContext() { return threadContextInfo; }
@@ -75,6 +76,7 @@ private:
 #endif
 
     ScriptContextDataIDL m_contextData;
+    intptr_t m_globalThisAddr;
 
     ServerThreadContext* threadContextInfo;
     uint m_refCount;

--- a/lib/JITIDL/JITTypes.h
+++ b/lib/JITIDL/JITTypes.h
@@ -321,7 +321,6 @@ typedef struct ScriptContextDataIDL
     CHAKRA_PTR charStringCacheAddr;
     CHAKRA_PTR libraryAddr;
     CHAKRA_PTR globalObjectAddr;
-    CHAKRA_PTR globalObjectThisAddr;
     CHAKRA_PTR sideEffectsAddr;
     CHAKRA_PTR arraySetElementFastPathVtableAddr;
     CHAKRA_PTR intArraySetElementFastPathVtableAddr;
@@ -664,7 +663,9 @@ typedef struct CodeGenWorkItemIDL
     FunctionJITTimeDataIDL * jitData;
     CHAKRA_PTR jittedLoopIterationsSinceLastBailoutAddr;
     CHAKRA_PTR functionBodyAddr;
+    CHAKRA_PTR globalThisAddr;
     CHAKRA_PTR nativeDataAddr;
+    X86_PAD4(0)
     __int64 startTime;
 } CodeGenWorkItemIDL;
 

--- a/lib/JITServer/JITServer.cpp
+++ b/lib/JITServer/JITServer.cpp
@@ -528,6 +528,7 @@ ServerRemoteCodeGen(
 
     return ServerCallWrapper(scriptContextInfo, [&]() ->HRESULT
     {
+        scriptContextInfo->UpdateGlobalObjectThisAddr(workItemData->globalThisAddr);
         ServerThreadContext * threadContextInfo = scriptContextInfo->GetThreadContext();
 
         NoRecoverMemoryJitArenaAllocator jitArena(L"JITArena", threadContextInfo->GetPageAllocator(), Js::Throw::OutOfMemory);

--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -4469,7 +4469,6 @@ void ScriptContext::RegisterPrototypeChainEnsuredToHaveOnlyWritableDataPropertie
         contextData.charStringCacheAddr = (intptr_t)&GetLibrary()->GetCharStringCache();
         contextData.libraryAddr = (intptr_t)GetLibrary();
         contextData.globalObjectAddr = (intptr_t)GetLibrary()->GetGlobalObject();
-        contextData.globalObjectThisAddr = (intptr_t)GetLibrary()->GetGlobalObject()->ToThis();
         contextData.builtinFunctionsBaseAddr = (intptr_t)GetLibrary()->GetBuiltinFunctions();
         contextData.sideEffectsAddr = optimizationOverrides.GetAddressOfSideEffects();
         contextData.arraySetElementFastPathVtableAddr = (intptr_t)optimizationOverrides.GetAddressOfArraySetElementFastPathVtable();


### PR DESCRIPTION
Host might set global object after we have already initialized the script context on JIT side, so instead pass global this address at JIT time