### PR TITLE
fix legacy builds

### DIFF
--- a/lib/Common/Memory/WriteBarrierMacros.h
+++ b/lib/Common/Memory/WriteBarrierMacros.h
@@ -16,12 +16,12 @@
 //
 
 #define FieldWithBarrier(type, ...) \
-    typename WriteBarrierFieldTypeTraits<type, ##__VA_ARGS__>::Type
+    WriteBarrierFieldTypeTraits<type, ##__VA_ARGS__>::Type
 
 #if GLOBAL_ENABLE_WRITE_BARRIER
 
 #define Field(type, ...) \
-    FieldWithBarrier(type, ##__VA_ARGS__)
+    typename FieldWithBarrier(type, ##__VA_ARGS__)
 #define FieldNoBarrier(type) \
     typename WriteBarrierFieldTypeTraits<type, _no_write_barrier_policy, _no_write_barrier_policy>::Type
 

--- a/lib/Runtime/Base/AuxPtrs.h
+++ b/lib/Runtime/Base/AuxPtrs.h
@@ -20,7 +20,7 @@ namespace Js
     {
         static const uint8 MaxCount;
         FieldWithBarrier(uint8) count;                 // always saving maxCount
-        FieldWithBarrier(FieldsEnum) type[_MaxCount];  // save instantiated pointer enum
+        typename FieldWithBarrier(FieldsEnum) type[_MaxCount];  // save instantiated pointer enum
         FieldWithBarrier(void*) ptr[_MaxCount];        // save instantiated pointer address
         AuxPtrsFix();
         AuxPtrsFix(AuxPtrsFix<FieldsEnum, 16>* ptr16); // called when promoting from AuxPtrs16 to AuxPtrs32

--- a/lib/Runtime/Base/CompactCounters.h
+++ b/lib/Runtime/Base/CompactCounters.h
@@ -30,7 +30,7 @@ namespace Js
         mutable FieldWithBarrier(bool) bgThreadCallStarted;
         FieldWithBarrier(bool) isCleaningUp;
 #endif
-        FieldWithBarrier(Fields*) fields;
+        typename FieldWithBarrier(Fields*) fields;
 
         CompactCounters() { }
         CompactCounters(T* host)

--- a/lib/Runtime/Base/Constants.cpp
+++ b/lib/Runtime/Base/Constants.cpp
@@ -37,5 +37,5 @@ const size_t Constants::StackLimitForScriptInterrupt = 0x7fffffff;
 #pragma warning(push)
 #pragma warning(disable:4815) // Allow no storage for zero-sized array at end of NullFrameDisplay struct.
 const Js::FrameDisplay Js::NullFrameDisplay = 0;
-const Js::FrameDisplay Js::StrictNullFrameDisplay = FrameDisplay(0, true);
+const Js::FrameDisplay Js::StrictNullFrameDisplay(0, true);
 #pragma warning(pop)

--- a/lib/Runtime/Language/InlineCachePointerArray.h
+++ b/lib/Runtime/Language/InlineCachePointerArray.h
@@ -10,7 +10,7 @@ namespace Js
     class InlineCachePointerArray
     {
     public:
-        FieldWithBarrier(Field(T*)*) inlineCaches;
+        typename FieldWithBarrier(Field(T*)*) inlineCaches;
     private:
 #if DBG
         Field(uint) inlineCacheCount;


### PR DESCRIPTION
Fix build errors raised in legacy builds. Majority of the changes are related to "error C2899:  typename cannot be used outside a template declaration" due to declaration with type FieldWithBarrier outside template. This is an error with older compilers. 