### PR TITLE
Fix sal warnings

### DIFF
--- a/lib/Backend/CodeGenNumberAllocator.cpp
+++ b/lib/Backend/CodeGenNumberAllocator.cpp
@@ -324,6 +324,9 @@ Js::JavascriptNumber* XProcNumberPageSegmentImpl::AllocateNumber(Func* func, dou
                 Recycler::FillPadNoCheck(pLocalNumber, sizeof(Js::JavascriptNumber), sizeCat, false);
                 pLocalNumber = new (pLocalNumber) Js::JavascriptNumber(localNumber);
             }
+#else
+            Assert(sizeCat == sizeof(Js::JavascriptNumber));
+            __analysis_assume(sizeCat == sizeof(Js::JavascriptNumber));
 #endif
             // change vtable to the remote one
             *(void**)pLocalNumber = (void*)func->GetScriptContextInfo()->GetVTableAddress(VTableValue::VtableJavascriptNumber);

--- a/lib/Backend/Encoder.cpp
+++ b/lib/Backend/Encoder.cpp
@@ -295,8 +295,9 @@ Encoder::Encode()
     {
         if (m_func->IsOOPJIT())
         {
-            Js::ThrowMapEntry * throwMap = NativeCodeDataNewArrayNoFixup(m_func->GetNativeCodeDataAllocator(), Js::ThrowMapEntry, m_pragmaInstrToRecordMap->Count());
-            for (int32 i = 0; i < m_pragmaInstrToRecordMap->Count(); i++)
+            int allocSize = m_pragmaInstrToRecordMap->Count();
+            Js::ThrowMapEntry * throwMap = NativeCodeDataNewArrayNoFixup(m_func->GetNativeCodeDataAllocator(), Js::ThrowMapEntry, allocSize);
+            for (int i = 0; i < allocSize; i++)
             {
                 IR::PragmaInstr *inst = m_pragmaInstrToRecordMap->Item(i);
                 throwMap[i].nativeBufferOffset = inst->m_offsetInBuffer;


### PR DESCRIPTION
Add annotation in CodeGenNumberAllocator.cpp to suppress sal warning.
Restructure code in Encoder.cpp, the two function calls were throwing off
the analyzer.
