### PR TITLE
lock down counters for inlinee function body

### DIFF
--- a/lib/Backend/CodeGenWorkItem.cpp
+++ b/lib/Backend/CodeGenWorkItem.cpp
@@ -25,9 +25,6 @@ CodeGenWorkItem::CodeGenWorkItem(
     , irViewerRequestContext(nullptr)
 #endif
 {
-#if DBG
-    functionBody->LockDownCounters();
-#endif
     this->jitData = {0};
     // work item data
     this->jitData.type = type;

--- a/lib/Backend/FunctionCodeGenJitTimeData.h
+++ b/lib/Backend/FunctionCodeGenJitTimeData.h
@@ -57,6 +57,8 @@ namespace Js
         // The profiled iterations need to be determined at the time of gathering code gen data on the main thread
         Field(const uint16) profiledIterations;
 
+        FunctionCodeGenJitTimeData(FunctionInfo *const functionInfo, EntryPointInfo *const entryPoint, Var globalThis, uint16 profiledIterations, bool isInlined = true);
+
 #ifdef FIELD_ACCESS_STATS
     public:
         Field(FieldAccessStatsPtr) inlineCacheStats;
@@ -66,7 +68,8 @@ namespace Js
 #endif
 
     public:
-        FunctionCodeGenJitTimeData(FunctionInfo *const functionInfo, EntryPointInfo *const entryPoint, bool isInlined = true);
+
+        static FunctionCodeGenJitTimeData* New(Recycler* recycler, FunctionInfo *const functionInfo, EntryPointInfo *const entryPoint, bool isInlined = true);
 
     public:
         Field(BVFixed *) inlineesBv;

--- a/lib/Backend/NativeCodeGenerator.cpp
+++ b/lib/Backend/NativeCodeGenerator.cpp
@@ -2978,7 +2978,7 @@ NativeCodeGenerator::GatherCodeGenData(Js::FunctionBody *const topFunctionBody, 
 
     const auto recycler = scriptContext->GetRecycler();
     {
-        const auto jitTimeData = RecyclerNew(recycler, Js::FunctionCodeGenJitTimeData, functionBody->GetFunctionInfo(), entryPoint);
+        const auto jitTimeData = Js::FunctionCodeGenJitTimeData::New(recycler, functionBody->GetFunctionInfo(), entryPoint);
         InliningDecider inliningDecider(functionBody, workItem->Type() == JsLoopBodyWorkItemType, functionBody->IsInDebugMode(), workItem->GetJitMode());
 
         BEGIN_TEMP_ALLOCATOR(gatherCodeGenDataAllocator, scriptContext, _u("GatherCodeGenData"));

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -6334,9 +6334,8 @@ namespace Js
         // Byte code generation failed for this function. Revert any intermediate state being tracked in the function body, in
         // case byte code generation is attempted again for this function body.
 
-#if DBG
-        this->UnlockCounters();
-#endif
+        DebugOnly(this->UnlockCounters());
+
         ResetInlineCaches();
         ResetObjectLiteralTypes();
         ResetLiteralRegexes();
@@ -6374,9 +6373,9 @@ namespace Js
         // pass may have failed, we need to restore state that is tracked on the function body by the visit pass.
         // Note: do not reset literal regexes if the function has already been compiled (e.g., is a parsed function enclosed by a
         // redeferred function) as we will not use the count of literals anyway, and the counters may be accessed by the background thread.
-#if DBG
-        this->UnlockCounters();
-#endif
+
+        DebugOnly(this->UnlockCounters());
+
         if (this->byteCodeBlock == nullptr)
         {
             ResetLiteralRegexes();
@@ -7937,9 +7936,8 @@ namespace Js
         {
             return;
         }
-#if DBG
-        this->UnlockCounters();
-#endif
+
+        DebugOnly(this->UnlockCounters());
 
         CleanupRecyclerData(isScriptContextClosing, false /* capture entry point cleanup stack trace */);
         CleanUpForInCache(isScriptContextClosing);
@@ -7978,9 +7976,7 @@ namespace Js
 
         this->cleanedUp = true;
 
-#if DBG
-        this->LockDownCounters();
-#endif
+        DebugOnly(this->LockDownCounters());
     }
 
 


### PR DESCRIPTION
we assume a function body counters won't change after JIT started so we did lock down the counters while the function begins execution or creating codeGen workitem on it. however, the inlinee function body can be jitted without creating work item or begin execution. this change is to lockdown the counters while creating JIT time data.

a better place to lockdown for function body might be right after bytecode generated, however in Asmjs and WAsm design, the counters(like varcount) can be changed after bytecode generated. that change will be pretty messy.
