### PR TITLE
remove invalid special case in regalloc

### DIFF
--- a/lib/Backend/LinearScan.cpp
+++ b/lib/Backend/LinearScan.cpp
@@ -886,7 +886,6 @@ LinearScan::SetDstReg(IR::Instr *instr)
                     return;
                 }
 
-
                 if (reg == RegNOREG)
                 {
                     IR::Opnd *src = instr->GetSrc1();
@@ -908,13 +907,7 @@ LinearScan::SetDstReg(IR::Instr *instr)
             if (!lifetime->isDeadStore && !lifetime->isSecondChanceAllocated)
             {
                 // Insert a store since the lifetime is spilled
-                IR::Opnd *nextDst = instr->m_next->GetDst();
-
-                // Don't need the store however if the next instruction has the same dst
-                if (nextDst == nullptr || !nextDst->IsEqual(regOpnd))
-                {
-                    this->InsertStore(instr, regOpnd->m_sym, reg);
-                }
+                this->InsertStore(instr, regOpnd->m_sym, reg);
             }
         }
         else


### PR DESCRIPTION
We had special case in regalloc if we are storing to a tmp reg and the next instr has the same dst, we don't need to insert a store. Unfortunately, this is invalid in case the sym is also a source of the next instr.

Benchmark perf is flat.

OS: 11480955