### PR TITLE
fix bug with inlining int64 args on x86

### DIFF
--- a/lib/Backend/Func.h
+++ b/lib/Backend/Func.h
@@ -872,6 +872,19 @@ public:
             top->DoGlobOpt() && !PHASE_OFF(Js::LoopFastPathPhase, top);
     }
 
+    static Js::OpCode GetLoadOpForType(IRType type)
+    {
+        if (type == TyVar || IRType_IsFloat(type))
+        {
+            return Js::OpCode::Ld_A;
+        }
+        else
+        {
+            Assert(IRType_IsNativeInt(type));
+            return Js::OpCode::Ld_I4;
+        }
+    }
+
     static Js::BuiltinFunction GetBuiltInIndex(IR::Opnd* opnd)
     {
         Assert(opnd);

--- a/lib/Backend/Inline.cpp
+++ b/lib/Backend/Inline.cpp
@@ -2169,7 +2169,7 @@ Inline::InlineBuiltInFunction(IR::Instr *callInstr, const FunctionJITTimeInfo * 
 
         if(tmpDst)
         {
-            IR::Instr * ldInstr = IR::Instr::New(Js::OpCode::Ld_A, callInstrDst, tmpDst, callInstr->m_func);
+            IR::Instr * ldInstr = IR::Instr::New(Func::GetLoadOpForType(callInstrDst->GetType()), callInstrDst, tmpDst, callInstr->m_func);
             inlineBuiltInEndInstr->InsertBefore(ldInstr);
         }
 
@@ -3021,7 +3021,7 @@ Inline::InlineCall(IR::Instr *callInstr, const FunctionJITTimeInfo *funcInfo, co
         // Change ArgOut to use temp as src1.
         StackSym * stackSym = StackSym::New(orgSrc1->GetStackSym()->GetType(), argImplicitInstr->m_func);
         IR::Opnd* tempDst = IR::RegOpnd::New(stackSym, orgSrc1->GetType(), argImplicitInstr->m_func);
-        IR::Instr *assignInstr = IR::Instr::New(Js::OpCode::Ld_A, tempDst, orgSrc1, argImplicitInstr->m_func);
+        IR::Instr *assignInstr = IR::Instr::New(Func::GetLoadOpForType(orgSrc1->GetType()), tempDst, orgSrc1, argImplicitInstr->m_func);
         assignInstr->SetByteCodeOffset(orgArgout);
         tempDst->SetIsJITOptimizedReg(true);
         orgArgout->InsertBefore(assignInstr);
@@ -4872,7 +4872,7 @@ Inline::MapFormals(Func *inlinee,
                 if (instr->m_func->GetJITFunctionBody()->IsAsmJsMode())
                 {
                     instr->SetSrc1(argOut->GetSrc1());
-                    instr->m_opcode = Js::OpCode::Ld_A;
+                    instr->m_opcode = Func::GetLoadOpForType(argOut->GetSrc1()->GetType());
                 }
                 else
                 {
@@ -5198,7 +5198,7 @@ Inline::MapFormals(Func *inlinee,
             else
             {
                 Assert(instr->GetSrc1() != nullptr);
-                instr->m_opcode = Js::OpCode::Ld_A;
+                instr->m_opcode = Func::GetLoadOpForType(instr->GetSrc1()->GetType());
                 instr->SetDst(retOpnd);
             }
             break;

--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -3747,6 +3747,7 @@ namespace Js
             JavascriptFunction::CallAsmJsFunction<int>(function, entrypointInfo->jsMethod, m_outParams, alignedArgsSize, reg);
             break;
         case AsmJsRetType::Signed:
+            
             m_localIntSlots[returnReg] = JavascriptFunction::CallAsmJsFunction<int>(function, entrypointInfo->jsMethod, m_outParams, alignedArgsSize, reg);
             break;
         case AsmJsRetType::Int64:


### PR DESCRIPTION
In some cases we would change args/ret to be a Ld_A in the inliner. This works in most cases, but wasm wants them to be Ld_I4 for int types and in particular lowering Ld_A of int64 doesn't work.

I've changed to pick a the appropriate opcode depending on type.

OS: 13867303