### PR TITLE
Use Unicode Windows API to print ChakraCore version (fix #3178)

### DIFF
--- a/bin/ch/ChakraRtInterface.cpp
+++ b/bin/ch/ChakraRtInterface.cpp
@@ -6,6 +6,7 @@
 
 #ifdef _WIN32
 LPCSTR chakraDllName = "chakracore.dll";
+LPCWSTR chakraDllNameW = _u("chakracore.dll");
 #else
 #include <dlfcn.h>
 #ifdef __APPLE__
@@ -23,10 +24,12 @@ ChakraRTInterface::ArgInfo* ChakraRTInterface::m_argInfo = nullptr;
 TestHooks ChakraRTInterface::m_testHooks = { 0 };
 JsAPIHooks ChakraRTInterface::m_jsApiHooks = { 0 };
 
-LPCSTR GetChakraDllName()
+#ifdef _WIN32
+LPCWSTR GetChakraDllNameW()
 {
-    return chakraDllName;
+    return chakraDllNameW;
 }
+#endif
 
 // Wrapper functions to abstract out loading ChakraCore
 // and resolving its symbols

--- a/bin/ch/ChakraRtInterface.h
+++ b/bin/ch/ChakraRtInterface.h
@@ -196,7 +196,9 @@ struct JsAPIHooks
     JsrtTTDReplayExecutionPtr pfJsrtTTDReplayExecution;
 };
 
-LPCSTR GetChakraDllName();
+#ifdef _WIN32
+LPCWSTR GetChakraDllNameW();
+#endif
 
 class ChakraRTInterface
 {

--- a/bin/ch/ch.cpp
+++ b/bin/ch/ch.cpp
@@ -105,27 +105,31 @@ void __stdcall PrintChVersion()
 #ifdef _WIN32
 void __stdcall PrintChakraCoreVersion()
 {
-    char filename[_MAX_PATH];
-    char drive[_MAX_DRIVE];
-    char dir[_MAX_DIR];
+    char16 filename[_MAX_PATH];
+    char16 drive[_MAX_DRIVE];
+    char16 dir[_MAX_DIR];
 
-    LPCSTR chakraDllName = GetChakraDllName();
+    LPCWSTR chakraDllName = GetChakraDllNameW();
 
-    char modulename[_MAX_PATH];
-    GetModuleFileNameA(NULL, modulename, _MAX_PATH);
-    _splitpath_s(modulename, drive, _MAX_DRIVE, dir, _MAX_DIR, nullptr, 0, nullptr, 0);
-    _makepath_s(filename, drive, dir, chakraDllName, nullptr);
+    char16 modulename[_MAX_PATH];
+    if (!GetModuleFileNameW(NULL, modulename, _MAX_PATH))
+    {
+        return;
+    }
+
+    _wsplitpath_s(modulename, drive, _MAX_DRIVE, dir, _MAX_DIR, nullptr, 0, nullptr, 0);
+    _wmakepath_s(filename, drive, dir, chakraDllName, nullptr);
 
     UINT size = 0;
     LPBYTE lpBuffer = NULL;
-    DWORD verSize = GetFileVersionInfoSizeA(filename, NULL);
+    DWORD verSize = GetFileVersionInfoSizeW(filename, NULL);
 
     if (verSize != NULL)
     {
         LPSTR verData = new char[verSize];
 
-        if (GetFileVersionInfoA(filename, NULL, verSize, verData) &&
-            VerQueryValue(verData, _u("\\"), (VOID FAR * FAR *)&lpBuffer, &size) &&
+        if (GetFileVersionInfoW(filename, NULL, verSize, verData) &&
+            VerQueryValueW(verData, _u("\\"), (VOID FAR * FAR *)&lpBuffer, &size) &&
             (size != 0))
         {
             VS_FIXEDFILEINFO *verInfo = (VS_FIXEDFILEINFO *)lpBuffer;
@@ -134,7 +138,7 @@ void __stdcall PrintChakraCoreVersion()
                 // Doesn't matter if you are on 32 bit or 64 bit,
                 // DWORD is always 32 bits, so first two revision numbers
                 // come from dwFileVersionMS, last two come from dwFileVersionLS
-                printf("%s version %d.%d.%d.%d\n",
+                wprintf(_u("%s version %d.%d.%d.%d\n"),
                     chakraDllName,
                     (verInfo->dwFileVersionMS >> 16) & 0xffff,
                     (verInfo->dwFileVersionMS >> 0) & 0xffff,


### PR DESCRIPTION
This PR adds a new WIN32-only function GetChakraDllNameW() to ChakraRtInterface.cpp, which returns wide string "ChakraCore.dll". In ch.cpp, the function PrintChakraCoreVersion() uses GetChakraDllNameW() and Unicode Windows APIs to obtain the file version of ChakraCore.dll, so that it will work even if the pathname contains non-ASCII characters.

Fixes #3178.

![unicodetest](https://user-images.githubusercontent.com/16713498/30884101-58a8e70e-a2dc-11e7-8a7e-9d19a34ff3a8.png)
