### PR TITLE
cache debugManager JIT addrs on new ScriptContext, instead of new ThreadContext

### DIFF
--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -11482,7 +11482,7 @@ Lowerer::LowerBailForDebugger(IR::Instr* instr, bool isInsideHelper /* = false *
 
     if (!(bailOutKind & IR::BailOutExplicit))
     {
-        intptr_t flags = m_func->GetThreadContextInfo()->GetDebuggingFlagsAddr();
+        intptr_t flags = m_func->GetScriptContextInfo()->GetDebuggingFlagsAddr();
 
         // Check 1 (do we need to bail out?)
         // JXX bailoutLabel
@@ -11556,13 +11556,13 @@ Lowerer::LowerBailForDebugger(IR::Instr* instr, bool isInsideHelper /* = false *
         {
             // TEST STEP_BAILOUT, [&stepController->StepType]
             // BNE BailoutLabel
-            IR::Opnd* opnd1 = IR::MemRefOpnd::New(m_func->GetThreadContextInfo()->GetDebugStepTypeAddr(), TyInt8, m_func);
+            IR::Opnd* opnd1 = IR::MemRefOpnd::New(m_func->GetScriptContextInfo()->GetDebugStepTypeAddr(), TyInt8, m_func);
             IR::Opnd* opnd2 = IR::IntConstOpnd::New(Js::STEP_BAILOUT, TyInt8, this->m_func, /*dontEncode*/ true);
             InsertTestBranch(opnd1, opnd2, Js::OpCode::BrNeq_A, bailOutLabel, continueBranchInstr);
 
             // CMP  STEP_DOCUMENT, [&stepController->StepType]
             // BEQ BailoutDocumentLabel
-            opnd1 = IR::MemRefOpnd::New(m_func->GetThreadContextInfo()->GetDebugStepTypeAddr(), TyInt8, m_func);
+            opnd1 = IR::MemRefOpnd::New(m_func->GetScriptContextInfo()->GetDebugStepTypeAddr(), TyInt8, m_func);
             opnd2 = IR::IntConstOpnd::New(Js::STEP_DOCUMENT, TyInt8, this->m_func, /*dontEncode*/ true);
             InsertCompareBranch(opnd1, opnd2, Js::OpCode::BrEq_A, /*isUnsigned*/ true, bailOutDocumentLabel, continueBranchInstr);
 
@@ -11583,12 +11583,12 @@ Lowerer::LowerBailForDebugger(IR::Instr* instr, bool isInsideHelper /* = false *
             effectiveFrameBaseReg = m_lowererMD.GetRegFramePointer();
 #endif
             IR::Opnd* opnd1 = IR::RegOpnd::New(nullptr, effectiveFrameBaseReg, TyMachReg, m_func);
-            IR::Opnd* opnd2 = IR::MemRefOpnd::New(m_func->GetThreadContextInfo()->GetDebugFrameAddressAddr(), TyMachReg, m_func);
+            IR::Opnd* opnd2 = IR::MemRefOpnd::New(m_func->GetScriptContextInfo()->GetDebugFrameAddressAddr(), TyMachReg, m_func);
             this->InsertCompareBranch(opnd1, opnd2, Js::OpCode::BrGt_A, /*isUnsigned*/ true, bailOutLabel, continueBranchInstr);
 
             // CMP  STEP_DOCUMENT, [&stepController->StepType]
             // BEQ BailoutDocumentLabel
-            opnd1 = IR::MemRefOpnd::New(m_func->GetThreadContextInfo()->GetDebugStepTypeAddr(), TyInt8, m_func);
+            opnd1 = IR::MemRefOpnd::New(m_func->GetScriptContextInfo()->GetDebugStepTypeAddr(), TyInt8, m_func);
             opnd2 = IR::IntConstOpnd::New(Js::STEP_DOCUMENT, TyInt8, this->m_func, /*dontEncode*/ true);
             InsertCompareBranch(opnd1, opnd2, Js::OpCode::BrEq_A, /*isUnsigned*/ true, bailOutDocumentLabel, continueBranchInstr);
 
@@ -11623,7 +11623,7 @@ Lowerer::LowerBailForDebugger(IR::Instr* instr, bool isInsideHelper /* = false *
             // bailOutLabel:                // (fallthrough bailOutLabel)
             IR::Opnd* opnd1 = IR::MemRefOpnd::New(m_func->GetJITFunctionBody()->GetScriptIdAddr(), TyInt32, m_func);
 
-            IR::Opnd* opnd2 = IR::MemRefOpnd::New(m_func->GetThreadContextInfo()->GetDebugScriptIdWhenSetAddr(), TyInt32, m_func);
+            IR::Opnd* opnd2 = IR::MemRefOpnd::New(m_func->GetScriptContextInfo()->GetDebugScriptIdWhenSetAddr(), TyInt32, m_func);
             IR::RegOpnd* reg1 = IR::RegOpnd::New(TyInt32, m_func);
             InsertMove(reg1, opnd2, bailOutLabel);
 

--- a/lib/Backend/ServerScriptContext.cpp
+++ b/lib/Backend/ServerScriptContext.cpp
@@ -259,6 +259,30 @@ ServerScriptContext::IsPRNGSeeded() const
     return m_isPRNGSeeded;
 }
 
+intptr_t
+ServerScriptContext::GetDebuggingFlagsAddr() const
+{
+    return static_cast<intptr_t>(m_contextData.debuggingFlagsAddr);
+}
+
+intptr_t
+ServerScriptContext::GetDebugStepTypeAddr() const
+{
+    return static_cast<intptr_t>(m_contextData.debugStepTypeAddr);
+}
+
+intptr_t
+ServerScriptContext::GetDebugFrameAddressAddr() const
+{
+    return static_cast<intptr_t>(m_contextData.debugFrameAddressAddr);
+}
+
+intptr_t
+ServerScriptContext::GetDebugScriptIdWhenSetAddr() const
+{
+    return static_cast<intptr_t>(m_contextData.debugScriptIdWhenSetAddr);
+}
+
 bool
 ServerScriptContext::IsClosed() const
 {

--- a/lib/Backend/ServerScriptContext.h
+++ b/lib/Backend/ServerScriptContext.h
@@ -42,6 +42,11 @@ public:
     virtual bool IsClosed() const override;
     virtual intptr_t GetBuiltinFunctionsBaseAddr() const override;
 
+    virtual intptr_t GetDebuggingFlagsAddr() const override;
+    virtual intptr_t GetDebugStepTypeAddr() const override;
+    virtual intptr_t GetDebugFrameAddressAddr() const override;
+    virtual intptr_t GetDebugScriptIdWhenSetAddr() const override;
+
     virtual intptr_t GetAddr() const override;
 
     virtual intptr_t GetVTableAddress(VTableValue vtableType) const override;

--- a/lib/Backend/ServerThreadContext.cpp
+++ b/lib/Backend/ServerThreadContext.cpp
@@ -86,30 +86,6 @@ ServerThreadContext::GetBailOutRegisterSaveSpaceAddr() const
     return static_cast<intptr_t>(m_threadContextData.bailOutRegisterSaveSpaceAddr);
 }
 
-intptr_t
-ServerThreadContext::GetDebuggingFlagsAddr() const
-{
-    return static_cast<intptr_t>(m_threadContextData.debuggingFlagsAddr);
-}
-
-intptr_t
-ServerThreadContext::GetDebugStepTypeAddr() const
-{
-    return static_cast<intptr_t>(m_threadContextData.debugStepTypeAddr);
-}
-
-intptr_t
-ServerThreadContext::GetDebugFrameAddressAddr() const
-{
-    return static_cast<intptr_t>(m_threadContextData.debugFrameAddressAddr);
-}
-
-intptr_t
-ServerThreadContext::GetDebugScriptIdWhenSetAddr() const
-{
-    return static_cast<intptr_t>(m_threadContextData.debugScriptIdWhenSetAddr);
-}
-
 ptrdiff_t
 ServerThreadContext::GetChakraBaseAddressDifference() const
 {

--- a/lib/Backend/ServerThreadContext.h
+++ b/lib/Backend/ServerThreadContext.h
@@ -27,11 +27,6 @@ public:
     virtual intptr_t GetImplicitCallFlagsAddr() const override;
     virtual intptr_t GetBailOutRegisterSaveSpaceAddr() const override;
 
-    virtual intptr_t GetDebuggingFlagsAddr() const override;
-    virtual intptr_t GetDebugStepTypeAddr() const override;
-    virtual intptr_t GetDebugFrameAddressAddr() const override;
-    virtual intptr_t GetDebugScriptIdWhenSetAddr() const override;
-
     ptrdiff_t GetChakraBaseAddressDifference() const;
     ptrdiff_t GetCRTBaseAddressDifference() const;
 

--- a/lib/JITIDL/JITTypes.h
+++ b/lib/JITIDL/JITTypes.h
@@ -283,10 +283,6 @@ typedef struct ThreadContextDataIDL
     CHAKRA_PTR bailOutRegisterSaveSpaceAddr;
     CHAKRA_PTR disableImplicitFlagsAddr;
     CHAKRA_PTR implicitCallFlagsAddr;
-    CHAKRA_PTR debuggingFlagsAddr;
-    CHAKRA_PTR debugStepTypeAddr;
-    CHAKRA_PTR debugFrameAddressAddr;
-    CHAKRA_PTR debugScriptIdWhenSetAddr;
     CHAKRA_PTR stringReplaceNameAddr;
     CHAKRA_PTR stringMatchNameAddr;
     CHAKRA_PTR simdTempAreaBaseAddr;
@@ -328,6 +324,10 @@ typedef struct ScriptContextDataIDL
     CHAKRA_PTR numberAllocatorAddr;
     CHAKRA_PTR recyclerAddr;
     CHAKRA_PTR builtinFunctionsBaseAddr;
+    CHAKRA_PTR debuggingFlagsAddr;
+    CHAKRA_PTR debugStepTypeAddr;
+    CHAKRA_PTR debugFrameAddressAddr;
+    CHAKRA_PTR debugScriptIdWhenSetAddr;
 } ScriptContextDataIDL;
 
 typedef struct SmallSpanSequenceIDL

--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -4488,6 +4488,11 @@ void ScriptContext::RegisterPrototypeChainEnsuredToHaveOnlyWritableDataPropertie
         contextData.isRecyclerVerifyEnabled = FALSE;
         contextData.recyclerVerifyPad = 0;
 #endif
+        contextData.debuggingFlagsAddr = GetDebuggingFlagsAddr();
+        contextData.debugStepTypeAddr = GetDebugStepTypeAddr();
+        contextData.debugFrameAddressAddr = GetDebugFrameAddressAddr();
+        contextData.debugScriptIdWhenSetAddr = GetDebugScriptIdWhenSetAddr();
+
         contextData.numberAllocatorAddr = (intptr_t)GetNumberAllocator();
         contextData.isSIMDEnabled = GetConfig()->IsSimdjsEnabled();
         CompileAssert(VTableValue::Count == VTABLE_COUNT); // need to update idl when this changes
@@ -4648,6 +4653,26 @@ void ScriptContext::RegisterPrototypeChainEnsuredToHaveOnlyWritableDataPropertie
     intptr_t ScriptContext::GetRecyclerAddr() const
     {
         return (intptr_t)GetRecycler();
+    }
+
+    intptr_t ScriptContext::GetDebuggingFlagsAddr() const
+    {
+        return this->threadContext->GetDebugManager()->GetDebuggingFlagsAddr();
+    }
+
+    intptr_t ScriptContext::GetDebugStepTypeAddr() const
+    {
+        return (intptr_t)this->threadContext->GetDebugManager()->stepController.GetAddressOfStepType();
+    }
+
+    intptr_t ScriptContext::GetDebugFrameAddressAddr() const
+    {
+        return (intptr_t)this->threadContext->GetDebugManager()->stepController.GetAddressOfFrameAddress();
+    }
+
+    intptr_t ScriptContext::GetDebugScriptIdWhenSetAddr() const
+    {
+        return (intptr_t)this->threadContext->GetDebugManager()->stepController.GetAddressOfScriptIdWhenSet();
     }
 
     bool ScriptContext::GetRecyclerAllowNativeCodeBumpAllocation() const

--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -1758,6 +1758,11 @@ private:
         virtual bool IsPRNGSeeded() const override;
         virtual intptr_t GetBuiltinFunctionsBaseAddr() const override;
 
+        virtual intptr_t GetDebuggingFlagsAddr() const override;
+        virtual intptr_t GetDebugStepTypeAddr() const override;
+        virtual intptr_t GetDebugFrameAddressAddr() const override;
+        virtual intptr_t GetDebugScriptIdWhenSetAddr() const override;
+
 #if ENABLE_NATIVE_CODEGEN
         virtual void AddToDOMFastPathHelperMap(intptr_t funcInfoAddr, IR::JnHelperMethod helper) override;
         virtual IR::JnHelperMethod GetDOMFastPathHelper(intptr_t funcInfoAddr) override;

--- a/lib/Runtime/Base/ScriptContextInfo.h
+++ b/lib/Runtime/Base/ScriptContextInfo.h
@@ -50,6 +50,11 @@ public:
 
     virtual Js::Var* GetModuleExportSlotArrayAddress(uint moduleIndex, uint slotIndex) = 0;
 
+    virtual intptr_t GetDebuggingFlagsAddr() const = 0;
+    virtual intptr_t GetDebugStepTypeAddr() const = 0;
+    virtual intptr_t GetDebugFrameAddressAddr() const = 0;
+    virtual intptr_t GetDebugScriptIdWhenSetAddr() const = 0;
+
 #if ENABLE_NATIVE_CODEGEN
     virtual void AddToDOMFastPathHelperMap(intptr_t funcInfoAddr, IR::JnHelperMethod helper) = 0;
     virtual IR::JnHelperMethod GetDOMFastPathHelper(intptr_t funcInfoAddr) = 0;

--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -341,30 +341,6 @@ ThreadContext::GetImplicitCallFlagsAddr() const
     return (intptr_t)&implicitCallFlags;
 }
 
-intptr_t
-ThreadContext::GetDebuggingFlagsAddr() const
-{
-    return this->debugManager->GetDebuggingFlagsAddr();
-}
-
-intptr_t
-ThreadContext::GetDebugStepTypeAddr() const
-{
-    return (intptr_t)this->debugManager->stepController.GetAddressOfStepType();
-}
-
-intptr_t
-ThreadContext::GetDebugFrameAddressAddr() const
-{
-    return (intptr_t)this->debugManager->stepController.GetAddressOfFrameAddress();
-}
-
-intptr_t
-ThreadContext::GetDebugScriptIdWhenSetAddr() const
-{
-    return (intptr_t)this->debugManager->stepController.GetAddressOfScriptIdWhenSet();
-}
-
 ptrdiff_t
 ThreadContext::GetChakraBaseAddressDifference() const
 {
@@ -1994,10 +1970,6 @@ ThreadContext::EnsureJITThreadContext(bool allowPrereserveAlloc)
     contextData.bailOutRegisterSaveSpaceAddr = (intptr_t)bailOutRegisterSaveSpace;
     contextData.disableImplicitFlagsAddr = (intptr_t)GetAddressOfDisableImplicitFlags();
     contextData.implicitCallFlagsAddr = (intptr_t)GetAddressOfImplicitCallFlags();
-    contextData.debuggingFlagsAddr = (intptr_t)this->debugManager->GetDebuggingFlags();
-    contextData.debugStepTypeAddr = (intptr_t)this->debugManager->stepController.GetAddressOfStepType();
-    contextData.debugFrameAddressAddr = (intptr_t)this->debugManager->stepController.GetAddressOfFrameAddress();
-    contextData.debugScriptIdWhenSetAddr = (intptr_t)this->debugManager->stepController.GetAddressOfScriptIdWhenSet();
     contextData.scriptStackLimit = GetScriptStackLimit();
     contextData.isThreadBound = IsThreadBound();
     contextData.allowPrereserveAlloc = allowPrereserveAlloc;

--- a/lib/Runtime/Base/ThreadContext.h
+++ b/lib/Runtime/Base/ThreadContext.h
@@ -1216,11 +1216,6 @@ public:
     virtual intptr_t GetDisableImplicitFlagsAddr() const override;
     virtual intptr_t GetImplicitCallFlagsAddr() const override;
 
-    virtual intptr_t GetDebuggingFlagsAddr() const override;
-    virtual intptr_t GetDebugStepTypeAddr() const override;
-    virtual intptr_t GetDebugFrameAddressAddr() const override;
-    virtual intptr_t GetDebugScriptIdWhenSetAddr() const override;
-
     ptrdiff_t GetChakraBaseAddressDifference() const;
     ptrdiff_t GetCRTBaseAddressDifference() const;
 

--- a/lib/Runtime/Base/ThreadContextInfo.h
+++ b/lib/Runtime/Base/ThreadContextInfo.h
@@ -90,11 +90,6 @@ public:
     virtual PreReservedVirtualAllocWrapper * GetPreReservedVirtualAllocator() = 0;
 #endif
 
-    virtual intptr_t GetDebuggingFlagsAddr() const = 0;
-    virtual intptr_t GetDebugStepTypeAddr() const = 0;
-    virtual intptr_t GetDebugFrameAddressAddr() const = 0;
-    virtual intptr_t GetDebugScriptIdWhenSetAddr() const = 0;
-
     virtual Js::PropertyRecord const * GetPropertyRecord(Js::PropertyId propertyId) = 0;
 
     bool CanBeFalsy(Js::TypeId typeId) { return typeId == this->wellKnownHostTypeHTMLAllCollectionTypeId; }


### PR DESCRIPTION
In case primary ScriptContext is closed, threadContext->debugManager can be freed, and if new ScriptContext is later opened, a new debugManager is created. In this case, the address we initially cached on the JIT will be wrong.