### PR TITLE
fix case where reused property record isn't updated correctly on server

### DIFF
--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -1119,8 +1119,10 @@ ThreadContext::AddPropertyRecordInternal(const Js::PropertyRecord * propertyReco
         Assert(m_reclaimedJITProperties);
         if (propertyRecord->IsNumeric())
         {
-            m_pendingJITProperties->Prepend(propertyRecord->GetPropertyId());
-            m_reclaimedJITProperties->Remove(propertyRecord->GetPropertyId());
+            if (!m_reclaimedJITProperties->Remove(propertyRecord->GetPropertyId()))
+            {
+                m_pendingJITProperties->Prepend(propertyRecord->GetPropertyId());
+            }
         }
     }
 #endif


### PR DESCRIPTION
There was a synchronization issue between numeric property map on server and runtime.

The following is the problematic sequence:
Add numeric property id
Update server map
Reclaim that property id
Add same numeric property id (this incorrectly causes to be put on pendingPropsList)
Remove that property (since it is in pendingPropsList, we don't think we need to update server)
Add same non-numeric property id
update server map (does nothing; should remove propId)
Codegen (with that propid used in an InitFld).

The server still has this propId in numeric props list, which breaks some assumptions in globopt.