### PR TITLE
Adding support for tagged values with JSRT weak reference APIs

### DIFF
--- a/lib/Jsrt/Jsrt.cpp
+++ b/lib/Jsrt/Jsrt.cpp
@@ -4637,6 +4637,13 @@ CHAKRA_API JsCreateWeakReference(
     PARAM_NOT_NULL(weakRef);
     *weakRef = nullptr;
 
+    if (Js::TaggedNumber::Is(value)) {
+        // non-recyclable-objects do not get GCd, so there is no difference
+        // between strong and weak references
+        *weakRef = value;
+        return JsNoError;
+    }
+
     return GlobalAPIWrapper_NoRecord([&]() -> JsErrorCode {
         ThreadContext* threadContext = ThreadContext::GetContextForCurrentThread();
         if (threadContext == nullptr)
@@ -4664,6 +4671,12 @@ CHAKRA_API JsGetWeakReferenceValue(
     VALIDATE_JSREF(weakRef);
     PARAM_NOT_NULL(value);
     *value = JS_INVALID_REFERENCE;
+
+    if (Js::TaggedNumber::Is(weakRef))
+    {
+        *value = weakRef;
+        return JsNoError;
+    }
 
     return GlobalAPIWrapper_NoRecord([&]() -> JsErrorCode {
         Memory::RecyclerWeakReference<char>* recyclerWeakReference =


### PR DESCRIPTION
Tagged values will never be GCd, and don't have correpsonding heap
blocks. Since tagged values are an internal detail, we should handle
it at the JSRT layer, and since tagged values won't be GCd there is
no difference between a strong reference and a weak reference.

Should fix https://github.com/nodejs/node-chakracore/issues/380

Alternative to https://github.com/Microsoft/ChakraCore/pull/3591