### PR TITLE
OS# 12999605: Fix deleting of DebugContext

### DIFF
--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -481,6 +481,13 @@ namespace Js
         }
 #endif
 
+        if (this->debugContext != nullptr)
+        {
+            Assert(this->debugContext->IsClosed());
+            HeapDelete(this->debugContext);
+            this->debugContext = nullptr;
+        }
+
 #if ENABLE_NATIVE_CODEGEN
         if (this->nativeCodeGen != nullptr)
         {
@@ -664,21 +671,20 @@ namespace Js
 #endif
 
         this->EnsureClearDebugDocument();
+
         if (this->debugContext != nullptr)
         {
-            if(this->debugContext->GetProbeContainer())
+            if (this->debugContext->GetProbeContainer() != nullptr)
             {
-                this->debugContext->GetProbeContainer()->UninstallInlineBreakpointProbe(NULL);
+                this->debugContext->GetProbeContainer()->UninstallInlineBreakpointProbe(nullptr);
                 this->debugContext->GetProbeContainer()->UninstallDebuggerScriptOptionCallback();
             }
 
-            // Guard the closing and deleting of DebugContext as in meantime PDM might
-            // call OnBreakFlagChange
+            // Guard the closing DebugContext as in meantime PDM might call OnBreakFlagChange
             AutoCriticalSection autoDebugContextCloseCS(&debugContextCloseCS);
-            DebugContext* tempDebugContext = this->debugContext;
-            this->debugContext = nullptr;
-            tempDebugContext->Close();
-            HeapDelete(tempDebugContext);
+            this->debugContext->Close();
+            // Not deleting debugContext here as Close above will clear all memory debugContext allocated.
+            // Actual deletion of debugContext will happen in ScriptContext destructor
         }
 
         if (this->diagnosticArena != nullptr)
@@ -5773,9 +5779,23 @@ void ScriptContext::RegisterPrototypeChainEnsuredToHaveOnlyWritableDataPropertie
     }
 #endif
 
+    DebugContext* ScriptContext::GetDebugContext() const
+    {
+        Assert(this->debugContext != nullptr);
+
+        if (this->debugContext->IsClosed())
+        {
+            // Once DebugContext is closed we should assume it's not there
+            // The actual deletion of debugContext happens in ScriptContext destructor
+            return nullptr;
+        }
+
+        return this->debugContext;
+    }
+
     bool ScriptContext::IsScriptContextInNonDebugMode() const
     {
-        if (this->debugContext != nullptr)
+        if (this->GetDebugContext() != nullptr)
         {
             return this->GetDebugContext()->IsDebugContextInNonDebugMode();
         }
@@ -5784,7 +5804,7 @@ void ScriptContext::RegisterPrototypeChainEnsuredToHaveOnlyWritableDataPropertie
 
     bool ScriptContext::IsScriptContextInDebugMode() const
     {
-        if (this->debugContext != nullptr)
+        if (this->GetDebugContext() != nullptr)
         {
             return this->GetDebugContext()->IsDebugContextInDebugMode();
         }
@@ -5793,7 +5813,7 @@ void ScriptContext::RegisterPrototypeChainEnsuredToHaveOnlyWritableDataPropertie
 
     bool ScriptContext::IsScriptContextInSourceRundownOrDebugMode() const
     {
-        if (this->debugContext != nullptr)
+        if (this->GetDebugContext() != nullptr)
         {
             return this->GetDebugContext()->IsDebugContextInSourceRundownOrDebugMode();
         }
@@ -5802,7 +5822,7 @@ void ScriptContext::RegisterPrototypeChainEnsuredToHaveOnlyWritableDataPropertie
 
     bool ScriptContext::IsDebuggerRecording() const
     {
-        if (this->debugContext != nullptr)
+        if (this->GetDebugContext() != nullptr)
         {
             return this->GetDebugContext()->IsDebuggerRecording();
         }
@@ -5811,7 +5831,7 @@ void ScriptContext::RegisterPrototypeChainEnsuredToHaveOnlyWritableDataPropertie
 
     void ScriptContext::SetIsDebuggerRecording(bool isDebuggerRecording)
     {
-        if (this->debugContext != nullptr)
+        if (this->GetDebugContext() != nullptr)
         {
             this->GetDebugContext()->SetIsDebuggerRecording(isDebuggerRecording);
         }

--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -993,7 +993,7 @@ private:
 #endif
 
         bool IsDebugContextInitialized() const { return this->isDebugContextInitialized; }
-        DebugContext* GetDebugContext() const { return this->debugContext; }
+        DebugContext* GetDebugContext() const;
         CriticalSection* GetDebugContextCloseCS() { return &debugContextCloseCS; }
 
         uint callCount;

--- a/lib/Runtime/Debug/DebugContext.cpp
+++ b/lib/Runtime/Debug/DebugContext.cpp
@@ -10,6 +10,7 @@ namespace Js
         scriptContext(scriptContext),
         hostDebugContext(nullptr),
         diagProbesContainer(nullptr),
+        isClosed(false),
         debuggerMode(DebuggerMode::NotDebugging),
         isDebuggerRecording(true)
     {
@@ -18,7 +19,7 @@ namespace Js
 
     DebugContext::~DebugContext()
     {
-        Assert(this->scriptContext == nullptr);
+        Assert(this->scriptContext != nullptr);
         Assert(this->hostDebugContext == nullptr);
         Assert(this->diagProbesContainer == nullptr);
     }
@@ -32,8 +33,18 @@ namespace Js
 
     void DebugContext::Close()
     {
+        if (this->isClosed)
+        {
+            return;
+        }
+
+        AssertMsg(this->scriptContext->IsActuallyClosed(), "Closing DebugContext before ScriptContext close might have consequences");
+
+        this->isClosed = true;
+
+        // Release all memory and do all cleanup. No operation should be done after isClosed is set
+
         Assert(this->scriptContext != nullptr);
-        this->scriptContext = nullptr;
 
         if (this->diagProbesContainer != nullptr)
         {
@@ -49,6 +60,11 @@ namespace Js
         }
     }
 
+    bool DebugContext::IsSelfOrScriptContextClosed() const
+    {
+        return (this->IsClosed() || this->scriptContext->IsClosed());
+    }
+
     void DebugContext::SetHostDebugContext(HostDebugContext * hostDebugContext)
     {
         Assert(this->hostDebugContext == nullptr);
@@ -59,10 +75,13 @@ namespace Js
 
     bool DebugContext::CanRegisterFunction() const
     {
-        if (this->hostDebugContext == nullptr || this->scriptContext == nullptr || this->scriptContext->IsClosed() || this->IsDebugContextInNonDebugMode())
+        if (this->IsSelfOrScriptContextClosed() ||
+            this->hostDebugContext == nullptr ||
+            this->IsDebugContextInNonDebugMode())
         {
             return false;
         }
+
         return true;
     }
 
@@ -170,14 +189,10 @@ namespace Js
             return hr;
         }
 
-        // Cache ScriptContext as multiple calls below can go out of engine and ScriptContext can be closed which will delete DebugContext
-        Js::ScriptContext* cachedScriptContext = this->scriptContext;
-
         utf8SourceInfoList->MapUntil([&](int index, Js::Utf8SourceInfo * sourceInfo) -> bool
         {
-            if (cachedScriptContext->IsClosed())
+            if (this->IsSelfOrScriptContextClosed())
             {
-                // ScriptContext could be closed in previous iteration
                 hr = E_FAIL;
                 return true;
             }
@@ -236,9 +251,8 @@ namespace Js
             bool fHasDoneSourceRundown = false;
             for (int i = 0; i < pFunctionsToRegister->Count(); i++)
             {
-                if (cachedScriptContext->IsClosed())
+                if (this->IsSelfOrScriptContextClosed())
                 {
-                    // ScriptContext could be closed in previous iteration
                     hr = E_FAIL;
                     return true;
                 }
@@ -251,7 +265,7 @@ namespace Js
 
                 if (shouldReparseFunctions)
                 {
-                    BEGIN_JS_RUNTIME_CALL_EX_AND_TRANSLATE_EXCEPTION_AND_ERROROBJECT_TO_HRESULT_NESTED(cachedScriptContext, false)
+                    BEGIN_JS_RUNTIME_CALL_EX_AND_TRANSLATE_EXCEPTION_AND_ERROROBJECT_TO_HRESULT_NESTED(this->scriptContext, false)
                     {
                         functionInfo->GetParseableFunctionInfo()->Parse();
                         // This is the first call to the function, ensure dynamic profile info
@@ -268,7 +282,7 @@ namespace Js
                 // Parsing the function may change its FunctionProxy.
                 Js::ParseableFunctionInfo *parseableFunctionInfo = functionInfo->GetParseableFunctionInfo();
 
-                if (!fHasDoneSourceRundown && shouldPerformSourceRundown && !cachedScriptContext->IsClosed())
+                if (!fHasDoneSourceRundown && shouldPerformSourceRundown && !this->IsSelfOrScriptContextClosed())
                 {
                     BEGIN_TRANSLATE_OOM_TO_HRESULT_NESTED
                     {
@@ -296,13 +310,13 @@ namespace Js
             return false;
         });
 
-        if (!cachedScriptContext->IsClosed())
+        if (!this->IsSelfOrScriptContextClosed())
         {
-            if (shouldPerformSourceRundown && cachedScriptContext->HaveCalleeSources() && this->hostDebugContext != nullptr)
+            if (shouldPerformSourceRundown && this->scriptContext->HaveCalleeSources() && this->hostDebugContext != nullptr)
             {
-                cachedScriptContext->MapCalleeSources([=](Js::Utf8SourceInfo* calleeSourceInfo)
+                this->scriptContext->MapCalleeSources([=](Js::Utf8SourceInfo* calleeSourceInfo)
                 {
-                    if (!cachedScriptContext->IsClosed())
+                    if (!this->IsSelfOrScriptContextClosed())
                     {
                         // This call goes out of engine
                         this->hostDebugContext->ReParentToCaller(calleeSourceInfo);

--- a/lib/Runtime/Debug/DebugContext.h
+++ b/lib/Runtime/Debug/DebugContext.h
@@ -47,6 +47,8 @@ namespace Js
         void Initialize();
         HRESULT RundownSourcesAndReparse(bool shouldPerformSourceRundown, bool shouldReparseFunctions);
         void RegisterFunction(Js::ParseableFunctionInfo * func, LPCWSTR title);
+        bool IsClosed() const { return this->isClosed; };
+        bool IsSelfOrScriptContextClosed() const;
         void Close();
         void SetHostDebugContext(HostDebugContext * hostDebugContext);
 
@@ -61,15 +63,15 @@ namespace Js
         void SetIsDebuggerRecording(bool isDebuggerRecording) { this->isDebuggerRecording = isDebuggerRecording; }
 
         ProbeContainer* GetProbeContainer() const { return this->diagProbesContainer; }
-
-        HostDebugContext * GetHostDebugContext() const { return hostDebugContext; }
+        HostDebugContext * GetHostDebugContext() const { return this->hostDebugContext; }
 
     private:
         ScriptContext * scriptContext;
         HostDebugContext* hostDebugContext;
         ProbeContainer* diagProbesContainer;
         DebuggerMode debuggerMode;
-        bool isDebuggerRecording;
+        bool isClosed : 1;
+        bool isDebuggerRecording : 1;
 
         // Private Functions
         void WalkAndAddUtf8SourceInfo(Js::Utf8SourceInfo* sourceInfo, JsUtil::List<Js::Utf8SourceInfo *, Recycler, false, Js::CopyRemovePolicy, RecyclerPointerComparer> *utf8SourceInfoList);


### PR DESCRIPTION
Don't delete debugContext when ScriptContext is closed as we might be
in middle of a PDM call. When ScriptContext is closed delete all memory
allocated by debugContext and mark it as closed. Delete debugContext in
ScriptContext destructor.
