### PR TITLE
fix issue where call will be in helper block if JIT thunk allocation fails

### DIFF
--- a/lib/Backend/JITOutput.cpp
+++ b/lib/Backend/JITOutput.cpp
@@ -256,7 +256,7 @@ JITOutput::FinalizeNativeCode()
         m_func->GetOOPCodeGenAllocators()->emitBufferManager.CompletePreviousAllocation(m_oopAlloc);
 #if defined(_CONTROL_FLOW_GUARD)
 #if _M_IX86 || _M_X64
-        if (m_func->GetThreadContextInfo()->IsCFGEnabled() && !m_func->IsLoopBody())
+        if (!m_func->IsLoopBody() && CONFIG_FLAG(UseJITTrampoline))
         {
             m_outputData->thunkAddress = m_func->GetOOPThreadContext()->GetJITThunkEmitter()->CreateThunk(m_outputData->codeAddress);
         }
@@ -276,7 +276,7 @@ JITOutput::FinalizeNativeCode()
 
 #if defined(_CONTROL_FLOW_GUARD)
 #if _M_IX86 || _M_X64
-        if (m_func->GetThreadContextInfo()->IsCFGEnabled() && !m_func->IsLoopBody())
+        if (!m_func->IsLoopBody() && CONFIG_FLAG(UseJITTrampoline))
         {
             m_outputData->thunkAddress = m_func->GetInProcThreadContext()->GetJITThunkEmitter()->CreateThunk(m_outputData->codeAddress);
         }

--- a/lib/Backend/LowerMDShared.cpp
+++ b/lib/Backend/LowerMDShared.cpp
@@ -5783,9 +5783,8 @@ LowererMD::GenerateNumberAllocation(IR::RegOpnd * opndDst, IR::Instr * instrInse
 void
 LowererMD::GenerateCFGCheck(IR::Opnd * entryPointOpnd, IR::Instr * insertBeforeInstr)
 {
-    bool useJITTrampoline = m_func->GetThreadContextInfo()->IsCFGEnabled();
-    IR::LabelInstr * callLabelInstr = IR::LabelInstr::New(Js::OpCode::Label, m_func);
-    IR::LabelInstr * cfgLabelInstr = IR::LabelInstr::New(Js::OpCode::Label, m_func, useJITTrampoline);
+    bool useJITTrampoline = CONFIG_FLAG(UseJITTrampoline);
+    IR::LabelInstr * callLabelInstr = nullptr;
     uintptr_t jitThunkStartAddress = NULL;
     if (useJITTrampoline)
     {
@@ -5810,6 +5809,9 @@ LowererMD::GenerateCFGCheck(IR::Opnd * entryPointOpnd, IR::Instr * insertBeforeI
             IR::AddrOpnd * endAddressOfSegmentConstOpnd = IR::AddrOpnd::New(endAddressOfSegment, IR::AddrOpndKindDynamicMisc, m_func);
             IR::RegOpnd *resultOpnd = IR::RegOpnd::New(TyMachReg, this->m_func);
 
+            callLabelInstr = IR::LabelInstr::New(Js::OpCode::Label, m_func);
+            IR::LabelInstr * cfgLabelInstr = IR::LabelInstr::New(Js::OpCode::Label, m_func, true);
+
             // resultOpnd = SUB endAddressOfSegmentConstOpnd, entryPointOpnd
             // CMP resultOpnd, TotalThunkSize
             // JAE $cfgLabel
@@ -5819,9 +5821,10 @@ LowererMD::GenerateCFGCheck(IR::Opnd * entryPointOpnd, IR::Instr * insertBeforeI
             m_lowerer->InsertCompareBranch(resultOpnd, IR::IntConstOpnd::New(InProcJITThunkEmitter::TotalThunkSize, TyMachReg, m_func, true), Js::OpCode::BrGe_A, true, cfgLabelInstr, insertBeforeInstr);
             m_lowerer->InsertAnd(entryPointOpnd, entryPointOpnd, IR::IntConstOpnd::New(InProcJITThunkEmitter::ThunkAlignmentMask, TyMachReg, m_func, true), insertBeforeInstr);
             m_lowerer->InsertBranch(Js::OpCode::Br, callLabelInstr, insertBeforeInstr);
+
+            insertBeforeInstr->InsertBefore(cfgLabelInstr);
         }
     }
-    insertBeforeInstr->InsertBefore(cfgLabelInstr);
     //MOV  ecx, entryPoint
     IR::RegOpnd * entryPointRegOpnd = IR::RegOpnd::New(TyMachReg, this->m_func);
 #if _M_IX86
@@ -5856,12 +5859,15 @@ LowererMD::GenerateCFGCheck(IR::Opnd * entryPointOpnd, IR::Instr * insertBeforeI
     if (jitThunkStartAddress)
     {
         Assert(callLabelInstr);
-#if DBG
-        //Always generate CFG check in DBG build to make sure that the address is still valid
-        movInstrEntryPointToRegister->InsertBefore(callLabelInstr);
-#else
-        insertBeforeInstr->InsertBefore(callLabelInstr);
-#endif
+        if (CONFIG_FLAG(ForceJITCFGCheck))
+        {
+            // Always generate CFG check to make sure that the address is still valid
+            movInstrEntryPointToRegister->InsertBefore(callLabelInstr);
+        }
+        else
+        {
+            insertBeforeInstr->InsertBefore(callLabelInstr);
+        }
     }
 }
 #endif

--- a/lib/Backend/LowerMDShared.cpp
+++ b/lib/Backend/LowerMDShared.cpp
@@ -5803,7 +5803,7 @@ LowererMD::GenerateCFGCheck(IR::Opnd * entryPointOpnd, IR::Instr * insertBeforeI
         if (jitThunkStartAddress)
         {
             uintptr_t endAddressOfSegment = jitThunkStartAddress + InProcJITThunkEmitter::TotalThunkSize;
-
+            Assert(endAddressOfSegment > jitThunkStartAddress);
             // Generate instructions for local Pre-Reserved Segment Range check
 
             IR::AddrOpnd * endAddressOfSegmentConstOpnd = IR::AddrOpnd::New(endAddressOfSegment, IR::AddrOpndKindDynamicMisc, m_func);

--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -676,6 +676,8 @@ PHASE(All)
 #define DEFAULT_CONFIG_PerfHintLevel (1)
 #define DEFAULT_CONFIG_OOPJITMissingOpts (true)
 #define DEFAULT_CONFIG_OOPCFGRegistration (true)
+#define DEFAULT_CONFIG_ForceJITCFGCheck (false)
+#define DEFAULT_CONFIG_UseJITTrampoline (true)
 
 #define DEFAULT_CONFIG_FailFastIfDisconnectedDelegate    (false)
 
@@ -1241,6 +1243,8 @@ FLAGNR(Boolean, NoDeferParse          , "Disable deferred parsing", false)
 FLAGNR(Boolean, NoLogo                , "No logo, which we don't display anyways", false)
 FLAGNR(Boolean, OOPJITMissingOpts     , "Use optimizations that are missing from OOP JIT", DEFAULT_CONFIG_OOPJITMissingOpts)
 FLAGNR(Boolean, OOPCFGRegistration    , "Do CFG registration OOP (under OOP JIT)", DEFAULT_CONFIG_OOPCFGRegistration)
+FLAGNR(Boolean, ForceJITCFGCheck      , "Have JIT code always do CFG check even if range check succeeded", DEFAULT_CONFIG_ForceJITCFGCheck)
+FLAGNR(Boolean, UseJITTrampoline      , "Use trampoline for JIT entry points and emit range checks for it", DEFAULT_CONFIG_UseJITTrampoline)
 #ifdef _ARM64_
 FLAGR (Boolean, NoNative              , "Disable native codegen", true)
 #else


### PR DESCRIPTION
We don't need to insert the helper label at all unless we are emitting range check.

Also, added a couple of config flags to help debugging.

OS#12460279