### PR TITLE
register scriptContext to the list after globalObject and javascriptLibrary are initialized(2.0)

### DIFF
--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -418,6 +418,7 @@ namespace Js
 
         ScriptContext *next;
         ScriptContext *prev;
+        bool IsRegistered() { return next != nullptr || prev != nullptr || threadContext->GetScriptContextList() == this; }
         union
         {
             int64 int64Val; // stores the double & float result for Asm interpreter

--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -2487,6 +2487,10 @@ ThreadContext::UnregisterScriptContext(Js::ScriptContext *scriptContext)
     {
         scriptContext->next->prev = scriptContext->prev;
     }
+
+    scriptContext->prev = nullptr;
+    scriptContext->next = nullptr;
+
 #if DBG || defined(RUNTIME_DATA_COLLECTION)
     scriptContextCount--;
 #endif

--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -1054,6 +1054,10 @@ namespace Js
             scriptContext->ResetWeakReferenceDictionaryList();
             scriptContext->SetIsFinalized();
             scriptContext->MarkForClose();
+            if (scriptContext->IsRegistered())
+            {
+                scriptContext->GetThreadContext()->UnregisterScriptContext(scriptContext);
+            }
         }
     }
 


### PR DESCRIPTION
while ETW kicks in, it goes through the list to do source rundown, which can hit a state that the scriptContext is in the list but javascriptLibrary/utf8sourceList is not initialized yet.
change to register the scriptContext after it's fully initialized
ensure scriptContext is regerstered before unregistering
Clear ScriptContext caches while ScriptContext closing to make the caches to be collected earlier
