### PR TITLE
Disable recording information on x = Array

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -8181,8 +8181,8 @@ void EmitCall(
         // and replace the former with the latter to save 4 characters. What that means for us is that it, at least
         // initially, uses the "Call" path. We want to guess that it _is_ just "new Array()" and change over to the
         // "new" path, since then our native array handling can kick in.
-        EmitNew(pnode, byteCodeGenerator, funcInfo);
-        return;
+        /*EmitNew(pnode, byteCodeGenerator, funcInfo);
+        return;*/
     }
 
     unsigned int argCount = CountArguments(pnode->sxCall.pnodeArgs, &fSideEffectArgs) + (unsigned int)fIsPut;


### PR DESCRIPTION
Change was to treat it as x = new Array if possible, recording
additional information on array creation sites. The problem is
with temporary register allocation/cleanup in some cases.
