### PR TITLE
Allow allocations during concurrent sweep.

### DIFF
--- a/lib/Common/CommonDefines.h
+++ b/lib/Common/CommonDefines.h
@@ -136,16 +136,21 @@
 #ifdef _WIN32
 #define SYSINFO_IMAGE_BASE_AVAILABLE 1
 #define ENABLE_CONCURRENT_GC 1
+#define ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP 1 // Only takes effect when ENABLE_CONCURRENT_GC is enabled.
+#define ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP_USE_SLIST 1 // Use Interlocked SLIST for allocableHeapBlockList
 #define SUPPORT_WIN32_SLIST 1
 #define ENABLE_JS_ETW                               // ETW support
 #else
 #define SYSINFO_IMAGE_BASE_AVAILABLE 0
 #ifndef ENABLE_VALGRIND
 #define ENABLE_CONCURRENT_GC 1
+#define ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP 1 // Only takes effect when ENABLE_CONCURRENT_GC is enabled.
 #else
 #define ENABLE_CONCURRENT_GC 0
+#define ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP 0 // Only takes effect when ENABLE_CONCURRENT_GC is enabled.
 #endif
 #define SUPPORT_WIN32_SLIST 0
+#define ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP_USE_SLIST 0 // Use Interlocked SLIST for allocableHeapBlockList
 #endif
 
 

--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -1318,6 +1318,7 @@ FLAGNR(Boolean, RecyclerForceMarkInterior, "Force all the mark as interior", DEF
 #if ENABLE_CONCURRENT_GC
 FLAGNR(Number,  RecyclerPriorityBoostTimeout, "Adjust priority boost timeout", 5000)
 FLAGNR(Number,  RecyclerThreadCollectTimeout, "Adjust thread collect timeout", 1000)
+FLAGRA(Boolean, EnableConcurrentSweepAlloc, ecsa, "Turns off the feature to allow allocations during concurrent sweep.", true)
 #endif
 #ifdef RECYCLER_PAGE_HEAP
 FLAGNR(Number,      PageHeap,             "Use full page for heap allocations", DEFAULT_CONFIG_PageHeap)

--- a/lib/Common/Memory/CollectionState.h
+++ b/lib/Common/Memory/CollectionState.h
@@ -38,7 +38,7 @@ enum CollectionState
     Collection_PostCollectionCallback      = 0x00020000,
     Collection_PostSweepRedeferralCallback = 0x00040000,
     Collection_WrapperCallback             = 0x00080000,
-    
+
 
     // Actual states
     CollectionStateNotCollecting          = 0,                                                                // not collecting

--- a/lib/Common/Memory/HeapBlock.h
+++ b/lib/Common/Memory/HeapBlock.h
@@ -353,6 +353,15 @@ public:
 #endif
 };
 
+#if ENABLE_CONCURRENT_GC && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP && SUPPORT_WIN32_SLIST && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP_USE_SLIST
+template <typename TBlockType>
+struct HeapBlockSListItem {
+    // SLIST_ENTRY needs to be the first element in the structure to avoid calculating offset with the SList API calls.
+    SLIST_ENTRY itemEntry;
+    TBlockType * itemHeapBlock;
+};
+#endif
+
 enum SweepMode
 {
     SweepMode_InThread,
@@ -694,7 +703,7 @@ protected:
     void CheckFreeBitVector(bool isCollecting);
 #endif
 
-    SmallHeapBlockBitVector * EnsureFreeBitVector();
+    SmallHeapBlockBitVector * EnsureFreeBitVector(bool isCollecting = true);
     SmallHeapBlockBitVector * BuildFreeBitVector();
     ushort BuildFreeBitVector(SmallHeapBlockBitVector * bv);
 

--- a/lib/Common/Memory/HeapInfo.cpp
+++ b/lib/Common/Memory/HeapInfo.cpp
@@ -1171,6 +1171,39 @@ HeapInfo::SweepPendingObjects(RecyclerSweep& recyclerSweep)
 }
 #endif
 
+#if ENABLE_CONCURRENT_GC && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
+void HeapInfo::StartAllocationsDuringConcurrentSweep()
+{
+    for (uint i = 0; i < HeapConstants::BucketCount; i++)
+    {
+        heapBuckets[i].StartAllocationDuringConcurrentSweep();
+    }
+
+#if defined(BUCKETIZE_MEDIUM_ALLOCATIONS) && SMALLBLOCK_MEDIUM_ALLOC
+    for (uint i = 0; i < HeapConstants::MediumBucketCount; i++)
+    {
+        mediumHeapBuckets[i].StartAllocationDuringConcurrentSweep();
+    }
+#endif
+}
+
+void
+HeapInfo::FinishConcurrentSweep()
+{
+    for (uint i = 0; i < HeapConstants::BucketCount; i++)
+    {
+        heapBuckets[i].FinishConcurrentSweep();
+    }
+
+#if defined(BUCKETIZE_MEDIUM_ALLOCATIONS) && SMALLBLOCK_MEDIUM_ALLOC
+    for (uint i = 0; i < HeapConstants::MediumBucketCount; i++)
+    {
+        mediumHeapBuckets[i].FinishConcurrentSweep();
+    }
+#endif
+}
+#endif
+
 #if ENABLE_CONCURRENT_GC
 void
 HeapInfo::TransferPendingHeapBlocks(RecyclerSweep& recyclerSweep)

--- a/lib/Common/Memory/HeapInfo.h
+++ b/lib/Common/Memory/HeapInfo.h
@@ -87,6 +87,10 @@ public:
 #endif
 #if ENABLE_CONCURRENT_GC
     void PrepareSweep();
+#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
+    void StartAllocationsDuringConcurrentSweep();
+    void FinishConcurrentSweep();
+#endif
 
     void TransferPendingHeapBlocks(RecyclerSweep& recyclerSweep);
     void ConcurrentTransferSweptObjects(RecyclerSweep& recyclerSweep);

--- a/lib/Common/Memory/Recycler.h
+++ b/lib/Common/Memory/Recycler.h
@@ -1573,6 +1573,10 @@ private:
     void SweepHeap(bool concurrent, RecyclerSweep& recyclerSweep);
     void FinishSweep(RecyclerSweep& recyclerSweep);
 
+#if ENABLE_CONCURRENT_GC && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
+    void FinishConcurrentSweep();
+#endif
+
     bool FinishDisposeObjects();
     template <CollectionFlags flags>
     bool FinishDisposeObjectsWrapped();
@@ -1626,6 +1630,8 @@ private:
     BOOL IsConcurrentFindRootState() const;
     BOOL IsConcurrentExecutingState() const;
     BOOL IsConcurrentSweepExecutingState() const;
+    BOOL IsConcurrentSweepSetupState() const;
+    BOOL IsConcurrentSweepState() const;
     BOOL IsConcurrentState() const;
     BOOL InConcurrentSweep()
     {
@@ -1659,6 +1665,7 @@ private:
     BOOL WaitForConcurrentThread(DWORD waitTime);
     void FlushBackgroundPages();
     BOOL FinishConcurrentCollect(CollectionFlags flags);
+    void FinishTransferSwept(CollectionFlags flags);
     BOOL FinishConcurrentCollectWrapped(CollectionFlags flags);
     void BackgroundMark();
     void BackgroundResetMarks();

--- a/lib/Common/Memory/RecyclerSweep.cpp
+++ b/lib/Common/Memory/RecyclerSweep.cpp
@@ -276,9 +276,16 @@ RecyclerSweep::BackgroundSweep()
 
     // Finish the concurrent part of the first pass
     this->recycler->autoHeap.SweepSmallNonFinalizable(*this);
-
+    
     // Finish the rest of the sweep
     this->FinishSweep();
+
+#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
+    if (CONFIG_FLAG_RELEASE(EnableConcurrentSweepAlloc))
+    {
+        this->recycler->FinishConcurrentSweep();
+    }
+#endif
 
     this->EndBackground();
 }

--- a/lib/Common/Memory/SmallFinalizableHeapBucket.h
+++ b/lib/Common/Memory/SmallFinalizableHeapBucket.h
@@ -312,6 +312,10 @@ public:
 #ifdef RECYCLER_VERIFY_MARK
     void VerifyMark();
 #endif
+#if ENABLE_CONCURRENT_GC && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
+    void StartAllocationDuringConcurrentSweep();
+    void FinishConcurrentSweep();
+#endif
 #if DBG
     bool AllocatorsAreEmpty();
 #endif

--- a/lib/Common/Memory/SmallNormalHeapBucket.h
+++ b/lib/Common/Memory/SmallNormalHeapBucket.h
@@ -37,7 +37,7 @@ protected:
 #if ENABLE_CONCURRENT_GC
     void SweepPendingObjects(RecyclerSweep& recyclerSweep);
     template <SweepMode mode>
-    static TBlockType * SweepPendingObjects(Recycler * recycler, TBlockType * list);
+    TBlockType * SweepPendingObjects(Recycler * recycler, TBlockType * list);
 #endif
     void Sweep(RecyclerSweep& recyclerSweep);
 #if ENABLE_PARTIAL_GC
@@ -45,7 +45,7 @@ protected:
 
     template <class Fn>
     static void SweepPartialReusePages(RecyclerSweep& recyclerSweep, TBlockType * heapBlockList,
-        TBlockType *& reuseBlocklist, TBlockType *&unusedBlockList, Fn callBack);
+        TBlockType *& reuseBlocklist, TBlockType *&unusedBlockList, bool allocationsAllowedDuringConcurrentSweep, Fn callBack);
     void SweepPartialReusePages(RecyclerSweep& recyclerSweep);
     void FinishPartialCollect(RecyclerSweep * recyclerSweep);
 


### PR DESCRIPTION
     1. We enable allocations during concurrent sweep using an interlocked SLIST for allocations. This list is used only during the concurrent sweep.
     2. As part of this change the heap blocks will become available for the allocators as soon as either SweepPartialReusePages or SweepPendingObjects make them available.
     3. The heap blocks we allocated from during concurrent sweep are kept track of separately and are processed during the next sweep so they will land in the heapBlockList or the fullBlockList as appropriate.