### PR TITLE
fix master build break - VSO

### DIFF
--- a/lib/Common/CommonDefines.h
+++ b/lib/Common/CommonDefines.h
@@ -765,9 +765,3 @@
     #endif
 #endif // __APPLE__
 #endif // THREAD_LOCAL
-
-#ifndef _WIN32
-#define NO_EXPORT __attribute__((visibility("hidden")))
-#else
-#define NO_EXPORT
-#endif

--- a/lib/Common/Memory/Allocator.h
+++ b/lib/Common/Memory/Allocator.h
@@ -351,7 +351,6 @@ public:
     void (*recoverMemoryFunc)();
 };
 
-
 template <typename T>
 void AssertValue(void * mem, T value, uint byteCount)
 {
@@ -365,12 +364,20 @@ void AssertValue(void * mem, T value, uint byteCount)
 }
 }
 
+#ifndef _WIN32
+#define NO_EXPORT(x) \
+    __attribute__((visibility("hidden"))) \
+    x
+#else
+#define NO_EXPORT(x) x
+#endif
+
 // For the debugger extension, we don't need the placement news
 #ifndef __PLACEMENT_NEW_INLINE
 #define __PLACEMENT_NEW_INLINE
 
-NO_EXPORT _Ret_notnull_
-inline void * __cdecl
+_Ret_notnull_
+NO_EXPORT(inline void *) __cdecl
 operator new(
 DECLSPEC_GUARD_OVERFLOW size_t byteSize,
 _In_ void * previousAllocation) throw()
@@ -379,7 +386,7 @@ _In_ void * previousAllocation) throw()
 }
 
 
-NO_EXPORT inline void __cdecl
+NO_EXPORT(inline void) __cdecl
 operator delete(
 void * allocationToFree,                // Allocation to free
 void * previousAllocation               // Previously allocated memory
@@ -394,7 +401,8 @@ void * previousAllocation               // Previously allocated memory
 // throwing operator new overrides
 //----------------------------------------
 template <typename TAllocator>
-NO_EXPORT _Ret_notnull_ void * __cdecl
+_Ret_notnull_
+NO_EXPORT(void *) __cdecl
 operator new(DECLSPEC_GUARD_OVERFLOW size_t byteSize, TAllocator * alloc, char * (TAllocator::*AllocFunc)(size_t))
 {
     AssertCanHandleOutOfMemory();
@@ -405,7 +413,8 @@ operator new(DECLSPEC_GUARD_OVERFLOW size_t byteSize, TAllocator * alloc, char *
 }
 
 template <typename TAllocator>
-NO_EXPORT _Ret_notnull_ inline void * __cdecl
+_Ret_notnull_
+NO_EXPORT(inline void *) __cdecl
 operator new[](DECLSPEC_GUARD_OVERFLOW size_t byteSize, TAllocator * alloc, char * (TAllocator::*AllocFunc)(size_t))
 {
     AssertCanHandleOutOfMemory();
@@ -416,7 +425,8 @@ operator new[](DECLSPEC_GUARD_OVERFLOW size_t byteSize, TAllocator * alloc, char
 }
 
 template <typename TAllocator>
-NO_EXPORT _Ret_notnull_ inline void * __cdecl
+_Ret_notnull_
+NO_EXPORT(inline void *) __cdecl
 operator new(DECLSPEC_GUARD_OVERFLOW size_t byteSize, TAllocator * alloc, char * (TAllocator::*AllocFunc)(size_t), DECLSPEC_GUARD_OVERFLOW size_t plusSize)
 {
     AssertCanHandleOutOfMemory();
@@ -433,7 +443,8 @@ operator new(DECLSPEC_GUARD_OVERFLOW size_t byteSize, TAllocator * alloc, char *
 // nothrow operator new overrides
 //----------------------------------------
 template <typename TAllocator>
-NO_EXPORT _Ret_maybenull_ inline void * __cdecl
+_Ret_maybenull_
+NO_EXPORT(inline void *) __cdecl
 operator new(DECLSPEC_GUARD_OVERFLOW size_t byteSize, TAllocator * alloc, bool nothrow, char * (TAllocator::*AllocFunc)(size_t))
 {
     Assert(nothrow);
@@ -442,9 +453,9 @@ operator new(DECLSPEC_GUARD_OVERFLOW size_t byteSize, TAllocator * alloc, bool n
     return buffer;
 }
 
-
 template <typename TAllocator>
-NO_EXPORT _Ret_maybenull_ inline void * __cdecl
+_Ret_maybenull_
+NO_EXPORT(inline void *) __cdecl
 operator new[](DECLSPEC_GUARD_OVERFLOW size_t byteSize, TAllocator * alloc, bool nothrow, char * (TAllocator::*AllocFunc)(size_t))
 {
     Assert(nothrow);
@@ -453,9 +464,9 @@ operator new[](DECLSPEC_GUARD_OVERFLOW size_t byteSize, TAllocator * alloc, bool
     return buffer;
 }
 
-
 template <typename TAllocator>
-NO_EXPORT _Ret_maybenull_ inline void * __cdecl
+_Ret_maybenull_
+NO_EXPORT(inline void *) __cdecl
 operator new(DECLSPEC_GUARD_OVERFLOW size_t byteSize, TAllocator * alloc, bool nothrow, char * (TAllocator::*AllocFunc)(size_t), DECLSPEC_GUARD_OVERFLOW size_t plusSize)
 {
     Assert(nothrow);
@@ -467,9 +478,9 @@ operator new(DECLSPEC_GUARD_OVERFLOW size_t byteSize, TAllocator * alloc, bool n
     return buffer;
 }
 
-
 template <typename TAllocator>
-NO_EXPORT _Ret_maybenull_ inline void * __cdecl
+_Ret_maybenull_
+NO_EXPORT(inline void *) __cdecl
 operator new(DECLSPEC_GUARD_OVERFLOW size_t byteSize, TAllocator * alloc, bool nothrow, char * (TAllocator::*AllocFunc)(size_t), DECLSPEC_GUARD_OVERFLOW size_t plusSize, bool prefix)
 {
     Assert(nothrow);


### PR DESCRIPTION
One particular project has dependency to Allocator.h hence pulled the definitions into Allocator. Also updated the NO_EXPORT shape a bit in order to match with old and new compilers we have. 