### PR TITLE
Do not assert on cross-site CustomExternalObject thrown as exception objects as they don't need marshalling

### DIFF
--- a/lib/Runtime/Language/JavascriptExceptionObject.cpp
+++ b/lib/Runtime/Language/JavascriptExceptionObject.cpp
@@ -111,7 +111,7 @@ namespace Js
                 {
                     if (RecyclableObject::Is(rethrownObject))
                     {
-                        if (((RecyclableObject*)rethrownObject)->GetScriptContext() != requestingScriptContext)
+                        if (CrossSite::NeedMarshalVar(rethrownObject, requestingScriptContext))
                         {
                             Assert(requestingScriptContext->GetHostScriptContext());
                             HRESULT hrSecurityCheck = requestingScriptContext->GetHostScriptContext()->CheckCrossDomainScriptContext(((RecyclableObject*)rethrownObject)->GetScriptContext());


### PR DESCRIPTION
If a cross-site CEO is thrown as an exception we will not marshall it as it is an external type. But in the debugEval this cause an access denied error later when the script context is validated for the same. But we never marshall CEO's, so updating the checks accordingly.
