### PR TITLE
Fix Issue #3376:  Escaped yield cannot be an identifier in strict mode

### DIFF
--- a/lib/Parser/JsScan.js
+++ b/lib/Parser/JsScan.js
@@ -15,14 +15,14 @@ function emitToken(token, d, indent) {
         r += indent + "p += " + d + ";\r\n";
     if (token.res == 1) {
         if (token.tk === "tkYIELD") {
-            r += indent + "if (this->m_fYieldIsKeyword || !this->m_parser || this->m_parser->IsStrictMode()) {" + "\r\n";
+            r += indent + "if (this->YieldIsKeyword()) {" + "\r\n";
             r += indent + "    token = " + token.tk + ";\r\n";
             r += indent + "    goto LReserved;\r\n";
             r += indent + "}\r\n";
             r += indent + "goto LIdentifier;\r\n";
         } else if (token.tk === "tkAWAIT") {
             // Note: `await` is only a FutureReservedWord when parsing module scripts (when Module is goal symbol of the grammar)
-            r += indent + "if (this->m_fAwaitIsKeyword || this->m_fIsModuleCode) {" + "\r\n";
+            r += indent + "if (this->AwaitIsKeyword()) {" + "\r\n";
             r += indent + "    token = " + token.tk + ";\r\n";
             r += indent + "    goto LReserved;\r\n";
             r += indent + "}\r\n";

--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -256,8 +256,8 @@ HRESULT Parser::ValidateSyntax(LPCUTF8 pszSrc, size_t encodedCharCount, bool isG
 
         // Give the scanner the source and get the first token
         m_pscan->SetText(pszSrc, 0, encodedCharCount, 0, grfscr);
-        m_pscan->SetYieldIsKeyword(isGenerator);
-        m_pscan->SetAwaitIsKeyword(isAsync);
+        m_pscan->SetYieldIsKeywordRegion(isGenerator);
+        m_pscan->SetAwaitIsKeywordRegion(isAsync);
         m_pscan->Scan();
 
         uint nestedCount = 0;
@@ -2929,9 +2929,9 @@ ParseNodePtr Parser::ParseTerm(BOOL fAllowCall,
             isAsyncExpr = true;
         }
 
-        bool previousAwaitIsKeyword = m_pscan->SetAwaitIsKeyword(isAsyncExpr);
+        bool previousAwaitIsKeyword = m_pscan->SetAwaitIsKeywordRegion(isAsyncExpr);
         m_pscan->Scan();
-        m_pscan->SetAwaitIsKeyword(previousAwaitIsKeyword);
+        m_pscan->SetAwaitIsKeywordRegion(previousAwaitIsKeyword);
 
         // We search for an Async expression (a function declaration or an async lambda expression)
         if (isAsyncExpr && !m_pscan->FHadNewLine())
@@ -4979,9 +4979,9 @@ bool Parser::ParseFncDeclHelper(ParseNodePtr pnodeFnc, LPCOLESTR pNameHint, usho
 
     // switch scanner to treat 'yield' as keyword in generator functions
     // or as an identifier in non-generator functions
-    bool fPreviousYieldIsKeyword = m_pscan->SetYieldIsKeyword(pnodeFnc && pnodeFnc->sxFnc.IsGenerator());
+    bool fPreviousYieldIsKeyword = m_pscan->SetYieldIsKeywordRegion(pnodeFnc && pnodeFnc->sxFnc.IsGenerator());
 
-    bool fPreviousAwaitIsKeyword = m_pscan->SetAwaitIsKeyword(fAsync);
+    bool fPreviousAwaitIsKeyword = m_pscan->SetAwaitIsKeywordRegion(fAsync);
 
     if (pnodeFnc && pnodeFnc->sxFnc.IsGenerator())
     {
@@ -5484,8 +5484,8 @@ bool Parser::ParseFncDeclHelper(ParseNodePtr pnodeFnc, LPCOLESTR pNameHint, usho
         m_grfscr |= uDeferSave;
     }
 
-    m_pscan->SetYieldIsKeyword(fPreviousYieldIsKeyword);
-    m_pscan->SetAwaitIsKeyword(fPreviousAwaitIsKeyword);
+    m_pscan->SetYieldIsKeywordRegion(fPreviousYieldIsKeyword);
+    m_pscan->SetAwaitIsKeywordRegion(fPreviousAwaitIsKeyword);
 
     // Restore the current function.
     if (buildAST)
@@ -6062,9 +6062,9 @@ bool Parser::ParseFncNames(ParseNodePtr pnodeFnc, ParseNodePtr pnodeFncParent, u
     {
         if (!fDeclaration)
         {
-            bool fPreviousYieldIsKeyword = m_pscan->SetYieldIsKeyword(!fDeclaration);
+            bool fPreviousYieldIsKeyword = m_pscan->SetYieldIsKeywordRegion(!fDeclaration);
             m_pscan->Scan();
-            m_pscan->SetYieldIsKeyword(fPreviousYieldIsKeyword);
+            m_pscan->SetYieldIsKeywordRegion(fPreviousYieldIsKeyword);
         }
         else
         {
@@ -6205,8 +6205,8 @@ void Parser::ParseFncFormals(ParseNodePtr pnodeFnc, ParseNodePtr pnodeParentFnc,
 
     if (fLambda)
     {
-        fPreviousYieldIsKeyword = m_pscan->SetYieldIsKeyword(pnodeParentFnc != nullptr && pnodeParentFnc->sxFnc.IsGenerator());
-        fPreviousAwaitIsKeyword = m_pscan->SetAwaitIsKeyword(fAsync || (pnodeParentFnc != nullptr && pnodeParentFnc->sxFnc.IsAsync()));
+        fPreviousYieldIsKeyword = m_pscan->SetYieldIsKeywordRegion(pnodeParentFnc != nullptr && pnodeParentFnc->sxFnc.IsGenerator());
+        fPreviousAwaitIsKeyword = m_pscan->SetAwaitIsKeywordRegion(fAsync || (pnodeParentFnc != nullptr && pnodeParentFnc->sxFnc.IsAsync()));
     }
 
     Assert(!fNoArg || !fOneArg); // fNoArg and fOneArg can never be true at the same time.
@@ -6236,8 +6236,8 @@ void Parser::ParseFncFormals(ParseNodePtr pnodeFnc, ParseNodePtr pnodeParentFnc,
 
         if (fLambda)
         {
-            m_pscan->SetYieldIsKeyword(fPreviousYieldIsKeyword);
-            m_pscan->SetAwaitIsKeyword(fPreviousAwaitIsKeyword);
+            m_pscan->SetYieldIsKeywordRegion(fPreviousYieldIsKeyword);
+            m_pscan->SetAwaitIsKeywordRegion(fPreviousAwaitIsKeyword);
         }
 
         return;
@@ -6487,8 +6487,8 @@ void Parser::ParseFncFormals(ParseNodePtr pnodeFnc, ParseNodePtr pnodeParentFnc,
 
     if (fLambda)
     {
-        m_pscan->SetYieldIsKeyword(fPreviousYieldIsKeyword);
-        m_pscan->SetAwaitIsKeyword(fPreviousAwaitIsKeyword);
+        m_pscan->SetYieldIsKeywordRegion(fPreviousYieldIsKeyword);
+        m_pscan->SetAwaitIsKeywordRegion(fPreviousAwaitIsKeyword);
     }
 }
 
@@ -6819,9 +6819,9 @@ void Parser::FinishFncNode(ParseNodePtr pnodeFnc)
 
     // switch scanner to treat 'yield' as keyword in generator functions
     // or as an identifier in non-generator functions
-    bool fPreviousYieldIsKeyword = m_pscan->SetYieldIsKeyword(pnodeFnc && pnodeFnc->sxFnc.IsGenerator());
+    bool fPreviousYieldIsKeyword = m_pscan->SetYieldIsKeywordRegion(pnodeFnc && pnodeFnc->sxFnc.IsGenerator());
 
-    bool fPreviousAwaitIsKeyword = m_pscan->SetAwaitIsKeyword(pnodeFnc && pnodeFnc->sxFnc.IsAsync());
+    bool fPreviousAwaitIsKeyword = m_pscan->SetAwaitIsKeywordRegion(pnodeFnc && pnodeFnc->sxFnc.IsAsync());
 
     // Skip the arg list.
     m_pscan->ScanNoKeywords();
@@ -6916,8 +6916,8 @@ void Parser::FinishFncNode(ParseNodePtr pnodeFnc)
     Assert(tempNextFunctionId == pnodeFnc->sxFnc.deferredParseNextFunctionId);
     this->m_nextFunctionId = nextFunctionIdSave;
 
-    m_pscan->SetYieldIsKeyword(fPreviousYieldIsKeyword);
-    m_pscan->SetAwaitIsKeyword(fPreviousAwaitIsKeyword);
+    m_pscan->SetYieldIsKeywordRegion(fPreviousYieldIsKeyword);
+    m_pscan->SetAwaitIsKeywordRegion(fPreviousAwaitIsKeyword);
 }
 
 void Parser::FinishFncDecl(ParseNodePtr pnodeFnc, LPCOLESTR pNameHint, ParseNodePtr *lastNodeRef, bool skipCurlyBraces)
@@ -8108,10 +8108,10 @@ ParseNodePtr Parser::ParseExpr(int oplMin,
 
         if (nop == knopYield)
         {
-            if (!m_pscan->YieldIsKeyword() || oplMin > opl)
+            if (!m_pscan->YieldIsKeywordRegion() || oplMin > opl)
             {
                 // The case where 'yield' is scanned as a keyword (tkYIELD) but the scanner
-                // is not treating yield as a keyword (!m_pscan->YieldIsKeyword()) occurs
+                // is not treating yield as a keyword (!m_pscan->YieldIsKeywordRegion()) occurs
                 // in strict mode non-generator function contexts.
                 //
                 // That is, 'yield' is a keyword because of strict mode, but YieldExpression
@@ -8128,7 +8128,7 @@ ParseNodePtr Parser::ParseExpr(int oplMin,
         }
         else if (nop == knopAwait)
         {
-            if (!m_pscan->AwaitIsKeyword() ||
+            if (!m_pscan->AwaitIsKeywordRegion() ||
                 m_currentScope->GetScopeType() == ScopeType_Parameter)
             {
                 // As with the 'yield' keyword, the case where 'await' is scanned as a keyword (tkAWAIT)

--- a/lib/Parser/Scan.cpp
+++ b/lib/Parser/Scan.cpp
@@ -104,8 +104,8 @@ Scanner<EncodingPolicy>::Scanner(Parser* parser, HashTbl *phtbl, Token *ptoken, 
 
     this->es6UnicodeMode = scriptContext->GetConfig()->IsES6UnicodeExtensionsEnabled();
 
-    m_fYieldIsKeyword = false;
-    m_fAwaitIsKeyword = false;
+    m_fYieldIsKeywordRegion = false;
+    m_fAwaitIsKeywordRegion = false;
 }
 
 template <typename EncodingPolicy>
@@ -475,12 +475,12 @@ tokens Scanner<EncodingPolicy>::ScanIdentifierContinue(bool identifyKwds, bool f
             // So we can just assume it is an ID
             DebugOnly(int32 cch = UnescapeToTempBuf(pchMin, p));
             DebugOnly(tokens tk = m_phtbl->TkFromNameLen(m_tempChBuf.m_prgch, cch, IsStrictMode()));
-            Assert(tk == tkID || (tk == tkYIELD && !m_fYieldIsKeyword) || (tk == tkAWAIT && !m_fAwaitIsKeyword));
+            Assert(tk == tkID || (tk == tkYIELD && !this->YieldIsKeyword()) || (tk == tkAWAIT && !this->AwaitIsKeyword()));
             return tkID;
         }
         int32 cch = UnescapeToTempBuf(pchMin, p);
         tokens tk = m_phtbl->TkFromNameLen(m_tempChBuf.m_prgch, cch, IsStrictMode());
-        return (!m_fYieldIsKeyword && tk == tkYIELD) || (!m_fAwaitIsKeyword && tk == tkAWAIT) ? tkID : tk;
+        return (!this->YieldIsKeyword() && tk == tkYIELD) || (!this->AwaitIsKeyword() && tk == tkAWAIT) ? tkID : tk;
     }
 
     // UTF16 Scanner are only for syntax coloring, so it shouldn't come here.
@@ -492,7 +492,7 @@ tokens Scanner<EncodingPolicy>::ScanIdentifierContinue(bool identifyKwds, bool f
         // So we can just assume it is an ID
         DebugOnly(int32 cch = UnescapeToTempBuf(pchMin, p));
         DebugOnly(tokens tk = m_phtbl->TkFromNameLen(m_tempChBuf.m_prgch, cch, IsStrictMode()));
-        Assert(tk == tkID || (tk == tkYIELD && !m_fYieldIsKeyword) || (tk == tkAWAIT && !m_fAwaitIsKeyword));
+        Assert(tk == tkID || (tk == tkYIELD && !this->YieldIsKeyword()) || (tk == tkAWAIT && !this->AwaitIsKeyword()));
 
         m_ptoken->SetIdentifier(reinterpret_cast<const char *>(pchMin), (int32)(p - pchMin));
         return tkID;
@@ -504,16 +504,16 @@ tokens Scanner<EncodingPolicy>::ScanIdentifierContinue(bool identifyKwds, bool f
     if (!fHasEscape)
     {
         // If it doesn't have escape, then Scan() should have taken care of keywords (except
-        // yield if m_fYieldIsKeyword is false, in which case yield is treated as an identifier, and except
-        // await if m_fAwaitIsKeyword is false, in which case await is treated as an identifier).
+        // yield if this->YieldIsKeyword() is false, in which case yield is treated as an identifier, and except
+        // await if this->AwaitIsKeyword() is false, in which case await is treated as an identifier).
         // We don't have to check if the name is reserved word and return it as an Identifier
         Assert(pid->Tk(IsStrictMode()) == tkID
-            || (pid->Tk(IsStrictMode()) == tkYIELD && !m_fYieldIsKeyword)
-            || (pid->Tk(IsStrictMode()) == tkAWAIT && !m_fAwaitIsKeyword));
+            || (pid->Tk(IsStrictMode()) == tkYIELD && !this->YieldIsKeyword())
+            || (pid->Tk(IsStrictMode()) == tkAWAIT && !this->AwaitIsKeyword()));
         return tkID;
     }
     tokens tk = pid->Tk(IsStrictMode());
-    return tk == tkID || (tk == tkYIELD && !m_fYieldIsKeyword) || (tk == tkAWAIT && !m_fAwaitIsKeyword) ? tkID : tkNone;
+    return tk == tkID || (tk == tkYIELD && !this->YieldIsKeyword()) || (tk == tkAWAIT && !this->AwaitIsKeyword()) ? tkID : tkNone;
 }
 
 template <typename EncodingPolicy>

--- a/lib/Parser/Scan.h
+++ b/lib/Parser/Scan.h
@@ -387,26 +387,35 @@ public:
     ScanState GetScanState() { return m_scanState; }
     void SetScanState(ScanState state) { m_scanState = state; }
 
-    bool SetYieldIsKeyword(bool fYieldIsKeyword)
+    bool SetYieldIsKeywordRegion(bool fYieldIsKeywordRegion)
     {
-        bool fPrevYieldIsKeyword = m_fYieldIsKeyword;
-        m_fYieldIsKeyword = fYieldIsKeyword;
-        return fPrevYieldIsKeyword;
+        bool fPrevYieldIsKeywordRegion = m_fYieldIsKeywordRegion;
+        m_fYieldIsKeywordRegion = fYieldIsKeywordRegion;
+        return fPrevYieldIsKeywordRegion;
+    }
+    bool YieldIsKeywordRegion()
+    {
+        return m_fYieldIsKeywordRegion;
     }
     bool YieldIsKeyword()
     {
-        return m_fYieldIsKeyword;
+        return YieldIsKeywordRegion() || this->IsStrictMode();
     }
 
-    bool SetAwaitIsKeyword(bool fAwaitIsKeyword)
+    bool SetAwaitIsKeywordRegion(bool fAwaitIsKeywordRegion)
     {
-        bool fPrevAwaitIsKeyword = m_fAwaitIsKeyword;
-        m_fAwaitIsKeyword = fAwaitIsKeyword;
-        return fPrevAwaitIsKeyword;
+        bool fPrevAwaitIsKeywordRegion = m_fAwaitIsKeywordRegion;
+        m_fAwaitIsKeywordRegion = fAwaitIsKeywordRegion;
+        return fPrevAwaitIsKeywordRegion;
     }
+    bool AwaitIsKeywordRegion()
+    {
+        return m_fAwaitIsKeywordRegion;
+    }
+
     bool AwaitIsKeyword()
     {
-        return m_fAwaitIsKeyword;
+        return AwaitIsKeywordRegion() || this->m_fIsModuleCode;
     }
 
     tokens TryRescanRegExp();
@@ -683,8 +692,8 @@ private:
     BYTE m_DeferredParseFlags:2;            // suppressStrPid and suppressIdPid
     charcount_t m_ichCheck;             // character at which completion is to be computed.
     bool es6UnicodeMode;                // True if ES6Unicode Extensions are enabled.
-    bool m_fYieldIsKeyword;             // Whether to treat 'yield' as an identifier or keyword
-    bool m_fAwaitIsKeyword;             // Whether to treat 'await' as an identifier or keyword
+    bool m_fYieldIsKeywordRegion;       // Whether to treat 'yield' as an identifier or keyword
+    bool m_fAwaitIsKeywordRegion;       // Whether to treat 'await' as an identifier or keyword
 
     // Temporary buffer.
     TemporaryBuffer m_tempChBuf;

--- a/lib/Parser/kwd-swtch.h
+++ b/lib/Parser/kwd-swtch.h
@@ -13,7 +13,7 @@
             case 'w':
                 if (p[1] == 'a' && p[2] == 'i' && p[3] == 't' && !IsIdContinueNext(p+4, last)) {
                     p += 4;
-                    if (this->m_fAwaitIsKeyword || this->m_fIsModuleCode) {
+                    if (this->AwaitIsKeyword()) {
                         token = tkAWAIT;
                         goto LReserved;
                     }
@@ -438,7 +438,7 @@
         {
             if (p[0] == 'i' && p[1] == 'e' && p[2] == 'l' && p[3] == 'd' && !IsIdContinueNext(p+4, last)) {
                 p += 4;
-                if (this->m_fYieldIsKeyword || !this->m_parser || this->m_parser->IsStrictMode()) {
+                if (this->YieldIsKeyword()) {
                     token = tkYIELD;
                     goto LReserved;
                 }

--- a/test/es6/await-futreserved-only-in-modules.js
+++ b/test/es6/await-futreserved-only-in-modules.js
@@ -24,12 +24,15 @@ function f() {
 }
 f();
 
-var m = '';
-try {
-    WScript.LoadModule('var await = 0;', 'samethread');
-} catch (e) {
-    m = e.message;
+function test(awaitStr)
+{
+    try {
+        WScript.LoadModule('var ' + awaitStr + ' = 0;', 'samethread');
+    } catch (e) {
+        return e.message === 'The use of a keyword for an identifier is invalid';
+    }
+    print("Failed: no syntax error of identifier '" + awaitStr + "'");
+    return false;
 }
 
-print(m === 'The use of a keyword for an identifier is invalid' ?
-        'pass' : 'fail');
+print(test("await") & test("\\u0061wait")? 'pass' : '');

--- a/test/strict/23.reservedWords.baseline
+++ b/test/strict/23.reservedWords.baseline
@@ -1,563 +1,1126 @@
 (function(){var break;})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0062reak;})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var case;})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0063ase;})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var catch;})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0063atch;})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var continue;})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0063ontinue;})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var debugger;})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0064ebugger;})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var default;})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0064efault;})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var delete;})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0064elete;})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var do;})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0064o;})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var else;})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0065lse;})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var finally;})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0066inally;})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var for;})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0066or;})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var function;})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0066unction;})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var if;})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0069f;})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var in;})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0069n;})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var instanceof;})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0069nstanceof;})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var new;})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u006eew;})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var return;})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0072eturn;})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var switch;})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0073witch;})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var this;})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0074his;})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var throw;})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0074hrow;})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var try;})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0074ry;})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var typeof;})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0074ypeof;})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var var;})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0076ar;})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var void;})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0076oid;})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var while;})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0077hile;})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var with;})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0077ith;})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var null;})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u006eull;})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var false;})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0066alse;})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var true;})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0074rue;})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var class;})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0063lass;})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var const;})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0063onst;})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var enum;})();
 SyntaxError: The use of a future reserved word for an identifier is invalid
+(function(){var \u0065num;})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var export;})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0065xport;})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var extends;})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0065xtends;})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var import;})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0069mport;})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var super;})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0073uper;})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var implements;})();
+(function(){var \u0069mplements;})();
 (function(){var interface;})();
+(function(){var \u0069nterface;})();
 (function(){var let;})();
+(function(){var \u006cet;})();
 (function(){var package;})();
+(function(){var \u0070ackage;})();
 (function(){var private;})();
+(function(){var \u0070rivate;})();
 (function(){var protected;})();
+(function(){var \u0070rotected;})();
 (function(){var public;})();
+(function(){var \u0070ublic;})();
 (function(){var static;})();
+(function(){var \u0073tatic;})();
 (function(){var yield;})();
+(function(){var \u0079ield;})();
 (function(){var foo;})();
+(function(){var \u0066oo;})();
 (function(){var <;})();
 SyntaxError: Expected identifier
+(function(){var \u003c;})();
+SyntaxError: Invalid character
 (function(){function break(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0062reak(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function case(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0063ase(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function catch(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0063atch(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function continue(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0063ontinue(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function debugger(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0064ebugger(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function default(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0064efault(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function delete(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0064elete(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function do(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0064o(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function else(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0065lse(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function finally(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0066inally(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function for(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0066or(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function function(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0066unction(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function if(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0069f(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function in(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0069n(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function instanceof(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0069nstanceof(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function new(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u006eew(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function return(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0072eturn(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function switch(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0073witch(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function this(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0074his(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function throw(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0074hrow(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function try(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0074ry(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function typeof(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0074ypeof(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function var(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0076ar(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function void(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0076oid(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function while(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0077hile(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function with(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0077ith(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function null(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u006eull(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function false(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0066alse(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function true(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0074rue(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function class(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0063lass(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function const(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0063onst(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function enum(){}})();
 SyntaxError: The use of a future reserved word for an identifier is invalid
+(function(){function \u0065num(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function export(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0065xport(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function extends(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0065xtends(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function import(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0069mport(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function super(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0073uper(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function implements(){}})();
+(function(){function \u0069mplements(){}})();
 (function(){function interface(){}})();
+(function(){function \u0069nterface(){}})();
 (function(){function let(){}})();
+(function(){function \u006cet(){}})();
 (function(){function package(){}})();
+(function(){function \u0070ackage(){}})();
 (function(){function private(){}})();
+(function(){function \u0070rivate(){}})();
 (function(){function protected(){}})();
+(function(){function \u0070rotected(){}})();
 (function(){function public(){}})();
+(function(){function \u0070ublic(){}})();
 (function(){function static(){}})();
+(function(){function \u0073tatic(){}})();
 (function(){function yield(){}})();
+(function(){function \u0079ield(){}})();
 (function(){function foo(){}})();
+(function(){function \u0066oo(){}})();
 (function(){function <(){}})();
 SyntaxError: Expected identifier
+(function(){function \u003c(){}})();
+SyntaxError: Invalid character
 (function(){(function break(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0062reak(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function case(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0063ase(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function catch(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0063atch(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function continue(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0063ontinue(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function debugger(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0064ebugger(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function default(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0064efault(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function delete(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0064elete(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function do(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0064o(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function else(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0065lse(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function finally(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0066inally(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function for(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0066or(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function function(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0066unction(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function if(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0069f(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function in(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0069n(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function instanceof(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0069nstanceof(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function new(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u006eew(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function return(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0072eturn(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function switch(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0073witch(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function this(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0074his(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function throw(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0074hrow(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function try(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0074ry(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function typeof(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0074ypeof(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function var(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0076ar(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function void(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0076oid(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function while(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0077hile(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function with(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0077ith(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function null(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u006eull(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function false(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0066alse(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function true(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0074rue(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function class(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0063lass(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function const(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0063onst(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function enum(){})})();
 SyntaxError: The use of a future reserved word for an identifier is invalid
+(function(){(function \u0065num(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function export(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0065xport(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function extends(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0065xtends(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function import(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0069mport(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function super(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0073uper(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function implements(){})})();
+(function(){(function \u0069mplements(){})})();
 (function(){(function interface(){})})();
+(function(){(function \u0069nterface(){})})();
 (function(){(function let(){})})();
+(function(){(function \u006cet(){})})();
 (function(){(function package(){})})();
+(function(){(function \u0070ackage(){})})();
 (function(){(function private(){})})();
+(function(){(function \u0070rivate(){})})();
 (function(){(function protected(){})})();
+(function(){(function \u0070rotected(){})})();
 (function(){(function public(){})})();
+(function(){(function \u0070ublic(){})})();
 (function(){(function static(){})})();
+(function(){(function \u0073tatic(){})})();
 (function(){(function yield(){})})();
+(function(){(function \u0079ield(){})})();
 (function(){(function foo(){})})();
+(function(){(function \u0066oo(){})})();
 (function(){(function <(){})})();
 SyntaxError: Expected '('
+(function(){(function \u003c(){})})();
+SyntaxError: Invalid character
 (function(){(function(break){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0062reak){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(case){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0063ase){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(catch){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0063atch){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(continue){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0063ontinue){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(debugger){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0064ebugger){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(default){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0064efault){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(delete){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0064elete){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(do){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0064o){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(else){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0065lse){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(finally){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0066inally){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(for){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0066or){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(function){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0066unction){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(if){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0069f){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(in){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0069n){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(instanceof){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0069nstanceof){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(new){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u006eew){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(return){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0072eturn){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(switch){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0073witch){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(this){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0074his){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(throw){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0074hrow){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(try){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0074ry){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(typeof){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0074ypeof){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(var){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0076ar){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(void){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0076oid){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(while){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0077hile){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(with){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0077ith){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(null){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u006eull){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(false){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0066alse){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(true){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0074rue){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(class){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0063lass){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(const){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0063onst){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(enum){});})();
 SyntaxError: The use of a future reserved word for an identifier is invalid
+(function(){(function(\u0065num){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(export){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0065xport){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(extends){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0065xtends){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(import){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0069mport){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(super){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0073uper){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(implements){});})();
+(function(){(function(\u0069mplements){});})();
 (function(){(function(interface){});})();
+(function(){(function(\u0069nterface){});})();
 (function(){(function(let){});})();
+(function(){(function(\u006cet){});})();
 (function(){(function(package){});})();
+(function(){(function(\u0070ackage){});})();
 (function(){(function(private){});})();
+(function(){(function(\u0070rivate){});})();
 (function(){(function(protected){});})();
+(function(){(function(\u0070rotected){});})();
 (function(){(function(public){});})();
+(function(){(function(\u0070ublic){});})();
 (function(){(function(static){});})();
+(function(){(function(\u0073tatic){});})();
 (function(){(function(yield){});})();
+(function(){(function(\u0079ield){});})();
 (function(){(function(foo){});})();
+(function(){(function(\u0066oo){});})();
 (function(){(function(<){});})();
 SyntaxError: Expected identifier
+(function(){(function(\u003c){});})();
+SyntaxError: Invalid character
 (function(){try{} catch(break){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0062reak){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(case){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0063ase){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(catch){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0063atch){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(continue){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0063ontinue){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(debugger){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0064ebugger){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(default){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0064efault){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(delete){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0064elete){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(do){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0064o){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(else){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0065lse){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(finally){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0066inally){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(for){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0066or){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(function){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0066unction){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(if){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0069f){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(in){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0069n){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(instanceof){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0069nstanceof){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(new){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u006eew){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(return){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0072eturn){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(switch){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0073witch){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(this){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0074his){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(throw){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0074hrow){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(try){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0074ry){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(typeof){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0074ypeof){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(var){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0076ar){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(void){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0076oid){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(while){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0077hile){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(with){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0077ith){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(null){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u006eull){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(false){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0066alse){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(true){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0074rue){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(class){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0063lass){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(const){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0063onst){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(enum){}})();
 SyntaxError: The use of a future reserved word for an identifier is invalid
+(function(){try{} catch(\u0065num){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(export){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0065xport){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(extends){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0065xtends){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(import){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0069mport){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(super){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0073uper){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(implements){}})();
+(function(){try{} catch(\u0069mplements){}})();
 (function(){try{} catch(interface){}})();
+(function(){try{} catch(\u0069nterface){}})();
 (function(){try{} catch(let){}})();
+(function(){try{} catch(\u006cet){}})();
 (function(){try{} catch(package){}})();
+(function(){try{} catch(\u0070ackage){}})();
 (function(){try{} catch(private){}})();
+(function(){try{} catch(\u0070rivate){}})();
 (function(){try{} catch(protected){}})();
+(function(){try{} catch(\u0070rotected){}})();
 (function(){try{} catch(public){}})();
+(function(){try{} catch(\u0070ublic){}})();
 (function(){try{} catch(static){}})();
+(function(){try{} catch(\u0073tatic){}})();
 (function(){try{} catch(yield){}})();
+(function(){try{} catch(\u0079ield){}})();
 (function(){try{} catch(foo){}})();
+(function(){try{} catch(\u0066oo){}})();
 (function(){try{} catch(<){}})();
 SyntaxError: Expected identifier
+(function(){try{} catch(\u003c){}})();
+SyntaxError: Invalid character
 (function(){({break: 0});})();
+(function(){({\u0062reak: 0});})();
 (function(){({case: 0});})();
+(function(){({\u0063ase: 0});})();
 (function(){({catch: 0});})();
+(function(){({\u0063atch: 0});})();
 (function(){({continue: 0});})();
+(function(){({\u0063ontinue: 0});})();
 (function(){({debugger: 0});})();
+(function(){({\u0064ebugger: 0});})();
 (function(){({default: 0});})();
+(function(){({\u0064efault: 0});})();
 (function(){({delete: 0});})();
+(function(){({\u0064elete: 0});})();
 (function(){({do: 0});})();
+(function(){({\u0064o: 0});})();
 (function(){({else: 0});})();
+(function(){({\u0065lse: 0});})();
 (function(){({finally: 0});})();
+(function(){({\u0066inally: 0});})();
 (function(){({for: 0});})();
+(function(){({\u0066or: 0});})();
 (function(){({function: 0});})();
+(function(){({\u0066unction: 0});})();
 (function(){({if: 0});})();
+(function(){({\u0069f: 0});})();
 (function(){({in: 0});})();
+(function(){({\u0069n: 0});})();
 (function(){({instanceof: 0});})();
+(function(){({\u0069nstanceof: 0});})();
 (function(){({new: 0});})();
+(function(){({\u006eew: 0});})();
 (function(){({return: 0});})();
+(function(){({\u0072eturn: 0});})();
 (function(){({switch: 0});})();
+(function(){({\u0073witch: 0});})();
 (function(){({this: 0});})();
+(function(){({\u0074his: 0});})();
 (function(){({throw: 0});})();
+(function(){({\u0074hrow: 0});})();
 (function(){({try: 0});})();
+(function(){({\u0074ry: 0});})();
 (function(){({typeof: 0});})();
+(function(){({\u0074ypeof: 0});})();
 (function(){({var: 0});})();
+(function(){({\u0076ar: 0});})();
 (function(){({void: 0});})();
+(function(){({\u0076oid: 0});})();
 (function(){({while: 0});})();
+(function(){({\u0077hile: 0});})();
 (function(){({with: 0});})();
+(function(){({\u0077ith: 0});})();
 (function(){({null: 0});})();
+(function(){({\u006eull: 0});})();
 (function(){({false: 0});})();
+(function(){({\u0066alse: 0});})();
 (function(){({true: 0});})();
+(function(){({\u0074rue: 0});})();
 (function(){({class: 0});})();
+(function(){({\u0063lass: 0});})();
 (function(){({const: 0});})();
+(function(){({\u0063onst: 0});})();
 (function(){({enum: 0});})();
+(function(){({\u0065num: 0});})();
 (function(){({export: 0});})();
+(function(){({\u0065xport: 0});})();
 (function(){({extends: 0});})();
+(function(){({\u0065xtends: 0});})();
 (function(){({import: 0});})();
+(function(){({\u0069mport: 0});})();
 (function(){({super: 0});})();
+(function(){({\u0073uper: 0});})();
 (function(){({implements: 0});})();
+(function(){({\u0069mplements: 0});})();
 (function(){({interface: 0});})();
+(function(){({\u0069nterface: 0});})();
 (function(){({let: 0});})();
+(function(){({\u006cet: 0});})();
 (function(){({package: 0});})();
+(function(){({\u0070ackage: 0});})();
 (function(){({private: 0});})();
+(function(){({\u0070rivate: 0});})();
 (function(){({protected: 0});})();
+(function(){({\u0070rotected: 0});})();
 (function(){({public: 0});})();
+(function(){({\u0070ublic: 0});})();
 (function(){({static: 0});})();
+(function(){({\u0073tatic: 0});})();
 (function(){({yield: 0});})();
+(function(){({\u0079ield: 0});})();
 (function(){({foo: 0});})();
+(function(){({\u0066oo: 0});})();
 (function(){({<: 0});})();
 SyntaxError: Expected identifier, string or number
+(function(){({\u003c: 0});})();
+SyntaxError: Invalid character
 (function(){var o = {}; o.break = 0;})();
+(function(){var o = {}; o.\u0062reak = 0;})();
 (function(){var o = {}; o.case = 0;})();
+(function(){var o = {}; o.\u0063ase = 0;})();
 (function(){var o = {}; o.catch = 0;})();
+(function(){var o = {}; o.\u0063atch = 0;})();
 (function(){var o = {}; o.continue = 0;})();
+(function(){var o = {}; o.\u0063ontinue = 0;})();
 (function(){var o = {}; o.debugger = 0;})();
+(function(){var o = {}; o.\u0064ebugger = 0;})();
 (function(){var o = {}; o.default = 0;})();
+(function(){var o = {}; o.\u0064efault = 0;})();
 (function(){var o = {}; o.delete = 0;})();
+(function(){var o = {}; o.\u0064elete = 0;})();
 (function(){var o = {}; o.do = 0;})();
+(function(){var o = {}; o.\u0064o = 0;})();
 (function(){var o = {}; o.else = 0;})();
+(function(){var o = {}; o.\u0065lse = 0;})();
 (function(){var o = {}; o.finally = 0;})();
+(function(){var o = {}; o.\u0066inally = 0;})();
 (function(){var o = {}; o.for = 0;})();
+(function(){var o = {}; o.\u0066or = 0;})();
 (function(){var o = {}; o.function = 0;})();
+(function(){var o = {}; o.\u0066unction = 0;})();
 (function(){var o = {}; o.if = 0;})();
+(function(){var o = {}; o.\u0069f = 0;})();
 (function(){var o = {}; o.in = 0;})();
+(function(){var o = {}; o.\u0069n = 0;})();
 (function(){var o = {}; o.instanceof = 0;})();
+(function(){var o = {}; o.\u0069nstanceof = 0;})();
 (function(){var o = {}; o.new = 0;})();
+(function(){var o = {}; o.\u006eew = 0;})();
 (function(){var o = {}; o.return = 0;})();
+(function(){var o = {}; o.\u0072eturn = 0;})();
 (function(){var o = {}; o.switch = 0;})();
+(function(){var o = {}; o.\u0073witch = 0;})();
 (function(){var o = {}; o.this = 0;})();
+(function(){var o = {}; o.\u0074his = 0;})();
 (function(){var o = {}; o.throw = 0;})();
+(function(){var o = {}; o.\u0074hrow = 0;})();
 (function(){var o = {}; o.try = 0;})();
+(function(){var o = {}; o.\u0074ry = 0;})();
 (function(){var o = {}; o.typeof = 0;})();
+(function(){var o = {}; o.\u0074ypeof = 0;})();
 (function(){var o = {}; o.var = 0;})();
+(function(){var o = {}; o.\u0076ar = 0;})();
 (function(){var o = {}; o.void = 0;})();
+(function(){var o = {}; o.\u0076oid = 0;})();
 (function(){var o = {}; o.while = 0;})();
+(function(){var o = {}; o.\u0077hile = 0;})();
 (function(){var o = {}; o.with = 0;})();
+(function(){var o = {}; o.\u0077ith = 0;})();
 (function(){var o = {}; o.null = 0;})();
+(function(){var o = {}; o.\u006eull = 0;})();
 (function(){var o = {}; o.false = 0;})();
+(function(){var o = {}; o.\u0066alse = 0;})();
 (function(){var o = {}; o.true = 0;})();
+(function(){var o = {}; o.\u0074rue = 0;})();
 (function(){var o = {}; o.class = 0;})();
+(function(){var o = {}; o.\u0063lass = 0;})();
 (function(){var o = {}; o.const = 0;})();
+(function(){var o = {}; o.\u0063onst = 0;})();
 (function(){var o = {}; o.enum = 0;})();
+(function(){var o = {}; o.\u0065num = 0;})();
 (function(){var o = {}; o.export = 0;})();
+(function(){var o = {}; o.\u0065xport = 0;})();
 (function(){var o = {}; o.extends = 0;})();
+(function(){var o = {}; o.\u0065xtends = 0;})();
 (function(){var o = {}; o.import = 0;})();
+(function(){var o = {}; o.\u0069mport = 0;})();
 (function(){var o = {}; o.super = 0;})();
+(function(){var o = {}; o.\u0073uper = 0;})();
 (function(){var o = {}; o.implements = 0;})();
+(function(){var o = {}; o.\u0069mplements = 0;})();
 (function(){var o = {}; o.interface = 0;})();
+(function(){var o = {}; o.\u0069nterface = 0;})();
 (function(){var o = {}; o.let = 0;})();
+(function(){var o = {}; o.\u006cet = 0;})();
 (function(){var o = {}; o.package = 0;})();
+(function(){var o = {}; o.\u0070ackage = 0;})();
 (function(){var o = {}; o.private = 0;})();
+(function(){var o = {}; o.\u0070rivate = 0;})();
 (function(){var o = {}; o.protected = 0;})();
+(function(){var o = {}; o.\u0070rotected = 0;})();
 (function(){var o = {}; o.public = 0;})();
+(function(){var o = {}; o.\u0070ublic = 0;})();
 (function(){var o = {}; o.static = 0;})();
+(function(){var o = {}; o.\u0073tatic = 0;})();
 (function(){var o = {}; o.yield = 0;})();
+(function(){var o = {}; o.\u0079ield = 0;})();
 (function(){var o = {}; o.foo = 0;})();
+(function(){var o = {}; o.\u0066oo = 0;})();
 (function(){var o = {}; o.< = 0;})();
 SyntaxError: Expected identifier
+(function(){var o = {}; o.\u003c = 0;})();
+SyntaxError: Invalid character
 (function(){var o = {}; o["break"] = 0;})();
+(function(){var o = {}; o["\u0062reak"] = 0;})();
 (function(){var o = {}; o["case"] = 0;})();
+(function(){var o = {}; o["\u0063ase"] = 0;})();
 (function(){var o = {}; o["catch"] = 0;})();
+(function(){var o = {}; o["\u0063atch"] = 0;})();
 (function(){var o = {}; o["continue"] = 0;})();
+(function(){var o = {}; o["\u0063ontinue"] = 0;})();
 (function(){var o = {}; o["debugger"] = 0;})();
+(function(){var o = {}; o["\u0064ebugger"] = 0;})();
 (function(){var o = {}; o["default"] = 0;})();
+(function(){var o = {}; o["\u0064efault"] = 0;})();
 (function(){var o = {}; o["delete"] = 0;})();
+(function(){var o = {}; o["\u0064elete"] = 0;})();
 (function(){var o = {}; o["do"] = 0;})();
+(function(){var o = {}; o["\u0064o"] = 0;})();
 (function(){var o = {}; o["else"] = 0;})();
+(function(){var o = {}; o["\u0065lse"] = 0;})();
 (function(){var o = {}; o["finally"] = 0;})();
+(function(){var o = {}; o["\u0066inally"] = 0;})();
 (function(){var o = {}; o["for"] = 0;})();
+(function(){var o = {}; o["\u0066or"] = 0;})();
 (function(){var o = {}; o["function"] = 0;})();
+(function(){var o = {}; o["\u0066unction"] = 0;})();
 (function(){var o = {}; o["if"] = 0;})();
+(function(){var o = {}; o["\u0069f"] = 0;})();
 (function(){var o = {}; o["in"] = 0;})();
+(function(){var o = {}; o["\u0069n"] = 0;})();
 (function(){var o = {}; o["instanceof"] = 0;})();
+(function(){var o = {}; o["\u0069nstanceof"] = 0;})();
 (function(){var o = {}; o["new"] = 0;})();
+(function(){var o = {}; o["\u006eew"] = 0;})();
 (function(){var o = {}; o["return"] = 0;})();
+(function(){var o = {}; o["\u0072eturn"] = 0;})();
 (function(){var o = {}; o["switch"] = 0;})();
+(function(){var o = {}; o["\u0073witch"] = 0;})();
 (function(){var o = {}; o["this"] = 0;})();
+(function(){var o = {}; o["\u0074his"] = 0;})();
 (function(){var o = {}; o["throw"] = 0;})();
+(function(){var o = {}; o["\u0074hrow"] = 0;})();
 (function(){var o = {}; o["try"] = 0;})();
+(function(){var o = {}; o["\u0074ry"] = 0;})();
 (function(){var o = {}; o["typeof"] = 0;})();
+(function(){var o = {}; o["\u0074ypeof"] = 0;})();
 (function(){var o = {}; o["var"] = 0;})();
+(function(){var o = {}; o["\u0076ar"] = 0;})();
 (function(){var o = {}; o["void"] = 0;})();
+(function(){var o = {}; o["\u0076oid"] = 0;})();
 (function(){var o = {}; o["while"] = 0;})();
+(function(){var o = {}; o["\u0077hile"] = 0;})();
 (function(){var o = {}; o["with"] = 0;})();
+(function(){var o = {}; o["\u0077ith"] = 0;})();
 (function(){var o = {}; o["null"] = 0;})();
+(function(){var o = {}; o["\u006eull"] = 0;})();
 (function(){var o = {}; o["false"] = 0;})();
+(function(){var o = {}; o["\u0066alse"] = 0;})();
 (function(){var o = {}; o["true"] = 0;})();
+(function(){var o = {}; o["\u0074rue"] = 0;})();
 (function(){var o = {}; o["class"] = 0;})();
+(function(){var o = {}; o["\u0063lass"] = 0;})();
 (function(){var o = {}; o["const"] = 0;})();
+(function(){var o = {}; o["\u0063onst"] = 0;})();
 (function(){var o = {}; o["enum"] = 0;})();
+(function(){var o = {}; o["\u0065num"] = 0;})();
 (function(){var o = {}; o["export"] = 0;})();
+(function(){var o = {}; o["\u0065xport"] = 0;})();
 (function(){var o = {}; o["extends"] = 0;})();
+(function(){var o = {}; o["\u0065xtends"] = 0;})();
 (function(){var o = {}; o["import"] = 0;})();
+(function(){var o = {}; o["\u0069mport"] = 0;})();
 (function(){var o = {}; o["super"] = 0;})();
+(function(){var o = {}; o["\u0073uper"] = 0;})();
 (function(){var o = {}; o["implements"] = 0;})();
+(function(){var o = {}; o["\u0069mplements"] = 0;})();
 (function(){var o = {}; o["interface"] = 0;})();
+(function(){var o = {}; o["\u0069nterface"] = 0;})();
 (function(){var o = {}; o["let"] = 0;})();
+(function(){var o = {}; o["\u006cet"] = 0;})();
 (function(){var o = {}; o["package"] = 0;})();
+(function(){var o = {}; o["\u0070ackage"] = 0;})();
 (function(){var o = {}; o["private"] = 0;})();
+(function(){var o = {}; o["\u0070rivate"] = 0;})();
 (function(){var o = {}; o["protected"] = 0;})();
+(function(){var o = {}; o["\u0070rotected"] = 0;})();
 (function(){var o = {}; o["public"] = 0;})();
+(function(){var o = {}; o["\u0070ublic"] = 0;})();
 (function(){var o = {}; o["static"] = 0;})();
+(function(){var o = {}; o["\u0073tatic"] = 0;})();
 (function(){var o = {}; o["yield"] = 0;})();
+(function(){var o = {}; o["\u0079ield"] = 0;})();
 (function(){var o = {}; o["foo"] = 0;})();
+(function(){var o = {}; o["\u0066oo"] = 0;})();
 (function(){var o = {}; o["<"] = 0;})();
+(function(){var o = {}; o["\u003c"] = 0;})();

--- a/test/strict/23.reservedWords.js
+++ b/test/strict/23.reservedWords.js
@@ -84,6 +84,19 @@ var wordUsage = {
     propertyNameInElementNotation: 7
 };
 
+function leftPadZero(str, len)
+{
+    var pad = len - str.length;
+    for (var i = 0; i < pad; i++) {
+        str = "0" + str;
+    }
+    return str;
+}
+function escapeFirstChar(word)
+{
+    return "\\u" + leftPadZero(word.charCodeAt(0).toString(16), 4) + word.substring(1);
+}
+
 function generateAndRunTest(word, usage) {
     var f = "(function(){";
     if(usage === wordUsage.varDeclaration)
@@ -119,6 +132,7 @@ for(var wordUsagePropertyName in wordUsage) {
         for(var wordSetPropertyName in wordSet) {
             var word = wordSet[wordSetPropertyName];
             generateAndRunTest(word, usage);
+            generateAndRunTest(escapeFirstChar(word), usage);
         }
     }
 }

--- a/test/strict/23.reservedWords_sm.baseline
+++ b/test/strict/23.reservedWords_sm.baseline
@@ -1,608 +1,1216 @@
 (function(){var break;})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0062reak;})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var case;})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0063ase;})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var catch;})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0063atch;})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var continue;})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0063ontinue;})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var debugger;})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0064ebugger;})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var default;})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0064efault;})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var delete;})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0064elete;})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var do;})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0064o;})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var else;})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0065lse;})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var finally;})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0066inally;})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var for;})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0066or;})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var function;})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0066unction;})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var if;})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0069f;})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var in;})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0069n;})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var instanceof;})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0069nstanceof;})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var new;})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u006eew;})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var return;})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0072eturn;})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var switch;})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0073witch;})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var this;})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0074his;})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var throw;})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0074hrow;})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var try;})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0074ry;})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var typeof;})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0074ypeof;})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var var;})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0076ar;})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var void;})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0076oid;})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var while;})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0077hile;})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var with;})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0077ith;})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var null;})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u006eull;})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var false;})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0066alse;})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var true;})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0074rue;})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var class;})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0063lass;})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var const;})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0063onst;})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var enum;})();
 SyntaxError: The use of a future reserved word for an identifier is invalid
+(function(){var \u0065num;})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var export;})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0065xport;})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var extends;})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0065xtends;})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var import;})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0069mport;})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var super;})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0073uper;})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var implements;})();
 SyntaxError: The use of a future reserved word for an identifier is invalid. The identifier name is reserved in strict mode.
+(function(){var \u0069mplements;})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var interface;})();
 SyntaxError: The use of a future reserved word for an identifier is invalid. The identifier name is reserved in strict mode.
+(function(){var \u0069nterface;})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var let;})();
 SyntaxError: The use of a future reserved word for an identifier is invalid. The identifier name is reserved in strict mode.
+(function(){var \u006cet;})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var package;})();
 SyntaxError: The use of a future reserved word for an identifier is invalid. The identifier name is reserved in strict mode.
+(function(){var \u0070ackage;})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var private;})();
 SyntaxError: The use of a future reserved word for an identifier is invalid. The identifier name is reserved in strict mode.
+(function(){var \u0070rivate;})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var protected;})();
 SyntaxError: The use of a future reserved word for an identifier is invalid. The identifier name is reserved in strict mode.
+(function(){var \u0070rotected;})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var public;})();
 SyntaxError: The use of a future reserved word for an identifier is invalid. The identifier name is reserved in strict mode.
+(function(){var \u0070ublic;})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var static;})();
 SyntaxError: The use of a future reserved word for an identifier is invalid. The identifier name is reserved in strict mode.
+(function(){var \u0073tatic;})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var yield;})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){var \u0079ield;})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){var foo;})();
+(function(){var \u0066oo;})();
 (function(){var <;})();
 SyntaxError: Expected identifier
+(function(){var \u003c;})();
+SyntaxError: Invalid character
 (function(){function break(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0062reak(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function case(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0063ase(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function catch(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0063atch(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function continue(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0063ontinue(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function debugger(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0064ebugger(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function default(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0064efault(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function delete(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0064elete(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function do(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0064o(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function else(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0065lse(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function finally(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0066inally(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function for(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0066or(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function function(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0066unction(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function if(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0069f(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function in(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0069n(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function instanceof(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0069nstanceof(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function new(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u006eew(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function return(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0072eturn(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function switch(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0073witch(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function this(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0074his(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function throw(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0074hrow(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function try(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0074ry(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function typeof(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0074ypeof(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function var(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0076ar(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function void(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0076oid(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function while(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0077hile(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function with(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0077ith(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function null(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u006eull(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function false(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0066alse(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function true(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0074rue(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function class(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0063lass(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function const(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0063onst(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function enum(){}})();
 SyntaxError: The use of a future reserved word for an identifier is invalid
+(function(){function \u0065num(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function export(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0065xport(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function extends(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0065xtends(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function import(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0069mport(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function super(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0073uper(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function implements(){}})();
 SyntaxError: The use of a future reserved word for an identifier is invalid. The identifier name is reserved in strict mode.
+(function(){function \u0069mplements(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function interface(){}})();
 SyntaxError: The use of a future reserved word for an identifier is invalid. The identifier name is reserved in strict mode.
+(function(){function \u0069nterface(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function let(){}})();
 SyntaxError: The use of a future reserved word for an identifier is invalid. The identifier name is reserved in strict mode.
+(function(){function \u006cet(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function package(){}})();
 SyntaxError: The use of a future reserved word for an identifier is invalid. The identifier name is reserved in strict mode.
+(function(){function \u0070ackage(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function private(){}})();
 SyntaxError: The use of a future reserved word for an identifier is invalid. The identifier name is reserved in strict mode.
+(function(){function \u0070rivate(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function protected(){}})();
 SyntaxError: The use of a future reserved word for an identifier is invalid. The identifier name is reserved in strict mode.
+(function(){function \u0070rotected(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function public(){}})();
 SyntaxError: The use of a future reserved word for an identifier is invalid. The identifier name is reserved in strict mode.
+(function(){function \u0070ublic(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function static(){}})();
 SyntaxError: The use of a future reserved word for an identifier is invalid. The identifier name is reserved in strict mode.
+(function(){function \u0073tatic(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function yield(){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){function \u0079ield(){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){function foo(){}})();
+(function(){function \u0066oo(){}})();
 (function(){function <(){}})();
 SyntaxError: Expected identifier
+(function(){function \u003c(){}})();
+SyntaxError: Invalid character
 (function(){(function break(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0062reak(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function case(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0063ase(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function catch(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0063atch(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function continue(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0063ontinue(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function debugger(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0064ebugger(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function default(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0064efault(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function delete(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0064elete(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function do(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0064o(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function else(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0065lse(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function finally(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0066inally(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function for(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0066or(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function function(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0066unction(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function if(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0069f(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function in(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0069n(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function instanceof(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0069nstanceof(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function new(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u006eew(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function return(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0072eturn(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function switch(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0073witch(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function this(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0074his(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function throw(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0074hrow(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function try(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0074ry(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function typeof(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0074ypeof(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function var(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0076ar(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function void(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0076oid(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function while(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0077hile(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function with(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0077ith(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function null(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u006eull(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function false(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0066alse(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function true(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0074rue(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function class(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0063lass(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function const(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0063onst(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function enum(){})})();
 SyntaxError: The use of a future reserved word for an identifier is invalid
+(function(){(function \u0065num(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function export(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0065xport(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function extends(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0065xtends(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function import(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0069mport(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function super(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0073uper(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function implements(){})})();
 SyntaxError: The use of a future reserved word for an identifier is invalid. The identifier name is reserved in strict mode.
+(function(){(function \u0069mplements(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function interface(){})})();
 SyntaxError: The use of a future reserved word for an identifier is invalid. The identifier name is reserved in strict mode.
+(function(){(function \u0069nterface(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function let(){})})();
 SyntaxError: The use of a future reserved word for an identifier is invalid. The identifier name is reserved in strict mode.
+(function(){(function \u006cet(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function package(){})})();
 SyntaxError: The use of a future reserved word for an identifier is invalid. The identifier name is reserved in strict mode.
+(function(){(function \u0070ackage(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function private(){})})();
 SyntaxError: The use of a future reserved word for an identifier is invalid. The identifier name is reserved in strict mode.
+(function(){(function \u0070rivate(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function protected(){})})();
 SyntaxError: The use of a future reserved word for an identifier is invalid. The identifier name is reserved in strict mode.
+(function(){(function \u0070rotected(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function public(){})})();
 SyntaxError: The use of a future reserved word for an identifier is invalid. The identifier name is reserved in strict mode.
+(function(){(function \u0070ublic(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function static(){})})();
 SyntaxError: The use of a future reserved word for an identifier is invalid. The identifier name is reserved in strict mode.
+(function(){(function \u0073tatic(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function yield(){})})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function \u0079ield(){})})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function foo(){})})();
+(function(){(function \u0066oo(){})})();
 (function(){(function <(){})})();
 SyntaxError: Expected '('
+(function(){(function \u003c(){})})();
+SyntaxError: Invalid character
 (function(){(function(break){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0062reak){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(case){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0063ase){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(catch){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0063atch){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(continue){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0063ontinue){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(debugger){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0064ebugger){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(default){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0064efault){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(delete){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0064elete){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(do){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0064o){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(else){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0065lse){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(finally){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0066inally){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(for){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0066or){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(function){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0066unction){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(if){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0069f){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(in){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0069n){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(instanceof){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0069nstanceof){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(new){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u006eew){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(return){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0072eturn){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(switch){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0073witch){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(this){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0074his){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(throw){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0074hrow){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(try){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0074ry){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(typeof){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0074ypeof){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(var){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0076ar){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(void){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0076oid){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(while){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0077hile){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(with){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0077ith){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(null){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u006eull){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(false){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0066alse){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(true){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0074rue){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(class){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0063lass){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(const){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0063onst){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(enum){});})();
 SyntaxError: The use of a future reserved word for an identifier is invalid
+(function(){(function(\u0065num){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(export){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0065xport){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(extends){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0065xtends){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(import){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0069mport){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(super){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0073uper){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(implements){});})();
 SyntaxError: The use of a future reserved word for an identifier is invalid. The identifier name is reserved in strict mode.
+(function(){(function(\u0069mplements){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(interface){});})();
 SyntaxError: The use of a future reserved word for an identifier is invalid. The identifier name is reserved in strict mode.
+(function(){(function(\u0069nterface){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(let){});})();
 SyntaxError: The use of a future reserved word for an identifier is invalid. The identifier name is reserved in strict mode.
+(function(){(function(\u006cet){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(package){});})();
 SyntaxError: The use of a future reserved word for an identifier is invalid. The identifier name is reserved in strict mode.
+(function(){(function(\u0070ackage){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(private){});})();
 SyntaxError: The use of a future reserved word for an identifier is invalid. The identifier name is reserved in strict mode.
+(function(){(function(\u0070rivate){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(protected){});})();
 SyntaxError: The use of a future reserved word for an identifier is invalid. The identifier name is reserved in strict mode.
+(function(){(function(\u0070rotected){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(public){});})();
 SyntaxError: The use of a future reserved word for an identifier is invalid. The identifier name is reserved in strict mode.
+(function(){(function(\u0070ublic){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(static){});})();
 SyntaxError: The use of a future reserved word for an identifier is invalid. The identifier name is reserved in strict mode.
+(function(){(function(\u0073tatic){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(yield){});})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){(function(\u0079ield){});})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){(function(foo){});})();
+(function(){(function(\u0066oo){});})();
 (function(){(function(<){});})();
 SyntaxError: Expected identifier
+(function(){(function(\u003c){});})();
+SyntaxError: Invalid character
 (function(){try{} catch(break){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0062reak){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(case){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0063ase){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(catch){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0063atch){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(continue){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0063ontinue){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(debugger){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0064ebugger){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(default){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0064efault){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(delete){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0064elete){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(do){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0064o){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(else){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0065lse){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(finally){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0066inally){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(for){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0066or){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(function){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0066unction){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(if){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0069f){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(in){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0069n){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(instanceof){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0069nstanceof){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(new){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u006eew){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(return){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0072eturn){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(switch){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0073witch){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(this){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0074his){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(throw){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0074hrow){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(try){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0074ry){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(typeof){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0074ypeof){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(var){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0076ar){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(void){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0076oid){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(while){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0077hile){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(with){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0077ith){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(null){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u006eull){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(false){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0066alse){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(true){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0074rue){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(class){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0063lass){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(const){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0063onst){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(enum){}})();
 SyntaxError: The use of a future reserved word for an identifier is invalid
+(function(){try{} catch(\u0065num){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(export){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0065xport){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(extends){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0065xtends){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(import){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0069mport){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(super){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0073uper){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(implements){}})();
 SyntaxError: The use of a future reserved word for an identifier is invalid. The identifier name is reserved in strict mode.
+(function(){try{} catch(\u0069mplements){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(interface){}})();
 SyntaxError: The use of a future reserved word for an identifier is invalid. The identifier name is reserved in strict mode.
+(function(){try{} catch(\u0069nterface){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(let){}})();
 SyntaxError: The use of a future reserved word for an identifier is invalid. The identifier name is reserved in strict mode.
+(function(){try{} catch(\u006cet){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(package){}})();
 SyntaxError: The use of a future reserved word for an identifier is invalid. The identifier name is reserved in strict mode.
+(function(){try{} catch(\u0070ackage){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(private){}})();
 SyntaxError: The use of a future reserved word for an identifier is invalid. The identifier name is reserved in strict mode.
+(function(){try{} catch(\u0070rivate){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(protected){}})();
 SyntaxError: The use of a future reserved word for an identifier is invalid. The identifier name is reserved in strict mode.
+(function(){try{} catch(\u0070rotected){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(public){}})();
 SyntaxError: The use of a future reserved word for an identifier is invalid. The identifier name is reserved in strict mode.
+(function(){try{} catch(\u0070ublic){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(static){}})();
 SyntaxError: The use of a future reserved word for an identifier is invalid. The identifier name is reserved in strict mode.
+(function(){try{} catch(\u0073tatic){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(yield){}})();
 SyntaxError: The use of a keyword for an identifier is invalid
+(function(){try{} catch(\u0079ield){}})();
+SyntaxError: The use of a keyword for an identifier is invalid
 (function(){try{} catch(foo){}})();
+(function(){try{} catch(\u0066oo){}})();
 (function(){try{} catch(<){}})();
 SyntaxError: Expected identifier
+(function(){try{} catch(\u003c){}})();
+SyntaxError: Invalid character
 (function(){({break: 0});})();
+(function(){({\u0062reak: 0});})();
 (function(){({case: 0});})();
+(function(){({\u0063ase: 0});})();
 (function(){({catch: 0});})();
+(function(){({\u0063atch: 0});})();
 (function(){({continue: 0});})();
+(function(){({\u0063ontinue: 0});})();
 (function(){({debugger: 0});})();
+(function(){({\u0064ebugger: 0});})();
 (function(){({default: 0});})();
+(function(){({\u0064efault: 0});})();
 (function(){({delete: 0});})();
+(function(){({\u0064elete: 0});})();
 (function(){({do: 0});})();
+(function(){({\u0064o: 0});})();
 (function(){({else: 0});})();
+(function(){({\u0065lse: 0});})();
 (function(){({finally: 0});})();
+(function(){({\u0066inally: 0});})();
 (function(){({for: 0});})();
+(function(){({\u0066or: 0});})();
 (function(){({function: 0});})();
+(function(){({\u0066unction: 0});})();
 (function(){({if: 0});})();
+(function(){({\u0069f: 0});})();
 (function(){({in: 0});})();
+(function(){({\u0069n: 0});})();
 (function(){({instanceof: 0});})();
+(function(){({\u0069nstanceof: 0});})();
 (function(){({new: 0});})();
+(function(){({\u006eew: 0});})();
 (function(){({return: 0});})();
+(function(){({\u0072eturn: 0});})();
 (function(){({switch: 0});})();
+(function(){({\u0073witch: 0});})();
 (function(){({this: 0});})();
+(function(){({\u0074his: 0});})();
 (function(){({throw: 0});})();
+(function(){({\u0074hrow: 0});})();
 (function(){({try: 0});})();
+(function(){({\u0074ry: 0});})();
 (function(){({typeof: 0});})();
+(function(){({\u0074ypeof: 0});})();
 (function(){({var: 0});})();
+(function(){({\u0076ar: 0});})();
 (function(){({void: 0});})();
+(function(){({\u0076oid: 0});})();
 (function(){({while: 0});})();
+(function(){({\u0077hile: 0});})();
 (function(){({with: 0});})();
+(function(){({\u0077ith: 0});})();
 (function(){({null: 0});})();
+(function(){({\u006eull: 0});})();
 (function(){({false: 0});})();
+(function(){({\u0066alse: 0});})();
 (function(){({true: 0});})();
+(function(){({\u0074rue: 0});})();
 (function(){({class: 0});})();
+(function(){({\u0063lass: 0});})();
 (function(){({const: 0});})();
+(function(){({\u0063onst: 0});})();
 (function(){({enum: 0});})();
+(function(){({\u0065num: 0});})();
 (function(){({export: 0});})();
+(function(){({\u0065xport: 0});})();
 (function(){({extends: 0});})();
+(function(){({\u0065xtends: 0});})();
 (function(){({import: 0});})();
+(function(){({\u0069mport: 0});})();
 (function(){({super: 0});})();
+(function(){({\u0073uper: 0});})();
 (function(){({implements: 0});})();
+(function(){({\u0069mplements: 0});})();
 (function(){({interface: 0});})();
+(function(){({\u0069nterface: 0});})();
 (function(){({let: 0});})();
+(function(){({\u006cet: 0});})();
 (function(){({package: 0});})();
+(function(){({\u0070ackage: 0});})();
 (function(){({private: 0});})();
+(function(){({\u0070rivate: 0});})();
 (function(){({protected: 0});})();
+(function(){({\u0070rotected: 0});})();
 (function(){({public: 0});})();
+(function(){({\u0070ublic: 0});})();
 (function(){({static: 0});})();
+(function(){({\u0073tatic: 0});})();
 (function(){({yield: 0});})();
+(function(){({\u0079ield: 0});})();
 (function(){({foo: 0});})();
+(function(){({\u0066oo: 0});})();
 (function(){({<: 0});})();
 SyntaxError: Expected identifier, string or number
+(function(){({\u003c: 0});})();
+SyntaxError: Invalid character
 (function(){var o = {}; o.break = 0;})();
+(function(){var o = {}; o.\u0062reak = 0;})();
 (function(){var o = {}; o.case = 0;})();
+(function(){var o = {}; o.\u0063ase = 0;})();
 (function(){var o = {}; o.catch = 0;})();
+(function(){var o = {}; o.\u0063atch = 0;})();
 (function(){var o = {}; o.continue = 0;})();
+(function(){var o = {}; o.\u0063ontinue = 0;})();
 (function(){var o = {}; o.debugger = 0;})();
+(function(){var o = {}; o.\u0064ebugger = 0;})();
 (function(){var o = {}; o.default = 0;})();
+(function(){var o = {}; o.\u0064efault = 0;})();
 (function(){var o = {}; o.delete = 0;})();
+(function(){var o = {}; o.\u0064elete = 0;})();
 (function(){var o = {}; o.do = 0;})();
+(function(){var o = {}; o.\u0064o = 0;})();
 (function(){var o = {}; o.else = 0;})();
+(function(){var o = {}; o.\u0065lse = 0;})();
 (function(){var o = {}; o.finally = 0;})();
+(function(){var o = {}; o.\u0066inally = 0;})();
 (function(){var o = {}; o.for = 0;})();
+(function(){var o = {}; o.\u0066or = 0;})();
 (function(){var o = {}; o.function = 0;})();
+(function(){var o = {}; o.\u0066unction = 0;})();
 (function(){var o = {}; o.if = 0;})();
+(function(){var o = {}; o.\u0069f = 0;})();
 (function(){var o = {}; o.in = 0;})();
+(function(){var o = {}; o.\u0069n = 0;})();
 (function(){var o = {}; o.instanceof = 0;})();
+(function(){var o = {}; o.\u0069nstanceof = 0;})();
 (function(){var o = {}; o.new = 0;})();
+(function(){var o = {}; o.\u006eew = 0;})();
 (function(){var o = {}; o.return = 0;})();
+(function(){var o = {}; o.\u0072eturn = 0;})();
 (function(){var o = {}; o.switch = 0;})();
+(function(){var o = {}; o.\u0073witch = 0;})();
 (function(){var o = {}; o.this = 0;})();
+(function(){var o = {}; o.\u0074his = 0;})();
 (function(){var o = {}; o.throw = 0;})();
+(function(){var o = {}; o.\u0074hrow = 0;})();
 (function(){var o = {}; o.try = 0;})();
+(function(){var o = {}; o.\u0074ry = 0;})();
 (function(){var o = {}; o.typeof = 0;})();
+(function(){var o = {}; o.\u0074ypeof = 0;})();
 (function(){var o = {}; o.var = 0;})();
+(function(){var o = {}; o.\u0076ar = 0;})();
 (function(){var o = {}; o.void = 0;})();
+(function(){var o = {}; o.\u0076oid = 0;})();
 (function(){var o = {}; o.while = 0;})();
+(function(){var o = {}; o.\u0077hile = 0;})();
 (function(){var o = {}; o.with = 0;})();
+(function(){var o = {}; o.\u0077ith = 0;})();
 (function(){var o = {}; o.null = 0;})();
+(function(){var o = {}; o.\u006eull = 0;})();
 (function(){var o = {}; o.false = 0;})();
+(function(){var o = {}; o.\u0066alse = 0;})();
 (function(){var o = {}; o.true = 0;})();
+(function(){var o = {}; o.\u0074rue = 0;})();
 (function(){var o = {}; o.class = 0;})();
+(function(){var o = {}; o.\u0063lass = 0;})();
 (function(){var o = {}; o.const = 0;})();
+(function(){var o = {}; o.\u0063onst = 0;})();
 (function(){var o = {}; o.enum = 0;})();
+(function(){var o = {}; o.\u0065num = 0;})();
 (function(){var o = {}; o.export = 0;})();
+(function(){var o = {}; o.\u0065xport = 0;})();
 (function(){var o = {}; o.extends = 0;})();
+(function(){var o = {}; o.\u0065xtends = 0;})();
 (function(){var o = {}; o.import = 0;})();
+(function(){var o = {}; o.\u0069mport = 0;})();
 (function(){var o = {}; o.super = 0;})();
+(function(){var o = {}; o.\u0073uper = 0;})();
 (function(){var o = {}; o.implements = 0;})();
+(function(){var o = {}; o.\u0069mplements = 0;})();
 (function(){var o = {}; o.interface = 0;})();
+(function(){var o = {}; o.\u0069nterface = 0;})();
 (function(){var o = {}; o.let = 0;})();
+(function(){var o = {}; o.\u006cet = 0;})();
 (function(){var o = {}; o.package = 0;})();
+(function(){var o = {}; o.\u0070ackage = 0;})();
 (function(){var o = {}; o.private = 0;})();
+(function(){var o = {}; o.\u0070rivate = 0;})();
 (function(){var o = {}; o.protected = 0;})();
+(function(){var o = {}; o.\u0070rotected = 0;})();
 (function(){var o = {}; o.public = 0;})();
+(function(){var o = {}; o.\u0070ublic = 0;})();
 (function(){var o = {}; o.static = 0;})();
+(function(){var o = {}; o.\u0073tatic = 0;})();
 (function(){var o = {}; o.yield = 0;})();
+(function(){var o = {}; o.\u0079ield = 0;})();
 (function(){var o = {}; o.foo = 0;})();
+(function(){var o = {}; o.\u0066oo = 0;})();
 (function(){var o = {}; o.< = 0;})();
 SyntaxError: Expected identifier
+(function(){var o = {}; o.\u003c = 0;})();
+SyntaxError: Invalid character
 (function(){var o = {}; o["break"] = 0;})();
+(function(){var o = {}; o["\u0062reak"] = 0;})();
 (function(){var o = {}; o["case"] = 0;})();
+(function(){var o = {}; o["\u0063ase"] = 0;})();
 (function(){var o = {}; o["catch"] = 0;})();
+(function(){var o = {}; o["\u0063atch"] = 0;})();
 (function(){var o = {}; o["continue"] = 0;})();
+(function(){var o = {}; o["\u0063ontinue"] = 0;})();
 (function(){var o = {}; o["debugger"] = 0;})();
+(function(){var o = {}; o["\u0064ebugger"] = 0;})();
 (function(){var o = {}; o["default"] = 0;})();
+(function(){var o = {}; o["\u0064efault"] = 0;})();
 (function(){var o = {}; o["delete"] = 0;})();
+(function(){var o = {}; o["\u0064elete"] = 0;})();
 (function(){var o = {}; o["do"] = 0;})();
+(function(){var o = {}; o["\u0064o"] = 0;})();
 (function(){var o = {}; o["else"] = 0;})();
+(function(){var o = {}; o["\u0065lse"] = 0;})();
 (function(){var o = {}; o["finally"] = 0;})();
+(function(){var o = {}; o["\u0066inally"] = 0;})();
 (function(){var o = {}; o["for"] = 0;})();
+(function(){var o = {}; o["\u0066or"] = 0;})();
 (function(){var o = {}; o["function"] = 0;})();
+(function(){var o = {}; o["\u0066unction"] = 0;})();
 (function(){var o = {}; o["if"] = 0;})();
+(function(){var o = {}; o["\u0069f"] = 0;})();
 (function(){var o = {}; o["in"] = 0;})();
+(function(){var o = {}; o["\u0069n"] = 0;})();
 (function(){var o = {}; o["instanceof"] = 0;})();
+(function(){var o = {}; o["\u0069nstanceof"] = 0;})();
 (function(){var o = {}; o["new"] = 0;})();
+(function(){var o = {}; o["\u006eew"] = 0;})();
 (function(){var o = {}; o["return"] = 0;})();
+(function(){var o = {}; o["\u0072eturn"] = 0;})();
 (function(){var o = {}; o["switch"] = 0;})();
+(function(){var o = {}; o["\u0073witch"] = 0;})();
 (function(){var o = {}; o["this"] = 0;})();
+(function(){var o = {}; o["\u0074his"] = 0;})();
 (function(){var o = {}; o["throw"] = 0;})();
+(function(){var o = {}; o["\u0074hrow"] = 0;})();
 (function(){var o = {}; o["try"] = 0;})();
+(function(){var o = {}; o["\u0074ry"] = 0;})();
 (function(){var o = {}; o["typeof"] = 0;})();
+(function(){var o = {}; o["\u0074ypeof"] = 0;})();
 (function(){var o = {}; o["var"] = 0;})();
+(function(){var o = {}; o["\u0076ar"] = 0;})();
 (function(){var o = {}; o["void"] = 0;})();
+(function(){var o = {}; o["\u0076oid"] = 0;})();
 (function(){var o = {}; o["while"] = 0;})();
+(function(){var o = {}; o["\u0077hile"] = 0;})();
 (function(){var o = {}; o["with"] = 0;})();
+(function(){var o = {}; o["\u0077ith"] = 0;})();
 (function(){var o = {}; o["null"] = 0;})();
+(function(){var o = {}; o["\u006eull"] = 0;})();
 (function(){var o = {}; o["false"] = 0;})();
+(function(){var o = {}; o["\u0066alse"] = 0;})();
 (function(){var o = {}; o["true"] = 0;})();
+(function(){var o = {}; o["\u0074rue"] = 0;})();
 (function(){var o = {}; o["class"] = 0;})();
+(function(){var o = {}; o["\u0063lass"] = 0;})();
 (function(){var o = {}; o["const"] = 0;})();
+(function(){var o = {}; o["\u0063onst"] = 0;})();
 (function(){var o = {}; o["enum"] = 0;})();
+(function(){var o = {}; o["\u0065num"] = 0;})();
 (function(){var o = {}; o["export"] = 0;})();
+(function(){var o = {}; o["\u0065xport"] = 0;})();
 (function(){var o = {}; o["extends"] = 0;})();
+(function(){var o = {}; o["\u0065xtends"] = 0;})();
 (function(){var o = {}; o["import"] = 0;})();
+(function(){var o = {}; o["\u0069mport"] = 0;})();
 (function(){var o = {}; o["super"] = 0;})();
+(function(){var o = {}; o["\u0073uper"] = 0;})();
 (function(){var o = {}; o["implements"] = 0;})();
+(function(){var o = {}; o["\u0069mplements"] = 0;})();
 (function(){var o = {}; o["interface"] = 0;})();
+(function(){var o = {}; o["\u0069nterface"] = 0;})();
 (function(){var o = {}; o["let"] = 0;})();
+(function(){var o = {}; o["\u006cet"] = 0;})();
 (function(){var o = {}; o["package"] = 0;})();
+(function(){var o = {}; o["\u0070ackage"] = 0;})();
 (function(){var o = {}; o["private"] = 0;})();
+(function(){var o = {}; o["\u0070rivate"] = 0;})();
 (function(){var o = {}; o["protected"] = 0;})();
+(function(){var o = {}; o["\u0070rotected"] = 0;})();
 (function(){var o = {}; o["public"] = 0;})();
+(function(){var o = {}; o["\u0070ublic"] = 0;})();
 (function(){var o = {}; o["static"] = 0;})();
+(function(){var o = {}; o["\u0073tatic"] = 0;})();
 (function(){var o = {}; o["yield"] = 0;})();
+(function(){var o = {}; o["\u0079ield"] = 0;})();
 (function(){var o = {}; o["foo"] = 0;})();
+(function(){var o = {}; o["\u0066oo"] = 0;})();
 (function(){var o = {}; o["<"] = 0;})();
+(function(){var o = {}; o["\u003c"] = 0;})();


### PR DESCRIPTION
The unescape ID scanning fast path already have the check for strict mode for yield.  Refactor the logic and share it with escaped ID scanning code path.
Also fixed the escaped await used as ID in module case as well.
