### PR TITLE
fix virtual alloc upper limit

### DIFF
--- a/lib/Common/Memory/RecyclerWriteBarrierManager.cpp
+++ b/lib/Common/Memory/RecyclerWriteBarrierManager.cpp
@@ -226,10 +226,28 @@ X64WriteBarrierCardTableManager::Initialize()
         // On Win8, reserving 32 GB is fine since reservations don't incur a cost. On Win7, the cost
         // of a reservation can be approximated as 2KB per MB of reserved size. In our case, we take
         // an overhead of 96KB for our card table.
-        const unsigned __int64 maxUmProcessAddressSpace = (__int64) AutoSystemInfo::Data.lpMaximumApplicationAddress;
+
+        // xplat: GetRLimit AS / RSS for ``the maximum size of the process's virtual memory``
+        size_t memoryLimit;
+        if (!PlatformAgnostic::SystemInfo::GetMaxVirtualMemory(&memoryLimit))
+        {
+            memoryLimit = (size_t) AutoSystemInfo::Data.lpMaximumApplicationAddress; // try upper limit
+        }
+        else
+        {
+            // Safest option : Max RSS can be beyond what we can allocate, aim the smaller one
+            memoryLimit = min(memoryLimit, (size_t) AutoSystemInfo::Data.lpMaximumApplicationAddress);
+        }
+        const unsigned __int64 maxUmProcessAddressSpace = (__int64) memoryLimit;
+
         _cardTableNumEntries = Math::Align<size_t>(maxUmProcessAddressSpace / AutoSystemInfo::PageSize, AutoSystemInfo::PageSize) /* s_writeBarrierPageSize */;
 
         LPVOID cardTableSpace = ::VirtualAlloc(NULL, _cardTableNumEntries, MEM_RESERVE, PAGE_READWRITE);
+        if (!cardTableSpace) // Crash Early with a meaningful message. Otherwise the behavior is undefined.
+        {
+            fprintf(stderr, "Out of Memory\n"); fflush(stderr);
+            abort();
+        }
 
         _cardTable = (BYTE*) cardTableSpace;
     }

--- a/lib/Common/PlatformAgnostic/SystemInfo.h
+++ b/lib/Common/PlatformAgnostic/SystemInfo.h
@@ -31,6 +31,8 @@ namespace PlatformAgnostic
             *totalRam = SystemInfo::data.totalRam;
             return true;
         }
+
+        static bool GetMaxVirtualMemory(size_t *totalAS);
     };
 } // namespace PlatformAgnostic
 

--- a/lib/Runtime/PlatformAgnostic/Platform/Linux/SystemInfo.cpp
+++ b/lib/Runtime/PlatformAgnostic/Platform/Linux/SystemInfo.cpp
@@ -6,6 +6,7 @@
 #include "Common.h"
 #include "ChakraPlatform.h"
 #include <sys/sysinfo.h>
+#include <sys/resource.h>
 
 namespace PlatformAgnostic
 {
@@ -22,5 +23,16 @@ namespace PlatformAgnostic
         {
             totalRam = systemInfo.totalram;
         }
+    }
+
+    bool SystemInfo::GetMaxVirtualMemory(size_t *totalAS)
+    {
+        struct rlimit limit;
+        if (getrlimit(RLIMIT_AS, &limit) != 0)
+        {
+            return false;
+        }
+        *totalAS = limit.rlim_cur;
+        return true;
     }
 }

--- a/lib/Runtime/PlatformAgnostic/Platform/Unix/SystemInfo.cpp
+++ b/lib/Runtime/PlatformAgnostic/Platform/Unix/SystemInfo.cpp
@@ -22,4 +22,16 @@ namespace PlatformAgnostic
             totalRam = 0;
         }
     }
+
+    bool SystemInfo::GetMaxVirtualMemory(size_t *totalAS)
+    {
+        struct rlimit limit;
+        if (getrlimit(RLIMIT_AS, &limit) != 0)
+        {
+            return false;
+        }
+
+        *totalAS = limit.rlim_cur;
+        return true;
+    }
 }

--- a/lib/Runtime/PlatformAgnostic/Platform/Windows/SystemInfo.cpp
+++ b/lib/Runtime/PlatformAgnostic/Platform/Windows/SystemInfo.cpp
@@ -19,4 +19,13 @@ namespace PlatformAgnostic
             totalRam = static_cast<size_t>(ram) * 1024;
         }
     }
+
+    bool SystemInfo::GetMaxVirtualMemory(size_t *totalAS)
+    {
+        SYSTEM_INFO info;
+        GetSystemInfo(&info);
+        *totalAS = (size_t) info.lpMaximumApplicationAddress;
+        return true;
+    }
+
 }


### PR DESCRIPTION
Default `lpMaximumApplicationAddress` can be beyond what is allowed for the process.
Get AS/RSS limit before sending an allocation request.

Also, crash early in case of allocation fails.

Fixes #2268