### PR TITLE
Change the bytecodeuse apis to better check for correctness going forward.

### DIFF
--- a/lib/Backend/BackwardPass.cpp
+++ b/lib/Backend/BackwardPass.cpp
@@ -6894,7 +6894,7 @@ BackwardPass::ProcessInlineeStart(IR::Instr* inlineeStart)
         if (!opnd->GetIsJITOptimizedReg() && sym && sym->HasByteCodeRegSlot())
         {
             // Replace instrs with bytecodeUses
-            IR::ByteCodeUsesInstr *bytecodeUse = IR::ByteCodeUsesInstr::New(argInstr, sym->m_id);
+            IR::ByteCodeUsesInstr *bytecodeUse = IR::ByteCodeUsesInstr::New(argInstr, opnd, sym->m_id);
             argInstr->InsertBefore(bytecodeUse);
         }
         startCallInstr = argInstr->GetSrc2()->GetStackSym()->m_instrDef;
@@ -6961,7 +6961,7 @@ BackwardPass::ProcessInlineeStart(IR::Instr* inlineeStart)
     if (!src1->GetIsJITOptimizedReg() && sym && sym->HasByteCodeRegSlot())
     {
         // Replace instrs with bytecodeUses
-        IR::ByteCodeUsesInstr *bytecodeUse = IR::ByteCodeUsesInstr::New(inlineeStart, sym->m_id);
+        IR::ByteCodeUsesInstr *bytecodeUse = IR::ByteCodeUsesInstr::New(inlineeStart, src1, sym->m_id);
         inlineeStart->InsertBefore(bytecodeUse);
     }
 

--- a/lib/Backend/BackwardPass.cpp
+++ b/lib/Backend/BackwardPass.cpp
@@ -1859,7 +1859,7 @@ BackwardPass::ProcessBailOutInfo(IR::Instr * instr)
             //
             // Handle the source side.
             IR::ByteCodeUsesInstr *byteCodeUsesInstr = instr->AsByteCodeUsesInstr();
-            const BVSparse<JitArenaAllocator> * byteCodeUpwardExposedUsed = byteCodeUsesInstr->getByteCodeUpwardExposedUsed();
+            const BVSparse<JitArenaAllocator> * byteCodeUpwardExposedUsed = byteCodeUsesInstr->GetByteCodeUpwardExposedUsed();
             if (byteCodeUpwardExposedUsed != nullptr)
             {
                 this->currentBlock->upwardExposedUses->Or(byteCodeUpwardExposedUsed);
@@ -1926,11 +1926,11 @@ BackwardPass::ProcessBailOutInfo(IR::Instr * instr)
             }
 
             IR::ByteCodeUsesInstr *byteCodeUsesInstr = instr->AsByteCodeUsesInstr();
-            if (byteCodeUsesInstr->getByteCodeUpwardExposedUsed() != nullptr)
+            if (byteCodeUsesInstr->GetByteCodeUpwardExposedUsed() != nullptr)
             {
-                this->currentBlock->byteCodeUpwardExposedUsed->Or(byteCodeUsesInstr->getByteCodeUpwardExposedUsed());
+                this->currentBlock->byteCodeUpwardExposedUsed->Or(byteCodeUsesInstr->GetByteCodeUpwardExposedUsed());
 #if DBG
-                FOREACH_BITSET_IN_SPARSEBV(symId, byteCodeUsesInstr->getByteCodeUpwardExposedUsed())
+                FOREACH_BITSET_IN_SPARSEBV(symId, byteCodeUsesInstr->GetByteCodeUpwardExposedUsed())
                 {
                     StackSym * stackSym = this->func->m_symTable->FindStackSym(symId);
                     Assert(!stackSym->IsTypeSpec());
@@ -6894,7 +6894,7 @@ BackwardPass::ProcessInlineeStart(IR::Instr* inlineeStart)
         {
             // Replace instrs with bytecodeUses
             IR::ByteCodeUsesInstr *bytecodeUse = IR::ByteCodeUsesInstr::New(argInstr);
-            bytecodeUse->Set(opnd->GetIsJITOptimizedReg(), sym->m_id);
+            bytecodeUse->Set(opnd);
             argInstr->InsertBefore(bytecodeUse);
         }
         startCallInstr = argInstr->GetSrc2()->GetStackSym()->m_instrDef;
@@ -6962,7 +6962,7 @@ BackwardPass::ProcessInlineeStart(IR::Instr* inlineeStart)
     {
         // Replace instrs with bytecodeUses
         IR::ByteCodeUsesInstr *bytecodeUse = IR::ByteCodeUsesInstr::New(inlineeStart);
-        bytecodeUse->Set(src1->GetIsJITOptimizedReg(), sym->m_id);
+        bytecodeUse->Set(src1);
         inlineeStart->InsertBefore(bytecodeUse);
     }
 
@@ -7266,7 +7266,7 @@ BackwardPass::ReverseCopyProp(IR::Instr *instr)
         if (instrPrev->m_opcode == Js::OpCode::ByteCodeUses)
         {
             byteCodeUseInstr = instrPrev->AsByteCodeUsesInstr();
-            const BVSparse<JitArenaAllocator>* byteCodeUpwardExposedUsed = byteCodeUseInstr->getByteCodeUpwardExposedUsed();
+            const BVSparse<JitArenaAllocator>* byteCodeUpwardExposedUsed = byteCodeUseInstr->GetByteCodeUpwardExposedUsed();
             if (byteCodeUpwardExposedUsed && byteCodeUpwardExposedUsed->Test(varSym->m_id) && byteCodeUpwardExposedUsed->Count() == 1)
             {
                 instrPrev = byteCodeUseInstr->GetPrevRealInstrOrLabel();

--- a/lib/Backend/FlowGraph.cpp
+++ b/lib/Backend/FlowGraph.cpp
@@ -3105,7 +3105,7 @@ bool FlowGraph::UnsignedCmpPeep(IR::Instr *cmpInstr)
 
     if (cmpSrc1 != newSrc1)
     {
-        if (cmpSrc1->IsRegOpnd())
+        if (cmpSrc1->IsRegOpnd() && !cmpSrc1->GetIsJITOptimizedReg())
         {
             bytecodeInstr->byteCodeUpwardExposedUsed->Set(cmpSrc1->AsRegOpnd()->m_sym->m_id);
         }
@@ -3117,7 +3117,7 @@ bool FlowGraph::UnsignedCmpPeep(IR::Instr *cmpInstr)
     }
     if (cmpSrc2 != newSrc2)
     {
-        if (cmpSrc2->IsRegOpnd())
+        if (cmpSrc2->IsRegOpnd() && !cmpSrc2->GetIsJITOptimizedReg())
         {
             bytecodeInstr->byteCodeUpwardExposedUsed->Set(cmpSrc2->AsRegOpnd()->m_sym->m_id);
         }

--- a/lib/Backend/FlowGraph.cpp
+++ b/lib/Backend/FlowGraph.cpp
@@ -2392,7 +2392,7 @@ FlowGraph::InsertInlineeOnFLowEdge(IR::BranchInstr *instrBr, IR::Instr *inlineeE
     newBr->InsertBefore(newInlineeEnd);
 
     IR::ByteCodeUsesInstr * useOrigBranchSrcInstr = IR::ByteCodeUsesInstr::New(origBrFunc, origByteCodeOffset);
-    useOrigBranchSrcInstr->Set(origBranchSrcOpndIsJITOpt, origBranchSrcSymId);
+    useOrigBranchSrcInstr->SetRemovedOpndSymbol(origBranchSrcOpndIsJITOpt, origBranchSrcSymId);
     newBr->InsertBefore(useOrigBranchSrcInstr);
 
     uint newBrFnNumber = newBr->m_func->GetFunctionNumber();
@@ -2598,7 +2598,7 @@ FlowGraph::RemoveInstr(IR::Instr *instr, GlobOpt * globOpt)
             globOpt->IsArgumentsOpnd(instr->GetSrc1()) && instr->m_func->GetScopeObjSym())
         {
             IR::ByteCodeUsesInstr * byteCodeUsesInstr = IR::ByteCodeUsesInstr::New(instr);
-            byteCodeUsesInstr->Set(false, instr->m_func->GetScopeObjSym()->m_id);
+            byteCodeUsesInstr->SetNonOpndSymbol(instr->m_func->GetScopeObjSym()->m_id);
             instr->InsertAfter(byteCodeUsesInstr);
         }
 
@@ -3105,7 +3105,7 @@ bool FlowGraph::UnsignedCmpPeep(IR::Instr *cmpInstr)
     {
         if (cmpSrc1->IsRegOpnd() && !cmpSrc1->GetIsJITOptimizedReg())
         {
-            bytecodeInstr->Set(cmpSrc1->AsRegOpnd()->GetIsJITOptimizedReg(), cmpSrc1->AsRegOpnd()->m_sym->m_id);
+            bytecodeInstr->Set(cmpSrc1);
         }
         cmpInstr->ReplaceSrc1(newSrc1);
         if (newSrc1->IsRegOpnd())
@@ -3117,7 +3117,7 @@ bool FlowGraph::UnsignedCmpPeep(IR::Instr *cmpInstr)
     {
         if (cmpSrc2->IsRegOpnd() && !cmpSrc2->GetIsJITOptimizedReg())
         {
-            bytecodeInstr->Set(cmpSrc2->AsRegOpnd()->GetIsJITOptimizedReg(), cmpSrc2->AsRegOpnd()->m_sym->m_id);
+            bytecodeInstr->Set(cmpSrc2);
         }
         cmpInstr->ReplaceSrc2(newSrc2);
         if (newSrc2->IsRegOpnd())

--- a/lib/Backend/FlowGraph.h
+++ b/lib/Backend/FlowGraph.h
@@ -199,7 +199,7 @@ private:
 #endif
 
 private:
-    void        InsertInlineeOnFLowEdge(IR::BranchInstr *instrBr, IR::Instr *inlineeEndInstr, IR::Instr *instrBytecode, Func* origBrFunc, uint32 origByteCodeOffset, uint32 origBranchSrcSymId);
+    void        InsertInlineeOnFLowEdge(IR::BranchInstr *instrBr, IR::Instr *inlineeEndInstr, IR::Instr *instrBytecode, Func* origBrFunc, uint32 origByteCodeOffset, bool origBranchSrcOpndIsJITOpt, uint32 origBranchSrcSymId);
 
 private:
     Func *                 func;

--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -20225,7 +20225,7 @@ GlobOpt::OptPeep(IR::Instr *instr, Value *src1Val, Value *src2Val)
                 dst = instr->UnlinkDst();
                 if (!dst->GetIsJITOptimizedReg())
                 {
-                    IR::ByteCodeUsesInstr *bytecodeUse = IR::ByteCodeUsesInstr::New(this->func);
+                    IR::ByteCodeUsesInstr *bytecodeUse = IR::ByteCodeUsesInstr::New(instr);
                     bytecodeUse->SetDst(dst);
                     instr->InsertAfter(bytecodeUse);
                 }

--- a/lib/Backend/IR.cpp
+++ b/lib/Backend/IR.cpp
@@ -880,11 +880,12 @@ ByteCodeUsesInstr::New(Func * func)
 }
 
 ByteCodeUsesInstr *
-ByteCodeUsesInstr::New(IR::Instr* originalBytecodeInstr, SymID symid)
+ByteCodeUsesInstr::New(IR::Instr* originalBytecodeInstr, IR::Opnd* srcopnd, SymID symid)
 {
     Func* func = originalBytecodeInstr->m_func;
     ByteCodeUsesInstr * byteCodeUses = JitAnew(func->m_alloc, IR::ByteCodeUsesInstr);
     byteCodeUses->Init(Js::OpCode::ByteCodeUses, InstrKindByteCodeUses, func);
+    Assert(!srcopnd == nullptr && !srcopnd->GetIsJITOptimizedReg());
     byteCodeUses->byteCodeUpwardExposedUsed = JitAnew(func->m_alloc, BVSparse<JitArenaAllocator>, func->m_alloc);
     byteCodeUses->byteCodeUpwardExposedUsed->Set(symid);
     byteCodeUses->SetByteCodeOffset(originalBytecodeInstr);
@@ -892,8 +893,9 @@ ByteCodeUsesInstr::New(IR::Instr* originalBytecodeInstr, SymID symid)
     return byteCodeUses;
 }
 
-void ByteCodeUsesInstr::Set(uint symId)
+void ByteCodeUsesInstr::Set(IR::Opnd* srcopnd, uint symId)
 {
+    Assert(!srcopnd == nullptr && !srcopnd->GetIsJITOptimizedReg());
     if(!byteCodeUpwardExposedUsed)
     {
         byteCodeUpwardExposedUsed = JitAnew(m_func->m_alloc, BVSparse<JitArenaAllocator>, m_func->m_alloc);

--- a/lib/Backend/IR.h
+++ b/lib/Backend/IR.h
@@ -507,11 +507,11 @@ class ByteCodeUsesInstr : public Instr
 {
 public:
     static ByteCodeUsesInstr * New(Func * func);
-    static ByteCodeUsesInstr* New(IR::Instr* originalBytecodeInstr, SymID symid);
+    static ByteCodeUsesInstr* New(IR::Instr* originalBytecodeInstr, Opnd* srcopnd, SymID symid);
     BVSparse<JitArenaAllocator> * byteCodeUpwardExposedUsed;
     PropertySym *              propertySymUse;
 
-    void Set(uint symId);
+    void Set(Opnd* srcopnd, uint symId);
 };
 
 class JitProfilingInstr : public Instr

--- a/lib/Backend/IR.h
+++ b/lib/Backend/IR.h
@@ -440,6 +440,7 @@ private:
     void            SetNumber(uint32 number);
     friend class ::Func;
     friend class ::Lowerer;
+    friend class IR::ByteCodeUsesInstr;
 
     void            SetByteCodeOffset(uint32 number);
     friend class ::IRBuilder;
@@ -505,13 +506,19 @@ protected:
 
 class ByteCodeUsesInstr : public Instr
 {
-public:
-    static ByteCodeUsesInstr * New(Func * func);
-    static ByteCodeUsesInstr* New(IR::Instr* originalBytecodeInstr, Opnd* srcopnd, SymID symid);
+private:
     BVSparse<JitArenaAllocator> * byteCodeUpwardExposedUsed;
-    PropertySym *              propertySymUse;
+    
+public:
+    static ByteCodeUsesInstr * New(IR::Instr * originalBytecodeInstr);
+    static ByteCodeUsesInstr * New(Func * originalBytecodeInstr, uint32 offset);
+    const BVSparse<JitArenaAllocator> * getByteCodeUpwardExposedUsed() const { return byteCodeUpwardExposedUsed; }
 
-    void Set(Opnd* srcopnd, uint symId);
+    PropertySym *              propertySymUse;
+    void Set(bool isjitoptimizedreg, uint symId);
+    void Clear(uint symId) { Assert(byteCodeUpwardExposedUsed != nullptr); byteCodeUpwardExposedUsed->Clear(symId); };
+    void SetBV(BVSparse<JitArenaAllocator>* newbv) { Assert(byteCodeUpwardExposedUsed == nullptr && newbv != nullptr); byteCodeUpwardExposedUsed = newbv; };
+    void Aggregate();
 };
 
 class JitProfilingInstr : public Instr

--- a/lib/Backend/IRBuilder.cpp
+++ b/lib/Backend/IRBuilder.cpp
@@ -2331,11 +2331,11 @@ IRBuilder::BuildReg4(Js::OpCode newOpcode, uint32 offset, Js::RegSlot dstRegSlot
         IR::ByteCodeUsesInstr * byteCodeUse = IR::ByteCodeUsesInstr::New(m_func, Js::Constants::NoByteCodeOffset);
         if (src1HasByteCodeRegSlot)
         {
-            byteCodeUse->Set(src1Opnd->GetIsJITOptimizedReg(), src1Opnd->m_sym->m_id);
+            byteCodeUse->Set(src1Opnd);
         }
         if (src2HasByteCodeRegSlot)
         {
-            byteCodeUse->Set(src2Opnd->GetIsJITOptimizedReg(), src2Opnd->m_sym->m_id);
+            byteCodeUse->Set(src2Opnd);
         }
         this->AddInstr(byteCodeUse, Js::Constants::NoByteCodeOffset);
     }
@@ -2475,7 +2475,7 @@ IRBuilder::BuildReg3B1(Js::OpCode newOpcode, uint32 offset, Js::RegSlot dstRegSl
     if (src1Opnd->m_sym->HasByteCodeRegSlot())
     {
         IR::ByteCodeUsesInstr * byteCodeUse = IR::ByteCodeUsesInstr::New(m_func, Js::Constants::NoByteCodeOffset);
-        byteCodeUse->Set(src1Opnd->GetIsJITOptimizedReg(), src1Opnd->m_sym->m_id);
+        byteCodeUse->Set(src1Opnd);
         this->AddInstr(byteCodeUse, Js::Constants::NoByteCodeOffset);
     }
 
@@ -3512,7 +3512,7 @@ LdLocalSlot:
             if (closureSym->HasByteCodeRegSlot())
             {
                 byteCodeUse = IR::ByteCodeUsesInstr::New(m_func, offset);
-                byteCodeUse->Set(false, closureSym->m_id);
+                byteCodeUse->SetNonOpndSymbol(closureSym->m_id);
                 this->AddInstr(byteCodeUse, offset);
             }
 
@@ -3574,7 +3574,7 @@ LdLocalObjSlot:
             if (closureSym->HasByteCodeRegSlot())
             {
                 byteCodeUse = IR::ByteCodeUsesInstr::New(m_func, offset);
-                byteCodeUse->Set(false, closureSym->m_id);
+                byteCodeUse->SetNonOpndSymbol(closureSym->m_id);
                 this->AddInstr(byteCodeUse, offset);
             }
 
@@ -3614,7 +3614,7 @@ LdLocalObjSlot:
             if (closureSym->HasByteCodeRegSlot())
             {
                 byteCodeUse = IR::ByteCodeUsesInstr::New(m_func, offset);
-                byteCodeUse->Set(false, closureSym->m_id);
+                byteCodeUse->SetNonOpndSymbol(closureSym->m_id);
                 this->AddInstr(byteCodeUse, offset);
             }
 
@@ -3667,7 +3667,7 @@ LdLocalObjSlot:
             if (closureSym->HasByteCodeRegSlot())
             {
                 byteCodeUse = IR::ByteCodeUsesInstr::New(m_func, offset);
-                byteCodeUse->Set(false, closureSym->m_id);
+                byteCodeUse->SetNonOpndSymbol(closureSym->m_id);
                 this->AddInstr(byteCodeUse, offset);
             }
 
@@ -4165,7 +4165,7 @@ IRBuilder::BuildElementP(Js::OpCode newOpcode, uint32 offset, Js::RegSlot regSlo
         if (m_func->GetLocalClosureSym()->HasByteCodeRegSlot())
         {
             IR::ByteCodeUsesInstr * byteCodeUse = IR::ByteCodeUsesInstr::New(m_func, offset);
-            byteCodeUse->Set(false, m_func->GetLocalClosureSym()->m_id);
+            byteCodeUse->SetNonOpndSymbol(m_func->GetLocalClosureSym()->m_id);
             this->AddInstr(byteCodeUse, offset);
         }
 
@@ -4194,7 +4194,7 @@ IRBuilder::BuildElementP(Js::OpCode newOpcode, uint32 offset, Js::RegSlot regSlo
         if (m_func->GetLocalClosureSym()->HasByteCodeRegSlot())
         {
             IR::ByteCodeUsesInstr * byteCodeUse = IR::ByteCodeUsesInstr::New(m_func, offset);
-            byteCodeUse->Set(false, m_func->GetLocalClosureSym()->m_id);
+            byteCodeUse->SetNonOpndSymbol(m_func->GetLocalClosureSym()->m_id);
             this->AddInstr(byteCodeUse, offset);
         }
 
@@ -4215,7 +4215,7 @@ IRBuilder::BuildElementP(Js::OpCode newOpcode, uint32 offset, Js::RegSlot regSlo
         if (m_func->GetLocalClosureSym()->HasByteCodeRegSlot())
         {
             IR::ByteCodeUsesInstr * byteCodeUse = IR::ByteCodeUsesInstr::New(m_func, offset);
-            byteCodeUse->Set(false, m_func->GetLocalClosureSym()->m_id);
+            byteCodeUse->SetNonOpndSymbol(m_func->GetLocalClosureSym()->m_id);
             this->AddInstr(byteCodeUse, offset);
         }
 
@@ -4701,7 +4701,7 @@ IRBuilder::BuildElementU(Js::OpCode newOpcode, uint32 offset, Js::RegSlot instan
             if (m_func->GetLocalClosureSym()->HasByteCodeRegSlot())
             {
                 IR::ByteCodeUsesInstr * byteCodeUse = IR::ByteCodeUsesInstr::New(m_func, offset);
-                byteCodeUse->Set(false, m_func->GetLocalClosureSym()->m_id);
+                byteCodeUse->SetNonOpndSymbol(m_func->GetLocalClosureSym()->m_id);
                 this->AddInstr(byteCodeUse, offset);
             }
 
@@ -7109,7 +7109,7 @@ IRBuilder::BuildBrLocalProperty(Js::OpCode newOpcode, uint32 offset)
     if (m_func->GetLocalClosureSym()->HasByteCodeRegSlot())
     {
         IR::ByteCodeUsesInstr * byteCodeUse = IR::ByteCodeUsesInstr::New(m_func, offset);
-        byteCodeUse->Set(false, m_func->GetLocalClosureSym()->m_id);
+        byteCodeUse->SetNonOpndSymbol(m_func->GetLocalClosureSym()->m_id);
         this->AddInstr(byteCodeUse, offset);
     }
 

--- a/lib/Backend/IRBuilder.cpp
+++ b/lib/Backend/IRBuilder.cpp
@@ -974,12 +974,13 @@ IRBuilder::EmitClosureRangeChecks()
         }
         if (bv)
         {
-            IR::ByteCodeUsesInstr * byteCodeUse = IR::ByteCodeUsesInstr::New(m_func);
-            byteCodeUse->byteCodeUpwardExposedUsed = bv;
+
             FOREACH_INSTR_IN_FUNC_BACKWARD(instr, m_func)
             {
                 if (instr->m_opcode == Js::OpCode::Ret)
                 {
+                    IR::ByteCodeUsesInstr * byteCodeUse = IR::ByteCodeUsesInstr::New(instr);
+                    byteCodeUse->SetBV(bv);
                     instr->InsertBefore(byteCodeUse);
                     break;
                 }
@@ -1131,7 +1132,10 @@ IRBuilder::AddInstr(IR::Instr *instr, uint32 offset)
         {
             Assert(m_lastInstr->GetByteCodeOffset() == offset);
         }
-        instr->SetByteCodeOffset(offset);
+        if (instr->GetByteCodeOffset() == Js::Constants::NoByteCodeOffset)
+        {
+            instr->SetByteCodeOffset(offset);
+        }
     }
     else
     {
@@ -2324,15 +2328,14 @@ IRBuilder::BuildReg4(Js::OpCode newOpcode, uint32 offset, Js::RegSlot dstRegSlot
     bool src2HasByteCodeRegSlot = src2Opnd->m_sym->HasByteCodeRegSlot();
     if (src1HasByteCodeRegSlot || src2HasByteCodeRegSlot)
     {
-        IR::ByteCodeUsesInstr * byteCodeUse = IR::ByteCodeUsesInstr::New(m_func);
-        byteCodeUse->byteCodeUpwardExposedUsed = JitAnew(m_func->m_alloc, BVSparse<JitArenaAllocator>, m_func->m_alloc);
+        IR::ByteCodeUsesInstr * byteCodeUse = IR::ByteCodeUsesInstr::New(m_func, Js::Constants::NoByteCodeOffset);
         if (src1HasByteCodeRegSlot)
         {
-            byteCodeUse->byteCodeUpwardExposedUsed->Set(src1Opnd->m_sym->m_id);
+            byteCodeUse->Set(src1Opnd->GetIsJITOptimizedReg(), src1Opnd->m_sym->m_id);
         }
         if (src2HasByteCodeRegSlot)
         {
-            byteCodeUse->byteCodeUpwardExposedUsed->Set(src2Opnd->m_sym->m_id);
+            byteCodeUse->Set(src2Opnd->GetIsJITOptimizedReg(), src2Opnd->m_sym->m_id);
         }
         this->AddInstr(byteCodeUse, Js::Constants::NoByteCodeOffset);
     }
@@ -2471,9 +2474,8 @@ IRBuilder::BuildReg3B1(Js::OpCode newOpcode, uint32 offset, Js::RegSlot dstRegSl
     // we will restore it.
     if (src1Opnd->m_sym->HasByteCodeRegSlot())
     {
-        IR::ByteCodeUsesInstr * byteCodeUse = IR::ByteCodeUsesInstr::New(m_func);
-        byteCodeUse->byteCodeUpwardExposedUsed = JitAnew(m_func->m_alloc, BVSparse<JitArenaAllocator>, m_func->m_alloc);
-        byteCodeUse->byteCodeUpwardExposedUsed->Set(src1Opnd->m_sym->m_id);
+        IR::ByteCodeUsesInstr * byteCodeUse = IR::ByteCodeUsesInstr::New(m_func, Js::Constants::NoByteCodeOffset);
+        byteCodeUse->Set(src1Opnd->GetIsJITOptimizedReg(), src1Opnd->m_sym->m_id);
         this->AddInstr(byteCodeUse, Js::Constants::NoByteCodeOffset);
     }
 
@@ -3509,9 +3511,8 @@ LdLocalSlot:
 
             if (closureSym->HasByteCodeRegSlot())
             {
-                byteCodeUse = IR::ByteCodeUsesInstr::New(m_func);
-                byteCodeUse->byteCodeUpwardExposedUsed = JitAnew(m_func->m_alloc, BVSparse<JitArenaAllocator>, m_func->m_alloc);
-                byteCodeUse->byteCodeUpwardExposedUsed->Set(closureSym->m_id);
+                byteCodeUse = IR::ByteCodeUsesInstr::New(m_func, offset);
+                byteCodeUse->Set(false, closureSym->m_id);
                 this->AddInstr(byteCodeUse, offset);
             }
 
@@ -3572,9 +3573,8 @@ LdLocalSlot:
 LdLocalObjSlot:
             if (closureSym->HasByteCodeRegSlot())
             {
-                byteCodeUse = IR::ByteCodeUsesInstr::New(m_func);
-                byteCodeUse->byteCodeUpwardExposedUsed = JitAnew(m_func->m_alloc, BVSparse<JitArenaAllocator>, m_func->m_alloc);
-                byteCodeUse->byteCodeUpwardExposedUsed->Set(closureSym->m_id);
+                byteCodeUse = IR::ByteCodeUsesInstr::New(m_func, offset);
+                byteCodeUse->Set(false, closureSym->m_id);
                 this->AddInstr(byteCodeUse, offset);
             }
 
@@ -3613,9 +3613,8 @@ LdLocalObjSlot:
 
             if (closureSym->HasByteCodeRegSlot())
             {
-                byteCodeUse = IR::ByteCodeUsesInstr::New(m_func);
-                byteCodeUse->byteCodeUpwardExposedUsed = JitAnew(m_func->m_alloc, BVSparse<JitArenaAllocator>, m_func->m_alloc);
-                byteCodeUse->byteCodeUpwardExposedUsed->Set(closureSym->m_id);
+                byteCodeUse = IR::ByteCodeUsesInstr::New(m_func, offset);
+                byteCodeUse->Set(false, closureSym->m_id);
                 this->AddInstr(byteCodeUse, offset);
             }
 
@@ -3667,9 +3666,8 @@ LdLocalObjSlot:
 
             if (closureSym->HasByteCodeRegSlot())
             {
-                byteCodeUse = IR::ByteCodeUsesInstr::New(m_func);
-                byteCodeUse->byteCodeUpwardExposedUsed = JitAnew(m_func->m_alloc, BVSparse<JitArenaAllocator>, m_func->m_alloc);
-                byteCodeUse->byteCodeUpwardExposedUsed->Set(closureSym->m_id);
+                byteCodeUse = IR::ByteCodeUsesInstr::New(m_func, offset);
+                byteCodeUse->Set(false, closureSym->m_id);
                 this->AddInstr(byteCodeUse, offset);
             }
 
@@ -4166,9 +4164,8 @@ IRBuilder::BuildElementP(Js::OpCode newOpcode, uint32 offset, Js::RegSlot regSlo
     case Js::OpCode::LdLocalFld:
         if (m_func->GetLocalClosureSym()->HasByteCodeRegSlot())
         {
-            IR::ByteCodeUsesInstr * byteCodeUse = IR::ByteCodeUsesInstr::New(m_func);
-            byteCodeUse->byteCodeUpwardExposedUsed = JitAnew(m_func->m_alloc, BVSparse<JitArenaAllocator>, m_func->m_alloc);
-            byteCodeUse->byteCodeUpwardExposedUsed->Set(m_func->GetLocalClosureSym()->m_id);
+            IR::ByteCodeUsesInstr * byteCodeUse = IR::ByteCodeUsesInstr::New(m_func, offset);
+            byteCodeUse->Set(false, m_func->GetLocalClosureSym()->m_id);
             this->AddInstr(byteCodeUse, offset);
         }
 
@@ -4196,9 +4193,8 @@ IRBuilder::BuildElementP(Js::OpCode newOpcode, uint32 offset, Js::RegSlot regSlo
     case Js::OpCode::StLocalFld:
         if (m_func->GetLocalClosureSym()->HasByteCodeRegSlot())
         {
-            IR::ByteCodeUsesInstr * byteCodeUse = IR::ByteCodeUsesInstr::New(m_func);
-            byteCodeUse->byteCodeUpwardExposedUsed = JitAnew(m_func->m_alloc, BVSparse<JitArenaAllocator>, m_func->m_alloc);
-            byteCodeUse->byteCodeUpwardExposedUsed->Set(m_func->GetLocalClosureSym()->m_id);
+            IR::ByteCodeUsesInstr * byteCodeUse = IR::ByteCodeUsesInstr::New(m_func, offset);
+            byteCodeUse->Set(false, m_func->GetLocalClosureSym()->m_id);
             this->AddInstr(byteCodeUse, offset);
         }
 
@@ -4218,9 +4214,8 @@ IRBuilder::BuildElementP(Js::OpCode newOpcode, uint32 offset, Js::RegSlot regSlo
     {
         if (m_func->GetLocalClosureSym()->HasByteCodeRegSlot())
         {
-            IR::ByteCodeUsesInstr * byteCodeUse = IR::ByteCodeUsesInstr::New(m_func);
-            byteCodeUse->byteCodeUpwardExposedUsed = JitAnew(m_func->m_alloc, BVSparse<JitArenaAllocator>, m_func->m_alloc);
-            byteCodeUse->byteCodeUpwardExposedUsed->Set(m_func->GetLocalClosureSym()->m_id);
+            IR::ByteCodeUsesInstr * byteCodeUse = IR::ByteCodeUsesInstr::New(m_func, offset);
+            byteCodeUse->Set(false, m_func->GetLocalClosureSym()->m_id);
             this->AddInstr(byteCodeUse, offset);
         }
 
@@ -4705,9 +4700,8 @@ IRBuilder::BuildElementU(Js::OpCode newOpcode, uint32 offset, Js::RegSlot instan
         case Js::OpCode::LdLocalElemUndef:
             if (m_func->GetLocalClosureSym()->HasByteCodeRegSlot())
             {
-                IR::ByteCodeUsesInstr * byteCodeUse = IR::ByteCodeUsesInstr::New(m_func);
-                byteCodeUse->byteCodeUpwardExposedUsed = JitAnew(m_func->m_alloc, BVSparse<JitArenaAllocator>, m_func->m_alloc);
-                byteCodeUse->byteCodeUpwardExposedUsed->Set(m_func->GetLocalClosureSym()->m_id);
+                IR::ByteCodeUsesInstr * byteCodeUse = IR::ByteCodeUsesInstr::New(m_func, offset);
+                byteCodeUse->Set(false, m_func->GetLocalClosureSym()->m_id);
                 this->AddInstr(byteCodeUse, offset);
             }
 
@@ -7114,9 +7108,8 @@ IRBuilder::BuildBrLocalProperty(Js::OpCode newOpcode, uint32 offset)
 
     if (m_func->GetLocalClosureSym()->HasByteCodeRegSlot())
     {
-        IR::ByteCodeUsesInstr * byteCodeUse = IR::ByteCodeUsesInstr::New(m_func);
-        byteCodeUse->byteCodeUpwardExposedUsed = JitAnew(m_func->m_alloc, BVSparse<JitArenaAllocator>, m_func->m_alloc);
-        byteCodeUse->byteCodeUpwardExposedUsed->Set(m_func->GetLocalClosureSym()->m_id);
+        IR::ByteCodeUsesInstr * byteCodeUse = IR::ByteCodeUsesInstr::New(m_func, offset);
+        byteCodeUse->Set(false, m_func->GetLocalClosureSym()->m_id);
         this->AddInstr(byteCodeUse, offset);
     }
 

--- a/lib/Backend/Inline.cpp
+++ b/lib/Backend/Inline.cpp
@@ -476,7 +476,7 @@ Inline::Optimize(Func *func, __in_ecount_opt(callerArgOutCount) IR::Instr *calle
 
                         // Insert a ByteCodeUsesInstr to make sure the methodValueDstOpnd's constant value is captured by any
                         // bailout that occurs between CheckFixedMethodField and CallI.
-                        IR::ByteCodeUsesInstr * useCallTargetInstr = IR::ByteCodeUsesInstr::New(instr, originalCallTargetStackSym->m_id);
+                        IR::ByteCodeUsesInstr * useCallTargetInstr = IR::ByteCodeUsesInstr::New(instr, instr->GetSrc1(), originalCallTargetStackSym->m_id);
                         instr->InsertBefore(useCallTargetInstr);
 
                         // Split NewScObject into NewScObjectNoCtor and CallI, but don't touch NewScObjectArray.
@@ -1070,7 +1070,7 @@ void Inline::CompletePolymorphicInlining(IR::Instr* callInstr, IR::RegOpnd* retu
         return false;
     });
 
-    callInstr->InsertBefore(IR::ByteCodeUsesInstr::New(callInstr, callInstr->GetSrc1()->GetStackSym()->m_id));
+    callInstr->InsertBefore(IR::ByteCodeUsesInstr::New(callInstr, callInstr->GetSrc1(), callInstr->GetSrc1()->GetStackSym()->m_id));
 
     IR::Instr* endCallInstr = IR::Instr::New(Js::OpCode::EndCallForPolymorphicInlinee, callInstr->m_func);
     endCallInstr->SetSrc1(IR::IntConstOpnd::New(actualsCount + Js::Constants::InlineeMetaArgCount, TyInt32, callInstr->m_func, /*dontEncode*/ true));
@@ -2025,7 +2025,7 @@ Inline::InlineBuiltInFunction(IR::Instr *callInstr, const FunctionJITTimeInfo * 
     // Insert a byteCodeUsesInstr to make sure the function object's lifetime is extended beyond the last bailout point
     // at which we may need to call the inlinee again in the interpreter.
     {
-        IR::ByteCodeUsesInstr * useCallTargetInstr = IR::ByteCodeUsesInstr::New(callInstr, originalCallTargetStackSym->m_id);
+        IR::ByteCodeUsesInstr * useCallTargetInstr = IR::ByteCodeUsesInstr::New(callInstr, callInstr->GetSrc1(), originalCallTargetStackSym->m_id);
         callInstr->InsertBefore(useCallTargetInstr);
     }
 
@@ -2061,7 +2061,7 @@ Inline::InlineBuiltInFunction(IR::Instr *callInstr, const FunctionJITTimeInfo * 
 
         // Insert a byteCodeUsesInstr to make sure the function object's lifetime is extended beyond the last bailout point
         // at which we may need to call the inlinee again in the interpreter.
-        IR::ByteCodeUsesInstr * useCallTargetInstr = IR::ByteCodeUsesInstr::New(callInstr->GetPrevRealInstrOrLabel(), originalCallTargetStackSym->m_id);
+        IR::ByteCodeUsesInstr * useCallTargetInstr = IR::ByteCodeUsesInstr::New(callInstr->GetPrevRealInstrOrLabel(), callInstr->GetSrc1(), originalCallTargetStackSym->m_id);
 
         if(inlineCallOpCode == Js::OpCode::InlineArrayPop)
         {
@@ -2423,7 +2423,7 @@ IR::Instr * Inline::InlineApplyWithArgumentsObject(IR::Instr * callInstr, IR::In
     // the bailout on non-stack arguments.
     if (callInstr->m_opcode == Js::OpCode::CallIFixed)
     {
-        IR::ByteCodeUsesInstr * useCallTargetInstr = IR::ByteCodeUsesInstr::New(callInstr, originalCallTargetStackSym->m_id);
+        IR::ByteCodeUsesInstr * useCallTargetInstr = IR::ByteCodeUsesInstr::New(callInstr, callInstr->GetSrc1(), originalCallTargetStackSym->m_id);
         callInstr->InsertBefore(useCallTargetInstr);
     }
 
@@ -2559,7 +2559,7 @@ IR::Instr * Inline::InlineApplyWithoutArrayArgument(IR::Instr *callInstr, const 
     if (TryOptimizeCallInstrWithFixedMethod(callInstr, applyTargetInfo, false /*isPolymorphic*/, false /*isBuiltIn*/, false /*isCtor*/, true /*isInlined*/, safeThis /*unused here*/))
     {
         Assert(callInstr->m_opcode == Js::OpCode::CallIFixed);
-        callInstr->InsertBefore(IR::ByteCodeUsesInstr::New(callInstr, callTargetStackSym->m_id));
+        callInstr->InsertBefore(IR::ByteCodeUsesInstr::New(callInstr, callInstr->GetSrc1(), callTargetStackSym->m_id));
     }
 
     return callInstr;
@@ -2723,13 +2723,13 @@ bool Inline::InlineApplyScriptTarget(IR::Instr *callInstr, const FunctionJITTime
     startCall->SetSrc2(IR::IntConstOpnd::New(startCall->GetArgOutCount(/*getInterpreterArgOutCount*/ false), TyUint32, startCall->m_func));
     startCall->GetSrc1()->AsIntConstOpnd()->IncrValue(-1); // update the count of argouts as seen by JIT, in the start call instruction
 
-    *returnInstr = InlineCallApplyTarget_Shared(callInstr, originalCallTargetStackSym, inlineeData, inlineCacheIndex,
+    *returnInstr = InlineCallApplyTarget_Shared(callInstr, callInstr->GetSrc1(), originalCallTargetStackSym, inlineeData, inlineCacheIndex,
                                                 safeThis, /*isApplyTarget*/ true, /*isCallTarget*/ false, recursiveInlineDepth);
     return true;
 }
 
 IR::Instr *
-Inline::InlineCallApplyTarget_Shared(IR::Instr *callInstr, StackSym* originalCallTargetStackSym, const FunctionJITTimeInfo *const inlineeData,
+Inline::InlineCallApplyTarget_Shared(IR::Instr *callInstr, IR::Opnd* originalCallTargetOpnd, StackSym* originalCallTargetStackSym, const FunctionJITTimeInfo *const inlineeData,
                                         uint inlineCacheIndex, bool safeThis, bool isApplyTarget, bool isCallTarget, uint recursiveInlineDepth)
 {
     Assert(isApplyTarget ^ isCallTarget);
@@ -2810,7 +2810,7 @@ Inline::InlineCallApplyTarget_Shared(IR::Instr *callInstr, StackSym* originalCal
     // instrNext
     IR::Instr* instrNext = callInstr->m_next;
 
-    return InlineFunctionCommon(callInstr, originalCallTargetStackSym, inlineeData, inlinee, instrNext, returnValueOpnd, callInstr, nullptr, recursiveInlineDepth, safeThis, isApplyTarget);
+    return InlineFunctionCommon(callInstr, originalCallTargetOpnd, originalCallTargetStackSym, inlineeData, inlinee, instrNext, returnValueOpnd, callInstr, nullptr, recursiveInlineDepth, safeThis, isApplyTarget);
 }
 
 IR::Opnd *
@@ -3007,7 +3007,7 @@ Inline::InlineCallTarget(IR::Instr *callInstr, const FunctionJITTimeInfo* inline
     startCall->SetSrc2(IR::IntConstOpnd::New(startCall->GetArgOutCount(/*getInterpreterArgOutCount*/ false), TyUint32, startCall->m_func));
     startCall->GetSrc1()->AsIntConstOpnd()->SetValue(startCall->GetSrc1()->AsIntConstOpnd()->GetValue() - 1);
 
-    *returnInstr = InlineCallApplyTarget_Shared(callInstr, originalCallTargetStackSym, inlineeData, inlineCacheIndex,
+    *returnInstr = InlineCallApplyTarget_Shared(callInstr, callInstr->GetSrc1(), originalCallTargetStackSym, inlineeData, inlineCacheIndex,
                                                 safeThis, /*isApplyTarget*/ false, /*isCallTarget*/ true, recursiveInlineDepth);
 
     return true;
@@ -3575,11 +3575,11 @@ Inline::InlineGetterSetterFunction(IR::Instr *accessorInstr, const FunctionJITTi
     bool safeThis = false;
     TryOptimizeCallInstrWithFixedMethod(accessorInstr, inlineeData, false, false, false, true, safeThis);
 
-    return InlineFunctionCommon(accessorInstr, nullptr, inlineeData, inlinee, instrNext, returnValueOpnd, inlineBailoutChecksBeforeInstr, symCallerThis, recursiveInlineDepth, safeThis);
+    return InlineFunctionCommon(accessorInstr, nullptr, nullptr, inlineeData, inlinee, instrNext, returnValueOpnd, inlineBailoutChecksBeforeInstr, symCallerThis, recursiveInlineDepth, safeThis);
 }
 
 IR::Instr *
-Inline::InlineFunctionCommon(IR::Instr *callInstr, StackSym* originalCallTargetStackSym, const FunctionJITTimeInfo *funcInfo, Func *inlinee, IR::Instr *instrNext,
+Inline::InlineFunctionCommon(IR::Instr *callInstr, IR::Opnd* originalCallTargetOpnd, StackSym* originalCallTargetStackSym, const FunctionJITTimeInfo *funcInfo, Func *inlinee, IR::Instr *instrNext,
                                 IR::RegOpnd * returnValueOpnd, IR::Instr *inlineBailoutChecksBeforeInstr, const StackSym *symCallerThis, uint recursiveInlineDepth, bool safeThis, bool isApplyTarget)
 {
     BuildIRForInlinee(inlinee, funcInfo->GetBody(), callInstr, isApplyTarget, recursiveInlineDepth);
@@ -3623,11 +3623,12 @@ Inline::InlineFunctionCommon(IR::Instr *callInstr, StackSym* originalCallTargetS
     if (callInstr->m_opcode == Js::OpCode::CallIFixed && !inlinee->isGetterSetter)
     {
         Assert(originalCallTargetStackSym != nullptr);
+        Assert(opnd != nullptr);
 
         // Insert a ByteCodeUsesInstr to make sure the function object's lifetimes is extended beyond the last bailout point
         // at which we may have to call the function again in the interpreter.
         // Don't need to do this for a getter/setter inlinee as, upon bailout, the execution will start in the interpreter at the LdFld/StFld itself.
-        callInstr->InsertBefore(IR::ByteCodeUsesInstr::New(callInstr, originalCallTargetStackSym->m_id));
+        callInstr->InsertBefore(IR::ByteCodeUsesInstr::New(callInstr, originalCallTargetOpnd, originalCallTargetStackSym->m_id));
     }
 
     // InlineeStart indicate the beginning of the inlinee, and we need the stack arg for the inlinee until InlineeEnd
@@ -3887,7 +3888,7 @@ Inline::InlineScriptFunction(IR::Instr *callInstr, const FunctionJITTimeInfo *co
         false);
 #endif
 
-    return InlineFunctionCommon(callInstr, originalCallTargetStackSym, inlineeData, inlinee, instrNext, returnValueOpnd, inlineBailoutChecksBeforeInstr, symCallerThis, recursiveInlineDepth, safeThis);
+    return InlineFunctionCommon(callInstr, callInstr->GetSrc1(), originalCallTargetStackSym, inlineeData, inlinee, instrNext, returnValueOpnd, inlineBailoutChecksBeforeInstr, symCallerThis, recursiveInlineDepth, safeThis);
 }
 
 bool
@@ -4190,7 +4191,7 @@ Inline::TryFixedMethodAndPrepareInsertionPoint(IR::Instr *callInstr, const Funct
         Assert(callInstr->m_opcode == Js::OpCode::CallIFixed);
 
         // If we optimized the call instruction for a fixed function, we must extend the function object's lifetime until after the last bailout before the call.
-        IR::ByteCodeUsesInstr * useCallTargetInstr = IR::ByteCodeUsesInstr::New(callInstr, originalCallTargetStackSym->m_id);
+        IR::ByteCodeUsesInstr * useCallTargetInstr = IR::ByteCodeUsesInstr::New(callInstr, callInstr->GetSrc1(), originalCallTargetStackSym->m_id);
         callInstr->InsertBefore(useCallTargetInstr);
     }
     else
@@ -4387,11 +4388,11 @@ bool Inline::InlConstFold(IR::Instr *instr, IntConstType *pValue, __in_ecount_op
         {
             if (src1Sym->HasByteCodeRegSlot())
             {
-                byteCodeInstr->Set(src1Sym->m_id);
+                byteCodeInstr->Set(src1->AsRegOpnd(), src1Sym->m_id);
             }
             if (src2Sym->HasByteCodeRegSlot())
             {
-                byteCodeInstr->Set(src2Sym->m_id);
+                byteCodeInstr->Set(src2->AsRegOpnd(), src2Sym->m_id);
             }
             instr->InsertBefore(byteCodeInstr);
         }
@@ -4426,7 +4427,7 @@ bool Inline::InlConstFold(IR::Instr *instr, IntConstType *pValue, __in_ecount_op
         {
             IR::ByteCodeUsesInstr * byteCodeInstr = IR::ByteCodeUsesInstr::New(instr->m_func);
             byteCodeInstr->SetByteCodeOffset(instr);
-            byteCodeInstr->Set(src1Sym->m_id);
+            byteCodeInstr->Set(src1->AsRegOpnd(), src1Sym->m_id);
             instr->InsertBefore(byteCodeInstr);
         }
 

--- a/lib/Backend/Inline.h
+++ b/lib/Backend/Inline.h
@@ -42,7 +42,7 @@ private:
     IR::Instr * InlineDOMGetterSetterFunction(IR::Instr *ldFldInstr, const FunctionJITTimeInfo *const inlineeData, const FunctionJITTimeInfo *const inlinerData);
 #endif
     IR::Instr * InlineGetterSetterFunction(IR::Instr *accessorInstr, const FunctionJITTimeInfo *const inlineeData, const StackSym *symCallerThis, const uint inlineCacheIndex, bool isGetter, bool *pIsInlined, uint recursiveInlineDepth);
-    IR::Instr * InlineFunctionCommon(IR::Instr *callInstr, IR::Opnd* originalCallTargetOpnd, StackSym* originalCallTargetStackSym, const FunctionJITTimeInfo *funcInfo, Func *inlinee, IR::Instr *instrNext,
+    IR::Instr * InlineFunctionCommon(IR::Instr *callInstr, bool originalCallTargetOpndIsJITOpt, StackSym* originalCallTargetStackSym, const FunctionJITTimeInfo *funcInfo, Func *inlinee, IR::Instr *instrNext,
                                 IR::RegOpnd * returnValueOpnd, IR::Instr *inlineBailoutChecksBeforeInstr, const StackSym *symCallerThis, uint recursiveInlineDepth, bool safeThis = false, bool isApplyTarget = false);
     IR::Instr * SimulateCallForGetterSetter(IR::Instr *accessorInstr, IR::Instr* insertInstr, IR::PropertySymOpnd* methodOpnd, bool isGetter);
 
@@ -61,7 +61,7 @@ private:
     bool        InlConstFoldArg(IR::Instr *instr, __in_ecount_opt(callerArgOutCount) IR::Instr *callerArgOuts[], Js::ArgSlot callerArgOutCount);
     bool        InlConstFold(IR::Instr *instr, IntConstType *pValue, __in_ecount_opt(callerArgOutCount) IR::Instr *callerArgOuts[], Js::ArgSlot callerArgOutCount);
 
-    IR::Instr * InlineCallApplyTarget_Shared(IR::Instr *callInstr, IR::Opnd* originalCallTargetOpnd, StackSym* originalCallTargetStackSym, const FunctionJITTimeInfo*const inlineeData,
+    IR::Instr * InlineCallApplyTarget_Shared(IR::Instr *callInstr, bool originalCallTargetOpndIsJITOpt, StackSym* originalCallTargetStackSym, const FunctionJITTimeInfo*const inlineeData,
                     uint inlineCacheIndex, bool safeThis, bool isApplyTarget, bool isCallTarget, uint recursiveInlineDepth);
     bool        SkipCallApplyScriptTargetInlining_Shared(IR::Instr *callInstr, const FunctionJITTimeInfo* inlinerData, const FunctionJITTimeInfo* inlineeData, bool isApplyTarget, bool isCallTarget);
     bool        TryGetFixedMethodsForBuiltInAndTarget(IR::Instr *callInstr, const FunctionJITTimeInfo* inlinerData, const FunctionJITTimeInfo* inlineeData, const FunctionJITTimeInfo *builtInFuncInfo,

--- a/lib/Backend/Inline.h
+++ b/lib/Backend/Inline.h
@@ -42,7 +42,7 @@ private:
     IR::Instr * InlineDOMGetterSetterFunction(IR::Instr *ldFldInstr, const FunctionJITTimeInfo *const inlineeData, const FunctionJITTimeInfo *const inlinerData);
 #endif
     IR::Instr * InlineGetterSetterFunction(IR::Instr *accessorInstr, const FunctionJITTimeInfo *const inlineeData, const StackSym *symCallerThis, const uint inlineCacheIndex, bool isGetter, bool *pIsInlined, uint recursiveInlineDepth);
-    IR::Instr * InlineFunctionCommon(IR::Instr *callInstr, StackSym* originalCallTargetStackSym, const FunctionJITTimeInfo *funcInfo, Func *inlinee, IR::Instr *instrNext,
+    IR::Instr * InlineFunctionCommon(IR::Instr *callInstr, IR::Opnd* originalCallTargetOpnd, StackSym* originalCallTargetStackSym, const FunctionJITTimeInfo *funcInfo, Func *inlinee, IR::Instr *instrNext,
                                 IR::RegOpnd * returnValueOpnd, IR::Instr *inlineBailoutChecksBeforeInstr, const StackSym *symCallerThis, uint recursiveInlineDepth, bool safeThis = false, bool isApplyTarget = false);
     IR::Instr * SimulateCallForGetterSetter(IR::Instr *accessorInstr, IR::Instr* insertInstr, IR::PropertySymOpnd* methodOpnd, bool isGetter);
 
@@ -61,7 +61,7 @@ private:
     bool        InlConstFoldArg(IR::Instr *instr, __in_ecount_opt(callerArgOutCount) IR::Instr *callerArgOuts[], Js::ArgSlot callerArgOutCount);
     bool        InlConstFold(IR::Instr *instr, IntConstType *pValue, __in_ecount_opt(callerArgOutCount) IR::Instr *callerArgOuts[], Js::ArgSlot callerArgOutCount);
 
-    IR::Instr * InlineCallApplyTarget_Shared(IR::Instr *callInstr, StackSym* originalCallTargetStackSym, const FunctionJITTimeInfo*const inlineeData,
+    IR::Instr * InlineCallApplyTarget_Shared(IR::Instr *callInstr, IR::Opnd* originalCallTargetOpnd, StackSym* originalCallTargetStackSym, const FunctionJITTimeInfo*const inlineeData,
                     uint inlineCacheIndex, bool safeThis, bool isApplyTarget, bool isCallTarget, uint recursiveInlineDepth);
     bool        SkipCallApplyScriptTargetInlining_Shared(IR::Instr *callInstr, const FunctionJITTimeInfo* inlinerData, const FunctionJITTimeInfo* inlineeData, bool isApplyTarget, bool isCallTarget);
     bool        TryGetFixedMethodsForBuiltInAndTarget(IR::Instr *callInstr, const FunctionJITTimeInfo* inlinerData, const FunctionJITTimeInfo* inlineeData, const FunctionJITTimeInfo *builtInFuncInfo,

--- a/lib/Backend/Peeps.cpp
+++ b/lib/Backend/Peeps.cpp
@@ -497,7 +497,7 @@ Peeps::PeepBranch(IR::BranchInstr *branchInstr, bool *const peepedRef)
                     IR::RegOpnd *regSrc = branchInstr->GetSrc1()->AsRegOpnd();
                     StackSym *symSrc = regSrc->GetStackSym();
 
-                    if (symSrc->HasByteCodeRegSlot())
+                    if (symSrc->HasByteCodeRegSlot() && !regSrc->GetIsJITOptimizedReg())
                     {
                         // No side-effects to worry about, but need to insert bytecodeUse.
                         IR::ByteCodeUsesInstr *byteCodeUsesInstr = IR::ByteCodeUsesInstr::New(branchInstr->m_func);

--- a/lib/Backend/Peeps.cpp
+++ b/lib/Backend/Peeps.cpp
@@ -500,10 +500,8 @@ Peeps::PeepBranch(IR::BranchInstr *branchInstr, bool *const peepedRef)
                     if (symSrc->HasByteCodeRegSlot() && !regSrc->GetIsJITOptimizedReg())
                     {
                         // No side-effects to worry about, but need to insert bytecodeUse.
-                        IR::ByteCodeUsesInstr *byteCodeUsesInstr = IR::ByteCodeUsesInstr::New(branchInstr->m_func);
-                        byteCodeUsesInstr->SetByteCodeOffset(branchInstr);
-                        byteCodeUsesInstr->byteCodeUpwardExposedUsed = JitAnew(branchInstr->m_func->m_alloc, BVSparse<JitArenaAllocator>, branchInstr->m_func->m_alloc);
-                        byteCodeUsesInstr->byteCodeUpwardExposedUsed->Set(regSrc->GetStackSym()->m_id);
+                        IR::ByteCodeUsesInstr *byteCodeUsesInstr = IR::ByteCodeUsesInstr::New(branchInstr);
+                        byteCodeUsesInstr->Set(regSrc->GetIsJITOptimizedReg(), regSrc->GetStackSym()->m_id);
                         branchInstr->InsertBefore(byteCodeUsesInstr);
                     }
                 }

--- a/lib/Backend/Peeps.cpp
+++ b/lib/Backend/Peeps.cpp
@@ -501,7 +501,7 @@ Peeps::PeepBranch(IR::BranchInstr *branchInstr, bool *const peepedRef)
                     {
                         // No side-effects to worry about, but need to insert bytecodeUse.
                         IR::ByteCodeUsesInstr *byteCodeUsesInstr = IR::ByteCodeUsesInstr::New(branchInstr);
-                        byteCodeUsesInstr->Set(regSrc->GetIsJITOptimizedReg(), regSrc->GetStackSym()->m_id);
+                        byteCodeUsesInstr->Set(regSrc);
                         branchInstr->InsertBefore(byteCodeUsesInstr);
                     }
                 }

--- a/lib/Backend/TempTracker.cpp
+++ b/lib/Backend/TempTracker.cpp
@@ -1513,7 +1513,7 @@ ObjectTempVerify::NotifyDeadByteCodeUses(IR::Instr * instr)
     }
 
     IR::ByteCodeUsesInstr *byteCodeUsesInstr = instr->AsByteCodeUsesInstr();
-    const BVSparse<JitArenaAllocator> * byteCodeUpwardExposedUsed = byteCodeUsesInstr->getByteCodeUpwardExposedUsed();
+    const BVSparse<JitArenaAllocator> * byteCodeUpwardExposedUsed = byteCodeUsesInstr->GetByteCodeUpwardExposedUsed();
     if (byteCodeUpwardExposedUsed != nullptr)
     {
         this->removedUpwardExposedUse.Or(byteCodeUpwardExposedUsed);

--- a/lib/Backend/TempTracker.cpp
+++ b/lib/Backend/TempTracker.cpp
@@ -1513,7 +1513,7 @@ ObjectTempVerify::NotifyDeadByteCodeUses(IR::Instr * instr)
     }
 
     IR::ByteCodeUsesInstr *byteCodeUsesInstr = instr->AsByteCodeUsesInstr();
-    BVSparse<JitArenaAllocator> * byteCodeUpwardExposedUsed = byteCodeUsesInstr->byteCodeUpwardExposedUsed;
+    const BVSparse<JitArenaAllocator> * byteCodeUpwardExposedUsed = byteCodeUsesInstr->getByteCodeUpwardExposedUsed();
     if (byteCodeUpwardExposedUsed != nullptr)
     {
         this->removedUpwardExposedUse.Or(byteCodeUpwardExposedUsed);

--- a/lib/Common/DataStructures/SparseBitVector.h
+++ b/lib/Common/DataStructures/SparseBitVector.h
@@ -111,7 +111,9 @@ protected:
 
 
             SparseBVUnit *      BitsFromIndex(BVIndex i, bool create = true);
+            const SparseBVUnit *      BitsFromIndex(BVIndex i) const;
             BVSparseNode*   NodeFromIndex(BVIndex i, BVSparseNode *** prevNextFieldOut, bool create = true);
+            const BVSparseNode*   NodeFromIndex(BVIndex i, BVSparseNode *const** prevNextFieldOut) const;
             BVSparseNode *  DeleteNode(BVSparseNode *node, bool bResetLastUsed = true);
             void            QueueInFreeList(BVSparseNode* node);
             BVSparseNode *  Allocate(const BVIndex searchIndex, BVSparseNode *prevNode);
@@ -126,7 +128,7 @@ protected:
 public:
 
             BOOLEAN         operator[](BVIndex i) const;
-            BOOLEAN         Test(BVIndex i);
+            BOOLEAN         Test(BVIndex i) const;
             BVIndex         GetNextBit(BVIndex i) const;
             BVIndex         GetNextBit(BVSparseNode * node) const;
 
@@ -304,6 +306,48 @@ BVSparse<TAllocator>::NodeFromIndex(BVIndex i, BVSparseNode *** prevNextFieldOut
     return newNode;
 }
 
+template <class TAllocator>
+const BVSparseNode *
+BVSparse<TAllocator>::NodeFromIndex(BVIndex i, BVSparseNode *const** prevNextFieldOut) const
+{
+    const BVIndex searchIndex = SparseBVUnit::Floor(i);
+
+    BVSparseNode *const* prevNextField = &this->head;
+    const BVSparseNode * curNode = (*prevNextField);
+    if (curNode != nullptr)
+    {
+        if (curNode->startIndex == searchIndex)
+        {
+            *prevNextFieldOut = prevNextField;
+            return curNode;
+        }
+
+        if (curNode->startIndex > searchIndex)
+        {
+            prevNextField = &this->head;
+            curNode = this->head;
+        }
+    }
+    else
+    {
+        prevNextField = &this->head;
+        curNode = this->head;
+    }
+
+    for (; curNode && searchIndex > curNode->startIndex; curNode = curNode->next)
+    {
+        prevNextField = &curNode->next;
+    }
+
+    if (curNode && searchIndex == curNode->startIndex)
+    {
+        *prevNextFieldOut = prevNextField;
+        return curNode;
+    }
+
+    return nullptr;
+}
+
 
 
 template <class TAllocator>
@@ -322,6 +366,21 @@ BVSparse<TAllocator>::BitsFromIndex(BVIndex i, bool create)
     }
 }
 
+template <class TAllocator>
+const SparseBVUnit *
+BVSparse<TAllocator>::BitsFromIndex(BVIndex i) const
+{
+    BVSparseNode *const* prevNextField;
+    const BVSparseNode * node = NodeFromIndex(i, &prevNextField);
+    if (node)
+    {
+        return &node->data;
+    }
+    else
+    {
+        return (SparseBVUnit *)&BVSparse::s_EmptyUnit;
+    }
+}
 
 template <class TAllocator>
 BVSparseNode *
@@ -446,9 +505,9 @@ BVSparse<TAllocator>::TestEmpty() const
 
 template <class TAllocator>
 BOOLEAN
-BVSparse<TAllocator>::Test(BVIndex i)
+BVSparse<TAllocator>::Test(BVIndex i) const
 {
-    return this->BitsFromIndex(i, false)->Test(SparseBVUnit::Offset(i));
+    return this->BitsFromIndex(i)->Test(SparseBVUnit::Offset(i));
 }
 
 template <class TAllocator>


### PR DESCRIPTION
There are a few cases where ByteCodeUses instructions can cause us to fail asserts due to being emitted with operands that are already jitoptimized away. A couple of changes to the api, as well as a few additional asserts, should help identify issues with inserting these much more locally to the issue.