### PR TITLE
Provide more information when test scripts fail.

### DIFF
--- a/test/jenkins.testall.cmd
+++ b/test/jenkins.testall.cmd
@@ -80,7 +80,7 @@ set _HadFailures=0
 
   call :do %_TestDir%\runtests.cmd -%1 -quiet -cleanupall -nottags exclude_jenkins %_ExtraTestArgs% -binDir %_BinDir%
 
-  if %ERRORLEVEL% NEQ 0 (
+  if "%ERRORLEVEL%" NEQ "0" (
     echo -- runcitests.cmd ^>^> runtests.cmd failed
     set _HadFailures=3
   )
@@ -95,7 +95,10 @@ set _HadFailures=0
   set _LogFile=%_LogDir%\nativetests.log
   call :do %_TestDir%\runnativetests.cmd -%1 -binDir %_BinDir% > %_LogFile% 2>&1
 
-  if %ERRORLEVEL% NEQ 0 (
+  set _error=%ERRORLEVEL%
+  echo error code: %_error%
+
+  if "%_error%" NEQ "0" (
     echo -- runcitests.cmd ^>^> runnativetests.cmd failed (printing %_LogFile% below)
     powershell "if (Test-Path %_LogFile%) { Get-Content  %_LogFile% }"
     set _HadFailures=4

--- a/test/jenkins.testone.cmd
+++ b/test/jenkins.testone.cmd
@@ -45,6 +45,7 @@ set _HadFailures=0
   set _TestDir=%CD%
 
   call jenkins.parsetestargs.cmd %*
+
   set _LogDir=%_TestDir%\logs\%_TestArch%_%_TestType%
   set _TestArgs=%_TestArch%%_TestType%
   set _BinDir=%_RootDir%\Build\VcBuild%_SpecialBuild%\bin
@@ -57,7 +58,7 @@ set _HadFailures=0
   call :summarizeLogs
 
   echo.
-  if "%_HadFailures%" == "1" (
+  if "%_HadFailures%" NEQ "0" (
     echo -- jenkins.testone.cmd ^>^> Tests failed! 1>&2
   ) else (
     echo -- jenkins.testone.cmd ^>^> Tests passed!
@@ -76,7 +77,10 @@ set _HadFailures=0
 
   call :do %_TestDir%\runtests.cmd -%1 -quiet -cleanupall -nottags exclude_jenkins %_ExtraTestArgs% -binDir %_BinDir%
 
-  if ERRORLEVEL 1 set _HadFailures=1
+  if %ERRORLEVEL% NEQ 0 (
+    echo -- runcitests.cmd ^>^> runtests.cmd failed
+    set _HadFailures=3
+  )
 
   goto :eof
 
@@ -85,9 +89,14 @@ set _HadFailures=0
 :: ============================================================================
 :runNativeTests
 
-  call :do %_TestDir%\runnativetests.cmd -%1 -binDir %_BinDir% > %_LogDir%\nativetests.log 2>&1
+  set _LogFile=%_LogDir%\nativetests.log
+  call :do %_TestDir%\runnativetests.cmd -%1 -binDir %_BinDir% > %_LogFile% 2>&1
 
-  if ERRORLEVEL 1 set _HadFailures=1
+  if %ERRORLEVEL% NEQ 0 (
+    echo -- runcitests.cmd ^>^> runnativetests.cmd failed (printing %_LogFile% below)
+    powershell "if (Test-Path %_LogFile%) { Get-Content  %_LogFile% }"
+    set _HadFailures=4
+  )
 
   goto :eof
 

--- a/test/jenkins.testone.cmd
+++ b/test/jenkins.testone.cmd
@@ -58,6 +58,7 @@ set _HadFailures=0
   call :summarizeLogs
 
   echo.
+  echo %_HadFailures%
   if "%_HadFailures%" NEQ "0" (
     echo -- jenkins.testone.cmd ^>^> Tests failed! 1>&2
   ) else (
@@ -77,7 +78,7 @@ set _HadFailures=0
 
   call :do %_TestDir%\runtests.cmd -%1 -quiet -cleanupall -nottags exclude_jenkins %_ExtraTestArgs% -binDir %_BinDir%
 
-  if %ERRORLEVEL% NEQ 0 (
+  if "%ERRORLEVEL%" NEQ "0" (
     echo -- runcitests.cmd ^>^> runtests.cmd failed
     set _HadFailures=3
   )
@@ -92,7 +93,7 @@ set _HadFailures=0
   set _LogFile=%_LogDir%\nativetests.log
   call :do %_TestDir%\runnativetests.cmd -%1 -binDir %_BinDir% > %_LogFile% 2>&1
 
-  if %ERRORLEVEL% NEQ 0 (
+  if "%ERRORLEVEL%" NEQ "0" (
     echo -- runcitests.cmd ^>^> runnativetests.cmd failed (printing %_LogFile% below)
     powershell "if (Test-Path %_LogFile%) { Get-Content  %_LogFile% }"
     set _HadFailures=4

--- a/test/runcitests.cmd
+++ b/test/runcitests.cmd
@@ -116,7 +116,10 @@ set _HadFailures=0
 
   call :do %_TestDir%\runtests.cmd -%1%2 -quiet -cleanupall -binDir %_StagingDir%\bin
 
-  if ERRORLEVEL 1 set _HadFailures=3
+  if %ERRORLEVEL% NEQ 0 (
+    echo -- runcitests.cmd ^>^> runtests.cmd failed
+    set _HadFailures=3
+  )
 
   goto :eof
 
@@ -127,7 +130,10 @@ set _HadFailures=0
 
   call :do %_TestDir%\runnativetests.cmd -%1%2 > %_TestDir%\logs\%1_%2\nativetests.log 2>&1
 
-  if ERRORLEVEL 1 set _HadFailures=4
+  if %ERRORLEVEL% NEQ 0 (
+    echo -- runcitests.cmd ^>^> runnativetests.cmd failed
+    set _HadFailures=4
+  )
 
   goto :eof
 

--- a/test/runcitests.cmd
+++ b/test/runcitests.cmd
@@ -128,11 +128,12 @@ set _HadFailures=0
 :: ============================================================================
 :runNativeTests
 
-  call :do %_TestDir%\runnativetests.cmd -%1%2 > %_TestDir%\logs\%1_%2\nativetests.log 2>&1
+  set _LogFile=%_TestDir%\logs\%1_%2\nativetests.log
+  call :do %_TestDir%\runnativetests.cmd -%1%2 > %_LogFile% 2>&1
 
   if %ERRORLEVEL% NEQ 0 (
-    echo -- runcitests.cmd ^>^> runnativetests.cmd failed (printing nativetests.log below)
-    powershell "if (Test-Path %_TestDir%\logs\%1_%2\nativetests.log) { Get-Content %_TestDir%\logs\%1_%2\nativetests.log }"
+    echo -- runcitests.cmd ^>^> runnativetests.cmd failed (printing %_LogFile% below)
+    powershell "if (Test-Path %_LogFile%) { Get-Content %_LogFile% }"
     set _HadFailures=4
   )
 

--- a/test/runcitests.cmd
+++ b/test/runcitests.cmd
@@ -79,7 +79,7 @@ set _HadFailures=0
     call :runNativeTests x86 test
     call :runNativeTests x64 debug
     call :runNativeTests x64 test
-    
+
     call :summarizeLogs summary.log
   ) else (
     call :runTests %_BuildArch% %_BuildType%
@@ -90,7 +90,7 @@ set _HadFailures=0
   call :copyLogsToDrop
 
   echo.
-  if "%_HadFailures%" == "1" (
+  if "%_HadFailures%" NEQ "0" (
     echo -- runcitests.cmd ^>^> Tests failed! 1>&2
   ) else (
     echo -- runcitests.cmd ^>^> Tests passed!
@@ -116,7 +116,7 @@ set _HadFailures=0
 
   call :do %_TestDir%\runtests.cmd -%1%2 -quiet -cleanupall -binDir %_StagingDir%\bin
 
-  if ERRORLEVEL 1 set _HadFailures=1
+  if ERRORLEVEL 1 set _HadFailures=3
 
   goto :eof
 
@@ -127,10 +127,10 @@ set _HadFailures=0
 
   call :do %_TestDir%\runnativetests.cmd -%1%2 > %_TestDir%\logs\%1_%2\nativetests.log 2>&1
 
-  if ERRORLEVEL 1 set _HadFailures=1
+  if ERRORLEVEL 1 set _HadFailures=4
 
   goto :eof
-  
+
 :: ============================================================================
 :: Copy all result logs to the drop share
 :: ============================================================================

--- a/test/runcitests.cmd
+++ b/test/runcitests.cmd
@@ -131,7 +131,8 @@ set _HadFailures=0
   call :do %_TestDir%\runnativetests.cmd -%1%2 > %_TestDir%\logs\%1_%2\nativetests.log 2>&1
 
   if %ERRORLEVEL% NEQ 0 (
-    echo -- runcitests.cmd ^>^> runnativetests.cmd failed
+    echo -- runcitests.cmd ^>^> runnativetests.cmd failed (printing nativetests.log below)
+    powershell "if (Test-Path %_TestDir%\logs\%1_%2\nativetests.log) { Get-Content %_TestDir%\logs\%1_%2\nativetests.log }"
     set _HadFailures=4
   )
 

--- a/test/runnativetests.cmd
+++ b/test/runnativetests.cmd
@@ -71,7 +71,7 @@ goto :main
   call :copyScriptsAndBinaries
 
   call :runtest
-  
+
   call :cleanup
 
   exit /b %_HadFailures%
@@ -167,7 +167,7 @@ goto :main
 :copyScriptsAndBinaries
   echo -- runnativetests.cmd ^>^> copying scripts from '%_RootDir%\bin\nativetests\Scripts' to '%_TestTempDir%'
   copy /y %_RootDir%\bin\nativetests\Scripts\*.js %_TestTempDir%
-  
+
   copy /y %_BinDir%ChakraCore.dll %_TestTempDir%
   copy /y %_BinDir%nativetests.exe %_TestTempDir%
 
@@ -179,7 +179,8 @@ goto :main
 :runtest
   pushd %_TestTempDir%
   call :do nativetests.exe
-  if ERRORLEVEL 1 set _HadFailures=1
+  if %ERRORLEVEL% NEQ 0 set _HadFailures=1
+  echo -- runnativetests.cmd ^>^> nativetests.exe exiting with exit code %_HadFailures%
   popd
 
   goto :eof

--- a/test/runtests.cmd
+++ b/test/runtests.cmd
@@ -118,7 +118,14 @@ goto :main
     )
   )
 
+  if "%_HadFailures%" NEQ "0" (
+    echo ^>^> Tests failed. See logs for details.
+  ) else (
+    echo ^>^> All tests passed!
+  )
+
   echo ^>^> exiting with exit code %_HadFailures%
+
   exit /b %_HadFailures%
 
 :: ============================================================================

--- a/test/runtests.cmd
+++ b/test/runtests.cmd
@@ -118,6 +118,7 @@ goto :main
     )
   )
 
+  echo ^>^> exiting with exit code %_HadFailures%
   exit /b %_HadFailures%
 
 :: ============================================================================
@@ -211,7 +212,7 @@ goto :main
     set _Variants=disable_jit
     goto :ArgOk
   )
-  
+
   if /i "%1" == "-nightly" (
     set _nightly=1
     if "%_ExtraVariants%" == "" (


### PR DESCRIPTION
This patch was helpful in identifying the cause of a build error (differentiating between unit tests and native tests) when both steps seemed to indicate nothing was wrong.