### PR TITLE
OS12113549: Assertion on module export in ProcessCapturedSym

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -3130,7 +3130,7 @@ void ByteCodeGenerator::ProcessCapturedSym(Symbol *sym)
     FuncInfo *funcHome = sym->GetScope()->GetFunc();
     FuncInfo *funcChild = funcHome->GetCurrentChildFunction();
 
-    Assert(sym->NeedsSlotAlloc(funcHome) || sym->GetIsGlobal() || sym->GetIsModuleImport());
+    Assert(sym->NeedsSlotAlloc(funcHome) || sym->GetIsGlobal() || sym->GetIsModuleImport() || sym->GetIsModuleExportStorage());
 
     // If this is not a local property, or not all its references can be tracked, or
     // it's not scoped to the function, or we're in debug mode, disable the delayed capture optimization.

--- a/test/es6/bug_OS12113549_module1.js
+++ b/test/es6/bug_OS12113549_module1.js
@@ -1,0 +1,11 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+var obj1 = {"BugID": "OS12113549"};
+    (function () {
+        eval('');
+    })();
+
+export { obj1 as module1_exportbinding_0 };

--- a/test/es6/module-bugfixes.js
+++ b/test/es6/module-bugfixes.js
@@ -1,0 +1,47 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+// ES6 Module tests for bugfixes
+
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+
+function testModuleScript(source, message, shouldFail = false) {
+    let testfunc = () => testRunner.LoadModule(source, 'samethread', shouldFail);
+
+    if (shouldFail) {
+        let caught = false;
+
+        // We can't use assert.throws here because the SyntaxError used to construct the thrown error
+        // is from a different context so it won't be strictly equal to our SyntaxError.
+        try {
+            testfunc();
+        } catch(e) {
+            caught = true;
+
+            // Compare toString output of SyntaxError and other context SyntaxError constructor.
+            assert.areEqual(e.constructor.toString(), SyntaxError.toString(), message);
+        }
+
+        assert.isTrue(caught, `Expected error not thrown: ${message}`);
+    } else {
+        assert.doesNotThrow(testfunc, message);
+    }
+}
+
+var tests = [
+    {
+        name: "OS12113549: Assertion on module export in ProcessCapturedSym",
+        body: function() {
+            let functionBody =
+                `
+                import { module1_exportbinding_0 as module2_localbinding_0 } from 'bug_OS12113549_module1.js';
+                assert.areEqual({"BugID": "OS12113549"}, module2_localbinding_0);
+                `
+            testRunner.LoadModule(functionBody, 'samethread');
+        }
+    },
+];
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -1371,6 +1371,13 @@
 </test>
 <test>
     <default>
+        <files>module-bugfixes.js</files>
+        <compile-flags>-ES6Module -args summary -endargs</compile-flags>
+        <tags>exclude_dynapogo,exclude_sanitize_address,bugfix</tags>
+    </default>
+</test>
+<test>
+    <default>
         <files>test_bug_2645.js</files>
         <compile-flags>-ES6Module</compile-flags>
         <tags>exclude_sanitize_address</tags>


### PR DESCRIPTION
Assertion in ByteCodeGenerator::ProcessCapturedSym() needs
to cover case when 'sym' is an export.
