### PR TITLE
Put OOP CFG registration under a flag in test builds

### DIFF
--- a/bin/ch/ChakraRtInterface.h
+++ b/bin/ch/ChakraRtInterface.h
@@ -244,6 +244,9 @@ public:
 #ifdef DEBUG
     static HRESULT SetCheckOpHelpersFlag(bool flag) { return CHECKED_CALL(SetCheckOpHelpersFlag, flag); }
 #endif
+#ifdef ENABLE_DEBUG_CONFIG_OPTIONS
+    static HRESULT SetOOPCFGRegistrationFlag(bool flag) { return CHECKED_CALL(SetOOPCFGRegistrationFlag, flag); }
+#endif
 
     static HRESULT GetCrashOnExceptionFlag(bool * flag)
     {

--- a/bin/ch/JITProcessManager.cpp
+++ b/bin/ch/JITProcessManager.cpp
@@ -67,7 +67,11 @@ HRESULT JITProcessManager::CreateServerProcess(int argc, __in_ecount(argc) LPWST
     RPC_WSTR connectionUuidString = NULL;
 
 #pragma warning(suppress: 6386) // buffer overrun
+#ifdef ENABLE_DEBUG_CONFIG_OPTIONS
+    hr = StringCchCopyW(cmdLine, cmdLineSize, L"ch.exe -OOPCFGRegistration- -CheckOpHelpers -jitserver:");
+#else
     hr = StringCchCopyW(cmdLine, cmdLineSize, L"ch.exe -jitserver:");
+#endif
     if (FAILED(hr))
     {
         return hr;

--- a/bin/ch/ch.cpp
+++ b/bin/ch/ch.cpp
@@ -537,6 +537,9 @@ HRESULT ExecuteTest(const char* fileName)
 #ifdef DEBUG
         ChakraRTInterface::SetCheckOpHelpersFlag(true);
 #endif
+#ifdef ENABLE_DEBUG_CONFIG_OPTIONS
+        ChakraRTInterface::SetOOPCFGRegistrationFlag(false);
+#endif
 
         if (!WScriptJsrt::Initialize())
         {

--- a/lib/Backend/Encoder.cpp
+++ b/lib/Backend/Encoder.cpp
@@ -33,7 +33,7 @@ Encoder::Encode()
     m_offsetBuffer = AnewArray(m_tempAlloc, uint, instrCount);
 #endif
 
-    m_pragmaInstrToRecordMap    = Anew(m_tempAlloc, PragmaInstrList, m_tempAlloc);
+    m_pragmaInstrToRecordMap = Anew(m_tempAlloc, PragmaInstrList, m_tempAlloc);
     if (DoTrackAllStatementBoundary())
     {
         // Create a new list, if we are tracking all statement boundaries.
@@ -48,7 +48,7 @@ Encoder::Encode()
 
 #if defined(_M_IX86) || defined(_M_X64)
     // for BR shortening
-    m_inlineeFrameRecords       = Anew(m_tempAlloc, InlineeFrameRecords, m_tempAlloc);
+    m_inlineeFrameRecords = Anew(m_tempAlloc, InlineeFrameRecords, m_tempAlloc);
 #endif
 
     m_pc = m_encodeBuffer;
@@ -72,7 +72,7 @@ Encoder::Encode()
         Fatal();
     }
 
-    uint bufferCRC = initialCRCSeed;  
+    uint bufferCRC = initialCRCSeed;
 
     FOREACH_INSTR_IN_FUNC(instr, m_func)
     {
@@ -89,7 +89,7 @@ Encoder::Encode()
 #endif
             if (instr->IsPragmaInstr())
             {
-                switch(instr->m_opcode)
+                switch (instr->m_opcode)
                 {
 #ifdef _M_X64
                 case Js::OpCode::PrologStart:
@@ -143,9 +143,9 @@ Encoder::Encode()
                     multiBranchInstr->MapMultiBrTargetByAddress([=](void ** offset) -> void
                     {
 #if defined(_M_ARM32_OR_ARM64)
-                        encoderMD->AddLabelReloc((byte*) offset);
+                        encoderMD->AddLabelReloc((byte*)offset);
 #else
-                        encoderMD->AppendRelocEntry(RelocTypeLabelUse, (void*) (offset), *(IR::LabelInstr**)(offset));
+                        encoderMD->AppendRelocEntry(RelocTypeLabelUse, (void*)(offset), *(IR::LabelInstr**)(offset));
                         *((size_t*)offset) = 0;
 #endif
                     });
@@ -223,7 +223,7 @@ Encoder::Encode()
 #if defined(_M_IX86) || defined(_M_X64)
             // for BR shortening.
             if (instr->isInlineeEntryInstr)
-                m_encoderMD.AppendRelocEntry(RelocType::RelocTypeInlineeEntryOffset, (void*) (m_pc - MachPtr));
+                m_encoderMD.AppendRelocEntry(RelocType::RelocTypeInlineeEntryOffset, (void*)(m_pc - MachPtr));
 #endif
             if (isCallInstr)
             {
@@ -240,7 +240,7 @@ Encoder::Encode()
             Fatal();
         }
     } NEXT_INSTR_IN_FUNC;
-    
+
     ptrdiff_t codeSize = m_pc - m_encodeBuffer + totalJmpTableSizeInBytes;
 
     BOOL isSuccessBrShortAndLoopAlign = false;
@@ -371,7 +371,10 @@ Encoder::Encode()
     m_func->GetJITOutput()->SetCodeAddress(m_func->GetJITOutput()->GetCodeAddress() | 0x1); // Set thumb mode
 #endif
 
-    m_func->GetThreadContextInfo()->SetValidCallTargetForCFG((PVOID)m_func->GetJITOutput()->GetCodeAddress());
+    if (CONFIG_FLAG(OOPCFGRegistration))
+    {
+        m_func->GetThreadContextInfo()->SetValidCallTargetForCFG((PVOID)m_func->GetJITOutput()->GetCodeAddress());
+    }
 
     const bool isSimpleJit = m_func->IsSimpleJit();
 

--- a/lib/Backend/InterpreterThunkEmitter.cpp
+++ b/lib/Backend/InterpreterThunkEmitter.cpp
@@ -369,7 +369,13 @@ void InterpreterThunkEmitter::NewOOPJITThunkBlock()
     );
     JITManager::HandleServerCallResult(hr);
 
+
     this->thunkBuffer = (BYTE*)thunkInfo.thunkBlockAddr;
+
+    if (!CONFIG_FLAG(OOPCFGRegistration))
+    {
+        this->scriptContext->GetThreadContext()->SetValidCallTargetForCFG(this->thunkBuffer);
+    }
 
     // Update object state only at the end when everything has succeeded - and no exceptions can be thrown.
     auto block = this->thunkBlocks.PrependNode(allocator, this->thunkBuffer);

--- a/lib/Backend/NativeCodeGenerator.cpp
+++ b/lib/Backend/NativeCodeGenerator.cpp
@@ -1082,6 +1082,11 @@ NativeCodeGenerator::CodeGen(PageAllocator * pageAllocator, CodeGenWorkItem* wor
     }
 #endif
 
+    if (!CONFIG_FLAG(OOPCFGRegistration))
+    {
+        scriptContext->GetThreadContext()->SetValidCallTargetForCFG((PVOID)jitWriteData.codeAddress);
+    }
+
     workItem->SetCodeAddress((size_t)jitWriteData.codeAddress);
 
     workItem->GetEntryPoint()->SetCodeGenRecorded((Js::JavascriptMethod)jitWriteData.codeAddress, jitWriteData.codeSize);
@@ -3180,7 +3185,7 @@ NativeCodeGenerator::QueueFreeNativeCodeGenAllocation(void* address)
         return;
     }
 
-    if (!JITManager::GetJITManager()->IsOOPJITEnabled())
+    if (!JITManager::GetJITManager()->IsOOPJITEnabled() || !CONFIG_FLAG(OOPCFGRegistration))
     {
         //DeRegister Entry Point for CFG
         ThreadContext::GetContextForCurrentThread()->SetValidCallTargetForCFG(address, false);

--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -651,6 +651,7 @@ PHASE(All)
 #define DEFAULT_CONFIG_DumpHeap (false)
 #define DEFAULT_CONFIG_PerfHintLevel (1)
 #define DEFAULT_CONFIG_OOPJITMissingOpts (true)
+#define DEFAULT_CONFIG_OOPCFGRegistration (true)
 
 #define DEFAULT_CONFIG_FailFastIfDisconnectedDelegate    (false)
 
@@ -1201,6 +1202,7 @@ FLAGNR(Number,  FuncObjectInlineCacheThreshold  , "Maximum number of inline cach
 FLAGNR(Boolean, NoDeferParse          , "Disable deferred parsing", false)
 FLAGNR(Boolean, NoLogo                , "No logo, which we don't display anyways", false)
 FLAGNR(Boolean, OOPJITMissingOpts     , "Use optimizations that are missing from OOP JIT", DEFAULT_CONFIG_OOPJITMissingOpts)
+FLAGNR(Boolean, OOPCFGRegistration    , "Do CFG registration OOP (under OOP JIT)", DEFAULT_CONFIG_OOPCFGRegistration)
 #ifdef _ARM64_
 FLAGR (Boolean, NoNative              , "Disable native codegen", true)
 #else

--- a/lib/JITServer/JITServer.cpp
+++ b/lib/JITServer/JITServer.cpp
@@ -435,8 +435,10 @@ ServerNewInterpreterThunkBlock(
             MemoryOperationLastError::CheckProcessAndThrowFatalError(threadContext->GetProcessHandle());
         }
 
-        // Call to set VALID flag for CFG check
-        threadContext->SetValidCallTargetForCFG(remoteBuffer);
+        if(CONFIG_FLAG(OOPCFGRegistration))
+        {
+            threadContext->SetValidCallTargetForCFG(remoteBuffer);
+        }
 
         thunkInfo->thunkBlockAddr = (intptr_t)remoteBuffer;
         thunkInfo->thunkCount = thunkCount;
@@ -465,7 +467,10 @@ ServerFreeAllocation(
 
     return ServerCallWrapper(context, [&]()->HRESULT 
     {
-        context->SetValidCallTargetForCFG((PVOID)address, false);
+        if (CONFIG_FLAG(OOPCFGRegistration))
+        {
+            context->SetValidCallTargetForCFG((PVOID)address, false);
+        }
         context->GetCodeGenAllocators()->emitBufferManager.FreeAllocation((void*)address);
         return S_OK;
     });


### PR DESCRIPTION
To help with downlevel testing, only enable OOP CFG registration on release build