### PR TITLE
Port fix for bad binding of async arrow function parameters

### DIFF
--- a/lib/Parser/Parse.h
+++ b/lib/Parser/Parse.h
@@ -835,6 +835,7 @@ private:
         ParseNodePtr pnode,
         BOOL fAllowCall, 
         BOOL fInNew, 
+        BOOL isAsyncExpr,
         BOOL *pfCanAssign, 
         _Inout_ IdentToken* pToken, 
         _Out_opt_ bool* pfIsDotOrIndex = nullptr);

--- a/test/es6/lambda-params-shadow.js
+++ b/test/es6/lambda-params-shadow.js
@@ -13,6 +13,8 @@ class B extends A {
         super();
         ((B) => { super.increment() })();
         (A=> { super.increment() })();
+        let C = async (B) => { B };
+        let D = async A => { A };
     }
 }
 let b = new B();

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -15,13 +15,13 @@
   <test>
     <default>
       <files>lambda-params-shadow.js</files>
-      <compile-flags>-off:deferparse -args summary -endargs</compile-flags>
+      <compile-flags>-off:deferparse -es7asyncawait</compile-flags>
     </default>
   </test>
   <test>
     <default>
       <files>lambda-params-shadow.js</files>
-      <compile-flags>-force:deferparse -args summary -endargs</compile-flags>
+      <compile-flags>-force:deferparse -es7asyncawait</compile-flags>
     </default>
   </test>
   <test>


### PR DESCRIPTION
Apply the same parse-time-binding logic to async arrow function parameter lists as to normal arrow function parameter lists. (They take different paths in the parser prior to the discovery of the arrow.)