### PR TITLE
Fix broken config parsing in ChakraFull

### DIFF
--- a/lib/Common/Core/ConfigParser.cpp
+++ b/lib/Common/Core/ConfigParser.cpp
@@ -375,10 +375,12 @@ void ConfigParser::ParseConfig(HANDLE hmod, CmdLineArgsParser &parser)
 #define ReadChar(file) fgetwc(file)
 #define UnreadChar(c, file) ungetwc(c, file)
 #define CharType wint_t
+#define EndChar WEOF
 #else
 #define ReadChar(file) fgetc(file)
 #define UnreadChar(c, file) ungetc(c, file)
 #define CharType int
+#define EndChar EOF
 #endif
 
     // We don't expect the token to overflow- if it does
@@ -390,9 +392,8 @@ void ConfigParser::ParseConfig(HANDLE hmod, CmdLineArgsParser &parser)
     while (index < MaxTokenSize)
     {
         CharType curChar = ReadChar(configFile);
-        const CharType end = static_cast<const CharType>(FINISHED);
 
-        if (curChar == end || isspace(curChar))
+        if (curChar == EndChar || isspace(curChar))
         {
             configBuffer[index] = 0;
             if ((err = parser.Parse(configBuffer)) != 0)
@@ -400,12 +401,12 @@ void ConfigParser::ParseConfig(HANDLE hmod, CmdLineArgsParser &parser)
                 break;
             }
 
-            while(curChar != end && isspace(curChar))
+            while(curChar != EndChar && isspace(curChar))
             {
                 curChar = ReadChar(configFile);
             }
 
-            if (curChar == end)
+            if (curChar == EndChar)
             {
                 break;
             }
@@ -428,6 +429,7 @@ void ConfigParser::ParseConfig(HANDLE hmod, CmdLineArgsParser &parser)
 #undef ReadChar
 #undef UnreadChar
 #undef CharType
+#undef EndChar
 
     fclose(configFile);
 

--- a/lib/Common/Core/ConfigParser.h
+++ b/lib/Common/Core/ConfigParser.h
@@ -37,14 +37,6 @@ private:
     const LPCWSTR _configFileName;
     CLANG_WNO_END
 
-    // NT version of CRT has the "backward compat" behavior that returns 0 instead of EOF
-    // for unicode version of fwscanf.
-#ifdef NTBUILD
-    static const int FINISHED = 0;
-#else
-    static const int FINISHED = EOF;
-#endif
-
     void ParseRegistryKey(HKEY hk, CmdLineArgsParser &parser);
 
 public:


### PR DESCRIPTION
ChakraFull had ifdef-ed the value of FINISHED. When the config parsing code was changed to use fget*c instead of fwscanf, the ifdef should have been removed. Not doing so caused us to fill in EOFs in the config buffer causing us to incorrectly parse the config file.

This change removes the old version of FINISHED and switches to using EOF or WEOF depending on the platform.
