### PR TITLE
When clearing inline cache remove it from invalidation list

### DIFF
--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -1677,7 +1677,7 @@ namespace Js
                         Output::Print(_u("PropertyString '%s' : Invalidating LdElem cache for type %p\n"), string->GetString(), type);
                     }
 #endif
-                    cache->GetInlineCaches()[cache->GetInlineCacheIndexForType(type)].Clear();
+                    cache->GetInlineCaches()[cache->GetInlineCacheIndexForType(type)].RemoveFromInvalidationListAndClear(this->GetThreadContext());
                 }
                 cache = string->GetStElemInlineCache();
                 if (cache->PretendTrySetProperty(type, type, &info))
@@ -1688,7 +1688,7 @@ namespace Js
                         Output::Print(_u("PropertyString '%s' : Invalidating StElem cache for type %p\n"), string->GetString(), type);
                     }
 #endif
-                    cache->GetInlineCaches()[cache->GetInlineCacheIndexForType(type)].Clear();
+                    cache->GetInlineCaches()[cache->GetInlineCacheIndexForType(type)].RemoveFromInvalidationListAndClear(this->GetThreadContext());
                 }
             }
         }

--- a/lib/Runtime/Language/InlineCache.cpp
+++ b/lib/Runtime/Language/InlineCache.cpp
@@ -391,6 +391,16 @@ namespace Js
         }
     }
 
+    void InlineCache::RemoveFromInvalidationListAndClear(ThreadContext* threadContext)
+    {
+        if (this->RemoveFromInvalidationList())
+        {
+            threadContext->NotifyInlineCacheBatchUnregistered(1);
+        }
+
+        this->Clear();
+    }
+
     InlineCache *InlineCache::Clone(Js::PropertyId propertyId, ScriptContext* scriptContext)
     {
         Assert(scriptContext);

--- a/lib/Runtime/Language/InlineCache.h
+++ b/lib/Runtime/Language/InlineCache.h
@@ -222,8 +222,11 @@ namespace Js
                 return false;
             }
 
+            Assert(*this->invalidationListSlotPtr == this);
+
             *this->invalidationListSlotPtr = nullptr;
             this->invalidationListSlotPtr = nullptr;
+
             return true;
         }
 
@@ -314,6 +317,7 @@ namespace Js
         bool PretendTrySetProperty(Type *const type, Type *const oldType, PropertyCacheOperationInfo * operationInfo) const;
 
         void Clear();
+        void RemoveFromInvalidationListAndClear(ThreadContext* threadContext);
         template <class TAllocator>
         InlineCache *Clone(TAllocator *const allocator);
         InlineCache *Clone(Js::PropertyId propertyId, ScriptContext* scriptContext);

--- a/lib/Runtime/Language/InlineCache.inl
+++ b/lib/Runtime/Language/InlineCache.inl
@@ -454,10 +454,8 @@ namespace Js
             }
             inlineCaches[tryInlineCacheIndex].u = inlineCaches[inlineCacheIndex].u;
             UpdateInlineCachesFillInfo(tryInlineCacheIndex, true /*set*/);
-            // Let's clear the cache slot on which we had the collision. We might have stolen the invalidationListSlotPtr,
-            // so it may not pass VerifyRegistrationForInvalidation. Besides, it will be repopulated with the incoming data,
-            // and registered for invalidation, if necessary.
-            inlineCaches[inlineCacheIndex].Clear();
+            // Let's clear the cache slot on which we had the collision.
+            inlineCaches[inlineCacheIndex].RemoveFromInvalidationListAndClear(type->GetScriptContext()->GetThreadContext());
             Assert((this->inlineCachesFillInfo & (1 << inlineCacheIndex)) != 0);
             UpdateInlineCachesFillInfo(inlineCacheIndex, false /*set*/);
         }

--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -4510,7 +4510,7 @@ namespace Js
                 // point on, when the same function object is used as a constructor, the a new object with the final type will
                 // be created. Whatever is stored in the inline cache currently will cause cache misses after the constructor
                 // cache update. So, just clear it now so that the caches won't be flagged as polymorphic.
-                inlineCache->Clear();
+                inlineCache->RemoveFromInvalidationListAndClear(this->GetScriptContext()->GetThreadContext());
             }
             return;
         }
@@ -4553,7 +4553,7 @@ namespace Js
             // point on, when the same function object is used as a constructor, the a new object with the final type will
             // be created. Whatever is stored in the inline cache currently will cause cache misses after the constructor
             // cache update. So, just clear it now so that the caches won't be flagged as polymorphic.
-            inlineCache->Clear();
+            inlineCache->RemoveFromInvalidationListAndClear(this->GetScriptContext()->GetThreadContext());
         }
     }
 
@@ -4582,7 +4582,7 @@ namespace Js
             // point on, when the same function object is used as a constructor, the a new object with the final type will
             // be created. Whatever is stored in the inline cache currently will cause cache misses after the constructor
             // cache update. So, just clear it now so that the caches won't be flagged as polymorphic.
-            inlineCache->Clear();
+            inlineCache->RemoveFromInvalidationListAndClear(this->GetScriptContext()->GetThreadContext());
         }
     }
 

--- a/lib/Runtime/Language/ProfilingHelpers.cpp
+++ b/lib/Runtime/Language/ProfilingHelpers.cpp
@@ -1176,7 +1176,7 @@ namespace Js
                 // point on, when the same function object is used as a constructor, the a new object with the final type will
                 // be created. Whatever is stored in the inline cache currently will cause cache misses after the constructor
                 // cache update. So, just clear it now so that the caches won't be flagged as polymorphic.
-                inlineCache->Clear();
+                inlineCache->RemoveFromInvalidationListAndClear(scriptContext->GetThreadContext());
             }
         }
         else


### PR DESCRIPTION
During non-shutdown scenarios clearing the inline cache zeroes the
invalidationListSlotPtr but the node in various inlinecachelist on
threadcontext still point to inlinecache. In release build we only check
for values which are null and compact them but in debug build we have
validation which access the type stored thus reading invalid memory.
Invalidation should also help in more compaction.
