### PR TITLE
Initialize locals

### DIFF
--- a/lib/Backend/BackwardPass.cpp
+++ b/lib/Backend/BackwardPass.cpp
@@ -3284,7 +3284,7 @@ BackwardPass::ProcessNoImplicitCallUses(IR::Instr *const instr)
     {
         IR::Opnd *const src = srcs[i];
         IR::ArrayRegOpnd *arraySrc = nullptr;
-        Sym *sym;
+        Sym *sym = nullptr;
         switch(src->GetKind())
         {
             case IR::OpndKindReg:
@@ -3412,7 +3412,7 @@ BackwardPass::ProcessNoImplicitCallDef(IR::Instr *const instr)
         return;
     }
 
-    Sym *srcSym;
+    Sym *srcSym = nullptr;
     switch(src->GetKind())
     {
         case IR::OpndKindReg:
@@ -6385,7 +6385,7 @@ BackwardPass::TrackFloatSymEquivalence(IR::Instr *const instr)
             return;
         }
 
-        FloatSymEquivalenceClass *dstEquivalenceClass, *srcEquivalenceClass;
+        FloatSymEquivalenceClass *dstEquivalenceClass = nullptr, *srcEquivalenceClass = nullptr;
         const bool dstHasEquivalenceClass = floatSymEquivalenceMap->TryGetValue(dst->m_id, &dstEquivalenceClass);
         const bool srcHasEquivalenceClass = floatSymEquivalenceMap->TryGetValue(src->m_id, &srcEquivalenceClass);
 
@@ -6446,7 +6446,7 @@ BackwardPass::TrackFloatSymEquivalence(IR::Instr *const instr)
     // kind on the instruction. Both are checked because in functions without loops, equivalence tracking is not done and only
     // the sym's non-number bailout bit will have the information, and in functions with loops, equivalence tracking is done
     // throughout the function and checking just the sym's non-number bailout bit is insufficient.
-    FloatSymEquivalenceClass *dstEquivalenceClass;
+    FloatSymEquivalenceClass *dstEquivalenceClass = nullptr;
     if(dst->m_requiresBailOnNotNumber ||
         (floatSymEquivalenceMap->TryGetValue(dst->m_id, &dstEquivalenceClass) && dstEquivalenceClass->RequiresBailOnNotNumber()))
     {

--- a/lib/Backend/BailOut.cpp
+++ b/lib/Backend/BailOut.cpp
@@ -1191,7 +1191,7 @@ BailOutRecord::BailOutInlinedCommon(Js::JavascriptCallStackLayout * layout, Bail
         sizeof(registerSaves));
     BailOutRecord const * currentBailOutRecord = bailOutRecord;
     BailOutReturnValue bailOutReturnValue;
-    Js::ScriptFunction * innerMostInlinee;
+    Js::ScriptFunction * innerMostInlinee = nullptr;
     BailOutInlinedHelper(layout, currentBailOutRecord, bailOutOffset, returnAddress, bailOutKind, registerSaves, &bailOutReturnValue, &innerMostInlinee, false, branchValue);
     Js::Var result = BailOutCommonNoCodeGen(layout, currentBailOutRecord, currentBailOutRecord->bailOutOffset, returnAddress, bailOutKind, branchValue,
         registerSaves, &bailOutReturnValue);
@@ -1218,7 +1218,7 @@ BailOutRecord::BailOutFromLoopBodyInlinedCommon(Js::JavascriptCallStackLayout * 
         sizeof(registerSaves));
     BailOutRecord const * currentBailOutRecord = bailOutRecord;
     BailOutReturnValue bailOutReturnValue;
-    Js::ScriptFunction * innerMostInlinee;
+    Js::ScriptFunction * innerMostInlinee = nullptr;
     BailOutInlinedHelper(layout, currentBailOutRecord, bailOutOffset, returnAddress, bailOutKind, registerSaves, &bailOutReturnValue, &innerMostInlinee, true, branchValue);
     uint32 result = BailOutFromLoopBodyHelper(layout, currentBailOutRecord, currentBailOutRecord->bailOutOffset,
         bailOutKind, nullptr, registerSaves, &bailOutReturnValue);

--- a/lib/Backend/FlowGraph.cpp
+++ b/lib/Backend/FlowGraph.cpp
@@ -2874,7 +2874,7 @@ FlowGraph::PeepCm(IR::Instr *instr)
     instrBr->SetSrc2(instr->UnlinkSrc2());
     instrBr->m_func = instr->m_func;
 
-    Js::OpCode newOpcode;
+    Js::OpCode newOpcode = Js::OpCode::InvalidOpCode;
 
     switch(instr->m_opcode)
     {

--- a/lib/Backend/Func.cpp
+++ b/lib/Backend/Func.cpp
@@ -1524,7 +1524,7 @@ Func::GetOrCreateSingleTypeGuard(intptr_t typeAddr)
 {
     EnsureSingleTypeGuards();
 
-    Js::JitTypePropertyGuard* guard;
+    Js::JitTypePropertyGuard* guard = nullptr;
     if (!this->singleTypeGuards->TryGetValue(typeAddr, &guard))
     {
         // Property guards are allocated by NativeCodeData::Allocator so that their lifetime extends as long as the EntryPointInfo is alive.

--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -1131,7 +1131,7 @@ BOOL GlobOpt::PreloadPRECandidate(Loop *loop, GlobHashBucket* candidate)
     loop->fieldPRESymStore->Set(symStore->m_id);
 
     ValueType valueType(ValueType::Uninitialized);
-    Value *initialValue;
+    Value *initialValue = nullptr;
 
     if (loop->initialValueFieldMap.TryGetValue(propertySym, &initialValue))
     {
@@ -3110,7 +3110,7 @@ GlobOpt::CopyPropDstUses(IR::Opnd *opnd, IR::Instr *instr, Value *src1Val)
 void
 GlobOpt::SetLoopFieldInitialValue(Loop *loop, IR::Instr *instr, PropertySym *propertySym, PropertySym *originalPropertySym)
 {
-    Value *initialValue;
+    Value *initialValue = nullptr;
     StackSym *symStore;
 
     if (loop->allFieldsKilled || loop->fieldKilled->Test(originalPropertySym->m_id))
@@ -4329,7 +4329,7 @@ GlobOpt::GetVarConstantValue(IR::AddrOpnd *addrOpnd)
     bool isVar = addrOpnd->IsVar();
     bool isString = isVar && addrOpnd->m_localAddress && JITJavascriptString::Is(addrOpnd->m_localAddress);
     Value *val = nullptr;
-    Value *cachedValue;
+    Value *cachedValue = nullptr;
     if(this->addrConstantToValueMap->TryGetValue(addrOpnd->m_address, &cachedValue))
     {
         // The cached value could be from a different block since this is a global (as opposed to a per-block) cache. Since
@@ -4464,7 +4464,7 @@ GlobOpt::NewFixedFunctionValue(Js::JavascriptFunction *function, IR::AddrOpnd *a
     Assert(function != nullptr);
 
     Value *val = nullptr;
-    Value *cachedValue;
+    Value *cachedValue = nullptr;
     if(this->addrConstantToValueMap->TryGetValue(addrOpnd->m_address, &cachedValue))
     {
         // The cached value could be from a different block since this is a global (as opposed to a per-block) cache. Since
@@ -13652,7 +13652,7 @@ GlobOpt::OptArraySrc(IR::Instr * *const instrRef)
             for(Loop *loop = currentBlock->loop; loop; loop = loop->parent)
             {
                 const JsArrayKills loopKills(loop->jsArrayKills);
-                Value *baseValueInLoopLandingPad;
+                Value *baseValueInLoopLandingPad = nullptr;
                 if((isLikelyJsArray && loopKills.KillsValueType(newBaseValueType)) ||
                     !OptIsInvariant(baseOpnd->m_sym, currentBlock, loop, baseValue, true, true, &baseValueInLoopLandingPad) ||
                     !(doArrayChecks || baseValueInLoopLandingPad->GetValueInfo()->IsObject()))

--- a/lib/Backend/GlobOptFields.cpp
+++ b/lib/Backend/GlobOptFields.cpp
@@ -1736,7 +1736,7 @@ void
 GlobOpt::ReloadFieldHoistStackSym(IR::Instr * instr, PropertySym * propertySym)
 {
     Assert(instr->TransfersSrcValue());
-    StackSym * fieldHoistSym;
+    StackSym * fieldHoistSym = nullptr;
     Loop * loop = this->FindFieldHoistStackSym(this->currentBlock->loop, propertySym->m_id, &fieldHoistSym, instr);
 
     if (loop == nullptr)

--- a/lib/Backend/GlobOptIntBounds.cpp
+++ b/lib/Backend/GlobOptIntBounds.cpp
@@ -2822,8 +2822,8 @@ void GlobOpt::DetermineArrayBoundCheckHoistability(
     // If the loop count is constant, (inductionVariableOffset + loopCount * maxMagnitudeChange) can be folded into an offset:
     //     bound = index + offset
     int offset;
-    StackSym *indexLoopCountBasedBoundBaseSym;
-    Value *indexLoopCountBasedBoundBaseValue;
+    StackSym *indexLoopCountBasedBoundBaseSym = nullptr;
+    Value *indexLoopCountBasedBoundBaseValue = nullptr;
     IntConstantBounds indexLoopCountBasedBoundBaseConstantBounds;
     bool generateLoopCountBasedIndexBound;
     if(!loopCount->HasBeenGenerated() || loopCount->LoopCountMinusOneSym())

--- a/lib/Backend/IR.cpp
+++ b/lib/Backend/IR.cpp
@@ -1138,7 +1138,7 @@ Instr::UnlinkBailOutInfo()
 bool
 Instr::ReplaceBailOutInfo(BailOutInfo *newBailOutInfo)
 {
-    BailOutInfo *oldBailOutInfo;
+    BailOutInfo *oldBailOutInfo = nullptr;
     bool deleteOld = false;
 
 #if DBG
@@ -3625,7 +3625,7 @@ bool Instr::UsesAllFields()
 BranchInstr *
 Instr::ChangeCmCCToBranchInstr(LabelInstr *targetInstr)
 {
-    Js::OpCode newOpcode;
+    Js::OpCode newOpcode = Js::OpCode::InvalidOpCode;
     switch (this->m_opcode)
     {
     case Js::OpCode::CmEq_A:

--- a/lib/Backend/IRBuilder.cpp
+++ b/lib/Backend/IRBuilder.cpp
@@ -1010,7 +1010,7 @@ IRBuilder::InsertLabels()
 
     while (iter.Next())
     {
-        IR::LabelInstr * labelInstr;
+        IR::LabelInstr * labelInstr = nullptr;
         BranchReloc * reloc = iter.Data();
         IR::BranchInstr * branchInstr = reloc->GetBranchInstr();
         uint offset = reloc->GetOffset();

--- a/lib/Backend/IRBuilderAsmJs.cpp
+++ b/lib/Backend/IRBuilderAsmJs.cpp
@@ -933,7 +933,7 @@ IRBuilderAsmJs::InsertLabels()
 
     while (iter.Next())
     {
-        IR::LabelInstr * labelInstr;
+        IR::LabelInstr * labelInstr = nullptr;
         BranchReloc * reloc = iter.Data();
         IR::BranchInstr * branchInstr = reloc->GetBranchInstr();
         uint offset = reloc->GetOffset();

--- a/lib/Backend/Inline.cpp
+++ b/lib/Backend/Inline.cpp
@@ -5147,13 +5147,14 @@ Inline::FixupExtraActualParams(IR::Instr * instr, IR::Instr *argOuts[], IR::Inst
 {
     Assert(instr->m_opcode == Js::OpCode::ArgOut_A_FromStackArgs);
 
-    int offsetFixup;
+    int offsetFixup = INT_MAX;
     Assert(instr->m_func->callSiteToArgumentsOffsetFixupMap->ContainsKey(callSiteId));
     instr->m_func->callSiteToArgumentsOffsetFixupMap->TryGetValue(callSiteId, &offsetFixup);
 
     StackSym *sym = instr->GetDst()->AsSymOpnd()->m_sym->AsStackSym();
     while (index < actualCount)
     {
+        Assert(offsetFixup != INT_MAX);
         IR::Instr* argOutToMapTo = argOuts[index] ? argOuts[index] : argOutsExtra[index];
         StackSym* newStackSym = StackSym::NewArgSlotSym(sym->GetArgSlotNum(), instr->m_func);
         newStackSym->m_isInlinedArgSlot = true;
@@ -5180,7 +5181,7 @@ Inline::RemoveExtraFixupArgouts(IR::Instr* instr, uint argoutRemoveCount, Js::Pr
 {
     Assert(instr->m_opcode == Js::OpCode::ArgOut_A_FromStackArgs);
 
-    int offsetFixup;
+    int offsetFixup = -1;
     Assert(instr->m_func->callSiteToArgumentsOffsetFixupMap->ContainsKey(callSiteId));
     instr->m_func->callSiteToArgumentsOffsetFixupMap->TryGetValue(callSiteId, &offsetFixup);
 
@@ -5188,6 +5189,7 @@ Inline::RemoveExtraFixupArgouts(IR::Instr* instr, uint argoutRemoveCount, Js::Pr
     IR::Instr* argInstr = instr->GetSrc2()->AsSymOpnd()->m_sym->AsStackSym()->GetInstrDef();
     for(uint argIndex = 0; argIndex < argoutRemoveCount; argIndex++)
     {
+        Assert(offsetFixup != -1);
         Assert(argInstr->m_opcode == Js::OpCode::ArgOut_A_FixupForStackArgs);
         Assert(!argInstr->HasByteCodeArgOutCapture()); // ArgOut_A_FixupForStackArgs should not be restored on bailout, so we don't generate ByteCodeArgOutCapture for these argouts.
 

--- a/lib/Backend/InterpreterThunkEmitter.cpp
+++ b/lib/Backend/InterpreterThunkEmitter.cpp
@@ -339,8 +339,8 @@ bool InterpreterThunkEmitter::NewThunkBlock()
     }
 
 #if PDATA_ENABLED
-    PRUNTIME_FUNCTION pdataStart;
-    intptr_t epilogEnd;
+    PRUNTIME_FUNCTION pdataStart = nullptr;
+    intptr_t epilogEnd = 0;
 #endif
 
     DWORD count = this->thunkCount;

--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -1159,7 +1159,7 @@ Lowerer::LowerRange(IR::Instr *instrStart, IR::Instr *instrEnd, bool defaultDoFa
                 }
             }
 
-            bool instrIsInHelperBlock;
+            bool instrIsInHelperBlock = false;
             if(!fastPath)
             {
                 LowerLdLen(instr, false);
@@ -1590,7 +1590,7 @@ Lowerer::LowerRange(IR::Instr *instrStart, IR::Instr *instrEnd, bool defaultDoFa
                 baseOpnd->SetValueType(baseOpnd->FindProfiledValueType());
             }
 
-            bool instrIsInHelperBlock;
+            bool instrIsInHelperBlock = false;
             if (!fastPath)
             {
                 this->LowerStElemI(
@@ -1657,7 +1657,7 @@ Lowerer::LowerRange(IR::Instr *instrStart, IR::Instr *instrEnd, bool defaultDoFa
                 baseOpnd->SetValueType(baseOpnd->FindProfiledValueType());
             }
 
-            bool instrIsInHelperBlock;
+            bool instrIsInHelperBlock = false;
 
             if (!fastPath)
             {
@@ -2662,7 +2662,7 @@ Lowerer::LowerRange(IR::Instr *instrStart, IR::Instr *instrEnd, bool defaultDoFa
 
         case Js::OpCode::BailOnNotArray:
         {
-            IR::Instr *bailOnNotArray, *bailOnMissingValue;
+            IR::Instr *bailOnNotArray = nullptr, *bailOnMissingValue = nullptr;
             SplitBailOnNotArray(instr, &bailOnNotArray, &bailOnMissingValue);
             IR::RegOpnd *const arrayOpnd = LowerBailOnNotArray(bailOnNotArray);
             if(bailOnMissingValue)
@@ -5141,8 +5141,7 @@ Lowerer::LowerUpdateNewScObjectCache(IR::Instr * insertInstr, IR::Opnd *dst, IR:
 IR::Instr *
 Lowerer::LowerNewScObjArray(IR::Instr *newObjInstr)
 {
-    IR::Instr* startCallInstr;
-    if (newObjInstr->HasEmptyArgOutChain(&startCallInstr))
+    if (newObjInstr->HasEmptyArgOutChain())
     {
         newObjInstr->FreeSrc2();
         return LowerNewScObjArrayNoArg(newObjInstr);
@@ -5277,7 +5276,7 @@ Lowerer::LowerNewScObjArray(IR::Instr *newObjInstr)
                 linkSym = linkOpnd->AsRegOpnd()->m_sym->AsStackSym();
                 AssertMsg(!linkSym->IsArgSlotSym() && linkSym->m_isSingleDef, "Arg tree not single def...");
 
-                startCallInstr = linkSym->m_instrDef;
+                IR::Instr* startCallInstr = linkSym->m_instrDef;
                 AssertMsg(startCallInstr->GetArgOutCount(false) == 2, "Generating ArrayFastPath for more than 1 parameter not allowed.");
 
                 // Since we emitted fast path above, move the startCall/argOut instruction right before helper
@@ -5673,7 +5672,7 @@ Lowerer::LowerProfiledLdFld(IR::JitProfilingInstr *ldFldInstr)
     auto src = ldFldInstr->UnlinkSrc1();
     AssertMsg(src->IsSymOpnd() && src->AsSymOpnd()->m_sym->IsPropertySym(), "Expected property sym as src");
 
-    IR::JnHelperMethod helper;
+    IR::JnHelperMethod helper = IR::HelperInvalid;
     switch (ldFldInstr->m_opcode)
     {
         case Js::OpCode::LdFld:
@@ -5755,7 +5754,6 @@ ldFldCommon:
 
         default:
             Assert(false);
-            __assume(false);
     }
 
     ldFldInstr->SetSrc1(IR::HelperCallOpnd::New(helper, m_func));
@@ -7468,7 +7466,7 @@ Lowerer::CreateEquivalentTypeGuardAndLinkToGuardedProperties(JITTypeHolder type,
 
         AssertMsg(!isTypeStatic || !propOpInfo->IsBeingStored(), "Why are we storing a field to an object of static type?");
 
-        Js::EquivalentPropertyEntry* entry;
+        Js::EquivalentPropertyEntry* entry = nullptr;
         if (propIds.TryGetValue(propertyId, &entry))
         {
             if (propOpIndex == entry->slotIndex && propOpUsesAuxSlot == entry->isAuxSlot)
@@ -11043,7 +11041,7 @@ Lowerer::InlineBuiltInLibraryCall(IR::Instr *callInstr)
 void Lowerer::LowerInlineBuiltIn(IR::Instr* builtInEndInstr)
 {
     Assert(builtInEndInstr->m_opcode == Js::OpCode::InlineBuiltInEnd || builtInEndInstr->m_opcode == Js::OpCode::InlineNonTrackingBuiltInEnd);
-    IR::Instr* startCallInstr;
+    IR::Instr* startCallInstr = nullptr;
     builtInEndInstr->IterateArgInstrs([&](IR::Instr* argInstr) {
         startCallInstr = argInstr->GetSrc2()->GetStackSym()->m_instrDef;
         return false;
@@ -18495,7 +18493,7 @@ Lowerer::GenerateFastInlineStringSplitMatch(IR::Instr * instr)
     // script context
     LoadScriptContext(instr);
 
-    IR::JnHelperMethod helperMethod;
+    IR::JnHelperMethod helperMethod = IR::JnHelperMethod::HelperInvalid;
     IR::AutoReuseOpnd autoReuseStackAllocationOpnd;
     if(callDst && instr->dstIsTempObject)
     {

--- a/lib/Backend/LowerMDShared.cpp
+++ b/lib/Backend/LowerMDShared.cpp
@@ -3721,7 +3721,7 @@ LowererMD::GenerateFastBrS(IR::BranchInstr *brInstr)
     brInstr->InsertBefore(cmpInstr);
     Legalize(cmpInstr);
 
-    Js::OpCode opcode;
+    Js::OpCode opcode = Js::OpCode::InvalidOpCode;
 
     switch(brInstr->m_opcode)
     {

--- a/lib/Backend/Opnd.cpp
+++ b/lib/Backend/Opnd.cpp
@@ -1868,6 +1868,7 @@ HelperCallOpnd::New(JnHelperMethod fnHelper, Func *func)
 void
 HelperCallOpnd::Init(JnHelperMethod fnHelper)
 {
+    Assert(fnHelper    != IR::HelperInvalid);
     this->m_fnHelper    = fnHelper;
     this->m_type        = TyMachPtr;
 

--- a/lib/Backend/Peeps.cpp
+++ b/lib/Backend/Peeps.cpp
@@ -1113,7 +1113,7 @@ Peeps::PeepCondMove(IR::LabelInstr *labelInstr, IR::Instr *nextInstr, const bool
 {
     IR::Instr *instr = labelInstr->GetPrevRealInstrOrLabel();
 
-    Js::OpCode newOpCode;
+    Js::OpCode newOpCode = Js::OpCode::InvalidOpCode;
 
     // Check if BB is all MOVs with both RegOpnd
     while(instr->m_opcode == Js::OpCode::MOV)

--- a/lib/Backend/SymTable.cpp
+++ b/lib/Backend/SymTable.cpp
@@ -161,7 +161,7 @@ SymTable::FindPropertySym(SymID id) const
 PropertySym *
 SymTable::FindPropertySym(SymID stackSymID, int32 propertyId) const
 {
-    PropertySym *  propertySym;
+    PropertySym *  propertySym = nullptr;
 
     stackSymID += this->m_IDAdjustment;
 

--- a/lib/Backend/TempTracker.cpp
+++ b/lib/Backend/TempTracker.cpp
@@ -818,7 +818,7 @@ NumberTemp::GetRepresentativePropertySymId(PropertySym * propertySym, BackwardPa
 {
     // Since we don't track alias with objects, all property accesses are all grouped together.
     // Use a single property sym id to represent a propertyId to track dependencies.
-    SymID symId;
+    SymID symId = (SymID)-1;
     Js::PropertyId propertyId = propertySym->m_propertyId;
     if (!backwardPass->numberTempRepresentativePropertySym->TryGetValue(propertyId, &symId))
     {
@@ -1146,7 +1146,7 @@ ObjectTemp::ProcessInstr(IR::Instr * instr)
         {
             // First (non-this) parameter is either a regexp or search string.
             // It doesn't escape.
-            IR::Instr * instrArgDef;
+            IR::Instr * instrArgDef = nullptr;
             instr->FindCallArgumentOpnd(2, &instrArgDef);
             instrArgDef->dstIsTempObject = true;
             break;
@@ -1154,7 +1154,7 @@ ObjectTemp::ProcessInstr(IR::Instr * instr)
 
         case IR::JnHelperMethod::HelperRegExp_Exec:
         {
-            IR::Instr * instrArgDef;
+            IR::Instr * instrArgDef = nullptr;
             instr->FindCallArgumentOpnd(1, &instrArgDef);
             instrArgDef->dstIsTempObject = true;
             break;

--- a/lib/Backend/amd64/LowererMDArch.cpp
+++ b/lib/Backend/amd64/LowererMDArch.cpp
@@ -752,7 +752,7 @@ LowererMDArch::LowerCallI(IR::Instr * callInstr, ushort callFlags, bool isHelper
     GeneratePreCall(callInstr, functionObjOpnd, insertBeforeInstrForCFGCheck);
 
     // We need to get the calculated CallInfo in SimpleJit because that doesn't include any changes for stack alignment
-    IR::IntConstOpnd *callInfo;
+    IR::IntConstOpnd *callInfo = nullptr;
     int32 argCount = LowerCallArgs(callInstr, callFlags, 1, &callInfo);
 
 
@@ -1065,7 +1065,7 @@ LowererMDArch::GetArgSlotOpnd(uint16 index, StackSym * argSym, bool isHelper /*=
 IR::Instr *
 LowererMDArch::LowerAsmJsCallE(IR::Instr *callInstr)
 {
-    IR::IntConstOpnd *callInfo;
+    IR::IntConstOpnd *callInfo = nullptr;
     int32 argCount = this->LowerCallArgs(callInstr, Js::CallFlags_Value, 1, &callInfo);
 
     IR::Instr* ret = this->LowerCall(callInstr, argCount);

--- a/lib/Common/Common/NumberUtilities_strtod.cpp
+++ b/lib/Common/Common/NumberUtilities_strtod.cpp
@@ -2262,9 +2262,9 @@ static int RoundTo(byte *pbSrc, byte *pbLim, int nDigits, __out_bcount(nDigits+1
 int Js::NumberUtilities::FDblToStr(double dbl, Js::NumberUtilities::FormatType ft, int nDigits, __out_ecount(cchDst) char16 *pchDst, int cchDst)
 {
     int n = 0; // the no. of chars in the result.
-    int wExp10;
+    int wExp10 = 0;
     byte rgb[kcbMaxRgb];
-    byte *pbLim;
+    byte *pbLim = nullptr;
 
     if (!Js::NumberUtilities::IsFinite(dbl))
     {

--- a/lib/Common/DataStructures/SparseBitVector.h
+++ b/lib/Common/DataStructures/SparseBitVector.h
@@ -454,7 +454,7 @@ template <class TAllocator>
 SparseBVUnit *
 BVSparse<TAllocator>::BitsFromIndex(BVIndex i, bool create)
 {
-    Field(BVSparseNode*, TAllocator)* prevNextField;
+    Field(BVSparseNode*, TAllocator)* prevNextField = nullptr;
     BVSparseNode * node = NodeFromIndex(i, &prevNextField, create);
     if (node)
     {
@@ -470,7 +470,7 @@ template <class TAllocator>
 const SparseBVUnit *
 BVSparse<TAllocator>::BitsFromIndex(BVIndex i) const
 {
-    Field(BVSparseNode*, TAllocator) const* prevNextField;
+    Field(BVSparseNode*, TAllocator) const* prevNextField = nullptr;
     const BVSparseNode * node = NodeFromIndex(i, &prevNextField);
     if (node)
     {
@@ -577,7 +577,7 @@ template <class TAllocator>
 void
 BVSparse<TAllocator>::Clear(BVIndex i)
 {
-    Field(BVSparseNode*, TAllocator)* prevNextField;
+    Field(BVSparseNode*, TAllocator)* prevNextField = nullptr;
     BVSparseNode * current = this->NodeFromIndex(i, &prevNextField, false /* create */);
     if(current)
     {
@@ -625,7 +625,7 @@ template <class TAllocator>
 BOOLEAN
 BVSparse<TAllocator>::TestAndClear(BVIndex i)
 {
-    Field(BVSparseNode*, TAllocator)* prevNextField;
+    Field(BVSparseNode*, TAllocator)* prevNextField = nullptr;
     BVSparseNode * current = this->NodeFromIndex(i, &prevNextField, false /* create */);
     if (current == nullptr)
     {

--- a/lib/Common/Memory/SmallNormalHeapBucket.cpp
+++ b/lib/Common/Memory/SmallNormalHeapBucket.cpp
@@ -274,7 +274,7 @@ template <SweepMode mode>
 TBlockType *
 SmallNormalHeapBucketBase<TBlockType>::SweepPendingObjects(Recycler * recycler, TBlockType * list)
 {
-    TBlockType * tail;
+    TBlockType * tail = nullptr;
     HeapBlockList::ForEach(list, [recycler, &tail](TBlockType * heapBlock)
     {
         // Note, page heap blocks are never swept concurrently

--- a/lib/Parser/Hash.cpp
+++ b/lib/Parser/Hash.cpp
@@ -258,7 +258,7 @@ IdentPtr HashTbl::PidHashNameLenWithHash(_In_reads_(cch) CharType const * prgch,
     AssertArrMemR(prgch, cch);
     Assert(luHash == CaseSensitiveComputeHash(prgch, end));
 
-    IdentPtr * ppid;
+    IdentPtr * ppid = nullptr;
     IdentPtr pid;
     LONG cb;
     int32 bucketCount;

--- a/lib/Parser/RegexCompileTime.cpp
+++ b/lib/Parser/RegexCompileTime.cpp
@@ -4517,7 +4517,7 @@ namespace UnifiedRegex
         {
             if (REGEX_CONFIG_FLAG(RegexOptimize))
             {
-                Char c;
+                Char c = 0;
                 if (root->IsSingleChar(compiler, c))
                 {
                     // SPECIAL CASE: c

--- a/lib/Parser/Scan.cpp
+++ b/lib/Parser/Scan.cpp
@@ -582,7 +582,7 @@ template <typename EncodingPolicy>
 typename Scanner<EncodingPolicy>::EncodedCharPtr Scanner<EncodingPolicy>::FScanNumber(EncodedCharPtr p, double *pdbl, bool& likelyInt)
 {
     EncodedCharPtr last = m_pchLast;
-    EncodedCharPtr pchT;
+    EncodedCharPtr pchT = nullptr;
     likelyInt = true;
     // Reset
     m_OctOrLeadingZeroOnLastTKNumber = false;

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -2354,7 +2354,7 @@ namespace Js
                     {
                         CompileScriptException se;
                         Parser ps(m_scriptContext, funcBody->GetIsStrictMode() ? TRUE : FALSE);
-                        ParseNodePtr parseTree;
+                        ParseNodePtr parseTree = nullptr;
 
                         uint nextFunctionId = funcBody->GetLocalFunctionId();
                         hrParser = ps.ParseSourceWithOffset(&parseTree, pszStart, offset, length, charOffset, isCesu8, grfscr, &se,
@@ -8601,7 +8601,7 @@ namespace Js
             Assert(this->jitTransferData->lazyBailoutProperties != nullptr);
 
             Js::PropertyId propertyId = this->jitTransferData->lazyBailoutProperties[i];
-            Js::PropertyGuard* sharedPropertyGuard;
+            Js::PropertyGuard* sharedPropertyGuard = nullptr;
             bool hasSharedPropertyGuard = TryGetSharedPropertyGuard(propertyId, sharedPropertyGuard);
             Assert(hasSharedPropertyGuard);
             bool isValid = hasSharedPropertyGuard ? sharedPropertyGuard->IsValid() : false;
@@ -8711,7 +8711,7 @@ namespace Js
             while (*next)
             {
                 Js::PropertyId propertyId = (*next)->propId;
-                Js::PropertyGuard* sharedPropertyGuard;
+                Js::PropertyGuard* sharedPropertyGuard = nullptr;
 
                 // We use the shared guard created during work item creation to ensure that the condition we assumed didn't change while
                 // we were JIT-ing. If we don't have a shared property guard for this property then we must not need to protect it,
@@ -8763,7 +8763,7 @@ namespace Js
             while (entry->propertyId != Js::Constants::NoProperty)
             {
                 Js::PropertyId propertyId = entry->propertyId;
-                Js::PropertyGuard* sharedPropertyGuard;
+                Js::PropertyGuard* sharedPropertyGuard = nullptr;
 
                 // We use the shared guard created during work item creation to ensure that the condition we assumed didn't change while
                 // we were JIT-ing. If we don't have a shared property guard for this property then we must not need to protect it,
@@ -8818,7 +8818,7 @@ namespace Js
             for (uint i = 0; i < this->jitTransferData->ctorCacheTransferData.ctorCachesCount; ++i)
             {
                 Js::PropertyId propertyId = entries[i]->propId;
-                Js::PropertyGuard* sharedPropertyGuard;
+                Js::PropertyGuard* sharedPropertyGuard = nullptr;
 
                 // We use the shared guard created during work item creation to ensure that the condition we assumed didn't change while
                 // we were JIT-ing. If we don't have a shared property guard for this property then we must not need to protect it,
@@ -8855,7 +8855,7 @@ namespace Js
             while (entry->propertyId != Js::Constants::NoProperty)
             {
                 Js::PropertyId propertyId = entry->propertyId;
-                Js::PropertyGuard* sharedPropertyGuard;
+                Js::PropertyGuard* sharedPropertyGuard = nullptr;
 
                 // We use the shared guard created during work item creation to ensure that the condition we assumed didn't change while
                 // we were JIT-ing. If we don't have a shared property guard for this property then we must not need to protect it,

--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -823,7 +823,7 @@ namespace Js
 
     PropertyId ScriptContext::GetOrAddPropertyIdTracked(JsUtil::CharacterBuffer<WCHAR> const& propName)
     {
-        Js::PropertyRecord const * propertyRecord;
+        Js::PropertyRecord const * propertyRecord = nullptr;
         threadContext->GetOrAddPropertyId(propName, &propertyRecord);
 
         this->TrackPid(propertyRecord);
@@ -838,7 +838,7 @@ namespace Js
 
     PropertyId ScriptContext::GetOrAddPropertyIdTracked(__in_ecount(propertyNameLength) LPCWSTR propertyName, __in int propertyNameLength)
     {
-        Js::PropertyRecord const * propertyRecord;
+        Js::PropertyRecord const * propertyRecord = nullptr;
         threadContext->GetOrAddPropertyId(propertyName, propertyNameLength, &propertyRecord);
         if (propertyNameLength == 2)
         {
@@ -1660,7 +1660,7 @@ namespace Js
         if (propertyStringMap != nullptr)
         {
             PropertyString *string = nullptr;
-            RecyclerWeakReference<PropertyString>* stringReference;
+            RecyclerWeakReference<PropertyString>* stringReference = nullptr;
             if (propertyStringMap->TryGetValue(propertyId, &stringReference))
             {
                 string = stringReference->Get();

--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -1623,7 +1623,7 @@ namespace Js
     {
         PropertyStringCacheMap* propertyStringMap = this->GetLibrary()->EnsurePropertyStringMap();
 
-        RecyclerWeakReference<PropertyString>* stringReference;
+        RecyclerWeakReference<PropertyString>* stringReference = nullptr;
         if (propertyStringMap->TryGetValue(propertyId, &stringReference))
         {
             PropertyString *string = stringReference->Get();
@@ -2406,7 +2406,7 @@ namespace Js
 
     SourceContextInfo* ScriptContext::GetSourceContextInfo(uint hash)
     {
-        SourceContextInfo * sourceContextInfo;
+        SourceContextInfo * sourceContextInfo = nullptr;
         if (this->Cache()->dynamicSourceContextInfoMap && this->Cache()->dynamicSourceContextInfoMap->TryGetValue(hash, &sourceContextInfo))
         {
             return sourceContextInfo;
@@ -2506,7 +2506,7 @@ namespace Js
 
         // We only init sourceContextInfoMap, don't need to lock.
         EnsureSourceContextInfoMap();
-        SourceContextInfo * sourceContextInfo;
+        SourceContextInfo * sourceContextInfo = nullptr;
         if (this->Cache()->sourceContextInfoMap->TryGetValue(sourceContext, &sourceContextInfo))
         {
 #if ENABLE_PROFILE_INFO

--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -3457,7 +3457,7 @@ ThreadContext::PropertyGuardEntry*
 ThreadContext::EnsurePropertyGuardEntry(const Js::PropertyRecord* propertyRecord, bool& foundExistingEntry)
 {
     PropertyGuardDictionary &guards = this->recyclableData->propertyGuards;
-    PropertyGuardEntry* entry;
+    PropertyGuardEntry* entry = nullptr;
 
     foundExistingEntry = guards.TryGetValue(propertyRecord, &entry);
     if (!foundExistingEntry)
@@ -3630,7 +3630,7 @@ ThreadContext::InvalidatePropertyGuardEntry(const Js::PropertyRecord* propertyRe
     if (entry->entryPoints && entry->entryPoints->Count() > 0)
     {
         Js::JavascriptStackWalker stackWalker(this->GetScriptContextList());
-        Js::JavascriptFunction* caller;
+        Js::JavascriptFunction* caller = nullptr;
         while (stackWalker.GetCaller(&caller, /*includeInlineFrames*/ false))
         {
             // If the current frame is already from a bailout - we do not need to do on stack invalidation
@@ -3662,7 +3662,7 @@ ThreadContext::InvalidatePropertyGuards(Js::PropertyId propertyId)
 {
     const Js::PropertyRecord* propertyRecord = GetPropertyName(propertyId);
     PropertyGuardDictionary &guards = this->recyclableData->propertyGuards;
-    PropertyGuardEntry* entry;
+    PropertyGuardEntry* entry = nullptr;
     if (guards.TryGetValueAndRemove(propertyRecord, &entry))
     {
         InvalidatePropertyGuardEntry(propertyRecord, entry, false);
@@ -3920,7 +3920,7 @@ void ThreadContext::RegisterTypeWithProtoPropertyCache(const Js::PropertyId prop
     Assert(type);
 
     PropertyIdToTypeHashSetDictionary &typesWithProtoPropertyCache = recyclableData->typesWithProtoPropertyCache;
-    TypeHashSet *typeHashSet;
+    TypeHashSet *typeHashSet = nullptr;
     if(!typesWithProtoPropertyCache.TryGetValue(propertyId, &typeHashSet))
     {
         typeHashSet = RecyclerNew(recycler, TypeHashSet, recycler);
@@ -3942,7 +3942,7 @@ void ThreadContext::InternalInvalidateProtoTypePropertyCaches(const Js::Property
     // Get the hash set of registered types associated with the property ID, invalidate each type in the hash set, and
     // remove the property ID and its hash set from the map
     PropertyIdToTypeHashSetDictionary &typesWithProtoPropertyCache = recyclableData->typesWithProtoPropertyCache;
-    TypeHashSet *typeHashSet;
+    TypeHashSet *typeHashSet = nullptr;
     if(typesWithProtoPropertyCache.Count() != 0 && typesWithProtoPropertyCache.TryGetValueAndRemove(propertyId, &typeHashSet))
     {
         DoInvalidateProtoTypePropertyCaches(propertyId, typeHashSet);
@@ -4191,7 +4191,7 @@ Js::SourceDynamicProfileManager* ThreadContext::GetSourceDynamicProfileManager(_
 {
       EnsureSourceProfileManagersByUrlMap();
       Js::SourceDynamicProfileManager* profileManager = nullptr;
-      SourceDynamicProfileManagerCache* managerCache;
+      SourceDynamicProfileManagerCache* managerCache = nullptr;
       bool newCache = false;
       if(!this->recyclableData->sourceProfileManagersByUrl->TryGetValue(url, &managerCache))
       {
@@ -4525,7 +4525,7 @@ void ThreadContext::CheckInterruptPoll()
 void *
 ThreadContext::GetDynamicObjectEnumeratorCache(Js::DynamicType const * dynamicType)
 {
-    void * data;
+    void * data = nullptr;
     return this->dynamicObjectEnumeratorCacheMap.TryGetValue(dynamicType, &data)? data : nullptr;
 }
 

--- a/lib/Runtime/ByteCode/ByteCodeSerializer.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeSerializer.cpp
@@ -2903,7 +2903,7 @@ public:
                 }
             case ctStringTemplateCallsite:
                 {
-                    Var callsite;
+                    Var callsite = nullptr;
                     current = ReadStringTemplateCallsiteConstant(current, function, callsite);
 
                     function->RecordConstant(reg, callsite);
@@ -3807,7 +3807,7 @@ public:
         {
             for(auto i = 0; i<nestedCount; ++i)
             {
-                const byte * nestedFunctionBytes;
+                const byte * nestedFunctionBytes = nullptr;
                 current = ReadOffsetAsPointer(current, &nestedFunctionBytes);
                 if (nestedFunctionBytes == nullptr)
                 {
@@ -3815,7 +3815,7 @@ public:
                 }
                 else
                 {
-                    FunctionProxy* nestedFunction;
+                    FunctionProxy* nestedFunction = nullptr;
 
                     // If we should deserialize nested functions, go ahead and do so
                     // If we shouldn't, and we're currently deserializing a function proxy

--- a/lib/Runtime/ByteCode/ByteCodeWriter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeWriter.cpp
@@ -136,7 +136,7 @@ namespace Js
         CheckOpen();
         Empty(OpCode::EndOfBlock);
 
-        ByteBlock* finalByteCodeBlock;
+        ByteBlock* finalByteCodeBlock = nullptr;
 
         ScriptContext* scriptContext = m_functionWrite->GetScriptContext();
         m_byteCodeData.Copy(scriptContext->GetRecycler(), &finalByteCodeBlock);
@@ -191,8 +191,8 @@ namespace Js
         //
         // Store the final trimmed byte-code on the function.
         //
-        ByteBlock* finalAuxiliaryBlock;
-        ByteBlock* finalAuxiliaryContextBlock;
+        ByteBlock* finalAuxiliaryBlock = nullptr;
+        ByteBlock* finalAuxiliaryContextBlock = nullptr;
 
         m_auxiliaryData.Copy(m_functionWrite->GetScriptContext()->GetRecycler(), &finalAuxiliaryBlock);
         m_auxContextData.Copy(m_functionWrite->GetScriptContext()->GetRecycler(), &finalAuxiliaryContextBlock);

--- a/lib/Runtime/ByteCode/OpCodeUtil.cpp
+++ b/lib/Runtime/ByteCode/OpCodeUtil.cpp
@@ -128,7 +128,7 @@ namespace Js
 
     OpCode OpCodeUtil::ConvertProfiledCallOpToNonProfiled(OpCode op)
     {
-        OpCode newOpcode;
+        OpCode newOpcode = Js::OpCode::InvalidOpCode;
         if (IsProfiledCallOp(op))
         {
             newOpcode = (OpCode)(op - Js::OpCode::ProfiledCallI + Js::OpCode::CallI);
@@ -148,7 +148,7 @@ namespace Js
 
     OpCode OpCodeUtil::ConvertProfiledReturnTypeCallOpToNonProfiled(OpCode op)
     {
-        OpCode newOpcode;
+        OpCode newOpcode = Js::OpCode::InvalidOpCode;
         if (IsProfiledReturnTypeCallOp(op))
         {
             newOpcode = (OpCode)(op - Js::OpCode::ProfiledReturnTypeCallI + Js::OpCode::CallI);

--- a/lib/Runtime/Debug/DiagStackFrame.cpp
+++ b/lib/Runtime/Debug/DiagStackFrame.cpp
@@ -374,7 +374,7 @@ namespace Js
             Js::PropertyId propertyId = activeScopeObject->GetPropertyId((Js::PropertyIndex)i);
             if (propertyId != Js::Constants::NoProperty)
             {
-                Js::Var value;
+                Js::Var value = nullptr;
                 if (Js::JavascriptOperators::GetProperty(activeScopeObject, propertyId, &value, scriptContext))
                 {
                     Js::IDiagObjectAddress * pAddress = nullptr;

--- a/lib/Runtime/Language/AsmJs.cpp
+++ b/lib/Runtime/Language/AsmJs.cpp
@@ -384,7 +384,7 @@ namespace Js
     bool AsmJSCompiler::CheckGlobalVariableInitImport( AsmJsModuleCompiler &m, PropertyName varName, ParseNode *initNode, bool isMutable /*= true*/)
     {
         AsmJSCoercion coercion;
-        ParseNode *coercedExpr;
+        ParseNode *coercedExpr = nullptr;
         if( !CheckTypeAnnotation( m, initNode, &coercion, &coercedExpr ) )
         {
             return false;
@@ -546,7 +546,7 @@ namespace Js
                 if (lib && lib->GetPropertyId() == PropertyIds::SIMD)
                 {
                     // global.SIMD.xxx
-                    AsmJsSIMDFunction *simdFunc;
+                    AsmJsSIMDFunction *simdFunc = nullptr;
 
                     if (!m.LookupStdLibSIMDName(field->GetPropertyId(), field, &simdFunc))
                     {

--- a/lib/Runtime/Language/AsmJsModule.cpp
+++ b/lib/Runtime/Language/AsmJsModule.cpp
@@ -2523,7 +2523,7 @@ namespace Js
         uint slotsCount = moduleBody->scopeSlotArraySize;
         for (uint i = 0; i < slotsCount; ++i)
         {
-            AsmJsSlot * asmSlot;
+            AsmJsSlot * asmSlot = nullptr;
             bool found = asmSlotMap->TryGetValue(propertyIdArray[i], &asmSlot);
             // we should have everything we need in the map
             Assert(found);

--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -7541,7 +7541,7 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
     template <class T>
     void InterpreterStackFrame::OP_ScopedLdInst(const unaligned T * playout)
     {
-        Var thisVar;
+        Var thisVar = nullptr;
         Var rootObject = GetFunctionBody()->GetRootObject();
         Var result = JavascriptOperators::OP_GetInstanceScoped(GetEnvForEvalCode(),
             m_functionBody->GetReferencedPropertyId(playout->PropertyIdIndex), rootObject, &thisVar, GetScriptContext());

--- a/lib/Runtime/Language/JavascriptConversion.cpp
+++ b/lib/Runtime/Language/JavascriptConversion.cpp
@@ -496,7 +496,7 @@ CommonNumber:
         //  3. If func is either undefined or null, return undefined.
         //  4. If IsCallable(func) is false, throw a TypeError exception.
         //  5. Return func.
-        Var varMethod;
+        Var varMethod = nullptr;
 
         if (!(requestContext->GetConfig()->IsES6ToPrimitiveEnabled()
             && JavascriptOperators::GetPropertyReference(recyclableObject, PropertyIds::_symbolToPrimitive, &varMethod, requestContext)

--- a/lib/Runtime/Language/JavascriptExceptionOperators.cpp
+++ b/lib/Runtime/Language/JavascriptExceptionOperators.cpp
@@ -21,7 +21,7 @@ namespace Js
         // If the outer try catch was already in the user code, no need to go any further.
         if (!m_previousCatchHandlerToUserCodeStatus)
         {
-            Js::JavascriptFunction* caller;
+            Js::JavascriptFunction* caller = nullptr;
             if (JavascriptStackWalker::GetCaller(&caller, scriptContext))
             {
                 Js::FunctionBody *funcBody = NULL;
@@ -1435,7 +1435,7 @@ namespace Js
                 scriptContext->GetThreadContext()->SetDisableImplicitFlags(DisableImplicitCallAndExceptionFlag);
             }
 
-            Var var;
+            Var var = nullptr;
             if (JavascriptOperators::GetProperty(error, PropertyIds::stackTraceLimit, &var, scriptContext))
             {
                 // Only accept the value if it is a "Number". Avoid potential valueOf() call.

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -353,7 +353,7 @@ namespace Js
             JavascriptError::ThrowTypeError(scriptContext, JSERR_Property_CannotGet_NullOrUndefined , scriptContext->GetPropertyName(propertyId)->GetBuffer());
         }
 
-        Var value;
+        Var value = nullptr;
         try
         {
             Js::JavascriptExceptionOperators::AutoCatchHandlerExists autoCatchHandlerExists(scriptContext);
@@ -435,7 +435,7 @@ namespace Js
             JavascriptError::ThrowTypeError(scriptContext, JSERR_Property_CannotGet_NullOrUndefined, GetPropertyDisplayNameForError(index, scriptContext));
         }
 
-        Var member;
+        Var member = nullptr;
         uint32 indexVal;
         PropertyRecord const * propertyRecord = nullptr;
 
@@ -1191,7 +1191,7 @@ CommonNumber:
             // filter enumerable keys
             uint32 resultLength = proxyResult->GetLength();
             Var element;
-            const Js::PropertyRecord *propertyRecord;
+            const Js::PropertyRecord *propertyRecord = nullptr;
             uint32 index = 0;
             for (uint32 i = 0; i < resultLength; i++)
             {
@@ -1264,7 +1264,7 @@ CommonNumber:
         Var getter, setter;
         if (false == JavascriptOperators::GetOwnAccessors(obj, propertyId, &getter, &setter, scriptContext))
         {
-            Var value;
+            Var value = nullptr;
             if (false == JavascriptOperators::GetOwnProperty(obj, propertyId, &value, scriptContext))
             {
                 return FALSE;
@@ -1474,7 +1474,7 @@ CommonNumber:
         if (JavascriptOperators::IsObject(unscopables))
         {
             DynamicObject *unscopablesList = DynamicObject::FromVar(unscopables);
-            Var value;
+            Var value = nullptr;
             //8.1.1.2.1.9.c If blocked is not undefined
             if (JavascriptOperators::GetProperty(unscopablesList, propertyId, &value, scriptContext))
             {
@@ -1593,7 +1593,7 @@ CommonNumber:
         {
             if (!dynamicObject->DynamicObject::GetAccessors(propertyId, &getter, &setter, requestContext))
             {
-                Var value;
+                Var value = nullptr;
                 if (!JavascriptConversion::PropertyQueryFlagsToBoolean(dynamicObject->DynamicObject::GetPropertyQuery(instance, propertyId, &value, NULL, requestContext)) ||
                     (requestContext->IsUndeclBlockVar(value) && (ActivationObject::Is(instance) || RootObjectBase::Is(instance))))
                 {
@@ -1605,7 +1605,7 @@ CommonNumber:
         {
             if (!object->GetAccessors(propertyId, &getter, &setter, requestContext))
             {
-                Var value;
+                Var value = nullptr;
                 if (!object->GetProperty(instance, propertyId, &value, NULL, requestContext) ||
                     (requestContext->IsUndeclBlockVar(value) && (ActivationObject::Is(instance) || RootObjectBase::Is(instance))))
                 {
@@ -1877,7 +1877,7 @@ CommonNumber:
     {
         AssertMsg(RootObjectBase::Is(instance), "Root must be an object!");
 
-        Var value;
+        Var value = nullptr;
         if (JavascriptOperators::GetRootProperty(RecyclableObject::FromVar(instance), propertyId, &value, scriptContext, info))
         {
             if (scriptContext->IsUndeclBlockVar(value))
@@ -1915,7 +1915,7 @@ CommonNumber:
 
         for (int i = 0; i < length; i += 1)
         {
-            Var value;
+            Var value = nullptr;
             RecyclableObject *obj = RecyclableObject::FromVar(pScope->GetItem(i));
             if (JavascriptOperators::GetProperty(obj, Js::PropertyIds::_lexicalThisSlotSymbol, &value, scriptContext))
             {
@@ -2072,7 +2072,7 @@ CommonNumber:
         {
             DynamicObject* dynamicObject = (DynamicObject*)object;
             DynamicTypeHandler* dynamicTypeHandler = dynamicObject->GetDynamicType()->GetTypeHandler();
-            Var property;
+            Var property = nullptr;
             if (dynamicTypeHandler->CheckFixedProperty(requestContext->GetPropertyName(propertyId), &property, requestContext))
             {
                 Assert(value == nullptr || *value == property);
@@ -2165,7 +2165,7 @@ CommonNumber:
     {
         GlobalObject * globalObject = scriptContext->GetGlobalObject();
         uint32 index;
-        PropertyRecord const * propertyRecord;
+        PropertyRecord const * propertyRecord = nullptr;
         IndexType indexType = GetIndexTypeFromString(propertyName, propertyLength, scriptContext, &index, &propertyRecord, true);
 
         if (indexType == IndexType_Number)
@@ -2299,7 +2299,7 @@ CommonNumber:
                 {
                     Assert(JavascriptProxy::Is(setterValueOrProxy));
                     JavascriptProxy* proxy = JavascriptProxy::FromVar(setterValueOrProxy);
-                    const PropertyRecord* propertyRecord;
+                    const PropertyRecord* propertyRecord = nullptr;
                     proxy->PropertyIdFromInt(index, &propertyRecord);
                     return proxy->SetPropertyTrap(receiver, JavascriptProxy::SetPropertyTrapKind::SetItemOnTaggedNumberKind, propertyRecord->GetPropertyId(), newValue, requestContext);
                 }
@@ -2521,7 +2521,7 @@ CommonNumber:
         if ( (instanceType == TypeIds_NativeIntArray || instanceType == TypeIds_NativeFloatArray) || (instanceType >= TypeIds_Int8Array && instanceType <= TypeIds_Uint64Array) )
         {
             RecyclableObject* object = RecyclableObject::FromVar(instance);
-            Var member;
+            Var member = nullptr;
 
             // If the item is found in the array own body, then it is a number
             if (JavascriptOperators::GetOwnItem(object, index, &member, scriptContext)
@@ -3074,7 +3074,7 @@ CommonNumber:
 
     BOOL JavascriptOperators::HasItem(RecyclableObject* object, uint64 index)
     {
-        PropertyRecord const * propertyRecord;
+        PropertyRecord const * propertyRecord = nullptr;
         ScriptContext* scriptContext = object->GetScriptContext();
         JavascriptOperators::GetPropertyIdForInt(index, scriptContext, &propertyRecord);
         return JavascriptOperators::HasProperty(object, propertyRecord->GetPropertyId());
@@ -3146,7 +3146,7 @@ CommonNumber:
 
     BOOL JavascriptOperators::SetItem(Var receiver, RecyclableObject* object, uint64 index, Var value, ScriptContext* scriptContext, PropertyOperationFlags propertyOperationFlags)
     {
-        PropertyRecord const * propertyRecord;
+        PropertyRecord const * propertyRecord = nullptr;
         JavascriptOperators::GetPropertyIdForInt(index, scriptContext, &propertyRecord);
         return JavascriptOperators::SetProperty(receiver, object, propertyRecord->GetPropertyId(), value, scriptContext, propertyOperationFlags);
     }
@@ -3177,7 +3177,7 @@ CommonNumber:
             {
                 Assert(JavascriptProxy::Is(setterValueOrProxy));
                 JavascriptProxy* proxy = JavascriptProxy::FromVar(setterValueOrProxy);
-                const PropertyRecord* propertyRecord;
+                const PropertyRecord* propertyRecord = nullptr;
                 proxy->PropertyIdFromInt(index, &propertyRecord);
                 return proxy->SetPropertyTrap(receiver, JavascriptProxy::SetPropertyTrapKind::SetItemKind, propertyRecord->GetPropertyId(), value, scriptContext, skipPrototypeCheck);
             }
@@ -3209,7 +3209,7 @@ CommonNumber:
     }
     BOOL JavascriptOperators::DeleteItem(RecyclableObject* object, uint64 index, PropertyOperationFlags propertyOperationFlags)
     {
-        PropertyRecord const * propertyRecord;
+        PropertyRecord const * propertyRecord = nullptr;
         JavascriptOperators::GetPropertyIdForInt(index, object->GetScriptContext(), &propertyRecord);
         return JavascriptOperators::DeleteProperty(object, propertyRecord->GetPropertyId(), propertyOperationFlags);
     }
@@ -3221,7 +3221,7 @@ CommonNumber:
             RecyclableObject::FromVar(instance);
 
         uint32 indexVal;
-        PropertyRecord const * propertyRecord;
+        PropertyRecord const * propertyRecord = nullptr;
         IndexType indexType = GetIndexType(index, scriptContext, &indexVal, &propertyRecord, false);
 
         if (indexType == IndexType_Number)
@@ -3830,9 +3830,9 @@ CommonNumber:
         }
 
         uint32 indexVal;
-        PropertyRecord const * propertyRecord;
-        JavascriptString * propertyNameString;
-        Var value;
+        PropertyRecord const * propertyRecord = nullptr;
+        JavascriptString * propertyNameString = nullptr;
+        Var value = nullptr;
 
         IndexType indexType = GetIndexType(index, scriptContext, &indexVal, &propertyRecord, &propertyNameString, false, true);
 
@@ -4057,7 +4057,7 @@ CommonNumber:
         threadContext->ClearImplicitCallFlags();
 
         uint32 indexVal;
-        PropertyRecord const * propertyRecord;
+        PropertyRecord const * propertyRecord = nullptr;
         Var value = NULL;
         BOOL hasProperty = FALSE;
         IndexType indexType = GetIndexType(index, scriptContext, &indexVal, &propertyRecord, false);
@@ -4966,7 +4966,7 @@ CommonNumber:
         RecyclableObject* object = RecyclableObject::FromVar(instance);
 
         uint32 indexVal;
-        PropertyRecord const * propertyRecord;
+        PropertyRecord const * propertyRecord = nullptr;
         JavascriptString * propertyNameString = nullptr;
         BOOL result = TRUE;
         IndexType indexType = GetIndexType(index, scriptContext, &indexVal, &propertyRecord, &propertyNameString, false, true);
@@ -7265,7 +7265,7 @@ CommonNumber:
             JavascriptError::ThrowTypeError(scriptContext, JSERR_Operand_Invalid_NeedObject, _u("in"));
         }
 
-        PropertyRecord const * propertyRecord;
+        PropertyRecord const * propertyRecord = nullptr;
         uint32 index;
         IndexType indexType = GetIndexType(argProperty, scriptContext, &index, &propertyRecord, true);
 
@@ -10836,7 +10836,7 @@ CommonNumber:
 
     BOOL JavascriptOperators::GetItem(RecyclableObject* instance, uint64 index, Var* value, ScriptContext* requestContext)
     {
-        PropertyRecord const * propertyRecord;
+        PropertyRecord const * propertyRecord = nullptr;
         JavascriptOperators::GetPropertyIdForInt(index, requestContext, &propertyRecord);
         return JavascriptOperators::GetProperty(instance, propertyRecord->GetPropertyId(), value, requestContext);
     }

--- a/lib/Runtime/Language/SourceTextModuleRecord.cpp
+++ b/lib/Runtime/Language/SourceTextModuleRecord.cpp
@@ -442,7 +442,7 @@ namespace Js
             }
             this->starExportRecordList->Map([=](ModuleImportOrExportEntry exportEntry) {
                 Assert(exportEntry.moduleRequest != nullptr);
-                SourceTextModuleRecord* moduleRecord;
+                SourceTextModuleRecord* moduleRecord = nullptr;
                 if (this->childrenModuleSet->TryGetValue(exportEntry.moduleRequest->Psz(), &moduleRecord))
                 {
                     Assert(moduleRecord->WasParsed());

--- a/lib/Runtime/Library/GlobalObject.cpp
+++ b/lib/Runtime/Library/GlobalObject.cpp
@@ -592,7 +592,7 @@ namespace Js
         scriptContext->TransitionToDebugModeIfFirstSource(/* utf8SourceInfo = */ nullptr);
 
         JavascriptString *argString = JavascriptString::FromVar(evalArg);
-        ScriptFunction *pfuncScript;
+        ScriptFunction *pfuncScript = nullptr;
         char16 const * sourceString = argString->GetSz();
         charcount_t sourceLen = argString->GetLength();
         FastEvalMapString key(sourceString, sourceLen, moduleID, strictMode, isLibraryCode);
@@ -684,7 +684,7 @@ namespace Js
             // The eval expression refers to "this"
             if (args.Info.Flags & CallFlags_ExtraArg)
             {
-                JavascriptFunction* pfuncCaller;
+                JavascriptFunction* pfuncCaller = nullptr;
                 JavascriptStackWalker::GetCaller(&pfuncCaller, scriptContext);
                 // If we are non-hidden call to eval then look for the "this" object in the frame display if the caller is a lambda else get "this" from the caller's frame.
 
@@ -884,7 +884,7 @@ namespace Js
             Parser parser(scriptContext, strictMode);
             bool forceNoNative = false;
 
-            ParseNodePtr parseTree;
+            ParseNodePtr parseTree = nullptr;
 
             SourceContextInfo * sourceContextInfo = pSrcInfo->sourceContextInfo;
             ULONG deferParseThreshold = Parser::GetDeferralThreshold(sourceContextInfo->IsSourceProfileLoaded());
@@ -970,7 +970,7 @@ namespace Js
             if ((grfscr & fscrIsLibraryCode) == 0)
             {
                 // For parented eval get the caller's utf8SourceInfo
-                JavascriptFunction* pfuncCaller;
+                JavascriptFunction* pfuncCaller = nullptr;
                 if (JavascriptStackWalker::GetCaller(&pfuncCaller, scriptContext) && pfuncCaller && pfuncCaller->IsScriptFunction())
                 {
                     FunctionBody* parentFuncBody = pfuncCaller->GetFunctionBody();
@@ -1043,7 +1043,7 @@ namespace Js
             Parser parser(scriptContext, strictMode);
             bool forceNoNative = false;
 
-            ParseNodePtr parseTree;
+            ParseNodePtr parseTree = nullptr;
 
             SourceContextInfo * sourceContextInfo = pSrcInfo->sourceContextInfo;
 

--- a/lib/Runtime/Library/IntlEngineInterfaceExtensionObject.cpp
+++ b/lib/Runtime/Library/IntlEngineInterfaceExtensionObject.cpp
@@ -697,7 +697,7 @@ namespace Js
         }
 
         HRESULT hr;
-        Var propertyValue;
+        Var propertyValue = nullptr;
         JavascriptString* localeJSstr;
         DynamicObject* options = DynamicObject::FromVar(args.Values[1]);
 
@@ -840,7 +840,7 @@ namespace Js
         DynamicObject* obj = DynamicObject::FromVar(args.Values[1]);
 
         HRESULT hr;
-        Var propertyValue;
+        Var propertyValue = nullptr;
         uint32 length;
 
         PCWSTR locale = GetTypedPropertyBuiltInFrom(obj, __locale, JavascriptString) ? JavascriptString::FromVar(propertyValue)->GetSz() : nullptr;
@@ -1218,7 +1218,7 @@ namespace Js
         obj->GetInternalProperty(obj, Js::InternalPropertyIds::HiddenObject, &hiddenObject, NULL, scriptContext);
 
         //We are going to perform the same check for timeZone as when caching the formatter.
-        Var propertyValue;
+        Var propertyValue = nullptr;
         AutoHSTRING result;
 
         //If timeZone is undefined; then use the standard dateTimeFormatter to format in local time; otherwise use the IDateTimeFormatter2 to format using specified timezone (UTC)

--- a/lib/Runtime/Library/JSON.cpp
+++ b/lib/Runtime/Library/JSON.cpp
@@ -390,7 +390,7 @@ namespace JSON
 
     Js::Var StringifySession::Str(uint32 index, Js::Var holder)
     {
-        Js::Var value;
+        Js::Var value = nullptr;
         Js::RecyclableObject *undefined = scriptContext->GetLibrary()->GetUndefined();
 
         if (Js::JavascriptArray::Is(holder) && !Js::JavascriptArray::FromVar(holder)->IsCrossSiteObject())
@@ -420,7 +420,7 @@ namespace JSON
 
     Js::Var StringifySession::Str(Js::JavascriptString* key, Js::PropertyId keyId, Js::Var holder)
     {
-        Js::Var value;
+        Js::Var value = nullptr;
         // We should look only into object's own properties here. When an object is serialized, only the own properties are considered,
         // the prototype chain is not considered. However, the property names can be selected via an array replacer. In this case
         // ES5 spec doesn't say the property has to own property or even to be enumerable. So, properties from the prototype, or non enum properties,
@@ -446,7 +446,7 @@ namespace JSON
         //check and apply 'toJSON' filter
         if (Js::JavascriptOperators::IsJsNativeObject(value) || (Js::JavascriptOperators::IsObject(value)))
         {
-            Js::Var tojson;
+            Js::Var tojson = nullptr;
             if (Js::JavascriptOperators::GetProperty(Js::RecyclableObject::FromVar(value), Js::PropertyIds::toJSON, &tojson, scriptContext) &&
                 Js::JavascriptConversion::IsCallable(tojson))
             {

--- a/lib/Runtime/Library/JSONScanner.cpp
+++ b/lib/Runtime/Library/JSONScanner.cpp
@@ -86,7 +86,7 @@ namespace JSON
                     }
                     currentChar = saveCurrentChar;
                     double val;
-                    const char16* end;
+                    const char16* end = nullptr;
                     val = Js::NumberUtilities::StrToDbl(currentChar, &end, scriptContext);
                     if(currentChar == end)
                     {

--- a/lib/Runtime/Library/JavascriptArray.cpp
+++ b/lib/Runtime/Library/JavascriptArray.cpp
@@ -2846,7 +2846,7 @@ namespace Js
                 return seg->elements[offset];
             }
         }
-        Var element;
+        Var element = nullptr;
         if (DirectGetItemAtFull(index, &element))
         {
             return element;
@@ -2868,7 +2868,7 @@ namespace Js
                 return JavascriptNumber::ToVar(seg->elements[offset], GetScriptContext());
             }
         }
-        Var element;
+        Var element = nullptr;
         if (DirectGetItemAtFull(index, &element))
         {
             return element;
@@ -2897,7 +2897,7 @@ namespace Js
                 return JavascriptNumber::ToVarWithCheck(seg->elements[offset], GetScriptContext());
             }
         }
-        Var element;
+        Var element = nullptr;
         if (DirectGetItemAtFull(index, &element))
         {
             return element;
@@ -3765,7 +3765,7 @@ namespace Js
 
         JS_REENTRANT(jsReentLock, TryGetArrayAndLength(args[0], scriptContext, _u("Array.prototype.indexOf"), &pArr, &obj, &length));
 
-        Var search;
+        Var search = nullptr;
         uint32 fromIndex = 0;
         uint64 fromIndex64 = 0;
 
@@ -4459,7 +4459,7 @@ CaseDefault:
                         static_cast<charcount_t>(arrLength + (hasSeparator ? arrLength - 1 : 0)));
                 CompoundString *const cs =
                     CompoundString::NewWithPointerCapacity(estimatedAppendCount, scriptContext->GetLibrary());
-                Var item;
+                Var item = nullptr;
                 BOOL gotItem;
                 JS_REENTRANT(jsReentLock, gotItem = TemplatedGetItem(arr, 0u, &item, scriptContext));
                 if (gotItem)
@@ -4493,7 +4493,7 @@ CaseDefault:
                 }
 
                 JavascriptString *res = nullptr;
-                Var item;
+                Var item = nullptr;
 
                 JS_REENTRANT(jsReentLock, gotItem = TemplatedGetItem(arr, 0u, &item, scriptContext));
                 if (gotItem)
@@ -4517,7 +4517,7 @@ CaseDefault:
 
             case 1:
             {
-                Var item;
+                Var item = nullptr;
                 BOOL gotItem;
                 JS_REENTRANT(jsReentLock, gotItem = TemplatedGetItem(arr, 0u, &item, scriptContext));
                 if (gotItem)
@@ -4556,7 +4556,7 @@ CaseDefault:
                         static_cast<charcount_t>(cSrcLength + (hasSeparator ? cSrcLength - 1 : 0)));
                 CompoundString *const cs =
                     CompoundString::NewWithPointerCapacity(estimatedAppendCount, scriptContext->GetLibrary());
-                Var value;
+                Var value = nullptr;
                 JS_REENTRANT(jsReentLock, gotItem = JavascriptOperators::GetItem(object, 0u, &value, scriptContext));
                 if (gotItem)
                 {
@@ -4587,7 +4587,7 @@ CaseDefault:
                 }
 
                 JavascriptString *res = nullptr;
-                Var value;
+                Var value = nullptr;
                 JS_REENTRANT(jsReentLock, gotItem = JavascriptOperators::GetItem(object, 0u, &value, scriptContext));
                 if (gotItem)
                 {
@@ -4608,7 +4608,7 @@ CaseDefault:
 
             case 1:
             {
-                Var value;
+                Var value = nullptr;
                 JS_REENTRANT(jsReentLock, BOOL gotItem = JavascriptOperators::GetItem(object, 0u, &value, scriptContext));
                 if (gotItem)
                 {
@@ -4641,7 +4641,7 @@ Case0:
 
         JS_REENTRANT(jsReentLock, TryGetArrayAndLength(args[0], scriptContext, _u("Array.prototype.lastIndexOf"), &pArr, &obj, &length));
 
-        Var search;
+        Var search = nullptr;
         int64 fromIndex;
         JS_REENTRANT(jsReentLock,
             BOOL gotParam = GetParamForLastIndexOf(length, args, search, fromIndex, scriptContext));
@@ -4873,7 +4873,7 @@ Case0:
         }
 
         uint32 index = length - 1;
-        Var element;
+        Var element = nullptr;
         JS_REENTRANT(jsReentLock, BOOL gotItem = arr->DirectGetItemAtFull(index, &element));
 
         if (!gotItem)
@@ -4912,7 +4912,7 @@ Case0:
         }
         BigIndex index = length;
         --index;
-        Var element;
+        Var element = nullptr;
         if (index.IsSmallIndex())
         {
             JS_REENTRANT(jsReentLock, BOOL gotItem = JavascriptOperators::GetItem(dynamicObject, index.GetSmallIndex(), &element, scriptContext));
@@ -5978,7 +5978,7 @@ Case0:
                 // need recheck array type before checking array item [i + start]
                 if (pArr->IsMissingItem(i + start))
                 {
-                    Var element;
+                    Var element = nullptr;
                     pnewArr->SetHasNoMissingValues(false);
                     JS_REENTRANT(jsReentLock, BOOL gotItem = pArr->DirectGetItemAtFull(i + start, &element));
                     if (gotItem)
@@ -6251,7 +6251,7 @@ Case0:
                 else
                 {
                     AssertMsg(CONFIG_FLAG(ForceES5Array), "newArr can only be ES5Array when it is forced");
-                    Var element;
+                    Var element = nullptr;
                     for (uint32 i = 0; i < newLen; i++)
                     {
                         JS_REENTRANT(jsReentLock, BOOL gotItem = pArr->DirectGetItemAtFull(i + start, &element));
@@ -6275,7 +6275,7 @@ Case0:
             else
             {
                 // The constructed object isn't an array, we'll need to use normal object manipulation
-                Var element;
+                Var element = nullptr;
 
                 for (uint32 i = 0; i < newLen; i++)
                 {
@@ -6815,7 +6815,7 @@ Case0:
 
                 for (uint32 i = 0; i < len; i++)
                 {
-                    Var item;
+                    Var item = nullptr;
                     JS_REENTRANT(jsReentLock, BOOL gotItem = JavascriptOperators::GetItem(pObj, i, &item, scriptContext));
                     if (gotItem)
                     {
@@ -8102,7 +8102,7 @@ Case0:
             scriptContext->PushObject(arr);
             pushedObject = true;
 
-            Var element;
+            Var element = nullptr;
             JS_REENTRANT(jsReentLock, BOOL gotItem = ItemTrace<T>::GetItem(arr, 0, &element, scriptContext));
             if (gotItem)
             {
@@ -11345,7 +11345,7 @@ Case0:
 
                 for (uint32 j = start; j < end; j++)
                 {
-                    Var element;
+                    Var element = nullptr;
                     JS_REENTRANT(jsReentLock, BOOL gotItem = JavascriptOperators::GetItem(srcArray, propertyObject, j, &element, scriptContext));
                     if (!gotItem)
                     {
@@ -12263,7 +12263,7 @@ Case0:
 
     PropertyQueryFlags JavascriptArray::HasItemQuery(uint32 index)
     {
-        Var value;
+        Var value = nullptr;
         return JavascriptConversion::BooleanToPropertyQueryFlags(this->DirectGetItemAt<Var>(index, &value));
     }
 

--- a/lib/Runtime/Library/JavascriptDate.cpp
+++ b/lib/Runtime/Library/JavascriptDate.cpp
@@ -287,7 +287,7 @@ namespace Js
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
-            Var result;
+            Var result = nullptr;
             if (TryInvokeRemotely(EntryGetDate, scriptContext, args, &result))
             {
                 return result;
@@ -314,7 +314,7 @@ namespace Js
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
-            Var result;
+            Var result = nullptr;
             if (TryInvokeRemotely(EntryGetDay, scriptContext, args, &result))
             {
                 return result;
@@ -341,7 +341,7 @@ namespace Js
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
-            Var result;
+            Var result = nullptr;
             if (TryInvokeRemotely(EntryGetFullYear, scriptContext, args, &result))
             {
                 return result;
@@ -368,7 +368,7 @@ namespace Js
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
-            Var result;
+            Var result = nullptr;
             if (TryInvokeRemotely(EntryGetYear, scriptContext, args, &result))
             {
                 return result;
@@ -395,7 +395,7 @@ namespace Js
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
-            Var result;
+            Var result = nullptr;
             if (TryInvokeRemotely(EntryGetHours, scriptContext, args, &result))
             {
                 return result;
@@ -422,7 +422,7 @@ namespace Js
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
-            Var result;
+            Var result = nullptr;
             if (TryInvokeRemotely(EntryGetMilliseconds, scriptContext, args, &result))
             {
                 return result;
@@ -449,7 +449,7 @@ namespace Js
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
-            Var result;
+            Var result = nullptr;
             if (TryInvokeRemotely(EntryGetMinutes, scriptContext, args, &result))
             {
                 return result;
@@ -476,7 +476,7 @@ namespace Js
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
-            Var result;
+            Var result = nullptr;
             if (TryInvokeRemotely(EntryGetMonth, scriptContext, args, &result))
             {
                 return result;
@@ -503,7 +503,7 @@ namespace Js
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
-            Var result;
+            Var result = nullptr;
             if (TryInvokeRemotely(EntryGetSeconds, scriptContext, args, &result))
             {
                 return result;
@@ -530,7 +530,7 @@ namespace Js
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
-            Var result;
+            Var result = nullptr;
             if (TryInvokeRemotely(EntryGetTime, scriptContext, args, &result))
             {
                 return result;
@@ -553,7 +553,7 @@ namespace Js
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
-            Var result;
+            Var result = nullptr;
             if (TryInvokeRemotely(EntryGetTimezoneOffset, scriptContext, args, &result))
             {
                 return result;
@@ -576,7 +576,7 @@ namespace Js
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
-            Var result;
+            Var result = nullptr;
             if (TryInvokeRemotely(EntryGetUTCDate, scriptContext, args, &result))
             {
                 return result;
@@ -599,7 +599,7 @@ namespace Js
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
-            Var result;
+            Var result = nullptr;
             if (TryInvokeRemotely(EntryGetUTCDay, scriptContext, args, &result))
             {
                 return result;
@@ -622,7 +622,7 @@ namespace Js
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
-            Var result;
+            Var result = nullptr;
             if (TryInvokeRemotely(EntryGetUTCFullYear, scriptContext, args, &result))
             {
                 return result;
@@ -645,7 +645,7 @@ namespace Js
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
-            Var result;
+            Var result = nullptr;
             if (TryInvokeRemotely(EntryGetUTCHours, scriptContext, args, &result))
             {
                 return result;
@@ -668,7 +668,7 @@ namespace Js
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
-            Var result;
+            Var result = nullptr;
             if (TryInvokeRemotely(EntryGetUTCMilliseconds, scriptContext, args, &result))
             {
                 return result;
@@ -691,7 +691,7 @@ namespace Js
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
-            Var result;
+            Var result = nullptr;
             if (TryInvokeRemotely(EntryGetUTCMinutes, scriptContext, args, &result))
             {
                 return result;
@@ -714,7 +714,7 @@ namespace Js
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
-            Var result;
+            Var result = nullptr;
             if (TryInvokeRemotely(EntryGetUTCMonth, scriptContext, args, &result))
             {
                 return result;
@@ -737,7 +737,7 @@ namespace Js
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
-            Var result;
+            Var result = nullptr;
             if (TryInvokeRemotely(EntryGetUTCSeconds, scriptContext, args, &result))
             {
                 return result;
@@ -760,7 +760,7 @@ namespace Js
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
-            Var result;
+            Var result = nullptr;
             if (TryInvokeRemotely(EntryGetVarDate, scriptContext, args, &result))
             {
                 return result;
@@ -851,7 +851,7 @@ namespace Js
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
-            Var result;
+            Var result = nullptr;
             if (TryInvokeRemotely(EntrySetDate, scriptContext, args, &result))
             {
                 return result;
@@ -874,7 +874,7 @@ namespace Js
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
-            Var result;
+            Var result = nullptr;
             if (TryInvokeRemotely(EntrySetFullYear, scriptContext, args, &result))
             {
                 return result;
@@ -897,7 +897,7 @@ namespace Js
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
-            Var result;
+            Var result = nullptr;
             if (TryInvokeRemotely(EntrySetYear, scriptContext, args, &result))
             {
                 return result;
@@ -920,7 +920,7 @@ namespace Js
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
-            Var result;
+            Var result = nullptr;
             if (TryInvokeRemotely(EntrySetHours, scriptContext, args, &result))
             {
                 return result;
@@ -943,7 +943,7 @@ namespace Js
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
-            Var result;
+            Var result = nullptr;
             if (TryInvokeRemotely(EntrySetMilliseconds, scriptContext, args, &result))
             {
                 return result;
@@ -966,7 +966,7 @@ namespace Js
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
-            Var result;
+            Var result = nullptr;
             if (TryInvokeRemotely(EntrySetMinutes, scriptContext, args, &result))
             {
                 return result;
@@ -989,7 +989,7 @@ namespace Js
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
-            Var result;
+            Var result = nullptr;
             if (TryInvokeRemotely(EntrySetMonth, scriptContext, args, &result))
             {
                 return result;
@@ -1012,7 +1012,7 @@ namespace Js
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
-            Var result;
+            Var result = nullptr;
             if (TryInvokeRemotely(EntrySetSeconds, scriptContext, args, &result))
             {
                 return result;
@@ -1035,7 +1035,7 @@ namespace Js
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
-            Var result;
+            Var result = nullptr;
             if (TryInvokeRemotely(EntrySetTime, scriptContext, args, &result))
             {
                 return result;
@@ -1075,7 +1075,7 @@ namespace Js
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
-            Var result;
+            Var result = nullptr;
             if (TryInvokeRemotely(EntrySetUTCDate, scriptContext, args, &result))
             {
                 return result;
@@ -1098,7 +1098,7 @@ namespace Js
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
-            Var result;
+            Var result = nullptr;
             if (TryInvokeRemotely(EntrySetUTCFullYear, scriptContext, args, &result))
             {
                 return result;
@@ -1121,7 +1121,7 @@ namespace Js
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
-            Var result;
+            Var result = nullptr;
             if (TryInvokeRemotely(EntrySetUTCHours, scriptContext, args, &result))
             {
                 return result;
@@ -1144,7 +1144,7 @@ namespace Js
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
-            Var result;
+            Var result = nullptr;
             if (TryInvokeRemotely(EntrySetUTCMilliseconds, scriptContext, args, &result))
             {
                 return result;
@@ -1167,7 +1167,7 @@ namespace Js
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
-            Var result;
+            Var result = nullptr;
             if (TryInvokeRemotely(EntrySetUTCMinutes, scriptContext, args, &result))
             {
                 return result;
@@ -1190,7 +1190,7 @@ namespace Js
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
-            Var result;
+            Var result = nullptr;
             if (TryInvokeRemotely(EntrySetUTCMonth, scriptContext, args, &result))
             {
                 return result;
@@ -1213,7 +1213,7 @@ namespace Js
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
-            Var result;
+            Var result = nullptr;
             if (TryInvokeRemotely(EntrySetUTCSeconds, scriptContext, args, &result))
             {
                 return result;
@@ -1236,7 +1236,7 @@ namespace Js
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
-            Var result;
+            Var result = nullptr;
             if (TryInvokeRemotely(EntryToDateString, scriptContext, args, &result))
             {
                 return result;
@@ -1263,7 +1263,7 @@ namespace Js
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
-            Var result;
+            Var result = nullptr;
             if (TryInvokeRemotely(EntryToISOString, scriptContext, args, &result))
             {
                 return result;
@@ -1295,7 +1295,7 @@ namespace Js
             JavascriptError::ThrowTypeError(scriptContext, JSERR_This_NullOrUndefined, _u("Date.prototype.toJSON"));
         }
 
-        Var result;
+        Var result = nullptr;
         if (TryInvokeRemotely(EntryToJSON, scriptContext, args, &result))
         {
             return result;
@@ -1328,7 +1328,7 @@ namespace Js
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
-            Var result;
+            Var result = nullptr;
             if (TryInvokeRemotely(EntryToLocaleDateString, scriptContext, args, &result))
             {
                 return result;
@@ -1378,7 +1378,7 @@ namespace Js
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
-            Var result;
+            Var result = nullptr;
             if (TryInvokeRemotely(EntryToLocaleString, scriptContext, args, &result))
             {
                 return result;
@@ -1438,7 +1438,7 @@ namespace Js
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
-            Var result;
+            Var result = nullptr;
             if (TryInvokeRemotely(EntryToLocaleTimeString, scriptContext, args, &result))
             {
                 return result;
@@ -1487,7 +1487,7 @@ namespace Js
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
-            Var result;
+            Var result = nullptr;
             if (TryInvokeRemotely(EntryToTimeString, scriptContext, args, &result))
             {
                 return result;
@@ -1524,7 +1524,7 @@ namespace Js
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
-            Var result;
+            Var result = nullptr;
             if (TryInvokeRemotely(EntryToUTCString, scriptContext, args, &result))
             {
                 return result;
@@ -1550,7 +1550,7 @@ namespace Js
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
-            Var result;
+            Var result = nullptr;
             if (TryInvokeRemotely(EntryValueOf, scriptContext, args, &result))
             {
                 return result;
@@ -1575,7 +1575,7 @@ namespace Js
 
         if (args.Info.Count == 0 || !JavascriptDate::Is(args[0]))
         {
-            Var result;
+            Var result = nullptr;
             if (TryInvokeRemotely(EntryToString, scriptContext, args, &result))
             {
                 return result;

--- a/lib/Runtime/Library/JavascriptFunction.cpp
+++ b/lib/Runtime/Library/JavascriptFunction.cpp
@@ -543,7 +543,7 @@ namespace Js
                 {
                     for (uint i = 0; i < len; i++)
                     {
-                        Var element;
+                        Var element = nullptr;
                         if (!JavascriptOperators::GetItem(dynamicObject, i, &element, scriptContext))
                         {
                             element = undefined;

--- a/lib/Runtime/Library/JavascriptMap.cpp
+++ b/lib/Runtime/Library/JavascriptMap.cpp
@@ -100,7 +100,7 @@ namespace Js
 
                 RecyclableObject* obj = RecyclableObject::FromVar(nextItem);
 
-                Var key, value;
+                Var key = nullptr, value = nullptr;
 
                 if (!JavascriptOperators::GetItem(obj, 0u, &key, scriptContext))
                 {

--- a/lib/Runtime/Library/JavascriptProxy.h
+++ b/lib/Runtime/Library/JavascriptProxy.h
@@ -162,7 +162,7 @@ namespace Js
         void GetOwnPropertyKeysHelper(ScriptContext* scriptContext, RecyclableObject* trapResultArray, uint32 len, JavascriptArray* trapResult,
             JsUtil::BaseDictionary<Js::PropertyId, bool, ArenaAllocator>& targetToTrapResultMap, Fn fn)
         {
-            Var element;
+            Var element = nullptr;
             const PropertyRecord* propertyRecord;
             uint32 trapResultIndex = 0;
             PropertyId propertyId;

--- a/lib/Runtime/Library/JavascriptRegExpEnumerator.cpp
+++ b/lib/Runtime/Library/JavascriptRegExpEnumerator.cpp
@@ -23,7 +23,7 @@ namespace Js
         propertyId = Constants::NoProperty;
         ScriptContext* scriptContext = this->GetScriptContext();
 
-        JavascriptString * item;
+        JavascriptString * item = nullptr;
         if (regExpObject->GetSpecialEnumerablePropertyName(++index, &item, scriptContext))
         {
             if (attributes != nullptr)

--- a/lib/Runtime/Library/JavascriptWeakMap.cpp
+++ b/lib/Runtime/Library/JavascriptWeakMap.cpp
@@ -120,7 +120,7 @@ namespace Js
 
                 RecyclableObject* obj = RecyclableObject::FromVar(nextItem);
 
-                Var key, value;
+                Var key = nullptr, value = nullptr;
 
                 if (!JavascriptOperators::GetItem(obj, 0u, &key, scriptContext))
                 {

--- a/lib/Runtime/Library/RegexHelper.cpp
+++ b/lib/Runtime/Library/RegexHelper.cpp
@@ -93,7 +93,7 @@ namespace Js
         }
 
         UnifiedRegex::RegexKey lookupKey(psz, csz, flags);
-        UnifiedRegex::RegexPattern* pattern;
+        UnifiedRegex::RegexPattern* pattern = nullptr;
         RegexPatternMruMap* dynamicRegexMap = scriptContext->GetDynamicRegexMap();
         if (!dynamicRegexMap->TryGetValue(lookupKey, &pattern))
         {

--- a/lib/Runtime/Library/StackScriptFunction.cpp
+++ b/lib/Runtime/Library/StackScriptFunction.cpp
@@ -414,7 +414,7 @@ namespace Js
         {
             // The case here is a frame that doesn't define any captured locals, so it blindly grabs the parent
             // function's environment, which may have been boxed.
-            FrameDisplay *boxedFrameDisplay;
+            FrameDisplay *boxedFrameDisplay = nullptr;
             if (boxedValues.TryGetValue(frameDisplay, (void **)&boxedFrameDisplay))
             {
                 nestedFunc->SetEnvironment(boxedFrameDisplay);
@@ -425,7 +425,7 @@ namespace Js
         for (uint i = 0; i < frameDisplay->GetLength(); i++)
         {
             Var* stackScopeSlots = (Var*)frameDisplay->GetItem(i);
-            Var* boxedScopeSlots;
+            Var* boxedScopeSlots = nullptr;
             if (boxedValues.TryGetValue(stackScopeSlots, (void**)&boxedScopeSlots))
             {
                 frameDisplay->SetItem(i, boxedScopeSlots);
@@ -509,7 +509,7 @@ namespace Js
         Js::FrameDisplay *stackFrameDisplay = this->GetFrameDisplayFromNativeFrame(walker, callerFunctionBody);
         if (ThreadContext::IsOnStack(stackFrameDisplay))
         {
-            Js::FrameDisplay *boxedFrameDisplay;
+            Js::FrameDisplay *boxedFrameDisplay = nullptr;
             if (boxedValues.TryGetValue(stackFrameDisplay, (void**)&boxedFrameDisplay))
             {
                 this->SetFrameDisplayFromNativeFrame(walker, callerFunctionBody, boxedFrameDisplay);
@@ -520,7 +520,7 @@ namespace Js
         Var              *stackScopeSlots = this->GetScopeSlotsFromNativeFrame(walker, callerFunctionBody);
         if (ThreadContext::IsOnStack(stackScopeSlots))
         {
-            Var              *boxedScopeSlots;
+            Var              *boxedScopeSlots = nullptr;
             if (boxedValues.TryGetValue(stackScopeSlots, (void**)&boxedScopeSlots))
             {
                 this->SetScopeSlotsFromNativeFrame(walker, callerFunctionBody, boxedScopeSlots);
@@ -617,7 +617,7 @@ namespace Js
             return frameDisplay;
         }
 
-        FrameDisplay * boxedFrameDisplay;
+        FrameDisplay * boxedFrameDisplay = nullptr;
         if (boxedValues.TryGetValue(frameDisplay, (void **)&boxedFrameDisplay))
         {
             return boxedFrameDisplay;
@@ -655,7 +655,7 @@ namespace Js
     {
         Assert(slotArray != nullptr);
         Assert(count != 0);
-        Field(Var) * boxedSlotArray;
+        Field(Var) * boxedSlotArray = nullptr;
         if (boxedValues.TryGetValue(slotArray, (void **)&boxedSlotArray))
         {
             return (Var*)boxedSlotArray;

--- a/lib/WasmReader/WasmBinaryReader.cpp
+++ b/lib/WasmReader/WasmBinaryReader.cpp
@@ -720,7 +720,7 @@ void WasmBinaryReader::ReadExportSection()
         const char16* exportName = ReadInlineName(length, nameLength);
 
         // Check if the name is already used
-        NameList* list;
+        NameList* list = nullptr;
         if (exportsNameDict.TryGetValue(nameLength, &list))
         {
             const char16** found = list->Find([exportName, nameLength](const char16* existing) { 


### PR DESCRIPTION
OS:11689018, OS:11688872, OS:11688790, OS:11688685, OS:11688481, OS:11666867,
OS:11500875, OS:11499068, OS:11498539, OS:11500490, OS:11498110, OS:11497430,
OS:11495656 and OS:11445851. Initialize a bunch of uninitialized local variables
used as out params.  This doesn't fix existing bugs but is good code hygiene
and can prevent future issues.

Fixed a couple more.
