### PR TITLE
Fix ES module filename not visible in stack trace/debugger

### DIFF
--- a/lib/Jsrt/Core/JsrtCore.cpp
+++ b/lib/Jsrt/Core/JsrtCore.cpp
@@ -77,7 +77,10 @@ JsParseModuleSource(
         SourceContextInfo* sourceContextInfo = scriptContext->GetSourceContextInfo(sourceContext, nullptr);
         if (sourceContextInfo == nullptr)
         {
-            sourceContextInfo = scriptContext->CreateSourceContextInfo(sourceContext, nullptr, 0, nullptr, nullptr, 0);
+            Js::JavascriptString *specifier = Js::JavascriptString::FromVar(moduleRecord->GetSpecifier());
+            const char16 *urlSz = specifier->GetSz();
+            size_t urlLength = specifier->GetLength();
+            sourceContextInfo = scriptContext->CreateSourceContextInfo(sourceContext, urlSz, urlLength, nullptr, nullptr, 0);
         }
         SRCINFO si = {
             /* sourceContextInfo   */ sourceContextInfo,

--- a/lib/Runtime/Language/SourceTextModuleRecord.cpp
+++ b/lib/Runtime/Language/SourceTextModuleRecord.cpp
@@ -171,7 +171,7 @@ namespace Js
         {
             if (*exceptionVar == nullptr)
             {
-                *exceptionVar = JavascriptError::CreateFromCompileScriptException(scriptContext, &se);
+                *exceptionVar = JavascriptError::CreateFromCompileScriptException(scriptContext, &se, this->GetSpecifierSz());
             }
             if (this->parser)
             {
@@ -831,7 +831,7 @@ namespace Js
         this->rootFunction = scriptContext->GenerateRootFunction(parseTree, sourceIndex, this->parser, this->pSourceInfo->GetParseFlags(), &se, _u("module"));
         if (rootFunction == nullptr)
         {
-            this->errorObject = JavascriptError::CreateFromCompileScriptException(scriptContext, &se);
+            this->errorObject = JavascriptError::CreateFromCompileScriptException(scriptContext, &se, this->GetSpecifierSz());
             OUTPUT_TRACE_DEBUGONLY(Js::ModulePhase, _u("\t>NotifyParentAsNeeded rootFunction == nullptr\n"));
             NotifyParentsAsNeeded();
         }


### PR DESCRIPTION
JsParseModuleSource() had been creating the source context with url set to `nullptr`, which caused the module name not to be visible in error backtraces or debugger JSON, e.g.:
```
Error: PIG!
   at mp3Demo (:28:3)
```

With this patch the URL for the module is set to the host-normalized module specifier, so that:
```
Error: PIG!
   at mp3Demo (@/bin/main.mjs:28:3)
```

I'm not sure if I implemented this properly; in particular I wasn't sure if SourceTextModuleRecord::GetSpecifier() could ever return nullptr, in which case the fix is incorrect.  Please advise on that point.

Fixes #3618.