### PR TITLE
Issue3054: NULL pointer crash when calling constructor with Proxy new_target

### DIFF
--- a/test/es6/classes_bugfixes.js
+++ b/test/es6/classes_bugfixes.js
@@ -350,6 +350,32 @@ var tests = [
         assert.areEqual('B1', B.n1(), "static method.call()");
     }
   },
+  {
+    name: "Issue3054: NULL pointer crash when calling constructor with Proxy new_target",
+    body: function () {
+        var result = "";
+        class B {
+            constructor() {
+                assert.areEqual(P, new.target, "B(): new.target === P");
+                result += "b";
+            }
+        }
+
+        class A extends B {
+            constructor() {
+                assert.areEqual(P, new.target, "A(): new.target === P");
+                result += "a";
+                super();
+                result += "c";
+            }
+        }
+
+        var P = new Proxy(B, {});
+        Reflect.construct(A, [], P);
+
+        assert.areEqual('abc', result, "result == 'abc'");
+    }
+  },
 ];
 
 testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });


### PR DESCRIPTION
Calls to NewScObjectNoCtorFull() with 'instance' being proxy expect
new object to be returned, whereas interpreter or JIT calls to
NewScObjectNoCtor() with 'instance' being proxy expect nullptr.
Checking for proxy in NewScObjectHostDispathOrProxy() causes problem
for the former case. Fix by making the proxy-checking only applicable
to NewScObjectNoCtor().
