### PR TITLE
RegAlloc fold spilled store

### DIFF
--- a/lib/Backend/LinearScan.cpp
+++ b/lib/Backend/LinearScan.cpp
@@ -870,7 +870,7 @@ LinearScan::SetDstReg(IR::Instr *instr)
                         RecordDef(lifetime, instr, 0);
                     }
                 }
-                if (LowererMD::IsAssign(instr) && instr->GetSrc1()->IsRegOpnd())
+                if (LowererMD::IsAssign(instr) && src1 && src1->IsRegOpnd() && src1->GetSize() == dst->GetSize())
                 {
                     // Fold the spilled store
                     if (reg != RegNOREG)


### PR DESCRIPTION
Fold a spilled store only if the source and dest have the same size.
This was causing problems in WebAssembly where we were doing a conversion from int32 to int64 and the int64 dest was getting spilled.
It was using the source's size to determine the spill size.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/2063)
<!-- Reviewable:end -->
