### PR TITLE
Yield at catch param binding pattern.

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -11670,6 +11670,13 @@ void Emit(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator, FuncInfo *func
             byteCodeGenerator->StartStatement(pnodeCatch);
             ParseNodePtr pnode1 = pnodeObj->sxParamPattern.pnode1;
             Assert(pnode1->IsPattern());
+
+            ByteCodeGenerator::TryScopeRecord tryRecForCatch(Js::OpCode::ResumeCatch, catchLabel);
+            if (funcInfo->byteCodeFunction->IsCoroutine())
+            {
+                byteCodeGenerator->tryScopeRecordsList.LinkToEnd(&tryRecForCatch);
+            }
+
             EmitAssignment(nullptr, pnode1, location, byteCodeGenerator, funcInfo);
             byteCodeGenerator->EndStatement(pnodeCatch);
         }
@@ -11686,12 +11693,12 @@ void Emit(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator, FuncInfo *func
             byteCodeGenerator->StartStatement(pnodeCatch);
             byteCodeGenerator->Writer()->Empty(Js::OpCode::Nop);
             byteCodeGenerator->EndStatement(pnodeCatch);
-        }
 
-        ByteCodeGenerator::TryScopeRecord tryRecForCatch(Js::OpCode::ResumeCatch, catchLabel);
-        if (funcInfo->byteCodeFunction->IsCoroutine())
-        {
-            byteCodeGenerator->tryScopeRecordsList.LinkToEnd(&tryRecForCatch);
+            ByteCodeGenerator::TryScopeRecord tryRecForCatch(Js::OpCode::ResumeCatch, catchLabel);
+            if (funcInfo->byteCodeFunction->IsCoroutine())
+            {
+                byteCodeGenerator->tryScopeRecordsList.LinkToEnd(&tryRecForCatch);
+            }
         }
 
         Emit(pnodeCatch->sxCatch.pnodeBody, byteCodeGenerator, funcInfo, fReturnValue);

--- a/test/es6/destructuring_bugs.js
+++ b/test/es6/destructuring_bugs.js
@@ -467,6 +467,34 @@ var tests = [
       assert.doesNotThrow(function () { [...this.x] = [1]; }, "array destructuring rest - referencing x from this in pattern is a correct syntax" );
     }
   },
+  {
+    name: "array destructuring as catch parameter can yield properly",
+    body: function () {
+        function * gn() {
+          try {
+            throw [];
+          } catch ([c = (yield 2)]) {
+          }
+        };
+        var it = gn();
+        var k = it.next();
+        assert.areEqual(2, k.value, "next should invoke the yield in the generator and which yields 2");
+    }
+  },
+  {
+    name: "array destructuring nested as catch parameter can yield properly",
+    body: function () {
+        function * gn() {
+          try {
+            throw [{x:[]}];
+          } catch ([{x:[c = (yield 2)]}]) {
+          }
+        };
+        var it = gn();
+        var k = it.next();
+        assert.areEqual(2, k.value, "next should invoke the yield in the generator and which yields 2");
+    }
+  }
 ];
 
 testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });


### PR DESCRIPTION
The yielding at catch param place gone wrong when there is destructuring. It had happened because the we were not doing correct book-keeping for catch block for the pattern. Fixed that by recording just before assignment.
