### PR TITLE
WASM - misc fixes

### DIFF
--- a/lib/Runtime/Language/AsmJsUtils.cpp
+++ b/lib/Runtime/Language/AsmJsUtils.cpp
@@ -238,7 +238,7 @@ namespace Js
                 if (!allowTestInputs)
 #endif
                 {
-                    JavascriptError::ThrowWebAssemblyRuntimeError(scriptContext, WASMERR_InvalidTypeConversion);
+                    JavascriptError::ThrowTypeError(scriptContext, WASMERR_InvalidTypeConversion);
                 }
 
 #if ENABLE_DEBUG_CONFIG_OPTIONS

--- a/lib/Runtime/Library/WebAssemblyInstance.cpp
+++ b/lib/Runtime/Library/WebAssemblyInstance.cpp
@@ -22,25 +22,14 @@ Var GetImportVariable(Wasm::WasmImport* wi, ScriptContext* ctx, Var ffi)
 
     const char16* name = wi->importName;
     uint32 nameLen = wi->importNameLen;
-    Var prop = nullptr;
-    if (nameLen > 0)
-    {
-        PropertyRecord const * propertyRecord = nullptr;
-        ctx->GetOrAddPropertyRecord(name, nameLen, &propertyRecord);
+    PropertyRecord const * propertyRecord = nullptr;
+    ctx->GetOrAddPropertyRecord(name, nameLen, &propertyRecord);
 
-        if (!RecyclableObject::Is(modProp))
-        {
-            JavascriptError::ThrowTypeError(ctx, WASMERR_InvalidImport);
-        }
-        prop = JavascriptOperators::OP_GetProperty(modProp, propertyRecord->GetPropertyId(), ctx);
-    }
-    else
+    if (!RecyclableObject::Is(modProp))
     {
-        // Use only first level if name is missing
-        prop = modProp;
+        JavascriptError::ThrowTypeError(ctx, WASMERR_InvalidImport);
     }
-
-    return prop;
+    return JavascriptOperators::OP_GetProperty(modProp, propertyRecord->GetPropertyId(), ctx);
 }
 
 WebAssemblyInstance::WebAssemblyInstance(WebAssemblyModule * wasmModule, DynamicType * type) :

--- a/test/wasm/api.js
+++ b/test/wasm/api.js
@@ -15,13 +15,13 @@ const imports = {
     g1: 45,
     g2: -8,
   },
-  table: new WebAssembly.Table({element: "anyfunc", initial: 30, maximum: 100})
+  table: {"": new WebAssembly.Table({element: "anyfunc", initial: 30, maximum: 100})}
 };
 
 function overrideImports(overrides) {
   return {
     test: Object.assign({}, imports.test, overrides),
-    table: overrides.table || imports.table
+    table: overrides.table ? {"":overrides.table} : imports.table
   };
 }
 


### PR DESCRIPTION
Fix an error type when trying to convert int64 from Js value. https://github.com/WebAssembly/design/blob/master/JS.md#towebassemblyvalue

I don't know when it was changed, but there is no longer a concept of default namespace for imports https://github.com/WebAssembly/design/blob/master/JS.md#webassemblyinstance-constructor. The steps shows that we should always perform 2 GetProperty to get teh import

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/2257)
<!-- Reviewable:end -->
