### PR TITLE
Solve an AST anomaly in rare redeferral cases.

### DIFF
--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -2132,28 +2132,7 @@ namespace Js
         bool isDebugOrAsmJsReparse = false;
         FunctionBody* funcBody = nullptr;
 
-        // If we throw or fail with the function body in an unfinished state, make sure the function info is still
-        // pointing to the old ParseableFunctionInfo and has the right attributes.
-        class AutoRestoreFunctionInfo {
-        public:
-            AutoRestoreFunctionInfo(ParseableFunctionInfo *pfi) : pfi(pfi), funcBody(nullptr) {}
-            ~AutoRestoreFunctionInfo() {
-                if (this->pfi != nullptr && this->pfi->GetFunctionInfo()->GetFunctionProxy() != this->pfi)
-                {
-                    FunctionInfo *functionInfo = this->pfi->functionInfo;
-                    functionInfo->SetAttributes(
-                        (FunctionInfo::Attributes)(functionInfo->GetAttributes() | FunctionInfo::Attributes::DeferredParse));
-                    functionInfo->SetFunctionProxy(this->pfi);
-                    functionInfo->SetOriginalEntryPoint(DefaultEntryThunk);
-                }
-
-                Assert(this->pfi == nullptr || (this->pfi->GetFunctionInfo()->GetFunctionProxy() == this->pfi && !this->pfi->IsFunctionBody()));
-            }
-            void Clear() { pfi = nullptr; funcBody = nullptr; }
-
-            ParseableFunctionInfo * pfi;
-            FunctionBody          * funcBody;
-        } autoRestoreFunctionInfo(this);
+        AutoRestoreFunctionInfo autoRestoreFunctionInfo(this, DefaultEntryThunk);
 
         // If m_hasBeenParsed = true, one of the following things happened:
         // - We had multiple function objects which were all defer-parsed, but with the same function body and one of them

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -3669,6 +3669,30 @@ namespace Js
         StatementAdjustmentRecordList* GetStatementAdjustmentRecords();
     };
 
+    class AutoRestoreFunctionInfo {
+    public:
+        AutoRestoreFunctionInfo(ParseableFunctionInfo *pfi, const JavascriptMethod originalEntryPoint) : pfi(pfi), funcBody(nullptr), originalEntryPoint(originalEntryPoint) {}
+        ~AutoRestoreFunctionInfo() {
+            if (this->pfi != nullptr && this->pfi->GetFunctionInfo()->GetFunctionProxy() != this->pfi)
+            {
+                FunctionInfo *functionInfo = this->pfi->GetFunctionInfo();
+                functionInfo->SetAttributes(
+                    (FunctionInfo::Attributes)(functionInfo->GetAttributes() | FunctionInfo::Attributes::DeferredParse));
+                functionInfo->SetFunctionProxy(this->pfi);
+                functionInfo->SetOriginalEntryPoint(originalEntryPoint);
+            }
+
+            Assert(this->pfi == nullptr || (this->pfi->GetFunctionInfo()->GetFunctionProxy() == this->pfi && !this->pfi->IsFunctionBody()));
+        }
+        void Clear() { pfi = nullptr; funcBody = nullptr; }
+
+        ParseableFunctionInfo * pfi;
+        FunctionBody          * funcBody;
+        const JavascriptMethod originalEntryPoint;
+    };
+
+    // If we throw or fail with the function body in an unfinished state, make sure the function info is still
+    // pointing to the old ParseableFunctionInfo and has the right attributes.
     typedef SynchronizableList<FunctionBody*, JsUtil::List<FunctionBody*, ArenaAllocator, false, Js::FreeListedRemovePolicy> > FunctionBodyList;
 
     struct ScopeSlots


### PR DESCRIPTION
We may redefer a nested function but choose not to defer it when we recompile the enclosing function. In such a case, the existing nested FunctionProxy is a compact ParseableFunctionInfo, not the full FunctionBody the front end expects to generate. We were keeping the compact structure and discarding the AST subtree belonging to the nested function, but this seems to be producing anomalous AST's that cause problems downstream. Generate the full FunctionBody on the fly instead.