### PR TITLE
Bugfix: Initialization of allocationBuckets in multi-thread env

### DIFF
--- a/lib/Runtime/Library/JavascriptArray.inl
+++ b/lib/Runtime/Library/JavascriptArray.inl
@@ -1670,18 +1670,12 @@ SECOND_PASS:
     template<class ArrayType> 
     void JavascriptArray::EnsureCalculationOfAllocationBuckets()
     {
-        // If allocation size for current ArrayType has already calculated, no need to recalculate it.
-        bool determineAllocationSize = ArrayType::allocationBuckets[0][MissingElementsCountIndex] == 0;
-        if (determineAllocationSize)
+        uint temp;
+        for (uint8 i = 0;i < ArrayType::AllocationBucketsCount;i++)
         {
-            uint temp;
-            for (uint8 i = 0;i < ArrayType::AllocationBucketsCount;i++)
-            {
-                ArrayType::allocationBuckets[i][AllocationSizeIndex] = (uint)DetermineAllocationSize<ArrayType, 0>(ArrayType::allocationBuckets[i][AllocationBucketIndex], nullptr, &temp);
-                ArrayType::allocationBuckets[i][MissingElementsCountIndex] = temp;
-            }
+            ArrayType::allocationBuckets[i][AllocationSizeIndex] = (uint)DetermineAllocationSize<ArrayType, 0>(ArrayType::allocationBuckets[i][AllocationBucketIndex], nullptr, &temp);
+            ArrayType::allocationBuckets[i][MissingElementsCountIndex] = temp;
         }
-        return;
     }
 
     template<class ArrayType, uint InlinePropertySlots>

--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -86,6 +86,7 @@ namespace Js
         InitializeGlobal(globalObject);
         InitializeComplexThings();
         InitializeStaticValues();
+        PrecalculateArrayAllocationBuckets();
 
 #if ENABLE_COPYONACCESS_ARRAY
         if (!PHASE_OFF1(CopyOnAccessArrayPhase))
@@ -749,6 +750,14 @@ namespace Js
             Assert(status);
             function->SetPropertyWithAttributes(PropertyIds::name, functionName, PropertyConfigurable, nullptr);
         }
+    }
+
+    /* static */
+    void JavascriptLibrary::PrecalculateArrayAllocationBuckets()
+    {
+        JavascriptArray::EnsureCalculationOfAllocationBuckets<Js::JavascriptNativeIntArray>();
+        JavascriptArray::EnsureCalculationOfAllocationBuckets<Js::JavascriptNativeFloatArray>();
+        JavascriptArray::EnsureCalculationOfAllocationBuckets<Js::JavascriptArray>();
     }
 
     template<bool addPrototype>

--- a/lib/Runtime/Library/JavascriptLibrary.h
+++ b/lib/Runtime/Library/JavascriptLibrary.h
@@ -1136,6 +1136,7 @@ namespace Js
         void InitializePrototypes();
         void InitializeTypes();
         void InitializeGlobal(GlobalObject * globalObject);
+        static void PrecalculateArrayAllocationBuckets();
 
         static void __cdecl InitializeArrayConstructor(DynamicObject* arrayConstructor, DeferredTypeHandlerBase * typeHandler, DeferredInitializeMode mode);
         static void __cdecl InitializeArrayPrototype(DynamicObject* arrayPrototype, DeferredTypeHandlerBase * typeHandler, DeferredInitializeMode mode);


### PR DESCRIPTION
In #1363, I added a static AllocationBuckets 2D matrix for JavascriptArray that will be initialize at runtime. However it can be simultaneously accessed by 2 threads (runtime and code-gen) and one thread might use old information of this matrix. Fixed it by adding a boolean flag to indicate when the initialization of matrix is done.
For ARM, since order of reads/writes are not guaranteed, added `MemoryBarrier` before reading and after writing to this boolean variable.

Test: Unit test passes.