### PR TITLE
fix: Visual Studio build on master

### DIFF
--- a/bin/ChakraCore/ChakraCore.vcxproj
+++ b/bin/ChakraCore/ChakraCore.vcxproj
@@ -165,6 +165,9 @@
     <ProjectReference Include="..\..\lib\Runtime\Types\Chakra.Runtime.Types.vcxproj">
       <Project>{706083f7-6aa4-4558-a153-6352ef9110f6}</Project>
     </ProjectReference>
+    <ProjectReference Include="..\..\lib\wabt.vcxproj">
+      <Project>{F48B3491-81DF-4F49-B35F-3308CBE6A379}</Project>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="TestHooks.h" />


### PR DESCRIPTION
ChakraCore master doesn't compile with VisualStudio IDE due to missing dependency link to wabt. If you have it running somehow, it's because it might have compiled previously or you compile the whole solution all the time.