### PR TITLE
fix bug with zero argument inlinees on ARM

### DIFF
--- a/lib/Backend/arm/EncoderMD.cpp
+++ b/lib/Backend/arm/EncoderMD.cpp
@@ -2236,8 +2236,9 @@ EncoderMD::BaseAndOffsetFromSym(IR::SymOpnd *symOpnd, RegNum *pBaseReg, int32 *p
         Assert(offset >= 0);
         Assert(baseReg != RegSP || (uint)offset >= (func->m_argSlotsForFunctionsCalled * MachRegInt));
 
-        if (func->HasInlinee())
+        if (func->GetMaxInlineeArgOutSize() != 0)
         {
+            Assert(func->HasInlinee());
             Assert(baseReg == RegSP);
             if (stackSym->IsArgSlotSym() && !stackSym->m_isOrphanedArg)
             {

--- a/lib/Backend/arm/LowerMD.cpp
+++ b/lib/Backend/arm/LowerMD.cpp
@@ -1313,7 +1313,7 @@ LowererMD::LowerEntryInstr(IR::EntryInstr * entryInstr)
     }
     Assert(fpOffsetSize >= 0);
 
-    if (m_func->HasInlinee())
+    if (m_func->GetMaxInlineeArgOutSize() != 0)
     {
         // subtracting 2 for frame pointer & return address
         this->m_func->GetJITOutput()->SetFrameHeight(this->m_func->m_localStackHeight + this->m_func->m_ArgumentsOffset - 2 * MachRegInt);
@@ -1452,7 +1452,7 @@ LowererMD::LowerEntryInstr(IR::EntryInstr * entryInstr)
     //As we have already allocated the stack here, we can safely zero out the inlinee argout slot.
 
     // Zero initialize the first inlinee frames argc.
-    if (m_func->HasInlinee())
+    if (m_func->GetMaxInlineeArgOutSize() != 0)
     {
         // This is done post prolog. so we don't have to emit unwind data.
         if (r12Opnd == nullptr || isScratchRegisterThrashed)


### PR DESCRIPTION
With my wasm inlining change I made some conditions use `func->HasInlinee()` rather than `func->GetMaxInlineeArgOutCount() != 0`. This was causing an assert to fire on ARM.

I reverted there and another suspicious location to use the old check.

OS: 13782295