### PR TITLE
Asm.js Math builtin cleanup

### DIFF
--- a/lib/Runtime/Language/AsmJs.cpp
+++ b/lib/Runtime/Language/AsmJs.cpp
@@ -139,7 +139,6 @@ namespace Js
         case knopCall: {
             ParseNode* target;
             AsmJsFunctionDeclaration* sym;
-            AsmJsMathFunction* mathSym;
             AsmJsSIMDFunction* simdSym;
 
             target = coercionNode->sxCall.pnodeTarget;
@@ -210,9 +209,8 @@ namespace Js
 
             *coercion = AsmJS_FRound;
             sym = m.LookupFunction(target->name());
-            mathSym = (AsmJsMathFunction*)sym;
 
-            if (!(mathSym && mathSym->GetMathBuiltInFunction() == AsmJSMathBuiltin_fround))
+            if (!AsmJsMathFunction::IsFround(sym))
             {
                 return m.Fail( coercionNode, _u("call must be to fround coercion") );
             }

--- a/lib/Runtime/Language/AsmJsBuiltInNames.h
+++ b/lib/Runtime/Language/AsmJsBuiltInNames.h
@@ -5,15 +5,19 @@
 
 // Default all macros to nothing
 #ifndef ASMJS_MATH_FUNC_NAMES
-#define ASMJS_MATH_FUNC_NAMES(name, propertyName)
+#define ASMJS_MATH_FUNC_NAMES(name, propertyName, funcInfo)
 #endif
 
 #ifndef ASMJS_MATH_CONST_NAMES
-#define ASMJS_MATH_CONST_NAMES(name, propertyName)
+#define ASMJS_MATH_CONST_NAMES(name, propertyName, value)
 #endif
 
 #ifndef ASMJS_ARRAY_NAMES
 #define ASMJS_ARRAY_NAMES(name, propertyName)
+#endif
+
+#ifndef ASMJS_TYPED_ARRAY_NAMES
+#define ASMJS_TYPED_ARRAY_NAMES(name, propertyName) ASMJS_ARRAY_NAMES(name, propertyName)
 #endif
 
 // ASMJS_SIMD_NAMES includes all constructors and operations
@@ -38,45 +42,45 @@
 #define ASMJS_SIMD_MARKERS(name)
 #endif
 
-ASMJS_MATH_FUNC_NAMES(sin,      sin)
-ASMJS_MATH_FUNC_NAMES(cos,      cos)
-ASMJS_MATH_FUNC_NAMES(tan,      tan)
-ASMJS_MATH_FUNC_NAMES(asin,     asin)
-ASMJS_MATH_FUNC_NAMES(acos,     acos)
-ASMJS_MATH_FUNC_NAMES(atan,     atan)
-ASMJS_MATH_FUNC_NAMES(ceil,     ceil)
-ASMJS_MATH_FUNC_NAMES(floor,    floor)
-ASMJS_MATH_FUNC_NAMES(exp,      exp)
-ASMJS_MATH_FUNC_NAMES(log,      log)
-ASMJS_MATH_FUNC_NAMES(pow,      pow)
-ASMJS_MATH_FUNC_NAMES(sqrt,     sqrt)
-ASMJS_MATH_FUNC_NAMES(abs,      abs)
-ASMJS_MATH_FUNC_NAMES(atan2,    atan2)
-ASMJS_MATH_FUNC_NAMES(imul,     imul)
-ASMJS_MATH_FUNC_NAMES(fround,   fround)
-ASMJS_MATH_FUNC_NAMES(min,      min)
-ASMJS_MATH_FUNC_NAMES(max,      max)
-ASMJS_MATH_FUNC_NAMES(clz32,    clz32)
+ASMJS_MATH_FUNC_NAMES(sin,      sin,    Math::EntryInfo::Sin    )
+ASMJS_MATH_FUNC_NAMES(cos,      cos,    Math::EntryInfo::Cos    )
+ASMJS_MATH_FUNC_NAMES(tan,      tan,    Math::EntryInfo::Tan    )
+ASMJS_MATH_FUNC_NAMES(asin,     asin,   Math::EntryInfo::Asin   )
+ASMJS_MATH_FUNC_NAMES(acos,     acos,   Math::EntryInfo::Acos   )
+ASMJS_MATH_FUNC_NAMES(atan,     atan,   Math::EntryInfo::Atan   )
+ASMJS_MATH_FUNC_NAMES(ceil,     ceil,   Math::EntryInfo::Ceil   )
+ASMJS_MATH_FUNC_NAMES(floor,    floor,  Math::EntryInfo::Floor  )
+ASMJS_MATH_FUNC_NAMES(exp,      exp,    Math::EntryInfo::Exp    )
+ASMJS_MATH_FUNC_NAMES(log,      log,    Math::EntryInfo::Log    )
+ASMJS_MATH_FUNC_NAMES(pow,      pow,    Math::EntryInfo::Pow    )
+ASMJS_MATH_FUNC_NAMES(sqrt,     sqrt,   Math::EntryInfo::Sqrt   )
+ASMJS_MATH_FUNC_NAMES(abs,      abs,    Math::EntryInfo::Abs    )
+ASMJS_MATH_FUNC_NAMES(atan2,    atan2,  Math::EntryInfo::Atan2  )
+ASMJS_MATH_FUNC_NAMES(imul,     imul,   Math::EntryInfo::Imul   )
+ASMJS_MATH_FUNC_NAMES(fround,   fround, Math::EntryInfo::Clz32  )
+ASMJS_MATH_FUNC_NAMES(min,      min,    Math::EntryInfo::Min    )
+ASMJS_MATH_FUNC_NAMES(max,      max,    Math::EntryInfo::Max    )
+ASMJS_MATH_FUNC_NAMES(clz32,    clz32,  Math::EntryInfo::Fround )
 
-ASMJS_MATH_CONST_NAMES(e,           E)
-ASMJS_MATH_CONST_NAMES(ln10,        LN10)
-ASMJS_MATH_CONST_NAMES(ln2,         LN2)
-ASMJS_MATH_CONST_NAMES(log2e,       LOG2E)
-ASMJS_MATH_CONST_NAMES(log10e,      LOG10E)
-ASMJS_MATH_CONST_NAMES(pi,          PI)
-ASMJS_MATH_CONST_NAMES(sqrt1_2,     SQRT1_2)
-ASMJS_MATH_CONST_NAMES(sqrt2,       SQRT2)
-ASMJS_MATH_CONST_NAMES(infinity,    Infinity)
-ASMJS_MATH_CONST_NAMES(nan,         NaN)
+ASMJS_MATH_CONST_NAMES(e,        E,        Math::E       )
+ASMJS_MATH_CONST_NAMES(ln10,     LN10,     Math::LN10    )
+ASMJS_MATH_CONST_NAMES(ln2,      LN2,      Math::LN2     )
+ASMJS_MATH_CONST_NAMES(log2e,    LOG2E,    Math::LOG2E   )
+ASMJS_MATH_CONST_NAMES(log10e,   LOG10E,   Math::LOG10E  )
+ASMJS_MATH_CONST_NAMES(pi,       PI,       Math::PI      )
+ASMJS_MATH_CONST_NAMES(sqrt1_2,  SQRT1_2,  Math::SQRT1_2 )
+ASMJS_MATH_CONST_NAMES(sqrt2,    SQRT2,    Math::SQRT2   )
+ASMJS_MATH_CONST_NAMES(infinity, Infinity, 0             )
+ASMJS_MATH_CONST_NAMES(nan,      NaN,      0             )
 
-ASMJS_ARRAY_NAMES(Uint8Array,   Uint8Array)
-ASMJS_ARRAY_NAMES(Int8Array,    Int8Array)
-ASMJS_ARRAY_NAMES(Uint16Array,  Uint16Array)
-ASMJS_ARRAY_NAMES(Int16Array,   Int16Array)
-ASMJS_ARRAY_NAMES(Uint32Array,  Uint32Array)
-ASMJS_ARRAY_NAMES(Int32Array,   Int32Array)
-ASMJS_ARRAY_NAMES(Float32Array, Float32Array)
-ASMJS_ARRAY_NAMES(Float64Array, Float64Array)
+ASMJS_TYPED_ARRAY_NAMES(Uint8Array,   Uint8Array)
+ASMJS_TYPED_ARRAY_NAMES(Int8Array,    Int8Array)
+ASMJS_TYPED_ARRAY_NAMES(Uint16Array,  Uint16Array)
+ASMJS_TYPED_ARRAY_NAMES(Int16Array,   Int16Array)
+ASMJS_TYPED_ARRAY_NAMES(Uint32Array,  Uint32Array)
+ASMJS_TYPED_ARRAY_NAMES(Int32Array,   Int32Array)
+ASMJS_TYPED_ARRAY_NAMES(Float32Array, Float32Array)
+ASMJS_TYPED_ARRAY_NAMES(Float64Array, Float64Array)
 ASMJS_ARRAY_NAMES(byteLength,   byteLength)
 
 // Int32x4
@@ -450,6 +454,7 @@ ASMJS_SIMD_MARKERS(Uint8x16_End) // just a marker
 #undef ASMJS_MATH_FUNC_NAMES
 #undef ASMJS_MATH_CONST_NAMES
 #undef ASMJS_ARRAY_NAMES
+#undef ASMJS_TYPED_ARRAY_NAMES
 #undef ASMJS_SIMD_NAMES
 #undef ASMJS_SIMD_C_NAMES
 #undef ASMJS_SIMD_O_NAMES

--- a/lib/Runtime/Language/AsmJsBuiltInNames.h
+++ b/lib/Runtime/Language/AsmJsBuiltInNames.h
@@ -12,6 +12,10 @@
 #define ASMJS_MATH_CONST_NAMES(name, propertyName, value)
 #endif
 
+#ifndef ASMJS_MATH_DOUBLE_CONST_NAMES
+#define ASMJS_MATH_DOUBLE_CONST_NAMES(name, propertyName, value) ASMJS_MATH_CONST_NAMES(name, propertyName, value)
+#endif
+
 #ifndef ASMJS_ARRAY_NAMES
 #define ASMJS_ARRAY_NAMES(name, propertyName)
 #endif
@@ -57,19 +61,19 @@ ASMJS_MATH_FUNC_NAMES(sqrt,     sqrt,   Math::EntryInfo::Sqrt   )
 ASMJS_MATH_FUNC_NAMES(abs,      abs,    Math::EntryInfo::Abs    )
 ASMJS_MATH_FUNC_NAMES(atan2,    atan2,  Math::EntryInfo::Atan2  )
 ASMJS_MATH_FUNC_NAMES(imul,     imul,   Math::EntryInfo::Imul   )
-ASMJS_MATH_FUNC_NAMES(fround,   fround, Math::EntryInfo::Clz32  )
+ASMJS_MATH_FUNC_NAMES(fround,   fround, Math::EntryInfo::Fround )
 ASMJS_MATH_FUNC_NAMES(min,      min,    Math::EntryInfo::Min    )
 ASMJS_MATH_FUNC_NAMES(max,      max,    Math::EntryInfo::Max    )
-ASMJS_MATH_FUNC_NAMES(clz32,    clz32,  Math::EntryInfo::Fround )
+ASMJS_MATH_FUNC_NAMES(clz32,    clz32,  Math::EntryInfo::Clz32  )
 
-ASMJS_MATH_CONST_NAMES(e,        E,        Math::E       )
-ASMJS_MATH_CONST_NAMES(ln10,     LN10,     Math::LN10    )
-ASMJS_MATH_CONST_NAMES(ln2,      LN2,      Math::LN2     )
-ASMJS_MATH_CONST_NAMES(log2e,    LOG2E,    Math::LOG2E   )
-ASMJS_MATH_CONST_NAMES(log10e,   LOG10E,   Math::LOG10E  )
-ASMJS_MATH_CONST_NAMES(pi,       PI,       Math::PI      )
-ASMJS_MATH_CONST_NAMES(sqrt1_2,  SQRT1_2,  Math::SQRT1_2 )
-ASMJS_MATH_CONST_NAMES(sqrt2,    SQRT2,    Math::SQRT2   )
+ASMJS_MATH_DOUBLE_CONST_NAMES(e,        E,        Math::E       )
+ASMJS_MATH_DOUBLE_CONST_NAMES(ln10,     LN10,     Math::LN10    )
+ASMJS_MATH_DOUBLE_CONST_NAMES(ln2,      LN2,      Math::LN2     )
+ASMJS_MATH_DOUBLE_CONST_NAMES(log2e,    LOG2E,    Math::LOG2E   )
+ASMJS_MATH_DOUBLE_CONST_NAMES(log10e,   LOG10E,   Math::LOG10E  )
+ASMJS_MATH_DOUBLE_CONST_NAMES(pi,       PI,       Math::PI      )
+ASMJS_MATH_DOUBLE_CONST_NAMES(sqrt1_2,  SQRT1_2,  Math::SQRT1_2 )
+ASMJS_MATH_DOUBLE_CONST_NAMES(sqrt2,    SQRT2,    Math::SQRT2   )
 ASMJS_MATH_CONST_NAMES(infinity, Infinity, 0             )
 ASMJS_MATH_CONST_NAMES(nan,      NaN,      0             )
 
@@ -453,6 +457,7 @@ ASMJS_SIMD_MARKERS(Uint8x16_End) // just a marker
 // help the caller to undefine all the macros
 #undef ASMJS_MATH_FUNC_NAMES
 #undef ASMJS_MATH_CONST_NAMES
+#undef ASMJS_MATH_DOUBLE_CONST_NAMES
 #undef ASMJS_ARRAY_NAMES
 #undef ASMJS_TYPED_ARRAY_NAMES
 #undef ASMJS_SIMD_NAMES

--- a/lib/Runtime/Language/AsmJsByteCodeGenerator.h
+++ b/lib/Runtime/Language/AsmJsByteCodeGenerator.h
@@ -83,8 +83,8 @@ namespace Js
         EmitExpressionInfo EmitAssignment( ParseNode * pnode );
         EmitExpressionInfo EmitReturn( ParseNode * pnode );
         EmitExpressionInfo EmitCall( ParseNode * pnode, AsmJsRetType expectedType = AsmJsRetType::Void );
-        EmitExpressionInfo EmitMathBuiltin( ParseNode* pnode, AsmJsMathFunction* mathFunction, AsmJsRetType expectedType );
-        EmitExpressionInfo EmitMinMax(ParseNode* pnode, AsmJsMathFunction* mathFunction, AsmJsRetType expectedType);
+        EmitExpressionInfo EmitMathBuiltin( ParseNode* pnode, AsmJsMathFunction* mathFunction);
+        EmitExpressionInfo EmitMinMax(ParseNode* pnode, AsmJsMathFunction* mathFunction);
         EmitExpressionInfo EmitUnaryPos( ParseNode * pnode );
         EmitExpressionInfo EmitUnaryNeg( ParseNode * pnode );
         EmitExpressionInfo EmitUnaryNot( ParseNode * pnode );
@@ -132,7 +132,6 @@ namespace Js
         void SetModuleSimd(RegSlot dst, RegSlot src, AsmJsVarType type);
         void LoadSimd(RegSlot dst, RegSlot src, AsmJsVarType type);
 
-        bool IsFRound(AsmJsMathFunction* sym);
         bool IsValidSimdFcnRetType(AsmJsSIMDFunction& simdFunction, const AsmJsRetType& expectedType, const AsmJsRetType& retType);
         /// TODO:: Finish removing references to old bytecode generator
         ByteCodeGenerator* GetOldByteCodeGenerator() const

--- a/lib/Runtime/Language/AsmJsLink.cpp
+++ b/lib/Runtime/Language/AsmJsLink.cpp
@@ -58,6 +58,9 @@ namespace Js{
 
     bool ASMLink::CheckStdLib(ScriptContext* scriptContext, const AsmJsModuleInfo* info, const Var stdlib)
     {
+        // We should already prevent implicit calls, but just to be safe in case someone changes that
+        JS_REENTRANCY_LOCK(lock, scriptContext->GetThreadContext());
+
         BVStatic<ASMMATH_BUILTIN_SIZE> mathBuiltinUsed = info->GetAsmMathBuiltinUsed();
         BVStatic<ASMARRAY_BUILTIN_SIZE> arrayBuiltinUsed = info->GetAsmArrayBuiltinUsed();
         BVStatic<ASMSIMD_BUILTIN_SIZE> simdBuiltinUsed = info->GetAsmSimdBuiltinUsed();
@@ -181,70 +184,9 @@ namespace Js{
                 }
             }
             break;
-        case AsmJSTypedArrayBuiltinFunction::AsmJSTypedArrayBuiltin_Int8Array:
-            arrayFuncObj = JavascriptOperators::OP_GetProperty(stdlib, PropertyIds::Int8Array, scriptContext);
-            if (JavascriptFunction::Is(arrayFuncObj))
-            {
-                JavascriptFunction* arrayLibFunc = (JavascriptFunction*)arrayFuncObj;
-                return arrayLibFunc->GetFunctionInfo()->GetOriginalEntryPoint() == (&Int8Array::EntryInfo::NewInstance)->GetOriginalEntryPoint();
-            }
-            break;
-        case AsmJSTypedArrayBuiltinFunction::AsmJSTypedArrayBuiltin_Uint8Array:
-            arrayFuncObj = JavascriptOperators::OP_GetProperty(stdlib, PropertyIds::Uint8Array, scriptContext);
-            if (JavascriptFunction::Is(arrayFuncObj))
-            {
-                JavascriptFunction* arrayLibFunc = (JavascriptFunction*)arrayFuncObj;
-                return arrayLibFunc->GetFunctionInfo()->GetOriginalEntryPoint() == (&Uint8Array::EntryInfo::NewInstance)->GetOriginalEntryPoint();
-            }
-            break;
-        case AsmJSTypedArrayBuiltinFunction::AsmJSTypedArrayBuiltin_Int16Array:
-            arrayFuncObj = JavascriptOperators::OP_GetProperty(stdlib, PropertyIds::Int16Array, scriptContext);
-            if (JavascriptFunction::Is(arrayFuncObj))
-            {
-                JavascriptFunction* arrayLibFunc = (JavascriptFunction*)arrayFuncObj;
-                return arrayLibFunc->GetFunctionInfo()->GetOriginalEntryPoint() == (&Int16Array::EntryInfo::NewInstance)->GetOriginalEntryPoint();
-            }
-            break;
-        case AsmJSTypedArrayBuiltinFunction::AsmJSTypedArrayBuiltin_Uint16Array:
-            arrayFuncObj = JavascriptOperators::OP_GetProperty(stdlib, PropertyIds::Uint16Array, scriptContext);
-            if (JavascriptFunction::Is(arrayFuncObj))
-            {
-                JavascriptFunction* arrayLibFunc = (JavascriptFunction*)arrayFuncObj;
-                return arrayLibFunc->GetFunctionInfo()->GetOriginalEntryPoint() == (&Uint16Array::EntryInfo::NewInstance)->GetOriginalEntryPoint();
-            }
-            break;
-        case AsmJSTypedArrayBuiltinFunction::AsmJSTypedArrayBuiltin_Int32Array:
-            arrayFuncObj = JavascriptOperators::OP_GetProperty(stdlib, PropertyIds::Int32Array, scriptContext);
-            if (JavascriptFunction::Is(arrayFuncObj))
-            {
-                JavascriptFunction* arrayLibFunc = (JavascriptFunction*)arrayFuncObj;
-                return arrayLibFunc->GetFunctionInfo()->GetOriginalEntryPoint() == (&Int32Array::EntryInfo::NewInstance)->GetOriginalEntryPoint();
-            }
-            break;
-        case AsmJSTypedArrayBuiltinFunction::AsmJSTypedArrayBuiltin_Uint32Array:
-            arrayFuncObj = JavascriptOperators::OP_GetProperty(stdlib, PropertyIds::Uint32Array, scriptContext);
-            if (JavascriptFunction::Is(arrayFuncObj))
-            {
-                JavascriptFunction* arrayLibFunc = (JavascriptFunction*)arrayFuncObj;
-                return arrayLibFunc->GetFunctionInfo()->GetOriginalEntryPoint() == (&Uint32Array::EntryInfo::NewInstance)->GetOriginalEntryPoint();
-            }
-            break;
-        case AsmJSTypedArrayBuiltinFunction::AsmJSTypedArrayBuiltin_Float32Array:
-            arrayFuncObj = JavascriptOperators::OP_GetProperty(stdlib, PropertyIds::Float32Array, scriptContext);
-            if (JavascriptFunction::Is(arrayFuncObj))
-            {
-                JavascriptFunction* arrayLibFunc = (JavascriptFunction*)arrayFuncObj;
-                return arrayLibFunc->GetFunctionInfo()->GetOriginalEntryPoint() == (&Float32Array::EntryInfo::NewInstance)->GetOriginalEntryPoint();
-            }
-            break;
-        case AsmJSTypedArrayBuiltinFunction::AsmJSTypedArrayBuiltin_Float64Array:
-            arrayFuncObj = JavascriptOperators::OP_GetProperty(stdlib, PropertyIds::Float64Array, scriptContext);
-            if (JavascriptFunction::Is(arrayFuncObj))
-            {
-                JavascriptFunction* arrayLibFunc = (JavascriptFunction*)arrayFuncObj;
-                return arrayLibFunc->GetFunctionInfo()->GetOriginalEntryPoint() == (&Float64Array::EntryInfo::NewInstance)->GetOriginalEntryPoint();
-            }
-            break;
+#define ASMJS_TYPED_ARRAY_NAMES(name, propertyName) case AsmJSTypedArrayBuiltinFunction::AsmJSTypedArrayBuiltin_##name: \
+            return CheckIsBuiltinFunction(scriptContext, stdlib, PropertyIds::##propertyName, propertyName##::EntryInfo::NewInstance);
+#include "AsmJsBuiltInNames.h"
         default:
             Assume(UNREACHED);
         }
@@ -253,308 +195,14 @@ namespace Js{
 
     bool ASMLink::CheckMathLibraryMethod(ScriptContext* scriptContext, const Var asmMathObject, const AsmJSMathBuiltinFunction mathLibMethod)
     {
-        Var mathFuncObj;
         switch (mathLibMethod)
         {
-        case AsmJSMathBuiltinFunction::AsmJSMathBuiltin_sin:
-            mathFuncObj = JavascriptOperators::OP_GetProperty(asmMathObject, PropertyIds::sin, scriptContext);
-            if (JavascriptFunction::Is(mathFuncObj))
-            {
-                JavascriptFunction* mathLibFunc = (JavascriptFunction*)mathFuncObj;
-                if (mathLibFunc->GetFunctionInfo()->GetOriginalEntryPoint() == (&Math::EntryInfo::Sin)->GetOriginalEntryPoint())
-                {
-                    return true;
-                }
-            }
-            break;
-        case AsmJSMathBuiltinFunction::AsmJSMathBuiltin_cos:
-            mathFuncObj = JavascriptOperators::OP_GetProperty(asmMathObject, PropertyIds::cos, scriptContext);
-            if (JavascriptFunction::Is(mathFuncObj))
-            {
-                JavascriptFunction* mathLibFunc = (JavascriptFunction*)mathFuncObj;
-                if (mathLibFunc->GetFunctionInfo()->GetOriginalEntryPoint() == (&Math::EntryInfo::Cos)->GetOriginalEntryPoint())
-                {
-                    return true;
-                }
-            }
-            break;
-        case AsmJSMathBuiltinFunction::AsmJSMathBuiltin_tan:
-            mathFuncObj = JavascriptOperators::OP_GetProperty(asmMathObject, PropertyIds::tan, scriptContext);
-            if (JavascriptFunction::Is(mathFuncObj))
-            {
-                JavascriptFunction* mathLibFunc = (JavascriptFunction*)mathFuncObj;
-                if (mathLibFunc->GetFunctionInfo()->GetOriginalEntryPoint() == (&Math::EntryInfo::Tan)->GetOriginalEntryPoint())
-                {
-                    return true;
-                }
-            }
-            break;
-        case AsmJSMathBuiltinFunction::AsmJSMathBuiltin_asin:
-            mathFuncObj = JavascriptOperators::OP_GetProperty(asmMathObject, PropertyIds::asin, scriptContext);
-            if (JavascriptFunction::Is(mathFuncObj))
-            {
-                JavascriptFunction* mathLibFunc = (JavascriptFunction*)mathFuncObj;
-                if (mathLibFunc->GetFunctionInfo()->GetOriginalEntryPoint() == (&Math::EntryInfo::Asin)->GetOriginalEntryPoint())
-                {
-                    return true;
-                }
-            }
-            break;
-        case AsmJSMathBuiltinFunction::AsmJSMathBuiltin_acos:
-            mathFuncObj = JavascriptOperators::OP_GetProperty(asmMathObject, PropertyIds::acos, scriptContext);
-            if (JavascriptFunction::Is(mathFuncObj))
-            {
-                JavascriptFunction* mathLibFunc = (JavascriptFunction*)mathFuncObj;
-                if (mathLibFunc->GetFunctionInfo()->GetOriginalEntryPoint() == (&Math::EntryInfo::Acos)->GetOriginalEntryPoint())
-                {
-                    return true;
-                }
-            }
-            break;
-        case AsmJSMathBuiltinFunction::AsmJSMathBuiltin_atan:
-            mathFuncObj = JavascriptOperators::OP_GetProperty(asmMathObject, PropertyIds::atan, scriptContext);
-            if (JavascriptFunction::Is(mathFuncObj))
-            {
-                JavascriptFunction* mathLibFunc = (JavascriptFunction*)mathFuncObj;
-                if (mathLibFunc->GetFunctionInfo()->GetOriginalEntryPoint() == (&Math::EntryInfo::Atan)->GetOriginalEntryPoint())
-                {
-                    return true;
-                }
-            }
-            break;
-        case AsmJSMathBuiltinFunction::AsmJSMathBuiltin_ceil:
-            mathFuncObj = JavascriptOperators::OP_GetProperty(asmMathObject, PropertyIds::ceil, scriptContext);
-            if (JavascriptFunction::Is(mathFuncObj))
-            {
-                JavascriptFunction* mathLibFunc = (JavascriptFunction*)mathFuncObj;
-                if (mathLibFunc->GetFunctionInfo()->GetOriginalEntryPoint() == (&Math::EntryInfo::Ceil)->GetOriginalEntryPoint())
-                {
-                    return true;
-                }
-            }
-            break;
-        case AsmJSMathBuiltinFunction::AsmJSMathBuiltin_floor:
-            mathFuncObj = JavascriptOperators::OP_GetProperty(asmMathObject, PropertyIds::floor, scriptContext);
-            if (JavascriptFunction::Is(mathFuncObj))
-            {
-                JavascriptFunction* mathLibFunc = (JavascriptFunction*)mathFuncObj;
-                if (mathLibFunc->GetFunctionInfo()->GetOriginalEntryPoint() == (&Math::EntryInfo::Floor)->GetOriginalEntryPoint())
-                {
-                    return true;
-                }
-            }
-            break;
-        case AsmJSMathBuiltinFunction::AsmJSMathBuiltin_exp:
-            mathFuncObj = JavascriptOperators::OP_GetProperty(asmMathObject, PropertyIds::exp, scriptContext);
-            if (JavascriptFunction::Is(mathFuncObj))
-            {
-                JavascriptFunction* mathLibFunc = (JavascriptFunction*)mathFuncObj;
-                if (mathLibFunc->GetFunctionInfo()->GetOriginalEntryPoint() == (&Math::EntryInfo::Exp)->GetOriginalEntryPoint())
-                {
-                    return true;
-                }
-            }
-            break;
-        case AsmJSMathBuiltinFunction::AsmJSMathBuiltin_log:
-            mathFuncObj = JavascriptOperators::OP_GetProperty(asmMathObject, PropertyIds::log, scriptContext);
-            if (JavascriptFunction::Is(mathFuncObj))
-            {
-                JavascriptFunction* mathLibFunc = (JavascriptFunction*)mathFuncObj;
-                if (mathLibFunc->GetFunctionInfo()->GetOriginalEntryPoint() == (&Math::EntryInfo::Log)->GetOriginalEntryPoint())
-                {
-                    return true;
-                }
-            }
-            break;
-        case AsmJSMathBuiltinFunction::AsmJSMathBuiltin_pow:
-            mathFuncObj = JavascriptOperators::OP_GetProperty(asmMathObject, PropertyIds::pow, scriptContext);
-            if (JavascriptFunction::Is(mathFuncObj))
-            {
-                JavascriptFunction* mathLibFunc = (JavascriptFunction*)mathFuncObj;
-                if (mathLibFunc->GetFunctionInfo()->GetOriginalEntryPoint() == (&Math::EntryInfo::Pow)->GetOriginalEntryPoint())
-                {
-                    return true;
-                }
-            }
-            break;
-        case AsmJSMathBuiltinFunction::AsmJSMathBuiltin_sqrt:
-            mathFuncObj = JavascriptOperators::OP_GetProperty(asmMathObject, PropertyIds::sqrt, scriptContext);
-            if (JavascriptFunction::Is(mathFuncObj))
-            {
-                JavascriptFunction* mathLibFunc = (JavascriptFunction*)mathFuncObj;
-                if (mathLibFunc->GetFunctionInfo()->GetOriginalEntryPoint() == (&Math::EntryInfo::Sqrt)->GetOriginalEntryPoint())
-                {
-                    return true;
-                }
-            }
-            break;
-        case AsmJSMathBuiltinFunction::AsmJSMathBuiltin_abs:
-            mathFuncObj = JavascriptOperators::OP_GetProperty(asmMathObject, PropertyIds::abs, scriptContext);
-            if (JavascriptFunction::Is(mathFuncObj))
-            {
-                JavascriptFunction* mathLibFunc = (JavascriptFunction*)mathFuncObj;
-                if (mathLibFunc->GetFunctionInfo()->GetOriginalEntryPoint() == (&Math::EntryInfo::Abs)->GetOriginalEntryPoint())
-                {
-                    return true;
-                }
-            }
-            break;
-        case AsmJSMathBuiltinFunction::AsmJSMathBuiltin_atan2:
-            mathFuncObj = JavascriptOperators::OP_GetProperty(asmMathObject, PropertyIds::atan2, scriptContext);
-            if (JavascriptFunction::Is(mathFuncObj))
-            {
-                JavascriptFunction* mathLibFunc = (JavascriptFunction*)mathFuncObj;
-                if (mathLibFunc->GetFunctionInfo()->GetOriginalEntryPoint() == (&Math::EntryInfo::Atan2)->GetOriginalEntryPoint())
-                {
-                    return true;
-                }
-            }
-            break;
-        case AsmJSMathBuiltinFunction::AsmJSMathBuiltin_imul:
-            mathFuncObj = JavascriptOperators::OP_GetProperty(asmMathObject, PropertyIds::imul, scriptContext);
-            if (JavascriptFunction::Is(mathFuncObj))
-            {
-                JavascriptFunction* mathLibFunc = (JavascriptFunction*)mathFuncObj;
-                if (mathLibFunc->GetFunctionInfo()->GetOriginalEntryPoint() == (&Math::EntryInfo::Imul)->GetOriginalEntryPoint())
-                {
-                    return true;
-                }
-            }
-            break;
-        case AsmJSMathBuiltinFunction::AsmJSMathBuiltin_clz32:
-            mathFuncObj = JavascriptOperators::OP_GetProperty(asmMathObject, PropertyIds::clz32, scriptContext);
-            if (JavascriptFunction::Is(mathFuncObj))
-            {
-                JavascriptFunction* mathLibFunc = (JavascriptFunction*)mathFuncObj;
-                if (mathLibFunc->GetFunctionInfo()->GetOriginalEntryPoint() == (&Math::EntryInfo::Clz32)->GetOriginalEntryPoint())
-                {
-                    return true;
-                }
-            }
-            break;
-        case AsmJSMathBuiltinFunction::AsmJSMathBuiltin_min:
-            mathFuncObj = JavascriptOperators::OP_GetProperty(asmMathObject, PropertyIds::min, scriptContext);
-            if (JavascriptFunction::Is(mathFuncObj))
-            {
-                JavascriptFunction* mathLibFunc = (JavascriptFunction*)mathFuncObj;
-                if (mathLibFunc->GetFunctionInfo()->GetOriginalEntryPoint() == (&Math::EntryInfo::Min)->GetOriginalEntryPoint())
-                {
-                    return true;
-                }
-            }
-            break;
-        case AsmJSMathBuiltinFunction::AsmJSMathBuiltin_max:
-            mathFuncObj = JavascriptOperators::OP_GetProperty(asmMathObject, PropertyIds::max, scriptContext);
-            if (JavascriptFunction::Is(mathFuncObj))
-            {
-                JavascriptFunction* mathLibFunc = (JavascriptFunction*)mathFuncObj;
-                if (mathLibFunc->GetFunctionInfo()->GetOriginalEntryPoint() == (&Math::EntryInfo::Max)->GetOriginalEntryPoint())
-                {
-                    return true;
-                }
-            }
-            break;
-
-        case AsmJSMathBuiltinFunction::AsmJSMathBuiltin_fround:
-            mathFuncObj = JavascriptOperators::OP_GetProperty(asmMathObject, PropertyIds::fround, scriptContext);
-            if (JavascriptFunction::Is(mathFuncObj))
-            {
-                JavascriptFunction* mathLibFunc = (JavascriptFunction*)mathFuncObj;
-                if (mathLibFunc->GetFunctionInfo()->GetOriginalEntryPoint() == (&Math::EntryInfo::Fround)->GetOriginalEntryPoint())
-                {
-                    return true;
-                }
-            }
-            break;
-
-        case AsmJSMathBuiltinFunction::AsmJSMathBuiltin_e:
-            mathFuncObj = JavascriptOperators::OP_GetProperty(asmMathObject, PropertyIds::E, scriptContext);
-            if (JavascriptNumber::Is(mathFuncObj))
-            {
-                JavascriptNumber* mathConstNumber = (JavascriptNumber*)mathFuncObj;
-                if (JavascriptNumber::GetValue(mathConstNumber) == (Math::E))
-                {
-                    return true;
-                }
-            }
-            break;
-        case AsmJSMathBuiltinFunction::AsmJSMathBuiltin_ln10:
-            mathFuncObj = JavascriptOperators::OP_GetProperty(asmMathObject, PropertyIds::LN10, scriptContext);
-            if (JavascriptNumber::Is(mathFuncObj))
-            {
-                JavascriptNumber* mathConstNumber = (JavascriptNumber*)mathFuncObj;
-                if (JavascriptNumber::GetValue(mathConstNumber) == (Math::LN10))
-                {
-                    return true;
-                }
-            }
-            break;
-        case AsmJSMathBuiltinFunction::AsmJSMathBuiltin_ln2:
-            mathFuncObj = JavascriptOperators::OP_GetProperty(asmMathObject, PropertyIds::LN2, scriptContext);
-            if (JavascriptNumber::Is(mathFuncObj))
-            {
-                JavascriptNumber* mathConstNumber = (JavascriptNumber*)mathFuncObj;
-                if (JavascriptNumber::GetValue(mathConstNumber) == (Math::LN2))
-                {
-                    return true;
-                }
-            }
-            break;
-        case AsmJSMathBuiltinFunction::AsmJSMathBuiltin_log2e:
-            mathFuncObj = JavascriptOperators::OP_GetProperty(asmMathObject, PropertyIds::LOG2E, scriptContext);
-            if (JavascriptNumber::Is(mathFuncObj))
-            {
-                JavascriptNumber* mathConstNumber = (JavascriptNumber*)mathFuncObj;
-                if (JavascriptNumber::GetValue(mathConstNumber) == (Math::LOG2E))
-                {
-                    return true;
-                }
-            }
-            break;
-        case AsmJSMathBuiltinFunction::AsmJSMathBuiltin_log10e:
-            mathFuncObj = JavascriptOperators::OP_GetProperty(asmMathObject, PropertyIds::LOG10E, scriptContext);
-            if (JavascriptNumber::Is(mathFuncObj))
-            {
-                JavascriptNumber* mathConstNumber = (JavascriptNumber*)mathFuncObj;
-                if (JavascriptNumber::GetValue(mathConstNumber) == (Math::LOG10E))
-                {
-                    return true;
-                }
-            }
-            break;
-        case AsmJSMathBuiltinFunction::AsmJSMathBuiltin_pi:
-            mathFuncObj = JavascriptOperators::OP_GetProperty(asmMathObject, PropertyIds::PI, scriptContext);
-            if (JavascriptNumber::Is(mathFuncObj))
-            {
-                JavascriptNumber* mathConstNumber = (JavascriptNumber*)mathFuncObj;
-                if (JavascriptNumber::GetValue(mathConstNumber) == (Math::PI))
-                {
-                    return true;
-                }
-            }
-            break;
-        case AsmJSMathBuiltinFunction::AsmJSMathBuiltin_sqrt1_2:
-            mathFuncObj = JavascriptOperators::OP_GetProperty(asmMathObject, PropertyIds::SQRT1_2, scriptContext);
-            if (JavascriptNumber::Is(mathFuncObj))
-            {
-                JavascriptNumber* mathConstNumber = (JavascriptNumber*)mathFuncObj;
-                if (JavascriptNumber::GetValue(mathConstNumber) == (Math::SQRT1_2))
-                {
-                    return true;
-                }
-            }
-            break;
-        case AsmJSMathBuiltinFunction::AsmJSMathBuiltin_sqrt2:
-            mathFuncObj = JavascriptOperators::OP_GetProperty(asmMathObject, PropertyIds::SQRT2, scriptContext);
-            if (JavascriptNumber::Is(mathFuncObj))
-            {
-                JavascriptNumber* mathConstNumber = (JavascriptNumber*)mathFuncObj;
-                if (JavascriptNumber::GetValue(mathConstNumber) == (Math::SQRT2))
-                {
-                    return true;
-                }
-            }
-            break;
+#define ASMJS_MATH_FUNC_NAMES(name, propertyName, funcInfo) case AsmJSMathBuiltinFunction::AsmJSMathBuiltin_##name: \
+            return CheckIsBuiltinFunction(scriptContext, asmMathObject, PropertyIds::##propertyName, funcInfo);
+#include "AsmJsBuiltInNames.h"
+#define ASMJS_MATH_CONST_NAMES(name, propertyName, value) case AsmJSMathBuiltinFunction::AsmJSMathBuiltin_##name: \
+            return CheckIsBuiltinValue(scriptContext, asmMathObject, PropertyIds::##propertyName, value);
+#include "AsmJsBuiltInNames.h"
         default:
             Assume(UNREACHED);
         }
@@ -581,7 +229,6 @@ namespace Js{
             } \
             break;
 
-
 #define ASMJS_SIMD_O_NAMES(builtInId, propertyId, libName, entryPoint) \
         case  AsmJsSIMDBuiltinFunction::AsmJsSIMDBuiltin_##builtInId: \
             simdConstructorObj = JavascriptOperators::OP_GetProperty(asmSimdObject, PropertyIds::##libName, scriptContext); \
@@ -597,8 +244,6 @@ namespace Js{
             break;
 #include "AsmJsBuiltinNames.h"
 
-
-
         default:
             Assume(UNREACHED);
         }
@@ -606,8 +251,19 @@ namespace Js{
     }
 #endif
 
+    bool ASMLink::CheckIsBuiltinFunction(ScriptContext* scriptContext, const Var object, PropertyId propertyId, const FunctionInfo& funcInfo)
+    {
+        Var mathFuncObj = JavascriptOperators::OP_GetProperty(object, propertyId, scriptContext);
+        return JavascriptFunction::Is(mathFuncObj) &&
+            JavascriptFunction::FromVar(mathFuncObj)->GetFunctionInfo()->GetOriginalEntryPoint() == funcInfo.GetOriginalEntryPoint();
+    }
 
-
+    bool ASMLink::CheckIsBuiltinValue(ScriptContext* scriptContext, const Var object, PropertyId propertyId, double value)
+    {
+        Var mathValue = JavascriptOperators::OP_GetProperty(object, propertyId, scriptContext);
+        return JavascriptNumber::Is(mathValue) &&
+            JavascriptNumber::GetValue(mathValue) == value;
+    }
 
     bool ASMLink::CheckParams(ScriptContext* scriptContext, AsmJsModuleInfo* info, const Var stdlib, const Var foreign, const Var bufferView)
     {

--- a/lib/Runtime/Language/AsmJsLink.cpp
+++ b/lib/Runtime/Language/AsmJsLink.cpp
@@ -200,7 +200,7 @@ namespace Js{
 #define ASMJS_MATH_FUNC_NAMES(name, propertyName, funcInfo) case AsmJSMathBuiltinFunction::AsmJSMathBuiltin_##name: \
             return CheckIsBuiltinFunction(scriptContext, asmMathObject, PropertyIds::##propertyName, funcInfo);
 #include "AsmJsBuiltInNames.h"
-#define ASMJS_MATH_CONST_NAMES(name, propertyName, value) case AsmJSMathBuiltinFunction::AsmJSMathBuiltin_##name: \
+#define ASMJS_MATH_DOUBLE_CONST_NAMES(name, propertyName, value) case AsmJSMathBuiltinFunction::AsmJSMathBuiltin_##name: \
             return CheckIsBuiltinValue(scriptContext, asmMathObject, PropertyIds::##propertyName, value);
 #include "AsmJsBuiltInNames.h"
         default:

--- a/lib/Runtime/Language/AsmJsLink.h
+++ b/lib/Runtime/Language/AsmJsLink.h
@@ -19,6 +19,8 @@ namespace Js{
 #ifdef ENABLE_SIMDJS
         static bool CheckSimdLibraryMethod(ScriptContext* scriptContext, const Var asmSimdObject, const AsmJsSIMDBuiltinFunction simdBuiltin);
 #endif
+        static bool CheckIsBuiltinFunction(ScriptContext* scriptContext, const Var object, PropertyId propertyId, const FunctionInfo& funcInfo);
+        static bool CheckIsBuiltinValue(ScriptContext* scriptContext, const Var object, PropertyId propertyId, double value);
     };
 }
 #endif

--- a/lib/Runtime/Language/AsmJsTypes.cpp
+++ b/lib/Runtime/Language/AsmJsTypes.cpp
@@ -803,6 +803,11 @@ namespace Js
         return mOverload && mOverload->SupportsMathCall(argCount, args, op, retType);
     }
 
+    bool AsmJsMathFunction::IsFround(AsmJsFunctionDeclaration* sym)
+    {
+        return sym && sym->GetSymbolType() == AsmJsSymbol::MathBuiltinFunction && sym->Cast<AsmJsMathFunction>()->GetMathBuiltInFunction() == AsmJSMathBuiltin_fround;
+    }
+
     WAsmJs::RegisterSpace*
         AllocateRegisterSpace(ArenaAllocator* alloc, WAsmJs::Types type)
     {

--- a/lib/Runtime/Language/AsmJsTypes.h
+++ b/lib/Runtime/Language/AsmJsTypes.h
@@ -100,10 +100,10 @@ namespace Js
     // The asm.js spec recognizes this set of builtin Math functions.
     enum AsmJSMathBuiltinFunction: int
     {
-#define ASMJS_MATH_FUNC_NAMES(name, propertyName) AsmJSMathBuiltin_##name,
+#define ASMJS_MATH_FUNC_NAMES(name, propertyName, funcInfo) AsmJSMathBuiltin_##name,
 #include "AsmJsBuiltInNames.h"
         AsmJSMathBuiltinFunction_COUNT,
-#define ASMJS_MATH_CONST_NAMES(name, propertyName) AsmJSMathBuiltin_##name,
+#define ASMJS_MATH_CONST_NAMES(name, propertyName, value) AsmJSMathBuiltin_##name,
 #include "AsmJsBuiltInNames.h"
         AsmJSMathBuiltin_COUNT
     };
@@ -654,6 +654,7 @@ namespace Js
         AsmJSMathBuiltinFunction GetMathBuiltInFunction(){ return mBuiltIn; };
         virtual bool CheckAndSetReturnType( Js::AsmJsRetType val ) override;
         bool SupportsMathCall(ArgSlot argCount, AsmJsType* args, OpCodeAsmJs& op, AsmJsRetType& retType);
+        static bool IsFround(AsmJsFunctionDeclaration* sym);
     private:
         virtual bool SupportsArgCall(ArgSlot argCount, AsmJsType* args, AsmJsRetType& retType ) override;
 


### PR DESCRIPTION
Fix bad cast to AsmJsMathFunction for Fround check, turns out the check was useless to begin with. Simply forced EmitMathBuiltin fround case to Float type.

All around cleanup of AsmJs MathBuiltin checks 

Fixes #3151

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/3154)
<!-- Reviewable:end -->
