### PR TITLE
fix incorrect parameter to call ChangeStringLinguisticCase

### DIFF
--- a/lib/Runtime/Library/JavascriptString.cpp
+++ b/lib/Runtime/Library/JavascriptString.cpp
@@ -3357,7 +3357,7 @@ case_2:
         BufferStringBuilder builder(count, scriptContext);
         char16* stringBuffer = builder.DangerousGetWritableBuffer();
 
-        int count1 = PlatformAgnostic::UnicodeText::ChangeStringLinguisticCase(caseFlags, str, count, stringBuffer, count, &err);
+        int count1 = PlatformAgnostic::UnicodeText::ChangeStringLinguisticCase(caseFlags, str, strLength, stringBuffer, count, &err);
 
         if (count1 <= 0)
         {

--- a/test/Strings/stringBuiltin.js
+++ b/test/Strings/stringBuiltin.js
@@ -217,3 +217,6 @@ a = b;
 Object.prototype.toUpperCase = String.prototype.toUpperCase;
 var f = obj.toUpperCase();
 WScript.Echo (a);
+
+// #3531
+"\u00DF".toLocaleUpperCase();


### PR DESCRIPTION
2nd call to ChangeStringLinguisticCase() was incorrectly passing buffer
size as source length.

Fix #3531