### PR TITLE
fix bug in BrBool peep where cmp2Src==cmp1Dst

### DIFF
--- a/lib/Backend/PreLowerPeeps.cpp
+++ b/lib/Backend/PreLowerPeeps.cpp
@@ -362,6 +362,10 @@ IR::Instr *Lowerer::PeepBrBool(IR::Instr *instrBr)
     {
         return instrBr;
     }
+    if (cm1DstReg->IsEqual(instrCm2->GetSrc1()) || cm1DstReg->IsEqual(instrCm2->GetSrc2()))
+    {
+        return instrBr;
+    }
     if (cm1DstReg->IsEqual(instrBinOp->GetSrc1()))
     {
         if (!instrBinOp->GetSrc1()->AsRegOpnd()->GetIsDead())

--- a/test/AsmJs/brbool.js
+++ b/test/AsmJs/brbool.js
@@ -1,0 +1,33 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+
+let test = (function ()
+{
+    "use asm";
+    function brbool(a, b, c) {
+        a = a|0;
+        b = b|0;
+        c = c|0;
+        var d = 0;
+        var e = 0;
+        d = (a|0) == (b|0);
+        e = (d|0) == (c|0);
+        if((d & e)|0)
+        {
+            return 1;
+        }
+        return 2;
+    }
+    return brbool;
+})()
+if(test(1,1,1) == 1 && test(1,2,3) == 2)
+{
+    print("PASS");
+}
+else
+{
+    print("FAIL");
+}

--- a/test/AsmJs/rlexe.xml
+++ b/test/AsmJs/rlexe.xml
@@ -619,6 +619,11 @@
   </test>
   <test>
     <default>
+      <files>brbool.js</files>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>constTest.js</files>
       <baseline>constTest.baseline</baseline>
       <compile-flags>-testtrace:asmjs</compile-flags>


### PR DESCRIPTION
Peep stops us from storing to the dst, so we shouldn't do the peep if result is used

OS: 12444855