### PR TITLE
remove debug specific codepath for VirtualQueryEx

### DIFF
--- a/lib/Backend/EmitBuffer.cpp
+++ b/lib/Backend/EmitBuffer.cpp
@@ -296,15 +296,7 @@ EmitBufferManager<TAlloc, TPreReservedAlloc, SyncObject>::AllocateBuffer(__in si
 #if DBG
     MEMORY_BASIC_INFORMATION memBasicInfo;
     size_t resultBytes = VirtualQueryEx(this->processHandle, allocation->allocation->address, &memBasicInfo, sizeof(memBasicInfo));
-    if (resultBytes == 0) 
-    {
-        MemoryOperationLastError::RecordLastError();
-        if (this->processHandle != GetCurrentProcess())
-        {            
-            return nullptr;
-        }
-    }
-    Assert(resultBytes != 0 && memBasicInfo.Protect == PAGE_EXECUTE);
+    Assert(resultBytes == 0 || memBasicInfo.Protect == PAGE_EXECUTE);
 #endif
 
     return allocation;

--- a/lib/Common/Memory/SectionAllocWrapper.cpp
+++ b/lib/Common/Memory/SectionAllocWrapper.cpp
@@ -625,7 +625,7 @@ PreReservedSectionAllocWrapper::IsInRange(void * address)
     {
         MEMORY_BASIC_INFORMATION memBasicInfo;
         size_t bytes = VirtualQueryEx(this->process, address, &memBasicInfo, sizeof(memBasicInfo));
-        Assert(bytes != 0 && memBasicInfo.State == MEM_COMMIT && memBasicInfo.AllocationProtect == PAGE_EXECUTE);
+        Assert(bytes == 0 || (memBasicInfo.State == MEM_COMMIT && memBasicInfo.AllocationProtect == PAGE_EXECUTE));
     }
 #endif
     return isInRange;


### PR DESCRIPTION
Also change couple assertions which say call to VirtualQueryEx must succeed... it can fail if runtime process terminated