### PR TITLE
Redeferral and deferred stubs

### DIFF
--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -703,6 +703,7 @@ namespace Js
         SetCountField(CounterFields::ConstantCount, 1);
 
         proxy->UpdateFunctionBodyImpl(this);
+        this->SetDeferredStubs(proxy->GetDeferredStubs());
 
         void* validationCookie = nullptr;
 
@@ -1408,7 +1409,6 @@ namespace Js
         CopyDeferParseField(scopeSlotArraySize);
         CopyDeferParseField(paramScopeSlotArraySize);
         other->SetCachedSourceString(this->GetCachedSourceString());
-        other->SetDeferredStubs(this->GetDeferredStubs());
         CopyDeferParseField(m_isAsmjsMode);
         CopyDeferParseField(m_isAsmJsFunction);
 


### PR DESCRIPTION
Do not copy the deferred stub tree to the new ParseableFunctionInfo on redeferral, as nested functions may not be deferred in that case. Recompute them instead if necessary.