### PR TITLE
Fix cases of bad binding in arrow function parameter lists. 

### DIFF
--- a/test/es6/lambda-params-shadow.js
+++ b/test/es6/lambda-params-shadow.js
@@ -29,4 +29,8 @@ if (count !== 4) {
     WScript.Echo('fail');
 }
 
+(vjczgj = (function(y) { try{}catch(e){} }), fkvcij = (y)) => {};
+
+(omabpn = (function(x) {return { getOwnPropertyNames: function(){ switch({}) { case 0:  "" ; }},  }; }), pkgrln = (TypeError(x))) => {};
+
 WScript.Echo('pass');


### PR DESCRIPTION
Fix some cases where block enumeration differed between buildAST and !buildAST compiles. If the initial parse of an arrow function parameter was deferred, and the reparse on discovery of the arrow token was (necessarily) not deferred, then the inconsistent state of the pid refs left by the initial parse led to incorrect bindings.