### PR TITLE
fix build break in JITTypes.h from merge

### DIFF
--- a/lib/JITIDL/JITTypes.h
+++ b/lib/JITIDL/JITTypes.h
@@ -663,7 +663,7 @@ typedef struct CodeGenWorkItemIDL
     CHAKRA_PTR functionBodyAddr;
     CHAKRA_PTR globalThisAddr;
     CHAKRA_PTR nativeDataAddr;
-    X86_PAD4(0)
+    X86_PAD4(2)
     __int64 startTime;
 } CodeGenWorkItemIDL;
 


### PR DESCRIPTION
After merging, build broke from having multiple changes which added explicit padding to same struct in JITTypes.h