### PR TITLE
don't assert on exit code if connection to JIT process fails

### DIFF
--- a/lib/JITClient/JITManager.cpp
+++ b/lib/JITClient/JITManager.cpp
@@ -138,11 +138,7 @@ JITManager::CreateBinding(
         waitStatus = WaitForSingleObject(serverProcessHandle, sleepInterval);
         if (waitStatus == WAIT_OBJECT_0)
         {
-            DWORD exitCode = (DWORD)-1;
-
             // The server process died for some reason. No need to reattempt.
-            // We use -1 as the exit code if GetExitCodeProcess fails.
-            Assert(GetExitCodeProcess(serverProcessHandle, &exitCode));
             status = RPC_S_SERVER_UNAVAILABLE;
             break;
         }


### PR DESCRIPTION
it's possible for GetExitCodeProcess to correctly be 0. it really doesn't matter what the exit code is -- we have to do same thing regardless of why jit process died, so remove the assert