### PR TITLE
Fixing on reentrant parsemodulesource.

### DIFF
--- a/bin/NativeTests/JsRTApiTest.cpp
+++ b/bin/NativeTests/JsRTApiTest.cpp
@@ -1689,4 +1689,247 @@ namespace JsRTApiTest
     {
         JsRTApiTest::RunWithAttributes(JsRTApiTest::ScriptTerminationTest);
     }
+
+    struct ModuleResponseData
+    {
+        ModuleResponseData()
+        : mainModule(JS_INVALID_REFERENCE), childModule(JS_INVALID_REFERENCE), mainModuleException(JS_INVALID_REFERENCE), mainModuleReady(false)
+        {
+        }
+        JsModuleRecord mainModule;
+        JsModuleRecord childModule;
+        JsValueRef mainModuleException;
+        bool mainModuleReady;
+    };
+    ModuleResponseData successTest;
+
+    static JsErrorCode CALLBACK Success_FIMC(_In_ JsModuleRecord referencingModule, _In_ JsValueRef specifier, _Outptr_result_maybenull_ JsModuleRecord* dependentModuleRecord)
+    {
+        JsModuleRecord moduleRecord = JS_INVALID_REFERENCE;
+        LPCWSTR specifierStr;
+        size_t length;
+
+        JsErrorCode errorCode = JsStringToPointer(specifier, &specifierStr, &length);
+        REQUIRE(errorCode == JsNoError);
+        REQUIRE(!wcscmp(specifierStr, _u("foo.js")));
+
+        errorCode = JsInitializeModuleRecord(referencingModule, specifier, &moduleRecord);
+        REQUIRE(errorCode == JsNoError);
+        *dependentModuleRecord = moduleRecord;
+        successTest.childModule = moduleRecord;
+        return JsNoError;
+    }
+
+    static JsErrorCode CALLBACK Succes_NMRC(_In_opt_ JsModuleRecord referencingModule, _In_opt_ JsValueRef exceptionVar)
+    {
+        if (successTest.mainModule == referencingModule)
+        {
+            successTest.mainModuleReady = true;
+            successTest.mainModuleException = exceptionVar;
+        }
+        return JsNoError;
+    }
+
+    void ModuleSuccessTest(JsRuntimeAttributes attributes, JsRuntimeHandle runtime)
+    {
+        JsModuleRecord requestModule = JS_INVALID_REFERENCE;
+        JsValueRef specifier;
+
+        REQUIRE(JsPointerToString(_u(""), 1, &specifier) == JsNoError);
+        REQUIRE(JsInitializeModuleRecord(nullptr, specifier, &requestModule) == JsNoError);
+        successTest.mainModule = requestModule;
+        REQUIRE(JsSetModuleHostInfo(requestModule, JsModuleHostInfo_FetchImportedModuleCallback, Success_FIMC) == JsNoError);
+        REQUIRE(JsSetModuleHostInfo(requestModule, JsModuleHostInfo_NotifyModuleReadyCallback, Succes_NMRC) == JsNoError);
+
+        JsValueRef errorObject = JS_INVALID_REFERENCE;
+        const char* fileContent = "import {x} from 'foo.js'";
+        JsErrorCode errorCode = JsParseModuleSource(requestModule, 0, (LPBYTE)fileContent,
+            (unsigned int)strlen(fileContent), JsParseModuleSourceFlags_DataIsUTF8, &errorObject);
+
+        CHECK(errorCode == JsNoError);
+        CHECK(errorObject == JS_INVALID_REFERENCE);
+        CHECK(successTest.mainModuleReady == false);
+        REQUIRE(successTest.childModule != JS_INVALID_REFERENCE);
+
+        errorObject = JS_INVALID_REFERENCE;
+        fileContent = "/*error code*/ var x x";
+
+        errorCode = JsParseModuleSource(successTest.childModule, 1, (LPBYTE)fileContent,
+            (unsigned int)strlen(fileContent), JsParseModuleSourceFlags_DataIsUTF8, &errorObject);
+
+        CHECK(errorCode == JsErrorScriptCompile);
+        CHECK(errorObject != JS_INVALID_REFERENCE);
+
+        CHECK(successTest.mainModuleReady == true);
+        REQUIRE(successTest.mainModuleException != JS_INVALID_REFERENCE);
+        JsPropertyIdRef message = JS_INVALID_REFERENCE;
+
+        REQUIRE(JsGetPropertyIdFromName(_u("message"), &message) == JsNoError);
+
+        JsValueRef value1Check = JS_INVALID_REFERENCE;
+        REQUIRE(JsGetProperty(successTest.mainModuleException, message, &value1Check) == JsNoError);
+
+        JsValueRef asString = JS_INVALID_REFERENCE;
+        REQUIRE(JsConvertValueToString(value1Check, &asString) == JsNoError);
+
+        LPCWSTR str = nullptr;
+        size_t length;
+        REQUIRE(JsStringToPointer(asString, &str, &length) == JsNoError);
+        REQUIRE(!wcscmp(str, _u("Expected ';'")));
+    }
+
+    TEST_CASE("ApiTest_ModuleSuccessTest", "[ApiTest]")
+    {
+        JsRTApiTest::WithSetup(JsRuntimeAttributeEnableExperimentalFeatures, ModuleSuccessTest);
+
+    }
+
+    ModuleResponseData reentrantParseData;
+    static JsErrorCode CALLBACK ReentrantParse_FIMC(_In_ JsModuleRecord referencingModule, _In_ JsValueRef specifier, _Outptr_result_maybenull_ JsModuleRecord* dependentModuleRecord)
+    {
+        JsModuleRecord moduleRecord = JS_INVALID_REFERENCE;
+        LPCWSTR specifierStr;
+        size_t length;
+
+        JsErrorCode errorCode = JsStringToPointer(specifier, &specifierStr, &length);
+        REQUIRE(!wcscmp(specifierStr, _u("foo.js")));
+
+        REQUIRE(errorCode == JsNoError);
+        errorCode = JsInitializeModuleRecord(referencingModule, specifier, &moduleRecord);
+        REQUIRE(errorCode == JsNoError);
+        *dependentModuleRecord = moduleRecord;
+        reentrantParseData.childModule = moduleRecord;
+
+        // directly make a call to parsemodulesource
+        JsValueRef errorObject = JS_INVALID_REFERENCE;
+        const char* fileContent = "/*error code*/ var x x";
+
+        // Not checking the error code.
+        JsParseModuleSource(moduleRecord, 1, (LPBYTE)fileContent,
+            (unsigned int)strlen(fileContent), JsParseModuleSourceFlags_DataIsUTF8, &errorObject);
+
+        // There must be an error
+        CHECK(errorObject != JS_INVALID_REFERENCE);
+
+        // Passed everything is valid.
+        return JsNoError;
+    }
+
+    static JsErrorCode CALLBACK ReentrantParse_NMRC(_In_opt_ JsModuleRecord referencingModule, _In_opt_ JsValueRef exceptionVar)
+    {
+        if (reentrantParseData.mainModule == referencingModule)
+        {
+            reentrantParseData.mainModuleReady = true;
+            reentrantParseData.mainModuleException = exceptionVar;
+        }
+        return JsNoError;
+    }
+
+    void ReentrantParseModuleTest(JsRuntimeAttributes attributes, JsRuntimeHandle runtime)
+    {
+        JsModuleRecord requestModule = JS_INVALID_REFERENCE;
+        JsValueRef specifier;
+
+        REQUIRE(JsPointerToString(_u(""), 1, &specifier) == JsNoError);
+        REQUIRE(JsInitializeModuleRecord(nullptr, specifier, &requestModule) == JsNoError);
+        reentrantParseData.mainModule = requestModule;
+        REQUIRE(JsSetModuleHostInfo(requestModule, JsModuleHostInfo_FetchImportedModuleCallback, ReentrantParse_FIMC) == JsNoError);
+        REQUIRE(JsSetModuleHostInfo(requestModule, JsModuleHostInfo_NotifyModuleReadyCallback, ReentrantParse_NMRC) == JsNoError);
+
+        JsValueRef errorObject = JS_INVALID_REFERENCE;
+        const char* fileContent = "import {x} from 'foo.js'";
+        JsParseModuleSource(requestModule, 0, (LPBYTE)fileContent,
+            (unsigned int)strlen(fileContent), JsParseModuleSourceFlags_DataIsUTF8, &errorObject);
+
+        CHECK(reentrantParseData.mainModuleReady == true);
+        REQUIRE(reentrantParseData.mainModuleException != JS_INVALID_REFERENCE);
+
+        JsPropertyIdRef message = JS_INVALID_REFERENCE;
+
+        REQUIRE(JsGetPropertyIdFromName(_u("message"), &message) == JsNoError);
+
+        JsValueRef value1Check = JS_INVALID_REFERENCE;
+        REQUIRE(JsGetProperty(reentrantParseData.mainModuleException, message, &value1Check) == JsNoError);
+
+        JsValueRef asString = JS_INVALID_REFERENCE;
+        REQUIRE(JsConvertValueToString(value1Check, &asString) == JsNoError);
+
+        LPCWSTR str = nullptr;
+        size_t length;
+        REQUIRE(JsStringToPointer(asString, &str, &length) == JsNoError);
+        REQUIRE(!wcscmp(str, _u("Expected ';'")));
+    }
+
+    TEST_CASE("ApiTest_ReentrantParseModuleTest", "[ApiTest]")
+    {
+        JsRTApiTest::WithSetup(JsRuntimeAttributeEnableExperimentalFeatures, ReentrantParseModuleTest);
+    }
+
+    ModuleResponseData reentrantNoErrorParseData;
+    static JsErrorCode CALLBACK reentrantNoErrorParse_FIMC(_In_ JsModuleRecord referencingModule, _In_ JsValueRef specifier, _Outptr_result_maybenull_ JsModuleRecord* dependentModuleRecord)
+    {
+        JsModuleRecord moduleRecord = JS_INVALID_REFERENCE;
+        LPCWSTR specifierStr;
+        size_t length;
+
+        JsErrorCode errorCode = JsStringToPointer(specifier, &specifierStr, &length);
+        REQUIRE(!wcscmp(specifierStr, _u("foo.js")));
+
+        REQUIRE(errorCode == JsNoError);
+        errorCode = JsInitializeModuleRecord(referencingModule, specifier, &moduleRecord);
+        REQUIRE(errorCode == JsNoError);
+        *dependentModuleRecord = moduleRecord;
+        reentrantNoErrorParseData.childModule = moduleRecord;
+
+        JsValueRef errorObject = JS_INVALID_REFERENCE;
+        const char* fileContent = "export var x = 10;";
+
+        // Not checking the error code.
+        JsParseModuleSource(moduleRecord, 1, (LPBYTE)fileContent,
+            (unsigned int)strlen(fileContent), JsParseModuleSourceFlags_DataIsUTF8, &errorObject);
+
+        // There must be an error
+        CHECK(errorObject == JS_INVALID_REFERENCE);
+
+        return JsNoError;
+    }
+
+    static JsErrorCode CALLBACK reentrantNoErrorParse_NMRC(_In_opt_ JsModuleRecord referencingModule, _In_opt_ JsValueRef exceptionVar)
+    {
+        if (reentrantNoErrorParseData.mainModule == referencingModule)
+        {
+            reentrantNoErrorParseData.mainModuleReady = true;
+            reentrantNoErrorParseData.mainModuleException = exceptionVar;
+        }
+        return JsNoError;
+    }
+
+    void ReentrantNoErrorParseModuleTest(JsRuntimeAttributes attributes, JsRuntimeHandle runtime)
+    {
+        JsModuleRecord requestModule = JS_INVALID_REFERENCE;
+        JsValueRef specifier;
+
+        REQUIRE(JsPointerToString(_u(""), 1, &specifier) == JsNoError);
+        REQUIRE(JsInitializeModuleRecord(nullptr, specifier, &requestModule) == JsNoError);
+        reentrantNoErrorParseData.mainModule = requestModule;
+        REQUIRE(JsSetModuleHostInfo(requestModule, JsModuleHostInfo_FetchImportedModuleCallback, reentrantNoErrorParse_FIMC) == JsNoError);
+        REQUIRE(JsSetModuleHostInfo(requestModule, JsModuleHostInfo_NotifyModuleReadyCallback, reentrantNoErrorParse_NMRC) == JsNoError);
+
+        JsValueRef errorObject = JS_INVALID_REFERENCE;
+        const char* fileContent = "import {x} from 'foo.js'";
+        JsErrorCode errorCode = JsParseModuleSource(requestModule, 0, (LPBYTE)fileContent,
+            (unsigned int)strlen(fileContent), JsParseModuleSourceFlags_DataIsUTF8, &errorObject);
+
+        // This is no error in this module parse.
+        CHECK(errorCode == JsNoError);
+        CHECK(errorObject == JS_INVALID_REFERENCE);
+        CHECK(reentrantNoErrorParseData.mainModuleReady == true);
+        REQUIRE(reentrantNoErrorParseData.mainModuleException == JS_INVALID_REFERENCE);
+    }
+
+    TEST_CASE("ApiTest_ReentrantNoErrorParseModuleTest", "[ApiTest]")
+    {
+        JsRTApiTest::WithSetup(JsRuntimeAttributeEnableExperimentalFeatures, ReentrantNoErrorParseModuleTest);
+    }
+
 }

--- a/bin/NativeTests/stdafx.h
+++ b/bin/NativeTests/stdafx.h
@@ -38,7 +38,7 @@ if (!(exp)) \
 
 #define Assert(exp)             AssertMsg(exp, #exp)
 #define _JSRT_
-#include "chakracommon.h"
+#include "chakracore.h"
 #include "Core/CommonTypedefs.h"
 
 #include <FileLoadHelpers.h>

--- a/lib/Jsrt/Core/JsrtCore.cpp
+++ b/lib/Jsrt/Core/JsrtCore.cpp
@@ -27,6 +27,10 @@ JsInitializeModuleRecord(
         if (normalizedSpecifier != JS_INVALID_REFERENCE)
         {
             childModuleRecord->SetSpecifier(normalizedSpecifier);
+            if (Js::SourceTextModuleRecord::Is(referencingModule) && Js::JavascriptString::Is(normalizedSpecifier))
+            {
+                childModuleRecord->SetParent(Js::SourceTextModuleRecord::FromHost(referencingModule), Js::JavascriptString::FromVar(normalizedSpecifier)->GetSz());
+            }
         }
         return JsNoError;
     });

--- a/lib/Runtime/Language/SourceTextModuleRecord.h
+++ b/lib/Runtime/Language/SourceTextModuleRecord.h
@@ -96,10 +96,8 @@ namespace Js
         ModuleNameRecord* GetNamespaceNameRecord() { return &namespaceRecord; }
 
         SourceTextModuleRecord* GetChildModuleRecord(LPCOLESTR specifier) const;
-#if DBG
-        void AddParent(SourceTextModuleRecord* parentRecord, LPCWSTR specifier, uint32 specifierLength);
-#endif
 
+        void SetParent(SourceTextModuleRecord* parentRecord, LPCOLESTR moduleName);
         Utf8SourceInfo* GetSourceInfo() { return this->pSourceInfo; }
 
     private:


### PR DESCRIPTION
When we get the ParseModuleSource while we fetch module - we go into a state where we don't notify the host about the error or ready state. That makes the module hung.
Fixed that by setting parent and child relation in the InitializeModuleRecord. That way when the ParseModuleSource re-entrancy happens and we can bubble up the error/ready state to parent properly.
Added native unittest for forcing the re-entrant parsemodulesource.
