### PR TITLE
Fixes to support node inspector

### DIFF
--- a/bin/ch/ChakraRtInterface.h
+++ b/bin/ch/ChakraRtInterface.h
@@ -67,7 +67,7 @@ struct JsAPIHooks
     typedef JsErrorCode(WINAPI *JsrtDiagGetStackProperties)(unsigned int stackFrameIndex, JsValueRef * properties);
     typedef JsErrorCode(WINAPI *JsrtDiagGetProperties)(unsigned int objectHandle, unsigned int fromCount, unsigned int totalCount, JsValueRef * propertiesObject);
     typedef JsErrorCode(WINAPI *JsrtDiagGetObjectFromHandle)(unsigned int handle, JsValueRef * handleObject);
-    typedef JsErrorCode(WINAPI *JsrtDiagEvaluate)(JsValueRef expression, unsigned int stackFrameIndex, JsParseScriptAttributes parseAttributes, JsValueRef * evalResult);
+    typedef JsErrorCode(WINAPI *JsrtDiagEvaluate)(JsValueRef expression, unsigned int stackFrameIndex, JsParseScriptAttributes parseAttributes, bool forceSetValueProp, JsValueRef * evalResult);
 
     typedef JsErrorCode(WINAPI *JsrtRun)(JsValueRef script, JsSourceContext sourceContext, JsValueRef sourceUrl, JsParseScriptAttributes parseAttributes, JsValueRef *result);
     typedef JsErrorCode(WINAPI *JsrtParse)(JsValueRef script, JsSourceContext sourceContext, JsValueRef sourceUrl, JsParseScriptAttributes parseAttributes, JsValueRef *result);
@@ -333,7 +333,7 @@ public:
     static JsErrorCode WINAPI JsDiagGetStackProperties(unsigned int stackFrameIndex, JsValueRef * properties) { return HOOK_JS_API(DiagGetStackProperties(stackFrameIndex, properties)); }
     static JsErrorCode WINAPI JsDiagGetProperties(unsigned int objectHandle, unsigned int fromCount, unsigned int totalCount, JsValueRef * propertiesObject) { return HOOK_JS_API(DiagGetProperties(objectHandle, fromCount, totalCount, propertiesObject)); }
     static JsErrorCode WINAPI JsDiagGetObjectFromHandle(unsigned int handle, JsValueRef * handleObject) { return HOOK_JS_API(DiagGetObjectFromHandle(handle, handleObject)); }
-    static JsErrorCode WINAPI JsDiagEvaluate(JsValueRef expression, unsigned int stackFrameIndex, JsParseScriptAttributes parseAttributes, JsValueRef * evalResult) { return HOOK_JS_API(DiagEvaluate(expression, stackFrameIndex, parseAttributes, evalResult)); }
+    static JsErrorCode WINAPI JsDiagEvaluate(JsValueRef expression, unsigned int stackFrameIndex, JsParseScriptAttributes parseAttributes, bool forceSetValueProp, JsValueRef * evalResult) { return HOOK_JS_API(DiagEvaluate(expression, stackFrameIndex, parseAttributes, forceSetValueProp, evalResult)); }
     static JsErrorCode WINAPI JsParseModuleSource(JsModuleRecord requestModule, JsSourceContext sourceContext, byte* sourceText, unsigned int sourceLength, JsParseModuleSourceFlags sourceFlag, JsValueRef* exceptionValueRef) {
         return HOOK_JS_API(ParseModuleSource(requestModule, sourceContext, sourceText, sourceLength, sourceFlag, exceptionValueRef));
     }

--- a/bin/ch/Debugger.cpp
+++ b/bin/ch/Debugger.cpp
@@ -174,7 +174,7 @@ JsValueRef Debugger::Evaluate(JsValueRef callee, bool isConstructCall, JsValueRe
     if (argumentCount > 2)
     {
         IfJsErrorFailLogAndRet(ChakraRTInterface::JsNumberToInt(arguments[1], &stackFrameIndex));
-        ChakraRTInterface::JsDiagEvaluate(arguments[2], stackFrameIndex, JsParseScriptAttributeNone, &result);
+        ChakraRTInterface::JsDiagEvaluate(arguments[2], stackFrameIndex, JsParseScriptAttributeNone, /* forceSetValueProp */ false, &result);
     }
 
     return result;

--- a/lib/Jsrt/ChakraDebug.h
+++ b/lib/Jsrt/ChakraDebug.h
@@ -106,7 +106,11 @@ typedef unsigned __int32 uint32_t;
         /// <summary>
         ///     Perform a reverse continue operation (only applicable in TTD mode).
         /// </summary>
-        JsDiagStepTypeStepReverseContinue = 4
+        JsDiagStepTypeReverseContinue = 4,
+        /// <summary>
+        ///     Perform a forward continue operation. Clears any existing step value.
+        /// </summary>
+        JsDiagStepTypeContinue = 5
     } JsDiagStepType;
 
     /// <summary>
@@ -563,6 +567,7 @@ typedef unsigned __int32 uint32_t;
     ///     - `JsParseScriptAttributeArrayBufferIsUtf16Encoded` when `expression` is Utf16 Encoded ArrayBuffer
     ///     - `JsParseScriptAttributeLibraryCode` has no use for this function and has similar effect with `JsParseScriptAttributeNone`
     /// </param>
+    /// <param name="forceSetValueProp">Forces the result to contain the raw value of the expression result.</param>
     /// <param name="evalResult">Result of evaluation.</param>
     /// <remarks>
     ///     <para>
@@ -600,6 +605,7 @@ typedef unsigned __int32 uint32_t;
             _In_ JsValueRef expression,
             _In_ unsigned int stackFrameIndex,
             _In_ JsParseScriptAttributes parseAttributes,
+            _In_ bool forceSetValueProp,
             _Out_ JsValueRef *evalResult);
 
     /////////////////////

--- a/lib/Jsrt/JsrtDebugUtils.h
+++ b/lib/Jsrt/JsrtDebugUtils.h
@@ -35,10 +35,11 @@ public:
     static void AddPropertyToObject(Js::DynamicObject* object, JsrtDebugPropertyId propertyId, bool value, Js::ScriptContext* scriptContext);
     static void AddPropertyToObject(Js::DynamicObject* object, JsrtDebugPropertyId propertyId, Js::Var value, Js::ScriptContext* scriptContext);
 
-    static void AddPropertyType(Js::DynamicObject * object, Js::IDiagObjectModelDisplay* objectDisplayRef, Js::ScriptContext * scriptContext);
+    static void AddPropertyType(Js::DynamicObject * object, Js::IDiagObjectModelDisplay* objectDisplayRef, Js::ScriptContext * scriptContext, bool forceSetValueProp);
 
 private:
     static void AddVarPropertyToObject(Js::DynamicObject* object, JsrtDebugPropertyId propertyId, Js::Var value, Js::ScriptContext* scriptContext);
+    static bool HasProperty(Js::DynamicObject* object, JsrtDebugPropertyId propertyId, Js::ScriptContext * scriptContext);
     static const char16* GetClassName(Js::TypeId typeId);
     static const char16* GetDebugPropertyName(JsrtDebugPropertyId propertyId);
 };

--- a/lib/Jsrt/JsrtDebuggerObject.h
+++ b/lib/Jsrt/JsrtDebuggerObject.h
@@ -27,18 +27,18 @@ public:
     JsrtDebuggerObjectType GetType() { return type; }
     uint GetHandle() const { return handle; }
     JsrtDebuggerObjectsManager* GetDebuggerObjectsManager();
-    virtual Js::DynamicObject* GetJSONObject(Js::ScriptContext* scriptContext) = 0;
+    virtual Js::DynamicObject* GetJSONObject(Js::ScriptContext* scriptContext, bool forceSetValueProp) = 0;
     virtual Js::DynamicObject* GetChildren(Js::ScriptContext* scriptContext, uint fromCount, uint totalCount);
 
     template<class JsrtDebuggerObjectType, class PostFunction>
-    static void CreateDebuggerObject(JsrtDebuggerObjectsManager* debuggerObjectsManager, Js::ResolvedObject resolvedObject, Js::ScriptContext* scriptContext, PostFunction postFunction)
+    static void CreateDebuggerObject(JsrtDebuggerObjectsManager* debuggerObjectsManager, Js::ResolvedObject resolvedObject, Js::ScriptContext* scriptContext, bool forceSetValueProp, PostFunction postFunction)
     {
         AutoPtr<WeakArenaReference<Js::IDiagObjectModelDisplay>> objectDisplayWeakRef(resolvedObject.GetObjectDisplay());
         Js::IDiagObjectModelDisplay* objectDisplay = objectDisplayWeakRef->GetStrongReference();
         if (objectDisplay != nullptr)
         {
             JsrtDebuggerObjectBase* debuggerObject = JsrtDebuggerObjectType::Make(debuggerObjectsManager, objectDisplayWeakRef);
-            Js::DynamicObject* object = debuggerObject->GetJSONObject(resolvedObject.scriptContext);
+            Js::DynamicObject* object = debuggerObject->GetJSONObject(resolvedObject.scriptContext, forceSetValueProp);
             Assert(object != nullptr);
             Js::Var marshaledObj = Js::CrossSite::MarshalVar(scriptContext, object);
             postFunction(marshaledObj);
@@ -59,7 +59,7 @@ class JsrtDebuggerObjectFunction : public JsrtDebuggerObjectBase
 {
 public:
     static JsrtDebuggerObjectBase* Make(JsrtDebuggerObjectsManager* debuggerObjectsManager, Js::FunctionBody* functionBody);
-    Js::DynamicObject* GetJSONObject(Js::ScriptContext* scriptContext);
+    Js::DynamicObject* GetJSONObject(Js::ScriptContext* scriptContext, bool forceSetValueProp);
 
 private:
     JsrtDebuggerObjectFunction(JsrtDebuggerObjectsManager* debuggerObjectsManager, Js::FunctionBody* functionBody);
@@ -72,7 +72,7 @@ class JsrtDebuggerObjectProperty : public JsrtDebuggerObjectBase
 public:
     static JsrtDebuggerObjectBase* Make(JsrtDebuggerObjectsManager* debuggerObjectsManager, WeakArenaReference<Js::IDiagObjectModelDisplay>* objectDisplay);
 
-    Js::DynamicObject* GetJSONObject(Js::ScriptContext* scriptContext);
+    Js::DynamicObject* GetJSONObject(Js::ScriptContext* scriptContext, bool forceSetValueProp);
     Js::DynamicObject* GetChildren(Js::ScriptContext* scriptContext, uint fromCount, uint totalCount);
 
 private:
@@ -87,7 +87,7 @@ class JsrtDebuggerObjectGlobalsNode : public JsrtDebuggerObjectBase
 public:
     static JsrtDebuggerObjectBase* Make(JsrtDebuggerObjectsManager* debuggerObjectsManager, WeakArenaReference<Js::IDiagObjectModelDisplay>* objectDisplay);
 
-    Js::DynamicObject* GetJSONObject(Js::ScriptContext* scriptContext);
+    Js::DynamicObject* GetJSONObject(Js::ScriptContext* scriptContext, bool forceSetValueProp);
     Js::DynamicObject* GetChildren(Js::ScriptContext* scriptContext, uint fromCount, uint totalCount);
 
 private:
@@ -102,7 +102,7 @@ class JsrtDebuggerObjectScope : public JsrtDebuggerObjectBase
 public:
     static JsrtDebuggerObjectBase* Make(JsrtDebuggerObjectsManager* debuggerObjectsManager, WeakArenaReference<Js::IDiagObjectModelDisplay>* objectDisplay, uint index);
 
-    Js::DynamicObject* GetJSONObject(Js::ScriptContext* scriptContext);
+    Js::DynamicObject* GetJSONObject(Js::ScriptContext* scriptContext, bool forceSetValueProp);
     Js::DynamicObject* GetChildren(Js::ScriptContext* scriptContext, uint fromCount, uint totalCount);
 
 private:
@@ -120,7 +120,7 @@ public:
     ~JsrtDebuggerStackFrame();
     Js::DynamicObject* GetJSONObject(Js::ScriptContext* scriptContext);
     Js::DynamicObject* GetLocalsObject(Js::ScriptContext* scriptContext);
-    bool Evaluate(Js::ScriptContext* scriptContext, const char16 *source, int sourceLength, bool isLibraryCode, Js::DynamicObject** evalResult);
+    bool Evaluate(Js::ScriptContext* scriptContext, const char16 *source, int sourceLength, bool isLibraryCode, bool forceSetValueProp, Js::DynamicObject** evalResult);
     uint GetIndex() const { return this->frameIndex; }
 
 private:

--- a/lib/Jsrt/JsrtDiag.cpp
+++ b/lib/Jsrt/JsrtDiag.cpp
@@ -451,7 +451,7 @@ CHAKRA_API JsDiagSetStepType(
             return JsErrorInvalidArgument;
 #endif
         }
-        else if(stepType == JsDiagStepTypeStepReverseContinue)
+        else if (stepType == JsDiagStepTypeReverseContinue)
         {
 #if ENABLE_TTD
             ThreadContext* threadContext = runtime->GetThreadContext();
@@ -472,6 +472,10 @@ CHAKRA_API JsDiagSetStepType(
 #else
             return JsErrorInvalidArgument;
 #endif
+        }
+        else if (stepType == JsDiagStepTypeContinue)
+        {
+            jsrtDebugManager->SetResumeType(BREAKRESUMEACTION_CONTINUE);
         }
 
         return JsNoError;
@@ -659,7 +663,7 @@ CHAKRA_API JsDiagGetObjectFromHandle(
             return JsErrorDiagInvalidHandle;
         }
 
-        Js::DynamicObject* object = debuggerObject->GetJSONObject(scriptContext);
+        Js::DynamicObject* object = debuggerObject->GetJSONObject(scriptContext, /* forceSetValueProp */ false);
 
         if (object != nullptr)
         {
@@ -675,6 +679,7 @@ CHAKRA_API JsDiagEvaluate(
     _In_ JsValueRef expressionVal,
     _In_ unsigned int stackFrameIndex,
     _In_ JsParseScriptAttributes parseAttributes,
+    _In_ bool forceSetValueProp,
     _Out_ JsValueRef *evalResult)
 {
     return ContextAPINoScriptWrapper_NoRecord([&](Js::ScriptContext *scriptContext) -> JsErrorCode {
@@ -742,7 +747,7 @@ CHAKRA_API JsDiagEvaluate(
         }
 
         Js::DynamicObject* result = nullptr;
-        bool success = debuggerStackFrame->Evaluate(scriptContext, expression, static_cast<int>(len), false, &result);
+        bool success = debuggerStackFrame->Evaluate(scriptContext, expression, static_cast<int>(len), false, forceSetValueProp, &result);
 
         if (result != nullptr)
         {

--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -134,7 +134,8 @@ namespace Js
         firstInterpreterFrameReturnAddress(nullptr),
         builtInLibraryFunctions(nullptr),
         m_remoteScriptContextAddr(nullptr),
-        isWeakReferenceDictionaryListCleared(false)
+        isWeakReferenceDictionaryListCleared(false),
+        isDebugContextInitialized(false)
 #if ENABLE_PROFILE_INFO
         , referencesSharedDynamicSourceContextInfo(false)
 #endif
@@ -1270,6 +1271,13 @@ namespace Js
         this->GetDebugContext()->Initialize();
 
         this->GetDebugContext()->GetProbeContainer()->Initialize(this);
+
+        isDebugContextInitialized = true;
+
+#if defined(_M_ARM32_OR_ARM64)
+        // We need to ensure that the above write to the isDebugContextInitialized is visible to the debugger thread.
+        MemoryBarrier();
+#endif
 
         AssertMsg(this->CurrentThunk == DefaultEntryThunk, "Creating non default thunk while initializing");
         AssertMsg(this->DeferredParsingThunk == DefaultDeferredParsingThunk, "Creating non default thunk while initializing");

--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -885,6 +885,8 @@ private:
         void InitializePostGlobal();
         void InitializeCache();
 
+        bool isDebugContextInitialized;
+
         // Source Info
         void EnsureSourceContextInfoMap();
         void EnsureDynamicSourceContextInfoMap();
@@ -970,6 +972,7 @@ private:
         bool IsInitialized() { return this->isInitialized; }
 #endif
 
+        bool IsDebugContextInitialized() const { return this->isDebugContextInitialized; }
         DebugContext* GetDebugContext() const { return this->debugContext; }
         CriticalSection* GetDebugContextCloseCS() { return &debugContextCloseCS; }
 


### PR DESCRIPTION
* Added support for "forceSetValueProp" which forces the raw value to
  be added to the diagnostics object.
* Handled the possibility that although a context may exist, it may
  not be fully initialized.
