### PR TITLE
clear scopeInfo->scope to avoid GC false positive

### DIFF
--- a/lib/Common/Memory/HeapBlock.cpp
+++ b/lib/Common/Memory/HeapBlock.cpp
@@ -917,13 +917,9 @@ void HeapBlock::PrintVerifyMarkFailure(Recycler* recycler, char* objectAddress, 
                     return;
                 }
 
-                if ((offset == 0x20 // scope field in scopeInfo
-                    || (offset >= 0x30 && (offset &0xf)==0) // symbol array at the end of scopeInfo, can point to arena allocated propertyRecord
-                    )
+                if (offset >= 0x30 && (offset & 0xf) == 0 // symbol array at the end of scopeInfo, can point to arena allocated propertyRecord
                     && strstr(typeName, "Js::ScopeInfo") != nullptr)
                 {
-                    // Js::ScopeInfo scope field is arena allocated and can be reused in recycler
-                    // TODO: (leish)(swb) find a good location to clear/tag this field
                     dumpFalsePositive();
                     return;
                 }

--- a/lib/Runtime/ByteCode/ScopeInfo.cpp
+++ b/lib/Runtime/ByteCode/ScopeInfo.cpp
@@ -15,7 +15,7 @@ namespace Js
         bool needScopeSlot = !sym->GetIsArguments() && sym->GetHasNonLocalReference()
             && (!mapSymbolData->func->IsInnerArgumentsSymbol(sym) || mapSymbolData->func->GetHasArguments());
         Js::PropertyId scopeSlot = Constants::NoSlot;
-        
+
         if (sym->GetIsModuleExportStorage())
         {
             // Export symbols aren't in slots but we need to persist the fact that they are export storage
@@ -184,7 +184,7 @@ namespace Js
         // We will have to implement encoding block scope info to enable, which will also
         // enable defer parsing function that are in block scopes.
 
-        if (funcInfo->byteCodeFunction && 
+        if (funcInfo->byteCodeFunction &&
             funcInfo->byteCodeFunction->GetScopeInfo() != nullptr &&
             !funcInfo->byteCodeFunction->GetScopeInfo()->IsParentInfoOnly())
         {
@@ -223,7 +223,7 @@ namespace Js
                     {
                         Assert(currentScope->GetEnclosingScope() == funcInfo->GetFuncExprScope() &&
                             currentScope->GetEnclosingScope()->GetEnclosingScope() ==
-                            (parentFunc->IsGlobalFunction() && parentFunc->GetGlobalEvalBlockScope()->GetMustInstantiate() ? 
+                            (parentFunc->IsGlobalFunction() && parentFunc->GetGlobalEvalBlockScope()->GetMustInstantiate() ?
                              parentFunc->GetGlobalEvalBlockScope() : parentFunc->GetBodyScope()));
                     }
                 }
@@ -240,7 +240,7 @@ namespace Js
                     }
 #if 0
                     else
-                    { 
+                    {
                         Assert(currentScope->GetEnclosingScope() ==
                             (parentFunc->IsGlobalFunction() && parentFunc->GetGlobalEvalBlockScope() && parentFunc->GetGlobalEvalBlockScope()->GetMustInstantiate() ? parentFunc->GetGlobalEvalBlockScope() : parentFunc->GetBodyScope()));
                     }
@@ -285,6 +285,12 @@ namespace Js
             Assert(!this->isCached || scope == funcInfo->GetBodyScope());
             funcInfo->SetHasCachedScope(this->isCached);
             byteCodeGenerator->PushScope(scope);
+
+            // this->scope was created/saved during parsing and used by
+            // ByteCodeGenerator::RestoreScopeInfo. We no longer need it by now.
+            // Clear it to avoid GC false positive (arena memory later used by GC).
+            Assert(this->scope == scope);
+            this->scope = nullptr;
 
             // The scope is already populated, so we're done.
             return;

--- a/lib/Runtime/ByteCode/ScopeInfo.h
+++ b/lib/Runtime/ByteCode/ScopeInfo.h
@@ -205,11 +205,6 @@ namespace Js {
             return paramScopeInfo;
         }
 
-        void SetScope(Scope *scope)
-        {
-            this->scope = scope;
-        }
-
         Scope * GetScope() const
         {
             return scope;


### PR DESCRIPTION
The given field holds a pointer to arena memory temporarily.
Clear it when done to avoid GC false positive (memory released
and reused by GC later).

This issue blocks -VerifyBarrierBit (without -KeepRecyclerTrackData
thus the filter doesn't work) test on Linux.