### PR TITLE
osx: fix ASM files are being compiled with later OS SDK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,11 +150,10 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
 
     if(NOT CC_XCODE_PROJECT)
         set(CLR_CMAKE_PLATFORM_DARWIN 1)
+        add_compile_options(-mmacosx-version-min=10.7)
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} \
             -mmacosx-version-min=10.7")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
-            -mmacosx-version-min=10.7")
-        set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} \
             -mmacosx-version-min=10.7")
     endif()
 else()


### PR DESCRIPTION
Minor fix for inconsistent linker target. This also shows up on embedding 3rd party.