### PR TITLE
WASM: Table grow(0) with initial: 0

### DIFF
--- a/lib/Runtime/Library/WebAssemblyTable.h
+++ b/lib/Runtime/Library/WebAssemblyTable.h
@@ -39,8 +39,6 @@ namespace Js
         uint32 GetInitialLength() const;
         uint32 GetMaximumLength() const;
 
-        Var * GetValues() const;
-
         void DirectSetValue(uint index, Var val);
         Var DirectGetValue(uint index) const;
 

--- a/test/wasm/api.js
+++ b/test/wasm/api.js
@@ -402,6 +402,13 @@ async function testTableApi(baseModule) {
   table.set(30, myFn);
   console.log(`call_i32(29): ${call_i32(29)}`);
   console.log(`call_i32(30): ${call_i32(30)}`);
+
+  const table2 = new WebAssembly.Table({element: "anyfunc"});
+  table.grow(0);
+  try {table2.get(0); console.log("Failed. Unexpected successfull call to table2.get(0)");} catch (e) {}
+  table.grow(1);
+  table.set(0, myFn);
+  console.log(`table2[0](): ${table.get(0)()}`);
 }
 
 async function main() {

--- a/test/wasm/baselines/api.baseline
+++ b/test/wasm/baselines/api.baseline
@@ -221,4 +221,5 @@ call_f32(2): NaN
 call_i32(0): 1
 call_i32(29): 123456
 call_i32(30): 123456
+table2[0](): 123456
 done


### PR DESCRIPTION
OS#13149792 
Do not call RecyclerNew with length 0 in case we call WebAssemblyTable.grow with initial length of 0. 
This crashes in clang, but is fine on msvc since we don't actually access whatever the Recycler returns

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/3539)
<!-- Reviewable:end -->
