### PR TITLE
swb: misc fixes from unit test verification

### DIFF
--- a/lib/Common/DataStructures/KeyValuePair.h
+++ b/lib/Common/DataStructures/KeyValuePair.h
@@ -23,6 +23,10 @@ namespace JsUtil
             this->value = value;
         }
 
+        KeyValuePair(const KeyValuePair& other)
+            : key(other.key), value(other.value)
+        {}
+
         TKey Key() { return key; }
         const TKey Key() const { return key; }
 

--- a/lib/Runtime/Language/DynamicProfileInfo.cpp
+++ b/lib/Runtime/Language/DynamicProfileInfo.cpp
@@ -1921,7 +1921,10 @@ namespace Js
 
             if (callSiteInfoCount != 0)
             {
-                callSiteInfo = RecyclerNewArray(recycler, CallSiteInfo, callSiteInfoCount);
+                // CallSiteInfo contains pointer "polymorphicCallSiteInfo", but
+                // we explicitly save that pointer in FunctionBody. Safe to
+                // allocate CallSiteInfo[] as Leaf here.
+                callSiteInfo = RecyclerNewArrayLeaf(recycler, CallSiteInfo, callSiteInfoCount);
                 if (!reader->ReadArray(callSiteInfo, callSiteInfoCount))
                 {
                     goto Error;

--- a/lib/Runtime/Library/ConcatString.h
+++ b/lib/Runtime/Library/ConcatString.h
@@ -153,12 +153,12 @@ namespace Js
         virtual void CopyVirtual(_Out_writes_(m_charLength) char16 *const buffer, StringCopyInfoStack &nestedStringTreeCopyInfos, const byte recursionDepth) override sealed
         {
             const_cast<ConcatStringWrapping *>(this)->EnsureAllSlots();
-            __super::CopyImpl(buffer, _countof(m_slots), m_slots, nestedStringTreeCopyInfos, recursionDepth);
+            __super::CopyImpl(buffer, _countof(m_slots), AddressOf(m_slots[0]), nestedStringTreeCopyInfos, recursionDepth);
         }
         virtual int GetRandomAccessItemsFromConcatString(Js::JavascriptString * const *& items) const override sealed
         {
             const_cast<ConcatStringWrapping *>(this)->EnsureAllSlots();
-            items = m_slots;
+            items = AddressOf(m_slots[0]);
             return _countof(m_slots);
         }
     public:
@@ -171,10 +171,11 @@ namespace Js
             m_slots[1] = m_inner;
             m_slots[2] = this->GetLastItem();
         }
-        JavascriptString * m_inner;
+
+        Field(JavascriptString *) m_inner;
 
         // Use the padding space for the concat
-        JavascriptString * m_slots[3];
+        Field(JavascriptString *) m_slots[3];
     };
 
     // Make sure the padding doesn't add tot he size of ConcatStringWrapping

--- a/lib/Runtime/Library/ConcatString.inl
+++ b/lib/Runtime/Library/ConcatString.inl
@@ -114,7 +114,7 @@ namespace Js
     {
         const char16 * sz = GetSzImpl<ConcatStringWrapping>();
         m_inner = nullptr;
-        memset(m_slots, 0, sizeof(m_slots));
+        ClearArray(m_slots);
         return sz;
     }
 

--- a/lib/Runtime/Library/JavascriptArray.h
+++ b/lib/Runtime/Library/JavascriptArray.h
@@ -81,7 +81,7 @@ namespace Js
         void Add(Recycler* recycler, SparseArraySegmentBase* newSeg);
         void Find(uint itemIndex, SparseArraySegmentBase*& prevOrMatch, SparseArraySegmentBase*& matchOrNext);
 
-        FieldNoBarrier(SparseArraySegmentBase *) lastUsedSegment;
+        Field(SparseArraySegmentBase *) lastUsedSegment;
     };
 
     class JavascriptArray : public ArrayObject

--- a/lib/Runtime/Library/JavascriptMap.h
+++ b/lib/Runtime/Library/JavascriptMap.h
@@ -9,7 +9,7 @@ namespace Js
     class JavascriptMap : public DynamicObject
     {
     public:
-        typedef JsUtil::KeyValuePair<Var, Var> MapDataKeyValuePair;
+        typedef JsUtil::KeyValuePair<Field(Var), Field(Var)> MapDataKeyValuePair;
         typedef MapOrSetDataNode<MapDataKeyValuePair> MapDataNode;
         typedef MapOrSetDataList<MapDataKeyValuePair> MapDataList;
         typedef JsUtil::BaseDictionary<Var, MapDataNode*, Recycler, PowerOf2SizePolicy, SameValueZeroComparer> MapDataMap;

--- a/lib/Runtime/Library/MapOrSetDataList.h
+++ b/lib/Runtime/Library/MapOrSetDataList.h
@@ -28,13 +28,13 @@ namespace Js
         template <typename TData>
         friend class MapOrSetDataList;
 
-        MapOrSetDataNode<TData>* next;
-        MapOrSetDataNode<TData>* prev;
+        Field(MapOrSetDataNode<TData>*) next;
+        Field(MapOrSetDataNode<TData>*) prev;
 
         MapOrSetDataNode(TData& data) : data(data), next(nullptr), prev(nullptr) { }
 
     public:
-        TData data;
+        Field(TData) data;
     };
 
     template <typename TData>
@@ -120,7 +120,7 @@ namespace Js
                 return false;
             }
 
-            TData& Current()
+            const TData& Current() const
             {
                 return current->data;
             }

--- a/lib/Runtime/Types/SimpleDictionaryTypeHandler.h
+++ b/lib/Runtime/Types/SimpleDictionaryTypeHandler.h
@@ -67,17 +67,17 @@ namespace Js
 
     private:
         Field(RecyclerWeakReference<DynamicObject>*) singletonInstance;
-        Field(TPropertyIndex) nextPropertyIndex;
 
     protected:
+        Field(bool) _gc_tag : 1;  // Tag the low bit to prevent possible GC false references
         // Determines whether this instance is actually a SimpleDictionaryUnorderedTypeHandler
         Field(bool) isUnordered : 1;
         // Tracks if an InternalPropertyRecord or symbol has been added to this type; will prevent conversion to string-keyed type handler
         Field(bool) hasNamelessPropertyId : 1;
-
     private:
         // Number of deleted properties in the property map
         Field(byte) numDeletedProperties;
+        Field(TPropertyIndex) nextPropertyIndex;
 
     public:
         DEFINE_GETCPPNAME();


### PR DESCRIPTION
Fix a few swb annotation issues.

Opnd::IsWriteBarrierTriggerableValue(): Skip some optimization in
verification mode.

SimpleDictionaryTypeHandler: reorder fields and add a tag bit to avoid
GC false positive.
