### PR TITLE
Add option to delay full JIT small functions

### DIFF
--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -409,6 +409,7 @@ PHASE(All)
 #define DEFAULT_CONFIG_DumpCommentsFromReferencedFiles (false)
 #define DEFAULT_CONFIG_ExtendedErrorStackForTestHost (false)
 #define DEFAULT_CONFIG_ForceSplitScope      (false)
+#define DEFAULT_CONFIG_DelayFullJITSmallFunc (0)
 
 
 //Following determines inline thresholds
@@ -1072,6 +1073,7 @@ FLAGNR(Boolean, ForceFastPath         , "Force fast-paths in native codegen", DE
 FLAGNR(Boolean, ForceFloatPref        , "Force float preferencing (JIT only)", false)
 FLAGNR(Boolean, ForceJITLoopBody      , "Force jit loop body only", DEFAULT_CONFIG_ForceJITLoopBody)
 FLAGNR(Boolean, DumpCommentsFromReferencedFiles, "Allow printing comments of comment-table of the referenced file as well (use with -trace:CommentTable)", DEFAULT_CONFIG_DumpCommentsFromReferencedFiles)
+FLAGNR(Number,  DelayFullJITSmallFunc , "Scale Full JIT threshold for small functions which are going to be inlined soon. To provide fraction scale, the final scale is scale following this option devided by 10", DEFAULT_CONFIG_DelayFullJITSmallFunc)
 
 #ifdef _M_ARM
 FLAGNR(Boolean, ForceLocalsPtr        , "Force use of alternative locals pointer (JIT only)", false)

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -6834,9 +6834,9 @@ namespace Js
                     - If the size is >= 100, scale by 1.6
             */
             const uint loopPercentage = GetByteCodeInLoopCount() * 100 / max(1u, GetByteCodeCount());
-            const int byteCodeSizeThresholdForInlineCandidate = CONFIG_FLAG(InlineThreshold) + CONFIG_FLAG(InlineThresholdAdjustCountInSmallFunction);
+            const int byteCodeSizeThresholdForInlineCandidate = CONFIG_FLAG(LoopInlineThreshold);
             bool delayFullJITThisFunc =
-                (CONFIG_FLAG(DelayFullJITSmallFunc) > 0) && (byteCodeSizeThresholdForInlineCandidate < 0 || this->GetByteCodeWithoutLDACount() > (uint)byteCodeSizeThresholdForInlineCandidate);
+                (CONFIG_FLAG(DelayFullJITSmallFunc) > 0) && (this->GetByteCodeWithoutLDACount() <= (uint)byteCodeSizeThresholdForInlineCandidate);
 
             if(loopPercentage <= 50 || delayFullJITThisFunc)
             {

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -6834,11 +6834,19 @@ namespace Js
                     - If the size is >= 100, scale by 1.6
             */
             const uint loopPercentage = GetByteCodeInLoopCount() * 100 / max(1u, GetByteCodeCount());
-            if(loopPercentage <= 50)
+            const int byteCodeSizeThresholdForInlineCandidate = CONFIG_FLAG(InlineThreshold) + CONFIG_FLAG(InlineThresholdAdjustCountInSmallFunction);
+            bool delayFullJITThisFunc =
+                (CONFIG_FLAG(DelayFullJITSmallFunc) > 0) && (byteCodeSizeThresholdForInlineCandidate < 0 || this->GetByteCodeWithoutLDACount() > (uint)byteCodeSizeThresholdForInlineCandidate);
+
+            if(loopPercentage <= 50 || delayFullJITThisFunc)
             {
                 const uint straightLineSize = GetByteCodeCount() - GetByteCodeInLoopCount();
                 double fullJitDelayMultiplier;
-                if(straightLineSize < 50)
+                if (delayFullJITThisFunc)
+                {
+                    fullJitDelayMultiplier = CONFIG_FLAG(DelayFullJITSmallFunc) / 10.0;
+                }
+                else if(straightLineSize < 50)
                 {
                     fullJitDelayMultiplier = 1.2;
                 }


### PR DESCRIPTION
Add a new option -delayFullJITSmallFunc. This is supposed to help JIT through but not turned on this time.