### PR TITLE
[MSFT 12988607] Don't bind name references outside the function when completing the function expression scope. 

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -1612,7 +1612,7 @@ void Parser::FinishParseFncExprScope(ParseNodePtr pnodeFnc, ParseNodePtr pnodeFn
     if (pnodeName)
     {
         Assert(pnodeName->nop == knopVarDecl);
-        BindPidRefsInScope(pnodeName->sxVar.pid, pnodeName->sxVar.sym, fncExprScopeId);
+        BindPidRefsInScope(pnodeName->sxVar.pid, pnodeName->sxVar.sym, fncExprScopeId, m_nextBlockId - 1);
     }
     FinishParseBlock(pnodeFncExprScope);
 }

--- a/test/es6/lambda-params-shadow.js
+++ b/test/es6/lambda-params-shadow.js
@@ -33,4 +33,14 @@ if (count !== 4) {
 
 (omabpn = (function(x) {return { getOwnPropertyNames: function(){ switch({}) { case 0:  "" ; }},  }; }), pkgrln = (TypeError(x))) => {};
 
+var error = false;
+try {
+    eval('( oqixuw = function  window () {}, (window)) => undefined;');
+}
+catch(e) {
+    // Above all should throw syntax error on parenthesized name in formals list
+    error = true;    
+}
+if (!error) WScript.Echo('fail');
+
 WScript.Echo('pass');


### PR DESCRIPTION
References to outer bindings may be left on the stack if we're reparsing an arrow function's formals.