### PR TITLE
WASM - Added checks for exports

### DIFF
--- a/lib/WasmReader/WasmBinaryReader.cpp
+++ b/lib/WasmReader/WasmBinaryReader.cpp
@@ -778,6 +778,10 @@ void WasmBinaryReader::ReadExportTable()
             {
                 ThrowDecodingError(_u("Unknown global %u for export %s"), index, exportName);
             }
+            if (m_module->GetGlobal(index)->IsMutable())
+            {
+                ThrowDecodingError(_u("Mutable globals cannot be exported"), index, exportName);
+            }
             m_module->SetExport(iExport, index, exportName, nameLength, kind);
             break;
         default:
@@ -997,6 +1001,10 @@ WasmBinaryReader::ReadImportEntries()
         {
             WasmTypes::WasmType type = ReadWasmType(len);
             bool isMutable = ReadConst<UINT8>() == 1;
+            if (isMutable)
+            {
+                ThrowDecodingError(_u("Mutable globals cannot be imported"));
+            }
             m_module->AddGlobal(GlobalReferenceTypes::ImportedReference, type, isMutable, {});
             m_module->AddGlobalImport(modName, modNameLen, fnName, fnNameLen);
             break;

--- a/lib/WasmReader/WasmBinaryReader.cpp
+++ b/lib/WasmReader/WasmBinaryReader.cpp
@@ -760,13 +760,24 @@ void WasmBinaryReader::ReadExportTable()
             break;
         }
         case ExternalKinds::Memory:
+            if (index != 0)
+            {
+                ThrowDecodingError(_u("Unknown memory index %u for export %s"), index, exportName);
+            }
+            m_module->SetExport(iExport, index, exportName, nameLength, kind);
+            break;
         case ExternalKinds::Table:
-        if (index != 0)
-        {
-            ThrowDecodingError(_u("Invalid index %u"), index);
-        }
-        // fallthrough
+            if (index != 0)
+            {
+                ThrowDecodingError(_u("Unknown table index %u for export %s"), index, exportName);
+            }
+            m_module->SetExport(iExport, index, exportName, nameLength, kind);
+            break;
         case ExternalKinds::Global:
+            if (index >= m_module->GetGlobalCount())
+            {
+                ThrowDecodingError(_u("Unknown global %u for export %s"), index, exportName);
+            }
             m_module->SetExport(iExport, index, exportName, nameLength, kind);
             break;
         default:

--- a/lib/WasmReader/WasmBinaryReader.cpp
+++ b/lib/WasmReader/WasmBinaryReader.cpp
@@ -740,7 +740,7 @@ void WasmBinaryReader::ReadExportTable()
         case ExternalKinds::Table:
         if (index != 0)
         {
-            ThrowDecodingError(_u("Invalid index %s"), index);
+            ThrowDecodingError(_u("Invalid index %u"), index);
         }
         // fallthrough
         case ExternalKinds::Global:


### PR DESCRIPTION
We were not behaving as spec for some aspects in the exports table.
We need to check for duplicate names and verify that the global exists.

Disallow export/import of mutable globals

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/2173)
<!-- Reviewable:end -->
