### PR TITLE
Fix lambda function source extents for a couple of cases

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -3141,7 +3141,7 @@ ParseNodePtr Parser::ParseTerm(BOOL fAllowCall,
         }
         else
         {
-            ParseNodePtr pnodeExpr = ParseTerm<buildAST>(FALSE, pNameHint, pHintLength, pShortNameOffset);
+            ParseNodePtr pnodeExpr = ParseTerm<buildAST>(FALSE, pNameHint, pHintLength, pShortNameOffset, nullptr, false, nullptr, nullptr, nullptr, plastRParen);
             if (buildAST)
             {
                 pnode = CreateCallNode(knopNew, pnodeExpr, nullptr);
@@ -8161,7 +8161,7 @@ ParseNodePtr Parser::ParseExpr(int oplMin,
         else
         {
             // Disallow spread after a unary operator.
-            pnodeT = ParseExpr<buildAST>(opl, &fCanAssign, TRUE, FALSE, nullptr /*hint*/, nullptr /*hintLength*/, nullptr /*hintOffset*/, &operandToken, true);
+            pnodeT = ParseExpr<buildAST>(opl, &fCanAssign, TRUE, FALSE, nullptr /*hint*/, nullptr /*hintLength*/, nullptr /*hintOffset*/, &operandToken, true, nullptr, plastRParen);
         }
 
         if (nop != knopYieldLeaf)
@@ -8452,7 +8452,7 @@ ParseNodePtr Parser::ParseExpr(int oplMin,
         {
             pnodeT = ParseExpr<buildAST>(koplAsg, NULL, fAllowIn);
             ChkCurTok(tkColon, ERRnoColon);
-            ParseNodePtr pnodeT2 = ParseExpr<buildAST>(koplAsg, NULL, fAllowIn);
+            ParseNodePtr pnodeT2 = ParseExpr<buildAST>(koplAsg, NULL, fAllowIn, 0, nullptr, nullptr, nullptr, nullptr, false, nullptr, plastRParen);
             if (buildAST)
             {
                 pnode = CreateTriNode(nop, pnode, pnodeT, pnodeT2);

--- a/test/es6/lambda1.js
+++ b/test/es6/lambda1.js
@@ -514,6 +514,49 @@ var tests = [
         body: function () {
             assert.throws(() => { eval('--par=>'); }, SyntaxError, "Expected syntax error.");
         }
+    },
+    {
+        name: "Lambda consisting of question-mark operator with false-branch wrapped in parens",
+        body: function () {
+            var l = () => true ? 1 : (0)
+            assert.areEqual('() => true ? 1 : (0)', '' + l, "Lambda to string should include the parens wrapping the false branch");
+            
+            var l = () => true ? 1 : ('๏บบ')
+            assert.areEqual("() => true ? 1 : ('๏บบ')", '' + l, "Multi-byte characters should not break the string");
+            
+            var s = "() => true ? 1 : ('\u{20ac}')";
+            var l = eval(s);
+            assert.areEqual(s, '' + l, "Unicode byte sequences should not break the string");
+            
+            var l = async() => true ? 1 : (0);
+            assert.areEqual('async() => true ? 1 : (0)', '' + l, "Async lambda should also be correct");
+            
+            var l = () => true ? 1 : (() => false ? 1 : (0))
+            assert.areEqual('() => true ? 1 : (() => false ? 1 : (0))', '' + l, "Nested lambda to string should be correct");
+            
+            var l = async() => true ? 1 : (() => false ? 1 : (0))
+            assert.areEqual("async() => true ? 1 : (() => false ? 1 : (0))", '' + l, "Nested async lambda should be correct");
+        }
+    },
+    {
+        name: "Lambda consisting of new expression where constructor is wrapped in parens",
+        body: function () {
+            var l = () => new (Boolean)
+            assert.areEqual('() => new (Boolean)', '' + l, "Lambda to string should include the parens wrapping the constructor");
+            
+            var l = async () => new (Boolean)
+            assert.areEqual('async () => new (Boolean)', '' + l, "Async lambda should work");
+        }
+    },
+    {
+        name: "Async lambda consisting of single await which is wrapped in parens",
+        body: function () {
+            var l = async () => await (5)
+            assert.areEqual('async () => await (5)', '' + l, "Lambda to string should include the parens wrapping the await argument");
+            
+            var l = () => await (5)
+            assert.areEqual('() => await (5)', '' + l, "Regular lambda should also work, though this await looks like a function call");
+        }
     }
 ];
 


### PR DESCRIPTION
When we convert a lambda function to a string, we decode characters from the UTF-8 source based on the extents of the function we calculated during parse-time. In some cases, the extents are wrong and we will crash during decode because the count of characters we decoded will not match the count of characters we expected to decode. This affects lambda functions rather than regular functions because curly braces are optional for lambdas which consist of a single expression and not all expressions handle trailing right-parens correctly. This change fixes three such cases.

Lambda consisting of a single question mark expression in which the false-branch is wrapped in parens:
`() => x ? 1 : (0)`

Lambda consisting of a single new expression in which the constructor is wrapped in parens:
`() => new (Boolean)`

Async lambda consisting of a single await expression where the argument to await is wrapped in parens:
`async() => await (5)`
