### PR TITLE
fix issue with rejit exception and no profile info

### DIFF
--- a/lib/Backend/BackwardPass.cpp
+++ b/lib/Backend/BackwardPass.cpp
@@ -191,8 +191,7 @@ BackwardPass::DoTrackCompoundedIntOverflow() const
 {
     return
         !PHASE_OFF(Js::TrackCompoundedIntOverflowPhase, func) &&
-        DoTrackIntOverflow() &&
-        (!func->HasProfileInfo() || !func->GetReadOnlyProfileInfo()->IsTrackCompoundedIntOverflowDisabled());
+        DoTrackIntOverflow() && !func->IsTrackCompoundedIntOverflowDisabled();
 }
 
 bool

--- a/lib/Backend/BailOut.cpp
+++ b/lib/Backend/BailOut.cpp
@@ -2222,7 +2222,7 @@ void BailOutRecord::ScheduleFunctionCodeGen(Js::ScriptFunction * function, Js::S
             Js::ScriptContext* scriptContext = executeFunction->GetScriptContext();
             if (scriptContext->rejitReasonCountsCap != nullptr)
             {
-                scriptContext->rejitReasonCountsCap[rejitReason]++;
+                scriptContext->rejitReasonCountsCap[static_cast<byte>(rejitReason)]++;
             }
 #endif
             reThunk = true;

--- a/lib/Backend/BailOut.cpp
+++ b/lib/Backend/BailOut.cpp
@@ -2237,7 +2237,7 @@ void BailOutRecord::ScheduleFunctionCodeGen(Js::ScriptFunction * function, Js::S
 
     REJIT_KIND_TESTTRACE(bailOutKind, _u("Bailout from function: function: %s, bailOutKindName: (%S), bailOutCount: %d, callCount: %d, reJitReason: %S, reThunk: %s\r\n"),
         function->GetFunctionBody()->GetDisplayName(), ::GetBailOutKindName(bailOutKind), bailOutRecord->bailOutCount, callsCount,
-        RejitReasonNames[rejitReason], reThunk ? trueString : falseString);
+        GetRejitReasonName(rejitReason), reThunk ? trueString : falseString);
 
 #ifdef REJIT_STATS
     executeFunction->GetScriptContext()->LogBailout(executeFunction, bailOutKind);
@@ -2303,7 +2303,7 @@ void BailOutRecord::ScheduleFunctionCodeGen(Js::ScriptFunction * function, Js::S
                 bailOutRecord->bailOutCount);
 
             Output::Print(_u(" callCount: %u"), callsCount);
-            Output::Print(_u(" reason: %S"), RejitReasonNames[rejitReason]);
+            Output::Print(_u(" reason: %S"), GetRejitReasonName(rejitReason));
             if(bailOutKind != IR::BailOutInvalid)
             {
                 Output::Print(_u(" (%S)"), ::GetBailOutKindName(bailOutKind));
@@ -2586,7 +2586,7 @@ void BailOutRecord::ScheduleLoopBodyCodeGen(Js::ScriptFunction * function, Js::S
 
     REJIT_KIND_TESTTRACE(bailOutKind, _u("Bailout from loop: function: %s, loopNumber: %d, bailOutKindName: (%S), reJitReason: %S\r\n"),
         function->GetFunctionBody()->GetDisplayName(), executeFunction->GetLoopNumber(loopHeader),
-        ::GetBailOutKindName(bailOutKind), RejitReasonNames[rejitReason]);
+        ::GetBailOutKindName(bailOutKind), GetRejitReasonName(rejitReason));
 
 #ifdef REJIT_STATS
     executeFunction->GetScriptContext()->LogBailout(executeFunction, bailOutKind);
@@ -2612,7 +2612,7 @@ void BailOutRecord::ScheduleLoopBodyCodeGen(Js::ScriptFunction * function, Js::S
                 executeFunction->GetDebugNumberSet(debugStringBuffer),
                 executeFunction->GetLoopNumber(loopHeader),
                 bailOutRecord->bailOutCount,
-                RejitReasonNames[rejitReason]);
+                GetRejitReasonName(rejitReason));
             if(bailOutKind != IR::BailOutInvalid)
             {
                 Output::Print(_u(" (%S)"), ::GetBailOutKindName(bailOutKind));

--- a/lib/Backend/Func.h
+++ b/lib/Backend/Func.h
@@ -752,12 +752,7 @@ public:
 
     bool                GetHasStackArgs() const
     {
-                        bool isStackArgOptDisabled = false;
-                        if (HasProfileInfo())
-                        {
-                            isStackArgOptDisabled = GetReadOnlyProfileInfo()->IsStackArgOptDisabled();
-                        }
-                        return this->hasStackArgs && !isStackArgOptDisabled && !PHASE_OFF1(Js::StackArgOptPhase);
+                        return this->hasStackArgs && !IsStackArgOptDisabled() && !PHASE_OFF1(Js::StackArgOptPhase);
     }
     void                SetHasStackArgs(bool has) { this->hasStackArgs = has;}
 
@@ -798,7 +793,6 @@ public:
                             }
                         }
     }
-
     void               DisableCanDoInlineArgOpt()
     {
                         Func* curFunc = this;
@@ -943,6 +937,11 @@ public:
 
     void SetScopeObjSym(StackSym * sym);
     StackSym * GetScopeObjSym();
+    bool IsTrackCompoundedIntOverflowDisabled() const;
+    bool IsArrayCheckHoistDisabled() const;
+    bool IsStackArgOptDisabled() const;
+    bool IsSwitchOptDisabled() const;
+    bool IsAggressiveIntTypeSpecDisabled() const;
 
 #if DBG
     bool                allowRemoveBailOutArgInstr;

--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -15597,7 +15597,7 @@ GlobOpt::VerifyIntSpecForIgnoringIntOverflow(IR::Instr *const instr)
     // This can happen for Neg_A if it needs to bail out on negative zero, and perhaps other cases as well. It's too late to fix
     // the problem (overflows may already be ignored), so handle it by bailing out at compile-time and disabling tracking int
     // overflow.
-    Assert(!func->HasProfileInfo() || !func->GetReadOnlyProfileInfo()->IsTrackCompoundedIntOverflowDisabled());
+    Assert(!func->IsTrackCompoundedIntOverflowDisabled());
 
     if(PHASE_TRACE(Js::BailOutPhase, this->func))
     {
@@ -15615,7 +15615,7 @@ GlobOpt::VerifyIntSpecForIgnoringIntOverflow(IR::Instr *const instr)
         Output::Flush();
     }
 
-    if(func->HasProfileInfo() && func->GetReadOnlyProfileInfo()->IsTrackCompoundedIntOverflowDisabled())
+    if(func->IsTrackCompoundedIntOverflowDisabled())
     {
         // Tracking int overflows is already off for some reason. Prevent trying to rejit again because it won't help and the
         // same thing will happen again and cause an infinite loop. Just abort jitting this function.
@@ -17011,7 +17011,7 @@ bool
 GlobOpt::IsSwitchOptEnabled(Func const * func)
 {
     Assert(func->IsTopFunc());
-    return !PHASE_OFF(Js::SwitchOptPhase, func) && (!func->HasProfileInfo() || !func->GetReadOnlyProfileInfo()->IsSwitchOptDisabled()) && !IsTypeSpecPhaseOff(func)
+    return !PHASE_OFF(Js::SwitchOptPhase, func) && !func->IsSwitchOptDisabled() && !IsTypeSpecPhaseOff(func)
         && func->DoGlobOpt() && !func->HasTry();
 }
 
@@ -17039,7 +17039,7 @@ GlobOpt::DoAggressiveIntTypeSpec(Func const * func)
     return
         !PHASE_OFF(Js::AggressiveIntTypeSpecPhase, func) &&
         !IsTypeSpecPhaseOff(func) &&
-        (!func->HasProfileInfo() || !func->GetReadOnlyProfileInfo()->IsAggressiveIntTypeSpecDisabled(func->IsLoopBody()));
+        !func->IsAggressiveIntTypeSpecDisabled();
 }
 
 bool
@@ -17130,7 +17130,7 @@ GlobOpt::DoArrayCheckHoist(Func const * const func)
     Assert(func->IsTopFunc());
     return
         !PHASE_OFF(Js::ArrayCheckHoistPhase, func) &&
-        (!func->HasProfileInfo() || !func->GetReadOnlyProfileInfo()->IsArrayCheckHoistDisabled(func->IsLoopBody())) &&
+        !func->IsArrayCheckHoistDisabled() &&
         !func->IsJitInDebugMode() && // StElemI fast path is not allowed when in debug mode, so it cannot have bailout
         func->DoGlobOptsForGeneratorFunc();
 }
@@ -17888,7 +17888,7 @@ GlobOpt::TraceSettings() const
     Output::Print(_u("    FloatTypeSpec: %s\r\n"), this->DoFloatTypeSpec() ? _u("enabled") : _u("disabled"));
     Output::Print(_u("    AggressiveIntTypeSpec: %s\r\n"), this->DoAggressiveIntTypeSpec() ? _u("enabled") : _u("disabled"));
     Output::Print(_u("    LossyIntTypeSpec: %s\r\n"), this->DoLossyIntTypeSpec() ? _u("enabled") : _u("disabled"));
-    Output::Print(_u("    ArrayCheckHoist: %s\r\n"),  (this->func->HasProfileInfo() && this->func->GetReadOnlyProfileInfo()->IsArrayCheckHoistDisabled(func->IsLoopBody())) ? _u("disabled") : _u("enabled"));
+    Output::Print(_u("    ArrayCheckHoist: %s\r\n"),  this->func->IsArrayCheckHoistDisabled() ? _u("disabled") : _u("enabled"));
     Output::Print(_u("    ImplicitCallFlags: %s\r\n"), Js::DynamicProfileInfo::GetImplicitCallFlagsString(this->func->m_fg->implicitCallFlags));
     for (Loop * loop = this->func->m_fg->loopList; loop != NULL; loop = loop->next)
     {

--- a/lib/Backend/JITOutput.cpp
+++ b/lib/Backend/JITOutput.cpp
@@ -57,6 +57,36 @@ JITOutput::RecordThrowMap(Js::ThrowMapEntry * throwMap, uint mapCount)
     m_outputData->throwMapCount = mapCount;
 }
 
+bool
+JITOutput::IsTrackCompoundedIntOverflowDisabled() const
+{
+    return m_outputData->disableTrackCompoundedIntOverflow != FALSE;
+}
+
+bool
+JITOutput::IsArrayCheckHoistDisabled() const
+{
+    return m_outputData->disableArrayCheckHoist != FALSE;
+}
+
+bool
+JITOutput::IsStackArgOptDisabled() const
+{
+    return m_outputData->disableStackArgOpt != FALSE;
+}
+
+bool
+JITOutput::IsSwitchOptDisabled() const
+{
+    return m_outputData->disableSwitchOpt != FALSE;
+}
+
+bool
+JITOutput::IsAggressiveIntTypeSpecDisabled() const
+{
+    return m_outputData->disableAggressiveIntTypeSpec != FALSE;
+}
+
 uint16
 JITOutput::GetArgUsedForBranch() const
 {

--- a/lib/Backend/JITOutput.h
+++ b/lib/Backend/JITOutput.h
@@ -21,6 +21,12 @@ public:
 #ifdef _M_ARM
     void RecordXData(BYTE * xdata);
 #endif
+    bool IsTrackCompoundedIntOverflowDisabled() const;
+    bool IsArrayCheckHoistDisabled() const;
+    bool IsStackArgOptDisabled() const;
+    bool IsSwitchOptDisabled() const;
+    bool IsAggressiveIntTypeSpecDisabled() const;
+
     uint16 GetArgUsedForBranch() const;
     intptr_t GetCodeAddress() const;
     size_t GetCodeSize() const;

--- a/lib/Backend/JITTimeProfileInfo.cpp
+++ b/lib/Backend/JITTimeProfileInfo.cpp
@@ -137,36 +137,6 @@ JITTimeProfileInfo::InitializeJITProfileData(
     data->flags |= profileInfo->IsTagCheckDisabled() ? Flags_disableTagCheck : 0;
 }
 
-void
-JITTimeProfileInfo::DisableAggressiveIntTypeSpec(bool isLoopBody)
-{
-    m_profileData.flags |= isLoopBody ? Flags_disableAggressiveIntTypeSpec_jitLoopBody : Flags_disableAggressiveIntTypeSpec;
-}
-
-void
-JITTimeProfileInfo::DisableArrayCheckHoist(bool isLoopBody)
-{
-    m_profileData.flags |= isLoopBody ? Flags_disableArrayCheckHoist_jitLoopBody : Flags_disableArrayCheckHoist;
-}
-
-void
-JITTimeProfileInfo::DisableStackArgOpt()
-{
-    m_profileData.flags |= Flags_disableStackArgOpt;
-}
-
-void
-JITTimeProfileInfo::DisableSwitchOpt()
-{
-    m_profileData.flags |= Flags_disableSwitchOpt;
-}
-
-void
-JITTimeProfileInfo::DisableTrackCompoundedIntOverflow()
-{
-    m_profileData.flags |= Flags_disableTrackCompoundedIntOverflow;
-}
-
 const Js::LdElemInfo *
 JITTimeProfileInfo::GetLdElemInfo(Js::ProfileId ldElemId) const
 {

--- a/lib/Backend/JITTimeProfileInfo.h
+++ b/lib/Backend/JITTimeProfileInfo.h
@@ -36,12 +36,6 @@ public:
 
     uint16 GetConstantArgInfo(Js::ProfileId callSiteId) const;
 
-    void DisableAggressiveIntTypeSpec(bool isLoopBody);
-    void DisableStackArgOpt();
-    void DisableSwitchOpt();
-    void DisableTrackCompoundedIntOverflow();
-    void DisableArrayCheckHoist(bool isLoopBody);
-
     bool IsModulusOpByPowerOf2(Js::ProfileId profileId) const;
     bool IsAggressiveIntTypeSpecDisabled(const bool isJitLoopBody) const;
     bool IsSwitchOptDisabled() const;

--- a/lib/Common/Common/RejitReason.cpp
+++ b/lib/Common/Common/RejitReason.cpp
@@ -11,5 +11,11 @@ const char *const RejitReasonNames[] =
     #include "RejitReasons.h"
     #undef REJIT_REASON
 };
+const char* const GetRejitReasonName(RejitReason reason)
+{
+    byte reasonIndex = static_cast<byte>(reason);
+    Assert(reasonIndex < NumRejitReasons);
+    return RejitReasonNames[reasonIndex];
+}
 
 const uint NumRejitReasons = _countof(RejitReasonNames);

--- a/lib/Common/Common/RejitReason.h
+++ b/lib/Common/Common/RejitReason.h
@@ -4,11 +4,14 @@
 //-------------------------------------------------------------------------------------------------------
 #pragma once
 
-BEGIN_ENUM_BYTE(RejitReason)
-    #define REJIT_REASON(n) n,
-    #include "RejitReasons.h"
-    #undef REJIT_REASON
-END_ENUM_BYTE();
+enum class RejitReason : byte
+{
+#define REJIT_REASON(n) n,
+#include "RejitReasons.h"
+#undef REJIT_REASON
+};
 
 extern const char *const RejitReasonNames[];
 extern const uint NumRejitReasons;
+
+extern const char *const GetRejitReasonName(RejitReason reason);

--- a/lib/Common/Exceptions/RejitException.h
+++ b/lib/Common/Exceptions/RejitException.h
@@ -24,7 +24,7 @@ namespace Js
 
         const char *ReasonName() const
         {
-            return RejitReasonNames[reason];
+            return RejitReasonNames[static_cast<byte>(reason)];
         }
     };
 }

--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -5694,15 +5694,16 @@ void ScriptContext::RegisterPrototypeChainEnsuredToHaveOnlyWritableDataPropertie
             }
         }
     }
-    void ScriptContext::LogRejit(Js::FunctionBody *body, uint reason)
+    void ScriptContext::LogRejit(Js::FunctionBody *body, RejitReason reason)
     {
-        Assert(reason < NumRejitReasons);
-        rejitReasonCounts[reason]++;
+        byte reasonIndex = static_cast<byte>(reason);
+        Assert(reasonIndex < NumRejitReasons);
+        rejitReasonCounts[reasonIndex]++;
 
 #if defined(FLAG) || defined(FLAG_REGOVR_EXP)
         if (Js::Configuration::Global.flags.Verbose)
         {
-            LogDataForFunctionBody(body, reason, true);
+            LogDataForFunctionBody(body, reasonIndex, true);
         }
 #endif
     }

--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -699,7 +699,7 @@ public:
 
         void LogDataForFunctionBody(Js::FunctionBody *body, uint idx, bool isRejit);
 
-        void LogRejit(Js::FunctionBody *body, uint reason);
+        void LogRejit(Js::FunctionBody *body, RejitReason reason);
         void LogBailout(Js::FunctionBody *body, uint kind);
 
         // Used to centrally collect stats for all function bodies.


### PR DESCRIPTION
In some cases it's possible to have a rejit exception which wants to disable some optimization even if you don't have profile info. For this to work it required refactoring a bit in how we check if an optimization is disabled, and while I was here I decided to do a bit of cleanup around the RejitReason enum as well.