### PR TITLE
Make -v actually enable verbose makefiles

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -153,7 +153,7 @@ while [[ $# -gt 0 ]]; do
         ;;
 
     -v | --verbose)
-        _VERBOSE="V=1"
+        _VERBOSE="VERBOSE=1"
         ;;
 
     -d | --debug)


### PR DESCRIPTION
-v wasn't allowing me to see the commands being run, and switching "V=1" to "VERBOSE=1" fixed that: https://stackoverflow.com/questions/5820303/how-do-i-force-make-gcc-to-show-me-the-commands#comment34121307_5820432
