### PR TITLE
xplat: extern non-pal interface for GetTickCount

### DIFF
--- a/lib/Common/Memory/Recycler.cpp
+++ b/lib/Common/Memory/Recycler.cpp
@@ -2364,8 +2364,9 @@ void Recycler::ResetPartialHeuristicCounters()
 void
 Recycler::ScheduleNextCollection()
 {
-    this->tickCountNextCollection = ::GetTickCount() + RecyclerHeuristic::TickCountCollection;
-    this->tickCountNextFinishCollection = ::GetTickCount() + RecyclerHeuristic::TickCountFinishCollection;
+    DWORD tick = ::GetTickCount();
+    this->tickCountNextCollection = tick + RecyclerHeuristic::TickCountCollection;
+    this->tickCountNextFinishCollection = tick + RecyclerHeuristic::TickCountFinishCollection;
 }
 
 #if ENABLE_CONCURRENT_GC
@@ -7987,7 +7988,7 @@ Recycler::VerifyMarkStack()
     }
 }
 
-bool 
+bool
 Recycler::VerifyMark(void * target)
 {
     return VerifyMark(nullptr, target);

--- a/pal/inc/pal_external.h
+++ b/pal/inc/pal_external.h
@@ -1,0 +1,22 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+// The interface on this file can be consumed from none chakracore dependents
+// Keep this file independent from the rest of PAL
+
+#ifndef PAL_INC_PAL_EXTERNAL_H
+#define PAL_INC_PAL_EXTERNAL_H
+#ifndef _WIN32
+
+namespace CCPAL
+{
+    unsigned long GetMilliseconds();
+}
+
+#define GetTickCount()   CCPAL::GetMilliseconds()
+#define GetTickCount64() CCPAL::GetMilliseconds()
+
+#endif // !_WIN32
+#endif // PAL_INC_PAL_EXTERNAL_H

--- a/pal/src/CMakeLists.txt
+++ b/pal/src/CMakeLists.txt
@@ -100,6 +100,7 @@ set(SOURCES
   cruntime/wchar.cpp
   cruntime/wchartls.cpp
   cruntime/runtime_proxy.cpp
+  external/pal_external.cpp
   safecrt/makepath_s.c
   safecrt/mbusafecrt.c
   safecrt/safecrt_input_s.c

--- a/pal/src/external/pal_external.cpp
+++ b/pal/src/external/pal_external.cpp
@@ -1,0 +1,14 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#include "pal.h"
+
+namespace CCPAL
+{
+    extern unsigned long GetMilliseconds()
+    {
+        return (unsigned long) GetTickCount();
+    }
+}


### PR DESCRIPTION
Provide necessarry interface, so we can enable IdleCollect on node-chakracore

See https://github.com/nodejs/node-chakracore/pull/248