### PR TITLE
Fix type mismatch for mono type check

### DIFF
--- a/lib/Backend/BackwardPass.cpp
+++ b/lib/Backend/BackwardPass.cpp
@@ -4474,7 +4474,12 @@ BackwardPass::TrackObjTypeSpecProperties(IR::PropertySymOpnd *opnd, BasicBlock *
                         // Some instr protected by this one requires a monomorphic type check. (E.g., final type opt,
                         // fixed field not loaded from prototype.) Note the IsTypeAvailable test above: only do this at
                         // the initial type check that protects this path.
-                        opnd->SetMonoGuardType(bucket->GetMonoGuardType());
+                        JITTypeHolder monoGuardType = bucket->GetMonoGuardType();
+                        opnd->SetMonoGuardType(monoGuardType);
+                        if (monoGuardType != opnd->GetType())
+                        {
+                            opnd->SetTypeMismatch(true);
+                        }
                         this->currentInstr->ChangeEquivalentToMonoTypeCheckBailOut();
                     }
                     bucket->SetMonoGuardType(nullptr);

--- a/test/Bugs/MismatchTypeForMonoTypeCheck.js
+++ b/test/Bugs/MismatchTypeForMonoTypeCheck.js
@@ -1,0 +1,32 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function test0() {
+  var loopInvariant = 10;
+  var obj0 = {};
+  var arrObj0 = {};
+  var litObj1 = { prop0: 0 };
+  function func3 () {
+    do {
+      if (9 >= loopInvariant) {
+        break;
+      }
+      this.prop0 = typeof 197985440;
+    } while (false);
+  };
+  var func4 = function () {
+    while (func3() >>> parseInt(typeof Number)) {
+    }
+  };
+  obj0.method0 = func3;
+  arrObj0.method1 = func4;
+  var protoObj0 = Object(obj0);
+  if (!protoObj0.method0.call(litObj1)) {
+    arrObj0.method1();
+  }
+}
+test0();
+test0();
+WScript.Echo('pass');

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -376,7 +376,7 @@
   <test>
     <default>
       <files>Math.abs_TypeSpecOnIntMin.js</files>
-      <compile-flags>-loopinterpretcount:1 -bgjit- -maxsimplejitruncount:1 -maxinterpretcount:1 -oopjit-</compile-flags>
+      <compile-flags>-lic:1 -bgjit- -maxsimplejitruncount:1 -maxinterpretcount:1 -oopjit-</compile-flags>
     </default>
   </test>
   <test>
@@ -390,6 +390,12 @@
     <default>
       <files>MissToGenerateStStSlotForJITLoopBody.js</files>
       <compile-flags>-mic:1 -off:simplejit -oopjit- -bgjit-</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
+      <files>MismatchTypeForMonoTypeCheck.js</files>
+      <compile-flags>-lic:1 -off:simplejit -force:fixdataprops -oopjit- -bgjit-</compile-flags>
     </default>
   </test>
 </regress-exe>


### PR DESCRIPTION
For `PropertySymOpnd` which needs mono type check, we should check the `monoGuardType` is the same `Type` as the operand, or the slot index (cached type) in the operand is invalid for property access, like `LdSlot` and `StSlot`, even if mono type check passed.