### PR TITLE
xplat: minor changes

### DIFF
--- a/lib/Common/Common/NumberUtilities.cpp
+++ b/lib/Common/Common/NumberUtilities.cpp
@@ -125,8 +125,8 @@ namespace Js
         {
             mov eax, lu1
             mul lu2
-                mov ebx, pluHi
-                mov DWORD PTR[ebx], edx
+            mov ebx, pluHi
+            mov DWORD PTR[ebx], edx
         }
 #else //!I386_ASM
         DWORDLONG llu = UInt32x32To64(lu1, lu2);

--- a/lib/Common/Core/SysInfo.cpp
+++ b/lib/Common/Core/SysInfo.cpp
@@ -109,11 +109,12 @@ AutoSystemInfo::Initialize()
         disableDebugScopeCapture = false;
     }
 
-    this->shouldQCMoreFrequently = false;
     this->supportsOnlyMultiThreadedCOM = false;
 #if defined(__ANDROID__) || defined(__IOS__)
     this->isLowMemoryDevice = true;
+    this->shouldQCMoreFrequently = true;
 #else
+    this->shouldQCMoreFrequently = false;
     this->isLowMemoryDevice = false;
 #endif
 

--- a/lib/Jsrt/JsrtInternal.h
+++ b/lib/Jsrt/JsrtInternal.h
@@ -34,7 +34,7 @@ typedef struct {} TTDRecorder;
             {  \
                 return JsErrorWrongRuntime;  \
             }  \
-            p = Js::CrossSite::MarshalVar(scriptContext, __obj); \
+            p = Js::CrossSite::MarshalVar(scriptContext, __obj, true); \
         }
 
 #define VALIDATE_INCOMING_RUNTIME_HANDLE(p) \
@@ -407,8 +407,8 @@ void HandleScriptCompileError(Js::ScriptContext * scriptContext, CompileScriptEx
 #else
 #define PERFORM_JSRT_TTD_RECORD_ACTION_CHECK(CTX) false
 
-#define PERFORM_JSRT_TTD_RECORD_ACTION(CTX, ACTION_CODE, ...) 
-#define PERFORM_JSRT_TTD_RECORD_ACTION_RESULT(CTX, RESULT) 
+#define PERFORM_JSRT_TTD_RECORD_ACTION(CTX, ACTION_CODE, ...)
+#define PERFORM_JSRT_TTD_RECORD_ACTION_RESULT(CTX, RESULT)
 
-#define PERFORM_JSRT_TTD_RECORD_ACTION_NOT_IMPLEMENTED(CTX) 
+#define PERFORM_JSRT_TTD_RECORD_ACTION_NOT_IMPLEMENTED(CTX)
 #endif

--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -1712,6 +1712,7 @@ ThreadContext::ProbeStackNoDispose(size_t size, Js::ScriptContext *scriptContext
         Js::Throw::StackOverflow(scriptContext, returnAddress);
     }
 
+#if defined(NTBUILD) || defined(__IOS__) || defined(__ANDROID__)
     // Use every Nth stack probe as a QC trigger.
     if (AutoSystemInfo::ShouldQCMoreFrequently() && this->HasInterruptPoller() && this->IsScriptActive())
     {
@@ -1722,6 +1723,7 @@ ThreadContext::ProbeStackNoDispose(size_t size, Js::ScriptContext *scriptContext
             this->CheckInterruptPoll();
         }
     }
+#endif
 }
 
 void


### PR DESCRIPTION
- do not check QCMoreFreq.. on non mobile platforms
   Removes redundant check on unrelated platforms.

- use force marshal instead of double condition
   If scriptContext doesn't match, no point comparing it again.

