### PR TITLE
Install exception filters only once for FaultInjection

### DIFF
--- a/lib/Common/Core/FaultInjection.cpp
+++ b/lib/Common/Core/FaultInjection.cpp
@@ -850,8 +850,15 @@ namespace Js
     }
 
     static bool faultInjectionDebug = false;
-    bool FaultInjection::InstallExceptionFilters()
+    static bool triedToInstallExceptionFilter = false;
+    void FaultInjection::InstallExceptionFilters()
     {
+        if (triedToInstallExceptionFilter)
+        {
+            return;
+        }
+
+        triedToInstallExceptionFilter = true;
         if (GetEnvironmentVariable(_u("FAULTINJECTION_DEBUG"), nullptr, 0) != 0)
         {
             faultInjectionDebug = true;
@@ -863,7 +870,7 @@ namespace Js
             // when the exception filter is handling stack overflow exception
             if (!FaultInjection::Global.InitializeSym())
             {
-                return false;
+                return;
             }
             //C28725:    Use Watson instead of this SetUnhandledExceptionFilter.
 #pragma prefast(suppress: 28725)
@@ -892,9 +899,7 @@ namespace Js
                     return EXCEPTION_CONTINUE_SEARCH;
                 }
             });
-            return true;
         }
-        return false;
     }
 
     void FaultInjection::RemoveExceptionFilters()

--- a/lib/Common/Core/FaultInjection.h
+++ b/lib/Common/Core/FaultInjection.h
@@ -140,7 +140,7 @@ namespace Js
         bool symInitialized;
         static PVOID vectoredExceptionHandler;
         static DWORD exceptionFilterRemovalLastError;
-        static bool InstallExceptionFilters();
+        static void InstallExceptionFilters();
         static void RemoveExceptionFilters();
         static UINT_PTR CalculateStackHash(void* frames[], WORD frameCount, WORD framesToSkip);
         static LONG WINAPI FaultInjectionExceptionFilter(_In_  struct _EXCEPTION_POINTERS *ExceptionInfo);


### PR DESCRIPTION
this was broken by a change that removing the static local var usage. causes exception filter installing and symInit are called on each allocation, which should causes the faultinjection run very slow
