### PR TITLE
register wasm created Utf8SourceInfo with ScriptContext

### DIFF
--- a/test/AsmJs/rlexe.xml
+++ b/test/AsmJs/rlexe.xml
@@ -14,7 +14,7 @@
       <compile-flags>-testtrace:asmjs -simdjs</compile-flags>
     </default>
   </test>
-    <test>
+  <test>
     <default>
       <files>BasicBranching.js</files>
       <baseline>BasicBranchingLinkFail.baseline</baseline>
@@ -813,6 +813,8 @@
       <baseline>vardeclnorhs.baseline</baseline>
       <compile-flags>-testtrace:asmjs -maic:1</compile-flags>
     </default>
+  </test>
+  <test>
     <default>
       <files>bugGH2270.js</files>
     </default>


### PR DESCRIPTION
ScriptContext::close cleans up all FunctionBody/EntryPointInfos
before destroying native code generator. On xplat this order
is required because EntryPointInfo finalizer may need to deregister
debug data which is managed by native code generator.

Register wasm created Utf8SourceInfo with ScriptContext, so that
ScriptContext can guarantee above shutdown order with wasm created
FunctionBody/EntryPointInfos.

Fix #2517 

Also fixes a rlexe.xml syntax error, seen from CI output.