### PR TITLE
fix recyclerList check failing on multi-thread usage

### DIFF
--- a/lib/Common/Memory/Recycler.h
+++ b/lib/Common/Memory/Recycler.h
@@ -1978,6 +1978,7 @@ public:
 #if DBG && GLOBAL_ENABLE_WRITE_BARRIER
 private:
     static Recycler* recyclerList;
+    static CriticalSection recyclerListLock;
     Recycler* next;
 public:
     static void WBSetBitJIT(char* addr)


### PR DESCRIPTION
Saw this while working on another bug. Only affects debug mode.