### PR TITLE
OS8050875:Direct super calls in a base class constructor

### DIFF
--- a/lib/Runtime/Base/FunctionInfo.h
+++ b/lib/Runtime/Base/FunctionInfo.h
@@ -38,7 +38,8 @@ namespace Js
             Async                          = 0x10000,
             Module                         = 0x20000, // The function is the function body wrapper for a module
             EnclosedByGlobalFunc           = 0x40000,
-            CanDefer                       = 0x80000
+            CanDefer                       = 0x80000,
+            AllowDirectSuper               = 0x100000
         };
         FunctionInfo(JavascriptMethod entryPoint, Attributes attributes = None, LocalFunctionId functionId = Js::Constants::NoFunctionId, FunctionProxy* functionBodyImpl = nullptr);
 
@@ -127,6 +128,8 @@ namespace Js
         bool GetCapturesThis() const { return (attributes & Attributes::CapturesThis) != 0; }
         void SetEnclosedByGlobalFunc() { attributes = (Attributes)(attributes | Attributes::EnclosedByGlobalFunc ); }
         bool GetEnclosedByGlobalFunc() const { return (attributes & Attributes::EnclosedByGlobalFunc) != 0; }
+        void SetAllowDirectSuper() { attributes = (Attributes)(attributes | Attributes::AllowDirectSuper); }
+        bool GetAllowDirectSuper() const { return (attributes & Attributes::AllowDirectSuper) != 0; }
 
     protected:
         JavascriptMethod originalEntryPoint;

--- a/lib/Runtime/ByteCode/ByteCodeSerializer.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeSerializer.cpp
@@ -2020,8 +2020,9 @@ public:
                   | FunctionInfo::Attributes::Generator
                   | FunctionInfo::Attributes::ClassConstructor
                   | FunctionInfo::Attributes::ClassMethod
-                  | FunctionInfo::Attributes::EnclosedByGlobalFunc)) == 0,
-                "Only the ErrorOnNew|SuperReference|Lambda|CapturesThis|Generator|ClassConstructor|Async|ClassMember|EnclosedByGlobalFunc attributes should be set on a serialized function");
+                  | FunctionInfo::Attributes::EnclosedByGlobalFunc
+                  | FunctionInfo::Attributes::AllowDirectSuper)) == 0,
+                "Only the ErrorOnNew|SuperReference|Lambda|CapturesThis|Generator|ClassConstructor|Async|ClassMember|EnclosedByGlobalFunc|AllowDirectSuper attributes should be set on a serialized function");
 
         PrependInt32(builder, _u("Offset Into Source"), sourceDiff);
         if (function->GetNestedCount() > 0)

--- a/lib/Runtime/ByteCode/RuntimeByteCodePch.h
+++ b/lib/Runtime/ByteCode/RuntimeByteCodePch.h
@@ -26,3 +26,4 @@
 #ifdef ENABLE_WASM
 #include "WasmReader.h"
 #endif
+#include "Language/JavascriptStackWalker.h"

--- a/lib/Runtime/Language/JavascriptStackWalker.cpp
+++ b/lib/Runtime/Language/JavascriptStackWalker.cpp
@@ -1083,8 +1083,30 @@ namespace Js
         return !!(this->GetCallInfoFromPhysicalFrame()->Flags & CallFlags_InternalFrame);
     }
 
+    bool JavascriptStackWalker::IsWalkable(ScriptContext *scriptContext)
+    {
+        if (scriptContext == NULL)
+        {
+            return false;
+        }
+
+        ThreadContext *threadContext = scriptContext->GetThreadContext();
+        if (threadContext == NULL)
+        {
+            return false;
+        }
+
+        return (threadContext->GetScriptEntryExit() != NULL);
+    }
+
     BOOL JavascriptStackWalker::GetCaller(JavascriptFunction** ppFunc, ScriptContext* scriptContext)
     {
+        if (!IsWalkable(scriptContext))
+        {
+            *ppFunc = nullptr;
+            return FALSE;
+        }
+
         JavascriptStackWalker walker(scriptContext);
         return walker.GetCaller(ppFunc);
     }

--- a/lib/Runtime/Language/JavascriptStackWalker.h
+++ b/lib/Runtime/Language/JavascriptStackWalker.h
@@ -246,7 +246,8 @@ namespace Js
         bool GetDisplayCaller(JavascriptFunction ** ppFunc);
         PCWSTR GetCurrentNativeLibraryEntryName() const;
         static bool IsLibraryStackFrameEnabled(Js::ScriptContext * scriptContext);
-        
+        static bool IsWalkable(ScriptContext *scriptContext);
+
         // Walk frames (until walkFrame returns true)
         template <class WalkFrame>
         ushort WalkUntil(ushort stackTraceLimit, WalkFrame walkFrame, bool onlyOnDebugMode = false, bool filterDiagnosticsOM = false)

--- a/test/es6/ES6Super.js
+++ b/test/es6/ES6Super.js
@@ -183,6 +183,27 @@ var tests = [
         assert.areEqual(1, value);
     }
   },
+  {
+    name: "direct super calls from a class constructors",
+    body: function () {
+        var count = 0;
+        assert.throws(function(){class A{constructor(){eval("count++; super();");}};new A();}, SyntaxError, "", "Invalid use of the 'super' keyword");
+        assert.throws(function(){class A{constructor(){(()=>eval("count++; super();"))();}};new A();}, SyntaxError, "", "Invalid use of the 'super' keyword");
+        assert.throws(function(){class A{constructor(){(()=>{(()=>eval("count++; super();"))();})();}};new A();}, SyntaxError, "", "Invalid use of the 'super' keyword");
+        assert.throws(function(){class A{constructor(){eval("eval(\"count++; super();\");");}};new A();}, SyntaxError, "", "Invalid use of the 'super' keyword");
+        assert.throws(function(){class A{constructor(){eval("(()=>{count++; super();})();");}};new A();}, SyntaxError, "", "Invalid use of the 'super' keyword");
+        assert.throws(function(){class A{constructor(){eval("(()=>eval(\"count++; super();\"))();");}};new A();}, SyntaxError, "", "Invalid use of the 'super' keyword");
+        assert.areEqual(0, count, "SyntaxError preempts side effects")
+
+        assert.doesNotThrow(function(){class A extends Object{constructor(){eval("count++; super();");}};new A();}, "");
+        assert.doesNotThrow(function(){class A extends Object{constructor(){(()=>eval("count++; super();"))();}};new A();}, "");
+        assert.doesNotThrow(function(){class A extends Object{constructor(){(()=>{(()=>eval("count++; super();"))();})();}};new A();}, "");
+        assert.doesNotThrow(function(){class A extends Object{constructor(){eval("eval(\"count++; super();\");");}};new A();}, "");
+        assert.doesNotThrow(function(){class A extends Object{constructor(){eval("(()=>{count++; super();})();");}};new A();}, "");
+        assert.doesNotThrow(function(){class A extends Object{constructor(){eval("(()=>eval(\"count++; super();\"))();");}};new A();}, "");
+        assert.areEqual(6, count, "Side effects expected without SyntaxError");
+    }
+  },
 ];
 
 testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/es6/classes.js
+++ b/test/es6/classes.js
@@ -418,7 +418,7 @@ var tests = [
       }
 
       // Test valid postfix operators in the wrong context
-      assert.throws(function () { eval("super();") },        ReferenceError, "Invalid use of super", "Missing or invalid 'super' binding");
+      assert.throws(function () { eval("super();") },        SyntaxError, "Invalid use of super", "Invalid use of the 'super' keyword");
       assert.throws(function () { eval("super[1];") },       ReferenceError, "Invalid use of super", "Missing or invalid 'super' binding");
       assert.throws(function () { eval("super.method();") }, ReferenceError, "Invalid use of super", "Missing or invalid 'super' binding");
 
@@ -688,8 +688,8 @@ var tests = [
       assert.areEqual("hello world", instance.method6(), "Nested lambdas and eval");
       assert.areEqual("hello world", instance.method7(), "Nested lambdas and nested evals");
       assert.areEqual("hello world", instance.method8(), "Lambda with an eval in the parent");
-      assert.throws(function() { instance.method9(); }, ReferenceError);
-      assert.throws(function() { (x => eval('super()'))(); }, ReferenceError);
+      assert.throws(function() { instance.method9(); }, SyntaxError);
+      assert.throws(function() { (x => eval('super()'))(); }, SyntaxError);
       assert.areEqual("hello world", instance.method10(), "Lambda with an eval in the lambda");
     }
   },

--- a/test/es6/rest.js
+++ b/test/es6/rest.js
@@ -351,6 +351,16 @@ var tests = [
     }
   },
   {
+    name: "Extra arguments passed to eval should not be visible",
+    body: function () {
+        var eval = function(...arg) {
+            assert.areEqual(1, arg.length, "arg.length == 1");
+            assert.areEqual("super()", arg[0], "arg[0] == 'super()'");
+        }
+        eval("super()");
+    }
+  },
+  {
     name: "OSG 5737917: Create arguments object when the only formal is a rest argument",
     body: function () {
       var func1 = function (...argArr0) {


### PR DESCRIPTION
Direct super calls in a base class constructor should be SyntaxError. Define new flags to signify where direct super calls are syntactically correct and pass these flags into eval() and multiple nested cases comprised of a mix of eval and lambda.