### PR TITLE
Update build system for more generic include paths

### DIFF
--- a/Build/Chakra.Build.Paths.props
+++ b/Build/Chakra.Build.Paths.props
@@ -11,9 +11,9 @@
   </PropertyGroup>
   <PropertyGroup Label="ICU">
     <!-- IcuLibDir can be set in environment or with "/p:IcuLibDir=..." -->
-    <IcuLibDir Condition="'$(IcuLibDir)'=='' AND '$(Configuration)'=='Debug'">$(ChakraCoreRootDirectory)\deps\static\icu-small\debug</IcuLibDir>
-    <IcuLibDir Condition="'$(IcuLibDir)'=='' AND ('$(Configuration)'=='Test' or '$(Configuration)'=='Release')">$(ChakraCoreRootDirectory)\deps\static\icu-small\release</IcuLibDir>
+    <!-- <IcuLibDir Condition="'$(IcuLibDir)'=='' AND '$(Configuration)'=='Debug'">$(ChakraCoreRootDirectory)\deps\static\icu-small\debug</IcuLibDir> -->
+    <!-- <IcuLibDir Condition="'$(IcuLibDir)'=='' AND ('$(Configuration)'=='Test' or '$(Configuration)'=='Release')">$(ChakraCoreRootDirectory)\deps\static\icu-small\release</IcuLibDir> -->
     <!-- IcuIncludeDir can be set in environment or with "/p:IcuIncludeDir=..." -->
-    <IcuIncludeDir Condition="'$(IcuIncludeDir)'==''">$(ChakraCoreRootDirectory)\deps\icu-small\source</IcuIncludeDir>
+    <!-- <IcuIncludeDir Condition="'$(IcuIncludeDir)'==''">$(ChakraCoreRootDirectory)\deps\icu-small\source</IcuIncludeDir> -->
   </PropertyGroup>
 </Project>

--- a/Build/Chakra.Build.Paths.props
+++ b/Build/Chakra.Build.Paths.props
@@ -11,9 +11,9 @@
   </PropertyGroup>
   <PropertyGroup Label="ICU">
     <!-- IcuLibDir can be set in environment or with "/p:IcuLibDir=..." -->
-    <!-- <IcuLibDir Condition="'$(IcuLibDir)'=='' AND '$(Configuration)'=='Debug'">$(ChakraCoreRootDirectory)\deps\static\icu-small\debug</IcuLibDir> -->
-    <!-- <IcuLibDir Condition="'$(IcuLibDir)'=='' AND ('$(Configuration)'=='Test' or '$(Configuration)'=='Release')">$(ChakraCoreRootDirectory)\deps\static\icu-small\release</IcuLibDir> -->
+    <IcuLibDir Condition="'$(IcuLibDir)'=='' AND '$(Configuration)'=='Debug'">$(ChakraCoreRootDirectory)\deps\static\icu-small\debug</IcuLibDir>
+    <IcuLibDir Condition="'$(IcuLibDir)'=='' AND ('$(Configuration)'=='Test' or '$(Configuration)'=='Release')">$(ChakraCoreRootDirectory)\deps\static\icu-small\release</IcuLibDir>
     <!-- IcuIncludeDir can be set in environment or with "/p:IcuIncludeDir=..." -->
-    <!-- <IcuIncludeDir Condition="'$(IcuIncludeDir)'==''">$(ChakraCoreRootDirectory)\deps\icu-small\source</IcuIncludeDir> -->
+    <IcuIncludeDir Condition="'$(IcuIncludeDir)'==''">$(ChakraCoreRootDirectory)\deps\icu-small\source</IcuIncludeDir>
   </PropertyGroup>
 </Project>

--- a/Build/Chakra.Build.props
+++ b/Build/Chakra.Build.props
@@ -50,7 +50,12 @@
       <RuntimeLibrary Condition="'$(Configuration)'=='Debug' AND '$(RuntimeLib)'=='static_library'">MultiThreadedDebug</RuntimeLibrary>
       <AdditionalIncludeDirectories>
         $(ChakraCoreRootDirectory)\lib\common\placeholder;
-        $(IntDir)..\CoreManifests\
+        $(IntDir)..\CoreManifests;
+        %(AdditionalIncludeDirectories)
+      </AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories Condition="'$(IcuIncludeDir)'!=''">
+        $(IcuIncludeDir)\common;
+        $(IcuIncludeDir)\i18n;
         %(AdditionalIncludeDirectories)
       </AdditionalIncludeDirectories>
     </ClCompile>

--- a/Build/Chakra.Build.props
+++ b/Build/Chakra.Build.props
@@ -53,7 +53,7 @@
         $(IntDir)..\CoreManifests;
         %(AdditionalIncludeDirectories)
       </AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories Condition="'$(IcuIncludeDir)'!=''">
+      <AdditionalIncludeDirectories Condition="'$(IntlICU)'=='true'">
         $(IcuIncludeDir)\common;
         $(IcuIncludeDir)\i18n;
         %(AdditionalIncludeDirectories)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -456,7 +456,8 @@ include_directories(
     pal
     pal/inc
     pal/inc/rt
-    ${ICU_INCLUDE_PATH}
+    ${ICU_INCLUDE_PATH}/common
+    ${ICU_INCLUDE_PATH}/i18n
     )
 
 if(ICU_INCLUDE_PATH)

--- a/bin/ChakraCore/ChakraCore.vcxproj
+++ b/bin/ChakraCore/ChakraCore.vcxproj
@@ -31,7 +31,6 @@
         $(ChakraCoreRootDirectory)Lib\Jsrt;
         $(IntDir);
         $(ChakraJITIDLIntDir);
-        $(IcuIncludeDir)\common;
         $(MSBuildThisFileDirectory)..\..\lib\JITClient;
         %(AdditionalIncludeDirectories);
       </AdditionalIncludeDirectories>

--- a/lib/Backend/Chakra.Backend.vcxproj
+++ b/lib/Backend/Chakra.Backend.vcxproj
@@ -36,7 +36,6 @@
         $(MSBuildThisFileDirectory)..\Parser;
         $(MSBuildThisFileDirectory)..\WasmReader;
         $(ChakraJITIDLIntDir);
-        $(IcuIncludeDir)\common;
         %(AdditionalIncludeDirectories)
       </AdditionalIncludeDirectories>
       <PrecompiledHeader>Use</PrecompiledHeader>

--- a/lib/JITServer/Chakra.JITServer.vcxproj
+++ b/lib/JITServer/Chakra.JITServer.vcxproj
@@ -48,7 +48,6 @@
         $(MSBuildThisFileDirectory)..\Backend\$(PlatformPathNameAlt);
         $(MSBuildThisFileDirectory)..\Backend;
         $(ChakraJITIDLIntDir);
-        $(IcuIncludeDir)\common;
         %(AdditionalIncludeDirectories)
       </AdditionalIncludeDirectories>
       <PrecompiledHeader>Use</PrecompiledHeader>

--- a/lib/Jsrt/Chakra.Jsrt.vcxproj
+++ b/lib/Jsrt/Chakra.Jsrt.vcxproj
@@ -24,7 +24,6 @@
         $(MSBuildThisFileDirectory);
         $(MSBuildThisFileDirectory)..\Runtime;
         $(ChakraJITIDLIntDir);
-        $(IcuIncludeDir)\common;
         $(MSBuildThisFileDirectory)..\JITClient;
         $(MSBuildThisFileDirectory)..\Runtime\ByteCode;
         $(MSBuildThisFileDirectory)..\Common;

--- a/lib/Jsrt/Core/Chakra.Jsrt.Core.vcxproj
+++ b/lib/Jsrt/Core/Chakra.Jsrt.Core.vcxproj
@@ -25,7 +25,6 @@
         $(MSBuildThisFileDirectory)..;
         $(MSBuildThisFileDirectory)..\..\Runtime;
         $(ChakraJITIDLIntDir);
-        $(IcuIncludeDir)\common;
         $(MSBuildThisFileDirectory)..\..\JITClient;
         $(MSBuildThisFileDirectory)..\..\Runtime\ByteCode;
         $(MSBuildThisFileDirectory)..\..\Common;

--- a/lib/Parser/Chakra.Parser.vcxproj
+++ b/lib/Parser/Chakra.Parser.vcxproj
@@ -28,7 +28,6 @@
         $(MSBuildThisFileDirectory)..\Runtime;
         $(MSBuildThisFileDirectory)..\Runtime\ByteCode;
         $(ChakraJITIDLIntDir);
-        $(IcuIncludeDir)\common;
         $(ChakraManifestsIncludeDirectory);
         %(AdditionalIncludeDirectories)
       </AdditionalIncludeDirectories>

--- a/lib/Runtime/Base/Chakra.Runtime.Base.vcxproj
+++ b/lib/Runtime/Base/Chakra.Runtime.Base.vcxproj
@@ -28,7 +28,6 @@
         $(MSBuildThisFileDirectory)..\..\Runtime\ByteCode;
         $(MSBuildThisFileDirectory)..\..\WasmReader;
         $(ChakraJITIDLIntDir);
-        $(IcuIncludeDir)\common;
         $(MSBuildThisFileDirectory)..\..\JITClient;
         %(AdditionalIncludeDirectories)
       </AdditionalIncludeDirectories>

--- a/lib/Runtime/ByteCode/ByteCodeCacheReleaseFileVersion.h
+++ b/lib/Runtime/ByteCode/ByteCodeCacheReleaseFileVersion.h
@@ -4,6 +4,6 @@
 //-------------------------------------------------------------------------------------------------------
 // NOTE: If there is a merge conflict the correct fix is to make a new GUID.
 
-// {5C44723E-F7DF-4397-A24B-AC1A90D221F9}
+// {131ae129-1863-4b97-b9b2-4802d60acefb}
 const GUID byteCodeCacheReleaseFileVersion =
-{ 0x5C44723E, 0xF7DF, 0x4397, { 0xA2, 0x4B, 0xAC, 0x1A, 0x90, 0xD2, 0x21, 0xF9 } };
+{ 0x131ae129, 0x1863, 0x4b97, { 0xb9, 0xb2, 0x48, 0x02, 0xd6, 0x0a, 0xce, 0xfb } };

--- a/lib/Runtime/ByteCode/Chakra.Runtime.ByteCode.vcxproj
+++ b/lib/Runtime/ByteCode/Chakra.Runtime.ByteCode.vcxproj
@@ -29,7 +29,6 @@
         $(MSBuildThisFileDirectory)..\..\Backend;
         $(MSBuildThisFileDirectory)..\..\JITClient;
         $(ChakraJITIDLIntDir);
-        $(IcuIncludeDir)\common;
         %(AdditionalIncludeDirectories)
       </AdditionalIncludeDirectories>
       <PrecompiledHeader>Use</PrecompiledHeader>

--- a/lib/Runtime/Debug/Chakra.Runtime.Debug.vcxproj
+++ b/lib/Runtime/Debug/Chakra.Runtime.Debug.vcxproj
@@ -34,7 +34,6 @@
         $(MSBuildThisFileDirectory)..\..\Runtime\ByteCode;
         $(MSBuildThisFileDirectory)..\..\JITClient;
         $(ChakraJITIDLIntDir);
-        $(IcuIncludeDir)\common;
         %(AdditionalIncludeDirectories)
       </AdditionalIncludeDirectories>
       <PrecompiledHeader>Use</PrecompiledHeader>

--- a/lib/Runtime/Language/Chakra.Runtime.Language.vcxproj
+++ b/lib/Runtime/Language/Chakra.Runtime.Language.vcxproj
@@ -35,7 +35,6 @@
         $(MSBuildThisFileDirectory)..\..\Runtime\Math;
         $(MSBuildThisFileDirectory)..\..\JITClient;
         $(ChakraJITIDLIntDir);
-        $(IcuIncludeDir)\common;
         %(AdditionalIncludeDirectories)
       </AdditionalIncludeDirectories>
       <PrecompiledHeader>Use</PrecompiledHeader>

--- a/lib/Runtime/Library/Chakra.Runtime.Library.vcxproj
+++ b/lib/Runtime/Library/Chakra.Runtime.Library.vcxproj
@@ -34,7 +34,6 @@
         $(MSBuildThisFileDirectory)..\..\Runtime\ByteCode;
         $(MSBuildThisFileDirectory)..\..\JITClient;
         $(ChakraJITIDLIntDir);
-        $(IcuIncludeDir)\common; <!-- // TODO (doilij): At end of IntlICU development, remove this if it is not needed here. -->
         $(MSBuildThisFileDirectory)..\Math;
         $(ChakraManifestsIncludeDirectory);
         $(ManifestsInboxIncludeDirectory);

--- a/lib/Runtime/Math/Chakra.Runtime.Math.vcxproj
+++ b/lib/Runtime/Math/Chakra.Runtime.Math.vcxproj
@@ -29,7 +29,6 @@
         $(MSBuildThisFileDirectory)..\..\Backend;
         $(MSBuildThisFileDirectory)..\..\JITClient;
         $(ChakraJITIDLIntDir);
-        $(IcuIncludeDir)\common;
         %(AdditionalIncludeDirectories)
       </AdditionalIncludeDirectories>
       <PrecompiledHeader>Use</PrecompiledHeader>

--- a/lib/Runtime/PlatformAgnostic/Chakra.Runtime.PlatformAgnostic.vcxproj
+++ b/lib/Runtime/PlatformAgnostic/Chakra.Runtime.PlatformAgnostic.vcxproj
@@ -28,7 +28,6 @@
         $(MSBuildThisFileDirectory)..\..\Runtime\ByteCode;
         $(MSBuildThisFileDirectory)..\..\Backend;
         $(ChakraJITIDLIntDir);
-        $(IcuIncludeDir)\common;
         $(MSBuildThisFileDirectory)..\..\JITClient;
         $(MSBuildThisFileDirectory)..;$(MSBuildThisFileDirectory);
         %(AdditionalIncludeDirectories)

--- a/lib/Runtime/Types/Chakra.Runtime.Types.vcxproj
+++ b/lib/Runtime/Types/Chakra.Runtime.Types.vcxproj
@@ -29,7 +29,6 @@
         $(MSBuildThisFileDirectory)..\..\Runtime\ByteCode;
         $(MSBuildThisFileDirectory)..\..\JITClient;
         $(ChakraJITIDLIntDir);
-        $(IcuIncludeDir)\common;
         %(AdditionalIncludeDirectories)
       </AdditionalIncludeDirectories>
       <PrecompiledHeader>Use</PrecompiledHeader>

--- a/lib/WasmReader/Chakra.WasmReader.vcxproj
+++ b/lib/WasmReader/Chakra.WasmReader.vcxproj
@@ -29,7 +29,6 @@
         $(MSBuildThisFileDirectory)..\Backend;
         $(MSBuildThisFileDirectory)..\JITClient;
         $(ChakraJITIDLIntDir);
-        $(IcuIncludeDir)\common;
         %(AdditionalIncludeDirectories)
       </AdditionalIncludeDirectories>
       <PrecompiledHeader>Use</PrecompiledHeader>


### PR DESCRIPTION
This will eventually be useful for standardizing how embedded ICU works across windows/xplat and ChakraCore/Node-ChakraCore. This also updates the bytecode version as a precaution.

Fixes #3773 