### PR TITLE
Change thrown non-Error objects to rethrow as uncaught exceptions

### DIFF
--- a/lib/Common/Exceptions/Throw.h
+++ b/lib/Common/Exceptions/Throw.h
@@ -208,6 +208,10 @@ namespace Js {
         {       \
             hr = GetRuntimeErrorFunc(Js::RecyclableObject::FromVar(errorObject), nullptr);   \
         }   \
+        else if (errorObject != nullptr) \
+        {  \
+            hr = JSERR_UncaughtException; \
+        }  \
         else \
         {  \
             AssertMsg(errorObject == nullptr, "errorObject should be NULL");  \


### PR DESCRIPTION
Fixes OS: 11743399.

The macro error handling for thrown objects makes an assumption that if we throw non-Error objects, it has to be null. In this case, we revert to OOM error handling since we expect that a null error object indicates a fatal error.

However, it's possible someone will throw a non-Error object, in which case we can rethrow to let the host handle it.

Tested with Crawler and things seem to be clean. We might get a spike of bugs that previously showed as OOM lower on the stack. These should be more actionable with this change.
