### PR TITLE
this is referenced in destructuring.

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -12362,7 +12362,7 @@ ParseNodePtr Parser::ParseDestructuredVarDecl(tokens declarationType, bool isDec
             }
         }
 
-        if (m_token.tk != tkID && m_token.tk != tkSUPER && m_token.tk != tkLCurly && m_token.tk != tkLBrack)
+        if (m_token.tk != tkID && m_token.tk != tkTHIS && m_token.tk != tkSUPER && m_token.tk != tkLCurly && m_token.tk != tkLBrack)
         {
             if (isDecl)
             {
@@ -12387,7 +12387,7 @@ ParseNodePtr Parser::ParseDestructuredVarDecl(tokens declarationType, bool isDec
             pnodeElem = ParsePostfixOperators<buildAST>(pnodeElem, TRUE, FALSE, FALSE, &fCanAssign, &token);
         }
     }
-    else if (m_token.tk == tkSUPER || m_token.tk == tkID)
+    else if (m_token.tk == tkSUPER || m_token.tk == tkID || m_token.tk == tkTHIS)
     {
         if (isDecl)
         {

--- a/test/es6/destructuring_bugs.js
+++ b/test/es6/destructuring_bugs.js
@@ -443,16 +443,30 @@ var tests = [
         assert.areEqual(c4, 35, "The variable in the enclosing scope should not have been changed.");
         assert.areEqual(d4, 20, "The variable in the enclosing scope should not have been changed.");
     }
-},
-{
+  },
+  {
     name: "Destructuring pattern with rest parameter has nested blocks.",
     body: function () {
-    [...((a5))] = [1, 2, 3];
-    assert.areEqual(a5, [1, 2, 3], "The rest parameter with extra parentheses gets assigned correctly.");
+       [...((a5))] = [1, 2, 3];
+       assert.areEqual(a5, [1, 2, 3], "The rest parameter with extra parentheses gets assigned correctly.");
 
-    assert.doesNotThrow(function () { eval("[...((a))] = [1, 2, 3]") }, "Should not throw when rest parameter name is enclosed in extra parentheses.");
+       assert.doesNotThrow(function () { eval("[...((a))] = [1, 2, 3]") }, "Should not throw when rest parameter name is enclosed in extra parentheses.");
     }
-}
+  },
+  {
+    name: "Destructuring bug fix - a reference from a 'this' object should be valid statement",
+    body: function () {
+      assert.doesNotThrow(function () { [this.x] = []; }, "array destructuring - referencing x from this in pattern is a correct syntax" );
+      assert.doesNotThrow(function () { ({x:this.x} = {}); }, "object destructuring - referencing x from this in pattern is a correct syntax" );
+      (function () {
+          this.x = 1, this.y = 2;
+          [this.x, this.y] = [this.y, this.x];
+          assert.areEqual(this.x, 2);
+          assert.areEqual(this.y, 1);
+      })();
+      assert.doesNotThrow(function () { [...this.x] = [1]; }, "array destructuring rest - referencing x from this in pattern is a correct syntax" );
+    }
+  },
 ];
 
 testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });


### PR DESCRIPTION
tkTHIS was not handled when we allow the reference for destructuring expression. Fixed that.
