### PR TITLE
fix double print in trace:backend

### DIFF
--- a/lib/Backend/NativeCodeGenerator.cpp
+++ b/lib/Backend/NativeCodeGenerator.cpp
@@ -1174,8 +1174,6 @@ NativeCodeGenerator::CodeGen(PageAllocator * pageAllocator, CodeGenWorkItem* wor
     {
         body->SetDisableInlineSpread(true);
     }
-    
-    NativeCodeGenerator::LogCodeGenDone(workItem, &start_time);
 
 #ifdef PROFILE_BAILOUT_RECORD_MEMORY
     if (Js::Configuration::Global.flags.ProfileBailOutRecordMemory)


### PR DESCRIPTION
This also causes ETW event for codegen done to fire twice