### PR TITLE
Fix issue#3254: Redeclaration error related to function declaration in module top-level

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -861,6 +861,13 @@ Symbol* Parser::AddDeclForPid(ParseNodePtr pnode, IdentPtr pid, SymbolType symbo
                 // If !errorOnRedecl, (old) let/const hides the (new) var, so do nothing.
                 break;
             case knopVarDecl:
+                // At the top level of a Module, function declarations are treated like lexical declarations rather than like var declarations.
+                if (errorOnRedecl && m_scriptContext->GetConfig()->IsES6ModuleEnabled() && IsImportOrExportStatementValidHere() &&
+                    (symbolType == STFunction || sym->GetSymbolType() == STFunction))
+                {
+                    Error(ERRRedeclaration);
+                }
+
                 // Legal redeclaration. Who wins?
                 if (errorOnRedecl || sym->GetDecl()->sxVar.isBlockScopeFncDeclVar || sym->GetIsArguments())
                 {

--- a/lib/Parser/perrors.h
+++ b/lib/Parser/perrors.h
@@ -54,7 +54,7 @@ LSC_ERROR_MSG( 1048, ERRKeywordNotId  , "The use of a keyword for an identifier 
 LSC_ERROR_MSG( 1049, ERRFutureReservedWordNotId, "The use of a future reserved word for an identifier is invalid")
 LSC_ERROR_MSG( 1050, ERRFutureReservedWordInStrictModeNotId, "The use of a future reserved word for an identifier is invalid. The identifier name is reserved in strict mode.")
 LSC_ERROR_MSG( 1051, ERRSetterMustHaveOneParameter, "Setter functions must have exactly one parameter")
-LSC_ERROR_MSG( 1052, ERRRedeclaration  , "Let/Const redeclaration") // "var x; let x;" is also a redeclaration
+LSC_ERROR_MSG( 1052, ERRRedeclaration  , "Identifier redeclaration") // "var x; let x;" is also a redeclaration
 LSC_ERROR_MSG( 1053, ERRUninitializedConst  , "Const must be initialized")
 LSC_ERROR_MSG( 1054, ERRDeclOutOfStmt  , "Declaration outside statement context")
 LSC_ERROR_MSG( 1055, ERRAssignmentToConst  , "Assignment to const")

--- a/test/Closures/bug_OS_2299723.baseline
+++ b/test/Closures/bug_OS_2299723.baseline
@@ -1,5 +1,5 @@
-eval('var x = 5') threw 'Let/Const redeclaration'
+eval('var x = 5') threw 'Identifier redeclaration'
 x: 5
-eval('var y = 5') threw 'Let/Const redeclaration'
+eval('var y = 5') threw 'Identifier redeclaration'
 eval('y = 5') threw 'Assignment to const'
 y: 1

--- a/test/LetConst/defer1.baseline
+++ b/test/LetConst/defer1.baseline
@@ -1,2 +1,2 @@
-SyntaxError: Let/Const redeclaration
+SyntaxError: Identifier redeclaration
 	at code (defer1.js:6:46)

--- a/test/LetConst/defer3.baseline
+++ b/test/LetConst/defer3.baseline
@@ -12,27 +12,27 @@ Syntax check succeeded
 SyntaxError: Const must be initialized
 SyntaxError: Const must be initialized
 SyntaxError: Const must be initialized
-SyntaxError: Let/Const redeclaration
-SyntaxError: Let/Const redeclaration
-SyntaxError: Let/Const redeclaration
-SyntaxError: Let/Const redeclaration
-SyntaxError: Let/Const redeclaration
-SyntaxError: Let/Const redeclaration
-SyntaxError: Let/Const redeclaration
-SyntaxError: Let/Const redeclaration
-SyntaxError: Let/Const redeclaration
-SyntaxError: Let/Const redeclaration
-SyntaxError: Let/Const redeclaration
-SyntaxError: Let/Const redeclaration
-SyntaxError: Let/Const redeclaration
-SyntaxError: Let/Const redeclaration
-SyntaxError: Let/Const redeclaration
-SyntaxError: Let/Const redeclaration
+SyntaxError: Identifier redeclaration
+SyntaxError: Identifier redeclaration
+SyntaxError: Identifier redeclaration
+SyntaxError: Identifier redeclaration
+SyntaxError: Identifier redeclaration
+SyntaxError: Identifier redeclaration
+SyntaxError: Identifier redeclaration
+SyntaxError: Identifier redeclaration
+SyntaxError: Identifier redeclaration
+SyntaxError: Identifier redeclaration
+SyntaxError: Identifier redeclaration
+SyntaxError: Identifier redeclaration
+SyntaxError: Identifier redeclaration
+SyntaxError: Identifier redeclaration
+SyntaxError: Identifier redeclaration
+SyntaxError: Identifier redeclaration
 Syntax check succeeded
 Syntax check succeeded
 Syntax check succeeded
 Syntax check succeeded
-SyntaxError: Let/Const redeclaration
-SyntaxError: Let/Const redeclaration
-SyntaxError: Let/Const redeclaration
-SyntaxError: Let/Const redeclaration
+SyntaxError: Identifier redeclaration
+SyntaxError: Identifier redeclaration
+SyntaxError: Identifier redeclaration
+SyntaxError: Identifier redeclaration

--- a/test/LetConst/eval1.baseline
+++ b/test/LetConst/eval1.baseline
@@ -1,18 +1,18 @@
 global z
 ReferenceError: 'x' is not defined
 ReferenceError: 'y' is not defined
-ReferenceError: Let/Const redeclaration
-ReferenceError: Let/Const redeclaration
+ReferenceError: Identifier redeclaration
+ReferenceError: Identifier redeclaration
 global block z
 ReferenceError: 'x' is not defined
 ReferenceError: 'y' is not defined
-ReferenceError: Let/Const redeclaration
+ReferenceError: Identifier redeclaration
 outer w
 outer z
 ReferenceError: 'x' is not defined
 ReferenceError: 'y' is not defined
 outer var y
-ReferenceError: Let/Const redeclaration
+ReferenceError: Identifier redeclaration
 inner w
 inner z
 ReferenceError: 'x' is not defined

--- a/test/LetConst/letvar.baseline
+++ b/test/LetConst/letvar.baseline
@@ -1,4 +1,4 @@
-SyntaxError: Let/Const redeclaration
+SyntaxError: Identifier redeclaration
 var x
 undefined
 let y

--- a/test/LetConst/redeclaration.baseline
+++ b/test/LetConst/redeclaration.baseline
@@ -1,42 +1,42 @@
 Test 1:
-SyntaxError: Let/Const redeclaration
+SyntaxError: Identifier redeclaration
 Test 2:
-SyntaxError: Let/Const redeclaration
+SyntaxError: Identifier redeclaration
 Test 3:
-SyntaxError: Let/Const redeclaration
+SyntaxError: Identifier redeclaration
 Test 4:
-SyntaxError: Let/Const redeclaration
+SyntaxError: Identifier redeclaration
 Test 5:
-SyntaxError: Let/Const redeclaration
+SyntaxError: Identifier redeclaration
 Test 6:
-SyntaxError: Let/Const redeclaration
+SyntaxError: Identifier redeclaration
 Test 7:
-SyntaxError: Let/Const redeclaration
+SyntaxError: Identifier redeclaration
 Test 8:
-SyntaxError: Let/Const redeclaration
+SyntaxError: Identifier redeclaration
 Test 9:
-SyntaxError: Let/Const redeclaration
+SyntaxError: Identifier redeclaration
 Test a1:
-SyntaxError: Let/Const redeclaration
+SyntaxError: Identifier redeclaration
 Test a2:
-SyntaxError: Let/Const redeclaration
+SyntaxError: Identifier redeclaration
 Test a3:
-SyntaxError: Let/Const redeclaration
+SyntaxError: Identifier redeclaration
 Test a4:
-SyntaxError: Let/Const redeclaration
+SyntaxError: Identifier redeclaration
 Test a5:
-SyntaxError: Let/Const redeclaration
+SyntaxError: Identifier redeclaration
 Test a6:
-SyntaxError: Let/Const redeclaration
+SyntaxError: Identifier redeclaration
 Test a7:
-SyntaxError: Let/Const redeclaration
+SyntaxError: Identifier redeclaration
 Test a8:
-SyntaxError: Let/Const redeclaration
+SyntaxError: Identifier redeclaration
 Test a9:
-SyntaxError: Let/Const redeclaration
+SyntaxError: Identifier redeclaration
 Test b1:
-SyntaxError: Let/Const redeclaration
+SyntaxError: Identifier redeclaration
 Test b2:
-SyntaxError: Let/Const redeclaration
+SyntaxError: Identifier redeclaration
 Test b3:
-SyntaxError: Let/Const redeclaration
+SyntaxError: Identifier redeclaration

--- a/test/es6/default-splitscope.js
+++ b/test/es6/default-splitscope.js
@@ -2139,7 +2139,7 @@ var tests = [
         assert.throws(function () { return function (a = eval("var a = 2"), b = a) { return [a, b]; }() },
                         ReferenceError,
                         "Redeclaring the current formal using var inside an eval throws",
-                        "Let/Const redeclaration");
+                        "Identifier redeclaration");
         assert.doesNotThrow(function () { "use strict"; return function (a = eval("var a = 2"), b = a) { return [a, b]; }() },
                             "Redeclaring the current formal using var inside a strict mode eval does not throw");
         assert.doesNotThrow(function () { "use strict"; return function (a = eval("var a = 2"), b = a) { return [a, b]; }() },
@@ -2148,12 +2148,12 @@ var tests = [
         assert.throws(function () { function foo(a = eval("var b"), b, c = b) { return [a, b, c]; } foo(); },
                         ReferenceError,
                         "Redeclaring a future formal using var inside an eval throws",
-                        "Let/Const redeclaration");
+                        "Identifier redeclaration");
 
         assert.throws(function () { function foo(a, b = eval("var a"), c = a) { return [a, b, c]; } foo(); },
                         ReferenceError,
                         "Redeclaring a previous formal using var inside an eval throws",
-                        "Let/Const redeclaration");
+                        "Identifier redeclaration");
 
         // Let and const do not leak outside of an eval, so the test cases below should never throw.
         // Redeclarations of formals - let

--- a/test/es6/default.js
+++ b/test/es6/default.js
@@ -52,25 +52,25 @@ var tests = [
       // Redeclaration errors - non-simple in this case means any parameter list with a default expression
       assert.doesNotThrow(function () { eval("function foo(a = 1) { var a; }"); },            "Var redeclaration with a non-simple parameter list");
       assert.doesNotThrow(function () { eval("function foo(a = 1, b) { var b; }"); },         "Var redeclaration does not throw with a non-simple parameter list on a non-default parameter");
-      assert.throws(function () { function foo(a = 1) { eval('var a;'); }; foo() },     ReferenceError, "Var redeclaration throws with a non-simple parameter list inside an eval", "Let/Const redeclaration");
-      assert.throws(function () { function foo(a = 1, b) { eval('var b;'); }; foo(); }, ReferenceError, "Var redeclaration throws with a non-simple parameter list on a non-default parameter inside eval", "Let/Const redeclaration");
+      assert.throws(function () { function foo(a = 1) { eval('var a;'); }; foo() },     ReferenceError, "Var redeclaration throws with a non-simple parameter list inside an eval", "Identifier redeclaration");
+      assert.throws(function () { function foo(a = 1, b) { eval('var b;'); }; foo(); }, ReferenceError, "Var redeclaration throws with a non-simple parameter list on a non-default parameter inside eval", "Identifier redeclaration");
 
-      assert.throws(function () { eval("function foo(a) { let a; };"); }, SyntaxError, "Duplicate let decalration in the body should throw redeclaration error", "Let/Const redeclaration");
-      assert.throws(function () { eval("function foo(a) { const a = 1; };"); }, SyntaxError, "Duplicate const decalration in the body should throw redeclaration error", "Let/Const redeclaration");
-      assert.throws(function () { eval("(a) => { let a; };"); }, SyntaxError, "Duplicate let decalration in the body of an arrow function should throw redeclaration error", "Let/Const redeclaration");
-      assert.throws(function () { eval("(a) => { const a = 1; };"); }, SyntaxError, "Duplicate const decalration in the body of an arrow function should throw redeclaration error", "Let/Const redeclaration", "Let/Const redeclaration");
-      assert.throws(function () { eval("function foo(a, b = () => a) { let b; };"); }, SyntaxError, "Duplicate let decalration in the body of a split scope function should throw redeclaration error", "Let/Const redeclaration");
-      assert.throws(function () { eval("function foo(a, b = () => a) { const b = 1; };"); }, SyntaxError, "Duplicate const decalration in the body of a split scope function should throw redeclaration error", "Let/Const redeclaration");
-      assert.throws(function () { eval("function foo(arguments, b = () => arguments) { let arguments; };"); }, SyntaxError, "Duplicate let definition of arguments should throw redeclaration error", "Let/Const redeclaration");
-      assert.throws(function () { eval("function foo(arguments, b = () => arguments) { const arguments = 1; };"); }, SyntaxError, "Duplicate const definition of arguments should throw redeclaration error", "Let/Const redeclaration");
-      assert.throws(function () { eval("(a, b = () => a) => { let b; };"); }, SyntaxError, "Duplicate let decalration in the body of a split scope arrow function should throw redeclaration error", "Let/Const redeclaration");
-      assert.throws(function () { eval("(a, b = () => a) => { const b = 1; };"); }, SyntaxError, "Duplicate const decalration in the body of a split scope arrow function should throw redeclaration error", "Let/Const redeclaration");
-      assert.throws(function () { eval("(arguments, b = () => arguments) => { let arguments; };"); }, SyntaxError, "Duplicate let definition of arguments in an arrow function should throw redeclaration error", "Let/Const redeclaration");
-      assert.throws(function () { eval("(arguments, b = () => arguments) => { const arguments = 1; };"); }, SyntaxError, "Duplicate const definition of arguments in an arrow function should throw redeclaration error", "Let/Const redeclaration");
-      assert.throws(function () { eval("function foo({a, b = () => a}) { let b; };"); }, SyntaxError, "Duplicate let decalration in the body of a function with destructured param should throw redeclaration error", "Let/Const redeclaration");
-      assert.throws(function () { eval("function foo([a], b = () => a) { const b = 1; };"); }, SyntaxError, "Duplicate const decalration in the body of a function with destructured param should throw redeclaration error", "Let/Const redeclaration");
-      assert.throws(function () { eval("function foo([arguments, b = () => arguments]) { let arguments; };"); }, SyntaxError, "Duplicate let definition of arguments in a function with destructured params should throw redeclaration error", "Let/Const redeclaration");
-      assert.throws(function () { eval("function foo(arguments, {b = () => arguments}) { const arguments = 1; };"); }, SyntaxError, "Duplicate const definition of arguments in a function with destructured params should throw redeclaration error", "Let/Const redeclaration");
+      assert.throws(function () { eval("function foo(a) { let a; };"); }, SyntaxError, "Duplicate let decalration in the body should throw redeclaration error", "Identifier redeclaration");
+      assert.throws(function () { eval("function foo(a) { const a = 1; };"); }, SyntaxError, "Duplicate const decalration in the body should throw redeclaration error", "Identifier redeclaration");
+      assert.throws(function () { eval("(a) => { let a; };"); }, SyntaxError, "Duplicate let decalration in the body of an arrow function should throw redeclaration error", "Identifier redeclaration");
+      assert.throws(function () { eval("(a) => { const a = 1; };"); }, SyntaxError, "Duplicate const decalration in the body of an arrow function should throw redeclaration error", "Identifier redeclaration", "Identifier redeclaration");
+      assert.throws(function () { eval("function foo(a, b = () => a) { let b; };"); }, SyntaxError, "Duplicate let decalration in the body of a split scope function should throw redeclaration error", "Identifier redeclaration");
+      assert.throws(function () { eval("function foo(a, b = () => a) { const b = 1; };"); }, SyntaxError, "Duplicate const decalration in the body of a split scope function should throw redeclaration error", "Identifier redeclaration");
+      assert.throws(function () { eval("function foo(arguments, b = () => arguments) { let arguments; };"); }, SyntaxError, "Duplicate let definition of arguments should throw redeclaration error", "Identifier redeclaration");
+      assert.throws(function () { eval("function foo(arguments, b = () => arguments) { const arguments = 1; };"); }, SyntaxError, "Duplicate const definition of arguments should throw redeclaration error", "Identifier redeclaration");
+      assert.throws(function () { eval("(a, b = () => a) => { let b; };"); }, SyntaxError, "Duplicate let decalration in the body of a split scope arrow function should throw redeclaration error", "Identifier redeclaration");
+      assert.throws(function () { eval("(a, b = () => a) => { const b = 1; };"); }, SyntaxError, "Duplicate const decalration in the body of a split scope arrow function should throw redeclaration error", "Identifier redeclaration");
+      assert.throws(function () { eval("(arguments, b = () => arguments) => { let arguments; };"); }, SyntaxError, "Duplicate let definition of arguments in an arrow function should throw redeclaration error", "Identifier redeclaration");
+      assert.throws(function () { eval("(arguments, b = () => arguments) => { const arguments = 1; };"); }, SyntaxError, "Duplicate const definition of arguments in an arrow function should throw redeclaration error", "Identifier redeclaration");
+      assert.throws(function () { eval("function foo({a, b = () => a}) { let b; };"); }, SyntaxError, "Duplicate let decalration in the body of a function with destructured param should throw redeclaration error", "Identifier redeclaration");
+      assert.throws(function () { eval("function foo([a], b = () => a) { const b = 1; };"); }, SyntaxError, "Duplicate const decalration in the body of a function with destructured param should throw redeclaration error", "Identifier redeclaration");
+      assert.throws(function () { eval("function foo([arguments, b = () => arguments]) { let arguments; };"); }, SyntaxError, "Duplicate let definition of arguments in a function with destructured params should throw redeclaration error", "Identifier redeclaration");
+      assert.throws(function () { eval("function foo(arguments, {b = () => arguments}) { const arguments = 1; };"); }, SyntaxError, "Duplicate const definition of arguments in a function with destructured params should throw redeclaration error", "Identifier redeclaration");
 
       assert.doesNotThrow(function () { function foo(a = 1) { eval('let a;'); }; foo() },           "Let redeclaration inside an eval does not throw with a non-simple parameter list");
       assert.doesNotThrow(function () { function foo(a = 1) { eval('const a = "str";'); }; foo() }, "Const redeclaration inside an eval does not throw with a non-simple parameter list");
@@ -469,7 +469,7 @@ var tests = [
         f8(1);
 
         assert.throws(function () { eval("function f(a, b = arguments) { class arguments { } }"); }, SyntaxError, "Class cannot be named arguments", "Invalid usage of 'arguments' in strict mode");
-        assert.throws(function () { eval("function f(a, arguments) { class arguments { } }"); }, SyntaxError, "Class cannot be named arguments even when one of the formal is named arguments", "Let/Const redeclaration");
+        assert.throws(function () { eval("function f(a, arguments) { class arguments { } }"); }, SyntaxError, "Class cannot be named arguments even when one of the formal is named arguments", "Identifier redeclaration");
 
         function f9( a = 0, b = {
             arguments() {

--- a/test/es6/destructuring.js
+++ b/test/es6/destructuring.js
@@ -206,8 +206,8 @@ var tests = [
 
       // Redeclarations
       assert.doesNotThrow(function () { eval("var [a, a] = [];"); },    "Destructured var array declaration with a repeated identifier reference does not throw");
-      assert.throws(function () { eval("let [a, a] = [];"); },   SyntaxError, "Destructured let array declaration with a repeated identifier reference throws", "Let/Const redeclaration");
-      assert.throws(function () { eval("const [a, a] = [];"); }, SyntaxError, "Destructured const array declaration with a repeated identifier reference throws", "Let/Const redeclaration");
+      assert.throws(function () { eval("let [a, a] = [];"); },   SyntaxError, "Destructured let array declaration with a repeated identifier reference throws", "Identifier redeclaration");
+      assert.throws(function () { eval("const [a, a] = [];"); }, SyntaxError, "Destructured const array declaration with a repeated identifier reference throws", "Identifier redeclaration");
       assert.doesNotThrow(function () { eval("var a; [a, a] = [];"); }, "Destructured var array assignment with a repeated identifier reference does not throw");
       assert.doesNotThrow(function () { eval("let a; [a, a] = [];"); }, "Destructured let array assignment with a repeated identifier reference does not throw");
 
@@ -219,12 +219,12 @@ var tests = [
 
       // Call expression property references
       assert.throws(function () { eval("function foo() { return {}; }; var [foo()] = [];"); },       SyntaxError,    "Destructured var array declaration with a call expression throws",                      "Syntax error");
-      assert.throws(function () { eval("function foo() { return {}; }; let [foo()] = [];"); },       SyntaxError,    "Destructured let array declaration with a call expression throws",                      "Let/Const redeclaration");
-      assert.throws(function () { eval("function foo() { return {}; }; const [foo()] = [];"); },     SyntaxError,    "Destructured const array declaration with a call expression throws",                    "Let/Const redeclaration");
+      assert.throws(function () { eval("function foo() { return {}; }; let [foo()] = [];"); },       SyntaxError,    "Destructured let array declaration with a call expression throws",                      "Identifier redeclaration");
+      assert.throws(function () { eval("function foo() { return {}; }; const [foo()] = [];"); },     SyntaxError,    "Destructured const array declaration with a call expression throws",                    "Identifier redeclaration");
       assert.throws(function () { eval("function foo() { return {}; }; [foo()] = [];"); },           SyntaxError,    "Destructured array assignment with a call expression throws",                           "Invalid destructuring assignment target");
       assert.throws(function () { eval("function foo() { return {}; }; var [foo().x] = [];"); },     SyntaxError,    "Destructured var array declaration with a call expression property reference throws",   "Syntax error");
-      assert.throws(function () { eval("function foo() { return {}; }; let [foo().x] = [];"); },     SyntaxError,    "Destructured let array declaration with a call expression property reference throws",   "Let/Const redeclaration");
-      assert.throws(function () { eval("function foo() { return {}; }; const [foo().x] = [];"); },   SyntaxError,    "Destructured const array declaration with a call expression property reference throws", "Let/Const redeclaration");
+      assert.throws(function () { eval("function foo() { return {}; }; let [foo().x] = [];"); },     SyntaxError,    "Destructured let array declaration with a call expression property reference throws",   "Identifier redeclaration");
+      assert.throws(function () { eval("function foo() { return {}; }; const [foo().x] = [];"); },   SyntaxError,    "Destructured const array declaration with a call expression property reference throws", "Identifier redeclaration");
       assert.doesNotThrow(function () { eval("function foo() { return {}; }; [foo().x] = [];"); },      "Destructured array assignment with super a property reference does not throw");
       assert.doesNotThrow(function () { eval("function foo() { return {}; }; [foo()[\"x\"]] = [];"); }, "Destructured array assignment with a call expression property reference does not throw");
 

--- a/test/es6/destructuring_catch.js
+++ b/test/es6/destructuring_catch.js
@@ -45,11 +45,11 @@ var tests = [
   {
     name: "Destructuring syntax as params - redeclarations",
     body: function () {
-      assert.throws(function () { eval("function foo() {try {} catch({x:x, x:x}) {} }"); },  SyntaxError,  "Catch param as object pattern has duplicate binding identifiers is not valid syntax", "Let/Const redeclaration");
-      assert.throws(function () { eval("function foo() {try {} catch([x, x]) {} }"); }, SyntaxError,   "Catch param as array pattern has duplicate binding identifiers is not valid syntax", "Let/Const redeclaration");
-      assert.throws(function () { eval("function foo() {try {} catch({z1, x:{z:[z1]}}) {} }"); }, SyntaxError,  "Catch param has nesting pattern has has matching is not valid syntax", "Let/Const redeclaration");
-      assert.throws(function () { eval("function foo() {try {} catch([x]) { let x = 10;} }"); }, SyntaxError,  "Catch param as a pattern and matching name with let/const variable in body is not valid syntax", "Let/Const redeclaration");
-      assert.throws(function () { eval("function foo() {try {} catch([x]) { function x() {} } }"); }, SyntaxError,  "Catch param as a pattern and matching name with function name in body is not valid syntax", "Let/Const redeclaration");
+      assert.throws(function () { eval("function foo() {try {} catch({x:x, x:x}) {} }"); },  SyntaxError,  "Catch param as object pattern has duplicate binding identifiers is not valid syntax", "Identifier redeclaration");
+      assert.throws(function () { eval("function foo() {try {} catch([x, x]) {} }"); }, SyntaxError,   "Catch param as array pattern has duplicate binding identifiers is not valid syntax", "Identifier redeclaration");
+      assert.throws(function () { eval("function foo() {try {} catch({z1, x:{z:[z1]}}) {} }"); }, SyntaxError,  "Catch param has nesting pattern has has matching is not valid syntax", "Identifier redeclaration");
+      assert.throws(function () { eval("function foo() {try {} catch([x]) { let x = 10;} }"); }, SyntaxError,  "Catch param as a pattern and matching name with let/const variable in body is not valid syntax", "Identifier redeclaration");
+      assert.throws(function () { eval("function foo() {try {} catch([x]) { function x() {} } }"); }, SyntaxError,  "Catch param as a pattern and matching name with function name in body is not valid syntax", "Identifier redeclaration");
       assert.doesNotThrow(function () { eval("function foo() {try {} catch([x]) { var x = 10;} }"); },  "Catch param as a pattern and matching name with var declared name in body is valid syntax");
 
       (function () {

--- a/test/es6/destructuring_obj.js
+++ b/test/es6/destructuring_obj.js
@@ -62,7 +62,7 @@ var tests = [
   {
     name: "Object destructuring syntax with identifier reference",
     body: function () {
-      assert.throws(function () { eval("function foo() { return {}; }; let {x:foo()} = {};"); }, SyntaxError,  "Object declaration pattern with a call expression is not valid syntax", "Let/Const redeclaration");
+      assert.throws(function () { eval("function foo() { return {}; }; let {x:foo()} = {};"); }, SyntaxError,  "Object declaration pattern with a call expression is not valid syntax", "Identifier redeclaration");
       assert.throws(function () { eval("function foo() { return {}; }; ({x:foo()} = {});"); }, SyntaxError,  "Object expression pattern with a call expression is not valid syntax", "Invalid destructuring assignment target");
       assert.throws(function () { eval("function foo() { return {}; }; var {x:foo().x} = {};"); }, SyntaxError,  "Object declaration pattern with property reference on call is not valid syntax", "Syntax error");
 
@@ -127,12 +127,12 @@ var tests = [
     name: "Object destructuring syntax with repeated identifier",
     body: function () {
       assert.doesNotThrow(function () { eval("var {a:a, a:a} = {};"); },    "var declaration pattern with a repeated identifier is valid syntax");
-      assert.throws(function () { eval("let {a:a, a:a} = {};"); },   SyntaxError, "let declaration pattern with a repeated identifier is not valid syntax", "Let/Const redeclaration");
-      assert.throws(function () { eval("const {a:a, a:a} = {};"); }, SyntaxError, "const declaration pattern with a repeated identifier is not valid syntax", "Let/Const redeclaration");
-      assert.throws(function () { eval("let {b, b} = {};"); },   SyntaxError, "let declaration pattern with a repeated identifier as shorthand is not valid syntax", "Let/Const redeclaration");
-      assert.throws(function () { eval("const {b, b} = {};"); }, SyntaxError, "const declaration pattern with a repeated identifier as shorthand is not valid syntax", "Let/Const redeclaration");
-      assert.throws(function () { eval("let {x:c, y:c} = {};"); },   SyntaxError, "let declaration pattern with a repeated identifier but different matching pattern is not valid syntax", "Let/Const redeclaration");
-      assert.throws(function () { eval("const {x:c, y:c} = {};"); }, SyntaxError, "const declaration pattern with a repeated identifier but different matching pattern is not valid syntax", "Let/Const redeclaration");
+      assert.throws(function () { eval("let {a:a, a:a} = {};"); },   SyntaxError, "let declaration pattern with a repeated identifier is not valid syntax", "Identifier redeclaration");
+      assert.throws(function () { eval("const {a:a, a:a} = {};"); }, SyntaxError, "const declaration pattern with a repeated identifier is not valid syntax", "Identifier redeclaration");
+      assert.throws(function () { eval("let {b, b} = {};"); },   SyntaxError, "let declaration pattern with a repeated identifier as shorthand is not valid syntax", "Identifier redeclaration");
+      assert.throws(function () { eval("const {b, b} = {};"); }, SyntaxError, "const declaration pattern with a repeated identifier as shorthand is not valid syntax", "Identifier redeclaration");
+      assert.throws(function () { eval("let {x:c, y:c} = {};"); },   SyntaxError, "let declaration pattern with a repeated identifier but different matching pattern is not valid syntax", "Identifier redeclaration");
+      assert.throws(function () { eval("const {x:c, y:c} = {};"); }, SyntaxError, "const declaration pattern with a repeated identifier but different matching pattern is not valid syntax", "Identifier redeclaration");
       assert.doesNotThrow(function () { eval("let a; ({a:a, a:a} = {});"); }, "Object expression pattern with a repeated identifier is valid syntax");
     }
    },

--- a/test/es6/destructuring_params.js
+++ b/test/es6/destructuring_params.js
@@ -109,15 +109,15 @@ var tests = [
   {
     name: "Destructuring syntax as params - redeclarations",
     body: function () {
-      assert.throws(function () { eval("function foo({x:x, x:x}) {}"); },  SyntaxError,  "One formal as object pattern has duplicate binding identifiers is not valid syntax", "Let/Const redeclaration");
-      assert.throws(function () { eval("function foo({x:x}, {x:x}) {}"); },  SyntaxError,  "Two formals as object patterns have duplicate binding identifiers is not valid syntax", "Let/Const redeclaration");
-      assert.throws(function () { eval("function foo([x, x]) {}"); }, SyntaxError,   "One formal as array pattern has duplicate binding identifiers is not valid syntax", "Let/Const redeclaration");
-      assert.throws(function () { eval("function foo([x], [x]) {}"); },  SyntaxError,  "Two formals as array patterns have duplicate binding identifiers is not valid syntax", "Let/Const redeclaration");
-      assert.throws(function () { eval("function foo([x], {x:x}) {}"); },  SyntaxError,  "Mixed array and object pattern with duplicate identifiers is not valid syntax", "Let/Const redeclaration");
+      assert.throws(function () { eval("function foo({x:x, x:x}) {}"); },  SyntaxError,  "One formal as object pattern has duplicate binding identifiers is not valid syntax", "Identifier redeclaration");
+      assert.throws(function () { eval("function foo({x:x}, {x:x}) {}"); },  SyntaxError,  "Two formals as object patterns have duplicate binding identifiers is not valid syntax", "Identifier redeclaration");
+      assert.throws(function () { eval("function foo([x, x]) {}"); }, SyntaxError,   "One formal as array pattern has duplicate binding identifiers is not valid syntax", "Identifier redeclaration");
+      assert.throws(function () { eval("function foo([x], [x]) {}"); },  SyntaxError,  "Two formals as array patterns have duplicate binding identifiers is not valid syntax", "Identifier redeclaration");
+      assert.throws(function () { eval("function foo([x], {x:x}) {}"); },  SyntaxError,  "Mixed array and object pattern with duplicate identifiers is not valid syntax", "Identifier redeclaration");
       assert.throws(function () { eval("function foo([x], x) {}"); },  SyntaxError,  "First formal as array pattern has matching name with the second formal is not valid syntax", "Duplicate formal parameter names not allowed in this context");
-      assert.throws(function () { eval("function foo(x, [x]) {}"); },  SyntaxError,  "First normal formal is matching with the second formal which is array pattern is not valid syntax", "Let/Const redeclaration");
+      assert.throws(function () { eval("function foo(x, [x]) {}"); },  SyntaxError,  "First normal formal is matching with the second formal which is array pattern is not valid syntax", "Identifier redeclaration");
       assert.throws(function () { eval("function foo({x:{z:[z1]}}, z1) {}"); },  SyntaxError,  "First formal as nesting object pattern has matching name with the second formal is not valid syntax", "Duplicate formal parameter names not allowed in this context");
-      assert.throws(function () { eval("function foo([x]) { let x = 10;}"); },  SyntaxError,  "Object destructuring pattern as a formal is valid syntax", "Let/Const redeclaration");
+      assert.throws(function () { eval("function foo([x]) { let x = 10;}"); },  SyntaxError,  "Object destructuring pattern as a formal is valid syntax", "Identifier redeclaration");
       assert.doesNotThrow(function () { eval("function foo([x]) { var x = 10;}"); },  "var declared names matching with formal (as array pattern) is valid syntax");
     }
   },

--- a/test/es6/lambda1.js
+++ b/test/es6/lambda1.js
@@ -348,9 +348,9 @@ var tests = [
     {
         name: "Formal names redeclared by local variables behave as if formals are var-like",
         body: function () {
-            assert.doesNotThrow(function () { eval('x => { var x; }'); }, "lambda formal parameters do not cause redeclaration error with local var bindings of the same name", "Let/Const redeclaration");
-            assert.throws(function () { eval('x => { let x; }'); }, SyntaxError, "lambda formal parameters cause redeclaration error with local function scoped let bindings of the same name", "Let/Const redeclaration");
-            assert.throws(function () { eval('x => { const x = 0; }'); }, SyntaxError, "lambda formal parameters cause redeclaration error with local function scoped const bindings of the same name", "Let/Const redeclaration");
+            assert.doesNotThrow(function () { eval('x => { var x; }'); }, "lambda formal parameters do not cause redeclaration error with local var bindings of the same name", "Identifier redeclaration");
+            assert.throws(function () { eval('x => { let x; }'); }, SyntaxError, "lambda formal parameters cause redeclaration error with local function scoped let bindings of the same name", "Identifier redeclaration");
+            assert.throws(function () { eval('x => { const x = 0; }'); }, SyntaxError, "lambda formal parameters cause redeclaration error with local function scoped const bindings of the same name", "Identifier redeclaration");
         }
     },
     {

--- a/test/es6/letconst_eval_redecl.baseline
+++ b/test/es6/letconst_eval_redecl.baseline
@@ -2,15 +2,15 @@
 1
 1
 1
-ReferenceError: Let/Const redeclaration
-ReferenceError: Let/Const redeclaration
-ReferenceError: Let/Const redeclaration
-ReferenceError: Let/Const redeclaration
+ReferenceError: Identifier redeclaration
+ReferenceError: Identifier redeclaration
+ReferenceError: Identifier redeclaration
+ReferenceError: Identifier redeclaration
 1
 1
 1
 1
-ReferenceError: Let/Const redeclaration
-ReferenceError: Let/Const redeclaration
-ReferenceError: Let/Const redeclaration
-ReferenceError: Let/Const redeclaration
+ReferenceError: Identifier redeclaration
+ReferenceError: Identifier redeclaration
+ReferenceError: Identifier redeclaration
+ReferenceError: Identifier redeclaration

--- a/test/es6/letconst_global_shadow_builtins_nonconfigurable.baseline
+++ b/test/es6/letconst_global_shadow_builtins_nonconfigurable.baseline
@@ -1,2 +1,2 @@
-ReferenceError: Let/Const redeclaration
+ReferenceError: Identifier redeclaration
 	at Global code (letconst_global_shadow_builtins_nonconfigurable.js:8:1)

--- a/test/es6/module-syntax.js
+++ b/test/es6/module-syntax.js
@@ -48,6 +48,15 @@ var tests = [
         }
     },
     {
+        name: "Syntax error of redeclaration in function declaration at module top level",
+        body: function () {
+            testModuleScript('var f; function f() {}', 'Syntax error of redeclaration in function declaration in module\'s top-level', true);
+            testModuleScript('var g; function *g() {}', 'Syntax error of redeclaration in function generator declaration in module\'s top-level', true);
+            testModuleScript('function e() { var f; function f() {} }', 'No syntax error of redeclaration in function declaration that is not in module\'s top-level');
+            testModuleScript('function e() { var g; function *g() {} }', 'No syntax error of redeclaration in function generator declaration that is not in module\'s top-level');
+        }
+    },
+    {
         name: "Valid default export statements",
         body: function () {
             testModuleScript('export default function () { };', 'Unnamed function expression default export');

--- a/test/es6/objlit.js
+++ b/test/es6/objlit.js
@@ -263,16 +263,16 @@ var tests = [
         name: "BLUE 603997: Method formals redeclaration error",
         body: function() {
             assert.doesNotThrow(function() { eval("var obj = { method(a) { var a; } };"); },                  "Object literal method with a var redeclaration does not throw");
-            assert.throws(function() { eval("var obj = { method(a) { let a; } };"); },           SyntaxError, "Object literal method with a let redeclaration throws",       "Let/Const redeclaration");
-            assert.throws(function() { eval("var obj = { method(a) { const a; } };"); },         SyntaxError, "Object literal method with a const redeclaration throws",     "Let/Const redeclaration");
+            assert.throws(function() { eval("var obj = { method(a) { let a; } };"); },           SyntaxError, "Object literal method with a let redeclaration throws",       "Identifier redeclaration");
+            assert.throws(function() { eval("var obj = { method(a) { const a; } };"); },         SyntaxError, "Object literal method with a const redeclaration throws",     "Identifier redeclaration");
 
             assert.doesNotThrow(function() { eval("var obj = { method(a,b,c) { var b; } };"); },              "Object literal method with a var redeclaration does not throw");
-            assert.throws(function() { eval("var obj = { method(a,b,c) { let b; } };"); },       SyntaxError, "Object literal method with a let redeclaration throws",       "Let/Const redeclaration");
-            assert.throws(function() { eval("var obj = { method(a,b,c) { const b; } };"); },     SyntaxError, "Object literal method with a const redeclaration throws",     "Let/Const redeclaration");
+            assert.throws(function() { eval("var obj = { method(a,b,c) { let b; } };"); },       SyntaxError, "Object literal method with a let redeclaration throws",       "Identifier redeclaration");
+            assert.throws(function() { eval("var obj = { method(a,b,c) { const b; } };"); },     SyntaxError, "Object literal method with a const redeclaration throws",     "Identifier redeclaration");
 
             assert.doesNotThrow(function() { eval("var obj = { set method(a) { var a; } };"); },              "Object literal set method with a var redeclaration does not throw");
-            assert.throws(function() { eval("var obj = { set method(a) { let a; } };"); },       SyntaxError, "Object literal set method with a let redeclaration throws",   "Let/Const redeclaration");
-            assert.throws(function() { eval("var obj = { set method(a) { const a; } };"); },     SyntaxError, "Object literal set method with a const redeclaration throws", "Let/Const redeclaration");
+            assert.throws(function() { eval("var obj = { set method(a) { let a; } };"); },       SyntaxError, "Object literal set method with a let redeclaration throws",   "Identifier redeclaration");
+            assert.throws(function() { eval("var obj = { set method(a) { const a; } };"); },     SyntaxError, "Object literal set method with a const redeclaration throws", "Identifier redeclaration");
         }
     },
     {

--- a/test/es6/rest.js
+++ b/test/es6/rest.js
@@ -29,26 +29,26 @@ var tests = [
       assert.throws(function () { function foo(...a) { eval('var a;'); }; foo(); },
           ReferenceError,
           "Var redeclaration throws with a non-simple parameter list inside an eval",
-          "Let/Const redeclaration");
+          "Identifier redeclaration");
       assert.throws(function () { function foo(a, ...b) { eval('var b;'); }; foo(); },
           ReferenceError,
           "Var redeclaration throws with a non-simple parameter list inside an eval",
-          "Let/Const redeclaration");
+          "Identifier redeclaration");
       assert.throws(function () { function foo(a = 1, ...b) { eval('var b;'); }; foo(); },
           ReferenceError,
           "Var redeclaration throws with a non-simple parameter list inside an eval",
-          "Let/Const redeclaration");
+          "Identifier redeclaration");
       assert.throws(function () { function foo(a, b = 1, ...c) { eval('var c;'); }; foo(); },
           ReferenceError,
           "Var redeclaration throws with a non-simple parameter list inside an eval",
-          "Let/Const redeclaration");
+          "Identifier redeclaration");
 
       assert.doesNotThrow(function () { function foo(...a) { eval('let a;'); }; foo(); }, "Let redeclaration inside an eval does not throw with a non-simple parameter list");
       assert.doesNotThrow(function () { function foo(...a) { eval('const a = "str";'); }; foo() }, "Const redeclaration inside an eval does not throw with a non-simple parameter list");
       assert.throws(function () { function foo(a, ...b) { eval('var a;'); }; foo(); },
                     ReferenceError,
                     "Var redeclaration throws with a non-simple parameter list on a non-rest parameter inside eval",
-                    "Let/Const redeclaration");
+                    "Identifier redeclaration");
       assert.doesNotThrow(function () { function foo(...a) { eval('let a;'); }; foo(); }, "Let redeclaration of a non-default parameter inside an eval does not throw with a non-simple parameter list");
       assert.doesNotThrow(function () { function foo(...a) { eval('const a = 0;'); }; foo(); }, "Const redeclaration of a non-default parameter inside an eval does not throw with a non-simple parameter list");
 

--- a/test/es7/asyncawait-syntax.js
+++ b/test/es7/asyncawait-syntax.js
@@ -184,10 +184,10 @@ var tests = [
         name: "local variables with same names as formal parameters have proper redeclaration semantics",
         body: function () {
             assert.doesNotThrow(function () { eval("async function af(x) { var x; }"); }, "var with same name as formal is not an error");
-            assert.throws(function () { eval("async function af(x) { let x; }"); }, SyntaxError, "let with same name as formal is an error", "Let/Const redeclaration");
-            assert.throws(function () { eval("async function af(x) { const x = 1; }"); }, SyntaxError, "const with same name as formal is an error", "Let/Const redeclaration");
+            assert.throws(function () { eval("async function af(x) { let x; }"); }, SyntaxError, "let with same name as formal is an error", "Identifier redeclaration");
+            assert.throws(function () { eval("async function af(x) { const x = 1; }"); }, SyntaxError, "const with same name as formal is an error", "Identifier redeclaration");
             assert.doesNotThrow(function () { eval("async function af(x) { function x() { } }"); }, "local function with same name as formal is not an error");
-            assert.throws(function () { eval("async function af(x) { class x { } }"); }, SyntaxError, "class with same name as formal is an error", "Let/Const redeclaration");
+            assert.throws(function () { eval("async function af(x) { class x { } }"); }, SyntaxError, "class with same name as formal is an error", "Identifier redeclaration");
         }
     },
     {


### PR DESCRIPTION
Function declarations in module top-level should be treated as a lexical declarations,
and early error should be thrown upon redeclaration. Fix by checking for function
declaration in module top-level in redeclaration code path.

15.2.1.1Static Semantics: Early Errors
It is a Syntax Error if any element of the LexicallyDeclaredNames of ModuleItemList also
occurs in the VarDeclaredNames of ModuleItemList

15.2.1.11 NOTE 2
At the top level of a Module, function declarations are treated like lexical declarations
rather than like var declarations.

Fixes https://github.com/Microsoft/ChakraCore/issues/3254