### PR TITLE
build-bug: fix C linkage

### DIFF
--- a/lib/Jsrt/ChakraCommon.h
+++ b/lib/Jsrt/ChakraCommon.h
@@ -331,7 +331,11 @@ typedef unsigned short uint16_t;
     /// <summary>
     ///     An invalid runtime handle.
     /// </summary>
+#ifdef __cplusplus
     const JsRuntimeHandle JS_INVALID_RUNTIME_HANDLE = 0;
+#else
+    #define JS_INVALID_RUNTIME_HANDLE (JsRuntimeHandle)0
+#endif
 
     /// <summary>
     ///     A reference to an object owned by the Chakra garbage collector.
@@ -348,7 +352,11 @@ typedef unsigned short uint16_t;
     /// <summary>
     ///     An invalid reference.
     /// </summary>
+#ifdef __cplusplus
     const JsRef JS_INVALID_REFERENCE = 0;
+#else
+    #define JS_INVALID_REFERENCE (JsRef)0
+#endif
 
     /// <summary>
     ///     A reference to a script context.
@@ -383,7 +391,11 @@ typedef unsigned short uint16_t;
     /// <summary>
     ///     An empty source context.
     /// </summary>
+#ifdef __cplusplus
     const JsSourceContext JS_SOURCE_CONTEXT_NONE = (JsSourceContext)-1;
+#else
+    #define JS_SOURCE_CONTEXT_NONE (JsSourceContext)-1
+#endif
 
     /// <summary>
     ///     A property identifier.

--- a/test/native-tests/test-char/Platform.js
+++ b/test/native-tests/test-char/Platform.js
@@ -24,7 +24,7 @@ LDIR=$(LIBRARY_PATH)/libChakraCoreStatic.a \n\
 \n\
 ifeq (darwin, ${PLATFORM})\n\
 \tICU4C_LIBRARY_PATH ?= /usr/local/opt/icu4c\n\
-\tCFLAGS=-lstdc++ -std=c++11 -I$(IDIR)\n\
+\tCFLAGS=-lstdc++ -I$(IDIR)\n\
 \tFORCE_STARTS=-Wl,-force_load,\n\
 \tFORCE_ENDS=\n\
 \tLIBS=-framework CoreFoundation -framework Security -lm -ldl -Wno-c++11-compat-deprecated-writable-strings \
@@ -33,7 +33,7 @@ ifeq (darwin, ${PLATFORM})\n\
     $(ICU4C_LIBRARY_PATH)/lib/libicuuc.a \
     $(ICU4C_LIBRARY_PATH)/lib/libicui18n.a\n\
 else\n\
-\tCFLAGS=-lstdc++ -std=c++0x -I$(IDIR)\n\
+\tCFLAGS=-lstdc++ -I$(IDIR)\n\
 \tFORCE_STARTS=-Wl,--whole-archive\n\
 \tFORCE_ENDS=-Wl,--no-whole-archive\n\
 \tLIBS=-pthread -lm -ldl -licuuc -lunwind-x86_64 -Wno-c++11-compat-deprecated-writable-strings \
@@ -41,7 +41,7 @@ else\n\
 endif\n\
 \n\
 testmake:\n\
-\t$(CC) sample.cpp $(CFLAGS) $(FORCE_STARTS) $(LDIR) $(FORCE_ENDS) $(LIBS)\n\
+\t$(CC) sample.cpp dummy-1.c dummy-2.c $(CFLAGS) $(FORCE_STARTS) $(LDIR) $(FORCE_ENDS) $(LIBS)\n\
 \n\
 .PHONY: clean\n\
 \n\

--- a/test/native-tests/test-char/dummy-1.c
+++ b/test/native-tests/test-char/dummy-1.c
@@ -1,0 +1,12 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#include "ChakraCore.h"
+#include <stdio.h>
+
+void Dummy1()
+{
+    printf("Dummy1 \n");
+}

--- a/test/native-tests/test-char/dummy-2.c
+++ b/test/native-tests/test-char/dummy-2.c
@@ -1,0 +1,12 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#include "ChakraCore.h"
+#include <stdio.h>
+
+void Dummy2()
+{
+    printf("Dummy2 \n");
+}

--- a/test/native-tests/test-char/sample.cpp
+++ b/test/native-tests/test-char/sample.cpp
@@ -23,8 +23,22 @@
 
 using namespace std;
 
+// Test ChakraCore.h is being included by multiple C source files
+extern "C"
+{
+    void Dummy1();
+    void Dummy2();
+}
+
+#ifndef nullptr
+#define nullptr 0
+#endif
+
 int main()
 {
+    Dummy1();
+    Dummy2();
+
     JsRuntimeHandle runtime;
     JsContextRef context;
     JsValueRef result;


### PR DESCRIPTION
Global variable values are set on common header file breaks the link process. This happens only when two or more C source files includes ChakraCore.h

Also updated one of the native test cases to test this particular scenario and prevent future mistakes.

Fixes #2574 