### PR TITLE
OS#10614839 Relax an assert for verifying cached value against current property value

### DIFF
--- a/lib/Runtime/Types/TypePropertyCache.cpp
+++ b/lib/Runtime/Types/TypePropertyCache.cpp
@@ -218,7 +218,9 @@ namespace Js
                     : DynamicObject::FromVar(propertyObject)->GetAuxSlot(propertyIndex);
             if(propertyObject->GetScriptContext() == requestContext)
             {
-                Assert(*propertyValue == JavascriptOperators::GetProperty(propertyObject, propertyId, requestContext));
+                DebugOnly(Var getPropertyValue = JavascriptOperators::GetProperty(propertyObject, propertyId, requestContext));
+                Assert(*propertyValue == getPropertyValue ||
+                    (getPropertyValue == requestContext->GetLibrary()->GetNull() && requestContext->GetThreadContext()->IsDisableImplicitCall() && propertyObject->GetType()->IsExternal()));
 
                 CacheOperators::Cache<false, true, false>(
                     false,


### PR DESCRIPTION
If disable implicit bit is set GetProperty returns a null value for external objects. Relax the assert to handle this.
