### PR TITLE
Disable test/Error/stack.js on osx re #2009

### DIFF
--- a/test/Error/rlexe.xml
+++ b/test/Error/rlexe.xml
@@ -30,6 +30,7 @@
     <default>
       <files>stack.js</files>
       <baseline>stack.baseline</baseline>
+      <tags>exclude_mac</tags>
     </default>
   </test>
   <test>


### PR DESCRIPTION
test/Error/stack.js sometimes fails, prominently in the OSX
osx_debug_static CI test.  See #2009

Disabling the test on mac for now to reduce pain on check-ins.