### PR TITLE
Fix MOVSXD encoding for exception filter

### DIFF
--- a/lib/Runtime/Library/JavascriptFunction.cpp
+++ b/lib/Runtime/Library/JavascriptFunction.cpp
@@ -1918,6 +1918,8 @@ LABEL1:
             instrData.isLoad = false;
             break;
         }
+        //MOVSXD
+        case 0x63:
         //MOV - Load
         case 0x8A:
         case 0x8B:
@@ -1930,7 +1932,7 @@ LABEL1:
         {
             // more than one byte opcode and hence we will read pc multiple times
             pc++;
-            //MOVSX  , MOVSXD
+            //MOVSX
             if (*pc == 0xBE || *pc == 0xBF)
             {
                 instrData.isLoad = true;

--- a/test/WasmSpec/baselines/memory_trap.baseline
+++ b/test/WasmSpec/baselines/memory_trap.baseline
@@ -1,0 +1,1 @@
+173/173 tests passed.

--- a/test/WasmSpec/convert-test-suite/index.js
+++ b/test/WasmSpec/convert-test-suite/index.js
@@ -28,7 +28,6 @@ const argv = require("yargs")
       alias: "e",
       description: "Spec tests to exclude from the conversion (use for known failures)",
       default: [
-        "memory_trap",
         "traps",
       ]
     },

--- a/test/WasmSpec/rlexe.xml
+++ b/test/WasmSpec/rlexe.xml
@@ -711,6 +711,22 @@
   <test>
     <default>
       <files>spec.js</files>
+      <baseline>baselines/memory_trap.baseline</baseline>
+      <compile-flags>-wasm -args testsuite/core/memory_trap.wast -endargs</compile-flags>
+      <tags>exclude_xplat</tags>
+    </default>
+  </test>
+  <test>
+    <default>
+      <files>spec.js</files>
+      <baseline>baselines/memory_trap.baseline</baseline>
+      <compile-flags>-wasm -args testsuite/core/memory_trap.wast -endargs -nonative</compile-flags>
+      <tags>exclude_dynapogo,exclude_xplat</tags>
+    </default>
+  </test>
+  <test>
+    <default>
+      <files>spec.js</files>
       <baseline>baselines/names.baseline</baseline>
       <compile-flags>-wasm -args testsuite/core/names.wast -endargs</compile-flags>
       <tags>exclude_xplat</tags>


### PR DESCRIPTION
We were incorrectly reading the opcode for MOVSXD causing the AV in virtual memory to escape instead of throwing a WebAssembly runtime exception.
Since the AV occurs in the 8GB array, it is not a security concern.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/3171)
<!-- Reviewable:end -->
