### PR TITLE
remove assert that global object cannot change; save it at WI creation

### DIFF
--- a/lib/Backend/NativeCodeGenerator.cpp
+++ b/lib/Backend/NativeCodeGenerator.cpp
@@ -884,7 +884,7 @@ NativeCodeGenerator::CodeGen(PageAllocator * pageAllocator, CodeGenWorkItem* wor
 #if !FLOATVAR
     workItem->GetJITData()->xProcNumberPageSegment = scriptContext->GetThreadContext()->GetXProcNumberPageSegmentManager()->GetFreeSegment(&alloc);
 #endif
-    workItem->GetJITData()->globalThisAddr = (intptr_t)scriptContext->GetLibrary()->GetGlobalObject()->ToThis();
+    workItem->GetJITData()->globalThisAddr = (intptr_t)workItem->RecyclableData()->JitTimeData()->GetGlobalThisObject();
 
     LARGE_INTEGER start_time = { 0 };
     NativeCodeGenerator::LogCodeGenStart(workItem, &start_time);

--- a/lib/Backend/ServerScriptContext.cpp
+++ b/lib/Backend/ServerScriptContext.cpp
@@ -193,8 +193,6 @@ ServerScriptContext::GetGlobalObjectThisAddr() const
 void
 ServerScriptContext::UpdateGlobalObjectThisAddr(intptr_t globalThis)
 {
-    // this should stay constant once context initialization is complete
-    Assert(!m_globalThisAddr || m_globalThisAddr == globalThis);
     m_globalThisAddr = globalThis;
 }
 

--- a/lib/Runtime/Language/FunctionCodeGenJitTimeData.cpp
+++ b/lib/Runtime/Language/FunctionCodeGenJitTimeData.cpp
@@ -16,6 +16,7 @@ namespace Js
 #endif
         next(0),
         ldFldInlinees(nullptr),
+        globalThisObject(isInlined ? nullptr : GetFunctionBody()->GetScriptContext()->GetLibrary()->GetGlobalObject()->ToThis()),
         profiledIterations(GetFunctionBody() && GetFunctionBody()->GetByteCode() ? GetFunctionBody()->GetProfiledIterations() : 0)
     {
     }
@@ -33,6 +34,11 @@ namespace Js
     FunctionBody *FunctionCodeGenJitTimeData::GetFunctionBody() const
     {
         return this->functionInfo->GetFunctionBody();
+    }
+
+    Var FunctionCodeGenJitTimeData::GetGlobalThisObject() const
+    {
+        return this->globalThisObject;
     }
 
     bool FunctionCodeGenJitTimeData::IsPolymorphicCallSite(const ProfileId profiledCallSiteId) const

--- a/lib/Runtime/Language/FunctionCodeGenJitTimeData.h
+++ b/lib/Runtime/Language/FunctionCodeGenJitTimeData.h
@@ -37,6 +37,9 @@ namespace Js
         PolymorphicInlineCacheInfoIDL* selfInfo;
         PolymorphicInlineCacheIDL* polymorphicInlineCaches;
 
+        // current value of global this object, may be changed in case of script engine invalidation
+        Var globalThisObject;
+
         // Number of functions that are to be inlined (this is not the length of the 'inlinees' array above, includes getter setter inlinee count)
         uint inlineeCount;
         // Number of counts of getter setter to be inlined. This is not an exact count as inline caches are shared and we have no way of knowing
@@ -70,6 +73,7 @@ namespace Js
 
         FunctionInfo *GetFunctionInfo() const;
         FunctionBody *GetFunctionBody() const;
+        Var GetGlobalThisObject() const;
         FunctionBodyDataIDL *GetJITBody() const;
         FunctionCodeGenJitTimeData *GetNext() const { return next; }
 


### PR DESCRIPTION
Assert I added yesterday in JIT was hitting. It seems that there are some script context invalidation scenarios where the global object will be updated. For deterministic usage, stash it at WI creation instead of at JIT time.