### PR TITLE
a bunch of fix for write barrier

### DIFF
--- a/lib/Backend/CodeGenNumberAllocator.cpp
+++ b/lib/Backend/CodeGenNumberAllocator.cpp
@@ -221,6 +221,12 @@ CodeGenNumberThreadAllocator::Integrate()
         {
             Js::Throw::OutOfMemory();
         }
+#if DBG
+        if (CONFIG_FLAG(ForceSoftwareWriteBarrier) && CONFIG_FLAG(RecyclerVerifyMark))
+        {
+            Recycler::WBSetBits(record.blockAddress, BlockSize / sizeof(void*));
+        }
+#endif
         pendingIntegrationChunkBlock.RemoveHead(&NoThrowHeapAllocator::Instance);
     }
 #ifdef TRACK_ALLOC

--- a/lib/Backend/CodeGenNumberAllocator.h
+++ b/lib/Backend/CodeGenNumberAllocator.h
@@ -55,8 +55,8 @@
 struct CodeGenNumberChunk
 {
     static int const MaxNumberCount = 3;
-    Js::JavascriptNumber * numbers[MaxNumberCount];
-    CodeGenNumberChunk * next;
+    Field(Js::JavascriptNumber*) numbers[MaxNumberCount];
+    Field(CodeGenNumberChunk*) next;
 };
 CompileAssert(
     sizeof(CodeGenNumberChunk) == HeapConstants::ObjectGranularity ||

--- a/lib/Backend/Func.cpp
+++ b/lib/Backend/Func.cpp
@@ -143,6 +143,7 @@ Func::Func(JitArenaAllocator *alloc, JITTimeWorkItem * workItem,
     , m_forInEnumeratorArrayOffset(-1)
     , argInsCount(0)
     , m_globalObjTypeSpecFldInfoArray(nullptr)
+    , m_lowerer(nullptr)
 {
 
     Assert(this->IsInlined() == !!runtimeInfo);

--- a/lib/Backend/Func.h
+++ b/lib/Backend/Func.h
@@ -996,6 +996,10 @@ private:
 #if DBG
     VtableHashMap * vtableMap;
 #endif
+#ifdef RECYCLER_WRITE_BARRIER_JIT
+public:
+    Lowerer* m_lowerer;
+#endif
 };
 
 class AutoCodeGenPhase

--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -16744,12 +16744,12 @@ Lowerer::GenerateFastStElemI(IR::Instr *& stElem, bool *instrIsInHelperBlockRef)
                     InsertConvertFloat64ToFloat32(reg, regSrc, stElem);
 
                     // MOVSS indirOpnd, reg
-                    InsertMove(indirOpnd, reg, stElem);
+                    InsertMove(indirOpnd, reg, stElem, false);
                 }
                 else
                 {
                     // MOVSD indirOpnd, regSrc
-                    InsertMove(indirOpnd, regSrc, stElem);
+                    InsertMove(indirOpnd, regSrc, stElem, false);
                 }
                 emitBailout = true;
             }

--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -101,34 +101,6 @@ Lowerer::Lower()
 
     this->LowerRange(m_func->m_headInstr, m_func->m_tailInstr, defaultDoFastPath, loopFastPath);
 
-#if DBG
-    // TODO: (leish)(swb) implement for arm
-#if defined(_M_IX86) || defined(_M_AMD64)
-    if (CONFIG_FLAG(ForceSoftwareWriteBarrier) && CONFIG_FLAG(RecyclerVerifyMark))
-    {
-        // find out all write barrier setting instr, call Recycler::WBSetBit for verification purpose
-        // should do this in LowererMD::GenerateWriteBarrier, however, can't insert call instruction there
-        FOREACH_INSTR_EDITING(instr, instrNext, m_func->m_headInstr)
-        if (instr->m_src1 && instr->m_src1->IsAddrOpnd())
-        {
-            IR::AddrOpnd* addrOpnd = instr->m_src1->AsAddrOpnd();
-            if (addrOpnd->GetAddrOpndKind() == IR::AddrOpndKindWriteBarrierCardTable)
-            {
-                auto& leaInstr = instr->m_prev->m_prev;
-                auto& shrInstr = instr->m_prev;
-                Assert(leaInstr->m_opcode == Js::OpCode::LEA);
-                Assert(shrInstr->m_opcode == Js::OpCode::SHR);
-                m_lowererMD.LoadHelperArgument(shrInstr, leaInstr->m_dst);
-                IR::Instr* instrCall = IR::Instr::New(Js::OpCode::Call, m_func);
-                shrInstr->InsertBefore(instrCall);
-                m_lowererMD.ChangeToHelperCall(instrCall, IR::HelperWriteBarrierSetVerifyBit);
-            }
-        }
-        NEXT_INSTR_EDITING
-    }
-#endif
-#endif
-
     this->m_func->ClearCloneMap();
 
     if (m_func->HasAnyStackNestedFunc())
@@ -10296,7 +10268,7 @@ Lowerer::LowerStSlot(IR::Instr *instr)
     }
     else
     {
-        m_lowererMD.ChangeToWriteBarrierAssign(instr);
+        m_lowererMD.ChangeToWriteBarrierAssign(instr, this->m_func);
     }
 
     return instr;
@@ -10568,7 +10540,7 @@ Lowerer::LowerStElemC(IR::Instr * stElem)
     IntConstType offset = base + (value << indirScale);
     Assert(Math::FitsInDWord(offset));
     indirOpnd->SetOffset((int32)offset);
-    m_lowererMD.ChangeToWriteBarrierAssign(stElem);
+    m_lowererMD.ChangeToWriteBarrierAssign(stElem, this->m_func);
 
     return instrPrev;
 }
@@ -14540,7 +14512,7 @@ IR::Instr *Lowerer::InsertMove(IR::Opnd *dst, IR::Opnd *src, IR::Instr *const in
 
     insertBeforeInstr->InsertBefore(instr);
 
-    LowererMD::ChangeToWriteBarrierAssign(instr);
+    LowererMD::ChangeToWriteBarrierAssign(instr, func);
 
     return instr;
 }
@@ -22436,7 +22408,7 @@ Lowerer::LowerSetConcatStrMultiItem(IR::Instr * instr)
 
     dstOpnd->SetOffset(dstOpnd->GetOffset() * sizeof(Js::JavascriptString *) + Js::ConcatStringMulti::GetOffsetOfSlots());
 
-    LowererMD::ChangeToWriteBarrierAssign(instr);
+    LowererMD::ChangeToWriteBarrierAssign(instr, func);
 }
 
 IR::RegOpnd *

--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -104,7 +104,7 @@ Lowerer::Lower()
 #if DBG
     // TODO: (leish)(swb) implement for arm
 #if defined(_M_IX86) || defined(_M_AMD64)
-    if (CONFIG_FLAG(ForceSoftwareWriteBarrier))
+    if (CONFIG_FLAG(ForceSoftwareWriteBarrier) && CONFIG_FLAG(RecyclerVerifyMark))
     {
         // find out all write barrier setting instr, call Recycler::WBSetBit for verification purpose
         // should do this in LowererMD::GenerateWriteBarrier, however, can't insert call instruction there

--- a/lib/Backend/Lower.h
+++ b/lib/Backend/Lower.h
@@ -57,6 +57,11 @@ public:
         , m_int64RegPairMap(nullptr)
 #endif
     {
+        m_func->m_lowerer = this;
+    }
+    ~Lowerer()
+    {
+        m_func->m_lowerer = nullptr;
     }
 
     void Lower();

--- a/lib/Backend/Lower.h
+++ b/lib/Backend/Lower.h
@@ -331,7 +331,7 @@ private:
 public:
     static IR::LabelInstr *     InsertLabel(const bool isHelper, IR::Instr *const insertBeforeInstr);
 
-    static IR::Instr *          InsertMove(IR::Opnd *dst, IR::Opnd *src, IR::Instr *const insertBeforeInstr, bool generateWriteBarrier = false);
+    static IR::Instr *          InsertMove(IR::Opnd *dst, IR::Opnd *src, IR::Instr *const insertBeforeInstr, bool generateWriteBarrier = true);
     static IR::Instr *          InsertMoveWithBarrier(IR::Opnd *dst, IR::Opnd *src, IR::Instr *const insertBeforeInstr);
 #if _M_X64
     static IR::Instr *          InsertMoveBitCast(IR::Opnd *const dst, IR::Opnd *const src1, IR::Instr *const insertBeforeInstr);

--- a/lib/Backend/LowerMDShared.cpp
+++ b/lib/Backend/LowerMDShared.cpp
@@ -4751,7 +4751,9 @@ LowererMD::ChangeToWriteBarrierAssign(IR::Instr * assignInstr, const Func* func)
 
     // Now insert write barrier if necessary
 #ifdef RECYCLER_WRITE_BARRIER_JIT
-    if (isPossibleBarrieredDest && assignInstr->GetSrc1()->IsWriteBarrierTriggerableValue())
+    if (isPossibleBarrieredDest 
+        && assignInstr->m_opcode == Js::OpCode::MOV // ignore SSE instructions like MOVSD
+        && assignInstr->GetSrc1()->IsWriteBarrierTriggerableValue())
     {
         func->GetTopFunc()->m_lowerer->GetLowererMD()->GenerateWriteBarrier(assignInstr);
     }

--- a/lib/Backend/LowerMDShared.cpp
+++ b/lib/Backend/LowerMDShared.cpp
@@ -4746,7 +4746,7 @@ LowererMD::GenerateWriteBarrierAssign(IR::MemRefOpnd * opndDst, IR::Opnd * opndS
         IR::Instr * movInstr = IR::Instr::New(Js::OpCode::MOV, cardTableEntry, IR::IntConstOpnd::New(1, TyInt8, insertBeforeInstr->m_func), insertBeforeInstr->m_func);
         insertBeforeInstr->InsertBefore(movInstr);
 #if DBG
-        if (CONFIG_FLAG(ForceSoftwareWriteBarrier))
+        if (CONFIG_FLAG(ForceSoftwareWriteBarrier) && CONFIG_FLAG(RecyclerVerifyMark))
         {
             this->LoadHelperArgument(insertBeforeInstr, opndDst);
             IR::Instr* instrCall = IR::Instr::New(Js::OpCode::Call, m_func);

--- a/lib/Backend/LowerMDShared.h
+++ b/lib/Backend/LowerMDShared.h
@@ -82,7 +82,7 @@ public:
             }
 #endif
             IR::Instr *     ChangeToHelperCallMem(IR::Instr * instr, IR::JnHelperMethod helperMethod);
-    static  IR::Instr *     CreateAssign(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsertPt);
+    static  IR::Instr *     CreateAssign(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsertPt, bool generateWriteBarrier = true);
 
     static  IR::Instr *     ChangeToAssign(IR::Instr * instr);
     static  IR::Instr *     ChangeToAssign(IR::Instr * instr, IRType type);

--- a/lib/Backend/LowerMDShared.h
+++ b/lib/Backend/LowerMDShared.h
@@ -305,7 +305,7 @@ public:
 
             void GenerateWriteBarrierAssign(IR::IndirOpnd * opndDst, IR::Opnd * opndSrc, IR::Instr * insertBeforeInstr);
             void GenerateWriteBarrierAssign(IR::MemRefOpnd * opndDst, IR::Opnd * opndSrc, IR::Instr * insertBeforeInstr);
-            static void ChangeToWriteBarrierAssign(IR::Instr * assignInstr);
+            static void ChangeToWriteBarrierAssign(IR::Instr * assignInstr, const Func* func);
 
             static IR::BranchInstr * GenerateLocalInlineCacheCheck(IR::Instr * instrLdSt, IR::RegOpnd * opndType, IR::RegOpnd * opndInlineCache, IR::LabelInstr * labelNext, bool checkTypeWithoutProperty = false);
             static IR::BranchInstr * GenerateProtoInlineCacheCheck(IR::Instr * instrLdSt, IR::RegOpnd * opndType, IR::RegOpnd * opndInlineCache, IR::LabelInstr * labelNext);
@@ -398,7 +398,7 @@ private:
 
     IR::LabelInstr*   EmitLoadFloatCommon(IR::Opnd *dst, IR::Opnd *src, IR::Instr *insertInstr, bool needLabelHelper);
 #ifdef RECYCLER_WRITE_BARRIER
-    static IR::Instr* GenerateWriteBarrier(IR::Instr * assignInstr);
+    IR::Instr* GenerateWriteBarrier(IR::Instr * assignInstr);
 #endif
 
     // Data

--- a/lib/Backend/Opnd.cpp
+++ b/lib/Backend/Opnd.cpp
@@ -109,6 +109,11 @@ Opnd::IsWriteBarrierTriggerableValue()
         return false;
     }
 
+    if (TySize[this->GetType()] != sizeof(void*))
+    {
+        return false;
+    }
+
 #if DBG
     if (CONFIG_FLAG(ForceSoftwareWriteBarrier) && CONFIG_FLAG(RecyclerVerifyMark))
     {

--- a/lib/Backend/Opnd.cpp
+++ b/lib/Backend/Opnd.cpp
@@ -98,7 +98,7 @@ Opnd::IsWriteBarrierTriggerableValue()
     // Determines whether if an operand is used as a source in a store instruction, whether the store needs a write barrier
 
     // If it's a tagged value, we don't need a write barrier
-    if (!this->IsNotTaggedValue()) // SWB-TODO: change to: this->IsTaggedValue()
+    if (this->IsTaggedValue())
     {
         return false;
     }

--- a/lib/Backend/arm/LowerMD.cpp
+++ b/lib/Backend/arm/LowerMD.cpp
@@ -2382,7 +2382,7 @@ LowererMD::ChangeToAssign(IR::Instr * instr, IRType type)
 }
 
 void
-LowererMD::ChangeToWriteBarrierAssign(IR::Instr * assignInstr)
+LowererMD::ChangeToWriteBarrierAssign(IR::Instr * assignInstr, const Func* func)
 {
 #ifdef RECYCLER_WRITE_BARRIER_JIT
     // WriteBarrier-TODO- Implement ARM JIT

--- a/lib/Backend/arm/LowerMD.cpp
+++ b/lib/Backend/arm/LowerMD.cpp
@@ -2422,9 +2422,9 @@ LowererMD::ChangeToLea(IR::Instr * instr, bool postRegAlloc)
 ///----------------------------------------------------------------------------
 
 IR::Instr *
-LowererMD::CreateAssign(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsertPt)
+LowererMD::CreateAssign(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsertPt, bool generateWriteBarrier)
 {
-    return Lowerer::InsertMove(dst, src, instrInsertPt);
+    return Lowerer::InsertMove(dst, src, instrInsertPt, generateWriteBarrier);
 }
 
 ///----------------------------------------------------------------------------

--- a/lib/Backend/arm/LowerMD.h
+++ b/lib/Backend/arm/LowerMD.h
@@ -68,7 +68,7 @@ public:
             IR::Instr *     ChangeToHelperCall(IR::Instr * instr, IR::JnHelperMethod helperMethod, IR::LabelInstr *labelBailOut = nullptr,
                                                IR::Opnd *opndInstance = nullptr, IR::PropertySymOpnd * propSymOpnd = nullptr, bool isHelperContinuation = false);
             IR::Instr *     ChangeToHelperCallMem(IR::Instr * instr, IR::JnHelperMethod helperMethod);
-    static  IR::Instr *     CreateAssign(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsertPt);
+    static  IR::Instr *     CreateAssign(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsertPt, bool generateWriteBarrier = true);
     static  IR::Instr *     ChangeToAssign(IR::Instr * instr);
     static  IR::Instr *     ChangeToAssign(IR::Instr * instr, IRType type);
     static  IR::Instr *     ChangeToLea(IR::Instr *const instr, bool postRegAlloc = false);

--- a/lib/Backend/arm/LowerMD.h
+++ b/lib/Backend/arm/LowerMD.h
@@ -270,7 +270,7 @@ public:
             static void GenerateStFldFromLocalInlineCache(IR::Instr * instrStFld, IR::RegOpnd * opndBase, IR::Opnd * opndSrc, IR::RegOpnd * opndInlineCache, IR::LabelInstr * labelFallThru, bool isInlineSlot);
             void        GenerateFunctionObjectTest(IR::Instr * callInstr, IR::RegOpnd  *functionOpnd, bool isHelper, IR::LabelInstr* continueAfterExLabel = nullptr);
 
-            static void ChangeToWriteBarrierAssign(IR::Instr * assignInstr);
+            static void ChangeToWriteBarrierAssign(IR::Instr * assignInstr, const Func* func);
 
             int                 GetHelperArgsCount() { return this->helperCallArgsCount; }
             void                ResetHelperArgsCount() { this->helperCallArgsCount = 0; }

--- a/lib/Backend/arm64/LowerMD.h
+++ b/lib/Backend/arm64/LowerMD.h
@@ -264,7 +264,7 @@ public:
               static void GenerateLdLocalFldFromFlagInlineCache(IR::Instr * instrLdFld, IR::RegOpnd * opndBase, IR::Opnd * opndDst, IR::RegOpnd * opndInlineCache, IR::LabelInstr * labelFallThru, bool isInlineSlot) { __debugbreak(); }
               static void GenerateStFldFromLocalInlineCache(IR::Instr * instrStFld, IR::RegOpnd * opndBase, IR::Opnd * opndSrc, IR::RegOpnd * opndInlineCache, IR::LabelInstr * labelFallThru, bool isInlineSlot) { __debugbreak(); }
 
-              static void ChangeToWriteBarrierAssign(IR::Instr * assignInstr) { __debugbreak(); }
+              static void ChangeToWriteBarrierAssign(IR::Instr * assignInstr, const Func* func) { __debugbreak(); }
 
               int                 GetHelperArgsCount() { __debugbreak(); return 0; }
               void                ResetHelperArgsCount() { __debugbreak(); }

--- a/lib/Common/Memory/HeapBlock.cpp
+++ b/lib/Common/Memory/HeapBlock.cpp
@@ -825,7 +825,10 @@ SmallHeapBlockT<TBlockAttributes>::VerifyMark()
                         void* target = *(void**) objectAddress;
                         if (recycler->VerifyMark(target))
                         {
-                            Assert(this->wbVerifyBits.Test((BVIndex)(objectAddress - this->address) / sizeof(void*)));
+                            if (CONFIG_FLAG(ForceSoftwareWriteBarrier))
+                            {
+                                Assert(this->wbVerifyBits.Test((BVIndex)(objectAddress - this->address) / sizeof(void*)));
+                            }
                         }
 
                         objectAddress += sizeof(void *);

--- a/lib/Common/Memory/HeapBlock.cpp
+++ b/lib/Common/Memory/HeapBlock.cpp
@@ -1267,7 +1267,7 @@ SmallHeapBlockT<TBlockAttributes>::EnqueueProcessedObject(FreeObject ** list, vo
     *list = freeObject;
 
 #if DBG
-    if (CONFIG_FLAG(ForceSoftwareWriteBarrier))
+    if (CONFIG_FLAG(ForceSoftwareWriteBarrier) && CONFIG_FLAG(RecyclerVerifyMark))
     {
         this->WBClearBits((char*)objectAddress);
     }

--- a/lib/Common/Memory/HeapBlock.h
+++ b/lib/Common/Memory/HeapBlock.h
@@ -437,6 +437,8 @@ public:
     SmallHeapBlockBitVector* markBits;
     SmallHeapBlockBitVector  freeBits;
 #if DBG
+    // TODO: (leish)(swb) move this to the block header if memory pressure on chk build is a problem
+    // this causes 1/64 more memory usage on x64 or 1/32 more on x86
     BVStatic<TBlockAttributes::PageCount * AutoSystemInfo::PageSize / sizeof(void*)> wbVerifyBits;
 #endif
 

--- a/lib/Common/Memory/LargeHeapBlock.cpp
+++ b/lib/Common/Memory/LargeHeapBlock.cpp
@@ -851,7 +851,10 @@ LargeHeapBlock::VerifyMark()
 
             if (recycler->VerifyMark(target))
             {
-                Assert(this->wbVerifyBits.Test((BVIndex)(objectAddress - this->address) / sizeof(void*)));
+                if (CONFIG_FLAG(ForceSoftwareWriteBarrier))
+                {
+                    Assert(this->wbVerifyBits.Test((BVIndex)(objectAddress - this->address) / sizeof(void*)));
+                }
             }
 
             objectAddress += sizeof(void *);

--- a/lib/Common/Memory/Recycler.h
+++ b/lib/Common/Memory/Recycler.h
@@ -1933,6 +1933,7 @@ public:
     }
     static void WBSetBit(char* addr);
     static void WBSetBits(char* addr, uint length);
+    static bool WBCheckIsRecyclerAddress(char* addr);
 #endif
 };
 

--- a/lib/Common/Memory/Recycler.inl
+++ b/lib/Common/Memory/Recycler.inl
@@ -276,7 +276,7 @@ Recycler::AllocZeroWithAttributesInlined(DECLSPEC_GUARD_OVERFLOW size_t size)
 #endif
 
 #if DBG
-    if (CONFIG_FLAG(ForceSoftwareWriteBarrier))
+    if (CONFIG_FLAG(ForceSoftwareWriteBarrier) && CONFIG_FLAG(RecyclerVerifyMark))
     {
         this->FindHeapBlock(obj)->WBClearBits(obj);
     }

--- a/lib/Common/Memory/RecyclerPointers.h
+++ b/lib/Common/Memory/RecyclerPointers.h
@@ -145,10 +145,14 @@ template <>
 struct _ArrayItemWriteBarrierPolicy<_write_barrier_policy>
     { typedef _write_barrier_policy Policy; };
 
+template <class T, int N> // in case calling with type WriteBarrierPtr<void> [N]
+struct _ArrayItemWriteBarrierPolicy<WriteBarrierPtr<T>[N]>
+    { typedef _write_barrier_policy Policy; };
+
 // Trigger write barrier on changing array content if element type determines
 // write barrier is needed. Ignore otherwise.
 //
-template <class T, class PolicyType = T, class Allocator = Recycler>
+template <class T, class PolicyType = T, class Allocator = Recycler, int size=0>
 void ArrayWriteBarrier(T * address, size_t count)
 {
     typedef typename _ArrayItemWriteBarrierPolicy<PolicyType>::Policy ItemPolicy;

--- a/lib/Common/Memory/RecyclerWriteBarrierManager.cpp
+++ b/lib/Common/Memory/RecyclerWriteBarrierManager.cpp
@@ -318,7 +318,10 @@ RecyclerWriteBarrierManager::WriteBarrier(void * address)
     }
 #endif
 #if DBG
-    Recycler::WBSetBit((char*)address);
+    if (CONFIG_FLAG(ForceSoftwareWriteBarrier) && CONFIG_FLAG(RecyclerVerifyMark))
+    {
+        Recycler::WBSetBit((char*)address);
+    }
 #endif
 }
 
@@ -337,7 +340,10 @@ RecyclerWriteBarrierManager::WriteBarrier(void * address, size_t bytes)
     GlobalSwbVerboseTrace(_u("Writing to 0x%p (CIndex: %u-%u)\n"), address, startIndex, endIndex);
 
 #if DBG
-    Recycler::WBSetBits((char*)address, (uint)bytes/sizeof(void*));
+    if (CONFIG_FLAG(ForceSoftwareWriteBarrier) && CONFIG_FLAG(RecyclerVerifyMark))
+    {
+        Recycler::WBSetBits((char*)address, (uint)bytes / sizeof(void*));
+    }
 #endif
 
 #else

--- a/lib/Runtime/Base/AuxPtrs.h
+++ b/lib/Runtime/Base/AuxPtrs.h
@@ -128,7 +128,8 @@ namespace Js
     template<class T, typename FieldsEnum>
     AuxPtrs<T, FieldsEnum>::AuxPtrs(uint8 capacity, AuxPtrs* ptr)
     {
-        memcpy(this, ptr, sizeof(AuxPtrs) + (ptr->count - 1)*sizeof(void*));
+        memcpy(this, ptr, offsetof(AuxPtrs, ptrs) + ptr->count * sizeof(void*));
+        ArrayWriteBarrier(&this->ptrs, ptr->count);
         this->capacity = capacity;
     }
     template<class T, typename FieldsEnum>

--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -8698,7 +8698,7 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
                 Js::Throw::FatalInternalError();
             }
         }
-        ((Var*)(instance))[slotIndex] = value;
+        ((Field(Var)*)(instance))[slotIndex] = value;
     }
 
     void InterpreterStackFrame::OP_StEnvSlot(Var instance, int32 slotIndex1, int32 slotIndex2, Var value)


### PR DESCRIPTION
1. should use !this->IsTaggedValue instead IsNotTaggedValue
2. save lowerer on Func so we don't need to go through the instr list second time to add the verification code
3. some jit code directly write to ThreadContext field which we don't need write barrier (and the cardTable is not initialized for heap memory)

4. some issues found with the verification
