### PR TITLE
Change error msg for Array.sort (Fix #2411)

### DIFF
--- a/lib/Runtime/Library/JavascriptArray.cpp
+++ b/lib/Runtime/Library/JavascriptArray.cpp
@@ -6594,7 +6594,7 @@ Case0:
                 bool useDefaultComparer = typeId == TypeIds_Undefined;
                 if (!useDefaultComparer)
                 {
-                    JavascriptError::ThrowTypeError(scriptContext, JSERR_FunctionArgument_NeedInternalObject, _u("Array.prototype.sort"));
+                    JavascriptError::ThrowTypeError(scriptContext, JSERR_FunctionArgument_NeedFunction, _u("Array.prototype.sort"));
                 }
             }
         }

--- a/test/Array/array_sort.baseline
+++ b/test/Array/array_sort.baseline
@@ -7,5 +7,5 @@ for,sample,some,strings,testing - Output different in cscript due to NaN
 1,2,3
 10
 1,1.2,4,4.8,12
-TypeError: Array.prototype.sort: argument is not a JavaScript object
+TypeError: Array.prototype.sort: argument is not a Function object
 1,2,3


### PR DESCRIPTION
Unfortunately, there is no "argument must be a function or undefined" message defined in `rterrors.h`. The closest one is `JSERR_FunctionArgument_NeedFunction`: argument is not a Function object.

See #2411 for the issue.