### PR TITLE
Avoid adding empty blocks while inserting an edge from finally block to early exit

### DIFF
--- a/lib/Backend/FlowGraph.cpp
+++ b/lib/Backend/FlowGraph.cpp
@@ -636,29 +636,40 @@ void FlowGraph::InsertEdgeFromFinallyToEarlyExit(BasicBlock *finallyEndBlock, IR
     IR::LabelInstr *leaveLabel = IR::LabelInstr::New(Js::OpCode::Label, this->func);
     lastInstr->InsertBefore(leaveLabel);
 
-    this->AddBlock(leaveLabel, lastInstr, finallyEndBlock->GetNext(), finallyEndBlock /*prevBlock*/);
+    this->AddBlock(leaveLabel, lastInstr, nextBB, finallyEndBlock /*prevBlock*/);
     leaveLabel->SetRegion(lastLabel->GetRegion());
 
     this->AddEdge(finallyEndBlock, leaveLabel->GetBasicBlock());
 
-    IR::LabelInstr *brLabel = IR::LabelInstr::New(Js::OpCode::Label, this->func);
-    leaveLabel->InsertBefore(brLabel);
+    // If the Leave/LeaveNull at the end of finally was not preceeded by a Label, we have to create a new block with BrOnException to early exit
+    if (!lastInstr->GetPrevRealInstrOrLabel()->IsLabelInstr())
+    {
+        IR::LabelInstr *brLabel = IR::LabelInstr::New(Js::OpCode::Label, this->func);
+        leaveLabel->InsertBefore(brLabel);
 
-    IR::BranchInstr *brToExit = IR::BranchInstr::New(Js::OpCode::BrOnException, exitLabel, this->func);
-    leaveLabel->InsertBefore(brToExit);
+        IR::BranchInstr *brToExit = IR::BranchInstr::New(Js::OpCode::BrOnException, exitLabel, this->func);
+        leaveLabel->InsertBefore(brToExit);
 
-    this->AddBlock(brLabel, brToExit, finallyEndBlock->GetNext(), finallyEndBlock /*prevBlock*/);
+        this->AddBlock(brLabel, brToExit, finallyEndBlock->GetNext(), finallyEndBlock /*prevBlock*/);
+        brLabel->SetRegion(lastLabel->GetRegion());
 
-    brLabel->SetRegion(lastLabel->GetRegion());
+        this->AddEdge(finallyEndBlock, brLabel->GetBasicBlock());
+    }
+    else
+    {
+        // If the Leave/LeaveNull at the end of finally was preceeded by a Label, we reuse the block inserting BrOnException to early exit in it
+        IR::BranchInstr *brToExit = IR::BranchInstr::New(Js::OpCode::BrOnException, exitLabel, this->func);
+        leaveLabel->InsertBefore(brToExit);
+        this->AddEdge(finallyEndBlock, exitLabel->GetBasicBlock());
+    }
 
-    // in case of throw/non-terminating loop, there maybe no edge to the next block
+    // In case of throw/non-terminating loop, there maybe no edge to the next block
     if (this->FindEdge(finallyEndBlock, nextBB))
     {
         finallyEndBlock->RemoveSucc(nextBB, this);
     }
-    this->AddEdge(finallyEndBlock, brLabel->GetBasicBlock());
 
-    this->regToFinallyEndMap->Item(lastLabel->GetRegion(), finallyEndBlock->next->next);
+    this->regToFinallyEndMap->Item(lastLabel->GetRegion(), leaveLabel->GetBasicBlock());
 }
 
 void

--- a/lib/Backend/FlowGraph.cpp
+++ b/lib/Backend/FlowGraph.cpp
@@ -3354,8 +3354,6 @@ FlowGraph::RemoveBlock(BasicBlock *block, GlobOpt * globOpt, bool tailDuping)
         {
             Assert(instr->IsLabelInstr());
             instr->AsLabelInstr()->m_isLoopTop = false;
-            instr->AsLabelInstr()->SetRegion(nullptr);
-            instr->AsLabelInstr()->m_hasNonBranchRef = false;
         }
         else
         {

--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -24676,7 +24676,7 @@ Lowerer::InsertReturnThunkForRegion(Region* region, IR::LabelInstr* restoreLabel
         if (region->IsNonExceptingFinally())
         {
             Assert(region->GetParent()->GetType() != RegionTypeRoot);
-            Region *ancestor = region->GetFirstAncestorOfNonExceptingFinallyParent();
+            Region *ancestor = region->GetParent()->GetFirstAncestorOfNonExceptingFinallyParent();
             Assert(ancestor && !ancestor->IsNonExceptingFinally());
             if (ancestor->GetType() != RegionTypeRoot)
             {

--- a/lib/Backend/Region.cpp
+++ b/lib/Backend/Region.cpp
@@ -68,10 +68,12 @@ Region::GetSelfOrFirstTryAncestor()
 }
 
 // Return the first ancestor of the region's parent which is not a non exception finally
+// Skip all non exception finally regions in the region tree
+// Return the parent of the first non-non-exception finally region
 Region *
 Region::GetFirstAncestorOfNonExceptingFinallyParent()
 {
-    Region * ancestor = this->GetParent();
+    Region * ancestor = this;
     while (ancestor && ancestor->IsNonExceptingFinally())
     {
         ancestor = ancestor->GetParent();
@@ -81,10 +83,11 @@ Region::GetFirstAncestorOfNonExceptingFinallyParent()
     // If the ancestor's parent is a non exception finally, recurse
     if (ancestor && ancestor->GetType() != RegionTypeRoot && ancestor->GetParent()->IsNonExceptingFinally())
     {
-        return ancestor->GetParent()->GetFirstAncestorOfNonExceptingFinallyParent();
+        return ancestor->GetParent()->GetFirstAncestorOfNonExceptingFinally();
     }
 
-    return ancestor ? (ancestor->GetType() == RegionTypeRoot ? ancestor : ancestor->GetParent()) : nullptr;
+    Assert(ancestor);
+    return ancestor->GetType() == RegionTypeRoot ? ancestor : ancestor->GetParent();
 }
 
 // Return first ancestor which is not a non exception finally

--- a/lib/Backend/Region.cpp
+++ b/lib/Backend/Region.cpp
@@ -87,7 +87,8 @@ Region::GetFirstAncestorOfNonExceptingFinallyParent()
     }
 
     Assert(ancestor);
-    return ancestor->GetType() == RegionTypeRoot ? ancestor : ancestor->GetParent();
+    // Null check added to avoid prefast warning only
+    return ancestor ? (ancestor->GetType() == RegionTypeRoot ? ancestor : ancestor->GetParent()) : nullptr;
 }
 
 // Return first ancestor which is not a non exception finally

--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -6876,8 +6876,6 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
 
                 m_reader.SetCurrentOffset(finallyOffset);
 
-                ResetOut();
-
                 this->nestedFinallyDepth++;
 
                 // mark the stackFrame as 'in finally block'


### PR DESCRIPTION
When we add an edge from end of finally block to an early exit, we need not create additional blocks
if the Leave/LeaveNull at the end of finally was in a separate block preceeded by a Label.
Creating empty blocks like this can lead to issues with DelateLeaveChains later on, moreover we want to keep the IR clean.

Also piggybacking 2 minor fixes:
1. Don't zero out region info on dead blocks, affects liveness info in the presence of regions
2. Don't call ResetOut on non exception path in ProcessTryHandlerBailout