### PR TITLE
Atomics check fails for virtual typedarray.

### DIFF
--- a/lib/Runtime/Library/AtomicsObject.cpp
+++ b/lib/Runtime/Library/AtomicsObject.cpp
@@ -24,17 +24,18 @@ namespace Js
             JavascriptError::ThrowTypeError(scriptContext, JSERR_NeedTypedArrayObject);
         }
 
+        TypeId typeId = JavascriptOperators::GetTypeId(typedArray);
         if (onlyInt32)
         {
-            if (!Int32Array::Is(typedArray))
+            if (typeId != TypeIds_Int32Array)
             {
                 JavascriptError::ThrowTypeError(scriptContext, JSERR_InvalidOperationOnTypedArray);
             }
         }
         else
         {
-            if (!(Int8Array::Is(typedArray) || Uint8Array::Is(typedArray) || Int16Array::Is(typedArray) ||
-                Uint16Array::Is(typedArray) || Int32Array::Is(typedArray) || Uint32Array::Is(typedArray)))
+            if (!(typeId == TypeIds_Int8Array || typeId == TypeIds_Uint8Array || typeId == TypeIds_Int16Array ||
+                typeId == TypeIds_Uint16Array || typeId == TypeIds_Int32Array || typeId == TypeIds_Uint32Array))
             {
                 JavascriptError::ThrowTypeError(scriptContext, JSERR_InvalidOperationOnTypedArray);
             }

--- a/test/es7/atomics_test.js
+++ b/test/es7/atomics_test.js
@@ -583,6 +583,20 @@ var tests = [{
             assert.areEqual(ret, "timed-out", "Negative infinity will be treated as 0 and so this will time-out");
 		}
 	},
+    {
+		name : "Atomics on virtual typedarray",
+		body : function () {
+            [2**15, 2**20, 2**25].forEach(function(size) {
+                IntViews.forEach(function(item) {
+                    var view = new item.ctor(new SharedArrayBuffer(size));
+                    Atomics.add(view, 0, 10);
+                    Atomics.store(view, 2**10, 20);
+                    assert.areEqual(Atomics.load(view, 0), 10);
+                    assert.areEqual(Atomics.load(view, 2**10), 20);
+                });
+            });
+		}
+	},
 ];
 
 testRunner.runTests(tests, {


### PR DESCRIPTION
Atomics operation failed on the virtual typedarray (when SharedArrayBuffer is more than 2^16). However In our case we don't need to check for virtual table check as the final operation happes on the typedarray itself. Fixed that by checking just the typeid.
