### PR TITLE
xplat: fix ICU lib tilde path problem

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -184,7 +184,8 @@ while [[ $# -gt 0 ]]; do
 
     --icu=*)
         ICU_PATH=$1
-        ICU_PATH="${ICU_PATH:6}"
+        # resolve tilde on path
+        eval ICU_PATH="${ICU_PATH:6}"
         if [[ ! -d ${ICU_PATH} ]]; then
             if [[ -d "${CHAKRACORE_DIR}/${ICU_PATH}" ]]; then
                 ICU_PATH="${CHAKRACORE_DIR}/${ICU_PATH}"


### PR DESCRIPTION
Bash doesn't auto expand tilde on the path hence directory exists condition fails