### PR TITLE
enable write barrier checker clang plugin in CI build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -408,11 +408,9 @@ fi
 WB_FLAG=
 WB_TARGET=
 if [[ $WB_CHECK || $WB_ANALYZE ]]; then
-    $CHAKRACORE_DIR/tools/RecyclerChecker/build.sh || exit 1
+    # build software write barrier checker clang plugin
+    $CHAKRACORE_DIR/tools/RecyclerChecker/build.sh --cxx=$_CXX || exit 1
 
-    if [[ $MAKE != 'ninja' ]]; then
-        echo "--wb-check/wb-analyze only works with --ninja" && exit 1
-    fi
     if [[ $WB_CHECK && $WB_ANALYZE ]]; then
         echo "Please run only one of --wb-check or --wb-analyze" && exit 1
     fi
@@ -432,7 +430,12 @@ if [[ $WB_CHECK || $WB_ANALYZE ]]; then
         WB_ARGS="-DWB_ARGS_SH=$WB_ARGS"
     fi
 
+    # support --wb-check ONE_CPP_FILE
     if [[ $WB_FILE != "*" ]]; then
+        if [[ $MAKE != 'ninja' ]]; then
+            echo "--wb-check/wb-analyze ONE_FILE only works with --ninja" && exit 1
+        fi
+
         if [[ -f $CHAKRACORE_DIR/$WB_FILE ]]; then
             touch $CHAKRACORE_DIR/$WB_FILE
         else

--- a/netci.groovy
+++ b/netci.groovy
@@ -122,9 +122,11 @@ def CreateXPlatBuildTask = { isPR, buildType, staticBuild, machine, platform, co
     def infoScript = "bash jenkins/get_system_info.sh --${platform}"
     def buildFlag = buildType == "release" ? "" : (buildType == "debug" ? "--debug" : "--test-build")
     def staticFlag = staticBuild ? "--static" : ""
+    def swbCheckFlag = (platform == "linux" && buildType == "debug" && !staticBuild) ? "--wb-check" : "";
     def icuFlag = (platform == "osx" ? "--icu=/usr/local/opt/icu4c/include" : "")
     def compilerPaths = (platform == "osx") ? "" : "--cxx=/usr/bin/clang++-3.8 --cc=/usr/bin/clang-3.8"
-    def buildScript = "bash ./build.sh ${staticFlag} -j=`${numConcurrentCommand}` ${buildFlag} ${compilerPaths} ${icuFlag} ${customOption}"
+    def buildScript = "bash ./build.sh ${staticFlag} -j=`${numConcurrentCommand}` ${buildFlag} " +
+                      "${swbCheckFlag} ${compilerPaths} ${icuFlag} ${customOption}"
     def testScript = "bash test/runtests.sh \"${testVariant}\""
 
     def newJob = job(jobName) {

--- a/tools/RecyclerChecker/RecyclerChecker.cpp
+++ b/tools/RecyclerChecker/RecyclerChecker.cpp
@@ -89,8 +89,8 @@ bool MainVisitor::VisitCXXRecordDecl(CXXRecordDecl* recordDecl)
 }
 
 template <class PushFieldType>
-void MainVisitor::ProcessUnbarriedFields(CXXRecordDecl* recordDecl,
-                                         const PushFieldType& pushFieldType)
+void MainVisitor::ProcessUnbarrieredFields(
+    CXXRecordDecl* recordDecl, const PushFieldType& pushFieldType)
 {
     std::string typeName = recordDecl->getQualifiedNameAsString();
     if (typeName == "Memory::WriteBarrierPtr")
@@ -101,7 +101,9 @@ void MainVisitor::ProcessUnbarriedFields(CXXRecordDecl* recordDecl,
     const auto& sourceMgr = _compilerInstance.getSourceManager();
     DiagnosticsEngine& diagEngine = _context.getDiagnostics();
     const unsigned diagID = diagEngine.getCustomDiagID(
-        DiagnosticsEngine::Error, "Unbarried field");
+        DiagnosticsEngine::Error,
+        "Unbarriered field, see "
+        "https://github.com/microsoft/ChakraCore/wiki/Software-Write-Barrier#coding-rules");
 
     for (auto field : recordDecl->fields())
     {
@@ -419,7 +421,7 @@ void MainVisitor::Inspect()
         if (r)
         {
             auto typeName = r->getQualifiedNameAsString();
-            ProcessUnbarriedFields(r, pushBarrierType);
+            ProcessUnbarrieredFields(r, pushBarrierType);
 
             // queue the type's base classes
             for (const auto& base: r->bases())

--- a/tools/RecyclerChecker/RecyclerChecker.h
+++ b/tools/RecyclerChecker/RecyclerChecker.h
@@ -69,7 +69,7 @@ private:
     void dump(const char* name, const unordered_set<const Type*> set);
 
     template <class PushFieldType>
-    void ProcessUnbarriedFields(CXXRecordDecl* recordDecl, const PushFieldType& pushFieldType);
+    void ProcessUnbarrieredFields(CXXRecordDecl* recordDecl, const PushFieldType& pushFieldType);
 
     bool MatchType(const string& type, const char* source, const char** pSourceEnd);
     const char* GetFieldTypeAnnotation(QualType qtype);

--- a/tools/RecyclerChecker/build.sh
+++ b/tools/RecyclerChecker/build.sh
@@ -12,12 +12,14 @@ echo ""
 echo "options:"
 echo "  -h, --help          Show help"
 echo "  --clang-inc=PATH    clang development include path"
+echo "  --cxx=PATH          Path to c++ compiler"
 echo "  --llvm-config=PATH  llvm-config executable"
 echo ""
 }
 
 SCRIPT_DIR=`dirname $0`
 CLANG_INC=
+CXX_COMPILER=
 LLVM_CONFIG=
 
 while [[ $# -gt 0 ]]; do
@@ -25,6 +27,11 @@ while [[ $# -gt 0 ]]; do
     --clang-inc=*)
         CLANG_INC=$1
         CLANG_INC="${CLANG_INC:12}"
+        ;;
+
+    --cxx=*)
+        CXX_COMPILER=$1
+        CXX_COMPILER=${CXX_COMPILER:6}
         ;;
 
     -h | --help)
@@ -46,10 +53,17 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ $CLANG_INC ]]; then
+    echo "CLANG_INCLUDE_DIRS: $CLANG_INC"
     CLANG_INC="-DCLANG_INCLUDE_DIRS:STRING=$CLANG_INC"
 fi
 
+if [[ $CXX_COMPILER ]]; then
+    echo "CXX_COMPILER: $CXX_COMPILER"
+    CXX_COMPILER="-DCMAKE_CXX_COMPILER=$CXX_COMPILER"
+fi
+
 if [[ $LLVM_CONFIG ]]; then
+    echo "LLVM_CONFIG: $LLVM_CONFIG"
     LLVM_CONFIG="-DLLVM_CONFIG_EXECUTABLE:STRING=$LLVM_CONFIG"
 fi
 
@@ -59,9 +73,8 @@ pushd $BUILD_DIR > /dev/null
 
 cmake \
     $CLANG_INC \
+    $CXX_COMPILER \
     $LLVM_CONFIG \
-    -DCMAKE_CXX_COMPILER=/usr/bin/g++ \
-    -DCMAKE_BUILD_TYPE=Debug \
     .. \
 && make
 _RET=$?


### PR DESCRIPTION
Enable the checker plugin in linux_debug CI build. The checker
will help prevent missing write barrier annotations in PRs.