### PR TITLE
Fix for missed stack references to FunctionBody in redeferral

### DIFF
--- a/lib/Common/Memory/CollectionState.h
+++ b/lib/Common/Memory/CollectionState.h
@@ -34,10 +34,11 @@ enum CollectionState
     Collection_ConcurrentSweep      = Collection_Concurrent | Collection_Sweep,
 #endif
     Collection_Parallel             = 0x00010000,
-
-    Collection_PostCollectionCallback     = 0x00020000,
-
-    Collection_WrapperCallback      = 0x00040000,
+    
+    Collection_PostCollectionCallback      = 0x00020000,
+    Collection_PostSweepRedeferralCallback = 0x00040000,
+    Collection_WrapperCallback             = 0x00080000,
+    
 
     // Actual states
     CollectionStateNotCollecting          = 0,                                                                // not collecting
@@ -69,6 +70,6 @@ enum CollectionState
     CollectionStateBackgroundParallelMark = Collection_ConcurrentMark | Collection_ExecutingConcurrent | Collection_Parallel,
     CollectionStateConcurrentWrapperCallback = Collection_Concurrent | Collection_ExecutingConcurrent | Collection_WrapperCallback,
 #endif
-
+    CollectionStatePostSweepRedeferralCallback = Collection_PostSweepRedeferralCallback,
     CollectionStatePostCollectionCallback = Collection_PostCollectionCallback,
 };

--- a/lib/Common/Memory/Recycler.h
+++ b/lib/Common/Memory/Recycler.h
@@ -330,6 +330,7 @@ public:
     virtual BOOL ExecuteRecyclerCollectionFunction(Recycler * recycler, CollectionFunction function, CollectionFlags flags) = 0;
     virtual uint GetRandomNumber() = 0;
     virtual bool DoSpecialMarkOnScanStack() = 0;
+    virtual void PostSweepRedeferralCallBack() = 0;
 
 #ifdef FAULT_INJECTION
     virtual void DisposeScriptContextByFaultInjectionCallBack() = 0;
@@ -378,6 +379,7 @@ public:
     virtual BOOL ExecuteRecyclerCollectionFunction(Recycler * recycler, CollectionFunction function, CollectionFlags flags) override;
     virtual uint GetRandomNumber() override { return 0; }
     virtual bool DoSpecialMarkOnScanStack() override { return false; }
+    virtual void PostSweepRedeferralCallBack() override {}
 #ifdef FAULT_INJECTION
     virtual void DisposeScriptContextByFaultInjectionCallBack() override {};
 #endif
@@ -1695,6 +1697,10 @@ private:
     void ProcessTrackedObjects();
 #endif
 
+    BOOL IsAllocatableCallbackState()
+    {
+        return (collectionState & (Collection_PostSweepRedeferralCallback | Collection_PostCollectionCallback));
+    }
 #if ENABLE_CONCURRENT_GC
     // Concurrent GC
     BOOL IsConcurrentEnabled() const { return this->enableConcurrentMark || this->enableParallelMark || this->enableConcurrentSweep; }

--- a/lib/Common/Memory/Recycler.inl
+++ b/lib/Common/Memory/Recycler.inl
@@ -56,10 +56,10 @@ Recycler::AllocWithAttributesInlined(size_t size)
 
 #if ENABLE_CONCURRENT_GC
     // We shouldn't be allocating memory when we are running GC in thread, including finalizers
-    Assert(this->IsConcurrentState() || !this->CollectionInProgress() || this->collectionState == CollectionStatePostCollectionCallback);
+    Assert(this->IsConcurrentState() || !this->CollectionInProgress() || this->IsAllocatableCallbackState());
 #else
     // We shouldn't be allocating memory when we are running GC in thread, including finalizers
-    Assert(!this->CollectionInProgress() || this->collectionState == CollectionStatePostCollectionCallback);
+    Assert(!this->CollectionInProgress() || this->IsAllocatableCallbackState());
 #endif
 
     // There are some cases where we allow allocation during heap enum that doesn't affect the enumeration

--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -2595,19 +2595,23 @@ ThreadContext::PostCollectionCallBack()
                 scriptContext->CleanupWeakReferenceDictionaries();
             }
         }
-
-        if (this->DoTryRedeferral())
-        {
-            HRESULT hr = S_OK;
-            BEGIN_TRANSLATE_OOM_TO_HRESULT
-            {
-                this->TryRedeferral();
-            }
-            END_TRANSLATE_OOM_TO_HRESULT(hr);
-        }
-
-        this->UpdateRedeferralState();
     }
+}
+
+void
+ThreadContext::PostSweepRedeferralCallBack()
+{
+    if (this->DoTryRedeferral())
+    {
+        HRESULT hr = S_OK;
+        BEGIN_TRANSLATE_OOM_TO_HRESULT
+        {
+            this->TryRedeferral();
+        }
+        END_TRANSLATE_OOM_TO_HRESULT(hr);
+    }
+
+    this->UpdateRedeferralState();
 }
 
 bool

--- a/lib/Runtime/Base/ThreadContext.h
+++ b/lib/Runtime/Base/ThreadContext.h
@@ -1547,6 +1547,7 @@ public:
 
     virtual uint GetRandomNumber() override;
     virtual bool DoSpecialMarkOnScanStack() override { return this->DoRedeferFunctionBodies(); }
+    virtual void PostSweepRedeferralCallBack() override;
 
     // DefaultCollectWrapper
     virtual void PreCollectionCallBack(CollectionFlags flags) override;


### PR DESCRIPTION
(Thanks to Curtis for help on this one.) Make the redeferral callback earlier in GC so that new FunctionBody references can't appear on the stack between the time that GC scans the stack and the time we gather our set of legal redeferral candidates.