### PR TITLE
Fix incorrect parsing of yield/await in arrow functions

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -2850,22 +2850,26 @@ ParseNodePtr Parser::ParseTerm(BOOL fAllowCall,
         ichMin = m_pscan->IchMinTok();
         iecpMin  = m_pscan->IecpMinTok();
 
+        if (pid == wellKnownPropertyPids.async &&
+            m_scriptContext->GetConfig()->IsES7AsyncAndAwaitEnabled())
+        {
+            isAsyncExpr = true;
+        }
+
+        bool previousAwaitIsKeyword = m_pscan->SetAwaitIsKeyword(isAsyncExpr);
         m_pscan->Scan();
+        m_pscan->SetAwaitIsKeyword(previousAwaitIsKeyword);
 
         // We search for an Async expression (a function declaration or an async lambda expression)
-        if (pid == wellKnownPropertyPids.async &&
-            !m_pscan->FHadNewLine() &&
-            m_scriptContext->GetConfig()->IsES7AsyncAndAwaitEnabled())
+        if (isAsyncExpr && !m_pscan->FHadNewLine())
         {
             if (m_token.tk == tkFUNCTION)
             {
-                isAsyncExpr = true;
                 goto LFunction;
             }
-            else if (m_token.tk == tkID)
+            else if (m_token.tk == tkID || m_token.tk == tkAWAIT)
             {
                 isLambdaExpr = true;
-                isAsyncExpr = true;
                 goto LFunction;
             }
         }
@@ -4735,6 +4739,8 @@ Parse a function definition.
 template<bool buildAST>
 bool Parser::ParseFncDeclHelper(ParseNodePtr pnodeFnc, LPCOLESTR pNameHint, ushort flags, bool *pHasName, bool fUnaryOrParen, bool noStmtContext, bool *pNeedScanRCurly, bool skipFormals)
 {
+    ParseNodePtr pnodeFncParent = GetCurrentFunctionNode();
+    // is the following correct? When buildAST is false, m_currentNodeDeferredFunc can be nullptr on transition to deferred parse from non-deferred
     ParseNodePtr pnodeFncSave = buildAST ? m_currentNodeFunc : m_currentNodeDeferredFunc;
     ParseNodePtr pnodeFncSaveNonLambda = buildAST ? m_currentNodeNonLambdaFunc : m_currentNodeNonLambdaDeferredFunc;
     int32* pAstSizeSave = m_pCurrentAstSize;
@@ -4964,7 +4970,7 @@ bool Parser::ParseFncDeclHelper(ParseNodePtr pnodeFnc, LPCOLESTR pNameHint, usho
 
         if (!skipFormals)
         {
-            this->ParseFncFormals<buildAST>(pnodeFnc, flags);
+            this->ParseFncFormals<buildAST>(pnodeFnc, pnodeFncParent, flags);
         }
 
         // Create function body scope
@@ -5993,14 +5999,14 @@ bool Parser::ParseFncNames(ParseNodePtr pnodeFnc, ParseNodePtr pnodeFncParent, u
 
 void Parser::ValidateFormals()
 {
-    ParseFncFormals<false>(NULL, fFncNoFlgs);
+    ParseFncFormals<false>(nullptr, nullptr, fFncNoFlgs);
     // Eat the tkRParen. The ParseFncDeclHelper caller expects to see it.
     m_pscan->Scan();
 }
 
 void Parser::ValidateSourceElementList()
 {
-    ParseStmtList<false>(NULL, NULL, SM_NotUsed, true);
+    ParseStmtList<false>(nullptr, nullptr, SM_NotUsed, true);
 }
 
 void Parser::UpdateOrCheckForDuplicateInFormals(IdentPtr pid, SList<IdentPtr> *formals)
@@ -6029,12 +6035,22 @@ void Parser::UpdateOrCheckForDuplicateInFormals(IdentPtr pid, SList<IdentPtr> *f
 }
 
 template<bool buildAST>
-void Parser::ParseFncFormals(ParseNodePtr pnodeFnc, ushort flags)
+void Parser::ParseFncFormals(ParseNodePtr pnodeFnc, ParseNodePtr pnodeParentFnc, ushort flags)
 {
     bool fLambda = (flags & fFncLambda) != 0;
     bool fMethod = (flags & fFncMethod) != 0;
     bool fNoArg = (flags & fFncNoArg) != 0;
     bool fOneArg = (flags & fFncOneArg) != 0;
+    bool fAsync = (flags & fFncAsync) != 0;
+
+    bool fPreviousYieldIsKeyword = false;
+    bool fPreviousAwaitIsKeyword = false;
+
+    if (fLambda)
+    {
+        fPreviousYieldIsKeyword = m_pscan->SetYieldIsKeyword(pnodeParentFnc != nullptr && pnodeParentFnc->sxFnc.IsGenerator());
+        fPreviousAwaitIsKeyword = m_pscan->SetAwaitIsKeyword(fAsync || (pnodeParentFnc != nullptr && pnodeParentFnc->sxFnc.IsAsync()));
+    }
 
     Assert(!fNoArg || !fOneArg); // fNoArg and fOneArg can never be true at the same time.
 
@@ -6050,6 +6066,7 @@ void Parser::ParseFncFormals(ParseNodePtr pnodeFnc, ushort flags)
     if (fLambda && m_token.tk == tkID)
     {
         IdentPtr pid = m_token.GetIdentifier(m_phtbl);
+
         CreateVarDeclNode(pid, STFormal, false, nullptr, false);
         CheckPidIsValid(pid);
 
@@ -6060,7 +6077,18 @@ void Parser::ParseFncFormals(ParseNodePtr pnodeFnc, ushort flags)
             Error(ERRsyntax, m_pscan->IchMinTok(), m_pscan->IchLimTok());
         }
 
+        if (fLambda)
+        {
+            m_pscan->SetYieldIsKeyword(fPreviousYieldIsKeyword);
+            m_pscan->SetAwaitIsKeyword(fPreviousAwaitIsKeyword);
+        }
+
         return;
+    }
+    else if (fLambda && m_token.tk == tkAWAIT)
+    {
+        // async await => {}
+        IdentifierExpectedError(m_token);
     }
 
     // Otherwise, must have a parameter list within parens.
@@ -6306,6 +6334,12 @@ void Parser::ParseFncFormals(ParseNodePtr pnodeFnc, ushort flags)
         }
     }
     Assert(m_token.tk == tkRParen);
+
+    if (fLambda)
+    {
+        m_pscan->SetYieldIsKeyword(fPreviousYieldIsKeyword);
+        m_pscan->SetAwaitIsKeyword(fPreviousAwaitIsKeyword);
+    }
 }
 
 template<bool buildAST>
@@ -7947,16 +7981,19 @@ ParseNodePtr Parser::ParseExpr(int oplMin,
                 // binding operator, be it unary or binary.
                 Error(ERRsyntax);
             }
-            if (GetCurrentFunctionNode()->sxFnc.IsGenerator()
-                && m_currentBlockInfo->pnodeBlock->sxBlock.blockType == PnodeBlockType::Parameter)
+            if (m_currentBlockInfo->pnodeBlock->sxBlock.blockType == PnodeBlockType::Parameter)
             {
+                // 'yield' can appear (as a keyword) in parameter scope as formal name or as
+                // expression within a default parameter expression, in either a generator
+                // function or an arrow function contained within a generator function.
+                // In all cases it is an error.
                 Error(ERRsyntax);
             }
         }
         else if (nop == knopAwait)
         {
             if (!m_pscan->AwaitIsKeyword() ||
-                (GetCurrentFunctionNode()->sxFnc.IsAsync() && m_currentScope->GetScopeType() == ScopeType_Parameter))
+                m_currentScope->GetScopeType() == ScopeType_Parameter)
             {
                 // As with the 'yield' keyword, the case where 'await' is scanned as a keyword (tkAWAIT)
                 // but the scanner is not treating await as a keyword (!m_pscan->AwaitIsKeyword())
@@ -8299,8 +8336,8 @@ ParseNodePtr Parser::ParseExpr(int oplMin,
             {
                 ichMin = m_pscan->IchMinTok();
                 iecpMin = m_pscan->IecpMinTok();
-                m_pscan->Scan();
 
+                m_pscan->Scan();
                 if ((m_token.tk == tkID || m_token.tk == tkLParen) && !m_pscan->FHadNewLine())
                 {
                     flags |= fFncAsync;
@@ -11129,6 +11166,7 @@ HRESULT Parser::ParseFunctionInBackground(ParseNodePtr pnodeFnc, ParseContext *p
     pnodeFnc->sxFnc.pnodeBody = nullptr;
     pnodeFnc->sxFnc.nestedCount = 0;
 
+    ParseNodePtr pnodeParentFnc = GetCurrentFunctionNode();
     m_currentNodeFunc = pnodeFnc;
     m_currentNodeDeferredFunc = nullptr;
     m_ppnodeScope = nullptr;
@@ -11148,7 +11186,7 @@ HRESULT Parser::ParseFunctionInBackground(ParseNodePtr pnodeFnc, ParseContext *p
         m_pscan->Scan();
 
         m_ppnodeVar = &pnodeFnc->sxFnc.pnodeParams;
-        this->ParseFncFormals<true>(pnodeFnc, fFncNoFlgs);
+        this->ParseFncFormals<true>(pnodeFnc, pnodeParentFnc, fFncNoFlgs);
 
         if (m_token.tk == tkRParen)
         {

--- a/lib/Parser/Parse.h
+++ b/lib/Parser/Parse.h
@@ -760,7 +760,7 @@ private:
     template<bool buildAST> ParseNodePtr ParseMemberGetSet(OpCode nop, LPCOLESTR* ppNameHint);
     template<bool buildAST> ParseNodePtr ParseFncDecl(ushort flags, LPCOLESTR pNameHint = NULL, const bool needsPIDOnRCurlyScan = false, bool resetParsingSuperRestrictionState = true, bool fUnaryOrParen = false);
     template<bool buildAST> bool ParseFncNames(ParseNodePtr pnodeFnc, ParseNodePtr pnodeFncParent, ushort flags, ParseNodePtr **pLastNodeRef);
-    template<bool buildAST> void ParseFncFormals(ParseNodePtr pnodeFnc, ushort flags);
+    template<bool buildAST> void ParseFncFormals(ParseNodePtr pnodeFnc, ParseNodePtr pnodeParentFnc, ushort flags);
     template<bool buildAST> bool ParseFncDeclHelper(ParseNodePtr pnodeFnc, LPCOLESTR pNameHint, ushort flags, bool *pHasName, bool fUnaryOrParen, bool noStmtContext, bool *pNeedScanRCurly, bool skipFormals = false);
     template<bool buildAST> void ParseExpressionLambdaBody(ParseNodePtr pnodeFnc);
     template<bool buildAST> void UpdateCurrentNodeFunc(ParseNodePtr pnodeFnc, bool fLambda);

--- a/test/es6/generators-syntax.js
+++ b/test/es6/generators-syntax.js
@@ -190,7 +190,28 @@ var tests = [
             assert.areEqual({value: undefined, done: true}, g.next(), "Generator is closed");
         }
     },
-    // TODO: add test case for function* gfoo() { (yield) => { /* use yield here */ } }
+    {
+        name: "yield is a keyword and disallowed within arrow function parameter syntax",
+        body: function () {
+            assert.throws(function () { eval("function* gf() { var a = yield => { }; }"); }, SyntaxError, "yield cannot appear as the formal name of an unparenthesized arrow function parameter list", "Syntax error");
+            assert.throws(function () { eval("function* gf() { var a = (yield) => { }; }"); }, SyntaxError, "yield cannot appear as a formal name within parenthesized arrow function parameter list (single formal)", "The use of a keyword for an identifier is invalid");
+            assert.throws(function () { eval("function* gf() { var a = (x, y, yield) => { }; }"); }, SyntaxError, "yield cannot appear as a formal name within parenthesized arrow function parameter list (middle formal)", "The use of a keyword for an identifier is invalid");
+            assert.throws(function () { eval("function* gf() { var a = (x, yield, y) => { }; }"); }, SyntaxError, "yield cannot appear as a formal name within parenthesized arrow function parameter list (last formal)", "The use of a keyword for an identifier is invalid");
+
+            assert.throws(function () { eval("function* gf() { var a = (x = yield) => { }; }"); }, SyntaxError, "nullary yield expression is disallowed within arrow function default parameter expression (single formal)", "Syntax error");
+            assert.throws(function () { eval("function* gf() { var a = (x, y = yield, z = 0) => { }; }"); }, SyntaxError, "nullary yield expression is disallowed within arrow function default parameter expression (middle formal)", "Syntax error");
+            assert.throws(function () { eval("function* gf() { var a = (x, y, z = yield) => { }; }"); }, SyntaxError, "nullary yield expression is disallowed within arrow function default parameter expression (last formal)", "Syntax error");
+
+            assert.throws(function () { eval("function* gf() { var a = (x = yield 0) => { }; }"); }, SyntaxError, "unary yield expression is disallowed within arrow function default parameter expression (single formal)", "Syntax error");
+            assert.throws(function () { eval("function* gf() { var a = (x, y = yield 0, z = 0) => { }; }"); }, SyntaxError, "unary yield expression is disallowed within arrow function default parameter expression (middle formal)", "Syntax error");
+            assert.throws(function () { eval("function* gf() { var a = (x, y, z = yield 0) => { }; }"); }, SyntaxError, "unary yield expression is disallowed within arrow function default parameter expression (last formal)", "Syntax error");
+
+            assert.throws(function () { eval("function* gf() { var a = (x = yield* 0) => { }; }"); }, SyntaxError, "yield* expression is disallowed within arrow function default parameter expression (single formal)", "Syntax error");
+            assert.throws(function () { eval("function* gf() { var a = (x, y = yield* 0, z = 0) => { }; }"); }, SyntaxError, "yield* expression is disallowed within arrow function default parameter expression (middle formal)", "Syntax error");
+            assert.throws(function () { eval("function* gf() { var a = (x, y, z = yield* 0) => { }; }"); }, SyntaxError, "yield* expression is disallowed within arrow function default parameter expression (last formal)", "Syntax error");
+            assert.throws(function () { eval("function *gf() { (a = (yield) => {}) => {}; }"); }, SyntaxError, "yield expression is disallowed within arrow function default parameter expression in nested case too", "The use of a keyword for an identifier is invalid");
+        }
+    },
 ];
 
 testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/es7/asyncawait-syntax.js
+++ b/test/es7/asyncawait-syntax.js
@@ -189,6 +189,28 @@ var tests = [
             assert.throws(function () { eval("async function af(x) { class x { } }"); }, SyntaxError, "class with same name as formal is an error", "Let/Const redeclaration");
         }
     },
+    {
+        name: "await is a keyword and disallowed within arrow function parameter syntax",
+        body: function () {
+            assert.throws(function () { eval("async function af() { var a = await => { }; }"); }, SyntaxError, "await cannot appear as the formal name of an unparenthesized arrow function parameter list", "Syntax error");
+            assert.throws(function () { eval("async function af() { var a = (await) => { }; }"); }, SyntaxError, "await cannot appear as a formal name within parenthesized arrow function parameter list (single formal)", "Syntax error");
+            assert.throws(function () { eval("async function af() { var a = (x, y, await) => { }; }"); }, SyntaxError, "await cannot appear as a formal name within parenthesized arrow function parameter list (middle formal)", "Syntax error");
+            assert.throws(function () { eval("async function af() { var a = (x, await, y) => { }; }"); }, SyntaxError, "await cannot appear as a formal name within parenthesized arrow function parameter list (last formal)", "Syntax error");
+
+            assert.throws(function () { eval("async function af() { var a = (x = await 0) => { }; }"); }, SyntaxError, "await expression is disallowed within arrow function default parameter expression (single formal)", "'await' expression not allowed in this context");
+            assert.throws(function () { eval("async function af() { var a = (x, y = await 0, z = 0) => { }; }"); }, SyntaxError, "await expression is disallowed within arrow function default parameter expression (middle formal)", "'await' expression not allowed in this context");
+            assert.throws(function () { eval("async function af() { var a = (x, y, z = await 0) => { }; }"); }, SyntaxError, "await expression is disallowed within arrow function default parameter expression (last formal)", "'await' expression not allowed in this context");
+            
+            assert.throws(function () { eval("async (a, await) => { }"); }, SyntaxError, "await cannot appear as the formal name of a parathensized async arrow function", "The use of a keyword for an identifier is invalid");
+            assert.throws(function () { eval("async await => { }"); }, SyntaxError, "await cannot appear as the formal name of a unparathensized async arrow function", "The use of a keyword for an identifier is invalid");
+            assert.throws(function () { eval("function () { a = async await => { } }"); }, SyntaxError, "await cannot appear as the formal name of a unparathensized async arrow function expression", "Expected identifier");
+            assert.throws(function () { eval("async (a, b = await 1) => {}"); }, SyntaxError, "await expression cannot appear in the formals of an async arrow function", "Expected ')'");
+            assert.throws(function () { eval("async () => { await => { }; }"); }, SyntaxError, "await cannot appear as the formal name of an unparathensized arrow function within an async arrow function", "Syntax error");
+            assert.throws(function () { eval("async () => { (a, await) => { }; }"); }, SyntaxError, "await cannot appear as the formal name of a parathensized arrow function within an async arrow function", "Syntax error");
+            assert.throws(function () { eval("async () => { (x, y, z = await 0) => { }; }"); }, SyntaxError, "await expression is disallowed within default parameter expression of an arrow function which is inside an async arrow function", "'await' expression not allowed in this context");
+            assert.throws(function () { eval("async function af() { (b = (c = await => {}) => {}) => {}; }"); }, SyntaxError, "await cannot appear as the formal name of an unparathensized arrow function in a nested case too", "Syntax error");
+        }
+    },
 ];
 
 testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });


### PR DESCRIPTION
The spec carries the Yield/Await parameter forward into the parameter
list grammar production for arrow functions specifically. We did not
adhere to this and erroneously treated these as identifiers in arrow
function parameter lists.

Fixes #333.  See it for more details.
