### PR TITLE
fix assert in ObjTypeSpecFldInfo::GetFixedFieldIfAvailableAsFixedFunction

### DIFF
--- a/lib/Backend/Inline.cpp
+++ b/lib/Backend/Inline.cpp
@@ -2575,6 +2575,11 @@ IR::Instr * Inline::InlineApplyWithoutArrayArgument(IR::Instr *callInstr, const 
         return callInstr;
     }
 
+    if (!applyTargetInfo)
+    {
+        return callInstr;
+    }
+
     bool safeThis = false;
     if (TryOptimizeCallInstrWithFixedMethod(callInstr, applyTargetInfo, false /*isPolymorphic*/, false /*isBuiltIn*/, false /*isCtor*/, true /*isInlined*/, safeThis /*unused here*/))
     {

--- a/lib/Backend/ObjTypeSpecFldInfo.cpp
+++ b/lib/Backend/ObjTypeSpecFldInfo.cpp
@@ -222,7 +222,10 @@ FixedFieldInfo *
 ObjTypeSpecFldInfo::GetFixedFieldIfAvailableAsFixedFunction()
 {
     Assert(HasFixedValue());
-    Assert(IsMono() || (IsPoly() && !DoesntHaveEquivalence()));
+    if (IsPoly() && DoesntHaveEquivalence())
+    {
+        return nullptr;
+    }
     Assert(GetFixedFieldInfoArray());
     if (GetFixedFieldInfoArray()[0].GetFuncInfoAddr() != 0)
     {

--- a/lib/Backend/ObjTypeSpecFldInfo.cpp
+++ b/lib/Backend/ObjTypeSpecFldInfo.cpp
@@ -222,10 +222,7 @@ FixedFieldInfo *
 ObjTypeSpecFldInfo::GetFixedFieldIfAvailableAsFixedFunction()
 {
     Assert(HasFixedValue());
-    if (IsPoly() && DoesntHaveEquivalence())
-    {
-        return nullptr;
-    }
+    Assert(IsMono() || (IsPoly() && !DoesntHaveEquivalence()));
     Assert(GetFixedFieldInfoArray());
     if (GetFixedFieldInfoArray()[0].GetFuncInfoAddr() != 0)
     {

--- a/test/Optimizer/nonequivpoly.js
+++ b/test/Optimizer/nonequivpoly.js
@@ -1,0 +1,30 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+var protoObj1 = {
+method0: function () {
+}};
+var v3 = {
+v4: function () {
+  return function bar() {
+    this.method0.apply({});
+  };
+}
+};
+protoObj1.v6 = v3.v4();
+protoObj1.v6.prototype = {
+method0: function () {
+}
+};
+protoObj1.v48 = v3.v4();
+protoObj1.v48.prototype = {
+method0: function () {
+  new protoObj1.v6();
+}
+};
+var v67 = new protoObj1.v48();
+var v68 = protoObj1.v48();
+
+print("Pass");

--- a/test/Optimizer/rlexe.xml
+++ b/test/Optimizer/rlexe.xml
@@ -1360,6 +1360,11 @@
   </test>
   <test>
     <default>
+      <files>nonequivpoly.js</files>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>memop-upperbound.js</files>
       <baseline>memop-upperbound.baseline</baseline>
       <compile-flags>-lic:1 -off:nativearray</compile-flags>


### PR DESCRIPTION
Assert isn't valid, as there isn't always a guarantee about equivalence. Instead, we should do a check in the API.