### PR TITLE
Reduced native nuspec (removed ch.exe from nuspec)

### DIFF
--- a/Build/NuGet/Microsoft.ChakraCore.vc140.nuspec
+++ b/Build/NuGet/Microsoft.ChakraCore.vc140.nuspec
@@ -30,40 +30,28 @@
     <file src="..\VcBuild\bin\x86_release\ChakraCore.dll" target="lib\native\v140\x86\release\ChakraCore.dll" />
     <file src="..\VcBuild\bin\x86_release\ChakraCore.lib" target="lib\native\v140\x86\release\ChakraCore.lib" />
     <file src="..\VcBuild\bin\x86_release\ChakraCore.pdb" target="lib\native\v140\x86\release\ChakraCore.pdb" />
-    <file src="..\VcBuild\bin\x86_release\ch.exe" target="lib\native\v140\x86\release\ch.exe" />
-    <file src="..\VcBuild\bin\x86_release\ch.pdb" target="lib\native\v140\x86\release\ch.pdb" />
 
     <!--Copying Release to Debug for now to save on build time-->
     <file src="..\VcBuild\bin\x86_release\ChakraCore.dll" target="lib\native\v140\x86\debug\ChakraCore.dll" />
     <file src="..\VcBuild\bin\x86_release\ChakraCore.lib" target="lib\native\v140\x86\debug\ChakraCore.lib" />
     <file src="..\VcBuild\bin\x86_release\ChakraCore.pdb" target="lib\native\v140\x86\debug\ChakraCore.pdb" />
-    <file src="..\VcBuild\bin\x86_release\ch.exe" target="lib\native\v140\x86\debug\ch.exe" />
-    <file src="..\VcBuild\bin\x86_release\ch.pdb" target="lib\native\v140\x86\debug\ch.pdb" />
 
     <file src="..\VcBuild\bin\x64_release\ChakraCore.dll" target="lib\native\v140\x64\release\ChakraCore.dll" />
     <file src="..\VcBuild\bin\x64_release\ChakraCore.lib" target="lib\native\v140\x64\release\ChakraCore.lib" />
     <file src="..\VcBuild\bin\x64_release\ChakraCore.pdb" target="lib\native\v140\x64\release\ChakraCore.pdb" />
-    <file src="..\VcBuild\bin\x64_release\ch.exe" target="lib\native\v140\x64\release\ch.exe" />
-    <file src="..\VcBuild\bin\x64_release\ch.pdb" target="lib\native\v140\x64\release\ch.pdb" />
 
     <!--Copying Release to Debug for now to save on build time-->
     <file src="..\VcBuild\bin\x64_release\ChakraCore.dll" target="lib\native\v140\x64\debug\ChakraCore.dll" />
     <file src="..\VcBuild\bin\x64_release\ChakraCore.lib" target="lib\native\v140\x64\debug\ChakraCore.lib" />
     <file src="..\VcBuild\bin\x64_release\ChakraCore.pdb" target="lib\native\v140\x64\debug\ChakraCore.pdb" />
-    <file src="..\VcBuild\bin\x64_release\ch.exe" target="lib\native\v140\x64\debug\ch.exe" />
-    <file src="..\VcBuild\bin\x64_release\ch.pdb" target="lib\native\v140\x64\debug\ch.pdb" />
 
     <file src="..\VcBuild\bin\arm_release\ChakraCore.dll" target="lib\native\v140\arm\release\ChakraCore.dll" />
     <file src="..\VcBuild\bin\arm_release\ChakraCore.lib" target="lib\native\v140\arm\release\ChakraCore.lib" />
     <file src="..\VcBuild\bin\arm_release\ChakraCore.pdb" target="lib\native\v140\arm\release\ChakraCore.pdb" />
-    <file src="..\VcBuild\bin\arm_release\ch.exe" target="lib\native\v140\arm\release\ch.exe" />
-    <file src="..\VcBuild\bin\arm_release\ch.pdb" target="lib\native\v140\arm\release\ch.pdb" />
 
     <!--Copying Release to Debug for now to save on build time-->
     <file src="..\VcBuild\bin\arm_release\ChakraCore.dll" target="lib\native\v140\arm\debug\ChakraCore.dll" />
     <file src="..\VcBuild\bin\arm_release\ChakraCore.lib" target="lib\native\v140\arm\debug\ChakraCore.lib" />
     <file src="..\VcBuild\bin\arm_release\ChakraCore.pdb" target="lib\native\v140\arm\debug\ChakraCore.pdb" />
-    <file src="..\VcBuild\bin\arm_release\ch.exe" target="lib\native\v140\arm\debug\ch.exe" />
-    <file src="..\VcBuild\bin\arm_release\ch.pdb" target="lib\native\v140\arm\debug\ch.pdb" />
   </files>
 </package>


### PR DESCRIPTION
(Mainly discussion -- don't merge yet.)

See #85 #2266 #2435 

**Advantage of this change:** package size is smaller, although not by a huge amount. Uncompressed size difference is greater, but again, by a relatively small percentage of the remaining size.

Package sizes:

> Microsoft.ChakraCore.1.4.1.nupkg -- 6.32 MB (unpacked: 15.8 MB)
> Microsoft.ChakraCore.vc140.1.4.1.nupkg -- **98.6 MB** (unpacked: **405 MB**)
> Microsoft.ChakraCore.vc140-reduced.1.4.1.nupkg -- **93.0 MB** (unpacked: **376 MB**)

**Disadvantage of this change:** for people who are interested in trying out the features by using ch.exe, they would have to build ch.exe themselves instead of having it already-available in the package. NuGet packages are our primary release distribution mechanism (the other being the files attached to GitHub releases) and they are the only release mechanism for preview builds, so this change would reduce the accessibility of ch.exe to developers who want to quickly explore new features or other changes between builds.

---

In summary, I'm personally leaning against this change as-is. I think another alternative can be found to solve the scenario of needing smaller package sizes.

For instance, we could add definitions for flavor-specific packages for Native in addition to .NET which only include the files necessary for development (i.e. not ch.exe). This also allows a developer who is only interested in targeting a specific architecture (for a low-memory device like an embedded system) to download a package containing just the files they need.

The disadvantage of such a proposal is that it represents yet more packages to maintain and publish on our end.

A compromise is to provide nuspec files for these flavor-specific configurations as well as reduced-size-for-all-flavors (this PR as a separate file) which would allow developers that need those specific configurations to repackage our nupkg for their needs, or easily build their own.