### PR TITLE
Fix miss OptInstr for InlineeEnd after upward it to follow BailOnNoProfile.

### DIFF
--- a/lib/Backend/FlowGraph.cpp
+++ b/lib/Backend/FlowGraph.cpp
@@ -1722,7 +1722,7 @@ FlowGraph::RemoveUnreachableBlocks()
 
 // If block has no predecessor, remove it.
 bool
-FlowGraph::RemoveUnreachableBlock(BasicBlock *block, GlobOpt * globOpt)
+FlowGraph::RemoveUnreachableBlock(BasicBlock *block, GlobOpt * globOpt, IR::Instr ** pUpwardedInstr)
 {
     bool isDead = false;
 
@@ -1745,7 +1745,7 @@ FlowGraph::RemoveUnreachableBlock(BasicBlock *block, GlobOpt * globOpt)
 
     if (isDead)
     {
-        this->RemoveBlock(block, globOpt);
+        this->RemoveBlock(block, globOpt, false /* tailDuping */, pUpwardedInstr);
         return true;
     }
     return false;
@@ -2641,8 +2641,21 @@ FlowGraph::RemoveInstr(IR::Instr *instr, GlobOpt * globOpt)
 // or it to after BailOnNoProfile above current InlineeEnd. The new InlineeEnd will be
 // visited by linearscan to generate InlineeFrameRecord.
 void
-FlowGraph::UpwardInlineeEndBeforeRemoving(BasicBlock * block, IR::Instr * inlineeEnd)
+FlowGraph::UpwardInlineeEndBeforeRemoving(
+    BasicBlock * block,
+    IR::Instr * inlineeEnd,
+    BVSparse<JitArenaAllocator> * visitedBlocks,
+    IR::Instr ** pUpwardedInstr)
 {
+
+    if (visitedBlocks->Test(block->GetBlockNum()))
+    {
+        return;
+    }
+    else
+    {
+        visitedBlocks->Set(block->GetBlockNum());
+    }
     bool stopUpward = false;
 
     FOREACH_INSTR_BACKWARD_IN_BLOCK_EDITING(instr, instrPrev, block)
@@ -2657,7 +2670,11 @@ FlowGraph::UpwardInlineeEndBeforeRemoving(BasicBlock * block, IR::Instr * inline
 
             case Js::OpCode::BailOnNoProfile:
             {
-                instr->InsertAfter(inlineeEnd->Copy());
+                Assert(pUpwardedInstr != nullptr);
+
+                IR::Instr * copiedInstr = inlineeEnd->Copy();
+                *pUpwardedInstr = copiedInstr;
+                instr->InsertAfter(copiedInstr);
 
                 stopUpward = true;
                 break;
@@ -2680,13 +2697,13 @@ FlowGraph::UpwardInlineeEndBeforeRemoving(BasicBlock * block, IR::Instr * inline
     {
         FOREACH_SLISTBASECOUNTED_ENTRY(FlowEdge*, edge, block->GetDeadPredList())
         {
-            UpwardInlineeEndBeforeRemoving(edge->GetPred(), inlineeEnd);
+            UpwardInlineeEndBeforeRemoving(edge->GetPred(), inlineeEnd, visitedBlocks, pUpwardedInstr);
         } NEXT_SLISTBASECOUNTED_ENTRY;
     }
 }
 
 void
-FlowGraph::RemoveBlock(BasicBlock *block, GlobOpt * globOpt, bool tailDuping)
+FlowGraph::RemoveBlock(BasicBlock *block, GlobOpt * globOpt, bool tailDuping, IR::Instr ** pUpwardedInstr)
 {
     Assert(!block->isDead && !block->isDeleted);
     IR::Instr * lastInstr = nullptr;
@@ -2707,11 +2724,15 @@ FlowGraph::RemoveBlock(BasicBlock *block, GlobOpt * globOpt, bool tailDuping)
         }
         else
         {
-            if (instr->m_opcode == Js::OpCode::InlineeEnd && instr->m_func->m_hasInlineArgsOpt)
+            if (instr->m_opcode == Js::OpCode::InlineeEnd && instr->m_func->m_hasInlineArgsOpt &&
+                pUpwardedInstr != nullptr && instr->GetSrc2()->GetStackSym()->GetInstrDef())
             {
+                NoRecoverMemoryJitArenaAllocator tempAlloc(_u("BE-FlowGraph-RemoveBlock"), this->func->m_alloc->GetPageAllocator(), Js::Throw::OutOfMemory);
+                BVSparse<JitArenaAllocator> * visitedBlocks = JitAnew(&tempAlloc, BVSparse<JitArenaAllocator>, &tempAlloc);
+
                 FOREACH_SLISTBASECOUNTED_ENTRY(FlowEdge*, edge, block->GetDeadPredList())
                 {
-                    UpwardInlineeEndBeforeRemoving(edge->GetPred(), instr);
+                    UpwardInlineeEndBeforeRemoving(edge->GetPred(), instr, visitedBlocks, pUpwardedInstr);
                 } NEXT_SLISTBASECOUNTED_ENTRY;
             }
 

--- a/lib/Backend/FlowGraph.h
+++ b/lib/Backend/FlowGraph.h
@@ -158,15 +158,18 @@ public:
     BasicBlock * InsertAirlockBlock(FlowEdge * edge);
     void         InsertCompBlockToLoopList(Loop *loop, BasicBlock* compBlock, BasicBlock* targetBlock, bool postTarget);
     void         RemoveUnreachableBlocks();
-    bool         RemoveUnreachableBlock(BasicBlock *block, GlobOpt * globOpt = nullptr);
+    bool         RemoveUnreachableBlock(BasicBlock *block, GlobOpt * globOpt = nullptr, IR::Instr ** pUpwardedInstr = nullptr);
     IR::Instr *  RemoveInstr(IR::Instr *instr, GlobOpt * globOpt);
-    void         RemoveBlock(BasicBlock *block, GlobOpt * globOpt = nullptr, bool tailDuping = false);
+    void         RemoveBlock(BasicBlock *block, GlobOpt * globOpt = nullptr, bool tailDuping = false, IR::Instr ** upwardedInstr = nullptr);
     BasicBlock * SetBlockTargetAndLoopFlag(IR::LabelInstr * labelInstr);
     Func*        GetFunc() { return func;};
     static void  SafeRemoveInstr(IR::Instr *instr);
     void         SortLoopLists();
     FlowEdge *   FindEdge(BasicBlock *predBlock, BasicBlock *succBlock);
-    void         UpwardInlineeEndBeforeRemoving(BasicBlock * block, IR::Instr * inlineeEnd);
+    void         UpwardInlineeEndBeforeRemoving(BasicBlock * block,
+                                                IR::Instr * inlineeEnd,
+                                                BVSparse<JitArenaAllocator> * visitedBlocks,
+                                                IR::Instr ** pUpwardedInstr);
 
 #if DBG_DUMP
     void         Dump();

--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -541,8 +541,14 @@ GlobOpt::ForwardPass()
 void
 GlobOpt::OptBlock(BasicBlock *block)
 {
-    if (this->func->m_fg->RemoveUnreachableBlock(block, this))
+    IR::Instr * upwardedInstr = nullptr;
+    if (this->func->m_fg->RemoveUnreachableBlock(block, this, &upwardedInstr))
     {
+        if (upwardedInstr)
+        {
+            bool isInstrRemoved = false;
+            this->OptInstr(upwardedInstr, &isInstrRemoved);
+        }
         GOPT_TRACE(_u("Removing unreachable block #%d\n"), block->GetBlockNum());
         return;
     }


### PR DESCRIPTION
In the previous fix #2582 which upwards `InlineeEnd` to follow `BailOnNoProfile`, it missed to call `OptInstr` on the upwarded `InlineeEnd` because this is in forward pass. Also added checks to ensure each block is visited one time at most in upward traversal.