### PR TITLE
xplat: rand_s fallback

### DIFF
--- a/pal/src/misc/random.cpp
+++ b/pal/src/misc/random.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 #include <stdlib.h>
@@ -26,7 +26,7 @@ public:
   static bool Init()
   {
       return pthread_mutex_init(&random_generator_mutex, NULL) == 0;
-  } 
+  }
 
   __attribute__((noinline))
   Lock() {
@@ -41,7 +41,10 @@ public:
 
 pthread_mutex_t Lock::random_generator_mutex;
 
-static bool GetRandom(unsigned int *result) noexcept
+// not needed to be a THREAD_LOCAL. GetRandom acquires a mutex lock
+unsigned int WEAK_RANDOM_SEED = 12345;
+
+static void GetRandom(unsigned int *result) noexcept
 {
     static bool mutex_initialized = Lock::Init();
     // Do not put the `if check` into `Init` or replace it with Assert
@@ -53,40 +56,45 @@ static bool GetRandom(unsigned int *result) noexcept
 
     if (cache_index < RANDOM_CACHE_SIZE) {
         *result = random_cache.result[cache_index++];
-        return true;
+        return;
     }
 
     const int rdev = open("/dev/urandom", O_RDONLY);
     unsigned len = 0;
+    bool failed = false;
 
     do
     {
         int added = read(rdev, random_cache.rstack + len, rand_byte_len - len);
         if (added < 0) {
             close(rdev);
-            return false;
+            // io starvation ?
+            failed = true;
+            goto LEAVE;
         }
         len += added;
     } while (len < rand_byte_len);
 
     close(rdev);
     *result = random_cache.result[0];
-    cache_index = 1;
-    return len == rand_byte_len;
+    failed = len != rand_byte_len;
+LEAVE:
+    if (failed) // fallback to weak rnd
+    {
+        WEAK_RANDOM_SEED += rand();
+        *result = rand_r(&WEAK_RANDOM_SEED);
+    }
+    else
+    {
+        cache_index = 1; // enable cache only when len == rand_byte_len
+    }
 }
 
 extern "C"
 errno_t __cdecl rand_s(unsigned int* randomValue) noexcept
 {
     if (randomValue == nullptr) return 1;
-    
-    if (GetRandom(randomValue)) 
-    {
-        return 0;
-    }
-    else
-    {
-        *randomValue = 0;
-        return 1;
-    }
+
+    GetRandom(randomValue);
+    return 0;
 }


### PR DESCRIPTION
- Fixes a failing node-chakracore test.
   In case of an IO starvation fallback to a weaker rand instead of fatal-crash.

- Discards RND cache in case of previously broken IO.