### PR TITLE
No need to mark use of scope object if there are no bailouts in the function

### DIFF
--- a/lib/Backend/BackwardPass.cpp
+++ b/lib/Backend/BackwardPass.cpp
@@ -301,7 +301,7 @@ BackwardPass::MarkScopeObjSymUseForStackArgOpt()
     IR::Instr * instr = this->currentInstr;
     if (tag == Js::DeadStorePhase)
     {
-        if (instr->DoStackArgsOpt(this->func) && instr->m_func->GetScopeObjSym() != nullptr)
+        if (instr->DoStackArgsOpt(this->func) && instr->m_func->GetScopeObjSym() != nullptr && this->DoByteCodeUpwardExposedUsed())
         {
             if (this->currentBlock->byteCodeUpwardExposedUsed == nullptr)
             {


### PR DESCRIPTION
Marking a use of scope object sym for stack args optimization was creating bytecodeUpwardExposedUsed bit vector for the current block without checking if the function had a bailout. This led to an assert that expects no byteCodeUpwardExposedUsed bv to be allocated in the absence of any bailout in the function.

Fix is to add the mentioned check.