### PR TITLE
Proxy object should be allowed in WeakMaps

### DIFF
--- a/lib/Runtime/Library/JavascriptProxy.cpp
+++ b/lib/Runtime/Library/JavascriptProxy.cpp
@@ -194,7 +194,8 @@ namespace Js
     {
         PROBE_STACK(GetScriptContext(), Js::Constants::MinStackDefault);
 
-        Assert((static_cast<DynamicType*>(GetType()))->GetTypeHandler()->GetPropertyCount() == 0);
+        Assert((static_cast<DynamicType*>(GetType()))->GetTypeHandler()->GetPropertyCount() == 0 ||
+            (static_cast<DynamicType*>(GetType()))->GetTypeHandler()->GetPropertyId(GetScriptContext(), 0) == InternalPropertyIds::WeakMapKeyMap);
         JavascriptFunction* gOPDMethod = GetMethodHelper(PropertyIds::getOwnPropertyDescriptor, requestContext);
         Var getResult;
         ThreadContext* threadContext = requestContext->GetThreadContext();
@@ -560,10 +561,13 @@ namespace Js
 
     BOOL JavascriptProxy::GetInternalProperty(Var instance, PropertyId internalPropertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext)
     {
-        // the spec change to not recognizing internal slots in proxy. We should remove the ability to forward to internal slots.
+        if (internalPropertyId == InternalPropertyIds::WeakMapKeyMap)
+        {
+            return __super::GetInternalProperty(instance, internalPropertyId, value, info, requestContext);
+        }
         return FALSE;
     }
-
+  
     BOOL JavascriptProxy::GetAccessors(PropertyId propertyId, Var* getter, Var* setter, ScriptContext * requestContext)
     {
         PropertyDescriptor result;
@@ -656,7 +660,10 @@ namespace Js
 
     BOOL JavascriptProxy::SetInternalProperty(PropertyId internalPropertyId, Var value, PropertyOperationFlags flags, PropertyValueInfo* info)
     {
-        // the spec change to not recognizing internal slots in proxy. We should remove the ability to forward to internal slots.
+        if (internalPropertyId == InternalPropertyIds::WeakMapKeyMap)
+        {
+            return __super::SetInternalProperty(internalPropertyId, value, flags, info);
+        }
         return FALSE;
     }
 

--- a/test/es6/proxybugs.js
+++ b/test/es6/proxybugs.js
@@ -1,0 +1,43 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+
+var tests = [
+    {
+        name: "Setting proxy object on Map and WeakMap",
+        body() {
+            [WeakMap, Map].forEach(function(ctor) {
+                var target = {};
+                let p = new Proxy(target, {});
+                let map = new ctor();
+                map.set(p, 101);
+                assert.areEqual(map.get(p), 101, ctor.name + " map should be able to set and get the proxy object");
+                p.x = 20;
+                assert.areEqual(target.x, 20, "target object should work as expected even after proxy object is added to map");
+            });
+        }
+    },
+    {
+        name: "Setting proxy object on Map and WeakMap - multiple sets and delete",
+        body() {
+            [WeakMap, Map].forEach(function(ctor) {
+                var target = {};
+                let p = new Proxy(target, {});
+                let map = new ctor();
+                map.set(p, 101);
+                assert.areEqual(map.get(p), 101);
+                map.delete(p);
+                assert.areEqual(map.get(p), undefined, ctor.name + " map can remove the proxy object properly");
+                map.set(p, 102);
+                assert.areEqual(map.get(p), 102, ctor.name + " proxy object can be set again and it returns 102");
+                p.x = 20;
+                assert.areEqual(target.x, 20, "target object should work as expected even after proxy object is added to map");
+            });
+        }
+    }
+];
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -722,6 +722,12 @@
   </test>
   <test>
     <default>
+      <files>proxybugs.js</files>
+      <compile-flags>-args summary -endargs</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>proxybug3.js</files>
     </default>
   </test>


### PR DESCRIPTION
When we use the WeakMaps we set the internal property on the object,
however proxy object didn't handle the Set/GetInternalProperty. Fixed that
by adding the support.

Added a test
