### PR TITLE
fix assert in cleaning up scriptContext

### DIFF
--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -503,8 +503,11 @@ namespace Js
         if (m_remoteScriptContextAddr)
         {
             Assert(JITManager::GetJITManager()->IsOOPJITEnabled());
-            JITManager::GetJITManager()->CleanupScriptContext(&m_remoteScriptContextAddr);
-            Assert(m_remoteScriptContextAddr == nullptr);
+            if (JITManager::GetJITManager()->CleanupScriptContext(&m_remoteScriptContextAddr) == S_OK)
+            {
+                Assert(m_remoteScriptContextAddr == nullptr);
+            }
+            m_remoteScriptContextAddr = nullptr;
         }
 #endif
 


### PR DESCRIPTION
only when server call succeeded the server context would be reset to null
