### PR TITLE
Implement Dump method on part of DynamicTypeHandler hierarchy

### DIFF
--- a/lib/Runtime/Base/PropertyRecord.cpp
+++ b/lib/Runtime/Base/PropertyRecord.cpp
@@ -142,7 +142,7 @@ namespace Js
 
         Output::Print(_u("%*sPropertyRecord (0x%p):\n"), indent, padding, this);
         Output::Print(_u("%*spid: %d\n"), fieldIndent, padding, this->pid);
-        Output::Print(_u("%*shash: %#08x\n"), fieldIndent, padding, this->hash);
+        Output::Print(_u("%*shash: 0x%08x\n"), fieldIndent, padding, this->hash);
         Output::Print(_u("%*sisNumeric: %d\n"), fieldIndent, padding, this->isNumeric);
         Output::Print(_u("%*sIsBound: %d\n"), fieldIndent, padding, this->isBound);
         Output::Print(_u("%*sIsSymbol: %d\n"), fieldIndent, padding, this->isSymbol);

--- a/lib/Runtime/Base/PropertyRecord.cpp
+++ b/lib/Runtime/Base/PropertyRecord.cpp
@@ -135,7 +135,7 @@ namespace Js
     }
 
 #if DBG_DUMP
-	void PropertyRecord::Dump(unsigned indent) const
+    void PropertyRecord::Dump(unsigned indent) const
     {
         const auto padding(_u(""));
         const unsigned fieldIndent(indent + 2);

--- a/lib/Runtime/Base/PropertyRecord.cpp
+++ b/lib/Runtime/Base/PropertyRecord.cpp
@@ -134,6 +134,22 @@ namespace Js
         }
     }
 
+#if DBG_DUMP
+	void PropertyRecord::Dump(unsigned indent) const
+    {
+        const auto padding(_u(""));
+        const unsigned fieldIndent(indent + 2);
+
+        Output::Print(_u("%*sPropertyRecord (0x%p):\n"), indent, padding, this);
+        Output::Print(_u("%*spid: %d\n"), fieldIndent, padding, this->pid);
+        Output::Print(_u("%*shash: %#08x\n"), fieldIndent, padding, this->hash);
+        Output::Print(_u("%*sisNumeric: %d\n"), fieldIndent, padding, this->isNumeric);
+        Output::Print(_u("%*sIsBound: %d\n"), fieldIndent, padding, this->isBound);
+        Output::Print(_u("%*sIsSymbol: %d\n"), fieldIndent, padding, this->isSymbol);
+        Output::Print(_u("%*sbyteCount: %u\n"), fieldIndent, padding, this->byteCount);
+    }
+#endif
+
     // Initialize all BuiltIn property records
     const BuiltInPropertyRecord<1> BuiltInPropertyRecords::EMPTY = { PropertyRecord(PropertyIds::_none, 0, false, 0, false), _u("") };
 #define ENTRY_INTERNAL_SYMBOL(n) const BuiltInPropertyRecord<ARRAYSIZE(_u("<") _u(#n) _u(">"))> BuiltInPropertyRecords::n = { PropertyRecord(PropertyIds::n, (uint)PropertyIds::n, false, (ARRAYSIZE(_u("<") _u(#n) _u(">")) - 1) * sizeof(char16), true), _u("<") _u(#n) _u(">") };

--- a/lib/Runtime/Base/PropertyRecord.h
+++ b/lib/Runtime/Base/PropertyRecord.h
@@ -100,6 +100,11 @@ namespace Js
         }
 
         virtual void Mark(Recycler *recycler) override { AssertMsg(false, "Mark called on object that isn't TrackableObject"); }
+
+#if DBG_DUMP
+    public:
+        void Dump(unsigned indent = 0) const;
+#endif
     };
 
     // This struct maps to the layout of runtime allocated PropertyRecord. Used for creating built-in PropertyRecords statically.

--- a/lib/Runtime/Types/DeferredTypeHandler.h
+++ b/lib/Runtime/Types/DeferredTypeHandler.h
@@ -144,6 +144,13 @@ namespace Js
 
         bool EnsureObjectReady(DynamicObject* instance, DeferredInitializeMode mode);
         virtual BOOL FreezeImpl(DynamicObject *instance, bool isConvertedType) override;
+#if DBG_DUMP
+    public:
+        void Dump(unsigned indent = 0) const override
+        {
+            Output::Print(_u("%*sDeferredTypeHandler (0x%p): Dump unimplemented\n"), indent, _u(""), this);
+        }
+#endif
     };
 
     template <DeferredTypeInitializer initializer, typename DeferredTypeFilter, bool isPrototypeTemplate, uint16 _inlineSlotCapacity, uint16 _offsetOfInlineSlots>

--- a/lib/Runtime/Types/DictionaryPropertyDescriptor.h
+++ b/lib/Runtime/Types/DictionaryPropertyDescriptor.h
@@ -314,7 +314,7 @@ namespace Js
 
         Output::Print(_u("%*sData: %d\n"), fieldIndent, padding, static_cast<int32>(this->Data));
         Output::Print(_u("%*sGetter: %d\n"), fieldIndent, padding, static_cast<int32>(this->Getter));
-        Output::Print(_u("%*sSetter: "), fieldIndent, padding, static_cast<int32>(this->Setter));
+        Output::Print(_u("%*sSetter: %d\n"), fieldIndent, padding, static_cast<int32>(this->Setter));
     }
 #endif
 }

--- a/lib/Runtime/Types/DictionaryPropertyDescriptor.h
+++ b/lib/Runtime/Types/DictionaryPropertyDescriptor.h
@@ -298,7 +298,7 @@ namespace Js
         Output::Print(_u("%*sIsFixed: %d\n"), fieldIndent, padding, this->IsFixed);
         Output::Print(_u("%*sUsedAsFixed: %d\n"), fieldIndent, padding, this->UsedAsFixed);
 #endif
-        Output::Print(_u("%*sAttributes: %#02x "), fieldIndent, padding, this->Attributes);
+        Output::Print(_u("%*sAttributes: 0x%02x "), fieldIndent, padding, this->Attributes);
         if (this->Attributes != PropertyNone)
         {
             if (this->Attributes & PropertyEnumerable) Output::Print(_u("PropertyEnumerable "));

--- a/lib/Runtime/Types/DictionaryPropertyDescriptor.h
+++ b/lib/Runtime/Types/DictionaryPropertyDescriptor.h
@@ -101,6 +101,11 @@ namespace Js
                 (!(this->Attributes & PropertyDeleted) && (this->Data != NoSlots || this->Getter != NoSlots || this->Setter != NoSlots)));
         }
 #endif
+
+#if DBG_DUMP
+    public:
+        void Dump(unsigned indent = 0) const;
+#endif
     };
 
 
@@ -272,7 +277,44 @@ namespace Js
 #if ENABLE_FIXED_FIELDS
         this->IsInitialized = descriptor.IsInitialized;
         this->IsFixed = descriptor.IsFixed;
-        this->UsedAsFixed = descriptor.UsedAsFixed;        
+        this->UsedAsFixed = descriptor.UsedAsFixed;
 #endif
     }
+
+#if DBG_DUMP
+    template<typename TPropertyIndex>
+    void DictionaryPropertyDescriptor<TPropertyIndex>::Dump(unsigned indent) const
+    {
+        const auto padding(_u(""));
+        const unsigned fieldIndent(indent + 2);
+
+        Output::Print(_u("%*sDictionaryPropertyDescriptor (0x%p)\n"), indent, padding, this);
+        Output::Print(_u("%*sPreventFalseReference: %d\n"), fieldIndent, padding, this->PreventFalseReference);
+        Output::Print(_u("%*sIsShadowed: %d\n"), fieldIndent, padding, this->IsShadowed);
+        Output::Print(_u("%*sIsAccessor: %d\n"), fieldIndent, padding, this->IsAccessor);
+#if ENABLE_FIXED_FIELDS
+        Output::Print(_u("%*sIsInitialized: %d\n"), fieldIndent, padding, this->IsInitialized);
+        Output::Print(_u("%*sIsOnlyOneAccessorInitialized: %d\n"), fieldIndent, padding, this->IsOnlyOneAccessorInitialized);
+        Output::Print(_u("%*sIsFixed: %d\n"), fieldIndent, padding, this->IsFixed);
+        Output::Print(_u("%*sUsedAsFixed: %d\n"), fieldIndent, padding, this->UsedAsFixed);
+#endif
+        Output::Print(_u("%*sAttributes: %#02x "), fieldIndent, padding, this->Attributes);
+        if (this->Attributes != PropertyNone)
+        {
+            if (this->Attributes & PropertyEnumerable) Output::Print(_u("PropertyEnumerable "));
+            if (this->Attributes & PropertyConfigurable) Output::Print(_u("PropertyConfigurable "));
+            if (this->Attributes & PropertyWritable) Output::Print(_u("PropertyWritable "));
+            if (this->Attributes & PropertyDeleted) Output::Print(_u("PropertyDeleted "));
+            if (this->Attributes & PropertyLetConstGlobal) Output::Print(_u("PropertyLetConstGlobal "));
+            if (this->Attributes & PropertyDeclaredGlobal) Output::Print(_u("PropertyDeclaredGlobal "));
+            if (this->Attributes & PropertyLet) Output::Print(_u("PropertyLet "));
+            if (this->Attributes & PropertyConst) Output::Print(_u("PropertyConst "));
+        }
+        Output::Print(_u("\n"));
+
+        Output::Print(_u("%*sData: %d\n"), fieldIndent, padding, static_cast<int32>(this->Data));
+        Output::Print(_u("%*sGetter: %d\n"), fieldIndent, padding, static_cast<int32>(this->Getter));
+        Output::Print(_u("%*sSetter: "), fieldIndent, padding, static_cast<int32>(this->Setter));
+    }
+#endif
 }

--- a/lib/Runtime/Types/DictionaryTypeHandler.cpp
+++ b/lib/Runtime/Types/DictionaryTypeHandler.cpp
@@ -2910,31 +2910,36 @@ namespace Js
 #endif
 
 #if DBG_DUMP
-	template<typename T> void DictionaryTypeHandlerBase<T>::Dump() const {
-        Output::Print(_u("DictionaryTypeHandlerBase (0x%p):\n"), this);
+	template<typename T> void DictionaryTypeHandlerBase<T>::Dump(unsigned indent) const {
+        const auto padding(_u(""));
+        const unsigned fieldIndent(indent + 2);
+        const unsigned mapLabelIndent(indent + 4);
+        const unsigned mapValueIndent(indent + 6);
+
+        Output::Print(_u("%*sDictionaryTypeHandlerBase (0x%p):\n"), indent, padding, this);
         if (this->propertyMap == nullptr)
         {
-            Output::Print(_u("  propertyMap: null\n"));
+            Output::Print(_u("%*spropertyMap: null\n"), fieldIndent, padding);
         }
         else
         {
-            Output::Print(_u("  propertyMap: 0x%p\n"), this->propertyMap);
+            Output::Print(_u("%*spropertyMap: 0x%p\n"), fieldIndent, padding, this->propertyMap);
             for (auto iter = this->propertyMap->GetIterator(); iter.IsValid(); iter.MoveNext())
             {
-                Output::Print(_u("    Key:\n"));
+                Output::Print(_u("%*sKey:\n"), mapLabelIndent, padding);
                 if (iter.CurrentKey() == nullptr)
                 {
-                    Output::Print(_u("      <null>\n"));
+                    Output::Print(_u("%*s<null>\n"), mapValueIndent, padding);
                 }
                 else
                 {
-                    iter.CurrentKey()->Dump(6);
+                    iter.CurrentKey()->Dump(mapValueIndent);
                 }
-                Output::Print(_u("    Value\n"));
-                iter.CurrentValue().Dump(6);
+                Output::Print(_u("%*sValue\n"), mapLabelIndent, padding);
+                iter.CurrentValue().Dump(mapValueIndent);
             }
         }
-        Output::Print(_u("  nextPropertyIndex: %d\n"), static_cast<int32>(this->nextPropertyIndex));
+        Output::Print(_u("%*snextPropertyIndex: %d\n"), fieldIndent, padding, static_cast<int32>(this->nextPropertyIndex));
     }
 
 #endif

--- a/lib/Runtime/Types/DictionaryTypeHandler.cpp
+++ b/lib/Runtime/Types/DictionaryTypeHandler.cpp
@@ -2911,7 +2911,7 @@ namespace Js
 
 #if DBG_DUMP
 	template<typename T> void DictionaryTypeHandlerBase<T>::Dump() const {
-        Output::Print(_u("DictionaryTypeHandlerBase:\n"));
+        Output::Print(_u("DictionaryTypeHandlerBase (0x%p):\n"), this);
         if (this->propertyMap == nullptr)
         {
             Output::Print(_u("  propertyMap: null\n"));

--- a/lib/Runtime/Types/DictionaryTypeHandler.cpp
+++ b/lib/Runtime/Types/DictionaryTypeHandler.cpp
@@ -2917,6 +2917,7 @@ namespace Js
         const unsigned mapValueIndent(indent + 6);
 
         Output::Print(_u("%*sDictionaryTypeHandlerBase (0x%p):\n"), indent, padding, this);
+        DynamicTypeHandler::Dump(indent + 2);
         if (this->propertyMap == nullptr)
         {
             Output::Print(_u("%*spropertyMap: <null>\n"), fieldIndent, padding);

--- a/lib/Runtime/Types/DictionaryTypeHandler.cpp
+++ b/lib/Runtime/Types/DictionaryTypeHandler.cpp
@@ -2910,7 +2910,7 @@ namespace Js
 #endif
 
 #if DBG_DUMP
-	template<typename T> void DictionaryTypeHandlerBase<T>::Dump(unsigned indent) const {
+    template<typename T> void DictionaryTypeHandlerBase<T>::Dump(unsigned indent) const {
         const auto padding(_u(""));
         const unsigned fieldIndent(indent + 2);
         const unsigned mapLabelIndent(indent + 4);

--- a/lib/Runtime/Types/DictionaryTypeHandler.cpp
+++ b/lib/Runtime/Types/DictionaryTypeHandler.cpp
@@ -2923,7 +2923,7 @@ namespace Js
         }
         else
         {
-            Output::Print(_u("%*spropertyMap: 0x%p\n"), fieldIndent, padding, this->propertyMap);
+            Output::Print(_u("%*spropertyMap: 0x%p\n"), fieldIndent, padding, static_cast<void*>(this->propertyMap));
             for (auto iter = this->propertyMap->GetIterator(); iter.IsValid(); iter.MoveNext())
             {
                 Output::Print(_u("%*sKey:\n"), mapLabelIndent, padding);

--- a/lib/Runtime/Types/DictionaryTypeHandler.cpp
+++ b/lib/Runtime/Types/DictionaryTypeHandler.cpp
@@ -2919,7 +2919,7 @@ namespace Js
         Output::Print(_u("%*sDictionaryTypeHandlerBase (0x%p):\n"), indent, padding, this);
         if (this->propertyMap == nullptr)
         {
-            Output::Print(_u("%*spropertyMap: null\n"), fieldIndent, padding);
+            Output::Print(_u("%*spropertyMap: <null>\n"), fieldIndent, padding);
         }
         else
         {

--- a/lib/Runtime/Types/DictionaryTypeHandler.cpp
+++ b/lib/Runtime/Types/DictionaryTypeHandler.cpp
@@ -2910,7 +2910,7 @@ namespace Js
 #endif
 
 #if DBG_DUMP
-	template<typename T> void DictionaryTypeHandlerBase<T>::Dump() {
+	template<typename T> void DictionaryTypeHandlerBase<T>::Dump() const {
         Output::Print(_u("DictionaryTypeHandlerBase:\n"));
         if (this->propertyMap == nullptr)
         {

--- a/lib/Runtime/Types/DictionaryTypeHandler.cpp
+++ b/lib/Runtime/Types/DictionaryTypeHandler.cpp
@@ -2924,20 +2924,20 @@ namespace Js
         else
         {
             Output::Print(_u("%*spropertyMap: 0x%p\n"), fieldIndent, padding, static_cast<void*>(this->propertyMap));
-            for (auto iter = this->propertyMap->GetIterator(); iter.IsValid(); iter.MoveNext())
+            this->propertyMap->Map([&](const PropertyRecord *key, const DictionaryPropertyDescriptor<T> &value)
             {
                 Output::Print(_u("%*sKey:\n"), mapLabelIndent, padding);
-                if (iter.CurrentKey() == nullptr)
+                if (key == nullptr)
                 {
                     Output::Print(_u("%*s<null>\n"), mapValueIndent, padding);
                 }
                 else
                 {
-                    iter.CurrentKey()->Dump(mapValueIndent);
+                    key->Dump(mapValueIndent);
                 }
                 Output::Print(_u("%*sValue\n"), mapLabelIndent, padding);
-                iter.CurrentValue().Dump(mapValueIndent);
-            }
+                value.Dump(mapValueIndent);
+            });
         }
         Output::Print(_u("%*snextPropertyIndex: %d\n"), fieldIndent, padding, static_cast<int32>(this->nextPropertyIndex));
     }

--- a/lib/Runtime/Types/DictionaryTypeHandler.cpp
+++ b/lib/Runtime/Types/DictionaryTypeHandler.cpp
@@ -2909,6 +2909,36 @@ namespace Js
     }
 #endif
 
+#if DBG_DUMP
+	template<typename T> void DictionaryTypeHandlerBase<T>::Dump() {
+        Output::Print(_u("DictionaryTypeHandlerBase:\n"));
+        if (this->propertyMap == nullptr)
+        {
+            Output::Print(_u("  propertyMap: null\n"));
+        }
+        else
+        {
+            Output::Print(_u("  propertyMap: 0x%p\n"), this->propertyMap);
+            for (auto iter = this->propertyMap->GetIterator(); iter.IsValid(); iter.MoveNext())
+            {
+                Output::Print(_u("    Key:\n"));
+                if (iter.CurrentKey() == nullptr)
+                {
+                    Output::Print(_u("      <null>\n"));
+                }
+                else
+                {
+                    iter.CurrentKey()->Dump(6);
+                }
+                Output::Print(_u("    Value\n"));
+                iter.CurrentValue().Dump(6);
+            }
+        }
+        Output::Print(_u("  nextPropertyIndex: %d\n"), static_cast<int32>(this->nextPropertyIndex));
+    }
+
+#endif
+
     template class DictionaryTypeHandlerBase<PropertyIndex>;
     template class DictionaryTypeHandlerBase<BigPropertyIndex>;
 

--- a/lib/Runtime/Types/DictionaryTypeHandler.h
+++ b/lib/Runtime/Types/DictionaryTypeHandler.h
@@ -266,7 +266,7 @@ namespace Js
 
 #if DBG_DUMP
     public:
-        void Dump() const;
+        void Dump(unsigned indent = 0) const;
 #endif
     };
 

--- a/lib/Runtime/Types/DictionaryTypeHandler.h
+++ b/lib/Runtime/Types/DictionaryTypeHandler.h
@@ -266,7 +266,7 @@ namespace Js
 
 #if DBG_DUMP
     public:
-        void Dump(unsigned indent = 0) const;
+        void Dump(unsigned indent = 0) const override;
 #endif
     };
 

--- a/lib/Runtime/Types/DictionaryTypeHandler.h
+++ b/lib/Runtime/Types/DictionaryTypeHandler.h
@@ -263,6 +263,11 @@ namespace Js
 
         virtual Js::BigPropertyIndex GetPropertyIndex_EnumerateTTD(const Js::PropertyRecord* pRecord) override;
 #endif
+
+#if DBG_DUMP
+    public:
+        void Dump();
+#endif
     };
 
     template <bool allowLetConstGlobal>

--- a/lib/Runtime/Types/DictionaryTypeHandler.h
+++ b/lib/Runtime/Types/DictionaryTypeHandler.h
@@ -266,7 +266,7 @@ namespace Js
 
 #if DBG_DUMP
     public:
-        void Dump();
+        void Dump() const;
 #endif
     };
 

--- a/lib/Runtime/Types/MissingPropertyTypeHandler.cpp
+++ b/lib/Runtime/Types/MissingPropertyTypeHandler.cpp
@@ -224,4 +224,11 @@ namespace Js
         Throw::FatalInternalError();
     }
 #endif
+
+#if DBG_DUMP
+	void MissingPropertyTypeHandler::Dump(unsigned indent) const
+    {
+        Output::Print(_u("%*sMissingPropertyTypeHandler (0x%p): Dump unimplemented\n"), indent, _u(""), this);
+    }
+#endif
 }

--- a/lib/Runtime/Types/MissingPropertyTypeHandler.cpp
+++ b/lib/Runtime/Types/MissingPropertyTypeHandler.cpp
@@ -226,7 +226,7 @@ namespace Js
 #endif
 
 #if DBG_DUMP
-	void MissingPropertyTypeHandler::Dump(unsigned indent) const
+    void MissingPropertyTypeHandler::Dump(unsigned indent) const
     {
         Output::Print(_u("%*sMissingPropertyTypeHandler (0x%p): Dump unimplemented\n"), indent, _u(""), this);
     }

--- a/lib/Runtime/Types/MissingPropertyTypeHandler.h
+++ b/lib/Runtime/Types/MissingPropertyTypeHandler.h
@@ -93,5 +93,9 @@ namespace Js
             return 0;
         }
 #endif
+#if DBG_DUMP
+    public:
+        void Dump(unsigned indent = 0) const override;
+#endif
     };
 }

--- a/lib/Runtime/Types/NullTypeHandler.cpp
+++ b/lib/Runtime/Types/NullTypeHandler.cpp
@@ -344,7 +344,7 @@ namespace Js
     NullTypeHandler<IsPrototypeTemplate> * NullTypeHandler<IsPrototypeTemplate>::GetDefaultInstance() { return &defaultInstance; }
 
 #if DBG_DUMP
-	template<bool IsPrototypeTemplate>
+    template<bool IsPrototypeTemplate>
     void NullTypeHandler<IsPrototypeTemplate>::Dump(unsigned indent) const
     {
         Output::Print(_u("%*sNullTypeHandler<%d> (0x%p): Dump unimplemented\n"), indent, _u(""), static_cast<int>(IsPrototypeTemplate), this);

--- a/lib/Runtime/Types/NullTypeHandler.cpp
+++ b/lib/Runtime/Types/NullTypeHandler.cpp
@@ -343,6 +343,14 @@ namespace Js
     template<bool IsPrototypeTemplate>
     NullTypeHandler<IsPrototypeTemplate> * NullTypeHandler<IsPrototypeTemplate>::GetDefaultInstance() { return &defaultInstance; }
 
+#if DBG_DUMP
+	template<bool IsPrototypeTemplate>
+    void NullTypeHandler<IsPrototypeTemplate>::Dump(unsigned indent) const
+    {
+        Output::Print(_u("%*sNullTypeHandler<%d> (0x%p): Dump unimplemented\n"), indent, _u(""), static_cast<int>(IsPrototypeTemplate), this);
+    }
+#endif
+
     template class NullTypeHandler<false>;
     template class NullTypeHandler<true>;
 }

--- a/lib/Runtime/Types/NullTypeHandler.h
+++ b/lib/Runtime/Types/NullTypeHandler.h
@@ -108,5 +108,9 @@ namespace Js
             return 0;
         }
 #endif
+#if DBG_DUMP
+    public:
+        void Dump(unsigned indent = 0) const override;
+#endif
     };
 }

--- a/lib/Runtime/Types/PathTypeHandler.cpp
+++ b/lib/Runtime/Types/PathTypeHandler.cpp
@@ -2679,8 +2679,10 @@ namespace Js
         propertySuccessors->Item(propertyRecord->GetPropertyId(), typeWeakRef);
     }
 
+#if DBG_DUMP
 	void PathTypeHandler::Dump(unsigned indent) const
     {
         Output::Print(_u("%*sPathTypeHandler (0x%p): Dump unimplemented\n"), indent, _u(""), this);
     }
+#endif
 }

--- a/lib/Runtime/Types/PathTypeHandler.cpp
+++ b/lib/Runtime/Types/PathTypeHandler.cpp
@@ -2481,6 +2481,13 @@ namespace Js
 #endif
     }
 
+#if DBG_DUMP
+	void SimplePathTypeHandler::Dump(unsigned indent) const
+    {
+        Output::Print(_u("%*sSimplePathTypeHandler (0x%p): Dump unimplemented\n"), indent, _u(""), this);
+    }
+#endif
+
     PathTypeHandler * PathTypeHandler::New(ScriptContext * scriptContext, TypePath* typePath, uint16 pathLength, uint16 inlineSlotCapacity, uint16 offsetOfInlineSlots, bool isLocked, bool isShared, DynamicType* predecessorType)
     {
         return New(scriptContext, typePath, pathLength, max(pathLength, inlineSlotCapacity), inlineSlotCapacity, offsetOfInlineSlots, isLocked, isShared, predecessorType);
@@ -2670,5 +2677,10 @@ namespace Js
             propertySuccessors = RecyclerNew(recycler, PropertySuccessorsMap, recycler, 3);
         }
         propertySuccessors->Item(propertyRecord->GetPropertyId(), typeWeakRef);
+    }
+
+	void PathTypeHandler::Dump(unsigned indent) const
+    {
+        Output::Print(_u("%*sPathTypeHandler (0x%p): Dump unimplemented\n"), indent, _u(""), this);
     }
 }

--- a/lib/Runtime/Types/PathTypeHandler.cpp
+++ b/lib/Runtime/Types/PathTypeHandler.cpp
@@ -2482,7 +2482,7 @@ namespace Js
     }
 
 #if DBG_DUMP
-	void SimplePathTypeHandler::Dump(unsigned indent) const
+    void SimplePathTypeHandler::Dump(unsigned indent) const
     {
         Output::Print(_u("%*sSimplePathTypeHandler (0x%p): Dump unimplemented\n"), indent, _u(""), this);
     }
@@ -2680,7 +2680,7 @@ namespace Js
     }
 
 #if DBG_DUMP
-	void PathTypeHandler::Dump(unsigned indent) const
+    void PathTypeHandler::Dump(unsigned indent) const
     {
         Output::Print(_u("%*sPathTypeHandler (0x%p): Dump unimplemented\n"), indent, _u(""), this);
     }

--- a/lib/Runtime/Types/PathTypeHandler.h
+++ b/lib/Runtime/Types/PathTypeHandler.h
@@ -252,6 +252,10 @@ namespace Js
         static SimplePathTypeHandler * New(ScriptContext * scriptContext, TypePath* typePath, uint16 pathLength, uint16 inlineSlotCapacity, uint16 offsetOfInlineSlots, bool isLocked = false, bool isShared = false, DynamicType* predecessorType = nullptr);
         static SimplePathTypeHandler * New(ScriptContext * scriptContext, TypePath* typePath, uint16 pathLength, const PropertyIndex slotCapacity, uint16 inlineSlotCapacity, uint16 offsetOfInlineSlots, bool isLocked = false, bool isShared = false, DynamicType* predecessorType = nullptr);
         static SimplePathTypeHandler * New(ScriptContext * scriptContext, SimplePathTypeHandler * typeHandler, bool isLocked, bool isShared);
+#if DBG_DUMP
+    public:
+        void Dump(unsigned indent = 0) const override;
+#endif
     };
 
     class PathTypeHandler sealed : public PathTypeHandlerBase
@@ -284,5 +288,9 @@ namespace Js
         static PathTypeHandler * New(ScriptContext * scriptContext, TypePath* typePath, uint16 pathLength, uint16 inlineSlotCapacity, uint16 offsetOfInlineSlots, bool isLocked = false, bool isShared = false, DynamicType* predecessorType = nullptr);
         static PathTypeHandler * New(ScriptContext * scriptContext, TypePath* typePath, uint16 pathLength, const PropertyIndex slotCapacity, uint16 inlineSlotCapacity, uint16 offsetOfInlineSlots, bool isLocked = false, bool isShared = false, DynamicType* predecessorType = nullptr);
         static PathTypeHandler * New(ScriptContext * scriptContext, PathTypeHandler * typeHandler, bool isLocked, bool isShared);
+#if DBG_DUMP
+    public:
+        void Dump(unsigned indent = 0) const override;
+#endif
     };
 }

--- a/lib/Runtime/Types/SimpleDictionaryTypeHandler.cpp
+++ b/lib/Runtime/Types/SimpleDictionaryTypeHandler.cpp
@@ -3434,7 +3434,7 @@ namespace Js
 #endif
 
 #if DBG_DUMP
-	template<typename TPropertyIndex, typename TMapKey, bool IsNotExtensibleSupported>
+    template<typename TPropertyIndex, typename TMapKey, bool IsNotExtensibleSupported>
     void SimpleDictionaryTypeHandlerBase<TPropertyIndex, TMapKey, IsNotExtensibleSupported>::Dump(unsigned indent) const
     {
         Output::Print(_u("%*sSimpleDictionaryTypeHandlerBase (0x%p): Dump unimplemented"), indent, _u(""), this);

--- a/lib/Runtime/Types/SimpleDictionaryTypeHandler.cpp
+++ b/lib/Runtime/Types/SimpleDictionaryTypeHandler.cpp
@@ -3433,6 +3433,14 @@ namespace Js
     }
 #endif
 
+#if DBG_DUMP
+	template<typename TPropertyIndex, typename TMapKey, bool IsNotExtensibleSupported>
+    void SimpleDictionaryTypeHandlerBase<TPropertyIndex, TMapKey, IsNotExtensibleSupported>::Dump(unsigned indent) const
+    {
+        Output::Print(_u("%*sSimpleDictionaryTypeHandlerBase (0x%p): Dump unimplemented"), indent, _u(""), this);
+    }
+#endif
+
     template <>
     BigSimpleDictionaryTypeHandler* SimpleDictionaryTypeHandlerBase<BigPropertyIndex, const PropertyRecord*, false>::ConvertToBigSimpleDictionaryTypeHandler(DynamicObject* instance)
     {

--- a/lib/Runtime/Types/SimpleDictionaryTypeHandler.h
+++ b/lib/Runtime/Types/SimpleDictionaryTypeHandler.h
@@ -314,6 +314,11 @@ namespace Js
 
         virtual Js::BigPropertyIndex GetPropertyIndex_EnumerateTTD(const Js::PropertyRecord* pRecord) override;
 #endif
+
+#if DBG_DUMP
+    public:
+        void Dump(unsigned indent = 0) const override;
+#endif
     };
 
 }

--- a/lib/Runtime/Types/SimpleTypeHandler.cpp
+++ b/lib/Runtime/Types/SimpleTypeHandler.cpp
@@ -1138,6 +1138,14 @@ namespace Js
 
 #endif
 
+#if DBG_DUMP
+	template<size_t size>
+    void SimpleTypeHandler<size>::Dump(unsigned indent) const
+    {
+        Output::Print(_u("%*sSimpleTypeHandler<%u> (0x%p): Dump unimplemented\n"), indent, _u(""), size, this);
+    }
+#endif
+
     template class SimpleTypeHandler<1>;
     template class SimpleTypeHandler<2>;
     template class SimpleTypeHandler<6>;

--- a/lib/Runtime/Types/SimpleTypeHandler.cpp
+++ b/lib/Runtime/Types/SimpleTypeHandler.cpp
@@ -1139,7 +1139,7 @@ namespace Js
 #endif
 
 #if DBG_DUMP
-	template<size_t size>
+    template<size_t size>
     void SimpleTypeHandler<size>::Dump(unsigned indent) const
     {
         Output::Print(_u("%*sSimpleTypeHandler<%u> (0x%p): Dump unimplemented\n"), indent, _u(""), size, this);

--- a/lib/Runtime/Types/SimpleTypeHandler.h
+++ b/lib/Runtime/Types/SimpleTypeHandler.h
@@ -104,6 +104,11 @@ namespace Js
 
         virtual Js::BigPropertyIndex GetPropertyIndex_EnumerateTTD(const Js::PropertyRecord* pRecord) override;
 #endif
+
+#if DBG_DUMP
+    public:
+        void Dump(unsigned indent = 0) const override;
+#endif
     };
 
     typedef SimpleTypeHandler<1> SimpleTypeHandlerSize1;

--- a/lib/Runtime/Types/TypeHandler.cpp
+++ b/lib/Runtime/Types/TypeHandler.cpp
@@ -823,4 +823,36 @@ namespace Js
         return false;
     }
 #endif
+
+#if DBG_DUMP
+    void DynamicTypeHandler::Dump(unsigned indent) const {
+        const auto padding(_u(""));
+        const unsigned fieldIndent(indent + 2);
+
+        Output::Print(_u("%*sDynamicTypeHandler: 0x%p\n"), indent, padding, this);
+        Output::Print(_u("%*spropertyTypes: 0x%02x "), fieldIndent, padding, this->propertyTypes);
+        if (this->propertyTypes & PropertyTypesReserved) Output::Print(_u("PropertyTypesReserved "));
+        if (this->propertyTypes & PropertyTypesWritableDataOnly) Output::Print(_u("PropertyTypesWritableDataOnly "));
+        if (this->propertyTypes & PropertyTypesWritableDataOnlyDetection) Output::Print(_u("PropertyTypesWritableDataOnlyDetection "));
+        if (this->propertyTypes & PropertyTypesInlineSlotCapacityLocked) Output::Print(_u("PropertyTypesInlineSlotCapacityLocked "));
+        Output::Print(_u("\n"));
+
+        Output::Print(_u("%*sflags: 0x%02x "), fieldIndent, padding, this->flags);
+        if (this->flags & IsExtensibleFlag) Output::Print(_u("IsExtensibleFlag "));
+        if (this->flags & HasKnownSlot0Flag) Output::Print(_u("HasKnownSlot0Flag "));
+        if (this->flags & IsLockedFlag) Output::Print(_u("IsLockedFlag "));
+        if (this->flags & MayBecomeSharedFlag) Output::Print(_u("MayBecomeSharedFlag "));
+        if (this->flags & IsSharedFlag) Output::Print(_u("IsSharedFlag "));
+        if (this->flags & IsPrototypeFlag) Output::Print(_u("IsPrototypeFlag "));
+        if (this->flags & IsSealedOnceFlag) Output::Print(_u("IsSealedOnceFlag "));
+        if (this->flags & IsFrozenOnceFlag) Output::Print(_u("IsFrozenOnceFlag "));
+        Output::Print(_u("\n"));
+
+        Output::Print(_u("%*soffsetOfInlineSlots: %u\n"), fieldIndent, padding, this->offsetOfInlineSlots);
+        Output::Print(_u("%*sslotCapacity: %d\n"), fieldIndent, padding, this->slotCapacity);
+        Output::Print(_u("%*sunusedBytes: %u\n"), fieldIndent, padding, this->unusedBytes);
+        Output::Print(_u("%*sinlineSlotCapacty: %u\n"), fieldIndent, padding, this->inlineSlotCapacity);
+        Output::Print(_u("%*sisNotPathTypeHandlerOrHasUserDefinedCtor: %d\n"), fieldIndent, padding, static_cast<int>(this->isNotPathTypeHandlerOrHasUserDefinedCtor));
+    }
+#endif
 }

--- a/lib/Runtime/Types/TypeHandler.h
+++ b/lib/Runtime/Types/TypeHandler.h
@@ -655,7 +655,7 @@ namespace Js
 
 #if DBG_DUMP
     public:
-         virtual void Dump(unsigned indent = 0) const = 0;
+         virtual void Dump(unsigned indent = 0) const;
 #endif
     };
 }

--- a/lib/Runtime/Types/TypeHandler.h
+++ b/lib/Runtime/Types/TypeHandler.h
@@ -652,5 +652,10 @@ namespace Js
          //Return true if this type handler is reseattable/false if we don't want to try
          virtual bool IsResetableForTTD(uint32 snapMaxIndex) const;
 #endif
+
+#if DBG_DUMP
+    public:
+         virtual void Dump(unsigned indent = 0) const = 0;
+#endif
     };
 }


### PR DESCRIPTION
As part of my current investigation, I need to be able to dump a human-readable represntation of DictionaryTypeHandlerBase objects.  Add a virtual Dump method to DynamicTypeHandle to allow this, and provide stub implementations for other subtypes of DynamicTypeHandler.  (As the need arises, I may provide full implementations for these stubs; others are welcome to do so if they get to it before I do.)