### PR TITLE
Fix lowering of BrOnNotEmpty

### DIFF
--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -9566,10 +9566,11 @@ Lowerer::GenerateFastBrBReturn(IR::Instr * instr)
     // CMP cacheData.completed, 0
     // JNE $loopEnd
     // JMP $helper
+    IR::LabelInstr * labelAfter = instr->GetOrCreateContinueLabel();
     InsertCompareBranch(
         IR::IndirOpnd::New(cachedDataOpnd, Js::DynamicObjectPropertyEnumerator::GetOffsetOfCachedDataCompleted(), TyInt8, this->m_func),
         IR::IntConstOpnd::New(0, TyInt8, this->m_func),
-        Js::OpCode::BrNeq_A, instr->AsBranchInstr()->GetTarget(), instr);
+        Js::OpCode::BrNeq_A, instr->m_opcode == Js::OpCode::BrOnNotEmpty ? labelAfter : instr->AsBranchInstr()->GetTarget(), instr);
     InsertBranch(Js::OpCode::Br, labelHelper, instr);
 
     // $loopBody:
@@ -9605,7 +9606,6 @@ Lowerer::GenerateFastBrBReturn(IR::Instr * instr)
         enumeratedCountOpnd, instr);
 
     // We know result propertyString (opndDst) != NULL
-    IR::LabelInstr * labelAfter = instr->GetOrCreateContinueLabel();
     InsertBranch(Js::OpCode::Br, instr->m_opcode == Js::OpCode::BrOnNotEmpty ? instr->AsBranchInstr()->GetTarget() : labelAfter, instr);
 
     // $helper


### PR DESCRIPTION
When we finish iterating the ForInCache in JIT'ed code and if the cache is completed, we can exit the loop.
We always generate BrOnEmpty in the byte code and it doesn't get inverted to BrOnNotEmpty usually.
But for BrOnNotEmpty, the target of the branch is the loop body instead of loop end.  We need to use the label after the instruction when the branch inversion happens.
