### PR TITLE
Another fix for redeferral with function objects with inline caches

### DIFF
--- a/lib/Runtime/Library/JavascriptFunction.cpp
+++ b/lib/Runtime/Library/JavascriptFunction.cpp
@@ -1689,7 +1689,18 @@ LABEL1:
             funcBody->SetAttributes((FunctionInfo::Attributes)(funcBody->GetAttributes() | FunctionInfo::Attributes::CanDefer));
         }
 
-        return (*functionRef)->UpdateUndeferredBody(funcBody);
+        JavascriptMethod thunkEntryPoint = (*functionRef)->UpdateUndeferredBody(funcBody);
+
+        if (ScriptFunctionWithInlineCache::Is(*functionRef))
+        {
+            ScriptFunctionWithInlineCache * funcObjectWithInlineCache = ScriptFunctionWithInlineCache::FromVar(*functionRef);
+            if (!funcObjectWithInlineCache->GetHasOwnInlineCaches())
+            {
+                funcObjectWithInlineCache->SetInlineCachesFromFunctionBody();
+            }
+        }
+
+        return thunkEntryPoint;
     }
 
     void JavascriptFunction::ReparseAsmJsModule(ScriptFunction** functionRef)

--- a/lib/Runtime/Library/ScriptFunction.h
+++ b/lib/Runtime/Library/ScriptFunction.h
@@ -174,6 +174,7 @@ namespace Js
         InlineCache * GetInlineCache(uint index);
         uint GetInlineCacheCount() { return inlineCacheCount; }
         void** GetInlineCaches() { return m_inlineCaches; }
+        bool GetHasOwnInlineCaches() { return hasOwnInlineCaches; }
         void SetInlineCachesFromFunctionBody();
         static uint32 GetOffsetOfInlineCaches() { return offsetof(ScriptFunctionWithInlineCache, m_inlineCaches); };
         template<bool isShutdown>


### PR DESCRIPTION
If the function object needs to use the inline caches from the function body and the body was redeferred, point them to the undeferred function body's caches right after undeferring it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/2091)
<!-- Reviewable:end -->
