### PR TITLE
xplat: xcode 8 on capitan std::string references + enable verbose for MAKE

### DIFF
--- a/bin/ch/CMakeLists.txt
+++ b/bin/ch/CMakeLists.txt
@@ -71,11 +71,17 @@ if(STATIC_LIBRARY)
       "-framework Security"
       )
   endif() # Linux ?
-else() # // !from shared library
+else() # // shared library below
   set(lib_target
     PRIVATE Chakra.Pal
     PRIVATE Chakra.Common.Codex.Singular
     PRIVATE Chakra.Runtime.PlatformAgnostic.Singular
+    )
+endif()
+
+if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  set(lib_target "${lib_target}"
+    "-stdlib=libstdc++" # expected 'deprecated' warning. needed for std::string
     )
 endif()
 

--- a/build.sh
+++ b/build.sh
@@ -60,7 +60,7 @@ PRINT_USAGE() {
 CHAKRACORE_DIR=`dirname $0`
 _CXX=""
 _CC=""
-VERBOSE=""
+_VERBOSE=""
 BUILD_TYPE="Release"
 CMAKE_GEN=
 MAKE=make
@@ -110,7 +110,7 @@ while [[ $# -gt 0 ]]; do
         ;;
 
     -v | --verbose)
-        _VERBOSE="verbose"
+        _VERBOSE="V=1"
         ;;
 
     -d | --debug)
@@ -253,7 +253,7 @@ if [[ ${#_VERBOSE} > 0 ]]; then
     echo "MULTICORE_BUILD=${MULTICORE_BUILD}"
     echo "ICU_PATH=${ICU_PATH}"
     echo "CMAKE_GEN=${CMAKE_GEN}"
-    echo "MAKE=${MAKE}"
+    echo "MAKE=${MAKE} $_VERBOSE"
     echo ""
 fi
 
@@ -327,7 +327,7 @@ cmake $CMAKE_GEN $CC_PREFIX $ICU_PATH $STATIC_LIBRARY $ARCH \
 _RET=$?
 if [[ $? == 0 ]]; then
     if [[ $MAKE != 0 ]]; then
-        $MAKE $MULTICORE_BUILD 2>&1 | tee build.log
+        $MAKE $MULTICORE_BUILD $_VERBOSE 2>&1 | tee build.log
         _RET=${PIPESTATUS[0]}
     else
         echo "Visit given folder above for xcode project file ----^"

--- a/lib/Common/PlatformAgnostic/AssemblyCommon.h
+++ b/lib/Common/PlatformAgnostic/AssemblyCommon.h
@@ -24,6 +24,9 @@ void mac_fde_wrapper(const char *dataStart, mac_fde_reg_op reg_op);
 #define __REGISTER_FRAME(addr) __register_frame(addr)
 #define __DEREGISTER_FRAME(addr) __deregister_frame(addr)
 #endif // __APPLE__
+#else
+#define __REGISTER_FRAME(addr)
+#define __DEREGISTER_FRAME(addr)
 #endif // _AMD64_ && !DISABLE_JIT
 
 #endif // !_WIN32

--- a/lib/Runtime/PlatformAgnostic/Platform/Unix/AssemblyCommon.cpp
+++ b/lib/Runtime/PlatformAgnostic/Platform/Unix/AssemblyCommon.cpp
@@ -6,6 +6,7 @@
 #include "Common.h"
 #include "PlatformAgnostic/AssemblyCommon.h"
 
+#ifndef DISABLE_JIT
 extern void mac_fde_wrapper(const char *dataStart, mac_fde_reg_op reg_op)
 {
     const char *head = dataStart;
@@ -28,3 +29,4 @@ extern void mac_fde_wrapper(const char *dataStart, mac_fde_reg_op reg_op)
         head += *length;
     } while(1);
 }
+#endif

--- a/netci.groovy
+++ b/netci.groovy
@@ -114,9 +114,67 @@ def CreateBuildTasks = { machine, configTag, buildExtra, testExtra, runCodeAnaly
     }
 }
 
+def CreateXPlatBuildTask = { isPR, buildType, staticBuild, machine, platform, configTag,
+    xplatBranch, nonDefaultTaskSetup, customOption ->
+
+    def config = (platform == "osx" ? "osx_${buildType}" : "linux_${buildType}")
+    def numConcurrentCommand = (platform == "osx" ? "sysctl -n hw.logicalcpu" : "nproc")
+
+    config = (configTag == null) ? config : "${configTag}_${config}"
+    config = staticBuild ? "${config}_static" : config
+
+    // params: Project, BaseTaskName, IsPullRequest (appends '_prtest')
+    def jobName = Utilities.getFullJobName(project, config, isPR) + customOption.replaceAll(/[-]+/, "_")
+
+    def infoScript = "bash jenkins/get_system_info.sh --${platform}"
+    def buildFlag = buildType == "release" ? "" : (buildType == "debug" ? "--debug" : "--test-build")
+    def staticFlag = staticBuild ? "--static" : ""
+    def icuFlag = (platform == "osx" ? "--icu=/usr/local/opt/icu4c/include" : "")
+    def compilerPaths = (platform == "osx") ? "" : "--cxx=/usr/bin/clang++-3.8 --cc=/usr/bin/clang-3.8"
+    def buildScript = "bash ./build.sh ${staticFlag} -j=`${numConcurrentCommand}` ${buildFlag} ${compilerPaths} ${icuFlag} ${customOption}"
+    def testScript = "bash test/runtests.sh"
+
+    def newJob = job(jobName) {
+        steps {
+            shell(infoScript)
+            shell(buildScript)
+            shell(testScript)
+        }
+    }
+
+    def archivalString = "BuildLinux/build.log"
+    Utilities.addArchival(newJob, archivalString,
+        '', // no exclusions from archival
+        true, // doNotFailIfNothingArchived=false ~= failIfNothingArchived (true ~= doNotFail)
+        false) // archiveOnlyIfSuccessful=false ~= archiveAlways
+
+    Utilities.setMachineAffinity(newJob, machine, 'latest-or-auto')
+    Utilities.standardJobSetup(newJob, project, isPR, "*/${branch}")
+
+    if (nonDefaultTaskSetup == null) {
+        if (isPR) {
+            def osTag = machineTypeToOSTagMap.get(machine)
+            // Set up checks which apply to PRs targeting any branch
+            Utilities.addGithubPRTriggerForBranch(newJob, xplatBranch, "${osTag} ${config}")
+        } else {
+            Utilities.addGithubPushTrigger(newJob)
+        }
+    } else {
+        // nonDefaultTaskSetup is e.g. DailyBuildTaskSetup (which sets up daily builds)
+        // These jobs will only be configured for the branch specified below,
+        // which is the name of the branch netci.groovy was processed for.
+        // See list of such branches at:
+        // https://github.com/dotnet/dotnet-ci/blob/master/jobs/data/repolist.txt
+        nonDefaultTaskSetup(newJob, isPR, config)
+    }
+}
+
 // Generic task to trigger clang-based cross-plat build tasks
 def CreateXPlatBuildTasks = { machine, platform, configTag, xplatBranch, nonDefaultTaskSetup ->
     [true, false].each { isPR ->
+        CreateXPlatBuildTask(isPR, "test", "", machine, platform,
+            configTag, xplatBranch, nonDefaultTaskSetup, "--no-jit")
+
         ['debug', 'test', 'release'].each { buildType ->
             def staticBuildConfigs = [true, false]
             if (platform == "osx") {
@@ -124,56 +182,8 @@ def CreateXPlatBuildTasks = { machine, platform, configTag, xplatBranch, nonDefa
             }
 
             staticBuildConfigs.each { staticBuild ->
-                def config = (platform == "osx" ? "osx_${buildType}" : "linux_${buildType}")
-                def numConcurrentCommand = (platform == "osx" ? "sysctl -n hw.logicalcpu" : "nproc")
-
-                config = (configTag == null) ? config : "${configTag}_${config}"
-                config = staticBuild ? "${config}_static" : config
-
-                // params: Project, BaseTaskName, IsPullRequest (appends '_prtest')
-                def jobName = Utilities.getFullJobName(project, config, isPR)
-
-                def infoScript = "bash jenkins/get_system_info.sh --${platform}"
-                def buildFlag = buildType == "release" ? "" : (buildType == "debug" ? "--debug" : "--test-build")
-                def staticFlag = staticBuild ? "--static" : ""
-                def icuFlag = (platform == "osx" ? "--icu=/usr/local/opt/icu4c/include" : "")
-                def compilerPaths = (platform == "osx") ? "" : "--cxx=/usr/bin/clang++-3.8 --cc=/usr/bin/clang-3.8"
-                def buildScript = "bash ./build.sh ${staticFlag} -j=`${numConcurrentCommand}` ${buildFlag} ${compilerPaths} ${icuFlag}"
-                def testScript = "bash test/runtests.sh"
-
-                def newJob = job(jobName) {
-                    steps {
-                        shell(infoScript)
-                        shell(buildScript)
-                        shell(testScript)
-                    }
-                }
-
-                def archivalString = "BuildLinux/build.log"
-                Utilities.addArchival(newJob, archivalString,
-                    '', // no exclusions from archival
-                    true, // doNotFailIfNothingArchived=false ~= failIfNothingArchived (true ~= doNotFail)
-                    false) // archiveOnlyIfSuccessful=false ~= archiveAlways
-
-                Utilities.setMachineAffinity(newJob, machine, 'latest-or-auto')
-                Utilities.standardJobSetup(newJob, project, isPR, "*/${branch}")
-
-                if (nonDefaultTaskSetup == null) {
-                    if (isPR) {
-                        def osTag = machineTypeToOSTagMap.get(machine)
-                        // Set up checks which apply to PRs targeting any branch
-                        Utilities.addGithubPRTriggerForBranch(newJob, xplatBranch, "${osTag} ${config}")
-                    } else {
-                        Utilities.addGithubPushTrigger(newJob)
-                    }
-                } else {
-                    // nonDefaultTaskSetup is e.g. DailyBuildTaskSetup (which sets up daily builds)
-                    // These jobs will only be configured for the branch specified below,
-                    // which is the name of the branch netci.groovy was processed for.
-                    // See list of such branches at:
-                    // https://github.com/dotnet/dotnet-ci/blob/master/jobs/data/repolist.txt
-                    nonDefaultTaskSetup(newJob, isPR, config)
-                }
+                CreateXPlatBuildTask(isPR, buildType, staticBuild, machine, platform,
+                    configTag, xplatBranch, nonDefaultTaskSetup, "")
             }
         }
     }


### PR DESCRIPTION

- xcode 8.0 on capitan asks for undefined std::string::compare reference on ch.

- Enabling verbose for MAKE too.

- fix `--no-jit` build