### PR TITLE
Update PR#3354: Module namespace entries are not sorted properly

### DIFF
--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -1148,20 +1148,6 @@ CommonNumber:
             return proxy->PropertyKeysTrap(JavascriptProxy::KeysTrapKind::GetOwnPropertyNamesKind, scriptContext);
         }
 
-        if (ModuleNamespace::Is(object))
-        {
-            ModuleNamespace *ns = ModuleNamespace::FromVar(object);
-            JavascriptArray *names = ns->GetSortedExportedNames();
-            if (names == nullptr)
-            {
-                names = JavascriptObject::CreateOwnStringPropertiesHelper(object, scriptContext);
-                names->Sort(nullptr);
-                ns->SetSortedExportedNames(names);
-            }
-
-            return names;
-        }
-
         return JavascriptObject::CreateOwnStringPropertiesHelper(object, scriptContext);
     }
 

--- a/lib/Runtime/Language/ModuleNamespace.h
+++ b/lib/Runtime/Language/ModuleNamespace.h
@@ -29,8 +29,7 @@ namespace Js
 
         static ModuleNamespace* GetModuleNamespace(ModuleRecordBase* moduleRecord);
         void Initialize();
-        JavascriptArray *GetSortedExportedNames() { return this->sortedExportedNames; }
-        void SetSortedExportedNames(JavascriptArray *val) { this->sortedExportedNames = val; }
+        ListForListIterator* GetSortedExportedNames() { return this->sortedExportedNames; }
         static bool Is(Var aValue) {  return JavascriptOperators::GetTypeId(aValue) == TypeIds_ModuleNamespace; }
         static ModuleNamespace* FromVar(Var obj) { Assert(JavascriptOperators::GetTypeId(obj) == TypeIds_ModuleNamespace); return static_cast<ModuleNamespace*>(obj); }
 
@@ -86,7 +85,7 @@ namespace Js
         Field(ModuleRecordBase*) moduleRecord;
         Field(UnambiguousExportMap*) unambiguousNonLocalExports;
         Field(SimplePropertyDescriptorMap*) propertyMap;   // local exports.
-        Field(JavascriptArray*) sortedExportedNames;   // sorted exported names
+        Field(ListForListIterator*) sortedExportedNames;   // sorted exported names for both local and indirect exports; excludes symbols.
         Field(Field(Var)*) nsSlots;
 
         void SetNSSlotsForModuleNS(Field(Var)* nsSlot) { this->nsSlots = nsSlot; }

--- a/lib/Runtime/Language/ModuleNamespaceEnumerator.h
+++ b/lib/Runtime/Language/ModuleNamespaceEnumerator.h
@@ -25,7 +25,7 @@ namespace Js
         Field(ModuleNamespace::UnambiguousExportMap*) nonLocalMap;
         Field(BigPropertyIndex) currentLocalMapIndex;
         Field(BigPropertyIndex) currentNonLocalMapIndex;
-        Field(bool) doneWithLocalExports;
+        Field(bool) doneWithExports;
         Field(bool) doneWithSymbol;
         Field(EnumeratorFlags) flags;
     };

--- a/test/es6/module-namespace.js
+++ b/test/es6/module-namespace.js
@@ -241,8 +241,21 @@ var tests = [
                 var p = new Proxy(ns, {});
                 var names = ["sym0","default","$","$$","_","\u03bb","aa","A","a","zz","z","\u03bc","Z","za","__","az","\u03c0"].sort();
 
-                assert.areEqual(names, Object.getOwnPropertyNames(ns), "ModuleNamespace");
-                assert.areEqual(names, Object.getOwnPropertyNames(p), "Proxy");
+                var verifyNamespaceOwnProperty = function(obj, objKind) {
+                    assert.areEqual(names, Object.getOwnPropertyNames(obj), objKind+" getOwnPropertyNames()");
+
+                    var propDesc = Object.getOwnPropertyDescriptors(obj);
+                    assert.areEqual('{"value":"Module","writable":false,"enumerable":false,"configurable":false}', JSON.stringify(propDesc[Symbol.toStringTag]),
+                        objKind+" getOwnPropertyDescriptors() @@toStringTag");
+                    assert.areEqual(names, Object.keys(propDesc), "ModuleNamespace", objKind+" getOwnPropertyDescriptors()");
+                };
+
+                verifyNamespaceOwnProperty(ns, "ModuleNamespace");
+                verifyNamespaceOwnProperty(p, "Proxy");
+
+                var propEn = [];
+                for (var k in ns) { propEn.push(k); }
+                assert.areEqual(names, propEn, "ModuleNamespace enumerator");
                 `;
             testModuleScript(functionBody, "Test importing as different binding identifiers", false);
        }


### PR DESCRIPTION
Add 'sortedExportedNames' to ModuleNamespace and update ModuleNamespaceEnumerator.

9.4.6 Module namespace exotic objects' [[OwnPropertyKeys]] should
return a list of property names as sorted with Array.prototype.sort
using undefined as comparefn.
