### PR TITLE
CanonicalizeAccessor returns wrong results on cross thread

### DIFF
--- a/lib/Runtime/Types/DictionaryTypeHandler.cpp
+++ b/lib/Runtime/Types/DictionaryTypeHandler.cpp
@@ -1986,7 +1986,7 @@ namespace Js
     template <typename T>
     Var DictionaryTypeHandlerBase<T>::CanonicalizeAccessor(Var accessor, /*const*/ JavascriptLibrary* library)
     {
-        if (accessor == nullptr || JavascriptOperators::IsUndefinedObject(accessor, library))
+        if (accessor == nullptr || JavascriptOperators::IsUndefinedObject(accessor))
         {
             accessor = library->GetDefaultAccessorFunction();
         }


### PR DESCRIPTION
`accessor` might be initialized under a different context hence `library->Undefined != accessor's->library->Undefined`

Recently added an Assert to IsUndefinedObject** checks. That assert helped revealing this issue.

See also https://github.com/Microsoft/ChakraCore/blame/master/lib/Runtime/Types/DictionaryTypeHandler.cpp#L2020