### PR TITLE
perf: Improve hot MOD arithmetic

### DIFF
--- a/lib/Common/DataStructures/QuickSort.h
+++ b/lib/Common/DataStructures/QuickSort.h
@@ -150,31 +150,29 @@ namespace JsUtil
     class QuickSortSwap
     {
     public:
+
         static inline void swap(T* a, T* b, size_t size)
         {
             if (a == b) return;
 
-            size_t tsize;
+            size_t mod;
             if (size >= 8)
             {
-                tsize = 8;
-                size_t nsize = size / tsize;
-                CC_QSORT_SWAP_LOOP(CC_QSORT_SWAP8, (CC_QSORT_SWAP8*) a, (CC_QSORT_SWAP8*) b, nsize)
+                mod = size & 7;
+                CC_QSORT_SWAP_LOOP(CC_QSORT_SWAP8, (CC_QSORT_SWAP8*) a, (CC_QSORT_SWAP8*) b, size / 8)
             }
             else if (size >= 4)
             {
-                tsize = 4;
-                size_t nsize = size / tsize;
-                CC_QSORT_SWAP_LOOP(CC_QSORT_SWAP4, (CC_QSORT_SWAP4*) a, (CC_QSORT_SWAP4*) b, nsize)
+                mod = size & 3;
+                CC_QSORT_SWAP_LOOP(CC_QSORT_SWAP4, (CC_QSORT_SWAP4*) a, (CC_QSORT_SWAP4*) b, size / 4)
             }
             else
             {
-                tsize = 2;
-                size_t nsize = size / tsize;
-                CC_QSORT_SWAP_LOOP(CC_QSORT_SWAP2, (CC_QSORT_SWAP2*) a, (CC_QSORT_SWAP2*) b, nsize)
+                mod = size & 1;
+                CC_QSORT_SWAP_LOOP(CC_QSORT_SWAP2, (CC_QSORT_SWAP2*) a, (CC_QSORT_SWAP2*) b, size / 2)
             }
 
-            CC_QSORT_SWAP_LOOP(char, (char*) a, (char*) b, size % tsize);
+            CC_QSORT_SWAP_LOOP(char, (char*) a, (char*) b, mod);
         }
     };
 

--- a/lib/Common/DataStructures/SizePolicy.cpp
+++ b/lib/Common/DataStructures/SizePolicy.cpp
@@ -9,8 +9,60 @@ static const uint primes[] = {
     1103, 1327, 1597, 1931, 2333, 2801, 3371, 4049, 4861, 5839, 7013, 8419, 10103, 12143, 14591,
     17519, 21023, 25229, 30293, 36353, 43627, 52361, 62851, 75431, 90523, 108631, 130363, 156437,
     187751, 225307, 270371, 324449, 389357, 467237, 560689, 672827, 807403, 968897, 1162687, 1395263,
-    1674319, 2009191, 2411033, 2893249, 3471899, 4166287, 4999559, 5999471, 7199369
+    1674319, 2009191, 2411033, 2893249, 3471899, 4166287, 4999559, 5999471, 7199369, 10453007, 13169977, 20906033
 };
+
+// If we know the modulo number at compile time, the compiler can optimize instructions.
+// These macros let the compiler do these optimizations for modulus optimizations of known primes
+static_assert(_countof(primes) == UNKNOWN_MOD_INDEX, "Adding / removing prime numbers ?");
+
+#define MOD_FNC_(x) static uint mod##x(const uint k, const uint) { return k % x##llu; }
+#define MOD_FNC__(a,b,c,d,e) MOD_FNC_(a) MOD_FNC_(b) MOD_FNC_(c) MOD_FNC_(d) MOD_FNC_(e)
+#define MOD_FNC(a,b,c,d,e,f,g,h,j,k) MOD_FNC__(a,b,c,d,e) MOD_FNC__(f,g,h,j,k)
+
+MOD_FNC(3, 7, 11, 17, 23, 29, 37, 47, 59, 71)
+MOD_FNC(89, 107, 131, 163, 197, 239, 293, 353, 431, 521)
+MOD_FNC(631, 761, 919, 1103, 1327, 1597, 1931, 2333, 2801, 3371)
+MOD_FNC(4049, 4861, 5839, 7013, 8419, 10103, 12143, 14591, 17519, 21023)
+MOD_FNC(25229, 30293, 36353, 43627, 52361, 62851, 75431, 90523, 108631, 130363)
+MOD_FNC(156437, 187751, 225307, 270371, 324449, 389357, 467237, 560689, 672827, 807403)
+MOD_FNC(968897, 1162687, 1395263, 1674319, 2009191, 2411033, 2893249, 3471899, 4166287, 4999559)
+MOD_FNC__(5999471, 7199369, 10453007, 13169977, 20906033)
+
+static uint modLAST(const uint k, const uint p) { return k % p; }
+
+#undef MOD_FNC_
+#undef MOD_FNC__
+#undef MOD_FNC
+
+#define MOD_FNC_(x) &mod##x
+#define MOD_FNC__(a,b,c,d,e) MOD_FNC_(a),MOD_FNC_(b),MOD_FNC_(c),MOD_FNC_(d),MOD_FNC_(e)
+#define MOD_FNC(a,b,c,d,e,f,g,h,j,k) MOD_FNC__(a,b,c,d,e),MOD_FNC__(f,g,h,j,k),
+
+// TODO: (obastemur) MOVE THIS UNDER .h file!!
+// We could have this on header file and inline the proxy function for good.
+// However, not every target we support comes with constexpr... and we need this done during compile time.
+static OPT_CONSTEXPR uint (* const mod_func[])(const uint, const uint) =
+{
+    MOD_FNC(3, 7, 11, 17, 23, 29, 37, 47, 59, 71)
+    MOD_FNC(89, 107, 131, 163, 197, 239, 293, 353, 431, 521)
+    MOD_FNC(631, 761, 919, 1103, 1327, 1597, 1931, 2333, 2801, 3371)
+    MOD_FNC(4049, 4861, 5839, 7013, 8419, 10103, 12143, 14591, 17519, 21023)
+    MOD_FNC(25229, 30293, 36353, 43627, 52361, 62851, 75431, 90523, 108631, 130363)
+    MOD_FNC(156437, 187751, 225307, 270371, 324449, 389357, 467237, 560689, 672827, 807403)
+    MOD_FNC(968897, 1162687, 1395263, 1674319, 2009191, 2411033, 2893249, 3471899, 4166287, 4999559)
+    MOD_FNC__(5999471, 7199369, 10453007, 13169977, 20906033)
+    , &modLAST
+};
+
+#undef MOD_FNC_
+#undef MOD_FNC__
+#undef MOD_FNC
+
+hash_t PrimePolicy::ModPrime(hash_t key, uint prime, int modFunctionIndex)
+{
+    return mod_func[modFunctionIndex](key, prime);
+}
 
 bool
 PrimePolicy::IsPrime(uint candidate)
@@ -29,17 +81,26 @@ PrimePolicy::IsPrime(uint candidate)
 }
 
 uint
-PrimePolicy::GetPrime(uint min)
+PrimePolicy::GetPrime(uint min, int *modFunctionIndex)
 {
     if (min <= 0)
+    {
+        *modFunctionIndex = 3;
+        AssertMsg(primes[3] == 17, "Update modFunctionIndex for 17");
         return 17;
+    }
 
     for (int i = 0; i < sizeof(primes)/sizeof(uint); i++)
     {
         uint prime = primes[i];
-        if (prime >= min) return prime;
+        if (prime >= min)
+        {
+            *modFunctionIndex = i;
+            return prime;
+        }
     }
 
+    *modFunctionIndex = UNKNOWN_MOD_INDEX;
     //outside of our predefined table.
     //compute the hard way.
     for (uint i = (min | 1); i < 0x7FFFFFFF; i += 2)

--- a/lib/Common/Memory/CustomHeap.cpp
+++ b/lib/Common/Memory/CustomHeap.cpp
@@ -115,7 +115,7 @@ void Heap<TAlloc, TPreReservedAlloc>::DecommitAll()
 
     DListBase<Allocation>::EditingIterator i(&this->largeObjectAllocations);
     while (i.Next())
-    { 
+    {
         Allocation& allocation = i.Data();
         Assert(!allocation.largeObjectAllocation.isDecommitted);
 
@@ -223,7 +223,8 @@ Allocation* Heap<TAlloc, TPreReservedAlloc>::Alloc(size_t bytes, ushort pdataCou
     Assert(pdataCount > 0 || (pdataCount == 0 && xdataSize == 0));
 
     // Round up to power of two to allocate, and figure out which bucket to allocate in
-    size_t bytesToAllocate = PowerOf2Policy::GetSize(bytes);
+    int _;
+    size_t bytesToAllocate = PowerOf2Policy::GetSize(bytes, &_ /* modFunctionIndex */);
     BucketId bucket = (BucketId) GetBucketForSize(bytesToAllocate);
 
     if (bucket == BucketId::LargeObjectList)
@@ -809,7 +810,7 @@ bool Heap<TAlloc, TPreReservedAlloc>::FreeAllocation(Allocation* object)
     if (page->inFullList)
     {
         VerboseHeapTrace(_u("Recycling page 0x%p because address 0x%p of size %d was freed\n"), page->address, object->address, object->size);
-       
+
         // If the object being freed is equal to the page size, we're
         // going to remove it anyway so don't add it to a bucket
         if (object->size != pageSize)
@@ -832,7 +833,7 @@ bool Heap<TAlloc, TPreReservedAlloc>::FreeAllocation(Allocation* object)
 
             void* pageAddress = page->address;
 
-            this->fullPages[page->currentBucket].RemoveElement(this->auxiliaryAllocator, page);            
+            this->fullPages[page->currentBucket].RemoveElement(this->auxiliaryAllocator, page);
 
             // The page is not in any bucket- just update the stats, free the allocation
             // and dump the page- we don't need to update free object size since the object
@@ -1020,7 +1021,7 @@ bool Heap<TAlloc, TPreReservedAlloc>::UpdateFullPages()
 template<typename TAlloc, typename TPreReservedAlloc>
 void Heap<TAlloc, TPreReservedAlloc>::FreeXdata(XDataAllocation* xdata, void* segment)
 {
-    Assert(!xdata->IsFreed()); 
+    Assert(!xdata->IsFreed());
     {
         AutoCriticalSection autoLock(&this->codePageAllocators->cs);
         this->codePageAllocators->ReleaseSecondary(*xdata, segment);

--- a/lib/Common/Memory/HeapBlockMap.h
+++ b/lib/Common/Memory/HeapBlockMap.h
@@ -98,9 +98,13 @@ private:
     }
 
 public:
+
+    static const uint L2CountPageSizePow2Modulo = (L2Count * PageSize) - 1;
     static uint GetLevel2Id(void * address)
     {
-        return ::Math::PointerCastToIntegralTruncate<uint>(address) % (L2Count * PageSize) / PageSize;
+        Assert((::Math::PointerCastToIntegralTruncate<uint>(address) & L2CountPageSizePow2Modulo) / PageSize
+              ==    (::Math::PointerCastToIntegralTruncate<uint>(address) % (L2Count * PageSize)) / PageSize); // see if L2Count * PageSize is no longer Pow2
+        return (::Math::PointerCastToIntegralTruncate<uint>(address) & L2CountPageSizePow2Modulo) / PageSize;
     }
 
 private:

--- a/lib/Runtime/Types/TypePath.cpp
+++ b/lib/Runtime/Types/TypePath.cpp
@@ -24,7 +24,8 @@ namespace Js {
         }
         else
         {
-            size = PowerOf2Policy::GetSize(size - TYPE_PATH_ALLOC_GRANULARITY_GAP);
+            int _;
+            size = PowerOf2Policy::GetSize(size - TYPE_PATH_ALLOC_GRANULARITY_GAP, &_ /* modFunctionIndex */);
             if (size < MaxPathTypeHandlerLength)
             {
                 size += TYPE_PATH_ALLOC_GRANULARITY_GAP;
@@ -331,4 +332,3 @@ namespace Js {
     }
 
 }
-


### PR DESCRIPTION
1 - Once the modulo number is known, compiler can optimize modulo aritmetic
(i.e. doesn't use DIV..) This brings up to 10 times less cpu cycles per
each modulo arithmetic. Used HashTable / Dictionary etc.

2 - For PrimePolicy, we know majority of the possible modulo numbers. Pow2 size policy already uses the special case.

3 - GetLevel2Id (hot function), QuickSort mod operation(s) are optimized to Pow2 special case since the MOD number is power of 2.

Well, we have bunch of other MOD arithmetic usage all over the places. However, these are the hot ones and reasonable to improve.