### PR TITLE
Fix F12 issue with block scope optimization. 

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -1642,7 +1642,7 @@ Symbol * ByteCodeGenerator::FindSymbol(Symbol **symRef, IdentPtr pid, bool forRe
             // (with/eval), and if the function is not declared in a loop. (Loops are problematic, because as the loop
             // iterates different instances can be captured. If we always capture the var-scoped binding, then we
             // always get the latest instance, when we should get the instance belonging to the iteration that captured it.)
-            if (sym->GetHasNonLocalReference() && !this->scriptContext->IsScriptContextInSourceRundownOrDebugMode())
+            if (sym->GetHasNonLocalReference())
             {
                 if (!scope)
                 {

--- a/test/DebuggerCommon/blockScopeFunctionDeclarationSlotArrayTest.js.dbg.baseline
+++ b/test/DebuggerCommon/blockScopeFunctionDeclarationSlotArrayTest.js.dbg.baseline
@@ -21,7 +21,6 @@
     "this": "Object {...}",
     "arguments": "Object {...}",
     "locals": {
-      "f": "function function f() { }",
       "g": "function <large string>",
       "a": "number 1"
     }


### PR DESCRIPTION
We were not doing block scope optimization related to redeferral in F12 debug mode, but this causes inconsistency when a function object gets byte code accessing an enclosing block scope, and the function was instantiated in non-debug mode and thus has a closure environment not containing the block scope.