### PR TITLE
fix minor out of bound read (JavascriptString::ToInteger)

### DIFF
--- a/lib/Runtime/Library/JavascriptString.cpp
+++ b/lib/Runtime/Library/JavascriptString.cpp
@@ -2837,17 +2837,18 @@ case_2:
         const char16* pchEnd =  pchStart + m_charLength;
         const char16 *pch = this->GetScriptContext()->GetCharClassifier()->SkipWhiteSpace(pchStart, pchEnd);
         bool isNegative = false;
-        switch (*pch)
+
+        if (pch < pchEnd)
         {
-        case '-':
-            isNegative = true;
-            // Fall through.
-        case '+':
-            if(pch < pchEnd)
+            switch (*pch)
             {
+            case '-':
+                isNegative = true;
+                // Fall through.
+            case '+':
                 pch++;
+                break;
             }
-            break;
         }
 
         if (0 == radix)
@@ -2856,7 +2857,7 @@ case_2:
             {
                 radix = 10;
             }
-            else if (('x' == pch[1] || 'X' == pch[1]) && pchEnd - pch >= 2)
+            else if (pchEnd - pch >= 2 && ('x' == pch[1] || 'X' == pch[1]))
             {
                 radix = 16;
                 pch += 2;
@@ -2870,7 +2871,7 @@ case_2:
         }
         else if (16 == radix)
         {
-            if('0' == pch[0] && ('x' == pch[1] || 'X' == pch[1]) && pchEnd - pch >= 2)
+            if(pchEnd - pch >= 2 && '0' == pch[0] && ('x' == pch[1] || 'X' == pch[1]))
             {
                 pch += 2;
             }


### PR DESCRIPTION
Reorder checks to avoid minor out of bound read.

Fix OS#13058871