### PR TITLE
Workaround LoopBodies infinite rejit

### DIFF
--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -1192,6 +1192,9 @@ namespace Js
         Field(uint) endOffset;
         Field(uint) interpretCount;
         Field(uint) profiledLoopCounter;
+#if ENABLE_NATIVE_CODEGEN
+        Field(uint) rejitCount;
+#endif
         Field(bool) isNested;
         Field(bool) isInTry;
         Field(FunctionBody *) functionBody;
@@ -1296,6 +1299,8 @@ namespace Js
 #if ENABLE_NATIVE_CODEGEN
         int CreateEntryPoint();
         void ReleaseEntryPoints();
+        void IncRejitCount() { ++rejitCount; }
+        uint GetRejitCount() { return rejitCount; }
 #endif
 
         void ResetInterpreterCount()


### PR DESCRIPTION
Patch infinite rejit for BailOnNotNativeArray happening in loop bodies

Should fix slow tests as this is what's causing the timeout on one of the test
Related #3127
Closes #3142 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/3126)
<!-- Reviewable:end -->
