### PR TITLE
Fix SAL annotations in Utf8Codex.cpp/.h

### DIFF
--- a/lib/Common/Codex/Utf8Codex.cpp
+++ b/lib/Common/Codex/Utf8Codex.cpp
@@ -323,7 +323,8 @@ LFourByte:
         return ptr;
     }
 
-    LPUTF8 EncodeSurrogatePair(char16 surrogateHigh, char16 surrogateLow, __out_ecount(3) LPUTF8 ptr)
+    _Use_decl_annotations_
+    LPUTF8 EncodeSurrogatePair(char16 surrogateHigh, char16 surrogateLow, LPUTF8 ptr)
     {
         // A unicode codepoint is encoded into a surrogate pair by doing the following:
         //  subtract 0x10000 from the codepoint
@@ -472,9 +473,10 @@ LSlowPath:
     }
 
     template <bool cesu8Encoding>
-    __range(0, cch * 3)
-    size_t EncodeIntoImpl(__out_ecount(cch * 3) LPUTF8 buffer, __in_ecount(cch) const char16 *source, charcount_t cch)
+    __range(0, cchIn * 3)
+    size_t EncodeIntoImpl(__out_ecount(cchIn * 3) LPUTF8 buffer, __in_ecount(cchIn) const char16 *source, charcount_t cchIn)
     {
+        charcount_t cch = cchIn; // SAL analysis gets confused by EncodeTrueUtf8's dest buffer requirement unless we alias cchIn with a local
         LPUTF8 dest = buffer;
 
         if (!ShouldFastPath(dest, source)) goto LSlowPath;

--- a/lib/Common/Codex/Utf8Codex.h
+++ b/lib/Common/Codex/Utf8Codex.h
@@ -162,7 +162,7 @@ namespace utf8
     LPUTF8 EncodeFull(char16 ch, __out_ecount(3) LPUTF8 ptr);
 
     // Encode a surrogate pair into a utf8 sequence 
-    LPUTF8 EncodeSurrogatePair(char16 surrogateHigh, char16 surrogateLow, __out_ecount(3) LPUTF8 ptr);
+    LPUTF8 EncodeSurrogatePair(char16 surrogateHigh, char16 surrogateLow, __out_ecount(4) LPUTF8 ptr);
 
     // Encode ch into a UTF8 sequence ignoring surrogate pairs (which are encoded as two
     // separate code points).
@@ -177,7 +177,7 @@ namespace utf8
     }
 
     // Encode ch into a UTF8 sequence while being aware of surrogate pairs.
-    inline LPUTF8 EncodeTrueUtf8(char16 ch, const char16** source, charcount_t* cch, __out_ecount(3) LPUTF8 ptr)
+    inline LPUTF8 EncodeTrueUtf8(char16 ch, const char16** source, charcount_t* cch, __out_ecount((*cch + 1) * 3) LPUTF8 ptr)
     {
         if (ch < 0x80)
         {
@@ -201,11 +201,16 @@ namespace utf8
             if ((surrogateHigh >= 0xD800 && surrogateHigh <= 0xDBFF) &&
                 (surrogateLow >= 0xDC00 && surrogateLow <= 0xDFFF))
             {
+                LPUTF8 retptr = EncodeSurrogatePair(surrogateHigh, surrogateLow, ptr);
+                
+                // SAL analysis gets confused if we call EncodeSurrogatePair after
+                // modifying cch
+
                 // Consume the low surrogate
                 *source = *source + 1;
                 *cch = *cch - 1;
 
-                return EncodeSurrogatePair(surrogateHigh, surrogateLow, ptr);
+                return retptr;
             }
         }
 


### PR DESCRIPTION
Copy pasta looking bug.  We modify four bytes in the out buffer but had
_ecount_out(3).  Bumped to 4.