### PR TITLE
Fix incorrect deletion of unreachable InlineeEnd

### DIFF
--- a/lib/Backend/FlowGraph.h
+++ b/lib/Backend/FlowGraph.h
@@ -166,6 +166,7 @@ public:
     static void  SafeRemoveInstr(IR::Instr *instr);
     void         SortLoopLists();
     FlowEdge *   FindEdge(BasicBlock *predBlock, BasicBlock *succBlock);
+    void         UpwardInlineeEndBeforeRemoving(BasicBlock * block, IR::Instr * inlineeEnd);
 
 #if DBG_DUMP
     void         Dump();

--- a/lib/Backend/TempTracker.cpp
+++ b/lib/Backend/TempTracker.cpp
@@ -576,9 +576,18 @@ NumberTemp::ProcessInstr(IR::Instr * instr, BackwardPass * backwardPass)
 #if DBG
     if (instr->m_opcode == Js::OpCode::BailOnNoProfile)
     {
-        // If we see BailOnNoProfile, we shouldn't have any successor to have any non temp syms
+        // If we see BailOnNoProfile, we shouldn't have any successor to have any non temp syms except InlineeEnd
         Assert(!this->nonTempElemLoad);
-        Assert(this->nonTempSyms.IsEmpty());
+
+        if(!this->nonTempSyms.IsEmpty())
+        {
+            // The only non temp which could be live at BailOnNoProfile is the 2nd operand for following InlineeEnd
+            IR::Instr * nextInstr = instr->m_next;
+            Assert(nextInstr && nextInstr->m_opcode == Js::OpCode::InlineeEnd);
+            Assert(this->nonTempSyms.Count() == 1 &&
+                this->nonTempSyms.Test(nextInstr->GetSrc2()->GetStackSym()->m_id));
+        }
+
         Assert(this->tempTransferredSyms.IsEmpty());
         Assert(this->elemLoadDependencies.IsEmpty());
         Assert(this->upwardExposedMarkTempObjectLiveFields.IsEmpty());


### PR DESCRIPTION
When there is `InlineeEnd` IR instruction in successor block following the block with `BailOnNoProfile`, the succesor block will be considered as dead if there is no other incoming block (or other incoming blocks are also dead). GlobOpt removes such dead block in the begining of `GlobOpt::OptBlock`  so no fall through instructions after `BailOnNoProfile`. But LinearScan only generates `InlineeFrameRecord` when handling `InlineeEnd`, and previous deletion of `InlineeEnd` could lead to incorrect generation of `InlineeFrameRecord`.