### PR TITLE
Float32Array memory leak problem #2328

### DIFF
--- a/lib/Runtime/Library/ArrayBuffer.cpp
+++ b/lib/Runtime/Library/ArrayBuffer.cpp
@@ -95,7 +95,7 @@ namespace Js
 
         if (this->otherParents != nullptr)
         {
-            this->otherParents->Map([&](int index, RecyclerWeakReference<ArrayBufferParent>* item)
+            this->otherParents->Map([&](RecyclerWeakReference<ArrayBufferParent>* item)
             {
                 this->ClearParentsLength(item->Get());
             });
@@ -114,40 +114,25 @@ namespace Js
         {
             if (this->otherParents == nullptr)
             {
-                this->otherParents = JsUtil::List<RecyclerWeakReference<ArrayBufferParent>*>::New(this->GetRecycler());
+                this->otherParents = RecyclerNew(this->GetRecycler(), OtherParents, this->GetRecycler());
             }
-            this->otherParents->Add(this->GetRecycler()->CreateWeakReferenceHandle(parent));
-        }
-    }
 
-    void ArrayBuffer::RemoveParent(ArrayBufferParent* parent)
-    {
-        if (this->primaryParent != nullptr && this->primaryParent->Get() == parent)
-        {
-            this->primaryParent = nullptr;
-        }
-        else
-        {
-            int foundIndex = -1;
-            bool parentFound = this->otherParents != nullptr && this->otherParents->MapUntil([&](int index, RecyclerWeakReference<ArrayBufferParent>* item)
+            if (this->otherParents->increasedCount >= ParentsCleanupThreshold)
             {
-                if (item->Get() == parent)
+                auto iter = this->otherParents->GetEditingIterator();
+                while (iter.Next())
                 {
-                    foundIndex = index;
-                    return true;
+                    if (iter.Data()->Get() == nullptr)
+                    {
+                        iter.RemoveCurrent();
+                    }
                 }
-                return false;
 
-            });
+                this->otherParents->increasedCount = 0;
+            }
 
-            if (parentFound)
-            {
-                this->otherParents->RemoveAt(foundIndex);
-            }
-            else
-            {
-                AssertMsg(false, "We shouldn't be clearing a parent that hasn't been set.");
-            }
+            this->otherParents->PrependNode(this->GetRecycler()->CreateWeakReferenceHandle(parent));
+            this->otherParents->increasedCount++;
         }
     }
 


### PR DESCRIPTION
the List keeping the weakreference that from ArrayBuffer to TypedArray kept expanding, there's no clean up after the TypedArray is collected.
cleanup the list while adding parent once a while. changing the list to be a hashset, because the removal on the list causes linear scan and very slow
