### PR TITLE
clear expirableObjectDisposeList at the end of disposal all objects

### DIFF
--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -1838,6 +1838,7 @@ void ThreadContext::DisposeOnLeaveScript()
     if (this->callDispose && this->recycler->NeedDispose())
     {
         this->recycler->FinishDisposeObjectsNow<FinishDispose>();
+        this->expirableObjectDisposeList->Clear();
     }
 }
 
@@ -3017,10 +3018,9 @@ ThreadContext::UnregisterExpirableObject(ExpirableObject* object)
 void
 ThreadContext::DisposeExpirableObject(ExpirableObject* object)
 {
-    Assert(this->expirableObjectDisposeList);
     Assert(object->registrationHandle == nullptr);
 
-    this->expirableObjectDisposeList->Remove(object);
+    //expirableObjectDisposeList will be cleared after finished disposing all objects
 
     OUTPUT_VERBOSE_TRACE(Js::ExpirableCollectPhase, _u("Disposed 0x%p\n"), object);
 }


### PR DESCRIPTION
currently removing one by one from this linked list is slow, might cause hang
remove an uncessary Assert (expirableObjectDisposeList is not null as long as recycler is not null)
