### PR TITLE
Fix spelling of variable names in WebAssemblyModule.cpp

### DIFF
--- a/lib/Runtime/Library/WebAssemblyModule.cpp
+++ b/lib/Runtime/Library/WebAssemblyModule.cpp
@@ -291,8 +291,8 @@ WebAssemblyModule::ValidateModule(
             {
                 CONFIG_FLAG(MaxAsmJsInterpreterRunCount) = 0;
                 AsmJsScriptFunction * funcObj = scriptContext->GetLibrary()->CreateAsmJsScriptFunction(body);
-                FunctionEntryPointInfo * entypointInfo = (FunctionEntryPointInfo*)funcObj->GetEntryPointInfo();
-                entypointInfo->SetIsAsmJSFunction(true);
+                FunctionEntryPointInfo * entrypointInfo = (FunctionEntryPointInfo*)funcObj->GetEntryPointInfo();
+                entrypointInfo->SetIsAsmJSFunction(true);
                 GenerateFunction(scriptContext->GetNativeCodeGenerator(), body, funcObj);
             }
 #endif


### PR DESCRIPTION
followup to #227

Note: I haven't rerun my tool against the current corpus, this is all work from when I made my original pass (I just never got around to proposing the other items in my series.)