### PR TITLE
Disabling StackArgs when the source is inside eval expression

### DIFF
--- a/lib/Runtime/Base/PerfHintDescriptions.h
+++ b/lib/Runtime/Base/PerfHintDescriptions.h
@@ -6,6 +6,7 @@
 
 PERFHINT_REASON(HasTryBlock,                        true, PerfHintLevels::L1,      _u("Function has try block"),                 _u("Un-optimized JIT code generated for this function"), _u("Move perf sensitive block inside of try to different function"))
 PERFHINT_REASON(HasTryBlock_Verbose,                true, PerfHintLevels::VERBOSE, _u("Function has try block"),                 _u("Un-optimized JIT code generated for this function"), _u("Move perf sensitive block inside of try to different function"))
+PERFHINT_REASON(SrcIsEval,                          true, PerfHintLevels::L1,      _u("Source is inside eval statement"),        _u("Extra scopes, affect inlining, high overhead in the JIT code"), _u("Check usage of eval statement"))
 PERFHINT_REASON(CallsEval,                          true, PerfHintLevels::L1,      _u("Function calls eval statement"),          _u("Extra scopes, affect inlining, high overhead in the JIT code"), _u("Check usage of eval statement"))
 PERFHINT_REASON(CallsEval_Verbose,                  true, PerfHintLevels::VERBOSE, _u("Function calls eval statement"),          _u("Extra scopes, affect inlining, high overhead in the JIT code"), _u("Check usage of eval statement"))
 PERFHINT_REASON(ChildCallsEval,                     true, PerfHintLevels::VERBOSE, _u("Function's child calls eval statement"),  _u("Extra scopes, affect inlining, high overhead in the JIT code"), _u("Check usage of eval statement"))

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -2355,14 +2355,22 @@ FuncInfo* PreVisitFunction(ParseNode* pnode, ByteCodeGenerator* byteCodeGenerato
                 //Go conservative if it has any nested functions, or any non-local references.
                 //With statements - need scope object to be present.
                 //Nested funtions - need scope object to be present - LdEnv/LdFrameDisplay needs it.
-                if ((doStackArgsOpt && pnode->sxFnc.funcInfo->GetParamScope()->Count() > 1) && (pnode->sxFnc.funcInfo->HasDeferredChild() ||
+                if ((doStackArgsOpt && pnode->sxFnc.funcInfo->GetParamScope()->Count() > 1) && (pnode->sxFnc.funcInfo->HasDeferredChild() || (byteCodeGenerator->GetFlags() & fscrEval) ||
                     pnode->sxFnc.HasWithStmt() || byteCodeGenerator->IsInDebugMode() || PHASE_OFF1(Js::StackArgFormalsOptPhase) || PHASE_OFF1(Js::StackArgOptPhase)))
                 {
                     doStackArgsOpt = false;
 #ifdef PERF_HINT
                     if (PHASE_TRACE1(Js::PerfHintPhase))
                     {
-                        WritePerfHint(PerfHints::HasWithBlock, funcInfo->GetParsedFunctionBody(), 0);
+                        if (pnode->sxFnc.HasWithStmt())
+                        {
+                            WritePerfHint(PerfHints::HasWithBlock, funcInfo->GetParsedFunctionBody(), 0);
+                        }
+                        
+                        if(byteCodeGenerator->GetFlags() & fscrEval)
+                        {
+                            WritePerfHint(PerfHints::SrcIsEval, funcInfo->GetParsedFunctionBody(), 0);
+                        }
                     }
 #endif
                 }

--- a/test/Function/StackArgsWithFormals.js
+++ b/test/Function/StackArgsWithFormals.js
@@ -272,6 +272,14 @@ test17(1);
 test17(2);
 verify([undefined, 20, undefined, 20], "TEST 17");
 
+function test18()
+{
+    eval('function inner(a,...b) {actuals.push(a + arguments[0]);}; inner(1,2); inner(3,4);');
+}
+
+test18();
+verify([2, 6], "TEST18");
+
 if(hasAllPassed)
 {
     print("PASSED");


### PR DESCRIPTION
This is a bug fix - where one of the assumptions was failing as an
assertion failure - This is true only when the source is inside an eval
expression.

Though the fix for this bug is really straight forward, I have decided to
disable the optimization when the source is inside an eval expression - to
minimize risk.
