### PR TITLE
AutoRestoreFunctionInfo does not handle throw during initialization

### DIFF
--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -2138,24 +2138,24 @@ namespace Js
         public:
             AutoRestoreFunctionInfo(ParseableFunctionInfo *pfi) : pfi(pfi), funcBody(nullptr) {}
             ~AutoRestoreFunctionInfo() {
-                if (this->funcBody && this->funcBody->GetFunctionInfo()->GetFunctionProxy() == this->funcBody)
+                if (this->pfi != nullptr && this->pfi->GetFunctionInfo()->GetFunctionProxy() != this->pfi)
                 {
-                    FunctionInfo *functionInfo = funcBody->GetFunctionInfo();
+                    FunctionInfo *functionInfo = this->pfi->functionInfo;
                     functionInfo->SetAttributes(
                         (FunctionInfo::Attributes)(functionInfo->GetAttributes() | FunctionInfo::Attributes::DeferredParse));
                     functionInfo->SetFunctionProxy(this->pfi);
                     functionInfo->SetOriginalEntryPoint(DefaultEntryThunk);
                 }
-                Assert(this->pfi == nullptr || 
-                       (this->pfi->GetFunctionInfo()->GetFunctionProxy() == this->pfi && !this->pfi->IsFunctionBody()));
+
+                Assert(this->pfi == nullptr || (this->pfi->GetFunctionInfo()->GetFunctionProxy() == this->pfi && !this->pfi->IsFunctionBody()));
             }
             void Clear() { pfi = nullptr; funcBody = nullptr; }
-            
+
             ParseableFunctionInfo * pfi;
             FunctionBody          * funcBody;
         } autoRestoreFunctionInfo(this);
 
-        // If m_hasBeenParsed = true, one of the following things happened things happened:
+        // If m_hasBeenParsed = true, one of the following things happened:
         // - We had multiple function objects which were all defer-parsed, but with the same function body and one of them
         //   got the body to be parsed before another was called
         // - We are in debug mode and had our thunks switched to DeferParseThunk


### PR DESCRIPTION
Fixes OS 10106951.

Paul's recent change in #2149 misses a case where we throw during creation of the new function body. We then assert because we did not restore the original function body.

Fixed by detecting the case where the function has not been parsed and we did not finish creating the new function body, using the ParsableFunctionInfo to restore the original state.
