### PR TITLE
rework JIT process memory errors

### DIFF
--- a/lib/Backend/CodeGenNumberAllocator.cpp
+++ b/lib/Backend/CodeGenNumberAllocator.cpp
@@ -341,7 +341,8 @@ Js::JavascriptNumber* XProcNumberPageSegmentImpl::AllocateNumber(Func* func, dou
             // initialize number by WriteProcessMemory
             if (!WriteProcessMemory(hProcess, (void*)number, pLocalNumber, sizeCat, NULL))
             {
-                MemoryOperationLastError::RecordLastErrorAndThrow();
+                MemoryOperationLastError::RecordLastError();
+                Js::Throw::OutOfMemory();
             }
 
             return (Js::JavascriptNumber*) number;

--- a/lib/Backend/NativeCodeGenerator.cpp
+++ b/lib/Backend/NativeCodeGenerator.cpp
@@ -3164,18 +3164,15 @@ bool NativeCodeGenerator::TryReleaseNonHiPriWorkItem(CodeGenWorkItem* workItem)
 void
 NativeCodeGenerator::FreeNativeCodeGenAllocation(void* address)
 {
-    if(this->backgroundAllocators)
+    if (JITManager::GetJITManager()->IsOOPJITEnabled())
     {
         ThreadContext * context = this->scriptContext->GetThreadContext();
-        if (JITManager::GetJITManager()->IsOOPJITEnabled())
-        {
-            // OOP JIT TODO: need error handling?
-            JITManager::GetJITManager()->FreeAllocation(context->GetRemoteThreadContextAddr(), (intptr_t)address);
-        }
-        else
-        {
-            this->backgroundAllocators->emitBufferManager.FreeAllocation(address);
-        }
+        HRESULT hr = JITManager::GetJITManager()->FreeAllocation(context->GetRemoteThreadContextAddr(), (intptr_t)address);
+        JITManager::HandleServerCallResult(hr, RemoteCallType::MemFree);
+    }
+    else if(this->backgroundAllocators)
+    {
+        this->backgroundAllocators->emitBufferManager.FreeAllocation(address);
     }
 }
 
@@ -3202,23 +3199,9 @@ NativeCodeGenerator::QueueFreeNativeCodeGenAllocation(void* address)
     }
 
     // The foreground allocators may have been used
-    ThreadContext * context = this->scriptContext->GetThreadContext();
-    if(this->foregroundAllocators)
+    if(this->foregroundAllocators && this->foregroundAllocators->emitBufferManager.FreeAllocation(address))
     {
-        if (JITManager::GetJITManager()->IsOOPJITEnabled())
-        {
-            // TODO: OOP JIT, should we always just queue this in background?
-            // OOP JIT TODO: need error handling?
-            JITManager::GetJITManager()->FreeAllocation(context->GetRemoteThreadContextAddr(), (intptr_t)address);
-            return;
-        }
-        else
-        {
-            if (this->foregroundAllocators->emitBufferManager.FreeAllocation(address))
-            {
-                return;
-            }
-        }
+        return;
     }
 
     // The background allocators were used. Queue a job to free the allocation from the background thread.
@@ -3664,7 +3647,15 @@ JITManager::HandleServerCallResult(HRESULT hr, RemoteCallType callType)
     case E_ABORT:
         throw Js::OperationAbortedException();
     case E_OUTOFMEMORY:
-        Js::Throw::OutOfMemory();
+        if (callType == RemoteCallType::MemFree)
+        {
+            // if freeing memory fails due to OOM, it means we failed to fill with debug breaks -- so failfast
+            RpcFailure_fatal_error(hr);
+        }
+        else
+        {
+            Js::Throw::OutOfMemory();
+        }
     case VBSERR_OutOfStack:
         throw Js::StackOverflowException();
     default:
@@ -3695,6 +3686,7 @@ JITManager::HandleServerCallResult(HRESULT hr, RemoteCallType callType)
     case RemoteCallType::ThunkCreation:
         Js::Throw::OutOfMemory();
     case RemoteCallType::StateUpdate:
+    case RemoteCallType::MemFree:
         // if server process is gone, we can ignore failures updating its state
         return;
     default:

--- a/lib/Backend/NativeCodeGenerator.cpp
+++ b/lib/Backend/NativeCodeGenerator.cpp
@@ -3197,6 +3197,7 @@ NativeCodeGenerator::QueueFreeNativeCodeGenAllocation(void* address)
     {
         this->scriptContext->GetJitFuncRangeCache()->RemoveFuncRange((void*)address);
     }
+    // OOP JIT will always queue a job
 
     // The foreground allocators may have been used
     if(this->foregroundAllocators && this->foregroundAllocators->emitBufferManager.FreeAllocation(address))

--- a/lib/Common/CommonDefines.h
+++ b/lib/Common/CommonDefines.h
@@ -145,6 +145,8 @@
 #endif
 
 
+#define MAKE_HR(errnum) (MAKE_HRESULT(SEVERITY_ERROR, FACILITY_CONTROL, errnum))
+
 #if ENABLE_CONCURRENT_GC
 // Write-barrier refers to a software write barrier implementation using a card table.
 // Write watch refers to a hardware backed write-watch feature supported by the Windows memory manager.

--- a/lib/Common/Memory/CommonMemoryPch.h
+++ b/lib/Common/Memory/CommonMemoryPch.h
@@ -21,6 +21,8 @@ typedef _Return_type_success_(return >= 0) LONG NTSTATUS;
 #include "Exceptions/ExceptionBase.h"
 #include "Exceptions/OutOfMemoryException.h"
 
+#include "../Parser/rterror.h"
+
 // Other Memory headers
 #include "Memory/LeakReport.h"
 #include "Memory/AutoPtr.h"
@@ -47,6 +49,7 @@ typedef _Return_type_success_(return >= 0) LONG NTSTATUS;
 #include "Memory/LargeHeapBucket.inl"
 #include "Memory/HeapBlock.inl"
 #include "Memory/HeapBlockMap.inl"
+
 
 // Memory Protections
 #ifdef _CONTROL_FLOW_GUARD

--- a/lib/Common/Memory/VirtualAllocWrapper.h
+++ b/lib/Common/Memory/VirtualAllocWrapper.h
@@ -24,6 +24,8 @@ class VirtualAllocWrapper
 public:
     LPVOID  Alloc(LPVOID lpAddress, DECLSPEC_GUARD_OVERFLOW size_t dwSize, DWORD allocationType, DWORD protectFlags, bool isCustomHeapAllocation);
     BOOL    Free(LPVOID lpAddress, size_t dwSize, DWORD dwFreeType);
+    LPVOID  AllocLocal(LPVOID lpAddress, DECLSPEC_GUARD_OVERFLOW size_t dwSize) { return lpAddress; }
+    BOOL    FreeLocal(LPVOID lpAddress) { return true; }
 
     static VirtualAllocWrapper Instance;  // single instance
 private:
@@ -54,6 +56,8 @@ public:
     ~PreReservedVirtualAllocWrapper();
     LPVOID      Alloc(LPVOID lpAddress, DECLSPEC_GUARD_OVERFLOW size_t dwSize, DWORD allocationType, DWORD protectFlags, bool isCustomHeapAllocation);
     BOOL        Free(LPVOID lpAddress,  size_t dwSize, DWORD dwFreeType);
+    LPVOID  AllocLocal(LPVOID lpAddress, DECLSPEC_GUARD_OVERFLOW size_t dwSize) { return lpAddress; }
+    BOOL    FreeLocal(LPVOID lpAddress) { return true; }
 
     bool        IsInRange(void * address);
     static bool IsInRange(void * regionStart, void * address);

--- a/lib/JITClient/JITManager.h
+++ b/lib/JITClient/JITManager.h
@@ -13,7 +13,8 @@ enum class RemoteCallType
     CodeGen,
     ThunkCreation,
     HeapQuery,
-    StateUpdate
+    StateUpdate,
+    MemFree
 };
 
 #if _WIN32 || ENABLE_OOP_NATIVE_CODEGEN

--- a/lib/JITServer/JITServer.cpp
+++ b/lib/JITServer/JITServer.cpp
@@ -913,15 +913,7 @@ HRESULT ServerCallWrapper(ServerThreadContext* threadContextInfo, Fn fn)
         AssertOrFailFastMsg(false, "Unknown exception caught in JIT server call.");
     }
 
-    if (hr == E_OUTOFMEMORY)
-    {
-        if (HRESULT_FROM_WIN32(MemoryOperationLastError::GetLastError()) != S_OK)
-        {
-            hr = HRESULT_FROM_WIN32(MemoryOperationLastError::GetLastError());
-        }
-    }
-
-    return hr;
+    return MemoryOperationLastError::GetLastError();
 }
 
 template<typename Fn>

--- a/lib/Parser/ParserCommon.h
+++ b/lib/Parser/ParserCommon.h
@@ -55,4 +55,3 @@ typedef SList<IdentPtr, ArenaAllocator> IdentPtrList;
 // Below was moved from scrutil.h to share with chakradiag.
 //
 #define HR(sc) ((HRESULT)(sc))
-#define MAKE_HR(vbserr) (MAKE_HRESULT(SEVERITY_ERROR, FACILITY_CONTROL, vbserr))

--- a/lib/Parser/rterror.cpp
+++ b/lib/Parser/rterror.cpp
@@ -3,7 +3,6 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "ParserPch.h"
-#include "rterror.h"
 
 // PUBLIC ERROR codes
 

--- a/lib/Parser/rterrors.h
+++ b/lib/Parser/rterrors.h
@@ -364,6 +364,7 @@ RT_ERROR_MSG(JSERR_CannotSuspendBuffer, 5665, "", "Current agent cannot be suspe
 RT_ERROR_MSG(JSERR_CantDeleteNonConfigProp, 5666, "Cannot delete non-configurable property '%s'", "Cannot delete non-configurable property", kjstTypeError, 0)
 RT_ERROR_MSG(JSERR_CantRedefineProp, 5667, "Cannot redefine property '%s'", "Cannot redefine property", kjstTypeError, 0)
 RT_ERROR_MSG(JSERR_FunctionArgument_NeedArrayLike, 5668, "%s: argument is not an array or array-like object", "Array or array-like object expected", kjstTypeError, 0)
+RT_ERROR_MSG(JSERR_FatalMemoryExhaustion, 5669, "", "Encountered a non-recoverable OOM", kjstError, 0)
 
 // WebAssembly Errors
 RT_ERROR_MSG(WASMERR_WasmCompileError, 7000, "%s", "Compilation failed.", kjstWebAssemblyCompileError, 0)


### PR DESCRIPTION
In case of memory exhaustion type scenarios, we don't want to crash the JIT process,  instead crash the runtime process, since the JIT may serve many runtimes.

Also, this resolves issue where we get memory violation due to runtime crashing. In such a case, now we will have runtime crash after the JIT returns