### PR TITLE
extend recycler verify mark to verify missing write barrier

### DIFF
--- a/bin/rl/rlrun.cpp
+++ b/bin/rl/rlrun.cpp
@@ -485,7 +485,7 @@ int
     }
     else if (kind == TK_JSCRIPT || kind==TK_HTML || kind == TK_COMMAND)
     {
-        char tempExtraCCFlags[MAX_PATH] = {0};
+        char tempExtraCCFlags[MAX_PATH*2] = {0};
 
         // Only append when EXTRA_CC_FLAGS isn't empty.
         if (EXTRA_CC_FLAGS[0])

--- a/lib/Backend/Backend.h
+++ b/lib/Backend/Backend.h
@@ -111,7 +111,7 @@ enum IRDumpFlags
 //
 
 #ifdef _WIN32
-#include "ChakraJIT.h"
+#include "../JITIDL/JITTypes.h"
 #endif
 #include "JITTimeProfileInfo.h"
 #include "JITRecyclableObject.h"

--- a/lib/Backend/JITTimePolymorphicInlineCacheInfo.cpp
+++ b/lib/Backend/JITTimePolymorphicInlineCacheInfo.cpp
@@ -53,8 +53,9 @@ JITTimePolymorphicInlineCacheInfo::InitializePolymorphicInlineCacheInfo(
     __in Js::PolymorphicInlineCacheInfo * runtimeInfo,
     __out PolymorphicInlineCacheInfoIDL * jitInfo)
 {
+#pragma warning(suppress: 6001)
     jitInfo->polymorphicCacheUtilizationArray = runtimeInfo->GetUtilByteArray();
-    jitInfo->functionBodyAddr = (intptr_t)runtimeInfo->GetFunctionBody();
+    jitInfo->functionBodyAddr = runtimeInfo->GetFunctionBody();
 
     if (runtimeInfo->GetPolymorphicInlineCaches()->HasInlineCaches())
     {

--- a/lib/Backend/JITTimeWorkItem.cpp
+++ b/lib/Backend/JITTimeWorkItem.cpp
@@ -146,7 +146,7 @@ JITTimeWorkItem::GetInlineePolymorphicInlineCacheInfo(intptr_t funcBodyAddr)
 {
     for (uint i = 0; i < m_workItemData->inlineeInfoCount; ++i)
     {
-        if (m_workItemData->inlineeInfo[i].functionBodyAddr == funcBodyAddr)
+        if (m_workItemData->inlineeInfo[i].functionBodyAddr == (void*)funcBodyAddr)
         {
             return (JITTimePolymorphicInlineCacheInfo *)&m_workItemData->inlineeInfo[i];
         }

--- a/lib/Backend/JITType.cpp
+++ b/lib/Backend/JITType.cpp
@@ -20,12 +20,12 @@ void
 JITType::BuildFromJsType(__in Js::Type * jsType, __out JITType * jitType)
 {
     TypeIDL * data = jitType->GetData();
-    data->addr = (intptr_t)jsType;
+    data->addr = jsType;
     data->typeId = jsType->GetTypeId();
-    data->libAddr = (intptr_t)jsType->GetLibrary();
-    data->protoAddr = (intptr_t)jsType->GetPrototype();
+    data->libAddr = jsType->GetLibrary();
+    data->protoAddr = jsType->GetPrototype();
     data->entrypointAddr = (intptr_t)jsType->GetEntryPoint();
-    data->propertyCacheAddr = (intptr_t)jsType->GetPropertyCache();
+    data->propertyCacheAddr = jsType->GetPropertyCache();
     if (Js::DynamicType::Is(jsType->GetTypeId()))
     {
         Js::DynamicType * dynamicType = static_cast<Js::DynamicType*>(jsType);
@@ -63,13 +63,13 @@ JITType::GetData()
 intptr_t
 JITType::GetAddr() const
 {
-    return m_data.addr;
+    return (intptr_t)PointerValue(m_data.addr);
 }
 
 intptr_t
 JITType::GetPrototypeAddr() const
 {
-    return m_data.protoAddr;
+    return (intptr_t)PointerValue(m_data.protoAddr);
 }
 
 const JITTypeHandler*

--- a/lib/Common/Common/Jobs.cpp
+++ b/lib/Common/Common/Jobs.cpp
@@ -26,6 +26,7 @@
 #include "Common/Jobs.h"
 #include "Common/Jobs.inl"
 #include "Core/CommonMinMax.h"
+#include "Memory/RecyclerWriteBarrierManager.h"
 
 namespace JsUtil
 {
@@ -1224,6 +1225,11 @@ namespace JsUtil
     unsigned int WINAPI BackgroundJobProcessor::StaticThreadProc(void *lpParam)
     {
         Assert(lpParam);
+
+#ifdef _M_X64_OR_ARM64
+        Memory::RecyclerWriteBarrierManager::OnThreadInit();
+#endif
+
 #if !defined(_UCRT)
         HMODULE dllHandle = NULL;
         if (!GetModuleHandleEx(0, AutoSystemInfo::GetJscriptDllFileName(), &dllHandle))

--- a/lib/Common/DataStructures/BaseDictionary.h
+++ b/lib/Common/DataStructures/BaseDictionary.h
@@ -892,7 +892,7 @@ namespace JsUtil
         }
 
         template <InsertOperations op>
-        int Insert(TKey key, TValue value)
+        int Insert(const TKey& key, const TValue& value)
         {
             int * localBuckets = buckets;
             if (localBuckets == nullptr)

--- a/lib/Common/DataStructures/List.h
+++ b/lib/Common/DataStructures/List.h
@@ -360,6 +360,7 @@ namespace JsUtil
         void SetItem(int index, const T& item)
         {
             EnsureArray(index + 1);
+            // TODO: (SWB)(leish) find a way to force user defined copy constructor
             this->buffer[index] = item;
             this->count = max(this->count, index + 1);
         }

--- a/lib/Common/Memory/LargeHeapBlock.h
+++ b/lib/Common/Memory/LargeHeapBlock.h
@@ -171,7 +171,7 @@ public:
 #endif
 #ifdef RECYCLER_VERIFY_MARK
     void VerifyMark();
-    virtual void VerifyMark(void * objectAddress) override;
+    virtual bool VerifyMark(void * objectAddress) override;
 #endif
 #ifdef RECYCLER_PERF_COUNTERS
     virtual void UpdatePerfCountersOnFree() override;
@@ -301,6 +301,15 @@ public:
     HeapInfo * heapInfo;
 #ifdef PROFILE_RECYCLER_ALLOC
     void ** GetTrackerDataArray();
+#endif
+
+#if DBG
+private:
+    BVSparse<HeapAllocator> wbVerifyBits;
+public:
+    virtual void WBSetBit(char* addr) override;
+    virtual void WBSetBits(char* addr, uint length) override;
+    virtual void WBClearBits(char* addr) override;
 #endif
 };
 }

--- a/lib/Common/Memory/Recycler.h
+++ b/lib/Common/Memory/Recycler.h
@@ -1696,7 +1696,7 @@ private:
     void VerifyMarkArena(ArenaData * arena);
     void VerifyMarkBigBlockList(BigBlock * memoryBlocks);
     void VerifyMarkArenaMemoryBlockList(ArenaMemoryBlock * memoryBlocks);
-    void VerifyMark(void * address);
+    bool VerifyMark(void * address);
 #endif
 #if DBG_DUMP
     bool forceTraceMark;
@@ -1921,6 +1921,15 @@ private:
     } objectBeforeCollectCallbackState;
 
     bool ProcessObjectBeforeCollectCallbacks(bool atShutdown = false);
+
+#if DBG
+private:
+    static Recycler* recyclerList;
+    Recycler* next;
+public:
+    static void WBSetBit(char* addr);
+    static void WBSetBits(char* addr, uint length);
+#endif
 };
 
 
@@ -2092,6 +2101,10 @@ class CollectedRecyclerWeakRefHeapBlock : public HeapBlock
 {
 public:
 #if DBG
+    virtual void WBSetBit(char* addr) override { Assert(false); }
+    virtual void WBSetBits(char* addr, uint length) override { Assert(false); }
+    virtual void WBClearBits(char* addr) override { Assert(false); }
+
     virtual BOOL IsFreeObject(void* objectAddress) override { Assert(false); return false; }
 #endif
     virtual BOOL IsValidObject(void* objectAddress) override { Assert(false); return false; }
@@ -2102,7 +2115,7 @@ public:
     virtual void SetObjectMarkedBit(void* objectAddress) override { Assert(false); }
 
 #ifdef RECYCLER_VERIFY_MARK
-    virtual void VerifyMark(void * objectAddress) override { Assert(false); }
+    virtual bool VerifyMark(void * objectAddress) override { Assert(false); return false; }
 #endif
 #ifdef RECYCLER_PERF_COUNTERS
     virtual void UpdatePerfCountersOnFree() override { Assert(false); }

--- a/lib/Common/Memory/Recycler.inl
+++ b/lib/Common/Memory/Recycler.inl
@@ -265,6 +265,14 @@ Recycler::AllocZeroWithAttributesInlined(DECLSPEC_GUARD_OVERFLOW size_t size)
 #if DBG
     VerifyPageHeapFillAfterAlloc<attributes>(obj, size);
 #endif
+
+#if DBG
+    if (CONFIG_FLAG(ForceSoftwareWriteBarrier))
+    {
+        this->FindHeapBlock(obj)->WBClearBits(obj);
+    }
+#endif
+
     return obj;
 }
 

--- a/lib/Common/Memory/RecyclerPointers.h
+++ b/lib/Common/Memory/RecyclerPointers.h
@@ -310,9 +310,23 @@ public:
     WriteBarrierPtr() : ptr(nullptr) {}
     WriteBarrierPtr(T * ptr)
     {
+#ifdef _WIN32
         // WriteBarrier
+        WriteBarrierSet(ptr);
+#else
+        // TODO: (leish)(swb) find a way to get dll load address on Linux, and initialize card table for 
+        // image write copy region
         NoWriteBarrierSet(ptr);
+#endif
     }
+    WriteBarrierPtr(WriteBarrierPtr<T>& other)
+    {
+        WriteBarrierSet(other.ptr);
+    }
+    WriteBarrierPtr(WriteBarrierPtr<T>&& other)
+    {
+        WriteBarrierSet(other.ptr);
+    }    
 
     // Getters
     T * operator->() const { return ptr; }

--- a/lib/Common/Memory/RecyclerWriteBarrierManager.cpp
+++ b/lib/Common/Memory/RecyclerWriteBarrierManager.cpp
@@ -310,6 +310,9 @@ RecyclerWriteBarrierManager::WriteBarrier(void * address)
         Output::Print(_u("Writing to 0x%p (CIndex: %u)\n"), address, index);
     }
 #endif
+#if DBG
+    Recycler::WBSetBit((char*)address);
+#endif
 }
 
 void
@@ -325,6 +328,11 @@ RecyclerWriteBarrierManager::WriteBarrier(void * address, size_t bytes)
     Assert(startIndex <= endIndex);
     memset(cardTable + startIndex, WRITE_BARRIER_PAGE_BIT | DIRTYBIT, endIndex - startIndex);
     GlobalSwbVerboseTrace(_u("Writing to 0x%p (CIndex: %u-%u)\n"), address, startIndex, endIndex);
+
+#if DBG
+    Recycler::WBSetBits((char*)address, (uint)bytes/sizeof(void*));
+#endif
+
 #else
     uint bitShift = (((uint)address) >> s_BitArrayCardTableShift);
     uint bitMask = 0xFFFFFFFF << bitShift;

--- a/lib/Common/Memory/RecyclerWriteBarrierManager.cpp
+++ b/lib/Common/Memory/RecyclerWriteBarrierManager.cpp
@@ -262,6 +262,13 @@ X64WriteBarrierCardTableManager::Initialize()
         _cardTable = (BYTE*) cardTableSpace;
     }
 
+    OnThreadInit();
+
+#if SYSINFO_IMAGE_BASE_AVAILABLE
+    // Image WRITE_COPY region
+    // TODO: find a way for linux
+    OnSegmentAlloc((char*)AutoSystemInfo::Data.dllLoadAddress, (AutoSystemInfo::Data.dllHighAddress - AutoSystemInfo::Data.dllLoadAddress) / AutoSystemInfo::Data.PageSize);
+#endif
     return _cardTable;
 }
 

--- a/lib/JITClient/JITClient.h
+++ b/lib/JITClient/JITClient.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "../JITIDL/JITTypes.h"
 #include "ChakraJIT.h"
 
 #include "JITManager.h"

--- a/lib/JITIDL/ChakraJIT.idl
+++ b/lib/JITIDL/ChakraJIT.idl
@@ -3,7 +3,12 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 
+cpp_quote("#ifndef __JITTypes_h__")
+cpp_quote("#define __JITTypes_h__")
+
 #include "JITTypes.h"
+
+cpp_quote("#endif //__JITTypes_h__")
 
 [
     uuid(ead694ed-2243-44cb-a9dc-85d3ba934dab),

--- a/lib/JITIDL/JITTypes.h
+++ b/lib/JITIDL/JITTypes.h
@@ -10,9 +10,19 @@ import "wtypes.idl";
 #endif
 
 #if defined(_M_IX86) || defined(_M_ARM)
+#ifdef __midl
+#define CHAKRA_WB_PTR int
+#else
+#define CHAKRA_WB_PTR void*
+#endif
 #define CHAKRA_PTR int
 #define BV_SHIFT 5
 #elif defined(_M_X64) || defined(_M_ARM64)
+#ifdef __midl
+#define CHAKRA_WB_PTR __int64
+#else
+#define CHAKRA_WB_PTR void*
+#endif
 #define CHAKRA_PTR __int64
 #define BV_SHIFT 6
 #endif
@@ -59,6 +69,9 @@ typedef unsigned char boolean;
 #define IDL_FieldNoBarrier(type)    FieldNoBarrier(type)
 #endif
 
+#ifndef __JITTypes_h__
+#define __JITTypes_h__
+
 // TODO: OOP JIT, how do we make this better?
 const int VTABLE_COUNT = 47;
 const int EQUIVALENT_TYPE_CACHE_SIZE = 8;
@@ -88,11 +101,11 @@ typedef struct TypeIDL
     IDL_PAD2(0)
     IDL_Field(int) typeId;
 
-    IDL_Field(CHAKRA_PTR) libAddr;
-    IDL_Field(CHAKRA_PTR) protoAddr;
+    IDL_Field(CHAKRA_WB_PTR) libAddr;
+    IDL_Field(CHAKRA_WB_PTR) protoAddr;
     IDL_Field(CHAKRA_PTR) entrypointAddr;
-    IDL_Field(CHAKRA_PTR) propertyCacheAddr;
-    IDL_Field(CHAKRA_PTR) addr;
+    IDL_Field(CHAKRA_WB_PTR) propertyCacheAddr;
+    IDL_Field(CHAKRA_WB_PTR) addr;
 
     IDL_Field(TypeHandlerIDL) handler;
 } TypeIDL;
@@ -654,7 +667,7 @@ typedef struct PolymorphicInlineCacheInfoIDL
     IDL_DEF([size_is(polymorphicInlineCacheCount)]) IDL_Field(byte *) polymorphicCacheUtilizationArray;
     IDL_DEF([size_is(polymorphicInlineCacheCount)]) IDL_Field(PolymorphicInlineCacheIDL *) polymorphicInlineCaches;
 
-    IDL_Field(CHAKRA_PTR) functionBodyAddr;
+    IDL_Field(CHAKRA_WB_PTR) functionBodyAddr;
 } PolymorphicInlineCacheInfoIDL;
 
 // CodeGenWorkItem fields, read only in JIT
@@ -831,3 +844,5 @@ typedef struct InterpreterThunkInfoIDL
     CHAKRA_PTR epilogEndAddr;
     CHAKRA_PTR thunkBlockAddr;
 } InterpreterThunkInfoIDL;
+
+#endif //__JITTypes_h__

--- a/lib/JITServer/JITServerPch.h
+++ b/lib/JITServer/JITServerPch.h
@@ -7,6 +7,7 @@
 
 #include "Common.h"
 
+#include "../JITIDL/JITTypes.h"
 #include "ChakraJIT.h"
 
 #include "Runtime.h"

--- a/lib/Jsrt/Jsrt.cpp
+++ b/lib/Jsrt/Jsrt.cpp
@@ -3235,7 +3235,7 @@ JsErrorCode RunSerializedScriptCore(
 
         SourceContextInfo *sourceContextInfo;
         SRCINFO *hsi;
-        Js::FunctionBody *functionBody = nullptr;
+        Field(Js::FunctionBody*) functionBody = nullptr;
 
         HRESULT hr;
 

--- a/lib/Parser/RegexCompileTime.cpp
+++ b/lib/Parser/RegexCompileTime.cpp
@@ -4448,7 +4448,7 @@ namespace UnifiedRegex
 #if ENABLE_REGEX_CONFIG_OPTIONS
         if (w != 0)
         {
-            w->PrintEOL(_u("REGEX AST /%s/ {"), program->source);
+            w->PrintEOL(_u("REGEX AST /%s/ {"), PointerValue(program->source));
             w->Indent();
             root->Print(w, litbuf);
             w->Unindent();
@@ -4560,7 +4560,7 @@ namespace UnifiedRegex
 #if ENABLE_REGEX_CONFIG_OPTIONS
                     if (w != 0)
                     {
-                        w->PrintEOL(_u("REGEX ANNOTATED AST /%s/ {"), program->source);
+                        w->PrintEOL(_u("REGEX ANNOTATED AST /%s/ {"), PointerValue(program->source));
                         w->Indent();
                         root->Print(w, program->rep.insts.litbuf);
                         w->Unindent();
@@ -4633,7 +4633,7 @@ namespace UnifiedRegex
 #if ENABLE_REGEX_CONFIG_OPTIONS
         if (w != 0)
         {
-            w->PrintEOL(_u("REGEX PROGRAM /%s/ "), program->source);
+            w->PrintEOL(_u("REGEX PROGRAM /%s/ "), PointerValue(program->source));
             program->Print(w);
             w->Flush();
         }

--- a/lib/Parser/RegexRuntime.cpp
+++ b/lib/Parser/RegexRuntime.cpp
@@ -5193,7 +5193,7 @@ namespace UnifiedRegex
         const bool isBaselineMode = Js::Configuration::Global.flags.BaselineMode;
         w->PrintEOL(_u("Program {"));
         w->Indent();
-        w->PrintEOL(_u("source:       %s"), source);
+        w->PrintEOL(_u("source:       %s"), PointerValue(source));
         w->Print(_u("flags:        "));
         if ((flags & GlobalRegexFlag) != 0) w->Print(_u("global "));
         if ((flags & MultilineRegexFlag) != 0) w->Print(_u("multiline "));

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -2173,11 +2173,11 @@ namespace Js
 
             if (!this->GetSourceContextInfo()->IsDynamic())
             {
-                PHASE_PRINT_TESTTRACE1(Js::DeferParsePhase, _u("TestTrace: Deferred function parsed - ID: %d; Display Name: %s; Length: %d; Nested Function Count: %d; Utf8SourceInfo: %d; Source Length: %d; Is Top Level: %s; Source Url: %s\n"), m_functionNumber, m_displayName, this->m_cchLength, this->GetNestedCount(), this->m_utf8SourceInfo->GetSourceInfoId(), this->m_utf8SourceInfo->GetCchLength(), this->GetIsTopLevel() ? _u("True") : _u("False"), this->GetSourceContextInfo()->url);
+                PHASE_PRINT_TESTTRACE1(Js::DeferParsePhase, _u("TestTrace: Deferred function parsed - ID: %d; Display Name: %s; Length: %d; Nested Function Count: %d; Utf8SourceInfo: %d; Source Length: %d; Is Top Level: %s; Source Url: %s\n"), m_functionNumber, this->GetDisplayName(), this->m_cchLength, this->GetNestedCount(), this->m_utf8SourceInfo->GetSourceInfoId(), this->m_utf8SourceInfo->GetCchLength(), this->GetIsTopLevel() ? _u("True") : _u("False"), this->GetSourceContextInfo()->url);
             }
             else
             {
-                PHASE_PRINT_TESTTRACE1(Js::DeferParsePhase, _u("TestTrace: Deferred function parsed - ID: %d; Display Name: %s; Length: %d; Nested Function Count: %d; Utf8SourceInfo: %d; Source Length: %d\n; Is Top Level: %s;"), m_functionNumber, m_displayName, this->m_cchLength, this->GetNestedCount(),  this->m_utf8SourceInfo->GetSourceInfoId(), this->m_utf8SourceInfo->GetCchLength(), this->GetIsTopLevel() ? _u("True") : _u("False"));
+                PHASE_PRINT_TESTTRACE1(Js::DeferParsePhase, _u("TestTrace: Deferred function parsed - ID: %d; Display Name: %s; Length: %d; Nested Function Count: %d; Utf8SourceInfo: %d; Source Length: %d\n; Is Top Level: %s;"), m_functionNumber, this->GetDisplayName(), this->m_cchLength, this->GetNestedCount(),  this->m_utf8SourceInfo->GetSourceInfoId(), this->m_utf8SourceInfo->GetCchLength(), this->GetIsTopLevel() ? _u("True") : _u("False"));
             }
 
             if (!this->GetIsTopLevel() &&
@@ -2444,11 +2444,11 @@ namespace Js
 
         if (!this->GetSourceContextInfo()->IsDynamic())
         {
-            PHASE_PRINT_TESTTRACE1(Js::DeferParsePhase, _u("TestTrace: Deferred function parsed - ID: %d; Display Name: %s; Length: %d; Nested Function Count: %d; Utf8SourceInfo: %d; Source Length: %d; Is Top Level: %s; Source Url: %s\n"), m_functionNumber, m_displayName, this->m_cchLength, this->GetNestedCount(), this->m_utf8SourceInfo->GetSourceInfoId(), this->m_utf8SourceInfo->GetCchLength(), this->GetIsTopLevel() ? _u("True") : _u("False"), this->GetSourceContextInfo()->url);
+            PHASE_PRINT_TESTTRACE1(Js::DeferParsePhase, _u("TestTrace: Deferred function parsed - ID: %d; Display Name: %s; Length: %d; Nested Function Count: %d; Utf8SourceInfo: %d; Source Length: %d; Is Top Level: %s; Source Url: %s\n"), m_functionNumber, this->GetDisplayName(), this->m_cchLength, this->GetNestedCount(), this->m_utf8SourceInfo->GetSourceInfoId(), this->m_utf8SourceInfo->GetCchLength(), this->GetIsTopLevel() ? _u("True") : _u("False"), this->GetSourceContextInfo()->url);
         }
         else
         {
-            PHASE_PRINT_TESTTRACE1(Js::DeferParsePhase, _u("TestTrace: Deferred function parsed - ID: %d; Display Name: %s; Length: %d; Nested Function Count: %d; Utf8SourceInfo: %d; Source Length: %d\n; Is Top Level: %s;"), m_functionNumber, m_displayName, this->m_cchLength, this->GetNestedCount(), this->m_utf8SourceInfo->GetSourceInfoId(), this->m_utf8SourceInfo->GetCchLength(), this->GetIsTopLevel() ? _u("True") : _u("False"));
+            PHASE_PRINT_TESTTRACE1(Js::DeferParsePhase, _u("TestTrace: Deferred function parsed - ID: %d; Display Name: %s; Length: %d; Nested Function Count: %d; Utf8SourceInfo: %d; Source Length: %d\n; Is Top Level: %s;"), m_functionNumber, this->GetDisplayName(), this->m_cchLength, this->GetNestedCount(), this->m_utf8SourceInfo->GetSourceInfoId(), this->m_utf8SourceInfo->GetCchLength(), this->GetIsTopLevel() ? _u("True") : _u("False"));
         }
 
 #if ENABLE_PROFILE_INFO
@@ -5409,7 +5409,7 @@ namespace Js
     {
         int indent = (GetScopeDepth() - 1) * 4;
 
-        Output::Print(indent, _u("Begin scope: Address: %p Type: %s Location: %d Sibling: %p Range: [%d, %d]\n "), this, GetDebuggerScopeTypeString(scopeType), scopeLocation, this->siblingScope, range.begin, range.end);
+        Output::Print(indent, _u("Begin scope: Address: %p Type: %s Location: %d Sibling: %p Range: [%d, %d]\n "), this, GetDebuggerScopeTypeString(scopeType), scopeLocation, PointerValue(this->siblingScope), range.begin, range.end);
         if (this->HasProperties())
         {
             this->scopeProperties->Map( [=] (int i, Js::DebuggerScopeProperty& scopeProperty) {
@@ -8489,7 +8489,7 @@ namespace Js
             // The original heap allocated array will be freed at the end of NativeCodeGenerator::CheckCodeGenDone
             void** jitPinnedTypeRefs = this->jitTransferData->GetRuntimeTypeRefs();
             size_t jitPinnedTypeRefCount = this->jitTransferData->GetRuntimeTypeRefCount();
-            this->runtimeTypeRefs = RecyclerNewArray(recycler, void*, jitPinnedTypeRefCount + 1);
+            this->runtimeTypeRefs = RecyclerNewArray(recycler, Field(void*), jitPinnedTypeRefCount + 1);
             //js_memcpy_s(this->runtimeTypeRefs, jitPinnedTypeRefCount * sizeof(void*), jitPinnedTypeRefs, jitPinnedTypeRefCount * sizeof(void*));
             for (size_t i = 0; i < jitPinnedTypeRefCount; i++)
             {
@@ -8614,7 +8614,7 @@ namespace Js
         if (jitTransferData->typeGuardTransferData.entries != nullptr)
         {
             this->propertyGuardCount = jitTransferData->typeGuardTransferData.propertyGuardCount;
-            this->propertyGuardWeakRefs = RecyclerNewArrayZ(scriptContext->GetRecycler(), FakePropertyGuardWeakReference*, this->propertyGuardCount);
+            this->propertyGuardWeakRefs = RecyclerNewArrayZ(scriptContext->GetRecycler(), Field(FakePropertyGuardWeakReference*), this->propertyGuardCount);
             ThreadContext* threadContext = scriptContext->GetThreadContext();
             auto next = &jitTransferData->typeGuardTransferData.entries;
             while (*next)
@@ -8664,7 +8664,7 @@ namespace Js
         if (this->jitTransferData->propertyGuardsByPropertyId != nullptr)
         {
             this->propertyGuardCount = this->jitTransferData->propertyGuardCount;
-            this->propertyGuardWeakRefs = RecyclerNewArrayZ(scriptContext->GetRecycler(), FakePropertyGuardWeakReference*, this->propertyGuardCount);
+            this->propertyGuardWeakRefs = RecyclerNewArrayZ(scriptContext->GetRecycler(), Field(FakePropertyGuardWeakReference*), this->propertyGuardCount);
 
             ThreadContext* threadContext = scriptContext->GetThreadContext();
 
@@ -9044,7 +9044,7 @@ namespace Js
                 else
                 {
                     HeapDeletePlus(offsetof(PinnedTypeRefsIDL, typeRefs) + sizeof(void*)*jitTransferData->runtimeTypeRefs->count - sizeof(PinnedTypeRefsIDL),
-                        jitTransferData->runtimeTypeRefs);
+                        PointerValue(jitTransferData->runtimeTypeRefs));
                 }
                 jitTransferData->runtimeTypeRefs = nullptr;
             }

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -452,7 +452,7 @@ namespace Js
         private:
             Field(TypeRefSet*) jitTimeTypeRefs;
 
-            FieldNoBarrier(PinnedTypeRefsIDL*) runtimeTypeRefs;
+            Field(PinnedTypeRefsIDL*) runtimeTypeRefs;
 
 
             Field(int) propertyGuardCount;
@@ -551,7 +551,7 @@ namespace Js
         // from the thread context, we would AV trying to access freed memory. Note that the guards themselves are allocated by
         // NativeCodeData::Allocator and are kept alive by the data field. The weak references are recycler allocated, and so
         // the array must be recycler allocated also, so that the recycler doesn't collect the weak references.
-        Field(FakePropertyGuardWeakReference**) propertyGuardWeakRefs;
+        Field(Field(FakePropertyGuardWeakReference*)*) propertyGuardWeakRefs;
         Field(EquivalentTypeCache*) equivalentTypeCaches;
         Field(EntryPointInfo **) registeredEquivalentTypeCacheRef;
 
@@ -572,7 +572,7 @@ namespace Js
         Field(JitTransferData*) jitTransferData;
 
         // If we pin types this array contains strong references to types, otherwise it holds weak references.
-        Field(void **) runtimeTypeRefs;
+        Field(Field(void*)*) runtimeTypeRefs;
      protected:
 #if PDATA_ENABLED
         Field(XDataAllocation *) xdataInfo;
@@ -3690,7 +3690,7 @@ namespace Js
         static uint const ScopeMetadataSlotIndex = 1;    // Either a FunctionBody* or DebuggerScope*
         static uint const FirstSlotIndex = 2;
     public:
-        ScopeSlots(Var* slotArray) : slotArray(slotArray)
+        ScopeSlots(Var* slotArray) : slotArray((Field(Var)*)slotArray)
         {
         }
 
@@ -3702,13 +3702,13 @@ namespace Js
         FunctionBody* GetFunctionBody()
         {
             Assert(IsFunctionScopeSlotArray());
-            return (FunctionBody*)(slotArray[ScopeMetadataSlotIndex]);
+            return (FunctionBody*)PointerValue(slotArray[ScopeMetadataSlotIndex]);
         }
 
         DebuggerScope* GetDebuggerScope()
         {
             Assert(!IsFunctionScopeSlotArray());
-            return (DebuggerScope*)(slotArray[ScopeMetadataSlotIndex]);
+            return (DebuggerScope*)PointerValue(slotArray[ScopeMetadataSlotIndex]);
         }
 
         Var GetScopeMetadataRaw() const
@@ -3769,7 +3769,7 @@ namespace Js
         }
 
     private:
-        Var* slotArray;
+        Field(Field(Var)*) slotArray;
     };
 
 

--- a/lib/Runtime/Base/FunctionInfo.h
+++ b/lib/Runtime/Base/FunctionInfo.h
@@ -135,7 +135,7 @@ namespace Js
         FieldNoBarrier(JavascriptMethod) originalEntryPoint;
         // WriteBarrier-TODO: Fix this? This is used only by proxies to keep the deserialized version around
         // However, proxies are not allocated as write barrier memory currently so its fine to not set the write barrier for this field
-        Field(FunctionProxy *) functionBodyImpl;     // Implementation of the function- null if the function doesn't have a body
+        FieldWithBarrier(FunctionProxy *) functionBodyImpl;     // Implementation of the function- null if the function doesn't have a body
         Field(LocalFunctionId) functionId;        // Per host source context (source file) function Id
         Field(uint) compileCount;
         Field(Attributes) attributes;

--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -57,6 +57,43 @@ public:
         SRCINFO* copySrcInfo = RecyclerNew(recycler, SRCINFO, *srcInfo);
         return copySrcInfo;
     }
+
+    SRCINFO()
+    {
+    }
+    SRCINFO(const SRCINFO& other)
+        :sourceContextInfo(other.sourceContextInfo),
+        dlnHost(other.dlnHost),
+        ulColumnHost(other.ulColumnHost),
+        lnMinHost(other.lnMinHost),
+        ichMinHost(other.ichMinHost),
+        ichLimHost(other.ichLimHost),
+        ulCharOffset(other.ulCharOffset),
+        moduleID(other.moduleID),
+        grfsi(other.grfsi)
+    {
+    }
+    SRCINFO(
+        SourceContextInfo*sourceContextInfo,
+        ULONG dlnHost,
+        ULONG ulColumnHost,
+        ULONG lnMinHost,
+        ULONG ichMinHost,
+        ULONG ichLimHost,
+        ULONG ulCharOffset,
+        Js::ModuleID moduleID,
+        ULONG grfsi
+    ):sourceContextInfo(sourceContextInfo),
+        dlnHost(dlnHost),
+        ulColumnHost(ulColumnHost),
+        lnMinHost(lnMinHost),
+        ichMinHost(ichMinHost),
+        ichLimHost(ichLimHost),
+        ulCharOffset(ulCharOffset),
+        moduleID(moduleID),
+        grfsi(grfsi)
+    {
+    }
 };
 
 struct CustomExternalObjectOperations

--- a/lib/Runtime/ByteCode/ByteCodeSerializer.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeSerializer.cpp
@@ -3842,7 +3842,7 @@ public:
     }
 
     // Read the top function body.
-    HRESULT ReadTopFunctionBody(FunctionBody** function, Utf8SourceInfo* sourceInfo, ByteCodeCache * cache, bool allowDefer, NativeModule *nativeModule)
+    HRESULT ReadTopFunctionBody(Field(FunctionBody*)* function, Utf8SourceInfo* sourceInfo, ByteCodeCache * cache, bool allowDefer, NativeModule *nativeModule)
     {
         auto topFunction = ReadInt32(functions, &functionCount);
         firstFunctionId = sourceInfo->GetSrcInfo()->sourceContextInfo->nextLocalFunctionId;
@@ -4126,17 +4126,17 @@ HRESULT ByteCodeSerializer::SerializeToBuffer(ScriptContext * scriptContext, Are
     return hr;
 }
 
-HRESULT ByteCodeSerializer::DeserializeFromBuffer(ScriptContext * scriptContext, uint32 scriptFlags, LPCUTF8 utf8Source, SRCINFO const * srcInfo, byte * buffer, NativeModule *nativeModule, FunctionBody** function, uint sourceIndex)
+HRESULT ByteCodeSerializer::DeserializeFromBuffer(ScriptContext * scriptContext, uint32 scriptFlags, LPCUTF8 utf8Source, SRCINFO const * srcInfo, byte * buffer, NativeModule *nativeModule, Field(FunctionBody*)* function, uint sourceIndex)
 {
     return ByteCodeSerializer::DeserializeFromBufferInternal(scriptContext, scriptFlags, utf8Source, /* sourceHolder */ nullptr, srcInfo, buffer, nativeModule, function, sourceIndex);
 }
 // Deserialize function body from supplied buffer
-HRESULT ByteCodeSerializer::DeserializeFromBuffer(ScriptContext * scriptContext, uint32 scriptFlags, ISourceHolder* sourceHolder, SRCINFO const * srcInfo, byte * buffer, NativeModule *nativeModule, FunctionBody** function, uint sourceIndex)
+HRESULT ByteCodeSerializer::DeserializeFromBuffer(ScriptContext * scriptContext, uint32 scriptFlags, ISourceHolder* sourceHolder, SRCINFO const * srcInfo, byte * buffer, NativeModule *nativeModule, Field(FunctionBody*)* function, uint sourceIndex)
 {
     AssertMsg(sourceHolder != nullptr, "SourceHolder can't be null, if you have an empty source then pass ISourceHolder::GetEmptySourceHolder()");
     return ByteCodeSerializer::DeserializeFromBufferInternal(scriptContext, scriptFlags, /* utf8Source */ nullptr, sourceHolder, srcInfo, buffer, nativeModule, function, sourceIndex);
 }
-HRESULT ByteCodeSerializer::DeserializeFromBufferInternal(ScriptContext * scriptContext, uint32 scriptFlags, LPCUTF8 utf8Source, ISourceHolder* sourceHolder, SRCINFO const * srcInfo, byte * buffer, NativeModule *nativeModule, FunctionBody** function, uint sourceIndex)
+HRESULT ByteCodeSerializer::DeserializeFromBufferInternal(ScriptContext * scriptContext, uint32 scriptFlags, LPCUTF8 utf8Source, ISourceHolder* sourceHolder, SRCINFO const * srcInfo, byte * buffer, NativeModule *nativeModule, Field(FunctionBody*)* function, uint sourceIndex)
 {
     //ETW Event start
     JS_ETW(EventWriteJSCRIPT_BYTECODEDESERIALIZE_START(scriptContext, 0));

--- a/lib/Runtime/ByteCode/ByteCodeSerializer.h
+++ b/lib/Runtime/ByteCode/ByteCodeSerializer.h
@@ -157,8 +157,8 @@ namespace Js
         static HRESULT SerializeToBuffer(ScriptContext * scriptContext, ArenaAllocator * alloc, DWORD sourceCodeLength, LPCUTF8 utf8Source, FunctionBody * function, SRCINFO const* srcInfo, bool allocateBuffer, byte ** buffer, DWORD * bufferBytes, DWORD dwFlags = 0);
 
         // Deserialize a function body. The content of utf8Source must be the same as was originally passed to SerializeToBuffer
-        static HRESULT DeserializeFromBuffer(ScriptContext * scriptContext, uint32 scriptFlags, LPCUTF8 utf8Source, SRCINFO const * srcInfo, byte * buffer, NativeModule *nativeModule, FunctionBody** function, uint sourceIndex = Js::Constants::InvalidSourceIndex);
-        static HRESULT DeserializeFromBuffer(ScriptContext * scriptContext, uint32 scriptFlags, ISourceHolder* sourceHolder, SRCINFO const * srcInfo, byte * buffer, NativeModule *nativeModule, FunctionBody** function, uint sourceIndex = Js::Constants::InvalidSourceIndex);
+        static HRESULT DeserializeFromBuffer(ScriptContext * scriptContext, uint32 scriptFlags, LPCUTF8 utf8Source, SRCINFO const * srcInfo, byte * buffer, NativeModule *nativeModule, Field(FunctionBody*)* function, uint sourceIndex = Js::Constants::InvalidSourceIndex);
+        static HRESULT DeserializeFromBuffer(ScriptContext * scriptContext, uint32 scriptFlags, ISourceHolder* sourceHolder, SRCINFO const * srcInfo, byte * buffer, NativeModule *nativeModule, Field(FunctionBody*)* function, uint sourceIndex = Js::Constants::InvalidSourceIndex);
 
         static FunctionBody* DeserializeFunction(ScriptContext* scriptContext, DeferDeserializeFunctionInfo* deferredFunction);
 
@@ -169,6 +169,6 @@ namespace Js
         static void ReadSourceInfo(const DeferDeserializeFunctionInfo* deferredFunction, int& lineNumber, int& columnNumber, bool& m_isEval, bool& m_isDynamicFunction);
 
     private:
-        static HRESULT DeserializeFromBufferInternal(ScriptContext * scriptContext, uint32 scriptFlags, LPCUTF8 utf8Source, ISourceHolder* sourceHolder, SRCINFO const * srcInfo, byte * buffer, NativeModule *nativeModule, FunctionBody** function, uint sourceIndex = Js::Constants::InvalidSourceIndex);
+        static HRESULT DeserializeFromBufferInternal(ScriptContext * scriptContext, uint32 scriptFlags, LPCUTF8 utf8Source, ISourceHolder* sourceHolder, SRCINFO const * srcInfo, byte * buffer, NativeModule *nativeModule, Field(FunctionBody*)* function, uint sourceIndex = Js::Constants::InvalidSourceIndex);
     };
 }

--- a/lib/Runtime/Language/Arguments.h
+++ b/lib/Runtime/Language/Arguments.h
@@ -117,6 +117,8 @@ namespace Js
 
         Arguments(VirtualTableInfoCtorEnum v) : Info(v) {}
 
+        Arguments(const Arguments& other) : Info(other.Info), Values(other.Values) {}
+
         Var operator [](int idxArg) { return const_cast<Var>(static_cast<const Arguments&>(*this)[idxArg]); }
         const Var operator [](int idxArg) const
         {

--- a/lib/Runtime/Language/DynamicProfileInfo.cpp
+++ b/lib/Runtime/Language/DynamicProfileInfo.cpp
@@ -111,7 +111,7 @@ namespace Js
         {
             if (batch[i].size > 0)
             {
-                BYTE** field = (BYTE**)(((BYTE*)info + batch[i].offset));
+                Field(BYTE*)* field = (Field(BYTE*)*)(((BYTE*)info + batch[i].offset));
                 *field = current;
                 current += batch[i].size;
             }

--- a/lib/Runtime/Language/FunctionCodeGenJitTimeData.h
+++ b/lib/Runtime/Language/FunctionCodeGenJitTimeData.h
@@ -38,7 +38,7 @@ namespace Js
         Field(PolymorphicInlineCacheIDL*) polymorphicInlineCaches;
 
         // current value of global this object, may be changed in case of script engine invalidation
-        FieldNoBarrier(Var) globalThisObject;
+        Field(Var) globalThisObject;
 
         // Number of functions that are to be inlined (this is not the length of the 'inlinees' array above, includes getter setter inlinee count)
         Field(uint) inlineeCount;

--- a/lib/Runtime/Language/InlineCachePointerArray.h
+++ b/lib/Runtime/Language/InlineCachePointerArray.h
@@ -10,7 +10,7 @@ namespace Js
     class InlineCachePointerArray
     {
     public:
-        WriteBarrierPtr<T*> inlineCaches;
+        FieldWithBarrier(Field(T*)*) inlineCaches;
     private:
 #if DBG
         Field(uint) inlineCacheCount;

--- a/lib/Runtime/Language/InlineCachePointerArray.inl
+++ b/lib/Runtime/Language/InlineCachePointerArray.inl
@@ -26,7 +26,7 @@ namespace Js
             return;
         }
 
-        inlineCaches = RecyclerNewArrayZ(recycler, T *, functionBody->GetInlineCacheCount());
+        inlineCaches = RecyclerNewArrayZ(recycler, Field(T*), functionBody->GetInlineCacheCount());
 #if DBG
         inlineCacheCount = functionBody->GetInlineCacheCount();
 #endif

--- a/lib/Runtime/Language/JavascriptExceptionContext.h
+++ b/lib/Runtime/Language/JavascriptExceptionContext.h
@@ -14,17 +14,27 @@ namespace Js {
         private:
             // Real script frames: functionBody, byteCodeOffset
             // Native library builtin (or potentially virtual) frames: name
-            FunctionBody* functionBody;
+            Field(FunctionBody*) functionBody;
             union
             {
-                uint32 byteCodeOffset;  // used for script functions        (functionBody != nullptr)
-                PCWSTR name;            // used for native/virtual frames   (functionBody == nullptr)
+                Field(uint32) byteCodeOffset;  // used for script functions        (functionBody != nullptr)
+                Field(PCWSTR) name;            // used for native/virtual frames   (functionBody == nullptr)
             };
-            StackTraceArguments argumentTypes;
+            Field(StackTraceArguments) argumentTypes;
 
         public:
             StackFrame() {}
             StackFrame(JavascriptFunction* func, const JavascriptStackWalker& walker, bool initArgumentTypes);
+            StackFrame(const StackFrame& other)
+                :functionBody(other.functionBody), name(other.name), argumentTypes(other.argumentTypes)
+            {}
+            StackFrame& operator=(const StackFrame& other)
+            {
+                functionBody = other.functionBody;
+                name = other.name;
+                argumentTypes = other.argumentTypes;
+                return *this;
+            }
 
             bool IsScriptFunction() const;
             FunctionBody* GetFunctionBody() const;

--- a/lib/Runtime/Language/JavascriptExceptionObject.cpp
+++ b/lib/Runtime/Language/JavascriptExceptionObject.cpp
@@ -173,7 +173,7 @@ namespace Js
     LPCWSTR JavascriptExceptionContext::StackFrame::GetFunctionName() const
     {
         return IsScriptFunction() ?
-            GetFunctionBody()->GetExternalDisplayName() : this->name;
+            GetFunctionBody()->GetExternalDisplayName() : PointerValue(this->name);
     }
 
     // Get function name with arguments info. Used by script WER.

--- a/lib/Runtime/Language/JavascriptExceptionOperators.cpp
+++ b/lib/Runtime/Language/JavascriptExceptionOperators.cpp
@@ -764,7 +764,7 @@ namespace Js
         JavascriptExceptionContext::StackTrace *stackTrace = exceptionContext.GetStackTrace();
         for (int i=0; i < stackTrace->Count(); i++)
         {
-            Js::JavascriptExceptionContext::StackFrame currFrame = stackTrace->Item(i);
+            Js::JavascriptExceptionContext::StackFrame& currFrame = stackTrace->Item(i);
             ULONG lineNumber = 0;
             LONG characterPosition = 0;
             if (currFrame.IsScriptFunction() && !currFrame.GetFunctionBody()->GetUtf8SourceInfo()->GetIsLibraryCode())
@@ -1119,7 +1119,7 @@ namespace Js
 
             for (int i = 0; i < stackTrace->Count(); i++)
             {
-                Js::JavascriptExceptionContext::StackFrame currentFrame = stackTrace->Item(i);
+                Js::JavascriptExceptionContext::StackFrame& currentFrame = stackTrace->Item(i);
 
                 // Defend in depth. Discard cross domain frames if somehow they creped in.
                 if (currentFrame.IsScriptFunction())

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -8444,7 +8444,7 @@ CommonNumber:
         GetPropertyIdForInt(static_cast<uint64>(value), scriptContext, propertyRecord);
     }
 
-    Var JavascriptOperators::FromPropertyDescriptor(PropertyDescriptor descriptor, ScriptContext* scriptContext)
+    Var JavascriptOperators::FromPropertyDescriptor(const PropertyDescriptor& descriptor, ScriptContext* scriptContext)
     {
         DynamicObject* object = scriptContext->GetLibrary()->CreateObject();
 
@@ -8848,7 +8848,7 @@ CommonNumber:
         return DefineOwnPropertyDescriptor(arr, propId, descriptor, throwOnError, scriptContext);
     }
 
-    BOOL JavascriptOperators::SetPropertyDescriptor(RecyclableObject* object, PropertyId propId, PropertyDescriptor descriptor)
+    BOOL JavascriptOperators::SetPropertyDescriptor(RecyclableObject* object, PropertyId propId, const PropertyDescriptor& descriptor)
     {
         if (descriptor.ValueSpecified())
         {

--- a/lib/Runtime/Language/JavascriptOperators.h
+++ b/lib/Runtime/Language/JavascriptOperators.h
@@ -524,9 +524,9 @@ namespace Js
         static BOOL ToPropertyDescriptor(Var propertySpec, PropertyDescriptor* descriptor, ScriptContext* scriptContext);
 
 
-        static Var FromPropertyDescriptor(PropertyDescriptor descriptor, ScriptContext* scriptContext);
+        static Var FromPropertyDescriptor(const PropertyDescriptor& descriptor, ScriptContext* scriptContext);
         static void CompletePropertyDescriptor(PropertyDescriptor* resultDescriptor, PropertyDescriptor* likePropertyDescriptor, ScriptContext* requestContext);
-        static BOOL SetPropertyDescriptor(RecyclableObject* object, PropertyId propId, PropertyDescriptor descriptor);
+        static BOOL SetPropertyDescriptor(RecyclableObject* object, PropertyId propId, const PropertyDescriptor& descriptor);
         static BOOL DefineOwnPropertyDescriptor(RecyclableObject* object, PropertyId propId, const PropertyDescriptor& descriptor, bool throwOnError, ScriptContext* scriptContext);
         static BOOL DefineOwnPropertyForArray(JavascriptArray* arr, PropertyId propId, const PropertyDescriptor& descriptor, bool throwOnError, ScriptContext* scriptContext);
 

--- a/lib/Runtime/Language/ModuleRecordBase.h
+++ b/lib/Runtime/Language/ModuleRecordBase.h
@@ -12,6 +12,13 @@ namespace Js
     typedef SList<ModuleRecordBase*> ExportModuleRecordList;
     struct ModuleNameRecord
     {
+        ModuleNameRecord(const ModuleNameRecord& other)
+            :module(other.module), bindingName(other.bindingName)
+        {}
+        ModuleNameRecord(ModuleRecordBase* module, PropertyId bindingName) 
+            :module(module), bindingName(bindingName) 
+        {}
+        ModuleNameRecord() {}
         Field(ModuleRecordBase*) module;
         Field(PropertyId) bindingName;
     };

--- a/lib/Runtime/Language/SourceTextModuleRecord.cpp
+++ b/lib/Runtime/Language/SourceTextModuleRecord.cpp
@@ -419,7 +419,7 @@ namespace Js
             Assert(*exportRecord == nullptr);
             return true;
         }
-        resolveSet->Prepend({ this, exportName });
+        resolveSet->Prepend(ModuleNameRecord(this, exportName));
 
         if (localExportRecordList != nullptr)
         {

--- a/lib/Runtime/Library/EngineInterfaceObject.h
+++ b/lib/Runtime/Library/EngineInterfaceObject.h
@@ -34,8 +34,8 @@ namespace Js
 #endif
 
     protected:
-        EngineInterfaceExtensionKind extensionKind;
-        ScriptContext* scriptContext;
+        Field(EngineInterfaceExtensionKind) extensionKind;
+        Field(ScriptContext*) scriptContext;
     };
 
 #define EngineInterfaceObject_CommonFunctionProlog(function, callInfo) \
@@ -52,9 +52,9 @@ namespace Js
         DEFINE_VTABLE_CTOR(EngineInterfaceObject, DynamicObject);
         DEFINE_MARSHAL_OBJECT_TO_SCRIPT_CONTEXT(EngineInterfaceObject);
 
-        DynamicObject* commonNativeInterfaces;
+        Field(DynamicObject*) commonNativeInterfaces;
 
-        EngineExtensionObjectBase* engineExtensions[MaxEngineInterfaceExtensionKind + 1];
+        Field(EngineExtensionObjectBase*) engineExtensions[MaxEngineInterfaceExtensionKind + 1];
 
     public:
         EngineInterfaceObject(DynamicType * type) : DynamicObject(type) {}

--- a/lib/Runtime/Library/IntlEngineInterfaceExtensionObject.h
+++ b/lib/Runtime/Library/IntlEngineInterfaceExtensionObject.h
@@ -95,16 +95,16 @@ namespace Js
         static Var EntryIntl_BuiltIn_CallInstanceFunction(RecyclableObject *function, CallInfo callInfo, ...);
 
     private:
-        JavascriptFunction* dateToLocaleString;
-        JavascriptFunction* dateToLocaleTimeString;
-        JavascriptFunction* dateToLocaleDateString;
-        JavascriptFunction* numberToLocaleString;
-        JavascriptFunction* stringLocaleCompare;
+        Field(JavascriptFunction*) dateToLocaleTimeString;
+        Field(JavascriptFunction*) dateToLocaleDateString;
+        Field(JavascriptFunction*) numberToLocaleString;
+        Field(JavascriptFunction*) stringLocaleCompare;
+        Field(JavascriptFunction*) dateToLocaleString;
 
-        DynamicObject* intlNativeInterfaces;
-        FunctionBody* intlByteCode;
+        Field(DynamicObject*) intlNativeInterfaces;
+        Field(FunctionBody*) intlByteCode;
 
-        bool wasInitialized;
+        Field(bool) wasInitialized;
         void EnsureIntlByteCode(_In_ ScriptContext * scriptContext);
         static void deletePrototypePropertyHelper(ScriptContext* scriptContext, DynamicObject* intlObject, Js::PropertyId objectPropertyId, Js::PropertyId getterFunctionId);
         static WindowsGlobalizationAdapter* GetWindowsGlobalizationAdapter(_In_ ScriptContext*);

--- a/lib/Runtime/Library/JavascriptFunction.cpp
+++ b/lib/Runtime/Library/JavascriptFunction.cpp
@@ -3006,7 +3006,7 @@ LABEL1:
 
             char16 debugStringBuffer[MAX_FUNCTION_BODY_DEBUG_STRING_SIZE];
 
-            Output::Print(_u("CtorCache: before invalidating cache (0x%p) for ctor %s (%s): "), this->constructorCache, ctorName,
+            Output::Print(_u("CtorCache: before invalidating cache (0x%p) for ctor %s (%s): "), PointerValue(this->constructorCache), ctorName,
                 body ? body->GetDebugNumberSet(debugStringBuffer) : _u("(null)"));
             this->constructorCache->Dump();
             Output::Print(_u("\n"));
@@ -3024,7 +3024,7 @@ LABEL1:
             const char16* ctorName = body != nullptr ? body->GetDisplayName() : _u("<unknown>");
             char16 debugStringBuffer[MAX_FUNCTION_BODY_DEBUG_STRING_SIZE];
 
-            Output::Print(_u("CtorCache: after invalidating cache (0x%p) for ctor %s (%s): "), this->constructorCache, ctorName,
+            Output::Print(_u("CtorCache: after invalidating cache (0x%p) for ctor %s (%s): "), PointerValue(this->constructorCache), ctorName,
                 body ? body->GetDebugNumberSet(debugStringBuffer) : _u("(null)"));
             this->constructorCache->Dump();
             Output::Print(_u("\n"));

--- a/lib/Runtime/Library/JavascriptLibrary.h
+++ b/lib/Runtime/Library/JavascriptLibrary.h
@@ -388,7 +388,7 @@ namespace Js
         Field(JavascriptFunction*) objectToStringFunction;
 
 #ifdef ENABLE_WASM
-        DynamicObject* webAssemblyObject;
+        Field(DynamicObject*) webAssemblyObject;
 #endif
 
         // SIMD_JS

--- a/lib/Runtime/Library/JavascriptLibraryBase.h
+++ b/lib/Runtime/Library/JavascriptLibraryBase.h
@@ -186,10 +186,10 @@ namespace Js
         Field(DynamicObject*) debugObject;
         Field(DynamicObject*) JSONObject;
 #ifdef ENABLE_INTL_OBJECT
-        DynamicObject* IntlObject;
+        Field(DynamicObject*) IntlObject;
 #endif
 #if defined(ENABLE_INTL_OBJECT) || defined(ENABLE_PROJECTION)
-        EngineInterfaceObject* engineInterfaceObject;
+        Field(EngineInterfaceObject*) engineInterfaceObject;
 #endif
         Field(DynamicObject*) reflectObject;
 

--- a/lib/Runtime/Library/JavascriptProxy.h
+++ b/lib/Runtime/Library/JavascriptProxy.h
@@ -111,7 +111,7 @@ namespace Js
         virtual BOOL IsEnumerable(PropertyId propertyId) override;
         virtual BOOL IsExtensible() override;
         virtual BOOL PreventExtensions() override;
-        virtual void ThrowIfCannotDefineProperty(PropertyId propId, PropertyDescriptor descriptor) { }
+        virtual void ThrowIfCannotDefineProperty(PropertyId propId, const PropertyDescriptor& descriptor) { }
         virtual void ThrowIfCannotGetOwnPropertyDescriptor(PropertyId propId) {};
         virtual BOOL GetDefaultPropertyDescriptor(PropertyDescriptor& descriptor) override;
         virtual BOOL Seal() override;

--- a/lib/Runtime/Runtime.h
+++ b/lib/Runtime/Runtime.h
@@ -370,12 +370,8 @@ enum tagDEBUG_EVENT_INFO_TYPE
 #define DBGPROP_ATTRIB_VALUE_PENDING_MUTATION 0x10000000
 #endif
 
-#ifdef _MSC_VER
-#include "JITClient.h"
-#else
-#include "JITTypes.h"
+#include "../JITIDL/JITTypes.h"
 #include "../JITClient/JITManager.h"
-#endif
 
 #include "Base/SourceHolder.h"
 #include "Base/Utf8SourceInfo.h"

--- a/lib/Runtime/Types/MissingPropertyTypeHandler.cpp
+++ b/lib/Runtime/Types/MissingPropertyTypeHandler.cpp
@@ -8,7 +8,7 @@ namespace Js
 {
     void MissingPropertyTypeHandler::SetUndefinedPropertySlot(DynamicObject* instance)
     {
-        Var * slots = reinterpret_cast<Var*>(reinterpret_cast<size_t>(instance) + sizeof(DynamicObject));
+        Field(Var)* slots = reinterpret_cast<Field(Var)*>(reinterpret_cast<size_t>(instance) + sizeof(DynamicObject));
         slots[0] = instance->GetLibrary()->GetUndefined();
     }
 

--- a/lib/Runtime/Types/PropertyDescriptor.h
+++ b/lib/Runtime/Types/PropertyDescriptor.h
@@ -10,12 +10,29 @@ namespace Js
     {
     public:
         PropertyDescriptor();
+        PropertyDescriptor(const PropertyDescriptor& other)
+            :Value(other.Value),
+            Getter(other.Getter),
+            Setter(other.Setter),
+            originalVar(other.originalVar),
+            writableSpecified(other.writableSpecified),
+            enumerableSpecified(other.enumerableSpecified),
+            configurableSpecified(other.configurableSpecified),
+            valueSpecified(other.valueSpecified),
+            getterSpecified(other.getterSpecified),
+            setterSpecified(other.setterSpecified),
+            Writable(other.Writable),
+            Enumerable(other.Enumerable),
+            Configurable(other.Configurable),
+            fromProxy(other.fromProxy)
+        {
+        }
 
     private:
-        Field(Var) Value;
-        Field(Var) Getter;
-        Field(Var) Setter;
-        Field(Var) originalVar;
+        Field(Var)  Value;
+        Field(Var)  Getter;
+        Field(Var)  Setter;
+        Field(Var)  originalVar;
 
         Field(bool) writableSpecified;
         Field(bool) enumerableSpecified;

--- a/lib/Runtime/Types/RecyclableObject.cpp
+++ b/lib/Runtime/Types/RecyclableObject.cpp
@@ -269,7 +269,7 @@ namespace Js
             this->SetAttributes(propertyId, attributes);
     }
 
-    void RecyclableObject::ThrowIfCannotDefineProperty(PropertyId propId, PropertyDescriptor descriptor)
+    void RecyclableObject::ThrowIfCannotDefineProperty(PropertyId propId, const PropertyDescriptor& descriptor)
     {
         // Do nothing
     }

--- a/lib/Runtime/Types/RecyclableObject.h
+++ b/lib/Runtime/Types/RecyclableObject.h
@@ -288,7 +288,7 @@ namespace Js {
         virtual BOOL IsExtensible() { return false; }
         virtual BOOL IsProtoImmutable() const { return false; }
         virtual BOOL PreventExtensions() { return false; };     // Sets [[Extensible]] flag of instance to false
-        virtual void ThrowIfCannotDefineProperty(PropertyId propId, PropertyDescriptor descriptor);
+        virtual void ThrowIfCannotDefineProperty(PropertyId propId, const PropertyDescriptor& descriptor);
         virtual void ThrowIfCannotGetOwnPropertyDescriptor(PropertyId propId) {}
         virtual BOOL GetDefaultPropertyDescriptor(PropertyDescriptor& descriptor);
         virtual BOOL Seal() { return false; }                   // Seals the instance, no additional property can be added or deleted

--- a/lib/Runtime/Types/TypePath.cpp
+++ b/lib/Runtime/Types/TypePath.cpp
@@ -112,7 +112,7 @@ namespace Js {
 #ifdef SUPPORT_FIXED_FIELDS_ON_PATH_TYPES
         if (PHASE_VERBOSE_TRACE1(FixMethodPropsPhase))
         {
-            Output::Print(_u("FixedFields: TypePath::Branch: singleton: 0x%p(0x%p)\n"), this->singletonInstance, this->singletonInstance->Get());
+            Output::Print(_u("FixedFields: TypePath::Branch: singleton: 0x%p(0x%p)\n"), PointerValue(this->singletonInstance), this->singletonInstance->Get());
             Output::Print(_u("   fixed fields:"));
 
             for (PropertyIndex i = 0; i < GetPathLength(); i++)
@@ -216,7 +216,7 @@ namespace Js {
         if (PHASE_VERBOSE_TRACE1(FixMethodPropsPhase))
         {
             Output::Print(_u("FixedFields: TypePath::AddInternal: singleton = 0x%p(0x%p)\n"),
-                this->singletonInstance, this->singletonInstance != nullptr ? this->singletonInstance->Get() : nullptr);
+                PointerValue(this->singletonInstance), this->singletonInstance != nullptr ? this->singletonInstance->Get() : nullptr);
             Output::Print(_u("   fixed fields:"));
 
             for (PropertyIndex i = 0; i < GetPathLength(); i++)
@@ -243,7 +243,7 @@ namespace Js {
         if (PHASE_VERBOSE_TRACE1(FixMethodPropsPhase))
         {
             Output::Print(_u("FixedFields: TypePath::AddBlankFieldAt: singleton = 0x%p(0x%p)\n"),
-                this->singletonInstance, this->singletonInstance != nullptr ? this->singletonInstance->Get() : nullptr);
+                PointerValue(this->singletonInstance), this->singletonInstance != nullptr ? this->singletonInstance->Get() : nullptr);
             Output::Print(_u("   fixed fields:"));
 
             for (PropertyIndex i = 0; i < GetPathLength(); i++)
@@ -285,7 +285,7 @@ namespace Js {
         if (PHASE_VERBOSE_TRACE1(FixMethodPropsPhase))
         {
             Output::Print(_u("FixedFields: TypePath::AddSingletonInstanceFieldAt: singleton = 0x%p(0x%p)\n"),
-                this->singletonInstance, this->singletonInstance != nullptr ? this->singletonInstance->Get() : nullptr);
+                PointerValue(this->singletonInstance), this->singletonInstance != nullptr ? this->singletonInstance->Get() : nullptr);
             Output::Print(_u("   fixed fields:"));
 
             for (PropertyIndex i = 0; i < GetPathLength(); i++)
@@ -314,7 +314,7 @@ namespace Js {
         if (PHASE_VERBOSE_TRACE1(FixMethodPropsPhase))
         {
             Output::Print(_u("FixedFields: TypePath::AddSingletonInstanceFieldAt: singleton = 0x%p(0x%p)\n"),
-                this->singletonInstance, this->singletonInstance != nullptr ? this->singletonInstance->Get() : nullptr);
+                PointerValue(this->singletonInstance), this->singletonInstance != nullptr ? this->singletonInstance->Get() : nullptr);
             Output::Print(_u("   fixed fields:"));
 
             for (PropertyIndex i = 0; i < GetPathLength(); i++)


### PR DESCRIPTION
record every write barrier bit set, while verifying mark, if an object is marked, verify the referencing pointer DID set the write barrier bit.
todo: support multiple recycler, clear the verification bits while destructing WriteBarrierPtr

and fix a bunch of missing write barrier found by this tool