### PR TITLE
JavascriptProxy::GetValueFromDescriptor instance should be Var

### DIFF
--- a/lib/Runtime/Library/JavascriptProxy.cpp
+++ b/lib/Runtime/Library/JavascriptProxy.cpp
@@ -545,7 +545,7 @@ namespace Js
         }
         else if (result.IsFromProxy())
         {
-            *value = GetValueFromDescriptor(RecyclableObject::FromVar(originalInstance), result, requestContext);
+            *value = GetValueFromDescriptor(originalInstance, result, requestContext);
         }
         return JavascriptConversion::BooleanToPropertyQueryFlags(foundProperty);
     }
@@ -572,7 +572,7 @@ namespace Js
         }
         else if (result.IsFromProxy())
         {
-            *value = GetValueFromDescriptor(RecyclableObject::FromVar(originalInstance), result, requestContext);
+            *value = GetValueFromDescriptor(originalInstance, result, requestContext);
         }
         return JavascriptConversion::BooleanToPropertyQueryFlags(foundProperty);
     }
@@ -623,7 +623,7 @@ namespace Js
         }
         else if (result.IsFromProxy())
         {
-            *value = GetValueFromDescriptor(RecyclableObject::FromVar(originalInstance), result, requestContext);
+            *value = GetValueFromDescriptor(originalInstance, result, requestContext);
         }
         return JavascriptConversion::BooleanToPropertyQueryFlags(foundProperty);
     }
@@ -886,7 +886,7 @@ namespace Js
         }
         else if (result.IsFromProxy())
         {
-            *value = GetValueFromDescriptor(RecyclableObject::FromVar(originalInstance), result, requestContext);
+            *value = GetValueFromDescriptor(originalInstance, result, requestContext);
         }
         return JavascriptConversion::BooleanToPropertyQueryFlags(foundProperty);
     }
@@ -909,7 +909,7 @@ namespace Js
         }
         else if (result.IsFromProxy())
         {
-            *value = GetValueFromDescriptor(RecyclableObject::FromVar(originalInstance), result, requestContext);
+            *value = GetValueFromDescriptor(originalInstance, result, requestContext);
         }
         return JavascriptConversion::BooleanToPropertyQueryFlags(foundProperty);
     }
@@ -1940,7 +1940,7 @@ namespace Js
         return JavascriptFunction::FromVar(varMethod);
     }
 
-    Var JavascriptProxy::GetValueFromDescriptor(RecyclableObject* instance, PropertyDescriptor propertyDescriptor, ScriptContext* requestContext)
+    Var JavascriptProxy::GetValueFromDescriptor(Var instance, PropertyDescriptor propertyDescriptor, ScriptContext* requestContext)
     {
         if (propertyDescriptor.ValueSpecified())
         {

--- a/lib/Runtime/Library/JavascriptProxy.h
+++ b/lib/Runtime/Library/JavascriptProxy.h
@@ -204,7 +204,7 @@ namespace Js
 
     private:
         JavascriptFunction* GetMethodHelper(PropertyId methodId, ScriptContext* requestContext);
-        Var GetValueFromDescriptor(RecyclableObject* instance, PropertyDescriptor propertyDescriptor, ScriptContext* requestContext);
+        Var GetValueFromDescriptor(Var instance, PropertyDescriptor propertyDescriptor, ScriptContext* requestContext);
         static Var GetName(ScriptContext* requestContext, PropertyId propertyId);
 
         static BOOL TestIntegrityLevel(IntegrityLevel integrityLevel, RecyclableObject* obj, ScriptContext* scriptContext);


### PR DESCRIPTION
We assert if reciever is tagged int, but the callee who uses this supports reciever to be a tagged value, so there's no reason to require RecyclableObject.

Fixes #3077