### PR TITLE
Bugfix: Retain slot capacity while type sharing

### DIFF
--- a/lib/Runtime/Types/DynamicType.cpp
+++ b/lib/Runtime/Types/DynamicType.cpp
@@ -11,6 +11,9 @@ namespace Js
 
     DynamicType::DynamicType(DynamicType * type, DynamicTypeHandler *typeHandler, bool isLocked, bool isShared)
         : Type(type), typeHandler(typeHandler), isLocked(isLocked), isShared(isShared)
+#if DBG
+        , isCachedForChangePrototype(false)
+#endif
     {
         Assert(!this->isLocked || this->typeHandler->GetIsLocked());
         Assert(!this->isShared || this->typeHandler->GetIsShared());
@@ -19,6 +22,9 @@ namespace Js
 
     DynamicType::DynamicType(ScriptContext* scriptContext, TypeId typeId, RecyclableObject* prototype, JavascriptMethod entryPoint, DynamicTypeHandler * typeHandler, bool isLocked, bool isShared)
         : Type(scriptContext, typeId, prototype, entryPoint) , typeHandler(typeHandler), isLocked(isLocked), isShared(isShared), hasNoEnumerableProperties(false)
+#if DBG
+        , isCachedForChangePrototype(false)
+#endif
     {
         Assert(typeHandler != nullptr);
         Assert(!this->isLocked || this->typeHandler->GetIsLocked());

--- a/lib/Runtime/Types/DynamicType.h
+++ b/lib/Runtime/Types/DynamicType.h
@@ -29,6 +29,9 @@ namespace Js
         bool isLocked;
         bool isShared;
         bool hasNoEnumerableProperties;
+#if DBG
+        bool isCachedForChangePrototype;
+#endif
 
     protected:
         DynamicType(DynamicType * type) : Type(type), typeHandler(type->typeHandler), isLocked(false), isShared(false) {}
@@ -41,6 +44,10 @@ namespace Js
         void SetPrototype(RecyclableObject* newPrototype) { this->prototype = newPrototype; }
         bool GetIsLocked() const { return this->isLocked; }
         bool GetIsShared() const { return this->isShared; }
+#if DBG
+        bool GetIsCachedForChangePrototype() const { return this->isCachedForChangePrototype; }
+        void SetIsCachedForChangePrototype() { this->isCachedForChangePrototype = true; }
+#endif
         void SetEntryPoint(JavascriptMethod method) { entryPoint = method; }
 
         BOOL AllPropertiesAreEnumerable() { return typeHandler->AllPropertiesAreEnumerable(); }

--- a/lib/Runtime/Types/PathTypeHandler.cpp
+++ b/lib/Runtime/Types/PathTypeHandler.cpp
@@ -1566,7 +1566,7 @@ namespace Js
 
         if (cachedDynamicType == nullptr)
         {
-            SimplePathTypeHandler* newTypeHandler = SimplePathTypeHandler::New(scriptContext, scriptContext->GetLibrary()->GetRootPath(), 0, this->GetInlineSlotCapacity(), this->GetOffsetOfInlineSlots(), true, true);
+            SimplePathTypeHandler* newTypeHandler = SimplePathTypeHandler::New(scriptContext, scriptContext->GetLibrary()->GetRootPath(), 0, static_cast<PropertyIndex>(this->GetSlotCapacity()), this->GetInlineSlotCapacity(), this->GetOffsetOfInlineSlots(), true, true);
 
             cachedDynamicType = instance->DuplicateType();
             cachedDynamicType->typeHandler = newTypeHandler;
@@ -1597,6 +1597,9 @@ namespace Js
                 }
 
                 // oldType is kind of weakReference here
+#if DBG
+                cachedDynamicType->SetIsCachedForChangePrototype();
+#endif
                 oldTypeToPromotedTypeMap->Item(reinterpret_cast<uintptr_t>(oldType), cachedDynamicType);
 
                 if (PHASE_TRACE1(TypeShareForChangePrototypePhase))
@@ -1650,8 +1653,9 @@ namespace Js
 
 
         // Make sure the offsetOfInlineSlots and inlineSlotCapacity matches with currentTypeHandler
-        Assert(cachedDynamicType->typeHandler->GetOffsetOfInlineSlots() == GetOffsetOfInlineSlots());
-        Assert(cachedDynamicType->typeHandler->GetInlineSlotCapacity() == roundedInlineSlotCapacity);
+        Assert(cachedDynamicType->GetTypeHandler()->GetOffsetOfInlineSlots() == GetOffsetOfInlineSlots());
+        Assert(cachedDynamicType->GetTypeHandler()->GetSlotCapacity() == this->GetSlotCapacity());
+        Assert(DynamicObject::IsTypeHandlerCompatibleForObjectHeaderInlining(this, cachedDynamicType->GetTypeHandler()));
 
         cachedDynamicType->SetPrototype(newPrototype);
         instance->ReplaceType(cachedDynamicType);


### PR DESCRIPTION
See [9020511](https://microsoft.visualstudio.com//defaultcollection/OS/_workItems?_a=edit&id=9020511&triage=true)

If we are sharing types, we should make sure the old type and new type has same slotCapacity. Added additional assert.

Also add a `DBG` only flag on `DynamicType` that will indicate if the type was cached for ChangePrototype feature. This will make debugging easy especially when one of the cached types are involved in failure in OOP codegen.
    