### PR TITLE
Fix for ArrayIterator object.

### DIFF
--- a/lib/Runtime/Library/JavascriptArray.cpp
+++ b/lib/Runtime/Library/JavascriptArray.cpp
@@ -8118,6 +8118,9 @@ Case0:
             JavascriptError::ThrowTypeError(scriptContext, JSERR_This_NullOrUndefined, _u("Array.prototype.values"));
         }
 
+#if ENABLE_COPYONACCESS_ARRAY
+        JavascriptLibrary::CheckAndConvertCopyOnAccessNativeIntArray<Var>(thisObj);
+#endif
         return scriptContext->GetLibrary()->CreateArrayIterator(thisObj, JavascriptArrayIteratorKind::Value);
     }
 

--- a/test/es6/typedarray_bugs.js
+++ b/test/es6/typedarray_bugs.js
@@ -91,6 +91,19 @@ var tests = [
         });
     }
   },
+  {
+    name: "typedarray.prototype.keys should take length from internal slot",
+    body: function () {
+        var a = new Int8Array(4);
+        Object.defineProperty(a, 'length', {value : 10});
+        var b = a.keys();
+        var counter = 0;
+        for (var i of b) {
+            counter++;
+        }
+        assert.areEqual(counter, 4, "The iterable object should iterate only 4 times, not 10 times");
+    }
+  },
   
 ];
 


### PR DESCRIPTION
typedarray.keys/values/entries should iterate over its internal length slot, instead of doing get('length'). Fixed that.
Also we should not be calling GetOwnItem (as per the spec). Fixed that.
