### PR TITLE
Fix TTD issues found during Node master merge

### DIFF
--- a/lib/Runtime/Debug/TTRuntmeInfoTracker.cpp
+++ b/lib/Runtime/Debug/TTRuntmeInfoTracker.cpp
@@ -697,6 +697,8 @@ namespace TTD
         this->EnqueueRootPathObject(_u("_stackTraceAccessor"), ctx->GetLibrary()->GetStackTraceAccessorFunction());
         this->EnqueueRootPathObject(_u("_throwTypeErrorRestrictedPropertyAccessor"), ctx->GetLibrary()->GetThrowTypeErrorRestrictedPropertyAccessorFunction());
 
+        this->EnqueueRootPathObject(_u("_arrayIteratorPrototype"), ctx->GetLibrary()->GetArrayIteratorPrototype());
+
         uint32 counter = 0;
         while(!this->m_worklist.Empty())
         {

--- a/lib/Runtime/Debug/TTSnapValues.cpp
+++ b/lib/Runtime/Debug/TTSnapValues.cpp
@@ -561,7 +561,7 @@ namespace TTD
                     compareMap.DiagnosticAssert((!!v1->u_boolValue) == (!!v2->u_boolValue));
                     break;
                 case Js::TypeIds_Number:
-                    compareMap.DiagnosticAssert(v1->u_doubleValue == v2->u_doubleValue); //This may be problematic wrt. precise FP values
+                    compareMap.DiagnosticAssert(CheckSnapEquivTTDDouble(v1->u_doubleValue, v2->u_doubleValue));
                     break;
                 case Js::TypeIds_Int64Number:
                     compareMap.DiagnosticAssert(v1->u_int64Value == v2->u_int64Value);


### PR DESCRIPTION
* The RuntimeInfoTracker wasn't tracking the ArrayIteratorPrototype as part of the well known root objects.
* The comparison of doubles between two snapshots wasn't accounting for NaN values.
