### PR TITLE
swb: fixes from stressing Basics and Strings tests

### DIFF
--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -22435,7 +22435,8 @@ Lowerer::LowerSetConcatStrMultiItem(IR::Instr * instr)
     InsertAdd(false, dstLength, dstLength, srcLength, instr);
 
     dstOpnd->SetOffset(dstOpnd->GetOffset() * sizeof(Js::JavascriptString *) + Js::ConcatStringMulti::GetOffsetOfSlots());
-    this->m_lowererMD.ChangeToAssign(instr);
+
+    LowererMD::ChangeToWriteBarrierAssign(instr);
 }
 
 IR::RegOpnd *

--- a/lib/Common/DataStructures/CharacterBuffer.h
+++ b/lib/Common/DataStructures/CharacterBuffer.h
@@ -15,6 +15,7 @@ namespace JsUtil
     public:
         CharacterBuffer() : string(nullptr), len((charcount_t)-1) {}
         CharacterBuffer(T const * string, charcount_t len) : string(string), len(len) {}
+        CharacterBuffer(const CharacterBuffer& other) : string(other.string), len(other.len) {}
 
         bool operator==(CharacterBuffer const& other) const
         {
@@ -76,8 +77,8 @@ namespace JsUtil
         T const * GetBuffer() const { return string; }
         charcount_t GetLength() const { return len; }
     private:
-        T const * string;
-        charcount_t len;
+        Field(T const *) string;
+        Field(charcount_t) len;
     };
 
     template<>

--- a/lib/Common/DataStructures/RegexKey.h
+++ b/lib/Common/DataStructures/RegexKey.h
@@ -11,9 +11,9 @@ namespace UnifiedRegex
     class RegexKey
     {
     private:
-        const char16 *source;
-        int length;
-        RegexFlags flags;
+        Field(const char16 *) source;
+        Field(int) length;
+        Field(RegexFlags) flags;
 
     public:
         RegexKey() : source(nullptr), length(0), flags(static_cast<RegexFlags>(0))
@@ -26,6 +26,10 @@ namespace UnifiedRegex
             Assert(source);
             Assert(length >= 0);
         }
+
+        RegexKey(const RegexKey& other)
+            : source(other.source), length(other.length), flags(other.flags)
+        {}
 
         RegexKey &operator =(const void *const nullValue)
         {

--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -2709,7 +2709,8 @@ void ByteCodeGenerator::EmitFunctionBody(FuncInfo *funcInfo)
                     Assert(decl);
                     if (PHASE_TRACE(Js::DelayCapturePhase, funcInfo->byteCodeFunction))
                     {
-                        Output::Print(_u("--- DelayCapture: Committed symbol '%s' to slot.\n"), sym->GetName());
+                        Output::Print(_u("--- DelayCapture: Committed symbol '%s' to slot.\n"),
+                            sym->GetName().GetBuffer());
                         Output::Flush();
                     }
                     // REVIEW[ianhall]: HACK to work around this causing an error due to sym not yet being initialized

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -5181,7 +5181,8 @@ void AssignRegisters(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator)
                     {
                         if (sym->NeedsSlotAlloc(byteCodeGenerator->TopFuncInfo()))
                         {
-                            Output::Print(_u("--- DelayCapture: Delayed capturing symbol '%s' during initialization.\n"), sym->GetName());
+                            Output::Print(_u("--- DelayCapture: Delayed capturing symbol '%s' during initialization.\n"),
+                                sym->GetName().GetBuffer());
                             Output::Flush();
                         }
                     }
@@ -5242,7 +5243,8 @@ void AssignRegisters(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator)
                 {
                     if (sym->NeedsSlotAlloc(byteCodeGenerator->TopFuncInfo()))
                     {
-                        Output::Print(_u("--- DelayCapture: Delayed capturing symbol '%s'.\n"), sym->GetName());
+                        Output::Print(_u("--- DelayCapture: Delayed capturing symbol '%s'.\n"),
+                            sym->GetName().GetBuffer());
                         Output::Flush();
                     }
                 }

--- a/lib/Runtime/Language/DynamicProfileInfo.cpp
+++ b/lib/Runtime/Language/DynamicProfileInfo.cpp
@@ -1921,7 +1921,7 @@ namespace Js
 
             if (callSiteInfoCount != 0)
             {
-                callSiteInfo = RecyclerNewArrayLeaf(recycler, CallSiteInfo, callSiteInfoCount);
+                callSiteInfo = RecyclerNewArray(recycler, CallSiteInfo, callSiteInfoCount);
                 if (!reader->ReadArray(callSiteInfo, callSiteInfoCount))
                 {
                     goto Error;
@@ -2074,13 +2074,13 @@ namespace Js
     CriticalSection DynamicProfileInfo::s_csOutput;
 
     template <typename T>
-    void DynamicProfileInfo::WriteData(T data, FILE * file)
+    void DynamicProfileInfo::WriteData(const T& data, FILE * file)
     {
         fwrite(&data, sizeof(T), 1, file);
     }
 
     template <>
-    void DynamicProfileInfo::WriteData<char16 const *>(char16 const * sz, FILE * file)
+    void DynamicProfileInfo::WriteData<char16 const *>(char16 const * const& sz, FILE * file)
     {
         if (sz)
         {
@@ -2115,7 +2115,7 @@ namespace Js
     }
 
     template <>
-    void DynamicProfileInfo::WriteData<FunctionBody *>(FunctionBody * functionBody, FILE * file)
+    void DynamicProfileInfo::WriteData<FunctionBody *>(FunctionBody * const& functionBody, FILE * file)
     {
         WriteData(functionBody->GetSourceContextInfo()->sourceContextId, file);
         WriteData(functionBody->GetLocalFunctionId(), file);

--- a/lib/Runtime/Language/DynamicProfileInfo.h
+++ b/lib/Runtime/Language/DynamicProfileInfo.h
@@ -84,24 +84,24 @@ namespace Js
 
     struct CallSiteInfo
     {
-        uint16 isArgConstant : 13;
-        uint16 isConstructorCall : 1;
-        uint16 dontInline : 1;
-        uint16 isPolymorphic : 1;
-        ValueType returnType;
-        InlineCacheIndex ldFldInlineCacheId;
-        union
+        Field(uint16) isArgConstant : 13;
+        Field(uint16) isConstructorCall : 1;
+        Field(uint16) dontInline : 1;
+        Field(uint16) isPolymorphic : 1;
+        Field(ValueType) returnType;
+        Field(InlineCacheIndex) ldFldInlineCacheId;
+        union _u_type
         {
             struct
             {
-                Js::SourceId sourceId;
-                Js::LocalFunctionId functionId;
+                Field(Js::SourceId) sourceId;
+                Field(Js::LocalFunctionId) functionId;
             } functionData;
             // As of now polymorphic info is allocated only if the source Id is current
-            PolymorphicCallSiteInfo* polymorphicCallSiteInfo;
+            Field(PolymorphicCallSiteInfo*) polymorphicCallSiteInfo;
+            _u_type() {}
         } u;
     };
-
 
 
     // TODO: include ImplicitCallFlags in this structure
@@ -552,14 +552,14 @@ namespace Js
 #ifdef RUNTIME_DATA_COLLECTION
         static CriticalSection s_csOutput;
         template <typename T>
-        static void WriteData(T data, FILE * file);
+        static void WriteData(const T& data, FILE * file);
 #if defined(_MSC_VER) && !defined(__clang__)
         template <>
-        static void WriteData<char16 const *>(char16 const * sz, FILE * file);
+        static void WriteData<char16 const *>(char16 const * const& sz, FILE * file);
         template <>
-        static void WriteData<FunctionInfo *>(FunctionInfo * functionInfo, FILE * file); // Not defined, to prevent accidentally writing function info
+        static void WriteData<FunctionInfo *>(FunctionInfo * const& functionInfo, FILE * file); // Not defined, to prevent accidentally writing function info
         template <>
-        static void WriteData<FunctionBody *>(FunctionBody * functionInfo, FILE * file);
+        static void WriteData<FunctionBody *>(FunctionBody * const& functionInfo, FILE * file);
 #endif
         template <typename T>
         static void WriteArray(uint count, T * arr, FILE * file);

--- a/lib/Runtime/Language/EvalMapRecord.h
+++ b/lib/Runtime/Language/EvalMapRecord.h
@@ -53,7 +53,7 @@ namespace Js
             return GetDictionary()->TryGetValue(key, value);
         }
 
-        void Add(const TKey& key, TValue& newValue)
+        void Add(const TKey& key, const TValue& newValue)
         {
             Assert(!singleValue);
             NestedKey nestedKey;
@@ -90,11 +90,11 @@ namespace Js
         bool IsDictionaryEntry() const { return !singleValue; }
 
     private:
-        bool singleValue;
+        Field(bool) singleValue;
         union
         {
-            TValue value;
-            SecondaryDictionary* nestedMap;
+            Field(TValue) value;
+            Field(SecondaryDictionary*) nestedMap;
         };
     };
 

--- a/lib/Runtime/Library/CompoundString.cpp
+++ b/lib/Runtime/Library/CompoundString.cpp
@@ -38,6 +38,8 @@ namespace Js
         Assert(charLength <= charCapacity);
 
         js_wmemcpy_s(Chars(), charLength, Chars(buffer), charLength);
+        // SWB: buffer may contain chars or pointers. Trigger write barrier for the whole buffer.
+        ArrayWriteBarrier(Pointers(), PointerLengthFromCharLength(charLength));
     }
 
     CompoundString::Block::Block(const Block &other, const CharCount usedCharLength)
@@ -120,18 +122,14 @@ namespace Js
         return static_cast<char16 *>(buffer);
     }
 
-    #endif
-
-    inline void *const *CompoundString::Block::Pointers(const void *const buffer)
+    const Field(void*) *CompoundString::Block::Pointers(const void *const buffer)
     {
-        return static_cast<void *const *>(buffer);
+        return static_cast<const Field(void*)*>(buffer);
     }
 
-    #ifndef IsJsDiag
-
-    void **CompoundString::Block::Pointers(void *const buffer)
+    Field(void*) *CompoundString::Block::Pointers(void *const buffer)
     {
-        return static_cast<void **>(buffer);
+        return static_cast<Field(void*)*>(buffer);
     }
 
     CharCount CompoundString::Block::PointerCapacityFromCharCapacity(const CharCount charCapacity)
@@ -226,12 +224,12 @@ namespace Js
         return charCapacity;
     }
 
-    void *const *CompoundString::Block::Pointers() const
+    const Field(void*) *CompoundString::Block::Pointers() const
     {
         return Pointers(Buffer());
     }
 
-    void **CompoundString::Block::Pointers()
+    Field(void*) *CompoundString::Block::Pointers()
     {
         return Pointers(Buffer());
     }
@@ -306,7 +304,7 @@ namespace Js
         return charCapacity;
     }
 
-    void **CompoundString::BlockInfo::Pointers() const
+    Field(void*) *CompoundString::BlockInfo::Pointers() const
     {
         return Block::Pointers(buffer);
     }
@@ -384,7 +382,9 @@ namespace Js
         {
             AllocateBuffer(charCapacity, recycler);
             charLength = usedCharLength;
-            js_wmemcpy_s((char16*)PointerValue(this->buffer), charCapacity, (char16*)(buffer), usedCharLength);
+            js_wmemcpy_s(Chars(), charCapacity, (const char16*)(buffer), usedCharLength);
+            // SWB: buffer may contain chars or pointers. Trigger write barrier for the whole buffer.
+            ArrayWriteBarrier(Pointers(), PointerLength());
             return nullptr;
         }
 
@@ -405,6 +405,8 @@ namespace Js
             const CharCount charLength = CharLength();
             js_wmemcpy_s((char16*)newBuffer, charCapacity, (char16*)PointerValue(buffer), charLength);
             buffer = newBuffer;
+            // SWB: buffer may contain chars or pointers. Trigger write barrier for the whole buffer.
+            ArrayWriteBarrier(Pointers(), PointerLength());
             return nullptr;
         }
 
@@ -679,7 +681,7 @@ namespace Js
         return lastBlockInfo.CharCapacity();
     }
 
-    void **CompoundString::LastBlockPointers() const
+    Field(void*) *CompoundString::LastBlockPointers() const
     {
         return lastBlockInfo.Pointers();
     }
@@ -1074,7 +1076,7 @@ namespace Js
         CharCount remainingCharLengthToCopy = totalCharLength;
         const Block *const lastBlock = this->lastBlock;
         const Block *block = lastBlock;
-        void *const *blockPointers = LastBlockPointers();
+        Field(void*) const *blockPointers = LastBlockPointers();
         CharCount pointerIndex = LastBlockPointerLength();
         while(remainingCharLengthToCopy > directCharLength)
         {
@@ -1184,6 +1186,7 @@ namespace Js
                 {
                     Assert(remainingCharLengthToCopy >= blockCharLength);
                     remainingCharLengthToCopy -= blockCharLength;
+                    // SWB: this is copying "direct chars" and there should be no pointers here. No write barrier needed.
                     js_wmemcpy_s(&buffer[remainingCharLengthToCopy], blockCharLength, blockChars, blockCharLength);
                     if(remainingCharLengthToCopy == 0)
                         break;

--- a/lib/Runtime/Library/CompoundString.h
+++ b/lib/Runtime/Library/CompoundString.h
@@ -133,8 +133,8 @@ namespace Js
         public:
             static const char16 *Chars(const void *const buffer);
             static char16 *Chars(void *const buffer);
-            static void *const *Pointers(const void *const buffer);
-            static void **Pointers(void *const buffer);
+            static const Field(void*) *Pointers(const void *const buffer);
+            static Field(void*) *Pointers(void *const buffer);
             static CharCount PointerCapacityFromCharCapacity(const CharCount charCapacity);
             static CharCount CharCapacityFromPointerCapacity(const CharCount pointerCapacity);
             static CharCount PointerLengthFromCharLength(const CharCount charLength);
@@ -157,8 +157,8 @@ namespace Js
             CharCount CharCapacity() const;
 
         public:
-            void *const *Pointers() const;
-            void **Pointers();
+            const Field(void*) *Pointers() const;
+            Field(void*) *Pointers();
             CharCount PointerLength() const;
             CharCount PointerCapacity() const;
 
@@ -197,7 +197,7 @@ namespace Js
             CharCount CharCapacity() const;
 
         public:
-            void **Pointers() const;
+            Field(void*) *Pointers() const;
             CharCount PointerLength() const;
             void SetPointerLength(const CharCount pointerLength);
             CharCount PointerCapacity() const;
@@ -268,7 +268,7 @@ namespace Js
             CharCount LastBlockCharCapacity() const;
 
         private:
-            void **LastBlockPointers();
+            Field(void*) *LastBlockPointers();
             CharCount LastBlockPointerLength() const;
             void SetLastBlockPointerLength(const CharCount pointerLength);
             CharCount LastBlockPointerCapacity() const;
@@ -366,7 +366,7 @@ namespace Js
         CharCount LastBlockCharCapacity() const;
 
     private:
-        void **LastBlockPointers() const;
+        Field(void*) *LastBlockPointers() const;
         CharCount LastBlockPointerLength() const;
         void SetLastBlockPointerLength(const CharCount pointerLength);
         CharCount LastBlockPointerCapacity() const;
@@ -538,7 +538,7 @@ namespace Js
     }
 
     template<CharCount MinimumCharCapacity>
-    void **CompoundString::Builder<MinimumCharCapacity>::LastBlockPointers()
+    Field(void*) *CompoundString::Builder<MinimumCharCapacity>::LastBlockPointers()
     {
         return Block::Pointers(buffer);
     }
@@ -957,7 +957,7 @@ namespace Js
         const CharCount appendPointerLength = 2 + !!packedSubstringInfo2;
         if(blockPointerLength < toString->LastBlockPointerCapacity() - (appendPointerLength - 1))
         {
-            void * *const pointers = toString->LastBlockPointers();
+            Field(void*)* pointers = toString->LastBlockPointers();
             pointers[blockPointerLength] = GetImmutableOrScriptUnreferencedString(s);
             if(packedSubstringInfo2)
                 pointers[blockPointerLength + 1] = packedSubstringInfo2;


### PR DESCRIPTION
Lower.cpp: needs WB from JIT set string item slots.

Added bunch of missing annotations that may contain GC pointers.

CompoundString: block buffer may contain chars or pointers. Ammended to
handle pointers correctly.
