### PR TITLE
Throw TypeError when accessing array with out-of-bound index in strict mode

### DIFF
--- a/lib/Runtime/Types/ES5ArrayTypeHandler.cpp
+++ b/lib/Runtime/Types/ES5ArrayTypeHandler.cpp
@@ -371,7 +371,7 @@ namespace Js
         // Reject if we need to grow non-writable length
         if (!CanSetItemAt(arr, index))
         {
-            return false;
+            return CantExtend(flags, scriptContext);
         }
 
         IndexPropertyDescriptor* descriptor;


### PR DESCRIPTION
This is for issue https://github.com/Microsoft/ChakraCore/issues/2083