### PR TITLE
xplat: fix script location

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -54,7 +54,7 @@ PRINT_USAGE() {
     echo "     --sanitize=CHECKS Build with clang -fsanitize checks,"
     echo "                       e.g. undefined,signed-integer-overflow."
     echo " -t, --test-build      Test build. Enables test flags on a release build."
-    echo "     --target-os[=S]   Target OS"
+    echo "     --target[=S]      Target OS"
     echo "     --target-path[=S] Output path for compiled binaries. Default: out/"
     echo "     --trace           Enables experimental built-in trace."
     echo "     --xcode           Generate XCode project."
@@ -79,7 +79,9 @@ script (at your own risk)"
     echo ""
 }
 
-CHAKRACORE_DIR=`dirname $0`
+pushd `dirname $0` > /dev/null
+CHAKRACORE_DIR=`pwd -P`
+popd > /dev/null
 _CXX=""
 _CC=""
 _VERBOSE=""

--- a/test/runtests.sh
+++ b/test/runtests.sh
@@ -8,8 +8,9 @@
 # This script is mainly for CI only. In case you have ChakraCore is compiled for multiple
 # targets, this script may fail to test all of them. Use runtests.py instead.
 
-test_path=`dirname "$0"`
-
+pushd `dirname $0` > /dev/null
+test_path=`pwd -P`
+popd > /dev/null
 build_type=
 binary_path=
 release_build=0
@@ -52,9 +53,8 @@ else
     fi
 fi
 
-RES=$(pwd)
-CH_ABSOLUTE_PATH="$RES/${test_path}/../out/${binary_path}/ch"
-RES=$(cd $RES/$test_path/native-tests; ./test_native.sh ${CH_ABSOLUTE_PATH} ${binary_path} 2>&1)
+CH_ABSOLUTE_PATH="${test_path}/../out/${binary_path}/ch"
+RES=$(cd $test_path/native-tests; ./test_native.sh ${CH_ABSOLUTE_PATH} ${binary_path} 2>&1)
 if [[ $? != 0 ]]; then
     echo "Error: Native tests failed"
     echo -e "$RES"

--- a/tools/RecyclerChecker/build.sh
+++ b/tools/RecyclerChecker/build.sh
@@ -17,7 +17,9 @@ echo "  --llvm-config=PATH  llvm-config executable"
 echo ""
 }
 
-SCRIPT_DIR=`dirname $0`
+pushd `dirname $0` > /dev/null
+SCRIPT_DIR=`pwd -P`
+popd > /dev/null
 CLANG_INC=
 CXX_COMPILER=
 LLVM_CONFIG=


### PR DESCRIPTION
`dirname $0` may return relative path, while some part of the script require it to be absolute.