### PR TITLE
Make PropertyQueryFlags an enum class

### DIFF
--- a/lib/Runtime/Language/JavascriptConversion.h
+++ b/lib/Runtime/Language/JavascriptConversion.h
@@ -16,8 +16,8 @@ namespace Js {
 
         static void ToPropertyKey(Var argument, ScriptContext* scriptContext, const PropertyRecord** propertyRecord);
 
-        static PropertyQueryFlags BooleanToPropertyQueryFlags(BOOL val) { return val ? Property_Found : Property_NotFound; }
-        static BOOL PropertyQueryFlagsToBoolean(PropertyQueryFlags val) { return val == Property_Found; }
+        static PropertyQueryFlags BooleanToPropertyQueryFlags(BOOL val) { return val ? PropertyQueryFlags::Property_Found : PropertyQueryFlags::Property_NotFound; }
+        static BOOL PropertyQueryFlagsToBoolean(PropertyQueryFlags val) { return val == PropertyQueryFlags::Property_Found; }
 
         static JavascriptString* ToString(Var aValue, ScriptContext* scriptContext);
         static JavascriptString* ToLocaleString(Var aValue, ScriptContext* scriptContext);

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -1487,9 +1487,9 @@ CommonNumber:
         while (JavascriptOperators::GetTypeId(instance) != TypeIds_Null)
         {
             PropertyQueryFlags result = instance->HasPropertyQuery(propertyId);
-            if (result != Property_NotFound)
+            if (result != PropertyQueryFlags::Property_NotFound)
             {
-                return JavascriptConversion::PropertyQueryFlagsToBoolean(result); // return false if instance is typed array and HasPropertyQuery() returns Property_Found_Undefined
+                return JavascriptConversion::PropertyQueryFlagsToBoolean(result); // return false if instance is typed array and HasPropertyQuery() returns PropertyQueryFlags::Property_Found_Undefined
             }
 
             instance = JavascriptOperators::GetPrototypeNoTrap(instance);
@@ -1702,7 +1702,7 @@ CommonNumber:
             else
             {
                 PropertyQueryFlags result = object->GetPropertyQuery(instance, propertyId, value, info, requestContext);
-                if (result != Property_NotFound)
+                if (result != PropertyQueryFlags::Property_NotFound)
                 {
                     foundProperty = JavascriptConversion::PropertyQueryFlagsToBoolean(result);
                     break;
@@ -1799,7 +1799,7 @@ CommonNumber:
         while (JavascriptOperators::GetTypeId(object) != TypeIds_Null)
         {
             PropertyQueryFlags result = object->GetPropertyQuery(instance, propertyKey, value, info, requestContext);
-            if (result != Property_NotFound)
+            if (result != PropertyQueryFlags::Property_NotFound)
             {
                 if (value && !WithScopeObject::Is(object) && info->GetPropertyString())
                 {
@@ -2008,7 +2008,7 @@ CommonNumber:
             else
             {
                 PropertyQueryFlags result = object->GetPropertyReferenceQuery(instance, propertyId, value, info, requestContext);
-                if (result != Property_NotFound)
+                if (result != PropertyQueryFlags::Property_NotFound)
                 {
                     foundProperty = JavascriptConversion::PropertyQueryFlagsToBoolean(result);
                     break;
@@ -3085,7 +3085,7 @@ CommonNumber:
         while (JavascriptOperators::GetTypeId(object) != TypeIds_Null)
         {
             PropertyQueryFlags result;
-            if ((result = object->HasItemQuery(index)) != Property_NotFound)
+            if ((result = object->HasItemQuery(index)) != PropertyQueryFlags::Property_NotFound)
             {
                 return JavascriptConversion::PropertyQueryFlagsToBoolean(result);
             }
@@ -3107,7 +3107,7 @@ CommonNumber:
         while (JavascriptOperators::GetTypeId(object) != TypeIds_Null)
         {
             PropertyQueryFlags result;
-            if ((result = object->GetItemQuery(instance, index, value, requestContext)) != Property_NotFound)
+            if ((result = object->GetItemQuery(instance, index, value, requestContext)) != PropertyQueryFlags::Property_NotFound)
             {
                 return JavascriptConversion::PropertyQueryFlagsToBoolean(result);
             }
@@ -3127,7 +3127,7 @@ CommonNumber:
         while (JavascriptOperators::GetTypeId(object) != TypeIds_Null)
         {
             PropertyQueryFlags result;
-            if ((result = object->GetItemReferenceQuery(instance, index, value, requestContext)) != Property_NotFound)
+            if ((result = object->GetItemReferenceQuery(instance, index, value, requestContext)) != PropertyQueryFlags::Property_NotFound)
             {
                 return JavascriptConversion::PropertyQueryFlagsToBoolean(result);
             }

--- a/lib/Runtime/Language/ModuleNamespace.cpp
+++ b/lib/Runtime/Language/ModuleNamespace.cpp
@@ -146,13 +146,13 @@ namespace Js
         }
         if (propertyMap != nullptr && propertyMap->TryGetValue(propertyRecord, &propertyDescriptor))
         {
-            return Property_Found;
+            return PropertyQueryFlags::Property_Found;
         }
         if (unambiguousNonLocalExports != nullptr)
         {
             return JavascriptConversion::BooleanToPropertyQueryFlags(unambiguousNonLocalExports->ContainsKey(propertyId));
         }
-        return Property_NotFound;
+        return PropertyQueryFlags::Property_NotFound;
     }
 
     BOOL ModuleNamespace::HasOwnProperty(PropertyId propertyId)
@@ -177,7 +177,7 @@ namespace Js
             //    PropertyValueInfo::Set(info, this, (PropertyIndex)propertyDescriptor.propertyIndex, propertyDescriptor.Attributes);
             //}
             *value = this->GetNSSlot(propertyDescriptor.propertyIndex);
-            return Property_Found;
+            return PropertyQueryFlags::Property_Found;
         }
         if (unambiguousNonLocalExports != nullptr)
         {
@@ -188,7 +188,7 @@ namespace Js
                 return JavascriptConversion::BooleanToPropertyQueryFlags(moduleNameRecord.module->GetNamespace()->GetProperty(originalInstance, moduleNameRecord.bindingName, value, info, requestContext));
             }
         }
-        return Property_NotFound;
+        return PropertyQueryFlags::Property_NotFound;
     }
 
     PropertyQueryFlags ModuleNamespace::GetPropertyQuery(Var originalInstance, JavascriptString* propertyNameString, Var* value, PropertyValueInfo* info, ScriptContext* requestContext)

--- a/lib/Runtime/Language/ModuleNamespace.h
+++ b/lib/Runtime/Language/ModuleNamespace.h
@@ -48,10 +48,10 @@ namespace Js
         virtual BOOL DeleteProperty(PropertyId propertyId, PropertyOperationFlags flags) override;
         virtual BOOL DeleteProperty(JavascriptString *propertyNameString, PropertyOperationFlags flags) override;
         virtual BOOL IsFixedProperty(PropertyId propertyId) override { return false; }
-        virtual PropertyQueryFlags HasItemQuery(uint32 index) override { return Property_NotFound; }
+        virtual PropertyQueryFlags HasItemQuery(uint32 index) override { return PropertyQueryFlags::Property_NotFound; }
         virtual BOOL HasOwnItem(uint32 index) override { return false; }
-        virtual PropertyQueryFlags GetItemQuery(Var originalInstance, uint32 index, Var* value, ScriptContext * requestContext) override { return Property_NotFound; }
-        virtual PropertyQueryFlags GetItemReferenceQuery(Var originalInstance, uint32 index, Var* value, ScriptContext * requestContext) override { return Property_NotFound; }
+        virtual PropertyQueryFlags GetItemQuery(Var originalInstance, uint32 index, Var* value, ScriptContext * requestContext) override { return PropertyQueryFlags::Property_NotFound; }
+        virtual PropertyQueryFlags GetItemReferenceQuery(Var originalInstance, uint32 index, Var* value, ScriptContext * requestContext) override { return PropertyQueryFlags::Property_NotFound; }
         virtual DescriptorFlags GetItemSetter(uint32 index, Var* setterValue, ScriptContext* requestContext) override { *setterValue = nullptr; return DescriptorFlags::None; }
         virtual BOOL SetItem(uint32 index, Var value, PropertyOperationFlags flags) override { return false; }
         virtual BOOL DeleteItem(uint32 index, PropertyOperationFlags flags) override { return true; }

--- a/lib/Runtime/Library/ArgumentsObject.cpp
+++ b/lib/Runtime/Library/ArgumentsObject.cpp
@@ -416,18 +416,18 @@ namespace Js
         {
             if (this->GetItemAt(index, value, requestContext))
             {
-                return Property_Found;
+                return PropertyQueryFlags::Property_Found;
             }
         }
 
         if (JavascriptConversion::PropertyQueryFlagsToBoolean(DynamicObject::GetPropertyQuery(originalInstance, propertyId, value, info, requestContext)))
         {
             // Property has been pre-set and not deleted. Use it.
-            return Property_Found;
+            return PropertyQueryFlags::Property_Found;
         }
 
         *value = requestContext->GetMissingPropertyResult();
-        return Property_NotFound;
+        return PropertyQueryFlags::Property_NotFound;
     }
 
     PropertyQueryFlags HeapArgumentsObject::GetPropertyQuery(Var originalInstance, JavascriptString* propertyNameString, Var* value, PropertyValueInfo* info, ScriptContext* requestContext)
@@ -439,11 +439,11 @@ namespace Js
         if (JavascriptConversion::PropertyQueryFlagsToBoolean(DynamicObject::GetPropertyQuery(originalInstance, propertyNameString, value, info, requestContext)))
         {
             // Property has been pre-set and not deleted. Use it.
-            return Property_Found;
+            return PropertyQueryFlags::Property_Found;
         }
 
         *value = requestContext->GetMissingPropertyResult();
-        return Property_NotFound;
+        return PropertyQueryFlags::Property_NotFound;
     }
 
     PropertyQueryFlags HeapArgumentsObject::GetPropertyReferenceQuery(Var originalInstance, PropertyId id, Var* value, PropertyValueInfo* info, ScriptContext* requestContext)
@@ -486,7 +486,7 @@ namespace Js
     {
         if (this->HasItemAt(index))
         {
-            return Property_Found;
+            return PropertyQueryFlags::Property_Found;
         }
         return DynamicObject::HasItemQuery(index);
     }
@@ -495,7 +495,7 @@ namespace Js
     {
         if (this->GetItemAt(index, value, requestContext))
         {
-            return Property_Found;
+            return PropertyQueryFlags::Property_Found;
         }
         return DynamicObject::GetItemQuery(originalInstance, index, value, requestContext);
     }

--- a/lib/Runtime/Library/BoundFunction.cpp
+++ b/lib/Runtime/Library/BoundFunction.cpp
@@ -307,7 +307,7 @@ namespace Js
     {
         if (propertyId == PropertyIds::length)
         {
-            return Property_Found;
+            return PropertyQueryFlags::Property_Found;
         }
 
         return JavascriptFunction::HasPropertyQuery(propertyId);

--- a/lib/Runtime/Library/ES5Array.cpp
+++ b/lib/Runtime/Library/ES5Array.cpp
@@ -38,7 +38,7 @@ namespace Js
     {
         if (propertyId == PropertyIds::length)
         {
-            return Property_Found;
+            return PropertyQueryFlags::Property_Found;
         }
 
         // Skip JavascriptArray override

--- a/lib/Runtime/Library/GlobalObject.cpp
+++ b/lib/Runtime/Library/GlobalObject.cpp
@@ -1773,7 +1773,7 @@ LHexError:
     {
         if (JavascriptConversion::PropertyQueryFlagsToBoolean(DynamicObject::GetPropertyQuery(originalInstance, propertyId, value, info, requestContext)))
         {
-            return Property_Found;
+            return PropertyQueryFlags::Property_Found;
         }
         return JavascriptConversion::BooleanToPropertyQueryFlags((this->directHostObject && JavascriptOperators::GetProperty(this->directHostObject, propertyId, value, requestContext, info)) ||
             (this->hostObject && JavascriptOperators::GetProperty(this->hostObject, propertyId, value, requestContext, info)));
@@ -1818,7 +1818,7 @@ LHexError:
     {
         if (JavascriptConversion::PropertyQueryFlagsToBoolean(DynamicObject::GetPropertyReferenceQuery(originalInstance, propertyId, value, info, requestContext)))
         {
-            return Property_Found;
+            return PropertyQueryFlags::Property_Found;
         }
         return JavascriptConversion::BooleanToPropertyQueryFlags((this->directHostObject && JavascriptOperators::GetPropertyReference(this->directHostObject, propertyId, value, requestContext, info)) ||
             (this->hostObject && JavascriptOperators::GetPropertyReference(this->hostObject, propertyId, value, requestContext, info)));
@@ -2188,7 +2188,7 @@ LHexError:
     {
         if (JavascriptConversion::PropertyQueryFlagsToBoolean(DynamicObject::GetItemReferenceQuery(originalInstance, index, value, requestContext)))
         {
-            return Property_Found;
+            return PropertyQueryFlags::Property_Found;
         }
         return JavascriptConversion::BooleanToPropertyQueryFlags(
             (this->directHostObject && JavascriptConversion::PropertyQueryFlagsToBoolean(this->directHostObject->GetItemReferenceQuery(originalInstance, index, value, requestContext))) ||
@@ -2205,7 +2205,7 @@ LHexError:
     {
         if (JavascriptConversion::PropertyQueryFlagsToBoolean(DynamicObject::GetItemQuery(originalInstance, index, value, requestContext)))
         {
-            return Property_Found;
+            return PropertyQueryFlags::Property_Found;
         }
 
         return JavascriptConversion::BooleanToPropertyQueryFlags((this->directHostObject && this->directHostObject->GetItem(originalInstance, index, value, requestContext)) ||

--- a/lib/Runtime/Library/JavascriptArray.cpp
+++ b/lib/Runtime/Library/JavascriptArray.cpp
@@ -11868,7 +11868,7 @@ Case0:
     {
         if (propertyId == PropertyIds::length)
         {
-            return Property_Found;
+            return PropertyQueryFlags::Property_Found;
         }
 
         ScriptContext* scriptContext = GetScriptContext();
@@ -12120,7 +12120,7 @@ Case0:
     {
         if (GetPropertyBuiltIns(propertyId, value))
         {
-            return Property_Found;
+            return PropertyQueryFlags::Property_Found;
         }
 
         ScriptContext* scriptContext = GetScriptContext();
@@ -12143,7 +12143,7 @@ Case0:
 
         if (propertyRecord != nullptr && GetPropertyBuiltIns(propertyRecord->GetPropertyId(), value))
         {
-            return Property_Found;
+            return PropertyQueryFlags::Property_Found;
         }
 
         return DynamicObject::GetPropertyQuery(originalInstance, propertyNameString, value, info, requestContext);

--- a/lib/Runtime/Library/JavascriptFunction.cpp
+++ b/lib/Runtime/Library/JavascriptFunction.cpp
@@ -2469,13 +2469,13 @@ LABEL1:
         case PropertyIds::arguments:
             if (this->HasRestrictedProperties())
             {
-                return Property_Found;
+                return PropertyQueryFlags::Property_Found;
             }
             break;
         case PropertyIds::length:
             if (this->IsScriptFunction())
             {
-                return Property_Found;
+                return PropertyQueryFlags::Property_Found;
             }
             break;
         }

--- a/lib/Runtime/Library/JavascriptGeneratorFunction.cpp
+++ b/lib/Runtime/Library/JavascriptGeneratorFunction.cpp
@@ -247,7 +247,7 @@ namespace Js
     {
         if (propertyId == PropertyIds::length)
         {
-            return Property_Found;
+            return PropertyQueryFlags::Property_Found;
         }
 
         if (propertyId == PropertyIds::caller || propertyId == PropertyIds::arguments)

--- a/lib/Runtime/Library/JavascriptRegExpConstructor.cpp
+++ b/lib/Runtime/Library/JavascriptRegExpConstructor.cpp
@@ -165,7 +165,7 @@ namespace Js
         case PropertyIds::$7:
         case PropertyIds::$8:
         case PropertyIds::$9:
-            return Property_Found;
+            return PropertyQueryFlags::Property_Found;
         default:
             return JavascriptFunction::HasPropertyQuery(propertyId);
         }

--- a/lib/Runtime/Library/JavascriptRegularExpression.cpp
+++ b/lib/Runtime/Library/JavascriptRegularExpression.cpp
@@ -1089,12 +1089,12 @@ namespace Js
         const ScriptConfiguration* scriptConfig = this->GetScriptContext()->GetConfig();
 
 #define HAS_PROPERTY(ownProperty) \
-        return (ownProperty ? Property_Found : DynamicObject::HasPropertyQuery(propertyId));
+        return (ownProperty ? PropertyQueryFlags::Property_Found : DynamicObject::HasPropertyQuery(propertyId));
 
         switch (propertyId)
         {
         case PropertyIds::lastIndex:
-            return Property_Found;
+            return PropertyQueryFlags::Property_Found;
         case PropertyIds::global:
         case PropertyIds::multiline:
         case PropertyIds::ignoreCase:

--- a/lib/Runtime/Library/JavascriptSimdFloat64x2.cpp
+++ b/lib/Runtime/Library/JavascriptSimdFloat64x2.cpp
@@ -59,11 +59,11 @@ namespace Js
 
         if (propertyRecord != nullptr && GetPropertyBuiltIns(propertyRecord->GetPropertyId(), value, requestContext))
         {
-            return Property_Found;
+            return PropertyQueryFlags::Property_Found;
         }
 
         *value = requestContext->GetMissingPropertyResult();
-        return Property_NotFound;
+        return PropertyQueryFlags::Property_NotFound;
     }
 
     PropertyQueryFlags JavascriptSIMDFloat64x2::GetPropertyReferenceQuery(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext)

--- a/lib/Runtime/Library/JavascriptSimdType.cpp
+++ b/lib/Runtime/Library/JavascriptSimdType.cpp
@@ -152,11 +152,11 @@ namespace Js
 
         if (propertyRecord != nullptr && GetPropertyBuiltIns(propertyRecord->GetPropertyId(), value, requestContext))
         {
-            return Property_Found;
+            return PropertyQueryFlags::Property_Found;
         }
 
         *value = requestContext->GetMissingPropertyResult();
-        return Property_NotFound;
+        return PropertyQueryFlags::Property_NotFound;
     }
 
     PropertyQueryFlags JavascriptSIMDType::GetPropertyReferenceQuery(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext)

--- a/lib/Runtime/Library/JavascriptString.cpp
+++ b/lib/Runtime/Library/JavascriptString.cpp
@@ -3729,7 +3729,7 @@ case_2:
     {
         if (propertyId == PropertyIds::length)
         {
-            return Property_Found;
+            return PropertyQueryFlags::Property_Found;
         }
         ScriptContext* scriptContext = GetScriptContext();
         charcount_t index;
@@ -3737,10 +3737,10 @@ case_2:
         {
             if (index < this->GetLength())
             {
-                return Property_Found;
+                return PropertyQueryFlags::Property_Found;
             }
         }
-        return Property_NotFound;
+        return PropertyQueryFlags::Property_NotFound;
     }
 
     BOOL JavascriptString::IsEnumerable(PropertyId propertyId)
@@ -3768,11 +3768,11 @@ case_2:
 
         if (propertyRecord != nullptr && GetPropertyBuiltIns(propertyRecord->GetPropertyId(), value, requestContext))
         {
-            return Property_Found;
+            return PropertyQueryFlags::Property_Found;
         }
 
         *value = requestContext->GetMissingPropertyResult();
-        return Property_NotFound;
+        return PropertyQueryFlags::Property_NotFound;
     }
     bool JavascriptString::GetPropertyBuiltIns(PropertyId propertyId, Var* value, ScriptContext* requestContext)
     {

--- a/lib/Runtime/Library/JavascriptStringObject.cpp
+++ b/lib/Runtime/Library/JavascriptStringObject.cpp
@@ -91,12 +91,12 @@ namespace Js
     {
         if (propertyId == PropertyIds::length)
         {
-            return Property_Found;
+            return PropertyQueryFlags::Property_Found;
         }
 
         if (JavascriptConversion::PropertyQueryFlagsToBoolean(DynamicObject::HasPropertyQuery(propertyId)))
         {
-            return Property_Found;
+            return PropertyQueryFlags::Property_Found;
         }
 
         return JavascriptConversion::BooleanToPropertyQueryFlags(JavascriptStringObject::IsValidIndex(propertyId, true));
@@ -238,7 +238,7 @@ namespace Js
 
         if (JavascriptConversion::PropertyQueryFlagsToBoolean(DynamicObject::GetPropertyQuery(originalInstance, propertyId, value, info, requestContext)))
         {
-            return Property_Found;
+            return PropertyQueryFlags::Property_Found;
         }
 
         // For NumericPropertyIds check that index is less than JavascriptString length
@@ -251,7 +251,7 @@ namespace Js
         }
 
         *value = requestContext->GetMissingPropertyResult();
-        return Property_NotFound;
+        return PropertyQueryFlags::Property_NotFound;
     }
 
     PropertyQueryFlags JavascriptStringObject::GetPropertyQuery(Var originalInstance, JavascriptString* propertyNameString, Var* value, PropertyValueInfo* info, ScriptContext* requestContext)
@@ -347,7 +347,7 @@ namespace Js
     {
         if (this->InternalUnwrap()->HasItem(index))
         {
-            return Property_Found;
+            return PropertyQueryFlags::Property_Found;
         }
         return DynamicObject::HasItemQuery(index);
     }
@@ -357,7 +357,7 @@ namespace Js
         JavascriptString* str = JavascriptString::FromVar(CrossSite::MarshalVar(requestContext, this->InternalUnwrap()));
         if (str->GetItemAt(index, value))
         {
-            return Property_Found;
+            return PropertyQueryFlags::Property_Found;
         }
         return DynamicObject::GetItemQuery(originalInstance, index, value, requestContext);
     }

--- a/lib/Runtime/Library/JavascriptVariantDate.cpp
+++ b/lib/Runtime/Library/JavascriptVariantDate.cpp
@@ -74,7 +74,7 @@ namespace Js
             JavascriptError::ThrowTypeError(requestContext, JSERR_Property_VarDate, requestContext->GetPropertyName(propertyId)->GetBuffer());
         }
         *value = nullptr;
-        return Property_Found;
+        return PropertyQueryFlags::Property_Found;
     };
 
     PropertyQueryFlags JavascriptVariantDate::GetPropertyQuery(Js::Var originalInstance, Js::JavascriptString* propertyNameString, Js::Var* value, PropertyValueInfo* info, Js::ScriptContext* requestContext)
@@ -84,7 +84,7 @@ namespace Js
             JavascriptError::ThrowTypeError(requestContext, JSERR_Property_VarDate, propertyNameString);
         }
         *value = nullptr;
-        return Property_Found;
+        return PropertyQueryFlags::Property_Found;
     };
 
     PropertyQueryFlags JavascriptVariantDate::GetPropertyReferenceQuery(Js::Var originalInstance, Js::PropertyId propertyId, Js::Var* value, PropertyValueInfo* info, Js::ScriptContext* requestContext)
@@ -94,7 +94,7 @@ namespace Js
             JavascriptError::ThrowTypeError(requestContext, JSERR_Property_VarDate, requestContext->GetPropertyName(propertyId)->GetBuffer());
         }
         *value = nullptr;
-        return Property_Found;
+        return PropertyQueryFlags::Property_Found;
     };
 
     BOOL JavascriptVariantDate::SetProperty(Js::PropertyId propertyId, Js::Var value, Js::PropertyOperationFlags flags, PropertyValueInfo* info)

--- a/lib/Runtime/Library/JavascriptVariantDate.h
+++ b/lib/Runtime/Library/JavascriptVariantDate.h
@@ -34,7 +34,7 @@ namespace Js
         double GetValue() { return value; }
 
         virtual BOOL Equals(Var other, BOOL* value, ScriptContext * requestContext) override;
-        virtual PropertyQueryFlags HasPropertyQuery(Js::PropertyId propertyId) override { return Property_NotFound; };
+        virtual PropertyQueryFlags HasPropertyQuery(Js::PropertyId propertyId) override { return PropertyQueryFlags::Property_NotFound; };
         virtual PropertyQueryFlags GetPropertyQuery(Js::Var originalInstance, Js::PropertyId propertyId, Js::Var* value, Js::PropertyValueInfo* info, Js::ScriptContext* requestContext) override;
         virtual PropertyQueryFlags GetPropertyQuery(Var originalInstance, JavascriptString* propertyNameString, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;
         virtual PropertyQueryFlags GetPropertyReferenceQuery(Js::Var originalInstance, Js::PropertyId propertyId, Js::Var* value, Js::PropertyValueInfo* info, Js::ScriptContext* requestContext) override;
@@ -43,7 +43,7 @@ namespace Js
         virtual BOOL InitProperty(Js::PropertyId propertyId, Js::Var value, PropertyOperationFlags flags = PropertyOperation_None, Js::PropertyValueInfo* info = NULL) override;
         virtual BOOL DeleteProperty(Js::PropertyId propertyId, Js::PropertyOperationFlags flags) override;
         virtual BOOL DeleteProperty(JavascriptString *propertyNameString, Js::PropertyOperationFlags flags) override;
-        virtual PropertyQueryFlags HasItemQuery(uint32 index) override { return Property_NotFound; }
+        virtual PropertyQueryFlags HasItemQuery(uint32 index) override { return PropertyQueryFlags::Property_NotFound; }
         virtual PropertyQueryFlags GetItemReferenceQuery(Js::Var originalInstance, uint32 index, Js::Var* value, Js::ScriptContext * scriptContext) override;
         virtual PropertyQueryFlags GetItemQuery(Js::Var originalInstance, uint32 index, Js::Var* value, Js::ScriptContext * scriptContext) override;
         virtual BOOL SetItem(uint32 index, Js::Var value, Js::PropertyOperationFlags flags) override;

--- a/lib/Runtime/Library/ModuleRoot.cpp
+++ b/lib/Runtime/Library/ModuleRoot.cpp
@@ -21,11 +21,11 @@ namespace Js
     {
         if (JavascriptConversion::PropertyQueryFlagsToBoolean(DynamicObject::HasPropertyQuery(propertyId)))
         {
-            return Property_Found;
+            return PropertyQueryFlags::Property_Found;
         }
         else if (this->hostObject && JavascriptOperators::HasProperty(this->hostObject, propertyId))
         {
-            return Property_Found;
+            return PropertyQueryFlags::Property_Found;
         }
         return this->GetLibrary()->GetGlobalObject()->GlobalObject::HasPropertyQuery(propertyId);
     }
@@ -73,11 +73,11 @@ namespace Js
                     PropertyValueInfo::DisableStoreFieldCache(info);
                 }
             }
-            return Property_Found;
+            return PropertyQueryFlags::Property_Found;
         }
         if (this->hostObject && JavascriptOperators::GetProperty(this->hostObject, propertyId, value, requestContext))
         {
-            return Property_Found;
+            return PropertyQueryFlags::Property_Found;
         }
 
         //
@@ -86,7 +86,7 @@ namespace Js
         //
 
         GlobalObject* globalObj = this->GetLibrary()->GetGlobalObject();
-        return JavascriptConversion::BooleanToPropertyQueryFlags(globalObj->GlobalObject::GetPropertyQuery(originalInstance, propertyId, value, NULL, requestContext));
+        return globalObj->GlobalObject::GetPropertyQuery(originalInstance, propertyId, value, NULL, requestContext);
     }
 
     BOOL ModuleRoot::GetRootProperty(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext)
@@ -157,11 +157,11 @@ namespace Js
                     PropertyValueInfo::DisableStoreFieldCache(info);
                 }
             }
-            return Property_Found;
+            return PropertyQueryFlags::Property_Found;
         }
         if (this->hostObject && JavascriptOperators::GetPropertyReference(this->hostObject, propertyId, value, requestContext))
         {
-            return Property_NotFound;
+            return PropertyQueryFlags::Property_NotFound;
         }
 
         //
@@ -421,14 +421,14 @@ namespace Js
     {
         if (JavascriptConversion::PropertyQueryFlagsToBoolean(DynamicObject::GetItemReferenceQuery(originalInstance, index, value, requestContext)))
         {
-            return Property_Found;
+            return PropertyQueryFlags::Property_Found;
         }
         if (this->hostObject && JavascriptConversion::PropertyQueryFlagsToBoolean(this->hostObject->GetItemReferenceQuery(originalInstance, index, value, requestContext)))
         {
-            return Property_Found;
+            return PropertyQueryFlags::Property_Found;
         }
         *value = requestContext->GetMissingItemResult();
-        return Property_NotFound;
+        return PropertyQueryFlags::Property_NotFound;
     }
 
     BOOL ModuleRoot::SetItem(uint32 index, Var value, PropertyOperationFlags flags)
@@ -449,14 +449,14 @@ namespace Js
     {
         if (JavascriptConversion::PropertyQueryFlagsToBoolean(DynamicObject::GetItemQuery(originalInstance, index, value, requestContext)))
         {
-            return Property_Found;
+            return PropertyQueryFlags::Property_Found;
         }
         if (this->hostObject && this->hostObject->GetItem(originalInstance, index, value, requestContext))
         {
-            return Property_Found;
+            return PropertyQueryFlags::Property_Found;
         }
         *value = requestContext->GetMissingItemResult();
-        return Property_NotFound;
+        return PropertyQueryFlags::Property_NotFound;
     }
 
     BOOL ModuleRoot::GetDiagValueString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext)

--- a/lib/Runtime/Library/TypedArray.cpp
+++ b/lib/Runtime/Library/TypedArray.cpp
@@ -630,12 +630,12 @@ namespace Js
         if (scriptContext->IsNumericPropertyId(propertyId, &index))
         {
             // All the slots within the length of the array are valid.
-            return index < this->GetLength() ? Property_Found : Property_NotFound_NoProto;
+            return index < this->GetLength() ? PropertyQueryFlags::Property_Found : PropertyQueryFlags::Property_NotFound_NoProto;
         }
 
         if (!scriptContext->GetPropertyName(propertyId)->IsSymbol() && CanonicalNumericIndexString(propertyId, scriptContext))
         {
-            return Property_NotFound_NoProto;
+            return PropertyQueryFlags::Property_NotFound_NoProto;
         }
 
         return DynamicObject::HasPropertyQuery(propertyId);
@@ -677,15 +677,15 @@ namespace Js
             *value = this->DirectGetItem(index);
             if (JavascriptOperators::GetTypeId(*value) == Js::TypeIds_Undefined)
             {
-                return Property_NotFound;
+                return PropertyQueryFlags::Property_NotFound;
             }
-            return Property_Found;
+            return PropertyQueryFlags::Property_Found;
         }
 
         if (!requestContext->GetPropertyName(propertyId)->IsSymbol() && CanonicalNumericIndexString(propertyId, requestContext))
         {
             *value = requestContext->GetLibrary()->GetUndefined();
-            return Property_NotFound_NoProto;
+            return PropertyQueryFlags::Property_NotFound_NoProto;
         }
 
         return DynamicObject::GetPropertyQuery(originalInstance, propertyId, value, info, requestContext);
@@ -699,7 +699,7 @@ namespace Js
         if (CanonicalNumericIndexString(propertyNameString, requestContext))
         {
             *value = requestContext->GetLibrary()->GetUndefined();
-            return Property_NotFound_NoProto;
+            return PropertyQueryFlags::Property_NotFound_NoProto;
         }
 
         return DynamicObject::GetPropertyQuery(originalInstance, propertyNameString, value, info, requestContext);
@@ -714,22 +714,22 @@ namespace Js
 
         if (index < GetLength())
         {
-            return Property_Found;
+            return PropertyQueryFlags::Property_Found;
         }
 
-        return Property_NotFound_NoProto;
+        return PropertyQueryFlags::Property_NotFound_NoProto;
     }
 
     PropertyQueryFlags TypedArrayBase::GetItemQuery(Var originalInstance, uint32 index, Var* value, ScriptContext* requestContext)
     {
         *value = DirectGetItem(index);
-        return index < GetLength() ? Property_Found : Property_NotFound_NoProto;
+        return index < GetLength() ? PropertyQueryFlags::Property_Found : PropertyQueryFlags::Property_NotFound_NoProto;
     }
 
     PropertyQueryFlags TypedArrayBase::GetItemReferenceQuery(Var originalInstance, uint32 index, Var* value, ScriptContext* requestContext)
     {
         *value = DirectGetItem(index);
-        return index < GetLength() ? Property_Found : Property_NotFound_NoProto;
+        return index < GetLength() ? PropertyQueryFlags::Property_Found : PropertyQueryFlags::Property_NotFound_NoProto;
     }
 
     BOOL TypedArrayBase::SetProperty(PropertyId propertyId, Var value, PropertyOperationFlags flags, PropertyValueInfo* info)

--- a/lib/Runtime/Types/ActivationObject.cpp
+++ b/lib/Runtime/Types/ActivationObject.cpp
@@ -262,9 +262,9 @@ namespace Js
         if (JavascriptConversion::PropertyQueryFlagsToBoolean(__super::GetPropertyQuery(originalInstance, propertyId, value, info, requestContext)))
         {
             GetPropertyCore(info, requestContext);
-            return Property_Found;
+            return PropertyQueryFlags::Property_Found;
         }
-        return Property_NotFound;
+        return PropertyQueryFlags::Property_NotFound;
     }
 
     PropertyQueryFlags ActivationObjectEx::GetPropertyQuery(Var originalInstance, JavascriptString* propertyNameString, Var *value, PropertyValueInfo *info, ScriptContext *requestContext)
@@ -272,9 +272,9 @@ namespace Js
         if (JavascriptConversion::PropertyQueryFlagsToBoolean(__super::GetPropertyQuery(originalInstance, propertyNameString, value, info, requestContext)))
         {
             GetPropertyCore(info, requestContext);
-            return Property_Found;
+            return PropertyQueryFlags::Property_Found;
         }
-        return Property_NotFound;
+        return PropertyQueryFlags::Property_NotFound;
     }
 
     void ActivationObjectEx::InvalidateCachedScope()

--- a/lib/Runtime/Types/RecyclableObject.cpp
+++ b/lib/Runtime/Types/RecyclableObject.cpp
@@ -327,7 +327,7 @@ namespace Js
 
     PropertyQueryFlags RecyclableObject::HasPropertyQuery(PropertyId propertyId)
     {
-        return Property_NotFound;
+        return PropertyQueryFlags::Property_NotFound;
     }
 
     BOOL RecyclableObject::HasOwnProperty(PropertyId propertyId)
@@ -342,12 +342,12 @@ namespace Js
 
     PropertyQueryFlags RecyclableObject::GetPropertyQuery(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext)
     {
-        return Property_NotFound;
+        return PropertyQueryFlags::Property_NotFound;
     }
 
     PropertyQueryFlags RecyclableObject::GetPropertyQuery(Var originalInstance, JavascriptString* propertyNameString, Var* value, PropertyValueInfo* info, ScriptContext* requestContext)
     {
-        return Property_NotFound;
+        return PropertyQueryFlags::Property_NotFound;
     }
 
     BOOL RecyclableObject::GetInternalProperty(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext)
@@ -357,7 +357,7 @@ namespace Js
 
     PropertyQueryFlags RecyclableObject::GetPropertyReferenceQuery(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext)
     {
-        return Property_NotFound;
+        return PropertyQueryFlags::Property_NotFound;
     }
 
     BOOL RecyclableObject::SetProperty(PropertyId propertyId, Var value, PropertyOperationFlags flags, PropertyValueInfo* info)
@@ -417,7 +417,7 @@ namespace Js
 
     PropertyQueryFlags RecyclableObject::HasItemQuery(uint32 index)
     {
-        return Property_NotFound;
+        return PropertyQueryFlags::Property_NotFound;
     }
 
     BOOL RecyclableObject::HasOwnItem(uint32 index)
@@ -427,12 +427,12 @@ namespace Js
 
     PropertyQueryFlags RecyclableObject::GetItemQuery(Var originalInstance, uint32 index, Var* value, ScriptContext * requestContext)
     {
-        return Property_NotFound;
+        return PropertyQueryFlags::Property_NotFound;
     }
 
     PropertyQueryFlags RecyclableObject::GetItemReferenceQuery(Var originalInstance, uint32 index, Var* value, ScriptContext * requestContext)
     {
-        return Property_NotFound;
+        return PropertyQueryFlags::Property_NotFound;
     }
 
     BOOL RecyclableObject::SetItem(uint32 index, Var value, PropertyOperationFlags flags)

--- a/lib/Runtime/Types/RecyclableObject.h
+++ b/lib/Runtime/Types/RecyclableObject.h
@@ -197,7 +197,7 @@ namespace Js {
         PropertyOperation_ThrowOnDeleteIfNotConfig      = 0x400,
     };
 
-    enum PropertyQueryFlags : int
+    enum class PropertyQueryFlags : int
     {
         Property_NotFound                               = 0,
         Property_Found                                  = 1,

--- a/lib/Runtime/Types/SpreadArgument.h
+++ b/lib/Runtime/Types/SpreadArgument.h
@@ -25,15 +25,15 @@ namespace Js
         uint GetArgumentSpreadCount()  const { return iteratorIndices ? iteratorIndices->Count() : 0; }
 
         // A SpreadArgument should never call the Functions defined below this comment
-        virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId) override { AssertAndFailFast();  return Property_NotFound; };
+        virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId) override { AssertAndFailFast();  return PropertyQueryFlags::Property_NotFound; };
         virtual BOOL HasOwnProperty(PropertyId propertyId) override { AssertAndFailFast(); return FALSE; };
         virtual BOOL SetProperty(PropertyId propertyId, Var value, PropertyOperationFlags flags, PropertyValueInfo* info) override { AssertAndFailFast(); return FALSE; };
-        virtual PropertyQueryFlags GetPropertyQuery(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override { AssertAndFailFast(); return Property_NotFound; };
+        virtual PropertyQueryFlags GetPropertyQuery(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override { AssertAndFailFast(); return PropertyQueryFlags::Property_NotFound; };
         virtual BOOL DeleteProperty(PropertyId propertyId, PropertyOperationFlags flags) override{ AssertAndFailFast(); return FALSE;};
         virtual BOOL DeleteProperty(JavascriptString * propertyNameString, PropertyOperationFlags flags) override { AssertAndFailFast(); return FALSE; };
-        virtual PropertyQueryFlags GetPropertyReferenceQuery(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override { AssertAndFailFast(); return Property_NotFound; };
+        virtual PropertyQueryFlags GetPropertyReferenceQuery(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override { AssertAndFailFast(); return PropertyQueryFlags::Property_NotFound; };
         virtual BOOL SetProperty(JavascriptString* propertyNameString, Var value, PropertyOperationFlags flags, PropertyValueInfo* info) override { AssertAndFailFast(); return FALSE; };
-        virtual PropertyQueryFlags GetPropertyQuery(Var originalInstance, JavascriptString* propertyNameString, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override { AssertAndFailFast(); return Property_NotFound; };
+        virtual PropertyQueryFlags GetPropertyQuery(Var originalInstance, JavascriptString* propertyNameString, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override { AssertAndFailFast(); return PropertyQueryFlags::Property_NotFound; };
         virtual DescriptorFlags GetSetter(PropertyId propertyId, Var *setterValue, PropertyValueInfo* info, ScriptContext* requestContext) override { AssertAndFailFast(); return None; };
         virtual DescriptorFlags GetSetter(JavascriptString* propertyNameString, Var *setterValue, PropertyValueInfo* info, ScriptContext* requestContext) override { AssertAndFailFast(); return None; };
         virtual int GetPropertyCount() override { AssertAndFailFast(); return 0; };
@@ -43,10 +43,10 @@ namespace Js
         virtual BOOL InitProperty(PropertyId propertyId, Var value, PropertyOperationFlags flags = PropertyOperation_None, PropertyValueInfo* info = NULL) override { AssertAndFailFast(); return FALSE; };
         virtual BOOL SetPropertyWithAttributes(PropertyId propertyId, Var value, PropertyAttributes attributes, PropertyValueInfo* info, PropertyOperationFlags flags = PropertyOperation_None, SideEffects possibleSideEffects = SideEffects_Any) override { AssertAndFailFast(); return FALSE; };
         virtual BOOL IsFixedProperty(PropertyId propertyId) override { AssertAndFailFast(); return FALSE; };
-        virtual PropertyQueryFlags HasItemQuery(uint32 index) override { AssertAndFailFast(); return Property_NotFound; };
+        virtual PropertyQueryFlags HasItemQuery(uint32 index) override { AssertAndFailFast(); return PropertyQueryFlags::Property_NotFound; };
         virtual BOOL HasOwnItem(uint32 index) override { AssertAndFailFast(); return FALSE; };
-        virtual PropertyQueryFlags GetItemQuery(Var originalInstance, uint32 index, Var* value, ScriptContext * requestContext) override { AssertAndFailFast(); return Property_NotFound; };
-        virtual PropertyQueryFlags GetItemReferenceQuery(Var originalInstance, uint32 index, Var* value, ScriptContext * requestContext) override { AssertAndFailFast(); return Property_NotFound; };
+        virtual PropertyQueryFlags GetItemQuery(Var originalInstance, uint32 index, Var* value, ScriptContext * requestContext) override { AssertAndFailFast(); return PropertyQueryFlags::Property_NotFound; };
+        virtual PropertyQueryFlags GetItemReferenceQuery(Var originalInstance, uint32 index, Var* value, ScriptContext * requestContext) override { AssertAndFailFast(); return PropertyQueryFlags::Property_NotFound; };
         virtual DescriptorFlags GetItemSetter(uint32 index, Var* setterValue, ScriptContext* requestContext) override { AssertAndFailFast(); return None; };
         virtual BOOL SetItem(uint32 index, Var value, PropertyOperationFlags flags) override { AssertAndFailFast(); return FALSE; };
         virtual BOOL DeleteItem(uint32 index, PropertyOperationFlags flags) override { AssertAndFailFast(); return FALSE; };

--- a/lib/Runtime/Types/WithScopeObject.h
+++ b/lib/Runtime/Types/WithScopeObject.h
@@ -29,7 +29,7 @@ namespace Js
 
             // A WithScopeObject should never call the Functions defined below this comment
             virtual BOOL SetProperty(JavascriptString* propertyNameString, Var value, PropertyOperationFlags flags, PropertyValueInfo* info) override { AssertAndFailFast(); return FALSE; };
-            virtual PropertyQueryFlags GetPropertyQuery(Var originalInstance, JavascriptString* propertyNameString, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override { AssertAndFailFast(); return Property_NotFound; };
+            virtual PropertyQueryFlags GetPropertyQuery(Var originalInstance, JavascriptString* propertyNameString, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override { AssertAndFailFast(); return PropertyQueryFlags::Property_NotFound; };
             virtual DescriptorFlags GetSetter(JavascriptString* propertyNameString, Var *setterValue, PropertyValueInfo* info, ScriptContext* requestContext) override { AssertAndFailFast(); return None; };
             virtual int GetPropertyCount() override { AssertAndFailFast(); return 0; };
             virtual PropertyId GetPropertyId(PropertyIndex index) override { AssertAndFailFast();  return Constants::NoProperty; };
@@ -38,10 +38,10 @@ namespace Js
             virtual BOOL InitProperty(PropertyId propertyId, Var value, PropertyOperationFlags flags = PropertyOperation_None, PropertyValueInfo* info = NULL) override { AssertAndFailFast(); return FALSE; };
             virtual BOOL SetPropertyWithAttributes(PropertyId propertyId, Var value, PropertyAttributes attributes, PropertyValueInfo* info, PropertyOperationFlags flags = PropertyOperation_None, SideEffects possibleSideEffects = SideEffects_Any) override { AssertAndFailFast(); return FALSE; };
             virtual BOOL IsFixedProperty(PropertyId propertyId) override { AssertAndFailFast(); return FALSE; };
-            virtual PropertyQueryFlags HasItemQuery(uint32 index) override { AssertAndFailFast(); return Property_NotFound; };
+            virtual PropertyQueryFlags HasItemQuery(uint32 index) override { AssertAndFailFast(); return PropertyQueryFlags::Property_NotFound; };
             virtual BOOL HasOwnItem(uint32 index) override { AssertAndFailFast(); return FALSE; };
-            virtual PropertyQueryFlags GetItemQuery(Var originalInstance, uint32 index, Var* value, ScriptContext * requestContext) override { AssertAndFailFast(); return Property_NotFound; };
-            virtual PropertyQueryFlags GetItemReferenceQuery(Var originalInstance, uint32 index, Var* value, ScriptContext * requestContext) override { AssertAndFailFast(); return Property_NotFound; };
+            virtual PropertyQueryFlags GetItemQuery(Var originalInstance, uint32 index, Var* value, ScriptContext * requestContext) override { AssertAndFailFast(); return PropertyQueryFlags::Property_NotFound; };
+            virtual PropertyQueryFlags GetItemReferenceQuery(Var originalInstance, uint32 index, Var* value, ScriptContext * requestContext) override { AssertAndFailFast(); return PropertyQueryFlags::Property_NotFound; };
             virtual DescriptorFlags GetItemSetter(uint32 index, Var* setterValue, ScriptContext* requestContext) override { AssertAndFailFast(); return None; };
             virtual BOOL SetItem(uint32 index, Var value, PropertyOperationFlags flags) override { AssertAndFailFast(); return FALSE; };
             virtual BOOL DeleteItem(uint32 index, PropertyOperationFlags flags) override { AssertAndFailFast(); return FALSE; };


### PR DESCRIPTION
Change PropertyQueryFlags from enum to enum class
Update references to enum class values
Fix unintended implicit conversions between PropertyQueryFlags and BOOL
