### PR TITLE
xplat: Improve ICU fallback conditions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,7 +194,9 @@ elseif(CC_TARGET_OS_OSX)
         -DPLATFORM_UNIX
     )
 
-    if(NOT ICULIB)
+    # in case ICU path was given but it doesn't exist, build script will fail.
+    # so, fallback only if ICU path wasn't given
+    if(NOT ICU_INCLUDE_PATH)
       set(NO_ICU_PATH_GIVEN 1)
       message("-- Couldn't find ICU. Falling back to --no-icu build")
     endif()

--- a/build.sh
+++ b/build.sh
@@ -184,7 +184,17 @@ while [[ $# -gt 0 ]]; do
 
     --icu=*)
         ICU_PATH=$1
-        ICU_PATH="-DICU_INCLUDE_PATH_SH=${ICU_PATH:6}"
+        ICU_PATH="${ICU_PATH:6}"
+        if [[ ! -d ${ICU_PATH} ]]; then
+            if [[ -d "${CHAKRACORE_DIR}/${ICU_PATH}" ]]; then
+                ICU_PATH="${CHAKRACORE_DIR}/${ICU_PATH}"
+            else
+                # if ICU_PATH is given, do not fallback to no-icu
+                echo "!!! couldn't find ICU at $ICU_PATH"
+                exit 1
+            fi
+        fi
+        ICU_PATH="-DICU_INCLUDE_PATH_SH=${ICU_PATH}"
         ;;
 
     --libs-only)


### PR DESCRIPTION
node-chakracore was silently falling back to `no-icu`. Couple of changes to be more proactive when a custom ICU path is given. Similarly, do not fallback to `no-icu` when custom ICU path is given.