### PR TITLE
BUILD: Remove fix dependency on Win8.1 SDK, and use latest Win10 SDK if it is installed

### DIFF
--- a/Build/Chakra.Build.Default.props
+++ b/Build/Chakra.Build.Default.props
@@ -2,11 +2,21 @@
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="Common.Build.Default.props"/>
   <Import Condition="'$(Clang)'!=''" Project="Chakra.Build.Clang.Default.props"/>
+  <PropertyGroup Condition="'$(WindowsTargetPlatformVersion)'==''">
+      <!-- Default the installed latest Win10 SDK -->
+      <WindowsSdkInstallFolder_10 Condition="'$(WindowsSdkInstallFolder_10)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v10.0@InstallationFolder)</WindowsSdkInstallFolder_10>
+      <WindowsSdkInstallFolder_10 Condition="'$(WindowsSdkInstallFolder_10)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Microsoft SDKs\Windows\v10.0@InstallationFolder)</WindowsSdkInstallFolder_10>
+      <WindowsTargetPlatformVersion_10 Condition="'$(WindowsTargetPlatformVersion_10)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v10.0@ProductVersion)</WindowsTargetPlatformVersion_10>
+      <WindowsTargetPlatformVersion_10 Condition="'$(WindowsTargetPlatformVersion_10)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Microsoft SDKs\Windows\v10.0@ProductVersion)"</WindowsTargetPlatformVersion_10>      
+      <!-- Sometimes the version in the registry has to .0 suffix, and sometimes it doesn't. Check and add it -->
+      <WindowsTargetPlatformVersion_10 Condition="'$(WindowsTargetPlatformVersion_10)' != '' and !$(WindowsTargetPlatformVersion_10.EndsWith('.0'))">$(WindowsTargetPlatformVersion_10).0</WindowsTargetPlatformVersion_10>
+      
+      <WindowsTargetPlatformVersion>$(WindowsTargetPlatformVersion_10)</WindowsTargetPlatformVersion>
+      
+      <!-- Default back to 10.0.10240.0 if the ARM version of the Win10 SDK is not installed -->
+      <WindowsTargetPlatformVersion Condition="'$(Platform)'=='ARM' and !Exists('$(WindowsSdkInstallFolder_10)\Include\$(WindowsTargetPlatformVersion_10)\shared\ksarm.h')">10.0.10240.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
   <PropertyGroup>
-    <WindowsTargetPlatformVersion Condition="'$(Platform)'=='ARM'">10.0.10240.0</WindowsTargetPlatformVersion>
-
-    <!-- Always use Platform SDK for core builds -->
-    <EventManifestXmlPath>$(WindowsSDK80Path)Include\um</EventManifestXmlPath>    
     <!-- Unless indicated otherwise, statically link the C++ Runtime into ChakraCore.dll -->
     <RuntimeLib Condition="'$(RuntimeLib)'==''">static_library</RuntimeLib>
 

--- a/Build/Chakra.Build.props
+++ b/Build/Chakra.Build.props
@@ -5,6 +5,10 @@
     <Win32_WinNTVersion Condition="'$(NtTargetVersion)'=='$(NtTargetVersion_Win7)'">0x0601</Win32_WinNTVersion>
     <Win32_WinNTVersion Condition="'$(NtTargetVersion)'=='$(NtTargetVersion_Win8)'">0x0602</Win32_WinNTVersion>
     <Win32_WinNTVersion Condition="'$(NtTargetVersion)'=='$(NtTargetVersion_Win10)'">0x0A00</Win32_WinNTVersion>
+
+    <!-- Always use Platform SDK for core builds -->
+    <EventManifestXmlPath Condition="'$(TargetPlatformVersion)'=='8.1'">$(WindowsSdkDir)Include\um</EventManifestXmlPath>
+    <EventManifestXmlPath Condition="'$(TargetPlatformVersion)'!='8.1'">$(WindowsSdkDir)Include\$(TargetPlatformVersion)\um</EventManifestXmlPath>
   </PropertyGroup>
   <PropertyGroup>
     <NoThrowNewLib>nothrownew.obj</NoThrowNewLib>

--- a/lib/JITClient/JITManager.cpp
+++ b/lib/JITClient/JITManager.cpp
@@ -8,8 +8,8 @@
 _Must_inspect_result_
 _Ret_maybenull_ _Post_writable_byte_size_(size)
 void * __RPC_USER midl_user_allocate(
-#if defined(NTBUILD) || defined(_M_ARM)
-    _In_ // starting win8, _In_ is in the signature
+#if defined(_WIN32_WINNT_WIN10)
+    _In_ // starting win10, _In_ is in the signature
 #endif
     size_t size)
 {

--- a/lib/Runtime/PlatformAgnostic/Chakra.Runtime.PlatformAgnostic.vcxproj
+++ b/lib/Runtime/PlatformAgnostic/Chakra.Runtime.PlatformAgnostic.vcxproj
@@ -8,7 +8,6 @@
     <RootNamespace>JS</RootNamespace>
     <Keyword>Win32Proj</Keyword>
     <ProjectName>Chakra.Runtime.PlatformAgnostic</ProjectName>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>

--- a/pal/pal.vcxproj
+++ b/pal/pal.vcxproj
@@ -1,23 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup Label="ProjectConfigurations">
-    <ProjectConfiguration Include="Debug|Win32">
-      <Configuration>Debug</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|Win32">
-      <Configuration>Release</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Debug|x64">
-      <Configuration>Debug</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|x64">
-      <Configuration>Release</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
-  </ItemGroup>
+  <Import Condition="'$(ChakraBuildPathImported)'!='true'" Project="$(SolutionDir)Chakra.Build.Paths.props"/>
+  <Import Project="$(BuildConfigPropsPath)Chakra.Build.ProjectConfiguration.props" />
   <ItemGroup>
     <None Include="inc\debugmacrosext.h" />
     <None Include="inc\mbusafecrt.h" />
@@ -213,55 +197,17 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{02D4FD92-AD34-40CA-85DF-4D6C7E3A1F22}</ProjectGuid>
     <RootNamespace>pal</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>Utility</ConfigurationType>
+  </PropertyGroup>
+  <Import Project="$(BuildConfigPropsPath)Chakra.Build.Default.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-    <ConfigurationType>Utility</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
-    <CharacterSet>MultiByte</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
-    <ConfigurationType>Utility</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>MultiByte</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>Utility</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
-    <CharacterSet>MultiByte</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>Utility</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>MultiByte</CharacterSet>
-  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-  <ImportGroup Label="ExtensionSettings">
-  </ImportGroup>
-  <ImportGroup Label="Shared">
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+  <Import Project="$(BuildConfigPropsPath)Chakra.Build.Props" />
+  <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <PropertyGroup Label="UserMacros" />
-  <PropertyGroup />
+  <Import Project="$(BuildConfigPropsPath)Chakra.Build.targets" Condition="exists('$(BuildConfigPropsPath)Chakra.Build.targets')"/>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-  <ImportGroup Label="ExtensionTargets">
-  </ImportGroup>
 </Project>


### PR DESCRIPTION
Fixes #2348 