### PR TITLE
VSO 8294189: Fix two incorrect, high-hitting asserts in RegexHelper::StringReplace

### DIFF
--- a/lib/Runtime/Library/JavascriptString.cpp
+++ b/lib/Runtime/Library/JavascriptString.cpp
@@ -1632,7 +1632,7 @@ case_2:
         AssertMsg(pMatch != nullptr, "Match string shouldn't be null");
         if (replacefn != nullptr)
         {
-            return RegexHelper::StringReplace(pMatch, input, replacefn);
+            return RegexHelper::StringReplace(scriptContext, pMatch, input, replacefn);
         }
         else
         {

--- a/lib/Runtime/Library/RegexHelper.cpp
+++ b/lib/Runtime/Library/RegexHelper.cpp
@@ -1389,10 +1389,9 @@ namespace Js
         return concatenated.ToString();
     }
 
-    Var RegexHelper::StringReplace(JavascriptString* match, JavascriptString* input, JavascriptFunction* replacefn)
+    Var RegexHelper::StringReplace(ScriptContext* scriptContext, JavascriptString* match, JavascriptString* input, JavascriptFunction* replacefn)
     {
         CharCount indexMatched = JavascriptString::strstr(input, match, true);
-        ScriptContext* scriptContext = replacefn->GetScriptContext();
         Assert(match->GetScriptContext() == scriptContext);
         Assert(input->GetScriptContext() == scriptContext);
 
@@ -1412,6 +1411,7 @@ namespace Js
                                     postfixStr, postfixLength);
             return bufferString.ToString();
         }
+
         return input;
     }
 

--- a/lib/Runtime/Library/RegexHelper.h
+++ b/lib/Runtime/Library/RegexHelper.h
@@ -105,7 +105,7 @@ namespace Js
         static Var RegexReplace(ScriptContext* scriptContext, RecyclableObject* thisObj, JavascriptString* input, JavascriptString* replace, bool noResult);
         static Var RegexReplaceFunction(ScriptContext* scriptContext, RecyclableObject* thisObj, JavascriptString* input, JavascriptFunction* replacefn);
         static Var StringReplace(JavascriptString* regularExpression, JavascriptString* input, JavascriptString* replace);
-        static Var StringReplace(JavascriptString* regularExpression, JavascriptString* input, JavascriptFunction* replacefn);
+        static Var StringReplace(ScriptContext* scriptContext, JavascriptString* regularExpression, JavascriptString* input, JavascriptFunction* replacefn);
         static Var RegexSplitResultUsed(ScriptContext* scriptContext, JavascriptRegExp* regularExpression, JavascriptString* input, CharCount limit);
         static Var RegexSplitResultUsedAndMayBeTemp(void *const stackAllocationPointer, ScriptContext* scriptContext, JavascriptRegExp* regularExpression, JavascriptString* input, CharCount limit);
         static Var RegexSplitResultNotUsed(ScriptContext* scriptContext, JavascriptRegExp* regularExpression, JavascriptString* input, CharCount limit);

--- a/test/Strings/replace-xsite.js
+++ b/test/Strings/replace-xsite.js
@@ -1,0 +1,28 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+
+var tests = [
+    {
+        name: "String.Replace ( Pattern as String , ReplaceFunction )",
+        body: function () {
+            assert.doesNotThrow(function() {
+                var str = "AAoooAAooo";
+                var script = `
+                    function foo(str) {
+                        return {
+                            toString: function () { return str + "ZZ" }
+                        }
+                    }`
+
+                var replacer = WScript.LoadScript(script, 'samethread')
+                var replaced = str.replace("A", replacer.foo);
+            });
+        }
+    }
+];
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/Strings/rlexe.xml
+++ b/test/Strings/rlexe.xml
@@ -117,6 +117,12 @@
   </test>
   <test>
     <default>
+      <files>replace-xsite.js</files>
+      <compile-flags>-args summary -endargs</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>trim.js</files>
       <baseline>trim.baseline</baseline>
     </default>


### PR DESCRIPTION
In the function

```
RegexHelper::StringReplace(JavascriptString* match, JavascriptString* input, JavascriptFunction* replacefn)
```

These two asserts would fail when `replacefn` is cross-site (where `scriptContext` is the context of the `replacefn`):

```
Assert(match->GetScriptContext() == scriptContext);
Assert(input->GetScriptContext() == scriptContext);
```

These asserts were overzealous. There is no actual problem here because the `replacefn`'s `ScriptContext` is not used for any outputs from this function and therefore is not observable.

The `scriptContext` in which `EntryReplace` is called should match `match->GetScriptContext()` and `input->GetScriptContext()`.

The fix for these asserts is to pass in the `scriptContext` from the calling function and check against that `scriptContext`. It is okay for the `scriptContext` of `replacefn` to be different, as the parameters and results will be marshalled correctly in other code.

Replaces #2458