### PR TITLE
jsrt: cleanup CHAKRACOREBUILD_ symbol in headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,6 +237,7 @@ if(STATIC_LIBRARY)
 endif()
 
 if(CLR_CMAKE_PLATFORM_XPLAT)
+    add_definitions(-D_CHAKRACOREBUILD)
     add_definitions(-DFEATURE_PAL)
     add_definitions(-DPLATFORM_UNIX=1)
 

--- a/lib/Jsrt/ChakraCommon.h
+++ b/lib/Jsrt/ChakraCommon.h
@@ -96,10 +96,6 @@ typedef unsigned short WCHAR;
 typedef unsigned short uint16_t;
 #endif
 
-#if !defined(NTBUILD) && !defined(CHAKRACOREBUILD_)
-#define CHAKRACOREBUILD_
-#endif
-
     /// <summary>
     ///     An error code returned from a Chakra hosting API.
     /// </summary>

--- a/lib/Jsrt/ChakraCore.h
+++ b/lib/Jsrt/ChakraCore.h
@@ -21,9 +21,15 @@
 #ifndef _CHAKRACORE_H_
 #define _CHAKRACORE_H_
 
-#include "ChakraCommon.h"
+#if !defined(NTBUILD) && !defined(_CHAKRACOREBUILD)
+#define _CHAKRACOREBUILD
+#endif
 
+#include "ChakraCommon.h"
 #include "ChakraDebug.h"
+
+// Begin ChakraCore only APIs
+#ifdef _CHAKRACOREBUILD
 
 typedef void* JsModuleRecord;
 
@@ -31,7 +37,7 @@ typedef void* JsModuleRecord;
 ///     A reference to an object owned by the SharedArrayBuffer.
 /// </summary>
 /// <remarks>
-///     This represents SharedContents which is heap allocated object, it can be passed through 
+///     This represents SharedContents which is heap allocated object, it can be passed through
 ///     different runtimes to share the underlying buffer.
 /// </remarks>
 typedef void *JsSharedArrayBufferContentHandle;
@@ -188,7 +194,6 @@ JsGetModuleHostInfo(
     _In_ JsModuleHostInfoKind moduleHostInfo,
     _Outptr_result_maybenull_ void** hostInfo);
 
-#ifdef CHAKRACOREBUILD_
 /// <summary>
 ///     Returns metadata relating to the exception that caused the runtime of the current context
 ///     to be in the exception state and resets the exception state for that runtime. The metadata
@@ -661,5 +666,5 @@ CHAKRA_API
 JsReleaseSharedArrayBufferContentHandle(
     _In_ JsSharedArrayBufferContentHandle sharedContents);
 
-#endif // CHAKRACOREBUILD_
+#endif // _CHAKRACOREBUILD
 #endif // _CHAKRACORE_H_

--- a/lib/Jsrt/ChakraDebug.h
+++ b/lib/Jsrt/ChakraDebug.h
@@ -20,8 +20,6 @@
 #ifndef _CHAKRADEBUG_H_
 #define _CHAKRADEBUG_H_
 
-#include "ChakraCommon.h"
-
 #ifdef _WIN32
 //Other platforms already include <stdint.h> and have this defined automatically
 typedef __int64 int64_t;

--- a/lib/Jsrt/Jsrt.cpp
+++ b/lib/Jsrt/Jsrt.cpp
@@ -1559,6 +1559,7 @@ CHAKRA_API JsCreateArrayBuffer(_In_ unsigned int byteLength, _Out_ JsValueRef *r
     });
 }
 
+#ifdef _CHAKRACOREBUILD
 CHAKRA_API JsCreateSharedArrayBufferWithSharedContent(_In_ JsSharedArrayBufferContentHandle sharedContents, _Out_ JsValueRef *result)
 {
     return ContextAPIWrapper<true>([&](Js::ScriptContext *scriptContext, TTDRecorder& _actionEntryPopper) -> JsErrorCode {
@@ -1585,7 +1586,7 @@ CHAKRA_API JsGetSharedArrayBufferContent(_In_ JsValueRef sharedArrayBuffer, _Out
         {
             return JsErrorInvalidArgument;
         }
-        
+
         Js::SharedContents**& content = (Js::SharedContents**&)sharedContents;
         *content = Js::SharedArrayBuffer::FromVar(sharedArrayBuffer)->GetSharedContents();
 
@@ -1607,6 +1608,7 @@ CHAKRA_API JsReleaseSharedArrayBufferContentHandle(_In_ JsSharedArrayBufferConte
         return JsNoError;
     });
 }
+#endif // _CHAKRACOREBUILD
 
 CHAKRA_API JsCreateExternalArrayBuffer(_Pre_maybenull_ _Pre_writable_byte_size_(byteLength) void *data, _In_ unsigned int byteLength,
     _In_opt_ JsFinalizeCallback finalizeCallback, _In_opt_ void *callbackState, _Out_ JsValueRef *result)
@@ -4130,7 +4132,7 @@ CHAKRA_API JsTTDReplayExecution(_Inout_ JsTTDMoveMode* moveMode, _Out_ int64_t* 
 #endif
 }
 
-#ifdef CHAKRACOREBUILD_
+#ifdef _CHAKRACOREBUILD
 
 template <class SrcChar, class DstChar>
 static void CastCopy(const SrcChar* src, DstChar* dst, size_t count)
@@ -4731,4 +4733,4 @@ CHAKRA_API JsGetAndClearExceptionWithMetadata(_Out_ JsValueRef *metadata)
         return JsNoError;
     });
 }
-#endif // CHAKRACOREBUILD_
+#endif // _CHAKRACOREBUILD


### PR DESCRIPTION
`CHAKRACOREBUILD_` symbol should not be defined in `ChakraCommon.h`. The
later is included by Chakra JSRT (Windows 10 SDK) and would thus
incorrectly define `CHAKRACOREBUILD_` and expose ChakraCore APIs (Note
that `NTBUILD` is not defined when a user includes Windows SDK headers).

Move the def to `ChakraCore.h` to solve this problem. Normally including
`ChakraCore.h` means using ChakraCore only APIs. (We define the symbol
only when `!NTBUILD` because of one exception -- shared implementation
`Jsrt.cpp` includes `ChakraCore.h`.)

Moved `#ifdef CHAKRACOREBUILD_` to top of file to enclose all recent new
ChakraCore APIs, to help ensure those APIs not defined/exposed to Chakra.

Lastly renamed all `CHAKRACOREBUILD_` to `_CHAKRACOREBUILD`. Use this one
symbol to differentiate ChakraCore APIs and implementations.