### PR TITLE
ArrayBuffer.detach fix

### DIFF
--- a/lib/Runtime/Library/Chakra.Runtime.Library.vcxproj
+++ b/lib/Runtime/Library/Chakra.Runtime.Library.vcxproj
@@ -171,6 +171,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)VerifyMarkFalseReference.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\DetachedStateBase.h" />
     <ClInclude Include="..\InternalPropertyList.h" />
     <ClInclude Include="..\RuntimeCommon.h" />
     <ClInclude Include="..\SerializableFunctionFields.h" />

--- a/lib/Runtime/Library/Chakra.Runtime.Library.vcxproj.filters
+++ b/lib/Runtime/Library/Chakra.Runtime.Library.vcxproj.filters
@@ -258,6 +258,7 @@
     <ClInclude Include="WabtInterface.h" />
     <ClInclude Include="CustomExternalIterator.h" />
     <ClInclude Include="JavascriptExceptionMetadata.h" />
+    <ClInclude Include="..\DetachedStateBase.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="ConcatString.inl" />


### PR DESCRIPTION
Correctly free the ArrayBuffer's buffer in ArrayBuffer.Detach()
ReportExternalMemoryFree when freeing the detached ArrayBuffer's buffer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/3823)
<!-- Reviewable:end -->
