### PR TITLE
Symbol : Equal leads to recursive call

### DIFF
--- a/lib/Runtime/Library/JavascriptSymbol.cpp
+++ b/lib/Runtime/Library/JavascriptSymbol.cpp
@@ -242,7 +242,14 @@ namespace Js
 
     BOOL JavascriptSymbol::Equals(JavascriptSymbol* left, Var right, BOOL* value, ScriptContext * requestContext)
     {
-        switch (JavascriptOperators::GetTypeId(right))
+        TypeId typeId = JavascriptOperators::GetTypeId(right);
+        if (typeId != TypeIds_Symbol && typeId != TypeIds_SymbolObject)
+        {
+            right = JavascriptConversion::ToPrimitive(right, JavascriptHint::None, requestContext);
+            typeId = JavascriptOperators::GetTypeId(right);
+        }
+
+        switch (typeId)
         {
         case TypeIds_Symbol:
             *value = left->GetValue() == JavascriptSymbol::FromVar(right)->GetValue();
@@ -251,7 +258,7 @@ namespace Js
             *value = left->GetValue() == JavascriptSymbolObject::FromVar(right)->GetValue();
             break;
         default:
-            *value = JavascriptOperators::Equal_Full(right, left, requestContext);
+            *value = FALSE;
             break;
         }
 

--- a/test/es6/ES6Symbol.js
+++ b/test/es6/ES6Symbol.js
@@ -972,6 +972,28 @@ var tests = [
             assert.throws(function () { o[Symbol.iterator](); }, TypeError, "Calling non-existent built-in symbol property with description fails", "Object doesn't support property or method 'Symbol(Symbol.iterator)'");
         }
     },
+    {
+        name: "Symbol equality logic",
+        body() {
+            assert.isTrue(Symbol.toPrimitive != 1);
+            assert.isTrue(Symbol.toPrimitive != NaN);
+            
+            var valueOfCalled = false;
+            var a = Symbol('f');
+            var b = {
+                valueOf : function() {
+                    valueOfCalled = true;
+                    return a;
+                }
+            };
+            assert.isTrue(a == b);
+            assert.isTrue(valueOfCalled);
+            valueOfCalled = false;
+            assert.isTrue(b == a);
+            assert.isTrue(valueOfCalled);
+            assert.isTrue(a == Object(a));
+        }
+    }
 ];
 
 testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });


### PR DESCRIPTION
JavascriptSymbol::Equal leads to recursive call when the right variable
is not symbol. Fixed that according to the spec.
