### PR TITLE
Fix bad code with call to closure-captured local function from inside 'with'. 

### DIFF
--- a/test/Basics/With.baseline
+++ b/test/Basics/With.baseline
@@ -24,3 +24,4 @@ local evalinwith
 global evalinwith
 Value of level1 after assignment at level 1: level1
 a is called
+in inner

--- a/test/Basics/With.js
+++ b/test/Basics/With.js
@@ -151,3 +151,16 @@ level1Func();
 with ({}) {
     var arrwithfunc = [(function handlerFactory() { return; })];
 }
+
+(function() {
+    function outer() {
+        function inner(){ WScript.Echo('in inner') }
+        with({}) 
+        {
+            {
+                (function(){ inner(); })();
+            }
+        }
+    }
+    outer();
+})();

--- a/test/Basics/rlexe.xml
+++ b/test/Basics/rlexe.xml
@@ -270,6 +270,14 @@
   </test>
   <test>
     <default>
+      <files>With.js</files>
+      <baseline>With.baseline</baseline>
+      <compile-flags>-force:deferparse</compile-flags>
+      <tags>fail_mutators</tags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>withBug940841.js</files>
       <compile-flags>-MaxinterpretCount:1 -MaxSimpleJITRunCount:1</compile-flags>
     </default>


### PR DESCRIPTION
The case where the with statement is in a function nested within the function that instantiates the called function is already handled. Now that functions nested within with can be deferred, we need to handle the case where the with is in the enclosing function itself.