### PR TITLE
lock inlineCache allocator after ZeroAll

### DIFF
--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -7616,7 +7616,7 @@ namespace Js
                     InlineCache* inlineCache = (InlineCache*)this->inlineCaches[i];
                     if (IsScriptContextShutdown)
                     {
-                        memset(inlineCache, 0, sizeof(InlineCache));
+                        inlineCache->Clear();
                     }
                     else
                     {
@@ -7635,10 +7635,9 @@ namespace Js
             {
                 if (nullptr != this->inlineCaches[i])
                 {
-                    InlineCache* inlineCache = (InlineCache*)this->inlineCaches[i];
                     if (IsScriptContextShutdown)
                     {
-                        memset(inlineCache, 0, sizeof(InlineCache));
+                        ((InlineCache*)this->inlineCaches[i])->Clear();
                     }
                     else
                     {
@@ -7656,10 +7655,9 @@ namespace Js
             {
                 if (nullptr != this->inlineCaches[i])
                 {
-                    InlineCache* inlineCache = (InlineCache*)this->inlineCaches[i];
                     if (IsScriptContextShutdown)
                     {
-                        memset(inlineCache, 0, sizeof(InlineCache));
+                        ((InlineCache*)this->inlineCaches[i])->Clear();
                     }
                     else
                     {
@@ -7677,10 +7675,9 @@ namespace Js
             {
                 if (nullptr != this->inlineCaches[i])
                 {
-                    InlineCache* inlineCache = (InlineCache*)this->inlineCaches[i];
                     if (IsScriptContextShutdown)
                     {
-                        memset(inlineCache, 0, sizeof(InlineCache));
+                        ((InlineCache*)this->inlineCaches[i])->Clear();
                     }
                     else
                     {
@@ -7701,7 +7698,7 @@ namespace Js
                     IsInstInlineCache* inlineCache = (IsInstInlineCache*)this->inlineCaches[i];
                     if (IsScriptContextShutdown)
                     {
-                        memset(inlineCache, 0, sizeof(IsInstInlineCache));
+                        inlineCache->Clear();
                     }
                     else
                     {
@@ -7729,7 +7726,7 @@ namespace Js
                         {
                             if (IsScriptContextShutdown)
                             {
-                                memset(inlineCache, 0, sizeof(InlineCache));
+                                inlineCache->Clear();
                             }
                             else
                             {
@@ -7759,7 +7756,7 @@ namespace Js
                         {
                             if (IsScriptContextShutdown)
                             {
-                                memset(inlineCache, 0, sizeof(InlineCache));
+                                inlineCache->Clear();
                             }
                             else
                             {

--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -931,7 +931,16 @@ private:
         }
 #endif
 
-        void SetHasUsedInlineCache(bool value) { hasUsedInlineCache = value; }
+        void SetHasUsedInlineCache(bool value) 
+        {
+            hasUsedInlineCache = value;
+#if DBG
+            if(hasUsedInlineCache)
+            {
+                inlineCacheAllocator.Unlock();
+            }
+#endif
+        }
 
         void SetDirectHostTypeId(TypeId typeId) {directHostTypeId = typeId; }
         TypeId GetDirectHostTypeId() const { return directHostTypeId; }

--- a/lib/Runtime/Language/InlineCache.cpp
+++ b/lib/Runtime/Language/InlineCache.cpp
@@ -383,12 +383,12 @@ namespace Js
 
     void InlineCache::Clear()
     {
-        // IsEmpty() is a quick check to see that the cache is not populated, it only checks u.local.type, which does not
-        // guarantee that the proto or flags cache would not hit. So Clear() must still clear everything.
-
-        u.local.type = nullptr;
-        u.local.isLocal = true;
-        u.local.typeWithoutProperty = nullptr;
+#if DBG
+        if (!IsAll((char*)this, sizeof(InlineCache), '\0'))
+#endif
+        {
+            memset(this, 0, sizeof(InlineCache));
+        }
     }
 
     InlineCache *InlineCache::Clone(Js::PropertyId propertyId, ScriptContext* scriptContext)
@@ -474,7 +474,13 @@ namespace Js
             }
         }
 
-        clone->u = this->u;
+#if DBG
+        // inline cache pages might been locked after ZeroAll
+        if (memcmp(&clone->u, &this->u, sizeof(this->u)) != 0)
+#endif
+        {
+            clone->u = this->u;
+        }
 
         DebugOnly(VerifyRegistrationForInvalidation(clone, scriptContext, propertyId));
     }
@@ -1151,9 +1157,12 @@ namespace Js
 
     void IsInstInlineCache::Clear()
     {
-        this->type = NULL;
-        this->function = NULL;
-        this->result = NULL;
+#if DBG
+        if (!IsAll((char*)this, sizeof(IsInstInlineCache), '\0'))
+#endif
+        {
+            memset(this, 0, sizeof(IsInstInlineCache));
+        }
     }
 
     void IsInstInlineCache::Unregister(ScriptContext * scriptContext)

--- a/lib/Runtime/Language/InlineCache.h
+++ b/lib/Runtime/Language/InlineCache.h
@@ -970,6 +970,7 @@ namespace Js
         bool TryGetResult(Var instance, JavascriptFunction * function, JavascriptBoolean ** result);
         void Cache(Type * instanceType, JavascriptFunction * function, JavascriptBoolean * result, ScriptContext * scriptContext);
         void Unregister(ScriptContext * scriptContext);
+        void Clear();
 
         static uint32 OffsetOfFunction();
         static uint32 OffsetOfResult();
@@ -977,7 +978,6 @@ namespace Js
 
     private:
         void Set(Type * instanceType, JavascriptFunction * function, JavascriptBoolean * result);
-        void Clear();
     };
 
     // Two-entry Type-indexed circular cache

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -9465,7 +9465,14 @@ CommonNumber:
         // collections, which may still happen from other script contexts.
         if (isShutdown)
         {
+#if DBG
+            for (int i = 0; i < size; i++)
+            {
+                inlineCaches[i].Clear();
+            }
+#else
             memset(inlineCaches, 0, size * sizeof(InlineCache));
+#endif
         }
         else
         {

--- a/lib/Runtime/Library/ScriptFunction.cpp
+++ b/lib/Runtime/Library/ScriptFunction.cpp
@@ -763,7 +763,7 @@ namespace Js
                     InlineCache* inlineCache = (InlineCache*)(void*)this->m_inlineCaches[i];
                     if (isShutdown)
                     {
-                        memset(this->m_inlineCaches[i], 0, sizeof(InlineCache));
+                        inlineCache->Clear();
                     }
                     else if(!scriptContext->IsClosed())
                     {
@@ -784,7 +784,7 @@ namespace Js
                 {
                     if (isShutdown)
                     {
-                        memset(this->m_inlineCaches[i], 0, sizeof(IsInstInlineCache));
+                        ((IsInstInlineCache*)this->m_inlineCaches[i])->Clear();
                     }
                     else if (!scriptContext->IsClosed())
                     {

--- a/lib/Runtime/Library/ScriptFunction.cpp
+++ b/lib/Runtime/Library/ScriptFunction.cpp
@@ -709,7 +709,7 @@ namespace Js
     {
         SetHasInlineCaches(true);
         Js::FunctionBody* functionBody = this->GetFunctionBody();
-        this->m_inlineCaches = (Field(void*)*)functionBody->GetInlineCaches();
+        this->m_inlineCaches = functionBody->GetInlineCaches();
 #if DBG
         this->m_inlineCacheTypes = functionBody->GetInlineCacheTypes();
 #endif
@@ -860,7 +860,7 @@ namespace Js
             this->m_inlineCacheTypes = RecyclerNewArrayLeafZ(functionBody->GetScriptContext()->GetRecycler(),
                 byte, totalCacheCount);
 #endif
-            this->m_inlineCaches = (Field(void*)*)inlineCaches;
+            this->m_inlineCaches = inlineCaches;
         }
     }
 

--- a/lib/Runtime/Library/ScriptFunction.h
+++ b/lib/Runtime/Library/ScriptFunction.h
@@ -142,7 +142,7 @@ namespace Js
     class ScriptFunctionWithInlineCache : public ScriptFunction
     {
     private:
-        Field(Field(void*)*) m_inlineCaches;
+        Field(void**) m_inlineCaches;
         Field(bool) hasOwnInlineCaches;
 
 #if DBG
@@ -173,7 +173,7 @@ namespace Js
         void ClearBorrowedInlineCacheOnFunctionObject();
         InlineCache * GetInlineCache(uint index);
         uint GetInlineCacheCount() { return inlineCacheCount; }
-        Field(void*)* GetInlineCaches() { return m_inlineCaches; }
+        Field(void**) GetInlineCaches() { return m_inlineCaches; }
         bool GetHasOwnInlineCaches() { return hasOwnInlineCaches; }
         void SetInlineCachesFromFunctionBody();
         static uint32 GetOffsetOfInlineCaches() { return offsetof(ScriptFunctionWithInlineCache, m_inlineCaches); };


### PR DESCRIPTION
we do check IsAllZero to make sure the inline caches is registered before use.
it can cause hang if we keep doing IsAllZero check in some hosting scenario.
this change makes the pages readonly after ensured all zero so we don't need really check next time.
it also useful to capture the issue that not registering inline cache before using.
