### PR TITLE
OS:10898061 fix bug with cached scopes and default/destrctured arguments

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -6312,6 +6312,7 @@ void Parser::ParseFncFormals(ParseNodePtr pnodeFnc, ParseNodePtr pnodeParentFnc,
                 {
                     // Mark that the function has a non simple parameter list before parsing the pattern since the pattern can have function definitions.
                     this->GetCurrentFunctionNode()->sxFnc.SetHasNonSimpleParameterList();
+                    this->GetCurrentFunctionNode()->sxFnc.SetHasDestructuredParams();
 
                     ParseNodePtr *const ppnodeVarSave = m_ppnodeVar;
                     m_ppnodeVar = &pnodeFnc->sxFnc.pnodeVars;

--- a/lib/Parser/ptree.h
+++ b/lib/Parser/ptree.h
@@ -182,7 +182,7 @@ enum FncFlags : uint
     kFunctionIsAccessor                         = 1 << 6, // function is a property getter or setter
     kFunctionHasNonThisStmt                     = 1 << 7,
     kFunctionStrictMode                         = 1 << 8,
-    // Free = 1 << 9,
+    kFunctionHasDestructuredParams              = 1 << 9,
     kFunctionIsModule                           = 1 << 10, // function is a module body
     // Free = 1 << 11,
     kFunctionHasWithStmt                        = 1 << 12, // function (or child) uses with
@@ -296,6 +296,7 @@ public:
     void SetChildCallsEval(bool set = true) { SetFlags(kFunctionChildCallsEval, set); }
     void SetDeclaration(bool set = true) { SetFlags(kFunctionDeclaration, set); }
     void SetHasDefaultArguments(bool set = true) { SetFlags(kFunctionHasDefaultArguments, set); }
+    void SetHasDestructuredParams(bool set = true) { SetFlags(kFunctionHasDestructuredParams, set); }
     void SetHasHeapArguments(bool set = true) { SetFlags(kFunctionHasHeapArguments, set); }
     void SetHasAnyWriteToFormals(bool set = true) { SetFlags((uint)kFunctionHasAnyWriteToFormals, set); }
     void SetHasNonSimpleParameterList(bool set = true) { SetFlags(kFunctionHasNonSimpleParameterList, set); }
@@ -330,6 +331,7 @@ public:
     bool GetAsmjsMode() const { return HasFlags(kFunctionAsmjsMode); }
     bool GetStrictMode() const { return HasFlags(kFunctionStrictMode); }
     bool HasDefaultArguments() const { return HasFlags(kFunctionHasDefaultArguments); }
+    bool HasDestructuredParams() const { return HasFlags(kFunctionHasDestructuredParams); }
     bool HasHeapArguments() const { return true; /* HasFlags(kFunctionHasHeapArguments); Disabling stack arguments. Always return HeapArguments as True */ }
     bool HasAnyWriteToFormals() const { return HasFlags((uint)kFunctionHasAnyWriteToFormals); }
     bool HasOnlyThisStmts() const { return !HasFlags(kFunctionHasNonThisStmt); }

--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -4011,6 +4011,8 @@ void ByteCodeGenerator::StartEmitFunction(ParseNode *pnodeFnc)
                 funcInfo->frameObjRegister != Js::Constants::NoRegister &&
                 !ApplyEnclosesArgs(pnodeFnc, this) &&
                 funcInfo->IsBodyAndParamScopeMerged() && // There is eval in the param scope
+                !pnodeFnc->sxFnc.HasDefaultArguments() &&
+                !pnodeFnc->sxFnc.HasDestructuredParams() &&
                 (PHASE_FORCE(Js::CachedScopePhase, funcInfo->byteCodeFunction) || !IsInDebugMode())
 #if ENABLE_TTD
                 && !funcInfo->GetParsedFunctionBody()->GetScriptContext()->GetThreadContext()->IsRuntimeInTTDMode()

--- a/test/es6/bug_OS10898061.js
+++ b/test/es6/bug_OS10898061.js
@@ -1,0 +1,42 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function foo( a = b )  
+{ 
+    eval(""); 
+    var b; 
+} 
+
+function bar( {a:a = b} )
+{
+    eval(""); 
+    var b; 
+} 
+
+
+function test()
+{
+    try
+    {
+        // foo should throw a ReferenceError: 'b' is not defined.
+        foo();
+        return false;
+    }
+    catch( a )
+    {}
+
+    try
+    {
+        // bar should throw a ReferenceError: 'b' is not defined.
+        bar({});
+        return false;
+    }
+    catch( a )
+    {}
+
+    return true;
+}
+
+WScript.Echo(test() ? "PASSED" : "FAILED");

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -1473,4 +1473,10 @@
     <tags>BugFix</tags>
   </default>
 </test>
+<test>
+  <default>
+    <files>bug_OS10898061.js</files>
+    <tags>BugFix</tags>
+  </default>
+</test>
 </regress-exe>


### PR DESCRIPTION
When cached scopes are used with default function arguments or destructured parameters, any variable references in the values of the default argument or destructured params would erroneously see the merged body and param scope