### PR TITLE
pal : Cherry-pick fix for not blocking signals in ubuntu

### DIFF
--- a/pal/src/exception/signal.cpp
+++ b/pal/src/exception/signal.cpp
@@ -155,8 +155,6 @@ void SEHCleanupSignals()
 {
     TRACE("Restoring default signal handlers\n");
 
-    // Do not remove handlers for SIGUSR1 and SIGUSR2. They must remain so threads can be suspended
-    // during cleanup after this function has been called.
     restore_signal(SIGILL, &g_previous_sigill);
     restore_signal(SIGTRAP, &g_previous_sigtrap);
     restore_signal(SIGFPE, &g_previous_sigfpe);

--- a/pal/src/include/pal/seh.hpp
+++ b/pal/src/include/pal/seh.hpp
@@ -25,8 +25,7 @@ Abstract:
 #include "pal/palinternal.h"
 #include "pal/corunix.hpp"
 
-// Uncomment this define to turn off the signal handling thread.
-// #define DO_NOT_USE_SIGNAL_HANDLING_THREAD
+#define DO_NOT_USE_SIGNAL_HANDLING_THREAD
 
 /*++
 Function :

--- a/pal/src/include/pal/threadsusp.hpp
+++ b/pal/src/include/pal/threadsusp.hpp
@@ -361,11 +361,6 @@ namespace CorUnix
                 DWORD *pdwSuspendCount
             );
 
-#if !HAVE_MACH_EXCEPTIONS
-            static 
-            VOID InitializeSignalSets();
-#endif // !HAVE_MACH_EXCEPTIONS
-
             VOID InitializeSuspensionLock();
 
             void SetBlockingPipe(

--- a/pal/src/thread/pal_thread.cpp
+++ b/pal/src/thread/pal_thread.cpp
@@ -1731,14 +1731,6 @@ CorUnix::InitializeGlobalThreadData(
         }
     }
 
-#if !HAVE_MACH_EXCEPTIONS
-    //
-    // Initialize the thread suspension signal sets.
-    //
-    
-    CThreadSuspensionInfo::InitializeSignalSets();
-#endif // !HAVE_MACH_EXCEPTIONS
-
     return palError;
 }
 

--- a/pal/src/thread/threadsusp.cpp
+++ b/pal/src/thread/threadsusp.cpp
@@ -64,10 +64,6 @@ performing one suspension or resumption in the PAL at a time. */
 static LONG g_ssSuspensionLock = 0;
 #endif
 
-#if !HAVE_MACH_EXCEPTIONS
-static sigset_t smDefaultmask; // masks signals that the PAL handles as exceptions.
-#endif // !HAVE_MACH_EXCEPTIONS
-
 /*++
 Function:
   InternalSuspendNewThreadFromData
@@ -770,56 +766,6 @@ CThreadSuspensionInfo::WaitOnResumeSemaphore()
 #endif // USE_POSIX_SEMAPHORES
 }
 
-#if !HAVE_MACH_EXCEPTIONS
-/*++
-Function:
-  InitializeSignalSets
-  
-InitializeSignalSets initializes the signal masks used for thread
-suspension operations. Each thread's signal mask is initially set
-to smDefaultMask in InitializePreCreate. This mask blocks SIGUSR2,
-and SIGUSR1 if suspension using signals is off. This mask
-also blocks common signals so they will be handled by the PAL's
-signal handling thread. 
---*/
-VOID
-CThreadSuspensionInfo::InitializeSignalSets()
-{
-    sigemptyset(&smDefaultmask);
-
-#ifndef DO_NOT_USE_SIGNAL_HANDLING_THREAD
-    // The default signal mask masks all common signals except those that represent 
-    // synchronous exceptions in the PAL or are used by the system (e.g. SIGPROF on BSD).
-    // Note that SIGPROF is used by the BSD thread scheduler and masking it caused a 
-    // significant reduction in performance.
-    sigaddset(&smDefaultmask, SIGHUP);
-    sigaddset(&smDefaultmask, SIGABRT);
-#ifdef SIGEMT
-    sigaddset(&smDefaultmask, SIGEMT);
-#endif
-    sigaddset(&smDefaultmask, SIGSYS);
-    sigaddset(&smDefaultmask, SIGALRM);
-    sigaddset(&smDefaultmask, SIGURG);
-    sigaddset(&smDefaultmask, SIGTSTP);
-    sigaddset(&smDefaultmask, SIGCONT);
-    sigaddset(&smDefaultmask, SIGCHLD);
-    sigaddset(&smDefaultmask, SIGTTIN);
-    sigaddset(&smDefaultmask, SIGTTOU);
-    sigaddset(&smDefaultmask, SIGIO);
-    sigaddset(&smDefaultmask, SIGXCPU);
-    sigaddset(&smDefaultmask, SIGXFSZ);
-    sigaddset(&smDefaultmask, SIGVTALRM);
-    sigaddset(&smDefaultmask, SIGWINCH);
-#ifdef SIGINFO
-    sigaddset(&smDefaultmask, SIGINFO);
-#endif
-    sigaddset(&smDefaultmask, SIGPIPE);
-    sigaddset(&smDefaultmask, SIGUSR1);
-    sigaddset(&smDefaultmask, SIGUSR2);
-#endif // DO_NOT_USE_SIGNAL_HANDLING_THREAD
-}
-#endif // !HAVE_MACH_EXCEPTIONS
-
 /*++
 Function:
   InitializeSuspensionLock
@@ -987,25 +933,6 @@ CThreadSuspensionInfo::InitializePreCreate()
 
     m_fSemaphoresInitialized = TRUE;
 #endif // USE_POSIX_SEMAPHORES
-
-#if !HAVE_MACH_EXCEPTIONS
-    // This signal mask blocks SIGUSR2 when signal suspension is turned on
-    // (SIGUSR2 must be blocked for signal suspension), and masks other signals
-    // when the signal waiting thread is turned on. We must use SIG_SETMASK 
-    // so all threads start with the same signal mask. Otherwise, issues can arise.
-    // For example, on BSD using suspension with signals, the control handler 
-    // routine thread, spawned from the signal handling thread, inherits the 
-    // signal handling thread's mask which blocks SIGUSR1. Thus, the
-    // control handler routine thread cannot be suspended. Using SETMASK 
-    // ensures that SIGUSR1 is not blocked.
-    
-    iError = pthread_sigmask(SIG_SETMASK, &smDefaultmask, NULL);
-    if (iError != 0)
-    {
-        ASSERT("pthread sigmask(SIG_SETMASK, &smDefaultmask) returned %d\n", iError);
-        goto InitializePreCreateExit;
-    }
-#endif // !HAVE_MACH_EXCEPTIONS
 
     // Initialization was successful.
     palError = NO_ERROR;


### PR DESCRIPTION
Behavior : I was investigating a hang in node-cc on Ubuntu. The repro was that parent process spawns child process and waits (_epoll in libuv) to receive `SIGCHLD` signal from child process when it terminates. Parent process never receives this signal. Looking at `/proc/<pid>/status` says that `SIGCHLD` is in `SigBlk` (signal blocked) and `ShdPnd` (shared pending signal) state.

Problem: In UNIX, parent process can mask certain signals from receiving for brief period of time so that signal requests that comes to the parent process doesn’t interfere what it is processing currently. When we create `NativeCodeGenerator`, it calls PAL’s `InitializePreCreate()` which blocks `SIGCHLD` from receiving. Later when libuv waits for `SIGCHLD` it never gets it because it was masked (or blocked) by PAL. Searching on PAL's repo, realized they already fixed the issue. So cherry picking https://github.com/dotnet/coreclr/pull/4863.