### PR TITLE
fixing bug in wcssstr

### DIFF
--- a/pal/src/cruntime/wchar.cpp
+++ b/pal/src/cruntime/wchar.cpp
@@ -1493,16 +1493,22 @@ PAL_wcsstr(
         i = 0;
         while (1)
         {
-            if (*(string + i) == 0 || *(strCharSet + i) == 0)
+            if (*(strCharSet + i) == 0)
             {
                 ret = (char16_t *) string;
+                goto leave;
+            }
+            else if (*(string + i) == 0)
+            {
+                ret = NULL;
                 goto leave;
             }
             if (*(string + i) != *(strCharSet + i))
             {
                 break;
             }
-        i++;
+
+            i++;
         }
         string++;
     }

--- a/test/native-tests/test-pal/Platform.js
+++ b/test/native-tests/test-pal/Platform.js
@@ -1,0 +1,54 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+var isWindows = !WScript.Platform || WScript.Platform.OS == 'win32';
+var path_sep = isWindows ? '\\' : '/';
+var isStaticBuild = WScript.Platform && WScript.Platform.LINK_TYPE == 'static';
+
+if (!isStaticBuild) {
+    // test will be ignored
+    print("# IGNORE_THIS_TEST");
+} else {
+    var platform = WScript.Platform.OS;
+    var binaryPath = WScript.Platform.BINARY_PATH;
+    // discard `ch` from path
+    binaryPath = binaryPath.substr(0, binaryPath.lastIndexOf(path_sep));
+    var makefile =
+"ROOT=" + binaryPath + "/../..\n\
+$(info $$ROOT is [${ROOT})\n\
+IDIR=" + binaryPath + "/../../lib/Jsrt\n\
+\n\
+LIBRARY_PATH=" + binaryPath + "/lib\n\
+PLATFORM=" + platform + "\n\
+LDIR=$(LIBRARY_PATH)/libChakraCoreStatic.a \n\
+\n\
+ifeq (darwin, ${PLATFORM})\n\
+\tICU4C_LIBRARY_PATH ?= /usr/local/opt/icu4c\n\
+\tCFLAGS=-lstdc++ -std=c++11 -I$(IDIR) -I$(ROOT) -I$(ROOT)/pal/inc/rt -I$(ROOT)/pal/inc -I$(ROOT)/pal -fms-extensions\n\
+\tFORCE_STARTS=-Wl,-force_load,\n\
+\tFORCE_ENDS=\n\
+\tLIBS=-framework CoreFoundation -framework Security -lm -ldl -Wno-c++11-compat-deprecated-writable-strings \
+    -Wno-deprecated-declarations -Wno-unknown-warning-option -o sample.o\n\
+\tLDIR+=$(ICU4C_LIBRARY_PATH)/lib/libicudata.a \
+    $(ICU4C_LIBRARY_PATH)/lib/libicuuc.a \
+    $(ICU4C_LIBRARY_PATH)/lib/libicui18n.a\n\
+else\n\
+\tCFLAGS=-lstdc++ -std=c++0x -I$(IDIR) -I$(ROOT) -I$(ROOT)/pal/inc/rt -I$(ROOT)/pal/inc -I$(ROOT)/pal -fms-extensions \n\
+\tFORCE_STARTS=-Wl,--whole-archive\n\
+\tFORCE_ENDS=-Wl,--no-whole-archive\n\
+\tLIBS=-pthread -lm -ldl -licuuc -Wno-c++11-compat-deprecated-writable-strings \
+    -Wno-deprecated-declarations -Wno-unknown-warning-option -o sample.o\n\
+endif\n\
+\n\
+testmake:\n\
+\t$(CC) sample.cpp $(CFLAGS) $(FORCE_STARTS) $(LDIR) $(FORCE_ENDS) $(LIBS)\n\
+\n\
+.PHONY: clean\n\
+\n\
+clean:\n\
+\trm sample.o\n";
+
+    print(makefile)
+}

--- a/test/native-tests/test-pal/sample.cpp
+++ b/test/native-tests/test-pal/sample.cpp
@@ -1,0 +1,68 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+extern "C"  int
+__cdecl
+PAL_wcscmp(
+       const char16_t *string1,
+       const char16_t *string2);
+
+extern "C" const char16_t *
+__cdecl
+PAL_wcsstr(
+       const char16_t *string,
+       const char16_t *strCharSet);
+
+extern "C" int
+__cdecl
+PAL_wprintf(
+        const char16_t*, ...);
+
+#ifndef NULL
+#if defined(__cplusplus)
+#define NULL    0
+#else
+#define NULL    ((void *)0)
+#endif
+#endif
+
+int validate(const char16_t *actual, const char16_t *expected, const char16_t *testName)
+{
+    int c = PAL_wcscmp(expected, actual);
+    if (c == 0)
+    {
+        return 0;
+    }
+    else
+    {
+        PAL_wprintf(u"Test Failed: %s\n", testName);
+        return 1;
+    }
+}
+
+int main()
+{
+    int result = 0;
+
+    result += validate(PAL_wcsstr(u"targetstringxxx", u"searchStringxxx"), NULL, u"test1");
+    result += validate(PAL_wcsstr(u"abcdefg", u"def"), u"defg", u"test2");
+    result += validate(PAL_wcsstr(u"abcdefg", u"a"), u"abcdefg", u"test3");
+    result += validate(PAL_wcsstr(u"abcdefg", u"g"), u"g", u"test4");
+    result += validate(PAL_wcsstr(u"abcdefg", u"gh"), NULL, u"test5");
+    result += validate(PAL_wcsstr(u"abcdefg", u"ah"), NULL, u"test6");
+    result += validate(PAL_wcsstr((const char16_t *)NULL, (const char16_t *)NULL), NULL, u"test7");
+    result += validate(PAL_wcsstr((const char16_t *)NULL, u""), NULL, u"test8");
+    result += validate(PAL_wcsstr(u"", (const char16_t *)NULL), NULL, u"test9");
+    result += validate(PAL_wcsstr(u"abcdefg", u""), u"abcdefg", u"test10");
+    result += validate(PAL_wcsstr(u"abcdefg", u"abcdefg"), u"abcdefg", u"test11");
+    result += validate(PAL_wcsstr(u"", u""), u"", u"test12");
+    result += validate(PAL_wcsstr(u"", u"def"), NULL, u"test13");
+    
+    if (result == 0)
+    {
+        PAL_wprintf(u"SUCCESS");
+    }
+    return result;
+}

--- a/test/native-tests/test-python/helloWorld.py
+++ b/test/native-tests/test-python/helloWorld.py
@@ -13,7 +13,7 @@ else:
     platform = "so"
 
 build_type = sys.argv[1]
-if sys.argv[2] != None:
+if sys.argv.__len__() > 2 and sys.argv[2] != None:
     so_path = sys.argv[2]
 else:
     so_path = "../../../out/" + build_type + "/libChakraCore." + platform

--- a/test/native-tests/test_native.sh
+++ b/test/native-tests/test_native.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 #-------------------------------------------------------------------------------------------------------
 # Copyright (C) Microsoft. All rights reserved.
 # Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
@@ -20,6 +21,9 @@ FIND_CLANG() {
     if [[ $CC == 0 ]]; then
         echo "Error: Couldn't find Clang"
         exit 1
+    else
+    echo "Using CC [${CC}]"
+    echo "Using CXX [${CXX}]"
     fi
 }
 
@@ -83,6 +87,9 @@ RUN "test-char"
 
 # test-char16
 RUN "test-char16"
+
+#test-pal
+RUN "test-pal"
 
 # test-static-native
 RUN "test-static-native"


### PR DESCRIPTION
Fixing https://github.com/Microsoft/ChakraCore/issues/3434..  Bug in wcsstr would return a match if the string being searched ended with a prefix of the search string.  Fixed this to behave correctly.  Also added tests to test_native.sh to verify this.

This is re-opened from PR #3542.