### PR TITLE
xplat perf improvements

### DIFF
--- a/pal/src/cruntime/wchar.cpp
+++ b/pal/src/cruntime/wchar.cpp
@@ -1230,7 +1230,7 @@ PAL_wmemcmp(
         const char16_t *string2,
         size_t count)
 {
-    size_t i;
+    size_t i, wi = 0;
     int diff = 0;
 
     PERF_ENTRY(wmemcmp);
@@ -1241,7 +1241,13 @@ PAL_wmemcmp(
 
     if (string1 == string2) return diff;
 
-    for (i = 0; i < count; i++)
+    constexpr size_t blockSize = sizeof(size_t) / sizeof(char16_t);
+    const     size_t *num1     = (const size_t*)(string1);
+    const     size_t *num2     = (const size_t*)(string2);
+
+    while( (count > blockSize * wi) && num1[wi] == num2[wi] ) ++wi;
+
+    for (i = blockSize * wi; i < count; ++i)
     {
         diff = string1[i] - string2[i];
         if (diff != 0)
@@ -1249,6 +1255,7 @@ PAL_wmemcmp(
             break;
         }
     }
+
     LOGEXIT("wmemcmp returning int %d\n", diff);
     PERF_EXIT(wmemcmp);
     return diff;

--- a/pal/src/include/pal/thread.hpp
+++ b/pal/src/include/pal/thread.hpp
@@ -802,24 +802,29 @@ Abstract:
   It is useful for tracing functions to display the thread ID
   without generating any new traces.
 
-  TODO: how does the perf of pthread_self compare to
-  InternalGetCurrentThread when we find the thread in the
-  cache?
-
-  If the perf of pthread_self is comparable to that of the stack
-  bounds based lookaside system, why aren't we using it in the
-  cache?
-
   In order to match the thread ids that debuggers use at least for
   linux we need to use gettid().
 
 --*/
+#ifndef __APPLE__
+#define THREAD_LOCAL thread_local
+#else
+#define THREAD_LOCAL _Thread_local
+#endif
+
 #if defined(__LINUX__)
 #define THREADSilentGetCurrentThreadId() (SIZE_T)syscall(SYS_gettid)
 #elif defined(__APPLE__)
 inline SIZE_T THREADSilentGetCurrentThreadId() {
+#ifndef __IOS__
+    static THREAD_LOCAL SIZE_T threadIdSelf = -1;
+    if (threadIdSelf != -1) return threadIdSelf;
+#endif
     uint64_t tid;
     pthread_threadid_np(pthread_self(), &tid);
+#ifndef __IOS__
+    threadIdSelf = (SIZE_T)tid;
+#endif
     return (SIZE_T)tid;
 }
 #else

--- a/pal/src/thread/pal_thread.cpp
+++ b/pal/src/thread/pal_thread.cpp
@@ -311,60 +311,6 @@ static void FreeTHREAD(CPalThread *pThread)
 
 /*++
 Function:
-  THREADGetThreadProcessId
-
-returns the process owner ID of the indicated hThread
---*/
-DWORD
-THREADGetThreadProcessId(
-    HANDLE hThread
-    // UNIXTODO Should take pThread parameter here (modify callers)
-    )
-{
-    CPalThread *pThread;
-    CPalThread *pTargetThread;
-    IPalObject *pobjThread = NULL;
-    PAL_ERROR palError = NO_ERROR;
-
-    DWORD dwProcessId = 0;
-
-    pThread = InternalGetCurrentThread();
-
-    palError = InternalGetThreadDataFromHandle(
-        pThread,
-        hThread,
-        0,
-        &pTargetThread,
-        &pobjThread
-        );
-
-    if (NO_ERROR != palError)
-    {
-        if (!pThread->IsDummy())
-        {
-            dwProcessId = GetCurrentProcessId();
-        }
-        else
-        {
-            ASSERT("Dummy thread passed to THREADGetProcessId\n");
-        }
-
-        if (NULL != pobjThread)
-        {
-           pobjThread->ReleaseReference(pThread);
-        }
-    }
-    else
-    {
-        ERROR("Couldn't retreive the hThread:%p pid owner !\n", hThread);
-    }
-
-
-    return dwProcessId;
-}
-
-/*++
-Function:
   GetThreadId
 
 See MSDN doc.
@@ -426,12 +372,6 @@ GetCurrentThreadId(
 
     PERF_ENTRY(GetCurrentThreadId);
     ENTRY("GetCurrentThreadId()\n");
-
-    //
-    // TODO: should do perf test to see how this compares
-    // with calling InternalGetCurrentThread (i.e., is our lookaside
-    // cache faster on average than pthread_self?)
-    //
 
     dwThreadId = (DWORD)THREADSilentGetCurrentThreadId();
 
@@ -2833,12 +2773,6 @@ int CorUnix::CThreadMachExceptionHandlers::GetIndexOfHandler(exception_mask_t bm
 }
 
 #endif // HAVE_MACH_EXCEPTIONS
-
-#ifndef __APPLE__
-#define THREAD_LOCAL thread_local
-#else
-#define THREAD_LOCAL _Thread_local
-#endif
 
 #ifndef __IOS__
 static THREAD_LOCAL ULONG_PTR s_cachedHighLimit = 0;


### PR DESCRIPTION
#### osx: cache expensive threadId retrieval
`pthread_threadid_np(pthread_self(), &tid);` call is very expensive. Cache expensive threadId retrieval instead. Same commit also removes unused `THREADGetThreadProcessId`

#### xplat: Improve PAL wmemcmp perf.
Since we know the char count, comparing with larger blocks reduces the total cycles to spend.