### PR TITLE
Replace GetModuleFileName with GetBinaryLocation (fix #2297)

### DIFF
--- a/bin/ch/ch.cpp
+++ b/bin/ch/ch.cpp
@@ -116,9 +116,8 @@ void __stdcall PrintChakraCoreVersion()
     char16 dir[_MAX_DIR];
 
     LPCWSTR chakraDllName = GetChakraDllNameW();
-
     char16 modulename[_MAX_PATH];
-    if (!GetModuleFileNameW(NULL, modulename, _MAX_PATH))
+    if (!PlatformAgnostic::SystemInfo::GetBinaryLocation(modulename, _MAX_PATH))
     {
         return;
     }

--- a/lib/Common/Core/ConfigParser.cpp
+++ b/lib/Common/Core/ConfigParser.cpp
@@ -594,7 +594,7 @@ HRESULT ConfigParser::SetOutputFile(const WCHAR* outputFile, const WCHAR* openMo
 
     char16 fileName[_MAX_PATH];
     char16 moduleName[_MAX_PATH];
-    GetModuleFileName(0, moduleName, _MAX_PATH);
+    PlatformAgnostic::SystemInfo::GetBinaryLocation(moduleName, _MAX_PATH);
     _wsplitpath_s(moduleName, nullptr, 0, nullptr, 0, fileName, _MAX_PATH, nullptr, 0);
     if (_wcsicmp(fileName, _u("WWAHost")) == 0 ||
         _wcsicmp(fileName, _u("ByteCodeGenerator")) == 0 ||

--- a/lib/Common/Core/DbgHelpSymbolManager.cpp
+++ b/lib/Common/Core/DbgHelpSymbolManager.cpp
@@ -63,7 +63,7 @@ DbgHelpSymbolManager::Initialize()
 
     if (wcscmp(wszModule, _u("")) == 0)
     {
-        if (GetModuleFileName(NULL, wszModuleName, static_cast<DWORD>(ceModuleName)))
+        if (PlatformAgnostic::SystemInfo::GetBinaryLocation(wszModuleName, static_cast<DWORD>(ceModuleName)))
         {
             wszModule = wszModuleName;
         }

--- a/lib/Common/Core/FaultInjection.cpp
+++ b/lib/Common/Core/FaultInjection.cpp
@@ -1235,7 +1235,7 @@ namespace Js
         //analyze duplication
         uintptr_t savedOffset = 0;
         auto& mainModule = modulePath;
-        GetModuleFileName(NULL, mainModule, MAX_PATH);
+        PlatformAgnostic::SystemInfo::GetBinaryLocation(mainModule, MAX_PATH);
         // multiple session of Fault Injection run shares the single crash offset recording file
         _snwprintf_s(filename, _TRUNCATE, _u("%s.FICrashes.txt"), mainModule);
 

--- a/lib/Common/Core/PerfCounterSet.h
+++ b/lib/Common/Core/PerfCounterSet.h
@@ -55,7 +55,7 @@ namespace PerfCounter
             if (IsProviderInitialized())
             {
                 char16 wszModuleName[_MAX_PATH];
-                if (!GetModuleFileName(NULL, wszModuleName, _MAX_PATH))
+                if (!PlatformAgnostic::SystemInfo::GetBinaryLocation(wszModuleName, _MAX_PATH))
                 {
                     return false;
                 }

--- a/lib/Common/PlatformAgnostic/SystemInfo.h
+++ b/lib/Common/PlatformAgnostic/SystemInfo.h
@@ -17,7 +17,7 @@ namespace PlatformAgnostic
     path[str_len] = char(0)
 
 #ifdef _WIN32
-        static void GetBinaryLocation(char *path, const unsigned size)
+        static bool GetBinaryLocation(char *path, const unsigned size)
         {
             // TODO: make AssertMsg available under PlatformAgnostic
             //AssertMsg(path != nullptr, "Path can not be nullptr");
@@ -27,14 +27,14 @@ namespace PlatformAgnostic
             if (!wpath)
             {
                 SET_BINARY_PATH_ERROR_MESSAGE(path, "GetBinaryLocation: GetModuleFileName has failed. OutOfMemory!");
-                return;
+                return false;
             }
             str_len = GetModuleFileNameW(NULL, wpath, size - 1);
             if (str_len <= 0)
             {
                 SET_BINARY_PATH_ERROR_MESSAGE(path, "GetBinaryLocation: GetModuleFileName has failed.");
                 free(wpath);
-                return;
+                return false;
             }
 
             str_len = WideCharToMultiByte(CP_UTF8, 0, wpath, str_len, path, size, NULL, NULL);
@@ -43,7 +43,7 @@ namespace PlatformAgnostic
             if (str_len <= 0)
             {
                 SET_BINARY_PATH_ERROR_MESSAGE(path, "GetBinaryLocation: GetModuleFileName (WideCharToMultiByte) has failed.");
-                return;
+                return false;
             }
 
             if ((unsigned)str_len > size - 1)
@@ -51,9 +51,27 @@ namespace PlatformAgnostic
                 str_len = (int)size - 1;
             }
             path[str_len] = char(0);
+            return true;
+        }
+
+        // Overloaded GetBinaryLocation: receive the location of current binary in char16.
+        // size: the second parameter is the size of the path buffer in count of wide characters.
+        static bool GetBinaryLocation(char16 *path, const unsigned size)
+        {
+            // TODO: make AssertMsg available under PlatformAgnostic
+            //AssertMsg(path != nullptr, "Path can not be nullptr");
+            //AssertMsg(size < INT_MAX, "Isn't it too big for a path buffer?");
+            int str_len = GetModuleFileNameW(NULL, path, size);
+            if (str_len <= 0)
+            {
+                wcscpy_s(path, size, _u("GetBinaryLocation: GetModuleFileName has failed."));
+                return false;
+            }
+            return true;
         }
 #else
-        static void GetBinaryLocation(char *path, const unsigned size);
+        static bool GetBinaryLocation(char *path, const unsigned size);
+        static bool GetBinaryLocation(char16 *path, const unsigned size);
 #endif
     };
 } // namespace PlatformAgnostic


### PR DESCRIPTION
This will fix the remaining task in Issue #2297: replace `GetModuleFileName` with `PlatformAgnostic::SystemInfo::GetBinaryLocation`.

This task is easy if the caller of `GetModuleFileName` can easily work with a UTF-8 string, like `TTDHostBuildCurrentExeDirectory`. But if the caller needs to pass the returned string to a Unicode version of Windows API (see #3178 for example), then it seems the UTF-8 string returned by `GetBinaryLocation` is not so suitable here. What to do in this case?