### PR TITLE
fix an issue on scriptContext close on OOM

### DIFF
--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -658,8 +658,11 @@ namespace Js
         this->EnsureClearDebugDocument();
         if (this->debugContext != nullptr)
         {
-            this->debugContext->GetProbeContainer()->UninstallInlineBreakpointProbe(NULL);
-            this->debugContext->GetProbeContainer()->UninstallDebuggerScriptOptionCallback();
+            if(this->debugContext->GetProbeContainer())
+            {
+                this->debugContext->GetProbeContainer()->UninstallInlineBreakpointProbe(NULL);
+                this->debugContext->GetProbeContainer()->UninstallDebuggerScriptOptionCallback();
+            }
 
             // Guard the closing and deleting of DebugContext as in meantime PDM might
             // call OnBreakFlagChange


### PR DESCRIPTION
while initializing scriptContext, OOM can happen between initializeing debugContext and debugContext->diagProbesContainer.  should check this while closing scriptContext
