### PR TITLE
Fixing environment variable parsing in PAL

### DIFF
--- a/pal/src/cruntime/misc.cpp
+++ b/pal/src/cruntime/misc.cpp
@@ -360,7 +360,7 @@ char *MiscGetenv(const char *name)
     {
         for(i = 0; palEnvironment[i] != NULL; i++)
         {
-            if (compare(palEnvironment[i], name, &length) == 0)
+            if (compare(name, palEnvironment[i], &length) == 0)
             {
                 equals = palEnvironment[i] + length;
                 if (*equals == '\0')


### PR DESCRIPTION
The `compare` function used in `MiscGetenv` checks if the first argument
is a prefix of the second argument, but `MiscGetenv` was passing the longer
argument (e.g. "HOME=/users/foo") first, meaning that it would never
find any environment variable.