### PR TITLE
Don't attempt to create a deferred stub for a non-deferred function. 

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -13455,6 +13455,13 @@ DeferredFunctionStub * BuildDeferredStubTree(ParseNode *pnodeFnc, Recycler *recy
         }
         AssertOrFailFast(i < nestedCount);
 
+        if (pnodeChild->sxFnc.pnodeBody != nullptr)
+        {
+            // Anomalous case of a non-deferred function nested within a deferred one.
+            // Work around by discarding the stub tree.
+            return nullptr;
+        }
+
         if (pnodeChild->sxFnc.IsGeneratedDefault())
         {
             ++i;


### PR DESCRIPTION
Works around a parser anomaly that appeared with re-deferral. I'll keep investigating the cause of the anomaly.