### PR TITLE
Numbers up to 10^21 shouldn't be displayed exponentially (Fixes #2751)

### DIFF
--- a/lib/Common/Common/NumberUtilities_strtod.cpp
+++ b/lib/Common/Common/NumberUtilities_strtod.cpp
@@ -2528,7 +2528,7 @@ BOOL Js::NumberUtilities::FNonZeroFiniteDblToStr(double dbl, _In_range_(2, 36) i
     maxOutDigits = g_rgcchSig[radix];
     __analysis_assume(maxOutDigits > 0);
 
-    if (wExp2 < -60 || wExp2 > 60)
+    if (dbl < 1e-21 || dbl > 1e+21)
     {
         // Use exponential notation. Get the exponent and normalize.
         if (cbitDigit != 0)

--- a/test/Number/toString_3.baseline
+++ b/test/Number/toString_3.baseline
@@ -116,10 +116,10 @@ n.toPrecision(20):  0.0000000000000000000
 Test: 1e21
 n.toString():  1e+21
 n.toString(10):  1e+21
-n.toString(8):  1.5432711533427365(e+23)
-n.toString(2):  1.101100011010111001001101011011100010111011110101(e+69)
-n.toString(16):  3.635c9adc5dea(e+17)
-n.toString(25):  1.1l259oooooof(e+15)
+n.toString(8):  154327115334273650000000
+n.toString(2):  1101100011010111001001101011011100010111011110101000000000000000000000
+n.toString(16):  3635c9adc5dea00000
+n.toString(25):  11l259ooooooo5ie
 n.toFixed():  1e+21
 n.toFixed(0):  1e+21
 n.toFixed(2):  1e+21


### PR DESCRIPTION
The spec section 7.1.12.1 requires that if a number's base 10 logarithm is <= 21, then it shouldn't use exponential notation when it's converted to String. The original code checks if the base 2 logarithm of the number is <= 60.

This fixes #2751.