### PR TITLE
fix invalid assert during property enumeration

### DIFF
--- a/lib/Runtime/Types/DynamicObjectPropertyEnumerator.cpp
+++ b/lib/Runtime/Types/DynamicObjectPropertyEnumerator.cpp
@@ -253,7 +253,7 @@ namespace Js
 
         if (info.GetPropertyString() != nullptr && info.GetPropertyString()->ShouldUseCache())
         {
-            Assert(propertyString == info.GetPropertyString());
+            Assert(info.IsNoCache() || propertyString == info.GetPropertyString());
             CacheOperators::CachePropertyRead(startingObject, this->object, false, propertyId, false, &info, scriptContext);
             if (info.IsStoreFieldCacheEnabled() && info.IsWritable() && ((info.GetFlags() & (InlineCacheGetterFlag | InlineCacheSetterFlag)) == 0))
             {

--- a/lib/Runtime/Types/DynamicObjectPropertyEnumerator.cpp
+++ b/lib/Runtime/Types/DynamicObjectPropertyEnumerator.cpp
@@ -251,9 +251,8 @@ namespace Js
             }
         } while (Js::IsInternalPropertyId(propertyId));
 
-        if (info.GetPropertyString() != nullptr && info.GetPropertyString()->ShouldUseCache())
+        if (info.GetPropertyString() != nullptr && info.GetPropertyString()->ShouldUseCache() && propertyString == info.GetPropertyString())
         {
-            Assert(info.IsNoCache() || propertyString == info.GetPropertyString());
             CacheOperators::CachePropertyRead(startingObject, this->object, false, propertyId, false, &info, scriptContext);
             if (info.IsStoreFieldCacheEnabled() && info.IsWritable() && ((info.GetFlags() & (InlineCacheGetterFlag | InlineCacheSetterFlag)) == 0))
             {

--- a/test/Optimizer/propstrbug.js
+++ b/test/Optimizer/propstrbug.js
@@ -1,0 +1,31 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+//reduced switches: -loopinterpretcount:1 -bgjit- -maxsimplejitruncount:2 -maxinterpretcount:1
+var obj0 = {};
+var protoObj0 = {};
+var obj1 = {};
+var arrObj0 = {};
+var func0 = function () {
+};
+var func2 = function () {
+  '*$*(#!O!\xA5!+%Q\xB4)'.concat((Object.defineProperty(obj0, 'length', { enumerable: true }))).replace().concat().replace();
+};
+obj0.method0 = func2;
+var ui32 = new Uint32Array();
+var IntArr2 = Array();
+var d = 1;
+var protoObj1 = Object();
+obj0.prop1 = -162;
+var id29 = func0(obj0.method0());
+for (var _strvar30 in obj0) {
+  if (!(!IntArr2.unshift(22 * protoObj0.prop0 + arrObj0.prop0, ui32[14 + 1 & 255], protoObj0.length, 908048702 * 1643133174725930000 + -28, ++d, true ? (Object.defineProperty(obj0, 'prop1', {
+      writable: true,
+      enumerable: false,
+      configurable: true
+    }), obj1.length) : obj1.length, typeof protoObj1.prop0 != 'number'))) {
+  }
+}
+print("PASS")

--- a/test/Optimizer/rlexe.xml
+++ b/test/Optimizer/rlexe.xml
@@ -1366,6 +1366,12 @@
   </test>
   <test>
     <default>
+      <files>propstrbug.js</files>
+      <compile-flags>-lic:1 -bgjit- -msjrc:2 -mic:1</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>memop-upperbound.js</files>
       <baseline>memop-upperbound.baseline</baseline>
       <compile-flags>-lic:1 -off:nativearray</compile-flags>


### PR DESCRIPTION
In case cache was disabled, PropertyValueInfo might not have the expected PropertyString. Change assert to ignore this case.

OS: 12327564