### PR TITLE
WASM.SIMD Use appropriate overloads (matching lane width) of CanonicalizeToBools

### DIFF
--- a/lib/Runtime/Language/SimdBool32x4OperationX86X64.cpp
+++ b/lib/Runtime/Language/SimdBool32x4OperationX86X64.cpp
@@ -42,13 +42,13 @@ namespace Js
         return mask_8 == 0xFFFF;
     }
 
-    template bool SIMDBool32x4Operation::OpAllTrue<int>(const SIMDValue& simd);
-    template bool SIMDBool32x4Operation::OpAllTrue<short>(const SIMDValue& simd);
-    template bool SIMDBool32x4Operation::OpAllTrue<char>(const SIMDValue& simd);
+    template bool SIMDBool32x4Operation::OpAllTrue<int32>(const SIMDValue& simd);
+    template bool SIMDBool32x4Operation::OpAllTrue<int16>(const SIMDValue& simd);
+    template bool SIMDBool32x4Operation::OpAllTrue<int8>(const SIMDValue& simd);
     //
-    template bool SIMDBool32x4Operation::OpAnyTrue<int>(const SIMDValue& simd);
-    template bool SIMDBool32x4Operation::OpAnyTrue<short>(const SIMDValue& simd);
-    template bool SIMDBool32x4Operation::OpAnyTrue<char>(const SIMDValue& simd);
+    template bool SIMDBool32x4Operation::OpAnyTrue<int32>(const SIMDValue& simd);
+    template bool SIMDBool32x4Operation::OpAnyTrue<int16>(const SIMDValue& simd);
+    template bool SIMDBool32x4Operation::OpAnyTrue<int8>(const SIMDValue& simd);
 }
 
 

--- a/lib/Runtime/Library/SimdBool16x8Lib.cpp
+++ b/lib/Runtime/Library/SimdBool16x8Lib.cpp
@@ -131,7 +131,7 @@ namespace Js
             JavascriptSIMDBool16x8 *a = JavascriptSIMDBool16x8::FromVar(args[1]);
             Assert(a);
 
-            bool result = SIMDBool32x4Operation::OpAllTrue(a->GetValue());
+            bool result = SIMDBool32x4Operation::OpAllTrue<int16>(a->GetValue());
 
             return JavascriptBoolean::ToVar(result, scriptContext);
         }

--- a/lib/Runtime/Library/SimdBool8x16Lib.cpp
+++ b/lib/Runtime/Library/SimdBool8x16Lib.cpp
@@ -131,7 +131,7 @@ namespace Js
             JavascriptSIMDBool8x16 *a = JavascriptSIMDBool8x16::FromVar(args[1]);
             Assert(a);
 
-            bool result = SIMDBool32x4Operation::OpAllTrue(a->GetValue());
+            bool result = SIMDBool32x4Operation::OpAllTrue<int8>(a->GetValue());
 
             return JavascriptBoolean::ToVar(result, scriptContext);
         }


### PR DESCRIPTION
This should fix failures in SIMD.validation