### PR TITLE
Fix memory leak in WScriptJsrt::LoadTextFileCallback

### DIFF
--- a/bin/ch/WScriptJsrt.cpp
+++ b/bin/ch/WScriptJsrt.cpp
@@ -999,6 +999,7 @@ JsValueRef __stdcall WScriptJsrt::LoadTextFileCallback(JsValueRef callee, bool i
     HRESULT hr = E_FAIL;
     JsValueRef returnValue = JS_INVALID_REFERENCE;
     JsErrorCode errorCode = JsNoError;
+    const char* fileContent = nullptr;
 
     if (argumentCount < 2)
     {
@@ -1006,7 +1007,6 @@ JsValueRef __stdcall WScriptJsrt::LoadTextFileCallback(JsValueRef callee, bool i
     }
     else
     {
-        const char* fileContent;
         AutoString fileName;
 
         IfJsrtErrorSetGo(fileName.Initialize(arguments[1]));
@@ -1023,16 +1023,17 @@ JsValueRef __stdcall WScriptJsrt::LoadTextFileCallback(JsValueRef callee, bool i
             }
             else
             {
-                JsValueRef stringObject;
                 IfJsrtErrorSetGo(ChakraRTInterface::JsCreateString(
-                    fileContent, lengthBytes, &stringObject));
-                free((void*)fileContent);
-                return stringObject;
+                    fileContent, lengthBytes, &returnValue));
             }
         }
     }
 
 Error:
+    if (fileContent)
+    {
+        free((void*)fileContent);
+    }
     return returnValue;
 }
 


### PR DESCRIPTION
`fileContent` should be freed when `ChakraRTInterface::JsCreateString` fails.