### PR TITLE
ResetObject is setting undefined for internal properties

### DIFF
--- a/lib/Runtime/Library/JavascriptWeakMap.cpp
+++ b/lib/Runtime/Library/JavascriptWeakMap.cpp
@@ -32,6 +32,13 @@ namespace Js
             return nullptr;
         }
 
+        if (key->GetScriptContext()->GetLibrary()->GetUndefined() == weakMapKeyData)
+        {
+            // Assert to find out where this can happen.
+            Assert(false);
+            return nullptr;
+        }
+
         return static_cast<WeakMapKeyMap*>(weakMapKeyData);
     }
 

--- a/lib/Runtime/Types/DynamicObject.cpp
+++ b/lib/Runtime/Types/DynamicObject.cpp
@@ -689,17 +689,30 @@ namespace Js
         {
             this->SetInternalProperty(InternalPropertyIds::StackTrace, nullptr, PropertyOperation_None, nullptr);
         }
+        else
+        {
+            // Above GetInternalProperty fails - which means the stackTraceValue is filed with Missing result. Reset to null so that we will not restore it back below.
+            stackTraceValue = nullptr;
+        }
 
         Var weakMapKeyMapValue = nullptr;
         if (this->GetInternalProperty(this, InternalPropertyIds::WeakMapKeyMap, &weakMapKeyMapValue, nullptr, this->GetScriptContext()))
         {
             this->SetInternalProperty(InternalPropertyIds::WeakMapKeyMap, nullptr, PropertyOperation_Force, nullptr);
         }
+        else
+        {
+            weakMapKeyMapValue = nullptr;
+        }
 
         Var mutationBpValue = nullptr;
         if (this->GetInternalProperty(this, InternalPropertyIds::MutationBp, &mutationBpValue, nullptr, this->GetScriptContext()))
         {
             this->SetInternalProperty(InternalPropertyIds::MutationBp, nullptr, PropertyOperation_Force, nullptr);
+        }
+        else
+        {
+            mutationBpValue = nullptr;
         }
 
         if (keepProperties)


### PR DESCRIPTION
Once the GetInternalProperty fails the stackTraceValue (and others) are set to GetMissingPropertyResult. Later below in that function we  set the undefined object for such property which actually leads to crashes in the Weakmap functionality as we never expect it to be undefined.
Fixed this and put an assert just incase in the Weakmap we get undefined again.