### PR TITLE
Memory allocation fixes and improvements

### DIFF
--- a/lib/Common/Memory/PageAllocator.cpp
+++ b/lib/Common/Memory/PageAllocator.cpp
@@ -124,6 +124,8 @@ SegmentBase<T>::Initialize(DWORD allocFlags, bool excludeGuardPages)
         return false;
     }
 
+    Assert( ((ULONG_PTR)this->address % (64 * 1024)) == 0 );
+
     originalAddress = this->address;
     bool committed = (allocFlags & MEM_COMMIT) != 0;
     if (addGuardPages)

--- a/lib/Common/Memory/PageAllocator.h
+++ b/lib/Common/Memory/PageAllocator.h
@@ -252,7 +252,7 @@ public:
     uint GetFreePageCount() const { return freePageCount; }
     uint GetDecommitPageCount() const { return decommitPageCount; }
 
-    static bool IsAllocationPageAligned(__in char* address, size_t pageCount);
+    static bool IsAllocationPageAligned(__in char* address, size_t pageCount, uint *nextIndex = nullptr);
 
     template <typename T, bool notPageAligned>
     char * AllocDecommitPages(DECLSPEC_GUARD_OVERFLOW uint pageCount, T freePages, T decommitPages);

--- a/pal/src/include/pal/virtual.h
+++ b/pal/src/include/pal/virtual.h
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -27,7 +27,7 @@ extern "C"
 #endif // __cplusplus
 
 typedef struct _CMI {
-    
+
     struct _CMI * pNext;        /* Link to the next entry. */
     struct _CMI * pLast;        /* Link to the previous entry. */
 
@@ -53,7 +53,7 @@ enum VIRTUAL_CONSTANTS
     /* Allocation type. */
     VIRTUAL_COMMIT_ALL_BITS     = 0xFF,
     VIRTUAL_RESERVE_ALL_BITS    = 0x0,
-    
+
     /* Protection Type. */
     VIRTUAL_READONLY,
     VIRTUAL_READWRITE,
@@ -61,7 +61,7 @@ enum VIRTUAL_CONSTANTS
     VIRTUAL_NOACCESS,
     VIRTUAL_EXECUTE,
     VIRTUAL_EXECUTE_READ,
-    
+
     /* Page manipulation constants. */
 #ifdef __sparc__
     VIRTUAL_PAGE_SIZE       = 0x2000,
@@ -80,9 +80,9 @@ Function :
 
 Return value:
     TRUE  if initialization succeeded
-    FALSE otherwise.        
+    FALSE otherwise.
 --*/
-BOOL VIRTUALInitialize(bool initializeExecutableMemoryAllocator);
+BOOL VIRTUALInitialize( void );
 
 /*++
 Function :
@@ -105,108 +105,6 @@ BOOL VIRTUALOwnedRegion( IN UINT_PTR address );
 
 #ifdef __cplusplus
 }
-
-/*++
-Class:
-    ExecutableMemoryAllocator
-
-    This class implements a virtual memory allocator for JIT'ed code.
-    The purpose of this allocator is to opportunistically reserve a chunk of virtual memory
-    that is located near the coreclr library (within 2GB range) that can be later used by
-    JIT. Having executable memory close to the coreclr library allows JIT to generate more
-    efficient code (by avoiding usage of jump stubs) and thus it can significantly improve
-    performance of the application.
-
-    This allocator is integrated with the VirtualAlloc/Reserve code. If VirtualAlloc has been
-    called with the MEM_RESERVE_EXECUTABLE flag then it will first try to obtain the requested size
-    of virtual memory from ExecutableMemoryAllocator. If ExecutableMemoryAllocator runs out of
-    the reserved memory (or fails to allocate it during initialization) then VirtualAlloc/Reserve code
-    will simply fall back to reserving memory using OS APIs.
-
-    Notes:
-        - the memory allocated by this class is NOT committed by default. It is responsibility
-          of the caller to commit the virtual memory before accessing it.
-        - in addition, this class does not provide ability to free the reserved memory. The caller
-          has full control of the memory it got from this allocator (i.e. the caller becomes
-          the owner of the allocated memory), so it is caller's responsibility to free the memory
-          if it is no longer needed.
---*/
-class ExecutableMemoryAllocator
-{
-public:
-    /*++
-    Function:
-        Initialize
-
-        This function initializes the allocator. It should be called early during process startup
-        (when process address space is pretty much empty) in order to have a chance to reserve
-        sufficient amount of memory that is close to the coreclr library.
-    --*/
-    void Initialize();
-
-    /*++
-    Function:
-        AllocateMemory
-
-        This function attempts to allocate the requested amount of memory from its reserved virtual
-        address space. The function will return NULL if the allocation request cannot
-        be satisfied by the memory that is currently available in the allocator.
-    --*/
-    void* AllocateMemory(SIZE_T allocationSize);
-
-private:
-    /*++
-    Function:
-        TryReserveInitialMemory
-
-        This function is called during initialization. It opportunistically tries to reserve
-        a large chunk of virtual memory that can be later used to store JIT'ed code.
-    --*/
-    void TryReserveInitialMemory();
-
-    /*++
-    Function:
-        GenerateRandomStartOffset
-
-        This function returns a random offset (in multiples of the virtual page size)
-        at which the allocator should start allocating memory from its reserved memory range.
-    --*/
-    int32_t GenerateRandomStartOffset();
-
-private:
-    // There does not seem to be an easy way find the size of a library on Unix.
-    // So this constant represents an approximation of the libcoreclr size (on debug build)
-    // that can be used to calculate an approximate location of the memory that
-    // is in 2GB range from the coreclr library. In addition, having precise size of libcoreclr
-    // is not necessary for the calculations.
-    const int32_t CoreClrLibrarySize = 100 * 1024 * 1024;
-
-    // This constant represent the max size of the virtual memory that this allocator
-    // will try to reserve during initialization. We want all JIT-ed code and the
-    // entire libcoreclr to be located in a 2GB range.
-    const int32_t MaxExecutableMemorySize = 0x7FFF0000 - CoreClrLibrarySize;
-
-    // Start address of the reserved virtual address space
-    void* m_startAddress;
-
-    // Next available address in the reserved address space
-    void* m_nextFreeAddress;
-
-    // Total size of the virtual memory that the allocator has been able to
-    // reserve during its initialization.
-    int32_t m_totalSizeOfReservedMemory;
-
-    // Remaining size of the reserved virtual memory that can be used to satisfy allocation requests.
-    int32_t m_remainingReservedMemory;
-};
-
 #endif // __cplusplus
 
 #endif /* _PAL_VIRTUAL_H_ */
-
-
-
-
-
-
-

--- a/pal/src/init/pal.cpp
+++ b/pal/src/init/pal.cpp
@@ -387,7 +387,6 @@ CLEANUP15:
     FILECleanupStdHandles();
 CLEANUP13:
     VIRTUALCleanup();
-CLEANUP10:
     MAPCleanup();
 CLEANUP6:
 CLEANUP5:
@@ -480,7 +479,7 @@ PAL_InitializeChakraCore()
         return error;
     }
 
-    if (FALSE == VIRTUALInitialize(true))
+    if (FALSE == VIRTUALInitialize())
     {
         ERROR("Unable to initialize virtual memory support\n");
         return ERROR_GEN_FAILURE;

--- a/pal/src/map/virtual.cpp
+++ b/pal/src/map/virtual.cpp
@@ -100,14 +100,9 @@ Function:
 
 --*/
 static LPVOID ReserveVirtualMemory(
-                IN CPalThread *pthrCurrent, /* Currently executing thread */
-                IN LPVOID lpAddress,        /* Region to reserve or commit */
-                IN SIZE_T dwSize);          /* Size of Region */
-
-
-// A memory allocator that allocates memory from a pre-reserved region
-// of virtual memory that is located near the coreclr library.
-static ExecutableMemoryAllocator g_executableMemoryAllocator PAL_GLOBAL;
+               IN CPalThread *pthrCurrent, /* Currently executing thread */
+               IN LPVOID lpAddress,        /* Region to reserve or commit */
+               IN SIZE_T dwSize);          /* Size of Region */
 
 /*++
 Function:
@@ -122,18 +117,13 @@ Return value:
 --*/
 extern "C"
 BOOL
-VIRTUALInitialize(bool initializeExecutableMemoryAllocator)
+VIRTUALInitialize( void )
 {
     TRACE( "Initializing the Virtual Critical Sections. \n" );
 
     InternalInitializeCriticalSection(&virtual_critsec);
 
     pVirtualMemory = NULL;
-
-    if (initializeExecutableMemoryAllocator)
-    {
-        g_executableMemoryAllocator.Initialize();
-    }
 
     return TRUE;
 }
@@ -878,14 +868,13 @@ static LPVOID VIRTUALReserveMemory(
     MemSize = ( ((UINT_PTR)lpAddress + dwSize + VIRTUAL_PAGE_MASK) & ~VIRTUAL_PAGE_MASK ) -
                StartBoundary;
 
-    InternalEnterCriticalSection(pthrCurrent, &virtual_critsec);
-
-    // If this is a request for special executable (JIT'ed) memory then, first of all,
-    // try to get memory from the executable memory allocator to satisfy the request.
-    if (((flAllocationType & MEM_RESERVE_EXECUTABLE) != 0) && (lpAddress == NULL))
+    if ((flAllocationType & MEM_RESERVE_EXECUTABLE) != 0)
     {
-        pRetVal = g_executableMemoryAllocator.AllocateMemory(MemSize);
+        fprintf(stderr, "MEM_RESERVE_EXECUTABLE is not supported!");
+        abort();
     }
+
+    InternalEnterCriticalSection(pthrCurrent, &virtual_critsec);
 
     if (pRetVal == NULL)
     {
@@ -901,6 +890,7 @@ static LPVOID VIRTUALReserveMemory(
 #endif  // MMAP_IGNORES_HINT
             /* Compute the real values instead of the null values. */
             StartBoundary = (UINT_PTR)pRetVal & ~VIRTUAL_PAGE_MASK;
+
             MemSize = ( ((UINT_PTR)pRetVal + dwSize + VIRTUAL_PAGE_MASK) & ~VIRTUAL_PAGE_MASK ) -
                       StartBoundary;
 #if !MMAP_IGNORES_HINT
@@ -2311,148 +2301,4 @@ ExitVirtualQuery:
     LOGEXIT( "VirtualQuery returning %d.\n", sizeof( *lpBuffer ) );
     PERF_EXIT(VirtualQuery);
     return sizeof( *lpBuffer );
-}
-
-/*++
-Function:
-    ExecutableMemoryAllocator::Initialize()
-
-    This function initializes the allocator. It should be called early during process startup
-    (when process address space is pretty much empty) in order to have a chance to reserve
-    sufficient amount of memory that is close to the coreclr library.
-
---*/
-void ExecutableMemoryAllocator::Initialize()
-{
-    m_startAddress = NULL;
-    m_nextFreeAddress = NULL;
-    m_totalSizeOfReservedMemory = 0;
-    m_remainingReservedMemory = 0;
-
-    // Enable the executable memory allocator on 64-bit platforms only
-    // because 32-bit platforms have limited amount of virtual address space.
-#ifdef BIT64
-    TryReserveInitialMemory();
-#endif // BIT64
-
-}
-
-/*++
-Function:
-    ExecutableMemoryAllocator::TryReserveInitialMemory()
-
-    This function is called during PAL initialization. It opportunistically tries to reserve
-    a large chunk of virtual memory that can be later used to store JIT'ed code.\
-
---*/
-void ExecutableMemoryAllocator::TryReserveInitialMemory()
-{
-    CPalThread* pthrCurrent = InternalGetCurrentThread();
-    int32_t sizeOfAllocation = MaxExecutableMemorySize;
-    int32_t startAddressIncrement;
-    UINT_PTR startAddress;
-    UINT_PTR coreclrLoadAddress;
-    const int32_t MemoryProbingIncrement = 128 * 1024 * 1024;
-
-    // Try to find and reserve an available region of virtual memory that is located
-    // within 2GB range (defined by the MaxExecutableMemorySize constant) from the
-    // location of the coreclr library.
-    // Potentially, as a possible future improvement, we can get precise information
-    // about available memory ranges by parsing data from '/proc/self/maps'.
-    // But since this code is called early during process startup, the user address space
-    // is pretty much empty so the simple algorithm that is implemented below is sufficient
-    // for this purpose.
-
-    // First of all, we need to determine the current address of libcoreclr. Please note that depending on
-    // the OS implementation, the library is usually loaded either at the end or at the start of the user
-    // address space. If the library is loaded at low addresses then try to reserve memory above libcoreclr
-    // (thus avoiding reserving memory below 4GB; besides some operating systems do not allow that).
-    // If libcoreclr is loaded at high addresses then try to reserve memory below its location.
-    coreclrLoadAddress = (UINT_PTR)PAL_GetSymbolModuleBase((void*)VirtualAlloc);
-    if ((coreclrLoadAddress < 0xFFFFFFFF) || ((coreclrLoadAddress - MaxExecutableMemorySize) < 0xFFFFFFFF))
-    {
-        // Try to allocate above the location of libcoreclr
-        startAddress = coreclrLoadAddress + CoreClrLibrarySize;
-        startAddressIncrement = MemoryProbingIncrement;
-    }
-    else
-    {
-        // Try to allocate below the location of libcoreclr
-        startAddress = coreclrLoadAddress - MaxExecutableMemorySize;
-        startAddressIncrement = 0;
-    }
-
-    // Do actual memory reservation.
-    do
-    {
-        m_startAddress = ReserveVirtualMemory(pthrCurrent, (void*)startAddress, sizeOfAllocation);
-        if (m_startAddress != NULL)
-        {
-            // Memory has been successfully reserved.
-            m_totalSizeOfReservedMemory = sizeOfAllocation;
-
-            // Randomize the location at which we start allocating from the reserved memory range.
-            int32_t randomOffset = GenerateRandomStartOffset();
-            m_nextFreeAddress = (void*)(((UINT_PTR)m_startAddress) + randomOffset);
-            m_remainingReservedMemory = sizeOfAllocation - randomOffset;
-            break;
-        }
-
-        // Try to allocate a smaller region
-        sizeOfAllocation -= MemoryProbingIncrement;
-        startAddress += startAddressIncrement;
-
-    } while (sizeOfAllocation >= MemoryProbingIncrement);
-}
-
-/*++
-Function:
-    ExecutableMemoryAllocator::AllocateMemory
-
-    This function attempts to allocate the requested amount of memory from its reserved virtual
-    address space. The function will return NULL if the allocation request cannot
-    be satisfied by the memory that is currently available in the allocator.
-
-    Note: This function MUST be called with the virtual_critsec lock held.
-
---*/
-void* ExecutableMemoryAllocator::AllocateMemory(SIZE_T allocationSize)
-{
-    void* allocatedMemory = NULL;
-
-    // Allocation size must be in multiples of the virtual page size.
-    _ASSERTE((allocationSize & VIRTUAL_PAGE_MASK) == 0);
-
-    // The code below assumes that the caller owns the virtual_critsec lock.
-    // So the calculations are not done in thread-safe manner.
-    if ((allocationSize > 0) && (allocationSize <= m_remainingReservedMemory))
-    {
-        allocatedMemory = m_nextFreeAddress;
-        m_nextFreeAddress = (void*)(((UINT_PTR)m_nextFreeAddress) + allocationSize);
-        m_remainingReservedMemory -= allocationSize;
-
-    }
-
-    return allocatedMemory;
-}
-
-/*++
-Function:
-    ExecutableMemoryAllocator::GenerateRandomStartOffset()
-
-    This function returns a random offset (in multiples of the virtual page size)
-    at which the allocator should start allocating memory from its reserved memory range.
-
---*/
-int32_t ExecutableMemoryAllocator::GenerateRandomStartOffset()
-{
-    int32_t pageCount;
-    const int32_t MaxStartPageOffset = 64;
-
-    // This code is similar to what coreclr runtime does on Windows.
-    // It generates a random number of pages to skip between 0...MaxStartPageOffset.
-    srandom(time(NULL));
-    pageCount = (int32_t)(MaxStartPageOffset * (int64_t)random() / RAND_MAX);
-
-    return pageCount * VIRTUAL_PAGE_SIZE;
 }


### PR DESCRIPTION
#### xplat: fix memory allocations. [align-allocate memory address to 64KB]
 - Improves xplat perf and reduces memory usage significantly.

#### xplat: do not reserve executable memory
 - Reduces xplat memory usage slightly

#### improve allocation loop on main thread
 - Improves perf slightly on both Win/Xplat

#### assert address_ptr % 64KB [ so we don't break in the future ]