### PR TITLE
swb: trivial cleanup

### DIFF
--- a/lib/Runtime/Language/Arguments.h
+++ b/lib/Runtime/Language/Arguments.h
@@ -105,9 +105,6 @@ inline int _count_args(const T1&, const T2&, const T3&, const T4&, Js::CallInfo 
 
 namespace Js
 {
-    // TODO: (leish)(swb) this is not always stack allocated now
-    // with ES6 Generator, this can be allocated with recycler
-    // need to find a good way to set write barrier, or big refactor.
     struct Arguments
     {
     public:
@@ -127,8 +124,11 @@ namespace Js
             AssertMsg((idxArg < (int)Info.Count) && (idxArg >= 0), "Ensure a valid argument index");
             return Values[idxArg];
         }
-        CallInfo Info;
-        Var* Values;
+
+        // swb: Arguments is mostly used on stack and does not need write barrier.
+        // It is recycler allocated with ES6 generators. We handle that specially.
+        FieldNoBarrier(CallInfo) Info;
+        FieldNoBarrier(Var*) Values;
 
         static uint32 GetCallInfoOffset() { return offsetof(Arguments, Info); }
         static uint32 GetValuesOffset() { return offsetof(Arguments, Values); }

--- a/test/StackTrace/rlexe.xml
+++ b/test/StackTrace/rlexe.xml
@@ -84,9 +84,8 @@
     <default>
       <tags>StackTrace,exclude_ship</tags>
       <files>StackTraceLimitOOS.js</files>
-      <compile-flags>-ExtendedErrorStackForTestHost -on:interruptprobe</compile-flags>
       <baseline>StackTraceLimitOOS.baseline</baseline>
-      <compile-flags>-ExtendedErrorStackForTestHost</compile-flags>
+      <compile-flags>-ExtendedErrorStackForTestHost -on:interruptprobe</compile-flags>
     </default>
   </test>
   <test>


### PR DESCRIPTION
Annotate "Arguments" fields with FieldNoBarrier, so that the plugin checker
is happy.

Revert a JavascriptGenerator change Lei accidentally removed (credit to
Lei).

One StackTrace test config seems incorrect. It contained 2 "compile-flags"
and the 2nd overrided 1st, making the test exactly the same as a previous
one.
