### PR TITLE
JSRT staticlib shutdown partial fix

### DIFF
--- a/lib/Jsrt/JsrtHelper.cpp
+++ b/lib/Jsrt/JsrtHelper.cpp
@@ -109,12 +109,7 @@ void JsrtCallbackState::ObjectBeforeCallectCallbackWrapper(JsObjectBeforeCollect
     // we do not track the main thread. When it exits do the cleanup below
 #ifdef CHAKRA_STATIC_LIBRARY
     atexit([]() {
-        ThreadContext *threadContext = ThreadContext::GetContextForCurrentThread();
-        if (threadContext)
-        {
-            if (threadContext->IsInScript()) return;
-            ThreadBoundThreadContextManager::DestroyContextAndEntryForCurrentThread();
-        }
+        ThreadBoundThreadContextManager::DestroyContextAndEntryForCurrentThread();
 
         JsrtRuntime::Uninitialize();
 

--- a/lib/Jsrt/JsrtRuntime.cpp
+++ b/lib/Jsrt/JsrtRuntime.cpp
@@ -53,16 +53,20 @@ void JsrtRuntime::Uninitialize()
     while (currentThreadContext)
     {
         Assert(!currentThreadContext->IsScriptActive());
-#ifdef CHAKRA_STATIC_LIBRARY
-        if (currentThreadContext->IsInScript()) break;
-#endif
         JsrtRuntime* currentRuntime = static_cast<JsrtRuntime*>(currentThreadContext->GetJSRTRuntime());
         tmpThreadContext = currentThreadContext;
         currentThreadContext = currentThreadContext->Next();
 
+#ifdef CHAKRA_STATIC_LIBRARY
+        // xplat-todo: Cleanup staticlib shutdown. This only shuts down threads.
+        // Other closing contexts / finalizers having trouble with current
+        // runtime/context.
+        RentalThreadContextManager::DestroyThreadContext(tmpThreadContext);
+#else
         currentRuntime->CloseContexts();
         RentalThreadContextManager::DestroyThreadContext(tmpThreadContext);
         HeapDelete(currentRuntime);
+#endif
     }
 }
 

--- a/lib/Runtime/Base/ThreadBoundThreadContextManager.cpp
+++ b/lib/Runtime/Base/ThreadBoundThreadContextManager.cpp
@@ -223,10 +223,19 @@ JsUtil::JobProcessor * ThreadBoundThreadContextManager::GetSharedJobProcessor()
 
 void RentalThreadContextManager::DestroyThreadContext(ThreadContext* threadContext)
 {
-    ShutdownThreadContext(threadContext);
+    bool deleteThreadContext = true;
+
+#ifdef CHAKRA_STATIC_LIBRARY
+    // xplat-todo: Cleanup staticlib shutdown. Deleting contexts / finalizers having
+    // trouble with current runtime/context.
+    deleteThreadContext = false;
+#endif
+
+    ShutdownThreadContext(threadContext, deleteThreadContext);
 }
 
-void ThreadContextManagerBase::ShutdownThreadContext(ThreadContext* threadContext)
+void ThreadContextManagerBase::ShutdownThreadContext(
+    ThreadContext* threadContext, bool deleteThreadContext /*= true*/)
 {
 
 #if DBG
@@ -238,5 +247,8 @@ void ThreadContextManagerBase::ShutdownThreadContext(ThreadContext* threadContex
 #endif
     threadContext->ShutdownThreads();
 
-    HeapDelete(threadContext);
+    if (deleteThreadContext)
+    {
+        HeapDelete(threadContext);
+    }
 }

--- a/lib/Runtime/Base/ThreadBoundThreadContextManager.h
+++ b/lib/Runtime/Base/ThreadBoundThreadContextManager.h
@@ -7,7 +7,8 @@ class ThreadContextManagerBase
 {
 protected:
 
-    static void ShutdownThreadContext(ThreadContext* threadContext);
+    static void ShutdownThreadContext(
+        ThreadContext* threadContext, bool deleteThreadContext = true);
 };
 
 class ThreadBoundThreadContextManager : public ThreadContextManagerBase


### PR DESCRIPTION
A lot of shutdown/finalizer code expects current context. The current
staticlib shutdown atexit runs into problems. Since atexit is at process
shutdown, releasing memory isn't strictly required. This change reduces
current atexit to only shutdown threads. We'll investigate more in future
how to shutdown cleanly.