### PR TITLE
Dev14 Migration: Removing the outdated flags

### DIFF
--- a/lib/Common/Core/ConfigParser.cpp
+++ b/lib/Common/Core/ConfigParser.cpp
@@ -36,16 +36,17 @@ public:
     ArenaAllocator* GetAllocator() { return &m_allocator; }
 };
 
+static ArenaHost s_arenaHost1(_u("For Output::Trace (1)"));
+static ArenaHost s_arenaHost2(_u("For Output::Trace (2)"));
+
 ArenaAllocator* GetOutputAllocator1()
 {
-    static ArenaHost s_arenaHost(_u("For Output::Trace (1)"));
-    return s_arenaHost.GetAllocator();
+    return s_arenaHost1.GetAllocator();
 }
 
 ArenaAllocator* GetOutputAllocator2()
 {
-    static ArenaHost s_arenaHost(_u("For Output::Trace (2)"));
-    return s_arenaHost.GetAllocator();
+    return s_arenaHost2.GetAllocator();
 }
 #endif
 

--- a/lib/Common/Core/FaultInjection.cpp
+++ b/lib/Common/Core/FaultInjection.cpp
@@ -1020,7 +1020,7 @@ namespace Js
         // install exception filter to smart dump for faultinjection
         // when reproing in debugger, only let debugger catch the exception
         // can't do this in ctor because the global flags are not initialized yet
-        static auto dummy = InstallExceptionFilters();
+        InstallExceptionFilters();
 
         bool validInjectionPoint = IsFaultEnabled(fType);
         if (!validInjectionPoint)
@@ -1095,7 +1095,7 @@ namespace Js
         // try to lookup stack hash, to see if it matches
         if (!shouldInjectionFault)
         {
-            const static UINT_PTR expectedHash = HexStrToAddress((LPCWSTR)globalFlags.FaultInjectionStackHash);
+            const UINT_PTR expectedHash = HexStrToAddress((LPCWSTR)globalFlags.FaultInjectionStackHash);
             if (expectedHash != 0)
             {
                 void* StackFrames[MAX_FRAME_COUNT];


### PR DESCRIPTION
Removing the below outdated flags from the source to enable the dev14
migration.
      1. threadSafeInit
      2. d1vc7dname
      3. d1NTcompat
      4. d1NonStandardNewDelete
