### PR TITLE
Recheck array type before checking element is MissingItem after prototype lookup on the array

### DIFF
--- a/lib/Runtime/Library/JavascriptArray.cpp
+++ b/lib/Runtime/Library/JavascriptArray.cpp
@@ -475,7 +475,7 @@ namespace Js
         return SparseArraySegment<T>::IsMissingItem(&headSeg->elements[index]);
     }
 
-    bool JavascriptArray::IsMissingItemForUnkownArrayTypeAt(uint32 index)
+    bool JavascriptArray::IsMissingItem(uint32 index)
     {
         bool isIntArray = false, isFloatArray = false;
         this->GetArrayTypeAndConvert(&isIntArray, &isFloatArray);
@@ -5780,7 +5780,7 @@ Case0:
             {
                 // array type might be changed in the below call to DirectGetItemAtFull
                 // need recheck array type before checking array item [i + start]
-                if (pArr->IsMissingItemForUnkownArrayTypeAt(i + start))
+                if (pArr->IsMissingItem(i + start))
                 {
                     Var element;
                     pnewArr->SetHasNoMissingValues(false);

--- a/lib/Runtime/Library/JavascriptArray.cpp
+++ b/lib/Runtime/Library/JavascriptArray.cpp
@@ -467,6 +467,33 @@ namespace Js
         return typeId == TypeIds_Array;
     }
 
+    template<typename T>
+    bool JavascriptArray::IsMissingItemAt(uint32 index) const
+    {
+        SparseArraySegment<T>* headSeg = (SparseArraySegment<T>*)this->head;
+
+        return SparseArraySegment<T>::IsMissingItem(&headSeg->elements[index]);
+    }
+
+    bool JavascriptArray::IsMissingItemForUnkownArrayTypeAt(uint32 index)
+    {
+        bool isIntArray = false, isFloatArray = false;
+        this->GetArrayTypeAndConvert(&isIntArray, &isFloatArray);
+
+        if (isIntArray)
+        {
+            return IsMissingItemAt<int32>(index);
+        }
+        else if (isFloatArray)
+        {
+            return IsMissingItemAt<double>(index);
+        }
+        else
+        {
+            return IsMissingItemAt<Var>(index);
+        }
+    }
+
     JavascriptArray* JavascriptArray::FromVar(Var aValue)
     {
         AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptArray'");
@@ -5751,7 +5778,9 @@ Case0:
         {
             for (uint32 i = 0; i < newLen; i++)
             {
-                if (SparseArraySegment<T>::IsMissingItem(&headSeg->elements[i+start]))
+                // array type might be changed in the below call to DirectGetItemAtFull
+                // need recheck array type before checking array item [i + start]
+                if (pArr->IsMissingItemForUnkownArrayTypeAt(i + start))
                 {
                     Var element;
                     pnewArr->SetHasNoMissingValues(false);

--- a/lib/Runtime/Library/JavascriptArray.h
+++ b/lib/Runtime/Library/JavascriptArray.h
@@ -438,6 +438,10 @@ namespace Js
         bool HasNoMissingValues_Unchecked() const; // do not use except in extreme circumstances
         void SetHasNoMissingValues(const bool hasNoMissingValues = true);
 
+        template<typename T>
+        bool JavascriptArray::IsMissingItemAt(uint32 index) const;
+        bool IsMissingItemForUnkownArrayTypeAt(uint32 index);
+
         virtual bool IsMissingHeadSegmentItem(const uint32 index) const;
 
         static VTableValue VtableHelper()

--- a/lib/Runtime/Library/JavascriptArray.h
+++ b/lib/Runtime/Library/JavascriptArray.h
@@ -440,7 +440,7 @@ namespace Js
 
         template<typename T>
         bool JavascriptArray::IsMissingItemAt(uint32 index) const;
-        bool IsMissingItemForUnkownArrayTypeAt(uint32 index);
+        bool IsMissingItem(uint32 index);
 
         virtual bool IsMissingHeadSegmentItem(const uint32 index) const;
 


### PR DESCRIPTION
When slicing an array (Array.prototype.slice),  we make a shadow copy of original array, then tries to populate the MissingItems in the copied array with elements from the prototype chain of the source array. Lookup in the prototype chain could change its array type so we need recheck the array type after the lookup returns before retrieving remaining items as MissItems, or we get the wrong element to check against.