### PR TITLE
WASM - Global mutable value

### DIFF
--- a/lib/WasmReader/WasmBinaryReader.cpp
+++ b/lib/WasmReader/WasmBinaryReader.cpp
@@ -932,7 +932,7 @@ WasmBinaryReader::ReadGlobalsSection()
     for (UINT i = 0; i < numEntries; ++i)
     {
         WasmTypes::WasmType type = ReadWasmType(len);
-        bool isMutable = ReadConst<UINT8>() == 1;
+        bool isMutable = ReadMutableValue();
         WasmNode globalNode = ReadInitExpr();
         GlobalReferenceTypes::Type refType = GlobalReferenceTypes::Const;
         WasmTypes::WasmType initType;
@@ -1008,7 +1008,7 @@ WasmBinaryReader::ReadImportEntries()
         case ExternalKinds::Global:
         {
             WasmTypes::WasmType type = ReadWasmType(len);
-            bool isMutable = ReadConst<UINT8>() == 1;
+            bool isMutable = ReadMutableValue();
             if (isMutable)
             {
                 ThrowDecodingError(_u("Mutable globals cannot be imported"));
@@ -1192,6 +1192,18 @@ T WasmBinaryReader::ReadConst()
     m_pc += sizeof(T);
 
     return value;
+}
+
+bool WasmBinaryReader::ReadMutableValue()
+{
+    uint8 mutableValue = ReadConst<UINT8>();
+    switch (mutableValue)
+    {
+    case 0: return false;
+    case 1: return true;
+    default:
+        ThrowDecodingError(_u("invalid mutability"));
+    }
 }
 
 WasmTypes::WasmType

--- a/lib/WasmReader/WasmBinaryReader.h
+++ b/lib/WasmReader/WasmBinaryReader.h
@@ -80,6 +80,7 @@ namespace Wasm
         // Primitive reader
         template <WasmTypes::WasmType type> void ConstNode();
         template <typename T> T ReadConst();
+        bool ReadMutableValue();
         const char16* ReadInlineName(uint32& length, uint32& nameLength);
         const char16* CvtUtf8Str(LPCUTF8 name, uint32 nameLen);
         template<typename MaxAllowedType = UINT>

--- a/test/wasm/invalid_global_mut.js
+++ b/test/wasm/invalid_global_mut.js
@@ -1,0 +1,98 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+'use strict';
+
+let soft_validate = true;
+
+let spectest = {
+  print: print || ((...xs) => console.log(...xs)),
+  global: 666,
+  table: new WebAssembly.Table({initial: 10, maximum: 20, element: 'anyfunc'}),  memory: new WebAssembly.Memory({initial: 1, maximum: 2}),};
+
+let registry = {spectest};
+let $$;
+
+function register(name, instance) {
+  registry[name] = instance.exports;
+}
+
+function module(bytes) {
+  let buffer = new ArrayBuffer(bytes.length);
+  let view = new Uint8Array(buffer);
+  for (let i = 0; i < bytes.length; ++i) {
+    view[i] = bytes.charCodeAt(i);
+  }
+  return new WebAssembly.Module(buffer);
+}
+
+function instance(bytes, imports = registry) {
+  return new WebAssembly.Instance(module(bytes), imports);
+}
+
+function assert_malformed(bytes) {
+  try { module(bytes) } catch (e) {
+    if (e instanceof WebAssembly.CompileError) return;
+  }
+  throw new Error("Wasm decoding failure expected");
+}
+
+function assert_invalid(bytes) {
+  try { module(bytes) } catch (e) {
+    if (e instanceof WebAssembly.CompileError) return;
+  }
+  throw new Error("Wasm validation failure expected");
+}
+
+function assert_soft_invalid(bytes) {
+  try { module(bytes) } catch (e) {
+    if (e instanceof WebAssembly.CompileError) return;
+    throw new Error("Wasm validation failure expected");
+  }
+  if (soft_validate)
+    throw new Error("Wasm validation failure expected");
+}
+
+function assert_unlinkable(bytes) {
+  let mod = module(bytes);
+  try { new WebAssembly.Instance(mod, registry) } catch (e) {
+    if (e instanceof TypeError) return;
+  }
+  throw new Error("Wasm linking failure expected");
+}
+
+function assert_uninstantiable(bytes) {
+  let mod = module(bytes);
+  try { new WebAssembly.Instance(mod, registry) } catch (e) {
+    if (e instanceof WebAssembly.RuntimeError) return;
+  }
+  throw new Error("Wasm trap expected");
+}
+
+function assert_trap(action) {
+  try { action() } catch (e) {
+    if (e instanceof WebAssembly.RuntimeError) return;
+  }
+  throw new Error("Wasm trap expected");
+}
+
+function assert_return(action, expected) {
+  let actual = action();
+  if (!Object.is(actual, expected)) {
+    throw new Error("Wasm return value " + expected + " expected, got " + actual);
+  };
+}
+
+function assert_return_nan(action) {
+  let actual = action();
+  if (!Number.isNaN(actual)) {
+    throw new Error("Wasm return value NaN expected, got " + actual);
+  };
+}
+
+assert_malformed("\x00\x61\x73\x6d\x0d\x00\x00\x00\x02\x94\x80\x80\x80\x00\x01\x08\x73\x70\x65\x63\x74\x65\x73\x74\x06\x67\x6c\x6f\x62\x61\x6c\x03\x7f\x02");
+assert_malformed("\x00\x61\x73\x6d\x0d\x00\x00\x00\x06\x86\x80\x80\x80\x00\x01\x7f\xff\x41\x00\x0b");
+assert_malformed("\x00\x61\x73\x6d\x0d\x00\x00\x00\x06\x86\x80\x80\x80\x00\x01\x7f\xd4\x41\x00\x0b");
+assert_malformed("\x00\x61\x73\x6d\x0d\x00\x00\x00\x06\x86\x80\x80\x80\x00\x01\x7f\x02\x41\x00\x0b");
+print("PASSED");

--- a/test/wasm/rlexe.xml
+++ b/test/wasm/rlexe.xml
@@ -124,6 +124,12 @@
 </test>
 <test>
   <default>
+    <files>invalid_global_mut.js</files>
+    <compile-flags>-wasm</compile-flags>
+  </default>
+</test>
+<test>
+  <default>
     <files>debugger.js</files>
     <compile-flags>-wasm -dbgbaseline:debugger.js.dbg.baseline</compile-flags>
     <tags>exclude_serialized,exclude_jshost,exclude_snap,require_debugger</tags>

--- a/test/wasm/wasts/invalid_global_mut.wast
+++ b/test/wasm/wasts/invalid_global_mut.wast
@@ -1,0 +1,16 @@
+;;-------------------------------------------------------------------------------------------------------
+;; Copyright (C) Microsoft Corporation and contributors. All rights reserved.
+;; Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+;;-------------------------------------------------------------------------------------------------------
+
+;;(module
+;;  (import "spectest" "global" (global i32))
+;;)
+(assert_malformed (module "\00asm\0d\00\00\00\02\94\80\80\80\00\01\08\73\70\65\63\74\65\73\74\06\67\6c\6f\62\61\6c\03\7f\02") "invalid mutability")
+
+;;(module
+;;  (global i32 (i32.const 0))
+;;)
+(assert_malformed (module "\00asm\0d\00\00\00\06\86\80\80\80\00\01\7f\ff\41\00\0b") "invalid mutability")
+(assert_malformed (module "\00asm\0d\00\00\00\06\86\80\80\80\00\01\7f\d4\41\00\0b") "invalid mutability")
+(assert_malformed (module "\00asm\0d\00\00\00\06\86\80\80\80\00\01\7f\02\41\00\0b") "invalid mutability")


### PR DESCRIPTION
Disallow any other values than 0 or 1 for global mutability encoding.
Fixes #2193

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/2218)
<!-- Reviewable:end -->
