### PR TITLE
Proxy got revoked when in the trap.

### DIFF
--- a/lib/Runtime/Library/JavascriptProxy.cpp
+++ b/lib/Runtime/Library/JavascriptProxy.cpp
@@ -215,7 +215,7 @@ namespace Js
         if (nullptr == gOPDMethod || GetScriptContext()->IsHeapEnumInProgress())
         {
             resultDescriptor->SetFromProxy(false);
-            return fn();
+            return fn(targetObj);
         }
         // Reject implicit call
         if (threadContext->IsDisableImplicitCall())
@@ -1652,8 +1652,8 @@ namespace Js
     BOOL JavascriptProxy::GetOwnPropertyDescriptor(RecyclableObject* obj, PropertyId propertyId, ScriptContext* scriptContext, PropertyDescriptor* propertyDescriptor)
     {
         JavascriptProxy* proxy = JavascriptProxy::FromVar(obj);
-        auto fn = [&]()-> BOOL {
-            return JavascriptOperators::GetOwnPropertyDescriptor(proxy->target, propertyId, scriptContext, propertyDescriptor);
+        auto fn = [&](RecyclableObject *targetObj)-> BOOL {
+            return JavascriptOperators::GetOwnPropertyDescriptor(targetObj, propertyId, scriptContext, propertyDescriptor);
         };
         auto getPropertyId = [&]() -> PropertyId {return propertyId; };
         BOOL foundProperty = proxy->GetPropertyDescriptorTrap(obj, fn, getPropertyId, propertyDescriptor, scriptContext);

--- a/test/es6/proxybugs.js
+++ b/test/es6/proxybugs.js
@@ -196,6 +196,23 @@ var tests = [
         }
     },
     {
+        name: "Assertion validation : revoking the proxy by invoking getOwnPropertyDescriptor trap but no handler present",
+        body() {
+            var trapCalled = false;
+            var handler = {
+                get(t, propertyKey) {
+                    trapCalled = true;
+                    if (propertyKey === "getOwnPropertyDescriptor")
+                        obj.revoke();
+                }
+            };
+            
+            var obj = Proxy.revocable({a:0}, new Proxy({}, handler));
+            Object.getOwnPropertyDescriptor(obj.proxy, 'a');
+            assert.isTrue(trapCalled);
+        }
+    },
+    {
         name: "Assertion validation : revoking the proxy in has trap",
         body() {
             var trapCalled = false;


### PR DESCRIPTION
During the GetOwnPropertyDescriptor trap we were looking for the getOwnPropertyHandler, which actually causes the revoke of the proxy, though we were using the proxy->target instead of using the targetObj we have cached locally.
Fixed that.
