### PR TITLE
Defer functions enclosed in all contexts. 

### DIFF
--- a/lib/Parser/Hash.h
+++ b/lib/Parser/Hash.h
@@ -144,6 +144,16 @@ public:
         return m_pidRefStack;
     }
 
+    PidRefStack *GetTopRef(uint maxBlockId) const
+    {
+        PidRefStack *ref;
+        for (ref = m_pidRefStack; ref && (uint)ref->id > maxBlockId; ref = ref->prev)
+        {
+            ; // nothing
+        }
+        return ref;
+    }
+
     void SetTopRef(PidRefStack *ref)
     {
         m_pidRefStack = ref;

--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -116,7 +116,6 @@ Parser::Parser(Js::ScriptContext* scriptContext, BOOL strictMode, PageAllocator 
     m_errorCallback = nullptr;
     m_uncertainStructure = FALSE;
     m_reparsingLambdaParams = false;
-    m_inFIB = false;
     currBackgroundParseItem = nullptr;
     backgroundParseItems = nullptr;
     fastScannedRegExpNodes = nullptr;
@@ -859,7 +858,6 @@ Symbol* Parser::AddDeclForPid(ParseNodePtr pnode, IdentPtr pid, SymbolType symbo
 
             if (sym->GetDecl() == nullptr)
             {
-                Assert(symbolType == STFunction);
                 sym->SetDecl(pnode);
                 break;
             }
@@ -1446,12 +1444,11 @@ template<bool buildAST>
 ParseNodePtr Parser::StartParseBlockWithCapacity(PnodeBlockType blockType, ScopeType scopeType, int capacity)
 {
     Scope *scope = nullptr;
-    // Block scopes are created lazily when we discover block-scoped content.
-    if (scopeType != ScopeType_Unknown && scopeType != ScopeType_Block)
-    {
-        scope = Anew(&m_nodeAllocator, Scope, &m_nodeAllocator, scopeType, capacity);
-        PushScope(scope);
-    }
+
+    // Block scopes are not created lazily in the case where we're repopulating a persisted scope.
+
+    scope = Anew(&m_nodeAllocator, Scope, &m_nodeAllocator, scopeType, capacity);
+    PushScope(scope);
 
     return StartParseBlockHelper<buildAST>(blockType, scope, nullptr, nullptr);
 }
@@ -4501,7 +4498,11 @@ BOOL Parser::DeferredParse(Js::LocalFunctionId functionId)
         {
             return false;
         }
-        if (PHASE_FORCE_RAW(Js::DeferParsePhase, m_sourceContextInfo->sourceContextId, functionId))
+        if (PHASE_FORCE_RAW(Js::DeferParsePhase, m_sourceContextInfo->sourceContextId, functionId)
+#ifdef ENABLE_DEBUG_CONFIG_OPTIONS
+            || Js::Configuration::Global.flags.IsEnabled(Js::ForceUndoDeferFlag)
+#endif
+           )
         {
             return true;
         }
@@ -4925,17 +4926,6 @@ bool Parser::ParseFncDeclHelper(ParseNodePtr pnodeFnc, LPCOLESTR pNameHint, usho
     pstmtSave = m_pstmtCur;
     SetCurrentStatement(nullptr);
 
-    // Function definition is inside the parent function's parameter scope
-    bool isEnclosedInParamScope = this->m_currentScope->GetScopeType() == ScopeType_Parameter;
-
-    if (this->m_currentScope->GetScopeType() == ScopeType_FuncExpr || this->m_currentScope->GetScopeType() == ScopeType_Block)
-    {
-        // Or this is a function expression or class enclosed in a parameter scope
-        isEnclosedInParamScope = this->m_currentScope->GetEnclosingScope() && this->m_currentScope->GetEnclosingScope()->GetScopeType() == ScopeType_Parameter;
-    }
-
-    Assert(!isEnclosedInParamScope || pnodeFncSave->sxFnc.HasNonSimpleParameterList());
-
     RestorePoint beginFormals;
     m_pscan->Capture(&beginFormals);
     BOOL fWasAlreadyStrictMode = IsStrictMode();
@@ -4947,22 +4937,14 @@ bool Parser::ParseFncDeclHelper(ParseNodePtr pnodeFnc, LPCOLESTR pNameHint, usho
     }
 
     uint uDeferSave = m_grfscr & fscrDeferFncParse;
-    if ((!fDeclaration && m_ppnodeExprScope) ||
-        isEnclosedInParamScope ||
-        (flags & (fFncNoName | fFncLambda)))
+    if (flags & (fFncNoName | fFncLambda))
     {
-        // NOTE: Don't defer if this is a function expression inside a construct that induces
-        // a scope nested within the current function (like a with, or a catch in ES5 mode, or
-        // any function declared inside a nested lexical block or param scope in ES6 mode).
-        // We won't be able to reconstruct the scope chain properly when we come back and
-        // try to compile just the function expression.
-        // Also shut off deferring on getter/setter or other construct with unusual text bounds
+        // Disable deferral on getter/setter or other construct with unusual text bounds
         // (fFncNoName|fFncLambda) as these are usually trivial, and re-parsing is problematic.
+        // NOTE: It is probably worth supporting these cases for memory and load-time purposes,
+        // especially as they become more and more common.
         m_grfscr &= ~fscrDeferFncParse;
     }
-
-    bool saveInFIB = this->m_inFIB;
-    this->m_inFIB = fFunctionInBlock || this->m_inFIB;
 
     bool isTopLevelDeferredFunc = false;
 
@@ -4995,20 +4977,7 @@ bool Parser::ParseFncDeclHelper(ParseNodePtr pnodeFnc, LPCOLESTR pNameHint, usho
         if (pnodeFnc)
         {
             pnodeFnc->sxFnc.SetCanBeDeferred(isTopLevelDeferredFunc && PnFnc::CanBeRedeferred(pnodeFnc->sxFnc.fncFlags));
-            pnodeFnc->sxFnc.SetFIBPreventsDeferral(false);
         }
-
-        if (this->m_inFIB)
-        {
-            if (isTopLevelDeferredFunc)
-            {
-                // Block-scoping is the only non-heuristic reason for not deferring this function up front.
-                // So on creating the full FunctionBody at byte code gen time, verify that there is no
-                // block-scoped content visible to this function so it can remain a redeferral candidate.
-                pnodeFnc->sxFnc.SetFIBPreventsDeferral(true);
-            }
-            isTopLevelDeferredFunc = false;
-        }        
 
         // These are heuristic conditions that prohibit upfront deferral but not redeferral.
         isTopLevelDeferredFunc = isTopLevelDeferredFunc && !isDeferredFnc && 
@@ -5287,12 +5256,7 @@ bool Parser::ParseFncDeclHelper(ParseNodePtr pnodeFnc, LPCOLESTR pNameHint, usho
             if (buildAST)
             {
                 DeferredFunctionStub *saveCurrentStub = m_currDeferredStub;
-                if (isEnclosedInParamScope)
-                {
-                    // if the enclosed scope is the param scope we would not have created the deferred stub.
-                    m_currDeferredStub = nullptr;
-                }
-                else if (pnodeFncSave && m_currDeferredStub)
+                if (pnodeFncSave && m_currDeferredStub)
                 {
                     // the Deferred stub will not match for the function which are defined on lambda formals.
                     // Since this is not determined upfront that the current function is a part of outer function or part of lambda formal until we have seen the Arrow token.
@@ -5449,7 +5413,6 @@ bool Parser::ParseFncDeclHelper(ParseNodePtr pnodeFnc, LPCOLESTR pNameHint, usho
     {
         m_grfscr |= uDeferSave;
     }
-    m_inFIB = saveInFIB;
 
     m_pscan->SetYieldIsKeyword(fPreviousYieldIsKeyword);
     m_pscan->SetAwaitIsKeyword(fPreviousAwaitIsKeyword);
@@ -8690,7 +8653,7 @@ PidRefStack* Parser::PushPidRef(IdentPtr pid)
 
     Assert(GetCurrentBlock() != nullptr);
     AssertMsg(pid != nullptr, "PID should be created");
-    PidRefStack *ref = pid->GetTopRef();
+    PidRefStack *ref = pid->GetTopRef(m_nextBlockId - 1);
     int blockId = GetCurrentBlock()->sxBlock.blockId;
     int funcId = GetCurrentFunctionNode()->sxFnc.functionId;
     if (!ref || (ref->GetScopeId() < blockId))
@@ -9161,7 +9124,7 @@ ParseNodePtr Parser::ParseCatch()
             }
 
             pidCatch = m_token.GetIdentifier(m_phtbl);
-            PidRefStack *ref = this->PushPidRef(pidCatch);
+            PidRefStack *ref = this->FindOrAddPidRef(pidCatch, GetCurrentBlock()->sxBlock.blockId, GetCurrentFunctionNode()->sxFnc.functionId);
 
             ParseNodePtr pnodeParam = CreateNameNode(pidCatch);
             pnodeParam->sxPid.symRef = ref->GetSymRef();
@@ -10558,15 +10521,31 @@ void Parser::ParseStmtList(ParseNodePtr *ppnodeList, ParseNodePtr **pppnodeLast,
 }
 
 template <class Fn>
-void Parser::VisitFunctionsInScope(ParseNodePtr pnodeScopeList, Fn fn)
+void Parser::FinishFunctionsInScope(ParseNodePtr pnodeScopeList, Fn fn)
 {
+    Scope * scope;
+    Scope * origCurrentScope = this->m_currentScope;
     ParseNodePtr pnodeScope;
+    ParseNodePtr pnodeBlock;
     for (pnodeScope = pnodeScopeList; pnodeScope;)
     {
         switch (pnodeScope->nop)
         {
         case knopBlock:
-            VisitFunctionsInScope(pnodeScope->sxBlock.pnodeScopes, fn);
+            m_nextBlockId = pnodeScope->sxBlock.blockId + 1;
+            PushBlockInfo(pnodeScope);
+            scope = pnodeScope->sxBlock.scope;
+            if (scope && scope != origCurrentScope)
+            {
+                PushScope(scope);
+            }
+            FinishFunctionsInScope(pnodeScope->sxBlock.pnodeScopes, fn);
+            if (scope && scope != origCurrentScope)
+            {
+                BindPidRefs<false>(GetCurrentBlockInfo(), m_nextBlockId - 1);
+                PopScope(scope);
+            }
+            PopBlockInfo();
             pnodeScope = pnodeScope->sxBlock.pnodeNext;
             break;
 
@@ -10576,12 +10555,29 @@ void Parser::VisitFunctionsInScope(ParseNodePtr pnodeScopeList, Fn fn)
             break;
 
         case knopCatch:
-            VisitFunctionsInScope(pnodeScope->sxCatch.pnodeScopes, fn);
+            scope = pnodeScope->sxCatch.scope;
+            if (scope)
+            {
+                PushScope(scope);
+            }
+            pnodeBlock = CreateBlockNode(PnodeBlockType::Regular);
+            pnodeBlock->sxBlock.scope = scope;
+            PushBlockInfo(pnodeBlock);
+            FinishFunctionsInScope(pnodeScope->sxCatch.pnodeScopes, fn);
+            if (scope)
+            {
+                BindPidRefs<false>(GetCurrentBlockInfo(), m_nextBlockId - 1);
+                PopScope(scope);
+            }
+            PopBlockInfo();
             pnodeScope = pnodeScope->sxCatch.pnodeNext;
             break;
 
         case knopWith:
-            VisitFunctionsInScope(pnodeScope->sxWith.pnodeScopes, fn);
+            PushBlockInfo(CreateBlockNode());
+            PushDynamicBlock();
+            FinishFunctionsInScope(pnodeScope->sxWith.pnodeScopes, fn);
+            PopBlockInfo();
             pnodeScope = pnodeScope->sxWith.pnodeNext;
             break;
 
@@ -10620,7 +10616,10 @@ ULONG Parser::GetDeferralThreshold(bool isProfileLoaded)
 
 void Parser::FinishDeferredFunction(ParseNodePtr pnodeScopeList)
 {
-    VisitFunctionsInScope(pnodeScopeList,
+    uint saveNextBlockId = m_nextBlockId;
+    m_nextBlockId = pnodeScopeList->sxBlock.blockId + 1;
+
+    FinishFunctionsInScope(pnodeScopeList,
         [this](ParseNodePtr pnodeFnc)
     {
         Assert(pnodeFnc->nop == knopFncDecl);
@@ -10637,22 +10636,24 @@ void Parser::FinishDeferredFunction(ParseNodePtr pnodeScopeList)
             this->m_currentNodeFunc = pnodeFnc;
 
             ParseNodePtr pnodeFncExprBlock = nullptr;
-            if (pnodeFnc->sxFnc.pnodeName &&
-                !pnodeFnc->sxFnc.IsDeclaration())
+            ParseNodePtr pnodeName = pnodeFnc->sxFnc.pnodeName;
+            if (pnodeName)
             {
-                // Set up the named function expression symbol so references inside the function can be bound.
-                ParseNodePtr pnodeName = pnodeFnc->sxFnc.pnodeName;
                 Assert(pnodeName->nop == knopVarDecl);
                 Assert(pnodeName->sxVar.pnodeNext == nullptr);
 
-                pnodeFncExprBlock = this->StartParseBlock<true>(PnodeBlockType::Function, ScopeType_FuncExpr);
-                PidRefStack *ref = this->PushPidRef(pnodeName->sxVar.pid);
-                pnodeName->sxVar.symRef = ref->GetSymRef();
-                ref->SetSym(pnodeName->sxVar.sym);
+                if (!pnodeFnc->sxFnc.IsDeclaration())
+                {
+                    // Set up the named function expression symbol so references inside the function can be bound.
+                    pnodeFncExprBlock = this->StartParseBlock<true>(PnodeBlockType::Function, ScopeType_FuncExpr);
+                    PidRefStack *ref = this->PushPidRef(pnodeName->sxVar.pid);
+                    pnodeName->sxVar.symRef = ref->GetSymRef();
+                    ref->SetSym(pnodeName->sxVar.sym);
 
-                Scope *fncExprScope = pnodeFncExprBlock->sxBlock.scope;
-                fncExprScope->AddNewSymbol(pnodeName->sxVar.sym);
-                pnodeFnc->sxFnc.scope = fncExprScope;
+                    Scope *fncExprScope = pnodeFncExprBlock->sxBlock.scope;
+                    fncExprScope->AddNewSymbol(pnodeName->sxVar.sym);
+                    pnodeFnc->sxFnc.scope = fncExprScope;
+                }
             }
 
             ParseNodePtr pnodeBlock = this->StartParseBlock<true>(PnodeBlockType::Parameter, ScopeType_Parameter);
@@ -10662,10 +10663,12 @@ void Parser::FinishDeferredFunction(ParseNodePtr pnodeScopeList)
 
             // Add the args to the scope, since we won't re-parse those.
             Scope *scope = pnodeBlock->sxBlock.scope;
+            uint blockId = GetCurrentBlock()->sxBlock.blockId;
+            uint funcId = GetCurrentFunctionNode()->sxFnc.functionId;
             auto addArgsToScope = [&](ParseNodePtr pnodeArg) {
                 if (pnodeArg->IsVarLetOrConst())
                 {
-                    PidRefStack *ref = this->PushPidRef(pnodeArg->sxVar.pid);
+                    PidRefStack *ref = this->FindOrAddPidRef(pnodeArg->sxVar.pid, blockId, funcId);//this->PushPidRef(pnodeArg->sxVar.pid);
                     pnodeArg->sxVar.symRef = ref->GetSymRef();
                     if (ref->GetSym() != nullptr)
                     {
@@ -10715,9 +10718,11 @@ void Parser::FinishDeferredFunction(ParseNodePtr pnodeScopeList)
             {
                 if (scope->GetCanMergeWithBodyScope())
                 {
-                    scope->ForEachSymbol([this](Symbol* paramSym)
+                    blockId = GetCurrentBlock()->sxBlock.blockId;
+                    funcId = GetCurrentFunctionNode()->sxFnc.functionId;
+                    scope->ForEachSymbol([this, blockId, funcId](Symbol* paramSym)
                     {
-                        PidRefStack* ref = PushPidRef(paramSym->GetPid());
+                        PidRefStack* ref = this->FindOrAddPidRef(paramSym->GetPid(), blockId, funcId);
                         ref->SetSym(paramSym);
                     });
                 }
@@ -10761,6 +10766,8 @@ void Parser::FinishDeferredFunction(ParseNodePtr pnodeScopeList)
             this->m_currentNodeFunc = pnodeFncSave;
         }
     });
+
+    m_nextBlockId = saveNextBlockId;
 }
 
 void Parser::InitPids()
@@ -10784,14 +10791,8 @@ void Parser::InitPids()
     wellKnownPropertyPids._star = m_phtbl->PidHashNameLen(_u("*"), sizeof("*") - 1);
 }
 
-void Parser::RestoreScopeInfo(Js::ParseableFunctionInfo* functionBody)
+void Parser::RestoreScopeInfo(Js::ScopeInfo * scopeInfo)
 {
-    if (!functionBody)
-    {
-        return;
-    }
-
-    Js::ScopeInfo* scopeInfo = functionBody->GetScopeInfo();
     if (!scopeInfo)
     {
         return;
@@ -10806,53 +10807,47 @@ void Parser::RestoreScopeInfo(Js::ParseableFunctionInfo* functionBody)
         PROBE_STACK(m_scriptContext, Js::Constants::MinStackByteCodeVisitor);
     }
 
-    RestoreScopeInfo(scopeInfo->GetParent()); // Recursively restore outer func scope info
-
-    Js::ScopeInfo* funcExprScopeInfo = scopeInfo->GetFuncExprScopeInfo();
-    if (funcExprScopeInfo)
-    {
-        funcExprScopeInfo->SetScopeId(m_nextBlockId);
-        ParseNodePtr pnodeFncExprScope = StartParseBlockWithCapacity<true>(PnodeBlockType::Function, ScopeType_FuncExpr, funcExprScopeInfo->GetSymbolCount());
-        Scope *scope = pnodeFncExprScope->sxBlock.scope;
-        funcExprScopeInfo->GetScopeInfo(this, nullptr, nullptr, scope);
-    }
-
-    Js::ScopeInfo* paramScopeInfo = scopeInfo->GetParamScopeInfo();
-    if (paramScopeInfo)
-    {
-        paramScopeInfo->SetScopeId(m_nextBlockId);
-        ParseNodePtr pnodeFncExprScope = StartParseBlockWithCapacity<true>(PnodeBlockType::Parameter, ScopeType_Parameter, paramScopeInfo->GetSymbolCount());
-        Scope *scope = pnodeFncExprScope->sxBlock.scope;
-        paramScopeInfo->GetScopeInfo(this, nullptr, nullptr, scope);
-    }
+    RestoreScopeInfo(scopeInfo->GetParentScopeInfo()); // Recursively restore outer func scope info
 
     scopeInfo->SetScopeId(m_nextBlockId);
-    ParseNodePtr pnodeFncScope = nullptr;
-    if (scopeInfo->IsGlobalEval())
+    ParseNodePtr pnodeScope = nullptr;
+    ScopeType scopeType = scopeInfo->GetScopeType();
+    PnodeBlockType blockType;
+    switch (scopeType)
     {
-        pnodeFncScope = StartParseBlockWithCapacity<true>(PnodeBlockType::Regular, ScopeType_GlobalEvalBlock, scopeInfo->GetSymbolCount());
+        case ScopeType_With:
+            PushDynamicBlock();
+            // fall through
+        case ScopeType_Block:
+        case ScopeType_Catch:
+        case ScopeType_CatchParamPattern:
+        case ScopeType_GlobalEvalBlock:
+            blockType = PnodeBlockType::Regular;
+            break;
+
+        case ScopeType_FunctionBody:
+        case ScopeType_FuncExpr:
+            blockType = PnodeBlockType::Function;
+            break;
+
+        case ScopeType_Parameter:
+            blockType = PnodeBlockType::Parameter;
+            break;
+
+
+        default:
+            Assert(0);
+            return;
     }
-    else
-    {
-        pnodeFncScope = StartParseBlockWithCapacity<true>(PnodeBlockType::Function, ScopeType_FunctionBody, scopeInfo->GetSymbolCount());
-    }
-    Scope *scope = pnodeFncScope->sxBlock.scope;
-    scopeInfo->GetScopeInfo(this, nullptr, nullptr, scope);
+
+    pnodeScope = StartParseBlockWithCapacity<true>(blockType, scopeType, scopeInfo->GetSymbolCount());
+    Scope *scope = pnodeScope->sxBlock.scope;
+    scope->SetScopeInfo(scopeInfo);
+    scopeInfo->ExtractScopeInfo(this, /*nullptr, nullptr,*/ scope);
 }
 
-void Parser::FinishScopeInfo(Js::ParseableFunctionInfo *functionBody)
+void Parser::FinishScopeInfo(Js::ScopeInfo * scopeInfo)
 {
-    if (!functionBody)
-    {
-        return;
-    }
-
-    Js::ScopeInfo* scopeInfo = functionBody->GetScopeInfo();
-    if (!scopeInfo)
-    {
-        return;
-    }
-
     if (this->IsBackgroundParser())
     {
         PROBE_STACK_NO_DISPOSE(m_scriptContext, Js::Constants::MinStackByteCodeVisitor);
@@ -10862,43 +10857,18 @@ void Parser::FinishScopeInfo(Js::ParseableFunctionInfo *functionBody)
         PROBE_STACK(m_scriptContext, Js::Constants::MinStackByteCodeVisitor);
     }
 
-    int scopeId = scopeInfo->GetScopeId();
-
-    scopeInfo->GetScope()->ForEachSymbol([this, scopeId](Symbol *sym)
+    for (;scopeInfo != nullptr; scopeInfo = scopeInfo->GetParentScopeInfo())
     {
-        this->BindPidRefsInScope(sym->GetPid(), sym, scopeId);
-    });
-    PopScope(scopeInfo->GetScope());
-    PopStmt(&m_currentBlockInfo->pstmt);
-    PopBlockInfo();
+        int scopeId = scopeInfo->GetScopeId();
 
-    Js::ScopeInfo *paramScopeInfo = scopeInfo->GetParamScopeInfo();
-    if (paramScopeInfo)
-    {
-        scopeId = paramScopeInfo->GetScopeId();
-        paramScopeInfo->GetScope()->ForEachSymbol([this, scopeId](Symbol *sym)
+        scopeInfo->GetScope()->ForEachSymbol([this, scopeId](Symbol *sym)
         {
             this->BindPidRefsInScope(sym->GetPid(), sym, scopeId);
         });
-        PopScope(paramScopeInfo->GetScope());
+        PopScope(scopeInfo->GetScope());
         PopStmt(&m_currentBlockInfo->pstmt);
         PopBlockInfo();
     }
-
-    Js::ScopeInfo *funcExprScopeInfo = scopeInfo->GetFuncExprScopeInfo();
-    if (funcExprScopeInfo)
-    {
-        scopeId = funcExprScopeInfo->GetScopeId();
-        funcExprScopeInfo->GetScope()->ForEachSymbol([this, scopeId](Symbol *sym)
-        {
-            this->BindPidRefsInScope(sym->GetPid(), sym, scopeId);
-        });
-        PopScope(funcExprScopeInfo->GetScope());
-        PopStmt(&m_currentBlockInfo->pstmt);
-        PopBlockInfo();
-    }
-
-    FinishScopeInfo(scopeInfo->GetParent());
 }
 
 /***************************************************************************
@@ -11054,7 +11024,7 @@ ParseNodePtr Parser::Parse(LPCUTF8 pszSrc, size_t offset, size_t length, charcou
             m_currentNodeFunc->sxFnc.nestedCount = m_functionBody->GetNestedCount();
             m_currentNodeFunc->sxFnc.SetStrictMode(!!this->m_fUseStrictMode);
 
-            this->RestoreScopeInfo(scopeInfo->GetParent());
+            this->RestoreScopeInfo(scopeInfo);
         }
     }
 
@@ -11079,7 +11049,7 @@ ParseNodePtr Parser::Parse(LPCUTF8 pszSrc, size_t offset, size_t length, charcou
     {
         if (scopeInfo)
         {
-            this->FinishScopeInfo(scopeInfo->GetParent());
+            this->FinishScopeInfo(scopeInfo);
         }
     }
 

--- a/lib/Parser/Parse.h
+++ b/lib/Parser/Parse.h
@@ -6,6 +6,11 @@
 
 #include "ParseFlags.h"
 
+namespace Js
+{
+    class ScopeInfo;
+};
+
 // Operator precedence levels
 enum
 {
@@ -369,7 +374,6 @@ private:
     bool m_inDeferredNestedFunc; // true if parsing a function in deferred mode, nested within the current node
     bool m_isInBackground;
     bool m_reparsingLambdaParams;
-    bool m_inFIB;
 
     // This bool is used for deferring the shorthand initializer error ( {x = 1}) - as it is allowed in the destructuring grammar.
     bool m_hasDeferredShorthandInitError;
@@ -976,8 +980,8 @@ private:
     void RemovePrevPidRef(IdentPtr pid, PidRefStack *lastRef);
     void SetPidRefsInScopeDynamic(IdentPtr pid, int blockId);
 
-    void RestoreScopeInfo(Js::ParseableFunctionInfo* functionBody);
-    void FinishScopeInfo(Js::ParseableFunctionInfo* functionBody);
+    void RestoreScopeInfo(Js::ScopeInfo * scopeInfo);
+    void FinishScopeInfo(Js::ScopeInfo * scopeInfo);
 
     BOOL PnodeLabelNoAST(IdentToken* pToken, LabelId* pLabelIdList);
     LabelId* CreateLabelId(IdentToken* pToken);
@@ -1011,7 +1015,7 @@ private:
     }
 
     template <class Fn>
-    void VisitFunctionsInScope(ParseNodePtr pnodeScopeList, Fn fn);
+    void FinishFunctionsInScope(ParseNodePtr pnodeScopeList, Fn fn);
     void FinishDeferredFunction(ParseNodePtr pnodeScopeList);
 
     /***********************************************************************

--- a/lib/Parser/ptree.h
+++ b/lib/Parser/ptree.h
@@ -247,7 +247,6 @@ struct PnFnc
     RestorePoint *pRestorePoint;
     DeferredFunctionStub *deferredStub;
     bool canBeDeferred;
-    bool fibPreventsDeferral;
 
     static const int32 MaxStackClosureAST = 800000;
 
@@ -286,7 +285,6 @@ public:
     {
         fncFlags = kFunctionNone;
         canBeDeferred = false;
-        fibPreventsDeferral = false;
     }
 
     void SetAsmjsMode(bool set = true) { SetFlags(kFunctionAsmjsMode, set); }
@@ -323,7 +321,6 @@ public:
     void SetIsDefaultModuleExport(bool set = true) { SetFlags(kFunctionIsDefaultModuleExport, set); }
     void SetNestedFuncEscapes(bool set = true) { nestedFuncEscapes = set; }
     void SetCanBeDeferred(bool set = true) { canBeDeferred = set; }
-    void SetFIBPreventsDeferral(bool set = true) { fibPreventsDeferral = set; }
 
     bool CallsEval() const { return HasFlags(kFunctionCallsEval); }
     bool ChildCallsEval() const { return HasFlags(kFunctionChildCallsEval); }
@@ -362,7 +359,6 @@ public:
     bool IsDefaultModuleExport() const { return HasFlags(kFunctionIsDefaultModuleExport); }
     bool NestedFuncEscapes() const { return nestedFuncEscapes; }
     bool CanBeDeferred() const { return canBeDeferred; }
-    bool FIBPreventsDeferral() const { return fibPreventsDeferral; }
 
     size_t LengthInBytes()
     {

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.h
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.h
@@ -207,7 +207,9 @@ public:
         return protoReg;
     }
 
-    void RestoreScopeInfo(Js::ParseableFunctionInfo* funcInfo);
+    void RestoreScopeInfo(Js::ScopeInfo *scopeInfo, FuncInfo * func);
+    void RestoreOneScope(Js::ScopeInfo * scopeInfo, FuncInfo * func);
+
     FuncInfo *StartBindGlobalStatements(ParseNode *pnode);
     void AssignPropertyId(Symbol *sym, Js::ParseableFunctionInfo* functionInfo);
     void AssignPropertyId(IdentPtr pid);

--- a/lib/Runtime/ByteCode/FuncInfo.cpp
+++ b/lib/Runtime/ByteCode/FuncInfo.cpp
@@ -105,7 +105,10 @@ FuncInfo::FuncInfo(
     maxForInLoopLevel(0)
 {
     this->byteCodeFunction = byteCodeFunction;
-    bodyScope->SetFunc(this);
+    if (bodyScope != nullptr)
+    {
+        bodyScope->SetFunc(this);
+    }
     if (paramScope != nullptr)
     {
         paramScope->SetFunc(this);

--- a/lib/Runtime/ByteCode/FuncInfo.h
+++ b/lib/Runtime/ByteCode/FuncInfo.h
@@ -263,24 +263,39 @@ public:
     //    1) new Function code's global code
     //    2) global code generated from the reparsing deferred parse function
 
-    bool IsFakeGlobalFunction(uint32 flags) const {
+    bool IsFakeGlobalFunction(uint32 flags) const 
+    {
         return IsGlobalFunction() && !(flags & fscrGlobalCode);
     }
 
-    Scope *GetBodyScope() const {
+    Scope *GetBodyScope() const 
+    {
         return bodyScope;
     }
 
-    Scope *GetParamScope() const {
+    void SetBodyScope(Scope * scope)
+    {
+        bodyScope = scope;
+    }
+
+    Scope *GetParamScope() const 
+    {
         return paramScope;
     }
 
-    Scope *GetTopLevelScope() const {
+    void SetParamScope(Scope * scope)
+    {
+        paramScope = scope;
+    }
+
+    Scope *GetTopLevelScope() const 
+    {
         // Top level scope will be the same for knopProg and knopFncDecl.
         return paramScope;
     }
 
-    Scope* GetFuncExprScope() const {
+    Scope* GetFuncExprScope() const 
+    {
         return funcExprScope;
     }
 

--- a/lib/Runtime/ByteCode/Scope.h
+++ b/lib/Runtime/ByteCode/Scope.h
@@ -22,6 +22,7 @@ class Scope
 {
 private:
     Scope *enclosingScope;
+    Js::ScopeInfo *scopeInfo;
     Js::RegSlot location;
     FuncInfo *func;
     Symbol *m_symList;
@@ -48,6 +49,7 @@ public:
         alloc(alloc),
         func(nullptr),
         enclosingScope(nullptr),
+        scopeInfo(nullptr),
         isDynamic(false),
         isObject(false),
         canMerge(true),
@@ -175,6 +177,16 @@ public:
     Scope *GetEnclosingScope() const
     {
         return enclosingScope;
+    }
+
+    void SetScopeInfo(Js::ScopeInfo * scopeInfo)
+    {
+        this->scopeInfo = scopeInfo;
+    }
+
+    Js::ScopeInfo * GetScopeInfo() const
+    {
+        return this->scopeInfo;
     }
 
     ScopeType GetScopeType() const

--- a/lib/Runtime/ByteCode/ScopeInfo.cpp
+++ b/lib/Runtime/ByteCode/ScopeInfo.cpp
@@ -42,15 +42,6 @@ namespace Js
         TRACE_BYTECODE(_u("%12s %d\n"), sym->GetName().GetBuffer(), sym->GetScopeSlot());
     }
 
-    //
-    // Create scope info for a deferred child to refer to its parent ParseableFunctionInfo.
-    //
-    ScopeInfo* ScopeInfo::FromParent(FunctionBody* parent)
-    {
-        return RecyclerNew(parent->GetScriptContext()->GetRecycler(), // Alloc with ParseableFunctionInfo
-            ScopeInfo, parent->GetFunctionInfo(), 0);
-    }
-
     inline void AddSlotCount(int& count, int addCount)
     {
         if (addCount != 0 && Int32Math::Add(count, addCount, &count))
@@ -60,10 +51,13 @@ namespace Js
     }
 
     //
-    // Create scope info for an outer scope.
+    // Create scope info for a single scope.
     //
-    ScopeInfo* ScopeInfo::FromScope(ByteCodeGenerator* byteCodeGenerator, ParseableFunctionInfo* parent, Scope* scope, ScriptContext *scriptContext)
+    ScopeInfo* ScopeInfo::SaveOneScopeInfo(/*ByteCodeGenerator* byteCodeGenerator, ParseableFunctionInfo* parent,*/ Scope* scope, ScriptContext *scriptContext)
     {
+        Assert(scope->GetScopeInfo() == nullptr);
+        Assert(scope->GetScopeType() != ScopeType_Global);
+
         int count = scope->Count();
 
         // Add argsPlaceHolder which includes same name args and destructuring patterns on parameters
@@ -74,25 +68,28 @@ namespace Js
 
         ScopeInfo* scopeInfo = RecyclerNewPlusZ(scriptContext->GetRecycler(),
             count * sizeof(SymbolInfo),
-            ScopeInfo, parent ? parent->GetFunctionInfo() : nullptr, count);
+            ScopeInfo, scope->GetFunc()->byteCodeFunction->GetFunctionInfo(),/*parent ? parent->GetFunctionInfo() : nullptr,*/ count);
+        scopeInfo->SetScopeType(scope->GetScopeType());
         scopeInfo->isDynamic = scope->GetIsDynamic();
         scopeInfo->isObject = scope->GetIsObject();
         scopeInfo->mustInstantiate = scope->GetMustInstantiate();
         scopeInfo->isCached = (scope->GetFunc()->GetBodyScope() == scope) && scope->GetFunc()->GetHasCachedScope();
-        scopeInfo->isGlobalEval = scope->GetScopeType() == ScopeType_GlobalEvalBlock;
         scopeInfo->canMergeWithBodyScope = scope->GetCanMergeWithBodyScope();
         scopeInfo->hasLocalInClosure = scope->GetHasOwnLocalInClosure();
+        
 
-        TRACE_BYTECODE(_u("\nSave ScopeInfo: %s parent: %s #symbols: %d %s\n"),
-            scope->GetFunc()->name, parent ? parent->GetDisplayName() : _u(""), count,
+        TRACE_BYTECODE(_u("\nSave ScopeInfo: %s #symbols: %d %s\n"),
+            scope->GetFunc()->name, count,
             scopeInfo->isObject ? _u("isObject") : _u(""));
 
-        MapSymbolData mapSymbolData = { byteCodeGenerator, scope->GetFunc(), 0 };
+        MapSymbolData mapSymbolData = { scope->GetFunc(), 0 };
         scope->ForEachSymbol([&mapSymbolData, scopeInfo, scope](Symbol * sym)
         {
             Assert(scope == sym->GetScope());
             scopeInfo->SaveSymbolInfo(sym, &mapSymbolData);
         });
+
+        scope->SetScopeInfo(scopeInfo);
 
         return scopeInfo;
     }
@@ -107,75 +104,46 @@ namespace Js
             auto propertyName = scriptContext->GetPropertyName(symbols[i].propertyId);
             scriptContext->TrackPid(propertyName);
         }
-        if (funcExprScopeInfo)
-        {
-            funcExprScopeInfo->EnsurePidTracking(scriptContext);
-        }
-        if (paramScopeInfo)
-        {
-            paramScopeInfo->EnsurePidTracking(scriptContext);
-        }
     }
 
     //
-    // Save needed scope info for a deferred child func. The scope info is empty and only links to parent.
+    // Save scope info for an individual scope and link it to its enclosing scope.
     //
-    void ScopeInfo::SaveParentScopeInfo(FuncInfo* parentFunc, FuncInfo* func)
+    ScopeInfo * ScopeInfo::SaveScopeInfo(Scope * scope/*ByteCodeGenerator* byteCodeGenerator, FuncInfo* parentFunc, FuncInfo* func*/, ScriptContext * scriptContext)
     {
-        Assert(func->IsDeferred() || func->byteCodeFunction->CanBeDeferred());
-
-        // Parent must be parsed
-        FunctionBody* parent = parentFunc->byteCodeFunction->GetFunctionBody();
-        ParseableFunctionInfo* funcBody = func->byteCodeFunction;
-
-        TRACE_BYTECODE(_u("\nSave ScopeInfo: %s parent: %s\n\n"),
-            funcBody->GetDisplayName(), parent->GetDisplayName());
-
-        ScopeInfo *info = FromParent(parent);
-        info->parentOnly = true;
-        funcBody->SetScopeInfo(info);
-    }
-
-    //
-    // Save scope info for an outer func which has deferred child.
-    //
-    void ScopeInfo::SaveScopeInfo(ByteCodeGenerator* byteCodeGenerator, FuncInfo* parentFunc, FuncInfo* func)
-    {
-        ParseableFunctionInfo* funcBody = func->byteCodeFunction;
-
-        Assert((!func->IsGlobalFunction() || byteCodeGenerator->GetFlags() & fscrEvalCode) &&
-            (func->HasDeferredChild() || func->HasRedeferrableChild() || funcBody->IsReparsed()));
-
-        // If we are reparsing a deferred function, we already have correct "parent" info in
-        // funcBody->scopeInfo. parentFunc is the knopProg shell and should not be used in this
-        // case. We should use existing parent if available.
-        ParseableFunctionInfo * parent = funcBody->GetScopeInfo() ?
-            funcBody->GetScopeInfo()->GetParent() :
-            parentFunc ? parentFunc->byteCodeFunction : nullptr;
-
-        ScopeInfo* funcExprScopeInfo = nullptr;
-        Scope* funcExprScope = func->GetFuncExprScope();
-        if (funcExprScope && funcExprScope->GetMustInstantiate())
+        // Advance past scopes that will be excluded from the closure environment. (But note that we always want the body scope.)
+        while (scope && (!scope->GetMustInstantiate() && scope != scope->GetFunc()->GetBodyScope()))
         {
-            funcExprScopeInfo = FromScope(byteCodeGenerator, parent, funcExprScope, funcBody->GetScriptContext());
+            scope = scope->GetEnclosingScope();
         }
 
-        Scope* bodyScope = func->IsGlobalFunction() ? func->GetGlobalEvalBlockScope() : func->GetBodyScope();
-        ScopeInfo* paramScopeInfo = nullptr;
-        Scope* paramScope = func->GetParamScope();
-        if (paramScope && !paramScope->GetCanMergeWithBodyScope())
+        // If we've exhausted the scope chain, we're done.
+        if (scope == nullptr || scope->GetScopeType() == ScopeType_Global)
         {
-            paramScopeInfo = FromScope(byteCodeGenerator, parent, paramScope, funcBody->GetScriptContext());
+            return nullptr;
         }
 
-        ScopeInfo* scopeInfo = FromScope(byteCodeGenerator, parent, bodyScope, funcBody->GetScriptContext());
-        scopeInfo->SetFuncExprScopeInfo(funcExprScopeInfo);
-        scopeInfo->SetParamScopeInfo(paramScopeInfo);
+        // If we've already collected info for this scope, we're done.
+        ScopeInfo * scopeInfo = scope->GetScopeInfo();
+        if (scopeInfo != nullptr)
+        {
+            return scopeInfo;
+        }
 
-        funcBody->SetScopeInfo(scopeInfo);
+        // Do the work for this scope.
+        scopeInfo = ScopeInfo::SaveOneScopeInfo(scope, scriptContext);
+
+        // Link to the parent (if any).
+        scope = scope->GetEnclosingScope();
+        if (scope)
+        {
+            scopeInfo->SetParentScopeInfo(ScopeInfo::SaveScopeInfo(scope, scriptContext));
+        }
+
+        return scopeInfo;
     }
 
-    void ScopeInfo::SaveScopeInfoForDeferParse(ByteCodeGenerator* byteCodeGenerator, FuncInfo* parentFunc, FuncInfo* funcInfo)
+    void ScopeInfo::SaveEnclosingScopeInfo(ByteCodeGenerator* byteCodeGenerator, FuncInfo* funcInfo)
     {
         // TODO: Not technically necessary, as we always do scope look up on eval if it is
         // not found in the scope chain, and block scopes are always objects in eval.
@@ -185,116 +153,51 @@ namespace Js
         // enable defer parsing function that are in block scopes.
 
         if (funcInfo->byteCodeFunction &&
-            funcInfo->byteCodeFunction->GetScopeInfo() != nullptr &&
-            !funcInfo->byteCodeFunction->GetScopeInfo()->IsParentInfoOnly())
+            funcInfo->byteCodeFunction->GetScopeInfo() != nullptr)
         {
             // No need to regenerate scope info if we re-compile an enclosing function
             return;
         }
 
         Scope* currentScope = byteCodeGenerator->GetCurrentScope();
-        Assert(currentScope == funcInfo->GetBodyScope());
-        if (funcInfo->HasDeferredChild() ||
-            funcInfo->HasRedeferrableChild() ||
-            (!funcInfo->IsGlobalFunction() &&
-                funcInfo->byteCodeFunction &&
-                funcInfo->byteCodeFunction->IsReparsed() &&
-                funcInfo->byteCodeFunction->GetFunctionBody()->HasAllNonLocalReferenced()))
-        {
-            // When we reparse due to attach, we would need to capture all of them, since they were captured before going to debug mode.
+        Assert(currentScope->GetFunc() == funcInfo);
 
-            Js::ScopeInfo::SaveScopeInfo(byteCodeGenerator, parentFunc, funcInfo);
-        }
-        else if (funcInfo->IsDeferred() || funcInfo->IsRedeferrable())
+        while (currentScope->GetFunc() == funcInfo)
         {
-            // Don't need to remember the parent function if we have a global function
-            if (!parentFunc->IsGlobalFunction() ||
-                ((byteCodeGenerator->GetFlags() & fscrEvalCode) && (parentFunc->HasDeferredChild() || parentFunc->HasRedeferrableChild())))
-            {
-                // TODO: currently we only support defer nested function that is in function scope (no block scope, no with scope, etc.)
-#if DBG
-                if (funcInfo->GetFuncExprScope() && funcInfo->GetFuncExprScope()->GetIsObject())
-                {
-                    if (funcInfo->paramScope && !funcInfo->paramScope->GetCanMergeWithBodyScope())
-                    {
-                        Assert(currentScope->GetEnclosingScope()->GetEnclosingScope() == funcInfo->GetFuncExprScope());
-                    }
-                    else
-                    {
-                        Assert(currentScope->GetEnclosingScope() == funcInfo->GetFuncExprScope() &&
-                            currentScope->GetEnclosingScope()->GetEnclosingScope() ==
-                            (parentFunc->IsGlobalFunction() && parentFunc->GetGlobalEvalBlockScope()->GetMustInstantiate() ?
-                             parentFunc->GetGlobalEvalBlockScope() : parentFunc->GetBodyScope()));
-                    }
-                }
-                else
-                {
-                    if (currentScope->GetEnclosingScope() == parentFunc->GetParamScope())
-                    {
-                        Assert(!parentFunc->GetParamScope()->GetCanMergeWithBodyScope());
-                        Assert(funcInfo->GetParamScope()->GetCanMergeWithBodyScope());
-                    }
-                    else if (currentScope->GetEnclosingScope() == funcInfo->GetParamScope())
-                    {
-                        Assert(!funcInfo->GetParamScope()->GetCanMergeWithBodyScope());
-                    }
-#if 0
-                    else
-                    {
-                        Assert(currentScope->GetEnclosingScope() ==
-                            (parentFunc->IsGlobalFunction() && parentFunc->GetGlobalEvalBlockScope() && parentFunc->GetGlobalEvalBlockScope()->GetMustInstantiate() ? parentFunc->GetGlobalEvalBlockScope() : parentFunc->GetBodyScope()));
-                    }
-#endif
-                }
-#endif
-                Js::ScopeInfo::SaveParentScopeInfo(parentFunc, funcInfo);
-            }
+            currentScope = currentScope->GetEnclosingScope();
+        }
+
+        ScopeInfo * scopeInfo = ScopeInfo::SaveScopeInfo(currentScope, byteCodeGenerator->GetScriptContext());
+        if (scopeInfo != nullptr)
+        {
+            funcInfo->byteCodeFunction->SetScopeInfo(scopeInfo);
         }
     }
 
     //
     // Load persisted scope info.
     //
-    void ScopeInfo::GetScopeInfo(Parser *parser, ByteCodeGenerator* byteCodeGenerator, FuncInfo* funcInfo, Scope* scope)
+    void ScopeInfo::ExtractScopeInfo(Parser *parser, /*ByteCodeGenerator* byteCodeGenerator, FuncInfo* funcInfo,*/ Scope* scope)
     {
         ScriptContext* scriptContext;
         ArenaAllocator* alloc;
 
         // Load scope attributes and push onto scope stack.
+        scope->SetMustInstantiate(this->mustInstantiate);
+        scope->SetHasOwnLocalInClosure(this->hasLocalInClosure);
         scope->SetIsDynamic(this->isDynamic);
         if (this->isObject)
         {
             scope->SetIsObject();
         }
-        scope->SetMustInstantiate(this->mustInstantiate);
         if (!this->GetCanMergeWithBodyScope())
         {
             scope->SetCannotMergeWithBodyScope();
         }
-        scope->SetHasOwnLocalInClosure(this->hasLocalInClosure);
-        if (parser)
-        {
-            scriptContext = parser->GetScriptContext();
-            alloc = parser->GetAllocator();
-        }
-        else
-        {
-            TRACE_BYTECODE(_u("\nRestore ScopeInfo: %s #symbols: %d %s\n"),
-                funcInfo->name, symbolCount, isObject ? _u("isObject") : _u(""));
+        Assert(parser);
 
-            Assert(!this->isCached || scope == funcInfo->GetBodyScope());
-            funcInfo->SetHasCachedScope(this->isCached);
-            byteCodeGenerator->PushScope(scope);
-
-            // this->scope was created/saved during parsing and used by
-            // ByteCodeGenerator::RestoreScopeInfo. We no longer need it by now.
-            // Clear it to avoid GC false positive (arena memory later used by GC).
-            Assert(this->scope == scope);
-            this->scope = nullptr;
-
-            // The scope is already populated, so we're done.
-            return;
-        }
+        scriptContext = parser->GetScriptContext();
+        alloc = parser->GetAllocator();
 
         // Load scope symbols
         // On first access to the scopeinfo, replace the ID's with PropertyRecord*'s to save the dictionary lookup

--- a/lib/Runtime/ByteCode/Symbol.cpp
+++ b/lib/Runtime/ByteCode/Symbol.cpp
@@ -200,7 +200,7 @@ Symbol * Symbol::GetFuncScopeVarSym() const
         Scope* paramScope = parentFuncInfo->GetParamScope();
         fncScopeSym = paramScope->FindLocalSymbol(this->GetName());
     }
-    Assert(fncScopeSym);
+
     // Parser should have added a fake var decl node for block scoped functions in non-strict mode
     // IsBlockVar() indicates a user let declared variable at function scope which
     // shadows the function's var binding, thus only emit the var binding init if

--- a/test/DebuggerCommon/blockScopeFunctionDeclarationSlotArrayTest.js.dbg.baseline
+++ b/test/DebuggerCommon/blockScopeFunctionDeclarationSlotArrayTest.js.dbg.baseline
@@ -21,6 +21,7 @@
     "this": "Object {...}",
     "arguments": "Object {...}",
     "locals": {
+      "f": "function function f() { }",
       "g": "function <large string>",
       "a": "number 1"
     }

--- a/test/stackfunc/let_blockescape.deferparse.baseline
+++ b/test/stackfunc/let_blockescape.deferparse.baseline
@@ -1,7 +1,7 @@
 HasFuncDecl: test
 HasFuncDecl: test
-HasMaybeEscapedUse: x
 HasMaybeEscapedNestedFunc (CrossScopeAssignment): test (function  (#1.1), #2)
 HasFuncAssignment: f
+HasMaybeEscapedUse: x
 test1str
 test2str

--- a/test/stackfunc/let_stackfunc.deferparse.baseline
+++ b/test/stackfunc/let_stackfunc.deferparse.baseline
@@ -2,17 +2,18 @@ HasFuncDecl: test
 HasFuncDecl: nested
 HasFuncDecl: test
 HasFuncDecl: nested
-HasMaybeEscapedUse: x
-HasMaybeEscapedUse: x
 HasFuncAssignment: f
 HasMaybeEscapedUse: i
 HasFuncAssignment: f2
 HasFuncAssignment: f3
 DoStackNestedFunc: test (function  (#1.1), #2)
 HasFuncDecl: nested
+HasMaybeEscapedUse: x
 test1glo yes
 test2glo yes
+HasMaybeEscapedUse: x
 0
+HasMaybeEscapedUse: x
 f30
 undefined
 f3undefined

--- a/test/stackfunc/with_namedfunc.deferparse.baseline
+++ b/test/stackfunc/with_namedfunc.deferparse.baseline
@@ -3,5 +3,6 @@ HasFuncDecl: blah
 HasFuncDecl: test
 HasFuncDecl: blah
 HasMaybeEscapedNestedFunc (UnknownAssignment): test (function  (#1.1), #2)
+HasFuncDecl: blah
 test1
 test2


### PR DESCRIPTION
Support deferral of functions enclosed in scopes other than function body and function expression scope -- in particular, ES6-style lexical scopes and parameter scopes. This requires changing ScopeInfo so that it is associated with a single scope rather than a function body. Instead of carrying per-function information for body/var scope, parameter scope, and function expression scope, ScopeInfo will describe one scope, with a value identifying the scope type, a pointer to the FunctionInfo that contains it, and a pointer to the enclosing ScopeInfo. A FunctionProxy will point to the ScopeInfo that is the nearest enclosing scope. At parse time, we will reconstitute the closure environment by walking the list of enclosing ScopeInfo's. The code that allowed redeferral to work around the context limitation of deferring parsing is deleted, and the OptimizeBlockScope feature is off by default, as it doesn't play well with this new logic and isn't required to make (re-)deferral effective. (We will want to revisit it, though, so I've left it there.)