### PR TITLE
Fix illegal qualified name in ThreadContext.h (Fix #3507)

### DIFF
--- a/lib/Runtime/Base/ThreadContext.h
+++ b/lib/Runtime/Base/ThreadContext.h
@@ -1785,7 +1785,7 @@ extern void(*InitializeAdditionalProperties)(ThreadContext *threadContext);
 class AutoDisableInterrupt
 {
 public:
-    AutoDisableInterrupt::AutoDisableInterrupt(ThreadContext *threadContext, bool explicitCompletion = true)
+    AutoDisableInterrupt(ThreadContext *threadContext, bool explicitCompletion = true)
         : m_operationCompleted(false), m_interruptDisableState(false), m_threadContext(threadContext), m_explicitCompletion(explicitCompletion)
     {
         if (m_threadContext->HasInterruptPoller())
@@ -1794,7 +1794,7 @@ public:
             m_threadContext->GetInterruptPoller()->SetDisabled(true);
         }
     }
-    AutoDisableInterrupt::~AutoDisableInterrupt()
+    ~AutoDisableInterrupt()
     {
         if (m_threadContext->HasInterruptPoller())
         {


### PR DESCRIPTION
See #3507. This patch removes the redundant prefix "AutoDisableInterrupt::" in member function declaration.