### PR TITLE
Fix spelling in comments in various files.

### DIFF
--- a/Build/Common.Build.props
+++ b/Build/Common.Build.props
@@ -82,7 +82,7 @@
       <ProgramDataBaseFileName Condition="'$(ConfigurationType)'=='StaticLibrary'">$(IntDir)$(TargetName).pdb</ProgramDataBaseFileName>
       <ProgramDataBaseFileName Condition="'$(ConfigurationType)'!='StaticLibrary'">$(IntDir)</ProgramDataBaseFileName>
 
-      <!-- ======== For Code Covearge ======== -->
+      <!-- ======== For Code Coverage ======== -->
       <PreprocessorDefinitions Condition="'$(ENABLE_CODECOVERAGE)'=='true'">
         %(PreprocessorDefinitions);
         BYTECODE_TESTING=1
@@ -114,7 +114,7 @@
       <AdditionalOptions>%(AdditionalOptions) /release</AdditionalOptions>
       <!-- Ignore Linker warning: This object file does not define any previously undefined public symbols -->
       <AdditionalOptions>%(AdditionalOptions) /ignore:4221</AdditionalOptions>
-      <!-- ======== For Code Covearge ======== -->
+      <!-- ======== For Code Coverage ======== -->
       <AdditionalOptions Condition="'$(ENABLE_CODECOVERAGE)'=='true'">%(AdditionalOptions) /DEBUGTYPE:CV,FIXUP</AdditionalOptions>
     </Link>
     <Lib>

--- a/bin/NativeTests/CodexTests.cpp
+++ b/bin/NativeTests/CodexTests.cpp
@@ -84,7 +84,7 @@ namespace CodexTest
     {
         // Each of these test cases verifies the encoding 
         // of a single surrogate pair into a 6 byte CESU string
-        // Each surrogate-pair unit is encoded seperately into utf8
+        // Each surrogate-pair unit is encoded separately into utf8
         struct TestCase
         {
             char16     surrogatePair[2];

--- a/bin/ch/WScriptJsrt.cpp
+++ b/bin/ch/WScriptJsrt.cpp
@@ -980,7 +980,7 @@ JsErrorCode WScriptJsrt::InitializeModuleCallbacks()
 
 bool WScriptJsrt::Uninitialize()
 {
-    // moduleRecordMap is a global std::map, its destructor may access overrided
+    // moduleRecordMap is a global std::map, its destructor may access overridden
     // "operator delete" / global HeapAllocator::Instance. Clear it manually here
     // to avoid worrying about global destructor order.
     moduleRecordMap.clear();

--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -5233,8 +5233,8 @@ Lowerer::LowerNewScObjArray(IR::Instr *newObjInstr)
     const uint16 upperBoundValue = 8;
     // Generate fast path only if it meets all the conditions:
     // 1. It is the only parameter
-    // 2a. If 1st paramter is a variable, emit fast path with checks
-    // 2b. If 1st paramter is a constant, it is in range 0 and upperBoundValue (inclusive)
+    // 2a. If 1st parameter is a variable, emit fast path with checks
+    // 2b. If 1st parameter is a constant, it is in range 0 and upperBoundValue (inclusive)
     if (opndOfArrayCtor->IsAddrOpnd() || opndOfArrayCtor->IsRegOpnd()) // #1
 
     {
@@ -5244,7 +5244,7 @@ Lowerer::LowerNewScObjArray(IR::Instr *newObjInstr)
             linkOpnd = argInstr->GetSrc2();
 
             bool emittedFastPath = true;
-            // 2a. If 1st paramter is a variable, emit fast path with checks
+            // 2a. If 1st parameter is a variable, emit fast path with checks
             if (opndOfArrayCtor->IsRegOpnd())
             {
                 // 3. GenerateFastPath
@@ -5265,7 +5265,7 @@ Lowerer::LowerNewScObjArray(IR::Instr *newObjInstr)
                     GenerateProfiledNewScObjArrayFastPath<Js::JavascriptArray>(newObjInstr, arrayInfo, arrayInfoAddr, weakFuncRef, helperLabel, labelDone, opndOfArrayCtor, 0, 0);
                 }
             }
-            // 2b. If 1st paramter is a constant, it is in range 0 and upperBoundValue (inclusive)
+            // 2b. If 1st parameter is a constant, it is in range 0 and upperBoundValue (inclusive)
             else
             {
                 int32 length = linkSym->GetIntConstValue();

--- a/lib/Backend/LowerMDSharedSimd128.cpp
+++ b/lib/Backend/LowerMDSharedSimd128.cpp
@@ -434,7 +434,7 @@ IR::Instr* LowererMD::Simd128LowerConstructor_8(IR::Instr *instr)
     while (!args->Empty() && i < 8)
     {
         srcs[i] = args->Pop();
-        // src's might have been constant prop'ed. Enregister them if so.
+        // src's might have been constant prop'd. Enregister them if so.
         srcs[i] = EnregisterIntConst(instr, srcs[i], TyInt16);
         Assert(srcs[i]->GetType() == TyInt16 && srcs[i]->IsRegOpnd());
         // PINSRW dst, srcs[i], i
@@ -473,7 +473,7 @@ IR::Instr* LowererMD::Simd128LowerConstructor_16(IR::Instr *instr)
     while (!args->Empty() && i < 16)
     {
         srcs[i] = args->Pop();
-        // src's might have been constant prop'ed. Enregister them if so.
+        // src's might have been constant prop'd. Enregister them if so.
         srcs[i] = EnregisterIntConst(instr, srcs[i], TyInt8);
         Assert(srcs[i]->GetType() == TyInt8 && srcs[i]->IsRegOpnd());
 
@@ -591,7 +591,7 @@ IR::Instr* LowererMD::Simd128LowerConstructor_4(IR::Instr *instr)
         //Simd128_IntsToI4/U4
         IR::RegOpnd *temp = IR::RegOpnd::New(TyFloat32, m_func);
 
-        // src's might have been constant prop'ed. Enregister them if so.
+        // src's might have been constant prop'd. Enregister them if so.
         src4 = EnregisterIntConst(instr, src4);
         src3 = EnregisterIntConst(instr, src3);
         src2 = EnregisterIntConst(instr, src2);

--- a/lib/Common/Core/FaultInjection.cpp
+++ b/lib/Common/Core/FaultInjection.cpp
@@ -370,7 +370,7 @@ namespace Js
     } FUNCTION_SIGNATURES, *PFUNCTION_SIGNATURES;
 
     // function address ranges of each signature
-    // use for faster address matching instead of symbol table lookup when reproing
+    // use for faster address matching instead of symbol table lookup when reproducing
     PFUNCTION_SIGNATURES baselineFuncSigs[FaultInjection::MAX_FRAME_COUNT] = { 0 };
     // record hit count of each frame when Faults are injected.
     unsigned int stackMatchRank[FaultInjection::MAX_FRAME_COUNT] = { 0 };
@@ -1030,7 +1030,7 @@ namespace Js
         }
 
         // install exception filter to smart dump for faultinjection
-        // when reproing in debugger, only let debugger catch the exception
+        // when reproducing in debugger, only let debugger catch the exception
         // can't do this in ctor because the global flags are not initialized yet
         InstallExceptionFilters();
 

--- a/lib/Common/Memory/ArenaAllocator.h
+++ b/lib/Common/Memory/ArenaAllocator.h
@@ -879,7 +879,7 @@ public:
 
         if (0 == refs)
         {
-            delete this;  // invokes overrided operator delete
+            delete this;  // invokes overridden operator delete
         }
 
         return refs;

--- a/lib/Common/Memory/Recycler.h
+++ b/lib/Common/Memory/Recycler.h
@@ -2465,7 +2465,7 @@ struct ForceLeafAllocator<RecyclerNonLeafAllocator>
 };
 
 // TODO: enable -profile for GC phases.
-// access the same profiler object from multiple GC threads which shares one recyler object,
+// access the same profiler object from multiple GC threads which shares one recycler object,
 // but profiler object is not thread safe
 #if defined(PROFILE_EXEC) && 0
 #define RECYCLER_PROFILE_EXEC_BEGIN(recycler, phase) if (recycler->profiler != nullptr) { recycler->profiler->Begin(phase); }

--- a/lib/Parser/Hash.cpp
+++ b/lib/Parser/Hash.cpp
@@ -34,7 +34,7 @@ HashTbl * HashTbl::Create(uint cidHash)
         return nullptr;
     if (!phtbl->Init(cidHash))
     {
-        delete phtbl;  // invokes overrided operator delete
+        delete phtbl;  // invokes overridden operator delete
         return nullptr;
     }
 

--- a/lib/Parser/Hash.h
+++ b/lib/Parser/Hash.h
@@ -334,7 +334,7 @@ public:
 
     void Release(void)
     {
-        delete this;  // invokes overrided operator delete
+        delete this;  // invokes overridden operator delete
     }
 
 

--- a/lib/Parser/Scan.h
+++ b/lib/Parser/Scan.h
@@ -369,7 +369,7 @@ public:
     }
     void Release(void)
     {
-        delete this;  // invokes overrided operator delete
+        delete this;  // invokes overridden operator delete
     }
 
     tokens Scan();

--- a/lib/Runtime/Debug/TTSerialize.h
+++ b/lib/Runtime/Debug/TTSerialize.h
@@ -24,7 +24,7 @@ namespace TTD
 {
     namespace NSTokens
     {
-        //Seperator tokens for records
+        //Separator tokens for records
         enum class Separator : byte
         {
             NoSeparator = 0x0,

--- a/lib/Runtime/Language/JavascriptConversion.cpp
+++ b/lib/Runtime/Language/JavascriptConversion.cpp
@@ -336,7 +336,7 @@ CommonNumber:
     //    Boolean:  The result equals the input argument (no conversion).
     //    Number:   The result equals the input argument (no conversion).
     //    String:   The result equals the input argument (no conversion).
-    //    VariantDate:Returns the value for variant date by calling ToPrimitve directly.
+    //    VariantDate:Returns the value for variant date by calling ToPrimitive directly.
     //    Object:   Return a default value for the Object.
     //              The default value of an object is retrieved by calling the [[DefaultValue]]
     //              internal method of the object, passing the optional hint PreferredType.

--- a/lib/Runtime/Library/JavascriptArray.cpp
+++ b/lib/Runtime/Library/JavascriptArray.cpp
@@ -8076,7 +8076,7 @@ Case0:
             return JavascriptString::NewCopyBuffer(szSeparator, count, scriptContext);
         }
 #else
-        // xplat-todo: Support locale-specific seperator
+        // xplat-todo: Support locale-specific separator
         return scriptContext->GetLibrary()->GetCommaSpaceDisplayString();
 #endif
     }

--- a/lib/Runtime/Library/JavascriptProxy.cpp
+++ b/lib/Runtime/Library/JavascriptProxy.cpp
@@ -671,7 +671,7 @@ namespace Js
         }
         else
         {
-            // ES2017 Spec'ed (9.1.9.1): 
+            // ES2017 Spec'd (9.1.9.1): 
             // If existingDescriptor is not undefined, then
             //    If IsAccessorDescriptor(existingDescriptor) is true, return false.
             //    If existingDescriptor.[[Writable]] is false, return false.

--- a/lib/Runtime/Library/JavascriptSimdObject.cpp
+++ b/lib/Runtime/Library/JavascriptSimdObject.cpp
@@ -179,7 +179,7 @@ namespace Js
             newArgs[2] = args[2];
         }
 
-        //Locale specifc seperator?? 
+        //Locale specific separator??
         JavascriptString *seperator = JavascriptString::NewWithSz(_u(", "), scriptContext);
         uint idx = 0;
         Var laneVar = nullptr;

--- a/pal/src/include/pal/corunix.hpp
+++ b/pal/src/include/pal/corunix.hpp
@@ -144,7 +144,7 @@ namespace CorUnix
     // have already deleted it. ($$REIVEW -- would someone ever need access
     // to the shared data in order to cleanup process local state?)
     //
-    // When the third paramter (fShutdown) is TRUE the process is in
+    // When the third parameter (fShutdown) is TRUE the process is in
     // the act of exiting. The cleanup routine should not perform any
     // unnecessary cleanup operations (e.g., closing file descriptors,
     // since the OS will automatically close them when the process exits)

--- a/pal/src/include/pal/thread.hpp
+++ b/pal/src/include/pal/thread.hpp
@@ -359,7 +359,7 @@ namespace CorUnix
         void* m_stackLimit;
 
         // The default stack size of a newly created thread (currently 256KB)
-        // when the dwStackSize paramter of PAL_CreateThread()
+        // when the dwStackSize parameter of PAL_CreateThread()
         // is zero. This value can be set by setting the
         // environment variable PAL_THREAD_DEFAULT_STACK_SIZE
         // (the value should be in bytes and in hex).

--- a/pal/src/include/pal/threadinfo.hpp
+++ b/pal/src/include/pal/threadinfo.hpp
@@ -12,7 +12,7 @@ Module Name:
     include/pal/threadinfo.hpp
 
 Abstract:
-    Header file for thread info initialzer
+    Header file for thread info initializer
 
 
 

--- a/test/benchmarks/Octane/gbemu.js
+++ b/test/benchmarks/Octane/gbemu.js
@@ -1343,7 +1343,7 @@ function resetCallbackAPIAudioBuffer(APISampleRate, bufferAlloc) {
     }
     try {
       audioSource = audioContextHandle.createBufferSource();            //We need to create a false input to get the chain started.
-      audioSource.loop = false;  //Keep this alive forever (Event handler will know when to ouput.)
+      audioSource.loop = false;  //Keep this alive forever (Event handler will know when to output.)
       XAudioJSSampleRate = webAudioActualSampleRate = audioContextHandle.sampleRate;
       audioSource.buffer = audioContextHandle.createBuffer(1, 1, webAudioActualSampleRate);  //Create a zero'd input buffer for the input to be valid.
       audioNode = audioContextHandle.createJavaScriptNode(samplesPerCallback, 1, 2);      //Create 2 outputs and ignore the input buffer (Just copy buffer 1 over if mono)

--- a/test/benchmarks/Octane_Closure/gbemu.js
+++ b/test/benchmarks/Octane_Closure/gbemu.js
@@ -1328,7 +1328,7 @@ function resetCallbackAPIAudioBuffer(APISampleRate, bufferAlloc) {
     }
     try {
       audioSource = audioContextHandle.createBufferSource();            //We need to create a false input to get the chain started.
-      audioSource.loop = false;  //Keep this alive forever (Event handler will know when to ouput.)
+      audioSource.loop = false;  //Keep this alive forever (Event handler will know when to output.)
       XAudioJSSampleRate = webAudioActualSampleRate = audioContextHandle.sampleRate;
       audioSource.buffer = audioContextHandle.createBuffer(1, 1, webAudioActualSampleRate);  //Create a zero'd input buffer for the input to be valid.
       audioNode = audioContextHandle.createJavaScriptNode(samplesPerCallback, 1, 2);      //Create 2 outputs and ignore the input buffer (Just copy buffer 1 over if mono)


### PR DESCRIPTION
followup to #227 (this is a fairly small set of changes, it's based on spillover from a couple of other commits)

Note: I haven't rerun my tool against the current corpus, this is all work from when I made my original pass (I just never got around to proposing the other items in my series.)