### PR TITLE
Clean up hasDeferredChild, hasRedeferrableChild, and IsRedeferrable() from FuncInfo. 

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -2473,7 +2473,7 @@ FuncInfo* PreVisitFunction(ParseNode* pnode, ByteCodeGenerator* byteCodeGenerato
 #endif
 
                 //With statements - need scope object to be present.
-                if ((doStackArgsOpt && pnode->sxFnc.funcInfo->GetParamScope()->Count() > 1) && (pnode->sxFnc.funcInfo->HasDeferredChild() || (byteCodeGenerator->GetFlags() & fscrEval) ||
+                if ((doStackArgsOpt && pnode->sxFnc.funcInfo->GetParamScope()->Count() > 1) && ((byteCodeGenerator->GetFlags() & fscrEval) ||
                     pnode->sxFnc.HasWithStmt() || byteCodeGenerator->IsInDebugMode() || PHASE_OFF1(Js::StackArgFormalsOptPhase) || PHASE_OFF1(Js::StackArgOptPhase)))
                 {
                     doStackArgsOpt = false;
@@ -2948,8 +2948,6 @@ FuncInfo* PostVisitFunction(ParseNode* pnode, ByteCodeGenerator* byteCodeGenerat
 
     Js::FunctionBody * parentFunctionBody = parentFunc->byteCodeFunction->GetFunctionBody();
     Assert(parentFunctionBody != nullptr);
-    bool const hasAnyDeferredChild = top->HasDeferredChild() || top->IsDeferred();
-    bool const hasAnyRedeferrableChild = top->HasRedeferrableChild() || top->IsRedeferrable();
     bool setHasNonLocalReference = parentFunctionBody->HasAllNonLocalReferenced();
 
     // If we have any deferred child, we need to instantiate the fake global block scope if it is not empty
@@ -2961,14 +2959,6 @@ FuncInfo* PostVisitFunction(ParseNode* pnode, ByteCodeGenerator* byteCodeGenerat
             if (globalEvalBlockScope->GetHasOwnLocalInClosure())
             {
                 globalEvalBlockScope->SetMustInstantiate(true);
-            }
-            if (hasAnyDeferredChild)
-            {
-                parentFunc->SetHasDeferredChild();
-            }
-            if (hasAnyRedeferrableChild)
-            {
-                parentFunc->SetHasRedeferrableChild();
             }
         }
     }
@@ -2984,18 +2974,6 @@ FuncInfo* PostVisitFunction(ParseNode* pnode, ByteCodeGenerator* byteCodeGenerat
                 parentFunc->GetParamScope()->SetIsObject();
             }
         }
-
-        // Propagate "hasDeferredChild" attribute back to parent.
-        if (hasAnyDeferredChild)
-        {
-            Assert(CONFIG_FLAG(DeferNested));
-            parentFunc->SetHasDeferredChild();
-        }
-        if (hasAnyRedeferrableChild)
-        {
-            parentFunc->SetHasRedeferrableChild();
-        }
-
         // Propagate HasMaybeEscapedNestedFunc
         if (!byteCodeGenerator->CanStackNestedFunc(top, false) ||
             byteCodeGenerator->NeedObjectAsFunctionScope(top, pnode))

--- a/lib/Runtime/ByteCode/FuncInfo.cpp
+++ b/lib/Runtime/ByteCode/FuncInfo.cpp
@@ -60,8 +60,6 @@ FuncInfo::FuncInfo(
     funcExprNameReference(false),
     applyEnclosesArgs(false),
     escapes(false),
-    hasDeferredChild(false),
-    hasRedeferrableChild(false),
     hasLoop(false),
     hasEscapedUseNestedFunc(false),
     needEnvRegister(false),
@@ -120,11 +118,6 @@ bool FuncInfo::IsGlobalFunction() const
 bool FuncInfo::IsDeferred() const
 {
     return root && root->sxFnc.pnodeBody == nullptr;
-}
-
-bool FuncInfo::IsRedeferrable() const
-{
-    return byteCodeFunction && byteCodeFunction->CanBeDeferred();
 }
 
 BOOL FuncInfo::HasSuperReference() const

--- a/lib/Runtime/ByteCode/FuncInfo.h
+++ b/lib/Runtime/ByteCode/FuncInfo.h
@@ -134,8 +134,6 @@ public:
     uint funcExprNameReference : 1;
     uint applyEnclosesArgs : 1;
     uint escapes : 1;
-    uint hasDeferredChild : 1; // switch for DeferNested to persist outer scopes
-    uint hasRedeferrableChild : 1;
     uint hasLoop : 1;
     uint hasEscapedUseNestedFunc : 1;
     uint needEnvRegister : 1;
@@ -408,24 +406,6 @@ public:
         // FuncInfo are from RestoredScopeInfo
         return root == nullptr;
     }
-
-    bool HasDeferredChild() const {
-        return hasDeferredChild;
-    }
-
-    void SetHasDeferredChild() {
-        hasDeferredChild = true;
-    }
-
-    bool HasRedeferrableChild() const {
-        return hasRedeferrableChild;
-    }
-
-    void SetHasRedeferrableChild() {
-        hasRedeferrableChild = true;
-    }
-
-    bool IsRedeferrable() const;
 
     Js::FunctionBody* GetParsedFunctionBody() const
     {


### PR DESCRIPTION
These were used to control scope info generation and stack args optimization but no longer are.