### PR TITLE
Add type assertions for opeq and mov instructions

### DIFF
--- a/lib/Backend/DbCheckPostLower.cpp
+++ b/lib/Backend/DbCheckPostLower.cpp
@@ -146,6 +146,29 @@ DbCheckPostLower::Check()
             {
                 Assert(instr->GetDst()->IsEqual(instr->GetSrc1()));
             }
+#if defined(_M_IX86) || defined(_M_X64)
+            // for op-eq's and assignment operators, make  sure the types match
+            // for shift operators make sure the types match and the third is an 8-bit immediate
+            // for cmp operators similarly check types are same
+            if (EncoderMD::IsOPEQ(instr))
+            {
+                Assert(instr->GetDst()->IsEqual(instr->GetSrc1()));
+
+#if defined(_M_X64)
+                Assert(!instr->GetSrc2() || instr->GetDst()->GetSize() == instr->GetSrc2()->GetSize() ||
+                    ((EncoderMD::IsSHIFT(instr) || instr->m_opcode == Js::OpCode::BTR ||
+                        instr->m_opcode == Js::OpCode::BTS ||
+                        instr->m_opcode == Js::OpCode::BT) && instr->GetSrc2()->GetSize() == 1));
+#else
+                Assert(!instr->GetSrc2() || instr->GetDst()->GetSize() == instr->GetSrc2()->GetSize() ||
+                    ((EncoderMD::IsSHIFT(instr) || instr->m_opcode == Js::OpCode::BTR ||
+                        instr->m_opcode == Js::OpCode::BT) && instr->GetSrc2()->GetSize() == 1));
+#endif
+            }
+            Assert(!LowererMD::IsAssign(instr) || instr->GetDst()->GetSize() == instr->GetSrc1()->GetSize());
+            Assert(instr->m_opcode != Js::OpCode::CMP || instr->GetSrc1()->GetType() == instr->GetSrc1()->GetType());
+#endif
+
             switch (instr->m_opcode)
             {
             case Js::OpCode::CMOVA:

--- a/lib/Backend/IRBuilder.cpp
+++ b/lib/Backend/IRBuilder.cpp
@@ -7367,7 +7367,7 @@ IR::Instr *
 IRBuilder::CreateLoopBodyReturnIPInstr(uint targetOffset, uint offset)
 {
     IR::RegOpnd * retOpnd = IR::RegOpnd::New(m_loopBodyRetIPSym, TyMachReg, m_func);
-    IR::IntConstOpnd * exitOffsetOpnd = IR::IntConstOpnd::New(targetOffset, TyInt32, m_func);
+    IR::IntConstOpnd * exitOffsetOpnd = IR::IntConstOpnd::New(targetOffset, TyMachReg, m_func);
     return IR::Instr::New(Js::OpCode::Ld_I4, retOpnd, exitOffsetOpnd, m_func);
 }
 

--- a/lib/Backend/LowerMDSharedSimd128.cpp
+++ b/lib/Backend/LowerMDSharedSimd128.cpp
@@ -386,7 +386,7 @@ IR::Instr* LowererMD::Simd128LoadConst(IR::Instr* instr)
     {
         int offset = NativeCodeData::GetDataTotalOffset(pValue);
 
-        simdRef = IR::IndirOpnd::New(IR::RegOpnd::New(m_func->GetTopFunc()->GetNativeCodeDataSym(), TyVar, m_func), offset, TyMachDouble,
+        simdRef = IR::IndirOpnd::New(IR::RegOpnd::New(m_func->GetTopFunc()->GetNativeCodeDataSym(), TyVar, m_func), offset, instr->GetDst()->GetType(),
 #if DBG
             NativeCodeData::GetDataDescription(pValue, m_func->m_alloc),
 #endif
@@ -732,7 +732,7 @@ IR::Instr* LowererMD::Simd128LowerLdLane(IR::Instr *instr)
             Legalize(shiftInstr);
         }
         // MOVSS/MOVSD/MOVD dst, tmp
-        instr->InsertBefore(IR::Instr::New(movOpcode, dst, tmp, m_func));
+        instr->InsertBefore(IR::Instr::New(movOpcode, movOpcode == Js::OpCode::MOVD ? dst : dst->UseWithNewType(tmp->GetType(), m_func), tmp, m_func));
     }
 
     // dst has the 4-byte lane
@@ -1289,7 +1289,7 @@ IR::Instr* LowererMD::Simd128LowerShift(IR::Instr *instr)
     IR::RegOpnd *shamt = IR::RegOpnd::New(src2->GetType(), m_func);
     // en-register
     IR::Opnd *origShamt = EnregisterIntConst(instr, src2); //unnormalized shift amount
-    pInstr = IR::Instr::New(Js::OpCode::AND, shamt, origShamt, IR::IntConstOpnd::New(Js::SIMDUtils::SIMDGetShiftAmountMask(elementSizeInBytes), TyInt8, m_func), m_func); // normalizing by elm width (i.e. shamt % elm_width)
+    pInstr = IR::Instr::New(Js::OpCode::AND, shamt, origShamt, IR::IntConstOpnd::New(Js::SIMDUtils::SIMDGetShiftAmountMask(elementSizeInBytes), TyInt32, m_func), m_func); // normalizing by elm width (i.e. shamt % elm_width)
     instr->InsertBefore(pInstr);
     Legalize(pInstr);
 

--- a/lib/Backend/Peeps.cpp
+++ b/lib/Backend/Peeps.cpp
@@ -207,7 +207,7 @@ Peeps::PeepFunc()
 
                     if (pattern_found)
                     {
-                        IR::IntConstOpnd* constOne  = IR::IntConstOpnd::New((IntConstType) 1, TyInt32, instr->m_func);
+                        IR::IntConstOpnd* constOne  = IR::IntConstOpnd::New((IntConstType) 1, instr->GetDst()->GetType(), instr->m_func);
                         IR::Instr * addOrSubInstr = IR::Instr::New(Js::OpCode::ADD, instr->GetDst(), instr->GetDst(), constOne, instr->m_func);
 
                         if (instr->m_opcode == Js::OpCode::DEC)

--- a/lib/Backend/amd64/EncoderMD.cpp
+++ b/lib/Backend/amd64/EncoderMD.cpp
@@ -1959,6 +1959,14 @@ bool EncoderMD::IsOPEQ(IR::Instr *instr)
     return instr->IsLowered() && (EncoderMD::GetOpdope(instr) & DOPEQ);
 }
 
+bool EncoderMD::IsSHIFT(IR::Instr *instr)
+{
+    return (instr->IsLowered() && EncoderMD::GetInstrForm(instr) == FORM_SHIFT) ||
+        instr->m_opcode == Js::OpCode::PSLLDQ || instr->m_opcode == Js::OpCode::PSRLDQ ||
+        instr->m_opcode == Js::OpCode::PSLLW || instr->m_opcode == Js::OpCode::PSRLW ||
+        instr->m_opcode == Js::OpCode::PSLLD;
+}
+
 bool EncoderMD::IsMOVEncoding(IR::Instr *instr)
 {
     return instr->IsLowered() && (EncoderMD::GetOpdope(instr) & DMOV);

--- a/lib/Backend/amd64/EncoderMD.h
+++ b/lib/Backend/amd64/EncoderMD.h
@@ -190,6 +190,7 @@ public:
     static bool     SetsConditionCode(IR::Instr *instr);
     static bool     UsesConditionCode(IR::Instr *instr);
     static bool     IsOPEQ(IR::Instr *instr);
+    static bool     IsSHIFT(IR::Instr *instr);
     static bool     IsMOVEncoding(IR::Instr *instr);
     RelocList*      GetRelocList() const { return m_relocList; }
     int             AppendRelocEntry(RelocType type, void *ptr, IR::LabelInstr *label= nullptr);

--- a/lib/Backend/amd64/PeepsMD.cpp
+++ b/lib/Backend/amd64/PeepsMD.cpp
@@ -69,6 +69,7 @@ PeepsMD::PeepAssign(IR::Instr *instr)
             if(src->IsIntConstOpnd() && src->GetSize() <= TySize[TyUint32])
             {
                 dst->SetType(TyUint32);
+                src->SetType(TyUint32);
             }
             else if(src->IsAddrOpnd() && (((size_t)src->AsAddrOpnd()->m_address >> 32) == 0 ))
             {

--- a/lib/Backend/i386/EncoderMD.cpp
+++ b/lib/Backend/i386/EncoderMD.cpp
@@ -1804,6 +1804,14 @@ bool EncoderMD::IsOPEQ(IR::Instr *instr)
     return instr->IsLowered() && (EncoderMD::GetOpdope(instr) & DOPEQ);
 }
 
+bool EncoderMD::IsSHIFT(IR::Instr *instr)
+{
+    return (instr->IsLowered() && EncoderMD::GetInstrForm(instr) == FORM_SHIFT) ||
+        instr->m_opcode == Js::OpCode::PSLLDQ || instr->m_opcode == Js::OpCode::PSRLDQ ||
+        instr->m_opcode == Js::OpCode::PSLLW || instr->m_opcode == Js::OpCode::PSRLW ||
+        instr->m_opcode == Js::OpCode::PSLLD;
+}
+
 void EncoderMD::AddLabelReloc(BYTE* relocAddress)
 {
     AppendRelocEntry(RelocTypeLabel, relocAddress);

--- a/lib/Backend/i386/EncoderMD.h
+++ b/lib/Backend/i386/EncoderMD.h
@@ -217,6 +217,7 @@ public:
     static bool     SetsConditionCode(IR::Instr *instr);
     static bool     UsesConditionCode(IR::Instr *instr);
     static bool     IsOPEQ(IR::Instr *instr);
+    static bool     IsSHIFT(IR::Instr *instr);
     RelocList*      GetRelocList() const { return m_relocList; }
     int             AppendRelocEntry(RelocType type, void *ptr, IR::LabelInstr * labelInstr = nullptr, const void * fnAddress = nullptr);
     int             FixRelocListEntry(uint32 index, int32 totalBytesSaved, BYTE *buffStart, BYTE* buffEnd);

--- a/lib/Backend/i386/LowererMDArch.cpp
+++ b/lib/Backend/i386/LowererMDArch.cpp
@@ -629,7 +629,7 @@ LowererMDArch::LowerCallIDynamic(IR::Instr * callInstr, IR::Instr*saveThisArgOut
     {
         Assert(argsLength->IsRegOpnd());
         /*callInfo*/
-        callInstr->InsertBefore(IR::Instr::New(Js::OpCode::ADD, argsLength, argsLength, IR::IntConstOpnd::New(1, TyInt8, this->m_func), this->m_func));
+        callInstr->InsertBefore(IR::Instr::New(Js::OpCode::ADD, argsLength, argsLength, IR::IntConstOpnd::New(1, TyUint32, this->m_func), this->m_func));
     }
 
     IR::Instr* argout = IR::Instr::New(Js::OpCode::ArgOut_A_Dynamic, this->m_func);
@@ -656,7 +656,7 @@ LowererMDArch::LowerCallIDynamic(IR::Instr * callInstr, IR::Instr*saveThisArgOut
     {
         IR::RegOpnd *argsLengthRegOpnd = argsLength->AsRegOpnd();
         //Account for callInfo & function object in argsLength
-        IR::Instr * addInstr = IR::Instr::New(Js::OpCode::ADD, argsLengthRegOpnd, argsLengthRegOpnd, IR::IntConstOpnd::New(2, TyInt8, this->m_func), this->m_func);
+        IR::Instr * addInstr = IR::Instr::New(Js::OpCode::ADD, argsLengthRegOpnd, argsLengthRegOpnd, IR::IntConstOpnd::New(2, TyUint32, this->m_func), this->m_func);
         callInstr->InsertBefore(addInstr);
 
         IR::Instr *insertInstr = callInstr->m_next;
@@ -1027,7 +1027,7 @@ LowererMDArch::LowerAsmJsLdElemHelper(IR::Instr * instr, bool isSimdLoad /*= fal
         // MOV tmp, cmpOnd
         Lowerer::InsertMove(tmp, cmpOpnd, helperLabel);
         // ADD tmp, dataWidth
-        Lowerer::InsertAdd(false, tmp, tmp, IR::IntConstOpnd::New((uint32)dataWidth, TyInt8, m_func, true), helperLabel);
+        Lowerer::InsertAdd(false, tmp, tmp, IR::IntConstOpnd::New((uint32)dataWidth, tmp->GetType(), m_func, true), helperLabel);
         // CMP tmp, size
         // JG  $helper
         lowererMD->m_lowerer->InsertCompareBranch(tmp, instr->UnlinkSrc2(), Js::OpCode::BrGt_A, true, helperLabel, helperLabel);
@@ -1087,7 +1087,7 @@ LowererMDArch::LowerAsmJsStElemHelper(IR::Instr * instr, bool isSimdStore /*= fa
         // MOV tmp, cmpOnd
         Lowerer::InsertMove(tmp, cmpOpnd, helperLabel);
         // ADD tmp, dataWidth
-        Lowerer::InsertAdd(false, tmp, tmp, IR::IntConstOpnd::New((uint32)dataWidth, TyInt8, m_func, true), helperLabel);
+        Lowerer::InsertAdd(false, tmp, tmp, IR::IntConstOpnd::New((uint32)dataWidth, tmp->GetType(), m_func, true), helperLabel);
         // CMP tmp, size
         // JG  $helper
         lowererMD->m_lowerer->InsertCompareBranch(tmp, instr->UnlinkSrc2(), Js::OpCode::BrGt_A, true, helperLabel, helperLabel);
@@ -4132,7 +4132,7 @@ LowererMDArch::GenerateArgOutForStackArgs(IR::Instr* callInstr, IR::Instr* stack
     this->LoadDynamicArgument(argout);
 
 
-    IR::Instr *subInstr = IR::Instr::New(Js::OpCode::Sub_I4, ldLenDstOpnd, ldLenDstOpnd, IR::IntConstOpnd::New(1, TyInt8, func),func);
+    IR::Instr *subInstr = IR::Instr::New(Js::OpCode::Sub_I4, ldLenDstOpnd, ldLenDstOpnd, IR::IntConstOpnd::New(1, TyUint32, func),func);
     callInstr->InsertBefore(subInstr);
     this->lowererMD->EmitInt4Instr(subInstr);
 


### PR DESCRIPTION
Add assertions to OPEQ instructions to make sure src2 has same type as
dst, and mov instructions to make sure src1 has atleast same size as dst.
Fix all instances in lowering that break this assertion.
