### PR TITLE
Ensure that LdHeapArguments is the first thing in the bytecode after recording constants

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -1982,17 +1982,6 @@ void ByteCodeGenerator::LoadAllConstants(FuncInfo *funcInfo)
         m_writer.RecordFrameDisplayRegister(funcInfo->frameDisplayRegister);
     }
 
-    // new.target may be used to construct the 'this' register so make sure to load it first
-    if (funcInfo->newTargetRegister != Js::Constants::NoRegister)
-    {
-        this->LoadNewTargetObject(funcInfo);
-    }
-
-    if (funcInfo->thisPointerRegister != Js::Constants::NoRegister)
-    {
-        this->LoadThisObject(funcInfo, thisLoadedFromParams);
-    }
-
     this->RecordAllIntConstants(funcInfo);
     this->RecordAllStrConstants(funcInfo);
     this->RecordAllStringTemplateCallsiteConstants(funcInfo);
@@ -2001,6 +1990,11 @@ void ByteCodeGenerator::LoadAllConstants(FuncInfo *funcInfo)
     {
         byteCodeFunction->RecordFloatConstant(byteCodeFunction->MapRegSlot(location), d);
     });
+
+    // WARNING !!!
+    // DO NOT emit any bytecode before loading the heap arguments. This is because those opcodes may bail 
+    // out (unlikely, since opcodes emitted in this function should not correspond to user code, but possible)
+    // and the Jit assumes that there cannot be any bailouts before LdHeapArguments (or its equivalent)
 
     if (funcInfo->GetHasArguments())
     {
@@ -2024,6 +2018,25 @@ void ByteCodeGenerator::LoadAllConstants(FuncInfo *funcInfo)
             GetFormalArgsArray(this, funcInfo, propIds);
             byteCodeFunction->SetPropertyIdsOfFormals(propIds);
         }
+    }
+
+    // Class constructors do not have a [[call]] slot but we don't implement a generic way to express this.
+    // What we do is emit a check for the new flag here. If we don't have CallFlags_New set, the opcode will throw.
+    // We need to do this before emitting 'this' since the base class constructor will try to construct a new object.
+    if (funcInfo->IsClassConstructor())
+    {
+        m_writer.Empty(Js::OpCode::ChkNewCallFlag);
+    }
+
+    // new.target may be used to construct the 'this' register so make sure to load it first
+    if (funcInfo->newTargetRegister != Js::Constants::NoRegister)
+    {
+        this->LoadNewTargetObject(funcInfo);
+    }
+
+    if (funcInfo->thisPointerRegister != Js::Constants::NoRegister)
+    {
+        this->LoadThisObject(funcInfo, thisLoadedFromParams);
     }
 
     //
@@ -3218,14 +3231,6 @@ void ByteCodeGenerator::EmitOneFunction(ParseNode *pnode)
         this->PushFuncInfo(_u("EmitOneFunction"), funcInfo);
 
         this->inPrologue = true;
-
-        // Class constructors do not have a [[call]] slot but we don't implement a generic way to express this.
-        // What we do is emit a check for the new flag here. If we don't have CallFlags_New set, the opcode will throw.
-        // We need to do this before emitting 'this' since the base class constructor will try to construct a new object.
-        if (funcInfo->IsClassConstructor())
-        {
-            m_writer.Empty(Js::OpCode::ChkNewCallFlag);
-        }
 
         Scope* paramScope = funcInfo->GetParamScope();
         Scope* bodyScope = funcInfo->GetBodyScope();

--- a/test/es6/bug-OS10595959.js
+++ b/test/es6/bug-OS10595959.js
@@ -1,0 +1,19 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+class BaseClass {
+}
+var FloatArr0 = [];
+var VarArr0 = Array();
+class class1 extends BaseClass {
+  constructor(argMath24 = 1577048671 ? f32[(e /= arguments[15] ? func0.call(arrObj0) : 'caller') & 255] : typeof a == 'string') {
+    super();
+  }
+}
+for (var v3 = 0; v3<10; v3++) {
+  FloatArr0.push(new class1(VarArr0, '$M+!,($9($.)!wm'));
+}
+
+print("Passed");

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -1450,4 +1450,11 @@
     <tags>BugFix</tags>
   </default>
 </test>
+<test>
+  <default>
+    <files>bug-OS10595959.js</files>
+    <compile-flags>-maxsimplejitruncount:1 -maxinterpretcount:1 -off:stackargopt -stress:bailonnoprofile -args summary -endargs</compile-flags>
+    <tags>BugFix</tags>
+  </default>
+</test>
 </regress-exe>


### PR DESCRIPTION
The Jit stack args optimization assumes that there will be no bailout before a LdHeapArguments (or equivalent) opcode. In this case, we had some class constructor related opcodes emitted before LdHeapArguments and when stressing bailouts, we were crashing. Note that the class constructor related opcodes will not get bailouts associated with them without any stress flag. But, its still good to maintain the jit assumption