### PR TITLE
fix bugs in MemoryOperationLastError

### DIFF
--- a/lib/Common/Memory/PageAllocator.h
+++ b/lib/Common/Memory/PageAllocator.h
@@ -397,7 +397,7 @@ public:
 #if ENABLE_OOP_NATIVE_CODEGEN
         if (MemOpLastError == S_OK)
         {
-            MemOpLastError = GetLastError();
+            MemOpLastError = HRESULT_FROM_WIN32(::GetLastError());
         }
 #endif
     }
@@ -407,7 +407,7 @@ public:
 #if ENABLE_OOP_NATIVE_CODEGEN
         if (MemOpLastError == S_OK)
         {
-            MemOpLastError = HRESULT_FROM_WIN32(error);
+            MemOpLastError = error;
         }
 #endif
     }


### PR DESCRIPTION
Fixes issues where RecordLastError was not calling GLE correctly, and RecordError was unnecessarily calling HRESULT_FROM_WIN32.

OS: 13294698