### PR TITLE
OS12095746: Missed ModuleReady callback

### DIFF
--- a/bin/ch/Helpers.cpp
+++ b/bin/ch/Helpers.cpp
@@ -139,7 +139,7 @@ HRESULT Helpers::LoadScriptFromFile(LPCSTR filename, LPCSTR& contents, UINT* len
     //
     if (fopen_s(&file, filename, "rb") != 0)
     {
-        if (!HostConfigFlags::flags.AsyncModuleLoadIsEnabled)
+        if (!HostConfigFlags::flags.MuteHostErrorMsgIsEnabled)
         {
 #ifdef _WIN32
             DWORD lastError = GetLastError();

--- a/bin/ch/HostConfigFlagsList.h
+++ b/bin/ch/HostConfigFlagsList.h
@@ -11,7 +11,9 @@ FLAG(int,  InspectMaxStringLength,          "Max string length to dump in locals
 FLAG(BSTR, Serialized,                      "If source is UTF8, deserializes from bytecode file", NULL)
 FLAG(bool, OOPJIT,                          "Run JIT in a separate process", false)
 FLAG(bool, EnsureCloseJITServer,            "JIT process will be force closed when ch is terminated", true)
-FLAG(bool, AsyncModuleLoad,                 "Silence host error output for module load failures to enable promise testing", false)
+FLAG(bool, IgnoreScriptErrorCode,           "Don't return error code on script error", false)
+FLAG(bool, MuteHostErrorMsg,                "Mute host error output, e.g. module load failures", false)
+FLAG(bool, TraceHostCallback,               "Output traces for host callbacks", false)
 FLAG(bool, $262,                            "load $262 harness", false)
 #undef FLAG
 #endif

--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -2465,7 +2465,10 @@ ParseNodePtr Parser::ParseImport()
     // import()
     if (m_token.tk == tkLParen)
     {
-        return ParseImportCall<buildAST>();
+        ParseNodePtr pnode = ParseImportCall<buildAST>();
+        BOOL fCanAssign;
+        IdentToken token;
+        return ParsePostfixOperators<buildAST>(pnode, TRUE, FALSE, FALSE, &fCanAssign, &token);
     }
 
     m_pscan->SeekTo(parsedImport);
@@ -3260,12 +3263,8 @@ LFunction :
         if (m_scriptContext->GetConfig()->IsES6ModuleEnabled())
         {
             m_pscan->Scan();
-            if (m_token.tk == tkLParen)
-            {
-                return ParseImportCall<buildAST>();
-            }
-
-            Error(ERRnoLparen);
+            ChkCurTokNoScan(tkLParen, ERRnoLparen);
+            pnode = ParseImportCall<buildAST>();
         }
         else
         {

--- a/test/es6/bug_OS12095746.baseline
+++ b/test/es6/bug_OS12095746.baseline
@@ -1,0 +1,6 @@
+NotifyModuleReadyCallback(exception) bug_OS12095746_mod0.js
+NotifyModuleReadyCallback(exception) bug_OS12095746_mod1.js
+mod0 catch:Syntax error
+mod1 catch:Expected ';'
+NotifyModuleReadyCallback(exception) bug_OS12095746_mod2.js
+mod2 catch:Expected ';'

--- a/test/es6/bug_OS12095746.js
+++ b/test/es6/bug_OS12095746.js
@@ -1,0 +1,17 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+import("bug_OS12095746_mod0.js")
+    .then((m)=>{ console.log('mod0 fail'); })
+    .catch((e)=>{ console.log("mod0 catch:"+e.message); });
+
+import('bug_OS12095746_mod1.js')
+    .then((m)=>{ console.log('mod1 fail'); })
+    .catch((e)=>{
+        console.log('mod1 catch:'+e.message);
+        import('bug_OS12095746_mod2.js')
+            .then((m)=>{ print('mod2 fail'); })
+            .catch((e)=>{ print('mod2 catch:'+e.message); });
+        });

--- a/test/es6/bug_OS12095746_mod0.js
+++ b/test/es6/bug_OS12095746_mod0.js
@@ -1,0 +1,7 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+var foo = null;
+export foo;

--- a/test/es6/bug_OS12095746_mod1.js
+++ b/test/es6/bug_OS12095746_mod1.js
@@ -1,0 +1,6 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+import test from "./bug_OS12095746_moddep.js";

--- a/test/es6/bug_OS12095746_mod2.js
+++ b/test/es6/bug_OS12095746_mod2.js
@@ -1,0 +1,6 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+import test from "./bug_OS12095746_moddep.js";

--- a/test/es6/bug_OS12095746_moddep.js
+++ b/test/es6/bug_OS12095746_moddep.js
@@ -1,0 +1,7 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+// Parse error in a dependent module
+1A

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -1286,8 +1286,8 @@
 <test>
   <default>
     <files>await-futreserved-only-in-modules.js</files>
-    <compile-flags>-ES6Module</compile-flags>
-    <tags>exclude_dynapogo,exclude_xplat</tags>
+    <compile-flags>-MuteHostErrorMsg -ES6Module</compile-flags>
+    <tags>exclude_dynapogo, exclude_xplat</tags>
   </default>
 </test>
 <test>
@@ -1307,7 +1307,7 @@
 <test>
     <default>
         <files>module-syntax.js</files>
-        <compile-flags>-ES6Module -args summary -endargs</compile-flags>
+        <compile-flags>-MuteHostErrorMsg -ES6Module -args summary -endargs</compile-flags>
         <tags>exclude_dynapogo,exclude_sanitize_address</tags>
     </default>
 </test>
@@ -1321,7 +1321,7 @@
 <test>
     <default>
         <files>module-functionality.js</files>
-        <compile-flags>-ES6Module -args summary -endargs</compile-flags>
+        <compile-flags>-MuteHostErrorMsg -ES6Module -args summary -endargs</compile-flags>
         <tags>exclude_dynapogo,exclude_sanitize_address</tags>
     </default>
 </test>
@@ -1335,14 +1335,14 @@
 <test>
     <default>
         <files>dynamic-module-import-specifier.js</files>
-        <compile-flags>-AsyncModuleLoad -ES6Module -args summary -endargs</compile-flags>
+        <compile-flags>-MuteHostErrorMsg -ES6Module -args summary -endargs</compile-flags>
         <tags>exclude_sanitize_address</tags>
     </default>
 </test>
 <test>
     <default>
         <files>module-syntax.js</files>
-        <compile-flags>-ES6Module -force:deferparse -args summary -endargs</compile-flags>
+        <compile-flags>-MuteHostErrorMsg -ES6Module -force:deferparse -args summary -endargs</compile-flags>
         <tags>exclude_sanitize_address</tags>
     </default>
 </test>
@@ -1365,6 +1365,14 @@
         <files>module-bugfixes.js</files>
         <compile-flags>-ES6Module -args summary -endargs</compile-flags>
         <tags>exclude_dynapogo,exclude_sanitize_address,bugfix</tags>
+    </default>
+</test>
+<test>
+    <default>
+        <files>bug_OS12095746.js</files>
+        <compile-flags>-MuteHostErrorMsg -IgnoreScriptErrorCode -TraceHostCallback -ES6Module</compile-flags>
+        <tags>exclude_dynapogo,exclude_sanitize_address,bugfix</tags>
+        <baseline>bug_OS12095746.baseline</baseline>
     </default>
 </test>
 <test>


### PR DESCRIPTION
This change addresses three issue:

1) Early error in root module
Chakra fails to call host's ModuleReady callback when it encounters
an early error during parsing of a root module (no parent)
Fix: add 'ModuleReady' notification to ParseSource()

2) Error in dependent module used by a 2nd root module
Error in a dependent module is bubbled up the hierarchy and notified
through the root module (or the dynamically-imported module). The 2nd
encounter of the dependent module referenced by a 2nd root module fails
to trigger a ModuleReady notification to the host
Fix: add checks for dependent modules' errorObject and report failure through HRESULT

3) import("mod.js").then().catch()
This sematic should be supported.
Fix: add parsing for post-fix operators for "import()" code path in parser.
