### PR TITLE
Update scanner handling of numeric literal suffixes (Fixes #3281)

### DIFF
--- a/lib/Parser/Scan.h
+++ b/lib/Parser/Scan.h
@@ -767,7 +767,6 @@ private:
     tokens SkipComment(EncodedCharPtr *pp, /* out */ bool* containTypeDef);
     tokens ScanRegExpConstant(ArenaAllocator* alloc);
     tokens ScanRegExpConstantNoAST(ArenaAllocator* alloc);
-    BOOL oFScanNumber(double *pdbl, bool& likelyInt);
     EncodedCharPtr FScanNumber(EncodedCharPtr p, double *pdbl, bool& likelyInt);
     IdentPtr PidOfIdentiferAt(EncodedCharPtr p, EncodedCharPtr last, bool fHadEscape, bool fHasMultiChar);
     IdentPtr PidOfIdentiferAt(EncodedCharPtr p, EncodedCharPtr last);

--- a/lib/Parser/perrors.h
+++ b/lib/Parser/perrors.h
@@ -22,6 +22,7 @@ LSC_ERROR_MSG( 1013, ERRbadNumber     , "Invalid number")
 LSC_ERROR_MSG( 1014, ERRillegalChar   , "Invalid character")
 LSC_ERROR_MSG( 1015, ERRnoStrEnd      , "Unterminated string constant")
 LSC_ERROR_MSG( 1016, ERRnoCmtEnd      , "Unterminated comment")
+LSC_ERROR_MSG( 1017, ERRIdAfterLit    , "Unexpected identifier after numeric literal")
 
 LSC_ERROR_MSG( 1018, ERRbadReturn     , "'return' statement outside of function")
 LSC_ERROR_MSG( 1019, ERRbadBreak      , "Can't have 'break' outside of loop")

--- a/test/Scanner/NumericLiteralSuffix.js
+++ b/test/Scanner/NumericLiteralSuffix.js
@@ -1,0 +1,80 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+
+// https://tc39.github.io/ecma262/#sec-reserved-words
+let keywords = ['await', 'break', 'case', 'catch', 'class', 'const', 'continue', 'debugger', 'default', 'delete', 'do', 'else', 'export', 'extends', 'finally', 'for', 'function', 'if', 'import', 'in', 'instanceof', 'new', 'return', 'super', 'switch', 'this', 'throw', 'try', 'typeof', 'var', 'void', 'while', 'with', 'yield'];
+let futureReservedWords = ['enum', 'implements', 'package', 'protected ', 'interface', 'private', 'public'];
+
+// https://tc39.github.io/ecma262/#sec-names-and-keywords
+let idStarts = ["\u{50}", '$', '_', "\\u{50}"];
+
+// https://tc39.github.io/ecma262/#sec-literals-numeric-literals
+let literalClasses = {
+    'Decimal Integer Literal': [
+        '0', '1', '123',
+        '0.1', '1.1', '123.1', '123.123',
+        '0e1', '1e1', '1e+1', '1e-1',
+        '0E1', '1E1', '1E+1', '1E-1',
+        '123e123', '123e+123', '123e-123',
+        '123E123', '123E+123', '123E-123'
+     ],
+     'Binary Integer Literal': [
+        '0b0', '0b1', '0b010101',
+        '0B0', '0B1', '0B010101',
+     ],
+     'Octal Integer Literal': [
+        '0o0', '0o1', '0o123',
+        '0O0', '0O1', '0O123'
+     ],
+     'Hex Integer Literal': [
+        '0x0', '0x1', '0x123', '0xabc', '0xABC', '0x123abc', '0x123ABC',
+        '0X0', '0X1', '0X123', '0Xabc', '0XABC', '0X123abc', '0X123ABC'
+     ]
+};
+
+var tests = [
+    {
+        name: "Numeric literal followed by an identifier start throws",
+        body: function () {
+            for (let literalClass in literalClasses) {
+                for (let literal of literalClasses[literalClass]) {
+                    for (let idStart of idStarts) {
+                        for (let keyword of keywords) {
+                          assert.throws(function () { eval(`${literal}${keyword}`); },            SyntaxError, `Keyword '${keyword}' directly after ${literalClass} '${literal}' throws`, "Unexpected identifier after numeric literal");
+                        }
+                        for (let futureReservedWord of futureReservedWords) {
+                          assert.throws(function () { eval(`${literal}${futureReservedWord}`); }, SyntaxError, `Future reserved word '${futureReservedWord}' directly after ${literalClass} '${literal}' throws`, "Unexpected identifier after numeric literal");
+                        }
+                        for (let idStart of idStarts) {
+                          assert.throws(function () { eval(`${literal}${idStart}`); },            SyntaxError, `Identifier start '${idStart}' directly after ${literalClass} '${literal}' throws`, "Unexpected identifier after numeric literal");
+                        }
+                    }
+                }
+            }
+        }
+    },
+    {
+        name: "Numeric literal followed by invalid digit throws",
+        body: function () {
+            let nonOctalDigits = ['8', '9'];
+            for (let literal of literalClasses['Octal Integer Literal']) {
+                for (let nonOctalDigit of nonOctalDigits) {
+                    assert.throws(function () { eval(`${literal}${nonOctalDigit}`); },            SyntaxError, `Non-octal digit '${nonOctalDigit}' directly after Octal Integer Literal '${literal}' throws`, "Invalid number");
+                }
+            }
+
+            let nonBinaryDigits = ['2', '3', '4', '5', '6', '7', '8', '9'];
+            for (let literal of literalClasses['Binary Integer Literal']) {
+                for (let nonBinaryDigit of nonBinaryDigits) {
+                    assert.throws(function () { eval(`${literal}${nonBinaryDigit}`); },            SyntaxError, `Non-binary digit '${nonBinaryDigit}' directly after Binary Integer Literal '${literal}' throws`, "Invalid number");
+                }
+            }
+        }
+    }
+];
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/Scanner/rlexe.xml
+++ b/test/Scanner/rlexe.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<regress-exe>
+  <test>
+    <default>
+      <files>NumericLiteralSuffix.js</files>
+      <compile-flags>-args summary -endargs</compile-flags>
+    </default>
+  </test>
+</regress-exe>

--- a/test/es6/bug_OS12095746.baseline
+++ b/test/es6/bug_OS12095746.baseline
@@ -1,6 +1,6 @@
 NotifyModuleReadyCallback(exception) bug_OS12095746_mod0.js
 NotifyModuleReadyCallback(exception) bug_OS12095746_mod1.js
 mod0 catch:Syntax error
-mod1 catch:Expected ';'
+mod1 catch:Unexpected identifier after numeric literal
 NotifyModuleReadyCallback(exception) bug_OS12095746_mod2.js
-mod2 catch:Expected ';'
+mod2 catch:Unexpected identifier after numeric literal

--- a/test/rlexedirs.xml
+++ b/test/rlexedirs.xml
@@ -321,4 +321,9 @@
     <tags>sequential,exclude_dynapogo,exclude_jshost,exclude_snap,exclude_serialized,require_debugger</tags>
   </default>
 </dir>
+<dir>
+  <default>
+    <files>Scanner</files>
+  </default>
+</dir>
 </regress-exe>


### PR DESCRIPTION
The scanner was missing logic to error out in some cases when we have forbidden characters after a numeric literal. The spec states that we cannot have an identifier start or a digit immediately following a numeric literal.

- Changed Scanner::FScanNumber to check for forbidden characters following a valid literal.
- Added an error message to convey the identifier after literal case.
- Removed the unused oFScanNumber function.
- Created a scanner test dir since we don't have one.
- Added a comprehensive test to test both the following literal and digit case (for octal and binary literals.)
