### PR TITLE
Add trampoline for JIT calls

### DIFF
--- a/lib/Backend/Backend.h
+++ b/lib/Backend/Backend.h
@@ -174,6 +174,7 @@ enum IRDumpFlags
 #include "Encoder.h"
 #include "EmitBuffer.h"
 #include "InterpreterThunkEmitter.h"
+#include "JITThunkEmitter.h"
 #include "InliningHeuristics.h"
 #include "InliningDecider.h"
 #include "Inline.h"

--- a/lib/Backend/CMakeLists.txt
+++ b/lib/Backend/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library (Chakra.Backend OBJECT
     InliningHeuristics.cpp
     IntBounds.cpp
     InterpreterThunkEmitter.cpp
+    JITThunkEmitter.cpp
     JITOutput.cpp
     JITTimeConstructorCache.cpp
     JITTimeFunctionBody.cpp

--- a/lib/Backend/Chakra.Backend.vcxproj
+++ b/lib/Backend/Chakra.Backend.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Condition="'$(ChakraBuildPathImported)'!='true'" Project="$(SolutionDir)Chakra.Build.Paths.props" />
   <Import Project="$(BuildConfigPropsPath)Chakra.Build.ProjectConfiguration.props" />
@@ -217,6 +217,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)FunctionCodeGenJitTimeData.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)GlobOptBlockData.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)ValueInfo.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)JITThunkEmitter.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="AgenPeeps.h" />
@@ -390,6 +391,7 @@
     <ClInclude Include="IRViewer.h" />
     <ClInclude Include="IRType.h" />
     <ClInclude Include="IRTypeList.h" />
+    <ClInclude Include="JITThunkEmitter.h" />
     <ClInclude Include="ObjTypeSpecFldInfo.h" />
     <ClInclude Include="JITOutput.h" />
     <ClInclude Include="JITRecyclableObject.h" />

--- a/lib/Backend/Chakra.Backend.vcxproj.filters
+++ b/lib/Backend/Chakra.Backend.vcxproj.filters
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <ClCompile Include="$(MSBuildThisFileDirectory)AgenPeeps.cpp" />
@@ -127,8 +127,9 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)FixedFieldInfo.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)ObjTypeSpecFldInfo.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)PageAllocatorPool.cpp" />
-    <ClCompile Include="GlobOptBlockData.cpp" />
-    <ClCompile Include="ValueInfo.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)GlobOptBlockData.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)ValueInfo.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)JITThunkEmitter.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="AgenPeeps.h" />
@@ -343,6 +344,7 @@
     <ClInclude Include="PageAllocatorPool.h" />
     <ClInclude Include="GlobOptBlockData.h" />
     <ClInclude Include="ValueInfo.h" />
+    <ClInclude Include="JITThunkEmitter.h" />
   </ItemGroup>
   <ItemGroup>
     <MASM Include="$(MSBuildThisFileDirectory)amd64\LinearScanMdA.asm">

--- a/lib/Backend/CodeGenWorkItem.cpp
+++ b/lib/Backend/CodeGenWorkItem.cpp
@@ -12,7 +12,6 @@ CodeGenWorkItem::CodeGenWorkItem(
     bool isJitInDebugMode,
     CodeGenWorkItemType type)
     : JsUtil::Job(manager)
-    , codeAddress(NULL)
     , functionBody(functionBody)
     , entryPointInfo(entryPointInfo)
     , recyclableData(nullptr)
@@ -209,7 +208,7 @@ void CodeGenWorkItem::OnWorkItemProcessFail(NativeCodeGenerator* codeGen)
 #if DBG
         this->allocation->allocation->isNotExecutableBecauseOOM = true;
 #endif
-        codeGen->FreeNativeCodeGenAllocation(this->allocation->allocation->address);
+        codeGen->FreeNativeCodeGenAllocation(this->allocation->allocation->address, nullptr);
     }
 }
 

--- a/lib/Backend/CodeGenWorkItem.h
+++ b/lib/Backend/CodeGenWorkItem.h
@@ -20,7 +20,6 @@ protected:
     CodeGenWorkItemIDL jitData;
 
     Js::FunctionBody *const functionBody;
-    size_t codeAddress;
     ptrdiff_t codeSize;
 
 public:
@@ -63,9 +62,6 @@ public:
     {
         return functionBody;
     }
-
-    void SetCodeAddress(size_t codeAddress) { this->codeAddress = codeAddress; }
-    size_t GetCodeAddress() { return codeAddress; }
 
     void SetCodeSize(ptrdiff_t codeSize) { this->codeSize = codeSize; }
     ptrdiff_t GetCodeSize() { return codeSize; }
@@ -267,17 +263,21 @@ struct JsLoopBodyCodeGen sealed : public CodeGenWorkItem
         JsUtil::JobManager *const manager, Js::FunctionBody *const functionBody,
         Js::EntryPointInfo* entryPointInfo, bool isJitInDebugMode, Js::LoopHeader * loopHeader) :
         CodeGenWorkItem(manager, functionBody, entryPointInfo, isJitInDebugMode, JsLoopBodyWorkItemType),
+        codeAddress(NULL),
         loopHeader(loopHeader)
     {
         this->jitData.loopNumber = GetLoopNumber();
     }
-
+    uintptr_t codeAddress;
     Js::LoopHeader * loopHeader;
 
     uint GetLoopNumber() const override
     {
         return functionBody->GetLoopNumberWithLock(loopHeader);
     }
+
+    void SetCodeAddress(uintptr_t codeAddress) { this->codeAddress = codeAddress; }
+    uintptr_t GetCodeAddress() const { return codeAddress; }
 
     uint GetByteCodeCount() const override
     {

--- a/lib/Backend/EmitBuffer.cpp
+++ b/lib/Backend/EmitBuffer.cpp
@@ -8,7 +8,7 @@
 // EmitBufferManager::EmitBufferManager
 //      Constructor
 //----------------------------------------------------------------------------
-template <typename TAlloc, typename TPreReservedAlloc, class SyncObject>
+template <typename TAlloc, typename TPreReservedAlloc, typename SyncObject>
 EmitBufferManager<TAlloc, TPreReservedAlloc, SyncObject>::EmitBufferManager(ArenaAllocator * allocator, CustomHeap::CodePageAllocators<TAlloc, TPreReservedAlloc> * codePageAllocators,
     Js::ScriptContext * scriptContext, LPCWSTR name, HANDLE processHandle) :
     allocationHeap(allocator, codePageAllocators, processHandle),

--- a/lib/Backend/Encoder.cpp
+++ b/lib/Backend/Encoder.cpp
@@ -433,11 +433,6 @@ Encoder::Encode()
     m_func->GetJITOutput()->SetCodeAddress(m_func->GetJITOutput()->GetCodeAddress() | 0x1); // Set thumb mode
 #endif
 
-    if (CONFIG_FLAG(OOPCFGRegistration))
-    {
-        m_func->GetThreadContextInfo()->SetValidCallTargetForCFG((PVOID)m_func->GetJITOutput()->GetCodeAddress());
-    }
-
     const bool isSimpleJit = m_func->IsSimpleJit();
 
     if (this->m_inlineeFrameMap->Count() > 0 &&

--- a/lib/Backend/JITOutput.cpp
+++ b/lib/Backend/JITOutput.cpp
@@ -224,18 +224,39 @@ JITOutput::FinalizeNativeCode()
     if (JITManager::GetJITManager()->IsJITServer())
     {
         m_func->GetOOPCodeGenAllocators()->emitBufferManager.CompletePreviousAllocation(m_oopAlloc);
+#if defined(_CONTROL_FLOW_GUARD)
+#if _M_IX86 || _M_X64
+        if (m_func->GetThreadContextInfo()->IsCFGEnabled() && !m_func->IsLoopBody())
+        {
+            m_outputData->thunkAddress = m_func->GetOOPThreadContext()->GetJITThunkEmitter()->CreateThunk(m_outputData->codeAddress);
+        }
+#endif
+#endif
     }
     else
 #endif
     {
         m_func->GetInProcCodeGenAllocators()->emitBufferManager.CompletePreviousAllocation(m_inProcAlloc);
-
         m_func->GetInProcJITEntryPointInfo()->SetInProcJITNativeCodeData(m_func->GetNativeCodeDataAllocator()->Finalize());
         m_func->GetInProcJITEntryPointInfo()->GetJitTransferData()->SetRawData(m_func->GetTransferDataAllocator()->Finalize());
 #if !FLOATVAR
         CodeGenNumberChunk * numberChunks = m_func->GetNumberAllocator()->Finalize();
         m_func->GetInProcJITEntryPointInfo()->SetNumberChunks(numberChunks);
 #endif
+
+#if defined(_CONTROL_FLOW_GUARD)
+#if _M_IX86 || _M_X64
+        if (m_func->GetThreadContextInfo()->IsCFGEnabled() && !m_func->IsLoopBody())
+        {
+            m_outputData->thunkAddress = m_func->GetInProcThreadContext()->GetJITThunkEmitter()->CreateThunk(m_outputData->codeAddress);
+        }
+#endif
+#endif
+    }
+
+    if (!m_outputData->thunkAddress && CONFIG_FLAG(OOPCFGRegistration))
+    {
+        m_func->GetThreadContextInfo()->SetValidCallTargetForCFG((PVOID)m_outputData->codeAddress);
     }
 }
 

--- a/lib/Backend/JITThunkEmitter.cpp
+++ b/lib/Backend/JITThunkEmitter.cpp
@@ -1,0 +1,285 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#include "Backend.h"
+
+#if defined(ENABLE_NATIVE_CODEGEN) && defined(_CONTROL_FLOW_GUARD) && (_M_IX86 || _M_X64)
+
+template class JITThunkEmitter<VirtualAllocWrapper>;
+
+#if ENABLE_OOP_NATIVE_CODEGEN
+template class JITThunkEmitter<SectionAllocWrapper>;
+#endif
+
+template <typename TAlloc>
+const BYTE JITThunkEmitter<TAlloc>::DirectJmp[] = {
+    0xE9, 0x00, 0x00, 0x00, 0x00, // JMP <relativeAddress>.32
+    0xCC, 0xCC, 0xCC,
+    0xCC, 0xCC, 0xCC, 0xCC,
+    0xCC, 0xCC, 0xCC, 0xCC
+};
+
+#if _M_X64
+template <typename TAlloc>
+const BYTE JITThunkEmitter<TAlloc>::IndirectJmp[] = {
+    0x48, 0xB8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // MOV RAX, <relativeAddress>.64
+    0x48, 0xFF, 0xE0,                                           // JMP RAX
+    0xCC, 0xCC, 0xCC
+};
+#endif
+
+template <typename TAlloc>
+JITThunkEmitter<TAlloc>::JITThunkEmitter(ThreadContextInfo * threadContext, TAlloc * codeAllocator, HANDLE processHandle) :
+    processHandle(processHandle),
+    codeAllocator(codeAllocator),
+    threadContext(threadContext),
+    baseAddress(NULL),
+    firstBitToCheck(0)
+{
+    freeThunks.SetAll();
+}
+
+template <typename TAlloc>
+JITThunkEmitter<TAlloc>::~JITThunkEmitter()
+{
+    if (baseAddress != NULL)
+    {
+        this->codeAllocator->Free((PVOID)baseAddress, TotalThunkSize, MEM_RELEASE);
+    }
+}
+
+template <typename TAlloc> inline
+uintptr_t
+JITThunkEmitter<TAlloc>::CreateThunk(uintptr_t entryPoint)
+{
+    AutoCriticalSection autoCs(&this->cs);
+    if(EnsureInitialized() == NULL)
+    {
+        return NULL;
+    }
+
+    // find available thunk
+    BVIndex thunkIndex = this->freeThunks.GetNextBit(this->firstBitToCheck);
+    if (thunkIndex == BVInvalidIndex)
+    {
+        return NULL;
+    }
+    uintptr_t thunkAddress = GetThunkAddressFromIndex(thunkIndex);
+
+    uintptr_t pageStartAddress = GetThunkPageStart(thunkAddress);
+    char * localPageAddress = (char *)this->codeAllocator->AllocLocal((PVOID)pageStartAddress, AutoSystemInfo::PageSize);
+    if (localPageAddress == nullptr)
+    {
+        return NULL;
+    }
+
+    if (IsThunkPageEmpty(pageStartAddress))
+    {
+        if (this->codeAllocator->Alloc((PVOID)pageStartAddress, AutoSystemInfo::PageSize, MEM_COMMIT, PAGE_EXECUTE, true) == nullptr)
+        {
+            this->codeAllocator->FreeLocal(localPageAddress);
+            return NULL;
+        }
+        UnprotectPage(localPageAddress);
+        memset(localPageAddress, 0xCC, AutoSystemInfo::PageSize);
+    }
+    else
+    {
+        UnprotectPage(localPageAddress);
+    }
+
+    EncodeJmp(localPageAddress, thunkAddress, entryPoint);
+
+    ProtectPage(localPageAddress);
+    this->codeAllocator->FreeLocal(localPageAddress);
+
+    if (CONFIG_FLAG(OOPCFGRegistration))
+    {
+        this->threadContext->SetValidCallTargetForCFG((PVOID)thunkAddress);
+    }
+    this->firstBitToCheck = (thunkIndex + 1 < JITThunkEmitter<TAlloc>::TotalThunkCount) ? thunkIndex + 1 : 0;
+    this->freeThunks.Clear(thunkIndex);
+
+    FlushInstructionCache(this->processHandle, (PVOID)thunkAddress, ThunkSize);
+
+    return thunkAddress;
+}
+
+template <typename TAlloc> inline
+void
+JITThunkEmitter<TAlloc>::FreeThunk(uintptr_t thunkAddress)
+{
+    AutoCriticalSection autoCs(&this->cs);
+    BVIndex thunkIndex = GetThunkIndexFromAddress(thunkAddress);
+    if (thunkIndex >= this->freeThunks.Length() || this->freeThunks.TestAndSet(thunkIndex))
+    {
+        Assert(UNREACHED);
+        this->firstBitToCheck = 0;
+        return;
+    }
+
+    if (thunkIndex < firstBitToCheck)
+    {
+        this->firstBitToCheck = thunkIndex;
+    }
+
+    if (CONFIG_FLAG(OOPCFGRegistration))
+    {
+        this->threadContext->SetValidCallTargetForCFG((PVOID)thunkAddress, false);
+    }
+
+    uintptr_t pageStartAddress = GetThunkPageStart(thunkAddress);
+    if (IsThunkPageEmpty(pageStartAddress))
+    {
+        this->codeAllocator->Free((PVOID)pageStartAddress, AutoSystemInfo::PageSize, MEM_DECOMMIT);
+    }
+    else
+    {
+        char * localAddress = (char *)this->codeAllocator->AllocLocal((PVOID)thunkAddress, ThunkSize);
+        if (localAddress == nullptr)
+        {
+            return;
+        }
+        UnprotectPage(localAddress);
+        memset(localAddress, 0xCC, ThunkSize);
+        ProtectPage(localAddress);
+        this->codeAllocator->FreeLocal(localAddress);
+    }
+    FlushInstructionCache(this->processHandle, (PVOID)thunkAddress, ThunkSize);
+}
+
+template <typename TAlloc> inline
+uintptr_t
+JITThunkEmitter<TAlloc>::EnsureInitialized()
+{
+    if (this->baseAddress != NULL)
+    {
+        return this->baseAddress;
+    }
+
+    // only take a lock if we need to initialize
+    {
+        AutoCriticalSection autoCs(&this->cs);
+        // check again because we did the first one outside of lock
+        if (this->baseAddress == NULL)
+        {
+            this->baseAddress = (uintptr_t)this->codeAllocator->Alloc(nullptr, TotalThunkSize, MEM_RESERVE, PAGE_EXECUTE, true);
+        }
+    }
+    return this->baseAddress;
+}
+
+template <typename TAlloc> inline
+bool
+JITThunkEmitter<TAlloc>::IsInThunk(uintptr_t address) const
+{
+    return IsInThunk(this->baseAddress, address);
+}
+
+/* static */
+template <typename TAlloc> inline
+bool
+JITThunkEmitter<TAlloc>::IsInThunk(uintptr_t thunkBaseAddress, uintptr_t address)
+{
+    bool isInThunk = address >= thunkBaseAddress && address < thunkBaseAddress + TotalThunkSize;
+    Assert(!isInThunk || address % ThunkSize == 0);
+    return isInThunk;
+}
+
+/* static */
+template <typename TAlloc> inline
+void
+JITThunkEmitter<TAlloc>::EncodeJmp(char * localPageAddress, uintptr_t thunkAddress, uintptr_t targetAddress)
+{
+    char * localAddress = localPageAddress + thunkAddress % AutoSystemInfo::PageSize;
+    ptrdiff_t relativeAddress = targetAddress - thunkAddress - DirectJmpIPAdjustment;
+#if _M_X64
+    if (relativeAddress > INT_MAX || relativeAddress < INT_MIN)
+    {
+        memcpy_s(localAddress, ThunkSize, IndirectJmp, ThunkSize);
+        uintptr_t * jmpTarget = (uintptr_t*)(localAddress + IndirectJmpTargetOffset);
+        *jmpTarget = targetAddress;
+    }
+    else
+#endif
+    {
+        memcpy_s(localAddress, ThunkSize, DirectJmp, ThunkSize);
+        uintptr_t * jmpTarget = (uintptr_t*)(localAddress + DirectJmpTargetOffset);
+        *jmpTarget = relativeAddress;
+    }
+}
+
+template <typename TAlloc> inline
+bool
+JITThunkEmitter<TAlloc>::IsThunkPageEmpty(uintptr_t address) const
+{
+    Assert(address == GetThunkPageStart(address));
+    BVIndex pageStartIndex = GetThunkIndexFromAddress(address);
+    Assert(pageStartIndex != BVInvalidIndex);
+    BVStatic<ThunksPerPage> * pageBV = this->freeThunks.GetRange<ThunksPerPage>(pageStartIndex);
+    return pageBV->IsAllSet();
+}
+
+template <> inline
+void
+JITThunkEmitter<VirtualAllocWrapper>::ProtectPage(void * address)
+{
+    DWORD oldProtect;
+    BOOL result = VirtualProtectEx(this->processHandle, address, ThunkSize, PAGE_EXECUTE, &oldProtect);
+    AssertOrFailFast(result && oldProtect == PAGE_EXECUTE_READWRITE);
+}
+
+template <> inline
+void
+JITThunkEmitter<VirtualAllocWrapper>::UnprotectPage(void * address)
+{
+    DWORD oldProtect;
+    BOOL result = VirtualProtectEx(this->processHandle, address, ThunkSize, PAGE_EXECUTE_READWRITE, &oldProtect);
+    AssertOrFailFast(result && oldProtect == PAGE_EXECUTE);
+}
+
+#if ENABLE_OOP_NATIVE_CODEGEN
+template <> inline
+void
+JITThunkEmitter<SectionAllocWrapper>::ProtectPage(void * address)
+{
+}
+
+template <> inline
+void
+JITThunkEmitter<SectionAllocWrapper>::UnprotectPage(void * address)
+{
+}
+#endif
+
+template <typename TAlloc> inline
+uintptr_t
+JITThunkEmitter<TAlloc>::GetThunkAddressFromIndex(BVIndex index) const
+{
+    return this->baseAddress + index * ThunkSize;
+}
+
+template <typename TAlloc> inline
+BVIndex
+JITThunkEmitter<TAlloc>::GetThunkIndexFromAddress(uintptr_t thunkAddress) const
+{
+    uintptr_t thunkIndex = (thunkAddress - this->baseAddress) / ThunkSize;
+#if TARGET_64
+    if (thunkIndex > BVInvalidIndex)
+    {
+        thunkIndex = BVInvalidIndex;
+    }
+#endif
+    return (BVIndex)thunkIndex;
+}
+
+/* static */
+template <typename TAlloc> inline
+uintptr_t
+JITThunkEmitter<TAlloc>::GetThunkPageStart(uintptr_t address)
+{
+    return address - address % AutoSystemInfo::PageSize;
+}
+#endif

--- a/lib/Backend/JITThunkEmitter.h
+++ b/lib/Backend/JITThunkEmitter.h
@@ -1,0 +1,62 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+#pragma once
+
+#if defined(ENABLE_NATIVE_CODEGEN) && defined(_CONTROL_FLOW_GUARD) && (_M_IX86 || _M_X64)
+template <typename TAlloc>
+class JITThunkEmitter
+{
+private:
+    static const BYTE DirectJmp[];
+    static const uint DirectJmpTargetOffset = 1;
+    static const uint DirectJmpIPAdjustment = 5;
+#if _M_AMD64
+    static const BYTE IndirectJmp[];
+    static const uint IndirectJmpTargetOffset = 2;
+#endif
+    static const uint PageCount = 100;
+    static const size_t ThunkSize = 16;
+    static const size_t ThunksPerPage = AutoSystemInfo::PageSize / ThunkSize;
+
+public:
+    static const uintptr_t ThunkAlignmentMask = ~(ThunkSize-1);
+    static const uint TotalThunkSize = AutoSystemInfo::PageSize * PageCount;
+    static const size_t TotalThunkCount = TotalThunkSize / ThunkSize;
+
+private:
+    CriticalSection cs;
+    TAlloc * codeAllocator;
+    uintptr_t baseAddress;
+    HANDLE processHandle;
+    BVStatic<TotalThunkCount> freeThunks;
+    ThreadContextInfo * threadContext;
+    BVIndex firstBitToCheck;
+
+public:
+    JITThunkEmitter(ThreadContextInfo * threadContext, TAlloc * codeAllocator, HANDLE processHandle);
+    ~JITThunkEmitter();
+
+    uintptr_t  CreateThunk(uintptr_t entryPoint);
+    void FreeThunk(uintptr_t thunkAddress);
+    uintptr_t EnsureInitialized();
+
+    bool IsInThunk(uintptr_t address) const;
+    static bool IsInThunk(uintptr_t thunkBaseAddress, uintptr_t address);
+private:
+    uintptr_t GetThunkAddressFromIndex(BVIndex index) const;
+    BVIndex GetThunkIndexFromAddress(uintptr_t index) const;
+    void ProtectPage(void * address);
+    void UnprotectPage(void * address);
+    bool IsThunkPageEmpty(uintptr_t address) const;
+
+    static void EncodeJmp(char * localPageAddress, uintptr_t thunkAddress, uintptr_t targetAddress);
+    static uintptr_t GetThunkPageStart(uintptr_t address);
+};
+
+#if ENABLE_OOP_NATIVE_CODEGEN
+typedef JITThunkEmitter<SectionAllocWrapper> OOPJITThunkEmitter;
+#endif
+typedef JITThunkEmitter<VirtualAllocWrapper> InProcJITThunkEmitter;
+#endif

--- a/lib/Backend/LowerMDShared.cpp
+++ b/lib/Backend/LowerMDShared.cpp
@@ -5778,68 +5778,45 @@ LowererMD::GenerateNumberAllocation(IR::RegOpnd * opndDst, IR::Instr * instrInse
 void
 LowererMD::GenerateCFGCheck(IR::Opnd * entryPointOpnd, IR::Instr * insertBeforeInstr)
 {
-    //PreReserve segment at this point, as we will definitely using this segment for JITted code(in almost all cases)
-    //This is for CFG check optimization
-    IR::LabelInstr * callLabelInstr = nullptr;
-    char * preReservedRegionStartAddress = nullptr;
-
-    if (m_func->CanAllocInPreReservedHeapPageSegment())
+    bool useJITTrampoline = m_func->GetThreadContextInfo()->IsCFGEnabled();
+    IR::LabelInstr * callLabelInstr = IR::LabelInstr::New(Js::OpCode::Label, m_func);
+    IR::LabelInstr * cfgLabelInstr = IR::LabelInstr::New(Js::OpCode::Label, m_func, useJITTrampoline);
+    uintptr_t jitThunkStartAddress = NULL;
+    if (useJITTrampoline)
     {
-        char* endAddressOfSegment = nullptr;
 #if ENABLE_OOP_NATIVE_CODEGEN
         if (m_func->IsOOPJIT())
         {
-            PreReservedSectionAllocWrapper * preReservedAllocator = m_func->GetOOPThreadContext()->GetPreReservedSectionAllocator();
-            preReservedRegionStartAddress = (char *)preReservedAllocator->EnsurePreReservedRegion();
-            if (preReservedRegionStartAddress != nullptr)
-            {
-                endAddressOfSegment = (char*)preReservedAllocator->GetPreReservedEndAddress();
-            }
+            OOPJITThunkEmitter * jitThunkEmitter = m_func->GetOOPThreadContext()->GetJITThunkEmitter();
+            jitThunkStartAddress = jitThunkEmitter->EnsureInitialized();
         }
         else
 #endif
         {
-            PreReservedVirtualAllocWrapper * preReservedVirtualAllocator = m_func->GetInProcThreadContext()->GetPreReservedVirtualAllocator();
-            preReservedRegionStartAddress = (char *)preReservedVirtualAllocator->EnsurePreReservedRegion();
-            if (preReservedRegionStartAddress != nullptr)
-            {
-                endAddressOfSegment = (char*)preReservedVirtualAllocator->GetPreReservedEndAddress();
-            }
-
+            InProcJITThunkEmitter * jitThunkEmitter = m_func->GetInProcThreadContext()->GetJITThunkEmitter();
+            jitThunkStartAddress = jitThunkEmitter->EnsureInitialized();
         }
-        if (preReservedRegionStartAddress != nullptr)
+        if (jitThunkStartAddress)
         {
-
-            int32 segmentSize = (int32) (endAddressOfSegment - preReservedRegionStartAddress);
+            uintptr_t endAddressOfSegment = jitThunkStartAddress + InProcJITThunkEmitter::TotalThunkSize;
 
             // Generate instructions for local Pre-Reserved Segment Range check
 
             IR::AddrOpnd * endAddressOfSegmentConstOpnd = IR::AddrOpnd::New(endAddressOfSegment, IR::AddrOpndKindDynamicMisc, m_func);
             IR::RegOpnd *resultOpnd = IR::RegOpnd::New(TyMachReg, this->m_func);
-#if _M_IX86
-            //resultOpnd = endAddressOfSegmentConstOpnd - entryPointOpnd
-            IR::Instr* subInstr = IR::Instr::New(Js::OpCode::Sub_I4, resultOpnd, endAddressOfSegmentConstOpnd, entryPointOpnd, m_func);
-            insertBeforeInstr->InsertBefore(subInstr);
-            this->EmitInt4Instr(subInstr);
-#elif _M_X64
-            //MOV resultOpnd, endAddressOfSegment
-            //resultOpnd = resultOpnd - entryPointOpnd
 
-            IR::Instr   *movInstr = IR::Instr::New(Js::OpCode::MOV, resultOpnd, endAddressOfSegmentConstOpnd, this->m_func);
-            insertBeforeInstr->InsertBefore(movInstr);
-            IR::Instr* subInstr = IR::Instr::New(Js::OpCode::SUB, resultOpnd, resultOpnd, entryPointOpnd, m_func);
-            insertBeforeInstr->InsertBefore(subInstr);
-#endif
-            //CMP subResultOpnd, segmentSize
-            //JL $callLabelInstr:
-
-            AssertMsg((size_t) segmentSize == (size_t) (endAddressOfSegment - preReservedRegionStartAddress), "Need a bigger datatype for segmentSize?");
-            IR::IntConstOpnd * segmentSizeOpnd = IR::IntConstOpnd::New(segmentSize, IRType::TyInt32, m_func, true);
-            callLabelInstr = IR::LabelInstr::New(Js::OpCode::Label, m_func);
-            this->m_lowerer->InsertCompareBranch(resultOpnd, segmentSizeOpnd, Js::OpCode::JBE, callLabelInstr, insertBeforeInstr);
+            // resultOpnd = SUB endAddressOfSegmentConstOpnd, entryPointOpnd
+            // CMP resultOpnd, TotalThunkSize
+            // JAE $cfgLabel
+            // AND entryPointOpnd,  ~(ThunkSize-1)
+            // JMP $callLabel
+            m_lowerer->InsertSub(false, resultOpnd, endAddressOfSegmentConstOpnd, entryPointOpnd, insertBeforeInstr);
+            m_lowerer->InsertCompareBranch(resultOpnd, IR::IntConstOpnd::New(InProcJITThunkEmitter::TotalThunkSize, TyMachReg, m_func, true), Js::OpCode::BrGe_A, true, cfgLabelInstr, insertBeforeInstr);
+            m_lowerer->InsertAnd(entryPointOpnd, entryPointOpnd, IR::IntConstOpnd::New(InProcJITThunkEmitter::ThunkAlignmentMask, TyMachReg, m_func, true), insertBeforeInstr);
+            m_lowerer->InsertBranch(Js::OpCode::Br, callLabelInstr, insertBeforeInstr);
         }
     }
-
+    insertBeforeInstr->InsertBefore(cfgLabelInstr);
     //MOV  ecx, entryPoint
     IR::RegOpnd * entryPointRegOpnd = IR::RegOpnd::New(TyMachReg, this->m_func);
 #if _M_IX86
@@ -5871,7 +5848,7 @@ LowererMD::GenerateCFGCheck(IR::Opnd * entryPointOpnd, IR::Instr * insertBeforeI
     //CALL cfg(rax)
     insertBeforeInstr->InsertBefore(cfgCallInstr);
 
-    if (preReservedRegionStartAddress != nullptr)
+    if (jitThunkStartAddress)
     {
         Assert(callLabelInstr);
 #if DBG

--- a/lib/Backend/ServerThreadContext.cpp
+++ b/lib/Backend/ServerThreadContext.cpp
@@ -18,6 +18,9 @@ ServerThreadContext::ServerThreadContext(ThreadContextDataIDL * data) :
     m_thunkPageAllocators(nullptr, /* allocXData */ false, &m_sectionAllocator, nullptr, (HANDLE)data->processHandle),
     m_codePageAllocators(nullptr, ALLOC_XDATA, &m_sectionAllocator, &m_preReservedSectionAllocator, (HANDLE)data->processHandle),
     m_codeGenAlloc(nullptr, nullptr, &m_codePageAllocators, (HANDLE)data->processHandle),
+#if defined(_CONTROL_FLOW_GUARD) && (_M_IX86 || _M_X64)
+    m_jitThunkEmitter(this, &m_sectionAllocator, (HANDLE)data->processHandle),
+#endif
     m_pageAlloc(nullptr, Js::Configuration::Global.flags, PageAllocatorType_BGJIT,
         AutoSystemInfo::Data.IsLowMemoryProcess() ?
         PageAllocator::DefaultLowMaxFreePageCount :
@@ -135,6 +138,14 @@ ServerThreadContext::GetCodeGenAllocators()
 {
     return &m_codeGenAlloc;
 }
+
+#if defined(_CONTROL_FLOW_GUARD) && (_M_IX86 || _M_X64)
+OOPJITThunkEmitter *
+ServerThreadContext::GetJITThunkEmitter()
+{
+    return &m_jitThunkEmitter;
+}
+#endif
 
 intptr_t
 ServerThreadContext::GetRuntimeChakraBaseAddress() const

--- a/lib/Backend/ServerThreadContext.h
+++ b/lib/Backend/ServerThreadContext.h
@@ -38,6 +38,9 @@ public:
     ptrdiff_t GetCRTBaseAddressDifference() const;
 
     OOPCodeGenAllocators * GetCodeGenAllocators();
+#if defined(_CONTROL_FLOW_GUARD) && (_M_IX86 || _M_X64)
+    OOPJITThunkEmitter * GetJITThunkEmitter();
+#endif
     CustomHeap::OOPCodePageAllocators * GetThunkPageAllocators();
     CustomHeap::OOPCodePageAllocators  * GetCodePageAllocators();
     SectionAllocWrapper * GetSectionAllocator();
@@ -74,6 +77,9 @@ private:
     SectionAllocWrapper m_sectionAllocator;
     CustomHeap::OOPCodePageAllocators m_thunkPageAllocators;
     CustomHeap::OOPCodePageAllocators  m_codePageAllocators;
+#if defined(_CONTROL_FLOW_GUARD) && (_M_IX86 || _M_X64)
+    OOPJITThunkEmitter m_jitThunkEmitter;
+#endif
     OOPCodeGenAllocators m_codeGenAlloc;
     // only allocate with this from foreground calls (never from CodeGen calls)
     PageAllocator m_pageAlloc;

--- a/lib/Common/BackendApi.h
+++ b/lib/Common/BackendApi.h
@@ -42,6 +42,7 @@ typedef double  FloatConstType;
 
 #include "EmitBuffer.h"
 #include "InterpreterThunkEmitter.h"
+#include "JITThunkEmitter.h"
 #include "BackendOpCodeAttr.h"
 #include "BackendOpCodeAttrAsmJs.h"
 #include "CodeGenNumberAllocator.h"
@@ -61,7 +62,7 @@ void UpdateNativeCodeGeneratorForDebugMode(NativeCodeGenerator* nativeCodeGen);
 CriticalSection *GetNativeCodeGenCriticalSection(NativeCodeGenerator *pNativeCodeGen);
 bool TryReleaseNonHiPriWorkItem(Js::ScriptContext* scriptContext, CodeGenWorkItem* workItem);
 void NativeCodeGenEnterScriptStart(NativeCodeGenerator * nativeCodeGen);
-void FreeNativeCodeGenAllocation(Js::ScriptContext* scriptContext, Js::JavascriptMethod address);
+void FreeNativeCodeGenAllocation(Js::ScriptContext* scriptContext, Js::JavascriptMethod codeAddress, Js::JavascriptMethod thunkAddress);
 InProcCodeGenAllocators* GetForegroundAllocator(NativeCodeGenerator * nativeCodeGen, PageAllocator* pageallocator);
 void GenerateFunction(NativeCodeGenerator * nativeCodeGen, Js::FunctionBody * functionBody, Js::ScriptFunction * function = NULL);
 void GenerateLoopBody(NativeCodeGenerator * nativeCodeGen, Js::FunctionBody * functionBody, Js::LoopHeader * loopHeader, Js::EntryPointInfo* entryPointInfo, uint localCount, Js::Var localSlots[]);

--- a/lib/Common/DataStructures/FixedBitVector.h
+++ b/lib/Common/DataStructures/FixedBitVector.h
@@ -534,7 +534,7 @@ public:
     const BVUnit * GetRawData() const { return data; }
 
     template <size_t rangeSize>
-    BVStatic<rangeSize> * GetRange(BVIndex startOffset)
+    BVStatic<rangeSize> * GetRange(BVIndex startOffset) const
     {
         AssertRange(startOffset);
         AssertRange(startOffset + rangeSize - 1);
@@ -673,6 +673,23 @@ public:
         for (BVIndex i = 0; i < wordCount; i++)
         {
             if (!this->data[i].IsEmpty())
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    bool IsAllSet() const
+    {
+        for (BVIndex i = 0; i < this->wordCount; i++)
+        {
+            if (i == this->wordCount - 1 && Length() % BVUnit::BitsPerWord != 0)
+            {
+                return this->data[i].Count() == Length() % BVUnit::BitsPerWord;
+            }
+            else if (!this->data[i].IsFull())
             {
                 return false;
             }

--- a/lib/JITClient/JITManager.cpp
+++ b/lib/JITClient/JITManager.cpp
@@ -285,14 +285,15 @@ HRESULT
 JITManager::InitializeThreadContext(
     __in ThreadContextDataIDL * data,
     __out PPTHREADCONTEXT_HANDLE threadContextInfoAddress,
-    __out intptr_t * prereservedRegionAddr)
+    __out intptr_t * prereservedRegionAddr,
+    __out intptr_t * jitThunkAddr)
 {
     Assert(IsOOPJITEnabled());
 
     HRESULT hr = E_FAIL;
     RpcTryExcept
     {
-        hr = ClientInitializeThreadContext(m_rpcBindingHandle, data, threadContextInfoAddress, prereservedRegionAddr);
+        hr = ClientInitializeThreadContext(m_rpcBindingHandle, data, threadContextInfoAddress, prereservedRegionAddr, jitThunkAddr);
     }
     RpcExcept(RpcExceptionFilter(RpcExceptionCode()))
     {
@@ -540,14 +541,15 @@ JITManager::CloseScriptContext(
 HRESULT
 JITManager::FreeAllocation(
     __in PTHREADCONTEXT_HANDLE threadContextInfoAddress,
-    __in intptr_t address)
+    __in intptr_t codeAddress,
+    __in intptr_t thunkAddress)
 {
     Assert(IsOOPJITEnabled());
 
     HRESULT hr = E_FAIL;
     RpcTryExcept
     {
-        hr = ClientFreeAllocation(m_rpcBindingHandle, threadContextInfoAddress, address);
+        hr = ClientFreeAllocation(m_rpcBindingHandle, threadContextInfoAddress, codeAddress, thunkAddress);
     }
     RpcExcept(RpcExceptionFilter(RpcExceptionCode()))
     {

--- a/lib/JITClient/JITManager.h
+++ b/lib/JITClient/JITManager.h
@@ -34,7 +34,8 @@ public:
     HRESULT InitializeThreadContext(
         __in ThreadContextDataIDL * data,
         __out PPTHREADCONTEXT_HANDLE threadContextInfoAddress,
-        __out intptr_t *prereservedRegionAddr);
+        __out intptr_t * prereservedRegionAddr,
+        __out intptr_t * jitThunkAddr);
 
     HRESULT CleanupThreadContext(
         __inout PPTHREADCONTEXT_HANDLE threadContextInfoAddress);
@@ -79,7 +80,8 @@ public:
 
     HRESULT FreeAllocation(
         __in PTHREADCONTEXT_HANDLE threadContextInfoAddress,
-        __in intptr_t address);
+        __in intptr_t codeAddress,
+        __in intptr_t thunkAddress);
 
     HRESULT SetIsPRNGSeeded(
         __in PSCRIPTCONTEXT_HANDLE scriptContextInfoAddress,
@@ -149,7 +151,8 @@ public:
     HRESULT InitializeThreadContext(
         __in ThreadContextDataIDL * data,
         __out PPTHREADCONTEXT_HANDLE threadContextInfoAddress,
-        __out intptr_t *prereservedRegionAddr)
+        __out intptr_t *prereservedRegionAddr,
+        __out intptr_t * jitThunkAddr)
         { Assert(false); return E_FAIL; }
 
     HRESULT DecommitInterpreterBufferManager(
@@ -199,7 +202,8 @@ public:
 
     HRESULT FreeAllocation(
         __in PTHREADCONTEXT_HANDLE threadContextInfoAddress,
-        __in intptr_t address)
+        __in intptr_t codeAddress,
+        __in intptr_t thunkAddress)
         { Assert(false); return E_FAIL; }
 
     HRESULT SetIsPRNGSeeded(

--- a/lib/JITIDL/ChakraJIT.idl
+++ b/lib/JITIDL/ChakraJIT.idl
@@ -22,7 +22,8 @@ interface IChakraJIT
         [in] handle_t binding,
         [in] ThreadContextDataIDL * threadData,
         [out] PPTHREADCONTEXT_HANDLE threadContextInfoAddress,
-        [out] CHAKRA_PTR * prereservedRegionAddr);
+        [out] CHAKRA_PTR * prereservedRegionAddr,
+        [out] CHAKRA_PTR * jitThunkAddr);
 
     HRESULT CleanupThreadContext(
         [in] handle_t binding,
@@ -67,7 +68,8 @@ interface IChakraJIT
     HRESULT FreeAllocation(
         [in] handle_t binding,
         [in] PTHREADCONTEXT_HANDLE threadContextInfoAddress,
-        [in] CHAKRA_PTR address);
+        [in] CHAKRA_PTR codeAddress,
+        [in] CHAKRA_PTR thunkAddress);
 
     HRESULT NewInterpreterThunkBlock(
         [in] handle_t binding,

--- a/lib/JITIDL/JITTypes.h
+++ b/lib/JITIDL/JITTypes.h
@@ -814,6 +814,7 @@ typedef struct JITOutputIDL
     unsigned int xdataOffset;
 #endif
     CHAKRA_PTR codeAddress;
+    CHAKRA_PTR thunkAddress;
     TypeGuardTransferEntryIDL* typeGuardEntries;
 
     IDL_DEF([size_is(ctorCachesCount)]) CtorCacheTransferEntryIDL ** ctorCacheEntries;
@@ -823,7 +824,6 @@ typedef struct JITOutputIDL
     NativeDataBuffer* buffer;
     EquivalentTypeGuardOffsets* equivalentTypeGuardOffsets;
     XProcNumberPageSegment* numberPageSegments;
-    X86_PAD4(1)
     __int64 startTime;
 } JITOutputIDL;
 

--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -4303,10 +4303,10 @@ namespace Js
     }
 #endif
 
-    void ScriptContext::FreeFunctionEntryPoint(Js::JavascriptMethod method)
+    void ScriptContext::FreeFunctionEntryPoint(Js::JavascriptMethod codeAddress, Js::JavascriptMethod thunkAddress)
     {
 #if ENABLE_NATIVE_CODEGEN
-        FreeNativeCodeGenAllocation(this, method);
+        FreeNativeCodeGenAllocation(this, codeAddress, thunkAddress);
 #endif
     }
 

--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -1416,7 +1416,7 @@ private:
         }
 
     public:
-        void FreeFunctionEntryPoint(Js::JavascriptMethod method);
+        void FreeFunctionEntryPoint(Js::JavascriptMethod codeAddress, Js::JavascriptMethod thunkAddress);
 
     private:
         uint CloneSource(Utf8SourceInfo* info);

--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -176,6 +176,9 @@ ThreadContext::ThreadContext(AllocationPolicyManager * allocationPolicyManager, 
     thunkPageAllocators(allocationPolicyManager, /* allocXData */ false, /* virtualAllocator */ nullptr, GetCurrentProcess()),
 #endif
     codePageAllocators(allocationPolicyManager, ALLOC_XDATA, GetPreReservedVirtualAllocator(), GetCurrentProcess()),
+#if defined(_CONTROL_FLOW_GUARD) && (_M_IX86 || _M_X64)
+    jitThunkEmitter(this, &VirtualAllocWrapper::Instance , GetCurrentProcess()),
+#endif
 #endif
     dynamicObjectEnumeratorCacheMap(&HeapAllocator::Instance, 16),
     //threadContextFlags(ThreadContextFlagNoFlag),
@@ -2008,7 +2011,7 @@ ThreadContext::EnsureJITThreadContext(bool allowPrereserveAlloc)
         }
     }
 
-    HRESULT hr = JITManager::GetJITManager()->InitializeThreadContext(&contextData, &m_remoteThreadContextInfo, &m_prereservedRegionAddr);
+    HRESULT hr = JITManager::GetJITManager()->InitializeThreadContext(&contextData, &m_remoteThreadContextInfo, &m_prereservedRegionAddr, &m_jitThunkStartAddr);
     JITManager::HandleServerCallResult(hr, RemoteCallType::StateUpdate);
 
     return m_remoteThreadContextInfo != nullptr;

--- a/lib/Runtime/Base/ThreadContext.h
+++ b/lib/Runtime/Base/ThreadContext.h
@@ -500,6 +500,7 @@ public:
 private:
     PTHREADCONTEXT_HANDLE m_remoteThreadContextInfo;
     intptr_t m_prereservedRegionAddr;
+    intptr_t m_jitThunkStartAddr;
 
 #if ENABLE_NATIVE_CODEGEN
     BVSparse<HeapAllocator> * m_jitNumericProperties;
@@ -508,6 +509,10 @@ public:
     intptr_t GetPreReservedRegionAddr()
     {
         return m_prereservedRegionAddr;
+    }
+    intptr_t GetJITThunkStartAddr()
+    {
+        return m_jitThunkStartAddr;
     }
     BVSparse<HeapAllocator> * GetJITNumericProperties() const
     {
@@ -714,6 +719,9 @@ private:
     CustomHeap::InProcCodePageAllocators thunkPageAllocators;
 #endif
     CustomHeap::InProcCodePageAllocators codePageAllocators;
+#if defined(_CONTROL_FLOW_GUARD) && (_M_IX86 || _M_X64)
+    InProcJITThunkEmitter jitThunkEmitter;
+#endif
 #endif
 
     RecyclerRootPtr<RecyclableData> recyclableData;
@@ -868,6 +876,10 @@ public:
     CustomHeap::InProcCodePageAllocators * GetThunkPageAllocators() { return &thunkPageAllocators; }
 #endif
     CustomHeap::InProcCodePageAllocators * GetCodePageAllocators() { return &codePageAllocators; }
+
+#if defined(_CONTROL_FLOW_GUARD) && (_M_IX86 || _M_X64)
+    InProcJITThunkEmitter * GetJITThunkEmitter() { return &jitThunkEmitter; }
+#endif
 #endif // ENABLE_NATIVE_CODEGEN
 
     CriticalSection* GetFunctionBodyLock() { return &csFunctionBody; }

--- a/lib/Runtime/Language/DynamicProfileInfo.cpp
+++ b/lib/Runtime/Language/DynamicProfileInfo.cpp
@@ -342,7 +342,7 @@ namespace Js
             }
             else
             {
-                directEntryPoint = (JavascriptMethod)entryPoint->GetNativeAddress();
+                directEntryPoint = entryPoint->GetNativeEntrypoint();
             }
 
             entryPoint->jsMethod = directEntryPoint;


### PR DESCRIPTION
This adds additional mitigation for JIT function calls. With this trampoline, we can range check and safely call to any 16 byte aligned address inside the block. If range check fails (e.g. function we are calling has not been JITed), we do a CFG check. Benchmarks are mostly flat, but there is about a 2.5% loss in Gameboy.