### PR TITLE
Wasm: Bug fix in the unreachable state

### DIFF
--- a/lib/WasmReader/WasmByteCodeGenerator.cpp
+++ b/lib/WasmReader/WasmByteCodeGenerator.cpp
@@ -986,6 +986,8 @@ WasmBytecodeGenerator::EmitIfElseExpr()
     EmitInfo falseExpr;
     if (endOnElse)
     {
+        // In case the true block sets the unreachable state, we still have to emit the else block
+        SetUnreachableState(false);
         EmitBlockCommon(&blockInfo);
     }
     m_writer.MarkAsmJsLabel(endLabel);

--- a/test/WasmSpec/baselines/br.baseline
+++ b/test/WasmSpec/baselines/br.baseline
@@ -2,11 +2,10 @@ br.wast:285: $assert_return_1 unexpectedly threw: Error: Compiling wasm failed: 
 br.wast:290: $assert_return_5 unexpectedly threw: Error: Compiling wasm failed: function $assert_return_5[64] at offset 3/7: I64 return type NYI
 br.wast:292: $assert_return_7 unexpectedly threw: Error: Compiling wasm failed: function $assert_return_7[66] at offset 4/16: Operator I64ReinterpretF64 NYI
 br.wast:313: $assert_return_22 unexpectedly threw: Error: Compiling wasm failed: function $assert_return_22[81] at offset 3/7: I64 return type NYI
-br.wast:317: $assert_return_25 failed.
 br.wast:339: $assert_return_42 unexpectedly threw: Error: Compiling wasm failed: function $assert_return_42[101] at offset 3/7: I64 return type NYI
 br.wast:342: $assert_return_44 unexpectedly threw: Error: Compiling wasm failed: function as-store-value[42] at offset 12/16: Operator I64StoreMem NYI
 br.wast:344: $assert_return_46 unexpectedly threw: Error: Compiling wasm failed: function as-storeN-value[44] at offset 12/16: Operator I64StoreMem16 NYI
 br.wast:349: $assert_return_49 unexpectedly threw: Error: Compiling wasm failed: function $assert_return_49[108] at offset 3/7: I64 return type NYI
 br.wast:356: $assert_return_53 unexpectedly threw: Error: Compiling wasm failed: function as-convert-operand[51] at offset 8/10: Operator I32ConvertI64 NYI
 br.wast:358: $assert_return_54 unexpectedly threw: Error: Compiling wasm failed: function as-grow_memory-size[52] at offset 8/10: Operator GrowMemory NYI
-50/61 tests passed.
+51/61 tests passed.

--- a/test/WasmSpec/baselines/br_table.baseline
+++ b/test/WasmSpec/baselines/br_table.baseline
@@ -2,11 +2,10 @@ br_table.wast:1202: $assert_return_1 unexpectedly threw: Error: Compiling wasm f
 br_table.wast:1207: $assert_return_5 unexpectedly threw: Error: Compiling wasm failed: function $assert_return_5[71] at offset 3/7: I64 return type NYI
 br_table.wast:1209: $assert_return_7 unexpectedly threw: Error: Compiling wasm failed: function $assert_return_7[73] at offset 4/16: Operator I64ReinterpretF64 NYI
 br_table.wast:1289: $assert_return_74 unexpectedly threw: Error: Compiling wasm failed: function $assert_return_74[140] at offset 3/7: I64 return type NYI
-br_table.wast:1293: $assert_return_77 failed.
 br_table.wast:1315: $assert_return_94 unexpectedly threw: Error: Compiling wasm failed: function $assert_return_94[160] at offset 3/7: I64 return type NYI
 br_table.wast:1318: $assert_return_96 unexpectedly threw: Error: Compiling wasm failed: function as-store-value[49] at offset 15/19: Operator I64StoreMem NYI
 br_table.wast:1320: $assert_return_98 unexpectedly threw: Error: Compiling wasm failed: function as-storeN-value[51] at offset 15/19: Operator I64StoreMem16 NYI
 br_table.wast:1325: $assert_return_101 unexpectedly threw: Error: Compiling wasm failed: function $assert_return_101[167] at offset 3/7: I64 return type NYI
 br_table.wast:1332: $assert_return_105 unexpectedly threw: Error: Compiling wasm failed: function as-convert-operand[58] at offset 11/13: Operator I32ConvertI64 NYI
 br_table.wast:1334: $assert_return_106 unexpectedly threw: Error: Compiling wasm failed: function as-grow_memory-size[59] at offset 11/13: Operator GrowMemory NYI
-132/143 tests passed.
+133/143 tests passed.

--- a/test/WasmSpec/baselines/return.baseline
+++ b/test/WasmSpec/baselines/return.baseline
@@ -2,11 +2,10 @@ return.wast:187: $assert_return_1 unexpectedly threw: Error: Compiling wasm fail
 return.wast:192: $assert_return_5 unexpectedly threw: Error: Compiling wasm failed: function $assert_return_5[60] at offset 4/16: Operator I64ReinterpretF64 NYI
 return.wast:214: $assert_return_21 unexpectedly threw: Error: Compiling wasm failed: function $assert_return_21[76] at offset 3/7: I64 return type NYI
 return.wast:218: $assert_return_24 unexpectedly threw: Error: Compiling wasm failed: function $assert_return_24[79] at offset 3/7: I64 return type NYI
-return.wast:222: $assert_return_27 failed.
 return.wast:244: $assert_return_44 unexpectedly threw: Error: Compiling wasm failed: function $assert_return_44[99] at offset 3/7: I64 return type NYI
 return.wast:247: $assert_return_46 unexpectedly threw: Error: Compiling wasm failed: function as-store-value[44] at offset 9/12: Operator I64StoreMem NYI
 return.wast:249: $assert_return_48 unexpectedly threw: Error: Compiling wasm failed: function as-storeN-value[46] at offset 9/12: Operator I64StoreMem16 NYI
 return.wast:254: $assert_return_51 unexpectedly threw: Error: Compiling wasm failed: function $assert_return_51[106] at offset 3/7: I64 return type NYI
 return.wast:261: $assert_return_55 unexpectedly threw: Error: Compiling wasm failed: function as-convert-operand[53] at offset 5/6: Operator I32ConvertI64 NYI
 return.wast:263: $assert_return_56 unexpectedly threw: Error: Compiling wasm failed: function as-grow_memory-size[54] at offset 5/6: Operator GrowMemory NYI
-46/57 tests passed.
+47/57 tests passed.


### PR DESCRIPTION
We need to reset the Unreachable state before emitting the Else block in an if/else expression.
Otherwise we won't emit the code the the else block thinking we are in unreachable code

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/1739)
<!-- Reviewable:end -->
