### PR TITLE
Fix IV analysis when a loop modifies an induction variable of another sibling loop sharing the same loop parent

### DIFF
--- a/test/Optimizer/invalidIVRangeBug.js
+++ b/test/Optimizer/invalidIVRangeBug.js
@@ -1,0 +1,41 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function test0() {
+  var GiantPrintArray = [];
+  var obj0 = {};
+  var IntArr0 = [];
+  var IntArr1 = [];
+  var VarArr0 = [obj0];
+  var e = -649211448;
+  var f = 137044716;
+  var protoObj1 = Object();
+  function v0(v1) {
+    var v4 = {};
+    v4.a = v1;
+    v4.a[1] = null;
+  }
+  GiantPrintArray.push(v0(IntArr0));
+  for (var _strvar26 in VarArr0) {
+    for (; IntArr1.push(); f++) {
+    }
+    for (var _strvar0 in IntArr0) {
+      f = (e > _strvar0 & 255);
+    }
+  }
+  protoObj1.prop5 = { prop3: !f };
+  return protoObj1.prop5.prop3;
+}
+
+var x = test0();
+x &= test0();
+x &= test0();
+
+if (x == true) {
+  WScript.Echo("PASSED");
+}
+else {
+  WScript.Echo("FAILED");
+}

--- a/test/Optimizer/rlexe.xml
+++ b/test/Optimizer/rlexe.xml
@@ -1424,4 +1424,9 @@
       <compile-flags>-maxinterpretcount:1 -maxsimplejitruncount:1</compile-flags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>invalidIVRangeBug.js</files>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
When there are two independent loops that share the same loop parent, and the second inner loop modifies the induction variable of the first inner loop, the induction variable's changes should be marked as indeterminate.
Failing which, incorrect induction variable info can flow into the parent loop, which can lead to incorrect optimizations and deadcode.

Example:
```
  var f = 137044716;
  for (var _strvar26 in VarArr0) {
    for (; ... ; f++) {
    }
    for (var ... in ...) {
      f = (e > _strvar0 & 255);
    }
  }
```
The induction variable f at the top of the outer loop ends up with incorrect bounds of (137044716, INT_MAX) incorrectly.
The induction variable analysis says that this loop has a induction variable with positive changed bounds.
Instead of marking it as indeterminate due to the & operation in the inner loop, because of this the min is taken as the max of the two merging lower bounds.
From this bad int range, blocks get optimized away and bad things happen.

The f++ operation in the first inner loop adds it as an induction variable and sets the bounds correctly.
The   f = (e > _strvar0 & 255); operation does not do any modification on the induction variable analysis.
At the end of this block this variable does not get detected as changing bounds because it was not in the block's induction variable list in the first place.
This change fixes this.

Fixes OS#12152925.
