### PR TITLE
WASM: 8GB array oob error message

### DIFF
--- a/lib/Runtime/Library/JavascriptFunction.cpp
+++ b/lib/Runtime/Library/JavascriptFunction.cpp
@@ -2289,7 +2289,7 @@ LABEL1:
         }
         else if (isWasmOnly)
         {
-            JavascriptError::ThrowWebAssemblyRuntimeError(func->GetScriptContext(), JSERR_InvalidTypedArrayIndex);
+            JavascriptError::ThrowWebAssemblyRuntimeError(func->GetScriptContext(), WASMERR_ArrayIndexOutOfRange);
         }
 
         // SIMD loads/stores do bounds checks.


### PR DESCRIPTION
Use the same error message for array access out of bounds in jit as in interpreter

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/3174)
<!-- Reviewable:end -->
