### PR TITLE
Enable delete last property optimization if obj is in for-in

### DIFF
--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -9519,17 +9519,12 @@ Lowerer::GenerateFastBrBReturn(IR::Instr * instr)
         Js::OpCode::BrNeq_A, labelHelper, instr);
 
     // MOV cachedDataOpnd, forInEnumeratorOpnd->enumerator.cachedData
-    // CMP cachedDataOpnd, nullptr
-    // JEQ $helper
     // MOV enumeratedCountOpnd, forInEnumeratorOpnd->enumerator.enumeratedCount
     // CMP enumeratedCountOpnd, cachedDataOpnd->cachedCount
     // JLT $loopBody
     IR::RegOpnd * cachedDataOpnd = IR::RegOpnd::New(TyMachPtr, m_func);
     InsertMove(cachedDataOpnd,
         GetForInEnumeratorFieldOpnd(forInEnumeratorOpnd, Js::ForInObjectEnumerator::GetOffsetOfEnumeratorCachedData(), TyMachPtr), instr);
-
-    InsertCompareBranch(cachedDataOpnd, IR::AddrOpnd::NewNull(m_func), Js::OpCode::BrEq_A, labelHelper, instr);
-
     IR::RegOpnd * enumeratedCountOpnd = IR::RegOpnd::New(TyUint32, m_func);
     InsertMove(enumeratedCountOpnd,
         GetForInEnumeratorFieldOpnd(forInEnumeratorOpnd, Js::ForInObjectEnumerator::GetOffsetOfEnumeratorEnumeratedCount(), TyUint32), instr);

--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -9519,12 +9519,17 @@ Lowerer::GenerateFastBrBReturn(IR::Instr * instr)
         Js::OpCode::BrNeq_A, labelHelper, instr);
 
     // MOV cachedDataOpnd, forInEnumeratorOpnd->enumerator.cachedData
+    // CMP cachedDataOpnd, nullptr
+    // JEQ $helper
     // MOV enumeratedCountOpnd, forInEnumeratorOpnd->enumerator.enumeratedCount
     // CMP enumeratedCountOpnd, cachedDataOpnd->cachedCount
     // JLT $loopBody
     IR::RegOpnd * cachedDataOpnd = IR::RegOpnd::New(TyMachPtr, m_func);
     InsertMove(cachedDataOpnd,
         GetForInEnumeratorFieldOpnd(forInEnumeratorOpnd, Js::ForInObjectEnumerator::GetOffsetOfEnumeratorCachedData(), TyMachPtr), instr);
+
+    InsertCompareBranch(cachedDataOpnd, IR::AddrOpnd::NewNull(m_func), Js::OpCode::BrEq_A, labelHelper, instr);
+
     IR::RegOpnd * enumeratedCountOpnd = IR::RegOpnd::New(TyUint32, m_func);
     InsertMove(enumeratedCountOpnd,
         GetForInEnumeratorFieldOpnd(forInEnumeratorOpnd, Js::ForInObjectEnumerator::GetOffsetOfEnumeratorEnumeratedCount(), TyUint32), instr);

--- a/lib/Runtime/Library/ForInObjectEnumerator.cpp
+++ b/lib/Runtime/Library/ForInObjectEnumerator.cpp
@@ -160,6 +160,10 @@ namespace Js
         {
             propertyId = Constants::NoProperty;
             Var currentIndex = enumerator.MoveAndGetNext(propertyId, &attributes);
+
+            // The object type may have changed and we may not be able to use fast path anymore.
+            this->canUseJitFastPath = enumerator.CanUseJITFastPath();
+
             if (currentIndex)
             {
                 if (this->shadowData == nullptr)

--- a/lib/Runtime/Library/ForInObjectEnumerator.cpp
+++ b/lib/Runtime/Library/ForInObjectEnumerator.cpp
@@ -161,8 +161,12 @@ namespace Js
             propertyId = Constants::NoProperty;
             Var currentIndex = enumerator.MoveAndGetNext(propertyId, &attributes);
 
-            // The object type may have changed and we may not be able to use fast path anymore.
-            this->canUseJitFastPath = enumerator.CanUseJITFastPath();
+            // The object type may have changed and we may not be able to use Jit fast path anymore.
+            // canUseJitFastPath is determined in ForInObjectEnumerator::Initialize, once we decide we can't use
+            // Jit fast path we will never go back to use fast path so && with current value  - if it's already
+            // false we don't call CanUseJITFastPath()
+
+            this->canUseJitFastPath = this->canUseJitFastPath && enumerator.CanUseJITFastPath();
 
             if (currentIndex)
             {

--- a/lib/Runtime/Types/DynamicObjectPropertyEnumerator.cpp
+++ b/lib/Runtime/Types/DynamicObjectPropertyEnumerator.cpp
@@ -260,6 +260,8 @@ namespace Js
         }
         if (this->object)
         {
+            // Once enters NoCache path, ensure never switches to Cache path above.
+            this->cachedData = nullptr;
             return MoveAndGetNextNoCache(propertyId, attributes);
         }
         return nullptr;


### PR DESCRIPTION
DeleteLastProperty optimization was relying on the map which holds type
participating in for-in enumeration, but the map is cleared during
PreSweepCallback causing wrong for in enumeration. Fix this by not relying
on the map.
