### PR TITLE
swb: annotate nested field type, union

### DIFF
--- a/lib/Backend/CodeGenNumberAllocator.cpp
+++ b/lib/Backend/CodeGenNumberAllocator.cpp
@@ -402,7 +402,7 @@ void XProcNumberPageSegmentImpl::Initialize(bool recyclerVerifyEnabled, uint rec
         uint padAllocSize = (uint)AllocSizeMath::Add(sizeof(Js::JavascriptNumber) + sizeof(size_t), recyclerVerifyPad);
         allocSize = padAllocSize < allocSize ? allocSize : padAllocSize;
     }
-#endif    
+#endif
 
     allocSize = (uint)HeapInfo::GetAlignedSizeNoCheck(allocSize);
 
@@ -415,7 +415,7 @@ void XProcNumberPageSegmentImpl::Initialize(bool recyclerVerifyEnabled, uint rec
     sizeCat = allocSize;
 }
 
-Js::JavascriptNumber** ::XProcNumberPageSegmentManager::RegisterSegments(XProcNumberPageSegment* segments)
+Field(Js::JavascriptNumber*)* ::XProcNumberPageSegmentManager::RegisterSegments(XProcNumberPageSegment* segments)
 {
     Assert(segments->pageAddress && segments->allocStartAddress && segments->allocEndAddress);
     XProcNumberPageSegmentImpl* segmentImpl = (XProcNumberPageSegmentImpl*)segments;
@@ -428,7 +428,7 @@ Js::JavascriptNumber** ::XProcNumberPageSegmentManager::RegisterSegments(XProcNu
         temp = (XProcNumberPageSegmentImpl*)temp->nextSegment;
     }
 
-    Js::JavascriptNumber** numbers = RecyclerNewArray(this->recycler, Js::JavascriptNumber*, totalCount);
+    Field(Js::JavascriptNumber*)* numbers = RecyclerNewArray(this->recycler, Field(Js::JavascriptNumber*), totalCount);
 
     temp = segmentImpl;
     int count = 0;
@@ -476,7 +476,7 @@ XProcNumberPageSegment * XProcNumberPageSegmentManager::GetFreeSegment(Memory::A
             // remove from the list
             XProcNumberPageSegment * seg = (XProcNumberPageSegment *)AnewStructZ(alloc, XProcNumberPageSegmentImpl);
             temp->nextSegment = 0;
-            memcpy(seg, temp, sizeof(XProcNumberPageSegment));            
+            memcpy(seg, temp, sizeof(XProcNumberPageSegment));
             midl_user_free(temp);
             return seg;
         }
@@ -526,7 +526,7 @@ void XProcNumberPageSegmentManager::Integrate()
                     }
                 }
 
-                if ((uintptr_t)temp->allocEndAddress + XProcNumberPageSegmentImpl::sizeCat 
+                if ((uintptr_t)temp->allocEndAddress + XProcNumberPageSegmentImpl::sizeCat
                     > (uintptr_t)temp->pageAddress + XProcNumberPageSegmentImpl::PageCount*AutoSystemInfo::PageSize)
                 {
                     *prev = (XProcNumberPageSegmentImpl*)temp->nextSegment;

--- a/lib/Backend/CodeGenNumberAllocator.h
+++ b/lib/Backend/CodeGenNumberAllocator.h
@@ -182,7 +182,7 @@ struct XProcNumberPageSegmentManager
     ~XProcNumberPageSegmentManager();
 
     XProcNumberPageSegment * GetFreeSegment(Memory::ArenaAllocator* alloc);
-    Js::JavascriptNumber** RegisterSegments(XProcNumberPageSegment* segments);
+    Field(Js::JavascriptNumber*)* RegisterSegments(XProcNumberPageSegment* segments);
 
     void Integrate();
 };

--- a/lib/Common/DataStructures/Cache.h
+++ b/lib/Common/DataStructures/Cache.h
@@ -118,7 +118,7 @@ namespace JsUtil
         }
 
     private:
-        TMRUStoreType* store;
+        Field(TMRUStoreType*, TAllocator) store;
     };
 
     template <

--- a/lib/Common/DataStructures/Dictionary.h
+++ b/lib/Common/DataStructures/Dictionary.h
@@ -12,7 +12,7 @@ namespace JsUtil
         static const int INVALID_HASH_VALUE = 0;
         hash_t hash;    // Lower 31 bits of hash code << 1 | 1, 0 if unused
         int next;        // Index of next entry, -1 if last
-        const RecyclerWeakReference<TKey>* key;      // Key of entry- this entry holds a weak reference to the key
+        Field(const RecyclerWeakReference<TKey>*) key;  // Key of entry- this entry holds a weak reference to the key
         TValue value;    // Value of entry
     };
 
@@ -21,15 +21,15 @@ namespace JsUtil
     template <class TKey, class TValue, class KeyComparer = DefaultComparer<const TKey*>, bool cleanOnInsert = true> class WeaklyReferencedKeyDictionary
     {
     public:
-        typedef WeakRefDictionaryEntry<TKey, TValue> EntryType;
+        typedef WeakRefDictionaryEntry<TKey, Field(TValue)> EntryType;
         typedef TKey KeyType;
         typedef TValue ValueType;
         typedef void (*EntryRemovalCallbackMethodType)(const EntryType& e, void* cookie);
 
         struct EntryRemovalCallback
         {
-            EntryRemovalCallbackMethodType fnCallback;
-            void* cookie;
+            FieldNoBarrier(EntryRemovalCallbackMethodType) fnCallback;
+            Field(void*) cookie;
         };
 
 
@@ -230,7 +230,7 @@ namespace JsUtil
             if (count > 0)
             {
                 for (int i = 0; i < size; i++) buckets[i] = -1;
-                memset(entries, 0, sizeof(EntryType) * size);
+                ClearArray(entries, size);
                 freeList = -1;
                 count = 0;
                 freeCount = 0;
@@ -353,7 +353,7 @@ namespace JsUtil
             int* newBuckets = RecyclerNewArrayLeaf(recycler, int, newSize);
             for (int i = 0; i < newSize; i++) newBuckets[i] = -1;
             EntryType* newEntries = RecyclerNewArray(recycler, EntryType, newSize);
-            js_memcpy_s(newEntries, sizeof(EntryType) * newSize, entries, sizeof(EntryType) * count);
+            CopyArray<EntryType, Field(const RecyclerWeakReference<TKey>*)>(newEntries, newSize, entries, count);
             AnalysisAssert(count < newSize);
             for (int i = 0; i < count; i++)
             {

--- a/lib/Common/DataStructures/DoublyLinkedList.h
+++ b/lib/Common/DataStructures/DoublyLinkedList.h
@@ -6,11 +6,12 @@
 
 namespace JsUtil
 {
-    template<class T>
+    template<class T, class TAllocator = ArenaAllocator>
     class DoublyLinkedList
     {
     private:
-        T *head, *tail;
+        Field(T *, TAllocator) head;
+        Field(T *, TAllocator) tail;
 
     public:
         DoublyLinkedList();

--- a/lib/Common/DataStructures/DoublyLinkedList.inl
+++ b/lib/Common/DataStructures/DoublyLinkedList.inl
@@ -6,122 +6,122 @@
 
 namespace JsUtil
 {
-    template<class T>
-    DoublyLinkedList<T>::DoublyLinkedList() : head(nullptr), tail(nullptr)
+    template<class T, class TAllocator>
+    DoublyLinkedList<T, TAllocator>::DoublyLinkedList() : head(nullptr), tail(nullptr)
     {
     }
 
-    template<class T>
-    T *DoublyLinkedList<T>::Head() const
+    template<class T, class TAllocator>
+    T *DoublyLinkedList<T, TAllocator>::Head() const
     {
         return head;
     }
 
-    template<class T>
-    T *DoublyLinkedList<T>::Tail() const
+    template<class T, class TAllocator>
+    T *DoublyLinkedList<T, TAllocator>::Tail() const
     {
         return tail;
     }
 
-    template<class T>
-    bool DoublyLinkedList<T>::Contains(T *const element) const
+    template<class T, class TAllocator>
+    bool DoublyLinkedList<T, TAllocator>::Contains(T *const element) const
     {
         return T::Contains(element, head);
     }
 
-    template<class T>
-    bool DoublyLinkedList<T>::ContainsSubsequence(T *const first, T *const last) const
+    template<class T, class TAllocator>
+    bool DoublyLinkedList<T, TAllocator>::ContainsSubsequence(T *const first, T *const last) const
     {
         return T::ContainsSubsequence(first, last, head);
     }
 
-    template<class T>
-    bool DoublyLinkedList<T>::IsEmpty()
+    template<class T, class TAllocator>
+    bool DoublyLinkedList<T, TAllocator>::IsEmpty()
     {
         return head == nullptr;
     }
 
-    template<class T>
-    void DoublyLinkedList<T>::Clear()
+    template<class T, class TAllocator>
+    void DoublyLinkedList<T, TAllocator>::Clear()
     {
         tail = head = nullptr;
     }
 
-    template<class T>
-    void DoublyLinkedList<T>::LinkToBeginning(T *const element)
+    template<class T, class TAllocator>
+    void DoublyLinkedList<T, TAllocator>::LinkToBeginning(T *const element)
     {
-        T::LinkToBeginning(element, &head, &tail);
+        T::LinkToBeginning(element, AddressOf(head), AddressOf(tail));
     }
 
-    template<class T>
-    void DoublyLinkedList<T>::LinkToEnd(T *const element)
+    template<class T, class TAllocator>
+    void DoublyLinkedList<T, TAllocator>::LinkToEnd(T *const element)
     {
-        T::LinkToEnd(element, &head, &tail);
+        T::LinkToEnd(element, AddressOf(head), AddressOf(tail));
     }
 
-    template<class T>
-    void DoublyLinkedList<T>::LinkBefore(T *const element, T *const nextElement)
+    template<class T, class TAllocator>
+    void DoublyLinkedList<T, TAllocator>::LinkBefore(T *const element, T *const nextElement)
     {
-        T::LinkBefore(element, nextElement, &head, &tail);
+        T::LinkBefore(element, nextElement, AddressOf(head), AddressOf(tail));
     }
 
-    template<class T>
-    void DoublyLinkedList<T>::LinkAfter(T *const element, T *const previousElement)
+    template<class T, class TAllocator>
+    void DoublyLinkedList<T, TAllocator>::LinkAfter(T *const element, T *const previousElement)
     {
-        T::LinkAfter(element, previousElement, &head, &tail);
+        T::LinkAfter(element, previousElement, AddressOf(head), AddressOf(tail));
     }
 
-    template<class T>
-    T *DoublyLinkedList<T>::UnlinkFromBeginning()
+    template<class T, class TAllocator>
+    T *DoublyLinkedList<T, TAllocator>::UnlinkFromBeginning()
     {
         T *const element = head;
         if(element)
-            T::UnlinkFromBeginning(element, &head, &tail);
+            T::UnlinkFromBeginning(element, AddressOf(head), AddressOf(tail));
         return element;
     }
 
-    template<class T>
-    T *DoublyLinkedList<T>::UnlinkFromEnd()
+    template<class T, class TAllocator>
+    T *DoublyLinkedList<T, TAllocator>::UnlinkFromEnd()
     {
         T *const element = tail;
         if(element)
-            T::UnlinkFromEnd(element, &head, &tail);
+            T::UnlinkFromEnd(element, AddressOf(head), AddressOf(tail));
         return element;
     }
 
-    template<class T>
-    void DoublyLinkedList<T>::UnlinkPartial(T *const element)
+    template<class T, class TAllocator>
+    void DoublyLinkedList<T, TAllocator>::UnlinkPartial(T *const element)
     {
-        T::UnlinkPartial(element, &head, &tail);
+        T::UnlinkPartial(element, AddressOf(head), AddressOf(tail));
     }
 
-    template<class T>
-    void DoublyLinkedList<T>::Unlink(T *const element)
+    template<class T, class TAllocator>
+    void DoublyLinkedList<T, TAllocator>::Unlink(T *const element)
     {
-        T::Unlink(element, &head, &tail);
+        T::Unlink(element, AddressOf(head), AddressOf(tail));
     }
 
-    template<class T>
-    void DoublyLinkedList<T>::MoveToBeginning(T *const element)
+    template<class T, class TAllocator>
+    void DoublyLinkedList<T, TAllocator>::MoveToBeginning(T *const element)
     {
-        T::MoveToBeginning(element, &head, &tail);
+        T::MoveToBeginning(element, AddressOf(head), AddressOf(tail));
     }
 
-    template<class T>
-    void DoublyLinkedList<T>::UnlinkSubsequenceFromEnd(T *const first)
+    template<class T, class TAllocator>
+    void DoublyLinkedList<T, TAllocator>::UnlinkSubsequenceFromEnd(T *const first)
     {
-        T::UnlinkSubsequenceFromEnd(first, &head, &tail);
+        T::UnlinkSubsequenceFromEnd(first, AddressOf(head), AddressOf(tail));
     }
 
-    template<class T>
-    void DoublyLinkedList<T>::UnlinkSubsequence(T *const first, T *const last)
+    template<class T, class TAllocator>
+    void DoublyLinkedList<T, TAllocator>::UnlinkSubsequence(T *const first, T *const last)
     {
-        T::UnlinkSubsequence(first, last, &head, &tail);
+        T::UnlinkSubsequence(first, last, AddressOf(head), AddressOf(tail));
     }
 
-    template<class T>
-    void DoublyLinkedList<T>::MoveSubsequenceToBeginning(T *const first, T *const last)
+    template<class T, class TAllocator>
+    void DoublyLinkedList<T, TAllocator>::MoveSubsequenceToBeginning(T *const first, T *const last)
     {
-        T::MoveSubsequenceToBeginning(first, last, &head, &tail);
+        T::MoveSubsequenceToBeginning(first, last, AddressOf(head), AddressOf(tail));
     }
 }

--- a/lib/Common/DataStructures/DoublyLinkedListElement.h
+++ b/lib/Common/DataStructures/DoublyLinkedListElement.h
@@ -20,22 +20,36 @@ namespace JsUtil
         T *Previous() const;
         T *Next() const;
 
-        template<class D> static bool Contains(D *const element, D *const head);
-        template<class D> static bool ContainsSubsequence(D *const first, D *const last, D *const head);
+        template<class D> static bool Contains(D *const element,
+            Field(D *, TAllocator) const head);
+        template<class D> static bool ContainsSubsequence(D *const first, D *const last,
+            Field(D *, TAllocator) const head);
 
-        template<class D> static void LinkToBeginning(D *const element, D * *const head, D * *const tail);
-        template<class D> static void LinkToEnd(D *const element, D * *const head, D * *const tail);
-        template<class D> static void LinkBefore(D *const element, D *const nextElement, D * *const head, D * *const tail);
-        template<class D> static void LinkAfter(D *const element, D *const previousElement, D * *const head, D * *const tail);
-        template<class D> static void UnlinkFromBeginning(D *const element, D * *const head, D * *const tail);
-        template<class D> static void UnlinkFromEnd(D *const element, D * *const head, D * *const tail);
-        template<class D> static void UnlinkPartial(D *const element, D * *const head, D * *const tail);
-        template<class D> static void Unlink(D *const element, D * *const head, D * *const tail);
-        template<class D> static void MoveToBeginning(D *const element, D * *const head, D * *const tail);
+        template<class D> static void LinkToBeginning(D *const element,
+            Field(D *, TAllocator) *const head, Field(D *, TAllocator) *const tail);
+        template<class D> static void LinkToEnd(D *const element,
+            Field(D *, TAllocator) *const head, Field(D *, TAllocator) *const tail);
+        template<class D> static void LinkBefore(D *const element, D *const nextElement,
+            Field(D *, TAllocator) *const head, Field(D *, TAllocator) *const tail);
+        template<class D> static void LinkAfter(D *const element, D *const previousElement,
+            Field(D *, TAllocator) *const head, Field(D *, TAllocator) *const tail);
+        template<class D> static void UnlinkFromBeginning(D *const element,
+            Field(D *, TAllocator) *const head, Field(D *, TAllocator) *const tail);
+        template<class D> static void UnlinkFromEnd(D *const element,
+            Field(D *, TAllocator) *const head, Field(D *, TAllocator) *const tail);
+        template<class D> static void UnlinkPartial(D *const element,
+            Field(D *, TAllocator) *const head, Field(D *, TAllocator) *const tail);
+        template<class D> static void Unlink(D *const element,
+            Field(D *, TAllocator) *const head, Field(D *, TAllocator) *const tail);
+        template<class D> static void MoveToBeginning(D *const element,
+            Field(D *, TAllocator) *const head, Field(D *, TAllocator) *const tail);
 
-        template<class D> static void UnlinkSubsequenceFromEnd(D *const first, D * *const head, D * *const tail);
-        template<class D> static void UnlinkSubsequence(D *const first, D *const last, D * *const head, D * *const tail);
-        template<class D> static void MoveSubsequenceToBeginning(D *const first, D *const last, D * *const head, D * *const tail);
+        template<class D> static void UnlinkSubsequenceFromEnd(D *const first,
+            Field(D *, TAllocator) *const head, Field(D *, TAllocator) *const tail);
+        template<class D> static void UnlinkSubsequence(D *const first, D *const last,
+            Field(D *, TAllocator) *const head, Field(D *, TAllocator) *const tail);
+        template<class D> static void MoveSubsequenceToBeginning(D *const first, D *const last,
+            Field(D *, TAllocator) *const head, Field(D *, TAllocator) *const tail);
 
         // JScriptDiag doesn't seem to like the PREVENT_COPY macro
     private:

--- a/lib/Common/DataStructures/DoublyLinkedListElement.inl
+++ b/lib/Common/DataStructures/DoublyLinkedListElement.inl
@@ -26,7 +26,8 @@ namespace JsUtil
 
     template<class T, class TAllocator>
     template<class D>
-    bool DoublyLinkedListElement<T, TAllocator>::Contains(D *const element, D *const head)
+    bool DoublyLinkedListElement<T, TAllocator>::Contains(
+        D *const element, Field(D *, TAllocator) const head)
     {
         TemplateParameter::SameOrDerivedFrom<D, T>();
         Assert(element);
@@ -45,7 +46,8 @@ namespace JsUtil
 
     template<class T, class TAllocator>
     template<class D>
-    bool DoublyLinkedListElement<T, TAllocator>::ContainsSubsequence(D *const first, D *const last, D *const head)
+    bool DoublyLinkedListElement<T, TAllocator>::ContainsSubsequence(
+        D *const first, D *const last, Field(D *, TAllocator) const head)
     {
         TemplateParameter::SameOrDerivedFrom<D, T>();
         Assert(first);
@@ -68,7 +70,9 @@ namespace JsUtil
 
     template<class T, class TAllocator>
     template<class D>
-    void DoublyLinkedListElement<T, TAllocator>::LinkToBeginning(D *const element, D * *const head, D * *const tail)
+    void DoublyLinkedListElement<T, TAllocator>::LinkToBeginning(
+        D *const element,
+        Field(D *, TAllocator) *const head, Field(D *, TAllocator) *const tail)
     {
         TemplateParameter::SameOrDerivedFrom<D, T>();
         Assert(element);
@@ -80,7 +84,7 @@ namespace JsUtil
         Assert(!element->next);
         Assert(!Contains(element, *head));
 
-        element->previous = 0;
+        element->previous = nullptr;
         element->next = *head;
         *head = element;
         if(element->next)
@@ -94,7 +98,9 @@ namespace JsUtil
 
     template<class T, class TAllocator>
     template<class D>
-    void DoublyLinkedListElement<T, TAllocator>::LinkToEnd(D *const element, D * *const head, D * *const tail)
+    void DoublyLinkedListElement<T, TAllocator>::LinkToEnd(
+        D *const element,
+        Field(D *, TAllocator) *const head, Field(D *, TAllocator) *const tail)
     {
         TemplateParameter::SameOrDerivedFrom<D, T>();
         Assert(element);
@@ -107,7 +113,7 @@ namespace JsUtil
         Assert(!Contains(element, *head));
 
         element->previous = *tail;
-        element->next = 0;
+        element->next = nullptr;
         *tail = element;
         if(element->previous)
             element->previous->next = element;
@@ -120,7 +126,9 @@ namespace JsUtil
 
     template<class T, class TAllocator>
     template<class D>
-    void DoublyLinkedListElement<T, TAllocator>::LinkBefore(D *const element, D *const nextElement, D * *const head, D * *const tail)
+    void DoublyLinkedListElement<T, TAllocator>::LinkBefore(
+        D *const element, D *const nextElement,
+        Field(D *, TAllocator) *const head, Field(D *, TAllocator) *const tail)
     {
         TemplateParameter::SameOrDerivedFrom<D, T>();
         Assert(element);
@@ -151,7 +159,9 @@ namespace JsUtil
 
     template<class T, class TAllocator>
     template<class D>
-    void DoublyLinkedListElement<T, TAllocator>::LinkAfter(D *const element, D *const previousElement, D * *const head, D * *const tail)
+    void DoublyLinkedListElement<T, TAllocator>::LinkAfter(
+        D *const element, D *const previousElement,
+        Field(D *, TAllocator) *const head, Field(D *, TAllocator) *const tail)
     {
         TemplateParameter::SameOrDerivedFrom<D, T>();
         Assert(element);
@@ -182,7 +192,9 @@ namespace JsUtil
 
     template<class T, class TAllocator>
     template<class D>
-    void DoublyLinkedListElement<T, TAllocator>::UnlinkFromBeginning(D *const element, D * *const head, D * *const tail)
+    void DoublyLinkedListElement<T, TAllocator>::UnlinkFromBeginning(
+        D *const element,
+        Field(D *, TAllocator) *const head, Field(D *, TAllocator) *const tail)
     {
         TemplateParameter::SameOrDerivedFrom<D, T>();
         Assert(element);
@@ -199,19 +211,21 @@ namespace JsUtil
 
         if(element->next)
         {
-            element->next->previous = 0;
-            element->next = 0;
+            element->next->previous = nullptr;
+            element->next = nullptr;
         }
         else
         {
             Assert(*tail == element);
-            *tail = 0;
+            *tail = nullptr;
         }
     }
 
     template<class T, class TAllocator>
     template<class D>
-    void DoublyLinkedListElement<T, TAllocator>::UnlinkFromEnd(D *const element, D * *const head, D * *const tail)
+    void DoublyLinkedListElement<T, TAllocator>::UnlinkFromEnd(
+        D *const element,
+        Field(D *, TAllocator) *const head, Field(D *, TAllocator) *const tail)
     {
         TemplateParameter::SameOrDerivedFrom<D, T>();
         Assert(element);
@@ -228,19 +242,21 @@ namespace JsUtil
 
         if(element->previous)
         {
-            element->previous->next = 0;
-            element->previous = 0;
+            element->previous->next = nullptr;
+            element->previous = nullptr;
         }
         else
         {
             Assert(*head == element);
-            *head = 0;
+            *head = nullptr;
         }
     }
 
     template<class T, class TAllocator>
     template<class D>
-    void DoublyLinkedListElement<T, TAllocator>::UnlinkPartial(D *const element, D * *const head, D * *const tail)
+    void DoublyLinkedListElement<T, TAllocator>::UnlinkPartial(
+        D *const element,
+        Field(D *, TAllocator) *const head, Field(D *, TAllocator) *const tail)
     {
         TemplateParameter::SameOrDerivedFrom<D, T>();
         Assert(element);
@@ -275,16 +291,20 @@ namespace JsUtil
 
     template<class T, class TAllocator>
     template<class D>
-    void DoublyLinkedListElement<T, TAllocator>::Unlink(D *const element, D * *const head, D * *const tail)
+    void DoublyLinkedListElement<T, TAllocator>::Unlink(
+        D *const element,
+        Field(D *, TAllocator) *const head, Field(D *, TAllocator) *const tail)
     {
         UnlinkPartial(element, head, tail);
-        element->previous = 0;
-        element->next = 0;
+        element->previous = nullptr;
+        element->next = nullptr;
     }
 
     template<class T, class TAllocator>
     template<class D>
-    void DoublyLinkedListElement<T, TAllocator>::MoveToBeginning(D *const element, D * *const head, D * *const tail)
+    void DoublyLinkedListElement<T, TAllocator>::MoveToBeginning(
+        D *const element,
+        Field(D *, TAllocator) *const head, Field(D *, TAllocator) *const tail)
     {
         TemplateParameter::SameOrDerivedFrom<D, T>();
         Assert(element);
@@ -311,7 +331,7 @@ namespace JsUtil
             *tail = static_cast<D *>(element->previous);
         }
 
-        element->previous = 0;
+        element->previous = nullptr;
         element->next = *head;
         *head = element;
         element->next->previous = element;
@@ -319,7 +339,9 @@ namespace JsUtil
 
     template<class T, class TAllocator>
     template<class D>
-    void DoublyLinkedListElement<T, TAllocator>::UnlinkSubsequenceFromEnd(D *const first, D * *const head, D * *const tail)
+    void DoublyLinkedListElement<T, TAllocator>::UnlinkSubsequenceFromEnd(
+        D *const first,
+        Field(D *, TAllocator) *const head, Field(D *, TAllocator) *const tail)
     {
         TemplateParameter::SameOrDerivedFrom<D, T>();
         Assert(first);
@@ -332,20 +354,22 @@ namespace JsUtil
         Assert(Contains(first, *head));
 
         if(first->previous)
-            first->previous->next = 0;
+            first->previous->next = nullptr;
         else
         {
             Assert(*head == first);
-            *head = 0;
+            *head = nullptr;
         }
 
         *tail = static_cast<D *>(first->previous);
-        first->previous = 0;
+        first->previous = nullptr;
     }
 
     template<class T, class TAllocator>
     template<class D>
-    void DoublyLinkedListElement<T, TAllocator>::UnlinkSubsequence(D *const first, D *const last, D * *const head, D * *const tail)
+    void DoublyLinkedListElement<T, TAllocator>::UnlinkSubsequence(
+        D *const first, D *const last,
+        Field(D *, TAllocator) *const head, Field(D *, TAllocator) *const tail)
     {
         TemplateParameter::SameOrDerivedFrom<D, T>();
         Assert(first);
@@ -374,13 +398,15 @@ namespace JsUtil
             *tail = static_cast<D *>(first->previous);
         }
 
-        first->previous = 0;
-        last->next = 0;
+        first->previous = nullptr;
+        last->next = nullptr;
     }
 
     template<class T, class TAllocator>
     template<class D>
-    void DoublyLinkedListElement<T, TAllocator>::MoveSubsequenceToBeginning(D *const first, D *const last, D * *const head, D * *const tail)
+    void DoublyLinkedListElement<T, TAllocator>::MoveSubsequenceToBeginning(
+        D *const first, D *const last,
+        Field(D *, TAllocator) *const head, Field(D *, TAllocator) *const tail)
     {
         TemplateParameter::SameOrDerivedFrom<D, T>();
         Assert(first);
@@ -408,7 +434,7 @@ namespace JsUtil
             *tail = static_cast<D *>(first->previous);
         }
 
-        first->previous = 0;
+        first->previous = nullptr;
         last->next = *head;
         *head = static_cast<D *>(first);
         last->next->previous = last;

--- a/lib/Common/DataStructures/FixedBitVector.h
+++ b/lib/Common/DataStructures/FixedBitVector.h
@@ -312,7 +312,7 @@ public:
 
 // Data
 private:
-    BVUnit data[wordCount];
+    Field(BVUnit) data[wordCount];
 
 public:
     // Break on member changes. We rely on the layout of this class being static so we can

--- a/lib/Common/DataStructures/Interval.h
+++ b/lib/Common/DataStructures/Interval.h
@@ -8,8 +8,8 @@ namespace regex
 {
     struct Interval
     {
-        int begin;
-        int end;
+        Field(int) begin;
+        Field(int) end;
 
     public:
         Interval(): begin(0), end(0)

--- a/lib/Common/DataStructures/List.h
+++ b/lib/Common/DataStructures/List.h
@@ -767,7 +767,7 @@ namespace Js
         typedef typename TListType::TElementType TElementType;
         typedef typename TListType::TComparerType TComparerType;
 
-        int freeItemIndex;
+        Field(int) freeItemIndex;
 
     public:
         FreeListedRemovePolicy(TListType * list):
@@ -852,7 +852,7 @@ namespace Js
         typedef FreeListedRemovePolicy<TListType, clearOldEntries> Base;
         typedef typename Base::TElementType TElementType;
     private:
-        uint lastWeakReferenceCleanupId;
+        Field(uint) lastWeakReferenceCleanupId;
 
         void CleanupWeakReference(TListType * list)
         {

--- a/lib/Common/DataStructures/MruDictionary.h
+++ b/lib/Common/DataStructures/MruDictionary.h
@@ -22,11 +22,11 @@ namespace JsUtil
     class MruDictionary
     {
     private:
-        struct MruListEntry : public DoublyLinkedListElement<MruListEntry>
+        struct MruListEntry : public DoublyLinkedListElement<MruListEntry, TAllocator>
         {
-            TValue value;
-            TKey key;
-            int dictionaryDataIndex;
+            Field(TValue, TAllocator) value;
+            Field(TKey, TAllocator) key;
+            Field(int) dictionaryDataIndex;
 
             MruListEntry(const TKey &key, const TValue &value) : key(key), value(value), dictionaryDataIndex(0)
             {
@@ -39,8 +39,8 @@ namespace JsUtil
         class MruDictionaryData
         {
         private:
-            MruListEntry *entry;
-            TValue value;
+            Field(MruListEntry *, TAllocator) entry;
+            Field(TValue, TAllocator) value;
 
         public:
             MruDictionaryData() : entry(nullptr)
@@ -86,10 +86,10 @@ namespace JsUtil
         };
 
     private:
-        const int mruListCapacity;
-        int mruListCount;
-        DoublyLinkedList<MruListEntry> entries;
-
+        Field(const int) mruListCapacity;
+        Field(int) mruListCount;
+        typedef DoublyLinkedList<MruListEntry, TAllocator> EntriesType;
+        Field(EntriesType) entries;
 
         typedef
             BaseDictionary<

--- a/lib/Common/DataStructures/QuickSort.h
+++ b/lib/Common/DataStructures/QuickSort.h
@@ -6,7 +6,7 @@
 #pragma once
 namespace JsUtil
 {
-    template <class T, typename Comparer>
+    template <class T, class Comparer>
     class QuickSort
     {
     public:
@@ -48,6 +48,3 @@ namespace JsUtil
         }
     };
 }
-
-
-

--- a/lib/Common/DataStructures/UnitBitVector.h
+++ b/lib/Common/DataStructures/UnitBitVector.h
@@ -74,8 +74,7 @@ class BVUnitT
 {
 // Data
 private:
-
-    T word;
+    Field(T) word;
 
 // Constructor
 public:
@@ -84,9 +83,9 @@ public:
         word = initial;
     }
     typedef T BVUnitTContainer;
+
 // Implementation
 private:
-
     static void AssertRange(BVIndex index)
     {
         AssertMsg(index < BitsPerWord, "index out of bound");

--- a/lib/Common/Memory/RecyclerWeakReference.h
+++ b/lib/Common/Memory/RecyclerWeakReference.h
@@ -41,14 +41,13 @@ protected:
     FieldNoBarrier(RecyclerWeakReferenceBase*) next;
 #if DBG
 #if ENABLE_RECYCLER_TYPE_TRACKING
-    type_info const * typeInfo;
+    FieldNoBarrier(type_info const *) typeInfo;
 #endif
 
 #if defined TRACK_ALLOC && defined(PERF_COUNTERS)
-    PerfCounter::Counter * counter;
+    FieldNoBarrier(PerfCounter::Counter *) counter;
 #endif
 #endif
-
 };
 
 /// Wrapper class template that can be used to acquire the underlying strong reference from the weak reference

--- a/lib/JITIDL/JITTypes.h
+++ b/lib/JITIDL/JITTypes.h
@@ -71,30 +71,30 @@ typedef IDL_DEF([ref]) PSCRIPTCONTEXT_HANDLE * PPSCRIPTCONTEXT_HANDLE;
 
 typedef struct TypeHandlerIDL
 {
-    boolean isObjectHeaderInlinedTypeHandler;
-    boolean isLocked;
+    IDL_Field(boolean) isObjectHeaderInlinedTypeHandler;
+    IDL_Field(boolean) isLocked;
 
-    unsigned short inlineSlotCapacity;
-    unsigned short offsetOfInlineSlots;
+    IDL_Field(unsigned short) inlineSlotCapacity;
+    IDL_Field(unsigned short) offsetOfInlineSlots;
     IDL_PAD2(0)
     X64_PAD4(1)
-    int slotCapacity;
+    IDL_Field(int) slotCapacity;
 } TypeHandlerIDL;
 
 typedef struct TypeIDL
 {
-    unsigned char flags;
-    boolean isShared;
+    IDL_Field(unsigned char) flags;
+    IDL_Field(boolean) isShared;
     IDL_PAD2(0)
-    int typeId;
+    IDL_Field(int) typeId;
 
-    CHAKRA_PTR libAddr;
-    CHAKRA_PTR protoAddr;
-    CHAKRA_PTR entrypointAddr;
-    CHAKRA_PTR propertyCacheAddr;
-    CHAKRA_PTR addr;
+    IDL_Field(CHAKRA_PTR) libAddr;
+    IDL_Field(CHAKRA_PTR) protoAddr;
+    IDL_Field(CHAKRA_PTR) entrypointAddr;
+    IDL_Field(CHAKRA_PTR) propertyCacheAddr;
+    IDL_Field(CHAKRA_PTR) addr;
 
-    TypeHandlerIDL handler;
+    IDL_Field(TypeHandlerIDL) handler;
 } TypeIDL;
 
 typedef struct EquivalentTypeSetIDL
@@ -120,22 +120,22 @@ typedef struct FixedFieldIDL
 
 typedef struct JITTimeConstructorCacheIDL
 {
-    boolean skipNewScObject;
-    boolean ctorHasNoExplicitReturnValue;
-    boolean typeIsFinal;
-    boolean isUsed;
+    IDL_Field(boolean) skipNewScObject;
+    IDL_Field(boolean) ctorHasNoExplicitReturnValue;
+    IDL_Field(boolean) typeIsFinal;
+    IDL_Field(boolean) isUsed;
 
-    short inlineSlotCount;
+    IDL_Field(short) inlineSlotCount;
 
     IDL_PAD2(0)
-    int slotCount;
+    IDL_Field(int) slotCount;
 
     X64_PAD4(1)
-    TypeIDL type;
+    IDL_Field(TypeIDL) type;
 
-    CHAKRA_PTR runtimeCacheAddr;
-    CHAKRA_PTR runtimeCacheGuardAddr;
-    CHAKRA_PTR guardedPropOps;
+    IDL_Field(CHAKRA_PTR) runtimeCacheAddr;
+    IDL_Field(CHAKRA_PTR) runtimeCacheGuardAddr;
+    IDL_Field(CHAKRA_PTR) guardedPropOps;
 } JITTimeConstructorCacheIDL;
 
 typedef struct ObjTypeSpecFldIDL

--- a/lib/Jsrt/JsrtContext.h
+++ b/lib/Jsrt/JsrtContext.h
@@ -35,7 +35,7 @@ private:
         return ptr;
     }
 
-    T* ptr;
+    FieldNoBarrier(T*) ptr;
 };
 
 class JsrtContext : public FinalizableObject

--- a/lib/Parser/CharMap.h
+++ b/lib/Parser/CharMap.h
@@ -221,10 +221,10 @@ namespace UnifiedRegex
             }
         };
 
-        BVStatic<directSize> isInMap;
-        V defv;
-        V directMap[directSize];
-        Node* root;
+        Field(BVStatic<directSize>) isInMap;
+        Field(V) defv;
+        Field(V) directMap[directSize];
+        FieldNoBarrier(Node*) root;
 
     public:
         CharMap(V defv)

--- a/lib/Parser/RegexCompileTime.cpp
+++ b/lib/Parser/RegexCompileTime.cpp
@@ -4373,7 +4373,7 @@ namespace UnifiedRegex
 
     void Compiler::CaptureNoLiterals(Program* program)
     {
-        program->rep.insts.litbuf = 0;
+        program->rep.insts.litbuf = nullptr;
         program->rep.insts.litbufLen = 0;
     }
 
@@ -4498,18 +4498,18 @@ namespace UnifiedRegex
 
                 OctoquadIdentifier oi(numCodes, *codeToChar, *charToCode);
                 // We haven't captured literals yet: temporarily set the program's litbuf to be the parser's litbuf
-                Assert(program->rep.insts.litbuf == 0);
+                Assert(program->rep.insts.litbuf == nullptr);
                 program->rep.insts.litbuf = (Char*)litbuf;
                 if (root->IsOctoquad(compiler, &oi) && oi.IsOctoquad())
                 {
-                    program->rep.insts.litbuf = 0;
+                    program->rep.insts.litbuf = nullptr;
                     oi.InitializeTrigramInfo(scriptContext, pattern);
                     program->tag = Program::OctoquadTag;
                     program->rep.octoquad.matcher = OctoquadMatcher::New(scriptContext->GetRecycler(), standardChars, program->GetCaseMappingSource(), &oi);
                     compiled = true;
                 }
                 else
-                    program->rep.insts.litbuf = 0;
+                    program->rep.insts.litbuf = nullptr;
             }
         }
 

--- a/lib/Parser/RegexParser.cpp
+++ b/lib/Parser/RegexParser.cpp
@@ -3052,7 +3052,7 @@ namespace UnifiedRegex
         if (litbuf != 0)
         {
             ctAllocator->Free(litbuf, litbufLen);
-            litbuf = 0;
+            litbuf = nullptr;
             litbufLen = 0;
             litbufNext = 0;
         }

--- a/lib/Parser/RegexPattern.cpp
+++ b/lib/Parser/RegexPattern.cpp
@@ -10,8 +10,8 @@ namespace UnifiedRegex
         : library(library), isLiteral(isLiteral), isShallowClone(false)
     {
         rep.unified.program = program;
-        rep.unified.matcher = 0;
-        rep.unified.trigramInfo = 0;
+        rep.unified.matcher = nullptr;
+        rep.unified.trigramInfo = nullptr;
     }
 
     RegexPattern *RegexPattern::New(Js::ScriptContext *scriptContext, Program* program, bool isLiteral)

--- a/lib/Parser/RegexPattern.h
+++ b/lib/Parser/RegexPattern.h
@@ -20,9 +20,9 @@ namespace UnifiedRegex
 
         struct UnifiedRep
         {
-            Program* program;
-            Matcher* matcher;
-            TrigramInfo* trigramInfo;
+            Field(Program*) program;
+            Field(Matcher*) matcher;
+            Field(TrigramInfo*) trigramInfo;
         };
 
         Field(Js::JavascriptLibrary *) const library;
@@ -32,7 +32,9 @@ namespace UnifiedRegex
 
         union Rep
         {
-            struct UnifiedRep unified;
+            Field(UnifiedRep) unified;
+
+            Rep() : unified() {}
         };
         Field(Rep) rep;
 

--- a/lib/Parser/RegexRuntime.cpp
+++ b/lib/Parser/RegexRuntime.cpp
@@ -605,7 +605,7 @@ namespace UnifiedRegex
         {
             infos[i]->FreeBody(rtAllocator);
 #if DBG
-            infos[i] = 0;
+            infos[i] = nullptr;
 #endif
         }
 #if DBG
@@ -3055,7 +3055,7 @@ namespace UnifiedRegex
     inline bool LoopSetWithFollowFirstInst::Exec(REGEX_INST_EXEC_PARAMETERS) const
     {
         LoopInfo* loopInfo = matcher.LoopIdToLoopInfo(loopId);
-        
+
         // If loop is contained in an outer loop, continuation stack may already have a RewindLoopFixed entry for
         // this loop. We must make sure it's state is preserved on backtrack.
         if (hasOuterLoops)
@@ -4213,12 +4213,12 @@ namespace UnifiedRegex
 
         LoopSetInst* begin = matcher.L2I(LoopSet, beginLabel);
         LoopInfo* loopInfo = matcher.LoopIdToLoopInfo(begin->loopId);
-        
+
         // loopInfo->number is the number of iterations completed before trying follow
         Assert(loopInfo->number > begin->repeats.lower);
         // Try follow with fewer iterations
         loopInfo->number--;
-        
+
         // Rewind input
         inputOffset = loopInfo->startInputOffset + loopInfo->number;
 
@@ -5106,11 +5106,11 @@ namespace UnifiedRegex
         , numLoops(0)
     {
         tag = InstructionsTag;
-        rep.insts.insts = 0;
+        rep.insts.insts = nullptr;
         rep.insts.instsLen = 0;
-        rep.insts.litbuf = 0;
+        rep.insts.litbuf = nullptr;
         rep.insts.litbufLen = 0;
-        rep.insts.scannersForSyncToLiterals = 0;
+        rep.insts.scannersForSyncToLiterals = nullptr;
     }
 
     Program *Program::New(Recycler *recycler, RegexFlags flags)
@@ -5118,7 +5118,7 @@ namespace UnifiedRegex
         return RecyclerNew(recycler, Program, flags);
     }
 
-    ScannerInfo **Program::CreateScannerArrayForSyncToLiterals(Recycler *const recycler)
+    Field(ScannerInfo *)*Program::CreateScannerArrayForSyncToLiterals(Recycler *const recycler)
     {
         Assert(tag == InstructionsTag);
         Assert(!rep.insts.scannersForSyncToLiterals);
@@ -5126,7 +5126,7 @@ namespace UnifiedRegex
 
         return
             rep.insts.scannersForSyncToLiterals =
-                RecyclerNewArrayZ(recycler, ScannerInfo *, ScannersMixin::MaxNumSyncLiterals);
+                RecyclerNewArrayZ(recycler, Field(ScannerInfo *), ScannersMixin::MaxNumSyncLiterals);
     }
 
     ScannerInfo *Program::AddScannerForSyncToLiterals(
@@ -5153,7 +5153,7 @@ namespace UnifiedRegex
         if(tag != InstructionsTag || !rep.insts.insts)
             return;
 
-        Inst *inst = reinterpret_cast<Inst *>(rep.insts.insts);
+        Inst *inst = reinterpret_cast<Inst *>(PointerValue(rep.insts.insts));
         const auto instEnd = reinterpret_cast<Inst *>(reinterpret_cast<uint8 *>(inst) + rep.insts.instsLen);
         Assert(inst < instEnd);
         do
@@ -5182,7 +5182,7 @@ namespace UnifiedRegex
         Assert(inst == instEnd);
 
 #if DBG
-        rep.insts.insts = 0;
+        rep.insts.insts = nullptr;
         rep.insts.instsLen = 0;
 #endif
     }

--- a/lib/Parser/RegexRuntime.h
+++ b/lib/Parser/RegexRuntime.h
@@ -81,57 +81,59 @@ namespace UnifiedRegex
         struct Instructions
         {
             // Instruction array, in run-time allocator, owned by program, never null
-            uint8* insts;
-            CharCount instsLen; // in bytes
+            Field(uint8*) insts;
+            Field(CharCount) instsLen; // in bytes
             // Literals
             // In run-time allocator, owned by program, may be 0
-            CharCount litbufLen; // length of litbuf in char16's, no terminating null
-            Char* litbuf;
+            Field(CharCount) litbufLen; // length of litbuf in char16's, no terminating null
+            Field(Char*) litbuf;
 
             // These scanner infos are used by ScannersMixin, which is used by only SyncToLiteralsAndBackupInst. There will only
             // ever be only one of those instructions per program. Since scanners are large (> 1 KB), for that instruction they
             // are allocated on the recycler with pointers stored here to reference them.
-            ScannerInfo **scannersForSyncToLiterals;
+            Field(Field(ScannerInfo *)*) scannersForSyncToLiterals;
         };
 
         struct SingleChar
         {
-            Char c;
-            uint8 padding[sizeof(Instructions) - sizeof(Char)];
+            Field(Char) c;
+            Field(uint8) padding[sizeof(Instructions) - sizeof(Char)];
         };
 
         struct Octoquad
         {
-            OctoquadMatcher* matcher;
-            uint8 padding[sizeof(Instructions) - sizeof(void*)];
+            Field(OctoquadMatcher*) matcher;
+            Field(uint8) padding[sizeof(Instructions) - sizeof(void*)];
         };
 
         struct BOILiteral2
         {
-            DWORD literal;
-            uint8 padding[sizeof(Instructions) - sizeof(DWORD)];
+            Field(DWORD) literal;
+            Field(uint8) padding[sizeof(Instructions) - sizeof(DWORD)];
         };
 
         struct LeadingTrailingSpaces
         {
-            CharCount beginMinMatch;
-            CharCount endMinMatch;
-            uint8 padding[sizeof(Instructions) - (sizeof(CharCount) * 2)];
+            Field(CharCount) beginMinMatch;
+            Field(CharCount) endMinMatch;
+            Field(uint8) padding[sizeof(Instructions) - (sizeof(CharCount) * 2)];
         };
 
         struct Other
         {
-            uint8 padding[sizeof(Instructions)];
+            Field(uint8) padding[sizeof(Instructions)];
         };
 
         union RepType
         {
-            Instructions insts;
-            SingleChar singleChar;
-            Octoquad octoquad;
-            BOILiteral2 boiLiteral2;
-            LeadingTrailingSpaces leadingTrailingSpaces;
-            Other other;
+            Field(Instructions) insts;
+            Field(SingleChar) singleChar;
+            Field(Octoquad) octoquad;
+            Field(BOILiteral2) boiLiteral2;
+            Field(LeadingTrailingSpaces) leadingTrailingSpaces;
+            Field(Other) other;
+
+            RepType() {}
         };
         Field(RepType) rep;
 
@@ -144,7 +146,7 @@ namespace UnifiedRegex
         static size_t GetOffsetOfBOILiteral2Literal() { return offsetof(BOILiteral2, literal); }
         static ProgramTag GetBOILiteral2Tag() { return ProgramTag::BOILiteral2Tag; }
 
-        ScannerInfo **CreateScannerArrayForSyncToLiterals(Recycler *const recycler);
+        Field(ScannerInfo *)*CreateScannerArrayForSyncToLiterals(Recycler *const recycler);
         ScannerInfo *AddScannerForSyncToLiterals(
             Recycler *const recycler,
             const int scannerIndex,
@@ -424,7 +426,7 @@ namespace UnifiedRegex
         static const int MaxNumSyncLiterals = 4;
 
         int numLiterals;
-        ScannerInfo** infos;
+        Field(ScannerInfo*)* infos;
 
         // scanner mixins must be added
         inline ScannersMixin(Recycler *const recycler, Program *const program)
@@ -1464,8 +1466,8 @@ namespace UnifiedRegex
 
     struct GroupInfo : protected Chars<char16>
     {
-        CharCount offset;
-        CharCountOrFlag length;  // CharCountFlag => group is undefined
+        Field(CharCount) offset;
+        Field(CharCountOrFlag) length;  // CharCountFlag => group is undefined
 
         inline GroupInfo() : offset(0), length(CharCountFlag) {}
 

--- a/lib/Parser/TextbookBoyerMoore.cpp
+++ b/lib/Parser/TextbookBoyerMoore.cpp
@@ -134,9 +134,9 @@ namespace UnifiedRegex
     {
         if(goodSuffix)
         {
-            AdeleteArray(allocator, patLen + 1, goodSuffix);
+            AdeleteArray(allocator, patLen + 1, PointerValue(goodSuffix));
 #if DBG
-            goodSuffix = 0;
+            goodSuffix = nullptr;
 #endif
         }
         lastOccurrence.FreeBody(allocator);

--- a/lib/Parser/TextbookBoyerMoore.h
+++ b/lib/Parser/TextbookBoyerMoore.h
@@ -105,8 +105,8 @@ namespace UnifiedRegex
         // NOTE: We don't store the actual pattern here since it may be moved between
         //       constructing the scanner and running it.
 
-        LastOccMap lastOccurrence;
-        int32 *goodSuffix;
+        Field(LastOccMap) lastOccurrence;
+        Field(int32 *) goodSuffix;
 
     public:
 

--- a/lib/Runtime/Base/CallInfo.h
+++ b/lib/Runtime/Base/CallInfo.h
@@ -56,10 +56,10 @@ namespace Js
         //  - scriptdirect.idl
         //  - LowererMDArch::LoadInputParamCount
         //
-        unsigned  Count : 24;
-        CallFlags Flags : 8;
+        Field(unsigned)  Count : 24;
+        Field(CallFlags) Flags : 8;
 #ifdef TARGET_64
-        unsigned unused : 32;
+        Field(unsigned) unused : 32;
 #endif
 
 #if DBG

--- a/lib/Runtime/Base/CharStringCache.cpp
+++ b/lib/Runtime/Base/CharStringCache.cpp
@@ -11,7 +11,7 @@ namespace Js
 {
     CharStringCache::CharStringCache() : charStringCache(nullptr)
     {
-        memset(charStringCacheA, 0, sizeof charStringCacheA);
+        ClearArray(charStringCacheA);
     }
 
     JavascriptString* CharStringCache::GetStringForCharA(char c)

--- a/lib/Runtime/Base/CharStringCache.h
+++ b/lib/Runtime/Base/CharStringCache.h
@@ -18,7 +18,6 @@ namespace Js
         // For JIT
         static const char16 CharStringCacheSize = 0x80; /*range of ASCII 7-bit chars*/
         static DWORD GetCharStringCacheAOffset() { return offsetof(CharStringCache, charStringCacheA); }
-        const PropertyString * const * GetCharStringCacheA() const { return charStringCacheA; }
 
         static JavascriptString* GetStringForChar(CharStringCache *charStringCache, char16 c) { return charStringCache->GetStringForChar(c); }
         static JavascriptString* GetStringForCharCodePoint(CharStringCache *charStringCache, codepoint_t c)
@@ -27,9 +26,10 @@ namespace Js
         }
 
     private:
-        PropertyString * charStringCacheA[CharStringCacheSize];
+        Field(PropertyString *) charStringCacheA[CharStringCacheSize];
+
         typedef JsUtil::BaseDictionary<char16, JavascriptString *, Recycler, PowerOf2SizePolicy> CharStringCacheMap;
-        CharStringCacheMap * charStringCache;
+        Field(CharStringCacheMap *) charStringCache;
 
         friend class CharStringCacheValidator;
     };

--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -344,10 +344,10 @@ namespace Js
     // valid if object!= NULL
     struct EnumeratedObjectCache {
         static const int kMaxCachedPropStrings=16;
-        DynamicObject* object;
-        DynamicType* type;
-        PropertyString* propertyStrings[kMaxCachedPropStrings];
-        int validPropStrings;
+        Field(DynamicObject*) object;
+        Field(DynamicType*) type;
+        Field(PropertyString*) propertyStrings[kMaxCachedPropStrings];
+        Field(int) validPropStrings;
     };
 
     typedef JsUtil::BaseDictionary<JavascriptMethod, JavascriptFunction*, Recycler, PowerOf2SizePolicy> BuiltInLibraryFunctionMap;

--- a/lib/Runtime/Base/TempArenaAllocatorObject.h
+++ b/lib/Runtime/Base/TempArenaAllocatorObject.h
@@ -10,8 +10,8 @@ namespace Js
     class TempArenaAllocatorWrapper sealed : public FinalizableObject
     {
     private:
-        Field(ArenaAllocator) allocator;
-        Field(ArenaData **) externalGuestArenaRef;
+        FieldNoBarrier(ArenaAllocator) allocator;
+        FieldNoBarrier(ArenaData **) externalGuestArenaRef;
         FieldNoBarrier(Recycler *) recycler;
 
         TempArenaAllocatorWrapper(__in LPCWSTR name, PageAllocator * pageAllocator, void (*outOfMemoryFunc)());

--- a/lib/Runtime/Base/ThreadContext.h
+++ b/lib/Runtime/Base/ThreadContext.h
@@ -581,7 +581,8 @@ private:
         Field(SourceProfileManagersByUrlMap*) sourceProfileManagersByUrl;
 
         // Used to register recyclable data that needs to be kept alive while jitting
-        Field(JsUtil::DoublyLinkedList<Js::CodeGenRecyclableData>) codeGenRecyclableDatas;
+        typedef JsUtil::DoublyLinkedList<Js::CodeGenRecyclableData, Recycler> CodeGenRecyclableDataList;
+        Field(CodeGenRecyclableDataList) codeGenRecyclableDatas;
 
         // Used to root old entry points so that they're not prematurely collected
         Field(Js::FunctionEntryPointInfo*) oldEntryPointInfo;

--- a/lib/Runtime/Base/Utf8SourceInfo.cpp
+++ b/lib/Runtime/Base/Utf8SourceInfo.cpp
@@ -18,7 +18,7 @@ namespace Js
         ScriptContext* scriptContext, bool isLibraryCode, Js::Var scriptSource):
         sourceHolder(mappableSource),
         m_cchLength(cchLength),
-        m_pOriginalSourceInfo(nullptr),
+        m_pHostBuffer(nullptr),
         m_srcInfo(srcInfo),
         m_secondaryHostSourceContext(secondaryHostSourceContext),
         m_debugDocument(nullptr),

--- a/lib/Runtime/Base/Utf8SourceInfo.h
+++ b/lib/Runtime/Base/Utf8SourceInfo.h
@@ -354,11 +354,8 @@ namespace Js
 
         Field(charcount_t) m_cchLength;               // The number of characters encoded in m_utf8Source.
         Field(ISourceHolder*) sourceHolder;
-        union
-        {
-            BYTE* m_pHostBuffer;  // Pointer to a host source buffer (null unless this is host code that we need to free)
-            Utf8SourceInfo const* m_pOriginalSourceInfo; // Pointer to source info with original source text, created during cloning
-        };
+
+        FieldNoBarrier(BYTE*) m_pHostBuffer;  // Pointer to a host source buffer (null unless this is host code that we need to free)
 
         Field(FunctionBodyDictionary*) functionBodyDictionary;
         Field(DeferredFunctionsDictionary*) m_deferredFunctionsDictionary;

--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -513,7 +513,7 @@ void ByteCodeGenerator::LoadUncachedHeapArguments(FuncInfo *funcInfo)
     Symbol *argSym = funcInfo->GetArgumentsSymbol();
     Assert(argSym && argSym->GetIsArguments());
     Js::RegSlot argumentsLoc = argSym->GetLocation();
-    
+
 
     Js::OpCode opcode = !funcInfo->root->sxFnc.HasNonSimpleParameterList() ? Js::OpCode::LdHeapArguments : Js::OpCode::LdLetHeapArguments;
     bool hasRest = funcInfo->root->sxFnc.pnodeRest != nullptr;
@@ -682,7 +682,7 @@ void ByteCodeGenerator::InitBlockScopedContent(ParseNode *pnodeBlock, Js::Debugg
             {
                 TrackSlotArrayPropertyForDebugger(debuggerScope, sym, sym->EnsurePosition(this), pnode->nop == knopConstDecl ? Js::DebuggerScopePropertyFlags_Const : Js::DebuggerScopePropertyFlags_None);
             }
-            else 
+            else
             {
                 TrackRegisterPropertyForDebugger(debuggerScope, sym, funcInfo, pnode->nop == knopConstDecl ? Js::DebuggerScopePropertyFlags_Const : Js::DebuggerScopePropertyFlags_None);
             }
@@ -1534,9 +1534,9 @@ void ByteCodeGenerator::EmitScopeObjectInit(FuncInfo *funcInfo)
 
     // Create and fill the array of local property ID's.
     // They all have slots assigned to them already (if they need them): see StartEmitFunction.
-    
+
     Js::PropertyIdArray *propIds = funcInfo->GetParsedFunctionBody()->AllocatePropertyIdArrayForFormals(extraAlloc, slotCount, Js::ActivationObjectEx::ExtraSlotCount());
-    
+
     ParseNode *pnodeFnc = funcInfo->root;
     ParseNode *pnode;
     Symbol *sym;
@@ -1688,7 +1688,7 @@ void ByteCodeGenerator::EmitScopeObjectInit(FuncInfo *funcInfo)
     slots[3] = funcInfo->GetParsedFunctionBody()->NewObjectLiteral();
 
     propIds->hasNonSimpleParams = funcInfo->root->sxFnc.HasNonSimpleParameterList();
-    
+
     funcInfo->GetParsedFunctionBody()->SetHasCachedScopePropIds(true);
 }
 
@@ -4179,7 +4179,8 @@ bool ByteCodeGenerator::EnsureSymbolModuleSlots(Symbol* sym, FuncInfo* funcInfo)
 
         AnalysisAssert(moduleNameRecord != nullptr);
         Assert(moduleNameRecord->module->IsSourceTextModuleRecord());
-        Js::SourceTextModuleRecord* resolvedModuleRecord = (Js::SourceTextModuleRecord*)moduleNameRecord->module;
+        Js::SourceTextModuleRecord* resolvedModuleRecord =
+            (Js::SourceTextModuleRecord*)PointerValue(moduleNameRecord->module);
 
         moduleIndex = resolvedModuleRecord->GetModuleId();
         moduleSlotIndex = resolvedModuleRecord->GetLocalExportSlotIndexByLocalName(moduleNameRecord->bindingName);
@@ -6508,7 +6509,7 @@ void EmitDestructuredArrayCore(
 // try {
 //    CallIteratorClose
 // } catch (e) {
-//    do nothing 
+//    do nothing
 // }
 
 void EmitTryCatchAroundClose(
@@ -6733,7 +6734,7 @@ void EmitDestructuredArray(
         regOffset = funcInfo->AcquireTmpRegister();
     }
 
-    // Insert try node here 
+    // Insert try node here
     Js::ByteCodeLabel finallyLabel = byteCodeGenerator->Writer()->DefineLabel();
     Js::ByteCodeLabel catchLabel = byteCodeGenerator->Writer()->DefineLabel();
     byteCodeGenerator->Writer()->RecordCrossFrameEntryExitRecord(true);
@@ -7723,7 +7724,7 @@ void EmitCallTarget(
 
         Emit(pnodeTarget->sxBin.pnode1, byteCodeGenerator, funcInfo, false);
         Js::PropertyId propertyId = pnodeTarget->sxBin.pnode2->sxPid.PropertyIdFromNameNode();
-        
+
         Js::RegSlot protoLocation =
             (pnodeTarget->sxBin.pnode1->nop == knopSuper) ?
             byteCodeGenerator->EmitLdObjProto(Js::OpCode::LdHomeObjProto, funcInfo->superRegister, funcInfo) :
@@ -9008,7 +9009,7 @@ void EmitIteratorNext(Js::RegSlot itemLocation, Js::RegSlot iteratorLocation, Js
 // Generating
 // if (hasReturnFunction) {
 //     value = Call Retrun;
-//     if (value != Object) 
+//     if (value != Object)
 //        throw TypeError;
 // }
 
@@ -9135,7 +9136,7 @@ void EmitForIn(ParseNode *loopNode,
 
     // branch past loop when MoveAndGetNext returns nullptr
     byteCodeGenerator->Writer()->BrReg1Unsigned1(Js::OpCode::BrOnEmpty, continuePastLoop, loopNode->sxForInOrForOf.itemLocation, forInLoopLevel);
-    
+
     EmitForInOfLoopBody(loopNode, loopEntrance, continuePastLoop, byteCodeGenerator, funcInfo, fReturnValue);
 
     byteCodeGenerator->Writer()->ExitLoop(loopId);
@@ -9219,7 +9220,7 @@ void EmitForInOrForOf(ParseNode *loopNode, ByteCodeGenerator *byteCodeGenerator,
 
     // These two temp variables store the information of return function to be called or not.
     // one variable is used for catch block and one is used for finally block. These variable will be set to true when we think that return function
-    // to be called on abrupt loop break. 
+    // to be called on abrupt loop break.
     // Why two variables? since these are temps and JIT does like not flow if single variable is used in multiple blocks.
     Js::RegSlot shouldCallReturnFunctionLocation = funcInfo->AcquireTmpRegister();
     Js::RegSlot shouldCallReturnFunctionLocationFinally = funcInfo->AcquireTmpRegister();
@@ -10486,7 +10487,7 @@ void Emit(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator, FuncInfo *func
             Js::PropertyId propertyId = pexpr->sxBin.pnode2->sxPid.PropertyIdFromNameNode();
             funcInfo->ReleaseLoc(pexpr->sxBin.pnode1);
             funcInfo->AcquireLoc(pnode);
-            
+
             if (pexpr->sxBin.pnode1->nop == knopSuper)
             {
                 byteCodeGenerator->Writer()->W1(Js::OpCode::RuntimeReferenceError, SCODE_CODE(JSERR_DeletePropertyWithSuper));

--- a/lib/Runtime/ByteCode/ScopeInfo.h
+++ b/lib/Runtime/ByteCode/ScopeInfo.h
@@ -22,15 +22,15 @@ namespace Js {
         {
             union
             {
-                PropertyId propertyId;
-                PropertyRecord const* name;
+                Field(PropertyId) propertyId;
+                Field(PropertyRecord const*) name;
             };
-            SymbolType symbolType;
-            bool hasFuncAssignment;
-            bool isBlockVariable;
-            bool isFuncExpr;
-            bool isModuleExportStorage;
-            bool isModuleImport;
+            Field(SymbolType) symbolType;
+            Field(bool) hasFuncAssignment;
+            Field(bool) isBlockVariable;
+            Field(bool) isFuncExpr;
+            Field(bool) isModuleExportStorage;
+            Field(bool) isModuleImport;
         };
 
     private:

--- a/lib/Runtime/Debug/SourceContextInfo.h
+++ b/lib/Runtime/Debug/SourceContextInfo.h
@@ -30,10 +30,10 @@ public:
     {
         struct
         {
-            char16 const * url;            // The url of the file
-            char16 const * sourceMapUrl;   // The url of the source map, such as actual non-minified source of JS on the server.
+            FieldNoBarrier(char16 const *) url;            // The url of the file
+            FieldNoBarrier(char16 const *) sourceMapUrl;   // The url of the source map, such as actual non-minified source of JS on the server.
         };
-        uint      hash;                 // hash for dynamic scripts
+        Field(uint)      hash;                 // hash for dynamic scripts
     };
 
 #if ENABLE_PROFILE_INFO

--- a/lib/Runtime/Debug/TTSnapObjects.cpp
+++ b/lib/Runtime/Debug/TTSnapObjects.cpp
@@ -79,7 +79,7 @@ namespace TTD
                 TTDVar* cpyBase = snpObject->VarArray;
                 if(sHandler->InlineSlotCapacity != 0)
                 {
-                    Js::Var* inlineSlots = dynObj->GetInlineSlots_TTD();
+                    Js::Var const* inlineSlots = dynObj->GetInlineSlots_TTD();
 
                     //copy all the properties (if they all fit into the inline slots) otherwise just copy all the inline slot values
                     uint32 inlineSlotCount = min(sHandler->MaxPropertyIndex, sHandler->InlineSlotCapacity);
@@ -89,7 +89,7 @@ namespace TTD
                 if(sHandler->MaxPropertyIndex > sHandler->InlineSlotCapacity)
                 {
                     cpyBase = cpyBase + sHandler->InlineSlotCapacity;
-                    Js::Var* auxSlots = dynObj->GetAuxSlots_TTD();
+                    Js::Var const* auxSlots = dynObj->GetAuxSlots_TTD();
 
                     //there are some values in aux slots (in addition to the inline slots) so copy them as well
                     uint32 auxSlotCount = (sHandler->MaxPropertyIndex - sHandler->InlineSlotCapacity);
@@ -529,7 +529,7 @@ namespace TTD
             reader->ReadRecordEnd();
         }
 
-#if ENABLE_SNAPSHOT_COMPARE 
+#if ENABLE_SNAPSHOT_COMPARE
         void AssertSnapEquiv(const SnapObject* sobj1, const SnapObject* sobj2, TTDCompareMap& compareMap)
         {
             compareMap.DiagnosticAssert(sobj1->SnapObjectTag == sobj2->SnapObjectTag);
@@ -750,7 +750,7 @@ namespace TTD
             SnapObjectSetAddtlInfoAs<SnapScriptFunctionInfo*, SnapObjectType::SnapScriptFunctionObject>(snpObject, snapFuncInfo);
         }
 
-#if ENABLE_SNAPSHOT_COMPARE 
+#if ENABLE_SNAPSHOT_COMPARE
         void AssertSnapEquiv_SnapScriptFunctionInfo(const SnapObject* sobj1, const SnapObject* sobj2, TTDCompareMap& compareMap)
         {
             const SnapScriptFunctionInfo* snapFuncInfo1 = SnapObjectGetAddtlInfoAs<SnapScriptFunctionInfo*, SnapObjectType::SnapScriptFunctionObject>(sobj1);
@@ -797,7 +797,7 @@ namespace TTD
         }
 
 
-#if ENABLE_SNAPSHOT_COMPARE 
+#if ENABLE_SNAPSHOT_COMPARE
         void AssertSnapEquiv_SnapExternalFunctionInfo(const SnapObject* sobj1, const SnapObject* sobj2, TTDCompareMap& compareMap)
         {
             TTString* snapName1 = SnapObjectGetAddtlInfoAs<TTString*, SnapObjectType::SnapExternalFunctionObject>(sobj1);
@@ -840,7 +840,7 @@ namespace TTD
             SnapObjectSetAddtlInfoAs<TTD_PTR_ID*, SnapObjectType::SnapRuntimeRevokerFunctionObject>(snpObject, revokerId);
         }
 
-#if ENABLE_SNAPSHOT_COMPARE 
+#if ENABLE_SNAPSHOT_COMPARE
         void AssertSnapEquiv_SnapRevokerFunctionInfo(const SnapObject* sobj1, const SnapObject* sobj2, TTDCompareMap& compareMap)
         {
             TTD_PTR_ID* revokeTrgt1 = SnapObjectGetAddtlInfoAs<TTD_PTR_ID*, SnapObjectType::SnapRuntimeRevokerFunctionObject>(sobj1);
@@ -920,7 +920,7 @@ namespace TTD
             SnapObjectSetAddtlInfoAs<SnapBoundFunctionInfo*, SnapObjectType::SnapBoundFunctionObject>(snpObject, snapBoundInfo);
         }
 
-#if ENABLE_SNAPSHOT_COMPARE 
+#if ENABLE_SNAPSHOT_COMPARE
         void AssertSnapEquiv_SnapBoundFunctionInfo(const SnapObject* sobj1, const SnapObject* sobj2, TTDCompareMap& compareMap)
         {
             SnapBoundFunctionInfo* snapBoundInfo1 = SnapObjectGetAddtlInfoAs<SnapBoundFunctionInfo*, SnapObjectType::SnapBoundFunctionObject>(sobj1);
@@ -1119,7 +1119,7 @@ namespace TTD
         }
 
 
-#if ENABLE_SNAPSHOT_COMPARE 
+#if ENABLE_SNAPSHOT_COMPARE
         void AssertSnapEquiv_SnapPromiseInfo(const SnapObject* sobj1, const SnapObject* sobj2, TTDCompareMap& compareMap)
         {
             const SnapPromiseInfo* promiseInfo1 = SnapObjectGetAddtlInfoAs<SnapPromiseInfo*, SnapObjectType::SnapPromiseObject>(sobj1);
@@ -1186,7 +1186,7 @@ namespace TTD
         }
 
 
-#if ENABLE_SNAPSHOT_COMPARE 
+#if ENABLE_SNAPSHOT_COMPARE
         void AssertSnapEquiv_SnapPromiseResolveOrRejectFunctionInfo(const SnapObject* sobj1, const SnapObject* sobj2, TTDCompareMap& compareMap)
         {
             SnapPromiseResolveOrRejectFunctionInfo* rrfInfo1 = SnapObjectGetAddtlInfoAs<SnapPromiseResolveOrRejectFunctionInfo*, SnapObjectType::SnapPromiseResolveOrRejectFunctionObject>(sobj1);
@@ -1239,7 +1239,7 @@ namespace TTD
         }
 
 
-#if ENABLE_SNAPSHOT_COMPARE 
+#if ENABLE_SNAPSHOT_COMPARE
         void AssertSnapEquiv_SnapPromiseReactionTaskFunctionInfo(const SnapObject* sobj1, const SnapObject* sobj2, TTDCompareMap& compareMap)
         {
             SnapPromiseReactionTaskFunctionInfo* rInfo1 = SnapObjectGetAddtlInfoAs<SnapPromiseReactionTaskFunctionInfo*, SnapObjectType::SnapPromiseReactionTaskFunctionObject>(sobj1);
@@ -1287,7 +1287,7 @@ namespace TTD
         }
 
 
-#if ENABLE_SNAPSHOT_COMPARE 
+#if ENABLE_SNAPSHOT_COMPARE
         void AssertSnapEquiv_SnapBoxedValue(const SnapObject* sobj1, const SnapObject* sobj2, TTDCompareMap& compareMap)
         {
             TTDVar snapBoxedVar1 = SnapObjectGetAddtlInfoAs<TTDVar, SnapObjectType::SnapBoxedValueObject>(sobj1);
@@ -1322,7 +1322,7 @@ namespace TTD
             SnapObjectSetAddtlInfoAs<double*, SnapObjectType::SnapDateObject>(snpObject, dateInfo);
         }
 
-#if ENABLE_SNAPSHOT_COMPARE 
+#if ENABLE_SNAPSHOT_COMPARE
         void AssertSnapEquiv_SnapDate(const SnapObject* sobj1, const SnapObject* sobj2, TTDCompareMap& compareMap)
         {
             const double* dateInfo1 = SnapObjectGetAddtlInfoAs<double*, SnapObjectType::SnapDateObject>(sobj1);
@@ -1373,7 +1373,7 @@ namespace TTD
             SnapObjectSetAddtlInfoAs<SnapRegexInfo*, SnapObjectType::SnapRegexObject>(snpObject, regexInfo);
         }
 
-#if ENABLE_SNAPSHOT_COMPARE 
+#if ENABLE_SNAPSHOT_COMPARE
         void AssertSnapEquiv_SnapRegexInfo(const SnapObject* sobj1, const SnapObject* sobj2, TTDCompareMap& compareMap)
         {
             const SnapRegexInfo* regexInfo1 = SnapObjectGetAddtlInfoAs<SnapRegexInfo*, SnapObjectType::SnapRegexObject>(sobj1);
@@ -1422,7 +1422,7 @@ namespace TTD
             *into = NSSnapValues::ParseTTDVar(false, reader);
         }
 
-#if ENABLE_SNAPSHOT_COMPARE 
+#if ENABLE_SNAPSHOT_COMPARE
         void SnapArrayInfo_EquivValue(int32 val1, int32 val2, TTDCompareMap& compareMap, int32 i)
         {
             compareMap.DiagnosticAssert(val1 == val2);

--- a/lib/Runtime/Language/Arguments.h
+++ b/lib/Runtime/Language/Arguments.h
@@ -123,8 +123,8 @@ namespace Js
             AssertMsg((idxArg < (int)Info.Count) && (idxArg >= 0), "Ensure a valid argument index");
             return Values[idxArg];
         }
-        CallInfo Info;
-        Var* Values;
+        Field(CallInfo) Info;
+        Field(Var*) Values;
 
         static uint32 GetCallInfoOffset() { return offsetof(Arguments, Info); }
         static uint32 GetValuesOffset() { return offsetof(Arguments, Values); }

--- a/lib/Runtime/Language/AsmJsModule.h
+++ b/lib/Runtime/Language/AsmJsModule.h
@@ -82,7 +82,7 @@ namespace Js {
     {
         static const int32   MemoryTableBeginOffset = 0;
         // Memory is allocated in this order
-        int32 mArrayBufferOffset
+        Field(int32) mArrayBufferOffset
             , mStdLibOffset
             , mDoubleOffset
             , mFuncOffset
@@ -92,7 +92,7 @@ namespace Js {
             , mFloatOffset
             , mSimdOffset // in SIMDValues
             ;
-        int32   mMemorySize;
+        Field(int32)   mMemorySize;
     };
 
     struct AsmJsFunctionMemory
@@ -331,14 +331,14 @@ namespace Js {
         Field(AsmJsSymbol::SymbolType) symType;
         union
         {
-            AsmJsVarType::Which varType;
-            ArrayBufferView::ViewType viewType;
-            double mathConstVal;
-            uint funcTableSize;
-            AsmJsModuleArg::ArgType argType;
-            AsmJSMathBuiltinFunction builtinMathFunc;
-            AsmJSTypedArrayBuiltinFunction builtinArrayFunc;
-            AsmJsSIMDBuiltinFunction builtinSIMDFunc;
+            Field(AsmJsVarType::Which) varType;
+            Field(ArrayBufferView::ViewType) viewType;
+            Field(double) mathConstVal;
+            Field(uint) funcTableSize;
+            Field(AsmJsModuleArg::ArgType) argType;
+            Field(AsmJSMathBuiltinFunction) builtinMathFunc;
+            Field(AsmJSTypedArrayBuiltinFunction) builtinArrayFunc;
+            Field(AsmJsSIMDBuiltinFunction) builtinSIMDFunc;
         };
         Field(bool) isConstVar = false;
     };

--- a/lib/Runtime/Language/AsmJsTypes.h
+++ b/lib/Runtime/Language/AsmJsTypes.h
@@ -217,7 +217,7 @@ namespace Js
         };
 
     private:
-        Which which_;
+        Field(Which) which_;
 
     public:
         AsmJsRetType();

--- a/lib/Runtime/Language/CodeGenRecyclableData.h
+++ b/lib/Runtime/Language/CodeGenRecyclableData.h
@@ -9,7 +9,7 @@ namespace Js
     class FunctionCodeGenJitTimeData;
 
     // Keeps data relevant to a function body that is needed for jitting the function, alive until jitting is complete
-    class CodeGenRecyclableData sealed : public JsUtil::DoublyLinkedListElement<CodeGenRecyclableData>
+    class CodeGenRecyclableData sealed : public JsUtil::DoublyLinkedListElement<CodeGenRecyclableData, Recycler>
     {
     private:
         Field(const FunctionCodeGenJitTimeData *) const jitTimeData;

--- a/lib/Runtime/Language/DynamicProfileInfo.h
+++ b/lib/Runtime/Language/DynamicProfileInfo.h
@@ -74,8 +74,8 @@ namespace Js
 
     struct ThisInfo
     {
-        ValueType valueType;
-        ThisType thisType;
+        Field(ValueType) valueType;
+        Field(ThisType) thisType;
 
         ThisInfo() : thisType(ThisType_Unknown)
         {
@@ -478,44 +478,44 @@ namespace Js
 
         struct Bits
         {
-            bool disableAggressiveIntTypeSpec : 1;
-            bool disableAggressiveIntTypeSpec_jitLoopBody : 1;
-            bool disableAggressiveMulIntTypeSpec : 1;
-            bool disableAggressiveMulIntTypeSpec_jitLoopBody : 1;
-            bool disableDivIntTypeSpec : 1;
-            bool disableDivIntTypeSpec_jitLoopBody : 1;
-            bool disableLossyIntTypeSpec : 1;
+            Field(bool) disableAggressiveIntTypeSpec : 1;
+            Field(bool) disableAggressiveIntTypeSpec_jitLoopBody : 1;
+            Field(bool) disableAggressiveMulIntTypeSpec : 1;
+            Field(bool) disableAggressiveMulIntTypeSpec_jitLoopBody : 1;
+            Field(bool) disableDivIntTypeSpec : 1;
+            Field(bool) disableDivIntTypeSpec_jitLoopBody : 1;
+            Field(bool) disableLossyIntTypeSpec : 1;
             // TODO: put this flag in LoopFlags if we can find a reliable way to determine the loopNumber in bailout for a hoisted instr
-            bool disableMemOp : 1;
-            bool disableTrackCompoundedIntOverflow : 1;
-            bool disableFloatTypeSpec : 1;
-            bool disableCheckThis : 1;
-            bool disableArrayCheckHoist : 1;
-            bool disableArrayCheckHoist_jitLoopBody : 1;
-            bool disableArrayMissingValueCheckHoist : 1;
-            bool disableArrayMissingValueCheckHoist_jitLoopBody : 1;
-            bool disableJsArraySegmentHoist : 1;
-            bool disableJsArraySegmentHoist_jitLoopBody : 1;
-            bool disableArrayLengthHoist : 1;
-            bool disableArrayLengthHoist_jitLoopBody : 1;
-            bool disableTypedArrayTypeSpec : 1;
-            bool disableTypedArrayTypeSpec_jitLoopBody : 1;
-            bool disableLdLenIntSpec : 1;
-            bool disableBoundCheckHoist : 1;
-            bool disableBoundCheckHoist_jitLoopBody : 1;
-            bool disableLoopCountBasedBoundCheckHoist : 1;
-            bool disableLoopCountBasedBoundCheckHoist_jitLoopBody : 1;
-            bool hasPolymorphicFldAccess : 1;
-            bool hasLdFldCallSite : 1; // getters, setters, .apply (possibly .call too in future)
-            bool disableFloorInlining : 1;
-            bool disableNoProfileBailouts : 1;
-            bool disableSwitchOpt : 1;
-            bool disableEquivalentObjTypeSpec : 1;
-            bool disableObjTypeSpec_jitLoopBody : 1;
-            bool disablePowIntIntTypeSpec : 1;
-            bool disableLoopImplicitCallInfo : 1;
-            bool disableStackArgOpt : 1;
-            bool disableTagCheck : 1;
+            Field(bool) disableMemOp : 1;
+            Field(bool) disableTrackCompoundedIntOverflow : 1;
+            Field(bool) disableFloatTypeSpec : 1;
+            Field(bool) disableCheckThis : 1;
+            Field(bool) disableArrayCheckHoist : 1;
+            Field(bool) disableArrayCheckHoist_jitLoopBody : 1;
+            Field(bool) disableArrayMissingValueCheckHoist : 1;
+            Field(bool) disableArrayMissingValueCheckHoist_jitLoopBody : 1;
+            Field(bool) disableJsArraySegmentHoist : 1;
+            Field(bool) disableJsArraySegmentHoist_jitLoopBody : 1;
+            Field(bool) disableArrayLengthHoist : 1;
+            Field(bool) disableArrayLengthHoist_jitLoopBody : 1;
+            Field(bool) disableTypedArrayTypeSpec : 1;
+            Field(bool) disableTypedArrayTypeSpec_jitLoopBody : 1;
+            Field(bool) disableLdLenIntSpec : 1;
+            Field(bool) disableBoundCheckHoist : 1;
+            Field(bool) disableBoundCheckHoist_jitLoopBody : 1;
+            Field(bool) disableLoopCountBasedBoundCheckHoist : 1;
+            Field(bool) disableLoopCountBasedBoundCheckHoist_jitLoopBody : 1;
+            Field(bool) hasPolymorphicFldAccess : 1;
+            Field(bool) hasLdFldCallSite : 1; // getters, setters, .apply (possibly .call too in future)
+            Field(bool) disableFloorInlining : 1;
+            Field(bool) disableNoProfileBailouts : 1;
+            Field(bool) disableSwitchOpt : 1;
+            Field(bool) disableEquivalentObjTypeSpec : 1;
+            Field(bool) disableObjTypeSpec_jitLoopBody : 1;
+            Field(bool) disablePowIntIntTypeSpec : 1;
+            Field(bool) disableLoopImplicitCallInfo : 1;
+            Field(bool) disableStackArgOpt : 1;
+            Field(bool) disableTagCheck : 1;
         };
         Field(Bits) bits;
 

--- a/lib/Runtime/Language/InlineCache.h
+++ b/lib/Runtime/Language/InlineCache.h
@@ -588,50 +588,50 @@ namespace Js
 
         struct GuardStruct
         {
-            CtorCacheGuardValues value;
+            Field(CtorCacheGuardValues) value;
         };
 
         struct ContentStruct
         {
-            DynamicType* type;
-            ScriptContext* scriptContext;
+            Field(DynamicType*) type;
+            Field(ScriptContext*) scriptContext;
             // In a pinch we could eliminate this and store type pending sharing in the type field as long
             // as the guard value flags fit below the object alignment boundary.  However, this wouldn't
             // keep the type alive, so it would only work if we zeroed constructor caches before GC.
-            DynamicType* pendingType;
+            Field(DynamicType*) pendingType;
 
             // We cache only types whose slotCount < 64K to ensure the slotCount field doesn't look like a pointer to the recycler.
-            int slotCount;
+            Field(int) slotCount;
 
             // This layout (i.e. one-byte bit fields first, then the one-byte updateAfterCtor, and then the two byte inlineSlotCount) is
             // chosen intentionally to make sure the whole four bytes never look like a pointer and create a false reference pinning something
             // in recycler heap.  The isPopulated bit is always set when the cache holds any data - even if it got invalidated.
-            bool isPopulated : 1;
-            bool isPolymorphic : 1;
-            bool typeUpdatePending : 1;
-            bool ctorHasNoExplicitReturnValue : 1;
-            bool skipDefaultNewObject : 1;
+            Field(bool) isPopulated : 1;
+            Field(bool) isPolymorphic : 1;
+            Field(bool) typeUpdatePending : 1;
+            Field(bool) ctorHasNoExplicitReturnValue : 1;
+            Field(bool) skipDefaultNewObject : 1;
             // This field indicates that the type stored in this cache is the final type after constructor.
-            bool typeIsFinal : 1;
+            Field(bool) typeIsFinal : 1;
             // This field indicates that the constructor cache has been invalidated due to a constructor's prototype property change.
             // We use this flag to determine if we should mark the cache as polymorphic and not attempt subsequent optimizations.
             // The cache may also be invalidated due to a guard invalidation resulting from some property change (e.g. in proto chain),
             // in which case we won't deem the cache polymorphic.
-            bool hasPrototypeChanged : 1;
+            Field(bool) hasPrototypeChanged : 1;
 
-            uint8 callCount;
+            Field(uint8) callCount;
 
             // Separate from the bit field below for convenient compare from the JIT-ed code. Doesn't currently increase the size.
             // If size becomes an issue, we could merge back into the bit field and use a TEST instead of CMP.
-            bool updateAfterCtor;
+            Field(bool) updateAfterCtor;
 
-            int16 inlineSlotCount;
+            Field(int16) inlineSlotCount;
         };
 
         union
         {
-            GuardStruct guard;
-            ContentStruct content;
+            Field(GuardStruct) guard;
+            Field(ContentStruct) content;
         };
 
         CompileAssert(offsetof(GuardStruct, value) == offsetof(ContentStruct, type));

--- a/lib/Runtime/Language/InlineCachePointerArray.h
+++ b/lib/Runtime/Language/InlineCachePointerArray.h
@@ -13,7 +13,7 @@ namespace Js
         WriteBarrierPtr<T*> inlineCaches;
     private:
 #if DBG
-        uint inlineCacheCount;
+        Field(uint) inlineCacheCount;
 #endif
 
     public:

--- a/lib/Runtime/Language/JavascriptExceptionContext.h
+++ b/lib/Runtime/Language/JavascriptExceptionContext.h
@@ -55,9 +55,9 @@ namespace Js {
         StackTrace* GetOriginalStackTrace() const { return m_originalStackTrace; }
 
     private:
-        JavascriptFunction* m_throwingFunction;
-        uint32 m_throwingFunctionByteCodeOffset;
-        StackTrace *m_stackTrace;
-        StackTrace *m_originalStackTrace;
+        Field(JavascriptFunction*) m_throwingFunction;
+        Field(uint32) m_throwingFunctionByteCodeOffset;
+        Field(StackTrace *) m_stackTrace;
+        Field(StackTrace *) m_originalStackTrace;
     };
 }

--- a/lib/Runtime/Language/ModuleRecordBase.h
+++ b/lib/Runtime/Language/ModuleRecordBase.h
@@ -12,8 +12,8 @@ namespace Js
     typedef SList<ModuleRecordBase*> ExportModuleRecordList;
     struct ModuleNameRecord
     {
-        ModuleRecordBase* module;
-        PropertyId bindingName;
+        Field(ModuleRecordBase*) module;
+        Field(PropertyId) bindingName;
     };
     typedef SList<ModuleNameRecord> ResolveSet;
 

--- a/lib/Runtime/Language/ObjTypeSpecFldInfo.h
+++ b/lib/Runtime/Language/ObjTypeSpecFldInfo.h
@@ -27,24 +27,24 @@ namespace Js
     {
         struct
         {
-            bool falseReferencePreventionBit : 1;
-            bool isPolymorphic : 1;
-            bool isRootObjectNonConfigurableField : 1;
-            bool isRootObjectNonConfigurableFieldLoad : 1;
-            bool usesAuxSlot : 1;
-            bool isLocal : 1;
-            bool isLoadedFromProto : 1;
-            bool usesAccessor : 1;
-            bool hasFixedValue : 1;
-            bool keepFieldValue : 1;
-            bool isBeingStored : 1;
-            bool isBeingAdded : 1;
-            bool doesntHaveEquivalence : 1;
-            bool isBuiltIn : 1;
+            Field(bool) falseReferencePreventionBit : 1;
+            Field(bool) isPolymorphic : 1;
+            Field(bool) isRootObjectNonConfigurableField : 1;
+            Field(bool) isRootObjectNonConfigurableFieldLoad : 1;
+            Field(bool) usesAuxSlot : 1;
+            Field(bool) isLocal : 1;
+            Field(bool) isLoadedFromProto : 1;
+            Field(bool) usesAccessor : 1;
+            Field(bool) hasFixedValue : 1;
+            Field(bool) keepFieldValue : 1;
+            Field(bool) isBeingStored : 1;
+            Field(bool) isBeingAdded : 1;
+            Field(bool) doesntHaveEquivalence : 1;
+            Field(bool) isBuiltIn : 1;
         };
         struct
         {
-            uint16 flags;
+            Field(uint16) flags;
         };
         ObjTypeSpecFldInfoFlags(uint16 flags) : flags(flags) { }
     };
@@ -372,7 +372,7 @@ namespace Js
     private:
         Field(Field(ObjTypeSpecFldInfo*)*) infoArray;
 #if DBG
-        uint infoCount;
+        Field(uint) infoCount;
 #endif
     public:
         ObjTypeSpecFldInfoArray();

--- a/lib/Runtime/Language/SimdUtils.h
+++ b/lib/Runtime/Language/SimdUtils.h
@@ -20,14 +20,14 @@
 #define SIMD_INDEX_VALUE_MAX     5
 #define SIMD_STRING_BUFFER_MAX   1024
 #define SIMD_DATA     \
-    int32   i32[4];\
-    int16   i16[8];\
-    int8    i8[16];\
-    uint32  u32[4];\
-    uint16  u16[8];\
-    uint8   u8[16];\
-    float   f32[4];\
-    double  f64[2];
+    Field(int32)   i32[4];\
+    Field(int16)   i16[8];\
+    Field(int8)    i8[16];\
+    Field(uint32)  u32[4];\
+    Field(uint16)  u16[8];\
+    Field(uint8)   u8[16];\
+    Field(float)   f32[4];\
+    Field(double)  f64[2];
 #define SIMD_TEMP_SIZE 3
 struct _SIMDValue
 {
@@ -137,7 +137,7 @@ const _x86_SIMDValue X86_TWO_31_I4          = X86_NEG_MASK_F4;                  
 const _x86_SIMDValue X86_WORD_SIGNBITS      = { 0x80008000, 0x80008000, 0x80008000, 0x80008000 };
 const _x86_SIMDValue X86_DWORD_SIGNBITS     = { 0x80000000, 0x80000000, 0x80000000, 0x80000000 };
 const _x86_SIMDValue X86_BYTE_SIGNBITS      = { 0x80808080, 0x80808080, 0x80808080, 0x80808080 };
-const _x86_SIMDValue X86_4LANES_MASKS[]     = {{ 0xffffffff, 0x00000000, 0x00000000, 0x00000000 }, 
+const _x86_SIMDValue X86_4LANES_MASKS[]     = {{ 0xffffffff, 0x00000000, 0x00000000, 0x00000000 },
                                                { 0x00000000, 0xffffffff, 0x00000000, 0x00000000 },
                                                { 0x00000000, 0x00000000, 0xffffffff, 0x00000000 },
                                                { 0x00000000, 0x00000000, 0x00000000, 0xffffffff }};
@@ -146,7 +146,7 @@ const _x86_SIMDValue X86_4LANES_MASKS[]     = {{ 0xffffffff, 0x00000000, 0x00000
 #pragma warning(pop)
 
 #if ENABLE_NATIVE_CODEGEN && defined(ENABLE_SIMDJS)
-// auxiliary SIMD values in memory to help JIT'ed code. E.g. used for Int8x16 shuffle. 
+// auxiliary SIMD values in memory to help JIT'ed code. E.g. used for Int8x16 shuffle.
 extern _x86_SIMDValue X86_TEMP_SIMD[];
 #endif
 

--- a/lib/Runtime/Language/ValueType.h
+++ b/lib/Runtime/Language/ValueType.h
@@ -63,20 +63,20 @@ private:
         // Don't use the following directly because they only apply to specific types. They're mostly for debugger-friendliness.
         struct
         {
-            TSize : VALUE_TYPE_OBJECT_BIT_INDEX;
-            TSize _objectBit : 1;
+            Field(TSize) : VALUE_TYPE_OBJECT_BIT_INDEX;
+            Field(TSize) _objectBit : 1;
         };
         struct
         {
-            Bits _nonObjectBits : VALUE_TYPE_COMMON_BIT_COUNT + VALUE_TYPE_NONOBJECT_BIT_COUNT;
+            Field(Bits) _nonObjectBits : VALUE_TYPE_COMMON_BIT_COUNT + VALUE_TYPE_NONOBJECT_BIT_COUNT;
         };
         struct
         {
-            Bits _objectBits : VALUE_TYPE_COMMON_BIT_COUNT + VALUE_TYPE_OBJECT_BIT_COUNT;
-            ObjectType _objectType : sizeof(TSize) * 8 - (VALUE_TYPE_COMMON_BIT_COUNT + VALUE_TYPE_OBJECT_BIT_COUNT); // use remaining bits
+            Field(Bits) _objectBits : VALUE_TYPE_COMMON_BIT_COUNT + VALUE_TYPE_OBJECT_BIT_COUNT;
+            Field(ObjectType) _objectType : sizeof(TSize) * 8 - (VALUE_TYPE_COMMON_BIT_COUNT + VALUE_TYPE_OBJECT_BIT_COUNT); // use remaining bits
         };
 
-        Bits bits;
+        Field(Bits) bits;
     };
 
 public:

--- a/lib/Runtime/Language/WAsmjsUtils.h
+++ b/lib/Runtime/Language/WAsmjsUtils.h
@@ -242,13 +242,13 @@ namespace WAsmJs
     struct TypedSlotInfo
     {
         TypedSlotInfo(): constCount(0), varCount(0), tmpCount(0), byteOffset(0), constSrcByteOffset(0) { }
-        uint32 constCount;
-        uint32 varCount;
-        uint32 tmpCount;
+        Field(uint32) constCount;
+        Field(uint32) varCount;
+        Field(uint32) tmpCount;
         // Offset in bytes from the start of InterpreterStack::m_localSlot
-        uint32 byteOffset;
+        Field(uint32) byteOffset;
         // Offset in bytes from the start of the const table before shuffling (InterpreterStackFrame::AlignMemoryForAsmJs())
-        uint32 constSrcByteOffset;
+        Field(uint32) constSrcByteOffset;
     };
 
     typedef RegisterSpace*(*AllocateRegisterSpaceFunc)(ArenaAllocator*, WAsmJs::Types);

--- a/lib/Runtime/Library/CompoundString.cpp
+++ b/lib/Runtime/Library/CompoundString.cpp
@@ -146,7 +146,7 @@ namespace Js
 
     #endif
 
-    // ChakraDiag includes CompoundString.cpp as a header file so this method needs to be marked as inline 
+    // ChakraDiag includes CompoundString.cpp as a header file so this method needs to be marked as inline
     // to handle that case
     JS_DIAG_INLINE CharCount CompoundString::Block::PointerLengthFromCharLength(const CharCount charLength)
     {
@@ -384,7 +384,7 @@ namespace Js
         {
             AllocateBuffer(charCapacity, recycler);
             charLength = usedCharLength;
-            js_wmemcpy_s((char16*)(this->buffer), charCapacity, (char16*)(buffer), usedCharLength);
+            js_wmemcpy_s((char16*)PointerValue(this->buffer), charCapacity, (char16*)(buffer), usedCharLength);
             return nullptr;
         }
 
@@ -403,7 +403,7 @@ namespace Js
             void *const newBuffer = RecyclerNewArray(recycler, char16, newCharCapacity);
             charCapacity = newCharCapacity;
             const CharCount charLength = CharLength();
-            js_wmemcpy_s((char16*)newBuffer, charCapacity, (char16*)buffer, charLength);
+            js_wmemcpy_s((char16*)newBuffer, charCapacity, (char16*)PointerValue(buffer), charLength);
             buffer = newBuffer;
             return nullptr;
         }

--- a/lib/Runtime/Library/CompoundString.h
+++ b/lib/Runtime/Library/CompoundString.h
@@ -182,9 +182,9 @@ namespace Js
         class BlockInfo
         {
         private:
-            void *buffer;
-            CharCount charLength;
-            CharCount charCapacity;
+            Field(void *) buffer;
+            Field(CharCount) charLength;
+            Field(CharCount) charCapacity;
 
         public:
             BlockInfo();

--- a/lib/Runtime/Library/DateImplementation.h
+++ b/lib/Runtime/Library/DateImplementation.h
@@ -74,11 +74,11 @@ namespace Js {
         // Time zone descriptor.
         struct TZD
         {
-            int minutes;
-            int offset;
+            Field(int) minutes;
+            Field(int) offset;
 
             // Indicates whether Daylight savings
-            bool fDst;
+            Field(bool) fDst;
         };
 
         template <class ScriptContext>
@@ -281,14 +281,14 @@ namespace Js {
         static StringBuilder* GetDateDefaultString(DateTime::YMD *pymd, TZD *ptzd, DateTimeFlag noDateTime, ScriptContext* scriptContext, NewStringBuilderFunc newStringBuilder);
 
     private:
-        double                  m_tvUtc;
-        double                  m_tvLcl;
-        DateTime::YMD           m_ymdUtc;
-        DateTime::YMD           m_ymdLcl;
-        TZD                     m_tzd;
-        uint32                  m_grfval; // Which fields are valid. m_tvUtc is always valid.
-        ScriptContext *         m_scriptContext;
-        bool                    m_modified : 1; // Whether SetDateData was called on this class
+        Field(double)                   m_tvUtc;
+        Field(double)                   m_tvLcl;
+        FieldNoBarrier(DateTime::YMD)   m_ymdUtc;
+        FieldNoBarrier(DateTime::YMD)   m_ymdLcl;
+        Field(TZD)                      m_tzd;
+        Field(uint32)                   m_grfval; // Which fields are valid. m_tvUtc is always valid.
+        FieldNoBarrier(ScriptContext *) m_scriptContext;
+        Field(bool)                     m_modified : 1; // Whether SetDateData was called on this class
 
         friend JavascriptDate;
     };

--- a/lib/Runtime/Library/JavascriptArray.cpp
+++ b/lib/Runtime/Library/JavascriptArray.cpp
@@ -2406,7 +2406,9 @@ namespace Js
 
     SparseArraySegmentBase * JavascriptArray::GetLastUsedSegment() const
     {
-        return (HasSegmentMap() ? segmentUnion.segmentBTreeRoot->lastUsedSegment : segmentUnion.lastUsedSegment);
+        return HasSegmentMap() ?
+            PointerValue(segmentUnion.segmentBTreeRoot->lastUsedSegment) :
+            PointerValue(segmentUnion.lastUsedSegment);
     }
 
     void JavascriptArray::SetHeadAndLastUsedSegment(SparseArraySegmentBase * segment)
@@ -6172,7 +6174,7 @@ Case0:
         // for arrays of more than 512 elements.
         if (length > 512)
         {
-            qsort_s(elements, length, sizeof(Field(Var)), compareVars, compareInfo);
+            qsort_s(elements, length, compareVars, compareInfo);
             return;
         }
 
@@ -6402,7 +6404,8 @@ Case0:
 
     void JavascriptArray::SortElements(Element* elements, uint32 left, uint32 right)
     {
-        qsort_s(elements, right - left + 1, sizeof(Element), CompareElements, this);
+        // Note: use write barrier policy of Field(Var)
+        qsort_s<Element, Field(Var)>(elements, right - left + 1, CompareElements, this);
     }
 
     Var JavascriptArray::EntrySort(RecyclableObject* function, CallInfo callInfo, ...)

--- a/lib/Runtime/Library/JavascriptArray.h
+++ b/lib/Runtime/Library/JavascriptArray.h
@@ -104,10 +104,11 @@ namespace Js
         Field(SparseArraySegmentBase*) head;
         union SegmentUnionType
         {
-            SparseArraySegmentBase* lastUsedSegment;
-            SegmentBTreeRoot* segmentBTreeRoot;
+            Field(SparseArraySegmentBase*) lastUsedSegment;
+            Field(SegmentBTreeRoot*) segmentBTreeRoot;
+
+            SegmentUnionType() {}
         };
-        // SWB-TODO: How to handle write barrier inside union?
         Field(SegmentUnionType) segmentUnion;
     public:
         typedef Var TElement;
@@ -566,9 +567,10 @@ namespace Js
         BOOL GetPropertyBuiltIns(PropertyId propertyId, Var* value);
         bool GetSetterBuiltIns(PropertyId propertyId, PropertyValueInfo* info, DescriptorFlags* descriptorFlags);
     private:
-        struct Element {
-            Var Value;
-            JavascriptString* StringValue;
+        struct Element
+        {
+            Field(Var) Value;
+            Field(JavascriptString*) StringValue;
         };
 
         static int __cdecl CompareElements(void* context, const void* elem1, const void* elem2);

--- a/lib/Runtime/Library/JavascriptExternalFunction.h
+++ b/lib/Runtime/Library/JavascriptExternalFunction.h
@@ -53,9 +53,9 @@ namespace Js
         Field(void *) callbackState;
         union
         {
-            ExternalMethod nativeMethod;
-            JavascriptExternalFunction* wrappedMethod;
-            StdCallJavascriptMethod stdCallNativeMethod;
+            FieldNoBarrier(ExternalMethod) nativeMethod;
+            Field(JavascriptExternalFunction*) wrappedMethod;
+            FieldNoBarrier(StdCallJavascriptMethod) stdCallNativeMethod;
         };
         Field(InitializeMethod) initMethod;
 

--- a/lib/Runtime/Library/MapOrSetDataList.h
+++ b/lib/Runtime/Library/MapOrSetDataList.h
@@ -41,8 +41,8 @@ namespace Js
     class MapOrSetDataList
     {
     private:
-        MapOrSetDataNode<TData>* first;
-        MapOrSetDataNode<TData>* last;
+        Field(MapOrSetDataNode<TData>*) first;
+        Field(MapOrSetDataNode<TData>*) last;
 
     public:
         MapOrSetDataList(VirtualTableInfoCtorEnum) {};
@@ -50,8 +50,8 @@ namespace Js
 
         class Iterator
         {
-            MapOrSetDataList<TData>* list;
-            MapOrSetDataNode<TData>* current;
+            Field(MapOrSetDataList<TData>*) list;
+            Field(MapOrSetDataNode<TData>*) current;
         public:
             Iterator() : list(nullptr), current(nullptr) { }
             Iterator(MapOrSetDataList<TData>* list) : list(list), current(nullptr) { }

--- a/lib/Runtime/Types/ActivationObject.h
+++ b/lib/Runtime/Types/ActivationObject.h
@@ -8,8 +8,8 @@ namespace Js
 {
     struct FuncCacheEntry
     {
-        ScriptFunction *func;
-        DynamicType *type;
+        Field(ScriptFunction *) func;
+        Field(DynamicType *) type;
     };
 
     class ActivationObject : public DynamicObject

--- a/lib/Runtime/Types/DynamicObject.cpp
+++ b/lib/Runtime/Types/DynamicObject.cpp
@@ -392,7 +392,7 @@ namespace Js
     }
 
     BOOL
-    DynamicObject::FindNextProperty(BigPropertyIndex& index, JavascriptString** propertyString, PropertyId* propertyId, PropertyAttributes* attributes, 
+    DynamicObject::FindNextProperty(BigPropertyIndex& index, JavascriptString** propertyString, PropertyId* propertyId, PropertyAttributes* attributes,
         DynamicType *typeToEnumerate, EnumeratorFlags flags, ScriptContext * requestContext) const
     {
         if(index == Constants::NoBigSlot)
@@ -856,14 +856,15 @@ namespace Js
         TTD::NSSnapObjects::StdExtractSetKindSpecificInfo<void*, TTD::NSSnapObjects::SnapObjectType::SnapDynamicObject>(objData, nullptr);
     }
 
-    Js::Var* DynamicObject::GetInlineSlots_TTD() const
+    Js::Var const* DynamicObject::GetInlineSlots_TTD() const
     {
-        return reinterpret_cast<Var*>(reinterpret_cast<size_t>(this) + this->GetTypeHandler()->GetOffsetOfInlineSlots());
+        return reinterpret_cast<Var const*>(
+            reinterpret_cast<size_t>(this) + this->GetTypeHandler()->GetOffsetOfInlineSlots());
     }
 
-    Js::Var* DynamicObject::GetAuxSlots_TTD() const
+    Js::Var const* DynamicObject::GetAuxSlots_TTD() const
     {
-        return this->auxSlots;
+        return &this->auxSlots[0];
     }
 
 #if ENABLE_OBJECT_SOURCE_TRACKING

--- a/lib/Runtime/Types/DynamicObject.h
+++ b/lib/Runtime/Types/DynamicObject.h
@@ -76,12 +76,12 @@ namespace Js
 
 #if ENABLE_OBJECT_SOURCE_TRACKING
     public:
-        //Field for tracking object allocation 
+        //Field for tracking object allocation
         TTD::DiagnosticOrigin TTDDiagOriginInfo;
 #endif
 
     private:
-        Field(Var*) auxSlots;
+        Field(Field(Var)*) auxSlots;
         // The objectArrayOrFlags field can store one of two things:
         //   a) a pointer to the object array holding numeric properties of this object, or
         //   b) a bitfield of flags.
@@ -95,11 +95,11 @@ namespace Js
 
         union
         {
-            ArrayObject * objectArray;          // Only if !IsAnyArray
+            Field(ArrayObject *) objectArray;          // Only if !IsAnyArray
             struct                                  // Only if IsAnyArray
             {
-                DynamicObjectFlags arrayFlags;
-                ProfileId arrayCallSiteIndex;
+                Field(DynamicObjectFlags) arrayFlags;
+                Field(ProfileId) arrayCallSiteIndex;
             };
         };
 
@@ -283,7 +283,7 @@ namespace Js
 
         void ChangeTypeIf(const Type* oldType);
 
-        BOOL FindNextProperty(BigPropertyIndex& index, JavascriptString** propertyString, PropertyId* propertyId, PropertyAttributes* attributes, 
+        BOOL FindNextProperty(BigPropertyIndex& index, JavascriptString** propertyString, PropertyId* propertyId, PropertyAttributes* attributes,
             DynamicType *typeToEnumerate, EnumeratorFlags flags, ScriptContext * requestContext) const;
 
         virtual BOOL HasDeferredTypeHandler() const sealed;
@@ -335,8 +335,8 @@ namespace Js
         virtual TTD::NSSnapObjects::SnapObjectType GetSnapTag_TTD() const override;
         virtual void ExtractSnapObjectDataInto(TTD::NSSnapObjects::SnapObject* objData, TTD::SlabAllocator& alloc) override;
 
-        Js::Var* GetInlineSlots_TTD() const;
-        Js::Var* GetAuxSlots_TTD() const;
+        Js::Var const* GetInlineSlots_TTD() const;
+        Js::Var const* GetAuxSlots_TTD() const;
 
 #if ENABLE_OBJECT_SOURCE_TRACKING
         void SetDiagOriginInfoAsNeeded();

--- a/lib/Runtime/Types/DynamicObjectPropertyEnumerator.cpp
+++ b/lib/Runtime/Types/DynamicObjectPropertyEnumerator.cpp
@@ -6,17 +6,17 @@
 
 namespace Js
 {
-    bool DynamicObjectPropertyEnumerator::GetEnumNonEnumerable() const 
-    { 
-        return !!(flags & EnumeratorFlags::EnumNonEnumerable); 
+    bool DynamicObjectPropertyEnumerator::GetEnumNonEnumerable() const
+    {
+        return !!(flags & EnumeratorFlags::EnumNonEnumerable);
     }
-    bool DynamicObjectPropertyEnumerator::GetEnumSymbols() const 
-    { 
-        return !!(flags & EnumeratorFlags::EnumSymbols); 
+    bool DynamicObjectPropertyEnumerator::GetEnumSymbols() const
+    {
+        return !!(flags & EnumeratorFlags::EnumSymbols);
     }
-    bool DynamicObjectPropertyEnumerator::GetSnapShotSemantics() const 
-    { 
-        return !!(flags & EnumeratorFlags::SnapShotSemantics); 
+    bool DynamicObjectPropertyEnumerator::GetSnapShotSemantics() const
+    {
+        return !!(flags & EnumeratorFlags::SnapShotSemantics);
     }
 
     bool DynamicObjectPropertyEnumerator::GetUseCache() const
@@ -58,7 +58,7 @@ namespace Js
             if (!object->GetDynamicType()->GetTypeHandler()->EnsureObjectReady(object))
             {
                 return false;
-            }            
+            }
             Initialize(object->GetDynamicType(), nullptr, GetSnapShotSemantics() ? this->object->GetPropertyCount() : Constants::NoBigSlot);
             return true;
         }
@@ -69,7 +69,7 @@ namespace Js
         if (forInCache && type == forInCache->type)
         {
             // We shouldn't have a for in cache when asking to enum symbols
-            Assert(!GetEnumSymbols());            
+            Assert(!GetEnumSymbols());
             data = (CachedData *)forInCache->data;
 
             Assert(data != nullptr);
@@ -82,7 +82,7 @@ namespace Js
                 return true;
             }
         }
-      
+
         data = (CachedData *)requestContext->GetThreadContext()->GetDynamicObjectEnumeratorCache(type);
 
         if (data != nullptr && data->scriptContext == this->scriptContext && data->enumNonEnumerable == GetEnumNonEnumerable() && data->enumSymbols == GetEnumSymbols())
@@ -163,7 +163,7 @@ namespace Js
             GetSnapShotSemantics() &&
             initialType->GetIsLocked() &&
             CONFIG_FLAG(TypeSnapshotEnumeration)
-            ? initialType
+            ? PointerValue(initialType)
             : object->GetDynamicType();
     }
 

--- a/lib/Runtime/Types/DynamicObjectPropertyEnumerator.h
+++ b/lib/Runtime/Types/DynamicObjectPropertyEnumerator.h
@@ -9,14 +9,14 @@ namespace Js
     class DynamicObjectPropertyEnumerator
     {
     private:
-        ScriptContext * scriptContext;
-        DynamicObject * object;
-        DynamicType * initialType;              // for snapshot enumeration
-        BigPropertyIndex objectIndex;
-        BigPropertyIndex initialPropertyCount;
-        int enumeratedCount;
+        Field(ScriptContext *) scriptContext;
+        Field(DynamicObject *) object;
+        Field(DynamicType *) initialType;              // for snapshot enumeration
+        Field(BigPropertyIndex) objectIndex;
+        Field(BigPropertyIndex) initialPropertyCount;
+        Field(int) enumeratedCount;
 
-        EnumeratorFlags flags;
+        Field(EnumeratorFlags) flags;
 
         struct CachedData
         {
@@ -29,12 +29,13 @@ namespace Js
             Field(bool) completed;
             Field(bool) enumNonEnumerable;
             Field(bool) enumSymbols;
-        } *cachedData;
+        };
+        Field(CachedData *) cachedData;
 
         DynamicType * GetTypeToEnumerate() const;
         JavascriptString * MoveAndGetNextWithCache(PropertyId& propertyId, PropertyAttributes* attributes);
         JavascriptString * MoveAndGetNextNoCache(PropertyId& propertyId, PropertyAttributes * attributes);
-        
+
         void Initialize(DynamicType * type, CachedData * data, Js::BigPropertyIndex initialPropertyCount);
     public:
         DynamicObject * GetObject() const { return object; }
@@ -59,14 +60,14 @@ namespace Js
         static uint32 GetOffsetOfInitialPropertyCount() { return offsetof(DynamicObjectPropertyEnumerator, initialPropertyCount); }
         static uint32 GetOffsetOfEnumeratedCount() { return offsetof(DynamicObjectPropertyEnumerator, enumeratedCount); }
         static uint32 GetOffsetOfCachedData() { return offsetof(DynamicObjectPropertyEnumerator, cachedData); }
-        static uint32 GetOffsetOfFlags() { return offsetof(DynamicObjectPropertyEnumerator, flags); 
+        static uint32 GetOffsetOfFlags() { return offsetof(DynamicObjectPropertyEnumerator, flags);
         }
         static uint32 GetOffsetOfCachedDataStrings() { return offsetof(CachedData, strings); }
         static uint32 GetOffsetOfCachedDataIndexes() { return offsetof(CachedData, indexes); }
         static uint32 GetOffsetOfCachedDataPropertyCount() { return offsetof(CachedData, propertyCount); }
         static uint32 GetOffsetOfCachedDataCachedCount() { return offsetof(CachedData, cachedCount); }
         static uint32 GetOffsetOfCachedDataPropertyAttributes() { return offsetof(CachedData, attributes); }
-        static uint32 GetOffsetOfCachedDataCompleted() { return offsetof(CachedData, completed); }        
+        static uint32 GetOffsetOfCachedDataCompleted() { return offsetof(CachedData, completed); }
         static uint32 GetOffsetOfCachedDataEnumNonEnumerable() { return offsetof(CachedData, enumNonEnumerable); }
     };
 };

--- a/lib/Runtime/Types/DynamicType.cpp
+++ b/lib/Runtime/Types/DynamicType.cpp
@@ -80,7 +80,7 @@ namespace Js
         int inlineSlotCapacity = GetTypeHandler()->GetInlineSlotCapacity();
         if (slotCapacity > inlineSlotCapacity)
         {
-            instance->auxSlots = RecyclerNewArrayZ(recycler, Var, slotCapacity - inlineSlotCapacity);
+            instance->auxSlots = RecyclerNewArrayZ(recycler, Field(Var), slotCapacity - inlineSlotCapacity);
         }
     }
 

--- a/lib/Runtime/Types/JavascriptStaticEnumerator.cpp
+++ b/lib/Runtime/Types/JavascriptStaticEnumerator.cpp
@@ -8,12 +8,12 @@
 namespace Js
 {
 
-    bool JavascriptStaticEnumerator::Initialize(JavascriptEnumerator * prefixEnumerator, ArrayObject * arrayToEnumerate, 
+    bool JavascriptStaticEnumerator::Initialize(JavascriptEnumerator * prefixEnumerator, ArrayObject * arrayToEnumerate,
         DynamicObject * objectToEnumerate, EnumeratorFlags flags, ScriptContext * requestContext, ForInCache * forInCache)
     {
         this->prefixEnumerator = prefixEnumerator;
         this->arrayEnumerator = arrayToEnumerate ? arrayToEnumerate->GetIndexEnumerator(flags, requestContext) : nullptr;
-        this->currentEnumerator = prefixEnumerator ? prefixEnumerator : arrayEnumerator;
+        this->currentEnumerator = prefixEnumerator ? prefixEnumerator : PointerValue(arrayEnumerator);
         return this->propertyEnumerator.Initialize(objectToEnumerate, flags, requestContext, forInCache);
     }
 

--- a/lib/Runtime/Types/JavascriptStaticEnumerator.h
+++ b/lib/Runtime/Types/JavascriptStaticEnumerator.h
@@ -20,10 +20,10 @@ namespace Js
     {
     protected:
         friend class ForInObjectEnumerator;
-        DynamicObjectPropertyEnumerator propertyEnumerator;
-        JavascriptEnumerator* currentEnumerator;
-        JavascriptEnumerator* prefixEnumerator;
-        JavascriptEnumerator* arrayEnumerator;
+        Field(DynamicObjectPropertyEnumerator) propertyEnumerator;
+        Field(JavascriptEnumerator*) currentEnumerator;
+        Field(JavascriptEnumerator*) prefixEnumerator;
+        Field(JavascriptEnumerator*) arrayEnumerator;
 
         Var MoveAndGetNextFromEnumerator(PropertyId& propertyId, PropertyAttributes* attributes);
     public:

--- a/lib/Runtime/Types/PropertyDescriptor.h
+++ b/lib/Runtime/Types/PropertyDescriptor.h
@@ -12,22 +12,22 @@ namespace Js
         PropertyDescriptor();
 
     private:
-        Var Value;
-        Var Getter;
-        Var Setter;
-        Var originalVar;
+        Field(Var) Value;
+        Field(Var) Getter;
+        Field(Var) Setter;
+        Field(Var) originalVar;
 
-        bool writableSpecified;
-        bool enumerableSpecified;
-        bool configurableSpecified;
-        bool valueSpecified;
-        bool getterSpecified;
-        bool setterSpecified;
+        Field(bool) writableSpecified;
+        Field(bool) enumerableSpecified;
+        Field(bool) configurableSpecified;
+        Field(bool) valueSpecified;
+        Field(bool) getterSpecified;
+        Field(bool) setterSpecified;
 
-        bool Writable;
-        bool Enumerable;
-        bool Configurable;
-        bool fromProxy;
+        Field(bool) Writable;
+        Field(bool) Enumerable;
+        Field(bool) Configurable;
+        Field(bool) fromProxy;
 
     public:
         bool IsDataDescriptor() const { return writableSpecified | valueSpecified;}

--- a/lib/Runtime/Types/SimplePropertyDescriptor.h
+++ b/lib/Runtime/Types/SimplePropertyDescriptor.h
@@ -13,11 +13,11 @@ namespace Js
         SimplePropertyDescriptor(const PropertyRecord* id) : Id(id), preventFalseReference(NULL) { Attributes = PropertyDynamicTypeDefaults; }
         SimplePropertyDescriptor(const PropertyRecord* id, PropertyAttributes attributes) : Id(id), preventFalseReference(NULL) { Attributes = attributes; }
 
-        const PropertyRecord* Id;
+        Field(const PropertyRecord*) Id;
         union
         {
-            PropertyAttributes Attributes;
-            void* preventFalseReference; // SimplePropertyDescriptor can be declared on stack. Always zero out to avoid this becoming a memory address reference.
+            Field(PropertyAttributes) Attributes;
+            FieldNoBarrier(void*) preventFalseReference; // SimplePropertyDescriptor can be declared on stack. Always zero out to avoid this becoming a memory address reference.
         };
     };
 

--- a/lib/Runtime/Types/SimpleTypeHandler.cpp
+++ b/lib/Runtime/Types/SimpleTypeHandler.cpp
@@ -36,7 +36,7 @@ namespace Js
         inlineSlotCapacity, offsetOfInlineSlots, DefaultFlags | IsLockedFlag | MayBecomeSharedFlag | IsSharedFlag), propertyCount(1)
     {
         Assert((attributes & PropertyDeleted) == 0);
-        descriptors[0].Id = id;
+        NoWriteBarrierSet(descriptors[0].Id, id); // Used to init from global static BuiltInPropertyId
         descriptors[0].Attributes = attributes;
 
         Assert((propertyTypes & (PropertyTypesAll & ~PropertyTypesWritableDataOnly)) == 0);
@@ -53,7 +53,8 @@ namespace Js
         for (size_t i = 0; i < size; i++)
         {
             Assert((SharedFunctionPropertyDescriptors[i].Attributes & PropertyDeleted) == 0);
-            descriptors[i].Id = SharedFunctionPropertyDescriptors[i].Id;
+             // Used to init from global static BuiltInPropertyId
+            NoWriteBarrierSet(descriptors[i].Id, SharedFunctionPropertyDescriptors[i].Id);
             descriptors[i].Attributes = SharedFunctionPropertyDescriptors[i].Attributes;
         }
         Assert((propertyTypes & (PropertyTypesAll & ~PropertyTypesWritableDataOnly)) == 0);

--- a/lib/Runtime/Types/TypeHandler.cpp
+++ b/lib/Runtime/Types/TypeHandler.cpp
@@ -160,7 +160,8 @@ namespace Js
         AssertMsg(index >= (int)(offsetOfInlineSlots / sizeof(Var)), "index should be relative to the address of the object");
         Assert(index - (int)(offsetOfInlineSlots / sizeof(Var)) < this->GetInlineSlotCapacity());
         Assert(propertyId == Constants::NoProperty || CanStorePropertyValueDirectly(instance, propertyId, allowLetConst));
-        Var * slots = reinterpret_cast<Var*>(instance);
+
+        Field(Var) * slots = reinterpret_cast<Field(Var)*>(instance);
         slots[index] = value;
     }
 
@@ -658,7 +659,8 @@ namespace Js
         // Allocate new aux slot array
         Recycler *const recycler = object->GetRecycler();
         TRACK_ALLOC_INFO(recycler, Var, Recycler, 0, newAuxSlotCapacity);
-        Var *const newAuxSlots = reinterpret_cast<Var *>(recycler->AllocZero(newAuxSlotCapacity * sizeof(Var)));
+        Field(Var) *const newAuxSlots = reinterpret_cast<Field(Var) *>(
+            recycler->AllocZero(newAuxSlotCapacity * sizeof(Field(Var))));
 
         DynamicTypeHandler *const oldTypeHandler = object->GetTypeHandler();
         const PropertyIndex oldInlineSlotCapacity = oldTypeHandler->GetInlineSlotCapacity();
@@ -669,7 +671,7 @@ namespace Js
             if(oldAuxSlotCapacity > 0)
             {
                 // Copy aux slots to the new array
-                Var *const oldAuxSlots = object->auxSlots;
+                Field(Var) *const oldAuxSlots = object->auxSlots;
                 Assert(oldAuxSlots);
                 int i = 0;
                 do
@@ -749,7 +751,7 @@ namespace Js
         {
             return TRUE;
         }
-        
+
         return DeleteProperty(instance, propertyRecord->GetPropertyId(), flags);
     }
 

--- a/lib/Runtime/Types/TypePath.h
+++ b/lib/Runtime/Types/TypePath.h
@@ -12,8 +12,8 @@ namespace Js
         static const int BUCKETS_DWORDS = PowerOf2_BUCKETS / sizeof(DWORD);
         static const byte NIL = 0xff;
 
-        DWORD bucketsData[BUCKETS_DWORDS];  // use DWORDs to enforce alignment
-        byte next[0];
+        Field(DWORD) bucketsData[BUCKETS_DWORDS];  // use DWORDs to enforce alignment
+        Field(byte) next[0];
 
 public:
         TinyDictionary()

--- a/lib/Runtime/Types/TypePropertyCache.cpp
+++ b/lib/Runtime/Types/TypePropertyCache.cpp
@@ -58,7 +58,7 @@ namespace Js
         this->isInlineSlot = isInlineSlot;
         this->isSetPropertyAllowed = isSetPropertyAllowed;
         this->isMissing = false;
-        this->prototypeObjectWithProperty = 0;
+        this->prototypeObjectWithProperty = nullptr;
     }
 
     void TypePropertyCacheElement::Cache(

--- a/lib/Runtime/Types/TypePropertyCache.h
+++ b/lib/Runtime/Types/TypePropertyCache.h
@@ -14,15 +14,15 @@ namespace Js
     class TypePropertyCacheElement
     {
     private:
-        DynamicObject *prototypeObjectWithProperty;
+        Field(DynamicObject *) prototypeObjectWithProperty;
 
         // tag the bit fields to avoid false positive
-        bool tag : 1;
-        bool isInlineSlot : 1;
-        bool isSetPropertyAllowed : 1;
-        bool isMissing : 1;
-        PropertyIndex index;
-        PropertyId id;
+        Field(bool) tag : 1;
+        Field(bool) isInlineSlot : 1;
+        Field(bool) isSetPropertyAllowed : 1;
+        Field(bool) isMissing : 1;
+        Field(PropertyIndex) index;
+        Field(PropertyId) id;
 
     public:
         TypePropertyCacheElement();

--- a/test/runtests.py
+++ b/test/runtests.py
@@ -56,6 +56,8 @@ parser.add_argument('--tag', nargs='*',
                     help='select tests with given tags')
 parser.add_argument('--not-tag', nargs='*',
                     help='exclude tests with given tags')
+parser.add_argument('--flag', nargs='*',
+                    help='global test flags to ch')
 parser.add_argument('--timeout', type=int, default=DEFAULT_TIMEOUT,
                     help='test timeout (default ' + str(DEFAULT_TIMEOUT) + ' seconds)')
 parser.add_argument('-l', '--logfile', metavar='logfile', help='file to log results to', default=None)
@@ -394,7 +396,9 @@ class TestVariant(object):
 
         flags = test.get('compile-flags')
         flags = self._expand_compile_flags(test) + \
+                    args.flag + \
                     (flags.split() if flags else [])
+
         cmd = [binary] + flags + [os.path.basename(js_file)]
 
         test.start()

--- a/tools/RecyclerChecker/RecyclerChecker.h
+++ b/tools/RecyclerChecker/RecyclerChecker.h
@@ -64,7 +64,9 @@ private:
     void dump(const char* name, const set<Item>& set);
     void dump(const char* name, const unordered_set<const Type*> set);
 
-    void ProcessUnbarriedFields(CXXRecordDecl* recordDecl);
+    template <class PushFieldType>
+    void ProcessUnbarriedFields(CXXRecordDecl* recordDecl, const PushFieldType& pushFieldType);
+
     bool MatchType(const string& type, const char* source, const char** pSourceEnd);
     const char* GetFieldTypeAnnotation(QualType qtype);
 };


### PR DESCRIPTION
plugin:
- Track down and annotate field type if an annotated field is of
  struct/class/union (RecordType) or array of such a type. To opt out, use
  FieldNoBarrier.
- Add logs to reason about annotation errors. To see why the plugin
  requires a class to be annotated, run
  `build.sh -n -d --wb-check THE_CPP_FILE --wb-args=-verbose`
  and read the traces at the bottom. It shows if the requirement is from
  a direct write barriered allocation, or a base class or a field type of
  such allocated class.

Fixed all newly discovered missing annotations. Notes:
- DoublyLinkedList/DoubleLinkedListElement now both takes TAllocator
  template parameter, and they must use the same TAllocator type.
- Fixed union with WriteBarrierPtr members with union constructor (c++11
  feature, thanks @leirocks for suggestion).
- FunctionBody.h was forced write barrier but some types should not force.
  Solved by moving "force" to only bottom region. To be refactored later
  after merged with master.
- Fixed bugs discovered from test: DynamicObject inline and aux slots were
  not annotated. Fixed.
- There are global static SimpleTypeHandler instances created from static
  BuildInPropertyIds that are not GC objects at all. They are used before
  WriteBarrierManager initialization. Fixed by using NoBarrierSet.

Fixed qsort_s overload to handle type that contains WriteBarrierPtr (use
a policy type similarly to CopyArray). Also emits compile error if qsort_s
is used on WriteBarrierPtr array.

Enhanced "runtests.py" to be able to pass ch flags. e.g. to disable a
default ch switch: `runtests.py -d --flag=-WriteBarrierTest-`.