### PR TITLE
Fix failure to reparse children of redeferred functions. 

### DIFF
--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -2002,6 +2002,9 @@ namespace Js
         void SetReparsed(bool set) { m_reparsed = set; }
         bool GetExternalDisplaySourceName(BSTR* sourceName);
 
+        void CleanupToReparse();
+        void CleanupToReparseHelper();
+
         bool EndsAfter(size_t offset) const;
 
         void SetDoBackendArgumentsOptimization(bool set)
@@ -3565,7 +3568,7 @@ namespace Js
         void SetEntryToDeferParseForDebugger();
         void ClearEntryPoints();
         void ResetEntryPoint();
-        void CleanupToReparse();
+        void CleanupToReparseHelper();
         void AddDeferParseAttribute();
         void RemoveDeferParseAttribute();
 #if DBG


### PR DESCRIPTION
On debug attach, we reparse the tree of compiled functions for debug mode, but sub-trees rooted at redeferred functions will not be reparsed, and this can leave functions still compiled for non-debug mode. Fix this by detecting redeferred functions, compiling them for debug mode, and continuing to reparse the sub-tree. Functions that have never been fully parsed will still be skipped, as they are guaranteed to have no fully parsed children.