### PR TITLE
Add missing StSlot for non-temp registers for JITLoopBody

### DIFF
--- a/lib/Backend/IRBuilder.cpp
+++ b/lib/Backend/IRBuilder.cpp
@@ -670,7 +670,7 @@ IRBuilder::Build()
     JsUtil::BaseDictionary<IR::Instr*, int, JitArenaAllocator> ignoreExBranchInstrToOffsetMap(m_tempAlloc);
 
     Js::LayoutSize layoutSize;
-    IR::Instr* lastProcessedInstrForJITLoopBody = nullptr;
+    IR::Instr* lastProcessedInstrForJITLoopBody = m_func->m_headInstr;
     for (Js::OpCode newOpcode = m_jnReader.ReadOp(layoutSize); (uint)m_jnReader.GetCurrentOffset() <= lastOffset; newOpcode = m_jnReader.ReadOp(layoutSize))
     {
         Assert(newOpcode != Js::OpCode::EndOfBlock);
@@ -760,7 +760,7 @@ IRBuilder::Build()
                 instr,
                 instrPrev,
                 m_lastInstr,
-                lastProcessedInstrForJITLoopBody ? lastProcessedInstrForJITLoopBody->m_next : m_lastInstr)
+                lastProcessedInstrForJITLoopBody->m_next)
             {
                 if (instr->GetDst() && instr->GetDst()->IsRegOpnd() && instr->GetDst()->GetStackSym()->HasByteCodeRegSlot())
                 {

--- a/lib/Backend/IRBuilder.cpp
+++ b/lib/Backend/IRBuilder.cpp
@@ -755,7 +755,7 @@ IRBuilder::Build()
         if (IsLoopBodyInTry() && lastProcessedInstrForJITLoopBody != m_lastInstr)
         {
             // traverse in backward so we get new/later value of given symId for storing instead of the earlier/stale
-            // symId value. m_stStores is used to prevent multiple stores to the same symId.
+            // symId value. m_stSlots is used to prevent multiple stores to the same symId.
             FOREACH_INSTR_BACKWARD_EDITING_IN_RANGE(
                 instr,
                 instrPrev,

--- a/lib/Backend/IRBuilder.cpp
+++ b/lib/Backend/IRBuilder.cpp
@@ -754,6 +754,8 @@ IRBuilder::Build()
 
         if (IsLoopBodyInTry() && lastProcessedInstrForJITLoopBody != m_lastInstr)
         {
+            // traverse in backward so we get new/later value of given symId for storing instead of the earlier/stale
+            // symId value. m_stStores is used to prevent multiple stores to the same symId.
             FOREACH_INSTR_BACKWARD_EDITING_IN_RANGE(
                 instr,
                 instrPrev,

--- a/test/Bugs/MissToGenerateStStSlotForJITLoopBody.js
+++ b/test/Bugs/MissToGenerateStStSlotForJITLoopBody.js
@@ -1,0 +1,20 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function test0(i)
+{
+    try{
+        for (var j = 0; j < 20010; j++) {
+            if (j > 20000)
+                return 'j ' + i + ' j in the loop ' + i;
+            else if (j > 30000)
+                return ' test0 ' + j;
+        }
+    } catch(e){}
+}
+
+var ret = test0() + ' test StSlot generation';
+
+print('pass');

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -380,4 +380,10 @@
       <compile-flags>-maxinterpretcount:1 -off:simplejit</compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>MissToGenerateStStSlotForJITLoopBody.js</files>
+      <compile-flags>-mic:1 -off:simplejit -oopjit- -bgjit-</compile-flags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
In JITLoopBody, we gnerate StSlot for the last instruction we imported from given bytecode instruction. This works fine when one bytecode instruction is mapped to one IR instruction. But in some cases, one bytecode instruction (`NewConcatStrMulti`) could be converted to multiple IR instructions (`Conv_primStr/NewConcatStrMulti/SetConcatStrMultiItem`), then we only check the very last IR instruction to generate StSlot and miss it for previous instructions.

This fix keeps the last processed IR instruction and processes all the IR instructions after that in backward order.