### PR TITLE
enhance TraceRing, enable xplat STACK_BACK_TRACE

### DIFF
--- a/lib/Common/CommonDefines.h
+++ b/lib/Common/CommonDefines.h
@@ -663,11 +663,8 @@
 #define ENABLE_TRACE
 #endif
 
-// xplat-todo: Capture stack backtrace on non-win32 platforms
-#ifdef _WIN32
 #if DBG || defined(CHECK_MEMORY_LEAK) || defined(LEAK_REPORT) || defined(TRACK_DISPATCH) || defined(ENABLE_TRACE) || defined(RECYCLER_PAGE_HEAP)
 #define STACK_BACK_TRACE
-#endif
 #endif
 
 // ENABLE_DEBUG_STACK_BACK_TRACE is for capturing stack back trace for debug only.
@@ -677,7 +674,9 @@
 #endif
 
 #if defined(STACK_BACK_TRACE) || defined(CONTROL_FLOW_GUARD_LOGGER)
+#ifdef _WIN32
 #define DBGHELP_SYMBOL_MANAGER
+#endif
 #endif
 
 #if defined(TRACK_DISPATCH) || defined(CHECK_MEMORY_LEAK) || defined(LEAK_REPORT)

--- a/lib/Common/Exceptions/Throw.cpp
+++ b/lib/Common/Exceptions/Throw.cpp
@@ -253,7 +253,7 @@ namespace Js {
     {
         IsInAssert = true;
 
-#ifdef STACK_BACK_TRACE
+#if defined(GENERATE_DUMP) && defined(STACK_BACK_TRACE)
         // This should be the last thing to happen in the process. Therefore, leaks are not an issue.
         stackBackTrace = StackBackTrace::Capture(&NoCheckHeapAllocator::Instance, Throw::StackToSkip, Throw::StackTraceDepth);
 #endif

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -590,7 +590,7 @@ namespace Js
         Field(InlineeFrameMap*)   inlineeFrameMap;
 #endif
 #if ENABLE_DEBUG_STACK_BACK_TRACE
-        StackBackTrace*    cleanupStack;
+        FieldNoBarrier(StackBackTrace*) cleanupStack;  // NoCheckHeapAllocator
 #endif
     public:
         Field(uint) frameHeight;


### PR DESCRIPTION
Make diagnostic helper TraceRing (renamed from StackBackTraceRing)
thread safe and strongly typed so it is easier to navigate to any frame
and easier to read frame data in debugger (windbg/gdb).

Use backtrace()/backtrace_symbols() to support STACK_BACK_TRACE on xplat.
