### PR TITLE
Fixing the Bytecode testing flag in code coverage builds

### DIFF
--- a/Build/Common.Build.props
+++ b/Build/Common.Build.props
@@ -81,7 +81,7 @@
       <ProgramDataBaseFileName Condition="'$(ConfigurationType)'!='StaticLibrary'">$(IntDir)</ProgramDataBaseFileName>
 
       <!-- ======== For Code Covearge ======== -->
-      <PreprocessorDefinitions Condition="'$(ENABLE_CODECOVERAGE)'=='true' AND '$(BYTECODE_TESTING)' == '0'">
+      <PreprocessorDefinitions Condition="'$(ENABLE_CODECOVERAGE)'=='true'">
         %(PreprocessorDefinitions);
         BYTECODE_TESTING=1
       </PreprocessorDefinitions>


### PR DESCRIPTION
The bytecode testing flag was not enabled for code coverage builds
