### PR TITLE
Use WCHAR instead of wchar_t

### DIFF
--- a/bin/External/catch.hpp
+++ b/bin/External/catch.hpp
@@ -1571,8 +1571,8 @@ std::string toString( std::string const& value );
 std::string toString( std::wstring const& value );
 std::string toString( const char* const value );
 std::string toString( char* const value );
-std::string toString( const wchar_t* const value );
-std::string toString( wchar_t* const value );
+std::string toString( const WCHAR* const value );
+std::string toString( WCHAR* const value );
 std::string toString( int value );
 std::string toString( unsigned long value );
 std::string toString( unsigned int value );
@@ -8095,14 +8095,14 @@ std::string toString( char* const value ) {
     return Catch::toString( static_cast<const char*>( value ) );
 }
 
-std::string toString( const wchar_t* const value )
+std::string toString( const WCHAR* const value )
 {
 	return value ? Catch::toString( std::wstring(value) ) : std::string( "{null string}" );
 }
 
-std::string toString( wchar_t* const value )
+std::string toString( WCHAR* const value )
 {
-	return Catch::toString( static_cast<const wchar_t*>( value ) );
+	return Catch::toString( static_cast<const WCHAR*>( value ) );
 }
 
 std::string toString( int value ) {
@@ -10506,4 +10506,3 @@ int main (int argc, char * const argv[]) {
 using Catch::Detail::Approx;
 
 #endif // TWOBLUECUBES_SINGLE_INCLUDE_CATCH_HPP_INCLUDED
-

--- a/bin/NativeTests/JsRTApiTest.cpp
+++ b/bin/NativeTests/JsRTApiTest.cpp
@@ -108,7 +108,7 @@ namespace JsRTApiTest
         REQUIRE(JsCreateObject(&object) == JsNoError);
 
         JsPropertyIdRef name1 = JS_INVALID_REFERENCE;
-        const wchar_t* name = nullptr;
+        const WCHAR* name = nullptr;
         REQUIRE(JsGetPropertyIdFromName(_u("stringProperty1"), &name1) == JsNoError);
         REQUIRE(JsGetPropertyNameFromId(name1, &name) == JsNoError);
         CHECK(!wcscmp(name, _u("stringProperty1")));
@@ -582,7 +582,7 @@ namespace JsRTApiTest
     JsValueRef CALLBACK ExternalFunctionPreScriptAbortionCallback(JsValueRef /* function */, bool /* isConstructCall */, JsValueRef * args /* args */, USHORT /* cargs */, void * /* callbackState */)
     {
         JsValueRef result = JS_INVALID_REFERENCE;
-        const wchar_t *scriptText = nullptr;
+        const WCHAR *scriptText = nullptr;
         size_t scriptTextLen;
 
         REQUIRE(JsStringToPointer(args[0], &scriptText, &scriptTextLen) == JsNoError);
@@ -593,7 +593,7 @@ namespace JsRTApiTest
     JsValueRef CALLBACK ExternalFunctionPostScriptAbortionCallback(JsValueRef /* function */, bool /* isConstructCall */, JsValueRef * args /* args */, USHORT /* cargs */, void * /* callbackState */)
     {
         JsValueRef result = JS_INVALID_REFERENCE;
-        const wchar_t *scriptText = nullptr;
+        const WCHAR *scriptText = nullptr;
         size_t scriptTextLen;
 
         REQUIRE(JsStringToPointer(args[0], &scriptText, &scriptTextLen) == JsNoError);
@@ -656,7 +656,7 @@ namespace JsRTApiTest
         REQUIRE(JsCreateFunction(ExternalFunctionCallback, nullptr, &function) == JsNoError);
         testConstructorName(function, _u(""), 0);
 
-        wchar_t name[] = _u("FooName");
+        WCHAR name[] = _u("FooName");
         JsValueRef nameString = JS_INVALID_REFERENCE;
         REQUIRE(JsPointerToString(name, _countof(name) - 1, &nameString) == JsNoError);
         REQUIRE(JsCreateNamedFunction(nameString, ExternalFunctionCallback, nullptr, &function) == JsNoError);
@@ -688,7 +688,7 @@ namespace JsRTApiTest
 
         JsValueRef args[] = { GetUndefined() };
 
-        // throw from script, handle in host        
+        // throw from script, handle in host
         REQUIRE(JsGetPropertyIdFromName(_u("throwAtHost"), &name) == JsNoError);
         REQUIRE(JsGetProperty(global, name, &function) == JsNoError);
         REQUIRE(JsCallFunction(function, args, _countof(args), &result) == JsErrorScriptException);
@@ -701,12 +701,12 @@ namespace JsRTApiTest
         REQUIRE(JsGetPropertyIdFromName(_u("callHost"), &name) == JsNoError);
         REQUIRE(JsSetProperty(global, name, result, true) == JsNoError);
 
-        // throw from host callback, catch in script        
+        // throw from host callback, catch in script
         REQUIRE(JsGetPropertyIdFromName(_u("callHostWithTryCatch"), &name) == JsNoError);
         REQUIRE(JsGetProperty(global, name, &function) == JsNoError);
         REQUIRE(JsCallFunction(function, args, _countof(args), &result) == JsNoError);
 
-        // throw from host callback, through script, handle in host        
+        // throw from host callback, through script, handle in host
         REQUIRE(JsGetPropertyIdFromName(_u("callHostWithNoTryCatch"), &name) == JsNoError);
         REQUIRE(JsGetProperty(global, name, &function) == JsNoError);
         REQUIRE(JsCallFunction(function, args, _countof(args), &result) == JsErrorScriptException);
@@ -855,7 +855,7 @@ namespace JsRTApiTest
             JsValueRef nameValue = JS_INVALID_REFERENCE;
             REQUIRE(JsGetIndexedProperty(propertyNames, indexValue, &nameValue) == JsNoError);
 
-            const wchar_t *name = nullptr;
+            const WCHAR *name = nullptr;
             size_t length;
             REQUIRE(JsStringToPointer(nameValue, &name, &length) == JsNoError);
 
@@ -879,7 +879,7 @@ namespace JsRTApiTest
         JsPropertyIdRef propertyId = JS_INVALID_REFERENCE;
         JsValueRef outValue = JS_INVALID_REFERENCE;
         JsValueRef propertySymbols = JS_INVALID_REFERENCE;
-        const wchar_t* name = nullptr;
+        const WCHAR* name = nullptr;
         JsPropertyIdType propertyIdType;
 
         REQUIRE(JsCreateObject(&object) == JsNoError);
@@ -1003,7 +1003,7 @@ namespace JsRTApiTest
         bool boolValue;
         BYTE *compiledScript = nullptr;
         unsigned int scriptSize = 0;
-        const wchar_t *stringValue;
+        const WCHAR *stringValue;
         size_t stringLength;
         ByteCodeCallbackTracker tracker = {};
 
@@ -1030,7 +1030,7 @@ namespace JsRTApiTest
 
         tracker.script = script;
         REQUIRE(JsRunSerializedScriptWithCallback(
-            [](JsSourceContext sourceContext, const wchar_t** scriptBuffer)
+            [](JsSourceContext sourceContext, const WCHAR** scriptBuffer)
         {
             ((ByteCodeCallbackTracker*)sourceContext)->loadedScript = true;
             *scriptBuffer = ((ByteCodeCallbackTracker*)sourceContext)->script;
@@ -1079,7 +1079,7 @@ namespace JsRTApiTest
         REQUIRE(oldProtect == PAGE_READWRITE);
         tracker.script = scriptFnToString;
         REQUIRE(JsRunSerializedScriptWithCallback(
-            [](JsSourceContext sourceContext, const wchar_t** scriptBuffer)
+            [](JsSourceContext sourceContext, const WCHAR** scriptBuffer)
         {
             ((ByteCodeCallbackTracker*)sourceContext)->loadedScript = true;
             *scriptBuffer = ((ByteCodeCallbackTracker*)sourceContext)->script;
@@ -1619,7 +1619,7 @@ namespace JsRTApiTest
             REQUIRE(JsCreateFunction(ExternalFunctionPostScriptAbortionCallback, nullptr, &postScriptAbortFunction) == JsNoError);
             JsValueRef scriptTextArg = JS_INVALID_REFERENCE;
 
-            wchar_t *scriptText = const_cast<wchar_t *>(terminationTests[i]);
+            WCHAR *scriptText = const_cast<WCHAR *>(terminationTests[i]);
             REQUIRE(JsPointerToString(scriptText, wcslen(scriptText), &scriptTextArg) == JsNoError);
             JsValueRef args[] = { scriptTextArg };
 

--- a/bin/ch/ch.cpp
+++ b/bin/ch/ch.cpp
@@ -21,7 +21,7 @@ JsRuntimeHandle chRuntime = JS_INVALID_RUNTIME_HANDLE;
 
 BOOL doTTRecord = false;
 BOOL doTTDebug = false;
-byte ttUri[MAX_PATH * sizeof(wchar_t)];
+byte ttUri[MAX_PATH * sizeof(WCHAR)];
 size_t ttUriByteLength = 0;
 UINT32 snapInterval = MAXUINT32;
 UINT32 snapHistoryLength = MAXUINT32;

--- a/lib/Common/CommonPal.h
+++ b/lib/Common/CommonPal.h
@@ -70,8 +70,6 @@
 #undef Yield /* winbase.h defines this but we want to use it for Js::OpCode::Yield; it is Win16 legacy, no harm undef'ing it */
 #pragma warning(pop)
 
-typedef wchar_t char16;
-
 // xplat-todo: get a better name for this macro
 #define _u(s) L##s
 #define INIT_PRIORITY(x)
@@ -635,7 +633,7 @@ void TryFinally(const TryFunc& tryFunc, const FinallyFunc& finallyFunc)
 #else
 #define __TRY_FINALLY_BEGIN __try
 #define __FINALLY   __finally
-#define __TRY_FINALLY_END 
+#define __TRY_FINALLY_END
 #endif
 
 namespace PlatformAgnostic

--- a/lib/JITIDL/JITTypes.h
+++ b/lib/JITIDL/JITTypes.h
@@ -435,7 +435,7 @@ typedef struct PropertyIdArrayIDL
 
 typedef struct JavascriptStringIDL
 {
-    IDL_DEF([size_is(m_charLength + 1)]) wchar_t* m_pszValue;
+    IDL_DEF([size_is(m_charLength + 1)]) WCHAR* m_pszValue;
     unsigned int m_charLength;
 } JavascriptStringIDL;
 
@@ -553,7 +553,7 @@ typedef struct FunctionBodyDataIDL
 
     IDL_DEF([size_is(referencedPropertyIdCount)]) int * referencedPropertyIdMap;
 
-    IDL_DEF([size_is(nameLength)]) wchar_t * displayName;
+    IDL_DEF([size_is(nameLength)]) WCHAR * displayName;
 
     IDL_DEF([size_is(literalRegexCount)]) CHAKRA_PTR * literalRegexes;
 

--- a/lib/Jsrt/ChakraCommon.h
+++ b/lib/Jsrt/ChakraCommon.h
@@ -87,6 +87,7 @@ typedef void* HANDLE;
 typedef unsigned char BYTE;
 typedef BYTE byte;
 typedef UINT32 DWORD;
+typedef unsigned short WCHAR;
 #endif
 
 #endif //  defined(_WIN32) && defined(_MSC_VER)

--- a/lib/Jsrt/ChakraCommonWindows.h
+++ b/lib/Jsrt/ChakraCommonWindows.h
@@ -20,7 +20,7 @@
     /// <returns>
     ///     true if the operation succeeded, false otherwise.
     /// </returns>
-    typedef bool (CHAKRA_CALLBACK * JsSerializedScriptLoadSourceCallback)(_In_ JsSourceContext sourceContext, _Outptr_result_z_ const wchar_t** scriptBuffer);
+    typedef bool (CHAKRA_CALLBACK * JsSerializedScriptLoadSourceCallback)(_In_ JsSourceContext sourceContext, _Outptr_result_z_ const WCHAR** scriptBuffer);
 
     /// <summary>
     ///     Parses a script and returns a function representing the script.

--- a/lib/Jsrt/ChakraDebug.h
+++ b/lib/Jsrt/ChakraDebug.h
@@ -591,7 +591,7 @@ typedef unsigned __int32 uint32_t;
     /// </remarks>
     CHAKRA_API
         JsDiagEvaluate(
-            _In_z_ const wchar_t *expression,
+            _In_z_ const WCHAR *expression,
             _In_ unsigned int stackFrameIndex,
             _Out_ JsValueRef *evalResult);
 

--- a/lib/Jsrt/Jsrt.cpp
+++ b/lib/Jsrt/Jsrt.cpp
@@ -1149,7 +1149,7 @@ CHAKRA_API JsGetStringLength(_In_ JsValueRef value, _Out_ int *length)
     END_JSRT_NO_EXCEPTION
 }
 
-CHAKRA_API JsPointerToString(_In_reads_(stringLength) const wchar_t *stringValue, _In_ size_t stringLength, _Out_ JsValueRef *string)
+CHAKRA_API JsPointerToString(_In_reads_(stringLength) const WCHAR *stringValue, _In_ size_t stringLength, _Out_ JsValueRef *string)
 {
     return ContextAPINoScriptWrapper([&](Js::ScriptContext *scriptContext, TTDRecorder& _actionEntryPopper) -> JsErrorCode {
         PERFORM_JSRT_TTD_RECORD_ACTION(scriptContext, RecordJsRTCreateString, stringValue, stringLength);
@@ -1173,7 +1173,7 @@ CHAKRA_API JsPointerToString(_In_reads_(stringLength) const wchar_t *stringValue
 // TODO: The annotation of stringPtr is wrong.  Need to fix definition in chakrart.h
 // The warning is '*stringPtr' could be '0' : this does not adhere to the specification for the function 'JsStringToPointer'.
 #pragma warning(suppress:6387)
-CHAKRA_API JsStringToPointer(_In_ JsValueRef stringValue, _Outptr_result_buffer_(*stringLength) const wchar_t **stringPtr, _Out_ size_t *stringLength)
+CHAKRA_API JsStringToPointer(_In_ JsValueRef stringValue, _Outptr_result_buffer_(*stringLength) const WCHAR **stringPtr, _Out_ size_t *stringLength)
 {
     VALIDATE_JSREF(stringValue);
     PARAM_NOT_NULL(stringPtr);
@@ -2704,7 +2704,7 @@ CHAKRA_API JsIsRuntimeExecutionDisabled(_In_ JsRuntimeHandle runtimeHandle, _Out
     return JsNoError;
 }
 
-CHAKRA_API JsGetPropertyIdFromName(_In_z_ const wchar_t *name, _Out_ JsPropertyIdRef *propertyId)
+CHAKRA_API JsGetPropertyIdFromName(_In_z_ const WCHAR *name, _Out_ JsPropertyIdRef *propertyId)
 {
     return ContextAPINoScriptWrapper_NoRecord([&](Js::ScriptContext * scriptContext) -> JsErrorCode {
         PARAM_NOT_NULL(name);
@@ -2767,7 +2767,7 @@ CHAKRA_API JsGetSymbolFromPropertyId(_In_ JsPropertyIdRef propertyId, _Out_ JsVa
 }
 
 #pragma prefast(suppress:6101, "Prefast doesn't see through the lambda")
-CHAKRA_API JsGetPropertyNameFromId(_In_ JsPropertyIdRef propertyId, _Outptr_result_z_ const wchar_t **name)
+CHAKRA_API JsGetPropertyNameFromId(_In_ JsPropertyIdRef propertyId, _Outptr_result_z_ const WCHAR **name)
 {
     return GlobalAPIWrapper_NoRecord([&]() -> JsErrorCode {
         VALIDATE_INCOMING_PROPERTYID(propertyId);
@@ -2868,7 +2868,7 @@ CHAKRA_API JsSetPromiseContinuationCallback(_In_ JsPromiseContinuationCallback p
 
 JsErrorCode RunScriptCore(JsValueRef scriptSource, const byte *script, size_t cb,
     LoadScriptFlag loadScriptFlag, JsSourceContext sourceContext,
-    const wchar_t *sourceUrl, bool parseOnly, JsParseScriptAttributes parseAttributes,
+    const WCHAR *sourceUrl, bool parseOnly, JsParseScriptAttributes parseAttributes,
     bool isSourceModule, JsValueRef *result)
 {
     Js::JavascriptFunction *scriptFunction;
@@ -2886,7 +2886,7 @@ JsErrorCode RunScriptCore(JsValueRef scriptSource, const byte *script, size_t cb
         }
 
         const int chsize = (loadScriptFlag & LoadScriptFlag_Utf8Source) ?
-                            sizeof(utf8char_t) : sizeof(wchar_t);
+                            sizeof(utf8char_t) : sizeof(WCHAR);
 
         SRCINFO si = {
             /* sourceContextInfo   */ sourceContextInfo,
@@ -3045,28 +3045,28 @@ JsErrorCode RunScriptCore(const char *script, JsSourceContext sourceContext,
         isSourceModule, result);
 }
 
-JsErrorCode RunScriptCore(const wchar_t *script, JsSourceContext sourceContext,
-    const wchar_t *sourceUrl, bool parseOnly, JsParseScriptAttributes parseAttributes,
+JsErrorCode RunScriptCore(const WCHAR *script, JsSourceContext sourceContext,
+    const WCHAR *sourceUrl, bool parseOnly, JsParseScriptAttributes parseAttributes,
     bool isSourceModule, JsValueRef *result)
 {
     return RunScriptCore(nullptr, reinterpret_cast<const byte*>(script),
-        wcslen(script) * sizeof(wchar_t),
+        wcslen(script) * sizeof(WCHAR),
         LoadScriptFlag_None, sourceContext, sourceUrl, parseOnly,
         parseAttributes, isSourceModule, result);
 }
 
 #ifdef _WIN32
-CHAKRA_API JsParseScript(_In_z_ const wchar_t * script, _In_ JsSourceContext sourceContext,
-    _In_z_ const wchar_t *sourceUrl, _Out_ JsValueRef * result)
+CHAKRA_API JsParseScript(_In_z_ const WCHAR * script, _In_ JsSourceContext sourceContext,
+    _In_z_ const WCHAR *sourceUrl, _Out_ JsValueRef * result)
 {
     return RunScriptCore(script, sourceContext, sourceUrl, true,
         JsParseScriptAttributeNone, false /*isModule*/, result);
 }
 
 CHAKRA_API JsParseScriptWithAttributes(
-    _In_z_ const wchar_t *script,
+    _In_z_ const WCHAR *script,
     _In_ JsSourceContext sourceContext,
-    _In_z_ const wchar_t *sourceUrl,
+    _In_z_ const WCHAR *sourceUrl,
     _In_ JsParseScriptAttributes parseAttributes,
     _Out_ JsValueRef *result)
 {
@@ -3074,15 +3074,15 @@ CHAKRA_API JsParseScriptWithAttributes(
         parseAttributes, false /*isModule*/, result);
 }
 
-CHAKRA_API JsRunScript(_In_z_ const wchar_t * script, _In_ JsSourceContext sourceContext,
-    _In_z_ const wchar_t *sourceUrl, _Out_ JsValueRef * result)
+CHAKRA_API JsRunScript(_In_z_ const WCHAR * script, _In_ JsSourceContext sourceContext,
+    _In_z_ const WCHAR *sourceUrl, _Out_ JsValueRef * result)
 {
     return RunScriptCore(script, sourceContext, sourceUrl, false,
         JsParseScriptAttributeNone, false /*isModule*/, result);
 }
 
-CHAKRA_API JsExperimentalApiRunModule(_In_z_ const wchar_t * script,
-    _In_ JsSourceContext sourceContext, _In_z_ const wchar_t *sourceUrl,
+CHAKRA_API JsExperimentalApiRunModule(_In_z_ const WCHAR * script,
+    _In_ JsSourceContext sourceContext, _In_z_ const WCHAR *sourceUrl,
     _Out_ JsValueRef * result)
 {
     return RunScriptCore(script, sourceContext, sourceUrl, false,
@@ -3115,7 +3115,7 @@ JsErrorCode JsSerializeScriptCore(const byte *script, size_t cb,
         SourceContextInfo * sourceContextInfo = scriptContext->GetSourceContextInfo(JS_SOURCE_CONTEXT_NONE, nullptr);
         Assert(sourceContextInfo != nullptr);
 
-        const int chsize = (loadScriptFlag & LoadScriptFlag_Utf8Source) ? sizeof(utf8char_t) : sizeof(wchar_t);
+        const int chsize = (loadScriptFlag & LoadScriptFlag_Utf8Source) ? sizeof(utf8char_t) : sizeof(WCHAR);
         SRCINFO si = {
             /* sourceContextInfo   */ sourceContextInfo,
             /* dlnHost             */ 0,
@@ -3200,11 +3200,11 @@ JsErrorCode JsSerializeScriptCore(const byte *script, size_t cb,
     });
 }
 
-CHAKRA_API JsSerializeScript(_In_z_ const wchar_t *script, _Out_writes_to_opt_(*bufferSize,
+CHAKRA_API JsSerializeScript(_In_z_ const WCHAR *script, _Out_writes_to_opt_(*bufferSize,
     *bufferSize) unsigned char *buffer,
     _Inout_ unsigned int *bufferSize)
 {
-    return JsSerializeScriptCore((const byte*)script, wcslen(script) * sizeof(wchar_t),
+    return JsSerializeScriptCore((const byte*)script, wcslen(script) * sizeof(WCHAR),
         LoadScriptFlag_None, nullptr, 0, buffer, bufferSize, nullptr);
 }
 
@@ -3213,7 +3213,7 @@ JsErrorCode RunSerializedScriptCore(
     TLoadCallback scriptLoadCallback, TUnloadCallback scriptUnloadCallback,
     JsSourceContext scriptLoadSourceContext, // only used by scriptLoadCallback
     unsigned char *buffer, JsValueRef bufferVal,
-    JsSourceContext sourceContext, const wchar_t *sourceUrl,
+    JsSourceContext sourceContext, const WCHAR *sourceUrl,
     bool parseOnly, JsValueRef *result)
 {
     Js::JavascriptFunction *function;
@@ -3312,16 +3312,16 @@ static void CHAKRA_CALLBACK DummyScriptUnloadCallback(_In_ JsSourceContext sourc
 }
 
 #ifdef _WIN32
-static bool CHAKRA_CALLBACK DummyScriptLoadSourceCallback(_In_ JsSourceContext sourceContext, _Outptr_result_z_ const wchar_t** scriptBuffer)
+static bool CHAKRA_CALLBACK DummyScriptLoadSourceCallback(_In_ JsSourceContext sourceContext, _Outptr_result_z_ const WCHAR** scriptBuffer)
 {
     // sourceContext is actually the script source pointer
-    *scriptBuffer = reinterpret_cast<const wchar_t*>(sourceContext);
+    *scriptBuffer = reinterpret_cast<const WCHAR*>(sourceContext);
     return true;
 }
 
-CHAKRA_API JsParseSerializedScript(_In_z_ const wchar_t * script, _In_ unsigned char *buffer,
+CHAKRA_API JsParseSerializedScript(_In_z_ const WCHAR * script, _In_ unsigned char *buffer,
     _In_ JsSourceContext sourceContext,
-    _In_z_ const wchar_t *sourceUrl,
+    _In_z_ const WCHAR *sourceUrl,
     _Out_ JsValueRef * result)
 {
     return RunSerializedScriptCore(
@@ -3330,9 +3330,9 @@ CHAKRA_API JsParseSerializedScript(_In_z_ const wchar_t * script, _In_ unsigned 
         buffer, nullptr, sourceContext, sourceUrl, true, result);
 }
 
-CHAKRA_API JsRunSerializedScript(_In_z_ const wchar_t * script, _In_ unsigned char *buffer,
+CHAKRA_API JsRunSerializedScript(_In_z_ const WCHAR * script, _In_ unsigned char *buffer,
     _In_ JsSourceContext sourceContext,
-    _In_z_ const wchar_t *sourceUrl,
+    _In_z_ const WCHAR *sourceUrl,
     _Out_ JsValueRef * result)
 {
     return RunSerializedScriptCore(
@@ -3344,7 +3344,7 @@ CHAKRA_API JsRunSerializedScript(_In_z_ const wchar_t * script, _In_ unsigned ch
 CHAKRA_API JsParseSerializedScriptWithCallback(_In_ JsSerializedScriptLoadSourceCallback scriptLoadCallback,
     _In_ JsSerializedScriptUnloadCallback scriptUnloadCallback,
     _In_ unsigned char *buffer, _In_ JsSourceContext sourceContext,
-    _In_z_ const wchar_t *sourceUrl, _Out_ JsValueRef * result)
+    _In_z_ const WCHAR *sourceUrl, _Out_ JsValueRef * result)
 {
     return RunSerializedScriptCore(
         scriptLoadCallback, scriptUnloadCallback,
@@ -3355,7 +3355,7 @@ CHAKRA_API JsParseSerializedScriptWithCallback(_In_ JsSerializedScriptLoadSource
 CHAKRA_API JsRunSerializedScriptWithCallback(_In_ JsSerializedScriptLoadSourceCallback scriptLoadCallback,
     _In_ JsSerializedScriptUnloadCallback scriptUnloadCallback,
     _In_ unsigned char *buffer, _In_ JsSourceContext sourceContext,
-    _In_z_ const wchar_t *sourceUrl, _Out_opt_ JsValueRef * result)
+    _In_z_ const WCHAR *sourceUrl, _Out_opt_ JsValueRef * result)
 {
     return RunSerializedScriptCore(
         scriptLoadCallback, scriptUnloadCallback,
@@ -4241,7 +4241,7 @@ _ALWAYSINLINE JsErrorCode CompileRun(
     LoadScriptFlag scriptFlag = LoadScriptFlag_None;
     const byte* script;
     size_t cb;
-    const wchar_t *url;
+    const WCHAR *url;
 
     if (isExternalArray)
     {
@@ -4268,8 +4268,8 @@ _ALWAYSINLINE JsErrorCode CompileRun(
             Js::JavascriptString* jsString = Js::JavascriptString::FromVar(scriptVal);
             script = (const byte*)jsString->GetSz();
 
-            // JavascriptString is 2 bytes (wchar_t/char16)
-            cb = jsString->GetLength() * sizeof(wchar_t);
+            // JavascriptString is 2 bytes (WCHAR/char16)
+            cb = jsString->GetLength() * sizeof(WCHAR);
         }
 
         if (!Js::JavascriptString::Is(sourceUrl))
@@ -4451,7 +4451,7 @@ CHAKRA_API JsParseSerialized(
     PARAM_NOT_NULL(bufferVal);
     PARAM_NOT_NULL(sourceUrl);
 
-    const wchar_t *url;
+    const WCHAR *url;
 
     if (Js::JavascriptString::Is(sourceUrl))
     {
@@ -4484,7 +4484,7 @@ CHAKRA_API JsRunSerialized(
     _Out_ JsValueRef *result)
 {
     PARAM_NOT_NULL(bufferVal);
-    const wchar_t *url;
+    const WCHAR *url;
 
     if (sourceUrl && Js::JavascriptString::Is(sourceUrl))
     {

--- a/lib/Jsrt/JsrtDiag.cpp
+++ b/lib/Jsrt/JsrtDiag.cpp
@@ -670,7 +670,7 @@ CHAKRA_API JsDiagGetObjectFromHandle(
 }
 
 CHAKRA_API JsDiagEvaluate(
-    _In_z_ const wchar_t *expression,
+    _In_z_ const WCHAR *expression,
     _In_ unsigned int stackFrameIndex,
     _Out_ JsValueRef *evalResult)
 {

--- a/lib/Jsrt/JsrtSourceHolder.cpp
+++ b/lib/Jsrt/JsrtSourceHolder.cpp
@@ -17,14 +17,14 @@ namespace Js
     class JsrtSourceHolderPolicy<JsSerializedScriptLoadSourceCallback>
     {
     public:
-        typedef wchar_t TLoadCharType;
+        typedef WCHAR TLoadCharType;
 
         // Helper function for converting a Unicode script to utf8.
         // If heapAlloc is true the returned buffer must be freed with HeapDelete.
         // Otherwise scriptContext must be provided and GCed object is
         // returned.
         static void ScriptToUtf8(_When_(heapAlloc, _In_opt_) _When_(!heapAlloc, _In_) Js::ScriptContext *scriptContext,
-            _In_z_ const wchar_t *script, _Outptr_result_buffer_(*utf8Length) utf8char_t **utf8Script, _Out_ size_t *utf8Length,
+            _In_z_ const WCHAR *script, _Outptr_result_buffer_(*utf8Length) utf8char_t **utf8Script, _Out_ size_t *utf8Length,
             _Out_ size_t *scriptLength, _Out_opt_ size_t *utf8AllocLength, _In_ bool heapAlloc)
         {
             Assert(utf8Script != nullptr);
@@ -81,7 +81,7 @@ namespace Js
 #endif  // _WIN32
 
     template <typename TLoadCallback, typename TUnloadCallback>
-    void JsrtSourceHolder<TLoadCallback, TUnloadCallback>::EnsureSource(MapRequestFor requestedFor, const wchar_t* reasonString)
+    void JsrtSourceHolder<TLoadCallback, TUnloadCallback>::EnsureSource(MapRequestFor requestedFor, const WCHAR* reasonString)
     {
         if (this->mappedSource != nullptr)
         {
@@ -164,7 +164,7 @@ namespace Js
             }
             else
             {
-                const wchar_t *script = (const wchar_t*) script_;
+                const WCHAR *script = (const WCHAR*) script_;
                 Assert(utf8Script != nullptr);
                 Assert(utf8Length != nullptr);
                 Assert(scriptLength != nullptr);
@@ -225,7 +225,7 @@ namespace Js
     template <>
     void JsrtSourceHolder<JsSerializedLoadScriptCallback,
         JsSerializedScriptUnloadCallback>::EnsureSource(MapRequestFor requestedFor,
-        const wchar_t* reasonString)
+        const WCHAR* reasonString)
     {
         if (this->mappedSource != nullptr)
         {

--- a/lib/Jsrt/JsrtSourceHolder.h
+++ b/lib/Jsrt/JsrtSourceHolder.h
@@ -40,7 +40,7 @@ namespace Js
             return mappedSourceByteLength;
         };
 
-        void EnsureSource(MapRequestFor requestedFor, const wchar_t* reasonString);
+        void EnsureSource(MapRequestFor requestedFor, const WCHAR* reasonString);
 
     public:
         JsrtSourceHolder(_In_ TLoadCallback scriptLoadCallback,
@@ -73,13 +73,13 @@ namespace Js
         }
 
         // Following two methods are calls to EnsureSource before attempting to get the source
-        virtual LPCUTF8 GetSource(const wchar_t* reasonString) override
+        virtual LPCUTF8 GetSource(const WCHAR* reasonString) override
         {
             this->EnsureSource(MapRequestFor::Source, reasonString);
             return this->GetMappedSource();
         }
 
-        virtual size_t GetByteLength(const wchar_t* reasonString) override
+        virtual size_t GetByteLength(const WCHAR* reasonString) override
         {
             this->EnsureSource(MapRequestFor::Length, reasonString);
             return this->GetMappedSourceLength();

--- a/lib/Runtime/Base/ittnotify_config.h
+++ b/lib/Runtime/Base/ittnotify_config.h
@@ -69,7 +69,7 @@
 #include <stddef.h>
 #if ITT_PLATFORM==ITT_PLATFORM_WIN
 // 4/29/2016 disable warning 4995 on deprecated _tccpy, wcsncpy, wcsncat, wcstok funcs in tchar.h
-#pragma warning( disable : 4995 )   
+#pragma warning( disable : 4995 )
 #include <tchar.h>
 #else  /* ITT_PLATFORM==ITT_PLATFORM_WIN */
 #include <stdint.h>
@@ -333,7 +333,7 @@ typedef struct ___itt_thread_info
 {
     const char* nameA; /*!< Copy of original name in ASCII. */
 #if defined(UNICODE) || defined(_UNICODE)
-    const wchar_t* nameW; /*!< Copy of original name in UNICODE. */
+    const WCHAR* nameW; /*!< Copy of original name in UNICODE. */
 #else  /* UNICODE || _UNICODE */
     void* nameW;
 #endif /* UNICODE || _UNICODE */
@@ -367,13 +367,13 @@ typedef struct __itt_counter_info
 {
     const char* nameA;  /*!< Copy of original name in ASCII. */
 #if defined(UNICODE) || defined(_UNICODE)
-    const wchar_t* nameW; /*!< Copy of original name in UNICODE. */
+    const WCHAR* nameW; /*!< Copy of original name in UNICODE. */
 #else  /* UNICODE || _UNICODE */
     void* nameW;
 #endif /* UNICODE || _UNICODE */
     const char* domainA;  /*!< Copy of original name in ASCII. */
 #if defined(UNICODE) || defined(_UNICODE)
-    const wchar_t* domainW; /*!< Copy of original name in UNICODE. */
+    const WCHAR* domainW; /*!< Copy of original name in UNICODE. */
 #else  /* UNICODE || _UNICODE */
     void* domainW;
 #endif /* UNICODE || _UNICODE */

--- a/lib/Runtime/PlatformAgnostic/Platform/Common/UnicodeText.Common.cpp
+++ b/lib/Runtime/PlatformAgnostic/Platform/Common/UnicodeText.Common.cpp
@@ -78,7 +78,7 @@ inline int readNumber(__inout CharType* &str)
 /// This code is in the common library so that we can unit test it on Windows too
 ///
 /// Basic algorithm is as follows:
-/// 
+///
 /// Iterate through both strings
 ///  If either current character is not a number, compare the rest of the strings lexically
 ///  else if they're both numbers:
@@ -189,7 +189,7 @@ int LogicalStringCompareImpl<char16>(__in const char16* str1, __in const char16*
 
 // Unnamespaced test code
 #if ENABLE_TEST_PLATFORM_AGNOSTIC
-void LogicalStringCompareTest(const wchar_t* str1, const wchar_t* str2, int expected)
+void LogicalStringCompareTest(const WCHAR* str1, const WCHAR* str2, int expected)
 {
     int compareStringResult = CompareStringW(LOCALE_USER_DEFAULT, NORM_IGNORECASE | SORT_DIGITSASNUMBERS, str1, -1, str2, -1);
 
@@ -201,7 +201,7 @@ void LogicalStringCompareTest(const wchar_t* str1, const wchar_t* str2, int expe
 
     compareStringResult = compareStringResult - CSTR_EQUAL;
 
-    int res = PlatformAgnostic::UnicodeText::Internal::LogicalStringCompareImpl<wchar_t>(str1, str2);
+    int res = PlatformAgnostic::UnicodeText::Internal::LogicalStringCompareImpl<WCHAR>(str1, str2);
     bool passed = res == expected;
 
     if (compareStringResult != expected)

--- a/pal/inc/pal_mstypes.h
+++ b/pal/inc/pal_mstypes.h
@@ -554,17 +554,9 @@ typedef LONG_PTR LPARAM;
 #define _PTRDIFF_T
 #endif
 
-// CC uses both char16_t and wchar_t internally
-#if !defined(PAL_WCHAR_T_DEFINED)
-#if defined(__cplusplus)
-#undef wchar_t
-#define wchar_t __wchar_16_cpp__
-typedef char16_t wchar_t;
-#else
+#if !defined(__cplusplus)
 typedef unsigned short char16_t;
 #endif // __cplusplus
-#define PAL_WCHAR_T_DEFINED
-#endif // PAL_WCHAR_T_DEFINED
 
 typedef char16_t WCHAR;
 #define WCHAR_IS_CHAR16_T 1

--- a/pal/inc/safemath.h
+++ b/pal/inc/safemath.h
@@ -20,18 +20,12 @@
 #define _ASSERTE_SAFEMATH _ASSERTE
 #else
 // Otherwise (eg. we're being used from a tool like SOS) there isn't much
-// we can rely on that is both available everywhere and rotor-safe.  In 
+// we can rely on that is both available everywhere and rotor-safe.  In
 // several other tools we just take the recourse of disabling asserts,
-// we'll do the same here.  
+// we'll do the same here.
 // Ideally we'd have a collection of common utilities available evererywhere.
-#define _ASSERTE_SAFEMATH(a) 
+#define _ASSERTE_SAFEMATH(a)
 #endif
-#endif
-
-// CC uses both char16_t and wchar_t internally
-#if defined(__cplusplus)
-#undef wchar_t
-#define wchar_t void*
 #endif
 
 #if !defined(__IOS__) && !defined(OSX_SDK_TR1) && defined(__APPLE__)
@@ -46,12 +40,6 @@
 #else
 #include <type_traits>
 #endif
-
-#if defined(__cplusplus)
-#undef wchar_t
-#define wchar_t __wchar_16_cpp__
-typedef char16_t wchar_t;
-#endif // __cplusplus
 
 //==================================================================
 // Semantics: if val can be represented as the exact same value


### PR DESCRIPTION
ChakraCore uses char16_t on xplat and wchar_t on Windows for 2 bytes wide strings.
The reason we alter wchar_t to two bytes char16_t is that Unix wchar_t is 4 bytes long.

This PR removes the code that alters wchar_t and replaces all the instances of wchar_t with WCHAR.

Only ChakraCommonWindows.h is not updated.