### PR TITLE
WASM - function import signature comparison

### DIFF
--- a/lib/Runtime/Library/WebAssemblyInstance.cpp
+++ b/lib/Runtime/Library/WebAssemblyInstance.cpp
@@ -322,7 +322,7 @@ void WebAssemblyInstance::LoadImports(
             {
                 Assert(env->GetWasmFunction(counter) == nullptr);
                 AsmJsScriptFunction* func = AsmJsScriptFunction::FromVar(prop);
-                if (!wasmModule->GetFunctionSignature(counter)->IsEquivalent(func->GetSignature()))
+                if (!wasmModule->GetWasmFunctionInfo(counter)->GetSignature()->IsEquivalent(func->GetSignature()))
                 {
                     JavascriptError::ThrowTypeError(ctx, WASMERR_SignatureMismatch);
                 }

--- a/lib/Runtime/Library/WebAssemblyInstance.cpp
+++ b/lib/Runtime/Library/WebAssemblyInstance.cpp
@@ -322,7 +322,7 @@ void WebAssemblyInstance::LoadImports(
             {
                 Assert(env->GetWasmFunction(counter) == nullptr);
                 AsmJsScriptFunction* func = AsmJsScriptFunction::FromVar(prop);
-                if (!wasmModule->GetSignature(counter)->IsEquivalent(func->GetSignature()))
+                if (!wasmModule->GetFunctionSignature(counter)->IsEquivalent(func->GetSignature()))
                 {
                     JavascriptError::ThrowTypeError(ctx, WASMERR_SignatureMismatch);
                 }

--- a/lib/Runtime/Library/WebAssemblyModule.cpp
+++ b/lib/Runtime/Library/WebAssemblyModule.cpp
@@ -281,25 +281,6 @@ WebAssemblyModule::GetMaxFunctionIndex() const
     return GetWasmFunctionCount();
 }
 
-Wasm::WasmSignature*
-WebAssemblyModule::GetFunctionSignature(uint32 funcIndex) const
-{
-    Wasm::FunctionIndexTypes::Type funcType = GetFunctionIndexType(funcIndex);
-    if (funcType == Wasm::FunctionIndexTypes::Invalid)
-    {
-        throw Wasm::WasmCompilationException(_u("Function index out of range"));
-    }
-
-    switch (funcType)
-    {
-    case Wasm::FunctionIndexTypes::ImportThunk:
-    case Wasm::FunctionIndexTypes::Function:
-        return GetWasmFunctionInfo(funcIndex)->GetSignature();
-    default:
-        throw Wasm::WasmCompilationException(_u("Unknown function index type"));
-    }
-}
-
 Wasm::FunctionIndexTypes::Type
 WebAssemblyModule::GetFunctionIndexType(uint32 funcIndex) const
 {

--- a/lib/Runtime/Library/WebAssemblyModule.h
+++ b/lib/Runtime/Library/WebAssemblyModule.h
@@ -55,7 +55,6 @@ public:
 
     // The index used by those methods is the function index as describe by the WebAssembly design, ie: imports first then wasm functions
     uint32 GetMaxFunctionIndex() const;
-    Wasm::WasmSignature* GetFunctionSignature(uint32 funcIndex) const;
     Wasm::FunctionIndexTypes::Type GetFunctionIndexType(uint32 funcIndex) const;
 
     void InitializeMemory(uint32 minSize, uint32 maxSize);

--- a/lib/WasmReader/WasmBinaryReader.cpp
+++ b/lib/WasmReader/WasmBinaryReader.cpp
@@ -993,7 +993,7 @@ WasmBinaryReader::ReadStartFunction()
     {
         ThrowDecodingError(_u("Invalid function index for start function %u"), id);
     }
-    WasmSignature* sig = m_module->GetFunctionSignature(id);
+    WasmSignature* sig = m_module->GetWasmFunctionInfo(id)->GetSignature();
     if (sig->GetParamCount() > 0 || sig->GetResultType() != WasmTypes::Void)
     {
         ThrowDecodingError(_u("Start function must be void and nullary"));

--- a/lib/WasmReader/WasmByteCodeGenerator.cpp
+++ b/lib/WasmReader/WasmByteCodeGenerator.cpp
@@ -805,7 +805,7 @@ WasmBytecodeGenerator::EmitCall()
     {
     case wbCall:
         funcNum = GetReader()->m_currentNode.call.num;
-        calleeSignature = m_module->GetFunctionSignature(funcNum);
+        calleeSignature = m_module->GetWasmFunctionInfo(funcNum)->GetSignature();
         break;
     case wbCallIndirect:
         indirectIndexInfo = PopEvalStack();


### PR DESCRIPTION
When comparing the function signature on imports, the counter represents the function index, not the signature index

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/2165)
<!-- Reviewable:end -->
