### PR TITLE
Don't throw RangeError for toExponential(undefined)

### DIFF
--- a/lib/Runtime/Library/JavascriptNumber.cpp
+++ b/lib/Runtime/Library/JavascriptNumber.cpp
@@ -585,6 +585,7 @@ namespace Js
         {
             //use the first arg as the fraction digits, ignore the rest.
             Var aFractionDigits = args[1];
+            bool noRangeCheck = false;
 
             // shortcut for tagged int's
             if(TaggedInt::Is(aFractionDigits))
@@ -592,12 +593,15 @@ namespace Js
                 fractionDigits = TaggedInt::ToInt32(aFractionDigits);
             }
             else if(JavascriptOperators::GetTypeId(aFractionDigits) == TypeIds_Undefined)
-                ; // fraction digits = -1
+            {
+                // fraction undefined -> digits = -1, output as many fractional digits as we can
+                noRangeCheck = true;
+            }
             else
             {
                 fractionDigits = (int)JavascriptConversion::ToInteger(aFractionDigits, scriptContext);
             }
-            if( fractionDigits < 0 || fractionDigits >20 )
+            if(!noRangeCheck && (fractionDigits < 0 || fractionDigits >20))
             {
                 JavascriptError::ThrowRangeError(scriptContext, JSERR_FractionOutOfRange);
             }

--- a/test/Number/toString.js
+++ b/test/Number/toString.js
@@ -31,6 +31,7 @@ function runTest(numberToTestAsString)
     safeCall(function () { n.toFixed(21); });
 
     writeLine("n.toExponential():  " + n.toExponential());
+    writeLine("n.toExponential(undefined):  " + n.toExponential(undefined));
     writeLine("n.toExponential(2):  " + n.toExponential(2));
     writeLine("n.toExponential(5):  " + n.toExponential(5));
 

--- a/test/Number/toString_3.baseline
+++ b/test/Number/toString_3.baseline
@@ -13,6 +13,7 @@ n.toFixed(20):  444123.00000000000000000000
 RangeError: The number of fractional digits is out of range
 RangeError: The number of fractional digits is out of range
 n.toExponential():  4.44123e+5
+n.toExponential(undefined):  4.44123e+5
 n.toExponential(2):  4.44e+5
 n.toExponential(5):  4.44123e+5
 n.toPrecision():  444123
@@ -35,6 +36,7 @@ n.toFixed(20):  -444123.00000000000000000000
 RangeError: The number of fractional digits is out of range
 RangeError: The number of fractional digits is out of range
 n.toExponential():  -4.44123e+5
+n.toExponential(undefined):  -4.44123e+5
 n.toExponential(2):  -4.44e+5
 n.toExponential(5):  -4.44123e+5
 n.toPrecision():  -444123
@@ -57,6 +59,7 @@ n.toFixed(20):  444123.78912345680000000000
 RangeError: The number of fractional digits is out of range
 RangeError: The number of fractional digits is out of range
 n.toExponential():  4.441237891234568e+5
+n.toExponential(undefined):  4.441237891234568e+5
 n.toExponential(2):  4.44e+5
 n.toExponential(5):  4.44124e+5
 n.toPrecision():  444123.7891234568
@@ -79,6 +82,7 @@ n.toFixed(20):  -444123.78963636360000000000
 RangeError: The number of fractional digits is out of range
 RangeError: The number of fractional digits is out of range
 n.toExponential():  -4.441237896363636e+5
+n.toExponential(undefined):  -4.441237896363636e+5
 n.toExponential(2):  -4.44e+5
 n.toExponential(5):  -4.44124e+5
 n.toPrecision():  -444123.7896363636
@@ -101,6 +105,7 @@ n.toFixed(20):  0.00000000000000000000
 RangeError: The number of fractional digits is out of range
 RangeError: The number of fractional digits is out of range
 n.toExponential():  0e+0
+n.toExponential(undefined):  0e+0
 n.toExponential(2):  0.00e+0
 n.toExponential(5):  0.00000e+0
 n.toPrecision():  0
@@ -123,6 +128,7 @@ n.toFixed(20):  1e+21
 RangeError: The number of fractional digits is out of range
 RangeError: The number of fractional digits is out of range
 n.toExponential():  1e+21
+n.toExponential(undefined):  1e+21
 n.toExponential(2):  1.00e+21
 n.toExponential(5):  1.00000e+21
 n.toPrecision():  1e+21


### PR DESCRIPTION
RangeError was raised for `Number.prototype.toExponential(undefined)` unexpectedly after refactoring range check (fraction should be between 1 to 20) out of else statement which converts non-integer and not undefined fractionDigits to integer. The spec also doesn't imply range error for it (see below link).

http://www.ecma-international.org/ecma-262/6.0/#sec-number.prototype.toexponential