### PR TITLE
Fix LdLen operand tags

### DIFF
--- a/lib/Backend/GlobOpt.h
+++ b/lib/Backend/GlobOpt.h
@@ -1322,6 +1322,7 @@ private:
     void                    MergeCapturedValues(GlobOptBlockData * toData, SListBase<CapturedList> * toList, SListBase<CapturedList> * fromList, CapturedItemsAreEqual itemsAreEqual);
     void                    MergeBlockData(GlobOptBlockData *toData, BasicBlock *toBlock, BasicBlock *fromBlock, BVSparse<JitArenaAllocator> *const symsRequiringCompensation, BVSparse<JitArenaAllocator> *const symsCreatedForMerge, bool forceTypeSpecOnLoopHeader);
     void                    DeleteBlockData(GlobOptBlockData *data);
+    void                    TryReplaceLdLen(IR::Instr *& instr);
     IR::Instr *             OptInstr(IR::Instr *&instr, bool* isInstrCleared);
     Value*                  OptDst(IR::Instr **pInstr, Value *dstVal, Value *src1Val, Value *src2Val, Value *dstIndirIndexVal, Value *src1IndirIndexVal);
     void                    CopyPropDstUses(IR::Opnd *opnd, IR::Instr *instr, Value *src1Val);

--- a/lib/Backend/Sym.h
+++ b/lib/Backend/Sym.h
@@ -86,13 +86,14 @@ public:
 
 class StackSym: public Sym
 {
+private:
+    static StackSym * New(SymID id, IRType type, Js::RegSlot byteCodeRegSlot, Func *func);
 public:
     static StackSym * NewArgSlotSym(Js::ArgSlot argSlotNum, Func * func, IRType = TyVar);
     static StackSym * NewArgSlotRegSym(Js::ArgSlot argSlotNum, Func * func, IRType = TyVar);
     static StackSym * NewParamSlotSym(Js::ArgSlot argSlotNum, Func * func);
     static StackSym * NewParamSlotSym(Js::ArgSlot argSlotNum, Func * func, IRType type);
     static StackSym *NewImplicitParamSym(Js::ArgSlot paramSlotNum, Func * func);
-    static StackSym * New(SymID id, IRType type, Js::RegSlot byteCodeRegSlot, Func *func);
     static StackSym * New(IRType type, Func *func);
     static StackSym * New(Func *func);
     static StackSym * FindOrCreate(SymID id, Js::RegSlot byteCodeRegSlot, Func *func, IRType type = TyVar);

--- a/test/fieldopts/argobjlengthhoist.js
+++ b/test/fieldopts/argobjlengthhoist.js
@@ -1,0 +1,26 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function Tm()
+{
+    var n = arguments[0];
+    for(var s = 0; s<n.length; s++)
+    {
+        var f = n.charCodeAt(s);
+    }
+}
+
+Tm("reallyLongTestString" + Math.random());
+Tm("reallyLongTestString" + Math.random());
+Tm("reallyLongTestString" + Math.random());
+Tm("reallyLongTestString" + Math.random());
+Tm("reallyLongTestString" + Math.random());
+Tm("reallyLongTestString" + Math.random());
+Tm("reallyLongTestString" + Math.random());
+Tm("reallyLongTestString" + Math.random());
+Tm("reallyLongTestString" + Math.random());
+Tm("reallyLongTestString" + Math.random());
+
+WScript.Echo("pass");

--- a/test/fieldopts/rlexe.xml
+++ b/test/fieldopts/rlexe.xml
@@ -876,4 +876,9 @@
       <baseline>add-prop-to-dictionary.baseline</baseline>
     </default>
   </test>
+  <test>
+    <default>
+      <files>argobjlengthhoist.js</files>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
In the change to defer handling of length field loads until later in the optimizer, the need arose to move from a LdFld on a PropertySym SymOpnd to a StackSym RegOpnd (ldfld a->length to ldlen a). Unfortunately, in this transition a few flags were lost on the operand; the most notable is the isJITOptimized flag, which was causing an assert to be hit a good number of times.