### PR TITLE
Fix region propagation of finally end blocks

### DIFF
--- a/lib/Backend/BailOut.cpp
+++ b/lib/Backend/BailOut.cpp
@@ -1095,6 +1095,9 @@ Js::Var BailOutRecord::BailOut(BailOutRecord const * bailOutRecord)
     Js::JavascriptCallStackLayout *const layout = bailOutRecord->GetStackLayout();
     Js::ScriptFunction * function = (Js::ScriptFunction *)layout->functionObject;
 
+    Assert(function->GetScriptContext()->GetThreadContext()->GetPendingFinallyException() == nullptr ||
+        bailOutRecord->bailOutKind == IR::BailOutOnException);
+
     if (bailOutRecord->bailOutKind == IR::BailOutOnImplicitCalls)
     {
         function->GetScriptContext()->GetThreadContext()->CheckAndResetImplicitCallAccessorFlag();

--- a/lib/Backend/FlowGraph.cpp
+++ b/lib/Backend/FlowGraph.cpp
@@ -452,6 +452,31 @@ FlowGraph::Build(void)
     } NEXT_BLOCK_ALL;
     AssertMsg(blockNum == this->blockCount, "Block count is out of whack");
 
+#if DBG_DUMP
+    if (PHASE_DUMP(Js::FGBuildPhase, this->GetFunc()))
+    {
+        if (assignRegionsBeforeGlobopt)
+        {
+            Output::Print(_u("Before adding early exit edges\n"));
+            FOREACH_BLOCK_ALL(block, this)
+            {
+                block->DumpHeader(true);
+                Region *region = block->GetFirstInstr()->AsLabelInstr()->GetRegion();
+                if (region)
+                {
+                    const char16 * regMap[] = { _u("RegionTypeInvalid"),
+                        _u("RegionTypeRoot"),
+                        _u("RegionTypeTry"),
+                        _u("RegionTypeCatch"),
+                        _u("RegionTypeFinally") };
+                    Output::Print(_u("Region %p RegionParent %p RegionType %s\n"), region, region->GetParent(), regMap[region->GetType()]);
+                }
+            } NEXT_BLOCK_ALL;
+            this->func->Dump();
+        }
+    }
+#endif
+
     if (this->finallyLabelStack)
     {
         Assert(this->finallyLabelStack->Empty());
@@ -535,17 +560,19 @@ FlowGraph::Build(void)
     } NEXT_BLOCK_ALL;
 
     this->FindLoops();
+
 #if DBG_DUMP
     if (PHASE_DUMP(Js::FGBuildPhase, this->GetFunc()))
     {
         if (assignRegionsBeforeGlobopt)
         {
-            Output::Print(_u("Before CanonicalizeLoops\n"));
+            Output::Print(_u("After adding early exit edges/Before CanonicalizeLoops\n"));
             FOREACH_BLOCK_ALL(block, this)
             {
                 block->DumpHeader(true);
                 Region *region = block->GetFirstInstr()->AsLabelInstr()->GetRegion();
-                if (region) {
+                if (region)
+                {
                     const char16 * regMap[] = { _u("RegionTypeInvalid"),
                         _u("RegionTypeRoot"),
                         _u("RegionTypeTry"),
@@ -554,9 +581,11 @@ FlowGraph::Build(void)
                     Output::Print(_u("Region %p RegionParent %p RegionType %s\n"), region, region->GetParent(), regMap[region->GetType()]);
                 }
             } NEXT_BLOCK_ALL;
+            this->func->Dump();
         }
     }
 #endif
+
     bool breakBlocksRelocated = this->CanonicalizeLoops();
 
     blockNum = 0;
@@ -578,26 +607,29 @@ FlowGraph::Build(void)
     } NEXT_BLOCK_ALL;
 #endif
 
-#if DBG
-    FOREACH_BLOCK_ALL(block, this)
+#if DBG_DUMP
+    if (PHASE_DUMP(Js::FGBuildPhase, this->GetFunc()))
     {
-        if (PHASE_DUMP(Js::FGBuildPhase, this->GetFunc()))
+        if (assignRegionsBeforeGlobopt)
         {
-            if (assignRegionsBeforeGlobopt)
+            Output::Print(_u("After CanonicalizeLoops\n"));
+            FOREACH_BLOCK_ALL(block, this)
             {
                 block->DumpHeader(true);
                 Region *region = block->GetFirstInstr()->AsLabelInstr()->GetRegion();
-                if (region) {
+                if (region)
+                {
                     const char16 * regMap[] = { _u("RegionTypeInvalid"),
-                        _u("RegionTypeRoot"),
-                        _u("RegionTypeTry"),
-                        _u("RegionTypeCatch"),
-                        _u("RegionTypeFinally") };
+                    _u("RegionTypeRoot"),
+                    _u("RegionTypeTry"),
+                    _u("RegionTypeCatch"),
+                    _u("RegionTypeFinally") };
                     Output::Print(_u("Region %p RegionParent %p RegionType %s\n"), region, region->GetParent(), regMap[region->GetType()]);
                 }
-            }
+            } NEXT_BLOCK_ALL;
+            this->func->Dump();
         }
-    } NEXT_BLOCK_ALL;
+    }
 #endif
 
     if (breakBlocksRelocated)

--- a/lib/Backend/FlowGraph.h
+++ b/lib/Backend/FlowGraph.h
@@ -142,6 +142,7 @@ public:
         finallyLabelStack(nullptr),
         leaveNullLabelStack(nullptr),
         regToFinallyEndMap(nullptr),
+        leaveNullLabelToFinallyLabelMap(nullptr),
         hasBackwardPassInfo(false),
         hasLoop(false),
         implicitCallFlags(Js::ImplicitCall_HasNoInfo)
@@ -188,6 +189,8 @@ public:
     SList<IR::LabelInstr*> *  leaveNullLabelStack;
     typedef JsUtil::BaseDictionary<Region *, BasicBlock *, JitArenaAllocator> RegionToFinallyEndMapType;
     RegionToFinallyEndMapType * regToFinallyEndMap;
+    typedef JsUtil::BaseDictionary<IR::LabelInstr *, IR::LabelInstr *, JitArenaAllocator> LeaveNullLabelToFinallyLabelMapType;
+    LeaveNullLabelToFinallyLabelMapType * leaveNullLabelToFinallyLabelMap;
     bool                      hasBackwardPassInfo;
     bool                      hasLoop;
     Js::ImplicitCallFlags     implicitCallFlags;

--- a/lib/Backend/GlobOpt.h
+++ b/lib/Backend/GlobOpt.h
@@ -922,7 +922,7 @@ private:
     void                    ProcessTryHandler(IR::Instr* instr);
     void                    InsertToVarAtDefInTryRegion(IR::Instr * instr, IR::Opnd * dstOpnd);
     void                    RemoveFlowEdgeToCatchBlock(IR::Instr * instr);
-    void                    RemoveFlowEdgeToFinallyOnExceptionBlock(IR::Instr * instr);
+    bool                    RemoveFlowEdgeToFinallyOnExceptionBlock(IR::Instr * instr);
 
     void                    CSEAddInstr(BasicBlock *block, IR::Instr *instr, Value *dstVal, Value *src1Val, Value *src2Val, Value *dstIndirIndexVal, Value *src1IndirIndexVal);
     void                    OptimizeChecks(IR::Instr * const instr);

--- a/lib/Backend/IR.h
+++ b/lib/Backend/IR.h
@@ -736,6 +736,8 @@ public:
     bool                 m_isAirlock : 1;
     bool                 m_isSwitchBr : 1;
     bool                 m_isOrphanedLeave : 1; // A Leave in a loop body in a try, most likely generated because of a return statement.
+    bool                 m_areCmpRegisterFlagsUsedLater : 1; // Indicate that this branch is not the only instr using the register flags set by cmp
+    bool                 m_brFinallyToEarlyExit : 1; // BrOnException from finally to early exit, can be turned into BrOnNoException on break blocks removal
 #if DBG
     bool                 m_isMultiBranch;
     bool                 m_isHelperToNonHelperBranch;
@@ -748,7 +750,7 @@ public:
     static BranchInstr * New(Js::OpCode opcode, Opnd* destOpnd, LabelInstr * branchTarget, Opnd *srcOpnd, Func *func);
     static BranchInstr * New(Js::OpCode opcode, LabelInstr * branchTarget, Opnd *src1Opnd, Opnd *src2Opnd, Func *func);
 
-    BranchInstr(bool hasBailOutInfo = false) : Instr(hasBailOutInfo), m_branchTarget(nullptr), m_isAirlock(false), m_isSwitchBr(false), m_isOrphanedLeave(false)
+    BranchInstr(bool hasBailOutInfo = false) : Instr(hasBailOutInfo), m_branchTarget(nullptr), m_isAirlock(false), m_isSwitchBr(false), m_isOrphanedLeave(false), m_areCmpRegisterFlagsUsedLater(false), m_brFinallyToEarlyExit(nullptr)
     {
 #if DBG
         m_isMultiBranch = false;

--- a/lib/Backend/IR.h
+++ b/lib/Backend/IR.h
@@ -750,7 +750,7 @@ public:
     static BranchInstr * New(Js::OpCode opcode, Opnd* destOpnd, LabelInstr * branchTarget, Opnd *srcOpnd, Func *func);
     static BranchInstr * New(Js::OpCode opcode, LabelInstr * branchTarget, Opnd *src1Opnd, Opnd *src2Opnd, Func *func);
 
-    BranchInstr(bool hasBailOutInfo = false) : Instr(hasBailOutInfo), m_branchTarget(nullptr), m_isAirlock(false), m_isSwitchBr(false), m_isOrphanedLeave(false), m_areCmpRegisterFlagsUsedLater(false), m_brFinallyToEarlyExit(nullptr)
+    BranchInstr(bool hasBailOutInfo = false) : Instr(hasBailOutInfo), m_branchTarget(nullptr), m_isAirlock(false), m_isSwitchBr(false), m_isOrphanedLeave(false), m_areCmpRegisterFlagsUsedLater(false), m_brFinallyToEarlyExit(false)
     {
 #if DBG
         m_isMultiBranch = false;

--- a/lib/Backend/IR.h
+++ b/lib/Backend/IR.h
@@ -739,6 +739,7 @@ public:
 #if DBG
     bool                 m_isMultiBranch;
     bool                 m_isHelperToNonHelperBranch;
+    bool                 m_leaveConvToBr;
 #endif
 
 public:
@@ -751,6 +752,7 @@ public:
     {
 #if DBG
         m_isMultiBranch = false;
+        m_leaveConvToBr = false;
 #endif
     }
 

--- a/test/EH/rlexe.xml
+++ b/test/EH/rlexe.xml
@@ -113,4 +113,9 @@
       <baseline>tryfinallybug0.baseline</baseline>
     </default>
   </test>
+  <test>
+    <default>
+      <files>tryfinallytests.js</files>
+    </default>
+  </test>
 </regress-exe>

--- a/test/EH/tryfinallytests.js
+++ b/test/EH/tryfinallytests.js
@@ -1,0 +1,61 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function test0() {
+  var ui32 = new Uint32Array();
+  for (var _strvar23 in ui32) {
+    if (typeof _strvar23) {
+      continue;
+    }
+    try {
+    } catch (ex) {
+      continue;
+    } finally {
+    }
+    break;
+  }
+}
+
+function test1() {
+  var arrObj0 = {};
+  if (arrObj0.length) {
+    for (var _strvar0 of IntArr0) {
+      if (typeof _strvar0) {
+        continue;
+      }
+      try {
+      } catch (ex) {
+        continue;
+      } finally {
+      }
+      break;
+    }
+  }
+}
+
+function test2() {
+  var obj1 = {};
+  var ary = Array();
+  var i8 = new Int8Array();
+  if (!(-530320868 >= ((obj1.method1) & 255))) {
+    for (var _strvar1 of i8) {
+    }
+  }
+  ary | 0;
+}
+
+test0();
+test0();
+test0();
+
+test1();
+test1();
+test1();
+
+test2();
+test2();
+test2();
+
+WScript.Echo("passed");


### PR DESCRIPTION
We add edge from infinite loops in finally region to end of finally block, so that unreachable block elimination does not remove finally end block. We have to retain finally end block, so that we can add edge from finally end block to early exit. 

When the only edge to finally block is an edge from a loop within some child region, we can end up in propagating incorrect region info from the predecessor. We have to use the region on the finally label for such an end of finally block. 

So create a new map called leaveNullLabelToFinallyLabelMap and pick up region info from here.

Also piggybacking other small changes:
- dumping
- fix asserts for Br instructions : 
Leaves in non exception finally are converted to Br instructions, for such branches the target region is the parent of the current region.
Also, a BrOnException from finally to early exit can be converted to BrOnNoException and Br, we cannot assert for such a Br that the target region is same as Br region
