### PR TITLE
Fix problems caused by late update of sparse segment's 'left' field

### DIFF
--- a/lib/Runtime/Library/JavascriptArray.cpp
+++ b/lib/Runtime/Library/JavascriptArray.cpp
@@ -2078,6 +2078,7 @@ namespace Js
                         limit = JavascriptArray::MaxArrayLength;
                     }
                     seg->size = min(newSize, limit - seg->left);
+                    seg->CheckLengthvsSize();
                 }
             }
             uint32 i;
@@ -7653,6 +7654,8 @@ Case0:
 
                 Assert(pArr->length <= MaxArrayLength - unshiftElements);
 
+                SparseArraySegmentBase* renumberSeg = pArr->head->next;
+
                 bool isIntArray = false;
                 bool isFloatArray = false;
 
@@ -7683,21 +7686,6 @@ Case0:
                     }
                 }
 
-                if (isIntArray)
-                {
-                    UnshiftHelper<int32>(pArr, unshiftElements, args.Values);
-                }
-                else if (isFloatArray)
-                {
-                    UnshiftHelper<double>(pArr, unshiftElements, args.Values);
-                }
-                else
-                {
-                    UnshiftHelper<Var>(pArr, unshiftElements, args.Values);
-                }
-
-                SparseArraySegmentBase* renumberSeg = pArr->head->next;
-
                 while (renumberSeg)
                 {
                     renumberSeg->left += unshiftElements;
@@ -7707,6 +7695,26 @@ Case0:
                         renumberSeg->EnsureSizeInBound();
                     }
                     renumberSeg = renumberSeg->next;
+                }
+
+                try
+                {
+                    if (isIntArray)
+                    {
+                        UnshiftHelper<int32>(pArr, unshiftElements, args.Values);
+                    }
+                    else if (isFloatArray)
+                    {
+                        UnshiftHelper<double>(pArr, unshiftElements, args.Values);
+                    }
+                    else
+                    {
+                        UnshiftHelper<Var>(pArr, unshiftElements, args.Values);
+                    }
+                }
+                catch (...)
+                {
+                    Js::Throw::FatalInternalError();
                 }
 
                 pArr->InvalidateLastUsedSegment();

--- a/test/Array/bug_12044876.js
+++ b/test/Array/bug_12044876.js
@@ -1,0 +1,38 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+//switches: -forcearraybtree
+
+// x86debug: lib\runtime\Library/JavascriptArray.inl, current->left >= lastindex
+function test0() {
+    var arr = [4294967296];
+    arr[9] = 19;
+    arr.unshift(1, 2, {}, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+}
+
+// x64debug: lib\Runtime\Library\SparseArraySegment.cpp, length <= size
+function test1() {
+    function makeArrayLength() {
+      return 100;
+    }
+    var obj0 = {};
+    var protoObj0 = {};
+    var obj1 = {};
+    var arrObj0 = {};
+    var func0 = function () {
+    };
+    var func1 = function () {
+    };
+    obj0.method1 = func0;
+    var ary = Array();
+    var IntArr1 = new Array();
+    IntArr1[15] = ~obj1.prop0;
+    arrObj0.length = makeArrayLength();
+    IntArr1[10] = arrObj0.length;
+    makeArrayLength(IntArr1.unshift(func1(), ary, obj0.method1(), protoObj0, Object(), arrObj0, -1877547837));
+}
+
+test0();
+test1();
+console.log("Pass");

--- a/test/Array/rlexe.xml
+++ b/test/Array/rlexe.xml
@@ -734,6 +734,13 @@
   </test>
   <test>
     <default>
+      <files>bug_12044876.js</files>
+        <compile-flags>-forcearraybtree</compile-flags>
+        <tags>BugFix</tags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>array_conv_src.js</files>
     </default>
   </test>


### PR DESCRIPTION
This bug was introduced https://github.com/Microsoft/ChakraCore/pull/2959 (CVE-2017-0238) Revert the move of 'left' field update and add try..catch