### PR TITLE
tweak rpc failfast

### DIFF
--- a/lib/Backend/NativeCodeGenerator.cpp
+++ b/lib/Backend/NativeCodeGenerator.cpp
@@ -3646,17 +3646,10 @@ JITManager::HandleServerCallResult(HRESULT hr, RemoteCallType callType)
     // if jit process is terminated, we can handle certain abnormal hresults
 
     // we should not have RPC failure if JIT process is still around
-    DWORD sleepInterval = 0;
-    uint retries = 0;
-    while (WaitForSingleObject(GetJITManager()->GetServerHandle(), sleepInterval) != WAIT_OBJECT_0)
+    // since this is going to be a failfast, lets wait a bit in case server is in process of terminating
+    if (WaitForSingleObject(GetJITManager()->GetServerHandle(), 250) != WAIT_OBJECT_0)
     {
-        // there could be scenarios where process is dying but still alive
-        // since this is going to be a failfast, lets wait a bit in case server is in process of terminating
-        if (++retries > 5)
-        {
-            RpcFailure_fatal_error(hr);
-        }
-        sleepInterval += 50;
+        RpcFailure_fatal_error(hr);
     }
 
     // we only expect to see these hresults in case server has been closed. failfast otherwise

--- a/lib/Backend/NativeCodeGenerator.cpp
+++ b/lib/Backend/NativeCodeGenerator.cpp
@@ -3629,10 +3629,11 @@ bool NativeCodeGenerator::TryAggressiveInlining(Js::FunctionBody *const topFunct
 void
 JITManager::HandleServerCallResult(HRESULT hr, RemoteCallType callType)
 {
+    // handle the normal hresults
     switch (hr)
     {
     case S_OK:
-        break;
+        return;
     case E_ABORT:
         throw Js::OperationAbortedException();
     case E_OUTOFMEMORY:
@@ -3640,32 +3641,45 @@ JITManager::HandleServerCallResult(HRESULT hr, RemoteCallType callType)
     case VBSERR_OutOfStack:
         throw Js::StackOverflowException();
     default:
-        // we should not have RPC failure if JIT process is still around
-        if (GetJITManager()->IsServerAlive())
-        {
-            RpcFailure_fatal_error(hr);
-        }
+        break;
+    }
+    // if jit process is terminated, we can handle certain abnormal hresults
 
-        // we only expect to see these hresults in case server has been closed. failfast otherwise
-        if (hr != HRESULT_FROM_WIN32(RPC_S_CALL_FAILED) && hr != HRESULT_FROM_WIN32(RPC_S_CALL_FAILED_DNE))
+    // we should not have RPC failure if JIT process is still around
+    DWORD sleepInterval = 0;
+    uint retries = 0;
+    while (WaitForSingleObject(GetJITManager()->GetServerHandle(), sleepInterval) != WAIT_OBJECT_0)
+    {
+        // there could be scenarios where process is dying but still alive
+        // since this is going to be a failfast, lets wait a bit in case server is in process of terminating
+        if (++retries > 5)
         {
             RpcFailure_fatal_error(hr);
         }
-        switch (callType)
-        {
-        case RemoteCallType::CodeGen:
-            // inform job manager that JIT work item has been cancelled
-            throw Js::OperationAbortedException();
-        case RemoteCallType::HeapQuery:
-        case RemoteCallType::ThunkCreation:
-            Js::Throw::OutOfMemory();
-        case RemoteCallType::StateUpdate:
-            // if server process is gone, we can ignore failures updating its state
-            return;
-        default:
-            Assert(UNREACHED);
-            RpcFailure_fatal_error(hr);
-        }
+        sleepInterval += 50;
+    }
+
+    // we only expect to see these hresults in case server has been closed. failfast otherwise
+    if (hr != HRESULT_FROM_WIN32(RPC_S_CALL_FAILED) &&
+        hr != HRESULT_FROM_WIN32(RPC_S_CALL_FAILED_DNE) &&
+        hr != HRESULT_FROM_WIN32(RPC_X_SS_IN_NULL_CONTEXT))
+    {
+        RpcFailure_fatal_error(hr);
+    }
+    switch (callType)
+    {
+    case RemoteCallType::CodeGen:
+        // inform job manager that JIT work item has been cancelled
+        throw Js::OperationAbortedException();
+    case RemoteCallType::HeapQuery:
+    case RemoteCallType::ThunkCreation:
+        Js::Throw::OutOfMemory();
+    case RemoteCallType::StateUpdate:
+        // if server process is gone, we can ignore failures updating its state
+        return;
+    default:
+        Assert(UNREACHED);
+        RpcFailure_fatal_error(hr);
     }
 }
 #endif

--- a/lib/JITClient/JITManager.cpp
+++ b/lib/JITClient/JITManager.cpp
@@ -195,6 +195,12 @@ JITManager::IsConnected() const
     return m_rpcBindingHandle != nullptr && m_targetHandle != nullptr;
 }
 
+HANDLE
+JITManager::GetServerHandle() const
+{
+    return m_serverHandle;
+}
+
 void
 JITManager::EnableOOPJIT()
 {
@@ -647,10 +653,4 @@ JITManager::RemoteCodeGenCall(
     RpcEndExcept;
 
     return hr;
-}
-
-bool
-JITManager::IsServerAlive() const
-{
-    return (WaitForSingleObject(this->m_serverHandle, 0) == WAIT_OBJECT_0);
 }

--- a/lib/JITClient/JITManager.h
+++ b/lib/JITClient/JITManager.h
@@ -27,9 +27,9 @@ public:
     void SetIsJITServer();
     bool IsOOPJITEnabled() const;
     void EnableOOPJIT();
-    bool IsServerAlive() const;
 
     HANDLE GetJITTargetHandle() const;
+    HANDLE GetServerHandle() const;
 
     HRESULT InitializeThreadContext(
         __in ThreadContextDataIDL * data,
@@ -139,10 +139,13 @@ public:
     void SetIsJITServer() { Assert(false); }
     bool IsOOPJITEnabled() const { return false; }
     void EnableOOPJIT() { Assert(false); }
-    bool IsServerAlive() const { return false; };
 
     HANDLE GetJITTargetHandle() const
         { Assert(false); return HANDLE(); }
+    HANDLE GetServerHandle() const
+    {
+        Assert(false); return HANDLE();
+    }
 
     HRESULT InitializeThreadContext(
         __in ThreadContextDataIDL * data,


### PR DESCRIPTION
tweak rpc failfast to allow additional hresult (RPC_X_SS_IN_NULL_CONTEXT). This is because we may have null context handle if context handle for ScriptContext wasn't able to be initialized (due to jit process going away).

Also, add retry logic on the server liveness check. Server may be in process of closing but still alive. Worth waiting a bit to find out rather than having failfast right away.