### PR TITLE
xplat: add ChakraCoreHeaders target.

### DIFF
--- a/bin/ChakraCore/CMakeLists.txt
+++ b/bin/ChakraCore/CMakeLists.txt
@@ -75,3 +75,6 @@ if(NOT CC_XCODE_PROJECT)
     ${CHAKRACORE_BINARY_DIR}/
     )
 endif()
+
+add_dependencies(ChakraCore ChakraCoreHeaders)
+

--- a/lib/Jsrt/CMakeLists.txt
+++ b/lib/Jsrt/CMakeLists.txt
@@ -52,3 +52,25 @@ target_include_directories (
     ../Runtime/Debug
     ../Parser
     )
+
+
+add_custom_target(ChakraCoreHeaders ALL
+  COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_BINARY_DIR}/include"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    "${CMAKE_CURRENT_SOURCE_DIR}/ChakraCore.h"
+    "${CMAKE_BINARY_DIR}/include"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    "${CMAKE_CURRENT_SOURCE_DIR}/ChakraCommon.h"
+    "${CMAKE_BINARY_DIR}/include"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    "${CMAKE_CURRENT_SOURCE_DIR}/ChakraDebug.h"
+    "${CMAKE_BINARY_DIR}/include"
+  )
+
+if(MSVC OR WIN32)
+  add_custom_command(TARGET ChakraCoreHeaders POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+      "${CMAKE_CURRENT_SOURCE_DIR}/ChakraCommonWindows.h"
+      "${CMAKE_BINARY_DIR}/include"
+    )
+endif()


### PR DESCRIPTION
Currently only the ChakraCore shared library uses this target, however this
target is also extremely useful for Static Library builds. To use this
target with any other target library/executable, simply add the following
line to cmake:

add_dependencies(myTarget ChakraCoreHeaders)

/cc @obastemur - Here is your request for adding a target for ChakraCoreHeaders. Also, this is future proofed a little for if/when using cmake to target MSVC/windows is added.