### PR TITLE
Don't hoist InlineeStart in peeps

### DIFF
--- a/lib/Backend/Peeps.cpp
+++ b/lib/Backend/Peeps.cpp
@@ -683,7 +683,10 @@ Peeps::HoistSameInstructionAboveSplit(IR::BranchInstr *branchInstr, IR::Instr *i
     Assert(instr && targetInstr);
     while (!instr->EndsBasicBlock() && !instr->IsLabelInstr() && instr->IsEqual(targetInstr) &&
         !EncoderMD::UsesConditionCode(instr) && !EncoderMD::SetsConditionCode(instr) &&
-        !this->peepsAgen.DependentInstrs(instrSetCondition, instr))
+        !this->peepsAgen.DependentInstrs(instrSetCondition, instr) &&
+        // cannot hoist InlineeStart from branch targets even for the same inlinee function.
+        // it is used by encoder to generate InlineeFrameRecord for each inlinee
+        instr->m_opcode != Js::OpCode::InlineeStart)
     {
         branchNextInstr = instr->GetNextRealInstrOrLabel();
         targetNextInstr = targetInstr->GetNextRealInstrOrLabel();


### PR DESCRIPTION
InlineeStart is hoisted in peeps for branching (the same instruction in branch follower and target is hoisted before branch). The owner function of InlineeStart is not checked for instruction equivalence (actually cannot hoist even for the same function, because the inline ranges in inliner function are different). Hoist InlineeStart causes encoder not generating InlineeFrameRecord for some inlinee which will corrupt baiout and stack walk in such inlinee.
