### PR TITLE
AsmJs Templatized Jit fixes

### DIFF
--- a/lib/Runtime/Language/AsmJsJitTemplate.h
+++ b/lib/Runtime/Language/AsmJsJitTemplate.h
@@ -9,7 +9,7 @@
 namespace Js
 {
 
-    void AsmJsCommonEntryPoint(Js::ScriptFunction* func, void* savedEbp);
+    void AsmJsCommonEntryPoint(Js::ScriptFunction* func, void* localSlot, void* args);
 
     namespace AsmJsJitTemplate
     {

--- a/lib/Runtime/Language/i386/AsmJsInstructionTemplate.h
+++ b/lib/Runtime/Language/i386/AsmJsInstructionTemplate.h
@@ -843,6 +843,12 @@ namespace Js
             return 1;
         }
 
+        OpFuncSignature( LEA )
+        {
+            *buffer++ = 0x8D;
+            return 1;
+        }
+
         OpFuncSignature( MOV )
         {
             int size = 1;

--- a/lib/Runtime/Language/i386/AsmJsInstructionTemplate.inl
+++ b/lib/Runtime/Language/i386/AsmJsInstructionTemplate.inl
@@ -161,6 +161,10 @@ InstructionStart( LAHF      , 1|4|8 , 1 , NoFlag    )
     FormatEmpty()
 InstructionEnd ( LAHF )
 
+InstructionStart( LEA       , 4   , 0, NoFlag    )
+    FormatRegAddr(EncodeModRM_RegRM)
+InstructionEnd ( LEA )
+
 InstructionStart( MOV       , 1|2|4   , 11, AffectOp1 )
     Format2Reg(EncodeModRM_2Reg)
     FormatRegAddr(EncodeModRM_RegRM)

--- a/lib/Runtime/Language/i386/AsmJsJitTemplate.cpp
+++ b/lib/Runtime/Language/i386/AsmJsJitTemplate.cpp
@@ -515,9 +515,8 @@ namespace Js
     // Function memory allocation should be done the same way as
     // void InterpreterStackFrame::AlignMemoryForAsmJs()  (InterpreterStackFrame.cpp)
     // update any changes there
-    void AsmJsCommonEntryPoint(Js::ScriptFunction* func, void* savedEbpPtr)
+    void AsmJsCommonEntryPoint(Js::ScriptFunction* func, void* localSlot, void* args)
     {
-        int savedEbp = (int)savedEbpPtr;
         FunctionBody* body = func->GetFunctionBody();
         Js::FunctionEntryPointInfo * entryPointInfo = body->GetDefaultFunctionEntryPointInfo();
         const uint32 minTemplatizedJitRunCount = (uint32)CONFIG_FLAG(MinTemplatizedJitRunCount);
@@ -540,10 +539,7 @@ namespace Js
         const int floatOffset = asmInfo->GetFloatByteOffset() / sizeof(float);
         const int simdByteOffset = asmInfo->GetSimdByteOffset(); // in bytes
 
-        // (2*sizeof(Var)) -- push ebp and ret address
-        //sizeof(ScriptFunction*) -- this is the argument passed to the TJ function
-        int argoffset = (2*sizeof(Var)) + sizeof(ScriptFunction*);
-        argoffset = argoffset +  savedEbp ;
+        int argoffset = (int)args;
         // initialize argument location
         int* intArg;
         double* doubleArg;
@@ -580,16 +576,8 @@ namespace Js
             ++AsmJsCallDepth;
         }
 #endif
-        // two args i.e. (ScriptFunction and savedEbp) + 2* (void*) i.e.(ebp + return address)
-        int beginSlotOffset = sizeof(ScriptFunction*) + sizeof(void*) + 2 * sizeof(void*);
-        __asm
         {
-            mov  eax, ebp
-            add  eax, beginSlotOffset
-            mov m_localSlots,eax
-        };
-
-        {
+            m_localSlots = (Var*)localSlot;
             const ArgSlot argCount = asmInfo->GetArgCount();
             m_localSlots[AsmJsFunctionMemory::ModuleEnvRegister] = moduleEnv;
             m_localSlots[AsmJsFunctionMemory::ArrayBufferRegister] = (Var)arrayPtr;
@@ -612,12 +600,12 @@ namespace Js
                 constTable = (void*)(((double*)constTable) + doubleConstCount);
                 m_localSimdSlots = (AsmJsSIMDValue*)((char*)m_localSlots + simdByteOffset);
                 memcpy_s(m_localSimdSlots, simdConstCount*sizeof(AsmJsSIMDValue), constTable, simdConstCount*sizeof(AsmJsSIMDValue));
+                simdArg = m_localSimdSlots + simdConstCount;
             }
 
             intArg = m_localIntSlots + intConstCount;
             doubleArg = m_localDoubleSlots + doubleConstCount;
             floatArg = m_localFloatSlots + floatConstCount;
-            simdArg = m_localSimdSlots + simdConstCount;
 
             for(ArgSlot i = 0; i < argCount; i++ )
             {
@@ -1567,10 +1555,17 @@ namespace Js
             int baseOffSet = stackSize + templateData->GetEBPOffsetCorrection();
             templateData->SetBaseOffset(baseOffSet);
 
-            // push EBP and push funcobj
+            // At this point EBP = [old ebp, return address, funcObj, args]
+
+            // AsmJsCommonEntryPoint(Js::ScriptFunction* func, void* localSlot, void* args);
             int funcOffSet = 2 * sizeof(Var);
+            int argsOffSet = 3 * sizeof(Var);
+
             //push args for CEP
-            size += PUSH::EncodeInstruction<int>(buffer, InstrParamsReg(RegEBP));
+            size += LEA::EncodeInstruction<int>(buffer, InstrParamsRegAddr(RegEAX, RegEBP, argsOffSet));
+            size += PUSH::EncodeInstruction<int>(buffer, InstrParamsReg(RegEAX));
+            size += LEA::EncodeInstruction<int>(buffer, InstrParamsRegAddr(RegEAX, RegEBP, templateData->GetModuleSlotOffset()));
+            size += PUSH::EncodeInstruction<int>(buffer, InstrParamsReg(RegEAX));
             size += PUSH::EncodeInstruction<int>(buffer, InstrParamsAddr(RegEBP, funcOffSet));
 
             // Call CEP


### PR DESCRIPTION
- Use the common function to determine if it's time to change from TemplatizedJit to FullJit.
- Pass the local slot and args addresses instead of calculating it. It was error prone and had some weird compiler bugs when changing locals in that functions.
- Respect the `-debugbreak:#` flag for templatized jit


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/2907)
<!-- Reviewable:end -->
