### PR TITLE
fix incorrect calculation in IsChakraAddress

### DIFF
--- a/lib/Common/Core/SysInfo.cpp
+++ b/lib/Common/Core/SysInfo.cpp
@@ -184,6 +184,12 @@ AutoSystemInfo::IsJscriptModulePointer(void * ptr)
 {
     return ((UINT_PTR)ptr >= Data.dllLoadAddress && (UINT_PTR)ptr < Data.dllHighAddress);
 }
+
+UINT_PTR
+AutoSystemInfo::GetChakraBaseAddr() const
+{
+    return dllLoadAddress;
+}
 #endif
 
 uint
@@ -209,20 +215,6 @@ AutoSystemInfo::VirtualSseAvailable(const int sseLevel) const
     #else
         return true;
     #endif
-}
-#endif
-
-
-#ifdef ENABLE_OOP_NATIVE_CODEGEN
-bool
-AutoSystemInfo::IsChakraAddress(void * addr) const
-{
-    return addr >= this->chakraBaseAddress && addr < (this->chakraBaseAddress + this->chakraSize);
-}
-void *
-AutoSystemInfo::GetChakraBaseAddr() const
-{
-    return this->chakraBaseAddress;
 }
 #endif
 
@@ -370,17 +362,7 @@ AutoSystemInfo::IsWinThresholdOrLater()
 
 DWORD AutoSystemInfo::SaveModuleFileName(HANDLE hMod)
 {
-    DWORD result = ::GetModuleFileNameW((HMODULE)hMod, Data.binaryName, MAX_PATH);
-
-#ifdef ENABLE_OOP_NATIVE_CODEGEN
-    Data.chakraBaseAddress = GetModuleHandle(Data.binaryName);
-    AnalysisAssert(Data.chakraBaseAddress != nullptr);
-    MODULEINFO chakraInfo = { 0 };
-    GetModuleInformation(GetCurrentProcess(), Data.chakraBaseAddress, &chakraInfo, sizeof(chakraInfo));
-    Data.chakraSize = chakraInfo.SizeOfImage;
-#endif
-
-    return result;
+    return ::GetModuleFileNameW((HMODULE)hMod, Data.binaryName, MAX_PATH);
 }
 
 LPCWSTR AutoSystemInfo::GetJscriptDllFileName()

--- a/lib/Common/Core/SysInfo.h
+++ b/lib/Common/Core/SysInfo.h
@@ -39,9 +39,8 @@ public:
     DWORD GetNumberOfLogicalProcessors() const { return this->dwNumberOfProcessors; }
     DWORD GetNumberOfPhysicalProcessors() const { return this->dwNumberOfPhysicalProcessors; }
 
-#ifdef ENABLE_OOP_NATIVE_CODEGEN
-    bool IsChakraAddress(void * addr) const;
-    void * GetChakraBaseAddr() const;
+#if SYSINFO_IMAGE_BASE_AVAILABLE
+    UINT_PTR GetChakraBaseAddr() const;
 #endif
 
 #if defined(_M_ARM32_OR_ARM64)
@@ -112,9 +111,6 @@ private:
     static HRESULT GetVersionInfo(__in LPCWSTR pszPath, DWORD* majorVersion, DWORD* minorVersion);
 
     static const DWORD INVALID_VERSION = (DWORD)-1;
-
-    HMODULE chakraBaseAddress;
-    size_t chakraSize;
 
     ULONG64 availableCommit;
     bool shouldQCMoreFrequently;

--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -3871,7 +3871,7 @@ BOOL ThreadContext::IsNativeAddress(void * pCodeAddr)
         {
             return false;
         }
-        if (AutoSystemInfo::Data.IsChakraAddress(pCodeAddr))
+        if (AutoSystemInfo::IsJscriptModulePointer(pCodeAddr))
         {
             return false;
         }


### PR DESCRIPTION
Previous code was incorrectly doing comparison of addr < base + chakraSize * sizeof(void*)

When debugging, I noticed that we already have code to do this, so my fix is to remove my methods and use the existing ones.