### PR TITLE
Proxy should allow duplicate ownKeys when returning getOwnPropertyDescriptors

### DIFF
--- a/lib/Runtime/Library/JavascriptProxy.h
+++ b/lib/Runtime/Library/JavascriptProxy.h
@@ -185,11 +185,13 @@ namespace Js
                     {
                         targetToTrapResultMap.Add(propertyId, true);
                     }
+                }
 
-                    if (fn(propertyRecord))
-                    {
-                        trapResult->DirectSetItemAt(trapResultIndex++, element);
-                    }
+                // We explicitly allow duplicates in the results. A map is sufficient since the spec steps that remove entries
+                // remove ALL of them at the same time.
+                if (fn(propertyRecord))
+                {
+                    trapResult->DirectSetItemAt(trapResultIndex++, element);
                 }
             }
         }


### PR DESCRIPTION
Fixes test262 test\built-ins\Object\getOwnPropertyDescriptors\duplicate-keys.js and OS: 8729344

Simple spec update to allow duplicate keys to be returned in Object.getOwnPropertyDescriptors by always assigning the return array value. We do not need to keep track of the count because we always remove all instances from the property map in spec code.
