### PR TITLE
Default case in InliningDecider::GetBuiltInInfoCommon

### DIFF
--- a/lib/Backend/InliningDecider.cpp
+++ b/lib/Backend/InliningDecider.cpp
@@ -624,26 +624,8 @@ bool InliningDecider::GetBuiltInInfoCommon(
         break;
 #endif
 
-#ifdef ENABLE_SIMDJS
-    // SIMD_JS
-    // we only inline, and hence type-spec on IA
-#if defined(_M_X64) || defined(_M_IX86)
     default:
-    {
-#if 0 // TODO OOP JIT, inline SIMD
-        // inline only if simdjs and simd128 type-spec is enabled.
-        if (scriptContext->GetConfig()->IsSimdjsEnabled() && SIMD128_TYPE_SPEC_FLAG)
-        {
-            *inlineCandidateOpCode = scriptContext->GetThreadContext()->GetSimdOpcodeFromFuncInfo(funcInfo);
-        }
-        else
-#endif
-        {
-            return false;
-        }
-    }
-#endif
-#endif // ENABLE_SIMDJS
+        return false;
     }
     return true;
 }


### PR DESCRIPTION
When turned off `ENABLE_SIMDJS` it changed the behavior of the switch case in `InliningDecider::GetBuiltInInfoCommon` 
Turns out we only use the return value for -off:<some inlining feature>, so this is just a clean up change

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/3506)
<!-- Reviewable:end -->
