### PR TITLE
swb: strictly check write barrier bit

### DIFF
--- a/lib/Backend/CodeGenNumberAllocator.cpp
+++ b/lib/Backend/CodeGenNumberAllocator.cpp
@@ -106,7 +106,7 @@ CodeGenNumberThreadAllocator::AllocNewNumberBlock()
     {
         Assert(cs.IsLocked());
         // Reserve the segment, but not committing it
-        currentNumberSegment = PageAllocator::AllocPageSegment(pendingIntegrationNumberSegment, this->recycler->GetRecyclerLeafPageAllocator(), false, true);
+        currentNumberSegment = PageAllocator::AllocPageSegment(pendingIntegrationNumberSegment, this->recycler->GetRecyclerLeafPageAllocator(), false, true, false);
         if (currentNumberSegment == nullptr)
         {
             currentNumberBlockEnd = nullptr;
@@ -153,7 +153,7 @@ CodeGenNumberThreadAllocator::AllocNewChunkBlock()
     {
         Assert(cs.IsLocked());
         // Reserve the segment, but not committing it
-        currentChunkSegment = PageAllocator::AllocPageSegment(pendingIntegrationChunkSegment, this->recycler->GetRecyclerPageAllocator(), false, true);
+        currentChunkSegment = PageAllocator::AllocPageSegment(pendingIntegrationChunkSegment, this->recycler->GetRecyclerPageAllocator(), false, true, false);
         if (currentChunkSegment == nullptr)
         {
             currentChunkBlockEnd = nullptr;
@@ -501,7 +501,7 @@ void XProcNumberPageSegmentManager::Integrate()
                 auto leafPageAllocator = recycler->GetRecyclerLeafPageAllocator();
                 DListBase<PageSegment> segmentList;
                 temp->pageSegment = (intptr_t)leafPageAllocator->AllocPageSegment(segmentList, leafPageAllocator,
-                    (void*)temp->pageAddress, XProcNumberPageSegmentImpl::PageCount, temp->committedEnd / AutoSystemInfo::PageSize);
+                    (void*)temp->pageAddress, XProcNumberPageSegmentImpl::PageCount, temp->committedEnd / AutoSystemInfo::PageSize, false);
 
                 if (temp->pageSegment)
                 {

--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -1475,6 +1475,9 @@ FLAGNR(Boolean, CFG, "Force enable CFG on jshost. version in the jshost's manife
 
 FLAGR(Number, JITServerIdleTimeout, "Idle timeout in seconds to do the cleanup in JIT server", 10)
 FLAGR(Number, JITServerMaxInactivePageAllocatorCount, "Max inactive page allocators to keep before schedule a cleanup", 10)
+
+FLAGNR(Boolean, StrictWriteBarrierCheck, "Check write barrier setting on none write barrier pages", false)
+
 #undef FLAG_REGOVR_EXP
 #undef FLAG_REGOVR_ASMJS
 

--- a/lib/Common/DataStructures/DList.h
+++ b/lib/Common/DataStructures/DList.h
@@ -59,6 +59,10 @@ public:
     template <typename TParam1, typename TParam2, typename TParam3, typename TParam4>
     DListNode(TParam1 param1, TParam2 param2, TParam3 param3, TParam4 param4) : data(param1, param2, param3, param4) {}
 
+    // Constructing with parameter
+    template <typename TParam1, typename TParam2, typename TParam3, typename TParam4, typename TParam5>
+    DListNode(TParam1 param1, TParam2 param2, TParam3 param3, TParam4 param4, TParam5 param5) : data(param1, param2, param3, param4, param5) {}
+
     // Constructing using copy constructor
     DListNode(TData const& data) : data(data) {};
     TData data;
@@ -299,6 +303,19 @@ public:
     TData * PrependNode(TAllocator * allocator, TParam1 param1, TParam2 param2, TParam3 param3, TParam4 param4)
     {
         Node * newNode = AllocatorNew(TAllocator, allocator, Node, param1, param2, param3, param4);
+        if (newNode)
+        {
+            DListBase::InsertNodeBefore(this->Next(), newNode);
+            this->IncrementCount();
+            return &newNode->data;
+        }
+        return nullptr;
+    }
+
+    template <typename TAllocator, typename TParam1, typename TParam2, typename TParam3, typename TParam4, typename TParam5>
+    TData * PrependNode(TAllocator * allocator, TParam1 param1, TParam2 param2, TParam3 param3, TParam4 param4, TParam5 param5)
+    {
+        Node * newNode = AllocatorNew(TAllocator, allocator, Node, param1, param2, param3, param4, param5);
         if (newNode)
         {
             DListBase::InsertNodeBefore(this->Next(), newNode);

--- a/lib/Common/Exceptions/ReportError.cpp
+++ b/lib/Common/Exceptions/ReportError.cpp
@@ -19,9 +19,6 @@ void ReportFatalException(
     if (IsDebuggerPresent())
     {
         DebugBreak();
-#if DBG
-        return;
-#endif
     }
 
 #ifdef DISABLE_SEH

--- a/lib/Common/Exceptions/ReportError.cpp
+++ b/lib/Common/Exceptions/ReportError.cpp
@@ -19,6 +19,9 @@ void ReportFatalException(
     if (IsDebuggerPresent())
     {
         DebugBreak();
+#if DBG
+        return;
+#endif
     }
 
 #ifdef DISABLE_SEH

--- a/lib/Common/Memory/HeapBlockMap.cpp
+++ b/lib/Common/Memory/HeapBlockMap.cpp
@@ -910,7 +910,7 @@ HeapBlockMap32::Rescan(Recycler * recycler, bool resetWriteWatch)
 
                 BYTE writeBarrierByte = RecyclerWriteBarrierManager::GetWriteBarrier(pageAddress);
                 SwbVerboseTrace(recycler->GetRecyclerFlagsTable(), _u("Address: 0x%p, Write Barrier value: %u\n"), pageAddress, writeBarrierByte);
-                bool isDirty = (writeBarrierByte == 1);
+                bool isDirty = (writeBarrierByte & DIRTYBIT);
 
                 if (isDirty)
                 {

--- a/lib/Common/Memory/IdleDecommitPageAllocator.cpp
+++ b/lib/Common/Memory/IdleDecommitPageAllocator.cpp
@@ -13,7 +13,7 @@ IdleDecommitPageAllocator::IdleDecommitPageAllocator(AllocationPolicyManager * p
 #if ENABLE_BACKGROUND_PAGE_FREEING 
     BackgroundPageQueue *  backgroundPageQueue,
 #endif
-    uint maxAllocPageCount) :
+    uint maxAllocPageCount, bool enableWriteBarrier) :
 #ifdef IDLE_DECOMMIT_ENABLED
     idleDecommitTryEnterWaitFactor(0),
     hasDecommitTimer(false),
@@ -27,7 +27,7 @@ IdleDecommitPageAllocator::IdleDecommitPageAllocator(AllocationPolicyManager * p
 #if ENABLE_BACKGROUND_PAGE_FREEING
     backgroundPageQueue,
 #endif        
-    maxAllocPageCount),
+    maxAllocPageCount, 0, false, false, GetCurrentProcess(), enableWriteBarrier),
     maxIdleDecommitFreePageCount(maxIdleFreePageCount),
     maxNonIdleDecommitFreePageCount(maxFreePageCount)
 {

--- a/lib/Common/Memory/IdleDecommitPageAllocator.h
+++ b/lib/Common/Memory/IdleDecommitPageAllocator.h
@@ -24,7 +24,8 @@ public:
 #if ENABLE_BACKGROUND_PAGE_FREEING
         BackgroundPageQueue * backgroundPageQueue = nullptr,
 #endif
-        uint maxAllocPageCount = PageAllocator::DefaultMaxAllocPageCount);
+        uint maxAllocPageCount = PageAllocator::DefaultMaxAllocPageCount,
+        bool enableWriteBarrier = false);
 
     void EnterIdleDecommit();
     IdleDecommitSignal LeaveIdleDecommit(bool allowTimer);

--- a/lib/Common/Memory/PageAllocator.cpp
+++ b/lib/Common/Memory/PageAllocator.cpp
@@ -58,20 +58,13 @@ SegmentBase<T>::~SegmentBase()
         GetAllocator()->ReportFree(this->segmentPageCount * AutoSystemInfo::PageSize); //Note: We reported the guard pages free when we decommitted them during segment initialization
 #if defined(_M_X64_OR_ARM64) && defined(RECYCLER_WRITE_BARRIER_BYTE)
 #if ENABLE_DEBUG_CONFIG_OPTIONS
-        if (Js::Configuration::Global.flags.StrictWriteBarrierCheck)
+        if (Js::Configuration::Global.flags.StrictWriteBarrierCheck && this->isWriteBarrierEnabled)
         {
-            if (this->isWriteBarrierEnabled)
-            {
-                RecyclerWriteBarrierManager::OnSegmentFree(this->address, this->segmentPageCount);
-                RecyclerWriteBarrierManager::ToggleBarrier(this->address, this->segmentPageCount * AutoSystemInfo::PageSize, false);
-            }
-        }
-        else
-#endif
-        {
-            RecyclerWriteBarrierManager::OnSegmentFree(this->address, this->segmentPageCount);
+            RecyclerWriteBarrierManager::ToggleBarrier(this->address, this->segmentPageCount * AutoSystemInfo::PageSize, false);
         }
 #endif
+#endif
+        RecyclerWriteBarrierManager::OnSegmentFree(this->address, this->segmentPageCount);
     }
 }
 

--- a/lib/Common/Memory/PageAllocator.cpp
+++ b/lib/Common/Memory/PageAllocator.cpp
@@ -23,7 +23,7 @@ bool SegmentBaseCommon::IsInPreReservedHeapPageAllocator() const
 }
 
 template<typename T>
-SegmentBase<T>::SegmentBase(PageAllocatorBase<T> * allocator, size_t pageCount) :
+SegmentBase<T>::SegmentBase(PageAllocatorBase<T> * allocator, size_t pageCount, bool enableWriteBarrier) :
     SegmentBaseCommon(allocator),
     address(nullptr),
     trailingGuardPageCount(0),
@@ -32,6 +32,7 @@ SegmentBase<T>::SegmentBase(PageAllocatorBase<T> * allocator, size_t pageCount) 
     secondaryAllocator(nullptr)
 #if defined(_M_X64_OR_ARM64) && defined(RECYCLER_WRITE_BARRIER)
     , isWriteBarrierAllowed(false)
+    , isWriteBarrierEnabled(enableWriteBarrier)
 #endif
 {
     this->segmentPageCount = pageCount + secondaryAllocPageCount;
@@ -56,7 +57,20 @@ SegmentBase<T>::~SegmentBase()
         GetAllocator()->GetVirtualAllocator()->Free(originalAddress, GetPageCount() * AutoSystemInfo::PageSize, MEM_RELEASE, this->GetAllocator()->processHandle);
         GetAllocator()->ReportFree(this->segmentPageCount * AutoSystemInfo::PageSize); //Note: We reported the guard pages free when we decommitted them during segment initialization
 #if defined(_M_X64_OR_ARM64) && defined(RECYCLER_WRITE_BARRIER_BYTE)
-        RecyclerWriteBarrierManager::OnSegmentFree(this->address, this->segmentPageCount);
+#if ENABLE_DEBUG_CONFIG_OPTIONS
+        if (Js::Configuration::Global.flags.StrictWriteBarrierCheck)
+        {
+            if (this->isWriteBarrierEnabled)
+            {
+                RecyclerWriteBarrierManager::OnSegmentFree(this->address, this->segmentPageCount);
+                RecyclerWriteBarrierManager::ToggleBarrier(this->address, this->segmentPageCount * AutoSystemInfo::PageSize, false);
+            }
+        }
+        else
+#endif
+        {
+            RecyclerWriteBarrierManager::OnSegmentFree(this->address, this->segmentPageCount);
+        }
 #endif
     }
 }
@@ -138,17 +152,39 @@ SegmentBase<T>::Initialize(DWORD allocFlags, bool excludeGuardPages)
         this->address = nullptr;
         return false;
     }
+
 #if defined(_M_X64_OR_ARM64) && defined(RECYCLER_WRITE_BARRIER_BYTE)
-    else if (!RecyclerWriteBarrierManager::OnSegmentAlloc(this->address, this->segmentPageCount))
+    bool registerBarrierResult = true;
+#if ENABLE_DEBUG_CONFIG_OPTIONS
+    if (Js::Configuration::Global.flags.StrictWriteBarrierCheck)
+    {
+        if (this->isWriteBarrierEnabled)
+        {
+            // only commit card table for write barrier pages for strict check
+            // we can do this in free build if all write barrier annotated struct only allocate with write barrier pages
+            registerBarrierResult = RecyclerWriteBarrierManager::OnSegmentAlloc(this->address, this->segmentPageCount);
+        }
+    }
+    else
+#endif
+    {
+        registerBarrierResult = RecyclerWriteBarrierManager::OnSegmentAlloc(this->address, this->segmentPageCount);
+    }
+
+    if (!registerBarrierResult)
     {
         GetAllocator()->GetVirtualAllocator()->Free(originalAddress, GetPageCount() * AutoSystemInfo::PageSize, MEM_RELEASE, this->GetAllocator()->processHandle);
         this->GetAllocator()->ReportFailure(GetPageCount() * AutoSystemInfo::PageSize);
         this->address = nullptr;
         return false;
     }
-    else
+#endif
+
+    this->isWriteBarrierAllowed = true;
+#if DBG
+    if (this->isWriteBarrierEnabled)
     {
-        this->isWriteBarrierAllowed = true;
+        RecyclerWriteBarrierManager::ToggleBarrier(this->address, this->segmentPageCount * AutoSystemInfo::PageSize, true);
     }
 #endif
 
@@ -160,8 +196,8 @@ SegmentBase<T>::Initialize(DWORD allocFlags, bool excludeGuardPages)
 //=============================================================================================================
 
 template<typename T>
-PageSegmentBase<T>::PageSegmentBase(PageAllocatorBase<T> * allocator, bool committed, bool allocated) :
-    SegmentBase<T>(allocator, allocator->maxAllocPageCount), decommitPageCount(0)
+PageSegmentBase<T>::PageSegmentBase(PageAllocatorBase<T> * allocator, bool committed, bool allocated, bool enableWriteBarrier) :
+    SegmentBase<T>(allocator, allocator->maxAllocPageCount, enableWriteBarrier), decommitPageCount(0)
 {
     Assert(this->segmentPageCount == allocator->maxAllocPageCount + allocator->secondaryAllocPageCount);
 
@@ -197,8 +233,8 @@ PageSegmentBase<T>::PageSegmentBase(PageAllocatorBase<T> * allocator, bool commi
 }
 
 template<typename T>
-PageSegmentBase<T>::PageSegmentBase(PageAllocatorBase<T> * allocator, void* address, uint pageCount, uint committedCount) :
-    SegmentBase<T>(allocator, allocator->maxAllocPageCount), decommitPageCount(0), freePageCount(0)
+PageSegmentBase<T>::PageSegmentBase(PageAllocatorBase<T> * allocator, void* address, uint pageCount, uint committedCount, bool enableWriteBarrier) :
+    SegmentBase<T>(allocator, allocator->maxAllocPageCount, enableWriteBarrier), decommitPageCount(0), freePageCount(0)
 {
     this->address = (char*)address;
     this->segmentPageCount = pageCount;
@@ -601,7 +637,7 @@ PageAllocatorBase<T>::PageAllocatorBase(AllocationPolicyManager * policyManager,
     BackgroundPageQueue * backgroundPageQueue,
 #endif
     uint maxAllocPageCount, uint secondaryAllocPageCount,
-    bool stopAllocationOnOutOfMemory, bool excludeGuardPages, HANDLE processHandle) :
+    bool stopAllocationOnOutOfMemory, bool excludeGuardPages, HANDLE processHandle, bool enableWriteBarrier) :
     policyManager(policyManager),
 #ifndef JD_PRIVATE
     pageAllocatorFlagTable(flagTable),
@@ -629,6 +665,7 @@ PageAllocatorBase<T>::PageAllocatorBase(AllocationPolicyManager * policyManager,
     , usedBytes(0)
     , numberOfSegments(0)
     , processHandle(processHandle)
+    , enableWriteBarrier(enableWriteBarrier)
 {
     AssertMsg(Math::IsPow2(maxAllocPageCount + secondaryAllocPageCount), "Illegal maxAllocPageCount: Why is this not a power of 2 aligned?");
 
@@ -746,9 +783,9 @@ PageAllocatorBase<T>::AllocPagesForBytes(size_t requestBytes)
 
 template<typename T>
 PageSegmentBase<T> *
-PageAllocatorBase<T>::AllocPageSegment(DListBase<PageSegmentBase<T>>& segmentList, PageAllocatorBase<T> * pageAllocator, bool committed, bool allocated)
+PageAllocatorBase<T>::AllocPageSegment(DListBase<PageSegmentBase<T>>& segmentList, PageAllocatorBase<T> * pageAllocator, bool committed, bool allocated, bool enableWriteBarrier)
 {
-    PageSegmentBase<T> * segment = segmentList.PrependNode(&NoThrowNoMemProtectHeapAllocator::Instance, pageAllocator, committed, allocated);
+    PageSegmentBase<T> * segment = segmentList.PrependNode(&NoThrowNoMemProtectHeapAllocator::Instance, pageAllocator, committed, allocated, enableWriteBarrier);
 
     if (segment == nullptr)
     {
@@ -765,9 +802,9 @@ PageAllocatorBase<T>::AllocPageSegment(DListBase<PageSegmentBase<T>>& segmentLis
 
 template<typename T>
 PageSegmentBase<T> *
-PageAllocatorBase<T>::AllocPageSegment(DListBase<PageSegmentBase<T>>& segmentList, PageAllocatorBase<T> * pageAllocator, void* address, uint pageCount, uint committedCount)
+PageAllocatorBase<T>::AllocPageSegment(DListBase<PageSegmentBase<T>>& segmentList, PageAllocatorBase<T> * pageAllocator, void* address, uint pageCount, uint committedCount, bool enableWriteBarrier)
 {
-    PageSegmentBase<T> * segment = segmentList.PrependNode(&NoThrowNoMemProtectHeapAllocator::Instance, pageAllocator, address, pageCount, committedCount);
+    PageSegmentBase<T> * segment = segmentList.PrependNode(&NoThrowNoMemProtectHeapAllocator::Instance, pageAllocator, address, pageCount, committedCount, enableWriteBarrier);
     pageAllocator->ReportExternalAlloc(pageCount * AutoSystemInfo::PageSize);
     return segment;
 }
@@ -778,7 +815,7 @@ PageAllocatorBase<T>::AddPageSegment(DListBase<PageSegmentBase<T>>& segmentList)
 {
     Assert(!this->HasMultiThreadAccess());
 
-    PageSegmentBase<T> * segment = AllocPageSegment(segmentList, this, true, false);
+    PageSegmentBase<T> * segment = AllocPageSegment(segmentList, this, true, false, this->enableWriteBarrier);
 
     if (segment != nullptr)
     {
@@ -1106,7 +1143,7 @@ PageAllocatorBase<T>::AllocSegment(size_t pageCount)
     // as using the page allocator
     this->isUsed = true;
 
-    SegmentBase<T> * segment = largeSegments.PrependNode(&NoThrowNoMemProtectHeapAllocator::Instance, this, pageCount);
+    SegmentBase<T> * segment = largeSegments.PrependNode(&NoThrowNoMemProtectHeapAllocator::Instance, this, pageCount, enableWriteBarrier);
     if (segment == nullptr)
     {
         return nullptr;
@@ -1374,7 +1411,7 @@ PageAllocatorBase<T>::SnailAllocPages(uint pageCount, PageSegmentBase<T> ** page
     if (maxAllocPageCount != pageCount && (maxFreePageCount < maxAllocPageCount - pageCount + freePageCount))
     {
         // If we exceed the number of max free page count, allocate from a new fully decommit block
-        PageSegmentBase<T> * decommitSegment = AllocPageSegment(this->decommitSegments, this, false, false);
+        PageSegmentBase<T> * decommitSegment = AllocPageSegment(this->decommitSegments, this, false, false, this->enableWriteBarrier);
         if (decommitSegment == nullptr)
         {
             return nullptr;

--- a/lib/Common/Memory/Recycler.cpp
+++ b/lib/Common/Memory/Recycler.cpp
@@ -128,7 +128,7 @@ Recycler::Recycler(AllocationPolicyManager * policyManager, IdleDecommitPageAllo
     recyclerLargeBlockPageAllocator(this, policyManager, configFlagsTable, RecyclerHeuristic::Instance.DefaultMaxFreePageCount),
     threadService(nullptr),
 #ifdef RECYCLER_WRITE_BARRIER_ALLOC_SEPARATE_PAGE
-    recyclerWithBarrierPageAllocator(this, policyManager, configFlagsTable, RecyclerHeuristic::Instance.DefaultMaxFreePageCount),
+    recyclerWithBarrierPageAllocator(this, policyManager, configFlagsTable, RecyclerHeuristic::Instance.DefaultMaxFreePageCount, PageAllocator::DefaultMaxAllocPageCount, true),
 #endif
     threadPageAllocator(pageAllocator),
     markPagePool(configFlagsTable),

--- a/lib/Common/Memory/Recycler.inl
+++ b/lib/Common/Memory/Recycler.inl
@@ -159,13 +159,17 @@ Recycler::AllocWithAttributesInlined(size_t size)
     SwbVerboseTrace(this->GetRecyclerFlagsTable(), _u("Allocated SWB memory: 0x%p\n"), memBlock);
 
 #pragma prefast(suppress:6313, "attributes is a template parameter and can be 0")
-    if (attributes & (NewTrackBit))
+    if (attributes & NewTrackBit & WithBarrierBit)
     {
+        //REVIEW: is following comment correct? I added WithBarrierBit above
+        // why we need to set write barrier bit for none write barrier page address
+
         // For objects allocated with NewTrackBit, we need to trigger the write barrier since
         // there could be a GC triggered by an allocation in the constructor, and we'd miss
         // calling track on the partially constructed object. To deal with this, we set the write
         // barrier on all the pages of objects allocated with the NewTrackBit
-        RecyclerWriteBarrierManager::WriteBarrier(memBlock, size / sizeof(void*));
+
+        RecyclerWriteBarrierManager::WriteBarrier(memBlock, size);
     }
 #endif
 

--- a/lib/Common/Memory/RecyclerPageAllocator.cpp
+++ b/lib/Common/Memory/RecyclerPageAllocator.cpp
@@ -8,7 +8,7 @@ RecyclerPageAllocator::RecyclerPageAllocator(Recycler* recycler, AllocationPolic
 #ifndef JD_PRIVATE
     Js::ConfigFlagsTable& flagTable,
 #endif
-    uint maxFreePageCount, uint maxAllocPageCount)
+    uint maxFreePageCount, uint maxAllocPageCount, bool enableWriteBarrier)
     : IdleDecommitPageAllocator(policyManager,
         PageAllocatorType_Recycler,
 #ifndef JD_PRIVATE
@@ -19,7 +19,9 @@ RecyclerPageAllocator::RecyclerPageAllocator(Recycler* recycler, AllocationPolic
 #if ENABLE_BACKGROUND_PAGE_ZEROING
         &zeroPageQueue,
 #endif
-        maxAllocPageCount)
+        maxAllocPageCount,
+        enableWriteBarrier
+        )
 {
     this->recycler = recycler;
 }

--- a/lib/Common/Memory/RecyclerPageAllocator.h
+++ b/lib/Common/Memory/RecyclerPageAllocator.h
@@ -13,7 +13,7 @@ public:
 #ifndef JD_PRIVATE
         Js::ConfigFlagsTable& flagTable,
 #endif
-        uint maxFreePageCount, uint maxAllocPageCount = PageAllocator::DefaultMaxAllocPageCount);
+        uint maxFreePageCount, uint maxAllocPageCount = PageAllocator::DefaultMaxAllocPageCount, bool enableWriteBarrier = false);
 #if ENABLE_CONCURRENT_GC
     void EnableWriteWatch();
     bool ResetWriteWatch();

--- a/lib/Common/Memory/RecyclerPointers.h
+++ b/lib/Common/Memory/RecyclerPointers.h
@@ -90,11 +90,26 @@ struct WriteBarrierFieldTypeTraits { typedef typename _WriteBarrierFieldType<T, 
 
 // ArrayWriteBarrier behavior
 //
+typedef void FN_VerifyIsNotBarrierAddress(void*, size_t);
+extern "C" FN_VerifyIsNotBarrierAddress* g_verifyIsNotBarrierAddress;
 template <class Policy>
 struct _ArrayWriteBarrier
 {
     template <class T>
-    static void WriteBarrier(T * address, size_t count) {}
+    static void WriteBarrier(T * address, size_t count)
+    {
+#if defined(RECYCLER_WRITE_BARRIER)
+#if ENABLE_DEBUG_CONFIG_OPTIONS
+        if (Js::Configuration::Global.flags.StrictWriteBarrierCheck)
+        {
+            if (g_verifyIsNotBarrierAddress)
+            {
+                g_verifyIsNotBarrierAddress(address, count);
+            }
+        }
+#endif
+#endif
+    }
 };
 
 #ifdef RECYCLER_WRITE_BARRIER
@@ -220,6 +235,9 @@ public:
     // Setters
     NoWriteBarrierField& operator=(T const& value)
     {
+#if defined(RECYCLER_WRITE_BARRIER)
+        RecyclerWriteBarrierManager::VerifyIsBarrierAddress(this);
+#endif
         this->value = value;
         return *this;
     }

--- a/lib/Common/Memory/RecyclerPointers.h
+++ b/lib/Common/Memory/RecyclerPointers.h
@@ -235,8 +235,8 @@ public:
     // Setters
     NoWriteBarrierField& operator=(T const& value)
     {
-#if defined(RECYCLER_WRITE_BARRIER)
-        RecyclerWriteBarrierManager::VerifyIsBarrierAddress(this);
+#if ENABLE_DEBUG_CONFIG_OPTIONS
+        RecyclerWriteBarrierManager::VerifyIsNotBarrierAddress(this);
 #endif
         this->value = value;
         return *this;
@@ -263,6 +263,9 @@ public:
     // Setters
     NoWriteBarrierPtr& operator=(T * value)
     {
+#if ENABLE_DEBUG_CONFIG_OPTIONS
+        RecyclerWriteBarrierManager::VerifyIsNotBarrierAddress(this);
+#endif
         this->value = value;
         return *this;
     }

--- a/lib/Common/Memory/RecyclerWriteBarrierManager.cpp
+++ b/lib/Common/Memory/RecyclerWriteBarrierManager.cpp
@@ -20,10 +20,12 @@
 #pragma init_seg(".CRT$XCAU")
 
 #ifdef RECYCLER_WRITE_BARRIER
+#if ENABLE_DEBUG_CONFIG_OPTIONS
 namespace Memory 
 {
     FN_VerifyIsNotBarrierAddress* g_verifyIsNotBarrierAddress = nullptr;
 }
+#endif
 #ifdef RECYCLER_WRITE_BARRIER_BYTE
 #ifdef _M_X64_OR_ARM64
 X64WriteBarrierCardTableManager RecyclerWriteBarrierManager::x64CardTableManager;
@@ -366,13 +368,13 @@ RecyclerWriteBarrierManager::ToggleBarrier(void * address, size_t bytes, bool en
     }
 }
 
-BOOL
+bool
 RecyclerWriteBarrierManager::IsBarrierAddress(void * address)
 {
     return IsBarrierAddress(GetCardTableIndex(address));
 }
 
-BOOL
+bool
 RecyclerWriteBarrierManager::IsBarrierAddress(uintptr_t index)
 {
     return cardTable[index] & WRITE_BARRIER_PAGE_BIT;

--- a/lib/Common/Memory/RecyclerWriteBarrierManager.cpp
+++ b/lib/Common/Memory/RecyclerWriteBarrierManager.cpp
@@ -20,7 +20,10 @@
 #pragma init_seg(".CRT$XCAU")
 
 #ifdef RECYCLER_WRITE_BARRIER
-
+namespace Memory 
+{
+    FN_VerifyIsNotBarrierAddress* g_verifyIsNotBarrierAddress = nullptr;
+}
 #ifdef RECYCLER_WRITE_BARRIER_BYTE
 #ifdef _M_X64_OR_ARM64
 X64WriteBarrierCardTableManager RecyclerWriteBarrierManager::x64CardTableManager;
@@ -30,6 +33,9 @@ BYTE* RecyclerWriteBarrierManager::cardTable = RecyclerWriteBarrierManager::x64C
 #else
 // Each byte in the card table covers 4096 bytes so the range covered by the table is 4GB
 BYTE RecyclerWriteBarrierManager::cardTable[1 * 1024 * 1024];
+#if ENABLE_DEBUG_CONFIG_OPTIONS
+bool dummy = RecyclerWriteBarrierManager::Initialize();
+#endif
 #endif
 
 #else
@@ -60,7 +66,9 @@ X64WriteBarrierCardTableManager::OnThreadInit()
 
     size_t numPages = (stackBase - stackEnd) / AutoSystemInfo::PageSize;
     // stackEnd is the lower boundary
-    return OnSegmentAlloc((char*) stackEnd, numPages);
+    bool ret = OnSegmentAlloc((char*) stackEnd, numPages);
+    RecyclerWriteBarrierManager::ToggleBarrier((char*)stackEnd, (stackBase - stackEnd), true);
+    return ret;
 }
 
 bool
@@ -218,6 +226,10 @@ X64WriteBarrierCardTableManager::Initialize()
 {
     AutoCriticalSection critSec(&_cardTableInitCriticalSection);
 
+#if ENABLE_DEBUG_CONFIG_OPTIONS
+    RecyclerWriteBarrierManager::Initialize();
+#endif
+
     if (_cardTable == nullptr)
     {
         // We have two sizes for the card table on 64 bit builds
@@ -264,8 +276,11 @@ void
 RecyclerWriteBarrierManager::WriteBarrier(void * address)
 {
 #ifdef RECYCLER_WRITE_BARRIER_BYTE
+#if ENABLE_DEBUG_CONFIG_OPTIONS
+    VerifyIsBarrierAddress(address);
+#endif
     const uintptr_t index = GetCardTableIndex(address);
-    cardTable[index] = 1;
+    cardTable[index] |= DIRTYBIT;
 #else
     uint bitShift = (((uint)address) >> s_BitArrayCardTableShift);
     uint bitMask = 1 << bitShift;
@@ -281,16 +296,18 @@ RecyclerWriteBarrierManager::WriteBarrier(void * address)
 #endif
 }
 
-
 void
 RecyclerWriteBarrierManager::WriteBarrier(void * address, size_t bytes)
 {
+#if ENABLE_DEBUG_CONFIG_OPTIONS
+    VerifyIsBarrierAddress(address, bytes);
+#endif
 #ifdef RECYCLER_WRITE_BARRIER_BYTE
     uintptr_t startIndex = GetCardTableIndex(address);
     char * endAddress = (char *)Math::Align<INT_PTR>((INT_PTR)((char *)address + bytes), s_WriteBarrierPageSize);
     uintptr_t endIndex = GetCardTableIndex(endAddress);
     Assert(startIndex <= endIndex);
-    memset(cardTable + startIndex, 1, endIndex - startIndex);
+    memset(cardTable + startIndex, WRITE_BARRIER_PAGE_BIT | DIRTYBIT, endIndex - startIndex);
     GlobalSwbVerboseTrace(_u("Writing to 0x%p (CIndex: %u-%u)\n"), address, startIndex, endIndex);
 #else
     uint bitShift = (((uint)address) >> s_BitArrayCardTableShift);
@@ -319,6 +336,113 @@ RecyclerWriteBarrierManager::WriteBarrier(void * address, size_t bytes)
 #endif
 }
 
+#if ENABLE_DEBUG_CONFIG_OPTIONS
+void
+RecyclerWriteBarrierManager::ToggleBarrier(void * address, size_t bytes, bool enable)
+{
+    if (Js::Configuration::Global.flags.StrictWriteBarrierCheck)
+    {
+        uintptr_t startIndex = GetCardTableIndex(address);
+        char * endAddress = (char *)Math::Align<INT_PTR>((INT_PTR)((char *)address + bytes), s_WriteBarrierPageSize);
+        uintptr_t endIndex = GetCardTableIndex(endAddress);
+        if (enable)
+        {
+            for (uintptr_t i = startIndex; i < endIndex; i++)
+            {
+                cardTable[i] |= WRITE_BARRIER_PAGE_BIT;
+            }
+        }
+        else
+        {
+            for (uintptr_t i = startIndex; i < endIndex; i++)
+            {
+                cardTable[i] &= ~WRITE_BARRIER_PAGE_BIT;
+            }
+        }
+
+        GlobalSwbVerboseTrace(_u("Enableing 0x%p (CIndex: %u-%u)\n"), address, startIndex, endIndex);
+    }
+}
+
+BOOL
+RecyclerWriteBarrierManager::IsBarrierAddress(void * address)
+{
+    return IsBarrierAddress(GetCardTableIndex(address));
+}
+
+BOOL
+RecyclerWriteBarrierManager::IsBarrierAddress(uintptr_t index)
+{
+    return cardTable[index] & WRITE_BARRIER_PAGE_BIT;
+}
+
+// TODO: SWB, looks we didn't initialize card table for heap allocation. 
+// we didn't hit such issue because we are not allocating write barrier 
+// annotated struct with heap today.
+// after SWB is widely enabled and if an annotated structure can be allocated
+// with both Heap and Recycler/Arena we'll capture the issue
+
+void
+RecyclerWriteBarrierManager::VerifyIsBarrierAddress(void * address)
+{
+    if (Js::Configuration::Global.flags.StrictWriteBarrierCheck)
+    {
+        if (!IsBarrierAddress(GetCardTableIndex(address)))
+        {
+            Js::Throw::FatalInternalError();
+        }
+    }
+}
+
+void
+RecyclerWriteBarrierManager::VerifyIsBarrierAddress(void * address, size_t bytes)
+{
+    if (Js::Configuration::Global.flags.StrictWriteBarrierCheck)
+    {
+        uintptr_t startIndex = GetCardTableIndex(address);
+        char * endAddress = (char *)Math::Align<INT_PTR>((INT_PTR)((char *)address + bytes), s_WriteBarrierPageSize);
+        uintptr_t endIndex = GetCardTableIndex(endAddress);
+        do 
+        {
+            // no need to check if cardTable is commited or not, if it's not commited it'll AV instead of assertion
+            if (!IsBarrierAddress(startIndex)) 
+            {
+                Js::Throw::FatalInternalError();
+            }
+        } while (startIndex++ < endIndex);
+    }
+}
+
+void
+RecyclerWriteBarrierManager::VerifyIsNotBarrierAddress(void * address, size_t bytes)
+{
+    if (Js::Configuration::Global.flags.StrictWriteBarrierCheck)
+    {
+        uintptr_t startIndex = GetCardTableIndex(address);
+        char * endAddress = (char *)Math::Align<INT_PTR>((INT_PTR)((char *)address + bytes), s_WriteBarrierPageSize);
+        uintptr_t endIndex = GetCardTableIndex(endAddress);
+        do 
+        {
+            if(IsCardTableCommited(startIndex))
+            {
+                if (IsBarrierAddress(startIndex)) 
+                {
+                    Js::Throw::FatalInternalError();
+                }
+            }
+
+        } while (++startIndex < endIndex);
+    }
+}
+
+bool 
+RecyclerWriteBarrierManager::Initialize()
+{
+    g_verifyIsNotBarrierAddress = RecyclerWriteBarrierManager::VerifyIsNotBarrierAddress;
+    return true;
+}
+#endif 
+
 uintptr_t
 RecyclerWriteBarrierManager::GetCardTableIndex(void *address)
 {
@@ -331,12 +455,12 @@ RecyclerWriteBarrierManager::ResetWriteBarrier(void * address, size_t pageCount)
     uintptr_t cardIndex = GetCardTableIndex(address);
     if (pageCount == 1)
     {
-        cardTable[cardIndex] = 0;
+        cardTable[cardIndex] = WRITE_BARRIER_PAGE_BIT;
     }
     else
     {
 #ifdef RECYCLER_WRITE_BARRIER_BYTE
-        memset(&cardTable[cardIndex], 0, pageCount);
+        memset(&cardTable[cardIndex], WRITE_BARRIER_PAGE_BIT, pageCount);
 #else
         memset(&cardTable[cardIndex], 0, sizeof(DWORD) * pageCount);
 #endif

--- a/lib/Common/Memory/RecyclerWriteBarrierManager.cpp
+++ b/lib/Common/Memory/RecyclerWriteBarrierManager.cpp
@@ -67,7 +67,9 @@ X64WriteBarrierCardTableManager::OnThreadInit()
     size_t numPages = (stackBase - stackEnd) / AutoSystemInfo::PageSize;
     // stackEnd is the lower boundary
     bool ret = OnSegmentAlloc((char*) stackEnd, numPages);
+#if ENABLE_DEBUG_CONFIG_OPTIONS
     RecyclerWriteBarrierManager::ToggleBarrier((char*)stackEnd, (stackBase - stackEnd), true);
+#endif
     return ret;
 }
 

--- a/lib/Common/Memory/RecyclerWriteBarrierManager.h
+++ b/lib/Common/Memory/RecyclerWriteBarrierManager.h
@@ -147,8 +147,8 @@ public:
     static void WriteBarrier(void * address, size_t bytes);
 #if ENABLE_DEBUG_CONFIG_OPTIONS
     static void ToggleBarrier(void * address, size_t bytes, bool enable);
-    static BOOL IsBarrierAddress(void * address);
-    static BOOL IsBarrierAddress(uintptr_t index);
+    static bool IsBarrierAddress(void * address);
+    static bool IsBarrierAddress(uintptr_t index);
     static void VerifyIsBarrierAddress(void * address, size_t bytes);
     static void VerifyIsNotBarrierAddress(void * address, size_t bytes);
     static void VerifyIsBarrierAddress(void * address);
@@ -156,20 +156,20 @@ public:
 #endif
 
 #if ENABLE_DEBUG_CONFIG_OPTIONS
-    static BOOLEAN IsCardTableCommited(_In_ uintptr_t index)
+    static bool IsCardTableCommited(_In_ uintptr_t index)
     {
 #ifdef _M_X64_OR_ARM64
-        return x64CardTableManager.IsCardTableCommited(index);
+        return x64CardTableManager.IsCardTableCommited(index) != FALSE;
 #else
-        return TRUE;
+        return true;
 #endif
     }
-    static BOOLEAN IsCardTableCommitedAddress(_In_ void* address)
+    static bool IsCardTableCommitedAddress(_In_ void* address)
     {
 #ifdef _M_X64_OR_ARM64
-        return x64CardTableManager.IsCardTableCommited(address);
+        return x64CardTableManager.IsCardTableCommited(address) != FALSE;
 #else
-        return TRUE;
+        return true;
 #endif
     }
 #endif


### PR DESCRIPTION
strictly check where write barrier bit is set for none write barrier pages, in order to check the unnecessary annotation
