### PR TITLE
fix JavascriptFunction::CheckValidDebugThunk CrossSite check

### DIFF
--- a/lib/Runtime/Library/JavascriptFunction.cpp
+++ b/lib/Runtime/Library/JavascriptFunction.cpp
@@ -806,7 +806,7 @@ namespace Js
         if (scriptContext->IsScriptContextInDebugMode()
             && !scriptContext->IsInterpreted() && !CONFIG_FLAG(ForceDiagnosticsMode)    // Does not work nicely if we change the default settings.
             && function->GetEntryPoint() != scriptContext->CurrentThunk
-            && function->GetEntryPoint() != scriptContext->CurrentCrossSiteThunk
+            && !CrossSite::IsThunk(function->GetEntryPoint())
             && JavascriptFunction::Is(function))
         {
 


### PR DESCRIPTION
Comparing with scriptContext->CurrentCrossSiteThunk is unreliable. The
function being checked could be CrossSite and its context closed, thus
could be using a cross site thunk different to scriptContext's (note we
have 2 cross site thunks: DefaultThunk and ProfileThunk).

Change to CrossSite::IsThunk to cover both.

Fix OS#11699485
