### PR TITLE
Prototype on cached type chain

### DIFF
--- a/lib/Runtime/Types/PathTypeHandler.cpp
+++ b/lib/Runtime/Types/PathTypeHandler.cpp
@@ -1229,6 +1229,9 @@ namespace Js
             {
                 // The new type isn't shared yet.  We will make it shared when the second instance attains it.
                 nextType = instance->DuplicateType();
+                // nextType's prototype and predecessorType's prototype can only be different here
+                // only for SetPrototype scenario where predecessorType is the cachedType with newPrototype
+                nextType->SetPrototype(predecessorType->GetPrototype());
                 nextType->typeHandler = nextPath;
                 markTypeAsShared ? nextType->SetIsLockedAndShared() : nextType->SetIsLocked();
             }
@@ -1576,6 +1579,7 @@ namespace Js
             SimplePathTypeHandler* newTypeHandler = SimplePathTypeHandler::New(scriptContext, scriptContext->GetLibrary()->GetRootPath(), 0, static_cast<PropertyIndex>(this->GetSlotCapacity()), this->GetInlineSlotCapacity(), this->GetOffsetOfInlineSlots(), true, true);
 
             cachedDynamicType = instance->DuplicateType();
+            cachedDynamicType->SetPrototype(newPrototype);
             cachedDynamicType->typeHandler = newTypeHandler;
 
             // Make type locked, shared only if we are using cache
@@ -1661,8 +1665,7 @@ namespace Js
         Assert(cachedDynamicType->GetTypeHandler()->GetOffsetOfInlineSlots() == GetOffsetOfInlineSlots());
         Assert(cachedDynamicType->GetTypeHandler()->GetSlotCapacity() == this->GetSlotCapacity());
         Assert(DynamicObject::IsTypeHandlerCompatibleForObjectHeaderInlining(this, cachedDynamicType->GetTypeHandler()));
-
-        cachedDynamicType->SetPrototype(newPrototype);
+        Assert(cachedDynamicType->GetPrototype() == newPrototype);
         instance->ReplaceType(cachedDynamicType);
     }
 


### PR DESCRIPTION
While investigating #2343, it was realized that when we set prototype, the
type chain that we cache doesn't have same prototype. All the predecessors
in the cached type chain before existing type of object still has oldPrototype
and only the existing type has new prototype.

Fix: Start with a type that has `newPrototype` object set because of which entire
chain will have `newPrototype` object.
