### PR TITLE
ES6 constructor returns class instead of object while switching F12 on or off

### DIFF
--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -4880,7 +4880,7 @@ namespace Js
         this->GetUtf8SourceInfo()->DeleteLineOffsetCache();
 
         // Reset to default.
-        this->flags = Flags_HasNoExplicitReturnValue;
+        this->flags = this->IsClassConstructor() ? Flags_None : Flags_HasNoExplicitReturnValue;
 
         ResetInParams();
 


### PR DESCRIPTION
This is related to https://github.com/Microsoft/ChakraCore/pull/1577 Fix by clearing out Flags_HasNoExplicitReturnValue for ES6 class constructors during FunctionBody clean-up before reparsing.