### PR TITLE
2 very simple redeferral fixes

### DIFF
--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -900,6 +900,10 @@ namespace Js
             {
                 functionType->SetEntryPoint(GetScriptContext()->DeferredParsingThunk);
             }
+            if (!CrossSite::IsThunk(functionType->GetEntryPointInfo()->jsMethod))
+            {
+                functionType->GetEntryPointInfo()->jsMethod = GetScriptContext()->DeferredParsingThunk;
+            }
         });
 
         this->Cleanup(false);

--- a/lib/Runtime/Library/StackScriptFunction.cpp
+++ b/lib/Runtime/Library/StackScriptFunction.cpp
@@ -349,8 +349,8 @@ namespace Js
                         ScopeSlots slots(slotArray);
                         if (slots.IsFunctionScopeSlotArray())
                         {
-                            FunctionBody *functionBody = slots.GetFunctionInfo()->GetFunctionBody();
-                            if (this->NeedBoxFrame(functionBody))
+                            FunctionProxy *functionProxy = slots.GetFunctionInfo()->GetFunctionProxy();
+                            if (functionProxy->IsFunctionBody() && this->NeedBoxFrame(functionProxy->GetFunctionBody()))
                             {
                                 break;
                             }


### PR DESCRIPTION
1. Now that the ScopeSlots structure uses a FunctionInfo*, make sure that the FunctionInfo points to a full FunctionBody before attempting to box a StackScriptFunction. 2. In addition to changing the type's entry point when we redefer, make sure we change a ScriptFunctionType's entry point info's entry point. This is necessary in the case of a cross-site call to a redeferred function.