### PR TITLE
Fix byte code gen for function-in-block in eval.

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -3834,11 +3834,13 @@ void ByteCodeGenerator::StartEmitFunction(ParseNode *pnodeFnc)
 
     FuncInfo *funcInfo = pnodeFnc->sxFnc.funcInfo;
 
-    if (funcInfo->byteCodeFunction->IsFunctionParsed() &&
-        !(flags & (fscrEval | fscrImplicitThis | fscrImplicitParents)))
+    if (funcInfo->byteCodeFunction->IsFunctionParsed())
     {
-        // Only set the environment depth if it's truly known (i.e., not in eval or event handler).
-        funcInfo->GetParsedFunctionBody()->SetEnvDepth(this->envDepth);
+        if (!(flags & (fscrEval | fscrImplicitThis | fscrImplicitParents)))
+        {
+            // Only set the environment depth if it's truly known (i.e., not in eval or event handler).
+            funcInfo->GetParsedFunctionBody()->SetEnvDepth(this->envDepth);
+        }
 
         if (pnodeFnc->sxFnc.FIBPreventsDeferral())
         {

--- a/test/Function/redefer-f-i-b-eval.js
+++ b/test/Function/redefer-f-i-b-eval.js
@@ -1,0 +1,19 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+eval(
+'function outer() {' +
+'    var f = "f";' +
+'    if (true) {' +
+'        let o = { x : function() { if (f !== "f") { WScript.Echo("fail"); throw 1; } } };' +
+'        function i() {}' +
+'        o.x();' +
+'    }' +
+'}');
+
+for (var i = 0; i < 100; i++)
+    arr = [10000];
+outer();
+WScript.Echo('pass');

--- a/test/Function/rlexe.xml
+++ b/test/Function/rlexe.xml
@@ -443,4 +443,10 @@
       <baseline>redefer-recursive-inlinees.baseline</baseline>
     </default>
   </test>
+  <test>
+    <default>
+      <files>redefer-f-i-b-eval.js</files>
+      <compile-flags>-force:deferparse -force:redeferral</compile-flags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
An optimization to permit redeferral of function-in-block was missing a legality check in eval code.