### PR TITLE
Date missing cross-site marshalling

### DIFF
--- a/lib/Runtime/Language/JavascriptConversion.cpp
+++ b/lib/Runtime/Language/JavascriptConversion.cpp
@@ -415,8 +415,7 @@ CommonNumber:
                         // if IsES6ToPrimitiveEnabled flag is off we also fall back to OrdinaryToPrimitive
                         return MethodCallToPrimitive(aValue, hint, requestContext);
                     }
-                    //NOTE: Consider passing requestContext to JavascriptDate::ToString
-                    return CrossSite::MarshalVar(requestContext, JavascriptDate::ToString(dateObject));
+                    return JavascriptDate::ToString(dateObject, requestContext);
                 }
             }
 

--- a/lib/Runtime/Library/JavascriptDate.cpp
+++ b/lib/Runtime/Library/JavascriptDate.cpp
@@ -12,13 +12,13 @@
 namespace Js
 {
     JavascriptDate::JavascriptDate(double value, DynamicType * type)
-        : DynamicObject(type), m_date(value, type->GetScriptContext())
+        : DynamicObject(type), m_date(value)
     {
         Assert(IsDateTypeId(type->GetTypeId()));
     }
 
     JavascriptDate::JavascriptDate(DynamicType * type)
-        : DynamicObject(type), m_date(0, type->GetScriptContext())
+        : DynamicObject(type), m_date(0)
     {
         Assert(type->GetTypeId() == TypeIds_Date);
     }
@@ -88,7 +88,7 @@ namespace Js
 
             // ES5 15.9.2.1: Date() should returns a string exactly the same as (new Date().toString()).
             JavascriptDate* pDate = NewInstanceAsConstructor(args, scriptContext, /* forceCurrentDate */ true);
-            JavascriptString* res = JavascriptDate::ToString(pDate);
+            JavascriptString* res = JavascriptDate::ToString(pDate, scriptContext);
 
 #if ENABLE_TTD
             if(scriptContext->ShouldPerformReplayAction())
@@ -228,7 +228,7 @@ namespace Js
             values[3] * 3600000 + values[4] * 60000 + values[5] * 1000 + values[6]);
 
         // Set the time.
-        pDate->m_date.SetTvLcl(timeValue);
+        pDate->m_date.SetTvLcl(timeValue, scriptContext);
 
         return pDate;
     }
@@ -298,7 +298,7 @@ namespace Js
 
         if (!date->m_date.IsNaN())
         {
-            return date->m_date.GetDate();
+            return date->m_date.GetDate(scriptContext);
         }
         return scriptContext->GetLibrary()->GetNaN();
     }
@@ -325,7 +325,7 @@ namespace Js
 
         if (!date->m_date.IsNaN())
         {
-            return date->m_date.GetDay();
+            return date->m_date.GetDay(scriptContext);
         }
         return scriptContext->GetLibrary()->GetNaN();
     }
@@ -352,7 +352,7 @@ namespace Js
 
         if (!date->m_date.IsNaN())
         {
-            return date->m_date.GetFullYear();
+            return date->m_date.GetFullYear(scriptContext);
         }
         return scriptContext->GetLibrary()->GetNaN();
     }
@@ -379,7 +379,7 @@ namespace Js
 
         if (!date->m_date.IsNaN())
         {
-            return date->m_date.GetYear();
+            return date->m_date.GetYear(scriptContext);
         }
         return scriptContext->GetLibrary()->GetNaN();
     }
@@ -406,7 +406,7 @@ namespace Js
 
         if (!date->m_date.IsNaN())
         {
-            return date->m_date.GetHours();
+            return date->m_date.GetHours(scriptContext);
         }
         return scriptContext->GetLibrary()->GetNaN();
     }
@@ -433,7 +433,7 @@ namespace Js
 
         if (!date->m_date.IsNaN())
         {
-            return date->m_date.GetDateMilliSeconds();
+            return date->m_date.GetDateMilliSeconds(scriptContext);
         }
         return scriptContext->GetLibrary()->GetNaN();
     }
@@ -460,7 +460,7 @@ namespace Js
 
         if (!date->m_date.IsNaN())
         {
-            return date->m_date.GetMinutes();
+            return date->m_date.GetMinutes(scriptContext);
         }
         return scriptContext->GetLibrary()->GetNaN();
     }
@@ -487,7 +487,7 @@ namespace Js
 
         if (!date->m_date.IsNaN())
         {
-            return date->m_date.GetMonth();
+            return date->m_date.GetMonth(scriptContext);
         }
         return scriptContext->GetLibrary()->GetNaN();
     }
@@ -514,7 +514,7 @@ namespace Js
 
         if (!date->m_date.IsNaN())
         {
-            return date->m_date.GetSeconds();
+            return date->m_date.GetSeconds(scriptContext);
         }
         return scriptContext->GetLibrary()->GetNaN();
     }
@@ -1247,7 +1247,7 @@ namespace Js
 
         AssertMsg(args.Info.Count > 0, "Negative argument count");
         return date->m_date.GetString(
-            DateImplementation::DateStringFormat::Default,
+            DateImplementation::DateStringFormat::Default, scriptContext,
             DateImplementation::DateTimeFlag::NoTime);
     }
 
@@ -1273,7 +1273,7 @@ namespace Js
         JavascriptDate* date = JavascriptDate::FromVar(args[0]);
 
         AssertMsg(args.Info.Count > 0, "Negative argument count");
-        return date->m_date.GetISOString();
+        return date->m_date.GetISOString(scriptContext);
     }
 
     Var JavascriptDate::EntryToJSON(RecyclableObject* function, CallInfo callInfo, ...)
@@ -1363,7 +1363,7 @@ namespace Js
 
         AssertMsg(args.Info.Count > 0, "Negative argument count");
         return date->m_date.GetString(
-            DateImplementation::DateStringFormat::Locale,
+            DateImplementation::DateStringFormat::Locale, scriptContext,
             DateImplementation::DateTimeFlag::NoTime);
     }
 
@@ -1411,18 +1411,20 @@ namespace Js
 #endif
 
         AssertMsg(args.Info.Count > 0, "Negative argument count");
-        return JavascriptDate::ToLocaleString(date);
+        return JavascriptDate::ToLocaleString(date, scriptContext);
     }
 
-    JavascriptString* JavascriptDate::ToLocaleString(JavascriptDate* date)
+    JavascriptString* JavascriptDate::ToLocaleString(JavascriptDate* date,
+        ScriptContext* requestContext)
     {
-        return date->m_date.GetString(DateImplementation::DateStringFormat::Locale);
+        return date->m_date.GetString(DateImplementation::DateStringFormat::Locale, requestContext);
     }
 
-    JavascriptString* JavascriptDate::ToString(JavascriptDate* date)
+    JavascriptString* JavascriptDate::ToString(JavascriptDate* date,
+        ScriptContext* requestContext)
     {
         Assert(date);
-        return date->m_date.GetString(DateImplementation::DateStringFormat::Default);
+        return date->m_date.GetString(DateImplementation::DateStringFormat::Default, requestContext);
     }
 
     Var JavascriptDate::EntryToLocaleTimeString(RecyclableObject* function, CallInfo callInfo, ...)
@@ -1470,7 +1472,7 @@ namespace Js
 
         AssertMsg(args.Info.Count > 0, "Negative argument count");
         return date->m_date.GetString(
-            DateImplementation::DateStringFormat::Locale,
+            DateImplementation::DateStringFormat::Locale, scriptContext,
             DateImplementation::DateTimeFlag::NoDate);
     }
 
@@ -1497,7 +1499,7 @@ namespace Js
 
         AssertMsg(args.Info.Count > 0, "Negative argument count");
         return date->m_date.GetString(
-            DateImplementation::DateStringFormat::Default,
+            DateImplementation::DateStringFormat::Default, scriptContext,
             DateImplementation::DateTimeFlag::NoDate);
     }
 
@@ -1533,7 +1535,7 @@ namespace Js
 
         AssertMsg(args.Info.Count > 0, "Negative argument count");
         return date->m_date.GetString(
-            DateImplementation::DateStringFormat::GMT,
+            DateImplementation::DateStringFormat::GMT, scriptContext,
             DateImplementation::DateTimeFlag::None);
     }
 
@@ -1583,7 +1585,7 @@ namespace Js
         JavascriptDate* date = JavascriptDate::FromVar(args[0]);
 
         AssertMsg(args.Info.Count > 0, "Negative argument count");
-        return JavascriptDate::ToString(date);
+        return JavascriptDate::ToString(date, scriptContext);
     }
 
     BOOL JavascriptDate::TryInvokeRemotely(JavascriptMethod entryPoint, ScriptContext * scriptContext, Arguments & args, Var * result)
@@ -1628,7 +1630,8 @@ namespace Js
     BOOL JavascriptDate::GetDiagValueString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext)
     {
         ENTER_PINNED_SCOPE(JavascriptString, valueStr);
-        valueStr = this->m_date.GetString(DateImplementation::DateStringFormat::Default);
+        valueStr = this->m_date.GetString(
+            DateImplementation::DateStringFormat::Default, requestContext);
         stringBuilder->Append(valueStr->GetString(), valueStr->GetLength());
         LEAVE_PINNED_SCOPE();
         return TRUE;

--- a/lib/Runtime/Library/JavascriptDate.h
+++ b/lib/Runtime/Library/JavascriptDate.h
@@ -132,8 +132,8 @@ namespace Js
         static Var EntryValueOf(RecyclableObject* function, CallInfo callInfo, ...);
         static Var EntrySymbolToPrimitive(RecyclableObject* function, CallInfo callInfo, ...);
 
-        static JavascriptString* ToLocaleString(JavascriptDate* date);
-        static JavascriptString* ToString(JavascriptDate* date);
+        static JavascriptString* ToLocaleString(JavascriptDate* date, ScriptContext* requestContext);
+        static JavascriptString* ToString(JavascriptDate* date, ScriptContext* requestContext);
 
         virtual BOOL ToPrimitive(JavascriptHint hint, Var* result, ScriptContext * requestContext) override;
         virtual BOOL GetDiagValueString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext) override;

--- a/test/Date/marshalbug.js
+++ b/test/Date/marshalbug.js
@@ -1,0 +1,19 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+const crossSiteDate =
+    WScript.LoadScript("var x = new Date()", "samethread").x;
+
+// Run every Date method on the cross-site instance
+Object.getOwnPropertyNames(Date.prototype)
+    .filter(name => !name.match(/^set/))
+    .forEach(name => {
+        print(name);
+        try {
+            print(Date.prototype[name].call(crossSiteDate));
+        } catch(e) {
+            // Ignore. Just to catch assertions on debug build.
+        }
+    });

--- a/test/Date/rlexe.xml
+++ b/test/Date/rlexe.xml
@@ -108,4 +108,13 @@
       </override>
     </condition>
   </test>
+  <test>
+    <default>
+      <files>marshalbug.js</files>
+      <!-- only to catch debug build assertions -->
+      <compile-flags>-nonative -intl-</compile-flags>
+      <baseline/>
+      <tags>exclude_fre,exclude_dynapogo</tags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
A lot of Date methods (the family of to???String) miss cross-site
marshalling. This change fixes that by removing
`DateImplementation::m_scriptContext` and pass in `requestContext`
everywhere.