### PR TITLE
Float32Array memory leak problem #2328

### DIFF
--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -129,9 +129,7 @@ namespace Js
         cache(nullptr),
         firstInterpreterFrameReturnAddress(nullptr),
         builtInLibraryFunctions(nullptr),
-        m_remoteScriptContextAddr(nullptr),
-        isWeakReferenceDictionaryListCleared(false),
-        weakReferenceDictionaryList(this->GeneralAllocator(), 1)
+        m_remoteScriptContextAddr(nullptr)
 #if ENABLE_PROFILE_INFO
         , referencesSharedDynamicSourceContextInfo(false)
 #endif
@@ -504,9 +502,6 @@ namespace Js
         }
 #endif
 
-        // In case there is something added to the list between close and dtor, just reset the list again
-        this->weakReferenceDictionaryList.Reset();
-
 #if ENABLE_NATIVE_CODEGEN
         if (m_remoteScriptContextAddr)
         {
@@ -741,9 +736,6 @@ namespace Js
 
         pActiveScriptDirect = nullptr;
 
-        isWeakReferenceDictionaryListCleared = true;
-        this->weakReferenceDictionaryList.Clear();
-
         // This can be null if the script context initialization threw
         // and InternalClose gets called in the destructor code path
         if (javascriptLibrary != nullptr)
@@ -894,16 +886,6 @@ namespace Js
 #endif
 
         return isNumericPropertyId;
-    }
-
-    void ScriptContext::RegisterWeakReferenceDictionary(JsUtil::IWeakReferenceDictionary* weakReferenceDictionary)
-    {
-        this->weakReferenceDictionaryList.Item(weakReferenceDictionary);
-    }
-
-    void ScriptContext::UnRegisterWeakReferenceDictionary(JsUtil::IWeakReferenceDictionary* weakReferenceDictionary)
-    {
-        this->weakReferenceDictionaryList.Remove(weakReferenceDictionary);
     }
 
     RecyclableObject *ScriptContext::GetMissingPropertyResult()
@@ -1626,17 +1608,6 @@ namespace Js
                     string->ClearPropertyCache();
                 }
             }
-        }
-    }
-
-    void ScriptContext::CleanupWeakReferenceDictionaries()
-    {
-        if (!isWeakReferenceDictionaryListCleared)
-        {
-            this->weakReferenceDictionaryList.Map([](JsUtil::IWeakReferenceDictionary* weakReferenceDictionary)
-            {
-                weakReferenceDictionary->Cleanup();
-            });
         }
     }
 

--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -849,7 +849,7 @@ private:
         // RegisterWeakReferenceDictionary. If you use JsUtil::WeakReferenceDictionary,
         // which also exposes the IWeakReferenceDictionary interface, it'll
         // automatically register the dictionary on the script context
-        SListBase<JsUtil::IWeakReferenceDictionary*> weakReferenceDictionaryList;
+        JsUtil::BaseHashSet<JsUtil::IWeakReferenceDictionary*, ArenaAllocator> weakReferenceDictionaryList;
         bool isWeakReferenceDictionaryListCleared;
 
         typedef void(*RaiseMessageToDebuggerFunctionType)(ScriptContext *, DEBUG_EVENT_INFO_TYPE, LPCWSTR, LPCWSTR);
@@ -1187,6 +1187,7 @@ private:
         BOOL IsNumericPropertyId(PropertyId propertyId, uint32* value);
 
         void RegisterWeakReferenceDictionary(JsUtil::IWeakReferenceDictionary* weakReferenceDictionary);
+        void UnRegisterWeakReferenceDictionary(JsUtil::IWeakReferenceDictionary* weakReferenceDictionary);
         void ResetWeakReferenceDictionaryList() { weakReferenceDictionaryList.Reset(); }
 
         BOOL ReserveStaticTypeIds(__in int first, __in int last);

--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -843,14 +843,6 @@ private:
         RecyclerRootPtr<SListBase<DynamicProfileInfo *>> profileInfoList;
 #endif
 #endif
-        // List of weak reference dictionaries. We'll walk through them
-        // and clean them up post-collection
-        // IWeakReferenceDictionary objects are added to this list by calling
-        // RegisterWeakReferenceDictionary. If you use JsUtil::WeakReferenceDictionary,
-        // which also exposes the IWeakReferenceDictionary interface, it'll
-        // automatically register the dictionary on the script context
-        JsUtil::BaseHashSet<JsUtil::IWeakReferenceDictionary*, ArenaAllocator> weakReferenceDictionaryList;
-        bool isWeakReferenceDictionaryListCleared;
 
         typedef void(*RaiseMessageToDebuggerFunctionType)(ScriptContext *, DEBUG_EVENT_INFO_TYPE, LPCWSTR, LPCWSTR);
         RaiseMessageToDebuggerFunctionType raiseMessageToDebuggerFunctionType;
@@ -1141,8 +1133,6 @@ private:
         void SetFirstInterpreterFrameReturnAddress(void * returnAddress) { firstInterpreterFrameReturnAddress = returnAddress;}
         void *GetFirstInterpreterFrameReturnAddress() { return firstInterpreterFrameReturnAddress;}
 
-        void CleanupWeakReferenceDictionaries();
-
         void Initialize();
         bool Close(bool inDestructor);
         void MarkForClose();
@@ -1185,10 +1175,6 @@ private:
         PropertyId GetOrAddPropertyIdTracked(__in_ecount(propertyNameLength) LPCWSTR pszPropertyName, __in int propertyNameLength);
         void GetOrAddPropertyRecord(__in_ecount(propertyNameLength) LPCWSTR pszPropertyName, __in int propertyNameLength, PropertyRecord const** propertyRecord);
         BOOL IsNumericPropertyId(PropertyId propertyId, uint32* value);
-
-        void RegisterWeakReferenceDictionary(JsUtil::IWeakReferenceDictionary* weakReferenceDictionary);
-        void UnRegisterWeakReferenceDictionary(JsUtil::IWeakReferenceDictionary* weakReferenceDictionary);
-        void ResetWeakReferenceDictionaryList() { weakReferenceDictionaryList.Reset(); }
 
         BOOL ReserveStaticTypeIds(__in int first, __in int last);
         TypeId ReserveTypeIds(int count);

--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -165,6 +165,8 @@ ThreadContext::ThreadContext(AllocationPolicyManager * allocationPolicyManager, 
     hasCatchHandlerToUserCode(false),
     caseInvariantPropertySet(nullptr),
     entryPointToBuiltInOperationIdCache(&threadAlloc, 0),
+    weakReferenceDictionaryListAllocator(_u("TC-WeakRefDict"), GetPageAllocator(), Js::Throw::OutOfMemory),
+    weakReferenceDictionaryList(&weakReferenceDictionaryListAllocator, 1),
 #if ENABLE_NATIVE_CODEGEN
 #if !FLOATVAR
     codeGenNumberThreadAllocator(nullptr),
@@ -2602,11 +2604,20 @@ ThreadContext::PostCollectionCallBack()
         if (this->recycler->InCacheCleanupCollection())
         {
             this->recycler->ClearCacheCleanupCollection();
-            for (Js::ScriptContext *scriptContext = scriptContextList; scriptContext; scriptContext = scriptContext->next)
+            //for (Js::ScriptContext *scriptContext = scriptContextList; scriptContext; scriptContext = scriptContext->next)
+            //{
+            //    scriptContext->CleanupWeakReferenceDictionaries();
+            //}
+
+            //if (!isWeakReferenceDictionaryListCleared)
             {
-                scriptContext->CleanupWeakReferenceDictionaries();
+                this->weakReferenceDictionaryList.Map([](JsUtil::IWeakReferenceDictionary* weakReferenceDictionary)
+                {
+                    weakReferenceDictionary->Cleanup();
+                });
             }
         }
+
     }
 }
 

--- a/lib/Runtime/Base/ThreadContext.h
+++ b/lib/Runtime/Base/ThreadContext.h
@@ -735,6 +735,9 @@ private:
     ArenaAllocator prototypeChainEnsuredToHaveOnlyWritableDataPropertiesAllocator;
     DListBase<Js::ScriptContext *> prototypeChainEnsuredToHaveOnlyWritableDataPropertiesScriptContext;
 
+    ArenaAllocator weakReferenceDictionaryListAllocator;
+    JsUtil::BaseHashSet<JsUtil::IWeakReferenceDictionary*, ArenaAllocator> weakReferenceDictionaryList;
+
     DListBase<CollectCallBack> collectCallBackList;
     CriticalSection csCollectionCallBack;
     bool hasCollectionCallBack;
@@ -1701,6 +1704,18 @@ public:
             --loopDepth;
         }
     }
+
+    void RegisterWeakReferenceDictionary(JsUtil::IWeakReferenceDictionary* weakReferenceDictionary)
+    {
+        this->weakReferenceDictionaryList.Item(weakReferenceDictionary);
+    }
+
+    void UnRegisterWeakReferenceDictionary(JsUtil::IWeakReferenceDictionary* weakReferenceDictionary)
+    {
+        this->weakReferenceDictionaryList.Remove(weakReferenceDictionary);
+    }
+
+    void ResetWeakReferenceDictionaryList() { weakReferenceDictionaryList.Reset(); }
 
 #if defined(CHECK_MEMORY_LEAK) || defined(LEAK_REPORT)
     static void ReportAndCheckLeaksOnProcessDetach();

--- a/lib/Runtime/Library/ArrayBuffer.cpp
+++ b/lib/Runtime/Library/ArrayBuffer.cpp
@@ -115,7 +115,7 @@ namespace Js
             if (this->otherParents == nullptr)
             {
                 ArrayBufferParentsMap* parents = RecyclerNew(this->GetRecycler(), ArrayBufferParentsMap, this->GetRecycler());
-                this->GetScriptContext()->RegisterWeakReferenceDictionary(parents);
+                this->GetScriptContext()->GetThreadContext()->RegisterWeakReferenceDictionary(parents);
                 this->otherParents = parents;
             }
             // Tag the parent to prevent a strong reference from ArrayBuffer to TypedArray
@@ -655,7 +655,7 @@ namespace Js
 
             if (this->otherParents) 
             {
-                this->GetScriptContext()->UnRegisterWeakReferenceDictionary(this->otherParents);
+                this->GetScriptContext()->GetThreadContext()->UnRegisterWeakReferenceDictionary(this->otherParents);
                 this->otherParents = nullptr;
             }
     }

--- a/lib/Runtime/Library/ArrayBuffer.cpp
+++ b/lib/Runtime/Library/ArrayBuffer.cpp
@@ -652,6 +652,12 @@ namespace Js
 
             buffer = nullptr;
             bufferLength = 0;
+
+            if (this->otherParents) 
+            {
+                this->GetScriptContext()->UnRegisterWeakReferenceDictionary(this->otherParents);
+                this->otherParents = nullptr;
+            }
     }
 
     void JavascriptArrayBuffer::Dispose(bool isShutdown)

--- a/lib/Runtime/Library/ArrayBuffer.cpp
+++ b/lib/Runtime/Library/ArrayBuffer.cpp
@@ -95,9 +95,9 @@ namespace Js
 
         if (this->otherParents != nullptr)
         {
-            this->otherParents->Map([&](int index, RecyclerWeakReference<ArrayBufferParent>* item)
+            this->otherParents->Map([&](const uintptr_t&, const RecyclerWeakReference<ArrayBufferParent>* parent)
             {
-                this->ClearParentsLength(item->Get());
+                this->ClearParentsLength(parent->Get());
             });
         }
 
@@ -114,9 +114,12 @@ namespace Js
         {
             if (this->otherParents == nullptr)
             {
-                this->otherParents = JsUtil::List<RecyclerWeakReference<ArrayBufferParent>*>::New(this->GetRecycler());
+                ArrayBufferParentsMap* parents = RecyclerNew(this->GetRecycler(), ArrayBufferParentsMap, this->GetRecycler());
+                this->GetScriptContext()->RegisterWeakReferenceDictionary(parents);
+                this->otherParents = parents;
             }
-            this->otherParents->Add(this->GetRecycler()->CreateWeakReferenceHandle(parent));
+            // Tag the parent to prevent a strong reference from ArrayBuffer to TypedArray
+            this->otherParents->Item((uintptr_t)parent + 1, this->GetRecycler()->CreateWeakReferenceHandle(parent));
         }
     }
 
@@ -128,23 +131,8 @@ namespace Js
         }
         else
         {
-            int foundIndex = -1;
-            bool parentFound = this->otherParents != nullptr && this->otherParents->MapUntil([&](int index, RecyclerWeakReference<ArrayBufferParent>* item)
-            {
-                if (item->Get() == parent)
-                {
-                    foundIndex = index;
-                    return true;
-                }
-                return false;
-
-            });
-
-            if (parentFound)
-            {
-                this->otherParents->RemoveAt(foundIndex);
-            }
-            else
+            RecyclerWeakReference<ArrayBufferParent>* item;
+            if (!this->otherParents->TryGetValueAndRemove((uintptr_t)parent + 1, &item))
             {
                 AssertMsg(false, "We shouldn't be clearing a parent that hasn't been set.");
             }

--- a/lib/Runtime/Library/ArrayBuffer.h
+++ b/lib/Runtime/Library/ArrayBuffer.h
@@ -147,7 +147,8 @@ namespace Js
 
         //In most cases, the ArrayBuffer will only have one parent
         RecyclerWeakReference<ArrayBufferParent>* primaryParent;
-        JsUtil::List<RecyclerWeakReference<ArrayBufferParent>*>* otherParents;
+        typedef JsUtil::WeakReferenceDictionary<uintptr_t, ArrayBufferParent, PowerOf2SizePolicy> ArrayBufferParentsMap;
+        ArrayBufferParentsMap* otherParents;
 
 
         BYTE  *buffer;             // Points to a heap allocated RGBA buffer, can be null
@@ -178,7 +179,7 @@ namespace Js
         {
             arrayBuffer->AddParent(this);
         }
-
+        
         void ClearArrayBuffer()
         {
             if (this->arrayBuffer != nullptr)

--- a/lib/Runtime/Library/JavascriptLibrary.h
+++ b/lib/Runtime/Library/JavascriptLibrary.h
@@ -1315,14 +1315,7 @@ namespace Js
         
 
     public:
-        virtual void Finalize(bool isShutdown) override
-        {
-            __super::Finalize(isShutdown);
-            if (this->referencedPropertyRecords != nullptr)
-            {
-                RECYCLER_PERF_COUNTER_SUB(PropertyRecordBindReference, this->referencedPropertyRecords->Count());
-            }
-        }
+        virtual void Finalize(bool isShutdown) override;
 
 #if DBG
         void DumpLibraryByteCode();


### PR DESCRIPTION
the List keeping the weakreference that from ArrayBuffer to TypedArray kept expanding, there's no clean up after the TypedArray is collected.
use WeakReferenceDictionay instead of the list, and register it to ScriptContext so it can be cleaned up on post collection stage.
