### PR TITLE
Removing few unwanted IsDetached check

### DIFF
--- a/lib/Runtime/Library/TypedArray.cpp
+++ b/lib/Runtime/Library/TypedArray.cpp
@@ -560,7 +560,7 @@ namespace Js
         }
         else if (jsArraySource)
         {
-            newArray->SetObject(jsArraySource, newArray->GetLength(), offset);
+            newArray->SetObjectNoDetachCheck(jsArraySource, newArray->GetLength(), offset);
             OUTPUT_TRACE(TypedArrayPhase, _u("Created a TypedArray from a JavaScript array source\n"));
         }
 
@@ -948,7 +948,7 @@ namespace Js
             {
                 for (uint32 i = 0; i < sourceLength; i++)
                 {
-                    DirectSetItem(offset + i, source->DirectGetItem(i));
+                    DirectSetItemNoDetachCheck(offset + i, source->DirectGetItemNoDetachCheck(i));
                 }
             }
             else
@@ -965,6 +965,48 @@ namespace Js
                     DirectSetItem(offset + i, tmpArray->DirectGetItem(i));
                 }
             }
+            if (source->IsDetachedBuffer() || this->IsDetachedBuffer())
+            {
+                Throw::FatalInternalError();
+            }
+        }
+    }
+
+    uint32 TypedArrayBase::GetSourceLength(RecyclableObject* arraySource, uint32 targetLength, uint32 offset)
+    {
+        ScriptContext* scriptContext = GetScriptContext();
+        uint32 sourceLength = JavascriptConversion::ToUInt32(JavascriptOperators::OP_GetProperty(arraySource, PropertyIds::length, scriptContext), scriptContext);
+        uint32 totalLength;
+        if (UInt32Math::Add(offset, sourceLength, &totalLength) ||
+            (totalLength > targetLength))
+        {
+            JavascriptError::ThrowRangeError(
+                scriptContext, JSERR_InvalidTypedArrayLength);
+        }
+        return sourceLength;
+    }
+
+    void TypedArrayBase::SetObjectNoDetachCheck(RecyclableObject* source, uint32 targetLength, uint32 offset)
+    {
+        ScriptContext* scriptContext = GetScriptContext();
+        uint32 sourceLength = GetSourceLength(source, targetLength, offset);
+        Assert(!this->IsDetachedBuffer());
+
+        Var itemValue;
+        Var undefinedValue = scriptContext->GetLibrary()->GetUndefined();
+        for (uint32 i = 0; i < sourceLength; i++)
+        {
+            if (!source->GetItem(source, i, &itemValue, scriptContext))
+            {
+                itemValue = undefinedValue;
+            }
+            DirectSetItemNoDetachCheck(offset + i, itemValue);
+        }
+
+        if (this->IsDetachedBuffer())
+        {
+            // We cannot be detached when we are creating the typed array itself. Terminate if that happens.
+            Throw::FatalInternalError();
         }
     }
 
@@ -973,14 +1015,8 @@ namespace Js
     void TypedArrayBase::SetObject(RecyclableObject* source, uint32 targetLength, uint32 offset)
     {
         ScriptContext* scriptContext = GetScriptContext();
-        uint32 sourceLength = JavascriptConversion::ToUInt32(JavascriptOperators::OP_GetProperty(source, PropertyIds::length, scriptContext), scriptContext);
-        uint32 totalLength;
-        if (UInt32Math::Add(offset, sourceLength, &totalLength) ||
-            (totalLength > targetLength))
-        {
-            JavascriptError::ThrowRangeError(
-                GetScriptContext(), JSERR_InvalidTypedArrayLength);
-        }
+        uint32 sourceLength = GetSourceLength(source, targetLength, offset);
+
         Var itemValue;
         Var undefinedValue = scriptContext->GetLibrary()->GetUndefined();
         for (uint32 i = 0; i < sourceLength; i ++)
@@ -2668,6 +2704,70 @@ namespace Js
         return BaseTypedDirectGetItem(index);
     }
 
+#define DIRECT_SET_NO_DETACH_CHECK(TypedArrayName, convertFn) \
+    template<> \
+    inline BOOL TypedArrayName##::DirectSetItemNoDetachCheck(__in uint32 index, __in Var value) \
+    { \
+        return BaseTypedDirectSetItemNoDetachCheck(index, value, convertFn); \
+    }
+
+    DIRECT_SET_NO_DETACH_CHECK(Int8Array, JavascriptConversion::ToInt8);
+    DIRECT_SET_NO_DETACH_CHECK(Int8VirtualArray, JavascriptConversion::ToInt8);
+    DIRECT_SET_NO_DETACH_CHECK(Uint8Array, JavascriptConversion::ToUInt8);
+    DIRECT_SET_NO_DETACH_CHECK(Uint8VirtualArray, JavascriptConversion::ToUInt8);
+    DIRECT_SET_NO_DETACH_CHECK(Int16Array, JavascriptConversion::ToInt16);
+    DIRECT_SET_NO_DETACH_CHECK(Int16VirtualArray, JavascriptConversion::ToInt16);
+    DIRECT_SET_NO_DETACH_CHECK(Uint16Array, JavascriptConversion::ToUInt16);
+    DIRECT_SET_NO_DETACH_CHECK(Uint16VirtualArray, JavascriptConversion::ToUInt16);
+    DIRECT_SET_NO_DETACH_CHECK(Int32Array, JavascriptConversion::ToInt32);
+    DIRECT_SET_NO_DETACH_CHECK(Int32VirtualArray, JavascriptConversion::ToInt32);
+    DIRECT_SET_NO_DETACH_CHECK(Uint32Array, JavascriptConversion::ToUInt32);
+    DIRECT_SET_NO_DETACH_CHECK(Uint32VirtualArray, JavascriptConversion::ToUInt32);
+    DIRECT_SET_NO_DETACH_CHECK(Float32Array, JavascriptConversion::ToFloat);
+    DIRECT_SET_NO_DETACH_CHECK(Float32VirtualArray, JavascriptConversion::ToFloat);
+    DIRECT_SET_NO_DETACH_CHECK(Float64Array, JavascriptConversion::ToNumber);
+    DIRECT_SET_NO_DETACH_CHECK(Float64VirtualArray, JavascriptConversion::ToNumber);
+    DIRECT_SET_NO_DETACH_CHECK(Int64Array, JavascriptConversion::ToInt64);
+    DIRECT_SET_NO_DETACH_CHECK(Uint64Array, JavascriptConversion::ToUInt64);
+    DIRECT_SET_NO_DETACH_CHECK(Uint8ClampedArray, JavascriptConversion::ToUInt8Clamped);
+    DIRECT_SET_NO_DETACH_CHECK(Uint8ClampedVirtualArray, JavascriptConversion::ToUInt8Clamped);
+    DIRECT_SET_NO_DETACH_CHECK(BoolArray, JavascriptConversion::ToBool);
+
+#define DIRECT_GET_NO_DETACH_CHECK(TypedArrayName) \
+    template<> \
+    inline Var TypedArrayName##::DirectGetItemNoDetachCheck(__in uint32 index) \
+    { \
+        return BaseTypedDirectGetItemNoDetachCheck(index); \
+    }
+
+#define DIRECT_GET_VAR_CHECK_NO_DETACH_CHECK(TypedArrayName) \
+    template<> \
+    inline Var TypedArrayName##::DirectGetItemNoDetachCheck(__in uint32 index) \
+    { \
+        return DirectGetItemVarCheckNoDetachCheck(index); \
+    }
+
+    DIRECT_GET_NO_DETACH_CHECK(Int8Array);
+    DIRECT_GET_NO_DETACH_CHECK(Int8VirtualArray);
+    DIRECT_GET_NO_DETACH_CHECK(Uint8Array);
+    DIRECT_GET_NO_DETACH_CHECK(Uint8VirtualArray);
+    DIRECT_GET_NO_DETACH_CHECK(Int16Array);
+    DIRECT_GET_NO_DETACH_CHECK(Int16VirtualArray);
+    DIRECT_GET_NO_DETACH_CHECK(Uint16Array);
+    DIRECT_GET_NO_DETACH_CHECK(Uint16VirtualArray);
+    DIRECT_GET_NO_DETACH_CHECK(Int32Array);
+    DIRECT_GET_NO_DETACH_CHECK(Int32VirtualArray);
+    DIRECT_GET_NO_DETACH_CHECK(Uint32Array);
+    DIRECT_GET_NO_DETACH_CHECK(Uint32VirtualArray);
+    DIRECT_GET_NO_DETACH_CHECK(Int64Array);
+    DIRECT_GET_NO_DETACH_CHECK(Uint64Array);
+    DIRECT_GET_NO_DETACH_CHECK(Uint8ClampedArray);
+    DIRECT_GET_NO_DETACH_CHECK(Uint8ClampedVirtualArray);
+    DIRECT_GET_VAR_CHECK_NO_DETACH_CHECK(Float32Array);
+    DIRECT_GET_VAR_CHECK_NO_DETACH_CHECK(Float32VirtualArray);
+    DIRECT_GET_VAR_CHECK_NO_DETACH_CHECK(Float64Array);
+    DIRECT_GET_VAR_CHECK_NO_DETACH_CHECK(Float64VirtualArray);
+
 #define TypedArrayBeginStub(type) \
         Assert(GetArrayBuffer() || GetArrayBuffer()->GetBuffer()); \
         Assert(index < GetLength()); \
@@ -3196,6 +3296,14 @@ namespace Js
         return GetLibrary()->GetUndefined();
     }
 
+    template<>
+    inline Var BoolArray::DirectGetItemNoDetachCheck(__in uint32 index)
+    {
+        Assert((index + 1)* sizeof(bool) + GetByteOffset() <= GetArrayBuffer()->GetByteLength());
+        bool* typedBuffer = (bool*)buffer;
+        return typedBuffer[index] ? GetLibrary()->GetTrue() : GetLibrary()->GetFalse();
+    }
+
     Var CharArray::Create(ArrayBufferBase* arrayBuffer, uint32 byteOffSet, uint32 mappedLength, JavascriptLibrary* javascriptLibrary)
     {
         CharArray* arr;
@@ -3283,6 +3391,16 @@ namespace Js
         }
 
         return FALSE;
+    }
+
+    inline BOOL CharArray::DirectSetItemNoDetachCheck(__in uint32 index, __in Js::Var value)
+    {
+        return DirectSetItem(index, value);
+    }
+
+    inline Var CharArray::DirectGetItemNoDetachCheck(__in uint32 index)
+    {
+        return DirectGetItem(index);
     }
 
     Var CharArray::TypedAdd(__in uint32 index, Var second)

--- a/lib/Runtime/Library/TypedArray.h
+++ b/lib/Runtime/Library/TypedArray.h
@@ -139,6 +139,9 @@ namespace Js
         virtual BOOL DirectSetItem(__in uint32 index, __in Js::Var value) = 0;
         virtual BOOL DirectSetItemNoSet(__in uint32 index, __in Js::Var value) = 0;
         virtual Var  DirectGetItem(__in uint32 index) = 0;
+        virtual BOOL DirectSetItemNoDetachCheck(__in uint32 index, __in Js::Var value) = 0;
+        virtual Var  DirectGetItemNoDetachCheck(__in uint32 index) = 0;
+
         virtual Var TypedAdd(__in uint32 index, Var second) = 0;
         virtual Var TypedAnd(__in uint32 index, Var second) = 0;
         virtual Var TypedLoad(__in uint32 index) = 0;
@@ -158,6 +161,7 @@ namespace Js
         static Var CommonSubarray(Arguments& args);
 
         void SetObject(RecyclableObject* arraySource, uint32 targetLength, uint32 offset = 0);
+        void SetObjectNoDetachCheck(RecyclableObject* arraySource, uint32 targetLength, uint32 offset = 0);
         void Set(TypedArrayBase* typedArraySource, uint32 offset = 0);
 
         virtual BOOL GetDiagValueString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext) override;
@@ -176,6 +180,9 @@ namespace Js
         static Var GetKeysEntriesValuesHelper(Arguments& args, ScriptContext *scriptContext, LPCWSTR apiName, JavascriptArrayIteratorKind kind);
 
         static uint32 GetFromIndex(Var arg, uint32 length, ScriptContext *scriptContext);
+
+    private:
+        uint32 GetSourceLength(RecyclableObject* arraySource, uint32 targetLength, uint32 offset);
 
     protected:
         static Var CreateNewInstanceFromIterator(RecyclableObject *iterator, ScriptContext *scriptContext, uint32 elementSize, PFNCreateTypedArray pfnCreateTypedArray);
@@ -270,6 +277,24 @@ namespace Js
                 return JavascriptNumber::ToVarWithCheck(typedBuffer[index], GetScriptContext());
             }
             return GetLibrary()->GetUndefined();
+        }
+
+        inline Var BaseTypedDirectGetItemNoDetachCheck(__in uint32 index)
+        {
+            Assert(!IsDetachedBuffer());
+            Assert(index < GetLength());
+            Assert((index + 1)* sizeof(TypeName) + GetByteOffset() <= GetArrayBuffer()->GetByteLength());
+            TypeName* typedBuffer = (TypeName*)buffer;
+            return JavascriptNumber::ToVar(typedBuffer[index], GetScriptContext());
+        }
+
+        inline Var DirectGetItemVarCheckNoDetachCheck(__in uint32 index)
+        {
+            Assert(!IsDetachedBuffer());
+            Assert(index < GetLength());
+            Assert((index + 1)* sizeof(TypeName) + GetByteOffset() <= GetArrayBuffer()->GetByteLength());
+            TypeName* typedBuffer = (TypeName*)buffer;
+            return JavascriptNumber::ToVarWithCheck(typedBuffer[index], GetScriptContext());
         }
 
         inline BOOL DirectSetItemAtRange(TypedArray *fromArray, __in int32 iSrcStart, __in int32 iDstStart, __in uint32 length, TypeName(*convFunc)(Var value, ScriptContext* scriptContext))
@@ -415,10 +440,29 @@ namespace Js
             return FALSE;
         }
 
+        inline BOOL BaseTypedDirectSetItemNoDetachCheck(__in uint32 index, __in Js::Var value, TypeName(*convFunc)(Var value, ScriptContext* scriptContext))
+        {
+            TypeName typedValue = convFunc(value, GetScriptContext());
+
+            // The caller of the function made sure that no IsDetached check required.
+            // The caller of the function also made sure that no length check required.
+
+            Assert(!IsDetachedBuffer());
+            AssertMsg(index < GetLength(), "Trying to set out of bound index for typed array.");
+            Assert((index + 1)* sizeof(TypeName) + GetByteOffset() <= GetArrayBuffer()->GetByteLength());
+            TypeName* typedBuffer = (TypeName*)buffer;
+
+            typedBuffer[index] = typedValue;
+
+            return TRUE;
+        }
+
+
         virtual BOOL DirectSetItem(__in uint32 index, __in Js::Var value) override sealed;
         virtual BOOL DirectSetItemNoSet(__in uint32 index, __in Js::Var value) override sealed;
         virtual Var  DirectGetItem(__in uint32 index) override sealed;
-
+        virtual BOOL DirectSetItemNoDetachCheck(__in uint32 index, __in Js::Var value) override sealed;
+        virtual Var  DirectGetItemNoDetachCheck(__in uint32 index) override sealed;
         virtual Var TypedAdd(__in uint32 index, Var second) override;
         virtual Var TypedAnd(__in uint32 index, Var second) override;
         virtual Var TypedLoad(__in uint32 index) override;
@@ -481,6 +525,8 @@ namespace Js
         virtual BOOL DirectSetItem(__in uint32 index, __in Js::Var value) override;
         virtual BOOL DirectSetItemNoSet(__in uint32 index, __in Js::Var value) override;
         virtual Var  DirectGetItem(__in uint32 index) override;
+        virtual BOOL DirectSetItemNoDetachCheck(__in uint32 index, __in Js::Var value) override;
+        virtual Var  DirectGetItemNoDetachCheck(__in uint32 index) override;
 
         virtual Var TypedAdd(__in uint32 index, Var second) override;
         virtual Var TypedAnd(__in uint32 index, Var second) override;


### PR DESCRIPTION
IsDetached check is not required in the code path where we are
a. constructing a typedarray itself.
b. when source is typedarray.

Fixed that.
Few macro benchmarks (yperf) get good win due to this fix.
