### PR TITLE
register scriptContext to the list after globalObject and javascriptLibrary are initialized

### DIFF
--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -294,7 +294,6 @@ namespace Js
 #endif
 
         // Do this after all operations that may cause potential exceptions. Note: InitialAllocations may still throw!
-        threadContext->RegisterScriptContext(this);
         numberAllocator.Initialize(this->GetRecycler());
 
 #if DEBUG
@@ -1408,6 +1407,8 @@ namespace Js
         // Assigned the global Object after we have successfully AddRef (in case of OOM)
         globalObject = localGlobalObject;
         globalObject->Initialize(this);
+
+        this->GetThreadContext()->RegisterScriptContext(this);
     }
 
     ArenaAllocator* ScriptContext::AllocatorForDiagnostics()


### PR DESCRIPTION
while ETW kicks in, it goes through the list to do source rundown, which can hit a state that the scriptContext is in the list but javascriptLibrary/utf8sourceList is not initialized yet.
change to register the scriptContext after it's fully initialized
