### PR TITLE
remove bad "ActivationObject*" cast

### DIFF
--- a/lib/Runtime/Debug/TTSnapObjects.cpp
+++ b/lib/Runtime/Debug/TTSnapObjects.cpp
@@ -1028,10 +1028,6 @@ namespace TTD
             {
                 activationObj = nullptr;
             }
-            else if(argsInfo->IsFrameJsNull)
-            {
-                activationObj = ctx->GetLibrary()->GetNull();
-            }
             else
             {
                 TTDAssert(argsInfo->FrameObject != TTD_INVALID_PTR_ID, "That won't work!");
@@ -1052,10 +1048,6 @@ namespace TTD
             if(argsInfo->IsFrameNullPtr)
             {
                 activationObj = nullptr;
-            }
-            else if(argsInfo->IsFrameJsNull)
-            {
-                activationObj = ctx->GetLibrary()->GetNull();
             }
             else
             {

--- a/lib/Runtime/Debug/TTSnapObjects.h
+++ b/lib/Runtime/Debug/TTSnapObjects.h
@@ -279,7 +279,6 @@ namespace TTD
 
             //The frame object 
             bool IsFrameNullPtr;
-            bool IsFrameJsNull;
             TTD_PTR_ID FrameObject;
 
             uint32 FormalCount;
@@ -300,7 +299,6 @@ namespace TTD
             writer->WriteUInt32(NSTokens::Key::numberOfArgs, argsInfo->NumOfArguments, NSTokens::Separator::CommaAndBigSpaceSeparator);
 
             writer->WriteBool(NSTokens::Key::boolVal, argsInfo->IsFrameNullPtr, NSTokens::Separator::CommaSeparator);
-            writer->WriteBool(NSTokens::Key::boolVal, argsInfo->IsFrameJsNull, NSTokens::Separator::CommaSeparator);
             writer->WriteAddr(NSTokens::Key::objectId, argsInfo->FrameObject, NSTokens::Separator::CommaSeparator);
 
             writer->WriteLengthValue(argsInfo->FormalCount, NSTokens::Separator::CommaSeparator);
@@ -322,7 +320,6 @@ namespace TTD
             argsInfo->NumOfArguments = reader->ReadUInt32(NSTokens::Key::numberOfArgs, true);
 
             argsInfo->IsFrameNullPtr = reader->ReadBool(NSTokens::Key::boolVal, true);
-            argsInfo->IsFrameJsNull = reader->ReadBool(NSTokens::Key::boolVal, true);
             argsInfo->FrameObject = reader->ReadAddr(NSTokens::Key::objectId, true);
 
             argsInfo->FormalCount = reader->ReadLengthValue(true);
@@ -357,7 +354,6 @@ namespace TTD
             compareMap.DiagnosticAssert(argsInfo1->NumOfArguments == argsInfo2->NumOfArguments);
 
             compareMap.DiagnosticAssert(argsInfo1->IsFrameNullPtr == argsInfo2->IsFrameNullPtr);
-            compareMap.DiagnosticAssert(argsInfo1->IsFrameJsNull == argsInfo2->IsFrameJsNull);
             compareMap.CheckConsistentAndAddPtrIdMapping_Special(argsInfo1->FrameObject, argsInfo2->FrameObject, _u("frameObject"));
 
             compareMap.DiagnosticAssert(argsInfo1->FormalCount == argsInfo2->FormalCount);

--- a/lib/Runtime/Library/ArgumentsObject.cpp
+++ b/lib/Runtime/Library/ArgumentsObject.cpp
@@ -111,6 +111,7 @@ namespace Js
     HeapArgumentsObject::HeapArgumentsObject(Recycler *recycler, ActivationObject* obj, uint32 formalCount, DynamicType * type)
         : ArgumentsObject(type), frameObject(obj), formalCount(formalCount), numOfArguments(0), callerDeleted(false), deletedArgs(nullptr)
     {
+        Assert(!frameObject || ActivationObject::Is(frameObject));
     }
 
     void HeapArgumentsObject::SetNumberOfArguments(uint32 len)
@@ -297,20 +298,14 @@ namespace Js
         TTD_PTR_ID* depOnArray = nullptr;
 
         argsInfo->IsFrameNullPtr = false;
-        argsInfo->IsFrameJsNull = false;
         argsInfo->FrameObject = TTD_INVALID_PTR_ID;
         if(this->frameObject == nullptr)
         {
             argsInfo->IsFrameNullPtr = true;
         }
-        else if(Js::JavascriptOperators::GetTypeId(this->frameObject) == TypeIds_Null)
-        {
-            argsInfo->IsFrameJsNull = true;
-        }
         else
         {
-            argsInfo->FrameObject = TTD_CONVERT_VAR_TO_PTR_ID(
-                static_cast<ActivationObject*>(this->frameObject));
+            argsInfo->FrameObject = TTD_CONVERT_VAR_TO_PTR_ID(this->frameObject);
 
             //Primitive kinds always inflated first so we only need to deal with complex kinds as depends on
             if(TTD::JsSupport::IsVarComplexKind(this->frameObject))

--- a/lib/Runtime/Library/ArgumentsObject.h
+++ b/lib/Runtime/Library/ArgumentsObject.h
@@ -122,6 +122,7 @@ namespace Js
         void SetFrameObject(ActivationObject * value)
         {
             AssertMsg(frameObject == nullptr, "Setting the frame object again?");
+            Assert(!value || ActivationObject::Is(value));
             frameObject = value;
         }
 

--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -1847,7 +1847,7 @@ namespace Js
         {
             library->AddMember(atomicsObject, PropertyIds::_symbolToStringTag, library->CreateStringFromCppLiteral(_u("Atomics")), PropertyConfigurable);
         }
-        
+
         atomicsObject->SetHasNoEnumerableProperties(true);
     }
 
@@ -2332,7 +2332,7 @@ namespace Js
         }
         return promiseResolveFunction;
     }
-    
+
     void JavascriptLibrary::InitializePromisePrototype(DynamicObject* promisePrototype, DeferredTypeHandlerBase * typeHandler, DeferredInitializeMode mode)
     {
         typeHandler->Convert(promisePrototype, mode, 4);
@@ -3492,7 +3492,7 @@ namespace Js
         defaultPropertyDescriptor.SetConfigurable(false);
 
 #if !defined(_M_X64_OR_ARM64)
-        
+
         VirtualTableRecorder<Js::JavascriptNumber>::RecordVirtualTableAddress(vtableAddresses, VTableValue::VtableJavascriptNumber);
 #else
         vtableAddresses[VTableValue::VtableJavascriptNumber] = 0;
@@ -3587,7 +3587,7 @@ namespace Js
             case TypeIds_SIMDFloat32x4:
                 typeDisplayStrings[typeId] = simdFloat32x4DisplayString;
                 break;
-            
+
            //case TypeIds_SIMDFloat64x2:  //Type under review by the spec.
                 // typeDisplayStrings[typeId] = simdFloat64x2DisplayString;
                 // break;
@@ -6079,7 +6079,9 @@ namespace Js
             argumentsType = heapArgumentsType;
         }
 
-        return RecyclerNew(recycler, HeapArgumentsObject, recycler, (ActivationObject*)frameObj, formalCount, argumentsType);
+        return RecyclerNew(recycler, HeapArgumentsObject, recycler,
+            frameObj != GetNull() ? static_cast<ActivationObject*>(frameObj) : nullptr,
+            formalCount, argumentsType);
     }
 
     JavascriptArray* JavascriptLibrary::CreateArray()


### PR DESCRIPTION
HeapArgumentsObject::frameObject is of type "ActivationObject*" but
supported casting from JS null placeholder (e.g. no formals). This change
removed the bad casts and asserts the parameters are ActivationObjects.
