### PR TITLE
OS#10665027 Stop using FrameDisplay in Asm.js + Cleanup

### DIFF
--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -7991,7 +7991,7 @@ Lowerer::LowerCheckWasmSignature(IR::Instr * instr)
 
     IR::Instr *instrPrev = instr->m_prev;
 
-    IR::IndirOpnd * actualSig = IR::IndirOpnd::New(instr->UnlinkSrc1()->AsRegOpnd(), Js::AsmJsScriptFunction::GetOffsetOfSignature(), TyMachReg, m_func);
+    IR::IndirOpnd * actualSig = IR::IndirOpnd::New(instr->UnlinkSrc1()->AsRegOpnd(), Js::WasmScriptFunction::GetOffsetOfSignature(), TyMachReg, m_func);
 
     Wasm::WasmSignature * expectedSig = m_func->GetJITFunctionBody()->GetAsmJsInfo()->GetWasmSignature(sigId);
     if (expectedSig->GetShortSig() == Js::Constants::InvalidSignature)

--- a/lib/Runtime/Base/CrossSite.cpp
+++ b/lib/Runtime/Base/CrossSite.cpp
@@ -326,7 +326,7 @@ namespace Js
         TTD_XSITE_LOG(callable->GetScriptContext(), "DefaultOrProfileThunk", callable);
 
 #ifdef ENABLE_WASM
-        if (AsmJsScriptFunction::IsWasmScriptFunction(function))
+        if (WasmScriptFunction::Is(function))
         {
             AsmJsFunctionInfo* asmInfo = funcInfo->GetFunctionBody()->GetAsmJsFunctionInfo();
             Assert(asmInfo);

--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -3464,7 +3464,7 @@ namespace Js
                 scriptFunction->GetFunctionBody()->GetAsmJsFunctionInfo()->GetModuleFunctionBody() != nullptr)
             {
                 AsmJsScriptFunction* asmFunc = AsmJsScriptFunction::FromVar(scriptFunction);
-                Var* env = asmFunc->GetModuleEnvironment();
+                void* env = (void*)asmFunc->GetModuleEnvironment();
                 SList<AsmJsScriptFunction*> * funcList = nullptr;
                 if (asmJsEnvironmentMap->TryGetValue(env, &funcList))
                 {

--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -3078,6 +3078,7 @@ namespace Js
                 void* newEnv = AsmJsModuleInfo::ConvertFrameForJavascript(asmEnvIter.CurrentKey(), funcList->Head());
                 funcList->Iterate([&](AsmJsScriptFunction * func)
                 {
+                    func->SetEnvironment(RecyclerNewPlus(this->GetRecycler(), sizeof(void*), FrameDisplay, 1));
                     func->GetEnvironment()->SetItem(0, newEnv);
                 });
                 asmEnvIter.MoveNext();
@@ -3091,7 +3092,7 @@ namespace Js
                 Assert(!funcList->Empty());
                 funcList->Iterate([](AsmJsScriptFunction * func)
                 {
-                    func->SetModuleMemory(nullptr);
+                    func->SetModuleEnvironment(nullptr);
                     func->GetFunctionBody()->ResetAsmJsInfo();
                 });
                 asmCleanupIter.MoveNext();
@@ -3462,17 +3463,18 @@ namespace Js
                 scriptFunction->GetFunctionBody()->GetAsmJsFunctionInfo() != nullptr &&
                 scriptFunction->GetFunctionBody()->GetAsmJsFunctionInfo()->GetModuleFunctionBody() != nullptr)
             {
-                void* env = scriptFunction->GetEnvironment()->GetItem(0);
+                AsmJsScriptFunction* asmFunc = AsmJsScriptFunction::FromVar(scriptFunction);
+                Var* env = asmFunc->GetModuleEnvironment();
                 SList<AsmJsScriptFunction*> * funcList = nullptr;
                 if (asmJsEnvironmentMap->TryGetValue(env, &funcList))
                 {
-                    funcList->Push((AsmJsScriptFunction*)scriptFunction);
+                    funcList->Push(asmFunc);
                 }
                 else
                 {
                     SList<AsmJsScriptFunction*> * newList = Anew(debugTransitionAlloc, SList<AsmJsScriptFunction*>, debugTransitionAlloc);
                     asmJsEnvironmentMap->AddNew(env, newList);
-                    newList->Push((AsmJsScriptFunction*)scriptFunction);
+                    newList->Push(asmFunc);
                 }
             }
         }

--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -3920,7 +3920,7 @@ namespace Js
 #if defined(ENABLE_SCRIPT_DEBUGGING) || defined(ENABLE_SCRIPT_PROFILING)
         RUNTIME_ARGUMENTS(args, callInfo);
 
-        Assert(!AsmJsScriptFunction::IsWasmScriptFunction(callable));
+        Assert(!WasmScriptFunction::Is(callable));
         JavascriptFunction* function = JavascriptFunction::FromVar(callable);
         ScriptContext* scriptContext = function->GetScriptContext();
 

--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -813,7 +813,7 @@ private:
 #ifdef ASMJS_PLAT
         InterpreterThunkEmitter* asmJsInterpreterThunkEmitter;
         AsmJsCodeGenerator* asmJsCodeGenerator;
-        typedef JsUtil::BaseDictionary<void *, SList<AsmJsScriptFunction *>*, ArenaAllocator> AsmFunctionMap;
+        typedef JsUtil::BaseDictionary<Var*, SList<AsmJsScriptFunction *>*, ArenaAllocator> AsmFunctionMap;
         AsmFunctionMap* asmJsEnvironmentMap;
         ArenaAllocator* debugTransitionAlloc;
 #endif

--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -813,7 +813,7 @@ private:
 #ifdef ASMJS_PLAT
         InterpreterThunkEmitter* asmJsInterpreterThunkEmitter;
         AsmJsCodeGenerator* asmJsCodeGenerator;
-        typedef JsUtil::BaseDictionary<Var*, SList<AsmJsScriptFunction *>*, ArenaAllocator> AsmFunctionMap;
+        typedef JsUtil::BaseDictionary<void*, SList<AsmJsScriptFunction *>*, ArenaAllocator> AsmFunctionMap;
         AsmFunctionMap* asmJsEnvironmentMap;
         ArenaAllocator* debugTransitionAlloc;
 #endif

--- a/lib/Runtime/Language/AsmJsModule.cpp
+++ b/lib/Runtime/Language/AsmJsModule.cpp
@@ -2449,27 +2449,27 @@ namespace Js
 
     void AsmJsModuleInfo::EnsureHeapAttached(ScriptFunction * func)
     {
-        FrameDisplay* frame = func->GetEnvironment();
-        ArrayBuffer* moduleArrayBuffer = nullptr;
 #ifdef ENABLE_WASM
-        if (func->GetFunctionBody()->IsWasmFunction())
+        if (WasmScriptFunction::Is(func))
         {
-            WebAssemblyMemory * wasmMem = *(WebAssemblyMemory**)((Var*)frame->GetItem(0) + AsmJsModuleMemory::MemoryTableBeginOffset);
-            if (wasmMem != nullptr)
+            WasmScriptFunction* wasmFunc = WasmScriptFunction::FromVar(func);
+            WebAssemblyMemory * wasmMem = wasmFunc->GetWebAssemblyMemory();
+            if (wasmMem && wasmMem->GetBuffer() && wasmMem->GetBuffer()->IsDetached())
             {
-                moduleArrayBuffer = wasmMem->GetBuffer();
+                Throw::OutOfMemory();
             }
         }
         else
 #endif
         {
-            moduleArrayBuffer = *(ArrayBuffer**)((Var*)frame->GetItem(0) + AsmJsModuleMemory::MemoryTableBeginOffset);
+            AsmJsScriptFunction* asmFunc = AsmJsScriptFunction::FromVar(func);
+            ArrayBuffer* moduleArrayBuffer = asmFunc->GetAsmJsArrayBuffer();
+            if (moduleArrayBuffer && moduleArrayBuffer->IsDetached())
+            {
+                Throw::OutOfMemory();
+            }
         }
 
-        if (moduleArrayBuffer && moduleArrayBuffer->IsDetached())
-        {
-            Throw::OutOfMemory();
-        }
     }
 
     void * AsmJsModuleInfo::ConvertFrameForJavascript(void * asmMemory, ScriptFunction* func)

--- a/lib/Runtime/Language/AsmJsModule.cpp
+++ b/lib/Runtime/Language/AsmJsModule.cpp
@@ -2472,7 +2472,7 @@ namespace Js
 
     }
 
-    void * AsmJsModuleInfo::ConvertFrameForJavascript(Var* asmJsEnvironment, AsmJsScriptFunction* func)
+    void * AsmJsModuleInfo::ConvertFrameForJavascript(void* env, AsmJsScriptFunction* func)
     {
         FunctionBody * body = func->GetFunctionBody();
         AsmJsFunctionInfo * asmFuncInfo = body->GetAsmJsFunctionInfo();
@@ -2482,6 +2482,7 @@ namespace Js
 
         ScriptContext * scriptContext = func->GetScriptContext();
         // AsmJsModuleEnvironment is all laid out here
+        Var * asmJsEnvironment = static_cast<Var*>(env);
         Var * asmBufferPtr = asmJsEnvironment + asmModuleInfo->GetModuleMemory().mArrayBufferOffset;
         ArrayBuffer * asmBuffer = *asmBufferPtr ? ArrayBuffer::FromVar(*asmBufferPtr) : nullptr;
 

--- a/lib/Runtime/Language/AsmJsModule.cpp
+++ b/lib/Runtime/Language/AsmJsModule.cpp
@@ -2472,7 +2472,7 @@ namespace Js
 
     }
 
-    void * AsmJsModuleInfo::ConvertFrameForJavascript(void * asmMemory, ScriptFunction* func)
+    void * AsmJsModuleInfo::ConvertFrameForJavascript(Var* asmJsEnvironment, AsmJsScriptFunction* func)
     {
         FunctionBody * body = func->GetFunctionBody();
         AsmJsFunctionInfo * asmFuncInfo = body->GetAsmJsFunctionInfo();
@@ -2482,7 +2482,6 @@ namespace Js
 
         ScriptContext * scriptContext = func->GetScriptContext();
         // AsmJsModuleEnvironment is all laid out here
-        Var * asmJsEnvironment = static_cast<Var*>(func->GetEnvironment()->GetItem(0));
         Var * asmBufferPtr = asmJsEnvironment + asmModuleInfo->GetModuleMemory().mArrayBufferOffset;
         ArrayBuffer * asmBuffer = *asmBufferPtr ? ArrayBuffer::FromVar(*asmBufferPtr) : nullptr;
 

--- a/lib/Runtime/Language/AsmJsModule.h
+++ b/lib/Runtime/Language/AsmJsModule.h
@@ -610,7 +610,7 @@ namespace Js {
         }
 
         static void EnsureHeapAttached(ScriptFunction * func);
-        static void * ConvertFrameForJavascript(Var* asmJsMemory, AsmJsScriptFunction * func);
+        static void * ConvertFrameForJavascript(void* asmJsMemory, AsmJsScriptFunction * func);
     };
 };
 #endif

--- a/lib/Runtime/Language/AsmJsModule.h
+++ b/lib/Runtime/Language/AsmJsModule.h
@@ -610,7 +610,7 @@ namespace Js {
         }
 
         static void EnsureHeapAttached(ScriptFunction * func);
-        static void * ConvertFrameForJavascript(void* asmJsMemory, ScriptFunction * func);
+        static void * ConvertFrameForJavascript(Var* asmJsMemory, AsmJsScriptFunction * func);
     };
 };
 #endif

--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -2760,8 +2760,10 @@ namespace Js
         threadContext->SetImplicitCallFlags(saveImplicitcallFlags);
         // scope
         {
-            FrameDisplay* pDisplay = RecyclerNewPlus(scriptContext->GetRecycler(), sizeof(void*), FrameDisplay, 1);
-            pDisplay->SetItem(0, moduleMemoryPtr);
+            FrameDisplay* pDisplay = RecyclerNewPlus(scriptContext->GetRecycler(), sizeof(void*), FrameDisplay, 0);
+            //DynamicObject* asmModule = scriptContext->GetLibrary()->CreateObject(false, 1);
+            //JavascriptOperators::OP_SetProperty(asmModule, PropertyIds::module, moduleMemoryPtr, scriptContext);
+            //pDisplay->SetItem(0, this->function);
             for (int i = 0; i < info->GetFunctionCount(); i++)
             {
                 const auto& modFunc = info->GetFunction(i);
@@ -2779,7 +2781,7 @@ namespace Js
 
                 scriptFuncObj->GetDynamicType()->SetEntryPoint(AsmJsExternalEntryPoint);
                 scriptFuncObj->GetFunctionBody()->GetAsmJsFunctionInfo()->SetModuleFunctionBody(asmJsModuleFunctionBody);
-                scriptFuncObj->SetModuleMemory((Field(Var)*)moduleMemoryPtr);
+                scriptFuncObj->SetModuleEnvironment((Field(Var)*)moduleMemoryPtr);
                 if (!info->IsRuntimeProcessed())
                 {
                     // don't reset entrypoint upon relinking
@@ -3019,7 +3021,7 @@ namespace Js
 
         // Load module environment
         AsmJsScriptFunction* asmJsFunc = AsmJsScriptFunction::FromVar(this->function);
-        m_localSlots[AsmJsFunctionMemory::ModuleEnvRegister] = asmJsFunc->GetModuleMemory();
+        m_localSlots[AsmJsFunctionMemory::ModuleEnvRegister] = asmJsFunc->GetModuleEnvironment();
         m_localSlots[AsmJsFunctionMemory::ArrayBufferRegister] = nullptr;
 #ifdef ENABLE_WASM
         if (WasmScriptFunction::Is(func))

--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -3022,20 +3022,20 @@ namespace Js
         }
 
         // Load module environment
-        FrameDisplay* frame = this->function->GetEnvironment();
-        m_localSlots[AsmJsFunctionMemory::ModuleEnvRegister] = frame->GetItem(0);
+        AsmJsScriptFunction* asmJsFunc = AsmJsScriptFunction::FromVar(this->function);
+        m_localSlots[AsmJsFunctionMemory::ModuleEnvRegister] = asmJsFunc->GetModuleMemory();
 #ifdef ENABLE_WASM
-        if (func->GetFunctionBody()->IsWasmFunction())
+        if (WasmScriptFunction::Is(func))
         {
-            WebAssemblyMemory * wasmMem = *(WebAssemblyMemory**)((Var*)frame->GetItem(0) + AsmJsModuleMemory::MemoryTableBeginOffset);
+            WasmScriptFunction* wasmFunc = WasmScriptFunction::FromVar(func);
+            m_wasmMemory = wasmFunc->GetWebAssemblyMemory();
             m_signatures = func->GetFunctionBody()->GetAsmJsFunctionInfo()->GetWebAssemblyModule()->GetSignatures();
-            m_wasmMemory = wasmMem;
             m_localSlots[AsmJsFunctionMemory::ArrayBufferRegister] = nullptr;
         }
         else
 #endif
         {
-            m_localSlots[AsmJsFunctionMemory::ArrayBufferRegister] = (Var*)frame->GetItem(0) + AsmJsModuleMemory::MemoryTableBeginOffset;
+            m_localSlots[AsmJsFunctionMemory::ArrayBufferRegister] = asmJsFunc->GetAsmJsArrayBufferAddr();
         }
 
         m_localSlots[AsmJsFunctionMemory::ArraySizeRegister] = 0; // do not cache ArraySize in the interpreter

--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -1152,6 +1152,10 @@ namespace Js
         newInstance->localClosure = nullptr;
         newInstance->paramClosure = nullptr;
         newInstance->innerScopeArray = nullptr;
+        newInstance->m_asmJsBuffer = nullptr;
+#ifdef ENABLE_WASM
+        newInstance->m_wasmMemory = nullptr;
+#endif
 
         bool doInterruptProbe = newInstance->scriptContext->GetThreadContext()->DoInterruptProbe(this->executeFunction);
 #if ENABLE_NATIVE_CODEGEN

--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -2531,10 +2531,11 @@ namespace Js
         return this->Process();
     }
 
+
+#ifdef ASMJS_PLAT
     Var InterpreterStackFrame::ProcessAsmJsModule()
     {
-#ifdef ASMJS_PLAT
-        Js::FunctionBody* asmJsModuleFunctionBody = GetFunctionBody();
+        FunctionBody* asmJsModuleFunctionBody = GetFunctionBody();
         AsmJsModuleInfo* info = asmJsModuleFunctionBody->GetAsmJsModuleInfo();
 
 #ifdef ENABLE_DEBUG_CONFIG_OPTIONS
@@ -2544,7 +2545,7 @@ namespace Js
             return this->ProcessLinkFailedAsmJsModule();
         }
 #endif
-        if( m_inSlotsCount != info->GetArgInCount() + 1 )
+        if (m_inSlotsCount != info->GetArgInCount() + 1)
         {
             // Error reparse without asm.js
             AsmJSCompiler::OutputError(this->scriptContext, _u("Asm.js Runtime Error : Invalid module argument count"));
@@ -2588,17 +2589,17 @@ namespace Js
             // don't need to print, because checkParams will do it for us
             goto linkFailure;
         }
-        else if(this->CheckAndResetImplicitCall(prevDisableImplicitFlags, saveImplicitcallFlags))
+        else if (this->CheckAndResetImplicitCall(prevDisableImplicitFlags, saveImplicitcallFlags))
         {
             AsmJSCompiler::OutputError(this->scriptContext, _u("Asm.js Runtime Error : Params have side effects"));
-             return this->ProcessLinkFailedAsmJsModule();
+            return this->ProcessLinkFailedAsmJsModule();
         }
         // Initialize Variables
         for (int i = 0; i < info->GetVarCount(); i++)
         {
-            const auto& var = info->GetVar( i );
+            const auto& var = info->GetVar(i);
             const AsmJsVarType type(var.type);
-            if(type.isInt() )
+            if (type.isInt())
             {
                 localIntSlots[var.location] = var.initialiser.intInit;
             }
@@ -2624,12 +2625,12 @@ namespace Js
         }
 
         // Load constant variables
-        for( int i = 0; i < info->GetVarImportCount(); i++ )
+        for (int i = 0; i < info->GetVarImportCount(); i++)
         {
-            const auto& import = info->GetVarImport( i );
+            const auto& import = info->GetVarImport(i);
             const AsmJsVarType type(import.type);
             // this might throw, but it would anyway in non-asm.js
-            Var value = JavascriptOperators::OP_GetProperty( foreign, import.field, scriptContext );
+            Var value = JavascriptOperators::OP_GetProperty(foreign, import.field, scriptContext);
             // check if there is implicit call and if there is implicit call then clear the disableimplicitcall flag
             if (this->CheckAndResetImplicitCall(prevDisableImplicitFlags, saveImplicitcallFlags))
             {
@@ -2646,9 +2647,9 @@ namespace Js
                 }
             }
 
-            if(type.isInt() )
+            if (type.isInt())
             {
-                int val = JavascriptMath::ToInt32( value, scriptContext );
+                int val = JavascriptMath::ToInt32(value, scriptContext);
                 localIntSlots[import.location] = val;
             }
             else if (type.isFloat())
@@ -2658,7 +2659,7 @@ namespace Js
             }
             else if (type.isDouble())
             {
-                double val = JavascriptConversion::ToNumber( value, scriptContext );
+                double val = JavascriptConversion::ToNumber(value, scriptContext);
                 localDoubleSlots[import.location] = val;
             }
 #ifdef ENABLE_SIMDJS
@@ -2670,52 +2671,52 @@ namespace Js
                 val.Zero();
                 switch (type.which())
                 {
-                    case AsmJsVarType::Int32x4:
-                        valid = JavascriptSIMDInt32x4::Is(value);
-                        val = (valid) ? ((JavascriptSIMDInt32x4*)value)->GetValue() : val;
-                        break;
-                    case AsmJsVarType::Bool32x4:
-                        valid = JavascriptSIMDBool32x4::Is(value);
-                        val = (valid) ? ((JavascriptSIMDBool32x4*)value)->GetValue() : val;
-                        break;
-                    case AsmJsVarType::Bool16x8:
-                        valid = JavascriptSIMDBool16x8::Is(value);
-                        val = (valid) ? ((JavascriptSIMDBool16x8*)value)->GetValue() : val;
-                        break;
-                    case AsmJsVarType::Bool8x16:
-                        valid = JavascriptSIMDBool8x16::Is(value);
-                        val = (valid) ? ((JavascriptSIMDBool8x16*)value)->GetValue() : val;
-                        break;
-                    case AsmJsVarType::Float32x4:
-                        valid = JavascriptSIMDFloat32x4::Is(value);
-                        val = (valid) ? ((JavascriptSIMDFloat32x4*)value)->GetValue() : val;
-                        break;
-                    case AsmJsVarType::Float64x2:
-                        valid = JavascriptSIMDFloat64x2::Is(value);
-                        val = (valid) ? ((JavascriptSIMDFloat64x2*)value)->GetValue() : val;
-                        break;
-                    case AsmJsVarType::Int16x8:
-                        valid = JavascriptSIMDInt16x8::Is(value);
-                        val = (valid) ? ((JavascriptSIMDInt16x8*)value)->GetValue() : val;
-                        break;
-                    case AsmJsVarType::Int8x16:
-                        valid = JavascriptSIMDInt8x16::Is(value);
-                        val = ((JavascriptSIMDInt8x16*)value)->GetValue();
-                        break;
-                    case AsmJsVarType::Uint32x4:
-                        valid = JavascriptSIMDUint32x4::Is(value);
-                        val = (valid) ? ((JavascriptSIMDUint32x4*)value)->GetValue() : val;
-                        break;
-                    case AsmJsVarType::Uint16x8:
-                        valid = JavascriptSIMDUint16x8::Is(value);
-                        val = (valid) ? ((JavascriptSIMDUint16x8*)value)->GetValue() : val;
-                        break;
-                    case AsmJsVarType::Uint8x16:
-                        valid = JavascriptSIMDUint8x16::Is(value);
-                        val = (valid) ? ((JavascriptSIMDUint8x16*)value)->GetValue() : val;
-                        break;
-                    default:
-                        Assert(UNREACHED);
+                case AsmJsVarType::Int32x4:
+                    valid = JavascriptSIMDInt32x4::Is(value);
+                    val = (valid) ? ((JavascriptSIMDInt32x4*)value)->GetValue() : val;
+                    break;
+                case AsmJsVarType::Bool32x4:
+                    valid = JavascriptSIMDBool32x4::Is(value);
+                    val = (valid) ? ((JavascriptSIMDBool32x4*)value)->GetValue() : val;
+                    break;
+                case AsmJsVarType::Bool16x8:
+                    valid = JavascriptSIMDBool16x8::Is(value);
+                    val = (valid) ? ((JavascriptSIMDBool16x8*)value)->GetValue() : val;
+                    break;
+                case AsmJsVarType::Bool8x16:
+                    valid = JavascriptSIMDBool8x16::Is(value);
+                    val = (valid) ? ((JavascriptSIMDBool8x16*)value)->GetValue() : val;
+                    break;
+                case AsmJsVarType::Float32x4:
+                    valid = JavascriptSIMDFloat32x4::Is(value);
+                    val = (valid) ? ((JavascriptSIMDFloat32x4*)value)->GetValue() : val;
+                    break;
+                case AsmJsVarType::Float64x2:
+                    valid = JavascriptSIMDFloat64x2::Is(value);
+                    val = (valid) ? ((JavascriptSIMDFloat64x2*)value)->GetValue() : val;
+                    break;
+                case AsmJsVarType::Int16x8:
+                    valid = JavascriptSIMDInt16x8::Is(value);
+                    val = (valid) ? ((JavascriptSIMDInt16x8*)value)->GetValue() : val;
+                    break;
+                case AsmJsVarType::Int8x16:
+                    valid = JavascriptSIMDInt8x16::Is(value);
+                    val = ((JavascriptSIMDInt8x16*)value)->GetValue();
+                    break;
+                case AsmJsVarType::Uint32x4:
+                    valid = JavascriptSIMDUint32x4::Is(value);
+                    val = (valid) ? ((JavascriptSIMDUint32x4*)value)->GetValue() : val;
+                    break;
+                case AsmJsVarType::Uint16x8:
+                    valid = JavascriptSIMDUint16x8::Is(value);
+                    val = (valid) ? ((JavascriptSIMDUint16x8*)value)->GetValue() : val;
+                    break;
+                case AsmJsVarType::Uint8x16:
+                    valid = JavascriptSIMDUint8x16::Is(value);
+                    val = (valid) ? ((JavascriptSIMDUint8x16*)value)->GetValue() : val;
+                    break;
+                default:
+                    Assert(UNREACHED);
                 };
                 if (!valid)
                 {
@@ -2736,18 +2737,18 @@ namespace Js
             }
         }
         // Load external functions
-        for( int i = 0; i < info->GetFunctionImportCount(); i++ )
+        for (int i = 0; i < info->GetFunctionImportCount(); i++)
         {
-            const auto& import = info->GetFunctionImport( i );
+            const auto& import = info->GetFunctionImport(i);
             // this might throw, but it would anyway in non-asm.js
-            Var importFunc = JavascriptOperators::OP_GetProperty( foreign, import.field, scriptContext );
+            Var importFunc = JavascriptOperators::OP_GetProperty(foreign, import.field, scriptContext);
             // check if there is implicit call and if there is implicit call then clear the disableimplicitcall flag
             if (this->CheckAndResetImplicitCall(prevDisableImplicitFlags, saveImplicitcallFlags))
             {
                 AsmJSCompiler::OutputError(this->scriptContext, _u("Asm.js Runtime Error : Accessing foreign function import %s has side effects"), this->scriptContext->GetPropertyName(import.field)->GetBuffer());
                 return this->ProcessLinkFailedAsmJsModule();
             }
-            if( !JavascriptFunction::Is( importFunc ) )
+            if (!JavascriptFunction::Is(importFunc))
             {
                 AsmJSCompiler::OutputError(this->scriptContext, _u("Asm.js Runtime Error : Foreign function import %s is not a function"), this->scriptContext->GetPropertyName(import.field)->GetBuffer());
                 goto linkFailure;
@@ -2760,7 +2761,7 @@ namespace Js
         // scope
         {
             FrameDisplay* pDisplay = RecyclerNewPlus(scriptContext->GetRecycler(), sizeof(void*), FrameDisplay, 1);
-            pDisplay->SetItem( 0, moduleMemoryPtr );
+            pDisplay->SetItem(0, moduleMemoryPtr);
             for (int i = 0; i < info->GetFunctionCount(); i++)
             {
                 const auto& modFunc = info->GetFunction(i);
@@ -2785,22 +2786,22 @@ namespace Js
                     FunctionEntryPointInfo* entrypointInfo = (FunctionEntryPointInfo*)scriptFuncObj->GetEntryPointInfo();
                     entrypointInfo->SetIsAsmJSFunction(true);
 
-    #if DYNAMIC_INTERPRETER_THUNK
+#if DYNAMIC_INTERPRETER_THUNK
                     if (!PHASE_ON1(AsmJsJITTemplatePhase))
                     {
                         entrypointInfo->jsMethod = AsmJsDefaultEntryThunk;
                     }
-    #endif
+#endif
                 }
             }
         }
 
         // Initialize function table arrays
-        for( int i = 0; i < info->GetFunctionTableCount(); i++ )
+        for (int i = 0; i < info->GetFunctionTableCount(); i++)
         {
-            const auto& modFuncTable = info->GetFunctionTable( i );
-            Field(Var)* funcTableArray = RecyclerNewArray( scriptContext->GetRecycler(), Field(Var), modFuncTable.size );
-            for (uint j = 0; j < modFuncTable.size ; j++)
+            const auto& modFuncTable = info->GetFunctionTable(i);
+            Field(Var)* funcTableArray = RecyclerNewArray(scriptContext->GetRecycler(), Field(Var), modFuncTable.size);
+            for (uint j = 0; j < modFuncTable.size; j++)
             {
                 // get the module function index
                 const RegSlot index = modFuncTable.moduleFunctionIndex[j];
@@ -2810,12 +2811,12 @@ namespace Js
             }
             localFunctionTables[i] = funcTableArray;
         }
-// Do MTJRC/MAIC:0 check
+        // Do MTJRC/MAIC:0 check
 #if ENABLE_DEBUG_CONFIG_OPTIONS
         if (
             (PHASE_ON1(Js::AsmJsJITTemplatePhase) && CONFIG_FLAG(MaxTemplatizedJitRunCount) == 0) ||
             (!PHASE_ON1(Js::AsmJsJITTemplatePhase) && (CONFIG_FLAG(MaxAsmJsInterpreterRunCount) == 0 || CONFIG_FLAG(ForceNative)))
-        )
+            )
         {
             if (PHASE_TRACE1(AsmjsEntryPointInfoPhase))
             {
@@ -2838,17 +2839,17 @@ namespace Js
         info->SetIsRuntimeProcessed(true);
 
         // create export object
-        if( info->GetExportsCount() )
+        if (info->GetExportsCount())
         {
-            Var newObj = JavascriptOperators::NewScObjectLiteral( GetScriptContext(), info->GetExportsIdArray(),
-                                                                  this->GetFunctionBody()->GetObjectLiteralTypeRef(0));
-            for( int i = 0; i < info->GetExportsCount(); i++ )
+            Var newObj = JavascriptOperators::NewScObjectLiteral(GetScriptContext(), info->GetExportsIdArray(),
+                this->GetFunctionBody()->GetObjectLiteralTypeRef(0));
+            for (int i = 0; i < info->GetExportsCount(); i++)
             {
-                auto ex = info->GetExport( i );
+                auto ex = info->GetExport(i);
                 Var func = localModuleFunctions[*ex.location];
-                JavascriptOperators::OP_InitProperty( newObj, *ex.id, func );
+                JavascriptOperators::OP_InitProperty(newObj, *ex.id, func);
             }
-            SetReg( (RegSlot) 0, newObj );
+            SetReg((RegSlot)0, newObj);
             return newObj;
         }
 
@@ -2942,17 +2943,12 @@ namespace Js
         }
 
         return retVal;
-#else
-        Assert(UNREACHED);
-        return nullptr;
-#endif
     }
 
 #if ENABLE_DEBUG_CONFIG_OPTIONS
     int AsmJsCallDepth = 0;
 #endif
 
-#ifdef ASMJS_PLAT
     // Function memory allocation should be done the same way as
     // T AsmJsCommunEntryPoint(Js::ScriptFunction* func, ...)  (AsmJSJitTemplate.cpp)
     // update any changes there
@@ -3024,18 +3020,18 @@ namespace Js
         // Load module environment
         AsmJsScriptFunction* asmJsFunc = AsmJsScriptFunction::FromVar(this->function);
         m_localSlots[AsmJsFunctionMemory::ModuleEnvRegister] = asmJsFunc->GetModuleMemory();
+        m_localSlots[AsmJsFunctionMemory::ArrayBufferRegister] = nullptr;
 #ifdef ENABLE_WASM
         if (WasmScriptFunction::Is(func))
         {
             WasmScriptFunction* wasmFunc = WasmScriptFunction::FromVar(func);
             m_wasmMemory = wasmFunc->GetWebAssemblyMemory();
             m_signatures = func->GetFunctionBody()->GetAsmJsFunctionInfo()->GetWebAssemblyModule()->GetSignatures();
-            m_localSlots[AsmJsFunctionMemory::ArrayBufferRegister] = nullptr;
         }
         else
 #endif
         {
-            m_localSlots[AsmJsFunctionMemory::ArrayBufferRegister] = asmJsFunc->GetAsmJsArrayBufferAddr();
+            m_asmJsBuffer = asmJsFunc->GetAsmJsArrayBuffer();
         }
 
         m_localSlots[AsmJsFunctionMemory::ArraySizeRegister] = 0; // do not cache ArraySize in the interpreter
@@ -7937,7 +7933,7 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
     int InterpreterStackFrame::OP_GetMemorySize()
     {
 #ifdef ENABLE_WASM
-        return (int)m_wasmMemory->GetCurrentMemoryPages();
+        return (int)GetWebAssemblyMemory()->GetCurrentMemoryPages();
 #else
         Assert(UNREACHED);
         return 0;
@@ -7947,7 +7943,7 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
     int InterpreterStackFrame::OP_GrowMemory(int32 delta)
     {
 #ifdef ENABLE_WASM
-        return m_wasmMemory->GrowInternal((uint32)delta);
+        return GetWebAssemblyMemory()->GrowInternal((uint32)delta);
 #else
         Assert(UNREACHED);
         return 0;
@@ -8003,9 +7999,8 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
     void InterpreterStackFrame::OP_SimdLdArrGeneric(const unaligned T* playout)
     {
         Assert(playout->ViewType < Js::ArrayBufferView::TYPE_COUNT);
-        AssertMsg(!m_functionBody->IsWasmFunction(), "Do not use AsmJsFunctionMemory::ArrayBufferRegister for Wasm, Use WebAssemblyMemory directly instead");
         const uint64 index = (uint32)GetRegRawInt(playout->SlotIndex) & ArrayBufferView::ViewMask[playout->ViewType];
-        JavascriptArrayBuffer* arr = *(JavascriptArrayBuffer**)GetNonVarReg(AsmJsFunctionMemory::ArrayBufferRegister);
+        JavascriptArrayBuffer* arr = GetAsmJsBuffer();
         BYTE* buffer = arr->GetBuffer();
         uint8 dataWidth = playout->DataWidth;
         RegSlot dstReg = playout->Value;
@@ -8025,9 +8020,8 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
     void InterpreterStackFrame::OP_SimdLdArrConstIndex(const unaligned T* playout)
     {
         Assert(playout->ViewType < Js::ArrayBufferView::TYPE_COUNT);
-        AssertMsg(!m_functionBody->IsWasmFunction(), "Do not use AsmJsFunctionMemory::ArrayBufferRegister for Wasm, Use WebAssemblyMemory directly instead");
         const uint64 index = (uint32)playout->SlotIndex;
-        JavascriptArrayBuffer* arr = *(JavascriptArrayBuffer**)GetNonVarReg(AsmJsFunctionMemory::ArrayBufferRegister);
+        JavascriptArrayBuffer* arr = GetAsmJsBuffer();
         BYTE* buffer = arr->GetBuffer();
         uint8 dataWidth = playout->DataWidth;
         RegSlot dstReg = playout->Value;
@@ -8047,9 +8041,8 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
     void InterpreterStackFrame::OP_SimdStArrGeneric(const unaligned T* playout)
     {
         Assert(playout->ViewType < Js::ArrayBufferView::TYPE_COUNT);
-        AssertMsg(!m_functionBody->IsWasmFunction(), "Do not use AsmJsFunctionMemory::ArrayBufferRegister for Wasm, Use WebAssemblyMemory directly instead");
         const uint64 index = (uint32)GetRegRawInt(playout->SlotIndex) & ArrayBufferView::ViewMask[playout->ViewType];
-        JavascriptArrayBuffer* arr = *(JavascriptArrayBuffer**)GetNonVarReg(AsmJsFunctionMemory::ArrayBufferRegister);
+        JavascriptArrayBuffer* arr = GetAsmJsBuffer();
         BYTE* buffer = arr->GetBuffer();
         uint8 dataWidth = playout->DataWidth;
         RegSlot srcReg = playout->Value;
@@ -8067,9 +8060,8 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
     void InterpreterStackFrame::OP_SimdStArrConstIndex(const unaligned T* playout)
     {
         Assert(playout->ViewType < Js::ArrayBufferView::TYPE_COUNT);
-        AssertMsg(!m_functionBody->IsWasmFunction(), "Do not use AsmJsFunctionMemory::ArrayBufferRegister for Wasm, Use WebAssemblyMemory directly instead");
         const uint64 index = (uint32)playout->SlotIndex;
-        JavascriptArrayBuffer* arr = *(JavascriptArrayBuffer**)GetNonVarReg(AsmJsFunctionMemory::ArrayBufferRegister);
+        JavascriptArrayBuffer* arr = GetAsmJsBuffer();
         BYTE* buffer = arr->GetBuffer();
         uint8 dataWidth = playout->DataWidth;
         RegSlot srcReg = playout->Value;
@@ -8510,8 +8502,7 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
     void InterpreterStackFrame::OP_StArr(uint32 index, RegSlot regSlot)
     {
         CompileAssert(Js::ArrayBufferView::TYPE_COUNT == (sizeof(InterpreterStackFrame::StArrFunc) / sizeof(InterpreterStackFrame::ArrFunc)));
-        AssertMsg(!m_functionBody->IsWasmFunction(), "Do not use AsmJsFunctionMemory::ArrayBufferRegister for Wasm, Use WebAssemblyMemory directly instead");
-        JavascriptArrayBuffer* arr = *(JavascriptArrayBuffer**)GetNonVarReg(AsmJsFunctionMemory::ArrayBufferRegister);
+        JavascriptArrayBuffer* arr = GetAsmJsBuffer();
         if (index < arr->GetByteLength())
         {
             BYTE* buffer = arr->GetBuffer();
@@ -8592,8 +8583,7 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
     void InterpreterStackFrame::OP_LdArr(uint32 index, RegSlot regSlot)
     {
         CompileAssert(Js::ArrayBufferView::TYPE_COUNT == (sizeof(InterpreterStackFrame::LdArrFunc) / sizeof(InterpreterStackFrame::ArrFunc)));
-        AssertMsg(!m_functionBody->IsWasmFunction(), "Do not use AsmJsFunctionMemory::ArrayBufferRegister for Wasm, Use WebAssemblyMemory directly instead");
-        JavascriptArrayBuffer* arr = *(JavascriptArrayBuffer**)GetNonVarReg(AsmJsFunctionMemory::ArrayBufferRegister);
+        JavascriptArrayBuffer* arr = GetAsmJsBuffer();
         BYTE* buffer = arr->GetBuffer();
         ArrayType val = index < (arr->GetByteLength()) ? *(ArrayType*)(buffer + index) : GetArrayViewOverflowVal<ArrayType>();
         SetRegRaw<RegType>(regSlot, (RegType)val);
@@ -8634,7 +8624,7 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
 #ifdef ENABLE_WASM
         Assert(playout->ViewType < Js::ArrayBufferView::TYPE_COUNT);
         const uint64 index = playout->Offset + (uint64)(uint32)GetRegRawInt(playout->SlotIndex);
-        WebAssemblyArrayBuffer* arr = m_wasmMemory->GetBuffer();
+        WebAssemblyArrayBuffer* arr = GetWebAssemblyMemory()->GetBuffer();
         if (index + TypeToSizeMap[playout->ViewType] > arr->GetByteLength())
         {
             JavascriptError::ThrowWebAssemblyRuntimeError(scriptContext, WASMERR_ArrayIndexOutOfRange);
@@ -8685,7 +8675,7 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
 #ifdef ENABLE_WASM
         Assert(playout->ViewType < Js::ArrayBufferView::TYPE_COUNT);
         const uint64 index = playout->Offset + (uint64)(uint32)GetRegRawInt(playout->SlotIndex);
-        WebAssemblyArrayBuffer* arr = m_wasmMemory->GetBuffer();
+        WebAssemblyArrayBuffer* arr = GetWebAssemblyMemory()->GetBuffer();
         if (index + TypeToSizeMap[playout->ViewType] > arr->GetByteLength())
         {
             JavascriptError::ThrowWebAssemblyRuntimeError(scriptContext, WASMERR_ArrayIndexOutOfRange);
@@ -8714,7 +8704,7 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
 #if DBG
         if (PHASE_TRACE(WasmMemWritesPhase, m_functionBody))
         {
-            m_wasmMemory->TraceMemWrite(m_wasmMemory, (uint32)GetRegRawInt(playout->SlotIndex), playout->Offset, playout->ViewType, (uint32)(size_t)this->DEBUG_currentByteOffset, scriptContext);
+            GetWebAssemblyMemory()->TraceMemWrite(GetWebAssemblyMemory(), (uint32)GetRegRawInt(playout->SlotIndex), playout->Offset, playout->ViewType, (uint32)(size_t)this->DEBUG_currentByteOffset, scriptContext);
         }
 #endif
         return;
@@ -9169,6 +9159,20 @@ const byte * InterpreterStackFrame::OP_ProfiledLoopBodyStart(const byte * ip)
         Output::Print(_u("("));
 #endif
     }
+
+    JavascriptArrayBuffer* InterpreterStackFrame::GetAsmJsBuffer() const
+    {
+        AssertMsg(!m_functionBody->IsWasmFunction(), "Do not use GetAsmJsBuffer for WebAssembly, Use GetWebAssemblyMemory instead");
+        return m_asmJsBuffer;
+    }
+
+#ifdef ENABLE_WASM
+    WebAssemblyMemory* InterpreterStackFrame::GetWebAssemblyMemory() const
+    {
+        AssertMsg(m_functionBody->IsWasmFunction(), "Do not use GetWebAssemblyMemory for Asm.js, Use GetAsmJsBuffer instead");
+        return m_wasmMemory;
+    }
+#endif
 
     template void* Js::InterpreterStackFrame::GetReg<unsigned int>(unsigned int) const;
     template void Js::InterpreterStackFrame::SetReg<unsigned int>(unsigned int, void*);

--- a/lib/Runtime/Language/InterpreterStackFrame.h
+++ b/lib/Runtime/Language/InterpreterStackFrame.h
@@ -163,10 +163,16 @@ namespace Js
         int64* m_localInt64Slots;
         double* m_localDoubleSlots;
         float* m_localFloatSlots;
+        union
+        {
+            JavascriptArrayBuffer* m_asmJsBuffer;
+#ifdef ENABLE_WASM
+            WebAssemblyMemory * m_wasmMemory;
+#endif
+        };
 
 #ifdef ENABLE_WASM
         Wasm::WasmSignature* m_signatures;
-        WebAssemblyMemory * m_wasmMemory;
 #endif
          _SIMDValue* m_localSimdSlots;
 
@@ -187,6 +193,10 @@ namespace Js
         //This class must have an empty ctor (otherwise it will break the code in InterpreterStackFrame::InterpreterThunk
         inline InterpreterStackFrame() { }
 
+        JavascriptArrayBuffer* GetAsmJsBuffer() const;
+#ifdef ENABLE_WASM
+        WebAssemblyMemory* GetWebAssemblyMemory() const;
+#endif
         void ProcessTryFinally(const byte* ip, Js::JumpOffset jumpOffset, Js::RegSlot regException = Js::Constants::NoRegister, Js::RegSlot regOffset = Js::Constants::NoRegister, bool hasYield = false);
     public:
         void OP_SetOutAsmInt(RegSlot outRegisterID, int val);

--- a/lib/Runtime/Language/i386/AsmJsJitTemplate.cpp
+++ b/lib/Runtime/Language/i386/AsmJsJitTemplate.cpp
@@ -551,14 +551,13 @@ namespace Js
         AsmJsSIMDValue* simdArg;
 
         // setup stack memory
-        FrameDisplay* frame = func->GetEnvironment();
-        Var moduleEnv = frame->GetItem(0);
-        Var* arrayBufferVar = (Var*)frame->GetItem(0) + AsmJsModuleMemory::MemoryTableBeginOffset;
+        AsmJsScriptFunction* asmJsFunc = AsmJsScriptFunction::FromVar(func);
+        Var moduleEnv = asmJsFunc->GetModuleMemory();
+        JavascriptArrayBuffer* arrayBuffer = asmJsFunc->GetAsmJsArrayBuffer();
         int arraySize = 0;
         BYTE* arrayPtr = nullptr;
-        if (*arrayBufferVar && JavascriptArrayBuffer::Is(*arrayBufferVar))
+        if (JavascriptArrayBuffer::Is(arrayBuffer))
         {
-            JavascriptArrayBuffer* arrayBuffer = *(JavascriptArrayBuffer**)arrayBufferVar;
             arrayPtr = arrayBuffer->GetBuffer();
             arraySize = arrayBuffer->GetByteLength();
         }

--- a/lib/Runtime/Language/i386/AsmJsJitTemplate.cpp
+++ b/lib/Runtime/Language/i386/AsmJsJitTemplate.cpp
@@ -552,7 +552,7 @@ namespace Js
 
         // setup stack memory
         AsmJsScriptFunction* asmJsFunc = AsmJsScriptFunction::FromVar(func);
-        Var moduleEnv = asmJsFunc->GetModuleMemory();
+        Var moduleEnv = asmJsFunc->GetModuleEnvironment();
         JavascriptArrayBuffer* arrayBuffer = asmJsFunc->GetAsmJsArrayBuffer();
         int arraySize = 0;
         BYTE* arrayPtr = nullptr;

--- a/lib/Runtime/Library/JavascriptFunction.cpp
+++ b/lib/Runtime/Library/JavascriptFunction.cpp
@@ -2301,15 +2301,15 @@ LABEL1:
         {
             return false;
         }
-        Js::FunctionBody* funcBody = func->GetFunctionBody();
-        bool isWAsmJs = funcBody->GetIsAsmJsFunction();
-        bool isWasmOnly = funcBody->IsWasmFunction();
+
+        bool isWAsmJs = AsmJsScriptFunction::Is(func);
+        bool isWasmOnly = WasmScriptFunction::Is(func);
         uintptr_t faultingAddr = helper.GetFaultingAddress();
         if (isWAsmJs)
         {
+            AsmJsScriptFunction* asmFunc = AsmJsScriptFunction::FromVar(func);
             // some extra checks for asm.js because we have slightly more information that we can validate
-            uintptr_t moduleMemory = (uintptr_t)((AsmJsScriptFunction*)func)->GetModuleMemory();
-            if (!moduleMemory)
+            if (!asmFunc->GetModuleMemory())
             {
                 return false;
             }
@@ -2319,14 +2319,14 @@ LABEL1:
 #ifdef ENABLE_WASM
             if (isWasmOnly)
             {
-                WebAssemblyMemory* mem = *(WebAssemblyMemory**)(moduleMemory + WebAssemblyModule::GetMemoryOffset());
+                WebAssemblyMemory* mem = WasmScriptFunction::FromVar(func)->GetWebAssemblyMemory();
                 arrayBuffer = mem->GetBuffer();
                 reservationSize = MAX_WASM__ARRAYBUFFER_LENGTH;
             }
             else
 #endif
             {
-                arrayBuffer = *(ArrayBuffer**)(moduleMemory + AsmJsModuleMemory::MemoryTableBeginOffset);
+                arrayBuffer = asmFunc->GetAsmJsArrayBuffer();
                 reservationSize = MAX_ASMJS_ARRAYBUFFER_LENGTH;
             }
 

--- a/lib/Runtime/Library/JavascriptFunction.cpp
+++ b/lib/Runtime/Library/JavascriptFunction.cpp
@@ -2302,10 +2302,10 @@ LABEL1:
             return false;
         }
 
-        bool isWAsmJs = AsmJsScriptFunction::Is(func);
+        bool isAsmJs = AsmJsScriptFunction::Is(func);
         bool isWasmOnly = WasmScriptFunction::Is(func);
         uintptr_t faultingAddr = helper.GetFaultingAddress();
-        if (isWAsmJs)
+        if (isAsmJs)
         {
             AsmJsScriptFunction* asmFunc = AsmJsScriptFunction::FromVar(func);
             // some extra checks for asm.js because we have slightly more information that we can validate

--- a/lib/Runtime/Library/JavascriptFunction.cpp
+++ b/lib/Runtime/Library/JavascriptFunction.cpp
@@ -2309,7 +2309,7 @@ LABEL1:
         {
             AsmJsScriptFunction* asmFunc = AsmJsScriptFunction::FromVar(func);
             // some extra checks for asm.js because we have slightly more information that we can validate
-            if (!asmFunc->GetModuleMemory())
+            if (!asmFunc->GetModuleEnvironment())
             {
                 return false;
             }

--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -6564,6 +6564,12 @@ namespace Js
         return RecyclerNewEnumClass(this->GetRecycler(), EnumFunctionClass, AsmJsScriptFunction, proxy, deferredPrototypeType);
     }
 
+    WasmScriptFunction * JavascriptLibrary::CreateWasmScriptFunction(FunctionProxy* proxy)
+    {
+        ScriptFunctionType* deferredPrototypeType = proxy->EnsureDeferredPrototypeType();
+        return RecyclerNewEnumClass(this->GetRecycler(), EnumFunctionClass, WasmScriptFunction, proxy, deferredPrototypeType);
+    }
+
     ScriptFunctionWithInlineCache* JavascriptLibrary::CreateScriptFunctionWithInlineCache(FunctionProxy * proxy)
     {
         ScriptFunctionType* deferredPrototypeType = proxy->EnsureDeferredPrototypeType();

--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -6564,11 +6564,13 @@ namespace Js
         return RecyclerNewEnumClass(this->GetRecycler(), EnumFunctionClass, AsmJsScriptFunction, proxy, deferredPrototypeType);
     }
 
+#ifdef ENABLE_WASM
     WasmScriptFunction * JavascriptLibrary::CreateWasmScriptFunction(FunctionProxy* proxy)
     {
         ScriptFunctionType* deferredPrototypeType = proxy->EnsureDeferredPrototypeType();
         return RecyclerNewEnumClass(this->GetRecycler(), EnumFunctionClass, WasmScriptFunction, proxy, deferredPrototypeType);
     }
+#endif
 
     ScriptFunctionWithInlineCache* JavascriptLibrary::CreateScriptFunctionWithInlineCache(FunctionProxy * proxy)
     {

--- a/lib/Runtime/Library/JavascriptLibrary.h
+++ b/lib/Runtime/Library/JavascriptLibrary.h
@@ -1029,7 +1029,9 @@ namespace Js
         DynamicType * CreateFunctionWithLengthAndPrototypeType(DynamicObject * prototype, FunctionInfo * functionInfo);
         ScriptFunction * CreateScriptFunction(FunctionProxy* proxy);
         AsmJsScriptFunction * CreateAsmJsScriptFunction(FunctionProxy* proxy);
+#ifdef ENABLE_WASM
         WasmScriptFunction * CreateWasmScriptFunction(FunctionProxy* proxy);
+#endif
         ScriptFunctionWithInlineCache * CreateScriptFunctionWithInlineCache(FunctionProxy* proxy);
         GeneratorVirtualScriptFunction * CreateGeneratorVirtualScriptFunction(FunctionProxy* proxy);
         DynamicType * CreateGeneratorType(RecyclableObject* prototype);

--- a/lib/Runtime/Library/JavascriptLibrary.h
+++ b/lib/Runtime/Library/JavascriptLibrary.h
@@ -1029,6 +1029,7 @@ namespace Js
         DynamicType * CreateFunctionWithLengthAndPrototypeType(DynamicObject * prototype, FunctionInfo * functionInfo);
         ScriptFunction * CreateScriptFunction(FunctionProxy* proxy);
         AsmJsScriptFunction * CreateAsmJsScriptFunction(FunctionProxy* proxy);
+        WasmScriptFunction * CreateWasmScriptFunction(FunctionProxy* proxy);
         ScriptFunctionWithInlineCache * CreateScriptFunctionWithInlineCache(FunctionProxy* proxy);
         GeneratorVirtualScriptFunction * CreateGeneratorVirtualScriptFunction(FunctionProxy* proxy);
         DynamicType * CreateGeneratorType(RecyclableObject* prototype);

--- a/lib/Runtime/Library/ScriptFunction.cpp
+++ b/lib/Runtime/Library/ScriptFunction.cpp
@@ -683,15 +683,24 @@ namespace Js
         return asmJsFunc;
     }
 
-    Js::JavascriptArrayBuffer** AsmJsScriptFunction::GetAsmJsArrayBufferAddr() const
-    {
-        return (JavascriptArrayBuffer**)(this->GetModuleEnvironment() + AsmJsModuleMemory::MemoryTableBeginOffset);
-    }
-
     JavascriptArrayBuffer* AsmJsScriptFunction::GetAsmJsArrayBuffer() const
     {
-        return *GetAsmJsArrayBufferAddr();
+#ifdef ASMJS_PLAT
+        return *(JavascriptArrayBuffer**)(this->GetModuleEnvironment() + AsmJsModuleMemory::MemoryTableBeginOffset);
+#else
+        Assert(UNREACHED);
+        return nullptr;
+#endif
     }
+
+#ifdef ENABLE_WASM
+    WasmScriptFunction::WasmScriptFunction(DynamicType * type) :
+        AsmJsScriptFunction(type), m_signature(nullptr)
+    {}
+
+    WasmScriptFunction::WasmScriptFunction(FunctionProxy * proxy, ScriptFunctionType* deferredPrototypeType) :
+        AsmJsScriptFunction(proxy, deferredPrototypeType), m_signature(nullptr)
+    {}
 
     bool WasmScriptFunction::Is(Var func)
     {
@@ -708,14 +717,7 @@ namespace Js
     {
         return *(WebAssemblyMemory**)(this->GetModuleEnvironment() + AsmJsModuleMemory::MemoryTableBeginOffset);
     }
-
-    WasmScriptFunction::WasmScriptFunction(DynamicType * type) :
-        AsmJsScriptFunction(type), m_signature(nullptr)
-    {}
-
-    WasmScriptFunction::WasmScriptFunction(FunctionProxy * proxy, ScriptFunctionType* deferredPrototypeType) :
-        AsmJsScriptFunction(proxy, deferredPrototypeType), m_signature(nullptr)
-    {}
+#endif
 
     ScriptFunctionWithInlineCache::ScriptFunctionWithInlineCache(FunctionProxy * proxy, ScriptFunctionType* deferredPrototypeType) :
         ScriptFunction(proxy, deferredPrototypeType), hasOwnInlineCaches(false)

--- a/lib/Runtime/Library/ScriptFunction.cpp
+++ b/lib/Runtime/Library/ScriptFunction.cpp
@@ -653,16 +653,7 @@ namespace Js
 
     bool AsmJsScriptFunction::Is(Var func)
     {
-        return ScriptFunction::Is(func) &&
-            ScriptFunction::FromVar(func)->HasFunctionBody() &&
-            ScriptFunction::FromVar(func)->GetFunctionBody()->GetIsAsmJsFunction();
-    }
-
-    bool AsmJsScriptFunction::IsWasmScriptFunction(Var func)
-    {
-        return ScriptFunction::Is(func) &&
-            ScriptFunction::FromVar(func)->HasFunctionBody() &&
-            ScriptFunction::FromVar(func)->GetFunctionBody()->IsWasmFunction();
+        return ScriptFunction::Is(func) && ScriptFunction::FromVar(func)->IsAsmJsFunction();
     }
 
     AsmJsScriptFunction* AsmJsScriptFunction::FromVar(Var func)
@@ -691,6 +682,40 @@ namespace Js
 
         return asmJsFunc;
     }
+
+    Js::JavascriptArrayBuffer** AsmJsScriptFunction::GetAsmJsArrayBufferAddr() const
+    {
+        return (JavascriptArrayBuffer**)(this->GetModuleMemory() + AsmJsModuleMemory::MemoryTableBeginOffset);
+    }
+
+    JavascriptArrayBuffer* AsmJsScriptFunction::GetAsmJsArrayBuffer() const
+    {
+        return *GetAsmJsArrayBufferAddr();
+    }
+
+    bool WasmScriptFunction::Is(Var func)
+    {
+        return ScriptFunction::Is(func) && ScriptFunction::FromVar(func)->IsWasmFunction();
+    }
+
+    WasmScriptFunction* WasmScriptFunction::FromVar(Var func)
+    {
+        Assert(WasmScriptFunction::Is(func));
+        return reinterpret_cast<WasmScriptFunction *>(func);
+    }
+
+    WebAssemblyMemory* WasmScriptFunction::GetWebAssemblyMemory() const
+    {
+        return *(WebAssemblyMemory**)(this->GetModuleMemory() + AsmJsModuleMemory::MemoryTableBeginOffset);
+    }
+
+    WasmScriptFunction::WasmScriptFunction(DynamicType * type) :
+        AsmJsScriptFunction(type), m_signature(nullptr)
+    {}
+
+    WasmScriptFunction::WasmScriptFunction(FunctionProxy * proxy, ScriptFunctionType* deferredPrototypeType) :
+        AsmJsScriptFunction(proxy, deferredPrototypeType), m_signature(nullptr)
+    {}
 
     ScriptFunctionWithInlineCache::ScriptFunctionWithInlineCache(FunctionProxy * proxy, ScriptFunctionType* deferredPrototypeType) :
         ScriptFunction(proxy, deferredPrototypeType), hasOwnInlineCaches(false)

--- a/lib/Runtime/Library/ScriptFunction.cpp
+++ b/lib/Runtime/Library/ScriptFunction.cpp
@@ -644,11 +644,11 @@ namespace Js
 #endif
 
     AsmJsScriptFunction::AsmJsScriptFunction(FunctionProxy * proxy, ScriptFunctionType* deferredPrototypeType) :
-        ScriptFunction(proxy, deferredPrototypeType), m_moduleMemory(nullptr)
+        ScriptFunction(proxy, deferredPrototypeType), m_moduleEnvironment(nullptr)
     {}
 
     AsmJsScriptFunction::AsmJsScriptFunction(DynamicType * type) :
-        ScriptFunction(type), m_moduleMemory(nullptr)
+        ScriptFunction(type), m_moduleEnvironment(nullptr)
     {}
 
     bool AsmJsScriptFunction::Is(Var func)
@@ -685,7 +685,7 @@ namespace Js
 
     Js::JavascriptArrayBuffer** AsmJsScriptFunction::GetAsmJsArrayBufferAddr() const
     {
-        return (JavascriptArrayBuffer**)(this->GetModuleMemory() + AsmJsModuleMemory::MemoryTableBeginOffset);
+        return (JavascriptArrayBuffer**)(this->GetModuleEnvironment() + AsmJsModuleMemory::MemoryTableBeginOffset);
     }
 
     JavascriptArrayBuffer* AsmJsScriptFunction::GetAsmJsArrayBuffer() const
@@ -706,7 +706,7 @@ namespace Js
 
     WebAssemblyMemory* WasmScriptFunction::GetWebAssemblyMemory() const
     {
-        return *(WebAssemblyMemory**)(this->GetModuleMemory() + AsmJsModuleMemory::MemoryTableBeginOffset);
+        return *(WebAssemblyMemory**)(this->GetModuleEnvironment() + AsmJsModuleMemory::MemoryTableBeginOffset);
     }
 
     WasmScriptFunction::WasmScriptFunction(DynamicType * type) :

--- a/lib/Runtime/Library/ScriptFunction.h
+++ b/lib/Runtime/Library/ScriptFunction.h
@@ -97,6 +97,8 @@ namespace Js
         virtual JavascriptString* GetDisplayNameImpl() const;
         JavascriptString* GetComputedName() const;
         virtual bool IsAnonymousFunction() const override;
+        virtual bool IsAsmJsFunction() const { return false; }
+        virtual bool IsWasmFunction() const { return false; }
 
         virtual JavascriptFunction* GetRealFunctionObject() { return this; }
 
@@ -124,19 +126,17 @@ namespace Js
         AsmJsScriptFunction(FunctionProxy * proxy, ScriptFunctionType* deferredPrototypeType);
 
         static bool Is(Var func);
-        static bool IsWasmScriptFunction(Var func);
         static AsmJsScriptFunction* FromVar(Var func);
         static AsmJsScriptFunction * OP_NewAsmJsFunc(FrameDisplay *environment, FunctionInfoPtrPtr infoRef);
 
+        virtual bool IsAsmJsFunction() const { return true; }
+
         void SetModuleMemory(Field(Var)* mem) { m_moduleMemory = mem; }
         Field(Var)* GetModuleMemory() const { return m_moduleMemory; }
-
-#ifdef ENABLE_WASM
-        void SetSignature(Wasm::WasmSignature * sig) { m_signature = sig; }
-        Wasm::WasmSignature * GetSignature() const { return m_signature; }
-        static uint32 GetOffsetOfSignature() { return offsetof(AsmJsScriptFunction, m_signature); }
-#endif
         static uint32 GetOffsetOfModuleMemory() { return offsetof(AsmJsScriptFunction, m_moduleMemory); }
+
+        JavascriptArrayBuffer** GetAsmJsArrayBufferAddr() const;
+        JavascriptArrayBuffer* GetAsmJsArrayBuffer() const;
     protected:
         AsmJsScriptFunction(DynamicType * type);
         DEFINE_VTABLE_CTOR(AsmJsScriptFunction, ScriptFunction);
@@ -144,10 +144,32 @@ namespace Js
 
     private:
         Field(Field(Var)*) m_moduleMemory;
-#ifdef ENABLE_WASM
-        Field(Wasm::WasmSignature *) m_signature;
-#endif
     };
+
+#ifdef ENABLE_WASM
+    class WasmScriptFunction : public AsmJsScriptFunction
+    {
+    public:
+        WasmScriptFunction(FunctionProxy * proxy, ScriptFunctionType* deferredPrototypeType);
+
+        static bool Is(Var func);
+        static WasmScriptFunction* FromVar(Var func);
+
+        void SetSignature(Wasm::WasmSignature * sig) { m_signature = sig; }
+        Wasm::WasmSignature * GetSignature() const { return m_signature; }
+        static uint32 GetOffsetOfSignature() { return offsetof(WasmScriptFunction, m_signature); }
+
+        WebAssemblyMemory* GetWebAssemblyMemory() const;
+
+        virtual bool IsWasmFunction() const { return true; }
+    protected:
+        WasmScriptFunction(DynamicType * type);
+        DEFINE_VTABLE_CTOR(WasmScriptFunction, AsmJsScriptFunction);
+        DEFINE_MARSHAL_OBJECT_TO_SCRIPT_CONTEXT(WasmScriptFunction);
+    private:
+        Field(Wasm::WasmSignature *) m_signature;
+    };
+#endif
 
     class ScriptFunctionWithInlineCache : public ScriptFunction
     {

--- a/lib/Runtime/Library/ScriptFunction.h
+++ b/lib/Runtime/Library/ScriptFunction.h
@@ -129,7 +129,7 @@ namespace Js
         static AsmJsScriptFunction* FromVar(Var func);
         static AsmJsScriptFunction * OP_NewAsmJsFunc(FrameDisplay *environment, FunctionInfoPtrPtr infoRef);
 
-        virtual bool IsAsmJsFunction() const { return true; }
+        virtual bool IsAsmJsFunction() const override { return true; }
 
         void SetModuleEnvironment(Field(Var)* mem) { m_moduleEnvironment = mem; }
         Field(Var)* GetModuleEnvironment() const { return m_moduleEnvironment; }
@@ -160,7 +160,7 @@ namespace Js
 
         WebAssemblyMemory* GetWebAssemblyMemory() const;
 
-        virtual bool IsWasmFunction() const { return true; }
+        virtual bool IsWasmFunction() const override { return true; }
     protected:
         WasmScriptFunction(DynamicType * type);
         DEFINE_VTABLE_CTOR(WasmScriptFunction, AsmJsScriptFunction);

--- a/lib/Runtime/Library/ScriptFunction.h
+++ b/lib/Runtime/Library/ScriptFunction.h
@@ -135,7 +135,6 @@ namespace Js
         Field(Var)* GetModuleEnvironment() const { return m_moduleEnvironment; }
         static uint32 GetOffsetOfModuleMemory() { return offsetof(AsmJsScriptFunction, m_moduleEnvironment); }
 
-        JavascriptArrayBuffer** GetAsmJsArrayBufferAddr() const;
         JavascriptArrayBuffer* GetAsmJsArrayBuffer() const;
     protected:
         AsmJsScriptFunction(DynamicType * type);
@@ -168,6 +167,12 @@ namespace Js
         DEFINE_MARSHAL_OBJECT_TO_SCRIPT_CONTEXT(WasmScriptFunction);
     private:
         Field(Wasm::WasmSignature *) m_signature;
+    };
+#else
+    class WasmScriptFunction
+    {
+    public:
+        static bool Is(Var) { return false; }
     };
 #endif
 

--- a/lib/Runtime/Library/ScriptFunction.h
+++ b/lib/Runtime/Library/ScriptFunction.h
@@ -131,9 +131,9 @@ namespace Js
 
         virtual bool IsAsmJsFunction() const { return true; }
 
-        void SetModuleMemory(Field(Var)* mem) { m_moduleMemory = mem; }
-        Field(Var)* GetModuleMemory() const { return m_moduleMemory; }
-        static uint32 GetOffsetOfModuleMemory() { return offsetof(AsmJsScriptFunction, m_moduleMemory); }
+        void SetModuleEnvironment(Field(Var)* mem) { m_moduleEnvironment = mem; }
+        Field(Var)* GetModuleEnvironment() const { return m_moduleEnvironment; }
+        static uint32 GetOffsetOfModuleMemory() { return offsetof(AsmJsScriptFunction, m_moduleEnvironment); }
 
         JavascriptArrayBuffer** GetAsmJsArrayBufferAddr() const;
         JavascriptArrayBuffer* GetAsmJsArrayBuffer() const;
@@ -143,7 +143,7 @@ namespace Js
         DEFINE_MARSHAL_OBJECT_TO_SCRIPT_CONTEXT(AsmJsScriptFunction);
 
     private:
-        Field(Field(Var)*) m_moduleMemory;
+        Field(Field(Var)*) m_moduleEnvironment;
     };
 
 #ifdef ENABLE_WASM

--- a/lib/Runtime/Library/WasmLibrary.cpp
+++ b/lib/Runtime/Library/WasmLibrary.cpp
@@ -14,7 +14,7 @@ namespace Js
 
     Var WasmLibrary::WasmLazyTrapCallback(RecyclableObject *callee, CallInfo, ...)
     {
-        AsmJsScriptFunction* asmFunction = static_cast<AsmJsScriptFunction*>(callee);
+        WasmScriptFunction* asmFunction = static_cast<WasmScriptFunction*>(callee);
         Assert(asmFunction);
         ScriptContext * scriptContext = asmFunction->GetScriptContext();
         Assert(scriptContext);
@@ -24,7 +24,7 @@ namespace Js
 
     void WasmLibrary::SetWasmEntryPointToInterpreter(Js::ScriptFunction* func, bool deferParse)
     {
-        Assert(AsmJsScriptFunction::Is(func));
+        Assert(WasmScriptFunction::Is(func));
         FunctionEntryPointInfo* entrypointInfo = (FunctionEntryPointInfo*)func->GetEntryPointInfo();
         entrypointInfo->SetIsAsmJSFunction(true);
 

--- a/lib/Runtime/Library/WebAssemblyEnvironment.cpp
+++ b/lib/Runtime/Library/WebAssemblyEnvironment.cpp
@@ -41,7 +41,7 @@ WebAssemblyEnvironment::WebAssemblyEnvironment(WebAssemblyModule* module):
 }
 
 template<typename T>
-void Js::WebAssemblyEnvironment::CheckPtrIsValid(intptr_t ptr) const
+void WebAssemblyEnvironment::CheckPtrIsValid(intptr_t ptr) const
 {
     if (ptr < (intptr_t)PointerValue(start) || (intptr_t)(ptr + sizeof(T)) > (intptr_t)PointerValue(end))
     {
@@ -50,7 +50,7 @@ void Js::WebAssemblyEnvironment::CheckPtrIsValid(intptr_t ptr) const
 }
 
 template<typename T>
-T* Js::WebAssemblyEnvironment::GetVarElement(Field(Var)* ptr, uint32 index, uint32 maxCount) const
+T* WebAssemblyEnvironment::GetVarElement(Field(Var)* ptr, uint32 index, uint32 maxCount) const
 {
     if (index >= maxCount)
     {
@@ -72,7 +72,7 @@ T* Js::WebAssemblyEnvironment::GetVarElement(Field(Var)* ptr, uint32 index, uint
 }
 
 template<typename T>
-void Js::WebAssemblyEnvironment::SetVarElement(Field(Var)* ptr, T* val, uint32 index, uint32 maxCount)
+void WebAssemblyEnvironment::SetVarElement(Field(Var)* ptr, T* val, uint32 index, uint32 maxCount)
 {
     if (index >= maxCount ||
         !T::Is(val))
@@ -86,25 +86,24 @@ void Js::WebAssemblyEnvironment::SetVarElement(Field(Var)* ptr, T* val, uint32 i
     *dst = val;
 }
 
-AsmJsScriptFunction* WebAssemblyEnvironment::GetWasmFunction(uint32 index) const
+WasmScriptFunction* WebAssemblyEnvironment::GetWasmFunction(uint32 index) const
 {
     if (!(module->GetFunctionIndexType(index) == Wasm::FunctionIndexTypes::Function ||
           module->GetFunctionIndexType(index) == Wasm::FunctionIndexTypes::ImportThunk))
     {
         Js::Throw::InternalError();
     }
-    return GetVarElement<AsmJsScriptFunction>(functions, index, module->GetWasmFunctionCount());
+    return GetVarElement<WasmScriptFunction>(functions, index, module->GetWasmFunctionCount());
 }
 
-void WebAssemblyEnvironment::SetWasmFunction(uint32 index, AsmJsScriptFunction* func)
+void WebAssemblyEnvironment::SetWasmFunction(uint32 index, WasmScriptFunction* func)
 {
     if (!(module->GetFunctionIndexType(index) == Wasm::FunctionIndexTypes::Function ||
-          module->GetFunctionIndexType(index) == Wasm::FunctionIndexTypes::ImportThunk) ||
-        !AsmJsScriptFunction::IsWasmScriptFunction(func))
+          module->GetFunctionIndexType(index) == Wasm::FunctionIndexTypes::ImportThunk))
     {
         Js::Throw::InternalError();
     }
-    SetVarElement<AsmJsScriptFunction>(functions, func, index, module->GetWasmFunctionCount());
+    SetVarElement<WasmScriptFunction>(functions, func, index, module->GetWasmFunctionCount());
 }
 
 void WebAssemblyEnvironment::SetImportedFunction(uint32 index, Var importedFunc)

--- a/lib/Runtime/Library/WebAssemblyEnvironment.h
+++ b/lib/Runtime/Library/WebAssemblyEnvironment.h
@@ -22,8 +22,8 @@ namespace Js
 
         Var* GetStartPtr() const { return (Var*)PointerValue(start); }
 
-        AsmJsScriptFunction* GetWasmFunction(uint32 index) const;
-        void SetWasmFunction(uint32 index, AsmJsScriptFunction* func);
+        WasmScriptFunction* GetWasmFunction(uint32 index) const;
+        void SetWasmFunction(uint32 index, WasmScriptFunction* func);
         void SetImportedFunction(uint32 index, Var importedFunc);
         WebAssemblyTable* GetTable(uint32 index) const;
         void SetTable(uint32 index, class WebAssemblyTable* table);

--- a/lib/Runtime/Library/WebAssemblyInstance.cpp
+++ b/lib/Runtime/Library/WebAssemblyInstance.cpp
@@ -131,20 +131,20 @@ WebAssemblyInstance::CreateInstance(WebAssemblyModule * module, Var importObject
     try
     {
         LoadImports(module, scriptContext, importObject, &environment);
-        LoadGlobals(module, scriptContext, &environment);
-        LoadFunctions(module, scriptContext, &environment);
         ValidateTableAndMemory(module, scriptContext, &environment);
+        InitialGlobals(module, scriptContext, &environment);
+        CreateWasmFunctions(module, scriptContext, &environment);
         try
         {
-            LoadDataSegs(module, scriptContext, &environment);
-            LoadIndirectFunctionTable(module, scriptContext, &environment);
+            InitializeDataSegs(module, scriptContext, &environment);
+            InitializeFunctionTable(module, scriptContext, &environment);
         }
         catch (...)
         {
             AssertMsg(UNREACHED, "By spec, we should not have any exceptions possible here");
             throw;
         }
-        newInstance->m_exports = BuildObject(module, scriptContext, &environment);
+        newInstance->m_exports = CreateExportObject(module, scriptContext, &environment);
     }
     catch (Wasm::WasmCompilationException& e)
     {
@@ -154,7 +154,7 @@ WebAssemblyInstance::CreateInstance(WebAssemblyModule * module, Var importObject
     uint32 startFuncIdx = module->GetStartFunction();
     if (startFuncIdx != Js::Constants::UninitializedValue)
     {
-        AsmJsScriptFunction* start = environment.GetWasmFunction(startFuncIdx);
+        WasmScriptFunction* start = environment.GetWasmFunction(startFuncIdx);
         Js::CallInfo info(Js::CallFlags_New, 1);
         Js::Arguments startArg(info, (Var*)&start);
         Js::JavascriptFunction::CallFunction<true>(start, start->GetEntryPoint(), startArg);
@@ -163,7 +163,7 @@ WebAssemblyInstance::CreateInstance(WebAssemblyModule * module, Var importObject
     return newInstance;
 }
 
-void WebAssemblyInstance::LoadFunctions(WebAssemblyModule * wasmModule, ScriptContext* ctx, WebAssemblyEnvironment* env)
+void WebAssemblyInstance::CreateWasmFunctions(WebAssemblyModule * wasmModule, ScriptContext* ctx, WebAssemblyEnvironment* env)
 {
     FrameDisplay * frameDisplay = RecyclerNewPlus(ctx->GetRecycler(), sizeof(void*), FrameDisplay, 1);
     frameDisplay->SetItem(0, env->GetStartPtr());
@@ -176,7 +176,7 @@ void WebAssemblyInstance::LoadFunctions(WebAssemblyModule * wasmModule, ScriptCo
         }
         Wasm::WasmFunctionInfo* wasmFuncInfo = wasmModule->GetWasmFunctionInfo(i);
         FunctionBody* body = wasmFuncInfo->GetBody();
-        AsmJsScriptFunction * funcObj = ctx->GetLibrary()->CreateAsmJsScriptFunction(body);
+        WasmScriptFunction* funcObj = ctx->GetLibrary()->CreateWasmScriptFunction(body);
         funcObj->SetModuleMemory((Field(Var)*)env->GetStartPtr());
         funcObj->SetSignature(body->GetAsmJsFunctionInfo()->GetWasmSignature());
         funcObj->SetEnvironment(frameDisplay);
@@ -210,7 +210,7 @@ void WebAssemblyInstance::LoadFunctions(WebAssemblyModule * wasmModule, ScriptCo
     }
 }
 
-void WebAssemblyInstance::LoadDataSegs(WebAssemblyModule * wasmModule, ScriptContext* ctx, WebAssemblyEnvironment* env)
+void WebAssemblyInstance::InitializeDataSegs(WebAssemblyModule * wasmModule, ScriptContext* ctx, WebAssemblyEnvironment* env)
 {
     WebAssemblyMemory* mem = env->GetMemory(0);
     Assert(mem);
@@ -230,7 +230,7 @@ void WebAssemblyInstance::LoadDataSegs(WebAssemblyModule * wasmModule, ScriptCon
     }
 }
 
-Var WebAssemblyInstance::BuildObject(WebAssemblyModule * wasmModule, ScriptContext* scriptContext, WebAssemblyEnvironment* env)
+Var WebAssemblyInstance::CreateExportObject(WebAssemblyModule * wasmModule, ScriptContext* scriptContext, WebAssemblyEnvironment* env)
 {
     Js::Var exportsNamespace = scriptContext->GetLibrary()->CreateObject(scriptContext->GetLibrary()->GetNull());
     for (uint32 iExport = 0; iExport < wasmModule->GetExportCount(); ++iExport)
@@ -317,10 +317,10 @@ void WebAssemblyInstance::LoadImports(
             Assert(wasmModule->GetFunctionIndexType(counter) == Wasm::FunctionIndexTypes::ImportThunk);
 
             env->SetImportedFunction(counter, prop);
-            if (AsmJsScriptFunction::IsWasmScriptFunction(prop))
+            if (WasmScriptFunction::Is(prop))
             {
                 Assert(env->GetWasmFunction(counter) == nullptr);
-                AsmJsScriptFunction* func = AsmJsScriptFunction::FromVar(prop);
+                WasmScriptFunction* func = WasmScriptFunction::FromVar(prop);
                 if (!wasmModule->GetWasmFunctionInfo(counter)->GetSignature()->IsEquivalent(func->GetSignature()))
                 {
                     char16 temp[2048] = { 0 };
@@ -412,7 +412,7 @@ void WebAssemblyInstance::LoadImports(
     }
 }
 
-void WebAssemblyInstance::LoadGlobals(WebAssemblyModule * wasmModule, ScriptContext* ctx, WebAssemblyEnvironment* env)
+void WebAssemblyInstance::InitialGlobals(WebAssemblyModule * wasmModule, ScriptContext* ctx, WebAssemblyEnvironment* env)
 {
     uint count = wasmModule->GetGlobalCount();
     for (uint i = 0; i < count; i++)
@@ -450,7 +450,7 @@ void WebAssemblyInstance::LoadGlobals(WebAssemblyModule * wasmModule, ScriptCont
     }
 }
 
-void WebAssemblyInstance::LoadIndirectFunctionTable(WebAssemblyModule * wasmModule, ScriptContext* ctx, WebAssemblyEnvironment* env)
+void WebAssemblyInstance::InitializeFunctionTable(WebAssemblyModule * wasmModule, ScriptContext* ctx, WebAssemblyEnvironment* env)
 {
     WebAssemblyTable* table = env->GetTable(0);
     Assert(table != nullptr);

--- a/lib/Runtime/Library/WebAssemblyInstance.cpp
+++ b/lib/Runtime/Library/WebAssemblyInstance.cpp
@@ -165,8 +165,7 @@ WebAssemblyInstance::CreateInstance(WebAssemblyModule * module, Var importObject
 
 void WebAssemblyInstance::CreateWasmFunctions(WebAssemblyModule * wasmModule, ScriptContext* ctx, WebAssemblyEnvironment* env)
 {
-    FrameDisplay * frameDisplay = RecyclerNewPlus(ctx->GetRecycler(), sizeof(void*), FrameDisplay, 1);
-    frameDisplay->SetItem(0, env->GetStartPtr());
+    FrameDisplay * frameDisplay = RecyclerNewPlus(ctx->GetRecycler(), sizeof(void*), FrameDisplay, 0);
 
     for (uint i = 0; i < wasmModule->GetWasmFunctionCount(); ++i)
     {
@@ -177,7 +176,7 @@ void WebAssemblyInstance::CreateWasmFunctions(WebAssemblyModule * wasmModule, Sc
         Wasm::WasmFunctionInfo* wasmFuncInfo = wasmModule->GetWasmFunctionInfo(i);
         FunctionBody* body = wasmFuncInfo->GetBody();
         WasmScriptFunction* funcObj = ctx->GetLibrary()->CreateWasmScriptFunction(body);
-        funcObj->SetModuleMemory((Field(Var)*)env->GetStartPtr());
+        funcObj->SetModuleEnvironment((Field(Var)*)env->GetStartPtr());
         funcObj->SetSignature(body->GetAsmJsFunctionInfo()->GetWasmSignature());
         funcObj->SetEnvironment(frameDisplay);
 

--- a/lib/Runtime/Library/WebAssemblyInstance.h
+++ b/lib/Runtime/Library/WebAssemblyInstance.h
@@ -32,12 +32,12 @@ namespace Js
     private:
         WebAssemblyInstance(WebAssemblyModule * wasmModule, DynamicType * type);
 
-        static void LoadDataSegs(WebAssemblyModule * wasmModule, ScriptContext* ctx, WebAssemblyEnvironment* env);
-        static void LoadFunctions(WebAssemblyModule * wasmModule, ScriptContext* ctx, WebAssemblyEnvironment* env);
-        static Var  BuildObject(WebAssemblyModule * wasmModule, ScriptContext* ctx, WebAssemblyEnvironment* env);
+        static void InitializeDataSegs(WebAssemblyModule * wasmModule, ScriptContext* ctx, WebAssemblyEnvironment* env);
+        static void CreateWasmFunctions(WebAssemblyModule * wasmModule, ScriptContext* ctx, WebAssemblyEnvironment* env);
+        static Var  CreateExportObject(WebAssemblyModule * wasmModule, ScriptContext* ctx, WebAssemblyEnvironment* env);
         static void LoadImports(WebAssemblyModule * wasmModule, ScriptContext* ctx, Var ffi, WebAssemblyEnvironment* env);
-        static void LoadGlobals(WebAssemblyModule * wasmModule, ScriptContext* ctx, WebAssemblyEnvironment* env);
-        static void LoadIndirectFunctionTable(WebAssemblyModule * wasmModule, ScriptContext* ctx, WebAssemblyEnvironment* env);
+        static void InitialGlobals(WebAssemblyModule * wasmModule, ScriptContext* ctx, WebAssemblyEnvironment* env);
+        static void InitializeFunctionTable(WebAssemblyModule * wasmModule, ScriptContext* ctx, WebAssemblyEnvironment* env);
         static void ValidateTableAndMemory(WebAssemblyModule * wasmModule, ScriptContext* ctx, WebAssemblyEnvironment* env);
 
         Field(WebAssemblyModule *) m_module;

--- a/lib/Runtime/Library/WebAssemblyModule.cpp
+++ b/lib/Runtime/Library/WebAssemblyModule.cpp
@@ -290,7 +290,7 @@ WebAssemblyModule::ValidateModule(
             if (PHASE_ON(WasmValidatePrejitPhase, body))
             {
                 CONFIG_FLAG(MaxAsmJsInterpreterRunCount) = 0;
-                AsmJsScriptFunction * funcObj = scriptContext->GetLibrary()->CreateAsmJsScriptFunction(body);
+                WasmScriptFunction * funcObj = scriptContext->GetLibrary()->CreateWasmScriptFunction(body);
                 FunctionEntryPointInfo * entrypointInfo = (FunctionEntryPointInfo*)funcObj->GetEntryPointInfo();
                 entrypointInfo->SetIsAsmJSFunction(true);
                 GenerateFunction(scriptContext->GetNativeCodeGenerator(), body, funcObj);

--- a/lib/Runtime/Library/WebAssemblyTable.cpp
+++ b/lib/Runtime/Library/WebAssemblyTable.cpp
@@ -194,7 +194,7 @@ WebAssemblyTable::EntrySet(RecyclableObject* function, CallInfo callInfo, ...)
     {
         value = nullptr;
     }
-    else if (!AsmJsScriptFunction::IsWasmScriptFunction(args[2]))
+    else if (!WasmScriptFunction::Is(args[2]))
     {
         JavascriptError::ThrowTypeError(scriptContext, WASMERR_NeedWebAssemblyFunc);
     }
@@ -229,7 +229,7 @@ void
 WebAssemblyTable::DirectSetValue(uint index, Var val)
 {
     Assert(index < m_currentLength);
-    Assert(!val || AsmJsScriptFunction::Is(val));
+    Assert(!val || WasmScriptFunction::Is(val));
     m_values[index] = val;
 }
 
@@ -238,7 +238,7 @@ WebAssemblyTable::DirectGetValue(uint index) const
 {
     Assert(index < m_currentLength);
     Var val = m_values[index];
-    Assert(!val || AsmJsScriptFunction::Is(val));
+    Assert(!val || WasmScriptFunction::Is(val));
     return val;
 }
 

--- a/lib/Runtime/Runtime.h
+++ b/lib/Runtime/Runtime.h
@@ -202,6 +202,7 @@ namespace Js
     class JavascriptGeneratorFunction;
     class JavascriptAsyncFunction;
     class AsmJsScriptFunction;
+    class WasmScriptFunction;
     class JavascriptRegExpConstructor;
     class JavascriptRegExpEnumerator;
     class BoundFunction;


### PR DESCRIPTION
- Stop using the FrameDisplay to store the ModuleEnvironment, it is available on the function itself instead
- Add new WasmScriptFunction for WebAssembly to ease how we check if it's a WasmFunction or AsmJsFunction
- Cleanup how we get the WebAssemblyMemory and/or JavascriptArrayBuffer.
- Since Asm.js function can't detach the buffer anymore, keep a pointer to the ArrayBuffer in the interpreter instead of an address in the Module Environment
- Some renaming to be more conform with how we call things


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/3586)
<!-- Reviewable:end -->
