### PR TITLE
Prioritize integer type in Lifetime

### DIFF
--- a/lib/Backend/Lifetime.h
+++ b/lib/Backend/Lifetime.h
@@ -13,8 +13,7 @@ public:
         : sym(sym), reg(reg), start(start), end(end), previousDefBlockNumber(0), defList(alloc),
         useList(alloc), lastUseLabel(NULL), region(NULL), isSpilled(false), useCount(0), useCountAdjust(0), allDefsCost(0), isLiveAcrossCalls(false),
         isLiveAcrossUserCalls(false), isDeadStore(true), isOpHelperSpilled(false), cantOpHelperSpill(false), isOpHelperSpillAsArg(false),
-        isFloat(false), isSimd128F4(false), isSimd128I4(false), isSimd128I8(false), isSimd128I16(false), isSimd128U4(false), isSimd128U8(false), isSimd128U16(false),
-        isSimd128D2(false), isSimd128B4(false), isSimd128B8(false), isSimd128B16(false), cantSpill(false), dontAllocate(false), isSecondChanceAllocated(false), isCheapSpill(false), spillStackSlot(NULL),
+        isFloat(0), cantSpill(false), dontAllocate(false), isSecondChanceAllocated(false), isCheapSpill(false), spillStackSlot(NULL),
           totalOpHelperLengthByEnd(0), needsStoreCompensation(false), alloc(alloc), regionUseCount(NULL), regionUseCountAdjust(NULL),
           cantStackPack(false)
     {
@@ -50,40 +49,17 @@ public:
     uint8               isOpHelperSpilled:1;
     uint8               isOpHelperSpillAsArg : 1;
     uint8               cantOpHelperSpill:1;
-    uint8               isFloat:1;
-    uint8               isSimd128F4 : 1;
-    uint8               isSimd128I4 : 1;
-    uint8               isSimd128I8 : 1;
-    uint8               isSimd128I16 : 1;
-    uint8               isSimd128B4 : 1;
-    uint8               isSimd128B8 : 1;
-    uint8               isSimd128B16 : 1;
-    uint8               isSimd128U4 : 1;
-    uint8               isSimd128U8 : 1;
-    uint8               isSimd128U16 : 1;
-    uint8               isSimd128D2 : 1;
     uint8               cantSpill:1;
     uint8               dontAllocate:1;
     uint8               isSecondChanceAllocated:1;
     uint8               isCheapSpill:1;
     uint8               needsStoreCompensation:1;
     uint8               cantStackPack : 1;
+    uint8               isFloat : 1;
 
-    bool isSimd128()
+    bool IsInt()
     {
-        bool result = isSimd128F4;
-        result |= isSimd128I4;
-        result |= isSimd128I8;
-        result |= isSimd128I16;
-        result |= isSimd128U4;
-        result |= isSimd128U8;
-        result |= isSimd128U16;
-        result |= isSimd128D2;
-        result |= isSimd128B4;
-        result |= isSimd128B8;
-        result |= isSimd128B16;
-
-        return result;
+        return !isFloat;
     }
 
     void AddToUseCount(uint32 newUseValue, Loop *loop, Func *func)

--- a/lib/Backend/LinearScan.cpp
+++ b/lib/Backend/LinearScan.cpp
@@ -2666,72 +2666,28 @@ RegNum
 LinearScan::FindReg(Lifetime *newLifetime, IR::RegOpnd *regOpnd, bool force)
 {
     BVIndex regIndex = BVInvalidIndex;
-    IRType type;
+    bool isRegAvailable = true;
     bool tryCallerSavedRegs = false;
     BitVector callerSavedAvailableBv;
 
     if (newLifetime)
     {
-        if (newLifetime->isFloat)
+        if (newLifetime->IsInt())
         {
-            type = TyFloat64;
-        }
-        else if (newLifetime->isSimd128F4)
-        {
-            type = TySimd128F4;
-        }
-        else if (newLifetime->isSimd128I4)
-        {
-            type = TySimd128I4;
-        }
-        else if (newLifetime->isSimd128I8)
-        {
-            type = TySimd128I8;
-        }
-        else if (newLifetime->isSimd128I16)
-        {
-            type = TySimd128I16;
-        }
-        else if (newLifetime->isSimd128U4)
-        {
-            type = TySimd128U4;
-        }
-        else if (newLifetime->isSimd128U8)
-        {
-            type = TySimd128U8;
-        }
-        else if (newLifetime->isSimd128U16)
-        {
-            type = TySimd128U16;
-        }
-        else if (newLifetime->isSimd128B4)
-        {
-            type = TySimd128B4;
-        }
-        else if (newLifetime->isSimd128B8)
-        {
-            type = TySimd128B8;
-        }
-        else if (newLifetime->isSimd128B16)
-        {
-            type = TySimd128B16;
-        }
-        else if (newLifetime->isSimd128D2)
-        {
-            type = TySimd128D2;
+            isRegAvailable = this->intRegUsedCount < INT_REG_COUNT;
         }
         else
         {
-            type = TyMachReg;
+            isRegAvailable = this->floatRegUsedCount < FLOAT_REG_COUNT;
         }
     }
     else
     {
         Assert(regOpnd);
-        type = regOpnd->GetType();
+        isRegAvailable = this->RegsAvailable(regOpnd->GetType());
     }
 
-    if (this->RegsAvailable(type))
+    if (isRegAvailable)
     {
         BitVector regsBv;
         regsBv.Copy(this->activeRegs);
@@ -2751,17 +2707,17 @@ LinearScan::FindReg(Lifetime *newLifetime, IR::RegOpnd *regOpnd, bool force)
                 }
             }
 
-            if (newLifetime->isFloat || newLifetime->isSimd128())
+            if (newLifetime->IsInt())
+            {
+                regsBv.And(this->int32Regs);
+                regsBv = this->linearScanMD.FilterRegIntSizeConstraints(regsBv, newLifetime->intUsageBv);
+            }
+            else
             {
 #ifdef _M_IX86
                 Assert(AutoSystemInfo::Data.SSE2Available());
 #endif
                 regsBv.And(this->floatRegs);
-            }
-            else
-            {
-                regsBv.And(this->int32Regs);
-                regsBv = this->linearScanMD.FilterRegIntSizeConstraints(regsBv, newLifetime->intUsageBv);
             }
 
 
@@ -2909,7 +2865,6 @@ LinearScan::Spill(Lifetime *newLifetime, IR::RegOpnd *regOpnd, bool dontSpillCur
 {
     uint minSpillCost = (uint)-1;
 
-    Assert(!newLifetime || !regOpnd || newLifetime->isFloat == (regOpnd->GetType() == TyMachDouble) || newLifetime->isSimd128() == (regOpnd->IsSimd128()));
     bool isFloatReg;
     BitVector intUsageBV;
     bool needCalleeSaved;
@@ -2917,7 +2872,7 @@ LinearScan::Spill(Lifetime *newLifetime, IR::RegOpnd *regOpnd, bool dontSpillCur
     // For now, we just spill the lifetime with the lowest spill cost.
     if (newLifetime)
     {
-        isFloatReg = newLifetime->isFloat || newLifetime->isSimd128();
+        isFloatReg = newLifetime->isFloat;
 
         if (!force)
         {
@@ -2948,7 +2903,7 @@ LinearScan::Spill(Lifetime *newLifetime, IR::RegOpnd *regOpnd, bool dontSpillCur
         uint spillCost = this->GetSpillCost(lifetime);
         if (spillCost < minSpillCost                        &&
             this->instrUseRegs.Test(lifetime->reg) == false &&
-            (lifetime->isFloat || lifetime->isSimd128()) == isFloatReg  &&
+            lifetime->isFloat == isFloatReg &&
             !lifetime->cantSpill                            &&
             (!needCalleeSaved || this->calleeSavedRegs.Test(lifetime->reg)) &&
             this->linearScanMD.FitRegIntSizeConstraints(lifetime->reg, intUsageBV))
@@ -2966,13 +2921,13 @@ LinearScan::Spill(Lifetime *newLifetime, IR::RegOpnd *regOpnd, bool dontSpillCur
         candidate.RemoveCurrent();
 
         this->activeRegs.Clear(spilledRange->reg);
-        if (spilledRange->isFloat || spilledRange->isSimd128())
+        if (spilledRange->IsInt())
         {
-            this->floatRegUsedCount--;
+            this->intRegUsedCount--;
         }
         else
         {
-            this->intRegUsedCount--;
+            this->floatRegUsedCount--;
         }
     }
     else if (dontSpillCurrent)
@@ -3145,13 +3100,13 @@ LinearScan::ProcessEHRegionBoundary(IR::Instr * instr)
     FOREACH_SLIST_ENTRY_EDITING(Lifetime *, lifetime, this->activeLiveranges, iter)
     {
         this->activeRegs.Clear(lifetime->reg);
-        if (lifetime->isFloat || lifetime->isSimd128())
+        if (lifetime->IsInt())
         {
-            this->floatRegUsedCount--;
+            this->intRegUsedCount--;
         }
         else
         {
-            this->intRegUsedCount--;
+            this->floatRegUsedCount--;
         }
         this->SpillLiveRange(lifetime, insertionInstr);
         iter.RemoveCurrent();
@@ -3354,11 +3309,6 @@ LinearScan::InsertStore(IR::Instr *instr, StackSym *sym, RegNum reg)
 
     IRType type = sym->GetType();
 
-    if (sym->IsSimd128())
-    {
-        type = sym->GetType();
-    }
-
     IR::Instr *store = IR::Instr::New(LowererMD::GetStoreOp(type),
         IR::SymOpnd::New(sym, type, this->func),
         IR::RegOpnd::New(sym, reg, type, this->func), this->func);
@@ -3384,11 +3334,6 @@ LinearScan::InsertLoad(IR::Instr *instr, StackSym *sym, RegNum reg)
     // The size of loads and stores to memory need to match. See the comment
     // around type in InsertStore above.
     IRType type = sym->GetType();
-
-    if (sym->IsSimd128())
-    {
-        type = sym->GetType();
-    }
 
     bool isMovSDZero = false;
     if (sym->IsConst())
@@ -3799,13 +3744,13 @@ LinearScan::AssignActiveReg(Lifetime * lifetime, RegNum reg)
     this->func->m_regsUsed.Set(reg);
     lifetime->reg = reg;
     this->activeRegs.Set(reg);
-    if (lifetime->isFloat || lifetime->isSimd128())
+    if (lifetime->IsInt())
     {
-        this->floatRegUsedCount++;
+        this->intRegUsedCount++;
     }
     else
     {
-        this->intRegUsedCount++;
+        this->floatRegUsedCount++;
     }
     this->AddToActive(lifetime);
 

--- a/lib/Backend/SccLiveness.cpp
+++ b/lib/Backend/SccLiveness.cpp
@@ -399,18 +399,7 @@ SCCLiveness::ProcessSrc(IR::Opnd *src, IR::Instr *instr)
             {
                 lifetime = this->InsertLifetime(stackSym, reg, this->func->m_headInstr->m_next);
                 lifetime->region = this->curRegion;
-                lifetime->isFloat = symOpnd->IsFloat();
-                lifetime->isSimd128F4 = symOpnd->IsSimd128F4();
-                lifetime->isSimd128I4 = symOpnd->IsSimd128I4();
-                lifetime->isSimd128I8 = symOpnd->IsSimd128I8();
-                lifetime->isSimd128I16 = symOpnd->IsSimd128I16();
-                lifetime->isSimd128U4 = symOpnd->IsSimd128U4();
-                lifetime->isSimd128U8 = symOpnd->IsSimd128U8();
-                lifetime->isSimd128U16 = symOpnd->IsSimd128U16();
-                lifetime->isSimd128B4 = symOpnd->IsSimd128B4();
-                lifetime->isSimd128B8 = symOpnd->IsSimd128B8();
-                lifetime->isSimd128B16 = symOpnd->IsSimd128B16();
-                lifetime->isSimd128D2 = symOpnd->IsSimd128D2();
+                lifetime->isFloat = symOpnd->IsFloat() || symOpnd->IsSimd128();
             }
 
             IR::RegOpnd * newRegOpnd = IR::RegOpnd::New(stackSym, reg, symOpnd->GetType(), this->func);
@@ -613,18 +602,7 @@ SCCLiveness::ProcessRegDef(IR::RegOpnd *regDef, IR::Instr *instr)
     {
         lifetime = this->InsertLifetime(stackSym, regDef->GetReg(), instr);
         lifetime->region = this->curRegion;
-        lifetime->isFloat = regDef->IsFloat();
-        lifetime->isSimd128F4   = regDef->IsSimd128F4();
-        lifetime->isSimd128I4   = regDef->IsSimd128I4 ();
-        lifetime->isSimd128I8   = regDef->IsSimd128I8 ();
-        lifetime->isSimd128I16  = regDef->IsSimd128I16();
-        lifetime->isSimd128U4   = regDef->IsSimd128U4 ();
-        lifetime->isSimd128U8   = regDef->IsSimd128U8 ();
-        lifetime->isSimd128U16  = regDef->IsSimd128U16();
-        lifetime->isSimd128B4 = regDef->IsSimd128B4();
-        lifetime->isSimd128B8 = regDef->IsSimd128B8();
-        lifetime->isSimd128B16 = regDef->IsSimd128B16();
-        lifetime->isSimd128D2   = regDef->IsSimd128D2();
+        lifetime->isFloat = regDef->IsFloat() || regDef->IsSimd128();
     }
     else
     {


### PR DESCRIPTION
No longer force us to check if the lifetime is a float or any of the simd types before determining that it's an integer type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/3537)
<!-- Reviewable:end -->
