### PR TITLE
Fix bad binding in the presence of destructured arrow function parameters. 

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -12265,6 +12265,12 @@ ParseNodePtr Parser::ParseDestructuredVarDecl(tokens declarationType, bool isDec
     {
         m_pscan->Scan();
         ++parenCount;
+        if (m_reparsingLambdaParams)
+        {
+            // Match the block increment we do upon entering parenthetical expressions
+            // so that the block ID's will match on reparsing of parameters.
+            GetCurrentBlock()->sxBlock.blockId = m_nextBlockId++;
+        }
     }
 
     if (m_token.tk == tkEllipsis)

--- a/test/es6/lambda-params-shadow.js
+++ b/test/es6/lambda-params-shadow.js
@@ -21,4 +21,10 @@ let b = new B();
 if (count !== 3) {
     WScript.Echo('fail');
 }
+
+{
+    ([((iydvhw)), gpvpgk]) => {/*jjj*/};
+}
+var iydvhw=function(){return this};
+
 WScript.Echo('pass');


### PR DESCRIPTION
Do the same adjustment of block ID's in the case of parentheses in a destructured parameter expression that we do on entering a parenthetical expression.