### PR TITLE
Fix issue#3249: Module namespace object's Symbol.toStringTag has incorrect attributes

### DIFF
--- a/lib/Runtime/Language/ModuleNamespace.h
+++ b/lib/Runtime/Language/ModuleNamespace.h
@@ -58,9 +58,9 @@ namespace Js
         virtual BOOL GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, ForInCache * forInCache = nullptr);
         virtual BOOL SetAccessors(PropertyId propertyId, Var getter, Var setter, PropertyOperationFlags flags = PropertyOperation_None) override { return false; }
         virtual BOOL GetAccessors(PropertyId propertyId, Var *getter, Var *setter, ScriptContext * requestContext) override { return false; }
-        virtual BOOL IsWritable(PropertyId propertyId) override { return true; }
+        virtual BOOL IsWritable(PropertyId propertyId) override { return false; }
         virtual BOOL IsConfigurable(PropertyId propertyId) override { return false; }
-        virtual BOOL IsEnumerable(PropertyId propertyId) override { return true; }
+        virtual BOOL IsEnumerable(PropertyId propertyId) override { return false; }
         virtual BOOL SetEnumerable(PropertyId propertyId, BOOL value) override { return false; }
         virtual BOOL SetWritable(PropertyId propertyId, BOOL value) override { return false; }
         virtual BOOL IsProtoImmutable() const { return true; }

--- a/test/es6/module-namespace.js
+++ b/test/es6/module-namespace.js
@@ -32,6 +32,18 @@ function testModuleScript(source, message, shouldFail = false) {
 
 var tests = [
     {
+        name: "Issue3249: Namespace object's Symbol.toStringTag",
+        body: function () {
+			testModuleScript(`
+			import * as foo from "ValidExportStatements.js";
+            var desc = Object.getOwnPropertyDescriptor(foo, Symbol.toStringTag);
+            assert.isFalse(desc.configurable, "configurable: false");
+            assert.isFalse(desc.enumerable, "enumerable: false");
+            assert.isFalse(desc.writable, "writable: false");
+		    `, '', false);
+        }
+    },
+    {
         name: "Basic import namespace",
         body: function () {
 			testModuleScript(`


### PR DESCRIPTION
Module namespace object's Symbol.toStringTag must be:
writable: false
enumerable: false
configurable: false
