### PR TITLE
remove assertion on existence of expirable object on the list

### DIFF
--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -3007,8 +3007,6 @@ ThreadContext::UnregisterExpirableObject(ExpirableObject* object)
 {
     Assert(this->expirableObjectList);
     Assert(object->registrationHandle != nullptr);
-    Assert(this->expirableObjectList->HasElement(
-        (ExpirableObject* const *)PointerValue(object->registrationHandle)));
 
     ExpirableObject** registrationData = (ExpirableObject**)PointerValue(object->registrationHandle);
     Assert(*registrationData == object);


### PR DESCRIPTION
this can cause hang in chk build
