### PR TITLE
WASM: Empty buffer error type + source refactor

### DIFF
--- a/lib/Runtime/Language/CMakeLists.txt
+++ b/lib/Runtime/Language/CMakeLists.txt
@@ -12,6 +12,7 @@ set(CRL_SOURCE_FILES ${CRL_SOURCE_FILES}
     AsmJsTypes.cpp
     AsmJsUtils.cpp
     WAsmjsUtils.cpp
+    WebAssemblySource.cpp
     CacheOperators.cpp
     CodeGenRecyclableData.cpp
     DynamicProfileInfo.cpp

--- a/lib/Runtime/Language/Chakra.Runtime.Language.vcxproj
+++ b/lib/Runtime/Language/Chakra.Runtime.Language.vcxproj
@@ -177,6 +177,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)SourceTextModuleRecord.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)WAsmjsUtils.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)ModuleNamespaceEnumerator.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)WebAssemblySource.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="amd64\StackFrame.h">
@@ -254,6 +255,7 @@
     <ClInclude Include="TaggedInt.h" />
     <ClInclude Include="RuntimeLanguagePch.h" />
     <ClInclude Include="WAsmjsUtils.h" />
+    <ClInclude Include="WebAssemblySource.h" />
   </ItemGroup>
   <ItemGroup>
     <MASM Include="$(MSBuildThisFileDirectory)amd64\JavascriptOperatorsA.asm">

--- a/lib/Runtime/Language/Chakra.Runtime.Language.vcxproj.filters
+++ b/lib/Runtime/Language/Chakra.Runtime.Language.vcxproj.filters
@@ -78,6 +78,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)ModuleNamespace.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)SourceTextModuleRecord.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)ModuleNamespaceEnumerator.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)WebAssemblySource.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="AsmJs.h" />
@@ -151,6 +152,7 @@
     <ClInclude Include="ObjTypeSpecFldInfo.h" />
     <ClInclude Include="ModuleNamespace.h" />
     <ClInclude Include="ModuleNamespaceEnumerator.h" />
+    <ClInclude Include="WebAssemblySource.h" />
   </ItemGroup>
   <ItemGroup>
     <MASM Include="$(MSBuildThisFileDirectory)amd64\amd64_Thunks.asm">

--- a/lib/Runtime/Language/WebAssemblySource.cpp
+++ b/lib/Runtime/Language/WebAssemblySource.cpp
@@ -1,0 +1,80 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#include "RuntimeLanguagePch.h"
+#include "WebAssemblySource.h"
+
+#ifdef ENABLE_WASM
+
+namespace Js
+{
+
+WebAssemblySource::WebAssemblySource(Var source, bool createNewContext, ScriptContext * scriptContext) :
+    buffer(nullptr), bufferLength(0), sourceInfo(nullptr)
+{
+    ReadBufferSource(source, scriptContext);
+    CreateSourceInfo(createNewContext, scriptContext);
+}
+
+void WebAssemblySource::ReadBufferSource(Var val, ScriptContext * scriptContext)
+{
+    BYTE* srcBuffer;
+    if (Js::TypedArrayBase::Is(val))
+    {
+        Js::TypedArrayBase* array = Js::TypedArrayBase::FromVar(val);
+        srcBuffer = array->GetByteBuffer();
+        bufferLength = array->GetByteLength();
+    }
+    else if (Js::ArrayBuffer::Is(val))
+    {
+        Js::ArrayBuffer* arrayBuffer = Js::ArrayBuffer::FromVar(val);
+        srcBuffer = arrayBuffer->GetBuffer();
+        bufferLength = arrayBuffer->GetByteLength();
+    }
+    else
+    {
+        // The buffer was not a TypedArray nor an ArrayBuffer
+        JavascriptError::ThrowTypeError(scriptContext, WASMERR_NeedBufferSource);
+    }
+    Assert(srcBuffer || bufferLength == 0);
+    if (bufferLength > 0)
+    {
+        // copy buffer so external changes to it don't cause issues when defer parsing
+        buffer = RecyclerNewArrayLeaf(scriptContext->GetRecycler(), byte, bufferLength);
+        js_memcpy_s(buffer, bufferLength, srcBuffer, bufferLength);
+    }
+}
+
+void WebAssemblySource::CreateSourceInfo(bool createNewContext, ScriptContext* scriptContext)
+{
+    SRCINFO si = {
+        /* sourceContextInfo   */ nullptr,
+        /* dlnHost             */ 0,
+        /* ulColumnHost        */ 0,
+        /* lnMinHost           */ 0,
+        /* ichMinHost          */ 0,
+        /* ichLimHost          */ 0,
+        /* ulCharOffset        */ 0,
+        /* mod                 */ 0,
+        /* grfsi               */ 0
+    };
+    SRCINFO const * srcInfo = scriptContext->cache->noContextGlobalSourceInfo;
+    if (createNewContext)
+    {
+        si.sourceContextInfo = scriptContext->CreateSourceContextInfo(scriptContext->GetNextSourceContextId(), nullptr, 0, nullptr);
+        srcInfo = &si;
+    }
+
+    // Note: We don't have real "source info" for Wasm. Following are just placeholders.
+    // Hack: Wasm handles debugging differently. Fake this as "LibraryCode" so that
+    // normal script debugging code ignores this source info and its functions.
+    const int32 cchLength = static_cast<int32>(bufferLength / sizeof(char16));
+    sourceInfo = Utf8SourceInfo::NewWithNoCopy(
+        scriptContext, (LPCUTF8)buffer, cchLength, bufferLength, srcInfo, /*isLibraryCode*/true);
+    scriptContext->SaveSourceNoCopy(sourceInfo, cchLength, /*isCesu8*/false);
+}
+
+}
+#endif

--- a/lib/Runtime/Language/WebAssemblySource.h
+++ b/lib/Runtime/Language/WebAssemblySource.h
@@ -1,0 +1,27 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#pragma once
+
+#ifdef ENABLE_WASM
+namespace Js
+{
+    class WebAssemblySource
+    {
+        BYTE* buffer;
+        uint bufferLength;
+        Js::Utf8SourceInfo* sourceInfo;
+    public:
+        WebAssemblySource(Var source, bool createNewContext, ScriptContext* scriptContext);
+
+        BYTE* GetBuffer() const { return buffer; }
+        uint GetBufferLength() const { return bufferLength; }
+        Js::Utf8SourceInfo* GetSourceInfo() const { return sourceInfo; }
+    private:
+        void ReadBufferSource(Var val, ScriptContext* scriptContext);
+        void CreateSourceInfo(bool createNewContext, ScriptContext* scriptContext);
+    };
+}
+#endif

--- a/lib/Runtime/Library/WebAssembly.cpp
+++ b/lib/Runtime/Library/WebAssembly.cpp
@@ -162,10 +162,20 @@ WebAssembly::ReadBufferSource(Var val, ScriptContext * ctx, _Out_ BYTE** buffer,
         *buffer = arrayBuffer->GetBuffer();
         *byteLength = arrayBuffer->GetByteLength();
     }
-
-    if (*buffer == nullptr || *byteLength == 0)
+    else
     {
+        // The buffer was not a TypedArray nor an ArrayBuffer
         JavascriptError::ThrowTypeError(ctx, WASMERR_NeedBufferSource);
+    }
+
+    if (*buffer == nullptr)
+    {
+        // ArrayBuffer and TypedArray return nullptr when the buffer is empty
+        // assign a dummy buffer to let the flow continue because this doesn't always result in an exception
+        static BYTE emptyBuffer[] = { 0, 0, 0, 0 };
+        *buffer = emptyBuffer;
+        Assert(*byteLength == 0);
+        *byteLength = 0;
     }
 }
 

--- a/lib/Runtime/Library/WebAssembly.cpp
+++ b/lib/Runtime/Library/WebAssembly.cpp
@@ -9,6 +9,7 @@
 // Included for AsmJsDefaultEntryThunk
 #include "Language/InterpreterStackFrame.h"
 #include "Language/AsmJsUtils.h"
+#include "Language/WebAssemblySource.h"
 
 namespace Js
 {
@@ -30,11 +31,8 @@ Var WebAssembly::EntryCompile(RecyclableObject* function, CallInfo callInfo, ...
             JavascriptError::ThrowTypeError(scriptContext, WASMERR_NeedBufferSource);
         }
 
-        BYTE* buffer;
-        uint byteLength;
-        WebAssembly::ReadBufferSource(args[1], scriptContext, &buffer, &byteLength);
-
-        module = WebAssemblyModule::CreateModule(scriptContext, buffer, byteLength);
+        WebAssemblySource src(args[1], true, scriptContext);
+        module = WebAssemblyModule::CreateModule(scriptContext, &src);
     }
     catch (JavascriptError & e)
     {
@@ -76,11 +74,8 @@ Var WebAssembly::EntryInstantiate(RecyclableObject* function, CallInfo callInfo,
         }
         else
         {
-            BYTE* buffer;
-            uint byteLength;
-            WebAssembly::ReadBufferSource(args[1], scriptContext, &buffer, &byteLength);
-
-            WebAssemblyModule * module = WebAssemblyModule::CreateModule(scriptContext, buffer, byteLength);
+            WebAssemblySource src(args[1], true, scriptContext);
+            WebAssemblyModule * module = WebAssemblyModule::CreateModule(scriptContext, &src);
 
             WebAssemblyInstance * instance = WebAssemblyInstance::CreateInstance(module, importObject);
 
@@ -116,11 +111,8 @@ Var WebAssembly::EntryValidate(RecyclableObject* function, CallInfo callInfo, ..
         JavascriptError::ThrowTypeError(scriptContext, WASMERR_NeedBufferSource);
     }
 
-    BYTE* buffer;
-    uint byteLength;
-    WebAssembly::ReadBufferSource(args[1], scriptContext, &buffer, &byteLength);
-
-    if (WebAssemblyModule::ValidateModule(scriptContext, buffer, byteLength))
+    WebAssemblySource src(args[1], false, scriptContext);
+    if (WebAssemblyModule::ValidateModule(scriptContext, &src))
     {
         return scriptContext->GetLibrary()->GetTrue();
     }
@@ -139,44 +131,6 @@ WebAssembly::ToNonWrappingUint32(Var val, ScriptContext * ctx)
         JavascriptError::ThrowRangeError(ctx, JSERR_ArgumentOutOfRange);
     }
     return (uint32)i;
-}
-
-void
-WebAssembly::ReadBufferSource(Var val, ScriptContext * ctx, _Out_ BYTE** buffer, _Out_ uint *byteLength)
-{
-    const BOOL isTypedArray = Js::TypedArrayBase::Is(val);
-    const BOOL isArrayBuffer = Js::ArrayBuffer::Is(val);
-
-    *buffer = nullptr;
-    *byteLength = 0;
-
-    if (isTypedArray)
-    {
-        Js::TypedArrayBase* array = Js::TypedArrayBase::FromVar(val);
-        *buffer = array->GetByteBuffer();
-        *byteLength = array->GetByteLength();
-    }
-    else if (isArrayBuffer)
-    {
-        Js::ArrayBuffer* arrayBuffer = Js::ArrayBuffer::FromVar(val);
-        *buffer = arrayBuffer->GetBuffer();
-        *byteLength = arrayBuffer->GetByteLength();
-    }
-    else
-    {
-        // The buffer was not a TypedArray nor an ArrayBuffer
-        JavascriptError::ThrowTypeError(ctx, WASMERR_NeedBufferSource);
-    }
-
-    if (*buffer == nullptr)
-    {
-        // ArrayBuffer and TypedArray return nullptr when the buffer is empty
-        // assign a dummy buffer to let the flow continue because this doesn't always result in an exception
-        static BYTE emptyBuffer[] = { 0, 0, 0, 0 };
-        *buffer = emptyBuffer;
-        Assert(*byteLength == 0);
-        *byteLength = 0;
-    }
 }
 
 void

--- a/lib/Runtime/Library/WebAssembly.h
+++ b/lib/Runtime/Library/WebAssembly.h
@@ -26,7 +26,6 @@ public:
     static Var EntryInstantiate(RecyclableObject* function, CallInfo callInfo, ...);
 
     static uint32 ToNonWrappingUint32(Var val, ScriptContext * ctx);
-    static void ReadBufferSource(Var val, ScriptContext * ctx, _Out_ BYTE** buffer, _Out_ uint *byteLength);
     static void CheckSignature(ScriptContext * scriptContext, Wasm::WasmSignature * sig1, Wasm::WasmSignature * sig2);
     static uint GetSignatureSize();
 #endif

--- a/lib/Runtime/Library/WebAssemblyModule.h
+++ b/lib/Runtime/Library/WebAssemblyModule.h
@@ -45,13 +45,11 @@ public:
 
     static WebAssemblyModule * CreateModule(
         ScriptContext* scriptContext,
-        const byte* buffer,
-        const uint lengthBytes);
+        class WebAssemblySource* src);
 
     static bool ValidateModule(
         ScriptContext* scriptContext,
-        const byte* buffer,
-        const uint lengthBytes);
+        class WebAssemblySource* src);
 
 public:
     WebAssemblyModule(Js::ScriptContext* scriptContext, const byte* binaryBuffer, uint binaryBufferLength, DynamicType * type);

--- a/lib/WasmReader/WasmByteCodeGenerator.cpp
+++ b/lib/WasmReader/WasmByteCodeGenerator.cpp
@@ -6,6 +6,7 @@
 #include "WasmReaderPch.h"
 
 #ifdef ENABLE_WASM
+#include "Language/WebAssemblySource.h"
 
 #if DBG_DUMP
 #define DebugPrintOp(op) if (PHASE_TRACE(Js::WasmReaderPhase, GetFunctionBody())) { PrintOpName(op); }
@@ -68,12 +69,12 @@ WasmToAsmJs::GetAsmJsVarType(WasmTypes::WasmType wasmType)
 typedef bool(*SectionProcessFunc)(WasmModuleGenerator*);
 typedef void(*AfterSectionCallback)(WasmModuleGenerator*);
 
-WasmModuleGenerator::WasmModuleGenerator(Js::ScriptContext* scriptContext, Js::Utf8SourceInfo* sourceInfo, const byte* binaryBuffer, uint binaryBufferLength) :
-    m_sourceInfo(sourceInfo),
+WasmModuleGenerator::WasmModuleGenerator(Js::ScriptContext* scriptContext, Js::WebAssemblySource* src) :
+    m_sourceInfo(src->GetSourceInfo()),
     m_scriptContext(scriptContext),
     m_recycler(scriptContext->GetRecycler())
 {
-    m_module = RecyclerNewFinalized(m_recycler, Js::WebAssemblyModule, scriptContext, binaryBuffer, binaryBufferLength, scriptContext->GetLibrary()->GetWebAssemblyModuleType());
+    m_module = RecyclerNewFinalized(m_recycler, Js::WebAssemblyModule, scriptContext, src->GetBuffer(), src->GetBufferLength(), scriptContext->GetLibrary()->GetWebAssemblyModuleType());
 
     m_sourceInfo->EnsureInitialized(0);
     m_sourceInfo->GetSrcInfo()->sourceContextInfo->EnsureInitialized();

--- a/lib/WasmReader/WasmByteCodeGenerator.h
+++ b/lib/WasmReader/WasmByteCodeGenerator.h
@@ -4,6 +4,11 @@
 //-------------------------------------------------------------------------------------------------------
 #pragma once
 
+namespace Js
+{
+    class WebAssemblySource;
+}
+
 namespace Wasm
 {
     struct EmitInfo : WAsmJs::EmitInfoBase
@@ -81,7 +86,7 @@ namespace Wasm
     class WasmModuleGenerator
     {
     public:
-        WasmModuleGenerator(Js::ScriptContext* scriptContext, Js::Utf8SourceInfo* sourceInfo, const byte* binaryBuffer, uint binaryBufferLength);
+        WasmModuleGenerator(Js::ScriptContext* scriptContext, Js::WebAssemblySource* src);
         Js::WebAssemblyModule* GenerateModule();
         void GenerateFunctionHeader(uint32 index);
     private:

--- a/test/WasmSpec/baselines/binary.baseline
+++ b/test/WasmSpec/baselines/binary.baseline
@@ -1,2 +1,1 @@
-(5) binary.wast:6: assert_malformed module binary.4.wasm failed. Expected a compile error: TypeError: BufferSource expected
-15/16 tests passed.
+16/16 tests passed.

--- a/test/wasm/api.js
+++ b/test/wasm/api.js
@@ -120,7 +120,11 @@ async function testValidate() {
       }
     })),
   ]);
-  console.log(`Validate: ${WebAssembly.validate(buf)}`);
+  // Make sure empty buffer doesn't validate and doesn't throw
+  const emptyBuffer = new ArrayBuffer();
+  console.log(`WebAssembly.validate(new ArrayBuffer()) = ${WebAssembly.validate(emptyBuffer)}`);
+  console.log(`WebAssembly.validate(new Uint8Array(emptyBuffer)) = ${WebAssembly.validate(new Uint8Array(emptyBuffer))}`);
+  console.log(`api.wasm valid: ${WebAssembly.validate(buf)}`);
 }
 
 async function testCompile() {

--- a/test/wasm/baselines/api.baseline
+++ b/test/wasm/baselines/api.baseline
@@ -7,10 +7,12 @@ Test 3 passed. Expected Error: TypeError: BufferSource expected
 Test 4 passed. Expected Error: TypeError: BufferSource expected
 Test 5 passed. Expected Error: TypeError: BufferSource expected
 Test 6 passed. Expected Error: TypeError: BufferSource expected
-Test 7 passed. Expected Error: TypeError: BufferSource expected
+Test 7 passed. Expected Error: Error: Buffer source is the right type, but doesn't validate
 Test 8 passed. Expected Error: Error: Buffer source is the right type, but doesn't validate
 Test 9 passed. Expected Error: TypeError: BufferSource expected
-Validate: true
+WebAssembly.validate(new ArrayBuffer()) = false
+WebAssembly.validate(new Uint8Array(emptyBuffer)) = false
+api.wasm valid: true
 
 WebAssembly.compile tests
 Test 0 passed. Expected Error: TypeError: Object expected
@@ -20,7 +22,7 @@ Test 3 passed. Expected Error: TypeError: BufferSource expected
 Test 4 passed. Expected Error: TypeError: BufferSource expected
 Test 5 passed. Expected Error: TypeError: BufferSource expected
 Test 6 passed. Expected Error: TypeError: BufferSource expected
-Test 7 passed. Expected Error: TypeError: BufferSource expected
+Test 7 passed. Expected Error: WebAssemblyCompileError: Out of file: Needed: 4, Left: 0
 Test 8 passed. Expected Error: WebAssemblyCompileError: Out of file: Needed: 1, Left: 0
 Test 9 passed. Expected Error: TypeError: BufferSource expected
 Testing module
@@ -37,7 +39,7 @@ Test 3 passed. Expected Error: TypeError: BufferSource expected
 Test 4 passed. Expected Error: TypeError: BufferSource expected
 Test 5 passed. Expected Error: TypeError: BufferSource expected
 Test 6 passed. Expected Error: TypeError: BufferSource expected
-Test 7 passed. Expected Error: TypeError: BufferSource expected
+Test 7 passed. Expected Error: WebAssemblyCompileError: Out of file: Needed: 4, Left: 0
 Test 8 passed. Expected Error: WebAssemblyCompileError: Out of file: Needed: 1, Left: 0
 Test 9 passed. Expected Error: TypeError: BufferSource expected
 Test 10 passed. Expected Error: TypeError: Object expected
@@ -85,7 +87,7 @@ Test 5 passed. Expected Error: TypeError: BufferSource expected
 Test 6 passed. Expected Error: TypeError: BufferSource expected
 Test 7 passed. Expected Error: TypeError: BufferSource expected
 Test 8 passed. Expected Error: TypeError: BufferSource expected
-Test 9 passed. Expected Error: TypeError: BufferSource expected
+Test 9 passed. Expected Error: WebAssemblyCompileError: Out of file: Needed: 4, Left: 0
 Test 10 passed. Expected Error: WebAssemblyCompileError: Out of file: Needed: 1, Left: 0
 Test 11 passed. Expected Error: TypeError: BufferSource expected
 Testing module


### PR DESCRIPTION
By spec, we're supposed to throw a WebAssemblyCompile exception when the source buffer is empty. We were throwing a TypeError.

Add class WebAssemblySource to centralize how we create sources for WebAssembly