### PR TITLE
Make toGMTString the same function object as toUTCString

### DIFF
--- a/lib/Runtime/Library/JavascriptBuiltInFunctionList.h
+++ b/lib/Runtime/Library/JavascriptBuiltInFunctionList.h
@@ -125,7 +125,6 @@ BUILTIN(JavascriptDate, ToLocaleTimeString, EntryToLocaleTimeString, FunctionInf
 BUILTIN(JavascriptDate, ToString, EntryToString, FunctionInfo::ErrorOnNew | FunctionInfo::HasNoSideEffect)
 BUILTIN(JavascriptDate, ToTimeString, EntryToTimeString, FunctionInfo::ErrorOnNew)
 BUILTIN(JavascriptDate, ToUTCString, EntryToUTCString, FunctionInfo::ErrorOnNew)
-BUILTIN(JavascriptDate, ToGMTString, EntryToGMTString, FunctionInfo::ErrorOnNew)
 BUILTIN(JavascriptDate, UTC, EntryUTC, FunctionInfo::ErrorOnNew)
 BUILTIN(JavascriptDate, ValueOf, EntryValueOf, FunctionInfo::ErrorOnNew | FunctionInfo::HasNoSideEffect)
 BUILTIN(JavascriptDate, SymbolToPrimitive, EntrySymbolToPrimitive, FunctionInfo::ErrorOnNew)

--- a/lib/Runtime/Library/JavascriptDate.cpp
+++ b/lib/Runtime/Library/JavascriptDate.cpp
@@ -1503,16 +1503,6 @@ namespace Js
             DateImplementation::DateTimeFlag::NoDate);
     }
 
-    // CONSIDER: ToGMTString and ToUTCString is the same, but currently the profiler use the entry point address to identify
-    // the entry point. So we will have to make the function different. Consider using FunctionInfo to identify the function
-    Var JavascriptDate::EntryToGMTString(RecyclableObject* function, CallInfo callInfo, ...)
-    {
-        PROBE_STACK(function->GetScriptContext(), Js::Constants::MinStackDefault);
-
-        ARGUMENTS(args, callInfo);
-        return JavascriptFunction::CallFunction<true>(function, JavascriptDate::EntryToUTCString, args);
-    }
-
     Var JavascriptDate::EntryToUTCString(RecyclableObject* function, CallInfo callInfo, ...)
     {
         PROBE_STACK(function->GetScriptContext(), Js::Constants::MinStackDefault);

--- a/lib/Runtime/Library/JavascriptDate.h
+++ b/lib/Runtime/Library/JavascriptDate.h
@@ -129,7 +129,6 @@ namespace Js
         static Var EntryToString(RecyclableObject* function, CallInfo callInfo, ...);
         static Var EntryToTimeString(RecyclableObject* function, CallInfo callInfo, ...);
         static Var EntryToUTCString(RecyclableObject* function, CallInfo callInfo, ...);
-        static Var EntryToGMTString(RecyclableObject* function, CallInfo callInfo, ...);
         static Var EntryUTC(RecyclableObject* function, CallInfo callInfo, ...);
         static Var EntryValueOf(RecyclableObject* function, CallInfo callInfo, ...);
         static Var EntrySymbolToPrimitive(RecyclableObject* function, CallInfo callInfo, ...);

--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -2595,7 +2595,7 @@ namespace Js
         scriptContext->SetBuiltInLibraryFunction(JavascriptDate::EntryInfo::ToISOString.GetOriginalEntryPoint(),
             library->AddFunctionToLibraryObject(datePrototype, PropertyIds::toISOString, &JavascriptDate::EntryInfo::ToISOString, 0));
         scriptContext->SetBuiltInLibraryFunction(JavascriptDate::EntryInfo::ToJSON.GetOriginalEntryPoint(),
-             library->AddFunctionToLibraryObject(datePrototype, PropertyIds::toJSON, &JavascriptDate::EntryInfo::ToJSON, 1));
+            library->AddFunctionToLibraryObject(datePrototype, PropertyIds::toJSON, &JavascriptDate::EntryInfo::ToJSON, 1));
         scriptContext->SetBuiltInLibraryFunction(JavascriptDate::EntryInfo::ToLocaleDateString.GetOriginalEntryPoint(),
             library->AddFunctionToLibraryObject(datePrototype, PropertyIds::toLocaleDateString, &JavascriptDate::EntryInfo::ToLocaleDateString, 0));
         scriptContext->SetBuiltInLibraryFunction(JavascriptDate::EntryInfo::ToLocaleString.GetOriginalEntryPoint(),
@@ -2606,9 +2606,12 @@ namespace Js
             library->AddFunctionToLibraryObject(datePrototype, PropertyIds::toString, &JavascriptDate::EntryInfo::ToString, 0));
         scriptContext->SetBuiltInLibraryFunction(JavascriptDate::EntryInfo::ToTimeString.GetOriginalEntryPoint(),
             library->AddFunctionToLibraryObject(datePrototype, PropertyIds::toTimeString, &JavascriptDate::EntryInfo::ToTimeString, 0));
-        scriptContext->SetBuiltInLibraryFunction(JavascriptDate::EntryInfo::ToUTCString.GetOriginalEntryPoint(),
-            library->AddFunctionToLibraryObject(datePrototype, PropertyIds::toUTCString, &JavascriptDate::EntryInfo::ToUTCString, 0));
-        library->AddFunctionToLibraryObject(datePrototype, PropertyIds::toGMTString, &JavascriptDate::EntryInfo::ToGMTString, 0);
+
+        // Spec stipulates toGMTString must be the same function object as toUTCString
+        JavascriptFunction *toUTCStringFunc = library->AddFunctionToLibraryObject(datePrototype, PropertyIds::toUTCString, &JavascriptDate::EntryInfo::ToUTCString, 0);
+        scriptContext->SetBuiltInLibraryFunction(JavascriptDate::EntryInfo::ToUTCString.GetOriginalEntryPoint(), toUTCStringFunc);
+        library->AddMember(datePrototype, PropertyIds::toGMTString, toUTCStringFunc, PropertyBuiltInMethodDefaults);
+
         scriptContext->SetBuiltInLibraryFunction(JavascriptDate::EntryInfo::ValueOf.GetOriginalEntryPoint(),
             library->AddFunctionToLibraryObject(datePrototype, PropertyIds::valueOf, &JavascriptDate::EntryInfo::ValueOf, 0));
 
@@ -5000,10 +5003,9 @@ namespace Js
 
     JavascriptFunction* JavascriptLibrary::AddFunction(DynamicObject* object, PropertyId propertyId, RuntimeFunction* function)
     {
-
-       AddMember(object, propertyId, function);
-       function->SetFunctionNameId(TaggedInt::ToVarUnchecked((int)propertyId));
-       return function;
+        AddMember(object, propertyId, function);
+        function->SetFunctionNameId(TaggedInt::ToVarUnchecked((int)propertyId));
+        return function;
     }
 
     JavascriptFunction * JavascriptLibrary::AddFunctionToLibraryObject(DynamicObject* object, PropertyId propertyId, FunctionInfo * functionInfo, int length, PropertyAttributes attributes)
@@ -7664,7 +7666,6 @@ namespace Js
         REG_OBJECTS_LIB_FUNC(toString, JavascriptDate::EntryToString);
         REG_OBJECTS_LIB_FUNC(toTimeString, JavascriptDate::EntryToTimeString);
         REG_OBJECTS_LIB_FUNC(toUTCString, JavascriptDate::EntryToUTCString);
-        REG_OBJECTS_LIB_FUNC(toGMTString, JavascriptDate::EntryToGMTString);
         REG_OBJECTS_LIB_FUNC(valueOf, JavascriptDate::EntryValueOf);
 
         return hr;

--- a/test/Date/DateUTC-DateGMT-same.js
+++ b/test/Date/DateUTC-DateGMT-same.js
@@ -1,0 +1,11 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+const areSame = Date.prototype.toGMTString === Date.prototype.toUTCString;
+if (areSame) {
+    console.log("PASS");
+} else {
+    console.log("FAIL");
+}

--- a/test/Date/rlexe.xml
+++ b/test/Date/rlexe.xml
@@ -56,6 +56,12 @@
   </test>
   <test>
     <default>
+      <files>DateUTC-DateGMT-same.js</files>
+      <compile-flags>-args summary -endargs</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>MillisecondTruncationCheckAfterCopyConstructor.js</files>
       <baseline>MillisecondTruncationCheckAfterCopyConstructor.es6.baseline</baseline>
     </default>

--- a/test/Lib/toString.baseline
+++ b/test/Lib/toString.baseline
@@ -148,7 +148,7 @@ function setUTCMonth() { [native code] }
 function setFullYear() { [native code] }
 function setUTCFullYear() { [native code] }
 function toUTCString() { [native code] }
-function toGMTString() { [native code] }
+function toUTCString() { [native code] }
 function toLocaleTimeString() { [native code] }
 function toUTCString() { [native code] }
 function setYear() { [native code] }


### PR DESCRIPTION
The spec requires that `Date.prototype.toGMTString` and `Date.prototype.toUTCString` are the same function object.

See: https://tc39.github.io/ecma262/#sec-date.prototype.togmtstring

Fixes #2808 