### PR TITLE
fix uint16_t bbrk on wasm.simd branch

### DIFF
--- a/lib/WasmReader/WasmBinaryReader.cpp
+++ b/lib/WasmReader/WasmBinaryReader.cpp
@@ -435,7 +435,7 @@ WasmOp WasmBinaryReader::ReadOpCode()
             ThrowDecodingError(_u("WebAssembly SIMD support is not enabled"));
         }
 
-        uint16_t offset = (op - wbExtended + 1) * 256;
+        uint16 offset = (op - wbExtended + 1) * 256;
         op = (WasmOp)*m_pc++;
         ++m_funcState.count;
 


### PR DESCRIPTION

@MikeHolman @Cellule fyi: @arunetm 

Mike brought to our attention that our wasm.simd changes were breaking some of ChakraFull tests:

> This is the error I see

> 2017-04-06T00:02:37.9142103Z        "E:\A\_work\2\s\core\lib\WasmReader\Chakra.WasmReader.vcxproj" (default target) (77:3) ->
> 2017-04-06T00:02:37.9142103Z        (ClCompile target) -> 
> 2017-04-06T00:02:37.9142103Z          > E:\A\_work\2\s\core\lib\WasmReader\WasmBinaryReader.cpp(438): error C2065: 'uint16_t': undeclared identifier [E:\A\_work\2\s\core\lib\WasmReader\Chakra.WasmReader.vcxproj]

I did a quick grep and looks like this was the only instance of using std types in `WasmBinaryReader`

```bash
$grep  -rP  'int\d+_t[ \t;]' * | grep -v wabt
Common/Codex/Utf8Codex.h:        typedef int8_t type;
Common/Codex/Utf8Codex.h:        typedef int16_t type;
Common/Codex/Utf8Codex.h:        typedef int32_t type;
Jsrt/ChakraCommon.h:typedef uint32_t UINT32;
Jsrt/ChakraCommon.h:typedef int64_t INT64;
Jsrt/ChakraCommon.h:typedef unsigned short uint16_t;
Jsrt/ChakraCore.h:        _In_ const uint16_t *content,
Jsrt/ChakraDebug.h:typedef __int64 int64_t;
Jsrt/ChakraDebug.h:typedef unsigned __int32 uint32_t;
Jsrt/ChakraDebug.h:        _In_opt_ uint32_t kthEvent,
Jsrt/ChakraDebug.h:        _In_ int64_t targetEventTime,
Jsrt/ChakraDebug.h:        _In_ int64_t currentSnapStartTime,
Jsrt/ChakraDebug.h:        _In_ int64_t startSnapTime,
Jsrt/ChakraDebug.h:        _In_ int64_t endSnapTime,
Jsrt/ChakraDebug.h:            _In_ int64_t snapshotTime,
Jsrt/ChakraDebug.h:            _In_ int64_t eventTime);
Jsrt/Jsrt.cpp:   _In_ JsTTDMoveMode moveMode, _In_opt_ uint32_t kthEvent,
Jsrt/Jsrt.cpp:    static_assert(sizeof(int64_t) == sizeof(int64), "int64_t and int64 size mis-match");
Jsrt/Jsrt.cpp:CHAKRA_API JsTTDGetSnapShotBoundInterval(_In_ JsRuntimeHandle runtimeHandle, _In_ int64_t targetEventTime, _Out_ int64_t* startSnapTime, _Out_ int64_t* endSnapTime)
Jsrt/Jsrt.cpp:    static_assert(sizeof(int64_t) == sizeof(int64), "int64_t and int64 size mis-match");
Jsrt/Jsrt.cpp:CHAKRA_API JsTTDGetPreviousSnapshotInterval(_In_ JsRuntimeHandle runtimeHandle, _In_ int64_t currentSnapStartTime, _Out_ int64_t* previousSnapTime)
Jsrt/Jsrt.cpp:JsErrorCode TTDHandleBreakpointInfoAndInflate(TTD::EventLog* elog, int64_t snapTime, JsrtRuntime* runtime, ThreadContext* threadContext)
Jsrt/Jsrt.cpp:CHAKRA_API JsTTDPreExecuteSnapShotInterval(_In_ JsRuntimeHandle runtimeHandle, _In_ int64_t startSnapTime, _In_ int64_t endSnapTime, _In_ JsTTDMoveMode moveMode, _Out_ int64_t* newTargetEventTime)
Jsrt/Jsrt.cpp:CHAKRA_API JsTTDMoveToTopLevelEvent(_In_ JsRuntimeHandle runtimeHandle, _In_ JsTTDMoveMode moveMode, _In_ int64_t snapshotTime, _In_ int64_t eventTime)
Jsrt/Jsrt.cpp:    _In_ const uint16_t *content,
Runtime/Language/AsmJsTypes.h:    typedef uint32 uint32_t;
Runtime/PlatformAgnostic/Platform/Common/Trace.cpp:    uint32_t path_size = SELF_PATH_SIZE;
Runtime/PlatformAgnostic/Platform/Linux/UnicodeText.ICU.cpp:            int32_t normalizedStringLength = destUniStr.length();
Runtime/PlatformAgnostic/Platform/Linux/UnicodeText.ICU.cpp:            int32_t resultStringLength = 0;
Runtime/PlatformAgnostic/Platform/Linux/UnicodeText.ICU.cpp:            int8_t charType = u_charType(ch);
Runtime/PlatformAgnostic/Platform/Unix/DateTime.cpp:        int64_t absoluteTime = tv / 1000;
Runtime/PlatformAgnostic/Platform/Unix/DateTime.cpp:        int64_t absoluteTime = tv / 1000;
WasmReader/WasmBinaryReader.cpp.bak:        uint16_t offset = (op - wbExtended + 1) * 256;
```
