### PR TITLE
Keep the same register allocation path for debug and non-debug mode in generators

### DIFF
--- a/test/DebuggerCommon/AsyncDynamicAttach.js
+++ b/test/DebuggerCommon/AsyncDynamicAttach.js
@@ -1,0 +1,22 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function attach(f) {
+  (function (r) {
+    WScript.Attach(r);
+  })(f);
+}
+
+async function mainTest(notAttachCall) {
+    if (notAttachCall) {
+        for (let i = 0; i < 1; ++i) {
+            await attach(mainTest);
+        }
+    } else {
+        var i = 10;/**bp:locals()**/
+    }
+}
+mainTest(true);
+WScript.Echo("PASSED");

--- a/test/DebuggerCommon/AsyncDynamicAttach.js.dbg.baseline
+++ b/test/DebuggerCommon/AsyncDynamicAttach.js.dbg.baseline
@@ -1,0 +1,10 @@
+[
+  {
+    "this": "Object {...}",
+    "arguments": "Object {...}",
+    "locals": {
+      "notAttachCall": "undefined undefined",
+      "i": "undefined undefined"
+    }
+  }
+]

--- a/test/DebuggerCommon/rlexe.xml
+++ b/test/DebuggerCommon/rlexe.xml
@@ -1348,4 +1348,11 @@
       <compile-flags>-debuglaunch -dbgbaseline:promisedisplay.js.dbg.baseline</compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>AsyncDynamicAttach.js</files>
+      <compile-flags>-dbgbaseline:AsyncDynamicAttach.js.dbg.baseline</compile-flags>
+      <tags>exclude_dynapogo</tags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
In debug mode we have different register allocation logic for inner scope slots. In case of generators if the debugger is attached dynamically before the generator completes then this can cause issues. Current fix is to avoid the different paths for register allocation.
