### PR TITLE
Check return value for GetModuleFileName

### DIFF
--- a/bin/ch/Helpers.cpp
+++ b/bin/ch/Helpers.cpp
@@ -22,7 +22,10 @@
 void TTDHostBuildCurrentExeDirectory(char* path, size_t* pathLength, size_t bufferLength)
 {
     wchar exePath[MAX_PATH];
-    GetModuleFileName(NULL, exePath, MAX_PATH);
+    if (!GetModuleFileName(NULL, exePath, MAX_PATH))
+    {
+        return;
+    }
 
     size_t i = wcslen(exePath) - 1;
     while(exePath[i] != _u('\\'))

--- a/bin/ch/ch.cpp
+++ b/bin/ch/ch.cpp
@@ -112,7 +112,10 @@ void __stdcall PrintChakraCoreVersion()
     LPCSTR chakraDllName = GetChakraDllName();
 
     char modulename[_MAX_PATH];
-    GetModuleFileNameA(NULL, modulename, _MAX_PATH);
+    if (!GetModuleFileNameA(NULL, modulename, _MAX_PATH))
+    {
+        return;
+    }
     _splitpath_s(modulename, drive, _MAX_DRIVE, dir, _MAX_DIR, nullptr, 0, nullptr, 0);
     _makepath_s(filename, drive, dir, chakraDllName, nullptr);
 

--- a/lib/Common/Core/ConfigParser.cpp
+++ b/lib/Common/Core/ConfigParser.cpp
@@ -318,7 +318,10 @@ void ConfigParser::ParseConfig(HANDLE hmod, CmdLineArgsParser &parser)
     char16 modulename[_MAX_PATH];
     char16 filename[_MAX_PATH];
 
-    GetModuleFileName((HMODULE)hmod, modulename, _MAX_PATH);
+    if (!GetModuleFileName((HMODULE)hmod, modulename, _MAX_PATH))
+    {
+        return;
+    }
     char16 drive[_MAX_DRIVE];
     char16 dir[_MAX_DIR];
 

--- a/lib/Common/Core/ConfigParser.cpp
+++ b/lib/Common/Core/ConfigParser.cpp
@@ -521,7 +521,7 @@ HRESULT ConfigParser::SetOutputFile(const WCHAR* outputFile, const WCHAR* openMo
     char16 moduleName[_MAX_PATH];
     if (!GetModuleFileName(0, moduleName, _MAX_PATH))
     {
-        AssertMsg(FALSE, "Get executable file name failed");
+        AssertMsg(FALSE, "Get filename of the current executable failed");
     }
     _wsplitpath_s(moduleName, nullptr, 0, nullptr, 0, fileName, _MAX_PATH, nullptr, 0);
     if (_wcsicmp(fileName, _u("WWAHost")) == 0 ||

--- a/lib/Common/Core/ConfigParser.cpp
+++ b/lib/Common/Core/ConfigParser.cpp
@@ -368,7 +368,10 @@ void ConfigParser::ProcessConfiguration(HANDLE hmod)
     bool hasOutput = false;
     char16 modulename[_MAX_PATH];
 
-    GetModuleFileName((HMODULE)hmod, modulename, _MAX_PATH);
+    if (!GetModuleFileName((HMODULE)hmod, modulename, _MAX_PATH))
+    {
+        return;
+    }
 
     // Win32 specific console creation code
     // xplat-todo: Consider having this mechanism available on other
@@ -516,7 +519,10 @@ HRESULT ConfigParser::SetOutputFile(const WCHAR* outputFile, const WCHAR* openMo
 
     char16 fileName[_MAX_PATH];
     char16 moduleName[_MAX_PATH];
-    GetModuleFileName(0, moduleName, _MAX_PATH);
+    if (!GetModuleFileName(0, moduleName, _MAX_PATH))
+    {
+        AssertMsg(FALSE, "Get executable file name failed");
+    }
     _wsplitpath_s(moduleName, nullptr, 0, nullptr, 0, fileName, _MAX_PATH, nullptr, 0);
     if (_wcsicmp(fileName, _u("WWAHost")) == 0 ||
         _wcsicmp(fileName, _u("ByteCodeGenerator")) == 0 ||

--- a/lib/Common/Core/FaultInjection.cpp
+++ b/lib/Common/Core/FaultInjection.cpp
@@ -1228,16 +1228,20 @@ namespace Js
         GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, reinterpret_cast<LPCTSTR>(ip), &mod);
         offset = ip - (uintptr_t)mod;
         auto& faultModule = modulePath;
-        GetModuleFileName(mod, faultModule, MAX_PATH);
-        fwprintf(stderr, _u("***FI: Exception: %08x, module: %s, offset: 0x%p\n"),
-            ep->ExceptionRecord->ExceptionCode, faultModule, (void*)offset);
+        if (GetModuleFileName(mod, faultModule, MAX_PATH))
+        {
+            fwprintf(stderr, _u("***FI: Exception: %08x, module: %s, offset: 0x%p\n"),
+                ep->ExceptionRecord->ExceptionCode, faultModule, (void*)offset);
+        }
 
         //analyze duplication
         uintptr_t savedOffset = 0;
         auto& mainModule = modulePath;
-        GetModuleFileName(NULL, mainModule, MAX_PATH);
-        // multiple session of Fault Injection run shares the single crash offset recording file
-        _snwprintf_s(filename, _TRUNCATE, _u("%s.FICrashes.txt"), mainModule);
+        if (GetModuleFileName(NULL, mainModule, MAX_PATH))
+        {
+            // multiple session of Fault Injection run shares the single crash offset recording file
+            _snwprintf_s(filename, _TRUNCATE, _u("%s.FICrashes.txt"), mainModule);
+        }
 
         auto fp = _wfsopen(filename, _u("a+t"), _SH_DENYNO);
         if (fp != nullptr)


### PR DESCRIPTION
This is a recreated pull request of PR #2757, as I messed up the commits there.

This patch checks the return values of calls to GetModuleFileName in ConfigParser.cpp. I am not so sure about how to test this. I saw most test cases in the `test` folder are js files, but this change is not related with JavaScript functionality.