### PR TITLE
Fix Issue#3530: Incorrect behavior of Array.prototype.filter()

### DIFF
--- a/lib/Runtime/Library/JavascriptArray.cpp
+++ b/lib/Runtime/Library/JavascriptArray.cpp
@@ -9587,6 +9587,12 @@ Case0:
             Assert(length <= UINT_MAX);
             for (uint32 k = 0; k < (uint32)length; k++)
             {
+                JS_REENTRANT(jsReentLock, BOOL hasItem = JavascriptOperators::HasItem(pArr, k));
+                if (!hasItem)
+                {
+                    continue;
+                }
+
                 JS_REENTRANT(jsReentLock, BOOL gotItem = pArr->DirectGetItemAtFull(k, &element));
                 if (!gotItem)
                 {

--- a/test/es6/arraywithproxy_bugs.js
+++ b/test/es6/arraywithproxy_bugs.js
@@ -1,0 +1,32 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+
+var tests = [
+  {
+    name: "Issue#3530 - Incorrect behavior of Array.prototype.filter()",
+    body: function () {
+        var words = ["abc", "aaaaaaa", "abcd", "aaaaabcd", "abcde", "aaaaabcdef"];
+
+        var p = new Proxy([],  {
+            get: function(oTarget, sKey) {
+                if (sKey.toString()=="constructor") {
+                    return Reflect.get(oTarget, sKey);
+                }
+            },
+            has: function (oTarget, sKey) {
+                return Reflect.has(oTarget, sKey);
+            },
+        });
+
+        Object.setPrototypeOf(words, p);
+        words.length = 10;
+        assert.areEqual(["aaaaaaa", "aaaaabcd", "aaaaabcdef"], Array.prototype.filter.call(words, function(word){ return word.length > 6; }));
+    }
+  },
+];
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -1478,4 +1478,11 @@
       <tags>BugFix</tags>
     </default>
   </test>
+  <test>
+    <default>
+      <files>arraywithproxy_bugs.js</files>
+      <compile-flags>-args summary -endargs</compile-flags>
+      <tags>BugFix</tags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
Fastpath of Array.prototype.filter() is missing following operation:
   b. Let kPresent be ? HasProperty(O, Pk).
Fix by adding call to JavascriptOperators::HasItem()
