### PR TITLE
Fix for legacy test asserts

### DIFF
--- a/lib/Backend/DbCheckPostLower.cpp
+++ b/lib/Backend/DbCheckPostLower.cpp
@@ -153,7 +153,10 @@ DbCheckPostLower::Check()
                 Assert(!instr->GetSrc2() || instr->GetDst()->GetSize() == instr->GetSrc2()->GetSize() ||
                     ((EncoderMD::IsSHIFT(instr) || instr->m_opcode == Js::OpCode::BTR ||
                         instr->m_opcode == Js::OpCode::BTS ||
-                        instr->m_opcode == Js::OpCode::BT) && instr->GetSrc2()->GetSize() == 1));
+                        instr->m_opcode == Js::OpCode::BT) && instr->GetSrc2()->GetSize() == 1) ||
+                    // Is src2 is TyVar and src1 is TyInt32/TyUint32, make sure the address fits in 32 bits 
+                        (instr->GetSrc2()->GetType() == TyVar && instr->GetDst()->GetSize() == 4 &&
+                         instr->GetSrc2()->IsAddrOpnd() && Math::FitsInDWord(reinterpret_cast<int64>(instr->GetSrc2()->AsAddrOpnd()->m_address))));
 #else
                 Assert(!instr->GetSrc2() || instr->GetDst()->GetSize() == instr->GetSrc2()->GetSize() ||
                     ((EncoderMD::IsSHIFT(instr) || instr->m_opcode == Js::OpCode::BTR ||


### PR DESCRIPTION
Addresses that fit in 32-bit can get constant folded into opeq instruction
with TyVar type. Handle this in the DBCheckPostLower asserts.

Fixes #2238