### PR TITLE
Free temporary data in reg-alloc

### DIFF
--- a/lib/Backend/LinearScan.h
+++ b/lib/Backend/LinearScan.h
@@ -40,6 +40,7 @@ public:
     }
 
     static LoweredBasicBlock* New(JitArenaAllocator * allocator);
+    void Delete(JitArenaAllocator* allocator);
     void Copy(LoweredBasicBlock* block);
     LoweredBasicBlock* Clone(JitArenaAllocator * allocator);
     bool HasData();


### PR DESCRIPTION
Delete regContent on forward branches when processing the target label.
Delete unneeded BasicBlock info.

24% reduction of temporary memory allcoations in reg-alloc.
