### PR TITLE
Fixing uninitialized pointer freeing in ArgInfo deconstructor

### DIFF
--- a/bin/ch/ChakraRtInterface.h
+++ b/bin/ch/ChakraRtInterface.h
@@ -196,6 +196,22 @@ public:
         HostPrintUsageFuncPtr hostPrintUsage;
         char* filename;
 
+        ArgInfo() :
+            argc(0),
+            argv(nullptr),
+            hostPrintUsage(nullptr),
+            filename(nullptr)
+        {
+        }
+
+        ArgInfo(int argc, LPWSTR* argv, HostPrintUsageFuncPtr hostPrintUsage, char* filename) :
+            argc(argc),
+            argv(argv),
+            hostPrintUsage(hostPrintUsage),
+            filename(filename)
+        {
+        }
+
         ~ArgInfo()
         {
             if (filename != nullptr)


### PR DESCRIPTION
Fixes #2932 