### PR TITLE
Retain subclass valueinfo while optimizing BailOnNotObject in OptTagChecks

### DIFF
--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -2820,7 +2820,9 @@ GlobOpt::OptTagChecks(IR::Instr *instr)
             {
                 if (valueType.CanBeTaggedValue())
                 {
-                    ChangeValueType(nullptr, value, valueType.SetCanBeTaggedValue(false), false);
+                    // We're not adding new information to the value other than changing the value type. Preserve any existing
+                    // information and just change the value type.
+                    ChangeValueType(nullptr, value, valueType.SetCanBeTaggedValue(false), true /*preserveSubClassInfo*/);
                     return false;
                 }
                 if (this->byteCodeUses)

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -355,4 +355,9 @@
       <files>bug11026788.js</files>
     </default>
   </test>
+  <test>
+    <default>
+      <files>valueInfoLossBug.js</files>
+    </default>
+  </test>
 </regress-exe>

--- a/test/Bugs/valueInfoLossBug.js
+++ b/test/Bugs/valueInfoLossBug.js
@@ -1,0 +1,20 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function test0() {
+  var ui16 = new Uint16Array();
+    for (var _strvar0 in ui16) {
+      litObj1.prop0 = ui16.length;
+      if (litObj1.prop0.prop0) {
+        ui16.length;
+      }
+    }
+}
+
+test0();
+test0();
+test0();
+WScript.Echo("PASSED");
+


### PR DESCRIPTION
Fixes OS#13115740.

In OptTagCheks currently, the valueinfo is being replaced by a new valueinfo changing the valuetype turning off Bits::CanBeTaggedValue for a BailOnNotObject instruction.
The initial valueInfo can be an IntRange ranging from 0 - INT_MAX for something like an array length. If the array length symbol is the opnd of BailOnNotObject then, the valueInfo will change to INT_MIN to INT_MAX.
Avoid this by preserving the subclass info while changing the value type.
```
function test0() {
  var ui16 = new Uint16Array();
    for (var _strvar0 in ui16) {
      litObj1.prop0 = ui16.length; // Array Length int specialized with int range 0 - INT_MAX
      if (litObj1.prop0.prop0) { // Generates BailOnNotObject on array length and force sets the value info to INT_MIN - INT_MAX
        ui16.length; // We end up with a negative lower bound on array length, assertion is fired during typespec
      }
    }
}
```