### PR TITLE
Bug 11712101: Hoist CheckObjType out of loops only when the operand's containing object type is also invariant

### DIFF
--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -16197,7 +16197,7 @@ GlobOpt::OptIsInvariant(
         }
         break;
     case Js::OpCode::CheckObjType:
-        // Bug 11712101: If the operand is a field, ensure that its containing object type is invariant 
+        // Bug 11712101: If the operand is a field, ensure that its containing object type is invariant
         // before hoisting -- that is, don't hoist a CheckObjType over a DeleteFld on that object.
         // (CheckObjType only checks the operand and its immediate parent, so we don't need to go
         // any farther up the object graph.)

--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -16196,6 +16196,22 @@ GlobOpt::OptIsInvariant(
             allowNonPrimitives = true;
         }
         break;
+    case Js::OpCode::CheckObjType:
+        // Bug 11712101: If the operand is a field, ensure that its containing object type is invariant 
+        // before hoisting -- that is, don't hoist a CheckObjType over a DeleteFld on that object.
+        // (CheckObjType only checks the operand and its immediate parent, so we don't need to go
+        // any farther up the object graph.)
+        Assert(instr->GetSrc1());
+        PropertySym *propertySym = instr->GetSrc1()->AsPropertySymOpnd()->GetPropertySym();
+        Assert(propertySym != nullptr);  // QUESTION FOR REVIEWER: Can this ever be false?
+        if (propertySym->HasObjectTypeSym()) {
+            StackSym *objectTypeSym = propertySym->GetObjectTypeSym();
+            if (!this->OptIsInvariant(objectTypeSym, block, loop, this->CurrentBlockData()->FindValue(objectTypeSym), true, true)) {
+                return false;
+            }
+        }
+
+        break;
     }
 
     IR::Opnd *dst = instr->GetDst();

--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -16203,7 +16203,6 @@ GlobOpt::OptIsInvariant(
         // any farther up the object graph.)
         Assert(instr->GetSrc1());
         PropertySym *propertySym = instr->GetSrc1()->AsPropertySymOpnd()->GetPropertySym();
-        Assert(propertySym != nullptr);  // QUESTION FOR REVIEWER: Can this ever be false?
         if (propertySym->HasObjectTypeSym()) {
             StackSym *objectTypeSym = propertySym->GetObjectTypeSym();
             if (!this->OptIsInvariant(objectTypeSym, block, loop, this->CurrentBlockData()->FindValue(objectTypeSym), true, true)) {

--- a/test/Optimizer/HoistCheckObjType.baseline
+++ b/test/Optimizer/HoistCheckObjType.baseline
@@ -1,0 +1,1 @@
+[object Object],[object Object],[object Object]

--- a/test/Optimizer/HoistCheckObjType.js
+++ b/test/Optimizer/HoistCheckObjType.js
@@ -1,0 +1,30 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+var GiantPrintArray = [];
+function makeArrayLength() {
+}
+var obj0 = {};
+var obj1 = {};
+var arrObj0 = {};
+var func3 = function () {
+  protoObj0._x = {};
+  for (var v0 = 0; v0 < 3; v0++) {
+    delete arrObj0.length;
+    protoObj0.length = protoObj0._x;
+  }
+  GiantPrintArray.push(arrObj0.length);
+};
+obj0.method1 = func3;
+obj1.method0 = obj0.method1;
+obj1.method1 = obj1.method0;
+arrObj0.length = makeArrayLength();
+protoObj0 = arrObj0;
+for (var _strvar13 in obj1) {
+  obj0.method1();
+}
+var uniqobj3 = [obj1];
+uniqobj3[0].method1();
+WScript.Echo(GiantPrintArray);

--- a/test/Optimizer/rlexe.xml
+++ b/test/Optimizer/rlexe.xml
@@ -1417,4 +1417,11 @@
       <compile-flags>-lic:1 -off:simplejit -bgjit-</compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>HoistCheckObjType.js</files>
+      <baseline>HoistCheckObjType.baseline</baseline>
+      <compile-flags>-PrintSystemException -CheckMemoryLeak- -maxinterpretcount:1 -maxsimplejitruncount:1 -MinMemOpCount:0 -werexceptionsupport -force:rejit -off:ArrayCheckHoist -force:atom</compile-flags>
+    </default>
+  </test>
 </regress-exe>

--- a/test/Optimizer/rlexe.xml
+++ b/test/Optimizer/rlexe.xml
@@ -1421,7 +1421,7 @@
     <default>
       <files>HoistCheckObjType.js</files>
       <baseline>HoistCheckObjType.baseline</baseline>
-      <compile-flags>-PrintSystemException -CheckMemoryLeak- -maxinterpretcount:1 -maxsimplejitruncount:1 -MinMemOpCount:0 -werexceptionsupport -force:rejit -off:ArrayCheckHoist -force:atom</compile-flags>
+      <compile-flags>-maxinterpretcount:1 -maxsimplejitruncount:1</compile-flags>
     </default>
   </test>
 </regress-exe>


### PR DESCRIPTION
Check object type of argument to CheckObjType before hoisting it out of a loop, to avoid hoisting it over a DeleteFld that invalidates the type.