### PR TITLE
Add an SFENCE following non temporal stores.

### DIFF
--- a/lib/Common/Core/Api.cpp
+++ b/lib/Common/Core/Api.cpp
@@ -37,6 +37,8 @@ void __stdcall js_memset_zero_nontemporal(__bcount(sizeInBytes) void *dst, size_
         {
             _mm_stream_si128(p, simdZero);
         }
+
+        _mm_sfence();
     }
     // cannot do non-temporal store directly if set size is not multiple of sizeof(__m128i)
     else


### PR DESCRIPTION
Add an SFENCE following non temporal stores in js_memset_zero_nontemporal.

Fixes https://github.com/Microsoft/ChakraCore/issues/2881.