### PR TITLE
fixes for enabling write barrier testing on windows

### DIFF
--- a/lib/Common/Memory/Recycler.cpp
+++ b/lib/Common/Memory/Recycler.cpp
@@ -995,8 +995,8 @@ Recycler::GetRecyclerPageAllocator()
     {
         return &this->recyclerWithBarrierPageAllocator;
     }
-#endif
     else
+#endif
     {
 #ifdef RECYCLER_WRITE_WATCH
         return &this->recyclerPageAllocator;

--- a/lib/Common/Memory/Recycler.inl
+++ b/lib/Common/Memory/Recycler.inl
@@ -93,8 +93,7 @@ Recycler::AllocWithAttributesInlined(DECLSPEC_GUARD_OVERFLOW size_t size)
 
     char* memBlock = nullptr;
 #if GLOBAL_ENABLE_WRITE_BARRIER
-    if (CONFIG_FLAG(ForceSoftwareWriteBarrier)
-        && ((attributes & LeafBit) != LeafBit || (attributes & FinalizeBit) == FinalizeBit)) // there's no Finalize Leaf bucket
+    if (CONFIG_FLAG(ForceSoftwareWriteBarrier) && (attributes & InternalObjectInfoBitMask ) != LeafBit)
     {
         // explicitly adding "& ~LeafBit" to avoid the CompilerAssert in SmallFinalizableHeapBucket.h
         // pure LeafBit going through the else below, and use the LeafBit specialization to get the bucket

--- a/lib/Common/Memory/Recycler.inl
+++ b/lib/Common/Memory/Recycler.inl
@@ -94,10 +94,12 @@ Recycler::AllocWithAttributesInlined(DECLSPEC_GUARD_OVERFLOW size_t size)
     char* memBlock = nullptr;
 #if GLOBAL_ENABLE_WRITE_BARRIER
     if (CONFIG_FLAG(ForceSoftwareWriteBarrier)
-        && ((attributes & LeafBit) != LeafBit
-            || (attributes & FinalizeBit) == FinalizeBit)) // there's no Finalize Leaf bucket
+        && ((attributes & LeafBit) != LeafBit || (attributes & FinalizeBit) == FinalizeBit)) // there's no Finalize Leaf bucket
     {
-        memBlock = RealAlloc<(ObjectInfoBits)((attributes | WithBarrierBit) & InternalObjectInfoBitMask), nothrow>(&autoHeap, allocSize);
+        // explicitly adding "& ~LeafBit" to avoid the CompilerAssert in SmallFinalizableHeapBucket.h
+        // pure LeafBit going through the else below, and use the LeafBit specialization to get the bucket
+        // if there FinalizeBit, it goes through FinalizeWithBarrier bucket, whatever there's LeafBit or not
+        memBlock = RealAlloc<(ObjectInfoBits)(((attributes | WithBarrierBit) & ~LeafBit) & InternalObjectInfoBitMask), nothrow>(&autoHeap, allocSize);
     }
     else
 #endif

--- a/lib/Common/Memory/RecyclerWriteBarrierManager.cpp
+++ b/lib/Common/Memory/RecyclerWriteBarrierManager.cpp
@@ -71,10 +71,18 @@ X64WriteBarrierCardTableManager::OnThreadInit()
     this->_stacklimit = (char*)stackEnd;
 #endif
 
-    // on Windows server 2012 stack limit can expand with process running, and causes
-    // accessing uncommitted card table page.
-    // TODO: use VirtualQuery twice to get the max possible stack limit
-    stackEnd -= AutoSystemInfo::PageSize * AutoSystemInfo::PageSize;
+    MEMORY_BASIC_INFORMATION memInfo;
+    VirtualQuery(stackEnd, &memInfo, sizeof(memInfo));
+
+    // using AllocationBase, while allocating stack, the OS reserve a chunk of memory for stack expanding, layout looks like:
+    // ----|-------------------------|-------------------|---------------------------------|---------------------
+    // stackBase  commited     stackLimit GuardPages            reserved region         hard limit
+    // the GuardPages can slide right in the reserved region while stack expanding, until hit the hard limit
+    // the AllocationBase from the VirtualQuery is the whole region possibly used for stack
+    // the BaseAddress from VirtualQuery is current commited base address, we can also query the region of GuardPages but seems not necessary
+
+    stackEnd = (char*)memInfo.AllocationBase;
+    Assert(memInfo.AllocationProtect == PAGE_READWRITE);
 
     size_t numPages = (stackBase - stackEnd) / AutoSystemInfo::PageSize;
     // stackEnd is the lower boundary

--- a/lib/Common/Memory/RecyclerWriteBarrierManager.cpp
+++ b/lib/Common/Memory/RecyclerWriteBarrierManager.cpp
@@ -93,6 +93,7 @@ X64WriteBarrierCardTableManager::OnThreadInit()
     pthread_attr_init(&attr);
     pthread_attr_getstacksize(&attr, &stacksize); // assuming no one is calling pthread_attr_setstacksize afterwards
     stackEnd = stackBase - stacksize;
+    pthread_attr_destroy(&attr);
 #endif
 
     size_t numPages = (stackBase - stackEnd) / AutoSystemInfo::PageSize;

--- a/lib/Common/Memory/SmallFinalizableHeapBucket.h
+++ b/lib/Common/Memory/SmallFinalizableHeapBucket.h
@@ -81,6 +81,7 @@ template <ObjectInfoBits attributes, class TBlockAttributes>
 class SmallHeapBlockType
 {
 public:
+    CompileAssert(attributes & FinalizeBit);
     typedef SmallFinalizableHeapBlockT<TBlockAttributes> BlockType;
     typedef SmallFinalizableHeapBucketT<TBlockAttributes> BucketType;
 };
@@ -173,7 +174,7 @@ class HeapBucketGroup
         typedef typename SmallHeapBlockType<objectAttributes, TBlockAttributes>::BucketType BucketType;
         static BucketType& GetBucket(HeapBucketGroup<TBlockAttributes> * heapBucketGroup)
         {
-            Assert(objectAttributes & FinalizeBit);
+            CompileAssert(objectAttributes & FinalizeBit);
             return heapBucketGroup->finalizableHeapBucket;
         }
     };

--- a/lib/Runtime/Language/ObjTypeSpecFldInfo.cpp
+++ b/lib/Runtime/Language/ObjTypeSpecFldInfo.cpp
@@ -533,7 +533,7 @@ namespace Js
 
         // Need to create a local array here and not allocate one from the recycler,
         // as the allocation may trigger a GC which can clear the inline caches.
-        FixedFieldInfo localFixedFieldInfoArray[Js::DynamicProfileInfo::maxPolymorphicInliningSize] = { 0 };
+        FixedFieldInfo localFixedFieldInfoArray[Js::DynamicProfileInfo::maxPolymorphicInliningSize] = { };
 
         // For polymorphic field loads we only support fixed functions on prototypes. This helps keep the equivalence check helper simple.
         // Since all types in the polymorphic cache share the same prototype, it's enough to grab the fixed function from the prototype object.


### PR DESCRIPTION
restore the compiler assert, thanks @curtisman  for the better solution
use VirtualQuery to get the reserve limit for the stack
