### PR TITLE
Clean up several unused/ineffectual flags in FE structures. 

### DIFF
--- a/lib/Parser/Hash.h
+++ b/lib/Parser/Hash.h
@@ -31,19 +31,6 @@ enum
     fidKwdRsvd      = 0x0001,     // the keyword is a reserved word
     fidKwdFutRsvd   = 0x0002,     // a future reserved word, but only in strict mode
 
-    // Flags to identify tracked aliases of "eval"
-    fidEval         = 0x0008,
-    // Flags to identify tracked aliases of "let"
-    fidLetOrConst   = 0x0010,     // ID has previously been used in a block-scoped declaration
-
-    // This flag is used by the Parser CountDcls and FillDcls methods.
-    // CountDcls sets the bit as it walks through the var decls so that
-    // it can skip duplicates. FillDcls clears the bit as it walks through
-    // again to skip duplicates.
-    fidGlobalDcl    = 0x2000,
-
-    fidUsed         = 0x4000,  // name referenced by source code
-
     fidModuleExport = 0x8000    // name is module export
 };
 
@@ -313,12 +300,6 @@ public:
 
     Js::PropertyId GetPropertyId() const { return m_propertyId; }
     void SetPropertyId(Js::PropertyId id) { m_propertyId = id; }
-
-    void SetIsEval() { m_grfid |= fidEval; }
-    BOOL GetIsEval() const { return m_grfid & fidEval; }
-
-    void SetIsLetOrConst() { m_grfid |= fidLetOrConst; }
-    BOOL GetIsLetOrConst() const { return m_grfid & fidLetOrConst; }
 
     void SetIsModuleExport() { m_grfid |= fidModuleExport; }
     BOOL GetIsModuleExport() const { return m_grfid & fidModuleExport; }

--- a/lib/Parser/Parse.h
+++ b/lib/Parser/Parse.h
@@ -271,8 +271,8 @@ public:
     ParseNodePtr CreateTempRef(ParseNode* tempNode);
 
     ParseNodePtr CreateNode(OpCode nop) { return CreateNode(nop, m_pscan? m_pscan->IchMinTok() : 0); }
-    ParseNodePtr CreateDeclNode(OpCode nop, IdentPtr pid, SymbolType symbolType, bool errorOnRedecl = true, bool *isRedecl = nullptr);
-    Symbol*      AddDeclForPid(ParseNodePtr pnode, IdentPtr pid, SymbolType symbolType, bool errorOnRedecl, bool *isRedecl = nullptr);
+    ParseNodePtr CreateDeclNode(OpCode nop, IdentPtr pid, SymbolType symbolType, bool errorOnRedecl = true);
+    Symbol*      AddDeclForPid(ParseNodePtr pnode, IdentPtr pid, SymbolType symbolType, bool errorOnRedecl);
     void         CheckRedeclarationErrorForBlockId(IdentPtr pid, int blockId);
     ParseNodePtr CreateNameNode(IdentPtr pid)
     {
@@ -325,7 +325,7 @@ public:
     void CheckPidIsValid(IdentPtr pid, bool autoArgumentsObject = false);
     void AddVarDeclToBlock(ParseNode *pnode);
     // Add a var declaration. Only use while parsing. Assumes m_ppnodeVar is pointing to the right place already
-    ParseNodePtr CreateVarDeclNode(IdentPtr pid, SymbolType symbolType, bool autoArgumentsObject = false, ParseNodePtr pnodeFnc = NULL, bool checkReDecl = true, bool *isRedecl = nullptr);
+    ParseNodePtr CreateVarDeclNode(IdentPtr pid, SymbolType symbolType, bool autoArgumentsObject = false, ParseNodePtr pnodeFnc = NULL, bool checkReDecl = true);
     // Add a var declaration, during parse tree rewriting. Will setup m_ppnodeVar for the given pnodeFnc
     ParseNodePtr AddVarDeclNode(IdentPtr pid, ParseNodePtr pnodeFnc);
     // Add a 'const' or 'let' declaration.

--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -1182,7 +1182,7 @@ void EmitAssignmentToFuncName(ParseNode *pnodeFnc, ByteCodeGenerator *byteCodeGe
             {
                 byteCodeGenerator->EmitPropStore(pnodeFnc->location, sym, nullptr, funcInfoParent);
             }
-            else if (!sym->GetIsBlockVar() || sym->HasRealBlockVarRef() || sym->GetScope()->GetIsObject())
+            else
             {
                 byteCodeGenerator->EmitLocalPropInit(pnodeFnc->location, sym, funcInfoParent);
             }

--- a/lib/Runtime/ByteCode/Symbol.h
+++ b/lib/Runtime/ByteCode/Symbol.h
@@ -40,8 +40,6 @@ private:
     BYTE isGlobalCatch : 1;
     BYTE isCommittedToSlot : 1;
     BYTE hasNonCommittedReference : 1;
-    BYTE hasRealBlockVarRef : 1;
-    BYTE hasBlockFncVarRedecl : 1;
     BYTE hasVisitedCapturingFunc : 1;
     BYTE isTrackedForDebugger : 1; // Whether the sym is tracked for debugger scope. This is fine because a sym can only be added to (not more than) one scope.
     BYTE isModuleExportStorage : 1; // If true, this symbol should be stored in the global scope export storage array.
@@ -75,8 +73,6 @@ public:
         isGlobalCatch(false),
         isCommittedToSlot(false),
         hasNonCommittedReference(false),
-        hasRealBlockVarRef(false),
-        hasBlockFncVarRedecl(false),
         hasVisitedCapturingFunc(false),
         isTrackedForDebugger(false),
         isNonSimpleParameter(false),
@@ -314,26 +310,6 @@ public:
     void SetIsUsed(bool is)
     {
         isUsed = is;
-    }
-
-    bool HasRealBlockVarRef() const
-    {
-        return hasRealBlockVarRef;
-    }
-
-    void SetHasRealBlockVarRef(bool has = true)
-    {
-        hasRealBlockVarRef = has;
-    }
-
-    bool HasBlockFncVarRedecl() const
-    {
-        return hasBlockFncVarRedecl;
-    }
-
-    void SetHasBlockFncVarRedecl(bool has = true)
-    {
-        hasBlockFncVarRedecl = has;
     }
 
     AssignmentState GetAssignmentState() const


### PR DESCRIPTION
Delete code that exposed more redeferral candidates in RS2 but is not needed now. Stop creating a node and scope to hold the name of a function expression if we're parsing an arrow function.