### PR TITLE
Fix bugs from PropertyString cache changes

### DIFF
--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -3725,7 +3725,7 @@ CommonNumber:
                 goto TaggedIntIndex;
             }
         }
-        else if (JavascriptString::Is(index)) // fastpath for PropertyStrings
+        else if (JavascriptString::Is(index) && RecyclableObject::Is(instance)) // fastpath for PropertyStrings
         {
             temp = JavascriptString::FromVar(index);
             Assert(temp->GetScriptContext() == scriptContext);

--- a/lib/Runtime/Types/DynamicObjectPropertyEnumerator.cpp
+++ b/lib/Runtime/Types/DynamicObjectPropertyEnumerator.cpp
@@ -232,7 +232,6 @@ namespace Js
     JavascriptString * DynamicObjectPropertyEnumerator::MoveAndGetNextNoCache(PropertyId& propertyId, PropertyAttributes * attributes)
     {
         JavascriptString* propertyString = nullptr;
-
         BigPropertyIndex newIndex = this->objectIndex;
         PropertyValueInfo info;
         RecyclableObject * startingObject = this->object;
@@ -247,12 +246,14 @@ namespace Js
                 // No more properties
                 newIndex--;
                 propertyString = nullptr;
+                PropertyValueInfo::ClearCacheInfo(&info);
                 break;
             }
         } while (Js::IsInternalPropertyId(propertyId));
 
         if (info.GetPropertyString() != nullptr && info.GetPropertyString()->ShouldUseCache())
         {
+            Assert(propertyString == info.GetPropertyString());
             CacheOperators::CachePropertyRead(startingObject, this->object, false, propertyId, false, &info, scriptContext);
             if (info.IsStoreFieldCacheEnabled() && info.IsWritable() && ((info.GetFlags() & (InlineCacheGetterFlag | InlineCacheSetterFlag)) == 0))
             {

--- a/lib/Runtime/Types/RecyclableObject.cpp
+++ b/lib/Runtime/Types/RecyclableObject.cpp
@@ -84,6 +84,7 @@ namespace Js
             info->functionBody = nullptr;
             info->inlineCache = nullptr;
             info->polymorphicInlineCache = nullptr;
+            info->propertyString = nullptr;
             info->inlineCacheIndex = Constants::NoInlineCacheIndex;
             info->allowResizingPolymorphicInlineCache = true;
         }

--- a/lib/Runtime/Types/SimpleDictionaryTypeHandler.cpp
+++ b/lib/Runtime/Types/SimpleDictionaryTypeHandler.cpp
@@ -643,7 +643,7 @@ namespace Js
                         PropertyValueInfo::SetCacheInfo(info, propertyString, propertyString->GetLdElemInlineCache(), false);
                         SetPropertyValueInfo(info, instance, descriptor.propertyIndex, descriptor.Attributes);
 
-                        if (descriptor.isFixed)
+                        if (!descriptor.isInitialized || descriptor.isFixed)
                         {
                             PropertyValueInfo::DisableStoreFieldCache(info);
                         }


### PR DESCRIPTION
Fixes following:
We were not disabling StoreFieldCache for SimpleDictionaryTypeHandle if PropertyDescriptor is not initialized.
We were attempting to cache enumeration of InternalPropertyId in case it was the last property.
We were attempting to cache property reads when object of a LdElem was a tagged number.