### PR TITLE
don't try to record arguments on inlinee frame for wasm/asm.js

### DIFF
--- a/lib/Backend/GlobOptBailOut.cpp
+++ b/lib/Backend/GlobOptBailOut.cpp
@@ -730,7 +730,7 @@ void GlobOpt::RecordInlineeFrameInfo(IR::Instr* inlineeEnd)
                 frameInfo->function = InlineFrameInfoValue(functionObject->m_sym);
             }
         }
-        else
+        else if(!GetIsAsmJSFunc()) // don't care about saving arg syms for wasm/asm.js
         {
             Js::ArgSlot argSlot = argInstr->GetDst()->AsSymOpnd()->m_sym->AsStackSym()->GetArgSlotNum();
             IR::Opnd* argOpnd = argInstr->GetSrc1();


### PR DESCRIPTION
They are only needed for bailout, so we don't care and there can be issues with trying to get the type spec equiv syms.

OS: 13875170