### PR TITLE
WASM - wabt float parsing fix

### DIFF
--- a/lib/wabt/src/win_prebuilt/config.h
+++ b/lib/wabt/src/win_prebuilt/config.h
@@ -193,15 +193,6 @@ __inline unsigned __int64 __popcnt64(unsigned __int64 value) {
 #error unexpected architecture
 #endif
 #define wabt_popcount_u64 __popcnt64
-
-#if _MSC_VER <= 1800
-// Reimplement buggy strtof and strtod
-namespace wabt {
-    float strtof(const char *nptr, char **endptr);
-    double strtod(const char *nptr, char **endptr);
-};
-#endif
-
 #else
 
 #error unknown compiler

--- a/test/WasmSpec/convert-test-suite/index.js
+++ b/test/WasmSpec/convert-test-suite/index.js
@@ -4,11 +4,9 @@
 //-------------------------------------------------------------------------------------------------------
 
 const path = require("path");
-const jsBeautify = require("js-beautify");
 const fs = require("fs-extra");
 const stringArgv = require("string-argv");
-const {execFile, spawn} = require("child_process");
-const which = require("which");
+const {spawn} = require("child_process");
 const slash = require("slash");
 
 const rlRoot = path.join(__dirname, "..");
@@ -31,11 +29,11 @@ const argv = require("yargs")
       description: "Spec tests to exclude from the conversion (use for known failures)",
       default: []
     },
-    "legacy-excludes": {
+    "jshost-excludes": {
       array: true,
-      description: "Spec tests to exclude when running on legacy (use for known failures)",
+      description: "Spec tests to exclude when running on jshost (use for known failures)",
       default: [
-        "float_literals" // Problem with float parsing precision in MSVC++ 12.0
+        "float_literals" // Problem with float parsing precision in the crt version we use
       ]
     },
     "xplat-excludes": {
@@ -147,7 +145,7 @@ function main() {
   })).then(specFiles => {
     const runs = specFiles.map(specFile => {
       const isXplatExcluded = argv.xplatExcludes.indexOf(path.basename(specFile, ".wast")) !== -1;
-      const isLegacyExcluded = argv.legacyExcludes.indexOf(path.basename(specFile, ".wast")) !== -1;
+      const isJshostExcluded = argv.jshostExcludes.indexOf(path.basename(specFile, ".wast")) !== -1;
       const baseline = getBaselinePath(specFile);
       const flags = hostFlags(specFile);
       const tests = [{
@@ -158,12 +156,12 @@ function main() {
         tags: ["exclude_dynapogo"],
         baseline: baseline,
         flags: [flags, "-nonative"]
-      }]
+      }];
       if (isXplatExcluded) {
         for (const test of tests) test.tags.push("exclude_xplat");
       }
-      if (isLegacyExcluded) {
-        for (const test of tests) test.tags.push("exclude_win7");
+      if (isJshostExcluded) {
+        for (const test of tests) test.tags.push("exclude_jshost", "exclude_win7");
       }
       return tests;
     });

--- a/test/WasmSpec/convert-test-suite/package.json
+++ b/test/WasmSpec/convert-test-suite/package.json
@@ -10,10 +10,8 @@
   "license": "MIT",
   "dependencies": {
     "fs-extra": "^0.30.0",
-    "js-beautify": "^1.6.3",
     "sexpr-plus": "^7.0.0",
     "string-argv": "0.0.2",
-    "which": "^1.2.12",
     "yargs": "^4.7.1",
     "slash": "^1.0.0"
   }

--- a/test/WasmSpec/rlexe.xml
+++ b/test/WasmSpec/rlexe.xml
@@ -127,6 +127,38 @@
   <test>
     <default>
       <files>spec.js</files>
+      <baseline>baselines/call.baseline</baseline>
+      <compile-flags>-wasm -args testsuite/core/call.wast -endargs</compile-flags>
+      <tags>exclude_xplat</tags>
+    </default>
+  </test>
+  <test>
+    <default>
+      <files>spec.js</files>
+      <baseline>baselines/call.baseline</baseline>
+      <compile-flags>-wasm -args testsuite/core/call.wast -endargs -nonative</compile-flags>
+      <tags>exclude_dynapogo,exclude_xplat</tags>
+    </default>
+  </test>
+  <test>
+    <default>
+      <files>spec.js</files>
+      <baseline>baselines/call_indirect.baseline</baseline>
+      <compile-flags>-wasm -args testsuite/core/call_indirect.wast -endargs</compile-flags>
+      <tags>exclude_xplat</tags>
+    </default>
+  </test>
+  <test>
+    <default>
+      <files>spec.js</files>
+      <baseline>baselines/call_indirect.baseline</baseline>
+      <compile-flags>-wasm -args testsuite/core/call_indirect.wast -endargs -nonative</compile-flags>
+      <tags>exclude_dynapogo,exclude_xplat</tags>
+    </default>
+  </test>
+  <test>
+    <default>
+      <files>spec.js</files>
       <baseline>baselines/comments.baseline</baseline>
       <compile-flags>-wasm -args testsuite/core/comments.wast -endargs</compile-flags>
     </default>
@@ -289,6 +321,22 @@
       <baseline>baselines/float_exprs.baseline</baseline>
       <compile-flags>-wasm -args testsuite/core/float_exprs.wast -endargs -nonative</compile-flags>
       <tags>exclude_dynapogo</tags>
+    </default>
+  </test>
+  <test>
+    <default>
+      <files>spec.js</files>
+      <baseline>baselines/float_literals.baseline</baseline>
+      <compile-flags>-wasm -args testsuite/core/float_literals.wast -endargs</compile-flags>
+      <tags>exclude_jshost,exclude_win7</tags>
+    </default>
+  </test>
+  <test>
+    <default>
+      <files>spec.js</files>
+      <baseline>baselines/float_literals.baseline</baseline>
+      <compile-flags>-wasm -args testsuite/core/float_literals.wast -endargs -nonative</compile-flags>
+      <tags>exclude_dynapogo,exclude_jshost,exclude_win7</tags>
     </default>
   </test>
   <test>


### PR DESCRIPTION
Fix wabt hexstring float parsing differently to support older crt versions. Ignore float_literals test because of known precision bug in the float parsing crt

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/2732)
<!-- Reviewable:end -->
