### PR TITLE
Fix Issue#3217: Reflect.construct permanently corrupts the invoked constructor

### DIFF
--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -6247,7 +6247,7 @@ CommonNumber:
                 if (typeHandler->IsSharable())
                 {
 #if DBG
-                    bool cachedProtoCanBeCached;
+                    bool cachedProtoCanBeCached = false;
                     Assert(type->GetPrototype() == JavascriptOperators::GetPrototypeObjectForConstructorCache(constructor, requestContext, cachedProtoCanBeCached));
                     Assert(cachedProtoCanBeCached);
                     Assert(type->GetScriptContext() == constructorCache->GetScriptContext());

--- a/lib/Runtime/Library/JavascriptFunction.cpp
+++ b/lib/Runtime/Library/JavascriptFunction.cpp
@@ -938,13 +938,15 @@ namespace Js
                 resultObject,
                 JavascriptFunction::Is(functionObj) && functionObj->GetScriptContext() == scriptContext ?
                 JavascriptFunction::FromVar(functionObj) :
-                nullptr);
+                nullptr,
+                overridingNewTarget != nullptr);
     }
 
     Var JavascriptFunction::FinishConstructor(
         const Var constructorReturnValue,
         Var newObject,
-        JavascriptFunction *const function)
+        JavascriptFunction *const function,
+        bool hasOverridingNewTarget)
     {
         Assert(constructorReturnValue);
 
@@ -954,7 +956,9 @@ namespace Js
             newObject = constructorReturnValue;
         }
 
-        if (function && function->GetConstructorCache()->NeedsUpdateAfterCtor())
+        // #3217: Cases with overriding newTarget are not what constructor cache is intended for;
+        //     Bypass constructor cache to avoid prototype mismatch/confusion.
+        if (function && function->GetConstructorCache()->NeedsUpdateAfterCtor() && !hasOverridingNewTarget)
         {
             JavascriptOperators::UpdateNewScObjectCache(function, newObject, function->GetScriptContext());
         }

--- a/lib/Runtime/Library/JavascriptFunction.h
+++ b/lib/Runtime/Library/JavascriptFunction.h
@@ -113,7 +113,7 @@ namespace Js
         static Var CallRootFunctionInScript(JavascriptFunction* func, Arguments args);
 
         static Var CallAsConstructor(Var v, Var overridingNewTarget, Arguments args, ScriptContext* scriptContext, const Js::AuxArray<uint32> *spreadIndices = nullptr);
-        static Var FinishConstructor(const Var constructorReturnValue, Var newObject, JavascriptFunction *const function);
+        static Var FinishConstructor(const Var constructorReturnValue, Var newObject, JavascriptFunction *const function, bool hasOverridingNewTarget = false);
 
 #if DBG
         static void CheckValidDebugThunk(ScriptContext* scriptContext, RecyclableObject *function);

--- a/test/es6/classes_bugfixes.js
+++ b/test/es6/classes_bugfixes.js
@@ -377,6 +377,18 @@ var tests = [
     }
   },
   {
+    name: "Issue3217: Reflect.construct permanently corrupts the invoked constructor",
+    body: function () {
+        function Base() {}
+        function Derived() {}
+        Derived.prototype = Object.create(Base.prototype);
+
+        assert.isFalse(new Base() instanceof Derived);
+        Reflect.construct(Base, [], Derived);
+        assert.isFalse(new Base() instanceof Derived);
+    }
+  },
+  {
     name: "OS12503560: assignment to super[prop] not accessing base class property",
     body: function () {
         var result = "";


### PR DESCRIPTION
With the optional newTarget argument, Reflect.construct has a legitimate
user case where cached constructor prototype mismatches prototype of
newly created object. Therefore it is necessary to tighten requirement for
sharing type by checking if constructor prototypes match.
Confirmed no perf impact.

Fixes #3328