### PR TITLE
change how we shift addresses from JIT proc to be more futureproof

### DIFF
--- a/lib/Backend/InterpreterThunkEmitter.cpp
+++ b/lib/Backend/InterpreterThunkEmitter.cpp
@@ -456,12 +456,12 @@ void InterpreterThunkEmitter::FillBuffer(
 #ifdef ASMJS_PLAT
     if (asmJsThunk)
     {
-        interpreterThunk = SHIFT_ADDR(threadContext, &Js::InterpreterStackFrame::InterpreterAsmThunk);
+        interpreterThunk = ShiftAddr(threadContext, &Js::InterpreterStackFrame::InterpreterAsmThunk);
     }
     else
 #endif
     {
-        interpreterThunk = SHIFT_ADDR(threadContext, &Js::InterpreterStackFrame::InterpreterThunk);
+        interpreterThunk = ShiftAddr(threadContext, &Js::InterpreterStackFrame::InterpreterThunk);
     }
 
 

--- a/lib/Backend/JnHelperMethod.cpp
+++ b/lib/Backend/JnHelperMethod.cpp
@@ -141,7 +141,7 @@ GetMethodAddress(ThreadContextInfo * context, IR::HelperCallOpnd* opnd)
 
         if (0 <= diagOpnd->m_argCount && diagOpnd->m_argCount <= LowererMDFinal::MaxArgumentsToHelper)
         {
-            return SHIFT_ADDR(context, helperMethodWrappers[diagOpnd->m_argCount]);
+            return ShiftAddr(context, helperMethodWrappers[diagOpnd->m_argCount]);
         }
         else
         {
@@ -175,109 +175,109 @@ DECLSPEC_GUARDIGNORE  _NOINLINE intptr_t GetNonTableMethodAddress(ThreadContextI
 #if defined(_M_IX86)
         // TODO: OOP JIT, have some way to validate that these are all loaded from CRT
     case HelperDirectMath_Acos:
-        return SHIFT_CRT_ADDR(context, (double(*)(double))__libm_sse2_acos);
+        return ShiftAddr(context, (double(*)(double))__libm_sse2_acos);
 
     case HelperDirectMath_Asin:
-        return SHIFT_CRT_ADDR(context, (double(*)(double))__libm_sse2_asin);
+        return ShiftAddr(context, (double(*)(double))__libm_sse2_asin);
 
     case HelperDirectMath_Atan:
-        return SHIFT_CRT_ADDR(context, (double(*)(double))__libm_sse2_atan);
+        return ShiftAddr(context, (double(*)(double))__libm_sse2_atan);
 
     case HelperDirectMath_Atan2:
-        return SHIFT_CRT_ADDR(context, (double(*)(double, double))__libm_sse2_atan2);
+        return ShiftAddr(context, (double(*)(double, double))__libm_sse2_atan2);
 
     case HelperDirectMath_Cos:
-        return SHIFT_CRT_ADDR(context, (double(*)(double))__libm_sse2_cos);
+        return ShiftAddr(context, (double(*)(double))__libm_sse2_cos);
 
     case HelperDirectMath_Exp:
-        return SHIFT_CRT_ADDR(context, (double(*)(double))__libm_sse2_exp);
+        return ShiftAddr(context, (double(*)(double))__libm_sse2_exp);
 
     case HelperDirectMath_Log:
-        return SHIFT_CRT_ADDR(context, (double(*)(double))__libm_sse2_log);
+        return ShiftAddr(context, (double(*)(double))__libm_sse2_log);
 
     case HelperDirectMath_Sin:
-        return SHIFT_CRT_ADDR(context, (double(*)(double))__libm_sse2_sin);
+        return ShiftAddr(context, (double(*)(double))__libm_sse2_sin);
 
     case HelperDirectMath_Tan:
-        return SHIFT_CRT_ADDR(context, (double(*)(double))__libm_sse2_tan);
+        return ShiftAddr(context, (double(*)(double))__libm_sse2_tan);
 #endif
 
     case HelperDirectMath_FloorDb:
-        return SHIFT_CRT_ADDR(context, (double(*)(double))floor);
+        return ShiftAddr(context, (double(*)(double))floor);
 
     case HelperDirectMath_CeilDb:
-        return SHIFT_CRT_ADDR(context, (double(*)(double))ceil);
+        return ShiftAddr(context, (double(*)(double))ceil);
 
     //
     // These are statically initialized to an import thunk, but let's keep them out of the table in case a new CRT changes this
     //
     case HelperWMemCmp:
-        return SHIFT_CRT_ADDR(context, (int(*)(const char16 *, const char16 *, size_t))wmemcmp);
+        return ShiftAddr(context, (int(*)(const char16 *, const char16 *, size_t))wmemcmp);
 
     case HelperMemCpy:
-        return SHIFT_CRT_ADDR(context, (void*(*)(void *, void const*, size_t))memcpy);
+        return ShiftAddr(context, (void*(*)(void *, void const*, size_t))memcpy);
 
     case HelperDirectMath_FloorFlt:
-        return SHIFT_CRT_ADDR(context, (float(*)(float))floor);
+        return ShiftAddr(context, (float(*)(float))floor);
 
     case HelperDirectMath_CeilFlt:
-        return SHIFT_CRT_ADDR(context, (float(*)(float))ceil);
+        return ShiftAddr(context, (float(*)(float))ceil);
 
 #if defined(_M_X64)
     case HelperDirectMath_Acos:
-        return SHIFT_CRT_ADDR(context, (double(*)(double))acos);
+        return ShiftAddr(context, (double(*)(double))acos);
 
     case HelperDirectMath_Asin:
-        return SHIFT_CRT_ADDR(context, (double(*)(double))asin);
+        return ShiftAddr(context, (double(*)(double))asin);
 
     case HelperDirectMath_Atan:
-        return SHIFT_CRT_ADDR(context, (double(*)(double))atan);
+        return ShiftAddr(context, (double(*)(double))atan);
 
     case HelperDirectMath_Atan2:
-        return SHIFT_CRT_ADDR(context, (double(*)(double, double))atan2);
+        return ShiftAddr(context, (double(*)(double, double))atan2);
 
     case HelperDirectMath_Cos:
-        return SHIFT_CRT_ADDR(context, (double(*)(double))cos);
+        return ShiftAddr(context, (double(*)(double))cos);
 
     case HelperDirectMath_Exp:
-        return SHIFT_CRT_ADDR(context, (double(*)(double))exp);
+        return ShiftAddr(context, (double(*)(double))exp);
 
     case HelperDirectMath_Log:
-        return SHIFT_CRT_ADDR(context, (double(*)(double))log);
+        return ShiftAddr(context, (double(*)(double))log);
 
     case HelperDirectMath_Sin:
-        return SHIFT_CRT_ADDR(context, (double(*)(double))sin);
+        return ShiftAddr(context, (double(*)(double))sin);
 
     case HelperDirectMath_Tan:
-        return SHIFT_CRT_ADDR(context, (double(*)(double))tan);
+        return ShiftAddr(context, (double(*)(double))tan);
 
 #elif defined(_M_ARM32_OR_ARM64)
     case HelperDirectMath_Acos:
-        return SHIFT_CRT_ADDR(context, (double(*)(double))acos);
+        return ShiftAddr(context, (double(*)(double))acos);
 
     case HelperDirectMath_Asin:
-        return SHIFT_CRT_ADDR(context, (double(*)(double))asin);
+        return ShiftAddr(context, (double(*)(double))asin);
 
     case HelperDirectMath_Atan:
-        return SHIFT_CRT_ADDR(context, (double(*)(double))atan);
+        return ShiftAddr(context, (double(*)(double))atan);
 
     case HelperDirectMath_Atan2:
-        return SHIFT_CRT_ADDR(context, (double(*)(double, double))atan2);
+        return ShiftAddr(context, (double(*)(double, double))atan2);
 
     case HelperDirectMath_Cos:
-        return SHIFT_CRT_ADDR(context, (double(*)(double))cos);
+        return ShiftAddr(context, (double(*)(double))cos);
 
     case HelperDirectMath_Exp:
-        return SHIFT_CRT_ADDR(context, (double(*)(double))exp);
+        return ShiftAddr(context, (double(*)(double))exp);
 
     case HelperDirectMath_Log:
-        return SHIFT_CRT_ADDR(context, (double(*)(double))log);
+        return ShiftAddr(context, (double(*)(double))log);
 
     case HelperDirectMath_Sin:
-        return SHIFT_CRT_ADDR(context, (double(*)(double))sin);
+        return ShiftAddr(context, (double(*)(double))sin);
 
     case HelperDirectMath_Tan:
-        return SHIFT_CRT_ADDR(context, (double(*)(double))tan);
+        return ShiftAddr(context, (double(*)(double))tan);
 #endif
 
     //
@@ -290,28 +290,28 @@ DECLSPEC_GUARDIGNORE  _NOINLINE intptr_t GetNonTableMethodAddress(ThreadContextI
 #endif
 
     case HelperOp_TryCatch:
-        return SHIFT_ADDR(context, Js::JavascriptExceptionOperators::OP_TryCatch);
+        return ShiftAddr(context, Js::JavascriptExceptionOperators::OP_TryCatch);
 
     case HelperOp_TryFinally:
-        return SHIFT_ADDR(context, Js::JavascriptExceptionOperators::OP_TryFinally);
+        return ShiftAddr(context, Js::JavascriptExceptionOperators::OP_TryFinally);
 
 
     case HelperOp_TryFinallySimpleJit:
-        return SHIFT_ADDR(context, Js::JavascriptExceptionOperators::OP_TryFinallySimpleJit);
+        return ShiftAddr(context, Js::JavascriptExceptionOperators::OP_TryFinallySimpleJit);
 
     //
     // Methods that we don't want to get marked as CFG targets as they dump all registers to a controlled address
     //
     case HelperSaveAllRegistersAndBailOut:
-        return SHIFT_ADDR(context, LinearScanMD::SaveAllRegistersAndBailOut);
+        return ShiftAddr(context, LinearScanMD::SaveAllRegistersAndBailOut);
     case HelperSaveAllRegistersAndBranchBailOut:
-        return SHIFT_ADDR(context, LinearScanMD::SaveAllRegistersAndBranchBailOut);
+        return ShiftAddr(context, LinearScanMD::SaveAllRegistersAndBranchBailOut);
 
     #ifdef _M_IX86
     case HelperSaveAllRegistersNoSse2AndBailOut:
-        return SHIFT_ADDR(context, LinearScanMD::SaveAllRegistersNoSse2AndBailOut);
+        return ShiftAddr(context, LinearScanMD::SaveAllRegistersNoSse2AndBailOut);
     case HelperSaveAllRegistersNoSse2AndBranchBailOut:
-        return SHIFT_ADDR(context, LinearScanMD::SaveAllRegistersNoSse2AndBranchBailOut);
+        return ShiftAddr(context, LinearScanMD::SaveAllRegistersNoSse2AndBranchBailOut);
     #endif
 
     }
@@ -337,7 +337,7 @@ intptr_t GetMethodOriginalAddress(ThreadContextInfo * context, JnHelperMethod he
         return GetNonTableMethodAddress(context, helperMethod);
     }
 
-    return SHIFT_ADDR(context, address);
+    return ShiftAddr(context, address);
 }
 
 #if DBG_DUMP || defined(ENABLE_IR_VIEWER)

--- a/lib/Backend/ServerThreadContext.cpp
+++ b/lib/Backend/ServerThreadContext.cpp
@@ -162,7 +162,7 @@ ServerThreadContext::GetRuntimeCRTBaseAddress() const
 intptr_t
 ServerThreadContext::GetJITCRTBaseAddress()
 {
-    return (intptr_t)AutoSystemInfo::GetCRTHandle();
+    return (intptr_t)AutoSystemInfo::Data.GetCRTHandle();
 }
 
 PageAllocator *

--- a/lib/Backend/ServerThreadContext.h
+++ b/lib/Backend/ServerThreadContext.h
@@ -34,8 +34,8 @@ public:
 
     virtual bool IsNumericProperty(Js::PropertyId propId) override;
 
-    ptrdiff_t GetChakraBaseAddressDifference() const;
-    ptrdiff_t GetCRTBaseAddressDifference() const;
+    virtual ptrdiff_t GetChakraBaseAddressDifference() const override;
+    virtual ptrdiff_t GetCRTBaseAddressDifference() const override;
 
     OOPCodeGenAllocators * GetCodeGenAllocators();
 #if defined(_CONTROL_FLOW_GUARD) && (_M_IX86 || _M_X64)

--- a/lib/Common/Core/SysInfo.cpp
+++ b/lib/Common/Core/SysInfo.cpp
@@ -398,30 +398,27 @@ LPCWSTR AutoSystemInfo::GetJscriptDllFileName()
 }
 
 #ifdef _WIN32
+/* static */
 HMODULE AutoSystemInfo::GetCRTHandle()
 {
-    if (Data.crtBase == 0)
-    {
-        Data.crtBase = GetModuleHandle(_u("msvcrt.dll"));
-    }
-    return Data.crtBase;
+    return GetModuleHandle(_u("msvcrt.dll"));
 }
 
 bool
 AutoSystemInfo::IsCRTModulePointer(uintptr_t ptr)
 {
-    uintptr_t base = (uintptr_t)GetCRTHandle();
+    HMODULE base = GetCRTHandle();
     if (Data.crtSize == 0)
     {
         MODULEINFO info;
-        if (!GetModuleInformation(GetCurrentProcess(), Data.crtBase, &info, sizeof(MODULEINFO)))
+        if (!GetModuleInformation(GetCurrentProcess(), base, &info, sizeof(MODULEINFO)))
         {
             AssertOrFailFast(UNREACHED);
         }
         Data.crtSize = info.SizeOfImage;
-        Assert(Data.crtBase == info.lpBaseOfDll);
+        Assert(base == info.lpBaseOfDll);
     }
-    return (ptr >= base && ptr < base + Data.crtSize);
+    return (ptr >= (uintptr_t)base && ptr < (uintptr_t)base + Data.crtSize);
 }
 #endif
 

--- a/lib/Common/Core/SysInfo.h
+++ b/lib/Common/Core/SysInfo.h
@@ -39,6 +39,11 @@ public:
     DWORD GetNumberOfLogicalProcessors() const { return this->dwNumberOfProcessors; }
     DWORD GetNumberOfPhysicalProcessors() const { return this->dwNumberOfPhysicalProcessors; }
 
+#ifdef _WIN32
+    HMODULE GetCRTHandle();
+    bool IsCRTModulePointer(uintptr_t ptr);
+#endif
+
 #if SYSINFO_IMAGE_BASE_AVAILABLE
     UINT_PTR GetChakraBaseAddr() const;
 #endif
@@ -49,7 +54,6 @@ public:
     static DWORD SaveModuleFileName(HANDLE hMod);
     static LPCWSTR GetJscriptDllFileName();
     static HRESULT GetJscriptFileVersion(DWORD* majorVersion, DWORD* minorVersion, DWORD *buildDateHash = nullptr, DWORD *buildTimeHash = nullptr);
-    static HMODULE GetCRTHandle();
 #if DBG
     static bool IsInitialized();
 #endif
@@ -78,11 +82,13 @@ public:
 #endif
     
 private:
-    AutoSystemInfo() : majorVersion(0), minorVersion(0), buildDateHash(0), buildTimeHash(0) { Initialize(); }
+    AutoSystemInfo() : majorVersion(0), minorVersion(0), buildDateHash(0), buildTimeHash(0), crtBase(0), crtSize(0) { Initialize(); }
     void Initialize();
     bool isWindows8OrGreater;
     uint allocationGranularityPageCount;
     HANDLE processHandle;
+    HMODULE crtBase;
+    DWORD crtSize;
 #if defined(_M_IX86) || defined(_M_X64)
     int CPUInfo[4];
 #endif

--- a/lib/Common/Core/SysInfo.h
+++ b/lib/Common/Core/SysInfo.h
@@ -40,7 +40,6 @@ public:
     DWORD GetNumberOfPhysicalProcessors() const { return this->dwNumberOfPhysicalProcessors; }
 
 #ifdef _WIN32
-    HMODULE GetCRTHandle();
     bool IsCRTModulePointer(uintptr_t ptr);
 #endif
 
@@ -59,6 +58,9 @@ public:
 #endif
 #if SYSINFO_IMAGE_BASE_AVAILABLE
     static bool IsJscriptModulePointer(void * ptr);
+#endif
+#ifdef _WIN32
+    static HMODULE GetCRTHandle();
 #endif
     static DWORD const PageSize = 4096;
 
@@ -82,12 +84,11 @@ public:
 #endif
     
 private:
-    AutoSystemInfo() : majorVersion(0), minorVersion(0), buildDateHash(0), buildTimeHash(0), crtBase(0), crtSize(0) { Initialize(); }
+    AutoSystemInfo() : majorVersion(0), minorVersion(0), buildDateHash(0), buildTimeHash(0), crtSize(0) { Initialize(); }
     void Initialize();
     bool isWindows8OrGreater;
     uint allocationGranularityPageCount;
     HANDLE processHandle;
-    HMODULE crtBase;
     DWORD crtSize;
 #if defined(_M_IX86) || defined(_M_X64)
     int CPUInfo[4];

--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -1975,7 +1975,7 @@ ThreadContext::EnsureJITThreadContext(bool allowPrereserveAlloc)
 
     ThreadContextDataIDL contextData;
     contextData.chakraBaseAddress = (intptr_t)AutoSystemInfo::Data.GetChakraBaseAddr();
-    contextData.crtBaseAddress = (intptr_t)AutoSystemInfo::GetCRTHandle();
+    contextData.crtBaseAddress = (intptr_t)AutoSystemInfo::Data.GetCRTHandle();
     contextData.threadStackLimitAddr = reinterpret_cast<intptr_t>(GetAddressOfStackLimitForCurrentThread());
     contextData.bailOutRegisterSaveSpaceAddr = (intptr_t)bailOutRegisterSaveSpace;
     contextData.disableImplicitFlagsAddr = (intptr_t)GetAddressOfDisableImplicitFlags();

--- a/lib/Runtime/Base/ThreadContext.h
+++ b/lib/Runtime/Base/ThreadContext.h
@@ -1299,8 +1299,8 @@ public:
     virtual intptr_t GetDisableImplicitFlagsAddr() const override;
     virtual intptr_t GetImplicitCallFlagsAddr() const override;
 
-    ptrdiff_t GetChakraBaseAddressDifference() const;
-    ptrdiff_t GetCRTBaseAddressDifference() const;
+    virtual ptrdiff_t GetChakraBaseAddressDifference() const override;
+    virtual ptrdiff_t GetCRTBaseAddressDifference() const override;
 
 private:
     void RegisterInlineCache(InlineCacheListMapByPropertyId& inlineCacheMap, Js::InlineCache* inlineCache, Js::PropertyId propertyId);

--- a/lib/Runtime/Base/ThreadContextInfo.cpp
+++ b/lib/Runtime/Base/ThreadContextInfo.cpp
@@ -29,197 +29,197 @@ ThreadContextInfo::ThreadContextInfo() :
 intptr_t
 ThreadContextInfo::GetNullFrameDisplayAddr() const
 {
-    return SHIFT_ADDR(this, &Js::NullFrameDisplay);
+    return ShiftAddr(this, &Js::NullFrameDisplay);
 }
 
 intptr_t
 ThreadContextInfo::GetStrictNullFrameDisplayAddr() const
 {
-    return SHIFT_ADDR(this, &Js::StrictNullFrameDisplay);
+    return ShiftAddr(this, &Js::StrictNullFrameDisplay);
 }
 
 intptr_t
 ThreadContextInfo::GetAbsDoubleCstAddr() const
 {
-    return SHIFT_ADDR(this, &Js::JavascriptNumber::AbsDoubleCst);
+    return ShiftAddr(this, &Js::JavascriptNumber::AbsDoubleCst);
 }
 
 intptr_t
 ThreadContextInfo::GetAbsFloatCstAddr() const
 {
-    return SHIFT_ADDR(this, &Js::JavascriptNumber::AbsFloatCst);
+    return ShiftAddr(this, &Js::JavascriptNumber::AbsFloatCst);
 }
 
 intptr_t ThreadContextInfo::GetSgnFloatBitCst() const
 {
-    return SHIFT_ADDR(this, &Js::JavascriptNumber::SgnFloatBitCst);
+    return ShiftAddr(this, &Js::JavascriptNumber::SgnFloatBitCst);
 }
 
 intptr_t ThreadContextInfo::GetSgnDoubleBitCst() const
 {
-    return SHIFT_ADDR(this, &Js::JavascriptNumber::SgnDoubleBitCst);
+    return ShiftAddr(this, &Js::JavascriptNumber::SgnDoubleBitCst);
 }
 
 intptr_t
 ThreadContextInfo::GetMaskNegFloatAddr() const
 {
-    return SHIFT_ADDR(this, &Js::JavascriptNumber::MaskNegFloat);
+    return ShiftAddr(this, &Js::JavascriptNumber::MaskNegFloat);
 }
 
 intptr_t
 ThreadContextInfo::GetMaskNegDoubleAddr() const
 {
-    return SHIFT_ADDR(this, &Js::JavascriptNumber::MaskNegDouble);
+    return ShiftAddr(this, &Js::JavascriptNumber::MaskNegDouble);
 }
 
 intptr_t
 ThreadContextInfo::GetUIntConvertConstAddr() const
 {
-    return SHIFT_ADDR(this, &Js::JavascriptNumber::UIntConvertConst);
+    return ShiftAddr(this, &Js::JavascriptNumber::UIntConvertConst);
 }
 
 intptr_t
 ThreadContextInfo::GetUint8ClampedArraySetItemAddr() const
 {
-    return SHIFT_ADDR(this, (BOOL(*)(Js::Uint8ClampedArray * arr, uint32 index, Js::Var value))&Js::Uint8ClampedArray::DirectSetItem);
+    return ShiftAddr(this, (BOOL(*)(Js::Uint8ClampedArray * arr, uint32 index, Js::Var value))&Js::Uint8ClampedArray::DirectSetItem);
 }
 
 intptr_t
 ThreadContextInfo::GetConstructorCacheDefaultInstanceAddr() const
 {
-    return SHIFT_ADDR(this, &Js::ConstructorCache::DefaultInstance);
+    return ShiftAddr(this, &Js::ConstructorCache::DefaultInstance);
 }
 
 intptr_t
 ThreadContextInfo::GetJavascriptObjectNewInstanceAddr() const
 {
-    return SHIFT_ADDR(this, &Js::JavascriptObject::EntryInfo::NewInstance);
+    return ShiftAddr(this, &Js::JavascriptObject::EntryInfo::NewInstance);
 }
 
 intptr_t
 ThreadContextInfo::GetJavascriptArrayNewInstanceAddr() const
 {
-    return SHIFT_ADDR(this, &Js::JavascriptArray::EntryInfo::NewInstance);
+    return ShiftAddr(this, &Js::JavascriptArray::EntryInfo::NewInstance);
 }
 
 intptr_t
 ThreadContextInfo::GetDoubleOnePointZeroAddr() const
 {
-    return SHIFT_ADDR(this, &Js::JavascriptNumber::ONE_POINT_ZERO);
+    return ShiftAddr(this, &Js::JavascriptNumber::ONE_POINT_ZERO);
 }
 
 intptr_t
 ThreadContextInfo::GetDoublePointFiveAddr() const
 {
-    return SHIFT_ADDR(this, &Js::JavascriptNumber::k_PointFive);
+    return ShiftAddr(this, &Js::JavascriptNumber::k_PointFive);
 }
 
 intptr_t
 ThreadContextInfo::GetFloatPointFiveAddr() const
 {
-    return SHIFT_ADDR(this, &Js::JavascriptNumber::k_Float32PointFive);
+    return ShiftAddr(this, &Js::JavascriptNumber::k_Float32PointFive);
 }
 
 intptr_t
 ThreadContextInfo::GetDoubleNegPointFiveAddr() const
 {
-    return SHIFT_ADDR(this, &Js::JavascriptNumber::k_NegPointFive);
+    return ShiftAddr(this, &Js::JavascriptNumber::k_NegPointFive);
 }
 
 intptr_t
 ThreadContextInfo::GetFloatNegPointFiveAddr() const
 {
-    return SHIFT_ADDR(this, &Js::JavascriptNumber::k_Float32NegPointFive);
+    return ShiftAddr(this, &Js::JavascriptNumber::k_Float32NegPointFive);
 }
 
 intptr_t
 ThreadContextInfo::GetDoubleNegOneAddr() const
 {
-    return SHIFT_ADDR(this, &Js::JavascriptNumber::k_NegOne);
+    return ShiftAddr(this, &Js::JavascriptNumber::k_NegOne);
 }
 
 intptr_t
 ThreadContextInfo::GetDoubleTwoToFractionAddr() const
 {
-    return SHIFT_ADDR(this, &Js::JavascriptNumber::k_TwoToFraction);
+    return ShiftAddr(this, &Js::JavascriptNumber::k_TwoToFraction);
 }
 
 intptr_t
 ThreadContextInfo::GetFloatTwoToFractionAddr() const
 {
-    return SHIFT_ADDR(this, &Js::JavascriptNumber::k_Float32TwoToFraction);
+    return ShiftAddr(this, &Js::JavascriptNumber::k_Float32TwoToFraction);
 }
 
 intptr_t
 ThreadContextInfo::GetDoubleNegTwoToFractionAddr() const
 {
-    return SHIFT_ADDR(this, &Js::JavascriptNumber::k_NegTwoToFraction);
+    return ShiftAddr(this, &Js::JavascriptNumber::k_NegTwoToFraction);
 }
 
 intptr_t
 ThreadContextInfo::GetDoubleNaNAddr() const
 {
-    return SHIFT_ADDR(this, &Js::JavascriptNumber::k_Nan);
+    return ShiftAddr(this, &Js::JavascriptNumber::k_Nan);
 }
 
 intptr_t
 ThreadContextInfo::GetDoubleUintMaxPlusOneAddr() const
 {
-    return SHIFT_ADDR(this, &Js::JavascriptNumber::k_UintMaxPlusOne);
+    return ShiftAddr(this, &Js::JavascriptNumber::k_UintMaxPlusOne);
 }
 
 intptr_t
 ThreadContextInfo::GetDoubleIntMaxPlusOneAddr() const
 {
-    return SHIFT_ADDR(this, &Js::JavascriptNumber::k_IntMaxPlusOne);
+    return ShiftAddr(this, &Js::JavascriptNumber::k_IntMaxPlusOne);
 }
 
 intptr_t
 ThreadContextInfo::GetDoubleIntMinMinusOneAddr() const
 {
-    return SHIFT_ADDR(this, &Js::JavascriptNumber::k_MinIntMinusOne);
+    return ShiftAddr(this, &Js::JavascriptNumber::k_MinIntMinusOne);
 }
 
 intptr_t
 ThreadContextInfo::GetFloatNaNAddr() const
 {
-    return SHIFT_ADDR(this, &Js::JavascriptNumber::k_Nan32);
+    return ShiftAddr(this, &Js::JavascriptNumber::k_Nan32);
 }
 
 intptr_t
 ThreadContextInfo::GetFloatNegTwoToFractionAddr() const
 {
-    return SHIFT_ADDR(this, &Js::JavascriptNumber::k_Float32NegTwoToFraction);
+    return ShiftAddr(this, &Js::JavascriptNumber::k_Float32NegTwoToFraction);
 }
 
 intptr_t
 ThreadContextInfo::GetDoubleZeroAddr() const
 {
-    return SHIFT_ADDR(this, &Js::JavascriptNumber::k_Zero);
+    return ShiftAddr(this, &Js::JavascriptNumber::k_Zero);
 }
 
 intptr_t
 ThreadContextInfo::GetFloatZeroAddr() const
 {
-    return SHIFT_ADDR(this, &Js::JavascriptNumber::k_Float32Zero);
+    return ShiftAddr(this, &Js::JavascriptNumber::k_Float32Zero);
 }
 
 intptr_t
 ThreadContextInfo::GetNativeFloatArrayMissingItemAddr() const
 {
-    return SHIFT_ADDR(this, &Js::JavascriptNativeFloatArray::MissingItem);
+    return ShiftAddr(this, &Js::JavascriptNativeFloatArray::MissingItem);
 }
 
 intptr_t
 ThreadContextInfo::GetExponentMaskAddr() const
 {
-    return SHIFT_ADDR(this, &Js::Constants::ExponentMask);
+    return ShiftAddr(this, &Js::Constants::ExponentMask);
 }
 
 intptr_t
 ThreadContextInfo::GetMantissaMaskAddr() const
 {
-    return SHIFT_ADDR(this, &Js::Constants::MantissaMask);
+    return ShiftAddr(this, &Js::Constants::MantissaMask);
 }
 
 #if _M_IX86 || _M_AMD64
@@ -227,134 +227,134 @@ ThreadContextInfo::GetMantissaMaskAddr() const
 intptr_t
 ThreadContextInfo::GetX86AbsMaskF4Addr() const
 {
-    return SHIFT_ADDR(this, &X86_ABS_MASK_F4);
+    return ShiftAddr(this, &X86_ABS_MASK_F4);
 }
 
 intptr_t
 ThreadContextInfo::GetX86AbsMaskD2Addr() const
 {
-    return SHIFT_ADDR(this, &X86_ABS_MASK_D2);
+    return ShiftAddr(this, &X86_ABS_MASK_D2);
 }
 
 intptr_t
 ThreadContextInfo::GetX86NegMaskF4Addr() const
 {
-    return SHIFT_ADDR(this, &X86_NEG_MASK_F4);
+    return ShiftAddr(this, &X86_NEG_MASK_F4);
 }
 
 intptr_t
 ThreadContextInfo::GetX86NegMaskD2Addr() const
 {
-    return SHIFT_ADDR(this, &X86_NEG_MASK_D2);
+    return ShiftAddr(this, &X86_NEG_MASK_D2);
 }
 
 intptr_t
 ThreadContextInfo::GetX86AllNegOnesAddr() const
 {
-    return SHIFT_ADDR(this, &X86_ALL_NEG_ONES);
+    return ShiftAddr(this, &X86_ALL_NEG_ONES);
 }
 
 intptr_t
 ThreadContextInfo::GetX86AllNegOnesF4Addr() const
 {
-    return SHIFT_ADDR(this, &X86_ALL_NEG_ONES_F4);
+    return ShiftAddr(this, &X86_ALL_NEG_ONES_F4);
 }
 
 intptr_t
 ThreadContextInfo::GetX86AllZerosAddr() const
 {
-    return SHIFT_ADDR(this, &X86_ALL_ZEROS);
+    return ShiftAddr(this, &X86_ALL_ZEROS);
 }
 
 intptr_t
 ThreadContextInfo::GetX86AllOnesF4Addr() const
 {
-    return SHIFT_ADDR(this, &X86_ALL_ONES_F4);
+    return ShiftAddr(this, &X86_ALL_ONES_F4);
 }
 
 intptr_t
 ThreadContextInfo::GetX86LowBytesMaskAddr() const
 {
-    return SHIFT_ADDR(this, &X86_LOWBYTES_MASK);
+    return ShiftAddr(this, &X86_LOWBYTES_MASK);
 }
 
 intptr_t
 ThreadContextInfo::GetX86HighBytesMaskAddr() const
 {
-    return SHIFT_ADDR(this, &X86_HIGHBYTES_MASK);
+    return ShiftAddr(this, &X86_HIGHBYTES_MASK);
 }
 
 intptr_t
 ThreadContextInfo::GetX86DoubleWordSignBitsAddr() const
 {
-    return SHIFT_ADDR(this, &X86_DWORD_SIGNBITS);
+    return ShiftAddr(this, &X86_DWORD_SIGNBITS);
 }
 
 intptr_t
 ThreadContextInfo::GetX86WordSignBitsAddr() const
 {
-    return SHIFT_ADDR(this, &X86_WORD_SIGNBITS);
+    return ShiftAddr(this, &X86_WORD_SIGNBITS);
 }
 
 intptr_t
 ThreadContextInfo::GetX86ByteSignBitsAddr() const
 {
-    return SHIFT_ADDR(this, &X86_BYTE_SIGNBITS);
+    return ShiftAddr(this, &X86_BYTE_SIGNBITS);
 }
 
 intptr_t
 ThreadContextInfo::GetX86TwoPower32F4Addr() const
 {
-    return SHIFT_ADDR(this, &X86_TWO_32_F4);
+    return ShiftAddr(this, &X86_TWO_32_F4);
 }
 
 intptr_t
 ThreadContextInfo::GetX86TwoPower31F4Addr() const
 {
-    return SHIFT_ADDR(this, &X86_TWO_31_F4);
+    return ShiftAddr(this, &X86_TWO_31_F4);
 }
 
 intptr_t
 ThreadContextInfo::GetX86TwoPower31I4Addr() const
 {
-    return SHIFT_ADDR(this, &X86_TWO_31_I4);
+    return ShiftAddr(this, &X86_TWO_31_I4);
 }
 
 intptr_t
 ThreadContextInfo::GetX86NegTwoPower31F4Addr() const
 {
-    return SHIFT_ADDR(this, &X86_NEG_TWO_31_F4);
+    return ShiftAddr(this, &X86_NEG_TWO_31_F4);
 }
 
 intptr_t
 ThreadContextInfo::GetX86FourLanesMaskAddr(uint8 minorityLane) const
 {
-    return SHIFT_ADDR(this, &X86_4LANES_MASKS[minorityLane]);
+    return ShiftAddr(this, &X86_4LANES_MASKS[minorityLane]);
 }
 
 intptr_t
 ThreadContextInfo::GetDoubleIntMinAddr() const
 {
-    return SHIFT_ADDR(this, &Js::JavascriptNumber::DOUBLE_INT_MIN);
+    return ShiftAddr(this, &Js::JavascriptNumber::DOUBLE_INT_MIN);
 }
 
 intptr_t
 ThreadContextInfo::GetDoubleTwoTo31Addr() const
 {
-    return SHIFT_ADDR(this, &Js::JavascriptNumber::DOUBLE_TWO_TO_31);
+    return ShiftAddr(this, &Js::JavascriptNumber::DOUBLE_TWO_TO_31);
 }
 #endif
 
 intptr_t
 ThreadContextInfo::GetStringReplaceNameAddr() const
 {
-    return SHIFT_ADDR(this, Js::Constants::StringReplace);
+    return ShiftAddr(this, Js::Constants::StringReplace);
 }
 
 intptr_t
 ThreadContextInfo::GetStringMatchNameAddr() const
 {
-    return SHIFT_ADDR(this, Js::Constants::StringMatch);
+    return ShiftAddr(this, Js::Constants::StringMatch);
 }
 #endif
 
@@ -487,46 +487,26 @@ ThreadContextInfo::IsClosed()
     return m_isClosed;
 }
 
-intptr_t SHIFT_ADDR(const ThreadContextInfo*const context, intptr_t address)
+uintptr_t ShiftAddr(const ThreadContextInfo * const context, uintptr_t address)
 {
 #if ENABLE_OOP_NATIVE_CODEGEN
-    Assert(AutoSystemInfo::Data.IsJscriptModulePointer((void*)address));
     ptrdiff_t diff = 0;
-    if (JITManager::GetJITManager()->IsJITServer())
-    {
-        diff = ((ServerThreadContext*)context)->GetChakraBaseAddressDifference();
-    }
-    else
-    {
-        diff = ((ThreadContext*)context)->GetChakraBaseAddressDifference();
-    }
-    return (intptr_t)address + diff;
-#else
-    return address;
-#endif
-
-}
-
-intptr_t SHIFT_CRT_ADDR(const ThreadContextInfo*const context, intptr_t address)
-{
-#if ENABLE_OOP_NATIVE_CODEGEN
     if (AutoSystemInfo::Data.IsJscriptModulePointer((void*)address))
     {
-        // the function is compiled to chakra.dll, or statically linked to crt
-        return SHIFT_ADDR(context, address);
+        diff = context->GetChakraBaseAddressDifference();
     }
-    ptrdiff_t diff = 0;
-    if (JITManager::GetJITManager()->IsJITServer())
+    else if(AutoSystemInfo::Data.IsCRTModulePointer(address))
     {
-        diff = ((ServerThreadContext*)context)->GetCRTBaseAddressDifference();
+        diff = context->GetCRTBaseAddressDifference();
     }
     else
     {
-        diff = ((ThreadContext*)context)->GetCRTBaseAddressDifference();
+        AssertOrFailFast(UNREACHED);
     }
+
     return (intptr_t)address + diff;
 #else
     return address;
 #endif
-}
 
+}

--- a/lib/Runtime/Base/ThreadContextInfo.h
+++ b/lib/Runtime/Base/ThreadContextInfo.h
@@ -99,6 +99,9 @@ public:
     virtual intptr_t GetDisableImplicitFlagsAddr() const = 0;
     virtual intptr_t GetImplicitCallFlagsAddr() const = 0;
 
+    virtual ptrdiff_t GetChakraBaseAddressDifference() const = 0;
+    virtual ptrdiff_t GetCRTBaseAddressDifference() const = 0;
+
 #if ENABLE_NATIVE_CODEGEN
 #if defined(ENABLE_SIMDJS) && (defined(_M_IX86) || defined(_M_X64))
     virtual intptr_t GetSimdTempAreaAddr(uint8 tempIndex) const = 0;
@@ -139,19 +142,11 @@ protected:
 
 };
 
-// TODO: OOP JIT, is there any issue when crossing over 2^31/2^63?
 template<typename T>
-intptr_t SHIFT_ADDR(const ThreadContextInfo*const context, T* address)
+uintptr_t ShiftAddr(const ThreadContextInfo*const context, T* address)
 {
-    return SHIFT_ADDR(context, (intptr_t)address);
+    return ShiftAddr(context, (uintptr_t)address);
 }
 
-template<typename T>
-intptr_t SHIFT_CRT_ADDR(const ThreadContextInfo*const context, T* address)
-{
-    return SHIFT_CRT_ADDR(context, (intptr_t)address);
-}
-
-intptr_t SHIFT_ADDR(const ThreadContextInfo*const context, intptr_t address);
-intptr_t SHIFT_CRT_ADDR(const ThreadContextInfo*const context, intptr_t address);
+uintptr_t ShiftAddr(const ThreadContextInfo*const context, uintptr_t address);
 

--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -3882,7 +3882,7 @@ namespace Js
     BuiltinFunction JavascriptLibrary::GetBuiltInForFuncInfo(intptr_t funcInfoAddr, ThreadContextInfo * context)
     {
 #define LIBRARY_FUNCTION(target, name, argc, flags, EntryInfo) \
-        if(funcInfoAddr == SHIFT_ADDR(context, (intptr_t)&EntryInfo)) \
+        if(funcInfoAddr == (intptr_t)ShiftAddr(context, &EntryInfo)) \
         { \
             return BuiltinFunction::##target##_##name; \
         }


### PR DESCRIPTION
Previously we were statically mandating what dll is used for fixing up JIT helper calls, but it is more resilient if we decide at runtime based on which dll the address falls into.