### PR TITLE
sequences for f32/f64_convert_u/s/i32/i64 on x86-x64 

### DIFF
--- a/lib/Backend/LowerMDShared.cpp
+++ b/lib/Backend/LowerMDShared.cpp
@@ -7966,7 +7966,7 @@ LowererMD::EmitFloat32ToFloat64(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrIn
 }
 
 void
-LowererMD::EmitInt64toFloat(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instr) 
+LowererMD::EmitInt64toFloat(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instr)
 {
     EmitInt64toFloatRec(dst, src, instr, false);
     instr->UnlinkDst();
@@ -8006,7 +8006,7 @@ LowererMD::EmitInt64toFloatRec(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instr, b
         dst = IR::RegOpnd::New(TyFloat64, this->m_func);
     }
 
-    if (src->IsUnsigned() && !recursive) 
+    if (src->IsUnsigned() && !recursive)
     {
         EmitInt64toFloatRec(dst, src, instr, true);
         IR::RegOpnd * highestBitOpnd = IR::RegOpnd::New(TyInt64, this->m_func);

--- a/lib/Backend/LowerMDShared.cpp
+++ b/lib/Backend/LowerMDShared.cpp
@@ -7969,9 +7969,11 @@ void
 LowererMD::EmitInt64toFloat(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instr)
 {
     EmitInt64toFloatRec(dst, src, instr, false);
+#ifdef _M_X64
     instr->UnlinkDst();
     instr->UnlinkSrc1();
     //instruction is removed by the caller
+#endif
 }
 
 void

--- a/lib/Backend/LowerMDShared.cpp
+++ b/lib/Backend/LowerMDShared.cpp
@@ -7968,17 +7968,6 @@ LowererMD::EmitFloat32ToFloat64(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrIn
 void
 LowererMD::EmitInt64toFloat(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instr)
 {
-    EmitInt64toFloatRec(dst, src, instr, false);
-#ifdef _M_X64
-    instr->UnlinkDst();
-    instr->UnlinkSrc1();
-    //instruction is removed by the caller
-#endif
-}
-
-void
-LowererMD::EmitInt64toFloatRec(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instr, bool recursive)
-{
 
 #ifdef _M_IX86
     IR::Opnd *srcOpnd = instr->UnlinkSrc1();
@@ -8008,9 +7997,9 @@ LowererMD::EmitInt64toFloatRec(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instr, b
         dst = IR::RegOpnd::New(TyFloat64, this->m_func);
     }
 
-    if (src->IsUnsigned() && !recursive)
+    instr->InsertBefore(IR::Instr::New(Js::OpCode::CVTSI2SD, dst, src, this->m_func));
+    if (src->IsUnsigned())
     {
-        EmitInt64toFloatRec(dst, src, instr, true);
         IR::RegOpnd * highestBitOpnd = IR::RegOpnd::New(TyInt64, this->m_func);
         IR::Instr* instrNew = IR::Instr::New(Js::OpCode::SHR, highestBitOpnd, src,
         IR::IntConstOpnd::New(63, TyInt8, this->m_func, true), this->m_func);
@@ -8027,17 +8016,12 @@ LowererMD::EmitInt64toFloatRec(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instr, b
             highestBitOpnd, IndirScale8, TyFloat64, this->m_func), this->m_func);
         instr->InsertBefore(instrNew);
     }
-    else 
-    {
-        instr->InsertBefore(IR::Instr::New(Js::OpCode::CVTSI2SD, dst, src, this->m_func));
-    }
 
     if (origDst)
     {
         instr->InsertBefore(IR::Instr::New(Js::OpCode::CVTSD2SS, origDst, dst, this->m_func));
     }
 #endif
-
 }
 
 void

--- a/lib/Backend/LowerMDShared.h
+++ b/lib/Backend/LowerMDShared.h
@@ -218,7 +218,6 @@ public:
             void            EmitLongToInt(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsert);
             void            EmitFloatToInt(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsert);
             void            EmitInt64toFloat(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsert);
-            void            EmitInt64toFloatRec(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsert, bool recursive);
             void            EmitFloat32ToFloat64(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsert);
             static IR::Instr *InsertConvertFloat64ToInt32(const RoundMode roundMode, IR::Opnd *const dst, IR::Opnd *const src, IR::Instr *const insertBeforeInstr);
             void            ConvertFloatToInt32(IR::Opnd* intOpnd, IR::Opnd* floatOpnd, IR::LabelInstr * labelHelper, IR::LabelInstr * labelDone, IR::Instr * instInsert);

--- a/lib/Backend/LowerMDShared.h
+++ b/lib/Backend/LowerMDShared.h
@@ -218,6 +218,7 @@ public:
             void            EmitLongToInt(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsert);
             void            EmitFloatToInt(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsert);
             void            EmitInt64toFloat(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsert);
+            void            EmitInt64toFloatRec(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsert, bool recursive);
             void            EmitFloat32ToFloat64(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsert);
             static IR::Instr *InsertConvertFloat64ToInt32(const RoundMode roundMode, IR::Opnd *const dst, IR::Opnd *const src, IR::Instr *const insertBeforeInstr);
             void            ConvertFloatToInt32(IR::Opnd* intOpnd, IR::Opnd* floatOpnd, IR::LabelInstr * labelHelper, IR::LabelInstr * labelDone, IR::Instr * instInsert);

--- a/lib/Common/Common/NumberUtilities.cpp
+++ b/lib/Common/Common/NumberUtilities.cpp
@@ -85,6 +85,8 @@ namespace Js
     __declspec(align(16)) double const NumberConstants::UIntConvertConst[2] = { 0, 4294967296.000000 };
     __declspec(align(16)) float const NumberConstants::MaskNegFloat[] = { -0.0f, -0.0f, -0.0f, -0.0f };
     __declspec(align(16)) double const NumberConstants::MaskNegDouble[] = { -0.0, -0.0 };
+    __declspec(align(16)) uint64 const NumberConstants::UInt64ConvertConst[2] = { 0, 0x43f0000000000000 };
+    
 
     bool NumberUtilities::IsDigit(int ch)
     {

--- a/lib/Common/Common/NumberUtilities.cpp
+++ b/lib/Common/Common/NumberUtilities.cpp
@@ -86,7 +86,7 @@ namespace Js
     __declspec(align(16)) float const NumberConstants::MaskNegFloat[] = { -0.0f, -0.0f, -0.0f, -0.0f };
     __declspec(align(16)) double const NumberConstants::MaskNegDouble[] = { -0.0, -0.0 };
     __declspec(align(16)) uint64 const NumberConstants::UInt64ConvertConst[2] = { 0, 0x43f0000000000000 };
-    
+
 
     bool NumberUtilities::IsDigit(int ch)
     {

--- a/lib/Common/Common/NumberUtilities.h
+++ b/lib/Common/Common/NumberUtilities.h
@@ -67,6 +67,8 @@ namespace Js
         static const BYTE AbsFloatCst[];
         static const BYTE SgnBitCst[];
         static double const UIntConvertConst[];
+        static uint64 const UInt64ConvertConst[];
+        
         static double const MaskNegDouble[];
         static float const MaskNegFloat[];
 

--- a/lib/Common/Common/NumberUtilities.h
+++ b/lib/Common/Common/NumberUtilities.h
@@ -68,7 +68,7 @@ namespace Js
         static const BYTE SgnBitCst[];
         static double const UIntConvertConst[];
         static uint64 const UInt64ConvertConst[];
-        
+
         static double const MaskNegDouble[];
         static float const MaskNegFloat[];
 

--- a/lib/Runtime/Base/ThreadContextInfo.cpp
+++ b/lib/Runtime/Base/ThreadContextInfo.cpp
@@ -66,6 +66,12 @@ ThreadContextInfo::GetUIntConvertConstAddr() const
 }
 
 intptr_t
+ThreadContextInfo::GetUInt64ConvertConstAddr() const
+{
+    return SHIFT_ADDR(this, &Js::JavascriptNumber::UInt64ConvertConst);
+}
+
+intptr_t
 ThreadContextInfo::GetUint8ClampedArraySetItemAddr() const
 {
     return SHIFT_ADDR(this, (BOOL(*)(Js::Uint8ClampedArray * arr, uint32 index, Js::Var value))&Js::Uint8ClampedArray::DirectSetItem);

--- a/lib/Runtime/Base/ThreadContextInfo.h
+++ b/lib/Runtime/Base/ThreadContextInfo.h
@@ -41,6 +41,7 @@ public:
     intptr_t GetDoubleTwoTo31Addr() const;
 
     intptr_t GetUIntConvertConstAddr() const;
+    intptr_t GetUInt64ConvertConstAddr() const;
     intptr_t GetUint8ClampedArraySetItemAddr() const;
     intptr_t GetConstructorCacheDefaultInstanceAddr() const;
     intptr_t GetJavascriptObjectNewInstanceAddr() const;


### PR DESCRIPTION
This PR implements fastpath sequences for f32/f64_convert_u/s/i32/i64 on x86-x64

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/1992)
<!-- Reviewable:end -->
