### PR TITLE
modify InterpreterThunkEmitter::IsInHeap to handle JIT process crashing

### DIFF
--- a/lib/Backend/InterpreterThunkEmitter.cpp
+++ b/lib/Backend/InterpreterThunkEmitter.cpp
@@ -761,11 +761,16 @@ InterpreterThunkEmitter::IsInHeap(void* address)
         PSCRIPTCONTEXT_HANDLE remoteScript = this->scriptContext->GetRemoteScriptAddr(false);
         if (!remoteScript || !JITManager::GetJITManager()->IsConnected())
         {
-            return false;
+            // this method is used in asserts to validate whether an entry point is valid
+            // in case JIT process crashed, let's just say true to keep asserts from firing
+            return true;
         }
         boolean result;
         HRESULT hr = JITManager::GetJITManager()->IsInterpreterThunkAddr(remoteScript, (intptr_t)address, this->isAsmInterpreterThunk, &result);
-        JITManager::HandleServerCallResult(hr, RemoteCallType::HeapQuery);
+        if (!JITManager::HandleServerCallResult(hr, RemoteCallType::HeapQuery))
+        {
+            return true;
+        }
         return result != FALSE;
     }
     else

--- a/lib/Backend/NativeCodeGenerator.cpp
+++ b/lib/Backend/NativeCodeGenerator.cpp
@@ -3715,7 +3715,9 @@ JITManager::HandleServerCallResult(HRESULT hr, RemoteCallType callType)
     case RemoteCallType::CodeGen:
         // inform job manager that JIT work item has been cancelled
         throw Js::OperationAbortedException();
+#if DBG
     case RemoteCallType::HeapQuery:
+#endif
     case RemoteCallType::ThunkCreation:
     case RemoteCallType::StateUpdate:
     case RemoteCallType::MemFree:

--- a/lib/Backend/NativeCodeGenerator.cpp
+++ b/lib/Backend/NativeCodeGenerator.cpp
@@ -3716,7 +3716,6 @@ JITManager::HandleServerCallResult(HRESULT hr, RemoteCallType callType)
         // inform job manager that JIT work item has been cancelled
         throw Js::OperationAbortedException();
     case RemoteCallType::HeapQuery:
-        Js::Throw::OutOfMemory();
     case RemoteCallType::ThunkCreation:
     case RemoteCallType::StateUpdate:
     case RemoteCallType::MemFree:


### PR DESCRIPTION
This is debug only method used in asserts to validate whether an entrypoint is valid. In case JIT process crashed, let's just return true to keep asserts from firing.