### PR TITLE
Fix and track tests disabled with "fail" tag (Track #3118, Track #3119; Fix #3120, Fix #3121)

### DIFF
--- a/test/Miscellaneous/rlexe.xml
+++ b/test/Miscellaneous/rlexe.xml
@@ -23,6 +23,9 @@
     <default>
       <files>oom.js</files>
       <baseline>oom.baseline</baseline>
+      <!-- TODO fix and re-enable (Microsoft/ChakraCore#3119) -->
+      <!-- Investigate: adding -bgjit makes this test pass -->
+      <!-- <compile-flags>-forcefragmentaddressspace:8000000 -bgjit</compile-flags> -->
       <compile-flags>-forcefragmentaddressspace:8000000</compile-flags>
       <tags>exclude_amd64,fail</tags>
     </default>

--- a/test/es5/rlexe.xml
+++ b/test/es5/rlexe.xml
@@ -295,7 +295,6 @@
     <default>
       <files>es5array_arrayproto_opt.js</files>
       <baseline>es5array_arrayproto_opt.baseline</baseline>
-      <tags>fail</tags>
     </default>
   </test>
   <test>

--- a/test/inlining/linenumber1.baseline
+++ b/test/inlining/linenumber1.baseline
@@ -1,1 +1,3 @@
-linenumber1.js(5, 5) JavaScript runtime error: 'p0' is undefined
+ReferenceError: 'p0' is not defined
+	at main (linenumber1.js:15:9)
+	at Global code (linenumber1.js:21:1)

--- a/test/inlining/linenumber1.js
+++ b/test/inlining/linenumber1.js
@@ -3,11 +3,19 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 
+if (this.WScript && this.WScript.LoadScriptFile) {
+    this.WScript.LoadScriptFile("../UnitTestFramework/TrimStackTracePath.js");
+}
+
 function f() { return 42; }
 function main()
 {
-    var i = 0;
-    return f() - p0;
+    try {
+        var i = 0;
+        return f() - p0;
+    } catch (e) {
+        console.log(TrimStackTracePath(e.stack));
+    }
 }
 
 main();

--- a/test/inlining/linenumber2.baseline
+++ b/test/inlining/linenumber2.baseline
@@ -1,1 +1,3 @@
-linenumber2.js(88, 10) JavaScript runtime error: 'd' is undefined
+ReferenceError: 'd' is not defined
+	at Anonymous function (linenumber2.js:99:10)
+	at Global code (linenumber2.js:12:2)

--- a/test/inlining/linenumber2.js
+++ b/test/inlining/linenumber2.js
@@ -3,6 +3,12 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 
+if (this.WScript && this.WScript.LoadScriptFile) {
+    this.WScript.LoadScriptFile("../UnitTestFramework/TrimStackTracePath.js");
+}
+
+try {
+
 (function(){
   var obj0 = 1;
   var obj1 = 1;
@@ -47,8 +53,8 @@
           c = (! (((obj0.c &= ary[(3)]) || obj1.c) > ((intary[((((obj0.b++ ) >= 0 ? (obj0.b++ ) : 0)) & 0XF)] >= 2147483647) >> a)));
         }
         var __loopvar3 = 0;
-        LABEL0: 
-        LABEL1: 
+        LABEL0:
+        LABEL1:
         while((209) && __loopvar3 < 3) {
           __loopvar3++;
           continue LABEL0;
@@ -81,7 +87,7 @@
     }
     else {
       var __loopvar2 = 0;
-      LABEL0: 
+      LABEL0:
       do {
         __loopvar2++;
         for(var __loopvar3 = 0; obj0.b < (ary[(7)]) && __loopvar3 < 3; obj0.b++ + __loopvar3++) {
@@ -97,3 +103,7 @@
     }
   }
 })();
+
+} catch (e) {
+    console.log(TrimStackTracePath(e.stack));
+}

--- a/test/inlining/linenumber3.baseline
+++ b/test/inlining/linenumber3.baseline
@@ -1,1 +1,3 @@
-linenumber3.js(14, 8) JavaScript runtime error: 'ary' is undefined
+ReferenceError: 'ary' is not defined
+	at Anonymous function (linenumber3.js:28:6)
+	at Global code (linenumber3.js:12:2)

--- a/test/inlining/linenumber3.js
+++ b/test/inlining/linenumber3.js
@@ -3,13 +3,19 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 
+if (this.WScript && this.WScript.LoadScriptFile) {
+    this.WScript.LoadScriptFile("../UnitTestFramework/TrimStackTracePath.js");
+}
+
+try {
+
 (function(){
   var __loopvar0 = 0;
   do {
     __loopvar0++;
     if(Math.acos(1)) {
       var __loopvar3 = 0;
-      LABEL2: 
+      LABEL2:
       while((1) && __loopvar3 < 3) {
         __loopvar3++;
         obj1.a *=Math.pow((1.1 / (-7.9574794502888E+18 == 0 ? 1 : -7.9574794502888E+18)), 1.1);
@@ -22,3 +28,7 @@
     (ary[(((1 >= 0 ? 1 : 0)) & 0XF)]);
   } while((1) && __loopvar0 < 3)
 })();
+
+} catch (e) {
+    console.log(TrimStackTracePath(e.stack));
+}

--- a/test/inlining/rlexe.xml
+++ b/test/inlining/rlexe.xml
@@ -10,28 +10,52 @@
   <test>
     <default>
       <files>linenumber1.js</files>
-      <tags>fail</tags>
       <compile-flags>-force:inline</compile-flags>
-      <tags>exclude_arm</tags>
       <baseline>linenumber1.baseline</baseline>
+      <tags>exclude_arm</tags>
+    </default>
+  </test>
+  <test>
+    <default>
+      <files>linenumber1.js</files>
+      <!-- Variant of test without -force:inline to ensure output is the same -->
+      <!-- <compile-flags>-force:inline</compile-flags> -->
+      <baseline>linenumber1.baseline</baseline>
+      <tags>exclude_arm</tags>
     </default>
   </test>
   <test>
     <default>
       <files>linenumber2.js</files>
-      <tags>fail</tags>
       <compile-flags>-force:inline</compile-flags>
-      <tags>exclude_arm</tags>
       <baseline>linenumber2.baseline</baseline>
+      <tags>exclude_arm</tags>
+    </default>
+  </test>
+  <test>
+    <default>
+      <files>linenumber2.js</files>
+      <!-- Variant of test without -force:inline to ensure output is the same -->
+      <!-- <compile-flags>-force:inline</compile-flags> -->
+      <baseline>linenumber2.baseline</baseline>
+      <tags>exclude_arm</tags>
     </default>
   </test>
   <test>
     <default>
       <files>linenumber3.js</files>
-      <tags>fail</tags>
       <compile-flags>-force:inline</compile-flags>
-      <tags>exclude_arm</tags>
       <baseline>linenumber3.baseline</baseline>
+      <tags>exclude_arm</tags>
+    </default>
+  </test>
+  <test>
+    <default>
+      <files>linenumber3.js</files>
+      <!-- Variant of test without -force:inline to ensure output is the same -->
+      <!-- <compile-flags>-force:inline</compile-flags> -->
+      <baseline>linenumber3.baseline</baseline>
+      <tags>exclude_arm</tags>
     </default>
   </test>
   <test>


### PR DESCRIPTION
Tracks issues:
* #3118: [Disabled Tests] test/Error/rlexe.xml: tests tagged "fail" should be fixed and re-enabled
* #3119: [Disabled Test] test/Miscellaneous/oom.js: fix and re-enable

Fixes issues:
* Fixes #3120: [Disabled Tests] test/inlining/linenumber*.js: fix and re-enable
* Fixes #3121: [Disabled Test] test/es5/es5array_arrayproto_opt.js: fix and re-enable