### PR TITLE
swb: annotate BaseDictionary (partial)

### DIFF
--- a/lib/Common/DataStructures/BaseDictionary.h
+++ b/lib/Common/DataStructures/BaseDictionary.h
@@ -90,17 +90,17 @@ namespace JsUtil
         friend class Js::RemoteDictionary<BaseDictionary>;
         template <typename ValueOrKey> struct ComparerType { typedef Comparer<ValueOrKey> Type; }; // Used by diagnostics to access Comparer type
 
-        int* buckets;
-        EntryType* entries;
-        AllocatorType* alloc;
-        int size;
-        uint bucketCount;
-        int count;
-        int freeList;
-        int freeCount;
+        Pointer(int, TAllocator) buckets;
+        Pointer(EntryType, TAllocator) entries;
+        PointerNoBarrier(AllocatorType) alloc;
+        Field(int) size;
+        Field(uint) bucketCount;
+        Field(int) count;
+        Field(int) freeList;
+        Field(int) freeCount;
 
 #if PROFILE_DICTIONARY
-        DictionaryStats *stats;
+        PointerNoBarrier(DictionaryStats) stats;
 #endif
         enum InsertOperations
         {
@@ -179,11 +179,8 @@ namespace JsUtil
             freeList = other.freeList;
             freeCount = other.freeCount;
 
-            size_t copySize = bucketCount * sizeof(buckets[0]);
-            js_memcpy_s(buckets, copySize, other.buckets, copySize);
-
-            copySize = size * sizeof(entries[0]);
-            js_memcpy_s(entries, copySize, other.entries, copySize);
+            CopyArray<TAllocator>(buckets, bucketCount, other.buckets, bucketCount);
+            CopyArray<TAllocator, EntryType, ValueType>(entries, size, other.entries, size);
 
 #if PROFILE_DICTIONARY
             stats = DictionaryStats::Create(typeid(this).name(), size);
@@ -698,11 +695,8 @@ namespace JsUtil
             freeList = other->freeList;
             freeCount = other->freeCount;
 
-            size_t copySize = bucketCount * sizeof(buckets[0]);
-            js_memcpy_s(buckets, copySize, other->buckets, copySize);
-
-            copySize = size * sizeof(entries[0]);
-            js_memcpy_s(entries, copySize, other->entries, copySize);
+            CopyArray<TAllocator>(buckets, bucketCount, other->buckets, bucketCount);
+            CopyArray<TAllocator, EntryType, ValueType>(entries, size, other->entries, size);
 
 #if PROFILE_DICTIONARY
             stats = DictionaryStats::Create(typeid(this).name(), size);
@@ -860,9 +854,14 @@ namespace JsUtil
             int initSize = max(capacity, 4);
             uint initBucketCount = SizePolicy::GetBucketSize(initSize);
             AssertMsg(initBucketCount > 0, "Size returned by policy should be greater than 0");
-            Allocate(&buckets, &entries, initBucketCount, initSize);
 
-            // Allocation can throw - assign the size only after allocation has succeeded.
+            int* newBuckets = nullptr;
+            EntryType* newEntries = nullptr;
+            Allocate(&newBuckets, &newEntries, initBucketCount, initSize);
+
+            // Allocation can throw - assign only after allocation has succeeded.
+            this->buckets = newBuckets;
+            this->entries = newEntries;
             this->bucketCount = initBucketCount;
             this->size = initSize;
             Assert(this->freeCount == 0);
@@ -1002,7 +1001,7 @@ namespace JsUtil
             {
                 // no need to rehash
                 newEntries = AllocateEntries(newSize);
-                js_memcpy_s(newEntries, sizeof(EntryType) * newSize, entries, sizeof(EntryType) * count);
+                CopyArray<TAllocator, EntryType, ValueType>(newEntries, newSize, entries, count);
 
                 DeleteEntries(entries, size);
 
@@ -1012,7 +1011,7 @@ namespace JsUtil
             }
 
             Allocate(&newBuckets, &newEntries, newBucketCount, newSize);
-            js_memcpy_s(newEntries, sizeof(EntryType) * newSize, entries, sizeof(EntryType) * count);
+            CopyArray<TAllocator, EntryType, ValueType>(newEntries, newSize, entries, count);
 
             // When TAllocator is of type Recycler, it is possible that the Allocate above causes a collection, which
             // in turn can cause entries in the dictionary to be removed - i.e. the dictionary contains weak references
@@ -1037,10 +1036,10 @@ namespace JsUtil
             if (stats)
                 stats->Resize(newSize, /*emptyBuckets=*/ newSize - size);
 #endif
-            buckets = newBuckets;
+            this->buckets = newBuckets;
+            this->entries = newEntries;
             bucketCount = newBucketCount;
             size = newSize;
-            entries = newEntries;
         }
 
         __ecount(bucketCount) int *AllocateBuckets(DECLSPEC_GUARD_OVERFLOW const uint bucketCount)
@@ -1560,7 +1559,7 @@ namespace JsUtil
     class SynchronizedDictionary: protected BaseDictionary<TKey, TValue, TAllocator, SizePolicy, Comparer, Entry>
     {
     private:
-        SyncObject* syncObj;
+        PointerNoBarrier(SyncObject) syncObj;
 
         typedef BaseDictionary<TKey, TValue, TAllocator, SizePolicy, Comparer, Entry> Base;
     public:
@@ -1812,4 +1811,3 @@ namespace JsUtil
         PREVENT_COPY(SynchronizedDictionary);
     };
 }
-

--- a/lib/Common/DataStructures/DefaultContainerLockPolicy.h
+++ b/lib/Common/DataStructures/DefaultContainerLockPolicy.h
@@ -14,7 +14,7 @@ namespace Js
         {
         public:
             template <class SyncObject>
-            NoLock(SyncObject*)
+            NoLock(const SyncObject&)
             {
                 // No lock, do nothing.
             }

--- a/lib/Common/Exceptions/Throw.cpp
+++ b/lib/Common/Exceptions/Throw.cpp
@@ -37,6 +37,7 @@ namespace Memory {
 using namespace Memory;
 #include "Memory/Allocator.h"
 #include "Memory/HeapAllocator.h"
+#include "Memory/RecyclerPointers.h"
 
 // Data structure
 #include "DataStructures/Comparer.h"

--- a/lib/Common/Memory/RecyclerWriteBarrierManager.cpp
+++ b/lib/Common/Memory/RecyclerWriteBarrierManager.cpp
@@ -57,7 +57,7 @@ X64WriteBarrierCardTableManager::OnThreadInit()
     ULONG_PTR stackEnd = 0;
     ::GetCurrentThreadStackLimits(&stackEnd, &stackBase);
 #endif
-    
+
     size_t numPages = (stackBase - stackEnd) / AutoSystemInfo::PageSize;
     // stackEnd is the lower boundary
     return OnSegmentAlloc((char*) stackEnd, numPages);
@@ -283,11 +283,11 @@ RecyclerWriteBarrierManager::WriteBarrier(void * address)
 
 
 void
-RecyclerWriteBarrierManager::WriteBarrier(void * address, size_t ptrCount)
+RecyclerWriteBarrierManager::WriteBarrier(void * address, size_t bytes)
 {
 #ifdef RECYCLER_WRITE_BARRIER_BYTE
     uintptr_t startIndex = GetCardTableIndex(address);
-    char * endAddress = (char *)Math::Align<INT_PTR>((INT_PTR)((char *)address + sizeof(void *) * ptrCount), s_WriteBarrierPageSize);
+    char * endAddress = (char *)Math::Align<INT_PTR>((INT_PTR)((char *)address + bytes), s_WriteBarrierPageSize);
     uintptr_t endIndex = GetCardTableIndex(endAddress);
     Assert(startIndex <= endIndex);
     memset(cardTable + startIndex, 1, endIndex - startIndex);
@@ -297,7 +297,7 @@ RecyclerWriteBarrierManager::WriteBarrier(void * address, size_t ptrCount)
     uint bitMask = 0xFFFFFFFF << bitShift;
     uint cardIndex = ((uint)address) / s_BytesPerCard);
 
-    char * endAddress = (char *)Math::Align((INT_PTR)((char *)address + sizeof(void *) * ptrCount), s_BytesPerCardBit);
+    char * endAddress = (char *)Math::Align((INT_PTR)((char *)address + bytes), s_BytesPerCardBit);
     char * alignedAddress = (char *)Math::Align((INT_PTR)address, s_WriteBarrierPageSize);
     if (alignedAddress > endAddress)
     {

--- a/lib/Common/Memory/RecyclerWriteBarrierManager.h
+++ b/lib/Common/Memory/RecyclerWriteBarrierManager.h
@@ -123,7 +123,7 @@ class RecyclerWriteBarrierManager
 {
 public:
     static void WriteBarrier(void * address);
-    static void WriteBarrier(void * address, size_t ptrCount);
+    static void WriteBarrier(void * address, size_t bytes);
 
     // For JIT
     static uintptr_t GetCardTableIndex(void * address);

--- a/lib/Common/Memory/WriteBarrierMacros.h
+++ b/lib/Common/Memory/WriteBarrierMacros.h
@@ -12,7 +12,7 @@
 // Usage:
 //   In general, don't need to use anything, just use the macros to annotate your fields
 //
-//   If you want to force your fields to always generate the right write-barrier types, 
+//   If you want to force your fields to always generate the right write-barrier types,
 //   at the start of the file, add the following:
 //     #define FORCE_USE_WRITE_BARRIER
 //     #include <Memory/WriteBarrierMacros.h>
@@ -27,34 +27,34 @@
 #define PushMacro(x) __pragma(push_macro( #x ))
 
 #define SAVE_WRITE_BARRIER_MACROS() \
-    PushMacro("PointerNoBarrier") \
     PushMacro("Field") \
+    PushMacro("PointerNoBarrier") \
     PushMacro("Pointer")
 
 #define RESTORE_WRITE_BARRIER_MACROS() \
-    PopMacro("PointerNoBarrier") \
     PopMacro("Field") \
+    PopMacro("PointerNoBarrier") \
     PopMacro("Pointer")
 
 #endif
 
 #ifdef FORCE_USE_WRITE_BARRIER
 SAVE_WRITE_BARRIER_MACROS()
-#undef PointerNoBarrier
 #undef Field
+#undef PointerNoBarrier
 #undef Pointer
 #endif
 
 // TODO: Turn off these annotations on Win32
 #if defined(__clang__) || defined(FORCE_USE_WRITE_BARRIER)
 // Various macros for defining field attributes
-#define PointerNoBarrier(type) NoWriteBarrierPtr<type>
 #define Field(type) NoWriteBarrierField<type>
-#define Pointer(type) WriteBarrierPtr<type>
+#define PointerNoBarrier(type) NoWriteBarrierPtr<type>
+#define Pointer(type, ...) typename WriteBarrierPtrTraits<type, ##__VA_ARGS__>::Ptr
 #else
-#define PointerNoBarrier(type) type*
 #define Field(type) type
-#define Pointer(type) type*
+#define PointerNoBarrier(type) type*
+#define Pointer(type, ...) type*
 #endif
 
 #undef FORCE_USE_WRITE_BARRIER

--- a/lib/Runtime/Base/AuxPtrs.h
+++ b/lib/Runtime/Base/AuxPtrs.h
@@ -142,7 +142,7 @@ namespace Js
     inline void* AuxPtrs<T, FieldsEnum>::Get(FieldsEnum e)
     {
         uint8 u = (uint8)e;
-        return offsets[u] == (uint8)FieldsEnum::Invalid ? nullptr : ptrs[offsets[u]];
+        return offsets[u] == (uint8)FieldsEnum::Invalid ? nullptr : (void*)ptrs[offsets[u]];
     }
     template<class T, typename FieldsEnum>
     inline bool AuxPtrs<T, FieldsEnum>::Set(FieldsEnum e, void* p)

--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -4722,7 +4722,8 @@ void ScriptContext::RegisterPrototypeChainEnsuredToHaveOnlyWritableDataPropertie
 
 #if ENABLE_PROFILE_INFO
     template<template<typename> class BarrierT>
-    void ScriptContext::AddDynamicProfileInfo(FunctionBody * functionBody, BarrierT<DynamicProfileInfo>& dynamicProfileInfo)
+    void ScriptContext::AddDynamicProfileInfo(
+        FunctionBody * functionBody, BarrierT<DynamicProfileInfo>& dynamicProfileInfo)
     {
         Assert(functionBody->GetScriptContext() == this);
         Assert(functionBody->HasValidSourceInfo());
@@ -4777,7 +4778,6 @@ void ScriptContext::RegisterPrototypeChainEnsuredToHaveOnlyWritableDataPropertie
         Assert(dynamicProfileInfo != nullptr);
     }
     template void  ScriptContext::AddDynamicProfileInfo<WriteBarrierPtr>(FunctionBody *, WriteBarrierPtr<DynamicProfileInfo>&);
-    template void  ScriptContext::AddDynamicProfileInfo<NoWriteBarrierPtr>(FunctionBody *, NoWriteBarrierPtr<DynamicProfileInfo>&);
 #endif
 
     CharClassifier const * ScriptContext::GetCharClassifier(void) const


### PR DESCRIPTION
Expand `Pointer` macro to choose `WriteBarrierPtr/NoWriteBarrierPtr`
based on optional `Allocator` type using `WriteBarrierPtrTraits`.
(E.g. pointer fields but using with Arena, choose NoWriteBarrierPtr.)

Add `WriteBarrier` function to trigger write barrier on array content
when needed.

Added `CopyArray` function to copy array data. Triggers write barrier
on the array content when needed.

By default only pointer types, WriteBarrierPtr wrapper, or explicit
_write_barrier_policy trigger write barrier (when using Recycler).
Users can also use template instantiation to alter custom allocator/type
write barrier policy.

This change does not handle individual `Item` write barrier yet.