### PR TITLE
Redeferral fix for cross-site functions

### DIFF
--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -875,7 +875,10 @@ namespace Js
             Assert(type->GetTypeId() == TypeIds_Function);
 
             ScriptFunctionType* functionType = (ScriptFunctionType*)type;
-            functionType->SetEntryPoint(GetScriptContext()->DeferredParsingThunk);
+            if (!CrossSite::IsThunk(functionType->GetEntryPoint()))
+            {
+                functionType->SetEntryPoint(GetScriptContext()->DeferredParsingThunk);
+            }
         });
 
         this->Cleanup(false);


### PR DESCRIPTION
Don't let redeferral update the entry point on a function object's type if the entry point is already a cross-site thunk.