### PR TITLE
Add support for a Recycler-managed "Host Heap" to facilitate tracing of objects which relate to scriptable types

### DIFF
--- a/bin/GCStress/GCStress.cpp
+++ b/bin/GCStress/GCStress.cpp
@@ -214,13 +214,17 @@ void BuildObjectCreationTable()
     objectCreationTable.AddWeightedEntry(&ScannedObject<1, 50>::New, 10000);
     objectCreationTable.AddWeightedEntry(&BarrierObject<1, 50>::New, 2000);
     objectCreationTable.AddWeightedEntry(&TrackedObject<1, 50>::New, 2000);
+#ifdef RECYCLER_VISITED_HOST
     objectCreationTable.AddWeightedEntry(&RecyclerVisitedObject<1, 50>::New, 2000);
+#endif
 
     objectCreationTable.AddWeightedEntry(&LeafObject<51, 1000>::New, 10);
     objectCreationTable.AddWeightedEntry(&ScannedObject<51, 1000>::New, 100);
     objectCreationTable.AddWeightedEntry(&BarrierObject<51, 1000>::New, 20);
     objectCreationTable.AddWeightedEntry(&TrackedObject<51, 1000>::New, 20);
+#ifdef RECYCLER_VISITED_HOST
     objectCreationTable.AddWeightedEntry(&RecyclerVisitedObject<51, 1000>::New, 40);
+#endif
     
     objectCreationTable.AddWeightedEntry(&LeafObject<1001, 50000>::New, 1);
     objectCreationTable.AddWeightedEntry(&ScannedObject<1001, 50000>::New, 10);

--- a/bin/GCStress/GCStress.cpp
+++ b/bin/GCStress/GCStress.cpp
@@ -214,16 +214,19 @@ void BuildObjectCreationTable()
     objectCreationTable.AddWeightedEntry(&ScannedObject<1, 50>::New, 10000);
     objectCreationTable.AddWeightedEntry(&BarrierObject<1, 50>::New, 2000);
     objectCreationTable.AddWeightedEntry(&TrackedObject<1, 50>::New, 2000);
+    objectCreationTable.AddWeightedEntry(&RecyclerVisitedObject<1, 50>::New, 2000);
 
     objectCreationTable.AddWeightedEntry(&LeafObject<51, 1000>::New, 10);
     objectCreationTable.AddWeightedEntry(&ScannedObject<51, 1000>::New, 100);
     objectCreationTable.AddWeightedEntry(&BarrierObject<51, 1000>::New, 20);
     objectCreationTable.AddWeightedEntry(&TrackedObject<51, 1000>::New, 20);
+    objectCreationTable.AddWeightedEntry(&RecyclerVisitedObject<51, 1000>::New, 40);
     
     objectCreationTable.AddWeightedEntry(&LeafObject<1001, 50000>::New, 1);
     objectCreationTable.AddWeightedEntry(&ScannedObject<1001, 50000>::New, 10);
     objectCreationTable.AddWeightedEntry(&BarrierObject<1001, 50000>::New, 2);
 //    objectCreationTable.AddWeightedEntry(&TrackedObject<1001, 50000>::New, 2);    // Large tracked objects are not supported
+//    objectCreationTable.AddWeightedEntry(&RecyclerVisitedObject<1001, 50000>::New, 2); // Large recycler visited objects are not supported
 }
 
 void BuildOperationTable()

--- a/bin/GCStress/RecyclerTestObject.cpp
+++ b/bin/GCStress/RecyclerTestObject.cpp
@@ -10,6 +10,7 @@ size_t RecyclerTestObject::walkObjectCount = 0;
 size_t RecyclerTestObject::walkScannedByteCount = 0;
 size_t RecyclerTestObject::walkBarrierByteCount = 0;
 size_t RecyclerTestObject::walkTrackedByteCount = 0;
+size_t RecyclerTestObject::walkRecyclerVisitedByteCount = 0;
 size_t RecyclerTestObject::walkLeafByteCount = 0;
 size_t RecyclerTestObject::currentWalkDepth = 0;
 size_t RecyclerTestObject::maxWalkDepth = 0;

--- a/bin/GCStress/RecyclerTestObject.h
+++ b/bin/GCStress/RecyclerTestObject.h
@@ -337,7 +337,7 @@ public:
             mem = RecyclerAllocVisitedHostFinalizedZero(recyclerInstance, size);
             break;
         case AllocationType::Leaf:
-            mem = RecyclerAllocVisitedHostLeafZero(recyclerInstance, size);
+            mem = RecyclerAllocLeafZero(recyclerInstance, size);
             break;
 
         default:

--- a/bin/GCStress/RecyclerTestObject.h
+++ b/bin/GCStress/RecyclerTestObject.h
@@ -311,6 +311,8 @@ private:
     FieldNoBarrier(RecyclerTestObject *) references[0];  // SWB-TODO: is this correct?
 };
 
+#ifdef RECYCLER_VISITED_HOST
+
 template <unsigned int minCount, unsigned int maxCount>
 class RecyclerVisitedObject : public RecyclerTestObject
 {
@@ -432,3 +434,4 @@ private:
     Field(unsigned int) count;
     FieldNoBarrier(RecyclerTestObject *) references[0];  // SWB-TODO: is this correct? (copied from TrackedObject)
 };
+#endif

--- a/bin/GCStress/RecyclerTestObject.h
+++ b/bin/GCStress/RecyclerTestObject.h
@@ -364,7 +364,7 @@ public:
         return true;
     }
 
-    virtual void __stdcall Trace(IRecyclerHeapMarkingContext* markContext) override
+    virtual void Trace(IRecyclerHeapMarkingContext* markContext) override
     {
         VerifyCondition(type == AllocationType::TraceAndFinalized || type == AllocationType::TraceOnly);
         // Note that the pointers in the references arrary are technically tagged. However, this is ok
@@ -372,12 +372,12 @@ public:
         markContext->MarkObjects(reinterpret_cast<void**>(&references[0]), count, this);
     }
 
-    virtual void __stdcall Finalize(bool isShutdown) override
+    virtual void Finalize(bool isShutdown) override
     {
         // Only types that request finalization should have Finalize called
         VerifyCondition(IsFinalizable());
     }
-    virtual void __stdcall Dispose(bool isShutdown) override
+    virtual void Dispose(bool isShutdown) override
     { 
         // Only types that request finalization should have Finalize called
         VerifyCondition(IsFinalizable());

--- a/bin/GCStress/RecyclerTestObject.h
+++ b/bin/GCStress/RecyclerTestObject.h
@@ -338,12 +338,9 @@ public:
         case AllocationType::FinalizeLeaf:
             mem = RecyclerAllocVisitedHostFinalizedZero(recyclerInstance, size);
             break;
-        case AllocationType::Leaf:
-            mem = RecyclerAllocLeafZero(recyclerInstance, size);
-            break;
-
         default:
-            Assert(false);
+            Assert(allocType == AllocationType::Leaf);
+            mem = RecyclerAllocLeafZero(recyclerInstance, size);
         }
 
         // Construct the v-table, allocType, and count information for the new object.

--- a/bin/GCStress/RecyclerTestObject.h
+++ b/bin/GCStress/RecyclerTestObject.h
@@ -4,7 +4,9 @@
 //-------------------------------------------------------------------------------------------------------
 #include "stdafx.h"
 
-class RecyclerTestObject : public FinalizableObject
+#include "core/RecyclerHeapMarkingContext.h"
+
+class RecyclerTestObject : public IRecyclerVisitedObject
 {
 protected:
     RecyclerTestObject()
@@ -13,10 +15,16 @@ protected:
     }
 
 public:
-    // FinalizableObject implementation
+    // IRecyclerVisitedObject implementation. We don't use FinalizableObject here as
+    // RecyclerVisitedObjects need to have Trace called on them, which is not allowed for
+    // FinalizableObject.
     virtual void Finalize(bool isShutdown) override { VerifyCondition(false); };
     virtual void Dispose(bool isShutdown) override { VerifyCondition(false); };
-    virtual void Mark(Recycler * recycler) override { VerifyCondition(false); };
+    virtual void OnMark() override {}
+    virtual void Mark(RecyclerHeapHandle recycler) override { Mark(static_cast<Recycler*>(recycler)); };
+    virtual void Trace(IRecyclerHeapMarkingContext* markContext) override { VerifyCondition(false); };
+
+    virtual void Mark(Recycler * recycler) { VerifyCondition(false); };
 
 public:
     static void BeginWalk()
@@ -27,6 +35,7 @@ public:
         walkScannedByteCount = 0;
         walkBarrierByteCount = 0;
         walkTrackedByteCount = 0;
+        walkRecyclerVisitedByteCount = 0;
         walkLeafByteCount = 0;
         maxWalkDepth = 0;
 
@@ -66,13 +75,14 @@ public:
         VerifyCondition(currentWalkDepth == 0);
 
         wprintf(_u("Full heap walk finished\n"));
-        wprintf(_u("Object Count:   %12llu\n"), (unsigned long long) walkObjectCount);
-        wprintf(_u("Scanned Bytes:  %12llu\n"), (unsigned long long) walkScannedByteCount);
-        wprintf(_u("Barrier Bytes:  %12llu\n"), (unsigned long long) walkBarrierByteCount);
-        wprintf(_u("Tracked Bytes:  %12llu\n"), (unsigned long long) walkTrackedByteCount);
-        wprintf(_u("Leaf Bytes:     %12llu\n"), (unsigned long long) walkLeafByteCount);
-        wprintf(_u("Total Bytes:    %12llu\n"), (unsigned long long) (walkScannedByteCount + walkBarrierByteCount + walkTrackedByteCount + walkLeafByteCount));
-        wprintf(_u("Max Depth:      %12llu\n"), (unsigned long long) maxWalkDepth);
+        wprintf(_u("Object Count:           %12llu\n"), (unsigned long long) walkObjectCount);
+        wprintf(_u("Scanned Bytes:          %12llu\n"), (unsigned long long) walkScannedByteCount);
+        wprintf(_u("Barrier Bytes:          %12llu\n"), (unsigned long long) walkBarrierByteCount);
+        wprintf(_u("Tracked Bytes:          %12llu\n"), (unsigned long long) walkTrackedByteCount);
+        wprintf(_u("RecyclerVisited Bytes:  %12llu\n"), (unsigned long long) walkRecyclerVisitedByteCount);
+        wprintf(_u("Leaf Bytes:             %12llu\n"), (unsigned long long) walkLeafByteCount);
+        wprintf(_u("Total Bytes:            %12llu\n"), (unsigned long long) (walkScannedByteCount + walkBarrierByteCount + walkTrackedByteCount + walkLeafByteCount + walkRecyclerVisitedByteCount));
+        wprintf(_u("Max Depth:              %12llu\n"), (unsigned long long) maxWalkDepth);
     }
 
     // Virtual methods
@@ -100,6 +110,7 @@ protected:
     static size_t walkLeafByteCount;
     static size_t walkBarrierByteCount;
     static size_t walkTrackedByteCount;
+    static size_t walkRecyclerVisitedByteCount;
     static size_t currentWalkDepth;
     static size_t maxWalkDepth;
 
@@ -232,8 +243,13 @@ private:
     FieldNoBarrier(RecyclerTestObject *) references[0];  // SWB-TODO: is this correct?
 };
 
+// TrackedObject must be a FinalizableObject (in order to be 'new'ed with RecyclerNewTrackedLeafPlusZ)
+// but it also must be a RecyclerTestObject to participate in GCStress. It must inherit from RecyclerTestObject
+// first so that the algined pointer is returned from New.
+// Fortunately, the v-tables for RecyclerTestObject and FinalizableObject line up, so the 
+// IRecyclerVisitedObject/FinalizableObject calls end up in the right place.
 template <unsigned int minCount, unsigned int maxCount>
-class TrackedObject : public RecyclerTestObject
+class TrackedObject : public RecyclerTestObject, public FinalizableObject
 {
 private:
     TrackedObject(unsigned int count) :
@@ -295,4 +311,124 @@ private:
     FieldNoBarrier(RecyclerTestObject *) references[0];  // SWB-TODO: is this correct?
 };
 
+template <unsigned int minCount, unsigned int maxCount>
+class RecyclerVisitedObject : public RecyclerTestObject
+{
+public:
+    static RecyclerTestObject * New()
+    {
+        // Determine a random amount of RecyclerTestObject* references to influence the size of this object.
+        const unsigned int count = minCount + GetRandomInteger(maxCount - minCount + 1);
 
+        void* mem = nullptr;
+        const size_t size = sizeof(RecyclerVisitedObject) + (sizeof(RecyclerTestObject*) * count);
+
+        // Randomly select the type of object to create
+        AllocationType allocType = static_cast<AllocationType>(GetRandomInteger(static_cast<unsigned int>(AllocationType::Count)));
+        switch (allocType)
+        {
+        case AllocationType::TraceAndFinalized:
+            mem = RecyclerAllocVisitedHostTracedAndFinalizedZero(recyclerInstance, size);
+            break;
+        case AllocationType::TraceOnly:
+            mem = RecyclerAllocVisitedHostTracedZero(recyclerInstance, size);
+            break;
+        case AllocationType::FinalizeLeaf:
+            mem = RecyclerAllocVisitedHostFinalizedZero(recyclerInstance, size);
+            break;
+        case AllocationType::Leaf:
+            mem = RecyclerAllocVisitedHostLeafZero(recyclerInstance, size);
+            break;
+
+        default:
+            Assert(false);
+        }
+
+        // Construct the v-table, allocType, and count information for the new object.
+        RecyclerVisitedObject* obj = new (mem) RecyclerVisitedObject(allocType, count);
+        return obj;
+    }
+
+    virtual bool TryGetRandomLocation(Location * location) override
+    {
+        // Leaf types should not return a location
+        if (type == AllocationType::Leaf || type == AllocationType::FinalizeLeaf)
+        {
+            return false;
+        }
+
+        // Get a random slot and construct a Location for it
+        // Make this a Tagged location so that we won't inadvertently keep objects alive
+        // in the case where this object gets put on the wrong mark stack.
+        *location = Location::Tagged(&references[GetRandomInteger(count)]);
+
+        return true;
+    }
+
+    virtual void __stdcall Trace(IRecyclerHeapMarkingContext* markContext) override
+    {
+        VerifyCondition(type == AllocationType::TraceAndFinalized || type == AllocationType::TraceOnly);
+        // Note that the pointers in the references arrary are technically tagged. However, this is ok
+        // as the Mark that we're performing is an interior mark, which gets us to the right object(s).
+        markContext->MarkObjects(reinterpret_cast<void**>(&references[0]), count, this);
+    }
+
+    virtual void __stdcall Finalize(bool isShutdown) override
+    {
+        // Only types that request finalization should have Finalize called
+        VerifyCondition(IsFinalizable());
+    }
+    virtual void __stdcall Dispose(bool isShutdown) override
+    { 
+        // Only types that request finalization should have Finalize called
+        VerifyCondition(IsFinalizable());
+        VerifyCondition(unmanagedResource != nullptr);
+        BOOL success = ::HeapFree(GetProcessHeap(), 0, unmanagedResource);
+        VerifyCondition(success != FALSE);
+        unmanagedResource = nullptr;
+    }
+
+
+protected:
+    virtual void DoWalkObject() override
+    {
+        walkRecyclerVisitedByteCount += sizeof(RecyclerVisitedObject) + count * sizeof(RecyclerTestObject *);
+
+        for (unsigned int i = 0; i < count; i++)
+        {
+            RecyclerTestObject::WalkReference(Location::Untag(references[i]));
+        }
+    }
+
+private:
+    enum class AllocationType : unsigned int
+    {
+        TraceAndFinalized = 0,
+        TraceOnly,
+        FinalizeLeaf,
+        Leaf,
+        Count,
+    };
+
+    bool IsFinalizable() const { return type == AllocationType::TraceAndFinalized || type == AllocationType::FinalizeLeaf; }
+    RecyclerVisitedObject(AllocationType allocType, unsigned int count) :
+        count(count),
+        type(allocType)
+    {
+        for (unsigned int i = 0; i < count; i++)
+        {
+            references[i] = nullptr;
+        }
+        if (IsFinalizable())
+        {
+            unmanagedResource = ::HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, GetRandomInteger(1024));
+            VerifyCondition(unmanagedResource != nullptr);
+        }
+    }
+
+
+    Field(AllocationType) type;
+    Field(void*) unmanagedResource;
+    Field(unsigned int) count;
+    FieldNoBarrier(RecyclerTestObject *) references[0];  // SWB-TODO: is this correct? (copied from TrackedObject)
+};

--- a/bin/GCStress/RecyclerTestObject.h
+++ b/bin/GCStress/RecyclerTestObject.h
@@ -4,7 +4,7 @@
 //-------------------------------------------------------------------------------------------------------
 #include "stdafx.h"
 
-#include "core/RecyclerHeapMarkingContext.h"
+#include "Core/RecyclerHeapMarkingContext.h"
 
 class RecyclerTestObject : public IRecyclerVisitedObject
 {

--- a/bin/ch/Helpers.cpp
+++ b/bin/ch/Helpers.cpp
@@ -192,7 +192,7 @@ HRESULT Helpers::LoadScriptFromFile(LPCSTR filename, LPCSTR& contents, UINT* len
         //
         {
 #pragma warning(push)
-// suppressing prefast warning that readable size if bufferLength bytes but 2 may be read as bufferLength is clearly > 2 in the code that follows
+// suppressing prefast warning that "readable size is bufferLength bytes but 2 may be read" as bufferLength is clearly > 2 in the code that follows
 #pragma warning(disable:6385)
             C_ASSERT(sizeof(WCHAR) == 2);
             if (bufferLength > 2)

--- a/bin/ch/Helpers.cpp
+++ b/bin/ch/Helpers.cpp
@@ -191,6 +191,9 @@ HRESULT Helpers::LoadScriptFromFile(LPCSTR filename, LPCSTR& contents, UINT* len
         // wrongly classified as ANSI
         //
         {
+#pragma warning(push)
+// suppressing prefast warning that readable size if bufferLength bytes but 2 may be read as bufferLength is clearly > 2 in the code that follows
+#pragma warning(disable:6385)
             C_ASSERT(sizeof(WCHAR) == 2);
             if (bufferLength > 2)
             {
@@ -211,6 +214,7 @@ HRESULT Helpers::LoadScriptFromFile(LPCSTR filename, LPCSTR& contents, UINT* len
 #pragma prefast(pop)
             }
         }
+#pragma warning(pop)
     }
 
     contents = reinterpret_cast<LPCSTR>(pRawBytes);

--- a/lib/Common/CommonDefines.h
+++ b/lib/Common/CommonDefines.h
@@ -239,7 +239,9 @@
 #error "Background page zeroing can't be turned on if freeing pages in the background is disabled"
 #endif
 
+#ifdef _WIN32
 #define RECYCLER_VISITED_HOST
+#endif
 
 // JIT features
 

--- a/lib/Common/CommonDefines.h
+++ b/lib/Common/CommonDefines.h
@@ -239,6 +239,8 @@
 #error "Background page zeroing can't be turned on if freeing pages in the background is disabled"
 #endif
 
+#define RECYCLER_VISITED_HOST
+
 // JIT features
 
 #if DISABLE_JIT

--- a/lib/Common/CommonMinMemory.h
+++ b/lib/Common/CommonMinMemory.h
@@ -40,5 +40,6 @@ class FinalizableObject;
 #include "Memory/RecyclerSweep.h"
 #include "Memory/RecyclerHeuristic.h"
 #include "Memory/MarkContext.h"
+#include "Memory/MarkContextWrapper.h"
 #include "Memory/RecyclerWatsonTelemetry.h"
 #include "Memory/Recycler.h"

--- a/lib/Common/Core/FinalizableObject.h
+++ b/lib/Common/Core/FinalizableObject.h
@@ -15,10 +15,9 @@ public:
         Mark(static_cast<Recycler*>(recycler));
     }
 
-    bool Trace(IRecyclerHeapMarkingContext* markingContext) final
+    void Trace(IRecyclerHeapMarkingContext* markingContext) final
     {
         AssertMsg(false, "Trace called on object that isn't implemented by the host");
-        return true;
     }
 
     virtual void Mark(Recycler* recycler) = 0;

--- a/lib/Common/Core/FinalizableObject.h
+++ b/lib/Common/Core/FinalizableObject.h
@@ -9,9 +9,17 @@ class FinalizableObject : public IRecyclerVisitedObject
 {
 public:
     virtual void OnMark() {}
+
+    void Mark(RecyclerHeapHandle recycler) final
+    {
+        Mark(static_cast<Recycler*>(recycler));
+    }
+
     bool Trace(IRecyclerHeapMarkingContext* markingContext) final
     {
         AssertMsg(false, "Trace called on object that isn't implemented by the host");
         return true;
     }
+
+    virtual void Mark(Recycler* recycler) = 0;
 };

--- a/lib/Common/Core/FinalizableObject.h
+++ b/lib/Common/Core/FinalizableObject.h
@@ -3,24 +3,15 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #pragma once
-class FinalizableObject
+#include "RecyclerVisitedObject.h"
+
+class FinalizableObject : public IRecyclerVisitedObject
 {
 public:
-    // Called right after finish marking and this object is determined to be dead.
-    // Should contain only simple clean up code.
-    // Can't run another script
-    // Can't cause a re-entrant collection
-
-    virtual void Finalize(bool isShutdown) = 0;
-
-    // Call after sweeping is done.
-    // Can call other script or cause another collection.
-
-    virtual void Dispose(bool isShutdown) = 0;
-
-    // Used only by TrackableObjects (created with TrackedBit on by RecyclerNew*Tracked)
-    virtual void Mark(Recycler * recycler) = 0;
-
-    // Special behavior on certain GC's
     virtual void OnMark() {}
+    bool Trace(RecyclerHeapMarkingContext markingContext) final
+    {
+        AssertMsg(false, "Trace called on object that isn't implemented by the host");
+        return true;
+    }
 };

--- a/lib/Common/Core/RecyclerHeapMarkingContext.h
+++ b/lib/Common/Core/RecyclerHeapMarkingContext.h
@@ -3,15 +3,9 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #pragma once
-#include "RecyclerVisitedObject.h"
 
-class FinalizableObject : public IRecyclerVisitedObject
+interface IRecyclerHeapMarkingContext
 {
-public:
-    virtual void OnMark() {}
-    bool Trace(IRecyclerHeapMarkingContext* markingContext) final
-    {
-        AssertMsg(false, "Trace called on object that isn't implemented by the host");
-        return true;
-    }
+    STDMETHOD_(void, MarkObjects)(void** objects, size_t count, void* parent) = 0;
 };
+

--- a/lib/Common/Core/RecyclerHeapMarkingContext.h
+++ b/lib/Common/Core/RecyclerHeapMarkingContext.h
@@ -6,6 +6,6 @@
 
 interface IRecyclerHeapMarkingContext
 {
-    STDMETHOD_(void, MarkObjects)(void** objects, size_t count, void* parent) = 0;
+    virtual void MarkObjects(void** objects, size_t count, void* parent) = 0;
 };
 

--- a/lib/Common/Core/RecyclerVisitedObject.h
+++ b/lib/Common/Core/RecyclerVisitedObject.h
@@ -5,6 +5,7 @@
 #pragma once
 
 typedef void* RecyclerHeapMarkingContext;
+interface IRecyclerHeapMarkingContext;
 
 interface IRecyclerVisitedObject
 {
@@ -26,6 +27,6 @@ interface IRecyclerVisitedObject
     virtual void OnMark() = 0;
 
     // Used only by RecyclerVisitedHost objects (created with RecyclerAllocVistedHost_Traced*)
-    virtual bool Trace(RecyclerHeapMarkingContext markingContext) = 0;
+    virtual bool Trace(IRecyclerHeapMarkingContext* markingContext) = 0;
 };
 

--- a/lib/Common/Core/RecyclerVisitedObject.h
+++ b/lib/Common/Core/RecyclerVisitedObject.h
@@ -7,6 +7,11 @@
 typedef void* RecyclerHeapMarkingContext;
 interface IRecyclerHeapMarkingContext;
 
+namespace Memory
+{
+    class Recycler;
+}
+
 interface IRecyclerVisitedObject
 {
     // Called right after finish marking and this object is determined to be dead.
@@ -17,11 +22,10 @@ interface IRecyclerVisitedObject
 
     // Call after sweeping is done.
     // Can call other script or cause another collection.
-
     virtual void Dispose(bool isShutdown) = 0;
 
     // Used only by TrackableObjects (created with TrackedBit on by RecyclerNew*Tracked)
-    virtual void Mark(Recycler * recycler) = 0;
+    virtual void Mark(Memory::Recycler* recycler) = 0;
 
     // Special behavior on certain GC's
     virtual void OnMark() = 0;

--- a/lib/Common/Core/RecyclerVisitedObject.h
+++ b/lib/Common/Core/RecyclerVisitedObject.h
@@ -1,0 +1,31 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+#pragma once
+
+typedef void* RecyclerHeapMarkingContext;
+
+interface IRecyclerVisitedObject
+{
+    // Called right after finish marking and this object is determined to be dead.
+    // Should contain only simple clean up code.
+    // Can't run another script
+    // Can't cause a re-entrant collection
+    virtual void Finalize(bool isShutdown) = 0;
+
+    // Call after sweeping is done.
+    // Can call other script or cause another collection.
+
+    virtual void Dispose(bool isShutdown) = 0;
+
+    // Used only by TrackableObjects (created with TrackedBit on by RecyclerNew*Tracked)
+    virtual void Mark(Recycler * recycler) = 0;
+
+    // Special behavior on certain GC's
+    virtual void OnMark() = 0;
+
+    // Used only by RecyclerVisitedHost objects (created with RecyclerAllocVistedHost_Traced*)
+    virtual bool Trace(RecyclerHeapMarkingContext markingContext) = 0;
+};
+

--- a/lib/Common/Core/RecyclerVisitedObject.h
+++ b/lib/Common/Core/RecyclerVisitedObject.h
@@ -4,13 +4,8 @@
 //-------------------------------------------------------------------------------------------------------
 #pragma once
 
-typedef void* RecyclerHeapMarkingContext;
 interface IRecyclerHeapMarkingContext;
-
-namespace Memory
-{
-    class Recycler;
-}
+typedef void* RecyclerHeapHandle;
 
 interface IRecyclerVisitedObject
 {
@@ -25,7 +20,7 @@ interface IRecyclerVisitedObject
     virtual void Dispose(bool isShutdown) = 0;
 
     // Used only by TrackableObjects (created with TrackedBit on by RecyclerNew*Tracked)
-    virtual void Mark(Memory::Recycler* recycler) = 0;
+    virtual void Mark(RecyclerHeapHandle recycler) = 0;
 
     // Special behavior on certain GC's
     virtual void OnMark() = 0;

--- a/lib/Common/Core/RecyclerVisitedObject.h
+++ b/lib/Common/Core/RecyclerVisitedObject.h
@@ -26,6 +26,6 @@ interface IRecyclerVisitedObject
     virtual void OnMark() = 0;
 
     // Used only by RecyclerVisitedHost objects (created with RecyclerAllocVistedHost_Traced*)
-    virtual bool Trace(IRecyclerHeapMarkingContext* markingContext) = 0;
+    virtual void Trace(IRecyclerHeapMarkingContext* markingContext) = 0;
 };
 

--- a/lib/Common/Exceptions/ReportError.h
+++ b/lib/Common/Exceptions/ReportError.h
@@ -27,6 +27,7 @@ enum ErrorReason
     Fatal_JsReentrancy_Error = 19,
     Fatal_TTDAbort = 20,
     Fatal_Failed_API_Result = 21,
+    Fatal_RecyclerVisitedHost_LargeHeapBlock = 22,
 };
 
 extern "C" void ReportFatalException(

--- a/lib/Common/Memory/HeapBlock.cpp
+++ b/lib/Common/Memory/HeapBlock.cpp
@@ -31,6 +31,7 @@ HeapBlock::AsFinalizableBlock()
     return static_cast<SmallFinalizableHeapBlockT<TBlockAttributes> *>(this);
 }
 
+#ifdef RECYCLER_VISITED_HOST
 template <typename TBlockAttributes>
 SmallRecyclerVisitedHostHeapBlockT<TBlockAttributes> *
 HeapBlock::AsRecyclerVisitedHostBlock()
@@ -38,6 +39,7 @@ HeapBlock::AsRecyclerVisitedHostBlock()
     Assert(IsRecyclerVisitedHostBlock());
     return static_cast<SmallRecyclerVisitedHostHeapBlockT<TBlockAttributes> *>(this);
 }
+#endif
 
 #ifdef RECYCLER_WRITE_BARRIER
 template <typename TBlockAttributes>

--- a/lib/Common/Memory/HeapBlock.cpp
+++ b/lib/Common/Memory/HeapBlock.cpp
@@ -31,6 +31,14 @@ HeapBlock::AsFinalizableBlock()
     return static_cast<SmallFinalizableHeapBlockT<TBlockAttributes> *>(this);
 }
 
+template <typename TBlockAttributes>
+SmallRecyclerVisitedHostHeapBlockT<TBlockAttributes> *
+HeapBlock::AsRecyclerVisitedHostBlock()
+{
+    Assert(IsRecyclerVisitedHostBlock());
+    return static_cast<SmallRecyclerVisitedHostHeapBlockT<TBlockAttributes> *>(this);
+}
+
 #ifdef RECYCLER_WRITE_BARRIER
 template <typename TBlockAttributes>
 SmallNormalWithBarrierHeapBlockT<TBlockAttributes> *

--- a/lib/Common/Memory/HeapBlock.h
+++ b/lib/Common/Memory/HeapBlock.h
@@ -73,7 +73,7 @@ enum ObjectInfoBits : unsigned short
     FinalizeBit                 = 0x80,    // Indicates that the object has a finalizer
     PendingDisposeBit           = 0x40,    // Indicates that the object is pending dispose
     LeafBit                     = 0x20,    // Indicates that the object is a leaf-object (objects without this bit need to be scanned)
-    TrackBit                    = 0x10,    // Indicates that the object is a TrackableObject
+    TrackBit                    = 0x10,    // Indicates that the object is a TrackableObject, but has also been overloaded to mean traced for RecyclerVisitedHostHeap objects
     ImplicitRootBit             = 0x08,
     NewTrackBit                 = 0x04,    // Tracked object is newly allocated and hasn't been process by concurrent GC
     MemoryProfilerOldObjectBit  = 0x02,

--- a/lib/Common/Memory/HeapBlock.h
+++ b/lib/Common/Memory/HeapBlock.h
@@ -142,18 +142,18 @@ enum ObjectInfoBits : unsigned short
     //
     // RecyclerVisitedHostBit is implicit in the heap block type and thus isn't part of the StoredObjectInfoBitMask.
     // LeafBit is also a requirement, since no objects in this heap block are conservatively traced.
-    RecyclerVisitedHost_RequiredBits = LeafBit | RecyclerVisitedHostBit,
-    RecyclerVisitedHost_TracedBits = RecyclerVisitedHost_RequiredBits | TrackBit | NewTrackBit,
-    RecyclerVisitedHost_FinalizableBits = RecyclerVisitedHost_RequiredBits | FinalizeBit | NewFinalizeBit,
-    RecyclerVisitedHost_TracedFinalizableBits = RecyclerVisitedHost_TracedBits | FinalizeBit,
+    RecyclerVisitedHostLeafBits = RecyclerVisitedHostBit | LeafBit,
+    RecyclerVisitedHostTracedBits = RecyclerVisitedHostLeafBits | TrackBit | NewTrackBit,
+    RecyclerVisitedHostFinalizableBits = RecyclerVisitedHostLeafBits | FinalizeBit | NewFinalizeBit,
+    RecyclerVisitedHostTracedFinalizableBits = RecyclerVisitedHostTracedBits | FinalizeBit,
 
     // These set of bits describe to two possible types of blocktype bits for recycler visited host heap blocks.
     // The reason we have to distinguish between the two is because we have some objects with FinalizeBit, which
     // is part of the GetBlockTypeBitMask below, and some without (i.e. traced only). In the end, these are treated
     // the same (they result in the same recycler visited heap block/bucket type being used),
     // but are defined here for ease of use.
-    RecyclerVisitedHost_BlockTypeBits = RecyclerVisitedHost_RequiredBits,
-    RecyclerVisitedHost_FinalizableBlockTypeBits = RecyclerVisitedHost_RequiredBits | FinalizeBit,
+    RecyclerVisitedHostBlockTypeBits = RecyclerVisitedHostBit | LeafBit,
+    RecyclerVisitedHostFinalizableBlockTypeBits = RecyclerVisitedHostBlockTypeBits | FinalizeBit,
 
 #ifdef RECYCLER_WRITE_BARRIER
     GetBlockTypeBitMask = FinalizeBit | LeafBit | WithBarrierBit | RecyclerVisitedHostBit,

--- a/lib/Common/Memory/HeapBlock.h
+++ b/lib/Common/Memory/HeapBlock.h
@@ -136,24 +136,24 @@ enum ObjectInfoBits : unsigned short
     PendingDisposeObjectBits    = PendingDisposeBit | LeafBit,
 
     // Bits for use with recycler visited host heap block.
-    // Recycler visited host heap block will both mark and finalize based on FinalizableObject v-table, as specified
+    // Recycler visited host heap block will both mark and finalize based on IRecyclerVisitedHost v-table, as specified
     // by TrackBit and FinalizeBit. These objects are expected to be allocated by chakra, but implemented by
-    // the host, including construction of the FinalizableObject v-table.
+    // the host, including construction of the IRecyclerVisitedHost v-table.
     //
     // RecyclerVisitedHostBit is implicit in the heap block type and thus isn't part of the StoredObjectInfoBitMask.
-    // LeafBit is also a requirement, since no objects in this heap block are conservatively traced.
+    // LeafBit is also set for any object that is not precisely traced.
     RecyclerVisitedHostLeafBits = RecyclerVisitedHostBit | LeafBit,
-    RecyclerVisitedHostTracedBits = RecyclerVisitedHostLeafBits | TrackBit | NewTrackBit,
+    RecyclerVisitedHostTracedBits = RecyclerVisitedHostBit | TrackBit | NewTrackBit,
     RecyclerVisitedHostFinalizableBits = RecyclerVisitedHostLeafBits | FinalizeBit | NewFinalizeBit,
     RecyclerVisitedHostTracedFinalizableBits = RecyclerVisitedHostTracedBits | FinalizeBit,
 
-    // These set of bits describe to two possible types of blocktype bits for recycler visited host heap blocks.
-    // The reason we have to distinguish between the two is because we have some objects with FinalizeBit, which
-    // is part of the GetBlockTypeBitMask below, and some without (i.e. traced only). In the end, these are treated
-    // the same (they result in the same recycler visited heap block/bucket type being used),
+    // These set of bits describe the four possible types of blocktype bits for recycler visited host heap blocks.
+    // These are the four combinations of the above bits, AND'd with GetBlockTypeBitMask.
+    // In the end, these are treated the same in terms of which heap block/bucket type they end up using and
     // but are defined here for ease of use.
-    RecyclerVisitedHostBlockTypeBits = RecyclerVisitedHostBit | LeafBit,
-    RecyclerVisitedHostFinalizableBlockTypeBits = RecyclerVisitedHostBlockTypeBits | FinalizeBit,
+    RecyclerVisitedHostLeafBlockTypeBits = RecyclerVisitedHostBit | LeafBit,
+    RecyclerVisitedHostFinalizableBlockTypeBits = RecyclerVisitedHostLeafBlockTypeBits | FinalizeBit,
+    RecyclerVisitedHostTracedFinalizableBlockTypeBits = RecyclerVisitedHostBit | FinalizeBit,
 
 #ifdef RECYCLER_WRITE_BARRIER
     GetBlockTypeBitMask = FinalizeBit | LeafBit | WithBarrierBit | RecyclerVisitedHostBit,

--- a/lib/Common/Memory/HeapBlock.h
+++ b/lib/Common/Memory/HeapBlock.h
@@ -142,17 +142,15 @@ enum ObjectInfoBits : unsigned short
     //
     // RecyclerVisitedHostBit is implicit in the heap block type and thus isn't part of the StoredObjectInfoBitMask.
     // LeafBit is also set for any object that is not precisely traced.
-    RecyclerVisitedHostLeafBits = RecyclerVisitedHostBit | LeafBit,
     RecyclerVisitedHostTracedBits = RecyclerVisitedHostBit | TrackBit | NewTrackBit,
-    RecyclerVisitedHostFinalizableBits = RecyclerVisitedHostLeafBits | FinalizeBit | NewFinalizeBit,
+    RecyclerVisitedHostFinalizableBits = RecyclerVisitedHostBit | LeafBit | FinalizeBit | NewFinalizeBit,
     RecyclerVisitedHostTracedFinalizableBits = RecyclerVisitedHostTracedBits | FinalizeBit,
 
     // These set of bits describe the four possible types of blocktype bits for recycler visited host heap blocks.
     // These are the four combinations of the above bits, AND'd with GetBlockTypeBitMask.
     // In the end, these are treated the same in terms of which heap block/bucket type they end up using and
     // but are defined here for ease of use.
-    RecyclerVisitedHostLeafBlockTypeBits = RecyclerVisitedHostBit | LeafBit,
-    RecyclerVisitedHostFinalizableBlockTypeBits = RecyclerVisitedHostLeafBlockTypeBits | FinalizeBit,
+    RecyclerVisitedHostFinalizableBlockTypeBits = RecyclerVisitedHostBit | LeafBit | FinalizeBit,
     RecyclerVisitedHostTracedFinalizableBlockTypeBits = RecyclerVisitedHostBit | FinalizeBit,
 
 #ifdef RECYCLER_WRITE_BARRIER

--- a/lib/Common/Memory/HeapBlock.h
+++ b/lib/Common/Memory/HeapBlock.h
@@ -160,12 +160,12 @@ enum ObjectInfoBits : unsigned short
 
     GetBlockTypeBitMask = FinalizeBit | LeafBit 
 #ifdef RECYCLER_WRITE_BARRIER
-	| WithBarrierBit
+    | WithBarrierBit
 #endif
 #ifdef RECYCLER_VISITED_HOST
-	| RecyclerVisitedHostBit
+    | RecyclerVisitedHostBit
 #endif
-	,
+    ,
 
     CollectionBitMask           = LeafBit | FinalizeBit | TrackBit | NewTrackBit,  // Bits relevant to collection
 
@@ -221,8 +221,8 @@ template <class TBlockAttributes> class SmallFinalizableWithBarrierHeapBlockT;
 
 #define INSTANTIATE_SWB_BLOCKTYPES(TemplateType) \
     template class TemplateType<Memory::SmallNormalWithBarrierHeapBlock>; \
-	template class TemplateType<Memory::SmallFinalizableWithBarrierHeapBlock>; \
-	template class TemplateType<Memory::MediumNormalWithBarrierHeapBlock>; \
+    template class TemplateType<Memory::SmallFinalizableWithBarrierHeapBlock>; \
+    template class TemplateType<Memory::MediumNormalWithBarrierHeapBlock>; \
     template class TemplateType<Memory::MediumFinalizableWithBarrierHeapBlock>; \
 
 
@@ -233,8 +233,8 @@ template <class TBlockAttributes> class SmallFinalizableWithBarrierHeapBlockT;
 #ifdef RECYCLER_VISITED_HOST
 template <class TBlockAttributes> class SmallRecyclerVisitedHostHeapBlockT;
 #define INSTANTIATE_RECYCLER_VISITED_BLOCKTYPES(TemplateType) \
-	template class TemplateType<Memory::SmallRecyclerVisitedHostHeapBlock>; \
-	template class TemplateType<Memory::MediumRecyclerVisitedHostHeapBlock>; \
+    template class TemplateType<Memory::SmallRecyclerVisitedHostHeapBlock>; \
+    template class TemplateType<Memory::MediumRecyclerVisitedHostHeapBlock>; \
 
 #else
 #define INSTANTIATE_RECYCLER_VISITED_BLOCKTYPES(TemplateType)
@@ -247,8 +247,8 @@ template <class TBlockAttributes> class SmallRecyclerVisitedHostHeapBlockT;
     template class TemplateType<Memory::MediumNormalHeapBlock>; \
     template class TemplateType<Memory::MediumLeafHeapBlock>; \
     template class TemplateType<Memory::MediumFinalizableHeapBlock>; \
-	INSTANTIATE_SWB_BLOCKTYPES(TemplateType) \
-	INSTANTIATE_RECYCLER_VISITED_BLOCKTYPES(TemplateType) \
+    INSTANTIATE_SWB_BLOCKTYPES(TemplateType) \
+    INSTANTIATE_RECYCLER_VISITED_BLOCKTYPES(TemplateType) \
 
 class RecyclerHeapObjectInfo;
 class HeapBlock
@@ -280,32 +280,32 @@ public:
         LargeBlockType,
 
 #ifdef RECYCLER_VISITED_HOST
-		SmallAllocBlockTypeCount = 7, // Actual number of types for blocks containing small allocations
+        SmallAllocBlockTypeCount = 7, // Actual number of types for blocks containing small allocations
 #else
-		SmallAllocBlockTypeCount = 6,
+        SmallAllocBlockTypeCount = 6,
 #endif
 
 #ifdef RECYCLER_VISITED_HOST
-		MediumAllocBlockTypeCount = 6, // Actual number of types for blocks containing medium allocations
+        MediumAllocBlockTypeCount = 6, // Actual number of types for blocks containing medium allocations
 #else
-		MediumAllocBlockTypeCount = 5,
+        MediumAllocBlockTypeCount = 5,
 #endif
 
         SmallBlockTypeCount = SmallAllocBlockTypeCount + MediumAllocBlockTypeCount,      // Distinct block types independent of allocation size using SmallHeapBlockT
-		LargeBlockTypeCount = 1, // There is only one LargeBlockType
+        LargeBlockTypeCount = 1, // There is only one LargeBlockType
 
         BlockTypeCount = SmallBlockTypeCount + LargeBlockTypeCount,
     };
     bool IsNormalBlock() const { return this->GetHeapBlockType() == SmallNormalBlockType || this->GetHeapBlockType() == MediumNormalBlockType; }
     bool IsLeafBlock() const { return this->GetHeapBlockType() == SmallLeafBlockType || this->GetHeapBlockType() == MediumLeafBlockType; }
-	bool IsFinalizableBlock() const 
-	{
-		return this->GetHeapBlockType() == SmallFinalizableBlockType || this->GetHeapBlockType() == MediumFinalizableBlockType
+    bool IsFinalizableBlock() const 
+    {
+        return this->GetHeapBlockType() == SmallFinalizableBlockType || this->GetHeapBlockType() == MediumFinalizableBlockType
 #ifdef RECYCLER_VISITED_HOST
-			|| IsRecyclerVisitedHostBlock()
+            || IsRecyclerVisitedHostBlock()
 #endif
-			;
-	}
+            ;
+    }
 #ifdef RECYCLER_VISITED_HOST
     bool IsRecyclerVisitedHostBlock() const { return this->GetHeapBlockType() == SmallRecyclerVisitedHostBlockType || this->GetHeapBlockType() == MediumRecyclerVisitedHostBlockType; }
 #endif
@@ -364,7 +364,7 @@ public:
         heapBlockType(heapBlockType),
         needOOMRescan(false)
     {
-		static_assert(HeapBlockType::LargeBlockType == HeapBlockType::SmallBlockTypeCount, "LargeBlockType must come right after small+medium alloc block types");
+        static_assert(HeapBlockType::LargeBlockType == HeapBlockType::SmallBlockTypeCount, "LargeBlockType must come right after small+medium alloc block types");
         Assert(GetHeapBlockType() <= HeapBlock::HeapBlockType::BlockTypeCount);
     }
 

--- a/lib/Common/Memory/HeapBlock.inl
+++ b/lib/Common/Memory/HeapBlock.inl
@@ -157,6 +157,8 @@ template <bool doSpecialMark, typename Fn>
 bool
 HeapBlock::UpdateAttributesOfMarkedObjects(MarkContext * markContext, void * objectAddress, size_t objectSize, unsigned char attributes, Fn fn)
 {
+    Assert(GetHeapBlockType() != HeapBlock::HeapBlockType::SmallRecyclerVisitedHostBlockType && GetHeapBlockType() != HeapBlock::HeapBlockType::MediumRecyclerVisitedHostBlockType);
+
     bool noOOMDuringMark = true;
 
     if (attributes & TrackBit)

--- a/lib/Common/Memory/HeapBlock.inl
+++ b/lib/Common/Memory/HeapBlock.inl
@@ -157,7 +157,9 @@ template <bool doSpecialMark, typename Fn>
 bool
 HeapBlock::UpdateAttributesOfMarkedObjects(MarkContext * markContext, void * objectAddress, size_t objectSize, unsigned char attributes, Fn fn)
 {
+#ifdef RECYCLER_VISITED_HOST
     Assert(GetHeapBlockType() != HeapBlock::HeapBlockType::SmallRecyclerVisitedHostBlockType && GetHeapBlockType() != HeapBlock::HeapBlockType::MediumRecyclerVisitedHostBlockType);
+#endif
 
     bool noOOMDuringMark = true;
 

--- a/lib/Common/Memory/HeapBlockMap.cpp
+++ b/lib/Common/Memory/HeapBlockMap.cpp
@@ -662,8 +662,10 @@ HeapBlockMap32::RescanPage(void * dirtyPage, bool* anyObjectsMarkedOnPage, Recyc
         case HeapBlock::HeapBlockType::SmallFinalizableBlockWithBarrierType:
 #endif
             return RescanHeapBlock<SmallFinalizableHeapBlock>(dirtyPage, blockType, chunk, id2, anyObjectsMarkedOnPage, recycler);
+#ifdef RECYCLER_VISITED_HOST
         case HeapBlock::HeapBlockType::SmallRecyclerVisitedHostBlockType:
             return RescanHeapBlock<SmallRecyclerVisitedHostHeapBlock>(dirtyPage, blockType, chunk, id2, anyObjectsMarkedOnPage, recycler);
+#endif
         case HeapBlock::HeapBlockType::MediumNormalBlockType:
 #ifdef RECYCLER_WRITE_BARRIER
         case HeapBlock::HeapBlockType::MediumNormalBlockWithBarrierType:
@@ -674,8 +676,10 @@ HeapBlockMap32::RescanPage(void * dirtyPage, bool* anyObjectsMarkedOnPage, Recyc
         case HeapBlock::HeapBlockType::MediumFinalizableBlockWithBarrierType:
 #endif
             return RescanHeapBlock<MediumFinalizableHeapBlock>(dirtyPage, blockType, chunk, id2, anyObjectsMarkedOnPage, recycler);
+#ifdef RECYCLER_VISITED_HOST
         case HeapBlock::HeapBlockType::MediumRecyclerVisitedHostBlockType:
             return RescanHeapBlock<MediumRecyclerVisitedHostHeapBlock>(dirtyPage, blockType, chunk, id2, anyObjectsMarkedOnPage, recycler);
+#endif
         default:
             // Shouldn't be here -- leaf blocks aren't rescanned, and large blocks are handled separately
             Assert(false);
@@ -747,19 +751,23 @@ HeapBlockMap32::GetHeapBlockForRescan(HeapBlockMap32::L2MapChunk* chunk, uint id
     return (MediumFinalizableHeapBlock*)chunk->map[id2];
 }
 
+#ifdef RECYCLER_VISITED_HOST
 template <>
 SmallRecyclerVisitedHostHeapBlock*
 HeapBlockMap32::GetHeapBlockForRescan(HeapBlockMap32::L2MapChunk* chunk, uint id2) const
 {
     return (SmallRecyclerVisitedHostHeapBlock*) chunk->map[id2];
 }
+#endif
 
+#ifdef RECYCLER_VISITED_HOST
 template <>
 MediumRecyclerVisitedHostHeapBlock*
 HeapBlockMap32::GetHeapBlockForRescan(HeapBlockMap32::L2MapChunk* chunk, uint id2) const
 {
     return (MediumRecyclerVisitedHostHeapBlock*)chunk->map[id2];
 }
+#endif
 
 void
 HeapBlockMap32::MakeAllPagesReadOnly(Recycler* recycler)
@@ -1040,12 +1048,14 @@ HeapBlockMap32::OOMRescan(Recycler * recycler)
                                     return;
                                 }
                                 break;
+#ifdef RECYCLER_VISITED_HOST
                             case HeapBlock::HeapBlockType::SmallRecyclerVisitedHostBlockType:
                                 if (!RescanHeapBlockOnOOM<SmallRecyclerVisitedHostHeapBlock>((SmallRecyclerVisitedHostHeapBlock*) heapBlock, pageAddress, blockType, chunk->blockInfo[id2].bucketIndex, chunk, recycler))
                                 {
                                     return;
                                 }
                                 break;
+#endif
 
                             case HeapBlock::HeapBlockType::MediumNormalBlockType:
 #ifdef RECYCLER_WRITE_BARRIER
@@ -1066,12 +1076,14 @@ HeapBlockMap32::OOMRescan(Recycler * recycler)
                                     return;
                                 }
                                 break;
+#ifdef RECYCLER_VISITED_HOST
                             case HeapBlock::HeapBlockType::MediumRecyclerVisitedHostBlockType:
                                 if (!RescanHeapBlockOnOOM<MediumRecyclerVisitedHostHeapBlock>((MediumRecyclerVisitedHostHeapBlock*) heapBlock, pageAddress, blockType, chunk->blockInfo[id2].bucketIndex, chunk, recycler))
                                 {
                                     return;
                                 }
                                 break;
+#endif
 
                             default:
                                 // Shouldn't be here -- leaf blocks aren't rescanned, and large blocks are handled separately

--- a/lib/Common/Memory/HeapBlockMap.cpp
+++ b/lib/Common/Memory/HeapBlockMap.cpp
@@ -658,6 +658,7 @@ HeapBlockMap32::RescanPage(void * dirtyPage, bool* anyObjectsMarkedOnPage, Recyc
 #endif
             return RescanHeapBlock<SmallNormalHeapBlock>(dirtyPage, blockType, chunk, id2, anyObjectsMarkedOnPage, recycler);
         case HeapBlock::HeapBlockType::SmallFinalizableBlockType:
+        case HeapBlock::HeapBlockType::SmallRecyclerVisitedHostBlockType:
 #ifdef RECYCLER_WRITE_BARRIER
         case HeapBlock::HeapBlockType::SmallFinalizableBlockWithBarrierType:
 #endif
@@ -668,6 +669,7 @@ HeapBlockMap32::RescanPage(void * dirtyPage, bool* anyObjectsMarkedOnPage, Recyc
 #endif
             return RescanHeapBlock<MediumNormalHeapBlock>(dirtyPage, blockType, chunk, id2, anyObjectsMarkedOnPage, recycler);
         case HeapBlock::HeapBlockType::MediumFinalizableBlockType:
+        case HeapBlock::HeapBlockType::MediumRecyclerVisitedHostBlockType:
 #ifdef RECYCLER_WRITE_BARRIER
         case HeapBlock::HeapBlockType::MediumFinalizableBlockWithBarrierType:
 #endif
@@ -1014,6 +1016,7 @@ HeapBlockMap32::OOMRescan(Recycler * recycler)
                                 break;
 
                             case HeapBlock::HeapBlockType::SmallFinalizableBlockType:
+                            case HeapBlock::HeapBlockType::SmallRecyclerVisitedHostBlockType:
 #ifdef RECYCLER_WRITE_BARRIER
                             case HeapBlock::HeapBlockType::SmallFinalizableBlockWithBarrierType:
 #endif
@@ -1034,6 +1037,7 @@ HeapBlockMap32::OOMRescan(Recycler * recycler)
                                 break;
 
                             case HeapBlock::HeapBlockType::MediumFinalizableBlockType:
+                            case HeapBlock::HeapBlockType::MediumRecyclerVisitedHostBlockType:
 #ifdef RECYCLER_WRITE_BARRIER
                             case HeapBlock::HeapBlockType::MediumFinalizableBlockWithBarrierType:
 #endif

--- a/lib/Common/Memory/HeapBlockMap.inl
+++ b/lib/Common/Memory/HeapBlockMap.inl
@@ -142,6 +142,7 @@ HeapBlockMap32::Mark(void * candidate, MarkContext * markContext)
 #endif
         ((SmallFinalizableHeapBlock*)chunk->map[id2])->ProcessMarkedObject<doSpecialMark>(candidate, markContext);
         break;
+#ifdef RECYCLER_VISITED_HOST
     case HeapBlock::HeapBlockType::SmallRecyclerVisitedHostBlockType:
         {
             void * realCandidate = ((SmallFinalizableHeapBlock*)chunk->map[id2])->GetRealAddressFromInterior(candidate);
@@ -153,12 +154,14 @@ HeapBlockMap32::Mark(void * candidate, MarkContext * markContext)
             ((SmallRecyclerVisitedHostHeapBlock*)chunk->map[id2])->ProcessMarkedObject<doSpecialMark>(realCandidate, markContext);
         }
         break;
+#endif
     case HeapBlock::HeapBlockType::MediumFinalizableBlockType:
 #ifdef RECYCLER_WRITE_BARRIER
     case HeapBlock::HeapBlockType::MediumFinalizableBlockWithBarrierType:
 #endif
         ((MediumFinalizableHeapBlock*)chunk->map[id2])->ProcessMarkedObject<doSpecialMark>(candidate, markContext);
         break;
+#ifdef RECYCLER_VISITED_HOST
     case HeapBlock::HeapBlockType::MediumRecyclerVisitedHostBlockType:
         {
             void * realCandidate = ((MediumFinalizableHeapBlock*)chunk->map[id2])->GetRealAddressFromInterior(candidate);
@@ -170,6 +173,7 @@ HeapBlockMap32::Mark(void * candidate, MarkContext * markContext)
             ((MediumRecyclerVisitedHostHeapBlock*)chunk->map[id2])->ProcessMarkedObject<doSpecialMark>(realCandidate, markContext);
         }
         break;
+#endif
     case HeapBlock::HeapBlockType::LargeBlockType:
         ((LargeHeapBlock*)chunk->map[id2])->Mark<doSpecialMark>(candidate, markContext);
         break;
@@ -388,6 +392,7 @@ HeapBlockMap32::MarkInterior(void * candidate, MarkContext * markContext)
             ((MediumFinalizableHeapBlock*)chunk->map[id2])->ProcessMarkedObject<false>(realCandidate, markContext);
         }
         break;
+#ifdef RECYCLER_VISITED_HOST
     case HeapBlock::HeapBlockType::SmallRecyclerVisitedHostBlockType:
         {
             void * realCandidate = ((SmallFinalizableHeapBlock*)chunk->map[id2])->GetRealAddressFromInterior(candidate);
@@ -410,6 +415,7 @@ HeapBlockMap32::MarkInterior(void * candidate, MarkContext * markContext)
             ((MediumRecyclerVisitedHostHeapBlock*)chunk->map[id2])->ProcessMarkedObject<false>(realCandidate, markContext);
         }
         break;
+#endif
     case HeapBlock::HeapBlockType::LargeBlockType:
         {
             void * realCandidate = ((LargeHeapBlock*)chunk->map[id2])->GetRealAddressFromInterior(candidate);

--- a/lib/Common/Memory/HeapBlockMap.inl
+++ b/lib/Common/Memory/HeapBlockMap.inl
@@ -137,12 +137,14 @@ HeapBlockMap32::Mark(void * candidate, MarkContext * markContext)
         }
         break;
     case HeapBlock::HeapBlockType::SmallFinalizableBlockType:
+    case HeapBlock::HeapBlockType::SmallRecyclerVisitedHostBlockType:
 #ifdef RECYCLER_WRITE_BARRIER
     case HeapBlock::HeapBlockType::SmallFinalizableBlockWithBarrierType:
 #endif
         ((SmallFinalizableHeapBlock*)chunk->map[id2])->ProcessMarkedObject<doSpecialMark>(candidate, markContext);
         break;
     case HeapBlock::HeapBlockType::MediumFinalizableBlockType:
+    case HeapBlock::HeapBlockType::MediumRecyclerVisitedHostBlockType:
 #ifdef RECYCLER_WRITE_BARRIER
     case HeapBlock::HeapBlockType::MediumFinalizableBlockWithBarrierType:
 #endif

--- a/lib/Common/Memory/HeapBucket.cpp
+++ b/lib/Common/Memory/HeapBucket.cpp
@@ -1588,7 +1588,9 @@ HeapBucketGroup<TBlockAttributes>::Initialize(HeapInfo * heapInfo, uint sizeCat)
     smallFinalizableWithBarrierHeapBucket.Initialize(heapInfo, sizeCat);
 #endif
     finalizableHeapBucket.Initialize(heapInfo, sizeCat);
+#ifdef RECYCLER_VISITED_HOST
     recyclerVisitedHostHeapBucket.Initialize(heapInfo, sizeCat);
+#endif
 }
 
 template <class TBlockAttributes>
@@ -1605,7 +1607,9 @@ HeapBucketGroup<TBlockAttributes>::ResetMarks(ResetMarkFlags flags)
     // Although we pass in premarkFreeObjects, the finalizable heap bucket ignores
     // this parameter and never pre-marks free objects
     finalizableHeapBucket.ResetMarks(flags);
+#ifdef RECYCLER_VISITED_HOST
     recyclerVisitedHostHeapBucket.ResetMarks(flags);
+#endif
 }
 
 template <class TBlockAttributes>
@@ -1619,7 +1623,9 @@ HeapBucketGroup<TBlockAttributes>::ScanInitialImplicitRoots(Recycler * recycler)
     smallFinalizableWithBarrierHeapBucket.ScanInitialImplicitRoots(recycler);
 #endif
     finalizableHeapBucket.ScanInitialImplicitRoots(recycler);
+#ifdef RECYCLER_VISITED_HOST
     recyclerVisitedHostHeapBucket.ScanInitialImplicitRoots(recycler);
+#endif
 }
 
 template <class TBlockAttributes>
@@ -1634,7 +1640,9 @@ HeapBucketGroup<TBlockAttributes>::ScanNewImplicitRoots(Recycler * recycler)
     smallFinalizableWithBarrierHeapBucket.ScanNewImplicitRoots(recycler);
 #endif
     finalizableHeapBucket.ScanNewImplicitRoots(recycler);
+#ifdef RECYCLER_VISITED_HOST
     recyclerVisitedHostHeapBucket.ScanNewImplicitRoots(recycler);
+#endif
 }
 
 template <class TBlockAttributes>
@@ -1655,7 +1663,9 @@ void
 HeapBucketGroup<TBlockAttributes>::SweepFinalizableObjects(RecyclerSweep& recyclerSweep)
 {
     finalizableHeapBucket.Sweep(recyclerSweep);
+#ifdef RECYCLER_VISITED_HOST
     recyclerVisitedHostHeapBucket.Sweep(recyclerSweep);
+#endif
 #ifdef RECYCLER_WRITE_BARRIER
     smallFinalizableWithBarrierHeapBucket.Sweep(recyclerSweep);
 #endif
@@ -1666,7 +1676,9 @@ void
 HeapBucketGroup<TBlockAttributes>::DisposeObjects()
 {
     finalizableHeapBucket.DisposeObjects();
+#ifdef RECYCLER_VISITED_HOST
     recyclerVisitedHostHeapBucket.DisposeObjects();
+#endif
 #ifdef RECYCLER_WRITE_BARRIER
     smallFinalizableWithBarrierHeapBucket.DisposeObjects();
 #endif
@@ -1677,7 +1689,9 @@ void
 HeapBucketGroup<TBlockAttributes>::TransferDisposedObjects()
 {
     finalizableHeapBucket.TransferDisposedObjects();
+#ifdef RECYCLER_VISITED_HOST
     recyclerVisitedHostHeapBucket.TransferDisposedObjects();
+#endif
 #ifdef RECYCLER_WRITE_BARRIER
     smallFinalizableWithBarrierHeapBucket.TransferDisposedObjects();
 #endif
@@ -1694,7 +1708,9 @@ HeapBucketGroup<TBlockAttributes>::EnumerateObjects(ObjectInfoBits infoBits, voi
     smallFinalizableWithBarrierHeapBucket.EnumerateObjects(infoBits, CallBackFunction);
 #endif
     finalizableHeapBucket.EnumerateObjects(infoBits, CallBackFunction);
+#ifdef RECYCLER_VISITED_HOST
     recyclerVisitedHostHeapBucket.EnumerateObjects(infoBits, CallBackFunction);
+#endif
 }
 
 template <class TBlockAttributes>
@@ -1702,7 +1718,9 @@ void
 HeapBucketGroup<TBlockAttributes>::FinalizeAllObjects()
 {
     finalizableHeapBucket.FinalizeAllObjects();
+#ifdef RECYCLER_VISITED_HOST
     recyclerVisitedHostHeapBucket.FinalizeAllObjects();
+#endif
 #ifdef RECYCLER_WRITE_BARRIER
     smallFinalizableWithBarrierHeapBucket.FinalizeAllObjects();
 #endif
@@ -1712,14 +1730,16 @@ template <class TBlockAttributes>
 uint
 HeapBucketGroup<TBlockAttributes>::Rescan(Recycler * recycler, RescanFlags flags)
 {
-    return heapBucket.Rescan(recycler, flags) +
-        leafHeapBucket.Rescan(recycler, flags) +
+	return heapBucket.Rescan(recycler, flags) +
+		leafHeapBucket.Rescan(recycler, flags) +
 #ifdef RECYCLER_WRITE_BARRIER
-        smallNormalWithBarrierHeapBucket.Rescan(recycler, flags) +
-        smallFinalizableWithBarrierHeapBucket.Rescan(recycler, flags) +
+		smallNormalWithBarrierHeapBucket.Rescan(recycler, flags) +
+		smallFinalizableWithBarrierHeapBucket.Rescan(recycler, flags) +
 #endif
-        finalizableHeapBucket.Rescan(recycler, flags) +
-        recyclerVisitedHostHeapBucket.Rescan(recycler, flags);
+#ifdef RECYCLER_VISITED_HOST
+		recyclerVisitedHostHeapBucket.Rescan(recycler, flags) +
+#endif
+		finalizableHeapBucket.Rescan(recycler, flags);
 }
 
 #if ENABLE_CONCURRENT_GC
@@ -1734,7 +1754,9 @@ HeapBucketGroup<TBlockAttributes>::PrepareSweep()
     smallFinalizableWithBarrierHeapBucket.PrepareSweep();
 #endif
     finalizableHeapBucket.PrepareSweep();
+#ifdef RECYCLER_VISITED_HOST
     recyclerVisitedHostHeapBucket.PrepareSweep();
+#endif
 }
 
 template <class TBlockAttributes>
@@ -1763,7 +1785,9 @@ HeapBucketGroup<TBlockAttributes>::SweepPartialReusePages(RecyclerSweep& recycle
 #endif
 
     finalizableHeapBucket.SweepPartialReusePages(recyclerSweep);
+#ifdef RECYCLER_VISITED_HOST
     recyclerVisitedHostHeapBucket.SweepPartialReusePages(recyclerSweep);
+#endif
 }
 
 template <class TBlockAttributes>
@@ -1776,7 +1800,9 @@ HeapBucketGroup<TBlockAttributes>::FinishPartialCollect(RecyclerSweep * recycler
     smallFinalizableWithBarrierHeapBucket.FinishPartialCollect(recyclerSweep);
 #endif
     finalizableHeapBucket.FinishPartialCollect(recyclerSweep);
+#ifdef RECYCLER_VISITED_HOST
     recyclerVisitedHostHeapBucket.FinishPartialCollect(recyclerSweep);
+#endif
 
     // Leaf heap block always do a full sweep instead of partial sweep
     // (since touching the page doesn't affect rescan)
@@ -1803,7 +1829,9 @@ HeapBucketGroup<TBlockAttributes>::SweepPendingObjects(RecyclerSweep& recyclerSw
 #endif
 
     finalizableHeapBucket.SweepPendingObjects(recyclerSweep);
+#ifdef RECYCLER_VISITED_HOST
     recyclerVisitedHostHeapBucket.SweepPendingObjects(recyclerSweep);
+#endif
 }
 
 template <class TBlockAttributes>
@@ -1817,7 +1845,9 @@ HeapBucketGroup<TBlockAttributes>::TransferPendingEmptyHeapBlocks(RecyclerSweep&
     recyclerSweep.TransferPendingEmptyHeapBlocks(&smallFinalizableWithBarrierHeapBucket);
 #endif
     recyclerSweep.TransferPendingEmptyHeapBlocks(&finalizableHeapBucket);
+#ifdef RECYCLER_VISITED_HOST
     recyclerSweep.TransferPendingEmptyHeapBlocks(&recyclerVisitedHostHeapBucket);
+#endif
 }
 #endif
 
@@ -1828,7 +1858,9 @@ HeapBucketGroup<TBlockAttributes>::GetNonEmptyHeapBlockCount(bool checkCount) co
 {
     return heapBucket.GetNonEmptyHeapBlockCount(checkCount) +
         finalizableHeapBucket.GetNonEmptyHeapBlockCount(checkCount) +
+#ifdef RECYCLER_VISITED_HOST
         recyclerVisitedHostHeapBucket.GetNonEmptyHeapBlockCount(checkCount) +
+#endif
 #ifdef RECYCLER_WRITE_BARRIER
         smallNormalWithBarrierHeapBucket.GetNonEmptyHeapBlockCount(checkCount) +
         smallFinalizableWithBarrierHeapBucket.GetNonEmptyHeapBlockCount(checkCount) +
@@ -1842,7 +1874,9 @@ HeapBucketGroup<TBlockAttributes>::GetEmptyHeapBlockCount() const
 {
     return heapBucket.GetEmptyHeapBlockCount() +
         finalizableHeapBucket.GetEmptyHeapBlockCount() +
+#ifdef RECYCLER_VISITED_HOST
         recyclerVisitedHostHeapBucket.GetEmptyHeapBlockCount() +
+#endif
 #ifdef RECYCLER_WRITE_BARRIER
         smallNormalWithBarrierHeapBucket.GetEmptyHeapBlockCount() +
         smallFinalizableWithBarrierHeapBucket.GetEmptyHeapBlockCount() +
@@ -1856,7 +1890,10 @@ template <class TBlockAttributes>
 size_t
 HeapBucketGroup<TBlockAttributes>::Check()
 {
-    return heapBucket.Check() + finalizableHeapBucket.Check() + leafHeapBucket.Check() + recyclerVisitedHostHeapBucket.Check()
+    return heapBucket.Check() + finalizableHeapBucket.Check() + leafHeapBucket.Check()
+#ifdef RECYCLER_VISITED_HOST
+		+ recyclerVisitedHostHeapBucket.Check()
+#endif
 #ifdef RECYCLER_WRITE_BARRIER
         + smallNormalWithBarrierHeapBucket.Check() + smallFinalizableWithBarrierHeapBucket.Check()
 #endif
@@ -1870,7 +1907,9 @@ HeapBucketGroup<TBlockAttributes>::Verify()
 {
     heapBucket.Verify();
     finalizableHeapBucket.Verify();
+#ifdef RECYCLER_VISITED_HOST
     recyclerVisitedHostHeapBucket.Verify();
+#endif
     leafHeapBucket.Verify();
 #ifdef RECYCLER_WRITE_BARRIER
     smallNormalWithBarrierHeapBucket.Verify();
@@ -1885,7 +1924,9 @@ HeapBucketGroup<TBlockAttributes>::VerifyMark()
 {
     heapBucket.VerifyMark();
     finalizableHeapBucket.VerifyMark();
+#ifdef RECYCLER_VISITED_HOST
     recyclerVisitedHostHeapBucket.VerifyMark();
+#endif
     leafHeapBucket.VerifyMark();
 #ifdef RECYCLER_WRITE_BARRIER
     smallNormalWithBarrierHeapBucket.VerifyMark();
@@ -1937,7 +1978,9 @@ HeapBucketGroup<TBlockAttributes>::AllocatorsAreEmpty()
 {
     return heapBucket.AllocatorsAreEmpty()
         && finalizableHeapBucket.AllocatorsAreEmpty()
+#ifdef RECYCLER_VISITED_HOST
         && recyclerVisitedHostHeapBucket.AllocatorsAreEmpty()
+#endif
         && leafHeapBucket.AllocatorsAreEmpty()
 #ifdef RECYCLER_WRITE_BARRIER
         && smallNormalWithBarrierHeapBucket.AllocatorsAreEmpty()

--- a/lib/Common/Memory/HeapBucket.cpp
+++ b/lib/Common/Memory/HeapBucket.cpp
@@ -1588,6 +1588,7 @@ HeapBucketGroup<TBlockAttributes>::Initialize(HeapInfo * heapInfo, uint sizeCat)
     smallFinalizableWithBarrierHeapBucket.Initialize(heapInfo, sizeCat);
 #endif
     finalizableHeapBucket.Initialize(heapInfo, sizeCat);
+    recyclerVisitedHostHeapBucket.Initialize(heapInfo, sizeCat);
 }
 
 template <class TBlockAttributes>
@@ -1604,6 +1605,7 @@ HeapBucketGroup<TBlockAttributes>::ResetMarks(ResetMarkFlags flags)
     // Although we pass in premarkFreeObjects, the finalizable heap bucket ignores
     // this parameter and never pre-marks free objects
     finalizableHeapBucket.ResetMarks(flags);
+    recyclerVisitedHostHeapBucket.ResetMarks(flags);
 }
 
 template <class TBlockAttributes>
@@ -1617,6 +1619,7 @@ HeapBucketGroup<TBlockAttributes>::ScanInitialImplicitRoots(Recycler * recycler)
     smallFinalizableWithBarrierHeapBucket.ScanInitialImplicitRoots(recycler);
 #endif
     finalizableHeapBucket.ScanInitialImplicitRoots(recycler);
+    recyclerVisitedHostHeapBucket.ScanInitialImplicitRoots(recycler);
 }
 
 template <class TBlockAttributes>
@@ -1631,6 +1634,7 @@ HeapBucketGroup<TBlockAttributes>::ScanNewImplicitRoots(Recycler * recycler)
     smallFinalizableWithBarrierHeapBucket.ScanNewImplicitRoots(recycler);
 #endif
     finalizableHeapBucket.ScanNewImplicitRoots(recycler);
+    recyclerVisitedHostHeapBucket.ScanNewImplicitRoots(recycler);
 }
 
 template <class TBlockAttributes>
@@ -1651,6 +1655,7 @@ void
 HeapBucketGroup<TBlockAttributes>::SweepFinalizableObjects(RecyclerSweep& recyclerSweep)
 {
     finalizableHeapBucket.Sweep(recyclerSweep);
+    recyclerVisitedHostHeapBucket.Sweep(recyclerSweep);
 #ifdef RECYCLER_WRITE_BARRIER
     smallFinalizableWithBarrierHeapBucket.Sweep(recyclerSweep);
 #endif
@@ -1661,6 +1666,7 @@ void
 HeapBucketGroup<TBlockAttributes>::DisposeObjects()
 {
     finalizableHeapBucket.DisposeObjects();
+    recyclerVisitedHostHeapBucket.DisposeObjects();
 #ifdef RECYCLER_WRITE_BARRIER
     smallFinalizableWithBarrierHeapBucket.DisposeObjects();
 #endif
@@ -1671,6 +1677,7 @@ void
 HeapBucketGroup<TBlockAttributes>::TransferDisposedObjects()
 {
     finalizableHeapBucket.TransferDisposedObjects();
+    recyclerVisitedHostHeapBucket.TransferDisposedObjects();
 #ifdef RECYCLER_WRITE_BARRIER
     smallFinalizableWithBarrierHeapBucket.TransferDisposedObjects();
 #endif
@@ -1687,6 +1694,7 @@ HeapBucketGroup<TBlockAttributes>::EnumerateObjects(ObjectInfoBits infoBits, voi
     smallFinalizableWithBarrierHeapBucket.EnumerateObjects(infoBits, CallBackFunction);
 #endif
     finalizableHeapBucket.EnumerateObjects(infoBits, CallBackFunction);
+    recyclerVisitedHostHeapBucket.EnumerateObjects(infoBits, CallBackFunction);
 }
 
 template <class TBlockAttributes>
@@ -1694,6 +1702,7 @@ void
 HeapBucketGroup<TBlockAttributes>::FinalizeAllObjects()
 {
     finalizableHeapBucket.FinalizeAllObjects();
+    recyclerVisitedHostHeapBucket.FinalizeAllObjects();
 #ifdef RECYCLER_WRITE_BARRIER
     smallFinalizableWithBarrierHeapBucket.FinalizeAllObjects();
 #endif
@@ -1709,7 +1718,8 @@ HeapBucketGroup<TBlockAttributes>::Rescan(Recycler * recycler, RescanFlags flags
         smallNormalWithBarrierHeapBucket.Rescan(recycler, flags) +
         smallFinalizableWithBarrierHeapBucket.Rescan(recycler, flags) +
 #endif
-        finalizableHeapBucket.Rescan(recycler, flags);
+        finalizableHeapBucket.Rescan(recycler, flags) +
+        recyclerVisitedHostHeapBucket.Rescan(recycler, flags);
 }
 
 #if ENABLE_CONCURRENT_GC
@@ -1724,6 +1734,7 @@ HeapBucketGroup<TBlockAttributes>::PrepareSweep()
     smallFinalizableWithBarrierHeapBucket.PrepareSweep();
 #endif
     finalizableHeapBucket.PrepareSweep();
+    recyclerVisitedHostHeapBucket.PrepareSweep();
 }
 
 template <class TBlockAttributes>
@@ -1752,6 +1763,7 @@ HeapBucketGroup<TBlockAttributes>::SweepPartialReusePages(RecyclerSweep& recycle
 #endif
 
     finalizableHeapBucket.SweepPartialReusePages(recyclerSweep);
+    recyclerVisitedHostHeapBucket.SweepPartialReusePages(recyclerSweep);
 }
 
 template <class TBlockAttributes>
@@ -1764,6 +1776,7 @@ HeapBucketGroup<TBlockAttributes>::FinishPartialCollect(RecyclerSweep * recycler
     smallFinalizableWithBarrierHeapBucket.FinishPartialCollect(recyclerSweep);
 #endif
     finalizableHeapBucket.FinishPartialCollect(recyclerSweep);
+    recyclerVisitedHostHeapBucket.FinishPartialCollect(recyclerSweep);
 
     // Leaf heap block always do a full sweep instead of partial sweep
     // (since touching the page doesn't affect rescan)
@@ -1790,6 +1803,7 @@ HeapBucketGroup<TBlockAttributes>::SweepPendingObjects(RecyclerSweep& recyclerSw
 #endif
 
     finalizableHeapBucket.SweepPendingObjects(recyclerSweep);
+    recyclerVisitedHostHeapBucket.SweepPendingObjects(recyclerSweep);
 }
 
 template <class TBlockAttributes>
@@ -1803,6 +1817,7 @@ HeapBucketGroup<TBlockAttributes>::TransferPendingEmptyHeapBlocks(RecyclerSweep&
     recyclerSweep.TransferPendingEmptyHeapBlocks(&smallFinalizableWithBarrierHeapBucket);
 #endif
     recyclerSweep.TransferPendingEmptyHeapBlocks(&finalizableHeapBucket);
+    recyclerSweep.TransferPendingEmptyHeapBlocks(&recyclerVisitedHostHeapBucket);
 }
 #endif
 
@@ -1813,6 +1828,7 @@ HeapBucketGroup<TBlockAttributes>::GetNonEmptyHeapBlockCount(bool checkCount) co
 {
     return heapBucket.GetNonEmptyHeapBlockCount(checkCount) +
         finalizableHeapBucket.GetNonEmptyHeapBlockCount(checkCount) +
+        recyclerVisitedHostHeapBucket.GetNonEmptyHeapBlockCount(checkCount) +
 #ifdef RECYCLER_WRITE_BARRIER
         smallNormalWithBarrierHeapBucket.GetNonEmptyHeapBlockCount(checkCount) +
         smallFinalizableWithBarrierHeapBucket.GetNonEmptyHeapBlockCount(checkCount) +
@@ -1826,6 +1842,7 @@ HeapBucketGroup<TBlockAttributes>::GetEmptyHeapBlockCount() const
 {
     return heapBucket.GetEmptyHeapBlockCount() +
         finalizableHeapBucket.GetEmptyHeapBlockCount() +
+        recyclerVisitedHostHeapBucket.GetEmptyHeapBlockCount() +
 #ifdef RECYCLER_WRITE_BARRIER
         smallNormalWithBarrierHeapBucket.GetEmptyHeapBlockCount() +
         smallFinalizableWithBarrierHeapBucket.GetEmptyHeapBlockCount() +
@@ -1839,7 +1856,7 @@ template <class TBlockAttributes>
 size_t
 HeapBucketGroup<TBlockAttributes>::Check()
 {
-    return heapBucket.Check() + finalizableHeapBucket.Check() + leafHeapBucket.Check()
+    return heapBucket.Check() + finalizableHeapBucket.Check() + leafHeapBucket.Check() + recyclerVisitedHostHeapBucket.Check()
 #ifdef RECYCLER_WRITE_BARRIER
         + smallNormalWithBarrierHeapBucket.Check() + smallFinalizableWithBarrierHeapBucket.Check()
 #endif
@@ -1853,6 +1870,7 @@ HeapBucketGroup<TBlockAttributes>::Verify()
 {
     heapBucket.Verify();
     finalizableHeapBucket.Verify();
+    recyclerVisitedHostHeapBucket.Verify();
     leafHeapBucket.Verify();
 #ifdef RECYCLER_WRITE_BARRIER
     smallNormalWithBarrierHeapBucket.Verify();
@@ -1867,6 +1885,7 @@ HeapBucketGroup<TBlockAttributes>::VerifyMark()
 {
     heapBucket.VerifyMark();
     finalizableHeapBucket.VerifyMark();
+    recyclerVisitedHostHeapBucket.VerifyMark();
     leafHeapBucket.VerifyMark();
 #ifdef RECYCLER_WRITE_BARRIER
     smallNormalWithBarrierHeapBucket.VerifyMark();
@@ -1918,6 +1937,7 @@ HeapBucketGroup<TBlockAttributes>::AllocatorsAreEmpty()
 {
     return heapBucket.AllocatorsAreEmpty()
         && finalizableHeapBucket.AllocatorsAreEmpty()
+        && recyclerVisitedHostHeapBucket.AllocatorsAreEmpty()
         && leafHeapBucket.AllocatorsAreEmpty()
 #ifdef RECYCLER_WRITE_BARRIER
         && smallNormalWithBarrierHeapBucket.AllocatorsAreEmpty()

--- a/lib/Common/Memory/HeapBucket.cpp
+++ b/lib/Common/Memory/HeapBucket.cpp
@@ -1730,16 +1730,16 @@ template <class TBlockAttributes>
 uint
 HeapBucketGroup<TBlockAttributes>::Rescan(Recycler * recycler, RescanFlags flags)
 {
-	return heapBucket.Rescan(recycler, flags) +
-		leafHeapBucket.Rescan(recycler, flags) +
+    return heapBucket.Rescan(recycler, flags) +
+        leafHeapBucket.Rescan(recycler, flags) +
 #ifdef RECYCLER_WRITE_BARRIER
-		smallNormalWithBarrierHeapBucket.Rescan(recycler, flags) +
-		smallFinalizableWithBarrierHeapBucket.Rescan(recycler, flags) +
+        smallNormalWithBarrierHeapBucket.Rescan(recycler, flags) +
+        smallFinalizableWithBarrierHeapBucket.Rescan(recycler, flags) +
 #endif
 #ifdef RECYCLER_VISITED_HOST
-		recyclerVisitedHostHeapBucket.Rescan(recycler, flags) +
+        recyclerVisitedHostHeapBucket.Rescan(recycler, flags) +
 #endif
-		finalizableHeapBucket.Rescan(recycler, flags);
+        finalizableHeapBucket.Rescan(recycler, flags);
 }
 
 #if ENABLE_CONCURRENT_GC
@@ -1892,7 +1892,7 @@ HeapBucketGroup<TBlockAttributes>::Check()
 {
     return heapBucket.Check() + finalizableHeapBucket.Check() + leafHeapBucket.Check()
 #ifdef RECYCLER_VISITED_HOST
-		+ recyclerVisitedHostHeapBucket.Check()
+        + recyclerVisitedHostHeapBucket.Check()
 #endif
 #ifdef RECYCLER_WRITE_BARRIER
         + smallNormalWithBarrierHeapBucket.Check() + smallFinalizableWithBarrierHeapBucket.Check()

--- a/lib/Common/Memory/HeapBucket.cpp
+++ b/lib/Common/Memory/HeapBucket.cpp
@@ -1623,9 +1623,6 @@ HeapBucketGroup<TBlockAttributes>::ScanInitialImplicitRoots(Recycler * recycler)
     smallFinalizableWithBarrierHeapBucket.ScanInitialImplicitRoots(recycler);
 #endif
     finalizableHeapBucket.ScanInitialImplicitRoots(recycler);
-#ifdef RECYCLER_VISITED_HOST
-    recyclerVisitedHostHeapBucket.ScanInitialImplicitRoots(recycler);
-#endif
 }
 
 template <class TBlockAttributes>
@@ -1640,9 +1637,6 @@ HeapBucketGroup<TBlockAttributes>::ScanNewImplicitRoots(Recycler * recycler)
     smallFinalizableWithBarrierHeapBucket.ScanNewImplicitRoots(recycler);
 #endif
     finalizableHeapBucket.ScanNewImplicitRoots(recycler);
-#ifdef RECYCLER_VISITED_HOST
-    recyclerVisitedHostHeapBucket.ScanNewImplicitRoots(recycler);
-#endif
 }
 
 template <class TBlockAttributes>

--- a/lib/Common/Memory/HeapBucket.h
+++ b/lib/Common/Memory/HeapBucket.h
@@ -168,7 +168,7 @@ public:
 protected:
     static bool const IsLeafBucket = TBlockType::RequiredAttributes == LeafBit;
     // Not all objects in the recycler visited host heap block are finalizable, but we still require finalizable semantics
-    static bool const IsFinalizableBucket = TBlockType::RequiredAttributes == FinalizeBit || TBlockType::RequiredAttributes == (RecyclerVisitedHost_RequiredBits);
+    static bool const IsFinalizableBucket = TBlockType::RequiredAttributes == FinalizeBit || ((TBlockType::RequiredAttributes & RecyclerVisitedHostBit) == (RecyclerVisitedHostBit));
     static bool const IsNormalBucket = TBlockType::RequiredAttributes == NoBit;
 #ifdef RECYCLER_WRITE_BARRIER
     static bool const IsWriteBarrierBucket = TBlockType::RequiredAttributes == WithBarrierBit;

--- a/lib/Common/Memory/HeapBucket.h
+++ b/lib/Common/Memory/HeapBucket.h
@@ -101,6 +101,9 @@ public:
     template <typename TBlockAttributes>
     friend class SmallFinalizableHeapBlockT;
 
+    template <typename TBlockAttributes>
+    friend class SmallRecyclerVisitedHostHeapBlockT;
+
     friend class LargeHeapBlock;
 #ifdef RECYCLER_WRITE_BARRIER
     template <typename TBlockAttributes>
@@ -164,7 +167,8 @@ public:
 
 protected:
     static bool const IsLeafBucket = TBlockType::RequiredAttributes == LeafBit;
-    static bool const IsFinalizableBucket = TBlockType::RequiredAttributes == FinalizeBit;
+    // Not all objects in the recycler visited host heap block are finalizable, but we still require finalizable semantics
+    static bool const IsFinalizableBucket = TBlockType::RequiredAttributes == FinalizeBit || TBlockType::RequiredAttributes == (RecyclerVisitedHost_RequiredBits);
     static bool const IsNormalBucket = TBlockType::RequiredAttributes == NoBit;
 #ifdef RECYCLER_WRITE_BARRIER
     static bool const IsWriteBarrierBucket = TBlockType::RequiredAttributes == WithBarrierBit;

--- a/lib/Common/Memory/HeapBucket.h
+++ b/lib/Common/Memory/HeapBucket.h
@@ -172,9 +172,9 @@ protected:
     // Not all objects in the recycler visited host heap block are finalizable, but we still require finalizable semantics
     static bool const IsFinalizableBucket = TBlockType::RequiredAttributes == FinalizeBit
 #ifdef RECYCLER_VISITED_HOST
-		|| ((TBlockType::RequiredAttributes & RecyclerVisitedHostBit) == (RecyclerVisitedHostBit))
+        || ((TBlockType::RequiredAttributes & RecyclerVisitedHostBit) == (RecyclerVisitedHostBit))
 #endif
-	;
+    ;
     static bool const IsNormalBucket = TBlockType::RequiredAttributes == NoBit;
 #ifdef RECYCLER_WRITE_BARRIER
     static bool const IsWriteBarrierBucket = TBlockType::RequiredAttributes == WithBarrierBit;

--- a/lib/Common/Memory/HeapBucket.h
+++ b/lib/Common/Memory/HeapBucket.h
@@ -101,8 +101,10 @@ public:
     template <typename TBlockAttributes>
     friend class SmallFinalizableHeapBlockT;
 
+#ifdef RECYCLER_VISITED_HOST
     template <typename TBlockAttributes>
     friend class SmallRecyclerVisitedHostHeapBlockT;
+#endif
 
     friend class LargeHeapBlock;
 #ifdef RECYCLER_WRITE_BARRIER
@@ -168,7 +170,11 @@ public:
 protected:
     static bool const IsLeafBucket = TBlockType::RequiredAttributes == LeafBit;
     // Not all objects in the recycler visited host heap block are finalizable, but we still require finalizable semantics
-    static bool const IsFinalizableBucket = TBlockType::RequiredAttributes == FinalizeBit || ((TBlockType::RequiredAttributes & RecyclerVisitedHostBit) == (RecyclerVisitedHostBit));
+    static bool const IsFinalizableBucket = TBlockType::RequiredAttributes == FinalizeBit
+#ifdef RECYCLER_VISITED_HOST
+		|| ((TBlockType::RequiredAttributes & RecyclerVisitedHostBit) == (RecyclerVisitedHostBit))
+#endif
+	;
     static bool const IsNormalBucket = TBlockType::RequiredAttributes == NoBit;
 #ifdef RECYCLER_WRITE_BARRIER
     static bool const IsWriteBarrierBucket = TBlockType::RequiredAttributes == WithBarrierBit;

--- a/lib/Common/Memory/HeapInfo.cpp
+++ b/lib/Common/Memory/HeapInfo.cpp
@@ -553,8 +553,8 @@ HeapInfo::~HeapInfo()
     MediumFinalizableHeapBucket::DeleteHeapBlockList(this->newMediumFinalizableHeapBlockList, recycler);
 
 #ifdef RECYCLER_VISITED_HOST
-	SmallFinalizableHeapBucket::DeleteHeapBlockList(this->newRecyclerVisitedHostHeapBlockList, recycler);
-	MediumFinalizableHeapBucket::DeleteHeapBlockList(this->newMediumRecyclerVisitedHostHeapBlockList, recycler);
+    SmallFinalizableHeapBucket::DeleteHeapBlockList(this->newRecyclerVisitedHostHeapBlockList, recycler);
+    MediumFinalizableHeapBucket::DeleteHeapBlockList(this->newMediumRecyclerVisitedHostHeapBlockList, recycler);
 #endif
 
 #endif
@@ -1090,8 +1090,8 @@ HeapInfo::Sweep(RecyclerSweep& recyclerSweep, bool concurrent)
     recyclerSweep.MergePendingNewMediumHeapBlockList<MediumFinalizableWithBarrierHeapBlock>();
 #endif
 #ifdef RECYCLER_VISITED_HOST
-	recyclerSweep.MergePendingNewHeapBlockList<SmallRecyclerVisitedHostHeapBlock>();
-	recyclerSweep.MergePendingNewMediumHeapBlockList<MediumRecyclerVisitedHostHeapBlock>();
+    recyclerSweep.MergePendingNewHeapBlockList<SmallRecyclerVisitedHostHeapBlock>();
+    recyclerSweep.MergePendingNewMediumHeapBlockList<MediumRecyclerVisitedHostHeapBlock>();
 #endif
 #endif
 
@@ -1600,7 +1600,7 @@ HeapInfo::GetSmallHeapBlockCount(bool checkCount) const
         + this->heapBlockCount[HeapBlock::HeapBlockType::SmallFinalizableBlockType]
 #ifdef RECYCLER_VISITED_HOST
         + this->heapBlockCount[HeapBlock::HeapBlockType::SmallRecyclerVisitedHostBlockType]
-		+ this->heapBlockCount[HeapBlock::HeapBlockType::MediumRecyclerVisitedHostBlockType]
+        + this->heapBlockCount[HeapBlock::HeapBlockType::MediumRecyclerVisitedHostBlockType]
 #endif
         + this->heapBlockCount[HeapBlock::HeapBlockType::MediumNormalBlockType]
         + this->heapBlockCount[HeapBlock::HeapBlockType::MediumLeafBlockType]
@@ -1674,10 +1674,10 @@ HeapInfo::Check()
     currentSmallHeapBlockCount += Check(true, false, this->newNormalWithBarrierHeapBlockList);
     currentSmallHeapBlockCount += Check(true, false, this->newFinalizableWithBarrierHeapBlockList);
 #endif
-	currentSmallHeapBlockCount += Check(true, false, this->newFinalizableHeapBlockList);
+    currentSmallHeapBlockCount += Check(true, false, this->newFinalizableHeapBlockList);
 #ifdef RECYCLER_VISITED_HOST
     currentSmallHeapBlockCount += Check(true, false, this->newRecyclerVisitedHostHeapBlockList);
-	currentSmallHeapBlockCount += Check(true, false, this->newMediumRecyclerVisitedHostHeapBlockList);
+    currentSmallHeapBlockCount += Check(true, false, this->newMediumRecyclerVisitedHostHeapBlockList);
 #endif
 #endif
 
@@ -1697,7 +1697,7 @@ HeapInfo::Check()
         + this->heapBlockCount[HeapBlock::HeapBlockType::SmallFinalizableBlockType]
 #ifdef RECYCLER_VISITED_HOST
         + this->heapBlockCount[HeapBlock::HeapBlockType::SmallRecyclerVisitedHostBlockType]
-		+ this->heapBlockCount[HeapBlock::HeapBlockType::MediumRecyclerVisitedHostBlockType]
+        + this->heapBlockCount[HeapBlock::HeapBlockType::MediumRecyclerVisitedHostBlockType]
 #endif
         + this->heapBlockCount[HeapBlock::HeapBlockType::MediumNormalBlockType]
         + this->heapBlockCount[HeapBlock::HeapBlockType::MediumLeafBlockType]

--- a/lib/Common/Memory/HeapInfo.cpp
+++ b/lib/Common/Memory/HeapInfo.cpp
@@ -771,13 +771,6 @@ HeapInfo::ResetMarks(ResetMarkFlags flags)
         });
 #endif
 
-#ifdef RECYCLER_VISITED_HOST
-        HeapBlockList::ForEach(newRecyclerVisitedHostHeapBlockList, [flags](SmallNormalHeapBlock * heapBlock)
-        {
-            heapBlock->MarkImplicitRoots();
-        });
-#endif
-
         HeapBlockList::ForEach(newFinalizableHeapBlockList, [flags](SmallNormalHeapBlock * heapBlock)
         {
             heapBlock->MarkImplicitRoots();
@@ -808,13 +801,6 @@ HeapInfo::ResetMarks(ResetMarkFlags flags)
         {
             heapBlock->MarkImplicitRoots();
         });
-
-#ifdef RECYCLER_VISITED_HOST
-        HeapBlockList::ForEach(newMediumRecyclerVisitedHostHeapBlockList, [flags](MediumNormalHeapBlock * heapBlock)
-        {
-            heapBlock->MarkImplicitRoots();
-        });
-#endif
     }
 #endif
 }
@@ -855,13 +841,6 @@ HeapInfo::ScanInitialImplicitRoots()
     });
 #endif
 
-#ifdef RECYCLER_VISITED_HOST
-    HeapBlockList::ForEach(newRecyclerVisitedHostHeapBlockList, [this](SmallNormalHeapBlock * heapBlock)
-    {
-        heapBlock->ScanInitialImplicitRoots(recycler);
-    });
-#endif
-
     HeapBlockList::ForEach(newFinalizableHeapBlockList, [this](SmallNormalHeapBlock * heapBlock)
     {
         heapBlock->ScanInitialImplicitRoots(recycler);
@@ -884,13 +863,6 @@ HeapInfo::ScanInitialImplicitRoots()
     });
 
     HeapBlockList::ForEach(newMediumFinalizableWithBarrierHeapBlockList, [this](MediumFinalizableWithBarrierHeapBlock * heapBlock)
-    {
-        heapBlock->ScanInitialImplicitRoots(recycler);
-    });
-#endif
-
-#ifdef RECYCLER_VISITED_HOST
-    HeapBlockList::ForEach(newMediumRecyclerVisitedHostHeapBlockList, [this](MediumNormalHeapBlock * heapBlock)
     {
         heapBlock->ScanInitialImplicitRoots(recycler);
     });
@@ -947,13 +919,6 @@ HeapInfo::ScanNewImplicitRoots()
     });
 #endif
 
-#ifdef RECYCLER_VISITED_HOST
-    HeapBlockList::ForEach(newRecyclerVisitedHostHeapBlockList, [this](SmallNormalHeapBlock * heapBlock)
-    {
-        heapBlock->ScanNewImplicitRoots(recycler);
-    });
-#endif
-
     HeapBlockList::ForEach(newFinalizableHeapBlockList, [this](SmallNormalHeapBlock * heapBlock)
     {
         heapBlock->ScanNewImplicitRoots(recycler);
@@ -977,12 +942,6 @@ HeapInfo::ScanNewImplicitRoots()
     });
 
     HeapBlockList::ForEach(newMediumFinalizableWithBarrierHeapBlockList, [this](MediumFinalizableWithBarrierHeapBlock * heapBlock)
-    {
-        heapBlock->ScanNewImplicitRoots(recycler);
-    });
-#endif
-#ifdef RECYCLER_VISITED_HOST
-    HeapBlockList::ForEach(newMediumRecyclerVisitedHostHeapBlockList, [this](MediumNormalHeapBlock * heapBlock)
     {
         heapBlock->ScanNewImplicitRoots(recycler);
     });

--- a/lib/Common/Memory/HeapInfo.cpp
+++ b/lib/Common/Memory/HeapInfo.cpp
@@ -446,14 +446,18 @@ HeapInfo::HeapInfo() :
     newFinalizableWithBarrierHeapBlockList(nullptr),
 #endif
     newFinalizableHeapBlockList(nullptr),
+#ifdef RECYCLER_VISITED_HOST
     newRecyclerVisitedHostHeapBlockList(nullptr),
+#endif
     newMediumLeafHeapBlockList(nullptr),
     newMediumNormalHeapBlockList(nullptr),
 #ifdef RECYCLER_WRITE_BARRIER
     newMediumNormalWithBarrierHeapBlockList(nullptr),
     newMediumFinalizableWithBarrierHeapBlockList(nullptr),
 #endif
+#ifdef RECYCLER_VISITED_HOST
     newMediumRecyclerVisitedHostHeapBlockList(nullptr),
+#endif
     newMediumFinalizableHeapBlockList(nullptr),
 #endif
 #ifdef RECYCLER_FINALIZE_CHECK
@@ -500,8 +504,10 @@ HeapInfo::~HeapInfo()
 #if ENABLE_CONCURRENT_GC
     SmallFinalizableHeapBucket::FinalizeHeapBlockList(this->newFinalizableHeapBlockList);
     MediumFinalizableHeapBucket::FinalizeHeapBlockList(this->newMediumFinalizableHeapBlockList);
+#ifdef RECYCLER_VISITED_HOST
     SmallRecyclerVisitedHostHeapBucket::FinalizeHeapBlockList(this->newRecyclerVisitedHostHeapBlockList);
     MediumRecyclerVisitedHostHeapBucket::FinalizeHeapBlockList(this->newMediumRecyclerVisitedHostHeapBlockList);
+#endif
 #ifdef RECYCLER_WRITE_BARRIER
     SmallFinalizableWithBarrierHeapBucket::FinalizeHeapBlockList(this->newFinalizableWithBarrierHeapBlockList);
     MediumFinalizableWithBarrierHeapBucket::FinalizeHeapBlockList(this->newMediumFinalizableWithBarrierHeapBlockList);
@@ -537,7 +543,6 @@ HeapInfo::~HeapInfo()
     SmallFinalizableWithBarrierHeapBucket::DeleteHeapBlockList(this->newFinalizableWithBarrierHeapBlockList, recycler);
 #endif
     SmallFinalizableHeapBucket::DeleteHeapBlockList(this->newFinalizableHeapBlockList, recycler);
-    SmallFinalizableHeapBucket::DeleteHeapBlockList(this->newRecyclerVisitedHostHeapBlockList, recycler);
 
     MediumLeafHeapBucket::DeleteHeapBlockList(this->newMediumLeafHeapBlockList, recycler);
     MediumNormalHeapBucket::DeleteHeapBlockList(this->newMediumNormalHeapBlockList, recycler);
@@ -545,8 +550,13 @@ HeapInfo::~HeapInfo()
     MediumNormalWithBarrierHeapBucket::DeleteHeapBlockList(this->newMediumNormalWithBarrierHeapBlockList, recycler);
     MediumFinalizableWithBarrierHeapBucket::DeleteHeapBlockList(this->newMediumFinalizableWithBarrierHeapBlockList, recycler);
 #endif
-    MediumFinalizableHeapBucket::DeleteHeapBlockList(this->newMediumRecyclerVisitedHostHeapBlockList, recycler);
     MediumFinalizableHeapBucket::DeleteHeapBlockList(this->newMediumFinalizableHeapBlockList, recycler);
+
+#ifdef RECYCLER_VISITED_HOST
+	SmallFinalizableHeapBucket::DeleteHeapBlockList(this->newRecyclerVisitedHostHeapBlockList, recycler);
+	MediumFinalizableHeapBucket::DeleteHeapBlockList(this->newMediumRecyclerVisitedHostHeapBlockList, recycler);
+#endif
+
 #endif
 
     // We do this here, instead of in the Recycler destructor, because the above stuff may
@@ -761,10 +771,12 @@ HeapInfo::ResetMarks(ResetMarkFlags flags)
         });
 #endif
 
+#ifdef RECYCLER_VISITED_HOST
         HeapBlockList::ForEach(newRecyclerVisitedHostHeapBlockList, [flags](SmallNormalHeapBlock * heapBlock)
         {
             heapBlock->MarkImplicitRoots();
         });
+#endif
 
         HeapBlockList::ForEach(newFinalizableHeapBlockList, [flags](SmallNormalHeapBlock * heapBlock)
         {
@@ -797,10 +809,12 @@ HeapInfo::ResetMarks(ResetMarkFlags flags)
             heapBlock->MarkImplicitRoots();
         });
 
+#ifdef RECYCLER_VISITED_HOST
         HeapBlockList::ForEach(newMediumRecyclerVisitedHostHeapBlockList, [flags](MediumNormalHeapBlock * heapBlock)
         {
             heapBlock->MarkImplicitRoots();
         });
+#endif
     }
 #endif
 }
@@ -841,10 +855,12 @@ HeapInfo::ScanInitialImplicitRoots()
     });
 #endif
 
+#ifdef RECYCLER_VISITED_HOST
     HeapBlockList::ForEach(newRecyclerVisitedHostHeapBlockList, [this](SmallNormalHeapBlock * heapBlock)
     {
         heapBlock->ScanInitialImplicitRoots(recycler);
     });
+#endif
 
     HeapBlockList::ForEach(newFinalizableHeapBlockList, [this](SmallNormalHeapBlock * heapBlock)
     {
@@ -873,10 +889,12 @@ HeapInfo::ScanInitialImplicitRoots()
     });
 #endif
 
+#ifdef RECYCLER_VISITED_HOST
     HeapBlockList::ForEach(newMediumRecyclerVisitedHostHeapBlockList, [this](MediumNormalHeapBlock * heapBlock)
     {
         heapBlock->ScanInitialImplicitRoots(recycler);
     });
+#endif
 
     HeapBlockList::ForEach(newMediumFinalizableHeapBlockList, [this](MediumNormalHeapBlock * heapBlock)
     {
@@ -929,10 +947,12 @@ HeapInfo::ScanNewImplicitRoots()
     });
 #endif
 
+#ifdef RECYCLER_VISITED_HOST
     HeapBlockList::ForEach(newRecyclerVisitedHostHeapBlockList, [this](SmallNormalHeapBlock * heapBlock)
     {
         heapBlock->ScanNewImplicitRoots(recycler);
     });
+#endif
 
     HeapBlockList::ForEach(newFinalizableHeapBlockList, [this](SmallNormalHeapBlock * heapBlock)
     {
@@ -961,10 +981,12 @@ HeapInfo::ScanNewImplicitRoots()
         heapBlock->ScanNewImplicitRoots(recycler);
     });
 #endif
+#ifdef RECYCLER_VISITED_HOST
     HeapBlockList::ForEach(newMediumRecyclerVisitedHostHeapBlockList, [this](MediumNormalHeapBlock * heapBlock)
     {
         heapBlock->ScanNewImplicitRoots(recycler);
     });
+#endif
 
     HeapBlockList::ForEach(newMediumFinalizableHeapBlockList, [this](MediumNormalHeapBlock * heapBlock)
     {
@@ -1061,12 +1083,15 @@ HeapInfo::Sweep(RecyclerSweep& recyclerSweep, bool concurrent)
 #if ENABLE_CONCURRENT_GC
     // Merge the new blocks before we sweep the finalizable object in thread
     recyclerSweep.MergePendingNewHeapBlockList<SmallFinalizableHeapBlock>();
-    recyclerSweep.MergePendingNewHeapBlockList<SmallRecyclerVisitedHostHeapBlock>();
     recyclerSweep.MergePendingNewMediumHeapBlockList<MediumFinalizableHeapBlock>();
-    recyclerSweep.MergePendingNewMediumHeapBlockList<MediumRecyclerVisitedHostHeapBlock>();
+   
 #ifdef RECYCLER_WRITE_BARRIER
     recyclerSweep.MergePendingNewHeapBlockList<SmallFinalizableWithBarrierHeapBlock>();
     recyclerSweep.MergePendingNewMediumHeapBlockList<MediumFinalizableWithBarrierHeapBlock>();
+#endif
+#ifdef RECYCLER_VISITED_HOST
+	recyclerSweep.MergePendingNewHeapBlockList<SmallRecyclerVisitedHostHeapBlock>();
+	recyclerSweep.MergePendingNewMediumHeapBlockList<MediumRecyclerVisitedHostHeapBlock>();
 #endif
 #endif
 
@@ -1498,7 +1523,9 @@ HeapInfo::EnumerateObjects(ObjectInfoBits infoBits, void (*CallBackFunction)(voi
     HeapBucket::EnumerateObjects(newFinalizableWithBarrierHeapBlockList, infoBits, CallBackFunction);
 #endif
 
+#ifdef RECYCLER_VISITED_HOST
     HeapBucket::EnumerateObjects(newRecyclerVisitedHostHeapBlockList, infoBits, CallBackFunction);
+#endif
     HeapBucket::EnumerateObjects(newFinalizableHeapBlockList, infoBits, CallBackFunction);
 
     HeapBucket::EnumerateObjects(newMediumLeafHeapBlockList, infoBits, CallBackFunction);
@@ -1508,7 +1535,9 @@ HeapInfo::EnumerateObjects(ObjectInfoBits infoBits, void (*CallBackFunction)(voi
     HeapBucket::EnumerateObjects(newMediumFinalizableWithBarrierHeapBlockList, infoBits, CallBackFunction);
 #endif
 
+#ifdef RECYCLER_VISITED_HOST
     HeapBucket::EnumerateObjects(newMediumRecyclerVisitedHostHeapBlockList, infoBits, CallBackFunction);
+#endif
     HeapBucket::EnumerateObjects(newMediumFinalizableHeapBlockList, infoBits, CallBackFunction);
 #endif
 }
@@ -1536,7 +1565,9 @@ HeapInfo::GetSmallHeapBlockCount(bool checkCount) const
     currentSmallHeapBlockCount += HeapBlockList::Count(this->newLeafHeapBlockList);
     currentSmallHeapBlockCount += HeapBlockList::Count(this->newNormalHeapBlockList);
     currentSmallHeapBlockCount += HeapBlockList::Count(this->newFinalizableHeapBlockList);
+#ifdef RECYCLER_VISITED_HOST
     currentSmallHeapBlockCount += HeapBlockList::Count(this->newRecyclerVisitedHostHeapBlockList);
+#endif
 #ifdef RECYCLER_WRITE_BARRIER
     currentSmallHeapBlockCount += HeapBlockList::Count(this->newNormalWithBarrierHeapBlockList);
     currentSmallHeapBlockCount += HeapBlockList::Count(this->newFinalizableWithBarrierHeapBlockList);
@@ -1544,7 +1575,9 @@ HeapInfo::GetSmallHeapBlockCount(bool checkCount) const
 
     currentSmallHeapBlockCount += HeapBlockList::Count(this->newMediumLeafHeapBlockList);
     currentSmallHeapBlockCount += HeapBlockList::Count(this->newMediumNormalHeapBlockList);
+#ifdef RECYCLER_VISITED_HOST
     currentSmallHeapBlockCount += HeapBlockList::Count(this->newMediumRecyclerVisitedHostHeapBlockList);
+#endif
     currentSmallHeapBlockCount += HeapBlockList::Count(this->newMediumFinalizableHeapBlockList);
 #ifdef RECYCLER_WRITE_BARRIER
     currentSmallHeapBlockCount += HeapBlockList::Count(this->newMediumNormalWithBarrierHeapBlockList);
@@ -1565,10 +1598,12 @@ HeapInfo::GetSmallHeapBlockCount(bool checkCount) const
         this->heapBlockCount[HeapBlock::HeapBlockType::SmallNormalBlockType]
         + this->heapBlockCount[HeapBlock::HeapBlockType::SmallLeafBlockType]
         + this->heapBlockCount[HeapBlock::HeapBlockType::SmallFinalizableBlockType]
+#ifdef RECYCLER_VISITED_HOST
         + this->heapBlockCount[HeapBlock::HeapBlockType::SmallRecyclerVisitedHostBlockType]
+		+ this->heapBlockCount[HeapBlock::HeapBlockType::MediumRecyclerVisitedHostBlockType]
+#endif
         + this->heapBlockCount[HeapBlock::HeapBlockType::MediumNormalBlockType]
         + this->heapBlockCount[HeapBlock::HeapBlockType::MediumLeafBlockType]
-        + this->heapBlockCount[HeapBlock::HeapBlockType::MediumRecyclerVisitedHostBlockType]
         + this->heapBlockCount[HeapBlock::HeapBlockType::MediumFinalizableBlockType];
 
 
@@ -1639,8 +1674,11 @@ HeapInfo::Check()
     currentSmallHeapBlockCount += Check(true, false, this->newNormalWithBarrierHeapBlockList);
     currentSmallHeapBlockCount += Check(true, false, this->newFinalizableWithBarrierHeapBlockList);
 #endif
-    currentSmallHeapBlockCount += Check(true, false, this->newFinalizableHeapBlockList);
+	currentSmallHeapBlockCount += Check(true, false, this->newFinalizableHeapBlockList);
+#ifdef RECYCLER_VISITED_HOST
     currentSmallHeapBlockCount += Check(true, false, this->newRecyclerVisitedHostHeapBlockList);
+	currentSmallHeapBlockCount += Check(true, false, this->newMediumRecyclerVisitedHostHeapBlockList);
+#endif
 #endif
 
 #if ENABLE_CONCURRENT_GC
@@ -1650,7 +1688,6 @@ HeapInfo::Check()
     currentSmallHeapBlockCount += Check(true, false, this->newMediumNormalWithBarrierHeapBlockList);
     currentSmallHeapBlockCount += Check(true, false, this->newMediumFinalizableWithBarrierHeapBlockList);
 #endif
-    currentSmallHeapBlockCount += Check(true, false, this->newMediumRecyclerVisitedHostHeapBlockList);
     currentSmallHeapBlockCount += Check(true, false, this->newMediumFinalizableHeapBlockList);
 #endif
 
@@ -1658,10 +1695,12 @@ HeapInfo::Check()
         this->heapBlockCount[HeapBlock::HeapBlockType::SmallNormalBlockType]
         + this->heapBlockCount[HeapBlock::HeapBlockType::SmallLeafBlockType]
         + this->heapBlockCount[HeapBlock::HeapBlockType::SmallFinalizableBlockType]
+#ifdef RECYCLER_VISITED_HOST
         + this->heapBlockCount[HeapBlock::HeapBlockType::SmallRecyclerVisitedHostBlockType]
+		+ this->heapBlockCount[HeapBlock::HeapBlockType::MediumRecyclerVisitedHostBlockType]
+#endif
         + this->heapBlockCount[HeapBlock::HeapBlockType::MediumNormalBlockType]
         + this->heapBlockCount[HeapBlock::HeapBlockType::MediumLeafBlockType]
-        + this->heapBlockCount[HeapBlock::HeapBlockType::MediumRecyclerVisitedHostBlockType]
         + this->heapBlockCount[HeapBlock::HeapBlockType::MediumFinalizableBlockType];
 
 #ifdef RECYCLER_WRITE_BARRIER
@@ -1696,7 +1735,10 @@ HeapInfo::Check(bool expectFull, bool expectPending, TBlockType * list, TBlockTy
 template size_t HeapInfo::Check<SmallNormalHeapBlock>(bool expectFull, bool expectPending, SmallNormalHeapBlock * list, SmallNormalHeapBlock * tail);
 template size_t HeapInfo::Check<SmallLeafHeapBlock>(bool expectFull, bool expectPending, SmallLeafHeapBlock * list, SmallLeafHeapBlock * tail);
 template size_t HeapInfo::Check<SmallFinalizableHeapBlock>(bool expectFull, bool expectPending, SmallFinalizableHeapBlock * list, SmallFinalizableHeapBlock * tail);
+#ifdef RECYCLER_VISITED_HOST
 template size_t HeapInfo::Check<SmallRecyclerVisitedHostHeapBlock>(bool expectFull, bool expectPending, SmallRecyclerVisitedHostHeapBlock * list, SmallRecyclerVisitedHostHeapBlock * tail);
+template size_t HeapInfo::Check<MediumRecyclerVisitedHostHeapBlock>(bool expectFull, bool expectPending, MediumRecyclerVisitedHostHeapBlock * list, MediumRecyclerVisitedHostHeapBlock * tail);
+#endif
 template size_t HeapInfo::Check<LargeHeapBlock>(bool expectFull, bool expectPending, LargeHeapBlock * list, LargeHeapBlock * tail);
 #ifdef RECYCLER_WRITE_BARRIER
 template size_t HeapInfo::Check<SmallNormalWithBarrierHeapBlock>(bool expectFull, bool expectPending, SmallNormalWithBarrierHeapBlock * list, SmallNormalWithBarrierHeapBlock * tail);
@@ -1706,7 +1748,6 @@ template size_t HeapInfo::Check<SmallFinalizableWithBarrierHeapBlock>(bool expec
 template size_t HeapInfo::Check<MediumNormalHeapBlock>(bool expectFull, bool expectPending, MediumNormalHeapBlock * list, MediumNormalHeapBlock * tail);
 template size_t HeapInfo::Check<MediumLeafHeapBlock>(bool expectFull, bool expectPending, MediumLeafHeapBlock * list, MediumLeafHeapBlock * tail);
 template size_t HeapInfo::Check<MediumFinalizableHeapBlock>(bool expectFull, bool expectPending, MediumFinalizableHeapBlock * list, MediumFinalizableHeapBlock * tail);
-template size_t HeapInfo::Check<MediumRecyclerVisitedHostHeapBlock>(bool expectFull, bool expectPending, MediumRecyclerVisitedHostHeapBlock * list, MediumRecyclerVisitedHostHeapBlock * tail);
 template size_t HeapInfo::Check<LargeHeapBlock>(bool expectFull, bool expectPending, LargeHeapBlock * list, LargeHeapBlock * tail);
 #ifdef RECYCLER_WRITE_BARRIER
 template size_t HeapInfo::Check<MediumNormalWithBarrierHeapBlock>(bool expectFull, bool expectPending, MediumNormalWithBarrierHeapBlock * list, MediumNormalWithBarrierHeapBlock * tail);
@@ -1763,10 +1804,12 @@ HeapInfo::Verify()
         heapBlock->Verify();
     });
 #endif
+#ifdef RECYCLER_VISITED_HOST
     HeapBlockList::ForEach(newRecyclerVisitedHostHeapBlockList, [](SmallFinalizableHeapBlock * heapBlock)
     {
         heapBlock->Verify();
     });
+#endif
     HeapBlockList::ForEach(newFinalizableHeapBlockList, [](SmallFinalizableHeapBlock * heapBlock)
     {
         heapBlock->Verify();
@@ -1792,10 +1835,12 @@ HeapInfo::Verify()
         heapBlock->Verify();
     });
 #endif
+#ifdef RECYCLER_VISITED_HOST
     HeapBlockList::ForEach(newMediumRecyclerVisitedHostHeapBlockList, [](MediumFinalizableHeapBlock * heapBlock)
     {
         heapBlock->Verify();
     });
+#endif
     HeapBlockList::ForEach(newMediumFinalizableHeapBlockList, [](MediumFinalizableHeapBlock * heapBlock)
     {
         heapBlock->Verify();
@@ -1841,10 +1886,12 @@ HeapInfo::VerifyMark()
         heapBlock->VerifyMark();
     });
 #endif
+#ifdef RECYCLER_VISITED_HOST
     HeapBlockList::ForEach(newRecyclerVisitedHostHeapBlockList, [](SmallFinalizableHeapBlock * heapBlock)
     {
         heapBlock->VerifyMark();
     });
+#endif
     HeapBlockList::ForEach(newFinalizableHeapBlockList, [](SmallFinalizableHeapBlock * heapBlock)
     {
         heapBlock->VerifyMark();
@@ -1870,10 +1917,12 @@ HeapInfo::VerifyMark()
         heapBlock->VerifyMark();
     });
 #endif
+#ifdef RECYCLER_VISITED_HOST
     HeapBlockList::ForEach(newMediumRecyclerVisitedHostHeapBlockList, [](MediumFinalizableHeapBlock * heapBlock)
     {
         heapBlock->VerifyMark();
     });
+#endif
     HeapBlockList::ForEach(newMediumFinalizableHeapBlockList, [](MediumFinalizableHeapBlock * heapBlock)
     {
         heapBlock->VerifyMark();

--- a/lib/Common/Memory/HeapInfo.h
+++ b/lib/Common/Memory/HeapInfo.h
@@ -494,7 +494,7 @@ private:
     friend class SmallFinalizableHeapBlockT;
 #ifdef RECYCLER_VISITED_HOST
     template <typename TBlockAttributes>
-	friend class SmallRecyclerVisitedHostHeapBlockT;
+    friend class SmallRecyclerVisitedHostHeapBlockT;
 #endif
     friend class LargeHeapBlock;
     friend class RecyclerSweep;

--- a/lib/Common/Memory/HeapInfo.h
+++ b/lib/Common/Memory/HeapInfo.h
@@ -214,11 +214,13 @@ private:
         // so new block can't go into heapBlockList
         return this->newFinalizableHeapBlockList;
     }
+#ifdef RECYCLER_VISITED_HOST
     template <>
     SmallRecyclerVisitedHostHeapBlock *& GetNewHeapBlockList<SmallRecyclerVisitedHostHeapBlock>(HeapBucketT<SmallRecyclerVisitedHostHeapBlock> * HeapBucket)
     {
         return this->newRecyclerVisitedHostHeapBlockList;
     }
+#endif
 
 #ifdef RECYCLER_WRITE_BARRIER
     template <>
@@ -252,11 +254,14 @@ private:
         // so new block can't go into heapBlockList
         return this->newMediumFinalizableHeapBlockList;
     }
+
+#ifdef RECYCLER_VISITED_HOST
     template <>
     MediumRecyclerVisitedHostHeapBlock *& GetNewHeapBlockList<MediumRecyclerVisitedHostHeapBlock>(HeapBucketT<MediumRecyclerVisitedHostHeapBlock> * HeapBucket)
     {
         return this->newMediumRecyclerVisitedHostHeapBlockList;
     }
+#endif
 
 #ifdef RECYCLER_WRITE_BARRIER
     template <>
@@ -411,7 +416,9 @@ private:
     SmallLeafHeapBlock * newLeafHeapBlockList;
     SmallNormalHeapBlock * newNormalHeapBlockList;
     SmallFinalizableHeapBlock * newFinalizableHeapBlockList;
+#ifdef RECYCLER_VISITED_HOST
     SmallRecyclerVisitedHostHeapBlock * newRecyclerVisitedHostHeapBlockList;
+#endif
 
 #ifdef RECYCLER_WRITE_BARRIER
     SmallNormalWithBarrierHeapBlock * newNormalWithBarrierHeapBlockList;
@@ -423,7 +430,9 @@ private:
     MediumLeafHeapBlock * newMediumLeafHeapBlockList;
     MediumNormalHeapBlock * newMediumNormalHeapBlockList;
     MediumFinalizableHeapBlock * newMediumFinalizableHeapBlockList;
+#ifdef RECYCLER_VISITED_HOST
     MediumRecyclerVisitedHostHeapBlock* newMediumRecyclerVisitedHostHeapBlockList;
+#endif
 
 #ifdef RECYCLER_WRITE_BARRIER
     MediumNormalWithBarrierHeapBlock * newMediumNormalWithBarrierHeapBlockList;
@@ -483,8 +492,10 @@ private:
     friend class SmallLeafHeapBlockT;
     template <typename TBlockAttributes>
     friend class SmallFinalizableHeapBlockT;
+#ifdef RECYCLER_VISITED_HOST
     template <typename TBlockAttributes>
-    friend class SmallRecyclerVisitedHostHeapBlockT;
+	friend class SmallRecyclerVisitedHostHeapBlockT;
+#endif
     friend class LargeHeapBlock;
     friend class RecyclerSweep;
 };

--- a/lib/Common/Memory/HeapInfo.h
+++ b/lib/Common/Memory/HeapInfo.h
@@ -217,7 +217,6 @@ private:
     template <>
     SmallRecyclerVisitedHostHeapBlock *& GetNewHeapBlockList<SmallRecyclerVisitedHostHeapBlock>(HeapBucketT<SmallRecyclerVisitedHostHeapBlock> * HeapBucket)
     {
-        // EdgeGC-TODO: Figure out what the above comment related to finalizable means for this function (same comment applies or do we have to do something else)
         return this->newRecyclerVisitedHostHeapBlockList;
     }
 
@@ -256,7 +255,6 @@ private:
     template <>
     MediumRecyclerVisitedHostHeapBlock *& GetNewHeapBlockList<MediumRecyclerVisitedHostHeapBlock>(HeapBucketT<MediumRecyclerVisitedHostHeapBlock> * HeapBucket)
     {
-        // EdgeGC-TODO: Figure out what the above comment related to finalizable means for this function (same comment applies or do we have to do something else)
         return this->newMediumRecyclerVisitedHostHeapBlockList;
     }
 

--- a/lib/Common/Memory/HeapInfo.h
+++ b/lib/Common/Memory/HeapInfo.h
@@ -214,6 +214,12 @@ private:
         // so new block can't go into heapBlockList
         return this->newFinalizableHeapBlockList;
     }
+    template <>
+    SmallRecyclerVisitedHostHeapBlock *& GetNewHeapBlockList<SmallRecyclerVisitedHostHeapBlock>(HeapBucketT<SmallRecyclerVisitedHostHeapBlock> * HeapBucket)
+    {
+        // EdgeGC-TODO: Figure out what the above comment related to finalizable means for this function (same comment applies or do we have to do something else)
+        return this->newRecyclerVisitedHostHeapBlockList;
+    }
 
 #ifdef RECYCLER_WRITE_BARRIER
     template <>
@@ -246,6 +252,12 @@ private:
         // find some partial swept block to be reused, thus modifying the heapBlockList in the background
         // so new block can't go into heapBlockList
         return this->newMediumFinalizableHeapBlockList;
+    }
+    template <>
+    MediumRecyclerVisitedHostHeapBlock *& GetNewHeapBlockList<MediumRecyclerVisitedHostHeapBlock>(HeapBucketT<MediumRecyclerVisitedHostHeapBlock> * HeapBucket)
+    {
+        // EdgeGC-TODO: Figure out what the above comment related to finalizable means for this function (same comment applies or do we have to do something else)
+        return this->newMediumRecyclerVisitedHostHeapBlockList;
     }
 
 #ifdef RECYCLER_WRITE_BARRIER
@@ -401,6 +413,7 @@ private:
     SmallLeafHeapBlock * newLeafHeapBlockList;
     SmallNormalHeapBlock * newNormalHeapBlockList;
     SmallFinalizableHeapBlock * newFinalizableHeapBlockList;
+    SmallRecyclerVisitedHostHeapBlock * newRecyclerVisitedHostHeapBlockList;
 
 #ifdef RECYCLER_WRITE_BARRIER
     SmallNormalWithBarrierHeapBlock * newNormalWithBarrierHeapBlockList;
@@ -412,6 +425,7 @@ private:
     MediumLeafHeapBlock * newMediumLeafHeapBlockList;
     MediumNormalHeapBlock * newMediumNormalHeapBlockList;
     MediumFinalizableHeapBlock * newMediumFinalizableHeapBlockList;
+    MediumRecyclerVisitedHostHeapBlock* newMediumRecyclerVisitedHostHeapBlockList;
 
 #ifdef RECYCLER_WRITE_BARRIER
     MediumNormalWithBarrierHeapBlock * newMediumNormalWithBarrierHeapBlockList;
@@ -471,6 +485,8 @@ private:
     friend class SmallLeafHeapBlockT;
     template <typename TBlockAttributes>
     friend class SmallFinalizableHeapBlockT;
+    template <typename TBlockAttributes>
+    friend class SmallRecyclerVisitedHostHeapBlockT;
     friend class LargeHeapBlock;
     friend class RecyclerSweep;
 };

--- a/lib/Common/Memory/LargeHeapBlock.cpp
+++ b/lib/Common/Memory/LargeHeapBlock.cpp
@@ -504,6 +504,11 @@ LargeHeapBlock::AllocFreeListEntry(DECLSPEC_GUARD_OVERFLOW size_t size, ObjectIn
     Assert(entry->headerIndex < this->objectCount);
     Assert(this->HeaderList()[entry->headerIndex] == nullptr);
 
+    if (attributes & RecyclerVisitedHostBit)
+    {
+        ReportFatalException(NULL, E_FAIL, Fatal_RecyclerVisitedHost_LargeHeapBlock, 1);
+    }
+
     uint headerIndex = entry->headerIndex;
     size_t originalSize = entry->objectSize;
 
@@ -571,6 +576,10 @@ LargeHeapBlock::Alloc(DECLSPEC_GUARD_OVERFLOW size_t size, ObjectInfoBits attrib
     Assert(HeapInfo::IsAlignedSize(size) || InPageHeapMode());
     Assert((attributes & InternalObjectInfoBitMask) == attributes);
     AssertMsg((attributes & TrackBit) == 0, "Large tracked object collection not implemented");
+    if (attributes & RecyclerVisitedHostBit)
+    {
+        ReportFatalException(NULL, E_FAIL, Fatal_RecyclerVisitedHost_LargeHeapBlock, 2);
+    }
 
     LargeObjectHeader * header = (LargeObjectHeader *)allocAddressEnd;
 #if ENABLE_PARTIAL_GC && ENABLE_CONCURRENT_GC

--- a/lib/Common/Memory/LargeHeapBlock.cpp
+++ b/lib/Common/Memory/LargeHeapBlock.cpp
@@ -504,10 +504,12 @@ LargeHeapBlock::AllocFreeListEntry(DECLSPEC_GUARD_OVERFLOW size_t size, ObjectIn
     Assert(entry->headerIndex < this->objectCount);
     Assert(this->HeaderList()[entry->headerIndex] == nullptr);
 
+#ifdef RECYCLER_VISITED_HOST
     if (attributes & RecyclerVisitedHostBit)
     {
         ReportFatalException(NULL, E_FAIL, Fatal_RecyclerVisitedHost_LargeHeapBlock, 1);
     }
+#endif
 
     uint headerIndex = entry->headerIndex;
     size_t originalSize = entry->objectSize;
@@ -576,10 +578,12 @@ LargeHeapBlock::Alloc(DECLSPEC_GUARD_OVERFLOW size_t size, ObjectInfoBits attrib
     Assert(HeapInfo::IsAlignedSize(size) || InPageHeapMode());
     Assert((attributes & InternalObjectInfoBitMask) == attributes);
     AssertMsg((attributes & TrackBit) == 0, "Large tracked object collection not implemented");
+#ifdef RECYCLER_VISITED_HOST
     if (attributes & RecyclerVisitedHostBit)
     {
         ReportFatalException(NULL, E_FAIL, Fatal_RecyclerVisitedHost_LargeHeapBlock, 2);
     }
+#endif
 
     LargeObjectHeader * header = (LargeObjectHeader *)allocAddressEnd;
 #if ENABLE_PARTIAL_GC && ENABLE_CONCURRENT_GC

--- a/lib/Common/Memory/MarkContext.h
+++ b/lib/Common/Memory/MarkContext.h
@@ -31,7 +31,9 @@ public:
     Recycler * GetRecycler() { return this->recycler; }
 
     bool AddMarkedObject(void * obj, size_t byteCount);
+#ifdef RECYCLER_VISITED_HOST
     bool AddPreciselyTracedObject(IRecyclerVisitedObject *obj);
+#endif
 #if ENABLE_CONCURRENT_GC
     bool AddTrackedObject(FinalizableObject * obj);
 #endif
@@ -56,9 +58,17 @@ public:
     void Release();
 
     bool HasPendingMarkObjects() const { return !markStack.IsEmpty(); }
+#ifdef RECYCLER_VISITED_HOST
     bool HasPendingPreciselyTracedObjects() const { return !preciseStack.IsEmpty(); }
+#endif
     bool HasPendingTrackObjects() const { return !trackStack.IsEmpty(); }
-    bool HasPendingObjects() const { return HasPendingMarkObjects() || HasPendingPreciselyTracedObjects() || HasPendingTrackObjects(); }
+    bool HasPendingObjects() const { 
+        return HasPendingMarkObjects() 
+#ifdef RECYCLER_VISITED_HOST
+            || HasPendingPreciselyTracedObjects() 
+#endif
+            || HasPendingTrackObjects(); 
+    }
 
     PageAllocator * GetPageAllocator() { return this->pagePool->GetPageAllocator(); }
 
@@ -92,7 +102,13 @@ public:
 
 
 #ifdef ENABLE_DEBUG_CONFIG_OPTIONS
-    void SetMaxPageCount(size_t maxPageCount) { markStack.SetMaxPageCount(maxPageCount); preciseStack.SetMaxPageCount(maxPageCount); trackStack.SetMaxPageCount(maxPageCount); }
+    void SetMaxPageCount(size_t maxPageCount) { 
+        markStack.SetMaxPageCount(maxPageCount); 
+#ifdef RECYCLER_VISITED_HOST
+        preciseStack.SetMaxPageCount(maxPageCount); 
+#endif
+        trackStack.SetMaxPageCount(maxPageCount); 
+    }
 #endif
 
 #ifdef RECYCLER_MARK_TRACK

--- a/lib/Common/Memory/MarkContext.h
+++ b/lib/Common/Memory/MarkContext.h
@@ -106,7 +106,9 @@ private:
     Recycler * recycler;
     PagePool * pagePool;
     PageStack<MarkCandidate> markStack;
+#ifdef RECYCLER_VISITED_HOST
     PageStack<IRecyclerVisitedObject*> preciseStack;
+#endif
     PageStack<FinalizableObject *> trackStack;
 
 #ifdef RECYCLER_MARK_TRACK

--- a/lib/Common/Memory/MarkContext.inl
+++ b/lib/Common/Memory/MarkContext.inl
@@ -241,7 +241,7 @@ void MarkContext::ProcessMark()
 
         if (!preciseStack.IsEmpty())
         {
-            MarkContextWrapper<parallel, interior> markContextWrapper(this);
+            MarkContextWrapper<parallel> markContextWrapper(this);
             IRecyclerVisitedObject* tracedObject;
             while (preciseStack.Pop(&tracedObject))
             {

--- a/lib/Common/Memory/MarkContext.inl
+++ b/lib/Common/Memory/MarkContext.inl
@@ -141,12 +141,6 @@ void MarkContext::Mark(void * candidate, void * parentReference)
 
     if (interior)
     {
-#if ENABLE_CONCURRENT_GC
-        Assert(recycler->enableScanInteriorPointers
-            || (!recycler->IsConcurrentState() && recycler->collectionState != CollectionStateParallelMark));
-#else
-        Assert(recycler->enableScanInteriorPointers || recycler->collectionState != CollectionStateParallelMark);
-#endif
         recycler->heapBlockMap.MarkInterior<parallel>(candidate, this);
         return;
     }

--- a/lib/Common/Memory/MarkContext.inl
+++ b/lib/Common/Memory/MarkContext.inl
@@ -245,7 +245,7 @@ void MarkContext::ProcessMark()
             IRecyclerVisitedObject* tracedObject;
             while (preciseStack.Pop(&tracedObject))
             {
-                tracedObject
+                tracedObject->Trace(&markContextWrapper);
             }
         }
 

--- a/lib/Common/Memory/MarkContext.inl
+++ b/lib/Common/Memory/MarkContext.inl
@@ -34,6 +34,13 @@ bool MarkContext::AddMarkedObject(void * objectAddress, size_t objectSize)
     return markStack.Push(markCandidate);
 }
 
+inline bool MarkContext::AddPreciselyTracedObject(IRecyclerVisitedObject* obj)
+{
+    FAULTINJECT_MEMORY_MARK_NOTHROW(_u("AddPreciselyTracedObject"), 0);
+
+    return preciseStack.Push(obj);
+}
+
 #if ENABLE_CONCURRENT_GC
 inline
 bool MarkContext::AddTrackedObject(FinalizableObject * obj)
@@ -195,40 +202,59 @@ void MarkContext::ProcessMark()
 #endif
 
 #if defined(_M_IX86) || defined(_M_X64)
-    MarkCandidate current, next;
-
-    while (markStack.Pop(&current))
+    // Flip between processing the generic mark stack (conservatively traced with ScanMemory) and
+    // the precise stack (precisely traced via IRecyclerVisitedObject::Trace). Each of those
+    // operations on an object has the potential to add new marked objects to either or both
+    // stacks so we must loop until they are both empty.
+    while (!markStack.IsEmpty() || !preciseStack.IsEmpty())
     {
-        // Process entries and prefetch as we go.
-        while (markStack.Pop(&next))
-        {
-            // Prefetch the next entry so it's ready when we need it.
-            _mm_prefetch((char *)next.obj, _MM_HINT_T0);
+        MarkCandidate current, next;
 
-            // Process the previously retrieved entry.
+        while (markStack.Pop(&current))
+        {
+            // Process entries and prefetch as we go.
+            while (markStack.Pop(&next))
+            {
+                // Prefetch the next entry so it's ready when we need it.
+                _mm_prefetch((char *)next.obj, _MM_HINT_T0);
+
+                // Process the previously retrieved entry.
+                ScanObject<parallel, interior>(current.obj, current.byteCount);
+
+                _mm_prefetch((char *)*(next.obj), _MM_HINT_T0);
+
+                current = next;
+            }
+
+            // The stack is empty, but we still have a previously retrieved entry; process it now.
             ScanObject<parallel, interior>(current.obj, current.byteCount);
 
-            _mm_prefetch((char *)*(next.obj), _MM_HINT_T0);
-
-            current = next;
+            // Processing that entry may have generated more entries in the mark stack, so continue the loop.
         }
-
-        // The stack is empty, but we still have a previously retrieved entry; process it now.
-        ScanObject<parallel, interior>(current.obj, current.byteCount);
-
-        // Processing that entry may have generated more entries in the mark stack, so continue the loop.
-    }
 #else
-    // _mm_prefetch intrinsic is specific to Intel platforms.
-    // CONSIDER: There does seem to be a compiler intrinsic for prefetch on ARM,
-    // however, the information on this is scarce, so for now just don't do prefetch on ARM.
-    MarkCandidate current;
+        // _mm_prefetch intrinsic is specific to Intel platforms.
+        // CONSIDER: There does seem to be a compiler intrinsic for prefetch on ARM,
+        // however, the information on this is scarce, so for now just don't do prefetch on ARM.
+        MarkCandidate current;
 
-    while (markStack.Pop(&current))
-    {
-        ScanObject<parallel, interior>(current.obj, current.byteCount);
-    }
+        while (markStack.Pop(&current))
+        {
+            ScanObject<parallel, interior>(current.obj, current.byteCount);
+        }
 #endif
 
-    Assert(markStack.IsEmpty());
+        Assert(markStack.IsEmpty());
+
+        if (!preciseStack.IsEmpty())
+        {
+            MarkContextWrapper<parallel, interior> markContextWrapper(this);
+            IRecyclerVisitedObject* tracedObject;
+            while (preciseStack.Pop(&tracedObject))
+            {
+                tracedObject
+            }
+        }
+
+        Assert(preciseStack.IsEmpty());
+    }
 }

--- a/lib/Common/Memory/MarkContext.inl
+++ b/lib/Common/Memory/MarkContext.inl
@@ -195,13 +195,13 @@ void MarkContext::ProcessMark()
     }
 #endif
 
-#if defined(_M_IX86) || defined(_M_X64)
     // Flip between processing the generic mark stack (conservatively traced with ScanMemory) and
     // the precise stack (precisely traced via IRecyclerVisitedObject::Trace). Each of those
     // operations on an object has the potential to add new marked objects to either or both
     // stacks so we must loop until they are both empty.
     while (!markStack.IsEmpty() || !preciseStack.IsEmpty())
     {
+#if defined(_M_IX86) || defined(_M_X64)
         MarkCandidate current, next;
 
         while (markStack.Pop(&current))

--- a/lib/Common/Memory/MarkContextWrapper.h
+++ b/lib/Common/Memory/MarkContextWrapper.h
@@ -7,7 +7,7 @@
 
 // Class used to wrap a MarkContext so that calls to MarkObjects during IRecyclerVisitedObject::Trace
 // can mark with the correct contextual template parameters
-template<bool parallel, bool interior>
+template<bool parallel>
 class MarkContextWrapper : public IRecyclerHeapMarkingContext
 {
 public:
@@ -19,9 +19,6 @@ public:
         {
             // We pass true for interior, since we expect a majority of the pointers being marked by
             // external objects to themselves be external (and thus candidates for interior pointers).
-            // EdgeGC-TODO: Review this logic and make sure everyone is on board. The implications of this
-            // not being the case are that we'd have to remove the alignment check from MarkContext::Mark
-            // and change HeapBlockMap.Mark to mod out the candidate pointer to force it to 16-byte alignment.
             markContext->Mark<parallel, /*interior*/true, /*doSpecialMark*/ false>(objects[i], parent);
         }
     }

--- a/lib/Common/Memory/MarkContextWrapper.h
+++ b/lib/Common/Memory/MarkContextWrapper.h
@@ -1,0 +1,33 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#include "core/RecyclerHeapMarkingContext.h"
+
+// Class used to wrap a MarkContext so that calls to MarkObjects during IRecyclerVisitedObject::Trace
+// can mark with the correct contextual template parameters
+template<bool parallel, bool interior>
+class MarkContextWrapper : public IRecyclerHeapMarkingContext
+{
+public:
+    MarkContextWrapper(MarkContext* context) : markContext(context) {}
+
+    void __stdcall MarkObjects(void** objects, size_t count, void* parent) override
+    {
+        for (size_t i = 0; i < count; i++)
+        {
+            // We pass true for interior, since we expect a majority of the pointers being marked by
+            // external objects to themselves be external (and thus candidates for interior pointers).
+            // EdgeGC-TODO: Review this logic and make sure everyone is on board. The implications of this
+            // not being the case are that we'd have to remove the alignment check from MarkContext::Mark
+            // and change HeapBlockMap.Mark to mod out the candidate pointer to force it to 16-byte alignment.
+            markContext->Mark<parallel, /*interior*/true, /*doSpecialMark*/ false>(objects[i], parent);
+        }
+    }
+
+private:
+    // Should only be created on the stack
+    void* operator new(size_t);
+    MarkContext* markContext;
+};

--- a/lib/Common/Memory/MarkContextWrapper.h
+++ b/lib/Common/Memory/MarkContextWrapper.h
@@ -13,7 +13,7 @@ class MarkContextWrapper : public IRecyclerHeapMarkingContext
 public:
     MarkContextWrapper(MarkContext* context) : markContext(context) {}
 
-    void __stdcall MarkObjects(void** objects, size_t count, void* parent) override
+    void MarkObjects(void** objects, size_t count, void* parent) override
     {
         for (size_t i = 0; i < count; i++)
         {

--- a/lib/Common/Memory/MarkContextWrapper.h
+++ b/lib/Common/Memory/MarkContextWrapper.h
@@ -3,7 +3,7 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 
-#include "core/RecyclerHeapMarkingContext.h"
+#include "Core/RecyclerHeapMarkingContext.h"
 
 // Class used to wrap a MarkContext so that calls to MarkObjects during IRecyclerVisitedObject::Trace
 // can mark with the correct contextual template parameters

--- a/lib/Common/Memory/Recycler.cpp
+++ b/lib/Common/Memory/Recycler.cpp
@@ -8723,7 +8723,9 @@ RecyclerHeapObjectInfo::GetSize() const
 }
 
 template char* Recycler::AllocWithAttributesInlined<(Memory::ObjectInfoBits)32, false>(size_t);
+#ifdef RECYCLER_VISITED_HOST
 template char* Recycler::AllocZeroWithAttributesInlined<RecyclerVisitedHostTracedFinalizableBits, /* nothrow = */true>(size_t);
 template char* Recycler::AllocZeroWithAttributesInlined<RecyclerVisitedHostFinalizableBits, /* nothrow = */true>(size_t);
 template char* Recycler::AllocZeroWithAttributesInlined<RecyclerVisitedHostTracedBits, /* nothrow = */true>(size_t);
 template char* Recycler::AllocZeroWithAttributesInlined<LeafBit, /* nothrow = */true>(size_t);
+#endif

--- a/lib/Common/Memory/Recycler.cpp
+++ b/lib/Common/Memory/Recycler.cpp
@@ -8723,3 +8723,7 @@ RecyclerHeapObjectInfo::GetSize() const
 }
 
 template char* Recycler::AllocWithAttributesInlined<(Memory::ObjectInfoBits)32, false>(size_t);
+template char* Recycler::AllocZeroWithAttributesInlined<RecyclerVisitedHostTracedFinalizableBits, /* nothrow = */true>(size_t);
+template char* Recycler::AllocZeroWithAttributesInlined<RecyclerVisitedHostFinalizableBits, /* nothrow = */true>(size_t);
+template char* Recycler::AllocZeroWithAttributesInlined<RecyclerVisitedHostTracedBits, /* nothrow = */true>(size_t);
+template char* Recycler::AllocZeroWithAttributesInlined<RecyclerVisitedHostLeafBits, /* nothrow = */true>(size_t);

--- a/lib/Common/Memory/Recycler.cpp
+++ b/lib/Common/Memory/Recycler.cpp
@@ -8726,4 +8726,4 @@ template char* Recycler::AllocWithAttributesInlined<(Memory::ObjectInfoBits)32, 
 template char* Recycler::AllocZeroWithAttributesInlined<RecyclerVisitedHostTracedFinalizableBits, /* nothrow = */true>(size_t);
 template char* Recycler::AllocZeroWithAttributesInlined<RecyclerVisitedHostFinalizableBits, /* nothrow = */true>(size_t);
 template char* Recycler::AllocZeroWithAttributesInlined<RecyclerVisitedHostTracedBits, /* nothrow = */true>(size_t);
-template char* Recycler::AllocZeroWithAttributesInlined<RecyclerVisitedHostLeafBits, /* nothrow = */true>(size_t);
+template char* Recycler::AllocZeroWithAttributesInlined<LeafBit, /* nothrow = */true>(size_t);

--- a/lib/Common/Memory/Recycler.h
+++ b/lib/Common/Memory/Recycler.h
@@ -185,7 +185,7 @@ struct InfoBitsWrapper{};
 #define RecyclerAllocVisitedHostTracedAndFinalizedZero(recycler,size) recycler->AllocVisitedHost<RecyclerVisitedHostTracedFinalizableBits>(size)
 #define RecyclerAllocVisitedHostFinalizedZero(recycler,size) recycler->AllocVisitedHost<RecyclerVisitedHostFinalizableBits>(size)
 #define RecyclerAllocVisitedHostTracedZero(recycler,size) recycler->AllocVisitedHost<RecyclerVisitedHostTracedBits>(size)
-#define RecyclerAllocVisitedHostLeafZero(recycler,size) recycler->AllocVisitedHost<RecyclerVisitedHostLeafBits>(size)
+#define RecyclerAllocLeafZero(recycler,size) recycler->AllocVisitedHost<LeafBit>(size)
 
 #ifdef TRACE_OBJECT_LIFETIME
 #define RecyclerNewLeafTrace(recycler,T,...) AllocatorNewBase(Recycler, recycler, AllocLeafTrace, T, __VA_ARGS__)

--- a/lib/Common/Memory/Recycler.h
+++ b/lib/Common/Memory/Recycler.h
@@ -182,13 +182,10 @@ struct InfoBitsWrapper{};
 #define RecyclerNewTrackedLeaf(recycler,T,...) static_cast<T *>(static_cast<FinalizableObject *>(AllocatorNewBase(Recycler, recycler, AllocTrackedLeafInlined, T, __VA_ARGS__)))
 #define RecyclerNewTrackedLeafPlusZ(recycler,size,T,...) static_cast<T *>(static_cast<FinalizableObject *>(AllocatorNewPlusBase(Recycler, recycler, AllocZeroTrackedLeafInlined, size, T, __VA_ARGS__)))
 
-#define RecyclerAllocVisitedHost_TracedAndFinalized(recycler,size) AllocatorNewBase(Recycler, recycler, AllocRecyclerVisitedHost_TracedAndFinalizedInlined, char[size])
-#define RecyclerAllocVisitedHost_TracedAndFinalizedZero(recycler,size) AllocatorNewBase(Recycler, recycler,AllocRecyclerVisitedHost_TracedAndFinalizedZeroInlined, char[size])
-#define RecyclerAllocVisitedHost_Finalized(recycler,size) AllocatorNewBase(Recycler, recycler, AllocRecyclerVisitedHost_FinalizedInlined, char[size])
-#define RecyclerAllocVisitedHost_FinalizedZero(recycler,size) AllocatorNewBase(Recycler, recycler, AllocRecyclerVisitedHost_FinalizedZeroInlined, char[size])
-#define RecyclerAllocVisitedHost_Traced(recycler,size) AllocatorNewBase(Recycler, recycler, AllocRecyclerVisitedHost_TracedInlined, char[size])
-#define RecyclerAllocVisitedHost_TracedZero(recycler,size) AllocatorNewBase(Recycler, recycler, AllocRecyclerVisitedHost_TracedZeroInlined, char[size])
-
+#define RecyclerAllocVisitedHostTracedAndFinalizedZero(recycler,size) AllocatorNewBase(Recycler, recycler,AllocRecyclerVisitedHostTracedAndFinalizedZeroInlined, char[size])
+#define RecyclerAllocVisitedHostFinalizedZero(recycler,size) AllocatorNewBase(Recycler, recycler, AllocRecyclerVisitedHostFinalizedZeroInlined, char[size])
+#define RecyclerAllocVisitedHostTracedZero(recycler,size) AllocatorNewBase(Recycler, recycler, AllocRecyclerVisitedHostTracedZeroInlined, char[size])
+#define RecyclerAllocVisitedHostLeafZero(recycler,size) AllocatorNewBase(Recycler, recycler, AllocRecyclerVisitedHostLeafZeroInlined, char[size])
 
 #ifdef TRACE_OBJECT_LIFETIME
 #define RecyclerNewLeafTrace(recycler,T,...) AllocatorNewBase(Recycler, recycler, AllocLeafTrace, T, __VA_ARGS__)
@@ -1280,12 +1277,10 @@ public:
     DEFINE_RECYCLER_ALLOC_ZERO(AllocLeafZero, LeafBit);
     DEFINE_RECYCLER_ALLOC_ZERO(AllocZeroTrackedLeaf, ClientTrackableLeafBits);
 
-    DEFINE_RECYCLER_ALLOC(AllocRecyclerVisitedHost_TracedAndFinalized, RecyclerVisitedHost_TracedFinalizableBits);
-    DEFINE_RECYCLER_ALLOC_ZERO(AllocRecyclerVisitedHost_TracedAndFinalizedZero, RecyclerVisitedHost_TracedFinalizableBits);
-    DEFINE_RECYCLER_ALLOC(AllocRecyclerVisitedHost_Traced, RecyclerVisitedHost_TracedBits);
-    DEFINE_RECYCLER_ALLOC_ZERO(AllocRecyclerVisitedHost_TracedZero, RecyclerVisitedHost_TracedBits);
-    DEFINE_RECYCLER_ALLOC(AllocRecyclerVisitedHost_Finalized, RecyclerVisitedHost_FinalizableBits);
-    DEFINE_RECYCLER_ALLOC_ZERO(AllocRecyclerVisitedHost_FinalizedZero, RecyclerVisitedHost_FinalizableBits);
+    DEFINE_RECYCLER_ALLOC_ZERO(AllocRecyclerVisitedHostTracedAndFinalizedZero, RecyclerVisitedHostTracedFinalizableBits);
+    DEFINE_RECYCLER_ALLOC_ZERO(AllocRecyclerVisitedHostTracedZero, RecyclerVisitedHostTracedBits);
+    DEFINE_RECYCLER_ALLOC_ZERO(AllocRecyclerVisitedHostFinalizedZero, RecyclerVisitedHostFinalizableBits);
+    DEFINE_RECYCLER_ALLOC_ZERO(AllocRecyclerVisitedHostLeafZero, RecyclerVisitedHostLeafBits);
 
     DEFINE_RECYCLER_NOTHROW_ALLOC_ZERO(AllocImplicitRootLeaf, ImplicitRootLeafBits);
     DEFINE_RECYCLER_NOTHROW_ALLOC_ZERO(AllocImplicitRoot, ImplicitRootBit);

--- a/lib/Common/Memory/Recycler.h
+++ b/lib/Common/Memory/Recycler.h
@@ -182,10 +182,12 @@ struct InfoBitsWrapper{};
 #define RecyclerNewTrackedLeaf(recycler,T,...) static_cast<T *>(static_cast<FinalizableObject *>(AllocatorNewBase(Recycler, recycler, AllocTrackedLeafInlined, T, __VA_ARGS__)))
 #define RecyclerNewTrackedLeafPlusZ(recycler,size,T,...) static_cast<T *>(static_cast<FinalizableObject *>(AllocatorNewPlusBase(Recycler, recycler, AllocZeroTrackedLeafInlined, size, T, __VA_ARGS__)))
 
+#ifdef RECYCLER_VISITED_HOST
 #define RecyclerAllocVisitedHostTracedAndFinalizedZero(recycler,size) recycler->AllocVisitedHost<RecyclerVisitedHostTracedFinalizableBits>(size)
 #define RecyclerAllocVisitedHostFinalizedZero(recycler,size) recycler->AllocVisitedHost<RecyclerVisitedHostFinalizableBits>(size)
 #define RecyclerAllocVisitedHostTracedZero(recycler,size) recycler->AllocVisitedHost<RecyclerVisitedHostTracedBits>(size)
 #define RecyclerAllocLeafZero(recycler,size) recycler->AllocVisitedHost<LeafBit>(size)
+#endif
 
 #ifdef TRACE_OBJECT_LIFETIME
 #define RecyclerNewLeafTrace(recycler,T,...) AllocatorNewBase(Recycler, recycler, AllocLeafTrace, T, __VA_ARGS__)
@@ -1726,7 +1728,9 @@ private:
     template <class TBlockAttributes> friend class SmallNormalHeapBlockT;
     template <class TBlockAttributes> friend class SmallLeafHeapBlockT;
     template <class TBlockAttributes> friend class SmallFinalizableHeapBlockT;
+#ifdef RECYCLER_VISITED_HOST
     template <class TBlockAttributes> friend class SmallRecyclerVisitedHostHeapBlockT;
+#endif
     friend class LargeHeapBlock;
     friend class HeapInfo;
     friend class LargeHeapBucket;

--- a/lib/Common/Memory/Recycler.h
+++ b/lib/Common/Memory/Recycler.h
@@ -182,6 +182,12 @@ struct InfoBitsWrapper{};
 #define RecyclerNewTrackedLeaf(recycler,T,...) static_cast<T *>(static_cast<FinalizableObject *>(AllocatorNewBase(Recycler, recycler, AllocTrackedLeafInlined, T, __VA_ARGS__)))
 #define RecyclerNewTrackedLeafPlusZ(recycler,size,T,...) static_cast<T *>(static_cast<FinalizableObject *>(AllocatorNewPlusBase(Recycler, recycler, AllocZeroTrackedLeafInlined, size, T, __VA_ARGS__)))
 
+#define RecyclerAllocVisitedHost_TracedAndFinalized(recycler,size) AllocatorNewBase(Recycler, recycler, AllocRecyclerVisitedHost_TracedAndFinalizedInlined, char[size])
+#define RecyclerAllocVisitedHost_TracedAndFinalizedZero(recycler,size) AllocatorNewBase(Recycler, recycler,AllocRecyclerVisitedHost_TracedAndFinalizedZeroInlined, char[size])
+#define RecyclerAllocVisitedHost_Finalized(recycler,size) AllocatorNewBase(Recycler, recycler, AllocRecyclerVisitedHost_FinalizedInlined, char[size])
+#define RecyclerAllocVisitedHost_FinalizedZero(recycler,size) AllocatorNewBase(Recycler, recycler, AllocRecyclerVisitedHost_FinalizedZeroInlined, char[size])
+#define RecyclerAllocVisitedHost_Traced(recycler,size) AllocatorNewBase(Recycler, recycler, AllocRecyclerVisitedHost_TracedInlined, char[size])
+#define RecyclerAllocVisitedHost_TracedZero(recycler,size) AllocatorNewBase(Recycler, recycler, AllocRecyclerVisitedHost_TracedZeroInlined, char[size])
 
 
 #ifdef TRACE_OBJECT_LIFETIME
@@ -1273,8 +1279,15 @@ public:
     DEFINE_RECYCLER_ALLOC(AllocTrackedLeaf, ClientTrackableLeafBits);
     DEFINE_RECYCLER_ALLOC_ZERO(AllocLeafZero, LeafBit);
     DEFINE_RECYCLER_ALLOC_ZERO(AllocZeroTrackedLeaf, ClientTrackableLeafBits);
-    DEFINE_RECYCLER_NOTHROW_ALLOC_ZERO(AllocImplicitRootLeaf, ImplicitRootLeafBits);
 
+    DEFINE_RECYCLER_ALLOC(AllocRecyclerVisitedHost_TracedAndFinalized, RecyclerVisitedHost_TracedFinalizableBits);
+    DEFINE_RECYCLER_ALLOC_ZERO(AllocRecyclerVisitedHost_TracedAndFinalizedZero, RecyclerVisitedHost_TracedFinalizableBits);
+    DEFINE_RECYCLER_ALLOC(AllocRecyclerVisitedHost_Traced, RecyclerVisitedHost_TracedBits);
+    DEFINE_RECYCLER_ALLOC_ZERO(AllocRecyclerVisitedHost_TracedZero, RecyclerVisitedHost_TracedBits);
+    DEFINE_RECYCLER_ALLOC(AllocRecyclerVisitedHost_Finalized, RecyclerVisitedHost_FinalizableBits);
+    DEFINE_RECYCLER_ALLOC_ZERO(AllocRecyclerVisitedHost_FinalizedZero, RecyclerVisitedHost_FinalizableBits);
+
+    DEFINE_RECYCLER_NOTHROW_ALLOC_ZERO(AllocImplicitRootLeaf, ImplicitRootLeafBits);
     DEFINE_RECYCLER_NOTHROW_ALLOC_ZERO(AllocImplicitRoot, ImplicitRootBit);
 
     template <ObjectInfoBits enumClass>

--- a/lib/Common/Memory/Recycler.h
+++ b/lib/Common/Memory/Recycler.h
@@ -1573,6 +1573,7 @@ private:
     template <bool doSpecialMark>
     void ScanMemory(void ** obj, size_t byteCount) { if (byteCount != 0) { ScanMemoryInline<doSpecialMark>(obj, byteCount); } }
     bool AddMark(void * candidate, size_t byteCount);
+    bool AddPreciselyTracedMark(IRecyclerVisitedObject * candidate);
 
     // Sweep
 #if ENABLE_PARTIAL_GC

--- a/lib/Common/Memory/Recycler.h
+++ b/lib/Common/Memory/Recycler.h
@@ -1725,6 +1725,7 @@ private:
     template <class TBlockAttributes> friend class SmallNormalHeapBlockT;
     template <class TBlockAttributes> friend class SmallLeafHeapBlockT;
     template <class TBlockAttributes> friend class SmallFinalizableHeapBlockT;
+    template <class TBlockAttributes> friend class SmallRecyclerVisitedHostHeapBlockT;
     friend class LargeHeapBlock;
     friend class HeapInfo;
     friend class LargeHeapBucket;

--- a/lib/Common/Memory/Recycler.h
+++ b/lib/Common/Memory/Recycler.h
@@ -1575,7 +1575,9 @@ private:
     template <bool doSpecialMark>
     void ScanMemory(void ** obj, size_t byteCount) { if (byteCount != 0) { ScanMemoryInline<doSpecialMark>(obj, byteCount); } }
     bool AddMark(void * candidate, size_t byteCount);
+#ifdef RECYCLER_VISITED_HOST
     bool AddPreciselyTracedMark(IRecyclerVisitedObject * candidate);
+#endif
 
     // Sweep
 #if ENABLE_PARTIAL_GC

--- a/lib/Common/Memory/Recycler.h
+++ b/lib/Common/Memory/Recycler.h
@@ -182,10 +182,10 @@ struct InfoBitsWrapper{};
 #define RecyclerNewTrackedLeaf(recycler,T,...) static_cast<T *>(static_cast<FinalizableObject *>(AllocatorNewBase(Recycler, recycler, AllocTrackedLeafInlined, T, __VA_ARGS__)))
 #define RecyclerNewTrackedLeafPlusZ(recycler,size,T,...) static_cast<T *>(static_cast<FinalizableObject *>(AllocatorNewPlusBase(Recycler, recycler, AllocZeroTrackedLeafInlined, size, T, __VA_ARGS__)))
 
-#define RecyclerAllocVisitedHostTracedAndFinalizedZero(recycler,size) AllocatorNewBase(Recycler, recycler,AllocRecyclerVisitedHostTracedAndFinalizedZeroInlined, char[size])
-#define RecyclerAllocVisitedHostFinalizedZero(recycler,size) AllocatorNewBase(Recycler, recycler, AllocRecyclerVisitedHostFinalizedZeroInlined, char[size])
-#define RecyclerAllocVisitedHostTracedZero(recycler,size) AllocatorNewBase(Recycler, recycler, AllocRecyclerVisitedHostTracedZeroInlined, char[size])
-#define RecyclerAllocVisitedHostLeafZero(recycler,size) AllocatorNewBase(Recycler, recycler, AllocRecyclerVisitedHostLeafZeroInlined, char[size])
+#define RecyclerAllocVisitedHostTracedAndFinalizedZero(recycler,size) recycler->AllocVisitedHost<RecyclerVisitedHostTracedFinalizableBits>(size)
+#define RecyclerAllocVisitedHostFinalizedZero(recycler,size) recycler->AllocVisitedHost<RecyclerVisitedHostFinalizableBits>(size)
+#define RecyclerAllocVisitedHostTracedZero(recycler,size) recycler->AllocVisitedHost<RecyclerVisitedHostTracedBits>(size)
+#define RecyclerAllocVisitedHostLeafZero(recycler,size) recycler->AllocVisitedHost<RecyclerVisitedHostLeafBits>(size)
 
 #ifdef TRACE_OBJECT_LIFETIME
 #define RecyclerNewLeafTrace(recycler,T,...) AllocatorNewBase(Recycler, recycler, AllocLeafTrace, T, __VA_ARGS__)
@@ -1276,13 +1276,8 @@ public:
     DEFINE_RECYCLER_ALLOC(AllocTrackedLeaf, ClientTrackableLeafBits);
     DEFINE_RECYCLER_ALLOC_ZERO(AllocLeafZero, LeafBit);
     DEFINE_RECYCLER_ALLOC_ZERO(AllocZeroTrackedLeaf, ClientTrackableLeafBits);
-
-    DEFINE_RECYCLER_ALLOC_ZERO(AllocRecyclerVisitedHostTracedAndFinalizedZero, RecyclerVisitedHostTracedFinalizableBits);
-    DEFINE_RECYCLER_ALLOC_ZERO(AllocRecyclerVisitedHostTracedZero, RecyclerVisitedHostTracedBits);
-    DEFINE_RECYCLER_ALLOC_ZERO(AllocRecyclerVisitedHostFinalizedZero, RecyclerVisitedHostFinalizableBits);
-    DEFINE_RECYCLER_ALLOC_ZERO(AllocRecyclerVisitedHostLeafZero, RecyclerVisitedHostLeafBits);
-
     DEFINE_RECYCLER_NOTHROW_ALLOC_ZERO(AllocImplicitRootLeaf, ImplicitRootLeafBits);
+
     DEFINE_RECYCLER_NOTHROW_ALLOC_ZERO(AllocImplicitRoot, ImplicitRootBit);
 
     template <ObjectInfoBits enumClass>
@@ -1297,6 +1292,11 @@ public:
     char * AllocWithInfoBits(DECLSPEC_GUARD_OVERFLOW size_t size)
     {
         return AllocWithAttributes<infoBits, /* nothrow = */ false>(size);
+    }
+    template <ObjectInfoBits infoBits>
+    char * AllocVisitedHost(DECLSPEC_GUARD_OVERFLOW size_t size)
+    {
+        return AllocZeroWithAttributes<infoBits, /* nothrow = */ true>(size);
     }
 
     template<typename T>

--- a/lib/Common/Memory/Recycler.inl
+++ b/lib/Common/Memory/Recycler.inl
@@ -517,6 +517,13 @@ Recycler::AddMark(void * candidate, size_t byteCount) throw()
     return markContext.AddMarkedObject(candidate, byteCount);
 }
 
+inline bool
+Recycler::AddPreciselyTracedMark(IRecyclerVisitedObject * candidate) throw()
+{
+    // This is never called during parallel marking
+    Assert(this->collectionState != CollectionStateParallelMark);
+    return markContext.AddPreciselyTracedObject(candidate);
+}
 
 template <typename T>
 void

--- a/lib/Common/Memory/Recycler.inl
+++ b/lib/Common/Memory/Recycler.inl
@@ -50,7 +50,7 @@ Recycler::AllocWithAttributesInlined(DECLSPEC_GUARD_OVERFLOW size_t size)
 #ifndef RECYCLER_VISITED_HOST
     CompileAssert((attributes & TrackBit) == 0 || (attributes & ClientTrackedBit) != 0);
 #else
-	CompileAssert((attributes & TrackBit) == 0 || (attributes & ClientTrackedBit) != 0 || (attributes & RecyclerVisitedHostBit) != 0);
+    CompileAssert((attributes & TrackBit) == 0 || (attributes & ClientTrackedBit) != 0 || (attributes & RecyclerVisitedHostBit) != 0);
 #endif
     Assert(this->enableScanImplicitRoots || (attributes & ImplicitRootBit) == 0);
     AssertMsg(this->disableThreadAccessCheck || this->mainThreadId == GetCurrentThreadContextId(),

--- a/lib/Common/Memory/Recycler.inl
+++ b/lib/Common/Memory/Recycler.inl
@@ -521,6 +521,7 @@ Recycler::AddMark(void * candidate, size_t byteCount) throw()
     return markContext.AddMarkedObject(candidate, byteCount);
 }
 
+#ifdef RECYCLER_VISITED_HOST
 inline bool
 Recycler::AddPreciselyTracedMark(IRecyclerVisitedObject * candidate) throw()
 {
@@ -528,6 +529,7 @@ Recycler::AddPreciselyTracedMark(IRecyclerVisitedObject * candidate) throw()
     Assert((this->collectionState & Collection_Parallel) == 0);
     return markContext.AddPreciselyTracedObject(candidate);
 }
+#endif
 
 template <typename T>
 void

--- a/lib/Common/Memory/Recycler.inl
+++ b/lib/Common/Memory/Recycler.inl
@@ -524,8 +524,8 @@ Recycler::AddMark(void * candidate, size_t byteCount) throw()
 inline bool
 Recycler::AddPreciselyTracedMark(IRecyclerVisitedObject * candidate) throw()
 {
-    // This is never called during parallel marking
-    Assert(this->collectionState != CollectionStateParallelMark);
+    // This API cannot be used for parallel marking as we don't have enough information to determine which MarkingContext to use.
+    Assert((this->collectionState & Collection_Parallel) == 0);
     return markContext.AddPreciselyTracedObject(candidate);
 }
 

--- a/lib/Common/Memory/Recycler.inl
+++ b/lib/Common/Memory/Recycler.inl
@@ -46,8 +46,8 @@ template <ObjectInfoBits attributes, bool nothrow>
 inline char *
 Recycler::AllocWithAttributesInlined(DECLSPEC_GUARD_OVERFLOW size_t size)
 {
-    // All tracked objects are client tracked objects
-    CompileAssert((attributes & TrackBit) == 0 || (attributes & ClientTrackedBit) != 0);
+    // All tracked objects are client tracked or recycler host visited objects
+    CompileAssert((attributes & TrackBit) == 0 || (attributes & ClientTrackedBit) != 0 || (attributes & RecyclerVisitedHostBit) != 0);
     Assert(this->enableScanImplicitRoots || (attributes & ImplicitRootBit) == 0);
     AssertMsg(this->disableThreadAccessCheck || this->mainThreadId == GetCurrentThreadContextId(),
         "Allocating from the recycler can only be done on the main thread");

--- a/lib/Common/Memory/Recycler.inl
+++ b/lib/Common/Memory/Recycler.inl
@@ -47,7 +47,11 @@ inline char *
 Recycler::AllocWithAttributesInlined(DECLSPEC_GUARD_OVERFLOW size_t size)
 {
     // All tracked objects are client tracked or recycler host visited objects
-    CompileAssert((attributes & TrackBit) == 0 || (attributes & ClientTrackedBit) != 0 || (attributes & RecyclerVisitedHostBit) != 0);
+#ifndef RECYCLER_VISITED_HOST
+    CompileAssert((attributes & TrackBit) == 0 || (attributes & ClientTrackedBit) != 0);
+#else
+	CompileAssert((attributes & TrackBit) == 0 || (attributes & ClientTrackedBit) != 0 || (attributes & RecyclerVisitedHostBit) != 0);
+#endif
     Assert(this->enableScanImplicitRoots || (attributes & ImplicitRootBit) == 0);
     AssertMsg(this->disableThreadAccessCheck || this->mainThreadId == GetCurrentThreadContextId(),
         "Allocating from the recycler can only be done on the main thread");

--- a/lib/Common/Memory/RecyclerSweep.cpp
+++ b/lib/Common/Memory/RecyclerSweep.cpp
@@ -512,7 +512,7 @@ RecyclerSweep::SetPendingMergeNewHeapBlockCount()
         + HeapBlockList::Count(finalizableData.pendingMergeNewHeapBlockList)
 #ifdef RECYCLER_VISITED_HOST
         + HeapBlockList::Count(recyclerVisitedHostData.pendingMergeNewHeapBlockList)
-		+ HeapBlockList::Count(mediumRecyclerVisitedHostData.pendingMergeNewHeapBlockList)
+        + HeapBlockList::Count(mediumRecyclerVisitedHostData.pendingMergeNewHeapBlockList)
 #endif
 #ifdef RECYCLER_WRITE_BARRIER
         + HeapBlockList::Count(withBarrierData.pendingMergeNewHeapBlockList)

--- a/lib/Common/Memory/RecyclerSweep.cpp
+++ b/lib/Common/Memory/RecyclerSweep.cpp
@@ -72,6 +72,7 @@ RecyclerSweep::BeginSweep(Recycler * recycler)
     finalizableWithBarrierData.pendingMergeNewHeapBlockList = recycler->autoHeap.newFinalizableWithBarrierHeapBlockList;
 #endif
     finalizableData.pendingMergeNewHeapBlockList = recycler->autoHeap.newFinalizableHeapBlockList;
+    recyclerVisitedHostData.pendingMergeNewHeapBlockList = recycler->autoHeap.newRecyclerVisitedHostHeapBlockList;
 
     mediumLeafData.pendingMergeNewHeapBlockList = recycler->autoHeap.newMediumLeafHeapBlockList;
     mediumNormalData.pendingMergeNewHeapBlockList = recycler->autoHeap.newMediumNormalHeapBlockList;
@@ -80,11 +81,13 @@ RecyclerSweep::BeginSweep(Recycler * recycler)
     mediumFinalizableWithBarrierData.pendingMergeNewHeapBlockList = recycler->autoHeap.newMediumFinalizableWithBarrierHeapBlockList;
 #endif
     mediumFinalizableData.pendingMergeNewHeapBlockList = recycler->autoHeap.newMediumFinalizableHeapBlockList;
+    mediumRecyclerVisitedHostData.pendingMergeNewHeapBlockList = recycler->autoHeap.newMediumRecyclerVisitedHostHeapBlockList;
 
 
     recycler->autoHeap.newLeafHeapBlockList = nullptr;
     recycler->autoHeap.newNormalHeapBlockList = nullptr;
     recycler->autoHeap.newFinalizableHeapBlockList = nullptr;
+    recycler->autoHeap.newRecyclerVisitedHostHeapBlockList = nullptr;
 #ifdef RECYCLER_WRITE_BARRIER
     recycler->autoHeap.newNormalWithBarrierHeapBlockList = nullptr;
     recycler->autoHeap.newFinalizableWithBarrierHeapBlockList = nullptr;
@@ -93,6 +96,7 @@ RecyclerSweep::BeginSweep(Recycler * recycler)
     recycler->autoHeap.newMediumLeafHeapBlockList = nullptr;
     recycler->autoHeap.newMediumNormalHeapBlockList = nullptr;
     recycler->autoHeap.newMediumFinalizableHeapBlockList = nullptr;
+    recycler->autoHeap.newMediumRecyclerVisitedHostHeapBlockList = nullptr;
 #ifdef RECYCLER_WRITE_BARRIER
     recycler->autoHeap.newMediumNormalWithBarrierHeapBlockList = nullptr;
     recycler->autoHeap.newMediumFinalizableWithBarrierHeapBlockList = nullptr;
@@ -401,6 +405,7 @@ RecyclerSweep::MergePendingNewHeapBlockList()
 template void RecyclerSweep::MergePendingNewHeapBlockList<SmallLeafHeapBlock>();
 template void RecyclerSweep::MergePendingNewHeapBlockList<SmallNormalHeapBlock>();
 template void RecyclerSweep::MergePendingNewHeapBlockList<SmallFinalizableHeapBlock>();
+template void RecyclerSweep::MergePendingNewHeapBlockList<SmallRecyclerVisitedHostHeapBlock>();
 #ifdef RECYCLER_WRITE_BARRIER
 template void RecyclerSweep::MergePendingNewHeapBlockList<SmallNormalWithBarrierHeapBlock>();
 template void RecyclerSweep::MergePendingNewHeapBlockList<SmallFinalizableWithBarrierHeapBlock>();
@@ -424,6 +429,7 @@ RecyclerSweep::MergePendingNewMediumHeapBlockList()
 template void RecyclerSweep::MergePendingNewMediumHeapBlockList<MediumLeafHeapBlock>();
 template void RecyclerSweep::MergePendingNewMediumHeapBlockList<MediumNormalHeapBlock>();
 template void RecyclerSweep::MergePendingNewMediumHeapBlockList<MediumFinalizableHeapBlock>();
+template void RecyclerSweep::MergePendingNewMediumHeapBlockList<MediumRecyclerVisitedHostHeapBlock>();
 #ifdef RECYCLER_WRITE_BARRIER
 template void RecyclerSweep::MergePendingNewMediumHeapBlockList<MediumNormalWithBarrierHeapBlock>();
 template void RecyclerSweep::MergePendingNewMediumHeapBlockList<MediumFinalizableWithBarrierHeapBlock>();
@@ -492,6 +498,7 @@ RecyclerSweep::SetPendingMergeNewHeapBlockCount()
     return HeapBlockList::Count(leafData.pendingMergeNewHeapBlockList)
         + HeapBlockList::Count(normalData.pendingMergeNewHeapBlockList)
         + HeapBlockList::Count(finalizableData.pendingMergeNewHeapBlockList)
+        + HeapBlockList::Count(recyclerVisitedHostData.pendingMergeNewHeapBlockList)
 #ifdef RECYCLER_WRITE_BARRIER
         + HeapBlockList::Count(withBarrierData.pendingMergeNewHeapBlockList)
         + HeapBlockList::Count(finalizableWithBarrierData.pendingMergeNewHeapBlockList)
@@ -499,6 +506,7 @@ RecyclerSweep::SetPendingMergeNewHeapBlockCount()
         + HeapBlockList::Count(mediumLeafData.pendingMergeNewHeapBlockList)
         + HeapBlockList::Count(mediumNormalData.pendingMergeNewHeapBlockList)
         + HeapBlockList::Count(mediumFinalizableData.pendingMergeNewHeapBlockList)
+        + HeapBlockList::Count(mediumRecyclerVisitedHostData.pendingMergeNewHeapBlockList)
 #ifdef RECYCLER_WRITE_BARRIER
         + HeapBlockList::Count(mediumWithBarrierData.pendingMergeNewHeapBlockList)
         + HeapBlockList::Count(mediumFinalizableWithBarrierData.pendingMergeNewHeapBlockList)

--- a/lib/Common/Memory/RecyclerSweep.cpp
+++ b/lib/Common/Memory/RecyclerSweep.cpp
@@ -72,7 +72,9 @@ RecyclerSweep::BeginSweep(Recycler * recycler)
     finalizableWithBarrierData.pendingMergeNewHeapBlockList = recycler->autoHeap.newFinalizableWithBarrierHeapBlockList;
 #endif
     finalizableData.pendingMergeNewHeapBlockList = recycler->autoHeap.newFinalizableHeapBlockList;
+#ifdef RECYCLER_VISITED_HOST
     recyclerVisitedHostData.pendingMergeNewHeapBlockList = recycler->autoHeap.newRecyclerVisitedHostHeapBlockList;
+#endif
 
     mediumLeafData.pendingMergeNewHeapBlockList = recycler->autoHeap.newMediumLeafHeapBlockList;
     mediumNormalData.pendingMergeNewHeapBlockList = recycler->autoHeap.newMediumNormalHeapBlockList;
@@ -81,13 +83,17 @@ RecyclerSweep::BeginSweep(Recycler * recycler)
     mediumFinalizableWithBarrierData.pendingMergeNewHeapBlockList = recycler->autoHeap.newMediumFinalizableWithBarrierHeapBlockList;
 #endif
     mediumFinalizableData.pendingMergeNewHeapBlockList = recycler->autoHeap.newMediumFinalizableHeapBlockList;
+#ifdef RECYCLER_VISITED_HOST
     mediumRecyclerVisitedHostData.pendingMergeNewHeapBlockList = recycler->autoHeap.newMediumRecyclerVisitedHostHeapBlockList;
+#endif
 
 
     recycler->autoHeap.newLeafHeapBlockList = nullptr;
     recycler->autoHeap.newNormalHeapBlockList = nullptr;
     recycler->autoHeap.newFinalizableHeapBlockList = nullptr;
+#ifdef RECYCLER_VISITED_HOST
     recycler->autoHeap.newRecyclerVisitedHostHeapBlockList = nullptr;
+#endif
 #ifdef RECYCLER_WRITE_BARRIER
     recycler->autoHeap.newNormalWithBarrierHeapBlockList = nullptr;
     recycler->autoHeap.newFinalizableWithBarrierHeapBlockList = nullptr;
@@ -96,7 +102,9 @@ RecyclerSweep::BeginSweep(Recycler * recycler)
     recycler->autoHeap.newMediumLeafHeapBlockList = nullptr;
     recycler->autoHeap.newMediumNormalHeapBlockList = nullptr;
     recycler->autoHeap.newMediumFinalizableHeapBlockList = nullptr;
+#ifdef RECYCLER_VISITED_HOST
     recycler->autoHeap.newMediumRecyclerVisitedHostHeapBlockList = nullptr;
+#endif
 #ifdef RECYCLER_WRITE_BARRIER
     recycler->autoHeap.newMediumNormalWithBarrierHeapBlockList = nullptr;
     recycler->autoHeap.newMediumFinalizableWithBarrierHeapBlockList = nullptr;
@@ -405,7 +413,9 @@ RecyclerSweep::MergePendingNewHeapBlockList()
 template void RecyclerSweep::MergePendingNewHeapBlockList<SmallLeafHeapBlock>();
 template void RecyclerSweep::MergePendingNewHeapBlockList<SmallNormalHeapBlock>();
 template void RecyclerSweep::MergePendingNewHeapBlockList<SmallFinalizableHeapBlock>();
+#ifdef RECYCLER_VISITED_HOST
 template void RecyclerSweep::MergePendingNewHeapBlockList<SmallRecyclerVisitedHostHeapBlock>();
+#endif
 #ifdef RECYCLER_WRITE_BARRIER
 template void RecyclerSweep::MergePendingNewHeapBlockList<SmallNormalWithBarrierHeapBlock>();
 template void RecyclerSweep::MergePendingNewHeapBlockList<SmallFinalizableWithBarrierHeapBlock>();
@@ -429,7 +439,9 @@ RecyclerSweep::MergePendingNewMediumHeapBlockList()
 template void RecyclerSweep::MergePendingNewMediumHeapBlockList<MediumLeafHeapBlock>();
 template void RecyclerSweep::MergePendingNewMediumHeapBlockList<MediumNormalHeapBlock>();
 template void RecyclerSweep::MergePendingNewMediumHeapBlockList<MediumFinalizableHeapBlock>();
+#ifdef RECYCLER_VISITED_HOST
 template void RecyclerSweep::MergePendingNewMediumHeapBlockList<MediumRecyclerVisitedHostHeapBlock>();
+#endif
 #ifdef RECYCLER_WRITE_BARRIER
 template void RecyclerSweep::MergePendingNewMediumHeapBlockList<MediumNormalWithBarrierHeapBlock>();
 template void RecyclerSweep::MergePendingNewMediumHeapBlockList<MediumFinalizableWithBarrierHeapBlock>();
@@ -498,7 +510,10 @@ RecyclerSweep::SetPendingMergeNewHeapBlockCount()
     return HeapBlockList::Count(leafData.pendingMergeNewHeapBlockList)
         + HeapBlockList::Count(normalData.pendingMergeNewHeapBlockList)
         + HeapBlockList::Count(finalizableData.pendingMergeNewHeapBlockList)
+#ifdef RECYCLER_VISITED_HOST
         + HeapBlockList::Count(recyclerVisitedHostData.pendingMergeNewHeapBlockList)
+		+ HeapBlockList::Count(mediumRecyclerVisitedHostData.pendingMergeNewHeapBlockList)
+#endif
 #ifdef RECYCLER_WRITE_BARRIER
         + HeapBlockList::Count(withBarrierData.pendingMergeNewHeapBlockList)
         + HeapBlockList::Count(finalizableWithBarrierData.pendingMergeNewHeapBlockList)
@@ -506,7 +521,6 @@ RecyclerSweep::SetPendingMergeNewHeapBlockCount()
         + HeapBlockList::Count(mediumLeafData.pendingMergeNewHeapBlockList)
         + HeapBlockList::Count(mediumNormalData.pendingMergeNewHeapBlockList)
         + HeapBlockList::Count(mediumFinalizableData.pendingMergeNewHeapBlockList)
-        + HeapBlockList::Count(mediumRecyclerVisitedHostData.pendingMergeNewHeapBlockList)
 #ifdef RECYCLER_WRITE_BARRIER
         + HeapBlockList::Count(mediumWithBarrierData.pendingMergeNewHeapBlockList)
         + HeapBlockList::Count(mediumFinalizableWithBarrierData.pendingMergeNewHeapBlockList)

--- a/lib/Common/Memory/RecyclerSweep.h
+++ b/lib/Common/Memory/RecyclerSweep.h
@@ -122,7 +122,9 @@ private:
     template <> Data<SmallLeafHeapBlock>& GetData<SmallLeafHeapBlock>() { return leafData; }
     template <> Data<SmallNormalHeapBlock>& GetData<SmallNormalHeapBlock>() { return normalData; }
     template <> Data<SmallFinalizableHeapBlock>& GetData<SmallFinalizableHeapBlock>() { return finalizableData; }
+#ifdef RECYCLER_VISITED_HOST
     template <> Data<SmallRecyclerVisitedHostHeapBlock>& GetData<SmallRecyclerVisitedHostHeapBlock>() { return recyclerVisitedHostData; }
+#endif
 #ifdef RECYCLER_WRITE_BARRIER
     template <> Data<SmallNormalWithBarrierHeapBlock>& GetData<SmallNormalWithBarrierHeapBlock>() { return withBarrierData; }
     template <> Data<SmallFinalizableWithBarrierHeapBlock>& GetData<SmallFinalizableWithBarrierHeapBlock>() { return finalizableWithBarrierData; }
@@ -131,7 +133,9 @@ private:
     template <> Data<MediumLeafHeapBlock>& GetData<MediumLeafHeapBlock>() { return mediumLeafData; }
     template <> Data<MediumNormalHeapBlock>& GetData<MediumNormalHeapBlock>() { return mediumNormalData; }
     template <> Data<MediumFinalizableHeapBlock>& GetData<MediumFinalizableHeapBlock>() { return mediumFinalizableData; }
+#ifdef RECYCLER_VISITED_HOST
     template <> Data<MediumRecyclerVisitedHostHeapBlock>& GetData<MediumRecyclerVisitedHostHeapBlock>() { return mediumRecyclerVisitedHostData; }
+#endif
 #ifdef RECYCLER_WRITE_BARRIER
     template <> Data<MediumNormalWithBarrierHeapBlock>& GetData<MediumNormalWithBarrierHeapBlock>() { return mediumWithBarrierData; }
     template <> Data<MediumFinalizableWithBarrierHeapBlock>& GetData<MediumFinalizableWithBarrierHeapBlock>() { return mediumFinalizableWithBarrierData; }
@@ -144,7 +148,9 @@ private:
     Data<SmallLeafHeapBlock> leafData;
     Data<SmallNormalHeapBlock> normalData;
     Data<SmallFinalizableHeapBlock> finalizableData;
+#ifdef RECYCLER_VISITED_HOST
     Data<SmallRecyclerVisitedHostHeapBlock> recyclerVisitedHostData;
+#endif
 #ifdef RECYCLER_WRITE_BARRIER
     Data<SmallNormalWithBarrierHeapBlock> withBarrierData;
     Data<SmallFinalizableWithBarrierHeapBlock> finalizableWithBarrierData;
@@ -152,7 +158,9 @@ private:
     Data<MediumLeafHeapBlock> mediumLeafData;
     Data<MediumNormalHeapBlock> mediumNormalData;
     Data<MediumFinalizableHeapBlock> mediumFinalizableData;
+#ifdef RECYCLER_VISITED_HOST
     Data<MediumRecyclerVisitedHostHeapBlock> mediumRecyclerVisitedHostData;
+#endif
 #ifdef RECYCLER_WRITE_BARRIER
     Data<MediumNormalWithBarrierHeapBlock> mediumWithBarrierData;
     Data<MediumFinalizableWithBarrierHeapBlock> mediumFinalizableWithBarrierData;

--- a/lib/Common/Memory/RecyclerSweep.h
+++ b/lib/Common/Memory/RecyclerSweep.h
@@ -122,6 +122,7 @@ private:
     template <> Data<SmallLeafHeapBlock>& GetData<SmallLeafHeapBlock>() { return leafData; }
     template <> Data<SmallNormalHeapBlock>& GetData<SmallNormalHeapBlock>() { return normalData; }
     template <> Data<SmallFinalizableHeapBlock>& GetData<SmallFinalizableHeapBlock>() { return finalizableData; }
+    template <> Data<SmallRecyclerVisitedHostHeapBlock>& GetData<SmallRecyclerVisitedHostHeapBlock>() { return recyclerVisitedHostData; }
 #ifdef RECYCLER_WRITE_BARRIER
     template <> Data<SmallNormalWithBarrierHeapBlock>& GetData<SmallNormalWithBarrierHeapBlock>() { return withBarrierData; }
     template <> Data<SmallFinalizableWithBarrierHeapBlock>& GetData<SmallFinalizableWithBarrierHeapBlock>() { return finalizableWithBarrierData; }
@@ -130,6 +131,7 @@ private:
     template <> Data<MediumLeafHeapBlock>& GetData<MediumLeafHeapBlock>() { return mediumLeafData; }
     template <> Data<MediumNormalHeapBlock>& GetData<MediumNormalHeapBlock>() { return mediumNormalData; }
     template <> Data<MediumFinalizableHeapBlock>& GetData<MediumFinalizableHeapBlock>() { return mediumFinalizableData; }
+    template <> Data<MediumRecyclerVisitedHostHeapBlock>& GetData<MediumRecyclerVisitedHostHeapBlock>() { return mediumRecyclerVisitedHostData; }
 #ifdef RECYCLER_WRITE_BARRIER
     template <> Data<MediumNormalWithBarrierHeapBlock>& GetData<MediumNormalWithBarrierHeapBlock>() { return mediumWithBarrierData; }
     template <> Data<MediumFinalizableWithBarrierHeapBlock>& GetData<MediumFinalizableWithBarrierHeapBlock>() { return mediumFinalizableWithBarrierData; }
@@ -142,6 +144,7 @@ private:
     Data<SmallLeafHeapBlock> leafData;
     Data<SmallNormalHeapBlock> normalData;
     Data<SmallFinalizableHeapBlock> finalizableData;
+    Data<SmallRecyclerVisitedHostHeapBlock> recyclerVisitedHostData;
 #ifdef RECYCLER_WRITE_BARRIER
     Data<SmallNormalWithBarrierHeapBlock> withBarrierData;
     Data<SmallFinalizableWithBarrierHeapBlock> finalizableWithBarrierData;
@@ -149,6 +152,7 @@ private:
     Data<MediumLeafHeapBlock> mediumLeafData;
     Data<MediumNormalHeapBlock> mediumNormalData;
     Data<MediumFinalizableHeapBlock> mediumFinalizableData;
+    Data<MediumRecyclerVisitedHostHeapBlock> mediumRecyclerVisitedHostData;
 #ifdef RECYCLER_WRITE_BARRIER
     Data<MediumNormalWithBarrierHeapBlock> mediumWithBarrierData;
     Data<MediumFinalizableWithBarrierHeapBlock> mediumFinalizableWithBarrierData;

--- a/lib/Common/Memory/SmallBlockDeclarations.inl
+++ b/lib/Common/Memory/SmallBlockDeclarations.inl
@@ -18,7 +18,9 @@ template SweepState SmallHeapBlockT<TBlockTypeAttributes>::Sweep(RecyclerSweep& 
 template SmallNormalHeapBlockT<TBlockTypeAttributes>* HeapBlock::AsNormalBlock<TBlockTypeAttributes>();
 template SmallLeafHeapBlockT<TBlockTypeAttributes>* HeapBlock::AsLeafBlock<TBlockTypeAttributes>();
 template SmallFinalizableHeapBlockT<TBlockTypeAttributes>* HeapBlock::AsFinalizableBlock<TBlockTypeAttributes>();
+#ifdef RECYCLER_VISITED_HOST
 template SmallRecyclerVisitedHostHeapBlockT<TBlockTypeAttributes>* HeapBlock::AsRecyclerVisitedHostBlock<TBlockTypeAttributes>();
+#endif
 #ifdef RECYCLER_WRITE_BARRIER
 template SmallNormalWithBarrierHeapBlockT<TBlockTypeAttributes>* HeapBlock::AsNormalWriteBarrierBlock<TBlockTypeAttributes>();
 template SmallFinalizableWithBarrierHeapBlockT<TBlockTypeAttributes>* HeapBlock::AsFinalizableWriteBarrierBlock<TBlockTypeAttributes>();
@@ -27,7 +29,9 @@ template SmallFinalizableWithBarrierHeapBlockT<TBlockTypeAttributes>* HeapBlock:
 template bool SmallHeapBlockT<TBlockTypeAttributes>::FindHeapObjectImpl<SmallLeafHeapBlockT<TBlockTypeAttributes>>(void* objectAddress, Recycler * recycler, FindHeapObjectFlags flags, RecyclerHeapObjectInfo& heapObject);
 template bool SmallHeapBlockT<TBlockTypeAttributes>::FindHeapObjectImpl<SmallNormalHeapBlockT<TBlockTypeAttributes>>(void* objectAddress, Recycler * recycler, FindHeapObjectFlags flags, RecyclerHeapObjectInfo& heapObject);
 template bool SmallHeapBlockT<TBlockTypeAttributes>::FindHeapObjectImpl<SmallFinalizableHeapBlockT<TBlockTypeAttributes>>(void* objectAddress, Recycler * recycler, FindHeapObjectFlags flags, RecyclerHeapObjectInfo& heapObject);
+#ifdef RECYCLER_VISITED_HOST
 template bool SmallHeapBlockT<TBlockTypeAttributes>::FindHeapObjectImpl<SmallRecyclerVisitedHostHeapBlockT<TBlockTypeAttributes>>(void* objectAddress, Recycler * recycler, FindHeapObjectFlags flags, RecyclerHeapObjectInfo& heapObject);
+#endif
 #ifdef RECYCLER_WRITE_BARRIER
 template bool SmallHeapBlockT<TBlockTypeAttributes>::FindHeapObjectImpl<SmallNormalWithBarrierHeapBlockT<TBlockTypeAttributes>>(void* objectAddress, Recycler * recycler, FindHeapObjectFlags flags, RecyclerHeapObjectInfo& heapObject);
 template bool SmallHeapBlockT<TBlockTypeAttributes>::FindHeapObjectImpl<SmallFinalizableWithBarrierHeapBlockT<TBlockTypeAttributes>>(void* objectAddress, Recycler * recycler, FindHeapObjectFlags flags, RecyclerHeapObjectInfo& heapObject);
@@ -37,7 +41,9 @@ template bool SmallHeapBlockT<TBlockTypeAttributes>::FindHeapObjectImpl<SmallFin
 template bool SmallHeapBlockT<TBlockTypeAttributes>::GetFreeObjectListOnAllocatorImpl<SmallNormalHeapBlockT<TBlockTypeAttributes>>(FreeObject ** freeObjectList);
 template bool SmallHeapBlockT<TBlockTypeAttributes>::GetFreeObjectListOnAllocatorImpl<SmallLeafHeapBlockT<TBlockTypeAttributes>>(FreeObject ** freeObjectList);
 template bool SmallHeapBlockT<TBlockTypeAttributes>::GetFreeObjectListOnAllocatorImpl<SmallFinalizableHeapBlockT<TBlockTypeAttributes>>(FreeObject ** freeObjectList);
+#ifdef RECYCLER_VISITED_HOST
 template bool SmallHeapBlockT<TBlockTypeAttributes>::GetFreeObjectListOnAllocatorImpl<SmallRecyclerVisitedHostHeapBlockT<TBlockTypeAttributes>>(FreeObject ** freeObjectList);
+#endif
 #ifdef RECYCLER_WRITE_BARRIER
 template bool SmallHeapBlockT<TBlockTypeAttributes>::GetFreeObjectListOnAllocatorImpl<SmallNormalWithBarrierHeapBlockT<TBlockTypeAttributes>>(FreeObject ** freeObjectList);
 template bool SmallHeapBlockT<TBlockTypeAttributes>::GetFreeObjectListOnAllocatorImpl<SmallFinalizableWithBarrierHeapBlockT<TBlockTypeAttributes>>(FreeObject ** freeObjectList);

--- a/lib/Common/Memory/SmallBlockDeclarations.inl
+++ b/lib/Common/Memory/SmallBlockDeclarations.inl
@@ -18,6 +18,7 @@ template SweepState SmallHeapBlockT<TBlockTypeAttributes>::Sweep(RecyclerSweep& 
 template SmallNormalHeapBlockT<TBlockTypeAttributes>* HeapBlock::AsNormalBlock<TBlockTypeAttributes>();
 template SmallLeafHeapBlockT<TBlockTypeAttributes>* HeapBlock::AsLeafBlock<TBlockTypeAttributes>();
 template SmallFinalizableHeapBlockT<TBlockTypeAttributes>* HeapBlock::AsFinalizableBlock<TBlockTypeAttributes>();
+template SmallRecyclerVisitedHostHeapBlockT<TBlockTypeAttributes>* HeapBlock::AsRecyclerVisitedHostBlock<TBlockTypeAttributes>();
 #ifdef RECYCLER_WRITE_BARRIER
 template SmallNormalWithBarrierHeapBlockT<TBlockTypeAttributes>* HeapBlock::AsNormalWriteBarrierBlock<TBlockTypeAttributes>();
 template SmallFinalizableWithBarrierHeapBlockT<TBlockTypeAttributes>* HeapBlock::AsFinalizableWriteBarrierBlock<TBlockTypeAttributes>();
@@ -26,6 +27,7 @@ template SmallFinalizableWithBarrierHeapBlockT<TBlockTypeAttributes>* HeapBlock:
 template bool SmallHeapBlockT<TBlockTypeAttributes>::FindHeapObjectImpl<SmallLeafHeapBlockT<TBlockTypeAttributes>>(void* objectAddress, Recycler * recycler, FindHeapObjectFlags flags, RecyclerHeapObjectInfo& heapObject);
 template bool SmallHeapBlockT<TBlockTypeAttributes>::FindHeapObjectImpl<SmallNormalHeapBlockT<TBlockTypeAttributes>>(void* objectAddress, Recycler * recycler, FindHeapObjectFlags flags, RecyclerHeapObjectInfo& heapObject);
 template bool SmallHeapBlockT<TBlockTypeAttributes>::FindHeapObjectImpl<SmallFinalizableHeapBlockT<TBlockTypeAttributes>>(void* objectAddress, Recycler * recycler, FindHeapObjectFlags flags, RecyclerHeapObjectInfo& heapObject);
+template bool SmallHeapBlockT<TBlockTypeAttributes>::FindHeapObjectImpl<SmallRecyclerVisitedHostHeapBlockT<TBlockTypeAttributes>>(void* objectAddress, Recycler * recycler, FindHeapObjectFlags flags, RecyclerHeapObjectInfo& heapObject);
 #ifdef RECYCLER_WRITE_BARRIER
 template bool SmallHeapBlockT<TBlockTypeAttributes>::FindHeapObjectImpl<SmallNormalWithBarrierHeapBlockT<TBlockTypeAttributes>>(void* objectAddress, Recycler * recycler, FindHeapObjectFlags flags, RecyclerHeapObjectInfo& heapObject);
 template bool SmallHeapBlockT<TBlockTypeAttributes>::FindHeapObjectImpl<SmallFinalizableWithBarrierHeapBlockT<TBlockTypeAttributes>>(void* objectAddress, Recycler * recycler, FindHeapObjectFlags flags, RecyclerHeapObjectInfo& heapObject);
@@ -35,6 +37,7 @@ template bool SmallHeapBlockT<TBlockTypeAttributes>::FindHeapObjectImpl<SmallFin
 template bool SmallHeapBlockT<TBlockTypeAttributes>::GetFreeObjectListOnAllocatorImpl<SmallNormalHeapBlockT<TBlockTypeAttributes>>(FreeObject ** freeObjectList);
 template bool SmallHeapBlockT<TBlockTypeAttributes>::GetFreeObjectListOnAllocatorImpl<SmallLeafHeapBlockT<TBlockTypeAttributes>>(FreeObject ** freeObjectList);
 template bool SmallHeapBlockT<TBlockTypeAttributes>::GetFreeObjectListOnAllocatorImpl<SmallFinalizableHeapBlockT<TBlockTypeAttributes>>(FreeObject ** freeObjectList);
+template bool SmallHeapBlockT<TBlockTypeAttributes>::GetFreeObjectListOnAllocatorImpl<SmallRecyclerVisitedHostHeapBlockT<TBlockTypeAttributes>>(FreeObject ** freeObjectList);
 #ifdef RECYCLER_WRITE_BARRIER
 template bool SmallHeapBlockT<TBlockTypeAttributes>::GetFreeObjectListOnAllocatorImpl<SmallNormalWithBarrierHeapBlockT<TBlockTypeAttributes>>(FreeObject ** freeObjectList);
 template bool SmallHeapBlockT<TBlockTypeAttributes>::GetFreeObjectListOnAllocatorImpl<SmallFinalizableWithBarrierHeapBlockT<TBlockTypeAttributes>>(FreeObject ** freeObjectList);

--- a/lib/Common/Memory/SmallFinalizableHeapBlock.cpp
+++ b/lib/Common/Memory/SmallFinalizableHeapBlock.cpp
@@ -141,10 +141,6 @@ template <class TBlockAttributes>
 void
 SmallRecyclerVisitedHostHeapBlockT<TBlockAttributes>::SetAttributes(void * address, unsigned char attributes)
 {
-    // Currently we require all objects in the recycler visited heap block to either be traced (which
-    // is designated by TrackBit) or finalized, otherwise it's not actually visited.
-    Assert((attributes & (TrackBit | FinalizeBit)) != 0);
-
     // Don't call __super, since that has behavior we don't want (it asserts that FinalizeBit is set
     // but recycler visited block allows traced only objects; it also unconditionally bumps the heap info
     // live/new finalizable object counts which will become unbalance if FinalizeBit is not set).

--- a/lib/Common/Memory/SmallFinalizableHeapBlock.cpp
+++ b/lib/Common/Memory/SmallFinalizableHeapBlock.cpp
@@ -185,8 +185,9 @@ bool SmallRecyclerVisitedHostHeapBlockT<TBlockAttributes>::UpdateAttributesOfMar
 
     if (attributes & TrackBit)
     {
+        Assert((attributes & LeafBit) == 0);
         IRecyclerVisitedObject* recyclerVisited = static_cast<IRecyclerVisitedObject*>(objectAddress);
-        noOOMDuringMark = recyclerVisited->Trace(markContext);
+        noOOMDuringMark = markContext->AddPreciselyTracedObject(recyclerVisited);
 
         if (noOOMDuringMark)
         {
@@ -201,9 +202,6 @@ bool SmallRecyclerVisitedHostHeapBlockT<TBlockAttributes>::UpdateAttributesOfMar
         }
         fn(attributes);
     }
-
-    // We only expect 'leaf' objects in here (though they are potentially precisely traced)
-    Assert((attributes & LeafBit) == LeafBit);
 
 #ifdef RECYCLER_STATS
     RECYCLER_STATS_INTERLOCKED_INC(markContext->GetRecycler(), markData.markCount);

--- a/lib/Common/Memory/SmallFinalizableHeapBlock.cpp
+++ b/lib/Common/Memory/SmallFinalizableHeapBlock.cpp
@@ -155,7 +155,7 @@ SmallRecyclerVisitedHostHeapBlockT<TBlockAttributes>::SetAttributes(void * addre
     if (attributes & FinalizeBit)
     {
         finalizeCount++;
-        HeapInfo * heapInfo = this->HeapBucket->heapInfo;
+        HeapInfo * heapInfo = this->heapBucket->heapInfo;
         heapInfo->liveFinalizableObjectCount++;
         heapInfo->newFinalizableObjectCount++;
     }

--- a/lib/Common/Memory/SmallFinalizableHeapBlock.cpp
+++ b/lib/Common/Memory/SmallFinalizableHeapBlock.cpp
@@ -655,7 +655,7 @@ namespace Memory
     template void SmallFinalizableHeapBlockT<MediumAllocationBlockAttributes>::ProcessMarkedObject<true>(void* objectAddress, MarkContext * markContext);;
     template void SmallFinalizableHeapBlockT<MediumAllocationBlockAttributes>::ProcessMarkedObject<false>(void* objectAddress, MarkContext * markContext);;
 #ifdef RECYCLER_VISITED_HOST
-	template class SmallRecyclerVisitedHostHeapBlockT<SmallAllocationBlockAttributes>;
+    template class SmallRecyclerVisitedHostHeapBlockT<SmallAllocationBlockAttributes>;
     template void SmallRecyclerVisitedHostHeapBlockT<SmallAllocationBlockAttributes>::ProcessMarkedObject<true>(void* objectAddress, MarkContext * markContext);
     template void SmallRecyclerVisitedHostHeapBlockT<SmallAllocationBlockAttributes>::ProcessMarkedObject<false>(void* objectAddress, MarkContext * markContext);
     template class SmallRecyclerVisitedHostHeapBlockT<MediumAllocationBlockAttributes>;

--- a/lib/Common/Memory/SmallFinalizableHeapBlock.cpp
+++ b/lib/Common/Memory/SmallFinalizableHeapBlock.cpp
@@ -29,6 +29,7 @@ SmallFinalizableWithBarrierHeapBlockT<TBlockAttributes>::Delete(SmallFinalizable
 }
 #endif
 
+#ifdef RECYCLER_VISITED_HOST
 template <class TBlockAttributes>
 SmallRecyclerVisitedHostHeapBlockT<TBlockAttributes>*
 SmallRecyclerVisitedHostHeapBlockT<TBlockAttributes>::New(HeapBucketT<SmallRecyclerVisitedHostHeapBlockT<TBlockAttributes>> * bucket)
@@ -50,6 +51,7 @@ SmallRecyclerVisitedHostHeapBlockT<TBlockAttributes>::Delete(SmallRecyclerVisite
 
     NoMemProtectHeapDeletePlusPrefix(Base::GetAllocPlusSize(heapBlock->objectCount), heapBlock);
 }
+#endif
 
 template <class TBlockAttributes>
 SmallFinalizableHeapBlockT<TBlockAttributes> *
@@ -96,6 +98,7 @@ SmallFinalizableHeapBlockT<MediumAllocationBlockAttributes>::SmallFinalizableHea
     Assert(!this->isPendingDispose);
 }
 
+#ifdef RECYCLER_VISITED_HOST
 template <class TBlockAttributes>
 SmallFinalizableHeapBlockT<TBlockAttributes>::SmallFinalizableHeapBlockT(HeapBucketT<SmallRecyclerVisitedHostHeapBlockT<TBlockAttributes>> * bucket, ushort objectSize, ushort objectCount, HeapBlockType blockType)
     : SmallNormalHeapBlockT<TBlockAttributes>(bucket, objectSize, objectCount, blockType)
@@ -107,6 +110,7 @@ SmallFinalizableHeapBlockT<TBlockAttributes>::SmallFinalizableHeapBlockT(HeapBuc
     Assert(this->disposedObjectListTail == nullptr);
     Assert(!this->isPendingDispose);
 }
+#endif
 
 #ifdef RECYCLER_WRITE_BARRIER
 template <class TBlockAttributes>
@@ -137,6 +141,7 @@ SmallFinalizableHeapBlockT<TBlockAttributes>::SetAttributes(void * address, unsi
 #endif
 }
 
+#ifdef RECYCLER_VISITED_HOST
 template <class TBlockAttributes>
 void
 SmallRecyclerVisitedHostHeapBlockT<TBlockAttributes>::SetAttributes(void * address, unsigned char attributes)
@@ -274,6 +279,7 @@ SmallRecyclerVisitedHostHeapBlockT<TBlockAttributes>::RescanObject(SmallRecycler
 
     return true;
 }
+#endif
 
 template <class TBlockAttributes>
 bool
@@ -648,12 +654,14 @@ namespace Memory
     template class SmallFinalizableHeapBlockT<MediumAllocationBlockAttributes>;
     template void SmallFinalizableHeapBlockT<MediumAllocationBlockAttributes>::ProcessMarkedObject<true>(void* objectAddress, MarkContext * markContext);;
     template void SmallFinalizableHeapBlockT<MediumAllocationBlockAttributes>::ProcessMarkedObject<false>(void* objectAddress, MarkContext * markContext);;
-    template class SmallRecyclerVisitedHostHeapBlockT<SmallAllocationBlockAttributes>;
+#ifdef RECYCLER_VISITED_HOST
+	template class SmallRecyclerVisitedHostHeapBlockT<SmallAllocationBlockAttributes>;
     template void SmallRecyclerVisitedHostHeapBlockT<SmallAllocationBlockAttributes>::ProcessMarkedObject<true>(void* objectAddress, MarkContext * markContext);
     template void SmallRecyclerVisitedHostHeapBlockT<SmallAllocationBlockAttributes>::ProcessMarkedObject<false>(void* objectAddress, MarkContext * markContext);
     template class SmallRecyclerVisitedHostHeapBlockT<MediumAllocationBlockAttributes>;
     template void SmallRecyclerVisitedHostHeapBlockT<MediumAllocationBlockAttributes>::ProcessMarkedObject<true>(void* objectAddress, MarkContext * markContext);;
     template void SmallRecyclerVisitedHostHeapBlockT<MediumAllocationBlockAttributes>::ProcessMarkedObject<false>(void* objectAddress, MarkContext * markContext);;
+#endif
 
 #ifdef RECYCLER_WRITE_BARRIER
     template class SmallFinalizableWithBarrierHeapBlockT<SmallAllocationBlockAttributes>;

--- a/lib/Common/Memory/SmallFinalizableHeapBlock.h
+++ b/lib/Common/Memory/SmallFinalizableHeapBlock.h
@@ -152,7 +152,12 @@ public:
 
     void SetAttributes(void * address, unsigned char attributes);
 
-    // EdgeGC-TODO: Specialize ProcessMarkedObject for this heap block type to call new Mark/Trace method.
+    template <bool doSpecialMark>
+    void ProcessMarkedObject(void* candidate, MarkContext * markContext);
+
+    template <bool doSpecialMark, typename Fn>
+    bool UpdateAttributesOfMarkedObjects(MarkContext * markContext, void * objectAddress, size_t objectSize, unsigned char attributes, Fn fn);
+    
 
     SmallRecyclerVisitedHostHeapBlockT * GetNextBlock() const
     {

--- a/lib/Common/Memory/SmallFinalizableHeapBlock.h
+++ b/lib/Common/Memory/SmallFinalizableHeapBlock.h
@@ -144,7 +144,7 @@ class SmallRecyclerVisitedHostHeapBlockT : public SmallFinalizableHeapBlockT<TBl
 public:
     typedef TBlockAttributes HeapBlockAttributes;
 
-    static const ObjectInfoBits RequiredAttributes = (ObjectInfoBits)(RecyclerVisitedHostBit | LeafBit);
+    static const ObjectInfoBits RequiredAttributes = RecyclerVisitedHostBit;
     static const bool IsLeafOnly = true;
 
     static SmallRecyclerVisitedHostHeapBlockT * New(HeapBucketT<SmallRecyclerVisitedHostHeapBlockT> * bucket);

--- a/lib/Common/Memory/SmallFinalizableHeapBlock.h
+++ b/lib/Common/Memory/SmallFinalizableHeapBlock.h
@@ -5,7 +5,9 @@
 namespace Memory
 {
 template <class TBlockAttributes> class SmallFinalizableHeapBucketT;
+#ifdef RECYCLER_VISITED_HOST
 template <class TBlockAttributes> class SmallRecyclerVisitedHostHeapBlockT;
+#endif
 #ifdef RECYCLER_WRITE_BARRIER
 template <class TBlockAttributes> class SmallFinalizableWithBarrierHeapBlockT;
 #endif
@@ -116,7 +118,9 @@ public:
     }
 protected:
     SmallFinalizableHeapBlockT(HeapBucketT<SmallFinalizableHeapBlockT>  * bucket, ushort objectSize, ushort objectCount);
+#ifdef RECYCLER_VISITED_HOST
     SmallFinalizableHeapBlockT(HeapBucketT<SmallRecyclerVisitedHostHeapBlockT<TBlockAttributes>> * bucket, ushort objectSize, ushort objectCount, HeapBlockType blockType);
+#endif
 #ifdef RECYCLER_WRITE_BARRIER
     SmallFinalizableHeapBlockT(HeapBucketT<SmallFinalizableWithBarrierHeapBlockT<TBlockAttributes>> * bucket, ushort objectSize, ushort objectCount, HeapBlockType blockType);
 #endif
@@ -136,6 +140,7 @@ protected:
 #endif
 };
 
+#ifdef RECYCLER_VISITED_HOST
 template <class TBlockAttributes>
 class SmallRecyclerVisitedHostHeapBlockT : public SmallFinalizableHeapBlockT<TBlockAttributes>
 {
@@ -176,6 +181,7 @@ protected:
     {
     }
 };
+#endif
 
 #ifdef RECYCLER_WRITE_BARRIER
 template <class TBlockAttributes>
@@ -213,8 +219,10 @@ protected:
 typedef SmallFinalizableHeapBlockT<SmallAllocationBlockAttributes>  SmallFinalizableHeapBlock;
 typedef SmallFinalizableHeapBlockT<MediumAllocationBlockAttributes>    MediumFinalizableHeapBlock;
 
+#ifdef RECYCLER_VISITED_HOST
 typedef SmallRecyclerVisitedHostHeapBlockT<SmallAllocationBlockAttributes> SmallRecyclerVisitedHostHeapBlock;
 typedef SmallRecyclerVisitedHostHeapBlockT<MediumAllocationBlockAttributes> MediumRecyclerVisitedHostHeapBlock;
+#endif
 
 #ifdef RECYCLER_WRITE_BARRIER
 typedef SmallFinalizableWithBarrierHeapBlockT<SmallAllocationBlockAttributes>   SmallFinalizableWithBarrierHeapBlock;

--- a/lib/Common/Memory/SmallFinalizableHeapBlock.h
+++ b/lib/Common/Memory/SmallFinalizableHeapBlock.h
@@ -150,7 +150,6 @@ public:
     typedef TBlockAttributes HeapBlockAttributes;
 
     static const ObjectInfoBits RequiredAttributes = RecyclerVisitedHostBit;
-    static const bool IsLeafOnly = true;
 
     static SmallRecyclerVisitedHostHeapBlockT * New(HeapBucketT<SmallRecyclerVisitedHostHeapBlockT> * bucket);
     static void Delete(SmallRecyclerVisitedHostHeapBlockT * block);
@@ -193,7 +192,6 @@ public:
     typedef TBlockAttributes HeapBlockAttributes;
 
     static const ObjectInfoBits RequiredAttributes = FinalizableWithBarrierBit;
-    static const bool IsLeafOnly = false;
 
     static SmallFinalizableWithBarrierHeapBlockT * New(HeapBucketT<SmallFinalizableWithBarrierHeapBlockT> * bucket);
     static void Delete(SmallFinalizableWithBarrierHeapBlockT * block);

--- a/lib/Common/Memory/SmallFinalizableHeapBlock.h
+++ b/lib/Common/Memory/SmallFinalizableHeapBlock.h
@@ -157,7 +157,8 @@ public:
 
     template <bool doSpecialMark, typename Fn>
     bool UpdateAttributesOfMarkedObjects(MarkContext * markContext, void * objectAddress, size_t objectSize, unsigned char attributes, Fn fn);
-    
+
+    static bool RescanObject(SmallRecyclerVisitedHostHeapBlockT<TBlockAttributes> * block, __in_ecount(localObjectSize) char * objectAddress, uint localObjectSize, uint objectIndex, Recycler * recycler);
 
     SmallRecyclerVisitedHostHeapBlockT * GetNextBlock() const
     {

--- a/lib/Common/Memory/SmallFinalizableHeapBucket.cpp
+++ b/lib/Common/Memory/SmallFinalizableHeapBucket.cpp
@@ -239,13 +239,15 @@ SmallFinalizableHeapBucketBaseT<TBlockType>::VerifyMark()
 namespace Memory
 {
     template class SmallFinalizableHeapBucketBaseT<SmallFinalizableHeapBlock>;
+#ifdef RECYCLER_VISITED_HOST
     template class SmallFinalizableHeapBucketBaseT<SmallRecyclerVisitedHostHeapBlock>;
+	template class SmallFinalizableHeapBucketBaseT<MediumRecyclerVisitedHostHeapBlock>;
+#endif
 #ifdef RECYCLER_WRITE_BARRIER
     template class SmallFinalizableHeapBucketBaseT<SmallFinalizableWithBarrierHeapBlock>;
 #endif
 
     template class SmallFinalizableHeapBucketBaseT<MediumFinalizableHeapBlock>;
-    template class SmallFinalizableHeapBucketBaseT<MediumRecyclerVisitedHostHeapBlock>;
 #ifdef RECYCLER_WRITE_BARRIER
     template class SmallFinalizableHeapBucketBaseT<MediumFinalizableWithBarrierHeapBlock>;
 #endif

--- a/lib/Common/Memory/SmallFinalizableHeapBucket.cpp
+++ b/lib/Common/Memory/SmallFinalizableHeapBucket.cpp
@@ -239,11 +239,13 @@ SmallFinalizableHeapBucketBaseT<TBlockType>::VerifyMark()
 namespace Memory
 {
     template class SmallFinalizableHeapBucketBaseT<SmallFinalizableHeapBlock>;
+    template class SmallFinalizableHeapBucketBaseT<SmallRecyclerVisitedHostHeapBlock>;
 #ifdef RECYCLER_WRITE_BARRIER
     template class SmallFinalizableHeapBucketBaseT<SmallFinalizableWithBarrierHeapBlock>;
 #endif
 
     template class SmallFinalizableHeapBucketBaseT<MediumFinalizableHeapBlock>;
+    template class SmallFinalizableHeapBucketBaseT<MediumRecyclerVisitedHostHeapBlock>;
 #ifdef RECYCLER_WRITE_BARRIER
     template class SmallFinalizableHeapBucketBaseT<MediumFinalizableWithBarrierHeapBlock>;
 #endif

--- a/lib/Common/Memory/SmallFinalizableHeapBucket.cpp
+++ b/lib/Common/Memory/SmallFinalizableHeapBucket.cpp
@@ -241,7 +241,7 @@ namespace Memory
     template class SmallFinalizableHeapBucketBaseT<SmallFinalizableHeapBlock>;
 #ifdef RECYCLER_VISITED_HOST
     template class SmallFinalizableHeapBucketBaseT<SmallRecyclerVisitedHostHeapBlock>;
-	template class SmallFinalizableHeapBucketBaseT<MediumRecyclerVisitedHostHeapBlock>;
+    template class SmallFinalizableHeapBucketBaseT<MediumRecyclerVisitedHostHeapBlock>;
 #endif
 #ifdef RECYCLER_WRITE_BARRIER
     template class SmallFinalizableHeapBucketBaseT<SmallFinalizableWithBarrierHeapBlock>;

--- a/lib/Common/Memory/SmallFinalizableHeapBucket.h
+++ b/lib/Common/Memory/SmallFinalizableHeapBucket.h
@@ -110,14 +110,6 @@ public:
 };
 
 template <>
-class SmallHeapBlockType<(ObjectInfoBits)(RecyclerVisitedHostLeafBlockTypeBits), SmallAllocationBlockAttributes>
-{
-public:
-    typedef SmallRecyclerVisitedHostHeapBlock BlockType;
-    typedef SmallRecyclerVisitedHostHeapBucket BucketType;
-};
-
-template <>
 class SmallHeapBlockType<(ObjectInfoBits)(RecyclerVisitedHostFinalizableBlockTypeBits), SmallAllocationBlockAttributes>
 {
 public:
@@ -186,14 +178,6 @@ public:
 
 template <>
 class SmallHeapBlockType<(ObjectInfoBits)(RecyclerVisitedHostTracedFinalizableBlockTypeBits), MediumAllocationBlockAttributes>
-{
-public:
-    typedef MediumRecyclerVisitedHostHeapBlock BlockType;
-    typedef MediumRecyclerVisitedHostHeapBucket BucketType;
-};
-
-template <>
-class SmallHeapBlockType<(ObjectInfoBits)(RecyclerVisitedHostLeafBlockTypeBits), MediumAllocationBlockAttributes>
 {
 public:
     typedef MediumRecyclerVisitedHostHeapBlock BlockType;
@@ -316,17 +300,6 @@ class HeapBucketGroup
     {
     public:
         typedef typename SmallHeapBlockType<(ObjectInfoBits)(RecyclerVisitedHostTracedFinalizableBlockTypeBits), TBlockAttributes>::BucketType BucketType;
-        static BucketType& GetBucket(HeapBucketGroup<TBlockAttributes> * HeapBucketGroup)
-        {
-            return HeapBucketGroup->recyclerVisitedHostHeapBucket;
-        }
-    };
-
-    template <>
-    class BucketGetter<(ObjectInfoBits)(RecyclerVisitedHostLeafBlockTypeBits)>
-    {
-    public:
-        typedef typename SmallHeapBlockType<(ObjectInfoBits)(RecyclerVisitedHostLeafBlockTypeBits), TBlockAttributes>::BucketType BucketType;
         static BucketType& GetBucket(HeapBucketGroup<TBlockAttributes> * HeapBucketGroup)
         {
             return HeapBucketGroup->recyclerVisitedHostHeapBucket;

--- a/lib/Common/Memory/SmallFinalizableHeapBucket.h
+++ b/lib/Common/Memory/SmallFinalizableHeapBucket.h
@@ -92,10 +92,10 @@ class SmallHeapBlockType
 {
 public:
    
-	CompileAssert((attributes & FinalizeBit) != 0);
+    CompileAssert((attributes & FinalizeBit) != 0);
 #ifdef RECYCLER_VISITED_HOST
-	// attributes with RecyclerVisitedHostBit must use SmallRecyclerVisitedHostHeap{Bucket|Block}T
-	CompileAssert((attributes & RecyclerVisitedHostBit) == 0);
+    // attributes with RecyclerVisitedHostBit must use SmallRecyclerVisitedHostHeap{Bucket|Block}T
+    CompileAssert((attributes & RecyclerVisitedHostBit) == 0);
 #endif
     typedef SmallFinalizableHeapBlockT<TBlockAttributes> BlockType;
     typedef SmallFinalizableHeapBucketT<TBlockAttributes> BucketType;

--- a/lib/Common/Memory/SmallFinalizableHeapBucket.h
+++ b/lib/Common/Memory/SmallFinalizableHeapBucket.h
@@ -94,7 +94,23 @@ public:
 };
 
 template <>
-class SmallHeapBlockType<(ObjectInfoBits)(RecyclerVisitedHostBlockTypeBits), SmallAllocationBlockAttributes>
+class SmallHeapBlockType<(ObjectInfoBits)(RecyclerVisitedHostBit), SmallAllocationBlockAttributes>
+{
+public:
+    typedef SmallRecyclerVisitedHostHeapBlock BlockType;
+    typedef SmallRecyclerVisitedHostHeapBucket BucketType;
+};
+
+template <>
+class SmallHeapBlockType<(ObjectInfoBits)(RecyclerVisitedHostTracedFinalizableBlockTypeBits), SmallAllocationBlockAttributes>
+{
+public:
+    typedef SmallRecyclerVisitedHostHeapBlock BlockType;
+    typedef SmallRecyclerVisitedHostHeapBucket BucketType;
+};
+
+template <>
+class SmallHeapBlockType<(ObjectInfoBits)(RecyclerVisitedHostLeafBlockTypeBits), SmallAllocationBlockAttributes>
 {
 public:
     typedef SmallRecyclerVisitedHostHeapBlock BlockType;
@@ -161,7 +177,23 @@ public:
 };
 
 template <>
-class SmallHeapBlockType<(ObjectInfoBits)(RecyclerVisitedHostBlockTypeBits), MediumAllocationBlockAttributes>
+class SmallHeapBlockType<(ObjectInfoBits)(RecyclerVisitedHostBit), MediumAllocationBlockAttributes>
+{
+public:
+    typedef MediumRecyclerVisitedHostHeapBlock BlockType;
+    typedef MediumRecyclerVisitedHostHeapBucket BucketType;
+};
+
+template <>
+class SmallHeapBlockType<(ObjectInfoBits)(RecyclerVisitedHostTracedFinalizableBlockTypeBits), MediumAllocationBlockAttributes>
+{
+public:
+    typedef MediumRecyclerVisitedHostHeapBlock BlockType;
+    typedef MediumRecyclerVisitedHostHeapBucket BucketType;
+};
+
+template <>
+class SmallHeapBlockType<(ObjectInfoBits)(RecyclerVisitedHostLeafBlockTypeBits), MediumAllocationBlockAttributes>
 {
 public:
     typedef MediumRecyclerVisitedHostHeapBlock BlockType;
@@ -269,10 +301,32 @@ class HeapBucketGroup
     };
 
     template <>
-    class BucketGetter<(ObjectInfoBits)(RecyclerVisitedHostBlockTypeBits)>
+    class BucketGetter<(ObjectInfoBits)(RecyclerVisitedHostBit)>
     {
     public:
-        typedef typename SmallHeapBlockType<(ObjectInfoBits)(RecyclerVisitedHostBlockTypeBits), TBlockAttributes>::BucketType BucketType;
+        typedef typename SmallHeapBlockType<(ObjectInfoBits)(RecyclerVisitedHostBit), TBlockAttributes>::BucketType BucketType;
+        static BucketType& GetBucket(HeapBucketGroup<TBlockAttributes> * HeapBucketGroup)
+        {
+            return HeapBucketGroup->recyclerVisitedHostHeapBucket;
+        }
+    };
+
+    template <>
+    class BucketGetter<(ObjectInfoBits)(RecyclerVisitedHostTracedFinalizableBlockTypeBits)>
+    {
+    public:
+        typedef typename SmallHeapBlockType<(ObjectInfoBits)(RecyclerVisitedHostTracedFinalizableBlockTypeBits), TBlockAttributes>::BucketType BucketType;
+        static BucketType& GetBucket(HeapBucketGroup<TBlockAttributes> * HeapBucketGroup)
+        {
+            return HeapBucketGroup->recyclerVisitedHostHeapBucket;
+        }
+    };
+
+    template <>
+    class BucketGetter<(ObjectInfoBits)(RecyclerVisitedHostLeafBlockTypeBits)>
+    {
+    public:
+        typedef typename SmallHeapBlockType<(ObjectInfoBits)(RecyclerVisitedHostLeafBlockTypeBits), TBlockAttributes>::BucketType BucketType;
         static BucketType& GetBucket(HeapBucketGroup<TBlockAttributes> * HeapBucketGroup)
         {
             return HeapBucketGroup->recyclerVisitedHostHeapBucket;

--- a/lib/Common/Memory/SmallFinalizableHeapBucket.h
+++ b/lib/Common/Memory/SmallFinalizableHeapBucket.h
@@ -61,10 +61,12 @@ template <class TBlockAttributes>
 class SmallFinalizableHeapBucketT : public SmallFinalizableHeapBucketBaseT<SmallFinalizableHeapBlockT<TBlockAttributes> >
 {
 };
+#ifdef RECYCLER_VISITED_HOST
 template <class TBlockAttributes> 
 class SmallRecyclerVisitedHostHeapBucketT : public SmallFinalizableHeapBucketBaseT<SmallRecyclerVisitedHostHeapBlockT<TBlockAttributes> >
 {
 };
+#endif
 #ifdef RECYCLER_WRITE_BARRIER
 template <class TBlockAttributes> 
 class SmallFinalizableWithBarrierHeapBucketT : public SmallFinalizableHeapBucketBaseT<SmallFinalizableWithBarrierHeapBlockT<TBlockAttributes> >
@@ -74,8 +76,10 @@ class SmallFinalizableWithBarrierHeapBucketT : public SmallFinalizableHeapBucket
 
 typedef SmallFinalizableHeapBucketT<MediumAllocationBlockAttributes> MediumFinalizableHeapBucket;
 typedef SmallFinalizableHeapBucketT<SmallAllocationBlockAttributes> SmallFinalizableHeapBucket;
+#ifdef RECYCLER_VISITED_HOST
 typedef SmallRecyclerVisitedHostHeapBucketT<MediumAllocationBlockAttributes> MediumRecyclerVisitedHostHeapBucket;
 typedef SmallRecyclerVisitedHostHeapBucketT<SmallAllocationBlockAttributes> SmallRecyclerVisitedHostHeapBucket;
+#endif
 #ifdef RECYCLER_WRITE_BARRIER
 typedef SmallFinalizableWithBarrierHeapBucketT<MediumAllocationBlockAttributes> MediumFinalizableWithBarrierHeapBucket;
 typedef SmallFinalizableWithBarrierHeapBucketT<SmallAllocationBlockAttributes> SmallFinalizableWithBarrierHeapBucket;
@@ -87,12 +91,17 @@ template <ObjectInfoBits attributes, class TBlockAttributes>
 class SmallHeapBlockType
 {
 public:
-    // attributes with RecyclerVisitedHostBit must use SmallRecyclerVisitedHostHeap{Bucket|Block}T
-    CompileAssert((attributes & FinalizeBit) != 0 && (attributes & RecyclerVisitedHostBit) == 0);
+   
+	CompileAssert((attributes & FinalizeBit) != 0);
+#ifdef RECYCLER_VISITED_HOST
+	// attributes with RecyclerVisitedHostBit must use SmallRecyclerVisitedHostHeap{Bucket|Block}T
+	CompileAssert((attributes & RecyclerVisitedHostBit) == 0);
+#endif
     typedef SmallFinalizableHeapBlockT<TBlockAttributes> BlockType;
     typedef SmallFinalizableHeapBucketT<TBlockAttributes> BucketType;
 };
 
+#ifdef RECYCLER_VISITED_HOST
 template <>
 class SmallHeapBlockType<(ObjectInfoBits)(RecyclerVisitedHostBit), SmallAllocationBlockAttributes>
 {
@@ -116,6 +125,7 @@ public:
     typedef SmallRecyclerVisitedHostHeapBlock BlockType;
     typedef SmallRecyclerVisitedHostHeapBucket BucketType;
 };
+#endif
 
 template <>
 class SmallHeapBlockType<LeafBit, SmallAllocationBlockAttributes>
@@ -168,6 +178,7 @@ public:
     typedef MediumFinalizableHeapBucket BucketType;
 };
 
+#ifdef RECYCLER_VISITED_HOST
 template <>
 class SmallHeapBlockType<(ObjectInfoBits)(RecyclerVisitedHostBit), MediumAllocationBlockAttributes>
 {
@@ -191,6 +202,7 @@ public:
     typedef MediumRecyclerVisitedHostHeapBlock BlockType;
     typedef MediumRecyclerVisitedHostHeapBucket BucketType;
 };
+#endif
 
 template <>
 class SmallHeapBlockType<LeafBit, MediumAllocationBlockAttributes>
@@ -284,6 +296,7 @@ class HeapBucketGroup
         }
     };
 
+#ifdef RECYCLER_VISITED_HOST
     template <>
     class BucketGetter<(ObjectInfoBits)(RecyclerVisitedHostBit)>
     {
@@ -316,6 +329,7 @@ class HeapBucketGroup
             return HeapBucketGroup->recyclerVisitedHostHeapBucket;
         }
     };
+#endif
 
 #ifdef RECYCLER_WRITE_BARRIER
     template <>
@@ -411,7 +425,9 @@ private:
     SmallNormalHeapBucketT<TBlockAttributes>       heapBucket;
     SmallLeafHeapBucketT<TBlockAttributes>         leafHeapBucket;
     SmallFinalizableHeapBucketT<TBlockAttributes>  finalizableHeapBucket;
+#ifdef RECYCLER_VISITED_HOST
     SmallRecyclerVisitedHostHeapBucketT<TBlockAttributes>  recyclerVisitedHostHeapBucket;
+#endif
 #ifdef RECYCLER_WRITE_BARRIER
     SmallNormalWithBarrierHeapBucketT<TBlockAttributes> smallNormalWithBarrierHeapBucket;
     SmallFinalizableWithBarrierHeapBucketT<TBlockAttributes> smallFinalizableWithBarrierHeapBucket;

--- a/lib/Common/Memory/SmallFinalizableHeapBucket.h
+++ b/lib/Common/Memory/SmallFinalizableHeapBucket.h
@@ -94,7 +94,7 @@ public:
 };
 
 template <>
-class SmallHeapBlockType<(ObjectInfoBits)(RecyclerVisitedHost_BlockTypeBits), SmallAllocationBlockAttributes>
+class SmallHeapBlockType<(ObjectInfoBits)(RecyclerVisitedHostBlockTypeBits), SmallAllocationBlockAttributes>
 {
 public:
     typedef SmallRecyclerVisitedHostHeapBlock BlockType;
@@ -102,7 +102,7 @@ public:
 };
 
 template <>
-class SmallHeapBlockType<(ObjectInfoBits)(RecyclerVisitedHost_FinalizableBlockTypeBits), SmallAllocationBlockAttributes>
+class SmallHeapBlockType<(ObjectInfoBits)(RecyclerVisitedHostFinalizableBlockTypeBits), SmallAllocationBlockAttributes>
 {
 public:
     typedef SmallRecyclerVisitedHostHeapBlock BlockType;
@@ -161,7 +161,7 @@ public:
 };
 
 template <>
-class SmallHeapBlockType<(ObjectInfoBits)(RecyclerVisitedHost_BlockTypeBits), MediumAllocationBlockAttributes>
+class SmallHeapBlockType<(ObjectInfoBits)(RecyclerVisitedHostBlockTypeBits), MediumAllocationBlockAttributes>
 {
 public:
     typedef MediumRecyclerVisitedHostHeapBlock BlockType;
@@ -169,7 +169,7 @@ public:
 };
 
 template <>
-class SmallHeapBlockType<(ObjectInfoBits)(RecyclerVisitedHost_FinalizableBlockTypeBits), MediumAllocationBlockAttributes>
+class SmallHeapBlockType<(ObjectInfoBits)(RecyclerVisitedHostFinalizableBlockTypeBits), MediumAllocationBlockAttributes>
 {
 public:
     typedef MediumRecyclerVisitedHostHeapBlock BlockType;
@@ -269,10 +269,10 @@ class HeapBucketGroup
     };
 
     template <>
-    class BucketGetter<(ObjectInfoBits)(RecyclerVisitedHost_BlockTypeBits)>
+    class BucketGetter<(ObjectInfoBits)(RecyclerVisitedHostBlockTypeBits)>
     {
     public:
-        typedef typename SmallHeapBlockType<(ObjectInfoBits)(RecyclerVisitedHost_BlockTypeBits), TBlockAttributes>::BucketType BucketType;
+        typedef typename SmallHeapBlockType<(ObjectInfoBits)(RecyclerVisitedHostBlockTypeBits), TBlockAttributes>::BucketType BucketType;
         static BucketType& GetBucket(HeapBucketGroup<TBlockAttributes> * HeapBucketGroup)
         {
             return HeapBucketGroup->recyclerVisitedHostHeapBucket;
@@ -280,10 +280,10 @@ class HeapBucketGroup
     };
 
     template <>
-    class BucketGetter<(ObjectInfoBits)(RecyclerVisitedHost_FinalizableBlockTypeBits)>
+    class BucketGetter<(ObjectInfoBits)(RecyclerVisitedHostFinalizableBlockTypeBits)>
     {
     public:
-        typedef typename SmallHeapBlockType<(ObjectInfoBits)(RecyclerVisitedHost_FinalizableBlockTypeBits), TBlockAttributes>::BucketType BucketType;
+        typedef typename SmallHeapBlockType<(ObjectInfoBits)(RecyclerVisitedHostFinalizableBlockTypeBits), TBlockAttributes>::BucketType BucketType;
         static BucketType& GetBucket(HeapBucketGroup<TBlockAttributes> * HeapBucketGroup)
         {
             return HeapBucketGroup->recyclerVisitedHostHeapBucket;

--- a/lib/Common/Memory/SmallNormalHeapBlock.h
+++ b/lib/Common/Memory/SmallNormalHeapBlock.h
@@ -18,7 +18,6 @@ public:
     typedef typename Base::SmallHeapBlockBitVector SmallHeapBlockBitVector;
     typedef TBlockAttributes HeapBlockAttributes;
     static const ObjectInfoBits RequiredAttributes = NoBit;
-    static const bool IsLeafOnly = false;
 
     static SmallNormalHeapBlockT * New(HeapBucketT<SmallNormalHeapBlockT> * bucket);
     static void Delete(SmallNormalHeapBlockT * block);
@@ -67,7 +66,6 @@ class SmallNormalWithBarrierHeapBlockT : public SmallNormalHeapBlockT<TBlockAttr
 public:
     typedef TBlockAttributes HeapBlockAttributes;
     static const ObjectInfoBits RequiredAttributes = WithBarrierBit;
-    static const bool IsLeafOnly = false;
 
     static SmallNormalWithBarrierHeapBlockT * New(HeapBucketT<SmallNormalWithBarrierHeapBlockT> * bucket);
     static void Delete(SmallNormalWithBarrierHeapBlockT * heapBlock);

--- a/lib/Common/Memory/SmallNormalHeapBucket.cpp
+++ b/lib/Common/Memory/SmallNormalHeapBucket.cpp
@@ -683,8 +683,10 @@ namespace Memory
     template class SmallNormalHeapBucketBase<SmallFinalizableHeapBlock>;
     template class SmallNormalHeapBucketBase<MediumFinalizableHeapBlock>;
 
+#ifdef RECYCLER_VISITED_HOST
     template class SmallNormalHeapBucketBase<SmallRecyclerVisitedHostHeapBlock>;
     template class SmallNormalHeapBucketBase<MediumRecyclerVisitedHostHeapBlock>;
+#endif
 
 #ifdef RECYCLER_WRITE_BARRIER
     template class SmallNormalHeapBucketBase<SmallFinalizableWithBarrierHeapBlock>;

--- a/lib/Common/Memory/SmallNormalHeapBucket.cpp
+++ b/lib/Common/Memory/SmallNormalHeapBucket.cpp
@@ -683,6 +683,9 @@ namespace Memory
     template class SmallNormalHeapBucketBase<SmallFinalizableHeapBlock>;
     template class SmallNormalHeapBucketBase<MediumFinalizableHeapBlock>;
 
+    template class SmallNormalHeapBucketBase<SmallRecyclerVisitedHostHeapBlock>;
+    template class SmallNormalHeapBucketBase<MediumRecyclerVisitedHostHeapBlock>;
+
 #ifdef RECYCLER_WRITE_BARRIER
     template class SmallNormalHeapBucketBase<SmallFinalizableWithBarrierHeapBlock>;
     template class SmallNormalHeapBucketBase<MediumFinalizableWithBarrierHeapBlock>;

--- a/lib/Parser/RegexParser.cpp
+++ b/lib/Parser/RegexParser.cpp
@@ -769,7 +769,6 @@ namespace UnifiedRegex
                         last->head = revisedPrev;
                     nextList = nextList->tail;
                 }
-                AnalysisAssert(nextList != nullptr);
                 if (last == 0)
                     node = Anew(ctAllocator, AltNode, node, nextList);
                 else

--- a/lib/Parser/RegexParser.cpp
+++ b/lib/Parser/RegexParser.cpp
@@ -773,6 +773,7 @@ namespace UnifiedRegex
                     node = Anew(ctAllocator, AltNode, node, nextList);
                 else
                     last->tail = nextList;
+                AnalysisAssert(nextList != nullptr);
                 while (nextList->tail != 0)
                     nextList = nextList->tail;
                 last = nextList;


### PR DESCRIPTION
This change exposes functions that will allocate memory inside of Chakra's GC. This memory can be precisely traced or leaf, and either finalizable or not. Traced objects will have IRecyclerVisitedObject::Trace called on them during ProcessMark if they were added to a new type of mark stack during Mark. Trace implementations will use a new API to tell the marking context to add a set of pointers to the appropriate mark stack.

Finalizable objects will have Dispose called when the the object is no longer reachable, in order to perform unmanaged resource cleanup.

These objects (except for non-finalizable leaf objects) will all live inside a new heap block type. Currently there is only support for small and medium blocks.

GCStress has been updated to allocate objects of the various new types. Finalizable objects hold onto some unmanaged heap resources which would point out (via OOM) if objects are not correctly being cleaned up.

More details:
- Add support for small and medium RecyclerVisitedHostHeapBlockTypes
  - For now, add failfast for RecyclerVisitedObjects that are placed in the LargeHeapBlock
- Publish IRecyclerVisitedObject interface which adds new method (compared to FinalizableObject) for precise tracing support
  - The old FinalizableObject is now a specialization of RecyclerVisitedObject and is used internally by Chakra
  - For host allocations, the host is expected to provide an appropriate implementation of IRecyclerVisitedObject
- Publish IRecyclerHeapMarkingContext (used as the argument to IRecyclerVisitedObject::Trace)
  - The host must implement precisely tracing the (non-leaf) memory it allocates by calling IRecyclerHeapMarkingContext::MarkObjects from inside its implementation of IRecyclerVisitedObject::Trace
  - It is implemented by a stack wrapper on MarkContext that captures the parallel and interior template parameters from MarkContext::ProcessMark. We always use false for doSpecialMark, since all calls to Mark that originate from ProcessMark would pass false (the only place we pass true is when scanning the stack)
- Create Chakra exports for allocation and rootaddref/release functions
- Introduce a new RecyclerHeap lib in chakra that defines the exports in the cpp and declares them in the h
- Add support for RecyclerVisitedObjects in GCStress

Note: this change is derived from a rebase of work done by Daniel Libby - all credit to him for the work to enable this concept.
