### PR TITLE
Don't remove dead syms which are referenced in callSequence in infinite loop blocks

### DIFF
--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -2528,14 +2528,36 @@ GlobOpt::CleanUpValueMaps()
     BVSparse<JitArenaAllocator> *upwardExposedFields = this->currentBlock->upwardExposedFields;
     bool isInLoop = !!this->currentBlock->loop;
 
+    BVSparse<JitArenaAllocator> symsInCallSequence(this->tempAlloc);
+    SListBase<IR::Opnd *> * callSequence = this->currentBlock->globOptData.callSequence;
+    if (callSequence && !callSequence->Empty())
+    {
+        FOREACH_SLISTBASE_ENTRY(IR::Opnd *, opnd, callSequence)
+        {
+            StackSym * sym = opnd->GetStackSym();
+            symsInCallSequence.Set(sym->m_id);
+        }
+    }
+    NEXT_SLISTBASE_ENTRY;
+
     for (uint i = 0; i < thisTable->tableSize; i++)
     {
         FOREACH_SLISTBASE_ENTRY_EDITING(GlobHashBucket, bucket, &thisTable->table[i], iter)
         {
+            bool isSymUpwardExposed = upwardExposedUses->Test(bucket.value->m_id) || upwardExposedFields->Test(bucket.value->m_id);
+            if (!isSymUpwardExposed && symsInCallSequence.Test(bucket.value->m_id))
+            {
+                // Don't remove/shink sym-value pair if the sym is referenced in callSequnced even if the sym is dead according to backward data flow.
+                // This is possible in some edge cases that an infinite loop is involved when evaluating parameter for a function (between StartCall and Call),
+                // there is no backward data flow into the infinite loop block, but non empty callSequence still populates to it in this (forward) pass.
+                // Shink it will cause error to fill out the bailout information for the loop blocks.
+                // Remove dead syms from callSequence has some risk because there are varies associated counters which need to be consistent.
+                continue;
+            }
             // Make sure symbol was created before backward pass.
             // If symbols isn't upward exposed, mark it as dead.
             // If a symbol was copy-prop'd in a loop prepass, the upwardExposedUses info could be wrong.  So wait until we are out of the loop before clearing it.
-            if ((SymID)bucket.value->m_id <= this->maxInitialSymID && !upwardExposedUses->Test(bucket.value->m_id) && !upwardExposedFields->Test(bucket.value->m_id)
+            if ((SymID)bucket.value->m_id <= this->maxInitialSymID && !isSymUpwardExposed
                 && (!isInLoop || !this->prePassCopyPropSym->Test(bucket.value->m_id)))
             {
                 Value *val = bucket.element;

--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -2547,10 +2547,11 @@ GlobOpt::CleanUpValueMaps()
             bool isSymUpwardExposed = upwardExposedUses->Test(bucket.value->m_id) || upwardExposedFields->Test(bucket.value->m_id);
             if (!isSymUpwardExposed && symsInCallSequence.Test(bucket.value->m_id))
             {
-                // Don't remove/shink sym-value pair if the sym is referenced in callSequnced even if the sym is dead according to backward data flow.
+                // Don't remove/shrink sym-value pair if the sym is referenced in callSequence even if the sym is dead according to backward data flow.
                 // This is possible in some edge cases that an infinite loop is involved when evaluating parameter for a function (between StartCall and Call),
-                // there is no backward data flow into the infinite loop block, but non empty callSequence still populates to it in this (forward) pass.
-                // Shink it will cause error to fill out the bailout information for the loop blocks.
+                // there is no backward data flow into the infinite loop block, but non empty callSequence still populates to it in this (forward) pass
+                // which causes error when looking up value for the syms in callSequence (cannot find the value).
+                // It would cause error to fill out the bailout information for the loop blocks.
                 // Remove dead syms from callSequence has some risk because there are varies associated counters which need to be consistent.
                 continue;
             }

--- a/test/Bugs/InlineFunctionParameterWithInfiniteLoop.js
+++ b/test/Bugs/InlineFunctionParameterWithInfiniteLoop.js
@@ -1,0 +1,15 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function bar(o) {if(!o)for(;;);}
+
+function baz(a){}
+function foo() {baz(bar({}))};
+
+foo();
+foo();
+
+print("pass");
+

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -354,4 +354,10 @@
       <compile-flags>-args summary -endargs</compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>InlineFunctionParameterWithInfiniteLoop.js</files>
+      <compile-flags>-maxinterpretcount:1 -off:simplejit</compile-flags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
When function with infinite loop is inlined as parameter evaluation for another function, callSequence is propagated to infinite loop blocks in forward pass, but usually the operands in callSequence are not live because there is no way to exit the loop (so it is uncontional infinite loop). This triggers assertion when filling bailout from callSequence (because no value for given sym). 

This change fixes it by not removing dead sym in symToValueMap if it is referenced in callSequence.