### PR TITLE
CheckIfTypeIsEquivalent for fixed field

### DIFF
--- a/lib/Backend/JnHelperMethodList.h
+++ b/lib/Backend/JnHelperMethodList.h
@@ -254,6 +254,7 @@ HELPERCALL(Op_ScopedGetMethod, ((Js::Var (*)(Js::FunctionBody *const, Js::Inline
 HELPERCALL(Op_ScopedGetMethodPolymorphic, ((Js::Var (*)(Js::FunctionBody *const, Js::PolymorphicInlineCache *const, const Js::InlineCacheIndex, Js::Var, Js::PropertyId, bool))Js::JavascriptOperators::PatchScopedGetMethod<true, Js::PolymorphicInlineCache>), AttrCanThrow)
 
 HELPERCALL(CheckIfTypeIsEquivalent, Js::JavascriptOperators::CheckIfTypeIsEquivalent, 0)
+HELPERCALL(CheckIfTypeIsEquivalentForFixedField, Js::JavascriptOperators::CheckIfTypeIsEquivalentForFixedField, 0)
 
 HELPERCALL(Op_Delete, Js::JavascriptOperators::Delete, AttrCanThrow)
 HELPERCALL(OP_InitSetter, Js::JavascriptOperators::OP_InitSetter, AttrCanThrow)

--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -7463,7 +7463,8 @@ Lowerer::GenerateCachedTypeCheck(IR::Instr *instrChk, IR::PropertySymOpnd *prope
         this->m_lowererMD.LoadHelperArgument(instrChk, typeOpnd);
 
         IR::RegOpnd* equivalentTypeCheckResultOpnd = IR::RegOpnd::New(TyUint8, func);
-        IR::HelperCallOpnd* equivalentTypeCheckHelperCallOpnd = IR::HelperCallOpnd::New(IR::HelperCheckIfTypeIsEquivalent, func);
+        IR::HelperCallOpnd* equivalentTypeCheckHelperCallOpnd = IR::HelperCallOpnd::New(
+            propertySymOpnd->HasFixedValue() ? IR::HelperCheckIfTypeIsEquivalentForFixedField : IR::HelperCheckIfTypeIsEquivalent, func);
         IR::Instr* equivalentTypeCheckCallInstr = IR::Instr::New(Js::OpCode::Call, equivalentTypeCheckResultOpnd, equivalentTypeCheckHelperCallOpnd, func);
         instrChk->InsertBefore(equivalentTypeCheckCallInstr);
         this->m_lowererMD.LowerCall(equivalentTypeCheckCallInstr, 0);

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -82,12 +82,8 @@ namespace Js
     class PropertyGuard
     {
         friend class PropertyGuardValidator;
+
     private:
-        enum GuardValue : intptr_t {
-            Invalidated = 0,
-            Uninitialized = 1,
-            Invalidated_DuringSweep = 2
-        };
         intptr_t value; // value is address of Js::Type
 #if DBG
         bool wasReincarnated = false;
@@ -130,6 +126,12 @@ namespace Js
 #if DBG
         bool WasReincarnated() { return this->wasReincarnated; }
 #endif
+        enum GuardValue : intptr_t
+        {
+            Invalidated = 0,
+            Uninitialized = 1,
+            Invalidated_DuringSweep = 2
+        };
     };
 
     class PropertyGuardValidator

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -8198,9 +8198,18 @@ CommonNumber:
         return entry->slotIndex == Constants::NoSlot && !entry->mustBeWritable;
     }
 
+    bool JavascriptOperators::CheckIfTypeIsEquivalentForFixedField(Type* type, JitEquivalentTypeGuard* guard)
+    {
+        if (guard->GetValue() == PropertyGuard::GuardValue::Invalidated_DuringSweep)
+        {
+            return false;
+        }
+        return CheckIfTypeIsEquivalent(type, guard);
+    }
+
     bool JavascriptOperators::CheckIfTypeIsEquivalent(Type* type, JitEquivalentTypeGuard* guard)
     {
-        if (guard->GetValue() == 0)
+        if (guard->GetValue() == PropertyGuard::GuardValue::Invalidated)
         {
             return false;
         }

--- a/lib/Runtime/Language/JavascriptOperators.h
+++ b/lib/Runtime/Language/JavascriptOperators.h
@@ -515,6 +515,7 @@ namespace Js
         static bool IsStaticTypeObjTypeSpecEquivalent(const TypeEquivalenceRecord& equivalenceRecord, uint& failedIndex);
         static bool IsStaticTypeObjTypeSpecEquivalent(const EquivalentPropertyEntry *entry);
         static bool CheckIfTypeIsEquivalent(Type* type, JitEquivalentTypeGuard* guard);
+        static bool CheckIfTypeIsEquivalentForFixedField(Type* type, JitEquivalentTypeGuard* guard);
 
         static void GetPropertyIdForInt(uint64 value, ScriptContext* scriptContext, PropertyRecord const ** propertyRecord);
         static void GetPropertyIdForInt(uint32 value, ScriptContext* scriptContext, PropertyRecord const ** propertyRecord);


### PR DESCRIPTION
With my CheckIfTypeIsEquivalent optimization, we were reusing the cached equivalent types even though guard value i.e. type got collected. This is fine as long as fields against which we are guarding are not fixed. If they are fixed, then we should not be referring to the cached types. Added a new helper for fixed fields/methods which will return false if the guard was invalidated or it was collected.

Refer: [9514714](https://microsoft.visualstudio.com//defaultcollection/OS/_workItems?_a=edit&id=9514714&triage=true)