### PR TITLE
 xplat: add ChakraCoreHeaders target.

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -73,3 +73,7 @@ add_subdirectory (Jsrt)
 if (CC_TARGETS_AMD64)
     add_subdirectory (WasmReader)
 endif()
+
+if(NOT CC_XCODE_PROJECT)
+    add_dependencies(ChakraCoreStatic ChakraCoreHeaders)
+endif(NOT CC_XCODE_PROJECT)

--- a/lib/Common/CMakeLists.txt
+++ b/lib/Common/CMakeLists.txt
@@ -9,3 +9,13 @@ add_subdirectory (DataStructures)
 add_subdirectory (Exceptions)
 add_subdirectory (Memory)
 add_subdirectory (Util)
+
+
+if(NOT CC_XCODE_PROJECT)
+    add_custom_target(ChakraCoreHeaders ALL
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_BINARY_DIR}/include"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "${CMAKE_CURRENT_SOURCE_DIR}/ChakraCoreVersion.h"
+            "${CMAKE_BINARY_DIR}/include"
+    )
+endif()

--- a/lib/Jsrt/CMakeLists.txt
+++ b/lib/Jsrt/CMakeLists.txt
@@ -27,3 +27,19 @@ target_include_directories (
     ../Runtime/Debug
     ../Parser
     )
+
+if(NOT CC_XCODE_PROJECT)
+    add_custom_command(TARGET ChakraCoreHeaders PRE_BUILD
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_BINARY_DIR}/include"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "${CMAKE_CURRENT_SOURCE_DIR}/ChakraCore.h"
+            "${CMAKE_BINARY_DIR}/include"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "${CMAKE_CURRENT_SOURCE_DIR}/ChakraCommon.h"
+            "${CMAKE_BINARY_DIR}/include"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            "${CMAKE_CURRENT_SOURCE_DIR}/ChakraDebug.h"
+            "${CMAKE_BINARY_DIR}/include"
+        APPEND
+    )
+endif(NOT CC_XCODE_PROJECT)


### PR DESCRIPTION
 Currently only the ChakraCore shared library uses this target, however
 this
 target is also extremely useful for Static Library builds. To use this
 target with any other target library/executable, simply add the following
 line to cmake:

 add_dependencies(myTarget ChakraCoreHeaders)

 Version 2: Add changes suggested by Oguz Bastemur and updated files to
 work with latest tree.

Also, this supersedes pull request #2129.