### PR TITLE
Fix flakiness in serialized tests in ch

### DIFF
--- a/bin/ch/ch.cpp
+++ b/bin/ch/ch.cpp
@@ -456,11 +456,6 @@ HRESULT CreateAndRunSerializedScript(const char* fileName, LPCSTR fileContents, 
     IfFailGo(RunScript(fileName, fileContents, bcBuffer, fullPath));
 
 Error:
-    if (bcBuffer != nullptr)
-    {
-        delete[] bcBuffer;
-    }
-
     if (current != JS_INVALID_REFERENCE)
     {
         ChakraRTInterface::JsSetCurrentContext(current);
@@ -470,6 +465,12 @@ Error:
     {
         ChakraRTInterface::JsDisposeRuntime(runtime);
     }
+
+    if (bcBuffer != nullptr)
+    {
+        delete[] bcBuffer;
+    }
+
     return hr;
 }
 


### PR DESCRIPTION
Serialized bytecode tests started seeing flakiness after my ETW change.
This is because that change exposed a bug in ch- ch was freeing the serialized bytecode before disposing the runtime. We just happened to
not need any of the serialized data during our test runs before- with the ETW change, we started logging the name of the function body being collected and this would AV if the serialized bytecode data got decommited before
we called JsDisposeRuntime.

The simplest fix for now is to call JsDisposeRuntime before freeing the bytecode data
