### PR TITLE
Add fast path for x86 to fix inconsistent issue

### DIFF
--- a/lib/Runtime/Library/MathLibrary.cpp
+++ b/lib/Runtime/Library/MathLibrary.cpp
@@ -849,13 +849,19 @@ namespace Js
         }
         else
         {
-            if( AutoSystemInfo::Data.SSE2Available() )
+            int32 intY;
+            // range [-8, 8] is from JavascriptNumber::DirectPowDoubleInt
+            if (JavascriptNumber::TryGetInt32Value(y, &intY) && intY >= -8 && intY <= 8)
+            {
+                result = JavascriptNumber::DirectPowDoubleInt(x, intY);
+            }
+            else if( AutoSystemInfo::Data.SSE2Available() )
             {
                 _asm {
                     movsd xmm0, x
-                        movsd xmm1, y
-                        call dword ptr[__libm_sse2_pow]
-                        movsd result, xmm0
+                    movsd xmm1, y
+                    call dword ptr[__libm_sse2_pow]
+                    movsd result, xmm0
                 }
             }
             else


### PR DESCRIPTION
Math.pow uses inline assembly __libm_sse2_pow instead of pow from CRT, which makes it not handled the same way as other architectures where SSE2 instructions have already been used in pow from CRT. This change adds fast path for Math.pow call from interpreter to make it consistent with JIT code which goes to fast path already.