### PR TITLE
Fix #3040: Incorrect parsing of class expression

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -7268,7 +7268,7 @@ ParseNodePtr Parser::ParseClassDecl(BOOL isDeclaration, LPCOLESTR pNameHint, uin
     if (m_token.tk == tkEXTENDS)
     {
         m_pscan->Scan();
-        pnodeExtends = ParseExpr<buildAST>();
+        pnodeExtends = ParseTerm<buildAST>();
         hasExtends = true;
     }
 

--- a/test/es6/ES6Class_SuperChain.js
+++ b/test/es6/ES6Class_SuperChain.js
@@ -251,7 +251,8 @@ var tests = [
             function* gf(a) { yield 1 + a + this.a; }
             assert.throws(function () { class A extends gf { } }, TypeError, "Class deriving from a generator function throws TypeError", "Function is not a constructor");
 
-            assert.throws(function () { class A extends (a) => a {} }, TypeError, "Class deriving from a lambda throws TypeError", "Function is not a constructor");
+            var lambda = (a) => a;
+            assert.throws(function () { class A extends lambda { } }, TypeError, "Class deriving from a lambda throws TypeError", "Function is not a constructor");
         }
     },
     {

--- a/test/es6/classes_bugfixes.js
+++ b/test/es6/classes_bugfixes.js
@@ -483,6 +483,12 @@ var tests = [
         static igwgep() { }
       };
     }
+  },
+  {
+    name: "#3040 Class extends clause accepts LHS expressions only",
+    body: function() {
+      assert.throws(function () { eval("1,class extends[]/print(1){}"); }, SyntaxError, "Parsing extends expr should not go past a term", "Expected '{'");
+    }
   }
 ];
 


### PR DESCRIPTION
Class extends exprs should only be LHS exprs. Change to ParseTerm instead of blanket ParseExpr.
