### PR TITLE
Two bug fixes

### DIFF
--- a/lib/Backend/IRBuilder.cpp
+++ b/lib/Backend/IRBuilder.cpp
@@ -7473,7 +7473,8 @@ IRBuilder::DoClosureRegCheck(Js::RegSlot reg)
     }
     if (reg == m_func->GetJITFunctionBody()->GetEnvReg() ||
         reg == m_func->GetJITFunctionBody()->GetLocalClosureReg() ||
-        reg == m_func->GetJITFunctionBody()->GetLocalFrameDisplayReg())
+        reg == m_func->GetJITFunctionBody()->GetLocalFrameDisplayReg() ||
+        reg == m_func->GetJITFunctionBody()->GetParamClosureReg())
     {
         Js::Throw::FatalInternalError();
     }

--- a/lib/Backend/JITObjTypeSpecFldInfo.cpp
+++ b/lib/Backend/JITObjTypeSpecFldInfo.cpp
@@ -221,7 +221,11 @@ JITTimeFixedField *
 JITObjTypeSpecFldInfo::GetFixedFieldIfAvailableAsFixedFunction()
 {
     Assert(HasFixedValue());
-    Assert(IsMono() || (IsPoly() && !DoesntHaveEquivalence()));
+    if (IsPoly() && DoesntHaveEquivalence())
+    {
+        return nullptr;
+    }
+
     Assert(m_data.fixedFieldInfoArray);
     if (m_data.fixedFieldInfoArray[0].funcInfoAddr != 0)
     {

--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -5950,6 +5950,7 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
 
             RegSlot localClosureReg = this->m_functionBody->GetLocalClosureRegister();
             RegSlot localFrameDisplayReg = this->m_functionBody->GetLocalFrameDisplayRegister();
+            RegSlot paramClosureReg = this->m_functionBody->GetParamClosureRegister();
 
             if (entryPointInfo->HasJittedStackClosure())
             {
@@ -5965,6 +5966,11 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
                 {
                     this->SetNonVarReg(localFrameDisplayReg, &this->localFrameDisplay);
                 }
+
+                if (paramClosureReg != Constants::NoRegister)
+                {
+                    this->SetNonVarReg(paramClosureReg, &this->paramClosure);
+                }
             }
             else
             {
@@ -5978,6 +5984,11 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
                 if (localFrameDisplayReg != Constants::NoRegister)
                 {
                     this->SetNonVarReg(localFrameDisplayReg, this->localFrameDisplay);
+                }
+
+                if (paramClosureReg != Constants::NoRegister)
+                {
+                    this->SetNonVarReg(paramClosureReg, this->paramClosure);
                 }
             }
 
@@ -6014,6 +6025,11 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
             if (localFrameDisplayReg != Constants::NoRegister)
             {
                 SetNonVarReg(localFrameDisplayReg, nullptr);
+            }
+
+            if (paramClosureReg != Constants::NoRegister)
+            {
+                SetNonVarReg(paramClosureReg, nullptr);
             }
 
             for (uint32 i = 0; i < innerScopeCount; i++)
@@ -6807,7 +6823,7 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
         // Save the current closure. We have to use this while copying the initial value of body symbols
         // from the corresponding symbols in the param.
         this->SetParamClosure(this->GetLocalClosure());
-        this->SetNonVarReg(executeFunction->GetParamClosureRegister(), this->GetLocalClosure());
+        this->SetNonVarReg(executeFunction->GetParamClosureRegister(), nullptr);
 
         this->SetIsParamScopeDone(true);
 

--- a/test/Closures/bug_OS_9781249.js
+++ b/test/Closures/bug_OS_9781249.js
@@ -1,0 +1,33 @@
+function test0() {
+  var obj0 = {};
+  var arrObj0 = {};
+  var func1 = function (argMath4, argMath6 = false ? (Object.defineProperty(protoObj1, 'prop0', {
+    set: function (_x) {
+      protoObj1.prop4 = protoObj0.prop0 < protoObj0.prop0 || argMath4 > argMath4;
+    },
+    configurable: true
+  }), arrObj0[((false ? arrObj0[(-493942660.9 instanceof (typeof EvalError == 'function' ? EvalError : Object) >= 0 ? -493942660.9 instanceof (typeof EvalError == 'function' ? EvalError : Object) : 0) & 15] = 'x' : undefined, -493942660.9 instanceof (typeof EvalError == 'function' ? EvalError : Object)) >= 0 ? -493942660.9 instanceof (typeof EvalError == 'function' ? EvalError : Object) : 0) & 15]) : arrObj0[((false ? arrObj0[(-493942660.9 instanceof (typeof EvalError == 'function' ? EvalError : Object) >= 0 ? -493942660.9 instanceof (typeof EvalError == 'function' ? EvalError : Object) : 0) & 15] = 'x' : undefined, -493942660.9 instanceof (typeof EvalError == 'function' ? EvalError : Object)) >= 0 ? -493942660.9 instanceof (typeof EvalError == 'function' ? EvalError : Object) : 0) & 15]) {
+    while (argMath6 >> (uic8[129])) {
+      if (!(argMath6 = argMath4)) {
+      }
+    }
+  };
+  var func2 = function () {
+    return func1();
+  };
+  var func3 = function () {
+    func2();
+  };
+  var func4 = function () {
+    func2();
+    return func2();
+  };
+  obj0.method0 = func3;
+  var uic8 = new Uint8ClampedArray();
+  arrObj0[0] = -1148316534.9;
+  var protoObj0 = Object(obj0);
+  func4();
+  protoObj0.method0();
+}
+test0();
+print("PASSED");

--- a/test/Closures/bug_OS_9781249.js
+++ b/test/Closures/bug_OS_9781249.js
@@ -1,3 +1,8 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
 function test0() {
   var obj0 = {};
   var arrObj0 = {};

--- a/test/Closures/rlexe.xml
+++ b/test/Closures/rlexe.xml
@@ -151,4 +151,11 @@
       <tags>BugFix</tags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>bug_OS_9781249.js</files>
+      <compile-flags>-forcejitloopbody -force:inline -force:rejit</compile-flags>
+      <tags>BugFix</tags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
1. Set the paramClosure from the field on InterpreterStackFrame to its reserved bytecode register before calling out to a jitted loop body, and set the register back to nullptr after returning from loop body.

2. Change an assert in JITObjTypeSpecFldInfo into a condition check as we now have a valid case which fails the assert.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/2024)
<!-- Reviewable:end -->
