### PR TITLE
swb: check base classes, annotations 4

### DIFF
--- a/bin/GCStress/RecyclerTestObject.h
+++ b/bin/GCStress/RecyclerTestObject.h
@@ -107,7 +107,7 @@ private:
     // Instance variables
 
     // See comments above re currentGeneration
-    size_t generation;
+    Field(size_t) generation;
 };
 
 template <unsigned int minCount, unsigned int maxCount>

--- a/lib/Common/DataStructures/DoublyLinkedListElement.h
+++ b/lib/Common/DataStructures/DoublyLinkedListElement.h
@@ -6,11 +6,12 @@
 
 namespace JsUtil
 {
-    template<class T>
+    template<class T, class TAllocator = ArenaAllocator>
     class DoublyLinkedListElement
     {
     private:
-        T *previous, *next;
+        Field(T*, TAllocator) previous;
+        Field(T*, TAllocator) next;
 
     public:
         DoublyLinkedListElement();

--- a/lib/Common/DataStructures/DoublyLinkedListElement.inl
+++ b/lib/Common/DataStructures/DoublyLinkedListElement.inl
@@ -6,27 +6,27 @@
 
 namespace JsUtil
 {
-    template<class T>
-    DoublyLinkedListElement<T>::DoublyLinkedListElement() : previous(0), next(0)
+    template<class T, class TAllocator>
+    DoublyLinkedListElement<T, TAllocator>::DoublyLinkedListElement() : previous(0), next(0)
     {
-        TemplateParameter::SameOrDerivedFrom<T, DoublyLinkedListElement<T>>();
+        TemplateParameter::SameOrDerivedFrom<T, DoublyLinkedListElement<T, TAllocator>>();
     }
 
-    template<class T>
-    T *DoublyLinkedListElement<T>::Previous() const
+    template<class T, class TAllocator>
+    T *DoublyLinkedListElement<T, TAllocator>::Previous() const
     {
         return previous;
     }
 
-    template<class T>
-    T *DoublyLinkedListElement<T>::Next() const
+    template<class T, class TAllocator>
+    T *DoublyLinkedListElement<T, TAllocator>::Next() const
     {
         return next;
     }
 
-    template<class T>
+    template<class T, class TAllocator>
     template<class D>
-    bool DoublyLinkedListElement<T>::Contains(D *const element, D *const head)
+    bool DoublyLinkedListElement<T, TAllocator>::Contains(D *const element, D *const head)
     {
         TemplateParameter::SameOrDerivedFrom<D, T>();
         Assert(element);
@@ -43,9 +43,9 @@ namespace JsUtil
         return false;
     }
 
-    template<class T>
+    template<class T, class TAllocator>
     template<class D>
-    bool DoublyLinkedListElement<T>::ContainsSubsequence(D *const first, D *const last, D *const head)
+    bool DoublyLinkedListElement<T, TAllocator>::ContainsSubsequence(D *const first, D *const last, D *const head)
     {
         TemplateParameter::SameOrDerivedFrom<D, T>();
         Assert(first);
@@ -66,9 +66,9 @@ namespace JsUtil
         return false;
     }
 
-    template<class T>
+    template<class T, class TAllocator>
     template<class D>
-    void DoublyLinkedListElement<T>::LinkToBeginning(D *const element, D * *const head, D * *const tail)
+    void DoublyLinkedListElement<T, TAllocator>::LinkToBeginning(D *const element, D * *const head, D * *const tail)
     {
         TemplateParameter::SameOrDerivedFrom<D, T>();
         Assert(element);
@@ -92,9 +92,9 @@ namespace JsUtil
         }
     }
 
-    template<class T>
+    template<class T, class TAllocator>
     template<class D>
-    void DoublyLinkedListElement<T>::LinkToEnd(D *const element, D * *const head, D * *const tail)
+    void DoublyLinkedListElement<T, TAllocator>::LinkToEnd(D *const element, D * *const head, D * *const tail)
     {
         TemplateParameter::SameOrDerivedFrom<D, T>();
         Assert(element);
@@ -118,9 +118,9 @@ namespace JsUtil
         }
     }
 
-    template<class T>
+    template<class T, class TAllocator>
     template<class D>
-    void DoublyLinkedListElement<T>::LinkBefore(D *const element, D *const nextElement, D * *const head, D * *const tail)
+    void DoublyLinkedListElement<T, TAllocator>::LinkBefore(D *const element, D *const nextElement, D * *const head, D * *const tail)
     {
         TemplateParameter::SameOrDerivedFrom<D, T>();
         Assert(element);
@@ -149,9 +149,9 @@ namespace JsUtil
         }
     }
 
-    template<class T>
+    template<class T, class TAllocator>
     template<class D>
-    void DoublyLinkedListElement<T>::LinkAfter(D *const element, D *const previousElement, D * *const head, D * *const tail)
+    void DoublyLinkedListElement<T, TAllocator>::LinkAfter(D *const element, D *const previousElement, D * *const head, D * *const tail)
     {
         TemplateParameter::SameOrDerivedFrom<D, T>();
         Assert(element);
@@ -180,9 +180,9 @@ namespace JsUtil
         }
     }
 
-    template<class T>
+    template<class T, class TAllocator>
     template<class D>
-    void DoublyLinkedListElement<T>::UnlinkFromBeginning(D *const element, D * *const head, D * *const tail)
+    void DoublyLinkedListElement<T, TAllocator>::UnlinkFromBeginning(D *const element, D * *const head, D * *const tail)
     {
         TemplateParameter::SameOrDerivedFrom<D, T>();
         Assert(element);
@@ -209,9 +209,9 @@ namespace JsUtil
         }
     }
 
-    template<class T>
+    template<class T, class TAllocator>
     template<class D>
-    void DoublyLinkedListElement<T>::UnlinkFromEnd(D *const element, D * *const head, D * *const tail)
+    void DoublyLinkedListElement<T, TAllocator>::UnlinkFromEnd(D *const element, D * *const head, D * *const tail)
     {
         TemplateParameter::SameOrDerivedFrom<D, T>();
         Assert(element);
@@ -238,9 +238,9 @@ namespace JsUtil
         }
     }
 
-    template<class T>
+    template<class T, class TAllocator>
     template<class D>
-    void DoublyLinkedListElement<T>::UnlinkPartial(D *const element, D * *const head, D * *const tail)
+    void DoublyLinkedListElement<T, TAllocator>::UnlinkPartial(D *const element, D * *const head, D * *const tail)
     {
         TemplateParameter::SameOrDerivedFrom<D, T>();
         Assert(element);
@@ -273,18 +273,18 @@ namespace JsUtil
         // this unlink
     }
 
-    template<class T>
+    template<class T, class TAllocator>
     template<class D>
-    void DoublyLinkedListElement<T>::Unlink(D *const element, D * *const head, D * *const tail)
+    void DoublyLinkedListElement<T, TAllocator>::Unlink(D *const element, D * *const head, D * *const tail)
     {
         UnlinkPartial(element, head, tail);
         element->previous = 0;
         element->next = 0;
     }
 
-    template<class T>
+    template<class T, class TAllocator>
     template<class D>
-    void DoublyLinkedListElement<T>::MoveToBeginning(D *const element, D * *const head, D * *const tail)
+    void DoublyLinkedListElement<T, TAllocator>::MoveToBeginning(D *const element, D * *const head, D * *const tail)
     {
         TemplateParameter::SameOrDerivedFrom<D, T>();
         Assert(element);
@@ -317,9 +317,9 @@ namespace JsUtil
         element->next->previous = element;
     }
 
-    template<class T>
+    template<class T, class TAllocator>
     template<class D>
-    void DoublyLinkedListElement<T>::UnlinkSubsequenceFromEnd(D *const first, D * *const head, D * *const tail)
+    void DoublyLinkedListElement<T, TAllocator>::UnlinkSubsequenceFromEnd(D *const first, D * *const head, D * *const tail)
     {
         TemplateParameter::SameOrDerivedFrom<D, T>();
         Assert(first);
@@ -343,9 +343,9 @@ namespace JsUtil
         first->previous = 0;
     }
 
-    template<class T>
+    template<class T, class TAllocator>
     template<class D>
-    void DoublyLinkedListElement<T>::UnlinkSubsequence(D *const first, D *const last, D * *const head, D * *const tail)
+    void DoublyLinkedListElement<T, TAllocator>::UnlinkSubsequence(D *const first, D *const last, D * *const head, D * *const tail)
     {
         TemplateParameter::SameOrDerivedFrom<D, T>();
         Assert(first);
@@ -378,9 +378,9 @@ namespace JsUtil
         last->next = 0;
     }
 
-    template<class T>
+    template<class T, class TAllocator>
     template<class D>
-    void DoublyLinkedListElement<T>::MoveSubsequenceToBeginning(D *const first, D *const last, D * *const head, D * *const tail)
+    void DoublyLinkedListElement<T, TAllocator>::MoveSubsequenceToBeginning(D *const first, D *const last, D * *const head, D * *const tail)
     {
         TemplateParameter::SameOrDerivedFrom<D, T>();
         Assert(first);

--- a/lib/Common/DataStructures/SList.h
+++ b/lib/Common/DataStructures/SList.h
@@ -30,7 +30,7 @@ protected:
 public:
     uint Count() const { return count; }
 private:
-    uint count;
+    Field(uint) count;
 };
 
 #if DBG

--- a/lib/Jsrt/JsrtContext.h
+++ b/lib/Jsrt/JsrtContext.h
@@ -68,10 +68,10 @@ protected:
     void SetJavascriptLibrary(Js::JavascriptLibrary * library);
     void PinCurrentJsrtContext();
 private:
-    Js::JavascriptLibrary * javascriptLibrary;
+    Field(Js::JavascriptLibrary *) javascriptLibrary;
 
-    JsrtRuntime * runtime;
-    void* externalData = nullptr;
-    GC_MARKED_OBJECT<JsrtContext> previous;
-    GC_MARKED_OBJECT<JsrtContext> next;
+    Field(JsrtRuntime *) runtime;
+    Field(void*) externalData = nullptr;
+    Field(GC_MARKED_OBJECT<JsrtContext>) previous;
+    Field(GC_MARKED_OBJECT<JsrtContext>) next;
 };

--- a/lib/Parser/RegexRuntime.h
+++ b/lib/Parser/RegexRuntime.h
@@ -336,8 +336,8 @@ namespace UnifiedRegex
 
     struct LiteralMixin
     {
-        CharCount offset;  // into program's literal buffer
-        CharCount length;  // in char16's
+        Field(CharCount) offset;  // into program's literal buffer
+        Field(CharCount) length;  // in char16's
 
         inline LiteralMixin(CharCount offset, CharCount length) : offset(offset), length(length) {}
 
@@ -375,7 +375,7 @@ namespace UnifiedRegex
     template <typename ScannerT>
     struct ScannerMixinT : LiteralMixin
     {
-        ScannerT scanner;
+        Field(ScannerT) scanner;
 
         // scanner must be setup
         ScannerMixinT(CharCount offset, CharCount length) : LiteralMixin(offset, length) {}
@@ -628,7 +628,7 @@ namespace UnifiedRegex
 #undef MTemplate
         };
 
-        InstTag tag;
+        Field(InstTag) tag;
 
         inline Inst(InstTag tag) : tag(tag) {}
         void FreeBody(ArenaAllocator* rtAllocator) {}

--- a/lib/Runtime/Base/ExpirableObject.h
+++ b/lib/Runtime/Base/ExpirableObject.h
@@ -28,6 +28,6 @@ public:
     }
 
 private:
-    void* registrationHandle;
-    bool isUsed;
+    Field(void*) registrationHandle;
+    Field(bool) isUsed;
 };

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -436,15 +436,15 @@ namespace Js
         };
 
         // The following fields are packed into a 32-bit/64-bit, and the tag to avoid fals positive.
-        const bool          tag : 1;
-        bool                isLoopBody : 1;
-        bool                hasJittedStackClosure : 1;
-        bool                isAsmJsFunction : 1; // true if entrypoint is for asmjs function
-        State               state; // Single state member so users can query state w/o a lock
+        Field(const bool)          tag : 1;
+        Field(bool)                isLoopBody : 1;
+        Field(bool)                hasJittedStackClosure : 1;
+        Field(bool)                isAsmJsFunction : 1; // true if entrypoint is for asmjs function
+        Field(State)               state; // Single state member so users can query state w/o a lock
 #if ENABLE_NATIVE_CODEGEN
-        BYTE                pendingInlinerVersion;
-        ImplicitCallFlags   pendingImplicitCallFlags;
-        uint32              pendingPolymorphicCacheState;
+        Field(BYTE)                pendingInlinerVersion;
+        Field(ImplicitCallFlags)   pendingImplicitCallFlags;
+        Field(uint32)              pendingPolymorphicCacheState;
 
         class JitTransferData
         {
@@ -529,73 +529,73 @@ namespace Js
             void EnsureJitTimeTypeRefs(Recycler* recycler);
         };
 
-        NativeCodeData * inProcJITNaticeCodedata;
-        char* nativeDataBuffer;
+        Field(NativeCodeData *) inProcJITNaticeCodedata;
+        FieldNoBarrier(char*) nativeDataBuffer;
         union
         {
             Js::JavascriptNumber** numberArray;
             CodeGenNumberChunk* numberChunks;
         };
-        XProcNumberPageSegment* numberPageSegments;
+        Field(XProcNumberPageSegment*) numberPageSegments;
 
-        SmallSpanSequence *nativeThrowSpanSequence;
+        FieldNoBarrier(SmallSpanSequence *) nativeThrowSpanSequence;
         typedef JsUtil::BaseHashSet<RecyclerWeakReference<FunctionBody>*, Recycler, PowerOf2SizePolicy> WeakFuncRefSet;
-        WeakFuncRefSet *weakFuncRefSet;
+        Field(WeakFuncRefSet *) weakFuncRefSet;
         // Need to keep strong references to the guards here so they don't get collected while the entry point is alive.
         typedef JsUtil::BaseDictionary<Js::PropertyId, PropertyGuard*, Recycler, PowerOf2SizePolicy> SharedPropertyGuardDictionary;
-        SharedPropertyGuardDictionary* sharedPropertyGuards;
+        Field(SharedPropertyGuardDictionary*) sharedPropertyGuards;
         typedef JsUtil::List<LazyBailOutRecord, HeapAllocator> BailOutRecordMap;
-        BailOutRecordMap* bailoutRecordMap;
+        Field(BailOutRecordMap*) bailoutRecordMap;
 
         // This array holds fake weak references to type property guards. We need it to zero out the weak references when the
         // entry point is finalized and the guards are about to be freed. Otherwise, if one of the guards was to be invalidated
         // from the thread context, we would AV trying to access freed memory. Note that the guards themselves are allocated by
         // NativeCodeData::Allocator and are kept alive by the data field. The weak references are recycler allocated, and so
         // the array must be recycler allocated also, so that the recycler doesn't collect the weak references.
-        FakePropertyGuardWeakReference** propertyGuardWeakRefs;
-        EquivalentTypeCache* equivalentTypeCaches;
-        EntryPointInfo ** registeredEquivalentTypeCacheRef;
+        Field(FakePropertyGuardWeakReference**) propertyGuardWeakRefs;
+        Field(EquivalentTypeCache*) equivalentTypeCaches;
+        Field(EntryPointInfo **) registeredEquivalentTypeCacheRef;
 
-        int propertyGuardCount;
-        int equivalentTypeCacheCount;
+        Field(int) propertyGuardCount;
+        Field(int) equivalentTypeCacheCount;
 
-        uint inlineeFrameOffsetArrayOffset;
-        uint inlineeFrameOffsetArrayCount;
+        Field(uint) inlineeFrameOffsetArrayOffset;
+        Field(uint) inlineeFrameOffsetArrayCount;
 
         typedef SListCounted<ConstructorCache*, Recycler> ConstructorCacheList;
-        ConstructorCacheList* constructorCaches;
+        Field(ConstructorCacheList*) constructorCaches;
 
-        EntryPointPolymorphicInlineCacheInfo * polymorphicInlineCacheInfo;
+        Field(EntryPointPolymorphicInlineCacheInfo *) polymorphicInlineCacheInfo;
 
         // This field holds any recycler allocated references that must be kept alive until
         // we install the entry point.  It is freed at that point, so anything that must survive
         // until the EntryPointInfo itself goes away, must be copied somewhere else.
-        JitTransferData* jitTransferData;
+        Field(JitTransferData*) jitTransferData;
 
         // If we pin types this array contains strong references to types, otherwise it holds weak references.
-        void **runtimeTypeRefs;
+        Field(void **) runtimeTypeRefs;
      protected:
 #if PDATA_ENABLED
-        XDataAllocation * xdataInfo;
+        Field(XDataAllocation *) xdataInfo;
 #endif
 #endif // ENABLE_NATIVE_CODEGEN
 
-        CodeGenWorkItem * workItem;
-        Js::JavascriptMethod nativeAddress;
-        ptrdiff_t codeSize;
-        uintptr_t  mModuleAddress; //asm Module address
+        Field(CodeGenWorkItem *) workItem;
+        FieldNoBarrier(Js::JavascriptMethod) nativeAddress;
+        Field(ptrdiff_t) codeSize;
+        Field(uintptr_t)  mModuleAddress; //asm Module address
 
     protected:
-        JavascriptLibrary* library;
+        Field(JavascriptLibrary*) library;
 #if ENABLE_NATIVE_CODEGEN
         typedef JsUtil::List<NativeOffsetInlineeFramePair, HeapAllocator> InlineeFrameMap;
-        InlineeFrameMap*   inlineeFrameMap;
+        Field(InlineeFrameMap*)   inlineeFrameMap;
 #endif
 #if ENABLE_DEBUG_STACK_BACK_TRACE
         StackBackTrace*    cleanupStack;
 #endif
     public:
-        uint frameHeight;
+        Field(uint) frameHeight;
 
 #if ENABLE_DEBUG_CONFIG_OPTIONS
     public:
@@ -611,12 +611,12 @@ namespace Js
             CleanUpForFinalize
         };
     private:
-        CleanupReason cleanupReason;
+        Field(CleanupReason) cleanupReason;
 #endif
 
 #ifdef FIELD_ACCESS_STATS
     private:
-        FieldAccessStatsPtr fieldAccessStats;
+        Field(FieldAccessStatsPtr) fieldAccessStats;
 #endif
 
     public:
@@ -1021,7 +1021,7 @@ namespace Js
          };
 
      private:
-         JsUtil::List<NativeOffsetMap, HeapAllocator> nativeOffsetMaps;
+         Field(JsUtil::List<NativeOffsetMap, HeapAllocator>) nativeOffsetMaps;
      public:
          void RecordNativeMap(uint32 offset, uint32 statementIndex);
 
@@ -1048,7 +1048,7 @@ namespace Js
 #endif
 
     protected:
-        void* validationCookie;
+        Field(void*) validationCookie;
     };
 
     class FunctionEntryPointInfo : public EntryPointInfo
@@ -1460,8 +1460,8 @@ namespace Js
 
         Field(uint) m_functionNumber;  // Per thread global function number
 
-        bool m_isTopLevel : 1; // Indicates that this function is top-level function, currently being used in script profiler and debugger
-        bool m_isPublicLibraryCode: 1; // Indicates this function is public boundary library code that should be visible in JS stack
+        Field(bool) m_isTopLevel : 1; // Indicates that this function is top-level function, currently being used in script profiler and debugger
+        Field(bool) m_isPublicLibraryCode: 1; // Indicates this function is public boundary library code that should be visible in JS stack
         void CleanupFunctionProxyCounters()
         {
             PERF_COUNTER_DEC(Code, TotalFunction);

--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -2776,9 +2776,10 @@ ThreadContext::UnregisterExpirableObject(ExpirableObject* object)
 {
     Assert(this->expirableObjectList);
     Assert(object->registrationHandle != nullptr);
-    Assert(this->expirableObjectList->HasElement((ExpirableObject* const *) object->registrationHandle));
+    Assert(this->expirableObjectList->HasElement(
+        (ExpirableObject* const *)PointerValue(object->registrationHandle)));
 
-    ExpirableObject** registrationData = (ExpirableObject**) object->registrationHandle;
+    ExpirableObject** registrationData = (ExpirableObject**)PointerValue(object->registrationHandle);
     Assert(*registrationData == object);
 
     this->expirableObjectList->MoveElementTo(registrationData, this->expirableObjectDisposeList);

--- a/lib/Runtime/Language/ModuleRecordBase.h
+++ b/lib/Runtime/Language/ModuleRecordBase.h
@@ -40,9 +40,9 @@ namespace Js
         virtual bool IsSourceTextModuleRecord() { return false; }
 
     protected:
-        uint32 magicNumber;
-        ModuleNamespace* namespaceObject;
-        bool wasEvaluated;
-        JavascriptLibrary* javascriptLibrary;
+        Field(uint32) magicNumber;
+        Field(ModuleNamespace*) namespaceObject;
+        Field(bool) wasEvaluated;
+        Field(JavascriptLibrary*) javascriptLibrary;
     };
 }

--- a/lib/Runtime/Library/ArrayBuffer.h
+++ b/lib/Runtime/Library/ArrayBuffer.h
@@ -146,18 +146,18 @@ namespace Js
         static uint32 GetIndexFromVar(Js::Var arg, uint32 length, ScriptContext* scriptContext);
 
         //In most cases, the ArrayBuffer will only have one parent
-        RecyclerWeakReference<ArrayBufferParent>* primaryParent;
-        JsUtil::List<RecyclerWeakReference<ArrayBufferParent>*>* otherParents;
+        Field(RecyclerWeakReference<ArrayBufferParent>*) primaryParent;
+        Field(JsUtil::List<RecyclerWeakReference<ArrayBufferParent>*>*) otherParents;
 
 
-        BYTE  *buffer;             // Points to a heap allocated RGBA buffer, can be null
-        uint32 bufferLength;       // Number of bytes allocated
+        Field(BYTE  *) buffer;             // Points to a heap allocated RGBA buffer, can be null
+        Field(uint32) bufferLength;       // Number of bytes allocated
 
         // When an ArrayBuffer is detached, the TypedArray and DataView objects pointing to it must be made aware,
         // for this purpose the ArrayBuffer needs to hold WeakReferences to them
-        bool isDetached;
-        bool mIsAsmJsBuffer;
-        bool isBufferCleared;
+        Field(bool) isDetached;
+        Field(bool) mIsAsmJsBuffer;
+        Field(bool) isBufferCleared;
 
     };
 
@@ -167,7 +167,7 @@ namespace Js
         friend ArrayBufferBase;
 
     private:
-        ArrayBufferBase* arrayBuffer;
+        Field(ArrayBufferBase*) arrayBuffer;
 
     protected:
         DEFINE_VTABLE_CTOR_ABSTRACT(ArrayBufferParent, ArrayObject);

--- a/lib/Runtime/Library/JavascriptArray.h
+++ b/lib/Runtime/Library/JavascriptArray.h
@@ -873,7 +873,7 @@ namespace Js
         // For BoxStackInstance
         JavascriptNativeArray(JavascriptNativeArray * instance);
 
-        RecyclerWeakReference<FunctionBody> *weakRefToFuncBody;
+        Field(RecyclerWeakReference<FunctionBody> *) weakRefToFuncBody;
 
     public:
         static bool Is(Var aValue);

--- a/lib/Runtime/Library/JavascriptArrayIndexEnumeratorBase.h
+++ b/lib/Runtime/Library/JavascriptArrayIndexEnumeratorBase.h
@@ -9,10 +9,10 @@ namespace Js
     class JavascriptArrayIndexEnumeratorBase _ABSTRACT : public JavascriptEnumerator
     {
     protected:
-        JavascriptArray* arrayObject;
-        uint32 index;
-        bool doneArray;
-        EnumeratorFlags flags;
+        Field(JavascriptArray*) arrayObject;
+        Field(uint32) index;
+        Field(bool) doneArray;
+        Field(EnumeratorFlags) flags;
 
         DEFINE_VTABLE_CTOR_ABSTRACT(JavascriptArrayIndexEnumeratorBase, JavascriptEnumerator)
 

--- a/lib/Runtime/Library/JavascriptLibraryBase.h
+++ b/lib/Runtime/Library/JavascriptLibraryBase.h
@@ -130,154 +130,154 @@ namespace Js
         DynamicObject* GetURIErrorPrototype() const { return uriErrorPrototype; }
 
     protected:
-        GlobalObject* globalObject;
-        RuntimeFunction* mapConstructor;
-        RuntimeFunction* setConstructor;
-        RuntimeFunction* weakMapConstructor;
-        RuntimeFunction* weakSetConstructor;
-        RuntimeFunction* arrayConstructor;
-        RuntimeFunction* typedArrayConstructor;
-        RuntimeFunction* Int8ArrayConstructor;
-        RuntimeFunction* Uint8ArrayConstructor;
-        RuntimeFunction* Uint8ClampedArrayConstructor;
-        RuntimeFunction* Int16ArrayConstructor;
-        RuntimeFunction* Uint16ArrayConstructor;
-        RuntimeFunction* Int32ArrayConstructor;
-        RuntimeFunction* Uint32ArrayConstructor;
-        RuntimeFunction* Float32ArrayConstructor;
-        RuntimeFunction* Float64ArrayConstructor;
-        RuntimeFunction* arrayBufferConstructor;
-        RuntimeFunction* dataViewConstructor;
-        RuntimeFunction* booleanConstructor;
-        RuntimeFunction* dateConstructor;
-        RuntimeFunction* functionConstructor;
-        RuntimeFunction* numberConstructor;
-        RuntimeFunction* objectConstructor;
-        RuntimeFunction* symbolConstructor;
-        JavascriptRegExpConstructor* regexConstructor;
-        RuntimeFunction* stringConstructor;
-        RuntimeFunction* pixelArrayConstructor;
+        Field(GlobalObject*) globalObject;
+        Field(RuntimeFunction*) mapConstructor;
+        Field(RuntimeFunction*) setConstructor;
+        Field(RuntimeFunction*) weakMapConstructor;
+        Field(RuntimeFunction*) weakSetConstructor;
+        Field(RuntimeFunction*) arrayConstructor;
+        Field(RuntimeFunction*) typedArrayConstructor;
+        Field(RuntimeFunction*) Int8ArrayConstructor;
+        Field(RuntimeFunction*) Uint8ArrayConstructor;
+        Field(RuntimeFunction*) Uint8ClampedArrayConstructor;
+        Field(RuntimeFunction*) Int16ArrayConstructor;
+        Field(RuntimeFunction*) Uint16ArrayConstructor;
+        Field(RuntimeFunction*) Int32ArrayConstructor;
+        Field(RuntimeFunction*) Uint32ArrayConstructor;
+        Field(RuntimeFunction*) Float32ArrayConstructor;
+        Field(RuntimeFunction*) Float64ArrayConstructor;
+        Field(RuntimeFunction*) arrayBufferConstructor;
+        Field(RuntimeFunction*) dataViewConstructor;
+        Field(RuntimeFunction*) booleanConstructor;
+        Field(RuntimeFunction*) dateConstructor;
+        Field(RuntimeFunction*) functionConstructor;
+        Field(RuntimeFunction*) numberConstructor;
+        Field(RuntimeFunction*) objectConstructor;
+        Field(RuntimeFunction*) symbolConstructor;
+        Field(JavascriptRegExpConstructor*) regexConstructor;
+        Field(RuntimeFunction*) stringConstructor;
+        Field(RuntimeFunction*) pixelArrayConstructor;
 
-        RuntimeFunction* errorConstructor;
-        RuntimeFunction* evalErrorConstructor;
-        RuntimeFunction* rangeErrorConstructor;
-        RuntimeFunction* referenceErrorConstructor;
-        RuntimeFunction* syntaxErrorConstructor;
-        RuntimeFunction* typeErrorConstructor;
-        RuntimeFunction* uriErrorConstructor;
-        RuntimeFunction* proxyConstructor;
-        RuntimeFunction* promiseConstructor;
-        RuntimeFunction* generatorFunctionConstructor;
-        RuntimeFunction* asyncFunctionConstructor;
+        Field(RuntimeFunction*) errorConstructor;
+        Field(RuntimeFunction*) evalErrorConstructor;
+        Field(RuntimeFunction*) rangeErrorConstructor;
+        Field(RuntimeFunction*) referenceErrorConstructor;
+        Field(RuntimeFunction*) syntaxErrorConstructor;
+        Field(RuntimeFunction*) typeErrorConstructor;
+        Field(RuntimeFunction*) uriErrorConstructor;
+        Field(RuntimeFunction*) proxyConstructor;
+        Field(RuntimeFunction*) promiseConstructor;
+        Field(RuntimeFunction*) generatorFunctionConstructor;
+        Field(RuntimeFunction*) asyncFunctionConstructor;
 
-        JavascriptFunction* defaultAccessorFunction;
-        JavascriptFunction* stackTraceAccessorFunction;
-        JavascriptFunction* throwTypeErrorRestrictedPropertyAccessorFunction;
-        JavascriptFunction* debugObjectNonUserGetterFunction;
-        JavascriptFunction* debugObjectNonUserSetterFunction;
-        JavascriptFunction* debugObjectDebugModeGetterFunction;
-        JavascriptFunction* __proto__getterFunction;
-        JavascriptFunction* __proto__setterFunction;
-        JavascriptFunction* arrayIteratorPrototypeBuiltinNextFunction;
-        DynamicObject* mathObject;
+        Field(JavascriptFunction*) defaultAccessorFunction;
+        Field(JavascriptFunction*) stackTraceAccessorFunction;
+        Field(JavascriptFunction*) throwTypeErrorRestrictedPropertyAccessorFunction;
+        Field(JavascriptFunction*) debugObjectNonUserGetterFunction;
+        Field(JavascriptFunction*) debugObjectNonUserSetterFunction;
+        Field(JavascriptFunction*) debugObjectDebugModeGetterFunction;
+        Field(JavascriptFunction*) __proto__getterFunction;
+        Field(JavascriptFunction*) __proto__setterFunction;
+        Field(JavascriptFunction*) arrayIteratorPrototypeBuiltinNextFunction;
+        Field(DynamicObject*) mathObject;
         // SIMD_JS
-        DynamicObject* simdObject;
+        Field(DynamicObject*) simdObject;
 
-        DynamicObject* debugObject;
-        DynamicObject* JSONObject;
+        Field(DynamicObject*) debugObject;
+        Field(DynamicObject*) JSONObject;
 #ifdef ENABLE_INTL_OBJECT
         DynamicObject* IntlObject;
 #endif
 #if defined(ENABLE_INTL_OBJECT) || defined(ENABLE_PROJECTION)
         EngineInterfaceObject* engineInterfaceObject;
 #endif
-        DynamicObject* reflectObject;
+        Field(DynamicObject*) reflectObject;
 
-        DynamicObject* arrayPrototype;
+        Field(DynamicObject*) arrayPrototype;
 
-        DynamicObject* typedArrayPrototype;
-        DynamicObject* Int8ArrayPrototype;
-        DynamicObject* Uint8ArrayPrototype;
-        DynamicObject* Uint8ClampedArrayPrototype;
-        DynamicObject* Int16ArrayPrototype;
-        DynamicObject* Uint16ArrayPrototype;
-        DynamicObject* Int32ArrayPrototype;
-        DynamicObject* Uint32ArrayPrototype;
-        DynamicObject* Float32ArrayPrototype;
-        DynamicObject* Float64ArrayPrototype;
-        DynamicObject* Int64ArrayPrototype;
-        DynamicObject* Uint64ArrayPrototype;
-        DynamicObject* BoolArrayPrototype;
-        DynamicObject* CharArrayPrototype;
-        DynamicObject* arrayBufferPrototype;
-        DynamicObject* dataViewPrototype;
-        DynamicObject* pixelArrayPrototype;
-        DynamicObject* booleanPrototype;
-        DynamicObject* datePrototype;
-        DynamicObject* functionPrototype;
-        DynamicObject* numberPrototype;
-        ObjectPrototypeObject* objectPrototype;
-        DynamicObject* regexPrototype;
-        DynamicObject* stringPrototype;
-        DynamicObject* mapPrototype;
-        DynamicObject* setPrototype;
-        DynamicObject* weakMapPrototype;
-        DynamicObject* weakSetPrototype;
-        DynamicObject* symbolPrototype;
-        DynamicObject* iteratorPrototype;           // aka %IteratorPrototype%
-        DynamicObject* arrayIteratorPrototype;
-        DynamicObject* mapIteratorPrototype;
-        DynamicObject* setIteratorPrototype;
-        DynamicObject* stringIteratorPrototype;
-        DynamicObject* promisePrototype;
-        DynamicObject* generatorFunctionPrototype;  // aka %Generator%
-        DynamicObject* generatorPrototype;          // aka %GeneratorPrototype%
-        DynamicObject* asyncFunctionPrototype;      // aka %AsyncFunctionPrototype%
+        Field(DynamicObject*) typedArrayPrototype;
+        Field(DynamicObject*) Int8ArrayPrototype;
+        Field(DynamicObject*) Uint8ArrayPrototype;
+        Field(DynamicObject*) Uint8ClampedArrayPrototype;
+        Field(DynamicObject*) Int16ArrayPrototype;
+        Field(DynamicObject*) Uint16ArrayPrototype;
+        Field(DynamicObject*) Int32ArrayPrototype;
+        Field(DynamicObject*) Uint32ArrayPrototype;
+        Field(DynamicObject*) Float32ArrayPrototype;
+        Field(DynamicObject*) Float64ArrayPrototype;
+        Field(DynamicObject*) Int64ArrayPrototype;
+        Field(DynamicObject*) Uint64ArrayPrototype;
+        Field(DynamicObject*) BoolArrayPrototype;
+        Field(DynamicObject*) CharArrayPrototype;
+        Field(DynamicObject*) arrayBufferPrototype;
+        Field(DynamicObject*) dataViewPrototype;
+        Field(DynamicObject*) pixelArrayPrototype;
+        Field(DynamicObject*) booleanPrototype;
+        Field(DynamicObject*) datePrototype;
+        Field(DynamicObject*) functionPrototype;
+        Field(DynamicObject*) numberPrototype;
+        Field(ObjectPrototypeObject*) objectPrototype;
+        Field(DynamicObject*) regexPrototype;
+        Field(DynamicObject*) stringPrototype;
+        Field(DynamicObject*) mapPrototype;
+        Field(DynamicObject*) setPrototype;
+        Field(DynamicObject*) weakMapPrototype;
+        Field(DynamicObject*) weakSetPrototype;
+        Field(DynamicObject*) symbolPrototype;
+        Field(DynamicObject*) iteratorPrototype;           // aka %IteratorPrototype%
+        Field(DynamicObject*) arrayIteratorPrototype;
+        Field(DynamicObject*) mapIteratorPrototype;
+        Field(DynamicObject*) setIteratorPrototype;
+        Field(DynamicObject*) stringIteratorPrototype;
+        Field(DynamicObject*) promisePrototype;
+        Field(DynamicObject*) generatorFunctionPrototype;  // aka %Generator%
+        Field(DynamicObject*) generatorPrototype;          // aka %GeneratorPrototype%
+        Field(DynamicObject*) asyncFunctionPrototype;      // aka %AsyncFunctionPrototype%
 
-        DynamicObject* errorPrototype;
-        DynamicObject* evalErrorPrototype;
-        DynamicObject* rangeErrorPrototype;
-        DynamicObject* referenceErrorPrototype;
-        DynamicObject* syntaxErrorPrototype;
-        DynamicObject* typeErrorPrototype;
-        DynamicObject* uriErrorPrototype;
+        Field(DynamicObject*) errorPrototype;
+        Field(DynamicObject*) evalErrorPrototype;
+        Field(DynamicObject*) rangeErrorPrototype;
+        Field(DynamicObject*) referenceErrorPrototype;
+        Field(DynamicObject*) syntaxErrorPrototype;
+        Field(DynamicObject*) typeErrorPrototype;
+        Field(DynamicObject*) uriErrorPrototype;
 
         //SIMD Prototypes
-        DynamicObject* simdBool8x16Prototype;
-        DynamicObject* simdBool16x8Prototype;
-        DynamicObject* simdBool32x4Prototype;
-        DynamicObject* simdInt8x16Prototype;
-        DynamicObject* simdInt16x8Prototype;
-        DynamicObject* simdInt32x4Prototype;
-        DynamicObject* simdUint8x16Prototype;
-        DynamicObject* simdUint16x8Prototype;
-        DynamicObject* simdUint32x4Prototype;
-        DynamicObject* simdFloat32x4Prototype;
-        DynamicObject* simdFloat64x2Prototype;
+        Field(DynamicObject*) simdBool8x16Prototype;
+        Field(DynamicObject*) simdBool16x8Prototype;
+        Field(DynamicObject*) simdBool32x4Prototype;
+        Field(DynamicObject*) simdInt8x16Prototype;
+        Field(DynamicObject*) simdInt16x8Prototype;
+        Field(DynamicObject*) simdInt32x4Prototype;
+        Field(DynamicObject*) simdUint8x16Prototype;
+        Field(DynamicObject*) simdUint16x8Prototype;
+        Field(DynamicObject*) simdUint32x4Prototype;
+        Field(DynamicObject*) simdFloat32x4Prototype;
+        Field(DynamicObject*) simdFloat64x2Prototype;
 
-        JavascriptBoolean* booleanTrue;
-        JavascriptBoolean* booleanFalse;
+        Field(JavascriptBoolean*) booleanTrue;
+        Field(JavascriptBoolean*) booleanFalse;
 
-        Var nan;
-        Var negativeInfinite;
-        Var positiveInfinite;
-        Var pi;
-        Var minValue;
-        Var maxValue;
-        Var negativeZero;
-        RecyclableObject* undefinedValue;
-        RecyclableObject* nullValue;
+        Field(Var) nan;
+        Field(Var) negativeInfinite;
+        Field(Var) positiveInfinite;
+        Field(Var) pi;
+        Field(Var) minValue;
+        Field(Var) maxValue;
+        Field(Var) negativeZero;
+        Field(RecyclableObject*) undefinedValue;
+        Field(RecyclableObject*) nullValue;
 
-        JavascriptSymbol* symbolHasInstance;
-        JavascriptSymbol* symbolIsConcatSpreadable;
-        JavascriptSymbol* symbolIterator;
-        JavascriptSymbol* symbolSpecies;
-        JavascriptSymbol* symbolToPrimitive;
-        JavascriptSymbol* symbolToStringTag;
-        JavascriptSymbol* symbolUnscopables;
+        Field(JavascriptSymbol*) symbolHasInstance;
+        Field(JavascriptSymbol*) symbolIsConcatSpreadable;
+        Field(JavascriptSymbol*) symbolIterator;
+        Field(JavascriptSymbol*) symbolSpecies;
+        Field(JavascriptSymbol*) symbolToPrimitive;
+        Field(JavascriptSymbol*) symbolToStringTag;
+        Field(JavascriptSymbol*) symbolUnscopables;
 
     public:
-        ScriptContext* scriptContext;
+        Field(ScriptContext*) scriptContext;
 
     private:
         virtual void Dispose(bool isShutdown) override;

--- a/lib/Runtime/Library/JavascriptSimdType.h
+++ b/lib/Runtime/Library/JavascriptSimdType.h
@@ -9,7 +9,7 @@ namespace Js
     class JavascriptSIMDType : public RecyclableObject
     {
     protected:
-        SIMDValue value;
+        Field(SIMDValue) value;
     public:
         DEFINE_VTABLE_CTOR(JavascriptSIMDType, RecyclableObject);
         JavascriptSIMDType(StaticType *type);

--- a/lib/Runtime/Library/JavascriptString.h
+++ b/lib/Runtime/Library/JavascriptString.h
@@ -54,8 +54,8 @@ namespace Js
         friend bool IsValidCharCount(size_t);
 
     private:
-        const char16* m_pszValue;         // Flattened, '\0' terminated contents
-        charcount_t m_charLength;          // Length in characters, not including '\0'.
+        Field(const char16*) m_pszValue;         // Flattened, '\0' terminated contents
+        Field(charcount_t) m_charLength;          // Length in characters, not including '\0'.
 
         static const charcount_t MaxCharLength = INT_MAX - 1;  // Max number of chars not including '\0'.
 

--- a/lib/Runtime/Library/RootObjectBase.h
+++ b/lib/Runtime/Library/RootObjectBase.h
@@ -65,12 +65,12 @@ namespace Js
         RootObjectBase(DynamicType * type);
         RootObjectBase(DynamicType * type, ScriptContext* scriptContext);
 
-        HostObjectBase * hostObject;
+        Field(HostObjectBase *) hostObject;
 
         typedef JsUtil::BaseDictionary<PropertyRecord const *, RootObjectInlineCache *, Recycler> RootObjectInlineCacheMap;
-        RootObjectInlineCacheMap * loadInlineCacheMap;
-        RootObjectInlineCacheMap * loadMethodInlineCacheMap;
-        RootObjectInlineCacheMap * storeInlineCacheMap;
+        Field(RootObjectInlineCacheMap *) loadInlineCacheMap;
+        Field(RootObjectInlineCacheMap *) loadMethodInlineCacheMap;
+        Field(RootObjectInlineCacheMap *) storeInlineCacheMap;
     };
 
     template <typename Fn>

--- a/lib/Runtime/Library/SharedArrayBuffer.h
+++ b/lib/Runtime/Library/SharedArrayBuffer.h
@@ -125,7 +125,7 @@ namespace Js
         virtual bool IsValidVirtualBufferLength(uint length) { return false; }
 
     protected:
-        SharedContents *sharedContents;
+        FieldNoBarrier(SharedContents *) sharedContents;
     };
 
     class JavascriptSharedArrayBuffer : public SharedArrayBuffer

--- a/lib/Runtime/Library/TypedArray.h
+++ b/lib/Runtime/Library/TypedArray.h
@@ -193,9 +193,9 @@ namespace Js
         virtual CompareElementsFunction GetCompareElementsFunction() = 0;
 
         virtual Var Subarray(uint32 begin, uint32 end) = 0;
-        int32 BYTES_PER_ELEMENT;
-        uint32 byteOffset;
-        BYTE* buffer;   // beginning of mapped array.
+        Field(int32) BYTES_PER_ELEMENT;
+        Field(uint32) byteOffset;
+        FieldNoBarrier(BYTE*) buffer;   // beginning of mapped array.
 
     public:
         static uint32 GetOffsetOfBuffer()  { return offsetof(TypedArrayBase, buffer); }

--- a/lib/Runtime/Types/ArrayObject.h
+++ b/lib/Runtime/Types/ArrayObject.h
@@ -18,7 +18,7 @@ namespace Js
     class ArrayObject : public DynamicObject
     {
     protected:
-        uint32 length;
+        Field(uint32) length;
 
     protected:
         DEFINE_VTABLE_CTOR_ABSTRACT(ArrayObject, DynamicObject);

--- a/lib/Runtime/Types/PathTypeHandler.h
+++ b/lib/Runtime/Types/PathTypeHandler.h
@@ -14,8 +14,8 @@ namespace Js
         friend class SimplePathTypeHandler;
         friend class PathTypeHandler;
     private:
-        TypePath* typePath;
-        DynamicType* predecessorType; // Strong reference to predecessor type so that predecessor types remain in the cache even though they might not be used
+        Field(TypePath*) typePath;
+        Field(DynamicType*) predecessorType; // Strong reference to predecessor type so that predecessor types remain in the cache even though they might not be used
 
     public:
         DEFINE_GETCPPNAME();

--- a/lib/Runtime/Types/Type.h
+++ b/lib/Runtime/Types/Type.h
@@ -28,15 +28,15 @@ namespace Js
         friend class ScriptEngineBase;
 
     protected:
-        TypeId typeId;
-        TypeFlagMask flags;
+        Field(TypeId) typeId;
+        Field(TypeFlagMask) flags;
 
-        JavascriptLibrary* javascriptLibrary;
+        Field(JavascriptLibrary*) javascriptLibrary;
 
-        RecyclableObject* prototype;
-        JavascriptMethod entryPoint;
+        Field(RecyclableObject*) prototype;
+        Field(JavascriptMethod) entryPoint;
     private:
-        TypePropertyCache *propertyCache;
+        Field(TypePropertyCache *) propertyCache;
     protected:
         Type(Type * type);
         Type(ScriptContext* scriptContext, TypeId typeId, RecyclableObject* prototype, JavascriptMethod entryPoint);

--- a/lib/Runtime/Types/TypeHandler.h
+++ b/lib/Runtime/Types/TypeHandler.h
@@ -66,13 +66,13 @@ namespace Js
 
         // PropertyTypesReserved (0x1) is always on so that the DWORD formed with the following boolean doesn't look like
         // a pointer.
-        PropertyTypes propertyTypes;
-        BYTE flags;
-        uint16 offsetOfInlineSlots;
-        int slotCapacity;
-        uint16 unusedBytes;             // This always has it's lowest bit set to avoid false references
-        uint16 inlineSlotCapacity;
-        bool isNotPathTypeHandlerOrHasUserDefinedCtor;
+        Field(PropertyTypes) propertyTypes;
+        Field(BYTE) flags;
+        Field(uint16) offsetOfInlineSlots;
+        Field(int) slotCapacity;
+        Field(uint16) unusedBytes;             // This always has it's lowest bit set to avoid false references
+        Field(uint16) inlineSlotCapacity;
+        Field(bool) isNotPathTypeHandlerOrHasUserDefinedCtor;
 
     public:
         DEFINE_GETCPPNAME_ABSTRACT();

--- a/tools/RecyclerChecker/RecyclerChecker.h
+++ b/tools/RecyclerChecker/RecyclerChecker.h
@@ -4,6 +4,8 @@
 //-------------------------------------------------------------------------------------------------------
 #pragma once
 
+#include <unordered_set>
+#include <queue>
 #include "clang/Frontend/FrontendPluginRegistry.h"
 #include "clang/AST/AST.h"
 #include "clang/AST/ASTConsumer.h"
@@ -60,7 +62,7 @@ private:
     void dump(const char* name, const Set& set, const DumpItemFunc& func);
     template <class Item>
     void dump(const char* name, const set<Item>& set);
-    void dump(const char* name, const set<const Type*> set);
+    void dump(const char* name, const unordered_set<const Type*> set);
 
     void ProcessUnbarriedFields(CXXRecordDecl* recordDecl);
     bool MatchType(const string& type, const char* source, const char** pSourceEnd);


### PR DESCRIPTION
Changed the plugin to also check base classes. When a class needs write
barrier annotations, its base classes also need to be fully annotated.

Annotate all discovered base classes.
