### PR TITLE
swb: a few more unit test verification fixes

### DIFF
--- a/lib/Backend/JITTimePolymorphicInlineCache.cpp
+++ b/lib/Backend/JITTimePolymorphicInlineCache.cpp
@@ -13,7 +13,7 @@ JITTimePolymorphicInlineCache::JITTimePolymorphicInlineCache()
 intptr_t
 JITTimePolymorphicInlineCache::GetAddr() const
 {
-    return m_data.addr;
+    return reinterpret_cast<intptr_t>(PointerValue(m_data.addr));
 }
 
 intptr_t

--- a/lib/Backend/JITTimePolymorphicInlineCacheInfo.cpp
+++ b/lib/Backend/JITTimePolymorphicInlineCacheInfo.cpp
@@ -67,7 +67,7 @@ JITTimePolymorphicInlineCacheInfo::InitializePolymorphicInlineCacheInfo(
             if (pic != nullptr)
             {
                 jitInfo->polymorphicInlineCaches[j].size = pic->GetSize();
-                jitInfo->polymorphicInlineCaches[j].addr = (intptr_t)pic;
+                jitInfo->polymorphicInlineCaches[j].addr = pic;
                 jitInfo->polymorphicInlineCaches[j].inlineCachesAddr = (intptr_t)pic->GetInlineCaches();
             }
         }

--- a/lib/Backend/JnHelperMethod.cpp
+++ b/lib/Backend/JnHelperMethod.cpp
@@ -215,7 +215,7 @@ DECLSPEC_GUARDIGNORE  _NOINLINE intptr_t GetNonTableMethodAddress(ThreadContextI
         return SHIFT_CRT_ADDR(context, (int(*)(void *, void *, size_t))memcmp);
 
     case HelperMemCpy:
-        return SHIFT_CRT_ADDR(context, (int(*)(void *, void *, size_t))memcpy);
+        return SHIFT_CRT_ADDR(context, (void*(*)(void *, void const*, size_t))memcpy);
 
     case HelperDirectMath_FloorFlt:
         return SHIFT_CRT_ADDR(context, (float(*)(float))floor);

--- a/lib/Common/DataStructures/Cache.h
+++ b/lib/Common/DataStructures/Cache.h
@@ -6,7 +6,7 @@
 
 namespace JsUtil
 {
-    template <typename T, uint size>
+    template <typename T, uint size, class TAllocator>
     class CircularBuffer
     {
     public:
@@ -87,16 +87,16 @@ namespace JsUtil
         }
 
     private:
-        uint writeIndex;
-        bool filled;
-        T entries[size];
+        Field(uint) writeIndex;
+        Field(bool) filled;
+        Field(T, TAllocator) entries[size];
     };
 
     template <class TKey, int MRUSize, class TAllocator = Recycler>
     class MRURetentionPolicy
     {
     public:
-        typedef CircularBuffer<TKey, MRUSize> TMRUStoreType;
+        typedef CircularBuffer<TKey, MRUSize, TAllocator> TMRUStoreType;
         MRURetentionPolicy(TAllocator* allocator)
         {
             store = AllocatorNew(TAllocator, allocator, TMRUStoreType);

--- a/lib/Common/DataStructures/List.h
+++ b/lib/Common/DataStructures/List.h
@@ -209,6 +209,7 @@ namespace JsUtil
         friend TRemovePolicy<TListType, true>;
         typedef TRemovePolicy<TListType, true /* clearOldEntries */>  TRemovePolicyType;
         typedef ListTypeAllocatorFunc<TAllocator, isLeaf> AllocatorInfo;
+        typedef typename AllocatorInfo::EffectiveAllocatorType EffectiveAllocatorType;
 
         Field(int) length;
         Field(int) increment;
@@ -273,7 +274,7 @@ namespace JsUtil
 
                 Field(T, TAllocator)* newbuffer = AllocArray(newLength);
                 Field(T, TAllocator)* oldbuffer = this->buffer;
-                CopyArray<Field(T, TAllocator), Field(T, TAllocator), TAllocator>(
+                CopyArray<Field(T, TAllocator), Field(T, TAllocator), EffectiveAllocatorType>(
                     newbuffer, newLength, oldbuffer, length);
 
                 FreeArray(oldbuffer, oldBufferSize);
@@ -502,7 +503,7 @@ namespace JsUtil
                 (IsSame<TRemovePolicyType, Js::CopyRemovePolicy<TListType, true> >::IsTrue));
             if (this->count)
             {
-                qsort_s<Field(T, TAllocator), Field(T, TAllocator), TAllocator>(
+                qsort_s<Field(T, TAllocator), Field(T, TAllocator), EffectiveAllocatorType>(
                     this->buffer, this->count, _PtFuncCompare, _Context);
             }
         }

--- a/lib/Common/DataStructures/SparseBitVector.h
+++ b/lib/Common/DataStructures/SparseBitVector.h
@@ -92,7 +92,7 @@ public:
 
 private:
     FieldNoBarrier(TAllocator*)         alloc;
-    FieldNoBarrier(Field(BVSparseNode*, TAllocator)*) lastUsedNodePrevNextField;
+    Field(Field(BVSparseNode*, TAllocator)*, TAllocator) lastUsedNodePrevNextField;
 
     static const SparseBVUnit s_EmptyUnit;
 

--- a/lib/Common/Memory/Allocator.h
+++ b/lib/Common/Memory/Allocator.h
@@ -188,6 +188,7 @@ template <typename TAllocator, bool isLeaf>
 class ListTypeAllocatorFunc
 {
 public:
+    typedef TAllocator EffectiveAllocatorType;  // used by write barrier type traits
     typedef char * (TAllocator::*AllocFuncType)(size_t);
     typedef void(TAllocator::*FreeFuncType)(void*, size_t);
 

--- a/lib/Common/Memory/RecyclerPointers.h
+++ b/lib/Common/Memory/RecyclerPointers.h
@@ -525,6 +525,12 @@ void *  __cdecl memmove(_Out_writes_bytes_all_opt_(_Size) WriteBarrierPtr<T> * _
 }
 
 template <typename T>
+void* __cdecl memcpy(WriteBarrierPtr<T> *dst, const void *src, size_t count)
+{
+    CompileAssert(false);
+}
+
+template <typename T>
 void __stdcall js_memcpy_s(__bcount(sizeInBytes) WriteBarrierPtr<T> *dst, size_t sizeInBytes, __bcount(count) const void *src, size_t count)
 {
     CompileAssert(false);

--- a/lib/JITIDL/JITTypes.h
+++ b/lib/JITIDL/JITTypes.h
@@ -656,7 +656,7 @@ typedef struct PolymorphicInlineCacheIDL
     IDL_Field(unsigned short) size;
     IDL_PAD2(0)
     X64_PAD4(1)
-    IDL_Field(CHAKRA_PTR) addr;
+    IDL_Field(CHAKRA_WB_PTR) addr;
     IDL_Field(CHAKRA_PTR) inlineCachesAddr;
 } PolymorphicInlineCacheIDL;
 

--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -2439,8 +2439,8 @@ namespace Js
             {
                 uint newCount = moduleID + 4;  // Preallocate 4 more slots, moduleID don't usually grow much
 
-                SRCINFO const ** newModuleSrcInfo = RecyclerNewArrayZ(this->GetRecycler(), SRCINFO const*, newCount);
-                memcpy(newModuleSrcInfo, cache->moduleSrcInfo, sizeof(SRCINFO const *)* moduleSrcInfoCount);
+                Field(SRCINFO const *)* newModuleSrcInfo = RecyclerNewArrayZ(this->GetRecycler(), Field(SRCINFO const*), newCount);
+                CopyArray(newModuleSrcInfo, newCount, cache->moduleSrcInfo, moduleSrcInfoCount);
                 cache->moduleSrcInfo = newModuleSrcInfo;
                 moduleSrcInfoCount = newCount;
                 cache->moduleSrcInfo[0] = this->cache->noContextGlobalSourceInfo;

--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -410,7 +410,7 @@ namespace Js
         Field(DynamicSourceContextInfoMap*) dynamicSourceContextInfoMap;
         Field(SourceContextInfo*) noContextSourceContextInfo;
         Field(SRCINFO*) noContextGlobalSourceInfo;
-        Field(SRCINFO const **) moduleSrcInfo;
+        Field(Field(SRCINFO const *)*) moduleSrcInfo;
         Field(BuiltInLibraryFunctionMap*) builtInLibraryFunctions;
     };
 

--- a/lib/Runtime/Language/ObjTypeSpecFldInfo.cpp
+++ b/lib/Runtime/Language/ObjTypeSpecFldInfo.cpp
@@ -619,12 +619,13 @@ namespace Js
         if (gatherDataForInlining)
         {
             fixedFieldInfoArray = RecyclerNewArrayZ(recycler, FixedFieldInfo, fixedFunctionCount);
-            memcpy(fixedFieldInfoArray, localFixedFieldInfoArray, fixedFunctionCount * sizeof(FixedFieldInfo));
+            CopyArray<FixedFieldInfo, Field(Var)>(
+                fixedFieldInfoArray, fixedFunctionCount, localFixedFieldInfoArray, fixedFunctionCount);
         }
         else
         {
             fixedFieldInfoArray = RecyclerNewArrayZ(recycler, FixedFieldInfo, 1);
-            memcpy(fixedFieldInfoArray, localFixedFieldInfoArray, 1 * sizeof(FixedFieldInfo));
+            CopyArray<FixedFieldInfo, Field(Var)>(fixedFieldInfoArray, 1, localFixedFieldInfoArray, 1);
         }
 
         Js::PropertyId propertyId = functionBody->GetPropertyIdFromCacheId(cacheId);

--- a/lib/Runtime/Types/DynamicObjectPropertyEnumerator.cpp
+++ b/lib/Runtime/Types/DynamicObjectPropertyEnumerator.cpp
@@ -112,11 +112,11 @@ namespace Js
 
         uint propertyCount = this->object->GetPropertyCount();
         data = RecyclerNewStructPlus(requestContext->GetRecycler(),
-            propertyCount * sizeof(PropertyString *) + propertyCount * sizeof(BigPropertyIndex) + propertyCount * sizeof(PropertyAttributes), CachedData);
+            propertyCount * sizeof(Field(PropertyString*)) + propertyCount * sizeof(BigPropertyIndex) + propertyCount * sizeof(PropertyAttributes), CachedData);
         data->scriptContext = requestContext;
         data->cachedCount = 0;
         data->propertyCount = propertyCount;
-        data->strings = (PropertyString **)(data + 1);
+        data->strings = reinterpret_cast<Field(PropertyString*)*>(data + 1);
         data->indexes = (BigPropertyIndex *)(data->strings + propertyCount);
         data->attributes = (PropertyAttributes*)(data->indexes + propertyCount);
         data->completed = false;

--- a/lib/Runtime/Types/DynamicObjectPropertyEnumerator.h
+++ b/lib/Runtime/Types/DynamicObjectPropertyEnumerator.h
@@ -21,7 +21,7 @@ namespace Js
         struct CachedData
         {
             Field(ScriptContext *) scriptContext;
-            Field(PropertyString **) strings;
+            Field(Field(PropertyString*)*) strings;
             Field(BigPropertyIndex *) indexes;
             Field(PropertyAttributes *) attributes;
             Field(int) cachedCount;

--- a/lib/Runtime/Types/TypePath.cpp
+++ b/lib/Runtime/Types/TypePath.cpp
@@ -141,7 +141,7 @@ namespace Js {
 
         clonedPath->GetData()->pathLength = (uint8)currentPathLength;
         memcpy(&clonedPath->GetData()->map, &this->GetData()->map, sizeof(TinyDictionary) + currentPathLength);
-        memcpy(clonedPath->assignments, this->assignments, sizeof(PropertyRecord *) * currentPathLength);
+        CopyArray(clonedPath->assignments, currentPathLength, this->assignments, currentPathLength);
 
 #ifdef SUPPORT_FIXED_FIELDS_ON_PATH_TYPES
         // Copy fixed field info


### PR DESCRIPTION
A few fixes from running unit test verification.

Previously missed disabling "memcpy" on "WriteBarrierPtr*".

List uses "bool isLeaf" to indicate leaf/non-leaf. Use the same info to
determine write barrier in CopyArray/qsort_s inside List.
