### PR TITLE
Fix leak in deferred function dictionary. 

### DIFF
--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -2145,6 +2145,7 @@ namespace Js
         // - This is an already parsed asm.js module, which has been invalidated at link time and must be reparsed as a non-asm.js function
         if (!this->m_hasBeenParsed)
         {
+            this->GetUtf8SourceInfo()->StopTrackingDeferredFunction(this->GetLocalFunctionId());
             funcBody = FunctionBody::NewFromParseableFunctionInfo(this);
             autoRestoreFunctionInfo.funcBody = funcBody;
 

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -1282,6 +1282,7 @@ FuncInfo * ByteCodeGenerator::StartBindFunction(const char16 *name, uint nameLen
             {
                 if (!reuseNestedFunc->IsFunctionBody())
                 {
+                    reuseNestedFunc->GetUtf8SourceInfo()->StopTrackingDeferredFunction(reuseNestedFunc->GetLocalFunctionId());
                     Js::FunctionBody * parsedFunctionBody =
                         Js::FunctionBody::NewFromParseableFunctionInfo(reuseNestedFunc->GetParseableFunctionInfo());
                     autoRestoreFunctionInfo.funcBody = parsedFunctionBody;


### PR DESCRIPTION
Now that the deferred function dictionary is leaf memory, we need to remove ParseableFunctionInfo's from it as they are undeferred.