### PR TITLE
clean up asm.js/wasm entrypoint management

### DIFF
--- a/lib/Backend/NativeCodeGenerator.cpp
+++ b/lib/Backend/NativeCodeGenerator.cpp
@@ -549,10 +549,6 @@ NativeCodeGenerator::GenerateFunction(Js::FunctionBody *fn, Js::ScriptFunction *
         // Set asmjs to be true in entrypoint
         entryPointInfo->SetIsAsmJSFunction(true);
 
-        // Update the native address of the older entry point - this should be either the TJ entrypoint or the Interpreter Entry point
-        entryPointInfo->SetNativeAddress(oldFuncObjEntryPointInfo->jsMethod);
-        // have a reference to TJ entrypointInfo, this will be queued for collection in checkcodegen
-        entryPointInfo->SetOldFunctionEntryPointInfo(oldFuncObjEntryPointInfo);
         Assert(PHASE_ON1(Js::AsmJsJITTemplatePhase) || (!oldFuncObjEntryPointInfo->GetIsTJMode() && !entryPointInfo->GetIsTJMode()));
         // this changes the address in the entrypointinfo to be the AsmJsCodgenThunk
         function->UpdateThunkEntryPoint(entryPointInfo, NativeCodeGenerator::CheckAsmJsCodeGenThunk);
@@ -1530,7 +1526,7 @@ NativeCodeGenerator::CheckAsmJsCodeGen(Js::ScriptFunction * function)
         {
             Output::Print(_u("Codegen not done yet for function: %s, Entrypoint is CheckAsmJsCodeGenThunk\n"), function->GetFunctionBody()->GetDisplayName());
         }
-        return reinterpret_cast<Js::Var>(entryPoint->GetNativeEntrypoint());
+        return reinterpret_cast<Js::Var>(functionBody->GetOriginalEntryPoint());
     }
     if (PHASE_TRACE1(Js::AsmjsEntryPointInfoPhase))
     {

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -3735,18 +3735,7 @@ namespace Js
         {
             entryPointInfo->jsMethod = directEntryPoint;
         }
-#ifdef ASMJS_PLAT
-        if (isAsmJs)
-        {
-            // release the old entrypointinfo if available
-            FunctionEntryPointInfo* oldEntryPointInfo = entryPointInfo->GetOldFunctionEntryPointInfo();
-            if (oldEntryPointInfo)
-            {
-                this->GetScriptContext()->GetThreadContext()->QueueFreeOldEntryPointInfoIfInScript(oldEntryPointInfo);
-                oldEntryPointInfo = nullptr;
-            }
-        }
-#endif
+
         this->CaptureDynamicProfileState(entryPointInfo);
 
         if(entryPointInfo->GetJitMode() == ExecutionMode::SimpleJit)
@@ -9569,18 +9558,6 @@ namespace Js
     }
 
 #ifdef ASMJS_PLAT
-    void FunctionEntryPointInfo::SetOldFunctionEntryPointInfo(FunctionEntryPointInfo* entrypointInfo)
-    {
-        Assert(this->GetIsAsmJSFunction());
-        Assert(entrypointInfo);
-        mOldFunctionEntryPointInfo = entrypointInfo;
-    };
-
-    FunctionEntryPointInfo* FunctionEntryPointInfo::GetOldFunctionEntryPointInfo()const
-    {
-        Assert(this->GetIsAsmJSFunction());
-        return mOldFunctionEntryPointInfo;
-    };
     void FunctionEntryPointInfo::SetIsTJMode(bool value)
     {
         Assert(this->GetIsAsmJSFunction());

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -1068,16 +1068,11 @@ namespace Js
 
     private:
         Field(ExecutionMode) jitMode;
-        Field(FunctionEntryPointInfo*) mOldFunctionEntryPointInfo; // strong ref to oldEntryPointInfo(Int or TJ) in asm to ensure we don't collect it before JIT is completed
         Field(bool)       mIsTemplatizedJitMode; // true only if in TJ mode, used only for debugging
     public:
         FunctionEntryPointInfo(FunctionProxy * functionInfo, Js::JavascriptMethod method, ThreadContext* context, void* validationCookie);
 
 #ifdef ASMJS_PLAT
-        //AsmJS Support
-
-        void SetOldFunctionEntryPointInfo(FunctionEntryPointInfo* entrypointInfo);
-        FunctionEntryPointInfo* GetOldFunctionEntryPointInfo()const;
         void SetIsTJMode(bool value);
         bool GetIsTJMode()const;
         //End AsmJS Support

--- a/lib/Runtime/Library/ScriptFunction.cpp
+++ b/lib/Runtime/Library/ScriptFunction.cpp
@@ -225,19 +225,16 @@ namespace Js
             entryPointInfo->jsMethod = entryPoint;
         }
 
-        if (!isAsmJS)
+        ProxyEntryPointInfo* oldEntryPointInfo = this->GetScriptFunctionType()->GetEntryPointInfo();
+        if (oldEntryPointInfo
+            && oldEntryPointInfo != entryPointInfo
+            && oldEntryPointInfo->SupportsExpiration())
         {
-            ProxyEntryPointInfo* oldEntryPointInfo = this->GetScriptFunctionType()->GetEntryPointInfo();
-            if (oldEntryPointInfo
-                && oldEntryPointInfo != entryPointInfo
-                && oldEntryPointInfo->SupportsExpiration())
-            {
-                // The old entry point could be executing so we need root it to make sure
-                // it isn't prematurely collected. The rooting is done by queuing it up on the threadContext
-                ThreadContext* threadContext = ThreadContext::GetContextForCurrentThread();
+            // The old entry point could be executing so we need root it to make sure
+            // it isn't prematurely collected. The rooting is done by queuing it up on the threadContext
+            ThreadContext* threadContext = ThreadContext::GetContextForCurrentThread();
 
-                threadContext->QueueFreeOldEntryPointInfoIfInScript((FunctionEntryPointInfo*)oldEntryPointInfo);
-            }
+            threadContext->QueueFreeOldEntryPointInfoIfInScript((FunctionEntryPointInfo*)oldEntryPointInfo);
         }
 
         this->GetScriptFunctionType()->SetEntryPointInfo(entryPointInfo);


### PR DESCRIPTION
There were a few places where asm.js strayed needlessly from how js manages entrypoints.

In case of NativeAddress usage, there was a race condition that could lead to us calling direct JIT address rather than the JIT thunk, leading to CFG failure.

It also looks like we may have been leaking old entrypoints.

OS: 12228631