### PR TITLE
Don't marshal symbol when it is just created from the same script context

### DIFF
--- a/lib/Runtime/Library/JavascriptObject.cpp
+++ b/lib/Runtime/Library/JavascriptObject.cpp
@@ -1161,7 +1161,8 @@ namespace Js
                     if (propertyRecord->IsSymbol())
                     {
                         symbol = scriptContext->GetLibrary()->CreateSymbol(propertyRecord);
-                        newArrForSymbols->DirectSetItemAt(symbolIndex++, CrossSite::MarshalVar(scriptContext, symbol));
+                        // no need to marshal symbol because it is created from scriptContext
+                        newArrForSymbols->DirectSetItemAt(symbolIndex++, symbol);
                         continue;
                     }
                 }


### PR DESCRIPTION
Marshal symbol in JavascriptObject::CreateKeysHelper is unnecessary because it is just created from the same script context.