### PR TITLE
use stack memory for some of the allocation in interpreter thunk emitter

### DIFF
--- a/lib/Backend/Func.cpp
+++ b/lib/Backend/Func.cpp
@@ -120,9 +120,6 @@ Func::Func(JitArenaAllocator *alloc, JITTimeWorkItem * workItem,
 #endif
     , m_funcStartLabel(nullptr)
     , m_funcEndLabel(nullptr)
-#ifdef _M_X64
-    , m_prologEncoder(alloc)
-#endif
 #if DBG
     , hasCalledSetDoFastPaths(false)
     , allowRemoveBailOutArgInstr(false)

--- a/lib/Backend/InterpreterThunkEmitter.cpp
+++ b/lib/Backend/InterpreterThunkEmitter.cpp
@@ -222,8 +222,6 @@ const BYTE InterpreterThunkEmitter::Call[] = {
 
 #endif
 
-const BYTE InterpreterThunkEmitter::PageCount = 1;
-const uint InterpreterThunkEmitter::BlockSize = AutoSystemInfo::PageSize * InterpreterThunkEmitter::PageCount;
 const BYTE InterpreterThunkEmitter::HeaderSize = sizeof(InterpreterThunk);
 const BYTE InterpreterThunkEmitter::ThunkSize = sizeof(Call);
 const uint InterpreterThunkEmitter::ThunksPerBlock = (BlockSize - HeaderSize) / ThunkSize;
@@ -325,7 +323,6 @@ void InterpreterThunkEmitter::NewThunkBlock()
 #endif
 
     FillBuffer(
-        this->allocator,
         this->scriptContext->GetThreadContext(),
         this->isAsmInterpreterThunk,
         (intptr_t)buffer,
@@ -387,7 +384,6 @@ void InterpreterThunkEmitter::NewOOPJITThunkBlock()
 
 /* static */
 void InterpreterThunkEmitter::FillBuffer(
-    _In_ ArenaAllocator * arena,
     _In_ ThreadContextInfo * threadContext,
     _In_ bool asmJsThunk,
     _In_ intptr_t finalAddr,
@@ -401,7 +397,7 @@ void InterpreterThunkEmitter::FillBuffer(
     )
 {
 #ifdef _M_X64
-    PrologEncoder prologEncoder(arena);
+    PrologEncoder prologEncoder;
     prologEncoder.EncodeSmallProlog(PrologSize, StackAllocSize);
     DWORD pdataSize = prologEncoder.SizeOfPData();
 #elif defined(_M_ARM32_OR_ARM64)

--- a/lib/Backend/InterpreterThunkEmitter.h
+++ b/lib/Backend/InterpreterThunkEmitter.h
@@ -86,7 +86,7 @@ private:
 
     static const BYTE Epilog[];
 
-    static const BYTE PageCount;
+    static const BYTE PageCount = 1;
 #if defined(_M_X64)
     static const BYTE PrologSize;
     static const BYTE StackAllocSize;
@@ -126,7 +126,7 @@ public:
     static const BYTE HeaderSize;
     static const BYTE ThunkSize;
     static const uint ThunksPerBlock;
-    static const uint BlockSize;
+    static const uint BlockSize= AutoSystemInfo::PageSize * PageCount;
     static void* ConvertToEntryPoint(PVOID dynamicInterpreterThunk);
 
     InterpreterThunkEmitter(Js::ScriptContext * context, ArenaAllocator* allocator, CustomHeap::CodePageAllocators * codePageAllocators, bool isAsmInterpreterThunk = false);
@@ -145,7 +145,6 @@ public:
     }
 
     static void FillBuffer(
-        _In_ ArenaAllocator * arena,
         _In_ ThreadContextInfo * context,
         _In_ bool asmJsThunk,
         _In_ intptr_t finalAddr,

--- a/lib/Backend/PrologEncoder.cpp
+++ b/lib/Backend/PrologEncoder.cpp
@@ -32,24 +32,13 @@ DWORD PrologEncoder::SizeOfPData()
     return sizeof(PData) + (sizeof(UNWIND_CODE) * requiredUnwindCodeNodeCount);
 }
 
-void PrologEncoder::SetPDataPtr(void *pdata)
-{
-    this->pdata = static_cast<PData *>(pdata);
-}
-
 void PrologEncoder::EncodeSmallProlog(uint8 prologSize, size_t allocaSize)
 {
-    Assert(!pdata);
     Assert(allocaSize <= 128);
     Assert(requiredUnwindCodeNodeCount == 0);
 
     // Increment requiredUnwindCodeNodeCount to ensure we do the Alloc for the correct size
     currentUnwindCodeNodeIndex = ++requiredUnwindCodeNodeCount;
-
-    if (!pdata)
-    {
-        pdata = (PData *)alloc->Alloc(SizeOfPData());
-    }
 
     currentInstrOffset = prologSize;
 
@@ -66,15 +55,6 @@ void PrologEncoder::EncodeInstr(IR::Instr *instr, unsigned __int8 size)
 {
     Assert(instr);
     Assert(size);
-
-    // We've started encoding instructions. This is a good time to initialize
-    // pdata as we now have the final size.
-    if (!pdata)
-    {
-        pdata = (PData *)alloc->Alloc(SizeOfPData());
-    }
-
-    Assert(pdata);
 
     UnwindCode       *unwindCode       = nullptr;
     unsigned __int8   unwindCodeOp     = PrologEncoderMD::GetOp(instr);
@@ -172,33 +152,32 @@ BYTE *PrologEncoder::Finalize(BYTE *functionStart,
                               DWORD codeSize,
                               BYTE *pdataBuffer)
 {
-    Assert(pdata);
     Assert(pdataBuffer > functionStart);
     Assert((size_t)pdataBuffer % sizeof(DWORD) == 0);
 
-    pdata->runtimeFunction.BeginAddress = 0;
-    pdata->runtimeFunction.EndAddress   = codeSize;
-    pdata->runtimeFunction.UnwindData   = (DWORD)((pdataBuffer + sizeof(RUNTIME_FUNCTION)) - functionStart);
+    pdata.runtimeFunction.BeginAddress = 0;
+    pdata.runtimeFunction.EndAddress   = codeSize;
+    pdata.runtimeFunction.UnwindData   = (DWORD)((pdataBuffer + sizeof(RUNTIME_FUNCTION)) - functionStart);
 
     FinalizeUnwindInfo(functionStart, codeSize);
 
-    return (BYTE *)&pdata->runtimeFunction;
+    return (BYTE *)&pdata.runtimeFunction;
 }
 
 void PrologEncoder::FinalizeUnwindInfo(BYTE *functionStart, DWORD codeSize)
 {
-    pdata->unwindInfo.Version           = 1;
-    pdata->unwindInfo.Flags             = 0;
-    pdata->unwindInfo.SizeOfProlog      = currentInstrOffset;
-    pdata->unwindInfo.CountOfCodes      = requiredUnwindCodeNodeCount;
+    pdata.unwindInfo.Version           = 1;
+    pdata.unwindInfo.Flags             = 0;
+    pdata.unwindInfo.SizeOfProlog      = currentInstrOffset;
+    pdata.unwindInfo.CountOfCodes      = requiredUnwindCodeNodeCount;
 
     // We don't use the frame pointer in the standard way, and since we don't do dynamic stack allocation, we don't change the
     // stack pointer except during calls. From the perspective of the unwind info, it needs to restore information relative to
     // the stack pointer, so don't register the frame pointer.
-    pdata->unwindInfo.FrameRegister     = 0;
-    pdata->unwindInfo.FrameOffset       = 0;
+    pdata.unwindInfo.FrameRegister     = 0;
+    pdata.unwindInfo.FrameOffset       = 0;
 
-    AssertMsg(requiredUnwindCodeNodeCount <= 34, "We allocate 72 bytes for xdata - 34 (UnwindCodes) * 2 + 4 (UnwindInfo)");
+    AssertMsg(requiredUnwindCodeNodeCount <= MaxRequiredUnwindCodeNodeCount, "We allocate 72 bytes for xdata - 34 (UnwindCodes) * 2 + 4 (UnwindInfo)");
 }
 
 PrologEncoder::UnwindCode *PrologEncoder::GetUnwindCode(unsigned __int8 nodeCount)
@@ -206,7 +185,7 @@ PrologEncoder::UnwindCode *PrologEncoder::GetUnwindCode(unsigned __int8 nodeCoun
     Assert(nodeCount && ((currentUnwindCodeNodeIndex - nodeCount) >= 0));
     currentUnwindCodeNodeIndex -= nodeCount;
 
-    return static_cast<UnwindCode *>(&pdata->unwindInfo.unwindCodes[currentUnwindCodeNodeIndex]);
+    return static_cast<UnwindCode *>(&pdata.unwindInfo.unwindCodes[currentUnwindCodeNodeIndex]);
 }
 
 DWORD PrologEncoder::SizeOfUnwindInfo()
@@ -216,7 +195,7 @@ DWORD PrologEncoder::SizeOfUnwindInfo()
 
 BYTE *PrologEncoder::GetUnwindInfo()
 {
-    return (BYTE *)&pdata->unwindInfo;
+    return (BYTE *)&pdata.unwindInfo;
 }
 
 #else  // !_WIN32
@@ -224,65 +203,51 @@ BYTE *PrologEncoder::GetUnwindInfo()
 //  !_WIN32 x64 unwind uses .eh_frame
 // ----------------------------------------------------------------------------
 
-static const int SMALL_EHFRAME_SIZE = 0x40;
-
 void PrologEncoder::EncodeSmallProlog(uint8 prologSize, size_t size)
 {
-    Assert(ehFrame == nullptr);
-
-    BYTE* buffer = AnewArray(alloc, BYTE, SMALL_EHFRAME_SIZE);
-    ehFrame = Anew(alloc, EhFrame, buffer, SMALL_EHFRAME_SIZE);
-
-    auto fde = ehFrame->GetFDE();
+    auto fde = ehFrame.GetFDE();
 
     // prolog: push rbp
     fde->cfi_advance_loc(1);                    // DW_CFA_advance_loc: 1
     fde->cfi_def_cfa_offset(MachPtr * 2);       // DW_CFA_def_cfa_offset: 16
     fde->cfi_offset(GetDwarfRegNum(LowererMDArch::GetRegFramePointer()), 2); // DW_CFA_offset: r6 (rbp) at cfa-16
 
-    ehFrame->End();
+    ehFrame.End();
 }
 
 DWORD PrologEncoder::SizeOfPData()
 {
-    return ehFrame->Count();
+    return ehFrame.Count();
 }
 
 BYTE* PrologEncoder::Finalize(BYTE *functionStart, DWORD codeSize, BYTE *pdataBuffer)
 {
-    auto fde = ehFrame->GetFDE();
+    auto fde = ehFrame.GetFDE();
     fde->UpdateAddressRange(functionStart, codeSize);
-    return ehFrame->Buffer();
+    return ehFrame.Buffer();
 }
-
-// TODO: We can also pre-calculate size needed based on #push/xmm/saves/stack allocs
-static const int JIT_EHFRAME_SIZE = 0x80;
 
 void PrologEncoder::Begin(size_t prologStartOffset)
 {
-    Assert(ehFrame == nullptr);
     Assert(currentInstrOffset == 0);
-
-    BYTE* buffer = AnewArray(alloc, BYTE, JIT_EHFRAME_SIZE);
-    ehFrame = Anew(alloc, EhFrame, buffer, JIT_EHFRAME_SIZE);
 
     currentInstrOffset = prologStartOffset;
 }
 
 void PrologEncoder::End()
 {
-    ehFrame->End();
+    ehFrame.End();
 }
 
 void PrologEncoder::FinalizeUnwindInfo(BYTE *functionStart, DWORD codeSize)
 {
-    auto fde = ehFrame->GetFDE();
+    auto fde = ehFrame.GetFDE();
     fde->UpdateAddressRange(functionStart, codeSize);
 }
 
 void PrologEncoder::EncodeInstr(IR::Instr *instr, unsigned __int8 size)
 {
-    auto fde = ehFrame->GetFDE();
+    auto fde = ehFrame.GetFDE();
 
     uint8 unwindCodeOp = PrologEncoderMD::GetOp(instr);
 

--- a/lib/JITServer/JITServer.cpp
+++ b/lib/JITServer/JITServer.cpp
@@ -403,19 +403,12 @@ ServerNewInterpreterThunkBlock(
         ServerThreadContext * threadContext = scriptContext->GetThreadContext();
         EmitBufferManager<> * emitBufferManager = scriptContext->GetEmitBufferManager(asmJsThunk != FALSE);
 
-        // REVIEW: OOP JIT should we clear arena at end?
-        ArenaAllocator * arena = scriptContext->GetSourceCodeArena();
-        BYTE * localBuffer = AnewArray(arena, BYTE, bufferSize);
-
         BYTE* remoteBuffer;
         EmitBufferAllocation * allocation = emitBufferManager->AllocateBuffer(bufferSize, &remoteBuffer);
-        if (!allocation)
-        {
-            Js::Throw::OutOfMemory();
-        }
 
+        Assert(bufferSize <= 0x1000); // in case this is changed some day we might switch to use other allocator
+        BYTE  localBuffer[bufferSize];
         InterpreterThunkEmitter::FillBuffer(
-            arena,
             threadContext,
             asmJsThunk != FALSE,
             (intptr_t)remoteBuffer,


### PR DESCRIPTION
looks these allocation is small and can just use stack memory, otherwise we need use a seperater arena allocator or heap allocator to prevent leak.
