### PR TITLE
xplat: reduce source changes between Static and Shared Libraries.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,10 +167,6 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL AppleClang
     add_definitions("-fdiagnostics-color=always")
 endif()
 
-if(STATIC_LIBRARY)
-    add_definitions(-DCHAKRA_STATIC_LIBRARY=1)
-endif()
-
 if(CLR_CMAKE_PLATFORM_XPLAT)
     add_definitions(-DFEATURE_PAL)
     add_definitions(-DPLATFORM_UNIX=1)

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_subdirectory (GCStress)
+add_subdirectory (ChakraCore)
 add_subdirectory (ch)
-if(NOT STATIC_LIBRARY)
-    add_subdirectory (ChakraCore)
-endif()
+
+

--- a/bin/ChakraCore/CMakeLists.txt
+++ b/bin/ChakraCore/CMakeLists.txt
@@ -1,8 +1,38 @@
+
+
+add_library (ChakraCoreStatic STATIC 
+  ChakraCoreCommon.cpp
+  ConfigParserExternals.cpp
+  TestHooks.cpp
+  ${Chakra.Jsrt}
+  )
+
 add_library (ChakraCore SHARED
+  ChakraCoreCommon.cpp
   ChakraCoreDllFunc.cpp
   ConfigParserExternals.cpp
   TestHooks.cpp
-)
+  )
+
+target_compile_options(ChakraCoreStatic PRIVATE "-fPIC")
+target_compile_definitions(ChakraCoreStatic
+  PUBLIC
+    -DCHAKRA_STATIC_LIBRARY=1
+  )
+CHAKRACORE_ADD_JSRT_OBJECTS(ChakraCore)
+CHAKRACORE_ADD_JSRT_OBJECTS(ChakraCoreStatic)
+
+target_include_directories (
+  ChakraCoreStatic PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  ${CHAKRACORE_SOURCE_DIR}/lib/Common
+  ${CHAKRACORE_SOURCE_DIR}/lib/Runtime
+  ${CHAKRACORE_SOURCE_DIR}/lib/Parser
+  ${CHAKRACORE_SOURCE_DIR}/lib/Jsrt
+  ${CHAKRACORE_SOURCE_DIR}/lib/JITIDL
+  ${CHAKRACORE_SOURCE_DIR}/lib/Backend
+  ${CHAKRACORE_SOURCE_DIR}/lib/Runtime/ByteCode/
+  )
 
 target_include_directories (
   ChakraCore PUBLIC
@@ -11,6 +41,9 @@ target_include_directories (
   ${CHAKRACORE_SOURCE_DIR}/lib/Runtime
   ${CHAKRACORE_SOURCE_DIR}/lib/Parser
   ${CHAKRACORE_SOURCE_DIR}/lib/Jsrt
+  ${CHAKRACORE_SOURCE_DIR}/lib/JITIDL
+  ${CHAKRACORE_SOURCE_DIR}/lib/Backend
+  ${CHAKRACORE_SOURCE_DIR}/lib/Runtime/ByteCode/
   )
 
 #
@@ -39,9 +72,9 @@ endif()
 set(lib_target "${lib_target}"
   -Wl,-undefined,error
   ${LINKER_START_GROUP}
-  Chakra.Pal
-  Chakra.Common.Core
-  Chakra.Jsrt
+  #Chakra.Pal
+  #Chakra.Common.Core
+  #Chakra.Jsrt
   ${LINKER_END_GROUP}
   pthread
   stdc++
@@ -49,16 +82,36 @@ set(lib_target "${lib_target}"
   ${ICULIB}
   )
 
-if(CMAKE_SYSTEM_NAME STREQUAL Linux)
+if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
   set(lib_target "${lib_target}"
-    -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/libChakraCoreLib.version
-    )
+    "-framework CoreFoundation"
+    "-framework Security"
+  )
+elseif(CMAKE_SYSTEM_NAME STREQUAL Linux)
+  if(CC_TARGETS_AMD64)
+      set(lib_target "${lib_target}"
+        unwind-x86_64
+      )
+  endif()
+
+  set(lib_target "${lib_target}"
+    gcc_s
+    rt
+    unwind
+    unwind-generic
+  )
 endif()
 
 if(CC_TARGETS_X86)
   set(lib_target "${lib_target} -m32")
 endif()
+target_link_libraries (ChakraCoreStatic ${lib_target})
 
+if(CMAKE_SYSTEM_NAME STREQUAL Linux)
+  set(lib_target "${lib_target}"
+    -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/libChakraCoreLib.version
+    )
+endif()
 target_link_libraries (ChakraCore ${lib_target})
 
 if(NOT CC_XCODE_PROJECT)

--- a/bin/ChakraCore/ChakraCore.vcxproj
+++ b/bin/ChakraCore/ChakraCore.vcxproj
@@ -68,6 +68,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="$(MsBuildThisFileDirectory)ConfigParserExternals.cpp" />
+    <ClCompile Include="$(MsBuildThisFileDirectory)ChakraCoreCommon.cpp" />
     <ClCompile Include="$(MsBuildThisFileDirectory)ChakraCoreDllFunc.cpp" />
     <ClCompile Include="$(MsBuildThisFileDirectory)TestHooks.cpp" />
     <None Include="..\CoreCommon.ver" />

--- a/bin/ChakraCore/ChakraCoreCommon.cpp
+++ b/bin/ChakraCore/ChakraCoreCommon.cpp
@@ -1,0 +1,132 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+#include "JsrtPch.h"
+#include "jsrtHelper.h"
+#include "Base/ThreadContextTlsEntry.h"
+#include "Base/ThreadBoundThreadContextManager.h"
+#include "Core/ConfigParser.h"
+
+void ChakraBinaryAutoSystemInfoInit(AutoSystemInfo * autoSystemInfo)
+{
+    autoSystemInfo->buildDateHash = JsUtil::CharacterBuffer<char>::StaticGetHashCode(__DATE__, _countof(__DATE__));
+    autoSystemInfo->buildTimeHash = JsUtil::CharacterBuffer<char>::StaticGetHashCode(__TIME__, _countof(__TIME__));
+}
+
+// todo: We need an interface for thread/process exit.
+// At the moment we do handle thread exit for non main threads on xplat
+// However, it could be nice/necessary to provide an interface to make sure
+// we cover additional edge cases.
+
+#ifndef _WIN32
+#include <pthread.h>
+static pthread_key_t s_threadLocalDummy;
+#endif
+
+static THREAD_LOCAL bool s_threadWasEntered = false;
+
+_NOINLINE void DISPOSE_CHAKRA_CORE_THREAD(void *_)
+{
+    free(_);
+    ThreadBoundThreadContextManager::DestroyContextAndEntryForCurrentThread();
+}
+
+_NOINLINE bool InitializeProcess()
+{
+#if !defined(_WIN32)
+    pthread_key_create(&s_threadLocalDummy, DISPOSE_CHAKRA_CORE_THREAD);
+#endif
+
+// setup the cleanup
+// we do not track the main thread. When it exits do the cleanup below
+atexit([]() {
+    ThreadBoundThreadContextManager::DestroyContextAndEntryForCurrentThread();
+
+    JsrtRuntime::Uninitialize();
+
+    // thread-bound entrypoint should be able to get cleanup correctly, however tlsentry
+    // for current thread might be left behind if this thread was initialized.
+    ThreadContextTLSEntry::CleanupThread();
+    ThreadContextTLSEntry::CleanupProcess();
+});
+
+// Attention: shared library is handled under (see ChakraCore/ChakraCoreDllFunc.cpp)
+// todo: consolidate similar parts from shared and static library initialization
+#ifndef _WIN32
+    PAL_InitializeChakraCore(0, NULL);
+#endif
+
+    HMODULE mod = GetModuleHandleW(NULL);
+
+    AutoSystemInfo::SaveModuleFileName(mod);
+
+#if defined(_M_IX86) && !defined(__clang__)
+    // Enable SSE2 math functions in CRT if SSE2 is available
+#pragma prefast(suppress:6031, "We don't require SSE2, but will use it if available")
+    _set_SSE2_enable(TRUE);
+#endif
+
+    {
+        CmdLineArgsParser parser;
+        ConfigParser::ParseOnModuleLoad(parser, mod);
+    }
+
+#ifdef ENABLE_JS_ETW
+    EtwTrace::Register();
+#endif
+    ValueType::Initialize();
+    ThreadContext::GlobalInitialize();
+
+    // Needed to make sure that only ChakraCore is loaded into the process
+    // This is unnecessary on Linux since there aren't other flavors of
+    // Chakra binaries that can be loaded into the process
+#ifdef _WIN32
+    char16 *engine = szChakraCoreLock;
+    if (::FindAtom(szChakraLock) != 0)
+    {
+        AssertMsg(FALSE, "Expecting to load chakracore.dll but process already loaded chakra.dll");
+        Binary_Inconsistency_fatal_error();
+    }
+    lockedDll = ::AddAtom(engine);
+    AssertMsg(lockedDll, "Failed to lock chakracore.dll");
+#endif // _WIN32
+
+#ifdef ENABLE_BASIC_TELEMETRY
+    g_TraceLoggingClient = NoCheckHeapNewStruct(TraceLoggingClient);
+#endif
+
+#ifdef DYNAMIC_PROFILE_STORAGE
+    DynamicProfileStorage::Initialize();
+#endif
+    return true;
+}
+
+_NOINLINE void VALIDATE_ENTER_CURRENT_THREAD()
+{
+
+#if defined(CHAKRA_STATIC_LIBRARY) || !defined(_WIN32)
+    // We do also initialize the process part here
+    // This is thread safe by the standard
+    // Let's hope compiler doesn't fail
+    static bool _has_init = InitializeProcess();
+
+    if (!_has_init) // do not assert this.
+    {
+        abort();
+    }
+
+    if (s_threadWasEntered) return;
+    s_threadWasEntered = true;
+
+#ifdef HEAP_TRACK_ALLOC
+    HeapAllocator::InitializeThread();
+#endif
+
+#ifndef _WIN32
+    // put something into key to make sure destructor is going to be called
+    pthread_setspecific(s_threadLocalDummy, malloc(1));
+#endif
+#endif
+}
+

--- a/bin/ChakraCore/ChakraCoreDllFunc.cpp
+++ b/bin/ChakraCore/ChakraCoreDllFunc.cpp
@@ -199,12 +199,6 @@ EXTERN_C BOOL WINAPI DllMain(HINSTANCE hmod, DWORD dwReason, PVOID pvReserved)
     }
 }
 
-void ChakraBinaryAutoSystemInfoInit(AutoSystemInfo * autoSystemInfo)
-{
-    autoSystemInfo->buildDateHash = JsUtil::CharacterBuffer<char>::StaticGetHashCode(__DATE__, _countof(__DATE__));
-    autoSystemInfo->buildTimeHash = JsUtil::CharacterBuffer<char>::StaticGetHashCode(__TIME__, _countof(__TIME__));
-}
-
 #if !ENABLE_NATIVE_CODEGEN
 EXPORT_FUNC
 HRESULT JsInitializeJITServer(

--- a/bin/GCStress/CMakeLists.txt
+++ b/bin/GCStress/CMakeLists.txt
@@ -26,9 +26,8 @@ endif()
 set(lib_target "${lib_target}"
   -Wl,-undefined,error
   ${LINKER_START_GROUP}
-  Chakra.Common.Core
-  Chakra.Pal
-  Chakra.Jsrt
+  #Chakra.Pal
+  ChakraCoreStatic
   ${LINKER_END_GROUP}
   )
 

--- a/bin/ch/CMakeLists.txt
+++ b/bin/ch/CMakeLists.txt
@@ -1,18 +1,11 @@
 set(ch_source_files
   ch.cpp
   ChakraRtInterface.cpp
-  CodexAssert.cpp
   Debugger.cpp
   Helpers.cpp
   HostConfigFlags.cpp
   WScriptJsrt.cpp
   )
-
-if (STATIC_LIBRARY)
-  set(ch_source_files "${ch_source_files}"
-    ../ChakraCore/TestHooks.cpp
-    )
-endif()
 
 add_executable (ch ${ch_source_files})
 
@@ -45,38 +38,47 @@ if(STATIC_LIBRARY)
   elseif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
     set(LINKER_START_GROUP -Wl,-force_load,)
   endif()
-
   # common link deps
   set(lib_target "${lib_target}"
-    -Wl,-undefined,error
-    ${LINKER_START_GROUP}
-    Chakra.Pal
-    Chakra.Common.Core
-    Chakra.Jsrt
-    ${LINKER_END_GROUP}
+    ChakraCoreStatic
     pthread
     stdc++
     dl
   )
 
-  if(CMAKE_SYSTEM_NAME STREQUAL Linux)
-    set(lib_target "${lib_target}"
-      ${ICULIB}
-      unwind-x86_64
-      )
-  elseif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
-    set(lib_target "${lib_target}"
-      ${ICULIB}
-      "-framework CoreFoundation"
-      "-framework Security"
-      )
-  endif() # Linux ?
 else() # // shared library below
-  set(lib_target
-    PRIVATE Chakra.Pal
+  target_sources(ch PRIVATE
+    CodexAssert.cpp
+    $<TARGET_OBJECTS:Chakra.Pal>
+    )
+
+  set(lib_target "${lib_target}"
     PRIVATE Chakra.Common.Codex.Singular
     PRIVATE Chakra.Runtime.PlatformAgnostic.Singular
+    pthread
+    dl
+    ${ICULIB}
     )
+endif()
+
+if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  set(lib_target "${lib_target}"
+    "-framework CoreFoundation"
+    "-framework Security"
+  )
+elseif(CMAKE_SYSTEM_NAME STREQUAL Linux)
+  if(CC_TARGETS_AMD64)
+      set(lib_target "${lib_target}"
+        unwind-x86_64
+      )
+  endif()
+
+  set(lib_target "${lib_target}"
+    gcc_s
+    rt
+    unwind
+    unwind-generic
+  )
 endif()
 
 if(NOT CC_XCODE_PROJECT)

--- a/lib/Common/Core/CMakeLists.txt
+++ b/lib/Common/Core/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library (Chakra.Common.Core STATIC
+add_library (Chakra.Common.Core OBJECT
     Api.cpp
     BinaryFeatureControl.cpp
     CmdParser.cpp

--- a/lib/Jsrt/CMakeLists.txt
+++ b/lib/Jsrt/CMakeLists.txt
@@ -1,8 +1,5 @@
-if(BuildJIT)
-    set(chakra_backend_objects $<TARGET_OBJECTS:Chakra.Backend>)
-endif()
 
-add_library (Chakra.Jsrt STATIC
+add_library (Chakra.Jsrt.object OBJECT
     Jsrt.cpp
     JsrtDebugUtils.cpp
     JsrtDebugManager.cpp
@@ -17,12 +14,27 @@ add_library (Chakra.Jsrt STATIC
     JsrtRuntime.cpp
     JsrtSourceHolder.cpp
     JsrtThreadService.cpp
+    )
+
+macro(CHAKRACORE_ADD_JSRT_OBJECTS _TARGET)
+  target_sources(${_TARGET} PRIVATE
+    $<TARGET_OBJECTS:Chakra.Pal>
+    $<TARGET_OBJECTS:Chakra.Common.Core>
+    $<TARGET_OBJECTS:Chakra.Common.Memory>
+    $<TARGET_OBJECTS:Chakra.Common.Exceptions>
+    $<TARGET_OBJECTS:Chakra.Runtime.PlatformAgnostic>
     $<TARGET_OBJECTS:Chakra.Jsrt.Core>
-    ${chakra_backend_objects}
+    )
+  if(TARGET Chakra.Backend)
+    target_sources(${_TARGET} PRIVATE
+      $<TARGET_OBJECTS:Chakra.Backend>
+      )
+  endif()
+  target_sources(${_TARGET} PRIVATE  
 #   Do not take this in. We need to control the
 #   linker order because of global constructors
 #   and cross dependencies among them
-#   $<TARGET_OBJECTS:Chakra.Common.Core>
+    $<TARGET_OBJECTS:Chakra.Common.Core>
     $<TARGET_OBJECTS:Chakra.Common.Common>
     $<TARGET_OBJECTS:Chakra.Common.Codex>
     $<TARGET_OBJECTS:Chakra.Common.DataStructures>
@@ -38,12 +50,15 @@ add_library (Chakra.Jsrt STATIC
     $<TARGET_OBJECTS:Chakra.Runtime.Types>
     $<TARGET_OBJECTS:Chakra.Runtime.PlatformAgnostic>
     $<TARGET_OBJECTS:Chakra.Parser>
+    $<TARGET_OBJECTS:Chakra.Jsrt.object>
     )
+endmacro(CHAKRACORE_ADD_JSRT_OBJECTS)
+
 
 add_subdirectory(Core)
 
 target_include_directories (
-    Chakra.Jsrt PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+    Chakra.Jsrt.object PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
     ../Backend
     ../JITIDL
     ../Runtime

--- a/lib/Jsrt/JsrtHelper.cpp
+++ b/lib/Jsrt/JsrtHelper.cpp
@@ -5,33 +5,11 @@
 #include "JsrtPch.h"
 #include "jsrtHelper.h"
 #include "Base/ThreadContextTlsEntry.h"
+#include "Core/ConfigParser.h"
+#include "Base/ThreadBoundThreadContextManager.h"
 
 #ifdef DYNAMIC_PROFILE_STORAGE
 #include "Language/DynamicProfileStorage.h"
-#endif
-
-#ifdef CHAKRA_STATIC_LIBRARY
-#include "Core/ConfigParser.h"
-
-void ChakraBinaryAutoSystemInfoInit(AutoSystemInfo * autoSystemInfo)
-{
-    autoSystemInfo->buildDateHash = JsUtil::CharacterBuffer<char>::StaticGetHashCode(__DATE__, _countof(__DATE__));
-    autoSystemInfo->buildTimeHash = JsUtil::CharacterBuffer<char>::StaticGetHashCode(__TIME__, _countof(__TIME__));
-}
-
-bool ConfigParserAPI::FillConsoleTitle(__ecount(cchBufferSize) LPWSTR buffer, size_t cchBufferSize, __in LPWSTR moduleName)
-{
-    return false;
-}
-
-void ConfigParserAPI::DisplayInitialOutput(__in LPWSTR moduleName)
-{
-}
-
-LPCWSTR JsUtil::ExternalApi::GetFeatureKeyName()
-{
-    return _u("");
-}
 #endif
 
 JsrtCallbackState::JsrtCallbackState(ThreadContext* currentThreadContext)
@@ -78,122 +56,3 @@ void JsrtCallbackState::ObjectBeforeCallectCallbackWrapper(JsObjectBeforeCollect
     callback(object, callbackState);
 }
 
-// todo: We need an interface for thread/process exit.
-// At the moment we do handle thread exit for non main threads on xplat
-// However, it could be nice/necessary to provide an interface to make sure
-// we cover additional edge cases.
-#if defined(CHAKRA_STATIC_LIBRARY) || !defined(_WIN32)
-    #include "Core/ConfigParser.h"
-    #include "Base/ThreadBoundThreadContextManager.h"
-
-#ifndef _WIN32
-    #include <pthread.h>
-    static pthread_key_t s_threadLocalDummy;
-#endif
-
-    static THREAD_LOCAL bool s_threadWasEntered = false;
-
-    _NOINLINE void DISPOSE_CHAKRA_CORE_THREAD(void *_)
-    {
-        free(_);
-        ThreadBoundThreadContextManager::DestroyContextAndEntryForCurrentThread();
-    }
-
-    _NOINLINE bool InitializeProcess()
-    {
-#if !defined(_WIN32)
-        pthread_key_create(&s_threadLocalDummy, DISPOSE_CHAKRA_CORE_THREAD);
-#endif
-
-#if defined(CHAKRA_STATIC_LIBRARY)
-
-    // setup the cleanup
-    // we do not track the main thread. When it exits do the cleanup below
-    atexit([]() {
-        ThreadBoundThreadContextManager::DestroyContextAndEntryForCurrentThread();
-
-        JsrtRuntime::Uninitialize();
-
-        // thread-bound entrypoint should be able to get cleanup correctly, however tlsentry
-        // for current thread might be left behind if this thread was initialized.
-        ThreadContextTLSEntry::CleanupThread();
-        ThreadContextTLSEntry::CleanupProcess();
-    });
-
-    // Attention: shared library is handled under (see ChakraCore/ChakraCoreDllFunc.cpp)
-    // todo: consolidate similar parts from shared and static library initialization
-#ifndef _WIN32
-        PAL_InitializeChakraCore(0, NULL);
-#endif
-
-        HMODULE mod = GetModuleHandleW(NULL);
-
-        AutoSystemInfo::SaveModuleFileName(mod);
-
-    #if defined(_M_IX86) && !defined(__clang__)
-        // Enable SSE2 math functions in CRT if SSE2 is available
-    #pragma prefast(suppress:6031, "We don't require SSE2, but will use it if available")
-        _set_SSE2_enable(TRUE);
-    #endif
-
-        {
-            CmdLineArgsParser parser;
-            ConfigParser::ParseOnModuleLoad(parser, mod);
-        }
-
-    #ifdef ENABLE_JS_ETW
-        EtwTrace::Register();
-    #endif
-        ValueType::Initialize();
-        ThreadContext::GlobalInitialize();
-
-        // Needed to make sure that only ChakraCore is loaded into the process
-        // This is unnecessary on Linux since there aren't other flavors of
-        // Chakra binaries that can be loaded into the process
-    #ifdef _WIN32
-        char16 *engine = szChakraCoreLock;
-        if (::FindAtom(szChakraLock) != 0)
-        {
-            AssertMsg(FALSE, "Expecting to load chakracore.dll but process already loaded chakra.dll");
-            Binary_Inconsistency_fatal_error();
-        }
-        lockedDll = ::AddAtom(engine);
-        AssertMsg(lockedDll, "Failed to lock chakracore.dll");
-    #endif // _WIN32
-
-    #ifdef ENABLE_BASIC_TELEMETRY
-        g_TraceLoggingClient = NoCheckHeapNewStruct(TraceLoggingClient);
-    #endif
-
-    #ifdef DYNAMIC_PROFILE_STORAGE
-        DynamicProfileStorage::Initialize();
-    #endif
-#endif // STATIC_LIBRARY
-        return true;
-    }
-
-    _NOINLINE void VALIDATE_ENTER_CURRENT_THREAD()
-    {
-        // We do also initialize the process part here
-        // This is thread safe by the standard
-        // Let's hope compiler doesn't fail
-        static bool _has_init = InitializeProcess();
-
-        if (!_has_init) // do not assert this.
-        {
-            abort();
-        }
-
-        if (s_threadWasEntered) return;
-        s_threadWasEntered = true;
-
-    #ifdef HEAP_TRACK_ALLOC
-        HeapAllocator::InitializeThread();
-    #endif
-
-#ifndef _WIN32
-        // put something into key to make sure destructor is going to be called
-        pthread_setspecific(s_threadLocalDummy, malloc(1));
-#endif
-    }
-#endif

--- a/lib/Jsrt/jsrtHelper.h
+++ b/lib/Jsrt/jsrtHelper.h
@@ -15,9 +15,5 @@ private:
     JsrtContext* originalJsrtContext;
 };
 
-#if defined(CHAKRA_STATIC_LIBRARY) || !defined(_WIN32)
 _NOINLINE void VALIDATE_ENTER_CURRENT_THREAD();
-#else
-// Windows  Shared Library: DllMain is responsible from handling all these stuff
-#define VALIDATE_ENTER_CURRENT_THREAD()
-#endif
+

--- a/pal/src/CMakeLists.txt
+++ b/pal/src/CMakeLists.txt
@@ -161,37 +161,11 @@ set(SOURCES
 )
 
 add_library(Chakra.Pal
-  STATIC
+  OBJECT
   ${SOURCES}
   ${PLATFORM_SOURCES}
   ${ARCH_SOURCES}
 )
 
-if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
-  target_link_libraries(Chakra.Pal
-    pthread
-    dl
-    "-framework CoreFoundation"
-    "-framework Security"
-  )
-endif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
-
-if(CMAKE_SYSTEM_NAME STREQUAL Linux)
-  if(CC_TARGETS_AMD64)
-    target_link_libraries(Chakra.Pal
-      unwind-x86_64
-    )
-  endif()
-
-  target_link_libraries(Chakra.Pal
-    gcc_s
-    pthread
-    rt
-    dl
-    unwind
-    unwind-generic
-  )
-endif(CMAKE_SYSTEM_NAME STREQUAL Linux)
-
 # Install the static PAL library for VS
-install (TARGETS Chakra.Pal DESTINATION lib)
+# install (TARGETS Chakra.Pal DESTINATION lib)


### PR DESCRIPTION
This greatly reduces the complexity of switching between static and shared libraries by converting most of the static libraries to Shared libraries. Now it is possible to test a static build of chakracore by simply linking
aginst libChakraCoreStatic. Also, this greatly reduces compile time when changing between the two since the changes between static and shared libraries has been isolated to within the bin folder.

As a quick note, This patch greatly reduces the runtime to run the Following commands...
``` sh
./build.sh -n
./build.sh -n --static
./build.sh -n --debug
./build.sh -n --static --debug
```

Also as a quick note, This has not been tested against OSX/Windows, but I do not believe this will break any builds.