### PR TITLE
Proxy : fixing a case related to GetOwnProperty.

### DIFF
--- a/lib/Runtime/Library/JavascriptProxy.cpp
+++ b/lib/Runtime/Library/JavascriptProxy.cpp
@@ -645,6 +645,21 @@ namespace Js
         }
         else
         {
+            // ES2017 Spec'ed (9.1.9.1): 
+            // If existingDescriptor is not undefined, then
+            //    If IsAccessorDescriptor(existingDescriptor) is true, return false.
+            //    If existingDescriptor.[[Writable]] is false, return false.
+
+            if (proxyPropertyDescriptor.IsAccessorDescriptor())
+            {
+                return FALSE;
+            }
+
+            if (proxyPropertyDescriptor.WritableSpecified() && !proxyPropertyDescriptor.IsWritable())
+            {
+                return FALSE;
+            }
+
             proxyPropertyDescriptor.SetValue(value);
             proxyPropertyDescriptor.SetOriginal(nullptr);
             return Js::JavascriptOperators::DefineOwnPropertyDescriptor(this, propertyId, proxyPropertyDescriptor, true, scriptContext);


### PR DESCRIPTION
According to OridinarySet(9.1.9.1) if the proxy returns the existing reciever we need to apply few checks and return from there.
Let existingDescriptor be ? Receiver.[[GetOwnProperty]](P).
If existingDescriptor is not undefined, then
    If IsAccessorDescriptor(existingDescriptor) is true, return false.
    If existingDescriptor.[[Writable]] is false, return false.

Fixed the codebase now, which fixes one assert as well.
