### PR TITLE
Enable VTune JIT Profiling in Linux

### DIFF
--- a/lib/Jsrt/JsrtHelper.cpp
+++ b/lib/Jsrt/JsrtHelper.cpp
@@ -12,6 +12,8 @@
 #include "jsrtHelper.h"
 #include "Base/ThreadContextTlsEntry.h"
 
+#include "Base/VTuneChakraProfile.h"
+
 #ifdef DYNAMIC_PROFILE_STORAGE
 #include "Language/DynamicProfileStorage.h"
 #endif
@@ -143,6 +145,9 @@ void JsrtCallbackState::ObjectBeforeCallectCallbackWrapper(JsObjectBeforeCollect
 
     #ifdef ENABLE_JS_ETW
         EtwTrace::Register();
+    #endif
+    #ifdef VTUNE_PROFILING
+        VTuneChakraProfile::Register();
     #endif
         ValueType::Initialize();
         ThreadContext::GlobalInitialize();

--- a/pal/src/cruntime/misc.cpp
+++ b/pal/src/cruntime/misc.cpp
@@ -378,6 +378,10 @@ char *MiscGetenv(const char *name)
     }
 done:
     InternalLeaveCriticalSection(pthrCurrent, &gcsEnvironment);
+    if (pRet == NULL)
+    {
+        return getenv(name);
+    }
     return pRet;
 }
 


### PR DESCRIPTION
Enable VTune JIT Profiling in Linux. Added VTuneChakraProfile::Register(); along with EtwTrace::Register(), also added undef and def for getenv in jitprofiling.cpp on Linux to resolve the conflict introduced by pal.h definition for getenv. 