### PR TITLE
Asm.js jitLoopBody slot signed type

### DIFF
--- a/lib/Backend/IRBuilderAsmJs.cpp
+++ b/lib/Backend/IRBuilderAsmJs.cpp
@@ -3334,6 +3334,8 @@ IRBuilderAsmJs::InsertLoopBodyReturnIPInstr(uint targetOffset, uint offset)
 IR::SymOpnd *
 IRBuilderAsmJs::BuildAsmJsLoopBodySlotOpnd(SymID symId, IRType opndType)
 {
+    // There is no unsigned locals, make sure we create only signed locals
+    opndType = IRType_EnsureSigned(opndType);
     // Get the interpreter frame instance that was passed in.
     StackSym *loopParamSym = m_func->EnsureLoopParamSym();
 

--- a/lib/Backend/IRType.cpp
+++ b/lib/Backend/IRType.cpp
@@ -57,6 +57,24 @@ bool IRType_IsSimd128(IRType type)
     return type >= TySimd128F4 && type <= TySimd128D2;
 }
 
+IRType IRType_EnsureSigned(IRType type)
+{
+    if (IRType_IsUnsignedInt(type))
+    {
+        return (IRType)(type - (TyUint8 - TyInt8));
+    }
+    return type;
+}
+
+IRType IRType_EnsureUnsigned(IRType type)
+{
+    if (IRType_IsSignedInt(type))
+    {
+        return (IRType)(type + (TyUint8 - TyInt8));
+    }
+    return type;
+}
+
 #if DBG_DUMP || defined(ENABLE_IR_VIEWER)
 void IRType_Dump(IRType type)
 {

--- a/lib/Backend/IRType.cpp
+++ b/lib/Backend/IRType.cpp
@@ -59,18 +59,30 @@ bool IRType_IsSimd128(IRType type)
 
 IRType IRType_EnsureSigned(IRType type)
 {
+    CompileAssert(TyUint8 > TyInt8);
+    CompileAssert((TyUint8 - TyInt8) == (TyUint16 - TyInt16));
+    CompileAssert((TyUint8 - TyInt8) == (TyUint32 - TyInt32));
+    CompileAssert((TyUint8 - TyInt8) == (TyUint64 - TyInt64));
     if (IRType_IsUnsignedInt(type))
     {
-        return (IRType)(type - (TyUint8 - TyInt8));
+        IRType signedType = (IRType)(type - (TyUint8 - TyInt8));
+        Assert(IRType_IsSignedInt(signedType));
+        return signedType;
     }
     return type;
 }
 
 IRType IRType_EnsureUnsigned(IRType type)
 {
+    CompileAssert(TyUint8 > TyInt8);
+    CompileAssert((TyUint8 - TyInt8) == (TyUint16 - TyInt16));
+    CompileAssert((TyUint8 - TyInt8) == (TyUint32 - TyInt32));
+    CompileAssert((TyUint8 - TyInt8) == (TyUint64 - TyInt64));
     if (IRType_IsSignedInt(type))
     {
-        return (IRType)(type + (TyUint8 - TyInt8));
+        IRType unsignedType = (IRType)(type + (TyUint8 - TyInt8));
+        Assert(IRType_IsUnsignedInt(unsignedType));
+        return unsignedType;
     }
     return type;
 }

--- a/lib/Backend/IRType.h
+++ b/lib/Backend/IRType.h
@@ -32,6 +32,8 @@ extern bool IRType_IsNativeInt(IRType type);
 extern bool IRType_IsInt64(IRType type);
 extern bool IRType_IsSimd(IRType type);
 extern bool IRType_IsSimd128(IRType type);
+extern IRType IRType_EnsureSigned(IRType type);
+extern IRType IRType_EnsureUnsigned(IRType type);
 
 #if DBG_DUMP || defined(ENABLE_IR_VIEWER)
 extern void IRType_Dump(IRType type);

--- a/test/AsmJs/bug9883547.js
+++ b/test/AsmJs/bug9883547.js
@@ -1,0 +1,20 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function AsmModule() {
+  "use asm";
+  function f() {
+    var a = 0, b = 0.0;
+    while((b) == 0.0) {
+      b = +(a>>>0); // First use of a in the loop as a uint32
+      a = 5|0; // def of a in the loop as an int32
+    }
+    return +b;
+  }
+  return f;
+}
+
+var f = AsmModule();
+console.log("PASSED");

--- a/test/AsmJs/rlexe.xml
+++ b/test/AsmJs/rlexe.xml
@@ -845,6 +845,11 @@
   </test>
   <test>
     <default>
+      <files>bug9883547.js</files>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>constFoldTests.js</files>
       <compile-flags>-asmjs -maic:0</compile-flags>
     </default>


### PR DESCRIPTION
Make sure we create loop body slot opnd as signed int.

[VSO bug](https://microsoft.visualstudio.com/OS/_workitems?id=9883547)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/3146)
<!-- Reviewable:end -->
