### PR TITLE
remove global operator new/delete override

### DIFF
--- a/lib/Backend/BackendApi.cpp
+++ b/lib/Backend/BackendApi.cpp
@@ -197,5 +197,8 @@ SetProfilerFromNativeCodeGen(NativeCodeGenerator * toNativeCodeGen, NativeCodeGe
 
 void DeleteNativeCodeData(NativeCodeData * data)
 {
-    delete data;
+    if (data)
+    {
+        HeapDelete(data);
+    }
 }

--- a/lib/Backend/JITType.h
+++ b/lib/Backend/JITType.h
@@ -39,7 +39,7 @@ public:
     JITTypeHolderBase(JITType * t);
 
     template <class S>
-    JITTypeHolderBase(JITTypeHolderBase<S> other) : t(PointerValue(other.t)) {}
+    JITTypeHolderBase(const JITTypeHolderBase<S>& other) : t(PointerValue(other.t)) {}
 
     template <class S>
     void operator =(const JITTypeHolderBase<S> &other) { t = other.t; }

--- a/lib/Backend/NativeCodeData.cpp
+++ b/lib/Backend/NativeCodeData.cpp
@@ -4,7 +4,7 @@
 //-------------------------------------------------------------------------------------------------------
 #include "Backend.h"
 
-NativeCodeData::NativeCodeData(DataChunk * chunkList) 
+NativeCodeData::NativeCodeData(DataChunk * chunkList)
     : chunkList(chunkList)
 {
 #ifdef PERF_COUNTERS
@@ -169,7 +169,7 @@ NativeCodeData::VerifyExistFixupEntry(void* targetAddr, void* addrToFixup, void*
     {
         if (entry->addrOffset == offset)
         {
-            // The following assertions can be false positive in case a data field happen to 
+            // The following assertions can be false positive in case a data field happen to
             // have value fall into NativeCodeData memory range
             AssertMsg(entry->targetTotalOffset == targetChunk->offset, "Missing fixup");
             return;
@@ -188,12 +188,14 @@ NativeCodeData::DeleteChunkList(DataChunkT * chunkList)
     {
         DataChunkT * current = next;
         next = next->next;
-        delete current;
+
+        // TODO: Should be HeapDeletePlus, but we don't know plusSize
+        HeapDelete(current, AllocatorDeleteFlags::UnknownSize);
     }
 }
 
-NativeCodeData::Allocator::Allocator() 
-    : chunkList(nullptr), 
+NativeCodeData::Allocator::Allocator()
+    : chunkList(nullptr),
     lastChunkList(nullptr),
     isOOPJIT(JITManager::GetJITManager()->IsJITServer())
 {
@@ -226,7 +228,7 @@ char *
 NativeCodeData::Allocator::Alloc(DECLSPEC_GUARD_OVERFLOW size_t requestSize)
 {
     Assert(!finalized);
-    char * data = nullptr;    
+    char * data = nullptr;
     requestSize = Math::Align(requestSize, sizeof(void*));
 
     if (isOOPJIT)
@@ -237,9 +239,9 @@ NativeCodeData::Allocator::Alloc(DECLSPEC_GUARD_OVERFLOW size_t requestSize)
         // positive while verifying missing fixup entries
         // Allocation without zeroing out, and with bool field in the structure
         // will increase the chance of false positive because of reusing memory
-        // without zeroing, and the bool field is set to false, makes the garbage 
-        // memory not changed, and the garbage memory might be just pointing to the 
-        // same range of NativeCodeData memory, the checking tool will report false 
+        // without zeroing, and the bool field is set to false, makes the garbage
+        // memory not changed, and the garbage memory might be just pointing to the
+        // same range of NativeCodeData memory, the checking tool will report false
         // poisitive, see NativeCodeData::VerifyExistFixupEntry for more
         DataChunk * newChunk = HeapNewStructPlusZ(requestSize, DataChunk);
 #else
@@ -301,7 +303,7 @@ NativeCodeData::Allocator::AllocZero(DECLSPEC_GUARD_OVERFLOW size_t requestSize)
     // Allocated with HeapNewStructPlusZ for chk build
     memset(data, 0, requestSize);
 #else
-    if (!isOOPJIT) 
+    if (!isOOPJIT)
     {
         memset(data, 0, requestSize);
     }

--- a/lib/Backend/NativeCodeGenerator.cpp
+++ b/lib/Backend/NativeCodeGenerator.cpp
@@ -953,13 +953,13 @@ NativeCodeGenerator::CodeGen(PageAllocator * pageAllocator, CodeGenWorkItem* wor
             pNumberAllocator,
 #endif
             codeGenProfiler, !foreground);
-        
+
         if (!this->scriptContext->GetThreadContext()->GetPreReservedVirtualAllocator()->IsInRange((void*)jitWriteData.codeAddress))
         {
             this->scriptContext->GetJitFuncRangeCache()->AddFuncRange((void*)jitWriteData.codeAddress, jitWriteData.codeSize);
         }
     }
-    
+
     if (JITManager::GetJITManager()->IsOOPJITEnabled() && PHASE_VERBOSE_TRACE(Js::BackEndPhase, workItem->GetFunctionBody()))
     {
         LARGE_INTEGER freq;
@@ -1198,7 +1198,7 @@ void NativeCodeGenerator::LogCodeGenStart(CodeGenWorkItem * workItem, LARGE_INTE
             size_t sizeInChars = workItem->GetDisplayName(displayName, 256);
             if (sizeInChars > 256)
             {
-                displayName = new WCHAR[sizeInChars];
+                displayName = HeapNewArray(WCHAR, sizeInChars);
                 workItem->GetDisplayName(displayName, 256);
             }
             JS_ETW(EventWriteJSCRIPT_FUNCTION_JIT_START(
@@ -1213,7 +1213,7 @@ void NativeCodeGenerator::LogCodeGenStart(CodeGenWorkItem * workItem, LARGE_INTE
 
             if (displayName != displayNameBuffer)
             {
-                delete[] displayName;
+                HeapDeleteArray(sizeInChars, displayName);
             }
         }
     }
@@ -1315,7 +1315,7 @@ void NativeCodeGenerator::LogCodeGenDone(CodeGenWorkItem * workItem, LARGE_INTEG
             size_t sizeInChars = workItem->GetDisplayName(displayName, 256);
             if (sizeInChars > 256)
             {
-                displayName = new WCHAR[sizeInChars];
+                displayName = HeapNewArray(WCHAR, sizeInChars);
                 workItem->GetDisplayName(displayName, 256);
             }
             void* entryPoint;
@@ -1331,7 +1331,7 @@ void NativeCodeGenerator::LogCodeGenDone(CodeGenWorkItem * workItem, LARGE_INTEG
 
             if (displayName != displayNameBuffer)
             {
-                delete[] displayName;
+                HeapDeleteArray(sizeInChars, displayName);
             }
         }
     }
@@ -3194,7 +3194,7 @@ NativeCodeGenerator::QueueFreeNativeCodeGenAllocation(void* address)
         //DeRegister Entry Point for CFG
         ThreadContext::GetContextForCurrentThread()->SetValidCallTargetForCFG(address, false);
     }
-    
+
     if ((!JITManager::GetJITManager()->IsOOPJITEnabled() && !this->scriptContext->GetThreadContext()->GetPreReservedVirtualAllocator()->IsInRange((void*)address)) ||
         (JITManager::GetJITManager()->IsOOPJITEnabled() && !PreReservedVirtualAllocWrapper::IsInRange((void*)this->scriptContext->GetThreadContext()->GetPreReservedRegionAddr(), (void*)address)))
     {

--- a/lib/Common/Core/StackBackTrace.h
+++ b/lib/Common/Core/StackBackTrace.h
@@ -141,8 +141,8 @@ template <class T, LONG count, bool useStatic>
 struct _TraceRingBuffer
 {
     T* buf;
-    _TraceRingBuffer() { buf = new T[count]; }
-    ~_TraceRingBuffer() { delete[] buf; }
+    _TraceRingBuffer() { buf = HeapNewArray(T, count); }
+    ~_TraceRingBuffer() { HeapDeleteArray(count, buf); }
 };
 template <class T, LONG count>
 struct _TraceRingBuffer<T, count, true>

--- a/lib/Common/DataStructures/DictionaryStats.cpp
+++ b/lib/Common/DataStructures/DictionaryStats.cpp
@@ -15,7 +15,7 @@ DictionaryStats* DictionaryStats::Create(const char* name, uint bucketCount)
         Js::Configuration::Global.flags.ProfileDictionary < 0)
         return NULL;
 
-    return ::new DictionaryStats(name, bucketCount);
+    return NoCheckHeapNew(DictionaryStats, name, bucketCount);
 }
 
 DictionaryStats* DictionaryStats::Clone()
@@ -238,10 +238,10 @@ void DictionaryStats::ClearStats()
         {
             DictionaryStats *pCurrent = pNext;
             pNext = pNext->pNext;
-            delete pCurrent;
+            NoCheckHeapDelete(pCurrent);
         }
         current = current->pNext;
-        delete type;
+        NoCheckHeapDelete(type);
     }
     dictionaryTypes = NULL;
 }

--- a/lib/Common/DataStructures/ImmutableList.cpp
+++ b/lib/Common/DataStructures/ImmutableList.cpp
@@ -50,16 +50,16 @@ void regex::ImmutableStringBuilder<chunkSize>::AppendWithCopy(_In_z_ LPCWSTR str
     AssertMsg(str != nullptr, "str != nullptr");
     size_t strLength = wcslen(str) + 1; // include null-terminated
 
-    WCHAR* buffer = new WCHAR[strLength];
+    WCHAR* buffer = HeapNewNoThrowArray(WCHAR, strLength);
     IfNullThrowOutOfMemory(buffer);
     wcsncpy_s(buffer, strLength, str, strLength);
 
     // append in front of the tracked allocated strings
-    AllocatedStringChunk* newAllocatedString = new AllocatedStringChunk();
+    AllocatedStringChunk* newAllocatedString = HeapNewNoThrow(AllocatedStringChunk);
     if (newAllocatedString == nullptr)
     {
         // cleanup
-        delete[] buffer;
+        HeapDeleteArray(strLength, buffer);
         Js::Throw::OutOfMemory();
     }
 

--- a/lib/Common/Memory/Allocator.h
+++ b/lib/Common/Memory/Allocator.h
@@ -146,18 +146,29 @@ inline T* PostAllocationCallback(const type_info& objType, T *obj)
 
 #define AllocatorNewNoThrowNoRecoveryArrayZ(AllocatorType, alloc, T, count) AllocatorNewNoThrowNoRecoveryArrayBase(AllocatorType, alloc, AllocZero, T, count)
 
-#define AllocatorDelete(AllocatorType, alloc, obj) DeleteObject<AllocatorType>(alloc, obj)
-#define AllocatorDeleteInline(AllocatorType, alloc, obj) DeleteObjectInline<AllocatorType>(alloc, obj)
-#define AllocatorDeleteLeaf(TAllocator, alloc, obj) DeleteObject<ForceLeafAllocator<TAllocator>::AllocatorType>(alloc, obj)
-#define AllocatorDeletePlus(AllocatorType, alloc, size,  obj)  DeleteObject<AllocatorType>(alloc, obj, size);
-#define AllocatorDeletePlusLeaf(TAllocator, alloc, size,  obj)  DeleteObject<ForceLeafAllocator<TAllocator>::AllocatorType>(alloc, obj, size);
-#define AllocatorDeletePlusPrefix(AllocatorType, alloc, size,  obj)  DeleteObject<AllocatorType>(alloc, obj, size, true);
-#define AllocatorDeletePlusPrefixLeaf(TAllocator, alloc, size,  obj)  DeleteObject<ForceLeafAllocator<TAllocator>::AllocatorType>(alloc, obj, size, true);
-#define AllocatorDeleteArray(AllocatorType, alloc, count, obj) DeleteArray<AllocatorType>(alloc, count, obj)
-#define AllocatorDeleteArrayLeaf(TAllocator, alloc, count, obj) DeleteArray<ForceLeafAllocator<TAllocator>::AllocatorType>(alloc, count, obj)
+// A few versions below supplies optional flags through ..., used by HeapDelete.
+#define AllocatorDelete(AllocatorType, alloc, obj, ...) \
+        DeleteObject<AllocatorType, ##__VA_ARGS__>(alloc, obj)
+#define AllocatorDeleteInline(AllocatorType, alloc, obj) \
+        DeleteObjectInline<AllocatorType>(alloc, obj)
+#define AllocatorDeleteLeaf(TAllocator, alloc, obj) \
+        DeleteObject<ForceLeafAllocator<TAllocator>::AllocatorType>(alloc, obj)
+#define AllocatorDeletePlus(AllocatorType, alloc, size,  obj, ...) \
+        DeleteObject<AllocatorType, ##__VA_ARGS__>(alloc, obj, size);
+#define AllocatorDeletePlusLeaf(TAllocator, alloc, size,  obj) \
+        DeleteObject<ForceLeafAllocator<TAllocator>::AllocatorType>(alloc, obj, size);
+#define AllocatorDeletePlusPrefix(AllocatorType, alloc, size, obj, ...) \
+        DeleteObject<AllocatorType, ##__VA_ARGS__>(alloc, obj, size, true);
+#define AllocatorDeletePlusPrefixLeaf(TAllocator, alloc, size,  obj) \
+        DeleteObject<ForceLeafAllocator<TAllocator>::AllocatorType>(alloc, obj, size, true);
+#define AllocatorDeleteArray(AllocatorType, alloc, count, obj) \
+        DeleteArray<AllocatorType>(alloc, count, obj)
+#define AllocatorDeleteArrayLeaf(TAllocator, alloc, count, obj) \
+        DeleteArray<ForceLeafAllocator<TAllocator>::AllocatorType>(alloc, count, obj)
 
 // Free routine where we don't care about following C++ semantics (e.g. calling the destructor)
-#define AllocatorFree(alloc, freeFunc, obj, size) (alloc->*freeFunc)(obj, size)
+#define AllocatorFree(alloc, freeFunc, obj, size) \
+        (alloc->*freeFunc)((void*)obj, size)
 
 // default type allocator implementation
 template <typename TAllocator, typename T>
@@ -226,31 +237,43 @@ struct ForceLeafAllocator
     typedef TAllocator AllocatorType;
 };
 
-template <typename TAllocator, typename T>
+// Optional AllocatorDelete flags
+enum class AllocatorDeleteFlags
+{
+    None,
+    UnknownSize,  // used to bypass size check
+};
+template <typename T, AllocatorDeleteFlags deleteFlags>
+struct _AllocatorDelete
+{
+    static size_t Size() { return sizeof(T); }
+    static size_t Size(size_t plusSize) { return sizeof(T) + plusSize; }
+};
+template <typename T>
+struct _AllocatorDelete<T, AllocatorDeleteFlags::UnknownSize>
+{
+    static size_t Size() { return (size_t)-1; }
+    static size_t Size(size_t plusSize) { return (size_t)-1; }
+};
+
+template <typename TAllocator,
+          AllocatorDeleteFlags deleteFlags = AllocatorDeleteFlags::None,
+          typename T>
 void DeleteObject(typename AllocatorInfo<TAllocator, T>::AllocatorType * allocator, T * obj)
 {
     obj->~T();
 
     auto freeFunc = AllocatorInfo<TAllocator, T>::InstAllocatorFunc::GetFreeFunc(); // Use InstAllocatorFunc
-    (allocator->*freeFunc)(obj, sizeof(T));
+    (allocator->*freeFunc)(
+        (void*)obj, _AllocatorDelete<T, deleteFlags>::Size());
 }
 
-template <typename TAllocator, typename T>
+template <typename TAllocator,
+          AllocatorDeleteFlags deleteFlags = AllocatorDeleteFlags::None,
+          typename T>
 void DeleteObject(typename AllocatorInfo<TAllocator, T>::AllocatorType * allocator, WriteBarrierPtr<T> obj)
 {
-    obj->~T();
-
-    auto freeFunc = AllocatorInfo<TAllocator, T>::InstAllocatorFunc::GetFreeFunc(); // Use InstAllocatorFunc
-    (allocator->*freeFunc)(obj, sizeof(T));
-}
-
-template <typename TAllocator, typename T>
-void DeleteObject(typename AllocatorInfo<TAllocator, T>::AllocatorType * allocator, NoWriteBarrierPtr<T> obj)
-{
-    obj->~T();
-
-    auto freeFunc = AllocatorInfo<TAllocator, T>::InstAllocatorFunc::GetFreeFunc(); // Use InstAllocatorFunc
-    (allocator->*freeFunc)(obj, sizeof(T));
+    DeleteObject<TAllocator, deleteFlags>(allocator, PointerValue(obj));
 }
 
 template <typename TAllocator, typename T>
@@ -260,7 +283,9 @@ void DeleteObjectInline(TAllocator * allocator, T * obj)
     allocator->FreeInline(obj, sizeof(T));
 }
 
-template <typename TAllocator, typename T>
+template <typename TAllocator,
+          AllocatorDeleteFlags deleteFlags = AllocatorDeleteFlags::None,
+          typename T>
 void DeleteObject(typename AllocatorInfo<TAllocator, T>::AllocatorType * allocator, T * obj, size_t plusSize)
 {
     obj->~T();
@@ -270,10 +295,13 @@ void DeleteObject(typename AllocatorInfo<TAllocator, T>::AllocatorType * allocat
     Assert(sizeof(T) + plusSize >= sizeof(T));
 
     auto freeFunc = AllocatorInfo<TAllocator, T>::InstAllocatorFunc::GetFreeFunc(); // Use InstAllocatorFunc
-    (allocator->*freeFunc)(obj, sizeof(T) + plusSize);
+    (allocator->*freeFunc)(
+        (void*)obj, _AllocatorDelete<T, deleteFlags>::Size(plusSize));
 }
 
-template <typename TAllocator, typename T>
+template <typename TAllocator,
+          AllocatorDeleteFlags deleteFlags = AllocatorDeleteFlags::None,
+          typename T>
 void DeleteObject(typename AllocatorInfo<TAllocator, T>::AllocatorType * allocator, T * obj, size_t plusSize, bool prefix)
 {
     Assert(prefix);
@@ -287,7 +315,8 @@ void DeleteObject(typename AllocatorInfo<TAllocator, T>::AllocatorType * allocat
     Assert(plusSize == Math::Align<size_t>(plusSize, sizeof(size_t)));
 
     auto freeFunc = AllocatorInfo<TAllocator, T>::InstAllocatorFunc::GetFreeFunc(); // Use InstAllocatorFunc
-    (allocator->*freeFunc)(((char *)obj) - plusSize, sizeof(T) + plusSize);
+    (allocator->*freeFunc)(((char *)obj) - plusSize,
+        _AllocatorDelete<T, deleteFlags>::Size(plusSize));
 }
 
 #define ZERO_LENGTH_ARRAY (void *)sizeof(void *)
@@ -311,18 +340,54 @@ inline T * AllocateArray(TAllocator * allocator, char * (TAllocator::*AllocFunc)
     return new (allocator, AllocFunc) T[count];
 }
 
+// Skip item destructor loop on some trivial types. The loop is likely to be
+// optimized away in release build. Skipping it improves debug build.
+//
+struct _true_value { static const bool value = true; };
+struct _false_value { static const bool value = false; };
+template <typename T> struct _has_trivial_destructor : _false_value {};
+template <typename T> struct _has_trivial_destructor<T*> : _true_value {};
+template <> struct _has_trivial_destructor<char> : _true_value {};
+template <> struct _has_trivial_destructor<const char> : _true_value {};
+template <> struct _has_trivial_destructor<unsigned char> : _true_value {};
+template <> struct _has_trivial_destructor<char16> : _true_value {};
+template <> struct _has_trivial_destructor<const char16> : _true_value {};
+template <> struct _has_trivial_destructor<int> : _true_value {};
+
+template <bool trivial_destructor>
+struct _DestructArray
+{
+    template <typename T>
+    static void Destruct(size_t count, T* obj)
+    {
+        for (size_t i = 0; i < count; i++)
+        {
+            obj[i].~T();
+        }
+    }
+};
+template <>
+struct _DestructArray</*trivial_destructor*/true>
+{
+    template <typename T>
+    static void Destruct(size_t count, T* obj) {}
+};
+
+template <typename T>
+void DestructArray(size_t count, T* obj)
+{
+    _DestructArray<_has_trivial_destructor<T>::value>::Destruct(count, obj);
+}
+
 template <typename TAllocator, typename T>
 void DeleteArray(typename AllocatorInfo<TAllocator, T>::AllocatorType * allocator, size_t count, T * obj)
 {
-    if(count == 0)
+    if (count == 0)
     {
         return;
     }
 
-    for (size_t i = 0; i < count; i++)
-    {
-        obj[i].~T();
-    }
+    DestructArray(count, obj);
 
     // DeleteArray can only be called when an array is allocated successfully.
     // So the add should never overflow

--- a/lib/Common/Memory/ArenaAllocator.h
+++ b/lib/Common/Memory/ArenaAllocator.h
@@ -802,16 +802,21 @@ class RefCounted
     volatile LONG refCount;
 
 protected:
-    virtual ~RefCounted()
-    {
-    }
-
-public:
     RefCounted()
         : refCount(1)
     {
     }
 
+    virtual ~RefCounted()
+    {
+    }
+
+    void operator delete(void* p, size_t size)
+    {
+        HeapFree(p, size);
+    }
+
+public:
     uint32 AddRef(void)
     {
         return (uint32)InterlockedIncrement(&refCount);
@@ -823,7 +828,7 @@ public:
 
         if (0 == refs)
         {
-            delete this;
+            delete this;  // invokes overrided operator delete
         }
 
         return refs;
@@ -882,7 +887,6 @@ class ReferencedArenaAdapter : public RefCounted
     bool deleteFlag;
 
 public:
-
     ~ReferencedArenaAdapter()
     {
         if (this->arena)

--- a/lib/Common/Memory/HeapAllocatorOperators.cpp
+++ b/lib/Common/Memory/HeapAllocatorOperators.cpp
@@ -8,6 +8,16 @@
 // Default operator new/delete overrides
 //----------------------------------------
 
+// Update:
+//
+// Overriding global operator new/delete causes problems in host.
+// Do not use global operator new/delete.
+//
+// To support memory tracking, use explicit HeapNew/HeapDelete.
+//
+
+// Only keep following for Chakra Full
+#ifdef NTBUILD
 _Ret_maybenull_ void * __cdecl
 operator new(DECLSPEC_GUARD_OVERFLOW size_t byteSize)
 {
@@ -31,3 +41,4 @@ operator delete[](void * obj) _NOEXCEPT_
 {
     HeapAllocator::Instance.Free(obj, (size_t)-1);
 }
+#endif

--- a/lib/Parser/Hash.cpp
+++ b/lib/Parser/Hash.cpp
@@ -34,7 +34,7 @@ HashTbl * HashTbl::Create(uint cidHash, ErrHandler * perr)
         return nullptr;
     if (!phtbl->Init(cidHash))
     {
-        delete phtbl;
+        delete phtbl;  // invokes overrided operator delete
         return nullptr;
     }
 

--- a/lib/Parser/Hash.h
+++ b/lib/Parser/Hash.h
@@ -318,7 +318,7 @@ public:
 
     void Release(void)
     {
-        delete this;
+        delete this;  // invokes overrided operator delete
     }
 
 
@@ -378,8 +378,8 @@ public:
     NoReleaseAllocator* GetAllocator() {return &m_noReleaseAllocator;}
 
     bool Contains(_In_reads_(cch) LPCOLESTR prgch, int32 cch);
-private:
 
+private:
     NoReleaseAllocator m_noReleaseAllocator;            // to allocate identifiers
     Ident ** m_prgpidName;        // hash table for names
 
@@ -395,6 +395,11 @@ private:
         memset(&m_rpid, 0, sizeof(m_rpid));
     }
     ~HashTbl(void) {}
+
+    void operator delete(void* p, size_t size)
+    {
+        HeapFree(p, size);
+    }
 
     // Called to grow the number of buckets in the table to reduce the table density.
     void Grow();

--- a/lib/Parser/Scan.cpp
+++ b/lib/Parser/Scan.cpp
@@ -1713,7 +1713,7 @@ tokens Scanner<EncodingPolicy>::ScanForcingPid()
             {
                 this->m_DeferredParseFlags = deferredParseFlagsSave;
             });
-        
+
         return result;
     }
     return Scan();
@@ -1748,7 +1748,7 @@ tokens Scanner<EncodingPolicy>::ScanCore(bool identifyKwds)
     EncodedCharPtr p = m_currentCharacter;
     EncodedCharPtr last = m_pchLast;
     bool seenDelimitedCommentEnd = false;
-    
+
     // store the last token
     m_tkPrevious = m_ptoken->tk;
     m_iecpLimTokPrevious = IecpLimTok();    // Introduced for use by lambda parsing to find correct span of expression lambdas

--- a/lib/Parser/Scan.h
+++ b/lib/Parser/Scan.h
@@ -370,7 +370,7 @@ public:
     }
     void Release(void)
     {
-        delete this;
+        delete this;  // invokes overrided operator delete
     }
 
     tokens Scan();
@@ -713,6 +713,11 @@ private:
 
     Scanner(Parser* parser, HashTbl *phtbl, Token *ptoken, ErrHandler *perr, Js::ScriptContext *scriptContext);
     ~Scanner(void);
+
+    void operator delete(void* p, size_t size)
+    {
+        HeapFree(p, size);
+    }
 
     template <bool forcePid>
     void SeekAndScan(const RestorePoint& restorePoint);

--- a/lib/Runtime/Base/EtwTrace.h
+++ b/lib/Runtime/Base/EtwTrace.h
@@ -79,11 +79,12 @@ enum MethodType : uint16
     Assert(entryPoint->IsNativeCode());                                                             \
     char16 functionNameArray[NameBufferLength];                                                     \
     const char16 *functionName;                                                                     \
+    size_t requiredCharCapacity = 0;                                                                \
     bool deleteFunctionName = false;                                                                \
     const ExecutionMode jitMode = entryPoint->GetJitMode();                                         \
     if(jitMode == ExecutionMode::SimpleJit)                                                         \
     {                                                                                               \
-        const size_t requiredCharCapacity =                                                         \
+        requiredCharCapacity =                                                                      \
             GetSimpleJitFunctionName(Body, functionNameArray, _countof(functionNameArray));         \
         if(requiredCharCapacity == 0)                                                               \
         {                                                                                           \
@@ -92,7 +93,7 @@ enum MethodType : uint16
         else                                                                                        \
         {                                                                                           \
             Assert(requiredCharCapacity > NameBufferLength);                                        \
-            char16 *const allocatedFunctionName = new char16[requiredCharCapacity];                 \
+            char16 *const allocatedFunctionName = HeapNewNoThrowArray(char16, requiredCharCapacity);\
             if(allocatedFunctionName)                                                               \
             {                                                                                       \
                 const size_t newRequiredCharCapacity =                                              \
@@ -136,7 +137,7 @@ enum MethodType : uint16
         functionName);                                                                              \
     if(deleteFunctionName)                                                                          \
     {                                                                                               \
-        delete[] functionName;                                                                      \
+        HeapDeleteArray(requiredCharCapacity, functionName);                                        \
     }
 
 #define LogMethodInterpretedThunkEvent(Function, Body)                        \
@@ -172,7 +173,7 @@ enum MethodType : uint16
     size_t bufferSize = GetLoopBodyName(Body, loopHeader, loopBodyName, NameBufferLength);                 \
     if(bufferSize > NameBufferLength) /* insufficient buffer space*/                                       \
     {                                                                                                      \
-        loopBodyName = new WCHAR[bufferSize];                                                              \
+        loopBodyName = HeapNewNoThrowArray(WCHAR, bufferSize);                                             \
         if(loopBodyName)                                                                                   \
         {                                                                                                  \
             GetLoopBodyName(Body, loopHeader, loopBodyName, bufferSize);                                   \
@@ -206,7 +207,7 @@ enum MethodType : uint16
         loopBodyName);                                                                                     \
     if(loopBodyNameArray != loopBodyName)                                                                  \
     {                                                                                                      \
-        delete[] loopBodyName;                                                                             \
+        HeapDeleteArray(bufferSize, loopBodyName);                                                         \
     }
 
 
@@ -218,7 +219,7 @@ enum MethodType : uint16
     size_t bufferSize = Body->GetLoopBodyName(loopNumber, loopBodyName, NameBufferLength);                 \
     if(bufferSize > NameBufferLength) /* insufficient buffer space*/                                       \
     {                                                                                                      \
-        loopBodyName = new WCHAR[bufferSize];                                                              \
+        loopBodyName = HeapNewNoThrowArray(WCHAR, bufferSize);                                             \
         if(loopBodyName)                                                                                   \
         {                                                                                                  \
             GetLoopBodyName(Body, loopHeader, loopBodyName, bufferSize);                                   \
@@ -252,7 +253,7 @@ enum MethodType : uint16
         loopBodyName);                                                                                     \
     if(loopBodyNameArray != loopBodyName)                                                                  \
     {                                                                                                      \
-        delete[] loopBodyName;                                                                             \
+        HeapDeleteArray(bufferSize, loopBodyName);                                                         \
     }
 
 //

--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -3813,6 +3813,7 @@ namespace Js
         ScriptContext* scriptContext = function->GetScriptContext();
         bool functionEnterEventSent = false;
         char16 *pwszExtractedFunctionName = NULL;
+        size_t functionNameLen = 0;
         const char16 *pwszFunctionName = NULL;
         HRESULT hrOfEnterEvent = S_OK;
 
@@ -3872,16 +3873,16 @@ namespace Js
                         const char16 *pwszNameEnd = wcsstr(pwszToString, _u("("));
                         if (pwszNameStart == nullptr || pwszNameEnd == nullptr || ((int)(pwszNameEnd - pwszNameStart) <= 0))
                         {
-                            int len = ((JavascriptString *)sourceString)->GetLength() + 1;
-                            pwszExtractedFunctionName = new char16[len];
-                            wcsncpy_s(pwszExtractedFunctionName, len, pwszToString, _TRUNCATE);
+                            functionNameLen = ((JavascriptString *)sourceString)->GetLength() + 1;
+                            pwszExtractedFunctionName = HeapNewArray(char16, functionNameLen);
+                            wcsncpy_s(pwszExtractedFunctionName, functionNameLen, pwszToString, _TRUNCATE);
                         }
                         else
                         {
-                            int len = (int)(pwszNameEnd - pwszNameStart);
-                            AssertMsg(len > 0, "Allocating array with zero or negative length?");
-                            pwszExtractedFunctionName = new char16[len];
-                            wcsncpy_s(pwszExtractedFunctionName, len, pwszNameStart + 1, _TRUNCATE);
+                            functionNameLen = pwszNameEnd - pwszNameStart;
+                            AssertMsg(functionNameLen < INT_MAX, "Allocating array with zero or negative length?");
+                            pwszExtractedFunctionName = HeapNewArray(char16, functionNameLen);
+                            wcsncpy_s(pwszExtractedFunctionName, functionNameLen, pwszNameStart + 1, _TRUNCATE);
                         }
                         pwszFunctionName = pwszExtractedFunctionName;
                     }
@@ -3998,7 +3999,7 @@ namespace Js
                             scriptContext->OnDispatchFunctionExit(pwszFunctionName);
                             if (pwszExtractedFunctionName != NULL)
                             {
-                                delete[]pwszExtractedFunctionName;
+                                HeapDeleteArray(functionNameLen, pwszExtractedFunctionName);
                             }
                         }
                     }
@@ -4468,7 +4469,7 @@ void ScriptContext::RegisterConstructorCache(Js::PropertyId propertyId, Js::Cons
 }
 #endif
 
-JITPageAddrToFuncRangeCache * 
+JITPageAddrToFuncRangeCache *
 ScriptContext::GetJitFuncRangeCache()
 {
     return jitFuncRangeCache;
@@ -6149,7 +6150,7 @@ void ScriptContext::RegisterPrototypeChainEnsuredToHaveOnlyWritableDataPropertie
     {
         return jitPageAddrToFuncRangeMap;
     }
-    
+
     JITPageAddrToFuncRangeCache::LargeJITFuncAddrToSizeMap * JITPageAddrToFuncRangeCache::GetLargeJITFuncAddrToSizeMap()
     {
         return largeJitFuncToSizeMap;

--- a/lib/Runtime/Base/WindowsGlobalizationAdapter.cpp
+++ b/lib/Runtime/Base/WindowsGlobalizationAdapter.cpp
@@ -151,7 +151,7 @@ namespace Js
     public:
         HRESULT RuntimeClassInitialize(HSTRING *string, uint32 length)
         {
-            this->items = new HSTRING[length];
+            this->items = HeapNewNoThrowArray(HSTRING, length);
 
             if (this->items == nullptr)
             {
@@ -171,7 +171,7 @@ namespace Js
         {
             if(this->items != nullptr)
             {
-                delete [] items;
+                HeapDeleteArray(this->length, items);
             }
         }
 
@@ -666,7 +666,7 @@ if (this->object) \
         HRESULT hr = formatter->get_NumeralSystem(hNumeralSystem);
         return VerifyResult(hNumeralSystem, hr);
     }
-    
+
     HRESULT WindowsGlobalizationAdapter::GetCalendar(_In_ DateTimeFormatting::IDateTimeFormatter* formatter, HSTRING * hCalendar)
     {
         HRESULT hr = formatter->get_Calendar(hCalendar);


### PR DESCRIPTION
Global operator new/delete override replaces the default used by hosts
unintendedly (not sure if there is reliable way to avoid that). This change
removes the global overrides and replaces all ChakraCore library new/delete
calls with HeapNew/HeapDelete.

HeapDelete: Added an optional flag "AllocatorDeleteFlags::UnknownSize"
for cases of unknown size to avoid size check. Default still checks size.

JITType.h: Add "const" to avoid an unintended copy constructor call, which
causes software write barrier access failure in JIT thread (not expecting
write barrier access on stack value).