### PR TITLE
Do not proactively set the stack nested func flag on recompiled functions. 

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -3061,7 +3061,9 @@ void ByteCodeGenerator::EmitOneFunction(ParseNode *pnode)
 
         if (!funcInfo->IsGlobalFunction())
         {
-            if (CanStackNestedFunc(funcInfo, true))
+            // Note: Do not set the stack nested func flag if the function has been redeferred and recompiled.
+            // In that case the flag already has the value we want.
+            if (CanStackNestedFunc(funcInfo, true) && byteCodeFunction->GetCompileCount() == 0)
             {
 #if DBG
                 byteCodeFunction->SetCanDoStackNestedFunc();


### PR DESCRIPTION
If the function has been compiled previously, the stack nested func flag already has the correct value, and resetting it may ignore an escape that has since been discovered.