### PR TITLE
Dev15 build

### DIFF
--- a/Build/Common.Build.Default.props
+++ b/Build/Common.Build.Default.props
@@ -9,10 +9,10 @@
 
   <!-- Auto tool set selection -->
   <PropertyGroup>
-    <PlatformToolset Condition="'$(VisualStudioVersion)'=='11.0'">v110</PlatformToolset>
-    <PlatformToolset Condition="'$(VisualStudioVersion)'=='12.0'">v120</PlatformToolset>
-    <PlatformToolset Condition="'$(VisualStudioVersion)'=='14.0'">v140</PlatformToolset>
-    <PlatformToolset Condition="'$(VisualStudioVersion)'=='15.0'">v141</PlatformToolset> 
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='11.0' or '$(MSBuildToolsVersion)'=='11.0'">v110</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='12.0' or '$(MSBuildToolsVersion)'=='12.0'">v120</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='14.0' or '$(MSBuildToolsVersion)'=='14.0'">v140</PlatformToolset>
+    <PlatformToolset Condition="'$(VisualStudioVersion)'=='15.0' or '$(MSBuildToolsVersion)'=='15.0'">v141</PlatformToolset>
   </PropertyGroup>
 
   <!-- Default ChakraDevConfigDir -->
@@ -57,7 +57,7 @@
   <PropertyGroup>
     <OutBaseDir Condition="'$(OutBaseDir)'!=''">$(OutBaseDir)\$(SolutionName)</OutBaseDir>
     <OutBaseDir Condition="'$(OutBaseDir)'==''">$(SolutionDir)VcBuild</OutBaseDir>
-    <OutBaseDir Condition="'$(Clang)'!=''">$(OutBaseDir).$(Clang)</OutBaseDir>    
+    <OutBaseDir Condition="'$(Clang)'!=''">$(OutBaseDir).$(Clang)</OutBaseDir>
     <OutBaseDir Condition="'$(BuildJIT)'=='false'">$(OutBaseDir).NoJIT</OutBaseDir>
     <OutBaseDir Condition="'$(ForceSWB)'=='true'">$(OutBaseDir).SWB</OutBaseDir>
     <IntBaseDir Condition="'$(IntBaseDir)'==''">$(OutBaseDir)</IntBaseDir>

--- a/bin/NativeTests/NativeTests.cpp
+++ b/bin/NativeTests/NativeTests.cpp
@@ -5,7 +5,10 @@
 #include "stdafx.h"
 
 #define CATCH_CONFIG_RUNNER
+#pragma warning(push)
+#pragma warning(disable:4244)
 #include "catch.hpp"
+#pragma warning(pop)
 
 // Use nativetests.exe -? to get all command line options
 


### PR DESCRIPTION
Disable warning for catch.hpp that happens on dev15 
Use MSBuildToolsVersion to check for which toolset to use when using msbuild15 directly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/2557)
<!-- Reviewable:end -->
