### PR TITLE
xplat: implement internal qsort_r

### DIFF
--- a/bin/ch/WScriptJsrt.cpp
+++ b/bin/ch/WScriptJsrt.cpp
@@ -855,6 +855,21 @@ bool WScriptJsrt::Initialize()
     IfJsrtErrorFail(ChakraRTInterface::JsSetProperty(platformObject, archProperty,
         archValue, true), false);
 
+    // Set Build Type
+    JsPropertyIdRef buildProperty;
+    IfJsrtErrorFail(CreatePropertyIdFromString("BUILD_TYPE", &buildProperty), false);
+    JsValueRef buildValue;
+#ifdef _DEBUG
+#define BUILD_TYPE_STRING_CH "Debug" // (O0)
+#else
+#define BUILD_TYPE_STRING_CH "Release" // consider Test is also Release build (O3)
+#endif
+    IfJsrtErrorFail(ChakraRTInterface::JsCreateStringUtf8(
+        (const uint8_t*)BUILD_TYPE_STRING_CH, strlen(BUILD_TYPE_STRING_CH), &buildValue), false);
+    IfJsrtErrorFail(ChakraRTInterface::JsSetProperty(platformObject, buildProperty,
+        buildValue, true), false);
+#undef BUILD_TYPE_STRING_CH
+
     // Set Link Type [static / shared]
     JsPropertyIdRef linkProperty;
     IfJsrtErrorFail(CreatePropertyIdFromString("LINK_TYPE", &linkProperty), false);

--- a/pal/src/cruntime/misc.cpp
+++ b/pal/src/cruntime/misc.cpp
@@ -251,14 +251,6 @@ PAL_qsort(void *base, size_t nmemb, size_t size,
     PERF_EXIT(qsort);
 }
 
-//
-// qsort_s is a variant of qsort that takes in a context parameter
-// It's similar to qsort_r that GCC provides, but with the difference
-// that qsort_s takes in the context as the first param to the compare
-// function, while qsort_r takes it as the last.
-// So we have to do this wrapper dance to deal with the translation
-// Lambda doesn't work here as qsort_r needs a function pointer
-//
 typedef int (__cdecl * qsort_s_comparer)(void*, const void *, const void *);
 struct CompareWrapperContext
 {
@@ -266,20 +258,249 @@ struct CompareWrapperContext
     void* real_context;
 };
 
-#if !defined(__APPLE__) && !defined(__FreeBSD__)
-static int qsort_compare_wrapper(const void* e1, const void* e2, void* context)
-{
-    CompareWrapperContext* wrapper = (CompareWrapperContext*) context;
-    return wrapper->real_comparer(wrapper->real_context, e1, e2);
-}
-#else
-// the qsort_r comparer is backwards from the way it's defined on linux
 static int qsort_compare_wrapper(void* context, const void* e1, const void* e2)
 {
     CompareWrapperContext* wrapper = (CompareWrapperContext*) context;
     return wrapper->real_comparer(wrapper->real_context, e1, e2);
 }
-#endif
+
+union swap8
+{
+    char chr[8]; // optimized for Js::Var
+};
+
+union swap4
+{
+    char chr[4]; // optimized for TypedArray
+};
+
+union swap2
+{
+    char chr[2]; // others
+};
+
+#define swap_big(T, a, b, nsize)        \
+{                                       \
+    for (size_t i = 0; i < nsize; i++)  \
+    {                                   \
+        T c = (a)[i];                   \
+        (a)[i] = (b)[i];                \
+        (b)[i] = c;                     \
+    }                                   \
+}
+
+__attribute__((no_instrument_function))
+inline static void
+cc_swap(void *a, void *b, const size_t size) noexcept
+{
+    if (a == b) return;
+
+    size_t tsize;
+    if (size >= 8)
+    {
+        tsize = 8;
+        size_t nsize = size / tsize;
+        swap_big(swap8, (swap8*) a, (swap8*) b, nsize)
+    }
+    else if (size >= 4)
+    {
+        tsize = 4;
+        size_t nsize = size / tsize;
+        swap_big(swap4, (swap4*) a, (swap4*) b, nsize)
+    }
+    else
+    {
+        tsize = 2;
+        size_t nsize = size / tsize;
+        swap_big(swap2, (swap2*) a, (swap2*) b, nsize)
+    }
+
+    swap_big(char, (char*) a, (char*) b, size % tsize);
+}
+
+// Sorting Networks BEGIN *****
+#define SORT2(a, b)                \
+    if (compar(thunk,              \
+        base + (b * size),         \
+        base + (a * size)) < 0)    \
+    {                              \
+        cc_swap(base + (a * size), \
+        base + (b * size), size);  \
+    }
+
+#define SORT3() \
+    SORT2(0, 1) \
+    SORT2(1, 2) \
+    SORT2(0, 1)
+
+#define SORT4() \
+    SORT2(0, 1) \
+    SORT2(2, 3) \
+    SORT2(0, 2) \
+    SORT2(1, 3) \
+    SORT2(1, 2)
+
+#define SORT5(a, b, c, d, e) \
+    SORT2(a, b) \
+    SORT2(d, e) \
+    SORT2(c, e) \
+    SORT2(c, d) \
+    SORT2(a, d) \
+    SORT2(a, c) \
+    SORT2(b, e) \
+    SORT2(b, d) \
+    SORT2(b, c)
+
+#define SORT6()  \
+    SORT2(1, 2)  \
+    SORT2(0, 2)  \
+    SORT2(0, 1)  \
+    SORT2(4, 5)  \
+    SORT2(3, 5)  \
+    SORT2(3, 4)  \
+    SORT2(0, 3)  \
+    SORT2(1, 4)  \
+    SORT2(2, 5)  \
+    SORT2(2, 4)  \
+    SORT2(1, 3)  \
+    SORT2(2, 3)
+
+#define SORT7() \
+    SORT2(1, 2) \
+    SORT2(0, 2) \
+    SORT2(0, 1) \
+    SORT2(3, 4) \
+    SORT2(5, 6) \
+    SORT2(3, 5) \
+    SORT2(4, 6) \
+    SORT2(4, 5) \
+    SORT2(0, 4) \
+    SORT2(0, 3) \
+    SORT2(1, 5) \
+    SORT2(2, 6) \
+    SORT2(2, 5) \
+    SORT2(1, 3) \
+    SORT2(2, 4) \
+    SORT2(2, 3)
+
+#define SORT8() \
+    SORT2(0, 1) \
+    SORT2(2, 3) \
+    SORT2(0, 2) \
+    SORT2(1, 3) \
+    SORT2(1, 2) \
+    SORT2(4, 5) \
+    SORT2(6, 7) \
+    SORT2(4, 6) \
+    SORT2(5, 7) \
+    SORT2(5, 6) \
+    SORT2(0, 4) \
+    SORT2(1, 5) \
+    SORT2(1, 4) \
+    SORT2(2, 6) \
+    SORT2(3, 7) \
+    SORT2(3, 6) \
+    SORT2(2, 4) \
+    SORT2(3, 5) \
+    SORT2(3, 4)
+
+#define SORT9() \
+    SORT2(0, 1) \
+    SORT2(3, 4) \
+    SORT2(6, 7) \
+    SORT2(1, 2) \
+    SORT2(4, 5) \
+    SORT2(7, 8) \
+    SORT2(0, 1) \
+    SORT2(3, 4) \
+    SORT2(6, 7) \
+    SORT2(0, 3) \
+    SORT2(3, 6) \
+    SORT2(0, 3) \
+    SORT2(1, 4) \
+    SORT2(4, 7) \
+    SORT2(1, 4) \
+    SORT2(2, 5) \
+    SORT2(5, 8) \
+    SORT2(2, 5) \
+    SORT2(1, 3) \
+    SORT2(5, 7) \
+    SORT2(2, 6) \
+    SORT2(4, 6) \
+    SORT2(2, 4) \
+    SORT2(2, 3) \
+    SORT2(5, 6)
+
+// Sorting Networks END *****
+
+__attribute__((no_instrument_function))
+static void
+cc_qsort_r(void *base_, size_t nmemb, size_t size,
+    int (__cdecl *compar )(void*, const void *, const void *), void *thunk)
+{
+    char *base = (char *) base_;
+
+    if (nmemb <= 9) // use sorting networks for members <= 2^3
+    {
+        switch(nmemb)
+        {
+            case 9:
+                SORT9()
+                break;
+            case 8:
+                SORT8()
+                break;
+            case 7:
+                SORT7()
+                break;
+            case 6:
+                SORT6()
+                break;
+            case 5:
+                SORT5(0, 1, 2, 3, 4)
+                break;
+            case 4:
+                SORT4()
+                break;
+            case 3:
+                SORT3()
+                break;
+            case 2:
+                SORT2(0, 1)
+                break;
+            default:
+                break; // nothing to sort
+        }
+
+        return;
+    }
+
+    // sort find for median. `compare` is expectedly more expensive than `swap`
+    SORT5(0, (nmemb / 4), (nmemb / 2), ((3 * nmemb) / 4), (nmemb - 1));
+    // guess the median is in the middle now. (from the list above)
+    size_t pos = 0;
+    size_t pivot = (nmemb - 1) * size;
+    // make last element the median(pivot)
+    cc_swap(base + pivot, base + ((nmemb / 2) * size), size);
+    // standard qsort pt. below
+    for (size_t i = 0; i < pivot; i += size)
+    {
+        if (compar(thunk, base + i, base + pivot) <= 0)
+        {
+            cc_swap(base + i, base + (pos * size), size);
+            pos++;
+        }
+    }
+    // issue the last change
+    cc_swap(base + (pos * size), base + pivot, size);
+
+    if (pos >= nmemb - 1) {
+        return; // looks like it was either all sorted OR nothing to sort
+    }
+
+    cc_qsort_r(base, pos++, size, compar, thunk);
+    cc_qsort_r(base + (pos * size), nmemb - pos, size, compar, thunk);
+}
 
 PALIMPORT
 void __cdecl
@@ -290,18 +511,12 @@ PAL_qsort_s(void *base, size_t nmemb, size_t size,
     qsort_s_context.real_comparer = compar;
     qsort_s_context.real_context  = context;
 
-    // REVIEW: Do we need to call some kind of invalid parameter handler here?
-    qsort_r(
+    cc_qsort_r(
         base,
         nmemb,
         size,
-#if !defined(__APPLE__) && !defined(__FreeBSD__)
         qsort_compare_wrapper,
         &qsort_s_context
-#else
-        &qsort_s_context,
-        qsort_compare_wrapper
-#endif
         );
 }
 

--- a/test/Array/array_qsortr.js
+++ b/test/Array/array_qsortr.js
@@ -1,0 +1,113 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+// Test our custom qsort_r implementation on xplat.
+if (WScript.Platform && WScript.Platform.OS != "win32") {
+    function testArray(SORT_FNC, limit, test_id) {
+        var THROW = function(pos) {
+            throw new Error("Broken qsort_r!!! (" + pos + ") for test:" + test_id);
+        };
+
+        function getArray(is_typed) {
+            var t = is_typed ? new Int32Array(limit) : new Array(limit);
+
+            for(var i = limit - 1; i >= 0; i--) {
+                t[i] = i;
+            }
+
+            return t.sort(SORT_FNC);
+        }
+
+        // test array of 1s
+        var arr = new Array(limit);
+        arr.fill(1);
+        arr = arr.sort(SORT_FNC);
+        if (arr[0] + arr[limit - 1] != 2) THROW(0); // 0
+
+        // what if we add couple of other numbers?
+        arr[0] = 5;
+        arr[limit - 1] = 0;
+        arr = arr.sort(SORT_FNC);
+        if (arr[0] + arr[limit - 1] != 5) THROW(1); // 1
+
+        // test reverse ordered JS Array
+        arr = getArray(0);
+        if (arr[0] + arr[1] + arr[limit - 1] != limit) THROW(2); // 2
+
+        // test reverse ordered JS TypedArray
+        arr = getArray(1);
+        if (arr[0] + arr[1] + arr[limit - 1] != limit) THROW(3); // 3
+
+        // scramble
+        for(var i = 1; i < limit / 10; i++) {
+            var tmp = arr[limit - i];
+            arr[limit - i] = arr[i];
+            arr[i] = tmp;
+        }
+
+        // test mixed ordered JS TypedArray
+        arr = arr.sort(SORT_FNC);
+        if (arr[0] + arr[1] + arr[limit - 1] != limit) THROW(4); // 4
+
+        // scramble further
+        for(var i = 1; i < limit / 10; i++) {
+            var tmp = arr[limit - i];
+            arr[limit - i] = arr[i];
+            arr[i] = tmp;
+        }
+
+        var pos = limit - 1;
+        for(var i = limit / 2; i < limit; i++) {
+            var tmp = arr[pos];
+            arr[pos] = arr[i];
+            arr[i] = tmp;
+            pos--;
+        }
+
+        // test scrambled JS TypedArray
+        arr = arr.sort(SORT_FNC);
+        if (arr[0] + arr[1] + arr[limit - 1] != limit) THROW(5); // 5
+    }
+
+    var arraySize = WScript.Platform.BUILD_TYPE == "Release" ? 5e5 /* 500K */ : 1e4; // CI timeout for Debug build
+
+    if (arraySize % 2 || arraySize < 1e4)
+    {
+        throw new Error(
+            "Array size is too small.. and some of the loops above works better with arraySize % 2 == 0")
+    }
+
+    testArray(
+        function(x, y) {
+            return x > y ? +1 : (x < y ? -1 : 0) ;
+        },
+        arraySize /* test 500K items */,
+        "NoThrow");
+
+    testArray(
+        function(x, y) {
+            try {
+                if (x % 2) throw new Error("Crash!!!! ?");
+            } catch (e) { /* no. this shouldn't crash! */ }
+
+            return x > y ? +1 : (x < y ? -1 : 0) ;
+        },
+        1000 /* no need to test bigger arrays. >= 512 is sufficient */,
+        "Throw-Catch Inside");
+
+    // This one actually doesn't sort anything.
+    try {
+        testArray(
+            function(x, y) {
+                if (x % 2) throw new Error("Crash!!!! ?");
+
+                return x > y ? +1 : (x < y ? -1 : 0) ;
+            },
+            1000 /* no need to test bigger arrays.*/,
+            "Throw-Catch Outside");
+    } catch (e) { /* no. this shouldn't crash! */ }
+}
+
+WScript.Echo("PASS");

--- a/test/Array/rlexe.xml
+++ b/test/Array/rlexe.xml
@@ -8,6 +8,11 @@
   </test>
   <test>
     <default>
+      <files>array_qsortr.js</files>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>array_init.js</files>
       <baseline>array_init.baseline</baseline>
       <tags>Slow</tags>

--- a/test/es6/ES6TypedArrayExtensions.js
+++ b/test/es6/ES6TypedArrayExtensions.js
@@ -1432,14 +1432,11 @@ var tests = [
             assert.areEqual([10,9,8,7,6,5,4,3,2,1], getTypedArray(10).sort(sortCallbackReverse), "%TypedArrayPrototype%.sort with a sort callback function which reverses elements");
             assert.areEqual([5,1,2,3,4,6,7,8,9,10], getTypedArray(10).sort(sortCallbackHate5), "%TypedArrayPrototype%.sort basic behavior with a lying sort callback which hates the number 5");
 
-            // exclude this particular test from xplat
-            // posix / bsd implementations of qsort is incompatible with the one on Windows
-            // result from the test below is strictly related to how qsort is implemented
-            // TODO (maybe) : implement consistent re-entrant qsort ?
-            // ChakraFull test host does not implements `Platform` below.
-            // So, consider that as Windows too
-            if (!WScript.Platform || WScript.Platform.OS == "win32") {
+            // we have a consistent qsort_r impl. on xplat.
+            if (!WScript.Platform || WScript.Platform.OS == "win32") { // Windows
                 assert.areEqual([9,8,7,2,10,5,4,3,1,6], getTypedArray(10).sort(sortCallbackMalformed), "%TypedArrayPrototype%.sort basic behavior with a sort callback which returns random values");
+            } else { // xplat
+                assert.areEqual([2,9,8,7,10,4,1,3,5,6], getTypedArray(10).sort(sortCallbackMalformed), "%TypedArrayPrototype%.sort basic behavior with a sort callback which returns random values");
             }
 
             assert.throws(function() { sort.call(); }, TypeError, "Calling %TypedArrayPrototype%.sort with no this throws TypeError", "'this' is not a typed array object");


### PR DESCRIPTION
Tested with an array of 100M ordered/random numbers.
Comparing to STL qsort_r ~10% to ~30% ~~~40%~~ slower.