### PR TITLE
Add event tracing function in test build

### DIFF
--- a/bin/ch/DbgController.js
+++ b/bin/ch/DbgController.js
@@ -66,6 +66,7 @@ var controllerObj = (function () {
             "ArrayBuffer",
             "Atomics",
             "Boolean",
+            "chWriteTraceEvent",
             "CollectGarbage",
             "console",
             "DataView",

--- a/lib/Runtime/Library/GlobalObject.cpp
+++ b/lib/Runtime/Library/GlobalObject.cpp
@@ -1598,6 +1598,23 @@ LHexError:
         return scriptContext->GetLibrary()->GetUndefined();
     }
 
+#ifdef ENABLE_DEBUG_CONFIG_OPTIONS
+    Var GlobalObject::EntryChWriteTraceEvent(RecyclableObject *function, CallInfo callInfo, ...)
+    {
+        PROBE_STACK(function->GetScriptContext(), Js::Constants::MinStackDefault);
+        ARGUMENTS(args, callInfo);
+
+        if (args.Info.Count < 2)
+        {
+            return function->GetScriptContext()->GetLibrary()->GetUndefined();
+        }
+
+        Js::JavascriptString* jsString = Js::JavascriptConversion::ToString(args[1], function->GetScriptContext());
+        PlatformAgnostic::EventTrace::FireGenericEventTrace(jsString->GetSz());
+        return function->GetScriptContext()->GetLibrary()->GetUndefined();
+    }
+#endif
+
 #if ENABLE_TTD
     //Log a string in the telemetry system (and print to the console)
     Var GlobalObject::EntryTelemetryLog(RecyclableObject* function, CallInfo callInfo, ...)

--- a/lib/Runtime/Library/GlobalObject.h
+++ b/lib/Runtime/Library/GlobalObject.h
@@ -58,6 +58,10 @@ namespace Js
             static FunctionInfo EmitTTDLog;
 #endif
 
+#ifdef ENABLE_DEBUG_CONFIG_OPTIONS
+            static FunctionInfo ChWriteTraceEvent;
+#endif
+
 #ifdef IR_VIEWER
             static FunctionInfo ParseIR;
             static FunctionInfo FunctionList;
@@ -85,6 +89,10 @@ namespace Js
 
         static Var EntryEnabledDiagnosticsTrace(RecyclableObject* function, CallInfo callInfo, ...);
         static Var EntryEmitTTDLog(RecyclableObject* function, CallInfo callInfo, ...);
+#endif
+
+#ifdef ENABLE_DEBUG_CONFIG_OPTIONS
+        static Var EntryChWriteTraceEvent(RecyclableObject* function, CallInfo callInfo, ...);
 #endif
 
 #ifdef IR_VIEWER

--- a/lib/Runtime/Library/JavascriptBuiltInFunctionList.h
+++ b/lib/Runtime/Library/JavascriptBuiltInFunctionList.h
@@ -30,6 +30,10 @@ BUILTIN(GlobalObject, EnabledDiagnosticsTrace, EntryEnabledDiagnosticsTrace, Fun
 BUILTIN(GlobalObject, EmitTTDLog, EntryEmitTTDLog, FunctionInfo::ErrorOnNew)
 #endif
 
+#ifdef ENABLE_DEBUG_CONFIG_OPTIONS
+BUILTIN(GlobalObject, ChWriteTraceEvent, EntryChWriteTraceEvent, FunctionInfo::ErrorOnNew)
+#endif
+
 #ifdef IR_VIEWER
     BUILTIN(GlobalObject, ParseIR, EntryParseIR, FunctionInfo::ErrorOnNew)
     BUILTIN(GlobalObject, FunctionList, EntryFunctionList, FunctionInfo::ErrorOnNew)

--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -1266,6 +1266,9 @@ namespace Js
             AddFunctionToLibraryObjectWithPropertyName(globalObject, _u("emitTTDLog"), &GlobalObject::EntryInfo::EmitTTDLog, 2);
         }
 #endif
+#ifdef ENABLE_DEBUG_CONFIG_OPTIONS
+        AddFunctionToLibraryObjectWithPropertyName(globalObject, _u("chWriteTraceEvent"), &GlobalObject::EntryInfo::ChWriteTraceEvent, 1);
+#endif
 
 #ifdef IR_VIEWER
         if (Js::Configuration::Global.flags.IsEnabled(Js::IRViewerFlag))

--- a/lib/Runtime/PlatformAgnostic/Chakra.Runtime.PlatformAgnostic.vcxproj
+++ b/lib/Runtime/PlatformAgnostic/Chakra.Runtime.PlatformAgnostic.vcxproj
@@ -47,11 +47,12 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)Platform\Windows\NumbersUtility.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)Platform\Windows\SystemInfo.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)Platform\Windows\Thread.cpp" />
-
     <ClCompile Include="$(MSBuildThisFileDirectory)Platform\Common\UnicodeText.Common.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)Platform\Windows\EventTrace.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ChakraPlatform.h" />
+    <ClInclude Include="EventTrace.h" />
     <ClInclude Include="RuntimePlatformAgnosticPch.h" />
     <ClInclude Include="UnicodeText.h" />
   </ItemGroup>

--- a/lib/Runtime/PlatformAgnostic/Chakra.Runtime.PlatformAgnostic.vcxproj.filters
+++ b/lib/Runtime/PlatformAgnostic/Chakra.Runtime.PlatformAgnostic.vcxproj.filters
@@ -4,6 +4,9 @@
     <ClCompile Include="Platform\Windows\UnicodeText.cpp">
       <Filter>Platform\Windows</Filter>
     </ClCompile>
+    <ClCompile Include="Platform\Windows\EventTrace.cpp">
+      <Filter>Platform\Windows</Filter>
+    </ClCompile>
     <ClCompile Include="Platform\Windows\DaylightHelper.cpp">
       <Filter>Platform\Windows</Filter>
     </ClCompile>
@@ -39,5 +42,8 @@
     </ClInclude>
     <ClInclude Include="ChakraPlatform.h" />
     <ClInclude Include="RuntimePlatformAgnosticPch.h" />
+    <ClInclude Include="EventTrace.h">
+      <Filter>Interfaces</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/lib/Runtime/PlatformAgnostic/EventTrace.h
+++ b/lib/Runtime/PlatformAgnostic/EventTrace.h
@@ -4,12 +4,12 @@
 //-------------------------------------------------------------------------------------------------------
 #pragma once
 
-#include "UnicodeText.h"
-#include "EventTrace.h"
+#include "Core/CommonTypedefs.h"
 
-#include "PlatformAgnostic/DateTime.h"
-#include "PlatformAgnostic/AssemblyCommon.h"
-
-#if !defined(_WIN32) && defined(DEBUG)
-#include <signal.h> // raise(SIGINT)
-#endif
+namespace PlatformAgnostic
+{
+    namespace EventTrace
+    {
+        void FireGenericEventTrace(const void* traceData);
+    }
+}

--- a/lib/Runtime/PlatformAgnostic/Platform/CMakeLists.txt
+++ b/lib/Runtime/PlatformAgnostic/Platform/CMakeLists.txt
@@ -3,6 +3,7 @@ project(CHAKRA_PLATFORM_AGNOSTIC)
 set(PL_SOURCE_FILES
   Common/UnicodeText.Common.cpp
   Common/HiResTimer.cpp
+  Linux/EventTrace.cpp
   Linux/UnicodeText.ICU.cpp
   Linux/NumbersUtility.cpp
   Linux/Thread.cpp

--- a/lib/Runtime/PlatformAgnostic/Platform/Linux/EventTrace.cpp
+++ b/lib/Runtime/PlatformAgnostic/Platform/Linux/EventTrace.cpp
@@ -2,14 +2,17 @@
 // Copyright (C) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
-#pragma once
 
-#include "UnicodeText.h"
-#include "EventTrace.h"
+#include "RuntimePlatformAgnosticPch.h"
+#include "CommonPal.h"
 
-#include "PlatformAgnostic/DateTime.h"
-#include "PlatformAgnostic/AssemblyCommon.h"
-
-#if !defined(_WIN32) && defined(DEBUG)
-#include <signal.h> // raise(SIGINT)
-#endif
+namespace PlatformAgnostic
+{
+    namespace EventTrace
+    {
+        void FireGenericEventTrace(const void* /*traceData*/)
+        {
+            // TODO: Implement this on Linux
+        }
+    } // namespace EventTrace
+} // namespace PlatformAgnostic

--- a/lib/Runtime/PlatformAgnostic/Platform/Windows/EventTrace.cpp
+++ b/lib/Runtime/PlatformAgnostic/Platform/Windows/EventTrace.cpp
@@ -2,14 +2,18 @@
 // Copyright (C) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
-#pragma once
 
-#include "UnicodeText.h"
-#include "EventTrace.h"
+#include "RuntimePlatformAgnosticPch.h"
+#include "Common.h"
+#include "ChakraPlatform.h"
 
-#include "PlatformAgnostic/DateTime.h"
-#include "PlatformAgnostic/AssemblyCommon.h"
-
-#if !defined(_WIN32) && defined(DEBUG)
-#include <signal.h> // raise(SIGINT)
-#endif
+namespace PlatformAgnostic
+{
+    namespace EventTrace
+    {
+        void FireGenericEventTrace(const void* traceData)
+        {
+            JS_ETW(EventWriteJSCRIPT_INTERNAL_GENERIC_EVENT(static_cast<const char16*>(traceData)));
+        }
+    }
+}

--- a/manifests/Microsoft-Scripting-Chakra-Instrumentation.man
+++ b/manifests/Microsoft-Scripting-Chakra-Instrumentation.man
@@ -136,6 +136,11 @@
                     name="MemProtectHeapSize"
                     symbol="MEMPROTECT_HEAP_SIZE_KEYWORD"
                     />
+                <keyword
+                    mask="0x1000000"
+                    name="Internal"
+                    symbol="INTERNAL_KEYWORD"
+                    />
             </keywords>
             <tasks>
                 <task
@@ -927,6 +932,11 @@
                     eventGUID="{09fdd3c1-a5f7-4b7f-aabc-6eecc4e30309}"
                     name="Memprotect_GC_Heap_Size"
                     value="107"
+                    />
+                <task
+                    eventGUID="{7aabacec-6052-4f52-9aae-10fd5b5bfc0c}"
+                    name="Jscript_Internal_Generic_Event"
+                    value="108"
                     />
             </tasks>
             <maps>
@@ -1886,6 +1896,12 @@
                 <data
                     inType="win:Boolean"
                     name="FromGC"
+                    />
+                </template>
+                <template tid="InternalGenericEvent">
+                <data
+                    inType="win:UnicodeString"
+                    name="eventData"
                     />
                 </template>
             </templates>
@@ -3840,6 +3856,14 @@
                     task="Memprotect_GC_Heap_Size"
                     template="MemprotectHeap"
                     value="241"
+                    />
+                <event
+                    keywords="Internal"
+                    opcode="win:Info"
+                    symbol="JSCRIPT_INTERNAL_GENERIC_EVENT"
+                    task="Jscript_Internal_Generic_Event"
+                    template="InternalGenericEvent"
+                    value="242"
                     />
             </events>
             </provider>


### PR DESCRIPTION
This commit introduces a global function chWriteTraceEvent. This function is analogous to msWriteProfilerMark in IE/Edge- however, it's only exposed in debug and test builds of Chakra. It's intention is for use in perf investigations.

The code to that actually fires the ETW event is in PlatformAgnostic. Currently it behaves as a no-op on Linux but it's intended to be filled out once we choose a tracing mechanism for Linux.
