### PR TITLE
Added a function to change the callback state of a JS external function

### DIFF
--- a/lib/Jsrt/ChakraCommon.h
+++ b/lib/Jsrt/ChakraCommon.h
@@ -2138,6 +2138,25 @@ typedef unsigned short uint16_t;
             _In_opt_ void *callbackState,
             _Out_ JsValueRef *function);
 
+
+    /// <summary>
+    ///     Changes the internal callback state for an external function.
+    /// </summary>
+    /// <remarks>
+    ///     Requires an active script context.
+    /// </remarks>
+    /// <param name="function">The function object.</param>
+    /// <param name="callbackState">
+    ///     User provided state that will be passed back to the callback.
+    /// </param>
+    /// <returns>
+    ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
+    /// </returns>
+    CHAKRA_API
+        JsSetExternalFunctionState(
+              _In_ JsValueRef function,
+              _In_opt_ void *callbackState);
+
     /// <summary>
     ///     Creates a new JavaScript error object
     /// </summary>

--- a/lib/Jsrt/Jsrt.cpp
+++ b/lib/Jsrt/Jsrt.cpp
@@ -2432,6 +2432,22 @@ CHAKRA_API JsCreateNamedFunction(_In_ JsValueRef name, _In_ JsNativeFunction nat
     });
 }
 
+CHAKRA_API JsSetExternalFunctionState(_In_ JsValueRef function, _In_opt_ void *callbackState)
+{
+    return ContextAPIWrapper<JSRT_MAYBE_TRUE>([&](Js::ScriptContext *scriptContext, TTDRecorder& _actionEntryPopper) -> JsErrorCode {
+        VALIDATE_INCOMING_FUNCTION(function, scriptContext);
+
+        Js::JavascriptFunction *jsFunction = Js::JavascriptFunction::FromVar(function);
+        if(jsFunction != JS_INVALID_REFERENCE && jsFunction->IsExternalFunction())
+        {
+            Js::JavascriptExternalFunction *externalFunction = (Js::JavascriptExternalFunction *) jsFunction;
+            externalFunction->SetCallbackState(callbackState);
+        }
+
+        return JsNoError;
+    });
+}
+
 void SetErrorMessage(Js::ScriptContext *scriptContext, JsValueRef newError, JsValueRef message)
 {
     Js::JavascriptOperators::OP_SetProperty(newError, Js::PropertyIds::message, message, scriptContext);


### PR DESCRIPTION
The functionality to change the callback state of a js::JavascriptExternalFunction already existed inside of the library, but there was no externally visible API in ChakraCore to use this functionality.