### PR TITLE
Fixing !ldsym in jd for OOPjit

### DIFF
--- a/lib/Backend/InterpreterThunkEmitter.cpp
+++ b/lib/Backend/InterpreterThunkEmitter.cpp
@@ -244,6 +244,12 @@ InterpreterThunkEmitter::InterpreterThunkEmitter(Js::ScriptContext* context, Are
 {
 }
 
+SListBase<ThunkBlock>* 
+InterpreterThunkEmitter::GetThunkBlocksList()
+{
+    return &thunkBlocks;
+}
+
 //
 // Returns the next thunk. Batch allocated PageCount pages of thunks and issue them one at a time
 //

--- a/lib/Backend/InterpreterThunkEmitter.h
+++ b/lib/Backend/InterpreterThunkEmitter.h
@@ -132,6 +132,7 @@ public:
 
     InterpreterThunkEmitter(Js::ScriptContext * context, ArenaAllocator* allocator, CustomHeap::InProcCodePageAllocators * codePageAllocators, bool isAsmInterpreterThunk = false);
     BYTE* GetNextThunk(PVOID* ppDynamicInterpreterThunk);
+    SListBase<ThunkBlock>* GetThunkBlocksList();
 
     void Close();
     void Release(BYTE* thunkAddress, bool addtoFreeList);

--- a/lib/Common/DataStructures/SList.h
+++ b/lib/Common/DataStructures/SList.h
@@ -63,6 +63,11 @@ class SListNode : public SListNodeBase<TData>
 {
     friend class SListBase<TData, FakeCount>;
     friend class SListBase<TData, RealCount>;
+public:
+    TData* GetData()
+    {
+        return &data;
+    }
 private:
 
     SListNode() : data() {}

--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -6045,4 +6045,15 @@ void ScriptContext::RegisterPrototypeChainEnsuredToHaveOnlyWritableDataPropertie
             return (key <= address && (uintptr_t)address < ((uintptr_t)key + value));
         });
     }
+
+    JITPageAddrToFuncRangeCache::JITPageAddrToFuncRangeMap * JITPageAddrToFuncRangeCache::GetJITPageAddrToFuncRangeMap()
+    {
+        return jitPageAddrToFuncRangeMap;
+    }
+    
+    JITPageAddrToFuncRangeCache::LargeJITFuncAddrToSizeMap * JITPageAddrToFuncRangeCache::GetLargeJITFuncAddrToSizeMap()
+    {
+        return largeJitFuncToSizeMap;
+    }
+
 } // End namespace Js

--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -383,11 +383,12 @@ namespace Js
     */
     class JITPageAddrToFuncRangeCache
     {
-    private:
+    public:
         typedef JsUtil::BaseDictionary<void *, uint, HeapAllocator> RangeMap;
         typedef JsUtil::BaseDictionary<void *, RangeMap*, HeapAllocator> JITPageAddrToFuncRangeMap;
         typedef JsUtil::BaseDictionary<void *, uint, HeapAllocator> LargeJITFuncAddrToSizeMap;
 
+    private:
         JITPageAddrToFuncRangeMap * jitPageAddrToFuncRangeMap;
         LargeJITFuncAddrToSizeMap * largeJitFuncToSizeMap;
 
@@ -404,6 +405,8 @@ namespace Js
         void RemoveFuncRange(void * address);
         void * GetPageAddr(void * address);
         bool IsNativeAddr(void * address);
+        JITPageAddrToFuncRangeMap * GetJITPageAddrToFuncRangeMap();
+        LargeJITFuncAddrToSizeMap * GetLargeJITFuncAddrToSizeMap();
         static CriticalSection * GetCriticalSection() { return &cs; }
     };
 

--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -4080,6 +4080,25 @@ void DumpRecyclerObjectGraph()
 #endif
 
 #if ENABLE_NATIVE_CODEGEN
+bool ThreadContext::IsNativeAddressHelper(void * pCodeAddr, Js::ScriptContext* currentScriptContext)
+{
+    bool isNativeAddr = false;
+    if (currentScriptContext && currentScriptContext->GetJitFuncRangeCache() != nullptr)
+    {
+        isNativeAddr = currentScriptContext->GetJitFuncRangeCache()->IsNativeAddr(pCodeAddr);
+    }
+
+    for (Js::ScriptContext *scriptContext = scriptContextList; scriptContext && !isNativeAddr; scriptContext = scriptContext->next)
+    {
+        if (scriptContext == currentScriptContext || scriptContext->GetJitFuncRangeCache() == nullptr)
+        {
+            continue;
+        }
+        isNativeAddr = scriptContext->GetJitFuncRangeCache()->IsNativeAddr(pCodeAddr);
+    }
+    return isNativeAddr;
+}
+
 BOOL ThreadContext::IsNativeAddress(void * pCodeAddr, Js::ScriptContext* currentScriptContext)
 {
 #if ENABLE_OOP_NATIVE_CODEGEN
@@ -4103,24 +4122,9 @@ BOOL ThreadContext::IsNativeAddress(void * pCodeAddr, Js::ScriptContext* current
         HRESULT hr = JITManager::GetJITManager()->IsNativeAddr(this->m_remoteThreadContextInfo, (intptr_t)pCodeAddr, &result);
         JITManager::HandleServerCallResult(hr, RemoteCallType::HeapQuery);
 #endif
-
-        bool isNativeAddr = false;
-        if (currentScriptContext && currentScriptContext->GetJitFuncRangeCache() != nullptr)
-        {
-            isNativeAddr = currentScriptContext->GetJitFuncRangeCache()->IsNativeAddr(pCodeAddr);
-        }
-
-        for (Js::ScriptContext *scriptContext = scriptContextList; scriptContext && !isNativeAddr; scriptContext = scriptContext->next)
-        {
-            if (scriptContext->GetJitFuncRangeCache() == nullptr || scriptContext == currentScriptContext)
-            {
-                continue;
-            }
-            isNativeAddr = scriptContext->GetJitFuncRangeCache()->IsNativeAddr(pCodeAddr);
-        }
-
+        bool isNativeAddr = IsNativeAddressHelper(pCodeAddr, currentScriptContext);
 #if DBG
-        Assert(result == (isNativeAddr? 1:0));
+        Assert(result == (isNativeAddr? TRUE:FALSE));
 #endif
         return isNativeAddr;
     }
@@ -4138,17 +4142,7 @@ BOOL ThreadContext::IsNativeAddress(void * pCodeAddr, Js::ScriptContext* current
 #if DBG
             AutoCriticalSection autoLock(&this->codePageAllocators.cs);
 #endif
-            
-            bool isNativeAddr = false;
-            for (Js::ScriptContext *scriptContext = scriptContextList; scriptContext && !isNativeAddr; scriptContext = scriptContext->next)
-            {
-                if (scriptContext->GetJitFuncRangeCache() == nullptr)
-                {
-                    continue;
-                }
-                isNativeAddr = scriptContext->GetJitFuncRangeCache()->IsNativeAddr(pCodeAddr);
-            }
-
+            bool isNativeAddr = IsNativeAddressHelper(pCodeAddr, currentScriptContext);
 #if DBG
             Assert(this->codePageAllocators.IsInNonPreReservedPageAllocator(pCodeAddr) == isNativeAddr);
 #endif

--- a/lib/Runtime/Base/ThreadContext.h
+++ b/lib/Runtime/Base/ThreadContext.h
@@ -1180,6 +1180,7 @@ public:
     void RegisterCodeGenRecyclableData(Js::CodeGenRecyclableData *const codeGenRecyclableData);
     void UnregisterCodeGenRecyclableData(Js::CodeGenRecyclableData *const codeGenRecyclableData);
 #if ENABLE_NATIVE_CODEGEN
+    bool IsNativeAddressHelper(void * pCodeAddr, Js::ScriptContext* currentScriptContext);
     BOOL IsNativeAddress(void * pCodeAddr, Js::ScriptContext* currentScriptContext = nullptr);
     JsUtil::JobProcessor *GetJobProcessor();
     Js::Var * GetBailOutRegisterSaveSpace() const { return bailOutRegisterSaveSpace; }


### PR DESCRIPTION
We don't register the native addresses and interpreter thunk addresses for OOPjit scenarios - since the allocations linked list is not populated by the runtime process.

Fix:
Used the cache that we now populate on the script context to register the address.
For interpreter thunk emitter - we use the thunkBlocks linked list.