### PR TITLE
BailOnNoProfile improvements

### DIFF
--- a/lib/Runtime/Language/ValueType.cpp
+++ b/lib/Runtime/Language/ValueType.cpp
@@ -1270,6 +1270,7 @@ void ValueType::InitializeTypeIdToBitsMap()
     TypeIdToBits[TypeIds_SIMDUint8x16      ] = GetObject(ObjectType::Simd128Int8x16).bits;
     TypeIdToBits[TypeIds_SIMDFloat64x2     ] = GetObject(ObjectType::Simd128Float64x2).bits;
 
+    TypeIdToBits[TypeIds_HostDispatch      ] = ValueType::UninitializedObject.bits;
 
     VirtualTypeIdToBits[TypeIds_Int8Array] = GetObject(ObjectType::Int8VirtualArray).bits;
     VirtualTypeIdToBits[TypeIds_Uint8Array] = GetObject(ObjectType::Uint8VirtualArray).bits;


### PR DESCRIPTION
1. Record in the profile that we loaded a HostDispatch object from a LdFld or LdSlot. This is to not let the IRBuilder think that the respective LdFld or LdSlot was non-profiled (IRBuilder would then insert a BailOnNoProfile before the operation and we'll bailout but not collect any new information, and we'll put the bailout in the next rejit too, and so on). I'm not recording anything specific for HostDispatch, but just that we've seen an object at that point.

2. While hoisting BailOnNoProfile from successors to predecessors, dont remove the bailouts from the successors as we may not end up moving the bailout all the way to the top of the predecessor and would just remove it then. If the bailouts were removed from the successors, we wouldn't have BailOnNoProfile on paths that should have it.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/1966)
<!-- Reviewable:end -->
