### PR TITLE
Update return symbol assignment in the presence of early return in try finally

### DIFF
--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -17467,6 +17467,7 @@ GlobOpt::PreOptPeep(IR::Instr *instr)
             IR::Opnd *oldDst = instr->UnlinkDst();
             instr->SetDst(newDst);
             IR::Instr *ld = IR::Instr::New(Js::OpCode::Ld_A, oldDst, newDst, this->func);
+            oldDst->SetIsJITOptimizedReg(true);
             instr->InsertAfter(ld);
         }
     }

--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -17460,7 +17460,7 @@ GlobOpt::PreOptPeep(IR::Instr *instr)
         // With try finallys, these blocks are not moved out due to the early return -> finally and finally -> early return edges
         //
         // This happens only with return s0 symbol, because we avoid creating new temporary destination register for the s0 case
-        if (dst && dst->GetSym() && dst->GetSym()->m_id == 0 && !dst->AsRegOpnd()->IsArrayRegOpnd() && instr->m_opcode != Js::OpCode::Ld_A)
+        if (dst && dst->GetSym() && dst->GetSym()->m_id == 0 && instr->m_opcode != Js::OpCode::Ld_A)
         {
             IR::RegOpnd *newDst = dst->AsRegOpnd()->Copy(this->func)->AsRegOpnd();
             newDst->m_sym = StackSym::New(dst->GetType(), this->func);


### PR DESCRIPTION
Currently we skip generating a Ld_A after LdElem for return symbol s0 to save a temporary register.
In the presence of try finally with an early return, we have to run the finally code after thfunction return.
This can lead to problems later on in globopt, this change fixes this.
