### PR TITLE
Fixing the Is check for console scope activation object

### DIFF
--- a/lib/Runtime/Types/ActivationObject.h
+++ b/lib/Runtime/Types/ActivationObject.h
@@ -116,7 +116,8 @@ namespace Js
 
         static bool Is(void* instance)
         {
-            return VirtualTableInfo<Js::ConsoleScopeActivationObject>::HasVirtualTable(instance);
+            return VirtualTableInfo<ConsoleScopeActivationObject>::HasVirtualTable(instance)
+                || VirtualTableInfo<CrossSiteObject<ConsoleScopeActivationObject>>::HasVirtualTable(instance);
         }
 
 #if ENABLE_TTD


### PR DESCRIPTION
While checking whether an activation object is console scope or not we were not checking it for the cross context object.
