### PR TITLE
xplat: enable optimize sibling calls and omit**frame-pointer + force O3

### DIFF
--- a/Build/CMakeFeatureDetect.cmake
+++ b/Build/CMakeFeatureDetect.cmake
@@ -1,0 +1,42 @@
+#-------------------------------------------------------------------------------------------------------
+# Copyright (C) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+#-------------------------------------------------------------------------------------------------------
+
+include(CheckCXXSourceCompiles)
+include(CheckCXXSourceRuns)
+
+if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+    # by default this is disabled for osx
+    # enable temporarily
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
+        -Werror"
+        )
+endif()
+
+check_cxx_source_runs("
+#include <stdlib.h>
+#include <stdio.h>
+
+__attribute__((disable_tail_calls))
+int inc(int a) { return a + 1; }
+
+int main(int argc, char **argv) {
+  printf(\"%d\", inc(argc + 1));
+  exit(0);
+}" CLANG_HAS_DISABLE_TAIL_CALLS_CFG)
+
+if(CLANG_HAS_DISABLE_TAIL_CALLS_CFG STREQUAL 1)
+  add_definitions(-DCLANG_HAS_DISABLE_TAIL_CALLS=1)
+  set(CXX_DO_NOT_OPTIMIZE_SIBLING_CALLS "")
+else()
+  set(CXX_DO_NOT_OPTIMIZE_SIBLING_CALLS "-fno-optimize-sibling-calls")
+endif()
+
+if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+    # by default this is disabled for osx
+    # disable back
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
+        -Wno-error"
+        )
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,6 +172,7 @@ if(STATIC_LIBRARY)
 endif()
 
 if(CLR_CMAKE_PLATFORM_XPLAT)
+    add_definitions(-DFEATURE_PAL)
     add_definitions(-DPLATFORM_UNIX=1)
 
     if(CLR_CMAKE_PLATFORM_LINUX)
@@ -238,15 +239,13 @@ if(CLR_CMAKE_PLATFORM_XPLAT)
         # -Wno-return-type # switch unreachable code
         # -Wno-switch # switch values not handled
 
-    # xplat-todo for release build
-    # -fno-inline.... -> -mno-omit.... are needed for more accurate stack inf.
-    # Release Builds: Not sure if this has to be as strict as the debug/test?
+    include(Build/CMakeFeatureDetect.cmake)
+
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
-        -fdelayed-template-parsing\
-        -fno-omit-frame-pointer\
-        -fno-optimize-sibling-calls\
-        -mno-omit-leaf-frame-pointer" # this is for compat reasons. i.e. It is a noop with gcc
-    )
+        ${CXX_DO_NOT_OPTIMIZE_SIBLING_CALLS} \
+        -fno-omit-frame-pointer \
+        -fdelayed-template-parsing"
+        )
 
     # CXX / CC COMPILER FLAGS
     add_compile_options(
@@ -285,9 +284,7 @@ elseif(CMAKE_BUILD_TYPE STREQUAL Test)
 endif(CMAKE_BUILD_TYPE STREQUAL Debug)
 
 if(NOT CMAKE_BUILD_TYPE STREQUAL Debug)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
-        -O3"
-    )
+    add_compile_options(-O3)
 endif(NOT CMAKE_BUILD_TYPE STREQUAL Debug)
 
 if(IS_64BIT_BUILD)
@@ -296,10 +293,6 @@ if(IS_64BIT_BUILD)
         -DSTACK_ALIGN=16
     )
 endif(IS_64BIT_BUILD)
-
-if(CLR_CMAKE_PLATFORM_XPLAT)
-   add_definitions(-DFEATURE_PAL)
-endif(CLR_CMAKE_PLATFORM_XPLAT)
 
 if(NO_JIT_SH)
     unset(NO_JIT_SH CACHE)      # don't cache

--- a/bin/ch/CMakeLists.txt
+++ b/bin/ch/CMakeLists.txt
@@ -79,10 +79,12 @@ else() # // shared library below
     )
 endif()
 
-if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
-  set(lib_target "${lib_target}"
-    "-stdlib=libstdc++" # expected 'deprecated' warning. needed for std::string
-    )
+if(NOT CC_XCODE_PROJECT)
+  if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+    set(lib_target "${lib_target}"
+      "-stdlib=libstdc++" # expected 'deprecated' warning. needed for std::string
+      )
+  endif()
 endif()
 
 if(CC_TARGETS_X86)

--- a/lib/Common/CommonPal.h
+++ b/lib/Common/CommonPal.h
@@ -16,7 +16,11 @@
         #define __forceinline _ALWAYSINLINE
     #endif
     #if __has_attribute(noinline)
-        #define _NOINLINE __attribute__((noinline))
+        #ifdef CLANG_HAS_DISABLE_TAIL_CALLS
+            #define _NOINLINE __attribute__((noinline, disable_tail_calls))
+        #else
+            #define _NOINLINE __attribute__((noinline))
+        #endif
     #else // No noinline support
         #pragma message __MAKE_WARNING__("noinline")
         #define _NOINLINE


### PR DESCRIPTION
additional ~4% performance gain (octane and load test)

The reason for some of the flags there because of old stability issues.

Besides, instead of disabling tail call optimization globally,
disabled only for functions with noinline attribute. Older Clang doesn't support this.