### PR TITLE
Fix #1176 MultiLineComment spec deviation

### DIFF
--- a/lib/Parser/Scan.cpp
+++ b/lib/Parser/Scan.cpp
@@ -1947,7 +1947,9 @@ LIdentifier:
                 token = tkDec;
                 if (!m_fIsModuleCode)
                 {
-                    if ('>' == this->PeekFirst(p, last) && (m_fHadEol || seenDelimitedCommentEnd)) // --> HTMLCloseComment
+                    // https://tc39.github.io/ecma262/#prod-annexB-MultiLineComment
+                    // If there was a new line in the multi-line comment, the text after --> is a comment.
+                    if ('>' == this->PeekFirst(p, last) && m_fHadEol)
                     {
                         goto LSkipLineComment;
                     }

--- a/test/es6/HTMLComments.baseline
+++ b/test/es6/HTMLComments.baseline
@@ -8,6 +8,4 @@ Code before CRPS--> is reachable
 Code before <!-- is reachable
 Code before <!-- --> is reachable
 Code before <!-- LineTerminator --> is reachable
-Code before /* */ --> is reachable
-Code before /* */--> is reachable
 Code after post-decrement with a greater-than comparison (-->) is reachable

--- a/test/es6/HTMLComments.js
+++ b/test/es6/HTMLComments.js
@@ -56,8 +56,16 @@ WScript.Echo("Code before <!-- LineTerminator --> is reachable"); <!-- WScript.E
 /* Multi
    Line
    Comment */ --> WScript.Echo("Code after */ --> is unreachable");
-WScript.Echo("Code before /* */ --> is reachable"); /* Comment */ --> WScript.Echo("Code after /* */ --> is unreachable");
-WScript.Echo("Code before /* */--> is reachable"); /* Comment */--> WScript.Echo("Code after /* */--> is unreachable"); // No WhiteSpaceSequence
+assert.throws(function () { eval('/* */ --> WScript.Echo("Code after /* */ --> is parsed");'); }, SyntaxError, "MultiLineComment without a line terminator throws a syntax error",                         "Syntax error");
+assert.throws(function () { eval('/* */--> WScript.Echo("Code after /* */--> is parsed");'); },   SyntaxError, "MultiLineComment without a line terminator and whitespace sequence throws a syntax error", "Syntax error");
+{
+    let x = 0;
+    if (x/* */--> -1) {
+        assert.areEqual(-1, x, "MultiLineComment without a line terminator does not parse --> as a HTML comment");
+    } else {
+        WScript.Echo('MultiLineComment without a line terminator test is broken!');
+    }
+}
 
 // Post-decrement with a greater-than comparison does not get interpreted as a comment
 var a = 1; a-->a; WScript.Echo("Code after post-decrement with a greater-than comparison (-->) is reachable");


### PR DESCRIPTION
Fix a case where a multi-line comment without a newline would treat the following text as a comment. E.g.

/* */ --> should be reachable

Fixes #1176