### PR TITLE
WASM - uint to int64 bug fix

### DIFF
--- a/lib/Backend/amd64/LowererMDArch.cpp
+++ b/lib/Backend/amd64/LowererMDArch.cpp
@@ -2569,13 +2569,7 @@ LowererMDArch::EmitIntToLong(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInser
     Assert(dst->IsRegOpnd() && dst->IsInt64());
     Assert(src->IsInt32());
 
-    if (src->IsIntConstOpnd())
-    {
-        Lowerer::InsertMove(dst, src, instrInsert);
-        return;
-    }
-    Assert(src->IsRegOpnd());
-    instrInsert->InsertBefore(IR::Instr::New(Js::OpCode::MOVSXD, dst, src, this->m_func));
+    Lowerer::InsertMove(dst, src, instrInsert);
 }
 
 void
@@ -2584,13 +2578,7 @@ LowererMDArch::EmitUIntToLong(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInse
     Assert(dst->IsRegOpnd() && dst->IsInt64());
     Assert(src->IsUInt32());
 
-    if (src->IsIntConstOpnd())
-    {
-        Lowerer::InsertMove(dst, src, instrInsert);
-        return;
-    }
-    Assert(src->IsRegOpnd());
-    instrInsert->InsertBefore(IR::Instr::New(Js::OpCode::MOV_TRUNC, dst, src, this->m_func));
+    Lowerer::InsertMove(dst, src, instrInsert);
 }
 
 void

--- a/lib/Backend/amd64/LowererMDArch.cpp
+++ b/lib/Backend/amd64/LowererMDArch.cpp
@@ -2590,7 +2590,7 @@ LowererMDArch::EmitUIntToLong(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInse
         return;
     }
     Assert(src->IsRegOpnd());
-    instrInsert->InsertBefore(IR::Instr::New(Js::OpCode::MOV, dst, src, this->m_func));
+    instrInsert->InsertBefore(IR::Instr::New(Js::OpCode::MOV_TRUNC, dst, src, this->m_func));
 }
 
 void


### PR DESCRIPTION
Use MOV_TRUNC instead of MOV when converting an unsigned int to int64

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/2067)
<!-- Reviewable:end -->
