### PR TITLE
fix possible memory leak

### DIFF
--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -7868,33 +7868,18 @@ namespace Js
         CleanupRecyclerData(isScriptContextClosing, false /* capture entry point cleanup stack trace */);
         CleanUpForInCache(isScriptContextClosing);
 
-        if(!isScriptContextClosing)
-        {
-            this->ResetObjectLiteralTypes();
+        this->SetObjLiteralCount(0);
+        this->SetScopeSlotArraySizes(0, 0);
 
-            // Manually clear these values to break any circular references
-            // that might prevent the script context from being disposed
-            this->SetAuxiliaryData(nullptr);
-            this->SetAuxiliaryContextData(nullptr);
-            this->byteCodeBlock = nullptr;
-            this->entryPoints = nullptr;
-            this->SetLoopHeaderArray(nullptr);
-            this->SetConstTable(nullptr);
-            this->SetCodeGenRuntimeData(nullptr);
-            this->SetCodeGenGetSetRuntimeData(nullptr);
-            this->SetPropertyIdOnRegSlotsContainer(nullptr);
-            this->inlineCaches = nullptr;
-            this->polymorphicInlineCaches.Reset();
-            this->SetPolymorphicInlineCachesHead(nullptr);
-            this->cacheIdToPropertyIdMap = nullptr;
-            this->SetFormalsPropIdArray(nullptr);
-            this->SetReferencedPropertyIdMap(nullptr);
-            this->SetLiteralRegexs(nullptr);
-            this->SetPropertyIdsForScopeSlotArray(nullptr, 0);
-#if ENABLE_PROFILE_INFO
-            this->SetPolymorphicCallSiteInfoHead(nullptr);
-#endif
-        }
+        // Manually clear these values to break any circular references
+        // that might prevent the script context from being disposed        
+        this->auxPtrs = nullptr;
+        this->byteCodeBlock = nullptr;
+        this->entryPoints = nullptr;
+        this->inlineCaches = nullptr;
+        this->cacheIdToPropertyIdMap = nullptr;
+        this->polymorphicInlineCaches.Reset();
+        this->SetConstTable(nullptr);
 
 #if DYNAMIC_INTERPRETER_THUNK
         if (this->HasInterpreterThunkGenerated())


### PR DESCRIPTION
while shutting down I assume there's no need to cleanup the pointers.
however there can be a situation with dynamic profile input, constant
table can hold a reference to a pinned var(like ImageData/typedarray)
causes two pinned object on a circle and lead to memory leak.
the circle is like this:

pinned typedArray(ImageData in my case, from another scriptContext)->type->
javascriptLibrary(pinned through global object)->
cache->sourceContextInfoMap->sourceDynamicProfileManager->
dynamicProfileInfoMap->functionBody(for global function)->
constTable[x](crossSite global object)->auxAlots[x] (CEO)->auxSlots[x] (typedArray(circle))

with change #2825 the constTable is not cleaned up while another scriptContext were forcibly closed and kept the above circle

also make better clean up -- just set auxPtrs to nullptr instead of updating each of them
