### PR TITLE
Remove constexpr from GetOffsetOfpszValue() and GetOffsetOfcharLength()

### DIFF
--- a/lib/Backend/JITRecyclableObject.h
+++ b/lib/Backend/JITRecyclableObject.h
@@ -55,10 +55,8 @@ public:
 
     static JITJavascriptString * FromVar(Js::Var var)
     {
-#ifdef HAS_CONSTEXPR
-        CompileAssert(offsetof(JITJavascriptString, m_pszValue) == Js::JavascriptString::GetOffsetOfpszValue());
-        CompileAssert(offsetof(JITJavascriptString, m_charLength) == Js::JavascriptString::GetOffsetOfcharLength());
-#endif
+        Assert(offsetof(JITJavascriptString, m_pszValue) == Js::JavascriptString::GetOffsetOfpszValue());
+        Assert(offsetof(JITJavascriptString, m_charLength) == Js::JavascriptString::GetOffsetOfcharLength());
         Assert(Is(var));
 
         return reinterpret_cast<JITJavascriptString*>(var);

--- a/lib/Runtime/Library/JavascriptString.h
+++ b/lib/Runtime/Library/JavascriptString.h
@@ -218,12 +218,12 @@ namespace Js
         static JavascriptString* Concat_BothOneChar(JavascriptString * pstLeft, JavascriptString * pstRight);
 
     public:
-        static OPT_CONSTEXPR uint32 GetOffsetOfpszValue()
+        static uint32 GetOffsetOfpszValue()
         {
             return offsetof(JavascriptString, m_pszValue);
         }
 
-        static OPT_CONSTEXPR uint32 GetOffsetOfcharLength()
+        static uint32 GetOffsetOfcharLength()
         {
             return offsetof(JavascriptString, m_charLength);
         }


### PR DESCRIPTION
The Microsoft C++ compiler defines offsetof() as a macro that uses
reinterpret_cast to calculate the offset of a member. reinterpret_cast
cannot be used in constant expressions. MSVC has been lax in this regard
in the past, but using offsetof() in a constexpr function definition is
illegal with the current implementation of offsetof().

This change adheres to the letter of the law by making GetOffsetOfpszValue()
and GetOffsetOfcharLength() not constexpr and converting the static asserts
that utilize these methods into runtime asserts. In the future, if the
implementation of offsetof() changes in MSVC, these can be converted back
into static_assert.