### PR TITLE
clang: full and thin LTO build options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,6 +263,14 @@ if(CLR_CMAKE_PLATFORM_XPLAT)
     endif()
 endif(CLR_CMAKE_PLATFORM_XPLAT)
 
+if(ENABLE_FULL_LTO_SH)
+    unset(DENABLE_FULL_LTO_SH CACHE)
+    add_compile_options(-flto)
+elseif(ENABLE_THIN_LTO_SH)
+    unset(ENABLE_THIN_LTO_SH CACHE)
+    add_compile_options(-flto=thin)
+endif()
+
 if(CMAKE_BUILD_TYPE STREQUAL Debug)
     add_definitions(
         -DDBG=1

--- a/build.sh
+++ b/build.sh
@@ -28,9 +28,10 @@ PRINT_USAGE() {
     echo "build.sh [options]"
     echo ""
     echo "options:"
-    echo "  --arch=[*]           Set target arch (x86)"
-    echo "      --cxx=PATH       Path to Clang++ (see example below)"
+    echo "      --arch=[*]       Set target arch (x86)"
     echo "      --cc=PATH        Path to Clang   (see example below)"
+    echo "      --cxx=PATH       Path to Clang++ (see example below)"
+    echo "      --create-deb=V   Create .deb package with given V version"
     echo "  -d, --debug          Debug build (by default Release build)"
     echo "      --embed-icu      Download and embed ICU-57 statically"
     echo "  -h, --help           Show help"
@@ -39,21 +40,22 @@ PRINT_USAGE() {
     echo "  -n, --ninja          Build with ninja instead of make"
     echo "      --no-icu         Compile without unicode/icu support"
     echo "      --no-jit         Disable JIT"
-    echo "      --xcode          Generate XCode project"
-    echo "  -t, --test-build     Test build (by default Release build)"
+    echo "      --lto            Enables LLVM Full LTO"
+    echo "      --lto-thin       Enables LLVM Thin LTO - xcode 8+ or clang 3.9+"
     echo "      --static         Build as static library (by default shared library)"
     echo "      --sanitize=CHECKS Build with clang -fsanitize checks,"
     echo "                       e.g. undefined,signed-integer-overflow"
-    echo "  -v, --verbose        Display verbose output including all options"
-    echo "      --create-deb=V   Create .deb package with given V version"
+    echo "  -t, --test-build     Test build (by default Release build)"
+    echo "      --xcode          Generate XCode project"
     echo "      --without=FEATURE,FEATURE,..."
     echo "                       Disable FEATUREs from JSRT experimental"
     echo "                       features."
+    echo "  -v, --verbose        Display verbose output including all options"
     echo ""
     echo "example:"
     echo "  ./build.sh --cxx=/path/to/clang++ --cc=/path/to/clang -j"
     echo "with icu:"
-    echo "  ./build.sh --icu=/usr/local/Cellar/icu4c/version/include/"
+    echo "  ./build.sh --icu=/usr/local/opt/icu4c/include"
     echo ""
 }
 
@@ -75,6 +77,7 @@ ARCH="-DCC_TARGETS_AMD64_SH=1"
 OS_LINUX=0
 OS_APT_GET=0
 OS_UNIX=0
+LTO=""
 
 if [ -f "/proc/version" ]; then
     OS_LINUX=1
@@ -185,6 +188,14 @@ while [[ $# -gt 0 ]]; do
     --icu=*)
         ICU_PATH=$1
         ICU_PATH="-DICU_INCLUDE_PATH_SH=${ICU_PATH:6}"
+        ;;
+
+    --lto)
+        LTO="-DENABLE_FULL_LTO_SH=1"
+        ;;
+
+    --lto-thin)
+        LTO="-DENABLE_THIN_LTO_SH=1"
         ;;
 
     -n | --ninja)
@@ -321,7 +332,7 @@ else
 fi
 
 echo Generating $BUILD_TYPE makefiles
-cmake $CMAKE_GEN $CC_PREFIX $ICU_PATH $STATIC_LIBRARY $ARCH \
+cmake $CMAKE_GEN $CC_PREFIX $ICU_PATH $LTO $STATIC_LIBRARY $ARCH \
     -DCMAKE_BUILD_TYPE=$BUILD_TYPE $SANITIZE $NO_JIT $WITHOUT_FEATURES ../..
 
 _RET=$?

--- a/test/runtests.sh
+++ b/test/runtests.sh
@@ -33,11 +33,10 @@ else
 fi
 
 if [[ $release_build != 1 ]]; then
-#    "$test_path/runtests.py" $build_type --not-tag exclude_jenkins $test_variant
+    "$test_path/runtests.py" $build_type --not-tag exclude_jenkins $test_variant
     if [[ $? != 0 ]]; then
         exit 1
     fi
-    exit 0 #temporarily disabled
 else
     # TEST flags are not enabled for release build
     # however we would like to test if the compiled binary


### PR DESCRIPTION
'--lto' for Full and '--lto-thin' for Thin LTO.

Thin LTO requires xcode 8+ and clang 3.9+

Performance numbers vary.
Observed ~3% performance gain with Thin LTO/Octane

Both options above add aprox. 10 to 20% to binary size.

See also http://blog.llvm.org/2016/06/thinlto-scalable-and-incremental-lto.html