### PR TITLE
Replace FunctionBody reference in ScopeSlots with FunctionInfo

### DIFF
--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -3264,6 +3264,12 @@ Lowerer::LowerRange(IR::Instr *instrStart, IR::Instr *instrEnd, bool defaultDoFa
     Assert(this->outerMostLoopLabel == nullptr);
 }
 
+IR::Opnd *
+Lowerer::LoadFunctionInfoOpnd(IR::Instr * instr)
+{
+    return IR::AddrOpnd::New(instr->m_func->GetWorkItem()->GetJITTimeInfo()->GetFunctionInfoAddr(), IR::AddrOpndKindDynamicFunctionInfo, instr->m_func);
+}
+
 IR::Instr *
 Lowerer::LoadFunctionBody(IR::Instr * instr)
 {
@@ -8342,6 +8348,13 @@ Lowerer::LowerUnaryHelperMem(IR::Instr *instr, IR::JnHelperMethod helperMethod, 
     instrPrev = LoadScriptContext(instr);
 
     return this->LowerUnaryHelper(instr, helperMethod, opndBailoutArg);
+}
+
+IR::Instr *
+Lowerer::LowerUnaryHelperMemWithFunctionInfo(IR::Instr *instr, IR::JnHelperMethod helperMethod)
+{
+    m_lowererMD.LoadHelperArgument(instr, this->LoadFunctionInfoOpnd(instr));
+    return this->LowerUnaryHelperMem(instr, helperMethod);
 }
 
 IR::Instr *
@@ -23325,7 +23338,7 @@ Lowerer::LowerNewScopeSlots(IR::Instr * instr, bool doStackSlots)
     Func * func = m_func;
     if (PHASE_OFF(Js::NewScopeSlotFastPathPhase, func))
     {
-        this->LowerUnaryHelperMemWithFuncBody(instr, IR::HelperOP_NewScopeSlots);
+        this->LowerUnaryHelperMemWithFunctionInfo(instr, IR::HelperOP_NewScopeSlots);
         return;
     }
 
@@ -23349,9 +23362,9 @@ Lowerer::LowerNewScopeSlots(IR::Instr * instr, bool doStackSlots)
     }
     GenerateMemInit(dst, Js::ScopeSlots::EncodedSlotCountSlotIndex * sizeof(Js::Var),
         min<uint>(actualSlotCount, Js::ScopeSlots::MaxEncodedSlotCount), instr, !doStackSlots);
-    IR::Opnd * functionBodyOpnd = this->LoadFunctionBodyOpnd(instr);
+    IR::Opnd * functionInfoOpnd = this->LoadFunctionInfoOpnd(instr);
     GenerateMemInit(dst, Js::ScopeSlots::ScopeMetadataSlotIndex * sizeof(Js::Var),
-        functionBodyOpnd, instr, !doStackSlots);
+        functionInfoOpnd, instr, !doStackSlots);
 
     IR::Opnd * undefinedOpnd = this->LoadLibraryValueOpnd(instr, LibraryValue::ValueUndefined);
     const IR::AutoReuseOpnd autoReuseUndefinedOpnd(undefinedOpnd, func);

--- a/lib/Backend/Lower.h
+++ b/lib/Backend/Lower.h
@@ -201,6 +201,7 @@ private:
     IR::Instr *     LowerUnaryHelper(IR::Instr *instr, IR::JnHelperMethod helperMethod, IR::Opnd* opndBailoutArg = nullptr);
     IR::Instr *     LowerUnaryHelperMem(IR::Instr *instr, IR::JnHelperMethod helperMethod, IR::Opnd* opndBailoutArg = nullptr);
     IR::Instr *     LowerUnaryHelperMemWithFuncBody(IR::Instr *instr, IR::JnHelperMethod helperMethod);
+    IR::Instr *     LowerUnaryHelperMemWithFunctionInfo(IR::Instr *instr, IR::JnHelperMethod helperMethod);
     IR::Instr *     LowerBinaryHelperMemWithFuncBody(IR::Instr *instr, IR::JnHelperMethod helperMethod);
     IR::Instr *     LowerUnaryHelperMemWithTemp(IR::Instr *instr, IR::JnHelperMethod helperMethod);
     IR::Instr *     LowerUnaryHelperMemWithTemp2(IR::Instr *instr, IR::JnHelperMethod helperMethod, IR::JnHelperMethod helperMethodWithTemp);
@@ -549,6 +550,7 @@ private:
     IR::Instr *         LoadScriptContext(IR::Instr *instr);
     IR::Instr *         LoadFunctionBody(IR::Instr * instr);
     IR::Opnd *          LoadFunctionBodyOpnd(IR::Instr *instr);
+    IR::Opnd *          LoadFunctionInfoOpnd(IR::Instr *instr);
     IR::Opnd *          LoadScriptContextOpnd(IR::Instr *instr);
     IR::Opnd *          LoadScriptContextValueOpnd(IR::Instr * instr, ScriptContextValue valueType);
     IR::Opnd *          LoadLibraryValueOpnd(IR::Instr * instr, LibraryValue valueType);

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -3687,13 +3687,13 @@ namespace Js
 
         bool IsFunctionScopeSlotArray()
         {
-            return FunctionBody::Is(slotArray[ScopeMetadataSlotIndex]);
+            return FunctionInfo::Is(slotArray[ScopeMetadataSlotIndex]);
         }
 
-        FunctionBody* GetFunctionBody()
+        FunctionInfo* GetFunctionInfo()
         {
             Assert(IsFunctionScopeSlotArray());
-            return (FunctionBody*)(slotArray[ScopeMetadataSlotIndex]);
+            return (FunctionInfo*)(slotArray[ScopeMetadataSlotIndex]);
         }
 
         DebuggerScope* GetDebuggerScope()

--- a/lib/Runtime/Base/FunctionInfo.cpp
+++ b/lib/Runtime/Base/FunctionInfo.cpp
@@ -14,6 +14,15 @@ namespace Js
 #endif
     }
 
+    bool FunctionInfo::Is(void* ptr)
+    {
+        if(!ptr)
+        {
+            return false;
+        }
+        return VirtualTableInfo<FunctionInfo>::HasVirtualTable(ptr);
+    }
+
     void FunctionInfo::VerifyOriginalEntryPoint() const
     {
         Assert(!this->HasBody() || this->IsDeferredParseFunction() || this->IsDeferredDeserializeFunction() || this->GetFunctionProxy()->HasValidEntryPoint());

--- a/lib/Runtime/Base/FunctionInfo.h
+++ b/lib/Runtime/Base/FunctionInfo.h
@@ -43,6 +43,7 @@ namespace Js
         };
         FunctionInfo(JavascriptMethod entryPoint, Attributes attributes = None, LocalFunctionId functionId = Js::Constants::NoFunctionId, FunctionProxy* functionBodyImpl = nullptr);
 
+        static bool Is(void *ptr);
         static DWORD GetFunctionBodyImplOffset() { return offsetof(FunctionInfo, functionBodyImpl); }
         static BYTE GetOffsetOfFunctionProxy()
         {

--- a/lib/Runtime/Debug/DiagObjectModel.cpp
+++ b/lib/Runtime/Debug/DiagObjectModel.cpp
@@ -571,7 +571,7 @@ namespace Js
             if (slotArray.IsFunctionScopeSlotArray())
             {
                 DebuggerScope *formalScope = GetScopeWhenHaltAtFormals();
-                Js::FunctionBody *pFBody = slotArray.GetFunctionBody();
+                Js::FunctionBody *pFBody = slotArray.GetFunctionInfo()->GetFunctionBody();
                 uint slotArrayCount = slotArray.GetCount();
 
                 if (formalScope != nullptr && !pFBody->IsParamAndBodyScopeMerged())
@@ -4048,7 +4048,7 @@ namespace Js
 
             if(slotArray.IsFunctionScopeSlotArray())
             {
-                Js::FunctionBody *functionBody = slotArray.GetFunctionBody();
+                Js::FunctionBody *functionBody = slotArray.GetFunctionInfo()->GetFunctionBody();
                 return functionBody->GetDisplayName();
             }
             else

--- a/lib/Runtime/Debug/TTSnapValues.cpp
+++ b/lib/Runtime/Debug/TTSnapValues.cpp
@@ -602,7 +602,7 @@ namespace TTD
             if(slotInfo->isFunctionBodyMetaData)
             {
                 Js::FunctionBody* fbody = inflator->LookupFunctionBody(slotInfo->OptFunctionBodyId);
-                scopeSlots.SetScopeMetadata(fbody);
+                scopeSlots.SetScopeMetadata(fbody->GetFunctionInfo());
 
                 //This is a doubly nested lookup so if the scope slot array is large this could be expensive
                 Js::PropertyId* propertyIds = fbody->GetPropertyIdsForScopeSlotArray();

--- a/lib/Runtime/Debug/TTSnapshotExtractor.cpp
+++ b/lib/Runtime/Debug/TTSnapshotExtractor.cpp
@@ -110,7 +110,7 @@ namespace TTD
 
             if(slots.IsFunctionScopeSlotArray())
             {
-                Js::FunctionBody* fb = slots.GetFunctionBody();
+                Js::FunctionBody* fb = slots.GetFunctionInfo()->GetFunctionBody();
 
                 slotInfo->isFunctionBodyMetaData = true;
                 slotInfo->OptFunctionBodyId = TTD_CONVERT_FUNCTIONBODY_TO_PTR_ID(fb);
@@ -384,7 +384,7 @@ namespace TTD
 
                         if(slotArray.IsFunctionScopeSlotArray())
                         {
-                            this->MarkFunctionBody(slotArray.GetFunctionBody());
+                            this->MarkFunctionBody(slotArray.GetFunctionInfo()->GetFunctionBody());
                         }
 
                         for(uint j = 0; j < slotArrayCount; j++)

--- a/lib/Runtime/Language/AsmJsModule.cpp
+++ b/lib/Runtime/Language/AsmJsModule.cpp
@@ -2615,7 +2615,7 @@ namespace Js
 #endif
         ScopeSlots scopeSlots(slotArray);
         scopeSlots.SetCount(moduleBody->scopeSlotArraySize);
-        scopeSlots.SetScopeMetadata(moduleBody);
+        scopeSlots.SetScopeMetadata(moduleBody->GetFunctionInfo());
 
         auto asmSlotMap = asmModuleInfo->GetAsmJsSlotMap();
         Assert((uint)asmModuleInfo->GetSlotsCount() >= moduleBody->scopeSlotArraySize);

--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -7280,7 +7280,7 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
         if (!functionBody->DoStackScopeSlots())
         {
             return this->NewScopeSlots(
-                scopeSlotCount + ScopeSlots::FirstSlotIndex, this->GetScriptContext(), (Var)functionBody);
+                scopeSlotCount + ScopeSlots::FirstSlotIndex, this->GetScriptContext(), (Var)functionBody->GetFunctionInfo());
         }
 
         slotArray = (Var*)this->GetLocalClosure();
@@ -7288,7 +7288,7 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
 
         ScopeSlots scopeSlots(slotArray);
         scopeSlots.SetCount(scopeSlotCount);
-        scopeSlots.SetScopeMetadata((Var)functionBody);
+        scopeSlots.SetScopeMetadata((Var)functionBody->GetFunctionInfo());
         Var undef = functionBody->GetScriptContext()->GetLibrary()->GetUndefined();
         for (unsigned int i = 0; i < scopeSlotCount; i++)
         {

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -6928,7 +6928,9 @@ CommonNumber:
         uint count = size - ScopeSlots::FirstSlotIndex;
         ScopeSlots slots(slotArray);
         slots.SetCount(count);
+        AssertMsg(!FunctionBody::Is(scope), "Scope should only be FunctionInfo or DebuggerScope, not FunctionBody");
         slots.SetScopeMetadata(scope);
+
         Var undef = scriptContext->GetLibrary()->GetUndefined();
         for (unsigned int i = 0; i < count; i++)
         {

--- a/lib/Runtime/Library/ScriptFunction.cpp
+++ b/lib/Runtime/Library/ScriptFunction.cpp
@@ -570,7 +570,7 @@ namespace Js
                 //get the function body associated with the scope
                 if(slotArray.IsFunctionScopeSlotArray())
                 {
-                    rctxInfo->EnqueueNewFunctionBodyObject(this, slotArray.GetFunctionBody(), scopePathString.GetStrValue());
+                    rctxInfo->EnqueueNewFunctionBodyObject(this, slotArray.GetFunctionInfo()->GetFunctionBody(), scopePathString.GetStrValue());
                 }
                 else
                 {

--- a/lib/Runtime/Library/StackScriptFunction.cpp
+++ b/lib/Runtime/Library/StackScriptFunction.cpp
@@ -349,7 +349,7 @@ namespace Js
                         ScopeSlots slots(slotArray);
                         if (slots.IsFunctionScopeSlotArray())
                         {
-                            FunctionBody *functionBody = slots.GetFunctionBody();
+                            FunctionBody *functionBody = slots.GetFunctionInfo()->GetFunctionBody();
                             if (this->NeedBoxFrame(functionBody))
                             {
                                 break;


### PR DESCRIPTION
The ScopeSlots structure used to hold closure-captured variables has a reference to the scope in the form of a FunctionBody*. But that FunctionBody may become a stale reference after redeferral. Replace with an immutable FunctionInfo*.