### PR TITLE
Resolves Bug#8971506. Defer parse case, assertions due to ByteCodeEmitter aggressively emitting nodes unprocessed yet by ByteCodeGenerator.

### DIFF
--- a/test/es6/default-splitscope.js
+++ b/test/es6/default-splitscope.js
@@ -1175,6 +1175,32 @@ var tests = [
             return h();
         }
         assert.areEqual(9, f2(), "Paramater scope remains split");
+
+        // Bug 8971506: This used to throw an ASSERT. The test is considered to be passing if no ASSERT is thrown.
+        function f3(a1 = class c1 extends eval('') { }) {
+        }
+
+        // Bug 8971506: This used to throw an ASSERT. The test is considered to be passing if no ASSERT is thrown.
+        var f4 = function () {
+        };
+        {
+            f4();
+        }
+        function f5() {
+            function f6(a2 = class c2 extends eval('') { }) {
+            }
+        }
+
+        // Bug 8971506: This used to throw an ASSERT. The test is considered to be passing if no ASSERT is thrown.
+        (eval(`
+        function f6(jirfmx = class c3 {}) { };
+        `));
+
+        // Bug 8971506: This used to throw an ASSERT. The test is considered to be passing if no ASSERT is thrown.
+        (eval(`
+        function f7(a3 = class c4 extends false {
+        }) { };
+        `));
     }
   },
   {  


### PR DESCRIPTION
In defer parse cases, sometimes byte code emitter seems to aggressively process nested scopes that the byte code generator hasn't visited. This results in assertion failures as certain flags are not set as expected. This surfaces more in cases where parameter scope has a class declaration and either the class declaration has an eval or the enclosing function is in an eval/global eval.