### PR TITLE
move fixup check to be behind flag

### DIFF
--- a/lib/Backend/Func.cpp
+++ b/lib/Backend/Func.cpp
@@ -569,20 +569,23 @@ Func::TryCodegen()
                     next1->fixupFunc(next1->data, chunk);
                 }
 #if DBG
-                // Scan memory to see if there's missing pointer needs to be fixed up
-                // This can hit false positive if some data field happens to have value 
-                // falls into the NativeCodeData memory range.
-                NativeCodeData::DataChunk *next2 = chunk;
-                while (next2)
+                if (CONFIG_FLAG(OOPJITFixupValidate))
                 {
-                    for (unsigned int i = 0; i < next1->len / sizeof(void*); i++)
+                    // Scan memory to see if there's missing pointer needs to be fixed up
+                    // This can hit false positive if some data field happens to have value 
+                    // falls into the NativeCodeData memory range.
+                    NativeCodeData::DataChunk *next2 = chunk;
+                    while (next2)
                     {
-                        if (((void**)next1->data)[i] == (void*)next2->data)
+                        for (unsigned int i = 0; i < next1->len / sizeof(void*); i++)
                         {
-                            NativeCodeData::VerifyExistFixupEntry((void*)next2->data, &((void**)next1->data)[i], next1->data);
+                            if (((void**)next1->data)[i] == (void*)next2->data)
+                            {
+                                NativeCodeData::VerifyExistFixupEntry((void*)next2->data, &((void**)next1->data)[i], next1->data);
+                            }
                         }
+                        next2 = next2->next;
                     }
-                    next2 = next2->next;
                 }
 #endif
                 next1 = next1->next;

--- a/lib/Backend/NativeCodeData.cpp
+++ b/lib/Backend/NativeCodeData.cpp
@@ -54,13 +54,16 @@ NativeCodeData::AddFixupEntry(void* targetAddr, void* targetStartAddr, void* add
     Assert(targetChunk->len >= inDataOffset);
 
 #if DBG
-    bool foundTargetChunk = false;
-    while (chunkList)
+    if (CONFIG_FLAG(OOPJITFixupValidate))
     {
-        foundTargetChunk |= (chunkList == targetChunk);
-        chunkList = chunkList->next;
+        bool foundTargetChunk = false;
+        while (chunkList)
+        {
+            foundTargetChunk |= (chunkList == targetChunk);
+            chunkList = chunkList->next;
+        }
+        AssertMsg(foundTargetChunk, "current pointer is not allocated with NativeCodeData allocator?"); // change to valid check instead of assertion?
     }
-    AssertMsg(foundTargetChunk, "current pointer is not allocated with NativeCodeData allocator?"); // change to valid check instead of assertion?
 #endif
 
     DataChunk* chunk = NativeCodeData::GetDataChunk(startAddress);

--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -836,6 +836,7 @@ PHASE(All)
 #if DBG
 FLAGNR(Boolean, ArrayValidate         , "Validate each array for valid elements (default: false)", false)
 FLAGNR(Boolean, MemOpMissingValueValidate, "Validate Missing Value Tracking on memset/memcopy", false)
+FLAGNR(Boolean, OOPJITFixupValidate, "Validate that all entries in fixup list are allocated as NativeCodeData and that all NativeCodeData gets fixed up", false)
 #endif
 #ifdef ARENA_MEMORY_VERIFY
 FLAGNR(Boolean, ArenaNoFreeList       , "Do not free list in arena", false)


### PR DESCRIPTION
Fixup check is very expensive, and was leading to some test timeouts. Since OOP JIT is stable, put this check behind a flag