### PR TITLE
[OSG 9773504] Silence a noisy assert. 

### DIFF
--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -4899,9 +4899,8 @@ namespace Js
         this->entryPoints->ClearAndZero();
 
         // Store the originalEntryPoint to restore it back immediately.
-        JavascriptMethod originalEntryPoint = this->GetOriginalEntryPoint_Unchecked();
         this->CreateNewDefaultEntryPoint();
-        this->SetOriginalEntryPoint(originalEntryPoint);
+        this->SetOriginalEntryPoint(this->GetScriptContext()->CurrentThunk);
         if (this->m_defaultEntryPointInfo)
         {
             this->GetDefaultFunctionEntryPointInfo()->entryPointIndex = 0;


### PR DESCRIPTION
In source rundown mode, we're hitting an assert in byte code gen to the effect that we don't have a proper initial entry point on the function we're compiling. Make CleanupToReparse set an initial entry point before proceeding.