### PR TITLE
Fix reuse of redeferred function's child

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -1233,7 +1233,7 @@ FuncInfo * ByteCodeGenerator::StartBindFunction(const char16 *name, uint nameLen
         // Create a function body if:
         //  1. The parse node is not defer parsed
         //  2. Or creating function proxies is disallowed
-        bool createFunctionBody = !isDeferParsed;
+        bool createFunctionBody = !isDeferParsed && (!reuseNestedFunc || reuseNestedFunc->IsFunctionBody());
         if (!CONFIG_FLAG(CreateFunctionProxy)) createFunctionBody = true;
 
         Js::FunctionInfo::Attributes attributes = Js::FunctionInfo::Attributes::None;
@@ -1313,6 +1313,7 @@ FuncInfo * ByteCodeGenerator::StartBindFunction(const char16 *name, uint nameLen
 
             if (reuseNestedFunc)
             {
+                pnode->sxFnc.pnodeBody = nullptr;
                 parseableFunctionInfo = reuseNestedFunc;
             }
             else


### PR DESCRIPTION
If a function is redeferred, we need to reuse any child FunctionInfo's that have already been created. Handle the case where a child we want to be re-use has also been redeferred but we went ahead and created an AST for it. For now, just discard the AST and treat it as deferred. Consider transitioning to full FunctionBody on the spot if this hits more than rarely (which I doubt).