### PR TITLE
Remove extra optimization on InlineeEnd which is not necessary

### DIFF
--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -544,10 +544,11 @@ GlobOpt::OptBlock(BasicBlock *block)
     IR::Instr * upwardedInstr = nullptr;
     if (this->func->m_fg->RemoveUnreachableBlock(block, this, &upwardedInstr))
     {
-        if (upwardedInstr)
+        if (upwardedInstr &&
+            upwardedInstr->m_opcode == Js::OpCode::InlineeEnd &&
+            upwardedInstr->m_func->m_hasInlineArgsOpt)
         {
-            bool isInstrRemoved = false;
-            this->OptInstr(upwardedInstr, &isInstrRemoved);
+            RecordInlineeFrameInfo(upwardedInstr);
         }
         GOPT_TRACE(_u("Removing unreachable block #%d\n"), block->GetBlockNum());
         return;


### PR DESCRIPTION
We do `OptInstr` on upwarded `InlineeEnd`, but the block is already been removed. So it is actually no need to do the extra optimizations, just need `RecordInlineeFrame`.