### PR TITLE
Fix #962: Copyright Check should check versus target branch instead of master.

### DIFF
--- a/jenkins/check_copyright.sh
+++ b/jenkins/check_copyright.sh
@@ -18,7 +18,7 @@ rm -f $ERRFILE
 rm -f $ERRFILETEMP
 
 echo "Check Copyright > Begin Checking..."
-git diff --name-only `git merge-base origin/master HEAD` HEAD |
+git diff --name-only `git merge-base origin/$ghprbTargetBranch HEAD` HEAD |
     grep -v -E '\.git.*' |
     grep -v -E '\.xml$' |
     grep -v -E '\.props$' |


### PR DESCRIPTION
See tests of the functionality in the following PRs:

* #2896 (`release/1.4-ci`)
* #2924 (`release/1.4` test output comparison)
* #2925 (`release/2.0-ci`)
* #2926 (`release/2.0` test output comparison)

Fixes #962