### PR TITLE
Fix for assertion fired in JSON.stringify.

### DIFF
--- a/lib/Parser/rterrors.h
+++ b/lib/Parser/rterrors.h
@@ -386,3 +386,4 @@ RT_ERROR_MSG(WASMERR_TableIndexOutOfRange, 7016, "", "Table index is out of rang
 RT_ERROR_MSG(WASMERR_ArrayIndexOutOfRange, 7017, "", "Memory index is out of range", kjstWebAssemblyRuntimeError, 0)
 RT_ERROR_MSG(WASMERR_InvalidInstantiateArgument, 7018, "", "Invalid arguments to instantiate", kjstTypeError, 0)
 RT_ERROR_MSG(WASMERR_WasmLinkError, 7019, "%s", "Linking failed.", kjstWebAssemblyLinkError, 0)
+RT_ERROR_MSG(JSERR_OutOfBoundString, 7020, "", "String length is out of bound", kjstRangeError, 0)

--- a/lib/Runtime/Library/JSON.cpp
+++ b/lib/Runtime/Library/JSON.cpp
@@ -774,10 +774,13 @@ namespace JSON
         }
         else
         {
-            // we are some kind of array (including proxy to array and es5array). in all cases the length should have been 32bit and we
-            // shouldn't have overflow here.
-            length = (uint32)Js::JavascriptConversion::ToLength(Js::JavascriptOperators::OP_GetLength(value, scriptContext), scriptContext);
-            Assert(Js::JavascriptConversion::ToLength(Js::JavascriptOperators::OP_GetLength(value, scriptContext), scriptContext) == length);
+            int64 len = Js::JavascriptConversion::ToLength(Js::JavascriptOperators::OP_GetLength(value, scriptContext), scriptContext);
+            if (MaxCharCount <= len)
+            {
+                // If the length goes more than MaxCharCount we will eventually fail (as OOM) in ConcatStringBuilder - so failing early.
+                JavascriptError::ThrowRangeError(scriptContext, JSERR_OutOfBoundString);
+            }
+            length = (uint32)len;
         }
 
         Js::JavascriptString* result;

--- a/test/Bugs/json_bugs.js
+++ b/test/Bugs/json_bugs.js
@@ -1,0 +1,41 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+
+var tests = [
+  {
+    name: "JSON.stringify on proxy object with different length",
+    body: function () {
+        var i = 0;
+        var ret = JSON.stringify(new Proxy([], {
+            get(t, pk, r){
+                if (pk === "length") {
+                    return ++i;
+                }
+                return Reflect.get(t, pk, r);
+            }
+        }));
+        assert.areEqual("[null]", ret, "JSON.stringify will work on the array with the length 1");
+        assert.areEqual(1, i, 'proxy.get with property "length" will be called only once');
+    }
+  },
+  {
+    name: "JSON.stringify on proxy object with length > 2**31",
+    body: function () {
+        assert.throws(() =>
+        JSON.stringify(new Proxy([], {
+            get(t, pk, r){
+                if (pk === "length") {
+                    return 2**31 + 1;
+                }
+                return Reflect.get(t, pk, r);
+            }
+        })), RangeError, "JSON.stringify will throw range error when needs to allocate string more that 2**31", "String length is out of bound");
+    }
+  },
+];
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -363,6 +363,12 @@
   </test>
   <test>
     <default>
+      <files>json_bugs.js</files>
+      <compile-flags>-args summary -endargs</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>InlineFunctionParameterWithInfiniteLoop.js</files>
       <compile-flags>-maxinterpretcount:1 -off:simplejit</compile-flags>
     </default>


### PR DESCRIPTION
We called the GetLength twice assuming that the length will not change. However with proxy you can give different length both time and that will causes an assert. No fre impact so just removed the assert. While testing I found that we can pass more that 2^32 and that will cause the overflow in the length. However the CompoundString cannot handle more than MaxCharLength (INT_MAX-1) and it will eventually OOM. Instead of waiting till that point I am raising the RangeError.
