### PR TITLE
SetPropertyWithAttributes assert does not cover static constructor case

### DIFF
--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -6641,6 +6641,11 @@ CommonNumber:
         return JavascriptFunction::Is(instance) && (JavascriptFunction::FromVar(instance)->GetFunctionInfo()->IsClassConstructor() || !JavascriptFunction::FromVar(instance)->IsScriptFunction());
     }
 
+    BOOL JavascriptOperators::IsClassMethod(Var instance)
+    {
+        return JavascriptFunction::Is(instance) && JavascriptFunction::FromVar(instance)->GetFunctionInfo()->IsClassMethod();
+    }
+
     BOOL JavascriptOperators::IsBaseConstructorKind(Var instance)
     {
         return JavascriptFunction::Is(instance) && (JavascriptFunction::FromVar(instance)->GetFunctionInfo()->GetBaseConstructorKind());

--- a/lib/Runtime/Language/JavascriptOperators.h
+++ b/lib/Runtime/Language/JavascriptOperators.h
@@ -227,6 +227,7 @@ namespace Js
         static BOOL IsUndefinedObject(Var instance, JavascriptLibrary* library);
         static BOOL IsAnyNumberValue(Var instance);
         static BOOL IsClassConstructor(Var instance);
+        static BOOL IsClassMethod(Var instance);
         static BOOL IsBaseConstructorKind(Var instance);
 
         static bool CanShortcutOnUnknownPropertyName(RecyclableObject * instance);

--- a/lib/Runtime/Types/DictionaryTypeHandler.cpp
+++ b/lib/Runtime/Types/DictionaryTypeHandler.cpp
@@ -1856,6 +1856,9 @@ namespace Js
             {
                 if (descriptor->IsAccessor && !(attributes & PropertyLetConstGlobal))
                 {
+#if DEBUG
+                    Var ctor = JavascriptOperators::GetProperty(instance, PropertyIds::constructor, scriptContext);
+#endif
                     AssertMsg(RootObjectBase::Is(instance) || JavascriptFunction::IsBuiltinProperty(instance, propertyId) ||
                         // ValidateAndApplyPropertyDescriptor says to preserve Configurable and Enumerable flags
 
@@ -1867,7 +1870,7 @@ namespace Js
                         // something else.  All we need to do is convert the descriptor to a data descriptor.
                         // Built-in Function.prototype properties 'length', 'arguments', and 'caller' are special cases.
 
-                        (JavascriptOperators::IsClassConstructor(JavascriptOperators::GetProperty(instance, PropertyIds::constructor, scriptContext)) &&
+                        ((JavascriptOperators::IsClassConstructor(ctor) || JavascriptOperators::IsClassMethod(ctor)) &&
                             (attributes & PropertyClassMemberDefaults) == PropertyClassMemberDefaults),
                         // 14.3.9: InitClassMember sets property descriptor to {writable:true, enumerable:false, configurable:true}
 

--- a/test/es6/classes_bugfixes.js
+++ b/test/es6/classes_bugfixes.js
@@ -474,6 +474,16 @@ var tests = [
       catch(e) {}
     }
   },
+  {
+    name: "OS: 12681861: SetPropertyWithAttributes assert does not cover static constructor case",
+    body: function () {
+      class tvawjo {
+        static constructor() { }
+        static get igwgep() { }
+        static igwgep() { }
+      };
+    }
+  }
 ];
 
 testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });


### PR DESCRIPTION
Fixes OS: 12681861

We have a condition in an assert in SetPropertyWithAttributes that checks to see if we are coming from an InitClassMember opcode. We check this by getting the constructor property on the class and checking if it has the constructor flag set.

This misses the case where we have a static method named 'constructor'. In this case we will have the class method flag set. I added this case to the assert.
