### PR TITLE
enable write barrier test on windows

### DIFF
--- a/lib/Common/CommonDefines.h
+++ b/lib/Common/CommonDefines.h
@@ -119,52 +119,53 @@
 #endif
 
 // GC features
-
 #define BUCKETIZE_MEDIUM_ALLOCATIONS 1              // *** TODO: Won't build if disabled currently
 #define SMALLBLOCK_MEDIUM_ALLOC 1                   // *** TODO: Won't build if disabled currently
 #define LARGEHEAPBLOCK_ENCODING 1                   // Large heap block metadata encoding
-#define RECYCLER_WRITE_BARRIER                      // Write Barrier support
 #define IDLE_DECOMMIT_ENABLED 1                     // Idle Decommit
 #define RECYCLER_PAGE_HEAP                          // PageHeap support
 
+#ifdef _WIN32
+#define SYSINFO_IMAGE_BASE_AVAILABLE 1
+#define ENABLE_CONCURRENT_GC 1
+#define SUPPORT_WIN32_SLIST 1
+#else
+#define SYSINFO_IMAGE_BASE_AVAILABLE 0
+#define ENABLE_CONCURRENT_GC 1
+#define SUPPORT_WIN32_SLIST 0
+#endif
+
+
+#if ENABLE_CONCURRENT_GC
 // Write-barrier refers to a software write barrier implementation using a card table. 
 // Write watch refers to a hardware backed write-watch feature supported by the Windows memory manager. 
 // Both are used for detecting changes to memory for concurrent and partial GC. 
-// GLOBAL_ENABLE_WRITE_BARRIER controls the former, ENABLE_WRITE_WATCH controls the latter.
+// RECYCLER_WRITE_BARRIER controls the former, RECYCLER_WRITE_WATCH controls the latter.
+// GLOBAL_ENABLE_WRITE_BARRIER controls the smart pointer wrapper at compile time, every Field annotation on the
+// recycler allocated class will take effect if GLOBAL_ENABLE_WRITE_BARRIER is 1, otherwise only  the class declared 
+// with FORCE_USE_WRITE_BARRIER will use the WriteBarrierPtr<>, see WriteBarrierMacros.h and RecyclerPointers.h for detail
+#define RECYCLER_WRITE_BARRIER                      // Write Barrier support
+#ifdef _WIN32
+#define RECYCLER_WRITE_WATCH                        // Support hardware write watch
+#endif
+
 #ifdef RECYCLER_WRITE_BARRIER
 #ifdef _WIN32
-#define GLOBAL_ENABLE_WRITE_BARRIER 0
+#define GLOBAL_ENABLE_WRITE_BARRIER 1
 #else
 #define GLOBAL_ENABLE_WRITE_BARRIER 1
 #endif
 #endif
 
-#ifdef _WIN32
-#define ENABLE_WRITE_WATCH 1
-#else
-#define ENABLE_WRITE_WATCH 0
-#endif
-
-// Concurrent and Partial GC are disabled on non-Windows builds
-// xplat-todo: re-enable this in the future
-// These are disabled because these GC features depend on hardware
-// write-watch support that the Windows Memory Manager provides.
-#ifdef _WIN32
-#define SYSINFO_IMAGE_BASE_AVAILABLE 1
-#define ENABLE_CONCURRENT_GC 1
 #define ENABLE_PARTIAL_GC 1
 #define ENABLE_BACKGROUND_PAGE_ZEROING 1
 #define ENABLE_BACKGROUND_PAGE_FREEING 1
 #define ENABLE_RECYCLER_TYPE_TRACKING 1
-#define SUPPORT_WIN32_SLIST 1
 #else
-#define SYSINFO_IMAGE_BASE_AVAILABLE 0
-#define ENABLE_CONCURRENT_GC 1
-#define ENABLE_PARTIAL_GC 1
-#define ENABLE_BACKGROUND_PAGE_ZEROING 1
-#define ENABLE_BACKGROUND_PAGE_FREEING 1
-#define ENABLE_RECYCLER_TYPE_TRACKING 1
-#define SUPPORT_WIN32_SLIST 0
+#define ENABLE_PARTIAL_GC 0
+#define ENABLE_BACKGROUND_PAGE_ZEROING 0
+#define ENABLE_BACKGROUND_PAGE_FREEING 0
+#define ENABLE_RECYCLER_TYPE_TRACKING 0
 #endif
 
 #if ENABLE_BACKGROUND_PAGE_ZEROING && !ENABLE_BACKGROUND_PAGE_FREEING

--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -715,15 +715,15 @@ PHASE(All)
 #endif
 
 #define DEFAULT_CONFIG_StrictWriteBarrierCheck  (false)
+#define DEFAULT_CONFIG_KeepRecyclerTrackData  (false)
+#define DEFAULT_CONFIG_EnableBGFreeZero (true)
 
 #ifdef _WIN32
 #define DEFAULT_CONFIG_ForceSoftwareWriteBarrier  (false)
 #define DEFAULT_CONFIG_WriteBarrierTest (false)
-#define DEFAULT_CONFIG_EnableBGFreeZero (true)
 #else
 #define DEFAULT_CONFIG_ForceSoftwareWriteBarrier  (true)
 #define DEFAULT_CONFIG_WriteBarrierTest (true) // TODO: SWB change to false after all write barrier annotations are done
-#define DEFAULT_CONFIG_EnableBGFreeZero (true)
 #endif
 
 #define TraceLevel_Error        (1)
@@ -1492,6 +1492,7 @@ FLAGNR(Boolean, StrictWriteBarrierCheck, "Check write barrier setting on none wr
 FLAGNR(Boolean, WriteBarrierTest, "Always return true while checking barrier to test recycler regardless of annotation", DEFAULT_CONFIG_WriteBarrierTest)
 FLAGNR(Boolean, ForceSoftwareWriteBarrier, "Use to turn off write watch to test software write barrier on windows", DEFAULT_CONFIG_ForceSoftwareWriteBarrier)
 FLAGNR(Boolean, EnableBGFreeZero, "Use to turn off background freeing and zeroing to simulate linux", DEFAULT_CONFIG_EnableBGFreeZero)
+FLAGNR(Boolean, KeepRecyclerTrackData, "Keep recycler track data after sweep until reuse", DEFAULT_CONFIG_KeepRecyclerTrackData)
 
 #undef FLAG_REGOVR_EXP
 #undef FLAG_REGOVR_ASMJS

--- a/lib/Common/Memory/HeapBlock.cpp
+++ b/lib/Common/Memory/HeapBlock.cpp
@@ -173,7 +173,7 @@ SmallHeapBlockT<MediumAllocationBlockAttributes>::ProtectUnusablePages()
         DWORD oldProtect;
         BOOL ret = ::VirtualProtect(startPage, count * AutoSystemInfo::PageSize, PAGE_READONLY, &oldProtect);
         Assert(ret && oldProtect == PAGE_READWRITE);
-#if ENABLE_WRITE_WATCH
+#ifdef RECYCLER_WRITE_WATCH
         if (!CONFIG_FLAG(ForceSoftwareWriteBarrier))
         {
             ::ResetWriteWatch(startPage, count*AutoSystemInfo::PageSize);

--- a/lib/Common/Memory/HeapBlockMap.h
+++ b/lib/Common/Memory/HeapBlockMap.h
@@ -113,7 +113,7 @@ public:
 
 private:
 #if ENABLE_CONCURRENT_GC
-#if ENABLE_WRITE_WATCH
+#ifdef RECYCLER_WRITE_WATCH
     static UINT GetWriteWatchHelper(Recycler * recycler, DWORD writeWatchFlags, void* baseAddress, size_t regionSize,
         void** addresses, ULONG_PTR* count, LPDWORD granularity);
     static UINT GetWriteWatchHelperOnOOM(DWORD writeWatchFlags, _In_ void* baseAddress, size_t regionSize,

--- a/lib/Common/Memory/HeapInfo.h
+++ b/lib/Common/Memory/HeapInfo.h
@@ -496,18 +496,7 @@ HeapInfo::RealAlloc(Recycler * recycler, size_t sizeCat, size_t size)
 {
     Assert(HeapInfo::IsAlignedSmallObjectSize(sizeCat));
     auto& bucket = this->GetBucket<(ObjectInfoBits)(attributes & GetBlockTypeBitMask)>(sizeCat);
-#if GLOBAL_ENABLE_WRITE_BARRIER
-    if (CONFIG_FLAG(ForceSoftwareWriteBarrier)
-        && ((attributes & LeafBit) != LeafBit
-            ||(attributes & FinalizeBit) == FinalizeBit)) // there's no Finalize Leaf bucket
-    {
-        return bucket.template RealAlloc<(ObjectInfoBits)(attributes | WithBarrierBit), nothrow>(recycler, sizeCat, size);
-    }
-    else
-#endif
-    {
-        return bucket.template RealAlloc<attributes, nothrow>(recycler, sizeCat, size);
-    }
+    return bucket.template RealAlloc<attributes, nothrow>(recycler, sizeCat, size);
 }
 
 #if defined(BUCKETIZE_MEDIUM_ALLOCATIONS)
@@ -517,18 +506,7 @@ inline char *
 HeapInfo::MediumAlloc(Recycler * recycler, size_t sizeCat, size_t size)
 {
     auto& bucket = this->GetMediumBucket<(ObjectInfoBits)(attributes & GetBlockTypeBitMask)>(sizeCat);
-#if GLOBAL_ENABLE_WRITE_BARRIER
-    if (CONFIG_FLAG(ForceSoftwareWriteBarrier)
-        && ((attributes & LeafBit) != LeafBit
-            || (attributes & FinalizeBit) == FinalizeBit)) // there's no Finalize Leaf bucket
-    {
-        return bucket.template RealAlloc<(ObjectInfoBits)(attributes | WithBarrierBit), nothrow>(recycler, sizeCat, size);
-    }
-    else
-#endif
-    {
-        return bucket.template RealAlloc<attributes, nothrow>(recycler, sizeCat, size);
-    }
+    return bucket.template RealAlloc<attributes, nothrow>(recycler, sizeCat, size);
 }
 
 #else

--- a/lib/Common/Memory/LargeHeapBlock.cpp
+++ b/lib/Common/Memory/LargeHeapBlock.cpp
@@ -989,7 +989,7 @@ bool LargeHeapBlock::IsPageDirty(char* page, RescanFlags flags, bool isWriteBarr
     }
 #endif
 
-#if ENABLE_WRITE_WATCH
+#ifdef RECYCLER_WRITE_WATCH
     if (!CONFIG_FLAG(ForceSoftwareWriteBarrier))
     {
         ULONG_PTR count = 1;

--- a/lib/Common/Memory/PageAllocator.h
+++ b/lib/Common/Memory/PageAllocator.h
@@ -188,7 +188,10 @@ public:
     {
         return isWriteBarrierAllowed;
     }
-
+    bool IsWriteBarrierEnabled()
+    {
+        return this->isWriteBarrierEnabled;
+    }
 #endif
 
 protected:
@@ -703,8 +706,12 @@ public:
     void ClearConcurrentThreadId() { this->concurrentThreadId = (DWORD)-1; }
     DWORD GetConcurrentThreadId() { return this->concurrentThreadId;  }
     DWORD HasConcurrentThreadId() { return this->concurrentThreadId != -1; }
-
 #endif
+
+    bool IsWriteWatchEnabled()
+    {
+        return (allocFlags & MEM_WRITE_WATCH) == MEM_WRITE_WATCH;
+    }
 
 #if DBG_DUMP
     char16 const * debugName;

--- a/lib/Common/Memory/Recycler.cpp
+++ b/lib/Common/Memory/Recycler.cpp
@@ -975,6 +975,13 @@ Recycler::GetUsedBytes()
 #endif
     usedBytes += recyclerPageAllocator.usedBytes;
     usedBytes += recyclerLargeBlockPageAllocator.usedBytes;
+
+#if GLOBAL_ENABLE_WRITE_BARRIER
+    if (CONFIG_FLAG(ForceSoftwareWriteBarrier))
+    {
+        Assert(recyclerPageAllocator.usedBytes == 0);
+    }
+#endif
     return usedBytes;
 }
 

--- a/lib/Common/Memory/RecyclerFastAllocator.h
+++ b/lib/Common/Memory/RecyclerFastAllocator.h
@@ -49,6 +49,9 @@ public:
 #endif
         size_t sizeCat = GetAlignedAllocSize();
         Assert(HeapInfo::IsSmallObject(sizeCat));
+
+        // TODO: SWB, currently RecyclerFastAllocator only used for number allocating, which is Leaf
+        // need to add WithBarrierBit if we have other usage with NonLeaf
         char * memBlock = allocator.template InlinedAlloc<(ObjectInfoBits)(attributes & InternalObjectInfoBitMask)>(recycler, sizeCat);
 
         if (memBlock == nullptr)

--- a/lib/Common/Memory/RecyclerPageAllocator.cpp
+++ b/lib/Common/Memory/RecyclerPageAllocator.cpp
@@ -32,7 +32,7 @@ bool RecyclerPageAllocator::IsMemProtectMode()
 }
 
 #if ENABLE_CONCURRENT_GC
-#if ENABLE_WRITE_WATCH
+#ifdef RECYCLER_WRITE_WATCH
 void
 RecyclerPageAllocator::EnableWriteWatch()
 {
@@ -48,7 +48,7 @@ RecyclerPageAllocator::EnableWriteWatch()
 bool
 RecyclerPageAllocator::ResetWriteWatch()
 {
-    if (allocFlags != MEM_WRITE_WATCH)
+    if (!IsWriteWatchEnabled())
     {
         return false;
     }
@@ -131,7 +131,7 @@ RecyclerPageAllocator::ResetAllWriteWatch(DListBase<T> * segmentList)
 }
 #endif
 
-#if ENABLE_WRITE_WATCH
+#ifdef RECYCLER_WRITE_WATCH
 #if DBG
 size_t
 RecyclerPageAllocator::GetWriteWatchPageCount()

--- a/lib/Common/Memory/RecyclerPageAllocator.h
+++ b/lib/Common/Memory/RecyclerPageAllocator.h
@@ -15,7 +15,7 @@ public:
 #endif
         uint maxFreePageCount, uint maxAllocPageCount = PageAllocator::DefaultMaxAllocPageCount, bool enableWriteBarrier = false);
 #if ENABLE_CONCURRENT_GC
-#if ENABLE_WRITE_WATCH
+#ifdef RECYCLER_WRITE_WATCH
     void EnableWriteWatch();
     bool ResetWriteWatch();
 #endif
@@ -24,7 +24,7 @@ public:
     static uint const DefaultPrimePageCount = 0x1000; // 16MB
 
 #if ENABLE_CONCURRENT_GC
-#if ENABLE_WRITE_WATCH
+#ifdef RECYCLER_WRITE_WATCH
 #if DBG
     size_t GetWriteWatchPageCount();
 #endif

--- a/lib/Common/Memory/RecyclerSweep.cpp
+++ b/lib/Common/Memory/RecyclerSweep.cpp
@@ -186,7 +186,7 @@ RecyclerSweep::FinishSweep()
 
             GCETW(GC_SWEEP_PARTIAL_REUSE_PAGE_STOP, (recycler));
 
-#if ENABLE_WRITE_WATCH
+#ifdef RECYCLER_WRITE_WATCH
             if (!CONFIG_FLAG(ForceSoftwareWriteBarrier))
             {
                 if (!this->IsBackground())

--- a/lib/Common/Memory/RecyclerWriteBarrierManager.cpp
+++ b/lib/Common/Memory/RecyclerWriteBarrierManager.cpp
@@ -66,6 +66,16 @@ X64WriteBarrierCardTableManager::OnThreadInit()
     ::GetCurrentThreadStackLimits(&stackEnd, &stackBase);
 #endif
 
+#ifdef X64_WB_DIAG
+    this->_stackbase = (char*)stackBase;
+    this->_stacklimit = (char*)stackEnd;
+#endif
+
+    // on Windows server 2012 stack limit can expand with process running, and causes
+    // accessing uncommitted card table page.
+    // TODO: use VirtualQuery twice to get the max possible stack limit
+    stackEnd -= AutoSystemInfo::PageSize * AutoSystemInfo::PageSize;
+
     size_t numPages = (stackBase - stackEnd) / AutoSystemInfo::PageSize;
     // stackEnd is the lower boundary
     bool ret = OnSegmentAlloc((char*) stackEnd, numPages);

--- a/lib/Common/Memory/RecyclerWriteBarrierManager.h
+++ b/lib/Common/Memory/RecyclerWriteBarrierManager.h
@@ -125,6 +125,8 @@ private:
     size_t _lastSectionIndexStart;
     size_t _lastSectionIndexLast;
     CommitState _lastCommitState;
+    char* _stackbase;
+    char* _stacklimit;
 #endif
 
 #ifdef X64_WB_DIAG

--- a/lib/Common/Memory/SmallFinalizableHeapBucket.h
+++ b/lib/Common/Memory/SmallFinalizableHeapBucket.h
@@ -81,7 +81,6 @@ template <ObjectInfoBits attributes, class TBlockAttributes>
 class SmallHeapBlockType
 {
 public:
-    CompileAssert(attributes & FinalizeBit);
     typedef SmallFinalizableHeapBlockT<TBlockAttributes> BlockType;
     typedef SmallFinalizableHeapBucketT<TBlockAttributes> BucketType;
 };
@@ -174,7 +173,7 @@ class HeapBucketGroup
         typedef typename SmallHeapBlockType<objectAttributes, TBlockAttributes>::BucketType BucketType;
         static BucketType& GetBucket(HeapBucketGroup<TBlockAttributes> * heapBucketGroup)
         {
-            CompileAssert(objectAttributes & FinalizeBit);
+            Assert(objectAttributes & FinalizeBit);
             return heapBucketGroup->finalizableHeapBucket;
         }
     };

--- a/lib/Common/Memory/SmallHeapBlockAllocator.h
+++ b/lib/Common/Memory/SmallHeapBlockAllocator.h
@@ -103,6 +103,7 @@ inline char*
 SmallHeapBlockAllocator<TBlockType>::InlinedAllocImpl(Recycler * recycler, size_t sizeCat, ObjectInfoBits attributes)
 {
     Assert((attributes & InternalObjectInfoBitMask) == attributes);
+    Assert(!CONFIG_FLAG(ForceSoftwareWriteBarrier) || (attributes & WithBarrierBit) || (attributes & LeafBit));
 
     AUTO_NO_EXCEPTION_REGION;
     if (canFaultInject)

--- a/lib/Runtime/Library/ArrayBuffer.h
+++ b/lib/Runtime/Library/ArrayBuffer.h
@@ -150,7 +150,7 @@ namespace Js
         Field(JsUtil::List<RecyclerWeakReference<ArrayBufferParent>*>*) otherParents;
 
 
-        Field(BYTE  *) buffer;             // Points to a heap allocated RGBA buffer, can be null
+        FieldNoBarrier(BYTE*) buffer;             // Points to a heap allocated RGBA buffer, can be null
         Field(uint32) bufferLength;       // Number of bytes allocated
 
         // When an ArrayBuffer is detached, the TypedArray and DataView objects pointing to it must be made aware,


### PR DESCRIPTION
make built with WriteBarrierPtr<> globaly enabled -- will turn this off before merging to master
by default still use write barrier for function body and write watch for the rest
use -ForceSoftwareWriteBarrier to use write barrier for all none leaf allocation
use -KeepRecyclerTrackData to keep the recycler track data longer until reuse
