### PR TITLE
Wasm disable tests in Razzle

### DIFF
--- a/test/rlexedirs.xml
+++ b/test/rlexedirs.xml
@@ -374,13 +374,13 @@
 <dir>
   <default>
     <files>WasmSpec</files>
-    <tags>exclude_serialized,exclude_arm,exclude_arm64,require_backend,exclude_xplat</tags>
+    <tags>exclude_serialized,exclude_arm,exclude_arm64,require_backend,exclude_xplat,exclude_razzle</tags>
   </default>
 </dir>
 <dir>
   <default>
     <files>wasm</files>
-    <tags>exclude_serialized,exclude_arm,exclude_arm64,require_backend,exclude_xplat</tags>
+    <tags>exclude_serialized,exclude_arm,exclude_arm64,require_backend,exclude_xplat,exclude_razzle</tags>
     <tags>exclude_arm,exclude_arm64</tags>
   </default>
 </dir>

--- a/test/wasm/rlexe.xml
+++ b/test/wasm/rlexe.xml
@@ -21,7 +21,6 @@
     <compile-flags>-on:wasm</compile-flags>
   </default>
 </test>
-<!--
 <test>
     <default>
        <files>f32.js</files>
@@ -29,7 +28,6 @@
        <compile-flags>-on:Wasm</compile-flags>
     </default>
 </test>
--->
 <test>
     <default>
        <files>dropteelocal.js</files>


### PR DESCRIPTION
Do not run Wasm tests in Razzle at this time. Will reenable once we stabilize our spec implementation.
Re-enable f32 test that was disabled because of razzle issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/1816)
<!-- Reviewable:end -->
