### PR TITLE
revert InterpreterThunkEmitter field change that was breaking compat with jd

### DIFF
--- a/lib/Backend/InterpreterThunkEmitter.cpp
+++ b/lib/Backend/InterpreterThunkEmitter.cpp
@@ -227,25 +227,13 @@ const BYTE InterpreterThunkEmitter::ThunkSize = sizeof(Call);
 const uint InterpreterThunkEmitter::ThunksPerBlock = (BlockSize - HeaderSize) / ThunkSize;
 
 InterpreterThunkEmitter::InterpreterThunkEmitter(Js::ScriptContext* context, ArenaAllocator* allocator, CustomHeap::CodePageAllocators * codePageAllocators, bool isAsmInterpreterThunk) :
-    emitBufferManager(nullptr),
+    emitBufferManager(allocator, codePageAllocators, /*scriptContext*/ nullptr, _u("Interpreter thunk buffer"), GetCurrentProcess()),
     scriptContext(context),
     allocator(allocator),
     thunkCount(0),
     thunkBuffer(nullptr),
     isAsmInterpreterThunk(isAsmInterpreterThunk)
 {
-    if (!JITManager::GetJITManager()->IsOOPJITEnabled())
-    {
-        emitBufferManager = HeapNew(EmitBufferManager<>, allocator, codePageAllocators, /*scriptContext*/ nullptr, _u("Interpreter thunk buffer"), GetCurrentProcess());
-    }
-}
-
-InterpreterThunkEmitter::~InterpreterThunkEmitter()
-{
-    if (emitBufferManager != nullptr)
-    {
-        HeapDelete(emitBufferManager);
-    }
 }
 
 //
@@ -307,12 +295,12 @@ void InterpreterThunkEmitter::NewThunkBlock()
     Assert(this->thunkCount == 0);
     BYTE* buffer;
 
-    EmitBufferAllocation * allocation = emitBufferManager->AllocateBuffer(BlockSize, &buffer);
+    EmitBufferAllocation * allocation = emitBufferManager.AllocateBuffer(BlockSize, &buffer);
     if (allocation == nullptr) 
     {
         Js::Throw::OutOfMemory();
     }
-    if (!emitBufferManager->ProtectBufferWithExecuteReadWriteForInterpreter(allocation))
+    if (!emitBufferManager.ProtectBufferWithExecuteReadWriteForInterpreter(allocation))
     {
         Js::Throw::OutOfMemory();
     }
@@ -335,7 +323,7 @@ void InterpreterThunkEmitter::NewThunkBlock()
         &this->thunkCount
     );
 
-    if (!emitBufferManager->CommitReadWriteBufferForInterpreter(allocation, buffer, BlockSize))
+    if (!emitBufferManager.CommitReadWriteBufferForInterpreter(allocation, buffer, BlockSize))
     {
         Js::Throw::OutOfMemory();
     }
@@ -725,7 +713,7 @@ InterpreterThunkEmitter::IsInHeap(void* address)
     else
 #endif
     {
-        return emitBufferManager->IsInHeap(address);
+        return emitBufferManager.IsInHeap(address);
     }
 }
 #endif
@@ -757,7 +745,7 @@ void InterpreterThunkEmitter::Close()
     else
 #endif
     {
-        emitBufferManager->Decommit();
+        emitBufferManager.Decommit();
     }
     this->thunkBuffer = nullptr;
     this->thunkCount = 0;

--- a/lib/Backend/InterpreterThunkEmitter.h
+++ b/lib/Backend/InterpreterThunkEmitter.h
@@ -57,7 +57,7 @@ class InterpreterThunkEmitter
 {
 private:
     /* ------- instance methods --------*/
-    EmitBufferManager<> * emitBufferManager;
+    EmitBufferManager<> emitBufferManager;
     SListBase<ThunkBlock> thunkBlocks;
     SListBase<ThunkBlock> freeListedThunkBlocks;
     bool isAsmInterpreterThunk; // To emit address of InterpreterAsmThunk or InterpreterThunk
@@ -130,7 +130,6 @@ public:
     static void* ConvertToEntryPoint(PVOID dynamicInterpreterThunk);
 
     InterpreterThunkEmitter(Js::ScriptContext * context, ArenaAllocator* allocator, CustomHeap::CodePageAllocators * codePageAllocators, bool isAsmInterpreterThunk = false);
-    ~InterpreterThunkEmitter();
     BYTE* GetNextThunk(PVOID* ppDynamicInterpreterThunk);
 
     void Close();
@@ -141,7 +140,7 @@ public:
 #endif
     const EmitBufferManager<>* GetEmitBufferManager() const
     {
-        return emitBufferManager;
+        return &emitBufferManager;
     }
 
     static void FillBuffer(


### PR DESCRIPTION
JD was relying on reading the emitBufferManager and changing it to a pointer instead of direct field breaks compat. This reverts to how it was before my change to move interpreter thunk emitter OOP.