### PR TITLE
A few random cleanups.

### DIFF
--- a/lib/Backend/DbCheckPostLower.cpp
+++ b/lib/Backend/DbCheckPostLower.cpp
@@ -262,6 +262,21 @@ void DbCheckPostLower::Check(IR::RegOpnd *regOpnd)
 #endif
         }
     }
+
+    if (regOpnd->GetSym())
+    {
+        StackSym *sym = regOpnd->GetSym()->AsStackSym();
+        IRType tySym = sym->GetType();
+        IRType tyReg = regOpnd->GetType();
+
+        if (!IRType_IsSimd(tySym))
+        {
+            Assert((IRType_IsNativeIntOrVar(tySym) && IRType_IsNativeIntOrVar(tyReg))
+                || (IRType_IsFloat(tySym) && IRType_IsFloat(tyReg)));
+
+            Assert(TySize[tySym] >= TySize[tyReg] || this->func->isPostRegAlloc);
+        }
+    }
 }
 
 #endif // DBG

--- a/lib/Backend/IR.cpp
+++ b/lib/Backend/IR.cpp
@@ -377,10 +377,13 @@ Instr::Free()
     if (this->GetSrc1())
     {
         this->FreeSrc1();
-        if (this->GetSrc2())
-        {
-            this->FreeSrc2();
-        }
+    }
+    if (this->GetSrc2())
+    {
+        // This pattern isn't so unusual:
+        //     src = instr->UnlinkSrc1();
+        //     instr->Remove();
+        this->FreeSrc2();
     }
 
     ClearBailOutInfo();

--- a/lib/Backend/IR.h
+++ b/lib/Backend/IR.h
@@ -456,9 +456,6 @@ private:
     void            SetBailOutKind_NoAssert(const IR::BailOutKind bailOutKind);
 
 public:
-    // used only for SIMD Ld/St from typed arrays.
-    // we keep these here to avoid increase in number of opcodes and to not use ExtendedArgs
-    uint8           dataWidth;
 
 #ifdef BAILOUT_INJECTION
     uint            bailOutByteCodeLocation;
@@ -472,6 +469,11 @@ public:
     // These should be together to pack into a uint32
     Js::OpCode      m_opcode;
     uint8           ignoreOverflowBitCount;      // Number of bits after which ovf matters. Currently used for MULs.
+
+    // used only for SIMD Ld/St from typed arrays.
+    // we keep these here to avoid increase in number of opcodes and to not use ExtendedArgs
+    uint8           dataWidth;
+
 
     bool            isFsBased : 1; // TEMP : just for BS testing
     bool            dstIsTempNumber : 1;

--- a/lib/Backend/IRBuilder.cpp
+++ b/lib/Backend/IRBuilder.cpp
@@ -437,7 +437,7 @@ IRBuilder::Build()
         // those as if they are local for the value of the with statement
         this->m_ldSlots = BVFixed::New<JitArenaAllocator>(m_func->GetJITFunctionBody()->GetLocalsCount(), m_tempAlloc);
         this->m_stSlots = BVFixed::New<JitArenaAllocator>(m_func->GetJITFunctionBody()->GetFirstTmpReg(), m_tempAlloc);
-        this->m_loopBodyRetIPSym = StackSym::New(TyInt32, this->m_func);
+        this->m_loopBodyRetIPSym = StackSym::New(TyMachReg, this->m_func);
 #if DBG
         if (m_func->GetJITFunctionBody()->GetTempCount() != 0)
         {

--- a/lib/Backend/IRType.cpp
+++ b/lib/Backend/IRType.cpp
@@ -47,6 +47,11 @@ bool IRType_IsNativeInt(IRType type)
 }
 bool IRType_IsInt64(IRType type) { return type == TyInt64 || type == TyUint64; }
 
+bool IRType_IsNativeIntOrVar(IRType type)
+{
+    return IRType_IsNativeInt(type) || type == TyVar;
+}
+
 bool IRType_IsSimd(IRType type)
 {
     return TyBaseType[type] == IRBaseType_Simd;

--- a/lib/Backend/IRType.h
+++ b/lib/Backend/IRType.h
@@ -29,6 +29,7 @@ extern bool IRType_IsUnsignedInt(IRType type);
 extern bool IRType_IsFloat(IRType type);
 extern bool IRType_IsNative(IRType type);
 extern bool IRType_IsNativeInt(IRType type);
+extern bool IRType_IsNativeIntOrVar(IRType type);
 extern bool IRType_IsInt64(IRType type);
 extern bool IRType_IsSimd(IRType type);
 extern bool IRType_IsSimd128(IRType type);

--- a/lib/Backend/LinearScan.cpp
+++ b/lib/Backend/LinearScan.cpp
@@ -3353,7 +3353,7 @@ LinearScan::InsertLoad(IR::Instr *instr, StackSym *sym, RegNum reg)
         else
         {
             StackSym * oldSym = sym;
-            sym = StackSym::New(TyVar, this->func);
+            sym = StackSym::New(sym->GetType(), this->func);
             sym->m_isConst = true;
             sym->m_isIntConst = oldSym->m_isIntConst;
             sym->m_isInt64Const = oldSym->m_isInt64Const;
@@ -4182,7 +4182,7 @@ LinearScan::ReconcileRegContent(Lifetime ** branchRegContent, Lifetime **labelRe
     }
     else
     {
-        Assert(type == TyFloat64 || IRType_IsSimd128(type));
+        Assert(type == TyFloat64 || IRType_IsSimd(type));
 
         FOREACH_FLOAT_REG(regIter)
         {
@@ -4611,7 +4611,7 @@ LinearScan::SaveRegContent(IR::Instr *instr)
 
 bool LinearScan::RegsAvailable(IRType type)
 {
-    if (IRType_IsFloat(type) || IRType_IsSimd128(type))
+    if (IRType_IsFloat(type) || IRType_IsSimd(type))
     {
         return (this->floatRegUsedCount < FLOAT_REG_COUNT);
     }

--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -11545,6 +11545,7 @@ Lowerer::LowerBailOnNotStackArgs(IR::Instr * instr)
     {
         //BailOut if the number of actuals (except "this" argument) is greater than or equal to 15.
         IR::RegOpnd* ldLenDstOpnd = IR::RegOpnd::New(TyUint32, instr->m_func);
+        const IR::AutoReuseOpnd autoReuseldLenDstOpnd(ldLenDstOpnd, instr->m_func);
         IR::Instr* ldLen = IR::Instr::New(Js::OpCode::LdLen_A, ldLenDstOpnd, instr->m_func);
         ldLenDstOpnd->SetValueType(ValueType::GetTaggedInt()); //LdLen_A works only on stack arguments
         instr->InsertBefore(ldLen);
@@ -19535,7 +19536,8 @@ Lowerer::GenerateArgOutForStackArgs(IR::Instr* callInstr, IR::Instr* stackArgsIn
     IR::RegOpnd* stackArgs = stackArgsInstr->GetSrc1()->AsRegOpnd();
 
     IR::RegOpnd* ldLenDstOpnd = IR::RegOpnd::New(TyMachReg, func);
-    IR::Instr* ldLen = IR::Instr::New(Js::OpCode::LdLen_A, ldLenDstOpnd ,stackArgs, func);
+    const IR::AutoReuseOpnd autoReuseLdLenDstOpnd(ldLenDstOpnd, func);
+    IR::Instr* ldLen = IR::Instr::New(Js::OpCode::LdLen_A, ldLenDstOpnd, stackArgs, func);
     ldLenDstOpnd->SetValueType(ValueType::GetTaggedInt()); /*LdLen_A works only on stack arguments*/
     callInstr->InsertBefore(ldLen);
     GenerateFastRealStackArgumentsLdLen(ldLen);
@@ -19563,6 +19565,7 @@ Lowerer::GenerateArgOutForStackArgs(IR::Instr* callInstr, IR::Instr* stackArgsIn
 
     IR::IndirOpnd *nthArgument = IR::IndirOpnd::New(stackArgs, ldLenDstOpnd, TyMachReg, func);
     IR::RegOpnd* ldElemDstOpnd = IR::RegOpnd::New(TyMachReg,func);
+    const IR::AutoReuseOpnd autoReuseldElemDstOpnd(ldElemDstOpnd, func);
     IR::Instr* ldElem = IR::Instr::New(Js::OpCode::LdElemI_A, ldElemDstOpnd, nthArgument, func);
     callInstr->InsertBefore(ldElem);
     GenerateFastStackArgumentsLdElemI(ldElem);
@@ -19586,6 +19589,7 @@ Lowerer::GenerateArgOutForStackArgs(IR::Instr* callInstr, IR::Instr* stackArgsIn
 
     nthArgument = IR::IndirOpnd::New(stackArgs, ldLenDstOpnd, TyMachReg, func);
     ldElemDstOpnd = IR::RegOpnd::New(TyMachReg,func);
+    const IR::AutoReuseOpnd autoReuseldElemDstOpnd2(ldElemDstOpnd, func);
     ldElem = IR::Instr::New(Js::OpCode::LdElemI_A, ldElemDstOpnd, nthArgument, func);
     callInstr->InsertBefore(ldElem);
     GenerateFastStackArgumentsLdElemI(ldElem);
@@ -22531,6 +22535,7 @@ Lowerer::GenerateFastCmTypeOf(IR::Instr *compare, IR::RegOpnd *object, IR::IntCo
     else // Other primitive types don't need helper
     {
         typeOf->Remove();
+        dst = compare->UnlinkDst()->AsRegOpnd();
         compare->Remove();
         *pfNoLower = true;
     }

--- a/lib/Backend/LowerMDShared.cpp
+++ b/lib/Backend/LowerMDShared.cpp
@@ -9409,7 +9409,7 @@ void LowererMD::GenerateFastInlineBuiltInCall(IR::Instr* instr, IR::JnHelperMeth
 
 void LowererMD::GenerateFastInlineBuiltInMathAbs(IR::Instr* inlineInstr)
 {
-    IR::Opnd* src = inlineInstr->GetSrc1();
+    IR::Opnd* src = inlineInstr->GetSrc1()->Copy(this->m_func);
     IR::Opnd* dst = inlineInstr->UnlinkDst();
     Assert(src);
     IR::Instr* tmpInstr;

--- a/lib/Backend/amd64/Reg.h
+++ b/lib/Backend/amd64/Reg.h
@@ -11,7 +11,7 @@
 #define RA_BYTEABLE         0x8
 
 
-enum RegNum {
+enum RegNum : BYTE {
 #define REGDAT(Name, Listing,    Encode,    Type,    BitVec)  Reg ## Name,
 #include "RegList.h"
     RegNumCount,

--- a/lib/Backend/i386/LowererMDArch.cpp
+++ b/lib/Backend/i386/LowererMDArch.cpp
@@ -4104,6 +4104,7 @@ LowererMDArch::GenerateArgOutForStackArgs(IR::Instr* callInstr, IR::Instr* stack
     IR::RegOpnd* stackArgs = stackArgsInstr->GetSrc1()->AsRegOpnd();
 
     IR::RegOpnd* ldLenDstOpnd = IR::RegOpnd::New(TyUint32, func);
+    const IR::AutoReuseOpnd autoReuseLdLenDstOpnd(ldLenDstOpnd, func);
     IR::Instr* ldLen = IR::Instr::New(Js::OpCode::LdLen_A, ldLenDstOpnd, stackArgs, func);
     ldLenDstOpnd->SetValueType(ValueType::GetTaggedInt()); // LdLen_A works only on stack arguments
     callInstr->InsertBefore(ldLen);
@@ -4129,6 +4130,7 @@ LowererMDArch::GenerateArgOutForStackArgs(IR::Instr* callInstr, IR::Instr* stack
     IR::IndirOpnd *nthArgument = IR::IndirOpnd::New(stackArgs, ldLenDstOpnd, TyMachReg, func);
     nthArgument->SetOffset(-1);
     IR::RegOpnd* ldElemDstOpnd = IR::RegOpnd::New(TyMachReg,func);
+    const IR::AutoReuseOpnd autoReuseldElemDstOpnd(ldElemDstOpnd, func);
     IR::Instr* ldElem = IR::Instr::New(Js::OpCode::LdElemI_A, ldElemDstOpnd, nthArgument, func);
     callInstr->InsertBefore(ldElem);
     this->lowererMD->m_lowerer->GenerateFastStackArgumentsLdElemI(ldElem);


### PR DESCRIPTION
Add assert to dbcheck to ensure sym type consistency.
Some better structure packing.  Make RegNum a BYTE instead of an int32.

Free srcs/dst during instr->Remove(). This reduces memory allocated in the func arean by about %2...
