### PR TITLE
Stack args fix for detecting scope obj restore

### DIFF
--- a/lib/Backend/BailOut.cpp
+++ b/lib/Backend/BailOut.cpp
@@ -990,12 +990,6 @@ BailOutRecord::RestoreValue(IR::BailOutKind bailOutKind, Js::JavascriptCallStack
         }
     }
 
-    Js::RegSlot localClosureReg = newInstance->function->GetFunctionBody()->GetLocalClosureRegister();
-    if (regSlot == localClosureReg)
-    {
-        this->globalBailOutRecordTable->isScopeObjRestored = true;
-    }
-
     values[regSlot] = value;
 
     BAILOUT_VERBOSE_TRACE(newInstance->function->GetFunctionBody(), bailOutKind, _u("\n"));
@@ -1633,6 +1627,7 @@ BailOutRecord::BailOutHelper(Js::JavascriptCallStackLayout * layout, Js::ScriptF
         Js::Var closure = newInstance->GetNonVarReg(localClosureReg);
         if (closure)
         {
+            bailOutRecord->globalBailOutRecordTable->isScopeObjRestored = true;
             newInstance->SetLocalClosure(closure);
             newInstance->SetNonVarReg(localClosureReg, nullptr);
         }


### PR DESCRIPTION
The flag that is used for detecting if we restored scope object in the bail out path, was wrongly being marked while restoring outparams for .call bailout scenarios.

Fix:
Moved the setter to a point where we actually set the localClosure property with the scope object.