### PR TITLE
Allow strongRefHeapBlock to be nullptr

### DIFF
--- a/bin/NativeTests/JsRTApiTest.cpp
+++ b/bin/NativeTests/JsRTApiTest.cpp
@@ -133,6 +133,40 @@ namespace JsRTApiTest
         JsRTApiTest::RunWithAttributes(JsRTApiTest::WeakReferenceTest);
     }
 
+    void WeakReferenceTaggedIntTest(JsRuntimeAttributes attributes, JsRuntimeHandle runtime)
+    {
+        JsValueRef valueRef = JS_INVALID_REFERENCE;
+        REQUIRE(JsIntToNumber(25, &valueRef) == JsNoError);
+
+        JsWeakRef weakRef = JS_INVALID_REFERENCE;
+        REQUIRE(JsCreateWeakReference(valueRef, &weakRef) == JsNoError);
+
+        // JsGetWeakReferenceValue should return the original value reference.
+        JsValueRef valueRefFromWeakRef = JS_INVALID_REFERENCE;
+        CHECK(JsGetWeakReferenceValue(weakRef, &valueRefFromWeakRef) == JsNoError);
+        CHECK(valueRefFromWeakRef != JS_INVALID_REFERENCE);
+        CHECK(valueRefFromWeakRef == valueRef);
+
+        // Clear the references on the stack, so that the value will be GC'd.
+        valueRef = JS_INVALID_REFERENCE;
+        valueRefFromWeakRef = JS_INVALID_REFERENCE;
+
+        CHECK(JsCollectGarbage(runtime) == JsNoError);
+
+        // JsGetWeakReferenceValue should return the value even after a GC since
+        // it's not heap allocated.
+        REQUIRE(JsIntToNumber(25, &valueRef) == JsNoError);
+
+        JsValueRef valueRefAfterGC = JS_INVALID_REFERENCE;
+        CHECK(JsGetWeakReferenceValue(weakRef, &valueRefAfterGC) == JsNoError);
+        CHECK(valueRefAfterGC == valueRef);
+    }
+
+    TEST_CASE("ApiTest_WeakReferenceTaggedIntTest", "[ApiTest]")
+    {
+        JsRTApiTest::RunWithAttributes(JsRTApiTest::WeakReferenceTaggedIntTest);
+    }
+
     void ObjectsAndPropertiesTest1(JsRuntimeAttributes attributes, JsRuntimeHandle runtime)
     {
         JsValueRef object = JS_INVALID_REFERENCE;

--- a/lib/Common/Memory/Recycler.cpp
+++ b/lib/Common/Memory/Recycler.cpp
@@ -3118,7 +3118,8 @@ Recycler::SweepWeakReference()
             return false;
         }
 
-        if (!weakRef->strongRefHeapBlock->TestObjectMarkedBit(weakRef->strongRef))
+        if (weakRef->strongRefHeapBlock != nullptr &&
+            !weakRef->strongRefHeapBlock->TestObjectMarkedBit(weakRef->strongRef))
         {
             hasCleanup = true;
             weakRef->strongRef = nullptr;

--- a/lib/Common/Memory/RecyclerWeakReference.h
+++ b/lib/Common/Memory/RecyclerWeakReference.h
@@ -346,7 +346,6 @@ private:
         entry = AllocatorNewBase(Recycler, recycler, AllocWeakReferenceEntry, RecyclerWeakReferenceBase);
         entry->strongRef = strongReference;
         entry->strongRefHeapBlock = recycler->FindHeapBlock(strongReference);
-        Assert(entry->strongRefHeapBlock != nullptr);
 
         HeapBlock * weakRefHeapBlock = recycler->FindHeapBlock(entry);
         Assert(!weakRefHeapBlock->IsLargeHeapBlock() || ((LargeHeapBlock*)weakRefHeapBlock)->InPageHeapMode());


### PR DESCRIPTION
Some objects, like tagged integers, aren't allocated on the heap. In this case there's no strongRefHeapBlock associated with the weak reference.