### PR TITLE
Fix CI logic to have all branches generate a complete set of their own Build Tasks.

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -27,14 +27,6 @@ def machineTypeToOSTagMap = [
 
 def dailyRegex = 'dailies'
 
-// Only generate PR check triggers for the version of netci.groovy in the master branch
-// since those PR checks will apply for all branches.
-def jobTypesToGenerate = [false]
-if (branch.startsWith('master')) {
-    // OK to generate PR checks (this ensures we only generate one set of them)
-    jobTypesToGenerate += true
-}
-
 // ---------------
 // HELPER CLOSURES
 // ---------------
@@ -106,7 +98,7 @@ def CreateBuildTask = { isPR, buildArch, buildType, machine, configTag, buildExt
 }
 
 def CreateBuildTasks = { machine, configTag, buildExtra, testExtra, runCodeAnalysis, excludeConfigIf, nonDefaultTaskSetup ->
-    jobTypesToGenerate.each { isPR ->
+    [true, false].each { isPR ->
         ['x86', 'x64', 'arm'].each { buildArch ->
             ['debug', 'test', 'release'].each { buildType ->
                 CreateBuildTask(isPR, buildArch, buildType, machine, configTag, buildExtra, testExtra, runCodeAnalysis, excludeConfigIf, nonDefaultTaskSetup)


### PR DESCRIPTION
Fixes a logic bug in generating tasks for non-master branches, introduced by the change in #2432.

The issue is revealed in #2449's `generator_prtest` task. Specifically, for the following non-PR tasks that were generated, there was no corresponding `_prtest` variant, which meant that PRs against release/1.4 have not been running PR checks for these variants: 

> Microsoft_ChakraCore » release_1.4 » GenPRTest » arm_debug
> Microsoft_ChakraCore » release_1.4 » GenPRTest » arm_release
> Microsoft_ChakraCore » release_1.4 » GenPRTest » arm_test
> Microsoft_ChakraCore » release_1.4 » GenPRTest » x64_debug
> Microsoft_ChakraCore » release_1.4 » GenPRTest » x64_release
> Microsoft_ChakraCore » release_1.4 » GenPRTest » x64_test
> Microsoft_ChakraCore » release_1.4 » GenPRTest » x86_debug
> Microsoft_ChakraCore » release_1.4 » GenPRTest » x86_release
> Microsoft_ChakraCore » release_1.4 » GenPRTest » x86_test

Fortunately, the non-PR tasks were not affected by the change and have still been running. The Build Status table has remained accurate, and the new checks (disablejit and legacy, x64_debug) have been enough coverage to prevent unforeseen breaks.

How this issue came up:

To simplify reasoning about CI checks against each branch, we've imposed the convention that each branch must now generate it's own set of checks. This makes the logic for generating PR checks consistent with the logic for generating non-PR (rolling build) checks. Because of the way the netci.groovy script works, this actually simplifies the script logic (as seen in this PR).

The reason for this inconsistency had to do with the original implementation of Jenkins and our corresponding netci.groovy logic. #2432 cleaned up this "deprecated" (read: inconsistent) behavior while adding the new checks, but did not account for the logical change which prevented the above PR checks from being generated on non-master branches.

This and #2432 mean that any feature branch which needs CI coverage needs to be specifically called out in https://github.com/dotnet/dotnet-ci/blob/master/jobs/data/repolist.txt -- previously, those 9 checks listed above would run on any branch, including branches for which CI was not explicitly enabled. This is by-design, as different branches in general will have different CI requirements, and it's best not to pollute their CI check set with potentially incorrect or unneeded checks.