### PR TITLE
[MSFT 13639200] Remove byte code serializer assert that a string template callsite constant cannot be a PropertyString. 

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeSerializer.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeSerializer.cpp
@@ -1407,7 +1407,6 @@ public:
         for (uint32 i = 0; i < callsite->GetLength(); i++)
         {
             callsite->DirectGetItemAt(i, &element);
-            Assert(!VirtualTableInfo<Js::PropertyString>::HasVirtualTable(element));
             size += PrependStringConstant(builder, element);
         }
 
@@ -1417,7 +1416,6 @@ public:
         for (uint32 i = 0; i < rawArray->GetLength(); i++)
         {
             rawArray->DirectGetItemAt(i, &element);
-            Assert(!VirtualTableInfo<Js::PropertyString>::HasVirtualTable(element));
             size += PrependStringConstant(builder, element);
         }
 


### PR DESCRIPTION
The condition is harmless and turns out to be a normal case for single-character strings.