### PR TITLE
Remove default arguments from member definitions

### DIFF
--- a/lib/Common/Memory/PageAllocator.cpp
+++ b/lib/Common/Memory/PageAllocator.cpp
@@ -2493,7 +2493,7 @@ HeapPageAllocator<T>::ReleaseDecommittedSegment(__in SegmentBase<T>* segment)
 // decommit the page but don't release it
 template<typename T>
 void
-HeapPageAllocator<T>::DecommitPages(__in char* address, size_t pageCount = 1)
+HeapPageAllocator<T>::DecommitPages(__in char* address, size_t pageCount)
 {
     Assert(pageCount <= MAXUINT32);
 #pragma prefast(suppress:__WARNING_WIN32UNRELEASEDVADS, "The remainder of the clean-up is done later.");

--- a/lib/Parser/RegexParser.cpp
+++ b/lib/Parser/RegexParser.cpp
@@ -234,7 +234,7 @@ namespace UnifiedRegex
     // Helpers
     //
     template <typename P, const bool IsLiteral>
-    int Parser<P, IsLiteral>::TryParseExtendedUnicodeEscape(Char& c, bool& previousSurrogatePart, bool trackSurrogatePair = false)
+    int Parser<P, IsLiteral>::TryParseExtendedUnicodeEscape(Char& c, bool& previousSurrogatePart, bool trackSurrogatePair)
     {
         if (!scriptContext->GetConfig()->IsES6UnicodeExtensionsEnabled())
         {

--- a/lib/Runtime/Base/CrossSiteObject.h
+++ b/lib/Runtime/Base/CrossSiteObject.h
@@ -126,7 +126,7 @@ namespace Js
     }
 
     template <typename T>
-    BOOL CrossSiteObject<T>::SetPropertyWithAttributes(PropertyId propertyId, Var value, PropertyAttributes attributes, PropertyValueInfo* info, PropertyOperationFlags flags, SideEffects possibleSideEffects = SideEffects_Any)
+    BOOL CrossSiteObject<T>::SetPropertyWithAttributes(PropertyId propertyId, Var value, PropertyAttributes attributes, PropertyValueInfo* info, PropertyOperationFlags flags, SideEffects possibleSideEffects)
     {
         value = CrossSite::MarshalVar(this->GetScriptContext(), value);
         return __super::SetPropertyWithAttributes(propertyId, value, attributes, info, flags, possibleSideEffects);

--- a/lib/Runtime/Types/SimpleDictionaryTypeHandler.cpp
+++ b/lib/Runtime/Types/SimpleDictionaryTypeHandler.cpp
@@ -309,7 +309,7 @@ namespace Js
     }
 
     template <typename TPropertyIndex, typename TMapKey, bool IsNotExtensibleSupported>
-    SimpleDictionaryTypeHandlerBase<TPropertyIndex, TMapKey, IsNotExtensibleSupported>::SimpleDictionaryTypeHandlerBase(Recycler* recycler, int slotCapacity, int propertyCapacity, uint16 inlineSlotCapacity, uint16 offsetOfInlineSlots, bool isLocked = false, bool isShared = false) :
+    SimpleDictionaryTypeHandlerBase<TPropertyIndex, TMapKey, IsNotExtensibleSupported>::SimpleDictionaryTypeHandlerBase(Recycler* recycler, int slotCapacity, int propertyCapacity, uint16 inlineSlotCapacity, uint16 offsetOfInlineSlots, bool isLocked, bool isShared) :
         // Do not RoundUp passed in slotCapacity. This may be called by ConvertTypeHandler for an existing DynamicObject and should use the real existing slotCapacity.
         DynamicTypeHandler(slotCapacity, inlineSlotCapacity, offsetOfInlineSlots, DefaultFlags | (isLocked ? IsLockedFlag : 0) | (isShared ? (MayBecomeSharedFlag | IsSharedFlag) : 0)),
         nextPropertyIndex(0),


### PR DESCRIPTION
Default arguments are not permitted on out-of-line definitions of members
of class templates. They can only be used in the declaration in the class.

This is a pre-emptive fix for upcoming MSVC compiler changes that will
diagnose this code. The Clang build only allows these currently
because they are built with -fms-extensions -Wno-microsoft.