### PR TITLE
enable write barrier test on windows

### DIFF
--- a/lib/Backend/JITTimePolymorphicInlineCacheInfo.cpp
+++ b/lib/Backend/JITTimePolymorphicInlineCacheInfo.cpp
@@ -22,7 +22,7 @@ JITTimePolymorphicInlineCacheInfo::InitializeEntryPointPolymorphicInlineCacheInf
         return;
     }
     Js::PolymorphicInlineCacheInfo * selfInfo = runtimeInfo->GetSelfInfo();
-    SListCounted<Js::PolymorphicInlineCacheInfo*, Recycler> * inlineeList = runtimeInfo->GetInlineeInfo();
+    SListCounted<Js::PolymorphicInlineCacheInfo*, RecyclerAllocator> * inlineeList = runtimeInfo->GetInlineeInfo();
     PolymorphicInlineCacheInfoIDL* selfInfoIDL = RecyclerNewStructZ(recycler, PolymorphicInlineCacheInfoIDL);
     PolymorphicInlineCacheInfoIDL* inlineeInfoIDL = nullptr;
 
@@ -31,7 +31,7 @@ JITTimePolymorphicInlineCacheInfo::InitializeEntryPointPolymorphicInlineCacheInf
     if (!inlineeList->Empty())
     {
         inlineeInfoIDL = RecyclerNewArray(recycler, PolymorphicInlineCacheInfoIDL, inlineeList->Count());
-        SListCounted<Js::PolymorphicInlineCacheInfo*, Recycler>::Iterator iter(inlineeList);
+        SListCounted<Js::PolymorphicInlineCacheInfo*, RecyclerAllocator>::Iterator iter(inlineeList);
         uint i = 0;
         while (iter.Next())
         {

--- a/lib/Backend/NativeCodeData.h
+++ b/lib/Backend/NativeCodeData.h
@@ -95,6 +95,10 @@ public:
 
         NativeCodeData * Finalize();
         void Free(void * buffer, size_t byteSize);
+        void FreeLeaf(void * buffer, size_t byteSize)
+        {
+            Free(buffer, byteSize);
+        }
 
         union
         {

--- a/lib/Backend/NativeCodeGenerator.cpp
+++ b/lib/Backend/NativeCodeGenerator.cpp
@@ -3026,7 +3026,7 @@ NativeCodeGenerator::GatherCodeGenData(Js::FunctionBody *const topFunctionBody, 
 #endif
 
         uint objTypeSpecFldInfoCount = objTypeSpecFldInfoList->Count();
-        jitTimeData->SetGlobalObjTypeSpecFldInfoArray(RecyclerNewArray(recycler, Field(Js::ObjTypeSpecFldInfo*), objTypeSpecFldInfoCount), objTypeSpecFldInfoCount);
+        jitTimeData->SetGlobalObjTypeSpecFldInfoArray(RecyclerNewArray(recycler, Js::ObjTypeSpecFldInfo::ObjTypeSpecFldInfoPtr, objTypeSpecFldInfoCount), objTypeSpecFldInfoCount);
         uint propertyInfoId = objTypeSpecFldInfoCount - 1;
         FOREACH_SLISTCOUNTED_ENTRY(Js::ObjTypeSpecFldInfo*, info, objTypeSpecFldInfoList)
         {

--- a/lib/Common/CommonDefines.h
+++ b/lib/Common/CommonDefines.h
@@ -119,52 +119,56 @@
 #endif
 
 // GC features
-
 #define BUCKETIZE_MEDIUM_ALLOCATIONS 1              // *** TODO: Won't build if disabled currently
 #define SMALLBLOCK_MEDIUM_ALLOC 1                   // *** TODO: Won't build if disabled currently
 #define LARGEHEAPBLOCK_ENCODING 1                   // Large heap block metadata encoding
-#define RECYCLER_WRITE_BARRIER                      // Write Barrier support
 #define IDLE_DECOMMIT_ENABLED 1                     // Idle Decommit
 #define RECYCLER_PAGE_HEAP                          // PageHeap support
+#define ENABLE_RECYCLER_TYPE_TRACKING 1
 
+#ifdef _WIN32
+#define SYSINFO_IMAGE_BASE_AVAILABLE 1
+#define ENABLE_CONCURRENT_GC 1
+#define SUPPORT_WIN32_SLIST 1
+#else
+#define SYSINFO_IMAGE_BASE_AVAILABLE 0
+#define ENABLE_CONCURRENT_GC 1
+#define SUPPORT_WIN32_SLIST 0
+#endif
+
+
+#if ENABLE_CONCURRENT_GC
 // Write-barrier refers to a software write barrier implementation using a card table. 
 // Write watch refers to a hardware backed write-watch feature supported by the Windows memory manager. 
 // Both are used for detecting changes to memory for concurrent and partial GC. 
-// GLOBAL_ENABLE_WRITE_BARRIER controls the former, ENABLE_WRITE_WATCH controls the latter.
+// RECYCLER_WRITE_BARRIER controls the former, RECYCLER_WRITE_WATCH controls the latter.
+// GLOBAL_ENABLE_WRITE_BARRIER controls the smart pointer wrapper at compile time, every Field annotation on the
+// recycler allocated class will take effect if GLOBAL_ENABLE_WRITE_BARRIER is 1, otherwise only  the class declared 
+// with FORCE_USE_WRITE_BARRIER will use the WriteBarrierPtr<>, see WriteBarrierMacros.h and RecyclerPointers.h for detail
+#define RECYCLER_WRITE_BARRIER                      // Write Barrier support
+#ifdef _WIN32
+#define RECYCLER_WRITE_WATCH                        // Support hardware write watch
+#endif
+
 #ifdef RECYCLER_WRITE_BARRIER
 #ifdef _WIN32
-#define GLOBAL_ENABLE_WRITE_BARRIER 0
+#define GLOBAL_ENABLE_WRITE_BARRIER 1 // TODO: change to 0 before merge to master
 #else
 #define GLOBAL_ENABLE_WRITE_BARRIER 1
 #endif
 #endif
 
-#ifdef _WIN32
-#define ENABLE_WRITE_WATCH 1
-#else
-#define ENABLE_WRITE_WATCH 0
+#if !GLOBAL_ENABLE_WRITE_BARRIER && !defined(RECYCLER_WRITE_WATCH)
+#error "Concurrent GC need at least GLOBAL_ENABLE_WRITE_BARRIER enable or RECYCLER_WRITE_WATCH enabled."
 #endif
 
-// Concurrent and Partial GC are disabled on non-Windows builds
-// xplat-todo: re-enable this in the future
-// These are disabled because these GC features depend on hardware
-// write-watch support that the Windows Memory Manager provides.
-#ifdef _WIN32
-#define SYSINFO_IMAGE_BASE_AVAILABLE 1
-#define ENABLE_CONCURRENT_GC 1
 #define ENABLE_PARTIAL_GC 1
-#define ENABLE_BACKGROUND_PAGE_ZEROING 1
 #define ENABLE_BACKGROUND_PAGE_FREEING 1
-#define ENABLE_RECYCLER_TYPE_TRACKING 1
-#define SUPPORT_WIN32_SLIST 1
+#define ENABLE_BACKGROUND_PAGE_ZEROING 1
 #else
-#define SYSINFO_IMAGE_BASE_AVAILABLE 0
-#define ENABLE_CONCURRENT_GC 1
-#define ENABLE_PARTIAL_GC 1
-#define ENABLE_BACKGROUND_PAGE_ZEROING 1
-#define ENABLE_BACKGROUND_PAGE_FREEING 1
-#define ENABLE_RECYCLER_TYPE_TRACKING 1
-#define SUPPORT_WIN32_SLIST 0
+#define ENABLE_PARTIAL_GC 0
+#define ENABLE_BACKGROUND_PAGE_ZEROING 0
+#define ENABLE_BACKGROUND_PAGE_FREEING 0
 #endif
 
 #if ENABLE_BACKGROUND_PAGE_ZEROING && !ENABLE_BACKGROUND_PAGE_FREEING

--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -715,16 +715,21 @@ PHASE(All)
 #endif
 
 #define DEFAULT_CONFIG_StrictWriteBarrierCheck  (false)
+#define DEFAULT_CONFIG_KeepRecyclerTrackData  (false)
 
 #ifdef _WIN32
+#ifndef RECYCLER_WRITE_WATCH
+#define DEFAULT_CONFIG_ForceSoftwareWriteBarrier  (true)
+#else
 #define DEFAULT_CONFIG_ForceSoftwareWriteBarrier  (false)
+#endif
 #define DEFAULT_CONFIG_WriteBarrierTest (false)
-#define DEFAULT_CONFIG_EnableBGFreeZero (true)
 #else
 #define DEFAULT_CONFIG_ForceSoftwareWriteBarrier  (true)
 #define DEFAULT_CONFIG_WriteBarrierTest (true) // TODO: SWB change to false after all write barrier annotations are done
-#define DEFAULT_CONFIG_EnableBGFreeZero (true)
 #endif
+
+
 
 #define TraceLevel_Error        (1)
 #define TraceLevel_Warning      (2)
@@ -1491,7 +1496,7 @@ FLAGR(Number, JITServerMaxInactivePageAllocatorCount, "Max inactive page allocat
 FLAGNR(Boolean, StrictWriteBarrierCheck, "Check write barrier setting on none write barrier pages", DEFAULT_CONFIG_StrictWriteBarrierCheck)
 FLAGNR(Boolean, WriteBarrierTest, "Always return true while checking barrier to test recycler regardless of annotation", DEFAULT_CONFIG_WriteBarrierTest)
 FLAGNR(Boolean, ForceSoftwareWriteBarrier, "Use to turn off write watch to test software write barrier on windows", DEFAULT_CONFIG_ForceSoftwareWriteBarrier)
-FLAGNR(Boolean, EnableBGFreeZero, "Use to turn off background freeing and zeroing to simulate linux", DEFAULT_CONFIG_EnableBGFreeZero)
+FLAGNR(Boolean, KeepRecyclerTrackData, "Keep recycler track data after sweep until reuse", DEFAULT_CONFIG_KeepRecyclerTrackData)
 
 #undef FLAG_REGOVR_EXP
 #undef FLAG_REGOVR_ASMJS

--- a/lib/Common/DataStructures/Cache.h
+++ b/lib/Common/DataStructures/Cache.h
@@ -92,7 +92,7 @@ namespace JsUtil
         T entries[size];
     };
 
-    template <class TKey, int MRUSize, class TAllocator = Recycler>
+    template <class TKey, int MRUSize, class TAllocator = RecyclerAllocator>
     class MRURetentionPolicy
     {
     public:
@@ -134,11 +134,10 @@ namespace JsUtil
     {
     private:
         typedef BaseDictionary<TKey, TValue, TAllocator, SizePolicy, Comparer, Entry> TCacheStoreType;
-        typedef typename TCacheStoreType::AllocatorType AllocatorType;
         class CacheStore : public TCacheStoreType
         {
         public:
-            CacheStore(AllocatorType* allocator, int capacity) : TCacheStoreType(allocator, capacity), inAdd(false) {};
+            CacheStore(TAllocator* allocator, int capacity) : TCacheStoreType(allocator, capacity), inAdd(false) {};
             bool IsInAdd()
             {
                 return this->inAdd;
@@ -158,10 +157,10 @@ namespace JsUtil
         typedef TValue ValueType;
         typedef void (*OnItemEvictedCallback)(const TKey& key, TValue value);
 
-        Cache(AllocatorType * allocator, int capacity = 0):
+        Cache(TAllocator * allocator, int capacity = 0):
             cachePolicyType(allocator)
         {
-            this->cacheStore = AllocatorNew(AllocatorType, allocator, CacheStore, allocator, capacity);
+            this->cacheStore = AllocatorNew(TAllocator, allocator, CacheStore, allocator, capacity);
         }
 
         int Add(const TKey& key, const TValue& value)

--- a/lib/Common/DataStructures/MruDictionary.h
+++ b/lib/Common/DataStructures/MruDictionary.h
@@ -15,7 +15,7 @@ namespace JsUtil
     template<
         class TKey,
         class TValue,
-        class TAllocator = Recycler,
+        class TAllocator = RecyclerAllocator,
         class TSizePolicy = PowerOf2SizePolicy,
         template<class ValueOrKey> class TComparer = DefaultComparer,
         template<class K, class V> class TDictionaryEntry = SimpleDictionaryEntry>
@@ -96,15 +96,14 @@ namespace JsUtil
                 TKey,
                 MruDictionaryData,
                 // MruDictionaryData always has pointer to GC pointer (MruEntry)
-                typename ForceNonLeafAllocator<TAllocator>::AllocatorType,
+                TAllocator,
                 TSizePolicy,
                 TComparer,
                 TDictionaryEntry>
             TDictionary;
         TDictionary dictionary;
-        typedef typename TDictionary::AllocatorType AllocatorType;
     public:
-        MruDictionary(AllocatorType *const allocator, const int mruListCapacity)
+        MruDictionary(TAllocator *const allocator, const int mruListCapacity)
             : mruListCapacity(mruListCapacity), mruListCount(0), dictionary(allocator)
         {
             Assert(allocator);

--- a/lib/Common/DataStructures/SList.h
+++ b/lib/Common/DataStructures/SList.h
@@ -160,7 +160,7 @@ public:
             const NodeBase *dead = this->current;
             UnlinkCurrent();
 
-            auto freeFunc = TypeAllocatorFunc<TAllocator, TData>::GetFreeFunc();
+            auto freeFunc = &TAllocator::Free;
 
             AllocatorFree(allocator, freeFunc, (Node *) dead, sizeof(Node));
         }
@@ -285,7 +285,7 @@ public:
         {
             NodeBase * next = current->Next();
 
-            auto freeFunc = TypeAllocatorFunc<TAllocator, TData>::GetFreeFunc();
+            auto freeFunc = &TAllocator::Free;
 
             AllocatorFree(allocator, freeFunc, (Node *)current, sizeof(Node));
             current = next;
@@ -376,7 +376,7 @@ public:
         NodeBase * node = this->Next();
         this->Next() = node->Next();
 
-        auto freeFunc = TypeAllocatorFunc<TAllocator, TData>::GetFreeFunc();
+        auto freeFunc = &TAllocator::Free;
         AllocatorFree(allocator, freeFunc, (Node *) node, sizeof(Node));
         this->DecrementCount();
     }

--- a/lib/Common/DataStructures/SparseBitVector.h
+++ b/lib/Common/DataStructures/SparseBitVector.h
@@ -306,9 +306,8 @@ inline void Dump(BVSparse<JitArenaAllocator> * const& bv)
     bv->Dump();
 }
 
-namespace Memory { class Recycler; }
 template<>
-inline void Dump(BVSparse<Recycler> * const& bv)
+inline void Dump(BVSparse<RecyclerAllocator> * const& bv)
 {
     bv->Dump();
 }

--- a/lib/Common/DataStructures/WeakReferenceDictionary.h
+++ b/lib/Common/DataStructures/WeakReferenceDictionary.h
@@ -17,15 +17,15 @@ namespace JsUtil
         class SizePolicy = PowerOf2SizePolicy,
         template <typename ValueOrKey> class Comparer = DefaultComparer
     >
-    class WeakReferenceDictionary: public BaseDictionary<TKey, RecyclerWeakReference<TValue>*, RecyclerNonLeafAllocator, SizePolicy, Comparer, WeakRefValueDictionaryEntry>,
+    class WeakReferenceDictionary: public BaseDictionary<TKey, RecyclerWeakReference<TValue>*, RecyclerAllocator, SizePolicy, Comparer, WeakRefValueDictionaryEntry>,
                                    public IWeakReferenceDictionary
     {
-        typedef BaseDictionary<TKey, RecyclerWeakReference<TValue>*, RecyclerNonLeafAllocator, SizePolicy, Comparer, WeakRefValueDictionaryEntry> Base;
+        typedef BaseDictionary<TKey, RecyclerWeakReference<TValue>*, RecyclerAllocator, SizePolicy, Comparer, WeakRefValueDictionaryEntry> Base;
         typedef typename Base::EntryType EntryType;
 
     public:
         WeakReferenceDictionary(Recycler* recycler, int capacity = 0):
-          Base(recycler, capacity)
+          Base(recycler->GetAllocator(), capacity)
         {
             Assert(reinterpret_cast<void*>(this) == reinterpret_cast<void*>((IWeakReferenceDictionary*) this));
         }

--- a/lib/Common/Memory/ArenaAllocator.h
+++ b/lib/Common/Memory/ArenaAllocator.h
@@ -231,6 +231,10 @@ public:
 
     char* Realloc(void* buffer, DECLSPEC_GUARD_OVERFLOW size_t existingBytes, DECLSPEC_GUARD_OVERFLOW size_t requestedBytes);
     void Free(void * buffer, size_t byteSize);
+    void FreeLeaf(void * buffer, size_t byteSize)
+    {
+        Free(buffer, byteSize);
+    }
 #if DBG
     bool HasDelayFreeList() const
     {

--- a/lib/Common/Memory/AutoAllocatorObjectPtr.h
+++ b/lib/Common/Memory/AutoAllocatorObjectPtr.h
@@ -11,11 +11,10 @@ template <typename T, typename TAllocator>
 class AutoAllocatorObjectPtr : public BasePtr<T>
 {
 private:
-    typedef typename AllocatorInfo<TAllocator, T>::AllocatorType AllocatorType;
-    AllocatorType* m_allocator;
+    TAllocator* m_allocator;
 
 public:
-    AutoAllocatorObjectPtr(T* ptr, AllocatorType* allocator) : BasePtr<T>(ptr), m_allocator(allocator)
+    AutoAllocatorObjectPtr(T* ptr, TAllocator* allocator) : BasePtr<T>(ptr), m_allocator(allocator)
     {
         Assert(allocator);
     }
@@ -41,12 +40,11 @@ template <typename T, typename TAllocator>
 class AutoAllocatorArrayPtr : public BasePtr<T>
 {
 protected:
-    typedef typename AllocatorInfo<TAllocator, T>::AllocatorType AllocatorType;
     size_t m_elementCount;
-    AllocatorType* m_allocator;
+    TAllocator* m_allocator;
 
 public:
-    AutoAllocatorArrayPtr(T * ptr, size_t elementCount, AllocatorType* allocator) : BasePtr(ptr), m_elementCount(elementCount), m_allocator(allocator)
+    AutoAllocatorArrayPtr(T * ptr, size_t elementCount, TAllocator* allocator) : BasePtr(ptr), m_elementCount(elementCount), m_allocator(allocator)
     {
         Assert(allocator);
     }
@@ -77,13 +75,13 @@ private:
 //      TAllocator      The allocator type used to allocate/free the objects.
 //      ArrayAllocator  The allocator type used to allocate/free the array.
 //
-template <typename T, typename TAllocator, typename ArrayAllocator = typename ForceNonLeafAllocator<TAllocator>::AllocatorType>
+template <typename T, typename TAllocator, typename ArrayAllocator = RecyclerAllocator>
 class AutoAllocatorObjectArrayPtr : public AutoAllocatorArrayPtr<T*, ArrayAllocator>
 {
     typedef AutoAllocatorArrayPtr<T*, ArrayAllocator> Base;
     
 public:
-    AutoAllocatorObjectArrayPtr(T** ptr, size_t elementCount, typename Base::AllocatorType* allocator) :
+    AutoAllocatorObjectArrayPtr(T** ptr, size_t elementCount, typename Base::TAllocator* allocator) :
         AutoAllocatorArrayPtr(ptr, elementCount, allocator)
     {
     }

--- a/lib/Common/Memory/HeapAllocator.h
+++ b/lib/Common/Memory/HeapAllocator.h
@@ -126,6 +126,10 @@ struct HeapAllocator
         return buffer;
     }
     void Free(void * buffer, size_t byteSize);
+    void FreeLeaf(void * buffer, size_t byteSize)
+    {
+        Free(buffer, byteSize);
+    }
 
     static HeapAllocator Instance;
     static HeapAllocator * GetNoMemProtectInstance();
@@ -260,10 +264,18 @@ public:
         }
         return buffer;
     }
+    char * AllocLeaf(DECLSPEC_GUARD_OVERFLOW size_t byteSize)
+    {
+        return Alloc(byteSize);
+    }
     void Free(void * buffer, size_t byteSize)
     {
         Assert(processHeap != NULL);
         HeapFree(processHeap, 0, buffer);
+    }
+    void FreeLeaf(void * buffer, size_t byteSize)
+    {
+        Free(buffer, byteSize);
     }
 
 #ifdef TRACK_ALLOC

--- a/lib/Common/Memory/HeapBlock.cpp
+++ b/lib/Common/Memory/HeapBlock.cpp
@@ -173,7 +173,7 @@ SmallHeapBlockT<MediumAllocationBlockAttributes>::ProtectUnusablePages()
         DWORD oldProtect;
         BOOL ret = ::VirtualProtect(startPage, count * AutoSystemInfo::PageSize, PAGE_READONLY, &oldProtect);
         Assert(ret && oldProtect == PAGE_READWRITE);
-#if ENABLE_WRITE_WATCH
+#ifdef RECYCLER_WRITE_WATCH
         if (!CONFIG_FLAG(ForceSoftwareWriteBarrier))
         {
             ::ResetWriteWatch(startPage, count*AutoSystemInfo::PageSize);

--- a/lib/Common/Memory/HeapBlockMap.cpp
+++ b/lib/Common/Memory/HeapBlockMap.cpp
@@ -607,15 +607,14 @@ HeapBlockMap32::ForEachSegment(Recycler * recycler, Fn func)
 void
 HeapBlockMap32::ResetDirtyPages(Recycler * recycler)
 {
-    this->ForEachSegment(recycler, [=] (char * segmentStart, size_t segmentLength, Segment * segment, PageAllocator * segmentPageAllocator) {
+    this->ForEachSegment(recycler, [=](char * segmentStart, size_t segmentLength, Segment * segment, PageAllocator * segmentPageAllocator) {
 
         Assert(segmentLength % AutoSystemInfo::PageSize == 0);
 
-#if ENABLE_WRITE_WATCH
+#ifdef RECYCLER_WRITE_WATCH
         if (!CONFIG_FLAG(ForceSoftwareWriteBarrier))
         {
-            if (segmentPageAllocator == recycler->GetRecyclerPageAllocator() ||
-                segmentPageAllocator == recycler->GetRecyclerLargeBlockPageAllocator())
+            if (segmentPageAllocator->IsWriteWatchEnabled())
             {
                 // Call ResetWriteWatch for Small non-leaf and Large segments.
                 UINT ret = ::ResetWriteWatch(segmentStart, segmentLength);
@@ -623,9 +622,11 @@ HeapBlockMap32::ResetDirtyPages(Recycler * recycler)
             }
         }
 #endif
+
 #ifdef RECYCLER_WRITE_BARRIER
-        if (segmentPageAllocator == recycler->GetRecyclerWithBarrierPageAllocator() ||
-            segmentPageAllocator == recycler->GetRecyclerLargeBlockPageAllocator()) // TODO: use different page allocator?
+#if defined(_M_X64_OR_ARM64)
+        if (segment->IsWriteBarrierEnabled())
+#endif
         {
             // Reset software write barrier for barrier segments.
             RecyclerWriteBarrierManager::ResetWriteBarrier(segmentStart, segmentLength / AutoSystemInfo::PageSize);
@@ -771,7 +772,7 @@ HeapBlockMap32::ChangeProtectionLevel(Recycler* recycler, DWORD protectFlags, DW
 }
 
 #if ENABLE_CONCURRENT_GC
-#if ENABLE_WRITE_WATCH
+#ifdef RECYCLER_WRITE_WATCH
 ///
 /// The GetWriteWatch API can fail under low-mem situations if called to retrieve write-watch for a large number of pages
 /// (On Win10, > 255 pages). This helper is to handle the failure case. In the case of failure, we degrade to retrieving
@@ -858,24 +859,23 @@ HeapBlockMap32::Rescan(Recycler * recycler, bool resetWriteWatch)
     uint scannedPageCount = 0;
     bool anyObjectsScannedOnPage = false;
 
-    this->ForEachSegment(recycler, [&] (char * segmentStart, size_t segmentLength, Segment * currentSegment, PageAllocator * segmentPageAllocator) {
+    this->ForEachSegment(recycler, [&](char * segmentStart, size_t segmentLength, Segment * currentSegment, PageAllocator * segmentPageAllocator)
+    {
         Assert(segmentLength % AutoSystemInfo::PageSize == 0);
+        DebugOnly(recycler->CheckPageAllocator(segmentPageAllocator));
 
-#if ENABLE_WRITE_WATCH
+#ifdef RECYCLER_WRITE_WATCH
         if (!CONFIG_FLAG(ForceSoftwareWriteBarrier))
         {
             // Call GetWriteWatch for Small non-leaf segments.
             // Large blocks have their own separate write watch handling.
             if (segmentPageAllocator == recycler->GetRecyclerPageAllocator())
             {
-                // array for WW results
-                void * dirtyPageAddresses[MaxGetWriteWatchPages];
-
                 Assert(segmentLength <= MaxGetWriteWatchPages * PageSize);
 
+                void * dirtyPageAddresses[MaxGetWriteWatchPages];
                 ULONG_PTR pageCount = MaxGetWriteWatchPages;
                 DWORD pageSize = PageSize;
-
                 const DWORD writeWatchFlags = (resetWriteWatch ? WRITE_WATCH_FLAG_RESET : 0);
 
                 UINT ret = HeapBlockMap32::GetWriteWatchHelper(recycler, writeWatchFlags, segmentStart, segmentLength, dirtyPageAddresses, &pageCount, &pageSize);
@@ -939,7 +939,7 @@ HeapBlockMap32::Rescan(Recycler * recycler, bool resetWriteWatch)
         }
 #endif
         Assert(segmentPageAllocator == recycler->GetRecyclerLeafPageAllocator() ||
-                segmentPageAllocator == recycler->GetRecyclerLargeBlockPageAllocator());
+            segmentPageAllocator == recycler->GetRecyclerLargeBlockPageAllocator());
     });
 
     return scannedPageCount;

--- a/lib/Common/Memory/HeapBlockMap.h
+++ b/lib/Common/Memory/HeapBlockMap.h
@@ -113,7 +113,7 @@ public:
 
 private:
 #if ENABLE_CONCURRENT_GC
-#if ENABLE_WRITE_WATCH
+#ifdef RECYCLER_WRITE_WATCH
     static UINT GetWriteWatchHelper(Recycler * recycler, DWORD writeWatchFlags, void* baseAddress, size_t regionSize,
         void** addresses, ULONG_PTR* count, LPDWORD granularity);
     static UINT GetWriteWatchHelperOnOOM(DWORD writeWatchFlags, _In_ void* baseAddress, size_t regionSize,

--- a/lib/Common/Memory/HeapBucket.inl
+++ b/lib/Common/Memory/HeapBucket.inl
@@ -6,7 +6,6 @@
 
 template <typename TBlockType>
 template <ObjectInfoBits attributes, bool nothrow>
-
 inline char *
 HeapBucketT<TBlockType>::RealAlloc(Recycler * recycler, size_t sizeCat, size_t size)
 {

--- a/lib/Common/Memory/LargeHeapBlock.cpp
+++ b/lib/Common/Memory/LargeHeapBlock.cpp
@@ -989,7 +989,7 @@ bool LargeHeapBlock::IsPageDirty(char* page, RescanFlags flags, bool isWriteBarr
     }
 #endif
 
-#if ENABLE_WRITE_WATCH
+#ifdef RECYCLER_WRITE_WATCH
     if (!CONFIG_FLAG(ForceSoftwareWriteBarrier))
     {
         ULONG_PTR count = 1;

--- a/lib/Common/Memory/PagePool.h
+++ b/lib/Common/Memory/PagePool.h
@@ -64,7 +64,7 @@ public:
     PagePool(Js::ConfigFlagsTable& flagsTable) :
         pageAllocator(NULL, flagsTable, PageAllocatorType_GCThread,
             PageAllocator::DefaultMaxFreePageCount, false,
-#if ENABLE_BACKGROUND_PAGE_ZEROING
+#if ENABLE_BACKGROUND_PAGE_FREEING
             nullptr,
 #endif
             PageAllocator::DefaultMaxAllocPageCount, 0, true),

--- a/lib/Common/Memory/Recycler.cpp
+++ b/lib/Common/Memory/Recycler.cpp
@@ -114,7 +114,7 @@ DefaultRecyclerCollectionWrapper::DisposeObjects(Recycler * recycler)
 
 static void* GetStackBase();
 
-template _ALWAYSINLINE char * Recycler::AllocWithAttributesInlined<NoBit, false>(size_t size);
+template _ALWAYSINLINE char * Recycler::AllocWithAttributes<NoBit, false>(size_t size);
 template _ALWAYSINLINE char* Recycler::RealAlloc<NoBit, false>(HeapInfo* heap, size_t size);
 template _ALWAYSINLINE _Ret_notnull_ void * __cdecl operator new<Recycler>(size_t byteSize, Recycler * alloc, char * (Recycler::*AllocFunc)(size_t));
 
@@ -8502,7 +8502,7 @@ RecyclerHeapObjectInfo::GetSize() const
 }
 
 // the following instantiation is require for clang while compiling Js::InternalString::New
-template char* Recycler::AllocWithAttributesInlined<(Memory::ObjectInfoBits)32, false>(size_t);
+template char* Recycler::AllocWithAttributes<(Memory::ObjectInfoBits)32, false>(size_t);
 
 // Allocators
 char * RecyclerAllocatorWithBarrier::Alloc(DECLSPEC_GUARD_OVERFLOW size_t byteSize)

--- a/lib/Common/Memory/Recycler.cpp
+++ b/lib/Common/Memory/Recycler.cpp
@@ -252,6 +252,9 @@ Recycler::Recycler(AllocationPolicyManager * policyManager, IdleDecommitPageAllo
 #endif
     , objectBeforeCollectCallbackMap(nullptr)
     , objectBeforeCollectCallbackState(ObjectBeforeCollectCallback_None)
+    , allocator(this)    
+    , allocatorWithBarrier(this)
+    , leafAllocator(this)
 {
 #ifdef RECYCLER_MARK_TRACK
     this->markMap = NoCheckHeapNew(MarkMap, &NoCheckHeapAllocator::Instance, 163, &markMapCriticalSection);
@@ -266,14 +269,20 @@ Recycler::Recycler(AllocationPolicyManager * policyManager, IdleDecommitPageAllo
     verifyEnabled =  GetRecyclerFlagsTable().IsEnabled(Js::RecyclerVerifyFlag);
     if (verifyEnabled)
     {
-        ForRecyclerPageAllocator(EnableVerify());
+        ForEachPageAllocator([](IdleDecommitPageAllocator* pageAlloc)
+        {
+            pageAlloc->EnableVerify();
+        });
     }
 #endif
 
 #ifdef RECYCLER_NO_PAGE_REUSE
     if (GetRecyclerFlagsTable().IsEnabled(Js::RecyclerNoPageReuseFlag))
     {
-        ForRecyclerPageAllocator(DisablePageReuse());
+        ForEachPageAllocator([](IdleDecommitPageAllocator* pageAlloc)
+        {
+            pageAlloc->DisablePageReuse();
+        });
     }
 #endif
 
@@ -433,7 +442,10 @@ void
 Recycler::ResetThreadId()
 {
     // Transfer all the page allocator to the current thread id
-    ForRecyclerPageAllocator(ClearConcurrentThreadId());
+    ForEachPageAllocator([](IdleDecommitPageAllocator* pageAlloc)
+    {
+        pageAlloc->ClearConcurrentThreadId();
+    });
 #if ENABLE_CONCURRENT_GC
     if (this->IsConcurrentEnabled())
     {
@@ -558,7 +570,10 @@ Recycler::~Recycler()
 
 #if DBG
     // Disable idle decommit asserts
-    ForRecyclerPageAllocator(ShutdownIdleDecommit());
+    ForEachPageAllocator([](IdleDecommitPageAllocator* pageAlloc)
+    {
+        pageAlloc->ShutdownIdleDecommit();
+    });
 #endif
     Assert(this->collectionState == CollectionStateExit || this->collectionState == CollectionStateNotCollecting);
 #if ENABLE_CONCURRENT_GC
@@ -765,7 +780,7 @@ Recycler::Initialize(const bool forceInThread, JsUtil::ThreadService *threadServ
             , captureAllocCallStack
             , captureFreeCallStack
 #endif
-            );
+        );
     }
     else
     {
@@ -775,7 +790,7 @@ Recycler::Initialize(const bool forceInThread, JsUtil::ThreadService *threadServ
             , captureAllocCallStack
             , captureFreeCallStack
 #endif
-            );
+        );
     }
 #else
     autoHeap.Initialize(this
@@ -784,7 +799,7 @@ Recycler::Initialize(const bool forceInThread, JsUtil::ThreadService *threadServ
         , captureAllocCallStack
         , captureFreeCallStack
 #endif
-        );
+    );
 #endif
 
     markContext.Init(Recycler::PrimaryMarkStackReservedPageCount);
@@ -823,7 +838,7 @@ Recycler::Initialize(const bool forceInThread, JsUtil::ThreadService *threadServ
 #endif
 #endif
 
-#if ENABLE_WRITE_WATCH
+#ifdef RECYCLER_WRITE_WATCH
     bool needWriteWatch = false;
 #endif
 
@@ -844,8 +859,8 @@ Recycler::Initialize(const bool forceInThread, JsUtil::ThreadService *threadServ
         this->disableConcurrent = true;
     }
     else if (CUSTOM_PHASE_OFF1(GetRecyclerFlagsTable(), Js::ConcurrentMarkPhase) &&
-             CUSTOM_PHASE_OFF1(GetRecyclerFlagsTable(), Js::ParallelMarkPhase) &&
-             CUSTOM_PHASE_OFF1(GetRecyclerFlagsTable(), Js::ConcurrentSweepPhase))
+        CUSTOM_PHASE_OFF1(GetRecyclerFlagsTable(), Js::ParallelMarkPhase) &&
+        CUSTOM_PHASE_OFF1(GetRecyclerFlagsTable(), Js::ConcurrentSweepPhase))
     {
         // All concurrent collection phases disabled
         this->disableConcurrent = true;
@@ -857,11 +872,8 @@ Recycler::Initialize(const bool forceInThread, JsUtil::ThreadService *threadServ
 
         if (deferThreadStartup || EnableConcurrent(threadService, false))
         {
-#if ENABLE_WRITE_WATCH
-            if (!CONFIG_FLAG(ForceSoftwareWriteBarrier))
-            {
-                needWriteWatch = true;
-            }
+#ifdef RECYCLER_WRITE_WATCH
+            needWriteWatch = true;
 #endif
         }
     }
@@ -870,17 +882,14 @@ Recycler::Initialize(const bool forceInThread, JsUtil::ThreadService *threadServ
 #if ENABLE_PARTIAL_GC
     if (this->enablePartialCollect)
     {
-#if ENABLE_WRITE_WATCH
-        if (!CONFIG_FLAG(ForceSoftwareWriteBarrier))
-        {
-            needWriteWatch = true;
-        }
+#ifdef RECYCLER_WRITE_WATCH
+        needWriteWatch = true;
 #endif
     }
 #endif
 
 #if ENABLE_CONCURRENT_GC
-#if ENABLE_WRITE_WATCH
+#ifdef RECYCLER_WRITE_WATCH
     if (!CONFIG_FLAG(ForceSoftwareWriteBarrier))
     {
         if (needWriteWatch)
@@ -892,9 +901,144 @@ Recycler::Initialize(const bool forceInThread, JsUtil::ThreadService *threadServ
     }
 #endif
 #else
+#ifdef RECYCLER_WRITE_WATCH
     Assert(!needWriteWatch);
 #endif
+#endif
 }
+
+BOOL
+Recycler::CollectionInProgress() const
+{
+    return collectionState != CollectionStateNotCollecting;
+}
+
+BOOL
+Recycler::IsExiting() const
+{
+    return (collectionState == Collection_Exit);
+}
+
+BOOL
+Recycler::IsSweeping() const
+{
+    return ((collectionState & Collection_Sweep) == Collection_Sweep);
+}
+
+void
+Recycler::SetIsScriptActive(bool isScriptActive)
+{
+    Assert(this->isInScript);
+    Assert(this->isScriptActive != isScriptActive);
+    this->isScriptActive = isScriptActive;
+    if (isScriptActive)
+    {
+        this->tickCountNextDispose = ::GetTickCount() + RecyclerHeuristic::TickCountFinishCollection;
+    }
+}
+void
+Recycler::SetIsInScript(bool isInScript)
+{
+    Assert(this->isInScript != isInScript);
+    this->isInScript = isInScript;
+}
+
+bool
+Recycler::NeedOOMRescan() const
+{
+    return this->needOOMRescan;
+}
+
+void
+Recycler::SetNeedOOMRescan()
+{
+    this->needOOMRescan = true;
+}
+
+void
+Recycler::ClearNeedOOMRescan()
+{
+    this->needOOMRescan = false;
+    markContext.GetPageAllocator()->ResetDisableAllocationOutOfMemory();
+    parallelMarkContext1.GetPageAllocator()->ResetDisableAllocationOutOfMemory();
+    parallelMarkContext2.GetPageAllocator()->ResetDisableAllocationOutOfMemory();
+    parallelMarkContext3.GetPageAllocator()->ResetDisableAllocationOutOfMemory();
+}
+
+bool
+Recycler::IsMemProtectMode()
+{
+    return this->enableScanImplicitRoots;
+}
+
+size_t
+Recycler::GetUsedBytes()
+{
+    size_t usedBytes = threadPageAllocator->usedBytes;
+#ifdef RECYCLER_WRITE_BARRIER_ALLOC_SEPARATE_PAGE
+    usedBytes += recyclerWithBarrierPageAllocator.usedBytes;
+#endif
+    usedBytes += recyclerPageAllocator.usedBytes;
+    usedBytes += recyclerLargeBlockPageAllocator.usedBytes;
+    return usedBytes;
+}
+
+IdleDecommitPageAllocator*
+Recycler::GetRecyclerPageAllocator()
+{
+    // TODO: SWB this is for Finalizable leaf allocation, which we didn't implement leaf bucket for it
+    // remove this after the finalizable leaf bucket is implemented
+#if GLOBAL_ENABLE_WRITE_BARRIER
+    if (CONFIG_FLAG(ForceSoftwareWriteBarrier))
+    {
+        return &this->recyclerWithBarrierPageAllocator;
+    }
+    else
+#endif
+    {
+#if ENABLE_CONCURRENT_GC
+#ifdef RECYCLER_WRITE_WATCH
+        return &this->recyclerPageAllocator;
+#else
+        return &this->recyclerWithBarrierPageAllocator;
+#endif
+#else
+        return &this->recyclerPageAllocator;
+#endif
+    }
+}
+
+IdleDecommitPageAllocator*
+Recycler::GetRecyclerLargeBlockPageAllocator()
+{
+    return &this->recyclerLargeBlockPageAllocator;
+}
+
+IdleDecommitPageAllocator*
+Recycler::GetRecyclerLeafPageAllocator()
+{
+    return this->threadPageAllocator;
+}
+
+#ifdef RECYCLER_WRITE_BARRIER_ALLOC_SEPARATE_PAGE
+IdleDecommitPageAllocator*
+Recycler::GetRecyclerWithBarrierPageAllocator()
+{
+    return &this->recyclerWithBarrierPageAllocator;
+}
+#endif
+
+#if DBG
+void 
+Recycler::CheckPageAllocator(PageAllocator* pageAlloc)
+{
+    if (CONFIG_FLAG(ForceSoftwareWriteBarrier))
+    {
+        Assert(pageAlloc != &this->recyclerPageAllocator);
+    }
+}
+#endif
+
 
 #if DBG
 BOOL
@@ -931,7 +1075,10 @@ Recycler::Prime()
         return;
     }
 #endif
-    ForRecyclerPageAllocator(Prime(RecyclerPageAllocator::DefaultPrimePageCount));
+    ForEachPageAllocator([](IdleDecommitPageAllocator* pageAlloc)
+    {
+        pageAlloc->Prime(RecyclerPageAllocator::DefaultPrimePageCount);
+    });
 }
 
 void
@@ -968,7 +1115,10 @@ void Recycler::ReportExternalMemoryFree(size_t size)
 void
 Recycler::EnterIdleDecommit()
 {
-    ForRecyclerPageAllocator(EnterIdleDecommit());
+    ForEachPageAllocator([](IdleDecommitPageAllocator* pageAlloc)
+    {
+        pageAlloc->EnterIdleDecommit();
+    });
 #ifdef IDLE_DECOMMIT_ENABLED
     ::InterlockedCompareExchange(&needIdleDecommitSignal, IdleDecommitSignal_None, IdleDecommitSignal_NeedTimer);
 #endif
@@ -1007,8 +1157,12 @@ Recycler::LeaveIdleDecommit()
             SetEvent(this->concurrentIdleDecommitEvent);
         }
     }
+
 #else
-    ForEachRecyclerPageAllocatorIn(this, LeaveIdleDecommit(false));
+    ForEachPageAllocator([](IdleDecommitPageAllocator* pageAlloc)
+    {
+        pageAlloc->LeaveIdleDecommit(false);
+    });
 #endif
 }
 
@@ -2252,7 +2406,7 @@ Recycler::RescanMark(DWORD waitTime)
             }
             Assert(collectionState == CollectionStateRescanWait);
             collectionState = CollectionStateRescanFindRoots;
-#if ENABLE_WRITE_WATCH
+#ifdef RECYCLER_WRITE_WATCH
             if (!CONFIG_FLAG(ForceSoftwareWriteBarrier))
             {
                 Assert(recyclerPageAllocator.GetWriteWatchPageCount() == 0);
@@ -2295,7 +2449,7 @@ Recycler::FinishMark(DWORD waitTime)
             RecyclerVerboseTrace(GetRecyclerFlagsTable(), _u("Processing regular tracked objects\n"));
 
             ProcessTrackedObjects();
-#if ENABLE_WRITE_WATCH
+#ifdef RECYCLER_WRITE_WATCH
             if (!CONFIG_FLAG(ForceSoftwareWriteBarrier))
             {
                 Assert(this->backgroundFinishMarkCount == 0 ||
@@ -2631,7 +2785,10 @@ Recycler::EndMarkOnLowMemory()
     RecyclerVerboseTrace(GetRecyclerFlagsTable(), _u("OOM during mark- rerunning mark\n"));
 
     // Try to release as much memory as possible
-    ForRecyclerPageAllocator(DecommitNow());
+    ForEachPageAllocator([](IdleDecommitPageAllocator* pageAlloc)
+    {
+        pageAlloc->DecommitNow();
+    });
 
 #ifdef ENABLE_DEBUG_CONFIG_OPTIONS
     uint iterations = 0;
@@ -2845,7 +3002,7 @@ Recycler::Sweep(bool concurrent)
 #if ENABLE_PARTIAL_GC
             if (this->inPartialCollectMode)
             {
-#if ENABLE_WRITE_WATCH
+#ifdef RECYCLER_WRITE_WATCH
                 if (!CONFIG_FLAG(ForceSoftwareWriteBarrier))
                 {
                     RECYCLER_PROFILE_EXEC_BEGIN(this, Js::ResetWriteWatchPhase);
@@ -2962,15 +3119,12 @@ Recycler::SweepHeap(bool concurrent, RecyclerSweep& recyclerSweep)
         collectionState = CollectionStateSetupConcurrentSweep;
 
 #if ENABLE_BACKGROUND_PAGE_ZEROING
-        if (CONFIG_FLAG(EnableBGFreeZero))
-        {
-            // Only queue up non-leaf pages- leaf pages don't need to be zeroed out
-            recyclerPageAllocator.StartQueueZeroPage();
-            recyclerLargeBlockPageAllocator.StartQueueZeroPage();
+        // Only queue up non-leaf pages- leaf pages don't need to be zeroed out
+        recyclerPageAllocator.StartQueueZeroPage();
+        recyclerLargeBlockPageAllocator.StartQueueZeroPage();
 #ifdef RECYCLER_WRITE_BARRIER_ALLOC_SEPARATE_PAGE
-            recyclerWithBarrierPageAllocator.StartQueueZeroPage();
+        recyclerWithBarrierPageAllocator.StartQueueZeroPage();
 #endif
-        }
 #endif 
     }
     else
@@ -3008,14 +3162,11 @@ Recycler::SweepHeap(bool concurrent, RecyclerSweep& recyclerSweep)
     if (concurrent)
     {
 #if ENABLE_BACKGROUND_PAGE_ZEROING
-        if (CONFIG_FLAG(EnableBGFreeZero))
-        {
-            recyclerPageAllocator.StopQueueZeroPage();
-            recyclerLargeBlockPageAllocator.StopQueueZeroPage();
+        recyclerPageAllocator.StopQueueZeroPage();
+        recyclerLargeBlockPageAllocator.StopQueueZeroPage();
 #ifdef RECYCLER_WRITE_BARRIER_ALLOC_SEPARATE_PAGE
-            recyclerWithBarrierPageAllocator.StopQueueZeroPage();
+        recyclerWithBarrierPageAllocator.StopQueueZeroPage();
 #endif
-        }
 #endif
 
         GCETW(GC_SETUPBACKGROUNDSWEEP_STOP, (this));
@@ -3023,14 +3174,11 @@ Recycler::SweepHeap(bool concurrent, RecyclerSweep& recyclerSweep)
     else
     {
 #if ENABLE_BACKGROUND_PAGE_ZEROING
-        if (CONFIG_FLAG(EnableBGFreeZero))
-        {
-            Assert(!recyclerPageAllocator.HasZeroQueuedPages());
-            Assert(!recyclerLargeBlockPageAllocator.HasZeroQueuedPages());
+        Assert(!recyclerPageAllocator.HasZeroQueuedPages());
+        Assert(!recyclerLargeBlockPageAllocator.HasZeroQueuedPages());
 #ifdef RECYCLER_WRITE_BARRIER_ALLOC_SEPARATE_PAGE
-            Assert(!recyclerWithBarrierPageAllocator.HasZeroQueuedPages());
+        Assert(!recyclerWithBarrierPageAllocator.HasZeroQueuedPages());
 #endif
-        }
 #endif
 
         uint sweptBytes = 0;
@@ -3823,7 +3971,10 @@ Recycler::EndCollection()
             Output::Print(_u("%04X> RC(%p): %s\n"), this->mainThreadId, this, _u("Decommit now"));
         }
 #endif
-        ForRecyclerPageAllocator(DecommitNow());
+        ForEachPageAllocator([](IdleDecommitPageAllocator* pageAlloc)
+        {
+            pageAlloc->DecommitNow();
+        });
         this->inDecommitNowCollection = false;
     }
 
@@ -4257,20 +4408,18 @@ Recycler::FinishConcurrent()
         if (forceFinish || !IsConcurrentExecutingState())
         {
 #if ENABLE_BACKGROUND_PAGE_FREEING
-            if (CONFIG_FLAG(EnableBGFreeZero))
+            if (this->collectionState == CollectionStateConcurrentSweep)
             {
-                if (this->collectionState == CollectionStateConcurrentSweep)
-                {
-                    // Help with the background thread to zero and flush zero pages
-                    // if we are going to wait anyways.
-                    recyclerPageAllocator.ZeroQueuedPages();
-                    recyclerLargeBlockPageAllocator.ZeroQueuedPages();
+#if ENABLE_BACKGROUND_PAGE_ZEROING
+                // Help with the background thread to zero and flush zero pages
+                // if we are going to wait anyways.
+                recyclerPageAllocator.ZeroQueuedPages();
+                recyclerLargeBlockPageAllocator.ZeroQueuedPages();
 #ifdef RECYCLER_WRITE_BARRIER_ALLOC_SEPARATE_PAGE
-                    recyclerWithBarrierPageAllocator.ZeroQueuedPages();
+                recyclerWithBarrierPageAllocator.ZeroQueuedPages();
 #endif
-
-                    this->FlushBackgroundPages();
-                }
+#endif
+                this->FlushBackgroundPages();
             }
 #endif
 #ifdef RECYCLER_TRACE
@@ -4869,7 +5018,7 @@ Recycler::StartBackgroundMark(bool foregroundResetMark, bool foregroundFindRoots
     if (foregroundResetMark || foregroundFindRoots)
     {
         // REVIEW: SWB, if there's only write barrier page change, we don't scan and mark?
-#if ENABLE_WRITE_WATCH
+#ifdef RECYCLER_WRITE_WATCH
         if (!CONFIG_FLAG(ForceSoftwareWriteBarrier))
         {
             RECYCLER_PROFILE_EXEC_BEGIN(this, Js::ResetWriteWatchPhase);
@@ -5369,7 +5518,7 @@ Recycler::FinishConcurrentCollect(CollectionFlags flags)
 #endif
 #if ENABLE_PARTIAL_GC
     RECYCLER_PROFILE_EXEC_BEGIN2(this, Js::RecyclerPhase,
-        (concurrentPhase = ((this->inPartialCollectMode && this->IsConcurrentMarkState())?
+        (concurrentPhase = ((this->inPartialCollectMode && this->IsConcurrentMarkState()) ?
             Js::ConcurrentPartialCollectPhase : Js::ConcurrentCollectPhase)));
 #else
     RECYCLER_PROFILE_EXEC_BEGIN2(this, Js::RecyclerPhase,
@@ -5384,7 +5533,7 @@ Recycler::FinishConcurrentCollect(CollectionFlags flags)
     collectionParam.priorityBoostConcurrentSweepOverride = priorityBoost;
 #endif
 
-    const DWORD waitTime = forceInThread? INFINITE : RecyclerHeuristic::FinishConcurrentCollectWaitTime(this->GetRecyclerFlagsTable());
+    const DWORD waitTime = forceInThread ? INFINITE : RecyclerHeuristic::FinishConcurrentCollectWaitTime(this->GetRecyclerFlagsTable());
     GCETW(GC_FINISHCONCURRENTWAIT_START, (this, waitTime));
     const BOOL waited = WaitForConcurrentThread(waitTime);
     GCETW(GC_FINISHCONCURRENTWAIT_STOP, (this, !waited));
@@ -5467,13 +5616,12 @@ Recycler::FinishConcurrentCollect(CollectionFlags flags)
         collectionState = CollectionStateTransferSwept;
 
 #if ENABLE_BACKGROUND_PAGE_FREEING
-        if (CONFIG_FLAG(EnableBGFreeZero))
-        {
-            // We should have zeroed all the pages in the background thread
-            Assert(!recyclerPageAllocator.HasZeroQueuedPages());
-            Assert(!recyclerLargeBlockPageAllocator.HasZeroQueuedPages());
-            this->FlushBackgroundPages();
-        }
+#if ENABLE_BACKGROUND_PAGE_ZEROING
+        // We should have zeroed all the pages in the background thread
+        Assert(!recyclerPageAllocator.HasZeroQueuedPages());
+        Assert(!recyclerLargeBlockPageAllocator.HasZeroQueuedPages());
+#endif
+        this->FlushBackgroundPages();
 #endif
 
         GCETW(GC_FLUSHZEROPAGE_STOP, (this));
@@ -5604,7 +5752,7 @@ Recycler::DoBackgroundWork(bool forceForeground)
     }
     else if (this->IsConcurrentMarkState())
     {
-        RECYCLER_PROFILE_EXEC_BACKGROUND_BEGIN(this, this->collectionState == CollectionStateConcurrentFinishMark?
+        RECYCLER_PROFILE_EXEC_BACKGROUND_BEGIN(this, this->collectionState == CollectionStateConcurrentFinishMark ?
             Js::BackgroundFinishMarkPhase : Js::ConcurrentMarkPhase);
         GCETW(GC_START, (this, BackgroundMarkETWEventGCActivationKind(this->collectionState)));
         DebugOnly(this->markContext.GetPageAllocator()->SetConcurrentThreadId(::GetCurrentThreadId()));
@@ -5639,7 +5787,7 @@ Recycler::DoBackgroundWork(bool forceForeground)
             break;
         };
         GCETW(GC_STOP, (this, BackgroundMarkETWEventGCActivationKind(this->collectionState)));
-        RECYCLER_PROFILE_EXEC_BACKGROUND_END(this, this->collectionState == CollectionStateConcurrentFinishMark?
+        RECYCLER_PROFILE_EXEC_BACKGROUND_END(this, this->collectionState == CollectionStateConcurrentFinishMark ?
             Js::BackgroundFinishMarkPhase : Js::ConcurrentMarkPhase);
 
         this->collectionState = CollectionStateRescanWait;
@@ -5655,15 +5803,12 @@ Recycler::DoBackgroundWork(bool forceForeground)
         Assert(this->collectionState == CollectionStateConcurrentSweep);
 
 #if ENABLE_BACKGROUND_PAGE_ZEROING
-        if (CONFIG_FLAG(EnableBGFreeZero))
-        {
-            // Zero the queued pages first so they are available to be allocated
-            recyclerPageAllocator.BackgroundZeroQueuedPages();
-            recyclerLargeBlockPageAllocator.BackgroundZeroQueuedPages();
+        // Zero the queued pages first so they are available to be allocated
+        recyclerPageAllocator.BackgroundZeroQueuedPages();
+        recyclerLargeBlockPageAllocator.BackgroundZeroQueuedPages();
 #ifdef RECYCLER_WRITE_BARRIER_ALLOC_SEPARATE_PAGE
-            recyclerWithBarrierPageAllocator.BackgroundZeroQueuedPages();
+        recyclerWithBarrierPageAllocator.BackgroundZeroQueuedPages();
 #endif
-        }
 #endif
 
         GCETW(GC_BACKGROUNDZEROPAGE_STOP, (this));
@@ -5679,18 +5824,15 @@ Recycler::DoBackgroundWork(bool forceForeground)
         GCETW(GC_BACKGROUNDSWEEP_STOP, (this, sweptBytes));
 
 #if ENABLE_BACKGROUND_PAGE_ZEROING
-        if (CONFIG_FLAG(EnableBGFreeZero))
-        {
-            // Drain the zero queue again as we might have free more during sweep
-            // in the background
-            GCETW(GC_BACKGROUNDZEROPAGE_START, (this));
-            recyclerPageAllocator.BackgroundZeroQueuedPages();
+        // Drain the zero queue again as we might have free more during sweep
+        // in the background
+        GCETW(GC_BACKGROUNDZEROPAGE_START, (this));
+        recyclerPageAllocator.BackgroundZeroQueuedPages();
 #ifdef RECYCLER_WRITE_BARRIER_ALLOC_SEPARATE_PAGE
-            recyclerWithBarrierPageAllocator.BackgroundZeroQueuedPages();
+        recyclerWithBarrierPageAllocator.BackgroundZeroQueuedPages();
 #endif
-            recyclerLargeBlockPageAllocator.BackgroundZeroQueuedPages();
-            GCETW(GC_BACKGROUNDZEROPAGE_STOP, (this));
-        }
+        recyclerLargeBlockPageAllocator.BackgroundZeroQueuedPages();
+        GCETW(GC_BACKGROUNDZEROPAGE_STOP, (this));
 #endif
         GCETW(GC_STOP, (this, ETWEvent_ConcurrentSweep));
 
@@ -5883,7 +6025,10 @@ Recycler::FinishCollection()
     // Do a partial page decommit now
     if (decommitOnFinish)
     {
-        ForRecyclerPageAllocator(DecommitNow(false));
+        ForEachPageAllocator([](IdleDecommitPageAllocator* pageAlloc)
+        {
+            pageAlloc->DecommitNow(false);
+        });
         this->decommitOnFinish = false;
     }
 
@@ -5932,9 +6077,44 @@ Recycler::FinishCollection()
     RECORD_TIMESTAMP(currentCollectionEndTime);
 }
 
+void
+Recycler::SetExternalRootMarker(ExternalRootMarker fn, void * context)
+{
+    externalRootMarker = fn;
+    externalRootMarkerContext = context;
+}
+// TODO: (leish) remove following function? seems not make sense to re-allocate in recycler
+ArenaData **
+Recycler::RegisterExternalGuestArena(ArenaData* guestArena)
+{
+    return externalGuestArenaList.PrependNode(&NoThrowHeapAllocator::Instance, guestArena);
+}
+
+void
+Recycler::UnregisterExternalGuestArena(ArenaData* guestArena)
+{
+    externalGuestArenaList.Remove(&NoThrowHeapAllocator::Instance, guestArena);
+}
+
+void
+Recycler::UnregisterExternalGuestArena(ArenaData** guestArena)
+{
+    externalGuestArenaList.RemoveElement(&NoThrowHeapAllocator::Instance, guestArena);
+}
+
+void
+Recycler::SetCollectionWrapper(RecyclerCollectionWrapper * wrapper)
+{
+    this->collectionWrapper = wrapper;
+#if LARGEHEAPBLOCK_ENCODING
+    this->Cookie = wrapper->GetRandomNumber();
+#else
+    this->Cookie = 0;
+#endif
+}
 
 char *
-Recycler::Realloc(void* buffer, size_t existingBytes, size_t requestedBytes, bool truncate)
+Recycler::Realloc(void* buffer, DECLSPEC_GUARD_OVERFLOW size_t existingBytes, DECLSPEC_GUARD_OVERFLOW size_t requestedBytes, bool truncate)
 {
     Assert(requestedBytes > 0);
 
@@ -5973,7 +6153,7 @@ Recycler::Realloc(void* buffer, size_t existingBytes, size_t requestedBytes, boo
 
     if (nbytesExisting > 0)
     {
-        this->Free(buffer, nbytesExisting);
+        //this->Free(buffer, nbytesExisting);
     }
 
     return replacementBuf;
@@ -7353,6 +7533,11 @@ Recycler::InitializeProfileAllocTracker()
 void
 Recycler::TrackAllocCore(void * object, size_t size, const TrackAllocData& trackAllocData, bool traceLifetime)
 {
+    if (CONFIG_FLAG(KeepRecyclerTrackData))
+    {
+        TrackFree((char*)object, size);
+    }
+
     Assert(GetTrackerData(object) == nullptr || GetTrackerData(object) == &TrackerData::ExplicitFreeListObjectData);
     Assert(trackAllocData.GetTypeInfo() != nullptr);
     TrackerItem * item;
@@ -7466,7 +7651,10 @@ BOOL Recycler::TrackFree(const char* address, size_t size)
         }
         else
         {
-            Assert(false);
+            if (!CONFIG_FLAG(KeepRecyclerTrackData))
+            {
+                Assert(false);
+            }
         }
         LeaveCriticalSection(&trackerCriticalSection);
     }
@@ -7493,23 +7681,28 @@ Recycler::SetTrackerData(void * address, TrackerData * data)
 void
 Recycler::TrackUnallocated(__in char* address, __in  char *endAddress, size_t sizeCat)
 {
-    if (this->trackerDictionary != nullptr)
+    if (!CONFIG_FLAG(KeepRecyclerTrackData))
     {
-        EnterCriticalSection(&trackerCriticalSection);
-        while (address + sizeCat <= endAddress)
+        if (this->trackerDictionary != nullptr)
         {
-            Assert(GetTrackerData(address) == nullptr);
-            SetTrackerData(address, &TrackerData::EmptyData);
-            address += sizeCat;
+            EnterCriticalSection(&trackerCriticalSection);
+            while (address + sizeCat <= endAddress)
+            {
+                Assert(GetTrackerData(address) == nullptr);
+                SetTrackerData(address, &TrackerData::EmptyData);
+                address += sizeCat;
+            }
+            LeaveCriticalSection(&trackerCriticalSection);
         }
-        LeaveCriticalSection(&trackerCriticalSection);
     }
 }
 
 void
 Recycler::TrackAllocWeakRef(RecyclerWeakReferenceBase * weakRef)
 {
+#if ENABLE_RECYCLER_TYPE_TRACKING
     Assert(weakRef->typeInfo != nullptr);
+#endif
 #if DBG && defined(PERF_COUNTERS)
     if (this->trackerDictionary != nullptr)
     {
@@ -8258,7 +8451,10 @@ Recycler::NotifyFree(__in char *address, size_t size)
 #endif
 
 #ifdef PROFILE_RECYCLER_ALLOC
-    TrackFree(address, size);
+    if (!CONFIG_FLAG(KeepRecyclerTrackData))
+    {
+        TrackFree(address, size);
+    }
 #endif
 
 #ifdef RECYCLER_STATS
@@ -8305,4 +8501,161 @@ RecyclerHeapObjectInfo::GetSize() const
     return size;
 }
 
+// the following instantiation is require for clang while compiling Js::InternalString::New
 template char* Recycler::AllocWithAttributesInlined<(Memory::ObjectInfoBits)32, false>(size_t);
+
+// Allocators
+char * RecyclerAllocatorWithBarrier::Alloc(DECLSPEC_GUARD_OVERFLOW size_t byteSize)
+{
+#if ENABLE_CONCURRENT_GC
+    return recycler.AllocWithBarrier(byteSize);
+#else
+    return recycler.Alloc(byteSize);
+#endif
+}
+char * RecyclerAllocatorWithBarrier::AllocZero(DECLSPEC_GUARD_OVERFLOW size_t byteSize)
+{
+#if ENABLE_CONCURRENT_GC
+    return recycler.AllocZeroWithBarrier(byteSize);
+#else
+    return recycler.AllocZero(byteSize);
+#endif
+}
+char * RecyclerAllocatorWithBarrier::AllocLeaf(DECLSPEC_GUARD_OVERFLOW size_t byteSize)
+{
+    return recycler.AllocLeaf(byteSize);
+}
+void RecyclerAllocatorWithBarrier::Free(void * buffer, size_t byteSize)
+{
+    recycler.ExplicitFreeNonLeaf(buffer, byteSize);
+}
+void RecyclerAllocatorWithBarrier::FreeLeaf(void * buffer, size_t byteSize)
+{
+    recycler.ExplicitFreeLeaf(buffer, byteSize);
+}
+
+#ifdef TRACK_ALLOC
+RecyclerAllocatorWithBarrier *
+RecyclerAllocatorWithBarrier::TrackAllocInfo(TrackAllocData const& data)
+{
+    this->recycler.TrackAllocInfo(data);
+    return this;
+}
+void
+RecyclerAllocatorWithBarrier::ClearTrackAllocInfo(TrackAllocData* data/* = NULL*/)
+{
+    this->recycler.ClearTrackAllocInfo(data);
+}
+#endif
+
+
+char * RecyclerAllocator::Alloc(DECLSPEC_GUARD_OVERFLOW size_t byteSize)
+{
+#if GLOBAL_ENABLE_WRITE_BARRIER
+    if (CONFIG_FLAG(ForceSoftwareWriteBarrier))
+    {
+        return recycler.AllocWithBarrier(byteSize);
+    }
+    else
+#endif
+    {
+#if ENABLE_CONCURRENT_GC && !defined(RECYCLER_WRITE_WATCH)
+        AssertMsg(false, "Need to force software barrier if there's no hardware writebarrier support");
+#endif
+        return recycler.Alloc(byteSize);
+    }
+
+}
+char * RecyclerAllocator::AllocZero(DECLSPEC_GUARD_OVERFLOW size_t byteSize)
+{
+#if GLOBAL_ENABLE_WRITE_BARRIER
+    if (CONFIG_FLAG(ForceSoftwareWriteBarrier))
+    {
+        return recycler.AllocZeroWithBarrier(byteSize);
+    }
+    else
+#endif
+    {
+#if ENABLE_CONCURRENT_GC && !defined(RECYCLER_WRITE_WATCH)
+        AssertMsg(false, "Need to force software barrier if there's no hardware writebarrier support");
+#endif
+        return recycler.AllocZero(byteSize);
+    }
+}
+char * RecyclerAllocator::AllocLeaf(DECLSPEC_GUARD_OVERFLOW size_t byteSize)
+{
+    return recycler.AllocLeaf(byteSize);
+}
+void RecyclerAllocator::Free(void * buffer, size_t byteSize)
+{
+    recycler.ExplicitFreeNonLeaf(buffer, byteSize);
+}
+void RecyclerAllocator::FreeLeaf(void * buffer, size_t byteSize)
+{
+    recycler.ExplicitFreeLeaf(buffer, byteSize);
+}
+
+#ifdef TRACK_ALLOC
+RecyclerAllocator *
+RecyclerAllocator::TrackAllocInfo(TrackAllocData const& data)
+{
+    this->recycler.TrackAllocInfo(data);
+    return this;
+}
+void
+RecyclerAllocator::ClearTrackAllocInfo(TrackAllocData* data/* = NULL*/)
+{
+    this->recycler.ClearTrackAllocInfo(data);
+}
+#endif
+
+char * RecyclerLeafAllocator::Alloc(DECLSPEC_GUARD_OVERFLOW size_t byteSize)
+{
+    return recycler.AllocLeaf(byteSize);
+}
+char * RecyclerLeafAllocator::AllocLeaf(DECLSPEC_GUARD_OVERFLOW size_t byteSize)
+{
+    return recycler.AllocLeaf(byteSize);
+}
+char * RecyclerLeafAllocator::AllocZero(DECLSPEC_GUARD_OVERFLOW size_t byteSize)
+{
+    return recycler.AllocLeafZero(byteSize);
+}
+void RecyclerLeafAllocator::Free(void * buffer, size_t byteSize)
+{
+    recycler.ExplicitFreeLeaf(buffer, byteSize);
+}
+void RecyclerLeafAllocator::FreeLeaf(void * buffer, size_t byteSize)
+{
+    recycler.ExplicitFreeLeaf(buffer, byteSize);
+}
+
+#ifdef TRACK_ALLOC
+RecyclerLeafAllocator *
+RecyclerLeafAllocator::TrackAllocInfo(TrackAllocData const& data)
+{
+    this->recycler.TrackAllocInfo(data);
+    return this;
+}
+void
+RecyclerLeafAllocator::ClearTrackAllocInfo(TrackAllocData* data/* = NULL*/)
+{
+    this->recycler.ClearTrackAllocInfo(data);
+}
+#endif
+
+RecyclerAllocator* 
+Recycler::GetAllocator()
+{
+    return const_cast<RecyclerAllocator*>(&allocator);
+}
+RecyclerAllocatorWithBarrier* 
+Recycler::GetAllocatorWithBarrier()
+{
+    return const_cast<RecyclerAllocatorWithBarrier*>(&allocatorWithBarrier);
+}
+RecyclerLeafAllocator* 
+Recycler::GetLeafAllocator()
+{
+    return const_cast<RecyclerLeafAllocator*>(&leafAllocator);
+}

--- a/lib/Common/Memory/Recycler.h
+++ b/lib/Common/Memory/Recycler.h
@@ -115,60 +115,40 @@ struct InfoBitsWrapper{};
 
 
 // Allocation macro
-
-#if !defined(RECYCLER_WRITE_BARRIER_ALLOC) || !GLOBAL_ENABLE_WRITE_BARRIER
-#define RecyclerNew(recycler,T,...) AllocatorNewBase(Recycler, recycler, AllocInlined, T, __VA_ARGS__)
-#define RecyclerNewPlus(recycler,size,T,...) AllocatorNewPlus(Recycler, recycler, size, T, __VA_ARGS__)
-#define RecyclerNewPlusZ(recycler,size,T,...) AllocatorNewPlusZ(Recycler, recycler, size, T, __VA_ARGS__)
-#define RecyclerNewZ(recycler,T,...) AllocatorNewBase(Recycler, recycler, AllocZeroInlined, T, __VA_ARGS__)
-#define RecyclerNewStruct(recycler,T) AllocatorNewStructBase(Recycler, recycler, AllocInlined, T)
-#define RecyclerNewStructZ(recycler,T) AllocatorNewStructBase(Recycler, recycler, AllocZeroInlined, T)
-#define RecyclerNewStructPlus(recycler,size,T) AllocatorNewStructPlus(Recycler, recycler, size, T)
-#define RecyclerNewArray(recycler,T,count) AllocatorNewArrayBase(Recycler, recycler, Alloc, T, count)
-#define RecyclerNewArrayZ(recycler,T,count) AllocatorNewArrayBase(Recycler, recycler, AllocZero, T, count)
+#define RecyclerNew(recycler,T,...) AllocatorNewBase(RecyclerAllocator, recycler->GetAllocator(), Alloc, T, __VA_ARGS__)
+#define RecyclerNewPlus(recycler,size,T,...) AllocatorNewPlus(RecyclerAllocator, recycler->GetAllocator(), size, T, __VA_ARGS__)
+#define RecyclerNewPlusZ(recycler,size,T,...) AllocatorNewPlusZ(RecyclerAllocator, recycler->GetAllocator(), size, T, __VA_ARGS__)
+#define RecyclerNewZ(recycler,T,...) AllocatorNewBase(RecyclerAllocator, recycler->GetAllocator(), AllocZero, T, __VA_ARGS__)
+#define RecyclerNewStruct(recycler,T) AllocatorNewStructBase(RecyclerAllocator, recycler->GetAllocator(), Alloc, T)
+#define RecyclerNewStructZ(recycler,T) AllocatorNewStructBase(RecyclerAllocator, recycler->GetAllocator(), AllocZero, T)
+#define RecyclerNewStructPlus(recycler,size,T) AllocatorNewStructPlus(RecyclerAllocator, recycler->GetAllocator(), size, T)
+#define RecyclerNewArray(recycler,T,count) AllocatorNewArrayBase(RecyclerAllocator, recycler->GetAllocator(), Alloc, T, count)
+#define RecyclerNewArrayZ(recycler,T,count) AllocatorNewArrayBase(RecyclerAllocator, recycler->GetAllocator(), AllocZero, T, count)
+// special allocators
 #define RecyclerNewFinalized(recycler,T,...) static_cast<T *>(static_cast<FinalizableObject *>(AllocatorNewBase(Recycler, recycler, AllocFinalizedInlined, T, __VA_ARGS__)))
 #define RecyclerNewFinalizedPlus(recycler, size, T,...) static_cast<T *>(static_cast<FinalizableObject *>(AllocatorNewPlusBase(Recycler, recycler, AllocFinalized, size, T, __VA_ARGS__)))
 #define RecyclerNewTracked(recycler,T,...) static_cast<T *>(static_cast<FinalizableObject *>(AllocatorNewBase(Recycler, recycler, AllocTrackedInlined, T, __VA_ARGS__)))
 #define RecyclerNewEnumClass(recycler, enumClass, T, ...) new (TRACK_ALLOC_INFO(static_cast<Recycler *>(recycler), T, Recycler, 0, (size_t)-1), InfoBitsWrapper<enumClass>()) T(__VA_ARGS__)
 #define RecyclerNewWithInfoBits(recycler, infoBits, T, ...) new (TRACK_ALLOC_INFO(static_cast<Recycler *>(recycler), T, Recycler, 0, (size_t)-1), InfoBitsWrapper<infoBits>()) T(__VA_ARGS__)
 #define RecyclerNewFinalizedClientTracked(recycler,T,...) static_cast<T *>(static_cast<FinalizableObject *>(AllocatorNewBase(Recycler, recycler, AllocFinalizedClientTrackedInlined, T, __VA_ARGS__)))
-#endif
 
 #if defined(RECYCLER_WRITE_BARRIER_ALLOC)
-#define RecyclerNewWithBarrier(recycler,T,...) AllocatorNewBase(Recycler, recycler, AllocWithBarrier, T, __VA_ARGS__)
-#define RecyclerNewWithBarrierPlus(recycler,size,T,...) AllocatorNewPlusBase(Recycler, recycler, AllocWithBarrier, size, T, __VA_ARGS__)
-#define RecyclerNewWithBarrierPlusZ(recycler,size,T,...) AllocatorNewPlusBase(Recycler, recycler, AllocZeroWithBarrier, size, T, __VA_ARGS__)
-#define RecyclerNewWithBarrierZ(recycler,T,...) AllocatorNewBase(Recycler, recycler, AllocZeroWithBarrier, T, __VA_ARGS__)
-#define RecyclerNewWithBarrierStruct(recycler,T) AllocatorNewStructBase(Recycler, recycler, AllocWithBarrier, T)
-#define RecyclerNewWithBarrierStructZ(recycler,T) AllocatorNewStructBase(Recycler, recycler, AllocZeroWithBarrier, T)
-#define RecyclerNewWithBarrierStructPlus(recycler,size,T) AllocatorNewStructPlusBase(Recycler, recycler, AllocWithBarrier, size, T)
-#define RecyclerNewWithBarrierArray(recycler,T,count) AllocatorNewArrayBase(Recycler, recycler, AllocWithBarrier, T, count)
-#define RecyclerNewWithBarrierArrayZ(recycler,T,count) AllocatorNewArrayBase(Recycler, recycler, AllocZeroWithBarrier, T, count)
+#define RecyclerNewWithBarrier(recycler,T,...) AllocatorNewBase(RecyclerAllocatorWithBarrier, recycler->GetAllocatorWithBarrier(), Alloc, T, __VA_ARGS__)
+#define RecyclerNewWithBarrierPlus(recycler,size,T,...) AllocatorNewPlusBase(RecyclerAllocatorWithBarrier, recycler->GetAllocatorWithBarrier(), Alloc, size, T, __VA_ARGS__)
+#define RecyclerNewWithBarrierPlusZ(recycler,size,T,...) AllocatorNewPlusBase(RecyclerAllocatorWithBarrier, recycler->GetAllocatorWithBarrier(), AllocZero, size, T, __VA_ARGS__)
+#define RecyclerNewWithBarrierZ(recycler,T,...) AllocatorNewBase(RecyclerAllocatorWithBarrier, recycler->GetAllocatorWithBarrier(), AllocZero, T, __VA_ARGS__)
+#define RecyclerNewWithBarrierStruct(recycler,T) AllocatorNewStructBase(RecyclerAllocatorWithBarrier, recycler->GetAllocatorWithBarrier(), Alloc, T)
+#define RecyclerNewWithBarrierStructZ(recycler,T) AllocatorNewStructBase(RecyclerAllocatorWithBarrier, recycler->GetAllocatorWithBarrier(), AllocZero, T)
+#define RecyclerNewWithBarrierStructPlus(recycler,size,T) AllocatorNewStructPlusBase(RecyclerAllocatorWithBarrier, recycler->GetAllocatorWithBarrier(), Alloc, size, T)
+#define RecyclerNewWithBarrierArray(recycler,T,count) AllocatorNewArrayBase(RecyclerAllocatorWithBarrier, recycler->GetAllocatorWithBarrier(), Alloc, T, count)
+#define RecyclerNewWithBarrierArrayZ(recycler,T,count) AllocatorNewArrayBase(RecyclerAllocatorWithBarrier, recycler->GetAllocatorWithBarrier(), AllocZero, T, count)
+// special allocators, can also change to use RecyclerAllocatorWithBarrier as well
 #define RecyclerNewWithBarrierFinalized(recycler,T,...) static_cast<T *>(static_cast<FinalizableObject *>(AllocatorNewBase(Recycler, recycler, AllocFinalizedWithBarrierInlined, T, __VA_ARGS__)))
 #define RecyclerNewWithBarrierFinalizedPlus(recycler, size, T,...) static_cast<T *>(static_cast<FinalizableObject *>(AllocatorNewPlusBase(Recycler, recycler, AllocFinalizedWithBarrier, size, T, __VA_ARGS__)))
 #define RecyclerNewWithBarrierTracked(recycler,T,...) static_cast<T *>(static_cast<FinalizableObject *>(AllocatorNewBase(Recycler, recycler, AllocTrackedWithBarrierInlined, T, __VA_ARGS__)))
 #define RecyclerNewWithBarrierEnumClass(recycler, enumClass, T, ...) new (TRACK_ALLOC_INFO(static_cast<Recycler *>(recycler), T, Recycler, 0, (size_t)-1), InfoBitsWrapper<(ObjectInfoBits)(enumClass | WithBarrierBit)>()) T(__VA_ARGS__)
 #define RecyclerNewWithBarrierWithInfoBits(recycler, infoBits, T, ...) new (TRACK_ALLOC_INFO(static_cast<Recycler *>(recycler), T, Recycler, 0, (size_t)-1), InfoBitsWrapper<(ObjectInfoBits)(infoBits | WithBarrierBit)>()) T(__VA_ARGS__)
 #define RecyclerNewWithBarrierFinalizedClientTracked(recycler,T,...) static_cast<T *>(static_cast<FinalizableObject *>(AllocatorNewBase(Recycler, recycler, AllocFinalizedClientTrackedWithBarrierInlined, T, __VA_ARGS__)))
-#endif
-
-
-#if defined(RECYCLER_WRITE_BARRIER_ALLOC) && GLOBAL_ENABLE_WRITE_BARRIER
-#define RecyclerNew                         RecyclerNewWithBarrier
-#define RecyclerNewPlus                     RecyclerNewWithBarrierPlus
-#define RecyclerNewPlusZ                    RecyclerNewWithBarrierPlusZ
-#define RecyclerNewZ                        RecyclerNewWithBarrierZ
-#define RecyclerNewStruct                   RecyclerNewWithBarrierStruct
-#define RecyclerNewStructZ                  RecyclerNewWithBarrierStructZ
-#define RecyclerNewStructPlus               RecyclerNewWithBarrierStructPlus
-#define RecyclerNewArray                    RecyclerNewWithBarrierArray
-#define RecyclerNewArrayZ                   RecyclerNewWithBarrierArrayZ
-#define RecyclerNewFinalized                RecyclerNewWithBarrierFinalized
-#define RecyclerNewFinalizedPlus            RecyclerNewWithBarrierFinalizedPlus
-#define RecyclerNewTracked                  RecyclerNewWithBarrierTracked
-#define RecyclerNewEnumClass                RecyclerNewWithBarrierEnumClass
-#define RecyclerNewWithInfoBits             RecyclerNewWithBarrierWithInfoBits
-#define RecyclerNewFinalizedClientTracked   RecyclerNewWithBarrierFinalizedClientTracked
 #endif
 
 #ifndef RECYCLER_WRITE_BARRIER
@@ -566,42 +546,6 @@ struct CollectionParam
 
 #include "RecyclerObjectGraphDumper.h"
 
-#ifdef RECYCLER_WRITE_BARRIER_ALLOC_SEPARATE_PAGE
-// Macro to be used within the recycler
-#define ForRecyclerPageAllocator(action) { \
-    this->recyclerPageAllocator.##action; \
-    this->recyclerLargeBlockPageAllocator.##action; \
-    this->recyclerWithBarrierPageAllocator.##action; \
-    this->threadPageAllocator->##action; \
-}
-
-// Macro that external objects referencing the recycler can use
-#define ForEachRecyclerPageAllocatorIn(recycler, action) { \
-    recycler->GetRecyclerPageAllocator()->##action; \
-    recycler->GetRecyclerLargeBlockPageAllocator()->##action; \
-    recycler->GetRecyclerWithBarrierPageAllocator()->##action; \
-    recycler->GetRecyclerLeafPageAllocator()->##action; \
-}
-
-#else
-
-// Macro to be used within the recycler
-#define ForRecyclerPageAllocator(action) { \
-    this->recyclerPageAllocator.##action; \
-    this->recyclerLargeBlockPageAllocator.##action; \
-    this->threadPageAllocator->##action; \
-}
-
-// Macro that external objects referencing the recycler can use
-#define ForEachRecyclerPageAllocatorIn(recycler, action) { \
-    recycler->GetRecyclerPageAllocator()->##action; \
-    recycler->GetRecyclerLargeBlockPageAllocator()->##action; \
-    recycler->GetRecyclerLeafPageAllocator()->##action; \
-}
-
-#endif
-
-
 #if ENABLE_CONCURRENT_GC
 class RecyclerParallelThread
 {
@@ -661,8 +605,73 @@ private:
 #endif
 
 
+class RecyclerAllocatorBase
+{
+protected:
+    Recycler& recycler;
+public:
+    static const bool FakeZeroLengthArray = true;
+
+    RecyclerAllocatorBase(Recycler* recycler) :recycler(*recycler) {}
+    Recycler* GetRecycler()
+    {
+        return &recycler;
+    }
+};
+class RecyclerAllocatorWithBarrier : public RecyclerAllocatorBase
+{
+public:
+    RecyclerAllocatorWithBarrier(Recycler* recycler) :RecyclerAllocatorBase(recycler) {}
+    char * Alloc(DECLSPEC_GUARD_OVERFLOW size_t byteSize);
+    char * AllocLeaf(DECLSPEC_GUARD_OVERFLOW size_t byteSize);
+    char * AllocZero(DECLSPEC_GUARD_OVERFLOW size_t byteSize);
+    void Free(void * buffer, size_t byteSize);
+    void FreeLeaf(void * buffer, size_t byteSize);
+
+#ifdef TRACK_ALLOC
+    RecyclerAllocatorWithBarrier *TrackAllocInfo(TrackAllocData const& data);
+    void ClearTrackAllocInfo(TrackAllocData* data = nullptr);
+#endif
+};
+
+class RecyclerAllocator : public RecyclerAllocatorBase
+{
+public:
+    RecyclerAllocator(Recycler* recycler) :RecyclerAllocatorBase(recycler) {}
+    char * Alloc(DECLSPEC_GUARD_OVERFLOW size_t byteSize);
+    char * AllocLeaf(DECLSPEC_GUARD_OVERFLOW size_t byteSize);
+    char * AllocZero(DECLSPEC_GUARD_OVERFLOW size_t byteSize);
+    void Free(void * buffer, size_t byteSize);
+    void FreeLeaf(void * buffer, size_t byteSize);
+
+#ifdef TRACK_ALLOC
+    RecyclerAllocator *TrackAllocInfo(TrackAllocData const& data);
+    void ClearTrackAllocInfo(TrackAllocData* data = nullptr);
+#endif
+};
+
+class RecyclerLeafAllocator : public RecyclerAllocatorBase
+{
+public:
+    RecyclerLeafAllocator(Recycler* recycler) :RecyclerAllocatorBase(recycler) {}
+    char * Alloc(DECLSPEC_GUARD_OVERFLOW size_t byteSize);
+    char * AllocLeaf(DECLSPEC_GUARD_OVERFLOW size_t byteSize);
+    char * AllocZero(DECLSPEC_GUARD_OVERFLOW size_t byteSize);
+    void Free(void * buffer, size_t byteSize);
+    void FreeLeaf(void * buffer, size_t byteSize);
+
+#ifdef TRACK_ALLOC
+    RecyclerLeafAllocator *TrackAllocInfo(TrackAllocData const& data);
+    void ClearTrackAllocInfo(TrackAllocData* data = nullptr);
+#endif
+};
+
 class Recycler
 {
+#if !GLOBAL_FORCE_USE_WRITE_BARRIER
+    friend class RecyclerAllocator;
+#endif
+    friend class RecyclerAllocatorWithBarrier;
     friend class RecyclerScanMemoryCallback;
     friend class RecyclerSweep;
     friend class MarkContext;
@@ -729,6 +738,24 @@ public:
     };
 
 private:
+    IdleDecommitPageAllocator * threadPageAllocator;
+#ifdef RECYCLER_WRITE_BARRIER_ALLOC_SEPARATE_PAGE
+    RecyclerPageAllocator recyclerWithBarrierPageAllocator;
+#endif
+    RecyclerPageAllocator recyclerPageAllocator;
+    RecyclerPageAllocator recyclerLargeBlockPageAllocator;
+public:
+    template<typename Action>
+    void ForEachPageAllocator(Action action)
+    {        
+        action(&this->recyclerPageAllocator);
+        action(&this->recyclerLargeBlockPageAllocator);
+#ifdef RECYCLER_WRITE_BARRIER_ALLOC_SEPARATE_PAGE
+        action(&this->recyclerWithBarrierPageAllocator);
+#endif
+        action(threadPageAllocator);
+    }
+private:
     class AutoSwitchCollectionStates
     {
     public:
@@ -750,13 +777,6 @@ private:
     };
 
     CollectionState collectionState;
-    IdleDecommitPageAllocator * threadPageAllocator;
-#ifdef RECYCLER_WRITE_BARRIER_ALLOC_SEPARATE_PAGE
-    RecyclerPageAllocator recyclerWithBarrierPageAllocator;
-#endif
-    RecyclerPageAllocator recyclerPageAllocator;
-    RecyclerPageAllocator recyclerLargeBlockPageAllocator;
-
     JsUtil::ThreadService *threadService;
 
     HeapBlockMap heapBlockMap;
@@ -812,8 +832,8 @@ private:
     };
     DListBase<GuestArenaAllocator> guestArenaList;
     DListBase<ArenaData*> externalGuestArenaList;    // guest arenas are scanned for roots
-#ifdef RECYCLER_PAGE_HEAP
 
+#ifdef RECYCLER_PAGE_HEAP
     inline bool IsPageHeapEnabled() const { return isPageHeapEnabled; }
     template<ObjectInfoBits attributes>
     bool IsPageHeapEnabled(size_t size);
@@ -1115,70 +1135,24 @@ public:
 
     Js::ConfigFlagsTable& GetRecyclerFlagsTable() const { return this->recyclerFlagsTable; }
     void SetMemProtectMode();
-
-    bool IsMemProtectMode()
-    {
-        return this->enableScanImplicitRoots;
-    }
-
-    size_t GetUsedBytes()
-    {
-        size_t usedBytes = threadPageAllocator->usedBytes;
-#ifdef RECYCLER_WRITE_BARRIER_ALLOC_SEPARATE_PAGE
-        usedBytes += recyclerWithBarrierPageAllocator.usedBytes;
-#endif
-        usedBytes += recyclerPageAllocator.usedBytes;
-        usedBytes += recyclerLargeBlockPageAllocator.usedBytes;
-        return usedBytes;
-    }
-
+    bool IsMemProtectMode();
+    size_t GetUsedBytes();
     void LogMemProtectHeapSize(bool fromGC);
-
     char* Realloc(void* buffer, DECLSPEC_GUARD_OVERFLOW size_t existingBytes, DECLSPEC_GUARD_OVERFLOW size_t requestedBytes, bool truncate = true);
 #ifdef NTBUILD
     void SetTelemetryBlock(RecyclerWatsonTelemetryBlock * telemetryBlock) { this->telemetryBlock = telemetryBlock; }
 #endif
 
     void Prime();
-
     void* GetOwnerContext() { return (void*) this->collectionWrapper; }
     PageAllocator * GetPageAllocator() { return threadPageAllocator; }
-
-    bool NeedOOMRescan() const
-    {
-        return this->needOOMRescan;
-    }
-
-    void SetNeedOOMRescan()
-    {
-        this->needOOMRescan = true;
-    }
-
-    void ClearNeedOOMRescan()
-    {
-        this->needOOMRescan = false;
-        markContext.GetPageAllocator()->ResetDisableAllocationOutOfMemory();
-        parallelMarkContext1.GetPageAllocator()->ResetDisableAllocationOutOfMemory();
-        parallelMarkContext2.GetPageAllocator()->ResetDisableAllocationOutOfMemory();
-        parallelMarkContext3.GetPageAllocator()->ResetDisableAllocationOutOfMemory();
-    }
-
+    bool NeedOOMRescan() const;
+    void SetNeedOOMRescan();
+    void ClearNeedOOMRescan();
     BOOL RequestConcurrentWrapperCallback();
-
-    BOOL CollectionInProgress() const
-    {
-        return collectionState != CollectionStateNotCollecting;
-    }
-
-    BOOL IsExiting() const
-    {
-        return (collectionState == Collection_Exit);
-    }
-
-    BOOL IsSweeping() const
-    {
-        return ((collectionState & Collection_Sweep) == Collection_Sweep);
-    }
+    BOOL CollectionInProgress() const;
+    BOOL IsExiting() const;
+    BOOL IsSweeping() const;
 
 #ifdef RECYCLER_PAGE_HEAP
     inline bool ShouldCapturePageHeapFreeStack() const { return capturePageHeapFreeStack; }
@@ -1187,58 +1161,19 @@ public:
 #endif
 
     void SetIsThreadBound();
-    void SetIsScriptActive(bool isScriptActive)
-    {
-        Assert(this->isInScript);
-        Assert(this->isScriptActive != isScriptActive);
-        this->isScriptActive = isScriptActive;
-        if (isScriptActive)
-        {
-            this->tickCountNextDispose = ::GetTickCount() + RecyclerHeuristic::TickCountFinishCollection;
-        }
-    }
-    void SetIsInScript(bool isInScript)
-    {
-        Assert(this->isInScript != isInScript);
-        this->isInScript = isInScript;
-    }
-
+    void SetIsScriptActive(bool isScriptActive);
+    void SetIsInScript(bool isInScript);
     bool ShouldIdleCollectOnExit();
     void ScheduleNextCollection();
 
-    IdleDecommitPageAllocator * GetRecyclerLeafPageAllocator()
-    {
-        return this->threadPageAllocator;
-    }
-
-    IdleDecommitPageAllocator * GetRecyclerPageAllocator()
-    {
-        // TODO: SWB this is for Finalizable leaf allocation, which we didn't implement leaf bucket for it
-        // remove this after the finalizable leaf bucket is implemented
-#if GLOBAL_ENABLE_WRITE_BARRIER
-        return &this->recyclerWithBarrierPageAllocator;
-#else
-        if (CONFIG_FLAG(ForceSoftwareWriteBarrier))
-        {
-            return &this->recyclerWithBarrierPageAllocator;
-        }
-        else
-        {
-            return &this->recyclerPageAllocator;
-        }
+    IdleDecommitPageAllocator * GetRecyclerLeafPageAllocator();
+    IdleDecommitPageAllocator * GetRecyclerPageAllocator();
+    IdleDecommitPageAllocator * GetRecyclerLargeBlockPageAllocator();
+#if DBG
+    void CheckPageAllocator(PageAllocator* pageAlloc);
 #endif
-    }
-
-    IdleDecommitPageAllocator * GetRecyclerLargeBlockPageAllocator()
-    {
-        return &this->recyclerLargeBlockPageAllocator;
-    }
-
 #ifdef RECYCLER_WRITE_BARRIER_ALLOC_SEPARATE_PAGE
-    IdleDecommitPageAllocator * GetRecyclerWithBarrierPageAllocator()
-    {
-        return &this->recyclerWithBarrierPageAllocator;
-    }
+    IdleDecommitPageAllocator * GetRecyclerWithBarrierPageAllocator();
 #endif
 
     BOOL IsShuttingDown() const { return this->isShuttingDown; }
@@ -1275,51 +1210,20 @@ public:
     void ClearCacheCleanupCollection() { Assert(inCacheCleanupCollection); inCacheCleanupCollection = false; }
 
     // Finalizer support
-    void SetExternalRootMarker(ExternalRootMarker fn, void * context)
-    {
-        externalRootMarker = fn;
-        externalRootMarkerContext = context;
-    }
-
-    HeapInfo* CreateHeap();
-    void DestroyHeap(HeapInfo* heapInfo);
-
+    void SetExternalRootMarker(ExternalRootMarker fn, void * context);
     ArenaAllocator * CreateGuestArena(char16 const * name, void (*outOfMemoryFunc)());
     void DeleteGuestArena(ArenaAllocator * arenaAllocator);
-
-    ArenaData ** RegisterExternalGuestArena(ArenaData* guestArena)
-    {
-        return externalGuestArenaList.PrependNode(&NoThrowHeapAllocator::Instance, guestArena);
-    }
-
-    void UnregisterExternalGuestArena(ArenaData* guestArena)
-    {
-        externalGuestArenaList.Remove(&NoThrowHeapAllocator::Instance, guestArena);
-    }
-
-    void UnregisterExternalGuestArena(ArenaData** guestArena)
-    {
-        externalGuestArenaList.RemoveElement(&NoThrowHeapAllocator::Instance, guestArena);
-    }
+    ArenaData ** RegisterExternalGuestArena(ArenaData* guestArena);
+    void UnregisterExternalGuestArena(ArenaData* guestArena);
+    void UnregisterExternalGuestArena(ArenaData** guestArena);
 
 #ifdef RECYCLER_TEST_SUPPORT
     void SetCheckFn(BOOL(*checkFn)(char* addr, size_t size));
 #endif
 
-    void SetCollectionWrapper(RecyclerCollectionWrapper * wrapper)
-    {
-        this->collectionWrapper = wrapper;
-#if LARGEHEAPBLOCK_ENCODING
-        this->Cookie = wrapper->GetRandomNumber();
-#else
-        this->Cookie = 0;
-#endif
-    }
-
+    void SetCollectionWrapper(RecyclerCollectionWrapper * wrapper);
     static size_t GetAlignedSize(size_t size) { return HeapInfo::GetAlignedSize(size); }
-
     HeapInfo* GetAutoHeap() { return &autoHeap; }
-
     template <CollectionFlags flags>
     BOOL CollectNow();
 
@@ -1329,14 +1233,10 @@ public:
 
     void AddExternalMemoryUsage(size_t size);
 
-    bool NeedDispose()
-    {
-        return this->hasDisposableObject;
-    }
+    bool NeedDispose() { return this->hasDisposableObject; }
 
     template <CollectionFlags flags>
     bool FinishDisposeObjectsNow();
-
     BOOL ReportExternalMemoryAllocation(size_t size);
     void ReportExternalMemoryFailure(size_t size);
     void ReportExternalMemoryFree(size_t size);
@@ -1378,19 +1278,11 @@ public:
 #define DEFINE_RECYCLER_NOTHROW_ALLOC(AllocFunc, attributes) DEFINE_RECYCLER_NOTHROW_ALLOC_BASE(AllocFunc, AllocWithAttributes, attributes)
 #define DEFINE_RECYCLER_NOTHROW_ALLOC_ZERO(AllocFunc, attributes) DEFINE_RECYCLER_NOTHROW_ALLOC_BASE(AllocFunc, AllocZeroWithAttributes, attributes)
 
-#if GLOBAL_ENABLE_WRITE_BARRIER
-    DEFINE_RECYCLER_ALLOC(Alloc, WithBarrierBit);
-    DEFINE_RECYCLER_ALLOC_ZERO(AllocZero, WithBarrierBit);
-    DEFINE_RECYCLER_ALLOC(AllocFinalized, FinalizableWithBarrierObjectBits);
-    DEFINE_RECYCLER_ALLOC(AllocTracked, ClientTrackableObjectWithBarrierBits);
-    DEFINE_RECYCLER_ALLOC(AllocFinalizedClientTracked, ClientTrackableObjectWithBarrierBits);
-#else
     DEFINE_RECYCLER_ALLOC(Alloc, NoBit);
     DEFINE_RECYCLER_ALLOC_ZERO(AllocZero, NoBit);
     DEFINE_RECYCLER_ALLOC(AllocFinalized, FinalizableObjectBits);
     DEFINE_RECYCLER_ALLOC(AllocTracked, ClientTrackableObjectBits);
     DEFINE_RECYCLER_ALLOC(AllocFinalizedClientTracked, ClientFinalizableObjectBits);
-#endif
 
 #ifdef RECYCLER_WRITE_BARRIER_ALLOC
     DEFINE_RECYCLER_ALLOC(AllocWithBarrier, WithBarrierBit);
@@ -1459,10 +1351,11 @@ public:
     bool AllowNativeCodeBumpAllocation();
     static void TrackNativeAllocatedMemoryBlock(Recycler * recycler, void * memBlock, size_t sizeCat);
 
-    void Free(void* buffer, size_t size)
-    {
-        Assert(false);
-    }
+    //void Free(void* buffer, size_t size)
+    //{
+    //    // TODO: SWB, remove this,this is used in Recycler::Realloc, maybe need to be removed as well
+    //    Assert(false);
+    //}
 
     bool ExplicitFreeLeaf(void* buffer, size_t size);
     bool ExplicitFreeNonLeaf(void* buffer, size_t size);
@@ -1553,10 +1446,7 @@ public:
     void CheckLeaksOnProcessDetach(char16 const * header);
 #endif
 #ifdef RECYCLER_TRACE
-    void SetDomCollect(bool isDomCollect)
-    {
-        collectionParam.domCollect = isDomCollect;
-    }
+    void SetDomCollect(bool isDomCollect) { collectionParam.domCollect = isDomCollect; }
     void CaptureCollectionParam(CollectionFlags flags, bool repeat = false);
 #endif
 
@@ -2089,8 +1979,17 @@ private:
     } objectBeforeCollectCallbackState;
 
     bool ProcessObjectBeforeCollectCallbacks(bool atShutdown = false);
-};
 
+private:
+    const RecyclerAllocator allocator;
+    const RecyclerAllocatorWithBarrier allocatorWithBarrier;
+    const RecyclerLeafAllocator leafAllocator;
+public:
+    RecyclerAllocator* GetAllocator();
+    RecyclerAllocatorWithBarrier* GetAllocatorWithBarrier();
+    RecyclerLeafAllocator* GetLeafAllocator();
+
+}; // class Recycler
 
 class RecyclerHeapObjectInfo
 {
@@ -2319,217 +2218,6 @@ Recycler::SmallAllocatorAlloc(SmallHeapBlockAllocatorType * allocator, DECLSPEC_
 {
     return autoHeap.SmallAllocatorAlloc<attributes>(this, allocator, sizeCat, size);
 }
-
-// Dummy recycler allocator policy classes to choose the allocation function
-class _RecyclerLeafPolicy;
-class _RecyclerNonLeafPolicy;
-
-#ifdef RECYCLER_WRITE_BARRIER
-class _RecyclerWriteBarrierPolicy;
-#endif
-
-template <typename Policy>
-class _RecyclerAllocatorFunc
-{};
-
-template <>
-class _RecyclerAllocatorFunc<_RecyclerLeafPolicy>
-{
-public:
-    typedef char * (Recycler::*AllocFuncType)(size_t);
-    typedef bool (Recycler::*FreeFuncType)(void*, size_t);
-
-    static AllocFuncType GetAllocFunc()
-    {
-        return &Recycler::AllocLeaf;
-    }
-
-    static AllocFuncType GetAllocZeroFunc()
-    {
-        return &Recycler::AllocLeafZero;
-    }
-
-    static FreeFuncType GetFreeFunc()
-    {
-        return &Recycler::ExplicitFreeLeaf;
-    }
-};
-
-template <>
-class _RecyclerAllocatorFunc<_RecyclerNonLeafPolicy>
-{
-public:
-    typedef char * (Recycler::*AllocFuncType)(size_t);
-    typedef bool (Recycler::*FreeFuncType)(void*, size_t);
-
-    static AllocFuncType GetAllocFunc()
-    {
-        return &Recycler::Alloc;
-    }
-
-    static AllocFuncType GetAllocZeroFunc()
-    {
-        return &Recycler::AllocZero;
-    }
-
-    static FreeFuncType GetFreeFunc()
-    {
-        return &Recycler::ExplicitFreeNonLeaf;
-    }
-};
-
-#ifdef RECYCLER_WRITE_BARRIER
-template <>
-class _RecyclerAllocatorFunc<_RecyclerWriteBarrierPolicy>
-{
-public:
-    typedef char * (Recycler::*AllocFuncType)(size_t);
-    typedef bool (Recycler::*FreeFuncType)(void*, size_t);
-
-    static AllocFuncType GetAllocFunc()
-    {
-        return &Recycler::AllocWithBarrier;
-    }
-
-    static AllocFuncType GetAllocZeroFunc()
-    {
-        return &Recycler::AllocZeroWithBarrier;
-    }
-
-    static FreeFuncType GetFreeFunc()
-    {
-        return &Recycler::ExplicitFreeNonLeaf;
-    }
-};
-#endif
-
-// This is used by the compiler; when T is NOT a pointer i.e. a value type - it causes leaf allocation
-template <typename T>
-class TypeAllocatorFunc<Recycler, T> : public _RecyclerAllocatorFunc<_RecyclerLeafPolicy>
-{
-};
-
-#if GLOBAL_ENABLE_WRITE_BARRIER
-template <typename T>
-class TypeAllocatorFunc<Recycler, T *> : public _RecyclerAllocatorFunc<_RecyclerWriteBarrierPolicy>
-{
-};
-#else
-// Partial template specialization; applies to T when it is a pointer
-template <typename T>
-class TypeAllocatorFunc<Recycler, T *> : public _RecyclerAllocatorFunc<_RecyclerNonLeafPolicy>
-{
-};
-#endif
-
-template <bool isLeaf>
-class ListTypeAllocatorFunc<Recycler, isLeaf>
-{
-public:
-    typedef char * (Recycler::*AllocFuncType)(size_t);
-    typedef bool (Recycler::*FreeFuncType)(void*, size_t);
-
-    static AllocFuncType GetAllocFunc()
-    {
-        return isLeaf ? &Recycler::AllocLeaf : &Recycler::Alloc;
-    }
-
-    static FreeFuncType GetFreeFunc()
-    {
-        if (isLeaf)
-        {
-            return &Recycler::ExplicitFreeLeaf;
-        }
-        else
-        {
-            return &Recycler::ExplicitFreeNonLeaf;
-        }
-    }
-};
-
-// Dummy class to choose the allocation function
-class RecyclerLeafAllocator;
-class RecyclerNonLeafAllocator;
-class RecyclerWriteBarrierAllocator;
-
-// Partial template specialization to allocate as non leaf
-template <typename T>
-class TypeAllocatorFunc<RecyclerNonLeafAllocator, T> : 
-#if GLOBAL_ENABLE_WRITE_BARRIER
-    public _RecyclerAllocatorFunc<_RecyclerWriteBarrierPolicy>
-#else
-    public _RecyclerAllocatorFunc<_RecyclerNonLeafPolicy>
-#endif
-{
-};
-
-#ifdef RECYCLER_WRITE_BARRIER
-template <typename T>
-class TypeAllocatorFunc<RecyclerWriteBarrierAllocator, T> : public _RecyclerAllocatorFunc<_RecyclerWriteBarrierPolicy>
-{
-};
-#endif
-
-template <typename T>
-class TypeAllocatorFunc<RecyclerLeafAllocator, T> : public _RecyclerAllocatorFunc<_RecyclerLeafPolicy>
-{
-};
-
-template <typename TAllocType>
-struct AllocatorInfo<Recycler, TAllocType>
-{
-    typedef Recycler AllocatorType;
-    typedef TypeAllocatorFunc<Recycler, TAllocType> AllocatorFunc;
-    typedef _RecyclerAllocatorFunc<_RecyclerNonLeafPolicy> InstAllocatorFunc; // By default any instance considered non-leaf
-};
-
-template <typename TAllocType>
-struct AllocatorInfo<RecyclerNonLeafAllocator, TAllocType>
-{
-    typedef Recycler AllocatorType;
-    typedef TypeAllocatorFunc<RecyclerNonLeafAllocator, TAllocType> AllocatorFunc;
-    typedef TypeAllocatorFunc<RecyclerNonLeafAllocator, TAllocType> InstAllocatorFunc; // Same as TypeAllocatorFunc
-};
-
-template <typename TAllocType>
-struct AllocatorInfo<RecyclerWriteBarrierAllocator, TAllocType>
-{
-    typedef Recycler AllocatorType;
-    typedef TypeAllocatorFunc<RecyclerWriteBarrierAllocator, TAllocType> AllocatorFunc;
-    typedef TypeAllocatorFunc<RecyclerWriteBarrierAllocator, TAllocType> InstAllocatorFunc; // Same as TypeAllocatorFunc
-};
-
-template <typename TAllocType>
-struct AllocatorInfo<RecyclerLeafAllocator, TAllocType>
-{
-    typedef Recycler AllocatorType;
-    typedef TypeAllocatorFunc<RecyclerLeafAllocator, TAllocType> AllocatorFunc;
-    typedef TypeAllocatorFunc<RecyclerLeafAllocator, TAllocType> InstAllocatorFunc; // Same as TypeAllocatorFunc
-};
-
-template <>
-struct ForceNonLeafAllocator<Recycler>
-{
-    typedef RecyclerNonLeafAllocator AllocatorType;
-};
-
-template <>
-struct ForceNonLeafAllocator<RecyclerLeafAllocator>
-{
-    typedef RecyclerNonLeafAllocator AllocatorType;
-};
-
-template <>
-struct ForceLeafAllocator<Recycler>
-{
-    typedef RecyclerLeafAllocator AllocatorType;
-};
-
-template <>
-struct ForceLeafAllocator<RecyclerNonLeafAllocator>
-{
-    typedef RecyclerLeafAllocator AllocatorType;
-};
 
 // TODO: enable -profile for GC phases.
 // access the same profiler object from multiple GC threads which shares one recyler object,

--- a/lib/Common/Memory/Recycler.h
+++ b/lib/Common/Memory/Recycler.h
@@ -125,12 +125,12 @@ struct InfoBitsWrapper{};
 #define RecyclerNewArray(recycler,T,count) AllocatorNewArrayBase(RecyclerAllocator, recycler->GetAllocator(), Alloc, T, count)
 #define RecyclerNewArrayZ(recycler,T,count) AllocatorNewArrayBase(RecyclerAllocator, recycler->GetAllocator(), AllocZero, T, count)
 // special allocators
-#define RecyclerNewFinalized(recycler,T,...) static_cast<T *>(static_cast<FinalizableObject *>(AllocatorNewBase(Recycler, recycler, AllocFinalizedInlined, T, __VA_ARGS__)))
+#define RecyclerNewFinalized(recycler,T,...) static_cast<T *>(static_cast<FinalizableObject *>(AllocatorNewBase(Recycler, recycler, AllocFinalized, T, __VA_ARGS__)))
 #define RecyclerNewFinalizedPlus(recycler, size, T,...) static_cast<T *>(static_cast<FinalizableObject *>(AllocatorNewPlusBase(Recycler, recycler, AllocFinalized, size, T, __VA_ARGS__)))
-#define RecyclerNewTracked(recycler,T,...) static_cast<T *>(static_cast<FinalizableObject *>(AllocatorNewBase(Recycler, recycler, AllocTrackedInlined, T, __VA_ARGS__)))
+#define RecyclerNewTracked(recycler,T,...) static_cast<T *>(static_cast<FinalizableObject *>(AllocatorNewBase(Recycler, recycler, AllocTracked, T, __VA_ARGS__)))
 #define RecyclerNewEnumClass(recycler, enumClass, T, ...) new (TRACK_ALLOC_INFO(static_cast<Recycler *>(recycler), T, Recycler, 0, (size_t)-1), InfoBitsWrapper<enumClass>()) T(__VA_ARGS__)
 #define RecyclerNewWithInfoBits(recycler, infoBits, T, ...) new (TRACK_ALLOC_INFO(static_cast<Recycler *>(recycler), T, Recycler, 0, (size_t)-1), InfoBitsWrapper<infoBits>()) T(__VA_ARGS__)
-#define RecyclerNewFinalizedClientTracked(recycler,T,...) static_cast<T *>(static_cast<FinalizableObject *>(AllocatorNewBase(Recycler, recycler, AllocFinalizedClientTrackedInlined, T, __VA_ARGS__)))
+#define RecyclerNewFinalizedClientTracked(recycler,T,...) static_cast<T *>(static_cast<FinalizableObject *>(AllocatorNewBase(Recycler, recycler, AllocFinalizedClientTracked, T, __VA_ARGS__)))
 
 #if defined(RECYCLER_WRITE_BARRIER_ALLOC)
 #define RecyclerNewWithBarrier(recycler,T,...) AllocatorNewBase(RecyclerAllocatorWithBarrier, recycler->GetAllocatorWithBarrier(), Alloc, T, __VA_ARGS__)
@@ -143,12 +143,12 @@ struct InfoBitsWrapper{};
 #define RecyclerNewWithBarrierArray(recycler,T,count) AllocatorNewArrayBase(RecyclerAllocatorWithBarrier, recycler->GetAllocatorWithBarrier(), Alloc, T, count)
 #define RecyclerNewWithBarrierArrayZ(recycler,T,count) AllocatorNewArrayBase(RecyclerAllocatorWithBarrier, recycler->GetAllocatorWithBarrier(), AllocZero, T, count)
 // special allocators, can also change to use RecyclerAllocatorWithBarrier as well
-#define RecyclerNewWithBarrierFinalized(recycler,T,...) static_cast<T *>(static_cast<FinalizableObject *>(AllocatorNewBase(Recycler, recycler, AllocFinalizedWithBarrierInlined, T, __VA_ARGS__)))
+#define RecyclerNewWithBarrierFinalized(recycler,T,...) static_cast<T *>(static_cast<FinalizableObject *>(AllocatorNewBase(Recycler, recycler, AllocFinalizedWithBarrier, T, __VA_ARGS__)))
 #define RecyclerNewWithBarrierFinalizedPlus(recycler, size, T,...) static_cast<T *>(static_cast<FinalizableObject *>(AllocatorNewPlusBase(Recycler, recycler, AllocFinalizedWithBarrier, size, T, __VA_ARGS__)))
-#define RecyclerNewWithBarrierTracked(recycler,T,...) static_cast<T *>(static_cast<FinalizableObject *>(AllocatorNewBase(Recycler, recycler, AllocTrackedWithBarrierInlined, T, __VA_ARGS__)))
+#define RecyclerNewWithBarrierTracked(recycler,T,...) static_cast<T *>(static_cast<FinalizableObject *>(AllocatorNewBase(Recycler, recycler, AllocTrackedWithBarrier, T, __VA_ARGS__)))
 #define RecyclerNewWithBarrierEnumClass(recycler, enumClass, T, ...) new (TRACK_ALLOC_INFO(static_cast<Recycler *>(recycler), T, Recycler, 0, (size_t)-1), InfoBitsWrapper<(ObjectInfoBits)(enumClass | WithBarrierBit)>()) T(__VA_ARGS__)
 #define RecyclerNewWithBarrierWithInfoBits(recycler, infoBits, T, ...) new (TRACK_ALLOC_INFO(static_cast<Recycler *>(recycler), T, Recycler, 0, (size_t)-1), InfoBitsWrapper<(ObjectInfoBits)(infoBits | WithBarrierBit)>()) T(__VA_ARGS__)
-#define RecyclerNewWithBarrierFinalizedClientTracked(recycler,T,...) static_cast<T *>(static_cast<FinalizableObject *>(AllocatorNewBase(Recycler, recycler, AllocFinalizedClientTrackedWithBarrierInlined, T, __VA_ARGS__)))
+#define RecyclerNewWithBarrierFinalizedClientTracked(recycler,T,...) static_cast<T *>(static_cast<FinalizableObject *>(AllocatorNewBase(Recycler, recycler, AllocFinalizedClientTrackedWithBarrier, T, __VA_ARGS__)))
 #endif
 
 #ifndef RECYCLER_WRITE_BARRIER
@@ -170,18 +170,18 @@ struct InfoBitsWrapper{};
 #endif
 
 // Leaf allocators
-#define RecyclerNewLeaf(recycler,T,...) AllocatorNewBase(Recycler, recycler, AllocLeafInlined, T, __VA_ARGS__)
-#define RecyclerNewLeafZ(recycler,T,...) AllocatorNewBase(Recycler, recycler, AllocLeafZeroInlined, T, __VA_ARGS__)
+#define RecyclerNewLeaf(recycler,T,...) AllocatorNewBase(Recycler, recycler, AllocLeaf, T, __VA_ARGS__)
+#define RecyclerNewLeafZ(recycler,T,...) AllocatorNewBase(Recycler, recycler, AllocLeafZero, T, __VA_ARGS__)
 #define RecyclerNewPlusLeaf(recycler,size,T,...) AllocatorNewPlusLeaf(Recycler, recycler, size, T, __VA_ARGS__)
 #define RecyclerNewPlusLeafZ(recycler,size,T,...) AllocatorNewPlusLeafZ(Recycler, recycler, size, T, __VA_ARGS__)
-#define RecyclerNewStructLeaf(recycler,T) AllocatorNewStructBase(Recycler, recycler, AllocLeafInlined, T)
-#define RecyclerNewStructLeafZ(recycler,T) AllocatorNewStructBase(Recycler, recycler, AllocLeafZeroInlined, T)
+#define RecyclerNewStructLeaf(recycler,T) AllocatorNewStructBase(Recycler, recycler, AllocLeaf, T)
+#define RecyclerNewStructLeafZ(recycler,T) AllocatorNewStructBase(Recycler, recycler, AllocLeafZero, T)
 #define RecyclerNewArrayLeafZ(recycler,T,count) AllocatorNewArrayBase(Recycler, recycler, AllocLeafZero, T, count)
 #define RecyclerNewArrayLeaf(recycler,T,count) AllocatorNewArrayBase(Recycler, recycler, AllocLeaf, T, count)
-#define RecyclerNewFinalizedLeaf(recycler,T,...) static_cast<T *>(static_cast<FinalizableObject *>(AllocatorNewBase(Recycler, recycler, AllocFinalizedLeafInlined, T, __VA_ARGS__)))
+#define RecyclerNewFinalizedLeaf(recycler,T,...) static_cast<T *>(static_cast<FinalizableObject *>(AllocatorNewBase(Recycler, recycler, AllocFinalizedLeaf, T, __VA_ARGS__)))
 #define RecyclerNewFinalizedLeafPlus(recycler, size, T,...) static_cast<T *>(static_cast<FinalizableObject *>(AllocatorNewPlusBase(Recycler, recycler, AllocFinalizedLeaf, size, T, __VA_ARGS__)))
-#define RecyclerNewTrackedLeaf(recycler,T,...) static_cast<T *>(static_cast<FinalizableObject *>(AllocatorNewBase(Recycler, recycler, AllocTrackedLeafInlined, T, __VA_ARGS__)))
-#define RecyclerNewTrackedLeafPlusZ(recycler,size,T,...) static_cast<T *>(static_cast<FinalizableObject *>(AllocatorNewPlusBase(Recycler, recycler, AllocZeroTrackedLeafInlined, size, T, __VA_ARGS__)))
+#define RecyclerNewTrackedLeaf(recycler,T,...) static_cast<T *>(static_cast<FinalizableObject *>(AllocatorNewBase(Recycler, recycler, AllocTrackedLeaf, T, __VA_ARGS__)))
+#define RecyclerNewTrackedLeafPlusZ(recycler,size,T,...) static_cast<T *>(static_cast<FinalizableObject *>(AllocatorNewPlusBase(Recycler, recycler, AllocZeroTrackedLeaf, size, T, __VA_ARGS__)))
 
 
 
@@ -668,9 +668,7 @@ public:
 
 class Recycler
 {
-#if !GLOBAL_FORCE_USE_WRITE_BARRIER
     friend class RecyclerAllocator;
-#endif
     friend class RecyclerAllocatorWithBarrier;
     friend class RecyclerScanMemoryCallback;
     friend class RecyclerSweep;
@@ -1255,20 +1253,12 @@ public:
     { \
         return AllocWithAttributesFunc<attributes, /* nothrow = */ false>(size); \
     } \
-    __forceinline char * AllocFunc##Inlined(DECLSPEC_GUARD_OVERFLOW size_t size) \
-    { \
-        return AllocWithAttributesFunc##Inlined<attributes, /* nothrow = */ false>(size);  \
-    } \
     DEFINE_RECYCLER_ALLOC_TRACE(AllocFunc, AllocWithAttributesFunc, attributes);
 
 #define DEFINE_RECYCLER_NOTHROW_ALLOC_BASE(AllocFunc, AllocWithAttributesFunc, attributes) \
     inline char * NoThrow##AllocFunc(DECLSPEC_GUARD_OVERFLOW size_t size) \
     { \
         return AllocWithAttributesFunc<attributes, /* nothrow = */ true>(size); \
-    } \
-    inline char * NoThrow##AllocFunc##Inlined(DECLSPEC_GUARD_OVERFLOW size_t size) \
-    { \
-        return AllocWithAttributesFunc##Inlined<attributes, /* nothrow = */ true>(size);  \
     } \
     DEFINE_RECYCLER_ALLOC_TRACE(AllocFunc, AllocWithAttributesFunc, attributes);
 
@@ -1483,25 +1473,13 @@ private:
     template <typename SmallHeapBlockAllocatorType>
     void RemoveSmallAllocator(SmallHeapBlockAllocatorType * allocator, size_t sizeCat);
     template <ObjectInfoBits attributes, typename SmallHeapBlockAllocatorType>
-    char * SmallAllocatorAlloc(SmallHeapBlockAllocatorType * allocator, size_t sizeCat, size_t size);
+    char * SmallAllocatorAlloc(SmallHeapBlockAllocatorType * allocator, DECLSPEC_GUARD_OVERFLOW size_t sizeCat, size_t size);
 
     // Allocation
     template <ObjectInfoBits attributes, bool nothrow>
-    inline char * AllocWithAttributesInlined(DECLSPEC_GUARD_OVERFLOW size_t size);
+    inline char * AllocWithAttributes(DECLSPEC_GUARD_OVERFLOW size_t size);
     template <ObjectInfoBits attributes, bool nothrow>
-    char * AllocWithAttributes(DECLSPEC_GUARD_OVERFLOW size_t size)
-    {
-        return AllocWithAttributesInlined<attributes, nothrow>(size);
-    }
-
-    template <ObjectInfoBits attributes, bool nothrow>
-    inline char* AllocZeroWithAttributesInlined(DECLSPEC_GUARD_OVERFLOW size_t size);
-
-    template <ObjectInfoBits attributes, bool nothrow>
-    char* AllocZeroWithAttributes(DECLSPEC_GUARD_OVERFLOW size_t size)
-    {
-        return AllocZeroWithAttributesInlined<attributes, nothrow>(size);
-    }
+    inline char* AllocZeroWithAttributes(DECLSPEC_GUARD_OVERFLOW size_t size);
 
     char* AllocWeakReferenceEntry(DECLSPEC_GUARD_OVERFLOW size_t size)
     {

--- a/lib/Common/Memory/Recycler.inl
+++ b/lib/Common/Memory/Recycler.inl
@@ -311,7 +311,7 @@ void Recycler::VerifyPageHeapFillAfterAlloc(char* memBlock, size_t size)
 
 template <ObjectInfoBits attributes, bool isSmallAlloc, bool nothrow>
 inline char*
-Recycler::RealAllocFromBucket(HeapInfo* heap, size_t size)
+Recycler::RealAllocFromBucket(HeapInfo* heap, DECLSPEC_GUARD_OVERFLOW size_t size)
 {
     // Align the size
     Assert(HeapInfo::GetAlignedSizeNoCheck(size) <= UINT_MAX);
@@ -379,7 +379,7 @@ Recycler::RealAllocFromBucket(HeapInfo* heap, size_t size)
 
 template <ObjectInfoBits attributes, bool nothrow>
 inline char*
-Recycler::RealAlloc(HeapInfo* heap, size_t size)
+Recycler::RealAlloc(HeapInfo* heap, DECLSPEC_GUARD_OVERFLOW size_t size)
 {
 #ifdef RECYCLER_STRESS
     this->StressCollectNow();

--- a/lib/Common/Memory/Recycler.inl
+++ b/lib/Common/Memory/Recycler.inl
@@ -44,7 +44,7 @@ public:
 
 template <ObjectInfoBits attributes, bool nothrow>
 inline char *
-Recycler::AllocWithAttributesInlined(DECLSPEC_GUARD_OVERFLOW size_t size)
+Recycler::AllocWithAttributes(DECLSPEC_GUARD_OVERFLOW size_t size)
 {
     // All tracked objects are client tracked objects
     CompileAssert((attributes & TrackBit) == 0 || (attributes & ClientTrackedBit) != 0);
@@ -203,9 +203,9 @@ Recycler::AllocWithAttributesInlined(DECLSPEC_GUARD_OVERFLOW size_t size)
 
 template <ObjectInfoBits attributes, bool nothrow>
 inline char *
-Recycler::AllocZeroWithAttributesInlined(DECLSPEC_GUARD_OVERFLOW size_t size)
+Recycler::AllocZeroWithAttributes(DECLSPEC_GUARD_OVERFLOW size_t size)
 {
-    char* obj = AllocWithAttributesInlined<attributes, nothrow>(size);
+    char* obj = AllocWithAttributes<attributes, nothrow>(size);
 
     if (nothrow)
     {

--- a/lib/Common/Memory/RecyclerPageAllocator.cpp
+++ b/lib/Common/Memory/RecyclerPageAllocator.cpp
@@ -16,7 +16,7 @@ RecyclerPageAllocator::RecyclerPageAllocator(Recycler* recycler, AllocationPolic
 #endif
         0, maxFreePageCount,
         true,
-#if ENABLE_BACKGROUND_PAGE_ZEROING
+#if ENABLE_BACKGROUND_PAGE_FREEING
         &zeroPageQueue,
 #endif
         maxAllocPageCount,
@@ -32,7 +32,7 @@ bool RecyclerPageAllocator::IsMemProtectMode()
 }
 
 #if ENABLE_CONCURRENT_GC
-#if ENABLE_WRITE_WATCH
+#ifdef RECYCLER_WRITE_WATCH
 void
 RecyclerPageAllocator::EnableWriteWatch()
 {
@@ -48,7 +48,7 @@ RecyclerPageAllocator::EnableWriteWatch()
 bool
 RecyclerPageAllocator::ResetWriteWatch()
 {
-    if (allocFlags != MEM_WRITE_WATCH)
+    if (!IsWriteWatchEnabled())
     {
         return false;
     }
@@ -131,7 +131,7 @@ RecyclerPageAllocator::ResetAllWriteWatch(DListBase<T> * segmentList)
 }
 #endif
 
-#if ENABLE_WRITE_WATCH
+#ifdef RECYCLER_WRITE_WATCH
 #if DBG
 size_t
 RecyclerPageAllocator::GetWriteWatchPageCount()

--- a/lib/Common/Memory/RecyclerPageAllocator.h
+++ b/lib/Common/Memory/RecyclerPageAllocator.h
@@ -15,7 +15,7 @@ public:
 #endif
         uint maxFreePageCount, uint maxAllocPageCount = PageAllocator::DefaultMaxAllocPageCount, bool enableWriteBarrier = false);
 #if ENABLE_CONCURRENT_GC
-#if ENABLE_WRITE_WATCH
+#ifdef RECYCLER_WRITE_WATCH
     void EnableWriteWatch();
     bool ResetWriteWatch();
 #endif
@@ -24,7 +24,7 @@ public:
     static uint const DefaultPrimePageCount = 0x1000; // 16MB
 
 #if ENABLE_CONCURRENT_GC
-#if ENABLE_WRITE_WATCH
+#ifdef RECYCLER_WRITE_WATCH
 #if DBG
     size_t GetWriteWatchPageCount();
 #endif
@@ -41,8 +41,11 @@ private:
 #endif
 
 private:
+
 #if ENABLE_BACKGROUND_PAGE_ZEROING
     ZeroPageQueue zeroPageQueue;
+#elif ENABLE_BACKGROUND_PAGE_FREEING
+    BackgroundPageQueue zeroPageQueue;
 #endif
     
     Recycler* recycler;

--- a/lib/Common/Memory/RecyclerPointers.h
+++ b/lib/Common/Memory/RecyclerPointers.h
@@ -42,20 +42,18 @@ struct TypeWriteBarrierPolicy<_write_barrier_policy> { typedef _write_barrier_po
 //
 
 class RecyclerAllocatorWithBarrier;
-#if GLOBAL_FORCE_USE_WRITE_BARRIER
-typedef RecyclerAllocatorWithBarrier RecyclerAllocator;
-#else
 class RecyclerAllocator;
-#endif
 class RecyclerLeafAllocator;
+
 template <class AllocatorType>
 struct _AllocatorTypeWriteBarrierPolicy { typedef _no_write_barrier_policy Policy; };
-#if !GLOBAL_FORCE_USE_WRITE_BARRIER
+
 template <>
 struct _AllocatorTypeWriteBarrierPolicy<RecyclerAllocator> { typedef _no_write_barrier_policy Policy; };
-#endif
+
 template <>
 struct _AllocatorTypeWriteBarrierPolicy<RecyclerAllocatorWithBarrier> { typedef _write_barrier_policy Policy; };
+
 template <>
 struct _AllocatorTypeWriteBarrierPolicy<RecyclerLeafAllocator> { typedef _no_write_barrier_policy Policy; };
 
@@ -81,9 +79,9 @@ template <class T>
 struct AllocatorWriteBarrierPolicy<RecyclerAllocatorWithBarrier, T> { typedef _write_barrier_policy Policy; };
 template <>
 struct AllocatorWriteBarrierPolicy<RecyclerAllocatorWithBarrier, int> { typedef _no_write_barrier_policy Policy; };
-#if !GLOBAL_FORCE_USE_WRITE_BARRIER
+#if GLOBAL_ENABLE_WRITE_BARRIER
 template <class T>
-struct AllocatorWriteBarrierPolicy<RecyclerAllocator, T> { typedef _no_write_barrier_policy Policy; };
+struct AllocatorWriteBarrierPolicy<RecyclerAllocator, T> { typedef _write_barrier_policy Policy; };
 template <>
 struct AllocatorWriteBarrierPolicy<RecyclerAllocator, int> { typedef _no_write_barrier_policy Policy; };
 #endif

--- a/lib/Common/Memory/RecyclerSweep.cpp
+++ b/lib/Common/Memory/RecyclerSweep.cpp
@@ -186,7 +186,7 @@ RecyclerSweep::FinishSweep()
 
             GCETW(GC_SWEEP_PARTIAL_REUSE_PAGE_STOP, (recycler));
 
-#if ENABLE_WRITE_WATCH
+#ifdef RECYCLER_WRITE_WATCH
             if (!CONFIG_FLAG(ForceSoftwareWriteBarrier))
             {
                 if (!this->IsBackground())

--- a/lib/Common/Memory/RecyclerSweep.h
+++ b/lib/Common/Memory/RecyclerSweep.h
@@ -197,23 +197,20 @@ void
 RecyclerSweep::QueueEmptyHeapBlock(HeapBucketT<TBlockType> const *heapBucket, TBlockType * heapBlock)
 {
 #if ENABLE_BACKGROUND_PAGE_FREEING
-    if (CONFIG_FLAG(EnableBGFreeZero))
+    auto& bucketData = this->GetBucketData(heapBucket);
+    Assert(heapBlock->heapBucket == heapBucket);
+
+    heapBlock->BackgroundReleasePagesSweep(recycler);
+
+    TBlockType * list = bucketData.pendingEmptyBlockList;
+    if (list == nullptr)
     {
-        auto& bucketData = this->GetBucketData(heapBucket);
-        Assert(heapBlock->heapBucket == heapBucket);
-
-        heapBlock->BackgroundReleasePagesSweep(recycler);
-
-        TBlockType * list = bucketData.pendingEmptyBlockList;
-        if (list == nullptr)
-        {
-            Assert(bucketData.pendingEmptyBlockListTail == nullptr);
-            bucketData.pendingEmptyBlockListTail = heapBlock;
-            this->hasPendingEmptyBlocks = true;
-        }
-        heapBlock->SetNextBlock(list);
-        bucketData.pendingEmptyBlockList = heapBlock;
+        Assert(bucketData.pendingEmptyBlockListTail == nullptr);
+        bucketData.pendingEmptyBlockListTail = heapBlock;
+        this->hasPendingEmptyBlocks = true;
     }
+    heapBlock->SetNextBlock(list);
+    bucketData.pendingEmptyBlockList = heapBlock;
 #endif
 }
 

--- a/lib/Common/Memory/RecyclerWriteBarrierManager.cpp
+++ b/lib/Common/Memory/RecyclerWriteBarrierManager.cpp
@@ -66,6 +66,16 @@ X64WriteBarrierCardTableManager::OnThreadInit()
     ::GetCurrentThreadStackLimits(&stackEnd, &stackBase);
 #endif
 
+#ifdef X64_WB_DIAG
+    this->_stackbase = (char*)stackBase;
+    this->_stacklimit = (char*)stackEnd;
+#endif
+
+    // on Windows server 2012 stack limit can expand with process running, and causes
+    // accessing uncommitted card table page.
+    // TODO: use VirtualQuery twice to get the max possible stack limit
+    stackEnd -= AutoSystemInfo::PageSize * AutoSystemInfo::PageSize;
+
     size_t numPages = (stackBase - stackEnd) / AutoSystemInfo::PageSize;
     // stackEnd is the lower boundary
     bool ret = OnSegmentAlloc((char*) stackEnd, numPages);

--- a/lib/Common/Memory/RecyclerWriteBarrierManager.h
+++ b/lib/Common/Memory/RecyclerWriteBarrierManager.h
@@ -125,6 +125,8 @@ private:
     size_t _lastSectionIndexStart;
     size_t _lastSectionIndexLast;
     CommitState _lastCommitState;
+    char* _stackbase;
+    char* _stacklimit;
 #endif
 
 #ifdef X64_WB_DIAG

--- a/lib/Common/Memory/StressTest.cpp
+++ b/lib/Common/Memory/StressTest.cpp
@@ -12,8 +12,8 @@
 #include <malloc.h>
 #endif
 
-typedef JsUtil::BaseDictionary<TestObject*, bool, RecyclerNonLeafAllocator> ObjectTracker_t;
-typedef JsUtil::List<TestObject*, Recycler> ObjectList_t;
+typedef JsUtil::BaseDictionary<TestObject*, bool, RecyclerAllocator> ObjectTracker_t;
+typedef JsUtil::List<TestObject*, RecyclerAllocator> ObjectList_t;
 
 template<size_t align> bool IsAligned(void *p)
 {
@@ -105,8 +105,8 @@ template<class Fn> void TestObject::Visit(Recycler *recycler, TestObject *root, 
 {
     // TODO: move these allocations to HeapAllocator.
 
-    ObjectTracker_t *objectTracker = RecyclerNew(recycler, ObjectTracker_t, recycler);
-    ObjectList_t *objectList = RecyclerNew(recycler, ObjectList_t, recycler);
+    ObjectTracker_t *objectTracker = RecyclerNew(recycler, ObjectTracker_t, recycler->GetAllocator());
+    ObjectList_t *objectList = RecyclerNew(recycler, ObjectList_t, recycler->GetAllocator());
 
     // Prime the list with the first object
     objectList->Add(root);

--- a/lib/Common/Memory/WriteBarrierMacros.h
+++ b/lib/Common/Memory/WriteBarrierMacros.h
@@ -42,7 +42,7 @@ SAVE_WRITE_BARRIER_MACROS()
 #if GLOBAL_ENABLE_WRITE_BARRIER || defined(FORCE_USE_WRITE_BARRIER)
 // Various macros for defining field attributes
 #define Field(type, ...) \
-    typename WriteBarrierFieldTypeTraits<type, ##__VA_ARGS__>::Type
+    typename WriteBarrierFieldTypeTraits<type, RecyclerAllocatorWithBarrier, ##__VA_ARGS__>::Type
 #define FieldNoBarrier(type) \
     typename WriteBarrierFieldTypeTraits<type, _no_write_barrier_policy, _no_write_barrier_policy>::Type
 #else

--- a/lib/Common/Memory/WriteBarrierMacros.h
+++ b/lib/Common/Memory/WriteBarrierMacros.h
@@ -42,7 +42,7 @@ SAVE_WRITE_BARRIER_MACROS()
 #if GLOBAL_ENABLE_WRITE_BARRIER || defined(FORCE_USE_WRITE_BARRIER)
 // Various macros for defining field attributes
 #define Field(type, ...) \
-    typename WriteBarrierFieldTypeTraits<type, RecyclerAllocatorWithBarrier, ##__VA_ARGS__>::Type
+    typename WriteBarrierFieldTypeTraits<type, ##__VA_ARGS__>::Type
 #define FieldNoBarrier(type) \
     typename WriteBarrierFieldTypeTraits<type, _no_write_barrier_policy, _no_write_barrier_policy>::Type
 #else

--- a/lib/Parser/RegexRuntime.cpp
+++ b/lib/Parser/RegexRuntime.cpp
@@ -5124,9 +5124,10 @@ namespace UnifiedRegex
         Assert(!rep.insts.scannersForSyncToLiterals);
         Assert(recycler);
 
+        typedef Field(ScannerInfo *) ScannerInfoPtr;
         return
             rep.insts.scannersForSyncToLiterals =
-                RecyclerNewArrayZ(recycler, Field(ScannerInfo *), ScannersMixin::MaxNumSyncLiterals);
+                RecyclerNewArrayZ(recycler, ScannerInfoPtr, ScannersMixin::MaxNumSyncLiterals);
     }
 
     ScannerInfo *Program::AddScannerForSyncToLiterals(

--- a/lib/Runtime/Base/CharStringCache.cpp
+++ b/lib/Runtime/Base/CharStringCache.cpp
@@ -56,7 +56,7 @@ namespace Js
             if (charStringCache == nullptr)
             {
                 Recycler * recycler = scriptContext->GetRecycler();
-                charStringCache = RecyclerNew(recycler, CharStringCacheMap, recycler, 17);
+                charStringCache = RecyclerNew(recycler, CharStringCacheMap, recycler->GetAllocator(), 17);
             }
             if (!charStringCache->TryGetValue(c, &str))
             {

--- a/lib/Runtime/Base/CharStringCache.h
+++ b/lib/Runtime/Base/CharStringCache.h
@@ -27,8 +27,7 @@ namespace Js
 
     private:
         Field(PropertyString *) charStringCacheA[CharStringCacheSize];
-
-        typedef JsUtil::BaseDictionary<char16, JavascriptString *, Recycler, PowerOf2SizePolicy> CharStringCacheMap;
+        typedef JsUtil::BaseDictionary<char16, JavascriptString *, RecyclerAllocator, PowerOf2SizePolicy> CharStringCacheMap;
         Field(CharStringCacheMap *) charStringCache;
 
         friend class CharStringCacheValidator;

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -212,7 +212,7 @@ namespace Js
         StatementMapList * statementMaps = this->GetStatementMaps();
         if (!statementMaps)
         {
-            statementMaps = RecyclerNew(recycler, StatementMapList, recycler);
+            statementMaps = RecyclerNew(recycler, StatementMapList, recycler->GetAllocator());
             this->SetStatementMaps(statementMaps);
         }
 
@@ -240,7 +240,7 @@ namespace Js
         Recycler* recycler = this->m_scriptContext->GetRecycler();
         if (this->GetStatementAdjustmentRecords() == nullptr)
         {
-            m_sourceInfo.m_auxStatementData->m_statementAdjustmentRecords = RecyclerNew(recycler, StatementAdjustmentRecordList, recycler);
+            m_sourceInfo.m_auxStatementData->m_statementAdjustmentRecords = RecyclerNew(recycler, StatementAdjustmentRecordList, recycler->GetAllocator());
         }
 
         StatementAdjustmentRecord record(adjType, offset);
@@ -560,7 +560,7 @@ namespace Js
 
         // Sync entryPoints changes to etw rundown lock
         CriticalSection* syncObj = scriptContext->GetThreadContext()->GetEtwRundownCriticalSection();
-        this->entryPoints = RecyclerNew(this->m_scriptContext->GetRecycler(), FunctionEntryPointList, this->m_scriptContext->GetRecycler(), syncObj);
+        this->entryPoints = RecyclerNew(this->m_scriptContext->GetRecycler(), FunctionEntryPointList, this->m_scriptContext->GetRecycler()->GetAllocator(), syncObj);
 
         this->AddEntryPointToEntryPointList(this->GetDefaultFunctionEntryPointInfo());
 
@@ -1570,7 +1570,7 @@ namespace Js
         if (functionObjectTypeList == nullptr)
         {
             Recycler* recycler = this->GetScriptContext()->GetRecycler();
-            this->SetAuxPtr(AuxPointerType::FunctionObjectTypeList, RecyclerNew(recycler, FunctionTypeWeakRefList, recycler));
+            this->SetAuxPtr(AuxPointerType::FunctionObjectTypeList, RecyclerNew(recycler, FunctionTypeWeakRefList, recycler->GetAllocator()));
         }
 
         return static_cast<FunctionTypeWeakRefList*>(this->GetAuxPtr(AuxPointerType::FunctionObjectTypeList));
@@ -1693,7 +1693,7 @@ namespace Js
         FunctionBody* returnFunctionBody = nullptr;
         ENTER_PINNED_SCOPE(Js::PropertyRecordList, propertyRecordList);
         Recycler* recycler = this->m_scriptContext->GetRecycler();
-        propertyRecordList = RecyclerNew(recycler, Js::PropertyRecordList, recycler);
+        propertyRecordList = RecyclerNew(recycler, Js::PropertyRecordList, recycler->GetAllocator());
 
         bool isDebugOrAsmJsReparse = false;
         FunctionBody* funcBody = nullptr;
@@ -1968,7 +1968,7 @@ namespace Js
         FunctionBody* returnFunctionBody = nullptr;
         ENTER_PINNED_SCOPE(Js::PropertyRecordList, propertyRecordList);
         Recycler* recycler = this->m_scriptContext->GetRecycler();
-        propertyRecordList = RecyclerNew(recycler, Js::PropertyRecordList, recycler);
+        propertyRecordList = RecyclerNew(recycler, Js::PropertyRecordList, recycler->GetAllocator());
 
         FunctionBody* funcBody = nullptr;
 
@@ -5102,7 +5102,7 @@ namespace Js
     {
         if (this->scopeProperties == nullptr)
         {
-            this->scopeProperties = RecyclerNew(this->recycler, DebuggerScopePropertyList, this->recycler);
+            this->scopeProperties = RecyclerNew(this->recycler, DebuggerScopePropertyList, this->recycler->GetAllocator());
         }
     }
 
@@ -7711,7 +7711,7 @@ namespace Js
         Recycler* recycler = this->m_scriptContext->GetRecycler();
         if (this->GetCrossFrameEntryExitRecords() == nullptr)
         {
-            m_sourceInfo.m_auxStatementData->m_crossFrameBlockEntryExisRecords = RecyclerNew(recycler, CrossFrameEntryExitRecordList, recycler);
+            m_sourceInfo.m_auxStatementData->m_crossFrameBlockEntryExisRecords = RecyclerNew(recycler, CrossFrameEntryExitRecordList, recycler->GetAllocator());
         }
         Assert(this->GetCrossFrameEntryExitRecords());
 
@@ -7779,13 +7779,13 @@ namespace Js
 
     EntryPointPolymorphicInlineCacheInfo::EntryPointPolymorphicInlineCacheInfo(FunctionBody * functionBody) :
         selfInfo(functionBody),
-        inlineeInfo(functionBody->GetRecycler())
+        inlineeInfo(functionBody->GetRecycler()->GetAllocator())
     {
     }
 
     PolymorphicInlineCacheInfo * EntryPointPolymorphicInlineCacheInfo::GetInlineeInfo(FunctionBody * inlineeFunctionBody)
     {
-        SListCounted<PolymorphicInlineCacheInfo*, Recycler>::Iterator iter(&inlineeInfo);
+        SListCounted<PolymorphicInlineCacheInfo*, RecyclerAllocator>::Iterator iter(&inlineeInfo);
         while (iter.Next())
         {
             PolymorphicInlineCacheInfo * info = iter.Data();
@@ -7872,7 +7872,7 @@ namespace Js
     {
         if (this->weakFuncRefSet == nullptr)
         {
-            this->weakFuncRefSet = RecyclerNew(recycler, WeakFuncRefSet, recycler);
+            this->weakFuncRefSet = RecyclerNew(recycler, WeakFuncRefSet, recycler->GetAllocator());
         }
 
         return this->weakFuncRefSet;
@@ -7981,7 +7981,7 @@ namespace Js
     {
         if (this->jitTimeTypeRefs == nullptr)
         {
-            this->jitTimeTypeRefs = RecyclerNew(recycler, TypeRefSet, recycler);
+            this->jitTimeTypeRefs = RecyclerNew(recycler, TypeRefSet, recycler->GetAllocator());
         }
     }
 
@@ -8314,7 +8314,7 @@ namespace Js
         if (this->sharedPropertyGuards == nullptr)
         {
             Recycler* recycler = scriptContext->GetRecycler();
-            this->sharedPropertyGuards = RecyclerNew(recycler, SharedPropertyGuardDictionary, recycler);
+            this->sharedPropertyGuards = RecyclerNew(recycler, SharedPropertyGuardDictionary, recycler->GetAllocator());
         }
 
         PropertyGuard* guard = nullptr;
@@ -8733,7 +8733,7 @@ namespace Js
 
         if (!this->constructorCaches)
         {
-            this->constructorCaches = RecyclerNew(recycler, ConstructorCacheList, recycler);
+            this->constructorCaches = RecyclerNew(recycler, ConstructorCacheList, recycler->GetAllocator());
         }
 
         this->constructorCaches->Prepend(constructorCache);
@@ -9439,7 +9439,7 @@ namespace Js
 
         // Sync entryPoints changes to etw rundown lock
         auto syncObj = functionBody->GetScriptContext()->GetThreadContext()->GetEtwRundownCriticalSection();
-        this->entryPoints = RecyclerNew(recycler, LoopEntryPointList, recycler, syncObj);
+        this->entryPoints = RecyclerNew(recycler, LoopEntryPointList, recycler->GetAllocator(), syncObj);
 
         this->CreateEntryPoint();
 #endif

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -53,8 +53,8 @@ namespace Js
     class JavascriptNumber;
 #pragma endregion
 
-    typedef JsUtil::BaseDictionary<Js::PropertyId, const Js::PropertyRecord*, RecyclerNonLeafAllocator, PowerOf2SizePolicy, DefaultComparer, JsUtil::SimpleDictionaryEntry> PropertyRecordList;
-    typedef JsUtil::BaseHashSet<void*, Recycler, PowerOf2SizePolicy> TypeRefSet;
+    typedef JsUtil::BaseDictionary<Js::PropertyId, const Js::PropertyRecord*, RecyclerAllocator, PowerOf2SizePolicy, DefaultComparer, JsUtil::SimpleDictionaryEntry> PropertyRecordList;
+    typedef JsUtil::BaseHashSet<void*, RecyclerAllocator, PowerOf2SizePolicy> TypeRefSet;
 
      // Definition of scopes such as With, Catch and Block which will be used further in the debugger for additional look-ups.
     enum DiagExtraScopesType
@@ -309,7 +309,7 @@ namespace Js
     private:
         Field(PolymorphicInlineCacheInfo) selfInfo;
 
-        typedef SListCounted<PolymorphicInlineCacheInfo*, Recycler> PolymorphicInlineCacheInfoListType;
+        typedef SListCounted<PolymorphicInlineCacheInfo*, RecyclerAllocator> PolymorphicInlineCacheInfoListType;
         Field(PolymorphicInlineCacheInfoListType) inlineeInfo;
 
         static void SetPolymorphicInlineCache(PolymorphicInlineCacheInfo * polymorphicInlineCacheInfo, FunctionBody * functionBody, uint index, PolymorphicInlineCache * polymorphicInlineCache, byte polyCacheUtil);
@@ -320,14 +320,14 @@ namespace Js
         PolymorphicInlineCacheInfo * GetSelfInfo() { return &selfInfo; }
         PolymorphicInlineCacheInfo * EnsureInlineeInfo(Recycler * recycler, FunctionBody * inlineeFunctionBody);
         PolymorphicInlineCacheInfo * GetInlineeInfo(FunctionBody * inlineeFunctionBody);
-        SListCounted<PolymorphicInlineCacheInfo*, Recycler> * GetInlineeInfo() { return &this->inlineeInfo; }
+        SListCounted<PolymorphicInlineCacheInfo*, RecyclerAllocator> * GetInlineeInfo() { return &this->inlineeInfo; }
 
         void SetPolymorphicInlineCache(FunctionBody * functionBody, uint index, PolymorphicInlineCache * polymorphicInlineCache, bool isInlinee, byte polyCacheUtil);
 
         template <class Fn>
         void MapInlinees(Fn fn)
         {
-            SListCounted<PolymorphicInlineCacheInfo*, Recycler>::Iterator iter(&inlineeInfo);
+            SListCounted<PolymorphicInlineCacheInfo*, RecyclerAllocator>::Iterator iter(&inlineeInfo);
             while (iter.Next())
             {
                 fn(iter.Data());
@@ -534,10 +534,10 @@ namespace Js
         Field(XProcNumberPageSegment*) numberPageSegments;
 
         FieldNoBarrier(SmallSpanSequence *) nativeThrowSpanSequence;
-        typedef JsUtil::BaseHashSet<RecyclerWeakReference<FunctionBody>*, Recycler, PowerOf2SizePolicy> WeakFuncRefSet;
+        typedef JsUtil::BaseHashSet<RecyclerWeakReference<FunctionBody>*, RecyclerAllocator, PowerOf2SizePolicy> WeakFuncRefSet;
         Field(WeakFuncRefSet *) weakFuncRefSet;
         // Need to keep strong references to the guards here so they don't get collected while the entry point is alive.
-        typedef JsUtil::BaseDictionary<Js::PropertyId, PropertyGuard*, Recycler, PowerOf2SizePolicy> SharedPropertyGuardDictionary;
+        typedef JsUtil::BaseDictionary<Js::PropertyId, PropertyGuard*, RecyclerAllocator, PowerOf2SizePolicy> SharedPropertyGuardDictionary;
         Field(SharedPropertyGuardDictionary*) sharedPropertyGuards;
         typedef JsUtil::List<LazyBailOutRecord, HeapAllocator> BailOutRecordMap;
         Field(BailOutRecordMap*) bailoutRecordMap;
@@ -557,7 +557,7 @@ namespace Js
         Field(uint) inlineeFrameOffsetArrayOffset;
         Field(uint) inlineeFrameOffsetArrayCount;
 
-        typedef SListCounted<ConstructorCache*, Recycler> ConstructorCacheList;
+        typedef SListCounted<ConstructorCache*, RecyclerAllocator> ConstructorCacheList;
         Field(ConstructorCacheList*) constructorCaches;
 
         Field(EntryPointPolymorphicInlineCacheInfo *) polymorphicInlineCacheInfo;
@@ -1013,15 +1013,15 @@ namespace Js
         {
             uint32 statementIndex;
             regex::Interval nativeOffsetSpan;
-        };
+         };
 
-    private:
-        typedef JsUtil::List<NativeOffsetMap, HeapAllocator> NativeOffsetMapListType;
-        Field(NativeOffsetMapListType) nativeOffsetMaps;
-    public:
-        void RecordNativeMap(uint32 offset, uint32 statementIndex);
+         typedef JsUtil::List<NativeOffsetMap, HeapAllocator> NativeOffsetMapListType;
+     private:
+         Field(NativeOffsetMapListType) nativeOffsetMaps;
+     public:
+         void RecordNativeMap(uint32 offset, uint32 statementIndex);
 
-        int GetNativeOffsetMapCount() const;
+         int GetNativeOffsetMapCount() const;
 #endif
 
 #if DBG_DUMP && ENABLE_NATIVE_CODEGEN
@@ -1318,7 +1318,7 @@ namespace Js
     public:
         static CriticalSection* GetLock() { return &GlobalLock; }
         typedef RecyclerWeakReference<DynamicType> FunctionTypeWeakRef;
-        typedef JsUtil::List<FunctionTypeWeakRef*, Recycler, false, WeakRefFreeListedRemovePolicy> FunctionTypeWeakRefList;
+        typedef JsUtil::List<FunctionTypeWeakRef*, RecyclerAllocator, false, WeakRefFreeListedRemovePolicy> FunctionTypeWeakRefList;
 
     protected:
         FunctionProxy(JavascriptMethod entryPoint, Attributes attributes,
@@ -1988,8 +1988,8 @@ namespace Js
             typedef JsUtil::List<Js::FunctionBody::StatementMap*> StatementMapList;
 
             // Note: isLeaf = true template param below means that recycler should not be used to dispose the items.
-            typedef JsUtil::List<StatementAdjustmentRecord, Recycler, /* isLeaf = */ true> StatementAdjustmentRecordList;
-            typedef JsUtil::List<CrossFrameEntryExitRecord, Recycler, /* isLeaf = */ true> CrossFrameEntryExitRecordList;
+            typedef JsUtil::List<StatementAdjustmentRecord, RecyclerAllocator, /* isLeaf = */ true> StatementAdjustmentRecordList;
+            typedef JsUtil::List<CrossFrameEntryExitRecord, RecyclerAllocator, /* isLeaf = */ true> CrossFrameEntryExitRecordList;
 
             // Contains recorded at bytecode generation time information about statements and try-catch blocks.
             // Used by debugger.
@@ -3789,7 +3789,7 @@ namespace Js
         ScopeObjectChain(Recycler* recycler)
             : pScopeChain(nullptr)
         {
-            pScopeChain = RecyclerNew(recycler, ScopeObjectChainList, recycler);
+            pScopeChain = RecyclerNew(recycler, ScopeObjectChainList, recycler->GetAllocator());
         }
 
         // This function will return DebuggerScopeProperty when the property is found and correctly in the range.

--- a/lib/Runtime/Base/PropertyRecord.h
+++ b/lib/Runtime/Base/PropertyRecord.h
@@ -261,7 +261,7 @@ namespace Js
     {
     public:
         CaseInvariantPropertyListWithHashCode(Recycler* recycler, int increment):
-          JsUtil::List<const RecyclerWeakReference<Js::PropertyRecord const>*>(recycler, increment),
+          JsUtil::List<const RecyclerWeakReference<Js::PropertyRecord const>*>(recycler->GetAllocator(), increment),
           caseInvariantHashCode(0)
           {
           }

--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -1139,7 +1139,7 @@ namespace Js
 
         this->cache->dynamicRegexMap =
             RegexPatternMruMap::New(
-                recycler,
+                recycler->GetAllocator(),
                 REGEX_CONFIG_FLAG(DynamicRegexMruListSize) <= 0 ? 16 : REGEX_CONFIG_FLAG(DynamicRegexMruListSize));
 
         SourceContextInfo* sourceContextInfo = RecyclerNewStructZ(this->GetRecycler(), SourceContextInfo);
@@ -1209,14 +1209,14 @@ namespace Js
         AssertMsg(this->DeferredDeserializationThunk == DefaultDeferredDeserializeThunk, "Creating non default thunk while initializing");
 
 #ifdef FIELD_ACCESS_STATS
-        this->fieldAccessStatsByFunctionNumber = RecyclerNew(this->recycler, FieldAccessStatsByFunctionNumberMap, recycler);
+        this->fieldAccessStatsByFunctionNumber = RecyclerNew(this->recycler, FieldAccessStatsByFunctionNumberMap, recycler->GetAllocator());
         BindReference(this->fieldAccessStatsByFunctionNumber);
 #endif
 
 if (!sourceList)
         {
             AutoCriticalSection critSec(threadContext->GetEtwRundownCriticalSection());
-            sourceList.Root(RecyclerNew(this->GetRecycler(), SourceList, this->GetRecycler()), this->GetRecycler());
+            sourceList.Root(RecyclerNew(this->GetRecycler(), SourceList, this->GetRecycler()->GetAllocator()), this->GetRecycler());
         }
 
 #if DYNAMIC_INTERPRETER_THUNK
@@ -2180,7 +2180,7 @@ if (!sourceList)
         EvalCacheDictionary *dict = isIndirect ? this->cache->indirectEvalCacheDictionary : this->cache->evalCacheDictionary;
         if (dict == nullptr)
         {
-            EvalCacheTopLevelDictionary* evalTopDictionary = RecyclerNew(this->recycler, EvalCacheTopLevelDictionary, this->recycler);
+            EvalCacheTopLevelDictionary* evalTopDictionary = RecyclerNew(this->recycler, EvalCacheTopLevelDictionary, this->recycler->GetAllocator());
             dict = RecyclerNew(this->recycler, EvalCacheDictionary, evalTopDictionary, recycler);
             if (isIndirect)
             {
@@ -2221,7 +2221,7 @@ if (!sourceList)
     {
         if (this->cache->newFunctionCache == nullptr)
         {
-            this->cache->newFunctionCache = RecyclerNew(this->recycler, NewFunctionCache, this->recycler);
+            this->cache->newFunctionCache = RecyclerNew(this->recycler, NewFunctionCache, this->recycler->GetAllocator());
         }
         this->cache->newFunctionCache->Add(key, pFuncBody);
     }
@@ -2231,7 +2231,7 @@ if (!sourceList)
     {
         if (this->cache->sourceContextInfoMap == nullptr)
         {
-            this->cache->sourceContextInfoMap = RecyclerNew(this->GetRecycler(), SourceContextInfoMap, this->GetRecycler());
+            this->cache->sourceContextInfoMap = RecyclerNew(this->GetRecycler(), SourceContextInfoMap, this->GetRecycler()->GetAllocator());
         }
     }
 
@@ -2239,7 +2239,7 @@ if (!sourceList)
     {
         if (this->cache->dynamicSourceContextInfoMap == nullptr)
         {
-            this->cache->dynamicSourceContextInfoMap = RecyclerNew(this->GetRecycler(), DynamicSourceContextInfoMap, this->GetRecycler());
+            this->cache->dynamicSourceContextInfoMap = RecyclerNew(this->GetRecycler(), DynamicSourceContextInfoMap, this->GetRecycler()->GetAllocator());
         }
     }
 
@@ -4450,7 +4450,7 @@ void ScriptContext::RegisterPrototypeChainEnsuredToHaveOnlyWritableDataPropertie
             {
                 Assert(this->recycler);
 
-                builtInLibraryFunctions = RecyclerNew(this->recycler, BuiltInLibraryFunctionMap, this->recycler);
+                builtInLibraryFunctions = RecyclerNew(this->recycler, BuiltInLibraryFunctionMap, this->recycler->GetAllocator());
                 cache->builtInLibraryFunctions = builtInLibraryFunctions;
             }
 
@@ -5573,7 +5573,7 @@ void ScriptContext::RegisterPrototypeChainEnsuredToHaveOnlyWritableDataPropertie
     {
         if (cacheDataMap == NULL)
         {
-            cacheDataMap = RecyclerNew(this->recycler, CacheDataMap, this->recycler);
+            cacheDataMap = RecyclerNew(this->recycler, CacheDataMap, this->recycler->GetAllocator());
             BindReference(cacheDataMap);
         }
 
@@ -5676,7 +5676,7 @@ void ScriptContext::RegisterPrototypeChainEnsuredToHaveOnlyWritableDataPropertie
         if (!calleeUtf8SourceInfoList)
         {
             Recycler *recycler = this->GetRecycler();
-            calleeUtf8SourceInfoList.Root(RecyclerNew(recycler, CalleeSourceList, recycler), recycler);
+            calleeUtf8SourceInfoList.Root(RecyclerNew(recycler, CalleeSourceList, recycler->GetAllocator()), recycler);
         }
 
         if (!calleeUtf8SourceInfoList->Contains(sourceInfoWeakRef))

--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -319,14 +319,14 @@ namespace Js
     };
 
     static const unsigned int EvalMRUSize = 15;
-    typedef JsUtil::BaseDictionary<DWORD_PTR, SourceContextInfo *, Recycler, PowerOf2SizePolicy> SourceContextInfoMap;
-    typedef JsUtil::BaseDictionary<uint, SourceContextInfo *, Recycler, PowerOf2SizePolicy> DynamicSourceContextInfoMap;
+    typedef JsUtil::BaseDictionary<DWORD_PTR, SourceContextInfo *, RecyclerAllocator, PowerOf2SizePolicy> SourceContextInfoMap;
+    typedef JsUtil::BaseDictionary<uint, SourceContextInfo *, RecyclerAllocator, PowerOf2SizePolicy> DynamicSourceContextInfoMap;
 
-    typedef JsUtil::BaseDictionary<EvalMapString, ScriptFunction*, RecyclerNonLeafAllocator, PrimeSizePolicy> SecondLevelEvalCache;
+    typedef JsUtil::BaseDictionary<EvalMapString, ScriptFunction*, RecyclerAllocator, PrimeSizePolicy> SecondLevelEvalCache;
     typedef TwoLevelHashRecord<FastEvalMapString, ScriptFunction*, SecondLevelEvalCache, EvalMapString> EvalMapRecord;
-    typedef JsUtil::Cache<FastEvalMapString, EvalMapRecord*, RecyclerNonLeafAllocator, PrimeSizePolicy, JsUtil::MRURetentionPolicy<FastEvalMapString, EvalMRUSize>, FastEvalMapStringComparer> EvalCacheTopLevelDictionary;
-    typedef JsUtil::Cache<EvalMapString, ParseableFunctionInfo*, RecyclerNonLeafAllocator, PrimeSizePolicy, JsUtil::MRURetentionPolicy<EvalMapString, EvalMRUSize>> NewFunctionCache;
-    typedef JsUtil::BaseDictionary<ParseableFunctionInfo*, ParseableFunctionInfo*, Recycler, PrimeSizePolicy, RecyclerPointerComparer> ParseableFunctionInfoMap;
+    typedef JsUtil::Cache<FastEvalMapString, EvalMapRecord*, RecyclerAllocator, PrimeSizePolicy, JsUtil::MRURetentionPolicy<FastEvalMapString, EvalMRUSize>, FastEvalMapStringComparer> EvalCacheTopLevelDictionary;
+    typedef JsUtil::Cache<EvalMapString, ParseableFunctionInfo*, RecyclerAllocator, PrimeSizePolicy, JsUtil::MRURetentionPolicy<EvalMapString, EvalMRUSize>> NewFunctionCache;
+    typedef JsUtil::BaseDictionary<ParseableFunctionInfo*, ParseableFunctionInfo*, RecyclerAllocator, PrimeSizePolicy, RecyclerPointerComparer> ParseableFunctionInfoMap;
     // This is the dictionary used by script context to cache the eval.
     typedef TwoLevelHashDictionary<FastEvalMapString, ScriptFunction*, EvalMapRecord, EvalCacheTopLevelDictionary, EvalMapString> EvalCacheDictionary;
 
@@ -350,7 +350,7 @@ namespace Js
         Field(int) validPropStrings;
     };
 
-    typedef JsUtil::BaseDictionary<JavascriptMethod, JavascriptFunction*, Recycler, PowerOf2SizePolicy> BuiltInLibraryFunctionMap;
+    typedef JsUtil::BaseDictionary<JavascriptMethod, JavascriptFunction*, RecyclerAllocator, PowerOf2SizePolicy> BuiltInLibraryFunctionMap;
 
     // this is allocated in GC directly to avoid force pinning the object, it is linked from JavascriptLibrary such that it has
     // the same lifetime as JavascriptLibrary, and it can be collected without ScriptContext Close.
@@ -458,7 +458,7 @@ namespace Js
         bool IsScriptContextInSourceRundownOrDebugMode() const;
         bool IsRunningScript() const { return this->threadContext->GetScriptEntryExit() != nullptr; }
 
-        typedef JsUtil::List<RecyclerWeakReference<Utf8SourceInfo>*, Recycler, false, Js::WeakRefFreeListedRemovePolicy> CalleeSourceList;
+        typedef JsUtil::List<RecyclerWeakReference<Utf8SourceInfo>*, RecyclerAllocator, false, Js::WeakRefFreeListedRemovePolicy> CalleeSourceList;
         RecyclerRootPtr<CalleeSourceList> calleeUtf8SourceInfoList;
         void AddCalleeSourceInfoToList(Utf8SourceInfo* sourceInfo);
         bool HaveCalleeSources() { return calleeUtf8SourceInfoList && !calleeUtf8SourceInfoList->Empty(); }
@@ -693,14 +693,14 @@ public:
         };
 
         // This is a strongly referenced dictionary, since we want to know hit rates for dead caches.
-        typedef JsUtil::BaseDictionary<const Js::PolymorphicInlineCache*, CacheData*, Recycler> CacheDataMap;
+        typedef JsUtil::BaseDictionary<const Js::PolymorphicInlineCache*, CacheData*, RecyclerAllocator> CacheDataMap;
         CacheDataMap *cacheDataMap;
 
         void LogCacheUsage(Js::PolymorphicInlineCache *cache, bool isGet, Js::PropertyId propertyId, bool hit, bool collision);
 #endif
 
 #ifdef FIELD_ACCESS_STATS
-        typedef SList<FieldAccessStatsPtr, Recycler> FieldAccessStatsList;
+        typedef SList<FieldAccessStatsPtr, RecyclerAllocator> FieldAccessStatsList;
 
         struct FieldAccessStatsEntry
         {
@@ -708,10 +708,10 @@ public:
             Field(FieldAccessStatsList) stats;
 
             FieldAccessStatsEntry(RecyclerWeakReference<FunctionBody>* functionBodyWeakRef, Recycler* recycler)
-                : functionBodyWeakRef(functionBodyWeakRef), stats(recycler) {}
+                : functionBodyWeakRef(functionBodyWeakRef), stats(recycler->GetAllocator()) {}
         };
 
-        typedef JsUtil::BaseDictionary<uint, FieldAccessStatsEntry*, Recycler> FieldAccessStatsByFunctionNumberMap;
+        typedef JsUtil::BaseDictionary<uint, FieldAccessStatsEntry*, RecyclerAllocator> FieldAccessStatsByFunctionNumberMap;
 
         FieldAccessStatsByFunctionNumberMap* fieldAccessStatsByFunctionNumber;
 
@@ -818,7 +818,7 @@ private:
         size_t sourceSize;
 
         void CleanSourceListInternal(bool calledDuringMark);
-        typedef JsUtil::List<RecyclerWeakReference<Utf8SourceInfo>*, Recycler, false, Js::FreeListedRemovePolicy> SourceList;
+        typedef JsUtil::List<RecyclerWeakReference<Utf8SourceInfo>*, RecyclerAllocator, false, Js::FreeListedRemovePolicy> SourceList;
         RecyclerRootPtr<SourceList> sourceList;
 
 #ifdef ENABLE_SCRIPT_PROFILING

--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -85,7 +85,7 @@ ThreadContext::RecyclableData::RecyclableData(Recycler *const recycler) :
     soErrorObject(nullptr, nullptr, nullptr, true),
     oomErrorObject(nullptr, nullptr, nullptr, true),
     terminatedErrorObject(nullptr, nullptr, nullptr),
-    typesWithProtoPropertyCache(recycler),
+    typesWithProtoPropertyCache(recycler->GetAllocator()),
     propertyGuards(recycler, 128),
     oldEntryPointInfo(nullptr),
     returnedValueList(nullptr),
@@ -927,7 +927,7 @@ void ThreadContext::InitializePropertyMaps()
     try
     {
         this->propertyMap = HeapNew(PropertyMap, &HeapAllocator::Instance, TotalNumberOfBuiltInProperties + 700);
-        this->recyclableData->boundPropertyStrings = RecyclerNew(this->recycler, JsUtil::List<Js::PropertyRecord const*>, this->recycler);
+        this->recyclableData->boundPropertyStrings = RecyclerNew(this->recycler, JsUtil::List<Js::PropertyRecord const*>, this->recycler->GetAllocator());
 
         memset(propertyNamesDirect, 0, 128*sizeof(Js::PropertyRecord *));
 
@@ -1309,7 +1309,7 @@ Js::PropertyId ThreadContext::GetMaxPropertyId()
 void ThreadContext::CreateNoCasePropertyMap()
 {
     Assert(caseInvariantPropertySet == nullptr);
-    caseInvariantPropertySet = RecyclerNew(recycler, PropertyNoCaseSetType, recycler, 173);
+    caseInvariantPropertySet = RecyclerNew(recycler, PropertyNoCaseSetType, recycler->GetAllocator(), 173);
 
     // Prevent the set from being reclaimed
     // Individual items in the set can be reclaimed though since they're lists of weak references
@@ -3908,7 +3908,7 @@ void ThreadContext::EnsureSourceProfileManagersByUrlMap()
     if(this->recyclableData->sourceProfileManagersByUrl == nullptr)
     {
         this->EnsureRecycler();
-        this->recyclableData->sourceProfileManagersByUrl = RecyclerNew(GetRecycler(), SourceProfileManagersByUrlMap, GetRecycler());
+        this->recyclableData->sourceProfileManagersByUrl = RecyclerNew(GetRecycler(), SourceProfileManagersByUrlMap, GetRecycler()->GetAllocator());
     }
 }
 
@@ -3934,7 +3934,7 @@ Js::SourceDynamicProfileManager* ThreadContext::GetSourceDynamicProfileManager(_
       bool createProfileManager = false;
       if(!managerCache->sourceProfileManagerMap)
       {
-          managerCache->sourceProfileManagerMap = RecyclerNew(this->GetRecycler(), SourceDynamicProfileManagerMap, this->GetRecycler());
+          managerCache->sourceProfileManagerMap = RecyclerNew(this->GetRecycler(), SourceDynamicProfileManagerMap, this->GetRecycler()->GetAllocator());
           createProfileManager = true;
       }
       else
@@ -4001,7 +4001,7 @@ void ThreadContext::EnsureSymbolRegistrationMap()
     if (this->recyclableData->symbolRegistrationMap == nullptr)
     {
         this->EnsureRecycler();
-        this->recyclableData->symbolRegistrationMap = RecyclerNew(GetRecycler(), SymbolRegistrationMap, GetRecycler());
+        this->recyclableData->symbolRegistrationMap = RecyclerNew(GetRecycler(), SymbolRegistrationMap, GetRecycler()->GetAllocator());
     }
 }
 

--- a/lib/Runtime/Base/ThreadContext.h
+++ b/lib/Runtime/Base/ThreadContext.h
@@ -453,7 +453,7 @@ private:
     struct PropertyGuardEntry
     {
     public:
-        typedef JsUtil::BaseHashSet<RecyclerWeakReference<Js::PropertyGuard>*, Recycler, PowerOf2SizePolicy> PropertyGuardHashSet;
+        typedef JsUtil::BaseHashSet<RecyclerWeakReference<Js::PropertyGuard>*, RecyclerAllocator, PowerOf2SizePolicy> PropertyGuardHashSet;
         // we do not have WeaklyReferencedKeyHashSet - hence use BYTE as a dummy value.
         typedef JsUtil::WeaklyReferencedKeyDictionary<Js::EntryPointInfo, BYTE> EntryPointDictionary;
         // The sharedGuard is strongly referenced and will be kept alive by ThreadContext::propertyGuards until it's invalidated or
@@ -465,7 +465,7 @@ private:
         Field(PropertyGuardHashSet) uniqueGuards;
         Field(EntryPointDictionary*) entryPoints;
 
-        PropertyGuardEntry(Recycler* recycler) : sharedGuard(nullptr), uniqueGuards(recycler), entryPoints(nullptr) {}
+        PropertyGuardEntry(Recycler* recycler) : sharedGuard(nullptr), uniqueGuards(recycler->GetAllocator()), entryPoints(nullptr) {}
     };
 
 public:
@@ -475,10 +475,10 @@ public:
 
     typedef SListCounted<Js::PropertyId, HeapAllocator> PropertyList;
 
-    typedef JsUtil::BaseHashSet<Js::CaseInvariantPropertyListWithHashCode*, Recycler, PowerOf2SizePolicy, Js::CaseInvariantPropertyListWithHashCode*, JsUtil::NoCaseComparer, JsUtil::SimpleDictionaryEntry>
+    typedef JsUtil::BaseHashSet<Js::CaseInvariantPropertyListWithHashCode*, RecyclerAllocator, PowerOf2SizePolicy, Js::CaseInvariantPropertyListWithHashCode*, JsUtil::NoCaseComparer, JsUtil::SimpleDictionaryEntry>
         PropertyNoCaseSetType;
     typedef JsUtil::WeaklyReferencedKeyDictionary<Js::Type, bool> TypeHashSet;
-    typedef JsUtil::BaseDictionary<Js::PropertyId, TypeHashSet *, Recycler, PowerOf2SizePolicy> PropertyIdToTypeHashSetDictionary;
+    typedef JsUtil::BaseDictionary<Js::PropertyId, TypeHashSet *, RecyclerAllocator, PowerOf2SizePolicy> PropertyIdToTypeHashSetDictionary;
     typedef JsUtil::WeaklyReferencedKeyDictionary<const Js::PropertyRecord, PropertyGuardEntry*, Js::PropertyRecordPointerComparer> PropertyGuardDictionary;
 
 private:
@@ -511,8 +511,8 @@ public:
 #endif
 
 private:
-    typedef JsUtil::BaseDictionary<uint, Js::SourceDynamicProfileManager*, Recycler, PowerOf2SizePolicy> SourceDynamicProfileManagerMap;
-    typedef JsUtil::BaseDictionary<const char16*, const Js::PropertyRecord*, Recycler, PowerOf2SizePolicy> SymbolRegistrationMap;
+    typedef JsUtil::BaseDictionary<uint, Js::SourceDynamicProfileManager*, RecyclerAllocator, PowerOf2SizePolicy> SourceDynamicProfileManagerMap;
+    typedef JsUtil::BaseDictionary<const char16*, const Js::PropertyRecord*, RecyclerAllocator, PowerOf2SizePolicy> SymbolRegistrationMap;
 
     class SourceDynamicProfileManagerCache
     {
@@ -526,7 +526,7 @@ private:
         Field(uint) refCount;              // For every script context using this cache, there is a ref count added.
     };
 
-    typedef JsUtil::BaseDictionary<const WCHAR*, SourceDynamicProfileManagerCache*, Recycler, PowerOf2SizePolicy> SourceProfileManagersByUrlMap;
+    typedef JsUtil::BaseDictionary<const WCHAR*, SourceDynamicProfileManagerCache*, RecyclerAllocator, PowerOf2SizePolicy> SourceProfileManagersByUrlMap;
 
     struct RecyclableData
     {
@@ -581,7 +581,7 @@ private:
         Field(SourceProfileManagersByUrlMap*) sourceProfileManagersByUrl;
 
         // Used to register recyclable data that needs to be kept alive while jitting
-        typedef JsUtil::DoublyLinkedList<Js::CodeGenRecyclableData, Recycler> CodeGenRecyclableDataList;
+        typedef JsUtil::DoublyLinkedList<Js::CodeGenRecyclableData, RecyclerAllocator> CodeGenRecyclableDataList;
         Field(CodeGenRecyclableDataList) codeGenRecyclableDatas;
 
         // Used to root old entry points so that they're not prematurely collected

--- a/lib/Runtime/Base/Utf8SourceInfo.cpp
+++ b/lib/Runtime/Base/Utf8SourceInfo.cpp
@@ -150,14 +150,14 @@ namespace Js
             // This collection is allocated with leaf allocation policy. The references to the function body
             // here does not keep the function alive. However, the functions remove themselves at finalize
             // so if a function actually is in this map, it means that it is alive.
-            this->functionBodyDictionary = RecyclerNew(recycler, FunctionBodyDictionary, recycler,
+            this->functionBodyDictionary = RecyclerNew(recycler, FunctionBodyDictionary, recycler->GetAllocator(),
                 initialFunctionCount, threadContext->GetEtwRundownCriticalSection());
         }
 
         if (CONFIG_FLAG(DeferTopLevelTillFirstCall) && !m_deferredFunctionsInitialized)
         {
             Assert(this->m_deferredFunctionsDictionary == nullptr);
-            this->m_deferredFunctionsDictionary = RecyclerNew(recycler, DeferredFunctionsDictionary, recycler,
+            this->m_deferredFunctionsDictionary = RecyclerNew(recycler, DeferredFunctionsDictionary, recycler->GetAllocator(),
                 initialFunctionCount, threadContext->GetEtwRundownCriticalSection());
             m_deferredFunctionsInitialized = true;
         }
@@ -258,7 +258,7 @@ namespace Js
             int64 byteStartOffset = (sourceAfterBOM - sourceStart);
 
             Recycler* recycler = this->m_scriptContext->GetRecycler();
-            this->m_lineOffsetCache = RecyclerNew(recycler, JsUtil::LineOffsetCache<Recycler>, recycler, sourceAfterBOM, sourceEnd, startChar, (int)byteStartOffset);
+            this->m_lineOffsetCache = RecyclerNew(recycler, JsUtil::LineOffsetCache<RecyclerAllocator>, recycler->GetAllocator(), sourceAfterBOM, sourceEnd, startChar, (int)byteStartOffset);
         }
     }
 
@@ -312,11 +312,11 @@ namespace Js
         *outColumn = charPosition - lineCharOffset;
     }
 
-    void Utf8SourceInfo::CreateLineOffsetCache(const JsUtil::LineOffsetCache<Recycler>::LineOffsetCacheItem *items, charcount_t numberOfItems)
+    void Utf8SourceInfo::CreateLineOffsetCache(const JsUtil::LineOffsetCache<RecyclerAllocator>::LineOffsetCacheItem *items, charcount_t numberOfItems)
     {
         AssertMsg(this->m_lineOffsetCache == nullptr, "LineOffsetCache is already initialized!");
         Recycler* recycler = this->m_scriptContext->GetRecycler();
-        this->m_lineOffsetCache = RecyclerNew(recycler, JsUtil::LineOffsetCache<Recycler>, recycler, items, numberOfItems);
+        this->m_lineOffsetCache = RecyclerNew(recycler, JsUtil::LineOffsetCache<RecyclerAllocator>, recycler->GetAllocator(), items, numberOfItems);
     }
 
     DWORD_PTR Utf8SourceInfo::GetHostSourceContext() const

--- a/lib/Runtime/Base/Utf8SourceInfo.h
+++ b/lib/Runtime/Base/Utf8SourceInfo.h
@@ -9,8 +9,8 @@ namespace Js
     struct Utf8SourceInfo : public FinalizableObject
     {
         // TODO: Change this to LeafValueDictionary
-        typedef JsUtil::SynchronizedDictionary<Js::LocalFunctionId, Js::FunctionBody*, Recycler> FunctionBodyDictionary;
-        typedef JsUtil::SynchronizedDictionary<Js::LocalFunctionId, Js::ParseableFunctionInfo*, Recycler> DeferredFunctionsDictionary;
+        typedef JsUtil::SynchronizedDictionary<Js::LocalFunctionId, Js::FunctionBody*, RecyclerAllocator> FunctionBodyDictionary;
+        typedef JsUtil::SynchronizedDictionary<Js::LocalFunctionId, Js::ParseableFunctionInfo*, RecyclerAllocator> DeferredFunctionsDictionary;
 
         friend class RemoteUtf8SourceInfo;
         friend class ScriptContext;
@@ -294,14 +294,14 @@ namespace Js
             this->m_lineOffsetCache = nullptr;
         }
 
-        void CreateLineOffsetCache(const JsUtil::LineOffsetCache<Recycler>::LineOffsetCacheItem *items, charcount_t numberOfItems);
+        void CreateLineOffsetCache(const JsUtil::LineOffsetCache<RecyclerAllocator>::LineOffsetCacheItem *items, charcount_t numberOfItems);
 
         size_t GetLineCount()
         {
             return this->GetLineOffsetCache()->GetLineCount();
         }
 
-        JsUtil::LineOffsetCache<Recycler> *GetLineOffsetCache()
+        JsUtil::LineOffsetCache<RecyclerAllocator> *GetLineOffsetCache()
         {
             AssertMsg(this->m_lineOffsetCache != nullptr, "LineOffsetCache wasn't created, EnsureLineOffsetCache should have been called.");
             return m_lineOffsetCache;
@@ -371,7 +371,7 @@ namespace Js
         Field(ScriptContext* const) m_scriptContext;   // Pointer to ScriptContext under which this source info was created
 
         // Line offset cache used for quickly finding line/column offsets.
-        Field(JsUtil::LineOffsetCache<Recycler>*) m_lineOffsetCache;
+        Field(JsUtil::LineOffsetCache<RecyclerAllocator>*) m_lineOffsetCache;
 
         // Utf8SourceInfo of the caller, used for mapping eval/new Function node to its caller node for debugger
         Field(Utf8SourceInfo*) callerUtf8SourceInfo;

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.h
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.h
@@ -130,7 +130,7 @@ public:
         if (this->propertyRecords == nullptr)
         {
             Recycler* recycler = this->scriptContext->GetRecycler();
-            this->propertyRecords = RecyclerNew(recycler, Js::PropertyRecordList, recycler);
+            this->propertyRecords = RecyclerNew(recycler, Js::PropertyRecordList, recycler->GetAllocator());
         }
 
         return this->propertyRecords;

--- a/lib/Runtime/ByteCode/ByteCodeSerializer.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeSerializer.cpp
@@ -2232,7 +2232,7 @@ public:
     const byte * sourceSpans;
     int lineInfoCacheCount;
     const byte * lineInfoCaches;
-    const JsUtil::LineOffsetCache<Recycler>::LineOffsetCacheItem * lineInfoCache;
+    const JsUtil::LineOffsetCache<RecyclerAllocator>::LineOffsetCacheItem * lineInfoCache;
     const byte * functions;
     int sourceSize;
     int sourceCharLength;
@@ -2708,7 +2708,7 @@ public:
 
         // Read strings header
         string16IndexTable = (StringIndexRecord*)ReadInt32(string16s, &string16Count);
-        lineInfoCache = (JsUtil::LineOffsetCache<Recycler>::LineOffsetCacheItem *)ReadInt32(lineInfoCaches, &lineInfoCacheCount);
+        lineInfoCache = (JsUtil::LineOffsetCache<RecyclerAllocator>::LineOffsetCacheItem *)ReadInt32(lineInfoCaches, &lineInfoCacheCount);
 
         string16Table = (byte*)(string16IndexTable + string16Count + 1);
 

--- a/lib/Runtime/Debug/DebugContext.cpp
+++ b/lib/Runtime/Debug/DebugContext.cpp
@@ -124,7 +124,7 @@ namespace Js
 
         Js::TempArenaAllocatorObject *tempAllocator = nullptr;
         JsUtil::List<Js::FunctionBody *, ArenaAllocator>* pFunctionsToRegister = nullptr;
-        JsUtil::List<Js::Utf8SourceInfo *, Recycler, false, Js::CopyRemovePolicy, RecyclerPointerComparer>* utf8SourceInfoList = nullptr;
+        JsUtil::List<Js::Utf8SourceInfo *, RecyclerAllocator, false, Js::CopyRemovePolicy, RecyclerPointerComparer>* utf8SourceInfoList = nullptr;
 
         HRESULT hr = S_OK;
         ThreadContext* threadContext = this->scriptContext->GetThreadContext();
@@ -133,7 +133,7 @@ namespace Js
         tempAllocator = threadContext->GetTemporaryAllocator(_u("debuggerAlloc"));
 
         pFunctionsToRegister = JsUtil::List<Js::FunctionBody*, ArenaAllocator>::New(tempAllocator->GetAllocator());
-        utf8SourceInfoList = JsUtil::List<Js::Utf8SourceInfo *, Recycler, false, Js::CopyRemovePolicy, RecyclerPointerComparer>::New(this->scriptContext->GetRecycler());
+        utf8SourceInfoList = JsUtil::List<Js::Utf8SourceInfo *, RecyclerAllocator, false, Js::CopyRemovePolicy, RecyclerPointerComparer>::New(this->scriptContext->GetRecycler()->GetAllocator());
 
         this->MapUTF8SourceInfoUntil([&](Js::Utf8SourceInfo * sourceInfo) -> bool
         {
@@ -374,7 +374,7 @@ namespace Js
     }
 
     // Create an ordered flat list of sources to reparse. Caller of a source should be added to the list before we add the source itself.
-    void DebugContext::WalkAndAddUtf8SourceInfo(Js::Utf8SourceInfo* sourceInfo, JsUtil::List<Js::Utf8SourceInfo *, Recycler, false, Js::CopyRemovePolicy, RecyclerPointerComparer> *utf8SourceInfoList)
+    void DebugContext::WalkAndAddUtf8SourceInfo(Js::Utf8SourceInfo* sourceInfo, JsUtil::List<Js::Utf8SourceInfo *, RecyclerAllocator, false, Js::CopyRemovePolicy, RecyclerPointerComparer> *utf8SourceInfoList)
     {
         Js::Utf8SourceInfo* callerUtf8SourceInfo = sourceInfo->GetCallerUtf8SourceInfo();
         if (callerUtf8SourceInfo)

--- a/lib/Runtime/Debug/DebugContext.h
+++ b/lib/Runtime/Debug/DebugContext.h
@@ -79,7 +79,7 @@ namespace Js
 
         // Private Functions
         void FetchTopLevelFunction(JsUtil::List<Js::FunctionBody *, ArenaAllocator>* pFunctions, Js::Utf8SourceInfo * sourceInfo);
-        void WalkAndAddUtf8SourceInfo(Js::Utf8SourceInfo* sourceInfo, JsUtil::List<Js::Utf8SourceInfo *, Recycler, false, Js::CopyRemovePolicy, RecyclerPointerComparer> *utf8SourceInfoList);
+        void WalkAndAddUtf8SourceInfo(Js::Utf8SourceInfo* sourceInfo, JsUtil::List<Js::Utf8SourceInfo *, RecyclerAllocator, false, Js::CopyRemovePolicy, RecyclerPointerComparer> *utf8SourceInfoList);
         bool CanRegisterFunction() const;
         void RegisterFunction(Js::FunctionBody * functionBody, DWORD_PTR dwDebugSourceContext, LPCWSTR title);
 

--- a/lib/Runtime/Debug/DiagProbe.cpp
+++ b/lib/Runtime/Debug/DiagProbe.cpp
@@ -108,7 +108,7 @@ namespace Js
 
         if (this->returnedValueList == nullptr)
         {
-            this->returnedValueList = JsUtil::List<ReturnedValue*>::New(this->pActivatedContext->GetRecycler());
+            this->returnedValueList = JsUtil::List<ReturnedValue*>::New(this->pActivatedContext->GetRecycler()->GetAllocator());
             this->pActivatedContext->GetThreadContext()->SetReturnedValueList(this->returnedValueList);
         }
     }

--- a/lib/Runtime/Debug/MutationBreakpoint.h
+++ b/lib/Runtime/Debug/MutationBreakpoint.h
@@ -50,7 +50,7 @@ namespace Js
         Var newValue;
         PropertyId parentPropertyId;
         const PropertyRecord *propertyRecord;
-        typedef JsUtil::List<PropertyMutation, Recycler> PropertyMutationList;
+        typedef JsUtil::List<PropertyMutation, RecyclerAllocator> PropertyMutationList;
         PropertyMutationList *properties;
         MutationBreakpointDelegate *mutationBreakpointDelegate;
         MutationType breakMutationType;

--- a/lib/Runtime/Debug/ProbeContainer.cpp
+++ b/lib/Runtime/Debug/ProbeContainer.cpp
@@ -68,7 +68,7 @@ namespace Js
 
             this->pScriptContext = pScriptContext;
             this->debugManager = this->pScriptContext->GetThreadContext()->GetDebugManager();
-            this->pinnedPropertyRecords = JsUtil::List<const Js::PropertyRecord*>::New(this->pScriptContext->GetRecycler());
+            this->pinnedPropertyRecords = JsUtil::List<const Js::PropertyRecord*>::New(this->pScriptContext->GetRecycler()->GetAllocator());
             this->pScriptContext->BindReference((void *)this->pinnedPropertyRecords);
         }
     }

--- a/lib/Runtime/Debug/ProbeContainer.h
+++ b/lib/Runtime/Debug/ProbeContainer.h
@@ -179,7 +179,7 @@ namespace Js
         DebugManager *GetDebugManager() const { return this->debugManager; }
 
 #ifdef ENABLE_MUTATION_BREAKPOINT
-        typedef JsUtil::List<RecyclerWeakReference<Js::MutationBreakpoint>*, Recycler, false, Js::WeakRefFreeListedRemovePolicy> MutationBreakpointList;
+        typedef JsUtil::List<RecyclerWeakReference<Js::MutationBreakpoint>*, RecyclerAllocator, false, Js::WeakRefFreeListedRemovePolicy> MutationBreakpointList;
         RecyclerRootPtr<MutationBreakpointList> mutationBreakpointList;
         bool HasMutationBreakpoints();
         void InsertMutationBreakpoint(MutationBreakpoint *mutationBreakpoint);

--- a/lib/Runtime/Debug/TTEventLog.cpp
+++ b/lib/Runtime/Debug/TTEventLog.cpp
@@ -456,7 +456,7 @@ namespace TTD
 
         if(this->m_propertyRecordPinSet != nullptr)
         {
-            this->m_propertyRecordPinSet.Unroot(this->m_propertyRecordPinSet->GetAllocator());
+            this->m_propertyRecordPinSet.Unroot(this->m_propertyRecordPinSet->GetAllocator()->GetRecycler());
         }
     }
 
@@ -642,7 +642,7 @@ namespace TTD
         this->m_modeStack.Push(TTDMode::Invalid);
 
         Recycler * recycler = threadContext->GetRecycler();
-        this->m_propertyRecordPinSet.Root(RecyclerNew(recycler, PropertyRecordPinSet, recycler), recycler);
+        this->m_propertyRecordPinSet.Root(RecyclerNew(recycler, PropertyRecordPinSet, recycler->GetAllocator()), recycler);
     }
 
     EventLog::~EventLog()

--- a/lib/Runtime/Debug/TTInflateMap.cpp
+++ b/lib/Runtime/Debug/TTInflateMap.cpp
@@ -22,22 +22,22 @@ namespace TTD
     {
         if(this->m_inflatePinSet != nullptr)
         {
-            this->m_inflatePinSet.Unroot(this->m_inflatePinSet->GetAllocator());
+            this->m_inflatePinSet.Unroot(this->m_inflatePinSet->GetAllocator()->GetRecycler());
         }
 
         if(this->m_environmentPinSet != nullptr)
         {
-            this->m_environmentPinSet.Unroot(this->m_environmentPinSet->GetAllocator());
+            this->m_environmentPinSet.Unroot(this->m_environmentPinSet->GetAllocator()->GetRecycler());
         }
 
         if(this->m_slotArrayPinSet != nullptr)
         {
-            this->m_slotArrayPinSet.Unroot(this->m_slotArrayPinSet->GetAllocator());
+            this->m_slotArrayPinSet.Unroot(this->m_slotArrayPinSet->GetAllocator()->GetRecycler());
         }
 
         if(this->m_oldInflatePinSet != nullptr)
         {
-            this->m_oldInflatePinSet.Unroot(this->m_oldInflatePinSet->GetAllocator());
+            this->m_oldInflatePinSet.Unroot(this->m_oldInflatePinSet->GetAllocator()->GetRecycler());
         }
     }
 
@@ -55,9 +55,9 @@ namespace TTD
         this->m_promiseDataMap.Clear();
 
         Recycler * recycler = threadContext->GetRecycler();
-        this->m_inflatePinSet.Root(RecyclerNew(recycler, ObjectPinSet, recycler, objectCount), recycler);
-        this->m_environmentPinSet.Root(RecyclerNew(recycler, EnvironmentPinSet, recycler, objectCount), recycler);
-        this->m_slotArrayPinSet.Root(RecyclerNew(recycler, SlotArrayPinSet, recycler, objectCount), recycler);
+        this->m_inflatePinSet.Root(RecyclerNew(recycler, ObjectPinSet, recycler->GetAllocator(), objectCount), recycler);
+        this->m_environmentPinSet.Root(RecyclerNew(recycler, EnvironmentPinSet, recycler->GetAllocator(), objectCount), recycler);
+        this->m_slotArrayPinSet.Root(RecyclerNew(recycler, SlotArrayPinSet, recycler->GetAllocator(), objectCount), recycler);
     }
 
     void InflateMap::PrepForReInflate(uint32 ctxCount, uint32 handlerCount, uint32 typeCount, uint32 objectCount, uint32 bodyCount, uint32 dbgScopeCount, uint32 envCount, uint32 slotCount)
@@ -81,8 +81,8 @@ namespace TTD
 
         //allocate the old pin set and fill it
         AssertMsg(this->m_oldInflatePinSet == nullptr, "Old pin set is not null.");
-        Recycler* pinRecycler = this->m_inflatePinSet->GetAllocator();
-        this->m_oldInflatePinSet.Root(RecyclerNew(pinRecycler, ObjectPinSet, pinRecycler, this->m_inflatePinSet->Count()), pinRecycler);
+        Recycler* pinRecycler = this->m_inflatePinSet->GetAllocator()->GetRecycler();
+        this->m_oldInflatePinSet.Root(RecyclerNew(pinRecycler, ObjectPinSet, pinRecycler->GetAllocator(), this->m_inflatePinSet->Count()), pinRecycler);
 
         for(auto iter = this->m_inflatePinSet->GetIterator(); iter.IsValid(); iter.MoveNext())
         {
@@ -115,7 +115,7 @@ namespace TTD
 
         if(this->m_oldInflatePinSet != nullptr)
         {
-            this->m_oldInflatePinSet.Unroot(this->m_oldInflatePinSet->GetAllocator());
+            this->m_oldInflatePinSet.Unroot(this->m_oldInflatePinSet->GetAllocator()->GetRecycler());
         }
     }
 

--- a/lib/Runtime/Debug/TTRuntmeInfoTracker.cpp
+++ b/lib/Runtime/Debug/TTRuntmeInfoTracker.cpp
@@ -50,8 +50,8 @@ namespace TTD
 
         Recycler* tctxRecycler = this->m_threadCtx->GetRecycler();
 
-        this->m_ttdRootSet.Root(RecyclerNew(tctxRecycler, TTD::ObjectPinSet, tctxRecycler), tctxRecycler);
-        this->m_ttdLocalRootSet.Root(RecyclerNew(tctxRecycler, TTD::ObjectPinSet, tctxRecycler), tctxRecycler);
+        this->m_ttdRootSet.Root(RecyclerNew(tctxRecycler, TTD::ObjectPinSet, tctxRecycler->GetAllocator()), tctxRecycler);
+        this->m_ttdLocalRootSet.Root(RecyclerNew(tctxRecycler, TTD::ObjectPinSet, tctxRecycler->GetAllocator()), tctxRecycler);
     }
 
     ThreadContextTTD::~ThreadContextTTD()
@@ -68,12 +68,12 @@ namespace TTD
 
         if(this->m_ttdRootSet != nullptr)
         {
-            this->m_ttdRootSet.Unroot(this->m_ttdRootSet->GetAllocator());
+            this->m_ttdRootSet.Unroot(this->m_ttdRootSet->GetAllocator()->GetRecycler());
         }
 
         if(this->m_ttdLocalRootSet != nullptr)
         {
-            this->m_ttdLocalRootSet.Unroot(this->m_ttdLocalRootSet->GetAllocator());
+            this->m_ttdLocalRootSet.Unroot(this->m_ttdLocalRootSet->GetAllocator()->GetRecycler());
         }
 
         this->m_ttdRootTagIdMap.Clear();
@@ -347,8 +347,8 @@ namespace TTD
     {
         Recycler* ctxRecycler = this->m_ctx->GetRecycler();
 
-        this->m_ttdPinnedRootFunctionSet.Root(RecyclerNew(ctxRecycler, TTD::FunctionBodyPinSet, ctxRecycler), ctxRecycler);
-        this->TTDWeakReferencePinSet.Root(RecyclerNew(ctxRecycler, TTD::ObjectPinSet, ctxRecycler), ctxRecycler);
+        this->m_ttdPinnedRootFunctionSet.Root(RecyclerNew(ctxRecycler, TTD::FunctionBodyPinSet, ctxRecycler->GetAllocator()), ctxRecycler);
+        this->TTDWeakReferencePinSet.Root(RecyclerNew(ctxRecycler, TTD::ObjectPinSet, ctxRecycler->GetAllocator()), ctxRecycler);
     }
 
     ScriptContextTTD::~ScriptContextTTD()
@@ -361,14 +361,14 @@ namespace TTD
 
         if(this->m_ttdPinnedRootFunctionSet != nullptr)
         {
-            this->m_ttdPinnedRootFunctionSet.Unroot(this->m_ttdPinnedRootFunctionSet->GetAllocator());
+            this->m_ttdPinnedRootFunctionSet.Unroot(this->m_ttdPinnedRootFunctionSet->GetAllocator()->GetRecycler());
         }
 
         this->m_ttdFunctionBodyParentMap.Clear();
 
         if(this->TTDWeakReferencePinSet != nullptr)
         {
-            this->TTDWeakReferencePinSet.Unroot(this->TTDWeakReferencePinSet->GetAllocator());
+            this->TTDWeakReferencePinSet.Unroot(this->TTDWeakReferencePinSet->GetAllocator()->GetRecycler());
         }
     }
 

--- a/lib/Runtime/Language/AsmJsModule.cpp
+++ b/lib/Runtime/Language/AsmJsModule.cpp
@@ -2543,7 +2543,7 @@ namespace Js
     {
         Assert(mSlotMap == nullptr);
         mSlotsCount = val;
-        mSlotMap = RecyclerNew(mRecycler, AsmJsSlotMap, mRecycler);
+        mSlotMap = RecyclerNew(mRecycler, AsmJsSlotMap, mRecycler->GetAllocator());
     }
 
     void AsmJsModuleInfo::SetFunctionTableSize( int index, uint size )

--- a/lib/Runtime/Language/AsmJsModule.h
+++ b/lib/Runtime/Language/AsmJsModule.h
@@ -386,7 +386,7 @@ namespace Js {
             RegSlot* moduleFunctionIndex;
         };
 
-        typedef JsUtil::BaseDictionary<PropertyId, AsmJsSlot*, Memory::Recycler> AsmJsSlotMap;
+        typedef JsUtil::BaseDictionary<PropertyId, AsmJsSlot*, Memory::RecyclerAllocator> AsmJsSlotMap;
 
     private:
         FieldNoBarrier(Recycler*) mRecycler;

--- a/lib/Runtime/Language/AsmJsTypes.cpp
+++ b/lib/Runtime/Language/AsmJsTypes.cpp
@@ -940,7 +940,7 @@ namespace Js
         mArgSizes = RecyclerNewArrayLeafZ(recycler, uint, mArgSizesLength);
 
         mReturnType = func->GetReturnType();
-        mbyteCodeTJMap = RecyclerNew(recycler, ByteCodeToTJMap,recycler);
+        mbyteCodeTJMap = RecyclerNew(recycler, ByteCodeToTJMap,recycler->GetAllocator());
 
         for(ArgSlot i = 0; i < GetArgCount(); i++)
         {

--- a/lib/Runtime/Language/AsmJsTypes.h
+++ b/lib/Runtime/Language/AsmJsTypes.h
@@ -896,7 +896,7 @@ namespace Js
                               mArgType(nullptr),
                               mArgSizes(nullptr) {}
         // the key is the bytecode address
-        typedef JsUtil::BaseDictionary<int, ptrdiff_t, Recycler> ByteCodeToTJMap;
+        typedef JsUtil::BaseDictionary<int, ptrdiff_t, RecyclerAllocator> ByteCodeToTJMap;
         Field(ByteCodeToTJMap*) mbyteCodeTJMap;
         Field(BYTE*) mTJBeginAddress;
         WAsmJs::TypedSlotInfo* GetTypedSlotInfo(WAsmJs::Types type);

--- a/lib/Runtime/Language/CodeGenRecyclableData.h
+++ b/lib/Runtime/Language/CodeGenRecyclableData.h
@@ -9,7 +9,7 @@ namespace Js
     class FunctionCodeGenJitTimeData;
 
     // Keeps data relevant to a function body that is needed for jitting the function, alive until jitting is complete
-    class CodeGenRecyclableData sealed : public JsUtil::DoublyLinkedListElement<CodeGenRecyclableData, Recycler>
+    class CodeGenRecyclableData sealed : public JsUtil::DoublyLinkedListElement<CodeGenRecyclableData, RecyclerAllocator>
     {
     private:
         Field(const FunctionCodeGenJitTimeData *) const jitTimeData;

--- a/lib/Runtime/Language/DynamicProfileInfo.cpp
+++ b/lib/Runtime/Language/DynamicProfileInfo.cpp
@@ -712,7 +712,7 @@ namespace Js
                 else
                 {
                     // For call across files find the function from the right source
-                    typedef JsUtil::List<RecyclerWeakReference<Utf8SourceInfo>*, Recycler, false, Js::FreeListedRemovePolicy> SourceList;
+                    typedef JsUtil::List<RecyclerWeakReference<Utf8SourceInfo>*, RecyclerAllocator, false, Js::FreeListedRemovePolicy> SourceList;
                     SourceList * sourceList = functionBody->GetScriptContext()->GetSourceList();
                     bool found = false;
                     for (int j = 0; j < sourceList->Count() && !found; j++)
@@ -786,7 +786,7 @@ namespace Js
             if (sourceId != NoSourceId && sourceId != InvalidSourceId)
             {
                 // For call across files find the function from the right source
-                JsUtil::List<RecyclerWeakReference<Utf8SourceInfo>*, Recycler, false, Js::FreeListedRemovePolicy> * sourceList = functionBody->GetScriptContext()->GetSourceList();
+                JsUtil::List<RecyclerWeakReference<Utf8SourceInfo>*, RecyclerAllocator, false, Js::FreeListedRemovePolicy> * sourceList = functionBody->GetScriptContext()->GetSourceList();
                 for (int i = 0; i < sourceList->Count(); i++)
                 {
                     if (sourceList->IsItemValid(i))

--- a/lib/Runtime/Language/EvalMapRecord.h
+++ b/lib/Runtime/Language/EvalMapRecord.h
@@ -78,7 +78,7 @@ namespace Js
         void ConvertToDictionary(TKey& key, Recycler* recycler)
         {
             Assert(singleValue);
-            SecondaryDictionary* dictionary = RecyclerNew(recycler, SecondaryDictionary, recycler);
+            SecondaryDictionary* dictionary = RecyclerNew(recycler, SecondaryDictionary, recycler->GetAllocator());
             auto newValue = value;
             nestedMap = dictionary;
             singleValue = false;

--- a/lib/Runtime/Language/FunctionCodeGenJitTimeData.cpp
+++ b/lib/Runtime/Language/FunctionCodeGenJitTimeData.cpp
@@ -91,7 +91,7 @@ namespace Js
 
         if (!inlinees)
         {
-            inlinees = RecyclerNewArrayZ(recycler, Field(FunctionCodeGenJitTimeData *), functionBody->GetProfiledCallSiteCount());
+            inlinees = RecyclerNewArrayZ(recycler, FunctionCodeGenJitTimeDataPtr, functionBody->GetProfiledCallSiteCount());
         }
 
         FunctionCodeGenJitTimeData *inlineeData = nullptr;
@@ -127,7 +127,7 @@ namespace Js
 
         if (!ldFldInlinees)
         {
-            ldFldInlinees = RecyclerNewArrayZ(recycler, Field(FunctionCodeGenJitTimeData*), GetFunctionBody()->GetInlineCacheCount());
+            ldFldInlinees = RecyclerNewArrayZ(recycler, FunctionCodeGenJitTimeDataPtr, GetFunctionBody()->GetInlineCacheCount());
         }
 
         const auto inlineeData = RecyclerNew(recycler, FunctionCodeGenJitTimeData, inlinee, nullptr);

--- a/lib/Runtime/Language/FunctionCodeGenJitTimeData.h
+++ b/lib/Runtime/Language/FunctionCodeGenJitTimeData.h
@@ -15,6 +15,8 @@ namespace Js
     //     - Also keeps the function body and inlinee function bodies alive while jitting.
     class FunctionCodeGenJitTimeData
     {
+    public:
+        typedef Field(FunctionCodeGenJitTimeData*) FunctionCodeGenJitTimeDataPtr;
     private:
         Field(FunctionInfo *) const functionInfo;
 
@@ -161,7 +163,7 @@ namespace Js
         {
             if (!inlinees)
             {
-                inlinees = RecyclerNewArrayZ(recycler, Field(FunctionCodeGenJitTimeData *), GetFunctionBody()->GetProfiledCallSiteCount());
+                inlinees = RecyclerNewArrayZ(recycler, FunctionCodeGenJitTimeDataPtr, GetFunctionBody()->GetProfiledCallSiteCount());
             }
             inlinees[profiledCallSiteId] = this;
             inlineeCount++;

--- a/lib/Runtime/Language/JavascriptExceptionOperators.cpp
+++ b/lib/Runtime/Language/JavascriptExceptionOperators.cpp
@@ -686,7 +686,7 @@ namespace Js
         HRESULT hr;
         BEGIN_TRANSLATE_EXCEPTION_AND_ERROROBJECT_TO_HRESULT_NESTED
         {
-            stackTrace = RecyclerNew(scriptContext.GetRecycler(), JavascriptExceptionContext::StackTrace, scriptContext.GetRecycler());
+            stackTrace = RecyclerNew(scriptContext.GetRecycler(), JavascriptExceptionContext::StackTrace, scriptContext.GetRecycler()->GetAllocator());
             if (stackCrawlLimit > 0)
             {
                 const bool crawlStackForWER = CrawlStackForWER(scriptContext);
@@ -940,7 +940,7 @@ namespace Js
             HRESULT hr;
             BEGIN_TRANSLATE_EXCEPTION_AND_ERROROBJECT_TO_HRESULT_NESTED
             {
-                stackTraceTrimmed = RecyclerNew(scriptContext.GetRecycler(), JavascriptExceptionContext::StackTrace, scriptContext.GetRecycler());
+                stackTraceTrimmed = RecyclerNew(scriptContext.GetRecycler(), JavascriptExceptionContext::StackTrace, scriptContext.GetRecycler()->GetAllocator());
                 for (int i = 0; i < stackTraceLimit; i++)
                 {
                     stackTraceTrimmed->Add(stackTraceIn->Item(i));

--- a/lib/Runtime/Language/ModuleNamespace.cpp
+++ b/lib/Runtime/Language/ModuleNamespace.cpp
@@ -66,7 +66,7 @@ namespace Js
         // like {export foo as foo1, foo2, foo3}, and external properties as reexport from current module. The problem with aliasing
         // is that multiple propertyId can be associated with one slotIndex. We need to build from PropertyMap directly here.
         // there is one instance of ModuleNamespace per module file; we can always use the BigPropertyIndex for security.
-        propertyMap = RecyclerNew(recycler, SimplePropertyDescriptorMap, recycler, sourceTextModuleRecord->GetLocalExportCount());
+        propertyMap = RecyclerNew(recycler, SimplePropertyDescriptorMap, recycler->GetAllocator(), sourceTextModuleRecord->GetLocalExportCount());
         if (localExportList != nullptr)
         {
             localExportList->Map([=](ModuleImportOrExportEntry exportEntry) {
@@ -139,7 +139,7 @@ namespace Js
         Recycler* recycler = GetScriptContext()->GetRecycler();
         if (unambiguousNonLocalExports == nullptr)
         {
-            unambiguousNonLocalExports = RecyclerNew(recycler, UnambiguousExportMap, recycler, 4);
+            unambiguousNonLocalExports = RecyclerNew(recycler, UnambiguousExportMap, recycler->GetLeafAllocator(), 4);
         }
         // keep a local copy of the module/
         unambiguousNonLocalExports->AddNew(propertyId, *nonLocalExportNameRecord);
@@ -318,7 +318,7 @@ namespace Js
         {
             ExportedNames* exportedNames = moduleRecord->GetExportedNames(nullptr);
             ScriptContext* scriptContext = GetScriptContext();
-            sortedExportedNames = ListForListIterator::New(scriptContext->GetRecycler());
+            sortedExportedNames = ListForListIterator::New(scriptContext->GetRecycler()->GetAllocator());
             exportedNames->Map([&](PropertyId propertyId) {
                 JavascriptString* propertyString = scriptContext->GetPropertyString(propertyId);
                 sortedExportedNames->Add(propertyString);

--- a/lib/Runtime/Language/ModuleNamespace.h
+++ b/lib/Runtime/Language/ModuleNamespace.h
@@ -11,7 +11,7 @@ namespace Js
     public:
         friend class ModuleNamespaceEnumerator;
         typedef JsUtil::BaseDictionary<PropertyId, ModuleNameRecord, RecyclerLeafAllocator, PowerOf2SizePolicy> UnambiguousExportMap;
-        typedef JsUtil::BaseDictionary<const PropertyRecord*, SimpleDictionaryPropertyDescriptor<BigPropertyIndex>, RecyclerNonLeafAllocator,
+        typedef JsUtil::BaseDictionary<const PropertyRecord*, SimpleDictionaryPropertyDescriptor<BigPropertyIndex>, RecyclerAllocator,
             DictionarySizePolicy<PowerOf2Policy, 1>, PropertyRecordStringHashComparer, PropertyMapKeyTraits<const PropertyRecord*>::template Entry>
             SimplePropertyDescriptorMap;
     protected:

--- a/lib/Runtime/Language/ObjTypeSpecFldInfo.cpp
+++ b/lib/Runtime/Language/ObjTypeSpecFldInfo.cpp
@@ -789,7 +789,7 @@ namespace Js
             return;
         }
 
-        this->infoArray = RecyclerNewArrayZ(recycler, Field(ObjTypeSpecFldInfo*), functionBody->GetInlineCacheCount());
+        this->infoArray = RecyclerNewArrayZ(recycler, ObjTypeSpecFldInfo::ObjTypeSpecFldInfoPtr, functionBody->GetInlineCacheCount());
 #if DBG
         this->infoCount = functionBody->GetInlineCacheCount();
 #endif

--- a/lib/Runtime/Language/ObjTypeSpecFldInfo.h
+++ b/lib/Runtime/Language/ObjTypeSpecFldInfo.h
@@ -69,6 +69,7 @@ namespace Js
         Field(uint16) fixedFieldCount; // currently used only for fields that are functions
 
     public:
+        typedef Field(ObjTypeSpecFldInfo*) ObjTypeSpecFldInfoPtr;
         ObjTypeSpecFldInfo() :
             id(0), typeId(TypeIds_Limit), typeSet(nullptr), initialType(nullptr), flags(InitialObjTypeSpecFldInfoFlagValue),
             slotIndex(Constants::NoSlot), propertyId(Constants::NoProperty), protoObject(nullptr), propertyGuard(nullptr),

--- a/lib/Runtime/Language/SourceDynamicProfileManager.h
+++ b/lib/Runtime/Language/SourceDynamicProfileManager.h
@@ -21,7 +21,8 @@ namespace Js
     class SourceDynamicProfileManager
     {
     public:
-        SourceDynamicProfileManager(Recycler* allocator) : isNonCachableScript(false), cachedStartupFunctions(nullptr), recycler(allocator), dynamicProfileInfoMap(allocator), startupFunctions(nullptr), profileDataCache(nullptr) {}
+        SourceDynamicProfileManager(Recycler* allocator) : isNonCachableScript(false), cachedStartupFunctions(nullptr), 
+            recycler(allocator), dynamicProfileInfoMap(allocator->GetAllocator()), startupFunctions(nullptr), profileDataCache(nullptr) {}
 
         ExecutionFlags IsFunctionExecuted(Js::LocalFunctionId functionId);
         DynamicProfileInfo * GetDynamicProfileInfo(FunctionBody * functionBody);
@@ -61,8 +62,7 @@ namespace Js
         Field(BVFixed*) startupFunctions;                   // Bit vector representing functions that are executed at startup
         Field(BVFixed const *) cachedStartupFunctions;      // Bit vector representing functions executed at startup that are loaded from a persistent or in-memory cache
                                                             // It's not modified but used as an input for deferred parsing/bytecodegen
-        typedef JsUtil::BaseDictionary<LocalFunctionId, DynamicProfileInfo *, Recycler, PowerOf2SizePolicy>
-            DynamicProfileInfoMapType;
+        typedef JsUtil::BaseDictionary<LocalFunctionId, DynamicProfileInfo *, RecyclerAllocator, PowerOf2SizePolicy> DynamicProfileInfoMapType;
         Field(DynamicProfileInfoMapType) dynamicProfileInfoMap;
 
         static const uint MAX_FUNCTION_COUNT = 10000;  // Consider data corrupt if there are more functions than this

--- a/lib/Runtime/Language/SourceTextModuleRecord.cpp
+++ b/lib/Runtime/Language/SourceTextModuleRecord.cpp
@@ -581,7 +581,7 @@ namespace Js
                     childrenModuleSet->AddNew(moduleName, moduleRecord);
                     if (moduleRecord->parentModuleList == nullptr)
                     {
-                        moduleRecord->parentModuleList = RecyclerNew(recycler, ModuleRecordList, recycler);
+                        moduleRecord->parentModuleList = RecyclerNew(recycler, ModuleRecordList, recycler->GetAllocator());
                     }
                     moduleRecord->parentModuleList->Add(this);
                     if (!moduleRecord->WasDeclarationInitialized())

--- a/lib/Runtime/Library/ArgumentsObject.cpp
+++ b/lib/Runtime/Library/ArgumentsObject.cpp
@@ -229,7 +229,7 @@ namespace Js
             if (this->deletedArgs == nullptr)
             {
                 Recycler *recycler = GetScriptContext()->GetRecycler();
-                deletedArgs = RecyclerNew(recycler, BVSparse<Recycler>, recycler);
+                deletedArgs = RecyclerNew(recycler, BVSparse<RecyclerAllocator>, recycler->GetAllocator());
             }
 
             if (!this->deletedArgs->Test(index))

--- a/lib/Runtime/Library/ArgumentsObject.h
+++ b/lib/Runtime/Library/ArgumentsObject.h
@@ -63,7 +63,7 @@ namespace Js
     protected:
         Field(uint32)              formalCount;
         Field(ActivationObject*)   frameObject;
-        Field(BVSparse<Recycler>*) deletedArgs;
+        Field(BVSparse<RecyclerAllocator>*) deletedArgs;
 
     public:
         HeapArgumentsObject(DynamicType * type);

--- a/lib/Runtime/Library/ArrayBuffer.cpp
+++ b/lib/Runtime/Library/ArrayBuffer.cpp
@@ -114,7 +114,7 @@ namespace Js
         {
             if (this->otherParents == nullptr)
             {
-                this->otherParents = JsUtil::List<RecyclerWeakReference<ArrayBufferParent>*>::New(this->GetRecycler());
+                this->otherParents = JsUtil::List<RecyclerWeakReference<ArrayBufferParent>*>::New(this->GetRecycler()->GetAllocator());
             }
             this->otherParents->Add(this->GetRecycler()->CreateWeakReferenceHandle(parent));
         }

--- a/lib/Runtime/Library/ArrayBuffer.h
+++ b/lib/Runtime/Library/ArrayBuffer.h
@@ -150,7 +150,7 @@ namespace Js
         Field(JsUtil::List<RecyclerWeakReference<ArrayBufferParent>*>*) otherParents;
 
 
-        Field(BYTE  *) buffer;             // Points to a heap allocated RGBA buffer, can be null
+        FieldNoBarrier(BYTE*) buffer;             // Points to a heap allocated RGBA buffer, can be null
         Field(uint32) bufferLength;       // Number of bytes allocated
 
         // When an ArrayBuffer is detached, the TypedArray and DataView objects pointing to it must be made aware,

--- a/lib/Runtime/Library/ConcatString.cpp
+++ b/lib/Runtime/Library/ConcatString.cpp
@@ -194,8 +194,8 @@ namespace Js
             if (newSlotCount <= c_maxChunkSlotCount)
             {
                 // While we fit into MAX chunk size, realloc/grow current chunk.
-                Field(JavascriptString*)* newSlots = RecyclerNewArray(
-                    this->GetScriptContext()->GetRecycler(), Field(JavascriptString*), newSlotCount);
+                JavascriptStringPtr* newSlots = RecyclerNewArray(
+                    this->GetScriptContext()->GetRecycler(), JavascriptStringPtr, newSlotCount);
                 CopyArray(newSlots, newSlotCount, m_slots, m_slotCount);
                 m_slots = newSlots;
                 m_slotCount = newSlotCount;
@@ -227,7 +227,7 @@ namespace Js
         if (requestedSlotCount > 0)
         {
             m_slotCount = min(requestedSlotCount, this->c_maxChunkSlotCount);
-            m_slots = RecyclerNewArray(this->GetScriptContext()->GetRecycler(), Field(JavascriptString*), m_slotCount);
+            m_slots = RecyclerNewArray(this->GetScriptContext()->GetRecycler(), JavascriptStringPtr, m_slotCount);
         }
         else
         {

--- a/lib/Runtime/Library/ConcatString.h
+++ b/lib/Runtime/Library/ConcatString.h
@@ -120,6 +120,7 @@ namespace Js
         virtual void CopyVirtual(_Out_writes_(m_charLength) char16 *const buffer, StringCopyInfoStack &nestedStringTreeCopyInfos, const byte recursionDepth) override sealed;
 
     public:
+        typedef Field(JavascriptString*) JavascriptStringPtr;
         static ConcatStringBuilder* New(ScriptContext* scriptContext, int initialSlotCount);
         const char16 * GetSz() override sealed;
         void Append(JavascriptString* str);

--- a/lib/Runtime/Library/ForInObjectEnumerator.cpp
+++ b/lib/Runtime/Library/ForInObjectEnumerator.cpp
@@ -9,7 +9,7 @@
 namespace Js
 {
     ForInObjectEnumerator::ShadowData::ShadowData(RecyclableObject * initObject, RecyclableObject * firstPrototype, Recycler * recycler)
-        : currentObject(initObject), firstPrototype(firstPrototype), propertyIds(recycler)
+        : currentObject(initObject), firstPrototype(firstPrototype), propertyIds(recycler->GetAllocator())
     {
 
     }
@@ -174,7 +174,7 @@ namespace Js
                         // We keep the track of what is enumerated using a bit vector of propertyID.
                         // so the propertyId can't be collected until the end of the for in enumerator
                         // Keep a list of the property string.
-                        this->shadowData->newPropertyStrings.Prepend(GetScriptContext()->GetRecycler(), propRecord);
+                        this->shadowData->newPropertyStrings.Prepend(GetScriptContext()->GetRecycler()->GetAllocator(), propRecord);
                     }
                 }
 

--- a/lib/Runtime/Library/ForInObjectEnumerator.h
+++ b/lib/Runtime/Library/ForInObjectEnumerator.h
@@ -16,8 +16,8 @@ namespace Js
 
             Field(RecyclableObject *) currentObject;
             Field(RecyclableObject *) firstPrototype;
-            Field(BVSparse<Recycler>) propertyIds;
-            typedef SListBase<Js::PropertyRecord const *, Recycler> _PropertyStringsListType;
+            Field(BVSparse<RecyclerAllocator>) propertyIds;
+            typedef SListBase<Js::PropertyRecord const *, RecyclerAllocator> _PropertyStringsListType;
             Field(_PropertyStringsListType) newPropertyStrings;
         } *shadowData;
 

--- a/lib/Runtime/Library/GlobalObject.cpp
+++ b/lib/Runtime/Library/GlobalObject.cpp
@@ -124,7 +124,7 @@ namespace Js
         if (reservedProperties == nullptr)
         {
             Recycler* recycler = this->GetScriptContext()->GetRecycler();
-            reservedProperties = RecyclerNew(recycler, ReservedPropertiesHashSet, recycler, 3);
+            reservedProperties = RecyclerNew(recycler, ReservedPropertiesHashSet, recycler->GetAllocator(), 3);
         }
         reservedProperties->AddNew(propertyId);
         return true;
@@ -247,7 +247,7 @@ namespace Js
         // Note: the typedefs below help make the following code more readable
 
         // See: Js::ScriptContext::SourceList (declaration not visible from this file)
-        typedef JsUtil::List<RecyclerWeakReference<Utf8SourceInfo>*, Recycler, false, Js::FreeListedRemovePolicy> SourceList;
+        typedef JsUtil::List<RecyclerWeakReference<Utf8SourceInfo>*, RecyclerAllocator, false, Js::FreeListedRemovePolicy> SourceList;
         typedef RecyclerWeakReference<Js::Utf8SourceInfo> Utf8SourceInfoRef;
 
         ScriptContext *originalScriptContext = function->GetScriptContext();

--- a/lib/Runtime/Library/GlobalObject.h
+++ b/lib/Runtime/Library/GlobalObject.h
@@ -164,7 +164,7 @@ namespace Js
         Field(RecyclableObject*) directHostObject;
         Field(RecyclableObject*) secureDirectHostObject;
 
-        typedef JsUtil::BaseHashSet<PropertyId, Recycler, PowerOf2SizePolicy> ReservedPropertiesHashSet;
+        typedef JsUtil::BaseHashSet<PropertyId, RecyclerAllocator, PowerOf2SizePolicy> ReservedPropertiesHashSet;
         Field(ReservedPropertiesHashSet *) reservedProperties;
 
 #if ENABLE_TTD

--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -75,7 +75,7 @@ namespace Js
         this->recycler = scriptContext->GetRecycler();
         this->undeclBlockVarSentinel = RecyclerNew(recycler, UndeclaredBlockVariable, StaticType::New(scriptContext, TypeIds_Null, nullptr, nullptr));
 
-        typesEnsuredToHaveOnlyWritableDataPropertiesInItAndPrototypeChain = RecyclerNew(recycler, JsUtil::List<Type *>, recycler);
+        typesEnsuredToHaveOnlyWritableDataPropertiesInItAndPrototypeChain = RecyclerNew(recycler, JsUtil::List<Type *>, recycler->GetAllocator());
 
         // Library is not zero-initialized. memset the memory occupied by builtinFunctions array to 0.
         ClearArray(builtinFunctions, BuiltinFunction::Count);
@@ -5370,7 +5370,7 @@ namespace Js
     {
         if (this->stringTemplateCallsiteObjectList == nullptr)
         {
-            this->stringTemplateCallsiteObjectList = RecyclerNew(GetRecycler(), StringTemplateCallsiteObjectList, GetRecycler());
+            this->stringTemplateCallsiteObjectList = RecyclerNew(GetRecycler(), StringTemplateCallsiteObjectList, GetRecycler()->GetAllocator());
         }
     }
 
@@ -6884,7 +6884,7 @@ namespace Js
     {
         if (moduleRecordList == nullptr)
         {
-            moduleRecordList = RecyclerNew(recycler, ModuleRecordList, recycler);
+            moduleRecordList = RecyclerNew(recycler, ModuleRecordList, recycler->GetAllocator());
         }
         return moduleRecordList;
     }
@@ -6904,8 +6904,9 @@ namespace Js
         // The last void* is the linklist connecting to next block.
         if (bindRefChunkCurrent == bindRefChunkEnd)
         {
-            Field(void*)* tmpBindRefChunk = RecyclerNewArrayZ(recycler,
-                Field(void*), HeapConstants::ObjectGranularity / sizeof(void *));
+            typedef Field(void*) voidPtr;
+            voidPtr* tmpBindRefChunk = RecyclerNewArrayZ(recycler,
+                voidPtr, HeapConstants::ObjectGranularity / sizeof(void *));
             // reserve the last void* as the linklist node.
             bindRefChunkEnd = tmpBindRefChunk + (HeapConstants::ObjectGranularity / sizeof(void *) -1 );
             if (bindRefChunkBegin == nullptr)
@@ -6935,7 +6936,7 @@ namespace Js
     {
         if (this->dynamicFunctionReference == nullptr)
         {
-            this->dynamicFunctionReference = RecyclerNew(this->recycler, FunctionReferenceList, this->recycler);
+            this->dynamicFunctionReference = RecyclerNew(this->recycler, FunctionReferenceList, this->recycler->GetAllocator());
             this->BindReference(this->dynamicFunctionReference);
             this->dynamicFunctionReferenceDepth = 0;
         }

--- a/lib/Runtime/Library/JavascriptLibrary.h
+++ b/lib/Runtime/Library/JavascriptLibrary.h
@@ -33,7 +33,7 @@ namespace Js
     class ArrayBufferBase;
     class SharedContents;
     typedef RecyclerFastAllocator<JavascriptNumber, LeafBit> RecyclerJavascriptNumberAllocator;
-    typedef JsUtil::List<Var, Recycler> ListForListIterator;
+    typedef JsUtil::List<Var, RecyclerAllocator> ListForListIterator;
 
     class UndeclaredBlockVariable : public RecyclableObject
     {
@@ -446,7 +446,7 @@ namespace Js
         FieldNoBarrier(PromiseContinuationCallback) nativeHostPromiseContinuationFunction;
         Field(void *) nativeHostPromiseContinuationFunctionState;
 
-        typedef SList<Js::FunctionProxy*, Recycler> FunctionReferenceList;
+        typedef SList<Js::FunctionProxy*, RecyclerAllocator> FunctionReferenceList;
 
         Field(void *) bindRefChunkBegin;
         Field(Field(void*)*) bindRefChunkCurrent;
@@ -457,7 +457,7 @@ namespace Js
         Field(uint) dynamicFunctionReferenceDepth;
         Field(FinalizableObject*) jsrtContextObject;
 
-        typedef JsUtil::BaseHashSet<RecyclerWeakReference<RecyclableObject>*, Recycler, PowerOf2SizePolicy, RecyclerWeakReference<RecyclableObject>*, StringTemplateCallsiteObjectComparer> StringTemplateCallsiteObjectList;
+        typedef JsUtil::BaseHashSet<RecyclerWeakReference<RecyclableObject>*, RecyclerAllocator, PowerOf2SizePolicy, RecyclerWeakReference<RecyclableObject>*, StringTemplateCallsiteObjectComparer> StringTemplateCallsiteObjectList;
 
         // Used to store a list of template callsite objects.
         // We use the raw strings in the callsite object (or a string template parse node) to identify unique callsite objects in the list.
@@ -1312,7 +1312,7 @@ namespace Js
         void DumpLibraryByteCode();
 #endif
     private:
-        typedef JsUtil::BaseHashSet<Js::PropertyRecord const *, Recycler, PowerOf2SizePolicy> ReferencedPropertyRecordHashSet;
+        typedef JsUtil::BaseHashSet<Js::PropertyRecord const *, RecyclerAllocator, PowerOf2SizePolicy> ReferencedPropertyRecordHashSet;
         Field(ReferencedPropertyRecordHashSet*) referencedPropertyRecords;
 
         ReferencedPropertyRecordHashSet * EnsureReferencedPropertyRecordList()
@@ -1320,7 +1320,7 @@ namespace Js
             ReferencedPropertyRecordHashSet* pidList = this->referencedPropertyRecords;
             if (pidList == nullptr)
             {
-                pidList = RecyclerNew(this->recycler, ReferencedPropertyRecordHashSet, this->recycler, 173);
+                pidList = RecyclerNew(this->recycler, ReferencedPropertyRecordHashSet, this->recycler->GetAllocator(), 173);
                 this->referencedPropertyRecords = pidList;
             }
             return pidList;

--- a/lib/Runtime/Library/JavascriptMap.cpp
+++ b/lib/Runtime/Library/JavascriptMap.cpp
@@ -14,7 +14,7 @@ namespace Js
     JavascriptMap* JavascriptMap::New(ScriptContext* scriptContext)
     {
         JavascriptMap* map = scriptContext->GetLibrary()->CreateMap();
-        map->map = RecyclerNew(scriptContext->GetRecycler(), MapDataMap, scriptContext->GetRecycler());
+        map->map = RecyclerNew(scriptContext->GetRecycler(), MapDataMap, scriptContext->GetRecycler()->GetAllocator());
 
         return map;
     }
@@ -83,7 +83,7 @@ namespace Js
             JavascriptError::ThrowTypeErrorVar(scriptContext, JSERR_ObjectIsAlreadyInitialized, _u("Map"), _u("Map"));
         }
 
-        mapObject->map = RecyclerNew(scriptContext->GetRecycler(), MapDataMap, scriptContext->GetRecycler());
+        mapObject->map = RecyclerNew(scriptContext->GetRecycler(), MapDataMap, scriptContext->GetRecycler()->GetAllocator());
 
         if (iter != nullptr)
         {
@@ -450,7 +450,7 @@ namespace Js
     JavascriptMap* JavascriptMap::CreateForSnapshotRestore(ScriptContext* ctx)
     {
         JavascriptMap* res = ctx->GetLibrary()->CreateMap();
-        res->map = RecyclerNew(ctx->GetRecycler(), MapDataMap, ctx->GetRecycler());
+        res->map = RecyclerNew(ctx->GetRecycler(), MapDataMap, ctx->GetRecycler()->GetAllocator());
 
         return res;
     }

--- a/lib/Runtime/Library/JavascriptMap.h
+++ b/lib/Runtime/Library/JavascriptMap.h
@@ -12,7 +12,7 @@ namespace Js
         typedef JsUtil::KeyValuePair<Var, Var> MapDataKeyValuePair;
         typedef MapOrSetDataNode<MapDataKeyValuePair> MapDataNode;
         typedef MapOrSetDataList<MapDataKeyValuePair> MapDataList;
-        typedef JsUtil::BaseDictionary<Var, MapDataNode*, Recycler, PowerOf2SizePolicy, SameValueZeroComparer> MapDataMap;
+        typedef JsUtil::BaseDictionary<Var, MapDataNode*, RecyclerAllocator, PowerOf2SizePolicy, SameValueZeroComparer> MapDataMap;
 
     private:
         Field(MapDataList) list;

--- a/lib/Runtime/Library/JavascriptPromise.cpp
+++ b/lib/Runtime/Library/JavascriptPromise.cpp
@@ -105,8 +105,8 @@ namespace Js
 
         promise->status = PromiseStatusCode_Unresolved;
 
-        promise->resolveReactions = RecyclerNew(recycler, JavascriptPromiseReactionList, recycler);
-        promise->rejectReactions = RecyclerNew(recycler, JavascriptPromiseReactionList, recycler);
+        promise->resolveReactions = RecyclerNew(recycler, JavascriptPromiseReactionList, recycler->GetAllocator());
+        promise->rejectReactions = RecyclerNew(recycler, JavascriptPromiseReactionList, recycler->GetAllocator());
 
         JavascriptPromiseResolveOrRejectFunctionAlreadyResolvedWrapper* alreadyResolvedRecord = RecyclerNewStructZ(scriptContext->GetRecycler(), JavascriptPromiseResolveOrRejectFunctionAlreadyResolvedWrapper);
         alreadyResolvedRecord->alreadyResolved = false;
@@ -1213,10 +1213,10 @@ namespace Js
         promise->status = (PromiseStatus)status;
         promise->result = result;
 
-        promise->resolveReactions = RecyclerNew(recycler, JavascriptPromiseReactionList, recycler);
+        promise->resolveReactions = RecyclerNew(recycler, JavascriptPromiseReactionList, recycler->GetAllocator());
         promise->resolveReactions->Copy(&resolveReactions);
 
-        promise->rejectReactions = RecyclerNew(recycler, JavascriptPromiseReactionList, recycler);
+        promise->rejectReactions = RecyclerNew(recycler, JavascriptPromiseReactionList, recycler->GetAllocator());
         promise->rejectReactions->Copy(&rejectReactions);
 
         return promise;

--- a/lib/Runtime/Library/JavascriptProxy.cpp
+++ b/lib/Runtime/Library/JavascriptProxy.cpp
@@ -911,7 +911,7 @@ namespace Js
         Var propertyName = nullptr;
         PropertyId propertyId;
         int index = 0;
-        JsUtil::BaseDictionary<const char16*, Var, Recycler> dict(requestContext->GetRecycler());
+        JsUtil::BaseDictionary<const char16*, Var, RecyclerAllocator> dict(requestContext->GetRecycler()->GetAllocator());
         JavascriptArray* arrResult = requestContext->GetLibrary()->CreateArray();
 
         // 13.7.5.15 EnumerateObjectProperties(O) (https://tc39.github.io/ecma262/#sec-enumerate-object-properties)

--- a/lib/Runtime/Library/JavascriptSet.cpp
+++ b/lib/Runtime/Library/JavascriptSet.cpp
@@ -14,7 +14,7 @@ namespace Js
     JavascriptSet* JavascriptSet::New(ScriptContext* scriptContext)
     {
         JavascriptSet* set = scriptContext->GetLibrary()->CreateSet();
-        set->set = RecyclerNew(scriptContext->GetRecycler(), SetDataSet, scriptContext->GetRecycler());
+        set->set = RecyclerNew(scriptContext->GetRecycler(), SetDataSet, scriptContext->GetRecycler()->GetAllocator());
 
         return set;
     }
@@ -84,7 +84,7 @@ namespace Js
         }
 
 
-        setObject->set = RecyclerNew(scriptContext->GetRecycler(), SetDataSet, scriptContext->GetRecycler());
+        setObject->set = RecyclerNew(scriptContext->GetRecycler(), SetDataSet, scriptContext->GetRecycler()->GetAllocator());
 
         if (iter != nullptr)
         {
@@ -371,7 +371,7 @@ namespace Js
     JavascriptSet* JavascriptSet::CreateForSnapshotRestore(ScriptContext* ctx)
     {
         JavascriptSet* res = ctx->GetLibrary()->CreateSet();
-        res->set = RecyclerNew(ctx->GetRecycler(), SetDataSet, ctx->GetRecycler());
+        res->set = RecyclerNew(ctx->GetRecycler(), SetDataSet, ctx->GetRecycler()->GetAllocator());
 
         return res;
     }

--- a/lib/Runtime/Library/JavascriptSet.h
+++ b/lib/Runtime/Library/JavascriptSet.h
@@ -11,7 +11,7 @@ namespace Js
     public:
         typedef MapOrSetDataNode<Var> SetDataNode;
         typedef MapOrSetDataList<Var> SetDataList;
-        typedef JsUtil::BaseDictionary<Var, SetDataNode*, Recycler, PowerOf2SizePolicy, SameValueZeroComparer> SetDataSet;
+        typedef JsUtil::BaseDictionary<Var, SetDataNode*, RecyclerAllocator, PowerOf2SizePolicy, SameValueZeroComparer> SetDataSet;
 
     private:
         Field(SetDataList) list;

--- a/lib/Runtime/Library/JavascriptWeakMap.cpp
+++ b/lib/Runtime/Library/JavascriptWeakMap.cpp
@@ -42,7 +42,7 @@ namespace Js
         DebugOnly(Var unused = nullptr);
         Assert(!key->GetInternalProperty(key, InternalPropertyIds::WeakMapKeyMap, &unused, nullptr, key->GetScriptContext()) || unused == nullptr);
 
-        WeakMapKeyMap* weakMapKeyData = RecyclerNew(GetScriptContext()->GetRecycler(), WeakMapKeyMap, GetScriptContext()->GetRecycler());
+        WeakMapKeyMap* weakMapKeyData = RecyclerNew(GetScriptContext()->GetRecycler(), WeakMapKeyMap, GetScriptContext()->GetRecycler()->GetAllocator());
         BOOL success = key->SetInternalProperty(InternalPropertyIds::WeakMapKeyMap, weakMapKeyData, PropertyOperation_Force, nullptr);
         Assert(success);
 

--- a/lib/Runtime/Library/JavascriptWeakMap.h
+++ b/lib/Runtime/Library/JavascriptWeakMap.h
@@ -41,7 +41,7 @@ namespace Js
         // to add and remove InternalPropertyIds from an object without affecting
         // its type and therefore without invalidating cache and JIT assumptions.
         //
-        typedef JsUtil::BaseDictionary<WeakMapId, Var, Recycler, PowerOf2SizePolicy, RecyclerPointerComparer> WeakMapKeyMap;
+        typedef JsUtil::BaseDictionary<WeakMapId, Var, RecyclerAllocator, PowerOf2SizePolicy, RecyclerPointerComparer> WeakMapKeyMap;
         typedef JsUtil::WeaklyReferencedKeyDictionary<DynamicObject, bool, RecyclerPointerComparer<const DynamicObject*>> KeySet;
 
         Field(KeySet) keySet;

--- a/lib/Runtime/Library/RegexHelper.cpp
+++ b/lib/Runtime/Library/RegexHelper.cpp
@@ -934,7 +934,7 @@ namespace Js
 
         Recycler* recycler = scriptContext->GetRecycler();
 
-        JsUtil::List<RecyclableObject*>* results = RecyclerNew(recycler, JsUtil::List<RecyclableObject*>, recycler);
+        JsUtil::List<RecyclableObject*>* results = RecyclerNew(recycler, JsUtil::List<RecyclableObject*>, recycler->GetAllocator());
 
         while (true)
         {

--- a/lib/Runtime/Library/RootObjectBase.cpp
+++ b/lib/Runtime/Library/RootObjectBase.cpp
@@ -67,7 +67,7 @@ namespace Js
         if (inlineCacheMap == nullptr)
         {
             Recycler * recycler = this->GetLibrary()->GetRecycler();
-            inlineCacheMap = RecyclerNew(recycler, RootObjectInlineCacheMap, recycler);
+            inlineCacheMap = RecyclerNew(recycler, RootObjectInlineCacheMap, recycler->GetAllocator());
             if (isStore)
             {
                 this->storeInlineCacheMap = inlineCacheMap;

--- a/lib/Runtime/Library/RootObjectBase.h
+++ b/lib/Runtime/Library/RootObjectBase.h
@@ -67,7 +67,7 @@ namespace Js
 
         Field(HostObjectBase *) hostObject;
 
-        typedef JsUtil::BaseDictionary<PropertyRecord const *, RootObjectInlineCache *, Recycler> RootObjectInlineCacheMap;
+        typedef JsUtil::BaseDictionary<PropertyRecord const *, RootObjectInlineCache *, RecyclerAllocator> RootObjectInlineCacheMap;
         Field(RootObjectInlineCacheMap *) loadInlineCacheMap;
         Field(RootObjectInlineCacheMap *) loadMethodInlineCacheMap;
         Field(RootObjectInlineCacheMap *) storeInlineCacheMap;

--- a/lib/Runtime/Library/WebAssemblyModule.cpp
+++ b/lib/Runtime/Library/WebAssemblyModule.cpp
@@ -35,7 +35,7 @@ WebAssemblyModule::WebAssemblyModule(Js::ScriptContext* scriptContext, const byt
 {
     //the first elm is the number of Vars in front of I32; makes for a nicer offset computation
     memset(globalCounts, 0, sizeof(uint) * Wasm::WasmTypes::Limit);
-    m_functionsInfo = RecyclerNew(scriptContext->GetRecycler(), WasmFunctionInfosList, scriptContext->GetRecycler());
+    m_functionsInfo = RecyclerNew(scriptContext->GetRecycler(), WasmFunctionInfosList, scriptContext->GetRecycler()->GetAllocator());
     m_imports = Anew(&m_alloc, WasmImportsList, &m_alloc);
     globals = Anew(&m_alloc, WasmGlobalsList, &m_alloc);
     m_reader = Anew(&m_alloc, Wasm::WasmBinaryReader, &m_alloc, this, binaryBuffer, binaryBufferLength);

--- a/lib/Runtime/Library/WebAssemblyModule.h
+++ b/lib/Runtime/Library/WebAssemblyModule.h
@@ -155,7 +155,7 @@ private:
     Wasm::WasmSignature* m_signatures;
     uint32* m_indirectfuncs;
     Wasm::WasmElementSegment** m_elementsegs;
-    typedef JsUtil::List<Wasm::WasmFunctionInfo*, Recycler> WasmFunctionInfosList;
+    typedef JsUtil::List<Wasm::WasmFunctionInfo*, RecyclerAllocator> WasmFunctionInfosList;
     WasmFunctionInfosList* m_functionsInfo;
     Wasm::WasmExport* m_exports;
     typedef JsUtil::List<Wasm::WasmImport*, ArenaAllocator> WasmImportsList;

--- a/lib/Runtime/Runtime.h
+++ b/lib/Runtime/Runtime.h
@@ -328,11 +328,11 @@ namespace Js
 namespace TTD
 {
     //typedef for a pin set (ensure that objects are kept live).
-    typedef JsUtil::BaseHashSet<Js::PropertyRecord*, Recycler> PropertyRecordPinSet;
-    typedef JsUtil::BaseHashSet<Js::FunctionBody*, Recycler> FunctionBodyPinSet;
-    typedef JsUtil::BaseHashSet<Js::RecyclableObject*, Recycler> ObjectPinSet;
-    typedef JsUtil::BaseHashSet<Js::FrameDisplay*, Recycler> EnvironmentPinSet;
-    typedef JsUtil::BaseHashSet<Js::Var, Recycler> SlotArrayPinSet;
+    typedef JsUtil::BaseHashSet<Js::PropertyRecord*, RecyclerAllocator> PropertyRecordPinSet;
+    typedef JsUtil::BaseHashSet<Js::FunctionBody*, RecyclerAllocator> FunctionBodyPinSet;
+    typedef JsUtil::BaseHashSet<Js::RecyclableObject*, RecyclerAllocator> ObjectPinSet;
+    typedef JsUtil::BaseHashSet<Js::FrameDisplay*, RecyclerAllocator> EnvironmentPinSet;
+    typedef JsUtil::BaseHashSet<Js::Var, RecyclerAllocator> SlotArrayPinSet;
 }
 
 #include "PlatformAgnostic/ChakraPlatform.h"

--- a/lib/Runtime/Types/DictionaryTypeHandler.cpp
+++ b/lib/Runtime/Types/DictionaryTypeHandler.cpp
@@ -32,7 +32,7 @@ namespace Js
         singletonInstance(nullptr)
     {
         SetIsInlineSlotCapacityLocked();
-        propertyMap = RecyclerNew(recycler, PropertyDescriptorMap, recycler, this->GetSlotCapacity());
+        propertyMap = RecyclerNew(recycler, PropertyDescriptorMap, recycler->GetAllocator(), this->GetSlotCapacity());
     }
 
     template <typename T>
@@ -44,7 +44,7 @@ namespace Js
     {
         SetIsInlineSlotCapacityLocked();
         Assert(GetSlotCapacity() <= MaxPropertyIndexSize);
-        propertyMap = RecyclerNew(recycler, PropertyDescriptorMap, recycler, slotCapacity);
+        propertyMap = RecyclerNew(recycler, PropertyDescriptorMap, recycler->GetAllocator(), slotCapacity);
     }
 
     //

--- a/lib/Runtime/Types/DictionaryTypeHandler.h
+++ b/lib/Runtime/Types/DictionaryTypeHandler.h
@@ -23,7 +23,7 @@ namespace Js
         template <typename T> friend class DictionaryTypeHandlerBase;
 
         // Explicit non leaf allocator as the key is non-leaf
-        typedef JsUtil::BaseDictionary<const PropertyRecord*, DictionaryPropertyDescriptor<T>, RecyclerNonLeafAllocator, DictionarySizePolicy<PowerOf2Policy, 1>, PropertyRecordStringHashComparer>
+        typedef JsUtil::BaseDictionary<const PropertyRecord*, DictionaryPropertyDescriptor<T>, RecyclerAllocator, DictionarySizePolicy<PowerOf2Policy, 1>, PropertyRecordStringHashComparer>
             PropertyDescriptorMap;
         typedef PropertyDescriptorMap PropertyDescriptorMapType; // alias used by diagnostics
 

--- a/lib/Runtime/Types/DynamicType.cpp
+++ b/lib/Runtime/Types/DynamicType.cpp
@@ -80,7 +80,8 @@ namespace Js
         int inlineSlotCapacity = GetTypeHandler()->GetInlineSlotCapacity();
         if (slotCapacity > inlineSlotCapacity)
         {
-            instance->auxSlots = RecyclerNewArrayZ(recycler, Field(Var), slotCapacity - inlineSlotCapacity);
+            typedef Field(Var) VarType;
+            instance->auxSlots = RecyclerNewArrayZ(recycler, VarType, slotCapacity - inlineSlotCapacity);
         }
     }
 

--- a/lib/Runtime/Types/ES5ArrayTypeHandler.cpp
+++ b/lib/Runtime/Types/ES5ArrayTypeHandler.cpp
@@ -11,7 +11,7 @@ namespace Js
     IndexPropertyDescriptorMap::IndexPropertyDescriptorMap(Recycler* recycler)
         : recycler(recycler), indexList(NULL), lastIndexAt(-1)
     {
-        indexPropertyMap = RecyclerNew(recycler, InnerMap, recycler);
+        indexPropertyMap = RecyclerNew(recycler, InnerMap, recycler->GetAllocator());
     }
 
     void IndexPropertyDescriptorMap::Add(uint32 key, const IndexPropertyDescriptor& value)

--- a/lib/Runtime/Types/ES5ArrayTypeHandler.h
+++ b/lib/Runtime/Types/ES5ArrayTypeHandler.h
@@ -33,7 +33,7 @@ namespace Js
     {
     private:
         // Note: IndexPropertyDescriptor contains references. We need to allocate entries as non-leaf node.
-        typedef JsUtil::BaseDictionary<uint32, IndexPropertyDescriptor, ForceNonLeafAllocator<Recycler>::AllocatorType, PowerOf2SizePolicy>
+        typedef JsUtil::BaseDictionary<uint32, IndexPropertyDescriptor, RecyclerAllocator, PowerOf2SizePolicy>
             InnerMap;
 
         Field(Recycler*) recycler;

--- a/lib/Runtime/Types/PathTypeHandler.cpp
+++ b/lib/Runtime/Types/PathTypeHandler.cpp
@@ -1592,7 +1592,7 @@ namespace Js
             {
                 if (oldTypeToPromotedTypeMap == nullptr)
                 {
-                    oldTypeToPromotedTypeMap = RecyclerNew(instance->GetRecycler(), TypeTransitionMap, instance->GetRecycler(), 2);
+                    oldTypeToPromotedTypeMap = RecyclerNew(instance->GetRecycler(), TypeTransitionMap, instance->GetRecycler()->GetAllocator(), 2);
                     newPrototype->SetInternalProperty(Js::InternalPropertyIds::TypeOfPrototypeObjectDictionary, (Var)oldTypeToPromotedTypeMap, PropertyOperationFlags::PropertyOperation_Force, nullptr);
                 }
 

--- a/lib/Runtime/Types/PathTypeHandler.h
+++ b/lib/Runtime/Types/PathTypeHandler.h
@@ -19,7 +19,7 @@ namespace Js
 
     public:
         DEFINE_GETCPPNAME();
-        typedef JsUtil::BaseDictionary<uintptr_t, DynamicType *, Recycler, PowerOf2SizePolicy> TypeTransitionMap;
+        typedef JsUtil::BaseDictionary<uintptr_t, DynamicType *, RecyclerAllocator, PowerOf2SizePolicy> TypeTransitionMap;
 
     protected:
         PathTypeHandlerBase(TypePath* typePath, uint16 pathLength, const PropertyIndex slotCapacity, uint16 inlineSlotCapacity, uint16 offsetOfInlineSlots, bool isLocked = false, bool isShared = false, DynamicType* predecessorType = nullptr);

--- a/lib/Runtime/Types/SimpleDictionaryTypeHandler.cpp
+++ b/lib/Runtime/Types/SimpleDictionaryTypeHandler.cpp
@@ -266,7 +266,7 @@ namespace Js
         numDeletedProperties(0)
     {
         SetIsInlineSlotCapacityLocked();
-        propertyMap = RecyclerNew(recycler, SimplePropertyDescriptorMap, recycler, this->GetSlotCapacity());
+        propertyMap = RecyclerNew(recycler, SimplePropertyDescriptorMap, recycler->GetAllocator(), this->GetSlotCapacity());
     }
 
     template <typename TPropertyIndex, typename TMapKey, bool IsNotExtensibleSupported>
@@ -281,7 +281,7 @@ namespace Js
     {
         SetIsInlineSlotCapacityLocked();
         Assert(slotCapacity <= MaxPropertyIndexSize);
-        propertyMap = RecyclerNew(scriptContext->GetRecycler(), SimplePropertyDescriptorMap, scriptContext->GetRecycler(), propertyCount);
+        propertyMap = RecyclerNew(scriptContext->GetRecycler(), SimplePropertyDescriptorMap, scriptContext->GetRecycler()->GetAllocator(), propertyCount);
 
         for (int i=0; i < propertyCount; i++)
         {
@@ -301,7 +301,7 @@ namespace Js
     {
         SetIsInlineSlotCapacityLocked();
         Assert(slotCapacity <= MaxPropertyIndexSize);
-        propertyMap = RecyclerNew(recycler, SimplePropertyDescriptorMap, recycler, this->GetSlotCapacity());
+        propertyMap = RecyclerNew(recycler, SimplePropertyDescriptorMap, recycler->GetAllocator(), this->GetSlotCapacity());
     }
 
     template <typename TPropertyIndex, typename TMapKey, bool IsNotExtensibleSupported>
@@ -317,7 +317,7 @@ namespace Js
         SetIsInlineSlotCapacityLocked();
         Assert(slotCapacity <= MaxPropertyIndexSize);
 
-        propertyMap = RecyclerNew(recycler, SimplePropertyDescriptorMap, recycler, propertyCapacity);
+        propertyMap = RecyclerNew(recycler, SimplePropertyDescriptorMap, recycler->GetAllocator(), propertyCapacity);
     }
 
     template <typename TPropertyIndex, typename TMapKey, bool IsNotExtensibleSupported>

--- a/lib/Runtime/Types/SimpleDictionaryTypeHandler.h
+++ b/lib/Runtime/Types/SimpleDictionaryTypeHandler.h
@@ -58,7 +58,7 @@ namespace Js
         template <typename TPropertyIndex, typename TMapKey, bool IsNotExtensibleSupported> friend class SimpleDictionaryTypeHandlerBase;
 
         // Explicit non leaf allocator now that the key is non-leaf
-        typedef JsUtil::BaseDictionary<TMapKey, SimpleDictionaryPropertyDescriptor<TPropertyIndex>, RecyclerNonLeafAllocator, DictionarySizePolicy<PowerOf2Policy, 1>, PropertyRecordStringHashComparer, PropertyMapKeyTraits<TMapKey>::template Entry>
+        typedef JsUtil::BaseDictionary<TMapKey, SimpleDictionaryPropertyDescriptor<TPropertyIndex>, RecyclerAllocator, DictionarySizePolicy<PowerOf2Policy, 1>, PropertyRecordStringHashComparer, PropertyMapKeyTraits<TMapKey>::template Entry>
             SimplePropertyDescriptorMap;
         typedef SimplePropertyDescriptorMap PropertyDescriptorMapType; // alias used by diagnostics
 

--- a/lib/Runtime/Types/SpreadArgument.cpp
+++ b/lib/Runtime/Types/SpreadArgument.cpp
@@ -26,7 +26,7 @@ namespace Js
         {
             if (iteratorIndices == nullptr)
             {
-                iteratorIndices = RecyclerNew(scriptContext->GetRecycler(), VarList, scriptContext->GetRecycler());
+                iteratorIndices = RecyclerNew(scriptContext->GetRecycler(), VarList, scriptContext->GetRecycler()->GetAllocator());
             }
 
             iteratorIndices->Add(nextItem);

--- a/lib/Runtime/Types/SpreadArgument.h
+++ b/lib/Runtime/Types/SpreadArgument.h
@@ -11,7 +11,7 @@ namespace Js
     private:
         Field(Var) iterable;
         Field(RecyclableObject*) iterator;
-        typedef JsUtil::List<Var, Recycler> VarList;
+        typedef JsUtil::List<Var, RecyclerAllocator> VarList;
         Field(VarList*) iteratorIndices;
 
         void AssertAndFailFast() { AssertMsg(false, "This function should not be invoked"); Js::Throw::InternalError();}


### PR DESCRIPTION
- seperate recycle allocators to be nonleaf, nonleaf with barrier and leaf to make it easy to control at both compile time and run time
- make it built with WriteBarrierPtr<> globaly enabled -- will turn this off before merging to master. by default still use write barrier for function body and write watch for the rest
- use -ForceSoftwareWriteBarrier to use write barrier for all none leaf allocation and do not check hardware write barrier, this is basically simulate Linux behavior on windows
- use -KeepRecyclerTrackData to keep the recycler track data longer until reuse for easier missing barrier investigation
- make disabling background freeing and zeroing work
