### PR TITLE
fix race in jit server init

### DIFF
--- a/lib/JITServer/JITServer.cpp
+++ b/lib/JITServer/JITServer.cpp
@@ -58,6 +58,9 @@ HRESULT JsInitializeJITServer(
         return status;
     }
 
+    JITManager::GetJITManager()->SetIsJITServer();
+    PageAllocatorPool::Initialize();
+
     status = RpcEpRegister(
         ServerIChakraJIT_v0_0_s_ifspec,
         bindingVector,
@@ -74,9 +77,6 @@ HRESULT JsInitializeJITServer(
     {
         return status;
     }
-
-    JITManager::GetJITManager()->SetIsJITServer();
-    PageAllocatorPool::Initialize();
 
     status = RpcServerListen(1, RPC_C_LISTEN_MAX_CALLS_DEFAULT, FALSE);
 


### PR DESCRIPTION
once RpcEpRegister is called, JIT process can be called. If a call happens after that but before PageAllocatorPool::Initialize completes, PageAllocatorPool::Instance will be null.