### PR TITLE
Added support to post_build.ps1 and runcitests.cmd to have extra test params.

### DIFF
--- a/Build/scripts/post_build.ps1
+++ b/Build/scripts/post_build.ps1
@@ -30,6 +30,8 @@ param (
     [string]$srcsrvcmdpath,
 
     [string]$bvtcmdpath = "",
+    [string]$testparams = "",
+    
     [string]$repo = "core",
     [string]$logFile = "",
 
@@ -71,8 +73,8 @@ if ($arch -eq "*") {
 
     $buildName = ConstructBuildName -arch $arch -flavor $flavor -subtype $subtype
 
-    if (($logFile -eq "") -and (Test-Path Env:\TF_BUILD_BINARIESDIRECTORY)) {
-        $logFile = "${Env:TF_BUILD_BINARIESDIRECTORY}\logs\post_build.${buildName}.log"
+    if (($logFile -eq "") -and (Test-Path $buildRoot)) {
+        $logFile = "${buildRoot}\logs\post_build.${buildName}.log"
         if (Test-Path -Path $logFile) {
             Remove-Item $logFile -Force
         }
@@ -114,7 +116,9 @@ if ($arch -eq "*") {
 
         # run tests
         if (-not $skipTests) {
-            ExecuteCommand("$bvtcmdpath -$arch$flavor")
+            # marshall environment var for cmd script
+            $Env:TF_BUILD_BINARIESDIRECTORY = $buildRoot
+            ExecuteCommand("$bvtcmdpath -$arch$flavor $testparams")
         }
     }
 

--- a/test/runcitests.cmd
+++ b/test/runcitests.cmd
@@ -28,8 +28,14 @@
 @echo off
 setlocal
 
+if "%TF_BUILD_BINARIESDIRECTORY%" == "" (
+  echo TF_BUILD_BINARIESDIRECTORY is required for this script to work correctly.
+  exit /b 1
+)
+
 set _RootDir=%~dp0..
 set _StagingDir=%TF_BUILD_BINARIESDIRECTORY%
+REM %TF_BUILD_DROPLOCATION% is not required -- used only for an informational message
 set _DropRootDir=%TF_BUILD_DROPLOCATION%
 set _HadFailures=0
 
@@ -82,7 +88,7 @@ set _HadFailures=0
     
     call :summarizeLogs summary.log
   ) else (
-    call :runTests %_BuildArch% %_BuildType%
+    call :runTests %_BuildArch% %_BuildType% %_ExtraArgs%
     call :runNativeTests %_BuildArch% %_BuildType%
     call :summarizeLogs summary.%_BuildArch%%_BuildType%.log
   )
@@ -114,7 +120,7 @@ set _HadFailures=0
 :: ============================================================================
 :runTests
 
-  call :do %_TestDir%\runtests.cmd -%1%2 -quiet -cleanupall -binDir %_StagingDir%\bin
+  call :do %_TestDir%\runtests.cmd -%1%2 %3 -quiet -cleanupall -binDir %_StagingDir%\bin
 
   if ERRORLEVEL 1 set _HadFailures=1
 
@@ -229,7 +235,7 @@ set _HadFailures=0
 
   if /i "%1" == "-all"              set _RunAll=1&                                              goto :ArgOk
 
-  if not "%1" == "" echo Unknown argument: %1 & set fShowGetHelp=1
+  if not "%1" == ""                 set _ExtraArgs=%_ExtraArgs% %1&                             goto :ArgOk
 
   goto :eof
 


### PR DESCRIPTION
The build scripts pass a new parameter to post_build.ps1 (-testparams)
which post_build.ps1 on release/1.4 does not know about. This causes post_build.ps1 to
throw an error.

Fixed by porting the change from master. Cherry-picked 803abd5a30.
