### PR TITLE
Better Debug coverage, smaller binary size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -370,6 +370,7 @@ elseif(CMAKE_BUILD_TYPE STREQUAL Test)
     add_definitions(
         -DENABLE_DEBUG_CONFIG_OPTIONS=1
     )
+    add_compile_options(-g)
 endif(CMAKE_BUILD_TYPE STREQUAL Debug)
 
 if(NOT CMAKE_BUILD_TYPE STREQUAL Debug)

--- a/lib/wabt/CMakeLists.txt
+++ b/lib/wabt/CMakeLists.txt
@@ -47,9 +47,6 @@ include_directories(chakra src ${CMAKE_CURRENT_SOURCE_DIR}/built)
 # disable -Wunused-parameter: this is really common when implementing
 #   interfaces, etc.
 # disable -Wpointer-arith: this is a GCC extension, and doesn't work in MSVC.
-add_definitions(
-  -g -std=c++11
-)
 
 if (MINGW)
   # Mingw won't define format (e.g. PRIu64) or limit (e.g. UINT32_MAX) macros


### PR DESCRIPTION
- add debug symbols to test builds
- keep libwabt debug symbols are being included on release builds.