### PR TITLE
OS#9030969 fix stack trace with jitted loops

### DIFF
--- a/lib/Runtime/Language/JavascriptStackWalker.cpp
+++ b/lib/Runtime/Language/JavascriptStackWalker.cpp
@@ -522,17 +522,6 @@ namespace Js
     {
         this->isJavascriptFrame = this->CheckJavascriptFrame(includeInlineFrames);
 
-#if ENABLE_NATIVE_CODEGEN
-        if (this->IsJavascriptFrame() && this->interpreterFrame && lastInternalFrameInfo.codeAddress != nullptr)
-        {
-            this->previousInterpreterFrameIsForLoopBody = true;
-        }
-        else
-        {
-            this->previousInterpreterFrameIsForLoopBody = false;
-        }
-#endif
-
         if (this->IsJavascriptFrame())
         {
             // In case we have a cross site thunk, update the script context
@@ -543,6 +532,13 @@ namespace Js
 #endif
             if (this->interpreterFrame)
             {
+#if ENABLE_NATIVE_CODEGEN
+                if (lastInternalFrameInfo.codeAddress != nullptr)
+                {
+                    this->previousInterpreterFrameIsForLoopBody = true;
+                }
+#endif
+
                 // We might've bailed out of an inlinee, so check if there were any inlinees.
                 if (this->interpreterFrame->GetFlags() & InterpreterStackFrameFlags_FromBailOut)
                 {
@@ -678,6 +674,7 @@ namespace Js
 #if ENABLE_NATIVE_CODEGEN
         if (lastInternalFrameInfo.codeAddress != nullptr && this->previousInterpreterFrameIsForLoopBody)
         {
+            this->previousInterpreterFrameIsForLoopBody = false;
             ClearCachedInternalFrameInfo();
         }
 

--- a/lib/Runtime/Language/JavascriptStackWalker.cpp
+++ b/lib/Runtime/Language/JavascriptStackWalker.cpp
@@ -523,17 +523,17 @@ namespace Js
         this->isJavascriptFrame = this->CheckJavascriptFrame(includeInlineFrames);
 
 #if ENABLE_NATIVE_CODEGEN
-		if (this->IsJavascriptFrame() && this->interpreterFrame && lastInternalFrameInfo.codeAddress != nullptr)
-		{
-			this->previousInterpreterFrameIsForLoopBody = true;
-		}
-		else
-		{
-			this->previousInterpreterFrameIsForLoopBody = false;
-		}
+        if (this->IsJavascriptFrame() && this->interpreterFrame && lastInternalFrameInfo.codeAddress != nullptr)
+        {
+            this->previousInterpreterFrameIsForLoopBody = true;
+        }
+        else
+        {
+            this->previousInterpreterFrameIsForLoopBody = false;
+        }
 #endif
-		
-		if (this->IsJavascriptFrame())
+
+        if (this->IsJavascriptFrame())
         {
             // In case we have a cross site thunk, update the script context
             Js::JavascriptFunction *function = this->GetCurrentFunction();

--- a/lib/Runtime/Language/JavascriptStackWalker.cpp
+++ b/lib/Runtime/Language/JavascriptStackWalker.cpp
@@ -522,7 +522,18 @@ namespace Js
     {
         this->isJavascriptFrame = this->CheckJavascriptFrame(includeInlineFrames);
 
-        if (this->IsJavascriptFrame())
+#if ENABLE_NATIVE_CODEGEN
+		if (this->IsJavascriptFrame() && this->interpreterFrame && lastInternalFrameInfo.codeAddress != nullptr)
+		{
+			this->previousInterpreterFrameIsForLoopBody = true;
+		}
+		else
+		{
+			this->previousInterpreterFrameIsForLoopBody = false;
+		}
+#endif
+		
+		if (this->IsJavascriptFrame())
         {
             // In case we have a cross site thunk, update the script context
             Js::JavascriptFunction *function = this->GetCurrentFunction();
@@ -532,17 +543,6 @@ namespace Js
 #endif
             if (this->interpreterFrame)
             {
-#if ENABLE_NATIVE_CODEGEN
-                if (lastInternalFrameInfo.codeAddress != nullptr)
-                {
-                    this->previousInterpreterFrameIsForLoopBody = true;
-                }
-                else
-#endif
-                {
-                    this->previousInterpreterFrameIsForLoopBody = false;
-                }
-
                 // We might've bailed out of an inlinee, so check if there were any inlinees.
                 if (this->interpreterFrame->GetFlags() & InterpreterStackFrameFlags_FromBailOut)
                 {


### PR DESCRIPTION
native code address was being cleared more often than it should, causing the trace to use the line/column numbers of the last bytecode instruction executed, which is not where the error occurs if it was during jitted code.