### PR TITLE
Fix TVS false positive by using a failfast

### DIFF
--- a/lib/Common/Core/Assertions.h
+++ b/lib/Common/Core/Assertions.h
@@ -75,6 +75,18 @@ __declspec(selectany) int IsInAssert = false;
 #define AnalysisAssert(x)               Assert(x); __analysis_assume(x)
 #define AnalysisAssertMsg(x, comment)   AssertMsg(x, comment); __analysis_assume(x)
 
+#ifdef DBG
+#define AssertOrFailFast(x)                 Assert(x)
+#define AssertOrFailFastMsg(x, msg)         AssertMsg(x, msg)
+#define AnalysisAssertOrFailFast(x)         AnalysisAssert(x)
+#define AnalysisAssertOrFailFastMsg(x, msg) AnalysisAssertMsg(x, msg)
+#else
+#define AssertOrFailFast(x)                 do { if (!(x)) { Js::Throw::FatalInternalError(); } } while (false)
+#define AssertOrFailFastMsg(x, msg)         AssertOrFailFast(x)
+#define AnalysisAssertOrFailFast(x)         AssertOrFailFast(x)
+#define AnalysisAssertOrFailFastMsg(x, msg) AssertOrFailFast(x)
+#endif
+
 #define Unused(var) var;
 
 #define UNREACHED   (0)

--- a/lib/Common/Core/Assertions.h
+++ b/lib/Common/Core/Assertions.h
@@ -75,16 +75,18 @@ __declspec(selectany) int IsInAssert = false;
 #define AnalysisAssert(x)               Assert(x); __analysis_assume(x)
 #define AnalysisAssertMsg(x, comment)   AssertMsg(x, comment); __analysis_assume(x)
 
+#define FailFast(x) do { if (!(x)) { Js::Throw::FatalInternalError(); } } while (false)
+
 #ifdef DBG
 #define AssertOrFailFast(x)                 Assert(x)
 #define AssertOrFailFastMsg(x, msg)         AssertMsg(x, msg)
 #define AnalysisAssertOrFailFast(x)         AnalysisAssert(x)
 #define AnalysisAssertOrFailFastMsg(x, msg) AnalysisAssertMsg(x, msg)
 #else
-#define AssertOrFailFast(x)                 do { if (!(x)) { Js::Throw::FatalInternalError(); } } while (false)
-#define AssertOrFailFastMsg(x, msg)         AssertOrFailFast(x)
-#define AnalysisAssertOrFailFast(x)         AssertOrFailFast(x)
-#define AnalysisAssertOrFailFastMsg(x, msg) AssertOrFailFast(x)
+#define AssertOrFailFast(x)                 FailFast(x)
+#define AssertOrFailFastMsg(x, msg)         FailFast(x)
+#define AnalysisAssertOrFailFast(x)         FailFast(x)
+#define AnalysisAssertOrFailFastMsg(x, msg) FailFast(x)
 #endif
 
 #define Unused(var) var;

--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -13378,7 +13378,7 @@ DeferredFunctionStub * BuildDeferredStubTree(ParseNode *pnodeFnc, Recycler *recy
             pnodeChild = pnodeChild->sxBlock.pnodeNext;
             continue;
         }
-        Assert(i < nestedCount);
+        AssertOrFailFast(i < nestedCount);
 
         if (pnodeChild->sxFnc.IsGeneratedDefault())
         {
@@ -13387,7 +13387,7 @@ DeferredFunctionStub * BuildDeferredStubTree(ParseNode *pnodeFnc, Recycler *recy
             continue;
         }
 
-        __analysis_assume(i < nestedCount);
+        AnalysisAssertOrFailFast(i < nestedCount);
 
         deferredStubs[i].fncFlags = pnodeChild->sxFnc.fncFlags;
         deferredStubs[i].nestedCount = pnodeChild->sxFnc.nestedCount;


### PR DESCRIPTION
Fixes OS 9022474.

PREFast warns of a potential overflow when writing halfway through a struct. We don't think this will overflow halfway, but change to a failfast just in case.
