### PR TITLE
Fix summary.log by appending to file instead of overwriting it.

### DIFF
--- a/test/jenkins.testall.cmd
+++ b/test/jenkins.testall.cmd
@@ -102,7 +102,7 @@ set _HadFailures=0
 
   pushd %_TestDir%\logs
   findstr /sp failed rl.results.log > summary.log
-  findstr /sip failed nativetests.log > summary.log
+  findstr /sip failed nativetests.log >> summary.log
   rem Echo to stderr so that VSO includes the output in the build summary
   type summary.log 1>&2
   popd

--- a/test/jenkins.testone.cmd
+++ b/test/jenkins.testone.cmd
@@ -98,7 +98,7 @@ set _HadFailures=0
 
   pushd %_LogDir%
   findstr /sp failed rl.results.log > summary.log
-  findstr /sip failed nativetests.log > summary.log
+  findstr /sip failed nativetests.log >> summary.log
   rem Echo to stderr so that VSO includes the output in the build summary
   type summary.log 1>&2
   popd

--- a/test/runcitests.cmd
+++ b/test/runcitests.cmd
@@ -158,7 +158,7 @@ set _HadFailures=0
 
   pushd %_TestDir%\logs
   findstr /sp failed rl.results.log > %1
-  findstr /sip failed nativetests.log > %1
+  findstr /sip failed nativetests.log >> %1
   rem Echo to stderr so that VSO includes the output in the build summary
   type %1 1>&2
   popd


### PR DESCRIPTION
For a while now, summary.log has been empty in CI artifacts when unit tests fail. Turns out we were overwriting the file with native test results instead of appending to it.