### PR TITLE
xplat: link stdlibc++ statically by default

### DIFF
--- a/bin/ChakraCore/CMakeLists.txt
+++ b/bin/ChakraCore/CMakeLists.txt
@@ -30,6 +30,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL Linux)
   set(LINKER_END_GROUP
     -Wl,--no-whole-archive
     -Wl,--end-group
+    -static-libstdc++
     )
 elseif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
   set(LINKER_START_GROUP -Wl,-force_load,)
@@ -44,7 +45,6 @@ set(lib_target "${lib_target}"
   Chakra.Jsrt
   ${LINKER_END_GROUP}
   pthread
-  stdc++
   dl
   ${ICULIB}
   )

--- a/bin/ch/CMakeLists.txt
+++ b/bin/ch/CMakeLists.txt
@@ -32,16 +32,10 @@ target_include_directories (ch
   ../../lib/Parser
   )
 
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fPIE")
-
-if(CMAKE_SYSTEM_NAME STREQUAL Linux)
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pie") # osx clang sets this by default
-endif()
-
 if(STATIC_LIBRARY)
   if(CMAKE_SYSTEM_NAME STREQUAL Linux)
     set(LINKER_START_GROUP -Wl,--start-group)
-    set(LINKER_END_GROUP -Wl,--end-group)
+    set(LINKER_END_GROUP -Wl,--end-group -static-libstdc++)
   elseif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
     set(LINKER_START_GROUP -Wl,-force_load,)
   endif()
@@ -55,35 +49,28 @@ if(STATIC_LIBRARY)
     Chakra.Jsrt
     ${LINKER_END_GROUP}
     pthread
-    stdc++
     dl
-  )
+    ${ICULIB}
+    )
 
-  if(CMAKE_SYSTEM_NAME STREQUAL Linux)
+  if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
     set(lib_target "${lib_target}"
-      ${ICULIB}
-      )
-  elseif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
-    set(lib_target "${lib_target}"
-      ${ICULIB}
       "-framework CoreFoundation"
       "-framework Security"
       )
   endif() # Linux ?
 else() # // shared library below
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fPIE")
+
+  if(CMAKE_SYSTEM_NAME STREQUAL Linux)
+      set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pie") # osx clang sets this by default
+  endif()
+
   set(lib_target
     PRIVATE Chakra.Pal
     PRIVATE Chakra.Common.Codex.Singular
     PRIVATE Chakra.Runtime.PlatformAgnostic.Singular
     )
-endif()
-
-if(NOT CC_XCODE_PROJECT)
-  if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
-    set(lib_target "${lib_target}"
-      "-stdlib=libstdc++" # expected 'deprecated' warning. needed for std::string
-      )
-  endif()
 endif()
 
 if(CC_TARGETS_X86)

--- a/pal/CMakeLists.txt
+++ b/pal/CMakeLists.txt
@@ -5,8 +5,6 @@ project(COREPAL)
 include_directories(${COREPAL_SOURCE_DIR}/inc)
 include_directories(${COREPAL_SOURCE_DIR}/src)
 
-add_compile_options(-gdwarf-3)
-add_compile_options(-fexceptions)
-add_compile_options(-fstack-protector-all)
+add_compile_options(-fstack-protector)
 
 add_subdirectory(src)

--- a/pal/src/CMakeLists.txt
+++ b/pal/src/CMakeLists.txt
@@ -169,29 +169,12 @@ add_library(Chakra.Pal
 
 if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
   target_link_libraries(Chakra.Pal
-    pthread
-    dl
     "-framework CoreFoundation"
     "-framework Security"
   )
-endif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
-
-if(CMAKE_SYSTEM_NAME STREQUAL Linux)
-  if(CC_TARGETS_AMD64)
-    target_link_libraries(Chakra.Pal
-      unwind-x86_64
-    )
-  endif()
-
+else() # Linux
   target_link_libraries(Chakra.Pal
-    gcc_s
     pthread
-    rt
     dl
-    unwind
-    unwind-generic
   )
-endif(CMAKE_SYSTEM_NAME STREQUAL Linux)
-
-# Install the static PAL library for VS
-install (TARGETS Chakra.Pal DESTINATION lib)
+endif(CMAKE_SYSTEM_NAME STREQUAL Darwin)


### PR DESCRIPTION
We already had `--embed-icu` for ICU static linking. Besides, we had also removed libunwind dependency.

This PR forward we should have a smoother cross platform binary distribution. Statically embedding the dependencies, increases the final `CH` binary size drastically. However, embedders of ChakraCore are free to decide whether they want to link the dependencies statically or not as before.

Also minor cleanup on PAL's CMakeLists