### PR TITLE
Clean up some redeferral logic subsumed by other fixes. 

### DIFF
--- a/lib/Runtime/Base/FunctionInfo.h
+++ b/lib/Runtime/Base/FunctionInfo.h
@@ -153,25 +153,4 @@ namespace Js
             : FunctionInfo(entryPoint, Attributes::DoNotProfile)
         {}
     };
-
-    class AutoDisableRedeferral
-    {
-    public:
-        bool canBeDeferred;
-        FunctionInfo * functionInfo;
-        AutoDisableRedeferral(FunctionInfo* functionInfo)
-        {
-            this->functionInfo = functionInfo;
-            this->canBeDeferred = functionInfo->CanBeDeferred();
-            this->functionInfo->SetAttributes((FunctionInfo::Attributes)(this->functionInfo->GetAttributes() & ~FunctionInfo::Attributes::CanDefer));
-        }
-
-        ~AutoDisableRedeferral()
-        {
-            if (this->canBeDeferred)
-            {
-                this->functionInfo->SetAttributes((FunctionInfo::Attributes)(this->functionInfo->GetAttributes() | FunctionInfo::Attributes::CanDefer));
-            }
-        }
-    };
 };

--- a/lib/Runtime/Library/JavascriptFunction.cpp
+++ b/lib/Runtime/Library/JavascriptFunction.cpp
@@ -1648,10 +1648,6 @@ LABEL1:
 
         Assert(functionInfo);
 
-        // Prevent redeferring during parsing
-        bool canBeDeferred = functionInfo->CanBeDeferred();
-        functionInfo->SetAttributes((FunctionInfo::Attributes)(functionInfo->GetAttributes() & ~FunctionInfo::Attributes::CanDefer));
-
         if (functionInfo->IsDeferredParseFunction())
         {
             if (ScriptFunctionWithInlineCache::Is(*functionRef))
@@ -1683,12 +1679,6 @@ LABEL1:
 #else // !ENABLE_SCRIPT_PROFILING
         Assert(directEntryPoint != DefaultDeferredParsingThunk);
 #endif
-
-        // Restore the can-be-deferred attribute.
-        if (canBeDeferred)
-        {
-            funcBody->SetAttributes((FunctionInfo::Attributes)(funcBody->GetAttributes() | FunctionInfo::Attributes::CanDefer));
-        }
 
         JavascriptMethod thunkEntryPoint = (*functionRef)->UpdateUndeferredBody(funcBody);
 

--- a/lib/Runtime/Library/ScriptFunction.cpp
+++ b/lib/Runtime/Library/ScriptFunction.cpp
@@ -66,10 +66,6 @@ namespace Js
         FunctionProxy* functionProxy = (*infoRef)->GetFunctionProxy();
         AssertMsg(functionProxy!= nullptr, "BYTE-CODE VERIFY: Must specify a valid function to create");
 
-        // Prevent redeferral if GC happens during creation of function object.
-        // REVIEW: Should we treat creation of a function object as a "use" of the function body?
-        Js::AutoDisableRedeferral autoDisableRedeferral(functionProxy->GetFunctionInfo());
-
         ScriptContext* scriptContext = functionProxy->GetScriptContext();
 
         bool hasSuperReference = functionProxy->HasSuperReference();


### PR DESCRIPTION
Remove AutoDisableRedeferral and the attribute-setting logic under ParseableFunctionInfo::Parse.