### PR TITLE
SAL/TVS Fixes

### DIFF
--- a/lib/Common/Codex/Utf8Helper.h
+++ b/lib/Common/Codex/Utf8Helper.h
@@ -14,9 +14,7 @@ namespace utf8
     /// The returned string is null terminated.
     ///
     template <class Allocator>
-    HRESULT WideStringToNarrow(
-        LPCWSTR sourceString, size_t sourceCount,
-        LPSTR* destStringPtr, size_t* destCount)
+    HRESULT WideStringToNarrow(_In_ LPCWSTR sourceString, size_t sourceCount, _Out_ LPSTR* destStringPtr, _Out_ size_t* destCount)
     {
         size_t cchSourceString = sourceCount;
 
@@ -54,9 +52,7 @@ namespace utf8
     /// The returned string is null terminated.
     ///
     template <class Allocator>
-    HRESULT NarrowStringToWide(
-        LPCSTR sourceString, size_t sourceCount,
-        LPWSTR* destStringPtr, size_t* destCount)
+    HRESULT NarrowStringToWide(_In_ LPCSTR sourceString, size_t sourceCount, _Out_ LPWSTR* destStringPtr, _Out_ size_t* destCount)
     {
         size_t cbSourceString = sourceCount;
         charcount_t cchDestString = utf8::ByteIndexIntoCharacterIndex((LPCUTF8) sourceString, cbSourceString);
@@ -93,21 +89,21 @@ namespace utf8
         static void free(void* ptr, size_t count) { ::free(ptr); }
     };
 
-    inline HRESULT WideStringToNarrowDynamic(LPCWSTR sourceString, LPSTR* destStringPtr)
+    inline HRESULT WideStringToNarrowDynamic(_In_ LPCWSTR sourceString, _Out_ LPSTR* destStringPtr)
     {
         size_t unused;
         return WideStringToNarrow<malloc_allocator>(
             sourceString, wcslen(sourceString), destStringPtr, &unused);
     }
 
-    inline HRESULT NarrowStringToWideDynamic(LPCSTR sourceString, LPWSTR* destStringPtr)
+    inline HRESULT NarrowStringToWideDynamic(_In_ LPCSTR sourceString, _Out_ LPWSTR* destStringPtr)
     {
         size_t unused;
         return NarrowStringToWide<malloc_allocator>(
             sourceString, strlen(sourceString), destStringPtr, &unused);
     }
 
-    inline HRESULT NarrowStringToWideDynamicGetLength(LPCSTR sourceString, LPWSTR* destStringPtr, size_t* destLength)
+    inline HRESULT NarrowStringToWideDynamicGetLength(_In_ LPCSTR sourceString, _Out_ LPWSTR* destStringPtr, _Out_ size_t* destLength)
     {
         return NarrowStringToWide<malloc_allocator>(
             sourceString, strlen(sourceString), destStringPtr, destLength);

--- a/lib/Common/Common/NumberUtilities_strtod.cpp
+++ b/lib/Common/Common/NumberUtilities_strtod.cpp
@@ -2068,25 +2068,23 @@ static int FormatDigitsFixed(byte *pbSrc, byte *pbLim, int wExp10, int nFraction
     return n;
 }
 
-__success(return <= cchDst)
+_Success_(return <= cchDst)
+// The return value is not the number of elements set in pchDst in the 'failure' case.
+// We need to suppress 6101 as it expects us to return 0 in that case.
+#pragma prefast(suppress:6101)
 static int FormatDigitsExponential(
-                            byte *  pbSrc,
-                            byte *  pbLim,
-                            int     wExp10,
-                            int     nFractionDigits,
-                            __out_ecount_part(cchDst,return) char16 * pchDst,
-                            int     cchDst
-                            )
+    _In_reads_bytes_(pbLim - pbSrc) byte *   pbSrc,
+    _In_                            byte *   pbLim,
+    _In_range_(0, 1000)             int      wExp10,
+                                    int      nFractionDigits,
+    _Out_writes_to_(cchDst, return) char16 * pchDst,
+                                    int      cchDst)
 {
     AnalysisAssert(pbLim > pbSrc);
     Assert(pbLim - pbSrc <= kcbMaxRgb);
     AssertArrMem(pbSrc, pbLim - pbSrc);
     AssertArrMem(pchDst, cchDst);
-    AnalysisAssert(wExp10 < 1000);
-
-    __analysis_assume(pbLim > pbSrc);
-    __analysis_assume(pbLim - pbSrc <= kcbMaxRgb);
-    __analysis_assume(wExp10 < 1000);
+    Assert(wExp10 < 1000);
 
     int n = 1; // first digit
 
@@ -2158,7 +2156,6 @@ static int FormatDigitsExponential(
     *pchDst++ = 'e';
     if (--wExp10 < 0)
     {
-#pragma prefast(suppress:26014, "We have calculate the check the buffer size above already")
         *pchDst++ = '-';
         wExp10 = -wExp10;
     }


### PR DESCRIPTION
lib/Common/Codex/Utf8Helper.h:
- UTF8Codex has outdated SAL annotations, but without fixing them we can let SAL know that the pointers are just passed through for the Narrow <-> Wide string conversions.

lib/Common/Common/NumberUtilities_strtod.cpp:
- SAL false positive mitigations left us with some more breaks to do with loop invariants.
- Removing our forced analysis asserts and assumes fixes the analysis!
- Re-enabled a disabled SAL warning.
- Updated SAL to SAL2.
