### PR TITLE
Fix memory leak in AutoSystemInfo::InitPhysicalProcessorCount

### DIFF
--- a/lib/Common/Core/SysInfo.cpp
+++ b/lib/Common/Core/SysInfo.cpp
@@ -166,6 +166,7 @@ AutoSystemInfo::InitPhysicalProcessorCount()
     bResult = GetLogicalProcessorInformation(pBufferCurrent, &size);
     if (!bResult)
     {
+        NoCheckHeapDeleteArray(count, pBufferStart);
         return false;
     }
 


### PR DESCRIPTION
The heap buffer `pBufferStart` is not deleted if `GetLogicalProcessorInformation` fails.