### PR TITLE
Cmake Automatic Configuration

### DIFF
--- a/ChakraAutoConfigure.cmake
+++ b/ChakraAutoConfigure.cmake
@@ -1,0 +1,68 @@
+
+
+# Simple Macro that Autoconfigures ChakraCore
+MACRO(CHAKRACORE_AUTOCONFIGURE)
+  #-------------------------------
+  # BEGIN CPU Autodetection
+  #-------------------------------
+
+  # Clear up variables that get Modified by this Macro.
+  unset(CC_TARGETS_X86_SH CACHE)
+  unset(CC_TARGETS_AMD64_SH CACHE)
+  unset(CC_TARGETS_X86 CACHE)
+  unset(CC_TARGETS_AMD64 CACHE)
+
+  # Configure CPU Architecture.
+  # Currently only x86 and AMD64 are all that are autocnfigured.
+  if( ${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64|amd64|AMD64")
+    set(CC_TARGETS_AMD64 1)
+    message(STATUS "ChakraCore: Building 64-bit x86 code (AMD64)")
+  elseif( ${CMAKE_SYSTEM_PROCESSOR} MATCHES "i[3-6]86.*|x86.*")
+    set(CC_TARGETS_X86 1)
+    set(CMAKE_SYSTEM_PROCESSOR "i386")
+    message(STATUS "ChakraCore: Building 32-bit x86 code.")
+  else()
+    message(FATAL_ERROR "ChakraCore: Autodetection for ${CMAKE_SYSTEM_PROCESSOR} not supported.")
+  endif()
+
+  #-------------------------------
+  # END CPU Autodetection
+  #-------------------------------
+
+  #-------------------------------
+  # BEGIN Autodection for International Components for Unicode ( ICU )
+  #-------------------------------
+
+  # TODO: Ensure this works for cross-compile.
+ 
+  # Clear all ICU Variables.
+  unset(ICU_SETTINGS_RESET CACHE)
+  unset(ICU_INCLUDE_PATH CACHE)
+  unset(ICU_INCLUDE_PATH_SH CACHE)
+  unset(NO_ICU_PATH_GIVEN_SH CACHE)
+  unset(NO_ICU_PATH_GIVEN CACHE)
+  unset(CC_EMBED_ICU_SH CACHE)
+  unset(CC_AUTODETECT_ICU CACHE)
+  unset(ICULIB CACHE)
+  unset(ICU_CC_PATH CACHE)
+  # Auto-Detect ICU Using pkg-config. 
+  # To Cross-compile using pkg_config use version 0.23 or newer.
+  # Also do not forget to specify the following variables:
+  # System Root is defined using: PKG_CONFIG_SYSROOT_DIR
+  # pkg-config default Search path: PKG_CONFIG_LIBDIR
+  # pkg-config additional search paths: PKG_CONFIG_PATH
+  # NOTE: you can make PKG_CONFIG_LIBDIR and PKG_CONFIG_PATH identical.
+  find_package(PkgConfig)
+  if(PKG_CONFIG_FOUND)
+    # Find ICU Common and Data files
+    pkg_check_modules(PKGCFG_ICU_UC icu-uc)
+    # Find ICU Internationalization Library.
+    pkg_check_modules(PKGCFG_ICU_I18N icu-i18n)
+    if(PKGCFG_ICU_UC_FOUND AND PKGCFG_ICU_I18N_FOUND)
+      # This should include internationalization.
+      set(ICU_CC_PATH "${PKGCFG_ICU_UC_INCLUDE_DIRS}")
+      set(ICULIB      "${PKGCFG_ICU_UC_LDFLAGS}")
+    endif()
+  endif()
+ENDMACRO(CHAKRACORE_AUTOCONFIGURE)
+

--- a/bin/ChakraCore/CMakeLists.txt
+++ b/bin/ChakraCore/CMakeLists.txt
@@ -59,7 +59,7 @@ if(CC_TARGETS_X86)
   set(lib_target "${lib_target} -m32")
 endif()
 
-target_link_libraries (ChakraCore ${lib_target})
+target_link_libraries (ChakraCore PRIVATE ${lib_target})
 
 if(NOT CC_XCODE_PROJECT)
   set(CC_LIB_EXT "so")


### PR DESCRIPTION
This is a rework for the ChakraCore automatic configuration. This is two patches that will allow many developers to quickly start developing using ChakraCore. I will be pushing a rework of the patches to the ChakraCore examples later, however the general process for this is as follows:


An example of how to use this is as follows...
```CMake
# include Auto-Configure macro.
include("${CMAKE_SOURCE_DIR}/ChakraCore/ChakraAutoConfigure.cmake")
# Configure ChakraCore:
CHAKRACORE_AUTOCONFIGURE()
add_subdirectory(ChakraCore)
add_custom_target(CopyChakraHeaders ALL
	COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_BINARY_DIR}/include"
	COMMAND ${CMAKE_COMMAND} -E copy_if_different
		"${CMAKE_SOURCE_DIR}/ChakraCore/lib/Jsrt/ChakraCore.h"
		"${CMAKE_BINARY_DIR}/include"
	COMMAND ${CMAKE_COMMAND} -E copy_if_different
		"${CMAKE_SOURCE_DIR}/ChakraCore/lib/Jsrt/ChakraCommon.h"
		"${CMAKE_BINARY_DIR}/include"
	COMMAND ${CMAKE_COMMAND} -E copy_if_different
		"${CMAKE_SOURCE_DIR}/ChakraCore/lib/Jsrt/ChakraCommonWindows.h"
		"${CMAKE_BINARY_DIR}/include"
	COMMAND ${CMAKE_COMMAND} -E copy_if_different
		"${CMAKE_SOURCE_DIR}/ChakraCore/lib/Jsrt/ChakraDebug.h"
		"${CMAKE_BINARY_DIR}/include"
)
# enable C++11
add_executable(ChakraSample sample.cpp)
set_target_properties(ChakraSample PROPERTIES COMPILE_FLAGS "-std=c++11")
# link to ChakraCore.
target_link_libraries(ChakraSample ChakraCore)
# Make sure Chakra Core Headers are in a location that is easy to use.
add_dependencies(ChakraSample CopyChakraHeaders)
# Actually include the headers.
target_include_directories(ChakraSample PUBLIC "${CMAKE_BINARY_DIR}/include")
```
