### PR TITLE
Change policy on root removal

### DIFF
--- a/lib/Common/Memory/Recycler.cpp
+++ b/lib/Common/Memory/Recycler.cpp
@@ -702,9 +702,9 @@ Recycler::RootRelease(void* obj, uint *count)
         RECYCLER_PERF_COUNTER_DEC(PinnedObject);
     }
 
-    // Not a real collection. This doesn't activate GC.
-    // This tell the GC that we have an exhaustive candidate, and should trigger
-    // another GC if there is an exhaustive GC going on.
+    // Any time a root is removed during a GC, it indicates that an exhaustive
+    // collection is likely going to have work to do so trigger an exhaustive
+    // candidate GC to indicate this fact
     this->CollectNow<CollectExhaustiveCandidate>();
 }
 
@@ -7717,6 +7717,11 @@ Recycler::DeleteGuestArena(ArenaAllocator * arenaAllocator)
     {
         guestArenaList.RemoveElement(&HeapAllocator::Instance, guestArenaAllocator);
     }
+
+    // Any time a root is removed during a GC, it indicates that an exhaustive
+    // collection is likely going to have work to do so trigger an exhaustive
+    // candidate GC to indicate this fact
+    this->CollectNow<CollectExhaustiveCandidate>();
 }
 
 #ifdef LEAK_REPORT

--- a/lib/Common/Memory/Recycler.h
+++ b/lib/Common/Memory/Recycler.h
@@ -1247,11 +1247,21 @@ public:
     void UnregisterExternalGuestArena(ArenaData* guestArena)
     {
         externalGuestArenaList.Remove(&NoThrowHeapAllocator::Instance, guestArena);
+
+        // Any time a root is removed during a GC, it indicates that an exhaustive
+        // collection is likely going to have work to do so trigger an exhaustive
+        // candidate GC to indicate this fact
+        this->CollectNow<CollectExhaustiveCandidate>();
     }
 
     void UnregisterExternalGuestArena(ArenaData** guestArena)
     {
         externalGuestArenaList.RemoveElement(&NoThrowHeapAllocator::Instance, guestArena);
+
+        // Any time a root is removed during a GC, it indicates that an exhaustive
+        // collection is likely going to have work to do so trigger an exhaustive
+        // candidate GC to indicate this fact
+        this->CollectNow<CollectExhaustiveCandidate>();
     }
 
 #ifdef RECYCLER_TEST_SUPPORT

--- a/test/typedarray/rlexe.xml
+++ b/test/typedarray/rlexe.xml
@@ -314,14 +314,13 @@ Below test fails with difference in space. Investigate the cause and re-enable t
       <compile-flags>-mic:1 -off:simplejit -off:JITLoopBody -mmoc:0</compile-flags>
     </default>
   </test>
-  <!--Disabling this test case until the bug 9706251 is fixed
   <test>
     <default>
       <files>typedarray_bugfixes.js</files>
       <compile-flags>-Off:Deferparse -args summary -endargs</compile-flags>
       <tags>BugFix</tags>
     </default>
-  </test>-->
+  </test>
   <test>
     <default>
       <files>bug_OS_6911900.js</files>


### PR DESCRIPTION
Currently, if RootRelease is called on a pinned object, we indicate that we have a candidate for an exhaustive GC. However, we don't do this for other sources of root removal- this change expands the RootRelease behavior to all cases of explicit root unpinning, since any such unpinning indicates a candidate for an exhaustive GC.
