### PR TITLE
TryFinally Fixes

### DIFF
--- a/lib/Backend/FlowGraph.cpp
+++ b/lib/Backend/FlowGraph.cpp
@@ -693,6 +693,7 @@ void FlowGraph::InsertEdgeFromFinallyToEarlyExit(BasicBlock *finallyEndBlock, IR
 
         IR::BranchInstr *brToExit = IR::BranchInstr::New(Js::OpCode::BrOnException, exitLabel, this->func);
         brToExit->m_brFinallyToEarlyExit = true;
+        brToExit->SetByteCodeOffset(lastInstr);
         leaveLabel->InsertBefore(brToExit);
 
         this->AddBlock(brLabel, brToExit, finallyEndBlock->GetNext(), finallyEndBlock /*prevBlock*/);
@@ -704,6 +705,7 @@ void FlowGraph::InsertEdgeFromFinallyToEarlyExit(BasicBlock *finallyEndBlock, IR
     {
         // If the Leave/LeaveNull at the end of finally was preceeded by a Label, we reuse the block inserting BrOnException to early exit in it
         IR::BranchInstr *brToExit = IR::BranchInstr::New(Js::OpCode::BrOnException, exitLabel, this->func);
+        brToExit->SetByteCodeOffset(lastInstr);
         brToExit->m_brFinallyToEarlyExit = true;
         leaveLabel->InsertBefore(brToExit);
         this->AddEdge(finallyEndBlock, exitLabel->GetBasicBlock());

--- a/lib/Backend/FlowGraph.cpp
+++ b/lib/Backend/FlowGraph.cpp
@@ -1978,6 +1978,12 @@ FlowGraph::UpdateRegionForBlockFromEHPred(BasicBlock * block, bool reassign)
         Assert(this->func->HasTry() && (this->func->DoOptimizeTry() || (this->func->IsSimpleJit() && this->func->hasBailout)));
         return;
     }
+    if (block->isDead || block->isDeleted)
+    {
+        // We can end up calling this function with such blocks, return doing nothing
+        // See test5() in tryfinallytests.js
+        return;
+    }
 
     if (block == this->blockList)
     {

--- a/lib/Backend/GlobOpt.h
+++ b/lib/Backend/GlobOpt.h
@@ -921,6 +921,7 @@ private:
     void                    OptimizeIndirUses(IR::IndirOpnd *indir, IR::Instr * *pInstr, Value **indirIndexValRef);
     void                    RemoveCodeAfterNoFallthroughInstr(IR::Instr *instr);
     void                    ProcessTryHandler(IR::Instr* instr);
+    bool                    ProcessExceptionHandlingEdges(IR::Instr* instr);
     void                    InsertToVarAtDefInTryRegion(IR::Instr * instr, IR::Opnd * dstOpnd);
     void                    RemoveFlowEdgeToCatchBlock(IR::Instr * instr);
     bool                    RemoveFlowEdgeToFinallyOnExceptionBlock(IR::Instr * instr);

--- a/test/EH/tryfinallytests.js
+++ b/test/EH/tryfinallytests.js
@@ -79,6 +79,30 @@ function test5() {
   }
 }
 
+function test4() {
+  var obj0 = {};
+  var obj1 = {};
+  var arrObj0 = {};
+  var func0 = function () {
+  };
+  var func2 = function () {
+  };
+  obj0.method1 = func0;
+  obj1.method1 = func2;
+  var ary = Array();
+  var protoObj1 = Object(obj1);
+  while (typeof 11) {
+    protoObj1.method1(obj0.method1(ary.unshift((Object.defineProperty(obj1, 'prop1', {})))));
+    try {
+    } catch (ex) {
+      continue;
+    } finally {
+      obj1.prop1 = typeof arrObj0.length;
+      break;
+    }
+  }
+}
+
 test0();
 test0();
 test0();
@@ -95,8 +119,13 @@ test3();
 test3();
 test3();
 
+test4();
+test4();
+test4();
+
 test5();
 test5();
 test5();
+
 
 WScript.Echo("passed");

--- a/test/EH/tryfinallytests.js
+++ b/test/EH/tryfinallytests.js
@@ -46,6 +46,23 @@ function test2() {
   ary | 0;
 }
 
+function test3() {
+  var IntArr0 = new Array();
+  var VarArr0 = [];
+  try {
+  } catch (ex) {
+  } finally {
+    do {
+      try {
+        VarArr0.reverse();
+      } catch (ex) {
+        continue;
+      } finally {
+      }
+    } while (IntArr0[5]);
+  }
+}
+
 function test5() {
   for (let rwcjvd = 0, ljcyer = /x/g; rwcjvd; rwcjvd) {
     {
@@ -73,6 +90,10 @@ test1();
 test2();
 test2();
 test2();
+
+test3();
+test3();
+test3();
 
 test5();
 test5();

--- a/test/EH/tryfinallytests.js
+++ b/test/EH/tryfinallytests.js
@@ -46,6 +46,22 @@ function test2() {
   ary | 0;
 }
 
+function test5() {
+  for (let rwcjvd = 0, ljcyer = /x/g; rwcjvd; rwcjvd) {
+    {
+      if (/x/) {
+        try {
+        } catch (e) {
+        }
+      } else {
+        throw "err" ;
+        while (new Array.isArray(/x/g, 'u56DC') && 0) {
+        }
+      }
+    }
+  }
+}
+
 test0();
 test0();
 test0();
@@ -57,5 +73,9 @@ test1();
 test2();
 test2();
 test2();
+
+test5();
+test5();
+test5();
 
 WScript.Echo("passed");


### PR DESCRIPTION
-  Dont run region propagation code on deleted/dead blocks
- Set m_hasNonBranchRef on a label in eh region which can become unreferenced after globopt removes BrOnException edges
-  Add ByteCodeOffset to BrOnException added from finally to early exit
