### PR TITLE
port two fixes back to github

### DIFF
--- a/lib/Backend/EmitBuffer.cpp
+++ b/lib/Backend/EmitBuffer.cpp
@@ -403,7 +403,7 @@ EmitBufferManager<TAlloc, TPreReservedAlloc, SyncObject>::CommitBuffer(TEmitBuff
     Assert(allocation != nullptr);
 
     BYTE *currentDestBuffer = destBuffer + allocation->GetBytesUsed();
-    BYTE *bufferToFlush = currentDestBuffer;
+    char *bufferToFlush = allocation->allocation->address + allocation->GetBytesUsed();
     Assert(allocation->BytesFree() >= bytes + alignPad);
 
     size_t bytesLeft = bytes + alignPad;

--- a/lib/JITIDL/Chakra.JITIDL.vcxproj
+++ b/lib/JITIDL/Chakra.JITIDL.vcxproj
@@ -31,7 +31,7 @@
   <ItemGroup>
     <Midl Include="$(MsBuildThisFileDirectory)ChakraJIT.idl">
       <OutputDirectory>$(IntDir)</OutputDirectory>
-      <AdditionalOptions>%(AdditionalOptions) /prefix client "Client" server "Server"</AdditionalOptions>
+      <AdditionalOptions>%(AdditionalOptions) /acf $(MsBuildThisFileDirectory)ChakraJIT.acf /prefix client "Client" server "Server"</AdditionalOptions>
     </Midl>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
1. Flush correct code buffer in case of OOP JIT.
after section change, there are 3 buffers, source buffer, local buffer, remote buffer. the local buffer and remote buffer are pointing to same address in kernel, but have different mapping in client and server process. before the section
change don't have 3 buffers, we were using WriteProcessMemory, so local buffer above is actually using address from client process

2. Fix a hang
For some reason ChakraJIT.acf is not compiled with midl in razzle build(it built correctly in VSO), the context creating server call is serialized, which waits for all on-going codegen call to complete, hence blocks the UI thread and resulting a hang
