### PR TITLE
reduce native code data memory usage for in-proc jit

### DIFF
--- a/lib/Backend/BackendApi.cpp
+++ b/lib/Backend/BackendApi.cpp
@@ -195,7 +195,7 @@ SetProfilerFromNativeCodeGen(NativeCodeGenerator * toNativeCodeGen, NativeCodeGe
 }
 #endif
 
-void DeleteNativeCodeData(NativeCodeData * data)
+void DeleteNativeCodeData(NativeCodeDataNoFixup * data)
 {
     delete data;
 }

--- a/lib/Backend/BailOut.cpp
+++ b/lib/Backend/BailOut.cpp
@@ -2816,9 +2816,9 @@ void LazyBailOutRecord::Dump(Js::FunctionBody* functionBody)
 }
 #endif
 
-void GlobalBailOutRecordDataTable::Finalize(NativeCodeData::Allocator *allocator, JitArenaAllocator *tempAlloc)
+void GlobalBailOutRecordDataTable::Finalize(Func* func, JitArenaAllocator *tempAlloc)
 {
-    GlobalBailOutRecordDataRow *newRows = NativeCodeDataNewArrayZNoFixup(allocator, GlobalBailOutRecordDataRow, length);
+    GlobalBailOutRecordDataRow *newRows = NativeCodeDataNewArrayZNoFixup(func, GlobalBailOutRecordDataRow, length);
     memcpy(newRows, globalBailOutRecordDataRows, sizeof(GlobalBailOutRecordDataRow) * length);
     JitAdeleteArray(tempAlloc, length, globalBailOutRecordDataRows);
     globalBailOutRecordDataRows = newRows;

--- a/lib/Backend/BailOut.h
+++ b/lib/Backend/BailOut.h
@@ -471,7 +471,7 @@ struct GlobalBailOutRecordDataTable
     bool isLoopBody;
     bool hasNonSimpleParams;
     bool hasStackArgOpt;
-    void Finalize(NativeCodeData::Allocator *allocator, JitArenaAllocator *tempAlloc);
+    void Finalize(Func* func, JitArenaAllocator *tempAlloc);
     void AddOrUpdateRow(JitArenaAllocator *allocator, uint32 bailOutRecordId, uint32 regSlot, bool isFloat, bool isInt,
         bool isSimd128F4, bool isSimd128I4, bool isSimd128I8, bool isSimd128I16, bool isSimd128U4, bool isSimd128U8, bool isSimd128U16, bool isSimd128B4, bool isSimd128B8, bool isSimd128B16,
         int32 offset, uint *lastUpdatedRowIndex);

--- a/lib/Backend/Encoder.cpp
+++ b/lib/Backend/Encoder.cpp
@@ -273,7 +273,7 @@ Encoder::Encode()
     {
         if (m_func->IsOOPJIT())
         {
-            Js::ThrowMapEntry * throwMap = NativeCodeDataNewArrayNoFixup(m_func->GetNativeCodeDataAllocator(), Js::ThrowMapEntry, m_pragmaInstrToRecordMap->Count());
+            Js::ThrowMapEntry * throwMap = NativeCodeDataNewArrayNoFixup(m_func, Js::ThrowMapEntry, m_pragmaInstrToRecordMap->Count());
             for (int32 i = 0; i < m_pragmaInstrToRecordMap->Count(); i++)
             {
                 IR::PragmaInstr *inst = m_pragmaInstrToRecordMap->Item(i);
@@ -358,7 +358,7 @@ Encoder::Encode()
     if (m_func->IsOOPJIT())
     {
         size_t allocSize = XDataAllocator::GetAllocSize(alloc->allocation->xdata.pdataCount, alloc->allocation->xdata.xdataSize);
-        BYTE * xprocXdata = NativeCodeDataNewArrayNoFixup(m_func->GetNativeCodeDataAllocator(), BYTE, allocSize);
+        BYTE * xprocXdata = NativeCodeDataNewArrayNoFixup(m_func, BYTE, allocSize);
         memcpy_s(xprocXdata, allocSize, alloc->allocation->xdata.address, allocSize);
         m_func->GetJITOutput()->RecordXData(xprocXdata);
     }
@@ -387,7 +387,7 @@ Encoder::Encode()
         }
         else // OOP JIT
         {
-            NativeOffsetInlineeFrameRecordOffset* pairs = NativeCodeDataNewArrayZNoFixup(m_func->GetNativeCodeDataAllocator(), NativeOffsetInlineeFrameRecordOffset, this->m_inlineeFrameMap->Count());
+            NativeOffsetInlineeFrameRecordOffset* pairs = NativeCodeDataNewArrayZNoFixup(m_func, NativeOffsetInlineeFrameRecordOffset, this->m_inlineeFrameMap->Count());
 
             this->m_inlineeFrameMap->Map([&pairs](int i, NativeOffsetInlineeFramePair& p)
             {

--- a/lib/Backend/Func.cpp
+++ b/lib/Backend/Func.cpp
@@ -1372,7 +1372,7 @@ Func::GetOrCreateSingleTypeGuard(intptr_t typeAddr)
     if (!this->singleTypeGuards->TryGetValue(typeAddr, &guard))
     {
         // Property guards are allocated by NativeCodeData::Allocator so that their lifetime extends as long as the EntryPointInfo is alive.
-        guard = NativeCodeDataNewNoFixup(GetNativeCodeDataAllocator(), Js::JitTypePropertyGuard, typeAddr, this->indexedPropertyGuardCount++);
+        guard = NativeCodeDataNewNoFixup(this, Js::JitTypePropertyGuard, typeAddr, this->indexedPropertyGuardCount++);
         this->singleTypeGuards->Add(typeAddr, guard);
     }
     else
@@ -1397,7 +1397,7 @@ Func::CreateEquivalentTypeGuard(JITTypeHolder type, uint32 objTypeSpecFldId)
 {
     EnsureEquivalentTypeGuards();
 
-    Js::JitEquivalentTypeGuard* guard = NativeCodeDataNewNoFixup(GetNativeCodeDataAllocator(), Js::JitEquivalentTypeGuard, type->GetAddr(), this->indexedPropertyGuardCount++, objTypeSpecFldId);
+    Js::JitEquivalentTypeGuard* guard = NativeCodeDataNewNoFixup(this, Js::JitEquivalentTypeGuard, type->GetAddr(), this->indexedPropertyGuardCount++, objTypeSpecFldId);
 
     // If we want to hard code the address of the cache, we will need to go back to allocating it from the native code data allocator.
     // We would then need to maintain consistency (double write) to both the recycler allocated cache and the one on the heap.
@@ -1408,7 +1408,7 @@ Func::CreateEquivalentTypeGuard(JITTypeHolder type, uint32 objTypeSpecFldId)
     }
     else
     {
-        cache = NativeCodeDataNewZNoFixup(GetTransferDataAllocator(), Js::EquivalentTypeCache);
+        cache = TransferDataNewZ(GetTransferDataAllocator(), Js::EquivalentTypeCache);
     }
     guard->SetCache(cache);
 

--- a/lib/Backend/Func.h
+++ b/lib/Backend/Func.h
@@ -120,7 +120,11 @@ public:
     {
         return &this->GetTopFunc()->nativeCodeDataAllocator;
     }
-    NativeCodeData::Allocator *GetTransferDataAllocator()
+    NativeCodeDataNoFixup::Allocator *GetNativeCodeDataNoFixupAllocator()
+    {
+        return &this->GetTopFunc()->nativeCodeDataNoFixupAllocator;
+    }
+    NativeCodeDataNoFixup::Allocator *GetTransferDataAllocator()
     {
         return &this->GetTopFunc()->transferDataAllocator;
     }
@@ -974,8 +978,11 @@ private:
     bool                hasNonSimpleParams;
     Cloner *            m_cloner;
     InstrMap *          m_cloneMap;
-    NativeCodeData::Allocator       nativeCodeDataAllocator;
-    NativeCodeData::Allocator       transferDataAllocator;
+
+    NativeCodeData::Allocator               nativeCodeDataAllocator;
+    NativeCodeDataNoFixup::Allocator        nativeCodeDataNoFixupAllocator;
+
+    NativeCodeDataNoFixup::Allocator       transferDataAllocator;
 #if !FLOATVAR
     CodeGenNumberAllocator *        numberAllocator;
 #endif

--- a/lib/Backend/IR.h
+++ b/lib/Backend/IR.h
@@ -767,7 +767,9 @@ private:
 
 private:
     typedef JITJavascriptString* TBranchKey;
-    typedef Js::BranchDictionaryWrapper<TBranchKey> BranchDictionaryWrapper;
+    typedef Js::BranchDictionaryWrapper<TBranchKey, Js::OOPJITBranchDictAllocator> BranchDictionaryWrapperOOP;
+    typedef BranchDictionaryWrapperOOP::BranchDictionary BranchDictionaryOOP;
+    typedef Js::BranchDictionaryWrapper<TBranchKey, NativeCodeDataNoFixup::Allocator> BranchDictionaryWrapper;
     typedef BranchDictionaryWrapper::BranchDictionary BranchDictionary;
     typedef BranchJumpTableWrapper BranchJumpTable;
 
@@ -802,6 +804,7 @@ public:
     void                            MultiBranchInstr::FixMultiBrDefaultTarget(uint32 targetOffset);
     void                            ClearTarget();
     BranchDictionaryWrapper *       GetBranchDictionary();
+    BranchDictionaryWrapperOOP*     GetBranchDictionaryOOP();
     BranchJumpTable *               GetBranchJumpTable();
 
 

--- a/lib/Backend/InlineeFrameInfo.cpp
+++ b/lib/Backend/InlineeFrameInfo.cpp
@@ -76,7 +76,6 @@ bool BailoutConstantValue::IsEqual(const BailoutConstantValue & bailoutConstValu
     return false;
 }
 
-
 void InlineeFrameInfo::AllocateRecord(Func* func, intptr_t functionBodyAddr)
 {
     uint constantCount = 0;
@@ -100,7 +99,7 @@ void InlineeFrameInfo::AllocateRecord(Func* func, intptr_t functionBodyAddr)
     // update the record
     if (!this->record)
     {
-        this->record = InlineeFrameRecord::New(func->GetNativeCodeDataAllocator(), (uint)arguments->Count(), constantCount, functionBodyAddr, this);
+        this->record = InlineeFrameRecord::New(func, (uint)arguments->Count(), constantCount, functionBodyAddr, this);
     }
 
     uint i = 0;
@@ -156,6 +155,15 @@ void InlineeFrameInfo::AllocateRecord(Func* func, intptr_t functionBodyAddr)
         this->record->constants[constantIndex] = function.constValue.ToVar(func);
         this->record->functionOffset = constantIndex;
     }
+}
+
+InlineeFrameRecord* InlineeFrameRecord::New(Func* func, uint argCount, uint constantCount, intptr_t functionBodyAddr, InlineeFrameInfo* frameInfo)
+{
+    InlineeFrameRecord* record = NativeCodeDataNewZ(func, InlineeFrameRecord, argCount, (Js::FunctionBody*)functionBodyAddr, frameInfo);
+    record->argOffsets = reinterpret_cast<int*>(NativeCodeDataNewArrayNoFixup(func, IntType<DataDesc_InlineeFrameRecord_ArgOffsets>, argCount));
+    record->constants = reinterpret_cast<Js::Var*>(NativeCodeDataNewArrayNoFixup(func, VarType<DataDesc_InlineeFrameRecord_Constants>, constantCount));
+    DebugOnly(record->constantCount = constantCount);
+    return record;
 }
 
 void InlineeFrameRecord::PopulateParent(Func* func)

--- a/lib/Backend/InlineeFrameInfo.h
+++ b/lib/Backend/InlineeFrameInfo.h
@@ -98,14 +98,7 @@ struct InlineeFrameRecord
 #endif
     {}
 
-    static InlineeFrameRecord* New(NativeCodeData::Allocator* alloc, uint argCount, uint constantCount, intptr_t functionBodyAddr, InlineeFrameInfo* frameInfo)
-    {
-        InlineeFrameRecord* record = NativeCodeDataNewZ(alloc, InlineeFrameRecord, argCount, (Js::FunctionBody*)functionBodyAddr, frameInfo);
-        record->argOffsets = (int*)NativeCodeDataNewArrayNoFixup(alloc, IntType<DataDesc_InlineeFrameRecord_ArgOffsets>, argCount);
-        record->constants = (Js::Var*)NativeCodeDataNewArrayNoFixup(alloc, VarType<DataDesc_InlineeFrameRecord_Constants>, constantCount);
-        DebugOnly(record->constantCount = constantCount);
-        return record;
-    }
+    static InlineeFrameRecord* New(Func* func, uint argCount, uint constantCount, intptr_t functionBodyAddr, InlineeFrameInfo* frameInfo);
 
     void PopulateParent(Func* func);
     void RestoreFrames(Js::FunctionBody* functionBody, InlinedFrameLayout* outerMostInlinee, Js::JavascriptCallStackLayout* callstack);

--- a/lib/Backend/JITOutput.cpp
+++ b/lib/Backend/JITOutput.cpp
@@ -177,7 +177,7 @@ JITOutput::FinalizeNativeCode(Func *func, EmitBufferAllocation * alloc)
     func->GetEmitBufferManager()->CompletePreviousAllocation(alloc);
     if (!func->IsOOPJIT())
     {
-        func->GetInProcJITEntryPointInfo()->SetInProcJITNativeCodeData(func->GetNativeCodeDataAllocator()->Finalize());
+        func->GetInProcJITEntryPointInfo()->SetInProcJITNativeCodeData(func->GetNativeCodeDataNoFixupAllocator()->Finalize());
         func->GetInProcJITEntryPointInfo()->GetJitTransferData()->SetRawData(func->GetTransferDataAllocator()->Finalize());
 #if !FLOATVAR
         CodeGenNumberChunk * numberChunks = func->GetNumberAllocator()->Finalize();

--- a/lib/Backend/JnHelperMethodList.h
+++ b/lib/Backend/JnHelperMethodList.h
@@ -145,6 +145,7 @@ HELPERCALL(Op_StrictEqualString, Js::JavascriptOperators::StrictEqualString, 0)
 HELPERCALL(Op_StrictEqualEmptyString, Js::JavascriptOperators::StrictEqualEmptyString, 0)
 HELPERCALL(Op_NotStrictEqual, Js::JavascriptOperators::NotStrictEqual, 0)
 
+HELPERCALL(Op_SwitchStringLookUp_OOP, Js::JavascriptNativeOperators::Op_SwitchStringLookUp_OOP, 0)
 HELPERCALL(Op_SwitchStringLookUp, Js::JavascriptNativeOperators::Op_SwitchStringLookUp, 0)
 
 HELPERCALL(Op_HasProperty, Js::JavascriptOperators::OP_HasProperty, 0)

--- a/lib/Backend/LowerMDShared.cpp
+++ b/lib/Backend/LowerMDShared.cpp
@@ -6351,7 +6351,7 @@ LowererMD::EmitLoadFloatCommon(IR::Opnd *dst, IR::Opnd *src, IR::Instr *insertIn
         Assert(regOpnd->m_sym->m_isSingleDef);
         Js::Var value = regOpnd->m_sym->GetFloatConstValueAsVar_PostGlobOpt();
 #if FLOATVAR
-        void *pDouble = (double*)NativeCodeDataNewNoFixup(this->m_func->GetNativeCodeDataAllocator(), DoubleType<DataDesc_LowererMD_EmitLoadFloatCommon_Double>, Js::JavascriptNumber::GetValue(value));
+        void *pDouble = (double*)NativeCodeDataNewNoFixup(this->m_func, DoubleType<DataDesc_LowererMD_EmitLoadFloatCommon_Double>, Js::JavascriptNumber::GetValue(value));
         IR::Opnd * doubleRef;
         if (!m_func->IsOOPJIT())
         {
@@ -7153,12 +7153,12 @@ LowererMD::LoadFloatValue(IR::Opnd * opndDst, double value, IR::Instr * instrIns
     bool isFloat64 = opndDst->IsFloat64();
     if (isFloat64)
     {
-        pValue = NativeCodeDataNewNoFixup(instrInsert->m_func->GetNativeCodeDataAllocator(), DoubleType<DataDesc_LowererMD_LoadFloatValue_Double>, value);
+        pValue = NativeCodeDataNewNoFixup(instrInsert->m_func, DoubleType<DataDesc_LowererMD_LoadFloatValue_Double>, value);
     }
     else
     {
         Assert(opndDst->IsFloat32());
-        pValue = (float*)NativeCodeDataNewNoFixup(instrInsert->m_func->GetNativeCodeDataAllocator(), FloatType<DataDesc_LowererMD_LoadFloatValue_Float>, (float)value);
+        pValue = (float*)NativeCodeDataNewNoFixup(instrInsert->m_func, FloatType<DataDesc_LowererMD_LoadFloatValue_Float>, (float)value);
     }
 
     if (!instrInsert->m_func->IsOOPJIT())

--- a/lib/Backend/LowerMDSharedSimd128.cpp
+++ b/lib/Backend/LowerMDSharedSimd128.cpp
@@ -376,7 +376,7 @@ IR::Instr* LowererMD::Simd128LoadConst(IR::Instr* instr)
 
     // MOVUPS dst, [const]
     
-    void *pValue = NativeCodeDataNewNoFixup(this->m_func->GetNativeCodeDataAllocator(), SIMDType<DataDesc_LowererMD_Simd128LoadConst>, value);
+    void *pValue = NativeCodeDataNewNoFixup(this->m_func, SIMDType<DataDesc_LowererMD_Simd128LoadConst>, value);
     IR::Opnd * simdRef;
     if (!m_func->IsOOPJIT())
     {

--- a/lib/Backend/Region.cpp
+++ b/lib/Backend/Region.cpp
@@ -24,11 +24,11 @@ Region::AllocateEHBailoutData(Func * func, IR::Instr * tryInstr)
 {
     if (this->GetType() == RegionTypeRoot)
     {
-        this->ehBailoutData = NativeCodeDataNew(func->GetNativeCodeDataAllocator(), Js::EHBailoutData, -1 /*nestingDepth*/, 0 /*catchOffset*/, nullptr /*parent*/);
+        this->ehBailoutData = NativeCodeDataNew(func, Js::EHBailoutData, -1 /*nestingDepth*/, 0 /*catchOffset*/, nullptr /*parent*/);
     }
     else
     {
-        this->ehBailoutData = NativeCodeDataNew(func->GetNativeCodeDataAllocator(), Js::EHBailoutData, this->GetParent()->ehBailoutData->nestingDepth + 1, 0, this->GetParent()->ehBailoutData);
+        this->ehBailoutData = NativeCodeDataNew(func, Js::EHBailoutData, this->GetParent()->ehBailoutData->nestingDepth + 1, 0, this->GetParent()->ehBailoutData);
         if (this->GetType() == RegionTypeTry)
         {
             Assert(tryInstr);

--- a/lib/Backend/arm/LowerMD.cpp
+++ b/lib/Backend/arm/LowerMD.cpp
@@ -8999,7 +8999,7 @@ LowererMD::LoadFloatValue(IR::Opnd * opndDst, double value, IR::Instr * instrIns
     {
         return LowererMD::LoadFloatZero(opndDst, instrInsert);
     }
-    void * pValue = NativeCodeDataNewNoFixup(instrInsert->m_func->GetNativeCodeDataAllocator(), DoubleType<DataDesc_LowererMD_LoadFloatValue_Double>, value);
+    void * pValue = NativeCodeDataNewNoFixup(instrInsert->m_func, DoubleType<DataDesc_LowererMD_LoadFloatValue_Double>, value);
     IR::Opnd * opnd;
     if (instrInsert->m_func->IsOOPJIT())
     {

--- a/lib/Common/BackendApi.h
+++ b/lib/Common/BackendApi.h
@@ -97,7 +97,7 @@ void ProfilePrintNativeCodeGen(NativeCodeGenerator * nativeCodeGen);
 void SetProfilerFromNativeCodeGen(NativeCodeGenerator * toNativeCodeGen, NativeCodeGenerator * fromNativeCodeGen);
 #endif
 
-void DeleteNativeCodeData(NativeCodeData * data);
+void DeleteNativeCodeData(NativeCodeDataNoFixup * data);
 #else
 inline BOOL IsIntermediateCodeGenThunk(Js::JavascriptMethod codeAddress) { return false; }
 inline BOOL IsAsmJsCodeGenThunk(Js::JavascriptMethod codeAddress) { return false; }

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -458,7 +458,7 @@ namespace Js
             JitEquivalentTypeGuard** equivalentTypeGuards;
             Js::PropertyId* lazyBailoutProperties;
 #if ENABLE_NATIVE_CODEGEN
-            NativeCodeData* jitTransferRawData;
+            NativeCodeDataNoFixup* jitTransferRawData;
 #endif
             EquivalentTypeGuardOffsets* equivalentTypeGuardOffsets;
             TypeGuardTransferData typeGuardTransferData;
@@ -476,7 +476,7 @@ namespace Js
                 falseReferencePreventionBit(true), isReady(false), lazyBailoutProperties(nullptr), lazyBailoutPropertyCount(0){}
 
 #if ENABLE_NATIVE_CODEGEN
-            void SetRawData(NativeCodeData* rawData) { jitTransferRawData = rawData; }
+            void SetRawData(NativeCodeDataNoFixup* rawData) { jitTransferRawData = rawData; }
 #endif
             void AddJitTimeTypeRef(void* typeRef, Recycler* recycler);
 
@@ -516,7 +516,7 @@ namespace Js
             void EnsureJitTimeTypeRefs(Recycler* recycler);
         };
 #if ENABLE_NATIVE_CODEGEN
-        NativeCodeData * inProcJITNaticeCodedata;
+        NativeCodeDataNoFixup * inProcJITNaticeCodedata;
         char* nativeDataBuffer;
         union
         {
@@ -589,7 +589,7 @@ namespace Js
 #if ENABLE_NATIVE_CODEGEN
         char** GetNativeDataBufferRef() { return &nativeDataBuffer; }
         char* GetNativeDataBuffer() { return nativeDataBuffer; }
-        void SetInProcJITNativeCodeData(NativeCodeData* nativeCodeData) { inProcJITNaticeCodedata = nativeCodeData; }
+        void SetInProcJITNativeCodeData(NativeCodeDataNoFixup* nativeCodeData) { inProcJITNaticeCodedata = nativeCodeData; }
         void SetNumberChunks(CodeGenNumberChunk* chunks)
         {
             Assert(numberPageSegments == nullptr);

--- a/lib/Runtime/Language/JavascriptNativeOperators.cpp
+++ b/lib/Runtime/Language/JavascriptNativeOperators.cpp
@@ -8,10 +8,25 @@
 namespace Js
 {
 #if ENABLE_NATIVE_CODEGEN
-    void * JavascriptNativeOperators::Op_SwitchStringLookUp(JavascriptString* str, Js::BranchDictionaryWrapper<JavascriptString*>* branchTargets, uintptr_t funcStart, uintptr_t funcEnd)
+    void * JavascriptNativeOperators::Op_SwitchStringLookUp_OOP(JavascriptString* str, Js::BranchDictionaryWrapper<JavascriptString*, OOPJITBranchDictAllocator>* branchTargets, uintptr_t funcStart, uintptr_t funcEnd)
     {
         void* defaultTarget = branchTargets->defaultTarget;
-        Js::BranchDictionaryWrapper<JavascriptString*>::BranchDictionary& stringDictionary = branchTargets->dictionary;
+        Js::BranchDictionaryWrapper<JavascriptString*, OOPJITBranchDictAllocator>::BranchDictionary& stringDictionary = branchTargets->dictionary;
+        void* target = stringDictionary.Lookup(str, defaultTarget);
+        uintptr_t utarget = (uintptr_t)target;
+
+        if ((utarget - funcStart) > (funcEnd - funcStart))
+        {
+            AssertMsg(false, "Switch string dictionary jump target outside of function");
+            Throw::FatalInternalError();
+        }
+        return target;
+    }
+
+    void * JavascriptNativeOperators::Op_SwitchStringLookUp(JavascriptString* str, Js::BranchDictionaryWrapper<JavascriptString*, NativeCodeDataNoFixup::Allocator>* branchTargets, uintptr_t funcStart, uintptr_t funcEnd)
+    {
+        void* defaultTarget = branchTargets->defaultTarget;
+        Js::BranchDictionaryWrapper<JavascriptString*, NativeCodeDataNoFixup::Allocator>::BranchDictionary& stringDictionary = branchTargets->dictionary;
         void* target = stringDictionary.Lookup(str, defaultTarget);
         uintptr_t utarget = (uintptr_t)target;
 


### PR DESCRIPTION
In OOP JIT when allocating native code data we record some information about the allocation. At the end of a JIT work item, the allocation information is used to make the pointer fixing up table which then used to fixup the internal pointers after passing native code data to runtime process. After a JIT work item is done, all the native code data including the allocation information are freed in JIT server, only the fixup table and aggregated data buffer is passed to runtime process. The fixup table is freed right after doing fixup in runntime process after the codegen call returned.

When doing in-proc jit we don't need these fixup information, and we don't do pointer fixing up and data aggregating/copying, the the fixup information has same life time as the native code data themselves, thus wasting memory.

This change bring back the same data structure which before the OOP JIT change and use it for in-proc JIT

Note in OOP JIT it uses one pointer size less memory than in-proc JIT because even the next pointer on DataChunk is not kept after data aggregating.
