### PR TITLE
Adding a new enumerator flag to support short-term accesses

### DIFF
--- a/lib/Runtime/Library/JSON.cpp
+++ b/lib/Runtime/Library/JSON.cpp
@@ -638,7 +638,7 @@ namespace JSON
             {
                 uint32 precisePropertyCount = 0;
                 Js::JavascriptStaticEnumerator enumerator;
-                if (object->GetEnumerator(&enumerator, EnumeratorFlags::SnapShotSemantics, scriptContext))
+                if (object->GetEnumerator(&enumerator, EnumeratorFlags::SnapShotSemantics | EnumeratorFlags::EphemeralReference, scriptContext))
                 {
                     bool isPrecise;
                     uint32 propertyCount = GetPropertyCount(object, &enumerator, &isPrecise);

--- a/lib/Runtime/Library/JSON.cpp
+++ b/lib/Runtime/Library/JSON.cpp
@@ -433,9 +433,20 @@ namespace JSON
         // can end up being serialized. Well, that is the ES5 spec word.
         //if(!Js::RecyclableObject::FromVar(holder)->GetType()->GetProperty(holder, keyId, &value))
 
-        if(!Js::JavascriptOperators::GetProperty(Js::RecyclableObject::FromVar(holder),keyId, &value, scriptContext))
+        if (VirtualTableInfo<Js::PropertyString>::HasVirtualTable(key))
         {
-            return scriptContext->GetLibrary()->GetUndefined();
+            PropertyValueInfo info;
+            Js::PropertyString* propertyString = (Js::PropertyString*)key;
+            PropertyValueInfo::SetCacheInfo(&info, propertyString, propertyString->GetLdElemInlineCache(), false);
+            CacheOperators::TryGetProperty<true, false, true, false, true, false, false, true, false>(holder, false, Js::RecyclableObject::FromVar(holder), keyId, &value, scriptContext, nullptr, &info);
+        }
+
+        if (value == nullptr)
+        {
+            if (!Js::JavascriptOperators::GetProperty(Js::RecyclableObject::FromVar(holder), keyId, &value, scriptContext))
+            {
+                return scriptContext->GetLibrary()->GetUndefined();
+            }
         }
         return StrHelper(key, value, holder);
     }

--- a/lib/Runtime/Library/RuntimeLibraryPch.h
+++ b/lib/Runtime/Library/RuntimeLibraryPch.h
@@ -88,9 +88,11 @@
 
 #include "Language/JavascriptStackWalker.h"
 #include "Language/CacheOperators.h"
+#include "Types/TypePropertyCache.h"
 // .inl files
 #include "Library/JavascriptString.inl"
 #include "Library/ConcatString.inl"
+#include "Language/CacheOperators.inl"
 
 #ifdef INTL_ICU
 #define U_STATIC_IMPLEMENTATION

--- a/lib/Runtime/Types/DynamicObjectPropertyEnumerator.cpp
+++ b/lib/Runtime/Types/DynamicObjectPropertyEnumerator.cpp
@@ -251,10 +251,10 @@ namespace Js
             }
         } while (Js::IsInternalPropertyId(propertyId));
 
-        if ((!(this->flags & EnumeratorFlags::EphemeralReference)) && info.GetPropertyString() != nullptr && info.GetPropertyString()->ShouldUseCache() && propertyString == info.GetPropertyString())
+        if (info.GetPropertyString() != nullptr && info.GetPropertyString()->ShouldUseCache() && propertyString == info.GetPropertyString())
         {
             CacheOperators::CachePropertyRead(startingObject, this->object, false, propertyId, false, &info, scriptContext);
-            if (info.IsStoreFieldCacheEnabled() && info.IsWritable() && ((info.GetFlags() & (InlineCacheGetterFlag | InlineCacheSetterFlag)) == 0))
+            if ((!(this->flags & EnumeratorFlags::EphemeralReference)) && info.IsStoreFieldCacheEnabled() && info.IsWritable() && ((info.GetFlags() & (InlineCacheGetterFlag | InlineCacheSetterFlag)) == 0))
             {
                 PropertyValueInfo::SetCacheInfo(&info, info.GetPropertyString(), info.GetPropertyString()->GetStElemInlineCache(), info.AllowResizingPolymorphicInlineCache());
                 CacheOperators::CachePropertyWrite(this->object, false, this->object->GetType(), propertyId, &info, scriptContext);

--- a/lib/Runtime/Types/DynamicObjectPropertyEnumerator.cpp
+++ b/lib/Runtime/Types/DynamicObjectPropertyEnumerator.cpp
@@ -251,7 +251,7 @@ namespace Js
             }
         } while (Js::IsInternalPropertyId(propertyId));
 
-        if (info.GetPropertyString() != nullptr && info.GetPropertyString()->ShouldUseCache() && propertyString == info.GetPropertyString())
+        if ((!(this->flags & EnumeratorFlags::EphemeralReference)) && info.GetPropertyString() != nullptr && info.GetPropertyString()->ShouldUseCache() && propertyString == info.GetPropertyString())
         {
             CacheOperators::CachePropertyRead(startingObject, this->object, false, propertyId, false, &info, scriptContext);
             if (info.IsStoreFieldCacheEnabled() && info.IsWritable() && ((info.GetFlags() & (InlineCacheGetterFlag | InlineCacheSetterFlag)) == 0))

--- a/lib/Runtime/Types/JavascriptStaticEnumerator.h
+++ b/lib/Runtime/Types/JavascriptStaticEnumerator.h
@@ -12,7 +12,8 @@ namespace Js
         EnumNonEnumerable   = 0x1,
         EnumSymbols         = 0x2,
         SnapShotSemantics   = 0x4,
-        UseCache            = 0x8
+        UseCache            = 0x8,
+        EphemeralReference  = 0x10
     };
     ENUM_CLASS_HELPERS(EnumeratorFlags, byte);
 


### PR DESCRIPTION
JSON::Stringify uses enumerators to extract all properties from an object.
By default this enumerator will attempt to populate read/write caches, but
when stringifying an object we are unlikely to access these values again.