### PR TITLE
Add Sharp S and Kelvin sign to word-chars. Fixes #1181.

### DIFF
--- a/lib/Parser/RegexParser.cpp
+++ b/lib/Parser/RegexParser.cpp
@@ -1694,7 +1694,14 @@ namespace UnifiedRegex
             case 'w':
                 {
                     MatchSetNode *setNode = Anew(ctAllocator, MatchSetNode, false, false);
-                    standardChars->SetWordChars(ctAllocator, setNode->set);
+                    if (this->unicodeFlagPresent && this->caseInsensitiveFlagPresent)
+                    {
+                        standardChars->SetWordIUChars(ctAllocator, setNode->set);
+                    }
+                    else
+                    {
+                        standardChars->SetWordChars(ctAllocator, setNode->set);
+                    }
                     node = setNode;
                     return false; // not an assertion
                 }
@@ -3006,7 +3013,14 @@ namespace UnifiedRegex
                 standardChars->SetNonDigits(ctAllocator, partialPrefixSetNode->set);
                 break;
             case 'W':
-                standardChars->SetNonWordChars(ctAllocator, partialPrefixSetNode->set);
+                if (this->caseInsensitiveFlagPresent)
+                {
+                    standardChars->SetNonWordIUChars(ctAllocator, partialPrefixSetNode->set);
+                }
+                else
+                {
+                    standardChars->SetNonWordChars(ctAllocator, partialPrefixSetNode->set);
+                }
                 break;
             default:
                 AssertMsg(false, "");

--- a/lib/Parser/StandardChars.cpp
+++ b/lib/Parser/StandardChars.cpp
@@ -193,6 +193,8 @@ END {
     const char16* const StandardChars<char16>::whitespaceStr = _u("\x0009\x000d\x0020\x0020\x00a0\x00a0\x1680\x1680\x2000\x200a\x2028\x2029\x202f\x202f\x205f\x205f\x3000\x3000\xfeff\xfeff");
     const int StandardChars<char16>::numWordPairs = 4;
     const char16* const StandardChars<char16>::wordStr = _u("09AZ__az");
+    const int StandardChars<char16>::numWordIUPairs = 6; // Under /iu flags, Sharp S and Kelvin sign map to S and K, respectively.
+    const char16* const StandardChars<char16>::wordIUStr = _u("09AZ__az\x017F\x017F\x212A\x212A");
     const int StandardChars<char16>::numNewlinePairs = 3;
     const char16* const StandardChars<char16>::newlineStr = _u("\x000a\x000a\x000d\x000d\x2028\x2029");
 
@@ -237,6 +239,16 @@ END {
     void StandardChars<char16>::SetNonWordChars(ArenaAllocator* setAllocator, CharSet<Char> &set)
     {
         set.SetNotRanges(setAllocator, numWordPairs, wordStr);
+    }
+
+    void StandardChars<char16>::SetWordIUChars(ArenaAllocator* setAllocator, CharSet<Char> &set)
+    {
+        set.SetRanges(setAllocator, numWordIUPairs, wordIUStr);
+    }
+
+    void StandardChars<char16>::SetNonWordIUChars(ArenaAllocator* setAllocator, CharSet<Char> &set)
+    {
+        set.SetNotRanges(setAllocator, numWordIUPairs, wordIUStr);
     }
 
     void StandardChars<char16>::SetNewline(ArenaAllocator* setAllocator, CharSet<Char> &set)

--- a/lib/Parser/StandardChars.h
+++ b/lib/Parser/StandardChars.h
@@ -243,6 +243,8 @@ namespace UnifiedRegex
         static const Char* const whitespaceStr;
         static const int numWordPairs;
         static const Char* const wordStr;
+        static const int numWordIUPairs;
+        static const Char* const wordIUStr;
         static const int numNewlinePairs;
         static const Char* const newlineStr;
 
@@ -257,6 +259,8 @@ namespace UnifiedRegex
         CharSet<Char>* emptySet;
         CharSet<Char>* wordSet;
         CharSet<Char>* nonWordSet;
+        CharSet<Char>* wordIUSet;
+        CharSet<Char>* nonWordIUSet;
         CharSet<Char>* newlineSet;
         CharSet<Char>* whitespaceSet;
         CharSet<Char>* surrogateUpperRange;
@@ -315,6 +319,8 @@ namespace UnifiedRegex
         void SetNonWhitespace(ArenaAllocator* setAllocator, CharSet<Char> &set);
         void SetWordChars(ArenaAllocator* setAllocator, CharSet<Char> &set);
         void SetNonWordChars(ArenaAllocator* setAllocator, CharSet<Char> &set);
+        void SetWordIUChars(ArenaAllocator* setAllocator, CharSet<Char> &set);
+        void SetNonWordIUChars(ArenaAllocator* setAllocator, CharSet<Char> &set);
         void SetNewline(ArenaAllocator* setAllocator, CharSet<Char> &set);
         void SetNonNewline(ArenaAllocator* setAllocator, CharSet<Char> &set);
 

--- a/test/es6/regex-w-sharp-s-kelvin-sign.js
+++ b/test/es6/regex-w-sharp-s-kelvin-sign.js
@@ -1,0 +1,73 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+var reWordChar = /\w/;
+var reNonWordChar = /\W/;
+var reWordCharI = /\w/i;
+var reNonWordCharI = /\W/i;
+var reWordCharU = /\w/u;
+var reNonWordCharU = /\W/u;
+var reWordCharIU = /\w/iu;
+var reNonWordCharIU = /\W/iu;
+
+var reWordCharName = "word-char";
+var reNonWordCharName = "NON-word-char";
+
+basic_tests = [
+    's', 'S', 'k', 'K'
+];
+
+basic_tests_names = ['lowercase s', 'uppercase S', 'lowercase k', 'uppercase K'];
+
+u_tests = [
+    '\u017F', // Sharp S
+    '\u212A', // Kelvin sign
+];
+
+u_tests_names = ['Sharp S', 'Kelvin sign'];
+
+function assert(a, msg) {
+    if (!a) {
+        console.log("FAIL: " + msg);
+    }
+}
+
+function assertMatch(regex, reName, string, name) {
+    var b = regex.test(string);
+    var msg = "" + regex + " " + reName + " should match '" + string + "' (" + name + ")";
+    assert(b, msg);
+}
+
+function assertNonMatch(regex, reName, string, name) {
+    var b = !regex.test(string);
+    var msg = "" + regex + " " + reName + " should not match '" + string + "' (" + name + ")";
+    assert(b, msg);
+}
+
+for (i in basic_tests) {
+    assertMatch(reWordChar, reWordCharName, basic_tests[i], basic_tests_names[i]);
+    assertMatch(reWordCharI, reWordCharName, basic_tests[i], basic_tests_names[i]);
+    assertMatch(reWordCharU, reWordCharName, basic_tests[i], basic_tests_names[i]);
+    assertMatch(reWordCharIU, reWordCharName, basic_tests[i], basic_tests_names[i]);
+
+    assertNonMatch(reNonWordChar, reNonWordCharName, basic_tests[i], basic_tests_names[i]);
+    assertNonMatch(reNonWordCharI, reNonWordCharName, basic_tests[i], basic_tests_names[i]);
+    assertNonMatch(reNonWordCharU, reNonWordCharName, basic_tests[i], basic_tests_names[i]);
+    assertNonMatch(reNonWordCharIU, reNonWordCharName, basic_tests[i], basic_tests_names[i]);
+}
+
+for (i in u_tests) {
+    assertNonMatch(reWordChar, reWordCharName, u_tests[i], u_tests_names[i]);
+    assertNonMatch(reWordCharI, reWordCharName, u_tests[i], u_tests_names[i]);
+    assertNonMatch(reWordCharU, reWordCharName, u_tests[i], u_tests_names[i]);
+    assertMatch(reWordCharIU, reWordCharName, u_tests[i], u_tests_names[i]);
+
+    assertMatch(reNonWordChar, reWordCharName, u_tests[i], u_tests_names[i]);
+    assertMatch(reNonWordCharI, reNonWordCharName, u_tests[i], u_tests_names[i]);
+    assertMatch(reNonWordCharU, reWordCharName, u_tests[i], u_tests_names[i]);
+    assertNonMatch(reNonWordCharIU, reNonWordCharName, u_tests[i], u_tests_names[i]);
+}
+
+console.log("PASS");

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -1017,6 +1017,11 @@
   </test>
   <test>
     <default>
+      <files>regex-w-sharp-s-kelvin-sign.js</files>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>regexflags.js</files>
       <compile-flags>-version:6 -ES6RegExSticky -ES6Unicode -ES6RegExPrototypeProperties -ES6Destructuring -args summary -endargs</compile-flags>
     </default>


### PR DESCRIPTION
Fixes #1181 

Reviewed by @tcare and @bterlson