### PR TITLE
remove invalid assert about dead slots in JIT loop body

### DIFF
--- a/lib/Backend/BackwardPass.cpp
+++ b/lib/Backend/BackwardPass.cpp
@@ -6530,8 +6530,6 @@ BackwardPass::ProcessDef(IR::Opnd * opnd)
             if (propertySym->m_fieldKind == PropertyKindLocalSlots || propertySym->m_fieldKind == PropertyKindSlots)
             {
                 BOOLEAN isPropertySymUsed = !block->slotDeadStoreCandidates->TestAndSet(propertySym->m_id);
-                // we should not do any dead slots in asmjs loop body
-                Assert(!(this->func->GetJITFunctionBody()->IsAsmJsMode() && this->func->IsLoopBody() && !isPropertySymUsed));
                 Assert(isPropertySymUsed || !block->upwardExposedUses->Test(propertySym->m_id));
 
                 isUsed = isPropertySymUsed || block->upwardExposedUses->Test(propertySym->m_stackSym->m_id);

--- a/test/wasm/loopstslot.js
+++ b/test/wasm/loopstslot.js
@@ -1,0 +1,23 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft Corporation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+const buf = WebAssembly.wabt.convertWast2Wasm(`
+(module
+    (global $x (mut i32) (i32.const -12))
+
+  (func (export "stslot") (param i32)
+    (loop
+      (br_if 1 (i32.eqz (get_local 0)))
+    (set_global $x (get_local 0))
+    (set_global $x (get_local 0))
+    (br 0)
+    )
+  )
+)`);
+const view = new Uint8Array(buf);
+var mod = new WebAssembly.Module(buf);
+var {stslot} = new WebAssembly.Instance(mod).exports;
+stslot(0);
+print("Pass");

--- a/test/wasm/rlexe.xml
+++ b/test/wasm/rlexe.xml
@@ -340,4 +340,11 @@
     <tags>exclude_xplat,exclude_jshost,exclude_win7,exclude_chk,exclude_dynapogo,exclude_x86,Slow</tags>
   </default>
 </test>
+<test>
+  <default>
+    <files>loopstslot.js</files>
+    <compile-flags>-forcejitloopbody</compile-flags>
+    <tags>exclude_jshost,exclude_win7,exclude_xplat</tags>
+  </default>
+</test>
 </regress-exe>


### PR DESCRIPTION
It's totally reasonable to have dead slots in JIT loop body for asm.js/wasm.

IIRC we only used StSlot for saving locals in JIT loop body, but now we use it for globals as well

OS: 13874418