### PR TITLE
xplat: Better Perf + PAL cleanup

### DIFF
--- a/lib/Common/Core/FaultInjection.cpp
+++ b/lib/Common/Core/FaultInjection.cpp
@@ -137,11 +137,11 @@ namespace Js
         {
             memcpy(&Context, pCtx, sizeof(CONTEXT));
         }
-        RtlZeroMemory(&UnwindHistoryTable, sizeof(UNWIND_HISTORY_TABLE));
+        memset(&UnwindHistoryTable, 0, sizeof(UNWIND_HISTORY_TABLE));
         while (true)
         {
             RuntimeFunction = RtlLookupFunctionEntry(Context.Rip, &ImageBase, &UnwindHistoryTable);
-            RtlZeroMemory(&NvContext, sizeof(KNONVOLATILE_CONTEXT_POINTERS));
+            memset(&NvContext, 0, sizeof(KNONVOLATILE_CONTEXT_POINTERS));
             if (!RuntimeFunction)
             {
                 Context.Rip = (ULONG64)(*(PULONG64)Context.Rsp);
@@ -906,9 +906,9 @@ namespace Js
         {
             RemoveVectoredExceptionHandler(vectoredExceptionHandler);
 
-            // remove the handler from the list second time. 
-            // This code is called inside an exception handler, when the exception handler is called, 
-            // the refcount of the handler in ntdll!LdrpVectorHandlerList is increased, 
+            // remove the handler from the list second time.
+            // This code is called inside an exception handler, when the exception handler is called,
+            // the refcount of the handler in ntdll!LdrpVectorHandlerList is increased,
             // so need to call RemoveVectoredExceptionHandler twice to really remove the handler from the list
             // otherwise the exception from the handler itself will re-enter the handler
             RemoveVectoredExceptionHandler(vectoredExceptionHandler);
@@ -1080,7 +1080,7 @@ namespace Js
         case CountOnly:
             break;
         case DisplayAvailableFaultTypes:
-        case InstallExceptionHandlerOnly:        
+        case InstallExceptionHandlerOnly:
             return false;
         default:
             AssertMsg(false, "Invalid FaultInjection mode");
@@ -1206,7 +1206,7 @@ namespace Js
 
         bool needDump = true;
         uintptr_t ip = (uintptr_t)ep->ExceptionRecord->ExceptionAddress;
-        uintptr_t offset = 0;       
+        uintptr_t offset = 0;
 
         // static to not use local stack space since stack space might be low at this point
         THREAD_LOCAL static char16 modulePath[MAX_PATH + 1];
@@ -1435,7 +1435,7 @@ namespace Js
         if (ExceptionInfo->ExceptionRecord->ExceptionCode == STATUS_STACK_OVERFLOW) // hard stack overflow
         {
             DebugBreak(); // let the postmortem debugger to create the dump, make sure they are filing bug with same bucket
-        }        
+        }
 
         __try
         {

--- a/lib/Common/Memory/HeapInfo.cpp
+++ b/lib/Common/Memory/HeapInfo.cpp
@@ -46,37 +46,6 @@ ushort ValidPointers<TBlockAttributes>::GetInteriorAddressIndex(uint index) cons
 }
 
 template <class TBlockAttributes>
-const ValidPointers<TBlockAttributes>
-HeapInfo::ValidPointersMap<TBlockAttributes>::GetValidPointersForIndex(uint index) const
-{
-    Assert(index < TBlockAttributes::BucketCount);
-    __analysis_assume(index < TBlockAttributes::BucketCount);
-    return validPointersBuffer[index];
-}
-
-template <class TBlockAttributes>
-const typename SmallHeapBlockT<TBlockAttributes>::SmallHeapBlockBitVector *
-HeapInfo::ValidPointersMap<TBlockAttributes>::GetInvalidBitVector(uint index) const
-{
-    Assert(index < TBlockAttributes::BucketCount);
-    __analysis_assume(index < TBlockAttributes::BucketCount);
-#if USE_STATIC_VPM
-    return &(*invalidBitsBuffers)[index];
-#else
-    return &invalidBitsBuffers[index];
-#endif
-}
-
-template <class TBlockAttributes>
-const typename SmallHeapBlockT<TBlockAttributes>::BlockInfo *
-HeapInfo::ValidPointersMap<TBlockAttributes>::GetBlockInfo (uint index) const
-{
-    Assert(index < TBlockAttributes::BucketCount);
-    __analysis_assume(index < TBlockAttributes::BucketCount);
-    return blockInfoBuffer[index];
-}
-
-template <class TBlockAttributes>
 void HeapInfo::ValidPointersMap<TBlockAttributes>::GenerateValidPointersMap(ValidPointersMapTable& validTable, InvalidBitsTable& invalidTable, BlockInfoMapTable& blockInfoTable)
 {
     // Create the valid pointer map to be shared by the buckets.

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -8697,18 +8697,19 @@ namespace Js
                     // compact the types array by moving non-null types
                     // at the beginning.
                     this->types[nonNullIndex++] = type;
-                    isAnyTypeLive = true;
 #if DBG
                     isGuardValuePresent = this->guard->GetValue() == reinterpret_cast<intptr_t>(type) ? true : isGuardValuePresent;
 #endif
+                    this->types[i] = nullptr;
                 }
             }
         }
+
         if (nonNullIndex > 0)
         {
-            memset((void*)(this->types + nonNullIndex), 0, sizeof(Js::Type*) * (EQUIVALENT_TYPE_CACHE_SIZE - nonNullIndex));
+            isAnyTypeLive = true;
         }
-        else if(guard->IsInvalidatedDuringSweep())
+        else if (guard->IsInvalidatedDuringSweep())
         {
             // just mark this as actual invalidated since there are no types
             // present

--- a/pal/inc/pal.h
+++ b/pal/inc/pal.h
@@ -3978,21 +3978,6 @@ ReadProcessMemory(
           IN SIZE_T nSize,
           OUT SIZE_T * lpNumberOfBytesRead);
 
-PALIMPORT
-VOID
-PALAPI
-RtlMoveMemory(
-          IN PVOID Destination,
-          IN CONST VOID *Source,
-          IN SIZE_T Length);
-
-PALIMPORT
-VOID
-PALAPI
-RtlZeroMemory(
-    IN PVOID Destination,
-    IN SIZE_T Length);
-
 #define MoveMemory memmove
 #define CopyMemory memcpy
 #define FillMemory(Destination,Length,Fill) memset((Destination),(Fill),(Length))

--- a/pal/inc/pal_safecrt.h
+++ b/pal/inc/pal_safecrt.h
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -36,13 +36,6 @@ Wrapper for including SafeCRT for Mac build of CoreCLR
 #define _SAFECRT_SET_ERRNO 0
 #define _SAFECRT_DEFINE_MBS_FUNCTIONS 0
 #define _SAFECRT_DEFINE_TCS_MACROS 1
-//#define _SAFECRT_INVALID_PARAMETER(message) WARN(message "\n")
-
-#if defined (SAFECRT_IN_PAL)
-
-#define DUMMY_memset void * __cdecl memset(void *, int, size_t);
-
-#endif
 
 // Include the safecrt implementation
 #include "../../palrt/inc/safecrt.h"

--- a/pal/src/include/pal/palinternal.h
+++ b/pal/src/include/pal/palinternal.h
@@ -177,7 +177,6 @@ function_name() to call the system's implementation
 #define div_t DUMMY_div_t
 #define memcpy DUMMY_memcpy
 #define memcmp DUMMY_memcmp
-#define memset DUMMY_memset
 #define memchr DUMMY_memchr
 #define strlen DUMMY_strlen
 #define strnlen DUMMY_strnlen
@@ -359,7 +358,6 @@ function_name() to call the system's implementation
 #undef div_t
 #undef memcpy
 #undef memcmp
-#undef memset
 #undef memmove
 #undef memchr
 #undef strlen

--- a/pal/src/memory/heap.cpp
+++ b/pal/src/memory/heap.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -48,7 +48,7 @@ SET_DEFAULT_DEBUG_CHANNEL(MEM);
  *
  * We need to know whether an instruction pointer fault is in our executable
  * heap, but the intersection between the HeapX functions on Windows and the
- * malloc_zone functions on Mac OS X are somewhat at odds and we'd have to 
+ * malloc_zone functions on Mac OS X are somewhat at odds and we'd have to
  * implement an unnecessarily complicated HeapWalk. Instead, we cache the only
  * "heap" we create, knowing it's the executable heap, and use that instead
  * with the much simpler malloc_zone_from_ptr.
@@ -56,51 +56,6 @@ SET_DEFAULT_DEBUG_CHANNEL(MEM);
 extern malloc_zone_t *s_pExecutableHeap;
 malloc_zone_t *s_pExecutableHeap = NULL;
 #endif // CACHE_HEAP_ZONE
-
-/*++
-Function:
-  RtlMoveMemory
-
-See MSDN doc.
---*/
-VOID
-PALAPI
-RtlMoveMemory(
-          IN PVOID Destination,
-          IN CONST VOID *Source,
-          IN SIZE_T Length)
-{
-    PERF_ENTRY(RtlMoveMemory);
-    ENTRY("RtlMoveMemory(Destination:%p, Source:%p, Length:%d)\n", 
-          Destination, Source, Length);
-    
-    memmove(Destination, Source, Length);
-    
-    LOGEXIT("RtlMoveMemory returning\n");
-    PERF_EXIT(RtlMoveMemory);
-}
-
-/*++
-Function:
-  RtlZeroMemory
-
-See MSDN doc.
---*/
-VOID
-PALAPI
-RtlZeroMemory(
-    PVOID Destination,
-    SIZE_T Length
-)
-{
-    PERF_ENTRY(RtlZeroMemory);
-    ENTRY("RtlZeroMemory(Destination:%p, Length:%x)\n", Destination, Length);
-    
-    memset(Destination, 0, Length);
-    
-    LOGEXIT("RtlZeroMemory returning.\n");
-    PERF_EXIT(RtlZeroMemory);
-}
 
 /*++
 Function:
@@ -139,7 +94,7 @@ HeapCreate(
     {
         ret = (HANDLE)malloc_create_zone(dwInitialSize, 0 /* flags */);
     }
-    
+
 #else // __APPLE__
     ret = (HANDLE)DUMMY_HEAP;
 #endif // __APPLE__
@@ -183,7 +138,7 @@ GetProcessHeap(
 #else
     ret = (HANDLE) DUMMY_HEAP;
 #endif
-  
+
     LOGEXIT("GetProcessHeap returning HANDLE %p\n", ret);
     PERF_EXIT(GetProcessHeap);
     return ret;
@@ -282,7 +237,7 @@ HeapFree(
     BOOL bRetVal = FALSE;
 
     PERF_ENTRY(HeapFree);
-    ENTRY("HeapFree (hHeap=%p, dwFlags = %#x, lpMem=%p)\n", 
+    ENTRY("HeapFree (hHeap=%p, dwFlags = %#x, lpMem=%p)\n",
           hHeap, dwFlags, lpMem);
 
 #ifdef __APPLE__


### PR DESCRIPTION
On xplat, measured ~20% better perf with Octane. Didn't check others.

Details;
- Cleanup RtlXXXX stuff from PAL and ch. FaultInjection is not yet active on Xplat.
- inline couple of one liner methods (they are in a very hot zone)
- prefered updating array index in place instead of a seperate memset call (in a very hot zone)