### PR TITLE
Add Dev15 MSBuild to MSBuild search path

### DIFF
--- a/Build/scripts/add_msbuild_path.cmd
+++ b/Build/scripts/add_msbuild_path.cmd
@@ -6,11 +6,10 @@
 :: add_msbuild_path.cmd
 ::
 :: Locate msbuild.exe and add it to the PATH
-
 set USE_MSBUILD_12=%1
 
 if "%USE_MSBUILD_12%" == "True" (
-    echo Skipping Dev14 and trying Dev12...
+    echo Skipping Dev15 and trying Dev12...
     goto :LABEL_USE_MSBUILD_12
 )
 
@@ -19,7 +18,25 @@ if "%ERRORLEVEL%" == "0" (
     goto :SkipMsBuildSetup
 )
 
-REM Try Dev14 first
+REM Try Dev15 first
+
+set MSBUILD_VERSION=15.0
+set MSBUILD_PATH="%ProgramFiles%\Microsoft Visual Studio\2017\Enterprise\MSBuild\%MSBUILD_VERSION%\Bin\x86"
+
+if not exist %MSBUILD_PATH%\msbuild.exe (
+    set MSBUILD_PATH="%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Enterprise\MSBuild\%MSBUILD_VERSION%\Bin"
+)
+
+if not exist %MSBUILD_PATH%\msbuild.exe (
+    set MSBUILD_PATH="%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Enterprise\MSBuild\%MSBUILD_VERSION%\Bin\amd64"
+)
+
+if exist %MSBUILD_PATH%\msbuild.exe (
+    goto :MSBuildFound
+)
+
+echo Dev15 not found, trying Dev14...
+
 set MSBUILD_VERSION=14.0
 set MSBUILD_PATH="%ProgramFiles%\msbuild\%MSBUILD_VERSION%\Bin\x86"
 


### PR DESCRIPTION
Search Dev15 Enterprise path for MSBuild.

It should search other variants and perhaps use amd64 if appropriate, but I don't have the time to fix that right now. :)