### PR TITLE
Add Dev15 MSBuild to MSBuild search path (cmd and powershell)

### DIFF
--- a/Build/scripts/add_msbuild_path.cmd
+++ b/Build/scripts/add_msbuild_path.cmd
@@ -6,11 +6,10 @@
 :: add_msbuild_path.cmd
 ::
 :: Locate msbuild.exe and add it to the PATH
-
 set USE_MSBUILD_12=%1
 
 if "%USE_MSBUILD_12%" == "True" (
-    echo Skipping Dev14 and trying Dev12...
+    echo Skipping Dev15 and trying Dev12...
     goto :LABEL_USE_MSBUILD_12
 )
 
@@ -19,7 +18,25 @@ if "%ERRORLEVEL%" == "0" (
     goto :SkipMsBuildSetup
 )
 
-REM Try Dev14 first
+REM Try Dev15 first
+
+set MSBUILD_VERSION=15.0
+set MSBUILD_PATH="%ProgramFiles%\Microsoft Visual Studio\2017\Enterprise\MSBuild\%MSBUILD_VERSION%\Bin\x86"
+
+if not exist %MSBUILD_PATH%\msbuild.exe (
+    set MSBUILD_PATH="%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Enterprise\MSBuild\%MSBUILD_VERSION%\Bin"
+)
+
+if not exist %MSBUILD_PATH%\msbuild.exe (
+    set MSBUILD_PATH="%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Enterprise\MSBuild\%MSBUILD_VERSION%\Bin\amd64"
+)
+
+if exist %MSBUILD_PATH%\msbuild.exe (
+    goto :MSBuildFound
+)
+
+echo Dev15 not found, trying Dev14...
+
 set MSBUILD_VERSION=14.0
 set MSBUILD_PATH="%ProgramFiles%\msbuild\%MSBUILD_VERSION%\Bin\x86"
 

--- a/Build/scripts/util.ps1
+++ b/Build/scripts/util.ps1
@@ -32,14 +32,14 @@ function GetRepoRoot() {
 
 function WriteMessage($str) {
     Write-Output $str
-    if ($logFile -ne "") {
+    if ($logFile) {
         Write-Output $str | Out-File $logFile -Append
     }
 }
 
 function WriteErrorMessage($str) {
     $host.ui.WriteErrorLine($str)
-    if ($logFile -ne "") {
+    if ($logFile) {
         Write-Output $str | Out-File $logFile -Append
     }
 }


### PR DESCRIPTION
Compromise between #2570 and #2835 -- avoid the refactor of add_msbuild_path.cmd for now so that we can get this working.

Replaces #2835, and reduces #2570 to a refactoring that can cook a little longer.