### PR TITLE
Repair incorrect fix for double increment of literal regex count. 

### DIFF
--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -6110,13 +6110,12 @@ namespace Js
 
     uint FunctionBody::NewLiteralRegex()
     {
-        if (this->byteCodeBlock)
+        if (this->GetLiteralRegexes() != nullptr)
         {
-            // This is a function nested in a redeferred function, so we won't make use of the index.
-            // Don't increment to avoid breaking thread-safety requirements of the compact counters.
+            // This is a function nested in a redeferred function, so we won't regenerate byte code and won't make use of the index.
+            // The regex count is already correct, so don't increment it.
             return 0;
         }
-        Assert(!this->GetLiteralRegexes());
         return IncLiteralRegexCount();
     }
 


### PR DESCRIPTION
On redeferral of an enclosing function, where nested functions are still in a compiled state, we do not want to re-increment the literal regex count for the nested functions. But we do still want to count the regexes and allocate new regex storage for the function we're recompiling. A new simple fix handles both cases.