### PR TITLE
Fix early exception throws in the presence of function calls within finally code

### DIFF
--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -6751,6 +6751,9 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
                 this->ProcessTryHandlerBailout(ehBailoutData->child, --tryNestingDepth);
             }
 
+            Js::JavascriptExceptionObject * exceptionObj = this->scriptContext->GetThreadContext()->GetPendingFinallyException();
+            this->scriptContext->GetThreadContext()->SetPendingFinallyException(nullptr);
+
             int finallyEndOffset = this->ProcessFinally();
 
             if (--this->nestedFinallyDepth == -1)
@@ -6759,8 +6762,6 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
                 this->m_flags &= ~InterpreterStackFrameFlags_WithinFinallyBlock;
             }
 
-            volatile Js::JavascriptExceptionObject * exceptionObj = this->scriptContext->GetThreadContext()->GetPendingFinallyException();
-            this->scriptContext->GetThreadContext()->SetPendingFinallyException(nullptr);
             // Finally exited with LeaveNull, We don't throw for early returns
             if (finallyEndOffset == 0 && exceptionObj)
             {

--- a/test/EH/rlexe.xml
+++ b/test/EH/rlexe.xml
@@ -107,4 +107,10 @@
       <baseline>early2.baseline</baseline>
     </default>
   </test>
+  <test>
+    <default>
+      <files>tryfinallybug0.js</files>
+      <baseline>tryfinallybug0.baseline</baseline>
+    </default>
+  </test>
 </regress-exe>

--- a/test/EH/tryfinallybug0.baseline
+++ b/test/EH/tryfinallybug0.baseline
@@ -1,0 +1,9 @@
+ in 0
+ done 0
+ in 0
+ done 0
+ in 1
+ in 2
+ done 2
+RangeError: The precision is out of range
+ done 1

--- a/test/EH/tryfinallybug0.js
+++ b/test/EH/tryfinallybug0.js
@@ -1,0 +1,35 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function foo(arg0){
+  WScript.Echo(" in " + arg0);
+       ui32;
+  try {
+    try {
+      var num = 100;
+      if (arg0 == 1) {
+      num.toPrecision(500);
+      }
+    }
+    finally {
+      if (arg0 == 1) {
+        foo(2);
+      }
+      if (arg0 == 2) {
+        ui32[187953167];
+      }
+    }
+  }
+  catch(e) {
+          WScript.Echo(e);
+  }
+  WScript.Echo(" done " + arg0);
+}
+
+var ui32 = new Uint32Array();
+foo(0);
+foo(0);
+foo(1);
+


### PR DESCRIPTION
When there is an exception in tryfinally, we set the pendinfFinallyException object on the threadContext and bailout to the interpreter.
In the interpreter we read the pendingFinallyException from the threadContext and throw.
But if the finally code calls a function which has try finally, and bails out in the finally code due to a different reason,
we will end up reading the pendingFinallyExceptionObject on the threadContext and throw early.
With this change, we read the pendingFinallyExceptionObject from the threadContext before running finally code.
