### PR TITLE
xplat: do not inline class function in source file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,6 @@ if(CC_EMBED_ICU_SH)
     unset(CC_EMBED_ICU_SH CACHE)
     set(CC_EMBED_ICU 1)
     set(ICU_INCLUDE_PATH "deps/icu/source/output/include/")
-    add_definitions(-DU_STATIC_IMPLEMENTATION)
 endif()
 
 if(ICU_INCLUDE_PATH_SH)

--- a/lib/Backend/IRBuilderAsmJs.cpp
+++ b/lib/Backend/IRBuilderAsmJs.cpp
@@ -943,7 +943,7 @@ IRBuilderAsmJs::BuildArgInTracing()
     int32 doubleArgInCount = 0;
     int32 simd128ArgInCount = 0;
 
-    Js::ArgSlot nArgs = 0; 
+    Js::ArgSlot nArgs = 0;
     if (m_func->GetJITFunctionBody()->HasImplicitArgIns())
     {
         // -1 to remove the implicit this pointer
@@ -3260,7 +3260,7 @@ IRBuilderAsmJs::BuildLong1Double1(Js::OpCodeAsmJs newOpcode, uint32 offset, Js::
 {
     IR::RegOpnd * srcOpnd = BuildSrcOpnd(src1RegSlot, TyFloat64);
     srcOpnd->SetValueType(ValueType::Float);
-    
+
     IRType dstType;
     Js::OpCode op;
     bool doTruncTrapCheck = false;
@@ -3536,7 +3536,7 @@ IR::Instr* IRBuilderAsmJs::GenerateStSlotForReturn(IR::RegOpnd* srcOpnd, IRType 
     return stSlotInstr;
 }
 
-inline Js::OpCode IRBuilderAsmJs::GetSimdOpcode(Js::OpCodeAsmJs asmjsOpcode)
+Js::OpCode IRBuilderAsmJs::GetSimdOpcode(Js::OpCodeAsmJs asmjsOpcode)
 {
     Js::OpCode opcode = (Js::OpCode) 0;
     Assert(IsSimd128AsmJsOpcode(asmjsOpcode));
@@ -5505,7 +5505,7 @@ IRBuilderAsmJs::BuildUint16x8_1Uint8x16_1(Js::OpCodeAsmJs newOpcode, uint32 offs
 void IRBuilderAsmJs::BuildUint8x16_1Int16(Js::OpCodeAsmJs newOpcode, uint32 offset, BUILD_SIMD_ARGS_REG17)
 {
     AssertMsg(newOpcode == Js::OpCodeAsmJs::Simd128_IntsToU16, "Unexpected opcode for this format.");
- 
+
     uint const LANES = 16;
     Js::RegSlot srcRegSlots[LANES];
 

--- a/lib/Backend/InterpreterThunkEmitter.cpp
+++ b/lib/Backend/InterpreterThunkEmitter.cpp
@@ -304,7 +304,7 @@ void InterpreterThunkEmitter::NewThunkBlock()
     BYTE* buffer;
 
     EmitBufferAllocation<VirtualAllocWrapper, PreReservedVirtualAllocWrapper> * allocation = emitBufferManager.AllocateBuffer(BlockSize, &buffer);
-    if (allocation == nullptr) 
+    if (allocation == nullptr)
     {
         Js::Throw::OutOfMemory();
     }
@@ -683,9 +683,7 @@ void InterpreterThunkEmitter::EncodeInterpreterThunk(
 }
 #endif
 
-
-
-inline /*static*/
+/*static*/
 DWORD InterpreterThunkEmitter::FillDebugBreak(_Out_writes_bytes_all_(count) BYTE* dest, _In_ DWORD count)
 {
 #if defined(_M_ARM)
@@ -697,9 +695,7 @@ DWORD InterpreterThunkEmitter::FillDebugBreak(_Out_writes_bytes_all_(count) BYTE
     return count;
 }
 
-
-
-inline /*static*/
+/*static*/
 DWORD InterpreterThunkEmitter::CopyWithAlignment(
     _Out_writes_bytes_all_(sizeInBytes) BYTE* dest,
     _In_ const DWORD sizeInBytes,
@@ -876,4 +872,3 @@ bool ThunkBlock::IsFreeListEmpty() const
 }
 
 #endif
-

--- a/lib/Parser/CharSet.cpp
+++ b/lib/Parser/CharSet.cpp
@@ -196,7 +196,7 @@ namespace UnifiedRegex
     // CharSetNode
     // ----------------------------------------------------------------------
 
-    inline CharSetNode* CharSetNode::For(ArenaAllocator* allocator, int level)
+    CharSetNode* CharSetNode::For(ArenaAllocator* allocator, int level)
     {
         if (level == 0)
             return Anew(allocator, CharSetLeaf);

--- a/lib/Runtime/Library/JavascriptString.cpp
+++ b/lib/Runtime/Library/JavascriptString.cpp
@@ -403,7 +403,7 @@ case_2:
         }
     }
 
-    inline JavascriptString* JavascriptString::ConcatDestructive(JavascriptString* pstRight)
+    JavascriptString* JavascriptString::ConcatDestructive(JavascriptString* pstRight)
     {
         Assert(pstRight);
 

--- a/pal/src/config.h.in
+++ b/pal/src/config.h.in
@@ -11,8 +11,6 @@
 #cmakedefine01 HAVE_SYS_TIME_H
 #cmakedefine01 HAVE_PTHREAD_NP_H
 #cmakedefine01 HAVE_SYS_LWP_H
-#cmakedefine01 HAVE_LIBUUID_H
-#cmakedefine01 HAVE_BSD_UUID_H
 #cmakedefine01 HAVE_RUNETYPE_H
 
 #cmakedefine01 HAVE_KQUEUE

--- a/pal/src/configure.cmake
+++ b/pal/src/configure.cmake
@@ -916,7 +916,6 @@ else() # ANDROID
   set(HAVE_SYS_TIME_H 1)
   set(HAVE_PTHREAD_NP_H 0)
   set(HAVE_SYS_LWP_H 0)
-  set(HAVE_LIBUUID_H 1)
   set(HAVE_RUNETYPE_H 0)
   set(HAVE_KQUEUE 0)
   set(HAVE_GETPWUID_R 1)


### PR DESCRIPTION
- Fixes clang/homebrew '-Os' build breaks
- Remove unused definition from CMakeLists