### PR TITLE
prevent re-entering GC in freeing ThunkBlocks

### DIFF
--- a/lib/Common/DataStructures/FixedBitVector.h
+++ b/lib/Common/DataStructures/FixedBitVector.h
@@ -161,7 +161,7 @@ BVFixed * BVFixed::New(DECLSPEC_GUARD_OVERFLOW BVIndex length, TAllocator * allo
 template <typename TAllocator>
 BVFixed * BVFixed::NewNoThrow(DECLSPEC_GUARD_OVERFLOW BVIndex length, TAllocator * alloc, bool initialSet)
 {
-    BVFixed *result = AllocatorNewNoThrowPlus(TAllocator, alloc, sizeof(BVUnit) * BVFixed::WordCount(length), BVFixed, length, initialSet);
+    BVFixed *result = AllocatorNewNoThrowNoRecoveryPlus(TAllocator, alloc, sizeof(BVUnit) * BVFixed::WordCount(length), BVFixed, length, initialSet);
     return result;
 }
 

--- a/lib/Common/Memory/Allocator.h
+++ b/lib/Common/Memory/Allocator.h
@@ -147,8 +147,10 @@ inline T* PostAllocationCallback(const type_info& objType, T *obj)
 #define AllocatorNewNoThrowArrayZ(AllocatorType, alloc, T, count) AllocatorNewNoThrowArrayBase(AllocatorType, alloc, AllocZero, T, count)
 
 #define AllocatorNewNoThrowNoRecoveryArrayBase(AllocatorType, alloc, AllocFunc, T, count) AllocateArray<AllocatorType, T, true>(TRACK_ALLOC_INFO(alloc, T, AllocatorType, 0, count), &AllocatorType::NoThrowNoRecovery ## AllocFunc, count)
+#define AllocatorNewNoThrowNoRecoveryPlusBase(AllocatorType, alloc, AllocFunc, size, T, ...) new (TRACK_ALLOC_INFO(static_cast<AllocatorType *>(alloc), T, AllocatorType, size, (size_t)-1), true, &AllocatorType::NoThrowNoRecovery ## AllocFunc, size) T(__VA_ARGS__)
 
 #define AllocatorNewNoThrowNoRecoveryArrayZ(AllocatorType, alloc, T, count) AllocatorNewNoThrowNoRecoveryArrayBase(AllocatorType, alloc, AllocZero, T, count)
+#define AllocatorNewNoThrowNoRecoveryPlus(AllocatorType, alloc, size, T, ...) AllocatorNewNoThrowNoRecoveryPlusBase(AllocatorType, alloc, Alloc, size, T, __VA_ARGS__)
 
 // A few versions below supplies optional flags through ..., used by HeapDelete.
 #define AllocatorDelete(AllocatorType, alloc, obj, ...) \


### PR DESCRIPTION
While system memory is very low, it's trying to free some memory from recycler, which trigger's functionBody Cleanup, then triggers Releasing Interpreter ThunkBlocks, while releasing ThunkBlocks it tries to add to a free list, which is a dynamic allocated freelist, hence trigger another memory allocation and re-entering recycler memory recover routine
Fix is to use no-recovery alloc for this free list in arena
