### PR TITLE
xplat: fix shared lib linux global symbols for WASM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,8 @@ tags
 *.a
 *.gch
 *.o
+*.so
+*.dylib
 Makefile
 pal/src/config.h
 DbgController.js.h

--- a/lib/Runtime/Language/amd64/amd64_Thunks.S
+++ b/lib/Runtime/Language/amd64/amd64_Thunks.S
@@ -353,12 +353,6 @@ NESTED_END _ZN2Js23AsmJsExternalEntryPointEPNS_16RecyclableObjectENS_8CallInfoEz
 // WasmLibrary::WasmDeferredParseExternalThunk
 //============================================================================================================
 
-.global C_FUNC(_ZN2Js11WasmLibrary27WasmDeferredParseEntryPointEPNS_16RecyclableObjectENS_8CallInfoEz)
-
-#ifndef __APPLE__
-.type _ZN2Js11WasmLibrary27WasmDeferredParseEntryPointEPNS_16RecyclableObjectENS_8CallInfoEz, @function
-#endif
-
 // Var WasmLibrary::WasmDeferredParseExternalThunk(RecyclableObject* function, CallInfo callInfo, ...)
 .balign 16
 NESTED_ENTRY _ZN2Js11WasmLibrary30WasmDeferredParseExternalThunkEPNS_16RecyclableObjectENS_8CallInfoEz, _TEXT, NoHandler

--- a/test/native-tests/test-c98/Platform.js
+++ b/test/native-tests/test-c98/Platform.js
@@ -36,7 +36,7 @@ else\n\
 \tCFLAGS=-lstdc++ -std=c++98 -I$(IDIR)\n\
 \tFORCE_STARTS=-Wl,--whole-archive\n\
 \tFORCE_ENDS=-Wl,--no-whole-archive\n\
-\tLIBS=-pthread -lm -ldl -licuuc -lunwind-x86_64 -Wno-c++11-compat-deprecated-writable-strings \
+\tLIBS=-pthread -lm -ldl -licuuc -Wno-c++11-compat-deprecated-writable-strings \
     -Wno-deprecated-declarations -Wno-unknown-warning-option -o sample.o\n\
 endif\n\
 \n\

--- a/test/native-tests/test-char16/Platform.js
+++ b/test/native-tests/test-char16/Platform.js
@@ -36,7 +36,7 @@ else\n\
 \tCFLAGS=-lstdc++ -std=c++0x -I$(IDIR)\n\
 \tFORCE_STARTS=-Wl,--whole-archive\n\
 \tFORCE_ENDS=-Wl,--no-whole-archive\n\
-\tLIBS=-pthread -lm -ldl -licuuc -lunwind-x86_64 -Wno-c++11-compat-deprecated-writable-strings \
+\tLIBS=-pthread -lm -ldl -licuuc -Wno-c++11-compat-deprecated-writable-strings \
     -Wno-deprecated-declarations -Wno-unknown-warning-option -o sample.o\n\
 endif\n\
 \n\

--- a/test/native-tests/test-shared-basic/Platform.js
+++ b/test/native-tests/test-shared-basic/Platform.js
@@ -6,8 +6,9 @@
 var isWindows = !WScript.Platform || WScript.Platform.OS == 'win32';
 var path_sep = isWindows ? '\\' : '/';
 var isStaticBuild = WScript.Platform && WScript.Platform.LINK_TYPE == 'static';
+var sharedExtension = (WScript.Platform.OS == "darwin") ? ".dylib" : ".so";
 
-if (!isStaticBuild) {
+if (isStaticBuild) {
     // test will be ignored
     print("# IGNORE_THIS_TEST");
 } else {
@@ -18,13 +19,13 @@ if (!isStaticBuild) {
     var makefile =
 "IDIR=" + binaryPath + "/../../lib/Jsrt \n\
 \n\
-LIBRARY_PATH=" + binaryPath + "/lib\n\
+LIBRARY_PATH=" + binaryPath + "/\n\
 PLATFORM=" + platform + "\n\
-LDIR=$(LIBRARY_PATH)/libChakraCoreStatic.a \n\
+LDIR=$(LIBRARY_PATH)/libChakraCore" + sharedExtension + " \n\
 \n\
 ifeq (darwin, ${PLATFORM})\n\
 \tICU4C_LIBRARY_PATH ?= /usr/local/opt/icu4c\n\
-\tCFLAGS=-lstdc++ -I$(IDIR)\n\
+\tCFLAGS=-lstdc++ -std=c++11 -I$(IDIR)\n\
 \tFORCE_STARTS=-Wl,-force_load,\n\
 \tFORCE_ENDS=\n\
 \tLIBS=-framework CoreFoundation -framework Security -lm -ldl -Wno-c++11-compat-deprecated-writable-strings \
@@ -33,7 +34,7 @@ ifeq (darwin, ${PLATFORM})\n\
     $(ICU4C_LIBRARY_PATH)/lib/libicuuc.a \
     $(ICU4C_LIBRARY_PATH)/lib/libicui18n.a\n\
 else\n\
-\tCFLAGS=-lstdc++ -I$(IDIR)\n\
+\tCFLAGS=-lstdc++ -std=c++0x -I$(IDIR)\n\
 \tFORCE_STARTS=-Wl,--whole-archive\n\
 \tFORCE_ENDS=-Wl,--no-whole-archive\n\
 \tLIBS=-pthread -lm -ldl -licuuc -Wno-c++11-compat-deprecated-writable-strings \
@@ -41,7 +42,7 @@ else\n\
 endif\n\
 \n\
 testmake:\n\
-\t$(CC) sample.cpp dummy-1.c dummy-2.c $(CFLAGS) $(FORCE_STARTS) $(LDIR) $(FORCE_ENDS) $(LIBS)\n\
+\t$(CC) sample.cpp $(CFLAGS) $(FORCE_STARTS) $(LDIR) $(FORCE_ENDS) $(LIBS)\n\
 \n\
 .PHONY: clean\n\
 \n\

--- a/test/native-tests/test-shared-basic/sample.cpp
+++ b/test/native-tests/test-shared-basic/sample.cpp
@@ -1,0 +1,73 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#include "ChakraCore.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <string>
+#include <cstring>
+
+#define FAIL_CHECK(cmd)                     \
+    do                                      \
+    {                                       \
+        JsErrorCode errCode = cmd;          \
+        if (errCode != JsNoError)           \
+        {                                   \
+            printf("Error %d at '%s'\n",    \
+                errCode, #cmd);             \
+            return 1;                       \
+        }                                   \
+    } while(0)
+
+using namespace std;
+
+int main()
+{
+    JsRuntimeHandle runtime;
+    JsContextRef context;
+    JsValueRef result;
+    unsigned currentSourceContext = 0;
+
+    const char* script = "(()=>{return \'SUCCESS\';})()";
+
+    // Create a runtime.
+    JsCreateRuntime(JsRuntimeAttributeNone, nullptr, &runtime);
+
+    // Create an execution context.
+    JsCreateContext(runtime, &context);
+
+    // Now set the current execution context.
+    JsSetCurrentContext(context);
+
+    JsValueRef fname;
+    FAIL_CHECK(JsCreateString("sample", strlen("sample"), &fname));
+
+    JsValueRef scriptSource;
+    FAIL_CHECK(JsCreateExternalArrayBuffer((void*)script, (unsigned int)strlen(script),
+        nullptr, nullptr, &scriptSource));
+    // Run the script.
+    FAIL_CHECK(JsRun(scriptSource, currentSourceContext++, fname, JsParseScriptAttributeNone, &result));
+
+    // Convert your script result to String in JavaScript; redundant if your script returns a String
+    JsValueRef resultJSString;
+    FAIL_CHECK(JsConvertValueToString(result, &resultJSString));
+
+    // Project script result back to C++.
+    char *resultSTR = nullptr;
+    size_t stringLength;
+    FAIL_CHECK(JsCopyString(resultJSString, nullptr, 0, &stringLength));
+    resultSTR = (char*) malloc(stringLength + 1);
+    FAIL_CHECK(JsCopyString(resultJSString, resultSTR, stringLength + 1, nullptr));
+    resultSTR[stringLength] = 0;
+
+    printf("Result -> %s \n", resultSTR);
+    free(resultSTR);
+
+    // Dispose runtime
+    JsSetCurrentContext(JS_INVALID_REFERENCE);
+    JsDisposeRuntime(runtime);
+
+    return 0;
+}

--- a/test/native-tests/test-static-native/Platform.js
+++ b/test/native-tests/test-static-native/Platform.js
@@ -36,7 +36,7 @@ else\n\
 \tCFLAGS=-lstdc++ -std=c++0x -I$(IDIR)\n\
 \tFORCE_STARTS=-Wl,--whole-archive\n\
 \tFORCE_ENDS=-Wl,--no-whole-archive\n\
-\tLIBS=-pthread -lm -ldl -licuuc -lunwind-x86_64 -Wno-c++11-compat-deprecated-writable-strings \
+\tLIBS=-pthread -lm -ldl -licuuc -Wno-c++11-compat-deprecated-writable-strings \
     -Wno-deprecated-declarations -Wno-unknown-warning-option -o sample.o\n\
 endif\n\
 \n\

--- a/test/native-tests/test_native.sh
+++ b/test/native-tests/test_native.sh
@@ -88,6 +88,14 @@ RUN "test-char16"
 RUN "test-static-native"
 
 # shared lib tests
+LIB_DIR="$(dirname ${CH_DIR})"
+if [[ `uname -a` =~ "Darwin" ]]; then
+    export DYLD_LIBRARY_PATH=${LIB_DIR}/:$DYLD_LIBRARY_PATH
+else
+    export LD_LIBRARY_PATH=${LIB_DIR}/:$LD_LIBRARY_PATH
+fi
+
+RUN "test-shared-basic"
 
 # test python
 RUN_CMD "test-python" "python helloWorld.py ${BUILD_TYPE}"

--- a/test/runtests.sh
+++ b/test/runtests.sh
@@ -41,10 +41,12 @@ else
     # TEST flags are not enabled for release build
     # however we would like to test if the compiled binary
     # works or not
-    RES=$($test_path/../out/${binary_path}/ch $test_path/basics/hello.js)
-    if [[ $RES =~ "Error :" ]]; then
+    RES=$($test_path/../out/${binary_path}/ch $test_path/Basics/hello.js)
+    EXIT_CODE=$?
+
+    if [[ $RES =~ "Error :" || $EXIT_CODE != 0 ]]; then
         echo "FAILED"
-        exit 1
+        exit $EXIT_CODE
     else
         echo "Release Build Passes hello.js run"
     fi


### PR DESCRIPTION
- Fixes a wrong global reference for WASM
- Fixes folder case/naming for Release binary testing
- Adds a native test case to catch similar issues on CI
- Removes unnecessary unwind referencing on native tests

Fixes #2859 