### PR TITLE
fix issue when polymorphic inline info layouts differ in JIT and runtime data

### DIFF
--- a/lib/Runtime/Language/FunctionCodeGenRuntimeData.cpp
+++ b/lib/Runtime/Language/FunctionCodeGenRuntimeData.cpp
@@ -27,14 +27,16 @@ namespace Js
         return &clonedInlineCaches;
     }
 
-    FunctionCodeGenRuntimeData * FunctionCodeGenRuntimeData::GetNextForTarget(FunctionBody *targetFuncBody) const
+    const FunctionCodeGenRuntimeData * FunctionCodeGenRuntimeData::GetForTarget(FunctionBody *targetFuncBody) const
     {
-        FunctionCodeGenRuntimeData * next = this->next;
-        if (next->GetFunctionBody() != targetFuncBody)
+        const FunctionCodeGenRuntimeData * target = this;
+        while (target && target->GetFunctionBody() != targetFuncBody)
         {
-            next = next->next;
+            target = target->next;
         }
-        return next;
+        // we should always find the info
+        Assert(target);
+        return target;
     }
 
     const FunctionCodeGenRuntimeData *FunctionCodeGenRuntimeData::GetInlinee(const ProfileId profiledCallSiteId) const

--- a/lib/Runtime/Language/FunctionCodeGenRuntimeData.h
+++ b/lib/Runtime/Language/FunctionCodeGenRuntimeData.h
@@ -36,7 +36,7 @@ namespace Js
     public:
         FunctionBody *GetFunctionBody() const;
         FunctionCodeGenRuntimeData *GetNext() const { return next; };
-        FunctionCodeGenRuntimeData *GetNextForTarget(FunctionBody *targetFuncBody) const;
+        const FunctionCodeGenRuntimeData *GetForTarget(FunctionBody *targetFuncBody) const;
         const InlineCachePointerArray<InlineCache> *ClonedInlineCaches() const;
         InlineCachePointerArray<InlineCache> *ClonedInlineCaches();
 


### PR DESCRIPTION
Exact order of next pointers for polymorphic CodeGen JIT and CodeGen Runtime data may differ. So, while walking CodeGen JIT data during BuildJITTimeData data we should pass along the head CodeGen Runtime pointer, otherwise inner calls will not be able to find inlinees who appear earlier in the list.