### PR TITLE
Keep AutoString::length in sync w/ AutoString::data

### DIFF
--- a/bin/ch/stdafx.h
+++ b/bin/ch/stdafx.h
@@ -201,7 +201,6 @@ public:
             strValue = value;
         }
         int strLen = 0;
-        size_t writtenLen = 0;
         size_t actualLen = 0;
         if (errorCode == JsNoError)
         {
@@ -210,19 +209,19 @@ public:
             {
                 // Assume ascii characters
                 data = (char*)malloc((strLen + 1) * sizeof(char));
-                errorCode = ChakraRTInterface::JsCopyString(strValue, data, strLen, &writtenLen, &actualLen);
+                errorCode = ChakraRTInterface::JsCopyString(strValue, data, strLen, &length, &actualLen);
                 if (errorCode == JsNoError)
                 {
                     // If non-ascii, take slow path
-                    if (writtenLen != actualLen)
+                    if (length != actualLen)
                     {
                         free(data);
                         data = (char*)malloc((actualLen + 1) * sizeof(char));
 
-                        errorCode = ChakraRTInterface::JsCopyString(strValue, data, actualLen + 1, &writtenLen, nullptr);
+                        errorCode = ChakraRTInterface::JsCopyString(strValue, data, actualLen + 1, &length, nullptr);
                         if (errorCode == JsNoError)
                         {
-                            AssertMsg(actualLen == writtenLen, "If you see this message.. There is something seriously wrong. Good Luck!");
+                            AssertMsg(actualLen == length, "If you see this message.. There is something seriously wrong. Good Luck!");
                             
                         }
                     }


### PR DESCRIPTION
This fix makes sure that `AutoString::length` and `AutoString::data` are in sync.
