### PR TITLE
Fix call to Math.pow x86 from JIT code

### DIFF
--- a/lib/Runtime/Library/JavascriptNumber.cpp
+++ b/lib/Runtime/Library/JavascriptNumber.cpp
@@ -236,6 +236,11 @@ namespace Js
         return ::pow(x, y);
     }
 #else
+
+#pragma warning(push)
+// C4740: flow in or out of inline asm code suppresses global optimization
+// It is fine to disable glot opt on this function which is mostly written in assembly
+#pragma warning(disable:4740)
     __declspec(naked)
     double JavascriptNumber::DirectPow(double x, double y)
     {
@@ -295,6 +300,8 @@ namespace Js
             }
         }
     }
+#pragma warning(pop)
+
 #endif
 
 #elif defined(_M_AMD64) || defined(_M_ARM32_OR_ARM64)


### PR DESCRIPTION
When x86 JIT code assumes both parameters for Math.pow are double according to its profile data, the function (DirectPow) could still get small integer within our fast path. Need to check that before going to CRT function for result consistency of Math.pow.