### PR TITLE
Fix memory leak in Debugger::SetBaseline

### DIFF
--- a/bin/ch/Debugger.cpp
+++ b/bin/ch/Debugger.cpp
@@ -327,7 +327,7 @@ bool Debugger::SetBaseline()
                 script[numChars] = '\0';
 
                 JsValueRef wideScriptRef;
-                IfJsrtErrorFailLogAndRetFalse(ChakraRTInterface::JsCreateString(
+                IfJsErrorFailLogAndHR(ChakraRTInterface::JsCreateString(
                   script, strlen(script), &wideScriptRef));
 
                 this->CallFunctionNoResult("SetBaseline", wideScriptRef);

--- a/bin/ch/stdafx.h
+++ b/bin/ch/stdafx.h
@@ -103,6 +103,17 @@ do { \
     } \
 } while (0)
 
+#define IfJsErrorFailLogAndHR(expr) \
+do { \
+    JsErrorCode jsErrorCode = expr; \
+    if ((jsErrorCode) != JsNoError) { \
+        hr = E_FAIL; \
+        fwprintf(stderr, _u("ERROR: ") _u(#expr) _u(" failed. JsErrorCode=0x%x (%s)\n"), jsErrorCode, Helpers::JsErrorCodeToString(jsErrorCode)); \
+        fflush(stderr); \
+        goto Error; \
+    } \
+} while (0)
+
 #define IfJsErrorFailLogLabel(expr, label) \
 do { \
     JsErrorCode jsErrorCode = expr; \


### PR DESCRIPTION
If `ChakraRTInterface::JsCreateString` fails, `IfJsrtErrorFailLogAndRetFalse` causes the function `Debugger::SetBaseline()` to return false, without deleting `script` and closing `file`.