### PR TITLE
fixes for enabling write barrier testing on windows

### DIFF
--- a/lib/Common/Memory/Recycler.cpp
+++ b/lib/Common/Memory/Recycler.cpp
@@ -995,8 +995,8 @@ Recycler::GetRecyclerPageAllocator()
     {
         return &this->recyclerWithBarrierPageAllocator;
     }
-#endif
     else
+#endif
     {
 #ifdef RECYCLER_WRITE_WATCH
         return &this->recyclerPageAllocator;

--- a/lib/Common/Memory/RecyclerWriteBarrierManager.cpp
+++ b/lib/Common/Memory/RecyclerWriteBarrierManager.cpp
@@ -56,10 +56,17 @@ X64WriteBarrierCardTableManager::OnThreadInit()
 
     // xplat-todo: Replace this on Windows too with GetCurrentThreadStackBounds
 #ifdef _WIN32
+    // check StackProber.cpp for the stack pages layout information
     NT_TIB* teb = (NT_TIB*) ::NtCurrentTeb();
-
     char* stackBase = (char*) teb->StackBase;
-    char* stackEnd  = (char*) teb->StackLimit;
+    char* stackEnd = (char*)__readgsqword(0x1478); // 0x1478 is offset of DeallocationStack field on ntdll!_TEB on x64
+                                                   // this is undocumented, verifying with following code
+#if DBG
+    MEMORY_BASIC_INFORMATION memInfo;
+    VirtualQuery((LPCVOID)teb->StackLimit, &memInfo, sizeof(memInfo));
+    Assert((char*)memInfo.AllocationBase == stackEnd);
+    Assert(memInfo.AllocationProtect == PAGE_READWRITE);
+#endif
 #else
     ULONG_PTR stackBase = 0;
     ULONG_PTR stackEnd = 0;
@@ -70,11 +77,6 @@ X64WriteBarrierCardTableManager::OnThreadInit()
     this->_stackbase = (char*)stackBase;
     this->_stacklimit = (char*)stackEnd;
 #endif
-
-    // on Windows server 2012 stack limit can expand with process running, and causes
-    // accessing uncommitted card table page.
-    // TODO: use VirtualQuery twice to get the max possible stack limit
-    stackEnd -= AutoSystemInfo::PageSize * AutoSystemInfo::PageSize;
 
     size_t numPages = (stackBase - stackEnd) / AutoSystemInfo::PageSize;
     // stackEnd is the lower boundary

--- a/lib/Common/Memory/SmallFinalizableHeapBucket.h
+++ b/lib/Common/Memory/SmallFinalizableHeapBucket.h
@@ -81,6 +81,7 @@ template <ObjectInfoBits attributes, class TBlockAttributes>
 class SmallHeapBlockType
 {
 public:
+    CompileAssert(attributes & FinalizeBit);
     typedef SmallFinalizableHeapBlockT<TBlockAttributes> BlockType;
     typedef SmallFinalizableHeapBucketT<TBlockAttributes> BucketType;
 };
@@ -173,7 +174,7 @@ class HeapBucketGroup
         typedef typename SmallHeapBlockType<objectAttributes, TBlockAttributes>::BucketType BucketType;
         static BucketType& GetBucket(HeapBucketGroup<TBlockAttributes> * heapBucketGroup)
         {
-            Assert(objectAttributes & FinalizeBit);
+            CompileAssert(objectAttributes & FinalizeBit);
             return heapBucketGroup->finalizableHeapBucket;
         }
     };

--- a/lib/Runtime/Language/ObjTypeSpecFldInfo.cpp
+++ b/lib/Runtime/Language/ObjTypeSpecFldInfo.cpp
@@ -533,7 +533,7 @@ namespace Js
 
         // Need to create a local array here and not allocate one from the recycler,
         // as the allocation may trigger a GC which can clear the inline caches.
-        FixedFieldInfo localFixedFieldInfoArray[Js::DynamicProfileInfo::maxPolymorphicInliningSize] = { 0 };
+        FixedFieldInfo localFixedFieldInfoArray[Js::DynamicProfileInfo::maxPolymorphicInliningSize] = { };
 
         // For polymorphic field loads we only support fixed functions on prototypes. This helps keep the equivalence check helper simple.
         // Since all types in the polymorphic cache share the same prototype, it's enough to grab the fixed function from the prototype object.


### PR DESCRIPTION
restore the compiler assert, thanks @CurtisMan for the better solution
get the hard limit of stack to initialize the card table, instead a hard coded 1 page more
some other minor fixes
