### PR TITLE
Fix JsParse/JsRun for JavascriptString argument

### DIFF
--- a/test/native-tests/test-char/Platform.js
+++ b/test/native-tests/test-char/Platform.js
@@ -1,0 +1,54 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+var isWindows = !WScript.Platform || WScript.Platform.OS == 'win32';
+var path_sep = isWindows ? '\\' : '/';
+var isStaticBuild = WScript.Platform && WScript.Platform.LINK_TYPE == 'static';
+
+if (!isStaticBuild) {
+    // test will be ignored
+    print("# IGNORE_THIS_TEST");
+} else {
+    var platform = WScript.Platform.OS;
+    var binaryPath = WScript.Platform.BINARY_PATH;
+    // discard `ch` from path
+    binaryPath = binaryPath.substr(0, binaryPath.lastIndexOf(path_sep));
+    var makefile =
+"IDIR=" + binaryPath + "/../../lib/Jsrt \n\
+\n\
+LIBRARY_PATH=" + binaryPath + "/lib\n\
+PLATFORM=" + platform + "\n\
+LDIR=$(LIBRARY_PATH)/../pal/src/libChakra.Pal.a \
+  $(LIBRARY_PATH)/Common/Core/libChakra.Common.Core.a \
+  $(LIBRARY_PATH)/Jsrt/libChakra.Jsrt.a \n\
+\n\
+ifeq (darwin, ${PLATFORM})\n\
+\tICU4C_LIBRARY_PATH ?= /usr/local/opt/icu4c\n\
+\tCFLAGS=-lstdc++ -std=c++11 -I$(IDIR)\n\
+\tFORCE_STARTS=-Wl,-force_load,\n\
+\tFORCE_ENDS=\n\
+\tLIBS=-framework CoreFoundation -framework Security -lm -ldl -Wno-c++11-compat-deprecated-writable-strings \
+    -Wno-deprecated-declarations -Wno-unknown-warning-option -o sample.o\n\
+\tLDIR+=$(ICU4C_LIBRARY_PATH)/lib/libicudata.a \
+    $(ICU4C_LIBRARY_PATH)/lib/libicuuc.a \
+    $(ICU4C_LIBRARY_PATH)/lib/libicui18n.a\n\
+else\n\
+\tCFLAGS=-lstdc++ -std=c++0x -I$(IDIR)\n\
+\tFORCE_STARTS=-Wl,--whole-archive\n\
+\tFORCE_ENDS=-Wl,--no-whole-archive\n\
+\tLIBS=-pthread -lm -ldl -licuuc -lunwind-x86_64 -Wno-c++11-compat-deprecated-writable-strings \
+    -Wno-deprecated-declarations -Wno-unknown-warning-option -o sample.o\n\
+endif\n\
+\n\
+testmake:\n\
+\t$(CC) sample.cpp $(CFLAGS) $(FORCE_STARTS) $(LDIR) $(FORCE_ENDS) $(LIBS)\n\
+\n\
+.PHONY: clean\n\
+\n\
+clean:\n\
+\trm sample.o\n";
+
+    print(makefile)
+}

--- a/test/native-tests/test-char/sample.cpp
+++ b/test/native-tests/test-char/sample.cpp
@@ -50,7 +50,7 @@ int main()
 
     // Run the script.
     FAIL_CHECK(JsRun(scriptSource, currentSourceContext++, fname,
-        JsParseScriptAttributeArrayBufferIsUtf16Encoded, &result));
+        JsParseScriptAttributeNone, &result));
 
     // Convert your script result to String in JavaScript; redundant if your script returns a String
     JsValueRef resultJSString;

--- a/test/native-tests/test-char/sample.cpp
+++ b/test/native-tests/test-char/sample.cpp
@@ -1,0 +1,75 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#include "ChakraCore.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <string>
+#include <cstring>
+
+#define FAIL_CHECK(cmd)                     \
+    do                                      \
+    {                                       \
+        JsErrorCode errCode = cmd;          \
+        if (errCode != JsNoError)           \
+        {                                   \
+            printf("Error %d at '%s'\n",    \
+                errCode, #cmd);             \
+            return 1;                       \
+        }                                   \
+    } while(0)
+
+using namespace std;
+
+int main()
+{
+    JsRuntimeHandle runtime;
+    JsContextRef context;
+    JsValueRef result;
+    unsigned currentSourceContext = 0;
+
+    const char* script = "(()=>{return \'SUCCESS\';})()";
+    size_t length = strlen(script);
+
+    // Create a runtime.
+    JsCreateRuntime(JsRuntimeAttributeNone, nullptr, &runtime);
+
+    // Create an execution context.
+    JsCreateContext(runtime, &context);
+
+    // Now set the current execution context.
+    JsSetCurrentContext(context);
+
+    JsValueRef fname;
+    FAIL_CHECK(JsCreateString("sample", strlen("sample"), &fname));
+
+    JsValueRef scriptSource;
+    FAIL_CHECK(JsCreateString(script, length, &scriptSource));
+
+    // Run the script.
+    FAIL_CHECK(JsRun(scriptSource, currentSourceContext++, fname,
+        JsParseScriptAttributeArrayBufferIsUtf16Encoded, &result));
+
+    // Convert your script result to String in JavaScript; redundant if your script returns a String
+    JsValueRef resultJSString;
+    FAIL_CHECK(JsConvertValueToString(result, &resultJSString));
+
+    // Project script result back to C++.
+    uint8_t *resultSTR = nullptr;
+    size_t stringLength;
+    FAIL_CHECK(JsCopyStringUtf8(resultJSString, nullptr, 0, &stringLength));
+    resultSTR = (uint8_t*)malloc(stringLength + 1);
+    FAIL_CHECK(JsCopyStringUtf8(resultJSString, resultSTR, stringLength + 1, nullptr));
+    resultSTR[stringLength] = 0;
+
+    printf("Result -> %s \n", resultSTR);
+    free(resultSTR);
+
+    // Dispose runtime
+    JsSetCurrentContext(JS_INVALID_REFERENCE);
+    JsDisposeRuntime(runtime);
+
+    return 0;
+}

--- a/test/native-tests/test-char16/sample.cpp
+++ b/test/native-tests/test-char16/sample.cpp
@@ -54,13 +54,13 @@ int main()
     FAIL_CHECK(JsCreateStringUtf8((const uint8_t*)"sample", strlen("sample"), &fname));
 
     JsValueRef scriptSource;
-    FAIL_CHECK(JsCreateStringUtf16(script16, length * sizeof(uint16_t), &scriptSource));
+    FAIL_CHECK(JsCreateStringUtf16(script16, length, &scriptSource));
     // now we don't need our own copy
     free(script16);
 
     // Run the script.
     FAIL_CHECK(JsRun(scriptSource, currentSourceContext++, fname,
-        JsParseScriptAttributeArrayBufferIsUtf16Encoded, &result));
+        JsParseScriptAttributeNone, &result));
 
     // Convert your script result to String in JavaScript; redundant if your script returns a String
     JsValueRef resultJSString;


### PR DESCRIPTION
JavascriptString is internally wide, so pass correct length and flag in
CompileRun.

GetSz for JavascriptString can allocate memory and need to handle OOM so
need API wrapper.

We are using the wrapper twice but refactoring is not simple as
RunScriptCore is called at multiple, for now lets keep two wrappers
