### PR TITLE
OS11907290 InitPorperty inside eval code should have configurable true

### DIFF
--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -8057,6 +8057,15 @@ CommonNumber:
 
         Type *typeWithoutProperty = object->GetType();
 
+        if (functionBody->IsEval())
+        {
+            if (object->InitPropertyInEval(propertyId, newValue, flags, &info))
+            {
+                CacheOperators::CachePropertyWrite(object, false, typeWithoutProperty, propertyId, &info, scriptContext);
+                return;
+            }
+        }
+
         // Ideally the lowerer would emit a call to the right flavor of PatchInitValue, so that we can ensure that we only
         // ever initialize to NULL in the right cases.  But the backend uses the StFld opcode for initialization, and it
         // would be cumbersome to thread the different helper calls all the way down
@@ -8075,6 +8084,16 @@ CommonNumber:
         PropertyValueInfo info;
         PropertyValueInfo::SetCacheInfo(&info, functionBody, inlineCache, inlineCacheIndex, true);
         Type *typeWithoutProperty = object->GetType();
+
+        if (functionBody->IsEval())
+        {
+            if (object->InitPropertyInEval(propertyId, newValue, PropertyOperation_None, &info))
+            {
+                CacheOperators::CachePropertyWrite(object, false, typeWithoutProperty, propertyId, &info, functionBody->GetScriptContext());
+                return;
+            }
+        }
+
         if (object->InitProperty(propertyId, newValue, PropertyOperation_None, &info))
         {
             CacheOperators::CachePropertyWrite(object, false, typeWithoutProperty, propertyId, &info, functionBody->GetScriptContext());

--- a/lib/Runtime/Library/GlobalObject.cpp
+++ b/lib/Runtime/Library/GlobalObject.cpp
@@ -1872,6 +1872,14 @@ LHexError:
         return DynamicObject::SetPropertyWithAttributes(propertyId, value, attributes, info, flags);
     }
 
+    BOOL GlobalObject::InitPropertyInEval(PropertyId propertyId, Var value, PropertyOperationFlags flags, PropertyValueInfo* info)
+    {
+        // This is var/function declared inside the 'eval'
+        PropertyAttributes attributes = PropertyDynamicTypeDefaults | PropertyDeclaredGlobal;
+        flags = static_cast<PropertyOperationFlags>(flags | PropertyOperation_ThrowIfNotExtensible);
+        return DynamicObject::SetPropertyWithAttributes(propertyId, value, attributes, info, flags);
+    }
+
     BOOL GlobalObject::InitPropertyScoped(PropertyId propertyId, Var value)
     {
         // var x = 10; variables declared with "var" inside "eval"

--- a/lib/Runtime/Library/GlobalObject.h
+++ b/lib/Runtime/Library/GlobalObject.h
@@ -138,6 +138,7 @@ namespace Js
         virtual PropertyQueryFlags GetPropertyQuery(Var originalInstance, PropertyId propertyId, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;
         virtual PropertyQueryFlags GetPropertyQuery(Var originalInstance, JavascriptString* propertyNameString, Var* value, PropertyValueInfo* info, ScriptContext* requestContext) override;
         virtual BOOL InitProperty(PropertyId propertyId, Var value, PropertyOperationFlags flags = PropertyOperation_None, PropertyValueInfo* info = NULL) override;
+        virtual BOOL InitPropertyInEval(PropertyId propertyId, Var value, PropertyOperationFlags flags = PropertyOperation_None, PropertyValueInfo* info = NULL) override;
         virtual BOOL InitPropertyScoped(PropertyId propertyId, Var value) override;
         virtual BOOL InitFuncScoped(PropertyId propertyId, Var value) override;
         virtual BOOL SetProperty(PropertyId propertyId, Var value, PropertyOperationFlags flags, PropertyValueInfo* info) override;

--- a/lib/Runtime/Types/RecyclableObject.cpp
+++ b/lib/Runtime/Types/RecyclableObject.cpp
@@ -380,6 +380,11 @@ namespace Js
         return false;
     }
 
+    BOOL RecyclableObject::InitPropertyInEval(PropertyId propertyId, Var value, PropertyOperationFlags flags, PropertyValueInfo* info)
+    {
+        return false;
+    }
+
     BOOL RecyclableObject::InitPropertyScoped(PropertyId propertyId, Var value)
     {
         return false;

--- a/lib/Runtime/Types/RecyclableObject.h
+++ b/lib/Runtime/Types/RecyclableObject.h
@@ -283,6 +283,7 @@ namespace Js {
         virtual BOOL SetProperty(JavascriptString* propertyNameString, Var value, PropertyOperationFlags flags, PropertyValueInfo* info);
         virtual BOOL SetInternalProperty(PropertyId internalPropertyId, Var value, PropertyOperationFlags flags, PropertyValueInfo* info);
         virtual BOOL InitProperty(PropertyId propertyId, Var value, PropertyOperationFlags flags = PropertyOperation_None, PropertyValueInfo* info = NULL);
+        virtual BOOL InitPropertyInEval(PropertyId propertyId, Var value, PropertyOperationFlags flags = PropertyOperation_None, PropertyValueInfo* info = NULL);
         virtual BOOL EnsureProperty(PropertyId propertyId);
         virtual BOOL EnsureNoRedeclProperty(PropertyId propertyId);
         virtual BOOL SetPropertyWithAttributes(PropertyId propertyId, Var value, PropertyAttributes attributes, PropertyValueInfo* info, PropertyOperationFlags flags = PropertyOperation_None, SideEffects possibleSideEffects = SideEffects_Any);

--- a/test/Bugs/os11907290.js
+++ b/test/Bugs/os11907290.js
@@ -1,0 +1,22 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+var glob = this;
+
+function testthis() {
+    "use strict";
+    function foo() {
+        var globaObject = glob;
+        var indirectEval = eval;
+        indirectEval('function bar() { return "blah blah"; }');
+        var desc = Object.getOwnPropertyDescriptor(globaObject, 'bar');
+        if(!desc.configurable) {
+            print("Failed - function should be configurable");
+        }
+        delete globaObject['bar'];
+    }
+    foo();
+}
+testthis();
+console.log("Pass");

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -381,6 +381,11 @@
   </test>
   <test>
     <default>
+      <files>os11907290.js</files>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>bug13383062.js</files>
       <compile-flags>-maxinterpretcount:2 -off:simplejit -off:lossyinttypespec -bgjit-</compile-flags>
       <baseline>bug13383062.baseline</baseline>


### PR DESCRIPTION
As per EvalDeclarationInstantiation CreateGlobalFunctionBinding will make sure to have global function to be configurable. But we didn't set that which breaks a web-page
 https://spb.tele2.ru/mobile/internet/skylink, where we throw error for such scenario. Fixed that.
