### PR TITLE
Utf8Codex DecodeTail read past end of buffer

### DIFF
--- a/lib/Common/Codex/Utf8Codex.cpp
+++ b/lib/Common/Codex/Utf8Codex.cpp
@@ -397,7 +397,9 @@ LFastPath:
 LSlowPath:
         while (cch-- > 0)
         {
-            *buffer++ = Decode(ptr, ptr + 4, localOptions); // WARNING: Assume cch correct, suppress end-of-buffer checking
+            LPCUTF8 end = ptr + cch + 1; // WARNING: Assume cch correct, suppress end-of-buffer checking
+
+            *buffer++ = Decode(ptr, end, localOptions);
             if (ShouldFastPath(ptr, buffer)) goto LFastPath;
         }
     }
@@ -466,7 +468,9 @@ LSlowPath:
         DecodeOptions localOptions = options;
         while (cch-- > 0)
         {
-            if (*pch++ != utf8::Decode(bch, bch + 4, localOptions)) // WARNING: Assume cch correct, suppress end-of-buffer checking
+            LPCUTF8 end = bch + cch + 1; // WARNING: Assume cch correct, suppress end-of-buffer checking
+
+            if (*pch++ != utf8::Decode(bch, end, localOptions))
                 return false;
         }
         return true;

--- a/lib/Parser/HashFunc.cpp
+++ b/lib/Parser/HashFunc.cpp
@@ -31,7 +31,11 @@ ULONG CaseSensitiveComputeHashCch(LPCUTF8 prgch, int32 cch)
     ULONG luHash = 0;
 
     while (cch-- > 0)
-        luHash = 17 * luHash + utf8::Decode(prgch, prgch + 4, options); // WARNING: Assume cch correct, suppress end-of-buffer checking
+    {
+        LPCUTF8 end = prgch + cch + 1; // WARNING: Assume cch correct, suppress end-of-buffer checking
+
+        luHash = 17 * luHash + utf8::Decode(prgch, end, options);
+    }
     return luHash;
 }
 


### PR DESCRIPTION
    Decoding a Unicode byte-sequence can cause us to read extra bytes past the end of the source buffer if the sequence is truncated by the end of buffer immediately after the starting character.
    
    The read characters are unused as the unicode sequence will include a NULL character and, thus, be considered badly-formed resulting in the decoded character becoming the unknown character (0xFFFD).
    
    Bug is in DecodeInto, where we always add 4 to the source pointer and use that as a pointer to the end of the buffer. Because we always add 4, we always assume there are 4 more characters in the buffer, even when there are less.
    
    Fix is to calculate the real end of the source buffer and pass that down to DecodeTail which will allow us to avoid reading past the end of the buffer.
    
    Fixes https://microsoft.visualstudio.com/OS/_workitems?id=8989055&_a=edit