### PR TITLE
Dont give a (backend) Value to the property sym for 'arguments' property

### DIFF
--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -3317,6 +3317,13 @@ GlobOpt::OptSrc(IR::Opnd *opnd, IR::Instr * *pInstr, Value **indirIndexValRef, I
         }
         originalPropertySym = sym->AsPropertySym();
 
+        // Dont give a vale to 'arguments' property sym to prevent field copy prop of 'arguments'
+        if (originalPropertySym->AsPropertySym()->m_propertyId == Js::PropertyIds::arguments &&
+            originalPropertySym->AsPropertySym()->m_fieldKind == PropertyKindData)
+        {
+            return nullptr;
+        }
+
         Value *const objectValue = CurrentBlockData()->FindValue(originalPropertySym->m_stackSym);
         opnd->AsSymOpnd()->SetPropertyOwnerValueType(
             objectValue ? objectValue->GetValueInfo()->Type() : ValueType::Uninitialized);

--- a/lib/Runtime/Language/ProfilingHelpers.cpp
+++ b/lib/Runtime/Language/ProfilingHelpers.cpp
@@ -890,12 +890,6 @@ namespace Js
                 }
             }
 
-            if (propertyId == Js::PropertyIds::arguments)
-            {
-                fldInfoFlags = DynamicProfileInfo::MergeFldInfoFlags(fldInfoFlags, FldInfo_FromAccessor);
-                scriptContext->GetThreadContext()->AddImplicitCallFlags(ImplicitCall_Accessor);
-            }
-
             if (!Root && operationInfo.isPolymorphic)
             {
                 fldInfoFlags = DynamicProfileInfo::MergeFldInfoFlags(fldInfoFlags, FldInfo_Polymorphic);


### PR DESCRIPTION
We dont want to field copy prop loads of 'arguments' property from a function object (<function>.arguments). This was achieved by marking 'arguments' property load in the interpreter as having implicit calls. However, this misses some cases when the 'arguments' load wasn't profiled. In this change I'm trying to fix the original problem in the globopt by not giving a value to the property sym for the 'arguments' property.