### PR TITLE
Modified Array.prototype.toLocaleString to use the length of the internal slot for TypedArray.

### DIFF
--- a/lib/Runtime/Library/JavascriptArray.cpp
+++ b/lib/Runtime/Library/JavascriptArray.cpp
@@ -7858,7 +7858,18 @@ Case0:
     template <typename T>
     JavascriptString* JavascriptArray::ToLocaleString(T* arr, ScriptContext* scriptContext)
     {
-        uint32 length = ItemTrace<T>::GetLength(arr, scriptContext);
+        uint32 length = 0;
+        if (TypedArrayBase::Is(arr))
+        {
+            // For a TypedArray use the actual length of the array.
+            length = TypedArrayBase::FromVar(arr)->GetLength();
+        }
+        else
+        {
+            //For anything else, use the "length" property if present.
+            length = ItemTrace<T>::GetLength(arr, scriptContext);
+        }
+
         if (length == 0 || scriptContext->CheckObject(arr))
         {
             return scriptContext->GetLibrary()->GetEmptyString();

--- a/test/Array/toLocaleString.baseline
+++ b/test/Array/toLocaleString.baseline
@@ -35,3 +35,11 @@ TypeError : The value of the property 'toLocaleString' is not a Function object
 
 7. Object: element toLocaleString
 0.00, anObject, , , another Object, 1.00, a 3rd Object, 2.00
+
+
+8. TypedArray: toLocaleString should use length from internal slot
+0.00, 31.00
+
+
+9. Array: toLocaleString should use length property
+10.00, 20.00, 30.00, , , 

--- a/test/Array/toLocaleString.js
+++ b/test/Array/toLocaleString.js
@@ -154,3 +154,33 @@ guarded_call(function () {
         echo(output);
     }
 });
+
+scenario("TypedArray: toLocaleString should use length from internal slot");
+var o = new Int8Array(2);
+o[1] = 31;
+Object.defineProperty(o, 'length', {value : 4});
+
+guarded_call(function () {
+    output = Array.prototype.toLocaleString.apply(o);
+    // On OSX and Linux the values are printed as 0 instead 0.00. This is a valid workaround as we have still validated the toLocaleString behavior is correct.
+    if (output == "0, 31") {
+        echo("0.00, 31.00");
+    } else {
+        echo(output);
+    }
+});
+
+scenario("Array: toLocaleString should use length property");
+var o = [10, 20];
+o[2] = 30;
+Object.defineProperty(o, 'length', {value : 6});
+
+guarded_call(function () {
+    output = Array.prototype.toLocaleString.apply(o);
+    // On OSX and Linux the values are printed as 0 instead 0.00. This is a valid workaround as we have still validated the toLocaleString behavior is correct.
+    if (output == "10, 20, 30, , , ") {
+        echo("10.00, 20.00, 30.00, , , ");
+    } else {
+        echo(output);
+    }
+});

--- a/test/UnitTestFramework/UnitTestFramework.js
+++ b/test/UnitTestFramework/UnitTestFramework.js
@@ -92,6 +92,11 @@ var helpers = function helpers() {
                 Object.defineProperty(object, propertyName, descriptor);
             }
         },
+
+        getTypeOf: function getTypeOf(object)
+        {
+            return Object.prototype.toString.call(object);
+        },
     }
 }(); // helpers module.
 

--- a/test/typedarray/TypedArrayBuiltins.js
+++ b/test/typedarray/TypedArrayBuiltins.js
@@ -315,6 +315,29 @@ var tests = [
             }));
             assert.areEqual(count, 1, "TypedArray.from calls proxy's getter with @@iterator as parameter only once");
         }
+    },
+    {
+        name: "ISSUE1896: TypedArray : toLocaleString should use length from internal slot",
+        body: function () {
+            var test = function(taCtor) {
+                var o = new this[taCtor](2);
+                o[1] = 31;
+                Object.defineProperty(o, 'length', {value : 4});
+                result = o.toLocaleString();
+
+                // On OSX and Linux the values are printed as 0 instead 0.00. This is a valid workaround as we have still validated the toLocaleString behavior is correct.
+                if (result == "0, 31") {
+                    result = "0.00, 31.00";
+                }
+
+                assert.areEqual("0.00, 31.00", result, "TypedArray" + helpers.getTypeOf(o) + ".toLocaleString should use length from internal slot.");
+                return result;
+            };
+
+            for (let taCtor of TypedArrayCtors) {
+                test(taCtor);
+            }
+        }
     }
 ];
 


### PR DESCRIPTION
Modified Array.prototype.toLocaleString to use the length of the internal slot for TypedArray. Added tests for different types of typed arrays. Also, added a test to ensure that the normal array behavior has not changed after this change.