### PR TITLE
xplat: Better Performance

### DIFF
--- a/lib/Common/Memory/HeapInfo.cpp
+++ b/lib/Common/Memory/HeapInfo.cpp
@@ -46,37 +46,6 @@ ushort ValidPointers<TBlockAttributes>::GetInteriorAddressIndex(uint index) cons
 }
 
 template <class TBlockAttributes>
-const ValidPointers<TBlockAttributes>
-HeapInfo::ValidPointersMap<TBlockAttributes>::GetValidPointersForIndex(uint index) const
-{
-    Assert(index < TBlockAttributes::BucketCount);
-    __analysis_assume(index < TBlockAttributes::BucketCount);
-    return validPointersBuffer[index];
-}
-
-template <class TBlockAttributes>
-const typename SmallHeapBlockT<TBlockAttributes>::SmallHeapBlockBitVector *
-HeapInfo::ValidPointersMap<TBlockAttributes>::GetInvalidBitVector(uint index) const
-{
-    Assert(index < TBlockAttributes::BucketCount);
-    __analysis_assume(index < TBlockAttributes::BucketCount);
-#if USE_STATIC_VPM
-    return &(*invalidBitsBuffers)[index];
-#else
-    return &invalidBitsBuffers[index];
-#endif
-}
-
-template <class TBlockAttributes>
-const typename SmallHeapBlockT<TBlockAttributes>::BlockInfo *
-HeapInfo::ValidPointersMap<TBlockAttributes>::GetBlockInfo (uint index) const
-{
-    Assert(index < TBlockAttributes::BucketCount);
-    __analysis_assume(index < TBlockAttributes::BucketCount);
-    return blockInfoBuffer[index];
-}
-
-template <class TBlockAttributes>
 void HeapInfo::ValidPointersMap<TBlockAttributes>::GenerateValidPointersMap(ValidPointersMapTable& validTable, InvalidBitsTable& invalidTable, BlockInfoMapTable& blockInfoTable)
 {
     // Create the valid pointer map to be shared by the buckets.


### PR DESCRIPTION
On xplat, measured ~8-12% better perf with Octane. Didn't check others.
This should also affect Windows performance numbers.

- replaced `memset` call with an in-place assignment. `memset` was taking the most expensive path.

less importantly;
- inline couple of one liner methods (they are in a very hot zone)

EDIT: Revising ~20% to ~8-12% . Tested on a cleaner system.