### PR TITLE
Refactor JavascriptPromise to provide convenience methods for creating and resolving promise objects within the engine

### DIFF
--- a/lib/Runtime/Library/JavascriptPromise.cpp
+++ b/lib/Runtime/Library/JavascriptPromise.cpp
@@ -451,13 +451,9 @@ namespace Js
         }
 
         // 3. Let promiseCapability be NewPromiseCapability(C).
-        JavascriptPromiseCapability* promiseCapability = NewPromiseCapability(constructor, scriptContext);
-
         // 4. Perform ? Call(promiseCapability.[[Reject]], undefined, << r >>).
-        TryCallResolveOrRejectHandler(promiseCapability->GetReject(), r, scriptContext);
-
         // 5. Return promiseCapability.[[Promise]].
-        return promiseCapability->GetPromise();
+        return CreateRejectedPromise(r, scriptContext, constructor);
     }
 
     // Promise.resolve as described in ES 2015 Section 25.4.4.5
@@ -505,13 +501,9 @@ namespace Js
         }
 
         // 4. Let promiseCapability be NewPromiseCapability(C).
-        JavascriptPromiseCapability* promiseCapability = NewPromiseCapability(constructor, scriptContext);
-
         // 5. Perform ? Call(promiseCapability.[[Resolve]], undefined, << x >>).
-        TryCallResolveOrRejectHandler(promiseCapability->GetResolve(), x, scriptContext);
-
         // 6. Return promiseCapability.[[Promise]].
-        return promiseCapability->GetPromise();
+        return CreateResolvedPromise(x, scriptContext, constructor);
     }
 
     // Promise.prototype.then as described in ES 2015 Section 25.4.5.3
@@ -525,18 +517,13 @@ namespace Js
 
         AUTO_TAG_NATIVE_LIBRARY_ENTRY(function, callInfo, _u("Promise.prototype.then"));
 
-        JavascriptPromise* promise;
-
         if (args.Info.Count < 1 || !JavascriptPromise::Is(args[0]))
         {
             JavascriptError::ThrowTypeError(scriptContext, JSERR_This_NeedPromise, _u("Promise.prototype.then"));
         }
 
-        promise = JavascriptPromise::FromVar(args[0]);
-
         JavascriptLibrary* library = scriptContext->GetLibrary();
-        Var constructor = JavascriptOperators::SpeciesConstructor(promise, scriptContext->GetLibrary()->GetPromiseConstructor(), scriptContext);
-        JavascriptPromiseCapability* promiseCapability = NewPromiseCapability(constructor, scriptContext);
+        JavascriptPromise* promise = JavascriptPromise::FromVar(args[0]);
         RecyclableObject* rejectionHandler;
         RecyclableObject* fulfillmentHandler;
 
@@ -558,27 +545,7 @@ namespace Js
             rejectionHandler = library->GetThrowerFunction();
         }
 
-        JavascriptPromiseReaction* resolveReaction = JavascriptPromiseReaction::New(promiseCapability, fulfillmentHandler, scriptContext);
-        JavascriptPromiseReaction* rejectReaction = JavascriptPromiseReaction::New(promiseCapability, rejectionHandler, scriptContext);
-
-        switch (promise->status)
-        {
-        case PromiseStatusCode_Unresolved:
-            promise->resolveReactions->Add(resolveReaction);
-            promise->rejectReactions->Add(rejectReaction);
-            break;
-        case PromiseStatusCode_HasResolution:
-            EnqueuePromiseReactionTask(resolveReaction, promise->result, scriptContext);
-            break;
-        case PromiseStatusCode_HasRejection:
-            EnqueuePromiseReactionTask(rejectReaction, promise->result, scriptContext);
-            break;
-        default:
-            AssertMsg(false, "Promise status is in an invalid state");
-            break;
-        }
-
-        return promiseCapability->GetPromise();
+        return CreateThenPromise(promise, fulfillmentHandler, rejectionHandler, scriptContext);
     }
 
     // Promise Reject and Resolve Functions as described in ES 2015 Section 25.4.1.4.1 and 25.4.1.4.2
@@ -615,16 +582,34 @@ namespace Js
 
         JavascriptPromise* promise = resolveOrRejectFunction->GetPromise();
 
+        return promise->ResolveHelper(resolution, rejecting, scriptContext);
+    }
+
+    Var JavascriptPromise::Resolve(Var resolution, ScriptContext* scriptContext)
+    {
+        return this->ResolveHelper(resolution, false, scriptContext);
+    }
+
+    Var JavascriptPromise::Reject(Var resolution, ScriptContext* scriptContext)
+    {
+        return this->ResolveHelper(resolution, true, scriptContext);
+    }
+
+    Var JavascriptPromise::ResolveHelper(Var resolution, bool isRejecting, ScriptContext* scriptContext)
+    {
+        JavascriptLibrary* library = scriptContext->GetLibrary();
+        Var undefinedVar = library->GetUndefined();
+
         // We only need to check SameValue and check for thenable resolution in the Resolve function case (not Reject)
-        if (!rejecting)
+        if (!isRejecting)
         {
-            if (JavascriptConversion::SameValue(resolution, promise))
+            if (JavascriptConversion::SameValue(resolution, this))
             {
                 JavascriptError* selfResolutionError = scriptContext->GetLibrary()->CreateTypeError();
                 JavascriptError::SetErrorMessage(selfResolutionError, JSERR_PromiseSelfResolution, _u(""), scriptContext);
 
                 resolution = selfResolutionError;
-                rejecting = true;
+                isRejecting = true;
             }
             else if (RecyclableObject::Is(resolution))
             {
@@ -635,7 +620,7 @@ namespace Js
 
                     if (JavascriptConversion::IsCallable(then))
                     {
-                        JavascriptPromiseResolveThenableTaskFunction* resolveThenableTaskFunction = library->CreatePromiseResolveThenableTaskFunction(EntryResolveThenableTaskFunction, promise, thenable, RecyclableObject::FromVar(then));
+                        JavascriptPromiseResolveThenableTaskFunction* resolveThenableTaskFunction = library->CreatePromiseResolveThenableTaskFunction(EntryResolveThenableTaskFunction, this, thenable, RecyclableObject::FromVar(then));
 
                         library->EnqueueTask(resolveThenableTaskFunction);
 
@@ -651,7 +636,7 @@ namespace Js
                         resolution = undefinedVar;
                     }
 
-                    rejecting = true;
+                    isRejecting = true;
                 }
             }
         }
@@ -660,23 +645,23 @@ namespace Js
         PromiseStatus newStatus;
 
         // Need to check rejecting state again as it might have changed due to failures
-        if (rejecting)
+        if (isRejecting)
         {
-            reactions = promise->GetRejectReactions();
+            reactions = this->GetRejectReactions();
             newStatus = PromiseStatusCode_HasRejection;
         }
         else
         {
-            reactions = promise->GetResolveReactions();
+            reactions = this->GetResolveReactions();
             newStatus = PromiseStatusCode_HasResolution;
         }
 
         Assert(resolution != nullptr);
 
-        promise->result = resolution;
-        promise->resolveReactions = nullptr;
-        promise->rejectReactions = nullptr;
-        promise->status = newStatus;
+        this->result = resolution;
+        this->resolveReactions = nullptr;
+        this->rejectReactions = nullptr;
+        this->status = newStatus;
 
         return TriggerPromiseReactions(reactions, resolution, scriptContext);
     }
@@ -785,6 +770,69 @@ namespace Js
         }
 
         return TryCallResolveOrRejectHandler(handler, thrownObject, scriptContext);
+    }
+
+    Var JavascriptPromise::CreateRejectedPromise(Var resolution, ScriptContext* scriptContext, Var promiseConstructor)
+    {
+        if (promiseConstructor == nullptr)
+        {
+            promiseConstructor = scriptContext->GetLibrary()->GetPromiseConstructor();
+        }
+
+        JavascriptPromiseCapability* promiseCapability = NewPromiseCapability(promiseConstructor, scriptContext);
+
+        TryCallResolveOrRejectHandler(promiseCapability->GetReject(), resolution, scriptContext);
+
+        return promiseCapability->GetPromise();
+    }
+
+    Var JavascriptPromise::CreateResolvedPromise(Var resolution, ScriptContext* scriptContext, Var promiseConstructor)
+    {
+        if (promiseConstructor == nullptr)
+        {
+            promiseConstructor = scriptContext->GetLibrary()->GetPromiseConstructor();
+        }
+
+        JavascriptPromiseCapability* promiseCapability = NewPromiseCapability(promiseConstructor, scriptContext);
+
+        TryCallResolveOrRejectHandler(promiseCapability->GetResolve(), resolution, scriptContext);
+
+        return promiseCapability->GetPromise();
+    }
+
+    Var JavascriptPromise::CreatePassThroughPromise(JavascriptPromise* sourcePromise, ScriptContext* scriptContext)
+    {
+        JavascriptLibrary* library = scriptContext->GetLibrary();
+
+        return CreateThenPromise(sourcePromise, library->GetIdentityFunction(), library->GetThrowerFunction(), scriptContext);
+    }
+
+    Var JavascriptPromise::CreateThenPromise(JavascriptPromise* sourcePromise, RecyclableObject* fulfillmentHandler, RecyclableObject* rejectionHandler, ScriptContext* scriptContext)
+    {
+        Var constructor = JavascriptOperators::SpeciesConstructor(sourcePromise, scriptContext->GetLibrary()->GetPromiseConstructor(), scriptContext);
+        JavascriptPromiseCapability* promiseCapability = NewPromiseCapability(constructor, scriptContext);
+
+        JavascriptPromiseReaction* resolveReaction = JavascriptPromiseReaction::New(promiseCapability, fulfillmentHandler, scriptContext);
+        JavascriptPromiseReaction* rejectReaction = JavascriptPromiseReaction::New(promiseCapability, rejectionHandler, scriptContext);
+
+        switch (sourcePromise->status)
+        {
+        case PromiseStatusCode_Unresolved:
+            sourcePromise->resolveReactions->Add(resolveReaction);
+            sourcePromise->rejectReactions->Add(rejectReaction);
+            break;
+        case PromiseStatusCode_HasResolution:
+            EnqueuePromiseReactionTask(resolveReaction, sourcePromise->result, scriptContext);
+            break;
+        case PromiseStatusCode_HasRejection:
+            EnqueuePromiseReactionTask(rejectReaction, sourcePromise->result, scriptContext);
+            break;
+        default:
+            AssertMsg(false, "Promise status is in an invalid state");
+            break;
+        }
+
+        return promiseCapability->GetPromise();
     }
 
     // Promise Resolve Thenable Job as described in ES 2015 Section 25.4.2.2

--- a/lib/Runtime/Library/JavascriptPromise.h
+++ b/lib/Runtime/Library/JavascriptPromise.h
@@ -422,6 +422,11 @@ namespace Js
         static bool Is(Var aValue);
         static JavascriptPromise* FromVar(Js::Var aValue);
 
+        static Var CreateRejectedPromise(Var resolution, ScriptContext* scriptContext, Var promiseConstructor = nullptr);
+        static Var CreateResolvedPromise(Var resolution, ScriptContext* scriptContext, Var promiseConstructor = nullptr);
+        static Var CreatePassThroughPromise(JavascriptPromise* sourcePromise, ScriptContext* scriptContext);
+        static Var CreateThenPromise(JavascriptPromise* sourcePromise, RecyclableObject* fulfillmentHandler, RecyclableObject* rejectionHandler, ScriptContext* scriptContext);
+
         virtual BOOL GetDiagValueString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext) override;
         virtual BOOL GetDiagTypeString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext) override;
 
@@ -437,6 +442,9 @@ namespace Js
         static Var TryCallResolveOrRejectHandler(Var handler, Var value, ScriptContext* scriptContext);
         static Var TryRejectWithExceptionObject(JavascriptExceptionObject* exceptionObject, Var handler, ScriptContext* scriptContext);
 
+        Var Resolve(Var resolution, ScriptContext* scriptContext);
+        Var Reject(Var resolution, ScriptContext* scriptContext);
+
         enum PromiseStatus
         {
             PromiseStatusCode_Undefined,
@@ -447,6 +455,9 @@ namespace Js
 
         PromiseStatus GetStatus() const { return status; }
         Var GetResult() const { return result; }
+
+    protected:
+        Var ResolveHelper(Var resolution, bool isRejecting, ScriptContext* scriptContext);
 
     protected:
         PromiseStatus status;


### PR DESCRIPTION
Provides four main convenience methods for creating new promises which are simplified as:
 - JavascriptPromise::CreateRejectedPromise(resolution)
   - Returns a new promise rejected with resolution. Effectively same as Promise.reject(resolution)
 - JavascriptPromise::CreateResolvedPromise(resolution)
   - Returns a new promise resolved with resolution. Effectively same as Promise.resolve(resolution)
 - JavascriptPromise::CreateThenPromise(sourcePromise, fulfillmentHandler, rejectionHandler)
   - Effectively the same as calling sourcePromise.then(fulfillmentHandler, rejectionHandler) in Javascript
 - JavascriptPromise::CreatePassThroughPromise(sourcePromise)
   - A passthrough promise is used to return a new wrapper promise which is resolved in the same was as the source promise in order to avoid exposing the source promise

Also provides two convenience methods JavascriptPromise::Resolve and JavascriptPromise::Reject which take a Var resolution and resolves or rejects the promise object. This will trigger the promise reaction tasks.
