### PR TITLE
fix bug with inlining isArray where src isn't RegOpnd

### DIFF
--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -18101,7 +18101,7 @@ Lowerer::GenerateFastInlineIsArray(IR::Instr * instr)
     else
     {
         src = IR::RegOpnd::New(argsOpnd[1]->GetType(), m_func);
-        InsertMove(src, argsOpnd[1], instr);
+        InsertMove(src, argsOpnd[1], insertInstr);
     }
 
     IR::LabelInstr *checkNotArrayLabel = IR::LabelInstr::New(Js::OpCode::Label, m_func, valueType.IsLikelyArray());

--- a/test/Optimizer/isarrbug.js
+++ b/test/Optimizer/isarrbug.js
@@ -1,0 +1,13 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function foo(){
+    return Array.isArray(1);
+};
+
+let failed = foo();
+failed |= foo();
+failed |= foo();
+failed ? print("Fail") : print("Pass");

--- a/test/Optimizer/rlexe.xml
+++ b/test/Optimizer/rlexe.xml
@@ -27,6 +27,11 @@
   </test>
   <test>
     <default>
+      <files>isarrbug.js</files>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>bug469.js</files>
       <compile-flags>-maxinterpretcount:1 -bgjit- -loopinterpretcount:1 -force:fixdataprops -off:aggressiveinttypespec -off:bailonnoprofile</compile-flags>
     </default>


### PR DESCRIPTION
In such a case, we need to load into a RegOpnd, but we were doing this in the wrong location.