### PR TITLE
fix bug where we were comparing Win32 and NTSTATUS values

### DIFF
--- a/lib/Runtime/Base/ThreadContextInfo.cpp
+++ b/lib/Runtime/Base/ThreadContextInfo.cpp
@@ -450,9 +450,9 @@ ThreadContextInfo::SetValidCallTargetForCFG(PVOID callTargetAddress, bool isSetV
                 //Throw OOM, if there is not enough virtual memory for paging (required for CFG BitMap)
                 Js::Throw::OutOfMemory();
             }
-            else if (gle == STATUS_PROCESS_IS_TERMINATING)
+            else if (gle == ERROR_ACCESS_DENIED)
             {
-                // When this error is set, the target process is exiting and thus cannot proceed with
+                // When this error is set, the target process may be exiting and thus cannot proceed with
                 // JIT output. Throw this exception to safely abort this call.
                 throw Js::OperationAbortedException();
             }


### PR DESCRIPTION
We were trying to handle failure registering CFG target when runtime process is exiting by checking GLE against STATUS_PROCESS_IS_TERMINATING.

Unfortunately, that is an NTSTATUS code, and the Win32 code saved for this is a generic ERROR_ACCESS_DENIED, so I've changed to compare against ERROR_ACCESS_DENIED.

See here for the NTSTATUS to Win32 mapping table:
https://support.microsoft.com/en-us/help/113996/info-mapping-nt-status-error-codes-to-win32-error-codes

OS: 9871464