### PR TITLE
Module export field issue with namespace.

### DIFF
--- a/lib/Runtime/Language/ModuleNamespace.cpp
+++ b/lib/Runtime/Language/ModuleNamespace.cpp
@@ -77,8 +77,7 @@ namespace Js
                 AssertMsg(exportNameId != Js::Constants::NoProperty, "should have been initialized already");
                 // ignore local exports that are actually indirect exports.
                 if (sourceTextModuleRecord->GetImportEntryList() == nullptr ||
-                    (sourceTextModuleRecord->ResolveImport(localNameId, &importRecord)
-                    && importRecord == nullptr))
+                    !sourceTextModuleRecord->ResolveImport(localNameId, &importRecord))
                 {
                     BigPropertyIndex index = sourceTextModuleRecord->GetLocalExportSlotIndexByExportName(exportNameId);
                     Assert((uint)index < sourceTextModuleRecord->GetLocalExportCount());

--- a/test/es6/module_1_2645.js
+++ b/test/es6/module_1_2645.js
@@ -1,0 +1,6 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+import * as mod2 from "module_2_2645.js";
+export function simpleExport() { return 'exported'; }

--- a/test/es6/module_2_2645.js
+++ b/test/es6/module_2_2645.js
@@ -1,0 +1,5 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+export function simpleExport() { return 'module2.exported'; }

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -1367,6 +1367,12 @@
     </default>
 </test>
 <test>
+    <default>
+        <files>test_bug_2645.js</files>
+        <compile-flags>-ES6Module</compile-flags>
+    </default>
+</test>
+<test>
   <default>
     <files>OS_5500719.js</files>
     <compile-flags>-forceserialized</compile-flags>

--- a/test/es6/test_bug_2645.js
+++ b/test/es6/test_bug_2645.js
@@ -1,0 +1,10 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+// Validation for the github issue 2645
+
+WScript.LoadModule(`import * as mod1 from 'module_1_2645.js';
+var ret = mod1.simpleExport();
+print(ret === "exported" ? "PASS" : "FAILED");
+`);


### PR DESCRIPTION
The export function is not put to the module namespace object as the logic of namespace's initialize has an issue. We should be putting the exports to the namespace if we don't find it in the importlist. However the logic was saying otherwise. Fixed that.
