### PR TITLE
WASM: memory 

### DIFF
--- a/lib/Parser/rterrors.h
+++ b/lib/Parser/rterrors.h
@@ -394,6 +394,7 @@ RT_ERROR_MSG(WASMERR_NeedResponse, 7020, "%s is not a Reponse", "Response expect
 RT_ERROR_MSG(WASMERR_CantDetach, 7021, "", "Not allowed to detach WebAssembly.Memory buffer", kjstTypeError, 0)
 RT_ERROR_MSG(WASMERR_BufferGrowOnly, 7022, "", "WebAssembly.Memory can only grow", kjstTypeError, 0)
 RT_ERROR_MSG(WASMERR_LinkSignatureMismatch, 7023, "Cannot link import %s in link table due to a signature mismatch", "Function called with invalid signature", kjstWebAssemblyRuntimeError, 0)
+RT_ERROR_MSG(WASMERR_MemoryCreateFailed, 7024, "", "Failed to create WebAssembly.Memory", kjstTypeError, 0)
 
 // Wabt Errors
 RT_ERROR_MSG(WABTERR_WabtError, 7200, "%s", "Wabt Error.", kjstTypeError, 0)

--- a/lib/Parser/rterrors.h
+++ b/lib/Parser/rterrors.h
@@ -365,6 +365,9 @@ RT_ERROR_MSG(JSERR_CantDeleteNonConfigProp, 5666, "Cannot delete non-configurabl
 RT_ERROR_MSG(JSERR_CantRedefineProp, 5667, "Cannot redefine property '%s'", "Cannot redefine property", kjstTypeError, 0)
 RT_ERROR_MSG(JSERR_FunctionArgument_NeedArrayLike, 5668, "%s: argument is not an array or array-like object", "Array or array-like object expected", kjstTypeError, 0)
 RT_ERROR_MSG(JSERR_FatalMemoryExhaustion, 5669, "", "Encountered a non-recoverable OOM", kjstError, 0)
+RT_ERROR_MSG(JSERR_OutOfBoundString, 5670, "", "String length is out of bound", kjstRangeError, 0)
+RT_ERROR_MSG(JSERR_InvalidIterableObject, 5671, "%s : Invalid iterable object", "Invalid iterable object", kjstTypeError, 0)
+RT_ERROR_MSG(JSERR_InvalidIteratorObject, 5672, "%s : Invalid iterator object", "Invalid iterator object", kjstTypeError, 0)
 
 // WebAssembly Errors
 RT_ERROR_MSG(WASMERR_WasmCompileError, 7000, "%s", "Compilation failed.", kjstWebAssemblyCompileError, 0)
@@ -387,11 +390,10 @@ RT_ERROR_MSG(WASMERR_TableIndexOutOfRange, 7016, "", "Table index is out of rang
 RT_ERROR_MSG(WASMERR_ArrayIndexOutOfRange, 7017, "", "Memory index is out of range", kjstWebAssemblyRuntimeError, 0)
 RT_ERROR_MSG(WASMERR_InvalidInstantiateArgument, 7018, "", "Invalid arguments to instantiate", kjstTypeError, 0)
 RT_ERROR_MSG(WASMERR_WasmLinkError, 7019, "%s", "Linking failed.", kjstWebAssemblyLinkError, 0)
-RT_ERROR_MSG(JSERR_OutOfBoundString, 7020, "", "String length is out of bound", kjstRangeError, 0)
-RT_ERROR_MSG(JSERR_InvalidIterableObject, 7021, "%s : Invalid iterable object", "Invalid iterable object", kjstTypeError, 0)
-RT_ERROR_MSG(JSERR_InvalidIteratorObject, 7022, "%s : Invalid iterator object", "Invalid iterator object", kjstTypeError, 0)
-RT_ERROR_MSG(WASMERR_NeedResponse, 7023, "%s is not a Reponse", "Response expected", kjstTypeError, 0)
-RT_ERROR_MSG(WASMERR_LinkSignatureMismatch, 7024, "Cannot link import %s in link table due to a signature mismatch", "Function called with invalid signature", kjstWebAssemblyRuntimeError, 0)
+RT_ERROR_MSG(WASMERR_NeedResponse, 7020, "%s is not a Reponse", "Response expected", kjstTypeError, 0)
+RT_ERROR_MSG(WASMERR_CantDetach, 7021, "", "Not allowed to detach WebAssembly.Memory buffer", kjstTypeError, 0)
+RT_ERROR_MSG(WASMERR_BufferGrowOnly, 7022, "", "WebAssembly.Memory can only grow", kjstTypeError, 0)
+RT_ERROR_MSG(WASMERR_LinkSignatureMismatch, 7023, "Cannot link import %s in link table due to a signature mismatch", "Function called with invalid signature", kjstWebAssemblyRuntimeError, 0)
 
 // Wabt Errors
 RT_ERROR_MSG(WABTERR_WabtError, 7200, "%s", "Wabt Error.", kjstTypeError, 0)

--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -3044,6 +3044,7 @@ namespace Js
             WebAssemblyMemory * wasmMem = *(WebAssemblyMemory**)((Var*)frame->GetItem(0) + AsmJsModuleMemory::MemoryTableBeginOffset);
             m_signatures = func->GetFunctionBody()->GetAsmJsFunctionInfo()->GetWebAssemblyModule()->GetSignatures();
             m_wasmMemory = wasmMem;
+            m_localSlots[AsmJsFunctionMemory::ArrayBufferRegister] = nullptr;
         }
         else
 #endif
@@ -7972,6 +7973,7 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
     void InterpreterStackFrame::OP_SimdLdArrGeneric(const unaligned T* playout)
     {
         Assert(playout->ViewType < Js::ArrayBufferView::TYPE_COUNT);
+        AssertMsg(!m_functionBody->IsWasmFunction(), "Do not use AsmJsFunctionMemory::ArrayBufferRegister for Wasm, Use WebAssemblyMemory directly instead");
         const uint32 index = (uint32)GetRegRawInt(playout->SlotIndex) & ArrayBufferView::ViewMask[playout->ViewType];
         JavascriptArrayBuffer* arr = *(JavascriptArrayBuffer**)GetNonVarReg(AsmJsFunctionMemory::ArrayBufferRegister);
         BYTE* buffer = arr->GetBuffer();
@@ -7993,6 +7995,7 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
     void InterpreterStackFrame::OP_SimdLdArrConstIndex(const unaligned T* playout)
     {
         Assert(playout->ViewType < Js::ArrayBufferView::TYPE_COUNT);
+        AssertMsg(!m_functionBody->IsWasmFunction(), "Do not use AsmJsFunctionMemory::ArrayBufferRegister for Wasm, Use WebAssemblyMemory directly instead");
         const uint32 index = playout->SlotIndex;
         JavascriptArrayBuffer* arr = *(JavascriptArrayBuffer**)GetNonVarReg(AsmJsFunctionMemory::ArrayBufferRegister);
         BYTE* buffer = arr->GetBuffer();
@@ -8014,6 +8017,7 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
     void InterpreterStackFrame::OP_SimdStArrGeneric(const unaligned T* playout)
     {
         Assert(playout->ViewType < Js::ArrayBufferView::TYPE_COUNT);
+        AssertMsg(!m_functionBody->IsWasmFunction(), "Do not use AsmJsFunctionMemory::ArrayBufferRegister for Wasm, Use WebAssemblyMemory directly instead");
         const uint32 index = (uint32)GetRegRawInt(playout->SlotIndex) & ArrayBufferView::ViewMask[playout->ViewType];
         JavascriptArrayBuffer* arr = *(JavascriptArrayBuffer**)GetNonVarReg(AsmJsFunctionMemory::ArrayBufferRegister);
         BYTE* buffer = arr->GetBuffer();
@@ -8033,6 +8037,7 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
     void InterpreterStackFrame::OP_SimdStArrConstIndex(const unaligned T* playout)
     {
         Assert(playout->ViewType < Js::ArrayBufferView::TYPE_COUNT);
+        AssertMsg(!m_functionBody->IsWasmFunction(), "Do not use AsmJsFunctionMemory::ArrayBufferRegister for Wasm, Use WebAssemblyMemory directly instead");
         const uint32 index = playout->SlotIndex;
         JavascriptArrayBuffer* arr = *(JavascriptArrayBuffer**)GetNonVarReg(AsmJsFunctionMemory::ArrayBufferRegister);
         BYTE* buffer = arr->GetBuffer();
@@ -8475,6 +8480,7 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
     void InterpreterStackFrame::OP_StArr(uint32 index, RegSlot regSlot)
     {
         CompileAssert(Js::ArrayBufferView::TYPE_COUNT == (sizeof(InterpreterStackFrame::StArrFunc) / sizeof(InterpreterStackFrame::ArrFunc)));
+        AssertMsg(!m_functionBody->IsWasmFunction(), "Do not use AsmJsFunctionMemory::ArrayBufferRegister for Wasm, Use WebAssemblyMemory directly instead");
         JavascriptArrayBuffer* arr = *(JavascriptArrayBuffer**)GetNonVarReg(AsmJsFunctionMemory::ArrayBufferRegister);
         if (index < arr->GetByteLength())
         {
@@ -8556,6 +8562,7 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
     void InterpreterStackFrame::OP_LdArr(uint32 index, RegSlot regSlot)
     {
         CompileAssert(Js::ArrayBufferView::TYPE_COUNT == (sizeof(InterpreterStackFrame::LdArrFunc) / sizeof(InterpreterStackFrame::ArrFunc)));
+        AssertMsg(!m_functionBody->IsWasmFunction(), "Do not use AsmJsFunctionMemory::ArrayBufferRegister for Wasm, Use WebAssemblyMemory directly instead");
         JavascriptArrayBuffer* arr = *(JavascriptArrayBuffer**)GetNonVarReg(AsmJsFunctionMemory::ArrayBufferRegister);
         BYTE* buffer = arr->GetBuffer();
         ArrayType val = index < (arr->GetByteLength()) ? *(ArrayType*)(buffer + index) : GetArrayViewOverflowVal<ArrayType>();

--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -8601,6 +8601,7 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
     template <class T>
     void InterpreterStackFrame::OP_LdArrWasm(const unaligned T* playout)
     {
+#ifdef ENABLE_WASM
         Assert(playout->ViewType < Js::ArrayBufferView::TYPE_COUNT);
         const uint64 index = playout->Offset + (uint64)(uint32)GetRegRawInt(playout->SlotIndex);
         WebAssemblyArrayBuffer* arr = m_wasmMemory->GetBuffer();
@@ -8628,6 +8629,9 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
         case ArrayBufferView::ViewType::TYPE_UINT32_TO_INT64 : SetRegRaw<int64>(playout->Value, (int64)*(uint32*)(buffer + index)); return;
         default:Assert(UNREACHED);
         }
+#else
+        Assert(UNREACHED);
+#endif
     }
     template <class T>
     void InterpreterStackFrame::OP_LdArrConstIndex(const unaligned T* playout)
@@ -8646,6 +8650,7 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
     template <class T>
     void InterpreterStackFrame::OP_StArrWasm(const unaligned T* playout)
     {
+#ifdef ENABLE_WASM
         Assert(playout->ViewType < Js::ArrayBufferView::TYPE_COUNT);
         const uint64 index = playout->Offset + (uint64)(uint32)GetRegRawInt(playout->SlotIndex);
         WebAssemblyArrayBuffer* arr = m_wasmMemory->GetBuffer();
@@ -8673,6 +8678,9 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
         case ArrayBufferView::ViewType::TYPE_UINT32_TO_INT64: *(uint32*)(buffer + index) = (uint32) (GetRegRaw<int64>(playout->Value)); return;
         default:Assert(UNREACHED);
         }
+#else
+        Assert(UNREACHED);
+#endif
     }
     template <class T>
     void InterpreterStackFrame::OP_StArrConstIndex(const unaligned T* playout)

--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -3042,13 +3042,6 @@ namespace Js
         if (func->GetFunctionBody()->IsWasmFunction())
         {
             WebAssemblyMemory * wasmMem = *(WebAssemblyMemory**)((Var*)frame->GetItem(0) + AsmJsModuleMemory::MemoryTableBeginOffset);
-            Var * val = nullptr;
-            if (wasmMem != nullptr)
-            {
-                val = (Var*)((BYTE*)wasmMem + WebAssemblyMemory::GetOffsetOfArrayBuffer());
-            }
-            m_localSlots[AsmJsFunctionMemory::ArrayBufferRegister] = val;
-
             m_signatures = func->GetFunctionBody()->GetAsmJsFunctionInfo()->GetWebAssemblyModule()->GetSignatures();
             m_wasmMemory = wasmMem;
         }
@@ -7927,10 +7920,10 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
 
     int InterpreterStackFrame::OP_GetMemorySize()
     {
-#ifdef ASMJS_PLAT
-        JavascriptArrayBuffer* arr = *(JavascriptArrayBuffer**)GetNonVarReg(AsmJsFunctionMemory::ArrayBufferRegister);
-        return arr ? arr->GetByteLength() >> 16 : 0;
+#ifdef ENABLE_WASM
+        return (int)m_wasmMemory->GetCurrentMemoryPages();
 #else
+        Assert(UNREACHED);
         return 0;
 #endif
     }
@@ -7938,10 +7931,7 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
     int InterpreterStackFrame::OP_GrowMemory(int32 delta)
     {
 #ifdef ENABLE_WASM
-        int32 oldPageCount = m_wasmMemory->GrowInternal((uint32)delta);
-
-        SetNonVarReg(AsmJsFunctionMemory::ArrayBufferRegister, m_wasmMemory->GetBuffer());
-        return oldPageCount;
+        return m_wasmMemory->GrowInternal((uint32)delta);
 #else
         Assert(UNREACHED);
         return 0;
@@ -8605,8 +8595,8 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
     void InterpreterStackFrame::OP_LdArrWasm(const unaligned T* playout)
     {
         Assert(playout->ViewType < Js::ArrayBufferView::TYPE_COUNT);
-        const uint64 index = playout->Offset + (uint64)GetRegRawInt(playout->SlotIndex);
-        JavascriptArrayBuffer* arr = *(JavascriptArrayBuffer**)GetNonVarReg(AsmJsFunctionMemory::ArrayBufferRegister);
+        const uint64 index = playout->Offset + (uint64)(uint32)GetRegRawInt(playout->SlotIndex);
+        WebAssemblyArrayBuffer* arr = m_wasmMemory->GetBuffer();
         if (index + TypeToSizeMap[playout->ViewType] > arr->GetByteLength())
         {
             JavascriptError::ThrowWebAssemblyRuntimeError(scriptContext, WASMERR_ArrayIndexOutOfRange);
@@ -8650,8 +8640,8 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
     void InterpreterStackFrame::OP_StArrWasm(const unaligned T* playout)
     {
         Assert(playout->ViewType < Js::ArrayBufferView::TYPE_COUNT);
-        const uint64 index = playout->Offset + (uint64)GetRegRawInt(playout->SlotIndex);
-        JavascriptArrayBuffer* arr = *(JavascriptArrayBuffer**)GetNonVarReg(AsmJsFunctionMemory::ArrayBufferRegister);
+        const uint64 index = playout->Offset + (uint64)(uint32)GetRegRawInt(playout->SlotIndex);
+        WebAssemblyArrayBuffer* arr = m_wasmMemory->GetBuffer();
         if (index + TypeToSizeMap[playout->ViewType] > arr->GetByteLength())
         {
             JavascriptError::ThrowWebAssemblyRuntimeError(scriptContext, WASMERR_ArrayIndexOutOfRange);

--- a/lib/Runtime/Library/ArrayBuffer.cpp
+++ b/lib/Runtime/Library/ArrayBuffer.cpp
@@ -970,15 +970,14 @@ namespace Js
 #endif
         Assert(allocator == WasmVirtualAllocator);
         // Make sure we always have a buffer even if the length is 0
-        if (buffer == nullptr)
+        if (buffer == nullptr && length == 0)
         {
             // We want to allocate an empty buffer using virtual memory
-            Assert(length == 0);
             buffer = (BYTE*)allocator(0);
-            if (buffer == nullptr)
-            {
-                JavascriptError::ThrowOutOfMemoryError(GetScriptContext());
-            }
+        }
+        if (buffer == nullptr)
+        {
+            JavascriptError::ThrowOutOfMemoryError(GetScriptContext());
         }
     }
 

--- a/lib/Runtime/Library/ArrayBuffer.h
+++ b/lib/Runtime/Library/ArrayBuffer.h
@@ -72,6 +72,7 @@ namespace Js
 
         virtual bool IsArrayBuffer() = 0;
         virtual bool IsSharedArrayBuffer() = 0;
+        virtual bool IsWebAssemblyArrayBuffer() { return false; }
         virtual ArrayBuffer * GetAsArrayBuffer() = 0;
         virtual SharedArrayBuffer * GetAsSharedArrayBuffer() { return nullptr; }
         virtual void AddParent(ArrayBufferParent* parent) { }
@@ -279,6 +280,8 @@ namespace Js
 
     class WebAssemblyArrayBuffer : public JavascriptArrayBuffer
     {
+        template<typename Allocator>
+        WebAssemblyArrayBuffer(uint32 length, DynamicType * type, Allocator allocator);
         WebAssemblyArrayBuffer(uint32 length, DynamicType * type);
         WebAssemblyArrayBuffer(byte* buffer, uint32 length, DynamicType * type);
     protected:
@@ -286,8 +289,11 @@ namespace Js
         DEFINE_MARSHAL_OBJECT_TO_SCRIPT_CONTEXT(WebAssemblyArrayBuffer);
     public:
         static WebAssemblyArrayBuffer* Create(byte* buffer, DECLSPEC_GUARD_OVERFLOW uint32 length, DynamicType * type);
+        WebAssemblyArrayBuffer* GrowMemory(DECLSPEC_GUARD_OVERFLOW uint32 newBufferLength);
+
         virtual bool IsValidVirtualBufferLength(uint length) const override;
         virtual ArrayBuffer * TransferInternal(DECLSPEC_GUARD_OVERFLOW uint32 newBufferLength) override;
+        virtual bool IsWebAssemblyArrayBuffer() override { return true; }
     };
 
     // the memory must be allocated via CoTaskMemAlloc.

--- a/lib/Runtime/Library/ArrayBuffer.h
+++ b/lib/Runtime/Library/ArrayBuffer.h
@@ -260,6 +260,8 @@ namespace Js
 
         virtual ArrayBuffer * TransferInternal(DECLSPEC_GUARD_OVERFLOW uint32 newBufferLength) override;
 
+        template<typename Func>
+        void ReportDifferentialAllocation(uint32 newBufferLength, Func reportFailureFn);
         void ReportDifferentialAllocation(uint32 newBufferLength);
 
     protected:

--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -6185,12 +6185,12 @@ namespace Js
         return arr;
     }
 
-    Js::ArrayBuffer* JavascriptLibrary::CreateWebAssemblyArrayBuffer(uint32 length)
+    Js::WebAssemblyArrayBuffer* JavascriptLibrary::CreateWebAssemblyArrayBuffer(uint32 length)
     {
         return WebAssemblyArrayBuffer::Create(nullptr, length, arrayBufferType);
     }
 
-    Js::ArrayBuffer* JavascriptLibrary::CreateWebAssemblyArrayBuffer(byte* buffer, uint32 length)
+    Js::WebAssemblyArrayBuffer* JavascriptLibrary::CreateWebAssemblyArrayBuffer(byte* buffer, uint32 length)
     {
         return WebAssemblyArrayBuffer::Create(buffer, length, arrayBufferType);
     }

--- a/lib/Runtime/Library/JavascriptLibrary.h
+++ b/lib/Runtime/Library/JavascriptLibrary.h
@@ -949,8 +949,8 @@ namespace Js
         JavascriptArray* CreateArray(uint32 length, uint32 size);
         ArrayBuffer* CreateArrayBuffer(uint32 length);
         ArrayBuffer* CreateArrayBuffer(byte* buffer, uint32 length);
-        ArrayBuffer* CreateWebAssemblyArrayBuffer(uint32 length);
-        ArrayBuffer* CreateWebAssemblyArrayBuffer(byte* buffer, uint32 length);
+        class WebAssemblyArrayBuffer* CreateWebAssemblyArrayBuffer(uint32 length);
+        class WebAssemblyArrayBuffer* CreateWebAssemblyArrayBuffer(byte* buffer, uint32 length);
         SharedArrayBuffer* CreateSharedArrayBuffer(uint32 length);
         SharedArrayBuffer* CreateSharedArrayBuffer(SharedContents *contents);
         ArrayBuffer* CreateProjectionArraybuffer(uint32 length);

--- a/lib/Runtime/Library/WebAssemblyInstance.cpp
+++ b/lib/Runtime/Library/WebAssemblyInstance.cpp
@@ -463,6 +463,10 @@ void WebAssemblyInstance::ValidateTableAndMemory(WebAssemblyModule * wasmModule,
     else
     {
         mem = wasmModule->CreateMemory();
+        if (mem == nullptr)
+        {
+            JavascriptError::ThrowWebAssemblyLinkError(ctx, WASMERR_MemoryCreateFailed);
+        }
         env->SetMemory(0, mem);
     }
     ArrayBuffer * buffer = mem->GetBuffer();

--- a/lib/Runtime/Library/WebAssemblyMemory.cpp
+++ b/lib/Runtime/Library/WebAssemblyMemory.cpp
@@ -16,6 +16,8 @@ WebAssemblyMemory::WebAssemblyMemory(WebAssemblyArrayBuffer* buffer, uint32 init
     m_initial(initial),
     m_maximum(maximum)
 {
+    Assert(m_buffer);
+    Assert(m_buffer->GetByteLength() >= UInt32Math::Mul<WebAssembly::PageSize>(initial));
 }
 
 /* static */
@@ -213,6 +215,12 @@ uint
 WebAssemblyMemory::GetMaximumLength() const
 {
     return m_maximum;
+}
+
+uint
+WebAssemblyMemory::GetCurrentMemoryPages() const
+{
+    return m_buffer->GetByteLength() / WebAssembly::PageSize;
 }
 
 } // namespace Js

--- a/lib/Runtime/Library/WebAssemblyMemory.h
+++ b/lib/Runtime/Library/WebAssemblyMemory.h
@@ -35,6 +35,7 @@ namespace Js
         WebAssemblyArrayBuffer * GetBuffer() const;
         uint GetInitialLength() const;
         uint GetMaximumLength() const;
+        uint GetCurrentMemoryPages() const;
 
         int32 GrowInternal(uint32 deltaPages);
         static int32 GrowHelper(Js::WebAssemblyMemory * memory, uint32 deltaPages);

--- a/lib/Runtime/Library/WebAssemblyMemory.h
+++ b/lib/Runtime/Library/WebAssemblyMemory.h
@@ -32,7 +32,7 @@ namespace Js
 
         static WebAssemblyMemory * CreateMemoryObject(uint32 initial, uint32 maximum, ScriptContext * scriptContext);
 
-        ArrayBuffer * GetBuffer() const;
+        WebAssemblyArrayBuffer * GetBuffer() const;
         uint GetInitialLength() const;
         uint GetMaximumLength() const;
 
@@ -41,9 +41,9 @@ namespace Js
 
         static int GetOffsetOfArrayBuffer() { return offsetof(WebAssemblyMemory, m_buffer); }
     private:
-        WebAssemblyMemory(ArrayBuffer * buffer, uint32 initial, uint32 maximum, DynamicType * type);
+        WebAssemblyMemory(WebAssemblyArrayBuffer * buffer, uint32 initial, uint32 maximum, DynamicType * type);
 
-        Field(ArrayBuffer *) m_buffer;
+        Field(WebAssemblyArrayBuffer *) m_buffer;
 
         Field(uint) m_initial;
         Field(uint) m_maximum;

--- a/lib/Runtime/Library/WebAssemblyModule.cpp
+++ b/lib/Runtime/Library/WebAssemblyModule.cpp
@@ -344,7 +344,15 @@ WebAssemblyModule::InitializeMemory(uint32 minPage, uint32 maxPage)
 
     if (maxPage < minPage)
     {
-        throw Wasm::WasmCompilationException(_u("Memory: MaxPage (%d) must be greater than MinPage (%d)"), maxPage, minPage);
+        throw Wasm::WasmCompilationException(_u("Memory: MaxPage (%u) must be greater than MinPage (%u)"), maxPage, minPage);
+    }
+    auto minPageTooBig = [minPage] {
+        throw Wasm::WasmCompilationException(_u("Memory: Unable to allocate minimum pages (%u)"), minPage);
+    };
+    uint32 minBytes = UInt32Math::Mul<WebAssembly::PageSize>(minPage, minPageTooBig);
+    if (minBytes > ArrayBuffer::MaxArrayBufferLength)
+    {
+        minPageTooBig();
     }
     m_hasMemory = true;
     m_memoryInitSize = minPage;

--- a/lib/WasmReader/WasmByteCodeGenerator.cpp
+++ b/lib/WasmReader/WasmByteCodeGenerator.cpp
@@ -272,6 +272,7 @@ WasmModuleGenerator::GenerateFunctionHeader(uint32 index)
         {
             Wasm::WasmExport* wasmExport = m_module->GetExport(iExport);
             if (wasmExport  &&
+                wasmExport->kind == ExternalKinds::Function &&
                 wasmExport->nameLength > 0 &&
                 m_module->GetFunctionIndexType(wasmExport->index) == FunctionIndexTypes::Function &&
                 wasmExport->index == wasmInfo->GetNumber())

--- a/test/wasm/memory.js
+++ b/test/wasm/memory.js
@@ -1,0 +1,147 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft Corporation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+const cliArgs = WScript.Arguments || [];
+
+if (cliArgs.indexOf("--help") !== -1) {
+  print("usage: ch memory.js -args [-verbose] -endargs");
+  WScript.quit(0);
+}
+
+// Parse arguments
+let verbose = 0;
+while (true) {
+  const iVerbose = cliArgs.indexOf("-verbose");
+  if (iVerbose === -1) {
+    break;
+  }
+  cliArgs.splice(iVerbose, 1);
+  ++verbose;
+}
+
+function testTransfer(buffer) {
+  if (ArrayBuffer.transfer) {
+    try {
+      ArrayBuffer.transfer(buffer);
+      print("Failed. Expected an error when trying to transfer ");
+    } catch (e) {
+      if (verbose > 1) {
+        print(`Passed. Expected error: ${e.message}`);
+      }
+    }
+  } else {
+    print("ArrayBuffer.tranfer is missing");
+  }
+}
+
+
+
+function test({init, max} = {}) {
+  if (verbose) {
+    print(`Testing memory {init: ${init|0}, max: ${max}}`);
+  }
+  const moduleTxt = `
+  (module
+    (memory (export "mem") ${init|0} ${max !== undefined ? max|0 : ""})
+    (func (export "grow") (param i32) (result i32) (grow_memory (get_local 0)))
+    (func (export "current") (result i32) (current_memory))
+    (func (export "load") (param i32) (result i32) (i32.load (get_local 0)))
+    (func (export "store") (param i32 i32) (i32.store (get_local 0) (get_local 1)))
+  )`;
+  if (verbose > 1) {
+    print(moduleTxt);
+  }
+  const module = new WebAssembly.Module(WebAssembly.wabt.convertWast2Wasm(moduleTxt));
+  const {exports: {grow, current, load, store, mem}} = new WebAssembly.Instance(module);
+  function testReadWrite(index, value, currentSize) {
+    const shouldTrap = index < 0 || (index + 4) > currentSize;
+    const commonMsg = op => `trap on ${op}(${index}, ${value})`;
+    try {
+      store(index, value);
+      if (shouldTrap) {
+        print(`Failed. Expected ${commonMsg("store")}`);
+        return;
+      }
+    } catch (e) {
+      if (shouldTrap) {
+        if (verbose) {
+          print(`Passed. Expected ${commonMsg("store")}`);
+        }
+      } else {
+        print(`Failed. Unexpected ${commonMsg("store")}`);
+      }
+    }
+
+    try {
+      const loadedValue = load(index);
+      if (shouldTrap) {
+        print(`Failed. Expected ${commonMsg("load")}`);
+        return;
+      }
+      if ((loadedValue|0) !== (value|0)) {
+        print(`Failed. Expected value ${value|0} after load. Got ${loadedValue|0}`);
+      }
+    } catch (e) {
+      if (shouldTrap) {
+        if (verbose) {
+          print(`Passed. Expected ${commonMsg("load")}`);
+        }
+      } else {
+        print(`Failed. Unexpected ${commonMsg("load")}`);
+      }
+    }
+  }
+  function run(delta) {
+    testTransfer(mem.buffer);
+    let beforePages = current();
+    let growRes = grow(delta);
+    if (growRes !== -1 && growRes !== beforePages) {
+      print(`FAILED. Expected grow(${delta}) to return ${beforePages}`);
+    }
+    let afterPages = current();
+    if (growRes !== -1 && beforePages + delta !== afterPages) {
+      print(`FAILED. Expected to have ${beforePages + delta} pages. Got ${afterPages} pages`);
+    }
+    if (verbose) {
+      print(`current: ${beforePages}, grow(${delta}): ${growRes}, after: ${afterPages}`);
+    }
+    const currentSize = afterPages * 0x10000;
+    testReadWrite(-4, -4, currentSize);
+    testReadWrite(-3, -3, currentSize);
+    testReadWrite(-2, -2, currentSize);
+    testReadWrite(-1, -1, currentSize);
+    testReadWrite(0, 6, currentSize);
+    testTransfer(mem.buffer);
+    testReadWrite(1, 7, currentSize);
+    testTransfer(mem.buffer);
+    testReadWrite(1, 7, currentSize);
+    testReadWrite(currentSize-4, 457, currentSize);
+    testReadWrite(currentSize-3, -98745, currentSize);
+    testReadWrite(currentSize-2, 786452, currentSize);
+    testReadWrite(currentSize-1, -1324, currentSize);
+    testReadWrite(currentSize, 123, currentSize);
+    testTransfer(mem.buffer);
+  }
+  run(0);
+  run(3);
+  run(5);
+  run(1 << 13);
+}
+
+test({init: 0});
+test({init: 0, max: 5});
+test({init: 0, max: 10});
+test({init: 5});
+test({init: 5, max: 10});
+test({init: 1 << 14});
+try {
+  test({init: 1 << 15});
+  print("Failed. Expected an error when allocating WebAssembly.Memory too big");
+} catch (e) {
+  if (verbose) {
+    print(`Passed. Expected error: ${e.message}`);
+  }
+}
+print("PASSED");

--- a/test/wasm/rlexe.xml
+++ b/test/wasm/rlexe.xml
@@ -243,14 +243,14 @@
   <default>
     <files>memory.js</files>
     <compile-flags>-wasm -ArrayBufferTransfer</compile-flags>
-    <tags>exclude_jshost,exclude_win7</tags>
+    <tags>exclude_jshost,exclude_win7,exclude_xplat</tags>
   </default>
 </test>
 <test>
   <default>
     <files>memory.js</files>
     <compile-flags>-wasm -ArrayBufferTransfer -wasmfastarray-</compile-flags>
-    <tags>exclude_jshost,exclude_win7</tags>
+    <tags>exclude_jshost,exclude_win7,exclude_xplat</tags>
   </default>
 </test>
 <test>

--- a/test/wasm/rlexe.xml
+++ b/test/wasm/rlexe.xml
@@ -241,6 +241,20 @@
 </test>
 <test>
   <default>
+    <files>memory.js</files>
+    <compile-flags>-wasm -ArrayBufferTransfer</compile-flags>
+    <tags>exclude_jshost,exclude_win7</tags>
+  </default>
+</test>
+<test>
+  <default>
+    <files>memory.js</files>
+    <compile-flags>-wasm -ArrayBufferTransfer -wasmfastarray-</compile-flags>
+    <tags>exclude_jshost,exclude_win7</tags>
+  </default>
+</test>
+<test>
+  <default>
     <files>superlongsignaturemismatch.js</files>
     <compile-flags>-wasm</compile-flags>
     <tags>exclude_xplat,exclude_jshost,exclude_win7</tags>


### PR DESCRIPTION
- Alwasy create a WebAssemblyArrayBuffer for WebAssemblyMemory
- Prevent detaching the WebAssemblyArrayBuffer except in grow_memory scenario
- Fix bug in Interpreter with negative indexes in load/store wasm
- Do not use ArrayBufferRegister slot for wasm, use WebAssemblyMemory directly instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/2992)
<!-- Reviewable:end -->
