### PR TITLE
Prevent clearing of closure environment from live eval function object. 

### DIFF
--- a/test/GlobalFunctions/eval1.js
+++ b/test/GlobalFunctions/eval1.js
@@ -110,6 +110,20 @@ alias();
 // bug 1147044
 eval("with ({}) (function fibonacci() {})();"); 
 
+// Test recursive evals to make sure closure environments remain intact
+var flg = 0;
+function TestDirect() {
+  var func = "if(flg == 0) { flg = 1; eval(func); (function(a){(function(){if (a !== undefined) throw 0;})()})(); WScript.Echo('pass direct')}";
+  eval(func);
+}
+TestDirect();
+
+var func = "if(flg == 1) { flg = 2; this.eval(func); (function(a){(function(){if (a !== undefined) throw 0;})()})(); WScript.Echo('pass indirect');}";
+function TestIndirect() {
+  this.eval(func);
+}
+TestIndirect();
+
 // 8. Set up a custom eval that indirectly calls built-in eval, evoke it, and verify the effect.
 var q = eval;
 var eval = function(s) {

--- a/test/GlobalFunctions/eval1_v3.baseline
+++ b/test/GlobalFunctions/eval1_v3.baseline
@@ -21,6 +21,8 @@ inside eval: this.name = global object
 42
 42
 [object Object]
+pass direct
+pass indirect
 Custom eval:
 arg 0 = 'x[i][0] = 2;'
 2


### PR DESCRIPTION
We clear the environment from cached eval functions to avoid pinning captured variables. But if the same function is fetched from the cache while another instance of the same eval is executing, then when the newer invocation returns we clear the environment out from under the instance that is still running. Fix this by making sure we use a different function object to execute a direct eval if there is already a running instance, indicated by a non-null environment on the function.