### PR TITLE
Move GetBinaryLocation to SystemInfo.Common.cpp

### DIFF
--- a/bin/ch/Helpers.cpp
+++ b/bin/ch/Helpers.cpp
@@ -6,14 +6,6 @@
 
 #include <sys/stat.h>
 
-#if defined(__APPLE__)
-#include <mach-o/dyld.h> // _NSGetExecutablePath
-#elif defined(__linux__)
-#include <unistd.h> // readlink
-#elif !defined(_WIN32)
-#error "How to get the executable path for this platform?"
-#endif // _WIN32 ?
-
 //TODO: x-plat definitions
 #ifdef _WIN32
 #define MAX_URI_LENGTH 512
@@ -569,78 +561,6 @@ void CALLBACK Helpers::TTFlushAndCloseStreamCallback(JsTTDStreamHandle handle, b
     fclose((FILE*)handle);
 }
 
-#define SET_BINARY_PATH_ERROR_MESSAGE(path, msg) \
-    str_len = (int) strlen(msg);                 \
-    memcpy(path, msg, (size_t)str_len);          \
-    path[str_len] = char(0)
-
-void GetBinaryLocation(char *path, const unsigned size)
-{
-    AssertMsg(path != nullptr, "Path can not be nullptr");
-    AssertMsg(size < INT_MAX, "Isn't it too big for a path buffer?");
-#ifdef _WIN32
-    LPWSTR wpath = (WCHAR*)malloc(sizeof(WCHAR) * size);
-    int str_len;
-    if (!wpath)
-    {
-        SET_BINARY_PATH_ERROR_MESSAGE(path, "GetBinaryLocation: GetModuleFileName has failed. OutOfMemory!");
-        return;
-    }
-    str_len = GetModuleFileNameW(NULL, wpath, size - 1);
-    if (str_len <= 0)
-    {
-        SET_BINARY_PATH_ERROR_MESSAGE(path, "GetBinaryLocation: GetModuleFileName has failed.");
-        free(wpath);
-        return;
-    }
-
-    str_len = WideCharToMultiByte(CP_UTF8, 0, wpath, str_len, path, size, NULL, NULL);
-    free(wpath);
-
-    if (str_len <= 0)
-    {
-        SET_BINARY_PATH_ERROR_MESSAGE(path, "GetBinaryLocation: GetModuleFileName (WideCharToMultiByte) has failed.");
-        return;
-    }
-
-    if ((unsigned)str_len > size - 1)
-    {
-        str_len = (int) size - 1;
-    }
-    path[str_len] = char(0);
-#elif defined(__APPLE__)
-    uint32_t path_size = (uint32_t)size;
-    char *tmp = nullptr;
-    int str_len;
-    if (_NSGetExecutablePath(path, &path_size))
-    {
-        SET_BINARY_PATH_ERROR_MESSAGE(path, "GetBinaryLocation: _NSGetExecutablePath has failed.");
-        return;
-    }
-
-    tmp = (char*)malloc(size);
-    char *result = realpath(path, tmp);
-    str_len = strlen(result);
-    memcpy(path, result, str_len);
-    free(tmp);
-    path[str_len] = char(0);
-#elif defined(__linux__)
-    int str_len = readlink("/proc/self/exe", path, size - 1);
-    if (str_len <= 0)
-    {
-        SET_BINARY_PATH_ERROR_MESSAGE(path, "GetBinaryLocation: /proc/self/exe has failed.");
-        return;
-    }
-    path[str_len] = char(0);
-#else
-#warning "Implement GetBinaryLocation for this platform"
-#endif
-}
-
-// xplat-todo: Implement a corresponding solution for GetModuleFileNameW
-// and cleanup PAL. [ https://github.com/Microsoft/ChakraCore/pull/2288 should be merged first ]
-// GetModuleFileName* PAL is not reliable and forces us to explicitly double initialize PAL
-// with argc / argv....
 void GetBinaryPathWithFileNameA(char *path, const size_t buffer_size, const char* filename)
 {
     char fullpath[_MAX_PATH];
@@ -648,7 +568,7 @@ void GetBinaryPathWithFileNameA(char *path, const size_t buffer_size, const char
     char dir[_MAX_DIR];
 
     char modulename[_MAX_PATH];
-    GetBinaryLocation(modulename, _MAX_PATH);
+    PlatformAgnostic::SystemInfo::GetBinaryLocation(modulename, _MAX_PATH);
     _splitpath_s(modulename, drive, _MAX_DRIVE, dir, _MAX_DIR, nullptr, 0, nullptr, 0);
     _makepath_s(fullpath, drive, dir, filename, nullptr);
 

--- a/bin/ch/WScriptJsrt.cpp
+++ b/bin/ch/WScriptJsrt.cpp
@@ -830,7 +830,7 @@ bool WScriptJsrt::Initialize()
 
     // Set Binary Location
     JsValueRef binaryPathValue;
-    GetBinaryLocation(CH_BINARY_LOCATION, sizeof(CH_BINARY_LOCATION));
+    PlatformAgnostic::SystemInfo::GetBinaryLocation(CH_BINARY_LOCATION, sizeof(CH_BINARY_LOCATION));
 
     JsPropertyIdRef binaryPathProperty;
     IfJsrtErrorFail(CreatePropertyIdFromString("BINARY_PATH", &binaryPathProperty), false);

--- a/bin/ch/stdafx.h
+++ b/bin/ch/stdafx.h
@@ -93,6 +93,8 @@ using utf8::NarrowStringToWideDynamic;
 using utf8::WideStringToNarrowDynamic;
 #include "Helpers.h"
 
+#include "PlatformAgnostic/SystemInfo.h"
+
 #define IfJsErrorFailLog(expr) \
 do { \
     JsErrorCode jsErrorCode = expr; \
@@ -271,6 +273,5 @@ inline JsErrorCode CreatePropertyIdFromString(const char* str, JsPropertyIdRef *
     return ChakraRTInterface::JsCreatePropertyId(str, strlen(str), Id);
 }
 
-void GetBinaryLocation(char *path, const unsigned size);
 void GetBinaryPathWithFileNameA(char *path, const size_t buffer_size, const char* filename);
 extern "C" HRESULT __stdcall OnChakraCoreLoadedEntry(TestHooks& testHooks);

--- a/lib/Common/PlatformAgnostic/SystemInfo.h
+++ b/lib/Common/PlatformAgnostic/SystemInfo.h
@@ -33,6 +33,51 @@ namespace PlatformAgnostic
         }
 
         static bool GetMaxVirtualMemory(size_t *totalAS);
+
+#define SET_BINARY_PATH_ERROR_MESSAGE(path, msg) \
+    str_len = (int) strlen(msg);                 \
+    memcpy(path, msg, (size_t)str_len);          \
+    path[str_len] = char(0)
+
+#ifdef _WIN32
+        static void GetBinaryLocation(char *path, const unsigned size)
+        {
+            // TODO: make AssertMsg available under PlatformAgnostic
+            //AssertMsg(path != nullptr, "Path can not be nullptr");
+            //AssertMsg(size < INT_MAX, "Isn't it too big for a path buffer?");
+            LPWSTR wpath = (WCHAR*)malloc(sizeof(WCHAR) * size);
+            int str_len;
+            if (!wpath)
+            {
+                SET_BINARY_PATH_ERROR_MESSAGE(path, "GetBinaryLocation: GetModuleFileName has failed. OutOfMemory!");
+                return;
+            }
+            str_len = GetModuleFileNameW(NULL, wpath, size - 1);
+            if (str_len <= 0)
+            {
+                SET_BINARY_PATH_ERROR_MESSAGE(path, "GetBinaryLocation: GetModuleFileName has failed.");
+                free(wpath);
+                return;
+            }
+
+            str_len = WideCharToMultiByte(CP_UTF8, 0, wpath, str_len, path, size, NULL, NULL);
+            free(wpath);
+
+            if (str_len <= 0)
+            {
+                SET_BINARY_PATH_ERROR_MESSAGE(path, "GetBinaryLocation: GetModuleFileName (WideCharToMultiByte) has failed.");
+                return;
+            }
+
+            if ((unsigned)str_len > size - 1)
+            {
+                str_len = (int)size - 1;
+            }
+            path[str_len] = char(0);
+        }
+#else
+        static void GetBinaryLocation(char *path, const unsigned size);
+#endif
     };
 } // namespace PlatformAgnostic
 

--- a/lib/Runtime/PlatformAgnostic/Platform/CMakeLists.txt
+++ b/lib/Runtime/PlatformAgnostic/Platform/CMakeLists.txt
@@ -7,6 +7,7 @@ set(PL_SOURCE_FILES
   Linux/NumbersUtility.cpp
   Linux/Thread.cpp
   Common/Trace.cpp
+  Common/SystemInfo.Common.cpp
   )
 
 if(CC_TARGET_OS_ANDROID OR CC_TARGET_OS_LINUX)

--- a/lib/Runtime/PlatformAgnostic/Platform/Common/SystemInfo.Common.cpp
+++ b/lib/Runtime/PlatformAgnostic/Platform/Common/SystemInfo.Common.cpp
@@ -1,0 +1,52 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#include "RuntimePlatformAgnosticPch.h"
+#include "../../Common/Core/CommonTypedefs.h"
+#include "../../Common/PlatformAgnostic/SystemInfo.h"
+
+#if defined(__APPLE__)
+#include <mach-o/dyld.h> // _NSGetExecutablePath
+#elif defined(__linux__)
+#include <unistd.h> // readlink
+#endif
+
+namespace PlatformAgnostic
+{
+    void SystemInfo::GetBinaryLocation(char *path, const unsigned size)
+    {
+        // TODO: make AssertMsg available under PlatformAgnostic
+        //AssertMsg(path != nullptr, "Path can not be nullptr");
+        //AssertMsg(size < INT_MAX, "Isn't it too big for a path buffer?");
+#ifdef __APPLE__
+        uint32_t path_size = (uint32_t)size;
+        char *tmp = nullptr;
+        int str_len;
+        if (_NSGetExecutablePath(path, &path_size))
+        {
+            SET_BINARY_PATH_ERROR_MESSAGE(path, "GetBinaryLocation: _NSGetExecutablePath has failed.");
+            return;
+        }
+
+        tmp = (char*)malloc(size);
+        char *result = realpath(path, tmp);
+        str_len = strlen(result);
+        memcpy(path, result, str_len);
+        free(tmp);
+        path[str_len] = char(0);
+#elif defined(__linux__)
+        int str_len = readlink("/proc/self/exe", path, size - 1);
+        if (str_len <= 0)
+        {
+            SET_BINARY_PATH_ERROR_MESSAGE(path, "GetBinaryLocation: /proc/self/exe has failed.");
+            return;
+        }
+        path[str_len] = char(0);
+#else
+        #warning "Implement GetBinaryLocation for this platform"
+#endif
+    }
+
+} // namespace PlatformAgnostic


### PR DESCRIPTION
This is the first step towards fixing #2297. This patch copies the `GetBinaryLocation` function from `bin/ch/Helpers.cpp`
to `lib/Runtime/PlatformAgnostic/Platform/Common/SystemInfo.Common.cpp` (new file) under namespace `PlaatformAgnostic`.