### PR TITLE
OS9791203:Failfast in Tweetium and other UWA background task

### DIFF
--- a/lib/Backend/JITTimeFunctionBody.cpp
+++ b/lib/Backend/JITTimeFunctionBody.cpp
@@ -139,11 +139,6 @@ JITTimeFunctionBody::InitializeJITFunctionData(
     jitBody->attributes = functionBody->GetAttributes();
     jitBody->isInstInlineCacheCount = functionBody->GetIsInstInlineCacheCount();
 
-    if (functionBody->GetUtf8SourceInfo()->GetCbLength() > UINT_MAX)
-    {
-        Js::Throw::OutOfMemory();
-    }
-
     jitBody->byteCodeCount = functionBody->GetByteCodeCount();
     jitBody->byteCodeInLoopCount = functionBody->GetByteCodeInLoopCount();
     jitBody->nonLoadByteCodeCount = functionBody->GetByteCodeWithoutLDACount();


### PR DESCRIPTION
Multi-thread race condition causes inconsistency in chakra's DynamicSourceHolder vs. WWAHost's internal mapping count. Fix by removing call to dynamic source holder from backend JIT code.