### PR TITLE
Reduce memory consumption of Utf8SourceInfo objects

### DIFF
--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -1814,7 +1814,7 @@ namespace Js
             // Free unused bytes
             Assert(cbNeeded + 1 <= cbUtf8Buffer);
             *ppSourceInfo = Utf8SourceInfo::New(this, utf8Script, (int)length,
-                cbNeeded, pSrcInfo, isLibraryCode, scriptSource);
+                cbNeeded, pSrcInfo, isLibraryCode);
         }
         else
         {
@@ -1834,7 +1834,7 @@ namespace Js
                     // the 'length' here is not correct - we will get the length from the parser - however parser hasn't done yet.
                     // Once the parser is done we will update the utf8sourceinfo's lenght correctly with parser's
                     *ppSourceInfo = Utf8SourceInfo::New(this, script,
-                        (int)length, cb, pSrcInfo, isLibraryCode, scriptSource);
+                        (int)length, cb, pSrcInfo, isLibraryCode);
                 }
             }
         }

--- a/lib/Runtime/Base/Utf8SourceInfo.cpp
+++ b/lib/Runtime/Base/Utf8SourceInfo.cpp
@@ -218,12 +218,12 @@ namespace Js
 
     Utf8SourceInfo*
     Utf8SourceInfo::New(ScriptContext* scriptContext, LPCUTF8 utf8String, int32 length,
-        size_t numBytes, SRCINFO const* srcInfo, bool isLibraryCode, Js::Var scriptSource)
+        size_t numBytes, SRCINFO const* srcInfo, bool isLibraryCode)
     {
         utf8char_t * newUtf8String = RecyclerNewArrayLeaf(scriptContext->GetRecycler(), utf8char_t, numBytes + 1);
         js_memcpy_s(newUtf8String, numBytes + 1, utf8String, numBytes + 1);
         return NewWithNoCopy(scriptContext, newUtf8String, length, numBytes,
-            srcInfo, isLibraryCode, scriptSource);
+            srcInfo, isLibraryCode);
     }
 
     Utf8SourceInfo*

--- a/lib/Runtime/Base/Utf8SourceInfo.h
+++ b/lib/Runtime/Base/Utf8SourceInfo.h
@@ -299,7 +299,7 @@ namespace Js
             bool isLibraryCode, Js::Var scriptSource = nullptr);
         static Utf8SourceInfo* New(ScriptContext* scriptContext, LPCUTF8 utf8String,
             int32 length, size_t numBytes, SRCINFO const* srcInfo,
-            bool isLibraryCode, Js::Var scriptSource = nullptr);
+            bool isLibraryCode);
         static Utf8SourceInfo* NewWithNoCopy(ScriptContext* scriptContext,
             LPCUTF8 utf8String, int32 length, size_t numBytes,
             SRCINFO const* srcInfo, bool isLibraryCode, Js::Var scriptSource = nullptr);

--- a/lib/Runtime/Library/GlobalObject.cpp
+++ b/lib/Runtime/Library/GlobalObject.cpp
@@ -882,7 +882,7 @@ namespace Js
             // So we need to pin it here (TODO: Change GenerateByteCode to take in the sourceInfo itself)
             ENTER_PINNED_SCOPE(Utf8SourceInfo, sourceInfo);
             sourceInfo = Utf8SourceInfo::New(scriptContext, utf8Source, cchSource,
-              cbSource, pSrcInfo, ((grfscr & fscrIsLibraryCode) != 0), nullptr);
+              cbSource, pSrcInfo, ((grfscr & fscrIsLibraryCode) != 0));
 
             Parser parser(scriptContext, strictMode);
             bool forceNoNative = false;


### PR DESCRIPTION
Today we hold on to `scriptSource` objects inside `Utf8SourceInfo` even if we make a copy of the script source inside source holder. This is unnecessary and increase the working set. The fix is to not hold reference anymore.

However if the `scriptSource` is external array buffer and is managing its own life time, we don't need to make copy of it and instead we just hold the reference to `scriptSource` for scenarios like `function.name.toString()` to work (which is how it is done today).