### PR TITLE
2 redeferral-related fixes in Recycler

### DIFF
--- a/lib/Common/Memory/HeapBlockMap.h
+++ b/lib/Common/Memory/HeapBlockMap.h
@@ -188,6 +188,8 @@ private:
     template <bool interlocked>
     bool MarkInternal(L2MapChunk * chunk, void * candidate);
 
+    void OnSpecialMark(L2MapChunk * chunk, void * candidate);
+
     template <bool interlocked, bool updateChunk>
     bool MarkInteriorInternal(MarkContext * markContext, L2MapChunk *& chunk, void * originalCandidate, void * realCandidate);
 

--- a/lib/Common/Memory/LargeHeapBlock.h
+++ b/lib/Common/Memory/LargeHeapBlock.h
@@ -149,6 +149,9 @@ public:
     char* GetBeginAddress() const { return address; }
     char* GetEndAddress() const { return addressEnd; }
 
+    bool TryGetAttributes(void* objectAddress, unsigned char * pAttr);
+    bool TryGetAttributes(LargeObjectHeader *objectHeader, unsigned char * pAttr);
+
     char * Alloc(DECLSPEC_GUARD_OVERFLOW size_t size, ObjectInfoBits attributes);
     char * TryAllocFromFreeList(DECLSPEC_GUARD_OVERFLOW size_t size, ObjectInfoBits attributes);
 

--- a/lib/Common/Memory/Recycler.cpp
+++ b/lib/Common/Memory/Recycler.cpp
@@ -4974,15 +4974,7 @@ Recycler::BackgroundScanStack()
     if (stackTop != nullptr)
     {
         size_t size = (char *)stackBase - stackTop;
-        bool doSpecialMark = collectionWrapper->DoSpecialMarkOnScanStack();
-        if (doSpecialMark)
-        {
-            ScanMemoryInline<true>((void **)stackTop, size);
-        }
-        else
-        {
-            ScanMemoryInline<false>((void **)stackTop, size);
-        }
+        ScanMemoryInline<false>((void **)stackTop, size);
         return size;
     }
 

--- a/lib/Common/Memory/SmallFinalizableHeapBlock.h
+++ b/lib/Common/Memory/SmallFinalizableHeapBlock.h
@@ -30,6 +30,9 @@ public:
     }
     void SetNextBlock(SmallFinalizableHeapBlockT * next) { Base::SetNextBlock(next); }
 
+    bool TryGetAddressOfAttributes(void* objectAddress, unsigned char **ppAttr);
+    bool TryGetAttributes(void* objectAddress, unsigned char *pAttr);
+
     template <bool doSpecialMark>
     void ProcessMarkedObject(void* candidate, MarkContext * markContext);
 


### PR DESCRIPTION
1. Do not try to take special mark actions in BackgroundScanStack, only in ScanStack, as memory may be unstable in the background case. 2. In marking, if MarkInternal returns true (indicating no further work is necessary), and if we're required to take special mark actions, detect finalizable object and take the action.