### PR TITLE
Fix a bug with inlining functions invoked via LdFld (getter/setters, apply/call targets

### DIFF
--- a/lib/Backend/NativeCodeGenerator.cpp
+++ b/lib/Backend/NativeCodeGenerator.cpp
@@ -2833,8 +2833,8 @@ NativeCodeGenerator::GatherCodeGenData(
                 continue;
             }
 
-            bool getSetInlineCandidate = inlineGetterSetter && ((cacheType & Js::FldInfo_FromAccessor) != 0);
-            bool callApplyInlineCandidate = (inlineCallTarget || inlineApplyTarget) && ((cacheType & Js::FldInfo_FromAccessor) == 0);
+            bool getSetInlineCandidate = inlineGetterSetter && ((cacheType & Js::FldInfo_InlineCandidate) != 0) && ((cacheType & Js::FldInfo_FromAccessor) != 0);
+            bool callApplyInlineCandidate = (inlineCallTarget || inlineApplyTarget) && ((cacheType & Js::FldInfo_InlineCandidate) != 0) && ((cacheType & Js::FldInfo_FromAccessor) == 0);
 
             // 1. Do not inline if the x in a.x is both a getter/setter and is followed by a .apply
             // 2. If we were optimistic earlier in assuming that the inline caches on the function object would be monomorphic and asserted that we may possibly inline apply target,

--- a/test/inlining/bug11265991.js
+++ b/test/inlining/bug11265991.js
@@ -1,0 +1,52 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+var shouldBailout = false;
+function test0() {
+  var GiantPrintArray = [];
+  var obj1 = {};
+  var func1 = function () {
+    var v0 = true;
+    var v1 = function v2() {
+      if (v0) {
+        v0 = false;
+        v2();
+      }
+      protoObj0.prop0 = i16;
+      test0;
+    };
+    v1();
+    function v5(v6) {
+      var v9 = {};
+      v9.a = v6;
+      v9.a[1] = null;
+    }
+    GiantPrintArray.push(v5(ary));
+    return shouldBailout ? (Object.defineProperty(protoObj0, 'prop0', {
+      set: function () {
+      }
+    })) : Error();
+  };
+  var func2 = function () {
+    for (var _strvar4 of ary) {
+      Math.tan((func1()));
+    }
+  };
+  var func3 = function () {
+    func2(func2(func1()));
+    func1();
+  };
+  obj1.method1 = func1;
+  var ary = Array();
+  var i16 = new Int16Array();
+  var protoObj0 = Object();
+  if (!(obj1.method1() + (func3()))) {
+  }
+  func1();
+}
+test0();
+shouldBailout = true;
+test0();
+print("Passed");

--- a/test/inlining/rlexe.xml
+++ b/test/inlining/rlexe.xml
@@ -279,4 +279,9 @@
       <files>bug9936017.js</files>
     </default>
   </test>
+  <test>
+    <default>
+      <files>bug11265991.js</files>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
Make sure to check if the value loaded from an inline cache is an inline candidate when recording inlining data for it