### PR TITLE
UTF8 decode index signedness

### DIFF
--- a/lib/Common/Codex/Utf8Codex.cpp
+++ b/lib/Common/Codex/Utf8Codex.cpp
@@ -427,7 +427,7 @@ LSlowPath:
     size_t DecodeUnitsIntoAndNullTerminate(char16 *buffer, LPCUTF8& pbUtf8, LPCUTF8 pbEnd, DecodeOptions options)
     {
         size_t result = DecodeUnitsInto(buffer, pbUtf8, pbEnd, options);
-        buffer[(int)result] = 0;
+        buffer[result] = 0;
         return result;
     }
 


### PR DESCRIPTION
Do not convert index from unsigned to signed when null termination in DecodeUnitsIntoAndNullTerminate

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/3081)
<!-- Reviewable:end -->
