### PR TITLE
Fix for a regex bug

### DIFF
--- a/lib/Parser/RegexRuntime.cpp
+++ b/lib/Parser/RegexRuntime.cpp
@@ -4286,9 +4286,16 @@ namespace UnifiedRegex
             else
             {
                 // Backtrack to the previous offset where we matched the LoopSet's followFirst
+                // We will be doing one unnecessary match. But, if we wanted to avoid it, we'd have 
+                // to propagate to the next Inst, that the first character is already matched.
+                // Seems like an overkill to avoid one match.
                 loopInfo->number = loopInfo->offsetsOfFollowFirst->RemoveAtEnd();
             }
         }
+
+        // If loopInfo->number now is less than begins->repeats.lower, the loop
+        // shouldn't match anything. In that case, stop backtracking.
+        loopInfo->number = max(loopInfo->number, begin->repeats.lower);
 
         // Rewind input
         inputOffset = loopInfo->startInputOffset + loopInfo->number;

--- a/test/Regex/regex1.baseline
+++ b/test/Regex/regex1.baseline
@@ -21,3 +21,6 @@ lastIndex test 5 passed
 lastIndex test 6 passed
 lastIndex test 7 passed
 aa,a,a
+null
+null
+null

--- a/test/Regex/regex1.js
+++ b/test/Regex/regex1.js
@@ -148,4 +148,9 @@ c=[/[\300-\306]/g,"A",/[\340-\346]/g,"a",/\307/g,"C",/\347/g,"c",/[\310-\313]/g,
 //Negation of empty char set [^] test
 write("aa".match(/([^])(\1)/));
 
+write(/^.+ ab/g.exec(" ab"))
+write(/^.+a /.exec("a "))
+write(/^.+ax/.exec("ax"))
+
+
 


### PR DESCRIPTION
Fixing a bug where .+ was matching 0 characters also, in some cases.