### PR TITLE
fixing an assert in bytecodedump while printing int64 consts for asm.js function 

### DIFF
--- a/lib/Runtime/ByteCode/AsmJsByteCodeDumper.cpp
+++ b/lib/Runtime/ByteCode/AsmJsByteCodeDumper.cpp
@@ -227,6 +227,10 @@ namespace Js
         for (int i = 0; i < WAsmJs::LIMIT; ++i)
         {
             WAsmJs::Types type = (WAsmJs::Types)i;
+            if (func->GetTypedRegisterAllocator().IsTypeExcluded(type))
+            {
+                continue;
+            }
             uint constCount = func->GetTypedRegisterAllocator().GetRegisterSpace(type)->GetConstCount();
             if (constCount > 0)
             {


### PR DESCRIPTION
-dump:bytecode hits an assertion when dumping bytecodes for an asm.js function due to the fact we are trying to print int64 consts. 
