### PR TITLE
fix issue with caching global this object incorrectly

### DIFF
--- a/lib/Runtime/Language/FunctionCodeGenJitTimeData.cpp
+++ b/lib/Runtime/Language/FunctionCodeGenJitTimeData.cpp
@@ -16,7 +16,7 @@ namespace Js
 #endif
         next(0),
         ldFldInlinees(nullptr),
-        globalThisObject(isInlined ? nullptr : GetFunctionBody()->GetScriptContext()->GetLibrary()->GetGlobalObject()->ToThis()),
+        globalThisObject(GetFunctionBody() && GetFunctionBody()->GetByteCode() ? GetFunctionBody()->GetScriptContext()->GetLibrary()->GetGlobalObject()->ToThis() : 0),
         profiledIterations(GetFunctionBody() && GetFunctionBody()->GetByteCode() ? GetFunctionBody()->GetProfiledIterations() : 0)
     {
     }


### PR DESCRIPTION
I misunderstood meaning of FunctionCodeGenJitTimeData::isInlined and was trying to use that to save global this address for topfunc only, but that field has a different meaning. Instead, just always store it when creating FunctionCodeGenJitTimeData for full FunctionBody.