### PR TITLE
Improve StrictEqual

### DIFF
--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -879,8 +879,13 @@ namespace Js
     BOOL JavascriptOperators::StrictEqual(Var aLeft, Var aRight, ScriptContext* requestContext)
     {
         double dblLeft, dblRight;
-        TypeId leftType = JavascriptOperators::GetTypeId(aLeft);
-        TypeId rightType = JavascriptOperators::GetTypeId(aRight);
+        TypeId rightType, leftType;
+        leftType = JavascriptOperators::GetTypeId(aLeft);
+
+        // Because NaN !== NaN, we may not return TRUE when typeId is Number
+        if (aLeft == aRight && leftType != TypeIds_Number) return TRUE;
+
+        rightType = JavascriptOperators::GetTypeId(aRight);
 
         switch (leftType)
         {
@@ -6822,7 +6827,7 @@ CommonNumber:
                 // CONSIDER : When we delay type sharing until the second instance is created, pass an argument indicating we want the types
                 // and handlers created here to be marked as shared up-front. This is to ensure we don't get any fixed fields and that the handler
                 // is ready for storing values directly to slots.
-                DynamicType* newType = PathTypeHandlerBase::CreateNewScopeObject(scriptContext, frameObject->GetDynamicType(), propIds, nonSimpleParamList ? PropertyLetDefaults : PropertyNone);    
+                DynamicType* newType = PathTypeHandlerBase::CreateNewScopeObject(scriptContext, frameObject->GetDynamicType(), propIds, nonSimpleParamList ? PropertyLetDefaults : PropertyNone);
                 int oldSlotCapacity = frameObject->GetDynamicType()->GetTypeHandler()->GetSlotCapacity();
                 int newSlotCapacity = newType->GetTypeHandler()->GetSlotCapacity();
                 __analysis_assume((uint32)newSlotCapacity >= formalsCount);
@@ -6922,7 +6927,7 @@ CommonNumber:
 
         frameObject->EnsureSlots(oldSlotCapacity, newSlotCapacity, scriptContext, newType->GetTypeHandler());
         frameObject->ReplaceType(newType);
-        
+
         return frameObject;
     }
 

--- a/lib/Runtime/Library/JavascriptString.cpp
+++ b/lib/Runtime/Library/JavascriptString.cpp
@@ -3892,6 +3892,8 @@ case_2:
     {
         AssertMsg(T::Is(aLeft) && T::Is(aRight), "string comparison");
 
+        if (aLeft == aRight) return true;
+
         T *leftString = T::FromVar(aLeft);
         T *rightString = T::FromVar(aRight);
 

--- a/pal/src/cruntime/wchar.cpp
+++ b/pal/src/cruntime/wchar.cpp
@@ -1239,6 +1239,8 @@ PAL_wmemcmp(
           string1?string1:W16_NULLSTRING, string2?string2:W16_NULLSTRING, string2?string2:W16_NULLSTRING,
           (unsigned long) count);
 
+    if (string1 == string2) return diff;
+
     for (i = 0; i < count; i++)
     {
         diff = string1[i] - string2[i];


### PR DESCRIPTION
#### 1 -     Improve String::StrictEqual

Neither `PAL_wmemcmp` / `Windows wmemcmp` checks for `ptr1 == ptr2` hence we end up with the worst case scenario / perf.

#### 2 -     StrictEqual overall improvement

CC calls `JavascriptOperators::StrictEqual`with final calculated values. So, when ptr1 == ptr2 and typeOf (ptr*) != TypeIds_Number, we may not need to go further for strict equal check. The importance with the `TypeIds_Number` check is due to `NaN !== NaN`

#### Why

mt. http req. triggers a strict check for ptr1 === ptr2 aprox. 200.000 times each second.