### PR TITLE
Add option -debugbreakonphasebegin to break on a backend phase for given function

### DIFF
--- a/lib/Backend/Func.cpp
+++ b/lib/Backend/Func.cpp
@@ -1079,6 +1079,11 @@ Func::BeginPhase(Js::Phase tag)
 {
 #ifdef DBG
     this->GetTopFunc()->currentPhases.Push(tag);
+
+    if (PHASE_DEBUGBREAK_ON_PHASE_BEGIN(tag, this))
+    {
+        __debugbreak();
+    }
 #endif
 
 #ifdef PROFILE_EXEC

--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -914,6 +914,8 @@ FLAGNR(Boolean, CrashOnException      , "Removes the top-level exception handler
 FLAGNR(Boolean, Debug                 , "Disable phases (layout, security code, etc) which makes JIT output harder to debug", false)
 FLAGNR(NumberSet,  DebugBreak         , "Index of the function where you want to break", )
 FLAGNR(NumberTrioSet,  StatementDebugBreak, "Index of the statement where you want to break", )
+FLAGNR(Phases,  DebugBreakOnPhaseBegin, "Break into debugger at the beginning of given phase for listed function", )
+
 FLAGNR(Boolean, DebugWindow           , "Send console output to debugger window", false)
 FLAGNR(Boolean, DeferNested           , "Enable deferred parsing of nested function", DEFAULT_CONFIG_DeferNested)
 FLAGNR(Boolean, DeferTopLevelTillFirstCall      , "Enable tracking of deferred top level functions in a script file, until the first function of the script context is parsed.", DEFAULT_CONFIG_DeferTopLevelTillFirstCall)

--- a/lib/Common/Core/ConfigFlagsTable.h
+++ b/lib/Common/Core/ConfigFlagsTable.h
@@ -634,6 +634,8 @@ namespace Js
 
 #define PHASE_DUMP(phase, func)     Js::Configuration::Global.flags.Dump.IsEnabled((phase), (func)->GetSourceContextId(),(func)->GetLocalFunctionId())
 
+#define PHASE_DEBUGBREAK_ON_PHASE_BEGIN(phase, func) Js::Configuration::Global.flags.DebugBreakOnPhaseBegin.IsEnabled((phase), (func)->GetSourceContextId(), (func)->GetLocalFunctionId())
+
 #define PHASE_STATS1(phase)         Js::Configuration::Global.flags.Stats.IsEnabled((phase))
 #define CUSTOM_PHASE_STATS1(flags, phase) flags.Stats.IsEnabled((phase))
 #define PHASE_VERBOSE_STATS1(phase) \


### PR DESCRIPTION
This simple change breaks into debugger for a phase and function passed from command line. This is very helpful when I was looking at some bad transformation in a given phase for some known function. Usually we could look at the dump output to see which phase produces the incorrect IR, then trace the transformation and understand how it is generated. This breakpoint would make it easier to do so, especially for looking at such issue from website.