### PR TITLE
Change to address CVE-2016-7207

### DIFF
--- a/lib/Parser/Parse.h
+++ b/lib/Parser/Parse.h
@@ -367,6 +367,7 @@ private:
     ParseNodePtr * m_ppnodeVar;  // variable list tail
     bool m_inDeferredNestedFunc; // true if parsing a function in deferred mode, nested within the current node
     bool m_isInBackground;
+    bool m_reparsingLambdaParams;
 
     // This bool is used for deferring the shorthand initializer error ( {x = 1}) - as it is allowed in the destructuring grammar.
     bool m_hasDeferredShorthandInitError;

--- a/test/es6/lambda-params-shadow.js
+++ b/test/es6/lambda-params-shadow.js
@@ -1,0 +1,22 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+var count = 0;
+class A {
+    constructor() { count++; }
+    increment() { count++; }
+}
+class B extends A {
+    constructor() {
+        super();
+        ((B) => { super.increment() })();
+        (A=> { super.increment() })();
+    }
+}
+let b = new B();
+if (count !== 3) {
+    WScript.Echo('fail');
+}
+WScript.Echo('pass');

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -14,6 +14,18 @@
   </test>
   <test>
     <default>
+      <files>lambda-params-shadow.js</files>
+      <compile-flags>-off:deferparse -args summary -endargs</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
+      <files>lambda-params-shadow.js</files>
+      <compile-flags>-force:deferparse -args summary -endargs</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>NumericLiteralTest.js</files>
       <compile-flags>-args summary -endargs</compile-flags>
     </default>


### PR DESCRIPTION
Fix incorrect identification of non-local-references when parsing arrow function parameter lists. Since we can't identify such syntax on the initial scan and have to backtrack and re-parse, our stacks of identifier references enter an inconsistent state that causes us to bind non-existent references and treat them as closure-captured. This in turn leads to bad byte code generation. The problem is easy to solve in the case of a single arrow function parameter not enclosed in parentheses. To handle the harder case of a list enclosed in parens, advance the current block ID when we begin parsing a parenthetical expression. Identifier references will be created that are amenable to the arrow function case, and if we do wind up with an arrow function, we only need to correct the function ID's on the references we've already made.