### PR TITLE
change page allocator cleanup heuristic

### DIFF
--- a/lib/Backend/PageAllocatorPool.h
+++ b/lib/Backend/PageAllocatorPool.h
@@ -19,9 +19,9 @@ public:
 private:
 
     static VOID CALLBACK IdleCleanupRoutine(
-        _In_opt_ LPVOID lpArgToCompletionRoutine,
-        _In_     DWORD  dwTimerLowValue,
-        _In_     DWORD  dwTimerHighValue);
+        _Inout_     PTP_CALLBACK_INSTANCE Instance,
+        _Inout_opt_ PVOID Context,
+        _Inout_     PTP_TIMER Timer);
 
     PageAllocator* GetPageAllocator();
     void ReturnPageAllocator(PageAllocator* pageAllocator);
@@ -30,7 +30,7 @@ private:
     SList<PageAllocator*, NoThrowHeapAllocator, RealCount> pageAllocators;
     static CriticalSection cs;
     static PageAllocatorPool* Instance;
-    HANDLE idleCleanupTimer;
+    PTP_TIMER idleCleanupTimer;
     volatile unsigned long long activePageAllocatorCount;
 };
 

--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -1489,7 +1489,7 @@ FLAGNR(Boolean, CFG, "Force enable CFG on jshost. version in the jshost's manife
     FLAGNR(Number, SimulatePolyCacheWithOneTypeForInlineCacheIndex, "Use with SimulatePolyCacheWithOneTypeForFunction to simulate creating a polymorphic inline cache containing only one type due to a collision, for testing ObjTypeSpec", -1)
 #endif
 
-FLAGR(Number, JITServerIdleTimeout, "Idle timeout in seconds to do the cleanup in JIT server", 10)
+FLAGR(Number, JITServerIdleTimeout, "Idle timeout in milliseconds to do the cleanup in JIT server", 500)
 FLAGR(Number, JITServerMaxInactivePageAllocatorCount, "Max inactive page allocators to keep before schedule a cleanup", 10)
 #undef FLAG_REGOVR_EXP
 #undef FLAG_REGOVR_ASMJS


### PR DESCRIPTION
changing from idle for 10 seconds to 500 ms to trigger the cleanup
changing from waitable timer to threadpool timer. Because waitable time using scheduling thread's APC queue to trigger the callback, and looks RPC server is using thread pool, the waitable timer scheduling thread can be gone from the thread pool so the callback won't happen, if that's the case we'll miss a scheduled cleanup. Our cleaning up procedure is not thread affinity so it should be OK to use the default call back environment.
