### PR TITLE
Add delay free listing for func arenas in debug builds

### DIFF
--- a/lib/Backend/Func.cpp
+++ b/lib/Backend/Func.cpp
@@ -1163,6 +1163,7 @@ Func::EndPhase(Js::Phase tag, bool dump)
         dbCheck.Check();
 #endif
     }
+    this->m_alloc->MergeDelayFreeList();
 #endif
 }
 

--- a/lib/Backend/NativeCodeGenerator.cpp
+++ b/lib/Backend/NativeCodeGenerator.cpp
@@ -908,7 +908,9 @@ NativeCodeGenerator::CodeGen(PageAllocator * pageAllocator, CodeGenWorkItem* wor
         CodeGenAllocators *const allocators =
             foreground ? EnsureForegroundAllocators(pageAllocator) : GetBackgroundAllocator(pageAllocator); // okay to do outside lock since the respective function is called only from one thread
         NoRecoverMemoryJitArenaAllocator jitArena(_u("JITArena"), pageAllocator, Js::Throw::OutOfMemory);
-
+#if DBG
+        jitArena.SetNeedsDelayFreeList();
+#endif
         JITTimeWorkItem * jitWorkItem = Anew(&jitArena, JITTimeWorkItem, workItem->GetJITData());
 
 #if !FLOATVAR

--- a/lib/Backend/Opnd.cpp
+++ b/lib/Backend/Opnd.cpp
@@ -176,46 +176,64 @@ void Opnd::Free(Func *func)
     {
     case OpndKindIntConst:
         //NOTE: use to be Sealed do not do sub class checks like in CloneUse
-        return static_cast<IntConstOpnd*>(this)->FreeInternal(func);
+        static_cast<IntConstOpnd*>(this)->FreeInternal(func);
+        break;
 
     case OpndKindSimd128Const:
-        return static_cast<Simd128ConstOpnd*>(this)->FreeInternal(func);
+        static_cast<Simd128ConstOpnd*>(this)->FreeInternal(func);
+        break;
 
     case OpndKindFloatConst:
-        return static_cast<FloatConstOpnd*>(this)->FreeInternal(func);
+        static_cast<FloatConstOpnd*>(this)->FreeInternal(func);
+        break;
 
     case OpndKindHelperCall:
-        return static_cast<HelperCallOpnd*>(this)->FreeInternal(func);
+        static_cast<HelperCallOpnd*>(this)->FreeInternal(func);
+        break;
 
     case OpndKindSym:
-        return static_cast<SymOpnd*>(this)->FreeInternal(func);
+        static_cast<SymOpnd*>(this)->FreeInternal(func);
+        break;
 
     case OpndKindReg:
         if ((*static_cast<RegOpnd*>(this)).IsArrayRegOpnd())
         {
-            return static_cast<ArrayRegOpnd*>(this)->FreeInternalSub(func);
+            static_cast<ArrayRegOpnd*>(this)->FreeInternalSub(func);
+            break;
         }
-        return static_cast<RegOpnd*>(this)->FreeInternal(func);
+        static_cast<RegOpnd*>(this)->FreeInternal(func);
+        break;
 
     case OpndKindAddr:
-        return static_cast<AddrOpnd*>(this)->FreeInternal(func);
+        static_cast<AddrOpnd*>(this)->FreeInternal(func);
+        break;
 
     case OpndKindIndir:
-        return static_cast<IndirOpnd*>(this)->FreeInternal(func);
+        static_cast<IndirOpnd*>(this)->FreeInternal(func);
+        break;
 
     case OpndKindMemRef:
-        return static_cast<MemRefOpnd*>(this)->FreeInternal(func);
+        static_cast<MemRefOpnd*>(this)->FreeInternal(func);
+        break;
 
     case OpndKindLabel:
-        return static_cast<LabelOpnd*>(this)->FreeInternal(func);
+        static_cast<LabelOpnd*>(this)->FreeInternal(func);
+        break;
 
     case OpndKindRegBV:
-        return static_cast<RegBVOpnd*>(this)->FreeInternal(func);
+        static_cast<RegBVOpnd*>(this)->FreeInternal(func);
+        break;
     default:
         Assert(UNREACHED);
         __assume(UNREACHED);
 
     };
+#if DBG
+    if (func->m_alloc->HasDelayFreeList())
+    {
+        this->isDeleted = true;
+    }
+#endif
 }
 
 /*

--- a/lib/Backend/Opnd.h
+++ b/lib/Backend/Opnd.h
@@ -124,6 +124,7 @@ protected:
     {
 #if DBG
         isFakeDst = false;
+        isDeleted = false;
 #endif
         m_kind = (OpndKind)0;
     }
@@ -137,6 +138,7 @@ protected:
     {
 #if DBG
         isFakeDst = false;
+        isDeleted = false;
 #endif
         m_kind = oldOpnd.m_kind;
     }
@@ -280,11 +282,22 @@ protected:
     bool                isPropertySymOpnd : 1;
 public:
 #if DBG
-    bool                isFakeDst:1;
+    bool                isFakeDst : 1;
 #endif
     OpndKind            m_kind;
 
+#ifdef DBG
+public:
+    bool                isDeleted;
+#endif
 };
+
+// We will set isDeleted bit on a freed Opnd, this should not overlap with the next field of BVSparseNode
+// because BVSparseNode* are used to maintain freelist of memory of BVSparseNode size
+#if DBG
+CompileAssert(offsetof(Opnd, isDeleted) > offsetof(BVSparseNode, next) + sizeof(BVSparseNode*) ||
+              offsetof(Opnd, isDeleted) < offsetof(BVSparseNode, next) + sizeof(BVSparseNode*));
+#endif
 
 ///---------------------------------------------------------------------------
 ///

--- a/lib/Backend/Opnd.inl
+++ b/lib/Backend/Opnd.inl
@@ -17,6 +17,7 @@ namespace IR {
 inline Opnd *
 Opnd::Use(Func *func)
 {
+    AssertMsg(!isDeleted, "Using deleted operand");
     if (!m_inUse)
     {
         m_inUse = true;

--- a/lib/Common/DataStructures/SparseBitVector.h
+++ b/lib/Common/DataStructures/SparseBitVector.h
@@ -59,8 +59,8 @@ typedef  BVUnit64 SparseBVUnit;
 
 struct BVSparseNode
 {
-    BVIndex         startIndex;
     BVSparseNode *  next;
+    BVIndex         startIndex;
     SparseBVUnit    data;
 
     BVSparseNode(BVIndex beginIndex, BVSparseNode * nextNode);

--- a/lib/Common/Memory/ArenaAllocator.h
+++ b/lib/Common/Memory/ArenaAllocator.h
@@ -150,6 +150,9 @@ private:
 #ifdef PROFILE_MEM
     struct ArenaMemoryData * memoryData;
 #endif
+#if DBG
+    bool needsDelayFreeList;
+#endif
 
 public:
     static const size_t ObjectAlignmentBitShift = ObjectAlignmentBitShiftArg;
@@ -228,6 +231,17 @@ public:
 
     char* Realloc(void* buffer, DECLSPEC_GUARD_OVERFLOW size_t existingBytes, DECLSPEC_GUARD_OVERFLOW size_t requestedBytes);
     void Free(void * buffer, size_t byteSize);
+#if DBG
+    bool HasDelayFreeList() const
+    {
+        return needsDelayFreeList;
+    }
+    void SetNeedsDelayFreeList()
+    {
+        needsDelayFreeList = true;
+    }
+    void MergeDelayFreeList();
+#endif
 #ifdef TRACK_ALLOC
     // Doesn't support tracking information, dummy implementation
     ArenaAllocatorBase * TrackAllocInfo(TrackAllocData const& data) { return this; }
@@ -292,6 +306,9 @@ public:
     static void * Allocate(void * policy, DECLSPEC_GUARD_OVERFLOW size_t size);
     static void * Free(void * policy, void * object, size_t size);
     static void * Reset(void * policy);
+#if DBG
+    static void MergeDelayFreeList(void * freeList);
+#endif
     static void PrepareFreeObject(__out_bcount(size) void * object, _In_ size_t size)
     {
 #ifdef ARENA_MEMORY_VERIFY
@@ -352,6 +369,9 @@ public:
     }
 #ifdef ARENA_MEMORY_VERIFY
     static void VerifyFreeObjectIsFreeMemFilled(void * object, size_t size);
+#endif
+#if DBG
+    static void MergeDelayFreeList(void * freeList);
 #endif
     static void Release(void * policy);
 };
@@ -613,6 +633,9 @@ public:
         memset(object, NULL, size);
 #endif
     }
+#if DBG
+    static void MergeDelayFreeList(void * freeList);
+#endif
 #ifdef ARENA_MEMORY_VERIFY
     static void VerifyFreeObjectIsFreeMemFilled(void * object, size_t size);
 #endif

--- a/lib/JITServer/JITServer.cpp
+++ b/lib/JITServer/JITServer.cpp
@@ -596,6 +596,9 @@ ServerRemoteCodeGen(
         PageAllocator* pageAllocator = autoReturnPageAllocator.GetPageAllocator();
 
         NoRecoverMemoryJitArenaAllocator jitArena(L"JITArena", pageAllocator, Js::Throw::OutOfMemory);
+#if DBG
+        jitArena.SetNeedsDelayFreeList();
+#endif
         JITTimeWorkItem * jitWorkItem = Anew(&jitArena, JITTimeWorkItem, workItemData);
 
         if (PHASE_VERBOSE_TRACE_RAW(Js::BackEndPhase, jitWorkItem->GetJITTimeInfo()->GetSourceContextId(), jitWorkItem->GetJITTimeInfo()->GetLocalFunctionId()))


### PR DESCRIPTION
Freed memory on func arenas are returned to a delay free list instead of
making them available immediately for allocation. For Opnd frees,
isDeleted bit is set, this enables detecting erroneous code that can use-afer-free of Opnd
memory. At the end of a phase, the delay free list is merged into the free
list making it available for subsequent allocations.
