### PR TITLE
Bug fixes for Section API

### DIFF
--- a/lib/Backend/ServerThreadContext.cpp
+++ b/lib/Backend/ServerThreadContext.cpp
@@ -9,6 +9,7 @@
 #include "JITServer/JITServer.h"
 
 ServerThreadContext::ServerThreadContext(ThreadContextDataIDL * data) :
+    m_autoProcessHandle((HANDLE)data->processHandle),
     m_threadContextData(*data),
     m_refCount(0),
     m_numericPropertyBV(nullptr),

--- a/lib/Backend/ServerThreadContext.h
+++ b/lib/Backend/ServerThreadContext.h
@@ -52,6 +52,17 @@ private:
     intptr_t GetRuntimeChakraBaseAddress() const;
     intptr_t GetRuntimeCRTBaseAddress() const;
 
+    class AutoCloseHandle
+    {
+    public:
+        AutoCloseHandle(HANDLE handle) : handle(handle) { Assert(handle != GetCurrentProcess()); }
+        ~AutoCloseHandle() { CloseHandle(this->handle); }
+    private:
+        HANDLE handle;
+    };
+
+    AutoCloseHandle m_autoProcessHandle;
+
     BVSparse<HeapAllocator> * m_numericPropertyBV;
 
     PreReservedSectionAllocWrapper m_preReservedSectionAllocator;

--- a/lib/JITClient/JITManager.cpp
+++ b/lib/JITClient/JITManager.cpp
@@ -30,7 +30,6 @@ JITManager::JITManager() :
     m_rpcBindingHandle(nullptr),
     m_oopJitEnabled(false),
     m_isJITServer(false),
-    m_targetHandle(nullptr),
     m_serverHandle(nullptr),
     m_jitConnectionId()
 {
@@ -38,10 +37,6 @@ JITManager::JITManager() :
 
 JITManager::~JITManager()
 {
-    if (m_targetHandle)
-    {
-        CleanupProcess();
-    }
     if (m_rpcBindingHandle)
     {
         RpcBindingFree(&m_rpcBindingHandle);
@@ -192,7 +187,7 @@ bool
 JITManager::IsConnected() const
 {
     Assert(IsOOPJITEnabled());
-    return m_rpcBindingHandle != nullptr && m_targetHandle != nullptr;
+    return m_rpcBindingHandle != nullptr;
 }
 
 HANDLE
@@ -213,23 +208,11 @@ JITManager::IsOOPJITEnabled() const
     return m_oopJitEnabled;
 }
 
-HANDLE
-JITManager::GetJITTargetHandle() const
-{
-    if (!IsOOPJITEnabled())
-    {
-        return GetCurrentProcess();
-    }
-    Assert(m_targetHandle != nullptr);
-    return m_targetHandle;
-}
-
 HRESULT
 JITManager::ConnectRpcServer(__in HANDLE jitProcessHandle, __in_opt void* serverSecurityDescriptor, __in UUID connectionUuid)
 {
     Assert(IsOOPJITEnabled());
     Assert(m_rpcBindingHandle == nullptr);
-    Assert(m_targetHandle == nullptr);
     Assert(m_serverHandle == nullptr);
 
     HRESULT hr = E_FAIL;
@@ -246,12 +229,6 @@ JITManager::ConnectRpcServer(__in HANDLE jitProcessHandle, __in_opt void* server
         goto FailureCleanup;
     }
 
-    if (!DuplicateHandle(GetCurrentProcess(), GetCurrentProcess(), jitProcessHandle, &m_targetHandle, 0, FALSE, DUPLICATE_SAME_ACCESS))
-    {
-        hr = HRESULT_FROM_WIN32(GetLastError());
-        goto FailureCleanup;
-    }
-
     hr = CreateBinding(jitProcessHandle, serverSecurityDescriptor, &connectionUuid, &m_rpcBindingHandle);
     if (FAILED(hr))
     {
@@ -263,11 +240,6 @@ JITManager::ConnectRpcServer(__in HANDLE jitProcessHandle, __in_opt void* server
     return hr;
 
 FailureCleanup:
-    if (m_targetHandle)
-    {
-        CloseHandle(m_targetHandle);
-        m_targetHandle = nullptr;
-    }
     if (m_serverHandle)
     {
         CloseHandle(m_serverHandle);
@@ -283,28 +255,6 @@ FailureCleanup:
 }
 
 HRESULT
-JITManager::CleanupProcess()
-{
-    Assert(JITManager::IsOOPJITEnabled());
-    Assert(m_targetHandle != nullptr);
-
-    HRESULT hr = E_FAIL;
-    RpcTryExcept
-    {
-        hr = ClientCleanupProcess(m_rpcBindingHandle, (intptr_t)m_targetHandle);
-    }
-    RpcExcept(RpcExceptionFilter(RpcExceptionCode()))
-    {
-        hr = HRESULT_FROM_WIN32(RpcExceptionCode());
-    }
-    RpcEndExcept;
-
-    m_targetHandle = nullptr;
-
-    return hr;
-}
-
-HRESULT
 JITManager::Shutdown()
 {
     // this is special case of shutdown called when runtime process is a parent of the server process
@@ -312,8 +262,6 @@ JITManager::Shutdown()
     HRESULT hr = S_OK;
     Assert(IsOOPJITEnabled());
     Assert(m_rpcBindingHandle != nullptr);
-
-    CleanupProcess();
 
     RpcTryExcept
     {

--- a/lib/JITClient/JITManager.h
+++ b/lib/JITClient/JITManager.h
@@ -28,7 +28,6 @@ public:
     bool IsOOPJITEnabled() const;
     void EnableOOPJIT();
 
-    HANDLE GetJITTargetHandle() const;
     HANDLE GetServerHandle() const;
 
     HRESULT InitializeThreadContext(
@@ -66,8 +65,6 @@ public:
         __in ScriptContextDataIDL * data,
         __in  PTHREADCONTEXT_HANDLE threadContextInfoAddress,
         __out PPSCRIPTCONTEXT_HANDLE scriptContextInfoAddress);
-
-    HRESULT CleanupProcess();
 
     HRESULT CleanupScriptContext(
         __inout PPSCRIPTCONTEXT_HANDLE scriptContextInfoAddress);
@@ -109,7 +106,6 @@ private:
         __out RPC_BINDING_HANDLE* bindingHandle);
 
     RPC_BINDING_HANDLE m_rpcBindingHandle;
-    HANDLE m_targetHandle;
     HANDLE m_serverHandle;
     UUID m_jitConnectionId;
     bool m_oopJitEnabled;
@@ -132,8 +128,6 @@ public:
     bool IsOOPJITEnabled() const { return false; }
     void EnableOOPJIT() { Assert(false); }
 
-    HANDLE GetJITTargetHandle() const
-        { Assert(false); return HANDLE(); }
     HANDLE GetServerHandle() const
     {
         Assert(false); return HANDLE();
@@ -175,9 +169,6 @@ public:
         __in ScriptContextDataIDL * data,
         __in PTHREADCONTEXT_HANDLE threadContextInfoAddress,
         __out PPSCRIPTCONTEXT_HANDLE scriptContextInfoAddress)
-        { Assert(false); return E_FAIL; }
-
-    HRESULT CleanupProcess()
         { Assert(false); return E_FAIL; }
 
     HRESULT CleanupScriptContext(

--- a/lib/JITIDL/ChakraJIT.idl
+++ b/lib/JITIDL/ChakraJIT.idl
@@ -19,10 +19,6 @@ interface IChakraJIT
         [out] PPTHREADCONTEXT_HANDLE threadContextInfoAddress,
         [out] CHAKRA_PTR * prereservedRegionAddr);
 
-    HRESULT CleanupProcess(
-        [in] handle_t binding,
-        [in] CHAKRA_PTR processHandle);
-
     HRESULT CleanupThreadContext(
         [in] handle_t binding,
         [in, out] PPTHREADCONTEXT_HANDLE threadContextInfoAddress);

--- a/lib/JITServer/JITServer.cpp
+++ b/lib/JITServer/JITServer.cpp
@@ -123,17 +123,6 @@ ServerShutdown(
     return ShutdownCommon();
 }
 
-HRESULT
-ServerCleanupProcess(
-    /* [in] */ handle_t binding,
-    /* [in] */ intptr_t processHandle)
-{
-    ServerContextManager::CleanUpForProcess((HANDLE)processHandle);
-    CloseHandle((HANDLE)processHandle);
-    return S_OK;
-}
-
-
 void
 __RPC_USER PTHREADCONTEXT_HANDLE_rundown(__RPC__in PTHREADCONTEXT_HANDLE phContext)
 {
@@ -174,6 +163,7 @@ ServerInitializeThreadContext(
     }
     catch (Js::OutOfMemoryException)
     {
+        CloseHandle((HANDLE)threadContextData->processHandle);
         return E_OUTOFMEMORY;
     }
 
@@ -727,42 +717,6 @@ void ServerContextManager::UnRegisterThreadContext(ServerThreadContext* threadCo
             iter.RemoveCurrent();
         }
         iter.MoveNext();
-    }
-}
-
-void ServerContextManager::CleanUpForProcess(HANDLE hProcess)
-{
-    // there might be multiple thread context(webworker)
-    AutoCriticalSection autoCS(&cs);
-
-    auto iterScriptCtx = scriptContexts.GetIteratorWithRemovalSupport();
-    while (iterScriptCtx.IsValid())
-    {
-        ServerScriptContext* scriptContext = iterScriptCtx.Current().Key();
-        if (scriptContext->GetThreadContext()->GetProcessHandle() == hProcess)
-        {
-            if (!scriptContext->IsClosed())
-            {
-                scriptContext->Close();
-            }
-            iterScriptCtx.RemoveCurrent();
-        }
-        iterScriptCtx.MoveNext();
-    }
-
-    auto iterThreadCtx = threadContexts.GetIteratorWithRemovalSupport();
-    while (iterThreadCtx.IsValid())
-    {
-        ServerThreadContext* threadContext = iterThreadCtx.Current().Key();
-        if (threadContext->GetProcessHandle() == hProcess)
-        {
-            if (!threadContext->IsClosed())
-            {
-                threadContext->Close();
-            }
-            iterThreadCtx.RemoveCurrent();
-        }
-        iterThreadCtx.MoveNext();
     }
 }
 

--- a/lib/JITServer/JITServer.h
+++ b/lib/JITServer/JITServer.h
@@ -9,11 +9,8 @@ public:
     static void RegisterThreadContext(ServerThreadContext* threadContext);
     static void UnRegisterThreadContext(ServerThreadContext* threadContext);
 
-    static void CleanUpForProcess(HANDLE hProcess);
-
     static void RegisterScriptContext(ServerScriptContext* scriptContext);
-    static void UnRegisterScriptContext(ServerScriptContext* scriptContext);    
-
+    static void UnRegisterScriptContext(ServerScriptContext* scriptContext);
     static bool CheckLivenessAndAddref(ServerScriptContext* context);
     static bool CheckLivenessAndAddref(ServerThreadContext* context);
 

--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -1959,7 +1959,15 @@ ThreadContext::EnsureJITThreadContext(bool allowPrereserveAlloc)
     }
 
     ThreadContextDataIDL contextData;
-    contextData.processHandle = (intptr_t)JITManager::GetJITManager()->GetJITTargetHandle();
+    HANDLE serverHandle = JITManager::GetJITManager()->GetServerHandle();
+
+    HANDLE jitTargetHandle = nullptr;
+    if (!DuplicateHandle(GetCurrentProcess(), GetCurrentProcess(), serverHandle, &jitTargetHandle, 0, FALSE, DUPLICATE_SAME_ACCESS))
+    {
+        return;
+    }
+
+    contextData.processHandle = (intptr_t)jitTargetHandle;
 
     contextData.chakraBaseAddress = (intptr_t)AutoSystemInfo::Data.GetChakraBaseAddr();
     contextData.crtBaseAddress = (intptr_t)GetModuleHandle(UCrtC99MathApis::LibraryName);


### PR DESCRIPTION
We need process handle for ServerThreadContext destructor. In some cases this would be unavailable. Have changed to give each ServerThreadContext its own handle to keep lifetime management simpler.

We weren't correctly handling some cases where AllocLocal fails.