### PR TITLE
Fix bookkeeping of unregisteredInlineCacheCount

### DIFF
--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -7723,7 +7723,7 @@ namespace Js
                         // and doesn't get released to the allocator until there are no more outstanding references.  Thus we don't need
                         // to (and, in fact, cannot) remove it from the invalidation list here.  Instead, we'll do it in ReleaseInlineCache
                         // when there are no more outstanding references.
-                        rootObjectBase->ReleaseInlineCache(this->GetPropertyIdFromCacheId(i), false, false, IsScriptContextShutdown);
+                        unregisteredInlineCacheCount += rootObjectBase->ReleaseInlineCache(this->GetPropertyIdFromCacheId(i), false, false, IsScriptContextShutdown);
                     }
                 }
             }
@@ -7743,7 +7743,7 @@ namespace Js
                         // and doesn't get released to the allocator until there are no more outstanding references.  Thus we don't need
                         // to (and, in fact, cannot) remove it from the invalidation list here.  Instead, we'll do it in ReleaseInlineCache
                         // when there are no more outstanding references.
-                        rootObjectBase->ReleaseInlineCache(this->GetPropertyIdFromCacheId(i), true, false, IsScriptContextShutdown);
+                        unregisteredInlineCacheCount += rootObjectBase->ReleaseInlineCache(this->GetPropertyIdFromCacheId(i), true, false, IsScriptContextShutdown);
                     }
                 }
             }
@@ -7763,7 +7763,7 @@ namespace Js
                         // and doesn't get released to the allocator until there are no more outstanding references.  Thus we don't need
                         // to (and, in fact, cannot) remove it from the invalidation list here.  Instead, we'll do it in ReleaseInlineCache
                         // when there are no more outstanding references.
-                        rootObjectBase->ReleaseInlineCache(this->GetPropertyIdFromCacheId(i), false, true, IsScriptContextShutdown);
+                        unregisteredInlineCacheCount += rootObjectBase->ReleaseInlineCache(this->GetPropertyIdFromCacheId(i), false, true, IsScriptContextShutdown);
                     }
                 }
             }

--- a/lib/Runtime/Library/RootObjectBase.cpp
+++ b/lib/Runtime/Library/RootObjectBase.cpp
@@ -96,7 +96,7 @@ namespace Js
 
     // TODO: Switch to take PropertyRecord instead once we clean up the function body to hold onto propertyRecord
     // instead of propertyId.
-    void
+    uint
     RootObjectBase::ReleaseInlineCache(Js::PropertyId propertyId, bool isLoadMethod, bool isStore, bool isShutdown)
     {
         uint unregisteredInlineCacheCount = 0;
@@ -129,10 +129,7 @@ namespace Js
             }
         );
         Assert(found);
-        if (unregisteredInlineCacheCount > 0)
-        {
-            this->GetScriptContext()->GetThreadContext()->NotifyInlineCacheBatchUnregistered(unregisteredInlineCacheCount);
-        }
+        return unregisteredInlineCacheCount;
     }
 
     BOOL

--- a/lib/Runtime/Library/RootObjectBase.h
+++ b/lib/Runtime/Library/RootObjectBase.h
@@ -27,7 +27,7 @@ namespace Js
 
         Js::InlineCache * GetInlineCache(Js::PropertyRecord const* propertyRecord, bool isLoadMethod, bool isStore);
         Js::RootObjectInlineCache * GetRootInlineCache(Js::PropertyRecord const* propertyRecord, bool isLoadMethod, bool isStore);
-        void ReleaseInlineCache(PropertyId propertyId, bool isLoadMethod, bool isStore, bool isShutdown);
+        uint ReleaseInlineCache(PropertyId propertyId, bool isLoadMethod, bool isStore, bool isShutdown);
 
         virtual BOOL EnsureProperty(PropertyId propertyId) override;
         virtual BOOL EnsureNoRedeclProperty(PropertyId propertyId) override sealed;


### PR DESCRIPTION
We were removing inlineCache from invalidation list but were not
updating the count at `ThreadContext` level. In between we were calling
compacting the invalidation list and find that there are more null
entries in the invalidation list than we thought (as per `threadContext->unregisteredInlineCacheCount`).

Fix by calling compact only after we update the variable at threadContext.
