### PR TITLE
Adding wasm type conversion ops

### DIFF
--- a/lib/Backend/IRBuilderAsmJs.cpp
+++ b/lib/Backend/IRBuilderAsmJs.cpp
@@ -3194,6 +3194,21 @@ IRBuilderAsmJs::BuildLong1Float1(Js::OpCodeAsmJs newOpcode, uint32 offset, Js::R
 void
 IRBuilderAsmJs::BuildFloat1Long1(Js::OpCodeAsmJs newOpcode, uint32 offset, Js::RegSlot dstRegSlot, Js::RegSlot src1RegSlot)
 {
+    IR::RegOpnd * srcOpnd = nullptr;
+    IR::RegOpnd * dstOpnd  = BuildDstOpnd(dstRegSlot, TyFloat32);
+    switch (newOpcode)
+    {
+    case Js::OpCodeAsmJs::Conv_LTF:
+        srcOpnd = BuildSrcOpnd(src1RegSlot, TyInt64);
+        break;
+    case Js::OpCodeAsmJs::Conv_ULTF:
+        srcOpnd = BuildSrcOpnd(src1RegSlot, TyUint64);
+        break;
+    default:
+        Assume(UNREACHED);
+    }
+    IR::Instr * instr = IR::Instr::New(Js::OpCode::Conv_Prim, dstOpnd, srcOpnd, m_func);
+    AddInstr(instr, offset);
 }
 
 void
@@ -3242,16 +3257,28 @@ IRBuilderAsmJs::BuildLong1Double1(Js::OpCodeAsmJs newOpcode, uint32 offset, Js::
 void
 IRBuilderAsmJs::BuildDouble1Long1(Js::OpCodeAsmJs newOpcode, uint32 offset, Js::RegSlot dstRegSlot, Js::RegSlot srcRegSlot)
 {
-    Assert(newOpcode == Js::OpCodeAsmJs::Reinterpret_LTD);
-
     IR::RegOpnd * srcOpnd = nullptr;
-    srcOpnd = BuildSrcOpnd(srcRegSlot, TyInt64);
-    srcOpnd->SetValueType(ValueType::GetInt(false));
+    Js::OpCode op = Js::OpCode::Conv_Prim;
 
     IR::RegOpnd * dstOpnd = BuildDstOpnd(dstRegSlot, TyFloat64);
     dstOpnd->SetValueType(ValueType::Float);
-
-    IR::Instr * instr = IR::Instr::New(Js::OpCode::Reinterpret_Prim, dstOpnd, srcOpnd, m_func);
+    switch (newOpcode)
+    {
+    case Js::OpCodeAsmJs::Conv_LTD:
+        srcOpnd = BuildSrcOpnd(srcRegSlot, TyInt64);
+        break;
+    case Js::OpCodeAsmJs::Conv_ULTD:
+        srcOpnd = BuildSrcOpnd(srcRegSlot, TyUint64);
+        break;
+    case Js::OpCodeAsmJs::Reinterpret_LTD:
+        srcOpnd = BuildSrcOpnd(srcRegSlot, TyInt64);
+        op = Js::OpCode::Reinterpret_Prim;
+        break;
+    default:
+        Assume(UNREACHED);
+    }
+    srcOpnd->SetValueType(ValueType::GetInt(false));
+    IR::Instr* instr = IR::Instr::New(op, dstOpnd, srcOpnd, m_func);
     AddInstr(instr, offset);
 }
 

--- a/lib/Backend/JnHelperMethodList.h
+++ b/lib/Backend/JnHelperMethodList.h
@@ -538,6 +538,11 @@ CONVERSION_HELPER(F64TOI64)
 CONVERSION_HELPER(F64TOU64)
 #undef CONVERSION_HELPER
 
+HELPERCALL(I64TOF64,        Js::JavascriptConversion::LongToDouble,        0)
+HELPERCALL(UI64TOF64,       Js::JavascriptConversion::ULongToDouble,       0)
+HELPERCALL(I64TOF32,        Js::JavascriptConversion::LongToFloat,         0)
+HELPERCALL(UI64TOF32,       Js::JavascriptConversion::ULongToFloat,        0)
+
 #if (defined(ASMJS_PLAT) || defined(ENABLE_WASM)) && defined(ENABLE_DEBUG_CONFIG_OPTIONS)
 HELPERCALL(TraceAsmJsArgIn, WAsmJs::TraceAsmJsArgsIn, 0)
 #endif

--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -2008,6 +2008,14 @@ Lowerer::LowerRange(IR::Instr *instrStart, IR::Instr *instrEnd, bool defaultDoFa
                     Assert(instr->GetDst()->IsFloat64());
                     m_lowererMD.EmitUIntToFloat(instr->GetDst(), instr->GetSrc1(), instr);
                 }
+                else if (instr->GetSrc1()->IsInt64() && instr->GetDst()->IsFloat32())
+                {
+                    m_lowererMD.EmitInt64toFloat32(instr->GetDst(), instr->GetSrc1(), instr);
+                }
+                else if (instr->GetSrc1()->IsInt64() && instr->GetDst()->IsFloat64())
+                {
+                    m_lowererMD.EmitInt64toFloat64(instr->GetDst(), instr->GetSrc1(), instr);
+                }
                 else
                 {
                     Assert(instr->GetDst()->IsFloat64());

--- a/lib/Backend/LowerMDShared.cpp
+++ b/lib/Backend/LowerMDShared.cpp
@@ -8017,6 +8017,51 @@ LowererMD::EmitFloat32ToFloat64(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrIn
 }
 
 void
+LowererMD::EmitInt64toFloat32(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instr)
+{
+    IR::Opnd *srcOpnd = instr->UnlinkSrc1();
+
+    LoadInt64HelperArgument(instr, srcOpnd);
+
+    IR::Instr* callinstr = IR::Instr::New(Js::OpCode::CALL, dst, this->m_func);
+    instr->InsertBefore(callinstr);
+
+    switch (srcOpnd->GetType())
+    {
+    case TyInt64:
+        this->ChangeToHelperCall(callinstr, IR::HelperI64TOF32);
+        break;
+    case TyUint64:
+        this->ChangeToHelperCall(callinstr, IR::HelperUI64TOF32);
+        break;
+    default:
+        Assert(UNREACHED);
+    }
+}
+
+void
+LowererMD::EmitInt64toFloat64(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instr)
+{
+    IR::Opnd *srcOpnd = instr->UnlinkSrc1();
+
+    LoadInt64HelperArgument(instr, srcOpnd);
+
+    IR::Instr* callinstr = IR::Instr::New(Js::OpCode::CALL, dst, this->m_func);
+    instr->InsertBefore(callinstr);
+
+    switch (srcOpnd->GetType())
+    {
+    case TyInt64:
+        this->ChangeToHelperCall(callinstr, IR::HelperI64TOF64);
+        break;
+    case TyUint64:
+        this->ChangeToHelperCall(callinstr, IR::HelperUI64TOF64);
+        break;
+    default:
+        Assert(UNREACHED);
+    }
+}
+void
 LowererMD::EmitNon32BitOvfCheck(IR::Instr *instr, IR::Instr *insertInstr, IR::LabelInstr* bailOutLabel)
 {
     AssertMsg(instr->m_opcode == Js::OpCode::IMUL, "IMUL should be used to check for non-32 bit overflow check on x86.");

--- a/lib/Backend/LowerMDShared.h
+++ b/lib/Backend/LowerMDShared.h
@@ -215,6 +215,8 @@ public:
             void            EmitIntToLong(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsert);
             void            EmitUIntToLong(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsert);
             void            EmitFloatToInt(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsert);
+            void            EmitInt64toFloat32(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsert);
+            void            EmitInt64toFloat64(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsert);
             void            EmitFloat32ToFloat64(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsert);
             static IR::Instr *InsertConvertFloat64ToInt32(const RoundMode roundMode, IR::Opnd *const dst, IR::Opnd *const src, IR::Instr *const insertBeforeInstr);
             void            ConvertFloatToInt32(IR::Opnd* intOpnd, IR::Opnd* floatOpnd, IR::LabelInstr * labelHelper, IR::LabelInstr * labelDone, IR::Instr * instInsert);

--- a/lib/Backend/arm/LowerMD.h
+++ b/lib/Backend/arm/LowerMD.h
@@ -204,6 +204,8 @@ public:
             void                EmitUIntToFloat(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsert);
             void                EmitFloatToInt(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsert);
             void                EmitFloat32ToFloat64(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsert) { Assert(UNREACHED); }
+            void                EmitInt64toFloat32(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsert) { __debugbreak(); }
+            void                EmitInt64toFloat64(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsert) { __debugbreak(); }
             static IR::Instr *  InsertConvertFloat64ToInt32(const RoundMode roundMode, IR::Opnd *const dst, IR::Opnd *const src, IR::Instr *const insertBeforeInstr);
             void                EmitIntToLong(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsert);
             void                EmitUIntToLong(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsert);

--- a/lib/Backend/arm64/LowerMD.h
+++ b/lib/Backend/arm64/LowerMD.h
@@ -201,6 +201,8 @@ public:
               void                EmitUIntToFloat(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsert) { __debugbreak(); }
               void                EmitFloatToInt(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsert) { __debugbreak(); }
               void                EmitFloat32ToFloat64(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsert) { __debugbreak(); }
+              void                EmitInt64toFloat32(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsert) { __debugbreak(); }
+              void                EmitInt64toFloat64(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsert) { __debugbreak(); }
               void                EmitIntToLong(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsert) { __debugbreak(); }
               void                EmitUIntToLong(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsert) { __debugbreak(); }
               static IR::Instr *  InsertConvertFloat64ToInt32(const RoundMode roundMode, IR::Opnd *const dst, IR::Opnd *const src, IR::Instr *const insertBeforeInstr) { __debugbreak(); return 0; }

--- a/lib/Runtime/ByteCode/OpCodesAsmJs.h
+++ b/lib/Runtime/ByteCode/OpCodesAsmJs.h
@@ -96,6 +96,7 @@ MACRO_WMS       ( Conv_UTD                   , Double1Int1     , None           
 MACRO_WMS       ( Conv_UTF                   , Float1Int1      , None            ) // convert unsigned int to float
 MACRO_WMS       ( Conv_ULTD                  , Double1Long1    , None            ) // convert unsigned int64 to double
 MACRO_WMS       ( Conv_ULTF                  , Float1Long1     , None            ) // convert unsigned int64 to float
+MACRO_WMS       ( Conv_LTF                   , Float1Long1     , None            ) // convert int64 to float
 MACRO_WMS       ( Return_Long                , Long2           , None            ) // convert int64 to var
 MACRO_WMS       ( Return_Db                  , Double2         , None            ) // convert double to var
 MACRO_WMS       ( Return_Flt                 , Float2          , None            ) // convert float to var

--- a/lib/Runtime/Language/InterpreterHandlerAsmJs.inl
+++ b/lib/Runtime/Language/InterpreterHandlerAsmJs.inl
@@ -78,6 +78,10 @@ EXDEF2    (NOPASMJS          , InvalidOpCode, Empty                             
   DEF2_WMS( F1toD1Mem        , Conv_FTD     , (double)                                           ) // convert unsigned float to double
   DEF2_WMS( I1toL1Mem        , Conv_ITL     , (int64)                                            ) // extend signed int to int64
   DEF2_WMS( U1toL1Mem        , Conv_UTL     , (int64)                                            ) // extend unsigned int to int64
+  DEF2_WMS( UL1toD1Mem       , Conv_ULTD    , JavascriptConversion::ULongToDouble                )
+  DEF2_WMS( L1toD1Mem        , Conv_LTD     , JavascriptConversion::LongToDouble                 )
+  DEF2_WMS( UL1toF1Mem       , Conv_ULTF    , JavascriptConversion::ULongToFloat                 )
+  DEF2_WMS( L1toF1Mem        , Conv_LTF     , JavascriptConversion::LongToFloat                  )
   DEF2_WMS( I1toI1Mem        , Ld_Int       , (int)                                              )
   DEF2_WMS( L1toL1Mem        , Ld_Long      , (int64)                                            )
   DEF2_WMS( D1toD1Mem        , Ld_Db        , (double)                                           )

--- a/lib/Runtime/Language/InterpreterProcessOpCodeAsmJs.h
+++ b/lib/Runtime/Language/InterpreterProcessOpCodeAsmJs.h
@@ -200,6 +200,42 @@
         break; \
                                                                 }
 
+#define PROCESS_UL1toD1Mem_COMMON(name, func, suffix) \
+    case OpCodeAsmJs::name: \
+                                                                { \
+        PROCESS_READ_LAYOUT_ASMJS(name, Double1Long1, suffix); \
+        SetRegRawDouble(playout->D0, \
+                func(GetRegRawInt64(playout->L1))); \
+        break; \
+                                                                }
+
+#define PROCESS_UL1toF1Mem_COMMON(name, func, suffix) \
+    case OpCodeAsmJs::name: \
+                                                                { \
+        PROCESS_READ_LAYOUT_ASMJS(name, Float1Long1, suffix); \
+        SetRegRawFloat(playout->F0, \
+                func(GetRegRawInt64(playout->L1))); \
+        break; \
+                                                                }
+
+#define PROCESS_L1toF1Mem_COMMON(name, func, suffix) \
+    case OpCodeAsmJs::name: \
+                                                                { \
+        PROCESS_READ_LAYOUT_ASMJS(name, Float1Long1, suffix); \
+        SetRegRawFloat(playout->F0, \
+                func(GetRegRawInt64(playout->L1))); \
+        break; \
+                                                                }
+
+#define PROCESS_L1toD1Mem_COMMON(name, func, suffix) \
+    case OpCodeAsmJs::name: \
+                                                                { \
+        PROCESS_READ_LAYOUT_ASMJS(name, Double1Long1, suffix); \
+        SetRegRawDouble(playout->D0, \
+                func(GetRegRawInt64(playout->L1))); \
+        break; \
+                                                                }
+
 #define PROCESS_D1toD1_COMMON(name, func, suffix) \
     case OpCodeAsmJs::name: \
                                                                 { \

--- a/lib/Runtime/Language/JavascriptConversion.cpp
+++ b/lib/Runtime/Language/JavascriptConversion.cpp
@@ -1525,6 +1525,26 @@ CommonNumber:
         return ToString(ToPrimitive(aValue, JavascriptHint::None, scriptContext), scriptContext);
     }
 
+    double JavascriptConversion::LongToDouble(__int64 aValue)
+    {
+        return static_cast<double>(aValue);
+    }
+
+    double JavascriptConversion::ULongToDouble(unsigned __int64 aValue)
+    {
+        return static_cast<double>(aValue);
+    }
+
+    float JavascriptConversion::LongToFloat(__int64 aValue)
+    {
+        return static_cast<float>(aValue);
+    }
+
+    float JavascriptConversion::ULongToFloat (unsigned __int64 aValue)
+    {
+        return static_cast<float>(aValue);
+    }
+
     int32 JavascriptConversion::F32TOI32(float src, ScriptContext * ctx)
     {
         if (Wasm::WasmMath::isInRange<float, uint32, NumberConstants::k_Float32TwoTo31, NumberConstants::k_Float32NegZero, NumberConstants::k_Float32NegTwoTo31,

--- a/lib/Runtime/Language/JavascriptConversion.h
+++ b/lib/Runtime/Language/JavascriptConversion.h
@@ -77,6 +77,12 @@ namespace Js {
         static int32 F64TOI32(double src, ScriptContext * ctx);
         static uint32 F64TOU32(double src, ScriptContext * ctx);
 
+        static float  LongToFloat(__int64 aValue);
+        static float  ULongToFloat(unsigned __int64 aValue);
+        static double LongToDouble(__int64 aValue);
+        static double ULongToDouble(unsigned __int64 aValue);
+
+
     private:
         static BOOL ToInt32Finite(double value, int32* result);
         template<bool zero>

--- a/lib/WasmReader/WasmBinaryOpCodes.h
+++ b/lib/WasmReader/WasmBinaryOpCodes.h
@@ -263,15 +263,15 @@ WASM_UNARY__OPCODE(I64TruncS_F64,     0xb0, L_D , Conv_Check_DTL , false)
 WASM_UNARY__OPCODE(I64TruncU_F64,     0xb1, L_D , Conv_Check_DTUL, false)
 
 WASM_UNARY__OPCODE(F32SConvertI32,    0xb2, F_I , Fround_Int     , false)
-WASM_UNARY__OPCODE(F32UConvertI32,    0xb3, F_I , Conv_UTF       , true)
-WASM_UNARY__OPCODE(F32SConvertI64,    0xb4, F_L , Nop            , true)
-WASM_UNARY__OPCODE(F32UConvertI64,    0xb5, F_L , Nop            , true)
+WASM_UNARY__OPCODE(F32UConvertI32,    0xb3, F_I , Conv_UTF       , false)
+WASM_UNARY__OPCODE(F32SConvertI64,    0xb4, F_L , Conv_LTF       , false)
+WASM_UNARY__OPCODE(F32UConvertI64,    0xb5, F_L , Conv_ULTF      , false)
 WASM_UNARY__OPCODE(F32DemoteF64,      0xb6, F_D , Fround_Db      , false)
 
 WASM_UNARY__OPCODE(F64SConvertI32,    0xb7, D_I , Conv_ITD       , false)
 WASM_UNARY__OPCODE(F64UConvertI32,    0xb8, D_I , Conv_UTD       , false)
-WASM_UNARY__OPCODE(F64SConvertI64,    0xb9, D_L , Nop            , true)
-WASM_UNARY__OPCODE(F64UConvertI64,    0xba, D_L , Nop            , true)
+WASM_UNARY__OPCODE(F64SConvertI64,    0xb9, D_L , Conv_LTD       , false)
+WASM_UNARY__OPCODE(F64UConvertI64,    0xba, D_L , Conv_ULTD      , false)
 WASM_UNARY__OPCODE(F64PromoteF32,     0xbb, D_F , Conv_FTD       , false)
 ////////////////////////////////////////////////////////////
 

--- a/test/WasmSpec/baselines/get_local.baseline
+++ b/test/WasmSpec/baselines/get_local.baseline
@@ -1,2 +1,1 @@
-get_local.wast:81: $assert_return_9 unexpectedly threw: WebAssemblyCompileError: Compiling wasm failed: function read[9] at offset 32/63: Operator F64UConvertI64 NYI
-9/10 tests passed.
+10/10 tests passed.

--- a/test/WasmSpec/baselines/set_local.baseline
+++ b/test/WasmSpec/baselines/set_local.baseline
@@ -1,2 +1,1 @@
-set_local.wast:85: $assert_return_9 unexpectedly threw: WebAssemblyCompileError: Compiling wasm failed: function write[9] at offset 47/79: Operator F64UConvertI64 NYI
-9/10 tests passed.
+10/10 tests passed.

--- a/test/WasmSpec/baselines/tee_local.baseline
+++ b/test/WasmSpec/baselines/tee_local.baseline
@@ -1,3 +1,1 @@
-tee_local.wast:115: $assert_return_9 unexpectedly threw: WebAssemblyCompileError: Compiling wasm failed: function write[9] at offset 53/85: Operator F64UConvertI64 NYI
-tee_local.wast:122: $assert_return_10 unexpectedly threw: WebAssemblyCompileError: Compiling wasm failed: function result[10] at offset 12/79: Operator F64UConvertI64 NYI
-9/11 tests passed.
+11/11 tests passed.


### PR DESCRIPTION
f32.convert_s/i64
f32.convert_u/i64
f64.convert_s/i64
f64.convert_u/i64

Fixes:
https://github.com/Microsoft/ChakraCore/issues/1866
https://github.com/Microsoft/ChakraCore/issues/1867
https://github.com/Microsoft/ChakraCore/issues/1868
https://github.com/Microsoft/ChakraCore/issues/1869