### PR TITLE
Array type change to ES5Array due to side-effects results in incorrect behavior in various Array methods.

### DIFF
--- a/lib/Runtime/Library/JavascriptArray.cpp
+++ b/lib/Runtime/Library/JavascriptArray.cpp
@@ -3727,46 +3727,79 @@ namespace Js
             length = JavascriptConversion::ToUInt32(JavascriptOperators::OP_GetLength(obj, scriptContext), scriptContext);
         }
 
-        if (pArr)
+        Var search;
+        uint32 fromIndex = 0;
+        uint64 fromIndex64 = 0;
+
+        // The evaluation of method arguments may change the type of the array. Hence, we do that prior to the actual helper method calls.
+        // The if clause of the conditional statement below applies to an JavascriptArray or TypedArray instances. The rest of the conditional 
+        // clauses apply to an ES5Array or other valid Javascript objects.
+        if ((pArr || TypedArrayBase::Is(obj)) && (length.IsSmallIndex() || length.IsUint32Max()))
         {
-            Var search;
-            uint32 fromIndex;
             uint32 len = length.IsUint32Max() ? MaxArrayLength : length.GetSmallIndex();
             if (!GetParamForIndexOf(len, args, search, fromIndex, scriptContext))
             {
                 return includesAlgorithm ? falseValue : TaggedInt::ToVarUnchecked(-1);
             }
-            int32 index = pArr->HeadSegmentIndexOfHelper(search, fromIndex, len, includesAlgorithm, scriptContext);
-
-            // If we found the search value in the head segment, or if we determined there is no need to search other segments,
-            // we stop right here.
-            if (index != -1 || fromIndex == -1)
+        }
+        else if (length.IsSmallIndex())
+        {
+            if (!GetParamForIndexOf(length.GetSmallIndex(), args, search, fromIndex, scriptContext))
             {
-                if (includesAlgorithm)
-                {
-                    //Array.prototype.includes
-                    return (index == -1)? falseValue : trueValue;
-                }
-                else
-                {
-                    //Array.prototype.indexOf
-                    return JavascriptNumber::ToVar(index, scriptContext);
-                }
+                return includesAlgorithm ? falseValue : TaggedInt::ToVarUnchecked(-1);
             }
-
-            //  If we really must search other segments, let's do it now. We'll have to search the slow way (dealing with holes, etc.).
-
-            switch (pArr->GetTypeId())
+        }
+        else
+        {
+            if (!GetParamForIndexOf(length.GetBigIndex(), args, search, fromIndex64, scriptContext))
             {
-            case Js::TypeIds_Array:
-                return TemplatedIndexOfHelper<includesAlgorithm>(pArr, search, fromIndex, len, scriptContext);
-            case Js::TypeIds_NativeIntArray:
-                return TemplatedIndexOfHelper<includesAlgorithm>(JavascriptNativeIntArray::FromVar(pArr), search, fromIndex, len, scriptContext);
-            case Js::TypeIds_NativeFloatArray:
-                return TemplatedIndexOfHelper<includesAlgorithm>(JavascriptNativeFloatArray::FromVar(pArr), search, fromIndex, len, scriptContext);
-            default:
-                AssertMsg(FALSE, "invalid array typeid");
-                return TemplatedIndexOfHelper<includesAlgorithm>(pArr, search, fromIndex, len, scriptContext);
+                return includesAlgorithm ? falseValue : TaggedInt::ToVarUnchecked(-1);
+            }
+        }
+
+        // Side effects (such as defining a property in a ToPrimitive call) during evaluation of fromIndex argument may convert the array to an ES5 array.
+        if (pArr && !JavascriptArray::Is(obj))
+        {
+            AssertOrFailFastMsg(ES5Array::Is(obj), "The array should have been converted to an ES5Array");
+            pArr = nullptr;
+        }
+
+        if (pArr)
+        {
+            if (length.IsSmallIndex() || length.IsUint32Max())
+            {
+                uint32 len = length.IsUint32Max() ? MaxArrayLength : length.GetSmallIndex();
+                int32 index = pArr->HeadSegmentIndexOfHelper(search, fromIndex, len, includesAlgorithm, scriptContext);
+
+                // If we found the search value in the head segment, or if we determined there is no need to search other segments,
+                // we stop right here.
+                if (index != -1 || fromIndex == -1)
+                {
+                    if (includesAlgorithm)
+                    {
+                        //Array.prototype.includes
+                        return (index == -1) ? falseValue : trueValue;
+                    }
+                    else
+                    {
+                        //Array.prototype.indexOf
+                        return JavascriptNumber::ToVar(index, scriptContext);
+                    }
+                }
+
+                //  If we really must search other segments, let's do it now. We'll have to search the slow way (dealing with holes, etc.).
+                switch (pArr->GetTypeId())
+                {
+                case Js::TypeIds_Array:
+                    return TemplatedIndexOfHelper<includesAlgorithm>(pArr, search, fromIndex, len, scriptContext);
+                case Js::TypeIds_NativeIntArray:
+                    return TemplatedIndexOfHelper<includesAlgorithm>(JavascriptNativeIntArray::FromVar(pArr), search, fromIndex, len, scriptContext);
+                case Js::TypeIds_NativeFloatArray:
+                    return TemplatedIndexOfHelper<includesAlgorithm>(JavascriptNativeFloatArray::FromVar(pArr), search, fromIndex, len, scriptContext);
+                default:
+                    AssertMsg(FALSE, "invalid array typeid");
+                    return TemplatedIndexOfHelper<includesAlgorithm>(pArr, search, fromIndex, len, scriptContext);
+                }
             }
         }
 
@@ -3775,35 +3808,16 @@ namespace Js
         {
             if (length.IsSmallIndex() || length.IsUint32Max())
             {
-                Var search;
-                uint32 fromIndex;
-                uint32 len = length.IsUint32Max() ? MaxArrayLength : length.GetSmallIndex();
-                if (!GetParamForIndexOf(len, args, search, fromIndex, scriptContext))
-                {
-                    return includesAlgorithm ? falseValue : TaggedInt::ToVarUnchecked(-1);
-                }
                 return TemplatedIndexOfHelper<includesAlgorithm>(TypedArrayBase::FromVar(obj), search, fromIndex, length.GetSmallIndex(), scriptContext);
             }
         }
         if (length.IsSmallIndex())
         {
-            Var search;
-            uint32 fromIndex;
-            if (!GetParamForIndexOf(length.GetSmallIndex(), args, search, fromIndex, scriptContext))
-            {
-                return includesAlgorithm ? falseValue : TaggedInt::ToVarUnchecked(-1);
-            }
             return TemplatedIndexOfHelper<includesAlgorithm>(obj, search, fromIndex, length.GetSmallIndex(), scriptContext);
         }
         else
         {
-            Var search;
-            uint64 fromIndex;
-            if (!GetParamForIndexOf(length.GetBigIndex(), args, search, fromIndex, scriptContext))
-            {
-                return includesAlgorithm ? falseValue : TaggedInt::ToVarUnchecked(-1);
-            }
-            return TemplatedIndexOfHelper<includesAlgorithm>(obj, search, fromIndex, length.GetBigIndex(), scriptContext);
+            return TemplatedIndexOfHelper<includesAlgorithm>(obj, search, fromIndex64, length.GetBigIndex(), scriptContext);
         }
     }
 
@@ -4582,6 +4596,13 @@ Case0:
         if (!GetParamForLastIndexOf(length, args, search, fromIndex, scriptContext))
         {
             return TaggedInt::ToVarUnchecked(-1);
+        }
+
+        // Side effects (such as defining a property in a ToPrimitive call) during evaluation of fromIndex argument may convert the array to an ES5 array.
+        if (pArr && !JavascriptArray::Is(obj))
+        {
+            AssertOrFailFastMsg(ES5Array::Is(obj), "The array should have been converted to an ES5Array");
+            pArr = nullptr;
         }
 
         if (pArr)
@@ -5400,7 +5421,8 @@ Case0:
             }
             else
             {
-                for (uint32 lower = 0; lower < middle; lower++)
+                Assert(middle <= UINT_MAX);
+                for (uint32 lower = 0; lower < (uint32)middle; lower++)
                 {
                     uint32 upper = (uint32)length - lower - 1;
 
@@ -5792,9 +5814,9 @@ Case0:
                 AssertMsg(!SparseArraySegment<T>::IsMissingItem(&headSeg->elements[i+start]), "Array marked incorrectly as having missing value");
             }
         }
-
 #endif
     }
+
     // If the creating profile data has changed, convert it to the type of array indicated
     // in the profile
     void JavascriptArray::GetArrayTypeAndConvert(bool* isIntArray, bool* isFloatArray)
@@ -5939,6 +5961,13 @@ Case0:
             newLenT = endT > startT ? endT - startT : 0;
         }
 
+        // Side effects (such as defining a property in a ToPrimitive call) during evaluation of arguments start or end may convert the array to an ES5 array.
+        if (pArr && !JavascriptArray::Is(obj))
+        {
+            AssertOrFailFastMsg(ES5Array::Is(obj), "The array should have been converted to an ES5Array");
+            pArr = nullptr;
+        }
+
         if (TypedArrayBase::IsDetachedTypedArray(obj))
         {
             JavascriptError::ThrowTypeError(scriptContext, JSERR_DetachedTypedArray, _u("Array.prototype.slice"));
@@ -6046,6 +6075,14 @@ Case0:
             return newObj;
         }
 
+        // The ArraySpeciesCreate call above could have converted the source array into an ES5Array. If this happens
+        // we will process the array elements like an ES5Array.
+        if (pArr && !JavascriptArray::Is(obj))
+        {
+            AssertOrFailFastMsg(ES5Array::Is(obj), "The array should have been converted to an ES5Array");
+            pArr = nullptr;
+        }
+
         if (pArr)
         {
             // If we constructed a new Array object, we have some nice helpers here
@@ -6096,6 +6133,14 @@ Case0:
                         }
 
                         newArr->SetItem(i, element, PropertyOperation_None);
+
+                        // Side-effects in the prototype lookup may have changed the source array into an ES5Array. If this happens
+                        // we will process the rest of the array elements like an ES5Array.
+                        if (!JavascriptArray::Is(obj))
+                        {
+                            AssertOrFailFastMsg(ES5Array::Is(obj), "The array should have been converted to an ES5Array");
+                            return JavascriptArray::SliceObjectHelper(obj, start, i + 1, newArr, newObj, newLen, scriptContext);
+                        }
                     }
                 }
             }
@@ -6112,6 +6157,14 @@ Case0:
                     }
 
                     ThrowErrorOnFailure(JavascriptArray::SetArrayLikeObjects(newObj, i, element), scriptContext, i);
+
+                    // Side-effects in the prototype lookup may have changed the source array into an ES5Array. If this happens
+                    // we will process the rest of the array elements like an ES5Array.
+                    if (!JavascriptArray::Is(obj))
+                    {
+                        AssertOrFailFastMsg(ES5Array::Is(obj), "The array should have been converted to an ES5Array");
+                        return JavascriptArray::SliceObjectHelper(obj, start, i + 1, newArr, newObj, newLen, scriptContext);
+                    }
                 }
             }
         }
@@ -6154,27 +6207,43 @@ Case0:
         }
         else
         {
-            for (uint32 i = 0; i < newLen; i++)
-            {
-                if (JavascriptOperators::HasItem(obj, i + start))
-                {
-                    Var element = JavascriptOperators::GetItem(obj, i + start, scriptContext);
-                    if (newArr != nullptr)
-                    {
-                        newArr->SetItem(i, element, PropertyOperation_None);
-                    }
-                    else
-                    {
-                        ThrowErrorOnFailure(JavascriptArray::SetArrayLikeObjects(newObj, i, element), scriptContext, i);
-                    }
-                }
-            }
+            return JavascriptArray::SliceObjectHelper(obj, start, 0u, newArr, newObj, newLen, scriptContext);
         }
 
         if (!isTypedArrayEntryPoint)
         {
             JavascriptOperators::SetProperty(newObj, newObj, Js::PropertyIds::length, JavascriptNumber::ToVar(newLen, scriptContext), scriptContext, PropertyOperation_ThrowIfNotExtensible);
         }
+
+#ifdef VALIDATE_ARRAY
+        if (JavascriptArray::Is(newObj))
+        {
+            JavascriptArray::FromVar(newObj)->ValidateArray();
+        }
+#endif
+
+        return newObj;
+    }
+
+    Var JavascriptArray::SliceObjectHelper(RecyclableObject* obj, uint32 sliceStart, uint32 start, JavascriptArray* newArr, RecyclableObject* newObj, uint32 newLen, ScriptContext* scriptContext)
+    {
+        for (uint32 i = start; i < newLen; i++)
+        {
+            if (JavascriptOperators::HasItem(obj, i + sliceStart))
+            {
+                Var element = JavascriptOperators::GetItem(obj, i + sliceStart, scriptContext);
+                if (newArr != nullptr)
+                {
+                    newArr->SetItem(i, element, PropertyOperation_None);
+                }
+                else
+                {
+                    ThrowErrorOnFailure(JavascriptArray::SetArrayLikeObjects(newObj, i, element), scriptContext, i);
+                }
+            }
+        }
+
+        JavascriptOperators::SetProperty(newObj, newObj, Js::PropertyIds::length, JavascriptNumber::ToVar(newLen, scriptContext), scriptContext, PropertyOperation_ThrowIfNotExtensible);
 
 #ifdef VALIDATE_ARRAY
         if (JavascriptArray::Is(newObj))
@@ -6729,6 +6798,13 @@ Case0:
             }
             deleteLen = min(len - start, deleteLen);
             break;
+        }
+
+        // Side effects (such as defining a property in a ToPrimitive call) during evaluation of arguments start or deleteCount may convert the array to an ES5 array.
+        if (isArr && !JavascriptArray::Is(pObj))
+        {
+            AssertOrFailFastMsg(ES5Array::Is(pObj), "The array should have been converted to an ES5Array");
+            isArr = false;
         }
 
         Var* insertArgs = args.Info.Count > 3 ? &args.Values[3] : nullptr;
@@ -7984,7 +8060,6 @@ Case0:
             length = JavascriptConversion::ToLength(lenValue, scriptContext);
         }
 
-
         return JavascriptArray::FindHelper<false>(pArr, nullptr, obj, length, args, scriptContext);
     }
 
@@ -8030,7 +8105,9 @@ Case0:
         if (pArr)
         {
             Var undefined = scriptContext->GetLibrary()->GetUndefined();
-            for (uint32 k = 0; k < length; k++)
+
+            Assert(length <= UINT_MAX);
+            for (uint32 k = 0; k < (uint32)length; k++)
             {
                 element = undefined;
                 pArr->DirectGetItemAtFull(k, &element);
@@ -8046,11 +8123,20 @@ Case0:
                 {
                     return findIndex ? index : element;
                 }
+
+                // Side-effects in the callback function may have changed the source array into an ES5Array. If this happens
+                // we will process the rest of the array elements like an ES5Array.
+                if (!JavascriptArray::Is(obj))
+                {
+                    AssertOrFailFastMsg(ES5Array::Is(obj), "The array should have been converted to an ES5Array");
+                    return JavascriptArray::FindObjectHelper<findIndex>(obj, length, k + 1, callBackFn, thisArg, scriptContext);
+                }
             }
         }
         else if (typedArrayBase)
         {
-            for (uint32 k = 0; k < length; k++)
+            Assert(length <= UINT_MAX);
+            for (uint32 k = 0; k < (uint32)length; k++)
             {
                 element = typedArrayBase->DirectGetItem(k);
 
@@ -8069,20 +8155,33 @@ Case0:
         }
         else
         {
-            for (uint32 k = 0; k < length; k++)
+            return JavascriptArray::FindObjectHelper<findIndex>(obj, length, 0u, callBackFn, thisArg, scriptContext);
+        }
+
+        return findIndex ? JavascriptNumber::ToVar(-1, scriptContext) : scriptContext->GetLibrary()->GetUndefined();
+    }
+
+    template <bool findIndex>
+    Var JavascriptArray::FindObjectHelper(RecyclableObject* obj, int64 length, int64 start, RecyclableObject* callBackFn, Var thisArg, ScriptContext* scriptContext)
+    {
+        // The correct flag value is CallFlags_Value but we pass CallFlags_None in compat modes
+        CallFlags flags = CallFlags_Value;
+        Var element = nullptr;
+        Var testResult = nullptr;
+
+        for (int64 k = start; k < length; k++)
+        {
+            element = JavascriptOperators::GetItem(obj, (uint64)k, scriptContext);
+            Var index = JavascriptNumber::ToVar(k, scriptContext);
+
+            testResult = CALL_FUNCTION(callBackFn, CallInfo(flags, 4), thisArg,
+                element,
+                index,
+                obj);
+
+            if (JavascriptConversion::ToBoolean(testResult, scriptContext))
             {
-                element = JavascriptOperators::GetItem(obj, k, scriptContext);
-                Var index = JavascriptNumber::ToVar(k, scriptContext);
-
-                testResult = CALL_FUNCTION(callBackFn, CallInfo(flags, 4), thisArg,
-                    element,
-                    index,
-                    obj);
-
-                if (JavascriptConversion::ToBoolean(testResult, scriptContext))
-                {
-                    return findIndex ? index : element;
-                }
+                return findIndex ? index : element;
             }
         }
 
@@ -8319,7 +8418,8 @@ Case0:
 
         if (pArr)
         {
-            for (uint32 k = 0; k < length; k++)
+            Assert(length <= UINT_MAX);
+            for (uint32 k = 0; k < (uint32)length; k++)
             {
                 if (!pArr->DirectGetItemAtFull(k, &element))
                 {
@@ -8335,13 +8435,21 @@ Case0:
                 {
                     return scriptContext->GetLibrary()->GetFalse();
                 }
+
+                // Side-effects in the callback function may have changed the source array into an ES5Array. If this happens
+                // we will process the rest of the array elements like an ES5Array.
+                if (!JavascriptArray::Is(obj))
+                {
+                    AssertOrFailFastMsg(ES5Array::Is(obj), "The array should have been converted to an ES5Array");
+                    return JavascriptArray::EveryObjectHelper<T>(obj, length, k + 1, callBackFn, thisArg, scriptContext);
+                }
             }
         }
         else if (typedArrayBase)
         {
             Assert(length <= UINT_MAX);
 
-            for (uint32 k = 0; k < length; k++)
+            for (uint32 k = 0; k < (uint32)length; k++)
             {
                 if (!typedArrayBase->HasItem(k))
                 {
@@ -8363,22 +8471,35 @@ Case0:
         }
         else
         {
-            for (T k = 0; k < length; k++)
+            return JavascriptArray::EveryObjectHelper<T>(obj, length, 0u, callBackFn, thisArg, scriptContext);
+        }
+
+        return scriptContext->GetLibrary()->GetTrue();
+    }
+
+    template <typename T>
+    Var JavascriptArray::EveryObjectHelper(RecyclableObject* obj, T length, T start, RecyclableObject* callBackFn, Var thisArg, ScriptContext* scriptContext)
+    {
+        // The correct flag value is CallFlags_Value but we pass CallFlags_None in compat modes
+        CallFlags flags = CallFlags_Value;
+        Var element = nullptr;
+        Var testResult = nullptr;
+
+        for (T k = start; k < length; k++)
+        {
+            // According to es6 spec, we need to call Has first before calling Get
+            if (JavascriptOperators::HasItem(obj, k))
             {
-                // According to es6 spec, we need to call Has first before calling Get
-                if (JavascriptOperators::HasItem(obj, k))
+                element = JavascriptOperators::GetItem(obj, k, scriptContext);
+
+                testResult = CALL_FUNCTION(callBackFn, CallInfo(flags, 4), thisArg,
+                    element,
+                    JavascriptNumber::ToVar(k, scriptContext),
+                    obj);
+
+                if (!JavascriptConversion::ToBoolean(testResult, scriptContext))
                 {
-                    element = JavascriptOperators::GetItem(obj, k, scriptContext);
-
-                    testResult = CALL_FUNCTION(callBackFn, CallInfo(flags, 4), thisArg,
-                        element,
-                        JavascriptNumber::ToVar(k, scriptContext),
-                        obj);
-
-                    if (!JavascriptConversion::ToBoolean(testResult, scriptContext))
-                    {
-                        return scriptContext->GetLibrary()->GetFalse();
-                    }
+                    return scriptContext->GetLibrary()->GetFalse();
                 }
             }
         }
@@ -8430,7 +8551,7 @@ Case0:
             length = JavascriptConversion::ToUInt32(JavascriptOperators::OP_GetLength(obj, scriptContext), scriptContext);
         }
 
-            if (length.IsSmallIndex())
+        if (length.IsSmallIndex())
         {
             return JavascriptArray::SomeHelper(pArr, nullptr, obj, length.GetSmallIndex(), args, scriptContext);
         }
@@ -8480,7 +8601,8 @@ Case0:
 
         if (pArr)
         {
-            for (uint32 k = 0; k < length; k++)
+            Assert(length <= UINT_MAX);
+            for (uint32 k = 0; k < (uint32)length; k++)
             {
                 if (!pArr->DirectGetItemAtFull(k, &element))
                 {
@@ -8496,13 +8618,21 @@ Case0:
                 {
                     return scriptContext->GetLibrary()->GetTrue();
                 }
+
+                // Side-effects in the callback function may have changed the source array into an ES5Array. If this happens
+                // we will process the rest of the array elements like an ES5Array.
+                if (!JavascriptArray::Is(obj))
+                {
+                    AssertOrFailFastMsg(ES5Array::Is(obj), "The array should have been converted to an ES5Array");
+                    return JavascriptArray::SomeObjectHelper<T>(obj, length, k + 1, callBackFn, thisArg, scriptContext);
+                }
             }
         }
         else if (typedArrayBase)
         {
             Assert(length <= UINT_MAX);
 
-            for (uint32 k = 0; k < length; k++)
+            for (uint32 k = 0; k < (uint32)length; k++)
             {
                 // If k < typedArrayBase->length, we know that HasItem will return true.
                 // But we still have to call it in case there's a proxy trap or in the case that we are calling
@@ -8527,20 +8657,33 @@ Case0:
         }
         else
         {
-            for (T k = 0; k < length; k++)
-            {
-                if (JavascriptOperators::HasItem(obj, k))
-                {
-                    element = JavascriptOperators::GetItem(obj, k, scriptContext);
-                    testResult = CALL_FUNCTION(callBackFn, CallInfo(flags, 4), thisArg,
-                        element,
-                        JavascriptNumber::ToVar(k, scriptContext),
-                        obj);
+            return JavascriptArray::SomeObjectHelper<T>(obj, length, 0u, callBackFn, thisArg, scriptContext);
+        }
 
-                    if (JavascriptConversion::ToBoolean(testResult, scriptContext))
-                    {
-                        return scriptContext->GetLibrary()->GetTrue();
-                    }
+        return scriptContext->GetLibrary()->GetFalse();
+    }
+
+    template <typename T>
+    Var JavascriptArray::SomeObjectHelper(RecyclableObject* obj, T length, T start, RecyclableObject* callBackFn, Var thisArg, ScriptContext* scriptContext)
+    {
+        // The correct flag value is CallFlags_Value but we pass CallFlags_None in compat modes
+        CallFlags flags = CallFlags_Value;
+        Var element = nullptr;
+        Var testResult = nullptr;
+
+        for (T k = start; k < length; k++)
+        {
+            if (JavascriptOperators::HasItem(obj, k))
+            {
+                element = JavascriptOperators::GetItem(obj, k, scriptContext);
+                testResult = CALL_FUNCTION(callBackFn, CallInfo(flags, 4), thisArg,
+                    element,
+                    JavascriptNumber::ToVar(k, scriptContext),
+                    obj);
+
+                if (JavascriptConversion::ToBoolean(testResult, scriptContext))
+                {
+                    return scriptContext->GetLibrary()->GetTrue();
                 }
             }
         }
@@ -8752,6 +8895,13 @@ Case0:
             direction = 1;
         }
 
+        // Side effects (such as defining a property in a ToPrimitive call) during evaluation of arguments may convert the array to an ES5 array.
+        if (pArr && !JavascriptArray::Is(obj))
+        {
+            AssertOrFailFastMsg(ES5Array::Is(obj), "The array should have been converted to an ES5Array");
+            pArr = nullptr;
+        }
+
         // If we are going to copy elements from or to indices > 2^32-1 we'll execute this (slightly slower path)
         // It's possible to optimize here so that we use the normal code below except for the > 2^32-1 indices
         if ((direction == -1 && (fromVal >= MaxArrayLength || toVal >= MaxArrayLength))
@@ -8801,6 +8951,12 @@ Case0:
                         Var val = pArr->DirectGetItem(fromIndex);
 
                         pArr->SetItem(toIndex, val, Js::PropertyOperation_ThrowIfNotExtensible);
+
+                        if (!JavascriptArray::Is(obj))
+                        {
+                            AssertOrFailFastMsg(ES5Array::Is(obj), "The array should have been converted to an ES5Array");
+                            pArr = nullptr;
+                        }
                     }
                     else
                     {
@@ -8894,6 +9050,14 @@ Case0:
             if (args.Info.Count > 3 && !JavascriptOperators::IsUndefinedObject(args[3]))
             {
                 finalVal = JavascriptArray::GetIndexFromVar(args[3], length, scriptContext);
+            }
+
+            // Side-effects in the callback function may have changed the source array into an ES5Array. If this happens
+            // we will process the array elements like an ES5Array.
+            if (pArr && !JavascriptArray::Is(obj))
+            {
+                AssertOrFailFastMsg(ES5Array::Is(obj), "The array should have been converted to an ES5Array");
+                pArr = nullptr;
             }
         }
 
@@ -9097,11 +9261,19 @@ Case0:
         // We at least have to have newObj as a valid object
         Assert(newObj);
 
+        // The ArraySpeciesCreate call above could have converted the source array into an ES5Array. If this happens
+        // we will process the array elements like an ES5Array.
+        if (pArr && !JavascriptArray::Is(obj))
+        {
+            AssertOrFailFastMsg(ES5Array::Is(obj), "The array should have been converted to an ES5Array");
+            pArr = nullptr;
+        }
+
         if (pArr != nullptr)
         {
             // If source is a JavascriptArray, newObj may or may not be an array based on what was in source's constructor property
-
-            for (uint32 k = 0; k < length; k++)
+            Assert(length <= UINT_MAX);
+            for (uint32 k = 0; k < (uint32)length; k++)
             {
                 if (!pArr->DirectGetItemAtFull(k, &element))
                 {
@@ -9120,7 +9292,15 @@ Case0:
                 }
                 else
                 {
-                    ThrowErrorOnFailure(JavascriptArray::SetArrayLikeObjects(RecyclableObject::FromVar(newObj), k, mappedValue), scriptContext, k);
+                    ThrowErrorOnFailure(JavascriptArray::SetArrayLikeObjects(newObj, k, mappedValue), scriptContext, k);
+                }
+
+                // Side-effects in the callback function may have changed the source array into an ES5Array. If this happens
+                // we will process the rest of the array elements like an ES5Array.
+                if (!JavascriptArray::Is(obj))
+                {
+                    AssertOrFailFastMsg(ES5Array::Is(obj), "The array should have been converted to an ES5Array");
+                    return JavascriptArray::MapObjectHelper<T>(obj, length, k + 1, newObj, newArr, isBuiltinArrayCtor, callBackFn, thisArg, scriptContext);
                 }
             }
         }
@@ -9134,7 +9314,8 @@ Case0:
                 newTypedArray = TypedArrayBase::FromVar(newObj);
             }
 
-            for (uint32 k = 0; k < length; k++)
+            Assert(length <= UINT_MAX);
+            for (uint32 k = 0; k < (uint32)length; k++)
             {
                 // We can't rely on the length value being equal to typedArrayBase->GetLength() because user code may lie and
                 // attach any length property to a TypedArray instance and pass it as this parameter when .calling
@@ -9165,30 +9346,52 @@ Case0:
                 }
                 else
                 {
-                    JavascriptArray::SetArrayLikeObjects(RecyclableObject::FromVar(newObj), k, mappedValue);
+                    JavascriptArray::SetArrayLikeObjects(newObj, k, mappedValue);
                 }
             }
         }
         else
         {
-            for (uint32 k = 0; k < length; k++)
-            {
-                if (JavascriptOperators::HasItem(obj, k))
-                {
-                    element = JavascriptOperators::GetItem(obj, k, scriptContext);
-                    mappedValue = CALL_FUNCTION(callBackFn, callBackFnInfo, thisArg,
-                        element,
-                        JavascriptNumber::ToVar(k, scriptContext),
-                        obj);
+            return JavascriptArray::MapObjectHelper<T>(obj, length, 0u, newObj, newArr, isBuiltinArrayCtor, callBackFn, thisArg, scriptContext);
+        }
 
-                    if (newArr && isBuiltinArrayCtor)
-                    {
-                        newArr->SetItem(k, mappedValue, PropertyOperation_None);
-                    }
-                    else
-                    {
-                        ThrowErrorOnFailure(JavascriptArray::SetArrayLikeObjects(RecyclableObject::FromVar(newObj), k, mappedValue), scriptContext, k);
-                    }
+#ifdef VALIDATE_ARRAY
+        if (JavascriptArray::Is(newObj))
+        {
+            newArr->ValidateArray();
+        }
+#endif
+
+        return newObj;
+    }
+
+    template<typename T>
+    Var JavascriptArray::MapObjectHelper(RecyclableObject* obj, T length, T start, RecyclableObject* newObj, JavascriptArray* newArr,
+        bool isBuiltinArrayCtor, RecyclableObject* callBackFn, Var thisArg, ScriptContext* scriptContext)
+    {
+        // The correct flag value is CallFlags_Value but we pass CallFlags_None in compat modes
+        CallFlags callBackFnflags = CallFlags_Value;
+        CallInfo callBackFnInfo = CallInfo(callBackFnflags, 4);
+        Var element = nullptr;
+        Var mappedValue = nullptr;
+
+        for (T k = start; k < length; k++)
+        {
+            if (JavascriptOperators::HasItem(obj, k))
+            {
+                element = JavascriptOperators::GetItem(obj, k, scriptContext);
+                mappedValue = CALL_FUNCTION(callBackFn, callBackFnInfo, thisArg,
+                    element,
+                    JavascriptNumber::ToVar(k, scriptContext),
+                    obj);
+
+                if (newArr && isBuiltinArrayCtor)
+                {
+                    newArr->SetItem((uint32)k, mappedValue, PropertyOperation_None);
+                }
+                else
+                {
+                    ThrowErrorOnFailure(JavascriptArray::SetArrayLikeObjects(newObj, BigIndex(k), mappedValue), scriptContext, BigIndex(k));
                 }
             }
         }
@@ -9295,6 +9498,14 @@ Case0:
             }
         }
 
+        // The ArraySpeciesCreate call above could have converted the source array into an ES5Array. If this happens
+        // we will process the array elements like an ES5Array.
+        if (pArr && !JavascriptArray::Is(obj))
+        {
+            AssertOrFailFastMsg(ES5Array::Is(obj), "The array should have been converted to an ES5Array");
+            pArr = nullptr;
+        }
+
         Var element = nullptr;
         Var selected = nullptr;
 
@@ -9303,7 +9514,8 @@ Case0:
             Assert(length <= MaxArrayLength);
             uint32 i = 0;
 
-            for (uint32 k = 0; k < length; k++)
+            Assert(length <= UINT_MAX);
+            for (uint32 k = 0; k < (uint32)length; k++)
             {
                 if (!pArr->DirectGetItemAtFull(k, &element))
                 {
@@ -9329,35 +9541,62 @@ Case0:
                     }
                     ++i;
                 }
+
+                // Side-effects in the callback function may have changed the source array into an ES5Array. If this happens
+                // we will process the rest of the array elements like an ES5Array.
+                if (!JavascriptArray::Is(obj))
+                {
+                    AssertOrFailFastMsg(ES5Array::Is(obj), "The array should have been converted to an ES5Array");
+                    return JavascriptArray::FilterObjectHelper<T>(obj, length, k + 1, newArr, newObj, i, callBackFn, thisArg, scriptContext);
+                }
             }
         }
         else
         {
-            BigIndex i = 0u;
+            return JavascriptArray::FilterObjectHelper<T>(obj, length, 0u, newArr, newObj, 0u, callBackFn, thisArg, scriptContext);
+        }
 
-            for (T k = 0; k < length; k++)
+#ifdef VALIDATE_ARRAY
+        if (newArr)
+        {
+            newArr->ValidateArray();
+        }
+#endif
+
+        return newObj;
+    }
+
+    template <typename T>
+    Var JavascriptArray::FilterObjectHelper(RecyclableObject* obj, T length, T start, JavascriptArray* newArr, RecyclableObject* newObj, T newStart,
+        RecyclableObject* callBackFn, Var thisArg, ScriptContext* scriptContext)
+    {
+        Var element = nullptr;
+        Var selected = nullptr;
+        BigIndex i = BigIndex(newStart);
+
+        for (T k = start; k < length; k++)
+        {
+            if (JavascriptOperators::HasItem(obj, k))
             {
-                if (JavascriptOperators::HasItem(obj, k))
-                {
-                    element = JavascriptOperators::GetItem(obj, k, scriptContext);
-                    selected = CALL_ENTRYPOINT(callBackFn->GetEntryPoint(), callBackFn, CallInfo(CallFlags_Value, 4),
-                        thisArg,
-                        element,
-                        JavascriptNumber::ToVar(k, scriptContext),
-                        obj);
+                element = JavascriptOperators::GetItem(obj, k, scriptContext);
+                selected = CALL_ENTRYPOINT(callBackFn->GetEntryPoint(), callBackFn, CallInfo(CallFlags_Value, 4),
+                    thisArg,
+                    element,
+                    JavascriptNumber::ToVar(k, scriptContext),
+                    obj);
 
-                    if (JavascriptConversion::ToBoolean(selected, scriptContext))
+                if (JavascriptConversion::ToBoolean(selected, scriptContext))
+                {
+                    if (newArr)
                     {
-                        if (newArr)
-                        {
-                            newArr->DirectSetItemAt(i, element);
-                        }
-                        else
-                        {
-                            ThrowErrorOnFailure(JavascriptArray::SetArrayLikeObjects(newObj, i, element), scriptContext, i);
-                        }
-                        ++i;
+                        newArr->DirectSetItemAt(i, element);
                     }
+                    else
+                    {
+                        ThrowErrorOnFailure(JavascriptArray::SetArrayLikeObjects(newObj, i, element), scriptContext, i);
+                    }
+
+                    ++i;
                 }
             }
         }
@@ -9475,6 +9714,14 @@ Case0:
                     bPresent = true;
                     accumulator = element;
                 }
+
+                // Side-effects in the callback function may have changed the source array into an ES5Array. If this happens
+                // we will process the array elements like an ES5Array.
+                if (!JavascriptArray::Is(obj))
+                {
+                    AssertOrFailFastMsg(ES5Array::Is(obj), "The array should have been converted to an ES5Array");
+                    pArr = nullptr;
+                }
             }
             else if (typedArrayBase)
             {
@@ -9531,6 +9778,14 @@ Case0:
                     element,
                     JavascriptNumber::ToVar(k, scriptContext),
                     pArr);
+
+                // Side-effects in the callback function may have changed the source array into an ES5Array. If this happens
+                // we will process the rest of the array elements like an ES5Array.
+                if (!JavascriptArray::Is(obj))
+                {
+                    AssertOrFailFastMsg(ES5Array::Is(obj), "The array should have been converted to an ES5Array");
+                    return JavascriptArray::ReduceObjectHelper<T>(obj, length, k + 1, callBackFn, accumulator, scriptContext);
+                }
             }
         }
         else if (typedArrayBase)
@@ -9554,18 +9809,30 @@ Case0:
         }
         else
         {
-            for (; k < length; k++)
-            {
-                if (JavascriptOperators::HasItem(obj, k))
-                {
-                    element = JavascriptOperators::GetItem(obj, k, scriptContext);
+            return JavascriptArray::ReduceObjectHelper<T>(obj, length, k, callBackFn, accumulator, scriptContext);
+        }
 
-                    accumulator = CALL_FUNCTION(callBackFn, CallInfo(flags, 5), undefinedValue,
-                        accumulator,
-                        element,
-                        JavascriptNumber::ToVar(k, scriptContext),
-                        obj);
-                }
+        return accumulator;
+    }
+
+    template <typename T>
+    Var JavascriptArray::ReduceObjectHelper(RecyclableObject* obj, T length, T start, RecyclableObject* callBackFn, Var accumulator, ScriptContext* scriptContext)
+    {
+        // The correct flag value is CallFlags_Value but we pass CallFlags_None in compat modes
+        CallFlags flags = CallFlags_Value;
+        Var element = nullptr;
+
+        for (T k = start; k < length; k++)
+        {
+            if (JavascriptOperators::HasItem(obj, k))
+            {
+                element = JavascriptOperators::GetItem(obj, k, scriptContext);
+
+                accumulator = CALL_FUNCTION(callBackFn, CallInfo(flags, 5), scriptContext->GetLibrary()->GetUndefined(),
+                    accumulator,
+                    element,
+                    JavascriptNumber::ToVar(k, scriptContext),
+                    obj);
             }
         }
 
@@ -9674,6 +9941,14 @@ Case0:
                     bPresent = true;
                     accumulator = element;
                 }
+
+                // Side-effects in the callback function may have changed the source array into an ES5Array. If this happens
+                // we will process the array elements like an ES5Array.
+                if (!JavascriptArray::Is(obj))
+                {
+                    AssertOrFailFastMsg(ES5Array::Is(obj), "The array should have been converted to an ES5Array");
+                    pArr = nullptr;
+                }
             }
             else if (typedArrayBase)
             {
@@ -9706,7 +9981,6 @@ Case0:
             {
                 JavascriptError::ThrowTypeError(scriptContext, VBSERR_ActionNotSupported);
             }
-
         }
 
         // The correct flag value is CallFlags_Value but we pass CallFlags_None in compat modes
@@ -9728,6 +10002,14 @@ Case0:
                     element,
                     JavascriptNumber::ToVar(index, scriptContext),
                     pArr);
+
+                // Side-effects in the callback function may have changed the source array into an ES5Array. If this happens
+                // we will process the rest of the array elements like an ES5Array.
+                if (!JavascriptArray::Is(obj))
+                {
+                    AssertOrFailFastMsg(ES5Array::Is(obj), "The array should have been converted to an ES5Array");
+                    return JavascriptArray::ReduceRightObjectHelper<T>(obj, length, k + 1, callBackFn, accumulator, scriptContext);
+                }
             }
         }
         else if (typedArrayBase)
@@ -9752,18 +10034,31 @@ Case0:
         }
         else
         {
-            for (; k < length; k++)
+            return JavascriptArray::ReduceRightObjectHelper<T>(obj, length, k, callBackFn, accumulator, scriptContext);
+        }
+
+        return accumulator;
+    }
+
+    template <typename T>
+    Var JavascriptArray::ReduceRightObjectHelper(RecyclableObject* obj, T length, T start, RecyclableObject* callBackFn, Var accumulator, ScriptContext* scriptContext)
+    {
+        // The correct flag value is CallFlags_Value but we pass CallFlags_None in compat modes
+        CallFlags flags = CallFlags_Value;
+        Var element = nullptr;
+        T index = 0;
+
+        for (T k = start; k < length; k++)
+        {
+            index = length - k - 1;
+            if (JavascriptOperators::HasItem(obj, index))
             {
-                index = length - k - 1;
-                if (JavascriptOperators::HasItem(obj, index))
-                {
-                    element = JavascriptOperators::GetItem(obj, index, scriptContext);
-                    accumulator = CALL_FUNCTION(callBackFn, CallInfo(flags, 5), undefinedValue,
-                        accumulator,
-                        element,
-                        JavascriptNumber::ToVar(index, scriptContext),
-                        obj);
-                }
+                element = JavascriptOperators::GetItem(obj, index, scriptContext);
+                accumulator = CALL_FUNCTION(callBackFn, CallInfo(flags, 5), scriptContext->GetLibrary()->GetUndefined(),
+                    accumulator,
+                    element,
+                    JavascriptNumber::ToVar(index, scriptContext),
+                    obj);
             }
         }
 
@@ -9874,7 +10169,7 @@ Case0:
                 }
                 else
                 {
-                    ThrowErrorOnFailure(JavascriptArray::SetArrayLikeObjects(RecyclableObject::FromVar(newObj), k, nextValue), scriptContext, k);
+                    ThrowErrorOnFailure(JavascriptArray::SetArrayLikeObjects(newObj, k, nextValue), scriptContext, k);
                 }
 
                 k++;
@@ -9943,7 +10238,7 @@ Case0:
                 }
                 else
                 {
-                    ThrowErrorOnFailure(JavascriptArray::SetArrayLikeObjects(RecyclableObject::FromVar(newObj), k, kValue), scriptContext, k);
+                    ThrowErrorOnFailure(JavascriptArray::SetArrayLikeObjects(newObj, k, kValue), scriptContext, k);
                 }
             }
 

--- a/lib/Runtime/Library/JavascriptArray.h
+++ b/lib/Runtime/Library/JavascriptArray.h
@@ -465,6 +465,9 @@ namespace Js
         static int64 GetIndexFromVar(Js::Var arg, int64 length, ScriptContext* scriptContext);
         template <typename T>
         static Var MapHelper(JavascriptArray* pArr, Js::TypedArrayBase* typedArrayBase, RecyclableObject* obj, T length, Arguments& args, ScriptContext* scriptContext);
+        template <typename T>
+        static Var MapObjectHelper(RecyclableObject* obj, T length, T start, RecyclableObject* newObj, JavascriptArray* newArr,
+            bool isBuiltinArrayCtor, RecyclableObject* callBackFn, Var thisArg, ScriptContext* scriptContext);
         static Var FillHelper(JavascriptArray* pArr, Js::TypedArrayBase* typedArrayBase, RecyclableObject* obj, int64 length, Arguments& args, ScriptContext* scriptContext);
         static Var CopyWithinHelper(JavascriptArray* pArr, Js::TypedArrayBase* typedArrayBase, RecyclableObject* obj, int64 length, Arguments& args, ScriptContext* scriptContext);
         template <typename T>
@@ -483,18 +486,32 @@ namespace Js
         static Var ReverseHelper(JavascriptArray* pArr, Js::TypedArrayBase* typedArrayBase, RecyclableObject* obj, T length, ScriptContext* scriptContext);
         template <typename T = uint32>
         static Var SliceHelper(JavascriptArray* pArr, Js::TypedArrayBase* typedArrayBase, RecyclableObject* obj, T length, Arguments& args, ScriptContext* scriptContext);
+        static Var SliceObjectHelper(RecyclableObject* obj, uint32 sliceStart, uint32 start, JavascriptArray* newArr, RecyclableObject* newObj, uint32 newLen, ScriptContext* scriptContext);
         template <typename T = uint32>
         static Var EveryHelper(JavascriptArray* pArr, Js::TypedArrayBase* typedArrayBase, RecyclableObject* obj, T length, Arguments& args, ScriptContext* scriptContext);
         template <typename T = uint32>
+        static Var EveryObjectHelper(RecyclableObject* obj, T length, T start, RecyclableObject* callBackFn, Var thisArg, ScriptContext* scriptContext);
+        template <typename T = uint32>
         static Var SomeHelper(JavascriptArray* pArr, Js::TypedArrayBase* typedArrayBase, RecyclableObject* obj, T length, Arguments& args, ScriptContext* scriptContext);
+        template <typename T = uint32>
+        static Var SomeObjectHelper(RecyclableObject* obj, T length, T start, RecyclableObject* callBackFn, Var thisArg, ScriptContext* scriptContext);
         template <bool findIndex>
         static Var FindHelper(JavascriptArray* pArr, Js::TypedArrayBase* typedArrayBase, RecyclableObject* obj, int64 length, Arguments& args, ScriptContext* scriptContext);
+        template <bool findIndex>
+        static Var FindObjectHelper(RecyclableObject* obj, int64 length, int64 start, RecyclableObject* callBackFn, Var thisArg, ScriptContext* scriptContext);
         template <typename T = uint32>
         static Var ReduceHelper(JavascriptArray* pArr, Js::TypedArrayBase* typedArrayBase, RecyclableObject* obj, T length, Arguments& args, ScriptContext* scriptContext);
         template <typename T>
+        static Var ReduceObjectHelper(RecyclableObject* obj, T length, T start, RecyclableObject* callBackFn, Var accumulator, ScriptContext* scriptContext);
+            template <typename T>
         static Var FilterHelper(JavascriptArray* pArr, RecyclableObject* obj, T length, Arguments& args, ScriptContext* scriptContext);
+        template <typename T>
+        static Var FilterObjectHelper(RecyclableObject* obj, T length, T start, JavascriptArray* newArr, RecyclableObject* newObj, T newStart,
+            RecyclableObject* callBackFn, Var thisArg, ScriptContext* scriptContext);
         template <typename T = uint32>
         static Var ReduceRightHelper(JavascriptArray* pArr, Js::TypedArrayBase* typedArrayBase, RecyclableObject* obj, T length, Arguments& args, ScriptContext* scriptContext);
+        template <typename T>
+        static Var ReduceRightObjectHelper(RecyclableObject* obj, T length, T start, RecyclableObject* callBackFn, Var accumulator, ScriptContext* scriptContext);
         static Var OfHelper(bool isTypedArrayEntryPoint, Arguments& args, ScriptContext* scriptContext);
 
         static uint32 GetFromIndex(Var arg, uint32 length, ScriptContext *scriptContext);
@@ -604,9 +621,17 @@ namespace Js
 
                 if (hasSideEffect && MayChangeType<T>() && !T::Is(arr))
                 {
-                    // The function has changed, go to another ForEachItemInRange
-                    JavascriptArray::FromVar(arr)->template ForEachItemInRange<true>(i + 1, limitIndex, missingItem, scriptContext, fn);
-                    return;
+                    // The function has changed, go to another ForEachItemInRange. It is possible that the array might have changed to 
+                    // an ES5Array, in such cases we don't need to call the JavascriptArray specific implementation.
+                    if (JavascriptArray::Is(arr))
+                    {
+                        JavascriptArray::FromVar(arr)->template ForEachItemInRange<true>(i + 1, limitIndex, missingItem, scriptContext, fn);
+                        return;
+                    }
+                    else
+                    {
+                        AssertOrFailFastMsg(ES5Array::Is(arr), "The array should have been converted to an ES5Array");
+                    }
                 }
             }
         }
@@ -623,9 +648,17 @@ namespace Js
 
                     if (hasSideEffect && MayChangeType<T>() && !T::Is(arr))
                     {
-                        // The function has changed, go to another ForEachItemInRange
-                        JavascriptArray::FromVar(arr)->template ForEachItemInRange<true>(i + 1, limitIndex, scriptContext, fn);
-                        return;
+                        // The function has changed, go to another ForEachItemInRange. It is possible that the array might have changed to 
+                        // an ES5Array, in such cases we don't need to call the JavascriptArray specific implementation.
+                        if (JavascriptArray::Is(arr))
+                        {
+                            JavascriptArray::FromVar(arr)->template ForEachItemInRange<true>(i + 1, limitIndex, scriptContext, fn);
+                            return;
+                        }
+                        else
+                        {
+                            AssertOrFailFastMsg(ES5Array::Is(arr), "The array should have been converted to an ES5Array");
+                        }
                     }
                 }
             }

--- a/test/es6/toPrimitive.js
+++ b/test/es6/toPrimitive.js
@@ -5,6 +5,11 @@
 
 WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
 
+function AddNumbers(first, second)
+{
+    return first + second;
+}
+
 var tests = [
     {
        name: "Number Object Test",
@@ -473,6 +478,596 @@ var tests = [
                 assert.throws(()=>(o==Symbol()), TypeError, "o==Symbol()", "[Symbol.toPrimitive]: invalid argument");
             });
         }
+    },
+    {
+       name: "Array type conversion tests: lastIndexOf()",
+       body: function ()
+       {
+            var p1 = {
+                [Symbol.toPrimitive] (hint) {
+                    Object.defineProperty(a1, "0", {configurable : true, get: function(){ return 30;}});
+                    return a1.length;
+                }
+            };
+            var a1 = [1, 2, 3, 4, 5];
+            assert.areEqual(3, a1.lastIndexOf(4, p1), "ToPrimitive: lastIndexOf() method returned incorrect result as array type changed to ES5 array.");
+
+            var a1_proto = {};
+            Object.defineProperty(a1_proto, "1", {
+                  get: function(){
+                        Object.defineProperty(a1_prototest, "0", {configurable : true, get: function(){ return 30;}});
+                        return 2;
+                  }
+            });
+
+            var a1_prototest = [, , 3, 4, 5];
+            a1_prototest.__proto__ = a1_proto;
+            var c1_prototest = [].lastIndexOf.call(a1_prototest, 30);
+            assert.areEqual(0, c1_prototest, "ToPrimitive: The lastIndexOf() method returned incorrect result as array type changed to ES5 array in the property getter of the prototype.");
+        }
+    },
+    {
+       name: "Array type conversion tests: indexOf()",
+       body: function ()
+       {
+            var p2 = {
+                [Symbol.toPrimitive] (hint) {
+                    Object.defineProperty(a2, "0", {configurable : true, get: function(){ return 30;}});
+                    return 0;
+                }
+            };
+            var a2 = [1, 2, 3, 4, 5];
+            assert.areEqual(3, a2.indexOf(4, p2), "ToPrimitive: indexOf() method returned incorrect result as array type changed to ES5 array.");
+
+            var a2_proto = {};
+            Object.defineProperty(a2_proto, "0", {
+                  get: function(){
+                        Object.defineProperty(a2_prototest, "1", {configurable : true, get: function(){ return 30;}});
+                        return 1;
+                  }
+            });
+
+            var a2_prototest = [, , 3, 4, 5];
+            a2_prototest.__proto__ = a2_proto;
+            var c2_prototest = [].indexOf.call(a2_prototest, 30);
+            assert.areEqual(1, c2_prototest, "ToPrimitive: The indexOf() method returned incorrect result as array type changed to ES5 array in the property getter of the prototype.");
+       }
+    },
+    {
+       name: "Array type conversion tests: splice()",
+       body: function ()
+       {
+            var p3 = {
+                [Symbol.toPrimitive] (hint) {
+                    Object.defineProperty(a3, "0", {configurable : true, get: function(){ return 30;}});
+                    return 0;
+                }
+            };
+            var a3 = [1, 2, 3, 4, 5];
+            var b3 = a3.splice(p3);
+            assert.areEqual([30,2,3,4,5], b3, "ToPrimitive: splice() method returned incorrect result as array type changed to ES5 array.");
+ 
+            var a3_proto = {};
+            Object.defineProperty(a3_proto, "0", {
+                  get: function(){
+                        Object.defineProperty(a3_prototest, "1", {configurable : true, get: function(){ return 30;}});
+                        return 1;
+                  }
+            });
+
+            var a3_prototest = [, , 3, 4, 5];
+            a3_prototest.__proto__ = a3_proto;
+            var c3_prototest = [].splice.call(a3_prototest, 0);
+            assert.areEqual([1,30,3,4,5], c3_prototest, "ToPrimitive: The splice() method returned incorrect result as array type changed to ES5 array in the property getter of the prototype.");
+
+            function a3_constructor(x) { };
+            a3_constructor[Symbol.species] = function () {
+                Object.defineProperty(a3_species, "0", { configurable: true, get: function () { return 30; } });
+                return {};
+            };
+
+            var a3_species = [1, 2, 3, 4, 5];
+            a3_species['constructor'] = a3_constructor;
+            var c3_species = a3_species.splice(0);
+            assert.areEqual(30, c3_species["0"], "The splice() method returned incorrect result as array was converted to an ES5Array.");            
+            assert.areEqual("30,2,3,4,5", [].join.call(c3_species, ","), "The splice() method returned incorrect result as array was converted to an ES5Array.");
+       }
+   },
+    {
+       name: "Array type conversion tests: slice()",
+       body: function ()
+       {
+            var p4 = {
+                [Symbol.toPrimitive] (hint) {
+                    Object.defineProperty(a4, "0", {configurable : true, get: function(){ return 30;}});
+                    return 0;
+                }
+            };
+            var a4 = [1, 2, 3, 4, 5];
+            var b4 = a4.slice(p4);
+            assert.areEqual([30,2,3,4,5], b4, "ToPrimitive: slice() method returned incorrect result as array type changed to ES5 array.");
+
+            var a4_proto = {};
+            Object.defineProperty(a4_proto, "0", {
+                  get: function(){
+                        Object.defineProperty(a4_prototest, "1", {configurable : true, get: function(){ return 30;}});
+                        return 1;
+                  }
+            });
+
+            var a4_prototest = [, , 3, 4, 5];
+            a4_prototest.__proto__ = a4_proto;
+            var c4_prototest = [].slice.call(a4_prototest, 0);
+            assert.areEqual([1,30,3,4,5], c4_prototest, "ToPrimitive: The slice() method returned incorrect result as array type changed to ES5 array in the property getter of the prototype.");
+ 
+            function a4_constructor(x) { };
+            a4_constructor[Symbol.species] = function () {
+                Object.defineProperty(a4_species, "0", { configurable: true, get: function () { return 30; } });
+                return {};
+            };
+
+            var a4_species = [1, 2, 3, 4, 5];
+            a4_species['constructor'] = a4_constructor;
+            var c4_species = a4_species.slice(0);
+            assert.areEqual(30, c4_species["0"], "The slice() method returned incorrect result as array was converted to an ES5Array.");            
+            assert.areEqual("30,2,3,4,5", [].join.call(c4_species, ","), "The slice() method returned incorrect result as array was converted to an ES5Array.");
+       }
+   },
+    {
+       name: "Array type conversion tests: includes()",
+       body: function ()
+       {
+            var p5 = {
+                [Symbol.toPrimitive] (hint) {
+                    Object.defineProperty(a5, "0", {configurable : true, get: function(){ return 30;}});
+                    return 0;
+                }
+            };
+            var a5 = [1, 2, 3, 4, 5];
+            assert.isTrue(a5.includes(30, p5), "ToPrimitive: includes() method returned incorrect result as array type changed to ES5 array.");
+
+            var a5_proto = {};
+            Object.defineProperty(a5_proto, "0", {
+                  get: function(){
+                        Object.defineProperty(a5_prototest, "1", {configurable : true, get: function(){ return 30;}});
+                        return 1;
+                  }
+            });
+
+            var a5_prototest = [, , 3, 4, 5];
+            a5_prototest.__proto__ = a5_proto;
+            assert.isTrue([].includes.call(a5_prototest, 30), "The includes() method returned incorrect result as array type changed to ES5 array in the property getter of the prototype.");
+       }
+    },
+    {
+       name: "Array type conversion tests: find() and findIndex().",
+       body: function ()
+       {
+            var p2 = {
+                [Symbol.toPrimitive] (hint) {
+                    // The first element changes during the visit to the first element; so it's side-effect won't be seen by Find method.
+                    Object.defineProperty(a2, "0", {configurable : true, get: function(){ return 20;}});
+
+                    // The second element changes during the visit to the first element; so it's side-effect will be seen by Find method.
+                    Object.defineProperty(a2, "1", {configurable : true, get: function(){ return 30;}});
+                    return 10;
+                }
+            };
+            var a2 = [1, 2, 3, 4, 5];
+            var c2 = a2.find(function(x) { return x % p2 == 0; });
+            assert.areEqual(30, c2, "The find() method returned incorrect result as array was converted to an ES5Array.");
+
+            var a2_prototest = [,, 3, 4, 5];
+            var a2_proto = {};
+            Object.defineProperty(a2_proto, "0", {
+                get: function(){
+                        Object.defineProperty(a2_prototest, "1", {configurable : true, get: function(){ return 30;}});
+                        return 7;
+                }
+            });
+
+            a2_prototest.__proto__ = a2_proto;
+            var c2_prototest = [].find.call(a2_prototest, function(x) { return x % 10 == 0; });
+            assert.areEqual(30, c2_prototest, "The find() method returned incorrect result as array was converted to an ES5Array in the property getter of the prototype.");
+
+            var p3 = {
+                [Symbol.toPrimitive] (hint) {
+                    // The first element changes during the visit to the first element; so it's side-effect won't be seen by FindIndex method.
+                    Object.defineProperty(a3, "0", {configurable : true, get: function(){ return 30;}});
+
+                    // The second element changes during the visit to the first element; so it's side-effect will be seen by FindIndex method.
+                    Object.defineProperty(a3, "1", {configurable : true, get: function(){ return 30;}});
+                    return 30;
+                }
+            };
+            var a3 = [1, 2, 3, 4, 5];
+            var c3 = a3.findIndex(function(x) { return x == p3; });
+            assert.areEqual(1, c3, "The findIndex() method returned incorrect result as array was converted to an ES5Array.");
+        }
+    },
+    {
+       name: "Array type conversion tests: map().",
+       body: function ()
+       {
+            var p4 = function(x)
+            {
+                    Object.defineProperty(a4, "1", {configurable : true, get: function(){ return 30;}});
+                    return x * x;
+            };
+            var a4 = [1, 2, 3, 4, 5];
+            var c4 = a4.map(p4);
+            assert.areEqual([1,900,9,16,25], c4, "The map() method returned incorrect result as array was converted to an ES5Array.");
+
+            var p4_typedarray = function(x)
+            {
+                    Object.defineProperty(a4_typedarray, "1", {configurable : false, value: 30});
+                    return x * x;
+            };
+            var a4_typedarray = new Int32Array([1, 2, 3, 4, 5]);
+            var c4_typedarray = a4_typedarray.map(p4_typedarray);
+            assert.areEqual([1,900,9,16,25], c4_typedarray, "The map() method returned incorrect result for TypedArray.");
+
+            function a4_constructor(x) { };
+            a4_constructor[Symbol.species] = function () {
+                Object.defineProperty(a4_species, "1", { configurable: true, get: function () { return 30; } });
+                return {};
+            };
+
+            var a4_species = [1, 2, 3, 4, 5];
+            a4_species['constructor'] = a4_constructor;
+            var c4_species = a4_species.map(function (x) { return x * x; });
+            assert.areEqual([1, 900, 9, 16, 25], c4_species, "Map returned incorrect result as array was converted to an ES5Array.");
+
+            var a4_proto = {};
+            Object.defineProperty(a4_proto, "0", {
+                get: function(){
+                        Object.defineProperty(a4_prototest, "1", {configurable : true, get: function(){ return 30;}});
+                        return 7;
+                }
+            });
+
+            var SquareNumber = function(x)
+            {
+                return x * x;
+            };
+            var a4_prototest = [, , 3, 4, 5];
+            a4_prototest.__proto__ = a4_proto;
+            var c4_prototest = [].map.call(a4_prototest, SquareNumber);
+            assert.areEqual([49,900,9,16,25], c4_prototest, "The map() method returned incorrect result as array was converted to an ES5Array in the property getter of the prototype.");
+       }
+    },
+    {
+       name: "Array type conversion tests: reduce().",
+       body: function ()
+       {
+            var p6 = {
+                [Symbol.toPrimitive] (hint) {
+                    // The first element changes during the visit to the first element; so it's side-effect won't be seen by Reduce method.
+                    Object.defineProperty(a6, "0", {configurable : true, get: function(){ return 30;}});
+
+                    // The second element changes during the visit to the first element; so it's side-effect will be seen by Reduce method.
+                    Object.defineProperty(a6, "1", {configurable : true, get: function(){ return 30;}});
+                    return 0;
+                }
+            };
+
+            var a6 = [1, 2, 3, 4, 5];
+            var c6 = a6.reduce(AddNumbers, p6);
+            assert.areEqual(43, c6, "The reduce() method returned incorrect result as array was converted to an ES5Array.");
+
+            var a6_proto = {};
+            Object.defineProperty(a6_proto, "0", {
+                get: function(){
+                        Object.defineProperty(a6_prototest, "1", {configurable : true, get: function(){ return 30;}});
+                        return 1;
+                }
+            });
+
+            var a6_prototest = [, , 3, 4, 5];
+            a6_prototest.__proto__ = a6_proto;
+            var c6_prototest = [].reduce.call(a6_prototest, AddNumbers);
+            assert.areEqual(43, c6_prototest, "The reduce() method returned incorrect result as array was converted to an ES5Array in the property getter of the prototype.");
+
+            // Regression tests
+            var a6_es5 = [1, 2, 3, 4, 5];
+            Object.defineProperty(a6_es5, "0", {configurable : true, get: function(){ return 30;}});
+            var c6_es5 = a6_es5.reduce(AddNumbers);
+            assert.areEqual(44, c6_es5, "The reduce() method returned incorrect result for an ES5Array.");
+        }
+    },
+    {
+       name: "Array type conversion tests: reduceRight().",
+       body: function ()
+       {
+            var p7 = {
+                [Symbol.toPrimitive] (hint) {
+                    // The last element changes during the visit to the last element; so it's side-effect won't be seen by ReduceRight method.
+                    Object.defineProperty(a7, "4", {configurable : true, get: function(){ return 30;}});
+
+                    // The second element changes during the visit to the first element; so it's side-effect will be seen by ReduceRight method.
+                    Object.defineProperty(a7, "1", {configurable : true, get: function(){ return 30;}});
+                    return 0;
+                }
+            };
+
+            var a7 = [1, 2, 3, 4, 5];
+            var c7 = a7.reduceRight(AddNumbers, p7);
+            assert.areEqual(43, c7, "The reduceRight() method returned incorrect result as array was converted to an ES5Array.");
+
+            var a7_proto = {};
+            Object.defineProperty(a7_proto, "4", {
+                get: function(){
+                        Object.defineProperty(a7_prototest, "1", {configurable : true, get: function(){ return 30;}});
+                        return 5;
+                }
+            });
+
+            var a7_prototest = [1, , 3, 4, ,];
+            a7_prototest.__proto__ = a7_proto;
+            var c7_prototest = [].reduceRight.call(a7_prototest, AddNumbers);
+            assert.areEqual(43, c7_prototest, "The reduceRight() method returned incorrect result as array was converted to an ES5Array in the property getter of the prototype.");
+
+            // Regression test
+            var a7_es5 = [1, 2, 3, 4, 5];
+            Object.defineProperty(a7_es5, "0", {configurable : true, get: function(){ return 30;}});
+            var c7_es5 = a7_es5.reduceRight(AddNumbers);
+            assert.areEqual(44, c7_es5, "The reduceRight() method returned incorrect result for an ES5Array.");
+        }
+    },
+    {
+       name: "Array type conversion tests: some().",
+       body: function ()
+       {
+            var p8 = {
+                [Symbol.toPrimitive] (hint) {
+                    Object.defineProperty(a8, "1", {configurable : true, get: function(){ return 30;}});
+                    return 30;
+                }
+            };
+
+            function MatchNumber(numberToMatch)
+            {
+                return numberToMatch == p8;
+            }
+            var a8 = [1, 2, 3, 4, 5];
+            var c8 = a8.some(MatchNumber);
+            assert.isTrue(c8, "The some() method returned incorrect result as array was converted to an ES5Array.");
+
+            var a8_proto = {};
+            Object.defineProperty(a8_proto, "0", {
+                get: function(){
+                        Object.defineProperty(a8_prototest, "1", {configurable : true, get: function(){ return 30;}});
+                        return 5;
+                }
+            });
+
+            var a8_prototest = [, , 3, 4, 5];
+            a8_prototest.__proto__ = a8_proto;
+            var c8_prototest = [].some.call(a8_prototest, function(elem){ return elem == 30; });
+            assert.isTrue(c8_prototest, "The some() method returned incorrect result as array was converted to an ES5Array in the property getter of the prototype.");
+        }
+    },
+    {
+       name: "Array type conversion tests: every().",
+       body: function ()
+       {
+            var p9 = {
+                [Symbol.toPrimitive] (hint) {
+                    Object.defineProperty(a9, "1", {configurable : true, get: function(){ return 30;}});
+                    return 30;
+                }
+            };
+
+            function CompareNumber(numberToMatch)
+            {
+                return numberToMatch < p9;
+            }
+            var a9 = [1, 2, 3, 4, 5];
+            var c9 = a9.every(CompareNumber);
+            assert.isFalse(c9, "The every() method returned incorrect result as array was converted to an ES5Array.");
+
+            var a9_proto = {};
+            Object.defineProperty(a9_proto, "0", {
+                get: function(){
+                        Object.defineProperty(a9_prototest, "1", {configurable : true, get: function(){ return 30;}});
+                        return 1;
+                }
+            });
+
+            var a9_prototest = [, , 3, 4, 5];
+            a9_prototest.__proto__ = a9_proto;
+            var c9_prototest = [].every.call(a9_prototest, function(elem){ return elem < 30;});
+            assert.isFalse(c9_prototest, "The every() method returned incorrect result as array was converted to an ES5Array in the property getter of the prototype.");
+        }
+    },
+    {
+        name: "Array type conversion tests: fill().",
+        body: function ()
+        {
+            var temp = 30;
+            var p10 = {
+                [Symbol.toPrimitive] (hint) {
+                    Object.defineProperty(a10, 1, {configurable : true, get: function(){ return temp;}, set: function(value){ temp = value;}});
+                    return 0;
+                }
+            };
+            var a10 = [1, 2, 3, 4, 5];
+            var c10 = a10.fill(0, p10);
+            assert.areEqual([0,0,0,0,0], c10, "ToPrimitive: The fill() method returned incorrect result as array type changed to ES5 array.");
+        }
+    },
+    {
+       name: "Array type conversion tests: filter().",
+       body: function ()
+       {
+            var p11 = {
+                [Symbol.toPrimitive] (hint) {
+                    // The first element changes during the visit to the first element; so it's side-effect won't be seen by filter method.
+                    Object.defineProperty(a11, "0", {configurable : true, get: function(){ return 30;}});
+
+                    // The last element changes during the visit to the first element; so it's side-effect will be seen by filter method.
+                    Object.defineProperty(a11, "4", {configurable : true, get: function(){ return 30;}});
+                    return 0;
+                }
+            };
+
+            var a11 = [1, 2, 3, 4, 5];
+            var c11 = a11.filter(function(elem){ return elem %2 == p11; });
+            assert.areEqual([2,4,30], c11, "ToPrimitive: The filter() method returned incorrect result as array type changed to ES5 array.");
+
+            var a11_proto = {};
+            Object.defineProperty(a11_proto, "0", {
+                  get: function(){
+                        Object.defineProperty(a11_prototest, "1", {configurable : true, get: function(){ return 30;}});
+                        return 1;
+                  }
+            });
+
+            var a11_prototest = [, , 3, 4, 5];
+            a11_prototest.__proto__ = a11_proto;
+            var c11_prototest = [].filter.call(a11_prototest, function(elem){ return elem %2 == 0; });
+            assert.areEqual([30,4], c11_prototest, "ToPrimitive: The filter() method returned incorrect result as array type changed to ES5 array in the property getter of the prototype.");
+
+            var p11_typedarray = {
+                [Symbol.toPrimitive] (hint) {
+                    // The first element changes during the visit to the first element; so it's side-effect won't be seen by filter method.
+                    Object.defineProperty(a11_typedarray, "0", {configurable : false, value:30 });
+
+                    // The last element changes during the visit to the first element; so it's side-effect will be seen by filter method.
+                    Object.defineProperty(a11_typedarray, "4", {configurable : false, value:30 });
+                    return 0;
+                }
+            };
+
+            var a11_typedarray = new Int16Array([1,2,3,4,5]);
+            var c11_typedarray = a11_typedarray.filter(function(elem){ return elem %2 == p11_typedarray; });
+            assert.areEqual([2,4,30], c11_typedarray, "ToPrimitive: The filter() method returned incorrect result for TypedArray.");
+
+            function a11_constructor(x) { };
+            a11_constructor[Symbol.species] = function () {
+                Object.defineProperty(a11_species, "0", { configurable: true, get: function () { return 30; } });
+                return {};
+            };
+
+            var a11_species = [1, 2, 3, 4, 5];
+            a11_species['constructor'] = a11_constructor;
+            var c11_species = a11_species.filter(function (elem) { return elem % 2 == 0; });
+            assert.areEqual([30, 2, 4], c11_species, "The filter() returned incorrect result as array was converted to an ES5Array.");
+       }
+    },
+    {
+       name: "Array type conversion tests: foreach().",
+       body: function ()
+       {
+            var a18 = [1,2,3,4,5];
+            var c18 = "";
+
+            a18.forEach( function (item, index)
+                {
+                    if(index==0)
+                    {
+                        // The first element changes during the visit to the first element; so it's side-effect won't be seen by forEach method.
+                        Object.defineProperty(a18, "0", {configurable : true, get: function(){ return 30;}});
+
+                        // The last element changes during the visit to the first element; so it's side-effect will be seen by forEach method.
+                        Object.defineProperty(a18, "1", {configurable : true, get: function(){ return 30;}});
+                    }
+                    else
+                    {
+                        c18 = c18 + ","
+                    }
+
+                    c18 = c18 + item*item;
+                });
+            assert.areEqual("1,900,9,16,25", c18, "ToPrimitive: The forEach() method returned incorrect result for as array type changed to ES5 array.");
+
+            var a18_proto = {};
+            Object.defineProperty(a18_proto, "0", {
+                  get: function(){
+                        Object.defineProperty(a18_prototest, "1", {configurable : true, get: function(){ return 30;}});
+                        return 1;
+                  }
+            });
+
+            var a18_prototest  = [,,3,4,5];
+            a18_prototest.__proto__ = a18_proto;
+            var c18_prototest  = "";
+
+            [].forEach.call(a18_prototest, function (item, index)
+                {
+                    if(index>0)
+                    {
+                        c18_prototest  += ","
+                    }
+
+                    c18_prototest += item*item;
+                });
+            assert.areEqual("1,900,9,16,25", c18_prototest, "ToPrimitive: The forEach() method returned incorrect result for as array type changed to ES5 array.");
+
+            var a18_typedarray = new Int16Array([1,2,3,4,5]);
+            var c18_typedarray = "";
+
+            a18_typedarray.forEach( function (item, index)
+                {
+                    if(index==0)
+                    {
+                        // The first element changes during the visit to the first element; so it's side-effect won't be seen by forEach method.
+                        Object.defineProperty(a18_typedarray, "0", {configurable : false, value:30 });
+
+                        // The last element changes during the visit to the first element; so it's side-effect will be seen by forEach method.
+                        Object.defineProperty(a18_typedarray, "1", {configurable : false, value:30 });
+                    }
+                    else
+                    {
+                        c18_typedarray = c18_typedarray + ","
+                    }
+
+                    c18_typedarray = c18_typedarray + item*item;
+                });
+            assert.areEqual("1,900,9,16,25", c18_typedarray, "ToPrimitive: The forEach() returned incorrect result for TypedArray.");
+        }
+    },
+    {
+       name: "Array type conversion tests: copyWithin().",
+       body: function ()
+       {
+            var p21 = {
+                [Symbol.toPrimitive] (hint) {
+                    Object.defineProperty(a21, "0", {configurable : true, get: function(){ return 30;}});
+                    return -2;
+                }
+            };
+
+            var a21 = [1,2,3,4,5];
+            var c21 = a21.copyWithin(p21);
+            assert.areEqual([30,2,3,30,2], c21, "ToPrimitive: The copyWithin() method returned incorrect result as array type changed to ES5 array.");
+
+            //This test is failing due to following bug.
+            // 10747539: The CopyWithin array method implementation needs to do prototype lookup for property lookup (HasItem).
+            // var a21_proto = {};
+            // Object.defineProperty(a21_proto, "0", {
+            //       get: function(){
+            //             Object.defineProperty(a21_prototest, "1", {configurable : true, get: function(){ return 2;}});
+            //             return 30;
+            //       }
+            // });
+
+            // var a21_prototest = [,,3,4,5];
+            // a21_prototest.__proto__ = a21_proto;
+            // var c21_prototest = [].copyWithin.call(a21_prototest, -2);
+            // assert.areEqual("30,2,3,30,2", [].join.call(c21_prototest, ","), "ToPrimitive: The copyWithin() method returned incorrect result as array type changed to ES5Array in the property getter of the prototype.");
+
+            var p21_typedarray = {
+                [Symbol.toPrimitive] (hint) {
+                    Object.defineProperty(a21_typedarray, "0", {configurable : false, value:30 });
+                    return -2;
+                }
+            };
+
+            var a21_typedarray = new Int16Array([1,2,3,4,5]);
+            var c21_typedarray = a21_typedarray.copyWithin(p21_typedarray);
+            assert.areEqual([30,2,3,30,2], c21_typedarray, "ToPrimitive: The copyWithin() method returned incorrect result for TypedArray.");
+       }
     },
 ];
 


### PR DESCRIPTION
 Addresses 2 types of issues:
1. If side-effects while reading array method arguments change the array type to ES5Array we should process the array as an ES5Array would be.
2. If side-effects during executing callback function for methods such as map, filter etc. change the array type to ES5Array we should process the array as an ES5Array would be.