### PR TITLE
clarifying error message when trying to change non-configurable, non-writable property

### DIFF
--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -8673,9 +8673,12 @@ CommonNumber:
                 {
                     if (!currentDescriptor->IsWritable())
                     {
-                        if ((descriptor.WritableSpecified() && descriptor.IsWritable()) ||  // ES5 8.12.9.10.a.i
-                            (descriptor.ValueSpecified() &&
-                                !JavascriptConversion::SameValue(descriptor.GetValue(), currentDescriptor->GetValue()))) // ES5 8.12.9.10.a.ii
+                        if (descriptor.WritableSpecified() && descriptor.IsWritable())  // ES5 8.12.9.10.a.i
+                        {
+                            return Reject(throwOnError, scriptContext, JSERR_DefineProperty_NotConfigurable, propId);
+                        }
+                        else if (descriptor.ValueSpecified() &&
+                                !JavascriptConversion::SameValue(descriptor.GetValue(), currentDescriptor->GetValue())) // ES5 8.12.9.10.a.ii
                         {
                             return Reject(throwOnError, scriptContext, JSERR_DefineProperty_NotWritable, propId);
                         }

--- a/test/es5/defineProperty.js
+++ b/test/es5/defineProperty.js
@@ -320,7 +320,7 @@ var tests = {
       var pd = { value: 1 };
       Object.defineProperty(o, propertyName, pd);
       pd = { value: 2, writable: true };
-      assert.throws(function() { Object.defineProperty(o, propertyName, pd); }, TypeError);
+      assert.throws(function() { Object.defineProperty(o, propertyName, pd); }, TypeError, '', 'Cannot redefine non-configurable property \'foo21\'');
       return true;
     }
   },
@@ -333,7 +333,7 @@ var tests = {
       var pd = { value: 1 };
       Object.defineProperty(o, propertyName, pd);
       pd = { value: 2, writable: false };
-      assert.throws(function() { Object.defineProperty(o, propertyName, pd); }, TypeError);
+      assert.throws(function() { Object.defineProperty(o, propertyName, pd); }, TypeError, '', 'Cannot modify non-writable property \'foo22\'');
     }
   },
 


### PR DESCRIPTION
when trying to change e a non-configurable, non-writable property to a writable property, we would emit an error message saying "Cannot modify non-writable property".  Now, we say "Cannot redefine non-configurable property" since it is more accurate.  Also updated tests to check for correct message in the error that is raised. 

Fixes  #424.

