### PR TITLE
fix assertion on integrated block with page heap.

### DIFF
--- a/lib/Common/Memory/Recycler.inl
+++ b/lib/Common/Memory/Recycler.inl
@@ -285,17 +285,20 @@ void Recycler::VerifyPageHeapFillAfterAlloc(char* memBlock, size_t size)
 
         if (this->IsPageHeapEnabled<attributes>(size))
         {
-            Assert(heapBlock->IsLargeHeapBlock());
-        }
-
-        if (heapBlock->IsLargeHeapBlock())
-        {
-            LargeHeapBlock* largeHeapBlock = (LargeHeapBlock*)heapBlock;
-            if (largeHeapBlock->InPageHeapMode())
+            if (heapBlock->IsLargeHeapBlock())
             {
-                LargeObjectHeader* header = (LargeObjectHeader*)(memBlock - sizeof(LargeObjectHeader));
-                largeHeapBlock->VerifyPageHeapPattern();
-                header->isPageHeapFillVerified = true;
+                LargeHeapBlock* largeHeapBlock = (LargeHeapBlock*)heapBlock;
+                if (largeHeapBlock->InPageHeapMode())
+                {
+                    LargeObjectHeader* header = (LargeObjectHeader*)(memBlock - sizeof(LargeObjectHeader));
+                    largeHeapBlock->VerifyPageHeapPattern();
+                    header->isPageHeapFillVerified = true;
+                }
+            }
+            else
+            {
+                // currently we don't support integration of large blocks
+                Assert(((SmallHeapBlockT<SmallAllocationBlockAttributes>*)heapBlock)->isIntegratedBlock);
             }
         }
     }


### PR DESCRIPTION
currently all page heap allocations are done with large blocks. However, we don't support integration of large heap blocks. the complete fix should be that we support integration of large blocks. here just remove the assertion in case the allocation is from integrated page.
