### PR TITLE
Fix incorrect TypedArray constructor overloading

### DIFF
--- a/test/typedarray/float32array.js
+++ b/test/typedarray/float32array.js
@@ -7,32 +7,32 @@ WScript.LoadScriptFile("util.js");
 
 function oneTest(a)
 {
-a[1] = 0.54;
-a[5] = 10;
-WScript.Echo(a[5]);
-if (Object.getOwnPropertyDescriptor(a, 100000) != undefined) {
-    WScript.Echo('FAIL');
-}
+    a[1] = 0.54;
+    a[5] = 10;
+    WScript.Echo(a[5]);
+    if (Object.getOwnPropertyDescriptor(a, 100000) != undefined) {
+        WScript.Echo('FAIL');
+    }
 
-try {
-    var pro = Float32Array.prototype;
-    WScript.Echo(pro.toString());
+    try {
+        var pro = Float32Array.prototype;
+        WScript.Echo(pro.toString());
 
-    WScript.Echo("prototype is");
-    printObj(pro);
-} catch(e) {
-    WScript.Echo("constructor is");
-    printObj(Float32Array);
-}
+        WScript.Echo("prototype is");
+        printObj(pro);
+    } catch(e) {
+        WScript.Echo("constructor is");
+        printObj(Float32Array);
+    }
 
-WScript.Echo("object is");
-printObj(a);
+    WScript.Echo("object is");
+    printObj(a);
 
-a[20] =20;
-a.foo ='bar';
-WScript.Echo("object after expando is");
-printObj(a);
-WScript.Echo("");
+    a[20] =20;
+    a.foo ='bar';
+    WScript.Echo("object after expando is");
+    printObj(a);
+    WScript.Echo("");
 }
 
 WScript.Echo("test1");
@@ -86,25 +86,12 @@ test9.set(test5);
 oneTest(test9); 
 
 WScript.Echo("test10");
-try {
 var test10 = new Float32Array({});
 oneTest(test10);
-}
-catch(e)
-{
-WScript.Echo("succeed with catching" + e); 
-}
 
 WScript.Echo("test11");
-try
-{
 var test11 = new Float32Array('abcdefg');
 oneTest(test11);
-}
-catch(e)
-{
-WScript.Echo("succeed with catching" + e); 
-}
 
 WScript.Echo("test11.1");
 var test111 = new Float32Array(new String('abcdefg'));
@@ -124,35 +111,35 @@ oneTest(test13);
 WScript.Echo("test14");
 try 
 {
-var test14 = new Float32Array(arrayBuffer, 0, 0);
-oneTest(test14);
+    var test14 = new Float32Array(arrayBuffer, 0, 0);
+    oneTest(test14);
 }
 catch(e)
 {
-WScript.Echo("succeed with catching" + e); 
+    WScript.Echo("succeed with catching" + e); 
 }
 
 
 WScript.Echo("test15");
 try 
 {
-var test15 = new Float32Array(arrayBuffer, 0, 40);
-oneTest(test15);
+    var test15 = new Float32Array(arrayBuffer, 0, 40);
+    oneTest(test15);
 }
 catch(e)
 {
-WScript.Echo("succeed with catching" + e); 
+    WScript.Echo("succeed with catching" + e); 
 }
 
 WScript.Echo("test16");
 try 
 {
-var test16 = new Float32Array(arrayBuffer, 40, 4);
-oneTest(test16);
+    var test16 = new Float32Array(arrayBuffer, 40, 4);
+    oneTest(test16);
 }
 catch(e)
 {
-WScript.Echo("succeed with catching" + e); 
+    WScript.Echo("succeed with catching" + e); 
 }
 printObj(test5);
 WScript.Echo("test17");

--- a/test/typedarray/float32array_es6.baseline
+++ b/test/typedarray/float32array_es6.baseline
@@ -335,9 +335,31 @@ foo == bar
 byteLength = 48
 
 test10
-succeed with catchingTypeError: Typed array constructor argument is invalid
+undefined
+constructor is
+function Float32Array() { [native code] }
+byteLength = undefined
+object is
+
+byteLength = 0
+object after expando is
+
+foo == bar
+byteLength = 0
+
 test11
-succeed with catchingTypeError: Typed array constructor argument is invalid
+undefined
+constructor is
+function Float32Array() { [native code] }
+byteLength = undefined
+object is
+
+byteLength = 0
+object after expando is
+
+foo == bar
+byteLength = 0
+
 test11.1
 10
 constructor is

--- a/test/typedarray/float64array.js
+++ b/test/typedarray/float64array.js
@@ -7,32 +7,32 @@ WScript.LoadScriptFile("util.js");
 
 function oneTest(a)
 {
-a[1] = -0.65;
-a[5] = 10;
-WScript.Echo(a[5]);
-if (Object.getOwnPropertyDescriptor(a, 100000) != undefined) {
-    WScript.Echo('FAIL');
-}
+    a[1] = -0.65;
+    a[5] = 10;
+    WScript.Echo(a[5]);
+    if (Object.getOwnPropertyDescriptor(a, 100000) != undefined) {
+        WScript.Echo('FAIL');
+    }
 
-try {
-    var pro = Float64Array.prototype;
-    WScript.Echo(pro.toString());
+    try {
+        var pro = Float64Array.prototype;
+        WScript.Echo(pro.toString());
 
-    WScript.Echo("prototype is");
-    printObj(pro);
-} catch(e) {
-    WScript.Echo("constructor is");
-    printObj(Float64Array);
-}
+        WScript.Echo("prototype is");
+        printObj(pro);
+    } catch(e) {
+        WScript.Echo("constructor is");
+        printObj(Float64Array);
+    }
 
-WScript.Echo("object is");
-printObj(a);
+    WScript.Echo("object is");
+    printObj(a);
 
-a[20] =20;
-a.foo ='bar';
-WScript.Echo("object after expando is");
-printObj(a);
-WScript.Echo("");
+    a[20] =20;
+    a.foo ='bar';
+    WScript.Echo("object after expando is");
+    printObj(a);
+    WScript.Echo("");
 }
 
 WScript.Echo("test1");
@@ -86,25 +86,12 @@ test9.set(test5);
 oneTest(test9); 
 
 WScript.Echo("test10");
-try {
 var test10 = new Float64Array({});
 oneTest(test10);
-}
-catch(e)
-{
-WScript.Echo("succeed with catching" + e); 
-}
 
 WScript.Echo("test11");
-try
-{
 var test11 = new Float64Array('abcdefg');
 oneTest(test11);
-}
-catch(e)
-{
-WScript.Echo("succeed with catching" + e); 
-}
 
 WScript.Echo("test11.1");
 var test111 = new Float64Array(new String('abcdefg'));
@@ -123,35 +110,35 @@ oneTest(test13);
 WScript.Echo("test14");
 try 
 {
-var test14 = new Float64Array(arrayBuffer, 0, 0);
-oneTest(test14);
+    var test14 = new Float64Array(arrayBuffer, 0, 0);
+    oneTest(test14);
 }
 catch(e)
 {
-WScript.Echo("succeed with catching" + e); 
+    WScript.Echo("succeed with catching" + e); 
 }
 
 
 WScript.Echo("test15");
 try 
 {
-var test15 = new Float64Array(arrayBuffer, 0, 40);
-oneTest(test15);
+    var test15 = new Float64Array(arrayBuffer, 0, 40);
+    oneTest(test15);
 }
 catch(e)
 {
-WScript.Echo("succeed with catching" + e); 
+    WScript.Echo("succeed with catching" + e); 
 }
 
 WScript.Echo("test16");
 try 
 {
-var test16 = new Float64Array(arrayBuffer, 40, 4);
-oneTest(test16);
+    var test16 = new Float64Array(arrayBuffer, 40, 4);
+    oneTest(test16);
 }
 catch(e)
 {
-WScript.Echo("succeed with catching" + e); 
+    WScript.Echo("succeed with catching" + e); 
 }
 printObj(test5);
 WScript.Echo("test17");

--- a/test/typedarray/float64array_es6.baseline
+++ b/test/typedarray/float64array_es6.baseline
@@ -305,9 +305,31 @@ foo == bar
 byteLength = 96
 
 test10
-succeed with catchingTypeError: Typed array constructor argument is invalid
+undefined
+constructor is
+function Float64Array() { [native code] }
+byteLength = undefined
+object is
+
+byteLength = 0
+object after expando is
+
+foo == bar
+byteLength = 0
+
 test11
-succeed with catchingTypeError: Typed array constructor argument is invalid
+undefined
+constructor is
+function Float64Array() { [native code] }
+byteLength = undefined
+object is
+
+byteLength = 0
+object after expando is
+
+foo == bar
+byteLength = 0
+
 test11.1
 10
 constructor is

--- a/test/typedarray/int16array.js
+++ b/test/typedarray/int16array.js
@@ -7,32 +7,32 @@ WScript.LoadScriptFile("util.js");
 
 function oneTest(a)
 {
-a[1] = 0x8000;
-a[5] = 10;
-WScript.Echo(a[5]);
-if (Object.getOwnPropertyDescriptor(a, 100000) != undefined) {
-    WScript.Echo('FAIL');
-}
+    a[1] = 0x8000;
+    a[5] = 10;
+    WScript.Echo(a[5]);
+    if (Object.getOwnPropertyDescriptor(a, 100000) != undefined) {
+        WScript.Echo('FAIL');
+    }
 
-try {
-    var pro = Int16Array.prototype;
-    WScript.Echo(pro.toString());
+    try {
+        var pro = Int16Array.prototype;
+        WScript.Echo(pro.toString());
 
-    WScript.Echo("prototype is");
-    printObj(pro);
-} catch(e) {
-    WScript.Echo("constructor is");
-    printObj(Int16Array);
-}
+        WScript.Echo("prototype is");
+        printObj(pro);
+    } catch(e) {
+        WScript.Echo("constructor is");
+        printObj(Int16Array);
+    }
 
-WScript.Echo("object is");
-printObj(a);
+    WScript.Echo("object is");
+    printObj(a);
 
-a[20] =20;
-a.foo ='bar';
-WScript.Echo("object after expando is");
-printObj(a);
-WScript.Echo("");
+    a[20] =20;
+    a.foo ='bar';
+    WScript.Echo("object after expando is");
+    printObj(a);
+    WScript.Echo("");
 }
 
 WScript.Echo("test1");
@@ -86,25 +86,12 @@ test9.set(test5);
 oneTest(test9); 
 
 WScript.Echo("test10");
-try {
 var test10 = new Int16Array({});
 oneTest(test10);
-}
-catch(e)
-{
-WScript.Echo("succeed with catching" + e); 
-}
 
 WScript.Echo("test11");
-try
-{
 var test11 = new Int16Array('abcdefg');
 oneTest(test11);
-}
-catch(e)
-{
-WScript.Echo("succeed with catching" + e); 
-}
 
 WScript.Echo("test11.1");
 var test111 = new Int16Array(new String('abcdefg'));
@@ -124,35 +111,35 @@ oneTest(test13);
 WScript.Echo("test14");
 try 
 {
-var test14 = new Int16Array(arrayBuffer, 0, 0);
-oneTest(test14);
+    var test14 = new Int16Array(arrayBuffer, 0, 0);
+    oneTest(test14);
 }
 catch(e)
 {
-WScript.Echo("succeed with catching" + e); 
+    WScript.Echo("succeed with catching" + e); 
 }
 
 
 WScript.Echo("test15");
 try 
 {
-var test15 = new Int16Array(arrayBuffer, 0, 40);
-oneTest(test15);
+    var test15 = new Int16Array(arrayBuffer, 0, 40);
+    oneTest(test15);
 }
 catch(e)
 {
-WScript.Echo("succeed with catching" + e); 
+    WScript.Echo("succeed with catching" + e); 
 }
 
 WScript.Echo("test16");
 try 
 {
-var test16 = new Int16Array(arrayBuffer, 40, 4);
-oneTest(test16);
+    var test16 = new Int16Array(arrayBuffer, 40, 4);
+    oneTest(test16);
 }
 catch(e)
 {
-WScript.Echo("succeed with catching" + e); 
+    WScript.Echo("succeed with catching" + e); 
 }
 
 WScript.Echo("test17");

--- a/test/typedarray/int16array_es6.baseline
+++ b/test/typedarray/int16array_es6.baseline
@@ -359,9 +359,31 @@ foo == bar
 byteLength = 24
 
 test10
-succeed with catchingTypeError: Typed array constructor argument is invalid
+undefined
+constructor is
+function Int16Array() { [native code] }
+byteLength = undefined
+object is
+
+byteLength = 0
+object after expando is
+
+foo == bar
+byteLength = 0
+
 test11
-succeed with catchingTypeError: Typed array constructor argument is invalid
+undefined
+constructor is
+function Int16Array() { [native code] }
+byteLength = undefined
+object is
+
+byteLength = 0
+object after expando is
+
+foo == bar
+byteLength = 0
+
 test11.1
 10
 constructor is

--- a/test/typedarray/int32array.js
+++ b/test/typedarray/int32array.js
@@ -85,22 +85,12 @@ test9.set(test5);
 oneTest(test9);
 
 WScript.Echo("test10");
-try {
-    var test10 = new Int32Array({});
-    oneTest(test10);
-}
-catch (e) {
-    WScript.Echo("succeed with catching" + e);
-}
+var test10 = new Int32Array({});
+oneTest(test10);
 
 WScript.Echo("test11");
-try {
-    var test11 = new Int32Array('abcdefg');
-    oneTest(test11);
-}
-catch (e) {
-    WScript.Echo("succeed with catching" + e);
-}
+var test11 = new Int32Array('abcdefg');
+oneTest(test11);
 
 WScript.Echo("test11.1");
 var test111 = new Int32Array(new String('abcdefg'));

--- a/test/typedarray/int32array_es6.baseline
+++ b/test/typedarray/int32array_es6.baseline
@@ -335,9 +335,31 @@ foo == bar
 byteLength = 48
 
 test10
-succeed with catchingTypeError: Typed array constructor argument is invalid
+undefined
+constructor is
+function Int32Array() { [native code] }
+byteLength = undefined
+object is
+
+byteLength = 0
+object after expando is
+
+foo == bar
+byteLength = 0
+
 test11
-succeed with catchingTypeError: Typed array constructor argument is invalid
+undefined
+constructor is
+function Int32Array() { [native code] }
+byteLength = undefined
+object is
+
+byteLength = 0
+object after expando is
+
+foo == bar
+byteLength = 0
+
 test11.1
 10
 constructor is

--- a/test/typedarray/int8array.js
+++ b/test/typedarray/int8array.js
@@ -8,35 +8,35 @@ WScript.LoadScriptFile("util.js");
 function oneTest(a)
 {
 
-a[5] = 10;
-a[1] = 1.5;
-a[2]= 0x80;
-a[-1] = 2;
-a["-3"] = 4;
-WScript.Echo(a[5]);
-if (Object.getOwnPropertyDescriptor(a, 100000) != undefined) {
-    WScript.Echo('FAIL');
-}
+    a[5] = 10;
+    a[1] = 1.5;
+    a[2]= 0x80;
+    a[-1] = 2;
+    a["-3"] = 4;
+    WScript.Echo(a[5]);
+    if (Object.getOwnPropertyDescriptor(a, 100000) != undefined) {
+        WScript.Echo('FAIL');
+    }
 
-try {
-    var pro = Int8Array.prototype;
-    WScript.Echo(pro.toString());
+    try {
+        var pro = Int8Array.prototype;
+        WScript.Echo(pro.toString());
 
-    WScript.Echo("prototype is");
-    printObj(pro);
-} catch(e) {
-    WScript.Echo("constructor is");
-    printObj(Int8Array);
-}
+        WScript.Echo("prototype is");
+        printObj(pro);
+    } catch(e) {
+        WScript.Echo("constructor is");
+        printObj(Int8Array);
+    }
 
-WScript.Echo("object is");
-printObj(a);
+    WScript.Echo("object is");
+    printObj(a);
 
-a[20] =20;
-a.foo ='bar';
-WScript.Echo("object after expando is");
-printObj(a);
-WScript.Echo("");
+    a[20] =20;
+    a.foo ='bar';
+    WScript.Echo("object after expando is");
+    printObj(a);
+    WScript.Echo("");
 }
 
 WScript.Echo("test1");
@@ -89,24 +89,12 @@ test9.set(test5);
 oneTest(test9);
 
 WScript.Echo("test10");
-try {
 var test10 = new Int8Array({});
 oneTest(test10);
-}
-catch(e)
-{
-WScript.Echo("succeed with catching" + e);
-}
 
 WScript.Echo("test11");
-try {
 var test11 = new Int8Array('abcdefg');
 oneTest(test11);
-}
-catch(e)
-{
-WScript.Echo("succeed with catching" + e);
-}
 
 WScript.Echo("test11.1");
 var test111 = new Int8Array(new String('abcdefg'));
@@ -123,34 +111,34 @@ oneTest(test13);
 WScript.Echo("test14");
 try
 {
-var test14 = new Int8Array(arrayBuffer, 0, 0);
-oneTest(test14);
+    var test14 = new Int8Array(arrayBuffer, 0, 0);
+    oneTest(test14);
 }
 catch(e)
 {
-WScript.Echo("succeed with catching" + e);
+    WScript.Echo("succeed with catching" + e);
 }
 
 WScript.Echo("test15");
 try
 {
-var test15 = new Int8Array(arrayBuffer, 0, 40);
-oneTest(test15);
+    var test15 = new Int8Array(arrayBuffer, 0, 40);
+    oneTest(test15);
 }
- catch(e)
+catch(e)
 {
-WScript.Echo("succeed with catching" + e);
+    WScript.Echo("succeed with catching" + e);
 }
 
 WScript.Echo("test16");
 try
 {
-var test16 = new Int8Array(arrayBuffer, 40, 4);
-oneTest(test16);
+    var test16 = new Int8Array(arrayBuffer, 40, 4);
+    oneTest(test16);
 }
 catch(e)
 {
-WScript.Echo("succeed with catching" + e);
+    WScript.Echo("succeed with catching" + e);
 }
 
 printObj(test5);
@@ -189,28 +177,29 @@ printObj(test24);
 
 var arr;
 print("test23: constructor");
-    var validSizeValues = ["abc",
-                            "123",
-                              Infinity,
-                              -Infinity,
-                            ];
-        for (var i = 0; i < validSizeValues.length; i++) {
-            var size = validSizeValues[i];
-        print("size is" + size);
-            verifyNoThrow(function(){arr = new Int8Array(size);});
-            printObj(arr);
-    }
+var validSizeValues = ["abc",
+    "123",
+    undefined,
+    new Object(),
+    new Number(NaN),
+];
+for (var i = 0; i < validSizeValues.length; i++) {
+    var size = validSizeValues[i];
+    print("size is" + size);
+    verifyNoThrow(function(){arr = new Int8Array(size);});
+    printObj(arr);
+}
 
-    var invalidSizeValues = [ undefined,
-                              -1,
-                              new Object(),
-                              new Number(NaN),
-                            ];
+var invalidSizeValues = [
+    -1,
+    Infinity,
+    -Infinity,
+];
 
-        for (var i = 0; i < validSizeValues.length; i++) {
-            var size = invalidSizeValues[i];
-            verifyThrow(function(){arr = new Int8Array(size);});
-    }
+for (var i = 0; i < invalidSizeValues.length; i++) {
+    var size = invalidSizeValues[i];
+    verifyThrow(function(){arr = new Int8Array(size);});
+}
 
 WScript.Echo("test24");
 WScript.Echo(Int8Array.prototype[10]);

--- a/test/typedarray/int8array_es6.baseline
+++ b/test/typedarray/int8array_es6.baseline
@@ -415,9 +415,31 @@ foo == bar
 byteLength = 12
 
 test10
-succeed with catchingTypeError: Typed array constructor argument is invalid
+undefined
+constructor is
+function Int8Array() { [native code] }
+byteLength = undefined
+object is
+
+byteLength = 0
+object after expando is
+
+foo == bar
+byteLength = 0
+
 test11
-succeed with catchingTypeError: Typed array constructor argument is invalid
+undefined
+constructor is
+function Int8Array() { [native code] }
+byteLength = undefined
+object is
+
+byteLength = 0
+object after expando is
+
+foo == bar
+byteLength = 0
+
 test11.1
 10
 constructor is
@@ -607,25 +629,146 @@ test24
 byteLength = 2
 test23: constructor
 size isabc
-FAILED: get exception Typed array constructor argument is invalid
-1,2,3,4,5,6,7,8,9,10,11,12
-0 == 1
-1 == 2
-2 == 3
-3 == 4
-4 == 5
-5 == 6
-6 == 7
-7 == 8
-8 == 9
-9 == 10
-10 == 11
-11 == 12
-byteLength = undefined
-SUCCEEDED: get expected exception Typed array constructor argument is invalid
+
+byteLength = 0
+size is123
+0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+0 == 0
+1 == 0
+2 == 0
+3 == 0
+4 == 0
+5 == 0
+6 == 0
+7 == 0
+8 == 0
+9 == 0
+10 == 0
+11 == 0
+12 == 0
+13 == 0
+14 == 0
+15 == 0
+16 == 0
+17 == 0
+18 == 0
+19 == 0
+20 == 0
+21 == 0
+22 == 0
+23 == 0
+24 == 0
+25 == 0
+26 == 0
+27 == 0
+28 == 0
+29 == 0
+30 == 0
+31 == 0
+32 == 0
+33 == 0
+34 == 0
+35 == 0
+36 == 0
+37 == 0
+38 == 0
+39 == 0
+40 == 0
+41 == 0
+42 == 0
+43 == 0
+44 == 0
+45 == 0
+46 == 0
+47 == 0
+48 == 0
+49 == 0
+50 == 0
+51 == 0
+52 == 0
+53 == 0
+54 == 0
+55 == 0
+56 == 0
+57 == 0
+58 == 0
+59 == 0
+60 == 0
+61 == 0
+62 == 0
+63 == 0
+64 == 0
+65 == 0
+66 == 0
+67 == 0
+68 == 0
+69 == 0
+70 == 0
+71 == 0
+72 == 0
+73 == 0
+74 == 0
+75 == 0
+76 == 0
+77 == 0
+78 == 0
+79 == 0
+80 == 0
+81 == 0
+82 == 0
+83 == 0
+84 == 0
+85 == 0
+86 == 0
+87 == 0
+88 == 0
+89 == 0
+90 == 0
+91 == 0
+92 == 0
+93 == 0
+94 == 0
+95 == 0
+96 == 0
+97 == 0
+98 == 0
+99 == 0
+100 == 0
+101 == 0
+102 == 0
+103 == 0
+104 == 0
+105 == 0
+106 == 0
+107 == 0
+108 == 0
+109 == 0
+110 == 0
+111 == 0
+112 == 0
+113 == 0
+114 == 0
+115 == 0
+116 == 0
+117 == 0
+118 == 0
+119 == 0
+120 == 0
+121 == 0
+122 == 0
+byteLength = 123
+size isundefined
+
+byteLength = 0
+size is[object Object]
+
+byteLength = 0
+size isNaN
+
+byteLength = 0
 SUCCEEDED: get expected exception Invalid offset/length when creating typed array
-SUCCEEDED: get expected exception Typed array constructor argument is invalid
-SUCCEEDED: get expected exception Typed array constructor argument is invalid
+SUCCEEDED: get expected exception Invalid offset/length when creating typed array
+SUCCEEDED: get expected exception Invalid offset/length when creating typed array
 test24
 undefined
 undefined

--- a/test/typedarray/uint16array.js
+++ b/test/typedarray/uint16array.js
@@ -7,32 +7,32 @@ WScript.LoadScriptFile("util.js");
 
 function oneTest(a)
 {
-a[1] = 0x8000;
-a[5] = 10;
-WScript.Echo(a[5]);
-if (Object.getOwnPropertyDescriptor(a, 100000) != undefined) {
-    WScript.Echo('FAIL');
-}
+    a[1] = 0x8000;
+    a[5] = 10;
+    WScript.Echo(a[5]);
+    if (Object.getOwnPropertyDescriptor(a, 100000) != undefined) {
+        WScript.Echo('FAIL');
+    }
 
-try {
-    var pro = Uint16Array.prototype;
-    WScript.Echo(pro.toString());
+    try {
+        var pro = Uint16Array.prototype;
+        WScript.Echo(pro.toString());
 
-    WScript.Echo("prototype is");
-    printObj(pro);
-} catch(e) {
-    WScript.Echo("constructor is");
-    printObj(Uint16Array);
-}
+        WScript.Echo("prototype is");
+        printObj(pro);
+    } catch(e) {
+        WScript.Echo("constructor is");
+        printObj(Uint16Array);
+    }
 
-WScript.Echo("object is");
-printObj(a);
+    WScript.Echo("object is");
+    printObj(a);
 
-a[20] =20;
-a.foo ='bar';
-WScript.Echo("object after expando is");
-printObj(a);
-WScript.Echo("");
+    a[20] =20;
+    a.foo ='bar';
+    WScript.Echo("object after expando is");
+    printObj(a);
+    WScript.Echo("");
 }
 
 WScript.Echo("test1");
@@ -86,35 +86,22 @@ test9.set(test5);
 oneTest(test9); 
 
 WScript.Echo("test10");
-try {
 var test10 = new Uint16Array({});
 oneTest(test10);
-}
-catch(e)
-{
-WScript.Echo("succeed with catching" + e); 
-}
 
 WScript.Echo("test10.1");
 try {
-var test101 = new Uint16Array(test1.buffer, 3, 6);
-oneTest(test101);
+    var test101 = new Uint16Array(test1.buffer, 3, 6);
+    oneTest(test101);
 }
 catch(e)
 {
-WScript.Echo("succeed with catching" + e); 
+    WScript.Echo("succeed with catching" + e); 
 }
 
 WScript.Echo("test11");
-try
-{
 var test11 = new Uint16Array('abcdefg');
 oneTest(test11);
-}
-catch(e)
-{
-WScript.Echo("succeed with catching" + e); 
-}
 
 WScript.Echo("test11.1");
 var test111 = new Uint16Array(new String('abcdefg'));
@@ -133,35 +120,35 @@ oneTest(test13);
 WScript.Echo("test14");
 try 
 {
-var test14 = new Uint16Array(arrayBuffer, 0, 0);
-oneTest(test14);
+    var test14 = new Uint16Array(arrayBuffer, 0, 0);
+    oneTest(test14);
 }
 catch(e)
 {
-WScript.Echo("succeed with catching" + e); 
+    WScript.Echo("succeed with catching" + e); 
 }
 
 
 WScript.Echo("test15");
 try 
 {
-var test15 = new Uint16Array(arrayBuffer, 0, 40);
-oneTest(test15);
+    var test15 = new Uint16Array(arrayBuffer, 0, 40);
+    oneTest(test15);
 }
 catch(e)
 {
-WScript.Echo("succeed with catching" + e); 
+    WScript.Echo("succeed with catching" + e); 
 }
 
 WScript.Echo("test16");
 try 
 {
-var test16 = new Uint16Array(arrayBuffer, 40, 4);
-oneTest(test16);
+    var test16 = new Uint16Array(arrayBuffer, 40, 4);
+    oneTest(test16);
 }
 catch(e)
 {
-WScript.Echo("succeed with catching" + e); 
+    WScript.Echo("succeed with catching" + e); 
 }
 
 printObj(test5);

--- a/test/typedarray/uint16array_es6.baseline
+++ b/test/typedarray/uint16array_es6.baseline
@@ -363,11 +363,33 @@ foo == bar
 byteLength = 24
 
 test10
-succeed with catchingTypeError: Typed array constructor argument is invalid
+undefined
+constructor is
+function Uint16Array() { [native code] }
+byteLength = undefined
+object is
+
+byteLength = 0
+object after expando is
+
+foo == bar
+byteLength = 0
+
 test10.1
 succeed with catchingRangeError: Invalid offset/length when creating typed array
 test11
-succeed with catchingTypeError: Typed array constructor argument is invalid
+undefined
+constructor is
+function Uint16Array() { [native code] }
+byteLength = undefined
+object is
+
+byteLength = 0
+object after expando is
+
+foo == bar
+byteLength = 0
+
 test11.1
 10
 constructor is

--- a/test/typedarray/uint32array.js
+++ b/test/typedarray/uint32array.js
@@ -7,32 +7,32 @@ WScript.LoadScriptFile("util.js");
 
 function oneTest(a)
 {
-a[1] = 0x80000000;
-a[5] = 10;
-WScript.Echo(a[5]);
-if (Object.getOwnPropertyDescriptor(a, 100000) != undefined) {
-    WScript.Echo('FAIL');
-}
+    a[1] = 0x80000000;
+    a[5] = 10;
+    WScript.Echo(a[5]);
+    if (Object.getOwnPropertyDescriptor(a, 100000) != undefined) {
+        WScript.Echo('FAIL');
+    }
 
-try {
-    var pro = Uint32Array.prototype;
-    WScript.Echo(pro.toString());
+    try {
+        var pro = Uint32Array.prototype;
+        WScript.Echo(pro.toString());
 
-    WScript.Echo("prototype is");
-    printObj(pro);
-} catch(e) {
-    WScript.Echo("constructor is");
-    printObj(Uint32Array);
-}
+        WScript.Echo("prototype is");
+        printObj(pro);
+    } catch(e) {
+        WScript.Echo("constructor is");
+        printObj(Uint32Array);
+    }
 
-WScript.Echo("object is");
-printObj(a);
+    WScript.Echo("object is");
+    printObj(a);
 
-a[20] =20;
-a.foo ='bar';
-WScript.Echo("object after expando is");
-printObj(a);
-WScript.Echo("");
+    a[20] =20;
+    a.foo ='bar';
+    WScript.Echo("object after expando is");
+    printObj(a);
+    WScript.Echo("");
 }
 
 WScript.Echo("test1");
@@ -57,7 +57,7 @@ var test5 = new Uint32Array(arrayBuffer, 4, 6);
 oneTest(test5);
 
 WScript.Echo("test6");
-var mybuffer = test1.buffer; 
+var mybuffer = test1.buffer;
 WScript.Echo(mybuffer);
 var test6 = new Uint32Array(mybuffer);
 oneTest(test6);
@@ -83,38 +83,25 @@ oneTest(test9);
 
 WScript.Echo("test9.2");
 test9.set(test5);
-oneTest(test9); 
+oneTest(test9);
 
 WScript.Echo("test10");
-try {
 var test10 = new Uint32Array({});
 oneTest(test10);
-}
-catch(e)
-{
-WScript.Echo("succeed with catching" + e); 
-}
 
 WScript.Echo("test10.1");
 try {
-var test101 = new Uint32Array(test1.buffer, 3, 6);
-oneTest(test101);
+    var test101 = new Uint32Array(test1.buffer, 3, 6);
+    oneTest(test101);
 }
 catch(e)
 {
-WScript.Echo("succeed with catching" + e); 
+    WScript.Echo("succeed with catching" + e);
 }
 
 WScript.Echo("test11");
-try
-{
 var test11 = new Uint32Array('abcdefg');
 oneTest(test11);
-}
-catch(e)
-{
-WScript.Echo("succeed with catching" + e); 
-}
 
 WScript.Echo("test11.1");
 var test11 = new Uint32Array(new String('abcdefg'));
@@ -132,37 +119,37 @@ oneTest(test13);
 
 
 WScript.Echo("test14");
-try 
+try
 {
-var test14 = new Uint32Array(arrayBuffer, 0, 0);
-oneTest(test14);
+    var test14 = new Uint32Array(arrayBuffer, 0, 0);
+    oneTest(test14);
 }
 catch(e)
 {
-WScript.Echo("succeed with catching" + e); 
+    WScript.Echo("succeed with catching" + e);
 }
 
 
 WScript.Echo("test15");
-try 
+try
 {
-var test15 = new Uint32Array(arrayBuffer, 0, 40);
-oneTest(test15);
+    var test15 = new Uint32Array(arrayBuffer, 0, 40);
+    oneTest(test15);
 }
 catch(e)
 {
-WScript.Echo("succeed with catching" + e); 
+    WScript.Echo("succeed with catching" + e);
 }
 
 WScript.Echo("test16");
-try 
+try
 {
-var test16 = new Uint32Array(arrayBuffer, 40, 4);
-oneTest(test16);
+    var test16 = new Uint32Array(arrayBuffer, 40, 4);
+    oneTest(test16);
 }
 catch(e)
 {
-WScript.Echo("succeed with catching" + e); 
+    WScript.Echo("succeed with catching" + e);
 }
 
 WScript.Echo("test17");

--- a/test/typedarray/uint32array_es6.baseline
+++ b/test/typedarray/uint32array_es6.baseline
@@ -335,11 +335,33 @@ foo == bar
 byteLength = 48
 
 test10
-succeed with catchingTypeError: Typed array constructor argument is invalid
+undefined
+constructor is
+function Uint32Array() { [native code] }
+byteLength = undefined
+object is
+
+byteLength = 0
+object after expando is
+
+foo == bar
+byteLength = 0
+
 test10.1
 succeed with catchingRangeError: Invalid offset/length when creating typed array
 test11
-succeed with catchingTypeError: Typed array constructor argument is invalid
+undefined
+constructor is
+function Uint32Array() { [native code] }
+byteLength = undefined
+object is
+
+byteLength = 0
+object after expando is
+
+foo == bar
+byteLength = 0
+
 test11.1
 10
 constructor is

--- a/test/typedarray/uint8array.js
+++ b/test/typedarray/uint8array.js
@@ -7,33 +7,32 @@ WScript.LoadScriptFile("util.js");
 
 function oneTest(a)
 {
+    a[1] = 0x80;
+    a[5] = 10;
+    WScript.Echo(a[5]);
+    if (Object.getOwnPropertyDescriptor(a, 100000) != undefined) {
+        WScript.Echo('FAIL');
+    }
 
-a[1] = 0x80;
-a[5] = 10;
-WScript.Echo(a[5]);
-if (Object.getOwnPropertyDescriptor(a, 100000) != undefined) {
-    WScript.Echo('FAIL');
-}
+    try {
+        var pro = Uint8Array.prototype;
+        WScript.Echo(pro.toString());
 
-try {
-    var pro = Uint8Array.prototype;
-    WScript.Echo(pro.toString());
+        WScript.Echo("prototype is");
+        printObj(pro);
+    } catch(e) {
+        WScript.Echo("constructor is");
+        printObj(Uint8Array);
+    }
 
-    WScript.Echo("prototype is");
-    printObj(pro);
-} catch(e) {
-    WScript.Echo("constructor is");
-    printObj(Uint8Array);
-}
+    WScript.Echo("object is");
+    printObj(a);
 
-WScript.Echo("object is");
-printObj(a);
-
-a[20] =20;
-a.foo ='bar';
-WScript.Echo("object after expando is");
-printObj(a);
-WScript.Echo("");
+    a[20] =20;
+    a.foo ='bar';
+    WScript.Echo("object after expando is");
+    printObj(a);
+    WScript.Echo("");
 }
 
 WScript.Echo("test1");
@@ -58,7 +57,7 @@ var test5 = new Uint8Array(arrayBuffer, 3, 6);
 oneTest(test5);
 
 WScript.Echo("test6");
-var mybuffer = test1.buffer; 
+var mybuffer = test1.buffer;
 WScript.Echo(mybuffer);
 var test6 = new Uint8Array(mybuffer);
 oneTest(test6);
@@ -84,28 +83,15 @@ oneTest(test9);
 
 WScript.Echo("test9.2");
 test9.set(test5);
-oneTest(test9); 
+oneTest(test9);
 
 WScript.Echo("test10");
-try {
 var test10 = new Uint8Array({});
 oneTest(test10);
-}
-catch(e)
-{
-WScript.Echo("succeed with catching" + e); 
-}
 
 WScript.Echo("test11");
-try
-{
 var test11 = new Uint8Array('abcdefg');
 oneTest(test11);
-}
-catch(e)
-{
-WScript.Echo("succeed with catching" + e); 
-}
 
 WScript.Echo("test11.1");
 var test111 = new Uint16Array(new String('abcdefg'));
@@ -123,37 +109,37 @@ oneTest(test13);
 
 
 WScript.Echo("test14");
-try 
+try
 {
-var test14 = new Uint8Array(arrayBuffer, 0, 0);
-oneTest(test14);
+    var test14 = new Uint8Array(arrayBuffer, 0, 0);
+    oneTest(test14);
 }
 catch(e)
 {
-WScript.Echo("succeed with catching" + e); 
+    WScript.Echo("succeed with catching" + e);
 }
 
 
 WScript.Echo("test15");
-try 
+try
 {
-var test15 = new Uint8Array(arrayBuffer, 0, 40);
-oneTest(test15);
+    var test15 = new Uint8Array(arrayBuffer, 0, 40);
+    oneTest(test15);
 }
 catch(e)
 {
-WScript.Echo("succeed with catching" + e); 
+    WScript.Echo("succeed with catching" + e);
 }
 
 WScript.Echo("test16");
-try 
+try
 {
-var test16 = new Uint8Array(arrayBuffer, 40, 4);
-oneTest(test16);
+    var test16 = new Uint8Array(arrayBuffer, 40, 4);
+    oneTest(test16);
 }
 catch(e)
 {
-WScript.Echo("succeed with catching" + e); 
+    WScript.Echo("succeed with catching" + e);
 }
 
 WScript.Echo("test17");

--- a/test/typedarray/uint8array_es6.baseline
+++ b/test/typedarray/uint8array_es6.baseline
@@ -415,9 +415,31 @@ foo == bar
 byteLength = 12
 
 test10
-succeed with catchingTypeError: Typed array constructor argument is invalid
+undefined
+constructor is
+function Uint8Array() { [native code] }
+byteLength = undefined
+object is
+
+byteLength = 0
+object after expando is
+
+foo == bar
+byteLength = 0
+
 test11
-succeed with catchingTypeError: Typed array constructor argument is invalid
+undefined
+constructor is
+function Uint8Array() { [native code] }
+byteLength = undefined
+object is
+
+byteLength = 0
+object after expando is
+
+foo == bar
+byteLength = 0
+
 test11.1
 10
 constructor is

--- a/test/typedarray/util.js
+++ b/test/typedarray/util.js
@@ -5,52 +5,52 @@
 
 function printObj(obj)
 {
-WScript.Echo(obj.toString());
-for (i in obj)
-{
-WScript.Echo(i + " == " + obj[i]);
-};
-WScript.Echo("byteLength = " + obj.byteLength);
+    WScript.Echo(obj.toString());
+    for (var i in obj)
+    {
+        WScript.Echo(i + " == " + obj[i]);
+    };
+    WScript.Echo("byteLength = " + obj.byteLength);
 }
 
 function verifyThrow(func, obj)
 {
-var hasThrown = false;
-var result;
-try {
- result = func(obj);
-}
-catch(e)
-{
-  print("SUCCEEDED: get expected exception " + e.description);
-  hasThrown = true;
-}
-if (!hasThrown)
-{
-  print("FAILED: didn't get exception");
-}
+    var hasThrown = false;
+    var result;
+    try {
+        result = func(obj);
+    }
+    catch(e)
+    {
+        print("SUCCEEDED: get expected exception " + e.description);
+        hasThrown = true;
+    }
+    if (!hasThrown)
+    {
+        print("FAILED: didn't get exception");
+    }
 }
 
 
 function print(obj)
 {
-WScript? WScript.Echo(obj) : document.write(obj);
+    WScript? WScript.Echo(obj) : document.write(obj);
 }
 
 
 function verifyNoThrow(func, obj)
 {
-var hasThrown = false;
-var result;
-try {
- result = func(obj);
-}
-catch(e)
-{
-  print("FAILED: get exception " + e.description);
-  hasThrown = true;
-}
-return result;
+    var hasThrown = false;
+    var result;
+    try {
+        result = func(obj);
+    }
+    catch(e)
+    {
+        print("FAILED: get exception " + e.description);
+        hasThrown = true;
+    }
+    return result;
 }
 
 function setIntValue(typedArray, valueToSet) {
@@ -67,17 +67,17 @@ function testSetWithObj(startIndex, endIndex, typedArray, typedArrayForFloatInde
     var count = 0;
     valueToSet = { valueOf: function() { WScript.Echo(count); return count++; } }
 
-    for (var i = startIndex; i < endIndex; i++) 
-    {        
+    for (var i = startIndex; i < endIndex; i++)
+    {
         typedArray[-0] = valueToSet;
         typedArray[i] = valueToSet;
         typedArrayForFloatIndex[i + 0.892834] = valueToSet;
         typedArrayForStringIndex[i + "s"] = valueToSet;
     }
-    for (var i = startIndex; i < endIndex; i++) 
-    {        
+    for (var i = startIndex; i < endIndex; i++)
+    {
         WScript.Echo(typedArray[i]);
-        WScript.Echo(typedArrayForFloatIndex[i + 0.892834]); 
+        WScript.Echo(typedArrayForFloatIndex[i + 0.892834]);
         WScript.Echo(typedArrayForStringIndex[i + "s"]);
     }
     WScript.Echo(typedArray[-0]);
@@ -87,17 +87,17 @@ function testSetWithFloat(startIndex, endIndex, typedArray, typedArrayForFloatIn
 {
     var count = 0;
 
-    for (var i = startIndex; i < endIndex; i++) 
-    {        
+    for (var i = startIndex; i < endIndex; i++)
+    {
         typedArray[-0] = Math.sqrt(i);
         typedArray[i] = Math.sqrt(i);
         typedArrayForFloatIndex[i + 0.892834] = Math.sqrt(i);
         typedArrayForStringIndex[i + "s"] = Math.sqrt(i);
     }
-    for (var i = startIndex; i < endIndex; i++) 
-    {        
+    for (var i = startIndex; i < endIndex; i++)
+    {
         WScript.Echo(typedArray[i]);
-        WScript.Echo(typedArrayForFloatIndex[i + 0.892834]); 
+        WScript.Echo(typedArrayForFloatIndex[i + 0.892834]);
         WScript.Echo(typedArrayForStringIndex[i + "s"]);
     }
     WScript.Echo(typedArray[-0]);
@@ -107,17 +107,17 @@ function testSetWithInt(startIndex, endIndex, typedArray, typedArrayForFloatInde
 {
     var count = 0;
 
-    for (var i = startIndex; i < endIndex; i++) 
-    {        
+    for (var i = startIndex; i < endIndex; i++)
+    {
         typedArray[-0] = 5;
         typedArray[i] = 5;
         typedArrayForFloatIndex[i + 0.892834] = 5;
         typedArrayForStringIndex[i + "s"] = 5;
     }
-    for (var i = startIndex; i < endIndex; i++) 
-    {        
+    for (var i = startIndex; i < endIndex; i++)
+    {
         WScript.Echo(typedArray[i]);
-        WScript.Echo(typedArrayForFloatIndex[i + 0.892834]); 
+        WScript.Echo(typedArrayForFloatIndex[i + 0.892834]);
         WScript.Echo(typedArrayForStringIndex[i + "s"]);
     }
     WScript.Echo(typedArray[-0]);
@@ -127,44 +127,44 @@ function testIndexValueForSet(typedArray) {
     var count = 5;
     var obj = { valueOf: function() { WScript.Echo(count++); return count; } }
     var testIndices  = [
-    0,
-    "0",
-    -0,    // sets index 0
-    "-0",                                    
-    -2, 
-    "-2", 
-    1073741823, 
-    "1073741823", 
-    1, 
-    "1", 
-    2147483648 /*2 ^ 31*/, 
-    "2147483648" /*"2 ^ 31"*/,
-    2147483647 /*(2 ^ 31) - 1*/, 
-    "2147483647" /* "(2 ^ 31) - 1"*/ ,
-    4294967296 /*2 ^ 32*/,
-    "4294967296" /*"2 ^ 32"*/,
-    4294967295 /*(2 ^ 32) - 1*/,
-    "4294967295" /*(2 ^ 32) - 1*/,
-    1.5,
-    "1.5",
-    "a", /* doesn't call ToNumber(obj) */
-    1.0000000000000000000000000e+9,
-    "1.0000000000000000000000000e-9",
-    1/"a", /* NaN */
-    1/0,
-    -1/0,
-    (1/0).toString(),
-    (-1/0).toString()
-    ];
-    
+        0,
+        "0",
+        -0,    // sets index 0
+        "-0",
+        -2,
+        "-2",
+        1073741823,
+        "1073741823",
+        1,
+        "1",
+        2147483648 /*2 ^ 31*/,
+        "2147483648" /*"2 ^ 31"*/,
+        2147483647 /*(2 ^ 31) - 1*/,
+        "2147483647" /* "(2 ^ 31) - 1"*/ ,
+        4294967296 /*2 ^ 32*/,
+        "4294967296" /*"2 ^ 32"*/,
+        4294967295 /*(2 ^ 32) - 1*/,
+        "4294967295" /*(2 ^ 32) - 1*/,
+        1.5,
+        "1.5",
+        "a", /* doesn't call ToNumber(obj) */
+        1.0000000000000000000000000e+9,
+        "1.0000000000000000000000000e-9",
+        1/"a", /* NaN */
+        1/0,
+        -1/0,
+        (1/0).toString(),
+        (-1/0).toString()
+            ];
+
     for(var i = 0; i < testIndices.length; i++)
     {
         var testIndex = testIndices[i];
         if(typeof testIndex === "string")
         {
             WScript.Echo('***testing index ' + i + ' : "' + testIndex + '"');
-        } 
-        else 
+        }
+        else
         {
             WScript.Echo('***testing index ' + i + ' : ' + testIndex );
         }


### PR DESCRIPTION
Fixes #2014.

Since TypedArray was originally implemented the spec has changed and the
constructors have changed how they handle arguments.  Explicit undefined
is no longer a TypeError, instead it converts to zero.  Likewise bools,
null, strings, symbols, and numbers are converted via the ToIndex
algorithm.  Objects are treated as array-likes if not iterables, nor
array buffers nor typed arrays.