### PR TITLE
Issue3076: Assertion Failure in Parsing

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -2449,7 +2449,7 @@ template<bool buildAST> ParseNodePtr Parser::ParseImportCall()
     }
 
     m_pscan->Scan();
-    return CreateCallNode(knopCall, CreateNodeWithScanner<knopImport>(), specifier);
+    return buildAST ? CreateCallNode(knopCall, CreateNodeWithScanner<knopImport>(), specifier) : nullptr;
 }
 
 template<bool buildAST>

--- a/test/es6/bug_issue_3076.js
+++ b/test/es6/bug_issue_3076.js
@@ -1,0 +1,10 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function test() {
+    import('passmodule.js');
+}
+
+test();

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -1421,6 +1421,13 @@
 </test>
 <test>
   <default>
+    <files>bug_issue_3076.js</files>
+    <compile-flags>-force:deferparse</compile-flags>
+    <tags>BugFix</tags>
+  </default>
+</test>
+<test>
+  <default>
     <files>typedarray_bugs.js</files>
     <compile-flags>-args summary -endargs</compile-flags>
     <tags>BugFix</tags>


### PR DESCRIPTION
Assertion is triggered in parse.cpp on this->m_deferringAST
when CreateCallNode() is called in ParseImportCall().
Fix by adding check for buildAST.
