### PR TITLE
Generating branch and compare fast paths in additional conditions

### DIFF
--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -20007,7 +20007,8 @@ bool Lowerer::GenerateFastBooleanAndObjectEqLikely(IR::Instr * instr, IR::Opnd *
         break;
     }
 
-    if (src1->GetValueType().IsLikelyBoolean() && src2->GetValueType().IsLikelyBoolean())
+    bool generateObjectFastPath = true;
+    if ((src1->GetValueType().IsLikelyBoolean() || src1->GetValueType().HasBeenBoolean()) && (src2->GetValueType().IsLikelyBoolean() && src2->GetValueType().HasBeenBoolean()))
     {
         //
         // Booleans
@@ -20037,8 +20038,15 @@ bool Lowerer::GenerateFastBooleanAndObjectEqLikely(IR::Instr * instr, IR::Opnd *
                 instr->InsertBefore(IR::BranchInstr::New(LowererMD::MDUncondBranchOpcode, labelHelper, this->m_func));
             }
         }
+
+        if (src1->GetValueType().IsLikelyBoolean() && src2->GetValueType().IsLikelyBoolean())
+        {
+            generateObjectFastPath = false;
+        }
     }
-    else if (src1->GetValueType().IsLikelyObject() && src2->GetValueType().IsLikelyObject())
+
+    if (generateObjectFastPath &&
+        (src1->GetValueType().IsLikelyObject() || src1->GetValueType().HasBeenObject()) && (src2->GetValueType().IsLikelyObject() || src2->GetValueType().HasBeenObject()))
     {
         //
         // Objects

--- a/lib/Backend/LowerMDShared.cpp
+++ b/lib/Backend/LowerMDShared.cpp
@@ -2442,8 +2442,8 @@ LowererMD::GenerateFastBrOrCmString(IR::Instr* instr)
         !srcReg2 ||
         srcReg1->IsTaggedInt() ||
         srcReg2->IsTaggedInt() ||
-        !srcReg1->GetValueType().IsLikelyString() ||
-        !srcReg2->GetValueType().IsLikelyString())
+        (!srcReg1->GetValueType().IsLikelyString() && !srcReg1->GetValueType().HasBeenString()) ||
+        (!srcReg2->GetValueType().IsLikelyString() && !srcReg2->GetValueType().HasBeenString()))
     {
         return false;
     }
@@ -2556,7 +2556,12 @@ LowererMD::GenerateFastBrOrCmString(IR::Instr* instr)
 
     labelFallthrough->m_noHelperAssert = true;
 #endif
-
+    if (!srcReg1->GetValueType().IsLikelyString() || !srcReg2->GetValueType().IsLikelyString())
+    {
+        // If either of the sources were not likely stings but had been strings in the past,
+        // continue generating fast paths for other value types.
+        return false;
+    }
     return true;
 }
 

--- a/lib/Backend/arm/LowerMD.cpp
+++ b/lib/Backend/arm/LowerMD.cpp
@@ -3114,8 +3114,8 @@ LowererMD::GenerateFastBrOrCmString(IR::Instr* instr)
 
     // Check that we likely have strings or know we have strings as the arguments
     if (!regSrc1 || !regSrc2 ||
-        !regSrc1->GetValueType().IsLikelyString() ||
-        !regSrc2->GetValueType().IsLikelyString())
+        (!regSrc1->GetValueType().IsLikelyString() && !regSrc1->GetValueType().HasBeenString()) ||
+        (!regSrc2->GetValueType().IsLikelyString() && !regSrc2->GetValueType().HasBeenString()))
     {
         return false;
     }
@@ -3186,6 +3186,12 @@ LowererMD::GenerateFastBrOrCmString(IR::Instr* instr)
 
     instr->InsertAfter(labelFail);
 
+    if (!regSrc1->GetValueType().IsLikelyString() || !regSrc2->GetValueType().IsLikelyString())
+    {
+        // If either of the sources were not likely stings but had been strings in the past,
+        // continue generating fast paths for other value types.
+        return false;
+    }
     return true;
 }
 

--- a/test/Operators/strictequal.baseline
+++ b/test/Operators/strictequal.baseline
@@ -2807,3 +2807,10 @@ all[52](function foo() {}) === all[49](1,2,3) = false
 all[52](function foo() {}) === all[50]([object Object]) = false
 all[52](function foo() {}) === all[51](1,2,3) = false
 all[52](function foo() {}) === all[52](function foo() {}) = true
+true
+true
+true
+false
+false
+true
+false

--- a/test/Operators/strictequal.js
+++ b/test/Operators/strictequal.js
@@ -27,3 +27,38 @@ for (var i=0; i<all.length; ++i) {
         write("all[" + i + "](" + all[i] + ") === all[" + j + "](" + all[j] + ") = " + (all[i] === all[j]));
     }
 }
+
+function test(o1, o2)
+{
+  if(typeof o1 !== typeof o2){
+    return false;
+  }
+  if(o1 === o2){
+    return true;
+  }
+  
+  if(typeof o1 == "object"){
+    var props = {};
+    for(var prop in o1) {
+      if (!test(o1[prop], o2[prop])) return false;
+      props[prop] = true;
+    }
+    for(var prop in o2) {
+      if (!props[prop]) 
+        return false;
+    }
+    return true;
+  }
+  else{
+    return false
+  }
+}
+
+print(test({prop1: {}, prop2: "abc", prop3: true}, {prop1: {}, prop2: "abc", prop3: true}));
+print(test("abc", "abc"));
+print(test({int: 1, string: "xyz"}, {int: 1, string: "xyz"}));
+print(test({int: 1, string: "xyz", bool: false}, {int: 1, string: "xyz", float: 1.2}));
+print(test({}, {}));
+print(test(1,2));
+print(test(true, false));
+print(test(new Object(), true));


### PR DESCRIPTION
Allow generating string and object fast paths for branches and compares even if, along with strings and objects, we have seen objects of types other than string/object.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/1898)
<!-- Reviewable:end -->
