### PR TITLE
some pageheap fixes

### DIFF
--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -1326,6 +1326,7 @@ FLAGNR(Boolean,     PageHeapAllocStack,   "Capture alloc stack under page heap m
 FLAGNR(Boolean,     PageHeapFreeStack,    "Capture free stack under page heap mode", DEFAULT_CONFIG_PageHeapFreeStack)
 FLAGNR(NumberRange, PageHeapBucketNumber, "Bucket numbers to be used for page heap allocations", )
 FLAGNR(Number,      PageHeapBlockType,    "Type of blocks to use page heap for", DEFAULT_CONFIG_PageHeapBlockType)
+FLAGNR(Boolean,     PageHeapDecommitGuardPage, "Decommit page heap guard page", true)
 #endif
 #ifdef RECYCLER_NO_PAGE_REUSE
 FLAGNR(Boolean, RecyclerNoPageReuse,     "Do not reuse page in recycler", false)

--- a/lib/Common/Memory/Allocator.h
+++ b/lib/Common/Memory/Allocator.h
@@ -10,7 +10,7 @@
 // Page heap mode is supported currently only in the Recycler
 // Defining here so that other allocators can take advantage of this
 // in the future
-enum PageHeapMode
+enum PageHeapMode : byte
 {
     PageHeapModeOff = 0,   // No Page heap
     PageHeapModeBlockStart = 1,   // Allocate the object at the beginning of the page
@@ -23,6 +23,10 @@ enum PageHeapMode
 
 #if DBG || defined(RECYCLER_FREE_MEM_FILL)
 #define DbgMemFill 0XFE
+#endif
+
+#ifdef RECYCLER_PAGE_HEAP
+#define PageHeapMemFill 0XF0
 #endif
 
 namespace Memory

--- a/lib/Common/Memory/ArenaAllocator.cpp
+++ b/lib/Common/Memory/ArenaAllocator.cpp
@@ -1134,10 +1134,10 @@ void InlineCacheAllocator::CheckIsAllZero(bool lockdown)
             // will be debug pattern filled (specifically, at least their weak reference slots).
             // All other caches must be zeroed out (again, at least their weak reference slots).
 #ifdef ARENA_MEMORY_VERIFY
-            Assert(IsAll((char*)weakRefBytes, sizeof(cache->weakRefs), '\0') 
-                || IsAll((char*)weakRefBytes, sizeof(cache->weakRefs), InlineCacheFreeListPolicy::DbgFreeMemFill));
+            Assert(IsAll(weakRefBytes, sizeof(cache->weakRefs), 0) 
+                || IsAll(weakRefBytes, sizeof(cache->weakRefs), InlineCacheFreeListPolicy::DbgFreeMemFill));
 #else
-            Assert(IsAll((char*)weakRefBytes, sizeof(cache->weakRefs), '\0'));
+            Assert(IsAll(weakRefBytes, sizeof(cache->weakRefs), 0));
 #endif
         }
 
@@ -1160,10 +1160,10 @@ void InlineCacheAllocator::CheckIsAllZero(bool lockdown)
             char* weakRefBytes = (char *)cache->weakRefs;
 
 #ifdef ARENA_MEMORY_VERIFY
-            Assert(IsAll((char*)weakRefBytes, sizeof(cache->weakRefs), '\0')
-                || IsAll((char*)weakRefBytes, sizeof(cache->weakRefs), InlineCacheFreeListPolicy::DbgFreeMemFill));
+            Assert(IsAll((byte*)weakRefBytes, sizeof(cache->weakRefs), 0)
+                || IsAll((byte*)weakRefBytes, sizeof(cache->weakRefs), InlineCacheFreeListPolicy::DbgFreeMemFill));
 #else
-            Assert(IsAll((char*)weakRefBytes, sizeof(cache->weakRefs), '\0'));
+            Assert(IsAll(weakRefBytes, sizeof(cache->weakRefs), 0));
 #endif
         }
         if (lockdown)
@@ -1184,10 +1184,10 @@ void InlineCacheAllocator::CheckIsAllZero(bool lockdown)
         {
             unsigned char* weakRefBytes = (unsigned char *)cache->weakRefs;
 #ifdef ARENA_MEMORY_VERIFY
-            Assert(IsAll((char*)weakRefBytes, sizeof(cache->weakRefs), '\0')
-                || IsAll((char*)weakRefBytes, sizeof(cache->weakRefs), InlineCacheFreeListPolicy::DbgFreeMemFill));
+            Assert(IsAll(weakRefBytes, sizeof(cache->weakRefs), 0)
+                || IsAll(weakRefBytes, sizeof(cache->weakRefs), InlineCacheFreeListPolicy::DbgFreeMemFill));
 #else
-            Assert(IsAll((char*)weakRefBytes, sizeof(cache->weakRefs), '\0'));
+            Assert(IsAll(weakRefBytes, sizeof(cache->weakRefs), 0));
 #endif
         }
 
@@ -1477,20 +1477,20 @@ void InlineCacheAllocator::CheckIsAllZero()
     BigBlock *blockp = this->bigBlocks;
     while (blockp != NULL)
     {
-        Assert(IsAll(blockp->GetBytes(), blockp->currentByte, '\0'));
+        Assert(IsAll((byte*)blockp->GetBytes(), blockp->currentByte, 0));
         blockp = blockp->nextBigBlock;
     }
     blockp = this->fullBlocks;
     while (blockp != NULL)
     {
-        Assert(IsAll(blockp->GetBytes(), blockp->currentByte, '\0'));
+        Assert(IsAll((byte*)blockp->GetBytes(), blockp->currentByte, 0));
         blockp = blockp->nextBigBlock;
     }
 
     ArenaMemoryBlock * memoryBlock = this->mallocBlocks;
     while (memoryBlock != nullptr)
     {
-        Assert(IsAll(memoryBlock->GetBytes(), memoryBlock->nbytes, '\0'));
+        Assert(IsAll((byte*)memoryBlock->GetBytes(), memoryBlock->nbytes, 0'));
         memoryBlock = memoryBlock->next;
     }
 }
@@ -1534,7 +1534,7 @@ void CacheAllocator::CheckIsAllZero(bool lockdown)
     BigBlock *blockp = this->bigBlocks;
     while (blockp != NULL)
     {
-        Assert(IsAll(blockp->GetBytes(), blockp->currentByte, '\0'));
+        Assert(IsAll((byte*)blockp->GetBytes(), blockp->currentByte, 0));
         if (lockdown)
         {
             DWORD oldProtect;
@@ -1546,7 +1546,7 @@ void CacheAllocator::CheckIsAllZero(bool lockdown)
     blockp = this->fullBlocks;
     while (blockp != NULL)
     {
-        Assert(IsAll(blockp->GetBytes(), blockp->currentByte, '\0'));
+        Assert(IsAll((byte*)blockp->GetBytes(), blockp->currentByte, 0));
         if (lockdown)
         {
             DWORD oldProtect;
@@ -1558,7 +1558,7 @@ void CacheAllocator::CheckIsAllZero(bool lockdown)
     ArenaMemoryBlock * memoryBlock = this->mallocBlocks;
     while (memoryBlock != nullptr)
     {
-        Assert(IsAll(memoryBlock->GetBytes(), memoryBlock->nbytes, '\0'));
+        Assert(IsAll((byte*)memoryBlock->GetBytes(), memoryBlock->nbytes, 0));
         if (lockdown)
         {
             DWORD oldProtect;
@@ -1645,10 +1645,8 @@ namespace Memory
     template class ArenaAllocatorBase<StandAloneFreeListPolicy>;
     template class ArenaAllocatorBase<InlineCacheAllocatorTraits>;
 
-#if DBG
-    bool IsAll(char* buffer, size_t size, char c)
+    bool IsAll(byte* buffer, size_t size, byte c)
     {
         return size == 0 || ((*buffer == c) && (size == 1 || memcmp(buffer, buffer + 1, size - 1) == 0));
     }
-#endif
 }

--- a/lib/Common/Memory/ArenaAllocator.h
+++ b/lib/Common/Memory/ArenaAllocator.h
@@ -664,9 +664,7 @@ private:
     bool AreFreeListBucketsEmpty();
 };
 
-#if DBG
-bool IsAll(char* buffer, size_t size, char c);
-#endif
+bool IsAll(byte* buffer, size_t size, byte c);
 
 class InlineCacheAllocator : public InlineCacheAllocatorInfo, public ArenaAllocatorBase<InlineCacheAllocatorTraits>
 {

--- a/lib/Common/Memory/HeapBlock.h
+++ b/lib/Common/Memory/HeapBlock.h
@@ -333,7 +333,7 @@ public:
     virtual BOOL IsValidObject(void* objectAddress) = 0;
 
     virtual byte* GetRealAddressFromInterior(void* interiorAddress) = 0;
-    virtual size_t GetObjectSize(void* object) = 0;
+    virtual size_t GetObjectSize(void* object) const = 0;
     virtual bool FindHeapObject(void* objectAddress, Recycler * recycler, FindHeapObjectFlags flags, RecyclerHeapObjectInfo& heapObject) = 0;
     virtual bool TestObjectMarkedBit(void* objectAddress) = 0;
     virtual void SetObjectMarkedBit(void* objectAddress) = 0;
@@ -521,7 +521,6 @@ public:
     uint GetObjectWordCount() const { return this->objectSize / sizeof(void *); }
     uint GetPageCount() const;
 
-    template<bool checkPageHeap=true>
     bool HasFreeObject() const
     {
         return freeObjectList != nullptr;
@@ -610,7 +609,7 @@ public:
     byte* GetRealAddressFromInterior(void* interiorAddress) override sealed;
     bool TestObjectMarkedBit(void* objectAddress) override sealed;
     void SetObjectMarkedBit(void* objectAddress) override;
-    virtual size_t GetObjectSize(void* object) override { return objectSize; }
+    virtual size_t GetObjectSize(void* object) const override { return objectSize; }
 
     uint GetMarkCountForSweep();
     SweepState Sweep(RecyclerSweep& recyclerSweep, bool queuePendingSweep, bool allocable, ushort finalizeCount = 0, bool hasPendingDispose = false);

--- a/lib/Common/Memory/HeapBucket.cpp
+++ b/lib/Common/Memory/HeapBucket.cpp
@@ -382,19 +382,32 @@ HeapBucketT<TBlockType>::TryAllocFromNewHeapBlock(Recycler * recycler, TBlockAll
     return memBlock;
 }
 
+Recycler *
+HeapBucket::GetRecycler() const
+{
+    return this->heapInfo->recycler;
+}
+
 #ifdef RECYCLER_PAGE_HEAP
 template <typename TBlockType>
 char *
-HeapBucketT<TBlockType>::PageHeapAlloc(Recycler * recycler, size_t sizeCat, size_t size, ObjectInfoBits attributes, PageHeapMode mode, bool nothrow)
+HeapBucketT<TBlockType>::PageHeapAlloc(Recycler * recycler, DECLSPEC_GUARD_OVERFLOW size_t sizeCat, size_t size, ObjectInfoBits attributes, PageHeapMode mode, bool nothrow)
 {
     AllocationVerboseTrace(recycler->GetRecyclerFlagsTable(), _u("In PageHeapAlloc [Size: 0x%x, Attributes: 0x%x]\n"), size, attributes);
-    return heapInfo->largeObjectBucket.PageHeapAlloc(recycler, sizeCat, size, attributes, mode, nothrow);
+    char* addr =  heapInfo->largeObjectBucket.PageHeapAlloc(recycler, sizeCat, size, attributes, mode, nothrow);
+
+    if (addr)
+    {
+        this->GetRecycler()->autoHeap.uncollectedAllocBytes += sizeCat;
+    }
+
+    return addr;
 }
 #endif
 
 template <typename TBlockType>
 char *
-HeapBucketT<TBlockType>::SnailAlloc(Recycler * recycler, TBlockAllocatorType * allocator, size_t sizeCat, size_t size, ObjectInfoBits attributes, bool nothrow)
+HeapBucketT<TBlockType>::SnailAlloc(Recycler * recycler, TBlockAllocatorType * allocator, DECLSPEC_GUARD_OVERFLOW size_t sizeCat, size_t size, ObjectInfoBits attributes, bool nothrow)
 {
     AllocationVerboseTrace(recycler->GetRecyclerFlagsTable(), _u("In SnailAlloc [Size: 0x%x, Attributes: 0x%x]\n"), sizeCat, attributes);
 

--- a/lib/Common/Memory/HeapBucket.h
+++ b/lib/Common/Memory/HeapBucket.h
@@ -20,8 +20,8 @@ public:
     // Temporary data for Sweep list consistency checks
     bool expectFull;
     bool expectDispose;
-    SmallHeapBlockT<TBlockAttributes> * nextAllocableBlockHead;
     bool hasSetupVerifyListConsistencyData;
+    SmallHeapBlockT<TBlockAttributes> * nextAllocableBlockHead;
 
     template <typename TBlockAttributes>
     void SetupVerifyListConsistencyData(SmallHeapBlockT<TBlockAttributes>* block, bool expectFull, bool expectDispose)
@@ -90,9 +90,7 @@ public:
         return isPageHeapEnabled && ((attributes & ClientTrackableObjectBits) == 0);
     }
 #endif
-#if DBG || defined(RECYCLER_SLOW_CHECK_ENABLED)
     Recycler * GetRecycler() const;
-#endif
 
     template <typename TBlockType>
     friend class SmallHeapBlockAllocator;

--- a/lib/Common/Memory/HeapBucket.inl
+++ b/lib/Common/Memory/HeapBucket.inl
@@ -75,12 +75,3 @@ HeapBucketT<TBlockType>::ExplicitFree(void* object, size_t sizeCat)
     // Don't fill memory fill pattern here since we're still pretending like the object
     // is allocated to other parts of the GC.
 }
-
-#if DBG || defined(RECYCLER_SLOW_CHECK_ENABLED)
-inline
-Recycler *
-HeapBucket::GetRecycler() const
-{
-    return this->heapInfo->recycler;
-}
-#endif

--- a/lib/Common/Memory/LargeHeapBlock.cpp
+++ b/lib/Common/Memory/LargeHeapBlock.cpp
@@ -9,7 +9,7 @@ CompileAssert(
     sizeof(LargeObjectHeader) == HeapConstants::ObjectGranularity * 2);
 
 #ifdef STACK_BACK_TRACE
-const StackBackTrace* LargeHeapBlock::s_StackTraceAllocFailed = (StackBackTrace*)1;
+const StackBackTrace* PageHeapData::s_StackTraceAllocFailed = (StackBackTrace*)1;
 #endif
 
 void *
@@ -142,7 +142,7 @@ LargeObjectHeader::GetAttributes(uint cookie)
 }
 
 size_t
-LargeHeapBlock::GetAllocPlusSize(uint objectCount)
+LargeHeapBlock::GetAllocPlusSize(DECLSPEC_GUARD_OVERFLOW uint objectCount)
 {
     // Large Heap Block Layout:
     //      LargeHeapBlock
@@ -159,7 +159,7 @@ LargeHeapBlock::GetAllocPlusSize(uint objectCount)
 }
 
 LargeHeapBlock *
-LargeHeapBlock::New(__in char * address, size_t pageCount, Segment * segment, uint objectCount, LargeHeapBucket* bucket)
+LargeHeapBlock::New(__in char * address, DECLSPEC_GUARD_OVERFLOW size_t pageCount, Segment * segment, DECLSPEC_GUARD_OVERFLOW uint objectCount, LargeHeapBucket* bucket)
 {
     return NoMemProtectHeapNewNoThrowPlusZ(GetAllocPlusSize(objectCount), LargeHeapBlock, address, pageCount, segment, objectCount, bucket);
 }
@@ -172,9 +172,6 @@ LargeHeapBlock::Delete(LargeHeapBlock * heapBlock)
 
 LargeHeapBlock::LargeHeapBlock(__in char * address, size_t pageCount, Segment * segment, uint objectCount, LargeHeapBucket* bucket)
     : HeapBlock(LargeBlockType), pageCount(pageCount), allocAddressEnd(address), objectCount(objectCount), bucket(bucket), freeList(this)
-#if defined(RECYCLER_PAGE_HEAP) && defined(STACK_BACK_TRACE)
-    , pageHeapAllocStack(nullptr), pageHeapFreeStack(nullptr)
-#endif
 #if DBG && GLOBAL_ENABLE_WRITE_BARRIER
     ,wbVerifyBits(&HeapAllocator::Instance)
 #endif
@@ -204,10 +201,22 @@ LargeHeapBlock::~LargeHeapBlock()
         "ReleasePages needs to be called before delete");
     RECYCLER_PERF_COUNTER_DEC(LargeHeapBlockCount);
 
-#if defined(RECYCLER_PAGE_HEAP) && defined(STACK_BACK_TRACE)
+#ifdef RECYCLER_PAGE_HEAP
+    if (pageHeapData)
+    {
+        NoMemProtectHeapDelete(pageHeapData);
+        pageHeapData = nullptr;
+    }
+#endif
+}
+
+#ifdef RECYCLER_PAGE_HEAP
+PageHeapData::~PageHeapData()
+{
+#ifdef STACK_BACK_TRACE
     if (this->pageHeapAllocStack != nullptr)
     {
-        if (this->pageHeapAllocStack != s_StackTraceAllocFailed)
+        if (this->pageHeapAllocStack != PageHeapData::s_StackTraceAllocFailed)
         {
             this->pageHeapAllocStack->Delete(&NoThrowHeapAllocator::Instance);
         }
@@ -223,6 +232,7 @@ LargeHeapBlock::~LargeHeapBlock()
     }
 #endif
 }
+#endif
 
 Recycler *
 LargeHeapBlock::GetRecycler() const
@@ -231,7 +241,7 @@ LargeHeapBlock::GetRecycler() const
 }
 
 LargeObjectHeader **
-LargeHeapBlock::HeaderList()
+LargeHeapBlock::HeaderList() const
 {
     // See LargeHeapBlock::GetAllocPlusSize for layout description
     return (LargeObjectHeader **)(((byte *)this) + sizeof(LargeHeapBlock));
@@ -245,7 +255,7 @@ LargeHeapBlock::FinalizeAllObjects()
         DebugOnly(uint processedCount = 0);
         for (uint i = 0; i < allocCount; i++)
         {
-            LargeObjectHeader * header = this->GetHeader(i);
+            LargeObjectHeader * header = this->GetHeaderByIndex(i);
             if (header == nullptr || ((header->GetAttributes(this->heapInfo->recycler->Cookie) & FinalizeBit) == 0))
             {
                 continue;
@@ -305,21 +315,17 @@ LargeHeapBlock::ReleasePagesSweep(Recycler * recycler)
 _NOINLINE
 void LargeHeapBlock::VerifyPageHeapPattern()
 {
-    Assert(InPageHeapMode());
-    Assert(this->allocCount > 0);
-    byte* objectEndAddress = (byte*)this->allocAddressEnd;
-    byte* addrEnd = (byte*)this->addressEnd;
-
-    for (int i = 0; objectEndAddress + i < (byte*)addrEnd; i++)
+    if (!IsAll((byte*)pageHeapData->objectPageAddr, pageHeapData->paddingBytes, PageHeapMemFill))
     {
-        byte current = objectEndAddress[i];
-        if (current != 0xF0u)
-        {
-            Assert(false);
-            ReportFatalException(NULL, E_FAIL, Fatal_Recycler_MemoryCorruption, 2);
-        }
+        Assert(false);
+        ReportFatalException(NULL, E_FAIL, Fatal_Recycler_MemoryCorruption, 2);
     }
 
+    if (!IsAll((byte*)pageHeapData->objectEndAddr, pageHeapData->unusedBytes, PageHeapMemFill))
+    {
+        Assert(false);
+        ReportFatalException(NULL, E_FAIL, Fatal_Recycler_MemoryCorruption, 2);
+    }
 }
 #endif
 
@@ -328,41 +334,55 @@ LargeHeapBlock::ReleasePages(Recycler * recycler)
 {
     Assert(segment != nullptr);
 
+    IdleDecommitPageAllocator* pageAllocator = recycler->GetRecyclerLargeBlockPageAllocator();
     char* blockStartAddress = this->address;
     size_t realPageCount = this->pageCount;
 #ifdef RECYCLER_PAGE_HEAP
     if (InPageHeapMode())
     {
-        Assert(((LargeObjectHeader*)this->address)->isPageHeapFillVerified || this->allocCount == 0);
-        if (this->allocCount > 0) // in case OOM while adding heapblock to heapBlockMap, we release page before setting the pattern
-        {
-            Assert(this->allocCount == 1); // one object per heapblock in pageheap
-            VerifyPageHeapPattern();
-        }
+        size_t guardPageCount = pageHeapData->actualPageCount - this->pageCount;
+        realPageCount = pageHeapData->actualPageCount;
 
-        if (guardPageAddress != nullptr)
+        if (pageHeapData->isGuardPageDecommited)
         {
-            if (this->pageHeapMode == PageHeapMode::PageHeapModeBlockStart)
+            void* addr = nullptr;
+#ifdef RECYCLER_NO_PAGE_REUSE
+            if (!pageAllocator->IsPageReuseDisabled())
+#endif
             {
-                blockStartAddress = guardPageAddress;
+                addr = VirtualAlloc(pageHeapData->guardPageAddress, AutoSystemInfo::PageSize * guardPageCount, MEM_COMMIT, PAGE_READWRITE);
             }
-            realPageCount = this->actualPageCount;
-            size_t guardPageCount = this->actualPageCount - this->pageCount;
 
+            if (addr != pageHeapData->guardPageAddress // failed to re-commit guard page
+#ifdef RECYCLER_NO_PAGE_REUSE
+                || pageAllocator->IsPageReuseDisabled()
+#endif
+                )
+            {
+                VirtualFree((char*)pageHeapData->objectPageAddr, this->pageCount* AutoSystemInfo::PageSize, MEM_DECOMMIT);
+                RECYCLER_PERF_COUNTER_SUB(LargeHeapBlockPageSize, pageCount * AutoSystemInfo::PageSize);
+                this->segment = nullptr;
+                return;
+            }
+        }
+        else
+        {
             DWORD oldProtect;
-            BOOL ret = ::VirtualProtect(guardPageAddress, AutoSystemInfo::PageSize * guardPageCount, PAGE_READWRITE, &oldProtect);
+            BOOL ret = ::VirtualProtect(pageHeapData->guardPageAddress, AutoSystemInfo::PageSize * guardPageCount, PAGE_READWRITE, &oldProtect);
             Assert(ret && oldProtect == PAGE_NOACCESS);
         }
+
+        blockStartAddress = pageHeapData->pageHeapMode == PageHeapMode::PageHeapModeBlockStart ?
+            pageHeapData->guardPageAddress : pageHeapData->objectPageAddr;
+
     }
 #endif
 
 #ifdef RECYCLER_FREE_MEM_FILL
-    memset(this->address, DbgMemFill, AutoSystemInfo::PageSize * pageCount);
+    memset(blockStartAddress, DbgMemFill, AutoSystemInfo::PageSize * realPageCount);
 #endif
-    IdleDecommitPageAllocator* pageAllocator = recycler->GetRecyclerLargeBlockPageAllocator();
     pageAllocator->Release(blockStartAddress, realPageCount, segment);
     RECYCLER_PERF_COUNTER_SUB(LargeHeapBlockPageSize, pageCount * AutoSystemInfo::PageSize);
-
     this->segment = nullptr;
 }
 
@@ -378,7 +398,7 @@ BOOL
 LargeHeapBlock::IsFreeObject(void * objectAddress)
 {
     LargeObjectHeader * header = GetHeader(objectAddress);
-    return ((char *)header >= this->address && header->objectIndex < this->allocCount && this->GetHeader(header->objectIndex) == nullptr);
+    return ((char *)header >= this->address && header->objectIndex < this->allocCount && this->GetHeaderByIndex(header->objectIndex) == nullptr);
 }
 #endif
 
@@ -410,17 +430,12 @@ LargeHeapBlock::TryGetAttributes(LargeObjectHeader * header, unsigned char * pAt
         return false;
     }
 
-    if (this->InPageHeapMode())
-    {
-        this->VerifyPageHeapPattern();
-    }
-
     *pAttr = header->GetAttributes(this->heapInfo->recycler->Cookie);
     return true;
 }
 
 size_t
-LargeHeapBlock::GetPagesNeeded(size_t size, bool multiplyRequest)
+LargeHeapBlock::GetPagesNeeded(DECLSPEC_GUARD_OVERFLOW size_t size, bool multiplyRequest)
 {
     if (multiplyRequest)
     {
@@ -438,7 +453,7 @@ LargeHeapBlock::GetPagesNeeded(size_t size, bool multiplyRequest)
 }
 
 char*
-LargeHeapBlock::TryAllocFromFreeList(size_t size, ObjectInfoBits attributes)
+LargeHeapBlock::TryAllocFromFreeList(DECLSPEC_GUARD_OVERFLOW size_t size, ObjectInfoBits attributes)
 {
     Assert((attributes & InternalObjectInfoBitMask) == attributes);
 
@@ -477,7 +492,7 @@ LargeHeapBlock::TryAllocFromFreeList(size_t size, ObjectInfoBits attributes)
 }
 
 char*
-LargeHeapBlock::AllocFreeListEntry(size_t size, ObjectInfoBits attributes, LargeHeapBlockFreeListEntry* entry)
+LargeHeapBlock::AllocFreeListEntry(DECLSPEC_GUARD_OVERFLOW size_t size, ObjectInfoBits attributes, LargeHeapBlockFreeListEntry* entry)
 {
     Assert((attributes & InternalObjectInfoBitMask) == attributes);
     Assert(HeapInfo::IsAlignedSize(size));
@@ -548,7 +563,7 @@ LargeHeapBlock::AllocFreeListEntry(size_t size, ObjectInfoBits attributes, Large
 }
 
 char*
-LargeHeapBlock::Alloc(size_t size, ObjectInfoBits attributes)
+LargeHeapBlock::Alloc(DECLSPEC_GUARD_OVERFLOW size_t size, ObjectInfoBits attributes)
 {
     Assert(HeapInfo::IsAlignedSize(size) || InPageHeapMode());
     Assert((attributes & InternalObjectInfoBitMask) == attributes);
@@ -620,7 +635,9 @@ LargeHeapBlock::Mark(void* objectAddress, MarkContext * markContext)
 
     size_t objectSize = header->objectSize;
     if (this->InPageHeapMode())
-    {
+    {        
+        this->VerifyPageHeapPattern();
+
         // trim off the trailing part which is not a pointer
         objectSize = HeapInfo::RoundObjectSize(objectSize);
         if (objectSize == 0)
@@ -629,10 +646,18 @@ LargeHeapBlock::Mark(void* objectAddress, MarkContext * markContext)
             Assert((attributes & FinalizeBit) == 0);
             return;
         }
+#if DBG
+        this->pageHeapData->lastMarkedBy = markContext->parentRef ? (char*)markContext->parentRef : "root";
+#endif
     }
 
-    if (!UpdateAttributesOfMarkedObjects<doSpecialMark>(markContext, objectAddress, objectSize, attributes,
-        [&](unsigned char attributes) { header->SetAttributes(this->heapInfo->recycler->Cookie, attributes); }))
+    bool markSucceed = UpdateAttributesOfMarkedObjects<doSpecialMark>(markContext, objectAddress, objectSize, attributes,
+        [&](unsigned char attributes)
+            {
+                header->SetAttributes(this->heapInfo->recycler->Cookie, attributes);
+            });
+
+    if (!markSucceed)
     {
         // Couldn't mark children- bail out and come back later
         this->SetNeedOOMRescan(markContext->GetRecycler());
@@ -640,9 +665,14 @@ LargeHeapBlock::Mark(void* objectAddress, MarkContext * markContext)
         // Single page large heap block rescan all marked object on oom rescan
         if (this->GetPageCount() != 1)
         {
-            // Failed to mark the objects referenced by this object, so we'll
-            // revisit this on rescan
-            header->markOnOOMRescan = true;
+#ifdef RECYCLER_PAGE_HEAP
+            if (!header->isObjectPageLocked)
+#endif
+            {
+                // Failed to mark the objects referenced by this object, so we'll
+                // revisit this on rescan
+                header->markOnOOMRescan = true;
+            }
         }
     }
 }
@@ -756,7 +786,7 @@ LargeHeapBlock::ResetMarks(ResetMarkFlags flags, Recycler* recycler)
         for (uint objectIndex = 0; objectIndex < allocCount; objectIndex++)
         {
             // object is allocated during the concurrent mark or it is marked, do rescan
-            LargeObjectHeader * header = this->GetHeader(objectIndex);
+            LargeObjectHeader * header = this->GetHeaderByIndex(objectIndex);
             // check if the object index is not allocated
             if (header == nullptr)
             {
@@ -773,10 +803,23 @@ LargeHeapBlock::ResetMarks(ResetMarkFlags flags, Recycler* recycler)
 }
 
 LargeObjectHeader *
-LargeHeapBlock::GetHeader(void * objectAddress)
+LargeHeapBlock::GetHeader(void * objectAddress) const
 {
-    Assert(objectAddress >= this->address && objectAddress < this->addressEnd);
-    return GetHeaderFromAddress(objectAddress);
+    LargeObjectHeader * header = nullptr;
+    if (this->InPageHeapMode())
+    {
+        header = (LargeObjectHeader*)this->address;
+        if ((char*)objectAddress - (char*)header != sizeof(LargeObjectHeader))
+        {
+            header = nullptr;
+        }
+    }
+    else
+    {
+        Assert(objectAddress >= this->address && objectAddress < this->addressEnd);
+        header = GetHeaderFromAddress(objectAddress);
+    }
+    return header;
 }
 
 LargeObjectHeader *
@@ -820,7 +863,7 @@ LargeHeapBlock::VerifyMark()
 
     for (uint i = 0; i < allocCount; i++)
     {
-        LargeObjectHeader * header = this->GetHeader(i);
+        LargeObjectHeader * header = this->GetHeaderByIndex(i);
         if (header == nullptr)
         {
             continue;
@@ -914,7 +957,7 @@ LargeHeapBlock::ScanInitialImplicitRoots(Recycler * recycler)
     for (uint objectIndex = 0; objectIndex < allocCount; objectIndex++)
     {
         // object is allocated during the concurrent mark or it is marked, do rescan
-        LargeObjectHeader * header = this->GetHeader(objectIndex);
+        LargeObjectHeader * header = this->GetHeaderByIndex(objectIndex);
         // check if the object index is not allocated
         if (header == nullptr)
         {
@@ -965,7 +1008,7 @@ LargeHeapBlock::ScanNewImplicitRoots(Recycler * recycler)
     while (objectIndex < allocCount)
     {
         // object is allocated during the concurrent mark or it is marked, do rescan
-        LargeObjectHeader * header = this->GetHeader(objectIndex);
+        LargeObjectHeader * header = this->GetHeaderByIndex(objectIndex);
         objectIndex++;
 
         // check if the object index is not allocated
@@ -1074,8 +1117,12 @@ LargeHeapBlock::RescanOnePage(Recycler * recycler)
 
         // Check the write watch bit to see if we need to rescan
         // REVIEW: large object size if bigger than one page, to use header index 0 here should be OK
-        LargeObjectHeader* header = this->GetHeader(0u);
-        if ((header->GetAttributes(this->heapInfo->recycler->Cookie) & LeafBit) == LeafBit)
+        LargeObjectHeader* header = this->GetHeaderByIndex(0);
+        if (header == nullptr) // not allocated or it's pending dispose or disposed
+        {
+            return false;
+        }
+        if((header->GetAttributes(this->heapInfo->recycler->Cookie) & LeafBit) == LeafBit)
         {
             return false;
         }
@@ -1098,7 +1145,7 @@ LargeHeapBlock::RescanOnePage(Recycler * recycler)
     for (uint objectIndex = 0; objectIndex < allocCount; objectIndex++)
     {
         // object is allocated during the concurrent mark or it is marked, do rescan
-        LargeObjectHeader * header = this->GetHeader(objectIndex);
+        LargeObjectHeader * header = this->GetHeaderByIndex(objectIndex);
 
         // check if the object index is not allocated
         if (header == nullptr)
@@ -1205,7 +1252,7 @@ LargeHeapBlock::RescanMultiPage(Recycler * recycler)
     while (objectIndex < allocCount)
     {
         // object is allocated during the concurrent mark or it is marked, do rescan
-        LargeObjectHeader * header = this->GetHeader(objectIndex);
+        LargeObjectHeader * header = this->GetHeaderByIndex(objectIndex);
         objectIndex++;
 
         // check if the object index is not allocated
@@ -1260,7 +1307,12 @@ LargeHeapBlock::RescanMultiPage(Recycler * recycler)
             if (!recycler->AddMark(objectAddress, objectSize))
             {
                 this->SetNeedOOMRescan(recycler);
-                header->markOnOOMRescan = true;
+#ifdef RECYCLER_PAGE_HEAP
+                if (!header->isObjectPageLocked)
+#endif
+                {
+                    header->markOnOOMRescan = true;
+                }
 
                 // We need to bail out of rescan early only if the recycler is
                 // trying to finish marking because of low memory. If this is
@@ -1278,7 +1330,12 @@ LargeHeapBlock::RescanMultiPage(Recycler * recycler)
 
                 return rescanCount;
             }
-            header->markOnOOMRescan = false;
+#ifdef RECYCLER_PAGE_HEAP
+            if (!header->isObjectPageLocked)
+#endif
+            {
+                header->markOnOOMRescan = false;
+            }
 #ifdef RECYCLER_STATS
             objectScanned = true;
 #endif
@@ -1332,7 +1389,12 @@ LargeHeapBlock::RescanMultiPage(Recycler * recycler)
                 if (!recycler->AddMark(objectAddress, (checkEnd - objectAddress)))
                 {
                     this->SetNeedOOMRescan(recycler);
-                    header->markOnOOMRescan = true;
+#ifdef RECYCLER_PAGE_HEAP
+                    if (!header->isObjectPageLocked)
+#endif
+                    {
+                        header->markOnOOMRescan = true;
+                    }
                 }
 
 #ifdef RECYCLER_STATS
@@ -1657,7 +1719,7 @@ void LargeHeapBlock::FinalizeObjects(Recycler* recycler)
 
     for (uint i = 0; i < this->lastCollectAllocCount; i++)
     {
-        LargeObjectHeader * header = this->GetHeader(i);
+        LargeObjectHeader * header = this->GetHeaderByIndex(i);
         if (header == nullptr)
         {
             continue;
@@ -1706,7 +1768,7 @@ LargeHeapBlock::SweepObjects(Recycler * recycler)
     for (uint i = 0; i < lastCollectAllocCount; i++)
     {
         RECYCLER_STATS_ADD(recycler, objectSweepScanCount, !isForceSweeping);
-        LargeObjectHeader * header = this->GetHeader(i);
+        LargeObjectHeader * header = this->GetHeaderByIndex(i);
         if (header == nullptr)
         {
 #if DBG
@@ -1728,7 +1790,7 @@ LargeHeapBlock::SweepObjects(Recycler * recycler)
             Assert((header->GetAttributes(recycler->Cookie) & NewFinalizeBit) == 0);
 #endif
 
-            RECYCLER_STATS_ADD(recycler, largeHeapBlockUsedByteCount, this->GetHeader(i)->objectSize);
+            RECYCLER_STATS_ADD(recycler, largeHeapBlockUsedByteCount, this->GetHeaderByIndex(i)->objectSize);
             continue;
         }
 
@@ -1848,7 +1910,7 @@ LargeHeapBlock::EnumerateObjects(ObjectInfoBits infoBits, void (*CallBackFunctio
 {
     for (uint i = 0; i < allocCount; i++)
     {
-        LargeObjectHeader * header = this->GetHeader(i);
+        LargeObjectHeader * header = this->GetHeaderByIndex(i);
         if (header == nullptr)
         {
             continue;
@@ -1895,20 +1957,42 @@ void LargeHeapBlock::FillFreeMemory(Recycler * recycler, __in_bcount(size) void 
 {
     // For now, we don't do anything in release build because we don't reuse this memory until we return
     // the pages to the allocator which will zero out the whole page
+    byte memFill = 0;
+    bool doMemFill = false;
+
+#ifdef RECYCLER_FREE_MEM_FILL
+    memFill = DbgMemFill;
+    doMemFill = true;
+#endif
 
 #ifdef RECYCLER_MEMORY_VERIFY
     if (recycler->VerifyEnabled())
     {
-        memset(address, Recycler::VerifyMemFill, size);
-        return;
+        memFill = Recycler::VerifyMemFill;
+        doMemFill = true;
     }
 #endif
-#ifdef RECYCLER_FREE_MEM_FILL
-    memset(address, DbgMemFill, size);
+
+#if defined(RECYCLER_FREE_MEM_FILL) || defined(RECYCLER_MEMORY_VERIFY)
+    if (doMemFill)
+    {
+        if (this->InPageHeapMode() && pageHeapData->isLockedWithPageHeap) 
+        {
+            PageHeapUnLockPages();
+        }
+        memset(address, memFill, size);
+    }
+#endif
+
+#if defined(RECYCLER_NO_PAGE_REUSE)
+    if (this->InPageHeapMode() && this->GetPageAllocator(this->GetRecycler())->IsPageReuseDisabled())
+    {
+        this->PageHeapLockPages();
+    }
 #endif
 }
 
-size_t LargeHeapBlock::GetObjectSize(void* objectAddress)
+size_t LargeHeapBlock::GetObjectSize(void* objectAddress) const
 {
     LargeObjectHeader * header = GetHeader(objectAddress);
 
@@ -2047,6 +2131,44 @@ LargeHeapBlock::GetTrackerDataArray()
 #endif
 
 #ifdef RECYCLER_PAGE_HEAP
+void 
+LargeHeapBlock::PageHeapLockPages()
+{
+    if (!pageHeapData->isLockedWithPageHeap)
+    {
+        if (this->allocCount > 0) // in case OOM while adding heapblock to heapBlockMap, we release page before setting the pattern
+        {
+            Assert(this->allocCount == 1); // one object per heapblock in pageheap
+            VerifyPageHeapPattern();
+        }
+
+        DWORD oldProtect;
+        GetHeaderFromAddress(pageHeapData->objectAddress)->isObjectPageLocked = true;
+        if (VirtualProtect(pageHeapData->objectPageAddr, this->pageCount * AutoSystemInfo::PageSize, PAGE_READONLY, &oldProtect))
+        {
+            pageHeapData->isLockedWithPageHeap = true;
+        }
+        else
+        {
+            GetHeaderFromAddress(pageHeapData->objectAddress)->isObjectPageLocked = false;
+        }
+    }
+}
+
+void
+LargeHeapBlock::PageHeapUnLockPages()
+{
+    if (pageHeapData->isLockedWithPageHeap)
+    {
+        DWORD oldProtect;
+        if (VirtualProtect(pageHeapData->objectPageAddr, this->pageCount * AutoSystemInfo::PageSize, PAGE_READWRITE, &oldProtect))
+        {
+            pageHeapData->isLockedWithPageHeap = false;
+            GetHeaderFromAddress(pageHeapData->objectAddress)->isObjectPageLocked = false;
+        }
+    }
+}
+
 void
 LargeHeapBlock::CapturePageHeapAllocStack()
 {
@@ -2055,24 +2177,24 @@ LargeHeapBlock::CapturePageHeapAllocStack()
     {
         // These asserts are true because explicit free is disallowed in
         // page heap mode. If they weren't, we'd have to modify the asserts
-        Assert(this->pageHeapFreeStack == nullptr);
-        Assert(this->pageHeapAllocStack == nullptr);
+        Assert(this->pageHeapData->pageHeapFreeStack == nullptr);
+        Assert(this->pageHeapData->pageHeapAllocStack == nullptr);
 
         // Note: NoCheckHeapAllocator will fail fast if we can't allocate the stack to capture
         // REVIEW: Should we have a flag to configure the number of frames captured?
-        if (pageHeapAllocStack != nullptr && this->pageHeapAllocStack != s_StackTraceAllocFailed)
+        if (pageHeapData->pageHeapAllocStack != nullptr && this->pageHeapData->pageHeapAllocStack != PageHeapData::s_StackTraceAllocFailed)
         {
-            this->pageHeapAllocStack->Capture(Recycler::s_numFramesToSkipForPageHeapAlloc);
+            this->pageHeapData->pageHeapAllocStack->Capture(Recycler::s_numFramesToSkipForPageHeapAlloc);
         }
         else
         {
-            this->pageHeapAllocStack = StackBackTrace::Capture(&NoThrowHeapAllocator::Instance,
+            this->pageHeapData->pageHeapAllocStack = StackBackTrace::Capture(&NoThrowHeapAllocator::Instance,
                 Recycler::s_numFramesToSkipForPageHeapAlloc, Recycler::s_numFramesToCaptureForPageHeap);
         }
 
-        if (this->pageHeapAllocStack == nullptr)
+        if (this->pageHeapData->pageHeapAllocStack == nullptr)
         {
-            this->pageHeapAllocStack = const_cast<StackBackTrace*>(s_StackTraceAllocFailed); // allocate failed, mark it we have tried
+            this->pageHeapData->pageHeapAllocStack = const_cast<StackBackTrace*>(PageHeapData::s_StackTraceAllocFailed); // allocate failed, mark it we have tried
         }
     }
 #endif
@@ -2086,16 +2208,16 @@ LargeHeapBlock::CapturePageHeapFreeStack()
     {
         // These asserts are true because explicit free is disallowed in
         // page heap mode. If they weren't, we'd have to modify the asserts
-        Assert(this->pageHeapFreeStack == nullptr);
-        Assert(this->pageHeapAllocStack != nullptr);
+        Assert(this->pageHeapData->pageHeapFreeStack == nullptr);
+        Assert(this->pageHeapData->pageHeapAllocStack != nullptr);
 
-        if (this->pageHeapFreeStack != nullptr)
+        if (this->pageHeapData->pageHeapFreeStack != nullptr)
         {
-            this->pageHeapFreeStack->Capture(Recycler::s_numFramesToSkipForPageHeapFree);
+            this->pageHeapData->pageHeapFreeStack->Capture(Recycler::s_numFramesToSkipForPageHeapFree);
         }
         else
         {
-            this->pageHeapFreeStack = StackBackTrace::Capture(&NoThrowHeapAllocator::Instance,
+            this->pageHeapData->pageHeapFreeStack = StackBackTrace::Capture(&NoThrowHeapAllocator::Instance,
                 Recycler::s_numFramesToSkipForPageHeapFree, Recycler::s_numFramesToCaptureForPageHeap);
         }
     }

--- a/lib/Common/Memory/LargeHeapBlock.cpp
+++ b/lib/Common/Memory/LargeHeapBlock.cpp
@@ -359,6 +359,7 @@ LargeHeapBlock::ReleasePages(Recycler * recycler)
 #endif
                 )
             {
+#pragma prefast(suppress:6250, "Calling 'VirtualFree' without the MEM_RELEASE flag might free memory but not address descriptors (VADs).")
                 VirtualFree((char*)pageHeapData->objectPageAddr, this->pageCount* AutoSystemInfo::PageSize, MEM_DECOMMIT);
                 RECYCLER_PERF_COUNTER_SUB(LargeHeapBlockPageSize, pageCount * AutoSystemInfo::PageSize);
                 this->segment = nullptr;

--- a/lib/Common/Memory/LargeHeapBlock.h
+++ b/lib/Common/Memory/LargeHeapBlock.h
@@ -29,15 +29,16 @@ private:
 #endif
 
 public:
-    bool markOnOOMRescan:1;
+    bool markOnOOMRescan : 1;
 #ifdef RECYCLER_WRITE_BARRIER
-    bool hasWriteBarrier:1;
+    bool hasWriteBarrier : 1;
+#endif
+#ifdef RECYCLER_PAGE_HEAP
+    bool isObjectPageLocked : 1;
 #endif
 #if DBG
-    bool isExplicitFreed:1;
-    bool isPageHeapFillVerified:1;
+    bool isExplicitFreed : 1;
 #endif
-
     UINT_PAD_64BIT(unused4);
 
     void *GetAddress();
@@ -90,9 +91,34 @@ public:
 
 class HeapInfo;
 
+#ifdef RECYCLER_PAGE_HEAP
+struct PageHeapData
+{
+    ~PageHeapData();
+    bool isLockedWithPageHeap;
+    bool isGuardPageDecommited;
+    PageHeapMode pageHeapMode;
+
+    uint actualPageCount;
+    ushort paddingBytes;
+    ushort unusedBytes;
+    char* guardPageAddress;
+    char* objectAddress;
+    char* objectEndAddr;
+    char* objectPageAddr;    
+    char* lastMarkedBy;
+#ifdef STACK_BACK_TRACE
+    StackBackTrace* pageHeapAllocStack;
+    StackBackTrace* pageHeapFreeStack;
+    const static StackBackTrace* s_StackTraceAllocFailed;
+#endif
+};
+#endif
+
 // CONSIDER: Templatizing this so that we don't have free list support if we don't need it
 class LargeHeapBlock sealed : public HeapBlock
 {
+    friend class HeapInfo;
 public:
     Recycler * GetRecycler() const;
 
@@ -107,7 +133,7 @@ public:
     bool TestObjectMarkedBit(void* objectAddress) override;
     void SetObjectMarkedBit(void* objectAddress) override;
     bool FindHeapObject(void* objectAddress, Recycler * recycler, FindHeapObjectFlags flags, RecyclerHeapObjectInfo& heapObject) override;
-    virtual size_t GetObjectSize(void* object) override;
+    virtual size_t GetObjectSize(void* object) const override;
     bool FindImplicitRootObject(void* objectAddress, Recycler * recycler, RecyclerHeapObjectInfo& heapObject);
 
     size_t GetPageCount() const { return pageCount; }
@@ -131,9 +157,6 @@ public:
 #if ENABLE_PARTIAL_GC && ENABLE_CONCURRENT_GC
     void PartialTransferSweptObjects();
     void FinishPartialCollect(Recycler * recycler);
-#endif
-#ifdef RECYCLER_PAGE_HEAP
-    void VerifyPageHeapPattern();
 #endif
     void ReleasePages(Recycler * recycler);
     void ReleasePagesSweep(Recycler * recycler);
@@ -188,9 +211,9 @@ private:
 
     LargeHeapBlock(__in char * address, DECLSPEC_GUARD_OVERFLOW size_t pageCount, Segment * segment, DECLSPEC_GUARD_OVERFLOW uint objectCount, LargeHeapBucket* bucket);
     static LargeObjectHeader * GetHeaderFromAddress(void * address);
-    LargeObjectHeader * GetHeader(void * address);
-    LargeObjectHeader ** HeaderList();
-    LargeObjectHeader * GetHeader(uint index)
+    LargeObjectHeader * GetHeader(void * address) const;
+    LargeObjectHeader ** HeaderList() const;
+    LargeObjectHeader * GetHeaderByIndex(uint index) const
     {
         Assert(index < this->allocCount);
         LargeObjectHeader * header = this->HeaderList()[index];
@@ -235,7 +258,6 @@ private:
     static const size_t PartialFreeBit = 0x1;
 #endif
     size_t pageCount;
-    size_t actualPageCount;
 
     // The number of allocations that have occurred from this heap block
     // This only increases, never decreases. Instead, we rely on the mark/weakRef/finalize counts
@@ -261,44 +283,36 @@ private:
     LargeObjectHeader * pendingDisposeObject;
 
     LargeHeapBucket* bucket;
+    HeapInfo * heapInfo;
     LargeHeapBlockFreeList freeList;
 
-    uint lastCollectAllocCount;
-    uint finalizeCount;
-
-    bool isInPendingDisposeList;
-
 #ifdef RECYCLER_PAGE_HEAP
-    PageHeapMode pageHeapMode;
-    char* guardPageAddress;
-#ifdef STACK_BACK_TRACE
-    StackBackTrace* pageHeapAllocStack;
-    StackBackTrace* pageHeapFreeStack;
-#endif
-    
+    PageHeapData* pageHeapData;
 public:
-    inline bool InPageHeapMode() const { return pageHeapMode != PageHeapMode::PageHeapModeOff; }
+    void VerifyPageHeapPattern();
+    inline bool InPageHeapMode() const { return pageHeapData != nullptr && pageHeapData->pageHeapMode != PageHeapMode::PageHeapModeOff; }
+    PageHeapData* GetPageHeapData() { return pageHeapData; }
+    void PageHeapLockPages();
+    void PageHeapUnLockPages();
 
     void CapturePageHeapAllocStack();
     void CapturePageHeapFreeStack();
-#ifdef STACK_BACK_TRACE
-    const static StackBackTrace* s_StackTraceAllocFailed;
 #endif
-#endif
+
+    uint lastCollectAllocCount;
+    uint finalizeCount;
+    bool isInPendingDisposeList;
 
 #if DBG
     bool hasDisposeBeenCalled;
     bool hasPartialFreeObjects;
-    uint expectedSweepCount;
-
     // The following get set if an object is swept and we freed its pages
     bool hadTrimmed;
+    uint expectedSweepCount;
 #endif
 #ifdef ENABLE_DEBUG_CONFIG_OPTIONS
     friend class ::ScriptMemoryDumper;
 #endif
-    friend class HeapInfo;
-    HeapInfo * heapInfo;
 #ifdef PROFILE_RECYCLER_ALLOC
     void ** GetTrackerDataArray();
 #endif

--- a/lib/Common/Memory/LargeHeapBlock.h
+++ b/lib/Common/Memory/LargeHeapBlock.h
@@ -106,7 +106,7 @@ struct PageHeapData
     char* objectAddress;
     char* objectEndAddr;
     char* objectPageAddr;    
-    char* lastMarkedBy;
+    const char* lastMarkedBy;
 #ifdef STACK_BACK_TRACE
     StackBackTrace* pageHeapAllocStack;
     StackBackTrace* pageHeapFreeStack;

--- a/lib/Common/Memory/LargeHeapBucket.cpp
+++ b/lib/Common/Memory/LargeHeapBucket.cpp
@@ -110,90 +110,162 @@ LargeHeapBucket::SnailAlloc(Recycler * recycler, size_t sizeCat, size_t size, Ob
 char*
 LargeHeapBucket::PageHeapAlloc(Recycler * recycler, size_t sizeCat, size_t size, ObjectInfoBits attributes, PageHeapMode mode, bool nothrow)
 {
-    Segment * segment;
-    size_t pageCount = LargeHeapBlock::GetPagesNeeded(size, false);
-    if (pageCount == 0)
+    auto throwOrReturn = [&](char* memBlock) ->char*
     {
-        if (nothrow == false)
+        if (memBlock==nullptr && !nothrow)
         {
-            // overflow
-            // Since nothrow is false here, it's okay to throw
             recycler->OutOfMemory();
         }
+        return memBlock;
+    };
 
-        return nullptr;
+    PageHeapData* pageHeapData = NoMemProtectHeapNewNoThrowZ(PageHeapData);
+    if (pageHeapData == nullptr)
+    {
+        return throwOrReturn(nullptr);
     }
 
-    if(size<sizeof(void*))
+
+    if (size < sizeof(void*))
     {
         attributes = (ObjectInfoBits)(attributes | LeafBit);
     }
 
+#ifdef RECYCLER_MEMORY_VERIFY
+    if (recycler->VerifyEnabled())
+    {
+        // with recycler verify enabled, it uses the unaligned bytes
+        size = sizeCat;
+    }
+#endif
 
+    size_t pageCount = LargeHeapBlock::GetPagesNeeded(size, false);
+    Assert(pageCount != 0);
     size_t actualPageCount = pageCount + 1; // 1 for guard page
     auto pageAllocator = recycler->GetRecyclerLargeBlockPageAllocator();
+    Segment * segment;
     char * baseAddress = pageAllocator->Alloc(&actualPageCount, &segment);
+    Assert((size_t)baseAddress%AutoSystemInfo::PageSize == 0);
     if (baseAddress == nullptr)
     {
-        return nullptr;
+        NoMemProtectHeapDelete(pageHeapData);
+        return throwOrReturn(nullptr);
     }
 
     size_t guardPageCount = actualPageCount - pageCount; // pageAllocator can return more than asked pages
-
-    char* address = nullptr;
+    char* headerAddress = nullptr;
     char* guardPageAddress = nullptr;
-
-    if (heapInfo->pageHeapMode == PageHeapMode::PageHeapModeBlockStart)
+    size_t sizeWithHeader = size + sizeof(LargeObjectHeader);
+    pageHeapData->pageHeapMode = heapInfo->pageHeapMode;
+    if (pageHeapData->pageHeapMode == PageHeapMode::PageHeapModeBlockStart)
     {
-        address = baseAddress + AutoSystemInfo::PageSize * guardPageCount;
+        headerAddress = baseAddress + AutoSystemInfo::PageSize * guardPageCount;
         guardPageAddress = baseAddress;
+
+        pageHeapData->paddingBytes = 0;
+        pageHeapData->unusedBytes = (AutoSystemInfo::PageSize - (sizeWithHeader%AutoSystemInfo::PageSize)) % AutoSystemInfo::PageSize;
+
+        pageHeapData->objectPageAddr = headerAddress;
     }
-    else if (heapInfo->pageHeapMode == PageHeapMode::PageHeapModeBlockEnd)
+    else if (pageHeapData->pageHeapMode == PageHeapMode::PageHeapModeBlockEnd)
     {
-        address = baseAddress;
+        pageHeapData->unusedBytes = (HeapConstants::ObjectGranularity - (sizeWithHeader%HeapConstants::ObjectGranularity)) % HeapConstants::ObjectGranularity;
+        pageHeapData->paddingBytes = (ushort)((AutoSystemInfo::PageSize - pageHeapData->unusedBytes - sizeWithHeader%AutoSystemInfo::PageSize) % AutoSystemInfo::PageSize);
+        Assert(pageHeapData->paddingBytes%HeapConstants::ObjectGranularity == 0);
+
+        headerAddress = baseAddress + pageHeapData->paddingBytes;
         guardPageAddress = baseAddress + pageCount * AutoSystemInfo::PageSize;
+
+        pageHeapData->objectPageAddr = baseAddress;
     }
     else
     {
         AnalysisAssert(false);
     }
 
-
-
-    LargeHeapBlock * heapBlock = LargeHeapBlock::New(address, pageCount, segment, 1, this);
+    LargeHeapBlock * heapBlock = LargeHeapBlock::New(headerAddress, pageCount, segment, 1, this);
     if (!heapBlock)
     {
         pageAllocator->SuspendIdleDecommit();
         pageAllocator->Release(baseAddress, actualPageCount, segment);
         pageAllocator->ResumeIdleDecommit();
-        return nullptr;
+        NoMemProtectHeapDelete(pageHeapData);
+        return throwOrReturn(nullptr);
     }
 
-    heapBlock->heapInfo = this->heapInfo;
-    heapBlock->actualPageCount = actualPageCount;
-    heapBlock->guardPageAddress = guardPageAddress;
-    DWORD oldProtect;
-    BOOL ret = ::VirtualProtect(guardPageAddress, AutoSystemInfo::PageSize * guardPageCount, PAGE_NOACCESS, &oldProtect);
-    Assert(ret && oldProtect == PAGE_READWRITE);
-    
-    // fill pattern before set pageHeapMode, so background scan stack may verify the pattern
-    size_t usedSpace = sizeof(LargeObjectHeader) + size;
-    memset(address + usedSpace, 0xF0, pageCount * AutoSystemInfo::PageSize - usedSpace);
-    heapBlock->pageHeapMode = heapInfo->pageHeapMode;
 
-    if (!recycler->heapBlockMap.SetHeapBlock(address, pageCount, heapBlock, HeapBlock::HeapBlockType::LargeBlockType, 0))
+    // adjust the addressEnd
+    if (pageHeapData->pageHeapMode == PageHeapMode::PageHeapModeBlockStart)
+    {
+        heapBlock->addressEnd = baseAddress + AutoSystemInfo::PageSize * actualPageCount;
+    }
+    else
+    {
+        heapBlock->addressEnd = baseAddress + AutoSystemInfo::PageSize * pageCount;
+    }
+
+    pageHeapData->actualPageCount = (uint)actualPageCount;
+    pageHeapData->guardPageAddress = guardPageAddress;
+
+    heapBlock->heapInfo = this->heapInfo;
+    heapBlock->pageHeapData = pageHeapData;
+    
+    bool decommitGuardPage = true;
+#ifdef ENABLE_DEBUG_CONFIG_OPTIONS
+    decommitGuardPage = this->GetRecycler()->GetRecyclerFlagsTable().PageHeapDecommitGuardPage;
+#if defined(RECYCLER_NO_PAGE_REUSE)
+    decommitGuardPage |= heapBlock->GetPageAllocator(this->GetRecycler())->IsPageReuseDisabled();
+#endif
+#endif
+    if (decommitGuardPage)
+    {
+        if (VirtualFree(guardPageAddress, AutoSystemInfo::PageSize * guardPageCount, MEM_DECOMMIT))
+        {
+            pageHeapData->isGuardPageDecommited = true;
+        }
+        else
+        {
+            Js::Throw::FatalInternalError();
+        }
+    }
+    else
+    {
+        DWORD oldProtect;
+        if (VirtualProtect(guardPageAddress, AutoSystemInfo::PageSize * guardPageCount, PAGE_NOACCESS, &oldProtect))
+        {
+            pageHeapData->isGuardPageDecommited = false;
+        }
+        else
+        {
+            Js::Throw::FatalInternalError();
+        }        
+    }
+
+    pageHeapData->objectAddress = heapBlock->Alloc(size, attributes);
+    Assert(pageHeapData->objectAddress != nullptr);
+    if (!pageHeapData->objectAddress)
     {
         pageAllocator->SuspendIdleDecommit();
         heapBlock->ReleasePages(recycler);
         pageAllocator->ResumeIdleDecommit();
         LargeHeapBlock::Delete(heapBlock);
-        return nullptr;
+        return throwOrReturn(nullptr);
     }
 
-    heapBlock->ResetMarks(ResetMarkFlags_None, recycler);
+    pageHeapData->objectEndAddr = pageHeapData->objectAddress + size;
 
-    char * memBlock = heapBlock->Alloc(size, attributes);
-    Assert(memBlock != nullptr);
+    // fill pattern before set pageHeapMode, so background scan stack may verify the pattern
+    memset(pageHeapData->objectPageAddr, PageHeapMemFill, pageHeapData->paddingBytes);
+    memset(pageHeapData->objectAddress + size, PageHeapMemFill, pageHeapData->unusedBytes);
+
+    if (!recycler->heapBlockMap.SetHeapBlock(headerAddress, pageCount, heapBlock, HeapBlock::HeapBlockType::LargeBlockType, 0))
+    {
+        pageAllocator->SuspendIdleDecommit();
+        heapBlock->ReleasePages(recycler);
+        pageAllocator->ResumeIdleDecommit();
+        LargeHeapBlock::Delete(heapBlock);
+        return throwOrReturn(nullptr);
+    }
 
     heapBlock->SetNextBlock(this->largePageHeapBlockList);
     this->largePageHeapBlockList = heapBlock;
@@ -205,15 +277,14 @@ LargeHeapBucket::PageHeapAlloc(Recycler * recycler, size_t sizeCat, size_t size,
     RECYCLER_SLOW_CHECK(this->heapInfo->heapBlockCount[HeapBlock::HeapBlockType::LargeBlockType]++);
     RECYCLER_PERF_COUNTER_ADD(FreeObjectSize, heapBlock->GetPageCount() * AutoSystemInfo::PageSize);
 
-
+#ifdef STACK_BACK_TRACE
     if (recycler->ShouldCapturePageHeapAllocStack())
     {
-#ifdef STACK_BACK_TRACE
         heapBlock->CapturePageHeapAllocStack();
-#endif
     }
+#endif
 
-    return memBlock;
+    return throwOrReturn(pageHeapData->objectAddress);
 }
 #endif
 

--- a/lib/Common/Memory/LargeHeapBucket.cpp
+++ b/lib/Common/Memory/LargeHeapBucket.cpp
@@ -219,6 +219,7 @@ LargeHeapBucket::PageHeapAlloc(Recycler * recycler, size_t sizeCat, size_t size,
 #endif
     if (decommitGuardPage)
     {
+#pragma prefast(suppress:6250, "Calling 'VirtualFree' without the MEM_RELEASE flag might free memory but not address descriptors (VADs).")
         if (VirtualFree(guardPageAddress, AutoSystemInfo::PageSize * guardPageCount, MEM_DECOMMIT))
         {
             pageHeapData->isGuardPageDecommited = true;

--- a/lib/Common/Memory/MarkContext.h
+++ b/lib/Common/Memory/MarkContext.h
@@ -110,7 +110,7 @@ private:
     void OnObjectMarked(void* object, void* parent);
 #endif
 
-#if DBG && GLOBAL_ENABLE_WRITE_BARRIER
+#if DBG
 public:
     void* parentRef;
 #endif

--- a/lib/Common/Memory/MarkContext.inl
+++ b/lib/Common/Memory/MarkContext.inl
@@ -76,21 +76,15 @@ void MarkContext::ScanMemory(void ** obj, size_t byteCount)
         void * candidate = *(static_cast<void * volatile *>(obj));
 #endif
 
-#if DBG && GLOBAL_ENABLE_WRITE_BARRIER
-        if (CONFIG_FLAG(ForceSoftwareWriteBarrier) && CONFIG_FLAG(VerifyBarrierBit))
-        {
-            this->parentRef = obj;
-        }
+#if DBG
+        this->parentRef = obj;
 #endif
         Mark<parallel, interior, doSpecialMark>(candidate, parentObject);
         obj++;
     } while (obj != objEnd);
 
-#if DBG && GLOBAL_ENABLE_WRITE_BARRIER
-    if (CONFIG_FLAG(ForceSoftwareWriteBarrier) && CONFIG_FLAG(VerifyBarrierBit))
-    {
-        this->parentRef = nullptr;
-    }
+#if DBG
+    this->parentRef = nullptr;
 #endif
 
 #if DBG_DUMP

--- a/lib/Common/Memory/PageAllocator.cpp
+++ b/lib/Common/Memory/PageAllocator.cpp
@@ -1511,13 +1511,11 @@ void
 PageAllocatorBase<TVirtualAlloc, TSegment, TPageSegment>::ReleaseSegment(TSegment * segment)
 {
     ASSERT_THREAD();
-#if defined(RECYCLER_MEMORY_VERIFY) || defined(ARENA_MEMORY_VERIFY)
+#ifdef RECYCLER_NO_PAGE_REUSE
     if (disablePageReuse)
     {
         Assert(this->processHandle == GetCurrentProcess());
-        DWORD oldProtect;
-        BOOL vpresult = VirtualProtect(segment->GetAddress(), segment->GetPageCount() * AutoSystemInfo::PageSize, PAGE_NOACCESS, &oldProtect);
-        Assert(vpresult && oldProtect == PAGE_READWRITE);
+        VirtualFree(segment->GetAddress(), segment->GetPageCount() * AutoSystemInfo::PageSize, MEM_DECOMMIT);
         return;
     }
 #endif
@@ -1546,13 +1544,11 @@ PageAllocatorBase<TVirtualAlloc, TSegment, TPageSegment>::ReleasePages(__in void
     ASSERT_THREAD();
     Assert(!this->HasMultiThreadAccess());
 
-#if defined(RECYCLER_MEMORY_VERIFY) || defined(ARENA_MEMORY_VERIFY)
+#ifdef RECYCLER_NO_PAGE_REUSE
     if (disablePageReuse)
     {
         Assert(this->processHandle == GetCurrentProcess());
-        DWORD oldProtect;
-        BOOL vpresult = VirtualProtect(address, pageCount * AutoSystemInfo::PageSize, PAGE_NOACCESS, &oldProtect);
-        Assert(vpresult && oldProtect == PAGE_READWRITE);
+        VirtualFree(address, pageCount * AutoSystemInfo::PageSize, MEM_DECOMMIT);
         return;
     }
 #endif

--- a/lib/Common/Memory/PageAllocator.cpp
+++ b/lib/Common/Memory/PageAllocator.cpp
@@ -1515,6 +1515,7 @@ PageAllocatorBase<TVirtualAlloc, TSegment, TPageSegment>::ReleaseSegment(TSegmen
     if (disablePageReuse)
     {
         Assert(this->processHandle == GetCurrentProcess());
+#pragma prefast(suppress:6250, "Calling 'VirtualFree' without the MEM_RELEASE flag might free memory but not address descriptors (VADs).")
         VirtualFree(segment->GetAddress(), segment->GetPageCount() * AutoSystemInfo::PageSize, MEM_DECOMMIT);
         return;
     }
@@ -1548,6 +1549,7 @@ PageAllocatorBase<TVirtualAlloc, TSegment, TPageSegment>::ReleasePages(__in void
     if (disablePageReuse)
     {
         Assert(this->processHandle == GetCurrentProcess());
+#pragma prefast(suppress:6250, "Calling 'VirtualFree' without the MEM_RELEASE flag might free memory but not address descriptors (VADs).")
         VirtualFree(address, pageCount * AutoSystemInfo::PageSize, MEM_DECOMMIT);
         return;
     }

--- a/lib/Common/Memory/PageAllocator.h
+++ b/lib/Common/Memory/PageAllocator.h
@@ -698,6 +698,7 @@ public:
 #if defined(RECYCLER_NO_PAGE_REUSE) || defined(ARENA_MEMORY_VERIFY)
     void ReenablePageReuse() { Assert(disablePageReuse); disablePageReuse = false; }
     bool DisablePageReuse() { bool wasDisablePageReuse = disablePageReuse; disablePageReuse = true; return wasDisablePageReuse; }
+    bool IsPageReuseDisabled() { return disablePageReuse; }
 #endif
 
 #if DBG

--- a/lib/Common/Memory/RecyclerFastAllocator.h
+++ b/lib/Common/Memory/RecyclerFastAllocator.h
@@ -75,8 +75,8 @@ public:
 #ifdef RECYCLER_MEMORY_VERIFY
         recycler->FillCheckPad(memBlock, sizeof(T), sizeCat);
 #endif
-#if DBG
-        recycler->VerifyPageHeapFillAfterAlloc<attributes>(memBlock, size);
+#ifdef RECYCLER_PAGE_HEAP
+        recycler->VerifyPageHeapFillAfterAlloc(memBlock, size, attributes);
 #endif
         return memBlock;
     };

--- a/lib/Common/Memory/SmallFinalizableHeapBucket.cpp
+++ b/lib/Common/Memory/SmallFinalizableHeapBucket.cpp
@@ -159,9 +159,7 @@ SmallFinalizableHeapBucketBaseT<TBlockType>::TransferDisposedObjects()
         HeapBlockList::ForEach(currentPendingDisposeList, [=](TBlockType * heapBlock)
         {
             heapBlock->TransferDisposedObjects();
-
-            // in pageheap, we actually always have free object
-            Assert(heapBlock->template HasFreeObject<false>());
+            Assert(heapBlock->HasFreeObject());
         });
 
         // For partial collect, dispose will modify the object, and we

--- a/lib/Common/Memory/SmallHeapBlockAllocator.cpp
+++ b/lib/Common/Memory/SmallHeapBlockAllocator.cpp
@@ -256,5 +256,5 @@ namespace Memory
 {
     EXPLICIT_INSTANTIATE_WITH_SMALL_HEAP_BLOCK_TYPE(SmallHeapBlockAllocator)
 
-    template _ALWAYSINLINE char* SmallHeapBlockAllocator<SmallNormalHeapBlock>::InlinedAllocImpl</*canFaultInject*/true>(Recycler * recycler, size_t sizeCat, ObjectInfoBits attributes);
+    template _ALWAYSINLINE char* SmallHeapBlockAllocator<SmallNormalHeapBlock>::InlinedAllocImpl</*canFaultInject*/true>(Recycler * recycler, DECLSPEC_GUARD_OVERFLOW size_t sizeCat, ObjectInfoBits attributes);
 }

--- a/lib/Common/Memory/SmallHeapBlockAllocator.h
+++ b/lib/Common/Memory/SmallHeapBlockAllocator.h
@@ -100,7 +100,7 @@ private:
 template <typename TBlockType>
 template <bool canFaultInject>
 inline char*
-SmallHeapBlockAllocator<TBlockType>::InlinedAllocImpl(Recycler * recycler, size_t sizeCat, ObjectInfoBits attributes)
+SmallHeapBlockAllocator<TBlockType>::InlinedAllocImpl(Recycler * recycler, DECLSPEC_GUARD_OVERFLOW size_t sizeCat, ObjectInfoBits attributes)
 {
     Assert((attributes & InternalObjectInfoBitMask) == attributes);
 #ifdef RECYCLER_WRITE_BARRIER
@@ -183,7 +183,7 @@ SmallHeapBlockAllocator<TBlockType>::InlinedAllocImpl(Recycler * recycler, size_
 template <typename TBlockType>
 template <ObjectInfoBits attributes>
 inline char *
-SmallHeapBlockAllocator<TBlockType>::InlinedAlloc(Recycler * recycler, size_t sizeCat)
+SmallHeapBlockAllocator<TBlockType>::InlinedAlloc(Recycler * recycler, DECLSPEC_GUARD_OVERFLOW size_t sizeCat)
 {
     return InlinedAllocImpl<true /* allow fault injection */>(recycler, sizeCat, attributes);
 }
@@ -192,7 +192,7 @@ template <typename TBlockType>
 template <bool canFaultInject>
 inline
 char *
-SmallHeapBlockAllocator<TBlockType>::SlowAlloc(Recycler * recycler, size_t sizeCat, ObjectInfoBits attributes)
+SmallHeapBlockAllocator<TBlockType>::SlowAlloc(Recycler * recycler, DECLSPEC_GUARD_OVERFLOW size_t sizeCat, ObjectInfoBits attributes)
 {
     Assert((attributes & InternalObjectInfoBitMask) == attributes);
 

--- a/lib/Common/Memory/SmallNormalHeapBucket.cpp
+++ b/lib/Common/Memory/SmallNormalHeapBucket.cpp
@@ -236,7 +236,7 @@ SmallNormalHeapBucketBase<TBlockType>::SweepPendingObjects(RecyclerSweep& recycl
                 heapBlock->template SweepObjects<SweepMode_ConcurrentPartial>(recycler);
 
                 // page heap mode should never reach here, so don't check pageheap enabled or not
-                if (heapBlock->template HasFreeObject<false>())
+                if (heapBlock->HasFreeObject())
                 {
                     // We have pre-existing free objects, so put this in the partialSweptHeapBlockList
                     heapBlock->SetNextBlock(this->partialSweptHeapBlockList);

--- a/lib/Runtime/Base/ScriptMemoryDumper.cpp
+++ b/lib/Runtime/Base/ScriptMemoryDumper.cpp
@@ -170,7 +170,7 @@ void ScriptMemoryDumper::DumpLargeHeapBlock(LargeHeapBlock* heapBlock)
 
     for (uint32 i = 0; i < heapBlock->allocCount; i++)
     {
-        Memory::LargeObjectHeader* heapHeader = heapBlock->GetHeader(i);
+        Memory::LargeObjectHeader* heapHeader = heapBlock->GetHeaderByIndex(i);
         if (heapHeader != nullptr)
         {
             current.activeObjectCount++;

--- a/lib/Runtime/Language/InlineCache.cpp
+++ b/lib/Runtime/Language/InlineCache.cpp
@@ -384,7 +384,7 @@ namespace Js
     void InlineCache::Clear()
     {
 #if DBG
-        if (!IsAll((char*)this, sizeof(InlineCache), '\0'))
+        if (!IsAll((byte*)this, sizeof(InlineCache), 0))
 #endif
         {
             memset(this, 0, sizeof(InlineCache));
@@ -1347,7 +1347,7 @@ namespace Js
     void IsInstInlineCache::Clear()
     {
 #if DBG
-        if (!IsAll((char*)this, sizeof(IsInstInlineCache), '\0'))
+        if (!IsAll((byte*)this, sizeof(IsInstInlineCache), 0))
 #endif
         {
             memset(this, 0, sizeof(IsInstInlineCache));


### PR DESCRIPTION
- fix that pageheap allocation didn't count in heuristic, which causes very high memory usage
and often make the program not usable

- while page reusing is disabled, locked the object page as soon as it's swept to increase the
chance of catching memory corruption

- some performance improvement with IsAll instead of looping byte by byte while doing verification

- move allocation close to guard page when guard page is at end of allocation, to increase chance
of catching buffer overrun

- move pageheap metadata to seperate structure, so we don't allocate the memory for it while not
in pageheap mode
