### PR TITLE
Bug fix in array bounds check elimination

### DIFF
--- a/test/Array/bug11370283.js
+++ b/test/Array/bug11370283.js
@@ -1,0 +1,16 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+//Switches: -bgjit- -lic:1
+var a = Array(10).fill();
+function foo() {
+  for (var k = 0; k < a.length; ++k) {
+    if (k == 0) {
+      k += 1;
+    }
+    a[k];
+  }
+}
+foo();
+print("passed");

--- a/test/Array/rlexe.xml
+++ b/test/Array/rlexe.xml
@@ -60,6 +60,13 @@
   </test>
   <test>
     <default>
+      <files>bug11370283.js</files>
+      <compile-flags>-bgjit- -lic:1</compile-flags>
+      <tags>BugFix,exclude_dynapogo</tags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>bug4916987.js</files>
       <compile-flags>-mic:1 -off:simplejit</compile-flags>
       <tags>BugFix</tags>


### PR DESCRIPTION
In DetermineSymBoundOffsetOrValueRelativeToLandingPad, handle the case where bounds is null and TryGetIntConstantLowerBound or TryGetIntConstantupperBound 

Fixes OS#11370283

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/3350)
<!-- Reviewable:end -->
