### PR TITLE
OS:10898061 fix bug with cached scopes and default arguments

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -6284,6 +6284,7 @@ void Parser::ParseFncFormals(ParseNodePtr pnodeFnc, ParseNodePtr pnodeParentFnc,
                 {
                     // Mark that the function has a non simple parameter list before parsing the pattern since the pattern can have function definitions.
                     this->GetCurrentFunctionNode()->sxFnc.SetHasNonSimpleParameterList();
+                    this->GetCurrentFunctionNode()->sxFnc.SetHasDestructuredParam();
 
                     ParseNodePtr *const ppnodeVarSave = m_ppnodeVar;
                     m_ppnodeVar = &pnodeFnc->sxFnc.pnodeVars;

--- a/lib/Parser/ptree.h
+++ b/lib/Parser/ptree.h
@@ -251,6 +251,7 @@ struct PnFnc
     bool isBodyAndParamScopeMerged; // Indicates whether the param scope and the body scope of the function can be merged together or not.
                                     // We cannot merge both scopes together if there is any closure capture or eval is present in the param scope.
     bool fibPreventsDeferral;
+    bool hasDestructuredParam;
 
     static const int32 MaxStackClosureAST = 800000;
 
@@ -290,6 +291,7 @@ public:
         fncFlags = kFunctionNone;
         canBeDeferred = false;
         isBodyAndParamScopeMerged = true;
+        hasDestructuredParam = false;
     }
 
     void SetAsmjsMode(bool set = true) { SetFlags(kFunctionAsmjsMode, set); }
@@ -328,6 +330,7 @@ public:
     void SetCanBeDeferred(bool set = true) { canBeDeferred = set; }
     void ResetBodyAndParamScopeMerged() { isBodyAndParamScopeMerged = false; }
     void SetFIBPreventsDeferral(bool set = true) { fibPreventsDeferral = set; }
+    void SetHasDestructuredParam(bool set = true) { hasDestructuredParam = set; }
 
     bool CallsEval() const { return HasFlags(kFunctionCallsEval); }
     bool ChildCallsEval() const { return HasFlags(kFunctionChildCallsEval); }
@@ -368,6 +371,7 @@ public:
     bool CanBeDeferred() const { return canBeDeferred; }
     bool IsBodyAndParamScopeMerged() { return isBodyAndParamScopeMerged; }
     bool FIBPreventsDeferral() const { return fibPreventsDeferral; }
+    bool HasDestructuredParam() const { return hasDestructuredParam; }
 
     size_t LengthInBytes()
     {

--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -3997,6 +3997,7 @@ void ByteCodeGenerator::StartEmitFunction(ParseNode *pnodeFnc)
                 !funcInfo->Escapes() &&
                 funcInfo->frameObjRegister != Js::Constants::NoRegister &&
                 !ApplyEnclosesArgs(pnodeFnc, this) &&
+                !pnodeFnc->sxFnc.HasDefaultArguments() &&
                 funcInfo->IsBodyAndParamScopeMerged() && // There is eval in the param scope
                 (PHASE_FORCE(Js::CachedScopePhase, funcInfo->byteCodeFunction) || !IsInDebugMode())
 #if ENABLE_TTD

--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -3998,6 +3998,7 @@ void ByteCodeGenerator::StartEmitFunction(ParseNode *pnodeFnc)
                 funcInfo->frameObjRegister != Js::Constants::NoRegister &&
                 !ApplyEnclosesArgs(pnodeFnc, this) &&
                 !pnodeFnc->sxFnc.HasDefaultArguments() &&
+                !pnodeFnc->sxFnc.HasDestructuredParam() &&
                 funcInfo->IsBodyAndParamScopeMerged() && // There is eval in the param scope
                 (PHASE_FORCE(Js::CachedScopePhase, funcInfo->byteCodeFunction) || !IsInDebugMode())
 #if ENABLE_TTD

--- a/test/es6/bug_OS10898061.js
+++ b/test/es6/bug_OS10898061.js
@@ -1,0 +1,20 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function foo( a = b ) 
+{
+    eval("");
+    var b;
+}
+
+try
+{
+    foo();
+    WScript.Echo( "FAILED");
+}
+catch( a )
+{
+    WScript.Echo( "PASSED");
+}

--- a/test/es6/bug_OS10898061.js
+++ b/test/es6/bug_OS10898061.js
@@ -3,18 +3,40 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 
-function foo( a = b ) 
+function foo( a = b )  
+{ 
+    eval(""); 
+    var b; 
+} 
+
+function bar( {a:a = b} )
 {
-    eval("");
-    var b;
+    eval(""); 
+    var b; 
+} 
+
+
+function test()
+{
+    try
+    {
+        // foo should throw a ReferenceError: 'b' is not defined.
+        foo();
+        return false;
+    }
+    catch( a )
+    {}
+
+    try
+    {
+        // bar should throw a ReferenceError: 'b' is not defined.
+        bar({});
+        return false;
+    }
+    catch( a )
+    {}
+
+    return true;
 }
 
-try
-{
-    foo();
-    WScript.Echo( "FAILED");
-}
-catch( a )
-{
-    WScript.Echo( "PASSED");
-}
+WScript.Echo(test() ? "PASSED" : "FAILED");

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -1463,4 +1463,10 @@
     <tags>BugFix</tags>
   </default>
 </test>
+<test>
+  <default>
+    <files>bug_OS10898061.js</files>
+    <tags>BugFix</tags>
+  </default>
+</test>
 </regress-exe>


### PR DESCRIPTION
When cached scopes are used with default function arguments, any variable references in the default argument values would erroneously see the merged body and param scope