### PR TITLE
reduce property record storage on JIT server

### DIFF
--- a/lib/Backend/BackwardPass.cpp
+++ b/lib/Backend/BackwardPass.cpp
@@ -4344,7 +4344,7 @@ BackwardPass::TrackObjTypeSpecProperties(IR::PropertySymOpnd *opnd, BasicBlock *
             //Assert(!existingFldInfo->IsPoly() || !opnd->IsPoly() || GlobOpt::AreTypeSetsIdentical(existingFldInfo->GetEquivalentTypeSet(), opnd->GetEquivalentTypeSet()));
             //Assert(existingFldInfo->GetSlotIndex() == opnd->GetSlotIndex());
 
-            if (PHASE_TRACE(Js::EquivObjTypeSpecPhase, this->func))
+            if (PHASE_TRACE(Js::EquivObjTypeSpecPhase, this->func) && !JITManager::GetJITManager()->IsJITServer())
             {
                 if (existingFldInfo->IsPoly() && opnd->IsPoly() &&
                     (!GlobOpt::AreTypeSetsIdentical(existingFldInfo->GetEquivalentTypeSet(), opnd->GetEquivalentTypeSet()) ||
@@ -4354,7 +4354,7 @@ BackwardPass::TrackObjTypeSpecProperties(IR::PropertySymOpnd *opnd, BasicBlock *
 
                     Output::Print(_u("EquivObjTypeSpec: top function %s (%s): duplicate property clash on %s(#%d) on operation %u \n"),
                         this->func->GetJITFunctionBody()->GetDisplayName(), this->func->GetDebugNumberSet(debugStringBuffer),
-                        this->func->GetThreadContextInfo()->GetPropertyRecord(opnd->GetPropertyId())->GetBuffer(), opnd->GetPropertyId(), opnd->GetObjTypeSpecFldId());
+                        this->func->GetInProcThreadContext()->GetPropertyRecord(opnd->GetPropertyId())->GetBuffer(), opnd->GetPropertyId(), opnd->GetObjTypeSpecFldId());
                     Output::Flush();
                 }
             }

--- a/lib/Backend/Func.h
+++ b/lib/Backend/Func.h
@@ -217,10 +217,7 @@ public:
 
     ThreadContext * GetInProcThreadContext() const
     {
-        if (JITManager::GetJITManager()->IsOOPJITEnabled())
-        {
-            return nullptr;
-        }
+        Assert(!IsOOPJIT());
         return (ThreadContext*)m_threadContextInfo;
     }
 

--- a/lib/Backend/Func.h
+++ b/lib/Backend/Func.h
@@ -215,6 +215,15 @@ public:
         return m_workItem;
     }
 
+    ThreadContext * GetInProcThreadContext() const
+    {
+        if (JITManager::GetJITManager()->IsOOPJITEnabled())
+        {
+            return nullptr;
+        }
+        return (ThreadContext*)m_threadContextInfo;
+    }
+
     ThreadContextInfo * GetThreadContextInfo() const
     {
         return m_threadContextInfo;

--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -21036,7 +21036,7 @@ GlobOpt::GenerateBailOutMarkTempObjectIfNeeded(IR::Instr * instr, IR::Opnd * opn
                     const Js::PropertyId propertyId = propertySymOpnd->m_sym->AsPropertySym()->m_propertyId;
 
                     // We don't need to track numeric properties init
-                    if (!this->func->GetThreadContextInfo()->GetPropertyRecord(propertyId)->IsNumeric())
+                    if (!this->func->GetThreadContextInfo()->IsNumericProperty(propertyId))
                     {
                         DebugOnly(bool found = false);
                         globOptData.stackLiteralInitFldDataMap->RemoveIf(stackSym,

--- a/lib/Backend/IR.cpp
+++ b/lib/Backend/IR.cpp
@@ -123,8 +123,8 @@ Instr::TryOptimizeInstrWithFixedDataProperty(IR::Instr **pInstr, GlobOpt * globo
             IR::Instr* loadInstr = IR::Instr::NewConstantLoad(dataValueDstOpnd, (intptr_t)fixedValue, valType, instr->m_func);
 
             OUTPUT_VERBOSE_TRACE(Js::UseFixedDataPropsPhase,
-                _u("FixedFields: Replacing the source (fixed Data prop) with property id %s with 0x%x .\n"),
-                propSymOpnd->GetPropertySym()->GetName(), fixedValue);
+                _u("FixedFields: Replacing the source (fixed Data prop) with property id %u with 0x%x .\n"),
+                propSymOpnd->GetPropertyId(), fixedValue);
 
             instr->InsertAfter(loadInstr);
             propSymOpnd->SetUsesFixedValue(true);
@@ -3882,11 +3882,13 @@ Instr::DumpTestTrace()
         switch (propertySym->m_fieldKind)
         {
         case PropertyKindData:
+            if (!JITManager::GetJITManager()->IsOOPJITEnabled())
             {
-                Js::PropertyRecord const* fieldName = propertySym->GetFunc()->GetThreadContextInfo()->GetPropertyRecord(propertySym->m_propertyId);
+                Js::PropertyRecord const* fieldName = propertySym->GetFunc()->GetInProcThreadContext()->GetPropertyRecord(propertySym->m_propertyId);
                 Output::Print(_u("field: %s "), fieldName->GetBuffer());
                 break;
             }
+            // else fall through
         case PropertyKindSlots:
             Output::Print(_u("field: [%d] "), propertySym->m_propertyId);
             break;

--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -5866,10 +5866,9 @@ Lowerer::GenerateLdFldWithCachedType(IR::Instr * instrLdFld, bool* continueAsHel
     PHASE_PRINT_TESTTRACE(
         Js::ObjTypeSpecPhase,
         this->m_func,
-        _u("Field load: %s, property: %s, func: %s, cache ID: %d, cloned cache: true, layout: %s, redundant check: %s\n"),
+        _u("Field load: %s, property ID: %d, func: %s, cache ID: %d, cloned cache: true, layout: %s, redundant check: %s\n"),
         Js::OpCodeUtil::GetOpCodeName(instrLdFld->m_opcode),
-        this->m_func->GetThreadContextInfo()->GetPropertyRecord(
-            propertySymOpnd->m_sym->AsPropertySym()->m_propertyId)->GetBuffer(),
+        propertySymOpnd->m_sym->AsPropertySym()->m_propertyId,
         this->m_func->GetJITFunctionBody()->GetDisplayName(),
         propertySymOpnd->m_inlineCacheIndex,
         propertySymOpnd->GetCacheLayoutString(),
@@ -6074,9 +6073,9 @@ Lowerer::GenerateCheckFixedFld(IR::Instr * instrChkFld)
     OUTPUT_TRACE_FUNC(
         Js::ObjTypeSpecPhase,
         this->m_func,
-        _u("Fixed field check: %s, property: %s, cache ID: %u, cloned cache: true, layout: %s, redundant check: %s count of props: %u \n"),
+        _u("Fixed field check: %s, property ID: %d, cache ID: %u, cloned cache: true, layout: %s, redundant check: %s count of props: %u \n"),
         Js::OpCodeUtil::GetOpCodeName(instrChkFld->m_opcode),
-        this->m_func->GetThreadContextInfo()->GetPropertyRecord(propertySym->m_propertyId)->GetBuffer(),
+        propertySym->m_propertyId,
         inlineCacheIndex, propertySymOpnd->GetCacheLayoutString(), propertySymOpnd->IsTypeChecked() ? _u("true") : _u("false"),
         propertySymOpnd->GetGuardedPropOps() ? propertySymOpnd->GetGuardedPropOps()->Count() : 0);
 
@@ -6174,9 +6173,9 @@ Lowerer::GenerateCheckObjType(IR::Instr * instrChkObjType)
     PHASE_PRINT_TESTTRACE(
         Js::ObjTypeSpecPhase,
         this->m_func,
-        _u("Object type check: %s, property: %s, func: %s, cache ID: %d, cloned cache: true, layout: %s, redundant check: %s\n"),
+        _u("Object type check: %s, property ID: %d, func: %s, cache ID: %d, cloned cache: true, layout: %s, redundant check: %s\n"),
         Js::OpCodeUtil::GetOpCodeName(instrChkObjType->m_opcode),
-        this->m_func->GetThreadContextInfo()->GetPropertyRecord(propertySym->m_propertyId)->GetBuffer(),
+        propertySym->m_propertyId,
         this->m_func->GetJITFunctionBody()->GetDisplayName(),
         inlineCacheIndex, propertySymOpnd->GetCacheLayoutString(), _u("false"));
 
@@ -6967,9 +6966,9 @@ Lowerer::GenerateStFldWithCachedType(IR::Instr *instrStFld, bool* continueAsHelp
     PHASE_PRINT_TESTTRACE(
         Js::ObjTypeSpecPhase,
         this->m_func,
-        _u("Field store: %s, property: %s, func: %s, cache ID: %d, cloned cache: true, layout: %s, redundant check: %s\n"),
+        _u("Field store: %s, property ID: %d, func: %s, cache ID: %d, cloned cache: true, layout: %s, redundant check: %s\n"),
         Js::OpCodeUtil::GetOpCodeName(instrStFld->m_opcode),
-        this->m_func->GetThreadContextInfo()->GetPropertyRecord(propertySymOpnd->m_sym->AsPropertySym()->m_propertyId)->GetBuffer(),
+        propertySymOpnd->m_sym->AsPropertySym()->m_propertyId,
         this->m_func->GetJITFunctionBody()->GetDisplayName(),
         propertySymOpnd->m_inlineCacheIndex, propertySymOpnd->GetCacheLayoutString(),
         propertySymOpnd->IsTypeChecked() ? _u("true") : _u("false"));
@@ -7267,9 +7266,9 @@ Lowerer::PinTypeRef(JITTypeHolder type, void* typeRef, IR::Instr* instr, Js::Pro
     if (PHASE_TRACE(Js::TracePinnedTypesPhase, this->m_func))
     {
         char16 debugStringBuffer[MAX_FUNCTION_BODY_DEBUG_STRING_SIZE];
-        Output::Print(_u("PinnedTypes: function %s(%s) instr %s property %s(#%u) pinned %s reference 0x%p to type 0x%p.\n"),
+        Output::Print(_u("PinnedTypes: function %s(%s) instr %s property ID %u pinned %s reference 0x%p to type 0x%p.\n"),
             this->m_func->GetJITFunctionBody()->GetDisplayName(), this->m_func->GetDebugNumberSet(debugStringBuffer),
-            Js::OpCodeUtil::GetOpCodeName(instr->m_opcode), m_func->GetThreadContextInfo()->GetPropertyRecord(propertyId)->GetBuffer(), propertyId,
+            Js::OpCodeUtil::GetOpCodeName(instr->m_opcode), propertyId,
             typeRef == type.t ? _u("strong") : _u("weak"), typeRef, type.t);
         Output::Flush();
     }
@@ -7380,9 +7379,9 @@ Lowerer::CreateTypePropertyGuardForGuardedProperties(JITTypeHolder type, IR::Pro
                 if (PHASE_TRACE(Js::ObjTypeSpecPhase, this->m_func) || PHASE_TRACE(Js::TracePropertyGuardsPhase, this->m_func))
                 {
                     char16 debugStringBuffer[MAX_FUNCTION_BODY_DEBUG_STRING_SIZE];
-                    Output::Print(_u("ObjTypeSpec: function %s(%s) registered guard 0x%p with value 0x%p for property %s (%u).\n"),
+                    Output::Print(_u("ObjTypeSpec: function %s(%s) registered guard 0x%p with value 0x%p for property ID %u.\n"),
                         m_func->GetJITFunctionBody()->GetDisplayName(), this->m_func->GetDebugNumberSet(debugStringBuffer),
-                        guard, guard->GetValue(), m_func->GetThreadContextInfo()->GetPropertyRecord(propertyId)->GetBuffer(), propertyId);
+                        guard, guard->GetValue(), propertyId);
                     Output::Flush();
                 }
 
@@ -7410,9 +7409,9 @@ Lowerer::CreateEquivalentTypeGuardAndLinkToGuardedProperties(JITTypeHolder type,
             if (PHASE_TRACE(Js::ObjTypeSpecPhase, this->m_func) || PHASE_TRACE(Js::TracePropertyGuardsPhase, this->m_func))
             {
                 char16 debugStringBuffer[MAX_FUNCTION_BODY_DEBUG_STRING_SIZE];
-                Output::Print(_u("ObjTypeSpec: function %s(%s) registered equivalent type spec guard 0x%p with value 0x%p for property %s (%u).\n"),
+                Output::Print(_u("ObjTypeSpec: function %s(%s) registered equivalent type spec guard 0x%p with value 0x%p for property ID %u.\n"),
                     this->m_func->GetJITFunctionBody()->GetDisplayName(), this->m_func->GetDebugNumberSet(debugStringBuffer),
-                    guard, guard->GetValue(), m_func->GetThreadContextInfo()->GetPropertyRecord(propertyId)->GetBuffer(), propertyId);
+                    guard, guard->GetValue(), propertyId);
                 Output::Flush();
             }
 
@@ -7489,8 +7488,8 @@ Lowerer::CreateEquivalentTypeGuardAndLinkToGuardedProperties(JITTypeHolder type,
                 if (PHASE_TRACE(Js::EquivObjTypeSpecPhase, this->m_func))
                 {
                     char16 debugStringBuffer[MAX_FUNCTION_BODY_DEBUG_STRING_SIZE];
-                    Output::Print(_u("EquivObjTypeSpec: top function %s (%s): duplicate property clash on %s(#%d) \n"),
-                        m_func->GetJITFunctionBody()->GetDisplayName(), m_func->GetDebugNumberSet(debugStringBuffer), propertyId, m_func->GetThreadContextInfo()->GetPropertyRecord(propertyId)->GetBuffer());
+                    Output::Print(_u("EquivObjTypeSpec: top function %s (%s): duplicate property clash on %d \n"),
+                        m_func->GetJITFunctionBody()->GetDisplayName(), m_func->GetDebugNumberSet(debugStringBuffer), propertyId);
                     Output::Flush();
                 }
                 Assert(propIdCount < propOpCount);
@@ -7544,9 +7543,9 @@ Lowerer::LinkCtorCacheToGuardedProperties(JITTimeConstructorCache* ctorCache)
             if (PHASE_TRACE(Js::ObjTypeSpecPhase, this->m_func) || PHASE_TRACE(Js::TracePropertyGuardsPhase, this->m_func))
             {
                 char16 debugStringBuffer[MAX_FUNCTION_BODY_DEBUG_STRING_SIZE];
-                Output::Print(_u("ObjTypeSpec: function %s(%s) registered ctor cache 0x%p with value 0x%p for property %s (%u).\n"),
+                Output::Print(_u("ObjTypeSpec: function %s(%s) registered ctor cache 0x%p with value 0x%p for property %u.\n"),
                     this->m_func->GetJITFunctionBody()->GetDisplayName(), this->m_func->GetDebugNumberSet(debugStringBuffer),
-                    ctorCache->GetRuntimeCacheAddr(), ctorCache->GetType()->GetAddr(), m_func->GetThreadContextInfo()->GetPropertyRecord(propertyId)->GetBuffer(), propertyId);
+                    ctorCache->GetRuntimeCacheAddr(), ctorCache->GetType()->GetAddr(), propertyId);
                 Output::Flush();
             }
 
@@ -18991,9 +18990,9 @@ Lowerer::GenerateFastLdFld(IR::Instr * const instrLdFld, IR::JnHelperMethod help
     PHASE_PRINT_TESTTRACE(
         Js::ObjTypeSpecPhase,
         this->m_func,
-        _u("Field load: %s, property: %s, func: %s, cache ID: %d, cloned cache: false\n"),
+        _u("Field load: %s, property ID: %d, func: %s, cache ID: %d, cloned cache: false\n"),
         Js::OpCodeUtil::GetOpCodeName(instrLdFld->m_opcode),
-        this->m_func->GetThreadContextInfo()->GetPropertyRecord(propertySym->m_propertyId)->GetBuffer(),
+        propertySym->m_propertyId,
         this->m_func->GetJITFunctionBody()->GetDisplayName(),
         propertySymOpnd->m_inlineCacheIndex);
 
@@ -19247,9 +19246,9 @@ Lowerer::GenerateFastStFld(IR::Instr * const instrStFld, IR::JnHelperMethod help
     PHASE_PRINT_TESTTRACE(
         Js::ObjTypeSpecPhase,
         this->m_func,
-        _u("Field store: %s, property: %s, func: %s, cache ID: %d, cloned cache: false\n"),
+        _u("Field store: %s, property ID: %u, func: %s, cache ID: %d, cloned cache: false\n"),
         Js::OpCodeUtil::GetOpCodeName(instrStFld->m_opcode),
-        this->m_func->GetThreadContextInfo()->GetPropertyRecord(propertySym->m_propertyId)->GetBuffer(),
+        propertySym->m_propertyId,
         this->m_func->GetJITFunctionBody()->GetDisplayName(),
         propertySymOpnd->m_inlineCacheIndex);
 
@@ -19293,9 +19292,9 @@ Lowerer::GenerateFastStFld(IR::Instr * const instrStFld, IR::JnHelperMethod help
                 char16 debugStringBuffer[MAX_FUNCTION_BODY_DEBUG_STRING_SIZE];
                 #endif
                 PHASE_PRINT_TRACE(Js::AddFldFastPathPhase, this->m_func,
-                    _u("AddFldFastPath: function: %s(%s) property: %s(#%d) no fast path, because the phase is off.\n"),
+                    _u("AddFldFastPath: function: %s(%s) property ID: %u no fast path, because the phase is off.\n"),
                     this->m_func->GetJITFunctionBody()->GetDisplayName(), this->m_func->GetDebugNumberSet(debugStringBuffer),
-                    this->m_func->GetThreadContextInfo()->GetPropertyRecord(propertySym->m_propertyId)->GetBuffer(), propertySym->m_propertyId);
+                    propertySym->m_propertyId);
             }
 
             if ((profiledInstrStFld->u.FldInfo().flags & (Js::FldInfo_FromInlineSlots | Js::FldInfo_FromAuxSlots)) == Js::FldInfo_FromInlineSlots)
@@ -19334,9 +19333,9 @@ Lowerer::GenerateFastStFld(IR::Instr * const instrStFld, IR::JnHelperMethod help
         char16 debugStringBuffer[MAX_FUNCTION_BODY_DEBUG_STRING_SIZE];
 #endif
         PHASE_PRINT_TRACE(Js::AddFldFastPathPhase, this->m_func,
-            _u("AddFldFastPath: function: %s(%s) property: %s(#%d) %s fast path for %s.\n"),
+            _u("AddFldFastPath: function: %s(%s) property ID: %d %s fast path for %s.\n"),
             this->m_func->GetJITFunctionBody()->GetDisplayName(), this->m_func->GetDebugNumberSet(debugStringBuffer),
-            this->m_func->GetThreadContextInfo()->GetPropertyRecord(propertySym->m_propertyId)->GetBuffer(), propertySym->m_propertyId,
+            propertySym->m_propertyId,
             usePolymorphicInlineCache ? _u("poly") : _u("mono"), doStore ? _u("store and add") : _u("add only"));
     }
 

--- a/lib/Backend/NativeCodeGenerator.cpp
+++ b/lib/Backend/NativeCodeGenerator.cpp
@@ -2007,20 +2007,17 @@ NativeCodeGenerator::UpdateJITState()
         }
 
         // update all property records on server that have been changed since last jit
-        ThreadContext::PropertyMap * pendingProps = scriptContext->GetThreadContext()->GetPendingJITProperties();
-        PropertyRecordIDL ** newPropArray = nullptr;
+        ThreadContext::PropertyList * pendingProps = scriptContext->GetThreadContext()->GetPendingJITProperties();
+        int * newPropArray = nullptr;
         uint newCount = 0;
         if (pendingProps->Count() > 0)
         {
             newCount = (uint)pendingProps->Count();
-            newPropArray = HeapNewArray(PropertyRecordIDL*, newCount);
+            newPropArray = HeapNewArray(int, newCount);
             uint index = 0;
-            auto iter = pendingProps->GetIteratorWithRemovalSupport();
-            while (iter.IsValid())
+            while (!pendingProps->Empty())
             {
-                newPropArray[index++] = (PropertyRecordIDL*)iter.CurrentValue();
-                iter.RemoveCurrent();
-                iter.MoveNext();
+                newPropArray[index++] = (int)pendingProps->Pop();
             }
             Assert(index == newCount);
         }
@@ -2045,8 +2042,8 @@ NativeCodeGenerator::UpdateJITState()
             UpdatedPropertysIDL props = {0};
             props.reclaimedPropertyCount = reclaimedCount;
             props.reclaimedPropertyIdArray = reclaimedPropArray;
-            props.newRecordCount = newCount;
-            props.newRecordArray = newPropArray;
+            props.newPropertyCount = newCount;
+            props.newPropertyIdArray = newPropArray;
 
             HRESULT hr = JITManager::GetJITManager()->UpdatePropertyRecordMap(scriptContext->GetThreadContext()->GetRemoteThreadContextAddr(), &props);
 

--- a/lib/Backend/Opnd.cpp
+++ b/lib/Backend/Opnd.cpp
@@ -2808,7 +2808,12 @@ Opnd::Dump(IRDumpFlags flags, Func *func)
                             Output::Print(_u(","));
                         }
                         const JITObjTypeSpecFldInfo* propertyOpInfo = func->GetTopFunc()->GetGlobalObjTypeSpecFldInfo(propertyOpId);
-                        Output::Print(_u("%s(%u)"), func->GetThreadContextInfo()->GetPropertyRecord(propertyOpInfo->GetPropertyId())->GetBuffer(), propertyOpId);
+                        if (!JITManager::GetJITManager()->IsOOPJITEnabled())
+                        {
+                            Output::Print(_u("%s"), func->GetInProcThreadContext()->GetPropertyRecord(propertyOpInfo->GetPropertyId())->GetBuffer(), propertyOpId);
+                        }
+                        Output::Print(_u("(%u)"), propertyOpId);
+                        
                         if (propertyOpInfo->IsLoadedFromProto())
                         {
                             Output::Print(_u("~"));

--- a/lib/Backend/ServerThreadContext.h
+++ b/lib/Backend/ServerThreadContext.h
@@ -27,18 +27,19 @@ public:
     virtual intptr_t GetImplicitCallFlagsAddr() const override;
     virtual intptr_t GetBailOutRegisterSaveSpaceAddr() const override;
 
+    virtual PreReservedVirtualAllocWrapper * GetPreReservedVirtualAllocator() override;
+
+    virtual bool IsNumericProperty(Js::PropertyId propId) override;
+
     ptrdiff_t GetChakraBaseAddressDifference() const;
     ptrdiff_t GetCRTBaseAddressDifference() const;
-
-    virtual Js::PropertyRecord const * GetPropertyRecord(Js::PropertyId propertyId) override;
-    virtual PreReservedVirtualAllocWrapper * GetPreReservedVirtualAllocator() override;
 
     CodeGenAllocators * GetCodeGenAllocators();
     AllocationPolicyManager * GetAllocationPolicyManager();
     CustomHeap::CodePageAllocators * GetCodePageAllocators();
     PageAllocator* GetPageAllocator();
-    void RemoveFromPropertyMap(Js::PropertyId reclaimedId);
-    void AddToPropertyMap(const Js::PropertyRecord * propertyRecord);
+    void RemoveFromNumericPropertySet(Js::PropertyId reclaimedId);
+    void AddToNumericPropertySet(Js::PropertyId propertyId);
     void SetWellKnownHostTypeId(Js::TypeId typeId) { this->wellKnownHostTypeHTMLAllCollectionTypeId = typeId; }
 #if DYNAMIC_INTERPRETER_THUNK || defined(ASMJS_PLAT)
     CustomHeap::CodePageAllocators * GetThunkPageAllocators();
@@ -55,9 +56,9 @@ private:
     intptr_t GetRuntimeChakraBaseAddress() const;
     intptr_t GetRuntimeCRTBaseAddress() const;
 
-    typedef JsUtil::BaseHashSet<const Js::PropertyRecord *, HeapAllocator, PrimeSizePolicy, const Js::PropertyRecord *,
-        DefaultComparer, JsUtil::SimpleHashedEntry, JsUtil::AsymetricResizeLock> PropertyMap;
-    PropertyMap * m_propertyMap;
+    typedef JsUtil::BaseHashSet<Js::PropertyId, HeapAllocator, PrimeSizePolicy, Js::PropertyId,
+        DefaultComparer, JsUtil::SimpleHashedEntry, JsUtil::AsymetricResizeLock> PropertySet;
+    PropertySet * m_numericPropertySet;
 
     AllocationPolicyManager m_policyManager;
     JsUtil::BaseDictionary<DWORD, PageAllocator*, HeapAllocator> m_pageAllocs;

--- a/lib/Backend/Sym.cpp
+++ b/lib/Backend/Sym.cpp
@@ -1103,12 +1103,12 @@ Sym::Dump(IRDumpFlags flags, const ValueType valueType)
             propertySym->m_stackSym->Dump(flags, valueType);
             if (JITManager::GetJITManager()->IsOOPJITEnabled())
             {
-                Js::PropertyRecord const* fieldName = propertySym->m_func->GetInProcThreadContext()->GetPropertyRecord(propertySym->m_propertyId);
-                Output::Print(_u("->%s"), fieldName->GetBuffer());
+                Output::Print(_u("->#%d"), propertySym->m_propertyId);
             }
             else
             {
-                Output::Print(_u("->#%d"), propertySym->m_propertyId);
+                Js::PropertyRecord const* fieldName = propertySym->m_func->GetInProcThreadContext()->GetPropertyRecord(propertySym->m_propertyId);
+                Output::Print(_u("->%s"), fieldName->GetBuffer());
             }
             break;
         case PropertyKindSlots:

--- a/lib/Backend/Sym.cpp
+++ b/lib/Backend/Sym.cpp
@@ -45,10 +45,10 @@ StackSym::New(SymID id, IRType type, Js::RegSlot byteCodeRegSlot, Func *func)
     stackSym->m_isStrEmpty = false;
     stackSym->m_allocated = false;
     stackSym->m_isTypeSpec = false;
-	stackSym->m_isArgSlotSym = false;
-	stackSym->m_isArgSlotRegSym = false;
-	stackSym->m_isParamSym = false;
-	stackSym->m_isImplicitParamSym = false;
+    stackSym->m_isArgSlotSym = false;
+    stackSym->m_isArgSlotRegSym = false;
+    stackSym->m_isParamSym = false;
+    stackSym->m_isImplicitParamSym = false;
     stackSym->m_isBailOutReferenced = false;
     stackSym->m_isArgCaptured = false;
     stackSym->m_requiresBailOnNotNumber = false;
@@ -115,20 +115,20 @@ StackSym::New(IRType type, Func *func)
 StackSym *
 StackSym::NewImplicitParamSym(Js::ArgSlot paramSlotNum, Func * func)
 {
-	return func->m_symTable->GetImplicitParam(paramSlotNum);
+    return func->m_symTable->GetImplicitParam(paramSlotNum);
 }
 
 StackSym *
 StackSym::NewParamSlotSym(Js::ArgSlot paramSlotNum, Func * func)
 {
-	return NewParamSlotSym(paramSlotNum, func, TyVar);
+    return NewParamSlotSym(paramSlotNum, func, TyVar);
 }
 
 StackSym *
 StackSym::NewParamSlotSym(Js::ArgSlot paramSlotNum, Func * func, IRType type)
 {
     StackSym * stackSym = StackSym::New(type, func);
-	stackSym->m_isParamSym = true;
+    stackSym->m_isParamSym = true;
     stackSym->m_slotNum = paramSlotNum;
     return stackSym;
 }
@@ -460,10 +460,10 @@ StackSym::CloneDef(Func *func)
         newSym->m_isConst = m_isConst;
         newSym->m_isIntConst = m_isIntConst;
         newSym->m_isTaggableIntConst = m_isTaggableIntConst;
-		newSym->m_isArgSlotSym = m_isArgSlotSym;
-		newSym->m_isArgSlotRegSym = m_isArgSlotRegSym;
-		newSym->m_isParamSym = m_isParamSym;
-		newSym->m_isImplicitParamSym = m_isImplicitParamSym;
+        newSym->m_isArgSlotSym = m_isArgSlotSym;
+        newSym->m_isArgSlotRegSym = m_isArgSlotRegSym;
+        newSym->m_isParamSym = m_isParamSym;
+        newSym->m_isImplicitParamSym = m_isImplicitParamSym;
         newSym->m_isArgCaptured = m_isArgCaptured;
         newSym->m_isBailOutReferenced = m_isBailOutReferenced;
         newSym->m_slotNum = m_slotNum;
@@ -975,17 +975,6 @@ PropertySym::FindOrCreate(SymID stackSymID, int32 propertyId, uint32 propertyIdI
 
     return PropertySym::New(stackSymID, propertyId, propertyIdIndex, inlineCacheIndex, fieldKind, func);
 }
-#ifdef ENABLE_DEBUG_CONFIG_OPTIONS
-const char16* PropertySym::GetName() const
-{
-    if (this->m_fieldKind == PropertyKindData)
-    {
-        return m_func->GetThreadContextInfo()->GetPropertyRecord(this->m_propertyId)->GetBuffer();
-    }
-    Assert(false);
-    return _u("");
-}
-#endif
 #if DBG_DUMP || defined(ENABLE_IR_VIEWER)
 
 ///----------------------------------------------------------------------------
@@ -1069,7 +1058,7 @@ Sym::Dump(IRDumpFlags flags, const ValueType valueType)
                         {
                             uint index = stackSym->GetByteCodeRegSlot() - stackSym->GetByteCodeFunc()->GetJITFunctionBody()->GetConstCount();
                             Js::PropertyId propertyId = functionBody->GetPropertyIdOnRegSlotsContainer()->propertyIdsForRegSlots[index];
-                            Output::Print(_u("(%s)"), stackSym->GetByteCodeFunc()->GetThreadContextInfo()->GetPropertyRecord(propertyId)->GetBuffer());
+                            Output::Print(_u("(%s)"), stackSym->GetByteCodeFunc()->GetInProcThreadContext()->GetPropertyRecord(propertyId)->GetBuffer());
                         }
                     }
                 }
@@ -1111,12 +1100,17 @@ Sym::Dump(IRDumpFlags flags, const ValueType valueType)
         switch (propertySym->m_fieldKind)
         {
         case PropertyKindData:
-        {
             propertySym->m_stackSym->Dump(flags, valueType);
-            Js::PropertyRecord const* fieldName = propertySym->m_func->GetThreadContextInfo()->GetPropertyRecord(propertySym->m_propertyId);
-            Output::Print(_u("->%s"), fieldName->GetBuffer());
+            if (JITManager::GetJITManager()->IsOOPJITEnabled())
+            {
+                Js::PropertyRecord const* fieldName = propertySym->m_func->GetInProcThreadContext()->GetPropertyRecord(propertySym->m_propertyId);
+                Output::Print(_u("->%s"), fieldName->GetBuffer());
+            }
+            else
+            {
+                Output::Print(_u("->#%d"), propertySym->m_propertyId);
+            }
             break;
-        }
         case PropertyKindSlots:
         case PropertyKindSlotArray:
             propertySym->m_stackSym->Dump(flags, valueType);

--- a/lib/Backend/Sym.h
+++ b/lib/Backend/Sym.h
@@ -313,9 +313,6 @@ public:
     Func *          m_func;
     Func *          m_loadInlineCacheFunc;
     uint            m_loadInlineCacheIndex;
-#ifdef ENABLE_DEBUG_CONFIG_OPTIONS
-    const char16* GetName() const;
-#endif
 private:
     uint32          m_propertyIdIndex;
     uint            m_inlineCacheIndex;

--- a/lib/Backend/Sym.h
+++ b/lib/Backend/Sym.h
@@ -91,7 +91,7 @@ public:
     static StackSym * NewArgSlotRegSym(Js::ArgSlot argSlotNum, Func * func, IRType = TyVar);
     static StackSym * NewParamSlotSym(Js::ArgSlot argSlotNum, Func * func);
     static StackSym * NewParamSlotSym(Js::ArgSlot argSlotNum, Func * func, IRType type);
-	static StackSym *NewImplicitParamSym(Js::ArgSlot paramSlotNum, Func * func);
+    static StackSym *NewImplicitParamSym(Js::ArgSlot paramSlotNum, Func * func);
     static StackSym * New(SymID id, IRType type, Js::RegSlot byteCodeRegSlot, Func *func);
     static StackSym * New(IRType type, Func *func);
     static StackSym * New(Func *func);
@@ -99,8 +99,8 @@ public:
 
     IRType          GetType() const { return this->m_type; }
     bool            IsArgSlotSym() const;
-	bool            IsParamSlotSym() const;
-	bool            IsImplicitParamSym() const { return this->m_isImplicitParamSym; }
+    bool            IsParamSlotSym() const;
+    bool            IsImplicitParamSym() const { return this->m_isImplicitParamSym; }
     bool            IsAllocated() const;
     int32           GetIntConstValue() const;
     Js::Var         GetFloatConstValueAsVar_PostGlobOpt() const;
@@ -191,7 +191,7 @@ private:
     Js::ArgSlot     m_slotNum;
 public:
     uint8           m_isSingleDef:1;            // the symbol only has a single definition in the IR
-	uint8           m_isNotInt:1;
+    uint8           m_isNotInt:1;
     uint8           m_isSafeThis : 1;
     uint8           m_isConst : 1;              // single def and it is a constant
     uint8           m_isIntConst : 1;           // a constant and it's value is an Int32
@@ -210,10 +210,10 @@ public:
     uint8           m_isFromByteCodeConstantTable:1;
     uint8           m_mayNotBeTempLastUse:1;
     uint8           m_isArgSlotSym: 1;        // When set this implies an argument stack slot with no lifetime for register allocation
-	uint8           m_isArgSlotRegSym : 1;
-	uint8           m_isParamSym : 1;
-	uint8           m_isImplicitParamSym : 1;
-	uint8           m_isBailOutReferenced: 1;        // argument sym referenced by bailout
+    uint8           m_isArgSlotRegSym : 1;
+    uint8           m_isParamSym : 1;
+    uint8           m_isImplicitParamSym : 1;
+    uint8           m_isBailOutReferenced: 1;        // argument sym referenced by bailout
     uint8           m_isArgCaptured: 1;       // True if there is a ByteCodeArgOutCapture for this symbol
     uint8           m_nonEscapingArgObjAlias : 1;
     uint8           m_isCatchObjectSym : 1;   // a catch object sym (used while jitting loop bodies)

--- a/lib/Backend/TempTracker.cpp
+++ b/lib/Backend/TempTracker.cpp
@@ -263,9 +263,8 @@ TempTracker<T>::ProcessUse(StackSym * sym, BackwardPass * backwardPass)
 #if DBG_DUMP
         if (T::DoTrace(backwardPass) && this->tempTransferDependencies)
         {
-            Output::Print(_u("%s: %8s (PropId:%d %s)+[] -> s%d: "), T::GetTraceName(),
-                backwardPass->IsPrePass() ? _u("Prepass ") : _u(""), propertySym->m_propertyId,
-                backwardPass->func->GetThreadContextInfo()->GetPropertyRecord(propertySym->m_propertyId)->GetBuffer(), usedSymID);
+            Output::Print(_u("%s: %8s (PropId:%d)+[] -> s%d: "), T::GetTraceName(),
+                backwardPass->IsPrePass() ? _u("Prepass ") : _u(""), propertySym->m_propertyId, usedSymID);
             BVSparse<JitArenaAllocator> ** transferDependencies = this->tempTransferDependencies->Get(usedSymID);
             if (transferDependencies)
             {
@@ -712,7 +711,7 @@ NumberTemp::IsTempPropertyTransferStore(IR::Instr * instr, BackwardPass * backwa
                 PropertySym *propertySym = dst->AsSymOpnd()->m_sym->AsPropertySym();
                 SymID propertySymId = this->GetRepresentativePropertySymId(propertySym, backwardPass);
                 return !this->nonTempSyms.Test(propertySymId) &&
-                    !instr->m_func->GetThreadContextInfo()->GetPropertyRecord(propertySym->m_propertyId)->IsNumeric();
+                    !instr->m_func->GetThreadContextInfo()->IsNumericProperty(propertySym->m_propertyId);
             }
         };
 
@@ -914,9 +913,8 @@ NumberTemp::ProcessPropertySymUse(IR::SymOpnd * symOpnd, IR::Instr * instr, Back
 #if DBG_DUMP
         if (NumberTemp::DoTrace(backwardPass))
         {
-            Output::Print(_u("%s: %8s s%d -> PropId:%d %s: "), NumberTemp::GetTraceName(),
-                backwardPass->IsPrePass() ? _u("Prepass ") : _u(""), dstSymID, propertySym->m_propertyId,
-                backwardPass->func->GetThreadContextInfo()->GetPropertyRecord(propertySym->m_propertyId)->GetBuffer());
+            Output::Print(_u("%s: %8s s%d -> PropId:%d: "), NumberTemp::GetTraceName(),
+                backwardPass->IsPrePass() ? _u("Prepass ") : _u(""), dstSymID, propertySym->m_propertyId);
             (*this->propertyIdsTempTransferDependencies->Get(propertySym->m_propertyId))->Dump();
         }
 #endif
@@ -925,9 +923,8 @@ NumberTemp::ProcessPropertySymUse(IR::SymOpnd * symOpnd, IR::Instr * instr, Back
 #if DBG_DUMP
     if (NumberTemp::DoTrace(backwardPass))
     {
-        Output::Print(_u("%s: %8s%4sTemp Use (PropId:%d %s)"), NumberTemp::GetTraceName(),
-            backwardPass->IsPrePass() ? _u("Prepass ") : _u(""), isTempUse ? _u("") : _u("Non "), propertySym->m_propertyId,
-            backwardPass->func->GetThreadContextInfo()->GetPropertyRecord(propertySym->m_propertyId)->GetBuffer());
+        Output::Print(_u("%s: %8s%4sTemp Use (PropId:%d)"), NumberTemp::GetTraceName(),
+            backwardPass->IsPrePass() ? _u("Prepass ") : _u(""), isTempUse ? _u("") : _u("Non "), propertySym->m_propertyId);
         instr->DumpSimple();
     }
 #endif

--- a/lib/JITIDL/JITTypes.h
+++ b/lib/JITIDL/JITTypes.h
@@ -804,9 +804,9 @@ typedef struct JITOutputIDL
 typedef struct UpdatedPropertysIDL
 {
     unsigned int reclaimedPropertyCount;
-    unsigned int newRecordCount;
+    unsigned int newPropertyCount;
     [size_is(reclaimedPropertyCount)] int * reclaimedPropertyIdArray;
-    [size_is(newRecordCount)] PropertyRecordIDL ** newRecordArray;
+    [size_is(newPropertyCount)] int * newPropertyIdArray;
 } UpdatedPropertysIDL;
 
 typedef struct InterpreterThunkInfoIDL

--- a/lib/JITIDL/JITTypes.h
+++ b/lib/JITIDL/JITTypes.h
@@ -390,19 +390,6 @@ typedef struct AsmJsDataIDL
     IDL_DEF([size_is(argCount)]) byte * argTypeArray;
 } AsmJsDataIDL;
 
-typedef struct PropertyRecordIDL
-{
-    CHAKRA_PTR vTable;
-    int pid;
-    unsigned int hash;
-    boolean isNumeric;
-    boolean isBound;
-    boolean isSymbol;
-    IDL_PAD1(0)
-    unsigned int byteCount;
-    IDL_DEF([size_is(byteCount + sizeof(wchar_t) + (isNumeric ? sizeof(unsigned int) : 0))]) byte buffer[IDL_DEF(*)];
-} PropertyRecordIDL;
-
 typedef struct FunctionJITRuntimeIDL
 {
     unsigned int clonedCacheCount;

--- a/lib/JITServer/JITServer.cpp
+++ b/lib/JITServer/JITServer.cpp
@@ -190,12 +190,12 @@ ServerUpdatePropertyRecordMap(
     {
         for (uint i = 0; i < updatedProps->reclaimedPropertyCount; ++i)
         {
-            threadContextInfo->RemoveFromPropertyMap((Js::PropertyId)updatedProps->reclaimedPropertyIdArray[i]);
+            threadContextInfo->RemoveFromNumericPropertySet((Js::PropertyId)updatedProps->reclaimedPropertyIdArray[i]);
         }
 
-        for (uint i = 0; i < updatedProps->newRecordCount; ++i)
+        for (uint i = 0; i < updatedProps->newPropertyCount; ++i)
         {
-            threadContextInfo->AddToPropertyMap((Js::PropertyRecord *)updatedProps->newRecordArray[i]);
+            threadContextInfo->AddToNumericPropertySet((Js::PropertyId)updatedProps->newPropertyIdArray[i]);
         }
 
         return S_OK;

--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -881,6 +881,12 @@ ThreadContext::GetPropertyRecord(Js::PropertyId propertyId)
     return GetPropertyNameLocked(propertyId);
 }
 
+bool
+ThreadContext::IsNumericProperty(Js::PropertyId propertyId)
+{
+    return GetPropertyRecord(propertyId)->IsNumeric();
+}
+
 const Js::PropertyRecord *
 ThreadContext::FindPropertyRecord(const char16 * propertyName, int propertyNameLength)
 {
@@ -1106,8 +1112,11 @@ ThreadContext::AddPropertyRecordInternal(const Js::PropertyRecord * propertyReco
     if (m_pendingJITProperties)
     {
         Assert(m_reclaimedJITProperties);
-        m_pendingJITProperties->Add(propertyRecord);
-        m_reclaimedJITProperties->Remove(propertyRecord->GetPropertyId());
+        if (propertyRecord->IsNumeric())
+        {
+            m_pendingJITProperties->Prepend(propertyRecord->GetPropertyId());
+            m_reclaimedJITProperties->Remove(propertyRecord->GetPropertyId());
+        }
     }
 #endif
 
@@ -1264,7 +1273,7 @@ void ThreadContext::InvalidatePropertyRecord(const Js::PropertyRecord * property
 {
     InternalInvalidateProtoTypePropertyCaches(propertyRecord->GetPropertyId());     // use the internal version so we don't check for active property id
 #if ENABLE_NATIVE_CODEGEN
-    if (m_pendingJITProperties && !m_pendingJITProperties->Remove(propertyRecord))
+    if (propertyRecord->IsNumeric() && m_pendingJITProperties && !m_pendingJITProperties->Remove(propertyRecord->GetPropertyId()))
     {
         // if it wasn't pending, that means it was already sent to the jit, so add to list that jit needs to reclaim
         m_reclaimedJITProperties->PrependNoThrow(&HeapAllocator::Instance, propertyRecord->GetPropertyId());
@@ -1978,7 +1987,15 @@ ThreadContext::EnsureJITThreadContext(bool allowPrereserveAlloc)
 #endif
 
     m_reclaimedJITProperties = HeapNew(PropertyList, &HeapAllocator::Instance);
-    m_pendingJITProperties = propertyMap->Clone();
+    m_pendingJITProperties = HeapNew(PropertyList, &HeapAllocator::Instance);
+    
+    for (auto iter = propertyMap->GetIterator(); iter.IsValid(); iter.MoveNext())
+    {
+        if (iter.CurrentKey()->IsNumeric())
+        {
+            m_pendingJITProperties->Prepend(iter.CurrentKey()->GetPropertyId());
+        }
+    }
 
     HRESULT hr = JITManager::GetJITManager()->InitializeThreadContext(&contextData, &m_remoteThreadContextInfo, &m_prereservedRegionAddr);
     JITManager::HandleServerCallResult(hr);

--- a/lib/Runtime/Base/ThreadContext.h
+++ b/lib/Runtime/Base/ThreadContext.h
@@ -385,7 +385,9 @@ public:
     void SetHeapEnum(IActiveScriptProfilerHeapEnum* newHeapEnum);
     void ClearHeapEnum();
 
-    virtual Js::PropertyRecord const * GetPropertyRecord(Js::PropertyId propertyId) override;
+    Js::PropertyRecord const * GetPropertyRecord(Js::PropertyId propertyId);
+
+    virtual bool IsNumericProperty(Js::PropertyId propertyId) override;
 
 #ifdef ENABLE_BASIC_TELEMETRY
     Js::LanguageStats* GetLanguageStats()
@@ -482,7 +484,7 @@ private:
     intptr_t m_prereservedRegionAddr;
 
 #if ENABLE_NATIVE_CODEGEN
-    PropertyMap * m_pendingJITProperties;
+    PropertyList * m_pendingJITProperties;
     PropertyList  * m_reclaimedJITProperties;
 public:
 
@@ -491,7 +493,7 @@ public:
         return m_reclaimedJITProperties;
     }
 
-    PropertyMap * GetPendingJITProperties() const
+    PropertyList * GetPendingJITProperties() const
     {
         return m_pendingJITProperties;
     }

--- a/lib/Runtime/Base/ThreadContextInfo.h
+++ b/lib/Runtime/Base/ThreadContextInfo.h
@@ -90,7 +90,7 @@ public:
     virtual PreReservedVirtualAllocWrapper * GetPreReservedVirtualAllocator() = 0;
 #endif
 
-    virtual Js::PropertyRecord const * GetPropertyRecord(Js::PropertyId propertyId) = 0;
+    virtual bool IsNumericProperty(Js::PropertyId propertyId) = 0;
 
     bool CanBeFalsy(Js::TypeId typeId) { return typeId == this->wellKnownHostTypeHTMLAllCollectionTypeId; }
 


### PR DESCRIPTION
We only really need to know if a property ID is numeric, rest of property record was only being used for debug output.