### PR TITLE
Minor perf improvements

### DIFF
--- a/lib/Backend/BackendApi.cpp
+++ b/lib/Backend/BackendApi.cpp
@@ -149,11 +149,13 @@ void CheckIsExecutable(Js::RecyclableObject * function, Js::JavascriptMethod ent
     {
         return;
     }
-    if (Js::JavascriptOperators::GetTypeId(function) == Js::TypeIds_HostDispatch)
+    
+    Js::TypeId typeId = Js::JavascriptOperators::GetTypeId(function);
+    if (typeId == Js::TypeIds_HostDispatch)
     {
         AssertMsg(false, "Has to go through CallRootFunction to start calling Javascript function");
     }
-    else if (Js::JavascriptFunction::Is(function))
+    else if (typeId == Js::TypeId::TypeIds_Function)
     {
         if (((Js::JavascriptFunction*)function)->IsExternalFunction())
         {

--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -3004,7 +3004,7 @@ ThreadContext::TryEnterExpirableCollectMode()
             Js::JavascriptFunction* javascriptFunction = nullptr;
             while (walker.GetCallerWithoutInlinedFrames(&javascriptFunction))
             {
-                if (javascriptFunction != nullptr && Js::ScriptFunction::Is(javascriptFunction))
+                if (javascriptFunction != nullptr && Js::ScriptFunction::Test(javascriptFunction))
                 {
                     Js::ScriptFunction* scriptFunction = (Js::ScriptFunction*) javascriptFunction;
                     Js::FunctionEntryPointInfo* entryPointInfo =  scriptFunction->GetFunctionEntryPointInfo();
@@ -3641,7 +3641,7 @@ ThreadContext::InvalidatePropertyGuardEntry(const Js::PropertyRecord* propertyRe
         while (stackWalker.GetCaller(&caller, /*includeInlineFrames*/ false))
         {
             // If the current frame is already from a bailout - we do not need to do on stack invalidation
-            if (caller != nullptr && Js::ScriptFunction::Is(caller) && !stackWalker.GetCurrentFrameFromBailout())
+            if (caller != nullptr && Js::ScriptFunction::Test(caller) && !stackWalker.GetCurrentFrameFromBailout())
             {
                 BYTE dummy;
                 Js::FunctionEntryPointInfo* functionEntryPoint = caller->GetFunctionBody()->GetDefaultFunctionEntryPointInfo();

--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -7436,7 +7436,7 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
         {
             const Js::PropertyIdArray *propIds = this->m_functionBody->GetFormalsPropIdArray();
 
-            Var funcExpr = this->GetFunctionExpression();
+            JavascriptFunction* funcExpr = this->GetFunctionExpression();
             PropertyId objectId = ActivationObjectEx::GetLiteralObjectRef(propIds);
             scopeObject = JavascriptOperators::OP_InitCachedScope(funcExpr, propIds,
                 this->GetFunctionBody()->GetObjectLiteralTypeRef(objectId),
@@ -8418,7 +8418,7 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
     }
 #endif
 
-    Var InterpreterStackFrame::GetFunctionExpression()
+    JavascriptFunction* InterpreterStackFrame::GetFunctionExpression()
     {
         // Make sure we get the boxed function object if is there, (or the function itself)
         return StackScriptFunction::GetCurrentFunctionObject(this->function->GetRealFunctionObject());

--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -3365,9 +3365,9 @@ namespace Js
         } autoRestore(this);
 #endif
 
-        if ((m_flags & Js::InterpreterStackFrameFlags_FromBailOut) && !(m_flags & InterpreterStackFrameFlags_ProcessingBailOutFromEHCode))
+        if (this->ehBailoutData)
         {
-            if (this->ehBailoutData)
+            if ((m_flags & Js::InterpreterStackFrameFlags_FromBailOut) && !(m_flags & InterpreterStackFrameFlags_ProcessingBailOutFromEHCode))
             {
                 m_flags |= Js::InterpreterStackFrameFlags_ProcessingBailOutFromEHCode;
                 EHBailoutData * topLevelEHBailoutData = this->ehBailoutData;
@@ -3381,6 +3381,7 @@ namespace Js
                 this->ehBailoutData = nullptr;
             }
         }
+
 #ifdef ASMJS_PLAT
         if( GetFunctionBody()->GetIsAsmjsMode() )
         {

--- a/lib/Runtime/Language/InterpreterStackFrame.h
+++ b/lib/Runtime/Language/InterpreterStackFrame.h
@@ -590,7 +590,7 @@ namespace Js
 
         template <class T> void OP_LdArrayHeadSegment(const unaligned T* playout);
 
-        inline Var GetFunctionExpression();
+        inline JavascriptFunction* GetFunctionExpression();
 
         template <class T> inline void OP_LdFunctionExpression(const unaligned T* playout);
         template <class T> inline void OP_StFunctionExpression(const unaligned T* playout);

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -1692,9 +1692,9 @@ CommonNumber:
             RootObjectBase* rootObject = static_cast<RootObjectBase*>(object);
             foundProperty = rootObject->GetRootProperty(instance, propertyId, value, info, requestContext);
         }
+
         while (!foundProperty && JavascriptOperators::GetTypeId(object) != TypeIds_Null)
         {
-
             if (unscopables && IsPropertyUnscopable(object, propertyId))
             {
                 break;
@@ -5521,7 +5521,15 @@ CommonNumber:
 
     Var JavascriptOperators::OP_InitCachedScope(Var varFunc, const Js::PropertyIdArray *propIds, Field(DynamicType*)* literalType, bool formalsAreLetDecls, ScriptContext *scriptContext)
     {
-        ScriptFunction *func = JavascriptGeneratorFunction::Is(varFunc) || JavascriptAsyncFunction::Is(varFunc) ?
+        bool isGAFunction = JavascriptFunction::Is(varFunc);
+        Assert(isGAFunction);
+        if (isGAFunction)
+        {
+            JavascriptFunction *function = JavascriptFunction::FromVar(varFunc);
+            isGAFunction = JavascriptGeneratorFunction::Test(function) || JavascriptAsyncFunction::Test(function);
+        }
+
+        ScriptFunction *func = isGAFunction ?
             JavascriptGeneratorFunction::FromVar(varFunc)->GetGeneratorVirtualScriptFunction() :
             ScriptFunction::FromVar(varFunc);
 

--- a/lib/Runtime/Language/JavascriptStackWalker.cpp
+++ b/lib/Runtime/Language/JavascriptStackWalker.cpp
@@ -444,7 +444,7 @@ namespace Js
                 inlineeOffset = inlinedFrameWalker.GetCurrentInlineeOffset();
             }
         }
-        else if (ScriptFunction::Is(parentFunction) && HasInlinedFramesOnStack())
+        else if (ScriptFunction::Test(parentFunction) && HasInlinedFramesOnStack())
         {
             // Inlined frames are not being walked right now. However, if there
             // are inlined frames on the stack the InlineeCallInfo of the first inlined frame

--- a/lib/Runtime/Library/JavascriptArray.cpp
+++ b/lib/Runtime/Library/JavascriptArray.cpp
@@ -1560,11 +1560,11 @@ namespace Js
         {
 #if DBG
             Js::JavascriptStackWalker walker(intArray->GetScriptContext());
-            Js::JavascriptFunction* caller = NULL;
+            Js::JavascriptFunction* caller = nullptr;
             bool foundScriptCaller = false;
             while(walker.GetCaller(&caller))
             {
-                if(caller != NULL && Js::ScriptFunction::Is(caller))
+                if(caller != nullptr && Js::ScriptFunction::Test(caller))
                 {
                     foundScriptCaller = true;
                     break;
@@ -1998,11 +1998,11 @@ namespace Js
         {
 #if DBG
             Js::JavascriptStackWalker walker(intArray->GetScriptContext());
-            Js::JavascriptFunction* caller = NULL;
+            Js::JavascriptFunction* caller = nullptr;
             bool foundScriptCaller = false;
             while(walker.GetCaller(&caller))
             {
-                if(caller != NULL && Js::ScriptFunction::Is(caller))
+                if(caller != nullptr && Js::ScriptFunction::Test(caller))
                 {
                     foundScriptCaller = true;
                     break;
@@ -2196,11 +2196,11 @@ namespace Js
         {
 #if DBG
             Js::JavascriptStackWalker walker(fArray->GetScriptContext());
-            Js::JavascriptFunction* caller = NULL;
+            Js::JavascriptFunction* caller = nullptr;
             bool foundScriptCaller = false;
             while(walker.GetCaller(&caller))
             {
-                if(caller != NULL && Js::ScriptFunction::Is(caller))
+                if(caller != nullptr && Js::ScriptFunction::Test(caller))
                 {
                     foundScriptCaller = true;
                     break;

--- a/lib/Runtime/Library/JavascriptFunction.cpp
+++ b/lib/Runtime/Library/JavascriptFunction.cpp
@@ -2777,7 +2777,7 @@ LABEL1:
             {
                 JavascriptFunction* exceptionFunction = unhandledExceptionObject->GetFunction();
                 // This is for getcaller in window.onError. The behavior is different in different browsers
-                if (exceptionFunction 
+                if (exceptionFunction
                     && scriptContext == exceptionFunction->GetScriptContext()
                     && exceptionFunction->IsScriptFunction()
                     && !exceptionFunction->GetFunctionBody()->GetIsGlobalFunc())
@@ -3221,7 +3221,7 @@ LABEL1:
         FunctionProxy* proxy = this->GetFunctionProxy();
         JavascriptFunction* thisFunction = const_cast<JavascriptFunction*>(this);
 
-        if (proxy || thisFunction->IsBoundFunction() || JavascriptGeneratorFunction::Is(thisFunction) || JavascriptAsyncFunction::Is(thisFunction))
+        if (proxy || thisFunction->IsBoundFunction() || JavascriptGeneratorFunction::Test(thisFunction) || JavascriptAsyncFunction::Test(thisFunction))
         {
             *name = GetDisplayNameImpl();
             return true;

--- a/lib/Runtime/Library/JavascriptGeneratorFunction.h
+++ b/lib/Runtime/Library/JavascriptGeneratorFunction.h
@@ -32,6 +32,11 @@ namespace Js
 
         static JavascriptGeneratorFunction* FromVar(Var var);
         static bool Is(Var var);
+        inline static bool Test(JavascriptFunction *obj)
+        {
+            return VirtualTableInfo<JavascriptGeneratorFunction>::HasVirtualTable(obj)
+              || VirtualTableInfo<CrossSiteObject<JavascriptGeneratorFunction>>::HasVirtualTable(obj);
+        }
 
         static JavascriptGeneratorFunction* OP_NewScGenFunc(FrameDisplay* environment, FunctionInfoPtrPtr infoRef);
         static Var EntryGeneratorFunctionImplementation(RecyclableObject* function, CallInfo callInfo, ...);
@@ -106,6 +111,11 @@ namespace Js
 
         static JavascriptAsyncFunction* FromVar(Var var);
         static bool Is(Var var);
+        inline static bool Test(JavascriptFunction *obj)
+        {
+            return VirtualTableInfo<JavascriptAsyncFunction>::HasVirtualTable(obj)
+              || VirtualTableInfo<CrossSiteObject<JavascriptAsyncFunction>>::HasVirtualTable(obj);
+        }
 
 #if ENABLE_TTD
         virtual TTD::NSSnapObjects::SnapObjectType GetSnapTag_TTD() const override;

--- a/lib/Runtime/Library/ScriptFunction.cpp
+++ b/lib/Runtime/Library/ScriptFunction.cpp
@@ -16,7 +16,14 @@ namespace Js
 
     bool ScriptFunctionBase::Is(Var func)
     {
-        return ScriptFunction::Is(func) || JavascriptGeneratorFunction::Is(func) || JavascriptAsyncFunction::Is(func);
+        if (JavascriptFunction::Is(func))
+        {
+            JavascriptFunction *function = JavascriptFunction::FromVar(func);
+            return ScriptFunction::Test(function) || JavascriptGeneratorFunction::Test(function)
+                || JavascriptAsyncFunction::Test(function);
+        }
+
+        return false;
     }
 
     ScriptFunctionBase * ScriptFunctionBase::FromVar(Var func)

--- a/lib/Runtime/Library/ScriptFunction.h
+++ b/lib/Runtime/Library/ScriptFunction.h
@@ -45,6 +45,7 @@ namespace Js
     public:
         ScriptFunction(FunctionProxy * proxy, ScriptFunctionType* deferredPrototypeType);
         static bool Is(Var func);
+        inline static BOOL Test(JavascriptFunction *func) { return func->GetFunctionInfo()->HasBody(); }
         static ScriptFunction * FromVar(Var func);
         static ScriptFunction * OP_NewScFunc(FrameDisplay *environment, FunctionInfoPtrPtr infoRef);
 

--- a/lib/Runtime/Math/JavascriptMath.cpp
+++ b/lib/Runtime/Math/JavascriptMath.cpp
@@ -169,45 +169,38 @@ namespace Js
             Assert(aRight != nullptr);
             Assert(scriptContext != nullptr);
 
-            // If both sides are numbers, then we can do the addition directly, otherwise
-            // we need to call the helper.
-            if(JavascriptNumber::Is(aLeft))
+            Js::TypeId typeLeft = JavascriptOperators::GetTypeId(aLeft);
+            Js::TypeId typeRight = JavascriptOperators::GetTypeId(aRight);
+
+            if (typeRight == typeLeft)
             {
-                if(JavascriptNumber::Is(aRight))
+                // If both sides are numbers/string, then we can do the addition directly
+                if(typeLeft == TypeIds_Number)
                 {
                     double sum = JavascriptNumber::GetValue(aLeft) + JavascriptNumber::GetValue(aRight);
                     return JavascriptNumber::ToVarNoCheck(sum, scriptContext);
                 }
-                else if(TaggedInt::Is(aRight))
-                {
-                    double sum = TaggedInt::ToDouble(aRight) + JavascriptNumber::GetValue(aLeft);
-                    return JavascriptNumber::ToVarNoCheck(sum, scriptContext);
-                }
-            }
-            else if(JavascriptNumber::Is(aRight))
-            {
-                if(TaggedInt::Is(aLeft))
-                {
-                    double sum = TaggedInt::ToDouble(aLeft) + JavascriptNumber::GetValue(aRight);
-                    return JavascriptNumber::ToVarNoCheck(sum, scriptContext);
-                }
-            }
-            else if(TaggedInt::Is(aLeft))
-            {
-                if(TaggedInt::Is(aRight))
+                else if (typeLeft == TypeIds_Integer)
                 {
                     __int64 sum = TaggedInt::ToInt64(aLeft) + TaggedInt::ToInt64(aRight);
                     return JavascriptNumber::ToVar(sum, scriptContext);
                 }
+                else if (typeLeft == TypeIds_String)
+                {
+                    return JavascriptString::Concat(JavascriptString::FromVar(aLeft), JavascriptString::FromVar(aRight));
+                }
             }
-            else if (TaggedInt::Is(aRight))
+            else if(typeLeft == TypeIds_Number && typeRight == TypeIds_Integer)
             {
-                return Add_FullHelper_Wrapper(aLeft, aRight, scriptContext, nullptr, false);
+                double sum = JavascriptNumber::GetValue(aLeft) + TaggedInt::ToDouble(aRight);
+                return JavascriptNumber::ToVarNoCheck(sum, scriptContext);
             }
-            else if (RecyclableObject::FromVar(aLeft)->GetTypeId() == TypeIds_String && RecyclableObject::FromVar(aRight)->GetTypeId() == TypeIds_String)
+            else if(typeLeft == TypeIds_Integer && typeRight == TypeIds_Number)
             {
-                return JavascriptString::Concat(JavascriptString::FromVar(aLeft), JavascriptString::FromVar(aRight));
+                double sum = TaggedInt::ToDouble(aLeft) + JavascriptNumber::GetValue(aRight);
+                return JavascriptNumber::ToVarNoCheck(sum, scriptContext);
             }
+
             return Add_FullHelper_Wrapper(aLeft, aRight, scriptContext, nullptr, false);
          }
 #else

--- a/pal/src/cruntime/wchar.cpp
+++ b/pal/src/cruntime/wchar.cpp
@@ -1179,7 +1179,7 @@ PAL_wcscpy(
     }
 
     /* add terminating null */
-    *strDestination = '\0';
+    *strDestination = char16_t(0);
 
     LOGEXIT("wcscpy returning char16_t %p (%S)\n", start, start);
     PERF_EXIT(wcscpy);
@@ -1282,6 +1282,8 @@ PAL_wcsncmp(
           string1?string1:W16_NULLSTRING,
           string1?string1:W16_NULLSTRING, string2?string2:W16_NULLSTRING, string2?string2:W16_NULLSTRING,
           (unsigned long) count);
+
+    if (string1 == string2) return diff;
 
     for (i = 0; i < count; i++)
     {


### PR DESCRIPTION
#### type-checking: reduce unnecessary calls
Looking at the implementation, type checking methods are a pretty
inexpensive calls. However CC calls them so many times (mostly
unnecessary) hence they produce a significant heat signature on final
perf result. Reducing the unnecessary calls.

#### ISF-Process: condition-less
In case `!ehBailoutData` it is unlikely the other 2 comparisons will
result true. However, other two may result true but  actually we may
not have `ehBailoutData`. So, condition less.

#### pal: dismiss wcsncmp worst case