### PR TITLE
Array.includes should not call hasitem

### DIFF
--- a/lib/Runtime/Library/JavascriptArray.h
+++ b/lib/Runtime/Library/JavascriptArray.h
@@ -468,9 +468,9 @@ namespace Js
         template <typename T>
         static Var LastIndexOfHelper(T* pArr, Var search, int64 fromIndex, ScriptContext * scriptContext);
         template <typename T>
-        static BOOL TemplatedGetItem(T *pArr, uint32 index, Var * element, ScriptContext * scriptContext);
+        static BOOL TemplatedGetItem(T *pArr, uint32 index, Var * element, ScriptContext * scriptContext, bool checkHasItem = true);
         template <typename T>
-        static BOOL TemplatedGetItem(T *pArr, uint64 index, Var * element, ScriptContext * scriptContext);
+        static BOOL TemplatedGetItem(T *pArr, uint64 index, Var * element, ScriptContext * scriptContext, bool checkHasItem = true);
         template <typename T = uint32>
         static Var ReverseHelper(JavascriptArray* pArr, Js::TypedArrayBase* typedArrayBase, RecyclableObject* obj, T length, ScriptContext* scriptContext);
         template <typename T = uint32>
@@ -582,9 +582,9 @@ namespace Js
         template <typename T> static bool MayChangeType() { return false; }
 
         template<typename T, typename P>
-        static BOOL TryTemplatedGetItem(T *arr, P index, Var *element, ScriptContext *scriptContext)
+        static BOOL TryTemplatedGetItem(T *arr, P index, Var *element, ScriptContext *scriptContext, bool checkHasItem = true)
         {
-            return T::Is(arr) ? JavascriptArray::TemplatedGetItem(arr, index, element, scriptContext) :
+            return T::Is(arr) ? JavascriptArray::TemplatedGetItem(arr, index, element, scriptContext, checkHasItem) :
                 JavascriptOperators::GetItem(arr, index, element, scriptContext);
         }
 

--- a/test/Array/array_includes.js
+++ b/test/Array/array_includes.js
@@ -144,6 +144,25 @@ var tests = [
             assert.isTrue(y.includes(undefined), "includes(undefined):includes return true for search hit");
         }
     },
+    {
+        name: "Array.prototype.includes with proxy to validate that has is not called",
+        body: function () {
+
+            var calls = 0;
+            var p = new Proxy({}, {
+                get : function(_, k) {
+                    if (k == 'length') {
+                        return 4;
+                    }
+                    calls++
+                    return k*2;
+                }
+            });
+
+            var a = [].includes.call(p, 100);
+            assert.areEqual(calls, 4, "Even though 'has' is not there get will be called 4 times");
+        }
+    },
 ];
 
 testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });


### PR DESCRIPTION
As per the spec, when looping for finding the value, the includes should not perform the
hasproperty call. Fixed that by passing param to Template* functions.
