### PR TITLE
turning on real writebarrier mode on Linux

### DIFF
--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -726,7 +726,7 @@ PHASE(All)
 #define DEFAULT_CONFIG_WriteBarrierTest (false)
 #else
 #define DEFAULT_CONFIG_ForceSoftwareWriteBarrier  (true)
-#define DEFAULT_CONFIG_WriteBarrierTest (true) // TODO: SWB change to false after all write barrier annotations are done
+#define DEFAULT_CONFIG_WriteBarrierTest (false)
 #endif
 
 #define TraceLevel_Error        (1)


### PR DESCRIPTION
previousely I made the change to assume all write barrier pages are dirty, regardless there's missing annotation or not, to make the annotation work easier.
