### PR TITLE
Marshal value when traversing property keys via proxy

### DIFF
--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -1176,7 +1176,7 @@ CommonNumber:
                 {
                     if (propertyDescriptor.IsEnumerable())
                     {
-                        proxyResultToReturn->DirectSetItemAt(index++, element);
+                        proxyResultToReturn->DirectSetItemAt(index++, CrossSite::MarshalVar(scriptContext, element));
                     }
                 }
             }


### PR DESCRIPTION
We missed to marshal property key string when traversing (Object.keys()) an object via a proxy on it. Marshal is necessary because the object underlying the proxy could be from a difference script context.