### PR TITLE
Revert "Fix delete InlineeEnd incorrectly"

### DIFF
--- a/lib/Backend/FlowGraph.cpp
+++ b/lib/Backend/FlowGraph.cpp
@@ -1722,7 +1722,7 @@ FlowGraph::RemoveUnreachableBlocks()
 
 // If block has no predecessor, remove it.
 bool
-FlowGraph::RemoveUnreachableBlock(BasicBlock *block, GlobOpt * globOpt, IR::Instr ** pUpwardedInstr)
+FlowGraph::RemoveUnreachableBlock(BasicBlock *block, GlobOpt * globOpt)
 {
     bool isDead = false;
 
@@ -1745,7 +1745,7 @@ FlowGraph::RemoveUnreachableBlock(BasicBlock *block, GlobOpt * globOpt, IR::Inst
 
     if (isDead)
     {
-        this->RemoveBlock(block, globOpt, false /* tailDuping */, pUpwardedInstr);
+        this->RemoveBlock(block, globOpt);
         return true;
     }
     return false;
@@ -2637,73 +2637,8 @@ FlowGraph::RemoveInstr(IR::Instr *instr, GlobOpt * globOpt)
     }
 }
 
-// We cannot just remove Js::OpCode::InlineeEnd from cold path, need to make a copy 
-// or it to after BailOnNoProfile above current InlineeEnd. The new InlineeEnd will be
-// visited by linearscan to generate InlineeFrameRecord.
 void
-FlowGraph::UpwardInlineeEndBeforeRemoving(
-    BasicBlock * block,
-    IR::Instr * inlineeEnd,
-    BVSparse<JitArenaAllocator> * visitedBlocks,
-    IR::Instr ** pUpwardedInstr)
-{
-
-    if (visitedBlocks->Test(block->GetBlockNum()))
-    {
-        return;
-    }
-    else
-    {
-        visitedBlocks->Set(block->GetBlockNum());
-    }
-    bool stopUpward = false;
-
-    FOREACH_INSTR_BACKWARD_IN_BLOCK_EDITING(instr, instrPrev, block)
-    {
-        switch (instr->m_opcode)
-        {
-            case Js::OpCode::Label:
-            case Js::OpCode::ByteCodeUses:
-            {
-                continue;
-            }
-
-            case Js::OpCode::BailOnNoProfile:
-            {
-                Assert(pUpwardedInstr != nullptr);
-
-                IR::Instr * copiedInstr = inlineeEnd->Copy();
-                *pUpwardedInstr = copiedInstr;
-                instr->InsertAfter(copiedInstr);
-
-                stopUpward = true;
-                break;
-            }
-
-            default:
-            {
-                stopUpward = true;
-                break;
-            }
-        }
-
-        if (stopUpward)
-        {
-            break;
-        }
-    } NEXT_INSTR_BACKWARD_EDITING_IN_RANGE;
-
-    if (!stopUpward)
-    {
-        FOREACH_SLISTBASECOUNTED_ENTRY(FlowEdge*, edge, block->GetDeadPredList())
-        {
-            UpwardInlineeEndBeforeRemoving(edge->GetPred(), inlineeEnd, visitedBlocks, pUpwardedInstr);
-        } NEXT_SLISTBASECOUNTED_ENTRY;
-    }
-}
-
-void
-FlowGraph::RemoveBlock(BasicBlock *block, GlobOpt * globOpt, bool tailDuping, IR::Instr ** pUpwardedInstr)
+FlowGraph::RemoveBlock(BasicBlock *block, GlobOpt * globOpt, bool tailDuping)
 {
     Assert(!block->isDead && !block->isDeleted);
     IR::Instr * lastInstr = nullptr;
@@ -2716,7 +2651,6 @@ FlowGraph::RemoveBlock(BasicBlock *block, GlobOpt * globOpt, bool tailDuping, IR
             // rid of the epilog.
             break;
         }
-
         if (instr == block->GetFirstInstr())
         {
             Assert(instr->IsLabelInstr());
@@ -2724,18 +2658,6 @@ FlowGraph::RemoveBlock(BasicBlock *block, GlobOpt * globOpt, bool tailDuping, IR
         }
         else
         {
-            if (instr->m_opcode == Js::OpCode::InlineeEnd && instr->m_func->m_hasInlineArgsOpt &&
-                pUpwardedInstr != nullptr && instr->GetSrc2()->GetStackSym()->GetInstrDef())
-            {
-                NoRecoverMemoryJitArenaAllocator tempAlloc(_u("BE-FlowGraph-RemoveBlock"), this->func->m_alloc->GetPageAllocator(), Js::Throw::OutOfMemory);
-                BVSparse<JitArenaAllocator> * visitedBlocks = JitAnew(&tempAlloc, BVSparse<JitArenaAllocator>, &tempAlloc);
-
-                FOREACH_SLISTBASECOUNTED_ENTRY(FlowEdge*, edge, block->GetDeadPredList())
-                {
-                    UpwardInlineeEndBeforeRemoving(edge->GetPred(), instr, visitedBlocks, pUpwardedInstr);
-                } NEXT_SLISTBASECOUNTED_ENTRY;
-            }
-
             lastInstr = this->RemoveInstr(instr, globOpt);
         }
     } NEXT_INSTR_IN_BLOCK_EDITING;

--- a/lib/Backend/FlowGraph.h
+++ b/lib/Backend/FlowGraph.h
@@ -158,18 +158,14 @@ public:
     BasicBlock * InsertAirlockBlock(FlowEdge * edge);
     void         InsertCompBlockToLoopList(Loop *loop, BasicBlock* compBlock, BasicBlock* targetBlock, bool postTarget);
     void         RemoveUnreachableBlocks();
-    bool         RemoveUnreachableBlock(BasicBlock *block, GlobOpt * globOpt = nullptr, IR::Instr ** pUpwardedInstr = nullptr);
+    bool         RemoveUnreachableBlock(BasicBlock *block, GlobOpt * globOpt = nullptr);
     IR::Instr *  RemoveInstr(IR::Instr *instr, GlobOpt * globOpt);
-    void         RemoveBlock(BasicBlock *block, GlobOpt * globOpt = nullptr, bool tailDuping = false, IR::Instr ** upwardedInstr = nullptr);
+    void         RemoveBlock(BasicBlock *block, GlobOpt * globOpt = nullptr, bool tailDuping = false);
     BasicBlock * SetBlockTargetAndLoopFlag(IR::LabelInstr * labelInstr);
     Func*        GetFunc() { return func;};
     static void  SafeRemoveInstr(IR::Instr *instr);
     void         SortLoopLists();
     FlowEdge *   FindEdge(BasicBlock *predBlock, BasicBlock *succBlock);
-    void         UpwardInlineeEndBeforeRemoving(BasicBlock * block,
-                                                IR::Instr * inlineeEnd,
-                                                BVSparse<JitArenaAllocator> * visitedBlocks,
-                                                IR::Instr ** pUpwardedInstr);
 
 #if DBG_DUMP
     void         Dump();

--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -541,15 +541,8 @@ GlobOpt::ForwardPass()
 void
 GlobOpt::OptBlock(BasicBlock *block)
 {
-    IR::Instr * upwardedInstr = nullptr;
-    if (this->func->m_fg->RemoveUnreachableBlock(block, this, &upwardedInstr))
+    if (this->func->m_fg->RemoveUnreachableBlock(block, this))
     {
-        if (upwardedInstr &&
-            upwardedInstr->m_opcode == Js::OpCode::InlineeEnd &&
-            upwardedInstr->m_func->m_hasInlineArgsOpt)
-        {
-            RecordInlineeFrameInfo(upwardedInstr);
-        }
         GOPT_TRACE(_u("Removing unreachable block #%d\n"), block->GetBlockNum());
         return;
     }

--- a/lib/Backend/TempTracker.cpp
+++ b/lib/Backend/TempTracker.cpp
@@ -576,18 +576,9 @@ NumberTemp::ProcessInstr(IR::Instr * instr, BackwardPass * backwardPass)
 #if DBG
     if (instr->m_opcode == Js::OpCode::BailOnNoProfile)
     {
-        // If we see BailOnNoProfile, we shouldn't have any successor to have any non temp syms except InlineeEnd
+        // If we see BailOnNoProfile, we shouldn't have any successor to have any non temp syms
         Assert(!this->nonTempElemLoad);
-
-        if(!this->nonTempSyms.IsEmpty())
-        {
-            // The only non temp which could be live at BailOnNoProfile is the 2nd operand for following InlineeEnd
-            IR::Instr * nextInstr = instr->m_next;
-            Assert(nextInstr && nextInstr->m_opcode == Js::OpCode::InlineeEnd);
-            Assert(this->nonTempSyms.Count() == 1 &&
-                this->nonTempSyms.Test(nextInstr->GetSrc2()->GetStackSym()->m_id));
-        }
-
+        Assert(this->nonTempSyms.IsEmpty());
         Assert(this->tempTransferredSyms.IsEmpty());
         Assert(this->elemLoadDependencies.IsEmpty());
         Assert(this->upwardExposedMarkTempObjectLiveFields.IsEmpty());


### PR DESCRIPTION
This reverts changes from #2582, #2647, and #2652. #2582 fixed a bug around InlineeEnd and BailOnNoProfile but introduced more bugs which the later two commits attempted to fix. Currently there are a lot of bugs coming from these set of commits. So, reverting them for now - I have a different fix in mind for which I will create a PR soon.