### PR TITLE
Fixing the closure capturing issue in expression arrow function body

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -6657,7 +6657,7 @@ void Parser::ParseExpressionLambdaBody(ParseNodePtr pnodeLambda)
         pnodeLambda->sxFnc.pnodeScopes->ichLim = pnodeRet->ichLim;
 
         pnodeLambda->sxFnc.pnodeBody = nullptr;
-        AddToNodeList(&pnodeLambda->sxFnc.pnodeBody, &lastNodeRef, pnodeLambda->sxFnc.pnodeScopes);
+        AddToNodeList(&pnodeLambda->sxFnc.pnodeBody, &lastNodeRef, pnodeRet);
 
         // Append an EndCode node.
         ParseNodePtr end = CreateNodeWithScanner<knopEndCode>(pnodeRet->ichLim);

--- a/test/es6/destructuring_params.js
+++ b/test/es6/destructuring_params.js
@@ -222,6 +222,10 @@ var tests = [
             assert.areEqual(k, 62,  "Identifiers from patterns are captured and initialized correctly");
         }
         f3({x:10}, [20], 30);
+
+        function f4(a) { return a() }
+        var f5 = ({ x }) => f4(() => x);
+        assert.areEqual(f5({ x: 42 }), 42, "The destructured param is captured by the inner lambda");
      }
    },
   {
@@ -253,6 +257,10 @@ var tests = [
             })();
         }
         f3({x:5}, [6]);
+
+        function f4(a) { return a() }
+        var f5 = ({ x }) => f4(() => eval("x"));
+        assert.areEqual(f5({ x: 42 }), 42, "The destructured param is captured by the inner lambda with eval");
      }
    },
   {


### PR DESCRIPTION
While creating the parse node for the body of an arrow function we should be using the return statement to create the statement list. Right now we were using the param block scope.
