### PR TITLE
Change to address CVE-2016-7287,CVE-2016-7286,CVE-2016-7288,CVE-2016-7296

### DIFF
--- a/lib/Runtime/Library/IntlEngineInterfaceExtensionObject.cpp
+++ b/lib/Runtime/Library/IntlEngineInterfaceExtensionObject.cpp
@@ -295,35 +295,46 @@ namespace Js
 
     void IntlEngineInterfaceExtensionObject::deletePrototypePropertyHelper(ScriptContext* scriptContext, DynamicObject* intlObject, Js::PropertyId objectPropertyId, Js::PropertyId getterFunctionId)
     {
-        DynamicObject *prototypeVal = nullptr;
+        DynamicObject *prototypeObject = nullptr;
         DynamicObject *functionObj = nullptr;
-        Var propertyValue;
-        Var getter;
-        Var setter;
+        Var propertyValue = nullptr;
+        Var prototypeValue = nullptr;
+        Var resolvedOptionsValue = nullptr;
+        Var getter = nullptr;
+        Var setter = nullptr;
 
-        if (!Js::JavascriptOperators::GetProperty(intlObject, objectPropertyId, &propertyValue, scriptContext))
+        if (!JavascriptOperators::GetProperty(intlObject, objectPropertyId, &propertyValue, scriptContext) ||
+            !JavascriptOperators::IsObject(propertyValue))
         {
-            AssertMsg(false, "Error.");
             return;
         }
 
-        if (!Js::JavascriptOperators::GetProperty(DynamicObject::FromVar(propertyValue), Js::PropertyIds::prototype, &propertyValue, scriptContext))
+        if (!JavascriptOperators::GetProperty(DynamicObject::FromVar(propertyValue), Js::PropertyIds::prototype, &prototypeValue, scriptContext) ||
+            !JavascriptOperators::IsObject(prototypeValue))
         {
-            AssertMsg(false, "Can't be null, otherwise Intl library wasn't initialized correctly");
             return;
         }
 
-        if (!Js::JavascriptOperators::GetProperty(prototypeVal = DynamicObject::FromVar(propertyValue), Js::PropertyIds::resolvedOptions, &propertyValue, scriptContext))
+        prototypeObject = DynamicObject::FromVar(prototypeValue);
+
+        if (!JavascriptOperators::GetProperty(prototypeObject, Js::PropertyIds::resolvedOptions, &resolvedOptionsValue, scriptContext) ||
+            !JavascriptOperators::IsObject(resolvedOptionsValue))
         {
-            AssertMsg(false, "If these operations result in false, Intl tests will detect them");
             return;
         }
 
-        (functionObj = DynamicObject::FromVar(propertyValue))->SetConfigurable(Js::PropertyIds::prototype, true);
+        functionObj = DynamicObject::FromVar(resolvedOptionsValue);
+        functionObj->SetConfigurable(Js::PropertyIds::prototype, true);
         functionObj->DeleteProperty(Js::PropertyIds::prototype, Js::PropertyOperationFlags::PropertyOperation_None);
 
-        JavascriptOperators::GetOwnAccessors(prototypeVal, getterFunctionId, &getter, &setter, scriptContext);
-        (functionObj = DynamicObject::FromVar(getter))->SetConfigurable(Js::PropertyIds::prototype, true);
+        if (!JavascriptOperators::GetOwnAccessors(prototypeObject, getterFunctionId, &getter, &setter, scriptContext) ||
+            !JavascriptOperators::IsObject(getter))
+        {
+            return;
+        }
+
+        functionObj = DynamicObject::FromVar(getter);
+        functionObj->SetConfigurable(Js::PropertyIds::prototype, true);
         functionObj->DeleteProperty(Js::PropertyIds::prototype, Js::PropertyOperationFlags::PropertyOperation_None);
     }
 

--- a/lib/Runtime/Library/JavascriptFunction.cpp
+++ b/lib/Runtime/Library/JavascriptFunction.cpp
@@ -989,15 +989,16 @@ namespace Js
 
                     if (arr != nullptr && !arr->IsCrossSiteObject())
                     {
+                        uint32 length = arr->GetLength();
                         // CONSIDER: Optimize by creating a JavascriptArray routine which allows
                         // memcpy-like semantics in optimal situations (no gaps, etc.)
-                        if (argsIndex + arr->GetLength() > destArgs.Info.Count)
+                        if (argsIndex + length > destArgs.Info.Count)
                         {
                             AssertMsg(false, "The array length has changed since we allocated the destArgs buffer?");
                             Throw::FatalInternalError();
                         }
 
-                        for (uint32 j = 0; j < arr->GetLength(); j++)
+                        for (uint32 j = 0; j < length; j++)
                         {
                             Var element;
                             if (!arr->DirectGetItemAtFull(j, &element))

--- a/lib/Runtime/Library/SimdFloat32x4Lib.cpp
+++ b/lib/Runtime/Library/SimdFloat32x4Lib.cpp
@@ -1092,8 +1092,26 @@ namespace Js
         AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
         Assert(!(callInfo.Flags & CallFlags_New));
 
+        Var tarray;
+        Var index;
+        if (args.Info.Count > 1)
+        {
+            tarray = args[1];
+        }
+        else
+        {
+            tarray = scriptContext->GetLibrary()->GetUndefined();
+        }
+        if (args.Info.Count > 2)
+        {
+            index = args[2];
+        }
+        else
+        {
+            index = scriptContext->GetLibrary()->GetUndefined();
+        }
 
-        return SIMD128TypedArrayLoad<JavascriptSIMDFloat32x4>(args[1], args[2], 4 * FLOAT32_SIZE, scriptContext);
+        return SIMD128TypedArrayLoad<JavascriptSIMDFloat32x4>(tarray, index, 4 * FLOAT32_SIZE, scriptContext);
     }
 
     Var SIMDFloat32x4Lib::EntryLoad1(RecyclableObject* function, CallInfo callInfo, ...)
@@ -1106,7 +1124,26 @@ namespace Js
         AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
         Assert(!(callInfo.Flags & CallFlags_New));
 
-        return SIMD128TypedArrayLoad<JavascriptSIMDFloat32x4>(args[1], args[2], 1 * FLOAT32_SIZE, scriptContext);
+        Var tarray;
+        Var index;
+        if (args.Info.Count > 1)
+        {
+            tarray = args[1];
+        }
+        else
+        {
+            tarray = scriptContext->GetLibrary()->GetUndefined();
+        }
+        if (args.Info.Count > 2)
+        {
+            index = args[2];
+        }
+        else
+        {
+            index = scriptContext->GetLibrary()->GetUndefined();
+        }
+
+        return SIMD128TypedArrayLoad<JavascriptSIMDFloat32x4>(tarray, index, 1 * FLOAT32_SIZE, scriptContext);
     }
 
     Var SIMDFloat32x4Lib::EntryLoad2(RecyclableObject* function, CallInfo callInfo, ...)
@@ -1119,7 +1156,26 @@ namespace Js
         AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
         Assert(!(callInfo.Flags & CallFlags_New));
 
-        return SIMD128TypedArrayLoad<JavascriptSIMDFloat32x4>(args[1], args[2], 2 * FLOAT32_SIZE, scriptContext);
+        Var tarray;
+        Var index;
+        if (args.Info.Count > 1)
+        {
+            tarray = args[1];
+        }
+        else
+        {
+            tarray = scriptContext->GetLibrary()->GetUndefined();
+        }
+        if (args.Info.Count > 2)
+        {
+            index = args[2];
+        }
+        else
+        {
+            index = scriptContext->GetLibrary()->GetUndefined();
+        }
+
+        return SIMD128TypedArrayLoad<JavascriptSIMDFloat32x4>(tarray, index, 2 * FLOAT32_SIZE, scriptContext);
     }
 
     Var SIMDFloat32x4Lib::EntryLoad3(RecyclableObject* function, CallInfo callInfo, ...)
@@ -1132,7 +1188,26 @@ namespace Js
         AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
         Assert(!(callInfo.Flags & CallFlags_New));
 
-        return SIMD128TypedArrayLoad<JavascriptSIMDFloat32x4>(args[1], args[2], 3 * FLOAT32_SIZE, scriptContext);
+        Var tarray;
+        Var index;
+        if (args.Info.Count > 1)
+        {
+            tarray = args[1];
+        }
+        else
+        {
+            tarray = scriptContext->GetLibrary()->GetUndefined();
+        }
+        if (args.Info.Count > 2)
+        {
+            index = args[2];
+        }
+        else
+        {
+            index = scriptContext->GetLibrary()->GetUndefined();
+        }
+
+        return SIMD128TypedArrayLoad<JavascriptSIMDFloat32x4>(tarray, index, 3 * FLOAT32_SIZE, scriptContext);
     }
 
     Var SIMDFloat32x4Lib::EntryStore(RecyclableObject* function, CallInfo callInfo, ...)

--- a/lib/Runtime/Library/SimdFloat64x2Lib.cpp
+++ b/lib/Runtime/Library/SimdFloat64x2Lib.cpp
@@ -873,7 +873,26 @@ namespace Js
         AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
         Assert(!(callInfo.Flags & CallFlags_New));
 
-        return SIMD128TypedArrayLoad<JavascriptSIMDFloat64x2>(args[1], args[2], 2 * FLOAT64_SIZE, scriptContext);
+        Var tarray;
+        Var index;
+        if (args.Info.Count > 1)
+        {
+            tarray = args[1];
+        }
+        else
+        {
+            tarray = scriptContext->GetLibrary()->GetUndefined();
+        }
+        if (args.Info.Count > 2)
+        {
+            index = args[2];
+        }
+        else
+        {
+            index = scriptContext->GetLibrary()->GetUndefined();
+        }
+
+        return SIMD128TypedArrayLoad<JavascriptSIMDFloat64x2>(tarray, index, 2 * FLOAT64_SIZE, scriptContext);
     }
 
     Var SIMDFloat64x2Lib::EntryLoad1(RecyclableObject* function, CallInfo callInfo, ...)
@@ -886,7 +905,26 @@ namespace Js
         AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
         Assert(!(callInfo.Flags & CallFlags_New));
 
-        return SIMD128TypedArrayLoad<JavascriptSIMDFloat64x2>(args[1], args[2], 1 * FLOAT64_SIZE, scriptContext);
+        Var tarray;
+        Var index;
+        if (args.Info.Count > 1)
+        {
+            tarray = args[1];
+        }
+        else
+        {
+            tarray = scriptContext->GetLibrary()->GetUndefined();
+        }
+        if (args.Info.Count > 2)
+        {
+            index = args[2];
+        }
+        else
+        {
+            index = scriptContext->GetLibrary()->GetUndefined();
+        }
+
+        return SIMD128TypedArrayLoad<JavascriptSIMDFloat64x2>(tarray, index, 1 * FLOAT64_SIZE, scriptContext);
     }
 
     Var SIMDFloat64x2Lib::EntryStore(RecyclableObject* function, CallInfo callInfo, ...)

--- a/lib/Runtime/Library/SimdInt16x8Lib.cpp
+++ b/lib/Runtime/Library/SimdInt16x8Lib.cpp
@@ -703,8 +703,26 @@ namespace Js
         AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
         Assert(!(callInfo.Flags & CallFlags_New));
 
+        Var tarray;
+        Var index;
+        if (args.Info.Count > 1)
+        {
+            tarray = args[1];
+        }
+        else
+        {
+            tarray = scriptContext->GetLibrary()->GetUndefined();
+        }
+        if (args.Info.Count > 2)
+        {
+            index = args[2];
+        }
+        else
+        {
+            index = scriptContext->GetLibrary()->GetUndefined();
+        }
 
-        return SIMD128TypedArrayLoad<JavascriptSIMDInt16x8>(args[1], args[2], 8 * INT16_SIZE, scriptContext);
+        return SIMD128TypedArrayLoad<JavascriptSIMDInt16x8>(tarray, index, 8 * INT16_SIZE, scriptContext);
     }
 
     Var SIMDInt16x8Lib::EntryStore(RecyclableObject* function, CallInfo callInfo, ...)

--- a/lib/Runtime/Library/SimdInt32x4Lib.cpp
+++ b/lib/Runtime/Library/SimdInt32x4Lib.cpp
@@ -945,7 +945,26 @@ namespace Js
         AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
         Assert(!(callInfo.Flags & CallFlags_New));
 
-        return SIMD128TypedArrayLoad<JavascriptSIMDInt32x4>(args[1], args[2], 4 * INT32_SIZE, scriptContext);
+        Var tarray;
+        Var index;
+        if (args.Info.Count > 1)
+        {
+            tarray = args[1];
+        }
+        else
+        {
+            tarray = scriptContext->GetLibrary()->GetUndefined();
+        }
+        if (args.Info.Count > 2)
+        {
+            index = args[2];
+        }
+        else
+        {
+            index = scriptContext->GetLibrary()->GetUndefined();
+        }
+
+        return SIMD128TypedArrayLoad<JavascriptSIMDInt32x4>(tarray, index, 4 * INT32_SIZE, scriptContext);
     }
 
     Var SIMDInt32x4Lib::EntryLoad1(RecyclableObject* function, CallInfo callInfo, ...)
@@ -958,7 +977,26 @@ namespace Js
         AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
         Assert(!(callInfo.Flags & CallFlags_New));
 
-        return SIMD128TypedArrayLoad<JavascriptSIMDInt32x4>(args[1], args[2], 1 * INT32_SIZE, scriptContext);
+        Var tarray;
+        Var index;
+        if (args.Info.Count > 1)
+        {
+            tarray = args[1];
+        }
+        else
+        {
+            tarray = scriptContext->GetLibrary()->GetUndefined();
+        }
+        if (args.Info.Count > 2)
+        {
+            index = args[2];
+        }
+        else
+        {
+            index = scriptContext->GetLibrary()->GetUndefined();
+        }
+
+        return SIMD128TypedArrayLoad<JavascriptSIMDInt32x4>(tarray, index, 1 * INT32_SIZE, scriptContext);
     }
 
     Var SIMDInt32x4Lib::EntryLoad2(RecyclableObject* function, CallInfo callInfo, ...)
@@ -971,7 +1009,26 @@ namespace Js
         AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
         Assert(!(callInfo.Flags & CallFlags_New));
 
-        return SIMD128TypedArrayLoad<JavascriptSIMDInt32x4>(args[1], args[2], 2 * INT32_SIZE, scriptContext);
+        Var tarray;
+        Var index;
+        if (args.Info.Count > 1)
+        {
+            tarray = args[1];
+        }
+        else
+        {
+            tarray = scriptContext->GetLibrary()->GetUndefined();
+        }
+        if (args.Info.Count > 2)
+        {
+            index = args[2];
+        }
+        else
+        {
+            index = scriptContext->GetLibrary()->GetUndefined();
+        }
+
+        return SIMD128TypedArrayLoad<JavascriptSIMDInt32x4>(tarray, index, 2 * INT32_SIZE, scriptContext);
     }
 
     Var SIMDInt32x4Lib::EntryLoad3(RecyclableObject* function, CallInfo callInfo, ...)
@@ -984,7 +1041,26 @@ namespace Js
         AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
         Assert(!(callInfo.Flags & CallFlags_New));
 
-        return SIMD128TypedArrayLoad<JavascriptSIMDInt32x4>(args[1], args[2], 3 * INT32_SIZE, scriptContext);
+        Var tarray;
+        Var index;
+        if (args.Info.Count > 1)
+        {
+            tarray = args[1];
+        }
+        else
+        {
+            tarray = scriptContext->GetLibrary()->GetUndefined();
+        }
+        if (args.Info.Count > 2)
+        {
+            index = args[2];
+        }
+        else
+        {
+            index = scriptContext->GetLibrary()->GetUndefined();
+        }
+
+        return SIMD128TypedArrayLoad<JavascriptSIMDInt32x4>(tarray, index, 3 * INT32_SIZE, scriptContext);
     }
 
     Var SIMDInt32x4Lib::EntryStore(RecyclableObject* function, CallInfo callInfo, ...)

--- a/lib/Runtime/Library/SimdInt8x16Lib.cpp
+++ b/lib/Runtime/Library/SimdInt8x16Lib.cpp
@@ -792,8 +792,26 @@ namespace Js
         AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
         Assert(!(callInfo.Flags & CallFlags_New));
 
+        Var tarray;
+        Var index;
+        if (args.Info.Count > 1)
+        {
+            tarray = args[1];
+        }
+        else
+        {
+            tarray = scriptContext->GetLibrary()->GetUndefined();
+        }
+        if (args.Info.Count > 2)
+        {
+            index = args[2];
+        }
+        else
+        {
+            index = scriptContext->GetLibrary()->GetUndefined();
+        }
 
-        return SIMD128TypedArrayLoad<JavascriptSIMDInt8x16>(args[1], args[2], 16 * INT8_SIZE, scriptContext);
+        return SIMD128TypedArrayLoad<JavascriptSIMDInt8x16>(tarray, index, 16 * INT8_SIZE, scriptContext);
     }
 
     Var SIMDInt8x16Lib::EntryStore(RecyclableObject* function, CallInfo callInfo, ...)

--- a/lib/Runtime/Library/SimdUint16x8Lib.cpp
+++ b/lib/Runtime/Library/SimdUint16x8Lib.cpp
@@ -238,7 +238,26 @@ namespace Js
         AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
         Assert(!(callInfo.Flags & CallFlags_New));
 
-        return SIMD128TypedArrayLoad<JavascriptSIMDUint16x8>(args[1], args[2], 8 * INT16_SIZE, scriptContext);
+        Var tarray;
+        Var index;
+        if (args.Info.Count > 1)
+        {
+            tarray = args[1];
+        }
+        else
+        {
+            tarray = scriptContext->GetLibrary()->GetUndefined();
+        }
+        if (args.Info.Count > 2)
+        {
+            index = args[2];
+        }
+        else
+        {
+            index = scriptContext->GetLibrary()->GetUndefined();
+        }
+
+        return SIMD128TypedArrayLoad<JavascriptSIMDUint16x8>(tarray, index, 8 * INT16_SIZE, scriptContext);
     }
 
     Var SIMDUint16x8Lib::EntryStore(RecyclableObject* function, CallInfo callInfo, ...)

--- a/lib/Runtime/Library/SimdUint32x4Lib.cpp
+++ b/lib/Runtime/Library/SimdUint32x4Lib.cpp
@@ -891,7 +891,26 @@ namespace Js
         AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
         Assert(!(callInfo.Flags & CallFlags_New));
 
-        return SIMD128TypedArrayLoad<JavascriptSIMDUint32x4>(args[1], args[2], 4 * INT32_SIZE, scriptContext);
+        Var tarray;
+        Var index;
+        if (args.Info.Count > 1)
+        {
+            tarray = args[1];
+        }
+        else
+        {
+            tarray = scriptContext->GetLibrary()->GetUndefined();
+        }
+        if (args.Info.Count > 2)
+        {
+            index = args[2];
+        }
+        else
+        {
+            index = scriptContext->GetLibrary()->GetUndefined();
+        }
+
+        return SIMD128TypedArrayLoad<JavascriptSIMDUint32x4>(tarray, index, 4 * INT32_SIZE, scriptContext);
     }
 
     Var SIMDUint32x4Lib::EntryLoad1(RecyclableObject* function, CallInfo callInfo, ...)
@@ -904,7 +923,26 @@ namespace Js
         AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
         Assert(!(callInfo.Flags & CallFlags_New));
 
-        return SIMD128TypedArrayLoad<JavascriptSIMDUint32x4>(args[1], args[2], 1 * INT32_SIZE, scriptContext);
+        Var tarray;
+        Var index;
+        if (args.Info.Count > 1)
+        {
+            tarray = args[1];
+        }
+        else
+        {
+            tarray = scriptContext->GetLibrary()->GetUndefined();
+        }
+        if (args.Info.Count > 2)
+        {
+            index = args[2];
+        }
+        else
+        {
+            index = scriptContext->GetLibrary()->GetUndefined();
+        }
+
+        return SIMD128TypedArrayLoad<JavascriptSIMDUint32x4>(tarray, index, 1 * INT32_SIZE, scriptContext);
     }
 
     Var SIMDUint32x4Lib::EntryLoad2(RecyclableObject* function, CallInfo callInfo, ...)
@@ -917,7 +955,26 @@ namespace Js
         AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
         Assert(!(callInfo.Flags & CallFlags_New));
 
-        return SIMD128TypedArrayLoad<JavascriptSIMDUint32x4>(args[1], args[2], 2 * INT32_SIZE, scriptContext);
+        Var tarray;
+        Var index;
+        if (args.Info.Count > 1)
+        {
+            tarray = args[1];
+        }
+        else
+        {
+            tarray = scriptContext->GetLibrary()->GetUndefined();
+        }
+        if (args.Info.Count > 2)
+        {
+            index = args[2];
+        }
+        else
+        {
+            index = scriptContext->GetLibrary()->GetUndefined();
+        }
+
+        return SIMD128TypedArrayLoad<JavascriptSIMDUint32x4>(tarray, index, 2 * INT32_SIZE, scriptContext);
     }
 
     Var SIMDUint32x4Lib::EntryLoad3(RecyclableObject* function, CallInfo callInfo, ...)
@@ -930,7 +987,26 @@ namespace Js
         AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
         Assert(!(callInfo.Flags & CallFlags_New));
 
-        return SIMD128TypedArrayLoad<JavascriptSIMDUint32x4>(args[1], args[2], 3 * INT32_SIZE, scriptContext);
+        Var tarray;
+        Var index;
+        if (args.Info.Count > 1)
+        {
+            tarray = args[1];
+        }
+        else
+        {
+            tarray = scriptContext->GetLibrary()->GetUndefined();
+        }
+        if (args.Info.Count > 2)
+        {
+            index = args[2];
+        }
+        else
+        {
+            index = scriptContext->GetLibrary()->GetUndefined();
+        }
+
+        return SIMD128TypedArrayLoad<JavascriptSIMDUint32x4>(tarray, index, 3 * INT32_SIZE, scriptContext);
     }
 
     Var SIMDUint32x4Lib::EntryStore(RecyclableObject* function, CallInfo callInfo, ...)

--- a/lib/Runtime/Library/SimdUint8x16Lib.cpp
+++ b/lib/Runtime/Library/SimdUint8x16Lib.cpp
@@ -238,7 +238,26 @@ namespace Js
         AssertMsg(args.Info.Count > 0, "Should always have implicit 'this'");
         Assert(!(callInfo.Flags & CallFlags_New));
 
-        return SIMD128TypedArrayLoad<JavascriptSIMDUint8x16>(args[1], args[2], 16 * INT8_SIZE, scriptContext);
+        Var tarray;
+        Var index;
+        if (args.Info.Count > 1)
+        {
+            tarray = args[1];
+        }
+        else
+        {
+            tarray = scriptContext->GetLibrary()->GetUndefined();
+        }
+        if (args.Info.Count > 2)
+        {
+            index = args[2];
+        }
+        else
+        {
+            index = scriptContext->GetLibrary()->GetUndefined();
+        }
+
+        return SIMD128TypedArrayLoad<JavascriptSIMDUint8x16>(tarray, index, 16 * INT8_SIZE, scriptContext);
     }
 
     Var SIMDUint8x16Lib::EntryStore(RecyclableObject* function, CallInfo callInfo, ...)

--- a/lib/Runtime/Library/TypedArray.cpp
+++ b/lib/Runtime/Library/TypedArray.cpp
@@ -2335,6 +2335,12 @@ namespace Js
                 dblResult = JavascriptConversion::ToNumber_Full(retVal, scriptContext);
             }
 
+            // ToNumber may execute user-code which can cause the array to become detached
+            if (TypedArrayBase::IsDetachedTypedArray(contextArray[0]))
+            {
+                JavascriptError::ThrowTypeError(scriptContext, JSERR_DetachedTypedArray, _u("[TypedArray].prototype.sort"));
+            }
+
             if (dblResult < 0)
             {
                 return -1;


### PR DESCRIPTION
Fix for SpreadArgs overrun
The array's length gets changed when we do the get-item this will overrun already allocated buffer. Fixed that by creating a local initialized that length.

Use-after-free in TypedArray.sort
%TypedArray%.prototype.sort has a helper method which performs the compare between two elements of the array. This helper takes an optional compare function callback, which is user code, and executes it (if present) to compute the sort order in a user-defined way. We call ToNumber on the return value from the compare function callback. The issue here is that this compare function can return an object which executes user code in the ToNumber conversion (via valueOf). This valueOf function is user code which can detach the buffer in the TypedArray. We check to see if the buffer has been detached after calling the compare function but we don't check again after calling ToNumber. If the valueOf call detaches the buffer, our sort function will re-order elements in the buffer's memory after it was detached and potentially free'd.
Fix is to detect the buffer detach after calling ToNumber and throw out of the helper to make sure we don't shuffle elements in the detached memory.

Uninitialized Memory in SIMD.toLocaleString
JavascriptSIMDObject::ToLocaleString explicitly handles the number of arguments it copies into a temporary array before passing this array to a toLocaleString helper. We have a check for 1, 2, or 3 arguments but calling the function with more than 3 arguments causes it to skip copying any of the incoming arguments into the temporary array. This leads to the toLocaleString helper using uninitialized values in the temporary array since we access this array using the original argument count. There's also another bug here which is that the toLocaleString helper can throw an exception which leaks the temporary array memory since it was allocated on the heap and is not free'd when this helper throws.
Fix both issues by allocating the temporary array on the stack with a fixed size of 3, clamping the number of incoming arguments to 3, and removing the explicit checks for the number of incoming arguments. Now we insert into the temporary array the two optional arguments if our original set of args includes those optional arguments.

Uninitialized Memory in SIMD.Load
All of the EntryLoad variants in the SIMD Javascript library directly access elements in the arguments array regardless of how many arguments are actually in the array. If user code calls this API with no arguments we will end up loading values which are unknown and potentially uninitiailized. Simple fix is to check the count of arguments passed-in to the function and use undefined for missing arguments.

Type Confusion in Internationalization Initialization
IntlEngineInterfaceExtensionObject::deletePrototypePropertyHelper loads a property from an object and uses it as if it is a DynamicObject even if the property isn't an object. We can run into two different problems here. First, we can end up using an uninitialized stack var if the object we're loading the property from doesn't have this property. Second, we can treat a non-object as an object leading to reading from arbitrary memory addresses.
