### PR TITLE
Add -v and --version flags to ch to print ChakraCore version.

### DIFF
--- a/bin/ch/ChakraRtInterface.cpp
+++ b/bin/ch/ChakraRtInterface.cpp
@@ -23,6 +23,11 @@ ChakraRTInterface::ArgInfo* ChakraRTInterface::m_argInfo = nullptr;
 TestHooks ChakraRTInterface::m_testHooks = { 0 };
 JsAPIHooks ChakraRTInterface::m_jsApiHooks = { 0 };
 
+LPCSTR GetChakraDllName()
+{
+    return chakraDllName;
+}
+
 // Wrapper functions to abstract out loading ChakraCore
 // and resolving its symbols
 // Currently, these functions resolve to the PAL on Linux

--- a/bin/ch/ChakraRtInterface.h
+++ b/bin/ch/ChakraRtInterface.h
@@ -188,6 +188,8 @@ struct JsAPIHooks
     JsrtTTDReplayExecutionPtr pfJsrtTTDReplayExecution;
 };
 
+LPCSTR GetChakraDllName();
+
 class ChakraRTInterface
 {
 public:

--- a/bin/ch/HostConfigFlags.cpp
+++ b/bin/ch/HostConfigFlags.cpp
@@ -78,7 +78,7 @@ void HostConfigFlags::PrintUsage()
         pfnPrintUsage();
     }
 
-    wprintf(_u("\nFlag List : \n"));
+    wprintf(_u("\nHost Config Flags: \n\n"));
     HostConfigFlags::PrintUsageString();
     ChakraRTInterface::PrintConfigFlagsUsageString();
 }

--- a/bin/ch/ch.cpp
+++ b/bin/ch/ch.cpp
@@ -65,17 +65,28 @@ int HostExceptionFilter(int exceptionCode, _EXCEPTION_POINTERS *ep)
 
 void __stdcall PrintUsageFormat()
 {
-    wprintf(_u("\nUsage: %s [flaglist] <source file>\n"), hostName);
+    wprintf(_u("\nUsage: %s [-v|-version] [-h|-help] [-?] [flaglist] <source file>\n"), hostName);
+    wprintf(_u("\t-v|-version\t\tDisplays version info\n"));
+    wprintf(_u("\t-h|-help\t\tDisplays this help message\n"));
+    wprintf(_u("\t-?\t\t\tDisplays this help message with complete [flaglist] info\n"));
 }
+
+#if !defined(ENABLE_DEBUG_CONFIG_OPTIONS)
+void __stdcall PrintReleaseUsage()
+{
+    wprintf(_u("\nUsage: %s [-v|-version] [-h|-help|-?] <source file> %s"), hostName,
+        _u("\nNote: [flaglist] is not supported in Release builds; try a Debug or Test build to enable these flags.\n"));
+    wprintf(_u("\t-v|-version\t\tDisplays version info\n"));
+    wprintf(_u("\t-h|-help|-?\t\tDisplays this help message\n"));
+}
+#endif
 
 void __stdcall PrintUsage()
 {
 #if !defined(ENABLE_DEBUG_CONFIG_OPTIONS)
-    wprintf(_u("\nUsage: %s <source file> %s"), hostName,
-            _u("\n[flaglist] is not supported for Release mode\n"));
+    PrintReleaseUsage();
 #else
     PrintUsageFormat();
-    wprintf(_u("Try '%s -?' for help\n"), hostName);
 #endif
 }
 
@@ -802,6 +813,18 @@ int _cdecl wmain(int argc, __in_ecount(argc) LPWSTR argv[])
             (arglen == 7 && wcsncmp(arg, _u("version"), arglen) == 0))
         {
             PrintVersion();
+            PAL_Shutdown();
+            return EXIT_SUCCESS;
+        }
+        else if (
+#if !defined(ENABLE_DEBUG_CONFIG_OPTIONS) // release builds can display some kind of help message
+            (arglen == 1 && wcsncmp(arg, _u("?"),    arglen) == 0) ||
+#endif
+            (arglen == 1 && wcsncmp(arg, _u("h"),    arglen) == 0) ||
+            (arglen == 4 && wcsncmp(arg, _u("help"), arglen) == 0)
+            )
+        {
+            PrintUsage();
             PAL_Shutdown();
             return EXIT_SUCCESS;
         }

--- a/bin/ch/ch.cpp
+++ b/bin/ch/ch.cpp
@@ -4,6 +4,7 @@
 //-------------------------------------------------------------------------------------------------------
 #include "stdafx.h"
 #include "Core/AtomLockGuids.h"
+#include <CommonPal.h>
 #ifdef _WIN32
 #include <process.h>
 #endif
@@ -775,8 +776,8 @@ int _cdecl wmain(int argc, __in_ecount(argc) LPWSTR argv[])
     int cpos = 1;
     for(int i = 1; i < argc; ++i)
     {
-        wchar *arg = argv[i];
-        size_t arglen = wcsnlen(arg, 2); // just look for prefixes for now
+        const wchar *arg = argv[i];
+        size_t arglen = wcslen(arg);
 
         // support - or / prefix for flags
         if (arglen >= 1 && (arg[0] == _u('-')
@@ -796,9 +797,9 @@ int _cdecl wmain(int argc, __in_ecount(argc) LPWSTR argv[])
             }
         }
 
-        arglen = wcsnlen(arg, 8); // ensure that we get the entirety of "version" so we don't match e.g. "versions"
-        if (arglen == 1 && wcsncmp(arg, _u("v"), arglen) == 0 ||
-            arglen == 7 && wcsncmp(arg, _u("version"), arglen) == 0)
+        arglen = wcslen(arg); // get length of flag after prefix
+        if ((arglen == 1 && wcsncmp(arg, _u("v"),       arglen) == 0) ||
+            (arglen == 7 && wcsncmp(arg, _u("version"), arglen) == 0))
         {
             PrintVersion();
             PAL_Shutdown();

--- a/bin/ch/ch.vcxproj
+++ b/bin/ch/ch.vcxproj
@@ -37,6 +37,7 @@
         ole32.lib;
         kernel32.lib;
         Rpcrt4.lib;
+        version.lib;
       </AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>


### PR DESCRIPTION
Partially addresses #109 and #2472.

This is intended as a first pass at the issue to provide some information at this point.

Later, we plan to add more information such as whether a binary was produced as a developer build or an official build, what specific commit the binary was built from, which branch, which machine, etc. The specific set of information that we plan to provide is still being discussed in #109.

```
ch /v
ch /version
ch -v
ch --v
ch -version
ch --version
```

(Supporting `-` and `--` prefixes for short and long flag names is consistent with how we process all behaviors. The logic I used here is a replica of that in `CmdLineArgsParser::Parse`.)

The above all display the version information for `ch` and `ChakraCore` as `<major>.<minor>.<patch>.<QFE>` (note: by convention, ChakraCore's `QFE` is always `0`).

For example on Windows for ChakraCore 1.4.1 with `ch.exe` and `ChakraCore.dll` from the same build:

```
$ ch -v
ch.exe version 1.4.1.0
chakracore.dll version 1.4.1.0
```

If with the same `ch.exe`, if `ChakraCore.dll` was from, e.g., a 2.0.0 build:

```
$ ch -v
ch.exe version 1.4.1.0
chakracore.dll version 2.0.0.0
```

On Linux:

```
~/dev/ChakraCore$ ./BuildLinux/Release/ch -v
ch version 1.4.1.0
```

This flag is available in all flavors (including Release).

---

Updating the help message. Also enable `-h` and `-help` as per request in #2472.

Enables `-h` and `-help` for non-release builds, and `-?`, `-h`, and `-help` for release builds.

Messages will look as follows.

debug/test builds:

```
Usage: ch.exe [-v|-version] [-h|-help] [-?] [flaglist] <source file>
        -v|-version             Displays version info
        -h|-help                Displays this help message
        -?                      Displays this help message with complete [flaglist] info
```

release builds:

```
Usage: ch.exe [-v|-version] [-h|-help|-?] <source file>
Note: [flaglist] is not supported in Release builds; try a Debug or Test build to enable these flags.
        -v|-version             Displays version info
        -h|-help|-?             Displays this help message
```

The distinction is that `-?` is already implemented in debug/test builds to display full information about the `[flaglist]` options. This is a minimal change here that will result in guiding the user more accurately in all build flavors, the effect of which is that `-?` in debug/test builds is still the only way to get information about the `[flaglist]` options.