### PR TITLE
AsmJs: Fix bad cast in Lower

### DIFF
--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -10916,30 +10916,24 @@ Lowerer::LoadGeneratorObject(IR::Instr * instrInsert)
 }
 
 IR::Instr *
-Lowerer::LowerArgInAsmJs(IR::Instr * instrArgIn)
+Lowerer::LowerArgInAsmJs(IR::Instr * instr)
 {
     Assert(m_func->GetJITFunctionBody()->IsAsmJsMode());
 
-    int argCount = (int)(int16)m_func->argInsCount;
-    IR::Instr * instr = instrArgIn;
-
-    for (int argNum = argCount - 1; argNum >= 0; --argNum)
-    {
+    Assert(instr && instr->m_opcode == Js::OpCode::ArgIn_A);
+    IR::Instr* instrPrev = instr->m_prev;
 #ifdef _M_IX86
-        if (instr->GetDst()->IsInt64())
-        {
-            instr = m_lowererMD.LowerInt64Assign(instr);
-        }
-        else
+    if (instr->GetDst()->IsInt64())
+    {
+        m_lowererMD.LowerInt64Assign(instr);
+    }
+    else
 #endif
-        {
-            IR::Instr * instrPrev = instr->m_prev;
-            m_lowererMD.ChangeToAssign(instr);
-            instr = instrPrev;
-        }
+    {
+        m_lowererMD.ChangeToAssign(instr);
     }
 
-    return instr;
+    return instrPrev;
 }
 
 bool


### PR DESCRIPTION
Fix potentially bad cast in LowerArgInAsmJs. 
Since the size of the arguments is also an ArgSlot, the max value we can have as the number of arguments is 0x4000. This change is just to future proof this code. 
Add additional check to make sure we are lowering ArgIn_A.
Related [OSG 12366674](https://microsoft.visualstudio.com/os/_workitems?id=12366674)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/3218)
<!-- Reviewable:end -->
