### PR TITLE
Mark some tests as slow

### DIFF
--- a/test/Function/rlexe.xml
+++ b/test/Function/rlexe.xml
@@ -63,8 +63,9 @@
     <default>
       <files>argumentsLimits.js</files>
       <baseline>argumentsLimits.baseline</baseline>
-      <!-- this test takes a long time with dynapogo on chk build -->
-      <tags>exclude_chk</tags>
+      <!-- this test takes a long time with dynapogo on chk build-->
+      <!-- it's pretty slow on test builds too though-->
+      <tags>exclude_chk,Slow</tags>
     </default>
   </test>
   <test>

--- a/test/Object/rlexe.xml
+++ b/test/Object/rlexe.xml
@@ -171,7 +171,7 @@
   <test>
     <default>
       <files>Slow.js</files>
-      <tags>exclude_chk</tags>
+      <tags>exclude_chk,Slow</tags>
     </default>
   </test>
   <test>

--- a/test/typedarray/rlexe.xml
+++ b/test/typedarray/rlexe.xml
@@ -219,14 +219,14 @@ Below test fails with difference in space. Investigate the cause and re-enable t
   <test>
     <default>
       <files>allocation.js</files>
-      <tags>typedarray,exclude_arm,xplatslow</tags>
+      <tags>typedarray,exclude_arm,xplatslow,Slow</tags>
       <timeout>300</timeout>
     </default>
   </test>
   <test>
     <default>
       <files>allocation2.js</files>
-      <tags>typedarray,exclude_arm,xplatslow</tags>
+      <tags>typedarray,exclude_arm,xplatslow,Slow</tags>
       <timeout>300</timeout>
     </default>
   </test>


### PR DESCRIPTION
Some of tests tests take a long time; we should run them as part of the slow run, not as part of the normal runs.