### PR TITLE
fix etw logging for very long name function loop body

### DIFF
--- a/lib/Runtime/Base/EtwTrace.cpp
+++ b/lib/Runtime/Base/EtwTrace.cpp
@@ -192,11 +192,11 @@ void EtwTrace::PerformRundown(bool start)
                             {
                                 if (start)
                                 {
-                                    LogLoopBodyEventBG(EventWriteMethodDCStart, body, header, entryPoint, ((uint16)body->GetLoopNumberWithLock(header)));
+                                    LogLoopBodyEvent(EventWriteMethodDCStart, body, entryPoint, ((uint16)body->GetLoopNumberWithLock(header)));
                                 }
                                 else
                                 {
-                                    LogLoopBodyEventBG(EventWriteMethodDCEnd, body, header, entryPoint, ((uint16)body->GetLoopNumberWithLock(header)));
+                                    LogLoopBodyEvent(EventWriteMethodDCEnd, body, entryPoint, ((uint16)body->GetLoopNumberWithLock(header)));
                                 }
                             }
                         });
@@ -288,10 +288,10 @@ void EtwTrace::LogMethodNativeLoadEvent(FunctionBody* body, FunctionEntryPointIn
 #endif
 }
 
-void EtwTrace::LogLoopBodyLoadEvent(FunctionBody* body, LoopHeader* loopHeader, LoopEntryPointInfo* entryPoint, uint16 loopNumber)
+void EtwTrace::LogLoopBodyLoadEvent(FunctionBody* body, LoopEntryPointInfo* entryPoint, uint16 loopNumber)
 {
 #if ENABLE_NATIVE_CODEGEN
-    LogLoopBodyEventBG(EventWriteMethodLoad, body, loopHeader, entryPoint, loopNumber);
+    LogLoopBodyEvent(EventWriteMethodLoad, body, entryPoint, loopNumber);
 #else
     Assert(false); // Caller should not be enabled if JIT is disabled
 #endif
@@ -316,10 +316,10 @@ void EtwTrace::LogMethodNativeUnloadEvent(FunctionBody* body, FunctionEntryPoint
 #endif
 }
 
-void EtwTrace::LogLoopBodyUnloadEvent(FunctionBody* body, LoopHeader* loopHeader, LoopEntryPointInfo* entryPoint)
+void EtwTrace::LogLoopBodyUnloadEvent(FunctionBody* body, LoopEntryPointInfo* entryPoint, uint loopNumber)
 {
 #if ENABLE_NATIVE_CODEGEN
-    LogLoopBodyEvent(EventWriteMethodUnload, body, loopHeader, entryPoint);
+    LogLoopBodyEvent(EventWriteMethodUnload, body, entryPoint, loopNumber);
 #else
 Assert(false); // Caller should not be enabled if JIT is disabled
 #endif

--- a/lib/Runtime/Base/EtwTrace.h
+++ b/lib/Runtime/Base/EtwTrace.h
@@ -165,53 +165,8 @@ enum MethodType : uint16
     Body->GetColumnNumber(),                                 \
     GetFunctionName(Body))
 
-#define LogLoopBodyEvent(Function, Body, loopHeader, entryPoint)                                           \
-    Assert(entryPoint->GetNativeAddress() != NULL);                                                        \
-    Assert(entryPoint->GetCodeSize() > 0);                                                                 \
-    WCHAR loopBodyNameArray[NameBufferLength];                                                             \
-    WCHAR* loopBodyName = loopBodyNameArray;                                                               \
-    size_t bufferSize = GetLoopBodyName(Body, loopHeader, loopBodyName, NameBufferLength);                 \
-    if(bufferSize > NameBufferLength) /* insufficient buffer space*/                                       \
-    {                                                                                                      \
-        loopBodyName = HeapNewNoThrowArray(WCHAR, bufferSize);                                             \
-        if(loopBodyName)                                                                                   \
-        {                                                                                                  \
-            GetLoopBodyName(Body, loopHeader, loopBodyName, bufferSize);                                   \
-        }                                                                                                  \
-        else                                                                                               \
-        {                                                                                                  \
-            loopBodyNameArray[0] = _u('\0');                                                               \
-            loopBodyName = loopBodyNameArray;                                                              \
-        }                                                                                                  \
-    }                                                                                                      \
-    JS_ETW(Function(Body->GetScriptContext(),                                                              \
-        (void *)entryPoint->GetNativeAddress(),                                                            \
-        entryPoint->GetCodeSize(),                                                                         \
-        GetFunctionId(Body),                                                                               \
-        0 /* methodFlags - for future use*/,                                                               \
-        MethodType_LoopBody + (uint16)Body->GetLoopNumber(loopHeader),                                     \
-        GetSourceId(Body),                                                                                 \
-        /*line*/ 0,                                                                                        \
-        /*column*/ 0,                                                                                      \
-        loopBodyName));                                                                                    \
-   WriteMethodEvent(STRINGIZEW(Function),                                                                  \
-        Body->GetScriptContext(),                                                                          \
-        (void *)entryPoint->GetNativeAddress(),                                                            \
-        entryPoint->GetCodeSize(),                                                                         \
-        GetFunctionId(Body),                                                                               \
-        0 /* methodFlags - for future use*/,                                                               \
-        MethodType_LoopBody + (uint16)Body->GetLoopNumber(loopHeader),                                     \
-        GetSourceId(Body),                                                                                 \
-        /*line*/ 0,                                                                                        \
-        /*column*/ 0,                                                                                      \
-        loopBodyName);                                                                                     \
-    if(loopBodyNameArray != loopBodyName)                                                                  \
-    {                                                                                                      \
-        HeapDeleteArray(bufferSize, loopBodyName);                                                         \
-    }
 
-
-#define LogLoopBodyEventBG(Function, Body, loopHeader, entryPoint, loopNumber)                             \
+#define LogLoopBodyEvent(Function, Body, entryPoint, loopNumber)                                           \
     Assert(entryPoint->GetNativeAddress() != NULL);                                                        \
     Assert(entryPoint->GetCodeSize() > 0);                                                                 \
     WCHAR loopBodyNameArray[NameBufferLength];                                                             \
@@ -222,7 +177,7 @@ enum MethodType : uint16
         loopBodyName = HeapNewNoThrowArray(WCHAR, bufferSize);                                             \
         if(loopBodyName)                                                                                   \
         {                                                                                                  \
-            GetLoopBodyName(Body, loopHeader, loopBodyName, bufferSize);                                   \
+            Body->GetLoopBodyName(loopNumber, loopBodyName, NameBufferLength);                             \
         }                                                                                                  \
         else                                                                                               \
         {                                                                                                  \
@@ -274,14 +229,14 @@ public:
     static void LogSourceUnloadEvents(Js::ScriptContext* scriptContext);
     static void LogMethodNativeUnloadEvent(Js::FunctionBody* body, Js::FunctionEntryPointInfo* entryPoint);
     static void LogMethodInterpreterThunkUnloadEvent(Js::FunctionBody* body);
-    static void LogLoopBodyUnloadEvent(Js::FunctionBody* body, Js::LoopHeader* loopHeader, Js::LoopEntryPointInfo* entryPoint);
+    static void LogLoopBodyUnloadEvent(Js::FunctionBody* body, Js::LoopEntryPointInfo* entryPoint, uint loopNumber);
 
     /* Load events */
     static void LogMethodInterpreterThunkLoadEvent(Js::FunctionBody* body);
     static void LogMethodNativeLoadEvent(Js::FunctionBody* body, Js::FunctionEntryPointInfo* entryPoint);
 
 
-    static void LogLoopBodyLoadEvent(Js::FunctionBody* body, Js::LoopHeader* loopHeader, Js::LoopEntryPointInfo* entryPoint, uint16 loopNumber);
+    static void LogLoopBodyLoadEvent(Js::FunctionBody* body, Js::LoopEntryPointInfo* entryPoint, uint16 loopNumber);
     static void LogScriptContextLoadEvent(Js::ScriptContext* scriptContext);
     static void LogSourceModuleLoadEvent(Js::ScriptContext* scriptContext, DWORD_PTR sourceContext, _In_z_ const char16* url);
 

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -3835,9 +3835,9 @@ namespace Js
         {
             loopHeader->interpretCount = entryPointInfo->GetFunctionBody()->GetLoopInterpretCount(loopHeader) - 1;
         }
-        JS_ETW(EtwTrace::LogLoopBodyLoadEvent(this, loopHeader, ((LoopEntryPointInfo*)entryPointInfo), ((uint16)loopNum)));
+        JS_ETW(EtwTrace::LogLoopBodyLoadEvent(this, ((LoopEntryPointInfo*)entryPointInfo), ((uint16)loopNum)));
 #ifdef VTUNE_PROFILING
-        VTuneChakraProfile::LogLoopBodyLoadEvent(this, loopHeader, ((LoopEntryPointInfo*)entryPointInfo), ((uint16)loopNum));
+        VTuneChakraProfile::LogLoopBodyLoadEvent(this, ((LoopEntryPointInfo*)entryPointInfo), ((uint16)loopNum));
 #endif
     }
 #endif
@@ -9990,7 +9990,8 @@ namespace Js
         if (this->IsCodeGenDone())
 #endif
         {
-            JS_ETW(EtwTrace::LogLoopBodyUnloadEvent(this->loopHeader->functionBody, this->loopHeader, this));
+            uint loopNumber = this->loopHeader->functionBody->GetLoopNumber(this->loopHeader);
+            JS_ETW(EtwTrace::LogLoopBodyUnloadEvent(this->loopHeader->functionBody, this, loopNumber));
 
 #if ENABLE_NATIVE_CODEGEN
             if (nullptr != this->inlineeFrameMap)

--- a/lib/Runtime/Base/VTuneChakraProfile.cpp
+++ b/lib/Runtime/Base/VTuneChakraProfile.cpp
@@ -116,7 +116,7 @@ void VTuneChakraProfile::LogMethodNativeLoadEvent(Js::FunctionBody* body, Js::Fu
 //
 // Log loop body load event to VTune 
 //
-void VTuneChakraProfile::LogLoopBodyLoadEvent(Js::FunctionBody* body, Js::LoopHeader* loopHeader, Js::LoopEntryPointInfo* entryPoint, uint16 loopNumber)
+void VTuneChakraProfile::LogLoopBodyLoadEvent(Js::FunctionBody* body, Js::LoopEntryPointInfo* entryPoint, uint16 loopNumber)
 {
 #if ENABLE_NATIVE_CODEGEN
     if (isJitProfilingActive)

--- a/lib/Runtime/Base/VTuneChakraProfile.h
+++ b/lib/Runtime/Base/VTuneChakraProfile.h
@@ -16,7 +16,7 @@ public:
     static void UnRegister();
 
     static void LogMethodNativeLoadEvent(Js::FunctionBody* body, Js::FunctionEntryPointInfo* entryPoint);
-    static void LogLoopBodyLoadEvent(Js::FunctionBody* body, Js::LoopHeader* loopHeader, Js::LoopEntryPointInfo* entryPoint, uint16 loopNumber);
+    static void LogLoopBodyLoadEvent(Js::FunctionBody* body, Js::LoopEntryPointInfo* entryPoint, uint16 loopNumber);
 
     static const utf8char_t DynamicCode[];
     static bool isJitProfilingActive;


### PR DESCRIPTION
if a function has very long name(longer than 256), we calculate the loop body name from a loop number, the loop number is calculated from loop header, which is not necessary because after loop body code gen we already know the loop number. while calculating the loop number we access auxPtrs to get the loop header array in background thread, which is not allowed after JIT on the function is started.

the fix is to just not calculate the loop number again.
