### PR TITLE
WASM - improve some error messages

### DIFF
--- a/lib/Parser/rterrors.h
+++ b/lib/Parser/rterrors.h
@@ -402,7 +402,9 @@ RT_ERROR_MSG(WASMERR_MemoryCreateFailed, 7024, "", "Failed to create WebAssembly
 RT_ERROR_MSG(WASMERR_NeedInstanceObject, 7025, "%s is not a WebAssembly.Instance", "WebAssembly.Instance object expected", kjstWebAssemblyRuntimeError, 0)
 
 RT_ERROR_MSG(WASMERR_InvalidImportModule, 7026, "Import module '%s' is invalid", "Import module is invalid", kjstTypeError, 0)
-RT_ERROR_MSG(WASMERR_InvalidImport, 7027, "Import '%s.%s' is invalid", "Import is invalid", kjstTypeError, 0)
+RT_ERROR_MSG(WASMERR_InvalidImport, 7027, "Import '%s.%s' is invalid. Expected type %s", "Import is invalid", kjstTypeError, 0)
+RT_ERROR_MSG(WASMERR_InvalidInitialSize, 7028, "Imported %s initial size (%u) is smaller than declared (%u)", "Invalid initial size", kjstWebAssemblyLinkError, 0)
+RT_ERROR_MSG(WASMERR_InvalidMaximumSize, 7029, "Imported %s maximum size (%u) is larger than declared (%u)", "Invalid initial size", kjstWebAssemblyLinkError, 0)
 
 // Wabt Errors
 RT_ERROR_MSG(WABTERR_WabtError, 7200, "%s", "Wabt Error.", kjstTypeError, 0)

--- a/lib/Parser/rterrors.h
+++ b/lib/Parser/rterrors.h
@@ -380,7 +380,7 @@ RT_ERROR_MSG(WASMERR_NeedBufferSource, 7002, "%s is not a BufferSource", "Buffer
 RT_ERROR_MSG(WASMERR_NeedModule, 7003, "%s is not a WebAssembly.Module", "WebAssembly.Module expected", kjstTypeError, 0)
 RT_ERROR_MSG(WASMERR_DataSegOutOfRange, 7004, "", "Data segment is out of range", kjstWebAssemblyLinkError, 0)
 RT_ERROR_MSG(WASMERR_MutableGlobal, 7005, "", "Cannot export mutable global", kjstTypeError, 0)
-RT_ERROR_MSG(WASMERR_InvalidImport, 7006, "", "Import is invalid", kjstTypeError, 0)
+ // 7006 free
 RT_ERROR_MSG(WASMERR_InvalidGlobalRef, 7007, "", "Global initialization does not support forward reference", kjstTypeError, 0)
 RT_ERROR_MSG(WASMERR_NeedMemoryObject, 7008, "%s is not a WebAssembly.Memory", "WebAssembly.Memory object expected", kjstWebAssemblyLinkError, 0)
 RT_ERROR_MSG(WASMERR_InvalidTypeConversion, 7009, "Invalid WebAssembly type conversion %s to %s", "Invalid WebAssembly type conversion", kjstTypeError, 0)
@@ -400,6 +400,9 @@ RT_ERROR_MSG(WASMERR_BufferGrowOnly, 7022, "", "WebAssembly.Memory can only grow
 RT_ERROR_MSG(WASMERR_LinkSignatureMismatch, 7023, "Cannot link import %s in link table due to a signature mismatch", "Function called with invalid signature", kjstWebAssemblyRuntimeError, 0)
 RT_ERROR_MSG(WASMERR_MemoryCreateFailed, 7024, "", "Failed to create WebAssembly.Memory", kjstTypeError, 0)
 RT_ERROR_MSG(WASMERR_NeedInstanceObject, 7025, "%s is not a WebAssembly.Instance", "WebAssembly.Instance object expected", kjstWebAssemblyRuntimeError, 0)
+
+RT_ERROR_MSG(WASMERR_InvalidImportModule, 7026, "Import module '%s' is invalid", "Import module is invalid", kjstTypeError, 0)
+RT_ERROR_MSG(WASMERR_InvalidImport, 7027, "Import '%s.%s' is invalid", "Import is invalid", kjstTypeError, 0)
 
 // Wabt Errors
 RT_ERROR_MSG(WABTERR_WabtError, 7200, "%s", "Wabt Error.", kjstTypeError, 0)

--- a/lib/Runtime/Library/WasmLibrary.cpp
+++ b/lib/Runtime/Library/WasmLibrary.cpp
@@ -120,15 +120,13 @@ Js::JavascriptMethod Js::WasmLibrary::WasmDeferredParseEntryPoint(Js::AsmJsScrip
         catch (Wasm::WasmCompilationException& ex)
         {
             char16* originalMessage = ex.ReleaseErrorMessage();
-            intptr_t offset = readerInfo->m_module->GetReader()->GetCurrentOffset();
-            intptr_t start = readerInfo->m_funcInfo->m_readerInfo.startOffset;
-            uint32 size = readerInfo->m_funcInfo->m_readerInfo.size;
+            Wasm::BinaryLocation location = readerInfo->m_module->GetReader()->GetCurrentLocation();
 
             Wasm::WasmCompilationException newEx(
-                _u("function %s at offset %d/%d: %s"),
+                _u("function %s at offset %u/%u (0x%x/0x%x): %s"),
                 body->GetDisplayName(),
-                offset - start,
-                size,
+                location.offset, location.size,
+                location.offset, location.size,
                 originalMessage
             );
             SysFreeString(originalMessage);

--- a/lib/Runtime/Library/WebAssemblyModule.cpp
+++ b/lib/Runtime/Library/WebAssemblyModule.cpp
@@ -244,16 +244,14 @@ WebAssemblyModule::CreateModule(
         BSTR originalMessage = ex.GetTempErrorMessageRef();
         if (currentBody != nullptr)
         {
-            intptr_t offset = readerInfo->m_module->GetReader()->GetCurrentOffset();
-            intptr_t start = readerInfo->m_funcInfo->m_readerInfo.startOffset;
-            uint32 size = readerInfo->m_funcInfo->m_readerInfo.size;
+            Wasm::BinaryLocation location = readerInfo->m_module->GetReader()->GetCurrentLocation();
 
             originalMessage = ex.ReleaseErrorMessage();
             ex = Wasm::WasmCompilationException(
-                _u("function %s at offset %d/%d: %s"),
+                _u("function %s at offset %u/%u (0x%x/0x%x): %s"),
                 currentBody->GetDisplayName(),
-                offset - start,
-                size,
+                location.offset, location.size,
+                location.offset, location.size,
                 originalMessage
             );
             currentBody->GetAsmJsFunctionInfo()->SetWasmReaderInfo(nullptr);
@@ -417,12 +415,6 @@ WebAssemblyTable *
 WebAssemblyModule::CreateTable() const
 {
     return WebAssemblyTable::Create(m_tableInitSize, m_tableMaxSize, GetScriptContext());
-}
-
-bool
-WebAssemblyModule::IsValidTableImport(const WebAssemblyTable * table) const
-{
-    return m_tableImport && table->GetInitialLength() >= m_tableInitSize && table->GetMaximumLength() <= m_tableMaxSize;
 }
 
 uint32

--- a/lib/Runtime/Library/WebAssemblyModule.h
+++ b/lib/Runtime/Library/WebAssemblyModule.h
@@ -79,7 +79,8 @@ public:
     WebAssemblyTable * CreateTable() const;
     bool HasTable() const { return m_hasTable; }
     bool HasTableImport() const { return m_tableImport != nullptr; }
-    bool IsValidTableImport(const WebAssemblyTable * table) const;
+    uint32 GetTableInitSize() const { return m_tableInitSize; }
+    uint32 GetTableMaxSize() const { return m_tableMaxSize; }
 
     uint GetWasmFunctionCount() const;
     Wasm::WasmFunctionInfo* AddWasmFunctionInfo(Wasm::WasmSignature* funsig);

--- a/lib/WasmReader/WasmBinaryReader.h
+++ b/lib/WasmReader/WasmBinaryReader.h
@@ -35,6 +35,12 @@ namespace Wasm
         uint32 maximum;
     };
 
+    struct BinaryLocation
+    {
+        intptr_t offset;
+        intptr_t size;
+    };
+
     static const uint32 binaryVersion = 0x1;
 
     class WasmBinaryReader : public WasmReaderBase
@@ -53,7 +59,7 @@ namespace Wasm
 #if DBG_DUMP
         void PrintOps();
 #endif
-        intptr_t GetCurrentOffset() const { return m_pc - m_start; }
+        BinaryLocation GetCurrentLocation() const { return {m_pc - m_start, m_end - m_start}; }
     private:
         struct ReaderState
         {

--- a/test/wasm/baselines/api.baseline
+++ b/test/wasm/baselines/api.baseline
@@ -45,13 +45,13 @@ Test 9 passed. Expected Error: TypeError: BufferSource expected
 Test 10 passed. Expected Error: TypeError: Object expected
 Test 11 passed. Expected Error: TypeError: Object expected
 Test 12 passed. Expected Error: TypeError: Object expected
-Test 13 passed. Expected Error: TypeError: Unable to get property 'fn' of undefined or null reference
-Test 14 passed. Expected Error: TypeError: Unable to get property 'fn' of undefined or null reference
+Test 13 passed. Expected Error: TypeError: Import module 'test' is invalid
+Test 14 passed. Expected Error: TypeError: Import module 'test' is invalid
 Test 15 passed. Expected Error: TypeError: Object expected
 Test 16 passed. Expected Error: TypeError: Object expected
 Test 17 passed. Expected Error: TypeError: Object expected
-Test 18 passed. Expected Error: TypeError: Unable to get property 'fn' of undefined or null reference
-Test 19 passed. Expected Error: TypeError: Unable to get property 'fn' of undefined or null reference
+Test 18 passed. Expected Error: TypeError: Import module 'test' is invalid
+Test 19 passed. Expected Error: TypeError: Import module 'test' is invalid
 Testing module
 exports
 [{"kind":"function", "name":"fn"}, {"kind":"global", "name":"g1"}, {"kind":"function", "name":"f1"}, {"kind":"global", "name":"g2"}, {"kind":"table", "name":"table"}, {"kind":"function", "name":"fn2"}, {"kind":"function", "name":"call_i32"}, {"kind":"memory", "name":"mem"}, {"kind":"function", "name":"call_f32"}, {"kind":"global", "name":"g3"}, {"kind":"function", "name":"load"}]
@@ -125,16 +125,16 @@ Test 1 passed. Expected Error: TypeError: WebAssembly.Instance: cannot be called
 Test 2 passed. Expected Error: TypeError: Object expected
 Test 3 passed. Expected Error: TypeError: Object expected
 Test 4 passed. Expected Error: TypeError: Object expected
-Test 5 passed. Expected Error: TypeError: Unable to get property 'fn' of undefined or null reference
-Test 6 passed. Expected Error: TypeError: Unable to get property 'fn' of undefined or null reference
-Test 7 passed. Expected Error: LinkError: Function expected
+Test 5 passed. Expected Error: TypeError: Import module 'test' is invalid
+Test 6 passed. Expected Error: TypeError: Import module 'test' is invalid
+Test 7 passed. Expected Error: LinkError: Invalid import 'test.fn'. Expected a Function
 Test 8 passed. Expected Error: LinkError: Cannot link import test.fn.Thunk[0]()->i32 to fn2()->f32 in link table due to a signature mismatch
-Test 9 passed. Expected Error: LinkError: WebAssembly.Memory object expected
-Test 10 passed. Expected Error: LinkError: WebAssembly.Memory object expected
-Test 11 passed. Expected Error: LinkError: WebAssembly.Memory object expected
-Test 12 passed. Expected Error: LinkError: WebAssembly.Table object expected
-Test 13 passed. Expected Error: LinkError: WebAssembly.Table object expected
-Test 14 passed. Expected Error: LinkError: WebAssembly.Table object expected
+Test 9 passed. Expected Error: LinkError: Invalid import 'test.memory'. Expected a WebAssembly.Memory
+Test 10 passed. Expected Error: LinkError: Invalid import 'test.memory'. Expected a WebAssembly.Memory
+Test 11 passed. Expected Error: LinkError: Invalid import 'test.memory'. Expected a WebAssembly.Memory
+Test 12 passed. Expected Error: LinkError: Invalid import 'table.'. Expected a WebAssembly.Table
+Test 13 passed. Expected Error: LinkError: Invalid import 'table.'. Expected a WebAssembly.Table
+Test 14 passed. Expected Error: LinkError: Invalid import 'table.'. Expected a WebAssembly.Table
 Testing instance
 f1: 5
 fn: 1

--- a/test/wasm/baselines/api.baseline
+++ b/test/wasm/baselines/api.baseline
@@ -127,14 +127,14 @@ Test 3 passed. Expected Error: TypeError: Object expected
 Test 4 passed. Expected Error: TypeError: Object expected
 Test 5 passed. Expected Error: TypeError: Import module 'test' is invalid
 Test 6 passed. Expected Error: TypeError: Import module 'test' is invalid
-Test 7 passed. Expected Error: LinkError: Invalid import 'test.fn'. Expected a Function
+Test 7 passed. Expected Error: LinkError: Import 'test.fn' is invalid. Expected type Function
 Test 8 passed. Expected Error: LinkError: Cannot link import test.fn.Thunk[0]()->i32 to fn2()->f32 in link table due to a signature mismatch
-Test 9 passed. Expected Error: LinkError: Invalid import 'test.memory'. Expected a WebAssembly.Memory
-Test 10 passed. Expected Error: LinkError: Invalid import 'test.memory'. Expected a WebAssembly.Memory
-Test 11 passed. Expected Error: LinkError: Invalid import 'test.memory'. Expected a WebAssembly.Memory
-Test 12 passed. Expected Error: LinkError: Invalid import 'table.'. Expected a WebAssembly.Table
-Test 13 passed. Expected Error: LinkError: Invalid import 'table.'. Expected a WebAssembly.Table
-Test 14 passed. Expected Error: LinkError: Invalid import 'table.'. Expected a WebAssembly.Table
+Test 9 passed. Expected Error: LinkError: Import 'test.memory' is invalid. Expected type WebAssembly.Memory
+Test 10 passed. Expected Error: LinkError: Import 'test.memory' is invalid. Expected type WebAssembly.Memory
+Test 11 passed. Expected Error: LinkError: Import 'test.memory' is invalid. Expected type WebAssembly.Memory
+Test 12 passed. Expected Error: LinkError: Import 'table.' is invalid. Expected type WebAssembly.Table
+Test 13 passed. Expected Error: LinkError: Import 'table.' is invalid. Expected type WebAssembly.Table
+Test 14 passed. Expected Error: LinkError: Import 'table.' is invalid. Expected type WebAssembly.Table
 Testing instance
 f1: 5
 fn: 1


### PR DESCRIPTION
Improved some error messages to help debugging.
Also, change the CompileErrors offset to be relative to the binary buffer and not the function. This helps a lot to pinpoint where the error is exactly in the source.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/3487)
<!-- Reviewable:end -->
