### PR TITLE
use page allocator pool in JIT server

### DIFF
--- a/lib/Backend/Chakra.Backend.vcxproj
+++ b/lib/Backend/Chakra.Backend.vcxproj
@@ -402,6 +402,7 @@
     <ClInclude Include="LinearScanMDShared.h" />
     <ClInclude Include="LowerMDShared.h" />
     <ClInclude Include="NativeCodeData.h" />
+    <ClInclude Include="PageAllocatorPool.h" />
     <ClInclude Include="PDataManager.h" />
     <ClInclude Include="PrologEncoder.h">
       <ExcludedFromBuild Condition="'$(Platform)'!='x64'">true</ExcludedFromBuild>
@@ -458,6 +459,9 @@
     <ClInclude Include="CRC.h">
       <FileType>CppCode</FileType>
     </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="PageAllocatorPool.cpp" />
   </ItemGroup>
   <Import Project="$(BuildConfigPropsPath)Chakra.Build.targets" Condition="exists('$(BuildConfigPropsPath)Chakra.Build.targets')" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/lib/Backend/Chakra.Backend.vcxproj.filters
+++ b/lib/Backend/Chakra.Backend.vcxproj.filters
@@ -126,6 +126,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)ServerScriptContext.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)ServerThreadContext.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)JITTimeFixedField.cpp" />
+    <ClCompile Include="PageAllocatorPool.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="AgenPeeps.h" />
@@ -337,6 +338,7 @@
     <ClInclude Include="ExternalLowerer.h" />
     <ClInclude Include="JITRecyclableObject.h" />
     <ClInclude Include="CRC.h" />
+    <ClInclude Include="PageAllocatorPool.h" />
   </ItemGroup>
   <ItemGroup>
     <MASM Include="$(MSBuildThisFileDirectory)amd64\LinearScanMdA.asm">

--- a/lib/Backend/PageAllocatorPool.cpp
+++ b/lib/Backend/PageAllocatorPool.cpp
@@ -1,0 +1,136 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#include "Backend.h"
+
+#if ENABLE_OOP_NATIVE_CODEGEN
+#include "JITServer/JITServer.h"
+#include "PageAllocatorPool.h"
+
+CriticalSection PageAllocatorPool::cs;
+PageAllocatorPool* PageAllocatorPool::Instance = nullptr;
+
+PageAllocatorPool::PageAllocatorPool()
+    :pageAllocators(&NoThrowHeapAllocator::Instance),
+    activePageAllocatorCount(0)
+{
+    idleCleanupTimer = CreateWaitableTimerEx(NULL, L"JITServerIdle", 0/*auto reset*/, TIMER_ALL_ACCESS);
+}
+
+PageAllocatorPool::~PageAllocatorPool()
+{
+    RemoveAll();
+}
+
+void PageAllocatorPool::Initialize()
+{
+    Instance = HeapNewNoThrow(PageAllocatorPool);
+    if (Instance == nullptr)
+    {
+        Js::Throw::FatalInternalError();
+    }
+}
+void PageAllocatorPool::Shutdown()
+{
+    AutoCriticalSection autoCS(&cs);
+    if (Instance)
+    {
+        CloseHandle(Instance->idleCleanupTimer);
+        HeapDelete(Instance);
+        Instance = nullptr;
+    }
+}
+void PageAllocatorPool::RemoveAll()
+{
+    AutoCriticalSection autoCS(&cs);
+    while (!pageAllocators.Empty())
+    {
+        HeapDelete(pageAllocators.Pop());
+    }
+}
+
+unsigned int PageAllocatorPool::GetInactivePageAllocatorCount()
+{
+    AutoCriticalSection autoCS(&cs);
+    return pageAllocators.Count();
+}
+
+PageAllocator* PageAllocatorPool::GetPageAllocator()
+{
+    AutoCriticalSection autoCS(&cs);
+    PageAllocator* pageAllocator = nullptr;
+    if (pageAllocators.Count() > 0)
+    {
+        // TODO: OOP JIT, select the page allocator with right count of free pages
+        // base on some heuristic
+        pageAllocator = this->pageAllocators.Pop();
+    }
+    else
+    {
+        pageAllocator = HeapNew(PageAllocator, nullptr, Js::Configuration::Global.flags, PageAllocatorType_BGJIT,
+            AutoSystemInfo::Data.IsLowMemoryProcess() ? PageAllocator::DefaultLowMaxFreePageCount : PageAllocator::DefaultMaxFreePageCount);
+    }
+
+    activePageAllocatorCount++;
+    return pageAllocator;
+
+}
+void PageAllocatorPool::ReturnPageAllocator(PageAllocator* pageAllocator)
+{
+    AutoCriticalSection autoCS(&cs);
+    if (!this->pageAllocators.PrependNoThrow(&HeapAllocator::Instance, pageAllocator))
+    {
+        HeapDelete(pageAllocator);
+    }
+
+    activePageAllocatorCount--;
+    if (activePageAllocatorCount == 0 || GetInactivePageAllocatorCount() > (uint)Js::Configuration::Global.flags.JITServerMaxInactivePageAllocatorCount)
+    {
+        PageAllocatorPool::IdleCleanup();
+    }
+}
+
+void PageAllocatorPool::IdleCleanup()
+{
+    AutoCriticalSection autoCS(&cs);
+    if (Instance)
+    {
+        LARGE_INTEGER liDueTime;
+        liDueTime.QuadPart = Js::Configuration::Global.flags.JITServerIdleTimeout * -10000000LL; // wait for 10 seconds to do the cleanup
+
+        // If the timer is already active when you call SetWaitableTimer, the timer is stopped, then it is reactivated.
+        if (!SetWaitableTimer(Instance->idleCleanupTimer, &liDueTime, 0, IdleCleanupRoutine, NULL, 0))
+        {
+            Instance->RemoveAll();
+        }
+    }
+}
+
+VOID CALLBACK PageAllocatorPool::IdleCleanupRoutine(
+    _In_opt_ LPVOID lpArgToCompletionRoutine,
+    _In_     DWORD  dwTimerLowValue,
+    _In_     DWORD  dwTimerHighValue)
+{
+    AUTO_NESTED_HANDLED_EXCEPTION_TYPE(static_cast<ExceptionType>(ExceptionType_OutOfMemory | ExceptionType_StackOverflow));
+    try
+    {
+        if (Instance)
+        {
+            // TODO: OOP JIT, use better stragtegy to do the cleanup, like do not remove all,
+            // instead keep couple inactivate page allocator for next calls
+            Instance->RemoveAll();
+        }
+
+        ServerContextManager::IdleCleanup();
+    }
+    catch (Js::OutOfMemoryException&)
+    {
+    }
+    catch (...)
+    {
+        Assert(false);
+    }
+}
+#endif

--- a/lib/Backend/PageAllocatorPool.h
+++ b/lib/Backend/PageAllocatorPool.h
@@ -1,0 +1,60 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#pragma once
+
+class PageAllocatorPool
+{
+    friend class AutoReturnPageAllocator;
+public:
+    PageAllocatorPool();
+    ~PageAllocatorPool();
+    void RemoveAll();
+
+    static void Initialize();
+    static void Shutdown();
+    static void IdleCleanup();
+private:
+
+    static VOID CALLBACK IdleCleanupRoutine(
+        _In_opt_ LPVOID lpArgToCompletionRoutine,
+        _In_     DWORD  dwTimerLowValue,
+        _In_     DWORD  dwTimerHighValue);
+
+    PageAllocator* GetPageAllocator();
+    void ReturnPageAllocator(PageAllocator* pageAllocator);
+    unsigned int GetInactivePageAllocatorCount();
+
+    SList<PageAllocator*, NoThrowHeapAllocator, RealCount> pageAllocators;
+    static CriticalSection cs;
+    static PageAllocatorPool* Instance;
+    HANDLE idleCleanupTimer;
+    volatile unsigned long long activePageAllocatorCount;
+};
+
+class AutoReturnPageAllocator
+{
+public:
+    AutoReturnPageAllocator() :pageAllocator(nullptr) {}
+    ~AutoReturnPageAllocator()
+    {
+        if (pageAllocator)
+        {
+            PageAllocatorPool::Instance->ReturnPageAllocator(pageAllocator);
+        }
+    }
+    PageAllocator* GetPageAllocator()
+    {
+        if (pageAllocator == nullptr)
+        {
+            pageAllocator = PageAllocatorPool::Instance->GetPageAllocator();
+        }
+
+        return pageAllocator;
+    }
+
+private:
+    PageAllocator* pageAllocator;
+};

--- a/lib/Backend/ServerThreadContext.cpp
+++ b/lib/Backend/ServerThreadContext.cpp
@@ -4,26 +4,24 @@
 //-------------------------------------------------------------------------------------------------------
 
 #include "Backend.h"
+
 #if ENABLE_OOP_NATIVE_CODEGEN
 #include "JITServer/JITServer.h"
-#endif
 
 ServerThreadContext::ServerThreadContext(ThreadContextDataIDL * data) :
     m_threadContextData(*data),
     m_refCount(0),
-    m_policyManager(true),
     m_numericPropertySet(nullptr),
-    m_pageAllocs(&HeapAllocator::Instance),
     m_preReservedVirtualAllocator((HANDLE)data->processHandle),
-    m_codePageAllocators(&m_policyManager, ALLOC_XDATA, &m_preReservedVirtualAllocator, (HANDLE)data->processHandle),
+    m_codePageAllocators(nullptr, ALLOC_XDATA, &m_preReservedVirtualAllocator, (HANDLE)data->processHandle),
 #if DYNAMIC_INTERPRETER_THUNK || defined(ASMJS_PLAT)
-    m_thunkPageAllocators(&m_policyManager, /* allocXData */ false, /* virtualAllocator */ nullptr, (HANDLE)data->processHandle),
+    m_thunkPageAllocators(nullptr, /* allocXData */ false, /* virtualAllocator */ nullptr, (HANDLE)data->processHandle),
 #endif
-    m_codeGenAlloc(&m_policyManager, nullptr, &m_codePageAllocators, (HANDLE)data->processHandle),
-    m_pageAlloc(&m_policyManager, Js::Configuration::Global.flags, PageAllocatorType_BGJIT,
+    m_codeGenAlloc(nullptr, nullptr, &m_codePageAllocators, (HANDLE)data->processHandle),
+    m_pageAlloc(nullptr, Js::Configuration::Global.flags, PageAllocatorType_BGJIT,
         AutoSystemInfo::Data.IsLowMemoryProcess() ?
-            PageAllocator::DefaultLowMaxFreePageCount :
-            PageAllocator::DefaultMaxFreePageCount
+        PageAllocator::DefaultLowMaxFreePageCount :
+        PageAllocator::DefaultMaxFreePageCount
     ),
     // TODO: OOP JIT, don't hardcode name
 #ifdef NTBUILD
@@ -51,10 +49,7 @@ ServerThreadContext::~ServerThreadContext()
         HeapDelete(m_numericPropertySet);
         this->m_numericPropertySet = nullptr;
     }
-    this->m_pageAllocs.Map([](DWORD thread, PageAllocator* alloc)
-    {
-        HeapDelete(alloc);
-    });
+
 }
 
 PreReservedVirtualAllocWrapper *
@@ -62,26 +57,6 @@ ServerThreadContext::GetPreReservedVirtualAllocator()
 {
     return &m_preReservedVirtualAllocator;
 }
-
-PageAllocator*
-ServerThreadContext::GetPageAllocator()
-{
-    PageAllocator * alloc;
-
-    if (!m_pageAllocs.TryGetValue(GetCurrentThreadId(), &alloc))
-    {
-        alloc = HeapNew(PageAllocator,
-            &m_policyManager,
-            Js::Configuration::Global.flags, PageAllocatorType_BGJIT,
-            AutoSystemInfo::Data.IsLowMemoryProcess() ?
-            PageAllocator::DefaultLowMaxFreePageCount :
-            PageAllocator::DefaultMaxFreePageCount);
-
-        m_pageAllocs.Add(GetCurrentThreadId(), alloc);
-    }
-    return alloc;
-}
-
 
 intptr_t
 ServerThreadContext::GetBailOutRegisterSaveSpaceAddr() const
@@ -166,12 +141,6 @@ ServerThreadContext::GetCodeGenAllocators()
     return &m_codeGenAlloc;
 }
 
-AllocationPolicyManager *
-ServerThreadContext::GetAllocationPolicyManager()
-{
-    return &m_policyManager;
-}
-
 intptr_t
 ServerThreadContext::GetRuntimeChakraBaseAddress() const
 {
@@ -251,3 +220,5 @@ void ServerThreadContext::Close()
     ServerContextManager::RecordCloseContext(this);
 #endif
 }
+
+#endif //ENABLE_OOP_NATIVE_CODEGEN

--- a/lib/Backend/ServerThreadContext.cpp
+++ b/lib/Backend/ServerThreadContext.cpp
@@ -7,6 +7,7 @@
 
 #if ENABLE_OOP_NATIVE_CODEGEN
 #include "JITServer/JITServer.h"
+#endif //ENABLE_OOP_NATIVE_CODEGEN
 
 ServerThreadContext::ServerThreadContext(ThreadContextDataIDL * data) :
     m_threadContextData(*data),
@@ -220,5 +221,3 @@ void ServerThreadContext::Close()
     ServerContextManager::RecordCloseContext(this);
 #endif
 }
-
-#endif //ENABLE_OOP_NATIVE_CODEGEN

--- a/lib/Backend/ServerThreadContext.h
+++ b/lib/Backend/ServerThreadContext.h
@@ -35,9 +35,7 @@ public:
     ptrdiff_t GetCRTBaseAddressDifference() const;
 
     CodeGenAllocators * GetCodeGenAllocators();
-    AllocationPolicyManager * GetAllocationPolicyManager();
     CustomHeap::CodePageAllocators * GetCodePageAllocators();
-    PageAllocator* GetPageAllocator();
     void RemoveFromNumericPropertySet(Js::PropertyId reclaimedId);
     void AddToNumericPropertySet(Js::PropertyId propertyId);
     void SetWellKnownHostTypeId(Js::TypeId typeId) { this->wellKnownHostTypeHTMLAllCollectionTypeId = typeId; }
@@ -60,8 +58,6 @@ private:
         DefaultComparer, JsUtil::SimpleHashedEntry, JsUtil::AsymetricResizeLock> PropertySet;
     PropertySet * m_numericPropertySet;
 
-    AllocationPolicyManager m_policyManager;
-    JsUtil::BaseDictionary<DWORD, PageAllocator*, HeapAllocator> m_pageAllocs;
     PreReservedVirtualAllocWrapper m_preReservedVirtualAllocator;
 #if DYNAMIC_INTERPRETER_THUNK || defined(ASMJS_PLAT)
     CustomHeap::CodePageAllocators m_thunkPageAllocators;
@@ -78,5 +74,4 @@ private:
     intptr_t m_jitChakraBaseAddress;
     intptr_t m_jitCRTBaseAddress;
     uint m_refCount;
-
 };

--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -1478,6 +1478,8 @@ FLAGNR(Boolean, CFG, "Force enable CFG on jshost. version in the jshost's manife
     FLAGNR(Number, SimulatePolyCacheWithOneTypeForInlineCacheIndex, "Use with SimulatePolyCacheWithOneTypeForFunction to simulate creating a polymorphic inline cache containing only one type due to a collision, for testing ObjTypeSpec", -1)
 #endif
 
+FLAGR(Number, JITServerIdleTimeout, "Idle timeout in seconds to do the cleanup in JIT server", 10)
+FLAGR(Number, JITServerMaxInactivePageAllocatorCount, "Max inactive page allocators to keep before schedule a cleanup", 10)
 #undef FLAG_REGOVR_EXP
 #undef FLAG_REGOVR_ASMJS
 

--- a/lib/JITServer/JITServer.h
+++ b/lib/JITServer/JITServer.h
@@ -17,6 +17,8 @@ public:
     static bool CheckLivenessAndAddref(ServerScriptContext* context);
     static bool CheckLivenessAndAddref(ServerThreadContext* context);
 
+    static void IdleCleanup();
+
 private:
     static JsUtil::BaseHashSet<ServerThreadContext*, HeapAllocator> threadContexts;
     static JsUtil::BaseHashSet<ServerScriptContext*, HeapAllocator> scriptContexts;

--- a/lib/JITServer/JITServerPch.h
+++ b/lib/JITServer/JITServerPch.h
@@ -12,3 +12,4 @@
 #include "Runtime.h"
 #include "Backend.h"
 #include "JITServer.h"
+#include "PageAllocatorPool.h"


### PR DESCRIPTION
In Edge multiple tab shares one JIT server process, and counting webworker scenario, there can be many thread contexts in JIT server, also, there's multiple thread in the JIT server to handle the requests, and the thread is randomly selected. so in total, there can behuge number of page allocators (maximum: count_of_threadContext * count_of_threads). Changing to use same page allocator for same thread.

Removing the allocation policy manager in JIT server, it does not make sense that limiting content process memory usage in JIT server. we can revisit the memory throttling feature if we enable OOP JIT in JSRT in the future.
