### PR TITLE
Clear the auto restore data if we have a valid function already

### DIFF
--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -2276,6 +2276,9 @@ namespace Js
 
                 funcBody = this->GetFunctionBody();
 
+                // As we have a valid function body already clear the restore data
+                autoRestoreFunctionInfo.Clear();
+
                 if (isDebugOrAsmJsReparse)
                 {
 #if ENABLE_DEBUG_CONFIG_OPTIONS


### PR DESCRIPTION
We don't have to track the restore data if the function body is valid.
