### PR TITLE
Allow type sharing for Object.create objects

### DIFF
--- a/lib/Runtime/Base/CMakeLists.txt
+++ b/lib/Runtime/Base/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library (Chakra.Runtime.Base OBJECT
     FunctionInfo.cpp
     LeaveScriptObject.cpp
     LineOffsetCache.cpp
+    ObjectTypeCache.cpp
     PerfHint.cpp
     PropertyRecord.cpp
     RuntimeBasePch.cpp

--- a/lib/Runtime/Base/Chakra.Runtime.Base.vcxproj
+++ b/lib/Runtime/Base/Chakra.Runtime.Base.vcxproj
@@ -52,7 +52,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)FunctionBody.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)FunctionInfo.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)LeaveScriptObject.cpp" />
-    <ClCompile Include="$(MSBuildThisFileDirectory)LineOffsetCache.cpp" />    
+    <ClCompile Include="$(MSBuildThisFileDirectory)LineOffsetCache.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)PerfHint.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)PropertyRecord.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)ScriptContext.cpp" />
@@ -77,12 +77,14 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)ThreadContextInfo.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)jitprofiling.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)VTuneChakraProfile.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)ObjectTypeCache.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="CompactCounters.h" />
     <ClInclude Include="ittnotify_config.h" />
     <ClInclude Include="ittnotify_types.h" />
     <ClInclude Include="jitprofiling.h" />
+    <ClInclude Include="ObjectTypeCache.h" />
     <ClInclude Include="RuntimeBasePch.h" />
     <ClInclude Include="AuxPtrs.h" />
     <ClInclude Include="CallInfo.h" />

--- a/lib/Runtime/Base/ObjectTypeCache.cpp
+++ b/lib/Runtime/Base/ObjectTypeCache.cpp
@@ -1,0 +1,51 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#include "RuntimeBasePch.h"
+#include "Types/PathTypeHandler.h"
+
+namespace Js
+{
+
+DynamicType* ObjectTypeCache::FindOrCreateType(_In_ RecyclableObject* prototype)
+{
+    // For fast lookup, cache index is a function of prototype address
+    const uint index = (uint)(((uintptr_t)prototype) >> PolymorphicInlineCacheShift) & (ObjectTypeCache::MaxCachedTypes - 1);
+
+    RecyclerWeakReference<RecyclableObject>* cachedWeakProto = cache[index].prototype;
+
+    // Check for nullptr, because the cache will not have a weak ref yet if this is first access
+    if (cachedWeakProto != nullptr)
+    {
+        Assert(cache[index].type != nullptr);
+
+        DynamicType* cachedType = cache[index].type->Get();
+        RecyclableObject* cachedProto = cachedWeakProto->Get();
+
+        // We can use cache if the prototypes match and the Type hasn't been collected
+        if (cachedProto == prototype && cachedType != nullptr)
+        {
+            return cachedType;
+        }
+    }
+
+    // If we didn't already have a Type in our cache, we need to create a new one
+
+    JavascriptLibrary * library = prototype->GetLibrary();
+    ScriptContext * scriptContext = library->GetScriptContext();
+
+    SimplePathTypeHandler* typeHandler = SimplePathTypeHandler::New(scriptContext, library->GetRootPath(), 0, 0, 0, true, true);
+    DynamicType* newType = DynamicType::New(scriptContext, TypeIds_Object, prototype, nullptr, typeHandler, true, true);
+
+    // Store the Type and prototype as weak references to avoid unnecessarily extending their lifetimes
+    RecyclerWeakReference<RecyclableObject> *  newWeakProtoHandle = prototype->GetRecycler()->CreateWeakReferenceHandle(prototype);
+    RecyclerWeakReference<DynamicType> * newWeakTypeHandle = prototype->GetRecycler()->CreateWeakReferenceHandle(newType);
+
+    cache[index].prototype = newWeakProtoHandle;
+    cache[index].type = newWeakTypeHandle;
+    return newType;
+}
+
+} // namespace Js

--- a/lib/Runtime/Base/ObjectTypeCache.h
+++ b/lib/Runtime/Base/ObjectTypeCache.h
@@ -1,0 +1,29 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#pragma once
+
+namespace Js
+{
+
+class ObjectTypeCache
+{
+public:
+    static const uint MaxCachedTypes = 32;
+
+private:
+    struct CacheEntry
+    {
+        Field(RecyclerWeakReference<RecyclableObject>*) prototype;
+        Field(RecyclerWeakReference<DynamicType>*) type;
+    };
+
+    CacheEntry cache[MaxCachedTypes];
+
+public:
+    DynamicType* FindOrCreateType(_In_ RecyclableObject* prototype);
+};
+
+} // namespace Js

--- a/lib/Runtime/Language/ModuleNamespace.cpp
+++ b/lib/Runtime/Language/ModuleNamespace.cpp
@@ -7,7 +7,6 @@
 #include "Types/PropertyIndexRanges.h"
 #include "Types/SimpleDictionaryPropertyDescriptor.h"
 #include "Types/SimpleDictionaryTypeHandler.h"
-#include "Types/NullTypeHandler.h"
 #include "ModuleNamespace.h"
 #include "ModuleNamespaceEnumerator.h"
 

--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -653,8 +653,7 @@ namespace Js
                 DynamicType::New(scriptContext, TypeIds_Object, objectPrototype, nullptr, typeHandler, true, true);
         }
 
-        SimplePathTypeHandler * typeHandler = SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, sizeof(DynamicObject), true, true);
-        typeHandler->SetIsInlineSlotCapacityLocked();
+        SimplePathTypeHandler * typeHandler = SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, 0, true, true);
         nullPrototypeObjectType = DynamicType::New(scriptContext, TypeIds_Object, nullValue, nullptr, typeHandler, true, true);
 
         // Initialize regex types
@@ -7276,56 +7275,22 @@ namespace Js
     }
 #endif
 
-    // Finds or creates a shareable DynamicType for Object.create
-    DynamicType* JavascriptLibrary::GetObjectCreateType(_In_ RecyclableObject* prototype)
+    DynamicType* JavascriptLibrary::GetObjectType(_In_ RecyclableObject* prototype)
     {
-        // If prototype is Object.prototype, we can use our normal Object Type
+        // If prototype is Object.prototype, use our normal Object Type
         if (this->GetObjectPrototype() == prototype)
         {
             return GetObjectType();
         }
 
-        // Object.create(null) is a common case, so we can keep a Type especially for this
+        // Object.create(null) is a common case, so we keep a Type especially for this
         if (JavascriptOperators::IsNull(prototype))
         {
             return this->GetNullPrototypeObjectType();
         }
 
-        // If prototype is some other object, check our cache see if we already have a Type available
-
-        // For fast lookup, cache index is a function of prototype address
-        const uint cacheIndex = (uint)(((uintptr_t)prototype) >> PolymorphicInlineCacheShift) & (ObjectCreateTypeCache::MaxCachedTypes - 1);
-
-        RecyclerWeakReference<RecyclableObject>* cachedWeakProto = this->cache.objectCreateTypeCache[cacheIndex].prototype;
-
-        // Check for nullptr, because the cache will not have a weak ref yet if this is first access
-        if (cachedWeakProto != nullptr)
-        {
-            Assert(this->cache.objectCreateTypeCache[cacheIndex].type != nullptr);
-
-            DynamicType* cachedType = this->cache.objectCreateTypeCache[cacheIndex].type->Get();
-            RecyclableObject* cachedProto = cachedWeakProto->Get();
-
-            // We can use cache if the prototypes match and the Type hasn't been collected
-            if (cachedProto == prototype && cachedType != nullptr)
-            {
-                return cachedType;
-            }
-        }
-
-        // If we didn't already have a Type in our cache, we need to create a new one
-
-        SimplePathTypeHandler* typeHandler = SimplePathTypeHandler::New(scriptContext, this->GetRootPath(), 0, 0, sizeof(DynamicObject), true, true);
-        typeHandler->SetIsInlineSlotCapacityLocked();
-        DynamicType* newType = DynamicType::New(scriptContext, TypeIds_Object, prototype, nullptr, typeHandler, true, true);
-
-        // Store the Type and prototype as weak references to avoid unnecessarily extending their lifetimes
-        RecyclerWeakReference<RecyclableObject> *  newWeakProtoHandle = this->GetRecycler()->CreateWeakReferenceHandle(prototype);
-        RecyclerWeakReference<DynamicType> * newWeakTypeHandle = this->GetRecycler()->CreateWeakReferenceHandle(newType);
-
-        this->cache.objectCreateTypeCache[cacheIndex].prototype = newWeakProtoHandle;
-        this->cache.objectCreateTypeCache[cacheIndex].type = newWeakTypeHandle;
-        return newType;
+        // If prototype is some other object, find/add one to the cache
+        return this->cache.objectTypeCache->FindOrCreateType(prototype);
     }
 
     // Parses given flags and arg kind (dst or src1, or src2) returns the type the arg must be type-specialized to.

--- a/lib/Runtime/Library/JavascriptLibrary.h
+++ b/lib/Runtime/Library/JavascriptLibrary.h
@@ -55,6 +55,13 @@ namespace Js
         Field(int) validPropStrings;
     };
 
+    struct ObjectCreateTypeCache
+    {
+        static const uint MaxCachedTypes = 32;
+        Field(RecyclerWeakReference<RecyclableObject>*) prototype;
+        Field(RecyclerWeakReference<DynamicType>*) type;
+    };
+
     struct PropertyStringMap
     {
         Field(PropertyString*) strLen2[80];
@@ -71,6 +78,7 @@ namespace Js
         Field(PropertyStringMap*) propertyStrings[80];
         Field(JavascriptString *) lastNumberToStringRadix10String;
         Field(EnumeratedObjectCache) enumObjCache;
+        Field(ObjectCreateTypeCache) objectCreateTypeCache[ObjectCreateTypeCache::MaxCachedTypes];
         Field(JavascriptString *) lastUtcTimeFromStrString;
         Field(EvalCacheDictionary*) evalCacheDictionary;
         Field(EvalCacheDictionary*) indirectEvalCacheDictionary;
@@ -360,6 +368,7 @@ namespace Js
         Field(DynamicType *) numberTypeDynamic;
         Field(DynamicType *) objectTypes[PreInitializedObjectTypeCount];
         Field(DynamicType *) objectHeaderInlinedTypes[PreInitializedObjectTypeCount];
+        Field(DynamicType *) nullPrototypeObjectType;
         Field(DynamicType *) regexPrototypeType;
         Field(DynamicType *) regexType;
         Field(DynamicType *) regexResultType;
@@ -813,6 +822,8 @@ namespace Js
         DynamicType * GetObjectLiteralType(uint16 requestedInlineSlotCapacity);
         DynamicType * GetObjectHeaderInlinedLiteralType(uint16 requestedInlineSlotCapacity);
         DynamicType * GetObjectType() const { return objectTypes[0]; }
+        DynamicType * GetNullPrototypeObjectType() const { return nullPrototypeObjectType; }
+        DynamicType * GetObjectCreateType(_In_ RecyclableObject* prototype);
         DynamicType * GetObjectHeaderInlinedType() const { return objectHeaderInlinedTypes[0]; }
         StaticType  * GetSymbolTypeStatic() const { return symbolTypeStatic; }
         DynamicType * GetSymbolTypeDynamic() const { return symbolTypeDynamic; }

--- a/lib/Runtime/Library/JavascriptLibrary.h
+++ b/lib/Runtime/Library/JavascriptLibrary.h
@@ -55,13 +55,6 @@ namespace Js
         Field(int) validPropStrings;
     };
 
-    struct ObjectCreateTypeCache
-    {
-        static const uint MaxCachedTypes = 32;
-        Field(RecyclerWeakReference<RecyclableObject>*) prototype;
-        Field(RecyclerWeakReference<DynamicType>*) type;
-    };
-
     struct PropertyStringMap
     {
         Field(PropertyString*) strLen2[80];
@@ -78,7 +71,7 @@ namespace Js
         Field(PropertyStringMap*) propertyStrings[80];
         Field(JavascriptString *) lastNumberToStringRadix10String;
         Field(EnumeratedObjectCache) enumObjCache;
-        Field(ObjectCreateTypeCache) objectCreateTypeCache[ObjectCreateTypeCache::MaxCachedTypes];
+        Field(ObjectTypeCache) objectTypeCache[ObjectTypeCache::MaxCachedTypes];
         Field(JavascriptString *) lastUtcTimeFromStrString;
         Field(EvalCacheDictionary*) evalCacheDictionary;
         Field(EvalCacheDictionary*) indirectEvalCacheDictionary;
@@ -823,7 +816,6 @@ namespace Js
         DynamicType * GetObjectHeaderInlinedLiteralType(uint16 requestedInlineSlotCapacity);
         DynamicType * GetObjectType() const { return objectTypes[0]; }
         DynamicType * GetNullPrototypeObjectType() const { return nullPrototypeObjectType; }
-        DynamicType * GetObjectCreateType(_In_ RecyclableObject* prototype);
         DynamicType * GetObjectHeaderInlinedType() const { return objectHeaderInlinedTypes[0]; }
         StaticType  * GetSymbolTypeStatic() const { return symbolTypeStatic; }
         DynamicType * GetSymbolTypeDynamic() const { return symbolTypeDynamic; }
@@ -1088,6 +1080,9 @@ namespace Js
         DynamicType* CreateObjectTypeNoCache(RecyclableObject* prototype, Js::TypeId typeId);
         DynamicType* CreateObjectType(RecyclableObject* prototype, uint16 requestedInlineSlotCapacity);
         DynamicObject* CreateObject(RecyclableObject* prototype, uint16 requestedInlineSlotCapacity = 0);
+
+        // Finds or creates a shareable DynamicType with a given prototype object
+        DynamicType * GetObjectType(_In_ RecyclableObject* prototype);
 
         typedef JavascriptString* LibStringType; // used by diagnostics template
         template< size_t N > JavascriptString* CreateStringFromCppLiteral(const char16 (&value)[N]) const;

--- a/lib/Runtime/Library/JavascriptObject.cpp
+++ b/lib/Runtime/Library/JavascriptObject.cpp
@@ -1622,7 +1622,7 @@ namespace Js
 
         // Find/create a DynamicType for the given prototype
         RecyclableObject* protoObj = RecyclableObject::FromVar(protoVar);
-        DynamicType* objectType = function->GetLibrary()->GetObjectCreateType(protoObj);
+        DynamicType* objectType = function->GetLibrary()->GetObjectType(protoObj);
 
         DynamicObject* object = DynamicObject::New(recycler, objectType);
         JS_ETW(EventWriteJSCRIPT_RECYCLER_ALLOCATE_OBJECT(object));

--- a/lib/Runtime/Library/JavascriptObject.cpp
+++ b/lib/Runtime/Library/JavascriptObject.cpp
@@ -3,7 +3,6 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #include "RuntimeLibraryPch.h"
-#include "Types/NullTypeHandler.h"
 
 namespace Js
 {
@@ -1615,17 +1614,16 @@ namespace Js
             JavascriptError::ThrowTypeError(scriptContext, JSERR_FunctionArgument_NotObjectOrNull, _u("Object.create"));
         }
 
-        TypeId typeId = JavascriptOperators::GetTypeId(args[1]);
-        if (typeId != TypeIds_Null && !JavascriptOperators::IsObjectType(typeId))
+        Var protoVar = args[1];
+        if (!JavascriptOperators::IsObjectOrNull(protoVar))
         {
             JavascriptError::ThrowTypeError(scriptContext, JSERR_FunctionArgument_NotObjectOrNull, _u("Object.create"));
         }
 
-        //Create a new DynamicType with first argument as prototype and non shared type
-        RecyclableObject *prototype = RecyclableObject::FromVar(args[1]);
-        DynamicType *objectType = DynamicType::New(scriptContext, TypeIds_Object, prototype, nullptr, NullTypeHandler<false>::GetDefaultInstance(), false);
+        // Find/create a DynamicType for the given prototype
+        RecyclableObject* protoObj = RecyclableObject::FromVar(protoVar);
+        DynamicType* objectType = function->GetLibrary()->GetObjectCreateType(protoObj);
 
-        //Create a new Object using this type.
         DynamicObject* object = DynamicObject::New(recycler, objectType);
         JS_ETW(EventWriteJSCRIPT_RECYCLER_ALLOCATE_OBJECT(object));
 #if ENABLE_DEBUG_CONFIG_OPTIONS

--- a/lib/Runtime/Runtime.h
+++ b/lib/Runtime/Runtime.h
@@ -447,6 +447,7 @@ enum tagDEBUG_EVENT_INFO_TYPE
 #include "Library/CustomExternalIterator.h"
 
 #include "Base/CharStringCache.h"
+#include "Base/ObjectTypeCache.h"
 
 #include "Library/JavascriptObject.h"
 #include "Library/BuiltInFlags.h"


### PR DESCRIPTION
Object.create was always using null type handler, which meant that types could not be shared, which leads to all sorts of badness (e.g. our inline caches won't really work for these objects).

I've done a few things to make this better:
Use the normal Object type if prototype is Object.prototype
Use a new shared type for the case of null prototype (saved on javascriptLibrary)
Attempt to share types for other prototypes using a small global cache

Improves perf of Angular by about 25%.