### PR TITLE
Fix crash due to label breaking precise captures

### DIFF
--- a/test/Closures/bug_OS_9008744.js
+++ b/test/Closures/bug_OS_9008744.js
@@ -1,0 +1,23 @@
+function XLFuzzTest() {
+  try {
+    do {
+      function apInitTest() {
+        do {
+          function apEndTest() {
+            do {
+              apInitTest:
+                if (false) {
+                  return;
+                }
+              return;
+            } while (false);
+          }
+        } while (false);
+      }
+    } while (false);
+  } catch (e) {}
+}
+for (var i = 0; i < 1; i++) {
+  XLFuzzTest();
+}
+print("PASSED");

--- a/test/Closures/rlexe.xml
+++ b/test/Closures/rlexe.xml
@@ -158,4 +158,10 @@
       <tags>BugFix</tags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>bug_OS_9008744.js</files>
+      <tags>BugFix,exclude_dynapogo</tags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
Precise closure capture breaks when a label exists with the same name as a variable or function.

Label parsing used to rely on ParseExpr(), checking after the fact to see if the expression was a single identifier and if it is followed by a tkColon. Since it parsed, however, a pidref was pushed for the identifier setting up a new reference to that identifier which could then trick the front-end into thinking there was a closure capture where there actually wasn't.  This leads to invalid StSlots and LdSlots.

Fix it by looking for a label before parsing as an expression statement. Labels are by spec exactly a tkID followed by a tkColon.  Chakra unfortunately allows parenthesized label names, so we also check for balanced open and close parentheses here to maintain that behavior.  We will remove this legacy behavior in a future release.

If we don't find a label pattern in the syntax then we rewind and parse as an expression statement.