### PR TITLE
WASM: version 0x1

### DIFF
--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -387,6 +387,7 @@ PHASE(All)
 #else
     #define DEFAULT_CONFIG_WasmFastArray    (false)
 #endif
+#define DEFAULT_CONFIG_WasmCheckVersion     (true)
 #define DEFAULT_CONFIG_WasmFold             (true)
 #define DEFAULT_CONFIG_BgJitDelayFgBuffer   (0)
 #define DEFAULT_CONFIG_BgJitPendingFuncCap  (31)
@@ -857,6 +858,7 @@ FLAGNR(Boolean, AsmJsStopOnError      , "Stop execution on any AsmJs validation 
 FLAGNR(Boolean, AsmJsEdge             , "Enable asm.js features which may have backward incompatible changes or not validate on old demos", DEFAULT_CONFIG_AsmJsEdge)
 FLAGNR(Boolean, WasmI64               , "Enable Int64 testing for WebAssembly. ArgIns can be [number,string,{low:number,high:number}]. Return values will be {low:number,high:number}", DEFAULT_CONFIG_WasmI64)
 FLAGNR(Boolean, WasmFastArray         , "Enable fast array implementation for WebAssembly", DEFAULT_CONFIG_WasmFastArray)
+FLAGNR(Boolean, WasmCheckVersion      , "Check the binary version for WebAssembly", DEFAULT_CONFIG_WasmCheckVersion)
 
 #ifndef COMPILE_DISABLE_Simdjs
     #define COMPILE_DISABLE_Simdjs 0

--- a/lib/WasmReader/WasmBinaryReader.cpp
+++ b/lib/WasmReader/WasmBinaryReader.cpp
@@ -487,9 +487,17 @@ WasmBinaryReader::ValidateModuleHeader()
         ThrowDecodingError(_u("Malformed WASM module header!"));
     }
 
-    if (version != experimentalVersion)
+    if (CONFIG_FLAG(WasmCheckVersion))
     {
-        ThrowDecodingError(_u("Invalid WASM version!"));
+        // Accept version 0xd to avoid problem in our test infrastructure
+        // We should eventually remove support for 0xd.
+        // The Assert is here as a reminder in case we change the binary version and we haven't removed 0xd support yet
+        CompileAssert(binaryVersion == 0x1);
+
+        if (version != binaryVersion && version != 0xd)
+        {
+            ThrowDecodingError(_u("Invalid WASM version!"));
+        }
     }
 }
 

--- a/lib/WasmReader/WasmBinaryReader.h
+++ b/lib/WasmReader/WasmBinaryReader.h
@@ -29,7 +29,7 @@ namespace Wasm
         const char* name;
     };
 
-    static const unsigned int experimentalVersion = 0xd;
+    static const unsigned int binaryVersion = 0x1;
 
     class WasmBinaryReader : public WasmReaderBase
     {

--- a/test/wasm/bugs.js
+++ b/test/wasm/bugs.js
@@ -3,6 +3,7 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 WScript.Flag("-wasmI64");
+WScript.Flag("-wasmcheckversion-");
 function createView(bytes) {
   const buffer = new ArrayBuffer(bytes.length);
   const view = new Uint8Array(buffer);
@@ -17,18 +18,18 @@ async function main() {
   bar();
 
   try {
-    new WebAssembly.Module(createView(`\x00asm\x0d\x00\x00\x00\xff\xff\xff\xff\x7f\x00\x00\x00`));
+    new WebAssembly.Module(createView(`\x00asm\x01\x00\x00\x00\xff\xff\xff\xff\x7f\x00\x00\x00`));
     console.log("Should have had an error");
   } catch (e) {
-    if (!(e instanceof WebAssembly.CompileError)) {
+    if (!(e instanceof WebAssembly.CompileError && e.message.includes("Invalid known section opcode"))) {
       throw e;
     }
   }
   try {
-    new WebAssembly.Module(createView(`\x00asm\x0d\x00\x00\x00\x7f\x00\x00\x00`));
+    new WebAssembly.Module(createView(`\x00asm\x01\x00\x00\x00\x7f\x00\x00\x00`));
     console.log("Should have had an error");
   } catch (e) {
-    if (!(e instanceof WebAssembly.CompileError)) {
+    if (!(e instanceof WebAssembly.CompileError && e.message.includes("Invalid known section opcode"))) {
       throw e;
     }
   }
@@ -46,4 +47,6 @@ async function main() {
   }
 }
 
-main().then(() => console.log("PASSED"), console.log);
+main().then(() => console.log("PASSED"), err => {
+  console.log(err.stack);
+});


### PR DESCRIPTION
Accept binary version 0x1. 
Still accept version 0xd for a while to give us time to move our infra completely. 
Added flag -WasmCheckVersion to be able to do -WasmCheckVersion- in test infra where the binary version is rarely a problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/2643)
<!-- Reviewable:end -->
