### PR TITLE
Update the expected results for Percent formatter based on latest Windows::Globalization behavior.

### DIFF
--- a/test/Intl/NumberFormat.js
+++ b/test/Intl/NumberFormat.js
@@ -4,7 +4,6 @@
 //-------------------------------------------------------------------------------------------------------
 
 // WinTH: Changed to use non-breaking space in some output
-var NON_BREAKING_SPACE = String.fromCharCode(0xA0);
 
 function testNumberFormatOptions(opts, number, expected, altExpected) {
     try{
@@ -61,7 +60,7 @@ testNumberFormatOptions({ maximumSignificantDigits: 5 }, 125.125, "125.13");
 testNumberFormatOptions({ maximumSignificantDigits: 5 }, -125.125, "-125.13");
 testNumberFormatOptions({ useGrouping: true }, 12512, "12,512");
 testNumberFormatOptions({ useGrouping: false }, 12512, "12512");
-testNumberFormatOptions({ style: "percent" }, 1.5, "150 %", /*altExpected*/"150" + NON_BREAKING_SPACE + "%");
+testNumberFormatOptions({ style: "percent" }, 1.5, "150%", /*altExpected*/"150%");
 testNumberFormatOptions({ currency: "USD", style: "currency", maximumFractionDigits: 2, minimumFractionDigits: 2 }, 1.5, "$1.50");
 
 testNumberFormatOptions({ minimumIntegerDigits: NaN }, undefined, undefined);

--- a/test/Intl/NumberFormatOptionsImplSpecific-Win10.js
+++ b/test/Intl/NumberFormatOptionsImplSpecific-Win10.js
@@ -40,8 +40,8 @@ var tests = [
         body: function () {
             const baseSigFigs = { minimumSignificantDigits: 3, maximumSignificantDigits: 3 };
 
-            assert.areEqual(new Intl.NumberFormat("en-US", extendOptions(baseSigFigs, { style: "percent" })).format(123.1), `12,300${NON_BREAKING_SPACE}%`, "style: percent");
-            assert.areEqual(new Intl.NumberFormat("en-US", extendOptions(baseSigFigs, { style: "percent", useGrouping: false })).format(123.1), `12300${NON_BREAKING_SPACE}%`, "style: percent, no grouping");
+            assert.areEqual(new Intl.NumberFormat("en-US", extendOptions(baseSigFigs, { style: "percent" })).format(123.1), `12,300%`, "style: percent");
+            assert.areEqual(new Intl.NumberFormat("en-US", extendOptions(baseSigFigs, { style: "percent", useGrouping: false })).format(123.1), `12300%`, "style: percent, no grouping");
         }
     }
 ];


### PR DESCRIPTION
I have verified this with a C# app as well and it looks like a change in the Windows::Globalization API.