### PR TITLE
Remove JsShutdownJITServer API

### DIFF
--- a/bin/ChakraCore/ChakraCore.def
+++ b/bin/ChakraCore/ChakraCore.def
@@ -52,4 +52,3 @@ JsModuleEvaluation
 JsSetModuleHostInfo
 JsGetModuleHostInfo
 JsInitializeJITServer
-JsShutdownJITServer

--- a/bin/ChakraCore/ChakraCoreDllFunc.cpp
+++ b/bin/ChakraCore/ChakraCoreDllFunc.cpp
@@ -214,9 +214,4 @@ HRESULT JsInitializeJITServer(
 {
     return E_NOTIMPL;
 }
-EXPORT_FUNC
-HRESULT JsShutdownJITServer()
-{
-    return E_NOTIMPL;
-}
 #endif

--- a/bin/ch/JITProcessManager.cpp
+++ b/bin/ch/JITProcessManager.cpp
@@ -150,18 +150,6 @@ HRESULT JITProcessManager::CreateServerProcess(int argc, __in_ecount(argc) LPWST
     return NOERROR;
 }
 
-typedef HRESULT(WINAPI *JsShutdownJITServerPtr)();
-
-void JITProcessManager::StopRpcServer(HINSTANCE chakraLibrary)
-{
-    if (s_rpcServerProcessHandle)
-    {
-        JsShutdownJITServerPtr shutdownJITServer = (JsShutdownJITServerPtr)GetProcAddress(chakraLibrary, "JsShutdownJITServer");
-        shutdownJITServer();
-    }
-    s_rpcServerProcessHandle = NULL;
-}
-
 void
 JITProcessManager::TerminateJITServer()
 {

--- a/bin/ch/JITProcessManager.h
+++ b/bin/ch/JITProcessManager.h
@@ -9,7 +9,6 @@ class JITProcessManager
 {
 public:
     static HRESULT StartRpcServer(int argc, __in_ecount(argc) LPWSTR argv[]);
-    static void StopRpcServer(HINSTANCE chakraLibrary);
     static void TerminateJITServer();
 
     static HANDLE GetRpcProccessHandle();

--- a/bin/ch/ch.cpp
+++ b/bin/ch/ch.cpp
@@ -871,16 +871,10 @@ int _cdecl wmain(int argc, __in_ecount(argc) LPWSTR argv[])
         exitCode = ExecuteTestWithMemoryCheck(argInfo.filename);
 #endif
 
-#if ENABLE_NATIVE_CODEGEN && defined(_WIN32)
-        JITProcessManager::StopRpcServer(chakraLibrary);
-#endif
         ChakraRTInterface::UnloadChakraDll(chakraLibrary);
     }
 #if ENABLE_NATIVE_CODEGEN && defined(_WIN32)
-    else
-    {
-        JITProcessManager::TerminateJITServer();
-    }
+    JITProcessManager::TerminateJITServer();
 #endif
 
     PAL_Shutdown();

--- a/lib/JITServer/JITServer.cpp
+++ b/lib/JITServer/JITServer.cpp
@@ -99,23 +99,6 @@ ShutdownCommon()
     return status;
 }
 
-__declspec(dllexport)
-HRESULT
-JsShutdownJITServer()
-{
-    Assert(JITManager::GetJITManager()->IsOOPJITEnabled());
-
-    if (JITManager::GetJITManager()->IsConnected())
-    {
-        // if client is hosting jit process directly, call to remotely shutdown
-        return JITManager::GetJITManager()->Shutdown();
-    }
-    else
-    {
-        return ShutdownCommon();
-    }
-}
-
 HRESULT
 ServerShutdown(
     /* [in] */ handle_t binding)


### PR DESCRIPTION
The API is currently unused and has issues when the server never finished connecting.