### PR TITLE
enable write barrier checker clang plugin in CI build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -408,11 +408,9 @@ fi
 WB_FLAG=
 WB_TARGET=
 if [[ $WB_CHECK || $WB_ANALYZE ]]; then
+    # build software write barrier checker clang plugin
     $CHAKRACORE_DIR/tools/RecyclerChecker/build.sh || exit 1
 
-    if [[ $MAKE != 'ninja' ]]; then
-        echo "--wb-check/wb-analyze only works with --ninja" && exit 1
-    fi
     if [[ $WB_CHECK && $WB_ANALYZE ]]; then
         echo "Please run only one of --wb-check or --wb-analyze" && exit 1
     fi
@@ -432,7 +430,12 @@ if [[ $WB_CHECK || $WB_ANALYZE ]]; then
         WB_ARGS="-DWB_ARGS_SH=$WB_ARGS"
     fi
 
+    # support --wb-check ONE_CPP_FILE
     if [[ $WB_FILE != "*" ]]; then
+        if [[ $MAKE != 'ninja' ]]; then
+            echo "--wb-check/wb-analyze ONE_FILE only works with --ninja" && exit 1
+        fi
+
         if [[ -f $CHAKRACORE_DIR/$WB_FILE ]]; then
             touch $CHAKRACORE_DIR/$WB_FILE
         else

--- a/netci.groovy
+++ b/netci.groovy
@@ -122,9 +122,11 @@ def CreateXPlatBuildTask = { isPR, buildType, staticBuild, machine, platform, co
     def infoScript = "bash jenkins/get_system_info.sh --${platform}"
     def buildFlag = buildType == "release" ? "" : (buildType == "debug" ? "--debug" : "--test-build")
     def staticFlag = staticBuild ? "--static" : ""
+    def swbCheckFlag = (platform == "linux" && buildType == "debug" && !staticBuild) ? "--wb-check" : "";
     def icuFlag = (platform == "osx" ? "--icu=/usr/local/opt/icu4c/include" : "")
     def compilerPaths = (platform == "osx") ? "" : "--cxx=/usr/bin/clang++-3.8 --cc=/usr/bin/clang-3.8"
-    def buildScript = "bash ./build.sh ${staticFlag} -j=`${numConcurrentCommand}` ${buildFlag} ${compilerPaths} ${icuFlag} ${customOption}"
+    def buildScript = "bash ./build.sh ${staticFlag} -j=`${numConcurrentCommand}` ${buildFlag} " +
+                      "${swbCheckFlag} ${compilerPaths} ${icuFlag} ${customOption}"
     def testScript = "bash test/runtests.sh \"${testVariant}\""
 
     def newJob = job(jobName) {

--- a/tools/RecyclerChecker/RecyclerChecker.cpp
+++ b/tools/RecyclerChecker/RecyclerChecker.cpp
@@ -101,7 +101,9 @@ void MainVisitor::ProcessUnbarriedFields(CXXRecordDecl* recordDecl,
     const auto& sourceMgr = _compilerInstance.getSourceManager();
     DiagnosticsEngine& diagEngine = _context.getDiagnostics();
     const unsigned diagID = diagEngine.getCustomDiagID(
-        DiagnosticsEngine::Error, "Unbarried field");
+        DiagnosticsEngine::Error,
+        "Unbarried field, see "
+        "https://github.com/microsoft/ChakraCore/wiki/Software-Write-Barrier#coding-rules");
 
     for (auto field : recordDecl->fields())
     {


### PR DESCRIPTION
Enable the checker plugin in linux_debug CI build. The checker
will help prevent missing write barrier annotations in PRs.