### PR TITLE
Issue2681/2702: Multiple imports of same module

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -3139,7 +3139,7 @@ void ByteCodeGenerator::ProcessCapturedSym(Symbol *sym)
     FuncInfo *funcHome = sym->GetScope()->GetFunc();
     FuncInfo *funcChild = funcHome->GetCurrentChildFunction();
 
-    Assert(sym->NeedsSlotAlloc(funcHome) || sym->GetIsGlobal());
+    Assert(sym->NeedsSlotAlloc(funcHome) || sym->GetIsGlobal() || sym->GetIsModuleImport());
 
     // If this is not a local property, or not all its references can be tracked, or
     // it's not scoped to the function, or we're in debug mode, disable the delayed capture optimization.

--- a/lib/Runtime/Language/SourceTextModuleRecord.h
+++ b/lib/Runtime/Language/SourceTextModuleRecord.h
@@ -54,6 +54,8 @@ namespace Js
         void SetWasParsed() { wasParsed = true; }
         bool WasDeclarationInitialized() const { return wasDeclarationInitialized; }
         void SetWasDeclarationInitialized() { wasDeclarationInitialized = true; }
+        bool ReadyAsChildModule() const { return readyAsChildModule; }
+        void SetReadyAsChildModule() { readyAsChildModule = true; }
         void SetIsRootModule() { isRootModule = true; }
 
         void SetImportRecordList(ModuleImportOrExportEntryList* importList) { importRecordList = importList; }
@@ -107,6 +109,7 @@ namespace Js
         // This is the parsed tree resulted from compilation. 
         Field(bool) wasParsed;
         Field(bool) wasDeclarationInitialized;
+        Field(bool) readyAsChildModule;
         Field(bool) isRootModule;
         Field(bool) hadNotifyHostReady;
         Field(ParseNodePtr) parseTree;
@@ -124,7 +127,7 @@ namespace Js
         Field(LocalExportMap*) localExportMapByExportName;  // from propertyId to index map: for bytecode gen.
         Field(LocalExportMap*) localExportMapByLocalName;  // from propertyId to index map: for bytecode gen.
         Field(LocalExportIndexList*) localExportIndexList; // from index to propertyId: for typehandler.
-        Field(uint) numUnInitializedChildrenModule;
+        Field(uint) numPendingChildrenModule;
         Field(ExportedNames*) exportedNames;
         Field(ResolvedExportMap*) resolvedExportMap;
 

--- a/test/es6/moduletest2.js
+++ b/test/es6/moduletest2.js
@@ -1,0 +1,6 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+var loaded = 0;
+WScript.LoadScriptFile('moduletest2_mod0.js', "module");

--- a/test/es6/moduletest2_mod0.js
+++ b/test/es6/moduletest2_mod0.js
@@ -1,0 +1,9 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+import './moduletest2_mod1a.js';
+import './moduletest2_mod1b.js';
+
+loaded++;
+if (loaded == 5) console.log("Pass");

--- a/test/es6/moduletest2_mod1a.js
+++ b/test/es6/moduletest2_mod1a.js
@@ -1,0 +1,7 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+import './moduletest2_mod2a.js';
+import './moduletest2_mod1b.js';
+loaded++;

--- a/test/es6/moduletest2_mod1b.js
+++ b/test/es6/moduletest2_mod1b.js
@@ -1,0 +1,6 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+import './moduletest2_mod2b.js';
+loaded++;

--- a/test/es6/moduletest2_mod2a.js
+++ b/test/es6/moduletest2_mod2a.js
@@ -1,0 +1,6 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+import './moduletest2_mod1b.js';
+loaded++;

--- a/test/es6/moduletest2_mod2b.js
+++ b/test/es6/moduletest2_mod2b.js
@@ -1,0 +1,5 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+loaded++;

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -1331,6 +1331,13 @@
 </test>
 <test>
     <default>
+        <files>moduletest2.js</files>
+        <compile-flags>-ES6Module</compile-flags>
+        <tags>exclude_dynapogo</tags>
+    </default>
+</test>
+<test>
+    <default>
         <files>module-syntax.js</files>
         <compile-flags>-ES6Module -args summary -endargs</compile-flags>
         <tags>exclude_dynapogo</tags>


### PR DESCRIPTION
While resolving a module, a counter (`numUnInitializedChildModule`)
is maintained to reflect the number of its child modules that have
not been instantiated. Once a child module is parsed and all its children
resolved, its parent modules will be notified through `OnChildModuleReady()`,
where the counter is decremented. The counter has to be zero for a module
to be instantiated.

This causes a problem when there are multiple imports referring to
the same child module, and the child module is parsed and resolved
before some of its other parent modules. Because the child module is only parsed
once, parent modules that are parsed and linked to the child module after
the notification will never see their counter going back to zero. As a result,
these parent modules and all modules importing them will never be instantiated.

Proposed fix is to add a flag (`readyAsChildModule`) and flip it from false to true
upon notification of a module's parents. Future parent modules will see the
flag and deem that child module resolved. Also proposed a name change of the
counter from `numUnInitializedChildModule` to `numPendingChildModule` to
reflect the logic change.
