### PR TITLE
remove hresult check for isNativeAddr server call

### DIFF
--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -4123,11 +4123,10 @@ BOOL ThreadContext::IsNativeAddress(void * pCodeAddr, Js::ScriptContext* current
 #if DBG
         boolean result;
         HRESULT hr = JITManager::GetJITManager()->IsNativeAddr(this->m_remoteThreadContextInfo, (intptr_t)pCodeAddr, &result);
-        JITManager::HandleServerCallResult(hr, RemoteCallType::HeapQuery);
 #endif
         bool isNativeAddr = IsNativeAddressHelper(pCodeAddr, currentScriptContext);
 #if DBG
-        Assert(result == (isNativeAddr? TRUE:FALSE));
+        Assert(FAILED(hr) || result == (isNativeAddr? TRUE:FALSE));
 #endif
         return isNativeAddr;
     }


### PR DESCRIPTION
This was causing us to throw sometimes, which we should not be doing from IsNativeAddr. This is for debug only, and failure is possible e.g. in case server has crashed, so we don't really need the check