### PR TITLE
Jsrt: External data support for DynamicObject [experiment PR]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ test/benchmarks/*.dpl
 test/benchmarks/*.txt
 testout*
 packages.config
+lib/wabt/built/config.h
 
 # CMake Files
 cmake_install.cmake

--- a/bin/NativeTests/JsRTApiTest.cpp
+++ b/bin/NativeTests/JsRTApiTest.cpp
@@ -10,6 +10,16 @@
 #pragma warning(disable:6387) // suppressing preFAST which raises warning for passing null to the JsRT APIs
 #pragma warning(disable:6262) // CATCH is using stack variables to report errors, suppressing the preFAST warning.
 
+#ifndef NTBUILD
+#define JS_HAS_EXTERNAL_DATA JsObjectHasExternalData
+#define JS_GET_EXTERNAL_DATA JsObjectGetExternalData
+#define JS_SET_EXTERNAL_DATA JsObjectSetExternalData
+#else
+#define JS_HAS_EXTERNAL_DATA JsHasExternalData
+#define JS_GET_EXTERNAL_DATA JsGetExternalData
+#define JS_SET_EXTERNAL_DATA JsSetExternalData
+#endif
+
 namespace JsRTApiTest
 {
     bool TestSetup(JsRuntimeAttributes attributes, JsRuntimeHandle *runtime)
@@ -283,7 +293,7 @@ namespace JsRTApiTest
         REQUIRE(JsSetIndexedProperty(mainObjectRef, indexRef, secondValueRef) == JsNoError);
         REQUIRE(JsSetIndexedProperty(mainObjectRef, indexRef, secondObjectRef) == JsNoError);
         REQUIRE(JsSetPrototype(jsrtExternalObjectRef, mainObjectRef) == JsNoError);
-        REQUIRE(JsHasExternalData(jsrtExternalObjectRef, &hasExternalData) == JsNoError);
+        REQUIRE(JS_HAS_EXTERNAL_DATA(jsrtExternalObjectRef, &hasExternalData) == JsNoError);
         REQUIRE(hasExternalData);
     }
 

--- a/bin/ch/ChakraRtInterface.cpp
+++ b/bin/ch/ChakraRtInterface.cpp
@@ -99,8 +99,8 @@ bool ChakraRTInterface::LoadChakraDll(ArgInfo* argInfo, HINSTANCE *outLibrary)
     m_jsApiHooks.pfJsrtNumberToDouble = (JsAPIHooks::JsrtNumberToDoublePtr)GetChakraCoreSymbol(library, "JsNumberToDouble");
     m_jsApiHooks.pfJsrtNumberToInt = (JsAPIHooks::JsrtNumberToIntPtr)GetChakraCoreSymbol(library, "JsNumberToInt");
     m_jsApiHooks.pfJsrtDoubleToNumber = (JsAPIHooks::JsrtDoubleToNumberPtr)GetChakraCoreSymbol(library, "JsDoubleToNumber");
-    m_jsApiHooks.pfJsrtGetExternalData = (JsAPIHooks::JsrtGetExternalDataPtr)GetChakraCoreSymbol(library, "JsGetExternalData");
-    m_jsApiHooks.pfJsrtSetExternalData = (JsAPIHooks::JsrtSetExternalDataPtr)GetChakraCoreSymbol(library, "JsSetExternalData");
+    m_jsApiHooks.pfJsrtObjectGetExternalData = (JsAPIHooks::JsrtObjectGetExternalDataPtr)GetChakraCoreSymbol(library, "JsObjectGetExternalData");
+    m_jsApiHooks.pfJsrtObjectSetExternalData = (JsAPIHooks::JsrtObjectSetExternalDataPtr)GetChakraCoreSymbol(library, "JsObjectSetExternalData");
     m_jsApiHooks.pfJsrtCreateArray = (JsAPIHooks::JsrtCreateArrayPtr)GetChakraCoreSymbol(library, "JsCreateArray");
     m_jsApiHooks.pfJsrtCreateArrayBuffer = (JsAPIHooks::JsrtCreateArrayBufferPtr)GetChakraCoreSymbol(library, "JsCreateArrayBuffer");
     m_jsApiHooks.pfJsrtCreateSharedArrayBufferWithSharedContent = (JsAPIHooks::JsrtCreateSharedArrayBufferWithSharedContentPtr)GetChakraCoreSymbol(library, "JsCreateSharedArrayBufferWithSharedContent");

--- a/bin/ch/ChakraRtInterface.h
+++ b/bin/ch/ChakraRtInterface.h
@@ -35,8 +35,8 @@ struct JsAPIHooks
     typedef JsErrorCode (WINAPI *JsrtNumberToDoublePtr)(JsValueRef value, double *doubleValue);
     typedef JsErrorCode (WINAPI *JsrtNumberToIntPtr)(JsValueRef value, int *intValue);
     typedef JsErrorCode (WINAPI *JsrtDoubleToNumberPtr)(double doubleValue, JsValueRef* value);
-    typedef JsErrorCode (WINAPI *JsrtGetExternalDataPtr)(JsValueRef object, void **data);
-    typedef JsErrorCode (WINAPI *JsrtSetExternalDataPtr)(JsValueRef object, void *data);
+    typedef JsErrorCode (WINAPI *JsrtObjectGetExternalDataPtr)(JsValueRef object, void **data);
+    typedef JsErrorCode (WINAPI *JsrtObjectSetExternalDataPtr)(JsValueRef object, void *data);
     typedef JsErrorCode (WINAPI *JsrtCreateArrayPtr)(unsigned int length, JsValueRef *result);
     typedef JsErrorCode (WINAPI *JsrtCreateArrayBufferPtr)(unsigned int byteLength, JsValueRef *result);
     typedef JsErrorCode (WINAPI *JsrtCreateSharedArrayBufferWithSharedContentPtr)(JsSharedArrayBufferContentHandle sharedContent, JsValueRef *result);
@@ -81,7 +81,7 @@ struct JsAPIHooks
     typedef JsErrorCode(WINAPI *JsrtCopyString)(JsValueRef value, char* buffer, size_t bufferSize, size_t* length);
     typedef JsErrorCode(WINAPI *JsrtCreateString)(const char *content, size_t length, JsValueRef *value);
     typedef JsErrorCode(WINAPI *JsrtCreateStringUtf16)(const uint16_t *content, size_t length, JsValueRef *value);
-    
+
     typedef JsErrorCode(WINAPI *JsrtCreateExternalArrayBuffer)(void *data, unsigned int byteLength, JsFinalizeCallback finalizeCallback, void *callbackState, JsValueRef *result);
     typedef JsErrorCode(WINAPI *JsrtCreatePropertyId)(const char *name, size_t length, JsPropertyIdRef *propertyId);
 
@@ -132,12 +132,12 @@ struct JsAPIHooks
     JsrtNumberToDoublePtr pfJsrtNumberToDouble;
     JsrtNumberToIntPtr pfJsrtNumberToInt;
     JsrtDoubleToNumberPtr pfJsrtDoubleToNumber;
-    JsrtGetExternalDataPtr pfJsrtGetExternalData;
-    JsrtSetExternalDataPtr pfJsrtSetExternalData;
+    JsrtObjectGetExternalDataPtr pfJsrtObjectGetExternalData;
+    JsrtObjectSetExternalDataPtr pfJsrtObjectSetExternalData;
     JsrtCreateArrayPtr pfJsrtCreateArray;
     JsrtCreateArrayBufferPtr pfJsrtCreateArrayBuffer;
     JsrtCreateSharedArrayBufferWithSharedContentPtr pfJsrtCreateSharedArrayBufferWithSharedContent;
-    JsrtGetSharedArrayBufferContentPtr pfJsrtGetSharedArrayBufferContent;    
+    JsrtGetSharedArrayBufferContentPtr pfJsrtGetSharedArrayBufferContent;
     JsrtReleaseSharedArrayBufferContentHandlePtr pfJsrtReleaseSharedArrayBufferContentHandle;
     JsrtGetArrayBufferStoragePtr pfJsrtGetArrayBufferStorage;
     JsrtCreateErrorPtr pfJsrtCreateError;
@@ -333,8 +333,8 @@ public:
     static JsErrorCode WINAPI JsNumberToDouble(JsValueRef value, double* doubleValue) { return HOOK_JS_API(NumberToDouble(value, doubleValue)); }
     static JsErrorCode WINAPI JsNumberToInt(JsValueRef value, int* intValue) { return HOOK_JS_API(NumberToInt(value, intValue)); }
     static JsErrorCode WINAPI JsDoubleToNumber(double doubleValue, JsValueRef* value) { return HOOK_JS_API(DoubleToNumber(doubleValue, value)); }
-    static JsErrorCode WINAPI JsGetExternalData(JsValueRef object, void **data) { return HOOK_JS_API(GetExternalData(object, data)); }
-    static JsErrorCode WINAPI JsSetExternalData(JsValueRef object, void *data)  { return HOOK_JS_API(SetExternalData(object, data)); }
+    static JsErrorCode WINAPI JsObjectGetExternalData(JsValueRef object, void **data) { return HOOK_JS_API(ObjectGetExternalData(object, data)); }
+    static JsErrorCode WINAPI JsObjectSetExternalData(JsValueRef object, void *data)  { return HOOK_JS_API(ObjectSetExternalData(object, data)); }
     static JsErrorCode WINAPI JsCreateArray(unsigned int length, JsValueRef *result) { return HOOK_JS_API(CreateArray(length, result)); }
     static JsErrorCode WINAPI JsCreateArrayBuffer(unsigned int byteLength, JsValueRef *result) { return HOOK_JS_API(CreateArrayBuffer(byteLength, result)); }
     static JsErrorCode WINAPI JsCreateSharedArrayBufferWithSharedContent(JsSharedArrayBufferContentHandle sharedContent, JsValueRef *result) { return HOOK_JS_API(CreateSharedArrayBufferWithSharedContent(sharedContent, result)); }

--- a/lib/Backend/ObjTypeSpecFldInfo.cpp
+++ b/lib/Backend/ObjTypeSpecFldInfo.cpp
@@ -344,7 +344,7 @@ ObjTypeSpecFldInfo* ObjTypeSpecFldInfo::CreateFrom(uint id, Js::InlineCache* cac
         if (type != localCache.u.proto.type)
         {
             usesAuxSlot = true;
-            fieldValue = prototypeObject->GetAuxSlot(slotIndex);
+            fieldValue = prototypeObject->GetAuxSlotAt(slotIndex);
         }
         else
         {
@@ -359,7 +359,7 @@ ObjTypeSpecFldInfo* ObjTypeSpecFldInfo::CreateFrom(uint id, Js::InlineCache* cac
         if (type != localCache.u.accessor.type)
         {
             usesAuxSlot = true;
-            fieldValue = localCache.u.accessor.object->GetAuxSlot(slotIndex);
+            fieldValue = localCache.u.accessor.object->GetAuxSlotAt(slotIndex);
         }
         else
         {

--- a/lib/Jsrt/ChakraCommon.h
+++ b/lib/Jsrt/ChakraCommon.h
@@ -1810,51 +1810,6 @@ typedef unsigned short uint16_t;
             _Out_ bool *result);
 
     /// <summary>
-    ///     Determines whether an object is an external object.
-    /// </summary>
-    /// <param name="object">The object.</param>
-    /// <param name="value">Whether the object is an external object.</param>
-    /// <returns>
-    ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
-    /// </returns>
-    CHAKRA_API
-        JsHasExternalData(
-            _In_ JsValueRef object,
-            _Out_ bool *value);
-
-    /// <summary>
-    ///     Retrieves the data from an external object.
-    /// </summary>
-    /// <param name="object">The external object.</param>
-    /// <param name="externalData">
-    ///     The external data stored in the object. Can be null if no external data is stored in the
-    ///     object.
-    /// </param>
-    /// <returns>
-    ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
-    /// </returns>
-    CHAKRA_API
-        JsGetExternalData(
-            _In_ JsValueRef object,
-            _Out_ void **externalData);
-
-    /// <summary>
-    ///     Sets the external data on an external object.
-    /// </summary>
-    /// <param name="object">The external object.</param>
-    /// <param name="externalData">
-    ///     The external data to be stored in the object. Can be null if no external data is
-    ///     to be stored in the object.
-    /// </param>
-    /// <returns>
-    ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
-    /// </returns>
-    CHAKRA_API
-        JsSetExternalData(
-            _In_ JsValueRef object,
-            _In_opt_ void *externalData);
-
-    /// <summary>
     ///     Creates a Javascript array object.
     /// </summary>
     /// <remarks>

--- a/lib/Jsrt/ChakraCommonWindows.h
+++ b/lib/Jsrt/ChakraCommonWindows.h
@@ -364,4 +364,48 @@
             _Outptr_result_buffer_(*stringLength) const wchar_t **stringValue,
             _Out_ size_t *stringLength);
 
+    /// <summary>
+    ///     Determines whether an object is an external object.
+    /// </summary>
+    /// <param name="object">The object.</param>
+    /// <param name="value">Whether the object is an external object.</param>
+    /// <returns>
+    ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
+    /// </returns>
+    CHAKRA_API
+        JsHasExternalData(
+            _In_ JsValueRef object,
+            _Out_ bool *value);
+
+    /// <summary>
+    ///     Retrieves the data from an external object.
+    /// </summary>
+    /// <param name="object">The external object.</param>
+    /// <param name="externalData">
+    ///     The external data stored in the object. Can be null if no external data is stored in the
+    ///     object.
+    /// </param>
+    /// <returns>
+    ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
+    /// </returns>
+    CHAKRA_API
+        JsGetExternalData(
+            _In_ JsValueRef object,
+            _Out_ void **externalData);
+
+    /// <summary>
+    ///     Sets the external data on an external object.
+    /// </summary>
+    /// <param name="object">The external object.</param>
+    /// <param name="externalData">
+    ///     The external data to be stored in the object. Can be null if no external data is
+    ///     to be stored in the object.
+    /// </param>
+    /// <returns>
+    ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
+    /// </returns>
+    CHAKRA_API
+        JsSetExternalData(
+            _In_ JsValueRef object,
+            _In_opt_ void *externalData);
 #endif // _CHAKRACOMMONWINDOWS_H_

--- a/lib/Jsrt/ChakraCore.h
+++ b/lib/Jsrt/ChakraCore.h
@@ -739,5 +739,76 @@ CHAKRA_API
         _Out_opt_ unsigned int *byteOffset,
         _Out_opt_ unsigned int *byteLength);
 
+  /// <summary>
+  ///     Determines whether an object has any external data.
+  /// </summary>
+  /// <param name="object">The object.</param>
+  /// <param name="value">Whether the object has an external data.</param>
+  /// <returns>
+  ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
+  /// </returns>
+  CHAKRA_API
+      JsObjectHasExternalData(
+          _In_ JsValueRef object,
+          _Out_ bool *value);
+
+  /// <summary>
+  ///     Retrieves the external data from a Javascript object.
+  /// </summary>
+  /// <param name="object">The Javascript object.</param>
+  /// <param name="externalData">
+  ///     The external data stored in the object. Can be null if no external data is stored in the
+  ///     object.
+  /// </param>
+  /// <returns>
+  ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
+  /// </returns>
+  CHAKRA_API
+      JsObjectGetExternalData(
+          _In_ JsValueRef object,
+          _Out_ void **externalData);
+
+  /// <summary>
+  ///     Sets the external data on an object.
+  /// </summary>
+  /// <param name="object">The Javascript object.</param>
+  /// <param name="externalData">
+  ///     The external data to be stored in the object. Can be null if no external data is
+  ///     to be stored in the object.
+  /// </param>
+  /// <returns>
+  ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
+  /// </returns>
+  CHAKRA_API
+      JsObjectSetExternalData(
+          _In_ JsValueRef object,
+          _In_opt_ void *externalData);
+
+  /// <summary>
+  ///     Sets the external data and finalize callback on an object.
+  /// </summary>
+  /// <param name="object">The Javascript object.</param>
+  /// <param name="externalData">
+  ///     The external data to be stored in the object. Can be null if no external data is
+  ///     to be stored in the object.
+  /// </param>
+  /// <param name="finalizeCallback">The callback to be called once the host object
+  ///     is garbage collected.
+  /// </param>
+  /// <remarks>
+  ///     If host object is JsExternalObject, previously defined callback argument
+  ///     and data will be updated with the ones provided through this API call.
+  ///     If host object is a Javascript Object, and object has an external data
+  ///     with or without callback defined previously, similarly, the previous
+  ///     information will be altered.
+  /// </remarks>
+  /// <returns>
+  ///     The code <c>JsNoError</c> if the operation succeeded, a failure code otherwise.
+  /// </returns>
+  CHAKRA_API
+      JsObjectSetExternalDataWithCallback(
+          _In_     JsValueRef         value,
+          _In_opt_ void               *data,
+  _In_opt_ JsFinalizeCallback finalizeCallback);
 #endif // _CHAKRACOREBUILD
 #endif // _CHAKRACORE_H_

--- a/lib/Jsrt/JsrtCommonExports.inc
+++ b/lib/Jsrt/JsrtCommonExports.inc
@@ -60,9 +60,6 @@
     JsSetIndexedPropertiesToExternalData
     JsEquals
     JsStrictEquals
-    JsHasExternalData
-    JsGetExternalData
-    JsSetExternalData
     JsCallFunction
     JsCreateFunction
     JsCreateNamedFunction
@@ -122,4 +119,12 @@
     JsHasOwnProperty
     JsCopyStringOneByte
     JsGetDataViewInfo
+    JsObjectHasExternalData
+    JsObjectGetExternalData
+    JsObjectSetExternalData
+    JsObjectSetExternalDataWithCallback
+#else
+    JsHasExternalData
+    JsGetExternalData
+    JsSetExternalData
 #endif

--- a/lib/Jsrt/JsrtExternalObject.h
+++ b/lib/Jsrt/JsrtExternalObject.h
@@ -32,6 +32,9 @@ public:
 
     //Js::PropertyId GetNameId() const { return ((Js::PropertyRecord *)typeDescription.className)->GetPropertyId(); }
     JsFinalizeCallback GetJsFinalizeCallback() const { return this->jsFinalizeCallback; }
+    
+    void SetJsFinalizeCallback(JsFinalizeCallback finalizeCallback)
+    { this->jsFinalizeCallback = finalizeCallback; }
 
 private:
     FieldNoBarrier(JsFinalizeCallback) jsFinalizeCallback;

--- a/lib/Runtime/Language/InlineCache.cpp
+++ b/lib/Runtime/Language/InlineCache.cpp
@@ -321,7 +321,7 @@ namespace Js
             }
             else if (taggedType == u.accessor.type)
             {
-                *callee = RecyclableObject::FromVar(u.accessor.object->GetAuxSlot(u.accessor.slotIndex));
+                *callee = RecyclableObject::FromVar(u.accessor.object->GetAuxSlotAt(u.accessor.slotIndex));
                 return true;
             }
         }
@@ -347,10 +347,10 @@ namespace Js
             }
             else if (taggedType == u.local.type)
             {
-                const Var objectAtAuxSlot = DynamicObject::FromVar(obj)->GetAuxSlot(u.local.slotIndex);
+                const Var objectAtAuxSlot = DynamicObject::FromVar(obj)->GetAuxSlotAt(u.local.slotIndex);
                 if (!Js::TaggedNumber::Is(objectAtAuxSlot))
                 {
-                    *callee = RecyclableObject::FromVar(DynamicObject::FromVar(obj)->GetAuxSlot(u.local.slotIndex));
+                    *callee = RecyclableObject::FromVar(DynamicObject::FromVar(obj)->GetAuxSlotAt(u.local.slotIndex));
                     return true;
                 }
             }
@@ -369,7 +369,7 @@ namespace Js
             }
             else if (taggedType == u.proto.type)
             {
-                const Var objectAtAuxSlot = u.proto.prototypeObject->GetAuxSlot(u.proto.slotIndex);
+                const Var objectAtAuxSlot = u.proto.prototypeObject->GetAuxSlotAt(u.proto.slotIndex);
                 if (!Js::TaggedNumber::Is(objectAtAuxSlot))
                 {
                     *callee = RecyclableObject::FromVar(objectAtAuxSlot);
@@ -1416,7 +1416,7 @@ namespace Js
             this->Set(instanceType, function, result);
         }
     }
-    
+
     /* static */
     uint32 IsInstInlineCache::OffsetOfFunction()
     {

--- a/lib/Runtime/Language/InlineCache.inl
+++ b/lib/Runtime/Language/InlineCache.inl
@@ -49,7 +49,7 @@ namespace Js
         if (CheckLocal && TypeWithAuxSlotTag(type) == u.local.type)
         {
             Assert(propertyObject->GetScriptContext() == requestContext); // we never cache a type from another script context
-            *propertyValue = DynamicObject::FromVar(propertyObject)->GetAuxSlot(u.local.slotIndex);
+            *propertyValue = DynamicObject::FromVar(propertyObject)->GetAuxSlotAt(u.local.slotIndex);
             Assert(*propertyValue == JavascriptOperators::GetProperty(propertyObject, propertyId, requestContext) ||
                 (RootObjectBase::Is(propertyObject) && *propertyValue == JavascriptOperators::GetRootProperty(propertyObject, propertyId, requestContext)));
             if (ReturnOperationInfo)
@@ -77,7 +77,7 @@ namespace Js
         if (CheckProto && TypeWithAuxSlotTag(type) == u.proto.type && !this->u.proto.isMissing)
         {
             Assert(u.proto.prototypeObject->GetScriptContext() == requestContext); // we never cache a type from another script context
-            *propertyValue = u.proto.prototypeObject->GetAuxSlot(u.proto.slotIndex);
+            *propertyValue = u.proto.prototypeObject->GetAuxSlotAt(u.proto.slotIndex);
             Assert(*propertyValue == JavascriptOperators::GetProperty(propertyObject, propertyId, requestContext) ||
                 (RootObjectBase::Is(propertyObject) && *propertyValue == JavascriptOperators::GetRootProperty(propertyObject, propertyId, requestContext)));
             if (ReturnOperationInfo)
@@ -114,7 +114,7 @@ namespace Js
             Assert(propertyObject->GetScriptContext() == requestContext); // we never cache a type from another script context
             Assert(u.accessor.flags & InlineCacheGetterFlag);
 
-            RecyclableObject *const function = RecyclableObject::FromVar(u.accessor.object->GetAuxSlot(u.accessor.slotIndex));
+            RecyclableObject *const function = RecyclableObject::FromVar(u.accessor.object->GetAuxSlotAt(u.accessor.slotIndex));
 
             *propertyValue = JavascriptOperators::CallGetter(function, instance, requestContext);
 
@@ -155,7 +155,7 @@ namespace Js
         if (CheckMissing && TypeWithAuxSlotTag(type) == u.proto.type && this->u.proto.isMissing)
         {
             Assert(u.proto.prototypeObject->GetScriptContext() == requestContext); // we never cache a type from another script context
-            *propertyValue = u.proto.prototypeObject->GetAuxSlot(u.proto.slotIndex);
+            *propertyValue = u.proto.prototypeObject->GetAuxSlotAt(u.proto.slotIndex);
             Assert(*propertyValue == JavascriptOperators::GetProperty(propertyObject, propertyId, requestContext) ||
                 (RootObjectBase::Is(propertyObject) && *propertyValue == JavascriptOperators::GetRootProperty(propertyObject, propertyId, requestContext)));
 
@@ -203,7 +203,7 @@ namespace Js
 
         bool canSetField; // To verify if we can set a field on the object
         Var setterValue = nullptr;
-        { 
+        {
             // We need to disable implicit call to ensure the check doesn't cause unwanted side effects in debug code
             // Save old disableImplicitFlags and implicitCallFlags and disable implicit call and exception
             ThreadContext * threadContext = requestContext->GetThreadContext();
@@ -219,7 +219,7 @@ namespace Js
                 canSetField = true; // If there was an implicit call, inconclusive. Disable debug check.
                 setterValue = nullptr;
             }
-            else 
+            else
                 if ((flags & Accessor) == Accessor)
             {
                 Assert(setterValue != nullptr);
@@ -255,7 +255,7 @@ namespace Js
             Assert(isRoot || object->GetPropertyIndex(propertyId) == DynamicObject::FromVar(object)->GetTypeHandler()->InlineOrAuxSlotIndexToPropertyIndex(u.local.slotIndex, false));
             Assert(!isRoot || RootObjectBase::FromVar(object)->GetRootPropertyIndex(propertyId) == DynamicObject::FromVar(object)->GetTypeHandler()->InlineOrAuxSlotIndexToPropertyIndex(u.local.slotIndex, false));
             Assert(object->CanStorePropertyValueDirectly(propertyId, isRoot));
-            DynamicObject::FromVar(object)->SetAuxSlot(SetSlotArgumentsRoot(propertyId, isRoot, u.local.slotIndex, propertyValue));
+            DynamicObject::FromVar(object)->SetAuxSlotAt(SetSlotArgumentsRoot(propertyId, isRoot, u.local.slotIndex, propertyValue));
             if (ReturnOperationInfo)
             {
                 operationInfo->cacheType = CacheType_Local;
@@ -335,7 +335,7 @@ namespace Js
             Assert(isRoot || object->GetPropertyIndex(propertyId) == DynamicObject::FromVar(object)->GetTypeHandler()->InlineOrAuxSlotIndexToPropertyIndex(propertyIndex, false));
             Assert(!isRoot || RootObjectBase::FromVar(object)->GetRootPropertyIndex(propertyId) == DynamicObject::FromVar(object)->GetTypeHandler()->InlineOrAuxSlotIndexToPropertyIndex(propertyIndex, false));
 
-            dynamicObject->SetAuxSlot(SetSlotArgumentsRoot(propertyId, isRoot, propertyIndex, propertyValue));
+            dynamicObject->SetAuxSlotAt(SetSlotArgumentsRoot(propertyId, isRoot, propertyIndex, propertyValue));
 
             if (ReturnOperationInfo)
             {
@@ -369,7 +369,7 @@ namespace Js
             Assert(object->GetScriptContext() == requestContext); // we never cache a type from another script context
             Assert(u.accessor.flags & InlineCacheSetterFlag);
 
-            RecyclableObject *const function = RecyclableObject::FromVar(u.accessor.object->GetAuxSlot(u.accessor.slotIndex));
+            RecyclableObject *const function = RecyclableObject::FromVar(u.accessor.object->GetAuxSlotAt(u.accessor.slotIndex));
 
             Assert(setterValue == nullptr || setterValue == function);
             Js::JavascriptOperators::CallSetter(function, object, propertyValue, requestContext);

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -5604,7 +5604,7 @@ CommonNumber:
                 if (scopeSlot != Constants::NoProperty)
                 {
                     // CONSIDER: Store property IDs in FuncInfoArray in debug builds so we can properly assert in SetAuxSlot
-                    scopeObj->SetAuxSlot(SetSlotArguments(Constants::NoProperty, scopeSlot, entry->func));
+                    scopeObj->SetAuxSlotAt(SetSlotArguments(Constants::NoProperty, scopeSlot, entry->func));
                 }
             }
             return;
@@ -5629,7 +5629,7 @@ CommonNumber:
             if (scopeSlot != Constants::NoProperty)
             {
                 // CONSIDER: Store property IDs in FuncInfoArray in debug builds so we can properly assert in SetAuxSlot
-                scopeObj->SetAuxSlot(SetSlotArguments(Constants::NoProperty, scopeSlot, func));
+                scopeObj->SetAuxSlotAt(SetSlotArguments(Constants::NoProperty, scopeSlot, func));
             }
         }
     }
@@ -6070,10 +6070,13 @@ CommonNumber:
         // after we fail the guard check.  When invalidating the cache for proto change, make sure we zap the prototype field of the cache in
         // addition to the guard value.
         bool prototypeCanBeCached;
+        auto functionTypeHandler = ((Js::DynamicObject*)function)->GetTypeHandler();
+        bool hasExternalDataSupport = functionTypeHandler->HasExternalDataSupport();
+
         RecyclableObject* prototype = JavascriptOperators::GetPrototypeObjectForConstructorCache(function, constructorScriptContext, prototypeCanBeCached);
         prototype = RecyclableObject::FromVar(CrossSite::MarshalVar(requestContext, prototype));
 
-        DynamicObject* newObject = requestContext->GetLibrary()->CreateObject(prototype, 8);
+        DynamicObject* newObject = requestContext->GetLibrary()->CreateObject(prototype, 8, hasExternalDataSupport);
 
         JS_ETW(EventWriteJSCRIPT_RECYCLER_ALLOCATE_OBJECT(newObject));
 #if ENABLE_DEBUG_CONFIG_OPTIONS

--- a/lib/Runtime/Library/JavascriptGeneratorFunction.cpp
+++ b/lib/Runtime/Library/JavascriptGeneratorFunction.cpp
@@ -125,7 +125,8 @@ namespace Js
         CopyArray(argsHeapCopy, stackArgs.Info.Count, stackArgs.Values, stackArgs.Info.Count);
         Arguments heapArgs(callInfo, (Var*)argsHeapCopy);
 
-        DynamicObject* prototype = scriptContext->GetLibrary()->CreateGeneratorConstructorPrototypeObject();
+        auto typeHandler = ((DynamicObject*)function)->GetTypeHandler();
+        DynamicObject* prototype = scriptContext->GetLibrary()->CreateGeneratorConstructorPrototypeObject(typeHandler->HasExternalDataSupport());
         JavascriptGenerator* generator = scriptContext->GetLibrary()->CreateGenerator(heapArgs, generatorFunction->scriptFunction, prototype);
         // Set the prototype from constructor
         JavascriptOperators::OrdinaryCreateFromConstructor(function, generator, prototype, scriptContext);

--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -50,6 +50,16 @@ namespace Js
     SimpleTypeHandler<1> JavascriptLibrary::SharedNamespaceSymbolTypeHandler(NO_WRITE_BARRIER_TAG(ModuleNamespaceTypeDescriptors));
     MissingPropertyTypeHandler JavascriptLibrary::MissingPropertyHolderTypeHandler;
 
+    SimpleTypeHandlerWithExternal<1> JavascriptLibrary::SharedPrototypeTypeHandlerWithExternal(NO_WRITE_BARRIER_TAG(BuiltInPropertyRecords::constructor), PropertyWritable | PropertyConfigurable, PropertyTypesWritableDataOnly, 4, sizeof(DynamicObject));
+    SimpleTypeHandlerWithExternal<1> JavascriptLibrary::SharedFunctionWithoutPrototypeTypeHandlerWithExternal(NO_WRITE_BARRIER_TAG(BuiltInPropertyRecords::name), PropertyConfigurable);
+    SimpleTypeHandlerWithExternal<1> JavascriptLibrary::SharedFunctionWithPrototypeTypeHandlerV11WithExternal(NO_WRITE_BARRIER_TAG(BuiltInPropertyRecords::prototype), PropertyWritable);
+    SimpleTypeHandlerWithExternal<2> JavascriptLibrary::SharedFunctionWithPrototypeTypeHandlerWithExternal(NO_WRITE_BARRIER_TAG(SharedFunctionPropertyDescriptors));
+    SimpleTypeHandlerWithExternal<1> JavascriptLibrary::SharedIdMappedFunctionWithPrototypeTypeHandlerWithExternal(NO_WRITE_BARRIER_TAG(BuiltInPropertyRecords::prototype));
+    SimpleTypeHandlerWithExternal<1> JavascriptLibrary::SharedFunctionWithLengthTypeHandlerWithExternal(NO_WRITE_BARRIER_TAG(BuiltInPropertyRecords::length));
+    SimpleTypeHandlerWithExternal<2> JavascriptLibrary::SharedFunctionWithLengthAndNameTypeHandlerWithExternal(NO_WRITE_BARRIER_TAG(FunctionWithLengthAndNameTypeDescriptors));
+    SimpleTypeHandlerWithExternal<1> JavascriptLibrary::SharedNamespaceSymbolTypeHandlerWithExternal(NO_WRITE_BARRIER_TAG(ModuleNamespaceTypeDescriptors));
+    MissingPropertyTypeHandlerWithExternal JavascriptLibrary::MissingPropertyHolderTypeHandlerWithExternal;
+
 
     SimplePropertyDescriptor const JavascriptLibrary::HeapArgumentsPropertyDescriptors[3] =
     {
@@ -120,10 +130,14 @@ namespace Js
             DynamicType::New(scriptContext, TypeIds_Object, nullValue, nullptr,
             DeferredTypeHandler<InitializeObjectPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
 
-        constructorPrototypeObjectType = DynamicType::New(scriptContext, TypeIds_Object, objectPrototype, nullptr,
+        constructorPrototypeObjectType[ 0 /* normal */ ] = DynamicType::New(scriptContext, TypeIds_Object, objectPrototype, nullptr,
             &SharedPrototypeTypeHandler, true, true);
 
-        constructorPrototypeObjectType->SetHasNoEnumerableProperties(true);
+        constructorPrototypeObjectType[ 1 /* withExternalData */ ] = DynamicType::New(scriptContext, TypeIds_Object, objectPrototype, nullptr,
+                                                          &SharedPrototypeTypeHandlerWithExternal, true, true);
+
+        constructorPrototypeObjectType[0]->SetHasNoEnumerableProperties(true);
+        constructorPrototypeObjectType[1]->SetHasNoEnumerableProperties(true);
 
         arrayBufferPrototype = DynamicObject::New(recycler,
             DynamicType::New(scriptContext, TypeIds_Object, objectPrototype, nullptr,
@@ -525,26 +539,34 @@ namespace Js
         variantDateType = StaticType::New(scriptContext, TypeIds_VariantDate, nullValue, nullptr);
 
         anonymousFunctionTypeHandler = NullTypeHandler<false>::GetDefaultInstance();
+        anonymousFunctionTypeHandlerWithExternal = NullTypeHandlerWithExternal<false>::GetDefaultInstanceWithExternal();
         anonymousFunctionWithPrototypeTypeHandler = &SharedFunctionWithPrototypeTypeHandlerV11;
+        anonymousFunctionWithPrototypeTypeHandlerWithExternal = &SharedFunctionWithPrototypeTypeHandlerV11WithExternal;
+
         //  Initialize function types
         if (config->IsES6FunctionNameEnabled())
         {
             functionTypeHandler = &SharedFunctionWithoutPrototypeTypeHandler;
+            functionTypeHandlerWithExternal = &SharedFunctionWithoutPrototypeTypeHandlerWithExternal;
         }
         else
         {
             functionTypeHandler = anonymousFunctionTypeHandler;
+            functionTypeHandlerWithExternal = anonymousFunctionTypeHandlerWithExternal;
         }
 
         if (config->IsES6FunctionNameEnabled())
         {
             functionWithPrototypeTypeHandler = &SharedFunctionWithPrototypeTypeHandler;
+            functionWithPrototypeTypeHandlerWithExternal = &SharedFunctionWithPrototypeTypeHandlerWithExternal;
         }
         else
         {
             functionWithPrototypeTypeHandler = anonymousFunctionWithPrototypeTypeHandler;
+            functionWithPrototypeTypeHandlerWithExternal = anonymousFunctionWithPrototypeTypeHandlerWithExternal;
         }
         functionWithPrototypeTypeHandler->SetHasKnownSlot0();
+
 
         externalFunctionWithDeferredPrototypeType = CreateDeferredPrototypeFunctionTypeNoProfileThunk(JavascriptExternalFunction::ExternalFunctionThunk, true /*isShared*/);
         wrappedFunctionWithDeferredPrototypeType = CreateDeferredPrototypeFunctionTypeNoProfileThunk(JavascriptExternalFunction::WrappedFunctionThunk, true /*isShared*/);
@@ -698,10 +720,14 @@ namespace Js
 
         if (config->IsES6GeneratorsEnabled())
         {
-            generatorConstructorPrototypeObjectType = DynamicType::New(scriptContext, TypeIds_Object, generatorPrototype, nullptr,
+            generatorConstructorPrototypeObjectType[0 /* normal */] = DynamicType::New(scriptContext, TypeIds_Object, generatorPrototype, nullptr,
                 NullTypeHandler<false>::GetDefaultInstance(), true, true);
 
-            generatorConstructorPrototypeObjectType->SetHasNoEnumerableProperties(true);
+            generatorConstructorPrototypeObjectType[1 /* withExternalData */] = DynamicType::New(scriptContext, TypeIds_Object, generatorPrototype, nullptr,
+                NullTypeHandlerWithExternal<false>::GetDefaultInstanceWithExternal(), true, true);
+
+            generatorConstructorPrototypeObjectType[0]->SetHasNoEnumerableProperties(true);
+            generatorConstructorPrototypeObjectType[1]->SetHasNoEnumerableProperties(true);
         }
 
 #ifdef ENABLE_DEBUG_CONFIG_OPTIONS
@@ -718,8 +744,14 @@ namespace Js
         bool isAnonymousFunction = JavascriptGeneratorFunction::FromVar(function)->IsAnonymousFunction();
 
         JavascriptLibrary* javascriptLibrary = function->GetType()->GetLibrary();
-        typeHandler->Convert(function, isAnonymousFunction ? javascriptLibrary->anonymousFunctionWithPrototypeTypeHandler : javascriptLibrary->functionWithPrototypeTypeHandler);
-        function->SetPropertyWithAttributes(PropertyIds::prototype, javascriptLibrary->CreateGeneratorConstructorPrototypeObject(), PropertyWritable, nullptr);
+        bool hasExternal = typeHandler->HasExternalDataSupport();
+        auto baseTypeHandler = isAnonymousFunction ?
+          (hasExternal) ? javascriptLibrary->anonymousFunctionWithPrototypeTypeHandlerWithExternal : javascriptLibrary->anonymousFunctionWithPrototypeTypeHandler
+          : // else
+          (hasExternal) ? javascriptLibrary->functionWithPrototypeTypeHandlerWithExternal : javascriptLibrary->functionWithPrototypeTypeHandler;
+
+        typeHandler->Convert(function, baseTypeHandler);
+        function->SetPropertyWithAttributes(PropertyIds::prototype, javascriptLibrary->CreateGeneratorConstructorPrototypeObject(hasExternal), PropertyWritable, nullptr);
 
         if (function->GetScriptContext()->GetConfig()->IsES6FunctionNameEnabled() && !isAnonymousFunction)
         {
@@ -771,12 +803,21 @@ namespace Js
         if (!addPrototype)
         {
             Assert(!useAnonymous);
-            typeHandler->Convert(function, javascriptLibrary->functionTypeHandler);
+            bool hasExternal = typeHandler->HasExternalDataSupport();
+            typeHandler->Convert(function, hasExternal ? javascriptLibrary->functionTypeHandlerWithExternal :  javascriptLibrary->functionTypeHandler);
         }
         else
         {
-            typeHandler->Convert(function, useAnonymous ? javascriptLibrary->anonymousFunctionWithPrototypeTypeHandler : javascriptLibrary->functionWithPrototypeTypeHandler);
-            function->SetProperty(PropertyIds::prototype, javascriptLibrary->CreateConstructorPrototypeObject((Js::JavascriptFunction *)function), PropertyOperation_None, nullptr);
+            bool hasExternal = typeHandler->HasExternalDataSupport();
+            auto baseTypeHandler = useAnonymous ?
+              (hasExternal) ? javascriptLibrary->anonymousFunctionWithPrototypeTypeHandlerWithExternal : javascriptLibrary->anonymousFunctionWithPrototypeTypeHandler
+              : // else
+              (hasExternal) ? javascriptLibrary->functionWithPrototypeTypeHandlerWithExternal : javascriptLibrary->functionWithPrototypeTypeHandler;
+
+            typeHandler->Convert(function, baseTypeHandler);
+            function->SetProperty(PropertyIds::prototype,
+              javascriptLibrary->CreateConstructorPrototypeObject((Js::JavascriptFunction *)function,
+              hasExternal), PropertyOperation_None, nullptr);
         }
 
         if (scriptFunction)
@@ -1821,7 +1862,7 @@ namespace Js
         JavascriptLibrary* library = arrayBufferConstructor->GetLibrary();
         library->AddMember(arrayBufferConstructor, PropertyIds::length, TaggedInt::ToVarUnchecked(1), PropertyNone);
         library->AddMember(arrayBufferConstructor, PropertyIds::prototype, scriptContext->GetLibrary()->arrayBufferPrototype, PropertyNone);
-        library->AddSpeciesAccessorsToLibraryObject(arrayBufferConstructor, &ArrayBuffer::EntryInfo::GetterSymbolSpecies);       
+        library->AddSpeciesAccessorsToLibraryObject(arrayBufferConstructor, &ArrayBuffer::EntryInfo::GetterSymbolSpecies);
 
         if (scriptContext->GetConfig()->IsES6FunctionNameEnabled())
         {
@@ -4888,7 +4929,7 @@ namespace Js
         Js::RecyclableObject* objPrototype;
         if (prototype == nullptr)
         {
-            objPrototype = CreateConstructorPrototypeObject(function);
+            objPrototype = CreateConstructorPrototypeObject(function, false);
             Assert(!objPrototype->IsEnumerable(Js::PropertyIds::constructor));
         }
         else
@@ -5691,7 +5732,7 @@ namespace Js
             }
             else
             {
-                Assert(typeHandler == &SharedIdMappedFunctionWithPrototypeTypeHandler);
+                Assert(typeHandler == &SharedIdMappedFunctionWithPrototypeTypeHandler || typeHandler == &SharedIdMappedFunctionWithPrototypeTypeHandlerWithExternal);
                 function->ReplaceType(crossSiteIdMappedFunctionWithPrototypeType);
             }
         }
@@ -6716,18 +6757,18 @@ namespace Js
 
 #endif
 
-    DynamicObject* JavascriptLibrary::CreateGeneratorConstructorPrototypeObject()
+    DynamicObject* JavascriptLibrary::CreateGeneratorConstructorPrototypeObject(bool hasExternalData)
     {
-        AssertMsg(generatorConstructorPrototypeObjectType, "Where's generatorConstructorPrototypeObjectType?");
-        DynamicObject * prototype = DynamicObject::New(this->GetRecycler(), generatorConstructorPrototypeObjectType);
+        AssertMsg(generatorConstructorPrototypeObjectType[(int)hasExternalData], "Where's generatorConstructorPrototypeObjectType?");
+        DynamicObject * prototype = DynamicObject::New(this->GetRecycler(), generatorConstructorPrototypeObjectType[(int)hasExternalData]);
         // Generator functions' prototype objects are not created with a .constructor property
         return prototype;
     }
 
-    DynamicObject* JavascriptLibrary::CreateConstructorPrototypeObject(JavascriptFunction * constructor)
+    DynamicObject* JavascriptLibrary::CreateConstructorPrototypeObject(JavascriptFunction * constructor, bool hasExternalData)
     {
-        AssertMsg(constructorPrototypeObjectType, "Where's constructorPrototypeObjectType?");
-        DynamicObject * prototype = DynamicObject::New(this->GetRecycler(), constructorPrototypeObjectType);
+        AssertMsg(constructorPrototypeObjectType[(int)hasExternalData], "Where's constructorPrototypeObjectType?");
+        DynamicObject * prototype = DynamicObject::New(this->GetRecycler(), constructorPrototypeObjectType[(int)hasExternalData]);
         AddMember(prototype, PropertyIds::constructor, constructor);
         return prototype;
     }
@@ -6755,9 +6796,11 @@ namespace Js
                 RecyclableObject::DefaultEntryPoint, typeHandler, false, false));
     }
 
-    DynamicType* JavascriptLibrary::CreateObjectType(RecyclableObject* prototype, Js::TypeId typeId, uint16 requestedInlineSlotCapacity)
+    DynamicType* JavascriptLibrary::CreateObjectType(RecyclableObject* prototype, Js::TypeId typeId, uint16 requestedInlineSlotCapacity, bool hasExternalData)
     {
-        const bool useObjectHeaderInlining = FunctionBody::DoObjectHeaderInliningForConstructor(requestedInlineSlotCapacity);
+        // why !hasExternalData? -> when typeHandler has external data, member object will allocate initial auxSlot memory
+        // Thus, offsetOfInlineSlots shouldn't be the offset of aux slots.
+        const bool useObjectHeaderInlining = !hasExternalData && FunctionBody::DoObjectHeaderInliningForConstructor(requestedInlineSlotCapacity);
         const uint16 offsetOfInlineSlots =
             useObjectHeaderInlining
             ? DynamicTypeHandler::GetOffsetOfObjectHeaderInlineSlots()
@@ -6849,7 +6892,16 @@ namespace Js
         }
         oldCachedType = dynamicType;
 #endif
-        SimplePathTypeHandler* typeHandler = SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, requestedInlineSlotCapacity, offsetOfInlineSlots, true, true);
+        SimplePathTypeHandler* typeHandler;
+        if (!hasExternalData)
+        {
+            typeHandler = SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, requestedInlineSlotCapacity, offsetOfInlineSlots, true, true);
+        }
+        else
+        {
+            typeHandler = PathTypeHandlerWithExternal<SimplePathTypeHandler>::New(scriptContext, this->GetRootPath(), 0, requestedInlineSlotCapacity, offsetOfInlineSlots, true, true);
+        }
+
         dynamicType = DynamicType::New(scriptContext, typeId, prototype, RecyclableObject::DefaultEntryPoint, typeHandler, true, true);
 
         if (useCache)
@@ -6876,23 +6928,33 @@ namespace Js
         return dynamicType;
     }
 
-    DynamicType* JavascriptLibrary::CreateObjectTypeNoCache(RecyclableObject* prototype, Js::TypeId typeId)
+    DynamicType* JavascriptLibrary::CreateObjectTypeNoCache(RecyclableObject* prototype, Js::TypeId typeId, bool hasExternalData)
     {
+        SimplePathTypeHandler* typeHandler = nullptr;
+        if (hasExternalData)
+        {
+            typeHandler = PathTypeHandlerWithExternal<SimplePathTypeHandler>::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true);
+        }
+        else
+        {
+            typeHandler = SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true);
+        }
+
         return DynamicType::New(scriptContext, typeId, prototype, RecyclableObject::DefaultEntryPoint,
-            SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
+            typeHandler, true, true);
     }
 
-    DynamicType* JavascriptLibrary::CreateObjectType(RecyclableObject* prototype, uint16 requestedInlineSlotCapacity)
+    DynamicType* JavascriptLibrary::CreateObjectType(RecyclableObject* prototype, uint16 requestedInlineSlotCapacity, bool hasExternalData)
     {
         // We can't reuse the type in objectType even if the prototype is the object prototype, because those has inline slot capacity fixed
-        return CreateObjectType(prototype, TypeIds_Object, requestedInlineSlotCapacity);
+        return CreateObjectType(prototype, TypeIds_Object, requestedInlineSlotCapacity, hasExternalData);
     }
 
-    DynamicObject* JavascriptLibrary::CreateObject(RecyclableObject* prototype, uint16 requestedInlineSlotCapacity)
+    DynamicObject* JavascriptLibrary::CreateObject(RecyclableObject* prototype, uint16 requestedInlineSlotCapacity, bool hasExternalData)
     {
         Assert(JavascriptOperators::IsObjectOrNull(prototype));
 
-        DynamicType* dynamicType = CreateObjectType(prototype, requestedInlineSlotCapacity);
+        DynamicType* dynamicType = CreateObjectType(prototype, requestedInlineSlotCapacity, hasExternalData);
         return DynamicObject::New(this->GetRecycler(), dynamicType);
     }
 

--- a/lib/Runtime/Library/JavascriptLibrary.h
+++ b/lib/Runtime/Library/JavascriptLibrary.h
@@ -176,6 +176,11 @@ namespace Js
         static hash_t GetHashCode(RecyclerWeakReference<Js::RecyclableObject>* o);
     };
 
+    template <size_t size>
+    class SimpleTypeHandlerWithExternal;
+
+    class MissingPropertyTypeHandlerWithExternal;
+
     class JavascriptLibrary : public JavascriptLibraryBase
     {
         friend class EditAndContinue;
@@ -244,8 +249,9 @@ namespace Js
 
         Field(UndeclaredBlockVariable*) undeclBlockVarSentinel;
 
-        Field(DynamicType *) generatorConstructorPrototypeObjectType;
-        Field(DynamicType *) constructorPrototypeObjectType;
+        Field(DynamicType *) generatorConstructorPrototypeObjectType[2]; // 0: normal 1: hasExternalData
+        Field(DynamicType *) constructorPrototypeObjectType[2]; // 0: normal 1: hasExternalData
+
         Field(DynamicType *) heapArgumentsType;
         Field(DynamicType *) activationObjectType;
         Field(DynamicType *) arrayType;
@@ -297,6 +303,12 @@ namespace Js
         Field(DynamicTypeHandler *) anonymousFunctionWithPrototypeTypeHandler;
         Field(DynamicTypeHandler *) functionTypeHandler;
         Field(DynamicTypeHandler *) functionWithPrototypeTypeHandler;
+
+        Field(DynamicTypeHandler *) anonymousFunctionTypeHandlerWithExternal;
+        Field(DynamicTypeHandler *) anonymousFunctionWithPrototypeTypeHandlerWithExternal;
+        Field(DynamicTypeHandler *) functionTypeHandlerWithExternal;
+        Field(DynamicTypeHandler *) functionWithPrototypeTypeHandlerWithExternal;
+
         Field(DynamicType *) externalFunctionWithDeferredPrototypeType;
         Field(DynamicType *) wrappedFunctionWithDeferredPrototypeType;
         Field(DynamicType *) stdCallFunctionWithDeferredPrototypeType;
@@ -540,6 +552,16 @@ namespace Js
         static SimpleTypeHandler<1> SharedIdMappedFunctionWithPrototypeTypeHandler;
         static SimpleTypeHandler<1> SharedNamespaceSymbolTypeHandler;
         static MissingPropertyTypeHandler MissingPropertyHolderTypeHandler;
+
+        static SimpleTypeHandlerWithExternal<1> SharedPrototypeTypeHandlerWithExternal;
+        static SimpleTypeHandlerWithExternal<1> SharedFunctionWithoutPrototypeTypeHandlerWithExternal;
+        static SimpleTypeHandlerWithExternal<1> SharedFunctionWithPrototypeTypeHandlerV11WithExternal;
+        static SimpleTypeHandlerWithExternal<2> SharedFunctionWithPrototypeTypeHandlerWithExternal;
+        static SimpleTypeHandlerWithExternal<1> SharedFunctionWithLengthTypeHandlerWithExternal;
+        static SimpleTypeHandlerWithExternal<2> SharedFunctionWithLengthAndNameTypeHandlerWithExternal;
+        static SimpleTypeHandlerWithExternal<1> SharedIdMappedFunctionWithPrototypeTypeHandlerWithExternal;
+        static SimpleTypeHandlerWithExternal<1> SharedNamespaceSymbolTypeHandlerWithExternal;
+        static MissingPropertyTypeHandlerWithExternal MissingPropertyHolderTypeHandlerWithExternal;
 
         static SimplePropertyDescriptor const SharedFunctionPropertyDescriptors[2];
         static SimplePropertyDescriptor const HeapArgumentsPropertyDescriptors[3];
@@ -1058,18 +1080,18 @@ namespace Js
 #endif
 #endif
 
-        DynamicObject* CreateGeneratorConstructorPrototypeObject();
-        DynamicObject* CreateConstructorPrototypeObject(JavascriptFunction * constructor);
+        DynamicObject* CreateGeneratorConstructorPrototypeObject(bool hasExternalData);
+        DynamicObject* CreateConstructorPrototypeObject(JavascriptFunction * constructor, bool hasExternalData);
         DynamicObject* CreateObject(const bool allowObjectHeaderInlining = false, const PropertyIndex requestedInlineSlotCapacity = 0);
         DynamicObject* CreateObject(DynamicTypeHandler * typeHandler);
         DynamicObject* CreateActivationObject();
         DynamicObject* CreatePseudoActivationObject();
         DynamicObject* CreateBlockActivationObject();
         DynamicObject* CreateConsoleScopeActivationObject();
-        DynamicType* CreateObjectType(RecyclableObject* prototype, Js::TypeId typeId, uint16 requestedInlineSlotCapacity);
-        DynamicType* CreateObjectTypeNoCache(RecyclableObject* prototype, Js::TypeId typeId);
-        DynamicType* CreateObjectType(RecyclableObject* prototype, uint16 requestedInlineSlotCapacity);
-        DynamicObject* CreateObject(RecyclableObject* prototype, uint16 requestedInlineSlotCapacity = 0);
+        DynamicType* CreateObjectType(RecyclableObject* prototype, Js::TypeId typeId, uint16 requestedInlineSlotCapacity, bool hasExternalData = false);
+        DynamicType* CreateObjectTypeNoCache(RecyclableObject* prototype, Js::TypeId typeId, bool hasExternalData = false);
+        DynamicType* CreateObjectType(RecyclableObject* prototype, uint16 requestedInlineSlotCapacity, bool hasExternalData = false);
+        DynamicObject* CreateObject(RecyclableObject* prototype, uint16 requestedInlineSlotCapacity = 0, bool hasExternalData = false);
 
         typedef JavascriptString* LibStringType; // used by diagnostics template
         template< size_t N > JavascriptString* CreateStringFromCppLiteral(const char16 (&value)[N]) const;

--- a/lib/Runtime/RuntimeCommon.h
+++ b/lib/Runtime/RuntimeCommon.h
@@ -155,6 +155,8 @@ namespace Js
 
     template <typename TPropertyIndex, typename TMapKey, bool IsNotExtensibleSupported> class SimpleDictionaryTypeHandlerBase;
     template <typename TPropertyIndex, typename TMapKey, bool IsNotExtensibleSupported> class SimpleDictionaryUnorderedTypeHandler;
+    template <typename TPropertyIndex, typename TMapKey, bool IsNotExtensibleSupported> class SimpleDictionaryTypeHandlerBaseWithExternal;
+    template <typename TPropertyIndex, typename TMapKey, bool IsNotExtensibleSupported> class SimpleDictionaryUnorderedTypeHandlerWithExternal;
     template <typename TPropertyIndex> class DictionaryTypeHandlerBase;
     template <typename TPropertyIndex> class ES5ArrayTypeHandlerBase;
 
@@ -166,6 +168,11 @@ namespace Js
     typedef SimpleDictionaryTypeHandlerBase<BigPropertyIndex, const PropertyRecord*, false> BigSimpleDictionaryTypeHandler;
     typedef SimpleDictionaryTypeHandlerBase<BigPropertyIndex, const PropertyRecord*, true>  BigSimpleDictionaryTypeHandlerNotExtensible;
 
+    typedef SimpleDictionaryTypeHandlerBaseWithExternal<PropertyIndex, const PropertyRecord*, false>    SimpleDictionaryTypeHandlerWithExternal;
+    typedef SimpleDictionaryTypeHandlerBaseWithExternal<PropertyIndex, const PropertyRecord*, true>     SimpleDictionaryTypeHandlerNotExtensibleWithExternal;
+    typedef SimpleDictionaryTypeHandlerBaseWithExternal<BigPropertyIndex, const PropertyRecord*, false> BigSimpleDictionaryTypeHandlerWithExternal;
+    typedef SimpleDictionaryTypeHandlerBaseWithExternal<BigPropertyIndex, const PropertyRecord*, true>  BigSimpleDictionaryTypeHandlerNotExtensibleWithExternal;
+
     typedef SimpleDictionaryUnorderedTypeHandler<PropertyIndex, const PropertyRecord*, false>    SimpleDictionaryUnorderedPropertyRecordKeyedTypeHandler;
     typedef SimpleDictionaryUnorderedTypeHandler<PropertyIndex, const PropertyRecord*, true>     SimpleDictionaryUnorderedPropertyRecordKeyedTypeHandlerNotExtensible;
     typedef SimpleDictionaryUnorderedTypeHandler<BigPropertyIndex, const PropertyRecord*, false> BigSimpleDictionaryUnorderedPropertyRecordKeyedTypeHandler;
@@ -176,11 +183,31 @@ namespace Js
     typedef SimpleDictionaryUnorderedTypeHandler<BigPropertyIndex, JavascriptString*, false> BigSimpleDictionaryUnorderedStringKeyedTypeHandler;
     typedef SimpleDictionaryUnorderedTypeHandler<BigPropertyIndex, JavascriptString*, true>  BigSimpleDictionaryUnorderedStringKeyedTypeHandlerNotExtensible;
 
+    typedef SimpleDictionaryUnorderedTypeHandlerWithExternal<PropertyIndex, const PropertyRecord*, false>    SimpleDictionaryUnorderedPropertyRecordKeyedTypeHandlerWithExternal;
+    typedef SimpleDictionaryUnorderedTypeHandlerWithExternal<PropertyIndex, const PropertyRecord*, true>     SimpleDictionaryUnorderedPropertyRecordKeyedTypeHandlerNotExtensibleWithExternal;
+    typedef SimpleDictionaryUnorderedTypeHandlerWithExternal<BigPropertyIndex, const PropertyRecord*, false> BigSimpleDictionaryUnorderedPropertyRecordKeyedTypeHandlerWithExternal;
+    typedef SimpleDictionaryUnorderedTypeHandlerWithExternal<BigPropertyIndex, const PropertyRecord*, true>  BigSimpleDictionaryUnorderedPropertyRecordKeyedTypeHandlerNotExtensibleWithExternal;
+
+    typedef SimpleDictionaryUnorderedTypeHandlerWithExternal<PropertyIndex, JavascriptString*, false>    SimpleDictionaryUnorderedStringKeyedTypeHandlerWithExternal;
+    typedef SimpleDictionaryUnorderedTypeHandlerWithExternal<PropertyIndex, JavascriptString*, true>     SimpleDictionaryUnorderedStringKeyedTypeHandlerNotExtensibleWithExternal;
+    typedef SimpleDictionaryUnorderedTypeHandlerWithExternal<BigPropertyIndex, JavascriptString*, false> BigSimpleDictionaryUnorderedStringKeyedTypeHandlerWithExternal;
+    typedef SimpleDictionaryUnorderedTypeHandlerWithExternal<BigPropertyIndex, JavascriptString*, true>  BigSimpleDictionaryUnorderedStringKeyedTypeHandlerNotExtensibleWithExternal;
+
     typedef DictionaryTypeHandlerBase<PropertyIndex> DictionaryTypeHandler;
     typedef DictionaryTypeHandlerBase<BigPropertyIndex> BigDictionaryTypeHandler;
 
+    template <class T> class DictionaryTypeHandlerBaseWithExternal;
+
+    typedef DictionaryTypeHandlerBaseWithExternal<PropertyIndex> DictionaryTypeHandlerWithExternal;
+    typedef DictionaryTypeHandlerBaseWithExternal<BigPropertyIndex> BigDictionaryTypeHandlerWithExternal;
+
     typedef ES5ArrayTypeHandlerBase<PropertyIndex> ES5ArrayTypeHandler;
     typedef ES5ArrayTypeHandlerBase<BigPropertyIndex> BigES5ArrayTypeHandler;
+
+    template <class T> class ES5ArrayTypeHandlerBaseWithExternal;
+
+    typedef ES5ArrayTypeHandlerBaseWithExternal<PropertyIndex> ES5ArrayTypeHandlerWithExternal;
+    typedef ES5ArrayTypeHandlerBaseWithExternal<BigPropertyIndex> BigES5ArrayTypeHandlerWithExternal;
 
     template <int N> class ConcatStringN;
     typedef ConcatStringN<2> ConcatStringN2;
@@ -225,4 +252,3 @@ namespace JSON
 #define JS_DIAG_TYPE_JavascriptRegExpConstructor    _u("Object, (RegExp constructor)")
 
 #include "Language/SimdUtils.h"
-

--- a/lib/Runtime/Types/DictionaryTypeHandler.cpp
+++ b/lib/Runtime/Types/DictionaryTypeHandler.cpp
@@ -2181,6 +2181,8 @@ namespace Js
         Recycler* recycler = instance->GetRecycler();
 
         ES5ArrayTypeHandlerBase<T>* newTypeHandler = RecyclerNew(recycler, ES5ArrayTypeHandlerBase<T>, recycler, this);
+        newTypeHandler = instance->GetTypeHandler()->HasExternalDataSupport() ? (ES5ArrayTypeHandlerBaseWithExternal<T>*) newTypeHandler->ConvertToExternalDataSupport(recycler) : newTypeHandler;
+
         // Don't need to transfer the singleton instance, because the new handler takes over this handler.
         AssertMsg((newTypeHandler->GetFlags() & IsPrototypeFlag) == 0, "Why did we create a brand new type handler with a prototype flag set?");
         newTypeHandler->SetFlags(IsPrototypeFlag, this->GetFlags());
@@ -2858,5 +2860,11 @@ namespace Js
     PropertyAttributes GetLetConstGlobalPropertyAttributes(PropertyAttributes attributes)
     {
         return (allowLetConstGlobal && (attributes & PropertyLetConstGlobal) != 0) ? (attributes | PropertyWritable) : attributes;
+    }
+
+    template<typename T>
+    DynamicTypeHandler * DictionaryTypeHandlerBase<T>::ConvertToExternalDataSupport(Recycler* recycler)
+    {
+        return DictionaryTypeHandlerBaseWithExternal<T>::New(recycler, this);
     }
 }

--- a/lib/Runtime/Types/DictionaryTypeHandler.h
+++ b/lib/Runtime/Types/DictionaryTypeHandler.h
@@ -14,13 +14,22 @@ namespace Js
         friend class DeferredTypeHandlerBase;
         template <DeferredTypeInitializer initializer, typename DeferredTypeFilter, bool isPrototypeTemplate, uint16 inlineSlotCapacity, uint16 offsetOfInlineSlots>
         friend class DeferredTypeHandler;
+        template <DeferredTypeInitializer initializer, typename DeferredTypeFilter, bool isPrototypeTemplate, uint16 inlineSlotCapacity, uint16 offsetOfInlineSlots>
+        friend class DeferredTypeHandlerWithExternal;
         friend class PathTypeHandlerBase;
-        template<size_t size>
-        friend class SimpleTypeHandler;
+        template<size_t size> friend class SimpleTypeHandler;
+        template<size_t size> friend class SimpleTypeHandlerExternal;
         friend class DynamicObject;
         friend class DynamicTypeHandler;
         template <typename TPropertyIndex, typename TMapKey, bool IsNotExtensibleSupported> friend class SimpleDictionaryTypeHandlerBase;
+        template <typename TPropertyIndex, typename TMapKey, bool IsNotExtensibleSupported> friend class SimpleDictionaryTypeHandlerBaseWithExternal;
         template <typename T> friend class DictionaryTypeHandlerBase;
+        template <typename T> friend class DictionaryTypeHandlerBaseExternal;
+        template <typename T> friend class DictionaryTypeHandlerBaseWithExternal;
+        template <typename TPropertyIndex, typename TMapKey, bool IsNotExtensibleSupported>
+        friend class SimpleDictionaryUnorderedTypeHandler;
+        template <typename TPropertyIndex, typename TMapKey, bool IsNotExtensibleSupported>
+        friend class SimpleDictionaryUnorderedTypeHandlerWithExternal;
 
         // Explicit non leaf allocator as the key is non-leaf
         typedef JsUtil::BaseDictionary<const PropertyRecord*, DictionaryPropertyDescriptor<T>, RecyclerNonLeafAllocator, DictionarySizePolicy<PowerOf2Policy, 1>, PropertyRecordStringHashComparer>
@@ -246,6 +255,9 @@ namespace Js
         virtual BigDictionaryTypeHandler* NewBigDictionaryTypeHandler(Recycler* recycler, int slotCapacity, uint16 inlineSlotCapacity, uint16 offsetOfInlineSlots);
         static Var CanonicalizeAccessor(Var accessor, /*const*/ JavascriptLibrary* library);
 
+    public:
+        virtual DynamicTypeHandler* ConvertToExternalDataSupport(Recycler* recycler) override;
+
 #if ENABLE_TTD
     public:
         virtual void MarkObjectSlots_TTD(TTD::SnapshotExtractor* extractor, DynamicObject* obj) const override;
@@ -258,4 +270,29 @@ namespace Js
 
     template <bool allowLetConstGlobal>
     inline PropertyAttributes GetLetConstGlobalPropertyAttributes(PropertyAttributes attributes);
+
+    template <typename T>
+    class DictionaryTypeHandlerBaseWithExternal sealed: public DictionaryTypeHandlerBase<T>
+    {
+    public:
+        DEFINE_GETCPPNAME();
+
+        DictionaryTypeHandlerBaseWithExternal(Recycler* recycler):
+            DictionaryTypeHandlerBase<T>(recycler) { DEBUG_CHECKS_FOR_HANDLER_WITH_EXTERNAL(this) }
+
+        DictionaryTypeHandlerBaseWithExternal(Recycler* recycler, int slotCapacity, uint16 inlineSlotCapacity, uint16 offsetOfInlineSlots):
+            DictionaryTypeHandlerBase<T>(recycler, slotCapacity, inlineSlotCapacity, offsetOfInlineSlots) { DEBUG_CHECKS_FOR_HANDLER_WITH_EXTERNAL(this) }
+
+        DictionaryTypeHandlerBaseWithExternal(DictionaryTypeHandlerBase<T>* typeHandler):
+            DictionaryTypeHandlerBase<T>(typeHandler) { DEBUG_CHECKS_FOR_HANDLER_WITH_EXTERNAL(this) }
+
+        DEFINE_VTABLE_CTOR_NO_REGISTER(DictionaryTypeHandlerBaseWithExternal, DictionaryTypeHandlerBase<T>);
+
+    private:
+        DictionaryTypeHandlerBaseWithExternal(Recycler * recycler, DictionaryTypeHandlerBase<T>* sth):
+            DictionaryTypeHandlerBase<T>(sth) { DEBUG_CHECKS_FOR_HANDLER_WITH_EXTERNAL(this) }
+
+    public:
+        DEFINE_HANDLERWITHEXTERNAL_INTERFACE(DictionaryTypeHandlerBase<T>, DictionaryTypeHandlerBaseWithExternal<T>)
+    };
 }

--- a/lib/Runtime/Types/DynamicType.cpp
+++ b/lib/Runtime/Types/DynamicType.cpp
@@ -192,22 +192,6 @@ namespace Js
         return false;
     }
 
-    void DynamicObject::InitSlots(DynamicObject* instance)
-    {
-        InitSlots(instance, GetScriptContext());
-    }
-
-    void DynamicObject::InitSlots(DynamicObject * instance, ScriptContext * scriptContext)
-    {
-        Recycler * recycler = scriptContext->GetRecycler();
-        int slotCapacity = GetTypeHandler()->GetSlotCapacity();
-        int inlineSlotCapacity = GetTypeHandler()->GetInlineSlotCapacity();
-        if (slotCapacity > inlineSlotCapacity)
-        {
-            instance->auxSlots = RecyclerNewArrayZ(recycler, Field(Var), slotCapacity - inlineSlotCapacity);
-        }
-    }
-
     int DynamicObject::GetPropertyCount()
     {
         if (!this->GetTypeHandler()->EnsureObjectReady(this))
@@ -231,7 +215,13 @@ namespace Js
     {
         Assert(!Js::IsInternalPropertyId(propertyId));
         Assert(propertyId != Constants::NoProperty);
-        return GetTypeHandler()->GetPropertyIndex(this->GetScriptContext()->GetPropertyName(propertyId));
+
+        return GetPropertyIndex(this->GetScriptContext()->GetPropertyName(propertyId));
+    }
+
+    PropertyIndex DynamicObject::GetPropertyIndex(const PropertyRecord* propertyRecord)
+    {
+        return GetTypeHandler()->GetPropertyIndex(propertyRecord);
     }
 
     PropertyQueryFlags DynamicObject::HasPropertyQuery(PropertyId propertyId)

--- a/lib/Runtime/Types/ES5ArrayTypeHandler.cpp
+++ b/lib/Runtime/Types/ES5ArrayTypeHandler.cpp
@@ -1336,4 +1336,13 @@ namespace Js
 
     template class ES5ArrayTypeHandlerBase<PropertyIndex>;
     template class ES5ArrayTypeHandlerBase<BigPropertyIndex>;
+
+    template class ES5ArrayTypeHandlerBaseWithExternal<PropertyIndex>;
+    template class ES5ArrayTypeHandlerBaseWithExternal<BigPropertyIndex>;
+
+    template <class T>
+    DynamicTypeHandler* ES5ArrayTypeHandlerBase<T>::ConvertToExternalDataSupport(Recycler* recycler)
+    {
+        return ES5ArrayTypeHandlerBaseWithExternal<T>::New(recycler, this);
+    }
 }

--- a/lib/Runtime/Types/ES5ArrayTypeHandler.h
+++ b/lib/Runtime/Types/ES5ArrayTypeHandler.h
@@ -81,11 +81,13 @@ namespace Js
         }
     };
 
+    template <class T>
+    class ES5ArrayTypeHandlerBaseWithExternal;
     //
     // Private type handler used by ES5Array
     //
     template <class T>
-    class ES5ArrayTypeHandlerBase sealed: public DictionaryTypeHandlerBase<T>
+    class ES5ArrayTypeHandlerBase: public DictionaryTypeHandlerBase<T>
     {
         friend class NullTypeHandlerBase;
         friend class DeferredTypeHandlerBase;
@@ -97,6 +99,7 @@ namespace Js
         template <typename TPropertyIndex, typename TMapKey, bool IsNotExtensibleSupported> friend class SimpleDictionaryTypeHandlerBase;
         template <typename T> friend class DictionaryTypeHandlerBase;
         template <typename T> friend class ES5ArrayTypeHandlerBase;
+        template <class T> friend class ES5ArrayTypeHandlerBaseWithExternal;
 
     private:
         Field(IndexPropertyDescriptorMap*) indexPropertyMap;
@@ -199,10 +202,34 @@ namespace Js
         virtual BOOL FreezeImpl(DynamicObject* instance, bool isConvertedType) override;
         virtual BigDictionaryTypeHandler* NewBigDictionaryTypeHandler(Recycler* recycler, int slotCapacity, uint16 inlineSlotCapacity, uint16 offsetOfInlineSlots) override;
 
+    public:
+        virtual DynamicTypeHandler* ConvertToExternalDataSupport(Recycler* recycler) override;
 #if ENABLE_TTD
         //
         //We let the handler processing fall through -- the snap object extraction will take care of visiting/copying the info from this type into the object representation.
         //
 #endif
+    };
+
+    template <class T>
+    class ES5ArrayTypeHandlerBaseWithExternal sealed: public ES5ArrayTypeHandlerBase<T>
+    {
+    public:
+        DEFINE_GETCPPNAME();
+
+        DEFINE_VTABLE_CTOR_NO_REGISTER(ES5ArrayTypeHandlerBaseWithExternal, ES5ArrayTypeHandlerBase<T>);
+
+        ES5ArrayTypeHandlerBaseWithExternal(Recycler* recycler):
+          ES5ArrayTypeHandlerBase<T>(recycler) { DEBUG_CHECKS_FOR_HANDLER_WITH_EXTERNAL(this) }
+
+        ES5ArrayTypeHandlerBaseWithExternal(Recycler* recycler, int slotCapacity, uint16 inlineSlotCapacity, uint16 offsetOfInlineSlots):
+          ES5ArrayTypeHandlerBase<T>(recycler, slotCapacity, inlineSlotCapacity, offsetOfInlineSlots) { DEBUG_CHECKS_FOR_HANDLER_WITH_EXTERNAL(this) }
+
+    private:
+        ES5ArrayTypeHandlerBaseWithExternal(Recycler * recycler,
+          ES5ArrayTypeHandlerBase<T>* sth): ES5ArrayTypeHandlerBase<T>(recycler, sth) { DEBUG_CHECKS_FOR_HANDLER_WITH_EXTERNAL(this) }
+
+    public:
+        DEFINE_HANDLERWITHEXTERNAL_INTERFACE(ES5ArrayTypeHandlerBase<T>, ES5ArrayTypeHandlerBaseWithExternal<T>)
     };
 }

--- a/lib/Runtime/Types/MissingPropertyTypeHandler.cpp
+++ b/lib/Runtime/Types/MissingPropertyTypeHandler.cpp
@@ -64,7 +64,6 @@ namespace Js
         return false;
     }
 
-
     BOOL MissingPropertyTypeHandler::HasProperty(DynamicObject* instance, JavascriptString* propertyNameString)
     {
         return false;
@@ -172,6 +171,11 @@ namespace Js
     }
 
     BOOL MissingPropertyTypeHandler::FreezeImpl(DynamicObject* instance, bool isConvertedType)
+    {
+        Throw::FatalInternalError();
+    }
+
+    DynamicTypeHandler* MissingPropertyTypeHandler::ConvertToExternalDataSupport(Recycler* recycler)
     {
         Throw::FatalInternalError();
     }

--- a/lib/Runtime/Types/MissingPropertyTypeHandler.h
+++ b/lib/Runtime/Types/MissingPropertyTypeHandler.h
@@ -79,6 +79,9 @@ namespace Js
         BOOL AddProperty(DynamicObject* instance, PropertyId propertyId, Var value, PropertyAttributes attributes, PropertyValueInfo* info, PropertyOperationFlags flags, SideEffects possibleSideEffects);
         virtual BOOL FreezeImpl(DynamicObject* instance, bool isConvertedType) override;
 
+    public:
+        virtual DynamicTypeHandler* ConvertToExternalDataSupport(Recycler* recycler) override;
+
 #if ENABLE_TTD
     public:
         virtual void MarkObjectSlots_TTD(TTD::SnapshotExtractor* extractor, DynamicObject* obj) const override
@@ -91,5 +94,20 @@ namespace Js
             return 0;
         }
 #endif
+    };
+
+    class MissingPropertyTypeHandlerWithExternal sealed : public MissingPropertyTypeHandler
+    {
+    public:
+        DEFINE_GETCPPNAME();
+        MissingPropertyTypeHandlerWithExternal():
+            MissingPropertyTypeHandler() { DEBUG_CHECKS_FOR_HANDLER_WITH_EXTERNAL(this) }
+
+    private:
+        MissingPropertyTypeHandlerWithExternal(Recycler * recycler, MissingPropertyTypeHandler *base):
+            MissingPropertyTypeHandler() { DEBUG_CHECKS_FOR_HANDLER_WITH_EXTERNAL(this) }
+
+    public:
+        DEFINE_HANDLERWITHEXTERNAL_INTERFACE(MissingPropertyTypeHandler, MissingPropertyTypeHandlerWithExternal)
     };
 }

--- a/lib/Runtime/Types/NullTypeHandler.h
+++ b/lib/Runtime/Types/NullTypeHandler.h
@@ -60,6 +60,8 @@ namespace Js
 
         virtual void SetIsPrototype(DynamicObject* instance) override;
 
+        virtual DynamicTypeHandler* ConvertToExternalDataSupport(Recycler* recycler) override;
+
 #if DBG
         virtual bool SupportsPrototypeInstances() const override { return this->isPrototype; }
         virtual bool RespectsIsolatePrototypes() const { return false; }
@@ -79,9 +81,12 @@ namespace Js
         virtual BOOL FreezeImpl(DynamicObject* instance, bool isConvertedType) override;
     };
 
+    template <bool IsPrototypeTemplate> class NullTypeHandlerWithExternal;
+
     template <bool IsPrototypeTemplate>
     class NullTypeHandler : public NullTypeHandlerBase
     {
+        template <bool IsPrototypeTemplate> friend class NullTypeHandlerWithExternal;
     public:
         DEFINE_GETCPPNAME();
 
@@ -93,6 +98,8 @@ namespace Js
 
     public:
         static NullTypeHandler * GetDefaultInstance();
+
+        virtual DynamicTypeHandler* ConvertToExternalDataSupport(Recycler* recycler) override;
 
 #if ENABLE_TTD
     public:
@@ -107,4 +114,26 @@ namespace Js
         }
 #endif
     };
+
+    template <bool IsPrototypeTemplate>
+    class NullTypeHandlerWithExternal sealed : public NullTypeHandler<IsPrototypeTemplate>
+    {
+    public:
+        DEFINE_GETCPPNAME();
+
+    private:
+        NullTypeHandlerWithExternal<IsPrototypeTemplate>():
+            NullTypeHandler<IsPrototypeTemplate>() { DEBUG_CHECKS_FOR_HANDLER_WITH_EXTERNAL(this) }
+
+        NullTypeHandlerWithExternal(Recycler * recycler, NullTypeHandler<IsPrototypeTemplate> * base):
+            NullTypeHandler<IsPrototypeTemplate>() { DEBUG_CHECKS_FOR_HANDLER_WITH_EXTERNAL(this) }
+
+        static NullTypeHandlerWithExternal defaultInstanceWithExternal;
+    public:
+        static NullTypeHandlerWithExternal * GetDefaultInstanceWithExternal();
+
+        DEFINE_HANDLERWITHEXTERNAL_INTERFACE(NullTypeHandler<IsPrototypeTemplate>, NullTypeHandlerWithExternal<IsPrototypeTemplate>)
+    };
+
+
 }

--- a/lib/Runtime/Types/RecyclableObject.h
+++ b/lib/Runtime/Types/RecyclableObject.h
@@ -266,6 +266,7 @@ namespace Js {
         virtual PropertyId GetPropertyId(PropertyIndex index) { return Constants::NoProperty; }
         virtual PropertyId GetPropertyId(BigPropertyIndex index) { return Constants::NoProperty; }
         virtual PropertyIndex GetPropertyIndex(PropertyId propertyId) { return Constants::NoSlot; }
+        virtual PropertyIndex GetPropertyIndex(const PropertyRecord* propertyRecord) { return Constants::NoSlot; }
         virtual int GetPropertyCount() { return 0; }
         virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId);
         virtual BOOL HasOwnProperty( PropertyId propertyId);

--- a/lib/Runtime/Types/SimpleDictionaryTypeHandler.h
+++ b/lib/Runtime/Types/SimpleDictionaryTypeHandler.h
@@ -52,10 +52,20 @@ namespace Js
         friend class NullTypeHandlerBase;
         friend class DeferredTypeHandlerBase;
         friend class PathTypeHandlerBase;
+        template<class T>
+        friend class PathTypeHandlerWithExternal;
         template<size_t size>
         friend class SimpleTypeHandler;
-
-        template <typename TPropertyIndex, typename TMapKey, bool IsNotExtensibleSupported> friend class SimpleDictionaryTypeHandlerBase;
+        template<size_t size>
+        friend class SimpleTypeHandlerWithExternal;
+        template <typename TPropertyIndex, typename TMapKey, bool IsNotExtensibleSupported>
+        friend class SimpleDictionaryTypeHandlerBase;
+        template <typename TPropertyIndex, typename TMapKey, bool IsNotExtensibleSupported>
+        friend class SimpleDictionaryTypeHandlerBaseWithExternal;
+        template <typename TPropertyIndex, typename TMapKey, bool IsNotExtensibleSupported>
+        friend class SimpleDictionaryUnorderedTypeHandler;
+        template <typename TPropertyIndex, typename TMapKey, bool IsNotExtensibleSupported>
+        friend class SimpleDictionaryUnorderedTypeHandlerWithExternal;
 
         // Explicit non leaf allocator now that the key is non-leaf
         typedef JsUtil::BaseDictionary<TMapKey, SimpleDictionaryPropertyDescriptor<TPropertyIndex>, RecyclerNonLeafAllocator, DictionarySizePolicy<PowerOf2Policy, 1>, PropertyRecordStringHashComparer, PropertyMapKeyTraits<TMapKey>::template Entry>
@@ -86,7 +96,9 @@ namespace Js
         SimpleDictionaryTypeHandlerBase(Recycler * recycler);
         SimpleDictionaryTypeHandlerBase(Recycler * recycler, int slotCapacity, uint16 inlineSlotCapacity, uint16 offsetOfInlineSlots, bool isLocked = false, bool isShared = false);
         SimpleDictionaryTypeHandlerBase(ScriptContext * scriptContext, SimplePropertyDescriptor const* propertyDescriptors, int propertyCount, int slotCapacity, uint16 inlineSlotCapacity, uint16 offsetOfInlineSlots, bool isLocked = false, bool isShared = false);
+        SimpleDictionaryTypeHandlerBase(Recycler * recycler, SimpleDictionaryTypeHandlerBase<TPropertyIndex, TMapKey, IsNotExtensibleSupported>* base);
         SimpleDictionaryTypeHandlerBase(Recycler* recycler, int slotCapacity, int propertyCapacity, uint16 inlineSlotCapacity, uint16 offsetOfInlineSlots, bool isLocked = false, bool isShared = false);
+
         DEFINE_VTABLE_CTOR_NO_REGISTER(SimpleDictionaryTypeHandlerBase, DynamicTypeHandler);
 
         typedef PropertyIndexRanges<TPropertyIndex> PropertyIndexRangesType;
@@ -309,6 +321,31 @@ namespace Js
 
         virtual Js::BigPropertyIndex GetPropertyIndex_EnumerateTTD(const Js::PropertyRecord* pRecord) override;
 #endif
+    public:
+        virtual DynamicTypeHandler* ConvertToExternalDataSupport(Recycler* recycler) override;
     };
 
+    template <typename TPropertyIndex, typename TMapKey, bool IsNotExtensibleSupported>
+    class SimpleDictionaryTypeHandlerBaseWithExternal sealed : public SimpleDictionaryTypeHandlerBase<TPropertyIndex, TMapKey, IsNotExtensibleSupported>
+    {
+        typedef SimpleDictionaryTypeHandlerBase<TPropertyIndex, TMapKey, IsNotExtensibleSupported> SimpleDictionaryTypeHandlerBaseTypeDef;
+        typedef SimpleDictionaryTypeHandlerBaseWithExternal<TPropertyIndex, TMapKey, IsNotExtensibleSupported> SimpleDictionaryTypeHandlerBaseWithExternalTypeDef;
+    public:
+        DEFINE_GETCPPNAME();
+
+        SimpleDictionaryTypeHandlerBaseWithExternal(Recycler * recycler):
+            SimpleDictionaryTypeHandlerBaseTypeDef(recycler) { DEBUG_CHECKS_FOR_HANDLER_WITH_EXTERNAL(this) }
+        SimpleDictionaryTypeHandlerBaseWithExternal(Recycler * recycler, int slotCapacity,
+          uint16 inlineSlotCapacity, uint16 offsetOfInlineSlots, bool isLocked = false, bool isShared = false):
+            SimpleDictionaryTypeHandlerBaseTypeDef(recycler, slotCapacity,
+              inlineSlotCapacity, offsetOfInlineSlots, isLocked, isShared) { DEBUG_CHECKS_FOR_HANDLER_WITH_EXTERNAL(this) }
+
+    private:
+        SimpleDictionaryTypeHandlerBaseWithExternal(Recycler * recycler, SimpleDictionaryTypeHandlerBaseTypeDef * base):
+          SimpleDictionaryTypeHandlerBaseTypeDef(recycler, base) { DEBUG_CHECKS_FOR_HANDLER_WITH_EXTERNAL(this) }
+
+    public:
+        DEFINE_HANDLERWITHEXTERNAL_INTERFACE(SimpleDictionaryTypeHandlerBaseTypeDef,
+          SimpleDictionaryTypeHandlerBaseWithExternalTypeDef)
+    };
 }

--- a/lib/Runtime/Types/SimpleDictionaryUnorderedTypeHandler.cpp
+++ b/lib/Runtime/Types/SimpleDictionaryUnorderedTypeHandler.cpp
@@ -138,6 +138,14 @@ namespace Js
         return true;
     }
 
+    template<class TPropertyIndex, class TMapKey, bool IsNotExtensibleSupported>
+    DynamicTypeHandler* SimpleDictionaryUnorderedTypeHandler<TPropertyIndex, TMapKey,
+      IsNotExtensibleSupported>::ConvertToExternalDataSupport(Recycler* recycler)
+    {
+        return SimpleDictionaryUnorderedTypeHandlerWithExternal<TPropertyIndex, TMapKey,
+          IsNotExtensibleSupported>::New(recycler, this);
+    }
+
     template class SimpleDictionaryUnorderedTypeHandler<PropertyIndex, const PropertyRecord*, false>;
     template class SimpleDictionaryUnorderedTypeHandler<PropertyIndex, const PropertyRecord*, true>;
     template class SimpleDictionaryUnorderedTypeHandler<BigPropertyIndex, const PropertyRecord*, false>;
@@ -146,4 +154,13 @@ namespace Js
     template class SimpleDictionaryUnorderedTypeHandler<PropertyIndex, JavascriptString*, true>;
     template class SimpleDictionaryUnorderedTypeHandler<BigPropertyIndex, JavascriptString*, false>;
     template class SimpleDictionaryUnorderedTypeHandler<BigPropertyIndex, JavascriptString*, true>;
+
+    template class SimpleDictionaryUnorderedTypeHandlerWithExternal<PropertyIndex, const PropertyRecord*, false>;
+    template class SimpleDictionaryUnorderedTypeHandlerWithExternal<PropertyIndex, const PropertyRecord*, true>;
+    template class SimpleDictionaryUnorderedTypeHandlerWithExternal<BigPropertyIndex, const PropertyRecord*, false>;
+    template class SimpleDictionaryUnorderedTypeHandlerWithExternal<BigPropertyIndex, const PropertyRecord*, true>;
+    template class SimpleDictionaryUnorderedTypeHandlerWithExternal<PropertyIndex, JavascriptString*, false>;
+    template class SimpleDictionaryUnorderedTypeHandlerWithExternal<PropertyIndex, JavascriptString*, true>;
+    template class SimpleDictionaryUnorderedTypeHandlerWithExternal<BigPropertyIndex, JavascriptString*, false>;
+    template class SimpleDictionaryUnorderedTypeHandlerWithExternal<BigPropertyIndex, JavascriptString*, true>;
 }

--- a/lib/Runtime/Types/SimpleDictionaryUnorderedTypeHandler.h
+++ b/lib/Runtime/Types/SimpleDictionaryUnorderedTypeHandler.h
@@ -20,10 +20,12 @@ namespace Js
     // property indexes from deleted properties for new properties, even if the property ID is different. That is when it
     // transitions into this unordered type handler.
     template<class TPropertyIndex, class TMapKey, bool IsNotExtensibleSupported>
-    class SimpleDictionaryUnorderedTypeHandler sealed : public SimpleDictionaryTypeHandlerBase<TPropertyIndex, TMapKey, IsNotExtensibleSupported>
+    class SimpleDictionaryUnorderedTypeHandler : public SimpleDictionaryTypeHandlerBase<TPropertyIndex, TMapKey, IsNotExtensibleSupported>
     {
         template <typename TPropertyIndex, typename TMapKey, bool IsNotExtensibleSupported> friend class SimpleDictionaryUnorderedTypeHandler;
         template <typename TPropertyIndex, typename TMapKey, bool IsNotExtensibleSupported> friend class SimpleDictionaryTypeHandlerBase;
+        template <typename TPropertyIndex, typename TMapKey, bool IsNotExtensibleSupported> friend class SimpleDictionaryTypeHandlerBaseWithExternal;
+        template <typename TPropertyIndex, typename TMapKey, bool IsNotExtensibleSupported> friend class SimpleDictionaryUnorderedTypeHandlerWithExternal;
 
     private:
         // A deleted property ID that will be reused for the next property add. The object's slot corresponding to this property
@@ -34,6 +36,9 @@ namespace Js
         DEFINE_GETCPPNAME();
 
     public:
+        SimpleDictionaryUnorderedTypeHandler(Recycler * recycler, SimpleDictionaryUnorderedTypeHandler * base)
+          :SimpleDictionaryTypeHandlerBase<TPropertyIndex, TMapKey, IsNotExtensibleSupported>(recycler, base) { }
+
         SimpleDictionaryUnorderedTypeHandler(Recycler * recycler, int slotCapacity, uint16 inlineSlotCapacity, uint16 offsetOfInlineSlots);
         SimpleDictionaryUnorderedTypeHandler(ScriptContext * scriptContext, SimplePropertyDescriptor* propertyDescriptors, int propertyCount, int slotCapacity, uint16 inlineSlotCapacity, uint16 offsetOfInlineSlots);
         SimpleDictionaryUnorderedTypeHandler(Recycler* recycler, int slotCapacity, int propertyCapacity, uint16 inlineSlotCapacity, uint16 offsetOfInlineSlots);
@@ -77,5 +82,26 @@ namespace Js
             DynamicObject *const object,
             const TPropertyIndex existingPropertyIndex,
             TPropertyIndex *const propertyIndex);
+
+    public:
+        virtual DynamicTypeHandler* ConvertToExternalDataSupport(Recycler* recycler) override;
+    };
+
+    template<class TPropertyIndex, class TMapKey, bool IsNotExtensibleSupported>
+    class SimpleDictionaryUnorderedTypeHandlerWithExternal sealed : public SimpleDictionaryUnorderedTypeHandler<TPropertyIndex, TMapKey, IsNotExtensibleSupported>
+    {
+        typedef SimpleDictionaryUnorderedTypeHandler<TPropertyIndex, TMapKey, IsNotExtensibleSupported> SimpleDictionaryUnorderedTypeHandlerTypeDef;
+        typedef SimpleDictionaryUnorderedTypeHandlerWithExternal<TPropertyIndex, TMapKey, IsNotExtensibleSupported> SimpleDictionaryUnorderedTypeHandlerWithExternalTypeDef;
+    public:
+        DEFINE_GETCPPNAME();
+
+    private:
+        SimpleDictionaryUnorderedTypeHandlerWithExternal(Recycler * recycler,
+          SimpleDictionaryUnorderedTypeHandlerTypeDef * base):
+        SimpleDictionaryUnorderedTypeHandlerTypeDef(recycler, base) { }
+
+    public:
+        DEFINE_HANDLERWITHEXTERNAL_INTERFACE(SimpleDictionaryUnorderedTypeHandlerTypeDef,
+          SimpleDictionaryUnorderedTypeHandlerWithExternalTypeDef)
     };
 }

--- a/lib/Runtime/Types/TypePropertyCache.cpp
+++ b/lib/Runtime/Types/TypePropertyCache.cpp
@@ -215,7 +215,7 @@ namespace Js
             *propertyValue =
                 isInlineSlot
                     ? DynamicObject::FromVar(propertyObject)->GetInlineSlot(propertyIndex)
-                    : DynamicObject::FromVar(propertyObject)->GetAuxSlot(propertyIndex);
+                    : DynamicObject::FromVar(propertyObject)->GetAuxSlotAt(propertyIndex);
             if(propertyObject->GetScriptContext() == requestContext)
             {
                 Assert(*propertyValue == JavascriptOperators::GetProperty(propertyObject, propertyId, requestContext));
@@ -271,7 +271,7 @@ namespace Js
         *propertyValue =
             isInlineSlot
                 ? prototypeObjectWithProperty->GetInlineSlot(propertyIndex)
-                : prototypeObjectWithProperty->GetAuxSlot(propertyIndex);
+                : prototypeObjectWithProperty->GetAuxSlotAt(propertyIndex);
         if(prototypeObjectWithProperty->GetScriptContext() == requestContext)
         {
             Assert(*propertyValue == JavascriptOperators::GetProperty(propertyObject, propertyId, requestContext));
@@ -373,7 +373,7 @@ namespace Js
         }
         else
         {
-            DynamicObject::FromVar(object)->SetAuxSlot(SetSlotArguments(propertyId, propertyIndex, propertyValue));
+            DynamicObject::FromVar(object)->SetAuxSlotAt(SetSlotArguments(propertyId, propertyIndex, propertyValue));
         }
 
         if(objectScriptContext == requestContext)

--- a/test.diff
+++ b/test.diff
@@ -1,0 +1,1141 @@
+diff --git a/lib/Runtime/Language/JavascriptOperators.cpp b/lib/Runtime/Language/JavascriptOperators.cpp
+index 45ca92049..03ed26f24 100644
+--- a/lib/Runtime/Language/JavascriptOperators.cpp
++++ b/lib/Runtime/Language/JavascriptOperators.cpp
+@@ -6070,10 +6070,13 @@ CommonNumber:
+         // after we fail the guard check.  When invalidating the cache for proto change, make sure we zap the prototype field of the cache in
+         // addition to the guard value.
+         bool prototypeCanBeCached;
++        auto functionTypeHandler = ((Js::DynamicObject*)function)->GetTypeHandler();
++        bool hasExternalDataSupport = functionTypeHandler->HasExternalDataSupport();
++
+         RecyclableObject* prototype = JavascriptOperators::GetPrototypeObjectForConstructorCache(function, constructorScriptContext, prototypeCanBeCached);
+         prototype = RecyclableObject::FromVar(CrossSite::MarshalVar(requestContext, prototype));
+ 
+-        DynamicObject* newObject = requestContext->GetLibrary()->CreateObject(prototype, 8);
++        DynamicObject* newObject = requestContext->GetLibrary()->CreateObject(prototype, 8, hasExternalDataSupport);
+ 
+         JS_ETW(EventWriteJSCRIPT_RECYCLER_ALLOCATE_OBJECT(newObject));
+ #if ENABLE_DEBUG_CONFIG_OPTIONS
+diff --git a/lib/Runtime/Library/JavascriptGeneratorFunction.cpp b/lib/Runtime/Library/JavascriptGeneratorFunction.cpp
+index 9f9168a1a..8ed92b236 100644
+--- a/lib/Runtime/Library/JavascriptGeneratorFunction.cpp
++++ b/lib/Runtime/Library/JavascriptGeneratorFunction.cpp
+@@ -125,7 +125,8 @@ namespace Js
+         CopyArray(argsHeapCopy, stackArgs.Info.Count, stackArgs.Values, stackArgs.Info.Count);
+         Arguments heapArgs(callInfo, (Var*)argsHeapCopy);
+ 
+-        DynamicObject* prototype = scriptContext->GetLibrary()->CreateGeneratorConstructorPrototypeObject();
++        auto typeHandler = ((DynamicObject*)function)->GetTypeHandler();
++        DynamicObject* prototype = scriptContext->GetLibrary()->CreateGeneratorConstructorPrototypeObject(typeHandler->HasExternalDataSupport());
+         JavascriptGenerator* generator = scriptContext->GetLibrary()->CreateGenerator(heapArgs, generatorFunction->scriptFunction, prototype);
+         // Set the prototype from constructor
+         JavascriptOperators::OrdinaryCreateFromConstructor(function, generator, prototype, scriptContext);
+diff --git a/lib/Runtime/Library/JavascriptLibrary.cpp b/lib/Runtime/Library/JavascriptLibrary.cpp
+index d7344cecb..4c9bdbb07 100644
+--- a/lib/Runtime/Library/JavascriptLibrary.cpp
++++ b/lib/Runtime/Library/JavascriptLibrary.cpp
+@@ -50,6 +50,16 @@ namespace Js
+     SimpleTypeHandler<1> JavascriptLibrary::SharedNamespaceSymbolTypeHandler(NO_WRITE_BARRIER_TAG(ModuleNamespaceTypeDescriptors));
+     MissingPropertyTypeHandler JavascriptLibrary::MissingPropertyHolderTypeHandler;
+ 
++    SimpleTypeHandlerWithExternal<1> JavascriptLibrary::SharedPrototypeTypeHandlerWithExternal(NO_WRITE_BARRIER_TAG(BuiltInPropertyRecords::constructor), PropertyWritable | PropertyConfigurable, PropertyTypesWritableDataOnly, 4, sizeof(DynamicObject));
++    SimpleTypeHandlerWithExternal<1> JavascriptLibrary::SharedFunctionWithoutPrototypeTypeHandlerWithExternal(NO_WRITE_BARRIER_TAG(BuiltInPropertyRecords::name), PropertyConfigurable);
++    SimpleTypeHandlerWithExternal<1> JavascriptLibrary::SharedFunctionWithPrototypeTypeHandlerV11WithExternal(NO_WRITE_BARRIER_TAG(BuiltInPropertyRecords::prototype), PropertyWritable);
++    SimpleTypeHandlerWithExternal<2> JavascriptLibrary::SharedFunctionWithPrototypeTypeHandlerWithExternal(NO_WRITE_BARRIER_TAG(SharedFunctionPropertyDescriptors));
++    SimpleTypeHandlerWithExternal<1> JavascriptLibrary::SharedIdMappedFunctionWithPrototypeTypeHandlerWithExternal(NO_WRITE_BARRIER_TAG(BuiltInPropertyRecords::prototype));
++    SimpleTypeHandlerWithExternal<1> JavascriptLibrary::SharedFunctionWithLengthTypeHandlerWithExternal(NO_WRITE_BARRIER_TAG(BuiltInPropertyRecords::length));
++    SimpleTypeHandlerWithExternal<2> JavascriptLibrary::SharedFunctionWithLengthAndNameTypeHandlerWithExternal(NO_WRITE_BARRIER_TAG(FunctionWithLengthAndNameTypeDescriptors));
++    SimpleTypeHandlerWithExternal<1> JavascriptLibrary::SharedNamespaceSymbolTypeHandlerWithExternal(NO_WRITE_BARRIER_TAG(ModuleNamespaceTypeDescriptors));
++    MissingPropertyTypeHandlerWithExternal JavascriptLibrary::MissingPropertyHolderTypeHandlerWithExternal;
++
+ 
+     SimplePropertyDescriptor const JavascriptLibrary::HeapArgumentsPropertyDescriptors[3] =
+     {
+@@ -120,10 +130,14 @@ namespace Js
+             DynamicType::New(scriptContext, TypeIds_Object, nullValue, nullptr,
+             DeferredTypeHandler<InitializeObjectPrototype, DefaultDeferredTypeFilter, true>::GetDefaultInstance()));
+ 
+-        constructorPrototypeObjectType = DynamicType::New(scriptContext, TypeIds_Object, objectPrototype, nullptr,
++        constructorPrototypeObjectType[ 0 /* normal */ ] = DynamicType::New(scriptContext, TypeIds_Object, objectPrototype, nullptr,
+             &SharedPrototypeTypeHandler, true, true);
+ 
+-        constructorPrototypeObjectType->SetHasNoEnumerableProperties(true);
++        constructorPrototypeObjectType[ 1 /* withExternalData */ ] = DynamicType::New(scriptContext, TypeIds_Object, objectPrototype, nullptr,
++                                                          &SharedPrototypeTypeHandlerWithExternal, true, true);
++
++        constructorPrototypeObjectType[0]->SetHasNoEnumerableProperties(true);
++        constructorPrototypeObjectType[1]->SetHasNoEnumerableProperties(true);
+ 
+         arrayBufferPrototype = DynamicObject::New(recycler,
+             DynamicType::New(scriptContext, TypeIds_Object, objectPrototype, nullptr,
+@@ -525,34 +539,34 @@ namespace Js
+         variantDateType = StaticType::New(scriptContext, TypeIds_VariantDate, nullValue, nullptr);
+ 
+         anonymousFunctionTypeHandler = NullTypeHandler<false>::GetDefaultInstance();
++        anonymousFunctionTypeHandlerWithExternal = NullTypeHandlerWithExternal<false>::GetDefaultInstanceWithExternal();
+         anonymousFunctionWithPrototypeTypeHandler = &SharedFunctionWithPrototypeTypeHandlerV11;
+-
+-        anonymousFunctionTypeHandlerWithExternal = anonymousFunctionTypeHandler->ConvertToExternalDataSupport(recycler);
+-        anonymousFunctionWithPrototypeTypeHandlerWithExternal = anonymousFunctionWithPrototypeTypeHandler->ConvertToExternalDataSupport(recycler);
++        anonymousFunctionWithPrototypeTypeHandlerWithExternal = &SharedFunctionWithPrototypeTypeHandlerV11WithExternal;
+ 
+         //  Initialize function types
+         if (config->IsES6FunctionNameEnabled())
+         {
+             functionTypeHandler = &SharedFunctionWithoutPrototypeTypeHandler;
++            functionTypeHandlerWithExternal = &SharedFunctionWithoutPrototypeTypeHandlerWithExternal;
+         }
+         else
+         {
+             functionTypeHandler = anonymousFunctionTypeHandler;
++            functionTypeHandlerWithExternal = anonymousFunctionTypeHandlerWithExternal;
+         }
+ 
+-        functionTypeHandlerWithExternal = functionTypeHandler->ConvertToExternalDataSupport(recycler);
+-
+         if (config->IsES6FunctionNameEnabled())
+         {
+             functionWithPrototypeTypeHandler = &SharedFunctionWithPrototypeTypeHandler;
++            functionWithPrototypeTypeHandlerWithExternal = &SharedFunctionWithPrototypeTypeHandlerWithExternal;
+         }
+         else
+         {
+             functionWithPrototypeTypeHandler = anonymousFunctionWithPrototypeTypeHandler;
++            functionWithPrototypeTypeHandlerWithExternal = anonymousFunctionWithPrototypeTypeHandlerWithExternal;
+         }
+         functionWithPrototypeTypeHandler->SetHasKnownSlot0();
+ 
+-        functionWithPrototypeTypeHandlerWithExternal = functionWithPrototypeTypeHandler->ConvertToExternalDataSupport(recycler);
+ 
+         externalFunctionWithDeferredPrototypeType = CreateDeferredPrototypeFunctionTypeNoProfileThunk(JavascriptExternalFunction::ExternalFunctionThunk, true /*isShared*/);
+         wrappedFunctionWithDeferredPrototypeType = CreateDeferredPrototypeFunctionTypeNoProfileThunk(JavascriptExternalFunction::WrappedFunctionThunk, true /*isShared*/);
+@@ -706,10 +720,14 @@ namespace Js
+ 
+         if (config->IsES6GeneratorsEnabled())
+         {
+-            generatorConstructorPrototypeObjectType = DynamicType::New(scriptContext, TypeIds_Object, generatorPrototype, nullptr,
++            generatorConstructorPrototypeObjectType[0 /* normal */] = DynamicType::New(scriptContext, TypeIds_Object, generatorPrototype, nullptr,
+                 NullTypeHandler<false>::GetDefaultInstance(), true, true);
+ 
+-            generatorConstructorPrototypeObjectType->SetHasNoEnumerableProperties(true);
++            generatorConstructorPrototypeObjectType[1 /* withExternalData */] = DynamicType::New(scriptContext, TypeIds_Object, generatorPrototype, nullptr,
++                NullTypeHandlerWithExternal<false>::GetDefaultInstanceWithExternal(), true, true);
++
++            generatorConstructorPrototypeObjectType[0]->SetHasNoEnumerableProperties(true);
++            generatorConstructorPrototypeObjectType[1]->SetHasNoEnumerableProperties(true);
+         }
+ 
+ #ifdef ENABLE_DEBUG_CONFIG_OPTIONS
+@@ -733,7 +751,7 @@ namespace Js
+           (hasExternal) ? javascriptLibrary->functionWithPrototypeTypeHandlerWithExternal : javascriptLibrary->functionWithPrototypeTypeHandler;
+ 
+         typeHandler->Convert(function, baseTypeHandler);
+-        function->SetPropertyWithAttributes(PropertyIds::prototype, javascriptLibrary->CreateGeneratorConstructorPrototypeObject(), PropertyWritable, nullptr);
++        function->SetPropertyWithAttributes(PropertyIds::prototype, javascriptLibrary->CreateGeneratorConstructorPrototypeObject(hasExternal), PropertyWritable, nullptr);
+ 
+         if (function->GetScriptContext()->GetConfig()->IsES6FunctionNameEnabled() && !isAnonymousFunction)
+         {
+@@ -797,7 +815,9 @@ namespace Js
+               (hasExternal) ? javascriptLibrary->functionWithPrototypeTypeHandlerWithExternal : javascriptLibrary->functionWithPrototypeTypeHandler;
+ 
+             typeHandler->Convert(function, baseTypeHandler);
+-            function->SetProperty(PropertyIds::prototype, javascriptLibrary->CreateConstructorPrototypeObject((Js::JavascriptFunction *)function), PropertyOperation_None, nullptr);
++            function->SetProperty(PropertyIds::prototype,
++              javascriptLibrary->CreateConstructorPrototypeObject((Js::JavascriptFunction *)function,
++              hasExternal), PropertyOperation_None, nullptr);
+         }
+ 
+         if (scriptFunction)
+@@ -4909,7 +4929,7 @@ namespace Js
+         Js::RecyclableObject* objPrototype;
+         if (prototype == nullptr)
+         {
+-            objPrototype = CreateConstructorPrototypeObject(function);
++            objPrototype = CreateConstructorPrototypeObject(function, false);
+             Assert(!objPrototype->IsEnumerable(Js::PropertyIds::constructor));
+         }
+         else
+@@ -5712,7 +5732,7 @@ namespace Js
+             }
+             else
+             {
+-                Assert(typeHandler == &SharedIdMappedFunctionWithPrototypeTypeHandler);
++                Assert(typeHandler == &SharedIdMappedFunctionWithPrototypeTypeHandler || typeHandler == &SharedIdMappedFunctionWithPrototypeTypeHandlerWithExternal);
+                 function->ReplaceType(crossSiteIdMappedFunctionWithPrototypeType);
+             }
+         }
+@@ -6737,18 +6757,18 @@ namespace Js
+ 
+ #endif
+ 
+-    DynamicObject* JavascriptLibrary::CreateGeneratorConstructorPrototypeObject()
++    DynamicObject* JavascriptLibrary::CreateGeneratorConstructorPrototypeObject(bool hasExternalData)
+     {
+-        AssertMsg(generatorConstructorPrototypeObjectType, "Where's generatorConstructorPrototypeObjectType?");
+-        DynamicObject * prototype = DynamicObject::New(this->GetRecycler(), generatorConstructorPrototypeObjectType);
++        AssertMsg(generatorConstructorPrototypeObjectType[(int)hasExternalData], "Where's generatorConstructorPrototypeObjectType?");
++        DynamicObject * prototype = DynamicObject::New(this->GetRecycler(), generatorConstructorPrototypeObjectType[(int)hasExternalData]);
+         // Generator functions' prototype objects are not created with a .constructor property
+         return prototype;
+     }
+ 
+-    DynamicObject* JavascriptLibrary::CreateConstructorPrototypeObject(JavascriptFunction * constructor)
++    DynamicObject* JavascriptLibrary::CreateConstructorPrototypeObject(JavascriptFunction * constructor, bool hasExternalData)
+     {
+-        AssertMsg(constructorPrototypeObjectType, "Where's constructorPrototypeObjectType?");
+-        DynamicObject * prototype = DynamicObject::New(this->GetRecycler(), constructorPrototypeObjectType);
++        AssertMsg(constructorPrototypeObjectType[(int)hasExternalData], "Where's constructorPrototypeObjectType?");
++        DynamicObject * prototype = DynamicObject::New(this->GetRecycler(), constructorPrototypeObjectType[(int)hasExternalData]);
+         AddMember(prototype, PropertyIds::constructor, constructor);
+         return prototype;
+     }
+@@ -6776,9 +6796,11 @@ namespace Js
+                 RecyclableObject::DefaultEntryPoint, typeHandler, false, false));
+     }
+ 
+-    DynamicType* JavascriptLibrary::CreateObjectType(RecyclableObject* prototype, Js::TypeId typeId, uint16 requestedInlineSlotCapacity)
++    DynamicType* JavascriptLibrary::CreateObjectType(RecyclableObject* prototype, Js::TypeId typeId, uint16 requestedInlineSlotCapacity, bool hasExternalData)
+     {
+-        const bool useObjectHeaderInlining = FunctionBody::DoObjectHeaderInliningForConstructor(requestedInlineSlotCapacity);
++        // why !hasExternalData? -> when typeHandler has external data, member object will allocate initial auxSlot memory
++        // Thus, offsetOfInlineSlots shouldn't be the offset of aux slots.
++        const bool useObjectHeaderInlining = !hasExternalData && FunctionBody::DoObjectHeaderInliningForConstructor(requestedInlineSlotCapacity);
+         const uint16 offsetOfInlineSlots =
+             useObjectHeaderInlining
+             ? DynamicTypeHandler::GetOffsetOfObjectHeaderInlineSlots()
+@@ -6870,7 +6892,16 @@ namespace Js
+         }
+         oldCachedType = dynamicType;
+ #endif
+-        SimplePathTypeHandler* typeHandler = SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, requestedInlineSlotCapacity, offsetOfInlineSlots, true, true);
++        SimplePathTypeHandler* typeHandler;
++        if (!hasExternalData)
++        {
++            typeHandler = SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, requestedInlineSlotCapacity, offsetOfInlineSlots, true, true);
++        }
++        else
++        {
++            typeHandler = PathTypeHandlerWithExternal<SimplePathTypeHandler>::New(scriptContext, this->GetRootPath(), 0, requestedInlineSlotCapacity, offsetOfInlineSlots, true, true);
++        }
++
+         dynamicType = DynamicType::New(scriptContext, typeId, prototype, RecyclableObject::DefaultEntryPoint, typeHandler, true, true);
+ 
+         if (useCache)
+@@ -6897,23 +6928,33 @@ namespace Js
+         return dynamicType;
+     }
+ 
+-    DynamicType* JavascriptLibrary::CreateObjectTypeNoCache(RecyclableObject* prototype, Js::TypeId typeId)
++    DynamicType* JavascriptLibrary::CreateObjectTypeNoCache(RecyclableObject* prototype, Js::TypeId typeId, bool hasExternalData)
+     {
++        SimplePathTypeHandler* typeHandler = nullptr;
++        if (hasExternalData)
++        {
++            typeHandler = PathTypeHandlerWithExternal<SimplePathTypeHandler>::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true);
++        }
++        else
++        {
++            typeHandler = SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true);
++        }
++
+         return DynamicType::New(scriptContext, typeId, prototype, RecyclableObject::DefaultEntryPoint,
+-            SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true), true, true);
++            typeHandler, true, true);
+     }
+ 
+-    DynamicType* JavascriptLibrary::CreateObjectType(RecyclableObject* prototype, uint16 requestedInlineSlotCapacity)
++    DynamicType* JavascriptLibrary::CreateObjectType(RecyclableObject* prototype, uint16 requestedInlineSlotCapacity, bool hasExternalData)
+     {
+         // We can't reuse the type in objectType even if the prototype is the object prototype, because those has inline slot capacity fixed
+-        return CreateObjectType(prototype, TypeIds_Object, requestedInlineSlotCapacity);
++        return CreateObjectType(prototype, TypeIds_Object, requestedInlineSlotCapacity, hasExternalData);
+     }
+ 
+-    DynamicObject* JavascriptLibrary::CreateObject(RecyclableObject* prototype, uint16 requestedInlineSlotCapacity)
++    DynamicObject* JavascriptLibrary::CreateObject(RecyclableObject* prototype, uint16 requestedInlineSlotCapacity, bool hasExternalData)
+     {
+         Assert(JavascriptOperators::IsObjectOrNull(prototype));
+ 
+-        DynamicType* dynamicType = CreateObjectType(prototype, requestedInlineSlotCapacity);
++        DynamicType* dynamicType = CreateObjectType(prototype, requestedInlineSlotCapacity, hasExternalData);
+         return DynamicObject::New(this->GetRecycler(), dynamicType);
+     }
+ 
+diff --git a/lib/Runtime/Library/JavascriptLibrary.h b/lib/Runtime/Library/JavascriptLibrary.h
+index bfcaa9e6e..65aa849ed 100644
+--- a/lib/Runtime/Library/JavascriptLibrary.h
++++ b/lib/Runtime/Library/JavascriptLibrary.h
+@@ -176,6 +176,11 @@ namespace Js
+         static hash_t GetHashCode(RecyclerWeakReference<Js::RecyclableObject>* o);
+     };
+ 
++    template <size_t size>
++    class SimpleTypeHandlerWithExternal;
++
++    class MissingPropertyTypeHandlerWithExternal;
++
+     class JavascriptLibrary : public JavascriptLibraryBase
+     {
+         friend class EditAndContinue;
+@@ -244,8 +249,9 @@ namespace Js
+ 
+         Field(UndeclaredBlockVariable*) undeclBlockVarSentinel;
+ 
+-        Field(DynamicType *) generatorConstructorPrototypeObjectType;
+-        Field(DynamicType *) constructorPrototypeObjectType;
++        Field(DynamicType *) generatorConstructorPrototypeObjectType[2]; // 0: normal 1: hasExternalData
++        Field(DynamicType *) constructorPrototypeObjectType[2]; // 0: normal 1: hasExternalData
++
+         Field(DynamicType *) heapArgumentsType;
+         Field(DynamicType *) activationObjectType;
+         Field(DynamicType *) arrayType;
+@@ -547,6 +553,16 @@ namespace Js
+         static SimpleTypeHandler<1> SharedNamespaceSymbolTypeHandler;
+         static MissingPropertyTypeHandler MissingPropertyHolderTypeHandler;
+ 
++        static SimpleTypeHandlerWithExternal<1> SharedPrototypeTypeHandlerWithExternal;
++        static SimpleTypeHandlerWithExternal<1> SharedFunctionWithoutPrototypeTypeHandlerWithExternal;
++        static SimpleTypeHandlerWithExternal<1> SharedFunctionWithPrototypeTypeHandlerV11WithExternal;
++        static SimpleTypeHandlerWithExternal<2> SharedFunctionWithPrototypeTypeHandlerWithExternal;
++        static SimpleTypeHandlerWithExternal<1> SharedFunctionWithLengthTypeHandlerWithExternal;
++        static SimpleTypeHandlerWithExternal<2> SharedFunctionWithLengthAndNameTypeHandlerWithExternal;
++        static SimpleTypeHandlerWithExternal<1> SharedIdMappedFunctionWithPrototypeTypeHandlerWithExternal;
++        static SimpleTypeHandlerWithExternal<1> SharedNamespaceSymbolTypeHandlerWithExternal;
++        static MissingPropertyTypeHandlerWithExternal MissingPropertyHolderTypeHandlerWithExternal;
++
+         static SimplePropertyDescriptor const SharedFunctionPropertyDescriptors[2];
+         static SimplePropertyDescriptor const HeapArgumentsPropertyDescriptors[3];
+         static SimplePropertyDescriptor const FunctionWithLengthAndPrototypeTypeDescriptors[2];
+@@ -1064,18 +1080,18 @@ namespace Js
+ #endif
+ #endif
+ 
+-        DynamicObject* CreateGeneratorConstructorPrototypeObject();
+-        DynamicObject* CreateConstructorPrototypeObject(JavascriptFunction * constructor);
++        DynamicObject* CreateGeneratorConstructorPrototypeObject(bool hasExternalData);
++        DynamicObject* CreateConstructorPrototypeObject(JavascriptFunction * constructor, bool hasExternalData);
+         DynamicObject* CreateObject(const bool allowObjectHeaderInlining = false, const PropertyIndex requestedInlineSlotCapacity = 0);
+         DynamicObject* CreateObject(DynamicTypeHandler * typeHandler);
+         DynamicObject* CreateActivationObject();
+         DynamicObject* CreatePseudoActivationObject();
+         DynamicObject* CreateBlockActivationObject();
+         DynamicObject* CreateConsoleScopeActivationObject();
+-        DynamicType* CreateObjectType(RecyclableObject* prototype, Js::TypeId typeId, uint16 requestedInlineSlotCapacity);
+-        DynamicType* CreateObjectTypeNoCache(RecyclableObject* prototype, Js::TypeId typeId);
+-        DynamicType* CreateObjectType(RecyclableObject* prototype, uint16 requestedInlineSlotCapacity);
+-        DynamicObject* CreateObject(RecyclableObject* prototype, uint16 requestedInlineSlotCapacity = 0);
++        DynamicType* CreateObjectType(RecyclableObject* prototype, Js::TypeId typeId, uint16 requestedInlineSlotCapacity, bool hasExternalData = false);
++        DynamicType* CreateObjectTypeNoCache(RecyclableObject* prototype, Js::TypeId typeId, bool hasExternalData = false);
++        DynamicType* CreateObjectType(RecyclableObject* prototype, uint16 requestedInlineSlotCapacity, bool hasExternalData = false);
++        DynamicObject* CreateObject(RecyclableObject* prototype, uint16 requestedInlineSlotCapacity = 0, bool hasExternalData = false);
+ 
+         typedef JavascriptString* LibStringType; // used by diagnostics template
+         template< size_t N > JavascriptString* CreateStringFromCppLiteral(const char16 (&value)[N]) const;
+diff --git a/lib/Runtime/RuntimeCommon.h b/lib/Runtime/RuntimeCommon.h
+index 7c9af88c7..ee402c642 100644
+--- a/lib/Runtime/RuntimeCommon.h
++++ b/lib/Runtime/RuntimeCommon.h
+@@ -196,9 +196,19 @@ namespace Js
+     typedef DictionaryTypeHandlerBase<PropertyIndex> DictionaryTypeHandler;
+     typedef DictionaryTypeHandlerBase<BigPropertyIndex> BigDictionaryTypeHandler;
+ 
++    template <class T> class DictionaryTypeHandlerBaseWithExternal;
++
++    typedef DictionaryTypeHandlerBaseWithExternal<PropertyIndex> DictionaryTypeHandlerWithExternal;
++    typedef DictionaryTypeHandlerBaseWithExternal<BigPropertyIndex> BigDictionaryTypeHandlerWithExternal;
++
+     typedef ES5ArrayTypeHandlerBase<PropertyIndex> ES5ArrayTypeHandler;
+     typedef ES5ArrayTypeHandlerBase<BigPropertyIndex> BigES5ArrayTypeHandler;
+ 
++    template <class T> class ES5ArrayTypeHandlerBaseWithExternal;
++
++    typedef ES5ArrayTypeHandlerBaseWithExternal<PropertyIndex> ES5ArrayTypeHandlerWithExternal;
++    typedef ES5ArrayTypeHandlerBaseWithExternal<BigPropertyIndex> BigES5ArrayTypeHandlerWithExternal;
++
+     template <int N> class ConcatStringN;
+     typedef ConcatStringN<2> ConcatStringN2;
+     typedef ConcatStringN<4> ConcatStringN4;
+diff --git a/lib/Runtime/Types/DictionaryTypeHandler.h b/lib/Runtime/Types/DictionaryTypeHandler.h
+index 73e097990..4d1634342 100644
+--- a/lib/Runtime/Types/DictionaryTypeHandler.h
++++ b/lib/Runtime/Types/DictionaryTypeHandler.h
+@@ -256,7 +256,6 @@ namespace Js
+         static Var CanonicalizeAccessor(Var accessor, /*const*/ JavascriptLibrary* library);
+ 
+     public:
+-        virtual bool HasExternalDataSupport() override { return false; }
+         virtual DynamicTypeHandler* ConvertToExternalDataSupport(Recycler* recycler) override;
+ 
+ #if ENABLE_TTD
+@@ -278,8 +277,20 @@ namespace Js
+     public:
+         DEFINE_GETCPPNAME();
+ 
++        DictionaryTypeHandlerBaseWithExternal(Recycler* recycler):
++            DictionaryTypeHandlerBase<T>(recycler) { DEBUG_CHECKS_FOR_HANDLER_WITH_EXTERNAL(this) }
++
++        DictionaryTypeHandlerBaseWithExternal(Recycler* recycler, int slotCapacity, uint16 inlineSlotCapacity, uint16 offsetOfInlineSlots):
++            DictionaryTypeHandlerBase<T>(recycler, slotCapacity, inlineSlotCapacity, offsetOfInlineSlots) { DEBUG_CHECKS_FOR_HANDLER_WITH_EXTERNAL(this) }
++
++        DictionaryTypeHandlerBaseWithExternal(DictionaryTypeHandlerBase<T>* typeHandler):
++            DictionaryTypeHandlerBase<T>(typeHandler) { DEBUG_CHECKS_FOR_HANDLER_WITH_EXTERNAL(this) }
++
++        DEFINE_VTABLE_CTOR_NO_REGISTER(DictionaryTypeHandlerBaseWithExternal, DictionaryTypeHandlerBase<T>);
++
+     private:
+-        DictionaryTypeHandlerBaseWithExternal(Recycler * recycler, DictionaryTypeHandlerBase<T>* sth): DictionaryTypeHandlerBase<T>(sth) { }
++        DictionaryTypeHandlerBaseWithExternal(Recycler * recycler, DictionaryTypeHandlerBase<T>* sth):
++            DictionaryTypeHandlerBase<T>(sth) { DEBUG_CHECKS_FOR_HANDLER_WITH_EXTERNAL(this) }
+ 
+     public:
+         DEFINE_HANDLERWITHEXTERNAL_INTERFACE(DictionaryTypeHandlerBase<T>, DictionaryTypeHandlerBaseWithExternal<T>)
+diff --git a/lib/Runtime/Types/DynamicObject.cpp b/lib/Runtime/Types/DynamicObject.cpp
+index 94a221600..121e52b3b 100644
+--- a/lib/Runtime/Types/DynamicObject.cpp
++++ b/lib/Runtime/Types/DynamicObject.cpp
+@@ -15,13 +15,14 @@ namespace Js
+         objectArray(nullptr)
+     {
+         Assert(!UsesObjectArrayOrFlagsAsFlags());
+-        if(initSlots)
++        auto typeHandler = this->GetTypeHandler();
++        if(initSlots || typeHandler->HasExternalDataSupport())
+         {
+-            InitSlots(this);
++            InitSlots(this, typeHandler->HasExternalDataSupport());
+         }
+         else
+         {
+-            Assert(type->GetTypeHandler()->GetInlineSlotCapacity() == type->GetTypeHandler()->GetSlotCapacity());
++            Assert(typeHandler->GetInlineSlotCapacity() == typeHandler->GetSlotCapacity());
+         }
+ 
+ #if ENABLE_OBJECT_SOURCE_TRACKING
+@@ -39,7 +40,7 @@ namespace Js
+         objectArray(nullptr)
+     {
+         Assert(!UsesObjectArrayOrFlagsAsFlags());
+-        InitSlots(this, scriptContext);
++        InitSlots(this, scriptContext, GetTypeHandler()->HasExternalDataSupport());
+ 
+ #if ENABLE_OBJECT_SOURCE_TRACKING
+         TTD::InitializeDiagnosticOriginInformation(this->TTDDiagOriginInfo);
+@@ -848,19 +849,28 @@ namespace Js
+     }
+ #endif
+ 
+-    void DynamicObject::InitSlots(DynamicObject* instance)
++    void DynamicObject::InitSlots(DynamicObject* instance, bool hasExternalDataSupport)
+     {
+-        InitSlots(instance, GetScriptContext());
++        InitSlots(instance, GetScriptContext(), hasExternalDataSupport);
+     }
+ 
+-    void DynamicObject::InitSlots(DynamicObject * instance, ScriptContext * scriptContext)
++    void DynamicObject::InitSlots(DynamicObject * instance, ScriptContext * scriptContext, bool hasExternalDataSupport)
+     {
+         Recycler * recycler = scriptContext->GetRecycler();
+         int slotCapacity = GetTypeHandler()->GetSlotCapacity();
+         int inlineSlotCapacity = GetTypeHandler()->GetInlineSlotCapacity();
+-        if (slotCapacity > inlineSlotCapacity)
++        int auxSlotCount = slotCapacity - inlineSlotCapacity;
++        if (auxSlotCount > 0 || hasExternalDataSupport)
+         {
+-            instance->ResetAuxSlots(recycler, (slotCapacity - inlineSlotCapacity), 0);
++            if (auxSlotCount == 0)
++            {
++                auto typeHandler = GetTypeHandler();
++
++                auxSlotCount = 4;
++                typeHandler->SetSlotCapacity(4 + typeHandler->GetInlineSlotCapacity());
++            }
++
++            instance->ResetAuxSlots(recycler, auxSlotCount, 0);
+         }
+     }
+ 
+@@ -921,6 +931,12 @@ namespace Js
+ 
+             slotCount = newSlotCount;
+         }
++        else if (slotCount == 0)
++        {
++            this->ResetAuxSlots(scriptContext->GetRecycler(), 4, 0);
++            slotCount = 4;
++            typeHandler->SetSlotCapacity(slotCount + typeHandler->GetInlineSlotCapacity());
++        }
+ 
+         this->auxSlots_[slotCount] = data;
+     }
+diff --git a/lib/Runtime/Types/DynamicObject.h b/lib/Runtime/Types/DynamicObject.h
+index e83c2ea23..6a7a9f062 100644
+--- a/lib/Runtime/Types/DynamicObject.h
++++ b/lib/Runtime/Types/DynamicObject.h
+@@ -108,7 +108,7 @@ namespace Js
+         CompileAssert(sizeof(ProfileId) == 2);
+         CompileAssert(static_cast<intptr_t>(DynamicObjectFlags::ObjectArrayFlagsTag) != 0);
+ 
+-        void InitSlots(DynamicObject * instance, ScriptContext * scriptContext);
++        void InitSlots(DynamicObject * instance, ScriptContext * scriptContext, bool hasExternalDataSupport);
+         void SetTypeHandler(DynamicTypeHandler * typeHandler, bool hasChanged);
+         void ReplaceType(DynamicType * type);
+         void ReplaceTypeWithPredecessorType(DynamicType * previousType);
+@@ -225,11 +225,12 @@ namespace Js
+         bool SetHasNoEnumerableProperties(bool value);
+         virtual bool HasReadOnlyPropertiesInvisibleToTypeHandler() { return false; }
+ 
+-        void InitSlots(DynamicObject* instance);
++        void InitSlots(DynamicObject* instance, bool hasExternalDataSupport);
+         virtual int GetPropertyCount() override;
+         virtual PropertyId GetPropertyId(PropertyIndex index) override;
+         virtual PropertyId GetPropertyId(BigPropertyIndex index) override;
+         PropertyIndex GetPropertyIndex(PropertyId propertyId) sealed;
++        virtual PropertyIndex GetPropertyIndex(const PropertyRecord* propertyRecord) override;
+         virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId) override;
+         virtual BOOL HasOwnProperty(PropertyId propertyId) override;
+         virtual PropertyQueryFlags GetPropertyQuery(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;
+diff --git a/lib/Runtime/Types/DynamicType.cpp b/lib/Runtime/Types/DynamicType.cpp
+index 2f745761e..52b1d32d9 100644
+--- a/lib/Runtime/Types/DynamicType.cpp
++++ b/lib/Runtime/Types/DynamicType.cpp
+@@ -215,7 +215,13 @@ namespace Js
+     {
+         Assert(!Js::IsInternalPropertyId(propertyId));
+         Assert(propertyId != Constants::NoProperty);
+-        return GetTypeHandler()->GetPropertyIndex(this->GetScriptContext()->GetPropertyName(propertyId));
++
++        return GetPropertyIndex(this->GetScriptContext()->GetPropertyName(propertyId));
++    }
++
++    PropertyIndex DynamicObject::GetPropertyIndex(const PropertyRecord* propertyRecord)
++    {
++        return GetTypeHandler()->GetPropertyIndex(propertyRecord);
+     }
+ 
+     PropertyQueryFlags DynamicObject::HasPropertyQuery(PropertyId propertyId)
+diff --git a/lib/Runtime/Types/ES5ArrayTypeHandler.h b/lib/Runtime/Types/ES5ArrayTypeHandler.h
+index 33f3fefeb..f5822bdf8 100644
+--- a/lib/Runtime/Types/ES5ArrayTypeHandler.h
++++ b/lib/Runtime/Types/ES5ArrayTypeHandler.h
+@@ -203,7 +203,6 @@ namespace Js
+         virtual BigDictionaryTypeHandler* NewBigDictionaryTypeHandler(Recycler* recycler, int slotCapacity, uint16 inlineSlotCapacity, uint16 offsetOfInlineSlots) override;
+ 
+     public:
+-        virtual bool HasExternalDataSupport() override { return false; }
+         virtual DynamicTypeHandler* ConvertToExternalDataSupport(Recycler* recycler) override;
+ #if ENABLE_TTD
+         //
+@@ -218,9 +217,17 @@ namespace Js
+     public:
+         DEFINE_GETCPPNAME();
+ 
++        DEFINE_VTABLE_CTOR_NO_REGISTER(ES5ArrayTypeHandlerBaseWithExternal, ES5ArrayTypeHandlerBase<T>);
++
++        ES5ArrayTypeHandlerBaseWithExternal(Recycler* recycler):
++          ES5ArrayTypeHandlerBase<T>(recycler) { DEBUG_CHECKS_FOR_HANDLER_WITH_EXTERNAL(this) }
++
++        ES5ArrayTypeHandlerBaseWithExternal(Recycler* recycler, int slotCapacity, uint16 inlineSlotCapacity, uint16 offsetOfInlineSlots):
++          ES5ArrayTypeHandlerBase<T>(recycler, slotCapacity, inlineSlotCapacity, offsetOfInlineSlots) { DEBUG_CHECKS_FOR_HANDLER_WITH_EXTERNAL(this) }
++
+     private:
+         ES5ArrayTypeHandlerBaseWithExternal(Recycler * recycler,
+-          ES5ArrayTypeHandlerBase<T>* sth): ES5ArrayTypeHandlerBase<T>(recycler, sth) { }
++          ES5ArrayTypeHandlerBase<T>* sth): ES5ArrayTypeHandlerBase<T>(recycler, sth) { DEBUG_CHECKS_FOR_HANDLER_WITH_EXTERNAL(this) }
+ 
+     public:
+         DEFINE_HANDLERWITHEXTERNAL_INTERFACE(ES5ArrayTypeHandlerBase<T>, ES5ArrayTypeHandlerBaseWithExternal<T>)
+diff --git a/lib/Runtime/Types/MissingPropertyTypeHandler.h b/lib/Runtime/Types/MissingPropertyTypeHandler.h
+index 9f94045d7..fc3313ab9 100644
+--- a/lib/Runtime/Types/MissingPropertyTypeHandler.h
++++ b/lib/Runtime/Types/MissingPropertyTypeHandler.h
+@@ -80,7 +80,6 @@ namespace Js
+         virtual BOOL FreezeImpl(DynamicObject* instance, bool isConvertedType) override;
+ 
+     public:
+-        virtual bool HasExternalDataSupport() override { return false; }
+         virtual DynamicTypeHandler* ConvertToExternalDataSupport(Recycler* recycler) override;
+ 
+ #if ENABLE_TTD
+@@ -101,13 +100,12 @@ namespace Js
+     {
+     public:
+         DEFINE_GETCPPNAME();
++        MissingPropertyTypeHandlerWithExternal():
++            MissingPropertyTypeHandler() { DEBUG_CHECKS_FOR_HANDLER_WITH_EXTERNAL(this) }
+ 
+     private:
+-        MissingPropertyTypeHandlerWithExternal(Recycler * recycler, MissingPropertyTypeHandler *base)
+-        {
+-            fprintf(stderr, "How this happened? MissingPropertyTypeHandler doesn't really convert to external!");
+-            abort();
+-        }
++        MissingPropertyTypeHandlerWithExternal(Recycler * recycler, MissingPropertyTypeHandler *base):
++            MissingPropertyTypeHandler() { DEBUG_CHECKS_FOR_HANDLER_WITH_EXTERNAL(this) }
+ 
+     public:
+         DEFINE_HANDLERWITHEXTERNAL_INTERFACE(MissingPropertyTypeHandler, MissingPropertyTypeHandlerWithExternal)
+diff --git a/lib/Runtime/Types/NullTypeHandler.cpp b/lib/Runtime/Types/NullTypeHandler.cpp
+index 1b28789e1..00d3cb804 100644
+--- a/lib/Runtime/Types/NullTypeHandler.cpp
++++ b/lib/Runtime/Types/NullTypeHandler.cpp
+@@ -265,7 +265,7 @@ namespace Js
+         AssertMsg(false, "Not Supported!");
+         Throw::FatalInternalError();
+     }
+-    
++
+     template<bool IsPrototypeTemplate>
+     DynamicTypeHandler* NullTypeHandler<IsPrototypeTemplate>::ConvertToExternalDataSupport(Recycler* recycler)
+     {
+@@ -359,4 +359,13 @@ namespace Js
+ 
+     template class NullTypeHandler<false>;
+     template class NullTypeHandler<true>;
++
++    template<bool IsPrototypeTemplate>
++    NullTypeHandlerWithExternal<IsPrototypeTemplate> NullTypeHandlerWithExternal<IsPrototypeTemplate>::defaultInstanceWithExternal;
++
++    template<bool IsPrototypeTemplate>
++    NullTypeHandlerWithExternal<IsPrototypeTemplate> * NullTypeHandlerWithExternal<IsPrototypeTemplate>::GetDefaultInstanceWithExternal() { return &defaultInstanceWithExternal; }
++
++    template class NullTypeHandlerWithExternal<false>;
++    template class NullTypeHandlerWithExternal<true>;
+ }
+diff --git a/lib/Runtime/Types/NullTypeHandler.h b/lib/Runtime/Types/NullTypeHandler.h
+index 8dc580429..fcd62fd24 100644
+--- a/lib/Runtime/Types/NullTypeHandler.h
++++ b/lib/Runtime/Types/NullTypeHandler.h
+@@ -80,7 +80,7 @@ namespace Js
+         BOOL AddProperty(DynamicObject* instance, PropertyId propertyId, Var value, PropertyAttributes attributes, PropertyValueInfo* info, PropertyOperationFlags flags, SideEffects possibleSideEffects);
+         virtual BOOL FreezeImpl(DynamicObject* instance, bool isConvertedType) override;
+     };
+-    
++
+     template <bool IsPrototypeTemplate> class NullTypeHandlerWithExternal;
+ 
+     template <bool IsPrototypeTemplate>
+@@ -98,6 +98,7 @@ namespace Js
+ 
+     public:
+         static NullTypeHandler * GetDefaultInstance();
++
+         virtual DynamicTypeHandler* ConvertToExternalDataSupport(Recycler* recycler) override;
+ 
+ #if ENABLE_TTD
+@@ -113,19 +114,26 @@ namespace Js
+         }
+ #endif
+     };
+-    
++
+     template <bool IsPrototypeTemplate>
+     class NullTypeHandlerWithExternal sealed : public NullTypeHandler<IsPrototypeTemplate>
+     {
+     public:
+         DEFINE_GETCPPNAME();
+-        
++
+     private:
+-        NullTypeHandlerWithExternal(Recycler * recycler, NullTypeHandler<IsPrototypeTemplate> * base): NullTypeHandler<IsPrototypeTemplate>() { }
+-    
++        NullTypeHandlerWithExternal<IsPrototypeTemplate>():
++            NullTypeHandler<IsPrototypeTemplate>() { DEBUG_CHECKS_FOR_HANDLER_WITH_EXTERNAL(this) }
++
++        NullTypeHandlerWithExternal(Recycler * recycler, NullTypeHandler<IsPrototypeTemplate> * base):
++            NullTypeHandler<IsPrototypeTemplate>() { DEBUG_CHECKS_FOR_HANDLER_WITH_EXTERNAL(this) }
++
++        static NullTypeHandlerWithExternal defaultInstanceWithExternal;
+     public:
++        static NullTypeHandlerWithExternal * GetDefaultInstanceWithExternal();
++
+         DEFINE_HANDLERWITHEXTERNAL_INTERFACE(NullTypeHandler<IsPrototypeTemplate>, NullTypeHandlerWithExternal<IsPrototypeTemplate>)
+     };
+-    
+-    
++
++
+ }
+diff --git a/lib/Runtime/Types/PathTypeHandler.cpp b/lib/Runtime/Types/PathTypeHandler.cpp
+index 5f8ab350f..c8cc1960c 100644
+--- a/lib/Runtime/Types/PathTypeHandler.cpp
++++ b/lib/Runtime/Types/PathTypeHandler.cpp
+@@ -1231,10 +1231,15 @@ namespace Js
+                 newOffsetOfInlineSlots = sizeof(DynamicObject);
+             }
+             bool markTypeAsShared = !FixPropsOnPathTypes() || shareType;
+-            nextPath = SimplePathTypeHandler::New(scriptContext, newTypePath, newPropertyCount, newSlotCapacity, newInlineSlotCapacity, newOffsetOfInlineSlots, true, markTypeAsShared, predecessorType);
+             if (HasExternalDataSupport())
+             {
+-                nextPath = (SimplePathTypeHandler*) nextPath->ConvertToExternalDataSupport(recycler);
++                nextPath = PathTypeHandlerWithExternal<SimplePathTypeHandler>::New(scriptContext,
++                  newTypePath, newPropertyCount, newSlotCapacity, newInlineSlotCapacity, newOffsetOfInlineSlots, true, markTypeAsShared, predecessorType);
++            }
++            else
++            {
++                nextPath = SimplePathTypeHandler::New(scriptContext, newTypePath,
++                  newPropertyCount, newSlotCapacity, newInlineSlotCapacity, newOffsetOfInlineSlots, true, markTypeAsShared, predecessorType);
+             }
+ 
+             if (!markTypeAsShared) nextPath->SetMayBecomeShared();
+diff --git a/lib/Runtime/Types/PathTypeHandler.h b/lib/Runtime/Types/PathTypeHandler.h
+index 51055cf57..25f769ee0 100644
+--- a/lib/Runtime/Types/PathTypeHandler.h
++++ b/lib/Runtime/Types/PathTypeHandler.h
+@@ -7,12 +7,14 @@
+ namespace Js
+ {
+     class SimplePathTypeHandler;
++    template<class T> class PathTypeHandlerWithExternal;
+ 
+     class PathTypeHandlerBase : public DynamicTypeHandler
+     {
+         friend class DynamicObject;
+         friend class SimplePathTypeHandler;
+         friend class PathTypeHandler;
++        template<class T> friend class PathTypeHandlerWithExternal;
+     private:
+         Field(TypePath*) typePath;
+         Field(DynamicType*) predecessorType; // Strong reference to predecessor type so that predecessor types remain in the cache even though they might not be used
+@@ -225,6 +227,7 @@ namespace Js
+ 
+     class SimplePathTypeHandler : public PathTypeHandlerBase
+     {
++        template<class T> friend class PathTypeHandlerWithExternal;
+     private:
+         Field(const PropertyRecord *) successorPropertyRecord;
+         Field(RecyclerWeakReference<DynamicType> *) successorTypeWeakRef;
+@@ -260,6 +263,7 @@ namespace Js
+     class PathTypeHandler : public PathTypeHandlerBase
+     {
+         friend class SimplePathTypeHandler;
++        template<class T> friend class PathTypeHandlerWithExternal;
+ 
+     private:
+         typedef JsUtil::WeakReferenceDictionary<PropertyId, DynamicType, DictionarySizePolicy<PowerOf2Policy, 1>> PropertySuccessorsMap;
+@@ -300,7 +304,14 @@ namespace Js
+         DEFINE_GETCPPNAME();
+ 
+     private:
+-        PathTypeHandlerWithExternal(Recycler * recycler, T *base): T(recycler, base) { }
++        PathTypeHandlerWithExternal(Recycler * recycler, T *base): T(recycler, base)
++        { DEBUG_CHECKS_FOR_HANDLER_WITH_EXTERNAL(this) }
++
++        PathTypeHandlerWithExternal(TypePath* typePath, uint16 pathLength, const PropertyIndex slotCapacity, uint16 inlineSlotCapacity, uint16 offsetOfInlineSlots, bool isLocked = false, bool isShared = false, DynamicType* predecessorType = nullptr)
++        : T(typePath, pathLength, slotCapacity, inlineSlotCapacity, offsetOfInlineSlots, isLocked, isShared, predecessorType)
++        {
++            DEBUG_CHECKS_FOR_HANDLER_WITH_EXTERNAL(this)
++        }
+ 
+     protected:
+         virtual bool GetSuccessor(const PropertyRecord* propertyRecord, RecyclerWeakReference<DynamicType> ** typeWeakRef) override;
+@@ -314,5 +325,19 @@ namespace Js
+         virtual void VerifyInlineSlotCapacityIsLocked(bool startFromRoot) override;
+ 
+         DEFINE_HANDLERWITHEXTERNAL_INTERFACE(T, PathTypeHandlerWithExternal<T>);
++
++        static PathTypeHandlerWithExternal<T> * New(ScriptContext * scriptContext, TypePath* typePath,
++          uint16 pathLength, uint16 inlineSlotCapacity, uint16 offsetOfInlineSlots, bool isLocked = false, bool isShared = false, DynamicType* predecessorType = nullptr)
++        {
++            return RecyclerNew(scriptContext->GetRecycler(), PathTypeHandlerWithExternal<T>,
++              typePath, pathLength, max(pathLength, inlineSlotCapacity), inlineSlotCapacity, offsetOfInlineSlots, isLocked, isShared, predecessorType);
++        }
++
++        static PathTypeHandlerWithExternal<T> * New(ScriptContext * scriptContext, TypePath* typePath,
++          uint16 pathLength, const PropertyIndex slotCapacity, uint16 inlineSlotCapacity, uint16 offsetOfInlineSlots, bool isLocked = false, bool isShared = false, DynamicType* predecessorType = nullptr)
++        {
++            return RecyclerNew(scriptContext->GetRecycler(), PathTypeHandlerWithExternal<T>,
++              typePath, pathLength, slotCapacity, inlineSlotCapacity, offsetOfInlineSlots, isLocked, isShared, predecessorType);
++        }
+     };
+ }
+diff --git a/lib/Runtime/Types/RecyclableObject.h b/lib/Runtime/Types/RecyclableObject.h
+index 82343cb53..db774385d 100644
+--- a/lib/Runtime/Types/RecyclableObject.h
++++ b/lib/Runtime/Types/RecyclableObject.h
+@@ -266,6 +266,7 @@ namespace Js {
+         virtual PropertyId GetPropertyId(PropertyIndex index) { return Constants::NoProperty; }
+         virtual PropertyId GetPropertyId(BigPropertyIndex index) { return Constants::NoProperty; }
+         virtual PropertyIndex GetPropertyIndex(PropertyId propertyId) { return Constants::NoSlot; }
++        virtual PropertyIndex GetPropertyIndex(const PropertyRecord* propertyRecord) { return Constants::NoSlot; }
+         virtual int GetPropertyCount() { return 0; }
+         virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId);
+         virtual BOOL HasOwnProperty( PropertyId propertyId);
+diff --git a/lib/Runtime/Types/SimpleDictionaryTypeHandler.cpp b/lib/Runtime/Types/SimpleDictionaryTypeHandler.cpp
+index 1e7a3c004..c8f91316e 100644
+--- a/lib/Runtime/Types/SimpleDictionaryTypeHandler.cpp
++++ b/lib/Runtime/Types/SimpleDictionaryTypeHandler.cpp
+@@ -462,7 +462,7 @@ namespace Js
+         U* newTypeHandler = RecyclerNew(recycler, U, recycler, GetSlotCapacity(), GetInlineSlotCapacity(), GetOffsetOfInlineSlots());
+         // We expect the new type handler to start off marked as having only writable data properties.
+         Assert(newTypeHandler->GetHasOnlyWritableDataProperties());
+-        if (instance->GetTypeHandler()->HasExternalDataSupport())
++        if (instance->GetTypeHandler()->HasExternalDataSupport() && !newTypeHandler->HasExternalDataSupport())
+         {
+             newTypeHandler = (U*) newTypeHandler->ConvertToExternalDataSupport(recycler);
+         }
+diff --git a/lib/Runtime/Types/SimpleDictionaryTypeHandler.h b/lib/Runtime/Types/SimpleDictionaryTypeHandler.h
+index 3d2e0cbbd..81d499385 100644
+--- a/lib/Runtime/Types/SimpleDictionaryTypeHandler.h
++++ b/lib/Runtime/Types/SimpleDictionaryTypeHandler.h
+@@ -333,9 +333,16 @@ namespace Js
+     public:
+         DEFINE_GETCPPNAME();
+ 
++        SimpleDictionaryTypeHandlerBaseWithExternal(Recycler * recycler):
++            SimpleDictionaryTypeHandlerBaseTypeDef(recycler) { DEBUG_CHECKS_FOR_HANDLER_WITH_EXTERNAL(this) }
++        SimpleDictionaryTypeHandlerBaseWithExternal(Recycler * recycler, int slotCapacity,
++          uint16 inlineSlotCapacity, uint16 offsetOfInlineSlots, bool isLocked = false, bool isShared = false):
++            SimpleDictionaryTypeHandlerBaseTypeDef(recycler, slotCapacity,
++              inlineSlotCapacity, offsetOfInlineSlots, isLocked, isShared) { DEBUG_CHECKS_FOR_HANDLER_WITH_EXTERNAL(this) }
++
+     private:
+         SimpleDictionaryTypeHandlerBaseWithExternal(Recycler * recycler, SimpleDictionaryTypeHandlerBaseTypeDef * base):
+-          SimpleDictionaryTypeHandlerBaseTypeDef(recycler, base) { }
++          SimpleDictionaryTypeHandlerBaseTypeDef(recycler, base) { DEBUG_CHECKS_FOR_HANDLER_WITH_EXTERNAL(this) }
+ 
+     public:
+         DEFINE_HANDLERWITHEXTERNAL_INTERFACE(SimpleDictionaryTypeHandlerBaseTypeDef,
+diff --git a/lib/Runtime/Types/SimpleTypeHandler.cpp b/lib/Runtime/Types/SimpleTypeHandler.cpp
+index 7f06e7923..7348d2721 100644
+--- a/lib/Runtime/Types/SimpleTypeHandler.cpp
++++ b/lib/Runtime/Types/SimpleTypeHandler.cpp
+@@ -102,7 +102,7 @@ namespace Js
+ #endif
+ 
+         T* newTypeHandler = RecyclerNew(recycler, T, recycler, SimpleTypeHandler<size>::GetSlotCapacity(), GetInlineSlotCapacity(), GetOffsetOfInlineSlots());
+-        if (instance->GetTypeHandler()->HasExternalDataSupport())
++        if (instance->GetTypeHandler()->HasExternalDataSupport() && !newTypeHandler->HasExternalDataSupport())
+         {
+             newTypeHandler = (T*) newTypeHandler->ConvertToExternalDataSupport(recycler);
+         }
+@@ -143,7 +143,16 @@ namespace Js
+     template<size_t size>
+     DictionaryTypeHandler* SimpleTypeHandler<size>::ConvertToDictionaryType(DynamicObject* instance)
+     {
+-        DictionaryTypeHandler* newTypeHandler = ConvertToTypeHandler<DictionaryTypeHandler>(instance);
++        DictionaryTypeHandler* newTypeHandler;
++
++        if (HasExternalDataSupport())
++        {
++            newTypeHandler = ConvertToTypeHandler<DictionaryTypeHandlerWithExternal>(instance);
++        }
++        else
++        {
++            newTypeHandler = ConvertToTypeHandler<DictionaryTypeHandler>(instance);
++        }
+ 
+ #ifdef PROFILE_TYPES
+         instance->GetScriptContext()->convertSimpleToDictionaryCount++;
+@@ -154,7 +163,15 @@ namespace Js
+     template<size_t size>
+     SimpleDictionaryTypeHandler* SimpleTypeHandler<size>::ConvertToSimpleDictionaryType(DynamicObject* instance)
+     {
+-        SimpleDictionaryTypeHandler* newTypeHandler = ConvertToTypeHandler<SimpleDictionaryTypeHandler >(instance);
++        SimpleDictionaryTypeHandler* newTypeHandler;
++        if (HasExternalDataSupport())
++        {
++            newTypeHandler = ConvertToTypeHandler<SimpleDictionaryTypeHandlerWithExternal >(instance);
++        }
++        else
++        {
++            newTypeHandler = ConvertToTypeHandler<SimpleDictionaryTypeHandler >(instance);
++        }
+ 
+ #ifdef PROFILE_TYPES
+         instance->GetScriptContext()->convertSimpleToSimpleDictionaryCount++;
+@@ -165,7 +182,16 @@ namespace Js
+     template<size_t size>
+     ES5ArrayTypeHandler* SimpleTypeHandler<size>::ConvertToES5ArrayType(DynamicObject* instance)
+     {
+-        ES5ArrayTypeHandler* newTypeHandler = ConvertToTypeHandler<ES5ArrayTypeHandler>(instance);
++        ES5ArrayTypeHandler* newTypeHandler;
++
++        if (HasExternalDataSupport())
++        {
++            newTypeHandler = ConvertToTypeHandler<ES5ArrayTypeHandlerWithExternal>(instance);
++        }
++        else
++        {
++            newTypeHandler = ConvertToTypeHandler<ES5ArrayTypeHandler>(instance);
++        }
+ 
+ #ifdef PROFILE_TYPES
+         instance->GetScriptContext()->convertSimpleToDictionaryCount++;
+@@ -1139,9 +1165,25 @@ namespace Js
+         TTDAssert(false, "We found this during enum so what is going on here?");
+         return Js::Constants::NoBigSlot;
+     }
+-
+ #endif
+ 
++    template<size_t size>
++    SimpleTypeHandlerWithExternal<size>::SimpleTypeHandlerWithExternal(NO_WRITE_BARRIER_TAG_TYPE(const PropertyRecord* id),
++      PropertyAttributes attributes, PropertyTypes propertyTypes, uint16 inlineSlotCapacity, uint16 offsetOfInlineSlots) :
++      SimpleTypeHandler<size>(NO_WRITE_BARRIER_TAG(id), attributes, propertyTypes, inlineSlotCapacity, offsetOfInlineSlots)
++    {
++        DEBUG_CHECKS_FOR_HANDLER_WITH_EXTERNAL(this)
++    }
++
++    template<size_t size>
++    SimpleTypeHandlerWithExternal<size>::SimpleTypeHandlerWithExternal(NO_WRITE_BARRIER_TAG_TYPE(SimplePropertyDescriptor const
++      (&SharedFunctionPropertyDescriptors)[size]), PropertyTypes propertyTypes, uint16 inlineSlotCapacity, uint16 offsetOfInlineSlots) :
++      SimpleTypeHandler<size>(NO_WRITE_BARRIER_TAG(SharedFunctionPropertyDescriptors), propertyTypes, inlineSlotCapacity, offsetOfInlineSlots)
++    {
++        DEBUG_CHECKS_FOR_HANDLER_WITH_EXTERNAL(this)
++    }
++
++
+     template class SimpleTypeHandler<1>;
+     template class SimpleTypeHandler<2>;
+     template class SimpleTypeHandler<6>;
+diff --git a/lib/Runtime/Types/SimpleTypeHandler.h b/lib/Runtime/Types/SimpleTypeHandler.h
+index ad47bf27a..98fa5adc9 100644
+--- a/lib/Runtime/Types/SimpleTypeHandler.h
++++ b/lib/Runtime/Types/SimpleTypeHandler.h
+@@ -20,7 +20,7 @@ namespace Js
+     public:
+         DEFINE_GETCPPNAME();
+ 
+-    private:
++    protected:
+         SimpleTypeHandler(Recycler*);        // only used by NullTypeHandler
+         SimpleTypeHandler(SimpleTypeHandler<size> * typeHandler);
+         DEFINE_VTABLE_CTOR_NO_REGISTER(SimpleTypeHandler, DynamicTypeHandler);
+@@ -120,12 +120,27 @@ namespace Js
+     public:
+         DEFINE_GETCPPNAME();
+ 
++        SimpleTypeHandlerWithExternal(
++          NO_WRITE_BARRIER_TAG_TYPE(const PropertyRecord* pid),
++          PropertyAttributes attributes = PropertyNone,
++              PropertyTypes propertyTypes = PropertyTypesNone, uint16 inlineSlotCapacity = 0, uint16 offsetOfInlineSlots = 0);
++
++        SimpleTypeHandlerWithExternal(NO_WRITE_BARRIER_TAG_TYPE(SimplePropertyDescriptor const
++          (&SharedFunctionPropertyDescriptors)[size]), PropertyTypes propertyTypes = PropertyTypesNone, uint16 inlineSlotCapacity = 0, uint16 offsetOfInlineSlots = 0);
++
++        DEFINE_VTABLE_CTOR_NO_REGISTER(SimpleTypeHandlerWithExternal, SimpleTypeHandler<size>);
++
+     private:
+-        SimpleTypeHandlerWithExternal(Recycler * recycler, SimpleTypeHandler<size>* sth):
+-          SimpleTypeHandler<size>(sth) { }
++        SimpleTypeHandlerWithExternal(Recycler * recycler, SimpleTypeHandler<size>* sth) : SimpleTypeHandler<size>(sth) { DEBUG_CHECKS_FOR_HANDLER_WITH_EXTERNAL(this) }
++
++        SimpleTypeHandlerWithExternal(Recycler * recycler) : SimpleTypeHandler<size>(recycler) { DEBUG_CHECKS_FOR_HANDLER_WITH_EXTERNAL(this) }
++
++        SimpleTypeHandlerWithExternal(SimpleTypeHandlerWithExternal<size> * typeHandler) : SimpleTypeHandler<size>(typeHandler) { DEBUG_CHECKS_FOR_HANDLER_WITH_EXTERNAL(this) }
+ 
+     public:
+         DEFINE_HANDLERWITHEXTERNAL_INTERFACE(SimpleTypeHandler<size>, SimpleTypeHandlerWithExternal<size>)
+     };
+ 
++    typedef SimpleTypeHandlerWithExternal<1> SimpleTypeHandlerWithExternalSize1;
++    typedef SimpleTypeHandlerWithExternal<2> SimpleTypeHandlerWithExternalSize2;
+ }
+diff --git a/lib/Runtime/Types/TypeHandler.cpp b/lib/Runtime/Types/TypeHandler.cpp
+index c0a937529..9a1744710 100644
+--- a/lib/Runtime/Types/TypeHandler.cpp
++++ b/lib/Runtime/Types/TypeHandler.cpp
+@@ -133,9 +133,10 @@ namespace Js
+     {
+         // We should only assign a stack value only to a stack object (current mark temp number in mark temp object)
+         Assert(ThreadContext::IsOnStack(instance) || !ThreadContext::IsOnStack(value) || TaggedNumber::Is(value));
+-        uint16 inlineSlotCapacity = instance->GetTypeHandler()->GetInlineSlotCapacity();
+-        uint16 offsetOfInlineSlots = instance->GetTypeHandler()->GetOffsetOfInlineSlots();
+-        int slotCapacity = instance->GetTypeHandler()->GetSlotCapacity();
++        auto typeHandler = instance->GetTypeHandler();
++        uint16 inlineSlotCapacity = typeHandler->GetInlineSlotCapacity();
++        uint16 offsetOfInlineSlots = typeHandler->GetOffsetOfInlineSlots();
++        int slotCapacity = typeHandler->GetSlotCapacity();
+ 
+         if (index < inlineSlotCapacity)
+         {
+@@ -208,7 +209,7 @@ namespace Js
+     {
+         Assert(IsObjectHeaderInlined(GetOffsetOfInlineSlots()));
+         Assert(GetInlineSlotCapacity() >= GetObjectHeaderInlinableSlotCapacity());
+-        Assert(GetInlineSlotCapacity() == GetSlotCapacity());
++        Assert(GetInlineSlotCapacity() == GetSlotCapacity() || GetInlineSlotCapacity() + 4 /* externalData slots */ == GetSlotCapacity());
+     }
+ 
+     uint16 DynamicTypeHandler::GetOffsetOfObjectHeaderInlineSlots()
+diff --git a/lib/Runtime/Types/TypeHandler.h b/lib/Runtime/Types/TypeHandler.h
+index 25a5698a8..29b8dd840 100644
+--- a/lib/Runtime/Types/TypeHandler.h
++++ b/lib/Runtime/Types/TypeHandler.h
+@@ -161,7 +161,10 @@ namespace Js
+             return inlineSlotsToAllocate * sizeof(Var);
+         }
+ 
+-        uint16 GetOffsetOfInlineSlots() const { return this->offsetOfInlineSlots; }
++        uint16 GetOffsetOfInlineSlots() const
++        {
++            return this->offsetOfInlineSlots;
++        }
+ 
+         void EnsureSlots(DynamicObject * instance, int oldCount, int newCount, ScriptContext * scriptContext, DynamicTypeHandler * newTypeHandler = nullptr);
+ 
+@@ -648,7 +651,7 @@ namespace Js
+         virtual BOOL FreezeImpl(DynamicObject *instance, bool isConvertedType) = 0;
+ 
+     public:
+-        virtual bool HasExternalDataSupport() { Assert(this->hasExternalDataSupport == false); return false; }
++        virtual bool HasExternalDataSupport() const { Assert(this->hasExternalDataSupport == false); return false; }
+         virtual DynamicTypeHandler* ConvertToExternalDataSupport(Recycler* recycler) = 0;
+ 
+ #if ENABLE_TTD
+@@ -681,14 +684,14 @@ namespace Js
+     };
+ 
+ #ifdef DEBUG
+-#define DEBUG_CHECKS_FOR_HANDLER_WITH_EXTERNAL \
+-    baseWithExternal->hasExternalDataSupport = true;
++#define DEBUG_CHECKS_FOR_HANDLER_WITH_EXTERNAL(base) \
++    base->hasExternalDataSupport = true;
+ #else
+-#define DEBUG_CHECKS_FOR_HANDLER_WITH_EXTERNAL
++#define DEBUG_CHECKS_FOR_HANDLER_WITH_EXTERNAL(base)
+ #endif
+ 
+ #define DEFINE_HANDLERWITHEXTERNAL_INTERFACE(AA, BB) \
+-    virtual bool HasExternalDataSupport() override \
++    virtual bool HasExternalDataSupport() const override \
+     { \
+         Assert(this->hasExternalDataSupport); \
+         return true; \
+@@ -704,7 +707,7 @@ namespace Js
+     { \
+         AssertMsg(!base->HasExternalDataSupport(), "ConvertToExternalDataSupport for XXXX_WithExternal shouldn't be implemented or reached!"); \
+         AA* baseWithExternal = RecyclerNew(recycler, BB, recycler, base); \
+-        DEBUG_CHECKS_FOR_HANDLER_WITH_EXTERNAL \
++        DEBUG_CHECKS_FOR_HANDLER_WITH_EXTERNAL(baseWithExternal) \
+         return baseWithExternal; \
+     }
+ 
+diff --git a/test/native-tests/CommonDefinitions.h b/test/native-tests/CommonDefinitions.h
+index 998fe9bb1..49e0b4b80 100644
+--- a/test/native-tests/CommonDefinitions.h
++++ b/test/native-tests/CommonDefinitions.h
+@@ -11,7 +11,6 @@
+ 
+ #define ERROR_INSPECT                                                   \
+     do {                                                                \
+-        bool hasException = false;                                      \
+         JsValueRef exception = nullptr, exceptionString;                \
+         JsGetAndClearException(&exception);                             \
+         if (exception) {                                                \
+diff --git a/test/native-tests/test-char/sample.cpp b/test/native-tests/test-char/sample.cpp
+index 931bf4769..f4cf74396 100644
+--- a/test/native-tests/test-char/sample.cpp
++++ b/test/native-tests/test-char/sample.cpp
+@@ -3,7 +3,23 @@
+ // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+ //-------------------------------------------------------------------------------------------------------
+ 
+-#include "../CommonDefinitions.h"
++#include "ChakraCore.h"
++#include <stdlib.h>
++#include <stdio.h>
++#include <string>
++#include <cstring>
++
++#define FAIL_CHECK(cmd)                     \
++    do                                      \
++    {                                       \
++        JsErrorCode errCode = cmd;          \
++        if (errCode != JsNoError)           \
++        {                                   \
++            printf("Error %d at '%s'\n",    \
++                errCode, #cmd);             \
++            return 1;                       \
++        }                                   \
++    } while(0)
+ 
+ using namespace std;
+ 
+diff --git a/test/native-tests/test-external-object/sample.cpp b/test/native-tests/test-external-object/sample.cpp
+index e8e9012b1..2a15e574c 100644
+--- a/test/native-tests/test-external-object/sample.cpp
++++ b/test/native-tests/test-external-object/sample.cpp
+@@ -30,11 +30,43 @@ JsValueRef addExternalDataId(JsValueRef callee, bool isConstructCall,
+     return nullptr;
+ }
+ 
++JsValueRef sameTypeHandler(JsValueRef callee, bool isConstructCall,
++    JsValueRef * arguments, unsigned short argumentCount, void * callbackState)
++{
++    bool hasExternal = false;
++    JsValueRef obj1 = arguments[1];
++    JsValueRef obj2 = arguments[2];
++
++    char * fmem1 = (char*) obj1;
++    char * fmem2 = (char*) obj2;
++
++    union MemBlock
++    {
++      void* addr;
++      char  mem[8];
++    };
++
++    MemBlock first;
++    memcpy(first.mem, fmem1, 8); // copy the address of Type
++
++    MemBlock second;
++    memcpy(second.mem, fmem2, 8); // copy the address of Type
++
++    fprintf(stderr, "First: %p Second: %p \n", first.addr, second.addr);
++
++    JsValueRef boolValue;
++    JsBoolToBoolean(second.addr == second.addr, &boolValue);
++
++    return boolValue;
++}
++
+ JsValueRef hasExternalDataId(JsValueRef callee, bool isConstructCall,
+     JsValueRef * arguments, unsigned short argumentCount, void * callbackState)
+ {
+     bool hasExternal = false;
+-    JsErrorCode code = JsObjectHasExternalData(arguments[1], &hasExternal);
++    JsValueRef obj = arguments[1];
++
++    JsErrorCode code = JsObjectHasExternalData(obj, &hasExternal);
+     if (code != JsNoError) printf("FAILED to check external data %d \n", code);
+ 
+     JsValueRef boolValue;
+@@ -71,6 +103,8 @@ int main()
+ 
+     // Each array item triggers a letter from ESS!\n on their  ExternalData finalization.
+ 
++    // First part tests type sharing among objects with externalData
++
+     // obj[.....] parts (Date.now() + a / b) are to push type fork. (so we test type handler converters)
+     // prior to setting unique property, we set CommonPropertyName to force shared type handling
+ 
+@@ -79,6 +113,18 @@ int main()
+     // object property loop is to test auxSlot expansion
+     const char* script = "\
+     (function(){\
++        var fncBase = function(nn) { this.xyz = nn; };\
++        AddExternalData(fncBase);\
++        var obj1 = new fncBase(1), obj2 = new fncBase(2);\
++        obj1.y = 1;\
++        obj2.y = 2;\
++        AddExternalData(obj1);\
++        AddExternalData(obj2);\
++        obj1.a = 1;\
++        obj2.b = 2;\
++        if (!HasExternalData(obj1)) throw new Error('HasExternalData TypeHandler transfer failed (a)');\
++        if (!HasExternalData(obj2)) throw new Error('HasExternalData TypeHandler transfer failed (b)');\
++        if (!SameTypeHandler(obj1, obj2)) throw new Error('TypeHandler sharing failed');\
+         var retVal = \"UCC\";\
+         var arr = [ {}, [], function(r) { if (!r) return \"S\"; else this.X=r; }, new Date(), new Object() ];\
+         for (var i = 0; i < arr.length; i++) {\
+@@ -128,6 +174,8 @@ int main()
+ 
+     FAIL_CHECK(AddMethodProperty(global, "GetExternalData", &getExternalDataId));
+ 
++    FAIL_CHECK(AddMethodProperty(global, "SameTypeHandler", &sameTypeHandler));
++
+     // Run the script.
+     FAIL_CHECK(JsRun(scriptSource, currentSourceContext++, fname, JsParseScriptAttributeNone, &result));
+ 

--- a/test/native-tests/CommonDefinitions.h
+++ b/test/native-tests/CommonDefinitions.h
@@ -1,0 +1,51 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#include "ChakraCore.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <string>
+#include <cstring>
+
+#define ERROR_INSPECT                                                   \
+    do {                                                                \
+        JsValueRef exception = nullptr, exceptionString;                \
+        JsGetAndClearException(&exception);                             \
+        if (exception) {                                                \
+            JsConvertValueToString(exception, &exceptionString);        \
+            char errorString[8192];                                     \
+            JsCopyString(exceptionString, errorString, 8192, nullptr);  \
+            printf("Exception:\n%s\n", errorString);                    \
+        }                                                               \
+    } while(0);
+
+#define FAIL_CHECK(cmd)                     \
+    do                                      \
+    {                                       \
+        JsErrorCode errCode = cmd;          \
+        if (errCode != JsNoError)           \
+        {                                   \
+            ERROR_INSPECT                   \
+            printf("Error %d at '%s'\n",    \
+                errCode, #cmd);             \
+            return errCode;                 \
+        }                                   \
+    } while(0)
+
+JsErrorCode AddMethodProperty(JsValueRef target, const char* str, JsNativeFunction func)
+{
+    JsPropertyIdRef Id;
+    FAIL_CHECK(JsCreatePropertyId(str, strlen(str), &Id));
+
+    JsValueRef nameVar;
+    FAIL_CHECK(JsCreateString(str, strlen(str), &nameVar));
+
+    JsValueRef functionVar;
+    FAIL_CHECK(JsCreateNamedFunction(nameVar, func, nullptr, &functionVar));
+
+    FAIL_CHECK(JsSetProperty(target, Id, functionVar, true));
+
+    return JsNoError;
+}

--- a/test/native-tests/test-char16/sample.cpp
+++ b/test/native-tests/test-char16/sample.cpp
@@ -3,23 +3,7 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 
-#include "ChakraCore.h"
-#include <stdlib.h>
-#include <stdio.h>
-#include <string>
-#include <cstring>
-
-#define FAIL_CHECK(cmd)                     \
-    do                                      \
-    {                                       \
-        JsErrorCode errCode = cmd;          \
-        if (errCode != JsNoError)           \
-        {                                   \
-            printf("Error %d at '%s'\n",    \
-                errCode, #cmd);             \
-            return 1;                       \
-        }                                   \
-    } while(0)
+#include "../CommonDefinitions.h"
 
 using namespace std;
 

--- a/test/native-tests/test-external-object/Platform.js
+++ b/test/native-tests/test-external-object/Platform.js
@@ -1,0 +1,52 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+var isWindows = !WScript.Platform || WScript.Platform.OS == 'win32';
+var path_sep = isWindows ? '\\' : '/';
+var isStaticBuild = WScript.Platform && WScript.Platform.LINK_TYPE == 'static';
+
+if (!isStaticBuild) {
+    // test will be ignored
+    print("# IGNORE_THIS_TEST");
+} else {
+    var platform = WScript.Platform.OS;
+    var binaryPath = WScript.Platform.BINARY_PATH;
+    // discard `ch` from path
+    binaryPath = binaryPath.substr(0, binaryPath.lastIndexOf(path_sep));
+    var makefile =
+"IDIR=" + binaryPath + "/../../lib/Jsrt \n\
+\n\
+LIBRARY_PATH=" + binaryPath + "/lib\n\
+PLATFORM=" + platform + "\n\
+LDIR=$(LIBRARY_PATH)/libChakraCoreStatic.a \n\
+\n\
+ifeq (darwin, ${PLATFORM})\n\
+\tICU4C_LIBRARY_PATH ?= /usr/local/opt/icu4c\n\
+\tCFLAGS=-lstdc++ -std=c++11 -I$(IDIR)\n\
+\tFORCE_STARTS=-Wl,-force_load,\n\
+\tFORCE_ENDS=\n\
+\tLIBS=-framework CoreFoundation -framework Security -lm -ldl -Wno-c++11-compat-deprecated-writable-strings \
+    -Wno-deprecated-declarations -Wno-unknown-warning-option -o sample.o\n\
+\tLDIR+=$(ICU4C_LIBRARY_PATH)/lib/libicudata.a \
+    $(ICU4C_LIBRARY_PATH)/lib/libicuuc.a \
+    $(ICU4C_LIBRARY_PATH)/lib/libicui18n.a\n\
+else\n\
+\tCFLAGS=-lstdc++ -std=c++0x -I$(IDIR)\n\
+\tFORCE_STARTS=-Wl,--whole-archive\n\
+\tFORCE_ENDS=-Wl,--no-whole-archive\n\
+\tLIBS=-pthread -lm -ldl -licuuc -Wno-c++11-compat-deprecated-writable-strings \
+    -Wno-deprecated-declarations -Wno-unknown-warning-option -o sample.o\n\
+endif\n\
+\n\
+testmake:\n\
+\t$(CC) sample.cpp $(CFLAGS) $(FORCE_STARTS) $(LDIR) $(FORCE_ENDS) $(LIBS)\n\
+\n\
+.PHONY: clean\n\
+\n\
+clean:\n\
+\trm sample.o\n";
+
+    print(makefile)
+}

--- a/test/native-tests/test-external-object/sample.cpp
+++ b/test/native-tests/test-external-object/sample.cpp
@@ -1,0 +1,202 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#include "../CommonDefinitions.h"
+
+using namespace std;
+
+const char letters [5] = { 'E', 'S', 'S', '!', '\n' };
+static int hitCount = 0;
+
+JsValueRef addExternalDataId(JsValueRef callee, bool isConstructCall,
+    JsValueRef * arguments, unsigned short argumentCount, void * callbackState)
+{
+    size_t *org = new size_t[123];
+    org[0] = 12345;
+    org[122] = 54321;
+    JsErrorCode code = JsObjectSetExternalDataWithCallback(arguments[1], org, [](void* data)
+    {
+        size_t *buffer = (size_t*) data;
+        if (buffer[0] != 12345 || buffer[122] != 54321) abort();
+        delete buffer;
+
+        // Test checker searches for `SUCCESS` to determine if script was successful
+        // If everything goes well, this should print last
+        printf("%c", letters[hitCount++]);
+    });
+    if (code != JsNoError) printf("FAILED to set external data %d \n", code);
+    return nullptr;
+}
+
+JsValueRef sameTypeHandler(JsValueRef callee, bool isConstructCall,
+    JsValueRef * arguments, unsigned short argumentCount, void * callbackState)
+{
+    bool hasExternal = false;
+    JsValueRef obj1 = arguments[1];
+    JsValueRef obj2 = arguments[2];
+
+    char * fmem1 = (char*) obj1;
+    char * fmem2 = (char*) obj2;
+
+    union MemBlock
+    {
+      void* addr;
+      char  mem[8];
+    };
+
+    MemBlock first;
+    memcpy(first.mem, fmem1, 8); // copy the address of Type
+
+    MemBlock second;
+    memcpy(second.mem, fmem2, 8); // copy the address of Type
+
+    fprintf(stderr, "First: %p Second: %p \n", first.addr, second.addr);
+
+    JsValueRef boolValue;
+    JsBoolToBoolean(second.addr == second.addr, &boolValue);
+
+    return boolValue;
+}
+
+JsValueRef hasExternalDataId(JsValueRef callee, bool isConstructCall,
+    JsValueRef * arguments, unsigned short argumentCount, void * callbackState)
+{
+    bool hasExternal = false;
+    JsValueRef obj = arguments[1];
+
+    JsErrorCode code = JsObjectHasExternalData(obj, &hasExternal);
+    if (code != JsNoError) printf("FAILED to check external data %d \n", code);
+
+    JsValueRef boolValue;
+    JsBoolToBoolean(hasExternal, &boolValue);
+
+    return boolValue;
+}
+
+JsValueRef getExternalDataId(JsValueRef callee, bool isConstructCall,
+    JsValueRef * arguments, unsigned short argumentCount, void * callbackState)
+{
+    void *data;
+    JsErrorCode code = JsObjectGetExternalData(arguments[1], &data);
+    if (code != JsNoError) printf("FAILED to get external data %d \n", code);
+
+    if (!data) return nullptr;
+
+    size_t *buffer = (size_t*)data;
+    JsValueRef dblPtr;
+    JsDoubleToNumber(buffer[0], &dblPtr);
+
+    return dblPtr;
+}
+
+int main()
+{
+    JsRuntimeHandle runtime;
+    JsContextRef context;
+    JsValueRef result;
+    unsigned currentSourceContext = 0;
+
+    // this script will print `S` + `UCC` and callback defined under `addExternalDataId`
+    // will print `ESS!` afterwards. In combination, `SUCCESS!`
+
+    // Each array item triggers a letter from ESS!\n on their  ExternalData finalization.
+
+    // First part tests type sharing among objects with externalData
+
+    // obj[.....] parts (Date.now() + a / b) are to push type fork. (so we test type handler converters)
+    // prior to setting unique property, we set CommonPropertyName to force shared type handling
+
+    // the loop for function is to trigger further optimizations
+
+    // object property loop is to test auxSlot expansion
+    const char* script = "\
+    (function(){\
+        var fncBase = function(nn) { this.xyz = nn; };\
+        AddExternalData(fncBase);\
+        var obj1 = new fncBase(1), obj2 = new fncBase(2);\
+        obj1.y = 1;\
+        obj2.y = 2;\
+        AddExternalData(obj1);\
+        AddExternalData(obj2);\
+        obj1.a = 1;\
+        obj2.b = 2;\
+        if (!HasExternalData(obj1)) throw new Error('HasExternalData TypeHandler transfer failed (a)');\
+        if (!HasExternalData(obj2)) throw new Error('HasExternalData TypeHandler transfer failed (b)');\
+        if (!SameTypeHandler(obj1, obj2)) throw new Error('TypeHandler sharing failed');\
+        var retVal = \"UCC\";\
+        var arr = [ {}, [], function(r) { if (!r) return \"S\"; else this.X=r; }, new Date(), new Object() ];\
+        for (var i = 0; i < arr.length; i++) {\
+            var obj = arr[i];\
+            AddExternalData(obj);\
+            obj.CommonPropertyName = new arr[2](i);\
+            if (!HasExternalData(obj)) throw new Error('HasExternalData 1st Failed');\
+            obj[Date.now() + 'a'] = new Date();\
+            if (!HasExternalData(obj)) throw new Error('HasExternalData 2nd Failed');\
+            obj[Date.now() + 'b'] = new Date();\
+            if (GetExternalData(obj) != 12345) throw new Error('GetExternalData Failed');\
+        }\
+        var m = \"\";\
+        for (var j = 0; j < 1e6; j++) m = arr[2](j);\
+        if (!HasExternalData(arr[2])) throw new Error('HasExternalData 3rd Failed');\
+        for (var j = 0; j < 1e4; j++) \
+        { \
+            arr[0]['a' + j] = 4; \
+        } \
+        if (!HasExternalData(arr[0])) throw new Error('HasExternalData 4th Failed');\
+        return arr[2]() + retVal;\
+    })();\
+    ";
+
+    // Create a runtime.
+    JsCreateRuntime(JsRuntimeAttributeNone, nullptr, &runtime);
+
+    // Create an execution context.
+    JsCreateContext(runtime, &context);
+
+    // Now set the current execution context.
+    JsSetCurrentContext(context);
+
+    JsValueRef fname;
+    FAIL_CHECK(JsCreateString("sample", strlen("sample"), &fname));
+
+    JsValueRef scriptSource;
+    FAIL_CHECK(JsCreateExternalArrayBuffer((void*)script, (unsigned int)strlen(script),
+        nullptr, nullptr, &scriptSource));
+
+    JsValueRef global;
+    FAIL_CHECK(JsGetGlobalObject(&global));
+
+    FAIL_CHECK(AddMethodProperty(global, "AddExternalData", &addExternalDataId));
+
+    FAIL_CHECK(AddMethodProperty(global, "HasExternalData", &hasExternalDataId));
+
+    FAIL_CHECK(AddMethodProperty(global, "GetExternalData", &getExternalDataId));
+
+    FAIL_CHECK(AddMethodProperty(global, "SameTypeHandler", &sameTypeHandler));
+
+    // Run the script.
+    FAIL_CHECK(JsRun(scriptSource, currentSourceContext++, fname, JsParseScriptAttributeNone, &result));
+
+    // Convert your script result to String in JavaScript; redundant if your script returns a String
+    JsValueRef resultJSString;
+    FAIL_CHECK(JsConvertValueToString(result, &resultJSString));
+
+    // Project script result back to C++.
+    char *resultSTR = nullptr;
+    size_t stringLength;
+    FAIL_CHECK(JsCopyString(resultJSString, nullptr, 0, &stringLength));
+    resultSTR = (char*)malloc(stringLength + 1);
+    FAIL_CHECK(JsCopyString(resultJSString, resultSTR, stringLength, nullptr));
+    resultSTR[stringLength] = 0;
+
+    printf("%s", resultSTR); // prints `SUCC`
+    free(resultSTR);
+
+    // Dispose runtime
+    JsSetCurrentContext(JS_INVALID_REFERENCE);
+    JsDisposeRuntime(runtime);
+
+    return 0;
+}

--- a/test/native-tests/test-shared-basic/sample.cpp
+++ b/test/native-tests/test-shared-basic/sample.cpp
@@ -3,23 +3,7 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 
-#include "ChakraCore.h"
-#include <stdlib.h>
-#include <stdio.h>
-#include <string>
-#include <cstring>
-
-#define FAIL_CHECK(cmd)                     \
-    do                                      \
-    {                                       \
-        JsErrorCode errCode = cmd;          \
-        if (errCode != JsNoError)           \
-        {                                   \
-            printf("Error %d at '%s'\n",    \
-                errCode, #cmd);             \
-            return 1;                       \
-        }                                   \
-    } while(0)
+#include "../CommonDefinitions.h"
 
 using namespace std;
 

--- a/test/native-tests/test-static-native/sample.cpp
+++ b/test/native-tests/test-static-native/sample.cpp
@@ -3,23 +3,7 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 
-#include "ChakraCore.h"
-#include <stdlib.h>
-#include <stdio.h>
-#include <string>
-#include <cstring>
-
-#define FAIL_CHECK(cmd)                     \
-    do                                      \
-    {                                       \
-        JsErrorCode errCode = cmd;          \
-        if (errCode != JsNoError)           \
-        {                                   \
-            printf("Error %d at '%s'\n",    \
-                errCode, #cmd);             \
-            return 1;                       \
-        }                                   \
-    } while(0)
+#include "../CommonDefinitions.h"
 
 using namespace std;
 

--- a/test/native-tests/test_native.sh
+++ b/test/native-tests/test_native.sh
@@ -87,6 +87,9 @@ RUN "test-char16"
 # test-static-native
 RUN "test-static-native"
 
+# test-external-object
+RUN "test-external-object"
+
 # shared lib tests
 LIB_DIR="$(dirname ${CH_DIR})"
 if [[ `uname -a` =~ "Darwin" ]]; then


### PR DESCRIPTION
Adds API below to ChakraCore Jsrt;

 -  JsObjectHasExternalData
 -  JsObjectGetExternalData
 -  JsObjectSetExternalData
 -  JsObjectSetExternalDataWithCallback

Removes API from ChakraCore common Jsrt;

- JsHasExternalData
- JsGetExternalData
- JsSetExternalData