### PR TITLE
WASM - Debug trace memory writes

### DIFF
--- a/lib/Backend/JnHelperMethodList.h
+++ b/lib/Backend/JnHelperMethodList.h
@@ -88,6 +88,7 @@ HELPERCALL(Op_Rem_Double, Js::NumberUtilities::Modulus, 0)
 #ifdef ENABLE_WASM
 HELPERCALL(Op_CheckWasmSignature, Js::WebAssembly::CheckSignature, AttrCanThrow)
 HELPERCALL(Op_GrowWasmMemory, Js::WebAssemblyMemory::GrowHelper, 0)
+HELPERCALL(Op_WasmMemoryTraceWrite, Js::WebAssemblyMemory::TraceMemWrite, 0)
 #endif
 
 HELPERCALL_FULL_OR_INPLACE_MATH(Op_Increment, Js::JavascriptMath::Increment, Js::SSE2::JavascriptMath::Increment, AttrCanThrow)

--- a/lib/Backend/JnHelperMethodList.h
+++ b/lib/Backend/JnHelperMethodList.h
@@ -88,7 +88,9 @@ HELPERCALL(Op_Rem_Double, Js::NumberUtilities::Modulus, 0)
 #ifdef ENABLE_WASM
 HELPERCALL(Op_CheckWasmSignature, Js::WebAssembly::CheckSignature, AttrCanThrow)
 HELPERCALL(Op_GrowWasmMemory, Js::WebAssemblyMemory::GrowHelper, 0)
+#if DBG
 HELPERCALL(Op_WasmMemoryTraceWrite, Js::WebAssemblyMemory::TraceMemWrite, 0)
+#endif
 #endif
 
 HELPERCALL_FULL_OR_INPLACE_MATH(Op_Increment, Js::JavascriptMath::Increment, Js::SSE2::JavascriptMath::Increment, AttrCanThrow)

--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -44,6 +44,7 @@ PHASE(All)
         PHASE(WasmDeferred)
         PHASE(WasmValidatePrejit)
         PHASE(WasmInOut) // Trace input and output of wasm calls
+        PHASE(WasmMemWrites) // Trace memory writes
     PHASE(Asmjs)
         PHASE(AsmjsTmpRegisterAllocation)
         PHASE(AsmjsEncoder)

--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -8633,6 +8633,7 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
         {
             JavascriptError::ThrowWebAssemblyRuntimeError(scriptContext, WASMERR_ArrayIndexOutOfRange);
         }
+
         BYTE* buffer = arr->GetBuffer();
         switch (playout->ViewType)
         {
@@ -8653,6 +8654,7 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
         case ArrayBufferView::ViewType::TYPE_UINT32_TO_INT64 : SetRegRaw<int64>(playout->Value, (int64)*(uint32*)(buffer + index)); return;
         default:Assert(UNREACHED);
         }
+        CompileAssert(ArrayBufferView::ViewType::TYPE_COUNT == 15);
 #else
         Assert(UNREACHED);
 #endif
@@ -8685,23 +8687,31 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
         BYTE* buffer = arr->GetBuffer();
         switch (playout->ViewType)
         {
-        case ArrayBufferView::ViewType::TYPE_INT8: *(int8*)(buffer + index) = (int8) (GetRegRaw<int32>(playout->Value)); return;
-        case ArrayBufferView::ViewType::TYPE_UINT8: *(uint8*)(buffer + index) = (uint8) (GetRegRaw<int32>(playout->Value)); return;
-        case ArrayBufferView::ViewType::TYPE_INT16: *(int16*)(buffer + index) = (int16) (GetRegRaw<int32>(playout->Value)); return;
-        case ArrayBufferView::ViewType::TYPE_UINT16: *(uint16*)(buffer + index) = (uint16) (GetRegRaw<int32>(playout->Value)); return;
-        case ArrayBufferView::ViewType::TYPE_INT32: *(int32*)(buffer + index) = (int32) (GetRegRaw<int32>(playout->Value)); return;
-        case ArrayBufferView::ViewType::TYPE_UINT32: *(uint32*)(buffer + index) = (uint32) (GetRegRaw<int32>(playout->Value)); return;
-        case ArrayBufferView::ViewType::TYPE_FLOAT32: *(float*)(buffer + index) = (float) (GetRegRaw<float>(playout->Value)); return;
-        case ArrayBufferView::ViewType::TYPE_FLOAT64: *(double*)(buffer + index) = (double) (GetRegRaw<double>(playout->Value)); return;
-        case ArrayBufferView::ViewType::TYPE_INT64: *(int64*)(buffer + index) = (int64) (GetRegRaw<int64>(playout->Value)); return;
-        case ArrayBufferView::ViewType::TYPE_INT8_TO_INT64: *(int8*)(buffer + index) = (int8) (GetRegRaw<int64>(playout->Value)); return;
-        case ArrayBufferView::ViewType::TYPE_UINT8_TO_INT64: *(uint8*)(buffer + index) = (uint8) (GetRegRaw<int64>(playout->Value)); return;
-        case ArrayBufferView::ViewType::TYPE_INT16_TO_INT64: *(int16*)(buffer + index) = (int16) (GetRegRaw<int64>(playout->Value)); return;
-        case ArrayBufferView::ViewType::TYPE_UINT16_TO_INT64: *(uint16*)(buffer + index) = (uint16) (GetRegRaw<int64>(playout->Value)); return;
-        case ArrayBufferView::ViewType::TYPE_INT32_TO_INT64: *(int32*)(buffer + index) = (int32) (GetRegRaw<int64>(playout->Value)); return;
-        case ArrayBufferView::ViewType::TYPE_UINT32_TO_INT64: *(uint32*)(buffer + index) = (uint32) (GetRegRaw<int64>(playout->Value)); return;
+        case ArrayBufferView::ViewType::TYPE_INT8: *(int8*)(buffer + index) = (int8) (GetRegRaw<int32>(playout->Value)); break;
+        case ArrayBufferView::ViewType::TYPE_UINT8: *(uint8*)(buffer + index) = (uint8) (GetRegRaw<int32>(playout->Value)); break;
+        case ArrayBufferView::ViewType::TYPE_INT16: *(int16*)(buffer + index) = (int16) (GetRegRaw<int32>(playout->Value)); break;
+        case ArrayBufferView::ViewType::TYPE_UINT16: *(uint16*)(buffer + index) = (uint16) (GetRegRaw<int32>(playout->Value)); break;
+        case ArrayBufferView::ViewType::TYPE_INT32: *(int32*)(buffer + index) = (int32) (GetRegRaw<int32>(playout->Value)); break;
+        case ArrayBufferView::ViewType::TYPE_UINT32: *(uint32*)(buffer + index) = (uint32) (GetRegRaw<int32>(playout->Value)); break;
+        case ArrayBufferView::ViewType::TYPE_FLOAT32: *(float*)(buffer + index) = (float) (GetRegRaw<float>(playout->Value)); break;
+        case ArrayBufferView::ViewType::TYPE_FLOAT64: *(double*)(buffer + index) = (double) (GetRegRaw<double>(playout->Value)); break;
+        case ArrayBufferView::ViewType::TYPE_INT64: *(int64*)(buffer + index) = (int64) (GetRegRaw<int64>(playout->Value)); break;
+        case ArrayBufferView::ViewType::TYPE_INT8_TO_INT64: *(int8*)(buffer + index) = (int8) (GetRegRaw<int64>(playout->Value)); break;
+        case ArrayBufferView::ViewType::TYPE_UINT8_TO_INT64: *(uint8*)(buffer + index) = (uint8) (GetRegRaw<int64>(playout->Value)); break;
+        case ArrayBufferView::ViewType::TYPE_INT16_TO_INT64: *(int16*)(buffer + index) = (int16) (GetRegRaw<int64>(playout->Value)); break;
+        case ArrayBufferView::ViewType::TYPE_UINT16_TO_INT64: *(uint16*)(buffer + index) = (uint16) (GetRegRaw<int64>(playout->Value)); break;
+        case ArrayBufferView::ViewType::TYPE_INT32_TO_INT64: *(int32*)(buffer + index) = (int32) (GetRegRaw<int64>(playout->Value)); break;
+        case ArrayBufferView::ViewType::TYPE_UINT32_TO_INT64: *(uint32*)(buffer + index) = (uint32) (GetRegRaw<int64>(playout->Value)); break;
         default:Assert(UNREACHED);
         }
+        CompileAssert(ArrayBufferView::ViewType::TYPE_COUNT == 15);
+#if DBG
+        if (PHASE_TRACE(WasmMemWritesPhase, m_functionBody))
+        {
+            m_wasmMemory->TraceMemWrite(m_wasmMemory, (uint32)GetRegRawInt(playout->SlotIndex), playout->Offset, playout->ViewType, (uint32)(size_t)this->DEBUG_currentByteOffset, scriptContext);
+        }
+#endif
+        return;
 #else
         Assert(UNREACHED);
 #endif

--- a/lib/Runtime/Library/WebAssemblyMemory.cpp
+++ b/lib/Runtime/Library/WebAssemblyMemory.cpp
@@ -170,6 +170,53 @@ WebAssemblyMemory::GrowHelper(WebAssemblyMemory * mem, uint32 deltaPages)
     return mem->GrowInternal(deltaPages);
 }
 
+void WebAssemblyMemory::TraceMemWrite(WebAssemblyMemory* mem, uint32 index, uint32 offset, Js::ArrayBufferView::ViewType viewType, uint32 bytecodeOffset, ScriptContext* context)
+{
+#if DBG
+    // Must call after the write
+    Assert(mem);
+    Output::Print(_u("#%04x "), bytecodeOffset);
+    uint64 bigIndex = (uint64)index + (uint64)offset;
+    if (index >= mem->m_buffer->GetByteLength())
+    {
+        Output::Print(_u("WasmMemoryTrace:: Writing out of bounds. %llu >= %u\n"), bigIndex, mem->m_buffer->GetByteLength());
+    }
+    if (offset)
+    {
+        Output::Print(_u("WasmMemoryTrace:: buf[%u + %u (%llu)] = "), index, offset, bigIndex);
+    }
+    else
+    {
+        Output::Print(_u("WasmMemoryTrace:: buf[%u] = "), index);
+    }
+    BYTE* buffer = mem->m_buffer->GetBuffer();
+    switch (viewType)
+    {
+    case ArrayBufferView::ViewType::TYPE_INT8_TO_INT64:
+    case ArrayBufferView::ViewType::TYPE_INT8: Output::Print(_u("%d\n"), *(int8*)(buffer + bigIndex)); break;
+    case ArrayBufferView::ViewType::TYPE_UINT8_TO_INT64:
+    case ArrayBufferView::ViewType::TYPE_UINT8: Output::Print(_u("%u\n"), *(uint8*)(buffer + bigIndex)); break;
+    case ArrayBufferView::ViewType::TYPE_INT16_TO_INT64:
+    case ArrayBufferView::ViewType::TYPE_INT16: Output::Print(_u("%d\n"), *(int16*)(buffer + bigIndex)); break;
+    case ArrayBufferView::ViewType::TYPE_UINT16_TO_INT64:
+    case ArrayBufferView::ViewType::TYPE_UINT16: Output::Print(_u("%u\n"), *(uint16*)(buffer + bigIndex)); break;
+    case ArrayBufferView::ViewType::TYPE_INT32_TO_INT64:
+    case ArrayBufferView::ViewType::TYPE_INT32: Output::Print(_u("%d\n"), *(int32*)(buffer + bigIndex)); break;
+    case ArrayBufferView::ViewType::TYPE_UINT32_TO_INT64:
+    case ArrayBufferView::ViewType::TYPE_UINT32: Output::Print(_u("%u\n"), *(uint32*)(buffer + bigIndex)); break;
+    case ArrayBufferView::ViewType::TYPE_FLOAT32: Output::Print(_u("%.4f\n"), *(float*)(buffer + bigIndex)); break;
+    case ArrayBufferView::ViewType::TYPE_FLOAT64: Output::Print(_u("%.8f\n"), *(double*)(buffer + bigIndex)); break;
+    case ArrayBufferView::ViewType::TYPE_INT64: Output::Print(_u("%lld\n"), *(int64*)(buffer + bigIndex)); break;
+    default:
+        CompileAssert(ArrayBufferView::ViewType::TYPE_COUNT == 15);
+        Assert(UNREACHED);
+    }
+    return;
+#else
+    Assert(UNREACHED);
+#endif
+}
+
 Var
 WebAssemblyMemory::EntryGetterBuffer(RecyclableObject* function, CallInfo callInfo, ...)
 {

--- a/lib/Runtime/Library/WebAssemblyMemory.cpp
+++ b/lib/Runtime/Library/WebAssemblyMemory.cpp
@@ -170,9 +170,9 @@ WebAssemblyMemory::GrowHelper(WebAssemblyMemory * mem, uint32 deltaPages)
     return mem->GrowInternal(deltaPages);
 }
 
+#if DBG
 void WebAssemblyMemory::TraceMemWrite(WebAssemblyMemory* mem, uint32 index, uint32 offset, Js::ArrayBufferView::ViewType viewType, uint32 bytecodeOffset, ScriptContext* context)
 {
-#if DBG
     // Must call after the write
     Assert(mem);
     Output::Print(_u("#%04x "), bytecodeOffset);
@@ -212,10 +212,8 @@ void WebAssemblyMemory::TraceMemWrite(WebAssemblyMemory* mem, uint32 index, uint
         Assert(UNREACHED);
     }
     return;
-#else
-    Assert(UNREACHED);
-#endif
 }
+#endif
 
 Var
 WebAssemblyMemory::EntryGetterBuffer(RecyclableObject* function, CallInfo callInfo, ...)

--- a/lib/Runtime/Library/WebAssemblyMemory.h
+++ b/lib/Runtime/Library/WebAssemblyMemory.h
@@ -41,7 +41,9 @@ namespace Js
         static int32 GrowHelper(Js::WebAssemblyMemory * memory, uint32 deltaPages);
 
         static int GetOffsetOfArrayBuffer() { return offsetof(WebAssemblyMemory, m_buffer); }
+#if DBG
         static void TraceMemWrite(WebAssemblyMemory* mem, uint32 index, uint32 offset, Js::ArrayBufferView::ViewType viewType, uint32 bytecodeOffset, ScriptContext* context);
+#endif
     private:
         WebAssemblyMemory(WebAssemblyArrayBuffer * buffer, uint32 initial, uint32 maximum, DynamicType * type);
 

--- a/lib/Runtime/Library/WebAssemblyMemory.h
+++ b/lib/Runtime/Library/WebAssemblyMemory.h
@@ -41,6 +41,7 @@ namespace Js
         static int32 GrowHelper(Js::WebAssemblyMemory * memory, uint32 deltaPages);
 
         static int GetOffsetOfArrayBuffer() { return offsetof(WebAssemblyMemory, m_buffer); }
+        static void TraceMemWrite(WebAssemblyMemory* mem, uint32 index, uint32 offset, Js::ArrayBufferView::ViewType viewType, uint32 bytecodeOffset, ScriptContext* context);
     private:
         WebAssemblyMemory(WebAssemblyArrayBuffer * buffer, uint32 initial, uint32 maximum, DynamicType * type);
 


### PR DESCRIPTION
Add config flag to trace memory writes in wasm
Very useful to find bugs in jitted code because we can determine where things went wrong when used with `-trace:WasmInOut`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/3243)
<!-- Reviewable:end -->
