### PR TITLE
Large Constant Encoding revert

### DIFF
--- a/lib/Backend/Security.cpp
+++ b/lib/Backend/Security.cpp
@@ -240,7 +240,11 @@ Security::EncodeOpnd(IR::Instr *instr, IR::Opnd *opnd)
     {
         IR::IntConstOpnd *intConstOpnd = opnd->AsIntConstOpnd();
 
-        if (!this->IsLargeConstant(intConstOpnd->GetValue()))
+        if (
+#if TARGET_64
+            (IRType_IsInt64(intConstOpnd->GetType()) && !this->IsLargeConstant(intConstOpnd->GetValue())) ||
+#endif
+            !this->IsLargeConstant(intConstOpnd->AsInt32()))
         {
             return;
         }


### PR DESCRIPTION
Revert change made when encoding large constant for Wasm bug as it has a big perf impact. 
Reverts part of #2371

Jetstream perf

```
JetStream      Left score     Right score    ∆ Score  ∆ Score %  Comment
-------------  -------------  -------------  -------  ---------  --------
Bigfib.cpp     302.76 ±0.19%  332.25 ±0.19%    29.49      9.74%  Improved
Cdjs           153.57 ±0.57%  153.86 ±0.77%     0.29      0.19%
Container.cpp  308.72 ±0.16%  319.80 ±0.19%    11.08      3.59%  Improved
Dry.c          317.13 ±0.23%  354.33 ±0.10%    37.20     11.73%  Improved
Float-mm.c     363.87 ±0.20%  377.51 ±0.14%    13.64      3.75%  Improved
Gcc-loops.cpp  370.47 ±0.02%  458.92 ±0.01%    88.46     23.88%  Improved
Hash-map       145.78 ±0.52%  146.37 ±0.26%     0.59      0.40%
N-body.c       264.93 ±0.16%  306.27 ±0.13%    41.33     15.60%  Improved
Quicksort.c    237.85 ±0.10%  247.85 ±0.10%    10.00      4.20%  Improved
Towers.c       253.84 ±0.49%  256.77 ±0.33%     2.93      1.15%
-------------  -------------  -------------  -------  ---------  --------
Total          260.35 ±0.27%  279.05 ±0.22%    18.70      7.18%  Improved
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/2577)
<!-- Reviewable:end -->
