### PR TITLE
Detach WebAssemblyArrayBuffer 

### DIFF
--- a/lib/Runtime/Library/ArrayBuffer.cpp
+++ b/lib/Runtime/Library/ArrayBuffer.cpp
@@ -1038,6 +1038,11 @@ namespace Js
 #endif
     }
 
+    ArrayBufferDetachedStateBase* WebAssemblyArrayBuffer::CreateDetachedState(BYTE* buffer, uint32 bufferLength)
+    {
+        JavascriptError::ThrowTypeError(GetScriptContext(), WASMERR_CantDetach);
+    }
+
     WebAssemblyArrayBuffer* WebAssemblyArrayBuffer::GrowMemory(uint32 newBufferLength)
     {
         if (newBufferLength < this->bufferLength)

--- a/lib/Runtime/Library/ArrayBuffer.h
+++ b/lib/Runtime/Library/ArrayBuffer.h
@@ -297,6 +297,9 @@ namespace Js
         virtual bool IsValidVirtualBufferLength(uint length) const override;
         virtual ArrayBuffer * TransferInternal(DECLSPEC_GUARD_OVERFLOW uint32 newBufferLength) override;
         virtual bool IsWebAssemblyArrayBuffer() override { return true; }
+
+    protected:
+        virtual ArrayBufferDetachedStateBase* CreateDetachedState(BYTE* buffer, DECLSPEC_GUARD_OVERFLOW uint32 bufferLength) override;
     };
 
     // the memory must be allocated via CoTaskMemAlloc.


### PR DESCRIPTION
Do not allow WebAssemblyArrayBuffer to be detached by anything other than GrowMemory

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/3620)
<!-- Reviewable:end -->
