### PR TITLE
Check validity of memop on newly added typspec instructions

### DIFF
--- a/lib/Backend/GlobOpt.h
+++ b/lib/Backend/GlobOpt.h
@@ -1513,7 +1513,7 @@ private:
     ValueType               GetDivValueType(IR::Instr* instr, Value* src1Val, Value* src2Val, bool specialize);
 
     bool                    IsInstrInvalidForMemOp(IR::Instr *, Loop *, Value *, Value *);
-    bool                    CollectMemOpInfo(IR::Instr *, Value *, Value *);
+    bool                    CollectMemOpInfo(IR::Instr *, IR::Instr *, Value *, Value *);
     bool                    CollectMemOpStElementI(IR::Instr *, Loop *);
     bool                    CollectMemsetStElementI(IR::Instr *, Loop *);
     bool                    CollectMemcopyStElementI(IR::Instr *, Loop *);


### PR DESCRIPTION
When floattypespec is turned off either explicitly or via profile info, an
array copy loop may look like this in the IR :

    s32[LikelyCanBeTaggedValue_Int].var = LdElemI_A [s18[NativeFloatArray_NoMissingValues][seg: s50][segLen: s51][><].var+s48(s23).i32].var #00da  Bailout: #00e0 (BailOutOnImplicitCalls)
    s47(s32).f64    =  FromVar s32[LikelyCanBeTaggedValue_Int].var     #00e0  Bailout: #00e0 (BailOutNumberOnly)
    NoImplicitCallUses s18[NativeFloatArray_NoMissingValues][seg: s50][segLen: s51][><].var #00e0
    ByteCodeUses   s23, s32 #00e0
    [s18[NativeFloatArray_NoMissingValues][seg: s50][segLen: s51][><].var+s48(s23).u32].var = StElemI_A s47(s32).f64!  #00e0  Bailout: #00e0 (BailOutConventionalNativeArrayAccessOnly | BailOutOnArrayAccessHelperCall

The memcopy optimization can replace LdElem and StElem with a MemCopy. The
DeadStore pass is expected to cleanup rest of the loop. During deadstore,
the byteCodeUses instructions get removed and recorded. However FromVar
cannot be removed because it has a non dead storable bailout kind. The
FromVar instr was added during typespec and we need to check the validity
of memop of the current loop with the addition of these new instructions.
