### PR TITLE
Eliminate noisy assert involving thread-safe counters. 

### DIFF
--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -885,6 +885,9 @@ namespace Js
 
             // TODO: Get size of polymorphic caches, jitted code, etc.
         }
+
+        // We can't get here if the function is being jitted. Jitting was either completed or not begun.
+        this->counters.bgThreadCallStarted = false;
 #endif
 
         PHASE_PRINT_TRACE(Js::RedeferralPhase, this, _u("Redeferring function %d.%d: %s\n"), 


### PR DESCRIPTION
When we redefer, reset the flag indicating that a background thread may access the counters, as we can't be redeferring if we're jitting, and jitting from a redeferred state is impossible.