### PR TITLE
Fix SIMDCheckUint32Number when input value is not in range

### DIFF
--- a/lib/Runtime/Language/SimdUtils.cpp
+++ b/lib/Runtime/Language/SimdUtils.cpp
@@ -43,7 +43,7 @@ namespace Js
         uint32 uint32Value;
         Assert(index != NULL);
 
-        uint32Value = SIMDCheckUint32Number(scriptContext, index);
+        uint32Value = SIMDCheckUint32Number<true>(scriptContext, index);
         return uint32Value;
     }
 
@@ -60,13 +60,14 @@ namespace Js
     }
 
     // Is Number with uint32 value.
+    template<bool acceptNegZero>
     uint32 SIMDUtils::SIMDCheckUint32Number(ScriptContext* scriptContext, const Var value)
     {
         int32 int32Value;
 
         if (JavascriptNumber::Is(value))
         {
-            if (!JavascriptNumber::TryGetInt32Value(JavascriptNumber::GetValue(value), &int32Value))
+            if (!JavascriptNumber::TryGetInt32Value<acceptNegZero>(JavascriptNumber::GetValue(value), &int32Value))
             {
                 JavascriptError::ThrowRangeError(scriptContext, JSERR_ArgumentOutOfRange);
             }
@@ -77,7 +78,10 @@ namespace Js
         }
         else
         {
-            return static_cast<int32>(JavascriptConversion::ToNumber(value, scriptContext));
+            if (!JavascriptNumber::TryGetInt32Value<acceptNegZero>(JavascriptConversion::ToNumber(value, scriptContext), &int32Value))
+            {
+                JavascriptError::ThrowRangeError(scriptContext, JSERR_ArgumentOutOfRange);
+            }
         }
         return int32Value;
     }
@@ -188,7 +192,7 @@ namespace Js
             JavascriptError::ThrowTypeError(scriptContext, JSERR_SimdInvalidArgType, _u("Simd typed array access"));
         }
 
-        *index = SIMDCheckUint32Number(scriptContext, arg2);
+        *index = SIMDCheckUint32Number<true>(scriptContext, arg2);
 
         // bound check
         *tarray = TypedArrayBase::FromVar(arg1);

--- a/lib/Runtime/Language/SimdUtils.h
+++ b/lib/Runtime/Language/SimdUtils.h
@@ -288,6 +288,7 @@ namespace Js {
         ///////////////////////////////////////////
         static SIMDValue SIMDLdData(const SIMDValue *data, uint8 dataWidth);
         static void SIMDStData(SIMDValue *data, const SIMDValue simdValue, uint8 dataWidth);
+        template<bool acceptNegZero = false>
         static uint32 SIMDCheckUint32Number(ScriptContext* scriptContext, const Var value);
         static bool SIMDIsSupportedTypedArray(Var value);
         static SIMDValue*  SIMDCheckTypedArrayAccess(Var arg1, Var arg2, TypedArrayBase **tarray, int32 *index, uint32 dataWidth, ScriptContext *scriptContext);


### PR DESCRIPTION
JavascriptConversion::ToNumber on a string can result in -NaN, static_cast
on this is not valid. A RangeError should be thrown. Handle this scenario
in SIMDCheckUint32Number.
