### PR TITLE
Avoid calling CompileScriptException::ProcessError in the catch handler, where the stack is not unwounded.

### DIFF
--- a/lib/Common/CommonDefines.h
+++ b/lib/Common/CommonDefines.h
@@ -201,7 +201,6 @@
 #define ENABLE_PROFILE_INFO 1
 
 #define ENABLE_BACKGROUND_JOB_PROCESSOR 1
-#define ENABLE_BACKGROUND_PARSING 1
 #define ENABLE_COPYONACCESS_ARRAY 1
 #ifndef DYNAMIC_INTERPRETER_THUNK
 #if defined(_M_IX86_OR_ARM32) || defined(_M_X64_OR_ARM64)
@@ -210,6 +209,12 @@
 #define DYNAMIC_INTERPRETER_THUNK 0
 #endif
 #endif
+
+// Don't enable background parser in release build.
+#if ENABLE_DEBUG_CONFIG_OPTIONS
+#define ENABLE_BACKGROUND_PARSING 1
+#endif
+
 #endif
 
 #if ENABLE_NATIVE_CODEGEN

--- a/lib/Common/Memory/HeapInfo.cpp
+++ b/lib/Common/Memory/HeapInfo.cpp
@@ -1037,6 +1037,8 @@ HeapInfo::Rescan(RescanFlags flags)
     return scannedPageCount;
 }
 
+#ifdef DUMP_FRAGMENTATION_STATS
+
 template <ObjectInfoBits TBucketType, class TBlockAttributes>
 void DumpBucket(uint bucketIndex, typename SmallHeapBlockType<TBucketType, TBlockAttributes>::BucketType& bucket)
 {
@@ -1048,7 +1050,6 @@ void DumpBucket(uint bucketIndex, typename SmallHeapBlockType<TBucketType, TBloc
     Output::Print(_u("%d,%d,%d,%d,%d,%d,%d\n"), stats.totalBlockCount, stats.finalizeBlockCount, stats.emptyBlockCount, stats.objectCount, stats.finalizeCount, stats.objectByteCount, stats.totalByteCount);
 }
 
-#ifdef DUMP_FRAGMENTATION_STATS
 void
 HeapInfo::DumpFragmentationStats()
 {

--- a/lib/Parser/BackgroundParser.cpp
+++ b/lib/Parser/BackgroundParser.cpp
@@ -8,6 +8,7 @@
     "Cannot use this member of BackgroundParser from thread other than the creating context's current thread")
 
 #if ENABLE_NATIVE_CODEGEN
+#if ENABLE_BACKGROUND_PARSING
 BackgroundParser::BackgroundParser(Js::ScriptContext *scriptContext)
     :   JsUtil::WaitableJobManager(scriptContext->GetThreadContext()->GetJobProcessor()),
         scriptContext(scriptContext),
@@ -291,4 +292,5 @@ void BackgroundParseItem::AddRegExpNode(ParseNode *const pnode, ArenaAllocator *
 
     regExpNodes->Append(pnode);
 }
+#endif
 #endif

--- a/lib/Parser/Hash.cpp
+++ b/lib/Parser/Hash.cpp
@@ -26,11 +26,11 @@ const HashTbl::ReservedWordInfo HashTbl::s_reservedWordInfo[tkID] =
 #include "keywords.h"
 };
 
-HashTbl * HashTbl::Create(uint cidHash, ErrHandler * perr)
+HashTbl * HashTbl::Create(uint cidHash)
 {
     HashTbl * phtbl;
 
-    if (nullptr == (phtbl = HeapNewNoThrow(HashTbl,perr)))
+    if (nullptr == (phtbl = HeapNewNoThrow(HashTbl)))
         return nullptr;
     if (!phtbl->Init(cidHash))
     {
@@ -301,12 +301,12 @@ IdentPtr HashTbl::PidHashNameLenWithHash(_In_reads_(cch) CharType const * prgch,
         FAILED(ULongToLong(Len, &cb)))
     {
         cb = 0;
-        m_perr->Throw(ERRnoMemory);
+        OutOfMemory();
     }
 
 
     if (nullptr == (pid = (IdentPtr)m_noReleaseAllocator.Alloc(cb)))
-        m_perr->Throw(ERRnoMemory);
+        OutOfMemory();
 
     /* Insert the identifier into the hash list */
     *ppid = pid;
@@ -466,3 +466,8 @@ LDefault:
 }
 
 #pragma warning(pop)
+
+__declspec(noreturn) void HashTbl::OutOfMemory()
+{
+    throw ParseExceptionObject(ERRnoMemory);
+}

--- a/lib/Parser/Hash.h
+++ b/lib/Parser/Hash.h
@@ -314,7 +314,7 @@ public:
 class HashTbl
 {
 public:
-    static HashTbl * Create(uint cidHash, ErrHandler * perr);
+    static HashTbl * Create(uint cidHash);
 
     void Release(void)
     {
@@ -384,14 +384,12 @@ private:
     Ident ** m_prgpidName;        // hash table for names
 
     uint32 m_luMask;                // hash mask
-    uint32 m_luCount;              // count of the number of entires in the hash table
-    ErrHandler * m_perr;        // error handler to use
+    uint32 m_luCount;              // count of the number of entires in the hash table    
     IdentPtr m_rpid[tkLimKwd];
 
-    HashTbl(ErrHandler * perr)
+    HashTbl()
     {
         m_prgpidName = nullptr;
-        m_perr = perr;
         memset(&m_rpid, 0, sizeof(m_rpid));
     }
     ~HashTbl(void) {}
@@ -471,6 +469,7 @@ private:
     static const KWD * KwdOfTok(tokens tk)
     { return (unsigned int)tk < tkLimKwd ? g_mptkkwd + tk : nullptr; }
 
+    static __declspec(noreturn) void OutOfMemory();
 #if PROFILE_DICTIONARY
     DictionaryStats *stats;
 #endif

--- a/lib/Parser/Parse.h
+++ b/lib/Parser/Parse.h
@@ -204,7 +204,6 @@ private:
 protected:
     Js::ScriptContext* m_scriptContext;
     HashTbl *   m_phtbl;
-    ErrHandler  m_err;
 
     static const uint HASH_TABLE_SIZE = 256;
 
@@ -305,12 +304,14 @@ public:
     void PrepareScanner(bool fromExternal);
     void PrepareForBackgroundParse();
     void AddFastScannedRegExpNode(ParseNodePtr const pnode);
+#if ENABLE_BACKGROUND_PARSING
     void AddBackgroundRegExpNode(ParseNodePtr const pnode);
     void AddBackgroundParseItem(BackgroundParseItem *const item);
     void FinishBackgroundRegExpNodes();
     void FinishBackgroundPidRefs(BackgroundParseItem *const item, bool isOtherParser);
     void WaitForBackgroundJobs(BackgroundParser *bgp, CompileScriptException *pse);
     HRESULT ParseFunctionInBackground(ParseNodePtr pnodeFunc, ParseContext *parseContext, bool topLevelDeferred, CompileScriptException *pse);
+#endif
 
     void CheckPidIsValid(IdentPtr pid, bool autoArgumentsObject = false);
     void AddVarDeclToBlock(ParseNode *pnode);

--- a/lib/Parser/Scan.cpp
+++ b/lib/Parser/Scan.cpp
@@ -124,16 +124,14 @@ IdentPtr Token::CreateIdentifier(HashTbl * hashTbl)
 }
 
 template <typename EncodingPolicy>
-Scanner<EncodingPolicy>::Scanner(Parser* parser, HashTbl *phtbl, Token *ptoken, ErrHandler *perr, Js::ScriptContext* scriptContext)
+Scanner<EncodingPolicy>::Scanner(Parser* parser, HashTbl *phtbl, Token *ptoken, Js::ScriptContext* scriptContext)
 {
     AssertMem(phtbl);
     AssertMem(ptoken);
-    AssertMem(perr);
     m_parser = parser;
     m_phtbl = phtbl;
     m_ptoken = ptoken;
     m_cMinLineMultiUnits = 0;
-    m_perr = perr;
     m_fHadEol = FALSE;
 
     m_doubleQuoteOnLastTkStrCon = FALSE;

--- a/lib/Parser/Scan.h
+++ b/lib/Parser/Scan.h
@@ -364,9 +364,9 @@ class Scanner : public IScanner, public EncodingPolicy
     typedef typename EncodingPolicy::EncodedCharPtr EncodedCharPtr;
 
 public:
-    static Scanner * Create(Parser* parser, HashTbl *phtbl, Token *ptoken, ErrHandler *perr, Js::ScriptContext *scriptContext)
+    static Scanner * Create(Parser* parser, HashTbl *phtbl, Token *ptoken, Js::ScriptContext *scriptContext)
     {
-        return HeapNewNoThrow(Scanner, parser, phtbl, ptoken, perr, scriptContext);
+        return HeapNewNoThrow(Scanner, parser, phtbl, ptoken, scriptContext);
     }
     void Release(void)
     {
@@ -677,7 +677,6 @@ private:
     EncodedCharPtr m_pchPrevLine;      // beginning of previous line
     size_t m_cMinTokMultiUnits;        // number of multi-unit characters previous to m_pchMinTok
     size_t m_cMinLineMultiUnits;       // number of multi-unit characters previous to m_pchMinLine
-    ErrHandler *m_perr;                // error handler to use
     uint16 m_fStringTemplateDepth;     // we should treat } as string template middle starting character (depth instead of flag)
     BOOL m_fHadEol;
     BOOL m_fIsModuleCode : 1;
@@ -711,7 +710,7 @@ private:
     tokens m_tkPrevious;
     size_t m_iecpLimTokPrevious;
 
-    Scanner(Parser* parser, HashTbl *phtbl, Token *ptoken, ErrHandler *perr, Js::ScriptContext *scriptContext);
+    Scanner(Parser* parser, HashTbl *phtbl, Token *ptoken, Js::ScriptContext *scriptContext);
     ~Scanner(void);
 
     template <bool forcePid>
@@ -729,11 +728,9 @@ private:
 
     __declspec(noreturn) void Error(HRESULT hr)
     {
-        Assert(FAILED(hr));
         m_pchMinTok = m_currentCharacter;
         m_cMinTokMultiUnits = this->m_cMultiUnits;
-        AssertMem(m_perr);
-        m_perr->Throw(hr);
+        throw ParseExceptionObject(hr);
     }
 
     const EncodedCharPtr PchBase(void)

--- a/lib/Parser/cmperr.cpp
+++ b/lib/Parser/cmperr.cpp
@@ -4,14 +4,8 @@
 //-------------------------------------------------------------------------------------------------------
 #include "ParserPch.h"
 
-#if DEBUG
-#include <stdarg.h>
-#endif //DEBUG
-
-void ErrHandler::Throw(HRESULT hr)
+ParseExceptionObject::ParseExceptionObject(HRESULT hr) : m_hr(hr)
 {
-    Assert(fInited);
     Assert(FAILED(hr));
-    m_hr = hr;
-    throw ParseExceptionObject(hr);
 }
+

--- a/lib/Parser/cmperr.h
+++ b/lib/Parser/cmperr.h
@@ -17,28 +17,8 @@ enum
 class ParseExceptionObject
 {
 public:
-    ParseExceptionObject(HRESULT hr) : m_hr(hr) {}
+    ParseExceptionObject(HRESULT hr);
     HRESULT GetError() { return m_hr; }
 private:
     HRESULT m_hr;
 };
-
-typedef void (*ErrorCallback)(void *data, HRESULT hr);
-
-class ErrHandler
-{
-public:
-    HRESULT m_hr;
-
-    void *m_data;
-    ErrorCallback m_callback;
-
-    __declspec(noreturn) void Throw(HRESULT hr);
-
-#if DEBUG
-    BOOL fInited;
-    ErrHandler()
-    { fInited = FALSE; }
-#endif //DEBUG
-};
-

--- a/lib/Parser/screrror.cpp
+++ b/lib/Parser/screrror.cpp
@@ -245,9 +245,6 @@ void CompileScriptException::Free()
 
 HRESULT  CompileScriptException::ProcessError(IScanner * pScan, HRESULT hr, ParseNode * pnodeBase)
 {
-    if (nullptr == this)
-        return hr;
-
     // fill in the ScriptException structure
     Clear();
     ei.scode = GetScode(MapHr(hr));

--- a/lib/Parser/screrror.h
+++ b/lib/Parser/screrror.h
@@ -7,7 +7,6 @@
 /***************************************************************************
 Exception blocks
 ***************************************************************************/
-class ErrHandler;
 struct ParseNode;
 class COleScript;
 interface IScanner;

--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -1918,6 +1918,7 @@ namespace Js
     {
         Assert(!this->threadContext->IsScriptActive());
         Assert(pse != nullptr);
+        HRESULT hr = NOERROR;
         try
         {
             AUTO_NESTED_HANDLED_EXCEPTION_TYPE((ExceptionType)(ExceptionType_OutOfMemory | ExceptionType_StackOverflow));
@@ -1958,14 +1959,14 @@ namespace Js
         }
         catch (Js::OutOfMemoryException)
         {
-            pse->ProcessError(nullptr, E_OUTOFMEMORY, nullptr);
-            return nullptr;
+            hr = E_OUTOFMEMORY;
         }
         catch (Js::StackOverflowException)
         {
-            pse->ProcessError(nullptr, VBSERR_OutOfStack, nullptr);
-            return nullptr;
+            hr = VBSERR_OutOfStack;
         }
+        pse->ProcessError(nullptr, hr, nullptr);
+        return nullptr;
     }
 
     JavascriptFunction* ScriptContext::GenerateRootFunction(ParseNodePtr parseTree, uint sourceIndex, Parser* parser, uint32 grfscr, CompileScriptException * pse, const char16 *rootDisplayName)

--- a/lib/Runtime/Language/SourceTextModuleRecord.cpp
+++ b/lib/Runtime/Language/SourceTextModuleRecord.cpp
@@ -121,23 +121,25 @@ namespace Js
                     sourceLength, srcInfo, &se, &pResultSourceInfo, _u("module"),
                     loadScriptFlag, &sourceIndex, nullptr);
                 this->pSourceInfo = pResultSourceInfo;
-
-                if (parseTree == nullptr)
-                {
-                    hr = E_FAIL;
-                }
             }
             catch (Js::OutOfMemoryException)
             {
                 hr = E_OUTOFMEMORY;
-                se.ProcessError(nullptr, E_OUTOFMEMORY, nullptr);
             }
             catch (Js::StackOverflowException)
             {
                 hr = VBSERR_OutOfStack;
-                se.ProcessError(nullptr, VBSERR_OutOfStack, nullptr);
             }
-            if (SUCCEEDED(hr))
+
+            if (FAILED(hr))
+            {
+                se.ProcessError(nullptr, hr, nullptr);
+            }
+            else if (parseTree == nullptr)
+            {
+                hr = E_FAIL;
+            }
+            else
             {
                 hr = PostParseProcess();
                 if (hr == S_OK && this->errorObject != nullptr && this->hadNotifyHostReady)


### PR DESCRIPTION
If we are hitting a stack overflow, we should unwind the stack before running more code (like ProcessError)
Also clean up ErrHandler, which really does nothing but throw ParseException.  Change it to directly throw ParseException.

Clean up some debug only ifdef and disable background parsing code in release build, which is not enabled by default.

Fixes VSO: 11101148
