### PR TITLE
Adding Jsrt function JsCopyStringOneByte

### DIFF
--- a/bin/NativeTests/JsRTApiTest.cpp
+++ b/bin/NativeTests/JsRTApiTest.cpp
@@ -2143,4 +2143,32 @@ namespace JsRTApiTest
         JsRTApiTest::RunWithAttributes(JsRTApiTest::ObjectHasOwnPropertyMethodTest);
     }
 
+    void JsCopyStringOneByteMethodTest(JsRuntimeAttributes attributes, JsRuntimeHandle runtime)
+    {
+        size_t written = 0;
+        char buf[10] = {0};
+        JsValueRef value;
+        REQUIRE(JsCreateStringUtf16(reinterpret_cast<uint16_t*>(_u("0\x10\x80\xa9\uabcd\U000104377")), 8, &value) == JsNoError);
+        REQUIRE(JsCopyStringOneByte(value, 0, -1, nullptr, &written) == JsNoError);
+        CHECK(written == 8);
+        buf[written] = '\xff';
+
+        REQUIRE(JsCopyStringOneByte(value, 0, 10, buf, &written) == JsNoError);
+        CHECK(written == 8);
+        CHECK(buf[0] == '0');
+        CHECK(buf[1] == '\x10');
+        CHECK(buf[2] == '\x80');
+        CHECK(buf[3] == '\xA9');
+        CHECK(buf[4] == '\xcd');
+        CHECK(buf[5] == '\x01');
+        CHECK(buf[6] == '\x37');
+        CHECK(buf[7] == '7');
+        CHECK(buf[8] == '\xff');
+    }
+
+    TEST_CASE("ApiTest_JsCopyStringOneByteMethodTest", "[ApiTest]")
+    {
+        JsRTApiTest::RunWithAttributes(JsRTApiTest::JsCopyStringOneByteMethodTest);
+    }
+
 }

--- a/lib/Jsrt/ChakraCore.h
+++ b/lib/Jsrt/ChakraCore.h
@@ -679,5 +679,43 @@ CHAKRA_API
         _In_ JsPropertyIdRef propertyId,
         _Out_ bool *hasOwnProperty);
 
+/// <summary>
+///     Write JS string value into char string buffer without a null terminator
+/// </summary>
+/// <remarks>
+///     <para>
+///         When size of the `buffer` is unknown,
+///         `buffer` argument can be nullptr.
+///         In that case, `written` argument will return the length needed.
+///     </para>
+///     <para>
+///         When start is out of range or &lt; 0, returns JsErrorInvalidArgument
+///         and `written` will be equal to 0.
+///         If calculated length is 0 (It can be due to string length or `start`
+///         and length combination), then `written` will be equal to 0 and call
+///         returns JsNoError
+///     </para>
+///     <para>
+///         The JS string `value` will be converted one utf16 code point at a time,
+///         and if it has code points that do not fit in one byte, those values
+///         will be truncated.
+///     </para>
+/// </remarks>
+/// <param name="value">JavascriptString value</param>
+/// <param name="start">Start offset of buffer</param>
+/// <param name="length">Number of characters to be written</param>
+/// <param name="buffer">Pointer to buffer</param>
+/// <param name="written">Total number of characters written</param>
+/// <returns>
+///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
+/// </returns>
+CHAKRA_API
+JsCopyStringOneByte(
+    _In_ JsValueRef value,
+    _In_ int start,
+    _In_ int length,
+    _Out_opt_ char* buffer,
+    _Out_opt_ size_t* written);
+
 #endif // CHAKRACOREBUILD_
 #endif // _CHAKRACORE_H_

--- a/lib/Jsrt/JsrtCommonExports.inc
+++ b/lib/Jsrt/JsrtCommonExports.inc
@@ -120,4 +120,5 @@
     JsGetWeakReferenceValue
     JsGetAndClearExceptionWithMetadata
     JsHasOwnProperty
+    JsCopyStringOneByte
 #endif


### PR DESCRIPTION
For scenarios where a string is known to have values fitting in
one byte, this method allows directly copying those values into a
char* buffer rather than having to copy to a uint16_t* buffer
and then to a char* buffer, and treating the string as raw bytes
rather than a valid utf8 encoding.

This will help reduce overhead in some common nodejs use cases.