### PR TITLE
Debugger: keep new jobs while debugger is attached

### DIFF
--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -3137,7 +3137,13 @@ namespace Js
 
         } autoRestore(this->GetThreadContext());
 
+        // xplat-todo: (obastemur) Enable JIT on Debug mode
+        // CodeGen entrypoint can be deleted before we are able to unregister
+        // due to how we handle xdata on xplat, resetting the entrypoints below might affect CodeGen process.
+        // it is safer (on xplat) to turn JIT off during Debug for now.
+#ifdef _WIN32
         if (!Js::Configuration::Global.EnableJitInDebugMode())
+#endif
         {
             if (attach)
             {


### PR DESCRIPTION
~~Fixes #3352~~

If JIT is enabled (in debug mode) force NoNative.
