### PR TITLE
Support int64 type in ChangeToAssign and InsertMove

### DIFF
--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -1124,8 +1124,7 @@ Lowerer::LowerRange(IR::Instr *instrStart, IR::Instr *instrEnd, bool defaultDoFa
             LowerTrapIfMinIntOverNegOne(instr);
             break;
         case Js::OpCode::TrapIfTruncOverflow:
-            instr->m_opcode = Js::OpCode::Ld_I4;
-            LowerLdI4(instr);
+            LowererMD::ChangeToAssign(instr);
             break;
         case Js::OpCode::TrapIfZero:
             LowerTrapIfZero(instr);
@@ -1739,7 +1738,7 @@ Lowerer::LowerRange(IR::Instr *instrStart, IR::Instr *instrEnd, bool defaultDoFa
             break;
 #endif
         case Js::OpCode::Ld_I4:
-            LowerLdI4(instr);
+            LowererMD::ChangeToAssign(instr);
             break;
         case Js::OpCode::LdAsmJsFunc:
             if (instr->GetSrc1()->IsIndirOpnd())
@@ -1826,7 +1825,7 @@ Lowerer::LowerRange(IR::Instr *instrStart, IR::Instr *instrEnd, bool defaultDoFa
             {
                 GenerateRuntimeError(instr, WASMERR_InvalidTypeConversion);
                 instr->ReplaceSrc1(IR::Int64ConstOpnd::New(0, TyInt64, m_func));
-                m_lowererMD.LowerInt64Assign(instr);
+                LowererMD::ChangeToAssign(instr);
             }
 #ifdef ENABLE_SIMDJS
             // Support on IA only
@@ -8915,16 +8914,7 @@ Lowerer::LowerLdArrViewElem(IR::Instr * instr)
         }
         done = instr;
     }
-    if (dst->IsInt64())
-    {
-        IR::Instr* movInt64 = IR::Instr::New(Js::OpCode::Ld_I4, dst, src1, m_func);
-        done->InsertBefore(movInt64);
-        m_lowererMD.LowerInt64Assign(movInt64);
-    }
-    else
-    {
-        InsertMove(dst, src1, done);
-    }
+    InsertMove(dst, src1, done);
 
     instr->Remove();
     return instrPrev;
@@ -8972,22 +8962,14 @@ Lowerer::LowerLdArrViewElemWasm(IR::Instr * instr)
     Assert(!dst->IsFloat64() || src1->IsFloat64());
 
     IR::Instr * done = LowerWasmMemOp(instr, src1);
-    IR::Instr* newMove = nullptr;
-    if (dst->IsInt64())
-    {
-        IR::Instr* movInt64 = IR::Instr::New(Js::OpCode::Ld_I4, dst, src1, m_func);
-        done->InsertBefore(movInt64);
-        newMove = m_lowererMD.LowerInt64Assign(movInt64);
-    }
-    else
-    {
-        newMove = InsertMove(dst, src1, done);
-    }
+    IR::Instr* newMove = InsertMove(dst, src1, done);
 
 #if ENABLE_FAST_ARRAYBUFFER
     // We need to have an AV when accessing out of bounds memory even if the dst is not used
     // Make sure LinearScan doesn't dead store this instruction
     newMove->hasSideEffects = true;
+#else
+    Unused(newMove);
 #endif
     instr->Remove();
     return instrPrev;
@@ -9206,16 +9188,8 @@ Lowerer::LowerStArrViewElem(IR::Instr * instr)
             instr->FreeSrc2();
         }
     }
-    if (src1->IsInt64())
-    {
-        IR::Instr* movInt64 = IR::Instr::New(Js::OpCode::Ld_I4, dst, src1, m_func);
-        done->InsertBefore(movInt64);
-        m_lowererMD.LowerInt64Assign(movInt64);
-    }
-    else
-    {
-        InsertMove(dst, src1, done);
-    }
+    InsertMove(dst, src1, done);
+
     instr->Remove();
     return instrPrev;
 #else
@@ -10138,14 +10112,7 @@ Lowerer::LowerStSlot(IR::Instr *instr)
     dstOpnd->Free(this->m_func);
 
     instr->SetDst(dstNew);
-    if (instr->GetDst() && instr->GetDst()->IsInt64())
-    {
-        m_lowererMD.LowerInt64Assign(instr);
-    }
-    else
-    {
-        instr = m_lowererMD.ChangeToWriteBarrierAssign(instr, this->m_func);
-    }
+    instr = m_lowererMD.ChangeToWriteBarrierAssign(instr, this->m_func);
 
     return instr;
 }
@@ -10193,14 +10160,7 @@ Lowerer::LowerLdSlot(IR::Instr *instr)
     srcOpnd->Free(this->m_func);
 
     instr->SetSrc1(srcNew);
-    if (instr->GetDst() && instr->GetDst()->IsInt64())
-    {
-        m_lowererMD.LowerInt64Assign(instr);
-    }
-    else
-    {
-        m_lowererMD.ChangeToAssign(instr);
-    }
+    m_lowererMD.ChangeToAssign(instr);
 }
 
 IR::Instr *
@@ -10857,16 +10817,7 @@ Lowerer::LowerArgInAsmJs(IR::Instr * instr)
 
     Assert(instr && instr->m_opcode == Js::OpCode::ArgIn_A);
     IR::Instr* instrPrev = instr->m_prev;
-#ifdef _M_IX86
-    if (instr->GetDst()->IsInt64())
-    {
-        m_lowererMD.LowerInt64Assign(instr);
-    }
-    else
-#endif
-    {
-        m_lowererMD.ChangeToAssign(instr);
-    }
+    m_lowererMD.ChangeToAssign(instr);
 
     return instrPrev;
 }
@@ -13558,16 +13509,7 @@ Lowerer::LowerInlineeStart(IR::Instr * inlineeStartInstr)
 #pragma prefast(suppress:6235, "Non-Zero Constant in Condition")
         if (!PHASE_ON(Js::EliminateArgoutForInlineePhase, this->m_func) || inlineeStartInstr->m_func->GetJITFunctionBody()->HasOrParentHasArguments())
         {
-#ifdef _M_IX86
-            if (argInstr->GetDst()->IsInt64())
-            {
-                m_lowererMD.LowerInt64Assign(argInstr);
-            }
-            else
-#endif
-            {
-                m_lowererMD.ChangeToAssign(argInstr);
-            }
+            m_lowererMD.ChangeToAssign(argInstr);
         }
         else
         {
@@ -14479,7 +14421,18 @@ IR::Instr *Lowerer::InsertMove(IR::Opnd *dst, IR::Opnd *src, IR::Instr *const in
 
     if(TySize[dst->GetType()] < TySize[src->GetType()])
     {
-        src = src->UseWithNewType(dst->GetType(), func);
+#if _M_IX86
+        if (IRType_IsInt64(src->GetType()))
+        {
+            // On x86, if we are trying to move an int64 to a smaller type
+            // Insert a move of the low bits into dst
+            return InsertMove(dst, func->FindOrCreateInt64Pair(src).low, insertBeforeInstr, generateWriteBarrier);
+        }
+        else
+#endif
+        {
+            src = src->UseWithNewType(dst->GetType(), func);
+        }
     }
     IR::Instr * instr = IR::Instr::New(Js::OpCode::Ld_A, dst, src, func);
 
@@ -24004,8 +23957,7 @@ Lowerer::LowerTrapIfZero(IR::Instr * const instr)
         InsertLabel(true, doneLabel);
         GenerateThrow(IR::IntConstOpnd::NewFromType(SCODE_CODE(WASMERR_DivideByZero), TyInt32, m_func), doneLabel);
     }
-    instr->m_opcode = Js::OpCode::Ld_I4;
-    LowerLdI4(instr);
+    LowererMD::ChangeToAssign(instr);
 }
 
 void
@@ -24029,7 +23981,7 @@ Lowerer::LowerTrapIfMinIntOverNegOne(IR::Instr * const instr)
             // Const value not min int, will not trap
             doneLabel->Remove();
             src2->Free(m_func);
-            LowerLdI4(instr);
+            LowererMD::ChangeToAssign(instr);
             return;
         }
         // Is min int no need to do check
@@ -24045,7 +23997,7 @@ Lowerer::LowerTrapIfMinIntOverNegOne(IR::Instr * const instr)
             // Const value not min int, will not trap
             doneLabel->Remove();
             src2->Free(m_func);
-            LowerLdI4(instr);
+            LowererMD::ChangeToAssign(instr);
             return;
         }
         // Is -1 no need to do check
@@ -24057,8 +24009,7 @@ Lowerer::LowerTrapIfMinIntOverNegOne(IR::Instr * const instr)
     }
     InsertLabel(true, doneLabel);
     GenerateThrow(IR::IntConstOpnd::NewFromType(SCODE_CODE(VBSERR_Overflow), TyInt32, m_func), doneLabel);
-    instr->m_opcode = Js::OpCode::Ld_I4;
-    LowerLdI4(instr);
+    LowererMD::ChangeToAssign(instr);
 }
 
 void
@@ -24068,19 +24019,6 @@ Lowerer::GenerateThrow(IR::Opnd* errorCode, IR::Instr * instr)
     instr->InsertBefore(throwInstr);
     const bool isWasm = m_func->GetJITFunctionBody() && m_func->GetJITFunctionBody()->IsWasmFunction();
     LowerUnaryHelperMem(throwInstr, isWasm ? IR::HelperOp_WebAssemblyRuntimeError : IR::HelperOp_RuntimeTypeError);
-}
-
-void
-Lowerer::LowerLdI4(IR::Instr * const instr)
-{
-    if (instr->GetDst() && instr->GetDst()->IsInt64())
-    {
-        m_lowererMD.LowerInt64Assign(instr);
-    }
-    else
-    {
-        m_lowererMD.ChangeToAssign(instr);
-    }
 }
 
 void

--- a/lib/Backend/Lower.h
+++ b/lib/Backend/Lower.h
@@ -487,7 +487,6 @@ private:
     IR::LabelInstr *GenerateBailOut(IR::Instr * instr, IR::BranchInstr * branchInstr = nullptr, IR::LabelInstr * labelBailOut = nullptr, IR::LabelInstr * collectRuntimeStatsLabel = nullptr);
     void            GenerateJumpToEpilogForBailOut(BailOutInfo * bailOutInfo, IR::Instr *instrAfter);
     void            GenerateThrow(IR::Opnd* errorCode, IR::Instr * instr);
-    void            LowerLdI4(IR::Instr * const instr);
     void            LowerDivI4(IR::Instr * const instr);
     void            LowerRemI4(IR::Instr * const instr);
     void            LowerTrapIfZero(IR::Instr * const instr);

--- a/lib/Backend/LowerMDShared.cpp
+++ b/lib/Backend/LowerMDShared.cpp
@@ -740,6 +740,13 @@ LowererMD::ChangeToAssign(IR::Instr * instr, IRType type)
 {
     Assert(!instr->HasBailOutInfo() || instr->GetBailOutKind() == IR::BailOutExpectingString);
 
+#if _M_IX86
+    if (IRType_IsInt64(type))
+    {
+        return LowererMDArch::ChangeToAssignInt64(instr);
+    }
+#endif
+
     instr->m_opcode = LowererMDArch::GetAssignOp(type);
     Legalize(instr);
 
@@ -8681,12 +8688,6 @@ void LowererMD::EmitReinterpretIntToFloat(IR::Opnd* dst, IR::Opnd* src, IR::Inst
     Assert(dst->IsFloat());
     Assert(src->IsInt32() || src->IsUInt32() || src->IsInt64());
     EmitReinterpretPrimitive(dst, src, insertBeforeInstr);
-}
-
-IR::Instr *
-LowererMD::LowerInt64Assign(IR::Instr * instr)
-{
-    return this->lowererMDArch.LowerInt64Assign(instr);
 }
 
 IR::Instr *

--- a/lib/Backend/LowerMDShared.h
+++ b/lib/Backend/LowerMDShared.h
@@ -272,7 +272,6 @@ public:
             IR::Instr *         LowerExitInstrAsmJs(IR::ExitInstr * exitInstr);
             IR::Instr *         LoadNewScObjFirstArg(IR::Instr * instr, IR::Opnd * dst, ushort extraArgs = 0);
             IR::Instr *         LowerToFloat(IR::Instr *instr);
-            IR::Instr *         LowerInt64Assign(IR::Instr * instr);
      static IR::BranchInstr *   LowerFloatCondBranch(IR::BranchInstr *instrBranch, bool ignoreNan = false);
 
      static Js::OpCode          GetLoadOp(IRType type) { return LowererMDArch::GetAssignOp(type); }

--- a/lib/Backend/amd64/LowererMDArch.cpp
+++ b/lib/Backend/amd64/LowererMDArch.cpp
@@ -2089,13 +2089,6 @@ LowererMDArch::LowerExitInstrAsmJs(IR::ExitInstr * exitInstr)
     return LowerExitInstr(exitInstr);
 }
 
-IR::Instr *
-LowererMDArch::LowerInt64Assign(IR::Instr * instr)
-{
-    this->lowererMD->ChangeToAssign(instr);
-    return instr;
-}
-
 void
 LowererMDArch::EmitInt4Instr(IR::Instr *instr, bool signExtend /* = false */)
 {
@@ -2181,9 +2174,7 @@ idiv_common:
                 // we need to ensure that register allocator doesn't muck about with rdx
                 instr->HoistSrc2(Js::OpCode::MOV, RegRCX);
 
-                newInstr = IR::Instr::New(Js::OpCode::Ld_I4, regEDX, IR::IntConstOpnd::New(0, src1->GetType(), instr->m_func), instr->m_func);
-                instr->InsertBefore(newInstr);
-                LowererMD::ChangeToAssign(newInstr);
+                Lowerer::InsertMove(regEDX, IR::IntConstOpnd::New(0, src1->GetType(), instr->m_func), instr);
                 // NOP ensures that the EDX = Ld_I4 0 doesn't get deadstored, will be removed in peeps
                 instr->InsertBefore(IR::Instr::New(Js::OpCode::NOP, regEDX, regEDX, instr->m_func));
             }

--- a/lib/Backend/amd64/LowererMDArch.h
+++ b/lib/Backend/amd64/LowererMDArch.h
@@ -108,7 +108,6 @@ public:
     void                GeneratePrologueStackProbe(IR::Instr *entryInstr, IntConstType frameSize);
     IR::Instr *         LowerExitInstr(IR::ExitInstr * exitInstr);
     IR::Instr *         LowerExitInstrAsmJs(IR::ExitInstr * exitInstr);
-    IR::Instr *         LowerInt64Assign(IR::Instr * instr);
     static void         EmitInt4Instr(IR::Instr *instr, bool signExtend = false);
     void                EmitLoadVar(IR::Instr *instrLoad, bool isFromUint32 = false, bool isHelper = false);
     void                EmitIntToFloat(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsert);

--- a/lib/Backend/arm/LowerMD.h
+++ b/lib/Backend/arm/LowerMD.h
@@ -143,7 +143,6 @@ public:
      static void            EmitInt4Instr(IR::Instr *instr);
             void            EmitLoadVar(IR::Instr *instr, bool isFromUint32 = false, bool isHelper = false);
             bool            EmitLoadInt32(IR::Instr *instr, bool conversionFromObjectAllowed, bool bailOutOnHelper = false, IR::LabelInstr * labelBailOut = nullptr);
-            IR::Instr *     LowerInt64Assign(IR::Instr * instr) { Assert(UNREACHED); return nullptr; }
 
      static void            LowerInt4NegWithBailOut(IR::Instr *const instr, const IR::BailOutKind bailOutKind, IR::LabelInstr *const bailOutLabel, IR::LabelInstr *const skipBailOutLabel);
      static void            LowerInt4AddWithBailOut(IR::Instr *const instr, const IR::BailOutKind bailOutKind, IR::LabelInstr *const bailOutLabel, IR::LabelInstr *const skipBailOutLabel);

--- a/lib/Backend/arm64/LowerMD.h
+++ b/lib/Backend/arm64/LowerMD.h
@@ -143,7 +143,6 @@ public:
      static void            EmitInt4Instr(IR::Instr *instr);
             void            EmitLoadVar(IR::Instr *instr, bool isFromUint32 = false, bool isHelper = false);
             bool            EmitLoadInt32(IR::Instr *instr, bool conversionFromObjectAllowed, bool bailOutOnHelper = false, IR::LabelInstr * labelBailOut = nullptr);
-            IR::Instr *     LowerInt64Assign(IR::Instr * instr) { Assert(UNREACHED); return nullptr; }
 
      static void            LowerInt4NegWithBailOut(IR::Instr *const instr, const IR::BailOutKind bailOutKind, IR::LabelInstr *const bailOutLabel, IR::LabelInstr *const skipBailOutLabel);
      static void            LowerInt4AddWithBailOut(IR::Instr *const instr, const IR::BailOutKind bailOutKind, IR::LabelInstr *const bailOutLabel, IR::LabelInstr *const skipBailOutLabel);

--- a/lib/Backend/i386/LowererMDArch.h
+++ b/lib/Backend/i386/LowererMDArch.h
@@ -71,7 +71,7 @@ public:
             IR::Instr *         LowerExitInstr(IR::ExitInstr * exitInstr);
             IR::Instr *         LowerExitInstrAsmJs(IR::ExitInstr * exitInstr);
             IR::ExitInstr *     LowerExitInstrCommon(IR::ExitInstr * exitInstr);
-            IR::Instr *         LowerInt64Assign(IR::Instr * instr);
+     static IR::Instr *         ChangeToAssignInt64(IR::Instr * instr);
             void                GeneratePrologueStackProbe(IR::Instr *entryInstr, size_t frameSize);
             void                EmitInt64Instr(IR::Instr *instr);
             void                LowerInt64Branch(IR::Instr *instr);


### PR DESCRIPTION
Move check for int64 assign into the relevant place to minimize burden when trying to move an int64 on x86.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/3844)
<!-- Reviewable:end -->
