### PR TITLE
OS#13885461 WASM: Jit loop body yield restore

### DIFF
--- a/lib/Backend/IRBuilderAsmJs.cpp
+++ b/lib/Backend/IRBuilderAsmJs.cpp
@@ -86,7 +86,7 @@ IRBuilderAsmJs::Build()
     m_functionStartOffset = m_jnReader.GetCurrentOffset();
     m_lastInstr = m_func->m_headInstr;
 
-    AssertMsg(sizeof(SymID) >= sizeof(Js::RegSlot), "sizeof(SymID) != sizeof(Js::RegSlot)!!");
+    CompileAssert(sizeof(SymID) == sizeof(Js::RegSlot));
 
     offset = m_functionStartOffset;
 
@@ -97,10 +97,10 @@ IRBuilderAsmJs::Build()
     uint32 offsetToInstructionCount = lastOffset;
     if (this->IsLoopBody())
     {
-        // LdSlot needs to cover all the register, including the temps, because we might treat
-        // those as if they are local for the value of the with statement
+        // LdSlot & StSlot needs to cover all the register, including the temps, because we might treat
+        // those as if they are local for yielding
         this->m_ldSlots = BVFixed::New<JitArenaAllocator>(GetLastTmp(WAsmJs::LastType), m_tempAlloc);
-        this->m_stSlots = BVFixed::New<JitArenaAllocator>(GetFirstTmp(WAsmJs::FirstType), m_tempAlloc);
+        this->m_stSlots = BVFixed::New<JitArenaAllocator>(GetLastTmp(WAsmJs::FirstType), m_tempAlloc);
         this->m_loopBodyRetIPSym = StackSym::New(TyInt32, this->m_func);
 #if DBG
         uint32 tmpCount = GetLastTmp(WAsmJs::LastType) - GetFirstTmp(WAsmJs::FirstType);
@@ -315,7 +315,7 @@ IRBuilderAsmJs::BuildDstOpnd(Js::RegSlot dstRegSlot, IRType type)
         else if (IsLoopBody() && RegIsVar(dstRegSlot))
         {
             // Loop body and not constants
-            this->m_stSlots->Set(symID);
+            this->m_stSlots->Set(dstRegSlot);
             // We need to make sure that the symbols is loaded as well
             // so that the sym will be defined on all path.
             this->EnsureLoopBodyAsmJsLoadSlot(symID, type);
@@ -371,7 +371,7 @@ IRBuilderAsmJs::BuildIntConstOpnd(Js::RegSlot regSlot)
 SymID
 IRBuilderAsmJs::BuildSrcStackSymID(Js::RegSlot regSlot, IRType type /*= IRType::TyVar*/)
 {
-    SymID symID;
+    SymID symID = static_cast<SymID>(regSlot);
 
     if (this->RegIsTemp(regSlot))
     {
@@ -387,17 +387,15 @@ IRBuilderAsmJs::BuildSrcStackSymID(Js::RegSlot regSlot, IRType type /*= IRType::
 
             symID = static_cast<SymID>(regSlot);
             this->SetMappedTemp(regSlot, symID);
-            this->EnsureLoopBodyAsmJsLoadSlot(symID, type);
+            this->EnsureLoopBodyAsmJsLoadSlot(regSlot, type);
         }
         this->SetTempUsed(regSlot, TRUE);
     }
     else
     {
-        symID = static_cast<SymID>(regSlot);
         if (IsLoopBody() && RegIsVar(regSlot))
         {
-            this->EnsureLoopBodyAsmJsLoadSlot(symID, type);
-
+            this->EnsureLoopBodyAsmJsLoadSlot(regSlot, type);
         }
         else
         {
@@ -552,7 +550,7 @@ IRBuilderAsmJs::SetMappedTemp(Js::RegSlot reg, SymID tempId)
     m_tempMap[tempIndex] = tempId;
 }
 
-BOOL
+bool
 IRBuilderAsmJs::GetTempUsed(Js::RegSlot reg)
 {
     AssertMsg(RegIsTemp(reg), "Processing non-temp reg as a temp?");
@@ -560,11 +558,11 @@ IRBuilderAsmJs::GetTempUsed(Js::RegSlot reg)
 
     Js::RegSlot tempIndex = reg - GetFirstTmp(WAsmJs::FirstType);
     AssertOrFailFast(tempIndex < m_tempCount);
-    return m_fbvTempUsed->Test(tempIndex);
+    return !!m_fbvTempUsed->Test(tempIndex);
 }
 
 void
-IRBuilderAsmJs::SetTempUsed(Js::RegSlot reg, BOOL used)
+IRBuilderAsmJs::SetTempUsed(Js::RegSlot reg, bool used)
 {
     AssertMsg(RegIsTemp(reg), "Processing non-temp reg as a temp?");
     AssertMsg(m_fbvTempUsed, "Processing non-temp reg without a used BV?");
@@ -581,13 +579,13 @@ IRBuilderAsmJs::SetTempUsed(Js::RegSlot reg, BOOL used)
     }
 }
 
-BOOL
+bool
 IRBuilderAsmJs::RegIsTemp(Js::RegSlot reg)
 {
     return reg >= GetFirstTmp(WAsmJs::FirstType);
 }
 
-BOOL
+bool
 IRBuilderAsmJs::RegIsVar(Js::RegSlot reg)
 {
     for (int i = 0; i < WAsmJs::LIMIT; ++i)
@@ -600,10 +598,31 @@ IRBuilderAsmJs::RegIsVar(Js::RegSlot reg)
     return false;
 }
 
-BOOL
+bool
 IRBuilderAsmJs::RegIsTypedVar(Js::RegSlot reg, WAsmJs::Types type)
 {
     return reg >= GetFirstVar(type) && reg < GetLastVar(type);
+}
+
+bool
+IRBuilderAsmJs::RegIsTypedConst(Js::RegSlot reg, WAsmJs::Types type)
+{
+    return reg >= GetFirstConst(type) && reg < GetLastConst(type);
+}
+
+bool
+IRBuilderAsmJs::RegIsTypedTmp(Js::RegSlot reg, WAsmJs::Types type)
+{
+    return reg >= GetFirstTmp(type) && reg < GetLastTmp(type);
+}
+
+bool IRBuilderAsmJs::RegIs(Js::RegSlot reg, WAsmJs::Types type)
+{
+    return (
+        RegIsTypedVar(reg, type) ||
+        RegIsTypedConst(reg, type) ||
+        RegIsTypedTmp(reg, type)
+    );
 }
 
 bool
@@ -612,7 +631,7 @@ IRBuilderAsmJs::RegIsSimd128ReturnVar(Js::RegSlot reg)
     return (reg == GetFirstConst(WAsmJs::SIMD) &&
             Js::AsmJsRetType(m_asmFuncInfo->GetRetType()).toVarType().isSIMD());
 }
-BOOL
+bool
 IRBuilderAsmJs::RegIsConstant(Js::RegSlot reg)
 {
     return (reg > 0 && reg < GetLastConst(WAsmJs::LastType));
@@ -2395,8 +2414,8 @@ IRBuilderAsmJs::BuildInt2(Js::OpCodeAsmJs newOpcode, uint32 offset, Js::RegSlot 
         instr = IR::Instr::New(Js::OpCode::Ld_I4, dstOpnd, srcOpnd, m_func);
         if (m_func->IsLoopBody())
         {
-            IR::Instr* slotInstr = GenerateStSlotForReturn(srcOpnd, IRType::TyInt32);
-            AddInstr(slotInstr, offset);
+            // Make sure we set that slot when done with the loop
+            this->m_stSlots->Set(dstRegSlot);
         }
 
         break;
@@ -2661,8 +2680,8 @@ IRBuilderAsmJs::BuildDouble2(Js::OpCodeAsmJs newOpcode, uint32 offset, Js::RegSl
         instr = IR::Instr::New(Js::OpCode::Ld_A, dstOpnd, srcOpnd, m_func);
         if (m_func->IsLoopBody())
         {
-            IR::Instr* slotInstr = GenerateStSlotForReturn(srcOpnd, IRType::TyFloat64);
-            AddInstr(slotInstr, offset);
+            // Make sure we set that slot when done with the loop
+            this->m_stSlots->Set(dstRegSlot);
         }
         break;
     case Js::OpCodeAsmJs::Trunc_Db:
@@ -2714,8 +2733,8 @@ IRBuilderAsmJs::BuildFloat2(Js::OpCodeAsmJs newOpcode, uint32 offset, Js::RegSlo
         instr = IR::Instr::New(Js::OpCode::Ld_A, dstOpnd, srcOpnd, m_func);
         if (m_func->IsLoopBody())
         {
-            IR::Instr* slotInstr = GenerateStSlotForReturn(srcOpnd, IRType::TyFloat32);
-            AddInstr(slotInstr, offset);
+            // Make sure we set that slot when done with the loop
+            this->m_stSlots->Set(dstRegSlot);
         }
         break;
     case Js::OpCodeAsmJs::Trunc_Flt:
@@ -3066,8 +3085,8 @@ IRBuilderAsmJs::BuildLong2(Js::OpCodeAsmJs newOpcode, uint32 offset, Js::RegSlot
         instr = IR::Instr::New(Js::OpCode::Ld_I4, dstOpnd, srcOpnd, m_func);
         if (m_func->IsLoopBody())
         {
-            IR::Instr* slotInstr = GenerateStSlotForReturn(srcOpnd, IRType::TyInt64);
-            AddInstr(slotInstr, offset);
+            // Make sure we set that slot when done with the loop
+            this->m_stSlots->Set(dstRegSlot);
         }
         break;
     case Js::OpCodeAsmJs::I64Extend8_s:
@@ -3457,15 +3476,16 @@ IRBuilderAsmJs::InsertLoopBodyReturnIPInstr(uint targetOffset, uint offset)
 }
 
 IR::SymOpnd *
-IRBuilderAsmJs::BuildAsmJsLoopBodySlotOpnd(SymID symId, IRType opndType)
+IRBuilderAsmJs::BuildAsmJsLoopBodySlotOpnd(Js::RegSlot regSlot, IRType opndType)
 {
+    Assert(IsLoopBody());
     // There is no unsigned locals, make sure we create only signed locals
     opndType = IRType_EnsureSigned(opndType);
     // Get the interpreter frame instance that was passed in.
     StackSym *loopParamSym = m_func->EnsureLoopParamSym();
 
     // property ID is the offset
-    Js::PropertyId propOffSet = CalculatePropertyOffset(symId, opndType);
+    Js::PropertyId propOffSet = CalculatePropertyOffset(regSlot, opndType);
 
     // Get the bytecodeRegSlot and Get the offset from m_localSlots
     PropertySym * fieldSym = PropertySym::FindOrCreate(loopParamSym->m_id, propOffSet, (uint32)-1, (uint)-1, PropertyKindLocalSlots, m_func);
@@ -3473,16 +3493,17 @@ IRBuilderAsmJs::BuildAsmJsLoopBodySlotOpnd(SymID symId, IRType opndType)
 }
 
 void
-IRBuilderAsmJs::EnsureLoopBodyAsmJsLoadSlot(SymID symId, IRType type)
+IRBuilderAsmJs::EnsureLoopBodyAsmJsLoadSlot(Js::RegSlot regSlot, IRType type)
 {
-    if (this->m_ldSlots->TestAndSet(symId))
+    Assert(IsLoopBody());
+    if (this->m_ldSlots->TestAndSet(regSlot))
     {
         return;
     }
 
-    IR::SymOpnd * fieldSymOpnd = this->BuildAsmJsLoopBodySlotOpnd(symId, type);
+    IR::SymOpnd * fieldSymOpnd = this->BuildAsmJsLoopBodySlotOpnd(regSlot, type);
 
-    StackSym * symDst = StackSym::FindOrCreate(symId, (Js::RegSlot)symId, m_func, fieldSymOpnd->GetType());
+    StackSym * symDst = StackSym::FindOrCreate(static_cast<SymID>(regSlot), regSlot, m_func, fieldSymOpnd->GetType());
     IR::RegOpnd * dstOpnd = IR::RegOpnd::New(symDst, symDst->GetType(), m_func);
     IR::Instr * ldSlotInstr = IR::Instr::New(Js::OpCode::LdSlot, dstOpnd, fieldSymOpnd, m_func);
 
@@ -3514,70 +3535,64 @@ IRBuilderAsmJs::GenerateLoopBodySlotAccesses(uint offset)
     IR::Instr *instrArgIn = IR::Instr::New(Js::OpCode::ArgIn_A, loopParamOpnd, srcOpnd, m_func);
     m_func->m_headInstr->InsertAfter(instrArgIn);
 
-    GenerateLoopBodyStSlots(loopParamSym->m_id, offset);
+    if (this->m_stSlots->Count() > 0)
+    {
+        SymID loopParamSymId = loopParamSym->m_id;
+
+        FOREACH_BITSET_IN_FIXEDBV(index, this->m_stSlots)
+        {
+            Js::RegSlot regSlot = (Js::RegSlot)index;
+            IRType type = IRType::TyInt32;
+            ValueType valueType = ValueType::GetInt(false);
+            if (RegIs(regSlot, WAsmJs::INT32))
+            {
+                type = IRType::TyInt32;
+                valueType = ValueType::GetInt(false);
+            }
+            else if (RegIs(regSlot, WAsmJs::FLOAT32))
+            {
+                type = IRType::TyFloat32;
+                valueType = ValueType::Float;
+            }
+            else if (RegIs(regSlot, WAsmJs::FLOAT64))
+            {
+                type = IRType::TyFloat64;
+                valueType = ValueType::Float;
+            }
+            else if (RegIs(regSlot, WAsmJs::INT64))
+            {
+                type = IRType::TyInt64;
+                valueType = ValueType::GetInt(false);
+            }
+            else if (RegIs(regSlot, WAsmJs::SIMD))
+            {
+                type = IRType::TySimd128F4;
+                // SIMD regs are non-typed. There is no way to know the incoming SIMD type to a StSlot after a loop body, so we pick any type.
+                // However, at this point all src syms are already defined and assigned a type.
+                valueType = ValueType::GetObject(ObjectType::UninitializedObject);
+            }
+            else
+            {
+                AnalysisAssert(UNREACHED);
+            }
+
+            Js::PropertyId propOffSet = CalculatePropertyOffset(regSlot, type);
+            IR::RegOpnd* regOpnd = this->BuildSrcOpnd(regSlot, type);
+            regOpnd->SetValueType(valueType);
+
+            // Get the bytecodeRegSlot and Get the offset from m_localSlots
+            PropertySym * fieldSym = PropertySym::FindOrCreate(loopParamSymId, propOffSet, (uint32)-1, (uint)-1, PropertyKindLocalSlots, m_func);
+
+            IR::SymOpnd * fieldSymOpnd = IR::SymOpnd::New(fieldSym, regOpnd->GetType(), m_func);
+            Js::OpCode opcode = Js::OpCode::StSlot;
+            IR::Instr * stSlotInstr = IR::Instr::New(opcode, fieldSymOpnd, regOpnd, m_func);
+            this->AddInstr(stSlotInstr, offset);
+        }
+        NEXT_BITSET_IN_FIXEDBV;
+    }
 }
 
-void
-IRBuilderAsmJs::GenerateLoopBodyStSlots(SymID loopParamSymId, uint offset)
-{
-    if (this->m_stSlots->Count() == 0)
-    {
-        return;
-    }
-
-    FOREACH_BITSET_IN_FIXEDBV(regSlot, this->m_stSlots)
-    {
-        Assert(!this->RegIsConstant((Js::RegSlot)regSlot));
-        IRType type = IRType::TyInt32;
-        ValueType valueType = ValueType::GetInt(false);
-        if (RegIsIntVar(regSlot))
-        {
-            type = IRType::TyInt32;
-            valueType = ValueType::GetInt(false);
-        }
-        else if (RegIsFloatVar(regSlot))
-        {
-            type = IRType::TyFloat32;
-            valueType = ValueType::Float;
-        }
-        else if (RegIsDoubleVar(regSlot))
-        {
-            type = IRType::TyFloat64;
-            valueType = ValueType::Float;
-        }
-        else if (RegIsInt64Var(regSlot))
-        {
-            type = IRType::TyInt64;
-            valueType = ValueType::GetInt(false);
-        }
-        else if (RegIsSimd128Var(regSlot))
-        {
-            type = IRType::TySimd128F4;
-            // SIMD regs are non-typed. There is no way to know the incoming SIMD type to a StSlot after a loop body, so we pick any type.
-            // However, at this point all src syms are already defined and assigned a type.
-            valueType = ValueType::GetObject(ObjectType::UninitializedObject);
-        }
-        else
-        {
-            AnalysisAssert(UNREACHED);
-        }
-
-        Js::PropertyId propOffSet = CalculatePropertyOffset(regSlot, type);
-        IR::RegOpnd* regOpnd = this->BuildSrcOpnd((Js::RegSlot)regSlot, type);
-        regOpnd->SetValueType(valueType);
-
-        // Get the bytecodeRegSlot and Get the offset from m_localSlots
-        PropertySym * fieldSym = PropertySym::FindOrCreate(loopParamSymId, propOffSet, (uint32)-1, (uint)-1, PropertyKindLocalSlots, m_func);
-
-        IR::SymOpnd * fieldSymOpnd = IR::SymOpnd::New(fieldSym, regOpnd->GetType(), m_func);
-        Js::OpCode opcode = Js::OpCode::StSlot;
-        IR::Instr * stSlotInstr = IR::Instr::New(opcode, fieldSymOpnd, regOpnd, m_func);
-        this->AddInstr(stSlotInstr, offset);
-    }
-    NEXT_BITSET_IN_FIXEDBV;
-}
-
-Js::PropertyId IRBuilderAsmJs::CalculatePropertyOffset(SymID id, IRType type, bool isVar)
+Js::PropertyId IRBuilderAsmJs::CalculatePropertyOffset(Js::RegSlot regSlot, IRType type)
 {
     // Compute the offset to the start of the interpreter frame's locals array as a Var index.
     size_t localsOffset = 0;
@@ -3588,33 +3603,8 @@ Js::PropertyId IRBuilderAsmJs::CalculatePropertyOffset(SymID id, IRType type, bo
     Assert(localsOffset % sizeof(AsmJsSIMDValue) == 0);
     WAsmJs::Types asmType = WAsmJs::FromIRType(type);
     const auto typedInfo = m_asmFuncInfo->GetTypedSlotInfo(asmType);
-    uint32 regSlot = 0;
-    if (isVar)
-    {
-        // Get the bytecodeRegSlot
-        regSlot = id - GetFirstVar(asmType) + typedInfo.constCount;
-    }
-
-    return (Js::PropertyId)(regSlot * TySize[type] + typedInfo.byteOffset + localsOffset);
-}
-
-IR::Instr* IRBuilderAsmJs::GenerateStSlotForReturn(IR::RegOpnd* srcOpnd, IRType retType)
-{
-    // Compute the offset to the start of the interpreter frame's locals array as a Var index.
-    size_t localsOffset = 0;
-    if (!m_IsTJLoopBody)
-    {
-        localsOffset = Js::InterpreterStackFrame::GetOffsetOfLocals();
-    }
-    Assert(localsOffset % sizeof(AsmJsSIMDValue) == 0);
-    StackSym *loopParamSym = m_func->EnsureLoopParamSym();
-    Js::PropertyId propOffSet = CalculatePropertyOffset(0, retType, false);
-    // Get the bytecodeRegSlot and Get the offset from m_localSlots
-    PropertySym * fieldSym = PropertySym::FindOrCreate(loopParamSym->m_id, propOffSet, (uint32)-1, (uint)-1, PropertyKindLocalSlots, m_func);
-    IR::SymOpnd * fieldSymOpnd = IR::SymOpnd::New(fieldSym, srcOpnd->GetType(), m_func);
-    Js::OpCode opcode = Js::OpCode::StSlot;
-    IR::Instr * stSlotInstr = IR::Instr::New(opcode, fieldSymOpnd, srcOpnd, m_func);
-    return stSlotInstr;
+    uint32 bytecodeRegSlot = GetTypedRegFromRegSlot(regSlot, asmType);
+    return (Js::PropertyId)(bytecodeRegSlot * TySize[type] + typedInfo.byteOffset + localsOffset);
 }
 
 Js::OpCode IRBuilderAsmJs::GetSimdOpcode(Js::OpCodeAsmJs asmjsOpcode)
@@ -4570,8 +4560,8 @@ IRBuilderAsmJs::BuildFloat64x2_2(Js::OpCodeAsmJs newOpcode, uint32 offset, BUILD
     case Js::OpCodeAsmJs::Simd128_Return_D2:
     if (m_func->IsLoopBody())
     {
-        IR::Instr* slotInstr = GenerateStSlotForReturn(src1Opnd, IRType::TySimd128D2);
-        AddInstr(slotInstr, offset);
+        // Make sure we set that slot when done with the loop
+        this->m_stSlots->Set(dstRegSlot);
     }
     opcode = Js::OpCode::Ld_A;
     break;
@@ -6286,8 +6276,8 @@ void IRBuilderAsmJs::BuildSimd_2(Js::OpCodeAsmJs newOpcode, uint32 offset, Js::R
     case Js::OpCodeAsmJs::Simd128_Return_B16:
         if (m_func->IsLoopBody())
         {
-            IR::Instr* slotInstr = GenerateStSlotForReturn(src1Opnd, simdType);
-            AddInstr(slotInstr, offset);
+            // Make sure we set that slot when done with the loop
+            this->m_stSlots->Set(dstRegSlot);
         }
         opcode = Js::OpCode::Ld_A;
         break;

--- a/lib/Backend/IRBuilderAsmJs.h
+++ b/lib/Backend/IRBuilderAsmJs.h
@@ -61,10 +61,8 @@ private:
     void                    AddInstr(IR::Instr * instr, uint32 offset);
     bool                    IsLoopBody()const;
     uint                    GetLoopBodyExitInstrOffset() const;
-    IR::SymOpnd *           BuildLoopBodySlotOpnd(SymID symId);
-    IR::SymOpnd *           BuildAsmJsLoopBodySlotOpnd(SymID symId, IRType opndType);
-    void                    EnsureLoopBodyLoadSlot(SymID symId);
-    void                    EnsureLoopBodyAsmJsLoadSlot(SymID symId, IRType type);
+    IR::SymOpnd *           BuildAsmJsLoopBodySlotOpnd(Js::RegSlot regSlot, IRType opndType);
+    void                    EnsureLoopBodyAsmJsLoadSlot(Js::RegSlot regSlot, IRType type);
     bool                    IsLoopBodyOuterOffset(uint offset) const;
     bool                    IsLoopBodyReturnIPInstr(IR::Instr * instr) const;
     IR::Opnd *              InsertLoopBodyReturnIPInstr(uint targetOffset, uint offset);
@@ -113,17 +111,15 @@ private:
     bool                    RegIsSimd128ReturnVar(Js::RegSlot reg);
     SymID                   GetMappedTemp(Js::RegSlot reg);
     void                    SetMappedTemp(Js::RegSlot reg, SymID tempId);
-    BOOL                    GetTempUsed(Js::RegSlot reg);
-    void                    SetTempUsed(Js::RegSlot reg, BOOL used);
-    BOOL                    RegIsTemp(Js::RegSlot reg);
-    BOOL                    RegIsConstant(Js::RegSlot reg);
-    BOOL                    RegIsVar(Js::RegSlot reg);
-    BOOL                    RegIsTypedVar(Js::RegSlot reg, WAsmJs::Types type);
-    BOOL                    RegIsIntVar(Js::RegSlot reg) {return RegIsTypedVar(reg, WAsmJs::INT32);}
-    BOOL                    RegIsInt64Var(Js::RegSlot reg) {return RegIsTypedVar(reg, WAsmJs::INT64);}
-    BOOL                    RegIsFloatVar(Js::RegSlot reg) {return RegIsTypedVar(reg, WAsmJs::FLOAT32);}
-    BOOL                    RegIsDoubleVar(Js::RegSlot reg) {return RegIsTypedVar(reg, WAsmJs::FLOAT64);}
-    BOOL                    RegIsSimd128Var(Js::RegSlot reg) {return RegIsTypedVar(reg, WAsmJs::SIMD);}
+    bool                    GetTempUsed(Js::RegSlot reg);
+    void                    SetTempUsed(Js::RegSlot reg, bool used);
+    bool                    RegIsTemp(Js::RegSlot reg);
+    bool                    RegIsConstant(Js::RegSlot reg);
+    bool                    RegIsVar(Js::RegSlot reg);
+    bool                    RegIsTypedVar(Js::RegSlot reg, WAsmJs::Types type);
+    bool                    RegIsTypedConst(Js::RegSlot reg, WAsmJs::Types type);
+    bool                    RegIsTypedTmp(Js::RegSlot reg, WAsmJs::Types type);
+    bool                    RegIs(Js::RegSlot reg, WAsmJs::Types type);
 
     void                    BuildArgOut(IR::Opnd* srcOpnd, uint32 dstRegSlot, uint32 offset, IRType type, ValueType valueType = ValueType::Uninitialized);
     void                    BuildFromVar(uint32 offset, Js::RegSlot dstRegSlot, Js::RegSlot srcRegSlot, IRType irType, ValueType valueType);
@@ -155,13 +151,11 @@ private:
     void                    BuildBrInt1Const1(Js::OpCodeAsmJs newOpcode, uint32 offset, int32 relativeOffset, Js::RegSlot src1, int32 src2);
     void                    BuildBrCmp(Js::OpCodeAsmJs newOpcode, uint32 offset, int32 relativeOffset, IR::RegOpnd* src1Opnd, IR::Opnd* src2Opnd);
     void                    GenerateLoopBodySlotAccesses(uint offset);
-    void                    GenerateLoopBodyStSlots(SymID loopParamSymId, uint offset);
 
     static void             InitializeMemAccessTypeInfo(Js::ArrayBufferView::ViewType viewType, _Out_ MemAccessTypeInfo * typeInfo);
 
-    Js::PropertyId          CalculatePropertyOffset(SymID id, IRType type, bool isVar = true);
+    Js::PropertyId          CalculatePropertyOffset(Js::RegSlot regSlot, IRType type);
 
-    IR::Instr*              GenerateStSlotForReturn(IR::RegOpnd* srcOpnd, IRType type);
     IR::RegOpnd*            BuildTrapIfZero(IR::RegOpnd* srcOpnd, uint32 offset);
     IR::RegOpnd*            BuildTrapIfMinIntOverNegOne(IR::RegOpnd* src1Opnd, IR::RegOpnd* src2Opnd, uint32 offset);
 
@@ -201,7 +195,7 @@ private:
     StackSym *              m_loopBodyRetIPSym;
     BVFixed *               m_ldSlots;
     BVFixed *               m_stSlots;
-    BOOL                    m_IsTJLoopBody;
+    bool                    m_IsTJLoopBody;
     IRBuilderAsmJsSwitchAdapter m_switchAdapter;
     SwitchIRBuilder         m_switchBuilder;
     IR::RegOpnd *           m_funcOpnd;

--- a/lib/Runtime/ByteCode/AsmJsByteCodeDumper.cpp
+++ b/lib/Runtime/ByteCode/AsmJsByteCodeDumper.cpp
@@ -571,9 +571,9 @@ namespace Js
         switch (op)
         {
         case OpCodeAsmJs::LdArrWasm:
-            Output::Print(_u(" %c%d = %s[L%d + %d]"), tag.valueTag, data->Value, tag.heapTag, data->SlotIndex, data->Offset); break;
+            Output::Print(_u(" %c%d = %s[I%d + %d]"), tag.valueTag, data->Value, tag.heapTag, data->SlotIndex, data->Offset); break;
         case OpCodeAsmJs::StArrWasm:
-            Output::Print(_u(" %s[L%d + %d] = %c%d"), tag.heapTag, data->SlotIndex, data->Offset, tag.valueTag, data->Value); break;
+            Output::Print(_u(" %s[I%d + %d] = %c%d"), tag.heapTag, data->SlotIndex, data->Offset, tag.valueTag, data->Value); break;
         default:
             Assume(UNREACHED);
         }

--- a/lib/Runtime/Library/WebAssemblyMemory.cpp
+++ b/lib/Runtime/Library/WebAssemblyMemory.cpp
@@ -183,30 +183,30 @@ void WebAssemblyMemory::TraceMemWrite(WebAssemblyMemory* mem, uint32 index, uint
     }
     if (offset)
     {
-        Output::Print(_u("WasmMemoryTrace:: buf[%u + %u (%llu)] = "), index, offset, bigIndex);
+        Output::Print(_u("WasmMemoryTrace:: buf[%u + %u (%llu)]"), index, offset, bigIndex);
     }
     else
     {
-        Output::Print(_u("WasmMemoryTrace:: buf[%u] = "), index);
+        Output::Print(_u("WasmMemoryTrace:: buf[%u]"), index);
     }
     BYTE* buffer = mem->m_buffer->GetBuffer();
     switch (viewType)
     {
     case ArrayBufferView::ViewType::TYPE_INT8_TO_INT64:
-    case ArrayBufferView::ViewType::TYPE_INT8: Output::Print(_u("%d\n"), *(int8*)(buffer + bigIndex)); break;
+    case ArrayBufferView::ViewType::TYPE_INT8: Output::Print(_u(".int8 = %d\n"), *(int8*)(buffer + bigIndex)); break;
     case ArrayBufferView::ViewType::TYPE_UINT8_TO_INT64:
-    case ArrayBufferView::ViewType::TYPE_UINT8: Output::Print(_u("%u\n"), *(uint8*)(buffer + bigIndex)); break;
+    case ArrayBufferView::ViewType::TYPE_UINT8: Output::Print(_u(".uint8 = %u\n"), *(uint8*)(buffer + bigIndex)); break;
     case ArrayBufferView::ViewType::TYPE_INT16_TO_INT64:
-    case ArrayBufferView::ViewType::TYPE_INT16: Output::Print(_u("%d\n"), *(int16*)(buffer + bigIndex)); break;
+    case ArrayBufferView::ViewType::TYPE_INT16: Output::Print(_u(".int16 = %d\n"), *(int16*)(buffer + bigIndex)); break;
     case ArrayBufferView::ViewType::TYPE_UINT16_TO_INT64:
-    case ArrayBufferView::ViewType::TYPE_UINT16: Output::Print(_u("%u\n"), *(uint16*)(buffer + bigIndex)); break;
+    case ArrayBufferView::ViewType::TYPE_UINT16: Output::Print(_u(".uint16 = %u\n"), *(uint16*)(buffer + bigIndex)); break;
     case ArrayBufferView::ViewType::TYPE_INT32_TO_INT64:
-    case ArrayBufferView::ViewType::TYPE_INT32: Output::Print(_u("%d\n"), *(int32*)(buffer + bigIndex)); break;
+    case ArrayBufferView::ViewType::TYPE_INT32: Output::Print(_u(".int32 = %d\n"), *(int32*)(buffer + bigIndex)); break;
     case ArrayBufferView::ViewType::TYPE_UINT32_TO_INT64:
-    case ArrayBufferView::ViewType::TYPE_UINT32: Output::Print(_u("%u\n"), *(uint32*)(buffer + bigIndex)); break;
-    case ArrayBufferView::ViewType::TYPE_FLOAT32: Output::Print(_u("%.4f\n"), *(float*)(buffer + bigIndex)); break;
-    case ArrayBufferView::ViewType::TYPE_FLOAT64: Output::Print(_u("%.8f\n"), *(double*)(buffer + bigIndex)); break;
-    case ArrayBufferView::ViewType::TYPE_INT64: Output::Print(_u("%lld\n"), *(int64*)(buffer + bigIndex)); break;
+    case ArrayBufferView::ViewType::TYPE_UINT32: Output::Print(_u(".uint32 = %u\n"), *(uint32*)(buffer + bigIndex)); break;
+    case ArrayBufferView::ViewType::TYPE_FLOAT32: Output::Print(_u(".f32 = %.4f\n"), *(float*)(buffer + bigIndex)); break;
+    case ArrayBufferView::ViewType::TYPE_FLOAT64: Output::Print(_u(".f64 = %.8f\n"), *(double*)(buffer + bigIndex)); break;
+    case ArrayBufferView::ViewType::TYPE_INT64: Output::Print(_u(".int64 = %lld\n"), *(int64*)(buffer + bigIndex)); break;
     default:
         CompileAssert(ArrayBufferView::ViewType::TYPE_COUNT == 15);
         Assert(UNREACHED);

--- a/lib/WasmReader/WasmByteCodeGenerator.cpp
+++ b/lib/WasmReader/WasmByteCodeGenerator.cpp
@@ -1600,7 +1600,7 @@ void WasmBytecodeGenerator::YieldToBlock(BlockInfo blockInfo, EmitInfo expr)
         if (!IsUnreachable())
         {
             blockInfo.yieldInfo->didYield = true;
-            m_writer->AsmReg2(GetLoadOp(expr.type), yieldInfo.location, expr.location);
+            m_writer->AsmReg2(GetReturnOp(expr.type), yieldInfo.location, expr.location);
         }
     }
 }

--- a/test/wasm/loopyield.js
+++ b/test/wasm/loopyield.js
@@ -1,0 +1,64 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+const mod = new WebAssembly.Module(WebAssembly.wabt.convertWast2Wasm(`(module
+  (func (export "foo") (param $d i32) (result i32)
+    (local $tmp i32)
+    (set_local $tmp (i32.mul (get_local $d) (i32.const 100)))
+    (block $b1 (result i32)
+      (block $b2 (result i32)
+        (block $b3 (result i32)
+          (block $b4 (result i32)
+            (block $b5 (result i32)
+              (loop (result i32)
+                (tee_local $tmp (i32.sub (get_local $tmp) (get_local $d)))
+                (br_if 0 (i32.gt_u (get_local $d)))
+
+                (block $bloop (result i32)
+                  (block $breturn (result i32)
+                    (get_local $tmp) ;; Yield value
+                    (get_local $tmp) ;; br table index
+                    (br_table
+                      $bloop $b5 $b4 $b3 $b2 $b1 8 ;; 8 refers to the func depth
+                      $breturn ;; default
+                    )
+                  )
+                  (return)
+                )
+              )
+              (i32.add (i32.const 0x10))
+            )
+            (i32.add (i32.const 0x100))
+          )
+          (i32.add (i32.const 0x1000))
+        )
+        (i32.add (i32.const 0x10000))
+      )
+      (i32.add (i32.const 0x100000))
+    )
+    (i32.add (i32.const 0x1000000))
+  )
+)`));
+
+const {exports: {foo}} = new WebAssembly.Instance(mod);
+
+const expected = [
+  0x1111110,
+  0x1111101,
+  0x1111002,
+  0x1110003,
+  0x1100004,
+  0x1000005,
+  0x6,
+  0x7,
+  0x8,
+];
+for (const i in expected) {
+  const res = foo(i);
+  if (res !== expected[i]) {
+    print(`Failed foo(${i}). Expected 0x${expected[i].toString(16)}, got 0x${res.toString(16)}`);
+  }
+}
+print("pass");

--- a/test/wasm/rlexe.xml
+++ b/test/wasm/rlexe.xml
@@ -347,4 +347,11 @@
     <tags>exclude_jshost,exclude_win7,exclude_xplat</tags>
   </default>
 </test>
+<test>
+  <default>
+    <files>loopyield.js</files>
+    <compile-flags>-forcejitloopbody</compile-flags>
+    <tags>exclude_jshost,exclude_win7,exclude_xplat</tags>
+  </default>
+</test>
 </regress-exe>


### PR DESCRIPTION
Correctly restore yielded values from jit loop bodies.
Use `Return_****` opcodes when yielding.
Made restoring loop values more generic to include `const` (aka return) and `tmps` (aka yielded values)
Some cleanup in IRBuilderAsmJs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/3838)
<!-- Reviewable:end -->
