### PR TITLE
Dynamic Module Import

### DIFF
--- a/bin/NativeTests/JsRTApiTest.cpp
+++ b/bin/NativeTests/JsRTApiTest.cpp
@@ -1739,6 +1739,7 @@ namespace JsRTApiTest
         REQUIRE(JsInitializeModuleRecord(nullptr, specifier, &requestModule) == JsNoError);
         successTest.mainModule = requestModule;
         REQUIRE(JsSetModuleHostInfo(requestModule, JsModuleHostInfo_FetchImportedModuleCallback, Success_FIMC) == JsNoError);
+        REQUIRE(JsSetModuleHostInfo(requestModule, JsModuleHostInfo_FetchImportedModuleFromScriptCallback, Success_FIMC) == JsNoError);
         REQUIRE(JsSetModuleHostInfo(requestModule, JsModuleHostInfo_NotifyModuleReadyCallback, Succes_NMRC) == JsNoError);
 
         JsValueRef errorObject = JS_INVALID_REFERENCE;
@@ -1834,6 +1835,7 @@ namespace JsRTApiTest
         REQUIRE(JsInitializeModuleRecord(nullptr, specifier, &requestModule) == JsNoError);
         reentrantParseData.mainModule = requestModule;
         REQUIRE(JsSetModuleHostInfo(requestModule, JsModuleHostInfo_FetchImportedModuleCallback, ReentrantParse_FIMC) == JsNoError);
+        REQUIRE(JsSetModuleHostInfo(requestModule, JsModuleHostInfo_FetchImportedModuleFromScriptCallback, ReentrantParse_FIMC) == JsNoError);
         REQUIRE(JsSetModuleHostInfo(requestModule, JsModuleHostInfo_NotifyModuleReadyCallback, ReentrantParse_NMRC) == JsNoError);
 
         JsValueRef errorObject = JS_INVALID_REFERENCE;
@@ -1913,6 +1915,7 @@ namespace JsRTApiTest
         REQUIRE(JsInitializeModuleRecord(nullptr, specifier, &requestModule) == JsNoError);
         reentrantNoErrorParseData.mainModule = requestModule;
         REQUIRE(JsSetModuleHostInfo(requestModule, JsModuleHostInfo_FetchImportedModuleCallback, reentrantNoErrorParse_FIMC) == JsNoError);
+        REQUIRE(JsSetModuleHostInfo(requestModule, JsModuleHostInfo_FetchImportedModuleFromScriptCallback, reentrantNoErrorParse_FIMC) == JsNoError);
         REQUIRE(JsSetModuleHostInfo(requestModule, JsModuleHostInfo_NotifyModuleReadyCallback, reentrantNoErrorParse_NMRC) == JsNoError);
 
         JsValueRef errorObject = JS_INVALID_REFERENCE;

--- a/bin/ch/Helpers.cpp
+++ b/bin/ch/Helpers.cpp
@@ -139,26 +139,30 @@ HRESULT Helpers::LoadScriptFromFile(LPCSTR filename, LPCSTR& contents, UINT* len
     //
     if (fopen_s(&file, filename, "rb") != 0)
     {
-#ifdef _WIN32
-        DWORD lastError = GetLastError();
-        char16 wszBuff[512];
-        fprintf(stderr, "Error in opening file '%s' ", filename);
-        wszBuff[0] = 0;
-        if (FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM,
-            nullptr,
-            lastError,
-            0,
-            wszBuff,
-            _countof(wszBuff),
-            nullptr))
+        if (!HostConfigFlags::flags.AsyncModuleLoadIsEnabled)
         {
-            fwprintf(stderr, _u(": %s"), wszBuff);
-        }
-        fwprintf(stderr, _u("\n"));
+#ifdef _WIN32
+            DWORD lastError = GetLastError();
+            char16 wszBuff[512];
+            fprintf(stderr, "Error in opening file '%s' ", filename);
+            wszBuff[0] = 0;
+            if (FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM,
+                nullptr,
+                lastError,
+                0,
+                wszBuff,
+                _countof(wszBuff),
+                nullptr))
+            {
+                fwprintf(stderr, _u(": %s"), wszBuff);
+            }
+            fwprintf(stderr, _u("\n"));
 #elif defined(_POSIX_VERSION)
-        fprintf(stderr, "Error in opening file: ");
-        perror(filename);
+            fprintf(stderr, "Error in opening file: ");
+            perror(filename);
 #endif
+        }
+
         IfFailGo(E_FAIL);
     }
 

--- a/bin/ch/HostConfigFlagsList.h
+++ b/bin/ch/HostConfigFlagsList.h
@@ -11,5 +11,6 @@ FLAG(int,  InspectMaxStringLength,          "Max string length to dump in locals
 FLAG(BSTR, Serialized,                      "If source is UTF8, deserializes from bytecode file", NULL)
 FLAG(bool, OOPJIT,                          "Run JIT in a separate process", false)
 FLAG(bool, EnsureCloseJITServer,            "JIT process will be force closed when ch is terminated", true)
+FLAG(bool, AsyncModuleLoad,                 "Silence host error output for module load failures to enable promise testing", false)
 #undef FLAG
 #endif

--- a/bin/ch/WScriptJsrt.h
+++ b/bin/ch/WScriptJsrt.h
@@ -53,7 +53,9 @@ public:
     static void PushMessage(MessageBase *message) { messageQueue->InsertSorted(message); }
 
     static JsErrorCode FetchImportedModule(_In_ JsModuleRecord referencingModule, _In_ JsValueRef specifier, _Outptr_result_maybenull_ JsModuleRecord* dependentModuleRecord);
+    static JsErrorCode FetchImportedModuleFromScript(_In_ DWORD_PTR dwReferencingSourceContext, _In_ JsValueRef specifier, _Outptr_result_maybenull_ JsModuleRecord* dependentModuleRecord);
     static JsErrorCode NotifyModuleReadyCallback(_In_opt_ JsModuleRecord referencingModule, _In_opt_ JsValueRef exceptionVar);
+    static JsErrorCode InitializeModuleCallbacks();
     static void CALLBACK PromiseContinuationCallback(JsValueRef task, void *callbackState);
 
     static LPCWSTR ConvertErrorCodeToMessage(JsErrorCode errorCode)
@@ -115,6 +117,8 @@ private:
     static JsValueRef CALLBACK LoadBinaryFileCallback(JsValueRef callee, bool isConstructCall, JsValueRef *arguments, unsigned short argumentCount, void *callbackState);
     static JsValueRef CALLBACK LoadTextFileCallback(JsValueRef callee, bool isConstructCall, JsValueRef *arguments, unsigned short argumentCount, void *callbackState);
     static JsValueRef CALLBACK FlagCallback(JsValueRef callee, bool isConstructCall, JsValueRef *arguments, unsigned short argumentCount, void *callbackState);
+
+    static JsErrorCode FetchImportedModuleHelper(JsModuleRecord referencingModule, JsValueRef specifier, __out JsModuleRecord* dependentModuleRecord);
 
     static MessageQueue *messageQueue;
     static DWORD_PTR sourceContext;

--- a/lib/Backend/JnHelperMethodList.h
+++ b/lib/Backend/JnHelperMethodList.h
@@ -507,6 +507,8 @@ HELPERCALL(SetHomeObj,          Js::JavascriptOperators::OP_SetHomeObj,         
 HELPERCALL(LdHomeObjProto,      Js::JavascriptOperators::OP_LdHomeObjProto,     0)
 HELPERCALL(LdFuncObjProto,      Js::JavascriptOperators::OP_LdFuncObjProto,     0)
 
+HELPERCALL(ImportCall,          Js::JavascriptOperators::OP_ImportCall,         0)
+
 HELPERCALL(ResumeYield,   Js::JavascriptOperators::OP_ResumeYield,   AttrCanThrow)
 
 #include "ExternalHelperMethodList.h"

--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -2844,6 +2844,20 @@ Lowerer::LowerRange(IR::Instr *instrStart, IR::Instr *instrEnd, bool defaultDoFa
             break;
         }
 
+        case Js::OpCode::ImportCall:
+        {
+            IR::Opnd *src1Opnd = instr->UnlinkSrc1();
+            IR::Opnd *functionObjOpnd = nullptr;
+            m_lowererMD.LoadFunctionObjectOpnd(instr, functionObjOpnd);
+
+            LoadScriptContext(instr);
+            m_lowererMD.LoadHelperArgument(instr, src1Opnd);
+            m_lowererMD.LoadHelperArgument(instr, functionObjOpnd);
+            m_lowererMD.ChangeToHelperCall(instr, IR::HelperImportCall);
+
+            break;
+        }
+
         case Js::OpCode::SetComputedNameVar:
         {
             IR::Opnd *src2Opnd = instr->UnlinkSrc2();

--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -532,7 +532,7 @@ PHASE(All)
     // If ES6Module needs to be disabled by compile flag, DEFAULT_CONFIG_ES6Module should be false
     #define DEFAULT_CONFIG_ES6Module               (false)
 #else
-    #define DEFAULT_CONFIG_ES6Module               (false)
+    #define DEFAULT_CONFIG_ES6Module               (true)
 #endif
 #define DEFAULT_CONFIG_ES6Object               (true)
 #define DEFAULT_CONFIG_ES6Number               (true)
@@ -998,10 +998,7 @@ FLAGPR           (Boolean, ES6, ES7TrailingComma       , "Enable ES7 trailing co
 FLAGPR           (Boolean, ES6, ES6IsConcatSpreadable  , "Enable ES6 isConcatSpreadable Symbol"                     , DEFAULT_CONFIG_ES6IsConcatSpreadable)
 FLAGPR           (Boolean, ES6, ES6Math                , "Enable ES6 Math extensions"                               , DEFAULT_CONFIG_ES6Math)
 
-#ifndef COMPILE_DISABLE_ES6Module
-    #define COMPILE_DISABLE_ES6Module 0
-#endif
-FLAGPR_REGOVR_EXP(Boolean, ES6, ES6Module              , "Enable ES6 Modules"                                       , DEFAULT_CONFIG_ES6Module)
+FLAGPR           (Boolean, ES6, ES6Module              , "Enable ES6 Modules"                                       , DEFAULT_CONFIG_ES6Module)
 FLAGPR           (Boolean, ES6, ES6Object              , "Enable ES6 Object extensions"                             , DEFAULT_CONFIG_ES6Object)
 FLAGPR           (Boolean, ES6, ES6Number              , "Enable ES6 Number extensions"                             , DEFAULT_CONFIG_ES6Number)
 FLAGPR           (Boolean, ES6, ES6ObjectLiterals      , "Enable ES6 Object literal extensions"                     , DEFAULT_CONFIG_ES6ObjectLiterals)

--- a/lib/Common/Memory/ArenaAllocator.h
+++ b/lib/Common/Memory/ArenaAllocator.h
@@ -21,6 +21,12 @@ namespace Memory
 #define Adelete(alloc, obj) AllocatorDelete(ArenaAllocator, alloc, obj)
 #define AdeletePlus(alloc, size, obj) AllocatorDeletePlus(ArenaAllocator, alloc, size, obj)
 #define AdeleteArray(alloc, count, obj) AllocatorDeleteArray(ArenaAllocator, alloc, count, obj)
+#define AdeleteUnlessNull(alloc, obj) \
+    if (obj != nullptr) \
+    { \
+        Adelete(alloc, obj); \
+        obj = nullptr; \
+    }
 
 
 #define AnewNoThrow(alloc,T,...) AllocatorNewNoThrow(ArenaAllocator, alloc, T, __VA_ARGS__)

--- a/lib/Jsrt/ChakraCore.h
+++ b/lib/Jsrt/ChakraCore.h
@@ -38,7 +38,8 @@ typedef enum JsModuleHostInfoKind
     JsModuleHostInfo_Exception = 0x01,
     JsModuleHostInfo_HostDefined = 0x02,
     JsModuleHostInfo_NotifyModuleReadyCallback = 0x3,
-    JsModuleHostInfo_FetchImportedModuleCallback = 0x4
+    JsModuleHostInfo_FetchImportedModuleCallback = 0x4,
+    JsModuleHostInfo_FetchImportedModuleFromScriptCallback = 0x5
 } JsModuleHostInfoKind;
 
 /// <summary>
@@ -65,6 +66,21 @@ typedef JsErrorCode(CHAKRA_CALLBACK * FetchImportedModuleCallBack)(_In_ JsModule
 /// holds the exception. Otherwise the referencingModule is ready and the host should schedule execution afterwards.
 /// </remarks>
 /// <param name="referencingModule">The referencing module that have finished running ModuleDeclarationInstantiation step.</param>
+/// <param name="exceptionVar">If nullptr, the module is successfully initialized and host should queue the execution job
+///                           otherwise it's the exception object.</param>
+/// <returns>
+///     true if the operation succeeded, false otherwise.
+/// </returns>
+typedef JsErrorCode(CHAKRA_CALLBACK * FetchImportedModuleFromScriptCallBack)(_In_ JsSourceContext dwReferencingSourceContext, _In_ JsValueRef specifier, _Outptr_result_maybenull_ JsModuleRecord* dependentModuleRecord);
+
+/// <summary>
+///     User implemented callback to get notification when the module is ready.
+/// </summary>
+/// <remarks>
+/// Notify the host after ModuleDeclarationInstantiation step (15.2.1.1.6.4) is finished. If there was error in the process, exceptionVar
+/// holds the exception. Otherwise the referencingModule is ready and the host should schedule execution afterwards.
+/// </remarks>
+/// <param name="dwReferencingSourceContext">The referencing script that calls import()</param>
 /// <param name="exceptionVar">If nullptr, the module is successfully initialized and host should queue the execution job
 ///                           otherwise it's the exception object.</param>
 /// <returns>

--- a/lib/Jsrt/Core/JsrtContextCore.h
+++ b/lib/Jsrt/Core/JsrtContextCore.h
@@ -168,6 +168,7 @@ public:
     }
 
     HRESULT FetchImportedModule(Js::ModuleRecordBase* referencingModule, LPCOLESTR specifier, Js::ModuleRecordBase** dependentModuleRecord) override;
+    HRESULT FetchImportedModuleFromScript(JsSourceContext dwReferencingSourceContext, LPCOLESTR specifier, Js::ModuleRecordBase** dependentModuleRecord) override;
 
     HRESULT NotifyHostAboutModuleReady(Js::ModuleRecordBase* referencingModule, Js::Var exceptionVar) override;
 
@@ -176,6 +177,9 @@ public:
 
     void SetFetchImportedModuleCallback(FetchImportedModuleCallBack fetchCallback) { this->fetchImportedModuleCallback = fetchCallback ; }
     FetchImportedModuleCallBack GetFetchImportedModuleCallback() const { return this->fetchImportedModuleCallback; }
+
+    void SetFetchImportedModuleFromScriptCallback(FetchImportedModuleFromScriptCallBack fetchCallback) { this->fetchImportedModuleFromScriptCallback = fetchCallback; }
+    FetchImportedModuleFromScriptCallBack GetFetchImportedModuleFromScriptCallback() const { return this->fetchImportedModuleFromScriptCallback; }
 
 #if DBG_DUMP || defined(PROFILE_EXEC) || defined(PROFILE_MEM)
     void EnsureParentInfo(Js::ScriptContext* scriptContext = NULL) override
@@ -186,6 +190,9 @@ public:
 #endif
 
 private:
+    template<typename Fn>
+    HRESULT FetchImportedModuleHelper(Fn fetch, LPCOLESTR specifier, Js::ModuleRecordBase** dependentModuleRecord);
     FetchImportedModuleCallBack fetchImportedModuleCallback;
+    FetchImportedModuleFromScriptCallBack fetchImportedModuleFromScriptCallback;
     NotifyModuleReadyCallback notifyModuleReadyCallback;
 };

--- a/lib/Jsrt/Core/JsrtCore.cpp
+++ b/lib/Jsrt/Core/JsrtCore.cpp
@@ -162,6 +162,9 @@ JsSetModuleHostInfo(
         case JsModuleHostInfo_FetchImportedModuleCallback:
             currentContext->GetHostScriptContext()->SetFetchImportedModuleCallback(reinterpret_cast<FetchImportedModuleCallBack>(hostInfo));
             break;
+        case JsModuleHostInfo_FetchImportedModuleFromScriptCallback:
+            currentContext->GetHostScriptContext()->SetFetchImportedModuleFromScriptCallback(reinterpret_cast<FetchImportedModuleFromScriptCallBack>(hostInfo));
+            break;
         case JsModuleHostInfo_NotifyModuleReadyCallback:
             currentContext->GetHostScriptContext()->SetNotifyModuleReadyCallback(reinterpret_cast<NotifyModuleReadyCallback>(hostInfo));
             break;
@@ -202,6 +205,9 @@ JsGetModuleHostInfo(
             break;
         case JsModuleHostInfo_FetchImportedModuleCallback:
             *hostInfo = reinterpret_cast<void*>(currentContext->GetHostScriptContext()->GetFetchImportedModuleCallback());
+            break;
+        case JsModuleHostInfo_FetchImportedModuleFromScriptCallback:
+            *hostInfo = reinterpret_cast<void*>(currentContext->GetHostScriptContext()->GetFetchImportedModuleFromScriptCallback());
             break;
         case JsModuleHostInfo_NotifyModuleReadyCallback:
             *hostInfo = reinterpret_cast<void*>(currentContext->GetHostScriptContext()->GetNotifyModuleReadyCallback());

--- a/lib/Jsrt/JsrtInternal.h
+++ b/lib/Jsrt/JsrtInternal.h
@@ -369,6 +369,7 @@ JsErrorCode SetContextAPIWrapper(JsrtContext* newContext, Fn fn)
         return JsErrorOutOfMemory;
     }
     CATCH_OTHER_EXCEPTIONS(errorCode)
+    AUTO_NESTED_HANDLED_EXCEPTION_TYPE((ExceptionType)(ExceptionType_OutOfMemory | ExceptionType_StackOverflow));
     JsrtContext::TrySetCurrent(oldContext);
     return errorCode;
 }

--- a/lib/Parser/Parse.h
+++ b/lib/Parser/Parse.h
@@ -861,8 +861,9 @@ private:
 
     bool IsImportOrExportStatementValidHere();
 
-    template<bool buildAST> ParseNodePtr ParseImportDeclaration();
+    template<bool buildAST> ParseNodePtr ParseImport();
     template<bool buildAST> void ParseImportClause(ModuleImportOrExportEntryList* importEntryList, bool parsingAfterComma = false);
+    template<bool buildAST> ParseNodePtr ParseImportCall();
 
     template<bool buildAST> ParseNodePtr ParseExportDeclaration();
     template<bool buildAST> ParseNodePtr ParseDefaultExportClause();

--- a/lib/Parser/ptlist.h
+++ b/lib/Parser/ptlist.h
@@ -23,6 +23,7 @@ PTNODE(knopNone       , "<none>"           , Nop      , None        , fnopNone  
 ***************************************************************************/
 PTNODE(knopName       , "name"             , Nop      , Pid         , fnopLeaf              , "NameExpr"                       )
 PTNODE(knopInt        , "int const"        , Nop      , Int         , fnopLeaf|fnopConst    , "NumberLit"                      )
+PTNODE(knopImport     , "import"           , Nop      , None        , fnopLeaf              , "ImportExpr"                      )
 PTNODE(knopFlt        , "flt const"        , Nop      , Flt         , fnopLeaf|fnopConst    , "NumberLit"                      )
 PTNODE(knopStr        , "str const"        , Nop      , Pid         , fnopLeaf|fnopConst    , "StringLit"                      )
 PTNODE(knopRegExp     , "reg expr"         , Nop      , Pid         , fnopLeaf|fnopConst    , "RegExprLit"                     )

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -203,6 +203,11 @@ namespace Js
         scriptContext->GetDebugContext()->RegisterFunction(this, pszTitle);
     }
 
+    bool ParseableFunctionInfo::IsES6ModuleCode() const
+    {
+        return (GetGrfscr() & fscrIsModuleCode) == fscrIsModuleCode;
+    }
+
     // Given an offset into the source buffer, determine if the end of this SourceInfo
     // lies after the given offset.
     bool
@@ -3171,7 +3176,7 @@ namespace Js
 
     Js::RootObjectBase * FunctionBody::LoadRootObject() const
     {
-        if ((this->GetGrfscr() & fscrIsModuleCode) == fscrIsModuleCode || this->GetModuleID() == kmodGlobal)
+        if (this->IsES6ModuleCode() || this->GetModuleID() == kmodGlobal)
         {
             return JavascriptOperators::OP_LdRoot(this->GetScriptContext());
         }

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -2094,6 +2094,7 @@ namespace Js
         DeferredFunctionStub *GetDeferredStubs() const { return static_cast<DeferredFunctionStub *>(this->GetAuxPtr(AuxPointerType::DeferredStubs)); }
         void SetDeferredStubs(DeferredFunctionStub *stub) { this->SetAuxPtr(AuxPointerType::DeferredStubs, stub); }
         void RegisterFuncToDiag(ScriptContext * scriptContext, char16 const * pszTitle);
+        bool IsES6ModuleCode() const;
 
     protected:
         static HRESULT MapDeferredReparseError(HRESULT& hrParse, const CompileScriptException& se);

--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -153,6 +153,7 @@ public:
     virtual HRESULT EnqueuePromiseTask(Js::Var varTask) = 0;
 
     virtual HRESULT FetchImportedModule(Js::ModuleRecordBase* referencingModule, LPCOLESTR specifier, Js::ModuleRecordBase** dependentModuleRecord) = 0;
+    virtual HRESULT FetchImportedModuleFromScript(DWORD_PTR dwReferencingSourceContext, LPCOLESTR specifier, Js::ModuleRecordBase** dependentModuleRecord) = 0;
     virtual HRESULT NotifyHostAboutModuleReady(Js::ModuleRecordBase* referencingModule, Js::Var exceptionVar) = 0;
 
     Js::ScriptContext* GetScriptContext() { return scriptContext; }

--- a/lib/Runtime/Base/ThreadContext.h
+++ b/lib/Runtime/Base/ThreadContext.h
@@ -133,6 +133,30 @@ extern "C" void* MarkerForExternalDebugStep();
                 }\
         }
 
+#define LEAVE_SCRIPT_IF(scriptContext, condition, block) \
+        if (condition) \
+        { \
+            BEGIN_LEAVE_SCRIPT(scriptContext); \
+            block \
+            END_LEAVE_SCRIPT(scriptContext); \
+        } \
+        else \
+        { \
+            block \
+        }
+
+#define ENTER_SCRIPT_IF(scriptContext, doCleanup, isCallRoot, hasCaller, condition, block) \
+        if (condition) \
+        { \
+            BEGIN_ENTER_SCRIPT(scriptContext, doCleanup, isCallRoot, hasCaller); \
+            block \
+            END_ENTER_SCRIPT(scriptContext, doCleanup, isCallRoot, hasCaller); \
+        } \
+        else \
+        { \
+            block \
+        }
+
 #define BEGIN_LEAVE_SCRIPT(scriptContext) \
         LEAVE_SCRIPT_START_EX(scriptContext, /* stackProbe */ true, /* leaveForHost */ true, /* isFPUControlRestoreNeeded */ false)
 

--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -10803,6 +10803,15 @@ void Emit(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator, FuncInfo *func
         {
             byteCodeGenerator->EmitSuperCall(funcInfo, pnode, fReturnValue);
         }
+        else if (pnode->sxCall.pnodeTarget->nop == knopImport)
+        {
+            ParseNodePtr args = pnode->sxCall.pnodeArgs;
+            Assert(CountArguments(args) == 2); // import() takes one argument
+            Emit(args, byteCodeGenerator, funcInfo, false);
+            funcInfo->ReleaseLoc(args);
+            funcInfo->AcquireLoc(pnode);
+            byteCodeGenerator->Writer()->Reg2(Js::OpCode::ImportCall, pnode->location, args->location);
+        }
         else
         {
             if (pnode->sxCall.isApplyCall && funcInfo->GetApplyEnclosesArgs())

--- a/lib/Runtime/ByteCode/OpCodes.h
+++ b/lib/Runtime/ByteCode/OpCodes.h
@@ -734,6 +734,8 @@ MACRO_EXTEND_WMS(       LdHomeObjProto,     Reg2,           OpSideEffect)
 MACRO_EXTEND_WMS(       LdFuncObjProto,     Reg2,           OpSideEffect)
 MACRO_EXTEND_WMS(       SetHomeObj,         Reg2,           OpSideEffect)
 
+MACRO_EXTEND_WMS(       ImportCall,         Reg2,           OpSideEffect)
+
 MACRO_BACKEND_ONLY(     BrFncCachedScopeEq, Reg2,           None)
 MACRO_BACKEND_ONLY(     BrFncCachedScopeNeq,Reg2,           None)
 

--- a/lib/Runtime/Language/InterpreterHandler.inl
+++ b/lib/Runtime/Language/InterpreterHandler.inl
@@ -300,6 +300,7 @@ EXDEF2_WMS(XXtoA1Mem,               ScopedLdHomeObj,            OP_ScopedLdHomeO
 EXDEF2_WMS(XXtoA1Mem,               ScopedLdFuncObj,            OP_ScopedLdFuncObj)
 EXDEF2_WMS(A1toA1Mem,               LdHomeObjProto,             JavascriptOperators::OP_LdHomeObjProto)
 EXDEF2_WMS(A1toA1Mem,               LdFuncObjProto,             JavascriptOperators::OP_LdFuncObjProto)
+EXDEF2_WMS(A1toA1Mem,               ImportCall,                 OP_ImportCall)
 EXDEF2_WMS(A2toXX,                  SetHomeObj,                 JavascriptOperators::OP_SetHomeObj)
   DEF2_WMS(A1toA1Mem,               StrictLdThis,               JavascriptOperators::OP_StrictGetThis)
   DEF2_WMS(A1I1toA1Mem,             ProfiledLdThis,             PROFILEDOP(OP_ProfiledLdThis, JavascriptOperators::OP_GetThisNoFastPath))

--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -7555,6 +7555,11 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
         return JavascriptOperators::OP_ScopedLdFuncObj(function, scriptContext);
     }
 
+    Var InterpreterStackFrame::OP_ImportCall(Var specifier, ScriptContext *scriptContext)
+    {
+        return JavascriptOperators::OP_ImportCall(function, specifier, scriptContext);
+    }
+
     void InterpreterStackFrame::ValidateRegValue(Var value, bool allowStackVar, bool allowStackVarOnDisabledStackNestedFunc) const
     {
 #if DBG

--- a/lib/Runtime/Language/InterpreterStackFrame.h
+++ b/lib/Runtime/Language/InterpreterStackFrame.h
@@ -727,6 +727,7 @@ namespace Js
         template <LayoutSize layoutSize,bool profiled> const byte * OP_ProfiledLoopBodyStart(const byte *ip);
         template <typename T> void OP_ApplyArgs(const unaligned OpLayoutT_Reg5<T> * playout);
         template <class T> void OP_EmitTmpRegCount(const unaligned OpLayoutT_Unsigned1<T> * ip);
+        Var OP_ImportCall(Var specifier, ScriptContext *scriptContext);
 
         HeapArgumentsObject * CreateEmptyHeapArgumentsObject(ScriptContext* scriptContext);
         void TrySetFrameObjectInHeapArgObj(ScriptContext * scriptContext, bool hasNonSimpleParam, bool isScopeObjRestored);

--- a/lib/Runtime/Language/JavascriptOperators.h
+++ b/lib/Runtime/Language/JavascriptOperators.h
@@ -567,6 +567,7 @@ namespace Js
         static Var ScopedLdHomeObjFuncObjHelper(Var scriptFunction, Js::PropertyId propertyId, ScriptContext * scriptContext);
         static Var OP_LdHomeObjProto(Var aRight, ScriptContext* scriptContext);
         static Var OP_LdFuncObjProto(Var aRight, ScriptContext* scriptContext);
+        static Var OP_ImportCall(__in JavascriptFunction *function, __in Var specifier, __in ScriptContext* scriptContext);
 
         static Var OP_ResumeYield(ResumeYieldData* yieldData, RecyclableObject* iterator);
 

--- a/lib/Runtime/Language/SourceTextModuleRecord.h
+++ b/lib/Runtime/Language/SourceTextModuleRecord.h
@@ -41,6 +41,7 @@ namespace Js
         void Mark(Recycler * recycler) override { return; }
 
         HRESULT ResolveExternalModuleDependencies();
+        void EnsureChildModuleSet(ScriptContext *scriptContext);
 
         void* GetHostDefined() const { return hostDefined; }
         void SetHostDefined(void* hostObj) { hostDefined = hostObj; }
@@ -55,11 +56,9 @@ namespace Js
         void SetWasParsed() { wasParsed = true; }
         bool WasDeclarationInitialized() const { return wasDeclarationInitialized; }
         void SetWasDeclarationInitialized() { wasDeclarationInitialized = true; }
-#if DBG
-        bool ParentsNotified() const { return parentsNotified; }
-        void SetParentsNotified() { parentsNotified = true; }
-#endif
         void SetIsRootModule() { isRootModule = true; }
+        JavascriptPromise *GetPromise() { return this->promise; }
+        void SetPromise(JavascriptPromise *value) { this->promise = value; }
 
         void SetImportRecordList(ModuleImportOrExportEntryList* importList) { importRecordList = importList; }
         void SetLocalExportRecordList(ModuleImportOrExportEntryList* localExports) { localExportRecordList = localExports; }
@@ -103,6 +102,8 @@ namespace Js
 
         void SetParent(SourceTextModuleRecord* parentRecord, LPCOLESTR moduleName);
         Utf8SourceInfo* GetSourceInfo() { return this->pSourceInfo; }
+        static Var ResolveOrRejectDynamicImportPromise(bool isResolve, Var value, ScriptContext *scriptContext, SourceTextModuleRecord *mr = nullptr);
+        Var PostProcessDynamicModuleImport();
 
     private:
         const static uint InvalidModuleIndex = 0xffffffff;
@@ -112,9 +113,7 @@ namespace Js
         // This is the parsed tree resulted from compilation. 
         Field(bool) wasParsed;
         Field(bool) wasDeclarationInitialized;
-#if DBG
         Field(bool) parentsNotified;
-#endif
         Field(bool) isRootModule;
         Field(bool) hadNotifyHostReady;
         Field(ParseNodePtr) parseTree;
@@ -148,6 +147,7 @@ namespace Js
         Field(uint) moduleId;
 
         Field(ModuleNameRecord) namespaceRecord;
+        Field(JavascriptPromise*) promise;
 
         HRESULT PostParseProcess();
         HRESULT PrepareForModuleDeclarationInitialization();
@@ -158,6 +158,8 @@ namespace Js
         void InitializeLocalImports();
         void InitializeLocalExports();
         void InitializeIndirectExports();
+        bool ParentsNotified() const { return parentsNotified; }
+        void SetParentsNotified() { parentsNotified = true; }
         PropertyId EnsurePropertyIdForIdentifier(IdentPtr pid);
         LocalExportMap* GetLocalExportMap() const { return localExportMapByExportName; }
         LocalExportIndexList* GetLocalExportIndexList() const { return localExportIndexList; }

--- a/lib/Runtime/Library/JavascriptPromise.cpp
+++ b/lib/Runtime/Library/JavascriptPromise.cpp
@@ -1863,4 +1863,16 @@ namespace Js
 
         return args[0];
     }
+
+    //static
+    JavascriptPromise* JavascriptPromise::CreateEnginePromise(ScriptContext *scriptContext)
+    {
+        JavascriptPromiseResolveOrRejectFunction *resolve = nullptr;
+        JavascriptPromiseResolveOrRejectFunction *reject = nullptr;
+
+        JavascriptPromise *promise = scriptContext->GetLibrary()->CreatePromise();
+        JavascriptPromise::InitializePromise(promise, &resolve, &reject, scriptContext);
+
+        return promise;
+    }
 } // namespace Js

--- a/lib/Runtime/Library/JavascriptPromise.h
+++ b/lib/Runtime/Library/JavascriptPromise.h
@@ -442,6 +442,8 @@ namespace Js
         static Var TryCallResolveOrRejectHandler(Var handler, Var value, ScriptContext* scriptContext);
         static Var TryRejectWithExceptionObject(JavascriptExceptionObject* exceptionObject, Var handler, ScriptContext* scriptContext);
 
+        static JavascriptPromise* CreateEnginePromise(ScriptContext *scriptContext);
+
         Var Resolve(Var resolution, ScriptContext* scriptContext);
         Var Reject(Var resolution, ScriptContext* scriptContext);
 

--- a/test/es6/ModuleCircularBar.js
+++ b/test/es6/ModuleCircularBar.js
@@ -12,3 +12,7 @@ export function increment() {
     counter++;
 }
 export var counter = 0;
+
+export function reset() {
+    counter = 0;
+}

--- a/test/es6/ModuleCircularFoo.js
+++ b/test/es6/ModuleCircularFoo.js
@@ -12,4 +12,4 @@ export function circular_foo() {
         return counter;
     }
 }
-export { circular_bar as rexportbar } from "ModuleCircularBar.js"
+export { circular_bar as rexportbar, reset } from "ModuleCircularBar.js"

--- a/test/es6/ModuleComplexExports.js
+++ b/test/es6/ModuleComplexExports.js
@@ -41,13 +41,18 @@ export { genfoo as genfoo2, genbar, genbar as genbar2 };
 
 export default function () { return 'default'; };
 
-var mutatingExportTarget = function() { return 'before'; };
+var mutatingExportTarget;
+function resetMutatingExportTarget() {
+    mutatingExportTarget = function() { return 'before'; };
+    return 'ok';
+}
 function changeMutatingExportTarget() {
     mutatingExportTarget = function() { return 'after'; };
     return 'ok';
 }
+resetMutatingExportTarget();
 
-export { mutatingExportTarget as target, changeMutatingExportTarget as changeTarget };
+export { mutatingExportTarget as target, changeMutatingExportTarget as changeTarget, resetMutatingExportTarget as reset};
 
 var exportedAsKeyword = 'ModuleComplexExports';
 export { exportedAsKeyword as export };

--- a/test/es6/dynamic-module-functionality.js
+++ b/test/es6/dynamic-module-functionality.js
@@ -1,0 +1,372 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+// ES6 Module functionality tests -- verifies functionality of import and export statements
+
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+
+function testScript(source, message, shouldFail = false, explicitAsync = false) {
+    message += " (script)";
+    let testfunc = () => testRunner.LoadScript(source, undefined, shouldFail, explicitAsync);
+
+    if (shouldFail) {
+        let caught = false;
+
+        assert.throws(testfunc, SyntaxErrr, message);
+        assert.isTrue(caught, `Expected error not thrown: ${message}`);
+    } else {
+        assert.doesNotThrow(testfunc, message);
+    }
+}
+
+function testModuleScript(source, message, shouldFail = false, explicitAsync = false) {
+    message += " (module)";
+    let testfunc = () => testRunner.LoadModule(source, 'samethread', shouldFail, explicitAsync);
+
+    if (shouldFail) {
+        let caught = false;
+
+        // We can't use assert.throws here because the SyntaxError used to construct the thrown error
+        // is from a different context so it won't be strictly equal to our SyntaxError.
+        try {
+            testfunc();
+        } catch(e) {
+            caught = true;
+
+            // Compare toString output of SyntaxError and other context SyntaxError constructor.
+            assert.areEqual(e.constructor.toString(), SyntaxError.toString(), message);
+        }
+
+        assert.isTrue(caught, `Expected error not thrown: ${message}`);
+    } else {
+        assert.doesNotThrow(testfunc, message);
+    }
+}
+
+function testDynamicImport(importFunc, thenFunc, catchFunc, _asyncEnter, _asyncExit) {
+    var promise = importFunc();
+    assert.isTrue(promise instanceof Promise);
+    promise.then((v)=>{
+        _asyncEnter();
+        thenFunc(v);
+        _asyncExit();
+    }).catch((err)=>{
+        _asyncEnter();
+        catchFunc(err);
+        _asyncExit();
+    });
+}
+
+var tests = [
+    {
+        name: "Runtime evaluation of module specifier",
+        body: function () {
+            let functionBody =
+                `testDynamicImport(
+                    ()=>{
+                        var getName = ()=>{ return 'ModuleSimpleExport'; };
+                        return import( getName() + '.js');
+                    },
+                    (v)=>{
+                        assert.areEqual('ModuleSimpleExport', v.ModuleSimpleExport_foo(), 'Failed to import ModuleSimpleExport_foo from ModuleSimpleExport.js');
+                    },
+                    (err)=>{ assert.fail(err.message); }, _asyncEnter, _asyncExit
+                )`;
+            testScript(functionBody, "Test importing a simple exported function", false, true);
+            testModuleScript(functionBody, "Test importing a simple exported function", false, true);
+        }
+    },
+    {
+        name: "Validate a simple module export",
+        body: function () {
+            let functionBody =
+                `testDynamicImport(
+                    ()=>{ return import('ModuleSimpleExport.js'); },
+                    (v)=>{ assert.areEqual('ModuleSimpleExport', v.ModuleSimpleExport_foo(), 'Failed to import ModuleSimpleExport_foo from ModuleSimpleExport.js'); },
+                    (err)=>{ assert.fail(err.message); }, _asyncEnter, _asyncExit
+                )`;
+            testScript(functionBody, "Test importing a simple exported function", false, true);
+            testModuleScript(functionBody, "Test importing a simple exported function", false, true);
+        }
+    },
+    {
+        name: "Validate importing from multiple modules",
+        body: function () {
+            let functionBody =
+                `testDynamicImport(
+                    ()=>import('ModuleComplexExports.js'),
+                    (v)=>{
+                        assert.areEqual('foo', v.foo2(), 'Failed to import foo2 from ModuleComplexExports.js');
+                    },
+                    (err)=>{ assert.fail(err.message); }, _asyncEnter, _asyncExit
+                )`;
+            testScript(functionBody, "Test importing from multiple modules", false, true);
+            testModuleScript(functionBody, "Test importing from multiple modules", false, true);
+        }
+    },
+    {
+        name: "Validate a variety of more complex exports",
+        body: function () {
+            let functionBody =
+                `testDynamicImport(
+                    ()=>import('ModuleComplexExports.js'),
+                    (v)=>{
+                        assert.areEqual('foo', v.foo(), 'Failed to import foo from ModuleComplexExports.js');
+                        assert.areEqual('foo', v.foo2(), 'Failed to import foo2 from ModuleComplexExports.js');
+                        assert.areEqual('bar', v.bar(), 'Failed to import bar from ModuleComplexExports.js');
+                        assert.areEqual('bar', v.bar2(), 'Failed to import bar2 from ModuleComplexExports.js');
+                        assert.areEqual('let2', v.let2, 'Failed to import let2 from ModuleComplexExports.js');
+                        assert.areEqual('let3', v.let3, 'Failed to import let3 from ModuleComplexExports.js');
+                        assert.areEqual('let2', v.let4, 'Failed to import let4 from ModuleComplexExports.js');
+                        assert.areEqual('let3', v.let5, 'Failed to import let5 from ModuleComplexExports.js');
+                        assert.areEqual('const2', v.const2, 'Failed to import const2 from ModuleComplexExports.js');
+                        assert.areEqual('const3', v.const3, 'Failed to import const3 from ModuleComplexExports.js');
+                        assert.areEqual('const2', v.const4, 'Failed to import const4 from ModuleComplexExports.js');
+                        assert.areEqual('const3', v.const5, 'Failed to import const5 from ModuleComplexExports.js');
+                        assert.areEqual('var2', v.var2, 'Failed to import var2 from ModuleComplexExports.js');
+                        assert.areEqual('var3', v.var3, 'Failed to import var3 from ModuleComplexExports.js');
+                        assert.areEqual('var2', v.var4, 'Failed to import var4 from ModuleComplexExports.js');
+                        assert.areEqual('var3', v.var5, 'Failed to import var5 from ModuleComplexExports.js');
+                        assert.areEqual('class2', v.class2.static_member(), 'Failed to import class2 from ModuleComplexExports.js');
+                        assert.areEqual('class2', new v.class2().member(), 'Failed to create intance of class2 from ModuleComplexExports.js');
+                        assert.areEqual('class2', v.class3.static_member(), 'Failed to import class3 from ModuleComplexExports.js');
+                        assert.areEqual('class2', new v.class3().member(), 'Failed to create intance of class3 from ModuleComplexExports.js');
+                        assert.areEqual('class4', v.class4.static_member(), 'Failed to import class4 from ModuleComplexExports.js');
+                        assert.areEqual('class4', new v.class4().member(), 'Failed to create intance of class4 from ModuleComplexExports.js');
+                        assert.areEqual('class4', v.class5.static_member(), 'Failed to import class4 from ModuleComplexExports.js');
+                        assert.areEqual('class4', new v.class5().member(), 'Failed to create intance of class4 from ModuleComplexExports.js');
+                        assert.areEqual('default', v.default(), 'Failed to import default from ModuleComplexExports.js');
+                        assert.areEqual('ModuleComplexExports', v.function, 'Failed to import v.function from ModuleComplexExports.js');
+                        assert.areEqual('ModuleComplexExports', v.export, 'Failed to import v.export from ModuleComplexExports.js');
+                    },
+                    (err)=>{ assert.fail(err.message); }, _asyncEnter, _asyncExit);
+                `;
+            testScript(functionBody, "Test importing a variety of exports", false, true);
+            testModuleScript(functionBody, "Test importing a variety of exports", false, true);
+        }
+    },
+    {
+        name: "Exporting module changes exported value",
+        body: function () {
+            let functionBody =
+                `testDynamicImport(
+                    ()=>import('ModuleComplexExports.js'),
+                    (v)=>{
+                        v.reset();
+                        assert.areEqual('before', v.target(), 'Failed to import target from ModuleComplexExports.js');
+                        assert.areEqual('ok', v.changeTarget(), 'Failed to import changeTarget from ModuleComplexExports.js');
+                        assert.areEqual('after', v.target(), 'changeTarget failed to change export value');
+                    },
+                    (err)=>{ assert.fail(err.message); }, _asyncEnter, _asyncExit);
+                `;
+            testScript(functionBody, "Changing exported value", false, true);
+            testModuleScript(functionBody, "Changing exported value", false, true);
+        }
+    },
+    {
+        name: "Simple re-export forwards import to correct slot",
+        body: function () {
+            let functionBody =
+                `testDynamicImport(
+                    ()=>import('ModuleSimpleReexport.js'),
+                    (v)=>{
+                        assert.areEqual('ModuleSimpleExport', v.ModuleSimpleExport_foo(), 'Failed to import ModuleSimpleExport_foo from ModuleSimpleReexport.js');
+                    },
+                    (err)=>{ assert.fail(err.message); }, _asyncEnter, _asyncExit);
+                `;
+            testScript(functionBody, "Simple re-export from one module to another", false, true);
+            testModuleScript(functionBody, "Simple re-export from one module to another", false, true);
+        }
+    },
+    {
+        name: "Renamed re-export and dynamic import",
+        body: function () {
+            let functionBody =
+                `testDynamicImport(
+                    ()=>import('ModuleComplexReexports.js'),
+                    (v)=>{
+                        assert.areEqual('bar', v.ModuleComplexReexports_foo(), 'Failed to import ModuleComplexReexports_foo from ModuleComplexReexports.js');
+                    },
+                    (err)=>{ assert.fail(err.message); }, _asyncEnter, _asyncExit);
+                `;
+            testScript(functionBody, "Rename already renamed re-export", false, true);
+            testModuleScript(functionBody, "Rename already renamed re-export", false, true);
+        }
+    },
+    {
+        name: "Explicit export/import to default binding",
+        body: function () {
+            let functionBody =
+                `testDynamicImport(
+                    ()=>import('ModuleDefaultExport1.js'),
+                    (v)=>{
+                        assert.areEqual('ModuleDefaultExport1', v.default(), 'Failed to import default from ModuleDefaultExport1.js');
+                    },
+                    (err)=>{ assert.fail(err.message); }, _asyncEnter, _asyncExit);
+                `;
+            testScript(functionBody, "Explicitly export and import a local name to the default binding", false, true);
+            testModuleScript(functionBody, "Explicitly export and import a local name to the default binding", false, true);
+        }
+    },
+    {
+        name: "Explicit import of default binding",
+        body: function () {
+            let functionBody =
+                `testDynamicImport(
+                    ()=>import('ModuleDefaultExport2.js'),
+                    (v)=>{
+                        assert.areEqual('ModuleDefaultExport2', v.default(), 'Failed to import default from ModuleDefaultExport2.js');
+                    },
+                    (err)=>{ assert.fail(err.message); }, _asyncEnter, _asyncExit);
+                `;
+            testScript(functionBody, "Explicitly import the default export binding", false, true);
+            testModuleScript(functionBody, "Explicitly import the default export binding", false, true);
+        }
+    },
+    {
+        name: "Exporting module changes value of default export",
+        body: function () {
+            let functionBody =
+                `testDynamicImport(
+                    ()=>import('ModuleDefaultExport3.js'),
+                    (v)=>{
+                        assert.areEqual(2, v.default, 'Failed to import default from ModuleDefaultExport3.js');
+                    },
+                    (err)=>{ assert.fail(err.message); }, _asyncEnter, _asyncExit);
+                `;
+            testScript(functionBody, "Exported value incorrectly bound", false, true);
+            testModuleScript(functionBody, "Exported value incorrectly bound", false, true);
+
+            functionBody =
+                `testDynamicImport(
+                    ()=>import('ModuleDefaultExport4.js'),
+                    (v)=>{
+                        assert.areEqual(1, v.default, 'Failed to import default from ModuleDefaultExport4.js');
+                    },
+                    (err)=>{ assert.fail(err.message); }, _asyncEnter, _asyncExit);
+                `;
+            testScript(functionBody, "Exported value incorrectly bound", false, true);
+            testModuleScript(functionBody, "Exported value incorrectly bound", false, true);
+        }
+    },
+    {
+        name: "Import bindings used in a nested function",
+        body: function () {
+            let functionBody =
+                `function test(func) {
+                    assert.areEqual('ModuleDefaultExport2', func(), 'Failed to import default from ModuleDefaultExport2.js');
+                }
+                testDynamicImport(
+                    ()=>import('ModuleDefaultExport2.js'),
+                    (v)=>test(v.default),
+                    (err)=>{ assert.fail(err.message); }, _asyncEnter, _asyncExit);
+                `;
+            testScript(functionBody, "Failed to find imported name correctly in nested function", false, true);
+            testModuleScript(functionBody, "Failed to find imported name correctly in nested function", false, true);
+        }
+    },
+    {
+        name: "Exported name may be any keyword",
+        body: function () {
+            let functionBody =
+                `testDynamicImport(
+                    ()=>import('ModuleComplexExports.js'),
+                    (v)=>{
+                        assert.areEqual('ModuleComplexExports', v.export, 'Failed to import export from ModuleDefaultExport2.js');
+                        assert.areEqual('ModuleComplexExports', v.function, 'Failed to import function from ModuleDefaultExport2.js');
+                    },
+                    (err)=>{ assert.fail(err.message); }, _asyncEnter, _asyncExit);
+                `;
+            testScript(functionBody, "Exported name may be a keyword (import binding must be binding identifier)", false, true);
+            testModuleScript(functionBody, "Exported name may be a keyword (import binding must be binding identifier)", false, true);
+        }
+    },
+    {
+        name: "Odd case of 'export { as as as }; import { as as as };'",
+        body: function () {
+            let functionBody =
+                `testDynamicImport(
+                    ()=>import('ModuleComplexExports.js'),
+                    (v)=>{
+                        assert.areEqual('as', v.as(), 'String "as" is not reserved word');
+                    },
+                    (err)=>{ assert.fail(err.message); }, _asyncEnter, _asyncExit);
+                `;
+            testScript(functionBody, "Test 'import { as as as}'", false, true);
+            testModuleScript(functionBody, "Test 'import { as as as}'", false, true);
+        }
+    },
+    {
+        name: "Typeof a module export",
+        body: function () {
+            let functionBody =
+                `testDynamicImport(
+                    ()=>import('ModuleDefaultExport2.js'),
+                    (v)=>{
+                        assert.areEqual('function', typeof v.default, 'typeof default export from ModuleDefaultExport2.js is function');
+                    },
+                    (err)=>{ assert.fail(err.message); }, _asyncEnter, _asyncExit);
+                `;
+
+            testScript(functionBody, "Typeof a module export", false, true);
+            testModuleScript(functionBody, "Typeof a module export", false, true);
+        }
+    },
+    {
+        name: "Circular module dependency",
+        body: function () {
+            let functionBody =
+                `testDynamicImport(
+                    ()=>import('ModuleCircularFoo.js'),
+                    (v)=>{
+                        v.reset();
+                        assert.areEqual(2, v.circular_foo(), 'This function calls between both modules in the circular dependency incrementing a counter in each');
+                        assert.areEqual(4, v.rexportbar(), 'Second call originates in the other module but still increments the counter twice');
+                    },
+                    (err)=>{ assert.fail(err.message); }, _asyncEnter, _asyncExit);
+                `;
+
+            testScript(functionBody, "Circular module dependency", false, true);
+            testModuleScript(functionBody, "Circular module dependency", false, true);
+
+        }
+    },
+    {
+        name: "Implicitly re-exporting an import binding (import { foo } from ''; export { foo };)",
+        body: function () {
+            let functionBody =
+                `testDynamicImport(
+                    ()=>import('ModuleComplexReexports.js'),
+                    (v)=>{
+                        assert.areEqual('foo', v.foo(), 'Simple implicit re-export');
+                        assert.areEqual('foo', v.baz(), 'Renamed export imported and renamed during implicit re-export');
+                        assert.areEqual('foo', v.localfoo(), 'Export renamed as import and implicitly re-exported');
+                        assert.areEqual('foo', v.bar(), 'Renamed export renamed as import and renamed again during implicit re-exported');
+                        assert.areEqual('foo', v.localfoo2(), 'Renamed export renamed as import and implicitly re-exported');
+                        assert.areEqual('foo', v.bar2(), 'Renamed export renamed as import and renamed again during implicit re-export');
+                    },
+                    (err)=>{ assert.fail(err.message); }, _asyncEnter, _asyncExit);
+                `;
+
+            testScript(functionBody, "Implicitly re-exporting an import binding (import { foo } from ''; export { foo };)", false, true);
+            testModuleScript(functionBody, "Implicitly re-exporting an import binding (import { foo } from ''; export { foo };)", false, true);
+        }
+    },
+    {
+        name: "Validate a simple module export inside eval()",
+        body: function () {
+            let functionBody =
+                `testDynamicImport(
+                    ()=>{ return eval("import('ModuleSimpleExport.js')"); },
+                    (v)=>{ assert.areEqual('ModuleSimpleExport', v.ModuleSimpleExport_foo(), 'Failed to import ModuleSimpleExport_foo from ModuleSimpleExport.js'); },
+                    (err)=>{ assert.fail(err.message); }, _asyncEnter, _asyncExit
+                )`;
+            testScript(functionBody, "Test importing a simple exported function", false, true);
+            testModuleScript(functionBody, "Test importing a simple exported function", false, true);
+        }
+    },
+];
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/es6/dynamic-module-import-specifier.js
+++ b/test/es6/dynamic-module-import-specifier.js
@@ -1,0 +1,142 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+// ES6 Module functionality tests -- verifies functionality of import and export statements
+
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+
+function testScript(source, message, shouldFail = false, explicitAsync = false) {
+    message += " (script)";
+    let testfunc = () => testRunner.LoadScript(source, undefined, shouldFail, explicitAsync);
+
+    if (shouldFail) {
+        let caught = false;
+
+        assert.throws(testfunc, SyntaxErrr, message);
+        assert.isTrue(caught, `Expected error not thrown: ${message}`);
+    } else {
+        assert.doesNotThrow(testfunc, message);
+    }
+}
+
+function testModuleScript(source, message, shouldFail = false, explicitAsync = false) {
+    message += " (module)";
+    let testfunc = () => testRunner.LoadModule(source, 'samethread', shouldFail, explicitAsync);
+
+    if (shouldFail) {
+        let caught = false;
+
+        // We can't use assert.throws here because the SyntaxError used to construct the thrown error
+        // is from a different context so it won't be strictly equal to our SyntaxError.
+        try {
+            testfunc();
+        } catch(e) {
+            caught = true;
+
+            // Compare toString output of SyntaxError and other context SyntaxError constructor.
+            assert.areEqual(e.constructor.toString(), SyntaxError.toString(), message);
+        }
+
+        assert.isTrue(caught, `Expected error not thrown: ${message}`);
+    } else {
+        assert.doesNotThrow(testfunc, message);
+    }
+}
+
+function testDynamicImport(importFunc, thenFunc, catchFunc, _asyncEnter, _asyncExit) {
+    var promise = importFunc();
+    assert.isTrue(promise instanceof Promise);
+    promise.then((v)=>{
+        _asyncEnter();
+        thenFunc(v);
+        _asyncExit();
+    }).catch((err)=>{
+        _asyncEnter();
+        catchFunc(err);
+        _asyncExit();
+    });
+}
+
+var tests = [
+    {
+        name: "Valid cases for import()",
+        body: function () {
+                let functionBody =
+                    `
+                    assert.doesNotThrow(function () { eval("import(undefined)"); }, "undefined");
+                    assert.doesNotThrow(function () { eval("import(null)"); }, "null");
+                    assert.doesNotThrow(function () { eval("import(true)"); }, "boolean - true");
+                    assert.doesNotThrow(function () { eval("import(false)"); }, "boolean - false");
+                    assert.doesNotThrow(function () { eval("import(1234567890)"); }, "number");
+                    assert.doesNotThrow(function () { eval("import('abc789cde')"); }, "string literal");
+                    assert.doesNotThrow(function () { eval("import('number' + 100 + 0.4 * 18)"); }, "expression");
+                    assert.doesNotThrow(function () { eval("import(import(true))"); }, "nested import");
+                    assert.doesNotThrow(function () { eval("import(import(Infinity) + import(undefined))"); }, "nested import expression");
+                    `;
+
+                testScript(functionBody, "Test importing a simple exported function");
+                testModuleScript(functionBody, "Test importing a simple exported function");
+        }
+    },
+    {
+        name: "Syntax errors for import() call",
+        body: function () {
+                let functionBody =
+                    `
+                    assert.throws(function () { eval("import()"); }, SyntaxError, "no argument");
+                    assert.throws(function () { eval("import(1, 2)"); }, SyntaxError, "more than one arguments");
+                    assert.throws(function () { eval("import('abc.js', 'def.js')"); }, SyntaxError, "more than one argument - case 2");
+                    assert.throws(function () { eval("import(...['abc.js', 'def.js'])"); }, SyntaxError, "spread argument");
+                    `;
+
+                testScript(functionBody, "Test importing a simple exported function");
+                testModuleScript(functionBody, "Test importing a simple exported function");
+        }
+    },
+    {
+        name: "Module specifier that are not string",
+        body: function () {
+            var testNonStringSpecifier = function (specifier, expectedType, expectedErrMsg, message) {
+                if (typeof message === "undefined" ) {
+                    message = specifier;
+                }
+
+                let functionBody =
+                    `testDynamicImport(
+                        ()=>{
+                            return import(${specifier});
+                        },
+                        (v)=>{
+                            assert.fail('Expected: promise rejected; actual: promise resolved: ' + '${message}');
+                        },
+                        (err)=>{
+                            assert.isTrue(err instanceof Error, '${message}');
+                            assert.areEqual(${expectedType}, err.constructor, '${message}');
+                            assert.areEqual("${expectedErrMsg}", err.message, '${message}');
+                        }, _asyncEnter, _asyncExit
+                    )`;
+
+                testScript(functionBody, "Test importing a simple exported function", false, true);
+                testModuleScript(functionBody, "Test importing a simple exported function", false, true);
+            };
+
+            testNonStringSpecifier("undefined", "URIError", "undefined");
+            testNonStringSpecifier("null", "URIError", "null");
+            testNonStringSpecifier("true", "URIError", "true");
+            testNonStringSpecifier("false", "URIError", "false");
+            testNonStringSpecifier("NaN", "URIError", "NaN");
+            testNonStringSpecifier("+0", "URIError", "0");
+            testNonStringSpecifier("-0", "URIError", "0");
+            testNonStringSpecifier("-12345", "URIError", "-12345");
+            testNonStringSpecifier("1/0", "URIError", "Infinity");
+            testNonStringSpecifier("1.123456789012345678901", "URIError", "1.1234567890123457");
+            testNonStringSpecifier("-1.123456789012345678901", "URIError", "-1.1234567890123457");
+            testNonStringSpecifier('Symbol("abc")', "TypeError", "Object doesn't support property or method 'ToString'");
+            testNonStringSpecifier("{}", "URIError", "[object Object]");
+        }
+    },
+];
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/es6/es6_stable.baseline
+++ b/test/es6/es6_stable.baseline
@@ -31,8 +31,8 @@ FLAG ES6 = 1 - setting child flag ES6IsConcatSpreadable = 1
 FLAG ES6IsConcatSpreadable = 1
 FLAG ES6 = 1 - setting child flag ES6Math = 1
 FLAG ES6Math = 1
-FLAG ES6 = 1 - setting child flag ES6Module = 0
-FLAG ES6Module = 0
+FLAG ES6 = 1 - setting child flag ES6Module = 1
+FLAG ES6Module = 1
 FLAG ES6 = 1 - setting child flag ES6Object = 1
 FLAG ES6Object = 1
 FLAG ES6 = 1 - setting child flag ES6Number = 1

--- a/test/es6/es6_stable.enable_disable.baseline
+++ b/test/es6/es6_stable.enable_disable.baseline
@@ -31,8 +31,8 @@ FLAG ES6 = 1 - setting child flag ES6IsConcatSpreadable = 1
 FLAG ES6IsConcatSpreadable = 1
 FLAG ES6 = 1 - setting child flag ES6Math = 1
 FLAG ES6Math = 1
-FLAG ES6 = 1 - setting child flag ES6Module = 0
-FLAG ES6Module = 0
+FLAG ES6 = 1 - setting child flag ES6Module = 1
+FLAG ES6Module = 1
 FLAG ES6 = 1 - setting child flag ES6Object = 1
 FLAG ES6Object = 1
 FLAG ES6 = 1 - setting child flag ES6Number = 1

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -1363,6 +1363,20 @@
 </test>
 <test>
     <default>
+        <files>dynamic-module-functionality.js</files>
+        <compile-flags>-ES6Module -args summary -endargs</compile-flags>
+        <tags>exclude_sanitize_address</tags>
+    </default>
+</test>
+<test>
+    <default>
+        <files>dynamic-module-import-specifier.js</files>
+        <compile-flags>-AsyncModuleLoad -ES6Module -args summary -endargs</compile-flags>
+        <tags>exclude_sanitize_address</tags>
+    </default>
+</test>
+<test>
+    <default>
         <files>module-syntax.js</files>
         <compile-flags>-ES6Module -force:deferparse -args summary -endargs</compile-flags>
         <tags>exclude_sanitize_address</tags>


### PR DESCRIPTION
This PR adds support for `import()` dynamic module import sematic.

Per https://github.com/tc39/proposal-dynamic-import:

"A call to `import(specifier)` returns a promise for the module namespace object of the requested module, which is created after fetching, instantiating, and evaluating all of the module's dependencies, as well as the module itself.

"Here specifier will be interpreted the same way as in an import declaration (i.e., the same strings will work in both places). However, while specifier is a string it is not necessarily a string literal; thus code like import(`./language-packs/${navigator.language}.js`) will work—something impossible to accomplish with the usual import declarations.

"`import()` is proposed to work in both scripts and modules. This gives script code an easy asynchronous entry point into the module world, allowing it to start running module code."

This PR includes following changes:
	- Update parser and bytecode generator to support `import()` sematic in module and in script
	- Add new bytecode `ImportCall`
	- Add runtime function for `import()` that:
		○ Uses caller from stack to look up module record or source context that are associated with the module or script from which `import()` is called
		○ Requests host to load target module source file (gets module record in return)
		○ Creates promise unless the module record has one
		○ Resolves/rejects promise if appropriates
		○ Returns promise
	- Add new host callback (`FetchImportedModuleFromScript`) for fetching imported module from script (accepts source context)
	- Add `promiseCapability` field to module record class
	- Update `SourceTextModuleRecord`'s methods to accept callback from host and to handle dynamically imported module and its promise capability
	- Update exception checks and assertions to cover new usage scenario of importing and evaluating module code with active script
Add unit tests for dynamic import functionality
