### PR TITLE
On .caller, only invalidate cached scopes for nested parents

### DIFF
--- a/lib/Runtime/Debug/TTSnapObjects.cpp
+++ b/lib/Runtime/Debug/TTSnapObjects.cpp
@@ -743,7 +743,7 @@ namespace TTD
 
             if(snapFuncInfo->CachedScopeObjId != TTD_INVALID_PTR_ID)
             {
-                fobj->SetCachedScope((Js::ActivationObjectEx*)inflator->LookupObject(snapFuncInfo->CachedScopeObjId));
+                fobj->SetCachedScope(Js::ActivationObjectEx::FromVar(inflator->LookupObject(snapFuncInfo->CachedScopeObjId)));
             }
 
             if(snapFuncInfo->HomeObjId != TTD_INVALID_PTR_ID)

--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -5541,7 +5541,7 @@ namespace Js
 
     Var InterpreterStackFrame::OP_GetCachedFunc(Var instance, int32 index)
     {
-        ActivationObjectEx *obj = (ActivationObjectEx*)ActivationObjectEx::FromVar(instance);
+        ActivationObjectEx *obj = ActivationObjectEx::FromVar(instance);
 
         FuncCacheEntry *entry = obj->GetFuncCacheEntry((uint)index);
         return entry->func;
@@ -5555,7 +5555,7 @@ namespace Js
 
     void InterpreterStackFrame::OP_CommitScopeHelper(const PropertyIdArray *propIds)
     {
-        ActivationObjectEx *obj = (ActivationObjectEx*)ActivationObjectEx::FromVar(this->localClosure);
+        ActivationObjectEx *obj = ActivationObjectEx::FromVar(this->localClosure);
         ScriptFunction *func = obj->GetParentFunc();
 
         Assert(obj->GetParentFunc() == func);

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -5632,7 +5632,7 @@ CommonNumber:
 
     void JavascriptOperators::OP_InitCachedFuncs(Var varScope, FrameDisplay *pDisplay, const FuncInfoArray *info, ScriptContext *scriptContext)
     {
-        ActivationObjectEx *scopeObj = (ActivationObjectEx*)ActivationObjectEx::FromVar(varScope);
+        ActivationObjectEx *scopeObj = ActivationObjectEx::FromVar(varScope);
         Assert(scopeObj->GetTypeHandler()->GetInlineSlotCapacity() == 0);
 
         uint funcCount = info->count;

--- a/lib/Runtime/Library/JavascriptFunction.cpp
+++ b/lib/Runtime/Library/JavascriptFunction.cpp
@@ -2726,16 +2726,17 @@ LABEL1:
                 // If this is the internal function of a generator function then return the original generator function
                 funcCaller = ScriptFunction::FromVar(funcCaller)->GetRealFunctionObject();
 
-                // This function is escaping, so make sure there isn't some caller that has a cached scope.
-                JavascriptFunction * func;
-                while (walker.GetCaller(&func))
+                // This function is escaping, so make sure there isn't some nested parent that has a cached scope.
+                if (ScriptFunction::Is(funcCaller))
                 {
-                    if (ScriptFunction::Is(func))
+                    FrameDisplay * pFrameDisplay = Js::ScriptFunction::FromVar(funcCaller)->GetEnvironment();
+                    uint length = (uint)pFrameDisplay->GetLength();
+                    for (uint i = 0; i < length; i++)
                     {
-                        ActivationObjectEx * obj = ScriptFunction::FromVar(func)->GetCachedScope();
-                        if (obj)
+                        void * scope = pFrameDisplay->GetItem(i);
+                        if (!Js::ScopeSlots::Is(scope) && Js::ActivationObjectEx::Is(scope))
                         {
-                            obj->InvalidateCachedScope();
+                            Js::ActivationObjectEx::FromVar(scope)->InvalidateCachedScope();
                         }
                     }
                 }

--- a/lib/Runtime/Types/ActivationObject.h
+++ b/lib/Runtime/Types/ActivationObject.h
@@ -209,6 +209,12 @@ namespace Js
             return VirtualTableInfo<Js::ActivationObjectEx>::HasVirtualTable(instance);
         }
 
+        static ActivationObjectEx * FromVar(Var instance)
+        {
+            AssertOrFailFast(Is(instance));
+            return reinterpret_cast<ActivationObjectEx *>(instance);
+        }
+
     private:
         Field(ScriptFunction *) parentFunc;
         Field(uint) cachedFuncCount;


### PR DESCRIPTION
When a function escapes as the return value of .caller, we currently walk the whole stack and invalidate cached scope on every function on the stack that has one set. However, it seems that we only need to do the invalidation for nested parents of the result of .caller. This PR attempts to do just that.