### PR TITLE
Call SetInternalProperty and fix flags

### DIFF
--- a/lib/Runtime/RuntimeCommon.h
+++ b/lib/Runtime/RuntimeCommon.h
@@ -53,6 +53,7 @@ namespace Js
     #define PropertyLet             0x40
     #define PropertyConst           0x80
     // No more flags will fit unless PropertyAttributes is bumped up to a short instead of char
+    #define PropertyInternalDefaults        (PropertyConfigurable|PropertyWritable)
     #define PropertyBuiltInMethodDefaults   (PropertyConfigurable|PropertyWritable)
     #define PropertyDynamicTypeDefaults     (PropertyConfigurable|PropertyWritable|PropertyEnumerable)
     #define PropertyLetDefaults             (PropertyEnumerable|PropertyConfigurable|PropertyWritable|PropertyLet)

--- a/lib/Runtime/Types/DictionaryTypeHandler.cpp
+++ b/lib/Runtime/Types/DictionaryTypeHandler.cpp
@@ -867,7 +867,7 @@ namespace Js
     template <typename T>
     BOOL DictionaryTypeHandlerBase<T>::SetInternalProperty(DynamicObject* instance, PropertyId propertyId, Var value, PropertyOperationFlags flags)
     {
-        return SetPropertyWithAttributes(instance, propertyId, value, PropertyWritable & PropertyConfigurable, nullptr, flags);
+        return SetPropertyWithAttributes(instance, propertyId, value, PropertyInternalDefaults, nullptr, flags);
     }
 
     template <typename T>

--- a/lib/Runtime/Types/DynamicType.cpp
+++ b/lib/Runtime/Types/DynamicType.cpp
@@ -293,7 +293,7 @@ namespace Js
     BOOL DynamicObject::SetInternalProperty(PropertyId propertyId, Var value, PropertyOperationFlags flags, PropertyValueInfo* info)
     {
         Assert(Js::IsInternalPropertyId(propertyId));
-        return GetTypeHandler()->SetProperty(this, propertyId, value, flags, nullptr);
+        return GetTypeHandler()->SetInternalProperty(this, propertyId, value, flags);
     }
 
     DescriptorFlags DynamicObject::GetSetter(PropertyId propertyId, Var* setterValue, PropertyValueInfo* info, ScriptContext* requestContext)

--- a/lib/Runtime/Types/NullTypeHandler.cpp
+++ b/lib/Runtime/Types/NullTypeHandler.cpp
@@ -134,7 +134,7 @@ namespace Js
 
     BOOL NullTypeHandlerBase::SetInternalProperty(DynamicObject* instance, PropertyId propertyId, Var value, PropertyOperationFlags flags)
     {
-        return SetPropertyWithAttributes(instance, propertyId, value, PropertyWritable & PropertyConfigurable, nullptr, flags);
+        return SetPropertyWithAttributes(instance, propertyId, value, PropertyInternalDefaults, nullptr, flags);
     }
 
     BOOL NullTypeHandlerBase::AddProperty(DynamicObject* instance, PropertyId propertyId, Var value, PropertyAttributes attributes, PropertyValueInfo* info, PropertyOperationFlags flags, SideEffects possibleSideEffects)

--- a/lib/Runtime/Types/SimpleDictionaryTypeHandler.cpp
+++ b/lib/Runtime/Types/SimpleDictionaryTypeHandler.cpp
@@ -1455,7 +1455,7 @@ namespace Js
     template <typename TPropertyIndex, typename TMapKey, bool IsNotExtensibleSupported>
     BOOL SimpleDictionaryTypeHandlerBase<TPropertyIndex, TMapKey, IsNotExtensibleSupported>::SetInternalProperty(DynamicObject* instance, PropertyId propertyId, Var value, PropertyOperationFlags flags)
     {
-        return SetPropertyWithAttributes(instance, propertyId, value, PropertyWritable & PropertyConfigurable, nullptr, flags);
+        return SetPropertyWithAttributes(instance, propertyId, value, PropertyInternalDefaults, nullptr, flags);
     }
 
     template <typename TPropertyIndex, typename TMapKey, bool IsNotExtensibleSupported>

--- a/lib/Runtime/Types/SimpleTypeHandler.cpp
+++ b/lib/Runtime/Types/SimpleTypeHandler.cpp
@@ -1062,7 +1062,7 @@ namespace Js
     template<size_t size>
     BOOL SimpleTypeHandler<size>::SetInternalProperty(DynamicObject* instance, PropertyId propertyId, Var value, PropertyOperationFlags flags)
     {
-        return SetPropertyWithAttributes(instance, propertyId, value, PropertyWritable & PropertyConfigurable, nullptr, flags);
+        return SetPropertyWithAttributes(instance, propertyId, value, PropertyInternalDefaults, nullptr, flags);
     }
 
 #if DBG


### PR DESCRIPTION
SetPropertyInternal was never being called, and flags were &'d instead of |'d