### PR TITLE
OS#13894912 WASM: Yielding in unreachable code

### DIFF
--- a/lib/Runtime/Language/RuntimeLanguagePch.h
+++ b/lib/Runtime/Language/RuntimeLanguagePch.h
@@ -5,9 +5,9 @@
 #pragma once
 
 #include "Parser.h"
-#include "WasmReader.h"
 
 #include "Runtime.h"
+#include "WasmReader.h"
 
 #include "Language/AsmJsUtils.h"
 #include "Language/AsmJsLink.h"

--- a/lib/WasmReader/Chakra.WasmReader.vcxproj
+++ b/lib/WasmReader/Chakra.WasmReader.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Condition="'$(ChakraBuildPathImported)'!='true'" Project="$(SolutionDir)Chakra.Build.Paths.props" />
   <Import Project="$(BuildConfigPropsPath)Chakra.Build.ProjectConfiguration.props" />
@@ -60,6 +60,7 @@
     <ClInclude Include="WasmLimits.h" />
     <ClInclude Include="WasmReader.h" />
     <ClInclude Include="WasmReaderBase.h" />
+    <ClInclude Include="WasmReaderInfo.h" />
     <ClInclude Include="WasmReaderPch.h" />
     <ClInclude Include="WasmParseTree.h" />
     <ClInclude Include="WasmSection.h" />

--- a/lib/WasmReader/Chakra.WasmReader.vcxproj.filters
+++ b/lib/WasmReader/Chakra.WasmReader.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <ClInclude Include="WasmParseTree.h" />
@@ -18,6 +18,7 @@
     <ClInclude Include="WasmCustomReader.h" />
     <ClInclude Include="EmptyWasmByteCodeWriter.h" />
     <ClInclude Include="WasmLimits.h" />
+    <ClInclude Include="WasmReaderInfo.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="$(MSBuildThisFileDirectory)WasmBytecodeGenerator.cpp" />

--- a/lib/WasmReader/WasmByteCodeGenerator.h
+++ b/lib/WasmReader/WasmByteCodeGenerator.h
@@ -145,13 +145,6 @@ namespace Wasm
 
     typedef JsUtil::BaseDictionary<uint32, LPCUTF8, ArenaAllocator> WasmExportDictionary;
 
-    struct WasmReaderInfo
-    {
-        Field(WasmFunctionInfo*) m_funcInfo;
-        Field(Js::WebAssemblyModule*) m_module;
-        Field(Js::Var) m_bufferSrc;
-    };
-
     class WasmModuleGenerator
     {
     public:
@@ -237,7 +230,8 @@ namespace Wasm
         Js::OpCodeAsmJs GetReturnOp(WasmTypes::WasmType type);
         WasmRegisterSpace* GetRegisterSpace(WasmTypes::WasmType type);
 
-        EmitInfo PopEvalStackForYield();
+        EmitInfo PopValuePolymorphic() { return PopEvalStack(); }
+        EmitInfo PopStackPolymorphic(WasmTypes::WasmType expectedType = WasmTypes::Any, const char16* mismatchMessage = nullptr);
         EmitInfo PopEvalStack(WasmTypes::WasmType expectedType = WasmTypes::Any, const char16* mismatchMessage = nullptr);
         void PushEvalStack(EmitInfo);
         EmitInfo EnsureYield(BlockInfo);

--- a/lib/WasmReader/WasmByteCodeGenerator.h
+++ b/lib/WasmReader/WasmByteCodeGenerator.h
@@ -237,6 +237,7 @@ namespace Wasm
         Js::OpCodeAsmJs GetReturnOp(WasmTypes::WasmType type);
         WasmRegisterSpace* GetRegisterSpace(WasmTypes::WasmType type);
 
+        EmitInfo PopEvalStackForYield();
         EmitInfo PopEvalStack(WasmTypes::WasmType expectedType = WasmTypes::Any, const char16* mismatchMessage = nullptr);
         void PushEvalStack(EmitInfo);
         EmitInfo EnsureYield(BlockInfo);

--- a/lib/WasmReader/WasmFunctionInfo.h
+++ b/lib/WasmReader/WasmFunctionInfo.h
@@ -7,6 +7,14 @@
 
 namespace Wasm
 {
+    class WasmReaderBase;
+
+    struct FunctionBodyReaderInfo
+    {
+        Field(uint32) size;
+        Field(intptr_t) startOffset;
+    };
+
     class WasmFunctionInfo
     {
     public:

--- a/lib/WasmReader/WasmParseTree.h
+++ b/lib/WasmReader/WasmParseTree.h
@@ -25,6 +25,7 @@ namespace Wasm
         uint32 GetTypeByteSize(WasmType type);
         const char16* GetTypeName(WasmType type);
     }
+    typedef WasmTypes::WasmType Local;
 
     namespace ExternalKinds
     {

--- a/lib/WasmReader/WasmReader.h
+++ b/lib/WasmReader/WasmReader.h
@@ -5,67 +5,13 @@
 
 #pragma once
 
-#include "Common.h"
 
-#include "Runtime.h"
-#include "Language/WAsmjsUtils.h"
 #ifdef ENABLE_WASM
-#if ENABLE_DEBUG_CONFIG_OPTIONS
-#define TRACE_WASM(condition, ...) \
-    if (condition)\
-    {\
-        Output::Print(__VA_ARGS__); \
-        Output::Print(_u("\n")); \
-        Output::Flush(); \
-    }
 
-// Level of tracing
-#define WASM_TRACE_BODY_CHECK(phase) (GetFunctionBody() ? PHASE_TRACE(phase, GetFunctionBody()) : PHASE_TRACE1(phase))
-#define DO_WASM_TRACE_BYTECODE WASM_TRACE_BODY_CHECK(Js::WasmBytecodePhase)
-#define DO_WASM_TRACE_DECODER  WASM_TRACE_BODY_CHECK(Js::WasmReaderPhase)
-#define DO_WASM_TRACE_SECTION  WASM_TRACE_BODY_CHECK(Js::WasmSectionPhase)
-#else
-#define TRACE_WASM(...)
-#define DO_WASM_TRACE_BYTECODE (false)
-#define DO_WASM_TRACE_DECODER (false)
-#define DO_WASM_TRACE_SECTION (false)
-#endif
-#define TRACE_WASM_BYTECODE(...) TRACE_WASM(DO_WASM_TRACE_BYTECODE, __VA_ARGS__)
-#define TRACE_WASM_DECODER(...) TRACE_WASM(DO_WASM_TRACE_DECODER, __VA_ARGS__)
-#define TRACE_WASM_SECTION(...) TRACE_WASM(DO_WASM_TRACE_SECTION, __VA_ARGS__)
-
-namespace Wasm
-{
-    // forward declarations
-    struct WasmNode;
-    struct SExprParseContext;
-    class WasmFunctionInfo;
-}
-
+// These are the WasmReader related structures that are needed outside of Chakra.WasmReader lib
 #include "WasmParseTree.h"
-
-namespace Wasm
-{
-    typedef WasmTypes::WasmType Local;
-}
-
-#include "WasmReaderBase.h"
 #include "WasmSignature.h"
-#include "WasmDataSegment.h"
-#include "WasmElementSegment.h"
 #include "WasmFunctionInfo.h"
-
-#include "WasmSection.h"
-
-#include "WasmBinaryReader.h"
-#include "WasmCustomReader.h"
-#include "WasmByteCodeGenerator.h"
-
-#include "WasmGlobal.h"
-
-// TODO (michhol): cleanup includes
-#include "ByteCode/ByteCodeDumper.h"
-#include "ByteCode/AsmJsByteCodeDumper.h"
-#include "Language/AsmJsTypes.h"
+#include "WasmReaderInfo.h"
 
 #endif // ENABLE_WASM

--- a/lib/WasmReader/WasmReaderInfo.h
+++ b/lib/WasmReader/WasmReaderInfo.h
@@ -4,17 +4,19 @@
 //-------------------------------------------------------------------------------------------------------
 
 #pragma once
-#ifdef ENABLE_WASM
+
+namespace Js
+{
+class WebAssemblyModule;
+}
+
 namespace Wasm
 {
-    class WasmReaderBase
-    {
-    public:
-        virtual void SeekToFunctionBody(class WasmFunctionInfo* funcInfo) = 0;
-        virtual bool IsCurrentFunctionCompleted() const = 0;
-        virtual WasmOp ReadExpr() = 0;
-        virtual void FunctionEnd() = 0;
-        WasmNode m_currentNode;
-    };
-} // namespace Wasm
-#endif // ENABLE_WASM
+class WasmFunctionInfo;
+struct WasmReaderInfo
+{
+    Field(WasmFunctionInfo*) m_funcInfo;
+    Field(Js::WebAssemblyModule*) m_module;
+    Field(Js::Var) m_bufferSrc;
+};
+}

--- a/lib/WasmReader/WasmReaderPch.h
+++ b/lib/WasmReader/WasmReaderPch.h
@@ -6,12 +6,42 @@
 #pragma once
 
 // Parser Includes
+#include "Common.h"
+#include "Runtime.h"
 #include "WasmReader.h"
 
 #ifdef ENABLE_WASM
-// AsmJsFunctionMemory::RequiredVarConstants
-#include "../Language/AsmJsModule.h"
-#endif
+#if ENABLE_DEBUG_CONFIG_OPTIONS
+#define TRACE_WASM(condition, ...) \
+    if (condition)\
+    {\
+        Output::Print(__VA_ARGS__); \
+        Output::Print(_u("\n")); \
+        Output::Flush(); \
+    }
 
-// Runtime includes
-#include "../Runtime/Runtime.h"
+// Level of tracing
+#define WASM_TRACE_BODY_CHECK(phase) (GetFunctionBody() ? PHASE_TRACE(phase, GetFunctionBody()) : PHASE_TRACE1(phase))
+#define DO_WASM_TRACE_BYTECODE WASM_TRACE_BODY_CHECK(Js::WasmBytecodePhase)
+#define DO_WASM_TRACE_DECODER  WASM_TRACE_BODY_CHECK(Js::WasmReaderPhase)
+#define DO_WASM_TRACE_SECTION  WASM_TRACE_BODY_CHECK(Js::WasmSectionPhase)
+#else
+#define TRACE_WASM(...)
+#define DO_WASM_TRACE_BYTECODE (false)
+#define DO_WASM_TRACE_DECODER (false)
+#define DO_WASM_TRACE_SECTION (false)
+#endif
+#define TRACE_WASM_BYTECODE(...) TRACE_WASM(DO_WASM_TRACE_BYTECODE, __VA_ARGS__)
+#define TRACE_WASM_DECODER(...) TRACE_WASM(DO_WASM_TRACE_DECODER, __VA_ARGS__)
+#define TRACE_WASM_SECTION(...) TRACE_WASM(DO_WASM_TRACE_SECTION, __VA_ARGS__)
+
+#include "WasmSection.h"
+#include "WasmReaderBase.h"
+#include "WasmBinaryReader.h"
+#include "WasmCustomReader.h"
+#include "WasmGlobal.h"
+#include "WasmDataSegment.h"
+#include "WasmElementSegment.h"
+#include "WasmByteCodeGenerator.h"
+
+#endif

--- a/test/wasm/regress.js
+++ b/test/wasm/regress.js
@@ -1,0 +1,21 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft Corporation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+// Validate that it is valid to yield nothing when unreachable
+if (!WebAssembly.validate(WebAssembly.wabt.convertWast2Wasm(`
+(module
+  (func (export "foo") (result i32)
+    block (result i32)
+      loop
+        br 0
+      end
+      unreachable
+      drop
+    end)
+)`))) {
+  print("Module should be valid");
+}
+
+print("pass");

--- a/test/wasm/regress.js
+++ b/test/wasm/regress.js
@@ -3,19 +3,49 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 
-// Validate that it is valid to yield nothing when unreachable
-if (!WebAssembly.validate(WebAssembly.wabt.convertWast2Wasm(`
+const toValidate = {
+  "stack-polymorphic-yield": `
 (module
-  (func (export "foo") (result i32)
-    block (result i32)
-      loop
-        br 0
-      end
+  (func (result i32)
+    (block (result i32)
+      (loop (br 0))
       unreachable
       drop
-    end)
-)`))) {
-  print("Module should be valid");
+    )
+  )
+)`,
+  "stack-polymorphic-br_table": `
+(module
+  (func (result i32)
+    (block (result i32)
+      unreachable
+      drop
+      (br_table 0 0)
+    )
+  )
+)`,
+  "stack-polymorphic-br": `
+(module
+  (func (result i32)
+    unreachable
+    drop
+    br 0
+  )
+)`,
+  "stack-polymorphic-return": `
+(module
+  (func (result i32)
+    unreachable
+    drop
+    return
+  )
+)`,
+};
+
+for (const key in toValidate) {
+  if (!WebAssembly.validate(WebAssembly.wabt.convertWast2Wasm(toValidate[key]))) {
+    print(`Module ${key} should be valid`);
+  }
 }
 
 print("pass");

--- a/test/wasm/rlexe.xml
+++ b/test/wasm/rlexe.xml
@@ -2,6 +2,13 @@
 <regress-exe>
 <test>
   <default>
+    <files>regress.js</files>
+    <compile-flags>-wasm</compile-flags>
+    <tags>exclude_jshost,exclude_win7</tags>
+  </default>
+</test>
+<test>
+  <default>
     <files>rot.js</files>
     <baseline>rot.baseline</baseline>
     <compile-flags>-wasm</compile-flags>


### PR DESCRIPTION
Allow the eval stack to be empty when yielding values in Unreachable state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/3805)
<!-- Reviewable:end -->
