### PR TITLE
Add cache for RegExp.test

### DIFF
--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -835,8 +835,6 @@ private:
         EventHandler disposeScriptByFaultInjectionEventHandler;
 #endif
 
-        JsUtil::BaseDictionary<uint, JavascriptString *, ArenaAllocator> integerStringMap;
-
         double lastNumberToStringRadix10;
         double lastUtcTimeFromStr;
 

--- a/lib/Runtime/Debug/DiagObjectModel.h
+++ b/lib/Runtime/Debug/DiagObjectModel.h
@@ -218,7 +218,7 @@ namespace Js
         bool IsPropertyValid(PropertyId propertyId, RegSlot location, bool *isPropertyInDebuggerScope, bool* isConst, bool* isInDeadZone) const;
 
     private:
-        static JavascriptString * ParseFunctionName(JavascriptString* displayName, ScriptContext* scriptContext);
+        static const char16 * ParseFunctionName(const char16* displayNameBuffer, const charcount_t displayNameBufferLength, ScriptContext* scriptContext);
     };
 
 

--- a/lib/Runtime/Library/JavascriptLibrary.h
+++ b/lib/Runtime/Library/JavascriptLibrary.h
@@ -43,6 +43,7 @@ namespace Js
     typedef TwoLevelHashDictionary<FastEvalMapString, ScriptFunction*, EvalMapRecord, EvalCacheTopLevelDictionary, EvalMapString> EvalCacheDictionary;
 
     typedef JsUtil::BaseDictionary<JavascriptMethod, JavascriptFunction*, Recycler, PrimeSizePolicy> BuiltInLibraryFunctionMap;
+    typedef JsUtil::BaseDictionary<uint, JavascriptString *, Recycler> StringMap;
 
     // valid if object!= NULL
     struct EnumeratedObjectCache
@@ -74,6 +75,7 @@ namespace Js
         Field(EvalCacheDictionary*) evalCacheDictionary;
         Field(EvalCacheDictionary*) indirectEvalCacheDictionary;
         Field(NewFunctionCache*) newFunctionCache;
+        Field(StringMap *) integerStringMap;
         Field(RegexPatternMruMap *) dynamicRegexMap;
         Field(SourceContextInfoMap*) sourceContextInfoMap;   // maps host provided context cookie to the URL of the script buffer passed.
         Field(DynamicSourceContextInfoMap*) dynamicSourceContextInfoMap;

--- a/lib/Runtime/Library/JavascriptLibrary.h
+++ b/lib/Runtime/Library/JavascriptLibrary.h
@@ -649,6 +649,8 @@ namespace Js
         SCACHE_FUNCTION_PROXY(GetObjectNumberDisplayString)
         SCACHE_FUNCTION_PROXY(GetObjectRegExpDisplayString)
         SCACHE_FUNCTION_PROXY(GetObjectStringDisplayString)
+        SCACHE_FUNCTION_PROXY(GetObjectNullDisplayString)
+        SCACHE_FUNCTION_PROXY(GetObjectUndefinedDisplayString)
         SCACHE_FUNCTION_PROXY(GetUndefinedDisplayString)
         SCACHE_FUNCTION_PROXY(GetNaNDisplayString)
         SCACHE_FUNCTION_PROXY(GetNullDisplayString)

--- a/lib/Runtime/Library/JavascriptObject.cpp
+++ b/lib/Runtime/Library/JavascriptObject.cpp
@@ -365,12 +365,12 @@ namespace Js
         // 1. If the this value is undefined, return "[object Undefined]".
         if (type == TypeIds_Undefined)
         {
-            return library->CreateStringFromCppLiteral(_u("[object Undefined]"));
+            return library->GetObjectUndefinedDisplayString();
         }
         // 2. If the this value is null, return "[object Null]".
         if (type == TypeIds_Null)
         {
-            return library->CreateStringFromCppLiteral(_u("[object Null]"));
+            return library->GetObjectNullDisplayString();
         }
 
         // 3. Let O be ToObject(this value).

--- a/lib/Runtime/Library/JavascriptRegularExpression.h
+++ b/lib/Runtime/Library/JavascriptRegularExpression.h
@@ -9,7 +9,7 @@ namespace Js
     struct RegExpTestCache
     {
         bool result;
-        Field(JavascriptString*) input;
+        Field(RecyclerWeakReference<JavascriptString> *) input;
     };
     class JavascriptRegExp : public DynamicObject
     {

--- a/lib/Runtime/Library/JavascriptRegularExpression.h
+++ b/lib/Runtime/Library/JavascriptRegularExpression.h
@@ -6,6 +6,11 @@
 
 namespace Js
 {
+    struct RegExpTestCache
+    {
+        bool result;
+        Field(JavascriptString*) input;
+    };
     class JavascriptRegExp : public DynamicObject
     {
         friend class JavascriptRegularExpressionType;
@@ -25,14 +30,15 @@ namespace Js
         // Initialization of this pattern is deferred until split() is called, or it's copied from another
         // RegExp object.
         Field(UnifiedRegex::RegexPattern*) splitPattern;
-
         Field(Var) lastIndexVar;  // null => must build lastIndexVar from current lastIndex
+        Field(RegExpTestCache*) testCache;
 
     public:
-
         // Three states for lastIndex value:
         //  1. lastIndexVar has been updated, we must calculate lastIndex from it when we next need it
         static const CharCount NotCachedValue = (CharCount)-2;
+
+        static const uint TestCacheSize = 8;
     private:
         //  2. ToNumber(lastIndexVar) yields +inf or -inf or an integer not in range [0, MaxCharCount]
         static const CharCount InvalidValue = CharCountFlag;
@@ -133,6 +139,14 @@ namespace Js
         static Var OP_NewRegEx(Var aCompiledRegex, ScriptContext* scriptContext);
 
         JavascriptString *ToString(bool sourceOnly = false);
+
+        Field(RegExpTestCache*) EnsureTestCache();
+        void ClearTestCache();
+        static uint GetTestCacheIndex(JavascriptString* str);
+
+#if ENABLE_REGEX_CONFIG_OPTIONS
+        static void TraceTestCache(bool cacheHit, JavascriptString* input, JavascriptString* cachedValue, bool disabled);
+#endif
 
         class EntryInfo
         {

--- a/lib/Runtime/Library/JavascriptRegularExpression.h
+++ b/lib/Runtime/Library/JavascriptRegularExpression.h
@@ -8,7 +8,7 @@ namespace Js
 {
     struct RegExpTestCache
     {
-        bool result;
+        Field(bool) result;
         Field(RecyclerWeakReference<JavascriptString> *) input;
     };
     class JavascriptRegExp : public DynamicObject

--- a/lib/Runtime/Library/JavascriptString.cpp
+++ b/lib/Runtime/Library/JavascriptString.cpp
@@ -102,20 +102,9 @@ namespace Js
         return NewWithBuffer(content, GetBufferLength(content), scriptContext);
     }
 
-    JavascriptString* JavascriptString::NewWithArenaSz(__in_z const char16 * content, ScriptContext * scriptContext)
-    {
-        AssertMsg(content != nullptr, "NULL value passed to JavascriptString::New");
-        return NewWithArenaBuffer(content, GetBufferLength(content), scriptContext);
-    }
-
     JavascriptString* JavascriptString::NewWithBuffer(__in_ecount(cchUseLength) const char16 * content, charcount_t cchUseLength, ScriptContext * scriptContext)
     {
         return NewWithBufferT<LiteralString, false>(content, cchUseLength, scriptContext);
-    }
-
-    JavascriptString* JavascriptString::NewWithArenaBuffer(__in_ecount(cchUseLength) const char16* content, charcount_t cchUseLength, ScriptContext* scriptContext)
-    {
-        return NewWithBufferT<ArenaLiteralString, false>(content, cchUseLength, scriptContext);
     }
 
     JavascriptString* JavascriptString::NewCopySz(__in_z const char16* content, ScriptContext* scriptContext)
@@ -126,21 +115,6 @@ namespace Js
     JavascriptString* JavascriptString::NewCopyBuffer(__in_ecount(cchUseLength) const char16* content, charcount_t cchUseLength, ScriptContext* scriptContext)
     {
         return NewWithBufferT<LiteralString, true>(content, cchUseLength, scriptContext);
-    }
-
-    JavascriptString* JavascriptString::NewCopySzFromArena(__in_z const char16* content,
-        ScriptContext* scriptContext, ArenaAllocator *arena, charcount_t cchUseLength)
-    {
-        AssertMsg(content != nullptr, "NULL value passed to JavascriptString::New");
-
-        if (!cchUseLength)
-        {
-            cchUseLength = JavascriptString::GetBufferLength(content);
-        }
-
-        char16* buffer = JavascriptString::AllocateAndCopySz(arena, content, cchUseLength);
-        return ArenaLiteralString::New(scriptContext->GetLibrary()->GetStringTypeStatic(),
-            buffer, cchUseLength, arena);
     }
 
     Var JavascriptString::NewInstance(RecyclableObject* function, CallInfo callInfo, ...)

--- a/lib/Runtime/Library/JavascriptString.h
+++ b/lib/Runtime/Library/JavascriptString.h
@@ -172,11 +172,6 @@ namespace Js
         static JavascriptString* NewCopySz(__in_z const char16* content, ScriptContext* scriptContext);
         static JavascriptString* NewCopyBuffer(__in_ecount(charLength)  const char16* content, charcount_t charLength, ScriptContext* scriptContext);
 
-        static JavascriptString* NewWithArenaSz(__in_z const char16 * content, ScriptContext* scriptContext);
-        static JavascriptString* NewWithArenaBuffer(__in_ecount(charLength) const char16 * content, charcount_t charLength, ScriptContext * scriptContext);
-
-        static JavascriptString* NewCopySzFromArena(__in_z const char16* content, ScriptContext* scriptContext, ArenaAllocator *arena, charcount_t cchUseLength = 0);
-
         static __ecount(length+1) char16* AllocateLeafAndCopySz(__in Recycler* recycler, __in_ecount(length) const char16* content, charcount_t length);
         static __ecount(length+1) char16* AllocateAndCopySz(__in ArenaAllocator* arena, __in_ecount(length) const char16* content, charcount_t length);
         static void CopyHelper(__out_ecount(countNeeded) char16 *dst, __in_ecount(countNeeded) const char16 * str, charcount_t countNeeded);

--- a/lib/Runtime/Library/LiteralString.cpp
+++ b/lib/Runtime/Library/LiteralString.cpp
@@ -41,36 +41,4 @@ namespace Js
         return RecyclerNew(type->GetScriptContext()->GetRecycler(), LiteralString, type, _u(""), 0);
     }
 
-
-    ArenaLiteralString::ArenaLiteralString(StaticType * type, const char16* content, charcount_t charLength) :
-      JavascriptString(type, charLength, content)
-    {
-#if defined(DBG) && defined(_M_IX86)
-        // Make sure content isn't on the stack by comparing to stack bounds in TIB
-        AssertMsg(!ThreadContext::IsOnStack((void*)content),
-            "ArenaLiteralString object created using stack buffer...");
-#endif
-
-        AssertMsg(!type->GetScriptContext()->GetRecycler()->IsValidObject((void *)content),
-            "ArenaLiteralString should not be used with GC strings");
-
-#ifdef PROFILE_STRINGS
-        StringProfiler::RecordNewString( type->GetScriptContext(), content, charLength );
-#endif
-    }
-
-    ArenaLiteralString* ArenaLiteralString::New(StaticType* type, const char16* content, charcount_t charLength, Recycler* recycler)
-    {
-        return RecyclerNew(recycler, ArenaLiteralString, type, content, charLength);
-    }
-
-    ArenaLiteralString* ArenaLiteralString::New(StaticType* type, const char16* content, charcount_t charLength, ArenaAllocator* arena)
-    {
-        return Anew(arena, ArenaLiteralString, type, content, charLength);
-    }
-
-    RecyclableObject * ArenaLiteralString::CloneToScriptContext(ScriptContext* requestContext)
-    {
-        return JavascriptString::NewCopyBuffer(this->GetSz(), this->GetLength(), requestContext);
-    }
 } // namespace Js

--- a/lib/Runtime/Library/LiteralString.h
+++ b/lib/Runtime/Library/LiteralString.h
@@ -17,16 +17,4 @@ namespace Js
         static LiteralString* New(StaticType* type, const char16* content, charcount_t charLength, Recycler* recycler);
         static LiteralString* CreateEmptyString(StaticType* type);
     };
-
-    class ArenaLiteralString sealed : public JavascriptString
-    {
-    protected:
-        ArenaLiteralString(StaticType* type, const char16* content, charcount_t charLength);
-        DEFINE_VTABLE_CTOR(ArenaLiteralString, JavascriptString);
-
-    public:
-        static ArenaLiteralString* New(StaticType* type, const char16* content, charcount_t charLength, Recycler* recycler);
-        static ArenaLiteralString* New(StaticType* type, const char16* content, charcount_t charLength, ArenaAllocator* arena);
-        virtual RecyclableObject * CloneToScriptContext(ScriptContext* requestContext) override;
-    };
 }

--- a/lib/Runtime/Library/RegexHelper.cpp
+++ b/lib/Runtime/Library/RegexHelper.cpp
@@ -686,8 +686,9 @@ namespace Js
         JavascriptRegExp::TraceTestCache(cacheHit, input, cachedInput, !useCache);
 #endif
 
-        if (useCache && cacheHit)
+        if (cacheHit)
         {
+            Assert(useCache);
             cachedResult = cache[cacheIndex].result;
             // for debug builds, let's still do the real test so we can validate values in the cache
 #if !DBG

--- a/lib/Runtime/Library/RegexHelper.cpp
+++ b/lib/Runtime/Library/RegexHelper.cpp
@@ -678,7 +678,7 @@ namespace Js
         {
             cache = regularExpression->EnsureTestCache();
             cacheIndex = JavascriptRegExp::GetTestCacheIndex(input);
-            cachedInput = cache[cacheIndex].input;
+            cachedInput = cache[cacheIndex].input != nullptr ? cache[cacheIndex].input->Get() : nullptr;
             cacheHit = cachedInput == input;
         }
 #if ENABLE_REGEX_CONFIG_OPTIONS
@@ -704,7 +704,7 @@ namespace Js
                 Assert(offset == 0);
                 Assert(!cacheHit || cachedInput == input);
                 Assert(!cacheHit || cachedResult == false);
-                cache[cacheIndex].input = input;
+                cache[cacheIndex].input = regularExpression->GetRecycler()->CreateWeakReferenceHandle(input);
                 cache[cacheIndex].result = false;
             }
             return scriptContext->GetLibrary()->GetFalse();
@@ -723,7 +723,7 @@ namespace Js
             Assert(offset == 0);
             Assert(!cacheHit || cachedInput == input);
             Assert(!cacheHit || cachedResult == wasFound);
-            cache[cacheIndex].input = input;
+            cache[cacheIndex].input = regularExpression->GetRecycler()->CreateWeakReferenceHandle(input);
             cache[cacheIndex].result = wasFound;
         }
         return JavascriptBoolean::ToVar(wasFound, scriptContext);

--- a/lib/Runtime/Library/StringCache.h
+++ b/lib/Runtime/Library/StringCache.h
@@ -77,6 +77,8 @@ public:
       SCACHE_INIT_DEFAULT(GetObjectNumberDisplayString),
       SCACHE_INIT_DEFAULT(GetObjectRegExpDisplayString),
       SCACHE_INIT_DEFAULT(GetObjectStringDisplayString),
+      SCACHE_INIT_DEFAULT(GetObjectNullDisplayString),
+      SCACHE_INIT_DEFAULT(GetObjectUndefinedDisplayString),
       SCACHE_INIT_DEFAULT(GetUndefinedDisplayString),
       SCACHE_INIT_DEFAULT(GetNaNDisplayString),
       SCACHE_INIT_DEFAULT(GetNullDisplayString),
@@ -155,6 +157,8 @@ public:
     DEFINE_CACHED_STRING(GetObjectNumberDisplayString, _u("[object Number]"))
     DEFINE_CACHED_STRING(GetObjectRegExpDisplayString, _u("[object RegExp]"))
     DEFINE_CACHED_STRING(GetObjectStringDisplayString, _u("[object String]"))
+    DEFINE_CACHED_STRING(GetObjectNullDisplayString, _u("[object Null]"))
+    DEFINE_CACHED_STRING(GetObjectUndefinedDisplayString, _u("[object Undefined]"))
     DEFINE_CACHED_STRING(GetUndefinedDisplayString, _u("undefined"))
     DEFINE_CACHED_STRING(GetNaNDisplayString, _u("NaN"))
     DEFINE_CACHED_STRING(GetNullDisplayString, _u("null"))

--- a/lib/Runtime/Runtime.h
+++ b/lib/Runtime/Runtime.h
@@ -122,7 +122,6 @@ namespace Js
     struct JavascriptPromiseResolveOrRejectFunctionAlreadyResolvedWrapper;
     class JavascriptGenerator;
     class LiteralString;
-    class ArenaLiteralString;
     class JavascriptStringObject;
     struct PropertyDescriptor;
     class Type;


### PR DESCRIPTION
It seems to be a common enough pattern where people will create a RegExp and test a small number of unique strings many times.

For this, I added a simple cache of size 8 on the RegExp object for RegExp.test, which caches the result for some given input string.

I disable the cache it in case of using global or sticky, since the result can change depending on lastIndex and caching likely wouldn't help those patterns.

After experimentation I decided on size 8, because there were rapidly diminishing returns at size 16 and at size 4 I saw a big increase in cache misses.

I tried dynamic sizing as well, but megamorphic cases would quickly max out the cache and the polymorphic cases didn't seem to get much benefit above size 8, so it seemed better to avoid the overhead of resizing and stick with a fixed sized cache.

Improves perf of angular by about 6%.