### PR TITLE
os#11759200: end dead lifetimes after op helpers

### DIFF
--- a/lib/Backend/LinearScan.cpp
+++ b/lib/Backend/LinearScan.cpp
@@ -222,9 +222,10 @@ LinearScan::RegAlloc()
         }
 
         this->SetSrcRegs(instr);
-        this->EndDeadLifetimes(instr);
 
         this->CheckOpHelper(instr);
+
+        this->EndDeadLifetimes(instr);
 
         this->KillImplicitRegs(instr);
 


### PR DESCRIPTION
When an opHelper block ends a loop, lifetimes that would have ended during the block are extended to end on the branch instruction that ends both block and loop. When processing that instruction, dead spilled lifetimes are be moved from opHelperSpilledLiveranges to activeLiveranges after the call to EndDeadLifetimes but before EndDeadOpHelperLifetimes causing them to remain on the active list while dead, and potentially be considered for a spill on the next non-label instruction. 

The bug this PR fixes occurs when the loop is followed immediately by an empty OpHelper block. The empty block increments totalOpHelperVisitedLength by 1, and if the next non-label instruction requires a register to be spilled during SetSrcRegs, the dead lifetime will trigger the assert comparing opHelper lengths in GetSpillCost.
