### PR TITLE
xplat: add --libs-only build.sh option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ project (CHAKRACORE)
 # Keep CMake from caching static/shared library
 # option. Otherwise, CMake fails to update cached
 # references
+
+# todo: create a sub cmake file to take care of _SH uncaching...
 if(SHARED_LIBRARY_SH)
     unset(SHARED_LIBRARY_SH CACHE)
     unset(STATIC_LIBRARY_SH CACHE)
@@ -16,6 +18,11 @@ if(STATIC_LIBRARY_SH)
     unset(STATIC_LIBRARY_SH CACHE)
     unset(SHARED_LIBRARY CACHE)
     set(STATIC_LIBRARY 1)
+endif()
+
+if(LIBS_ONLY_BUILD_SH)
+    unset(LIBS_ONLY_BUILD_SH CACHE)
+    set(CC_LIBS_ONLY_BUILD 1)
 endif()
 
 if(CC_USES_SYSTEM_ARCH_SH)

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -1,8 +1,10 @@
-if(NOT CC_TARGET_OS_ANDROID)
-    add_subdirectory (GCStress)
-endif()
+if(NOT CC_LIBS_ONLY_BUILD)
+    if(NOT CC_TARGET_OS_ANDROID)
+        add_subdirectory (GCStress)
+    endif()
 
-add_subdirectory (ch)
+    add_subdirectory (ch)
+endif()
 
 if (NOT STATIC_LIBRARY)
     add_subdirectory (ChakraCore)

--- a/build.sh
+++ b/build.sh
@@ -40,6 +40,7 @@ PRINT_USAGE() {
     echo " -n, --ninja           Build with ninja instead of make."
     echo "     --no-icu          Compile without unicode/icu support."
     echo "     --no-jit          Disable JIT"
+    echo "     --libs-only       Do not build CH and GCStress"
     echo "     --lto             Enables LLVM Full LTO"
     echo "     --lto-thin        Enables LLVM Thin LTO - xcode 8+ or clang 3.9+"
     echo "     --static          Build as static library. Default: shared library"
@@ -95,6 +96,7 @@ WB_ARGS=
 TARGET_PATH=0
 # -DCMAKE_EXPORT_COMPILE_COMMANDS=ON useful for clang-query tool
 CMAKE_EXPORT_COMPILE_COMMANDS="-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
+LIBS_ONLY_BUILD=
 
 if [ -f "/proc/version" ]; then
     OS_LINUX=1
@@ -207,6 +209,10 @@ while [[ $# -gt 0 ]]; do
     --icu=*)
         ICU_PATH=$1
         ICU_PATH="-DICU_INCLUDE_PATH_SH=${ICU_PATH:6}"
+        ;;
+
+    --libs-only)
+        LIBS_ONLY_BUILD="-DLIBS_ONLY_BUILD_SH=1"
         ;;
 
     --lto)
@@ -487,7 +493,7 @@ fi
 echo Generating $BUILD_TYPE makefiles
 cmake $CMAKE_GEN $CC_PREFIX $ICU_PATH $LTO $STATIC_LIBRARY $ARCH $TARGET_OS \
     $ENABLE_CC_XPLAT_TRACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE $SANITIZE $NO_JIT \
-    $WITHOUT_FEATURES $WB_FLAG $WB_ARGS $CMAKE_EXPORT_COMPILE_COMMANDS \
+    $WITHOUT_FEATURES $WB_FLAG $WB_ARGS $CMAKE_EXPORT_COMPILE_COMMANDS $LIBS_ONLY_BUILD\
     ../..
 
 _RET=$?


### PR DESCRIPTION
This is to keep `build.sh` from compiling `ch/gcstress`. So, the embedder doesn't have to feed chakracore with third party libs for static library builds.