### PR TITLE
WASM - defer parsing js hook

### DIFF
--- a/lib/Runtime/Library/JavascriptLibrary.h
+++ b/lib/Runtime/Library/JavascriptLibrary.h
@@ -758,6 +758,7 @@ namespace Js
         DynamicType * GetPromiseType() const { return promiseType; }
 
         DynamicType * GetWebAssemblyModuleType()  const { return webAssemblyModuleType; }
+        DynamicObject* GetWebAssemblyModulePrototype()  const { return webAssemblyModulePrototype; }
         DynamicType * GetWebAssemblyInstanceType()  const { return webAssemblyInstanceType; }
         DynamicType * GetWebAssemblyMemoryType() const { return webAssemblyMemoryType; }
         DynamicType * GetWebAssemblyTableType() const { return webAssemblyTableType; }

--- a/lib/Runtime/Library/WebAssemblyInstance.cpp
+++ b/lib/Runtime/Library/WebAssemblyInstance.cpp
@@ -163,7 +163,7 @@ void WebAssemblyInstance::LoadFunctions(WebAssemblyModule * wasmModule, ScriptCo
         funcObj->SetEnvironment(frameDisplay);
         env->SetWasmFunction(i, funcObj);
 
-        if (!PHASE_OFF(WasmDeferredPhase, body))
+        if (!body->GetByteCode())
         {
             // if we still have WasmReaderInfo we haven't yet parsed
             if (body->GetAsmJsFunctionInfo()->GetWasmReaderInfo())

--- a/lib/Runtime/Library/WebAssemblyModule.cpp
+++ b/lib/Runtime/Library/WebAssemblyModule.cpp
@@ -166,6 +166,14 @@ WebAssemblyModule::CreateModule(
     AutoProfilingPhase wasmPhase(scriptContext, Js::WasmBytecodePhase);
     Unused(wasmPhase);
 
+#if ENABLE_DEBUG_CONFIG_OPTIONS
+    PropertyRecord const * propertyRecord = nullptr;;
+    scriptContext->GetOrAddPropertyRecord(_u("deferred"), lstrlen(_u("deferred")), &propertyRecord);
+    Var value = JavascriptOperators::GetProperty(scriptContext->GetLibrary()->GetWebAssemblyModulePrototype(), propertyRecord->GetPropertyId(), scriptContext);
+    bool forceDeffered = !JavascriptOperators::IsUndefined(value);
+    bool forceDeferredValue = JavascriptConversion::ToBool(value, scriptContext);
+#endif
+
     WebAssemblyModule * webAssemblyModule = nullptr;
     Wasm::WasmReaderInfo * readerInfo = nullptr;
     Js::FunctionBody * currentBody = nullptr;
@@ -186,7 +194,15 @@ WebAssemblyModule::CreateModule(
         for (uint i = 0; i < webAssemblyModule->GetWasmFunctionCount(); ++i)
         {
             currentBody = webAssemblyModule->GetWasmFunctionInfo(i)->GetBody();
-            if (!PHASE_OFF(WasmDeferredPhase, currentBody))
+            bool doDeferred = !PHASE_OFF(WasmDeferredPhase, currentBody);
+#if ENABLE_DEBUG_CONFIG_OPTIONS
+            if (forceDeffered)
+            {
+                doDeferred = forceDeferredValue;
+            }
+#endif
+
+            if (doDeferred)
             {
                 continue;
             }


### PR DESCRIPTION
Add a js test hook to force deferred parsing or not of WebAssembly Modules
This helps a lot to test spec invalid tests
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/2181)
<!-- Reviewable:end -->
