### PR TITLE
OS#13419689 - DOMFastPathGetter instructions do not propagate destination profile data, adding overhead to inlined getter calls

### DIFF
--- a/lib/Backend/Inline.cpp
+++ b/lib/Backend/Inline.cpp
@@ -3755,7 +3755,11 @@ void Inline::InlineDOMGetterSetterFunction(IR::Instr *ldFldInstr, const Function
 
     StackSym * tmpSym = StackSym::New(ldFldInstr->GetDst()->GetType(), ldFldInstr->m_func);
     IR::Opnd * tmpDst = IR::RegOpnd::New(tmpSym, tmpSym->GetType(), ldFldInstr->m_func);
-
+    // Ensure that the original LdFld's dst profile data is also copied to the new instruction for later
+    // type-specific optimizations. Otherwise, this optimization to reduce calls into the host will also
+    // result in relatively more expensive calls in the runtime.
+    tmpDst->SetValueType(ldFldInstr->GetDst()->GetValueType());
+    
     IR::Opnd * callInstrDst = ldFldInstr->UnlinkDst();
     ldFldInstr->SetDst(tmpDst);
 


### PR DESCRIPTION
This change addresses the issue of Get/SetElement being used a TypedArrays from the host, which should have specialized calls
from the backend. This bug happens because, when the Inliner creates the DOMFastPathGetter instruction to replace a LdFld
instruction, it does not propagate dst's profile data. Thus, though DOMFastPathGetter avoids calling into the host, it also
introduces a new cost of making generic calls because the type is unknown.
This change ensures that the original LdFld's dst profile data is also copied to the new instruction for later type-specific
optimizations.
