### PR TITLE
assert that function we are JITing has a body

### DIFF
--- a/lib/Backend/FunctionJITTimeInfo.cpp
+++ b/lib/Backend/FunctionJITTimeInfo.cpp
@@ -31,7 +31,7 @@ FunctionJITTimeInfo::BuildJITTimeData(
     }
     else
     {
-        // outermost function must have a body
+        // outermost function must have a body, but inlinees may not (if they are builtins)
         Assert(isInlinee);
     }
 

--- a/lib/Backend/FunctionJITTimeInfo.cpp
+++ b/lib/Backend/FunctionJITTimeInfo.cpp
@@ -29,6 +29,11 @@ FunctionJITTimeInfo::BuildJITTimeData(
         jitData->bodyData = AnewStructZ(alloc, FunctionBodyDataIDL);
         JITTimeFunctionBody::InitializeJITFunctionData(alloc, body, jitData->bodyData);
     }
+    else
+    {
+        // outermost function must have a body
+        Assert(isInlinee);
+    }
 
     jitData->localFuncId = codeGenData->GetFunctionInfo()->GetLocalFunctionId();
     jitData->isAggressiveInliningEnabled = codeGenData->GetIsAggressiveInliningEnabled();


### PR DESCRIPTION
There was a bug that caused this not to happen, and it hit null AV on JIT process. This assert should allow us to catch such an issue earlier, when we have more context.

OS: 12457116