### PR TITLE
use throw allocator for dynamicProfileInfoMapSaving

### DIFF
--- a/lib/Runtime/Language/SourceDynamicProfileManager.cpp
+++ b/lib/Runtime/Language/SourceDynamicProfileManager.cpp
@@ -329,11 +329,25 @@ namespace Js
         dynamicProfileInfoMapSaving.Reset();
     }
 
+    void SourceDynamicProfileManager::AddItem(LocalFunctionId functionId, DynamicProfileInfo *info)
+    {
+        try
+        {
+            // our BaseDictionary does not allow nothrow allocator
+            AUTO_NESTED_HANDLED_EXCEPTION_TYPE(ExceptionType_OutOfMemory);
+            dynamicProfileInfoMapSaving.Item(functionId, info);
+        }
+        catch (Js::OutOfMemoryException&)
+        {
+            Output::Print(_u("Hit OOM while saving dynamic profile info\n"));
+        }
+    }
+
     void SourceDynamicProfileManager::CopySavingData()
     {
         dynamicProfileInfoMap.Map([&](LocalFunctionId functionId, DynamicProfileInfo *info)
         {
-            dynamicProfileInfoMapSaving.Item(functionId, info);
+            this->AddItem(functionId, info);
         });
     }
 
@@ -341,7 +355,7 @@ namespace Js
     SourceDynamicProfileManager::SaveDynamicProfileInfo(LocalFunctionId functionId, DynamicProfileInfo * dynamicProfileInfo)
     {
         Assert(dynamicProfileInfo->GetFunctionBody()->HasExecutionDynamicProfileInfo());
-        dynamicProfileInfoMapSaving.Item(functionId, dynamicProfileInfo);
+        this->AddItem(functionId, dynamicProfileInfo);
     }
 
     template <typename T>

--- a/lib/Runtime/Language/SourceDynamicProfileManager.h
+++ b/lib/Runtime/Language/SourceDynamicProfileManager.h
@@ -23,7 +23,7 @@ namespace Js
     public:
         SourceDynamicProfileManager(Recycler* allocator) : isNonCachableScript(false), cachedStartupFunctions(nullptr), recycler(allocator),
 #ifdef DYNAMIC_PROFILE_STORAGE
-            dynamicProfileInfoMapSaving(&NoThrowHeapAllocator::Instance),
+            dynamicProfileInfoMapSaving(&HeapAllocator::Instance),
 #endif
             dynamicProfileInfoMap(allocator), startupFunctions(nullptr), profileDataCache(nullptr) 
         {
@@ -53,11 +53,12 @@ namespace Js
         FieldNoBarrier(Recycler*) recycler;
 
 #ifdef DYNAMIC_PROFILE_STORAGE
-        typedef JsUtil::BaseDictionary<LocalFunctionId, DynamicProfileInfo *, NoThrowHeapAllocator> DynamicProfileInfoMapSavingType;
+        typedef JsUtil::BaseDictionary<LocalFunctionId, DynamicProfileInfo *, HeapAllocator> DynamicProfileInfoMapSavingType;
         FieldNoBarrier(DynamicProfileInfoMapSavingType) dynamicProfileInfoMapSaving;
         
         void SaveDynamicProfileInfo(LocalFunctionId functionId, DynamicProfileInfo * dynamicProfileInfo);
         void SaveToDynamicProfileStorage(char16 const * url);
+        void AddItem(LocalFunctionId functionId, DynamicProfileInfo *info);
         template <typename T>
         static SourceDynamicProfileManager * Deserialize(T * reader, Recycler* allocator);
         template <typename T>


### PR DESCRIPTION
can't use nothrow allocator because our BaseDictionary does not support that.
need to handle the exception because saving dynamic profile info is in destructing code path.
