### PR TITLE
xplat: cover additional edge cases for interval caching

### DIFF
--- a/lib/Common/PlatformAgnostic/DateTimeInternal.h
+++ b/lib/Common/PlatformAgnostic/DateTimeInternal.h
@@ -97,8 +97,9 @@ namespace DateTime
     public:
         double    cacheSysTime;
         ULONGLONG cacheTick;
+        ULONGLONG previousDifference;
 
-        HiresTimerPlatformData():cacheSysTime(0), cacheTick(-1) { }
+        HiresTimerPlatformData():cacheSysTime(0), cacheTick(-1), previousDifference(0) { }
         void Reset() { /* dummy method for interface compatiblity */ }
     };
 

--- a/test/Date/xplatInterval.js
+++ b/test/Date/xplatInterval.js
@@ -8,13 +8,20 @@ if (WScript.Platform && WScript.Platform.OS != "win32") {
     function rand() {
         return parseInt(Math.random() * 1e2) + 50;
     }
+
     for (var j = 0; j < 1e2; j++) {
         var pre_time = Date.now(), now;
         for(var i = 0; i < 1e6; i++) {
             now = Date.now();
             var diff = now - pre_time
 
-            if (diff < 0) throw new Error ("Timer interval has failed. diff < 0");
+            // INTERVAL_FOR_TICK_BACKUP = 5
+            // So, anything beyond 5ms is not subject to our testing here.
+            if (diff < 0 && Math.abs(diff) <= 5)
+            {
+                throw new Error ("Timer interval has failed. diff < 0 -> " + diff);
+            }
+
             pre_time = now;
         }
 
@@ -23,7 +30,12 @@ if (WScript.Platform && WScript.Platform.OS != "win32") {
             now = Date.now();
         }
 
-        if (now < pre_time) throw new Error ("Timer interval has failed. now < pre_time");
+        // INTERVAL_FOR_TICK_BACKUP = 5
+        // So, anything beyond 5ms is not subject to our testing here.
+        if (now < pre_time && Math.abs(now - pre_time) <= 5)
+        {
+            throw new Error ("Timer interval has failed. now < pre_time");
+        }
     }
 } // !win32
 


### PR DESCRIPTION
- test update: Opt out the case for system time backward jumps.
- improve implementation: CPU tick value is circular. Make sure we don't miss updating `now`