### PR TITLE
Utilize PropertyString cache for Object.assign

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeSerializer.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeSerializer.cpp
@@ -1474,7 +1474,7 @@ public:
         case TypeIds_String:
         {
             auto size = PrependByte(builder, _u("String Constant 16"), 
-                VirtualTableInfo<Js::PropertyString>::HasVirtualTable(var)? ctPropertyString16 : ctString16);
+                Js::PropertyString::Is(var)? ctPropertyString16 : ctString16);
             return size + PrependStringConstant(builder, var);
         }
 

--- a/lib/Runtime/Debug/DiagObjectModel.cpp
+++ b/lib/Runtime/Debug/DiagObjectModel.cpp
@@ -2471,11 +2471,11 @@ namespace Js
                                 {
                                     if (propertyId == Constants::NoProperty)
                                     {
-                                        if (VirtualTableInfo<Js::PropertyString>::HasVirtualTable(obj))
+                                        PropertyString * propertyString = PropertyString::TryFromVar(obj);
+                                        if (propertyString != nullptr)
                                         {
                                             // If we have a property string, it is assumed that the propertyId is being
                                             // kept alive with the object
-                                            PropertyString * propertyString = (PropertyString *)obj;
                                             propertyId = propertyString->GetPropertyRecord()->GetPropertyId();
                                         }
                                         else

--- a/lib/Runtime/Debug/TTRuntmeInfoTracker.cpp
+++ b/lib/Runtime/Debug/TTRuntmeInfoTracker.cpp
@@ -833,7 +833,7 @@ namespace TTD
                 else
                 {
                     Js::Var pitem = nullptr;
-                    BOOL isproperty = Js::JavascriptOperators::GetOwnProperty(curr, precord->GetPropertyId(), &pitem, ctx);
+                    BOOL isproperty = Js::JavascriptOperators::GetOwnProperty(curr, precord->GetPropertyId(), &pitem, ctx, nullptr);
                     TTDAssert(isproperty, "Not sure what went wrong.");
 
                     this->EnqueueNewPathVarAsNeeded(curr, pitem, precord, nullptr);

--- a/lib/Runtime/Debug/TTSnapObjects.cpp
+++ b/lib/Runtime/Debug/TTSnapObjects.cpp
@@ -328,7 +328,7 @@ namespace TTD
                         {
                             //get the value to see if it is alreay ok
                             Js::Var currentValue = nullptr;
-                            Js::JavascriptOperators::GetOwnProperty(obj, pid, &currentValue, obj->GetScriptContext());
+                            Js::JavascriptOperators::GetOwnProperty(obj, pid, &currentValue, obj->GetScriptContext(), nullptr);
 
                             if(currentValue == pVal)
                             {

--- a/lib/Runtime/Language/JavascriptConversion.cpp
+++ b/lib/Runtime/Language/JavascriptConversion.cpp
@@ -290,32 +290,37 @@ CommonNumber:
             // For all other types, convert the key into a string and use that as the property name
             JavascriptString * propName = JavascriptConversion::ToString(key, scriptContext);
 
+            // Check if we have one of the JavascriptString types which allow us to directly read the PropertyRecord
             PropertyString * propertyString = PropertyString::TryFromVar(propName);
-            if (propertyString == nullptr)
-            {
-                LiteralStringWithPropertyStringPtr * strWithPtr = LiteralStringWithPropertyStringPtr::TryFromVar(propName);
-                if (strWithPtr != nullptr)
-                {
-                    if (!strWithPtr->GetPropertyString())
-                    {
-                        propertyString = strWithPtr->GetPropertyString();
-                    }
-                    else
-                    {
-                        scriptContext->GetOrAddPropertyRecord(propName->GetString(), propName->GetLength(), propertyRecord);
-                        propertyString = scriptContext->GetPropertyString((*propertyRecord)->GetPropertyId());
-                        strWithPtr->SetPropertyString(propertyString);
-                    }
-                }
-            }
-
             if (propertyString != nullptr)
             {
+                // If we have a PropertyString, we can simply read the PropertyRecord off of it
                 *propertyRecord = propertyString->GetPropertyRecord();
             }
             else
             {
-                scriptContext->GetOrAddPropertyRecord(propName->GetString(), propName->GetLength(), propertyRecord);
+                LiteralStringWithPropertyStringPtr * strWithPtr = LiteralStringWithPropertyStringPtr::TryFromVar(propName);
+                if (strWithPtr != nullptr)
+                {
+                    propertyString = strWithPtr->GetPropertyString();
+                    if (propertyString != nullptr)
+                    {
+                        // If the PropertyString field is set, we can again simply read the propertyRecord
+                        *propertyRecord = propertyString->GetPropertyRecord();
+                    }
+                    else
+                    {
+                        // Otherwise, we need to do a lookup for the PropertyRecord
+                        scriptContext->GetOrAddPropertyRecord(propName->GetString(), propName->GetLength(), propertyRecord);
+                        // While we have the PropertyRecord available, let's find/create a PropertyString so future usage can be optimized
+                        strWithPtr->SetPropertyString(scriptContext->GetPropertyString((*propertyRecord)->GetPropertyId()));
+                    }
+                }
+                else
+                {
+                    // If we don't have any special JavascriptString, we need to do a lookup for the PropertyRecord
+                    scriptContext->GetOrAddPropertyRecord(propName->GetString(), propName->GetLength(), propertyRecord);
+                }
             }
         }
     }

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -1222,7 +1222,7 @@ CommonNumber:
         return JavascriptObject::CreateOwnEnumerableStringSymbolPropertiesHelper(object, scriptContext);
     }
 
-    BOOL JavascriptOperators::GetOwnProperty(Var instance, PropertyId propertyId, Var* value, ScriptContext* requestContext)
+    BOOL JavascriptOperators::GetOwnProperty(Var instance, PropertyId propertyId, Var* value, ScriptContext* requestContext, PropertyValueInfo * propertyValueInfo)
     {
         BOOL result;
         if (TaggedNumber::Is(instance))
@@ -1232,7 +1232,7 @@ CommonNumber:
         else
         {
             RecyclableObject* object = RecyclableObject::FromVar(instance);
-            result = object && object->GetProperty(object, propertyId, value, NULL, requestContext);
+            result = object && object->GetProperty(object, propertyId, value, propertyValueInfo, requestContext);
         }
         return result;
     }
@@ -1261,7 +1261,7 @@ CommonNumber:
         if (false == JavascriptOperators::GetOwnAccessors(obj, propertyId, &getter, &setter, scriptContext))
         {
             Var value = nullptr;
-            if (false == JavascriptOperators::GetOwnProperty(obj, propertyId, &value, scriptContext))
+            if (false == JavascriptOperators::GetOwnProperty(obj, propertyId, &value, scriptContext, nullptr))
             {
                 return FALSE;
             }
@@ -3682,15 +3682,14 @@ CommonNumber:
             temp = JavascriptString::FromVar(index);
             Assert(temp->GetScriptContext() == scriptContext);
 
-            PropertyString * propertyString = nullptr;
-            if (VirtualTableInfo<Js::PropertyString>::HasVirtualTable(temp))
+            PropertyString * propertyString = PropertyString::TryFromVar(temp);
+            if (propertyString == nullptr)
             {
-                propertyString = (PropertyString*)temp;
-            }
-            else if (VirtualTableInfo<Js::LiteralStringWithPropertyStringPtr>::HasVirtualTable(temp))
-            {
-                LiteralStringWithPropertyStringPtr * str = (LiteralStringWithPropertyStringPtr *)temp;
-                propertyString = str->GetPropertyString();
+                LiteralStringWithPropertyStringPtr * strWithPtr = LiteralStringWithPropertyStringPtr::TryFromVar(temp);
+                if (strWithPtr)
+                {
+                    propertyString = strWithPtr->GetPropertyString();
+                }
             }
             if(propertyString != nullptr)
             {
@@ -3702,7 +3701,6 @@ CommonNumber:
                 }
 
                 PropertyRecord const * propertyRecord = propertyString->GetPropertyRecord();
-                const PropertyId propId = propertyRecord->GetPropertyId();
                 Var value;
 
                 if (propertyRecord->IsNumeric())
@@ -3715,33 +3713,10 @@ CommonNumber:
                 else
                 {
                     PropertyValueInfo info;
-                    if (propertyString->ShouldUseCache())
+                    if (propertyString->TryGetPropertyFromCache(instance, object, &value, scriptContext, &info))
                     {
-                        PropertyValueInfo::SetCacheInfo(&info, propertyString, propertyString->GetLdElemInlineCache(), true);
-                        if (CacheOperators::TryGetProperty<true, true, true, true, true, true, false, true, false>(
-                            instance, false, object, propId, &value, scriptContext, nullptr, &info))
-                        {
-                            propertyString->LogCacheHit();
-#ifdef ENABLE_DEBUG_CONFIG_OPTIONS
-                            if (PHASE_TRACE1(PropertyStringCachePhase))
-                            {
-                                Output::Print(_u("PropertyCache: GetElem cache hit for '%s': type %p\n"), propertyString->GetString(), object->GetType());
-                            }
-#endif
-                            return value;
-                        }
+                        return value;
                     }
-                    propertyString->LogCacheMiss();
-#ifdef ENABLE_DEBUG_CONFIG_OPTIONS
-                    if (PHASE_TRACE1(PropertyStringCachePhase))
-                    {
-                        Output::Print(_u("PropertyCache: GetElem cache miss for '%s': type %p, index %d\n"),
-                            propertyString->GetString(),
-                            object->GetType(),
-                            propertyString->GetLdElemInlineCache()->GetInlineCacheIndexForType(object->GetType()));
-                        propertyString->DumpCache(true);
-                    }
-#endif
                     if (JavascriptOperators::GetPropertyWPCache(instance, object, propertyRecord->GetPropertyId(), &value, scriptContext, &info))
                     {
                         return value;
@@ -4330,7 +4305,6 @@ CommonNumber:
 
     BOOL JavascriptOperators::SetElementIHelper(Var receiver, RecyclableObject* object, Var index, Var value, ScriptContext* scriptContext, PropertyOperationFlags flags)
     {
-        PropertyString * propertyString = nullptr;
         Js::IndexType indexType;
         uint32 indexVal = 0;
         PropertyRecord const * propertyRecord = nullptr;
@@ -4351,31 +4325,26 @@ CommonNumber:
         }
 
         // fastpath for PropertyStrings only if receiver == object
-        if (!TaggedInt::Is(index) && JavascriptString::Is(index) &&
-            (VirtualTableInfo<Js::PropertyString>::HasVirtualTable(index) || VirtualTableInfo<Js::LiteralStringWithPropertyStringPtr>::HasVirtualTable(index)))
+        PropertyString * propertyString = PropertyString::TryFromVar(index);
+        if (propertyString == nullptr)
         {
-            if (VirtualTableInfo<Js::LiteralStringWithPropertyStringPtr>::HasVirtualTable(index))
+            LiteralStringWithPropertyStringPtr * strWithPtr = LiteralStringWithPropertyStringPtr::TryFromVar(index);
+            if (strWithPtr != nullptr)
             {
-                LiteralStringWithPropertyStringPtr * str = (LiteralStringWithPropertyStringPtr *)index;
-                propertyString = str->GetPropertyString();
+                propertyString = strWithPtr->GetPropertyString();
                 if (propertyString == nullptr)
                 {
-                    scriptContext->GetOrAddPropertyRecord(str->GetString(), str->GetLength(), &propertyRecord);
+                    scriptContext->GetOrAddPropertyRecord(strWithPtr->GetString(), strWithPtr->GetLength(), &propertyRecord);
                     propertyString = scriptContext->GetPropertyString(propertyRecord->GetPropertyId());
-                    str->SetPropertyString(propertyString);
+                    strWithPtr->SetPropertyString(propertyString);
                 }
-                else
-                {
-                    propertyRecord = propertyString->GetPropertyRecord();
-                }
+            }
+        }
 
-            }
-            else
-            {
-                propertyString = (PropertyString*)index;
-                propertyRecord = propertyString->GetPropertyRecord();
-            }
+        if (propertyString != nullptr)
+        {
             Assert(propertyString->GetScriptContext() == scriptContext);
+            propertyRecord = propertyString->GetPropertyRecord();
 
             if (propertyRecord->IsNumeric())
             {
@@ -4386,47 +4355,13 @@ CommonNumber:
             {
                 if (receiver == object)
                 {
-                    if (propertyString->ShouldUseCache())
+                    if (propertyString->TrySetPropertyFromCache(object, value, scriptContext, flags, &propertyValueInfo))
                     {
-                        PropertyValueInfo::SetCacheInfo(&propertyValueInfo, propertyString, propertyString->GetStElemInlineCache(), true);
-                        if (CacheOperators::TrySetProperty<true, true, true, true, true, false, true, false>(
-                            object,
-                            false,
-                            propertyRecord->GetPropertyId(),
-                            value,
-                            scriptContext,
-                            flags,
-                            nullptr,
-                            &propertyValueInfo))
-                        {
-#ifdef ENABLE_DEBUG_CONFIG_OPTIONS
-                            if (PHASE_TRACE1(PropertyStringCachePhase))
-                            {
-                                Output::Print(_u("PropertyCache: SetElem cache hit for '%s': type %p\n"), propertyString->GetString(), object->GetType());
-                            }
-#endif
-                            propertyString->LogCacheHit();
-                            return true;
-                        }
+                        return true;
                     }
-                    propertyString->LogCacheMiss();
-#ifdef ENABLE_DEBUG_CONFIG_OPTIONS
-                    if (PHASE_TRACE1(PropertyStringCachePhase))
-                    {
-                        Output::Print(_u("PropertyCache: SetElem cache miss for '%s': type %p, index %d\n"),
-                            propertyString->GetString(),
-                            object->GetType(),
-                            propertyString->GetStElemInlineCache()->GetInlineCacheIndexForType(object->GetType()));
-                        propertyString->DumpCache(false);
-                    }
-#endif
                 }
                 indexType = IndexType_PropertyId;
             }
-
-#if DBG_DUMP
-            scriptContext->forinNoCache++;
-#endif
         }
         else
         {

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -1233,6 +1233,12 @@ CommonNumber:
         {
             RecyclableObject* object = RecyclableObject::FromVar(instance);
             result = object && object->GetProperty(object, propertyId, value, propertyValueInfo, requestContext);
+
+            if (propertyValueInfo && result)
+            {
+                // We can only update the cache in case a property was found, because if it wasn't found, we don't know if it is missing or on a prototype
+                CacheOperators::CachePropertyRead(instance, object, false /* isRoot */, propertyId, false /* isMissing */, propertyValueInfo, requestContext);
+            }
         }
         return result;
     }
@@ -3713,7 +3719,7 @@ CommonNumber:
                 else
                 {
                     PropertyValueInfo info;
-                    if (propertyString->TryGetPropertyFromCache(instance, object, &value, scriptContext, &info))
+                    if (propertyString->TryGetPropertyFromCache<false /* OwnPropertyOnly */>(instance, object, &value, scriptContext, &info))
                     {
                         return value;
                     }

--- a/lib/Runtime/Language/JavascriptOperators.h
+++ b/lib/Runtime/Language/JavascriptOperators.h
@@ -155,7 +155,7 @@ namespace Js
         static BOOL NotStrictEqual(Var aLeft, Var aRight,ScriptContext* scriptContext);
 
         static BOOL HasOwnProperty(Var instance, PropertyId propertyId, ScriptContext * requestContext);
-        static BOOL GetOwnProperty(Var instance, PropertyId propertyId, Var* value, ScriptContext* requestContext);
+        static BOOL GetOwnProperty(Var instance, PropertyId propertyId, Var* value, ScriptContext* requestContext, PropertyValueInfo * propertyValueInfo);
         static BOOL GetOwnAccessors(Var instance, PropertyId propertyId, Var* getter, Var* setter, ScriptContext * requestContext);
         static BOOL EnsureProperty(Var instance, PropertyId propertyId);
         static void OP_EnsureNoRootProperty(Var instance, PropertyId propertyId);

--- a/lib/Runtime/Library/ConcatString.cpp
+++ b/lib/Runtime/Library/ConcatString.cpp
@@ -27,6 +27,18 @@ namespace Js
         this->propertyString = propStr;
     }
 
+    /* static */
+    bool LiteralStringWithPropertyStringPtr::Is(RecyclableObject * obj)
+    {
+        return VirtualTableInfo<Js::LiteralStringWithPropertyStringPtr>::HasVirtualTable(obj);
+    }
+
+    /* static */
+    bool LiteralStringWithPropertyStringPtr::Is(Var var)
+    {
+        return RecyclableObject::Is(var) && LiteralStringWithPropertyStringPtr::Is(RecyclableObject::FromVar(var));
+    }
+
     /////////////////////// ConcatStringBase //////////////////////////
 
     ConcatStringBase::ConcatStringBase(StaticType* stringType) : LiteralString(stringType)

--- a/lib/Runtime/Library/ConcatString.h
+++ b/lib/Runtime/Library/ConcatString.h
@@ -18,7 +18,9 @@ namespace Js
         template <typename StringType> static LiteralStringWithPropertyStringPtr * ConvertString(StringType * originalString);
 
         static uint GetOffsetOfPropertyString() { return offsetof(LiteralStringWithPropertyStringPtr, propertyString); }
-
+        static bool Is(Var var);
+        static bool Is(RecyclableObject* var);
+        template <typename T> static LiteralStringWithPropertyStringPtr* TryFromVar(T var);
     protected:
         LiteralStringWithPropertyStringPtr(StaticType* stringTypeStatic);
         DEFINE_VTABLE_CTOR(LiteralStringWithPropertyStringPtr, LiteralString);

--- a/lib/Runtime/Library/ConcatString.inl
+++ b/lib/Runtime/Library/ConcatString.inl
@@ -20,7 +20,11 @@ namespace Js
         convertedString->SetPropertyString(nullptr);
         return convertedString;
     }
-    
+
+    // Templated so that the Is call dispatchs to different function depending
+    // on if argument is already a RecyclableObject* or only known to be a Var
+    //
+    // In case it is known to be a RecyclableObject*, the Is call skips that check
     template <typename T>
     inline LiteralStringWithPropertyStringPtr * LiteralStringWithPropertyStringPtr::TryFromVar(T var)
     {

--- a/lib/Runtime/Library/ConcatString.inl
+++ b/lib/Runtime/Library/ConcatString.inl
@@ -20,6 +20,15 @@ namespace Js
         convertedString->SetPropertyString(nullptr);
         return convertedString;
     }
+    
+    template <typename T>
+    inline LiteralStringWithPropertyStringPtr * LiteralStringWithPropertyStringPtr::TryFromVar(T var)
+    {
+        return LiteralStringWithPropertyStringPtr::Is(var)
+            ? reinterpret_cast<LiteralStringWithPropertyStringPtr*>(var)
+            : nullptr;
+    }
+
 
     /////////////////////// ConcatStringBase //////////////////////////
     template <typename ConcatStringType>

--- a/lib/Runtime/Library/ForInObjectEnumerator.cpp
+++ b/lib/Runtime/Library/ForInObjectEnumerator.cpp
@@ -184,11 +184,11 @@ namespace Js
                 // Property Id does not exist.
                 if (propertyId == Constants::NoProperty)
                 {
-                    if (VirtualTableInfo<Js::PropertyString>::HasVirtualTable(currentIndex))
+                    PropertyString * propertyString = PropertyString::TryFromVar(currentIndex);
+                    if(propertyString != nullptr)
                     {
                         // If we have a property string, it is assumed that the propertyId is being
                         // kept alive with the object
-                        PropertyString * propertyString = (PropertyString *)currentIndex;
                         propertyId = propertyString->GetPropertyRecord()->GetPropertyId();
                     }
                     else

--- a/lib/Runtime/Library/JSON.cpp
+++ b/lib/Runtime/Library/JSON.cpp
@@ -437,10 +437,10 @@ namespace JSON
 
         if (value == nullptr)
         {
-            if (VirtualTableInfo<Js::PropertyString>::HasVirtualTable(key))
+            Js::PropertyString* propertyString = Js::PropertyString::TryFromVar(key);
+            if (propertyString)
             {
                 PropertyValueInfo info;
-                Js::PropertyString* propertyString = (Js::PropertyString*)key;
                 PropertyValueInfo::SetCacheInfo(&info, propertyString, propertyString->GetLdElemInlineCache(), false);
                 CacheOperators::TryGetProperty<true, false, true, false, true, false, false, true, false>(holder, false, Js::RecyclableObject::FromVar(holder), keyId, &value, scriptContext, nullptr, &info);
             }

--- a/lib/Runtime/Library/PropertyString.h
+++ b/lib/Runtime/Library/PropertyString.h
@@ -6,57 +6,85 @@
 
 namespace Js
 {
-    class PropertyString : public JavascriptString
-    {
-    protected:
-        Field(int) hitRate;
-        Field(PolymorphicInlineCache*) ldElemInlineCache;
-        Field(PolymorphicInlineCache*) stElemInlineCache;
-        Field(const Js::PropertyRecord*) propertyRecord;
+class PropertyString : public JavascriptString
+{
+protected:
+    Field(int) hitRate;
+    Field(PolymorphicInlineCache*) ldElemInlineCache;
+    Field(PolymorphicInlineCache*) stElemInlineCache;
+    Field(const Js::PropertyRecord*) propertyRecord;
 
-        DEFINE_VTABLE_CTOR(PropertyString, JavascriptString);
+    DEFINE_VTABLE_CTOR(PropertyString, JavascriptString);
 
-        PropertyString(StaticType* type, const Js::PropertyRecord* propertyRecord);
-    public:
-        PolymorphicInlineCache * GetLdElemInlineCache() const;
-        PolymorphicInlineCache * GetStElemInlineCache() const;
-        Js::PropertyRecord const * GetPropertyRecord() const { return this->propertyRecord; }
-        PolymorphicInlineCache * CreateBiggerPolymorphicInlineCache(bool isLdElem);
-        void LogCacheMiss();
-        int GetHitRate() const { return this->hitRate; };
-        void LogCacheHit() { ++this->hitRate; };
-        bool ShouldUseCache() const;
+    PropertyString(StaticType* type, const Js::PropertyRecord* propertyRecord);
+public:
+    PolymorphicInlineCache * GetLdElemInlineCache() const;
+    PolymorphicInlineCache * GetStElemInlineCache() const;
+    Js::PropertyRecord const * GetPropertyRecord() const { return this->propertyRecord; }
+    PolymorphicInlineCache * CreateBiggerPolymorphicInlineCache(bool isLdElem);
+    void LogCacheMiss();
+    int GetHitRate() const { return this->hitRate; };
+    void LogCacheHit() { ++this->hitRate; };
+    bool ShouldUseCache() const;
 
-        static PropertyString* New(StaticType* type, const Js::PropertyRecord* propertyRecord, Recycler *recycler);
+    bool TrySetPropertyFromCache(
+        RecyclableObject *const object,
+        Var propertyValue,
+        ScriptContext *const requestContext,
+        const PropertyOperationFlags propertyOperationFlags,
+        PropertyValueInfo *const propertyValueInfo);
 
-        virtual void const * GetOriginalStringReference() override;
-        virtual RecyclableObject * CloneToScriptContext(ScriptContext* requestContext) override;
+    bool TryGetPropertyFromCache(
+        Var const instance,
+        RecyclableObject *const object,
+        Var *const propertyValue,
+        ScriptContext *const requestContext,
+        PropertyValueInfo *const propertyValueInfo);
 
-        static uint32 GetOffsetOfLdElemInlineCache() { return offsetof(PropertyString, ldElemInlineCache); }
-        static uint32 GetOffsetOfStElemInlineCache() { return offsetof(PropertyString, stElemInlineCache); }
-        static uint32 GetOffsetOfHitRate() { return offsetof(PropertyString, hitRate); }
+    static PropertyString* New(StaticType* type, const Js::PropertyRecord* propertyRecord, Recycler *recycler);
+
+    virtual void const * GetOriginalStringReference() override;
+    virtual RecyclableObject * CloneToScriptContext(ScriptContext* requestContext) override;
+
+    static uint32 GetOffsetOfLdElemInlineCache() { return offsetof(PropertyString, ldElemInlineCache); }
+    static uint32 GetOffsetOfStElemInlineCache() { return offsetof(PropertyString, stElemInlineCache); }
+    static uint32 GetOffsetOfHitRate() { return offsetof(PropertyString, hitRate); }
+    static bool Is(Var var);
+    static bool Is(RecyclableObject * var);
+
+    template <typename T> static PropertyString* TryFromVar(T var);
 
 #if ENABLE_DEBUG_CONFIG_OPTIONS
-        void DumpCache(bool ldElemCache)
+    void DumpCache(bool ldElemCache)
+    {
+        PolymorphicInlineCache * cache = ldElemCache ? GetLdElemInlineCache() : GetStElemInlineCache();
+        Output::Print(_u("PropertyCache HitRate: %i; types: "), this->hitRate);
+        for (uint i = 0; i < cache->GetSize(); ++i)
         {
-            PolymorphicInlineCache * cache = ldElemCache ? GetLdElemInlineCache() : GetStElemInlineCache();
-            Output::Print(_u("PropertyCache HitRate: %i; types: "), this->hitRate);
-            for (uint i = 0; i < cache->GetSize(); ++i)
-            {
-                Output::Print(_u("%p,"), cache->GetInlineCaches()[i].GetType());
-            }
-            Output::Print(_u("\n"));
+            Output::Print(_u("%p,"), cache->GetInlineCaches()[i].GetType());
         }
+        Output::Print(_u("\n"));
+    }
 #endif
 #if ENABLE_TTD
-        //Get the associated property id for this string if there is on (e.g. it is a propertystring otherwise return Js::PropertyIds::_none)
-        virtual Js::PropertyId TryGetAssociatedPropertyId() const override { return this->propertyRecord->GetPropertyId(); }
+    //Get the associated property id for this string if there is on (e.g. it is a propertystring otherwise return Js::PropertyIds::_none)
+    virtual Js::PropertyId TryGetAssociatedPropertyId() const override { return this->propertyRecord->GetPropertyId(); }
 #endif
 
-    public:
-        virtual VTableValue DummyVirtualFunctionToHinderLinkerICF()
-        {
-            return VTableValue::VtablePropertyString;
-        }
-    };
+public:
+    virtual VTableValue DummyVirtualFunctionToHinderLinkerICF()
+    {
+        return VTableValue::VtablePropertyString;
+    }
+};
+
+
+template <typename T> inline
+PropertyString * PropertyString::TryFromVar(T var)
+{
+    return PropertyString::Is(var)
+        ? reinterpret_cast<PropertyString*>(var)
+        : nullptr;
 }
+
+} // namespace Js

--- a/lib/Runtime/Library/RuntimeLibraryPch.h
+++ b/lib/Runtime/Library/RuntimeLibraryPch.h
@@ -91,7 +91,6 @@
 #include "Types/TypePropertyCache.h"
 // .inl files
 #include "Library/JavascriptString.inl"
-#include "Library/ConcatString.inl"
 #include "Language/CacheOperators.inl"
 
 #ifdef INTL_ICU

--- a/lib/Runtime/Runtime.h
+++ b/lib/Runtime/Runtime.h
@@ -581,6 +581,7 @@ enum tagDEBUG_EVENT_INFO_TYPE
 #include "Language/JavascriptOperators.inl"
 #include "Language/TaggedInt.inl"
 #include "Library/JavascriptGeneratorFunction.h"
+#include "Library/ConcatString.inl"
 
 #ifndef USED_IN_STATIC_LIB
 #ifdef ENABLE_INTL_OBJECT

--- a/lib/Runtime/Types/DynamicObjectPropertyEnumerator.cpp
+++ b/lib/Runtime/Types/DynamicObjectPropertyEnumerator.cpp
@@ -199,13 +199,17 @@ namespace Js
         {
             propertyStringName = this->MoveAndGetNextNoCache(propertyId, &propertyAttributes);
 
-            if (propertyStringName && VirtualTableInfo<PropertyString>::HasVirtualTable(propertyStringName))
+            if (propertyStringName)
             {
-                Assert(enumeratedCount < this->initialPropertyCount);
-                cachedData->strings[enumeratedCount] = (PropertyString*)propertyStringName;
-                cachedData->indexes[enumeratedCount] = this->objectIndex;
-                cachedData->attributes[enumeratedCount] = propertyAttributes;
-                cachedData->cachedCount = ++enumeratedCount;
+                PropertyString* propertyString = PropertyString::TryFromVar(propertyStringName);
+                if (propertyString != nullptr)
+                {
+                    Assert(enumeratedCount < this->initialPropertyCount);
+                    cachedData->strings[enumeratedCount] = propertyString;
+                    cachedData->indexes[enumeratedCount] = this->objectIndex;
+                    cachedData->attributes[enumeratedCount] = propertyAttributes;
+                    cachedData->cachedCount = ++enumeratedCount;
+                }
             }
             else
             {

--- a/lib/Runtime/Types/SimpleDictionaryTypeHandler.cpp
+++ b/lib/Runtime/Types/SimpleDictionaryTypeHandler.cpp
@@ -57,9 +57,10 @@ namespace Js
     const PropertyRecord* TMapKey_ConvertKey(ScriptContext* scriptContext, JavascriptString* key)
     {
         PropertyRecord const * propertyRecord;
-        if (VirtualTableInfo<Js::PropertyString>::HasVirtualTable(key))
+        PropertyString * propertyString = PropertyString::TryFromVar(key);
+        if (propertyString != nullptr)
         {
-            propertyRecord = ((PropertyString*)key)->GetPropertyRecord();
+            propertyRecord = propertyString->GetPropertyRecord();
         }
         else
         {
@@ -95,9 +96,10 @@ namespace Js
     const PropertyRecord* TMapKey_ConvertKey_TTD(ThreadContext* threadContext, JavascriptString* key)
     {
         PropertyRecord const * propertyRecord;
-        if(VirtualTableInfo<Js::PropertyString>::HasVirtualTable(key))
+        PropertyString * propertyString = PropertyString::TryFromVar(key);
+        if (propertyString != nullptr)
         {
-            propertyRecord = ((PropertyString*)key)->GetPropertyRecord();
+            propertyRecord = propertyString->GetPropertyRecord();
         }
         else
         {
@@ -110,7 +112,7 @@ namespace Js
     bool TPropertyKey_IsInternalPropertyId(JavascriptString* key)
     {
         // WARNING: This will return false for PropertyStrings that are actually InternalPropertyIds
-        Assert(!VirtualTableInfo<PropertyString>::HasVirtualTable(key) || !IsInternalPropertyId(((PropertyString*)key)->GetPropertyRecord()->GetPropertyId()));
+        Assert(!PropertyString::Is(key) || !IsInternalPropertyId(((PropertyString*)key)->GetPropertyRecord()->GetPropertyId()));
         return false;
     }
 


### PR DESCRIPTION
Actual change is pretty straightforward. Most of this is refactoring to centralize the PropertyString cache code.

Improves react-redux perf by about 2%.