### PR TITLE
Asm.js revert backend optimization

### DIFF
--- a/lib/Backend/IR.cpp
+++ b/lib/Backend/IR.cpp
@@ -3618,7 +3618,6 @@ bool Instr::BinaryCalculator(IntConstType src1Const, IntConstType src2Const, Int
 
     switch (this->m_opcode)
     {
-    case Js::OpCode::Add_I4:
     case Js::OpCode::Add_A:
         if (IntConstMath::Add(src1Const, src2Const, &value))
         {
@@ -3626,7 +3625,6 @@ bool Instr::BinaryCalculator(IntConstType src1Const, IntConstType src2Const, Int
         }
         break;
 
-    case Js::OpCode::Sub_I4:
     case Js::OpCode::Sub_A:
         if (IntConstMath::Sub(src1Const, src2Const, &value))
         {
@@ -3634,7 +3632,6 @@ bool Instr::BinaryCalculator(IntConstType src1Const, IntConstType src2Const, Int
         }
         break;
 
-    case Js::OpCode::Mul_I4:
     case Js::OpCode::Mul_A:
         if (IntConstMath::Mul(src1Const, src2Const, &value))
         {
@@ -3648,7 +3645,6 @@ bool Instr::BinaryCalculator(IntConstType src1Const, IntConstType src2Const, Int
         }
         break;
 
-    case Js::OpCode::Div_I4:
     case Js::OpCode::Div_A:
         if (src2Const == 0)
         {
@@ -3672,7 +3668,6 @@ bool Instr::BinaryCalculator(IntConstType src1Const, IntConstType src2Const, Int
         }
         break;
 
-    case Js::OpCode::Rem_I4:
     case Js::OpCode::Rem_A:
 
         if (src2Const == 0)
@@ -3692,19 +3687,16 @@ bool Instr::BinaryCalculator(IntConstType src1Const, IntConstType src2Const, Int
         }
         break;
 
-    case Js::OpCode::Shl_I4:
     case Js::OpCode::Shl_A:
         // We don't care about overflow here
         IntConstMath::Shl(src1Const, src2Const & 0x1F, &value);
         break;
 
-    case Js::OpCode::Shr_I4:
     case Js::OpCode::Shr_A:
         // We don't care about overflow here, and there shouldn't be any
         IntConstMath::Shr(src1Const, src2Const & 0x1F, &value);
         break;
 
-    case Js::OpCode::ShrU_I4:
     case Js::OpCode::ShrU_A:
         // We don't care about overflow here, and there shouldn't be any
         IntConstMath::ShrU(src1Const, src2Const & 0x1F, &value);
@@ -3716,19 +3708,16 @@ bool Instr::BinaryCalculator(IntConstType src1Const, IntConstType src2Const, Int
         }
         break;
 
-    case Js::OpCode::And_I4:
     case Js::OpCode::And_A:
         // We don't care about overflow here, and there shouldn't be any
         IntConstMath::And(src1Const, src2Const, &value);
         break;
 
-    case Js::OpCode::Or_I4:
     case Js::OpCode::Or_A:
         // We don't care about overflow here, and there shouldn't be any
         IntConstMath::Or(src1Const, src2Const, &value);
         break;
 
-    case Js::OpCode::Xor_I4:
     case Js::OpCode::Xor_A:
         // We don't care about overflow here, and there shouldn't be any
         IntConstMath::Xor(src1Const, src2Const, &value);
@@ -3757,7 +3746,6 @@ bool Instr::UnaryCalculator(IntConstType src1Const, IntConstType *pResult)
 
     switch (this->m_opcode)
     {
-    case Js::OpCode::Neg_I4:
     case Js::OpCode::Neg_A:
         if (src1Const == 0)
         {
@@ -3771,7 +3759,6 @@ bool Instr::UnaryCalculator(IntConstType src1Const, IntConstType *pResult)
         }
         break;
 
-    case Js::OpCode::Not_I4:
     case Js::OpCode::Not_A:
         IntConstMath::Not(src1Const, &value);
         break;
@@ -3786,7 +3773,6 @@ bool Instr::UnaryCalculator(IntConstType src1Const, IntConstType *pResult)
         break;
 
     case Js::OpCode::Conv_Num:
-    case Js::OpCode::LdC_A_I4:
     case Js::OpCode::Ld_I4:
         value = src1Const;
         break;
@@ -3816,11 +3802,6 @@ bool Instr::UnaryCalculator(IntConstType src1Const, IntConstType *pResult)
             value = src1Const < 0 ? -src1Const : src1Const;
         }
         break;
-
-    case Js::OpCode::Ctz:
-        Assert(this->GetSrc1()->GetSize() <= 4);
-        value = Wasm::WasmMath::Ctz((int)src1Const);
-        this->ClearBailOutInfo();
 
     case Js::OpCode::InlineMathClz:
         DWORD clz;


### PR DESCRIPTION
Reverts an optimization done in #1806.

We can't calculate const math in asm.js and wasm the same way we do for normal javascript.
The following case is erroneous.
```js
// flags: -maic:1
var asmHeap = new ArrayBuffer(1 << 20);
var m = function (stdlib, foreign, heap) {
  'use asm';
  function f(d0, i1) {
    d0 = +d0;
    i1 = i1 | 0;
    return 248749990 / 4294967295 | 0;
  }
  return f;
}({}, {}, asmHeap);
print(m());
print(m());
// Expected Output:
// 0
// 0
// Actual Output:
// 0
// -248749990
```

I am adding this work item in the wasm todo list to revisit this at a later time.
Most likely most operators can do it the same way as javascript, but it needs deeper investigation to find and deal with the special cases.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/1852)
<!-- Reviewable:end -->
