### PR TITLE
new way to do the writebarrier verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ Build/.vs/
 Build/ipch/
 Build/swum-cache.txt
 Build/VCBuild.NoJIT/
+Build/VCBuild.SWB/
 Build/VCBuild/
 buildchk.*
 buildfre.*

--- a/Build/Chakra.Build.props
+++ b/Build/Chakra.Build.props
@@ -24,6 +24,10 @@
         %(PreprocessorDefinitions);
         DISABLE_JIT=1
       </PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(ForceSWB)'=='true'">
+        %(PreprocessorDefinitions);
+        GLOBAL_ENABLE_WRITE_BARRIER=1
+      </PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(ENABLE_CODECOVERAGE)'=='true'">
         %(PreprocessorDefinitions);
         BYTECODE_TESTING=1

--- a/Build/Common.Build.Default.props
+++ b/Build/Common.Build.Default.props
@@ -59,6 +59,7 @@
     <OutBaseDir Condition="'$(OutBaseDir)'==''">$(SolutionDir)VcBuild</OutBaseDir>
     <OutBaseDir Condition="'$(Clang)'!=''">$(OutBaseDir).$(Clang)</OutBaseDir>    
     <OutBaseDir Condition="'$(BuildJIT)'=='false'">$(OutBaseDir).NoJIT</OutBaseDir>
+    <OutBaseDir Condition="'$(ForceSWB)'=='true'">$(OutBaseDir).SWB</OutBaseDir>
     <IntBaseDir Condition="'$(IntBaseDir)'==''">$(OutBaseDir)</IntBaseDir>
   </PropertyGroup>
 

--- a/lib/Backend/CodeGenNumberAllocator.cpp
+++ b/lib/Backend/CodeGenNumberAllocator.cpp
@@ -224,7 +224,7 @@ CodeGenNumberThreadAllocator::Integrate()
 #if DBG && GLOBAL_ENABLE_WRITE_BARRIER
         if (CONFIG_FLAG(ForceSoftwareWriteBarrier) && CONFIG_FLAG(RecyclerVerifyMark))
         {
-            Recycler::WBSetBits(record.blockAddress, BlockSize / sizeof(void*));
+            Recycler::WBSetBitRange(record.blockAddress, BlockSize / sizeof(void*));
         }
 #endif
         pendingIntegrationChunkBlock.RemoveHead(&NoThrowHeapAllocator::Instance);

--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -104,7 +104,7 @@ Lowerer::Lower()
 #if DBG && GLOBAL_ENABLE_WRITE_BARRIER
     // TODO: (leish)(swb) implement for arm
 #if defined(_M_IX86) || defined(_M_AMD64)
-    if (CONFIG_FLAG(ForceSoftwareWriteBarrier) && CONFIG_FLAG(RecyclerVerifyMark))
+    if (CONFIG_FLAG(ForceSoftwareWriteBarrier) && CONFIG_FLAG(VerifyBarrierBit))
     {
         // find out all write barrier setting instr, call Recycler::WBSetBit for verification purpose
         // should do this in LowererMD::GenerateWriteBarrier, however, can't insert call instruction there

--- a/lib/Backend/Opnd.cpp
+++ b/lib/Backend/Opnd.cpp
@@ -115,7 +115,7 @@ Opnd::IsWriteBarrierTriggerableValue()
     }
 
 #if DBG
-    if (CONFIG_FLAG(ForceSoftwareWriteBarrier) && CONFIG_FLAG(RecyclerVerifyMark))
+    if (CONFIG_FLAG(ForceSoftwareWriteBarrier) && CONFIG_FLAG(VerifyBarrierBit))
     {
         return true; // No further optimization if we are in verification
     }

--- a/lib/Common/CommonDefines.h
+++ b/lib/Common/CommonDefines.h
@@ -159,10 +159,12 @@
 #endif
 
 #ifdef RECYCLER_WRITE_BARRIER
+#if !GLOBAL_ENABLE_WRITE_BARRIER
 #ifdef _WIN32
 #define GLOBAL_ENABLE_WRITE_BARRIER 0
 #else
 #define GLOBAL_ENABLE_WRITE_BARRIER 1
+#endif
 #endif
 #endif
 

--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -733,6 +733,7 @@ PHASE(All)
 #define DEFAULT_CONFIG_ForceSoftwareWriteBarrier  (true)
 #define DEFAULT_CONFIG_WriteBarrierTest (false)
 #endif
+#define DEFAULT_CONFIG_VerifyBarrierBit  (false)
 
 #define TraceLevel_Error        (1)
 #define TraceLevel_Warning      (2)
@@ -1507,6 +1508,7 @@ FLAGR(Number, JITServerMaxInactivePageAllocatorCount, "Max inactive page allocat
 FLAGNR(Boolean, StrictWriteBarrierCheck, "Check write barrier setting on none write barrier pages", DEFAULT_CONFIG_StrictWriteBarrierCheck)
 FLAGNR(Boolean, WriteBarrierTest, "Always return true while checking barrier to test recycler regardless of annotation", DEFAULT_CONFIG_WriteBarrierTest)
 FLAGNR(Boolean, ForceSoftwareWriteBarrier, "Use to turn off write watch to test software write barrier on windows", DEFAULT_CONFIG_ForceSoftwareWriteBarrier)
+FLAGNR(Boolean, VerifyBarrierBit, "Verify software write barrier bit is set while marking", DEFAULT_CONFIG_VerifyBarrierBit)
 FLAGNR(Boolean, EnableBGFreeZero, "Use to turn off background freeing and zeroing to simulate linux", DEFAULT_CONFIG_EnableBGFreeZero)
 FLAGNR(Boolean, KeepRecyclerTrackData, "Keep recycler track data after sweep until reuse", DEFAULT_CONFIG_KeepRecyclerTrackData)
 

--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -726,13 +726,12 @@ PHASE(All)
 #define DEFAULT_CONFIG_KeepRecyclerTrackData  (false)
 #define DEFAULT_CONFIG_EnableBGFreeZero (true)
 
-#ifdef _WIN32
+#if !GLOBAL_ENABLE_WRITE_BARRIER
 #define DEFAULT_CONFIG_ForceSoftwareWriteBarrier  (false)
-#define DEFAULT_CONFIG_WriteBarrierTest (false)
 #else
 #define DEFAULT_CONFIG_ForceSoftwareWriteBarrier  (true)
-#define DEFAULT_CONFIG_WriteBarrierTest (false)
 #endif
+#define DEFAULT_CONFIG_WriteBarrierTest (false)
 #define DEFAULT_CONFIG_VerifyBarrierBit  (false)
 
 #define TraceLevel_Error        (1)

--- a/lib/Common/Core/FaultInjection.cpp
+++ b/lib/Common/Core/FaultInjection.cpp
@@ -1286,6 +1286,10 @@ namespace Js
             fflush(stderr);
         }
 
+        if (globalFlags.FaultInjection == InstallExceptionHandlerOnly)
+        {
+            needDump = true;
+        }
 
         // create dump for this crash
         if (needDump)

--- a/lib/Common/DataStructures/FixedBitVector.h
+++ b/lib/Common/DataStructures/FixedBitVector.h
@@ -436,6 +436,12 @@ public:
         return bit;
     }
 
+    BOOLEAN TestAndClearInterlocked(BVIndex i)
+    {
+        AssertRange(i);
+        return PlatformAgnostic::_InterlockedBitTestAndReset((LONG *)this->data, (LONG)i);
+    }
+
     void OrComplimented(const BVStatic * bv) { this->for_each(bv, &BVUnit::OrComplimented); ClearEnd(); }
     void Or(const BVStatic *bv) { this->for_each(bv, &BVUnit::Or); }
     void And(const BVStatic *bv) { this->for_each(bv, &BVUnit::And); }

--- a/lib/Common/Memory/HeapBlock.cpp
+++ b/lib/Common/Memory/HeapBlock.cpp
@@ -788,22 +788,41 @@ SmallHeapBlockT<TBlockAttributes>::ClearExplicitFreeBitForObject(void* objectAdd
 #if DBG && GLOBAL_ENABLE_WRITE_BARRIER
 void HeapBlock::WBPrintMissingBarrier(Recycler* recycler, char* objectAddress, char* target)
 {
+    HeapBlock* targetBlock = recycler->FindHeapBlock(target);
+    if (targetBlock == nullptr)
+    {
+        return;
+    }
+
 #ifdef TRACK_ALLOC
+    Recycler::TrackerData* trackerData = nullptr;
+    Recycler::TrackerData* targetTrackerData = nullptr;
+    const char* typeName = nullptr;
+    const char* targetTypeName = nullptr;
+    uint offset = 0;
+    uint targetOffset = 0;
+    char* objectStartAddress = nullptr;
+    char* targetStartAddress = nullptr;
+    byte barrier = RecyclerWriteBarrierManager::GetWriteBarrier(objectAddress);
+    Unused(barrier);
+
     if (Recycler::DoProfileAllocTracker())
     {
         // need CheckMemoryLeak or KeepRecyclerTrackData flag to have the tracker data and show following detailed info
 #ifdef __clang__
-        char buffer[1024];
-        auto getDemangledName = [&buffer](const type_info* typeinfo) ->const char*
+        auto getDemangledName = [](const type_info* typeinfo) ->const char*
         {
             int status;
+            char buffer[1024];
             size_t buflen = 1024;
             char* name = abi::__cxa_demangle(typeinfo->name(), buffer, &buflen, &status);
             if (status != 0)
             {
                 Output::Print(_u("Demangle failed: result=%d, buflen=%d\n"), status, buflen);
             }
-            return name;
+            char* demangledName = (char*)malloc(buflen);
+            memcpy(demangledName, name, buflen);
+            return demangledName;
         };
 #else
         auto getDemangledName = [](const type_info* typeinfo) ->const char*
@@ -812,7 +831,6 @@ void HeapBlock::WBPrintMissingBarrier(Recycler* recycler, char* objectAddress, c
         };
 #endif
 
-        uint offset = 0;
         if (this->IsLargeHeapBlock())
         {
             offset = (uint)(objectAddress - (char*)((LargeHeapBlock*)this)->GetRealAddressFromInterior(objectAddress));
@@ -821,11 +839,11 @@ void HeapBlock::WBPrintMissingBarrier(Recycler* recycler, char* objectAddress, c
         {
             offset = (uint)(objectAddress - this->address) % this->GetObjectSize(objectAddress);
         }
-        char* objectStartAddress = objectAddress - offset;
-        Recycler::TrackerData* trackerData = (Recycler::TrackerData*)this->GetTrackerData(objectStartAddress);
+        objectStartAddress = objectAddress - offset;
+        trackerData = (Recycler::TrackerData*)this->GetTrackerData(objectStartAddress);
         if (trackerData)
         {
-            const char* typeName = getDemangledName(trackerData->typeinfo);
+            typeName = getDemangledName(trackerData->typeinfo);
             if (trackerData->isArray)
             {
                 Output::Print(_u("Missing Barrier\nOn array of %S\n"), typeName);
@@ -839,18 +857,28 @@ void HeapBlock::WBPrintMissingBarrier(Recycler* recycler, char* objectAddress, c
             }
             else
             {
-                if (strcmp(typeName, "class Js::DynamicProfileInfo") == 0)
+                auto dumpFalsePositive = [&]() 
+                {
+                    if (CONFIG_FLAG(Verbose))
+                    {
+                        Output::Print(_u("False Positive: %S+0x%x => 0x%p -> 0x%p\n"), typeName, offset, objectAddress, target);
+                    }
+                };
+
+                if (strstr(typeName, "Js::DynamicProfileInfo") != nullptr)
                 {
                     // Js::DynamicProfileInfo allocate with non-Leaf in test/chk build
                     // TODO: (leish)(swb) find a way to set barrier for the Js::DynamicProfileInfo plus allocation
+                    dumpFalsePositive();
                     return;
                 }
 
                 if (offset <= Math::Align((3 * sizeof(uint)), sizeof(void*)) // left, length, size
-                    && strstr(typeName, "class Js::SparseArraySegment") != nullptr)
+                    && strstr(typeName, "Js::SparseArraySegment") != nullptr)
                 {
                     // Js::SparseArraySegmentBase left, length and size can easily form a false positive
                     // TODO: (leish)(swb) find a way to tag these fields
+                    dumpFalsePositive();
                     return;
                 }
 
@@ -861,20 +889,27 @@ void HeapBlock::WBPrintMissingBarrier(Recycler* recycler, char* objectAddress, c
 #else
                     0x10
 #endif
-                    && strcmp(typeName, "class Js::JavascriptDate") == 0)
+                    && strstr(typeName, "Js::JavascriptDate") != nullptr)
                 {
                     // the fields on Js::DateImplementation can easily form a false positive
                     // TODO: (leish)(swb) find a way to tag these
+                    dumpFalsePositive();
+                    return;
+                }
+
+                if (offset == 0x20 // scope field in scopeInfo
+                    && strstr(typeName, "Js::ScopeInfo") != nullptr)
+                {
+                    // Js::ScopeInfo scope field is arena allocated and can be reused in recycler
+                    // TODO: (leish)(swb) find a good location to clear/tag this field
+                    dumpFalsePositive();
                     return;
                 }
 
                 //TODO: (leish)(swb) analyze pdb to check if the field is a pointer field or not
                 Output::Print(_u("Missing Barrier\nOn type %S+0x%x\n"), typeName, offset);
             }
-        }
-
-        HeapBlock* targetBlock = recycler->FindHeapBlock(target);
-        uint targetOffset = 0;
+        }        
 
         if (targetBlock->IsLargeHeapBlock())
         {
@@ -884,8 +919,8 @@ void HeapBlock::WBPrintMissingBarrier(Recycler* recycler, char* objectAddress, c
         {
             targetOffset = (uint)(target - targetBlock->GetAddress()) % targetBlock->GetObjectSize(nullptr);
         }
-        char* targetStartAddress = target - targetOffset;
-        Recycler::TrackerData* targetTrackerData = (Recycler::TrackerData*)targetBlock->GetTrackerData(targetStartAddress);
+        targetStartAddress = target - targetOffset;
+        targetTrackerData = (Recycler::TrackerData*)targetBlock->GetTrackerData(targetStartAddress);
 
         if (targetOffset != 0)
         {
@@ -894,10 +929,10 @@ void HeapBlock::WBPrintMissingBarrier(Recycler* recycler, char* objectAddress, c
 
         if (targetTrackerData)
         {
-            const char* typeName = getDemangledName(targetTrackerData->typeinfo);
+            targetTypeName = getDemangledName(targetTrackerData->typeinfo);
             if (targetTrackerData->isArray)
             {
-                Output::Print(_u("Target type (missing barrier field type) is array item of %S\n"), typeName);
+                Output::Print(_u("Target type (missing barrier field type) is array item of %S\n"), targetTypeName);
 #ifdef STACK_BACK_TRACE
                 if (CONFIG_FLAG(KeepRecyclerTrackData))
                 {
@@ -908,11 +943,11 @@ void HeapBlock::WBPrintMissingBarrier(Recycler* recycler, char* objectAddress, c
             }
             else if (targetOffset == 0)
             {
-                Output::Print(_u("Target type (missing barrier field type) is %S\n"), typeName);
+                Output::Print(_u("Target type (missing barrier field type) is %S\n"), targetTypeName);
             }
             else
             {
-                Output::Print(_u("Target type (missing barrier field type) is pointing to %S+0x%x\n"), typeName, targetOffset);
+                Output::Print(_u("Target type (missing barrier field type) is pointing to %S+0x%x\n"), targetTypeName, targetOffset);
             }
         }
 
@@ -969,13 +1004,9 @@ SmallHeapBlockT<TBlockAttributes>::VerifyMark()
                         if (recycler->VerifyMark(target))
                         {
 #if DBG && GLOBAL_ENABLE_WRITE_BARRIER
-                            if (CONFIG_FLAG(ForceSoftwareWriteBarrier))
+                            if (CONFIG_FLAG(ForceSoftwareWriteBarrier) && CONFIG_FLAG(VerifyBarrierBit))
                             {
-                                uint verifyBitIndex = (BVIndex)(objectAddress - this->address) / sizeof(void*);
-                                if (!this->wbVerifyBits.Test(verifyBitIndex))
-                                {
-                                    WBPrintMissingBarrier(recycler, objectAddress, (char*)target);
-                                }
+                                this->WBVerifyBitIsSet(objectAddress);
                             }
 #endif
                         }
@@ -1421,7 +1452,7 @@ SmallHeapBlockT<TBlockAttributes>::EnqueueProcessedObject(FreeObject ** list, vo
 #if DBG && GLOBAL_ENABLE_WRITE_BARRIER
     if (CONFIG_FLAG(ForceSoftwareWriteBarrier) && CONFIG_FLAG(RecyclerVerifyMark))
     {
-        this->WBClearBits((char*)objectAddress);
+        this->WBClearObject((char*)objectAddress);
     }
 #endif
 

--- a/lib/Common/Memory/HeapBlock.h
+++ b/lib/Common/Memory/HeapBlock.h
@@ -472,7 +472,7 @@ public:
     virtual void WBVerifyBitIsSet(char* addr) override
     {
         uint index = (uint)(addr - this->address) / sizeof(void*);
-        if (!wbVerifyBits.Test(index))
+        if (!wbVerifyBits.Test(index)) // TODO: (leish)(swb) need interlocked? seems not
         {
             PrintVerifyMarkFailure(this->GetRecycler(), addr, *(char**)addr);
         }
@@ -493,13 +493,17 @@ public:
     virtual void WBClearBit(char* addr) override
     {
         uint index = (uint)(addr - this->address) / sizeof(void*);
-        wbVerifyBits.Clear(index);
+        wbVerifyBits.TestAndClearInterlocked(index);
     }
     virtual void WBClearObject(char* addr) override
     {
         Assert((uint)(addr - this->address) % this->objectSize == 0);
         uint index = (uint)(addr - this->address) / sizeof(void*);
-        wbVerifyBits.ClearRange(index, this->objectSize / sizeof(void*));
+        uint count = (uint)(this->objectSize / sizeof(void*));
+        for (uint i = 0; i < count; i++)
+        {
+            wbVerifyBits.TestAndClearInterlocked(index + i);
+        }
     }
 #endif
 

--- a/lib/Common/Memory/HeapBlockMap.inl
+++ b/lib/Common/Memory/HeapBlockMap.inl
@@ -75,6 +75,13 @@ HeapBlockMap32::Mark(void * candidate, MarkContext * markContext)
         return;
     }
 
+#if DBG && GLOBAL_ENABLE_WRITE_BARRIER
+    if (CONFIG_FLAG(ForceSoftwareWriteBarrier) && CONFIG_FLAG(VerifyBarrierBit))
+    {
+        Recycler::WBVerifyBitIsSet((char*)markContext->parentRef, (char*)candidate);
+    }
+#endif
+
     uint id2 = GetLevel2Id(candidate);
     HeapBlock::HeapBlockType blockType = chunk->blockInfo[id2].blockType;
 

--- a/lib/Common/Memory/LargeHeapBlock.h
+++ b/lib/Common/Memory/LargeHeapBlock.h
@@ -171,7 +171,7 @@ public:
 #endif
 #ifdef RECYCLER_VERIFY_MARK
     void VerifyMark();
-    virtual bool VerifyMark(void * objectAddress) override;
+    virtual bool VerifyMark(void * objectAddress, void * target) override;
 #endif
 #ifdef RECYCLER_PERF_COUNTERS
     virtual void UpdatePerfCountersOnFree() override;

--- a/lib/Common/Memory/LargeHeapBlock.h
+++ b/lib/Common/Memory/LargeHeapBlock.h
@@ -305,6 +305,7 @@ public:
 
 #if DBG && GLOBAL_ENABLE_WRITE_BARRIER
 private:
+    static CriticalSection wbVerifyBitsLock;
     BVSparse<HeapAllocator> wbVerifyBits;
 public:
     virtual void WBSetBit(char* addr) override;

--- a/lib/Common/Memory/LargeHeapBlock.h
+++ b/lib/Common/Memory/LargeHeapBlock.h
@@ -308,8 +308,10 @@ private:
     BVSparse<HeapAllocator> wbVerifyBits;
 public:
     virtual void WBSetBit(char* addr) override;
-    virtual void WBSetBits(char* addr, uint length) override;
-    virtual void WBClearBits(char* addr) override;
+    virtual void WBSetBitRange(char* addr, uint count) override;
+    virtual void WBClearBit(char* addr) override;
+    virtual void WBVerifyBitIsSet(char* addr) override;
+    virtual void WBClearObject(char* addr) override;
 #endif
 };
 }

--- a/lib/Common/Memory/LargeHeapBucket.cpp
+++ b/lib/Common/Memory/LargeHeapBucket.cpp
@@ -257,7 +257,7 @@ LargeHeapBucket::AddLargeHeapBlock(size_t size, bool nothrow)
     recycler->VerifyZeroFill(address, pageCount * AutoSystemInfo::PageSize);
 #endif
     uint objectCount = LargeHeapBlock::GetMaxLargeObjectCount(pageCount, size);
-    LargeHeapBlock * heapBlock = LargeHeapBlock::New(address, pageCount, segment, objectCount, supportFreeList ? this : nullptr);
+    LargeHeapBlock * heapBlock = LargeHeapBlock::New(address, pageCount, segment, objectCount, this);
 #if DBG
     LargeAllocationVerboseTrace(recycler->GetRecyclerFlagsTable(), _u("Allocated new large heap block 0x%p for sizeCat 0x%x\n"), heapBlock, sizeCat);
 #endif

--- a/lib/Common/Memory/LargeHeapBucket.cpp
+++ b/lib/Common/Memory/LargeHeapBucket.cpp
@@ -160,7 +160,7 @@ LargeHeapBucket::PageHeapAlloc(Recycler * recycler, size_t sizeCat, size_t size,
 
 
 
-    LargeHeapBlock * heapBlock = LargeHeapBlock::New(address, pageCount, segment, 1, nullptr);
+    LargeHeapBlock * heapBlock = LargeHeapBlock::New(address, pageCount, segment, 1, this);
     if (!heapBlock)
     {
         pageAllocator->SuspendIdleDecommit();

--- a/lib/Common/Memory/LargeHeapBucket.h
+++ b/lib/Common/Memory/LargeHeapBucket.h
@@ -40,6 +40,8 @@ public:
 
     LargeHeapBlock* AddLargeHeapBlock(DECLSPEC_GUARD_OVERFLOW size_t size, bool nothrow);
 
+    bool SupportFreeList() { return supportFreeList; }
+
     template <ObjectInfoBits attributes, bool nothrow>
     char* Alloc(Recycler * recycler, size_t sizeCat);
 #ifdef RECYCLER_PAGE_HEAP

--- a/lib/Common/Memory/MarkContext.h
+++ b/lib/Common/Memory/MarkContext.h
@@ -109,6 +109,11 @@ private:
 
     void OnObjectMarked(void* object, void* parent);
 #endif
+
+#if DBG && GLOBAL_ENABLE_WRITE_BARRIER
+public:
+    void* parentRef;
+#endif
 };
 
 

--- a/lib/Common/Memory/MarkContext.inl
+++ b/lib/Common/Memory/MarkContext.inl
@@ -74,9 +74,23 @@ void MarkContext::ScanMemory(void ** obj, size_t byteCount)
 #else
         void * candidate = *(static_cast<void * volatile *>(obj));
 #endif
+
+#if DBG && GLOBAL_ENABLE_WRITE_BARRIER
+        if (CONFIG_FLAG(ForceSoftwareWriteBarrier) && CONFIG_FLAG(VerifyBarrierBit))
+        {
+            this->parentRef = obj;
+        }
+#endif
         Mark<parallel, interior, doSpecialMark>(candidate, parentObject);
         obj++;
     } while (obj != objEnd);
+
+#if DBG && GLOBAL_ENABLE_WRITE_BARRIER
+    if (CONFIG_FLAG(ForceSoftwareWriteBarrier) && CONFIG_FLAG(VerifyBarrierBit))
+    {
+        this->parentRef = nullptr;
+    }
+#endif
 
 #if DBG_DUMP
     if (recycler->forceTraceMark || recycler->GetRecyclerFlagsTable().Trace.IsEnabled(Js::MarkPhase))

--- a/lib/Common/Memory/Recycler.cpp
+++ b/lib/Common/Memory/Recycler.cpp
@@ -7968,29 +7968,36 @@ Recycler::VerifyMarkStack()
     for (;stackTop < stackStart; stackTop++)
     {
         void* candidate = *stackTop;
-        VerifyMark(candidate);
+        VerifyMark(nullptr, candidate);
     }
 
     void** registers = this->savedThreadContext.GetRegisters();
     for (int i = 0; i < SavedRegisterState::NumRegistersToSave; i++)
     {
-        VerifyMark(registers[i]);
+        VerifyMark(nullptr, registers[i]);
     }
 }
 
+bool 
+Recycler::VerifyMark(void * target)
+{
+    return VerifyMark(nullptr, target);
+}
+
+// objectAddress is nullptr in case of roots
 bool
-Recycler::VerifyMark(void * candidate)
+Recycler::VerifyMark(void * objectAddress, void * target)
 {
     void * realAddress;
     HeapBlock * heapBlock;
     if (this->enableScanInteriorPointers)
     {
-        heapBlock = heapBlockMap.GetHeapBlock(candidate);
+        heapBlock = heapBlockMap.GetHeapBlock(target);
         if (heapBlock == nullptr)
         {
             return false;
         }
-        realAddress = heapBlock->GetRealAddressFromInterior(candidate);
+        realAddress = heapBlock->GetRealAddressFromInterior(target);
         if (realAddress == nullptr)
         {
             return false;
@@ -7998,14 +8005,14 @@ Recycler::VerifyMark(void * candidate)
     }
     else
     {
-        heapBlock = this->FindHeapBlock(candidate);
+        heapBlock = this->FindHeapBlock(target);
         if (heapBlock == nullptr)
         {
             return false;
         }
-        realAddress = candidate;
+        realAddress = target;
     }
-    return heapBlock->VerifyMark(realAddress);
+    return heapBlock->VerifyMark(objectAddress, realAddress);
 }
 #endif
 

--- a/lib/Common/Memory/Recycler.cpp
+++ b/lib/Common/Memory/Recycler.cpp
@@ -8545,6 +8545,21 @@ Recycler::UnRegisterPendingWriteBarrierBlock(void* address)
 
 #if DBG && GLOBAL_ENABLE_WRITE_BARRIER
 void
+Recycler::WBVerifyBitIsSet(char* addr, char* target)
+{
+    Recycler* recycler = Recycler::recyclerList;
+    while (recycler)
+    {
+        auto heapBlock = recycler->FindHeapBlock((void*)((UINT_PTR)addr&~HeapInfo::ObjectAlignmentMask));
+        if (heapBlock)
+        {
+            heapBlock->WBVerifyBitIsSet(addr);
+            break;
+        }
+        recycler = recycler->next;
+    }
+}
+void
 Recycler::WBSetBit(char* addr)
 {
     Recycler* recycler = Recycler::recyclerList;
@@ -8560,7 +8575,7 @@ Recycler::WBSetBit(char* addr)
     }
 }
 void
-Recycler::WBSetBits(char* addr, uint length)
+Recycler::WBSetBitRange(char* addr, uint count)
 {
     Recycler* recycler = Recycler::recyclerList;
     while (recycler)
@@ -8568,7 +8583,8 @@ Recycler::WBSetBits(char* addr, uint length)
         auto heapBlock = recycler->FindHeapBlock((void*)((UINT_PTR)addr&~HeapInfo::ObjectAlignmentMask));
         if (heapBlock)
         {
-            heapBlock->WBSetBits(addr, length);
+            heapBlock->WBSetBitRange(addr, count);
+            break;
         }
         recycler = recycler->next;
     }

--- a/lib/Common/Memory/Recycler.cpp
+++ b/lib/Common/Memory/Recycler.cpp
@@ -4212,10 +4212,12 @@ Recycler::BackgroundRescan(RescanFlags rescanFlags)
 #if GLOBAL_ENABLE_WRITE_BARRIER
     if (CONFIG_FLAG(ForceSoftwareWriteBarrier))
     {
+        pendingWriteBarrierBlockMap.LockResize();
         pendingWriteBarrierBlockMap.Map([](void* address, size_t size)
         {
             RecyclerWriteBarrierManager::WriteBarrier(address, size);
         });
+        pendingWriteBarrierBlockMap.UnlockResize();
     }
 #endif
 

--- a/lib/Common/Memory/Recycler.h
+++ b/lib/Common/Memory/Recycler.h
@@ -1968,7 +1968,8 @@ public:
         return WBSetBit(addr);
     }
     static void WBSetBit(char* addr);
-    static void WBSetBits(char* addr, uint length);
+    static void WBSetBitRange(char* addr, uint length);
+    static void WBVerifyBitIsSet(char* addr, char* target);
     static bool WBCheckIsRecyclerAddress(char* addr);
 #endif
 };
@@ -2142,9 +2143,11 @@ class CollectedRecyclerWeakRefHeapBlock : public HeapBlock
 {
 public:
 #if DBG && GLOBAL_ENABLE_WRITE_BARRIER
+    virtual void WBVerifyBitIsSet(char* addr) override { Assert(false); }
     virtual void WBSetBit(char* addr) override { Assert(false); }
-    virtual void WBSetBits(char* addr, uint length) override { Assert(false); }
-    virtual void WBClearBits(char* addr) override { Assert(false); }
+    virtual void WBSetBitRange(char* addr, uint count) override { Assert(false); }
+    virtual void WBClearBit(char* addr) override { Assert(false); }
+    virtual void WBClearObject(char* addr) override { Assert(false); }
 #endif
 
 #if DBG

--- a/lib/Common/Memory/Recycler.h
+++ b/lib/Common/Memory/Recycler.h
@@ -1951,7 +1951,7 @@ private:
 
 #if GLOBAL_ENABLE_WRITE_BARRIER
 private:
-    typedef JsUtil::BaseDictionary<void *, size_t, HeapAllocator, PrimeSizePolicy, RecyclerPointerComparer, JsUtil::SimpleDictionaryEntry, JsUtil::NoResizeLock> PendingWriteBarrierBlockMap;
+    typedef JsUtil::BaseDictionary<void *, size_t, HeapAllocator, PrimeSizePolicy, RecyclerPointerComparer, JsUtil::SimpleDictionaryEntry, JsUtil::AsymetricResizeLock> PendingWriteBarrierBlockMap;
 
     PendingWriteBarrierBlockMap pendingWriteBarrierBlockMap;
 public:

--- a/lib/Common/Memory/Recycler.h
+++ b/lib/Common/Memory/Recycler.h
@@ -1722,7 +1722,8 @@ private:
     void VerifyMarkArena(ArenaData * arena);
     void VerifyMarkBigBlockList(BigBlock * memoryBlocks);
     void VerifyMarkArenaMemoryBlockList(ArenaMemoryBlock * memoryBlocks);
-    bool VerifyMark(void * address);
+    bool VerifyMark(void * objectAddress, void * target);
+    bool VerifyMark(void * target);
 #endif
 #if DBG_DUMP
     bool forceTraceMark;
@@ -2161,7 +2162,7 @@ public:
     virtual void SetObjectMarkedBit(void* objectAddress) override { Assert(false); }
 
 #ifdef RECYCLER_VERIFY_MARK
-    virtual bool VerifyMark(void * objectAddress) override { Assert(false); return false; }
+    virtual bool VerifyMark(void * objectAddress, void * target) override { Assert(false); return false; }
 #endif
 #ifdef RECYCLER_PERF_COUNTERS
     virtual void UpdatePerfCountersOnFree() override { Assert(false); }

--- a/lib/Common/Memory/Recycler.inl
+++ b/lib/Common/Memory/Recycler.inl
@@ -275,7 +275,7 @@ Recycler::AllocZeroWithAttributesInlined(DECLSPEC_GUARD_OVERFLOW size_t size)
 #if DBG && GLOBAL_ENABLE_WRITE_BARRIER
     if (CONFIG_FLAG(ForceSoftwareWriteBarrier) && CONFIG_FLAG(RecyclerVerifyMark))
     {
-        this->FindHeapBlock(obj)->WBClearBits(obj);
+        this->FindHeapBlock(obj)->WBClearObject(obj);
     }
 #endif
 

--- a/lib/Common/Memory/RecyclerPointers.h
+++ b/lib/Common/Memory/RecyclerPointers.h
@@ -169,9 +169,10 @@ void ArrayWriteBarrier(T * address, size_t count)
 template <class T, class PolicyType = T, class Allocator = Recycler>
 void CopyArray(T* dst, size_t dstCount, const T* src, size_t srcCount)
 {
+    ArrayWriteBarrier<T, PolicyType, Allocator>(dst, dstCount);
+
     js_memcpy_s(reinterpret_cast<void*>(dst), sizeof(T) * dstCount,
                 reinterpret_cast<const void*>(src), sizeof(T) * srcCount);
-    ArrayWriteBarrier<T, PolicyType, Allocator>(dst, dstCount);
 }
 template <class T, class PolicyType = T, class Allocator = Recycler>
 void CopyArray(WriteBarrierPtr<T>& dst, size_t dstCount,
@@ -368,10 +369,10 @@ public:
     }
     void WriteBarrierSet(T * ptr)
     {
-        NoWriteBarrierSet(ptr);
 #ifdef RECYCLER_WRITE_BARRIER
         RecyclerWriteBarrierManager::WriteBarrier(this);
 #endif
+        NoWriteBarrierSet(ptr);
     }
 
     WriteBarrierPtr& operator=(WriteBarrierPtr const& other)
@@ -382,10 +383,10 @@ public:
 
     WriteBarrierPtr& operator++()  // prefix ++
     {
-        ++ptr;
 #ifdef RECYCLER_WRITE_BARRIER
         RecyclerWriteBarrierManager::WriteBarrier(this);
 #endif
+        ++ptr;
         return *this;
     }
 
@@ -398,10 +399,10 @@ public:
 
     WriteBarrierPtr& operator--()  // prefix --
     {
-        --ptr;
 #ifdef RECYCLER_WRITE_BARRIER
         RecyclerWriteBarrierManager::WriteBarrier(this);
 #endif
+        --ptr;
         return *this;
     }
 

--- a/lib/Runtime/ByteCode/ScopeInfo.h
+++ b/lib/Runtime/ByteCode/ScopeInfo.h
@@ -48,7 +48,7 @@ namespace Js {
         Field(BYTE) hasLocalInClosure : 1;
         Field(BYTE) parentOnly : 1;
 
-        Field(Scope *) scope;
+        FieldNoBarrier(Scope *) scope;
         Field(int) scopeId;
         Field(int) symbolCount;                // symbol count in this scope
         Field(SymbolInfo) symbols[];           // symbol PropertyIDs, index == sym.scopeSlot

--- a/test/jenkins.build.cmd
+++ b/test/jenkins.build.cmd
@@ -63,6 +63,11 @@ if not [%1]==[] (
         set _targets=/t:Clean,Build
         goto :ContinueArgParseEnd
     )
+    :: SWB
+    if /i [%1] EQU [swb] (
+        set _msbuildArgs=%_msbuildArgs% "/p:ForceSWB=true"
+        goto :ContinueArgParseEnd
+    )
 
     :: DEFAULT - add any other params to %_msBuildArgs%
     :: _msbuildArgs

--- a/test/jenkins.parsetestargs.cmd
+++ b/test/jenkins.parsetestargs.cmd
@@ -50,9 +50,15 @@ if not "%1"=="" (
         shift
         goto :ContinueArgParse
     )
+    
+    if "%1"=="-swb" (
+        :: todo: disallow -swb -disablejit combination
+        set _SpecialBuild=.SWB
+        goto :ContinueArgParse
+    )
 
     if "%1"=="-disablejit" (
-        set _NoJIT=.NoJIT
+        set _SpecialBuild=.NoJIT
         REM fallthrough to default (also add this to %_ExtraTestArgs%)
     )
 

--- a/test/jenkins.testone.cmd
+++ b/test/jenkins.testone.cmd
@@ -47,7 +47,7 @@ set _HadFailures=0
   call jenkins.parsetestargs.cmd %*
   set _LogDir=%_TestDir%\logs\%_TestArch%_%_TestType%
   set _TestArgs=%_TestArch%%_TestType%
-  set _BinDir=%_RootDir%\Build\VcBuild%_NoJIT%\bin
+  set _BinDir=%_RootDir%\Build\VcBuild%_SpecialBuild%\bin
 
   call :doSilent rd /s/q %_LogDir%
 

--- a/test/runtests.py
+++ b/test/runtests.py
@@ -60,6 +60,7 @@ parser.add_argument('--flags', default='',
                     help='global test flags to ch')
 parser.add_argument('--timeout', type=int, default=DEFAULT_TIMEOUT,
                     help='test timeout (default ' + str(DEFAULT_TIMEOUT) + ' seconds)')
+parser.add_argument('--swb', action='store_true', help='use binary from VcBuild.SWB to run the test')
 parser.add_argument('-l', '--logfile', metavar='logfile', help='file to log results to', default=None)
 parser.add_argument('--x86', action='store_true', help='use x86 build')
 parser.add_argument('--x64', action='store_true', help='use x64 build')
@@ -94,7 +95,8 @@ if not args.variants:
 binary = args.binary
 if binary == None:
     if sys.platform == 'win32':
-        binary = 'Build\\VcBuild\\bin\\{}_{}\\ch.exe'.format(arch, flavor)
+        build = "VcBuild.SWB" if args.swb else "VcBuild"
+        binary = 'Build\\' + build + '\\bin\\{}_{}\\ch.exe'.format(arch, flavor)
     else:
         binary = 'BuildLinux/{0}/ch'.format(flavor)
     binary = os.path.join(repo_root, binary)


### PR DESCRIPTION
verify the barrier bits while marking, instead of doing it in VerifyMark, to catch issue earier and more accurate
put it under VerifyBarrierBit flag, so don't need to run with RecyclerVerifyMark
set the write barrier bit and verification bit before updating the pointer first, to avoid some race issue
fix the logic on recording the write barrier bit has ever been set and then cleared

avoid assertion a false positive on ScopeInfo->scope, this is arena address resuing and causing false positive. here's just avoiding the verification code to assertion on it, added todo to really fix the false positive