### PR TITLE
add CSE attributes for conv_prim to differentiate on signedness

### DIFF
--- a/lib/Backend/GlobOpt.h
+++ b/lib/Backend/GlobOpt.h
@@ -762,6 +762,24 @@ public:
     }
 };
 
+class ConvAttributes : public ExprAttributes
+{
+private:
+    static const uint DstUnsignedIndex = 0;
+    static const uint SrcUnsignedIndex = 1;
+
+public:
+    ConvAttributes(const ExprAttributes &exprAttributes) : ExprAttributes(exprAttributes)
+    {
+    }
+
+    ConvAttributes(const bool isDstUnsigned, const bool isSrcUnsigned)
+    {
+        SetBitAttribute(DstUnsignedIndex, isDstUnsigned);
+        SetBitAttribute(SrcUnsignedIndex, isSrcUnsigned);
+    }
+};
+
 class DstIsIntOrNumberAttributes : public ExprAttributes
 {
 private:

--- a/lib/Backend/GlobOptExpr.cpp
+++ b/lib/Backend/GlobOptExpr.cpp
@@ -276,6 +276,10 @@ GlobOpt::CSEAddInstr(
             return;
         }
         break;
+
+    case Js::OpCode::Conv_Prim:
+        exprAttributes = ConvAttributes(instr->GetDst()->IsUnsigned(), instr->GetSrc1()->IsUnsigned());
+        break;
     }
 
     ValueInfo *valueInfo = NULL;
@@ -506,6 +510,10 @@ GlobOpt::CSEOptimize(BasicBlock *block, IR::Instr * *const instrRef, Value **pSr
                 return false;
             }
             exprAttributes = IntMathExprAttributes(ignoredIntOverflowForCurrentInstr, ignoredNegativeZeroForCurrentInstr);
+            break;
+
+        case Js::OpCode::Conv_Prim:
+            exprAttributes = ConvAttributes(instr->GetDst()->IsUnsigned(), instr->GetSrc1()->IsUnsigned());
             break;
 
         default:

--- a/test/AsmJs/cseBug.baseline
+++ b/test/AsmJs/cseBug.baseline
@@ -1,3 +1,6 @@
 Successfully compiled asm.js code
 258
 258
+Successfully compiled asm.js code
+-1
+-1

--- a/test/AsmJs/cseBug.js
+++ b/test/AsmJs/cseBug.js
@@ -26,3 +26,15 @@ var buffer = new ArrayBuffer(1<<20);
 var asmModule = AsmModule(stdlib,env,buffer);
 print(asmModule(0));
 print(asmModule(0));
+
+let m = function (stdlib, foreign) {
+  'use asm';
+  function f() {
+    +4294967295;
+    return + +(-1 | 0);
+  }
+  return f;
+}({}, {});
+
+print(m());
+print(m());

--- a/test/AsmJs/rlexe.xml
+++ b/test/AsmJs/rlexe.xml
@@ -533,7 +533,7 @@
     <default>
       <files>cseBug.js</files>
       <baseline>cseBug.baseline</baseline>
-      <compile-flags>-testtrace:asmjs -simdjs</compile-flags>
+      <compile-flags>-testtrace:asmjs -forcedeferparse -simdjs</compile-flags>
     </default>
   </test>
   <test>


### PR DESCRIPTION
This was long-standing bug on asm.js and wasm where CSE would get incorrectly kick in when converting the same sym with signed and unsigned conversion.