### PR TITLE
swb: update write barrier check plugin

### DIFF
--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -1376,7 +1376,7 @@ namespace Js
         void* GetAuxPtrWithLock(AuxPointerType e) const;
         void SetAuxPtr(AuxPointerType e, void* ptr);
 
-        FunctionInfo *functionInfo;
+        FieldWithBarrier(FunctionInfo *) functionInfo;
 
     public:
         enum SetDisplayNameFlags

--- a/tools/RecyclerChecker/Helpers.h
+++ b/tools/RecyclerChecker/Helpers.h
@@ -17,6 +17,7 @@ private:
     static LogLevel s_logLevel;
 
 public:
+    static LogLevel GetLevel() { return s_logLevel; }
     static void SetLevel(LogLevel level) { s_logLevel = level; }
 
     static raw_ostream& errs()


### PR DESCRIPTION
Recent changes required a plugin update. The plugin can no longer relies on
alloc function name containing "WithBarrier", instead should simply assume
the type being allocated needs write barrier annotation if it is not a
"Leaf" allocation, as on xplat it would be allocated in write barrier
memory. Similarly with InfoBitsWrapper, skipped "WithBarrierBit" check.

Fixed one missing annotation after merging from master by running the fixed
plugin.