### PR TITLE
OS10895818: F12 edge crash when debugging google.com

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -2585,7 +2585,7 @@ bool FuncAllowsDirectSuper(FuncInfo *funcInfo, ByteCodeGenerator *byteCodeGenera
     if (funcInfo->IsGlobalFunction() && ((byteCodeGenerator->GetFlags() & fscrEval) != 0))
     {
         Js::JavascriptFunction *caller = nullptr;
-        if (Js::JavascriptStackWalker::GetCaller(&caller, byteCodeGenerator->GetScriptContext()))
+        if (Js::JavascriptStackWalker::GetCaller(&caller, byteCodeGenerator->GetScriptContext()) && Js::ScriptFunction::Is(caller))
         {
             Js::FunctionBody * callerBody = caller->GetFunctionBody();
             Assert(callerBody);

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -2585,14 +2585,9 @@ bool FuncAllowsDirectSuper(FuncInfo *funcInfo, ByteCodeGenerator *byteCodeGenera
     if (funcInfo->IsGlobalFunction() && ((byteCodeGenerator->GetFlags() & fscrEval) != 0))
     {
         Js::JavascriptFunction *caller = nullptr;
-        if (Js::JavascriptStackWalker::GetCaller(&caller, byteCodeGenerator->GetScriptContext()) && Js::ScriptFunction::Is(caller))
+        if (Js::JavascriptStackWalker::GetCaller(&caller, byteCodeGenerator->GetScriptContext()) && caller->GetFunctionInfo()->GetAllowDirectSuper())
         {
-            Js::FunctionBody * callerBody = caller->GetFunctionBody();
-            Assert(callerBody);
-            if (callerBody->GetFunctionInfo()->GetAllowDirectSuper())
-            {
-                return true;
-            }
+            return true;
         }
     }
 


### PR DESCRIPTION
For global function inside direct eval, FuncAllowsDirectSuper() looks up JavaScript caller through stackwalker to determine if the eval is called from a class constructor. Need to check if functionBody exists to cover the case where eval is called by F12 from inside a built-in function.