### PR TITLE
disable redeferral when -testtrace:stackfunc

### DIFF
--- a/test/stackfunc/rlexe.xml
+++ b/test/stackfunc/rlexe.xml
@@ -4,7 +4,7 @@
     <default>
       <files>simple_escape.js</files>
       <baseline>simple_escape.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre</tags>
     </default>
   </test>
@@ -12,7 +12,7 @@
     <default>
       <files>simple_stackfunc.js</files>
       <baseline>simple_stackfunc.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simplejit -Off:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simplejit -Off:Deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre</tags>
     </default>
   </test>
@@ -20,7 +20,7 @@
     <default>
       <files>simple_stackfunc.js</files>
       <baseline>simple_stackfunc.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -Off:Deferparse -on:stackfunc -nonative</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -Off:Deferparse -on:stackfunc -nonative</compile-flags>
       <tags>exclude_fre,exclude_dynapogo</tags>
     </default>
   </test>
@@ -28,7 +28,7 @@
     <default>
       <files>trycatch_stackfunc.js</files>
       <baseline>trycatch_stackfunc.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc -nonative</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Off:Deferparse -on:stackfunc -nonative</compile-flags>
       <tags>exclude_fre,exclude_dynapogo</tags>
     </default>
   </test>
@@ -36,7 +36,7 @@
     <default>
       <files>simple_namedstackfunc.js</files>
       <baseline>simple_namedstackfunc.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre</tags>
     </default>
   </test>
@@ -44,7 +44,7 @@
     <default>
       <files>toString_escape.js</files>
       <baseline>toString_escape.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre</tags>
     </default>
   </test>
@@ -52,7 +52,7 @@
     <default>
       <files>chain_assign.js</files>
       <baseline>chain_assign.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre</tags>
     </default>
   </test>
@@ -60,7 +60,7 @@
     <default>
       <files>nested_escape.js</files>
       <baseline>nested_escape.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre</tags>
     </default>
   </test>
@@ -68,7 +68,7 @@
     <default>
       <files>funcname_escape.js</files>
       <baseline>funcname_escape.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre</tags>
     </default>
   </test>
@@ -76,7 +76,7 @@
     <default>
       <files>call_escape.js</files>
       <baseline>call_escape.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre</tags>
     </default>
   </test>
@@ -84,7 +84,7 @@
     <default>
       <files>argout_escape.js</files>
       <baseline>argout_escape.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc -off:disablestackfuncondeferredescape</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Off:Deferparse -on:stackfunc -off:disablestackfuncondeferredescape</compile-flags>
       <tags>exclude_fre</tags>
     </default>
   </test>
@@ -92,7 +92,7 @@
     <default>
       <files>throw_escape.js</files>
       <baseline>throw_escape.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre</tags>
     </default>
   </test>
@@ -100,7 +100,7 @@
     <default>
       <files>funcname_asg.js</files>
       <baseline>funcname_asg.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre</tags>
     </default>
   </test>
@@ -108,7 +108,7 @@
     <default>
       <files>arrlit_escape.js</files>
       <baseline>arrlit_escape.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre</tags>
     </default>
   </test>
@@ -116,7 +116,7 @@
     <default>
       <files>arrlit_asg_escape.js</files>
       <baseline>arrlit_asg_escape.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre</tags>
     </default>
   </test>
@@ -124,7 +124,7 @@
     <default>
       <files>objlit_escape.js</files>
       <baseline>objlit_escape.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre</tags>
     </default>
   </test>
@@ -132,7 +132,7 @@
     <default>
       <files>formal_asg.js</files>
       <baseline>formal_asg.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre</tags>
     </default>
   </test>
@@ -140,7 +140,7 @@
     <default>
       <files>argument_escape.js</files>
       <baseline>argument_escape.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre</tags>
     </default>
   </test>
@@ -156,7 +156,7 @@
     <default>
       <files>cross_scope.js</files>
       <baseline>cross_scope.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre</tags>
     </default>
   </test>
@@ -164,7 +164,7 @@
     <default>
       <files>eval_escape.js</files>
       <baseline>eval_escape.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre</tags>
     </default>
   </test>
@@ -172,7 +172,7 @@
     <default>
       <files>child_eval_escape.js</files>
       <baseline>child_eval_escape.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre</tags>
     </default>
   </test>
@@ -180,7 +180,7 @@
     <default>
       <files>with_namedfunc.js</files>
       <baseline>with_namedfunc.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre</tags>
     </default>
   </test>
@@ -188,7 +188,7 @@
     <default>
       <files>formal_namedfunc.js</files>
       <baseline>formal_namedfunc.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre</tags>
     </default>
   </test>
@@ -196,7 +196,7 @@
     <default>
       <files>throw_func.js</files>
       <baseline>throw_func.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre</tags>
     </default>
   </test>
@@ -204,7 +204,7 @@
     <default>
       <files>glo_asg.js</files>
       <baseline>glo_asg.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre</tags>
     </default>
   </test>
@@ -212,7 +212,7 @@
     <default>
       <files>multinested_escape.js</files>
       <baseline>multinested_escape.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre</tags>
     </default>
   </test>
@@ -220,7 +220,7 @@
     <default>
       <files>let_stackfunc.js</files>
       <baseline>let_stackfunc.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -off:deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -off:deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre</tags>
     </default>
   </test>
@@ -228,7 +228,7 @@
     <default>
       <files>let_blockescape.js</files>
       <baseline>let_blockescape.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -off:deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -off:deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre</tags>
     </default>
   </test>
@@ -236,7 +236,7 @@
     <default>
       <files>simple_escape.js</files>
       <baseline>simple_escape.deferparse.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre,exclude_dynapogo</tags>
     </default>
   </test>
@@ -244,7 +244,7 @@
     <default>
       <files>simple_stackfunc.js</files>
       <baseline>simple_stackfunc.deferparse.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre,exclude_dynapogo</tags>
     </default>
   </test>
@@ -252,7 +252,7 @@
     <default>
       <files>simple_namedstackfunc.js</files>
       <baseline>simple_namedstackfunc.deferparse.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre,exclude_dynapogo</tags>
     </default>
   </test>
@@ -260,7 +260,7 @@
     <default>
       <files>toString_escape.js</files>
       <baseline>toString_escape.deferparse.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre,exclude_dynapogo</tags>
     </default>
   </test>
@@ -268,7 +268,7 @@
     <default>
       <files>chain_assign.js</files>
       <baseline>chain_assign.deferparse.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre,exclude_dynapogo</tags>
     </default>
   </test>
@@ -276,7 +276,7 @@
     <default>
       <files>nested_escape.js</files>
       <baseline>nested_escape.deferparse.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -off:DisableStackFuncOnDeferredEscape</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Force:Deferparse -off:DisableStackFuncOnDeferredEscape</compile-flags>
       <tags>exclude_fre,exclude_dynapogo</tags>
     </default>
   </test>
@@ -284,7 +284,7 @@
     <default>
       <files>funcname_escape.js</files>
       <baseline>funcname_escape.deferparse.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc -off:disablestackfuncondeferredescape</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Force:Deferparse -on:stackfunc -off:disablestackfuncondeferredescape</compile-flags>
       <tags>exclude_fre,exclude_dynapogo</tags>
     </default>
   </test>
@@ -293,7 +293,7 @@
       <files>call_escape.js</files>
       <baseline>call_escape.deferparse.baseline</baseline>
       <!--Top Level function parsing on first call to script is turned off here, as this tests order of functions executed-->
-      <compile-flags>-DeferTopLevelTillFirstCall- -testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-DeferTopLevelTillFirstCall- -testtrace:stackfunc -off:redeferral -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre,exclude_dynapogo</tags>
     </default>
   </test>
@@ -302,7 +302,7 @@
       <files>throw_escape.js</files>
       <baseline>throw_escape.deferparse.baseline</baseline>
       <!--Top Level function parsing on first call to script is turned off here, as this tests order of functions executed-->
-      <compile-flags>-DeferTopLevelTillFirstCall- -testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-DeferTopLevelTillFirstCall- -testtrace:stackfunc -off:redeferral -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre,exclude_dynapogo</tags>
     </default>
   </test>
@@ -310,7 +310,7 @@
     <default>
       <files>funcname_asg.js</files>
       <baseline>funcname_asg.deferparse.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre,exclude_dynapogo</tags>
     </default>
   </test>
@@ -318,7 +318,7 @@
     <default>
       <files>arrlit_escape.js</files>
       <baseline>arrlit_escape.deferparse.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre,exclude_dynapogo</tags>
     </default>
   </test>
@@ -326,7 +326,7 @@
     <default>
       <files>arrlit_asg_escape.js</files>
       <baseline>arrlit_asg_escape.deferparse.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre,exclude_dynapogo</tags>
     </default>
   </test>
@@ -334,7 +334,7 @@
     <default>
       <files>objlit_escape.js</files>
       <baseline>objlit_escape.deferparse.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre,exclude_dynapogo</tags>
     </default>
   </test>
@@ -342,7 +342,7 @@
     <default>
       <files>formal_asg.js</files>
       <baseline>formal_asg.deferparse.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre,exclude_dynapogo</tags>
     </default>
   </test>
@@ -350,7 +350,7 @@
     <default>
       <files>argument_escape.js</files>
       <baseline>argument_escape.deferparse.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre,exclude_dynapogo</tags>
     </default>
   </test>
@@ -358,7 +358,7 @@
     <default>
       <files>cross_scope.js</files>
       <baseline>cross_scope.deferparse.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -off:cachescopeinfonames -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Force:Deferparse -off:cachescopeinfonames -on:stackfunc</compile-flags>
       <tags>exclude_fre,exclude_dynapogo</tags>
     </default>
   </test>
@@ -366,7 +366,7 @@
     <default>
       <files>eval_escape.js</files>
       <baseline>eval_escape.deferparse.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre,exclude_dynapogo</tags>
     </default>
   </test>
@@ -374,7 +374,7 @@
     <default>
       <files>child_eval_escape.js</files>
       <baseline>child_eval_escape.deferparse.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre,exclude_dynapogo</tags>
     </default>
   </test>
@@ -382,7 +382,7 @@
     <default>
       <files>with_namedfunc.js</files>
       <baseline>with_namedfunc.deferparse.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre,exclude_dynapogo</tags>
     </default>
   </test>
@@ -390,7 +390,7 @@
     <default>
       <files>formal_namedfunc.js</files>
       <baseline>formal_namedfunc.deferparse.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre,exclude_dynapogo</tags>
     </default>
   </test>
@@ -399,7 +399,7 @@
       <files>throw_func.js</files>
       <baseline>throw_func.deferparse.baseline</baseline>
       <!--Top Level function parsing on first call to script is turned off here, as this tests order of functions executed-->
-      <compile-flags>-DeferTopLevelTillFirstCall- -testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-DeferTopLevelTillFirstCall- -testtrace:stackfunc -off:redeferral -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre,exclude_dynapogo</tags>
     </default>
   </test>
@@ -407,7 +407,7 @@
     <default>
       <files>glo_asg.js</files>
       <baseline>glo_asg.deferparse.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre,exclude_dynapogo</tags>
     </default>
   </test>
@@ -415,7 +415,7 @@
     <default>
       <files>multinested_escape.js</files>
       <baseline>multinested_escape.deferparse.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -off:cachescopeinfonames -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Force:Deferparse -off:cachescopeinfonames -on:stackfunc</compile-flags>
       <tags>exclude_fre,exclude_dynapogo,exclude_arm</tags>
     </default>
   </test>
@@ -423,7 +423,7 @@
     <default>
       <files>let_stackfunc.js</files>
       <baseline>let_stackfunc.deferparse.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre,exclude_dynapogo</tags>
     </default>
   </test>
@@ -431,7 +431,7 @@
     <default>
       <files>let_blockescape.js</files>
       <baseline>let_blockescape.deferparse.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre,exclude_dynapogo</tags>
     </default>
   </test>
@@ -439,7 +439,7 @@
     <default>
       <files>box.js</files>
       <baseline>box.deferparse.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -off:cachescopeinfonames -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Force:Deferparse -off:cachescopeinfonames -on:stackfunc</compile-flags>
       <tags>exclude_fre,exclude_dynapogo,exclude_nonative,exclude_arm</tags>
     </default>
   </test>
@@ -447,7 +447,7 @@
     <default>
       <files>box.js</files>
       <baseline>box.deferparse.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -off:cachescopeinfonames -force:inline -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Force:Deferparse -off:cachescopeinfonames -force:inline -on:stackfunc</compile-flags>
       <tags>exclude_fre,exclude_dynapogo,exclude_nonative,exclude_arm</tags>
     </default>
   </test>
@@ -455,7 +455,7 @@
     <default>
       <files>callee_escape.js</files>
       <baseline>callee_escape.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -force:inline -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -force:inline -on:stackfunc</compile-flags>
       <tags>exclude_fre,exclude_dynapogo,exclude_arm</tags>
     </default>
   </test>
@@ -463,7 +463,7 @@
     <default>
       <files>callee_escape2.js</files>
       <baseline>callee_escape2.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -force:inline -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -force:inline -on:stackfunc</compile-flags>
       <tags>exclude_fre,exclude_dynapogo,exclude_arm</tags>
     </default>
   </test>
@@ -471,7 +471,7 @@
     <default>
       <files>callee_escape2.js</files>
       <baseline>callee_escape2.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -force:inline -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -force:inline -on:stackfunc</compile-flags>
       <tags>exclude_fre,exclude_dynapogo,exclude_arm</tags>
     </default>
   </test>
@@ -479,7 +479,7 @@
     <default>
       <files>caller_escape.js</files>
       <baseline>caller_escape.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Off:Deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre,exclude_dynapogo,exclude_nonative,exclude_arm</tags>
     </default>
   </test>
@@ -487,7 +487,7 @@
     <default>
       <files>singleuse.js</files>
       <baseline>singleuse.deferparse.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -Force:Deferparse -on:stackfunc</compile-flags>
       <tags>exclude_fre,exclude_dynapogo</tags>
     </default>
   </test>
@@ -495,7 +495,7 @@
     <default>
       <files>iffuncdecl.js</files>
       <baseline>iffuncdecl.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -on:stackfunc</compile-flags>
       <tags>exclude_fre,exclude_dynapogo</tags>
     </default>
   </test>
@@ -503,7 +503,7 @@
     <default>
       <files>cachescope.js</files>
       <baseline>cachescope.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -on:stackfunc</compile-flags>
       <tags>exclude_fre,exclude_dynapogo</tags>
     </default>
   </test>
@@ -511,7 +511,7 @@
     <default>
       <files>box_callparam.js</files>
       <baseline>box_callparam.deferparse.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -on:stackfunc -force:deferparse -off:cachescopeinfonames -off:disablestackfuncondeferredescape </compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -on:stackfunc -force:deferparse -off:cachescopeinfonames -off:disablestackfuncondeferredescape </compile-flags>
       <tags>exclude_fre,exclude_dynapogo</tags>
     </default>
   </test>
@@ -519,7 +519,7 @@
     <default>
       <files>inlinee_box.js</files>
       <baseline>inlinee_box.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -on:stackfunc -force:inline</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -on:stackfunc -force:inline</compile-flags>
       <tags>exclude_fre,exclude_dynapogo,exclude_nonative,exclude_arm</tags>
     </default>
   </test>
@@ -527,7 +527,7 @@
     <default>
       <files>blockscope_funcdecl.js</files>
       <baseline>blockscope_funcdecl.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -on:stackfunc</compile-flags>
       <tags>exclude_fre,exclude_dynapogo</tags>
     </default>
   </test>
@@ -535,7 +535,7 @@
     <default>
       <files>recurse.js</files>
       <baseline>recurse.deferparse.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -on:stackfunc -force:deferparse -off:disablestackfuncondeferredescape</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -on:stackfunc -force:deferparse -off:disablestackfuncondeferredescape</compile-flags>
       <tags>exclude_fre,exclude_dynapogo</tags>
     </default>
   </test>
@@ -543,7 +543,7 @@
     <default>
       <files>jitdefer.js</files>
       <baseline>jitdefer.deferparse.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -on:stackfunc -force:deferparse -off:cachescopeinfonames</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -on:stackfunc -force:deferparse -off:cachescopeinfonames</compile-flags>
       <tags>exclude_fre,exclude_dynapogo,exclude_arm,exclude_nonative</tags>
     </default>
   </test>
@@ -552,7 +552,7 @@
       <files>box_bailout.js</files>
       <baseline>box_bailout.deferparse.baseline</baseline>
       <!--Top Level function parsing on first call to script is turned off here, as this tests order of functions executed-->
-      <compile-flags>-DeferTopLevelTillFirstCall- -testtrace:stackfunc -off:simpleJit -on:stackfunc -force:deferparse -off:disablestackfuncondeferredescape</compile-flags>
+      <compile-flags>-DeferTopLevelTillFirstCall- -testtrace:stackfunc -off:redeferral -off:simpleJit -on:stackfunc -force:deferparse -off:disablestackfuncondeferredescape</compile-flags>
       <tags>exclude_fre,exclude_dynapogo,exclude_arm,exclude_nonative</tags>
     </default>
   </test>
@@ -561,7 +561,7 @@
       <files>box_inline_bailout.js</files>
       <baseline>box_inline_bailout.deferparse.baseline</baseline>
       <!--Top Level function parsing on first call to script is turned off here, as this tests order of functions executed-->
-      <compile-flags>-DeferTopLevelTillFirstCall- -testtrace:stackfunc -off:simpleJit -on:stackfunc -force:deferparse -off:disablestackfuncondeferredescape</compile-flags>
+      <compile-flags>-DeferTopLevelTillFirstCall- -testtrace:stackfunc -off:redeferral -off:simpleJit -on:stackfunc -force:deferparse -off:disablestackfuncondeferredescape</compile-flags>
       <tags>exclude_fre,exclude_dynapogo,exclude_arm,exclude_nonative</tags>
     </default>
   </test>
@@ -569,7 +569,7 @@
     <default>
       <files>withref_delayobjscope.js</files>
       <baseline>withref_delayobjscope.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -on:stackfunc</compile-flags>
       <tags>exclude_fre,exclude_dynapogo,exclude_arm</tags>
     </default>
   </test>
@@ -577,7 +577,7 @@
     <default>
       <files>funcexpr.js</files>
       <baseline>funcexpr.deferparse.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -on:stackfunc -force:deferparse -off:disablestackfuncondeferredescape</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -on:stackfunc -force:deferparse -off:disablestackfuncondeferredescape</compile-flags>
       <tags>exclude_fre,exclude_dynapogo,exclude_arm</tags>
     </default>
   </test>
@@ -585,7 +585,7 @@
     <default>
       <files>funcexpr_2.js</files>
       <baseline>funcexpr_2.deferparse.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -on:stackfunc -force:deferparse -off:disablestackfuncondeferredescape</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -on:stackfunc -force:deferparse -off:disablestackfuncondeferredescape</compile-flags>
       <tags>exclude_fre,exclude_dynapogo,exclude_arm</tags>
     </default>
   </test>
@@ -593,7 +593,7 @@
     <default>
       <files>funcexpr_2.js</files>
       <baseline>funcexpr_2.deferparse.native.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -on:stackfunc -force:deferparse -forceNative -off:simpleJit -off:disablestackfuncondeferredescape</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -on:stackfunc -force:deferparse -forceNative -off:simpleJit -off:disablestackfuncondeferredescape</compile-flags>
       <tags>exclude_fre,exclude_dynapogo,exclude_arm</tags>
     </default>
   </test>
@@ -601,7 +601,7 @@
     <default>
       <files>with_existing.js</files>
       <baseline>with_existing.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -on:stackfunc</compile-flags>
       <tags>exclude_fre,exclude_dynapogo,exclude_arm</tags>
     </default>
   </test>
@@ -609,7 +609,7 @@
     <default>
       <files>with_crossscope.js</files>
       <baseline>with_crossscope.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -on:stackfunc</compile-flags>
       <tags>exclude_fre,exclude_dynapogo,exclude_arm</tags>
     </default>
   </test>
@@ -617,7 +617,7 @@
     <default>
       <files>bug565705.js</files>
       <baseline>bug565705.baseline</baseline>
-      <compile-flags>-testtrace:stackfunc -off:simpleJit -on:stackfunc</compile-flags>
+      <compile-flags>-testtrace:stackfunc -off:redeferral -off:simpleJit -on:stackfunc</compile-flags>
       <tags>exclude_fre,exclude_dynapogo,exclude_arm</tags>
     </default>
   </test>
@@ -686,7 +686,7 @@
     <default>
       <files>box_blockscope.js</files>
       <baseline>box_blockscope.baseline</baseline>
-      <compile-flags>-off:simplejit -testtrace:stackfunc</compile-flags>
+      <compile-flags>-off:simplejit -testtrace:stackfunc -off:redeferral</compile-flags>
       <tags>exclude_fre,exclude_arm,exclude_dynapogo</tags>
     </default>
   </test>


### PR DESCRIPTION
If redeferral happens, -testtrace:stackfunc may output more content and
cause unit test output mismatching baseline.
