### PR TITLE
Adding the ability to dump perf.map files on non-windows systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -388,9 +388,14 @@ else()
 endif()
 
 if(WITHOUT_FEATURES_SH)
-    unset(WITHOUT_FEATURES_SH CACHE)    # don't cache
     add_definitions(${WITHOUT_FEATURES_SH})
+    unset(WITHOUT_FEATURES_SH CACHE)    # don't cache
 endif(WITHOUT_FEATURES_SH)
+
+if(EXTRA_DEFINES_SH)
+    add_definitions(${EXTRA_DEFINES_SH})
+    unset(EXTRA_DEFINES_SH CACHE)    #don't cache
+endif(EXTRA_DEFINES_SH)
 
 enable_language(ASM)
 

--- a/lib/Common/CommonDefines.h
+++ b/lib/Common/CommonDefines.h
@@ -256,6 +256,15 @@
 #define DELAYLOAD_SET_CFG_TARGET 1
 #endif
 
+// Configure whether we configure a signal handler
+// to produce perf-<pid>.map files
+#ifndef PERFMAP_TRACE_ENABLED
+#define PERFMAP_TRACE_ENABLED 0
+#endif
+#ifndef PERFMAP_SIGNAL
+#define PERFMAP_SIGNAL SIGUSR2
+#endif
+
 #ifndef NTBUILD
 #define DELAYLOAD_SECTIONAPI 1
 #endif

--- a/lib/Jsrt/JsrtHelper.cpp
+++ b/lib/Jsrt/JsrtHelper.cpp
@@ -149,6 +149,10 @@ void JsrtCallbackState::ObjectBeforeCallectCallbackWrapper(JsObjectBeforeCollect
     #ifdef VTUNE_PROFILING
         VTuneChakraProfile::Register();
     #endif
+#if PERFMAP_TRACE_ENABLED
+        PlatformAgnostic::PerfTrace::Register();
+#endif
+
         ValueType::Initialize();
         ThreadContext::GlobalInitialize();
 

--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -1735,6 +1735,13 @@ ThreadContext::ProbeStack(size_t size, Js::ScriptContext *scriptContext, PVOID r
 {
     this->ProbeStackNoDispose(size, scriptContext, returnAddress);
 
+#if PERFMAP_TRACE_ENABLED
+    if (PlatformAgnostic::PerfTrace::mapsRequested)
+    {
+        PlatformAgnostic::PerfTrace::WritePerfMap();
+    }
+#endif
+    
     // BACKGROUND-GC TODO: If we're stuck purely in JITted code, we should have the
     // background GC thread modify the threads stack limit to trigger the runtime stack probe
     if (this->callDispose && this->recycler->NeedDispose())

--- a/lib/Runtime/PlatformAgnostic/Chakra.Runtime.PlatformAgnostic.vcxproj
+++ b/lib/Runtime/PlatformAgnostic/Chakra.Runtime.PlatformAgnostic.vcxproj
@@ -49,10 +49,12 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)Platform\Windows\Thread.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)Platform\Common\UnicodeText.Common.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)Platform\Windows\EventTrace.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)Platform\Windows\PerfTrace.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ChakraPlatform.h" />
     <ClInclude Include="EventTrace.h" />
+    <ClInclude Include="PerfTrace.h" />
     <ClInclude Include="RuntimePlatformAgnosticPch.h" />
     <ClInclude Include="UnicodeText.h" />
   </ItemGroup>

--- a/lib/Runtime/PlatformAgnostic/Chakra.Runtime.PlatformAgnostic.vcxproj.filters
+++ b/lib/Runtime/PlatformAgnostic/Chakra.Runtime.PlatformAgnostic.vcxproj.filters
@@ -13,10 +13,16 @@
     <ClCompile Include="Platform\Windows\DateTime.cpp">
       <Filter>Platform\Windows</Filter>
     </ClCompile>
+    <ClCompile Include="Platform\Windows\PerfTrace.cpp">
+      <Filter>Platform\Windows</Filter>
+    </ClCompile>
     <ClCompile Include="Platform\Linux\UnicodeText.ICU.cpp">
       <Filter>Platform\Linux</Filter>
     </ClCompile>
     <ClCompile Include="Platform\Linux\DateTime.cpp">
+      <Filter>Platform\Linux</Filter>
+    </ClCompile>
+    <ClCompile Include="Platform\Linux\PerfTrace.cpp">
       <Filter>Platform\Linux</Filter>
     </ClCompile>
     <ClCompile Include="RuntimePlatformAgnosticPch.cpp" />
@@ -43,6 +49,9 @@
     <ClInclude Include="ChakraPlatform.h" />
     <ClInclude Include="RuntimePlatformAgnosticPch.h" />
     <ClInclude Include="EventTrace.h">
+      <Filter>Interfaces</Filter>
+    </ClInclude>
+    <ClInclude Include="PerfTrace.h">
       <Filter>Interfaces</Filter>
     </ClInclude>
   </ItemGroup>

--- a/lib/Runtime/PlatformAgnostic/PerfTrace.h
+++ b/lib/Runtime/PlatformAgnostic/PerfTrace.h
@@ -1,0 +1,33 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+#pragma once
+
+#include <signal.h>
+
+//
+// perf or perf_events is a tool for tracing in linux.
+// In order to make sense of perf traces in the presence of a JIT,
+// some metadata must be provided describing what memory address ranges
+// correspond to what compiled function.
+//
+
+
+namespace PlatformAgnostic
+{
+
+//
+// Encapsulates all perf event logging and registration related to symbol decoding.
+//
+class PerfTrace
+{
+public:
+    static void Register();
+
+    static void WritePerfMap();
+
+    static volatile sig_atomic_t mapsRequested;
+};
+
+};

--- a/lib/Runtime/PlatformAgnostic/Platform/CMakeLists.txt
+++ b/lib/Runtime/PlatformAgnostic/Platform/CMakeLists.txt
@@ -7,6 +7,7 @@ set(PL_SOURCE_FILES
   Linux/UnicodeText.ICU.cpp
   Linux/NumbersUtility.cpp
   Linux/Thread.cpp
+  Linux/PerfTrace.cpp
   Common/Trace.cpp
   Common/SystemInfo.Common.cpp
   )

--- a/lib/Runtime/PlatformAgnostic/Platform/Linux/PerfTrace.cpp
+++ b/lib/Runtime/PlatformAgnostic/Platform/Linux/PerfTrace.cpp
@@ -1,0 +1,152 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+#include "Common.h"
+#include "Runtime.h"
+#include "ChakraPlatform.h"
+
+#include <signal.h>
+#include <errno.h>
+#include <unistd.h>
+
+using namespace Js;
+
+//
+//  Handle the SIGUSR2 signal by setting a flag
+//  indicating that we should call WritePerfMap later on
+//
+void handle_signal(int signum)
+{
+    PlatformAgnostic::PerfTrace::mapsRequested = 1;
+}
+
+namespace PlatformAgnostic
+{
+
+volatile sig_atomic_t PerfTrace::mapsRequested = 0;
+  
+//
+// Registers a signal handler for SIGUSR2 
+//
+void PerfTrace::Register()
+{
+#if PERFMAP_TRACE_ENABLED
+    struct sigaction newAction = {0};
+    newAction.sa_flags = SA_RESTART;
+    newAction.sa_handler = handle_signal;
+    sigemptyset(&newAction.sa_mask);
+
+    struct sigaction previousAction = {0};
+
+    if (-1 == sigaction(PERFMAP_SIGNAL, &newAction, &previousAction))
+    {
+        AssertMsg(errno, "PerfTrace::Register: sigaction() call failed\n");
+    }
+#endif
+}
+
+void  PerfTrace::WritePerfMap()
+{
+#if ENABLE_NATIVE_CODEGEN
+    // Lock threadContext list during etw rundown
+    AutoCriticalSection autoThreadContextCs(ThreadContext::GetCriticalSection());
+
+    ThreadContext * threadContext = ThreadContext::GetThreadContextList();
+
+    FILE * perfMapFile;
+
+    {
+        const size_t PERFMAP_FILENAME_MAX_LENGTH = 30;
+        char perfMapFilename[PERFMAP_FILENAME_MAX_LENGTH];
+        pid_t processId = getpid();
+        snprintf(perfMapFilename, PERFMAP_FILENAME_MAX_LENGTH, "/tmp/perf-%d.map", processId);
+
+        perfMapFile = fopen(perfMapFilename, "w");
+        if (perfMapFile == NULL) {
+            return;
+        }
+    }
+
+    while(threadContext != nullptr)
+    {
+        // Take etw rundown lock on this thread context
+        AutoCriticalSection autoEtwRundownCs(threadContext->GetFunctionBodyLock());
+
+        ScriptContext* scriptContext = threadContext->GetScriptContextList();
+        while(scriptContext != NULL)
+        {
+            if(scriptContext->IsClosed())
+            {
+                scriptContext = scriptContext->next;
+                continue;
+            }
+
+            scriptContext->MapFunction([=] (FunctionBody* body)
+            {
+#if DYNAMIC_INTERPRETER_THUNK
+                if(body->HasInterpreterThunkGenerated())
+                {
+                    const char16* functionName = body->GetExternalDisplayName();
+                    fwprintf(perfMapFile, _u("%llX %llX %s(Interpreted)\n"),
+                        body->GetDynamicInterpreterEntryPoint(),
+                        body->GetDynamicInterpreterThunkSize(),
+                        functionName);
+                }
+#endif
+
+#if ENABLE_NATIVE_CODEGEN
+                body->MapEntryPoints([&](int index, FunctionEntryPointInfo * entryPoint)
+                {
+                    if(entryPoint->IsCodeGenDone())
+                    {
+                        const ExecutionMode jitMode = entryPoint->GetJitMode();
+                        if (jitMode == ExecutionMode::SimpleJit)
+                        {
+                            fwprintf(perfMapFile, _u("%llX %llX %s(SimpleJIT)\n"),
+                                entryPoint->GetNativeAddress(),
+                                entryPoint->GetCodeSize(),
+                                body->GetExternalDisplayName());
+                        }
+                        else
+                        {
+                            fwprintf(perfMapFile, _u("%llX %llX %s(FullJIT)\n"),
+                                entryPoint->GetNativeAddress(),
+                                entryPoint->GetCodeSize(),
+                                body->GetExternalDisplayName());
+                        }
+                    }
+                });
+
+                body->MapLoopHeadersWithLock([&](uint loopNumber, LoopHeader* header)
+                {
+                    header->MapEntryPoints([&](int index, LoopEntryPointInfo * entryPoint)
+                    {
+                        if(entryPoint->IsCodeGenDone())
+                        {
+                            const uint16 loopNumber = ((uint16)body->GetLoopNumberWithLock(header));
+                            fwprintf(perfMapFile, _u("%llX %llX %s(Loop%u)\n"),
+                                entryPoint->GetNativeAddress(),
+                                entryPoint->GetCodeSize(),
+                                body->GetExternalDisplayName(),
+                                loopNumber+1);
+                        }
+                    });
+                });
+#endif
+            });
+
+            scriptContext = scriptContext->next;
+        }
+
+        threadContext = threadContext->Next();
+    }
+
+    fflush(perfMapFile);
+    fclose(perfMapFile);
+#endif
+    PerfTrace::mapsRequested = 0;
+}
+
+}
+

--- a/lib/Runtime/PlatformAgnostic/Platform/Windows/PerfTrace.cpp
+++ b/lib/Runtime/PlatformAgnostic/Platform/Windows/PerfTrace.cpp
@@ -2,15 +2,26 @@
 // Copyright (C) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
-#pragma once
+#include "RuntimePlatformAgnosticPch.h"
 
-#include "UnicodeText.h"
-#include "EventTrace.h"
-#include "PerfTrace.h"
+#include "ChakraPlatform.h"
 
-#include "PlatformAgnostic/DateTime.h"
-#include "PlatformAgnostic/AssemblyCommon.h"
 
-#if !defined(_WIN32) && defined(DEBUG)
-#include <signal.h> // raise(SIGINT)
-#endif
+using namespace Js;
+
+namespace PlatformAgnostic
+{
+
+volatile sig_atomic_t PerfTrace::mapsRequested = 0;
+  
+void PerfTrace::Register()
+{
+    // TODO: Implement this on Windows?
+}
+
+void  PerfTrace::WritePerfMap()
+{
+    // TODO: Implement this on Windows?
+}
+
+}

--- a/netci.groovy
+++ b/netci.groovy
@@ -107,7 +107,7 @@ def CreateBuildTasks = { machine, configTag, buildExtra, testExtra, runCodeAnaly
 }
 
 def CreateXPlatBuildTask = { isPR, buildType, staticBuild, machine, platform, configTag,
-    xplatBranch, nonDefaultTaskSetup, customOption, testVariant ->
+    xplatBranch, nonDefaultTaskSetup, customOption, testVariant, extraBuildParams ->
 
     def config = (platform == "osx" ? "osx_${buildType}" : "linux_${buildType}")
     def numConcurrentCommand = (platform == "osx" ? "sysctl -n hw.logicalcpu" : "nproc")
@@ -126,7 +126,7 @@ def CreateXPlatBuildTask = { isPR, buildType, staticBuild, machine, platform, co
     def icuFlag = (platform == "osx" ? "--icu=/usr/local/opt/icu4c/include" : "")
     def compilerPaths = (platform == "osx") ? "" : "--cxx=/usr/bin/clang++-3.8 --cc=/usr/bin/clang-3.8"
     def buildScript = "bash ./build.sh ${staticFlag} -j=`${numConcurrentCommand}` ${buildFlag} " +
-                      "${swbCheckFlag} ${compilerPaths} ${icuFlag} ${customOption}"
+                      "${swbCheckFlag} ${compilerPaths} ${icuFlag} ${customOption} ${extraBuildParams}"
     def testScript = "bash test/runtests.sh \"${testVariant}\""
 
     def newJob = job(jobName) {
@@ -164,10 +164,10 @@ def CreateXPlatBuildTask = { isPR, buildType, staticBuild, machine, platform, co
 }
 
 // Generic task to trigger clang-based cross-plat build tasks
-def CreateXPlatBuildTasks = { machine, platform, configTag, xplatBranch, nonDefaultTaskSetup ->
+def CreateXPlatBuildTasks = { machine, platform, configTag, xplatBranch, nonDefaultTaskSetup, extraBuildParams ->
     [true, false].each { isPR ->
         CreateXPlatBuildTask(isPR, "test", "", machine, platform,
-            configTag, xplatBranch, nonDefaultTaskSetup, "--no-jit", "--variants disable_jit")
+            configTag, xplatBranch, nonDefaultTaskSetup, "--no-jit", "--variants disable_jit", extraBuildParams)
 
         ['debug', 'test', 'release'].each { buildType ->
             def staticBuildConfigs = [true, false]
@@ -177,7 +177,7 @@ def CreateXPlatBuildTasks = { machine, platform, configTag, xplatBranch, nonDefa
 
             staticBuildConfigs.each { staticBuild ->
                 CreateXPlatBuildTask(isPR, buildType, staticBuild, machine, platform,
-                    configTag, xplatBranch, nonDefaultTaskSetup, "", "")
+                    configTag, xplatBranch, nonDefaultTaskSetup, "", "", extraBuildParams)
             }
         }
     }
@@ -298,7 +298,7 @@ if (isXPlatCompatibleBranch) {
     def osString = 'Ubuntu16.04'
 
     // PR and CI checks
-    CreateXPlatBuildTasks(osString, "linux", "ubuntu", branch, null)
+    CreateXPlatBuildTasks(osString, "linux", "ubuntu", branch, null, "")
 
     // daily builds
     if (isXPlatDailyBranch) {
@@ -306,7 +306,8 @@ if (isXPlatCompatibleBranch) {
             /* nonDefaultTaskSetup */ { newJob, isPR, config ->
                 DailyBuildTaskSetup(newJob, isPR,
                     "Ubuntu ${config}",
-                    'linux\\s+tests')})
+                    'linux\\s+tests')},
+            /* extraBuildParams */ "--extra-defines=PERFMAP_TRACE_ENABLED=1")
     }
 }
 
@@ -318,7 +319,7 @@ if (isXPlatCompatibleBranch) {
     def osString = 'OSX'
 
     // PR and CI checks
-    CreateXPlatBuildTasks(osString, "osx", "osx", branch, null)
+    CreateXPlatBuildTasks(osString, "osx", "osx", branch, null, "")
 
     // daily builds
     if (isXPlatDailyBranch) {
@@ -326,7 +327,8 @@ if (isXPlatCompatibleBranch) {
             /* nonDefaultTaskSetup */ { newJob, isPR, config ->
                 DailyBuildTaskSetup(newJob, isPR,
                     "OSX ${config}",
-                    'linux\\s+tests')})
+                    'linux\\s+tests')},
+            /* extraBuildParams */ "")
     }
 }
 


### PR DESCRIPTION
To enable tools such as `perf` to provide diagnostic information on
generated code, we add the ability to dump out a mapping from memory
addresses to function names. Sending a `SIGUSR2` signal to a ChakraCore
process on Linux or OSX will cause it to write to `/tmp/perf-<pid>.map`
the next time the process performs a stack probe.