### PR TITLE
Remove additional edges in try finally flowgraph transformation

### DIFF
--- a/lib/Backend/FlowGraph.h
+++ b/lib/Backend/FlowGraph.h
@@ -140,9 +140,7 @@ public:
         loopList(nullptr),
         catchLabelStack(nullptr),
         finallyLabelStack(nullptr),
-        leaveNullLabelStack(nullptr),
         regToFinallyEndMap(nullptr),
-        leaveNullLabelToFinallyLabelMap(nullptr),
         hasBackwardPassInfo(false),
         hasLoop(false),
         implicitCallFlags(Js::ImplicitCall_HasNoInfo)
@@ -171,7 +169,7 @@ public:
     void         SortLoopLists();
     FlowEdge *   FindEdge(BasicBlock *predBlock, BasicBlock *succBlock);
     IR::LabelInstr * DeleteLeaveChainBlocks(IR::BranchInstr *leaveInstr, IR::Instr * &instrPrev);
-    bool         IsEarlyExitFromFinally(IR::BranchInstr *leaveInstr, Region *currentRegion, Region *branchTargetRegion, IR::Instr *&instrPrev, IR::LabelInstr *&exitLabel);
+    bool         CheckIfEarlyExitAndAddEdgeToFinally(IR::BranchInstr *leaveInstr, Region *currentRegion, Region *branchTargetRegion, IR::Instr *&instrPrev, IR::LabelInstr *&exitLabel);
     bool         Dominates(Region *finallyRegion, Region *exitLabelRegion);
     bool         DoesExitLabelDominate(IR::BranchInstr *leaveInstr);
     void         InsertEdgeFromFinallyToEarlyExit(BasicBlock * finallyEndBlock, IR::LabelInstr * exitLabel);

--- a/lib/Backend/SccLiveness.cpp
+++ b/lib/Backend/SccLiveness.cpp
@@ -165,8 +165,6 @@ SCCLiveness::Build()
                 if (labelInstr->isOpHelper == (this->lastOpHelperLabel != nullptr)
                     && lastLabelInstr && labelInstr->isOpHelper == lastLabelInstr->isOpHelper)
                 {
-                    // No such transition. Remove the label.
-                    Assert(!labelInstr->GetRegion() || labelInstr->GetRegion() == this->curRegion);
                     labelInstr->Remove();
                     continue;
                 }

--- a/test/EH/tryfinallytests.js
+++ b/test/EH/tryfinallytests.js
@@ -103,6 +103,24 @@ function test4() {
   }
 }
 
+function test6() {
+  var litObj0 = {};
+  for (; 87587180 < typeof ('prop0' in litObj0); arrObj0()) {
+    try {
+      continue;
+    }
+    finally {
+      var v1 = IntArr0();
+      while (1) {
+	WScript.Echo("help");
+	if (num > 10) {
+	WScript.Echo("help2");
+	}
+      }
+    }
+  }
+}
+
 test0();
 test0();
 test0();
@@ -127,5 +145,8 @@ test5();
 test5();
 test5();
 
+test6();
+test6();
+test6();
 
 WScript.Echo("passed");


### PR DESCRIPTION
  Remove additional edges in try finally flowgraph transformation.

  We used to add edge from infinite loops in finally region to end of finally block, so that unreachable block elimination does not remove finally end block.
  We didnt need this edge for globopt. But had one issue that came up with not adding these edges in building loops/processing basic blocks in flowgraphs.
  Because we don't cascade edge removal on calling RemoveBlock after early exit flowgraph transformation.

  This PR avoids adding this additional edge. And adds an extra call to RemoveUnreachableBlocks before FindLoops, so that unreachable blocks are correctly removed before loops are built.

  Fixes asserts in OS#13182223 and OS#12792486.