### PR TITLE
swb: write barrier annotations 3

### DIFF
--- a/bin/GCStress/GCStress.h
+++ b/bin/GCStress/GCStress.h
@@ -18,19 +18,19 @@ class RecyclerTestObject;
 class Location
 {
 private:
-    enum class Type 
+    enum class Type
     {
         Scanned,        // For regular locations in scanned objects (or stack locations)
         Rooted,         // This is a non-heap location that's explicitly rooted.
         Barrier,        // Write barrier location
         Tagged,         // Tagged location (used in tracked objects)
-        ImplicitRoot,   // Uses ImplicitRootBit to hold reference 
+        ImplicitRoot,   // Uses ImplicitRootBit to hold reference
     };
 
     class ImplicitRootHolder
     {
     private:
-        RecyclerTestObject * reference;
+        Field(RecyclerTestObject *) reference;
 
     public:
         ImplicitRootHolder(RecyclerTestObject * reference)
@@ -45,7 +45,7 @@ private:
             return this->reference;
         }
     };
-    
+
     Location(RecyclerTestObject ** location, Type type) :
         location(location), type(type)
     {
@@ -57,7 +57,7 @@ public:
     {
         return Location(location, Type::Scanned);
     }
-    
+
     static Location Rooted(RecyclerTestObject ** location)
     {
         return Location(location, Type::Rooted);
@@ -71,14 +71,14 @@ public:
     static Location Tagged(RecyclerTestObject ** location)
     {
         return Location(location, Type::Tagged);
-    }    
+    }
 
     static Location ImplicitRoot(RecyclerTestObject ** location)
     {
         return Location(location, Type::ImplicitRoot);
-    }    
-    
-    RecyclerTestObject * Get() 
+    }
+
+    RecyclerTestObject * Get()
     {
         switch (type)
         {
@@ -101,7 +101,7 @@ public:
                 {
                     return nullptr;
                 }
-                
+
                 return holder->GetReference();
         }
 
@@ -110,7 +110,7 @@ public:
         return nullptr;
     }
 
-    void Set(RecyclerTestObject * value) 
+    void Set(RecyclerTestObject * value)
     {
         switch (type)
         {
@@ -171,7 +171,7 @@ public:
 
         // Shouldn't get here
         VerifyCondition(false);
-    }    
+    }
 
     static RecyclerTestObject * Tag(RecyclerTestObject * untagged)
     {
@@ -211,7 +211,7 @@ private:
             recyclerInstance->RootRelease(*location);
         }
     }
-    
+
     void Root()
     {
         if (*location != nullptr)
@@ -219,7 +219,7 @@ private:
             recyclerInstance->RootAddRef(*location);
         }
     }
-    
+
 private:
     RecyclerTestObject ** location;
     Type type;

--- a/bin/GCStress/RecyclerTestObject.h
+++ b/bin/GCStress/RecyclerTestObject.h
@@ -7,7 +7,7 @@
 class RecyclerTestObject : public FinalizableObject
 {
 protected:
-    RecyclerTestObject() 
+    RecyclerTestObject()
     {
         generation = currentGeneration;
     }
@@ -35,7 +35,7 @@ public:
         wprintf(_u("-------------------------------------------\n"));
         wprintf(_u("Full heap walk starting\n"));
     }
-    
+
     static void WalkReference(RecyclerTestObject * object)
     {
         if (object != nullptr)
@@ -49,7 +49,7 @@ public:
                 VerifyCondition(object->generation == currentGeneration);
 
                 walkObjectCount++;
-                
+
                 currentWalkDepth++;
                 maxWalkDepth = max(currentWalkDepth, maxWalkDepth);
 
@@ -87,10 +87,10 @@ public:
 
 protected:
     // Global variables
-    
+
     // This global variable contains the "generation" of GC objects
     // It is used to validate the correctness of GC objects
-    // It is assigned initially during object creation, and 
+    // It is assigned initially during object creation, and
     // updated when we walk the entire object graph in TraverseAllObjects
     static size_t currentGeneration;
 
@@ -105,7 +105,7 @@ protected:
 
 private:
     // Instance variables
-    
+
     // See comments above re currentGeneration
     size_t generation;
 };
@@ -122,12 +122,12 @@ private:
             data[i] = i;
         }
     }
-    
+
 public:
     static RecyclerTestObject * New()
     {
         unsigned int count = minCount + GetRandomInteger(maxCount - minCount + 1);
-        
+
         return RecyclerNewPlusLeaf(recyclerInstance, sizeof(size_t) * count, LeafObject, count);
     }
 
@@ -138,8 +138,8 @@ protected:
     }
 
 private:
-    unsigned int count;
-    size_t data[0];
+    Field(unsigned int) count;
+    Field(size_t ) data[0];
 };
 
 template <unsigned int minCount, unsigned int maxCount>
@@ -154,12 +154,12 @@ private:
             references[i] = nullptr;
         }
     }
-    
+
 public:
     static RecyclerTestObject * New()
     {
         unsigned int count = minCount + GetRandomInteger(maxCount - minCount + 1);
-        
+
         return RecyclerNewPlus(recyclerInstance, sizeof(RecyclerTestObject *) * count, ScannedObject, count);
     }
 
@@ -181,10 +181,10 @@ protected:
             RecyclerTestObject::WalkReference(references[i]);
         }
     }
-    
+
 private:
-    unsigned int count;
-    RecyclerTestObject * references[0];
+    Field(unsigned int) count;
+    FieldNoBarrier(RecyclerTestObject *) references[0];  // SWB-TODO: is this correct?
 };
 
 template <unsigned int minCount, unsigned int maxCount>
@@ -199,12 +199,12 @@ private:
             references[i] = nullptr;
         }
     }
-    
+
 public:
     static RecyclerTestObject * New()
     {
         unsigned int count = minCount + GetRandomInteger(maxCount - minCount + 1);
-        
+
         return RecyclerNewWithBarrierPlus(recyclerInstance, sizeof(RecyclerTestObject *) * count, BarrierObject, count);
     }
 
@@ -226,10 +226,10 @@ protected:
             RecyclerTestObject::WalkReference(references[i]);
         }
     }
-    
+
 private:
-    unsigned int count;
-    RecyclerTestObject * references[0];
+    Field(unsigned int) count;
+    FieldNoBarrier(RecyclerTestObject *) references[0];  // SWB-TODO: is this correct?
 };
 
 template <unsigned int minCount, unsigned int maxCount>
@@ -244,12 +244,12 @@ private:
             references[i] = nullptr;
         }
     }
-    
+
 public:
     static RecyclerTestObject * New()
     {
         unsigned int count = minCount + GetRandomInteger(maxCount - minCount + 1);
-        
+
         return RecyclerNewTrackedLeafPlusZ(recyclerInstance, sizeof(RecyclerTestObject *) * count, TrackedObject, count);
     }
 
@@ -262,8 +262,8 @@ public:
     }
 
     // Tracked object implementation
-    virtual void Mark(Recycler * recycler) override 
-    { 
+    virtual void Mark(Recycler * recycler) override
+    {
         for (unsigned int i = 0; i < count; i++)
         {
             RecyclerTestObject * object = Location::Untag(references[i]);
@@ -277,8 +277,8 @@ public:
     // Tracked objects are always finalize as well. Just do nothing.
     virtual void Finalize(bool isShutdown) override { }
     virtual void Dispose(bool isShutdown) override { };
-    
-    
+
+
 protected:
     virtual void DoWalkObject() override
     {
@@ -289,10 +289,10 @@ protected:
             RecyclerTestObject::WalkReference(Location::Untag(references[i]));
         }
     }
-    
+
 private:
-    unsigned int count;
-    RecyclerTestObject * references[0];
+    Field(unsigned int) count;
+    FieldNoBarrier(RecyclerTestObject *) references[0];  // SWB-TODO: is this correct?
 };
 
 

--- a/lib/Backend/CodeGenNumberAllocator.h
+++ b/lib/Backend/CodeGenNumberAllocator.h
@@ -100,8 +100,8 @@ private:
     bool hasNewChunkBlock;
     struct BlockRecord
     {
-        BlockRecord(__in_ecount_pagesize char * blockAddress, PageSegment * segment) 
-            : blockAddress(blockAddress), segment(segment) 
+        BlockRecord(__in_ecount_pagesize char * blockAddress, PageSegment * segment)
+            : blockAddress(blockAddress), segment(segment)
         {
         }
         char * blockAddress;
@@ -114,19 +114,19 @@ private:
     size_t pendingIntegrationChunkSegmentPageCount;
     DListBase<PageSegment> pendingIntegrationNumberSegment;
     DListBase<PageSegment> pendingIntegrationChunkSegment;
-    SListBase<BlockRecord> pendingIntegrationNumberBlock;
-    SListBase<BlockRecord> pendingIntegrationChunkBlock;
+    SListBase<BlockRecord, NoThrowHeapAllocator> pendingIntegrationNumberBlock;
+    SListBase<BlockRecord, NoThrowHeapAllocator> pendingIntegrationChunkBlock;
 
     // These are finished pages during the code gen of the current function
     // We can't integrate them until the code gen is done for the function,
     // because the references for the number is not set on the entry point yet.
-    SListBase<BlockRecord> pendingFlushNumberBlock;
-    SListBase<BlockRecord> pendingFlushChunkBlock;
+    SListBase<BlockRecord, NoThrowHeapAllocator> pendingFlushNumberBlock;
+    SListBase<BlockRecord, NoThrowHeapAllocator> pendingFlushChunkBlock;
 
     // Numbers are reference by the chunks, so we need to wait until that is ready
     // to be flushed before the number page can be flushed. Otherwise, we might have number
     // integrated back to the GC, but the chunk hasn't yet, thus GC won't see the reference.
-    SListBase<BlockRecord> pendingReferenceNumberBlock;
+    SListBase<BlockRecord, NoThrowHeapAllocator> pendingReferenceNumberBlock;
 };
 
 class CodeGenNumberAllocator

--- a/lib/Backend/PageAllocatorPool.cpp
+++ b/lib/Backend/PageAllocatorPool.cpp
@@ -86,7 +86,7 @@ PageAllocator* PageAllocatorPool::GetPageAllocator()
 void PageAllocatorPool::ReturnPageAllocator(PageAllocator* pageAllocator)
 {
     AutoCriticalSection autoCS(&cs);
-    if (!this->pageAllocators.PrependNoThrow(&HeapAllocator::Instance, pageAllocator))
+    if (!this->pageAllocators.PrependNoThrow(&NoThrowHeapAllocator::Instance, pageAllocator))
     {
         HeapDelete(pageAllocator);
     }

--- a/lib/Common/Memory/HeapAllocator.h
+++ b/lib/Common/Memory/HeapAllocator.h
@@ -182,9 +182,21 @@ class NoThrowHeapAllocator
 {
 public:
     static const bool FakeZeroLengthArray = false;
+
     char * Alloc(DECLSPEC_GUARD_OVERFLOW size_t byteSize);
     char * AllocZero(DECLSPEC_GUARD_OVERFLOW size_t byteSize);
     void Free(void * buffer, size_t byteSize);
+
+    char * NoThrowAlloc(DECLSPEC_GUARD_OVERFLOW size_t byteSize)
+    {
+        return Alloc(byteSize);
+    }
+
+    char * NoThrowAllocZero(DECLSPEC_GUARD_OVERFLOW size_t byteSize)
+    {
+        return AllocZero(byteSize);
+    }
+
     static NoThrowHeapAllocator Instance;
 
 #ifdef TRACK_ALLOC

--- a/lib/Common/Memory/PageAllocator.cpp
+++ b/lib/Common/Memory/PageAllocator.cpp
@@ -63,8 +63,8 @@ SegmentBase<T>::~SegmentBase()
             RecyclerWriteBarrierManager::ToggleBarrier(this->address, this->segmentPageCount * AutoSystemInfo::PageSize, false);
         }
 #endif
-#endif
         RecyclerWriteBarrierManager::OnSegmentFree(this->address, this->segmentPageCount);
+#endif
     }
 }
 
@@ -343,7 +343,7 @@ PageSegmentBase<T>::AllocPages(uint pageCount)
                 MemoryOperationLastError::RecordLastError();
                 if (this->GetAllocator()->processHandle == GetCurrentProcess())
                 {
-                    Assert(false);                    
+                    Assert(false);
                 }
                 return nullptr;
             }

--- a/lib/Common/Memory/RecyclerPointers.h
+++ b/lib/Common/Memory/RecyclerPointers.h
@@ -424,6 +424,12 @@ template <class T>
 inline T* AddressOf(T& val) { return _AddressOfType<T>::AddressOf(val); }
 template <class T>
 inline const T* AddressOf(const T& val) { return _AddressOfType<T>::AddressOf(val); }
+
+template <class T>
+inline T* const& PointerValue(T* const& ptr) { return ptr; }
+template <class T>
+inline T* const& PointerValue(const WriteBarrierPtr<T>& ptr) { return ptr; }
+
 }  // namespace Memory
 
 

--- a/lib/Common/Memory/RecyclerWriteBarrierManager.cpp
+++ b/lib/Common/Memory/RecyclerWriteBarrierManager.cpp
@@ -21,7 +21,7 @@
 
 #ifdef RECYCLER_WRITE_BARRIER
 #if ENABLE_DEBUG_CONFIG_OPTIONS
-namespace Memory 
+namespace Memory
 {
     FN_VerifyIsNotBarrierAddress* g_verifyIsNotBarrierAddress = nullptr;
 }
@@ -377,11 +377,11 @@ RecyclerWriteBarrierManager::IsBarrierAddress(void * address)
 bool
 RecyclerWriteBarrierManager::IsBarrierAddress(uintptr_t index)
 {
-    return cardTable[index] & WRITE_BARRIER_PAGE_BIT;
+    return (cardTable[index] & WRITE_BARRIER_PAGE_BIT) == WRITE_BARRIER_PAGE_BIT;
 }
 
-// TODO: SWB, looks we didn't initialize card table for heap allocation. 
-// we didn't hit such issue because we are not allocating write barrier 
+// TODO: SWB, looks we didn't initialize card table for heap allocation.
+// we didn't hit such issue because we are not allocating write barrier
 // annotated struct with heap today.
 // after SWB is widely enabled and if an annotated structure can be allocated
 // with both Heap and Recycler/Arena we'll capture the issue
@@ -406,10 +406,10 @@ RecyclerWriteBarrierManager::VerifyIsBarrierAddress(void * address, size_t bytes
         uintptr_t startIndex = GetCardTableIndex(address);
         char * endAddress = (char *)Math::Align<INT_PTR>((INT_PTR)((char *)address + bytes), s_WriteBarrierPageSize);
         uintptr_t endIndex = GetCardTableIndex(endAddress);
-        do 
+        do
         {
             // no need to check if cardTable is commited or not, if it's not commited it'll AV instead of assertion
-            if (!IsBarrierAddress(startIndex)) 
+            if (!IsBarrierAddress(startIndex))
             {
                 Js::Throw::FatalInternalError();
             }
@@ -425,11 +425,11 @@ RecyclerWriteBarrierManager::VerifyIsNotBarrierAddress(void * address, size_t by
         uintptr_t startIndex = GetCardTableIndex(address);
         char * endAddress = (char *)Math::Align<INT_PTR>((INT_PTR)((char *)address + bytes), s_WriteBarrierPageSize);
         uintptr_t endIndex = GetCardTableIndex(endAddress);
-        do 
+        do
         {
             if(IsCardTableCommited(startIndex))
             {
-                if (IsBarrierAddress(startIndex)) 
+                if (IsBarrierAddress(startIndex))
                 {
                     Js::Throw::FatalInternalError();
                 }
@@ -439,13 +439,13 @@ RecyclerWriteBarrierManager::VerifyIsNotBarrierAddress(void * address, size_t by
     }
 }
 
-bool 
+bool
 RecyclerWriteBarrierManager::Initialize()
 {
     g_verifyIsNotBarrierAddress = RecyclerWriteBarrierManager::VerifyIsNotBarrierAddress;
     return true;
 }
-#endif 
+#endif
 
 uintptr_t
 RecyclerWriteBarrierManager::GetCardTableIndex(void *address)

--- a/lib/JITServer/JITServer.h
+++ b/lib/JITServer/JITServer.h
@@ -12,7 +12,7 @@ public:
     static void CleanUpForProcess(HANDLE hProcess);
 
     static void RegisterScriptContext(ServerScriptContext* scriptContext);
-    static void UnRegisterScriptContext(ServerScriptContext* scriptContext);    
+    static void UnRegisterScriptContext(ServerScriptContext* scriptContext);
 
     static bool CheckLivenessAndAddref(ServerScriptContext* context);
     static bool CheckLivenessAndAddref(ServerThreadContext* context);
@@ -44,7 +44,7 @@ public:
         T* context;
         union {
             DWORD runtimeProcId;
-            ServerThreadContext* threadCtx; 
+            ServerThreadContext* threadCtx;
         };
         StackBackTrace* stack;
     };
@@ -52,11 +52,11 @@ public:
     static void RecordCloseContext(ServerThreadContext* context)
     {
         auto record = HeapNewNoThrow(ClosedContextEntry<ServerThreadContext>, context);
-        if (record) 
+        if (record)
         {
             record->runtimeProcId = context->GetRuntimePid();
         }
-        ClosedThreadContextList.PrependNoThrow(&HeapAllocator::Instance, record);
+        ClosedThreadContextList.PrependNoThrow(&NoThrowHeapAllocator::Instance, record);
     }
     static void RecordCloseContext(ServerScriptContext* context)
     {
@@ -65,7 +65,7 @@ public:
         {
             record->threadCtx = context->GetThreadContext();
         }
-        ClosedScriptContextList.PrependNoThrow(&HeapAllocator::Instance, record);
+        ClosedScriptContextList.PrependNoThrow(&NoThrowHeapAllocator::Instance, record);
     }
 
     static SList<ClosedContextEntry<ServerThreadContext>*, NoThrowHeapAllocator> ClosedThreadContextList;

--- a/lib/Jsrt/JsrtExternalArrayBuffer.h
+++ b/lib/Jsrt/JsrtExternalArrayBuffer.h
@@ -18,8 +18,8 @@ namespace Js {
         void Finalize(bool isShutdown) override;
 
     private:
-        JsFinalizeCallback finalizeCallback;
-        void *callbackState;
+        FieldNoBarrier(JsFinalizeCallback) finalizeCallback;
+        Field(void *) callbackState;
     };
     AUTO_REGISTER_RECYCLER_OBJECT_DUMPER(JsrtExternalArrayBuffer, &Js::RecyclableObject::DumpObjectFunction);
 }

--- a/lib/Jsrt/JsrtExternalObject.h
+++ b/lib/Jsrt/JsrtExternalObject.h
@@ -34,7 +34,7 @@ public:
     JsFinalizeCallback GetJsFinalizeCallback() const { return this->jsFinalizeCallback; }
 
 private:
-    JsFinalizeCallback jsFinalizeCallback;
+    FieldNoBarrier(JsFinalizeCallback) jsFinalizeCallback;
 };
 AUTO_REGISTER_RECYCLER_OBJECT_DUMPER(JsrtExternalType, &Js::Type::DumpObjectFunction);
 
@@ -63,7 +63,7 @@ public:
     void SetSlotData(void * data);
 
 private:
-    void * slot;
+    Field(void *) slot;
 
 #if ENABLE_TTD
 public:

--- a/lib/Jsrt/JsrtSourceHolder.h
+++ b/lib/Jsrt/JsrtSourceHolder.h
@@ -13,16 +13,16 @@ namespace Js
     private:
         enum MapRequestFor { Source = 1, Length = 2 };
 
-        TLoadCallback scriptLoadCallback;
-        TUnloadCallback scriptUnloadCallback;
-        JsSourceContext sourceContext;
+        FieldNoBarrier(TLoadCallback) scriptLoadCallback;
+        FieldNoBarrier(TUnloadCallback) scriptUnloadCallback;
+        Field(JsSourceContext) sourceContext;
 
 #ifndef NTBUILD
-        JsValueRef mappedScriptValue;
+        Field(JsValueRef) mappedScriptValue;
 #endif
-        utf8char_t const * mappedSource;
-        size_t mappedSourceByteLength;
-        size_t mappedAllocLength;
+        Field(utf8char_t const *) mappedSource;
+        Field(size_t) mappedSourceByteLength;
+        Field(size_t) mappedAllocLength;
 
         // Wrapper methods with Asserts to ensure that we aren't trying to access unmapped source
         utf8char_t const * GetMappedSource()

--- a/lib/Parser/OctoquadIdentifier.h
+++ b/lib/Parser/OctoquadIdentifier.h
@@ -27,7 +27,7 @@ namespace UnifiedRegex
         Field(int) triPat1;
         Field(int) triPat2;
         Field(int) resultCount;
-        Field(int ) offsets[MaxResults];
+        Field(int) offsets[MaxResults];
         Field(Js::JavascriptString *) cachedResult[MaxResults];
 
         TrigramInfo(__in_ecount(PatternLength) char* pat1,__in_ecount(PatternLength) char* pat2, Recycler* recycler);
@@ -137,9 +137,9 @@ namespace UnifiedRegex
 
         // Maps characters (0..AsciTableSize-1) to 0 if not in alphabet, or 0x1, 0x2, 0x4 or 0x8.
         // Allocated and filled only if invoke Match below.
-        Field(uint8 ) charToBits[TrigramAlphabet::AsciiTableSize];
+        Field(uint8) charToBits[TrigramAlphabet::AsciiTableSize];
 
-        Field(uint32 ) patterns[OctoquadIdentifier::NumPatterns];
+        Field(uint32) patterns[OctoquadIdentifier::NumPatterns];
 
     public:
         static OctoquadMatcher *New(Recycler* recycler, const StandardChars<Char>* standardChars, CaseInsensitive::MappingSource mappingSource, OctoquadIdentifier* identifier);

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -1755,25 +1755,25 @@ namespace Js
     protected:
         static HRESULT MapDeferredReparseError(HRESULT& hrParse, const CompileScriptException& se);
 
-        bool m_hasBeenParsed : 1;       // Has function body been parsed- true for actual function bodies, false for deferparse
-        bool m_isDeclaration : 1;
-        bool m_isAccessor : 1;          // Function is a property getter or setter
-        bool m_isStaticNameFunction : 1;
-        bool m_isNamedFunctionExpression : 1;
-        bool m_isNameIdentifierRef  : 1;
-        bool m_isClassMember : 1;
-        bool m_isStrictMode : 1;
-        bool m_isAsmjsMode : 1;
-        bool m_isAsmJsFunction : 1;
-        bool m_isWasmFunction : 1;
-        bool m_isGlobalFunc : 1;
-        bool m_doBackendArgumentsOptimization : 1;
-        bool m_doScopeObjectCreation : 1;
-        bool m_usesArgumentsObject : 1;
-        bool m_isEval : 1;              // Source code is in 'eval'
-        bool m_isDynamicFunction : 1;   // Source code is in 'Function'
-        bool m_hasImplicitArgIns : 1;
-        bool m_dontInline : 1;            // Used by the JIT's inliner
+        Field(bool) m_hasBeenParsed : 1;       // Has function body been parsed- true for actual function bodies, false for deferparse
+        Field(bool) m_isDeclaration : 1;
+        Field(bool) m_isAccessor : 1;          // Function is a property getter or setter
+        Field(bool) m_isStaticNameFunction : 1;
+        Field(bool) m_isNamedFunctionExpression : 1;
+        Field(bool) m_isNameIdentifierRef  : 1;
+        Field(bool) m_isClassMember : 1;
+        Field(bool) m_isStrictMode : 1;
+        Field(bool) m_isAsmjsMode : 1;
+        Field(bool) m_isAsmJsFunction : 1;
+        Field(bool) m_isWasmFunction : 1;
+        Field(bool) m_isGlobalFunc : 1;
+        Field(bool) m_doBackendArgumentsOptimization : 1;
+        Field(bool) m_doScopeObjectCreation : 1;
+        Field(bool) m_usesArgumentsObject : 1;
+        Field(bool) m_isEval : 1;              // Source code is in 'eval'
+        Field(bool) m_isDynamicFunction : 1;   // Source code is in 'Function'
+        Field(bool) m_hasImplicitArgIns : 1;
+        Field(bool) m_dontInline : 1;            // Used by the JIT's inliner
 
         // Indicates if the function has been reparsed for debug attach/detach scenario.
         Field(bool) m_reparsed : 1;
@@ -3478,7 +3478,7 @@ namespace Js
 #if defined(_M_X64_OR_ARM64)
         Field(uint32) unused;
 #endif
-        Field(void* ) scopes[];
+        Field(void*) scopes[];
     };
 #pragma region Function Body helper classes
 #pragma region Debugging related source classes

--- a/lib/Runtime/Base/FunctionInfo.cpp
+++ b/lib/Runtime/Base/FunctionInfo.cpp
@@ -41,7 +41,7 @@ namespace Js
     FunctionInfo::GetFunctionBody() const
     {
         Assert(functionBodyImpl == nullptr || functionBodyImpl->IsFunctionBody());
-        return (FunctionBody *)functionBodyImpl;
+        return (FunctionBody *)PointerValue(functionBodyImpl);
     }
 
     FunctionInfo::Attributes FunctionInfo::GetAttributes(Js::RecyclableObject * function)

--- a/lib/Runtime/Base/FunctionInfo.h
+++ b/lib/Runtime/Base/FunctionInfo.h
@@ -76,7 +76,7 @@ namespace Js
         ParseableFunctionInfo* GetParseableFunctionInfo() const
         {
             Assert(functionBodyImpl == NULL || !IsDeferredDeserializeFunction());
-            return (ParseableFunctionInfo*) functionBodyImpl;
+            return (ParseableFunctionInfo*)PointerValue(functionBodyImpl);
         }
         ParseableFunctionInfo** GetParseableFunctionInfoRef() const
         {
@@ -86,7 +86,7 @@ namespace Js
         DeferDeserializeFunctionInfo* GetDeferDeserializeFunctionInfo() const
         {
             Assert(functionBodyImpl == NULL || IsDeferredDeserializeFunction());
-            return (DeferDeserializeFunctionInfo*)functionBodyImpl;
+            return (DeferDeserializeFunctionInfo*)PointerValue(functionBodyImpl);
         }
         FunctionBody * GetFunctionBody() const;
 
@@ -107,12 +107,12 @@ namespace Js
         BOOL IsDeferredParseFunction() const { return ((this->attributes & DeferredParse) == DeferredParse); }
 
     protected:
-        JavascriptMethod originalEntryPoint;
+        FieldNoBarrier(JavascriptMethod) originalEntryPoint;
         // WriteBarrier-TODO: Fix this? This is used only by proxies to keep the deserialized version around
         // However, proxies are not allocated as write barrier memory currently so its fine to not set the write barrier for this field
-        FunctionProxy * functionBodyImpl;     // Implementation of the function- null if the function doesn't have a body
-        LocalFunctionId functionId;        // Per host source context (source file) function Id
-        Attributes attributes;
+        Field(FunctionProxy *) functionBodyImpl;     // Implementation of the function- null if the function doesn't have a body
+        Field(LocalFunctionId) functionId;        // Per host source context (source file) function Id
+        Field(Attributes) attributes;
     };
 
     // Helper FunctionInfo for builtins that we don't want to profile (script profiler).

--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -1161,7 +1161,7 @@ namespace Js
 #if DBG_DUMP || defined(DYNAMIC_PROFILE_STORAGE) || defined(RUNTIME_DATA_COLLECTION)
         if (DynamicProfileInfo::NeedProfileInfoList())
         {
-            this->profileInfoList.Root(RecyclerNew(this->GetRecycler(), SListBase<DynamicProfileInfo *>), recycler);
+            this->profileInfoList.Root(RecyclerNew(this->GetRecycler(), DynamicProfileInfoList), recycler);
         }
 #endif
 #endif

--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -839,7 +839,7 @@ private:
 
 #if ENABLE_PROFILE_INFO
 #if DBG_DUMP || defined(DYNAMIC_PROFILE_STORAGE) || defined(RUNTIME_DATA_COLLECTION)
-        RecyclerRootPtr<SListBase<DynamicProfileInfo *>> profileInfoList;
+        RecyclerRootPtr<DynamicProfileInfoList> profileInfoList;
 #endif
 #endif
         // List of weak reference dictionaries. We'll walk through them
@@ -1061,7 +1061,7 @@ private:
             }
         }
 
-        SListBase<DynamicProfileInfo *> * GetProfileInfoList() { return profileInfoList; }
+        DynamicProfileInfoList * GetProfileInfoList() { return profileInfoList; }
 #endif
 #endif
 

--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -4130,7 +4130,7 @@ void ThreadContext::RemoveExternalWeakReferenceCache(ExternalWeakReferenceCache 
 
 void ThreadContext::MarkExternalWeakReferencedObjects(bool inPartialCollect)
 {
-    SListBase<ExternalWeakReferenceCache *>::Iterator iteratorWeakRefCache(&this->externalWeakReferenceCacheList);
+    SListBase<ExternalWeakReferenceCache *, HeapAllocator>::Iterator iteratorWeakRefCache(&this->externalWeakReferenceCacheList);
     while (iteratorWeakRefCache.Next())
     {
         iteratorWeakRefCache.Data()->MarkNow(recycler, inPartialCollect);
@@ -4139,7 +4139,7 @@ void ThreadContext::MarkExternalWeakReferencedObjects(bool inPartialCollect)
 
 void ThreadContext::ResolveExternalWeakReferencedObjects()
 {
-    SListBase<ExternalWeakReferenceCache *>::Iterator iteratorWeakRefCache(&this->externalWeakReferenceCacheList);
+    SListBase<ExternalWeakReferenceCache *, HeapAllocator>::Iterator iteratorWeakRefCache(&this->externalWeakReferenceCacheList);
     while (iteratorWeakRefCache.Next())
     {
         iteratorWeakRefCache.Data()->ResolveNow(recycler);

--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -1007,7 +1007,7 @@ ThreadContext::UncheckedAddPropertyId(JsUtil::CharacterBuffer<WCHAR> const& prop
         if(this->TTDContext->GetActiveScriptContext() != nullptr && this->TTDContext->GetActiveScriptContext()->ShouldPerformReplayAction())
         {
             //We reload all properties that occour in the trace so they only way we get here in TTD mode is:
-            //(1) if the program is creating a new symbol (which always gets a fresh id) and we should recreate it or 
+            //(1) if the program is creating a new symbol (which always gets a fresh id) and we should recreate it or
             //(2) if it is forcing arguments in debug parse mode (instead of regular which we recorded in)
             Js::PropertyId propertyId = Js::Constants::NoProperty;
             this->TTDLog->ReplaySymbolCreationEvent(&propertyId);
@@ -1995,7 +1995,7 @@ ThreadContext::EnsureJITThreadContext(bool allowPrereserveAlloc)
 
     m_reclaimedJITProperties = HeapNew(PropertyList, &HeapAllocator::Instance);
     m_pendingJITProperties = HeapNew(PropertyList, &HeapAllocator::Instance);
-    
+
     for (auto iter = propertyMap->GetIterator(); iter.IsValid(); iter.MoveNext())
     {
         if (iter.CurrentKey()->IsNumeric())
@@ -2020,7 +2020,7 @@ void ThreadContext::InitTimeTravel(ThreadContext* threadContext, void* runtimeHa
     this->TTDLog = HeapNew(TTD::EventLog, this);
 }
 
-void ThreadContext::InitHostFunctionsAndTTData(bool record, bool replay, bool debug, 
+void ThreadContext::InitHostFunctionsAndTTData(bool record, bool replay, bool debug,
     TTD::TTDInitializeForWriteLogStreamCallback writeInitializefp,
     TTD::TTDOpenResourceStreamCallback getResourceStreamfp, TTD::TTDReadBytesFromStreamCallback readBytesFromStreamfp,
     TTD::TTDWriteBytesToStreamCallback writeBytesToStreamfp, TTD::TTDFlushAndCloseStreamCallback flushAndCloseStreamfp,
@@ -2037,7 +2037,7 @@ void ThreadContext::InitHostFunctionsAndTTData(bool record, bool replay, bool de
     {
         this->TTDLog->InitForTTDRecord();
     }
-    else 
+    else
     {
         this->TTDLog->InitForTTDReplay(this->TTDContext->TTDStreamFunctions, this->TTDContext->TTDUri.UriByteLength, this->TTDContext->TTDUri.UriBytes, debug);
     }
@@ -2065,7 +2065,7 @@ ThreadContext::ExecuteRecyclerCollectionFunction(Recycler * recycler, Collection
 
 #if ENABLE_TTD
     //
-    //TODO: We lose any events that happen in the callbacks (such as JsRelease) which may be a problem in the future. 
+    //TODO: We lose any events that happen in the callbacks (such as JsRelease) which may be a problem in the future.
     //      It may be possible to defer the collection of these objects to an explicit collection at the yield loop (same for weak set/map).
     //      We already indirectly do this for ScriptContext collection.
     //
@@ -3141,7 +3141,7 @@ ThreadContext::CompactInlineCacheList(InlineCacheList* inlineCacheList)
     {
         if (inlineCache == nullptr)
         {
-            iterator.RemoveCurrent(&this->inlineCacheThreadInfoAllocator);
+            iterator.RemoveCurrent();
             cacheCount++;
         }
     }

--- a/lib/Runtime/Base/ThreadContext.h
+++ b/lib/Runtime/Base/ThreadContext.h
@@ -531,8 +531,8 @@ private:
     struct RecyclableData
     {
         RecyclableData(Recycler *const recycler);
-        Field(Js::TempArenaAllocatorObject * ) temporaryArenaAllocators[MaxTemporaryArenaAllocators];
-        Field(Js::TempGuestArenaAllocatorObject * ) temporaryGuestArenaAllocators[MaxTemporaryArenaAllocators];
+        Field(Js::TempArenaAllocatorObject *) temporaryArenaAllocators[MaxTemporaryArenaAllocators];
+        Field(Js::TempGuestArenaAllocatorObject *) temporaryGuestArenaAllocators[MaxTemporaryArenaAllocators];
 
         Field(Js::JavascriptExceptionObject *) exceptionObject;
         Field(bool) propagateException;
@@ -943,7 +943,7 @@ public:
     //Keep track of the number of re-entrant calls currently pending (i.e., if we make an external call it may call back into Chakra)
     int32 TTDRootNestingCount;
 
-    bool IsRuntimeInTTDMode() const 
+    bool IsRuntimeInTTDMode() const
     {
         return this->TTDLog != nullptr;
     }

--- a/lib/Runtime/Base/ThreadContext.h
+++ b/lib/Runtime/Base/ThreadContext.h
@@ -654,7 +654,7 @@ private:
     uint32 polymorphicCacheState;
 
 #ifdef ENABLE_PROJECTION
-    SListBase<ExternalWeakReferenceCache *> externalWeakReferenceCacheList;
+    SListBase<ExternalWeakReferenceCache *, HeapAllocator> externalWeakReferenceCacheList;
 #if DBG_DUMP
     IProjectionContextMemoryInfo *projectionMemoryInformation;
 #endif

--- a/lib/Runtime/Base/Utf8SourceInfo.h
+++ b/lib/Runtime/Base/Utf8SourceInfo.h
@@ -400,7 +400,7 @@ namespace Js
             bool isLibraryCode, Js::Var scriptSource = nullptr);
 
 #ifndef NTBUILD
-        Js::Var sourceRef; // keep source string reference to prevent GC
+        Field(Js::Var) sourceRef; // keep source string reference to prevent GC
 #endif
     };
 }

--- a/lib/Runtime/ByteCode/PropertyIdArray.h
+++ b/lib/Runtime/ByteCode/PropertyIdArray.h
@@ -13,7 +13,7 @@ namespace Js
         Field(bool)   hadDuplicates;
         Field(bool)   has__proto__; // Only used for object literal
         Field(bool)   hasNonSimpleParams;
-        Field(PropertyId ) elements[];
+        Field(PropertyId) elements[];
 
         PropertyIdArray(uint32 count, byte extraSlots, bool hadDuplicates = false, bool has__proto__ = false, bool hasNonSimpleParams = false) :
             count(count),

--- a/lib/Runtime/Debug/TTSupport.h
+++ b/lib/Runtime/Debug/TTSupport.h
@@ -4,7 +4,7 @@
 //-------------------------------------------------------------------------------------------------------
 #pragma once
 
-//This file contains definitions for general-ish purpose structures/algorithms that we use in the TTD system 
+//This file contains definitions for general-ish purpose structures/algorithms that we use in the TTD system
 //We may want to replace them with other versions (e.g. that are already in the codebase) at some later time
 
 #if ENABLE_TTD
@@ -15,7 +15,7 @@ namespace TTD
     class ThreadContextTTD;
     class ScriptContextTTD;
     class RuntimeContextInfo;
-    //We typedef Js::Var into a TTD version that has the same bit layout but we want to avoid confusion  
+    //We typedef Js::Var into a TTD version that has the same bit layout but we want to avoid confusion
     //if this bit layout is for the "live" state or potentially only for the snapshot state or the representations change later
     typedef Js::Var TTDVar;
     namespace NSSnapType
@@ -80,7 +80,7 @@ T* TTD_MEM_ALLOC_CHECK(T* alloc)
 #define TTD_ARRAY_BLOCK_SIZE 0x200
 #define TTD_ARRAY_SMALL_ARRAY 0x100
 
-//Convert from Js::Var to TTDVar 
+//Convert from Js::Var to TTDVar
 #define TTD_CONVERT_JSVAR_TO_TTDVAR(X) ((TTD::TTDVar)(X))
 #define TTD_CONVERT_TTDVAR_TO_JSVAR(X) ((Js::Var)(X))
 
@@ -88,7 +88,7 @@ T* TTD_MEM_ALLOC_CHECK(T* alloc)
 typedef uint64 TTD_PTR_ID;
 #define TTD_INVALID_PTR_ID 0ul
 
-#define TTD_CONVERT_VAR_TO_PTR_ID(X) reinterpret_cast<TTD_PTR_ID>(X)
+#define TTD_CONVERT_VAR_TO_PTR_ID(X) reinterpret_cast<TTD_PTR_ID>(PointerValue(X))
 #define TTD_CONVERT_TYPEINFO_TO_PTR_ID(X) reinterpret_cast<TTD_PTR_ID>(X)
 #define TTD_CONVERT_FUNCTIONBODY_TO_PTR_ID(X) reinterpret_cast<TTD_PTR_ID>(X)
 #define TTD_CONVERT_ENV_TO_PTR_ID(X) reinterpret_cast<TTD_PTR_ID>(X)
@@ -97,7 +97,7 @@ typedef uint64 TTD_PTR_ID;
 #define TTD_CONVERT_DEBUGSCOPE_TO_PTR_ID(X) reinterpret_cast<TTD_PTR_ID>(X)
 
 //Promises have a wide range of heap allocated bits -- we define He-Man casts for all of them -- ugly but so is having a bunch of specific functions
-#define TTD_CONVERT_PROMISE_INFO_TO_PTR_ID(X) reinterpret_cast<TTD_PTR_ID>(X)
+#define TTD_CONVERT_PROMISE_INFO_TO_PTR_ID(X) reinterpret_cast<TTD_PTR_ID>(PointerValue(X))
 #define TTD_CONVERT_PROMISE_INFO_TO_SPECIFIC_TYPE(T, X) static_cast<T*>(X)
 
 #define TTD_COERCE_PTR_ID_TO_VAR(X) (reinterpret_cast<Js::Var>(X))
@@ -250,7 +250,7 @@ namespace TTD
     //A struct that maintains the relation between a globally stable top-level body counter and the PTR id it has in this particular script context
     struct TopLevelFunctionInContextRelation
     {
-        //The globally unique body counter id from the log 
+        //The globally unique body counter id from the log
         uint64 TopLevelBodyCtr;
 
         //The PTR_ID that is used to refer to this top-level body within the given script context
@@ -358,7 +358,7 @@ namespace TTD
     {
     public:
         //Length of the uri data in bytes (including any null terminator)
-        size_t UriByteLength; 
+        size_t UriByteLength;
 
         //Actual URI data which the host is responsible for interpreting (ascii, utf8, wchar, etc.)
         byte* UriBytes;
@@ -661,7 +661,7 @@ namespace TTD
         SlabAllocatorBase(const SlabAllocatorBase&) = delete;
         SlabAllocatorBase& operator=(SlabAllocatorBase const&) = delete;
 
-        //clone a null terminated char16* string (or nullptr) into the allocator -- currently only used for wellknown tokens 
+        //clone a null terminated char16* string (or nullptr) into the allocator -- currently only used for wellknown tokens
         const char16* CopyRawNullTerminatedStringInto(const char16* str)
         {
             if(str == nullptr)
@@ -870,7 +870,7 @@ namespace TTD
             AssertMsg(canUnlink, "Unlink not allowed with this slab allocator.");
             AssertMsg(this->m_reserveActiveBytes == 0, "We don't have anything reserved.");
 
-            //get the meta-data for this allocation and see if it is a 
+            //get the meta-data for this allocation and see if it is a
             byte* realBase = ((byte*)allocation) - canUnlink;
             ptrdiff_t offset = *((ptrdiff_t*)realBase);
 
@@ -1143,7 +1143,7 @@ namespace TTD
 
         //The hash max capcity and data array
         uint32 m_capacity;
-        Entry* m_hashArray; 
+        Entry* m_hashArray;
 
         //Count of elements in the dictionary
         uint32 m_count;
@@ -1331,7 +1331,7 @@ namespace TTD
     class MarkTable
     {
     private:
-        //The addresses and their marks 
+        //The addresses and their marks
         uint64* m_addrArray;
         MarkTableTag* m_markArray;
 

--- a/lib/Runtime/Language/AsmJsTypes.h
+++ b/lib/Runtime/Language/AsmJsTypes.h
@@ -861,23 +861,24 @@ namespace Js
 
     class AsmJsFunctionInfo
     {
-        WAsmJs::TypedSlotInfo mTypedSlotInfos[WAsmJs::LIMIT];
-        ArgSlot mArgCount;
-        AsmJsVarType::Which * mArgType;
-        ArgSlot mArgSizesLength;
-        uint * mArgSizes;
-        ArgSlot mArgByteSize;
-        AsmJsRetType mReturnType;
+        Field(WAsmJs::TypedSlotInfo) mTypedSlotInfos[WAsmJs::LIMIT];
+        Field(ArgSlot) mArgCount;
+        Field(AsmJsVarType::Which *) mArgType;
+        Field(ArgSlot) mArgSizesLength;
+        Field(uint *) mArgSizes;
+        Field(ArgSlot) mArgByteSize;
+        Field(AsmJsRetType) mReturnType;
 #ifdef ENABLE_WASM
         Wasm::WasmSignature * mSignature;
         Wasm::WasmReaderInfo* mWasmReaderInfo;
         WebAssemblyModule* mWasmModule;
 #endif
-        bool mIsHeapBufferConst;
-        bool mUsesHeapBuffer;
+        Field(bool) mIsHeapBufferConst;
+        Field(bool) mUsesHeapBuffer;
 
-        FunctionBody* asmJsModuleFunctionBody;
-        Js::JavascriptError * mLazyError;
+        Field(FunctionBody*) asmJsModuleFunctionBody;
+        Field(Js::JavascriptError *) mLazyError;
+
     public:
         AsmJsFunctionInfo() : mArgCount(0),
                               mArgSizesLength(0),
@@ -896,8 +897,8 @@ namespace Js
                               mArgSizes(nullptr) {}
         // the key is the bytecode address
         typedef JsUtil::BaseDictionary<int, ptrdiff_t, Recycler> ByteCodeToTJMap;
-        ByteCodeToTJMap* mbyteCodeTJMap;
-        BYTE* mTJBeginAddress;
+        Field(ByteCodeToTJMap*) mbyteCodeTJMap;
+        Field(BYTE*) mTJBeginAddress;
         WAsmJs::TypedSlotInfo* GetTypedSlotInfo(WAsmJs::Types type);
 
 #define TYPED_SLOT_INFO_GETTER(name, type) \

--- a/lib/Runtime/Language/DynamicProfileInfo.cpp
+++ b/lib/Runtime/Language/DynamicProfileInfo.cpp
@@ -1614,12 +1614,13 @@ namespace Js
         }
     }
 
-    void DynamicProfileInfo::DumpList(SListBase<DynamicProfileInfo *> * profileInfoList, ArenaAllocator * dynamicProfileInfoAllocator)
+    void DynamicProfileInfo::DumpList(
+        DynamicProfileInfoList * profileInfoList, ArenaAllocator * dynamicProfileInfoAllocator)
     {
         AUTO_NESTED_HANDLED_EXCEPTION_TYPE(ExceptionType_DisableCheck);
         if (Configuration::Global.flags.Dump.IsEnabled(DynamicProfilePhase))
         {
-            FOREACH_SLISTBASE_ENTRY(DynamicProfileInfo *, info, profileInfoList)
+            FOREACH_SLISTBASE_ENTRY(DynamicProfileInfo * const, info, profileInfoList)
             {
                 if (Configuration::Global.flags.Dump.IsEnabled(DynamicProfilePhase, info->GetFunctionBody()->GetSourceContextId(), info->GetFunctionBody()->GetLocalFunctionId()))
                 {
@@ -1631,7 +1632,7 @@ namespace Js
 
         if (Configuration::Global.flags.Dump.IsEnabled(JITLoopBodyPhase) && !Configuration::Global.flags.Dump.IsEnabled(DynamicProfilePhase))
         {
-            FOREACH_SLISTBASE_ENTRY(DynamicProfileInfo *, info, profileInfoList)
+            FOREACH_SLISTBASE_ENTRY(DynamicProfileInfo * const, info, profileInfoList)
             {
                 if (info->functionBody->GetLoopCount() > 0)
                 {
@@ -1652,7 +1653,7 @@ namespace Js
             uint elementAccessSaved = 0;
             uint fldAccessSaved = 0;
 
-            FOREACH_SLISTBASE_ENTRY(DynamicProfileInfo *, info, profileInfoList)
+            FOREACH_SLISTBASE_ENTRY(DynamicProfileInfo * const, info, profileInfoList)
             {
                 bool hasHotLoop = false;
                 if (info->functionBody->DoJITLoopBody())
@@ -2055,8 +2056,8 @@ namespace Js
 
         // That means that the data will never go away, probably not a good policy if this is cached for web page in WININET.
 
-        SListBase<DynamicProfileInfo *> * profileInfoList = scriptContext->GetProfileInfoList();
-        FOREACH_SLISTBASE_ENTRY(DynamicProfileInfo *, info, profileInfoList)
+        DynamicProfileInfoList * profileInfoList = scriptContext->GetProfileInfoList();
+        FOREACH_SLISTBASE_ENTRY(DynamicProfileInfo * const, info, profileInfoList)
         {
             FunctionBody * functionBody = info->GetFunctionBody();
             SourceDynamicProfileManager * sourceDynamicProfileManager = functionBody->GetSourceContextInfo()->sourceDynamicProfileManager;
@@ -2146,7 +2147,7 @@ namespace Js
             });
         }
 
-        FOREACH_SLISTBASE_ENTRY(DynamicProfileInfo *, info, scriptContext->GetProfileInfoList())
+        FOREACH_SLISTBASE_ENTRY(DynamicProfileInfo * const, info, scriptContext->GetProfileInfoList())
         {
             WriteData((byte)1, file);
             WriteData(info->functionBody, file);

--- a/lib/Runtime/Language/DynamicProfileInfo.h
+++ b/lib/Runtime/Language/DynamicProfileInfo.h
@@ -318,6 +318,9 @@ namespace Js
         static byte const NotNativeFloatBit = 2;
     };
 
+    class DynamicProfileInfo;
+    typedef SListBase<DynamicProfileInfo*, Recycler> DynamicProfileInfoList;
+
     class DynamicProfileInfo
     {
     public:
@@ -527,7 +530,7 @@ namespace Js
 #endif
         static JavascriptMethod EnsureDynamicProfileInfo(Js::ScriptFunction * function);
 #if DBG_DUMP
-        static void DumpList(SListBase<DynamicProfileInfo *> * profileInfoList, ArenaAllocator * dynamicProfileInfoAllocator);
+        static void DumpList(DynamicProfileInfoList * profileInfoList, ArenaAllocator * dynamicProfileInfoAllocator);
         static void DumpProfiledValue(char16 const * name, uint * value, uint count);
         static void DumpProfiledValue(char16 const * name, ValueType * value, uint count);
         static void DumpProfiledValue(char16 const * name, CallSiteInfo * callSiteInfo, uint count);

--- a/lib/Runtime/Language/FunctionCodeGenJitTimeData.h
+++ b/lib/Runtime/Language/FunctionCodeGenJitTimeData.h
@@ -71,8 +71,8 @@ namespace Js
     public:
         Field(BVFixed *) inlineesBv;
 
-        Js::PropertyId* sharedPropertyGuards;
-        uint sharedPropertyGuardCount;
+        Field(Js::PropertyId*) sharedPropertyGuards;
+        Field(uint) sharedPropertyGuardCount;
 
         FunctionInfo *GetFunctionInfo() const;
         FunctionBody *GetFunctionBody() const;

--- a/lib/Runtime/Library/ArgumentsObject.cpp
+++ b/lib/Runtime/Library/ArgumentsObject.cpp
@@ -309,7 +309,8 @@ namespace Js
         }
         else
         {
-            argsInfo->FrameObject = TTD_CONVERT_VAR_TO_PTR_ID(this->frameObject);
+            argsInfo->FrameObject = TTD_CONVERT_VAR_TO_PTR_ID(
+                static_cast<ActivationObject*>(this->frameObject));
 
             //Primitive kinds always inflated first so we only need to deal with complex kinds as depends on
             if(TTD::JsSupport::IsVarComplexKind(this->frameObject))

--- a/lib/Runtime/Library/ArgumentsObject.h
+++ b/lib/Runtime/Library/ArgumentsObject.h
@@ -55,15 +55,15 @@ namespace Js
 
     private:
         // We currently support only 2^24 arguments
-        uint32              numOfArguments:31;
-        uint32              callerDeleted:1;
+        Field(uint32)              numOfArguments:31;
+        Field(uint32)              callerDeleted:1;
 
         DEFINE_MARSHAL_OBJECT_TO_SCRIPT_CONTEXT(HeapArgumentsObject);
 
     protected:
-        uint32              formalCount;
-        ActivationObject*   frameObject;
-        BVSparse<Recycler>* deletedArgs;
+        Field(uint32)              formalCount;
+        Field(ActivationObject*)   frameObject;
+        Field(BVSparse<Recycler>*) deletedArgs;
 
     public:
         HeapArgumentsObject(DynamicType * type);

--- a/lib/Runtime/Library/ConcatString.h
+++ b/lib/Runtime/Library/ConcatString.h
@@ -73,7 +73,7 @@ namespace Js
         void SetItem(_In_range_(0, N - 1) int index, JavascriptString* value);
 
     protected:
-        Field(JavascriptString* ) m_slots[N];   // These contain the child nodes. 1 slot is per 1 item (JavascriptString*).
+        Field(JavascriptString*) m_slots[N];   // These contain the child nodes. 1 slot is per 1 item (JavascriptString*).
     };
 
     // Concat string that uses binary tree, each node has 2 children.

--- a/lib/Runtime/Library/DataView.h
+++ b/lib/Runtime/Library/DataView.h
@@ -199,8 +199,8 @@ namespace Js
         template<> void SetValue<double>(uint32 byteOffset, double value, const char16 *funcName, BOOL isLittleEndian /* = FALSE */);
 #endif
 
-        uint32 byteOffset;
-        BYTE* buffer;   // beginning of buffer
+        Field(uint32) byteOffset;
+        Field(BYTE*) buffer;   // beginning of buffer
 
     };
 }

--- a/lib/Runtime/Library/ForInObjectEnumerator.h
+++ b/lib/Runtime/Library/ForInObjectEnumerator.h
@@ -13,10 +13,12 @@ namespace Js
         struct ShadowData
         {
             ShadowData(RecyclableObject * initObject, RecyclableObject * firstPrototype, Recycler * recycler);
+
             Field(RecyclableObject *) currentObject;
             Field(RecyclableObject *) firstPrototype;
             Field(BVSparse<Recycler>) propertyIds;
-            Field(SListBase<Js::PropertyRecord const *, Recycler>) newPropertyStrings;
+            typedef SListBase<Js::PropertyRecord const *, Recycler> _PropertyStringsListType;
+            Field(_PropertyStringsListType) newPropertyStrings;
         } *shadowData;
 
         // States

--- a/lib/Runtime/Library/ForInObjectEnumerator.h
+++ b/lib/Runtime/Library/ForInObjectEnumerator.h
@@ -16,7 +16,7 @@ namespace Js
             Field(RecyclableObject *) currentObject;
             Field(RecyclableObject *) firstPrototype;
             Field(BVSparse<Recycler>) propertyIds;
-            Field(SListBase<Js::PropertyRecord const *>) newPropertyStrings;
+            Field(SListBase<Js::PropertyRecord const *, Recycler>) newPropertyStrings;
         } *shadowData;
 
         // States

--- a/lib/Runtime/Library/JavascriptArray.cpp
+++ b/lib/Runtime/Library/JavascriptArray.cpp
@@ -158,7 +158,7 @@ namespace Js
 
             if (node->IsLeaf())
             {
-                matchOrNext = (i == 0 ? node->segments[0] : prev->next);
+                matchOrNext = (i == 0 ? node->segments[0] : PointerValue(prev->next));
             }
             else
             {
@@ -266,8 +266,8 @@ namespace Js
                 newNode.children[j] = child->children[j+MinDegree];
 
                 // Do not leave false positive references around in the b-tree
-                child->children[j+MinDegree].segments = NULL;
-                child->children[j+MinDegree].children = NULL;
+                child->children[j+MinDegree].segments = nullptr;
+                child->children[j+MinDegree].children = nullptr;
             }
         }
         child->segmentCount = MinKeys;
@@ -407,7 +407,7 @@ namespace Js
         Var fill = Js::JavascriptArray::MissingItem;
         for (uint i = 0; i < size; i++)
         {
-            ((SparseArraySegment<Var>*)head)->elements[i] = fill;
+            SparseArraySegment<Var>::From(head)->elements[i] = fill;
         }
     }
 
@@ -425,7 +425,7 @@ namespace Js
     {
         SetHeadAndLastUsedSegment(DetermineInlineHeadSegmentPointer<JavascriptNativeIntArray, 0, false>(this));
         head->size = size;
-        ((SparseArraySegment<int32>*)head)->FillSegmentBuffer(0, size);
+        SparseArraySegment<int32>::From(head)->FillSegmentBuffer(0, size);
     }
 
     JavascriptNativeFloatArray::JavascriptNativeFloatArray(uint32 length, uint32 size, DynamicType * type)
@@ -442,7 +442,7 @@ namespace Js
     {
         SetHeadAndLastUsedSegment(DetermineInlineHeadSegmentPointer<JavascriptNativeFloatArray, 0, false>(this));
         head->size = size;
-        ((SparseArraySegment<double>*)head)->FillSegmentBuffer(0, size);
+        SparseArraySegment<double>::From(head)->FillSegmentBuffer(0, size);
     }
 
     bool JavascriptArray::Is(Var aValue)
@@ -673,7 +673,7 @@ namespace Js
     {
         Assert(index < head->length);
 
-        return SparseArraySegment<T>::IsMissingItem(&static_cast<SparseArraySegment<T> *>(head)->elements[index]);
+        return SparseArraySegment<T>::IsMissingItem(&SparseArraySegment<T>::From(head)->elements[index]);
     }
 
     bool JavascriptArray::IsMissingHeadSegmentItem(const uint32 index) const
@@ -769,7 +769,7 @@ namespace Js
         // Called only to create array literals: size is known.
         JavascriptArray *arr = scriptContext->GetLibrary()->CreateArrayLiteral(elementCount);
 
-        SparseArraySegment<Var> *head = (SparseArraySegment<Var>*)arr->head;
+        SparseArraySegment<Var> *head = SparseArraySegment<Var>::From(arr->head);
         Assert(elementCount <= head->length);
         CopyArray(head->elements, head->length, elements, elementCount);
 
@@ -785,7 +785,7 @@ namespace Js
         // Called only to create array literals: size is known.
         JavascriptArray *const array = static_cast<JavascriptArray *>(OP_NewScArray(elementCount, scriptContext));
         array->SetHasNoMissingValues(false);
-        SparseArraySegment<Var> *head = (SparseArraySegment<Var>*)array->head;
+        SparseArraySegment<Var> *head = SparseArraySegment<Var>::From(array->head);
         head->FillSegmentBuffer(0, elementCount);
 
         return array;
@@ -816,7 +816,7 @@ namespace Js
     {
         uint32 count = ints->count;
         JavascriptArray *arr = scriptContext->GetLibrary()->CreateArrayLiteral(count);
-        SparseArraySegment<Var> *head = (SparseArraySegment<Var>*)arr->head;
+        SparseArraySegment<Var> *head = SparseArraySegment<Var>::From(arr->head);
         Assert(count > 0 && count == head->length);
         for (uint i = 0; i < count; i++)
         {
@@ -848,7 +848,7 @@ namespace Js
 #endif
             {
                 arr = scriptContext->GetLibrary()->CreateNativeIntArrayLiteral(count);
-                SparseArraySegment<int32> *head = static_cast<SparseArraySegment<int32>*>(arr->head);
+                SparseArraySegment<int32> *head = SparseArraySegment<int32>::From(arr->head);
                 Assert(count > 0 && count == head->length);
                 CopyArray(head->elements, head->length, ints->elements, count);
             }
@@ -861,7 +861,7 @@ namespace Js
         if (arrayInfo->IsNativeFloatArray())
         {
             JavascriptNativeFloatArray *arr = scriptContext->GetLibrary()->CreateNativeFloatArrayLiteral(count);
-            SparseArraySegment<double> *head = (SparseArraySegment<double>*)arr->head;
+            SparseArraySegment<double> *head = SparseArraySegment<double>::From(arr->head);
             Assert(count > 0 && count == head->length);
             for (uint i = 0; i < count; i++)
             {
@@ -880,7 +880,7 @@ namespace Js
     {
         uint32 count = doubles->count;
         JavascriptArray *arr = scriptContext->GetLibrary()->CreateArrayLiteral(count);
-        SparseArraySegment<Var> *head = (SparseArraySegment<Var>*)arr->head;
+        SparseArraySegment<Var> *head = SparseArraySegment<Var>::From(arr->head);
         Assert(count > 0 && count == head->length);
         for (uint i = 0; i < count; i++)
         {
@@ -907,7 +907,7 @@ namespace Js
             arrayInfo->SetIsNotNativeIntArray();
             uint32 count = doubles->count;
             JavascriptNativeFloatArray *arr = scriptContext->GetLibrary()->CreateNativeFloatArrayLiteral(count);
-            SparseArraySegment<double> *head = (SparseArraySegment<double>*)arr->head;
+            SparseArraySegment<double> *head = SparseArraySegment<double>::From(arr->head);
             Assert(count > 0 && count == head->length);
             CopyArray(head->elements, head->length, doubles->elements, count);
             arr->SetArrayProfileInfo(weakFuncRef, arrayInfo);
@@ -2279,7 +2279,7 @@ namespace Js
     template<typename T>
     void JavascriptArray::SetArrayLiteralItem(uint32 index, T value)
     {
-        SparseArraySegment<T> * segment = (SparseArraySegment<T>*)this->head;
+        SparseArraySegment<T> * segment = SparseArraySegment<T>::From(this->head);
 
         Assert(segment->left == 0);
         Assert(index < segment->length);
@@ -2543,7 +2543,7 @@ namespace Js
         SegmentBTreeRoot * segmentMap = GetSegmentMap();
         if(!useSegmentMap || !segmentMap)
         {
-            return seg ? seg : this->head;
+            return seg ? seg : PointerValue(this->head);
         }
 
         if(seg)
@@ -2611,7 +2611,7 @@ namespace Js
                     }
                 }
             }
-            current = (SparseArraySegment<T>*)current->next;
+            current = SparseArraySegment<T>::From(current->next);
             if (current != NULL)
             {
                 if (candidateIndex < current->left)
@@ -2658,7 +2658,7 @@ namespace Js
             // 5 <=
 
             SparseArraySegmentBase* next = GetBeginLookupSegment(newLength - 1); // head, or next.left < newLength
-            SparseArraySegmentBase** prev = &head;
+            Field(SparseArraySegmentBase*)* prev = AddressOf(head);
 
             while(next != nullptr)
             {
@@ -2683,7 +2683,7 @@ namespace Js
                 }
                 else
                 {
-                    prev = &next->next;
+                    prev = AddressOf(next->next);
                     next = next->next;
                 }
             }
@@ -2877,7 +2877,7 @@ namespace Js
                 }
                 break;
             }
-            next = (SparseArraySegment<T>*)next->next;
+            next = SparseArraySegment<T>::From(next->next);
         }
 #ifdef VALIDATE_ARRAY
         ValidateArray();
@@ -5278,7 +5278,7 @@ Case0:
             {
                 if (pArr->head && pArr->head->next && SparseArraySegmentBase::IsLeafSegment(pArr->head, recycler))
                 {
-                    pArr->ReallocNonLeafSegment((SparseArraySegment<int32>*)pArr->head, pArr->head->next);
+                    pArr->ReallocNonLeafSegment(SparseArraySegment<int32>::From(pArr->head), pArr->head->next);
                 }
                 pArr->EnsureHeadStartsFromZero<int32>(recycler);
             }
@@ -5286,7 +5286,7 @@ Case0:
             {
                 if (pArr->head && pArr->head->next && SparseArraySegmentBase::IsLeafSegment(pArr->head, recycler))
                 {
-                    pArr->ReallocNonLeafSegment((SparseArraySegment<double>*)pArr->head, pArr->head->next);
+                    pArr->ReallocNonLeafSegment(SparseArraySegment<double>::From(pArr->head), pArr->head->next);
                 }
                 pArr->EnsureHeadStartsFromZero<double>(recycler);
             }
@@ -5406,21 +5406,21 @@ Case0:
     {
         Recycler * recycler = scriptContext->GetRecycler();
 
-        SparseArraySegment<T>* next = (SparseArraySegment<T>*)pArr->head->next;
+        SparseArraySegment<T>* next = SparseArraySegment<T>::From(pArr->head->next);
         while (next)
         {
             next->left--;
-            next = (SparseArraySegment<T>*)next->next;
+            next = SparseArraySegment<T>::From(next->next);
         }
 
         // head and next might overlap as the next segment left is decremented
-        next = (SparseArraySegment<T>*)pArr->head->next;
+        next = SparseArraySegment<T>::From(pArr->head->next);
         if (next && (pArr->head->size > next->left))
         {
             AssertMsg(pArr->head->left == 0, "Array always points to a head starting at index 0");
             AssertMsg(pArr->head->size == next->left + 1, "Shift next->left overlaps current segment by more than 1 element");
 
-            SparseArraySegment<T> *head = (SparseArraySegment<T>*)pArr->head;
+            SparseArraySegment<T> *head = SparseArraySegment<T>::From(pArr->head);
             // Merge the two adjacent segments
             if (next->length != 0)
             {
@@ -5524,7 +5524,7 @@ Case0:
             {
                 if(isIntArray)
                 {
-                    int32 nativeResult = ((SparseArraySegment<int32>*)pArr->head)->GetElement(0);
+                    int32 nativeResult = SparseArraySegment<int32>::From(pArr->head)->GetElement(0);
 
                     if(SparseArraySegment<int32>::IsMissingItem(&nativeResult))
                     {
@@ -5534,11 +5534,11 @@ Case0:
                     {
                         res = Js::JavascriptNumber::ToVar(nativeResult, scriptContext);
                     }
-                    ((SparseArraySegment<int32>*)pArr->head)->RemoveElement(recycler, 0);
+                    SparseArraySegment<int32>::From(pArr->head)->RemoveElement(recycler, 0);
                 }
                 else if (isFloatArray)
                 {
-                    double nativeResult = ((SparseArraySegment<double>*)pArr->head)->GetElement(0);
+                    double nativeResult = SparseArraySegment<double>::From(pArr->head)->GetElement(0);
 
                     if(SparseArraySegment<double>::IsMissingItem(&nativeResult))
                     {
@@ -5548,11 +5548,11 @@ Case0:
                     {
                         res = Js::JavascriptNumber::ToVarNoCheck(nativeResult, scriptContext);
                     }
-                    ((SparseArraySegment<double>*)pArr->head)->RemoveElement(recycler, 0);
+                    SparseArraySegment<double>::From(pArr->head)->RemoveElement(recycler, 0);
                 }
                 else
                 {
-                    res = ((SparseArraySegment<Var>*)pArr->head)->GetElement(0);
+                    res = SparseArraySegment<Var>::From(pArr->head)->GetElement(0);
 
                     if(SparseArraySegment<Var>::IsMissingItem(&res))
                     {
@@ -5562,7 +5562,7 @@ Case0:
                     {
                         res = CrossSite::MarshalVar(scriptContext, res);
                     }
-                    ((SparseArraySegment<Var>*)pArr->head)->RemoveElement(recycler, 0);
+                    SparseArraySegment<Var>::From(pArr->head)->RemoveElement(recycler, 0);
                 }
             }
 
@@ -5684,8 +5684,8 @@ Case0:
     template<typename T>
     void JavascriptArray::SliceHelper(JavascriptArray* pArr,  JavascriptArray* pnewArr, uint32 start, uint32 newLen)
     {
-        SparseArraySegment<T>* headSeg = (SparseArraySegment<T>*)pArr->head;
-        SparseArraySegment<T>* pnewHeadSeg = (SparseArraySegment<T>*)pnewArr->head;
+        SparseArraySegment<T>* headSeg = SparseArraySegment<T>::From(pArr->head);
+        SparseArraySegment<T>* pnewHeadSeg = SparseArraySegment<T>::From(pnewArr->head);
 
         // Fill the newly created sliced array
         CopyArray(pnewHeadSeg->elements, newLen, headSeg->elements + start, newLen);
@@ -6223,7 +6223,7 @@ Case0:
         ClearSegmentMap();
 
         uint32 countUndefined = 0;
-        SparseArraySegment<Var>* startSeg = (SparseArraySegment<Var>*)head;
+        SparseArraySegment<Var>* startSeg = SparseArraySegment<Var>::From(head);
 
         // Sort may have side effects on the array. Setting a dummy head so that original array is not affected
         uint32 saveLength = length;
@@ -6267,7 +6267,7 @@ Case0:
                     {
                         allElements = SparseArraySegment<Var>::CopySegment(recycler, allElements, nextIndex, next, next->left, next->length);
                     }
-                    next = (SparseArraySegment<Var>*)next->next;
+                    next = SparseArraySegment<Var>::From(next->next);
                     nextIndex = allElements->length;
 
 #ifdef VALIDATE_ARRAY
@@ -6305,7 +6305,7 @@ Case0:
             uint32 index = head->length - 1;
             while (countNull < head->length)
             {
-                if (((SparseArraySegment<Var>*)head)->elements[index] != NULL)
+                if (SparseArraySegment<Var>::From(head)->elements[index] != NULL)
                 {
                     break;
                 }
@@ -6322,13 +6322,13 @@ Case0:
             uint32 newLength = head->length + countUndefined;
             if (newLength > head->size)
             {
-                head = ((SparseArraySegment<Var>*)head)->GrowByMin(recycler, newLength - head->size);
+                head = SparseArraySegment<Var>::From(head)->GrowByMin(recycler, newLength - head->size);
             }
 
             Var undefined = scriptContext->GetLibrary()->GetUndefined();
             for (uint32 i = head->length; i < newLength; i++)
             {
-                ((SparseArraySegment<Var>*)head)->elements[i] = undefined;
+                SparseArraySegment<Var>::From(head)->elements[i] = undefined;
             }
             head->length = newLength;
         }
@@ -6524,8 +6524,8 @@ Case0:
                     uint32 removeIndex = sortArray->head->length;
                     for (uint32 i = 0; i < removeIndex; i++)
                     {
-                        AssertMsg(!SparseArraySegment<Var>::IsMissingItem(&((SparseArraySegment<Var>*)sortArray->head)->elements[i]), "No gaps expected in sorted array");
-                        h.ThrowTypeErrorOnFailure(JavascriptOperators::SetItem(pObj, pObj, i, ((SparseArraySegment<Var>*)sortArray->head)->elements[i], scriptContext));
+                        AssertMsg(!SparseArraySegment<Var>::IsMissingItem(&SparseArraySegment<Var>::From(sortArray->head)->elements[i]), "No gaps expected in sorted array");
+                        h.ThrowTypeErrorOnFailure(JavascriptOperators::SetItem(pObj, pObj, i, SparseArraySegment<Var>::From(sortArray->head)->elements[i], scriptContext));
                     }
                     for (int i = 0; i < indexList->Count(); i++)
                     {
@@ -6747,15 +6747,15 @@ Case0:
                 {
                     if (isIntArray)
                     {
-                        ArraySegmentSpliceHelper<int32>(newArr, (SparseArraySegment<int32>*)pArr->head, (SparseArraySegment<int32>**)&pArr->head, start, deleteLen, insertArgs, insertLen, recycler);
+                        ArraySegmentSpliceHelper<int32>(newArr, SparseArraySegment<int32>::From(pArr->head), (SparseArraySegment<int32>**)AddressOf(pArr->head), start, deleteLen, insertArgs, insertLen, recycler);
                     }
                     else if (isFloatArray)
                     {
-                        ArraySegmentSpliceHelper<double>(newArr, (SparseArraySegment<double>*)pArr->head, (SparseArraySegment<double>**)&pArr->head, start, deleteLen, insertArgs, insertLen, recycler);
+                        ArraySegmentSpliceHelper<double>(newArr, SparseArraySegment<double>::From(pArr->head), (SparseArraySegment<double>**)AddressOf(pArr->head), start, deleteLen, insertArgs, insertLen, recycler);
                     }
                     else
                     {
-                        ArraySegmentSpliceHelper<Var>(newArr, (SparseArraySegment<Var>*)pArr->head, (SparseArraySegment<Var>**)&pArr->head, start, deleteLen, insertArgs, insertLen, recycler);
+                        ArraySegmentSpliceHelper<Var>(newArr, SparseArraySegment<Var>::From(pArr->head), (SparseArraySegment<Var>**)AddressOf(pArr->head), start, deleteLen, insertArgs, insertLen, recycler);
                     }
 
                     // Since the start index is within the bounds of the original array's head segment, it will not acquire any new
@@ -6874,7 +6874,7 @@ Case0:
         if (headDeleteLen != 0)
         {
             pnewArr->InvalidateLastUsedSegment();
-            pnewArr->head = SparseArraySegment<T>::CopySegment(recycler, (SparseArraySegment<T>*)pnewArr->head, 0, seg, start, headDeleteLen);
+            pnewArr->head = SparseArraySegment<T>::CopySegment(recycler, SparseArraySegment<T>::From(pnewArr->head), 0, seg, start, headDeleteLen);
         }
 
         if (newHeadLen != 0)
@@ -6922,7 +6922,7 @@ Case0:
         }
         else
         {
-            *prev = (SparseArraySegment<T>*)seg->next;
+            *prev = SparseArraySegment<T>::From(seg->next);
         }
     }
 
@@ -6932,13 +6932,13 @@ Case0:
         // Skip pnewArr->EnsureHead(): we don't use existing segment at all.
         Recycler *recycler  = scriptContext->GetRecycler();
 
-        SparseArraySegmentBase** prevSeg  = &pArr->head;        // holds the next pointer of previous
-        SparseArraySegmentBase** prevPrevSeg  = &pArr->head;    // this holds the previous pointer to prevSeg dirty trick.
+        Field(SparseArraySegmentBase*)* prevSeg  = AddressOf(pArr->head);        // holds the next pointer of previous
+        Field(SparseArraySegmentBase*)* prevPrevSeg  = AddressOf(pArr->head);    // this holds the previous pointer to prevSeg dirty trick.
         SparseArraySegmentBase* savePrev = nullptr;
 
         Assert(pArr->head); // We should never have a null head.
         pArr->EnsureHead<T>();
-        SparseArraySegment<T>* startSeg = (SparseArraySegment<T>*)pArr->head;
+        SparseArraySegment<T>* startSeg = SparseArraySegment<T>::From(pArr->head);
 
         const uint32 limit = start + deleteLen;
         uint32 rightLimit;
@@ -6952,8 +6952,8 @@ Case0:
         {
             savePrev = startSeg;
             prevPrevSeg = prevSeg;
-            prevSeg = &startSeg->next;
-            startSeg = (SparseArraySegment<T>*)startSeg->next;
+            prevSeg = AddressOf(startSeg->next);
+            startSeg = SparseArraySegment<T>::From(startSeg->next);
 
             if (startSeg)
             {
@@ -7019,7 +7019,7 @@ Case0:
             else
             {
                 SparseArraySegment<T>* newHeadSeg = nullptr; // pnewArr->head is null
-                SparseArraySegmentBase** prevNewHeadSeg = &(pnewArr->head);
+                Field(SparseArraySegmentBase*)* prevNewHeadSeg = AddressOf(pnewArr->head);
 
                 // delete till deleteLen and reuse segments for new array if it is possible.
                 // 3 steps -
@@ -7046,13 +7046,13 @@ Case0:
                         newHeadSeg = SparseArraySegment<T>::CopySegment(recycler, newHeadSeg, 0, startSeg, start, headDeleteLen);
                         newHeadSeg->next = nullptr;
                         *prevNewHeadSeg = newHeadSeg;
-                        prevNewHeadSeg = &newHeadSeg->next;
+                        prevNewHeadSeg = AddressOf(newHeadSeg->next);
                         startSeg->Truncate(start);
                     }
                     savePrev = startSeg;
                     prevPrevSeg = prevSeg;
-                    prevSeg = &startSeg->next;
-                    startSeg = (SparseArraySegment<T>*)startSeg->next;
+                    prevSeg = AddressOf(startSeg->next);
+                    startSeg = SparseArraySegment<T>::From(startSeg->next);
                 }
 
                 // Step (2) first we should do a hard copy if we have an inline head Segment
@@ -7073,18 +7073,18 @@ Case0:
                         }
                         newHeadSeg = SparseArraySegment<T>::CopySegment(recycler, newHeadSeg, 0, startSeg, start, headDeleteLen);
                         *prevNewHeadSeg = newHeadSeg;
-                        prevNewHeadSeg = &newHeadSeg->next;
+                        prevNewHeadSeg = AddressOf(newHeadSeg->next);
 
                         // Remove the entire segment from the original array
                         *prevSeg = startSeg->next;
-                        startSeg = (SparseArraySegment<T>*)startSeg->next;
+                        startSeg = SparseArraySegment<T>::From(startSeg->next);
                     }
                     // if we have an inline head segment with 0 elements, remove it
                     else if (startSeg->left == 0 && startSeg->length == 0)
                     {
                         Assert(startSeg->size != 0);
                         *prevSeg = startSeg->next;
-                        startSeg = (SparseArraySegment<T>*)startSeg->next;
+                        startSeg = SparseArraySegment<T>::From(startSeg->next);
                     }
                 }
                 // Step (2) proper
@@ -7097,7 +7097,7 @@ Case0:
                     startSeg->left = startSeg->left - start;
                     startSeg->next = nullptr;
                     *prevNewHeadSeg = startSeg;
-                    prevNewHeadSeg = &startSeg->next;
+                    prevNewHeadSeg = AddressOf(startSeg->next);
 
                     // Remove the entire segment from the original array
                     *prevSeg = temp;
@@ -7116,7 +7116,7 @@ Case0:
 
                     savePrev = pArr->head;
                     prevPrevSeg = prevSeg;
-                    prevSeg = &pArr->head->next;
+                    prevSeg = AddressOf(pArr->head->next);
                     dummyHeadNodeInserted = true;
                 }
 
@@ -7130,7 +7130,7 @@ Case0:
                     newHeadSeg = SparseArraySegment<T>::CopySegment(recycler, newHeadSeg, startSeg->left -  start, startSeg, startSeg->left, headDeleteLen);
                     newHeadSeg->next = nullptr;
                     *prevNewHeadSeg = newHeadSeg;
-                    prevNewHeadSeg = &newHeadSeg->next;
+                    prevNewHeadSeg = AddressOf(newHeadSeg->next);
 
                     // move the last segment
                     MoveArray(startSeg->elements, startSeg->elements + headDeleteLen, startSeg->length - headDeleteLen);
@@ -7146,7 +7146,7 @@ Case0:
                     // Remove the dummy head node to preserve array consistency.
                     pArr->head = startSeg;
                     savePrev = nullptr;
-                    prevSeg = &pArr->head;
+                    prevSeg = AddressOf(pArr->head);
                 }
 
                 while (startSeg)
@@ -7156,7 +7156,7 @@ Case0:
                     {
                         startSeg->EnsureSizeInBound();
                     }
-                    startSeg = (SparseArraySegment<T>*)startSeg->next;
+                    startSeg = SparseArraySegment<T>::From(startSeg->next);
                 }
             }
         }
@@ -7413,11 +7413,11 @@ Case0:
         if (nextToHeadSeg == nullptr)
         {
             pArr->EnsureHead<T>();
-            pArr->head = ((SparseArraySegment<T>*)pArr->head)->GrowByMin(recycler, unshiftElements);
+            pArr->head = SparseArraySegment<T>::From(pArr->head)->GrowByMin(recycler, unshiftElements);
         }
         else
         {
-            pArr->head = ((SparseArraySegment<T>*)pArr->head)->GrowByMinMax(recycler, unshiftElements, ((nextToHeadSeg->left + unshiftElements) - pArr->head->left - pArr->head->size));
+            pArr->head = SparseArraySegment<T>::From(pArr->head)->GrowByMinMax(recycler, unshiftElements, ((nextToHeadSeg->left + unshiftElements) - pArr->head->left - pArr->head->size));
         }
 
     }
@@ -7425,7 +7425,7 @@ Case0:
     template<typename T>
     void JavascriptArray::UnshiftHelper(JavascriptArray* pArr, uint32 unshiftElements, Js::Var * elements)
     {
-        SparseArraySegment<T>* head = (SparseArraySegment<T>*)pArr->head;
+        SparseArraySegment<T>* head = SparseArraySegment<T>::From(pArr->head);
         // Make enough room in the head segment to insert new elements at the front
         MoveArray(head->elements + unshiftElements, head->elements, pArr->head->length);
         uint32 oldHeadLength = head->length;
@@ -10029,7 +10029,7 @@ Case0:
             // some protection here. Save the head and switch this array to EmptySegment. Will be restored
             // correctly if allocating new segment succeeds.
             //
-            SparseArraySegment<T>* savedHead = (SparseArraySegment<T>*)this->head;
+            SparseArraySegment<T>* savedHead = SparseArraySegment<T>::From(this->head);
             SparseArraySegment<T>* savedLastUsedSegment = (SparseArraySegment<T>*)this->GetLastUsedSegment();
             SetHeadAndLastUsedSegment(const_cast<SparseArraySegmentBase*>(EmptySegment));
 
@@ -11172,7 +11172,7 @@ Case0:
         }
         ValidateArrayCommon();
         // Detailed segments validation
-        JavascriptArray::ValidateVarSegment((SparseArraySegment<Var>*)head);
+        JavascriptArray::ValidateVarSegment(SparseArraySegment<Var>::From(head));
     }
 
     void JavascriptNativeIntArray::ValidateArray()
@@ -11194,7 +11194,7 @@ Case0:
         }
         ValidateArrayCommon();
         // Detailed segments validation
-        JavascriptArray::ValidateSegment<int32>((SparseArraySegment<int32>*)head);
+        JavascriptArray::ValidateSegment<int32>(SparseArraySegment<int32>::From(head));
     }
 
     void JavascriptNativeFloatArray::ValidateArray()
@@ -11216,7 +11216,7 @@ Case0:
         }
         ValidateArrayCommon();
         // Detailed segments validation
-        JavascriptArray::ValidateSegment<double>((SparseArraySegment<double>*)head);
+        JavascriptArray::ValidateSegment<double>(SparseArraySegment<double>::From(head));
     }
 
 
@@ -11253,7 +11253,7 @@ Case0:
             }
             ValidateSegment(seg);
 
-            seg = (SparseArraySegment<Var>*)seg->next;
+            seg = SparseArraySegment<Var>::From(seg->next);
         }
     }
 
@@ -11274,7 +11274,7 @@ Case0:
                 i++;
             }
 
-            seg = (SparseArraySegment<T>*)seg->next;
+            seg = SparseArraySegment<T>::From(seg->next);
         }
     }
 #endif
@@ -11300,7 +11300,7 @@ Case0:
     {
         if (boxHead)
         {
-            InitBoxedInlineHeadSegment(DetermineInlineHeadSegmentPointer<JavascriptArray, 0, true>(this), (SparseArraySegment<Var>*)instance->head);
+            InitBoxedInlineHeadSegment(DetermineInlineHeadSegmentPointer<JavascriptArray, 0, true>(this), SparseArraySegment<Var>::From(instance->head));
         }
         else
         {
@@ -11424,7 +11424,7 @@ Case0:
     {
         if (boxHead)
         {
-            InitBoxedInlineHeadSegment(DetermineInlineHeadSegmentPointer<JavascriptNativeIntArray, 0, true>(this), (SparseArraySegment<int>*)instance->head);
+            InitBoxedInlineHeadSegment(DetermineInlineHeadSegmentPointer<JavascriptNativeIntArray, 0, true>(this), SparseArraySegment<int>::From(instance->head));
         }
         else
         {
@@ -11470,7 +11470,7 @@ Case0:
     {
         if (boxHead)
         {
-            InitBoxedInlineHeadSegment(DetermineInlineHeadSegmentPointer<JavascriptNativeFloatArray, 0, true>(this), (SparseArraySegment<double>*)instance->head);
+            InitBoxedInlineHeadSegment(DetermineInlineHeadSegmentPointer<JavascriptNativeFloatArray, 0, true>(this), SparseArraySegment<double>::From(instance->head));
         }
         else
         {

--- a/lib/Runtime/Library/JavascriptArray.h
+++ b/lib/Runtime/Library/JavascriptArray.h
@@ -21,10 +21,10 @@ namespace Js
         // Introduction to Algorithms by Corman, Leiserson, and Rivest.
 
     protected:
-        uint32*              keys;           // keys[i] == segments[i]->left
-        SparseArraySegmentBase** segments;   // Length of segmentCount.
-        SegmentBTree*        children;       // Length of segmentCount+1.
-        uint32               segmentCount;   // number of sparseArray segments in the Node
+        Field(uint32*)              keys;           // keys[i] == segments[i]->left
+        Field(SparseArraySegmentBase**) segments;   // Length of segmentCount.
+        Field(SegmentBTree*)        children;       // Length of segmentCount+1.
+        Field(uint32)               segmentCount;   // number of sparseArray segments in the Node
 
     public:
         static const uint MinDegree = 20; // Degree is the minimum branching factor. (If non-root, and non-leaf.)
@@ -99,16 +99,16 @@ namespace Js
         DEFINE_VTABLE_CTOR(JavascriptArray, ArrayObject);
         DEFINE_MARSHAL_OBJECT_TO_SCRIPT_CONTEXT(JavascriptArray);
     private:
-        bool isInitialized;
+        Field(bool) isInitialized;
     protected:
-        SparseArraySegmentBase* head;
+        Field(SparseArraySegmentBase*) head;
         union SegmentUnionType
         {
             SparseArraySegmentBase* lastUsedSegment;
             SegmentBTreeRoot* segmentBTreeRoot;
         };
         // SWB-TODO: How to handle write barrier inside union?
-        SegmentUnionType segmentUnion;
+        Field(SegmentUnionType) segmentUnion;
     public:
         typedef Var TElement;
 

--- a/lib/Runtime/Library/JavascriptArray.inl
+++ b/lib/Runtime/Library/JavascriptArray.inl
@@ -440,7 +440,7 @@ namespace Js
         const T newValue,
         StElemInfo *const stElemInfo)
     {
-        SparseArraySegment<T> *const seg = (SparseArraySegment<T>*)head;
+        SparseArraySegment<T> *const seg = SparseArraySegment<T>::From(head);
         Assert(seg);
         Assert(offset < seg->size);
         Assert(!(HasNoMissingValues() &&
@@ -650,7 +650,7 @@ SECOND_PASS:
         {
             if (endIndex >= current->left + current->size)
             {
-                current = (SparseArraySegment<T>*)head;
+                current = SparseArraySegment<T>::From(head);
             }
             else
             {
@@ -695,7 +695,7 @@ SECOND_PASS:
                     }
                 }
                 prev = current;
-                current = (SparseArraySegment<T>*)current->next;
+                current = SparseArraySegment<T>::From(current->next);
             }
             if (!startSeg && !endSeg)
             {
@@ -713,7 +713,7 @@ SECOND_PASS:
                 && startIndex - head->size <= MergeSegmentsLengthHeuristics     // Distance to next index is relatively small
                 )
             {
-                current = ((Js::SparseArraySegment<T>*)head)->GrowByMin(recycler, startIndex + length - head->size);
+                current = SparseArraySegment<T>::From(head)->GrowByMin(recycler, startIndex + length - head->size);
                 current->length = endIndex + 1;
                 head = current;
                 SetHasNoMissingValues(false);
@@ -790,7 +790,7 @@ SECOND_PASS:
             {
                 if (startIndex + 1 == startSeg->left && startPrev == head)
                 {
-                    current = ((Js::SparseArraySegment<T>*)head)->GrowByMin(recycler, startIndex + length - head->size);
+                    current = SparseArraySegment<T>::From(head)->GrowByMin(recycler, startIndex + length - head->size);
                     current->length = endIndex + 1;
                     head = current;
                 }
@@ -1026,7 +1026,7 @@ SECOND_PASS:
 
         if (startIndex == 0 && head != EmptySegment && length < head->size)
         {
-            CopyValueToSegmentBuferNoCheck(((Js::SparseArraySegment<T>*)head)->elements, length, newValue);
+            CopyValueToSegmentBuferNoCheck(SparseArraySegment<T>::From(head)->elements, length, newValue);
 
             if (length > this->length)
             {
@@ -1135,7 +1135,7 @@ SECOND_PASS:
         // need the prev
         if (current->left + current->size > current->left || itemIndex >= current->left + current->size)
         {
-            current = (SparseArraySegment<T>*)head;
+            current = SparseArraySegment<T>::From(head);
         }
         SparseArraySegmentBase* prev = nullptr;
 
@@ -1160,7 +1160,7 @@ SECOND_PASS:
                 bool extendPrevSeg = itemIndex <= prevSeg->left + prevSeg->size;
                 if (noExactMatch && extendPrevSeg)
                 {
-                    current = (SparseArraySegment<T>*)head;
+                    current = SparseArraySegment<T>::From(head);
                     prev = nullptr;
                     if (prevSeg != head)
                     {
@@ -1193,7 +1193,7 @@ SECOND_PASS:
             // need the prev
             if (current->left + current->size > current->left || itemIndex >= current->left + current->size)
             {
-                current = (SparseArraySegment<T>*)head;
+                current = SparseArraySegment<T>::From(head);
             }
             prev = nullptr;
         }
@@ -1215,7 +1215,7 @@ SECOND_PASS:
                 }
             }
             prev = current;
-            current = (SparseArraySegment<T>*)current->next;
+            current = SparseArraySegment<T>::From(current->next);
             Assert(segmentMap == GetSegmentMap());
             if (!segmentMap)
             {
@@ -1237,7 +1237,7 @@ SECOND_PASS:
                         bool extendPrevSeg = itemIndex <= prevSeg->left + prevSeg->size;
                         if (noExactMatch && extendPrevSeg)
                         {
-                            current = (SparseArraySegment<T>*)head;
+                            current = SparseArraySegment<T>::From(head);
                             prev = nullptr;
                             if (prevSeg != head)
                             {
@@ -1322,7 +1322,7 @@ SECOND_PASS:
                 //itemIndex is at boundary of current segment either at the left + size or at left - 1;
                 Assert((itemIndex == current->left + current->size) || (itemIndex + 1 == current->left));
 
-                SparseArraySegment<T>* next = (SparseArraySegment<T>*)current->next;
+                SparseArraySegment<T>* next = SparseArraySegment<T>::From(current->next);
 
                 Assert(segmentMap == GetSegmentMap());
                 if (!segmentMap && next != nullptr && (itemIndex + 1) == next->left)
@@ -1393,7 +1393,7 @@ SECOND_PASS:
                 && itemIndex - head->size <= MergeSegmentsLengthHeuristics  // Distance to next index is relatively small
                )
             {
-                current = ((Js::SparseArraySegment<T>*)head)->GrowByMin(recycler, itemIndex + 1 - head->size);
+                current = SparseArraySegment<T>::From(head)->GrowByMin(recycler, itemIndex + 1 - head->size);
                 current->elements[itemIndex] = newValue;
                 current->length =  itemIndex + 1;
 
@@ -1446,7 +1446,7 @@ SECOND_PASS:
         Assert(head);
         Assert(!HasNoMissingValues());
 
-        SparseArraySegment<T> *const segment = (SparseArraySegment<T>*)head;
+        SparseArraySegment<T> *const segment = SparseArraySegment<T>::From(head);
         const uint segmentLength = segment->length;
         const Field(T) * const segmentElements = segment->elements;
         for(uint i = startIndex; i < segmentLength; ++i)
@@ -1466,7 +1466,7 @@ SECOND_PASS:
         Assert(head);
         //Assert(!HasNoMissingValues());
 
-        SparseArraySegment<T> *const segment = (SparseArraySegment<T>*)head;
+        SparseArraySegment<T> *const segment = SparseArraySegment<T>::From(head);
         const Field(T) *const segmentElements = segment->elements;
         for (uint i = startIndex; i < endIndex; ++i)
         {
@@ -1492,7 +1492,7 @@ SECOND_PASS:
     template<typename unitType, typename classname>
     inline BOOL JavascriptArray::TryGrowHeadSegmentAndSetItem(uint32 indexInt, unitType iValue)
     {
-        SparseArraySegment<unitType> *current = (SparseArraySegment<unitType> *)this->head;
+        SparseArraySegment<unitType> *current = SparseArraySegment<unitType>::From(head);
 
         if (indexInt == current->length               // index is at the boundary of size & length
             && current->size                          // Make sure its not empty segment.

--- a/lib/Runtime/Library/JavascriptArrayIterator.h
+++ b/lib/Runtime/Library/JavascriptArrayIterator.h
@@ -16,9 +16,9 @@ namespace Js
     class JavascriptArrayIterator : public DynamicObject
     {
     private:
-        Var                         m_iterableObject;
-        int64                       m_nextIndex;
-        JavascriptArrayIteratorKind m_kind;
+        Field(Var)                         m_iterableObject;
+        Field(int64)                       m_nextIndex;
+        Field(JavascriptArrayIteratorKind) m_kind;
 
     protected:
         DEFINE_VTABLE_CTOR(JavascriptArrayIterator, DynamicObject);

--- a/lib/Runtime/Library/JavascriptBoolean.h
+++ b/lib/Runtime/Library/JavascriptBoolean.h
@@ -9,7 +9,7 @@ namespace Js
     class JavascriptBoolean sealed : public RecyclableObject
     {
     private:
-        BOOL value;
+        Field(BOOL) value;
 
         DEFINE_VTABLE_CTOR(JavascriptBoolean, RecyclableObject);
     public:

--- a/lib/Runtime/Library/JavascriptBooleanObject.h
+++ b/lib/Runtime/Library/JavascriptBooleanObject.h
@@ -9,7 +9,7 @@ namespace Js
     class JavascriptBooleanObject : public DynamicObject
     {
     private:
-        JavascriptBoolean* value;
+        Field(JavascriptBoolean*) value;
 
         DEFINE_VTABLE_CTOR(JavascriptBooleanObject, DynamicObject);
         DEFINE_MARSHAL_OBJECT_TO_SCRIPT_CONTEXT(JavascriptBooleanObject);

--- a/lib/Runtime/Library/JavascriptDate.h
+++ b/lib/Runtime/Library/JavascriptDate.h
@@ -9,7 +9,7 @@ namespace Js
     class JavascriptDate : public DynamicObject
     {
     protected:
-        DateImplementation m_date;
+        Field(DateImplementation) m_date;
 
         DEFINE_VTABLE_CTOR_MEMBER_INIT(JavascriptDate, DynamicObject, m_date);
         DEFINE_MARSHAL_OBJECT_TO_SCRIPT_CONTEXT(JavascriptDate);

--- a/lib/Runtime/Library/JavascriptError.h
+++ b/lib/Runtime/Library/JavascriptError.h
@@ -18,7 +18,7 @@ namespace Js
     private:
         DEFINE_MARSHAL_OBJECT_TO_SCRIPT_CONTEXT(JavascriptError);
 
-        ErrorTypeEnum m_errorType;
+        Field(ErrorTypeEnum) m_errorType;
 
     protected:
         DEFINE_VTABLE_CTOR(JavascriptError, DynamicObject);
@@ -155,11 +155,11 @@ namespace Js
 
     private:
 
-        BOOL isExternalError;
-        BOOL isPrototype;
-        bool isStackPropertyRedefined;
-        char16 const * originalRuntimeErrorMessage;
-        JavascriptExceptionObject *exceptionObject;
+        Field(BOOL) isExternalError;
+        Field(BOOL) isPrototype;
+        Field(bool) isStackPropertyRedefined;
+        Field(char16 const *) originalRuntimeErrorMessage;
+        Field(JavascriptExceptionObject *) exceptionObject;
 
 #ifdef ERROR_TRACE
         static void Trace(const char16 *form, ...) // const

--- a/lib/Runtime/Library/JavascriptExternalFunction.h
+++ b/lib/Runtime/Library/JavascriptExternalFunction.h
@@ -49,26 +49,26 @@ namespace Js
         void SetExternalFlags(UINT64 flags) { this->flags = flags; }
 
     private:
-        Var signature;
-        void *callbackState;
+        Field(Var) signature;
+        Field(void *) callbackState;
         union
         {
             ExternalMethod nativeMethod;
             JavascriptExternalFunction* wrappedMethod;
             StdCallJavascriptMethod stdCallNativeMethod;
         };
-        InitializeMethod initMethod;
+        Field(InitializeMethod) initMethod;
 
         // Ensure GC doesn't pin
-        unsigned int oneBit:1;
+        Field(unsigned int) oneBit:1;
         // Count of type slots for
-        unsigned int typeSlots:15;
+        Field(unsigned int) typeSlots:15;
         // Determines if we need are a dictionary type
-        unsigned int hasAccessors:1;
-        unsigned int unused:15;
+        Field(unsigned int) hasAccessors:1;
+        Field(unsigned int) unused:15;
 
-        JavascriptTypeId prototypeTypeId;
-        UINT64 flags;
+        Field(JavascriptTypeId) prototypeTypeId;
+        Field(UINT64) flags;
 
         static Var ExternalFunctionThunk(RecyclableObject* function, CallInfo callInfo, ...);
         static Var WrappedFunctionThunk(RecyclableObject* function, CallInfo callInfo, ...);

--- a/lib/Runtime/Library/JavascriptFunction.h
+++ b/lib/Runtime/Library/JavascriptFunction.h
@@ -31,11 +31,11 @@ namespace Js
         static PropertyId const specialPropertyIds[];
 
         // Need a constructor cache on every function (script and native) to avoid extra checks on the fast path, if the function isn't fixed.
-        ConstructorCache* constructorCache;
+        Field(ConstructorCache*) constructorCache;
 
     protected:
 
-        FunctionInfo * functionInfo;  // Underlying function
+        Field(FunctionInfo *) functionInfo;  // Underlying function
 
 
         DEFINE_VTABLE_CTOR(JavascriptFunction, DynamicObject);

--- a/lib/Runtime/Library/JavascriptGenerator.h
+++ b/lib/Runtime/Library/JavascriptGenerator.h
@@ -30,10 +30,10 @@ namespace Js
         static uint32 GetArgsPtrOffset() { return offsetof(JavascriptGenerator, args) + Arguments::GetValuesOffset(); }
 
     private:
-        InterpreterStackFrame* frame;
-        GeneratorState state;
-        Arguments args;
-        ScriptFunction* scriptFunction;
+        Field(InterpreterStackFrame*) frame;
+        Field(GeneratorState) state;
+        Field(Arguments) args;
+        Field(ScriptFunction*) scriptFunction;
 
         DEFINE_VTABLE_CTOR_MEMBER_INIT(JavascriptGenerator, DynamicObject, args);
         DEFINE_MARSHAL_OBJECT_TO_SCRIPT_CONTEXT(JavascriptGenerator);

--- a/lib/Runtime/Library/JavascriptGeneratorFunction.h
+++ b/lib/Runtime/Library/JavascriptGeneratorFunction.h
@@ -12,7 +12,7 @@ namespace Js
     {
     private:
         static FunctionInfo functionInfo;
-        GeneratorVirtualScriptFunction* scriptFunction;
+        Field(GeneratorVirtualScriptFunction*) scriptFunction;
 
         bool GetPropertyBuiltIns(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext, BOOL* result);
         bool SetPropertyBuiltIns(PropertyId propertyId, Var value, PropertyOperationFlags flags, PropertyValueInfo* info, BOOL* result);
@@ -108,7 +108,7 @@ namespace Js
         friend class JavascriptGeneratorFunction;
         friend Var Js::JavascriptFunction::NewInstanceHelper(ScriptContext*, RecyclableObject*, CallInfo, ArgumentReader&, Js::JavascriptFunction::FunctionKind);
 
-        JavascriptGeneratorFunction* realFunction;
+        Field(JavascriptGeneratorFunction*) realFunction;
 
         void SetRealGeneratorFunction(JavascriptGeneratorFunction* realFunction) { this->realFunction = realFunction; }
 

--- a/lib/Runtime/Library/JavascriptLibrary.h
+++ b/lib/Runtime/Library/JavascriptLibrary.h
@@ -48,8 +48,8 @@ namespace Js
     struct CacheForCopyOnAccessArraySegments
     {
         static const uint32 MAX_SIZE = 31;
-        SparseArraySegment<int32> *cache[MAX_SIZE];
-        uint32 count;
+        Field(SparseArraySegment<int32> *) cache[MAX_SIZE];
+        Field(uint32) count;
 
         uint32 AddSegment(SparseArraySegment<int32> *segment)
         {
@@ -226,9 +226,9 @@ namespace Js
         Field(DynamicType *) promiseType;
         Field(DynamicType *) listIteratorType;
 
-        Field(JavascriptFunction* ) builtinFunctions[BuiltinFunction::Count];
+        Field(JavascriptFunction*) builtinFunctions[BuiltinFunction::Count];
 
-        Field(INT_PTR ) vtableAddresses[VTableValue::Count];
+        Field(INT_PTR) vtableAddresses[VTableValue::Count];
         Field(ConstructorCache *) constructorCacheDefaultInstance;
         __declspec(align(16)) Field(const BYTE *) absDoubleCst;
         Field(double const *) uintConvertConst;
@@ -258,16 +258,16 @@ namespace Js
         Field(DynamicType *) syntaxErrorType;
         Field(DynamicType *) typeErrorType;
         Field(DynamicType *) uriErrorType;
-        DynamicType * webAssemblyCompileErrorType;
-        DynamicType * webAssemblyRuntimeErrorType;
+        Field(DynamicType *) webAssemblyCompileErrorType;
+        Field(DynamicType *) webAssemblyRuntimeErrorType;
         Field(StaticType  *) numberTypeStatic;
         Field(StaticType  *) int64NumberTypeStatic;
         Field(StaticType  *) uint64NumberTypeStatic;
 
-        DynamicType * webAssemblyModuleType;
-        DynamicType * webAssemblyInstanceType;
-        DynamicType * webAssemblyMemoryType;
-        DynamicType * webAssemblyTableType;
+        Field(DynamicType *) webAssemblyModuleType;
+        Field(DynamicType *) webAssemblyInstanceType;
+        Field(DynamicType *) webAssemblyMemoryType;
+        Field(DynamicType *) webAssemblyTableType;
 
         // SIMD_JS
         Field(DynamicType *) simdBool8x16TypeDynamic;
@@ -294,8 +294,8 @@ namespace Js
         Field(StaticType *) simdUint8x16TypeStatic;
 
         Field(DynamicType *) numberTypeDynamic;
-        Field(DynamicType * ) objectTypes[PreInitializedObjectTypeCount];
-        Field(DynamicType * ) objectHeaderInlinedTypes[PreInitializedObjectTypeCount];
+        Field(DynamicType *) objectTypes[PreInitializedObjectTypeCount];
+        Field(DynamicType *) objectHeaderInlinedTypes[PreInitializedObjectTypeCount];
         Field(DynamicType *) regexPrototypeType;
         Field(DynamicType *) regexType;
         Field(DynamicType *) regexResultType;
@@ -420,19 +420,19 @@ namespace Js
         Field(DynamicObject*) sharedArrayBufferPrototype;
         Field(DynamicObject*) atomicsObject;
 
-        DynamicObject* webAssemblyCompileErrorPrototype;
-        RuntimeFunction* webAssemblyCompileErrorConstructor;
-        DynamicObject* webAssemblyRuntimeErrorPrototype;
-        RuntimeFunction* webAssemblyRuntimeErrorConstructor;
+        Field(DynamicObject*) webAssemblyCompileErrorPrototype;
+        Field(RuntimeFunction*) webAssemblyCompileErrorConstructor;
+        Field(DynamicObject*) webAssemblyRuntimeErrorPrototype;
+        Field(RuntimeFunction*) webAssemblyRuntimeErrorConstructor;
 
-        DynamicObject* webAssemblyMemoryPrototype;
-        RuntimeFunction* webAssemblyMemoryConstructor;
-        DynamicObject* webAssemblyModulePrototype;
-        RuntimeFunction* webAssemblyModuleConstructor;
-        DynamicObject* webAssemblyInstancePrototype;
-        RuntimeFunction* webAssemblyInstanceConstructor;
-        DynamicObject* webAssemblyTablePrototype;
-        RuntimeFunction* webAssemblyTableConstructor;
+        Field(DynamicObject*) webAssemblyMemoryPrototype;
+        Field(RuntimeFunction*) webAssemblyMemoryConstructor;
+        Field(DynamicObject*) webAssemblyModulePrototype;
+        Field(RuntimeFunction*) webAssemblyModuleConstructor;
+        Field(DynamicObject*) webAssemblyInstancePrototype;
+        Field(RuntimeFunction*) webAssemblyInstanceConstructor;
+        Field(DynamicObject*) webAssemblyTablePrototype;
+        Field(RuntimeFunction*) webAssemblyTableConstructor;
 
         Field(int) regexConstructorSlotIndex;
         Field(int) regexExecSlotIndex;

--- a/lib/Runtime/Library/JavascriptListIterator.h
+++ b/lib/Runtime/Library/JavascriptListIterator.h
@@ -9,9 +9,9 @@ namespace Js
     class JavascriptListIterator : public DynamicObject
     {
     private:
-        ListForListIterator* listForIterator;
-        uint index;
-        uint count;
+        Field(ListForListIterator*) listForIterator;
+        Field(uint) index;
+        Field(uint) count;
 
     protected:
         DEFINE_VTABLE_CTOR(JavascriptListIterator, DynamicObject);

--- a/lib/Runtime/Library/JavascriptMap.h
+++ b/lib/Runtime/Library/JavascriptMap.h
@@ -15,8 +15,8 @@ namespace Js
         typedef JsUtil::BaseDictionary<Var, MapDataNode*, Recycler, PowerOf2SizePolicy, SameValueZeroComparer> MapDataMap;
 
     private:
-        MapDataList list;
-        MapDataMap* map;
+        Field(MapDataList) list;
+        Field(MapDataMap*) map;
 
         DEFINE_VTABLE_CTOR_MEMBER_INIT(JavascriptMap, DynamicObject, list);
         DEFINE_MARSHAL_OBJECT_TO_SCRIPT_CONTEXT(JavascriptMap);

--- a/lib/Runtime/Library/JavascriptMapIterator.h
+++ b/lib/Runtime/Library/JavascriptMapIterator.h
@@ -16,9 +16,9 @@ namespace Js
     class JavascriptMapIterator : public DynamicObject
     {
     private:
-        JavascriptMap*                          m_map;
-        JavascriptMap::MapDataList::Iterator    m_mapIterator;
-        JavascriptMapIteratorKind               m_kind;
+        Field(JavascriptMap*)                          m_map;
+        Field(JavascriptMap::MapDataList::Iterator)    m_mapIterator;
+        Field(JavascriptMapIteratorKind)               m_kind;
 
     protected:
         DEFINE_VTABLE_CTOR(JavascriptMapIterator, DynamicObject);

--- a/lib/Runtime/Library/JavascriptNumberObject.h
+++ b/lib/Runtime/Library/JavascriptNumberObject.h
@@ -9,7 +9,7 @@ namespace Js
     class JavascriptNumberObject : public DynamicObject
     {
     private:
-        Var value;
+        Field(Var) value;
 
         DEFINE_VTABLE_CTOR(JavascriptNumberObject, DynamicObject);
         DEFINE_MARSHAL_OBJECT_TO_SCRIPT_CONTEXT(JavascriptNumberObject);

--- a/lib/Runtime/Library/JavascriptPromise.h
+++ b/lib/Runtime/Library/JavascriptPromise.h
@@ -8,7 +8,7 @@ namespace Js
 {
     struct JavascriptPromiseResolveOrRejectFunctionAlreadyResolvedWrapper
     {
-        bool alreadyResolved;
+        Field(bool) alreadyResolved;
     };
 
     class JavascriptPromiseResolveOrRejectFunction : public RuntimeFunction
@@ -30,9 +30,9 @@ namespace Js
         void SetAlreadyResolved(bool is);
 
     private:
-        JavascriptPromise* promise;
-        bool isReject;
-        JavascriptPromiseResolveOrRejectFunctionAlreadyResolvedWrapper* alreadyResolvedWrapper;
+        Field(JavascriptPromise*) promise;
+        Field(bool) isReject;
+        Field(JavascriptPromiseResolveOrRejectFunctionAlreadyResolvedWrapper*) alreadyResolvedWrapper;
 
 #if ENABLE_TTD
     public:
@@ -59,8 +59,8 @@ namespace Js
         Var GetTarget();
 
     private:
-        JavascriptGenerator* generator;
-        Var target; // this
+        Field(JavascriptGenerator*) generator;
+        Field(Var) target; // this
 
 #if ENABLE_TTD
     public:
@@ -90,11 +90,11 @@ namespace Js
         Var GetArgument();
 
     private:
-        JavascriptGenerator* generator;
-        JavascriptFunction* reject;
-        JavascriptFunction* resolve;
-        bool isReject;
-        Var argument;
+        Field(JavascriptGenerator*) generator;
+        Field(JavascriptFunction*) reject;
+        Field(JavascriptFunction*) resolve;
+        Field(bool) isReject;
+        Field(Var) argument;
 
 #if ENABLE_TTD
     public:
@@ -120,7 +120,7 @@ namespace Js
         JavascriptPromiseCapability* GetCapability();
 
     private:
-        JavascriptPromiseCapability* capability;
+        Field(JavascriptPromiseCapability*) capability;
 
 #if ENABLE_TTD
     public:
@@ -168,9 +168,9 @@ namespace Js
 
 
     private:
-        JavascriptPromise* promise;
-        RecyclableObject* thenable;
-        RecyclableObject* thenFunction;
+        Field(JavascriptPromise*) promise;
+        Field(RecyclableObject*) thenable;
+        Field(RecyclableObject*) thenFunction;
 
 #if ENABLE_TTD
     public:
@@ -216,8 +216,8 @@ namespace Js
         Var GetArgument();
 
     private:
-        JavascriptPromiseReaction* reaction;
-        Var argument;
+        Field(JavascriptPromiseReaction*) reaction;
+        Field(Var) argument;
 
 #if ENABLE_TTD
     public:
@@ -230,7 +230,7 @@ namespace Js
 
     struct JavascriptPromiseAllResolveElementFunctionRemainingElementsWrapper
     {
-        uint32 remainingElements;
+        Field(uint32) remainingElements;
     };
 
     class JavascriptPromiseAllResolveElementFunction : public RuntimeFunction
@@ -256,11 +256,11 @@ namespace Js
         uint32 DecrementRemainingElements();
 
     private:
-        JavascriptPromiseCapability* capabilities;
-        uint32 index;
-        JavascriptPromiseAllResolveElementFunctionRemainingElementsWrapper* remainingElementsWrapper;
-        JavascriptArray* values;
-        bool alreadyCalled;
+        Field(JavascriptPromiseCapability*) capabilities;
+        Field(uint32) index;
+        Field(JavascriptPromiseAllResolveElementFunctionRemainingElementsWrapper*) remainingElementsWrapper;
+        Field(JavascriptArray*) values;
+        Field(bool) alreadyCalled;
 
 #if ENABLE_TTD
     public:
@@ -305,9 +305,9 @@ namespace Js
         }
 
     private:
-        Var promise;
-        Var resolve;
-        Var reject;
+        Field(Var) promise;
+        Field(Var) resolve;
+        Field(Var) reject;
 
 #if ENABLE_TTD
     public:
@@ -350,8 +350,8 @@ namespace Js
         }
 
     private:
-        JavascriptPromiseCapability* capabilities;
-        RecyclableObject* handler;
+        Field(JavascriptPromiseCapability*) capabilities;
+        Field(RecyclableObject*) handler;
 
 #if ENABLE_TTD
     public:
@@ -460,10 +460,10 @@ namespace Js
         Var ResolveHelper(Var resolution, bool isRejecting, ScriptContext* scriptContext);
 
     protected:
-        PromiseStatus status;
-        Var result;
-        JavascriptPromiseReactionList* resolveReactions;
-        JavascriptPromiseReactionList* rejectReactions;
+        Field(PromiseStatus) status;
+        Field(Var) result;
+        Field(JavascriptPromiseReactionList*) resolveReactions;
+        Field(JavascriptPromiseReactionList*) rejectReactions;
 
     private :
         static void AsyncSpawnStep(JavascriptPromiseAsyncSpawnStepArgumentExecutorFunction* nextFunction, JavascriptGenerator* gen, JavascriptFunction* resolve, JavascriptFunction* reject);

--- a/lib/Runtime/Library/JavascriptProxy.h
+++ b/lib/Runtime/Library/JavascriptProxy.h
@@ -16,8 +16,8 @@ namespace Js
         DEFINE_VTABLE_CTOR(JavascriptProxy, DynamicObject);
         DEFINE_MARSHAL_OBJECT_TO_SCRIPT_CONTEXT(JavascriptProxy);
     private:
-        RecyclableObject* handler;
-        RecyclableObject* target;
+        Field(RecyclableObject*) handler;
+        Field(RecyclableObject*) target;
 
         void RevokeObject();
     public:

--- a/lib/Runtime/Library/JavascriptRegExpConstructor.cpp
+++ b/lib/Runtime/Library/JavascriptRegExpConstructor.cpp
@@ -88,7 +88,8 @@ namespace Js
                 for (int groupId = 1; groupId < min(numGroups, NumCtorCaptures); groupId++)
                     captures[groupId] = RegexHelper::GetGroup(scriptContext, pattern, lastInput, nonMatchValue, groupId);
 
-                this->lastParen = numGroups <= NumCtorCaptures ? captures[numGroups - 1] :
+                this->lastParen = numGroups <= NumCtorCaptures ?
+                    PointerValue(captures[numGroups - 1]) :
                     RegexHelper::GetGroup(scriptContext, pattern, lastInput, nonMatchValue, numGroups - 1);
             }
             else

--- a/lib/Runtime/Library/JavascriptRegExpConstructor.h
+++ b/lib/Runtime/Library/JavascriptRegExpConstructor.h
@@ -56,16 +56,16 @@ namespace Js
 
         void EnsureValues();
 
-        UnifiedRegex::RegexPattern* lastPattern;
-        JavascriptString* lastInput;
-        UnifiedRegex::GroupInfo lastMatch;
-        bool reset; // true if following fields must be recalculated from above before first use
-        Var lastParen;
-        Var lastIndex;
-        Var index;
-        Var leftContext;
-        Var rightContext;
-        Var captures[NumCtorCaptures];
+        Field(UnifiedRegex::RegexPattern*) lastPattern;
+        Field(JavascriptString*) lastInput;
+        Field(UnifiedRegex::GroupInfo) lastMatch;
+        Field(bool) reset; // true if following fields must be recalculated from above before first use
+        Field(Var) lastParen;
+        Field(Var) lastIndex;
+        Field(Var) index;
+        Field(Var) leftContext;
+        Field(Var) rightContext;
+        Field(Var) captures[NumCtorCaptures];
     };
 
     class JavascriptRegExpConstructorProperties

--- a/lib/Runtime/Library/JavascriptRegExpEnumerator.h
+++ b/lib/Runtime/Library/JavascriptRegExpEnumerator.h
@@ -9,9 +9,9 @@ namespace Js
     class JavascriptRegExpEnumerator : public JavascriptEnumerator
     {
     private:
-        JavascriptRegExpConstructor* regExpObject;
-        uint index;
-        EnumeratorFlags flags;
+        Field(JavascriptRegExpConstructor*) regExpObject;
+        Field(uint) index;
+        Field(EnumeratorFlags) flags;
     protected:
         DEFINE_VTABLE_CTOR(JavascriptRegExpEnumerator, JavascriptEnumerator);
 

--- a/lib/Runtime/Library/JavascriptSet.h
+++ b/lib/Runtime/Library/JavascriptSet.h
@@ -14,8 +14,8 @@ namespace Js
         typedef JsUtil::BaseDictionary<Var, SetDataNode*, Recycler, PowerOf2SizePolicy, SameValueZeroComparer> SetDataSet;
 
     private:
-        SetDataList list;
-        SetDataSet* set;
+        Field(SetDataList) list;
+        Field(SetDataSet*) set;
 
         DEFINE_VTABLE_CTOR_MEMBER_INIT(JavascriptSet, DynamicObject, list);
         DEFINE_MARSHAL_OBJECT_TO_SCRIPT_CONTEXT(JavascriptSet);

--- a/lib/Runtime/Library/JavascriptSetIterator.h
+++ b/lib/Runtime/Library/JavascriptSetIterator.h
@@ -15,9 +15,9 @@ namespace Js
     class JavascriptSetIterator : public DynamicObject
     {
     private:
-        JavascriptSet*                          m_set;
-        JavascriptSet::SetDataList::Iterator    m_setIterator;
-        JavascriptSetIteratorKind               m_kind;
+        Field(JavascriptSet*)                          m_set;
+        Field(JavascriptSet::SetDataList::Iterator)    m_setIterator;
+        Field(JavascriptSetIteratorKind)               m_kind;
 
     protected:
         DEFINE_VTABLE_CTOR(JavascriptSetIterator, DynamicObject);

--- a/lib/Runtime/Library/JavascriptSimdFloat64x2.h
+++ b/lib/Runtime/Library/JavascriptSimdFloat64x2.h
@@ -13,7 +13,7 @@ namespace Js
     class JavascriptSIMDFloat64x2 sealed : public RecyclableObject
     {
     private:
-        SIMDValue value;
+        Field(SIMDValue) value;
 
         DEFINE_VTABLE_CTOR(JavascriptSIMDFloat64x2, RecyclableObject);
 

--- a/lib/Runtime/Library/JavascriptStringEnumerator.h
+++ b/lib/Runtime/Library/JavascriptStringEnumerator.h
@@ -9,8 +9,8 @@ namespace Js
     class JavascriptStringEnumerator : public JavascriptEnumerator
     {
     private:
-        JavascriptString* stringObject;
-        int index;
+        Field(JavascriptString*) stringObject;
+        Field(int) index;
     protected:
         DEFINE_VTABLE_CTOR(JavascriptStringEnumerator, JavascriptEnumerator);
 

--- a/lib/Runtime/Library/JavascriptStringIterator.h
+++ b/lib/Runtime/Library/JavascriptStringIterator.h
@@ -9,8 +9,8 @@ namespace Js
     class JavascriptStringIterator : public DynamicObject
     {
     private:
-        JavascriptString*   m_string;
-        charcount_t         m_nextIndex;
+        Field(JavascriptString*)   m_string;
+        Field(charcount_t)         m_nextIndex;
 
     protected:
         DEFINE_VTABLE_CTOR(JavascriptStringIterator, DynamicObject);

--- a/lib/Runtime/Library/JavascriptStringObject.h
+++ b/lib/Runtime/Library/JavascriptStringObject.h
@@ -12,7 +12,7 @@ namespace Js
         static PropertyId const specialPropertyIds[];
 
     protected:
-        JavascriptString* value;
+        Field(JavascriptString*) value;
 
         DEFINE_VTABLE_CTOR(JavascriptStringObject, DynamicObject);
         DEFINE_MARSHAL_OBJECT_TO_SCRIPT_CONTEXT(JavascriptStringObject);

--- a/lib/Runtime/Library/JavascriptSymbol.h
+++ b/lib/Runtime/Library/JavascriptSymbol.h
@@ -9,7 +9,7 @@ namespace Js
     class JavascriptSymbol sealed : public RecyclableObject
     {
     private:
-        const PropertyRecord* value;
+        Field(const PropertyRecord*) value;
 
         DEFINE_VTABLE_CTOR(JavascriptSymbol, RecyclableObject);
     public:

--- a/lib/Runtime/Library/JavascriptSymbolObject.h
+++ b/lib/Runtime/Library/JavascriptSymbolObject.h
@@ -9,7 +9,7 @@ namespace Js
     class JavascriptSymbolObject : public DynamicObject
     {
     private:
-        JavascriptSymbol* value;
+        Field(JavascriptSymbol*) value;
 
         DEFINE_VTABLE_CTOR(JavascriptSymbolObject, DynamicObject);
         DEFINE_MARSHAL_OBJECT_TO_SCRIPT_CONTEXT(JavascriptSymbolObject);

--- a/lib/Runtime/Library/JavascriptTypedNumber.h
+++ b/lib/Runtime/Library/JavascriptTypedNumber.h
@@ -10,7 +10,7 @@ namespace Js
     class JavascriptTypedNumber : public RecyclableObject
     {
     private:
-        T m_value;
+        Field(T) m_value;
         inline JavascriptTypedNumber(T value, StaticType * type) : RecyclableObject(type), m_value(value)
         {
 #if DBG

--- a/lib/Runtime/Library/JavascriptVariantDate.h
+++ b/lib/Runtime/Library/JavascriptVariantDate.h
@@ -13,7 +13,7 @@ namespace Js
     class JavascriptVariantDate : public RecyclableObject
     {
     private:
-        double value; // the double form of the value of a VT_DATE variant.
+        Field(double) value; // the double form of the value of a VT_DATE variant.
 
         static JavascriptString* ConvertVariantDateToStr(
             double dbl,

--- a/lib/Runtime/Library/JavascriptWeakMap.h
+++ b/lib/Runtime/Library/JavascriptWeakMap.h
@@ -44,7 +44,7 @@ namespace Js
         typedef JsUtil::BaseDictionary<WeakMapId, Var, Recycler, PowerOf2SizePolicy, RecyclerPointerComparer> WeakMapKeyMap;
         typedef JsUtil::WeaklyReferencedKeyDictionary<DynamicObject, bool, RecyclerPointerComparer<const DynamicObject*>> KeySet;
 
-        KeySet keySet;
+        Field(KeySet) keySet;
 
         WeakMapKeyMap* GetWeakMapKeyMapFromKey(DynamicObject* key) const;
         WeakMapKeyMap* AddWeakMapKeyMapToKey(DynamicObject* key);

--- a/lib/Runtime/Library/JavascriptWeakSet.h
+++ b/lib/Runtime/Library/JavascriptWeakSet.h
@@ -11,7 +11,7 @@ namespace Js
     private:
         typedef JsUtil::WeaklyReferencedKeyDictionary<DynamicObject, bool, RecyclerPointerComparer<const DynamicObject*>> KeySet;
 
-        KeySet keySet;
+        Field(KeySet) keySet;
 
         DEFINE_VTABLE_CTOR_MEMBER_INIT(JavascriptWeakSet, DynamicObject, keySet);
         DEFINE_MARSHAL_OBJECT_TO_SCRIPT_CONTEXT(JavascriptWeakSet);

--- a/lib/Runtime/Library/PropertyString.h
+++ b/lib/Runtime/Library/PropertyString.h
@@ -37,8 +37,8 @@ namespace Js
     class PropertyString : public JavascriptString
     {
     protected:
-        PropertyCache* propCache;
-        const Js::PropertyRecord* m_propertyRecord;
+        FieldNoBarrier(PropertyCache*) propCache;
+        Field(const Js::PropertyRecord*) m_propertyRecord;
         DEFINE_VTABLE_CTOR(PropertyString, JavascriptString);
         DECLARE_CONCRETE_STRING_CLASS;
 

--- a/lib/Runtime/Library/RootObjectBase.h
+++ b/lib/Runtime/Library/RootObjectBase.h
@@ -15,8 +15,8 @@ namespace Js
         Js::InlineCache * GetInlineCache() const { return inlineCache; }
         uint GetRefCount() { return refCount; }
     private:
-        uint refCount;
-        Js::InlineCache * inlineCache;
+        Field(uint) refCount;
+        Field(Js::InlineCache *) inlineCache;
     };
 
     class RootObjectBase: public DynamicObject

--- a/lib/Runtime/Library/ScriptFunction.cpp
+++ b/lib/Runtime/Library/ScriptFunction.cpp
@@ -260,7 +260,7 @@ namespace Js
     FunctionProxy * ScriptFunction::GetFunctionProxy() const
     {
         Assert(this->functionInfo->HasBody());
-        return reinterpret_cast<FunctionProxy *>(this->functionInfo);
+        return reinterpret_cast<FunctionProxy *>(PointerValue(this->functionInfo));
     }
     JavascriptMethod ScriptFunction::UpdateUndeferredBody(FunctionBody* newFunctionInfo)
     {
@@ -553,7 +553,7 @@ namespace Js
             {
             case Js::ScopeType::ScopeType_ActivationObject:
             case Js::ScopeType::ScopeType_WithScope:
-            {    
+            {
                 rctxInfo->EnqueueNewPathVarAsNeeded(this, (Js::Var)scope, scopePathString.GetStrValue());
                 break;
             }
@@ -968,7 +968,7 @@ namespace Js
         if (NULL != this->m_inlineCaches)
         {
             FreeOwnInlineCaches<false>();
-            this->m_inlineCaches = NULL;
+            this->m_inlineCaches = nullptr;
             this->inlineCacheCount = 0;
             this->rootObjectLoadInlineCacheStart = 0;
             this->rootObjectLoadMethodInlineCacheStart = 0;

--- a/lib/Runtime/Library/ScriptFunction.h
+++ b/lib/Runtime/Library/ScriptFunction.h
@@ -28,13 +28,13 @@ namespace Js
     class ScriptFunction : public ScriptFunctionBase
     {
     private:
-        FrameDisplay* environment;  // Optional environment, for closures
-        ActivationObjectEx *cachedScopeObj;
-        Var homeObj;
-        Var computedNameVar;
-        bool hasInlineCaches;
-        bool hasSuperReference;
-        bool isActiveScript;
+        Field(FrameDisplay*) environment;  // Optional environment, for closures
+        Field(ActivationObjectEx *) cachedScopeObj;
+        Field(Var) homeObj;
+        Field(Var) computedNameVar;
+        Field(bool) hasInlineCaches;
+        Field(bool) hasSuperReference;
+        Field(bool) isActiveScript;
 
         bool HasFunctionBody();
         Var FormatToString(JavascriptString* inputString);
@@ -134,27 +134,27 @@ namespace Js
         DEFINE_MARSHAL_OBJECT_TO_SCRIPT_CONTEXT(AsmJsScriptFunction);
 
     private:
-        Var * m_moduleMemory;
-        Wasm::WasmSignature * m_signature;
+        Field(Var *) m_moduleMemory;
+        Field(Wasm::WasmSignature *) m_signature;
     };
 
     class ScriptFunctionWithInlineCache : public ScriptFunction
     {
     private:
-        void** m_inlineCaches;
-        bool hasOwnInlineCaches;
+        Field(void**) m_inlineCaches;
+        Field(bool) hasOwnInlineCaches;
 
 #if DBG
 #define InlineCacheTypeNone         0x00
 #define InlineCacheTypeInlineCache  0x01
 #define InlineCacheTypeIsInst       0x02
-        byte * m_inlineCacheTypes;
+        Field(byte *) m_inlineCacheTypes;
 #endif
-        uint inlineCacheCount;
-        uint rootObjectLoadInlineCacheStart;
-        uint rootObjectLoadMethodInlineCacheStart;
-        uint rootObjectStoreInlineCacheStart;
-        uint isInstInlineCacheCount;
+        Field(uint) inlineCacheCount;
+        Field(uint) rootObjectLoadInlineCacheStart;
+        Field(uint) rootObjectLoadMethodInlineCacheStart;
+        Field(uint) rootObjectStoreInlineCacheStart;
+        Field(uint) isInstInlineCacheCount;
 
     protected:
         ScriptFunctionWithInlineCache(DynamicType * type);

--- a/lib/Runtime/Library/SingleCharString.h
+++ b/lib/Runtime/Library/SingleCharString.h
@@ -22,7 +22,7 @@ namespace Js
 
     private:
         SingleCharString(char16 ch, StaticType * type);
-        char16 m_buff[2]; // the 2nd is always NULL so that GetSz works
+        Field(char16) m_buff[2]; // the 2nd is always NULL so that GetSz works
     };
 
 } // namespace Js

--- a/lib/Runtime/Library/SparseArraySegment.h
+++ b/lib/Runtime/Library/SparseArraySegment.h
@@ -11,10 +11,10 @@ namespace Js
     public:
         static const uint32 MaxLength;
 
-        uint32 left;
-        uint32 length; //we use length instead of right so that we can denote a segment is empty
-        uint32 size;
-        SparseArraySegmentBase* next;
+        Field(uint32) left;
+        Field(uint32) length; //we use length instead of right so that we can denote a segment is empty
+        Field(uint32) size;
+        Field(SparseArraySegmentBase*) next;
 
         static const uint32 CHUNK_SIZE = 16;
         static const uint32 HEAD_CHUNK_SIZE = 16;
@@ -90,6 +90,11 @@ namespace Js
         static bool IsMissingItem(const T* value);
 
         static uint32 GetAlignedSize(uint32 size);
+
+        static inline SparseArraySegment* From(SparseArraySegmentBase* seg)
+        {
+            return static_cast<SparseArraySegment*>(seg);
+        }
 
     private:
         template<bool isLeaf>

--- a/lib/Runtime/Library/SubString.h
+++ b/lib/Runtime/Library/SubString.h
@@ -8,7 +8,8 @@ namespace Js
 {
     class SubString sealed : public JavascriptString
     {
-        void const * originalFullStringReference;          // Only here to prevent recycler to free this buffer.
+        Field(void const *) originalFullStringReference;          // Only here to prevent recycler to free this buffer.
+
         SubString(void const * originalFullStringReference, const char16* subString, charcount_t length, ScriptContext *scriptContext);
 
     protected:

--- a/lib/Runtime/Library/ThrowErrorObject.h
+++ b/lib/Runtime/Library/ThrowErrorObject.h
@@ -12,7 +12,7 @@ namespace Js
     class ThrowErrorObject : public RecyclableObject
     {
     private:
-        JavascriptError* m_error;
+        Field(JavascriptError*) m_error;
 
     protected:
         ThrowErrorObject(StaticType* type, JavascriptError* error);

--- a/lib/Runtime/Library/TypedArrayIndexEnumerator.h
+++ b/lib/Runtime/Library/TypedArrayIndexEnumerator.h
@@ -9,10 +9,10 @@ namespace Js
     class TypedArrayIndexEnumerator : public JavascriptEnumerator
     {
     private:
-        TypedArrayBase* typedArrayObject;
-        uint32 index;
-        bool doneArray;
-        EnumeratorFlags flags;
+        Field(TypedArrayBase*) typedArrayObject;
+        Field(uint32) index;
+        Field(bool) doneArray;
+        Field(EnumeratorFlags) flags;
 
     protected:
         DEFINE_VTABLE_CTOR(TypedArrayIndexEnumerator, JavascriptEnumerator);

--- a/lib/Runtime/Math/JavascriptMath.cpp
+++ b/lib/Runtime/Math/JavascriptMath.cpp
@@ -933,8 +933,8 @@ StringCommon:
                     return scriptContext->GetLibrary()->GetNegativeInfinite();
                 }
 
-                if (((Js::SparseArraySegmentBase*)argsArray->GetHead())->next != nullptr || !argsArray->HasNoMissingValues() ||
-                    ((Js::SparseArraySegmentBase*)argsArray->GetHead())->length != len)
+                if (argsArray->GetHead()->next != nullptr || !argsArray->HasNoMissingValues() ||
+                    argsArray->GetHead()->length != len)
                 {
                     return JavascriptFunction::CalloutHelper<false>(function, thisArg, /* overridingNewTarget = */nullptr, arrayArg, scriptContext);
                 }
@@ -991,8 +991,8 @@ StringCommon:
                     return scriptContext->GetLibrary()->GetPositiveInfinite();
                 }
 
-                if (((Js::SparseArraySegmentBase*)argsArray->GetHead())->next != nullptr || !argsArray->HasNoMissingValues() ||
-                    ((Js::SparseArraySegmentBase*)argsArray->GetHead())->length != len)
+                if (argsArray->GetHead()->next != nullptr || !argsArray->HasNoMissingValues() ||
+                    argsArray->GetHead()->length != len)
                 {
                     return JavascriptFunction::CalloutHelper<false>(function, thisArg, /* overridingNewTarget = */nullptr, arrayArg, scriptContext);
                 }

--- a/lib/Runtime/Types/DictionaryTypeHandler.h
+++ b/lib/Runtime/Types/DictionaryTypeHandler.h
@@ -28,10 +28,10 @@ namespace Js
         typedef PropertyDescriptorMap PropertyDescriptorMapType; // alias used by diagnostics
 
     private:
-        PropertyDescriptorMap* propertyMap;
+        Field(PropertyDescriptorMap*) propertyMap;
         Field(T) nextPropertyIndex;
 
-        RecyclerWeakReference<DynamicObject>* singletonInstance;
+        Field(RecyclerWeakReference<DynamicObject>*) singletonInstance;
 
         typedef PropertyIndexRanges<T> PropertyIndexRangesType;
         static const T MaxPropertyIndexSize = PropertyIndexRangesType::MaxValue;

--- a/lib/Runtime/Types/DynamicObject.h
+++ b/lib/Runtime/Types/DynamicObject.h
@@ -81,7 +81,7 @@ namespace Js
 #endif
 
     private:
-        Var* auxSlots;
+        Field(Var*) auxSlots;
         // The objectArrayOrFlags field can store one of two things:
         //   a) a pointer to the object array holding numeric properties of this object, or
         //   b) a bitfield of flags.

--- a/lib/Runtime/Types/DynamicObjectPropertyEnumerator.h
+++ b/lib/Runtime/Types/DynamicObjectPropertyEnumerator.h
@@ -20,15 +20,15 @@ namespace Js
 
         struct CachedData
         {
-            ScriptContext * scriptContext;
-            PropertyString ** strings;
-            BigPropertyIndex * indexes;
-            PropertyAttributes * attributes;
-            int cachedCount;
-            int propertyCount;
-            bool completed;
-            bool enumNonEnumerable;
-            bool enumSymbols;
+            Field(ScriptContext *) scriptContext;
+            Field(PropertyString **) strings;
+            Field(BigPropertyIndex *) indexes;
+            Field(PropertyAttributes *) attributes;
+            Field(int) cachedCount;
+            Field(int) propertyCount;
+            Field(bool) completed;
+            Field(bool) enumNonEnumerable;
+            Field(bool) enumSymbols;
         } *cachedData;
 
         DynamicType * GetTypeToEnumerate() const;

--- a/lib/Runtime/Types/DynamicType.h
+++ b/lib/Runtime/Types/DynamicType.h
@@ -25,7 +25,7 @@ namespace Js
         friend class SimpleDictionaryTypeHandlerBase;
 
     private:
-        DynamicTypeHandler * typeHandler;
+        Field(DynamicTypeHandler *) typeHandler;
         Field(bool) isLocked;
         Field(bool) isShared;
         Field(bool) hasNoEnumerableProperties;

--- a/lib/Runtime/Types/ES5ArrayTypeHandler.cpp
+++ b/lib/Runtime/Types/ES5ArrayTypeHandler.cpp
@@ -21,7 +21,7 @@ namespace Js
             Js::Throw::OutOfMemory(); // Would possibly overflow our dictionary
         }
 
-        indexList = NULL; // Discard indexList on change
+        indexList = nullptr; // Discard indexList on change
         indexPropertyMap->Add(key, value);
     }
 

--- a/lib/Runtime/Types/ES5ArrayTypeHandler.h
+++ b/lib/Runtime/Types/ES5ArrayTypeHandler.h
@@ -36,10 +36,10 @@ namespace Js
         typedef JsUtil::BaseDictionary<uint32, IndexPropertyDescriptor, ForceNonLeafAllocator<Recycler>::AllocatorType, PowerOf2SizePolicy>
             InnerMap;
 
-        Recycler* recycler;
-        InnerMap* indexPropertyMap; // The internal real index property map
-        uint32* indexList;          // The index list that's created on demand
-        int lastIndexAt;            // Last used index list entry
+        Field(Recycler*) recycler;
+        Field(InnerMap*) indexPropertyMap; // The internal real index property map
+        Field(uint32*) indexList;          // The index list that's created on demand
+        Field(int) lastIndexAt;            // Last used index list entry
 
     private:
         void EnsureIndexList();
@@ -99,9 +99,9 @@ namespace Js
         template <typename T> friend class ES5ArrayTypeHandlerBase;
 
     private:
-        IndexPropertyDescriptorMap* indexPropertyMap;
-        PropertyAttributes dataItemAttributes; // attributes for data item not in map
-        bool lengthWritable;
+        Field(IndexPropertyDescriptorMap*) indexPropertyMap;
+        Field(PropertyAttributes) dataItemAttributes; // attributes for data item not in map
+        Field(bool) lengthWritable;
 
     public:
         DEFINE_GETCPPNAME();

--- a/lib/Runtime/Types/PathTypeHandler.cpp
+++ b/lib/Runtime/Types/PathTypeHandler.cpp
@@ -1051,7 +1051,7 @@ namespace Js
 #endif
             for (uint i = 0; i < count; i++)
             {
-                PathTypeHandlerBase *pathHandler = (PathTypeHandlerBase *)type->typeHandler;
+                PathTypeHandlerBase *pathHandler = (PathTypeHandlerBase *)PointerValue(type->typeHandler);
                 Js::PropertyId propertyId = propIds->elements[i];
 
                 PropertyIndex propertyIndex = pathHandler->GetPropertyIndex(propertyId);

--- a/lib/Runtime/Types/PathTypeHandler.h
+++ b/lib/Runtime/Types/PathTypeHandler.h
@@ -221,8 +221,8 @@ namespace Js
     class SimplePathTypeHandler sealed : public PathTypeHandlerBase
     {
     private:
-        const PropertyRecord * successorPropertyRecord;
-        RecyclerWeakReference<DynamicType> * successorTypeWeakRef;
+        Field(const PropertyRecord *) successorPropertyRecord;
+        Field(RecyclerWeakReference<DynamicType> *) successorTypeWeakRef;
 
     public:
         DEFINE_GETCPPNAME();
@@ -254,7 +254,7 @@ namespace Js
 
     private:
         typedef JsUtil::WeakReferenceDictionary<PropertyId, DynamicType, DictionarySizePolicy<PowerOf2Policy, 1>> PropertySuccessorsMap;
-        PropertySuccessorsMap * propertySuccessors;
+        Field(PropertySuccessorsMap *) propertySuccessors;
 
     public:
         DEFINE_GETCPPNAME();

--- a/lib/Runtime/Types/RecyclableObject.h
+++ b/lib/Runtime/Types/RecyclableObject.h
@@ -206,7 +206,7 @@ namespace Js {
         void RecordAllocation(ScriptContext * scriptContext);
 #endif
     protected:
-        Type * type;
+        Field(Type *) type;
         DEFINE_VTABLE_CTOR_NOBASE(RecyclableObject);
 
         virtual RecyclableObject* GetPrototypeSpecial();

--- a/lib/Runtime/Types/ScriptFunctionType.h
+++ b/lib/Runtime/Types/ScriptFunctionType.h
@@ -18,7 +18,8 @@ namespace Js
         ScriptFunctionType(ScriptContext* scriptContext, RecyclableObject* prototype,
             JavascriptMethod entryPoint, ProxyEntryPointInfo * entryPointInfo, DynamicTypeHandler * typeHandler,
             bool isLocked, bool isShared);
-        ProxyEntryPointInfo * entryPointInfo;
+
+        Field(ProxyEntryPointInfo *) entryPointInfo;
 
         friend class ScriptFunction;
         friend class JavascriptLibrary;

--- a/lib/Runtime/Types/SimpleDictionaryTypeHandler.h
+++ b/lib/Runtime/Types/SimpleDictionaryTypeHandler.h
@@ -63,21 +63,21 @@ namespace Js
         typedef SimplePropertyDescriptorMap PropertyDescriptorMapType; // alias used by diagnostics
 
     protected:
-        SimplePropertyDescriptorMap* propertyMap;
+        Field(SimplePropertyDescriptorMap*) propertyMap;
 
     private:
-        RecyclerWeakReference<DynamicObject>* singletonInstance;
-        TPropertyIndex nextPropertyIndex;
+        Field(RecyclerWeakReference<DynamicObject>*) singletonInstance;
+        Field(TPropertyIndex) nextPropertyIndex;
 
     protected:
         // Determines whether this instance is actually a SimpleDictionaryUnorderedTypeHandler
-        bool isUnordered : 1;
+        Field(bool) isUnordered : 1;
         // Tracks if an InternalPropertyRecord or symbol has been added to this type; will prevent conversion to string-keyed type handler
-        bool hasNamelessPropertyId : 1;
+        Field(bool) hasNamelessPropertyId : 1;
 
     private:
         // Number of deleted properties in the property map
-        byte numDeletedProperties;
+        Field(byte) numDeletedProperties;
 
     public:
         DEFINE_GETCPPNAME();

--- a/lib/Runtime/Types/SimpleTypeHandler.h
+++ b/lib/Runtime/Types/SimpleTypeHandler.h
@@ -11,8 +11,8 @@ namespace Js
     {
         friend class NullTypeHandlerBase;
     private:
-        int propertyCount;
-        SimplePropertyDescriptor descriptors[size];
+        Field(int) propertyCount;
+        Field(SimplePropertyDescriptor) descriptors[size];
 
     public:
         DEFINE_GETCPPNAME();

--- a/lib/Runtime/Types/TypePath.cpp
+++ b/lib/Runtime/Types/TypePath.cpp
@@ -47,16 +47,18 @@ namespace Js {
 
     PropertyIndex TypePath::LookupInline(PropertyId propId,int typePathLength)
     {
-        if (propId == Constants::NoProperty) {
+        if (propId == Constants::NoProperty)
+        {
            return Constants::NoSlot;
         }
+
         PropertyIndex propIndex = Constants::NoSlot;
-        if (this->GetData()->map.TryGetValue(propId, &propIndex,
-                static_cast<const PropertyRecord **>(assignments))) {
-            if (propIndex<typePathLength) {
-                return propIndex;
-            }
+        if (this->GetData()->map.TryGetValue(propId, &propIndex, assignments) &&
+            propIndex < typePathLength)
+        {
+            return propIndex;
         }
+
         return Constants::NoSlot;
     }
 
@@ -184,7 +186,7 @@ namespace Js {
 
     }
 
-    int TypePath::Data::Add(const PropertyRecord* propId, const PropertyRecord ** assignments)
+    int TypePath::Data::Add(const PropertyRecord* propId, Field(const PropertyRecord *)* assignments)
     {
         uint currentPathLength = this->pathLength;
         Assert(currentPathLength < this->pathSize);

--- a/lib/Runtime/Types/TypePath.h
+++ b/lib/Runtime/Types/TypePath.h
@@ -77,7 +77,6 @@ public:
         static const uint InitialTypePathSize = 16 + TYPE_PATH_ALLOC_GRANULARITY_GAP;
 
     private:
-
         struct Data
         {
             Data(uint8 pathSize) : pathSize(pathSize), pathLength(0)
@@ -87,30 +86,31 @@ public:
             {}
 
 #ifdef SUPPORT_FIXED_FIELDS_ON_PATH_TYPES
-            BVStatic<MaxPathTypeHandlerLength> fixedFields;
-            BVStatic<MaxPathTypeHandlerLength> usedFixedFields;
+            Field(BVStatic<MaxPathTypeHandlerLength>) fixedFields;
+            Field(BVStatic<MaxPathTypeHandlerLength>) usedFixedFields;
 
             // We sometimes set up PathTypeHandlers and associate TypePaths before we create any instances
             // that populate the corresponding slots, e.g. for object literals or constructors with only
             // this statements.  This field keeps track of the longest instance associated with the given
             // TypePath.
-            uint8 maxInitializedLength;
+            Field(uint8) maxInitializedLength;
 #endif
-            uint8 pathLength;      // Entries in use
-            uint8 pathSize;        // Allocated entries
+            Field(uint8) pathLength;      // Entries in use
+            Field(uint8) pathSize;        // Allocated entries
 
             // This map has to be at the end, because TinyDictionary has a zero size array
-            TinyDictionary map;
+            Field(TinyDictionary) map;
 
-            int Add(const PropertyRecord * propertyId, const PropertyRecord ** assignments);
-        } * data;
+            int Add(const PropertyRecord * propertyId, Field(const PropertyRecord *)* assignments);
+        };
+        Field(Data*) data;
 
 #ifdef SUPPORT_FIXED_FIELDS_ON_PATH_TYPES
-        RecyclerWeakReference<DynamicObject>* singletonInstance;
+        Field(RecyclerWeakReference<DynamicObject>*) singletonInstance;
 #endif
 
         // PropertyRecord assignments are allocated off the end of the structure
-        const PropertyRecord * assignments[0];
+        Field(const PropertyRecord *) assignments[];
 
 
         TypePath() :
@@ -141,11 +141,6 @@ public:
                 return GetPropertyIdUnchecked(index);
             else
                 return nullptr;
-        }
-
-        const PropertyRecord ** GetPropertyAssignments()
-        {
-            return assignments;
         }
 
         int Add(const PropertyRecord * propertyRecord)

--- a/lib/Runtime/Types/TypePropertyCache.h
+++ b/lib/Runtime/Types/TypePropertyCache.h
@@ -50,7 +50,7 @@ namespace Js
     class TypePropertyCache
     {
     private:
-        TypePropertyCacheElement elements[TypePropertyCache_NumElements];
+        Field(TypePropertyCacheElement) elements[TypePropertyCache_NumElements];
 
     private:
         static size_t ElementIndex(const PropertyId id);

--- a/tools/RecyclerChecker/RecyclerChecker.cpp
+++ b/tools/RecyclerChecker/RecyclerChecker.cpp
@@ -198,11 +198,17 @@ bool MainVisitor::MatchType(const string& type, const char* source, const char**
             continue;
         }
 
-        if (SkipPrefix(p, "class ") || SkipPrefix(p, "struct ") ||
-            SkipPrefix(p, "union ") || SkipPrefix(p, "enum "))
+#define SKIP_EITHER_PREFIX(prefix) \
+            (SkipPrefix(p, prefix) || SkipPrefix(source, prefix))
+        if (SKIP_EITHER_PREFIX("const ") ||
+            SKIP_EITHER_PREFIX("class ") ||
+            SKIP_EITHER_PREFIX("struct ") ||
+            SKIP_EITHER_PREFIX("union ") ||
+            SKIP_EITHER_PREFIX("enum "))
         {
             continue;
         }
+#undef SKIP_EITHER_PREFIX
 
         // type may contain [...] array specifier, while source has it after field name
         if (*p == '[')


### PR DESCRIPTION
### swb: annotate SList, Array … 
Change SListNode to template on TAllocator. Annotate SList fields and fix
all usages.

Add PointerValue() function to retrieve a pointer type field's pointer
value. Simplifies casts.

Add SparseArraySegment<T>::From() function to simplify all
SparseArraySegment casts after annotation.

### swb: write barrier annotations 3 … 
This contains all the remaining annotations that can be detected by
current plugin. Mostly auto annotations + minor manual fixes.