### PR TITLE
-forcenative for wasm & asm.js

### DIFF
--- a/lib/Runtime/Language/WAsmjsUtils.cpp
+++ b/lib/Runtime/Language/WAsmjsUtils.cpp
@@ -96,6 +96,10 @@ template<> Types RegisterSpace::GetRegisterSpaceType<AsmJsSIMDValue>(){return WA
     bool ShouldJitFunction(Js::FunctionBody* body, uint interpretedCount)
     {
 #if ENABLE_NATIVE_CODEGEN
+        if (CONFIG_ISENABLED(Js::ForceNativeFlag))
+        {
+            return true;
+        }
         const bool noJit = PHASE_OFF(Js::BackEndPhase, body) ||
             PHASE_OFF(Js::FullJitPhase, body) ||
             body->GetScriptContext()->GetConfig()->IsNoNative() ||


### PR DESCRIPTION
We were working under the assumption that our test runner was prejitting unittest with -forcenative flag, however I found out this was wrong.
This fix makes wasm and asm.js respect the -forcenative flag.
Thankfully we didn't have any test failures by enabling this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/3042)
<!-- Reviewable:end -->
