### PR TITLE
Fix parsing a lambda consisting of a single statement wrapped in parens

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -2987,6 +2987,11 @@ ParseNodePtr Parser::ParseTerm(BOOL fAllowCall,
         pnode = ParseExpr<buildAST>(koplNo, &fCanAssign, TRUE, FALSE, nullptr, nullptr /*nameLength*/, nullptr  /*pShortNameOffset*/, &term, true);
         this->m_parenDepth--;
 
+        if (buildAST)
+        {
+            this->m_lastRParen = m_pscan->IchLimTok();
+        }
+
         ChkCurTok(tkRParen, ERRnoRparen);
 
         GetCurrentBlock()->sxBlock.blockId = saveCurrBlockId;
@@ -6633,6 +6638,7 @@ void Parser::ParseExpressionLambdaBody(ParseNodePtr pnodeLambda)
     }
 
     IdentToken token;
+    this->m_lastRParen = 0;
     ParseNodePtr result = ParseExpr<buildAST>(koplAsg, nullptr, TRUE, FALSE, nullptr, nullptr, nullptr, &token);
 
     this->MarkEscapingRef(result, &token);
@@ -6649,7 +6655,7 @@ void Parser::ParseExpressionLambdaBody(ParseNodePtr pnodeLambda)
         pnodeRet->sxStmt.grfnop = 0;
         pnodeRet->sxStmt.pnodeOuter = nullptr;
 
-        pnodeLambda->ichLim = pnodeRet->ichLim;
+        pnodeLambda->ichLim = max(pnodeRet->ichLim, this->m_lastRParen);
         pnodeLambda->sxFnc.cbLim = m_pscan->IecpLimTokPrevious();
         pnodeLambda->sxFnc.pnodeScopes->ichLim = pnodeRet->ichLim;
 

--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -2860,7 +2860,7 @@ ParseNodePtr Parser::ParseTerm(BOOL fAllowCall,
     _Out_opt_ BOOL* pfCanAssign /*= nullptr*/,
     _Inout_opt_ BOOL* pfLikelyPattern /*= nullptr*/,
     _Out_opt_ bool* pfIsDotOrIndex /*= nullptr*/,
-    _Out_opt_ charcount_t *plastRParen /*= nullptr*/)
+    _Inout_opt_ charcount_t *plastRParen /*= nullptr*/)
 {
     ParseNodePtr pnode = nullptr;
     charcount_t ichMin = 0;
@@ -8059,7 +8059,7 @@ ParseNodePtr Parser::ParseExpr(int oplMin,
     _Inout_opt_ IdentToken* pToken,
     bool fUnaryOrParen,
     _Inout_opt_ bool* pfLikelyPattern,
-    _Out_opt_ charcount_t *plastRParen)
+    _Inout_opt_ charcount_t *plastRParen)
 {
     Assert(pToken == nullptr || pToken->tk == tkNone); // Must be empty initially
     int opl;

--- a/lib/Parser/Parse.h
+++ b/lib/Parser/Parse.h
@@ -824,7 +824,7 @@ private:
         _Inout_opt_ IdentToken* pToken = NULL,
         bool fUnaryOrParen = false,
         _Inout_opt_ bool* pfLikelyPattern = nullptr,
-        _Out_opt_ charcount_t *plastRParen = nullptr);
+        _Inout_opt_ charcount_t *plastRParen = nullptr);
 
     template<bool buildAST> ParseNodePtr ParseTerm(
         BOOL fAllowCall = TRUE,
@@ -836,7 +836,7 @@ private:
         _Out_opt_ BOOL* pfCanAssign = nullptr,
         _Inout_opt_ BOOL* pfLikelyPattern = nullptr,
         _Out_opt_ bool* pfIsDotOrIndex = nullptr,
-        _Out_opt_ charcount_t *plastRParen = nullptr);
+        _Inout_opt_ charcount_t *plastRParen = nullptr);
 
     template<bool buildAST> ParseNodePtr ParsePostfixOperators(
         ParseNodePtr pnode,

--- a/lib/Parser/Parse.h
+++ b/lib/Parser/Parse.h
@@ -195,6 +195,7 @@ private:
     bool                m_hasParallelJob;
     bool                m_doingFastScan;
     int                 m_nextBlockId;
+    charcount_t         m_lastRParen;
 
     // RegexPattern objects created for literal regexes are recycler-allocated and need to be kept alive until the function body
     // is created during byte code generation. The RegexPattern pointer is stored in the script context's guest

--- a/lib/Parser/Parse.h
+++ b/lib/Parser/Parse.h
@@ -195,7 +195,6 @@ private:
     bool                m_hasParallelJob;
     bool                m_doingFastScan;
     int                 m_nextBlockId;
-    charcount_t         m_lastRParen;
 
     // RegexPattern objects created for literal regexes are recycler-allocated and need to be kept alive until the function body
     // is created during byte code generation. The RegexPattern pointer is stored in the script context's guest
@@ -824,7 +823,9 @@ private:
         uint32 *pShortNameOffset = nullptr,
         _Inout_opt_ IdentToken* pToken = NULL,
         bool fUnaryOrParen = false,
-        _Inout_opt_ bool* pfLikelyPattern = nullptr);
+        _Inout_opt_ bool* pfLikelyPattern = nullptr,
+        _Out_opt_ charcount_t *plastRParen = nullptr);
+
     template<bool buildAST> ParseNodePtr ParseTerm(
         BOOL fAllowCall = TRUE,
         LPCOLESTR pNameHint = nullptr,
@@ -834,7 +835,9 @@ private:
         bool fUnaryOrParen = false,
         _Out_opt_ BOOL* pfCanAssign = nullptr,
         _Inout_opt_ BOOL* pfLikelyPattern = nullptr,
-        _Out_opt_ bool* pfIsDotOrIndex = nullptr);
+        _Out_opt_ bool* pfIsDotOrIndex = nullptr,
+        _Out_opt_ charcount_t *plastRParen = nullptr);
+
     template<bool buildAST> ParseNodePtr ParsePostfixOperators(
         ParseNodePtr pnode,
         BOOL fAllowCall, 

--- a/test/es6/lambda1.js
+++ b/test/es6/lambda1.js
@@ -454,6 +454,23 @@ var tests = [
             assert.throws(function () { eval('var a = {}; a.x \n => d;'); }, SyntaxError, "Verify that badly formed arrow functions return correct error even if a newline is before the => token", "Syntax error");
             assert.throws(function () { eval('var a = {}; a\n.x => d;'); }, SyntaxError, "Verify that badly formed arrow functions return correct error even if a newline is before the => token", "Syntax error");
         }
+    },
+    {
+        name: "Lambda consisting of single expression wrapped in parens should have correct source string",
+        body: function () {
+            var l = () => (123)
+            assert.areEqual('() => (123)', '' + l, "Lambda to string should include the parens wrapping the return expression");
+            
+            var l = () => (('๏บบ'))
+            assert.areEqual("() => (('๏บบ'))", '' + l, "Multi-byte characters should not break the string");
+            
+            var s = "() => ('\u{20ac}')";
+            var l = eval(s);
+            assert.areEqual(s, '' + l, "Unicode byte sequences should not break the string");
+            
+            var l = async() => ({});
+            assert.areEqual('async() => ({})', '' + l, "Async lambda should also be correct");
+        }
     }
 ];
 

--- a/test/es6/lambda1.js
+++ b/test/es6/lambda1.js
@@ -470,6 +470,12 @@ var tests = [
             
             var l = async() => ({});
             assert.areEqual('async() => ({})', '' + l, "Async lambda should also be correct");
+            
+            var l = () => (() => (123))
+            assert.areEqual('() => (() => (123))', '' + l, "Nested lambda to string should be correct");
+            
+            var l = async() => (async() => ('str'));
+            assert.areEqual("async() => (async() => ('str'))", '' + l, "Nested async lambda should be correct");
         }
     }
 ];


### PR DESCRIPTION
If we parse a lambda which only has a single statement which is wrapped
in parens but not curly braces, we calculate the extent of that lambda
parse node incorrectly.

var a = () => (123)

In above, the parse node for the lambda has it's limit character set to
the limit character of the return node - which is the numeric constant
123. The return node throws away the parens and, thus, the character
extents for the lambda as a whole are incorrectly pointing to the last
character of 123.

This is not a regression in behavior. In existing code, if you try to
toString a lambda like this it will get cutoff:

print('"' + a + '"'); // "() => (123"

However, after improving the utf8 parsing such that we correctly
calculate the extents of the bytes we need to parse, toString of the
lambda will hit an assert due to the mismatch in expected length and
actual characters parsed.

Fix here is to keep track of the last right paren we parsed when we're
parsing the lambda body expression and use that instead of the character
extent of the return parse node.