### PR TITLE
OS12503560: assignment to super[prop] not accessing base class property

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -7106,9 +7106,16 @@ void EmitAssignment(
 
     case knopIndex:
     {
+        Js::RegSlot targetLocation =
+            (lhs->sxBin.pnode1->nop == knopSuper) ?
+            byteCodeGenerator->EmitLdObjProto(Js::OpCode::LdHomeObjProto, funcInfo->superRegister, funcInfo) :
+            lhs->sxBin.pnode1->location;
+
+        EmitSuperMethodBegin(lhs, byteCodeGenerator, funcInfo);
         byteCodeGenerator->Writer()->Element(
             ByteCodeGenerator::GetStElemIOpCode(funcInfo),
-            rhsLocation, lhs->sxBin.pnode1->location, lhs->sxBin.pnode2->location);
+            rhsLocation, targetLocation, lhs->sxBin.pnode2->location);
+
         break;
     }
 

--- a/test/es6/classes_bugfixes.js
+++ b/test/es6/classes_bugfixes.js
@@ -376,6 +376,33 @@ var tests = [
         assert.areEqual('abc', result, "result == 'abc'");
     }
   },
+  {
+    name: "OS12503560: assignment to super[prop] not accessing base class property",
+    body: function () {
+        var result = "";
+        class B {
+            get x1() { result += "Bgetter;"; return 0; }
+            set x1(v){ result += "Bsetter;"; }
+        }
+
+        class A extends B {
+            constructor() {
+                (()=>{
+                    super();
+                    var s = 'x';
+                    super[(s+s).substr(0,1)+1] = null;
+                    s = super[s+'1'];
+                })();
+            }
+
+            get x1() { result += "Agetter;"; return 0; } // should not be called
+            set x1(v){ result += "Asetter;"; }  // should not be called
+        };
+
+        new A();
+        assert.areEqual('Bsetter;Bgetter;', result);
+    }
+  },
 ];
 
 testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });


### PR DESCRIPTION
Assignments to super[expr] where expr contains variable references
are not being applied to super property objects. Fix bytecode emitter.
