### PR TITLE
fix assertion on AuxPtr

### DIFF
--- a/lib/Backend/NativeCodeGenerator.cpp
+++ b/lib/Backend/NativeCodeGenerator.cpp
@@ -806,7 +806,7 @@ NativeCodeGenerator::CodeGen(PageAllocator * pageAllocator, CodeGenWorkItem* wor
     if(foreground)
     {
         // Func::Codegen has a lot of things on the stack, so probe the stack here instead
-        PROBE_STACK(scriptContext, Js::Constants::MinStackJITCompile);
+        PROBE_STACK_NO_DISPOSE(scriptContext, Js::Constants::MinStackJITCompile);
     }
 
 #if ENABLE_DEBUG_CONFIG_OPTIONS
@@ -2204,7 +2204,7 @@ NativeCodeGenerator::GatherCodeGenData(
     if(IsInlinee)
     {
         // This function is recursive
-        PROBE_STACK(scriptContext, Js::Constants::MinStackDefault);
+        PROBE_STACK_NO_DISPOSE(scriptContext, Js::Constants::MinStackDefault);
     }
     else
     {
@@ -3442,7 +3442,7 @@ if (Js::Configuration::Global.flags.IsEnabled(Js::ProfileFlag))
 
 bool NativeCodeGenerator::TryAggressiveInlining(Js::FunctionBody *const topFunctionBody, Js::FunctionBody *const inlineeFunctionBody, InliningDecider &inliningDecider, uint& inlineeCount, uint recursiveInlineDepth)
 {
-    PROBE_STACK(scriptContext, Js::Constants::MinStackDefault);
+    PROBE_STACK_NO_DISPOSE(scriptContext, Js::Constants::MinStackDefault);
 
     if (!inlineeFunctionBody->GetProfiledCallSiteCount())
     {

--- a/lib/Common/Core/CriticalSection.h
+++ b/lib/Common/Core/CriticalSection.h
@@ -18,7 +18,6 @@ public:
     void Leave() { ::LeaveCriticalSection(&cs); }
 #if DBG
     bool IsLocked() const { return cs.OwningThread == (HANDLE)::GetCurrentThreadId(); }
-    bool IsLockedByAnyThread() const { return (InterlockedExchangeAdd((volatile LONG*)&cs.LockCount, 0L) & 1/*CS_LOCK_BIT*/) == 0; }
 #endif
 private:
     CRITICAL_SECTION cs;

--- a/lib/Runtime/Base/CompactCounters.h
+++ b/lib/Runtime/Base/CompactCounters.h
@@ -75,8 +75,7 @@ namespace Js
 
         uint32 Set(CountT typeEnum, uint32 val, T* host)
         {
-            Assert(bgThreadCallStarted == false || isCleaningUp == true
-                || host->GetScriptContext()->GetThreadContext()->GetEtwRundownCriticalSection()->IsLockedByAnyThread());
+            Assert(bgThreadCallStarted == false || isCleaningUp == true);
 
             uint8 type = static_cast<uint8>(typeEnum);
             if (fieldSize == 1)

--- a/lib/Runtime/Base/EtwTrace.cpp
+++ b/lib/Runtime/Base/EtwTrace.cpp
@@ -95,6 +95,9 @@ void EtwTrace::PerformRundown(bool start)
 
     while(threadContext != nullptr)
     {
+        // Take the auxPtrs updating lock, in case auxPtrs is expanding causes GC
+        // which locks Etw Rundown lock, hence dead lock.
+        AutoCriticalSection autoCs(FunctionProxy::GetLock());
         // Take etw rundown lock on this thread context
         AutoCriticalSection autoEtwRundownCs(threadContext->GetEtwRundownCriticalSection());
 


### PR DESCRIPTION
While fixing a dead lock bug and adding assertion for that the work item queue should not be locked at the time of getting the auxPtrs. The assertion is wrong when JIT is collecting data in foreground thread causes stack probing and hence call dispose then re-enter script, which can call GetAuxPtrsWithLock. Fixing with checking if JIT is in foreground.
Also change to not call dispose in codeGen/gathering data, to prevent unpredicted reentrant issue.

Fix the real possible points of dead lock on etw rundown and remove IsLockedByAnyThread (which is hacky and not accurate, should not allow the etw rundown thread to updated the counters on function body, if any we should fix it)