### PR TITLE
Avoid casting with scope object to Dynamic Object

### DIFF
--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -1913,7 +1913,7 @@ CommonNumber:
         for (int i = 0; i < length; i += 1)
         {
             Var value;
-            DynamicObject *obj = DynamicObject::FromVar(pScope->GetItem(i));
+            RecyclableObject *obj = RecyclableObject::FromVar(pScope->GetItem(i));
             if (JavascriptOperators::GetProperty(obj, Js::PropertyIds::_lexicalThisSlotSymbol, &value, scriptContext))
             {
                 return value;

--- a/test/es6/lambda1.js
+++ b/test/es6/lambda1.js
@@ -429,6 +429,13 @@ var tests = [
                 assert.areEqual(globalObject, globalEvalLambdaThisWithNestedEval(), "globalEvalLambdaThisWithNestedEval() should equal the global object");
                 assert.areEqual(globalObject, globalEvalNestedEvalLambdaThis(), "globalEvalNestedEvalLambdaThis() should equal the global object");
                 assert.areEqual(globalObject, globalEvalNestedEvalLambdaThisWithNestedEval(), "globalEvalNestedEvalLambdaThisWithNestedEval() should equal the global object");
+
+                this.x = 10;
+                with ({x : 100}) {
+                    lambdaInsideWithEval = (s) => eval(s);
+                    assert.areEqual(10, lambdaInsideWithEval("this.x"), "Arrow function should be able to access this variable within eval");
+                    assert.areEqual(100, x, "Property access on the with construct should work with eval and arrow in the body");
+                }
             }
 
             test.call(thisVal);


### PR DESCRIPTION
We were wrongly casting with scope object to a Dynamic Object while trying to access this.
