### PR TITLE
Disable fixed field and equivalent type spec code from DISABLE_JIT builds

### DIFF
--- a/lib/Backend/InterpreterThunkEmitter.cpp
+++ b/lib/Backend/InterpreterThunkEmitter.cpp
@@ -4,7 +4,7 @@
 //-------------------------------------------------------------------------------------------------------
 #include "Backend.h"
 
-#ifdef ENABLE_NATIVE_CODEGEN
+#if ENABLE_NATIVE_CODEGEN
 #ifdef _M_X64
 #ifdef _WIN32
 const BYTE InterpreterThunkEmitter::FunctionInfoOffset = 23;

--- a/lib/Backend/InterpreterThunkEmitter.h
+++ b/lib/Backend/InterpreterThunkEmitter.h
@@ -4,7 +4,7 @@
 //-------------------------------------------------------------------------------------------------------
 #pragma once
 
-#ifdef ENABLE_NATIVE_CODEGEN
+#if ENABLE_NATIVE_CODEGEN
 class ThunkBlock
 {
 private:

--- a/lib/Backend/NativeCodeGenerator.cpp
+++ b/lib/Backend/NativeCodeGenerator.cpp
@@ -2733,6 +2733,7 @@ NativeCodeGenerator::GatherCodeGenData(
             }
 
             Js::JavascriptFunction* fixedFunctionObject = nullptr;
+#if ENABLE_FIXED_FIELDS
             if (inlineCache && (inlineCache->IsLocal() || inlineCache->IsProto()))
             {
                 inlineCache->TryGetFixedMethodFromCache(functionBody, ldFldInlineCacheIndex, &fixedFunctionObject);
@@ -2742,6 +2743,7 @@ NativeCodeGenerator::GatherCodeGenData(
             {
                 fixedFunctionObject = nullptr;
             }
+#endif
 
             if (!PHASE_OFF(Js::InlineRecursivePhase, functionBody))
             {

--- a/lib/Common/CommonDefines.h
+++ b/lib/Common/CommonDefines.h
@@ -12,6 +12,7 @@
 #include "Warnings.h"
 #include "ChakraCoreVersion.h"
 
+
 //----------------------------------------------------------------------------------------------------
 // Default debug/fretest/release flags values
 //  - Set the default values of debug/fretest/release flags if it is not set by the command line
@@ -122,7 +123,15 @@
 
 // Type system features
 #define PERSISTENT_INLINE_CACHES                    // *** TODO: Won't build if disabled currently
-#define SUPPORT_FIXED_FIELDS_ON_PATH_TYPES          // *** TODO: Won't build if disabled currently
+
+#if !DISABLE_JIT
+#define ENABLE_FIXED_FIELDS 1                       // Turn on fixed fields if JIT is enabled
+#endif
+
+#if ENABLE_FIXED_FIELDS
+#define SUPPORT_FIXED_FIELDS_ON_PATH_TYPES
+#endif
+
 
 // xplat-todo: revisit these features
 #ifdef _WIN32

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -79,6 +79,8 @@ namespace Js
         Type * type;
         void * data;
     };
+
+#if ENABLE_NATIVE_CODEGEN
     class PropertyGuard
     {
         friend class PropertyGuardValidator;
@@ -271,6 +273,7 @@ namespace Js
             this->cache = cache;
         }
     };
+#endif // ENABLE_NATIVE_CODEGEN
 
 #pragma region Inline Cache Info class declarations
     class PolymorphicCacheUtilizationArray

--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -88,7 +88,9 @@ ThreadContext::RecyclableData::RecyclableData(Recycler *const recycler) :
     oomErrorObject(nullptr, nullptr, nullptr, true),
     terminatedErrorObject(nullptr, nullptr, nullptr),
     typesWithProtoPropertyCache(recycler),
+#if ENABLE_NATIVE_CODEGEN
     propertyGuards(recycler, 128),
+#endif
     oldEntryPointInfo(nullptr),
 #ifdef ENABLE_SCRIPT_DEBUGGING
     returnedValueList(nullptr),
@@ -3099,6 +3101,7 @@ ThreadContext::ClearInlineCachesWithDeadWeakRefs()
     }
 }
 
+#if ENABLE_NATIVE_CODEGEN
 void
 ThreadContext::ClearInvalidatedUniqueGuards()
 {
@@ -3131,6 +3134,7 @@ ThreadContext::ClearInvalidatedUniqueGuards()
         });
     });
 }
+#endif
 
 void
 ThreadContext::ClearInlineCaches()

--- a/lib/Runtime/Base/ThreadContext.h
+++ b/lib/Runtime/Base/ThreadContext.h
@@ -572,6 +572,7 @@ private:
         // that would not get removed, but it would also not get any bigger.
         Field(PropertyIdToTypeHashSetDictionary) typesWithProtoPropertyCache;
 
+#if ENABLE_NATIVE_CODEGEN
         // The property guard dictionary contains property guards which need to be invalidated in response to properties changing
         // from writable to read-only and vice versa, properties being shadowed or unshadowed on prototypes, etc.  The dictionary
         // holds only weak references to property guards and their lifetimes are controlled by their creators (typically entry points).
@@ -579,7 +580,7 @@ private:
         // the guards for a given property get invalidated.
         // TODO: Create and use a self-cleaning weak reference dictionary, which would periodically remove any unused weak references.
         Field(PropertyGuardDictionary) propertyGuards;
-
+#endif
 
         Field(PropertyNoCaseSetType *) caseInvariantPropertySet;
 

--- a/lib/Runtime/Language/CacheOperators.cpp
+++ b/lib/Runtime/Language/CacheOperators.cpp
@@ -38,9 +38,11 @@ namespace Js
             (RootObjectBase::Is(objectWithProperty) && propertyIndex == RootObjectBase::FromVar(objectWithProperty)->GetRootPropertyIndex(propertyId)));
         Assert(DynamicType::Is(objectWithProperty->GetTypeId()));
 
+#if ENABLE_FIXED_FIELDS
         // We are populating a cache guarded by the instance's type (not the type of the object with property somewhere in the prototype chain),
         // so we only care if the instance's property (if any) is fixed.
         Assert(info->IsNoCache() || !info->IsStoreFieldCacheEnabled() || info->GetInstance() != objectWithProperty || !objectWithProperty->IsFixedProperty(propertyId));
+#endif
 
         PropertyIndex slotIndex;
         bool isInlineSlot;
@@ -210,7 +212,9 @@ namespace Js
         {
             AssertMsg(instance == object, "invalid instance for non setter");
             Assert(DynamicType::Is(typeWithoutProperty->GetTypeId()));
+#if ENABLE_FIXED_FIELDS
             Assert(info->IsNoCache() || !info->IsStoreFieldCacheEnabled() || object->CanStorePropertyValueDirectly(propertyId, isRoot));
+#endif
             Assert(info->IsWritable());
 
             DynamicType* newType = (DynamicType*)object->GetType();

--- a/lib/Runtime/Language/InlineCache.cpp
+++ b/lib/Runtime/Language/InlineCache.cpp
@@ -413,6 +413,7 @@ namespace Js
         return clone;
     }
 
+#if ENABLE_FIXED_FIELDS
     bool InlineCache::TryGetFixedMethodFromCache(Js::FunctionBody* functionBody, uint cacheId, Js::JavascriptFunction** pFixedMethod)
     {
         Assert(pFixedMethod);
@@ -464,6 +465,7 @@ namespace Js
 
         return false;
     }
+#endif
 
     void InlineCache::CopyTo(PropertyId propertyId, ScriptContext * scriptContext, InlineCache * const clone)
     {

--- a/lib/Runtime/Language/InlineCache.h
+++ b/lib/Runtime/Language/InlineCache.h
@@ -322,7 +322,9 @@ namespace Js
         InlineCache *Clone(TAllocator *const allocator);
         InlineCache *Clone(Js::PropertyId propertyId, ScriptContext* scriptContext);
         void CopyTo(PropertyId propertyId, ScriptContext * scriptContext, InlineCache * const clone);
+#if ENABLE_FIXED_FIELDS
         bool TryGetFixedMethodFromCache(Js::FunctionBody* functionBody, uint cacheId, Js::JavascriptFunction** pFixedMethod);
+#endif
 
         bool GetGetterSetter(Type *const type, RecyclableObject **callee);
         bool GetCallApplyTarget(RecyclableObject* obj, RecyclableObject **callee);

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -1722,7 +1722,7 @@ CommonNumber:
 
         if (foundProperty)
         {
-#if DBG
+#if ENABLE_FIXED_FIELDS && DBG
             if (DynamicObject::Is(object))
             {
                 DynamicObject* dynamicObject = (DynamicObject*)object;
@@ -2067,7 +2067,8 @@ CommonNumber:
         {
             JavascriptError::ThrowReferenceError(requestContext, JSERR_UseBeforeDeclaration);
         }
-#if DBG
+
+#if ENABLE_FIXED_FIELDS && DBG
         if (DynamicObject::Is(object))
         {
             DynamicObject* dynamicObject = (DynamicObject*)object;
@@ -5435,7 +5436,9 @@ CommonNumber:
 
         if (!newType->GetIsShared())
         {
+#if ENABLE_FIXED_FIELDS
             newType->GetTypeHandler()->SetSingletonInstanceIfNeeded(instance);
+#endif
         }
 #ifdef PROFILE_OBJECT_LITERALS
         else
@@ -8135,6 +8138,7 @@ CommonNumber:
         }
     }
 
+#if ENABLE_NATIVE_CODEGEN
 #if ENABLE_DEBUG_CONFIG_OPTIONS
     void JavascriptOperators::TracePropertyEquivalenceCheck(const JitEquivalentTypeGuard* guard, const Type* type, const Type* refType, bool isEquivalent, uint failedPropertyIndex)
     {
@@ -8440,6 +8444,7 @@ CommonNumber:
         guard->SetTypeAddr((intptr_t)type);
         return true;
     }
+#endif
 
     void JavascriptOperators::GetPropertyIdForInt(uint64 value, ScriptContext* scriptContext, PropertyRecord const ** propertyRecord)
     {

--- a/lib/Runtime/Language/JavascriptOperators.h
+++ b/lib/Runtime/Language/JavascriptOperators.h
@@ -517,6 +517,7 @@ namespace Js
 
         static Var PatchGetMethodFromObject(Var instance, RecyclableObject * propertyObject, PropertyId propertyId, PropertyValueInfo * info, ScriptContext * scriptContext, bool isRootLd);
 
+#if ENABLE_NATIVE_CODEGEN
 #if ENABLE_DEBUG_CONFIG_OPTIONS
         static void TracePropertyEquivalenceCheck(const JitEquivalentTypeGuard* guard, const Type* type, const Type* refType, bool isEquivalent, uint failedPropertyIndex);
 #endif
@@ -524,6 +525,7 @@ namespace Js
         static bool IsStaticTypeObjTypeSpecEquivalent(const EquivalentPropertyEntry *entry);
         static bool CheckIfTypeIsEquivalent(Type* type, JitEquivalentTypeGuard* guard);
         static bool CheckIfTypeIsEquivalentForFixedField(Type* type, JitEquivalentTypeGuard* guard);
+#endif
 
         static void GetPropertyIdForInt(uint64 value, ScriptContext* scriptContext, PropertyRecord const ** propertyRecord);
         static void GetPropertyIdForInt(uint32 value, ScriptContext* scriptContext, PropertyRecord const ** propertyRecord);

--- a/lib/Runtime/Language/ModuleNamespace.h
+++ b/lib/Runtime/Language/ModuleNamespace.h
@@ -49,7 +49,9 @@ namespace Js
         virtual BOOL SetPropertyWithAttributes(PropertyId propertyId, Var value, PropertyAttributes attributes, PropertyValueInfo* info, PropertyOperationFlags flags = PropertyOperation_None, SideEffects possibleSideEffects = SideEffects_Any) override { return false; }
         virtual BOOL DeleteProperty(PropertyId propertyId, PropertyOperationFlags flags) override;
         virtual BOOL DeleteProperty(JavascriptString *propertyNameString, PropertyOperationFlags flags) override;
+#if ENABLE_FIXED_FIELDS
         virtual BOOL IsFixedProperty(PropertyId propertyId) override { return false; }
+#endif
         virtual PropertyQueryFlags HasItemQuery(uint32 index) override { return PropertyQueryFlags::Property_NotFound; }
         virtual BOOL HasOwnItem(uint32 index) override { return false; }
         virtual PropertyQueryFlags GetItemQuery(Var originalInstance, uint32 index, Var* value, ScriptContext * requestContext) override { return PropertyQueryFlags::Property_NotFound; }

--- a/lib/Runtime/Library/GlobalObject.cpp
+++ b/lib/Runtime/Library/GlobalObject.cpp
@@ -26,7 +26,9 @@ namespace Js
         GlobalObject* globalObject = RecyclerNewPlus(scriptContext->GetRecycler(),
             sizeof(Var) * InlineSlotCapacity, GlobalObject, globalType, scriptContext);
 
+#if ENABLE_FIXED_FIELDS
         globalTypeHandler->SetSingletonInstanceIfNeeded(scriptContext->GetRecycler()->CreateWeakReferenceHandle<DynamicObject>(globalObject));
+#endif
 
         return globalObject;
     }

--- a/lib/Runtime/Library/JavascriptProxy.cpp
+++ b/lib/Runtime/Library/JavascriptProxy.cpp
@@ -850,11 +850,13 @@ namespace Js
         return TRUE;
     }
 
+#if ENABLE_FIXED_FIELDS
     BOOL JavascriptProxy::IsFixedProperty(PropertyId propertyId)
     {
         // TODO: can we add support for fixed property? don't see a clear way to invalidate...
         return false;
     }
+#endif
 
     PropertyQueryFlags JavascriptProxy::HasItemQuery(uint32 index)
     {

--- a/lib/Runtime/Library/JavascriptProxy.h
+++ b/lib/Runtime/Library/JavascriptProxy.h
@@ -94,7 +94,9 @@ namespace Js
         virtual BOOL InitFuncScoped(PropertyId propertyId, Var value) override;
         virtual BOOL DeleteProperty(PropertyId propertyId, PropertyOperationFlags flags) override;
         virtual BOOL DeleteProperty(JavascriptString *propertyNameString, PropertyOperationFlags flags) override;
+#if ENABLE_FIXED_FIELDS
         virtual BOOL IsFixedProperty(PropertyId propertyId) override;
+#endif
         virtual PropertyQueryFlags HasItemQuery(uint32 index) override;
         virtual BOOL HasOwnItem(uint32 index) override;
         virtual PropertyQueryFlags GetItemQuery(Var originalInstance, uint32 index, Var* value, ScriptContext * requestContext) override;

--- a/lib/Runtime/Library/ModuleRoot.cpp
+++ b/lib/Runtime/Library/ModuleRoot.cpp
@@ -68,10 +68,12 @@ namespace Js
             if (info) // Avoid testing IsWritable if info not being queried
             {
                 PropertyValueInfo::Set(info, this, index, IsWritable(propertyId) ? PropertyWritable : PropertyNone);
+#if ENABLE_FIXED_FIELDS
                 if (this->IsFixedProperty(propertyId))
                 {
                     PropertyValueInfo::DisableStoreFieldCache(info);
                 }
+#endif
             }
             return PropertyQueryFlags::Property_Found;
         }
@@ -98,10 +100,12 @@ namespace Js
             if (info) // Avoid testing IsWritable if info not being queried
             {
                 PropertyValueInfo::Set(info, this, index, IsWritable(propertyId) ? PropertyWritable : PropertyNone);
+#if ENABLE_FIXED_FIELDS
                 if (this->IsFixedProperty(propertyId))
                 {
                     PropertyValueInfo::DisableStoreFieldCache(info);
                 }
+#endif
             }
             return TRUE;
         }
@@ -152,10 +156,12 @@ namespace Js
             if (info) // Avoid testing IsWritable if info not being queried
             {
                 PropertyValueInfo::Set(info, this, index, IsWritable(propertyId) ? PropertyWritable : PropertyNone);
+#if ENABLE_FIXED_FIELDS
                 if (this->IsFixedProperty(propertyId))
                 {
                     PropertyValueInfo::DisableStoreFieldCache(info);
                 }
+#endif
             }
             return PropertyQueryFlags::Property_Found;
         }
@@ -183,10 +189,12 @@ namespace Js
             if (info) // Avoid testing IsWritable if info not being queried
             {
                 PropertyValueInfo::Set(info, this, index, IsWritable(propertyId) ? PropertyWritable : PropertyNone);
+#if ENABLE_FIXED_FIELDS
                 if (this->IsFixedProperty(propertyId))
                 {
                     PropertyValueInfo::DisableStoreFieldCache(info);
                 }
+#endif
             }
             return TRUE;
         }
@@ -213,24 +221,28 @@ namespace Js
             {
                 JavascriptError::ThrowCantAssignIfStrictMode(flags, this->GetScriptContext());
 
-                if (!this->IsFixedProperty(propertyId))
-                {
-                    PropertyValueInfo::Set(info, this, index, PropertyNone); // Try to cache property info even if not writable
-                }
-                else
+#if ENABLE_FIXED_FIELDS
+                if (this->IsFixedProperty(propertyId))
                 {
                     PropertyValueInfo::SetNoCache(info, this);
+                }
+                else
+#endif
+                {
+                    PropertyValueInfo::Set(info, this, index, PropertyNone); // Try to cache property info even if not writable
                 }
                 return FALSE;
             }
             this->SetSlot(SetSlotArguments(propertyId, index, value));
-            if (!this->IsFixedProperty(propertyId))
-            {
-                PropertyValueInfo::Set(info, this, index);
-            }
-            else
+#if ENABLE_FIXED_FIELDS
+            if (this->IsFixedProperty(propertyId))
             {
                 PropertyValueInfo::SetNoCache(info, this);
+            }
+            else
+#endif
+            {
+                PropertyValueInfo::Set(info, this, index);
             }
             return TRUE;
         }
@@ -272,25 +284,29 @@ namespace Js
             {
                 JavascriptError::ThrowCantAssignIfStrictMode(flags, this->GetScriptContext());
 
-                if (!this->IsFixedProperty(propertyId))
-                {
-                    PropertyValueInfo::Set(info, this, index, PropertyNone); // Try to cache property info even if not writable
-                }
-                else
+#if ENABLE_FIXED_FIELDS
+                if (this->IsFixedProperty(propertyId))
                 {
                     PropertyValueInfo::SetNoCache(info, this);
+                }
+                else
+#endif
+                {
+                    PropertyValueInfo::Set(info, this, index, PropertyNone); // Try to cache property info even if not writable
                 }
                 return FALSE;
             }
             this->SetSlot(SetSlotArgumentsRoot(propertyId, true, index, value));
-            if (!this->IsFixedProperty(propertyId))
-            {
-                PropertyValueInfo::Set(info, this, index);
-            }
-            else
+#if ENABLE_FIXED_FIELDS
+            if (this->IsFixedProperty(propertyId))
             {
                 PropertyValueInfo::SetNoCache(info, this);
             }
+            else
+#endif
+            {
+                PropertyValueInfo::Set(info, this, index);
+            }            
             return TRUE;
         }
         else if (this->hostObject && this->hostObject->HasProperty(propertyId))

--- a/lib/Runtime/Types/ActivationObject.cpp
+++ b/lib/Runtime/Types/ActivationObject.cpp
@@ -141,7 +141,9 @@ namespace Js
     BlockActivationObject* BlockActivationObject::Clone(ScriptContext *scriptContext)
     {
         DynamicType* type = this->GetDynamicType();
+#if ENABLE_FIXED_FIELDS
         type->GetTypeHandler()->ClearSingletonInstance(); //We are going to share the type.
+#endif
 
         BlockActivationObject* blockScopeClone = DynamicObject::NewObject<BlockActivationObject>(scriptContext->GetRecycler(), type);
         int slotCapacity = this->GetTypeHandler()->GetSlotCapacity();

--- a/lib/Runtime/Types/DeferredTypeHandler.cpp
+++ b/lib/Runtime/Types/DeferredTypeHandler.cpp
@@ -83,8 +83,9 @@ namespace Js
 
         // Create new type handler, allowing slotCapacity round up here. We'll allocate instance slots below.
         T* newTypeHandler = T::New(recycler, initSlotCapacity, GetInlineSlotCapacity(), GetOffsetOfInlineSlots());
+#if ENABLE_FIXED_FIELDS
         newTypeHandler->SetSingletonInstanceIfNeeded(instance);
-
+#endif
         // EnsureSlots before updating the type handler and instance, as EnsureSlots allocates and may throw.
         instance->EnsureSlots(0, newTypeHandler->GetSlotCapacity(), scriptContext, newTypeHandler);
         newTypeHandler->SetFlags(IsPrototypeFlag, this->GetFlags());

--- a/lib/Runtime/Types/DeferredTypeHandler.h
+++ b/lib/Runtime/Types/DeferredTypeHandler.h
@@ -87,9 +87,11 @@ namespace Js
         virtual BOOL FindNextProperty(ScriptContext* scriptContext, PropertyIndex& index, JavascriptString** propertyString,
             PropertyId* propertyId, PropertyAttributes* attributes, Type* type, DynamicType *typeToEnumerate, EnumeratorFlags flags, DynamicObject* instance, PropertyValueInfo* info) override;
         virtual PropertyIndex GetPropertyIndex(PropertyRecord const* propertyRecord) override;
+#if ENABLE_NATIVE_CODEGEN
         virtual bool GetPropertyEquivalenceInfo(PropertyRecord const* propertyRecord, PropertyEquivalenceInfo& info) override;
         virtual bool IsObjTypeSpecEquivalent(const Type* type, const TypeEquivalenceRecord& record, uint& failedPropertyIndex) override;
         virtual bool IsObjTypeSpecEquivalent(const Type* type, const EquivalentPropertyEntry* entry) override;
+#endif
         virtual bool EnsureObjectReady(DynamicObject* instance) override;
         virtual BOOL HasProperty(DynamicObject* instance, PropertyId propertyId, __out_opt bool *noRedecl = nullptr) override;
         virtual BOOL HasProperty(DynamicObject* instance, JavascriptString* propertyNameString) override;
@@ -176,6 +178,7 @@ namespace Js
         return Constants::NoSlot;
     }
 
+#if ENABLE_NATIVE_CODEGEN
     template <DeferredTypeInitializer initializer, typename DeferredTypeFilter, bool isPrototypeTemplate, uint16 _inlineSlotCapacity, uint16 _offsetOfInlineSlots>
     bool DeferredTypeHandler<initializer, DeferredTypeFilter, isPrototypeTemplate, _inlineSlotCapacity, _offsetOfInlineSlots>::GetPropertyEquivalenceInfo(PropertyRecord const* propertyRecord, PropertyEquivalenceInfo& info)
     {
@@ -217,6 +220,7 @@ namespace Js
 
         return true;
     }
+#endif
 
     template <DeferredTypeInitializer initializer, typename DeferredTypeFilter, bool isPrototypeTemplate, uint16 _inlineSlotCapacity, uint16 _offsetOfInlineSlots>
     bool DeferredTypeHandler<initializer, DeferredTypeFilter, isPrototypeTemplate, _inlineSlotCapacity, _offsetOfInlineSlots>::EnsureObjectReady(DynamicObject* instance)

--- a/lib/Runtime/Types/DictionaryTypeHandler.cpp
+++ b/lib/Runtime/Types/DictionaryTypeHandler.cpp
@@ -27,8 +27,10 @@ namespace Js
     template <typename T>
     DictionaryTypeHandlerBase<T>::DictionaryTypeHandlerBase(Recycler* recycler) :
         DynamicTypeHandler(1),
-        nextPropertyIndex(0),
-        singletonInstance(nullptr)
+        nextPropertyIndex(0)
+#if ENABLE_FIXED_FIELDS
+        , singletonInstance(nullptr)
+#endif
     {
         SetIsInlineSlotCapacityLocked();
         propertyMap = RecyclerNew(recycler, PropertyDescriptorMap, recycler, this->GetSlotCapacity());
@@ -38,8 +40,10 @@ namespace Js
     DictionaryTypeHandlerBase<T>::DictionaryTypeHandlerBase(Recycler* recycler, int slotCapacity, uint16 inlineSlotCapacity, uint16 offsetOfInlineSlots) :
         // Do not RoundUp passed in slotCapacity. This may be called by ConvertTypeHandler for an existing DynamicObject and should use the real existing slotCapacity.
         DynamicTypeHandler(slotCapacity, inlineSlotCapacity, offsetOfInlineSlots),
-        nextPropertyIndex(0),
-        singletonInstance(nullptr)
+        nextPropertyIndex(0)
+#if ENABLE_FIXED_FIELDS
+        , singletonInstance(nullptr)
+#endif
     {
         SetIsInlineSlotCapacityLocked();
         Assert(GetSlotCapacity() <= MaxPropertyIndexSize);
@@ -52,8 +56,10 @@ namespace Js
     template <typename T>
     DictionaryTypeHandlerBase<T>::DictionaryTypeHandlerBase(DictionaryTypeHandlerBase* typeHandler) :
         DynamicTypeHandler(typeHandler->GetSlotCapacity(), typeHandler->GetInlineSlotCapacity(), typeHandler->GetOffsetOfInlineSlots()),
-        propertyMap(typeHandler->propertyMap), nextPropertyIndex(typeHandler->nextPropertyIndex),
-        singletonInstance(typeHandler->singletonInstance)
+        propertyMap(typeHandler->propertyMap), nextPropertyIndex(typeHandler->nextPropertyIndex)
+#if ENABLE_FIXED_FIELDS
+        , singletonInstance(typeHandler->singletonInstance)
+#endif
     {
         Assert(typeHandler->GetIsInlineSlotCapacityLocked());
         CopyPropertyTypes(PropertyTypesWritableDataOnly | PropertyTypesWritableDataOnlyDetection | PropertyTypesInlineSlotCapacityLocked, typeHandler->GetPropertyTypes());
@@ -131,7 +137,7 @@ namespace Js
                 {
                     PropertyValueInfo::SetCacheInfo(info, propertyString, propertyString->GetLdElemInlineCache(), false);
                     SetPropertyValueInfo(info, instance, dataSlot, descriptor.Attributes);
-                    if (!descriptor.IsInitialized || descriptor.IsFixed)
+                    if (descriptor.IsOrMayBecomeFixed())
                     {
                         PropertyValueInfo::DisableStoreFieldCache(info);
                     }
@@ -222,6 +228,7 @@ namespace Js
         return GetPropertyIndex_Internal<true>(propertyRecord);
     }
 
+#if ENABLE_NATIVE_CODEGEN
     template <typename T>
     bool DictionaryTypeHandlerBase<T>::GetPropertyEquivalenceInfo(PropertyRecord const* propertyRecord, PropertyEquivalenceInfo& info)
     {
@@ -304,8 +311,8 @@ namespace Js
             {
                 return false;
             }
-
-            if (entry->mustBeWritable && (!(descriptor->Attributes & PropertyWritable) || !descriptor->IsInitialized || descriptor->IsFixed))
+            
+            if (entry->mustBeWritable && (!(descriptor->Attributes & PropertyWritable) || descriptor->IsOrMayBecomeFixed()))
             {
                 return false;
             }
@@ -320,6 +327,7 @@ namespace Js
 
         return true;
     }
+#endif
 
     template <typename T>
     template <bool allowLetConstGlobal>
@@ -379,11 +387,12 @@ namespace Js
         T index = ::Math::PostInc(nextPropertyIndex);
 
         DictionaryPropertyDescriptor<T> descriptor(index, attributes);
+#if ENABLE_FIXED_FIELDS
         Assert((!isFixed && !usedAsFixed) || (!IsInternalPropertyId(propertyId->GetPropertyId()) && this->singletonInstance != nullptr));
         descriptor.IsInitialized = isInitialized;
         descriptor.IsFixed = isFixed;
         descriptor.UsedAsFixed = usedAsFixed;
-
+#endif
         propertyMap->Add(propertyId, descriptor);
 
         if (!(attributes & PropertyWritable))
@@ -518,7 +527,7 @@ namespace Js
         {
             *value = instance->GetSlot(dataSlot);
             SetPropertyValueInfo(info, instance, dataSlot, descriptor->Attributes);
-            if (!descriptor->IsInitialized || descriptor->IsFixed)
+            if (descriptor->IsOrMayBecomeFixed())
             {
                 PropertyValueInfo::DisableStoreFieldCache(info);
             }
@@ -715,9 +724,10 @@ namespace Js
 
         // DictionaryTypeHandlers are not supposed to be shared.
         Assert(!GetIsOrMayBecomeShared());
+#if ENABLE_FIXED_FIELDS
         DynamicObject* localSingletonInstance = this->singletonInstance != nullptr ? this->singletonInstance->Get() : nullptr;
         Assert(this->singletonInstance == nullptr || localSingletonInstance == instance);
-
+#endif
         T dataSlotAllowLetConstGlobal = descriptor->template GetDataPropertyIndex<allowLetConstGlobal>();
         if (dataSlotAllowLetConstGlobal != NoSlots)
         {
@@ -732,6 +742,7 @@ namespace Js
                 }
             }
 
+#if ENABLE_FIXED_FIELDS
             if (!descriptor->IsInitialized)
             {
                 if ((flags & PropertyOperation_PreInit) == 0)
@@ -751,12 +762,13 @@ namespace Js
             {
                 InvalidateFixedField(instance, propertyId, descriptor);
             }
+#endif
 
             SetSlotUnchecked(instance, dataSlotAllowLetConstGlobal, value);
 
             // If we just added a fixed method, don't populate the inline cache so that we always take the slow path
             // when overwriting this property and correctly invalidate any JIT-ed code that hard-coded this method.
-            if (descriptor->IsInitialized && !descriptor->IsFixed)
+            if (!descriptor->IsOrMayBecomeFixed())
             {
                 SetPropertyValueInfo(info, instance, dataSlotAllowLetConstGlobal, GetLetConstGlobalPropertyAttributes<allowLetConstGlobal>(descriptor->Attributes));
             }
@@ -800,7 +812,9 @@ namespace Js
         PropertyRecord const* propertyRecord = scriptContext->GetPropertyName(propertyId);
         if (propertyMap->TryGetReference(propertyRecord, &descriptor))
         {
+#if ENABLE_FIXED_FIELDS
             Assert(descriptor->SanityCheckFixedBits());
+#endif
             if (descriptor->Attributes & PropertyDeleted)
             {
                 if (!isForce)
@@ -882,8 +896,9 @@ namespace Js
 
         if (propertyMap->TryGetReference(propertyName, &descriptor))
         {
+#if ENABLE_FIXED_FIELDS
             Assert(descriptor->SanityCheckFixedBits());
-
+#endif
             if (descriptor->Attributes & PropertyDeleted)
             {
                 return true;
@@ -927,7 +942,9 @@ namespace Js
                     descriptor->Attributes &= ~PropertyDynamicTypeDefaults;
                     descriptor->Attributes |= PropertyDeletedDefaults;
                 }
+#if ENABLE_FIXED_FIELDS
                 InvalidateFixedField(instance, propertyNameString, descriptor);
+#endif
 
                 // Change the type so as we can invalidate the cache in fast path jit
                 if (instance->GetType()->HasBeenCached())
@@ -962,8 +979,9 @@ namespace Js
         PropertyRecord const* propertyRecord = scriptContext->GetPropertyName(propertyId);
         if (propertyMap->TryGetReference(propertyRecord, &descriptor))
         {
+#if ENABLE_FIXED_FIELDS
             Assert(descriptor->SanityCheckFixedBits());
-
+#endif
             if (descriptor->Attributes & PropertyDeleted)
             {
                 // If PropertyDeleted and PropertyLetConstGlobal are set then we have both
@@ -1019,7 +1037,9 @@ namespace Js
                     descriptor->Attributes &= ~PropertyDynamicTypeDefaults;
                     descriptor->Attributes |= PropertyDeletedDefaults;
                 }
+#if ENABLE_FIXED_FIELDS
                 InvalidateFixedField(instance, propertyId, descriptor);
+#endif
 
                 // Change the type so as we can invalidate the cache in fast path jit
                 if (instance->GetType()->HasBeenCached())
@@ -1043,6 +1063,7 @@ namespace Js
         return true;
     }
 
+#if ENABLE_FIXED_FIELDS
     template <typename T>
     BOOL DictionaryTypeHandlerBase<T>::IsFixedProperty(const DynamicObject* instance, PropertyId propertyId)
     {
@@ -1060,8 +1081,9 @@ namespace Js
             return false;
         }
     }
+#endif
 
-        template <typename T>
+    template <typename T>
     BOOL DictionaryTypeHandlerBase<T>::SetItem(DynamicObject* instance, uint32 index, Var value, PropertyOperationFlags flags)
     {
         if (!(this->GetFlags() & IsExtensibleFlag) && !instance->HasObjectArray())
@@ -1572,8 +1594,9 @@ namespace Js
         PropertyRecord const* propertyRecord = instance->GetScriptContext()->GetPropertyName(propertyId);
         if (propertyMap->TryGetReference(propertyRecord, &descriptor))
         {
+#if ENABLE_FIXED_FIELDS
             Assert(descriptor->SanityCheckFixedBits());
-
+#endif
             if (descriptor->Attributes & PropertyDeleted)
             {
                 if (descriptor->Attributes & PropertyLetConstGlobal)
@@ -1601,6 +1624,7 @@ namespace Js
 
             // DictionaryTypeHandlers are not supposed to be shared.
             Assert(!GetIsOrMayBecomeShared());
+#if ENABLE_FIXED_FIELDS
             DynamicObject* localSingletonInstance = this->singletonInstance != nullptr ? this->singletonInstance->Get() : nullptr;
             Assert(this->singletonInstance == nullptr || localSingletonInstance == instance);
 
@@ -1640,6 +1664,7 @@ namespace Js
             {
                 InvalidateFixedField(instance, propertyId, descriptor);
             }
+#endif
 
             // don't overwrite an existing accessor with null
             if (getter != nullptr)
@@ -1683,6 +1708,7 @@ namespace Js
 
         // DictionaryTypeHandlers are not supposed to be shared.
         Assert(!GetIsOrMayBecomeShared());
+#if ENABLE_FIXED_FIELDS
         DynamicObject* localSingletonInstance = this->singletonInstance != nullptr ? this->singletonInstance->Get() : nullptr;
         Assert(this->singletonInstance == nullptr || localSingletonInstance == instance);
         newDescriptor.IsInitialized = true;
@@ -1699,6 +1725,7 @@ namespace Js
                 newDescriptor.IsOnlyOneAccessorInitialized = true;
             }
         }
+#endif
 
         propertyMap->Add(propertyRecord, newDescriptor);
 
@@ -1747,8 +1774,9 @@ namespace Js
         PropertyRecord const* propertyRecord = instance->GetScriptContext()->GetPropertyName(propertyId);
         if (propertyMap->TryGetReference(propertyRecord, &descriptor))
         {
+#if ENABLE_FIXED_FIELDS
             Assert(descriptor->SanityCheckFixedBits());
-
+#endif
             if (attributes & descriptor->Attributes & PropertyLetConstGlobal)
             {
                 // Do not need to change the descriptor or its attributes if setting the initial value of a LetConstGlobal
@@ -1997,6 +2025,7 @@ namespace Js
         // We expect the new type handler to start off marked as having only writable data properties.
         Assert(newTypeHandler->GetHasOnlyWritableDataProperties());
 
+#if ENABLE_FIXED_FIELDS
 #ifdef ENABLE_DEBUG_CONFIG_OPTIONS
         DynamicType* oldType = instance->GetDynamicType();
         RecyclerWeakReference<DynamicObject>* oldSingletonInstance = GetSingletonInstance();
@@ -2004,6 +2033,7 @@ namespace Js
 #endif
 
         CopySingletonInstance(instance, newTypeHandler);
+#endif
 
         DictionaryPropertyDescriptor<T> descriptor;
         DictionaryPropertyDescriptor<BigPropertyIndex> bigDescriptor;
@@ -2020,7 +2050,9 @@ namespace Js
 
         newTypeHandler->nextPropertyIndex = nextPropertyIndex;
 
+#if ENABLE_FIXED_FIELDS
         ClearSingletonInstance();
+#endif
 
         AssertMsg((newTypeHandler->GetFlags() & IsPrototypeFlag) == 0, "Why did we create a brand new type handler with a prototype flag set?");
         newTypeHandler->SetFlags(IsPrototypeFlag, this->GetFlags());
@@ -2030,6 +2062,8 @@ namespace Js
         Assert(newTypeHandler->GetIsInlineSlotCapacityLocked());
         newTypeHandler->SetPropertyTypes(PropertyTypesWritableDataOnly | PropertyTypesWritableDataOnlyDetection,  this->GetPropertyTypes());
         newTypeHandler->SetInstanceTypeHandler(instance);
+
+#if ENABLE_FIXED_FIELDS
         // Unlike for SimpleDictionaryTypeHandler or PathTypeHandler, the DictionaryTypeHandler copies usedAsFixed indiscriminately above.
         // Therefore, we don't care if we changed the type or not, and don't need the assert below.
         // We assumed that we don't need to transfer used as fixed bits unless we are a prototype, which is only valid if we also changed the type.
@@ -2038,6 +2072,7 @@ namespace Js
 
 #ifdef ENABLE_DEBUG_CONFIG_OPTIONS
         TraceFixedFieldsAfterTypeHandlerChange(instance, this, newTypeHandler, oldType, oldSingletonInstance);
+#endif
 #endif
 
         return newTypeHandler;
@@ -2106,6 +2141,7 @@ namespace Js
 
         // DictionaryTypeHandlers are not supposed to be shared.
         Assert(!GetIsOrMayBecomeShared());
+#if ENABLE_FIXED_FIELDS
         DynamicObject* localSingletonInstance = this->singletonInstance != nullptr ? this->singletonInstance->Get() : nullptr;
         Assert(this->singletonInstance == nullptr || localSingletonInstance == instance);
 
@@ -2121,6 +2157,7 @@ namespace Js
                 newDescriptor.IsFixed = (JavascriptFunction::Is(value) ? ShouldFixMethodProperties() : (ShouldFixDataProperties() & CheckHeuristicsForFixedDataProps(instance, propertyRecord, value)));
             }
         }
+#endif
 
         propertyMap->Add(propertyRecord, newDescriptor);
 
@@ -2141,6 +2178,7 @@ namespace Js
 
         SetSlotUnchecked(instance, index, value);
 
+#if ENABLE_FIXED_FIELDS
         // If we just added a fixed method, don't populate the inline cache so that we always take the
         // slow path when overwriting this property and correctly invalidate any JIT-ed code that hard-coded
         // this method.
@@ -2149,6 +2187,7 @@ namespace Js
             PropertyValueInfo::SetNoCache(info, instance);
         }
         else
+#endif
         {
             SetPropertyValueInfo(info, instance, index, attributes);
         }
@@ -2200,6 +2239,7 @@ namespace Js
         // object has changed and/or property guards have already been invalidated through some other means.
         int propertyCount = this->propertyMap->Count();
 
+#if ENABLE_FIXED_FIELDS
         if (invalidateFixedFields)
         {
             for (int propertyIndex = 0; propertyIndex < propertyCount; propertyIndex++)
@@ -2209,6 +2249,7 @@ namespace Js
                 InvalidateFixedField(instance, propertyRecord->GetPropertyId(), descriptor);
             }
         }
+#endif
 
         Js::RecyclableObject* undefined = instance->GetLibrary()->GetUndefined();
         Js::JavascriptFunction* defaultAccessor = instance->GetLibrary()->GetDefaultAccessorFunction();
@@ -2232,6 +2273,7 @@ namespace Js
     template <typename T>
     void DictionaryTypeHandlerBase<T>::MarshalAllPropertiesToScriptContext(DynamicObject* instance, ScriptContext* targetScriptContext, bool invalidateFixedFields)
     {
+#if ENABLE_FIXED_FIELDS
         // Note: This method is currently only called from ResetObject, which in turn only applies to external objects.
         // Before using for other purposes, make sure the assumptions made here make sense in the new context.  In particular,
         // the invalidateFixedFields == false is only correct if a) the object is known not to have any, or b) the type of the
@@ -2246,6 +2288,7 @@ namespace Js
                 InvalidateFixedField(instance, propertyRecord->GetPropertyId(), descriptor);
             }
         }
+#endif
 
         int slotCount = this->nextPropertyIndex;
         for (int slotIndex = 0; slotIndex < slotCount; slotIndex++)
@@ -2272,6 +2315,11 @@ namespace Js
             return;
         }
 
+        // DictionaryTypeHandlers are never shared. If we allow sharing, we will have to handle this case
+        // just like SimpleDictionaryTypeHandler.
+        Assert(!GetIsOrMayBecomeShared());
+
+#if ENABLE_FIXED_FIELDS
         Assert(!GetIsShared() || this->singletonInstance == nullptr);
         Assert(this->singletonInstance == nullptr || this->singletonInstance->Get() == instance);
 
@@ -2324,14 +2372,11 @@ namespace Js
             }
         };
 
-        // DictionaryTypeHandlers are never shared. If we allow sharing, we will have to handle this case
-        // just like SimpleDictionaryTypeHandler.
-        Assert(!GetIsOrMayBecomeShared());
-
 #ifdef ENABLE_DEBUG_CONFIG_OPTIONS
         DynamicType* oldType = instance->GetDynamicType();
         RecyclerWeakReference<DynamicObject>* oldSingletonInstance = GetSingletonInstance();
         TraceFixedFieldsBeforeSetIsProto(instance, this, oldType, oldSingletonInstance);
+#endif
 #endif
 
         bool hasNewType = false;
@@ -2345,6 +2390,7 @@ namespace Js
 
         // Currently there is no way to become the prototype if you are a stack instance
         Assert(!ThreadContext::IsOnStack(instance));
+#if ENABLE_FIXED_FIELDS
         if (AreSingletonInstancesNeeded() && this->singletonInstance == nullptr)
         {
             this->singletonInstance = instance->CreateWeakReferenceToSelf();
@@ -2361,35 +2407,15 @@ namespace Js
                 setFixedFlags(propertyRecord, descriptor, hasNewType);
             }
         }
+#endif
 
         SetFlags(IsPrototypeFlag);
 
+#if ENABLE_FIXED_FIELDS
 #ifdef ENABLE_DEBUG_CONFIG_OPTIONS
         TraceFixedFieldsAfterSetIsProto(instance, this, this, oldType, oldSingletonInstance);
 #endif
-
-    }
-
-    template <typename T>
-    bool DictionaryTypeHandlerBase<T>::HasSingletonInstance() const
-    {
-        return this->singletonInstance != nullptr;
-    }
-
-    template <typename T>
-    bool DictionaryTypeHandlerBase<T>::TryUseFixedProperty(PropertyRecord const * propertyRecord, Var * pProperty, FixedPropertyKind propertyType, ScriptContext * requestContext)
-    {
-        bool result = TryGetFixedProperty<false, true>(propertyRecord, pProperty, propertyType, requestContext);
-        TraceUseFixedProperty(propertyRecord, pProperty, result, _u("DictionaryTypeHandler"), requestContext);
-        return result;
-    }
-
-    template <typename T>
-    bool DictionaryTypeHandlerBase<T>::TryUseFixedAccessor(PropertyRecord const * propertyRecord, Var * pAccessor, FixedPropertyKind propertyType, bool getter, ScriptContext * requestContext)
-    {
-        bool result = TryGetFixedAccessor<false, true>(propertyRecord, pAccessor, propertyType, getter, requestContext);
-        TraceUseFixedProperty(propertyRecord, pAccessor, result, _u("DictionaryTypeHandler"), requestContext);
-        return result;
+#endif
     }
 
 #if DBG
@@ -2414,7 +2440,7 @@ namespace Js
             }
             else
             {
-                return descriptor.IsInitialized && !descriptor.IsFixed;
+                return !descriptor.IsOrMayBecomeFixed();
             }
         }
         else
@@ -2424,6 +2450,65 @@ namespace Js
         }
     }
 
+    template <typename T>
+    bool DictionaryTypeHandlerBase<T>::IsLetConstGlobal(DynamicObject* instance, PropertyId propertyId)
+    {
+        DictionaryPropertyDescriptor<T>* descriptor;
+        PropertyRecord const* propertyRecord = instance->GetScriptContext()->GetPropertyName(propertyId);
+        if (propertyMap->TryGetReference(propertyRecord, &descriptor) && (descriptor->Attributes & PropertyLetConstGlobal))
+        {
+            return true;
+        }
+        return false;
+    }
+#endif
+
+    template <typename T>
+    bool DictionaryTypeHandlerBase<T>::NextLetConstGlobal(int& index, RootObjectBase* instance, const PropertyRecord** propertyRecord, Var* value, bool* isConst)
+    {
+        for (; index < propertyMap->Count(); index++)
+        {
+            DictionaryPropertyDescriptor<T> descriptor = propertyMap->GetValueAt(index);
+
+            if (descriptor.Attributes & PropertyLetConstGlobal)
+            {
+                *propertyRecord = propertyMap->GetKeyAt(index);
+                *value = instance->GetSlot(descriptor.template GetDataPropertyIndex<true>());
+                *isConst = (descriptor.Attributes & PropertyConst) != 0;
+
+                index += 1;
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+#if ENABLE_FIXED_FIELDS
+    template <typename T>
+    bool DictionaryTypeHandlerBase<T>::HasSingletonInstance() const
+    {
+        return this->singletonInstance != nullptr;
+    }
+
+    template <typename T>
+    bool DictionaryTypeHandlerBase<T>::TryUseFixedProperty(PropertyRecord const * propertyRecord, Var * pProperty, FixedPropertyKind propertyType, ScriptContext * requestContext)
+    {
+        bool result = TryGetFixedProperty<false, true>(propertyRecord, pProperty, propertyType, requestContext);
+        TraceUseFixedProperty(propertyRecord, pProperty, result, _u("DictionaryTypeHandler"), requestContext);
+        return result;
+    }
+
+    template <typename T>
+    bool DictionaryTypeHandlerBase<T>::TryUseFixedAccessor(PropertyRecord const * propertyRecord, Var * pAccessor, FixedPropertyKind propertyType, bool getter, ScriptContext * requestContext)
+    {
+        bool result = TryGetFixedAccessor<false, true>(propertyRecord, pAccessor, propertyType, getter, requestContext);
+        TraceUseFixedProperty(propertyRecord, pAccessor, result, _u("DictionaryTypeHandler"), requestContext);
+        return result;
+    }
+
+#if DBG
     template <typename T>
     bool DictionaryTypeHandlerBase<T>::CheckFixedProperty(PropertyRecord const * propertyRecord, Var * pProperty, ScriptContext * requestContext)
     {
@@ -2559,49 +2644,11 @@ namespace Js
             {
                 // Invalidate any JIT-ed code that hard coded this method. No need to invalidate
                 // any store field inline caches, because they have never been populated.
-#if ENABLE_NATIVE_CODEGEN
                 PropertyId propertyId = TMapKey_GetPropertyId(instance->GetScriptContext(), propertyKey);
                 instance->GetScriptContext()->GetThreadContext()->InvalidatePropertyGuards(propertyId);
-#endif
                 descriptor->UsedAsFixed = false;
             }
         }
-    }
-
-#if DBG
-    template <typename T>
-    bool DictionaryTypeHandlerBase<T>::IsLetConstGlobal(DynamicObject* instance, PropertyId propertyId)
-    {
-        DictionaryPropertyDescriptor<T>* descriptor;
-        PropertyRecord const* propertyRecord = instance->GetScriptContext()->GetPropertyName(propertyId);
-        if (propertyMap->TryGetReference(propertyRecord, &descriptor) && (descriptor->Attributes & PropertyLetConstGlobal))
-        {
-            return true;
-        }
-        return false;
-    }
-#endif
-
-    template <typename T>
-    bool DictionaryTypeHandlerBase<T>::NextLetConstGlobal(int& index, RootObjectBase* instance, const PropertyRecord** propertyRecord, Var* value, bool* isConst)
-    {
-        for (; index < propertyMap->Count(); index++)
-        {
-            DictionaryPropertyDescriptor<T> descriptor = propertyMap->GetValueAt(index);
-
-            if (descriptor.Attributes & PropertyLetConstGlobal)
-            {
-                *propertyRecord = propertyMap->GetKeyAt(index);
-                *value = instance->GetSlot(descriptor.template GetDataPropertyIndex<true>());
-                *isConst = (descriptor.Attributes & PropertyConst) != 0;
-
-                index += 1;
-
-                return true;
-            }
-        }
-
-        return false;
     }
 
 #ifdef ENABLE_DEBUG_CONFIG_OPTIONS
@@ -2729,6 +2776,7 @@ namespace Js
         }
     }
 #endif
+#endif // ENABLE_FIXED_FIELDS
 
 #if ENABLE_TTD
     template <typename T>
@@ -2744,7 +2792,11 @@ namespace Js
             //
 
             Js::PropertyId pid = iter.CurrentKey()->GetPropertyId();
+#if ENABLE_FIXED_FIELDS
             if((!DynamicTypeHandler::ShouldMarkPropertyId_TTD(pid)) | (!descriptor.IsInitialized) | (descriptor.Attributes & PropertyDeleted))
+#else
+            if ((!DynamicTypeHandler::ShouldMarkPropertyId_TTD(pid)) | (descriptor.Attributes & PropertyDeleted))
+#endif
             {
                 continue;
             }
@@ -2789,12 +2841,18 @@ namespace Js
             {
                 maxSlot = max(maxSlot, dIndex);
 
+#if ENABLE_FIXED_FIELDS
                 TTD::NSSnapType::SnapEntryDataKindTag tag = descriptor.IsInitialized ? TTD::NSSnapType::SnapEntryDataKindTag::Data : TTD::NSSnapType::SnapEntryDataKindTag::Uninitialized;
+#else
+                TTD::NSSnapType::SnapEntryDataKindTag tag = TTD::NSSnapType::SnapEntryDataKindTag::Data;
+#endif
                 TTD::NSSnapType::ExtractSnapPropertyEntryInfo(entryInfo + dIndex, pid, descriptor.Attributes, tag);
             }
             else
             {
+#if ENABLE_FIXED_FIELDS
                 TTDAssert(descriptor.IsInitialized, "How can this not be initialized?");
+#endif
 
                 T gIndex = descriptor.GetGetterPropertyIndex();
                 if(gIndex != NoSlots)

--- a/lib/Runtime/Types/DynamicObject.cpp
+++ b/lib/Runtime/Types/DynamicObject.cpp
@@ -649,6 +649,7 @@ namespace Js
         DynamicType * oldType = this->GetDynamicType();
         DynamicTypeHandler* oldTypeHandler = oldType->GetTypeHandler();
 
+#if ENABLE_FIXED_FIELDS
         // Consider: Because we've disabled fixed properties on DOM objects, we don't need to rely on a type change here to
         // invalidate fixed properties.  Under some circumstances (with F12 tools enabled) an object which
         // is already in the new context can be reset and newType == oldType. If we re-enable fixed properties on DOM objects
@@ -656,6 +657,7 @@ namespace Js
         // Assert(newType != oldType);
         // We only expect DOM objects to ever be reset and we explicitly disable fixed properties on DOM objects.
         Assert(!oldTypeHandler->HasAnyFixedProperties());
+#endif
 
         this->type = newType;
         if (!IsAnyArray(this))

--- a/lib/Runtime/Types/DynamicObject.h
+++ b/lib/Runtime/Types/DynamicObject.h
@@ -237,7 +237,9 @@ namespace Js
         virtual BOOL SetPropertyWithAttributes(PropertyId propertyId, Var value, PropertyAttributes attributes, PropertyValueInfo* info, PropertyOperationFlags flags = PropertyOperation_None, SideEffects possibleSideEffects = SideEffects_Any) override;
         virtual BOOL DeleteProperty(PropertyId propertyId, PropertyOperationFlags flags) override;
         virtual BOOL DeleteProperty(JavascriptString *propertyNameString, PropertyOperationFlags flags) override;
+#if ENABLE_FIXED_FIELDS
         virtual BOOL IsFixedProperty(PropertyId propertyId) override;
+#endif
         virtual PropertyQueryFlags HasItemQuery(uint32 index) override;
         virtual BOOL HasOwnItem(uint32 index) override;
         virtual PropertyQueryFlags GetItemQuery(Var originalInstance, uint32 index, Var* value, ScriptContext * requestContext) override;

--- a/lib/Runtime/Types/DynamicType.cpp
+++ b/lib/Runtime/Types/DynamicType.cpp
@@ -327,11 +327,13 @@ namespace Js
         return GetTypeHandler()->DeleteProperty(this, propertyNameString, flags);
     }
 
+#if ENABLE_FIXED_FIELDS
     BOOL DynamicObject::IsFixedProperty(PropertyId propertyId)
     {
         Assert(!Js::IsInternalPropertyId(propertyId));
         return GetTypeHandler()->IsFixedProperty(this, propertyId);
     }
+#endif
 
     PropertyQueryFlags DynamicObject::HasItemQuery(uint32 index)
     {

--- a/lib/Runtime/Types/MissingPropertyTypeHandler.cpp
+++ b/lib/Runtime/Types/MissingPropertyTypeHandler.cpp
@@ -36,6 +36,7 @@ namespace Js
         return 0;
     }
 
+#if ENABLE_NATIVE_CODEGEN
     bool MissingPropertyTypeHandler::GetPropertyEquivalenceInfo(PropertyRecord const* propertyRecord, PropertyEquivalenceInfo& info)
     {
         info.slotIndex = Constants::NoSlot;
@@ -53,6 +54,7 @@ namespace Js
     {
         return false;
     }
+#endif
 
     BOOL MissingPropertyTypeHandler::HasProperty(DynamicObject* instance, PropertyId propertyId, __out_opt bool *noRedecl)
     {

--- a/lib/Runtime/Types/MissingPropertyTypeHandler.h
+++ b/lib/Runtime/Types/MissingPropertyTypeHandler.h
@@ -26,9 +26,11 @@ namespace Js
         virtual BOOL FindNextProperty(ScriptContext* scriptContext, PropertyIndex& index, JavascriptString** propertyString,
             PropertyId* propertyId, PropertyAttributes* attributes, Type* type, DynamicType *typeToEnumerate, EnumeratorFlags flags, DynamicObject* instance, PropertyValueInfo* info) override;
         virtual PropertyIndex GetPropertyIndex(PropertyRecord const* propertyRecord) override;
+#if ENABLE_NATIVE_CODEGEN
         virtual bool GetPropertyEquivalenceInfo(PropertyRecord const* propertyRecord, PropertyEquivalenceInfo& info) override;
         virtual bool IsObjTypeSpecEquivalent(const Type* type, const TypeEquivalenceRecord& record, uint& failedPropertyIndex) override;
         virtual bool IsObjTypeSpecEquivalent(const Type* type, const EquivalentPropertyEntry* entry) override;
+#endif
         virtual BOOL HasProperty(DynamicObject* instance, PropertyId propertyId, __out_opt bool *noRedecl = nullptr) override;
         virtual BOOL HasProperty(DynamicObject* instance, JavascriptString* propertyNameString) override;
         virtual BOOL GetProperty(DynamicObject* instance, Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;

--- a/lib/Runtime/Types/NullTypeHandler.cpp
+++ b/lib/Runtime/Types/NullTypeHandler.cpp
@@ -41,6 +41,7 @@ namespace Js
         return Constants::NoSlot;
     }
 
+#if ENABLE_NATIVE_CODEGEN
     bool NullTypeHandlerBase::GetPropertyEquivalenceInfo(PropertyRecord const* propertyRecord, PropertyEquivalenceInfo& info)
     {
         info.slotIndex = Constants::NoSlot;
@@ -69,6 +70,7 @@ namespace Js
     {
         return entry->slotIndex == Constants::NoSlot && !entry->mustBeWritable;
     }
+#endif
 
     BOOL NullTypeHandlerBase::HasProperty(DynamicObject* instance, PropertyId propertyId, __out_opt bool *noRedecl)
     {

--- a/lib/Runtime/Types/NullTypeHandler.h
+++ b/lib/Runtime/Types/NullTypeHandler.h
@@ -30,9 +30,11 @@ namespace Js
         virtual BOOL FindNextProperty(ScriptContext* scriptContext, PropertyIndex& index, JavascriptString** propertyString,
             PropertyId* propertyId, PropertyAttributes* attributes, Type* type, DynamicType *typeToEnumerate, EnumeratorFlags flags, DynamicObject* instance, PropertyValueInfo* info) override;
         virtual PropertyIndex GetPropertyIndex(PropertyRecord const* propertyRecord) override;
+#if ENABLE_NATIVE_CODEGEN
         virtual bool GetPropertyEquivalenceInfo(PropertyRecord const* propertyRecord, PropertyEquivalenceInfo& info) override;
         virtual bool IsObjTypeSpecEquivalent(const Type* type, const TypeEquivalenceRecord& record, uint& failedPropertyIndex) override;
         virtual bool IsObjTypeSpecEquivalent(const Type* type, const EquivalentPropertyEntry* entry) override;
+#endif
         virtual BOOL HasProperty(DynamicObject* instance, PropertyId propertyId, __out_opt bool *noRedecl = nullptr) override;
         virtual BOOL HasProperty(DynamicObject* instance, JavascriptString* propertyNameString) override;
         virtual BOOL GetProperty(DynamicObject* instance, Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;

--- a/lib/Runtime/Types/RecyclableObject.cpp
+++ b/lib/Runtime/Types/RecyclableObject.cpp
@@ -410,10 +410,12 @@ namespace Js
         return true;
     }
 
+#if ENABLE_FIXED_FIELDS
     BOOL RecyclableObject::IsFixedProperty(PropertyId propertyId)
     {
         return false;
     }
+#endif
 
     PropertyQueryFlags RecyclableObject::HasItemQuery(uint32 index)
     {

--- a/lib/Runtime/Types/RecyclableObject.h
+++ b/lib/Runtime/Types/RecyclableObject.h
@@ -290,7 +290,9 @@ namespace Js {
         virtual BOOL InitFuncScoped(PropertyId propertyId, Var value);
         virtual BOOL DeleteProperty(PropertyId propertyId, PropertyOperationFlags flags);
         virtual BOOL DeleteProperty(JavascriptString *propertyNameString, PropertyOperationFlags flags);
+#if ENABLE_FIXED_FIELDS
         virtual BOOL IsFixedProperty(PropertyId propertyId);
+#endif
         virtual PropertyQueryFlags HasItemQuery(uint32 index);
         virtual BOOL HasOwnItem(uint32 index);
         virtual PropertyQueryFlags GetItemQuery(Var originalInstance, uint32 index, Var* value, ScriptContext * requestContext);

--- a/lib/Runtime/Types/SimpleDictionaryPropertyDescriptor.h
+++ b/lib/Runtime/Types/SimpleDictionaryPropertyDescriptor.h
@@ -11,23 +11,33 @@ namespace Js
     {
     public:
         SimpleDictionaryPropertyDescriptor() :
-            propertyIndex(NoSlots), Attributes(PropertyDynamicTypeDefaults),
-            preventFalseReference(true), isInitialized(false), isFixed(false), usedAsFixed(false) { }
+#if ENABLE_FIXED_FIELDS
+            preventFalseReference(true), isInitialized(false), isFixed(false), usedAsFixed(false),
+#endif
+            propertyIndex(NoSlots), Attributes(PropertyDynamicTypeDefaults) {}
 
         SimpleDictionaryPropertyDescriptor(TPropertyIndex inPropertyIndex) :
-            propertyIndex(inPropertyIndex), Attributes(PropertyDynamicTypeDefaults),
-            preventFalseReference(true), isInitialized(false), isFixed(false), usedAsFixed(false) { }
+#if ENABLE_FIXED_FIELDS
+            preventFalseReference(true), isInitialized(false), isFixed(false), usedAsFixed(false),
+#endif
+            propertyIndex(inPropertyIndex), Attributes(PropertyDynamicTypeDefaults) {}
+            
 
         SimpleDictionaryPropertyDescriptor(TPropertyIndex inPropertyIndex, PropertyAttributes attributes) :
-            propertyIndex(inPropertyIndex), Attributes(attributes),
-            preventFalseReference(true), isInitialized(false), isFixed(false), usedAsFixed(false) { }
+#if ENABLE_FIXED_FIELDS
+            preventFalseReference(true), isInitialized(false), isFixed(false), usedAsFixed(false),
+#endif
+            propertyIndex(inPropertyIndex), Attributes(attributes) {}
 
+
+#if ENABLE_FIXED_FIELDS
         // SimpleDictionaryPropertyDescriptor is allocated by a dictionary along with the PropertyRecord
         // so it can not allocate as leaf, tag the lower bit to prevent false reference
         bool preventFalseReference:1;
         bool isInitialized: 1;
         bool isFixed:1;
         bool usedAsFixed:1;
+#endif
 
         PropertyAttributes Attributes;
         TPropertyIndex propertyIndex;
@@ -37,6 +47,14 @@ namespace Js
             return (this->Attributes & PropertyLetConstGlobal) == 0;
         }
 
+        bool IsOrMayBecomeFixed() const
+        {
+#if ENABLE_FIXED_FIELDS
+            return !isInitialized || isFixed;
+#else
+            return false;
+#endif
+        }
      private:
         static const TPropertyIndex NoSlots = PropertyIndexRanges<TPropertyIndex>::NoSlots;
     };

--- a/lib/Runtime/Types/SimpleDictionaryTypeHandler.h
+++ b/lib/Runtime/Types/SimpleDictionaryTypeHandler.h
@@ -108,16 +108,17 @@ namespace Js
 
         virtual BOOL IsLockable() const override { return true; }
         virtual BOOL IsSharable() const override { return true; }
-        virtual void DoShareTypeHandler(ScriptContext* scriptContext) override;
 
         virtual int GetPropertyCount() override;
 
         virtual PropertyId GetPropertyId(ScriptContext* scriptContext, PropertyIndex index) override;
         virtual PropertyId GetPropertyId(ScriptContext* scriptContext, BigPropertyIndex index) override;
         virtual PropertyIndex GetPropertyIndex(const PropertyRecord* propertyRecord) override;
+#if ENABLE_NATIVE_CODEGEN
         virtual bool GetPropertyEquivalenceInfo(PropertyRecord const* propertyRecord, PropertyEquivalenceInfo& info) override;
         virtual bool IsObjTypeSpecEquivalent(const Type* type, const TypeEquivalenceRecord& record, uint& failedPropertyIndex) override;
         virtual bool IsObjTypeSpecEquivalent(const Type* type, const EquivalentPropertyEntry* entry) override;
+#endif
 
         virtual BOOL FindNextProperty(ScriptContext* scriptContext, PropertyIndex& index, JavascriptString** propertyString,
             PropertyId* propertyId, PropertyAttributes* attributes, Type* type, DynamicType *typeToEnumerate, EnumeratorFlags flags, DynamicObject* instance, PropertyValueInfo* info) override;
@@ -149,7 +150,6 @@ namespace Js
 #endif
         virtual bool NextLetConstGlobal(int& index, RootObjectBase* instance, const PropertyRecord** propertyRecord, Var* value, bool* isConst) override;
 
-        virtual BOOL IsFixedProperty(const DynamicObject* instance, PropertyId propertyId) override;
         virtual BOOL IsEnumerable(DynamicObject* instance, PropertyId propertyId) override;
         virtual BOOL IsWritable(DynamicObject* instance, PropertyId propertyId) override;
         virtual BOOL IsConfigurable(DynamicObject* instance, PropertyId propertyId) override;
@@ -174,14 +174,17 @@ namespace Js
 
 #if DBG
         virtual bool SupportsPrototypeInstances() const { return true; }
+        virtual bool CanStorePropertyValueDirectly(const DynamicObject* instance, PropertyId propertyId, bool allowLetConst) override;
 #endif
 
+#if ENABLE_FIXED_FIELDS
+        virtual void DoShareTypeHandler(ScriptContext* scriptContext) override;
+        virtual BOOL IsFixedProperty(const DynamicObject* instance, PropertyId propertyId) override;
         virtual bool HasSingletonInstance() const override sealed;
         virtual bool TryUseFixedProperty(PropertyRecord const * propertyRecord, Var * pProperty, FixedPropertyKind propertyType, ScriptContext * requestContext) override;
         virtual bool TryUseFixedAccessor(PropertyRecord const * propertyRecord, Var * pAccessor, FixedPropertyKind propertyType, bool getter, ScriptContext * requestContext) override;
 
 #if DBG
-        virtual bool CanStorePropertyValueDirectly(const DynamicObject* instance, PropertyId propertyId, bool allowLetConst) override;
         virtual bool CheckFixedProperty(PropertyRecord const * propertyRecord, Var * pProperty, ScriptContext * requestContext) override;
         virtual bool HasAnyFixedProperties() const override;
 #endif
@@ -201,14 +204,13 @@ namespace Js
             DynamicType* oldType, RecyclerWeakReference<DynamicObject>* oldSingletonInstanceBefore);
 #endif
 
-    private:
-        typedef SimpleDictionaryTypeHandlerBase<BigPropertyIndex, TMapKey, false> BigSimpleDictionaryTypeHandler;
+    private:        
 
-        template <bool doLock>
-        bool IsObjTypeSpecEquivalentImpl(const Type* type, const EquivalentPropertyEntry *entry);
         template <bool allowNonExistent, bool markAsUsed>
         bool TryGetFixedProperty(PropertyRecord const * propertyRecord, Var * pProperty, FixedPropertyKind propertyType, ScriptContext * requestContext);
 
+        template <typename TPropertyKey>
+        void InvalidateFixedField(const TPropertyKey propertyKey, SimpleDictionaryPropertyDescriptor<TPropertyIndex>* descriptor, ScriptContext* scriptContext);
     public:
         virtual RecyclerWeakReference<DynamicObject>* GetSingletonInstance() const sealed { Assert(HasSingletonInstanceOnlyIfNeeded()); return this->singletonInstance; }
 
@@ -231,12 +233,15 @@ namespace Js
             return AreSingletonInstancesNeeded() || this->singletonInstance == nullptr;
         }
 #endif
-
+#endif
     private:
-        void SetIsPrototype(DynamicObject* instance, bool hasNewType);
-        template <typename TPropertyKey>
-        void InvalidateFixedField(const TPropertyKey propertyKey, SimpleDictionaryPropertyDescriptor<TPropertyIndex>* descriptor, ScriptContext* scriptContext);
+        typedef SimpleDictionaryTypeHandlerBase<BigPropertyIndex, TMapKey, false> BigSimpleDictionaryTypeHandler;
 
+#if ENABLE_NATIVE_CODEGEN
+        template <bool doLock>
+        bool IsObjTypeSpecEquivalentImpl(const Type* type, const EquivalentPropertyEntry *entry);
+#endif
+        void SetIsPrototype(DynamicObject* instance, bool hasNewType);
         bool SupportsSwitchingToUnordered(const ScriptContext *const scriptContext) const;
         SimpleDictionaryUnorderedTypeHandler<TPropertyIndex, TMapKey, IsNotExtensibleSupported> *AsUnordered();
         void SetNumDeletedProperties(const byte n);

--- a/lib/Runtime/Types/SimpleTypeHandler.cpp
+++ b/lib/Runtime/Types/SimpleTypeHandler.cpp
@@ -91,11 +91,12 @@ namespace Js
         ScriptContext* scriptContext = instance->GetScriptContext();
         Recycler* recycler = scriptContext->GetRecycler();
 
-#if DBG
+#if ENABLE_FIXED_FIELDS && DBG
         DynamicType* oldType = instance->GetDynamicType();
 #endif
 
         T* newTypeHandler = RecyclerNew(recycler, T, recycler, SimpleTypeHandler<size>::GetSlotCapacity(), GetInlineSlotCapacity(), GetOffsetOfInlineSlots());
+#if ENABLE_FIXED_FIELDS
         Assert(HasSingletonInstanceOnlyIfNeeded());
 
         bool const hasSingletonInstance = newTypeHandler->SetSingletonInstanceIfNeeded(instance);
@@ -103,13 +104,18 @@ namespace Js
         // guarantees that any existing fast path field stores (which could quietly overwrite a fixed field
         // on this instance) will be invalidated.  It is safe to mark all fields as fixed.
         bool const allowFixedFields = hasSingletonInstance && instance->HasLockedType();
+#endif
 
         for (int i = 0; i < propertyCount; i++)
         {
             Var value = instance->GetSlot(i);
             Assert(value != nullptr || IsInternalPropertyId(descriptors[i].Id->GetPropertyId()));
+#if ENABLE_FIXED_FIELDS
             bool markAsFixed = allowFixedFields && !IsInternalPropertyId(descriptors[i].Id->GetPropertyId()) &&
                 (JavascriptFunction::Is(value) ? ShouldFixMethodProperties() : false);
+#else
+            bool markAsFixed = false;
+#endif
             newTypeHandler->Add(PointerValue(descriptors[i].Id), descriptors[i].Attributes, true, markAsFixed, false, scriptContext);
         }
 
@@ -121,7 +127,7 @@ namespace Js
         newTypeHandler->SetPropertyTypes(PropertyTypesWritableDataOnly | PropertyTypesWritableDataOnlyDetection, this->GetPropertyTypes());
         newTypeHandler->SetInstanceTypeHandler(instance);
 
-#if DBG
+#if ENABLE_FIXED_FIELDS && DBG
         // If we marked fields as fixed we had better forced a type transition.
         Assert(!allowFixedFields || instance->GetDynamicType() != oldType);
 #endif
@@ -252,6 +258,7 @@ namespace Js
         return Constants::NoSlot;
     }
 
+#if ENABLE_NATIVE_CODEGEN
     template<size_t size>
     bool SimpleTypeHandler<size>::GetPropertyEquivalenceInfo(PropertyRecord const* propertyRecord, PropertyEquivalenceInfo& info)
     {
@@ -326,7 +333,7 @@ namespace Js
 
         return true;
     }
-
+#endif
 
     template<size_t size>
     BOOL SimpleTypeHandler<size>::HasProperty(DynamicObject* instance, PropertyId propertyId, __out_opt bool *noRedecl)

--- a/lib/Runtime/Types/SimpleTypeHandler.h
+++ b/lib/Runtime/Types/SimpleTypeHandler.h
@@ -36,9 +36,11 @@ namespace Js
         virtual BOOL FindNextProperty(ScriptContext* scriptContext, PropertyIndex& index, JavascriptString** propertyString,
             PropertyId* propertyId, PropertyAttributes* attributes, Type* type, DynamicType *typeToEnumerate, EnumeratorFlags flags, DynamicObject* instance, PropertyValueInfo* info) override;
         virtual PropertyIndex GetPropertyIndex(PropertyRecord const* propertyRecord) override;
+#if ENABLE_NATIVE_CODEGEN
         virtual bool GetPropertyEquivalenceInfo(PropertyRecord const* propertyRecord, PropertyEquivalenceInfo& info) override;
         virtual bool IsObjTypeSpecEquivalent(const Type* type, const TypeEquivalenceRecord& record, uint& failedPropertyIndex) override;
         virtual bool IsObjTypeSpecEquivalent(const Type* type, const EquivalentPropertyEntry* entry) override;
+#endif
         virtual BOOL HasProperty(DynamicObject* instance, PropertyId propertyId, __out_opt bool *noRedecl = nullptr) override;
         virtual BOOL HasProperty(DynamicObject* instance, JavascriptString* propertyNameString) override;
         virtual BOOL GetProperty(DynamicObject* instance, Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;
@@ -70,14 +72,13 @@ namespace Js
 #if DBG
         virtual bool SupportsPrototypeInstances() const { return !ChangeTypeOnProto() && !(GetIsOrMayBecomeShared() && IsolatePrototypes()); }
         virtual bool CanStorePropertyValueDirectly(const DynamicObject* instance, PropertyId propertyId, bool allowLetConst) override;
-#endif
-
-#if DBG
+#if ENABLE_FIXED_FIELDS        
         bool HasSingletonInstanceOnlyIfNeeded() const
         {
             // If we add support for fixed fields to this type handler we will have to update this implementation.
             return true;
         }
+#endif
 #endif
 
     private:

--- a/lib/Runtime/Types/SpreadArgument.h
+++ b/lib/Runtime/Types/SpreadArgument.h
@@ -42,7 +42,9 @@ namespace Js
         virtual BOOL SetInternalProperty(PropertyId internalPropertyId, Var value, PropertyOperationFlags flags, PropertyValueInfo* info) override { AssertAndFailFast(); return FALSE; };
         virtual BOOL InitProperty(PropertyId propertyId, Var value, PropertyOperationFlags flags = PropertyOperation_None, PropertyValueInfo* info = NULL) override { AssertAndFailFast(); return FALSE; };
         virtual BOOL SetPropertyWithAttributes(PropertyId propertyId, Var value, PropertyAttributes attributes, PropertyValueInfo* info, PropertyOperationFlags flags = PropertyOperation_None, SideEffects possibleSideEffects = SideEffects_Any) override { AssertAndFailFast(); return FALSE; };
+#if ENABLE_FIXED_FIELDS
         virtual BOOL IsFixedProperty(PropertyId propertyId) override { AssertAndFailFast(); return FALSE; };
+#endif
         virtual PropertyQueryFlags HasItemQuery(uint32 index) override { AssertAndFailFast(); return PropertyQueryFlags::Property_NotFound; };
         virtual BOOL HasOwnItem(uint32 index) override { AssertAndFailFast(); return FALSE; };
         virtual PropertyQueryFlags GetItemQuery(Var originalInstance, uint32 index, Var* value, ScriptContext * requestContext) override { AssertAndFailFast(); return PropertyQueryFlags::Property_NotFound; };

--- a/lib/Runtime/Types/TypeHandler.cpp
+++ b/lib/Runtime/Types/TypeHandler.cpp
@@ -312,6 +312,7 @@ namespace Js
         instance->GetDynamicType()->SetPrototype(newPrototype);
     }
 
+#if ENABLE_FIXED_FIELDS
     bool DynamicTypeHandler::TryUseFixedProperty(PropertyRecord const* propertyRecord, Var * pProperty, FixedPropertyKind propertyType, ScriptContext * requestContext)
     {
         if (PHASE_VERBOSE_TRACE1(Js::FixedMethodsPhase) || PHASE_VERBOSE_TESTTRACE1(Js::FixedMethodsPhase) ||
@@ -452,6 +453,7 @@ namespace Js
             Output::Flush();
         }
     }
+#endif // ENABLE_FIXED_FIELDS
 
     BOOL DynamicTypeHandler::GetInternalProperty(DynamicObject* instance, Var originalInstance, PropertyId propertyId, Var* value)
     {

--- a/lib/Runtime/Types/TypePath.cpp
+++ b/lib/Runtime/Types/TypePath.cpp
@@ -154,6 +154,7 @@ namespace Js {
         return clonedPath;
     }
 
+#if ENABLE_FIXED_FIELDS
 #if DBG
     bool TypePath::HasSingletonInstanceOnlyIfNeeded()
     {
@@ -185,6 +186,7 @@ namespace Js {
 #endif
 
     }
+#endif
 
     int TypePath::Data::Add(const PropertyRecord* propId, Field(const PropertyRecord *)* assignments)
     {
@@ -234,12 +236,12 @@ namespace Js {
         return propertyIndex;
     }
 
+#ifdef SUPPORT_FIXED_FIELDS_ON_PATH_TYPES
     void TypePath::AddBlankFieldAt(PropertyIndex index, int typePathLength)
     {
         Assert(index >= this->GetMaxInitializedLength());
         this->SetMaxInitializedLength(index + 1);
 
-#ifdef SUPPORT_FIXED_FIELDS_ON_PATH_TYPES
         if (PHASE_VERBOSE_TRACE1(FixMethodPropsPhase))
         {
             Output::Print(_u("FixedFields: TypePath::AddBlankFieldAt: singleton = 0x%p(0x%p)\n"),
@@ -256,7 +258,6 @@ namespace Js {
 
             Output::Print(_u("\n"));
         }
-#endif
     }
 
     void TypePath::AddSingletonInstanceFieldAt(DynamicObject* instance, PropertyIndex index, bool isFixed, int typePathLength)
@@ -281,7 +282,6 @@ namespace Js {
             this->GetData()->fixedFields.Set(index);
         }
 
-#ifdef SUPPORT_FIXED_FIELDS_ON_PATH_TYPES
         if (PHASE_VERBOSE_TRACE1(FixMethodPropsPhase))
         {
             Output::Print(_u("FixedFields: TypePath::AddSingletonInstanceFieldAt: singleton = 0x%p(0x%p)\n"),
@@ -298,7 +298,6 @@ namespace Js {
 
             Output::Print(_u("\n"));
         }
-#endif
     }
 
     void TypePath::AddSingletonInstanceFieldAt(PropertyIndex index, int typePathLength)
@@ -310,7 +309,6 @@ namespace Js {
 
         this->SetMaxInitializedLength(index + 1);
 
-#ifdef SUPPORT_FIXED_FIELDS_ON_PATH_TYPES
         if (PHASE_VERBOSE_TRACE1(FixMethodPropsPhase))
         {
             Output::Print(_u("FixedFields: TypePath::AddSingletonInstanceFieldAt: singleton = 0x%p(0x%p)\n"),
@@ -327,8 +325,8 @@ namespace Js {
 
             Output::Print(_u("\n"));
         }
-#endif
     }
+#endif
 
 }
 

--- a/lib/Runtime/Types/TypePath.h
+++ b/lib/Runtime/Types/TypePath.h
@@ -161,6 +161,7 @@ public:
     private:
         int AddInternal(const PropertyRecord* propId);
 
+#if ENABLE_FIXED_FIELDS
 #ifdef SUPPORT_FIXED_FIELDS_ON_PATH_TYPES
         uint8 GetMaxInitializedLength() { return this->GetData()->maxInitializedLength; }
         void SetMaxInitializedLength(int newMaxInitializedLength)
@@ -264,7 +265,7 @@ public:
 #endif
 
 #else
-        int GetMaxInitializedLength() { Assert(false); return this->pathLength; }
+        int GetMaxInitializedLength() { Assert(false); return this->GetPathLength(); }
 
         Var GetSingletonFixedFieldAt(PropertyIndex index, int typePathLength, ScriptContext * requestContext);
 
@@ -272,8 +273,8 @@ public:
         RecyclerWeakReference<DynamicObject>* GetSingletonInstance() const { Assert(false); return nullptr; }
         void SetSingletonInstance(RecyclerWeakReference<DynamicObject>* instance, int typePathLength) { Assert(false); }
         void ClearSingletonInstance() { Assert(false); }
-        void ClearSingletonInstanceIfSame(RecyclerWeakReference<DynamicObject>* instance) { Assert(false); }
-        void ClearSingletonInstanceIfDifferent(RecyclerWeakReference<DynamicObject>* instance) { Assert(false); }
+        void ClearSingletonInstanceIfSame(DynamicObject* instance) { Assert(false); }
+        void ClearSingletonInstanceIfDifferent(DynamicObject* instance) { Assert(false); }
 
         bool GetIsFixedFieldAt(PropertyIndex index, int typePathLength) { Assert(false); return false; }
         bool GetIsUsedFixedFieldAt(PropertyIndex index, int typePathLength) { Assert(false); return false; }
@@ -287,7 +288,8 @@ public:
         bool HasSingletonInstanceOnlyIfNeeded();
 #endif
 #endif
+#endif
     };
 }
 
-CompileAssert((sizeof(Js::TypePath) % HeapConstants::ObjectGranularity) / sizeof(void *) == TYPE_PATH_ALLOC_GRANULARITY_GAP);
+CompileAssert((sizeof(Js::TypePath) % HeapConstants::ObjectGranularity) == (HeapConstants::ObjectGranularity - TYPE_PATH_ALLOC_GRANULARITY_GAP * sizeof(void *)) % HeapConstants::ObjectGranularity);

--- a/lib/Runtime/Types/TypePropertyCache.cpp
+++ b/lib/Runtime/Types/TypePropertyCache.cpp
@@ -349,7 +349,9 @@ namespace Js
         }
     #endif
 
+#if ENABLE_FIXED_FIELDS
         Assert(!object->IsFixedProperty(propertyId));
+#endif
         Assert(
             (
                 DynamicObject

--- a/lib/Runtime/Types/WithScopeObject.h
+++ b/lib/Runtime/Types/WithScopeObject.h
@@ -37,7 +37,9 @@ namespace Js
             virtual BOOL SetInternalProperty(PropertyId internalPropertyId, Var value, PropertyOperationFlags flags, PropertyValueInfo* info) override { AssertAndFailFast(); return FALSE; };
             virtual BOOL InitProperty(PropertyId propertyId, Var value, PropertyOperationFlags flags = PropertyOperation_None, PropertyValueInfo* info = NULL) override { AssertAndFailFast(); return FALSE; };
             virtual BOOL SetPropertyWithAttributes(PropertyId propertyId, Var value, PropertyAttributes attributes, PropertyValueInfo* info, PropertyOperationFlags flags = PropertyOperation_None, SideEffects possibleSideEffects = SideEffects_Any) override { AssertAndFailFast(); return FALSE; };
+#if ENABLE_FIXED_FIELDS
             virtual BOOL IsFixedProperty(PropertyId propertyId) override { AssertAndFailFast(); return FALSE; };
+#endif
             virtual PropertyQueryFlags HasItemQuery(uint32 index) override { AssertAndFailFast(); return PropertyQueryFlags::Property_NotFound; };
             virtual BOOL HasOwnItem(uint32 index) override { AssertAndFailFast(); return FALSE; };
             virtual PropertyQueryFlags GetItemQuery(Var originalInstance, uint32 index, Var* value, ScriptContext * requestContext) override { AssertAndFailFast(); return PropertyQueryFlags::Property_NotFound; };


### PR DESCRIPTION
Put equivalent type spec and property guard code under ENABLE_NATIVE_CODEGEN
Also fixed ability to disable SUPPORT_FIXED_FIELDS_ON_PATH_TYPES
Disable fixed field for when JIT is disabled.

Reduced binary size of the lite build by ~41K on x86 and ~65K on x64.
