### PR TITLE
xplat: Improve GetCurrent*Thread performance

### DIFF
--- a/lib/Runtime/PlatformAgnostic/Platform/Common/HiResTimer.cpp
+++ b/lib/Runtime/PlatformAgnostic/Platform/Common/HiResTimer.cpp
@@ -77,7 +77,7 @@ namespace DateTime
             // in case the system time wasn't updated backwards, and cache is still beyond...
             if (currentTime >= data.cacheSysTime && currentTime < data.cacheSysTime + INTERVAL_FOR_TICK_BACKUP)
             {
-                return data.cacheSysTime + INTERVAL_FOR_TICK_BACKUP - 1; // wait for real time
+                return data.cacheSysTime + INTERVAL_FOR_TICK_BACKUP; // wait for real time
             }
 
             data.cacheSysTime = currentTime;

--- a/pal/src/include/pal/thread.hpp
+++ b/pal/src/include/pal/thread.hpp
@@ -737,20 +737,9 @@ namespace CorUnix
     extern "C" CPalThread *CreateCurrentThreadData();
 #endif // FEATURE_PAL_SXS
 
-    inline CPalThread *GetCurrentPalThread()
-    {
-        return reinterpret_cast<CPalThread*>(pthread_getspecific(thObjKey));
-    }
+    CPalThread *GetCurrentPalThread(bool force = false);
 
-    inline CPalThread *InternalGetCurrentThread()
-    {
-        CPalThread *pThread = GetCurrentPalThread();
-#if defined(FEATURE_PAL_SXS)
-        if (pThread == nullptr)
-            pThread = CreateCurrentThreadData();
-#endif // FEATURE_PAL_SXS
-        return pThread;
-    }
+    CPalThread *InternalGetCurrentThread();
 
 /***
 


### PR DESCRIPTION
This PR targets node-chakracore server load testing scenarios.

Perf hungry JS application triggers GetCurrent*Thread more than 10K
times per second. Use front thread_local caching if possible.