### PR TITLE
Fix assert in cases of calls to captured function expressions inside 'with'. 

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -3175,6 +3175,11 @@ void ByteCodeGenerator::ProcessScopeWithCapturedSym(Scope *scope)
 {
     Assert(scope->GetHasOwnLocalInClosure());
 
+    if (scope->ContainsWith() && scope->GetScopeType() != ScopeType_Global)
+    {
+        scope->SetIsObject();
+    }
+
     // (Note: if any catch var is closure-captured, we won't merge the catch scope with the function scope.
     // So don't mark the function scope "has local in closure".)
     FuncInfo *func = scope->GetFunc();
@@ -3190,11 +3195,6 @@ void ByteCodeGenerator::ProcessScopeWithCapturedSym(Scope *scope)
             func->SetHasMaybeEscapedNestedFunc(DebugOnly(_u("InstantiateScopeWithCrossScopeAssignment")));
         }
         scope->SetMustInstantiate(true);
-    }
-
-    if (scope->ContainsWith() && scope->GetScopeType() != ScopeType_Global)
-    {
-        scope->SetIsObject();
     }
 }
 

--- a/test/Function/funcExpr.js
+++ b/test/Function/funcExpr.js
@@ -207,7 +207,16 @@ var Test23 = function F_Test23() {
     } );
 }
 
-var numTests = 24;
+var Test24 = function F_Test24() {  
+    with( "" ){
+        (function() { 
+           foo(F_Test24);
+        })();
+    }
+    function foo(f) { if (f.name !== 'F_Test24') WScript.Echo('fail Test24') };
+}
+
+var numTests = 25;
 
 for (var i=0;i<numTests;i++)
 {

--- a/test/Function/funcExpr5.baseline
+++ b/test/Function/funcExpr5.baseline
@@ -280,3 +280,6 @@ typeof F_Test23 === function
 typeof x === number
 check71: Test23('hello'); #undefined
 check72: F_Test23(); @'F_Test23' is undefined
+check73: Test24(); #undefined
+check74: Test24('hello'); #undefined
+check75: F_Test24(); @'F_Test24' is undefined


### PR DESCRIPTION
Make sure that the function expression scope is not marked for merging with the body scope if the function expression scope will be reified as an ActivationObject. This prevents firing of an assert on useless creation of empty scope slots.