### PR TITLE
swb: fix JitTypeHolder annotation

### DIFF
--- a/lib/Backend/JITType.cpp
+++ b/lib/Backend/JITType.cpp
@@ -78,24 +78,29 @@ JITType::GetTypeHandler() const
     return (const JITTypeHandler*)&m_data.handler;
 }
 
-JITTypeHolder::JITTypeHolder() :
+
+template <class TAllocator>
+JITTypeHolderBase<TAllocator>::JITTypeHolderBase() :
     t(nullptr)
 {
 }
 
-JITTypeHolder::JITTypeHolder(JITType * t) :
+template <class TAllocator>
+JITTypeHolderBase<TAllocator>::JITTypeHolderBase(JITType * t) :
     t(t)
 {
 }
 
+template <class TAllocator>
 const JITType *
-JITTypeHolder::operator->() const
+JITTypeHolderBase<TAllocator>::operator->() const
 {
     return this->t;
 }
 
+template <class TAllocator>
 bool
-JITTypeHolder::operator==(const JITTypeHolder& p) const
+JITTypeHolderBase<TAllocator>::operator==(const JITTypeHolderBase& p) const
 {
     if (this->t != nullptr && p != nullptr)
     {
@@ -104,26 +109,30 @@ JITTypeHolder::operator==(const JITTypeHolder& p) const
     return this->t == nullptr && p == nullptr;
 }
 
+template <class TAllocator>
 bool
-JITTypeHolder::operator!=(const JITTypeHolder& p) const
+JITTypeHolderBase<TAllocator>::operator!=(const JITTypeHolderBase& p) const
 {
     return !(*this == p);
 }
 
+template <class TAllocator>
 bool
-JITTypeHolder::operator==(const std::nullptr_t &p) const
+JITTypeHolderBase<TAllocator>::operator==(const std::nullptr_t &p) const
 {
     return this->t == nullptr;
 }
 
+template <class TAllocator>
 bool
-JITTypeHolder::operator!=(const std::nullptr_t &p) const
+JITTypeHolderBase<TAllocator>::operator!=(const std::nullptr_t &p) const
 {
     return this->t != nullptr;
 }
 
+template <class TAllocator>
 bool
-JITTypeHolder::operator>(const JITTypeHolder& p) const
+JITTypeHolderBase<TAllocator>::operator>(const JITTypeHolderBase& p) const
 {
     if (this->t != nullptr && p != nullptr)
     {
@@ -132,14 +141,16 @@ JITTypeHolder::operator>(const JITTypeHolder& p) const
     return false;
 }
 
+template <class TAllocator>
 bool
-JITTypeHolder::operator<=(const JITTypeHolder& p) const
+JITTypeHolderBase<TAllocator>::operator<=(const JITTypeHolderBase& p) const
 {
     return !(*this > p);
 }
 
+template <class TAllocator>
 bool
-JITTypeHolder::operator>=(const JITTypeHolder& p) const
+JITTypeHolderBase<TAllocator>::operator>=(const JITTypeHolderBase& p) const
 {
     if (this->t != nullptr && p != nullptr)
     {
@@ -148,14 +159,12 @@ JITTypeHolder::operator>=(const JITTypeHolder& p) const
     return false;
 }
 
+template <class TAllocator>
 bool
-JITTypeHolder::operator<(const JITTypeHolder& p) const
+JITTypeHolderBase<TAllocator>::operator<(const JITTypeHolderBase& p) const
 {
     return !(*this >= p);
 }
 
-void
-JITTypeHolder::operator=(const JITTypeHolder &p)
-{
-    this->t = p.t;
-}
+template class JITTypeHolderBase<void>;
+template class JITTypeHolderBase<Recycler>;

--- a/lib/Backend/JITType.h
+++ b/lib/Backend/JITType.h
@@ -29,23 +29,28 @@ private:
     Field(TypeIDL) m_data;
 };
 
-class JITTypeHolder
+template <class TAllocator>
+class JITTypeHolderBase
 {
 public:
-    // SWB-TODO: Fix this. JITTypeHolder is used both as GC object and also
-    // background JIT stack object. The later cannot use write barrier currently.
-    FieldNoBarrier(JITType *) t;
+    Field(JITType *, TAllocator) t;
 
-    JITTypeHolder();
-    JITTypeHolder(JITType * t);
+    JITTypeHolderBase();
+    JITTypeHolderBase(JITType * t);
+
+    template <class S>
+    JITTypeHolderBase(JITTypeHolderBase<S> other) : t(PointerValue(other.t)) {}
+
+    template <class S>
+    void operator =(const JITTypeHolderBase<S> &other) { t = other.t; }
+
     const JITType* operator->() const;
-    bool operator== (const JITTypeHolder& p) const;
-    bool operator!= (const JITTypeHolder& p) const;
-    bool operator> (const JITTypeHolder& p) const;
-    bool operator>= (const JITTypeHolder& p) const;
-    bool operator< (const JITTypeHolder& p) const;
-    bool operator<= (const JITTypeHolder& p) const;
-    void operator =(const JITTypeHolder &p);
+    bool operator== (const JITTypeHolderBase& p) const;
+    bool operator!= (const JITTypeHolderBase& p) const;
+    bool operator> (const JITTypeHolderBase& p) const;
+    bool operator>= (const JITTypeHolderBase& p) const;
+    bool operator< (const JITTypeHolderBase& p) const;
+    bool operator<= (const JITTypeHolderBase& p) const;
     bool operator== (const std::nullptr_t &p) const;
     bool operator!= (const std::nullptr_t &p) const;
 

--- a/lib/Common/Common/vtinfo.h
+++ b/lib/Common/Common/vtinfo.h
@@ -87,6 +87,8 @@ class VirtualTableInfoBase
 {
 public:
     static INT_PTR GetVirtualTable(void * ptr) { return (*(INT_PTR*)ptr); }
+protected:
+    static void SetVirtualTable(void * ptr, INT_PTR vt) { *(INT_PTR*)ptr = vt; }
 };
 
 template <typename T>
@@ -94,15 +96,15 @@ class VirtualTableInfo : public VirtualTableInfoBase
 {
 public:
     static INT_PTR const Address;
-    static INT_PTR RegisterVirtualTable(INT_PTR vtable);
-    static void SetVirtualTable(void * ptr) { new (ptr) T(VirtualTableInfoCtorValue); }
+    static INT_PTR RegisterVirtualTable();
+    static void SetVirtualTable(void * ptr);
     static bool HasVirtualTable(void * ptr) { return GetVirtualTable(ptr) == Address; }
 };
 
 #if !defined(USED_IN_STATIC_LIB)
 #pragma warning(disable:4238) // class rvalue used as lvalue
 template <typename T>
-INT_PTR const VirtualTableInfo<T>::Address = VirtualTableInfo<T>::RegisterVirtualTable(*(INT_PTR const*)&T(VirtualTableInfoCtorValue));
+INT_PTR const VirtualTableInfo<T>::Address = VirtualTableInfo<T>::RegisterVirtualTable();
 #endif
 
 #define DEFINE_VTABLE_CTOR_NOBASE_ABSTRACT(T) \

--- a/lib/Common/Memory/RecyclerPointers.h
+++ b/lib/Common/Memory/RecyclerPointers.h
@@ -227,7 +227,7 @@ template <typename T>
 class NoWriteBarrierField
 {
 public:
-    NoWriteBarrierField() {}
+    NoWriteBarrierField() : value() {}
     explicit NoWriteBarrierField(T const& value) : value(value) {}
 
     // Getters
@@ -255,7 +255,7 @@ template <typename T>
 class NoWriteBarrierPtr
 {
 public:
-    NoWriteBarrierPtr() {}
+    NoWriteBarrierPtr() : value(nullptr) {}
     NoWriteBarrierPtr(T * value) : value(value) {}
 
     // Getters
@@ -307,7 +307,7 @@ template <typename T>
 class WriteBarrierPtr
 {
 public:
-    WriteBarrierPtr() {}
+    WriteBarrierPtr() : ptr(nullptr) {}
     WriteBarrierPtr(T * ptr)
     {
         // WriteBarrier
@@ -396,26 +396,6 @@ public:
         return result;
     }
 
-    static void MoveArray(WriteBarrierPtr * dst, WriteBarrierPtr * src, size_t count)
-    {
-        memmove((void *)dst, src, sizeof(WriteBarrierPtr) * count);
-        WriteBarrier(dst, count);
-    }
-    static void CopyArray(WriteBarrierPtr * dst, size_t dstCount, T* src, size_t srcCount)
-    {
-        js_memcpy_s((void *)dst, sizeof(WriteBarrierPtr) * dstCount, src, sizeof(T *) * srcCount);
-        WriteBarrier(dst, dstCount);
-    }
-    static void CopyArray(WriteBarrierPtr * dst, size_t dstCount, WriteBarrierPtr const* src, size_t srcCount)
-    {
-        js_memcpy_s((void *)dst, sizeof(WriteBarrierPtr) * dstCount, src, sizeof(WriteBarrierPtr) * srcCount);
-        WriteBarrier(dst, dstCount);
-    }
-    static void ClearArray(WriteBarrierPtr * dst, size_t count)
-    {
-        // assigning NULL don't need write barrier, just cast it and null it out
-        memset((void *)dst, 0, sizeof(WriteBarrierPtr<T>) * count);
-    }
 private:
     T * ptr;
 };

--- a/lib/Runtime/Language/InlineCache.cpp
+++ b/lib/Runtime/Language/InlineCache.cpp
@@ -924,7 +924,7 @@ namespace Js
 #endif
 #if ENABLE_NATIVE_CODEGEN
 
-    EquivalentTypeSet::EquivalentTypeSet(JITTypeHolder * types, uint16 count)
+    EquivalentTypeSet::EquivalentTypeSet(JITTypeHolderObject * types, uint16 count)
         : types(types), count(count), sortedAndDuplicatesRemoved(false)
     {
     }
@@ -940,11 +940,6 @@ namespace Js
         return GetType(0);
     }
 
-    JITTypeHolder * EquivalentTypeSet::GetTypes() const
-    {
-        return this->types;
-    }
-
     bool EquivalentTypeSet::Contains(const JITTypeHolder type, uint16* pIndex)
     {
         if (!this->GetSortedAndDuplicatesRemoved())
@@ -953,7 +948,7 @@ namespace Js
         }
         for (uint16 ti = 0; ti < this->count; ti++)
         {
-            if (this->types[ti] == type)
+            if (this->GetType(ti) == type)
             {
                 if (pIndex)
                 {

--- a/lib/Runtime/Language/InlineCache.h
+++ b/lib/Runtime/Language/InlineCache.h
@@ -20,7 +20,9 @@
 // TODO: OOP JIT, move equiv set to backend?
 // forward decl
 class JITType;
-class JITTypeHolder;
+template <class TAllocator> class JITTypeHolderBase;
+typedef JITTypeHolderBase<void> JITTypeHolder;
+typedef JITTypeHolderBase<Recycler> JITTypeHolderObject;
 
 namespace Js
 {
@@ -544,10 +546,10 @@ namespace Js
     private:
         Field(bool) sortedAndDuplicatesRemoved;
         Field(uint16) count;
-        Field(JITTypeHolder *) types;
+        Field(JITTypeHolderObject *) types;
 
     public:
-        EquivalentTypeSet(JITTypeHolder * types, uint16 count);
+        EquivalentTypeSet(JITTypeHolderObject * types, uint16 count);
 
         uint16 GetCount() const
         {
@@ -557,8 +559,6 @@ namespace Js
         JITTypeHolder GetFirstType() const;
 
         JITTypeHolder GetType(uint16 index) const;
-
-        JITTypeHolder * GetTypes() const;
 
         bool GetSortedAndDuplicatesRemoved() const
         {

--- a/lib/Runtime/Language/ObjTypeSpecFldInfo.cpp
+++ b/lib/Runtime/Language/ObjTypeSpecFldInfo.cpp
@@ -326,7 +326,7 @@ namespace Js
         if (forcePoly)
         {
             uint16 typeCount = 1;
-            JITTypeHolder* types = RecyclerNewArray(recycler, JITTypeHolder, typeCount);
+            JITTypeHolderObject* types = RecyclerNewArray(recycler, JITTypeHolderObject, typeCount);
             types[0].t = RecyclerNew(recycler, JITType);
             JITType::BuildFromJsType(type, types[0].t);
             EquivalentTypeSet* typeSet = RecyclerNew(recycler, EquivalentTypeSet, types, typeCount);
@@ -642,7 +642,7 @@ namespace Js
         Assert(jitTransferData != nullptr);
         if (areEquivalent || areStressEquivalent)
         {
-            JITTypeHolder* types = RecyclerNewArray(recycler, JITTypeHolder, typeCount);
+            JITTypeHolderObject* types = RecyclerNewArray(recycler, JITTypeHolderObject, typeCount);
             for (uint16 i = 0; i < typeCount; i++)
             {
                 jitTransferData->AddJitTimeTypeRef(localTypes[i], recycler);


### PR DESCRIPTION
JitTypeHolder is used in both GC and on stack. Change it to a template
class to use with TAllocator respectively.
