### PR TITLE
Fix fgPeepTmp annotation and re-enable an optimization that uses it

### DIFF
--- a/lib/Backend/BackwardPass.cpp
+++ b/lib/Backend/BackwardPass.cpp
@@ -7072,19 +7072,14 @@ BackwardPass::ProcessBailOnNoProfile(IR::Instr *instr, BasicBlock *block)
     // because the bailout wouldn't be able to restore tmp.
     IR::Instr *curNext = curInstr->GetNextRealInstrOrLabel();
     IR::Instr *instrNope = nullptr;
-    if (curNext->m_opcode == Js::OpCode::Ld_A && curNext->GetDst()->IsRegOpnd() && curNext->GetDst()->AsRegOpnd()->m_fgPeepTmp)
+    while (curNext->m_opcode == Js::OpCode::Ld_A && curNext->GetDst()->IsRegOpnd() && curNext->GetDst()->AsRegOpnd()->m_fgPeepTmp)
     {
-        block->RemoveInstr(instr);
-        return true;
-        /*while (curNext->m_opcode == Js::OpCode::Ld_A && curNext->GetDst()->IsRegOpnd() && curNext->GetDst()->AsRegOpnd()->m_fgPeepTmp)
-        {
-            // Instead of just giving up, we can be a little trickier. We can instead treat the tmp declaration(s) as a
-            // part of the block prefix, and put the bailonnoprofile immediately after them. This has the added benefit
-            // that we can still merge up blocks beginning with bailonnoprofile, even if they would otherwise not allow
-            // us to, due to the fact that these tmp declarations would be pre-empted by the higher-level bailout.
-            instrNope = curNext;
-            curNext = curNext->GetNextRealInstrOrLabel();
-        }*/
+        // Instead of just giving up, we can be a little trickier. We can instead treat the tmp declaration(s) as a
+        // part of the block prefix, and put the bailonnoprofile immediately after them. This has the added benefit
+        // that we can still merge up blocks beginning with bailonnoprofile, even if they would otherwise not allow
+        // us to, due to the fact that these tmp declarations would be pre-empted by the higher-level bailout.
+        instrNope = curNext;
+        curNext = curNext->GetNextRealInstrOrLabel();
     }
 
     curInstr = instr->m_prev;

--- a/lib/Backend/FlowGraph.cpp
+++ b/lib/Backend/FlowGraph.cpp
@@ -2153,60 +2153,59 @@ FlowGraph::PeepCm(IR::Instr *instr)
     if (ldFound)
     {
         // Split Ld_A into "Ld_A TRUE"/"Ld_A FALSE"
+        IR::Opnd* branchTakenResult = nullptr;
+        IR::Opnd* fallthroughResult = nullptr;
+        IR::Opnd* ld2Dest = nullptr;
         if (brIsTrue)
         {
-            instrNew = IR::Instr::New(Js::OpCode::Ld_A, instrLd->GetSrc1(), trueOpnd, instrBr->m_func);
-            instrNew->SetByteCodeOffset(instrBr);
-            instrNew->GetDst()->AsRegOpnd()->m_fgPeepTmp = true;
-            instrBr->InsertBefore(instrNew);
-            instrNew = IR::Instr::New(Js::OpCode::Ld_A, instrLd->GetDst(), trueOpnd, instrBr->m_func);
-            instrNew->SetByteCodeOffset(instrBr);
-            instrNew->GetDst()->AsRegOpnd()->m_fgPeepTmp = true;
-            instrBr->InsertBefore(instrNew);
-
-            instrNew = IR::Instr::New(Js::OpCode::Ld_A, instrLd->GetSrc1(), falseOpnd, instrLd->m_func);
-            instrLd->InsertBefore(instrNew);
-            instrNew->SetByteCodeOffset(instrLd);
-            instrNew->GetDst()->AsRegOpnd()->m_fgPeepTmp = true;
-            instrLd->ReplaceSrc1(falseOpnd);
-
+            branchTakenResult = trueOpnd;
+            fallthroughResult = falseOpnd;
             if (instrLd2)
             {
-                instrLd2->ReplaceSrc1(falseOpnd);
-
-                instrNew = IR::Instr::New(Js::OpCode::Ld_A, instrLd2->GetDst(), trueOpnd, instrBr->m_func);
-                instrBr->InsertBefore(instrNew);
-                instrNew->SetByteCodeOffset(instrBr);
-                instrNew->GetDst()->AsRegOpnd()->m_fgPeepTmp = true;
+                ld2Dest = instrLd2->GetDst();
             }
         }
         else
         {
             instrBr->AsBranchInstr()->Invert();
-
-            instrNew = IR::Instr::New(Js::OpCode::Ld_A, instrLd->GetSrc1(), falseOpnd, instrBr->m_func);
-            instrBr->InsertBefore(instrNew);
-            instrNew->SetByteCodeOffset(instrBr);
-            instrNew->GetDst()->AsRegOpnd()->m_fgPeepTmp = true;
-            instrNew = IR::Instr::New(Js::OpCode::Ld_A, instrLd->GetDst(), falseOpnd, instrBr->m_func);
-            instrBr->InsertBefore(instrNew);
-            instrNew->SetByteCodeOffset(instrBr);
-            instrNew->GetDst()->AsRegOpnd()->m_fgPeepTmp = true;
-
-            instrNew = IR::Instr::New(Js::OpCode::Ld_A, instrLd->GetSrc1(), trueOpnd, instrLd->m_func);
-            instrLd->InsertBefore(instrNew);
-            instrNew->SetByteCodeOffset(instrLd);
-            instrLd->ReplaceSrc1(trueOpnd);
-            instrNew->GetDst()->AsRegOpnd()->m_fgPeepTmp = true;
-
+            branchTakenResult = falseOpnd;
+            fallthroughResult = trueOpnd;
             if (instrLd2)
             {
-                instrLd2->ReplaceSrc1(trueOpnd);
-                instrNew = IR::Instr::New(Js::OpCode::Ld_A, instrLd->GetSrc1(), trueOpnd, instrBr->m_func);
-                instrBr->InsertBefore(instrNew);
-                instrNew->SetByteCodeOffset(instrBr);
-                instrNew->GetDst()->AsRegOpnd()->m_fgPeepTmp = true;
+                ld2Dest = instrLd->GetSrc1();
             }
+        }
+
+        // Create the two Lds before the branch
+        instrNew = IR::Instr::New(Js::OpCode::Ld_A, instrLd->GetSrc1(), branchTakenResult, instrBr->m_func);
+        instrNew->SetByteCodeOffset(instrBr);
+        instrNew->GetDst()->AsRegOpnd()->m_fgPeepTmp = true;
+        instrBr->InsertBefore(instrNew);
+
+        instrNew = IR::Instr::New(Js::OpCode::Ld_A, instrLd->GetDst(), branchTakenResult, instrBr->m_func);
+        instrNew->SetByteCodeOffset(instrBr);
+        instrNew->GetDst()->AsRegOpnd()->m_fgPeepTmp = true;
+        instrBr->InsertBefore(instrNew);
+
+        // Create the one or two Lds after the branch
+        instrNew = IR::Instr::New(Js::OpCode::Ld_A, instrLd->GetSrc1(), fallthroughResult, instrLd->m_func);
+        instrLd->InsertBefore(instrNew);
+        instrNew->SetByteCodeOffset(instrLd);
+        instrNew->GetDst()->AsRegOpnd()->m_fgPeepTmp = true;
+        instrLd->ReplaceSrc1(fallthroughResult);
+
+        // We need to annotate instrLd as being an fgPeepTmp load, or we have issues with bailout placement
+        instrLd->GetDst()->AsRegOpnd()->m_fgPeepTmp = true;
+
+        if (instrLd2)
+        {
+            // this is the "compare result" temp
+            instrLd2->ReplaceSrc1(fallthroughResult);
+
+            instrNew = IR::Instr::New(Js::OpCode::Ld_A, ld2Dest, trueOpnd, instrBr->m_func);
+            instrBr->InsertBefore(instrNew);
+            instrNew->SetByteCodeOffset(instrBr);
+            instrNew->GetDst()->AsRegOpnd()->m_fgPeepTmp = true;
         }
     }
 


### PR DESCRIPTION
Marking the result load for fgPeepTmp as an fgPeepTmp load allows us to correctly handle this case.