### PR TITLE
Implement an additional bitflag to the debugger to distinguish variables still in TDZ

### DIFF
--- a/lib/Jsrt/ChakraDebug.h
+++ b/lib/Jsrt/ChakraDebug.h
@@ -414,6 +414,7 @@ typedef unsigned __int32 uint32_t;
     ///         NONE = 0x1,
     ///         HAVE_CHILDRENS = 0x2,
     ///         READ_ONLY_VALUE = 0x4,
+    ///         IN_TDZ = 0x8,
     ///     </para>
     ///     <para>
     ///     {

--- a/lib/Jsrt/JsrtDebugUtils.cpp
+++ b/lib/Jsrt/JsrtDebugUtils.cpp
@@ -145,6 +145,7 @@ void JsrtDebugUtils::AddPropertyType(Js::DynamicObject * object, Js::IDiagObject
     bool addValue = false;
 
     Js::Var varValue = objectDisplayRef->GetVarValue(FALSE);
+    Js::IDiagObjectAddress* varAddress = objectDisplayRef->GetDiagAddress();
 
     if (varValue != nullptr)
     {
@@ -364,6 +365,11 @@ void JsrtDebugUtils::AddPropertyType(Js::DynamicObject * object, Js::IDiagObject
     if (objectDisplayRef->HasChildren())
     {
         propertyAttributes |= JsrtDebugPropertyAttribute::HAVE_CHILDRENS;
+    }
+
+    if (varAddress != nullptr && varAddress->IsInDeadZone())
+    {
+        propertyAttributes |= JsrtDebugPropertyAttribute::IN_TDZ;
     }
 
     JsrtDebugUtils::AddPropertyToObject(object, JsrtDebugPropertyId::propertyAttributes, (UINT)propertyAttributes, scriptContext);

--- a/lib/Jsrt/JsrtDebugUtils.h
+++ b/lib/Jsrt/JsrtDebugUtils.h
@@ -14,6 +14,7 @@ BEGIN_ENUM_UINT(JsrtDebugPropertyAttribute)
     NONE = 0x1,
     HAVE_CHILDRENS = 0x2,
     READ_ONLY_VALUE = 0x4,
+    IN_TDZ = 0x8,
 END_ENUM_UINT()
 
 class JsrtDebugUtils


### PR DESCRIPTION
When examining local variables through the JSON debug API, variables which are still in the temporal dead zone now get an additional bitflag in their propertyAttributes, `IN_TDZ`, to allow the host to quickly distinguish them from variables already in play.

Fixes #3690 (in a sense).