### PR TITLE
Fix VSO 10259529: Add assertion to satisfy analysis of descriptors[descCount]

### DIFF
--- a/lib/Runtime/Library/JavascriptObject.cpp
+++ b/lib/Runtime/Library/JavascriptObject.cpp
@@ -1726,6 +1726,7 @@ namespace Js
 
             tempVar = JavascriptOperators::GetProperty(props, propId, scriptContext);
 
+            AnalysisAssert(descCount < descSize);
             if (!JavascriptOperators::ToPropertyDescriptor(tempVar, &descriptors[descCount].descriptor, scriptContext))
             {
                 JavascriptError::ThrowTypeError(scriptContext, JSERR_PropertyDescriptor_Invalid, scriptContext->GetPropertyName(propId)->GetBuffer());

--- a/lib/Runtime/Library/JavascriptObject.cpp
+++ b/lib/Runtime/Library/JavascriptObject.cpp
@@ -486,7 +486,7 @@ namespace Js
         if (type == TypeIds_HostDispatch)
         {
             RecyclableObject* hostDispatchObject = RecyclableObject::FromVar(thisArg);
-            DynamicObject* remoteObject = hostDispatchObject->GetRemoteObject();
+            const DynamicObject* remoteObject = hostDispatchObject->GetRemoteObject();
             if (!remoteObject)
             {
                 Var result = nullptr;
@@ -1901,7 +1901,7 @@ namespace Js
                 && _wcsicmp(Js::ScriptFunction::FromVar(descriptor.GetGetter())->GetFunctionProxy()->GetDisplayName(), _u("get")) == 0)
             {
                 // modify to name.get
-                char16* finalName = ConstructName(propertyRecord, _u(".get"), scriptContext);
+                const char16* finalName = ConstructName(propertyRecord, _u(".get"), scriptContext);
                 if (finalName != nullptr)
                 {
                     FunctionProxy::SetDisplayNameFlags flags = (FunctionProxy::SetDisplayNameFlags) (FunctionProxy::SetDisplayNameFlagsDontCopy | FunctionProxy::SetDisplayNameFlagsRecyclerAllocated);
@@ -1916,7 +1916,7 @@ namespace Js
                 && _wcsicmp(Js::ScriptFunction::FromVar(descriptor.GetSetter())->GetFunctionProxy()->GetDisplayName(), _u("set")) == 0)
             {
                 // modify to name.set
-                char16* finalName = ConstructName(propertyRecord, _u(".set"), scriptContext);
+                const char16* finalName = ConstructName(propertyRecord, _u(".set"), scriptContext);
                 if (finalName != nullptr)
                 {
                     FunctionProxy::SetDisplayNameFlags flags = (FunctionProxy::SetDisplayNameFlags) (FunctionProxy::SetDisplayNameFlagsDontCopy | FunctionProxy::SetDisplayNameFlagsRecyclerAllocated);
@@ -1933,7 +1933,7 @@ namespace Js
         BOOL returnValue;
         obj->ThrowIfCannotDefineProperty(propId, descriptor);
 
-        Type* oldType = obj->GetType();
+        const Type* oldType = obj->GetType();
         obj->ClearWritableDataOnlyDetectionBit();
 
         // HostDispatch: it doesn't support changing property attributes and default attributes are not per ES5,


### PR DESCRIPTION
Fix VSO 10259529: Add assertion to satisfy analysis of descriptors[descCount] in JavascriptObject::DefinePropertiesHelperForGenericObjects.

Fix some OACR warnings about non-const locals in JavascriptObject.cpp since I was already fixing an OACR warning in the area.