### PR TITLE
swb,plugin: handle RecyclerNewWithBarrierEnumClass/WithInfoBits

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -390,7 +390,7 @@ if [[ $WB_CHECK || $WB_ANALYZE ]]; then
 
         WB_FILE_CMAKELISTS="$CHAKRACORE_DIR/$WB_FILE_DIR/CMakeLists.txt"
         if [[ -f $WB_FILE_CMAKELISTS ]]; then
-            SUBDIR=$(grep -i add_library $WB_FILE_CMAKELISTS | sed "s/.*(\(.*\) .*/\1/")
+            SUBDIR=$(grep -i add_library $WB_FILE_CMAKELISTS | sed "s/.*(\([^ ]*\) .*/\1/")
         else
             echo "$WB_FILE_CMAKELISTS not found." && exit 1
         fi

--- a/tools/RecyclerChecker/Helpers.h
+++ b/tools/RecyclerChecker/Helpers.h
@@ -57,3 +57,8 @@ bool Contains(const Set& s, const Item& item)
 {
     return s.find(item) != s.end();
 }
+
+inline bool Contains(const string& s, const char* sub)
+{
+    return s.find(sub) != string::npos;
+}


### PR DESCRIPTION
Update the swb clang plugin to recognize RecyclerNewWithBarrierEnumClass
and RecyclerNewWithBarrierWithInfoBits.

Found no missing annotations.
