### PR TITLE
WebAssembly safe read init_expr

### DIFF
--- a/lib/WasmReader/WasmBinaryReader.cpp
+++ b/lib/WasmReader/WasmBinaryReader.cpp
@@ -54,7 +54,8 @@ LanguageTypes::ToWasmType(int8 binType)
 WasmBinaryReader::WasmBinaryReader(ArenaAllocator* alloc, Js::WebAssemblyModule * module, const byte* source, size_t length) :
     m_module(module),
     m_curFuncEnd(nullptr),
-    m_alloc(alloc)
+    m_alloc(alloc),
+    m_readerState(READER_STATE_UNKNOWN)
 {
     m_start = m_pc = source;
     m_end = source + length;
@@ -67,6 +68,7 @@ WasmBinaryReader::WasmBinaryReader(ArenaAllocator* alloc, Js::WebAssemblyModule 
 void WasmBinaryReader::InitializeReader()
 {
     ValidateModuleHeader();
+    m_readerState = READER_STATE_UNKNOWN;
 #if DBG_DUMP
     if (DO_WASM_TRACE_SECTION)
     {
@@ -135,6 +137,7 @@ WasmBinaryReader::ProcessCurrentSection()
 {
     Assert(m_currentSection.code != bSectInvalid);
     TRACE_WASM_SECTION(_u("Process section %s"), SectionInfo::All[m_currentSection.code].name);
+    m_readerState = READER_STATE_MODULE;
 
     switch (m_currentSection.code)
     {
@@ -151,7 +154,8 @@ WasmBinaryReader::ProcessCurrentSection()
         ReadFunctionsSignatures();
         break;
     case bSectFunctionBodies:
-        return ReadFunctionHeaders();
+        ReadFunctionHeaders();
+        break;
     case bSectExportTable:
         ReadExportTable();
         break;
@@ -175,8 +179,11 @@ WasmBinaryReader::ProcessCurrentSection()
         break;
     default:
         Assert(UNREACHED);
+        m_readerState = READER_STATE_UNKNOWN;
         return false;
     }
+
+    m_readerState = READER_STATE_UNKNOWN;
 
     return m_pc == m_currentSection.end;
 }
@@ -275,7 +282,7 @@ WasmBinaryReader::PrintOps()
 
 #endif
 
-bool
+void
 WasmBinaryReader::ReadFunctionHeaders()
 {
     uint32 len;
@@ -298,7 +305,6 @@ WasmBinaryReader::ReadFunctionHeaders()
         const byte* end = m_pc + funcSize;
         m_pc = end;
     }
-    return m_pc == m_currentSection.end;
 }
 
 void
@@ -308,6 +314,12 @@ WasmBinaryReader::SeekToFunctionBody(FunctionBodyReaderInfo readerInfo)
     {
         ThrowDecodingError(_u("Function byte offset out of bounds"));
     }
+    if (m_readerState != READER_STATE_UNKNOWN)
+    {
+        ThrowDecodingError(_u("Wasm reader in an invalid state to read function code"));
+    }
+    m_readerState = READER_STATE_FUNCTION;
+
     // Seek to the function start and skip function header (count)
     m_pc = m_start + readerInfo.startOffset;
     m_funcState.size = readerInfo.size;
@@ -344,6 +356,11 @@ WasmBinaryReader::SeekToFunctionBody(FunctionBodyReaderInfo readerInfo)
             break;
         }
     }
+}
+
+void WasmBinaryReader::FunctionEnd()
+{
+    m_readerState = READER_STATE_UNKNOWN;
 }
 
 bool WasmBinaryReader::IsCurrentFunctionCompleted() const
@@ -1066,8 +1083,13 @@ WasmBinaryReader::SLEB128(UINT &length)
 WasmNode
 WasmBinaryReader::ReadInitExpr()
 {
+    if (m_readerState != READER_STATE_MODULE)
+    {
+        ThrowDecodingError(_u("Wasm reader in an invalid state to read init_expr"));
+    }
+
     m_funcState.count = 0;
-    m_funcState.size = 123456; // some arbitrary big value
+    m_funcState.size = m_currentSection.end - m_pc;
     ReadExpr();
     WasmNode node = m_currentNode;
     switch (node.op)

--- a/lib/WasmReader/WasmBinaryReader.h
+++ b/lib/WasmReader/WasmBinaryReader.h
@@ -39,6 +39,7 @@ namespace Wasm
         // Fully read the section in the reader. Return true if the section fully read
         bool ProcessCurrentSection();
         void SeekToFunctionBody(FunctionBodyReaderInfo readerInfo);
+        void FunctionEnd();
         bool IsCurrentFunctionCompleted() const;
         WasmOp ReadExpr();
 #if DBG_DUMP
@@ -50,7 +51,7 @@ namespace Wasm
         struct ReaderState
         {
             UINT32 count; // current entry
-            UINT32 size;  // number of entries
+            size_t size;  // number of entries
         };
 
         void BlockNode();
@@ -67,7 +68,7 @@ namespace Wasm
         void ReadMemorySection();
         void ReadSignatures();
         void ReadFunctionsSignatures();
-        bool ReadFunctionHeaders();
+        void ReadFunctionHeaders();
         void ReadExportTable();
         void ReadTableSection();
         void ReadDataSegments();
@@ -101,6 +102,12 @@ namespace Wasm
         ReaderState m_funcState;   // func AST level
 
     private:
+        enum
+        {
+            READER_STATE_UNKNOWN,
+            READER_STATE_FUNCTION,
+            READER_STATE_MODULE
+        } m_readerState;
         Js::WebAssemblyModule * m_module;
 #if DBG_DUMP
         typedef JsUtil::BaseHashSet<WasmOp, ArenaAllocator, PowerOf2SizePolicy> OpSet;

--- a/lib/WasmReader/WasmByteCodeGenerator.cpp
+++ b/lib/WasmReader/WasmByteCodeGenerator.cpp
@@ -338,9 +338,11 @@ WasmBytecodeGenerator::GenerateFunction()
         m_writer.MarkAsmJsLabel(exitLabel);
         m_writer.EmptyAsm(Js::OpCodeAsmJs::Ret);
         m_writer.End();
+        GetReader()->FunctionEnd();
     }
     catch (...)
     {
+        GetReader()->FunctionEnd();
         m_writer.Reset();
         throw;
     }


### PR DESCRIPTION
Add a state to the wasm reader to prevent calling ReadInitExpr from a function body

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/1837)

<!-- Reviewable:end -->
