### PR TITLE
Module namespace objects should have @@toStringTag own property set to "Module"

### DIFF
--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -1124,7 +1124,7 @@ namespace Js
         functionTypeDisplayString = CreateStringFromCppLiteral(_u("function"));
         booleanTypeDisplayString = CreateStringFromCppLiteral(_u("boolean"));
         numberTypeDisplayString = CreateStringFromCppLiteral(_u("number"));
-        moduleTypeDisplayString = CreateStringFromCppLiteral(_u("module"));
+        moduleTypeDisplayString = CreateStringFromCppLiteral(_u("Module"));
         variantDateTypeDisplayString = CreateStringFromCppLiteral(_u("date"));
         promiseResolveFunction = nullptr;
         generatorNextFunction = nullptr;

--- a/test/es6/module-namespace.js
+++ b/test/es6/module-namespace.js
@@ -79,7 +79,8 @@ var tests = [
                 assert.areEqual(undefined, foo[6], 'cannot get item in namespace obect');
                 assert.areEqual(false, Reflect.set(foo, Symbol.species, 20), 'no species property');
                 assert.areEqual(undefined, foo[Symbol.species], 'namespace is not contructor');
-                assert.areEqual("module", foo[Symbol.toStringTag], 'namespace toStringTag');
+                assert.areEqual("Module", foo[Symbol.toStringTag], 'namespace toStringTag');
+                assert.areEqual("[object Module]", Object.prototype.toString.call(foo), 'Object.prototype.toString uses the module namespace @@toStringTag value');
                 helpers.writeln("in iterator"); for (var i of foo) helpers.writeln(i);
                 helpers.writeln("done with iterator")
                 var symbols = Object.getOwnPropertySymbols(foo);


### PR DESCRIPTION
Currently this value is set to "module" which is wrong according to the spec:
https://tc39.github.io/ecma262/#sec-module-namespace-objects

This fixes https://github.com/Microsoft/ChakraCore/issues/2250
