### PR TITLE
Avoid false positive in EntryPointInfo and TypePropertyCacheElement

### DIFF
--- a/lib/Runtime/Types/TypePropertyCache.cpp
+++ b/lib/Runtime/Types/TypePropertyCache.cpp
@@ -10,7 +10,7 @@ namespace Js
     // TypePropertyCacheElement
     // -------------------------------------------------------------------------------------------------------------------------
 
-    TypePropertyCacheElement::TypePropertyCacheElement() : id(Constants::NoProperty), index(0), prototypeObjectWithProperty(0)
+    TypePropertyCacheElement::TypePropertyCacheElement() : id(Constants::NoProperty), tag(1), index(0), prototypeObjectWithProperty(0)
     {
     }
 

--- a/lib/Runtime/Types/TypePropertyCache.h
+++ b/lib/Runtime/Types/TypePropertyCache.h
@@ -15,11 +15,14 @@ namespace Js
     {
     private:
         DynamicObject *prototypeObjectWithProperty;
-        PropertyId id;
-        PropertyIndex index;
+
+        // tag the bit fields to avoid false positive
+        bool tag : 1;
         bool isInlineSlot : 1;
         bool isSetPropertyAllowed : 1;
         bool isMissing : 1;
+        PropertyIndex index;
+        PropertyId id;
 
     public:
         TypePropertyCacheElement();


### PR DESCRIPTION
Add a tag to some integral data in EntryPointInfo and TypePropertyCacheElement to avoid false positive GC pointer.
