### PR TITLE
IRBuilder sets all 2 reg branches as switch branches, fix this

### DIFF
--- a/lib/Backend/IRBuilder.cpp
+++ b/lib/Backend/IRBuilder.cpp
@@ -6676,7 +6676,6 @@ IRBuilder::BuildBrReg2(Js::OpCode newOpcode, uint32 offset, uint targetOffset, J
     else
     {
         branchInstr = IR::BranchInstr::New(newOpcode, nullptr, src1Opnd, src2Opnd, m_func);
-        branchInstr->m_isSwitchBr = true;
         this->AddBranchInstr(branchInstr, offset, targetOffset);
     }
 }


### PR DESCRIPTION
IRBuilder is setting the flag m_isSwitchBr for all 2 register branch
instructions. Fixing this.
