### PR TITLE
WASM - Fix bug in -wasmi64 implementation

### DIFF
--- a/lib/Runtime/Language/AsmJsUtils.cpp
+++ b/lib/Runtime/Language/AsmJsUtils.cpp
@@ -245,9 +245,9 @@ namespace Js
                         Var low = JavascriptOperators::OP_GetProperty(object, lowPropRecord->GetPropertyId(), scriptContext);
                         Var high = JavascriptOperators::OP_GetProperty(object, highPropRecord->GetPropertyId(), scriptContext);
 
-                        int32 lowVal = JavascriptMath::ToInt32(low, scriptContext);
-                        int32 highVal = JavascriptMath::ToInt32(high, scriptContext);
-                        val = (int64)lowVal | ((int64)highVal << 32);
+                        uint64 lowVal = JavascriptMath::ToInt32(low, scriptContext);
+                        uint64 highVal = JavascriptMath::ToInt32(high, scriptContext);
+                        val = (highVal << 32) | (lowVal & 0xFFFFFFFF);
                     }
                     else
                     {


### PR DESCRIPTION
The case `someInt64Fn({high: 5, low: -2})` would incorrectly think the input is `-2` as the current implementation was doing signed extended conversion from int32 to int64 when merging low and high

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/2166)
<!-- Reviewable:end -->
