### PR TITLE
Fix inconsistent parser state when deferral is undone. 

### DIFF
--- a/lib/Parser/Hash.cpp
+++ b/lib/Parser/Hash.cpp
@@ -131,6 +131,18 @@ void HashTbl::Grow()
 #endif
 }
 
+void HashTbl::ClearPidRefStacks()
+{
+    // Clear pidrefstack pointers from all existing pid's.
+    for (uint i = 0; i < m_luMask; i++)
+    {
+        for (IdentPtr pid = m_prgpidName[i]; pid; pid = pid->m_pidNext)
+        {
+            pid->m_pidRefStack = nullptr;
+        }
+    }
+}
+
 #if DEBUG
 uint HashTbl::CountAndVerifyItems(IdentPtr *buckets, uint bucketCount, uint mask)
 {

--- a/lib/Parser/Hash.h
+++ b/lib/Parser/Hash.h
@@ -387,6 +387,7 @@ public:
     NoReleaseAllocator* GetAllocator() {return &m_noReleaseAllocator;}
 
     bool Contains(_In_reads_(cch) LPCOLESTR prgch, int32 cch);
+    void ClearPidRefStacks();
 
 private:
     NoReleaseAllocator m_noReleaseAllocator;            // to allocate identifiers


### PR DESCRIPTION
On stoppage of deferred parsing (i.e., when we discover mid-script that we want to stop deferring, and at the end we go back and undefer), complete binding of vars in global scope and restore scope and block info state before we start undeferral.