### PR TITLE
Fix Hoisting ValueType of String concat

### DIFF
--- a/lib/Backend/GlobOpt.h
+++ b/lib/Backend/GlobOpt.h
@@ -1641,11 +1641,12 @@ private:
     bool                    OptIsInvariant(Sym *sym, BasicBlock *block, Loop *loop, Value *srcVal, bool isNotTypeSpecConv, bool allowNonPrimitives, Value **loopHeadValRef = nullptr);
     bool                    OptDstIsInvariant(IR::RegOpnd *dst);
     bool                    OptIsInvariant(IR::Instr *instr, BasicBlock *block, Loop *loop, Value *src1Val, Value *src2Val, bool isNotTypeSpecConv, const bool forceInvariantHoisting = false);
-    void                    OptHoistInvariant(IR::Instr *instr, BasicBlock *block, Loop *loop, Value *dstVal, Value *const src1Val, bool isNotTypeSpecConv, bool lossy = false, IR::BailOutKind bailoutKind = IR::BailOutInvalid);
+    void                    OptHoistInvariant(IR::Instr *instr, BasicBlock *block, Loop *loop, Value *dstVal, Value *const src1Val, Value *const src2Value,
+                                                bool isNotTypeSpecConv, bool lossy = false, IR::BailOutKind bailoutKind = IR::BailOutInvalid);
     bool                    TryHoistInvariant(IR::Instr *instr, BasicBlock *block, Value *dstVal, Value *src1Val, Value *src2Val, bool isNotTypeSpecConv,
                                                 const bool lossy = false, const bool forceInvariantHoisting = false, IR::BailOutKind bailoutKind = IR::BailOutInvalid);
     void                    HoistInvariantValueInfo(ValueInfo *const invariantValueInfoToHoist, Value *const valueToUpdate, BasicBlock *const targetBlock);
-    void                    OptHoistToLandingPadUpdateValueType(BasicBlock* landingPad, IR::Instr* instr, IR::Opnd* opnd, Value *const srcVal);
+    void                    OptHoistUpdateValueType(Loop* loop, IR::Instr* instr, IR::Opnd* srcOpnd, Value *const srcVal);
 public:
     static bool             IsTypeSpecPhaseOff(Func* func);
     static bool             DoAggressiveIntTypeSpec(Func* func);

--- a/test/Optimizer/HoistStringConcat.js
+++ b/test/Optimizer/HoistStringConcat.js
@@ -1,0 +1,19 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function test0() {
+  var counter = 2;
+
+  function test0Inner() {
+    return counter--;
+  };
+
+  var outterStr = 't';
+  while (test0Inner()) {
+    var str2 = outterStr.replace('test', ' test ');
+    var str3 = 'test1' + 'test2' + outterStr;
+  }
+}
+test0();

--- a/test/Optimizer/HoistStringConcat.js
+++ b/test/Optimizer/HoistStringConcat.js
@@ -17,3 +17,5 @@ function test0() {
   }
 }
 test0();
+
+print("pass");

--- a/test/Optimizer/rlexe.xml
+++ b/test/Optimizer/rlexe.xml
@@ -1378,4 +1378,10 @@
       <compile-flags>-lic:1 -off:simplejit -off:aggressiveinttypespec -bgjit-</compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>HoistStringConcat.js</files>
+      <compile-flags>-lic:1 -off:simplejit -bgjit-</compile-flags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
When hoisting `SetConcatStrMultiItemBE` to loop landingpad, the type of src operands could be loosed to be non-string (this was ensured by some bailout in the loop, but the type guarantee will disappear in landing pad if the bailout was not also hoisted). In this case we need add `Conv_PrimStr` back to make sure `String` is passed to `SetConcatStrMultiItemBE` as src operands.