### PR TITLE
Extend return register lifetime

### DIFF
--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -23589,6 +23589,7 @@ Lowerer::ValidOpcodeAfterLower(IR::Instr* instr, Func * func)
     }
     switch (opcode)
     {
+    case Js::OpCode::Ret:
     case Js::OpCode::Label:
     case Js::OpCode::StatementBoundary:
     case Js::OpCode::DeletedNonHelperBranch:

--- a/lib/Backend/LowerMDShared.cpp
+++ b/lib/Backend/LowerMDShared.cpp
@@ -863,8 +863,10 @@ LowererMD::LowerRet(IR::Instr * retInstr)
                 retInstr->SetSrc1(lowOpnd);
 
                 // Mov high bits to edx
-                IR::RegOpnd* regEdx = IR::RegOpnd::New(nullptr, RegEDX, regType, this->m_func);
+                IR::RegOpnd* regEdx = IR::RegOpnd::New(regType, this->m_func);
+                regEdx->SetReg(RegEDX);
                 Lowerer::InsertMove(regEdx, highOpnd, retInstr);
+                retInstr->SetSrc2(regEdx);
             }
 #endif
             break;
@@ -910,17 +912,19 @@ LowererMD::LowerRet(IR::Instr * retInstr)
             Assert(UNREACHED);
         }
 
-        retReg = IR::RegOpnd::New(nullptr, lowererMDArch.GetRegReturnAsmJs(regType), regType, m_func);
+        retReg = IR::RegOpnd::New(regType, m_func);
+        retReg->SetReg(lowererMDArch.GetRegReturnAsmJs(regType));
     }
     else
 #endif
     {
-        retReg = IR::RegOpnd::New(nullptr, lowererMDArch.GetRegReturn(TyMachReg), TyMachReg, m_func);
+        retReg = IR::RegOpnd::New(TyMachReg, m_func);
+        retReg->SetReg(lowererMDArch.GetRegReturn(TyMachReg));
     }
 
-    retInstr->SetDst(retReg);
-
-    return this->ChangeToAssign(retInstr);
+    Lowerer::InsertMove(retReg, retInstr->UnlinkSrc1(), retInstr);
+    retInstr->SetSrc1(retReg);
+    return retInstr;
 }
 
 ///----------------------------------------------------------------------------

--- a/lib/Backend/amd64/LowererMDArch.cpp
+++ b/lib/Backend/amd64/LowererMDArch.cpp
@@ -3030,6 +3030,9 @@ LowererMDArch::FinalLower()
     {
         switch (instr->m_opcode)
         {
+        case Js::OpCode::Ret:
+            instr->Remove();
+            break;
         case Js::OpCode::LdArgSize:
             Assert(this->m_func->HasTry());
             instr->m_opcode = Js::OpCode::MOV;

--- a/lib/Backend/arm/LowerMD.cpp
+++ b/lib/Backend/arm/LowerMD.cpp
@@ -8675,6 +8675,9 @@ LowererMD::FinalLower()
 
             switch (instr->m_opcode)
             {
+            case Js::OpCode::Ret:
+                instr->Remove();
+                break;
             case Js::OpCode::Leave:
                 Assert(this->m_func->DoOptimizeTry() && !this->m_func->IsLoopBodyInTry());
                 instrPrev = this->LowerLeave(instr, instr->AsBranchInstr()->GetTarget(), true /*fromFinalLower*/);

--- a/lib/Backend/arm/LowerMD.cpp
+++ b/lib/Backend/arm/LowerMD.cpp
@@ -2424,11 +2424,13 @@ LowererMD::CreateAssign(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsertPt, 
 IR::Instr *
 LowererMD::LowerRet(IR::Instr * retInstr)
 {
-    IR::RegOpnd *retReg = IR::RegOpnd::New(nullptr, RETURN_REG, TyMachReg, m_func);
+    IR::RegOpnd *retReg = IR::RegOpnd::New(TyMachReg, m_func);
+    retReg->SetReg(RETURN_REG);
+    Lowerer::InsertMove(retReg, retInstr->UnlinkSrc1(), retInstr);
 
-    retInstr->SetDst(retReg);
+    retInstr->SetSrc1(retReg);
 
-    return this->ChangeToAssign(retInstr);
+    return retInstr;
 }
 
 

--- a/lib/Backend/i386/LowererMDArch.cpp
+++ b/lib/Backend/i386/LowererMDArch.cpp
@@ -3970,6 +3970,9 @@ LowererMDArch::FinalLower()
     {
         switch (instr->m_opcode)
         {
+        case Js::OpCode::Ret:
+            instr->Remove();
+            break;
         case Js::OpCode::Leave:
             Assert(this->m_func->DoOptimizeTry() && !this->m_func->IsLoopBodyInTry());
             this->lowererMD->LowerLeave(instr, instr->AsBranchInstr()->GetTarget(), true /*fromFinalLower*/);


### PR DESCRIPTION
Keep the `Ret` instruction to extend the lifetime of the return register(s) then remove it in FinalLower. 

Fixing a bug in wasm int64 returns on x86  where edx is reused to reload a spilled value for eax.

Fixes [OSG 12195427](https://microsoft.visualstudio.com/os/_workitems?id=12195427)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/3264)
<!-- Reviewable:end -->
