### PR TITLE
Enable -loop:<iterations> in ch.exe

### DIFF
--- a/bin/ch/ChakraRtInterface.cpp
+++ b/bin/ch/ChakraRtInterface.cpp
@@ -173,6 +173,9 @@ bool ChakraRTInterface::LoadChakraDll(ArgInfo* argInfo, HINSTANCE *outLibrary)
 /*static*/
 void ChakraRTInterface::UnloadChakraDll(HINSTANCE library)
 {
+    m_testHooks = { 0 };
+    m_testHooksSetup = false;
+    m_testHooksInitialized = false;
 #ifndef CHAKRA_STATIC_LIBRARY
     Assert(library != nullptr);
     FARPROC pDllCanUnloadNow = (FARPROC) GetChakraCoreSymbol(library, "DllCanUnloadNow");

--- a/bin/ch/ChakraRtInterface.h
+++ b/bin/ch/ChakraRtInterface.h
@@ -259,7 +259,15 @@ public:
     static HRESULT SetConfigFlags(__in int argc, __in_ecount(argc) LPWSTR argv[], ICustomConfigFlags* customConfigFlags) { return CHECKED_CALL(SetConfigFlags, argc, argv, customConfigFlags); }
     static HRESULT GetFileNameFlag(BSTR * filename) { return CHECKED_CALL(GetFilenameFlag, filename); }
     static HRESULT PrintConfigFlagsUsageString() { m_usageStringPrinted = true;  return CHECKED_CALL(PrintConfigFlagsUsageString); }
-
+    static HRESULT GetLoopFlag(int* flag)
+    {
+#ifdef ENABLE_DEBUG_CONFIG_OPTIONS
+        return CHECKED_CALL(GetLoopFlag, flag);
+#else
+        *flag = DEFAULT_CONFIG_Loop;
+        return S_OK;
+#endif
+    }
 #ifdef CHECK_MEMORY_LEAK
     static bool IsEnabledCheckMemoryFlag() { return CHECKED_CALL_RETURN(IsEnabledCheckMemoryLeakFlag, FALSE); }
     static HRESULT SetCheckMemoryLeakFlag(bool flag) { return CHECKED_CALL(SetCheckMemoryLeakFlag, flag); }

--- a/bin/ch/WScriptJsrt.cpp
+++ b/bin/ch/WScriptJsrt.cpp
@@ -980,6 +980,8 @@ JsErrorCode WScriptJsrt::InitializeModuleCallbacks()
 
 bool WScriptJsrt::Uninitialize()
 {
+    messageQueue = nullptr;
+    sourceContext = 0;
     // moduleRecordMap is a global std::map, its destructor may access overrided
     // "operator delete" / global HeapAllocator::Instance. Clear it manually here
     // to avoid worrying about global destructor order.


### PR DESCRIPTION
This is something we have in jshost.exe
I wasn't able to reproduce the exact same behavior as jshost where it reuses the same threadcontext, but at least it makes it easier to run multiple iterations of the same script.

@Microsoft/chakra-developers can someone review this please ?

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/3283)
<!-- Reviewable:end -->
