### PR TITLE
fix couple bugs with ShiftAdd peep

### DIFF
--- a/lib/Backend/PreLowerPeeps.cpp
+++ b/lib/Backend/PreLowerPeeps.cpp
@@ -82,8 +82,8 @@ Lowerer::TryShiftAdd(IR::Instr *instrAdd, IR::Opnd * opndFold, IR::Opnd * opndAd
         switch (constVal)
         {
         case 1:
-            scale = 0;
-            break;
+scale = 0;
+break;
         case 2:
             scale = 1;
             break;
@@ -181,6 +181,12 @@ Lowerer::PeepShiftAdd(IR::Instr *instrAdd)
 
     IR::Opnd * src2 = instrAdd->GetSrc2();
     IR::Opnd * src1 = instrAdd->GetSrc1();
+
+    // we can't remove t1 in case both srcs are uses of t1
+    if (src1->IsEqual(src2))
+    {
+        return instrAdd;
+    }
     IR::Instr * resultInstr = TryShiftAdd(instrAdd, src1, src2);
     if (resultInstr->m_opcode == Js::OpCode::Add_I4)
     {

--- a/lib/Backend/PreLowerPeeps.cpp
+++ b/lib/Backend/PreLowerPeeps.cpp
@@ -82,8 +82,8 @@ Lowerer::TryShiftAdd(IR::Instr *instrAdd, IR::Opnd * opndFold, IR::Opnd * opndAd
         switch (constVal)
         {
         case 1:
-scale = 0;
-break;
+            scale = 0;
+            break;
         case 2:
             scale = 1;
             break;

--- a/lib/Backend/SccLiveness.cpp
+++ b/lib/Backend/SccLiveness.cpp
@@ -781,12 +781,7 @@ SCCLiveness::FoldIndir(IR::Instr *instr, IR::Opnd *opnd)
         {
             return false;
         }
-        int32 newOffset = 0;
-        if(!Int32Math::Add(offset,indir->GetOffset(), &newOffset))
-        {
-            return false;
-        }
-        indir->SetOffset(newOffset);
+        indir->SetOffset(offset);
         indir->SetIndexOpnd(nullptr);
     }
 


### PR DESCRIPTION
Don't peep case where both sources to add use the same temp -- because the shl/mul instr will still be needed.

SCCLiveness::FoldIndir didn't handle case where base is null.