### PR TITLE
Adding func addr range cache on script context for IsNativeAddr (WER case)

### DIFF
--- a/lib/Backend/NativeCodeGenerator.cpp
+++ b/lib/Backend/NativeCodeGenerator.cpp
@@ -96,6 +96,11 @@ NativeCodeGenerator::~NativeCodeGenerator()
     }
 #endif
 
+    if (scriptContext->GetJitFuncRangeCache() != nullptr)
+    {
+        scriptContext->GetJitFuncRangeCache()->ClearCache();
+    }
+
     if(this->foregroundAllocators != nullptr)
     {
         HeapDelete(this->foregroundAllocators);
@@ -909,6 +914,11 @@ NativeCodeGenerator::CodeGen(PageAllocator * pageAllocator, CodeGenWorkItem* wor
             hr = E_ABORT;
         }
         JITManager::HandleServerCallResult(hr, RemoteCallType::CodeGen);
+
+        if (!PreReservedVirtualAllocWrapper::IsInRange((void*)this->scriptContext->GetThreadContext()->GetPreReservedRegionAddr(), (void*)jitWriteData.codeAddress))
+        {
+            this->scriptContext->GetJitFuncRangeCache()->AddFuncRange((void*)jitWriteData.codeAddress, jitWriteData.codeSize);
+        }
     }
     else
     {
@@ -943,7 +953,13 @@ NativeCodeGenerator::CodeGen(PageAllocator * pageAllocator, CodeGenWorkItem* wor
             pNumberAllocator, 
 #endif
             codeGenProfiler, !foreground);
+        
+        if (!this->scriptContext->GetThreadContext()->GetPreReservedVirtualAllocator()->IsInRange((void*)jitWriteData.codeAddress))
+        {
+            this->scriptContext->GetJitFuncRangeCache()->AddFuncRange((void*)jitWriteData.codeAddress, jitWriteData.codeSize);
+        }
     }
+    
     if (JITManager::GetJITManager()->IsOOPJITEnabled() && PHASE_VERBOSE_TRACE(Js::BackEndPhase, workItem->GetFunctionBody()))
     {
         LARGE_INTEGER freq;
@@ -3176,6 +3192,12 @@ NativeCodeGenerator::QueueFreeNativeCodeGenAllocation(void* address)
     {
         //DeRegister Entry Point for CFG
         ThreadContext::GetContextForCurrentThread()->SetValidCallTargetForCFG(address, false);
+    }
+    
+    if ((!JITManager::GetJITManager()->IsOOPJITEnabled() && !this->scriptContext->GetThreadContext()->GetPreReservedVirtualAllocator()->IsInRange((void*)address)) ||
+        (JITManager::GetJITManager()->IsOOPJITEnabled() && !PreReservedVirtualAllocWrapper::IsInRange((void*)this->scriptContext->GetThreadContext()->GetPreReservedRegionAddr(), (void*)address)))
+    {
+        this->scriptContext->GetJitFuncRangeCache()->RemoveFuncRange((void*)address);
     }
 
     // The foreground allocators may have been used

--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -377,6 +377,36 @@ namespace Js
         BuiltInLibraryFunctionMap* builtInLibraryFunctions;
     };
 
+    /*
+    * This class caches jitted func address ranges.
+    * This is to facilitate WER scenarios to use this cache for checking native addresses.
+    */
+    class JITPageAddrToFuncRangeCache
+    {
+    private:
+        typedef JsUtil::BaseDictionary<void *, uint, HeapAllocator> RangeMap;
+        typedef JsUtil::BaseDictionary<void *, RangeMap*, HeapAllocator> JITPageAddrToFuncRangeMap;
+        typedef JsUtil::BaseDictionary<void *, uint, HeapAllocator> LargeJITFuncAddrToSizeMap;
+
+        JITPageAddrToFuncRangeMap * jitPageAddrToFuncRangeMap;
+        LargeJITFuncAddrToSizeMap * largeJitFuncToSizeMap;
+
+        static CriticalSection cs;
+
+    public:
+        JITPageAddrToFuncRangeCache() :jitPageAddrToFuncRangeMap(nullptr), largeJitFuncToSizeMap(nullptr) {}
+        ~JITPageAddrToFuncRangeCache()
+        {
+            ClearCache();
+        }
+        void ClearCache();
+        void AddFuncRange(void * address, uint bytes);
+        void RemoveFuncRange(void * address);
+        void * GetPageAddr(void * address);
+        bool IsNativeAddr(void * address);
+        static CriticalSection * GetCriticalSection() { return &cs; }
+    };
+
     class ScriptContext : public ScriptContextBase, public ScriptContextInfo
     {
         friend class LowererMD;
@@ -389,6 +419,9 @@ namespace Js
         static DWORD GetOptimizationOverridesOffset() { return offsetof(ScriptContext, optimizationOverrides); }
         static DWORD GetRecyclerOffset() { return offsetof(ScriptContext, recycler); }
         static DWORD GetNumberAllocatorOffset() { return offsetof(ScriptContext, numberAllocator); }
+
+        JITPageAddrToFuncRangeCache * GetJitFuncRangeCache();
+        JITPageAddrToFuncRangeCache * jitFuncRangeCache;
 
         ScriptContext *next;
         ScriptContext *prev;

--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -4079,7 +4079,7 @@ void DumpRecyclerObjectGraph()
 #endif
 
 #if ENABLE_NATIVE_CODEGEN
-BOOL ThreadContext::IsNativeAddress(void * pCodeAddr)
+BOOL ThreadContext::IsNativeAddress(void * pCodeAddr, Js::ScriptContext* currentScriptContext)
 {
 #if ENABLE_OOP_NATIVE_CODEGEN
     if (JITManager::GetJITManager()->IsOOPJITEnabled())
@@ -4097,10 +4097,31 @@ BOOL ThreadContext::IsNativeAddress(void * pCodeAddr)
             return false;
         }
 
+#if DBG
         boolean result;
         HRESULT hr = JITManager::GetJITManager()->IsNativeAddr(this->m_remoteThreadContextInfo, (intptr_t)pCodeAddr, &result);
         JITManager::HandleServerCallResult(hr, RemoteCallType::HeapQuery);
-        return result;
+#endif
+
+        bool isNativeAddr = false;
+        if (currentScriptContext && currentScriptContext->GetJitFuncRangeCache() != nullptr)
+        {
+            isNativeAddr = currentScriptContext->GetJitFuncRangeCache()->IsNativeAddr(pCodeAddr);
+        }
+
+        for (Js::ScriptContext *scriptContext = scriptContextList; scriptContext && !isNativeAddr; scriptContext = scriptContext->next)
+        {
+            if (scriptContext->GetJitFuncRangeCache() == nullptr || scriptContext == currentScriptContext)
+            {
+                continue;
+            }
+            isNativeAddr = scriptContext->GetJitFuncRangeCache()->IsNativeAddr(pCodeAddr);
+        }
+
+#if DBG
+        Assert(result == (isNativeAddr? 1:0));
+#endif
+        return isNativeAddr;
     }
     else
 #endif
@@ -4113,8 +4134,24 @@ BOOL ThreadContext::IsNativeAddress(void * pCodeAddr)
 
         if (!this->IsAllJITCodeInPreReservedRegion())
         {
+#if DBG
             AutoCriticalSection autoLock(&this->codePageAllocators.cs);
-            return this->codePageAllocators.IsInNonPreReservedPageAllocator(pCodeAddr);
+#endif
+            
+            bool isNativeAddr = false;
+            for (Js::ScriptContext *scriptContext = scriptContextList; scriptContext && !isNativeAddr; scriptContext = scriptContext->next)
+            {
+                if (scriptContext->GetJitFuncRangeCache() == nullptr)
+                {
+                    continue;
+                }
+                isNativeAddr = scriptContext->GetJitFuncRangeCache()->IsNativeAddr(pCodeAddr);
+            }
+
+#if DBG
+            Assert(this->codePageAllocators.IsInNonPreReservedPageAllocator(pCodeAddr) == isNativeAddr);
+#endif
+            return isNativeAddr;
         }
         return FALSE;
     }

--- a/lib/Runtime/Base/ThreadContext.h
+++ b/lib/Runtime/Base/ThreadContext.h
@@ -489,6 +489,10 @@ private:
     BVSparse<HeapAllocator> * m_jitNumericProperties;
     bool m_jitNeedsPropertyUpdate;
 public:
+    intptr_t GetPreReservedRegionAddr()
+    {
+        return m_prereservedRegionAddr;
+    }
     BVSparse<HeapAllocator> * GetJITNumericProperties() const
     {
         return m_jitNumericProperties;
@@ -515,6 +519,7 @@ public:
 private:
     typedef JsUtil::BaseDictionary<uint, Js::SourceDynamicProfileManager*, Recycler, PowerOf2SizePolicy> SourceDynamicProfileManagerMap;
     typedef JsUtil::BaseDictionary<const char16*, const Js::PropertyRecord*, Recycler, PowerOf2SizePolicy> SymbolRegistrationMap;
+
 
     class SourceDynamicProfileManagerCache
     {
@@ -1179,7 +1184,7 @@ public:
     void RegisterCodeGenRecyclableData(Js::CodeGenRecyclableData *const codeGenRecyclableData);
     void UnregisterCodeGenRecyclableData(Js::CodeGenRecyclableData *const codeGenRecyclableData);
 #if ENABLE_NATIVE_CODEGEN
-    BOOL IsNativeAddress(void * pCodeAddr);
+    BOOL IsNativeAddress(void * pCodeAddr, Js::ScriptContext* currentScriptContext = nullptr);
     JsUtil::JobProcessor *GetJobProcessor();
     Js::Var * GetBailOutRegisterSaveSpace() const { return bailOutRegisterSaveSpace; }
     virtual intptr_t GetBailOutRegisterSaveSpaceAddr() const override { return (intptr_t)bailOutRegisterSaveSpace; }

--- a/lib/Runtime/Language/AsmJsCodeGenerator.cpp
+++ b/lib/Runtime/Language/AsmJsCodeGenerator.cpp
@@ -37,6 +37,11 @@ namespace Js
 #if ENABLE_DEBUG_CONFIG_OPTIONS
             funcEntrypointInfo->SetIsTJMode(true);
 #endif
+            if (!PreReservedVirtualAllocWrapper::IsInRange((void*)mScriptContext->GetThreadContext()->GetPreReservedRegionAddr(), (void*)address))
+            {
+                Assert(entrypointInfo->GetCodeSize() < (uint64)((uint64)1 << 32));
+                mScriptContext->GetJitFuncRangeCache()->AddFuncRange((void*)address, (uint)entrypointInfo->GetCodeSize());
+            }
         }
     }
 


### PR DESCRIPTION
- This is to enable WER scenario to perform IsNativeAddress check with OOPjit case.
- IsNativeAddress in DAC wasn't handling OOPjit case correctly today. 

Fix:
- Since we will not be able to make RPC call during WER, we cache the func ranges on the script context and check this cache during IsNativeAddress.

Pending:
- IE Perf lab for memory regression
- Unit tests