### PR TITLE
Fix operand types after hoisting IR instrs to landingpad

### DIFF
--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -19060,9 +19060,15 @@ GlobOpt::OptDstIsInvariant(IR::RegOpnd *dst)
 void
 GlobOpt::OptHoistToLandingPadUpdateValueType(
     BasicBlock* landingPad,
+    IR::Instr* instr,
     IR::Opnd* opnd,
     Value* opndVal)
 {
+    if (instr->m_opcode == Js::OpCode::FromVar)
+    {
+        return;
+    }
+
     Sym* opndSym = opnd->GetSym();;
 
     if (opndSym)
@@ -19106,7 +19112,7 @@ GlobOpt::OptHoistInvariant(
     if (src1)
     {
         // We are hoisting this instruction possibly past other uses, which might invalidate the last use info. Clear it.
-        OptHoistToLandingPadUpdateValueType(landingPad, src1, src1Val);
+        OptHoistToLandingPadUpdateValueType(landingPad, instr, src1, src1Val);
 
         if (src1->IsRegOpnd())
         {
@@ -19116,7 +19122,7 @@ GlobOpt::OptHoistInvariant(
         IR::Opnd* src2 = instr->GetSrc2();
         if (src2)
         {
-            OptHoistToLandingPadUpdateValueType(landingPad, src2, nullptr);
+            OptHoistToLandingPadUpdateValueType(landingPad, instr, src2, nullptr);
 
             if (src2->IsRegOpnd())
             {

--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -19058,6 +19058,38 @@ GlobOpt::OptDstIsInvariant(IR::RegOpnd *dst)
 }
 
 void
+GlobOpt::OptHoistToLandingPadUpdateValueType(
+    BasicBlock* landingPad,
+    IR::Opnd* opnd,
+    Value* opndVal)
+{
+    Sym* opndSym = opnd->GetSym();;
+
+    if (opndSym)
+    {
+        if (opndVal == nullptr)
+        {
+            opndVal = FindValue(opndSym);
+        }
+
+        Value* opndValueInLandingPad = FindValue(landingPad->globOptData.symToValueMap, opndSym);
+        Assert(opndVal->GetValueNumber() == opndValueInLandingPad->GetValueNumber());
+
+        opnd->SetValueType(opndValueInLandingPad->GetValueInfo()->Type());
+
+        if (opndSym->IsPropertySym())
+        {
+            // Also fix valueInfo on objPtr
+            StackSym* opndObjPtrSym = opndSym->AsPropertySym()->m_stackSym;
+            Value* opndObjPtrSymValInLandingPad = FindValue(landingPad->globOptData.symToValueMap, opndObjPtrSym);
+            ValueInfo* opndObjPtrSymValueInfoInLandingPad = opndObjPtrSymValInLandingPad->GetValueInfo();
+
+            opnd->AsSymOpnd()->SetPropertyOwnerValueType(opndObjPtrSymValueInfoInLandingPad->Type());
+        }
+    }
+}
+
+void
 GlobOpt::OptHoistInvariant(
     IR::Instr *instr,
     BasicBlock *block,
@@ -19069,6 +19101,30 @@ GlobOpt::OptHoistInvariant(
     IR::BailOutKind bailoutKind)
 {
     BasicBlock *landingPad = loop->landingPad;
+
+    IR::Opnd* src1 = instr->GetSrc1();
+    if (src1)
+    {
+        // We are hoisting this instruction possibly past other uses, which might invalidate the last use info. Clear it.
+        OptHoistToLandingPadUpdateValueType(landingPad, src1, src1Val);
+
+        if (src1->IsRegOpnd())
+        {
+            src1->AsRegOpnd()->m_isTempLastUse = false;
+        }
+
+        IR::Opnd* src2 = instr->GetSrc2();
+        if (src2)
+        {
+            OptHoistToLandingPadUpdateValueType(landingPad, src2, nullptr);
+
+            if (src2->IsRegOpnd())
+            {
+                src2->AsRegOpnd()->m_isTempLastUse = false;
+            }
+        }
+    }
+
     IR::RegOpnd *dst = instr->GetDst() ? instr->GetDst()->AsRegOpnd() : nullptr;
     if(dst)
     {
@@ -19307,26 +19363,6 @@ GlobOpt::OptHoistInvariant(
             // if the old bailout is deleted, reset capturedvalues cached in block
             block->globOptData.capturedValues = nullptr;
             block->globOptData.capturedValuesCandidate = nullptr;
-        }
-    }
-
-    if (instr->GetSrc1())
-    {
-        // We are hoisting this instruction possibly past other uses, which might invalidate the last use info. Clear it.
-        IR::Opnd *src1 = instr->GetSrc1();
-
-        if (src1->IsRegOpnd())
-        {
-            src1->AsRegOpnd()->m_isTempLastUse = false;
-        }
-        if (instr->GetSrc2())
-        {
-            IR::Opnd *src2 = instr->GetSrc2();
-
-            if (src2->IsRegOpnd())
-            {
-                src2->AsRegOpnd()->m_isTempLastUse = false;
-            }
         }
     }
 

--- a/lib/Backend/GlobOpt.h
+++ b/lib/Backend/GlobOpt.h
@@ -1605,7 +1605,7 @@ private:
     bool                    TryHoistInvariant(IR::Instr *instr, BasicBlock *block, Value *dstVal, Value *src1Val, Value *src2Val, bool isNotTypeSpecConv,
                                                 const bool lossy = false, const bool forceInvariantHoisting = false, IR::BailOutKind bailoutKind = IR::BailOutInvalid);
     void                    HoistInvariantValueInfo(ValueInfo *const invariantValueInfoToHoist, Value *const valueToUpdate, BasicBlock *const targetBlock);
-    void                    OptHoistToLandingPadUpdateValueType(BasicBlock* landingPad, IR::Opnd* opnd, Value *const srcVal);
+    void                    OptHoistToLandingPadUpdateValueType(BasicBlock* landingPad, IR::Instr* instr, IR::Opnd* opnd, Value *const srcVal);
 public:
     static bool             IsTypeSpecPhaseOff(Func* func);
     static bool             DoAggressiveIntTypeSpec(Func* func);

--- a/lib/Backend/GlobOpt.h
+++ b/lib/Backend/GlobOpt.h
@@ -1605,6 +1605,7 @@ private:
     bool                    TryHoistInvariant(IR::Instr *instr, BasicBlock *block, Value *dstVal, Value *src1Val, Value *src2Val, bool isNotTypeSpecConv,
                                                 const bool lossy = false, const bool forceInvariantHoisting = false, IR::BailOutKind bailoutKind = IR::BailOutInvalid);
     void                    HoistInvariantValueInfo(ValueInfo *const invariantValueInfoToHoist, Value *const valueToUpdate, BasicBlock *const targetBlock);
+    void                    OptHoistToLandingPadUpdateValueType(BasicBlock* landingPad, IR::Opnd* opnd, Value *const srcVal);
 public:
     static bool             IsTypeSpecPhaseOff(Func* func);
     static bool             DoAggressiveIntTypeSpec(Func* func);

--- a/lib/Backend/Opnd.cpp
+++ b/lib/Backend/Opnd.cpp
@@ -366,6 +366,20 @@ Opnd::GetStackSym() const
     }
 }
 
+Sym*
+Opnd::GetSym() const
+{
+    switch (this->GetKind())
+    {
+        case OpndKindSym:
+            return static_cast<SymOpnd const *>(this)->m_sym;
+        case OpndKindReg:
+            return static_cast<RegOpnd const *>(this)->m_sym;
+        default:
+            return nullptr;
+    }
+}
+
 int64
 Opnd::GetImmediateValue(Func* func)
 {

--- a/lib/Backend/Opnd.h
+++ b/lib/Backend/Opnd.h
@@ -181,6 +181,7 @@ public:
     Opnd *              CloneDef(Func *func);
     Opnd *              CloneUse(Func *func);
     StackSym *          GetStackSym() const;
+    Sym *               GetSym() const;
     Opnd *              UseWithNewType(IRType type, Func * func);
 
     bool                IsEqual(Opnd *opnd);

--- a/test/Optimizer/FixTypeAfterHoisting.js
+++ b/test/Optimizer/FixTypeAfterHoisting.js
@@ -1,0 +1,21 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function test0(a)
+{
+    for (var i = a.length; i--; )
+    {
+        c = a[i];
+        b =a.slice(i);
+    }
+}
+
+var arr = [0,1,2,3];
+
+test0(arr);
+test0(0);
+
+print('pass');
+

--- a/test/Optimizer/rlexe.xml
+++ b/test/Optimizer/rlexe.xml
@@ -1373,4 +1373,10 @@
       <baseline>negativeZero_bugs.baseline</baseline>
     </default>
   </test>
+  <test>
+    <default>
+      <files>FixTypeAfterHoisting.js</files>
+      <compile-flags>-lic:1 -off:simplejit -off:aggressiveinttypespec -bgjit-</compile-flags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
We don't fix value type of many IR instructions when hositing it into landingpad (like for `CheckFixFld`, we did it for `FromVar`). Then incorrect value type info in landingpad causes bad codegen, like missing some type checks required by the type info in landingpad (some type assertions in the loop are false in the landingpad because they are from bailout in the loop) , and the missing checked causes access violation finally.

I got this problem from crawler. The fix and simple repro was mostly made by Louis. Thanks @LouisLaf.