### PR TITLE
Fix #2983 WeakMap + HostObject === Sadness (TypeError when using HostObject with WeakMap)

### DIFF
--- a/lib/Runtime/Library/JavascriptWeakMap.cpp
+++ b/lib/Runtime/Library/JavascriptWeakMap.cpp
@@ -24,9 +24,12 @@ namespace Js
         return static_cast<JavascriptWeakMap *>(RecyclableObject::FromVar(aValue));
     }
 
-    JavascriptWeakMap::WeakMapKeyMap* JavascriptWeakMap::GetWeakMapKeyMapFromKey(DynamicObject* key) const
+    JavascriptWeakMap::WeakMapKeyMap* JavascriptWeakMap::GetWeakMapKeyMapFromKey(RecyclableObject* key) const
     {
+        AssertOrFailFast(DynamicType::Is(key->GetTypeId()) || JavascriptOperators::GetTypeId(key) == TypeIds_HostDispatch);
+
         Var weakMapKeyData = nullptr;
+
         if (!key->GetInternalProperty(key, InternalPropertyIds::WeakMapKeyMap, &weakMapKeyData, nullptr, key->GetScriptContext()))
         {
             return nullptr;
@@ -42,8 +45,10 @@ namespace Js
         return static_cast<WeakMapKeyMap*>(weakMapKeyData);
     }
 
-    JavascriptWeakMap::WeakMapKeyMap* JavascriptWeakMap::AddWeakMapKeyMapToKey(DynamicObject* key)
+    JavascriptWeakMap::WeakMapKeyMap* JavascriptWeakMap::AddWeakMapKeyMapToKey(RecyclableObject* key)
     {
+        AssertOrFailFast(DynamicType::Is(key->GetTypeId()) || JavascriptOperators::GetTypeId(key) == TypeIds_HostDispatch);
+
         // The internal property may exist on an object that has had DynamicObject::ResetObject called on itself.
         // In that case the value stored in the property slot should be null.
         DebugOnly(Var unused = nullptr);
@@ -163,9 +168,9 @@ namespace Js
         Var key = (args.Info.Count > 1) ? args[1] : scriptContext->GetLibrary()->GetUndefined();
         bool didDelete = false;
 
-        if (JavascriptOperators::IsObject(key) && JavascriptOperators::GetTypeId(key) != TypeIds_HostDispatch)
+        if (JavascriptOperators::IsObject(key))
         {
-            DynamicObject* keyObj = DynamicObject::FromVar(key);
+            RecyclableObject* keyObj = RecyclableObject::FromVar(key);
 
             didDelete = weakMap->Delete(keyObj);
         }
@@ -205,9 +210,9 @@ namespace Js
 
         bool loaded = false;
         Var value = nullptr;
-        if (JavascriptOperators::IsObject(key) && JavascriptOperators::GetTypeId(key) != TypeIds_HostDispatch)
+        if (JavascriptOperators::IsObject(key))
         {
-            DynamicObject* keyObj = DynamicObject::FromVar(key);
+            RecyclableObject* keyObj = RecyclableObject::FromVar(key);
             loaded = weakMap->Get(keyObj, &value);
         }
 
@@ -245,9 +250,9 @@ namespace Js
         Var key = (args.Info.Count > 1) ? args[1] : scriptContext->GetLibrary()->GetUndefined();
         bool hasValue = false;
 
-        if (JavascriptOperators::IsObject(key) && JavascriptOperators::GetTypeId(key) != TypeIds_HostDispatch)
+        if (JavascriptOperators::IsObject(key))
         {
-            DynamicObject* keyObj = DynamicObject::FromVar(key);
+            RecyclableObject* keyObj = RecyclableObject::FromVar(key);
 
             hasValue = weakMap->Has(keyObj);
         }
@@ -286,14 +291,12 @@ namespace Js
         Var key = (args.Info.Count > 1) ? args[1] : scriptContext->GetLibrary()->GetUndefined();
         Var value = (args.Info.Count > 2) ? args[2] : scriptContext->GetLibrary()->GetUndefined();
 
-        if (!JavascriptOperators::IsObject(key) || JavascriptOperators::GetTypeId(key) == TypeIds_HostDispatch)
+        if (!JavascriptOperators::IsObject(key))
         {
-            // HostDispatch can not expand so can't have internal property added to it.
-            // TODO: Support HostDispatch as WeakMap key
             JavascriptError::ThrowTypeError(scriptContext, JSERR_WeakMapSetKeyNotAnObject, _u("WeakMap.prototype.set"));
         }
 
-        DynamicObject* keyObj = DynamicObject::FromVar(key);
+        RecyclableObject* keyObj = RecyclableObject::FromVar(key);
 
 #if ENABLE_TTD
         //In replay we need to pin the object (and will release at snapshot points) -- in record we don't need to do anything
@@ -310,7 +313,7 @@ namespace Js
 
     void JavascriptWeakMap::Clear()
     {
-        keySet.Map([&](DynamicObject* key, bool value, const RecyclerWeakReference<DynamicObject>* weakRef) {
+        keySet.Map([&](RecyclableObject* key, bool value, const RecyclerWeakReference<RecyclableObject>* weakRef) {
             WeakMapKeyMap* keyMap = GetWeakMapKeyMapFromKey(key);
 
             // It may be the case that a CEO has been reset and the keyMap is now null.
@@ -326,7 +329,7 @@ namespace Js
         keySet.Clear();
     }
 
-    bool JavascriptWeakMap::Delete(DynamicObject* key)
+    bool JavascriptWeakMap::Delete(RecyclableObject* key)
     {
         WeakMapKeyMap* keyMap = GetWeakMapKeyMapFromKey(key);
 
@@ -343,7 +346,7 @@ namespace Js
         return false;
     }
 
-    bool JavascriptWeakMap::Get(DynamicObject* key, Var* value) const
+    bool JavascriptWeakMap::Get(RecyclableObject* key, Var* value) const
     {
         WeakMapKeyMap* keyMap = GetWeakMapKeyMapFromKey(key);
 
@@ -355,7 +358,7 @@ namespace Js
         return false;
     }
 
-    bool JavascriptWeakMap::Has(DynamicObject* key) const
+    bool JavascriptWeakMap::Has(RecyclableObject* key) const
     {
         WeakMapKeyMap* keyMap = GetWeakMapKeyMapFromKey(key);
 
@@ -367,7 +370,7 @@ namespace Js
         return false;
     }
 
-    void JavascriptWeakMap::Set(DynamicObject* key, Var value)
+    void JavascriptWeakMap::Set(RecyclableObject* key, Var value)
     {
         WeakMapKeyMap* keyMap = GetWeakMapKeyMapFromKey(key);
 
@@ -393,14 +396,14 @@ namespace Js
         Js::ScriptContext* scriptContext = this->GetScriptContext();
         if(scriptContext->IsTTDReplayModeEnabled())
         {
-            this->Map([&](DynamicObject* key, Js::Var value)
+            this->Map([&](RecyclableObject* key, Js::Var value)
             {
                 scriptContext->TTDContextInfo->TTDWeakReferencePinSet->AddNew(key);
             });
         }
 
         //Keys are weak so are always reachable from somewhere else but values are not so we must walk them
-        this->Map([&](DynamicObject* key, Js::Var value)
+        this->Map([&](RecyclableObject* key, Js::Var value)
         {
             extractor->MarkVisitVar(value);
         });
@@ -419,7 +422,7 @@ namespace Js
         smi->MapSize = 0;
         smi->MapKeyValueArray = alloc.SlabReserveArraySpace<TTD::TTDVar>(mapCountEst + 1); //always reserve at least 1 element
 
-        this->Map([&](DynamicObject* key, Js::Var value)
+        this->Map([&](RecyclableObject* key, Js::Var value)
         {
             AssertMsg(smi->MapSize + 1 < mapCountEst, "We are writting junk");
 

--- a/lib/Runtime/Library/JavascriptWeakMap.h
+++ b/lib/Runtime/Library/JavascriptWeakMap.h
@@ -42,12 +42,12 @@ namespace Js
         // its type and therefore without invalidating cache and JIT assumptions.
         //
         typedef JsUtil::BaseDictionary<WeakMapId, Var, Recycler, PowerOf2SizePolicy, RecyclerPointerComparer> WeakMapKeyMap;
-        typedef JsUtil::WeaklyReferencedKeyDictionary<DynamicObject, bool, RecyclerPointerComparer<const DynamicObject*>> KeySet;
+        typedef JsUtil::WeaklyReferencedKeyDictionary<RecyclableObject, bool, RecyclerPointerComparer<const RecyclableObject*>> KeySet;
 
         Field(KeySet) keySet;
 
-        WeakMapKeyMap* GetWeakMapKeyMapFromKey(DynamicObject* key) const;
-        WeakMapKeyMap* AddWeakMapKeyMapToKey(DynamicObject* key);
+        WeakMapKeyMap* GetWeakMapKeyMapFromKey(RecyclableObject* key) const;
+        WeakMapKeyMap* AddWeakMapKeyMapToKey(RecyclableObject* key);
 
         WeakMapId GetWeakMapId() const { return (void*)(((uintptr_t)this) | 1); }
         static JavascriptWeakMap* GetWeakMapFromId(WeakMapId id) { return reinterpret_cast<JavascriptWeakMap*>((uintptr_t)id & (~1)); }
@@ -64,10 +64,10 @@ namespace Js
         static JavascriptWeakMap* FromVar(Var aValue);
 
         void Clear();
-        bool Delete(DynamicObject* key);
-        bool Get(DynamicObject* key, Var* value) const;
-        bool Has(DynamicObject* key) const;
-        void Set(DynamicObject* key, Var value);
+        bool Delete(RecyclableObject* key);
+        bool Get(RecyclableObject* key, Var* value) const;
+        bool Has(RecyclableObject* key) const;
+        void Set(RecyclableObject* key, Var value);
 
         virtual void Finalize(bool isShutdown) override { Clear(); }
         virtual void Dispose(bool isShutdown) override { }
@@ -96,7 +96,7 @@ namespace Js
         template <typename Fn>
         void Map(Fn fn)
         {
-            return keySet.Map([&](DynamicObject* key, bool, const RecyclerWeakReference<DynamicObject>*)
+            return keySet.Map([&](RecyclableObject* key, bool, const RecyclerWeakReference<RecyclableObject>*)
             {
                 Var value = nullptr;
                 WeakMapKeyMap* keyMap = GetWeakMapKeyMapFromKey(key);

--- a/lib/Runtime/Library/JavascriptWeakSet.cpp
+++ b/lib/Runtime/Library/JavascriptWeakSet.cpp
@@ -105,7 +105,7 @@ namespace Js
             JavascriptError::ThrowTypeError(scriptContext, JSERR_WeakMapSetKeyNotAnObject, _u("WeakSet.prototype.add"));
         }
 
-        DynamicObject* keyObj = DynamicObject::FromVar(key);
+        RecyclableObject* keyObj = RecyclableObject::FromVar(key);
 
 #if ENABLE_TTD
         //In replay we need to pin the object (and will release at snapshot points) -- in record we don't need to do anything
@@ -139,7 +139,7 @@ namespace Js
 
         if (JavascriptOperators::IsObject(key) && JavascriptOperators::GetTypeId(key) != TypeIds_HostDispatch)
         {
-            DynamicObject* keyObj = DynamicObject::FromVar(key);
+            RecyclableObject* keyObj = RecyclableObject::FromVar(key);
 
             didDelete = weakSet->Delete(keyObj);
         }
@@ -180,7 +180,7 @@ namespace Js
 
         if (JavascriptOperators::IsObject(key) && JavascriptOperators::GetTypeId(key) != TypeIds_HostDispatch)
         {
-            DynamicObject* keyObj = DynamicObject::FromVar(key);
+            RecyclableObject* keyObj = RecyclableObject::FromVar(key);
 
             hasValue = weakSet->Has(keyObj);
         }
@@ -202,18 +202,18 @@ namespace Js
         return scriptContext->GetLibrary()->CreateBoolean(hasValue);
     }
 
-    void JavascriptWeakSet::Add(DynamicObject* key)
+    void JavascriptWeakSet::Add(RecyclableObject* key)
     {
         keySet.Item(key, true);
     }
 
-    bool JavascriptWeakSet::Delete(DynamicObject* key)
+    bool JavascriptWeakSet::Delete(RecyclableObject* key)
     {
         bool unused = false;
         return keySet.TryGetValueAndRemove(key, &unused);
     }
 
-    bool JavascriptWeakSet::Has(DynamicObject* key)
+    bool JavascriptWeakSet::Has(RecyclableObject* key)
     {
         bool unused = false;
         return keySet.TryGetValue(key, &unused);
@@ -232,7 +232,7 @@ namespace Js
         Js::ScriptContext* scriptContext = this->GetScriptContext();
         if(scriptContext->IsTTDReplayModeEnabled())
         {
-            this->Map([&](DynamicObject* key)
+            this->Map([&](RecyclableObject* key)
             {
                 scriptContext->TTDContextInfo->TTDWeakReferencePinSet->AddNew(key);
             });
@@ -252,7 +252,7 @@ namespace Js
         ssi->SetSize = 0;
         ssi->SetValueArray = alloc.SlabReserveArraySpace<TTD::TTDVar>(setCountEst + 1); //always reserve at least 1 element
 
-        this->Map([&](DynamicObject* key)
+        this->Map([&](RecyclableObject* key)
         {
             AssertMsg(ssi->SetSize < setCountEst, "We are writting junk");
 

--- a/lib/Runtime/Library/JavascriptWeakSet.h
+++ b/lib/Runtime/Library/JavascriptWeakSet.h
@@ -9,7 +9,7 @@ namespace Js
     class JavascriptWeakSet : public DynamicObject
     {
     private:
-        typedef JsUtil::WeaklyReferencedKeyDictionary<DynamicObject, bool, RecyclerPointerComparer<const DynamicObject*>> KeySet;
+        typedef JsUtil::WeaklyReferencedKeyDictionary<RecyclableObject, bool, RecyclerPointerComparer<const RecyclableObject*>> KeySet;
 
         Field(KeySet) keySet;
 
@@ -22,9 +22,9 @@ namespace Js
         static bool Is(Var aValue);
         static JavascriptWeakSet* FromVar(Var aValue);
 
-        void Add(DynamicObject* key);
-        bool Delete(DynamicObject* key);
-        bool Has(DynamicObject* key);
+        void Add(RecyclableObject* key);
+        bool Delete(RecyclableObject* key);
+        bool Has(RecyclableObject* key);
 
         virtual BOOL GetDiagTypeString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext) override;
 
@@ -48,7 +48,7 @@ namespace Js
         template <typename Fn>
         void Map(Fn fn)
         {
-            return keySet.Map([&](DynamicObject* key, bool, const RecyclerWeakReference<DynamicObject>*)
+            return keySet.Map([&](RecyclableObject* key, bool, const RecyclerWeakReference<RecyclableObject>*)
             {
                 fn(key);
             });


### PR DESCRIPTION
Our implementation of WeakMap and WeakSet uses internal properties on DynamicObjects to store the <WeakMap pointer, value> pair data. This allows us to follow the lifetime of the object. Unfortunately, HostDispatch objects such as window.location are not DynamicObjects, and so we throw a type error. We did not expect widespread use of HostDispatch objects as keys, so this was left as a TODO.

Since Ember is now encountering this with window.location, we need to support this scenario.

This change allows HostDispatch objects to be used as a WeakMap key. HostDispatch has a matching change to support this WeakMap data. No other RecyclableObjects are supported, and we assert as such when trying to access the object key map data from within it.
