### PR TITLE
OS#13910068 : WASM - Read opcode

### DIFF
--- a/lib/WasmReader/WasmBinaryReader.cpp
+++ b/lib/WasmReader/WasmBinaryReader.cpp
@@ -380,10 +380,18 @@ bool WasmBinaryReader::IsCurrentFunctionCompleted() const
     return m_pc == m_curFuncEnd;
 }
 
-WasmOp WasmBinaryReader::ReadExpr()
+WasmOp WasmBinaryReader::ReadOpCode()
 {
+    CheckBytesLeft(1);
     WasmOp op = m_currentNode.op = (WasmOp)*m_pc++;
     ++m_funcState.count;
+
+    return op;
+}
+
+WasmOp WasmBinaryReader::ReadExpr()
+{
+    WasmOp op = ReadOpCode();
 
     if (EndOfFunc())
     {

--- a/lib/WasmReader/WasmBinaryReader.h
+++ b/lib/WasmReader/WasmBinaryReader.h
@@ -69,6 +69,7 @@ namespace Wasm
             uint32 count; // current entry
             uint32 size;  // binary size of the function
         };
+        WasmOp ReadOpCode();
 
         void BlockNode();
         void CallNode();


### PR DESCRIPTION
Make sure we have at least a byte left before reading the wasm buffer instead of after.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/3804)
<!-- Reviewable:end -->
