### PR TITLE
WASM - call_indirect no table error

### DIFF
--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -3445,7 +3445,8 @@ namespace Js
             || (directEntryPoint == DynamicProfileInfo::EnsureDynamicProfileInfoThunk &&
             this->IsFunctionBody() && this->GetFunctionBody()->IsNativeOriginalEntryPoint())
 #ifdef ENABLE_WASM
-            || (GetFunctionBody()->IsWasmFunction() && directEntryPoint == WasmLibrary::WasmDeferredParseInternalThunk)
+            || (GetFunctionBody()->IsWasmFunction() &&
+                (directEntryPoint == WasmLibrary::WasmDeferredParseInternalThunk || directEntryPoint == WasmLibrary::WasmLazyTrapCallback))
 #endif
 #ifdef ASMJS_PLAT
             || (GetFunctionBody()->GetIsAsmJsFunction() && directEntryPoint == AsmJsDefaultEntryThunk)

--- a/lib/WasmReader/WasmBinaryReader.cpp
+++ b/lib/WasmReader/WasmBinaryReader.cpp
@@ -504,6 +504,10 @@ WasmBinaryReader::CallIndirectNode()
     UINT32 funcNum = LEB128(length);
     // Reserved value currently unused
     ReadConst<uint8>();
+    if (!m_module->HasTable() && !m_module->HasTableImport())
+    {
+        ThrowDecodingError(_u("Found call_indirect operator, but no table"));
+    }
 
     m_funcState.count += length;
     if (funcNum >= m_module->GetSignatureCount())

--- a/lib/WasmReader/WasmByteCodeGenerator.cpp
+++ b/lib/WasmReader/WasmByteCodeGenerator.cpp
@@ -1484,7 +1484,7 @@ WasmBytecodeGenerator::PopEvalStack()
     EmitInfo info = m_evalStack.Pop();
     if (info.type == WasmTypes::Limit)
     {
-        throw WasmCompilationException(_u("Missing operand"));
+        throw WasmCompilationException(_u("Reached end of stack"));
     }
     return info;
 }


### PR DESCRIPTION
call_indirect operator without a table is a compile error 
Add WasmLazyTrapCallback as a valid function entry point

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/2169)
<!-- Reviewable:end -->
