### PR TITLE
remove auxptrs global lock

### DIFF
--- a/lib/Runtime/Base/CompactCounters.h
+++ b/lib/Runtime/Base/CompactCounters.h
@@ -195,7 +195,7 @@ namespace Js
             }
             else
             {
-                AutoCriticalSection autoCS(host->GetScriptContext()->GetThreadContext()->GetEtwRundownCriticalSection());
+                AutoCriticalSection autoCS(host->GetScriptContext()->GetThreadContext()->GetFunctionBodyLock());
                 this->fieldSize = sizeof(FieldT);
                 this->fields = fieldsArray;
             }

--- a/lib/Runtime/Base/EtwTrace.cpp
+++ b/lib/Runtime/Base/EtwTrace.cpp
@@ -95,11 +95,8 @@ void EtwTrace::PerformRundown(bool start)
 
     while(threadContext != nullptr)
     {
-        // Take the auxPtrs updating lock, in case auxPtrs is expanding causes GC
-        // which locks Etw Rundown lock, hence dead lock.
-        AutoCriticalSection autoCs(FunctionProxy::GetLock());
         // Take etw rundown lock on this thread context
-        AutoCriticalSection autoEtwRundownCs(threadContext->GetEtwRundownCriticalSection());
+        AutoCriticalSection autoEtwRundownCs(threadContext->GetFunctionBodyLock());
 
         ScriptContext* scriptContext = threadContext->GetScriptContextList();
         while(scriptContext != NULL)

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -1315,9 +1315,7 @@ namespace Js
     //
     class FunctionProxy : public FinalizableObject
     {
-        static CriticalSection GlobalLock;
     public:
-        static CriticalSection* GetLock() { return &GlobalLock; }
         typedef RecyclerWeakReference<DynamicType> FunctionTypeWeakRef;
         typedef JsUtil::List<FunctionTypeWeakRef*, Recycler, false, WeakRefFreeListedRemovePolicy> FunctionTypeWeakRefList;
 

--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -2050,7 +2050,7 @@ ThreadContext::ExecuteRecyclerCollectionFunction(Recycler * recycler, Collection
     }
 
     // Take etw rundown lock on this thread context. We can't collect entryPoints if we are in etw rundown.
-    AutoCriticalSection autocs(this->GetEtwRundownCriticalSection());
+    AutoCriticalSection autocs(this->GetFunctionBodyLock());
 
     // Disable calling dispose from leave script or the stack probe
     // while we're executing the recycler wrapper

--- a/lib/Runtime/Base/ThreadContext.h
+++ b/lib/Runtime/Base/ThreadContext.h
@@ -799,8 +799,10 @@ private:
     THREAD_LOCAL static uint activeScriptSiteCount;
     bool isScriptActive;
 
-    // To synchronize with ETW rundown, which needs to walk scriptContext/functionBody/entryPoint lists.
-    CriticalSection csEtwRundown;
+    // When ETW rundown in background thread which needs to walk scriptContext/functionBody/entryPoint lists,
+    // or when JIT thread is getting auxPtrs from function body, we should not be modifying the list of 
+    // functionBody/entrypoints, or expanding the auxPtrs
+    CriticalSection csFunctionBody;
 
 #ifdef _M_X64
     friend class Js::Amd64StackFrame;
@@ -849,7 +851,7 @@ public:
     CustomHeap::InProcCodePageAllocators * GetCodePageAllocators() { return &codePageAllocators; }
 #endif // ENABLE_NATIVE_CODEGEN
 
-    CriticalSection* GetEtwRundownCriticalSection() { return &csEtwRundown; }
+    CriticalSection* GetFunctionBodyLock() { return &csFunctionBody; }
 
     Js::IsConcatSpreadableCache* GetIsConcatSpreadableCache() { return &isConcatSpreadableCache; }
 

--- a/lib/Runtime/Base/Utf8SourceInfo.cpp
+++ b/lib/Runtime/Base/Utf8SourceInfo.cpp
@@ -177,14 +177,14 @@ namespace Js
             // here does not keep the function alive. However, the functions remove themselves at finalize
             // so if a function actually is in this map, it means that it is alive.
             this->functionBodyDictionary = RecyclerNew(recycler, FunctionBodyDictionary, recycler,
-                initialFunctionCount, threadContext->GetEtwRundownCriticalSection());
+                initialFunctionCount, threadContext->GetFunctionBodyLock());
         }
 
         if (CONFIG_FLAG(DeferTopLevelTillFirstCall) && !m_deferredFunctionsInitialized)
         {
             Assert(this->m_deferredFunctionsDictionary == nullptr);
             this->m_deferredFunctionsDictionary = RecyclerNew(recycler, DeferredFunctionsDictionary, recycler,
-                initialFunctionCount, threadContext->GetEtwRundownCriticalSection());
+                initialFunctionCount, threadContext->GetFunctionBodyLock());
             m_deferredFunctionsInitialized = true;
         }
     }


### PR DESCRIPTION
after fixing a dead lock issue in PerformRundown, there are more code path still taking etwRundown lock, like the FunctionEntryPointList so we can still hit dead lock when doing etw tracing.
all these code path need to take both locks in same order to avoid dead lock. instead of doing this,
change to use single lock(the changed etwRundown lock to a more appropriate name) to solve the issue
also change the usage of this lock under ScriptContext::Close to only lock function body operation part