### PR TITLE
ENABLE_SEH instead of DISABLE_SEH

### DIFF
--- a/bin/ch/ch.cpp
+++ b/bin/ch/ch.cpp
@@ -663,20 +663,18 @@ HRESULT ExecuteTestWithMemoryCheck(char* fileName)
     ChakraRTInterface::SetEnableCheckMemoryLeakOutput(false);
 #endif
 
-#ifdef _WIN32
     __try
     {
         hr = ExecuteTest(fileName);
     }
+#ifdef ENABLE_SEH
+    // REVIEW: Do we need a SEH handler here?
     __except (HostExceptionFilter(GetExceptionCode(), GetExceptionInformation()))
     {
         Assert(false);
     }
-#else
-    // REVIEW: Do we need a SEH handler here?
-    hr = ExecuteTest(fileName);
-    if (FAILED(hr)) exit(0);
-#endif // _WIN32
+#endif
+    if (FAILED(hr)) exit(1);
 
     _flushall();
 #ifdef CHECK_MEMORY_LEAK

--- a/bin/ch/stdafx.h
+++ b/bin/ch/stdafx.h
@@ -148,6 +148,9 @@ do { \
 #include "JITProcessManager.h"
 #endif
 
+// Include this last. GNU redefines __try as `try`
+#include "PlatformAgnostic/Exception.h"
+
 class AutoString
 {
     size_t length;

--- a/lib/Common/Common/Jobs.cpp
+++ b/lib/Common/Common/Jobs.cpp
@@ -1242,13 +1242,11 @@ namespace JsUtil
         threadData->backgroundPageAllocator.SetConcurrentThreadId(GetCurrentThreadId());
 #endif
 
-#ifdef DISABLE_SEH
-        processor->Run(threadData);
-#else
         __try
         {
             processor->Run(threadData);
         }
+#ifdef ENABLE_SEH
         __except(ExceptFilter(GetExceptionInformation()))
         {
             Assert(false);
@@ -1271,7 +1269,7 @@ namespace JsUtil
         }
     }
 
-#ifndef DISABLE_SEH
+#ifdef ENABLE_SEH
     int BackgroundJobProcessor::ExceptFilter(LPEXCEPTION_POINTERS pEP)
     {
 #if DBG && defined(_WIN32)

--- a/lib/Common/Common/Jobs.h
+++ b/lib/Common/Common/Jobs.h
@@ -536,7 +536,7 @@ namespace JsUtil
 
     private:
         static unsigned int WINAPI StaticThreadProc(void *lpParam);
-#ifndef DISABLE_SEH
+#ifdef ENABLE_SEH
         static int ExceptFilter(LPEXCEPTION_POINTERS pEP);
 #endif
 

--- a/lib/Common/CommonDefines.h
+++ b/lib/Common/CommonDefines.h
@@ -111,10 +111,8 @@
 // dep: IActiveScriptProfilerCallback, IActiveScriptProfilerHeapEnum
 #define ENABLE_SCRIPT_PROFILING
 #ifndef __clang__
-// xplat-todo: change DISABLE_SEH to ENABLE_SEH and move here
 #define ENABLE_SIMDJS
 #endif
-
 #define ENABLE_CUSTOM_ENTROPY
 #endif
 
@@ -585,10 +583,6 @@
 #define PDATA_ENABLED 0
 #define ALLOC_XDATA (false)
 #endif
-#endif
-
-#ifndef _WIN32
-#define DISABLE_SEH 1
 #endif
 
 //----------------------------------------------------------------------------------------------------

--- a/lib/Common/CommonPal.h
+++ b/lib/Common/CommonPal.h
@@ -678,3 +678,4 @@ namespace PlatformAgnostic
 #include "PlatformAgnostic/Numbers.h"
 #include "PlatformAgnostic/SystemInfo.h"
 #include "PlatformAgnostic/Thread.h"
+#include "PlatformAgnostic/Exception.h"

--- a/lib/Common/Core/FaultInjection.cpp
+++ b/lib/Common/Core/FaultInjection.cpp
@@ -906,9 +906,9 @@ namespace Js
         {
             RemoveVectoredExceptionHandler(vectoredExceptionHandler);
 
-            // remove the handler from the list second time. 
-            // This code is called inside an exception handler, when the exception handler is called, 
-            // the refcount of the handler in ntdll!LdrpVectorHandlerList is increased, 
+            // remove the handler from the list second time.
+            // This code is called inside an exception handler, when the exception handler is called,
+            // the refcount of the handler in ntdll!LdrpVectorHandlerList is increased,
             // so need to call RemoveVectoredExceptionHandler twice to really remove the handler from the list
             // otherwise the exception from the handler itself will re-enter the handler
             RemoveVectoredExceptionHandler(vectoredExceptionHandler);
@@ -1080,7 +1080,7 @@ namespace Js
         case CountOnly:
             break;
         case DisplayAvailableFaultTypes:
-        case InstallExceptionHandlerOnly:        
+        case InstallExceptionHandlerOnly:
             return false;
         default:
             AssertMsg(false, "Invalid FaultInjection mode");
@@ -1206,7 +1206,7 @@ namespace Js
 
         bool needDump = true;
         uintptr_t ip = (uintptr_t)ep->ExceptionRecord->ExceptionAddress;
-        uintptr_t offset = 0;       
+        uintptr_t offset = 0;
 
         // static to not use local stack space since stack space might be low at this point
         THREAD_LOCAL static char16 modulePath[MAX_PATH + 1];
@@ -1435,7 +1435,7 @@ namespace Js
         if (ExceptionInfo->ExceptionRecord->ExceptionCode == STATUS_STACK_OVERFLOW) // hard stack overflow
         {
             DebugBreak(); // let the postmortem debugger to create the dump, make sure they are filing bug with same bucket
-        }        
+        }
 
         __try
         {
@@ -1443,10 +1443,12 @@ namespace Js
             // even stack is not deep yet
             FaultInjection::Global.FaultInjectionAnalyzeException(ExceptionInfo);
         }
+#ifdef ENABLE_SEH
         __except (EXCEPTION_EXECUTE_HANDLER)
         {
             DebugBreak();
         }
+#endif
         inExceptionHandler = false;
 
         return EXCEPTION_EXECUTE_HANDLER;

--- a/lib/Common/Exceptions/ReportError.cpp
+++ b/lib/Common/Exceptions/ReportError.cpp
@@ -21,7 +21,7 @@ void ReportFatalException(
         DebugBreak();
     }
 
-#ifdef DISABLE_SEH
+#ifndef ENABLE_SEH
     TerminateProcess(GetCurrentProcess(), (UINT)DBG_TERMINATE_PROCESS);
 #else
     __try
@@ -34,7 +34,7 @@ void ReportFatalException(
     __except(FatalExceptionFilter(GetExceptionInformation()))
     {
     }
-#endif // DISABLE_SEH
+#endif // ENABLE_SEH
 }
 
 // Disable optimization make sure all the frames are still available in Dr. Watson bug reports.

--- a/lib/Common/Exceptions/ReportError.h
+++ b/lib/Common/Exceptions/ReportError.h
@@ -23,7 +23,7 @@ enum ErrorReason
     Fatal_Debugger_AttachDetach_Failure = 15,
     Fatal_EntryExitRecordCorruption = 16,
     Fatal_UnexpectedExceptionHandling = 17,
-    Fatal_RpcFailure = 18, 
+    Fatal_RpcFailure = 18,
     // Reserved = 19,
     Fatal_TTDAbort = 20
 };
@@ -70,7 +70,7 @@ void FromDOM_NoScriptScope_fatal_error();
 void Debugger_AttachDetach_fatal_error(HRESULT hr);
 void RpcFailure_fatal_error(HRESULT hr);
 
-#ifndef DISABLE_SEH
+#ifdef ENABLE_SEH
 // RtlReportException is available on Vista and up, but we cannot use it for OOB release.
 // Use UnhandleExceptionFilter to let the default handler handles it.
 inline LONG FatalExceptionFilter(
@@ -113,9 +113,11 @@ static STDMETHODIMP DebugApiWrapper(Fn fn)
         return fn();
 #if ENABLE_DEBUG_API_WRAPPER
     }
+#ifdef ENABLE_SEH
     __except(FatalExceptionFilter(GetExceptionInformation()))
     {
     }
     return E_FAIL;
-#endif
+#endif // ENABLE_SEH
+#endif // ENABLE_DEBUG_API_WRAPPER
 }

--- a/lib/Common/Exceptions/Throw.cpp
+++ b/lib/Common/Exceptions/Throw.cpp
@@ -147,11 +147,13 @@ namespace Js {
                 RaiseException(0, 0, 0, NULL);
             }
         }
+#ifdef ENABLE_SEH
         __except(Throw::GenerateDump(GetExceptionInformation(), filePath,
             terminate? EXCEPTION_CONTINUE_SEARCH : EXCEPTION_EXECUTE_HANDLER), needLock)
         {
             // we don't do anything interesting in this handler
         }
+#endif
     }
 
     void Throw::GenerateDumpForAssert(LPCWSTR filePath)
@@ -160,10 +162,12 @@ namespace Js {
         {
             RaiseException(STATUS_ASSERTION_FAILURE, EXCEPTION_NONCONTINUABLE, 0, NULL);
         }
+#ifdef ENABLE_SEH
         __except (Throw::GenerateDump(GetExceptionInformation(), filePath, EXCEPTION_CONTINUE_SEARCH), false)
         {
             // no-op
         }
+#endif
     }
 
     int Throw::GenerateDump(PEXCEPTION_POINTERS exceptInfo, LPCWSTR filePath, int ret, bool needLock)

--- a/lib/Common/Memory/Recycler.cpp
+++ b/lib/Common/Memory/Recycler.cpp
@@ -3346,8 +3346,8 @@ Recycler::CollectWithHeuristic()
 {
     // CollectHeuristic_Never flag should only be used with exhaustive candidate
     Assert((flags & CollectHeuristic_Never) == 0);
-    
-    BOOL isScriptContextCloseGCPending = FALSE; 
+
+    BOOL isScriptContextCloseGCPending = FALSE;
     const BOOL allocSize = flags & CollectHeuristic_AllocSize;
     const BOOL timedIfScriptActive = flags & CollectHeuristic_TimeIfScriptActive;
     const BOOL timedIfInScript = flags & CollectHeuristic_TimeIfInScript;
@@ -5486,10 +5486,12 @@ Recycler::StaticThreadProc(LPVOID lpParameter)
 #endif
         ret = recycler->ThreadProc();
     }
+#ifdef ENABLE_SEH
     __except(Recycler::ExceptFilter(GetExceptionInformation()))
     {
         Assert(false);
     }
+#endif
 
     return ret;
 }
@@ -6221,10 +6223,12 @@ RecyclerParallelThread::StaticThreadProc(LPVOID lpParameter)
 #endif
         ret = 0;
     }
+#ifdef ENABLE_SEH
     __except(Recycler::ExceptFilter(GetExceptionInformation()))
     {
         Assert(false);
     }
+#endif
 
     return ret;
 }

--- a/lib/Common/PlatformAgnostic/Exception.h
+++ b/lib/Common/PlatformAgnostic/Exception.h
@@ -1,0 +1,15 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#ifdef __clang__
+    #undef __try
+    #undef __finally
+    #define __try
+    #define __finally
+#else
+    #ifndef ENABLE_SEH
+        #define ENABLE_SEH 1
+    #endif
+#endif

--- a/lib/Runtime/Library/RuntimeLibraryPch.h
+++ b/lib/Runtime/Library/RuntimeLibraryPch.h
@@ -100,3 +100,8 @@
 #else
 #define JS_DIAG_INLINE
 #endif
+
+// Include this last. GNU redefines __try as `try`
+#ifdef __clang__
+#include "PlatformAgnostic/Exception.h"
+#endif


### PR DESCRIPTION
I was enabling debugger on xplat. Saw DISABLE_SEH and notes on ENABLE_SEH.
Instead of adding another DISABLE_SEH, introducing couple of changes.

This PR also fixes an exit code issue with `ch` and SEH related build issues with Windows/Clang

New:

- Both `__try` and `__finally` are no-op on xplat.
- `ifdef` out only the `__except` logic. 