### PR TITLE
relax the rpc failfast

### DIFF
--- a/lib/Backend/InterpreterThunkEmitter.cpp
+++ b/lib/Backend/InterpreterThunkEmitter.cpp
@@ -362,7 +362,7 @@ void InterpreterThunkEmitter::NewOOPJITThunkBlock()
         this->isAsmInterpreterThunk,
         &thunkInfo
     );
-    JITManager::HandleServerCallResult(hr);
+    JITManager::HandleServerCallResult(hr, RemoteCallType::ThunkCreation);
 
 
     BYTE* buffer = (BYTE*)thunkInfo.thunkBlockAddr;
@@ -731,7 +731,7 @@ InterpreterThunkEmitter::IsInHeap(void* address)
         }
         boolean result;
         HRESULT hr = JITManager::GetJITManager()->IsInterpreterThunkAddr(remoteScript, (intptr_t)address, this->isAsmInterpreterThunk, &result);
-        JITManager::HandleServerCallResult(hr);
+        JITManager::HandleServerCallResult(hr, RemoteCallType::HeapQuery);
         return result != FALSE;
     }
     else

--- a/lib/JITClient/JITManager.cpp
+++ b/lib/JITClient/JITManager.cpp
@@ -31,6 +31,7 @@ JITManager::JITManager() :
     m_oopJitEnabled(false),
     m_isJITServer(false),
     m_targetHandle(nullptr),
+    m_serverHandle(nullptr),
     m_jitConnectionId()
 {
 }
@@ -170,7 +171,7 @@ JITManager::CreateBinding(
         RpcBindingFree(&localBindingHandle);
         return HRESULT_FROM_WIN32(status);
     }
-
+    m_serverHandle = serverProcessHandle;
     *bindingHandle = localBindingHandle;
     return S_OK;
 }
@@ -622,4 +623,10 @@ JITManager::RemoteCodeGenCall(
     RpcEndExcept;
 
     return hr;
+}
+
+bool
+JITManager::IsServerAlive() const
+{
+    return (WaitForSingleObject(this->m_serverHandle, 0) == WAIT_OBJECT_0);
 }

--- a/lib/JITClient/JITManager.cpp
+++ b/lib/JITClient/JITManager.cpp
@@ -46,6 +46,10 @@ JITManager::~JITManager()
     {
         RpcBindingFree(&m_rpcBindingHandle);
     }
+    if (m_serverHandle)
+    {
+        CloseHandle(&m_serverHandle);
+    }
 }
 
 /* static */
@@ -171,7 +175,12 @@ JITManager::CreateBinding(
         RpcBindingFree(&localBindingHandle);
         return HRESULT_FROM_WIN32(status);
     }
-    m_serverHandle = serverProcessHandle;
+    if (!DuplicateHandle(GetCurrentProcess(), serverProcessHandle, GetCurrentProcess(), &m_serverHandle, 0, FALSE, DUPLICATE_SAME_ACCESS))
+    {
+        RpcBindingFree(&localBindingHandle);
+
+        return HRESULT_FROM_WIN32(GetLastError());
+    }
     *bindingHandle = localBindingHandle;
     return S_OK;
 }

--- a/lib/JITClient/JITManager.cpp
+++ b/lib/JITClient/JITManager.cpp
@@ -170,19 +170,9 @@ JITManager::CreateBinding(
         }
     } while (status != RPC_S_OK); // redundant check, but compiler would not allow true here.
 
-    if (status != RPC_S_OK)
-    {
-        RpcBindingFree(&localBindingHandle);
-        return HRESULT_FROM_WIN32(status);
-    }
-    if (!DuplicateHandle(GetCurrentProcess(), serverProcessHandle, GetCurrentProcess(), &m_serverHandle, 0, FALSE, DUPLICATE_SAME_ACCESS))
-    {
-        RpcBindingFree(&localBindingHandle);
-
-        return HRESULT_FROM_WIN32(GetLastError());
-    }
     *bindingHandle = localBindingHandle;
-    return S_OK;
+
+    return HRESULT_FROM_WIN32(status);
 }
 
 bool
@@ -232,31 +222,56 @@ HRESULT
 JITManager::ConnectRpcServer(__in HANDLE jitProcessHandle, __in_opt void* serverSecurityDescriptor, __in UUID connectionUuid)
 {
     Assert(IsOOPJITEnabled());
+    Assert(m_rpcBindingHandle == nullptr);
+    Assert(m_targetHandle == nullptr);
+    Assert(m_serverHandle == nullptr);
 
-    HRESULT hr;
-    RPC_BINDING_HANDLE localBindingHandle;
+    HRESULT hr = E_FAIL;
 
-    if (IsConnected() && (connectionUuid != m_jitConnectionId))
+    if (IsConnected())
     {
+        Assert(UNREACHED);
         return E_FAIL;
     }
 
-    hr = CreateBinding(jitProcessHandle, serverSecurityDescriptor, &connectionUuid, &localBindingHandle);
-
-    HANDLE targetHandle;
-    BOOL succeeded = DuplicateHandle(
-        GetCurrentProcess(), GetCurrentProcess(),
-        jitProcessHandle, &targetHandle,
-        NULL, FALSE, DUPLICATE_SAME_ACCESS);
-
-    if (!succeeded)
+    if (!DuplicateHandle(GetCurrentProcess(), jitProcessHandle, GetCurrentProcess(), &m_serverHandle, 0, FALSE, DUPLICATE_SAME_ACCESS))
     {
-        return HRESULT_FROM_WIN32(GetLastError());
+        hr = HRESULT_FROM_WIN32(GetLastError());
+        goto FailureCleanup;
     }
 
-    m_targetHandle = targetHandle;
-    m_rpcBindingHandle = localBindingHandle;
+    if (!DuplicateHandle(GetCurrentProcess(), GetCurrentProcess(), jitProcessHandle, &m_targetHandle, 0, FALSE, DUPLICATE_SAME_ACCESS))
+    {
+        hr = HRESULT_FROM_WIN32(GetLastError());
+        goto FailureCleanup;
+    }
+
+    hr = CreateBinding(jitProcessHandle, serverSecurityDescriptor, &connectionUuid, &m_rpcBindingHandle);
+    if (FAILED(hr))
+    {
+        goto FailureCleanup;
+    }
+
     m_jitConnectionId = connectionUuid;
+
+    return hr;
+
+FailureCleanup:
+    if (m_targetHandle)
+    {
+        CloseHandle(m_targetHandle);
+        m_targetHandle = nullptr;
+    }
+    if (m_serverHandle)
+    {
+        CloseHandle(m_serverHandle);
+        m_serverHandle = nullptr;
+    }
+    if (m_rpcBindingHandle)
+    {
+        RpcBindingFree(&m_rpcBindingHandle);
+        m_rpcBindingHandle = nullptr;
+    }
 
     return hr;
 }

--- a/lib/JITClient/JITManager.h
+++ b/lib/JITClient/JITManager.h
@@ -7,6 +7,15 @@
 
 // We need real JITManager code when on _WIN32 or explict ENABLE_OOP_NATIVE_CODEGEN.
 // Otherwise we use a dummy JITManager which disables OOP JIT to reduce code noise.
+
+enum class RemoteCallType
+{
+    CodeGen,
+    ThunkCreation,
+    HeapQuery,
+    StateUpdate
+};
+
 #if _WIN32 || ENABLE_OOP_NATIVE_CODEGEN
 class JITManager
 {
@@ -96,7 +105,7 @@ public:
 
 
     static JITManager * GetJITManager();
-    static void HandleServerCallResult(HRESULT hr, bool isCodeGenCall = false);
+    static void HandleServerCallResult(HRESULT hr, RemoteCallType callType);
 private:
     JITManager();
     ~JITManager();
@@ -211,7 +220,7 @@ public:
 
     static JITManager * GetJITManager()
         { return &s_jitManager; }
-    static void HandleServerCallResult(HRESULT hr, bool isCodeGenCall = false) { Assert(UNREACHED); }
+    static void HandleServerCallResult(HRESULT hr, RemoteCallType callType) { Assert(UNREACHED); }
 
 private:
     static JITManager s_jitManager;

--- a/lib/JITClient/JITManager.h
+++ b/lib/JITClient/JITManager.h
@@ -18,6 +18,7 @@ public:
     void SetIsJITServer();
     bool IsOOPJITEnabled() const;
     void EnableOOPJIT();
+    bool IsServerAlive() const;
 
     HANDLE GetJITTargetHandle() const;
 
@@ -95,7 +96,7 @@ public:
 
 
     static JITManager * GetJITManager();
-    static void HandleServerCallResult(HRESULT hr);
+    static void HandleServerCallResult(HRESULT hr, bool isCodeGenCall = false);
 private:
     JITManager();
     ~JITManager();
@@ -108,6 +109,7 @@ private:
 
     RPC_BINDING_HANDLE m_rpcBindingHandle;
     HANDLE m_targetHandle;
+    HANDLE m_serverHandle;
     UUID m_jitConnectionId;
     bool m_oopJitEnabled;
     bool m_isJITServer;
@@ -128,6 +130,7 @@ public:
     void SetIsJITServer() { Assert(false); }
     bool IsOOPJITEnabled() const { return false; }
     void EnableOOPJIT() { Assert(false); }
+    bool IsServerAlive() const { return false; };
 
     HANDLE GetJITTargetHandle() const
         { Assert(false); return HANDLE(); }
@@ -208,7 +211,7 @@ public:
 
     static JITManager * GetJITManager()
         { return &s_jitManager; }
-    static void HandleServerCallResult(HRESULT hr);
+    static void HandleServerCallResult(HRESULT hr, bool isCodeGenCall = false) { Assert(UNREACHED); }
 
 private:
     static JITManager s_jitManager;

--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -4565,7 +4565,7 @@ void ScriptContext::RegisterPrototypeChainEnsuredToHaveOnlyWritableDataPropertie
         this->GetThreadContext()->EnsureJITThreadContext(allowPrereserveAlloc);
 
         HRESULT hr = JITManager::GetJITManager()->InitializeScriptContext(&contextData, this->GetThreadContext()->GetRemoteThreadContextAddr(), &m_remoteScriptContextAddr);
-        JITManager::HandleServerCallResult(hr);
+        JITManager::HandleServerCallResult(hr, RemoteCallType::StateUpdate);
     }
 #endif
 

--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -1987,7 +1987,7 @@ ThreadContext::EnsureJITThreadContext(bool allowPrereserveAlloc)
     }
 
     HRESULT hr = JITManager::GetJITManager()->InitializeThreadContext(&contextData, &m_remoteThreadContextInfo, &m_prereservedRegionAddr);
-    JITManager::HandleServerCallResult(hr);
+    JITManager::HandleServerCallResult(hr, RemoteCallType::StateUpdate);
 
 #endif
 }
@@ -2224,7 +2224,7 @@ void ThreadContext::SetWellKnownHostTypeId(WellKnownHostType wellKnownType, Js::
         if (this->m_remoteThreadContextInfo)
         {
             HRESULT hr = JITManager::GetJITManager()->SetWellKnownHostTypeId(this->m_remoteThreadContextInfo, (int)typeId);
-            JITManager::HandleServerCallResult(hr);
+            JITManager::HandleServerCallResult(hr, RemoteCallType::StateUpdate);
         }
 #endif
     }
@@ -4082,9 +4082,7 @@ BOOL ThreadContext::IsNativeAddress(void * pCodeAddr)
         }
 
         HRESULT hr = JITManager::GetJITManager()->IsNativeAddr(this->m_remoteThreadContextInfo, (intptr_t)pCodeAddr, &result);
-
-        // TODO: OOP JIT, can we throw here?
-        JITManager::HandleServerCallResult(hr);
+        JITManager::HandleServerCallResult(hr, RemoteCallType::HeapQuery);
         return result;
     }
     else

--- a/lib/Runtime/Language/SourceTextModuleRecord.cpp
+++ b/lib/Runtime/Language/SourceTextModuleRecord.cpp
@@ -872,7 +872,7 @@ namespace Js
                     scriptContext->GetRemoteScriptAddr(),
                     this->GetModuleId(),
                     (intptr_t)this->GetLocalExportSlots());
-                JITManager::HandleServerCallResult(hr);
+                JITManager::HandleServerCallResult(hr, RemoteCallType::StateUpdate);
             }
 #endif
         }

--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -6871,7 +6871,7 @@ namespace Js
         if (JITManager::GetJITManager()->IsOOPJITEnabled())
         {
             HRESULT hr = JITManager::GetJITManager()->SetIsPRNGSeeded(GetScriptContext()->GetRemoteScriptAddr(), val);
-            JITManager::HandleServerCallResult(hr);
+            JITManager::HandleServerCallResult(hr, RemoteCallType::StateUpdate);
         }
 #endif
     }


### PR DESCRIPTION
This failfast was a bit aggressive, and firing in scenarios where we don't necessarily want to get dumps (e.g. a user kills the server process as part of their shutdown). This excludes from firing a failfast for the known scenarios. Instead we will throw a codegen aborted error if this happened during codegen, or OOM in other cases.