### PR TITLE
Add a StatementDebugBreak flag for debug builds

### DIFF
--- a/bin/ChakraCore/TestHooks.cpp
+++ b/bin/ChakraCore/TestHooks.cpp
@@ -114,6 +114,7 @@ void __stdcall NotifyUnhandledException(PEXCEPTION_POINTERS exceptionInfo)
 #define FLAG_Phases(name)
 #define FLAG_NumberSet(name)
 #define FLAG_NumberPairSet(name)
+#define FLAG_NumberTrioSet(name)
 #define FLAG_NumberRange(name)
 #include "ConfigFlagsList.h"
 #undef FLAG
@@ -123,6 +124,7 @@ void __stdcall NotifyUnhandledException(PEXCEPTION_POINTERS exceptionInfo)
 #undef FLAG_Phases
 #undef FLAG_NumberSet
 #undef FLAG_NumberPairSet
+#undef FLAG_NumberTrioSet
 #undef FLAG_NumberRange
 
 HRESULT OnChakraCoreLoaded(OnChakraCoreLoadedPtr pfChakraCoreLoaded)
@@ -154,6 +156,7 @@ HRESULT OnChakraCoreLoaded(OnChakraCoreLoadedPtr pfChakraCoreLoaded)
 #define FLAG_Phases(name)
 #define FLAG_NumberSet(name)
 #define FLAG_NumberPairSet(name)
+#define FLAG_NumberTrioSet(name)
 #define FLAG_NumberRange(name)
 #include "ConfigFlagsList.h"
 #undef FLAG
@@ -163,6 +166,7 @@ HRESULT OnChakraCoreLoaded(OnChakraCoreLoadedPtr pfChakraCoreLoaded)
 #undef FLAG_Phases
 #undef FLAG_NumberSet
 #undef FLAG_NumberPairSet
+#undef FLAG_NumberTrioSet
 #undef FLAG_NumberRange
 #if ENABLE_NATIVE_CODEGEN && _WIN32
         ConnectJITServer,

--- a/bin/ChakraCore/TestHooks.h
+++ b/bin/ChakraCore/TestHooks.h
@@ -44,6 +44,7 @@ struct TestHooks
 #define FLAG_Phases(name)
 #define FLAG_NumberSet(name)
 #define FLAG_NumberPairSet(name)
+#define FLAG_NumberTrioSet(name)
 #define FLAG_NumberRange(name)
 #include "ConfigFlagsList.h"
 #undef FLAG
@@ -53,6 +54,7 @@ struct TestHooks
 #undef FLAG_Phases
 #undef FLAG_NumberSet
 #undef FLAG_NumberPairSet
+#undef FLAG_NumberTrioSet
 #undef FLAG_NumberRange
 
 #if ENABLE_NATIVE_CODEGEN

--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -2900,9 +2900,10 @@ Lowerer::LowerRange(IR::Instr *instrStart, IR::Instr *instrEnd, bool defaultDoFa
             // If we have a JITStatementBreakpoint, then we should break on this statement
             {
                 uint32 statementIndex = instr->AsPragmaInstr()->m_statementIndex;
-                if (Js::Configuration::Global.flags.StatementDebugBreak.Contains(instr->m_func->GetFunctionNumber(), statementIndex))
+                if (Js::Configuration::Global.flags.StatementDebugBreak.Contains(instr->m_func->GetSourceContextId(), instr->m_func->GetLocalFunctionId(), statementIndex))
                 {
                     IR::Instr* tempinstr = instr;
+                    Assert(tempinstr != nullptr);
                     // go past any labels, and then add a debug breakpoint
                     while (tempinstr->m_next != nullptr && tempinstr->m_next->m_opcode == Js::OpCode::Label)
                     {

--- a/lib/Backend/arm/LowerMD.cpp
+++ b/lib/Backend/arm/LowerMD.cpp
@@ -9303,7 +9303,7 @@ LowererMD::LowerTypeof(IR::Instr* typeOfInstr)
 //
 void LowererMD::GenerateDebugBreak( IR::Instr * insertInstr )
 {
-    IR::Instr *int3 = IR::Instr::New(Js::OpCode::DEBUGBREAK, insertInstr->m_func);\
-    insertInstr->InsertBefore(int3);\
+    IR::Instr *int3 = IR::Instr::New(Js::OpCode::DEBUGBREAK, insertInstr->m_func);
+    insertInstr->InsertBefore(int3);
 }
 #endif

--- a/lib/Backend/arm/LowerMD.cpp
+++ b/lib/Backend/arm/LowerMD.cpp
@@ -9296,3 +9296,14 @@ LowererMD::LowerTypeof(IR::Instr* typeOfInstr)
     typeOfInstr->InsertAfter(doneLabel);
     m_lowerer->LowerUnaryHelperMem(typeOfInstr, IR::HelperOp_Typeof);
 }
+
+#if DBG
+//
+// Helps in debugging of fast paths.
+//
+void LowererMD::GenerateDebugBreak( IR::Instr * insertInstr )
+{
+    IR::Instr *int3 = IR::Instr::New(Js::OpCode::DEBUGBREAK, insertInstr->m_func);\
+    insertInstr->InsertBefore(int3);\
+}
+#endif

--- a/lib/Backend/arm/LowerMD.h
+++ b/lib/Backend/arm/LowerMD.h
@@ -93,7 +93,7 @@ public:
             IR::Instr *     LowerLdSuper(IR::Instr * instr, IR::JnHelperMethod helperOpCode);
             IR::Instr *     GenerateSmIntPairTest(IR::Instr * instrInsert, IR::Opnd * opndSrc1, IR::Opnd * opndSrc2, IR::LabelInstr * labelFail);
 #if DBG
-    static  void            GenerateDebugBreak( IR::Instr * insertInstr );
+    static  void            GenerateDebugBreak(IR::Instr * insertInstr);
 #endif
             void            GenerateTaggedZeroTest( IR::Opnd * opndSrc, IR::Instr * instrInsert, IR::LabelInstr * labelHelper = nullptr);
             void            GenerateObjectPairTest(IR::Opnd * opndSrc1, IR::Opnd * opndSrc2, IR::Instr * insertInstr, IR::LabelInstr * labelTarget);

--- a/lib/Backend/arm/LowerMD.h
+++ b/lib/Backend/arm/LowerMD.h
@@ -92,6 +92,9 @@ public:
             IR::Instr *     LowerLdEnv(IR::Instr *instr);
             IR::Instr *     LowerLdSuper(IR::Instr * instr, IR::JnHelperMethod helperOpCode);
             IR::Instr *     GenerateSmIntPairTest(IR::Instr * instrInsert, IR::Opnd * opndSrc1, IR::Opnd * opndSrc2, IR::LabelInstr * labelFail);
+#if DBG
+    static  void            GenerateDebugBreak( IR::Instr * insertInstr );
+#endif
             void            GenerateTaggedZeroTest( IR::Opnd * opndSrc, IR::Instr * instrInsert, IR::LabelInstr * labelHelper = nullptr);
             void            GenerateObjectPairTest(IR::Opnd * opndSrc1, IR::Opnd * opndSrc2, IR::Instr * insertInstr, IR::LabelInstr * labelTarget);
             bool            GenerateObjectTest(IR::Opnd * opndSrc, IR::Instr * insertInstr, IR::LabelInstr * labelTarget, bool fContinueLabel = false);

--- a/lib/Backend/arm64/LowerMD.h
+++ b/lib/Backend/arm64/LowerMD.h
@@ -84,6 +84,9 @@ public:
               IR::Instr *     LoadFunctionObjectOpnd(IR::Instr *instr, IR::Opnd *&functionObjOpnd) { __debugbreak(); return 0; }
               IR::Instr *     LowerLdSuper(IR::Instr * instr, IR::JnHelperMethod helperOpCode) { __debugbreak(); return 0; }
               IR::Instr *     GenerateSmIntPairTest(IR::Instr * instrInsert, IR::Opnd * opndSrc1, IR::Opnd * opndSrc2, IR::LabelInstr * labelFail) { __debugbreak(); return 0; }
+#if DBG
+      static  void            GenerateDebugBreak(IR::Instr * insertInstr) { __debugbreak(); return 0; };
+#endif
               void            GenerateTaggedZeroTest( IR::Opnd * opndSrc, IR::Instr * instrInsert, IR::LabelInstr * labelHelper = NULL) { __debugbreak(); }
               void            GenerateObjectPairTest(IR::Opnd * opndSrc1, IR::Opnd * opndSrc2, IR::Instr * insertInstr, IR::LabelInstr * labelTarget) { __debugbreak(); }
               bool            GenerateObjectTest(IR::Opnd * opndSrc, IR::Instr * insertInstr, IR::LabelInstr * labelTarget, bool fContinueLabel = false) { __debugbreak(); return false; }

--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -913,6 +913,7 @@ FLAGNR(Boolean, CrashOnException      , "Removes the top-level exception handler
 #endif
 FLAGNR(Boolean, Debug                 , "Disable phases (layout, security code, etc) which makes JIT output harder to debug", false)
 FLAGNR(NumberSet,  DebugBreak         , "Index of the function where you want to break", )
+FLAGNR(NumberPairSet,  StatementDebugBreak, "Index of the statement where you want to break", )
 FLAGNR(Boolean, DebugWindow           , "Send console output to debugger window", false)
 FLAGNR(Boolean, DeferNested           , "Enable deferred parsing of nested function", DEFAULT_CONFIG_DeferNested)
 FLAGNR(Boolean, DeferTopLevelTillFirstCall      , "Enable tracking of deferred top level functions in a script file, until the first function of the script context is parsed.", DEFAULT_CONFIG_DeferTopLevelTillFirstCall)

--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -913,7 +913,7 @@ FLAGNR(Boolean, CrashOnException      , "Removes the top-level exception handler
 #endif
 FLAGNR(Boolean, Debug                 , "Disable phases (layout, security code, etc) which makes JIT output harder to debug", false)
 FLAGNR(NumberSet,  DebugBreak         , "Index of the function where you want to break", )
-FLAGNR(NumberPairSet,  StatementDebugBreak, "Index of the statement where you want to break", )
+FLAGNR(NumberTrioSet,  StatementDebugBreak, "Index of the statement where you want to break", )
 FLAGNR(Boolean, DebugWindow           , "Send console output to debugger window", false)
 FLAGNR(Boolean, DeferNested           , "Enable deferred parsing of nested function", DEFAULT_CONFIG_DeferNested)
 FLAGNR(Boolean, DeferTopLevelTillFirstCall      , "Enable tracking of deferred top level functions in a script file, until the first function of the script context is parsed.", DEFAULT_CONFIG_DeferTopLevelTillFirstCall)

--- a/lib/Common/Core/CmdParser.cpp
+++ b/lib/Common/Core/CmdParser.cpp
@@ -434,6 +434,35 @@ CmdLineArgsParser::ParseNumberPairSet(Js::NumberPairSet * numberPairSet)
     }
 }
 
+void
+CmdLineArgsParser::ParseNumberTrioSet(Js::NumberTrioSet * numberTrioSet)
+{
+    while (true)
+    {
+        int line = ParseInteger();
+        int col = -1;
+        int stmt = -1;
+        if (CurChar() == ',')
+        {
+            NextChar();
+            col = ParseInteger();
+        }
+        if (CurChar() == ',')
+        {
+            NextChar();
+            stmt = ParseInteger();
+        }
+
+        numberTrioSet->Add(line, col, stmt);
+
+        if (CurChar() != ';')
+        {
+            break;
+        }
+        NextChar();
+    }
+}
+
 bool
 CmdLineArgsParser::ParseBoolean()
 {
@@ -556,6 +585,10 @@ CmdLineArgsParser::ParseFlag()
 
             case FlagNumberPairSet:
                 ParseNumberPairSet(this->flagTable.GetAsNumberPairSet(flag));
+                break;
+
+            case FlagNumberTrioSet:
+                ParseNumberTrioSet(this->flagTable.GetAsNumberTrioSet(flag));
                 break;
 
             case FlagNumberRange:

--- a/lib/Common/Core/CmdParser.h
+++ b/lib/Common/Core/CmdParser.h
@@ -73,6 +73,7 @@ private:
             void                       ParseFlag();
             void                       ParseNumberSet(Js::NumberSet * numberSet);
             void                       ParseNumberPairSet(Js::NumberPairSet * numberPairSet);
+            void                       ParseNumberTrioSet(Js::NumberTrioSet * numberTrioSet);
             void                       PrintUsage();
 
             char16 CurChar()

--- a/lib/Common/Core/ConfigFlagsTable.cpp
+++ b/lib/Common/Core/ConfigFlagsTable.cpp
@@ -50,6 +50,18 @@ namespace Js
         return set.Contains(NumberPair(x, y));
     }
 
+    NumberTrioSet::NumberTrioSet() : set(&NoCheckHeapAllocator::Instance) {}
+
+    void NumberTrioSet::Add(uint32 x, uint32 y, uint32 z)
+    {
+        set.Item(NumberTrio(x, y, z));
+    }
+
+    bool NumberTrioSet::Contains(uint32 x, uint32 y, uint32 z)
+    {
+        return set.Contains(NumberTrio(x, y, z));
+    }
+
     ///----------------------------------------------------------------------------
     ///----------------------------------------------------------------------------
     ///
@@ -385,6 +397,12 @@ namespace Js
     ConfigFlagsTable::GetAsNumberPairSet(Flag flag)  const
     {
         return reinterpret_cast<NumberPairSet* >(GetProperty(flag));
+    }
+
+    NumberTrioSet *
+    ConfigFlagsTable::GetAsNumberTrioSet(Flag flag) const
+    {
+        return reinterpret_cast<NumberTrioSet*>(GetProperty(flag));
     }
 
     NumberRange *
@@ -887,6 +905,9 @@ namespace Js
             case FlagNumberPairSet:
                 printf("[:NumberPairSet] ");
                 break;
+            case FlagNumberTrioSet:
+                printf("[:NumberTrioSet] ");
+                break;
             case FlagNumberRange:
                 printf("[:NumberRange]   ");
                 break;
@@ -1012,6 +1033,7 @@ namespace Js
 #define FLAGDEFAULTNumberSet(name, defaultValue)
 #define FLAGDEFAULTNumberRange(name, defaultValue)
 #define FLAGDEFAULTNumberPairSet(name, defaultValue)
+#define FLAGDEFAULTNumberTrioSet(name, defaultValue)
             //   * and those we do care about
 #define FLAGDEFAULTBoolean(name, defaultValue) \
         case name##Flag: \
@@ -1023,6 +1045,7 @@ namespace Js
 #undef FLAGDEFAULTBoolean
 #undef FLAGDEFAULTNumberRange
 #undef FLAGDEFAULTNumberPairSet
+#undef FLAGDEFAULTNumberTrioSet
 #undef FLAGDEFAULTNumberSet
 #undef FLAGDEFAULTNumber
 #undef FLAGDEFAULTString
@@ -1032,6 +1055,7 @@ namespace Js
 #undef FLAGREGOVREXPBoolean
 #undef FLAGREGOVREXPNumberRange
 #undef FLAGREGOVREXPNumberPairSet
+#undef FLAGREGOVREXPNumberTrioSet
 #undef FLAGREGOVREXPNumberSet
 #undef FLAGREGOVREXPNumber
 #undef FLAGREGOVREXPString
@@ -1040,6 +1064,7 @@ namespace Js
 #undef FLAGREGOVRBoolean
 #undef FLAGREGOVRNumberRange
 #undef FLAGREGOVRNumberPairSet
+#undef FLAGREGOVRNumberTrioSet
 #undef FLAGREGOVRNumberSet
 #undef FLAGREGOVRNumber
 #undef FLAGREGOVRString
@@ -1107,6 +1132,7 @@ namespace Js
 #define FLAGDOCALLBACKNumber(name)        Assert(false);
 #define FLAGDOCALLBACKNumberSet(name)     Assert(false);
 #define FLAGDOCALLBACKNumberPairSet(name) Assert(false);
+#define FLAGDOCALLBACKNumberTrioSet(name) Assert(false);
             //   * and those we do care about
 #define FLAGDOCALLBACKBoolean(name)       if( flag == name##Flag ) this->FlagSetCallback_##name(value);
 
@@ -1115,6 +1141,7 @@ namespace Js
 #undef FLAGDOCALLBACKBoolean
 #undef FLAGDOCALLBACKNumberRange
 #undef FLAGDOCALLBACKNumberPairSet
+#undef FLAGDOCALLBACKNumberTrioSet
 #undef FLAGDOCALLBACKNumberSet
 #undef FLAGDOCALLBACKNumber
 #undef FLAGDOCALLBACKString

--- a/lib/Common/Core/ConfigFlagsTable.h
+++ b/lib/Common/Core/ConfigFlagsTable.h
@@ -26,6 +26,7 @@ namespace Js
         FlagBoolean,
         FlagNumberSet,
         FlagNumberPairSet,
+        FlagNumberTrioSet,
         FlagNumberRange
     };
 
@@ -196,6 +197,31 @@ namespace Js
         bool Empty() const { return set.Count() == 0; }
     private:
         JsUtil::BaseHashSet<NumberPair, NoCheckHeapAllocator, PrimeSizePolicy> set;
+    };
+
+    class NumberTrio
+    {
+    public:
+        NumberTrio(uint32 x, uint32 y, uint32 z) : x(x), y(y), z(z) {}
+        NumberTrio() : x((uint32)-1), y((uint32)-1) {}
+
+        operator hash_t() const { return (x << 20) + (y << 10) + z; }
+        bool operator ==(const NumberTrio &other) const { return x == other.x && y == other.y && z == other.z; }
+    private:
+        uint32 x;
+        uint32 y;
+        uint32 z;
+    };
+
+    class NumberTrioSet
+    {
+    public:
+        NumberTrioSet();
+        void Add(uint32 x, uint32 y, uint32 z);
+        bool Contains(uint32 x, uint32 y, uint32 z);
+        bool Empty() const { return set.Count() == 0; }
+    private:
+        JsUtil::BaseHashSet<NumberTrio, NoCheckHeapAllocator, PrimeSizePolicy> set;
     };
 
     struct SourceFunctionNode
@@ -431,6 +457,7 @@ namespace Js
                 Number*         GetAsNumber(Flag flag) const;
                 NumberSet*      GetAsNumberSet(Flag flag) const;
                 NumberPairSet * GetAsNumberPairSet(Flag flag) const;
+                NumberTrioSet * GetAsNumberTrioSet(Flag flag) const;
                 NumberRange *   GetAsNumberRange(Flag flag) const;
 
                 void            SetAsBoolean(Flag flag, Boolean value);


### PR DESCRIPTION
This flag allows you to insert a debugger break on a given statment.

(Also enables GenerateDebugBreak on arm, in non-macro form).

Note: was originally rolled into the es5 array length cache fix, split
for atomicity of pr purpose.
