### PR TITLE
WASM: Prevent folding cmp instr

### DIFF
--- a/lib/Backend/IR.h
+++ b/lib/Backend/IR.h
@@ -751,7 +751,7 @@ public:
     static BranchInstr * New(Js::OpCode opcode, Opnd* destOpnd, LabelInstr * branchTarget, Opnd *srcOpnd, Func *func);
     static BranchInstr * New(Js::OpCode opcode, LabelInstr * branchTarget, Opnd *src1Opnd, Opnd *src2Opnd, Func *func);
 
-    BranchInstr(bool hasBailOutInfo = false) : Instr(hasBailOutInfo), m_branchTarget(nullptr), m_isAirlock(false), m_isSwitchBr(false), m_isOrphanedLeave(false)
+    BranchInstr(bool hasBailOutInfo = false) : Instr(hasBailOutInfo), m_branchTarget(nullptr), m_isAirlock(false), m_isSwitchBr(false), m_isOrphanedLeave(false), m_areCmpRegisterFlagsUsedLater(false)
     {
 #if DBG
         m_isMultiBranch = false;

--- a/lib/Backend/IR.h
+++ b/lib/Backend/IR.h
@@ -739,6 +739,7 @@ public:
     bool                 m_isAirlock : 1;
     bool                 m_isSwitchBr : 1;
     bool                 m_isOrphanedLeave : 1; // A Leave in a loop body in a try, most likely generated because of a return statement.
+    bool                 m_areCmpRegisterFlagsUsedLater : 1; // Indicate that this branch is not the only instr using the register flags set by cmp
 #if DBG
     bool                 m_isMultiBranch;
     bool                 m_isHelperToNonHelperBranch;

--- a/lib/Backend/LowerMDShared.cpp
+++ b/lib/Backend/LowerMDShared.cpp
@@ -2861,6 +2861,7 @@ void LowererMD::GenerateFastCmXx(IR::Instr *instr)
     {
         IR::LabelInstr* skipLow = IR::LabelInstr::New(Js::OpCode::Label, m_func);
         newInstr = IR::BranchInstr::New(Js::OpCode::JNE, skipLow, this->m_func);
+        newInstr->AsBranchInstr()->m_areCmpRegisterFlagsUsedLater = true;
         done->InsertBefore(newInstr);
 
         newInstr = IR::Instr::New(cmpOp, this->m_func);

--- a/lib/Backend/amd64/EncoderMD.cpp
+++ b/lib/Backend/amd64/EncoderMD.cpp
@@ -1891,7 +1891,7 @@ bool EncoderMD::TryFold(IR::Instr *instr, IR::RegOpnd *regOpnd)
         {
             IR::Instr *instrNext = instr->GetNextRealInstrOrLabel();
 
-            if (instrNext->IsBranchInstr() && instrNext->AsBranchInstr()->IsConditional() && instrNext->AsBranchInstr()->m_areCmpRegisterFlagsUsedLater)
+            if (instrNext->IsBranchInstr() && instrNext->AsBranchInstr()->IsConditional() && !instrNext->AsBranchInstr()->m_areCmpRegisterFlagsUsedLater)
             {
                 // Swap src and reverse branch
                 src2 = instr->UnlinkSrc1();

--- a/lib/Backend/amd64/EncoderMD.cpp
+++ b/lib/Backend/amd64/EncoderMD.cpp
@@ -1891,7 +1891,7 @@ bool EncoderMD::TryFold(IR::Instr *instr, IR::RegOpnd *regOpnd)
         {
             IR::Instr *instrNext = instr->GetNextRealInstrOrLabel();
 
-            if (instrNext->IsBranchInstr() && instrNext->AsBranchInstr()->IsConditional())
+            if (instrNext->IsBranchInstr() && instrNext->AsBranchInstr()->IsConditional() && instrNext->AsBranchInstr()->m_areCmpRegisterFlagsUsedLater)
             {
                 // Swap src and reverse branch
                 src2 = instr->UnlinkSrc1();

--- a/lib/Backend/i386/EncoderMD.cpp
+++ b/lib/Backend/i386/EncoderMD.cpp
@@ -1700,7 +1700,7 @@ bool EncoderMD::TryFold(IR::Instr *instr, IR::RegOpnd *regOpnd)
         {
             IR::Instr *instrNext = instr->GetNextRealInstrOrLabel();
 
-            if (instrNext->IsBranchInstr() && instrNext->AsBranchInstr()->IsConditional())
+            if (instrNext->IsBranchInstr() && instrNext->AsBranchInstr()->IsConditional() && !instrNext->AsBranchInstr()->m_areCmpRegisterFlagsUsedLater)
             {
                 // Swap src and reverse branch
                 src2 = instr->UnlinkSrc1();


### PR DESCRIPTION
If we run out of registers during regalloc we'll try to fold the instruction and sometimes swap the operands.
In the case of `cmp` we swap the operands if we're able to reverse the logic of the next branch.

However, it is possible that another instr will want to use the flags set by `cmp` other than the branch.

The exact case I am seeing is this on x86
```asm
; Globopt
s1.i64 = Conv_Prim -2.u32
... ; some other operations
s2.i64 = Ld_I4 0xC5C6358EC332B00A.i64
s3.i32 = CmUnGe_I4 s1.i64, s2.i64
...

; after regalloc
s4.i32 = MOV 0
s4<-10>.i32 = MOV s4.i32 //spill
s5.i32 = MOV -2
... ; some other operations
s6.i32 = MOV 0xC5C6358E.i32
s7.i32 = MOV 0xC332B00A.i32

s10.i32 = MOV 0 ; comparison result
                ; Compare high bits of the i64
                CMP s6.i32, s4<-10> ; BUG: opnd swapped to avoid read spilled reg
                JNE $L1
                CMP s5.i32, s7.i32 ; compare low bits of the i64
$L1:
s10.i32 = SETAE s10.i32 ; Use the flags set by cmp to the comparison result
```

The _clean_ solution would be to track which instr uses/set the register flags to know if we're allowed to do such an optimization. However, this seems to be a lot of overhead so I opted for the quick fix.

I was also thinking of using the unused `dst` of the `cmp` instr to track which instr uses the flags it sets.
What do you guys think ?

I wasn't able to write a small enough test, I couldn't find a way to use all the registers and force trying to fold.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/3075)
<!-- Reviewable:end -->
