### PR TITLE
Expand an assert in FunctionEntryPointInfo::Expire

### DIFF
--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -9733,8 +9733,8 @@ namespace Js
                 }
                 else
                 {
-                    Assert(functionType->GetEntryPointInfo()->IsFunctionEntryPointInfo());
-                    Assert(((FunctionEntryPointInfo*)functionType->GetEntryPointInfo())->IsCleanedUp()
+                    Assert(!functionType->GetEntryPointInfo()->IsFunctionEntryPointInfo() || 
+                        ((FunctionEntryPointInfo*)functionType->GetEntryPointInfo())->IsCleanedUp()
                         || (DWORD_PTR)functionType->GetEntryPoint() != this->GetNativeAddress());
                 }
             });


### PR DESCRIPTION
With redeferral, function types can point to a ProxyEntryPointInfo object too. Expand an assert for that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/2127)
<!-- Reviewable:end -->
