### PR TITLE
Short circuit IsNativeAddress for Chakra.dll functions when OOP

### DIFF
--- a/lib/Backend/ServerThreadContext.cpp
+++ b/lib/Backend/ServerThreadContext.cpp
@@ -24,12 +24,6 @@ ServerThreadContext::ServerThreadContext(ThreadContextDataIDL * data) :
         PageAllocator::DefaultLowMaxFreePageCount :
         PageAllocator::DefaultMaxFreePageCount
     ),
-    // TODO: OOP JIT, don't hardcode name
-#ifdef NTBUILD
-    m_jitChakraBaseAddress((intptr_t)GetModuleHandle(_u("Chakra.dll"))),
-#else
-    m_jitChakraBaseAddress((intptr_t)GetModuleHandle(_u("ChakraCore.dll"))),
-#endif
     m_jitCRTBaseAddress((intptr_t)GetModuleHandle(UCrtC99MathApis::LibraryName))
 {
 #if ENABLE_OOP_NATIVE_CODEGEN
@@ -68,7 +62,11 @@ ServerThreadContext::GetBailOutRegisterSaveSpaceAddr() const
 ptrdiff_t
 ServerThreadContext::GetChakraBaseAddressDifference() const
 {
-    return GetRuntimeChakraBaseAddress() - m_jitChakraBaseAddress;
+#if ENABLE_OOP_NATIVE_CODEGEN
+    return GetRuntimeChakraBaseAddress() - (intptr_t)AutoSystemInfo::Data.GetChakraBaseAddr();
+#else
+    return 0;
+#endif
 }
 
 ptrdiff_t

--- a/lib/Backend/ServerThreadContext.h
+++ b/lib/Backend/ServerThreadContext.h
@@ -71,7 +71,6 @@ private:
 
     DWORD m_pid; //save client process id for easier diagnose
     
-    intptr_t m_jitChakraBaseAddress;
     intptr_t m_jitCRTBaseAddress;
     uint m_refCount;
 };

--- a/lib/Common/Core/SysInfo.h
+++ b/lib/Common/Core/SysInfo.h
@@ -39,6 +39,11 @@ public:
     DWORD GetNumberOfLogicalProcessors() const { return this->dwNumberOfProcessors; }
     DWORD GetNumberOfPhysicalProcessors() const { return this->dwNumberOfPhysicalProcessors; }
 
+#ifdef ENABLE_OOP_NATIVE_CODEGEN
+    bool IsChakraAddress(void * addr) const;
+    void * GetChakraBaseAddr() const;
+#endif
+
 #if defined(_M_ARM32_OR_ARM64)
     bool ArmDivAvailable() const { return this->armDivAvailable; }
 #endif
@@ -107,6 +112,9 @@ private:
     static HRESULT GetVersionInfo(__in LPCWSTR pszPath, DWORD* majorVersion, DWORD* minorVersion);
 
     static const DWORD INVALID_VERSION = (DWORD)-1;
+
+    HMODULE chakraBaseAddress;
+    size_t chakraSize;
 
     ULONG64 availableCommit;
     bool shouldQCMoreFrequently;

--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -1964,6 +1964,7 @@ ThreadContext::SetJITConnectionInfo(HANDLE processHandle, void* serverSecurityDe
 void
 ThreadContext::EnsureJITThreadContext(bool allowPrereserveAlloc)
 {
+#if ENABLE_OOP_NATIVE_CODEGEN
     Assert(JITManager::GetJITManager()->IsOOPJITEnabled());
     Assert(JITManager::GetJITManager()->IsConnected());
 
@@ -1975,12 +1976,7 @@ ThreadContext::EnsureJITThreadContext(bool allowPrereserveAlloc)
     ThreadContextDataIDL contextData;
     contextData.processHandle = (intptr_t)JITManager::GetJITManager()->GetJITTargetHandle();
 
-    // TODO: OOP JIT, use more generic method for getting name, e.g. in case of ChakraTest.dll
-#ifdef NTBUILD
-    contextData.chakraBaseAddress = (intptr_t)GetModuleHandle(_u("Chakra.dll"));
-#else
-    contextData.chakraBaseAddress = (intptr_t)GetModuleHandle(_u("ChakraCore.dll"));
-#endif
+    contextData.chakraBaseAddress = (intptr_t)AutoSystemInfo::Data.GetChakraBaseAddr();
     contextData.crtBaseAddress = (intptr_t)GetModuleHandle(UCrtC99MathApis::LibraryName);
     contextData.threadStackLimitAddr = reinterpret_cast<intptr_t>(GetAddressOfStackLimitForCurrentThread());
     contextData.bailOutRegisterSaveSpaceAddr = (intptr_t)bailOutRegisterSaveSpace;
@@ -2006,6 +2002,8 @@ ThreadContext::EnsureJITThreadContext(bool allowPrereserveAlloc)
 
     HRESULT hr = JITManager::GetJITManager()->InitializeThreadContext(&contextData, &m_remoteThreadContextInfo, &m_prereservedRegionAddr);
     JITManager::HandleServerCallResult(hr);
+
+#endif
 }
 #endif
 
@@ -3865,6 +3863,7 @@ void DumpRecyclerObjectGraph()
 BOOL ThreadContext::IsNativeAddress(void * pCodeAddr)
 {
     boolean result;
+#if ENABLE_OOP_NATIVE_CODEGEN
     if (JITManager::GetJITManager()->IsOOPJITEnabled())
     {
         if (PreReservedVirtualAllocWrapper::IsInRange((void*)m_prereservedRegionAddr, pCodeAddr))
@@ -3875,6 +3874,11 @@ BOOL ThreadContext::IsNativeAddress(void * pCodeAddr)
         {
             return false;
         }
+        if (AutoSystemInfo::Data.IsChakraAddress(pCodeAddr))
+        {
+            return false;
+        }
+
         HRESULT hr = JITManager::GetJITManager()->IsNativeAddr(this->m_remoteThreadContextInfo, (intptr_t)pCodeAddr, &result);
 
         // TODO: OOP JIT, can we throw here?
@@ -3882,6 +3886,7 @@ BOOL ThreadContext::IsNativeAddress(void * pCodeAddr)
         return result;
     }
     else
+#endif
     {
         PreReservedVirtualAllocWrapper *preReservedVirtualAllocWrapper = this->GetPreReservedVirtualAllocator();
         if (preReservedVirtualAllocWrapper->IsInRange(pCodeAddr))


### PR DESCRIPTION
In case all code is not in prereserved code segment or on platforms where prereserved code segment is not available, stack walking requires RPC for each frame to check if an address is JIT code.

If an address is in Chakra, we know it isn't JIT code. A large majority of functions on the stack at any time are interpreter frames, so by checking this we dramatically reduce the frequency of these calls.

Improves Octane CodeLoad perf by 20% on ARM, bringing it back to par with in-proc perf.