### PR TITLE
fix some errors in stack traces with inlining

### DIFF
--- a/lib/Backend/Inline.cpp
+++ b/lib/Backend/Inline.cpp
@@ -1026,6 +1026,11 @@ Inline::InlinePolymorphicFunction(IR::Instr *callInstr, const FunctionJITTimeInf
     callInstr->InsertBefore(dispatchStartLabel);
     for (uint i = 0; i < inlineeCount; i++)
     {
+        if (i > 0)
+        {
+            InsertStatementBoundary(callInstr);
+        }
+
         IR::LabelInstr* inlineeStartLabel = IR::LabelInstr::New(Js::OpCode::Label, callInstr->m_func);
         callInstr->InsertBefore(inlineeStartLabel);
         InsertOneInlinee(callInstr, returnValueOpnd, callInstr->GetSrc1(), inlineesDataArray[i], inlineesDataArray[i]->GetRuntimeInfo(), doneLabel, symCallerThis, /*fixedFunctionSafeThis*/ false, recursiveInlineDepth);

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -3365,6 +3365,15 @@ namespace Js
         SmallSpanSequence *spanSequence = entryPoint ? entryPoint->GetNativeThrowSpanSequence() : nullptr;
         int statementIndex = GetStatementIndexFromNativeOffset(spanSequence, offset);
 
+        // the offset passed in here is the offset of the Inlinee Start instruction. In some cases, the first statement of the inlinee may be mapped at that offset and would be matched 
+        // instead of matching the statement that made the call to the inlinee. In that case, to find the statement associated with the call to the inlinee we need to look earlier.
+        // We cannot alawys use the lower offset because for inlinees of inlinees the call statement and the inlinee start statement may occur at the same offset, in which case the 
+        // call statement is the one that gets matched and looking earlier would result in matching a statement from the enclosing function.
+        if (statementIndex == 0)
+        {
+            statementIndex = GetStatementIndexFromNativeOffset(spanSequence, offset - 1);
+        }
+
         return GetMatchingStatementMap(data, statementIndex, inlinee);
     }
 #endif


### PR DESCRIPTION
This commit fixes two issues with stack traces matching the wrong statements with inlined functions.
