### PR TITLE
throw asm.js error when trying to use lambdas

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -399,6 +399,10 @@ HRESULT Parser::ParseSourceInternal(
     {
         hr = e.GetError();
     }
+    catch (Js::AsmJsParseException&)
+    {
+        hr = JSERR_AsmJsCompileError;
+    }
 
     if (FAILED(hr))
     {
@@ -5244,6 +5248,15 @@ bool Parser::ParseFncDeclHelper(ParseNodePtr pnodeFnc, LPCOLESTR pNameHint, usho
 
         if (isTopLevelDeferredFunc || (m_InAsmMode && m_deferAsmJs))
         {
+#ifdef ASMJS_PLAT
+            if (m_InAsmMode && fLambda)
+            {
+                // asm.js doesn't support lambda functions
+                Js::AsmJSCompiler::OutputError(m_scriptContext, _u("Lambda functions are not supported."));
+                Js::AsmJSCompiler::OutputError(m_scriptContext, _u("Asm.js compilation failed."));
+                throw Js::AsmJsParseException();
+            }
+#endif
             AssertMsg(!fLambda, "Deferring function parsing of a function does not handle lambda syntax");
             fDeferred = true;
 

--- a/lib/Runtime/Language/RuntimeLanguagePch.h
+++ b/lib/Runtime/Language/RuntimeLanguagePch.h
@@ -9,11 +9,8 @@
 
 #include "Runtime.h"
 
-#include "Language/AsmJsTypes.h"
 #include "Language/AsmJsUtils.h"
 #include "Language/AsmJsLink.h"
-#include "Language/AsmJsModule.h"
-#include "Language/AsmJs.h"
 #ifdef ASMJS_PLAT
 #include "Language/AsmJsJitTemplate.h"
 #include "Language/AsmJsEncoder.h"

--- a/lib/Runtime/Runtime.h
+++ b/lib/Runtime/Runtime.h
@@ -547,6 +547,10 @@ enum tagDEBUG_EVENT_INFO_TYPE
 
 #include "../WasmReader/WasmReader.h"
 
+#include "Language/AsmJsTypes.h"
+#include "Language/AsmJsModule.h"
+#include "Language/AsmJs.h"
+
 //
 // .inl files
 //

--- a/test/AsmJs/lambda.baseline
+++ b/test/AsmJs/lambda.baseline
@@ -1,0 +1,2 @@
+Lambda functions are not supported.
+Asm.js compilation failed.

--- a/test/AsmJs/lambda.js
+++ b/test/AsmJs/lambda.js
@@ -1,0 +1,9 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+(function() {
+    "use asm";
+    m => 0;
+})();

--- a/test/AsmJs/rlexe.xml
+++ b/test/AsmJs/rlexe.xml
@@ -851,4 +851,11 @@
       <compile-flags>-testtrace:asmjs -maic:0</compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>lambda.js</files>
+      <baseline>lambda.baseline</baseline>
+      <compile-flags>-testtrace:asmjs</compile-flags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
We currently throw a js syntax error for this case(/assert on debug build). Instead we should throw an asm.js error and reparse with asm.js disabled.

Fixes #2237.