### PR TITLE
Fix some minor omissions with DynamicTypeHandler::Dump & related methods

### DIFF
--- a/lib/Runtime/Base/PropertyRecord.cpp
+++ b/lib/Runtime/Base/PropertyRecord.cpp
@@ -147,6 +147,14 @@ namespace Js
         Output::Print(_u("%*sIsBound: %d\n"), fieldIndent, padding, this->isBound);
         Output::Print(_u("%*sIsSymbol: %d\n"), fieldIndent, padding, this->isSymbol);
         Output::Print(_u("%*sbyteCount: %u\n"), fieldIndent, padding, this->byteCount);
+        if (this->isNumeric)
+        {
+            Output::Print(_u("%*sbuffer (numeric): %u\n"), fieldIndent, padding, this->GetNumericValue());
+        }
+        else
+        {
+            Output::Print(_u("%*sbuffer (string): %s\n"), fieldIndent, padding, this->GetBuffer());
+        }
     }
 #endif
 

--- a/lib/Runtime/Types/SimpleDictionaryTypeHandler.cpp
+++ b/lib/Runtime/Types/SimpleDictionaryTypeHandler.cpp
@@ -3437,7 +3437,7 @@ namespace Js
     template<typename TPropertyIndex, typename TMapKey, bool IsNotExtensibleSupported>
     void SimpleDictionaryTypeHandlerBase<TPropertyIndex, TMapKey, IsNotExtensibleSupported>::Dump(unsigned indent) const
     {
-        Output::Print(_u("%*sSimpleDictionaryTypeHandlerBase (0x%p): Dump unimplemented"), indent, _u(""), this);
+        Output::Print(_u("%*sSimpleDictionaryTypeHandlerBase (0x%p): Dump unimplemented\n"), indent, _u(""), this);
     }
 #endif
 


### PR DESCRIPTION
Couple of minor fixes to the DynamicTypeHandler Dump mechanism: add a missing newline, and more importantly, include PropertyRecord's buffer in the output.