### PR TITLE
swb: a few fixes (module namespace, Debugger)

### DIFF
--- a/bin/ch/Debugger.cpp
+++ b/bin/ch/Debugger.cpp
@@ -192,6 +192,11 @@ Debugger::Debugger(JsRuntimeHandle runtime)
 
 Debugger::~Debugger()
 {
+    if (this->m_context != JS_INVALID_REFERENCE)
+    {
+        ChakraRTInterface::JsRelease(this->m_context, nullptr);
+        this->m_context = JS_INVALID_REFERENCE;
+    }
     this->m_runtime = JS_INVALID_RUNTIME_HANDLE;
 }
 
@@ -225,7 +230,9 @@ bool Debugger::Initialize()
     // Create a new context and run dbgcontroller.js in that context
     // setup dbgcontroller.js callbacks
 
+    Assert(this->m_context == JS_INVALID_REFERENCE);
     IfJsrtErrorFailLogAndRetFalse(ChakraRTInterface::JsCreateContext(this->m_runtime, &this->m_context));
+    IfJsrtErrorFailLogAndRetFalse(ChakraRTInterface::JsAddRef(this->m_context, nullptr)); // Pin context
 
     AutoRestoreContext autoRestoreContext(this->m_context);
 

--- a/lib/Backend/IRBuilder.cpp
+++ b/lib/Backend/IRBuilder.cpp
@@ -3823,7 +3823,7 @@ IRBuilder::BuildElementSlotI2(Js::OpCode newOpcode, uint32 offset, Js::RegSlot r
         case Js::OpCode::LdModuleSlot:
         case Js::OpCode::StModuleSlot:
         {
-            Js::Var* moduleExportVarArrayAddr = Js::JavascriptOperators::OP_GetModuleExportSlotArrayAddress(slotId1, slotId2, m_func->GetScriptContextInfo());
+            Field(Js::Var)* moduleExportVarArrayAddr = Js::JavascriptOperators::OP_GetModuleExportSlotArrayAddress(slotId1, slotId2, m_func->GetScriptContextInfo());
             IR::AddrOpnd* addrOpnd = IR::AddrOpnd::New(moduleExportVarArrayAddr, IR::AddrOpndKindConstantAddress, m_func, true);
             regOpnd = IR::RegOpnd::New(TyVar, m_func);
             instr = IR::Instr::New(Js::OpCode::Ld_A, regOpnd, addrOpnd, m_func);

--- a/lib/Backend/ServerScriptContext.cpp
+++ b/lib/Backend/ServerScriptContext.cpp
@@ -351,7 +351,7 @@ ServerScriptContext::Release()
     }
 }
 
-Js::Var*
+Field(Js::Var)*
 ServerScriptContext::GetModuleExportSlotArrayAddress(uint moduleIndex, uint slotIndex)
 {
     Assert(m_moduleRecords.ContainsKey(moduleIndex));
@@ -370,7 +370,7 @@ ServerScriptContext::AddModuleRecordInfo(unsigned int moduleId, __int64 localExp
 {
     Js::ServerSourceTextModuleRecord* record = HeapNewStructZ(Js::ServerSourceTextModuleRecord);
     record->moduleId = moduleId;
-    record->localExportSlotsAddr = (Js::Var*)localExportSlotsAddr;
+    record->localExportSlotsAddr = (Field(Js::Var)*)localExportSlotsAddr;
     m_moduleRecords.Add(moduleId, record);
 }
 

--- a/lib/Backend/ServerScriptContext.h
+++ b/lib/Backend/ServerScriptContext.h
@@ -71,7 +71,7 @@ public:
     typedef JsUtil::BaseDictionary<uint, Js::ServerSourceTextModuleRecord*, Memory::HeapAllocator> ServerModuleRecords;
     ServerModuleRecords m_moduleRecords;
 
-    virtual Js::Var* GetModuleExportSlotArrayAddress(uint moduleIndex, uint slotIndex) override;
+    virtual Field(Js::Var)* GetModuleExportSlotArrayAddress(uint moduleIndex, uint slotIndex) override;
 
     void SetIsPRNGSeeded(bool value);
     void AddModuleRecordInfo(unsigned int moduleId, __int64 localExportSlotsAddr);

--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -5940,7 +5940,7 @@ void ScriptContext::RegisterPrototypeChainEnsuredToHaveOnlyWritableDataPropertie
         return nameLen;
     }
 
-    Js::Var* ScriptContext::GetModuleExportSlotArrayAddress(uint moduleIndex, uint slotIndex)
+    Field(Js::Var)* ScriptContext::GetModuleExportSlotArrayAddress(uint moduleIndex, uint slotIndex)
     {
         Js::SourceTextModuleRecord* moduleRecord = this->GetModuleRecord(moduleIndex);
         Assert(moduleRecord != nullptr);

--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -1745,7 +1745,7 @@ private:
         virtual bool IsRecyclerVerifyEnabled() const override;
         virtual uint GetRecyclerVerifyPad() const override;
 
-        virtual Js::Var* GetModuleExportSlotArrayAddress(uint moduleIndex, uint slotIndex) override;
+        virtual Field(Js::Var)* GetModuleExportSlotArrayAddress(uint moduleIndex, uint slotIndex) override;
 
         Js::SourceTextModuleRecord* GetModuleRecord(uint moduleId) const
         {

--- a/lib/Runtime/Base/ScriptContextInfo.h
+++ b/lib/Runtime/Base/ScriptContextInfo.h
@@ -48,7 +48,7 @@ public:
 
     virtual bool IsClosed() const = 0;
 
-    virtual Js::Var* GetModuleExportSlotArrayAddress(uint moduleIndex, uint slotIndex) = 0;
+    virtual Field(Js::Var)* GetModuleExportSlotArrayAddress(uint moduleIndex, uint slotIndex) = 0;
 
     virtual intptr_t GetDebuggingFlagsAddr() const = 0;
     virtual intptr_t GetDebugStepTypeAddr() const = 0;

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -6598,14 +6598,14 @@ CommonNumber:
         return propertyId;
     }
 
-    Var* JavascriptOperators::OP_GetModuleExportSlotArrayAddress(uint moduleIndex, uint slotIndex, ScriptContextInfo* scriptContext)
+    Field(Var)* JavascriptOperators::OP_GetModuleExportSlotArrayAddress(uint moduleIndex, uint slotIndex, ScriptContextInfo* scriptContext)
     {
         return scriptContext->GetModuleExportSlotArrayAddress(moduleIndex, slotIndex);
     }
 
-    Var* JavascriptOperators::OP_GetModuleExportSlotAddress(uint moduleIndex, uint slotIndex, ScriptContext* scriptContext)
+    Field(Var)* JavascriptOperators::OP_GetModuleExportSlotAddress(uint moduleIndex, uint slotIndex, ScriptContext* scriptContext)
     {
-        Var* moduleRecordSlots = OP_GetModuleExportSlotArrayAddress(moduleIndex, slotIndex, scriptContext);
+        Field(Var)* moduleRecordSlots = OP_GetModuleExportSlotArrayAddress(moduleIndex, slotIndex, scriptContext);
         Assert(moduleRecordSlots != nullptr);
 
         return &moduleRecordSlots[slotIndex];
@@ -6613,7 +6613,7 @@ CommonNumber:
 
     Var JavascriptOperators::OP_LdModuleSlot(uint moduleIndex, uint slotIndex, ScriptContext* scriptContext)
     {
-        Var* addr = OP_GetModuleExportSlotAddress(moduleIndex, slotIndex, scriptContext);
+        Field(Var)* addr = OP_GetModuleExportSlotAddress(moduleIndex, slotIndex, scriptContext);
 
         Assert(addr != nullptr);
 
@@ -6624,7 +6624,7 @@ CommonNumber:
     {
         Assert(value != nullptr);
 
-        Var* addr = OP_GetModuleExportSlotAddress(moduleIndex, slotIndex, scriptContext);
+        Field(Var)* addr = OP_GetModuleExportSlotAddress(moduleIndex, slotIndex, scriptContext);
 
         Assert(addr != nullptr);
 

--- a/lib/Runtime/Language/JavascriptOperators.h
+++ b/lib/Runtime/Language/JavascriptOperators.h
@@ -292,8 +292,8 @@ namespace Js
         static void OP_InitClassMemberSet(Var object, PropertyId propertyId, Var setter);
         static void OP_InitClassMemberSetComputedName(Var object, Var elementName, Var getter, ScriptContext* scriptContext, PropertyOperationFlags flags = PropertyOperation_None);
 
-        static Var* OP_GetModuleExportSlotArrayAddress(uint moduleIndex, uint slotIndex, ScriptContextInfo* scriptContext);
-        static Var* OP_GetModuleExportSlotAddress(uint moduleIndex, uint slotIndex, ScriptContext* scriptContext);
+        static Field(Var)* OP_GetModuleExportSlotArrayAddress(uint moduleIndex, uint slotIndex, ScriptContextInfo* scriptContext);
+        static Field(Var)* OP_GetModuleExportSlotAddress(uint moduleIndex, uint slotIndex, ScriptContext* scriptContext);
         static Var OP_LdModuleSlot(uint moduleIndex, uint slotIndex, ScriptContext* scriptContext);
         static void OP_StModuleSlot(uint moduleIndex, uint slotIndex, Var value, ScriptContext* scriptContext);
 

--- a/lib/Runtime/Language/ModuleNamespace.h
+++ b/lib/Runtime/Language/ModuleNamespace.h
@@ -90,7 +90,7 @@ namespace Js
         Field(ListForListIterator*) sortedExportedNames;   // sorted exported names for both local and indirect exports; excludes symbols.
         Field(Field(Var)*) nsSlots;
 
-        void SetNSSlotsForModuleNS(Var* nsSlot) { this->nsSlots = (Field(Var)*)nsSlot; }
+        void SetNSSlotsForModuleNS(Field(Var)* nsSlot) { this->nsSlots = nsSlot; }
         Var GetNSSlot(BigPropertyIndex propertyIndex);
         void AddUnambiguousNonLocalExport(PropertyId exportId, ModuleNameRecord* nonLocalExportNameRecord);
         UnambiguousExportMap* GetUnambiguousNonLocalExports() const { return unambiguousNonLocalExports; }

--- a/lib/Runtime/Language/SourceTextModuleRecord.h
+++ b/lib/Runtime/Language/SourceTextModuleRecord.h
@@ -87,8 +87,7 @@ namespace Js
 
         uint GetLocalExportSlotIndexByExportName(PropertyId exportNameId);
         uint GetLocalExportSlotIndexByLocalName(PropertyId localNameId);
-        Var* GetLocalExportSlots() const { return (Var*)(Field(Var)*)localExportSlots; }
-        Var* GetLocalExportSlotAddr(uint slotIndex) const { return (Var*)(Field(Var)*)&localExportSlots[slotIndex]; }
+        Field(Var)* GetLocalExportSlots() const { return localExportSlots; }
         uint GetLocalExportSlotCount() const { return localSlotCount; }
         uint GetModuleId() const { return moduleId; }
         uint GetLocalExportCount() const { return localExportCount; }
@@ -160,6 +159,6 @@ namespace Js
     struct ServerSourceTextModuleRecord
     {
         uint moduleId;
-        Var* localExportSlotsAddr;
+        Field(Var)* localExportSlotsAddr;
     };
 }

--- a/pal/src/cruntime/finite.cpp
+++ b/pal/src/cruntime/finite.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
 //
 
 /*++
@@ -21,15 +21,7 @@ Abstract:
 
 #include "pal/palinternal.h"
 #include "pal/dbgmsg.h"
-
-#if defined(__cplusplus)
-#undef wchar_t
-#endif
 #include <math.h>
-#if defined(__cplusplus)
-#undef wchar_t
-#define wchar_t __wchar_16_cpp__
-#endif // __cplusplus
 
 #if HAVE_IEEEFP_H
 #include <ieeefp.h>
@@ -106,8 +98,8 @@ Function:
 
 See MSDN doc
 --*/
-double
-__cdecl
+double 
+__cdecl 
 _copysign(
           double x,
           double y)
@@ -254,7 +246,7 @@ PALIMPORT double __cdecl PAL_exp(double x)
     PERF_ENTRY(exp);
     ENTRY("exp (x=%f)\n", x);
 #if !HAVE_COMPATIBLE_EXP
-    if (x == 1.0)
+    if (x == 1.0) 
     {
         ret = M_E;
     }
@@ -282,8 +274,8 @@ PALIMPORT LONG __cdecl PAL_labs(LONG l)
 
     PERF_ENTRY(labs);
     ENTRY("labs (l=%ld)\n", l);
-
-    lRet = labs(l);
+    
+    lRet = labs(l);    
 
     LOGEXIT("labs returns long %ld\n", lRet);
     PERF_EXIT(labs);


### PR DESCRIPTION
### swb: fix module namespace annotation

OP_StModuleSlot was changing slot without write barrier. Annotate all
related code.

(Credit to Lei for finding it is module namespace related.)

### Revert "fix a pal build issue on my machine"

This reverts commit c49e4af5d4242f07ed74c98b0afd9fcd1eb604a2.

It should now work after Oguz removed wchar_t redef from PAL.

### pin Debugger::m_context

Found under stress unit testing. Debugger::m_context was not pinned
and could be GC collected when not in use.