### PR TITLE
WASM: strengthen defer parse

### DIFF
--- a/lib/Runtime/Library/WasmLibrary.cpp
+++ b/lib/Runtime/Library/WasmLibrary.cpp
@@ -109,7 +109,6 @@ Js::JavascriptMethod Js::WasmLibrary::WasmDeferredParseEntryPoint(Js::AsmJsScrip
     Wasm::WasmReaderInfo* readerInfo = info->GetWasmReaderInfo();
     if (readerInfo)
     {
-        info->SetWasmReaderInfo(nullptr);
         try
         {
             Wasm::WasmBytecodeGenerator::GenerateFunctionBytecode(scriptContext, readerInfo);
@@ -142,6 +141,7 @@ Js::JavascriptMethod Js::WasmLibrary::WasmDeferredParseEntryPoint(Js::AsmJsScrip
             entrypointInfo->jsMethod = WasmLazyTrapCallback;
             info->SetLazyError(pError);
         }
+        info->SetWasmReaderInfo(nullptr);
     }
     else
     {

--- a/lib/WasmReader/WasmByteCodeGenerator.cpp
+++ b/lib/WasmReader/WasmByteCodeGenerator.cpp
@@ -429,7 +429,8 @@ void WasmBytecodeGenerator::GenerateFunction()
         m_originalWriter->Reset();
         throw;
     }
-
+    // Make sure we don't have any unforeseen exceptions as we finalize the body
+    AutoDisableInterrupt autoDisableInterrupt(m_scriptContext->GetThreadContext(), true);
 
 #if DBG_DUMP
     if (PHASE_DUMP(Js::ByteCodePhase, GetFunctionBody()) && !IsValidating())
@@ -443,6 +444,8 @@ void WasmBytecodeGenerator::GenerateFunction()
     mTypedRegisterAllocator.CommitToFunctionInfo(info, GetFunctionBody());
 
     GetFunctionBody()->CheckAndSetOutParamMaxDepth(m_maxArgOutDepth);
+
+    autoDisableInterrupt.Completed();
 }
 
 void WasmBytecodeGenerator::EnregisterLocals()


### PR DESCRIPTION
Only remove the WasmReaderInfo once we're done generating the bytecode 
Also, make sure we don't have any exceptions once we've generated the bytecode block until we've finalized the function body

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/3510)
<!-- Reviewable:end -->
