### PR TITLE
run_build.ps1: Refactor and fix some bugs with VSO pogo builds of ChakraCore.

### DIFF
--- a/Build/scripts/compose_build.ps1
+++ b/Build/scripts/compose_build.ps1
@@ -39,15 +39,15 @@ $changeInfo = (Get-Content $changeJson) -join "`n" | ConvertFrom-Json
 # between the partially-composed root and the metadata directories.
 # Exclude change.json and build.json, the results of a previous composition already in the root.
 Get-ChildItem -Path $rootPath "*.json" -Recurse `
-    | ? { -not ($_.Name -in @("change.json", "build.json")) } `
-    | % { Move-Item -Verbose -Force -Path $_.FullName -Destination $rootPath }
+    | Where-Object { -not ($_.Name -in @("change.json", "build.json")) } `
+    | ForEach-Object { Move-Item -Verbose -Force -Path $_.FullName -Destination $rootPath }
 
 # Determine the overall build status. Mark the build as "passed" until "failed" is encountered.
 $overallBuildStatus = "passed"
 
 $files = Get-ChildItem -Path $rootPath "*.json" -Recurse `
-    | ? { -not ($_.Name -in @("change.json", "build.json")) } `
-    | % { $_.FullName }
+    | Where-Object { -not ($_.Name -in @("change.json", "build.json")) } `
+    | ForEach-Object { $_.FullName }
 $builds = New-Object System.Collections.ArrayList
 foreach ($file in $files) {
     $json = (Get-Content $file) -join "`n" | ConvertFrom-Json

--- a/Build/scripts/finalize_build.ps1
+++ b/Build/scripts/finalize_build.ps1
@@ -23,11 +23,13 @@ param (
     $corePathSegment = "" # e.g. "core"
 )
 
-$sourcesDir = $Env:BUILD_SOURCESDIRECTORY
-$coreSourcesDir = Join-Path $sourcesDir $corePathSegment
+. $PSScriptRoot\pre_post_util.ps1
 
-$OuterScriptRoot = $PSScriptRoot
-. "$PSScriptRoot\pre_post_util.ps1"
+$sourcesDir, $_, $_, $_ = `
+    ComputePaths `
+        -arch $arch -flavor $flavor -subtype $subtype -OuterScriptRoot $PSScriptRoot
+
+$coreSourcesDir = Join-Path $sourcesDir $corePathSegment
 
 $buildName = ConstructBuildName -arch $arch -flavor $flavor -subtype $subtype
 
@@ -118,7 +120,7 @@ Copy-Item -Verbose -Force $buildFlavorJsonFile $metadataDir
 
 # Search for *.nuspec files and copy them to $metadataDir
 Get-ChildItem -Path (Join-Path $sourcesDir "Build") "*.nuspec" `
-    | % { Copy-Item -Verbose -Force $_.FullName $metadataDir }
+    | ForEach-Object { Copy-Item -Verbose -Force $_.FullName $metadataDir }
 
 #
 # Copy POGO directory if present for this build

--- a/Build/scripts/pre_build.ps1
+++ b/Build/scripts/pre_build.ps1
@@ -45,20 +45,25 @@ param (
     [string]$oauth
 )
 
-$OuterScriptRoot = $PSScriptRoot # Used in pre_post_util.ps1
-. "$PSScriptRoot\pre_post_util.ps1"
+. $PSScriptRoot\pre_post_util.ps1
 
-if (($logFile -eq "") -and (Test-Path Env:\TF_BUILD_BINARIESDIRECTORY)) {
-    if (-not(Test-Path -Path "${Env:TF_BUILD_BINARIESDIRECTORY}\logs")) {
-        $dummy = New-Item -Path "${Env:TF_BUILD_BINARIESDIRECTORY}\logs" -ItemType Directory -Force
+$srcpath, $buildRoot, $objpath, $binpath = `
+    ComputePaths `
+        -arch $arch -flavor $flavor -subtype $subtype -OuterScriptRoot $PSScriptRoot `
+        -srcpath $srcpath -buildRoot $buildRoot -objpath $objpath -binpath $binpath
+
+WriteCommonArguments
+
+$buildName = ConstructBuildName $arch $flavor $subtype
+if (($logFile -eq "") -and (Test-Path $buildRoot)) {
+    if (-not(Test-Path -Path "${buildRoot}\logs")) {
+        $dummy = New-Item -Path "${buildRoot}\logs" -ItemType Directory -Force
     }
-    $logFile = "${Env:TF_BUILD_BINARIESDIRECTORY}\logs\pre_build.${Env:BuildName}.log"
+    $logFile = "${buildRoot}\logs\pre_build.${buildName}.log"
     if (Test-Path -Path $logFile) {
         Remove-Item $logFile -Force
     }
 }
-
-WriteCommonArguments
 
 #
 # Create packages.config files
@@ -72,7 +77,7 @@ $packagesConfigFileText = @"
 "@
 
 $packagesFiles = Get-ChildItem -Path $Env:TF_BUILD_SOURCESDIRECTORY *.vcxproj -Recurse `
-    | % { Join-Path $_.DirectoryName "packages.config" }
+    | ForEach-Object { Join-Path $_.DirectoryName "packages.config" }
 
 foreach ($file in $packagesFiles) {
     if (-not (Test-Path $file)) {
@@ -91,7 +96,7 @@ if (Test-Path Env:\TF_BUILD_SOURCEGETVERSION)
 
     $CoreHash = ""
     if (Test-Path $corePath) {
-        $CoreHash = iex "$gitExe rev-parse ${commitHash}:core"
+        $CoreHash = Invoke-Expression "$gitExe rev-parse ${commitHash}:core"
         if (-not $?) {
             $CoreHash = ""
         }
@@ -112,7 +117,7 @@ if (Test-Path Env:\TF_BUILD_SOURCEGETVERSION)
 
     # commit message
     $command = "$gitExe log -1 --name-only -p $commitHash"
-    $CommitMessageLines = iex $command
+    $CommitMessageLines = Invoke-Expression $command
     $CommitMessage = $CommitMessageLines -join "`r`n"
 
     $changeTextFile = Join-Path -Path $outputDir -ChildPath "change.txt"
@@ -183,7 +188,7 @@ $CommitMessage
 </Project>
 "@
 
-    $propsFileContent = $propsFileTemplate -f $binpath, $objpath, $buildPushIdPart1, $buildPushIdPart2, $buildCommit, $buildDate
+    $propsFileContent = $propsFileTemplate -f $buildRoot, $objpath, $buildPushIdPart1, $buildPushIdPart2, $buildCommit, $buildDate
 
     Write-Output "-----"
     Write-Output $propsFile

--- a/Build/scripts/pre_post_util.ps1
+++ b/Build/scripts/pre_post_util.ps1
@@ -3,10 +3,11 @@
 # Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 #-------------------------------------------------------------------------------------------------------
 
-. "$PSScriptRoot\util.ps1"
+. $PSScriptRoot\util.ps1
 
 function WriteCommonArguments() {
     WriteMessage "  Source Path: $srcpath"
+    WriteMessage "   Build Root: $buildRoot"
     WriteMessage "  Object Path: $objpath"
     WriteMessage "Binaries Path: $binpath"
 }
@@ -14,7 +15,7 @@ function WriteCommonArguments() {
 function GetVersionField($fieldname) {
     $gitExe = GetGitPath
     $query = "#define ${fieldname} (\d+)"
-    $line = (iex "${gitExe} grep -P ""${query}"" :/")
+    $line = (Invoke-Expression "${gitExe} grep -P ""${query}"" :/")
     $matches = $line | Select-String $query
     if ($matches) {
         return $matches[0].Matches.Groups[1].Value
@@ -25,7 +26,8 @@ function GetVersionField($fieldname) {
 function GetBuildInfo($oauth, $commitHash) {
     # Get the git remote path and construct the REST API URI
     $gitExe = GetGitPath
-    $remote = (iex "$gitExe remote -v" | ? { $_.contains("_git") })[0].split()[1].replace("_git", "_apis/git/repositories")
+    $remote = (Invoke-Expression "$gitExe remote -v" `
+        | Where-Object { $_.contains("_git") })[0].split()[1].replace("_git", "_apis/git/repositories")
     $remote = $remote.replace("mshttps", "https")
 
     # Get the pushId and push date time to use that for build number and build date time
@@ -46,7 +48,25 @@ function GetBuildPushId($info) {
     return @($buildPushId, $buildPushIdPart1, $buildPushIdPart2, $buildPushIdString)
 }
 
+function EnsureVariables($functionName, $arch, $flavor, $OuterScriptRoot) {
+    if (("$arch" -eq "") -or ("$flavor" -eq "") -or ("$OuterScriptRoot" -eq ""))
+    {
+        WriteErrorMessage @"
+
+        ${functionName}: Required variables not set:
+            `$arch = $arch
+            `$flavor = $flavor
+            `$OuterScriptRoot = $OuterScriptRoot
+
+"@
+
+        throw "Cannot continue: ${functionName}: required variables not set."
+    }
+}
+
 function ConstructBuildName($arch, $flavor, $subtype) {
+    EnsureVariables "ConstructBuildName" $arch $flavor "(OuterScriptRoot not needed)"
+
     if ($subtype -eq "codecoverage") {
         # TODO eliminate tools' dependency on this particular formatting exception
         # Normalize the $BuildName of even if the $BuildType is e.g. x64_test_codecoverage
@@ -58,22 +78,12 @@ function ConstructBuildName($arch, $flavor, $subtype) {
     }
 }
 
-# Compute paths
-
-if (("$arch" -eq "") -or ("$flavor" -eq "") -or ("$OuterScriptRoot" -eq ""))
-{
-    WriteErrorMessage @"
-
-    Required variables not set before script was included:
-        `$arch = $arch
-        `$flavor = $flavor
-        `$OuterScriptRoot = $OuterScriptRoot
-
-"@
-
-    throw "Cannot continue - required variables not set."
+function ComputePaths($arch, $flavor, $subtype, $OuterScriptRoot, $srcpath = "", $buildRoot = "", $objpath = "", $binpath = "") {
+    EnsureVariables "ComputePaths" $arch $flavor $OuterScriptRoot
+    $buildName = ConstructBuildName $arch $flavor $subtype
+    $srcpath = UseValueOrDefault $srcpath "$Env:TF_BUILD_SOURCESDIRECTORY" (Resolve-Path "${OuterScriptRoot}\..\..")
+    $buildRoot = UseValueOrDefault $buildRoot "$Env:BinariesDirectory" "$Env:TF_BUILD_BINARIESDIRECTORY" (Join-Path $srcpath "Build\VcBuild")
+    $objpath = UseValueOrDefault $objpath "$Env:TF_BUILD_BUILDDIRECTORY" (Join-Path $buildRoot "obj\${buildName}")
+    $binpath = Join-Path $buildRoot "bin\${buildName}"
+    return @($srcpath, $buildRoot, $objpath, $binpath)
 }
-
-$srcpath = UseValueOrDefault $srcpath "$env:TF_BUILD_SOURCESDIRECTORY" (Resolve-Path "$OuterScriptRoot\..\..")
-$objpath = UseValueOrDefault $objpath "$env:TF_BUILD_BUILDDIRECTORY" "${srcpath}\Build\VcBuild\obj\${arch}_${flavor}"
-$binpath = UseValueOrDefault $binpath "$env:TF_BUILD_BINARIESDIRECTORY" "${srcpath}\Build\VcBuild"

--- a/Build/scripts/run_build.ps1
+++ b/Build/scripts/run_build.ps1
@@ -21,7 +21,7 @@ param (
 
     [switch]$clean,
 
-    [string]$binDir = "", # will be inferred if not provided.
+    [string]$buildRoot = "", # will be inferred if not provided
     [string]$buildlogsSubdir = "buildlogs",
 
     # assume NuGet is on the path, otherwise the caller must specify an explicit path
@@ -44,20 +44,21 @@ param (
     [string]$binaryName = "ch.exe"
 )
 
-#
-# Configure logging
-#
-
-$OuterScriptRoot = $PSScriptRoot
 . $PSScriptRoot\pre_post_util.ps1
 . $PSScriptRoot\locate_msbuild.ps1
 
+# TODO (doilij) update all scripts that use pre_post_util.ps1 and rely on ComputeProjectPaths
+$_, $buildRoot, $_, $binpath = `
+    ComputePaths `
+        -arch $arch -flavor $flavor -subtype $subtype -OuterScriptRoot $PSScriptRoot `
+        -buildRoot $buildRoot -binpath $binpath
+
 $buildName = ConstructBuildName -arch $arch -flavor $flavor -subtype $subtype
 
-if (($logFile -eq "") -and (Test-Path Env:\TF_BUILD_BINARIESDIRECTORY)) {
-    $logFile = "${Env:TF_BUILD_BINARIESDIRECTORY}\logs\run_build.${Env:BuildName}.log"
-}
+$buildlogsPath = Join-Path $buildRoot $buildlogsSubdir
+$logFile = UseValueOrDefault $logFile (Join-Path $buildRoot "logs\run_build.${buildName}.log")
 
+# Clear the log file
 if (($logFile -ne "") -and (Test-Path $logFile)) {
     Remove-Item $logFile -Force
 }
@@ -66,7 +67,10 @@ if (($logFile -ne "") -and (Test-Path $logFile)) {
 # NuGet restore
 #
 
-if (-not (Get-Command $nugetExe -ErrorAction SilentlyContinue)) {
+# To support both local builds where NuGet's location is known,
+# and VSO builds where the location is not known and which use a NuGet restore task instead:
+# Run `nuget restore` IFF $nugetExe exists.
+if (Get-Command $nugetExe -ErrorAction SilentlyContinue) {
     ExecuteCommand "& $nugetExe restore $solutionFile -NonInteractive"
 }
 
@@ -80,21 +84,18 @@ if (-not $msbuildExe) {
     exit 1
 }
 
-$binDir = UseValueOrDefault "$binDir" "${Env:BinariesDirectory}" "${Env:BUILD_SOURCESDIRECTORY}\Build\VcBuild"
-$buildlogsPath = Join-Path $binDir $buildlogsSubdir
-
 $skipPogo = $skipPogo -or (Test-Path Env:\SKIP_POGO)
 
-# if $binpath is not set or if it is an invalid path, then infer it
-if ((-not $binpath) -or (-not (Test-Path $binpath))) {
-    $binpath = Join-Path $binDir "bin\${buildName}"
+# If $binpath is not set, then infer it. A missing path is okay because it will be created.
+if (-not $binpath) {
+    $binpath = Join-Path $buildRoot "bin\${buildName}"
 }
 
 $defaultParams = "$solutionFile /nologo /m /nr:false /p:platform=`"${arch}`" /p:configuration=`"${flavor}`""
 $loggingParams = @(
-    "/fl1 `"/flp1:logfile=${buildlogsPath}\build.${Env:BuildName}.log;verbosity=normal`"",
-    "/fl2 `"/flp2:logfile=${buildlogsPath}\build.${Env:BuildName}.err;errorsonly`"",
-    "/fl3 `"/flp3:logfile=${buildlogsPath}\build.${Env:BuildName}.wrn;warningsonly`"",
+    "/fl1 `"/flp1:logfile=${buildlogsPath}\build.${buildName}.log;verbosity=normal`"",
+    "/fl2 `"/flp2:logfile=${buildlogsPath}\build.${buildName}.err;errorsonly`"",
+    "/fl3 `"/flp3:logfile=${buildlogsPath}\build.${buildName}.wrn;warningsonly`"",
     "/verbosity:normal"
     ) -join " "
 
@@ -154,8 +155,8 @@ if ($subtype -eq "pogo") {
 if (("$binpath" -ne "") -and (Test-Path $binpath)) {
     # remove *.pgc, *.pgd, and pgort*
     Get-ChildItem -Recurse -Path $binpath "*" `
-        | ? { $_.Name -match "(.*\.pg[cd]|pgort.*)" } `
-        | % { Remove-Item -Force $_.FullName }
+        | Where-Object { $_.Name -match "(.*\.pg[cd]|pgort.*)" } `
+        | ForEach-Object { Remove-Item -Force $_.FullName }
 }
 
 exit $global:lastexitcode

--- a/Build/scripts/util.ps1
+++ b/Build/scripts/util.ps1
@@ -27,7 +27,7 @@ function GetGitPath() {
 
 function GetRepoRoot() {
     $gitExe = GetGitPath
-    return iex "$gitExe rev-parse --show-toplevel"
+    return Invoke-Expression "$gitExe rev-parse --show-toplevel"
 }
 
 function WriteMessage($str) {


### PR DESCRIPTION
* Fix inverted logic for running NuGet.exe.
* Fix incorrect $binpath fallback location.
* Refactor build scripts: rename confusingly-named variables, information hiding.