### PR TITLE
Allocate more elements for `new Array()`

### DIFF
--- a/lib/Backend/Lower.h
+++ b/lib/Backend/Lower.h
@@ -520,11 +520,16 @@ private:
     void            GenerateRecyclerAlloc(IR::JnHelperMethod allocHelper, size_t allocSize, IR::RegOpnd* newObjDst, IR::Instr* insertionPointInstr, bool inOpHelper = false);
 
     template <typename ArrayType>
-    IR::RegOpnd *   GenerateArrayAlloc(IR::Instr *instr, uint32 * psize, Js::ArrayCallSiteInfo * arrayInfo, bool * pIsHeadSegmentZeroed, bool isArrayObjCtor = false);
+    IR::RegOpnd *   GenerateArrayAllocHelper(IR::Instr *instr, uint32 * psize, Js::ArrayCallSiteInfo * arrayInfo, bool * pIsHeadSegmentZeroed, bool isArrayObjCtor, bool isNoArgs);
+    template <typename ArrayType>
+    IR::RegOpnd *   GenerateArrayLiteralsAlloc(IR::Instr *instr, uint32 * psize, Js::ArrayCallSiteInfo * arrayInfo, bool * pIsHeadSegmentZeroed);
+    template <typename ArrayType>
+    IR::RegOpnd *   GenerateArrayObjectsAlloc(IR::Instr *instr, uint32 * psize, Js::ArrayCallSiteInfo * arrayInfo, bool * pIsHeadSegmentZeroed, bool isNoArgs);
+
     template <typename ArrayType>
     IR::RegOpnd *   GenerateArrayAlloc(IR::Instr *instr, IR::Opnd * sizeOpnd, Js::ArrayCallSiteInfo * arrayInfo);
 
-    void            GenerateProfiledNewScObjArrayFastPath(IR::Instr *instr, Js::ArrayCallSiteInfo * arrayInfo, intptr_t arrayInfoAddr, intptr_t weakFuncRef, uint32 length, IR::LabelInstr* labelDone);
+    void            GenerateProfiledNewScObjArrayFastPath(IR::Instr *instr, Js::ArrayCallSiteInfo * arrayInfo, intptr_t arrayInfoAddr, intptr_t weakFuncRef, uint32 length, IR::LabelInstr* labelDone, bool isNoArgs);
 
     template <typename ArrayType>
     void            GenerateProfiledNewScObjArrayFastPath(IR::Instr *instr, Js::ArrayCallSiteInfo * arrayInfo, intptr_t arrayInfoAddr, intptr_t weakFuncRef, IR::LabelInstr* helperLabel, IR::LabelInstr* labelDone, IR::Opnd* lengthOpnd, uint32 offsetOfCallSiteIndex, uint32 offsetOfWeakFuncRef);

--- a/lib/Runtime/Library/JavascriptArray.cpp
+++ b/lib/Runtime/Library/JavascriptArray.cpp
@@ -1109,15 +1109,8 @@ namespace Js
 
         if (callInfo.Count < 2)
         {
-            if (pNew == nullptr)
-            {
-                // No arguments passed to Array(), so create with the default size (0).
-                pNew = CreateArrayFromConstructor(function, 0, scriptContext);
-            }
-            else
-            {
-                pNew->SetLength((uint32)0);
-            }
+            // No arguments passed to Array(), so create with the default size (0).
+            pNew = CreateArrayFromConstructorNoArg(function, scriptContext);
 
             return isCtorSuperCall ?
                 JavascriptOperators::OrdinaryCreateFromConstructor(RecyclableObject::FromVar(newTarget), pNew, nullptr, scriptContext) :
@@ -1138,14 +1131,7 @@ namespace Js
                     JavascriptError::ThrowRangeError(scriptContext, JSERR_ArrayLengthConstructIncorrect);
                 }
 
-                if (pNew == nullptr)
-                {
-                    pNew = CreateArrayFromConstructor(function, elementCount, scriptContext);
-                }
-                else
-                {
-                    pNew->SetLength(elementCount);
-                }
+                pNew = CreateArrayFromConstructor(function, elementCount, scriptContext);
             }
             else if (JavascriptNumber::Is_NoTaggedIntCheck(firstArgument))
             {
@@ -1157,14 +1143,7 @@ namespace Js
                     JavascriptError::ThrowRangeError(scriptContext, JSERR_ArrayLengthConstructIncorrect);
                 }
 
-                if (pNew == nullptr)
-                {
-                    pNew = CreateArrayFromConstructor(function, uvalue, scriptContext);
-                }
-                else
-                {
-                    pNew->SetLength(uvalue);
-                }
+                pNew = CreateArrayFromConstructor(function, uvalue, scriptContext);
             }
             else
             {
@@ -1174,10 +1153,7 @@ namespace Js
                 // Set first element as the passed Var
                 //
 
-                if (pNew == nullptr)
-                {
-                    pNew = CreateArrayFromConstructor(function, 1, scriptContext);
-                }
+                pNew = CreateArrayFromConstructor(function, 1, scriptContext);
 
                 JavascriptOperators::SetItem(pNew, pNew, 0u, firstArgument, scriptContext, PropertyOperation_ThrowIfNotExtensible);
 
@@ -1193,22 +1169,7 @@ namespace Js
         {
             // Called with a list of initial element values.
             // Create an array of the appropriate length and walk the list.
-
-            if (pNew == nullptr)
-            {
-                pNew = CreateArrayFromConstructor(function, callInfo.Count - 1, scriptContext);
-            }
-            else
-            {
-                // If we were passed an uninitialized JavascriptArray as the this argument,
-                // we need to set the length. We should do this _after_ setting the
-                // elements as the array may have side effects such as a setter for property
-                // named '0' which would make the previous length of the array observable.
-                // Note: We don't support this case now as the DirectSetItemAt calls in FillFromArgs
-                // will not call the setter. Need to refactor that method.
-                pNew->SetLength(callInfo.Count - 1);
-            }
-
+            pNew = CreateArrayFromConstructor(function, callInfo.Count - 1, scriptContext);
             pNew->JavascriptArray::FillFromArgs(callInfo.Count - 1, 0, args.Values);
         }
 
@@ -1228,10 +1189,14 @@ namespace Js
         // Note: We need to use the library from the ScriptContext of the constructor, not the currently executing function.
         //       This is for the case where a built-in @@create method from a different JavascriptLibrary is installed on
         //       constructor.
-        JavascriptArray* arr = library->CreateArray(length);
+        return library->CreateArray(length);
+    }
 
-        return arr;
-}
+    JavascriptArray* JavascriptArray::CreateArrayFromConstructorNoArg(RecyclableObject* constructor, ScriptContext* scriptContext)
+    {
+        JavascriptLibrary* library = constructor->GetLibrary();
+        return library->CreateArray();
+    }
 
 #if ENABLE_PROFILE_INFO
     Var JavascriptArray::ProfiledNewInstanceNoArg(RecyclableObject *function, ScriptContext *scriptContext, ArrayCallSiteInfo *arrayInfo, RecyclerWeakReference<FunctionBody> *weakFuncRef)

--- a/lib/Runtime/Library/JavascriptArray.h
+++ b/lib/Runtime/Library/JavascriptArray.h
@@ -379,6 +379,7 @@ namespace Js
         }
 
         static JavascriptArray* CreateArrayFromConstructor(RecyclableObject* constructor, uint32 length, ScriptContext* scriptContext);
+        static JavascriptArray* CreateArrayFromConstructorNoArg(RecyclableObject* constructor, ScriptContext* scriptContext);
 
         template<typename unitType, typename className>
         static className* New(Recycler* recycler, DynamicType* arrayType);

--- a/lib/Runtime/Library/JavascriptArray.inl
+++ b/lib/Runtime/Library/JavascriptArray.inl
@@ -158,7 +158,7 @@ namespace Js
         size_t allocationPlusSize;
         uint alignedInlineElementSlots;
         DetermineAllocationSizeForArrayObjects<className, 0>(
-            0,
+            SparseArraySegmentBase::SMALL_CHUNK_SIZE,
             &allocationPlusSize,
             &alignedInlineElementSlots);
         return RecyclerNewPlusZ(recycler, allocationPlusSize, className, type, alignedInlineElementSlots);


### PR DESCRIPTION
With #1363, I changed the allocation buckets to allocate space for 2 elements if user calls `new Array()` or size passed to Array ctor is 0. However there can be cases where user creates array using `new Array()` but then set elements to indices beyond size 2. With my change, we will go through slow path to set these elements.
    
 As part of the fix, revert the `new Array()` case to allocate same amount of space before my #1363 changes. This doesn't change the `new Array(0) or (foo = 0; new Array(foo);` case and will continue to allocate space for just 2 elements.

I have opened #2324 to gather profile data of array's length which will help us specify the right length for such scenarios during array allocation in JIT.