### PR TITLE
record and stop calling JIT process on failure

### DIFF
--- a/lib/Backend/InterpreterThunkEmitter.cpp
+++ b/lib/Backend/InterpreterThunkEmitter.cpp
@@ -384,7 +384,7 @@ bool InterpreterThunkEmitter::NewOOPJITThunkBlock()
 {
     if (!JITManager::GetJITManager()->IsConnected())
     {
-        Js::Throw::OutOfMemory();
+        return false;
     }
     InterpreterThunkInputIDL thunkInput;
     thunkInput.asmJsThunk = this->isAsmInterpreterThunk;

--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -674,7 +674,6 @@ PHASE(All)
 #define DEFAULT_CONFIG_PerfHintLevel (1)
 #define DEFAULT_CONFIG_OOPJITMissingOpts (true)
 #define DEFAULT_CONFIG_OOPCFGRegistration (true)
-#define DEFAULT_CONFIG_RPCFailFastWait (3000)
 
 #define DEFAULT_CONFIG_FailFastIfDisconnectedDelegate    (false)
 
@@ -1239,7 +1238,6 @@ FLAGNR(Boolean, NoDeferParse          , "Disable deferred parsing", false)
 FLAGNR(Boolean, NoLogo                , "No logo, which we don't display anyways", false)
 FLAGNR(Boolean, OOPJITMissingOpts     , "Use optimizations that are missing from OOP JIT", DEFAULT_CONFIG_OOPJITMissingOpts)
 FLAGNR(Boolean, OOPCFGRegistration    , "Do CFG registration OOP (under OOP JIT)", DEFAULT_CONFIG_OOPCFGRegistration)
-FLAGNR(Number,  RPCFailFastWait       , "Wait time for JIT process termination before triggering failfast on RPC failure", DEFAULT_CONFIG_RPCFailFastWait)
 #ifdef _ARM64_
 FLAGR (Boolean, NoNative              , "Disable native codegen", true)
 #else

--- a/lib/JITClient/JITManager.cpp
+++ b/lib/JITClient/JITManager.cpp
@@ -30,6 +30,7 @@ JITManager::JITManager() :
     m_rpcBindingHandle(nullptr),
     m_oopJitEnabled(false),
     m_isJITServer(false),
+    m_failingHRESULT(S_OK),
     m_serverHandle(nullptr),
     m_jitConnectionId()
 {
@@ -183,7 +184,7 @@ bool
 JITManager::IsConnected() const
 {
     Assert(IsOOPJITEnabled());
-    return m_rpcBindingHandle != nullptr;
+    return m_rpcBindingHandle != nullptr && !HasJITFailed();
 }
 
 HANDLE
@@ -203,6 +204,19 @@ JITManager::EnableOOPJIT()
         // that will disable SetProcessValidCallTargets from being invoked.
         GlobalSecurityPolicy::DisableSetProcessValidCallTargets();
     }
+}
+
+void
+JITManager::SetJITFailed(HRESULT hr)
+{
+    Assert(hr != S_OK);
+    m_failingHRESULT = hr;
+}
+
+bool
+JITManager::HasJITFailed() const
+{
+    return m_failingHRESULT != S_OK;
 }
 
 bool

--- a/lib/JITClient/JITManager.h
+++ b/lib/JITClient/JITManager.h
@@ -28,6 +28,8 @@ public:
     void SetIsJITServer();
     bool IsOOPJITEnabled() const;
     void EnableOOPJIT();
+    void SetJITFailed(HRESULT hr);
+    bool HasJITFailed() const;
 
     HANDLE GetServerHandle() const;
 
@@ -125,6 +127,7 @@ private:
     UUID m_jitConnectionId;
     bool m_oopJitEnabled;
     bool m_isJITServer;
+    HRESULT m_failingHRESULT;
 
     static JITManager s_jitManager;
 
@@ -142,6 +145,7 @@ public:
     void SetIsJITServer() { Assert(false); }
     bool IsOOPJITEnabled() const { return false; }
     void EnableOOPJIT() { Assert(false); }
+    void SetJITFailed(HRESULT hr) { Assert(false); }
 
     HANDLE GetServerHandle() const
     {

--- a/lib/Runtime/Base/ThreadContext.h
+++ b/lib/Runtime/Base/ThreadContext.h
@@ -1062,7 +1062,7 @@ public:
             jobProcessor->Close();
         }
 
-        if (JITManager::GetJITManager()->IsOOPJITEnabled() && m_remoteThreadContextInfo)
+        if (JITManager::GetJITManager()->IsOOPJITEnabled() && JITManager::GetJITManager()->IsConnected() && m_remoteThreadContextInfo)
         {
             if (JITManager::GetJITManager()->CleanupThreadContext(&m_remoteThreadContextInfo) == S_OK)
             {


### PR DESCRIPTION
Resolves a failfast that sometimes hits in case JIT process crashed but postmortem debugger is still collecting dump.
Also, recording the failure allows someone debugging runtime process to know if JIT process is gone.