### PR TITLE
Fixing ninja builds as part of parent make

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -604,13 +604,17 @@ cmake $CMAKE_GEN $CC_PREFIX $ICU_PATH $LTO $STATIC_LIBRARY $ARCH $TARGET_OS \
 _RET=$?
 if [[ $? == 0 ]]; then
     if [[ $MAKE != 0 ]]; then
-        # $MFLAGS comes from host `make` process. Sub `make` process needs this (recursional make runs)
-        TEST_MFLAGS="${MFLAGS}*!"
-        if [[ $TEST_MFLAGS != "*!" ]]; then
-            # Get -j flag from the host
-            MULTICORE_BUILD=""
+        if [[ $MAKE != 'ninja' ]]; then
+            # $MFLAGS comes from host `make` process. Sub `make` process needs this (recursional make runs)
+            TEST_MFLAGS="${MFLAGS}*!"
+            if [[ $TEST_MFLAGS != "*!" ]]; then
+                # Get -j flag from the host
+                MULTICORE_BUILD=""
+            fi
+            $MAKE $MFLAGS $MULTICORE_BUILD $_VERBOSE $WB_TARGET 2>&1 | tee build.log
+        else
+            $MAKE $MULTICORE_BUILD $_VERBOSE $WB_TARGET 2>&1 | tee build.log
         fi
-        $MAKE $MFLAGS $MULTICORE_BUILD $_VERBOSE $WB_TARGET 2>&1 | tee build.log
         _RET=${PIPESTATUS[0]}
     else
         echo "Visit given folder above for xcode project file ----^"


### PR DESCRIPTION
When trying to use ninja builds as part of node-chakracore,
the parent make process was passing in flags like -r to the child
'make' process, which was actually ninja. The -r flag is not
understood by ninja, so it bails out and fails the build.

If we are building using ninja, then we shouldn't pass on flags
from make.