### PR TITLE
Fix bad byte code when block-scoped function is called from with. 

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -9885,6 +9885,10 @@ LEndSwitch:
         {
             GetCurrentFunctionNode()->sxFnc.SetHasWithStmt(); // Used by DeferNested
         }
+        for (Scope *scope = this->m_currentScope; scope; scope = scope->GetEnclosingScope())
+        {
+            scope->SetContainsWith();
+        }
 
         ichMin = m_pscan->IchMinTok();
         ChkNxtTok(tkLParen, ERRnoLparen);

--- a/lib/Runtime/ByteCode/FuncInfo.cpp
+++ b/lib/Runtime/ByteCode/FuncInfo.cpp
@@ -63,7 +63,6 @@ FuncInfo::FuncInfo(
     escapes(false),
     hasDeferredChild(false),
     hasRedeferrableChild(false),
-    childHasWith(false),
     hasLoop(false),
     hasEscapedUseNestedFunc(false),
     needEnvRegister(false),

--- a/lib/Runtime/ByteCode/FuncInfo.h
+++ b/lib/Runtime/ByteCode/FuncInfo.h
@@ -137,7 +137,6 @@ public:
     uint escapes : 1;
     uint hasDeferredChild : 1; // switch for DeferNested to persist outer scopes
     uint hasRedeferrableChild : 1;
-    uint childHasWith : 1; // deferNested needs to know if child has with
     uint hasLoop : 1;
     uint hasEscapedUseNestedFunc : 1;
     uint needEnvRegister : 1;
@@ -464,14 +463,6 @@ public:
         Assert(!IsDeferred() || this->byteCodeFunction->GetFunctionBody()->GetByteCode() != nullptr);
 
         return this->byteCodeFunction->GetFunctionBody();
-    }
-
-    bool ChildHasWith() const {
-        return childHasWith;
-    }
-
-    void SetChildHasWith() {
-        childHasWith = true;
     }
 
     bool HasCapturedThis() const {

--- a/lib/Runtime/ByteCode/Scope.h
+++ b/lib/Runtime/ByteCode/Scope.h
@@ -41,6 +41,7 @@ private:
     BYTE canMergeWithBodyScope : 1;
     BYTE hasLocalInClosure : 1;
     BYTE isBlockInLoop : 1;
+    BYTE containsWith : 1;
 public:
 #if DBG
     BYTE isRestored : 1;
@@ -60,6 +61,7 @@ public:
         canMergeWithBodyScope(true),
         hasLocalInClosure(false),
         isBlockInLoop(false),
+        containsWith(false),
         location(Js::Constants::NoRegister),
         m_symList(nullptr),
         m_count(0),
@@ -264,6 +266,9 @@ public:
 
     void SetIsBlockInLoop(bool is = true) { isBlockInLoop = is; }
     bool IsBlockInLoop() const { return isBlockInLoop; }
+
+    void SetContainsWith(bool does = true) { containsWith = does; }
+    bool ContainsWith() const { return containsWith; }
 
     bool HasInnerScopeIndex() const { return innerScopeIndex != (uint)-1; }
     uint GetInnerScopeIndex() const { return innerScopeIndex; }

--- a/test/Basics/With.baseline
+++ b/test/Basics/With.baseline
@@ -25,3 +25,4 @@ global evalinwith
 Value of level1 after assignment at level 1: level1
 a is called
 in inner
+in inner

--- a/test/Basics/With.js
+++ b/test/Basics/With.js
@@ -164,3 +164,15 @@ with ({}) {
     }
     outer();
 })();
+
+(function() {
+    {
+        function inner() { WScript.Echo('in inner'); }
+        function outer() {
+            with({}) {
+                inner();
+            }
+        }
+    }
+    outer();
+})();

--- a/test/DebuggerCommon/with_shadow.js.dbg.baseline
+++ b/test/DebuggerCommon/with_shadow.js.dbg.baseline
@@ -72,8 +72,10 @@
       "Symbol.iterator": "function function values() { [native code] }"
     },
     "scopes0": {
-      "foo": "function <large string>",
       "foo1": "string foo1"
+    },
+    "scopes1": {
+      "foo": "function <large string>"
     },
     "globals": {
       "WScript": "Object {...}",


### PR DESCRIPTION
Yesterday's fix was incomplete, because it failed to address the case in which the nested function called from a with statement is declared in a lexical scope. The concept we're conservatively using, of a scope containing a with statement as well as closure-captured data, has to be tracked on individual scopes rather than functions.