### PR TITLE
Fix byte code gen with block-scoped function called from with and captured elsewhere.

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -1687,7 +1687,9 @@ Symbol * ByteCodeGenerator::FindSymbol(Symbol **symRef, IdentPtr pid, bool forRe
             sym->SetHasRealBlockVarRef();
         }
 
-        if (nonLocalRef)
+        // This may not be a non-local reference, but the symbol may still be accessed non-locally. ('with', e.g.)
+        // In that case, make sure we still process the symbol and its scope for closure capture.
+        if (nonLocalRef || sym->GetHasNonLocalReference())
         {
             // Symbol referenced through a closure. Mark it as such and give it a property ID.
             this->ProcessCapturedSym(sym);

--- a/test/Closures/bug_OS_10735999.js
+++ b/test/Closures/bug_OS_10735999.js
@@ -1,0 +1,25 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function test0() {
+    var obj1 = {};
+    var func0 = function () {
+        if (true) {
+            function func5() {
+                return function () {
+                    (function () {
+                        func5;
+                    });
+                }();
+            }
+            with ({}) {
+                argMath2 = func5.call(obj1);
+            }
+        }
+    };
+    func0();
+}
+test0();
+WScript.Echo('pass');

--- a/test/Closures/rlexe.xml
+++ b/test/Closures/rlexe.xml
@@ -164,4 +164,10 @@
       <tags>BugFix,exclude_dynapogo</tags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>bug_OS_10735999.js</files>
+      <tags>BugFix</tags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
 Make sure that if some references to a block-scoped function are optimized to refer to the var-scoped binding and others are not, and both bindings are marked for closure capture, then both scopes are processed accordingly.