### PR TITLE
Fix issue#3245: Semicolon should not be required after certain module export forms

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -2709,7 +2709,7 @@ LDefault:
 }
 
 template<bool buildAST>
-ParseNodePtr Parser::ParseExportDeclaration()
+ParseNodePtr Parser::ParseExportDeclaration(bool *needTerminator)
 {
     Assert(m_scriptContext->GetConfig()->IsES6ModuleEnabled());
     Assert(m_token.tk == tkEXPORT);
@@ -2722,6 +2722,11 @@ ParseNodePtr Parser::ParseExportDeclaration()
     ParseNodePtr pnode = nullptr;
     IdentPtr moduleIdentifier = nullptr;
     tokens declarationType;
+
+    if (needTerminator != nullptr)
+    {
+        *needTerminator = false;
+    }
 
     // We just parsed an export token. Next valid tokens are *, {, var, let, const, async, function, class, default.
     m_pscan->Scan();
@@ -2742,6 +2747,11 @@ ParseNodePtr Parser::ParseExportDeclaration()
             IdentPtr importName = wellKnownPropertyPids._star;
 
             AddModuleImportOrExportEntry(EnsureModuleStarExportEntryList(), importName, nullptr, nullptr, moduleIdentifier);
+        }
+
+        if (needTerminator != nullptr)
+        {
+            *needTerminator = true;
         }
 
         break;
@@ -2784,6 +2794,12 @@ ParseNodePtr Parser::ParseExportDeclaration()
                 exportEntryList.Clear();
             }
         }
+
+        if (needTerminator != nullptr)
+        {
+            *needTerminator = true;
+        }
+
         break;
 
     case tkID:
@@ -10222,14 +10238,24 @@ LGetJumpStatement:
         goto LNeedTerminator;
 
     case tkEXPORT:
+    {
         if (!(m_grfscr & fscrIsModuleCode))
         {
             goto LDefaultToken;
         }
 
-        pnode = ParseExportDeclaration<buildAST>();
+        bool needTerminator = false;
+        pnode = ParseExportDeclaration<buildAST>(&needTerminator);
 
-        goto LNeedTerminator;
+        if (needTerminator)
+        {
+            goto LNeedTerminator;
+        }
+        else
+        {
+            break;
+        }
+    }
 
 LDefaultToken:
     default:

--- a/lib/Parser/Parse.h
+++ b/lib/Parser/Parse.h
@@ -868,7 +868,7 @@ private:
     template<bool buildAST> void ParseImportClause(ModuleImportOrExportEntryList* importEntryList, bool parsingAfterComma = false);
     template<bool buildAST> ParseNodePtr ParseImportCall();
 
-    template<bool buildAST> ParseNodePtr ParseExportDeclaration();
+    template<bool buildAST> ParseNodePtr ParseExportDeclaration(bool *needTerminator = nullptr);
     template<bool buildAST> ParseNodePtr ParseDefaultExportClause();
 
     template<bool buildAST> void ParseNamedImportOrExportClause(ModuleImportOrExportEntryList* importOrExportEntryList, bool isExportClause);

--- a/test/es6/module-syntax.js
+++ b/test/es6/module-syntax.js
@@ -66,6 +66,31 @@ var tests = [
         }
     },
     {
+        name: "Valid export statements without semicolon",
+        body: function () {
+            testModuleScript('export var v0 if (true) { }', 'var declaration export');
+            testModuleScript('export let l0 if (true) { }', 'let declaration export');
+            testModuleScript('export const const0 = 0 if (true) { }', 'const declaration export');
+            testModuleScript('export function f() { } if (true) { }', 'function declaration export');
+            testModuleScript('export function *g() { } if (true) { }', 'function generator declaration export');
+            testModuleScript('export var c0 = class { } if (true) { }', 'var with unnamed class expression export');
+            testModuleScript('export class c1 { } if (true) { }', 'Named class expression export');
+            testModuleScript('export default function () { } if (true) { }', 'Unnamed function expression default export');
+            testModuleScript('export default function _fn2 () { } if (true) { }', 'Named function expression default export');
+            testModuleScript('export default function* () { } if (true) { }', 'Unnamed generator function expression default export');
+            testModuleScript('export default function* _gn2 () { } if (true) { }', 'Named generator function expression default export');
+            testModuleScript('export default class { } if (true) { }', 'Unnamed class expression default export');
+            testModuleScript('export default class _cl2 { } if (true) { }', 'Named class default expression export');
+            testModuleScript('export default 1 if (true) { }', 'Primitive type default export');
+            testModuleScript('var a; export default a = 10 if (true) { }', 'Variable in assignment expression default export');
+            testModuleScript('export default () => 3 if (true) { }', 'Simple default lambda expression export statement');
+            testModuleScript('function _default() { }; export default _default if (true) { }', 'Named function statement default export');
+            testModuleScript('function* g() { }; export default g if (true) { }', 'Named generator function statement default export');
+            testModuleScript('class c { }; export default c if (true) { }', 'Named class statement default export');
+            testModuleScript("var _ = { method: function() { return 'method_result'; }, method2: function() { return 'method2_result'; } }; export default _ if (true) { }", 'Export object with methods - framework model');
+        }
+    },
+    {
         name: "Syntax error export statements",
         body: function () {
             testModuleScript('export const const1;', 'Syntax error if const decl is missing initializer', true);


### PR DESCRIPTION
Following export declaration forms do not require termination with semicolon (15.2.3):

exportVariableStatement[~Yield, ~Await]
exportDeclaration[~Yield, ~Await]
exportdefaultHoistableDeclaration[~Yield, ~Await, +Default]
exportdefaultClassDeclaration[~Yield, ~Await, +Default]
