### PR TITLE
swb,plugin: print error on unbarried type

### DIFF
--- a/lib/Common/Common.h
+++ b/lib/Common/Common.h
@@ -97,7 +97,6 @@ template<> struct IntMath<int64> { using Type = Int64Math; };
 #include "Core/FinalizableObject.h"
 #include "Memory/RecyclerRootPtr.h"
 #include "Memory/RecyclerFastAllocator.h"
-#include "Memory/RecyclerPointers.h"
 #include "Util/Pinned.h"
 
 // Data Structures 2

--- a/lib/Common/CommonMin.h
+++ b/lib/Common/CommonMin.h
@@ -58,10 +58,12 @@
 namespace Memory
 {
     class ArenaAllocator;
+    class Recycler;
 }
 using namespace Memory;
 #include "Memory/Allocator.h"
 #include "Memory/HeapAllocator.h"
+#include "Memory/RecyclerPointers.h"
 
 // === Data structures Header Files ===
 #include "DataStructures/DefaultContainerLockPolicy.h"


### PR DESCRIPTION
For any write barrier allocations, the allocated type declaration should
be write-barrier decorated. Otherwise we'd see it in "pointerClasses" and
print an error on this type.

Move "RecyclerPointers.h" header file include location earlier to start
examing more GC types.
