### PR TITLE
remove unused DECLARE_CONCRETE_STRING_CLASS

### DIFF
--- a/lib/Runtime/Library/BufferStringBuilder.h
+++ b/lib/Runtime/Library/BufferStringBuilder.h
@@ -54,7 +54,6 @@ namespace Js
 
         protected:
             DEFINE_VTABLE_CTOR(WritableString, JavascriptString);
-            DECLARE_CONCRETE_STRING_CLASS;
 
         private:
             WritableString(StaticType * type, charcount_t length, const char16* szValue)

--- a/lib/Runtime/Library/CompoundString.h
+++ b/lib/Runtime/Library/CompoundString.h
@@ -428,7 +428,6 @@ namespace Js
 
     protected:
         DEFINE_VTABLE_CTOR(CompoundString, LiteralString);
-        DECLARE_CONCRETE_STRING_CLASS;
 
     private:
         PREVENT_COPY(CompoundString);

--- a/lib/Runtime/Library/ConcatString.h
+++ b/lib/Runtime/Library/ConcatString.h
@@ -22,7 +22,6 @@ namespace Js
     protected:
         LiteralStringWithPropertyStringPtr(StaticType* stringTypeStatic);
         DEFINE_VTABLE_CTOR(LiteralStringWithPropertyStringPtr, LiteralString);
-        DECLARE_CONCRETE_STRING_CLASS;
 
     public:
         virtual VTableValue DummyVirtualFunctionToHinderLinkerICF()
@@ -80,7 +79,6 @@ namespace Js
     protected:
         ConcatStringN(StaticType* stringTypeStatic, bool doZeroSlotsAndLength = true);
         DEFINE_VTABLE_CTOR(ConcatStringN<N>, ConcatStringBase);
-        DECLARE_CONCRETE_STRING_CLASS;
 
         virtual void CopyVirtual(_Out_writes_(m_charLength) char16 *const buffer, StringCopyInfoStack &nestedStringTreeCopyInfos, const byte recursionDepth) override
         {
@@ -111,7 +109,6 @@ namespace Js
         ConcatString(JavascriptString* a, JavascriptString* b);
     protected:
         DEFINE_VTABLE_CTOR(ConcatString, ConcatStringN<2>);
-        DECLARE_CONCRETE_STRING_CLASS;
     public:
         static ConcatString* New(JavascriptString* a, JavascriptString* b);
         static const int MaxDepth = 1000;
@@ -141,7 +138,6 @@ namespace Js
 
     protected:
         DEFINE_VTABLE_CTOR(ConcatStringBuilder, ConcatStringBase);
-        DECLARE_CONCRETE_STRING_CLASS;
         virtual void CopyVirtual(_Out_writes_(m_charLength) char16 *const buffer, StringCopyInfoStack &nestedStringTreeCopyInfos, const byte recursionDepth) override sealed;
 
     public:
@@ -174,7 +170,6 @@ namespace Js
 
     protected:
         DEFINE_VTABLE_CTOR(ConcatStringWrapping, ConcatStringBase);
-        DECLARE_CONCRETE_STRING_CLASS;
         virtual void CopyVirtual(_Out_writes_(m_charLength) char16 *const buffer, StringCopyInfoStack &nestedStringTreeCopyInfos, const byte recursionDepth) override sealed
         {
             const_cast<ConcatStringWrapping *>(this)->EnsureAllSlots();
@@ -223,7 +218,6 @@ namespace Js
     protected:
         ConcatStringMulti(uint slotCount, JavascriptString * a1, JavascriptString * a2, StaticType* stringTypeStatic);
         DEFINE_VTABLE_CTOR(ConcatStringMulti, ConcatStringBase);
-        DECLARE_CONCRETE_STRING_CLASS;
 
         virtual void CopyVirtual(_Out_writes_(m_charLength) char16 *const buffer, StringCopyInfoStack &nestedStringTreeCopyInfos, const byte recursionDepth) override
         {
@@ -264,5 +258,3 @@ namespace Js
         }
     };
 }
-
-

--- a/lib/Runtime/Library/JSONString.h
+++ b/lib/Runtime/Library/JSONString.h
@@ -42,7 +42,6 @@ namespace Js
         virtual const char16* GetSz() override;
     protected:
         DEFINE_VTABLE_CTOR(JSONString, JavascriptString);
-        DECLARE_CONCRETE_STRING_CLASS;
     private:
         Field(JavascriptString*) m_originalString;
         Field(charcount_t) m_start; /* start of the escaping operation */

--- a/lib/Runtime/Library/JavascriptString.h
+++ b/lib/Runtime/Library/JavascriptString.h
@@ -29,24 +29,6 @@ namespace Js
     bool IsValidCharCount(size_t charCount);
     const charcount_t k_InvalidCharCount = static_cast<charcount_t>(-1);
 
-
-    //
-    // To inspect strings in hybrid debugging, we use vtable lookup to find out concrete string type
-    // then inspect string content accordingly.
-    //
-    // To ensure all known string vtables are listed and exported from chakra.dll and handler class
-    // exists in chakradiag.dll, declare an abstract method in base JavascriptString class. Any concrete
-    // subclass that has runtime string instance must DECLARE_CONCRETE_STRING_CLASS, otherwise
-    // we'll get a compile time error.
-    //
-#if DBG && defined(NTBUILD)
-#define DECLARE_CONCRETE_STRING_CLASS_BASE  virtual void _declareConcreteStringClass() = 0
-#define DECLARE_CONCRETE_STRING_CLASS       virtual void _declareConcreteStringClass() override
-#else
-#define DECLARE_CONCRETE_STRING_CLASS_BASE
-#define DECLARE_CONCRETE_STRING_CLASS
-#endif
-
     class JavascriptString _ABSTRACT : public RecyclableObject
     {
         friend Lowerer;
@@ -173,7 +155,6 @@ namespace Js
         JavascriptString(StaticType * type);
         JavascriptString(StaticType * type, charcount_t charLength, const char16* szValue);
         DEFINE_VTABLE_CTOR_ABSTRACT(JavascriptString, RecyclableObject);
-        DECLARE_CONCRETE_STRING_CLASS_BASE;
 
         void SetLength(charcount_t newLength);
         void SetBuffer(const char16* buffer);

--- a/lib/Runtime/Library/LiteralString.h
+++ b/lib/Runtime/Library/LiteralString.h
@@ -12,7 +12,6 @@ namespace Js
         LiteralString(StaticType* type);
         LiteralString(StaticType* type, const char16* content, charcount_t charLength);
         DEFINE_VTABLE_CTOR(LiteralString, JavascriptString);
-        DECLARE_CONCRETE_STRING_CLASS;
 
     public:
         static LiteralString* New(StaticType* type, const char16* content, charcount_t charLength, Recycler* recycler);
@@ -24,7 +23,6 @@ namespace Js
     protected:
         ArenaLiteralString(StaticType* type, const char16* content, charcount_t charLength);
         DEFINE_VTABLE_CTOR(ArenaLiteralString, JavascriptString);
-        DECLARE_CONCRETE_STRING_CLASS;
 
     public:
         static ArenaLiteralString* New(StaticType* type, const char16* content, charcount_t charLength, Recycler* recycler);

--- a/lib/Runtime/Library/PropertyString.h
+++ b/lib/Runtime/Library/PropertyString.h
@@ -15,7 +15,6 @@ namespace Js
         Field(const Js::PropertyRecord*) propertyRecord;
 
         DEFINE_VTABLE_CTOR(PropertyString, JavascriptString);
-        DECLARE_CONCRETE_STRING_CLASS;
 
         PropertyString(StaticType* type, const Js::PropertyRecord* propertyRecord);
     public:

--- a/lib/Runtime/Library/SingleCharString.h
+++ b/lib/Runtime/Library/SingleCharString.h
@@ -18,7 +18,6 @@ namespace Js
 
     protected:
         DEFINE_VTABLE_CTOR(SingleCharString, JavascriptString);
-        DECLARE_CONCRETE_STRING_CLASS;
 
     private:
         SingleCharString(char16 ch, StaticType * type);

--- a/lib/Runtime/Library/SubString.h
+++ b/lib/Runtime/Library/SubString.h
@@ -14,7 +14,6 @@ namespace Js
 
     protected:
         DEFINE_VTABLE_CTOR(SubString, JavascriptString);
-        DECLARE_CONCRETE_STRING_CLASS;
 
     public:
         static JavascriptString* New(JavascriptString* string, charcount_t start, charcount_t length);


### PR DESCRIPTION
This macro is no longer used.
