### PR TITLE
Disable tag checks optimization for BailOutOnTaggedValue

### DIFF
--- a/lib/Backend/BailOut.cpp
+++ b/lib/Backend/BailOut.cpp
@@ -2091,7 +2091,15 @@ void BailOutRecord::ScheduleFunctionCodeGen(Js::ScriptFunction * function, Js::S
                 break;
 
             case IR::BailOutOnTaggedValue:
-                rejitReason = RejitReason::FailedTagCheck;
+                if (profileInfo->IsTagCheckDisabled())
+                {
+                    reThunk = true;
+                }
+                else
+                {
+                    profileInfo->DisableTagCheck();
+                    rejitReason = RejitReason::FailedTagCheck;
+                }
                 break;
 
             case IR::BailOutFailedTypeCheck:
@@ -2531,6 +2539,8 @@ void BailOutRecord::ScheduleLoopBodyCodeGen(Js::ScriptFunction * function, Js::S
                 break;
 
             case IR::BailOutOnTaggedValue:
+                profileInfo->DisableTagCheck();
+                executeFunction->SetDontRethunkAfterBailout();
                 rejitReason = RejitReason::FailedTagCheck;
                 break;
 

--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -254,6 +254,8 @@ GlobOpt::GlobOpt(Func * func)
     doPowIntIntTypeSpec(
         doAggressiveIntTypeSpec &&
         (!func->HasProfileInfo() || !func->GetReadOnlyProfileInfo()->IsPowIntIntTypeSpecDisabled())),
+    doTagChecks(
+        (!func->HasProfileInfo() || !func->GetReadOnlyProfileInfo()->IsTagCheckDisabled())),
     isAsmJSFunc(func->GetJITFunctionBody()->IsAsmJsMode())
 {
 }
@@ -5235,7 +5237,7 @@ GlobOpt::OptInstr(IR::Instr *&instr, bool* isInstrRemoved)
 bool
 GlobOpt::OptTagChecks(IR::Instr *instr)
 {
-    if (PHASE_OFF(Js::OptTagChecksPhase, this->func))
+    if (PHASE_OFF(Js::OptTagChecksPhase, this->func) || !this->DoTagChecks())
     {
         return false;
     }
@@ -19949,6 +19951,12 @@ bool
 GlobOpt::DoPowIntIntTypeSpec() const
 {
     return doPowIntIntTypeSpec;
+}
+
+bool
+GlobOpt::DoTagChecks() const
+{
+    return doTagChecks;
 }
 
 bool

--- a/lib/Backend/GlobOpt.h
+++ b/lib/Backend/GlobOpt.h
@@ -1265,6 +1265,7 @@ private:
 
     bool                    doPowIntIntTypeSpec : 1;
     bool                    isAsmJSFunc : 1;
+    bool                    doTagChecks : 1;
     OpndList *              noImplicitCallUsesToInsert;
 
     ValueSetByValueNumber * valuesCreatedForClone;
@@ -1648,6 +1649,7 @@ private:
     bool                    DoBoundCheckHoist() const;
     bool                    DoLoopCountBasedBoundCheckHoist() const;
     bool                    DoPowIntIntTypeSpec() const;
+    bool                    DoTagChecks() const;
 
 private:
     // GlobOptBailout.cpp

--- a/lib/Backend/JITTimeProfileInfo.cpp
+++ b/lib/Backend/JITTimeProfileInfo.cpp
@@ -134,6 +134,7 @@ JITTimeProfileInfo::InitializeJITProfileData(
     data->flags |= profileInfo->IsStackArgOptDisabled() ? Flags_disableStackArgOpt : 0;
     data->flags |= profileInfo->IsLoopImplicitCallInfoDisabled() ? Flags_disableLoopImplicitCallInfo : 0;
     data->flags |= profileInfo->IsPowIntIntTypeSpecDisabled() ? Flags_disablePowIntIntTypeSpec : 0;
+    data->flags |= profileInfo->IsTagCheckDisabled() ? Flags_disableTagCheck : 0;
 }
 
 void
@@ -497,6 +498,12 @@ bool
 JITTimeProfileInfo::IsNoProfileBailoutsDisabled() const
 {
     return TestFlag(Flags_disableNoProfileBailouts);
+}
+
+bool
+JITTimeProfileInfo::IsTagCheckDisabled() const
+{
+    return TestFlag(Flags_disableTagCheck);
 }
 
 bool

--- a/lib/Backend/JITTimeProfileInfo.h
+++ b/lib/Backend/JITTimeProfileInfo.h
@@ -67,6 +67,7 @@ public:
     bool IsStackArgOptDisabled() const;
     bool IsLoopImplicitCallInfoDisabled() const;
     bool IsPowIntIntTypeSpecDisabled() const;
+    bool IsTagCheckDisabled() const;
 
 private:
     enum ProfileDataFlags : int64
@@ -106,7 +107,8 @@ private:
         Flags_hasLdFldCallSiteInfo = 1ll << 31,
         Flags_disableStackArgOpt = 1ll << 32,
         Flags_disableLoopImplicitCallInfo = 1ll << 33,
-        Flags_disablePowIntIntTypeSpec = 1ll << 34
+        Flags_disablePowIntIntTypeSpec = 1ll << 34,
+        Flags_disableTagCheck = 1ll << 35
     };
 
     Js::ProfileId GetProfiledArrayCallSiteCount() const;

--- a/lib/Runtime/Language/DynamicProfileInfo.cpp
+++ b/lib/Runtime/Language/DynamicProfileInfo.cpp
@@ -1558,9 +1558,10 @@ namespace Js
                 _u(" disableNoProfileBailouts: %s")
                 _u(" disableSwitchOpt : %s")
                 _u(" disableEquivalentObjTypeSpec : %s\n")
-                _u(" disableObjTypeSpec_jitLoopBody : %s\n"),
-                _u(" disablePowIntTypeSpec : %s\n"),
-                _u(" disableStackArgOpt : %s\n"),
+                _u(" disableObjTypeSpec_jitLoopBody : %s\n")
+                _u(" disablePowIntTypeSpec : %s\n")
+                _u(" disableStackArgOpt : %s\n")
+                _u(" disableTagCheck : %s\n"),
                 IsTrueOrFalse(this->bits.disableAggressiveIntTypeSpec),
                 IsTrueOrFalse(this->bits.disableAggressiveIntTypeSpec_jitLoopBody),
                 IsTrueOrFalse(this->bits.disableAggressiveMulIntTypeSpec),
@@ -1595,7 +1596,8 @@ namespace Js
                 IsTrueOrFalse(this->bits.disableEquivalentObjTypeSpec),
                 IsTrueOrFalse(this->bits.disableObjTypeSpec_jitLoopBody),
                 IsTrueOrFalse(this->bits.disablePowIntIntTypeSpec),
-                IsTrueOrFalse(this->bits.disableStackArgOpt));
+                IsTrueOrFalse(this->bits.disableStackArgOpt),
+                IsTrueOrFalse(this->bits.disableTagCheck));
         }
     }
 

--- a/lib/Runtime/Language/DynamicProfileInfo.h
+++ b/lib/Runtime/Language/DynamicProfileInfo.h
@@ -511,6 +511,7 @@ namespace Js
             bool disablePowIntIntTypeSpec : 1;
             bool disableLoopImplicitCallInfo : 1;
             bool disableStackArgOpt : 1;
+            bool disableTagCheck : 1;
         } bits;
 
         uint32 m_recursiveInlineInfo; // Bit is set for each callsites where the function is called recursively
@@ -802,6 +803,8 @@ namespace Js
         void DisableObjTypeSpecInJitLoopBody() { this->bits.disableObjTypeSpec_jitLoopBody = true; }
         bool IsPowIntIntTypeSpecDisabled() const { return bits.disablePowIntIntTypeSpec; }
         void DisablePowIntIntTypeSpec() { this->bits.disablePowIntIntTypeSpec = true; }
+        bool IsTagCheckDisabled() const { return bits.disableTagCheck; }
+        void DisableTagCheck() { this->bits.disableTagCheck = true; }
 
         static bool IsCallSiteNoInfo(Js::LocalFunctionId functionId) { return functionId == CallSiteNoInfo; }
         int IncRejitCount() { return this->rejitCount++; }


### PR DESCRIPTION
For BailOutOnTaggedValue, we could not have a chance to update profile when we get tagged value because profile will only be produced when defining the value, not using them. So even rejit after some bailouts will not help because of missing profile on the value type.  This change disable tag checks for rejit when BailOutOnTaggedValue is detected because disable it doesn't hurt perf when the value type is not fixed.