### PR TITLE
swb: fixes with verification on unit tests

### DIFF
--- a/lib/Backend/JITTimeConstructorCache.cpp
+++ b/lib/Backend/JITTimeConstructorCache.cpp
@@ -11,8 +11,8 @@ JITTimeConstructorCache::JITTimeConstructorCache(const Js::JavascriptFunction* c
 {
     Assert(constructor != nullptr);
     Assert(runtimeCache != nullptr);
-    m_data.runtimeCacheAddr = (intptr_t)runtimeCache;
-    m_data.runtimeCacheGuardAddr = (intptr_t)runtimeCache->GetAddressOfGuardValue();
+    m_data.runtimeCacheAddr = runtimeCache;
+    m_data.runtimeCacheGuardAddr = const_cast<void*>(runtimeCache->GetAddressOfGuardValue());
     m_data.slotCount = runtimeCache->content.slotCount;
     m_data.inlineSlotCount = runtimeCache->content.inlineSlotCount;
     m_data.skipNewScObject = runtimeCache->content.skipDefaultNewObject;
@@ -30,8 +30,8 @@ JITTimeConstructorCache::JITTimeConstructorCache(const JITTimeConstructorCache* 
 {
     Assert(other != nullptr);
     Assert(other->GetRuntimeCacheAddr() != 0);
-    m_data.runtimeCacheAddr = other->GetRuntimeCacheAddr();
-    m_data.runtimeCacheGuardAddr = other->GetRuntimeCacheGuardAddr();
+    m_data.runtimeCacheAddr = reinterpret_cast<void*>(other->GetRuntimeCacheAddr());
+    m_data.runtimeCacheGuardAddr = reinterpret_cast<void*>(other->GetRuntimeCacheGuardAddr());
     m_data.type = *(TypeIDL*)PointerValue(other->GetType().t);
     m_data.slotCount = other->GetSlotCount();
     m_data.inlineSlotCount = other->GetInlineSlotCount();
@@ -80,13 +80,13 @@ JITTimeConstructorCache::AddGuardedPropOps(const BVSparse<JitArenaAllocator>* pr
 intptr_t
 JITTimeConstructorCache::GetRuntimeCacheAddr() const
 {
-    return m_data.runtimeCacheAddr;
+    return reinterpret_cast<intptr_t>(PointerValue(m_data.runtimeCacheAddr));
 }
 
 intptr_t
 JITTimeConstructorCache::GetRuntimeCacheGuardAddr() const
 {
-    return m_data.runtimeCacheGuardAddr;
+    return reinterpret_cast<intptr_t>(PointerValue(m_data.runtimeCacheGuardAddr));
 }
 
 JITTypeHolder

--- a/lib/Common/Common.h
+++ b/lib/Common/Common.h
@@ -101,6 +101,7 @@ template<> struct IntMath<int64> { using Type = Int64Math; };
 
 // Data Structures 2
 
+#include "DataStructures/QuickSort.h"
 #include "DataStructures/StringBuilder.h"
 #include "DataStructures/WeakReferenceDictionary.h"
 #include "DataStructures/LeafValueDictionary.h"

--- a/lib/Common/DataStructures/BaseDictionary.h
+++ b/lib/Common/DataStructures/BaseDictionary.h
@@ -182,7 +182,7 @@ namespace JsUtil
             freeCount = other.freeCount;
 
             CopyArray(buckets, bucketCount, other.buckets, bucketCount);
-            CopyArray<EntryType, Field(ValueType, TAllocator)>(
+            CopyArray<EntryType, Field(ValueType, TAllocator), TAllocator>(
                 entries, size, other.entries, size);
 
 #if PROFILE_DICTIONARY
@@ -714,7 +714,7 @@ namespace JsUtil
             freeCount = other->freeCount;
 
             CopyArray(buckets, bucketCount, other->buckets, bucketCount);
-            CopyArray<EntryType, Field(ValueType, TAllocator)>(
+            CopyArray<EntryType, Field(ValueType, TAllocator), TAllocator>(
                 entries, size, other->entries, size);
 
 #if PROFILE_DICTIONARY
@@ -1022,7 +1022,7 @@ namespace JsUtil
             {
                 // no need to rehash
                 newEntries = AllocateEntries(newSize);
-                CopyArray<EntryType, Field(ValueType, TAllocator)>(
+                CopyArray<EntryType, Field(ValueType, TAllocator), TAllocator>(
                     newEntries, newSize, entries, count);
 
                 DeleteEntries(entries, size);
@@ -1033,7 +1033,7 @@ namespace JsUtil
             }
 
             Allocate(&newBuckets, &newEntries, newBucketCount, newSize);
-            CopyArray<EntryType, Field(ValueType, TAllocator)>(
+            CopyArray<EntryType, Field(ValueType, TAllocator), TAllocator>(
                 newEntries, newSize, entries, count);
 
             // When TAllocator is of type Recycler, it is possible that the Allocate above causes a collection, which

--- a/lib/Common/DataStructures/List.h
+++ b/lib/Common/DataStructures/List.h
@@ -273,7 +273,8 @@ namespace JsUtil
 
                 Field(T, TAllocator)* newbuffer = AllocArray(newLength);
                 Field(T, TAllocator)* oldbuffer = this->buffer;
-                CopyArray(newbuffer, newLength, oldbuffer, length);
+                CopyArray<Field(T, TAllocator), Field(T, TAllocator), TAllocator>(
+                    newbuffer, newLength, oldbuffer, length);
 
                 FreeArray(oldbuffer, oldBufferSize);
 
@@ -501,7 +502,8 @@ namespace JsUtil
                 (IsSame<TRemovePolicyType, Js::CopyRemovePolicy<TListType, true> >::IsTrue));
             if (this->count)
             {
-                qsort_s(this->buffer, this->count, sizeof(T), _PtFuncCompare, _Context);
+                qsort_s<Field(T, TAllocator), Field(T, TAllocator), TAllocator>(
+                    this->buffer, this->count, _PtFuncCompare, _Context);
             }
         }
 

--- a/lib/Common/Memory/Recycler.inl
+++ b/lib/Common/Memory/Recycler.inl
@@ -99,6 +99,15 @@ Recycler::AllocWithAttributesInlined(DECLSPEC_GUARD_OVERFLOW size_t size)
         // pure LeafBit going through the else below, and use the LeafBit specialization to get the bucket
         // if there FinalizeBit, it goes through FinalizeWithBarrier bucket, whatever there's LeafBit or not
         memBlock = RealAlloc<(ObjectInfoBits)(((attributes | WithBarrierBit) & ~LeafBit) & InternalObjectInfoBitMask), nothrow>(&autoHeap, allocSize);
+#if DBG
+        // Above does not allocate in a Leaf bucket and would trigger write
+        // barrier verifyMark failure for its fields. To work around, manually
+        // set write barrier bits right now.
+        if (attributes & LeafBit)
+        {
+            Recycler::WBSetBits(memBlock, (uint)(HeapInfo::GetAlignedSizeNoCheck(allocSize) / sizeof(void*)));
+        }
+#endif
     }
     else
 #endif

--- a/lib/Common/Memory/RecyclerWriteBarrierManager.h
+++ b/lib/Common/Memory/RecyclerWriteBarrierManager.h
@@ -13,8 +13,10 @@ namespace Memory
 // Controls whether we're using a 128 byte granularity card table or a 4K granularity byte array to indicate that a range of memory is dirty
 #define RECYCLER_WRITE_BARRIER_BYTE
 
+#if GLOBAL_ENABLE_WRITE_BARRIER
 // Controls whether the JIT is software write barrier aware
 #define RECYCLER_WRITE_BARRIER_JIT
+#endif
 
 // Controls whether we can allocate SWB memory or not
 // Turning this on leaves the rest of the SWB infrastructure intact,

--- a/lib/JITIDL/JITTypes.h
+++ b/lib/JITIDL/JITTypes.h
@@ -146,8 +146,8 @@ typedef struct JITTimeConstructorCacheIDL
     X64_PAD4(1)
     IDL_Field(TypeIDL) type;
 
-    IDL_Field(CHAKRA_PTR) runtimeCacheAddr;
-    IDL_Field(CHAKRA_PTR) runtimeCacheGuardAddr;
+    IDL_Field(CHAKRA_WB_PTR) runtimeCacheAddr;
+    IDL_Field(CHAKRA_WB_PTR) runtimeCacheGuardAddr;
     IDL_Field(CHAKRA_PTR) guardedPropOps;
 } JITTimeConstructorCacheIDL;
 

--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -1418,7 +1418,7 @@ namespace Js
             int excess = this->inSlotsCount - executeFunction->GetInParamsCount();
             *dest = JavascriptArray::OP_NewScArray(excess, executeFunction->GetScriptContext());
             JavascriptArray *array = static_cast<JavascriptArray *>(*dest);
-            Field(Var)* elements = ((SparseArraySegment<Var>*)array->GetHead())->elements;
+            Field(Var)* elements = SparseArraySegment<Var>::From(array->GetHead())->elements;
             CopyArray(elements, excess, src, excess);
         }
         else

--- a/lib/Runtime/Library/JavascriptArray.cpp
+++ b/lib/Runtime/Library/JavascriptArray.cpp
@@ -6,7 +6,6 @@
 #include "RuntimeLibraryPch.h"
 #include "Types/PathTypeHandler.h"
 #include "Types/SpreadArgument.h"
-#include "DataStructures/QuickSort.h"
 
 namespace Js
 {

--- a/lib/Runtime/Types/ES5ArrayTypeHandler.cpp
+++ b/lib/Runtime/Types/ES5ArrayTypeHandler.cpp
@@ -174,8 +174,8 @@ namespace Js
 
             if (descriptor->Attributes & PropertyConfigurable)
             {
-                descriptor->Getter = NULL;
-                descriptor->Setter = NULL;
+                descriptor->Getter = nullptr;
+                descriptor->Setter = nullptr;
                 descriptor->Attributes = PropertyDeleted | PropertyWritable | PropertyConfigurable;
             }
             else
@@ -646,8 +646,8 @@ namespace Js
             }
 
             arr->DirectDeleteItemAt<Var>(index);
-            descriptor->Getter = NULL;
-            descriptor->Setter = NULL;
+            descriptor->Getter = nullptr;
+            descriptor->Setter = nullptr;
             descriptor->Attributes = PropertyDeleted | PropertyWritable | PropertyConfigurable;
             return true;
         }

--- a/lib/Runtime/Types/ES5ArrayTypeHandler.h
+++ b/lib/Runtime/Types/ES5ArrayTypeHandler.h
@@ -9,9 +9,9 @@ namespace Js
     class IndexPropertyDescriptor
     {
     public:
-        PropertyAttributes Attributes;
-        Var Getter;
-        Var Setter;
+        Field(PropertyAttributes) Attributes;
+        Field(Var) Getter;
+        Field(Var) Setter;
 
         IndexPropertyDescriptor(PropertyAttributes attributes = PropertyDynamicTypeDefaults,
             Var getter = NULL, Var setter = NULL)

--- a/test/runtests.py
+++ b/test/runtests.py
@@ -56,7 +56,7 @@ parser.add_argument('--tag', nargs='*',
                     help='select tests with given tags')
 parser.add_argument('--not-tag', nargs='*',
                     help='exclude tests with given tags')
-parser.add_argument('--flag', nargs='*',
+parser.add_argument('--flags', default='',
                     help='global test flags to ch')
 parser.add_argument('--timeout', type=int, default=DEFAULT_TIMEOUT,
                     help='test timeout (default ' + str(DEFAULT_TIMEOUT) + ' seconds)')
@@ -394,10 +394,10 @@ class TestVariant(object):
 
         working_path = os.path.dirname(js_file)
 
-        flags = test.get('compile-flags')
+        flags = test.get('compile-flags') or ''
         flags = self._expand_compile_flags(test) + \
-                    (args.flag or []) + \
-                    (flags.split() if flags else [])
+                    args.flags.split() + \
+                    flags.split()
 
         cmd = [binary] + flags + [os.path.basename(js_file)]
 


### PR DESCRIPTION
Changed `runtests.py` to simplify passing multiple ch switches, e.g. to
run Lei's swb verification on test\Basics on x86_debug and interpreted
variants only:

```
python test\runtests.py -d test\Basics \
  --flags "-ForceSoftwareWriteBarrier -recyclerconcurrentstress -recyclerverifymark" \
  --variants interpreted
```

Fixed some found issues.

Notably, original swb type traits were missing "T* const" specification.
CopyArray/etc. also needs to take account of "TAllocator" type, as we may
copy structs that contain GC pointers (and we usually use RecyclerNonLeaf
with those).
