### PR TITLE
Remove undefined functions in ScriptContext.h

### DIFF
--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -914,7 +914,6 @@ private:
         char16 const * url;
 
         void PrintStats();
-        BOOL LeaveScriptStartCore(void * frameAddress, bool leaveForHost);
 
         void InternalClose();
 
@@ -1065,7 +1064,6 @@ private:
 
         template <typename TCacheType>
         void CleanDynamicFunctionCache(TCacheType* cacheType);
-        void CleanEvalMapCache(Js::EvalCacheTopLevelDictionary * cacheType);
 
         template <class TDelegate>
         void MapFunction(TDelegate mapper);
@@ -1201,7 +1199,6 @@ private:
         void SetFastDOMenabled();
         BOOL VerifyAlive(BOOL isJSFunction = FALSE, ScriptContext* requestScriptContext = nullptr);
         void VerifyAliveWithHostContext(BOOL isJSFunction, HostScriptContext* requestHostScriptContext);
-        void AddFunctionBodyToPropIdMap(FunctionBody* body);
 
         void BindReference(void* addr);
 


### PR DESCRIPTION
These member functions are declared in ScriptContext.h, but are not defined in ScriptContext.cpp:
[LeaveScriptStartCore](https://github.com/Microsoft/ChakraCore/search?q=LeaveScriptStartCore), [CleanEvalMapCache](https://github.com/Microsoft/ChakraCore/search?q=CleanEvalMapCache), [AddFunctionBodyToPropIdMap](https://github.com/Microsoft/ChakraCore/search?q=AddFunctionBodyToPropIdMap).

I wonder if we can remove them, since they are not used.