### PR TITLE
Redeferral checks should also be done on LoopEntryPointInfo's

### DIFF
--- a/lib/Common/DataStructures/List.h
+++ b/lib/Common/DataStructures/List.h
@@ -680,6 +680,13 @@ namespace Js
             __super::Map(map);
         }
 
+        template<class TMapFunction>
+        bool MapUntil(TMapFunction map) const
+        {
+            typename LockPolicy::ReadLock autoLock(syncObj);
+            return __super::MapUntil(map);
+        }
+
         template<class DebugSite, class TMapFunction>
         HRESULT Map(DebugSite site, TMapFunction map) const // external debugging version
         {

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -828,6 +828,22 @@ namespace Js
                 isJitCandidate = true;
             }
         });
+
+        if (!isJitCandidate)
+        {
+            // Now check loop body entry points
+            this->MapLoopHeaders([&](uint loopNumber, LoopHeader* header)
+            {
+                header->MapEntryPoints([&](int index, LoopEntryPointInfo* entryPointInfo)
+                {
+                    if ((entryPointInfo->IsCodeGenPending() && isJitModeFunction) || entryPointInfo->IsCodeGenQueued() || entryPointInfo->IsCodeGenRecorded() || (entryPointInfo->IsCodeGenDone() && !entryPointInfo->nativeEntryPointProcessed))
+                    {
+                        isJitCandidate = true;
+                    }
+                });
+            });
+        }
+
         if (isJitCandidate)
         {
             return false;
@@ -9380,7 +9396,6 @@ namespace Js
         localVarChangedOffset(Js::Constants::InvalidOffset),
         callsCount(0),
         jitMode(ExecutionMode::Interpreter),
-        nativeEntryPointProcessed(false),
         functionProxy(functionProxy),
         nextEntryPoint(nullptr),
         mIsTemplatizedJitMode(false)

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -591,9 +591,7 @@ namespace Js
 #endif
     public:
         uint frameHeight;
-#if ENABLE_NATIVE_CODEGEN
         bool nativeEntryPointProcessed;
-#endif
 
 #if ENABLE_DEBUG_CONFIG_OPTIONS
     public:
@@ -644,13 +642,13 @@ namespace Js
 
     protected:
         EntryPointInfo(Js::JavascriptMethod method, JavascriptLibrary* library, void* validationCookie, ThreadContext* context = nullptr, bool isLoopBody = false) :
-            ProxyEntryPointInfo(method, context), tag(1),
+            ProxyEntryPointInfo(method, context), tag(1), nativeEntryPointProcessed(false),
 #if ENABLE_NATIVE_CODEGEN
             nativeThrowSpanSequence(nullptr), workItem(nullptr), weakFuncRefSet(nullptr),
             jitTransferData(nullptr), sharedPropertyGuards(nullptr), propertyGuardCount(0), propertyGuardWeakRefs(nullptr),
             equivalentTypeCacheCount(0), equivalentTypeCaches(nullptr), constructorCaches(nullptr), state(NotScheduled), inProcJITNaticeCodedata(nullptr),
             numberChunks(nullptr), numberPageSegments(nullptr), polymorphicInlineCacheInfo(nullptr), runtimeTypeRefs(nullptr),
-            isLoopBody(isLoopBody), hasJittedStackClosure(false), registeredEquivalentTypeCacheRef(nullptr), bailoutRecordMap(nullptr), nativeEntryPointProcessed(false),
+            isLoopBody(isLoopBody), hasJittedStackClosure(false), registeredEquivalentTypeCacheRef(nullptr), bailoutRecordMap(nullptr),
 #if PDATA_ENABLED
             xdataInfo(nullptr),
 #endif

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -591,6 +591,9 @@ namespace Js
 #endif
     public:
         uint frameHeight;
+#if ENABLE_NATIVE_CODEGEN
+        bool nativeEntryPointProcessed;
+#endif
 
 #if ENABLE_DEBUG_CONFIG_OPTIONS
     public:
@@ -647,7 +650,7 @@ namespace Js
             jitTransferData(nullptr), sharedPropertyGuards(nullptr), propertyGuardCount(0), propertyGuardWeakRefs(nullptr),
             equivalentTypeCacheCount(0), equivalentTypeCaches(nullptr), constructorCaches(nullptr), state(NotScheduled), inProcJITNaticeCodedata(nullptr),
             numberChunks(nullptr), numberPageSegments(nullptr), polymorphicInlineCacheInfo(nullptr), runtimeTypeRefs(nullptr),
-            isLoopBody(isLoopBody), hasJittedStackClosure(false), registeredEquivalentTypeCacheRef(nullptr), bailoutRecordMap(nullptr),
+            isLoopBody(isLoopBody), hasJittedStackClosure(false), registeredEquivalentTypeCacheRef(nullptr), bailoutRecordMap(nullptr), nativeEntryPointProcessed(false),
 #if PDATA_ENABLED
             xdataInfo(nullptr),
 #endif
@@ -1065,7 +1068,6 @@ namespace Js
 
         uint32 callsCount;
         uint32 lastCallsCount;
-        bool nativeEntryPointProcessed;
 
     private:
         ExecutionMode jitMode;

--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -5945,6 +5945,7 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
 #endif
 
             entryPointInfo->EnsureIsReadyToCall();
+            entryPointInfo->nativeEntryPointProcessed = true;
 
             RegSlot envReg = this->m_functionBody->GetEnvRegister();
             if (envReg != Constants::NoRegister)


### PR DESCRIPTION
While deciding whether we can redefer a function body or not, if none of the function entry point infos suggest that the function could be jitted while we redefer the body, we should also do the same checks for loop entry point infos registered with the function body

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/2108)
<!-- Reviewable:end -->
