### PR TITLE
OS: 12891717 Missing conversion for CopyOnAccess Array on ForInObjectEnumerator

### DIFF
--- a/lib/Runtime/Library/JavascriptArray.cpp
+++ b/lib/Runtime/Library/JavascriptArray.cpp
@@ -12143,6 +12143,10 @@ Case0:
 
     JavascriptEnumerator * JavascriptArray::GetIndexEnumerator(EnumeratorFlags flags, ScriptContext* requestContext)
     {
+#if ENABLE_COPYONACCESS_ARRAY
+        JavascriptLibrary::CheckAndConvertCopyOnAccessNativeIntArray<Var>(this);
+#endif
+
         if (!!(flags & EnumeratorFlags::SnapShotSemantics))
         {
             return RecyclerNew(GetRecycler(), JavascriptArrayIndexSnapshotEnumerator, this, flags, requestContext);
@@ -12152,6 +12156,9 @@ Case0:
 
     BOOL JavascriptArray::GetNonIndexEnumerator(JavascriptStaticEnumerator * enumerator, ScriptContext* requestContext)
     {
+#if ENABLE_COPYONACCESS_ARRAY
+        JavascriptLibrary::CheckAndConvertCopyOnAccessNativeIntArray<Var>(this);
+#endif
         return enumerator->Initialize(nullptr, nullptr, this, EnumeratorFlags::SnapShotSemantics, requestContext, nullptr);
     }
 
@@ -12559,6 +12566,9 @@ Case0:
 
     BOOL JavascriptArray::GetEnumerator(JavascriptStaticEnumerator * enumerator, EnumeratorFlags flags, ScriptContext* requestContext, ForInCache * forInCache)
     {
+#if ENABLE_COPYONACCESS_ARRAY
+        JavascriptLibrary::CheckAndConvertCopyOnAccessNativeIntArray<Var>(this);
+#endif
         return enumerator->Initialize(nullptr, this, this, flags, requestContext, forInCache);
     }
 

--- a/test/Array/CopyOnAccessArray_bugs.baseline
+++ b/test/Array/CopyOnAccessArray_bugs.baseline
@@ -34,4 +34,10 @@ PASSED
 PASSED
 *** Running test #14 (13): Array.of
 PASSED
-Summary of tests: total executed: 14; passed: 14; failed: 0
+*** Running test #15 (14): CopyOnAccess in ForInEnumerator - native ints
+PASSED
+*** Running test #16 (15): CopyOnAccess in ForInEnumerator - native floats
+PASSED
+*** Running test #17 (16): CopyOnAccess in for..of - native ints
+PASSED
+Summary of tests: total executed: 17; passed: 17; failed: 0

--- a/test/Array/CopyOnAccessArray_bugs.js
+++ b/test/Array/CopyOnAccessArray_bugs.js
@@ -148,6 +148,63 @@ var tests = [
             var a = Array.of.call(constructor);
             assert.areEqual(a, [], "Array.of.call with custom constructor");
         }
-    }
+    },
+    {
+        name: "CopyOnAccess in ForInEnumerator - native ints",
+        body: function ()
+        {
+            eval("[1,1,1,1,1,1];".repeat(0x4));
+            x=[1,3,3,4,5,6,7];
+            var getPropCalled = false;
+            var handler = {
+                getPrototypeOf: function(target, name){
+                    getPropCalled = true;
+                    return x;
+                }
+            };
+            var s= [1,5,3,4,5,6,8,9,10,11,12];
+            p = new Proxy(s, handler);
+            for(var x1 in p) { };
+            assert.isTrue(getPropCalled, "for-in enumerator should call getProp from prototype");
+            assert.areEqual(x1,'10', "enumerator should complete");
+        }
+    },
+    {
+        name: "CopyOnAccess in ForInEnumerator - native floats",
+        body: function ()
+        {
+            eval("[1,1,1,1,1,1];".repeat(0x4));
+            x=[1.1,3.1,3.1,4.1,5.1,6.1,7.1];
+            var getPropCalled = false;
+            var handler = {
+                getPrototypeOf: function(target, name){
+                    getPropCalled = true;
+                    return x;
+                }
+            };
+            var s= [1.1,5.1,3.1,4.1,5.1,6.1,8.1,9.1,10.1,11.1,12.1];
+            p = new Proxy(s, handler);
+            for(var x1 in p) { };
+            assert.isTrue(getPropCalled, "for-in enumerator should call getProp from prototype");
+            assert.areEqual(x1,'10', "enumerator should complete");
+        }
+    },
+    {
+        name: "CopyOnAccess in for..of - native ints",
+        body: function ()
+        {
+            eval("[1,1,1,1,1,1];".repeat(0x4));
+            x=[1,3,3,4,5,6,7];
+            var handler = {
+                getPrototypeOf: function(target, name){
+                    return x;
+                }
+            };
+            var s= [1,5,3,4,5,6,8,9,10,11,12];
+            p = new Proxy(s, handler);
+            for(var x1 of p) { };
+            assert.areEqual(x1, 12, "enumerator should complete");
+        }
+    },
 ];
 testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });


### PR DESCRIPTION
We get copyonaccessnativeintarray when ForInObjectEnumerator. This happens when we are at proxy. Fixed that by converting that array to normal native int array.
