### PR TITLE
Fix inconsistency in F12 rundown/reparse after redeferral. 

### DIFF
--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -203,7 +203,7 @@ namespace Js
     // Given an offset into the source buffer, determine if the end of this SourceInfo
     // lies after the given offset.
     bool
-    FunctionBody::EndsAfter(size_t offset) const
+    ParseableFunctionInfo::EndsAfter(size_t offset) const
     {
         return offset < this->StartOffset() + this->LengthInBytes();
     }

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -1980,6 +1980,8 @@ namespace Js
         void SetReparsed(bool set) { m_reparsed = set; }
         bool GetExternalDisplaySourceName(BSTR* sourceName);
 
+        bool EndsAfter(size_t offset) const;
+
         void SetDoBackendArgumentsOptimization(bool set)
         {
             m_doBackendArgumentsOptimization = set;
@@ -2874,8 +2876,6 @@ namespace Js
         bool HasLineBreak(charcount_t start, charcount_t end) const;
 
         bool HasGeneratedFromByteCodeCache() const { return this->byteCodeCache != nullptr; }
-
-        bool EndsAfter(size_t offset) const;
 
         void TrackLoad(int ichMin);
 

--- a/lib/Runtime/Base/Utf8SourceInfo.cpp
+++ b/lib/Runtime/Base/Utf8SourceInfo.cpp
@@ -32,6 +32,7 @@ namespace Js
         m_lineOffsetCache(nullptr),
         m_deferredFunctionsDictionary(nullptr),
         m_deferredFunctionsInitialized(false),
+        topLevelFunctionInfoList(nullptr),
         debugModeSource(nullptr),
         debugModeSourceIsEmpty(false),
         debugModeSourceLength(0),
@@ -138,6 +139,31 @@ namespace Js
 
         functionBodyDictionary->Item(functionId, functionBody);
         functionBody->SetIsFuncRegistered(true);
+    }
+
+    void Utf8SourceInfo::AddTopLevelFunctionInfo(FunctionInfo * functionInfo, Recycler * recycler)
+    {
+        JsUtil::List<FunctionInfo *, Recycler> * list = EnsureTopLevelFunctionInfoList(recycler);
+        Assert(!list->Contains(functionInfo));
+        list->Add(functionInfo);
+    }
+
+    void Utf8SourceInfo::ClearTopLevelFunctionInfoList()
+    {
+        if (this->topLevelFunctionInfoList)
+        {
+            this->topLevelFunctionInfoList->Clear();
+        }
+    }
+
+    JsUtil::List<FunctionInfo *, Recycler> *
+    Utf8SourceInfo::EnsureTopLevelFunctionInfoList(Recycler * recycler)
+    {
+        if (this->topLevelFunctionInfoList == nullptr)
+        {
+            this->topLevelFunctionInfoList = JsUtil::List<FunctionInfo *, Recycler>::New(recycler);
+        }
+        return this->topLevelFunctionInfoList;
     }
 
     void Utf8SourceInfo::EnsureInitialized(int initialFunctionCount)

--- a/lib/Runtime/Base/Utf8SourceInfo.h
+++ b/lib/Runtime/Base/Utf8SourceInfo.h
@@ -130,6 +130,14 @@ namespace Js
         void SetFunctionBody(FunctionBody * functionBody);
         void RemoveFunctionBody(FunctionBody* functionBodyBeingRemoved);
 
+        void AddTopLevelFunctionInfo(Js::FunctionInfo * functionInfo, Recycler * recycler);
+        void ClearTopLevelFunctionInfoList();
+        JsUtil::List<Js::FunctionInfo *, Recycler> * EnsureTopLevelFunctionInfoList(Recycler * recycler);
+        JsUtil::List<Js::FunctionInfo *, Recycler> * GetTopLevelFunctionInfoList() const
+        {
+            return this->topLevelFunctionInfoList;
+        }
+
         // The following functions could get called even if EnsureInitialized hadn't gotten called
         // (Namely in the OOM scenario), so we simply guard against that condition rather than
         // asserting
@@ -376,6 +384,7 @@ namespace Js
 
         FunctionBodyDictionary* functionBodyDictionary;
         DeferredFunctionsDictionary* m_deferredFunctionsDictionary;
+        JsUtil::List<Js::FunctionInfo *, Recycler> *topLevelFunctionInfoList;
 
         DebugDocument* m_debugDocument;
 

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -775,6 +775,7 @@ void ByteCodeGenerator::SetRootFuncInfo(FuncInfo* func)
     }
 
     this->pRootFunc = func->byteCodeFunction->GetParseableFunctionInfo();
+    this->m_utf8SourceInfo->AddTopLevelFunctionInfo(func->byteCodeFunction->GetFunctionInfo(), scriptContext->GetRecycler());
 }
 
 Js::RegSlot ByteCodeGenerator::NextVarRegister()

--- a/lib/Runtime/ByteCode/ByteCodeSerializer.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeSerializer.cpp
@@ -3858,6 +3858,9 @@ public:
 
         (*function) = functionBody;
 
+        sourceInfo->ClearTopLevelFunctionInfoList();
+        sourceInfo->AddTopLevelFunctionInfo(functionBody->GetFunctionInfo(), this->scriptContext->GetRecycler());
+
 #if ENABLE_NATIVE_CODEGEN && defined(ENABLE_PREJIT)
         if (prejit)
         {

--- a/lib/Runtime/Debug/DebugContext.h
+++ b/lib/Runtime/Debug/DebugContext.h
@@ -67,9 +67,9 @@ namespace Js
         ProbeContainer* diagProbesContainer;
 
         // Private Functions
-        void FetchTopLevelFunction(JsUtil::List<Js::FunctionBody *, ArenaAllocator>* pFunctions, Js::Utf8SourceInfo * sourceInfo);
         void WalkAndAddUtf8SourceInfo(Js::Utf8SourceInfo* sourceInfo, JsUtil::List<Js::Utf8SourceInfo *, Recycler, false, Js::CopyRemovePolicy, RecyclerPointerComparer> *utf8SourceInfoList);
         bool CanRegisterFunction() const;
+        void RegisterFunction(Js::ParseableFunctionInfo * func, DWORD_PTR dwDebugSourceContext, LPCWSTR title);
         void RegisterFunction(Js::FunctionBody * functionBody, DWORD_PTR dwDebugSourceContext, LPCWSTR title);
 
         template<class TMapFunction>


### PR DESCRIPTION
F12 rundown/reparse counts on having function bodies stay around so that top-level functions can be discovered and reparsed. With the changes in redeferral, and making the function body dictionary into a LeafValueDictionary, function bodies can be discarded, so the functions that appear to be top-level at reparse time are missing information about enclosing scopes. Fix this by detecting top-level functions at byte code gen time and reparsing them even if they've been kicked out of the dictionary.