### PR TITLE
Fix #962: Copyright check versus target branch; Fix #2928: use Ubuntu 16.04 for style checks

### DIFF
--- a/jenkins/check_copyright.sh
+++ b/jenkins/check_copyright.sh
@@ -18,7 +18,7 @@ rm -f $ERRFILE
 rm -f $ERRFILETEMP
 
 echo "Check Copyright > Begin Checking..."
-git diff --name-only `git merge-base origin/master HEAD` HEAD |
+git diff --name-only `git merge-base origin/$ghprbTargetBranch HEAD` HEAD |
     grep -v -E '\.git.*' |
     grep -v -E '\.xml$' |
     grep -v -E '\.props$' |

--- a/netci.groovy
+++ b/netci.groovy
@@ -20,7 +20,6 @@ def msbuildTypeMap = [
 def machineTypeToOSTagMap = [
     'Windows 7': 'Windows 7',
     'Windows_NT': 'Windows',
-    'Ubuntu14.04': 'Ubuntu14.04',
     'Ubuntu16.04': 'Ubuntu',
     'OSX': 'OSX'
 ]
@@ -212,7 +211,7 @@ def CreateStyleCheckTasks = { taskString, taskName, checkName ->
             Utilities.addGithubPushTrigger(newJob)
         }
 
-        Utilities.setMachineAffinity(newJob, 'Ubuntu14.04', 'latest-or-auto')
+        Utilities.setMachineAffinity(newJob, 'Ubuntu16.04', 'latest-or-auto')
     }
 }
 


### PR DESCRIPTION
Replaces #2927

Fix #962: Copyright Check should check versus target branch instead of master.

See tests of the functionality in the following PRs:

- #2896 (release/1.4-ci)
- #2924 (release/1.4 test output comparison)
- #2925 (release/2.0-ci)
- #2926 (release/2.0 test output comparison)

Fix #2928: Update Style Checks to use Ubuntu16.04.

- Tested in #2929

Fixes #962
Fixes #2928