### PR TITLE
Keep property records live on IteratorObjectEnumerator

### DIFF
--- a/lib/Runtime/Library/IteratorObjectEnumerator.cpp
+++ b/lib/Runtime/Library/IteratorObjectEnumerator.cpp
@@ -45,6 +45,11 @@ namespace Js
             {
                 JavascriptString* propertyName = JavascriptConversion::ToString(currentIndex, scriptContext);
                 GetScriptContext()->GetOrAddPropertyRecord(propertyName->GetString(), propertyName->GetLength(), &propertyRecord);
+
+                // Need to keep property records alive during enumeration to prevent collection
+                // and eventual reuse during the same enumeration. For DynamicObjects, property
+                // records are kept alive by type handlers.
+                this->propertyRecords.Prepend(iteratorObject->GetRecycler(), propertyRecord);
             }
 
             propertyId = propertyRecord->GetPropertyId();

--- a/lib/Runtime/Library/IteratorObjectEnumerator.h
+++ b/lib/Runtime/Library/IteratorObjectEnumerator.h
@@ -21,6 +21,7 @@ namespace Js
         RecyclableObject* iteratorObject;
         Var value;
         BOOL done;
+        SListBase<Js::PropertyRecord const *> propertyRecords;
     };
 
 }


### PR DESCRIPTION
We need to keep property records for properties being enumerated live during enumeration. For dynamic objects, type handlers hold references to property records and for non-existent properties, we have code in ForInObjectEnumerator::MoveAndGetNext to keep the new records live. 

Taking care of this case for Proxies which use IteratorObjectEnumerator

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/2198)
<!-- Reviewable:end -->
