### PR TITLE
Introduce FunctionExecutionStateMachine

### DIFF
--- a/lib/Runtime/Base/CMakeLists.txt
+++ b/lib/Runtime/Base/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library (Chakra.Runtime.Base OBJECT
     Exception.cpp
     ExpirableObject.cpp
     FunctionBody.cpp
+    FunctionExecutionStateMachine.cpp
     FunctionInfo.cpp
     LeaveScriptObject.cpp
     LineOffsetCache.cpp

--- a/lib/Runtime/Base/Chakra.Runtime.Base.vcxproj
+++ b/lib/Runtime/Base/Chakra.Runtime.Base.vcxproj
@@ -49,6 +49,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)Exception.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)ExpirableObject.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)FunctionBody.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)FunctionExecutionStateMachine.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)FunctionInfo.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)LeaveScriptObject.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)LineOffsetCache.cpp" />    
@@ -96,6 +97,7 @@
     <ClInclude Include="Exception.h" />
     <ClInclude Include="ExpirableObject.h" />
     <ClInclude Include="FunctionBody.h" />
+    <ClInclude Include="FunctionExecutionStateMachine.h" />
     <ClInclude Include="FunctionInfo.h" />
     <ClInclude Include="JnDirectFields.h" />
     <ClInclude Include="LeaveScriptObject.h" />

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -550,7 +550,6 @@ namespace Js
         m_constTable(nullptr),
         inlineCaches(nullptr),
         cacheIdToPropertyIdMap(nullptr),
-        executionMode(ExecutionMode::Interpreter),
         interpreterLimit(0),
         autoProfilingInterpreter0Limit(0),
         profilingInterpreter0Limit(0),
@@ -692,7 +691,6 @@ namespace Js
         m_constTable(nullptr),
         inlineCaches(nullptr),
         cacheIdToPropertyIdMap(nullptr),
-        executionMode(ExecutionMode::Interpreter),
         interpreterLimit(0),
         autoProfilingInterpreter0Limit(0),
         profilingInterpreter0Limit(0),
@@ -6681,8 +6679,8 @@ namespace Js
 
     ExecutionMode FunctionBody::GetExecutionMode() const
     {
-        VerifyExecutionMode(executionMode);
-        return executionMode;
+        VerifyExecutionMode(executionState.GetExecutionMode());
+        return executionState.GetExecutionMode();
     }
 
     ExecutionMode FunctionBody::GetInterpreterExecutionMode(const bool isPostBailout)
@@ -6725,7 +6723,7 @@ namespace Js
     void FunctionBody::SetExecutionMode(const ExecutionMode executionMode)
     {
         VerifyExecutionMode(executionMode);
-        this->executionMode = executionMode;
+        executionState.SetExecutionMode(executionMode);
     }
 
     bool FunctionBody::IsInterpreterExecutionMode() const
@@ -7417,7 +7415,7 @@ namespace Js
                 _u("limits: %hu.%hu.%hu.%hu.%hu = %hu"),
             GetDisplayName(),
                 GetDebugNumberSet(functionIdString),
-            ExecutionModeName(executionMode),
+            ExecutionModeName(executionState.GetExecutionMode()),
             GetByteCodeCount(),
             interpreterLimit + autoProfilingInterpreter0Limit,
                 profilingInterpreter0Limit,

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -6750,6 +6750,7 @@ namespace Js
     //       |      v
     //       +-> FullJit
     //
+    // Transition to the next mode occurs when the limit for the current execution mode reaches 0.
     // Returns true when a transition occurs (i.e., the execution mode was updated since the beginning of
     // this function call). Otherwise, returns false to indicate no change in state.
     // See more details of each mode in ExecutionModes.h
@@ -6781,6 +6782,9 @@ namespace Js
 
             case ExecutionMode::AutoProfilingInterpreter:
             {
+                // autoProfilingInterpreter0Limit is the default limit for this mode
+                // autoProfilingInterpreter1Limit becomes the limit for this mode when this FunctionBody has
+                // already previously run in ProfilingInterpreter and AutoProfilingInterpreter
                 uint16 &autoProfilingInterpreterLimit =
                     autoProfilingInterpreter0Limit == 0 && profilingInterpreter0Limit == 0
                         ? autoProfilingInterpreter1Limit
@@ -6814,6 +6818,9 @@ namespace Js
 
             case ExecutionMode::ProfilingInterpreter:
             {
+                // profilingInterpreter0Limit is the default limit for this mode
+                // profilingInterpreter1Limit becomes the limit for this mode when this FunctionBody has already
+                // previously run in ProfilingInterpreter, AutoProfilingInterpreter, and SimpleJIT
                 uint16 &profilingInterpreterLimit =
                     profilingInterpreter0Limit == 0 && autoProfilingInterpreter1Limit == 0 && simpleJitLimit == 0
                         ? profilingInterpreter1Limit

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -3844,7 +3844,7 @@ namespace Js
         SetByteCodeInLoopCount(byteCodeInLoopCount);
         SetByteCodeWithoutLDACount(byteCodeWithoutLDACount);
 
-        executionState.InitializeExecutionModeAndLimits(this);
+        executionState.InitializeExecutionModeAndLimits();
 
         this->SetAuxiliaryData(auxBlock);
         this->SetAuxiliaryContextData(auxContextBlock);
@@ -6733,7 +6733,7 @@ namespace Js
 
     bool FunctionBody::TryTransitionToNextExecutionMode()
     {
-        return executionState.TryTransitionToNextExecutionMode(this);
+        return executionState.TryTransitionToNextExecutionMode();
     }
 
     void FunctionBody::TryTransitionToNextInterpreterExecutionMode()
@@ -6773,24 +6773,24 @@ namespace Js
 
     bool FunctionBody::TryTransitionToJitExecutionMode()
     {
-        return executionState.TryTransitionToJitExecutionMode(this);
+        return executionState.TryTransitionToJitExecutionMode();
     }
 
     void FunctionBody::TransitionToSimpleJitExecutionMode()
     {
-        executionState.TransitionToSimpleJitExecutionMode(this);
+        executionState.TransitionToSimpleJitExecutionMode();
     }
 
     void FunctionBody::TransitionToFullJitExecutionMode()
     {
-        executionState.TransitionToSimpleJitExecutionMode(this);
+        executionState.TransitionToSimpleJitExecutionMode();
     }
 
     void FunctionBody::ReinitializeExecutionModeAndLimits()
     {
         // Do not remove wasCalledFromLoop 
         wasCalledFromLoop = false;
-        executionState.ReinitializeExecutionModeAndLimits(this);
+        executionState.ReinitializeExecutionModeAndLimits();
     }
 
     uint16 FunctionBody::GetSimpleJitExecutedIterations() const
@@ -7038,7 +7038,7 @@ namespace Js
         {
             if(PHASE_TRACE(Phase::ExecutionModePhase, this))
             {
-                executionState.CommitExecutedIterations(this);
+                executionState.CommitExecutedIterations();
                 TraceExecutionMode("WasCalledFromLoop (before)");
             }
         }
@@ -7046,11 +7046,11 @@ namespace Js
         {
             // This function is likely going to be called frequently since it's called from a loop. Reduce the full JIT
             // threshold to realize the full JIT perf benefit sooner.
-            executionState.CommitExecutedIterations(this);
+            executionState.CommitExecutedIterations();
             TraceExecutionMode("WasCalledFromLoop (before)");
             if(fullJitThreshold > 1)
             {
-                executionState.SetFullJitThreshold(fullJitThreshold / 2, this, !CONFIG_FLAG(NewSimpleJit));
+                executionState.SetFullJitThreshold(fullJitThreshold / 2, !CONFIG_FLAG(NewSimpleJit));
             }
         }
 
@@ -7605,11 +7605,11 @@ namespace Js
             return;
         }
 
-        executionState.CommitExecutedIterations(this);
+        executionState.CommitExecutedIterations();
         TraceExecutionMode("HasHotLoop (before)");
         if(fullJitThreshold > 1)
         {
-            executionState.SetFullJitThreshold(1, this, true);
+            executionState.SetFullJitThreshold(1, true);
         }
         TraceExecutionMode("HasHotLoop");
     }

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -577,7 +577,6 @@ namespace Js
         , m_canDoStackNestedFunc(false)
         , m_inlineCacheTypes(nullptr)
         , m_iProfileSession(-1)
-        , initializedExecutionModeAndLimits(false)
 #endif
 #if ENABLE_DEBUG_CONFIG_OPTIONS
         , regAllocLoadCount(0)
@@ -707,7 +706,6 @@ namespace Js
         , m_canDoStackNestedFunc(false)
         , m_inlineCacheTypes(nullptr)
         , m_iProfileSession(-1)
-        , initializedExecutionModeAndLimits(false)
 #endif
 #if ENABLE_DEBUG_CONFIG_OPTIONS
         , regAllocLoadCount(0)
@@ -3822,7 +3820,7 @@ namespace Js
         SetByteCodeInLoopCount(byteCodeInLoopCount);
         SetByteCodeWithoutLDACount(byteCodeWithoutLDACount);
 
-        executionState.InitializeExecutionModeAndLimits();
+        executionState.InitializeExecutionModeAndLimits(this);
 
         this->SetAuxiliaryData(auxBlock);
         this->SetAuxiliaryContextData(auxContextBlock);
@@ -6669,14 +6667,14 @@ namespace Js
 
     void FunctionBody::TransitionToFullJitExecutionMode()
     {
-        executionState.TransitionToSimpleJitExecutionMode();
+        executionState.TransitionToFullJitExecutionMode();
     }
 
     void FunctionBody::ReinitializeExecutionModeAndLimits()
     {
         // Do not remove wasCalledFromLoop 
         wasCalledFromLoop = false;
-        executionState.ReinitializeExecutionModeAndLimits();
+        executionState.ReinitializeExecutionModeAndLimits(this);
     }
 
     void FunctionBody::ResetSimpleJitLimitAndCallCount()
@@ -6715,7 +6713,7 @@ namespace Js
 
     void FunctionBody::OnFullJitDequeued(const FunctionEntryPointInfo *const entryPointInfo)
     {
-        Assert(initializedExecutionModeAndLimits);
+        executionState.AssertIsInitialized();
         Assert(GetExecutionMode() == ExecutionMode::FullJit);
         Assert(entryPointInfo);
 
@@ -6730,7 +6728,7 @@ namespace Js
 
     void FunctionBody::TraceExecutionMode(const char *const eventDescription) const
     {
-        Assert(initializedExecutionModeAndLimits);
+        executionState.AssertIsInitialized();
 
         if(PHASE_TRACE(Phase::ExecutionModePhase, this))
         {
@@ -6740,7 +6738,7 @@ namespace Js
 
     void FunctionBody::TraceInterpreterExecutionMode() const
     {
-        Assert(initializedExecutionModeAndLimits);
+        executionState.AssertIsInitialized();
 
         if(!PHASE_TRACE(Phase::ExecutionModePhase, this))
         {
@@ -6760,7 +6758,7 @@ namespace Js
     void FunctionBody::DoTraceExecutionMode(const char *const eventDescription) const
     {
         Assert(PHASE_TRACE(Phase::ExecutionModePhase, this));
-        Assert(initializedExecutionModeAndLimits);
+        executionState.AssertIsInitialized();
 
         char16 functionIdString[MAX_FUNCTION_BODY_DEBUG_STRING_SIZE];
         Output::Print(

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -3844,7 +3844,7 @@ namespace Js
         SetByteCodeInLoopCount(byteCodeInLoopCount);
         SetByteCodeWithoutLDACount(byteCodeWithoutLDACount);
 
-        InitializeExecutionModeAndLimits();
+        executionState.InitializeExecutionModeAndLimits(this);
 
         this->SetAuxiliaryData(auxBlock);
         this->SetAuxiliaryContextData(auxContextBlock);
@@ -6731,157 +6731,9 @@ namespace Js
         return GetExecutionMode() <= ExecutionMode::ProfilingInterpreter;
     }
 
-    // Safely moves from one execution mode to another and updates appropriate execution state for the next
-    // mode. Note that there are other functions that modify executionMode that do not involve this function.
-    // This function transitions ExecutionMode in the following order:
-    //
-    //       +-- Interpreter
-    //       |
-    //       |  AutoProfilingInterpreter --+
-    //       |      |   ^                  |
-    //       |      |   |                  v
-    //       |      |   |               SimpleJit
-    //       |      v   |                  |
-    //       |  ProfilingInterpreter  <----+
-    //       |      |
-    //       |      |
-    //       |      v
-    //       +-> FullJit
-    //
-    // Transition to the next mode occurs when the limit for the current execution mode reaches 0.
-    // Returns true when a transition occurs (i.e., the execution mode was updated since the beginning of
-    // this function call). Otherwise, returns false to indicate no change in state.
-    // See more details of each mode in ExecutionModes.h
     bool FunctionBody::TryTransitionToNextExecutionMode()
     {
-        Assert(initializedExecutionModeAndLimits);
-
-        switch(GetExecutionMode())
-        {
-            // Managing transition from Interpreter
-            case ExecutionMode::Interpreter:
-                if(GetInterpretedCount() < interpreterLimit)
-                {
-                    VerifyExecutionMode(GetExecutionMode());
-                    return false;
-                }
-                CommitExecutedIterations(interpreterLimit, interpreterLimit);
-                goto TransitionToFullJit;
-
-            // Managing transition to and from AutoProfilingInterpreter
-            TransitionToAutoProfilingInterpreter:
-                if(autoProfilingInterpreter0Limit != 0 || autoProfilingInterpreter1Limit != 0)
-                {
-                    SetExecutionMode(ExecutionMode::AutoProfilingInterpreter);
-                    SetInterpretedCount(0);
-                    return true;
-                }
-                goto TransitionFromAutoProfilingInterpreter;
-
-            case ExecutionMode::AutoProfilingInterpreter:
-            {
-                // autoProfilingInterpreter0Limit is the default limit for this mode
-                // autoProfilingInterpreter1Limit becomes the limit for this mode when this FunctionBody has
-                // already previously run in ProfilingInterpreter and AutoProfilingInterpreter
-                uint16 &autoProfilingInterpreterLimit =
-                    autoProfilingInterpreter0Limit == 0 && profilingInterpreter0Limit == 0
-                        ? autoProfilingInterpreter1Limit
-                        : autoProfilingInterpreter0Limit;
-                if(GetInterpretedCount() < autoProfilingInterpreterLimit)
-                {
-                    VerifyExecutionMode(GetExecutionMode());
-                    return false;
-                }
-                CommitExecutedIterations(autoProfilingInterpreterLimit, autoProfilingInterpreterLimit);
-                // fall through
-            }
-
-            TransitionFromAutoProfilingInterpreter:
-                Assert(autoProfilingInterpreter0Limit == 0 || autoProfilingInterpreter1Limit == 0);
-                if(profilingInterpreter0Limit == 0 && autoProfilingInterpreter1Limit == 0)
-                {
-                    goto TransitionToSimpleJit;
-                }
-                // fall through
-
-            // Managing transition to and from ProfilingInterpreter
-            TransitionToProfilingInterpreter:
-                if(profilingInterpreter0Limit != 0 || profilingInterpreter1Limit != 0)
-                {
-                    SetExecutionMode(ExecutionMode::ProfilingInterpreter);
-                    SetInterpretedCount(0);
-                    return true;
-                }
-                goto TransitionFromProfilingInterpreter;
-
-            case ExecutionMode::ProfilingInterpreter:
-            {
-                // profilingInterpreter0Limit is the default limit for this mode
-                // profilingInterpreter1Limit becomes the limit for this mode when this FunctionBody has already
-                // previously run in ProfilingInterpreter, AutoProfilingInterpreter, and SimpleJIT
-                uint16 &profilingInterpreterLimit =
-                    profilingInterpreter0Limit == 0 && autoProfilingInterpreter1Limit == 0 && simpleJitLimit == 0
-                        ? profilingInterpreter1Limit
-                        : profilingInterpreter0Limit;
-                if(GetInterpretedCount() < profilingInterpreterLimit)
-                {
-                    VerifyExecutionMode(GetExecutionMode());
-                    return false;
-                }
-                CommitExecutedIterations(profilingInterpreterLimit, profilingInterpreterLimit);
-                // fall through
-            }
-
-            TransitionFromProfilingInterpreter:
-                Assert(profilingInterpreter0Limit == 0 || profilingInterpreter1Limit == 0);
-                if(autoProfilingInterpreter1Limit == 0 && simpleJitLimit == 0 && profilingInterpreter1Limit == 0)
-                {
-                    goto TransitionToFullJit;
-                }
-                goto TransitionToAutoProfilingInterpreter;
-
-            // Managing transition to and from SimpleJit
-            TransitionToSimpleJit:
-                if(simpleJitLimit != 0)
-                {
-                    SetExecutionMode(ExecutionMode::SimpleJit);
-
-                    // Zero the interpreted count here too, so that we can determine how many interpreter iterations ran
-                    // while waiting for simple JIT
-                    SetInterpretedCount(0);
-                    return true;
-                }
-                goto TransitionToProfilingInterpreter;
-
-            case ExecutionMode::SimpleJit:
-            {
-                FunctionEntryPointInfo *const simpleJitEntryPointInfo = GetSimpleJitEntryPointInfo();
-                if(!simpleJitEntryPointInfo || simpleJitEntryPointInfo->callsCount != 0)
-                {
-                    VerifyExecutionMode(GetExecutionMode());
-                    return false;
-                }
-                CommitExecutedIterations(simpleJitLimit, simpleJitLimit);
-                goto TransitionToProfilingInterpreter;
-            }
-
-            TransitionToFullJit:
-                if(!PHASE_OFF(FullJitPhase, this))
-                {
-                    SetExecutionMode(ExecutionMode::FullJit);
-                    return true;
-                }
-                // fall through
-
-            // Managing transtion to FullJit
-            case ExecutionMode::FullJit:
-                VerifyExecutionMode(GetExecutionMode());
-                return false;
-
-            default:
-                Assert(false);
-                __assume(false);
-        }
+        return executionState.TryTransitionToNextExecutionMode(this);
     }
 
     void FunctionBody::TryTransitionToNextInterpreterExecutionMode()
@@ -6921,355 +6773,24 @@ namespace Js
 
     bool FunctionBody::TryTransitionToJitExecutionMode()
     {
-        const ExecutionMode previousExecutionMode = GetExecutionMode();
-
-        TryTransitionToNextExecutionMode();
-        switch(GetExecutionMode())
-        {
-            case ExecutionMode::SimpleJit:
-                break;
-
-            case ExecutionMode::FullJit:
-                if(fullJitRequeueThreshold == 0)
-                {
-                    break;
-                }
-                --fullJitRequeueThreshold;
-                return false;
-
-            default:
-                return false;
-        }
-
-        if(GetExecutionMode() != previousExecutionMode)
-        {
-            TraceExecutionMode();
-        }
-        return true;
+        return executionState.TryTransitionToJitExecutionMode(this);
     }
 
     void FunctionBody::TransitionToSimpleJitExecutionMode()
     {
-        CommitExecutedIterations();
-
-        interpreterLimit = 0;
-        autoProfilingInterpreter0Limit = 0;
-        profilingInterpreter0Limit = 0;
-        autoProfilingInterpreter1Limit = 0;
-        fullJitThreshold = simpleJitLimit + profilingInterpreter1Limit;
-
-        VerifyExecutionModeLimits();
-        SetExecutionMode(ExecutionMode::SimpleJit);
+        executionState.TransitionToSimpleJitExecutionMode(this);
     }
 
     void FunctionBody::TransitionToFullJitExecutionMode()
     {
-        CommitExecutedIterations();
-
-        interpreterLimit = 0;
-        autoProfilingInterpreter0Limit = 0;
-        profilingInterpreter0Limit = 0;
-        autoProfilingInterpreter1Limit = 0;
-        simpleJitLimit = 0;
-        profilingInterpreter1Limit = 0;
-        fullJitThreshold = 0;
-
-        VerifyExecutionModeLimits();
-        SetExecutionMode(ExecutionMode::FullJit);
-    }
-
-    void FunctionBody::VerifyExecutionModeLimits()
-    {
-        Assert(initializedExecutionModeAndLimits);
-        Assert(
-            (
-                interpreterLimit +
-                autoProfilingInterpreter0Limit +
-                profilingInterpreter0Limit +
-                autoProfilingInterpreter1Limit +
-                simpleJitLimit +
-                profilingInterpreter1Limit
-            ) == fullJitThreshold);
-    }
-
-    void FunctionBody::InitializeExecutionModeAndLimits()
-    {
-        DebugOnly(initializedExecutionModeAndLimits = true);
-
-        const ConfigFlagsTable &configFlags = Configuration::Global.flags;
-
-        interpreterLimit = 0;
-        autoProfilingInterpreter0Limit = static_cast<uint16>(configFlags.AutoProfilingInterpreter0Limit);
-        profilingInterpreter0Limit = static_cast<uint16>(configFlags.ProfilingInterpreter0Limit);
-        autoProfilingInterpreter1Limit = static_cast<uint16>(configFlags.AutoProfilingInterpreter1Limit);
-        simpleJitLimit = static_cast<uint16>(configFlags.SimpleJitLimit);
-        profilingInterpreter1Limit = static_cast<uint16>(configFlags.ProfilingInterpreter1Limit);
-
-        // Based on which execution modes are disabled, calculate the number of additional iterations that need to be covered by
-        // the execution mode that will scale with the full JIT threshold
-        uint16 scale = 0;
-        const bool doInterpreterProfile = DoInterpreterProfile();
-        if(!doInterpreterProfile)
-        {
-            scale +=
-                autoProfilingInterpreter0Limit +
-                profilingInterpreter0Limit +
-                autoProfilingInterpreter1Limit +
-                profilingInterpreter1Limit;
-            autoProfilingInterpreter0Limit = 0;
-            profilingInterpreter0Limit = 0;
-            autoProfilingInterpreter1Limit = 0;
-            profilingInterpreter1Limit = 0;
-        }
-        else if(!DoInterpreterAutoProfile())
-        {
-            scale += autoProfilingInterpreter0Limit + autoProfilingInterpreter1Limit;
-            autoProfilingInterpreter0Limit = 0;
-            autoProfilingInterpreter1Limit = 0;
-            if(!CONFIG_FLAG(NewSimpleJit))
-            {
-                simpleJitLimit += profilingInterpreter0Limit;
-                profilingInterpreter0Limit = 0;
-            }
-        }
-        if(!DoSimpleJit())
-        {
-            if(!CONFIG_FLAG(NewSimpleJit) && doInterpreterProfile)
-            {
-                // The old simple JIT is off, but since it does profiling, it will be replaced with the profiling interpreter
-                profilingInterpreter1Limit += simpleJitLimit;
-            }
-            else
-            {
-                scale += simpleJitLimit;
-            }
-            simpleJitLimit = 0;
-        }
-        if(PHASE_OFF(FullJitPhase, this))
-        {
-            scale += profilingInterpreter1Limit;
-            profilingInterpreter1Limit = 0;
-        }
-
-        uint16 fullJitThreshold =
-            static_cast<uint16>(
-                configFlags.AutoProfilingInterpreter0Limit +
-                configFlags.ProfilingInterpreter0Limit +
-                configFlags.AutoProfilingInterpreter1Limit +
-                configFlags.SimpleJitLimit +
-                configFlags.ProfilingInterpreter1Limit);
-        if(!configFlags.EnforceExecutionModeLimits)
-        {
-            /*
-            Scale the full JIT threshold based on some heuristics:
-                - If the % of code in loops is > 50, scale by 1
-                - Byte-code size of code outside loops
-                    - If the size is < 50, scale by 1.2
-                    - If the size is < 100, scale by 1.4
-                    - If the size is >= 100, scale by 1.6
-            */
-            const uint loopPercentage = GetByteCodeInLoopCount() * 100 / max(1u, GetByteCodeCount());
-            const int byteCodeSizeThresholdForInlineCandidate = CONFIG_FLAG(LoopInlineThreshold);
-            bool delayFullJITThisFunc =
-                (CONFIG_FLAG(DelayFullJITSmallFunc) > 0) && (this->GetByteCodeWithoutLDACount() <= (uint)byteCodeSizeThresholdForInlineCandidate);
-
-            if(loopPercentage <= 50 || delayFullJITThisFunc)
-            {
-                const uint straightLineSize = GetByteCodeCount() - GetByteCodeInLoopCount();
-                double fullJitDelayMultiplier;
-                if (delayFullJITThisFunc)
-                {
-                    fullJitDelayMultiplier = CONFIG_FLAG(DelayFullJITSmallFunc) / 10.0;
-                }
-                else if(straightLineSize < 50)
-                {
-                    fullJitDelayMultiplier = 1.2;
-                }
-                else if(straightLineSize < 100)
-                {
-                    fullJitDelayMultiplier = 1.4;
-                }
-                else
-                {
-                    fullJitDelayMultiplier = 1.6;
-                }
-
-                const uint16 newFullJitThreshold = static_cast<uint16>(fullJitThreshold * fullJitDelayMultiplier);
-                scale += newFullJitThreshold - fullJitThreshold;
-                fullJitThreshold = newFullJitThreshold;
-            }
-        }
-
-        Assert(fullJitThreshold >= scale);
-        this->fullJitThreshold = fullJitThreshold - scale;
-        SetInterpretedCount(0);
-        SetExecutionMode(GetDefaultInterpreterExecutionMode());
-        SetFullJitThreshold(fullJitThreshold);
-        TryTransitionToNextInterpreterExecutionMode();
+        executionState.TransitionToSimpleJitExecutionMode(this);
     }
 
     void FunctionBody::ReinitializeExecutionModeAndLimits()
     {
         // Do not remove wasCalledFromLoop 
         wasCalledFromLoop = false;
-        fullJitRequeueThreshold = 0;
-        committedProfiledIterations = 0;
-        InitializeExecutionModeAndLimits();
-    }
-
-    void FunctionBody::SetFullJitThreshold(const uint16 newFullJitThreshold, const bool skipSimpleJit)
-    {
-        Assert(initializedExecutionModeAndLimits);
-        Assert(GetExecutionMode() != ExecutionMode::FullJit);
-
-        int scale = newFullJitThreshold - fullJitThreshold;
-        if(scale == 0)
-        {
-            VerifyExecutionModeLimits();
-            return;
-        }
-        fullJitThreshold = newFullJitThreshold;
-
-        const auto ScaleLimit = [&](uint16 &limit) -> bool
-        {
-            Assert(scale != 0);
-            const int limitScale = max(-static_cast<int>(limit), scale);
-            const int newLimit = limit + limitScale;
-            Assert(static_cast<int>(static_cast<uint16>(newLimit)) == newLimit);
-            limit = static_cast<uint16>(newLimit);
-            scale -= limitScale;
-            Assert(limit == 0 || scale == 0);
-
-            if(&limit == &simpleJitLimit)
-            {
-                FunctionEntryPointInfo *const simpleJitEntryPointInfo = GetSimpleJitEntryPointInfo();
-                if(GetDefaultFunctionEntryPointInfo() == simpleJitEntryPointInfo)
-                {
-                    Assert(GetExecutionMode() == ExecutionMode::SimpleJit);
-                    const int newSimpleJitCallCount = max(0, (int)simpleJitEntryPointInfo->callsCount + limitScale);
-                    Assert(static_cast<int>(static_cast<uint16>(newSimpleJitCallCount)) == newSimpleJitCallCount);
-                    SetSimpleJitCallCount(static_cast<uint16>(newSimpleJitCallCount));
-                }
-            }
-
-            return scale == 0;
-        };
-
-        /*
-        Determine which execution mode's limit scales with the full JIT threshold, in order of preference:
-            - New simple JIT
-            - Auto-profiling interpreter 1
-            - Auto-profiling interpreter 0
-            - Interpreter
-            - Profiling interpreter 0 (when using old simple JIT)
-            - Old simple JIT
-            - Profiling interpreter 1
-            - Profiling interpreter 0 (when using new simple JIT)
-        */
-        const bool doSimpleJit = DoSimpleJit();
-        const bool doInterpreterProfile = DoInterpreterProfile();
-        const bool fullyScaled =
-            (CONFIG_FLAG(NewSimpleJit) && doSimpleJit && ScaleLimit(simpleJitLimit)) ||
-            (
-                doInterpreterProfile
-                    ?   DoInterpreterAutoProfile() &&
-                        (ScaleLimit(autoProfilingInterpreter1Limit) || ScaleLimit(autoProfilingInterpreter0Limit))
-                    :   ScaleLimit(interpreterLimit)
-            ) ||
-            (
-                CONFIG_FLAG(NewSimpleJit)
-                    ?   doInterpreterProfile &&
-                        (ScaleLimit(profilingInterpreter1Limit) || ScaleLimit(profilingInterpreter0Limit))
-                    :   (doInterpreterProfile && ScaleLimit(profilingInterpreter0Limit)) ||
-                        (doSimpleJit && ScaleLimit(simpleJitLimit)) ||
-                        (doInterpreterProfile && ScaleLimit(profilingInterpreter1Limit))
-            );
-        Assert(fullyScaled);
-        Assert(scale == 0);
-
-        if(GetExecutionMode() != ExecutionMode::SimpleJit)
-        {
-            Assert(IsInterpreterExecutionMode());
-            if(simpleJitLimit != 0 &&
-                (skipSimpleJit || simpleJitLimit < DEFAULT_CONFIG_MinSimpleJitIterations) &&
-                !PHASE_FORCE(Phase::SimpleJitPhase, this))
-            {
-                // Simple JIT code has not yet been generated, and was either requested to be skipped, or the limit was scaled
-                // down too much. Skip simple JIT by moving any remaining iterations to an equivalent interpreter execution
-                // mode.
-                (CONFIG_FLAG(NewSimpleJit) ? autoProfilingInterpreter1Limit : profilingInterpreter1Limit) += simpleJitLimit;
-                simpleJitLimit = 0;
-                TryTransitionToNextInterpreterExecutionMode();
-            }
-        }
-
-        VerifyExecutionModeLimits();
-    }
-
-    void FunctionBody::CommitExecutedIterations()
-    {
-        Assert(initializedExecutionModeAndLimits);
-
-        switch(GetExecutionMode())
-        {
-            case ExecutionMode::Interpreter:
-                CommitExecutedIterations(interpreterLimit, GetInterpretedCount());
-                break;
-
-            case ExecutionMode::AutoProfilingInterpreter:
-                CommitExecutedIterations(
-                    autoProfilingInterpreter0Limit == 0 && profilingInterpreter0Limit == 0
-                        ? autoProfilingInterpreter1Limit
-                        : autoProfilingInterpreter0Limit,
-                    GetInterpretedCount());
-                break;
-
-            case ExecutionMode::ProfilingInterpreter:
-                CommitExecutedIterations(
-                    GetSimpleJitEntryPointInfo()
-                        ? profilingInterpreter1Limit
-                        : profilingInterpreter0Limit,
-                    GetInterpretedCount());
-                break;
-
-            case ExecutionMode::SimpleJit:
-                CommitExecutedIterations(simpleJitLimit, GetSimpleJitExecutedIterations());
-                break;
-
-            case ExecutionMode::FullJit:
-                break;
-
-            default:
-                Assert(false);
-                __assume(false);
-        }
-    }
-
-    void FunctionBody::CommitExecutedIterations(uint16 &limit, const uint executedIterations)
-    {
-        Assert(initializedExecutionModeAndLimits);
-        Assert(
-            &limit == &interpreterLimit ||
-            &limit == &autoProfilingInterpreter0Limit ||
-            &limit == &profilingInterpreter0Limit ||
-            &limit == &autoProfilingInterpreter1Limit ||
-            &limit == &simpleJitLimit ||
-            &limit == &profilingInterpreter1Limit);
-
-        const uint16 clampedExecutedIterations = executedIterations >= limit ? limit : static_cast<uint16>(executedIterations);
-        Assert(fullJitThreshold >= clampedExecutedIterations);
-        fullJitThreshold -= clampedExecutedIterations;
-        limit -= clampedExecutedIterations;
-        VerifyExecutionModeLimits();
-
-        if(&limit == &profilingInterpreter0Limit ||
-            (!CONFIG_FLAG(NewSimpleJit) && &limit == &simpleJitLimit) ||
-            &limit == &profilingInterpreter1Limit)
-        {
-            const uint16 newCommittedProfiledIterations = committedProfiledIterations + clampedExecutedIterations;
-            committedProfiledIterations =
-                newCommittedProfiledIterations >= committedProfiledIterations ? newCommittedProfiledIterations : UINT16_MAX;
-        }
+        executionState.ReinitializeExecutionModeAndLimits(this);
     }
 
     uint16 FunctionBody::GetSimpleJitExecutedIterations() const
@@ -7517,7 +7038,7 @@ namespace Js
         {
             if(PHASE_TRACE(Phase::ExecutionModePhase, this))
             {
-                CommitExecutedIterations();
+                executionState.CommitExecutedIterations(this);
                 TraceExecutionMode("WasCalledFromLoop (before)");
             }
         }
@@ -7525,11 +7046,11 @@ namespace Js
         {
             // This function is likely going to be called frequently since it's called from a loop. Reduce the full JIT
             // threshold to realize the full JIT perf benefit sooner.
-            CommitExecutedIterations();
+            executionState.CommitExecutedIterations(this);
             TraceExecutionMode("WasCalledFromLoop (before)");
             if(fullJitThreshold > 1)
             {
-                SetFullJitThreshold(fullJitThreshold / 2, !CONFIG_FLAG(NewSimpleJit));
+                executionState.SetFullJitThreshold(fullJitThreshold / 2, this, !CONFIG_FLAG(NewSimpleJit));
             }
         }
 
@@ -8084,11 +7605,11 @@ namespace Js
             return;
         }
 
-        CommitExecutedIterations();
+        executionState.CommitExecutedIterations(this);
         TraceExecutionMode("HasHotLoop (before)");
         if(fullJitThreshold > 1)
         {
-            SetFullJitThreshold(1, true);
+            executionState.SetFullJitThreshold(1, this, true);
         }
         TraceExecutionMode("HasHotLoop");
     }

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -7110,6 +7110,7 @@ namespace Js
 
     void FunctionBody::ReinitializeExecutionModeAndLimits()
     {
+        // Do not remove wasCalledFromLoop 
         wasCalledFromLoop = false;
         fullJitRequeueThreshold = 0;
         committedProfiledIterations = 0;

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -2350,10 +2350,6 @@ namespace Js
         FieldWithBarrier(bool) m_canDoStackNestedFunc : 1;
 #endif
 
-#if DBG
-        FieldWithBarrier(bool) initializedExecutionModeAndLimits : 1;
-#endif
-
 #ifdef IR_VIEWER
         // whether IR Dump is enabled for this function (used by parseIR)
         FieldWithBarrier(bool) m_isIRDumpEnabled : 1;

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -2362,20 +2362,34 @@ namespace Js
 
         FieldWithBarrier(byte) inlineDepth; // Used by inlining to avoid recursively inlining functions excessively
 
+        // Tracks the current execution mode. See ExecutionModes.h for more info.
         FieldWithBarrier(ExecutionMode) executionMode;
+
+        // Each of the following limits below is decremented when transitioning from its related mode:
+        // Number of times to run interpreter (no profiling) before advancing to next mode
         FieldWithBarrier(uint16) interpreterLimit;
+        // Number of times to run interpreter (min profiling) before advancing to next mode
         FieldWithBarrier(uint16) autoProfilingInterpreter0Limit;
+        // Number of times to run interpreter (full profiling) before advancing to next mode
         FieldWithBarrier(uint16) profilingInterpreter0Limit;
+        // Number of times to run interpreter (min profiling) after already running min and full profiling
         FieldWithBarrier(uint16) autoProfilingInterpreter1Limit;
+        // Number of times to run simple JIT before advancing to next mode
         FieldWithBarrier(uint16) simpleJitLimit;
+        // Number of times to run interpreter (full profiling) before advancing to next mode
         FieldWithBarrier(uint16) profilingInterpreter1Limit;
+
+        // Total limit to run in non-full JIT execution mode. Typically the sum of the other limits
         FieldWithBarrier(uint16) fullJitThreshold;
+        // Number of attempts to schedule FullJIT until it becomes forced
         FieldWithBarrier(uint16) fullJitRequeueThreshold;
+        // Total number of times this function has run under the interpreter with full profiling
         FieldWithBarrier(uint16) committedProfiledIterations;
-
-        FieldWithBarrier(uint) m_depth; // Indicates how many times the function has been entered (so increases by one on each recursive call, decreases by one when we're done)
-
+        // Indicates how many times the function has been entered (so increases by one on each recursive call, decreases by one when we're done)
+        FieldWithBarrier(uint) m_depth;
+        // Number of times this function has run under the interpreter in the current execution mode
         FieldWithBarrier(uint32) interpretedCount;
+        // Used to detect when interpretedCount changed from a particular call
         FieldWithBarrier(uint32) lastInterpretedCount;
         FieldWithBarrier(uint32) loopInterpreterLimit;
         FieldWithBarrier(uint32) debuggerScopeIndex;

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -2645,15 +2645,7 @@ namespace Js
         void TransitionToSimpleJitExecutionMode();
         void TransitionToFullJitExecutionMode();
 
-    private:
-        void VerifyExecutionModeLimits();
-        void InitializeExecutionModeAndLimits();
-    public:
         void ReinitializeExecutionModeAndLimits();
-    private:
-        void SetFullJitThreshold(const uint16 newFullJitThreshold, const bool skipSimpleJit = false);
-        void CommitExecutedIterations();
-        void CommitExecutedIterations(uint16 &limit, const uint executedIterations);
 
     private:
         uint16 GetSimpleJitExecutedIterations() const;

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -2367,32 +2367,9 @@ namespace Js
 
         FieldWithBarrier(FunctionExecutionStateMachine) executionState;
 
-        // Each of the following limits below is decremented when transitioning from its related mode:
-        // Number of times to run interpreter (no profiling) before advancing to next mode
-        FieldWithBarrier(uint16) interpreterLimit;
-        // Number of times to run interpreter (min profiling) before advancing to next mode
-        FieldWithBarrier(uint16) autoProfilingInterpreter0Limit;
-        // Number of times to run interpreter (full profiling) before advancing to next mode
-        FieldWithBarrier(uint16) profilingInterpreter0Limit;
-        // Number of times to run interpreter (min profiling) after already running min and full profiling
-        FieldWithBarrier(uint16) autoProfilingInterpreter1Limit;
-        // Number of times to run simple JIT before advancing to next mode
-        FieldWithBarrier(uint16) simpleJitLimit;
-        // Number of times to run interpreter (full profiling) before advancing to next mode
-        FieldWithBarrier(uint16) profilingInterpreter1Limit;
-
-        // Total limit to run in non-full JIT execution mode. Typically the sum of the other limits
-        FieldWithBarrier(uint16) fullJitThreshold;
-        // Number of attempts to schedule FullJIT until it becomes forced
-        FieldWithBarrier(uint16) fullJitRequeueThreshold;
-        // Total number of times this function has run under the interpreter with full profiling
-        FieldWithBarrier(uint16) committedProfiledIterations;
         // Indicates how many times the function has been entered (so increases by one on each recursive call, decreases by one when we're done)
         FieldWithBarrier(uint) m_depth;
-        // Number of times this function has run under the interpreter in the current execution mode
-        FieldWithBarrier(uint32) interpretedCount;
-        // Used to detect when interpretedCount changed from a particular call
-        FieldWithBarrier(uint32) lastInterpretedCount;
+
         FieldWithBarrier(uint32) loopInterpreterLimit;
         FieldWithBarrier(uint32) debuggerScopeIndex;
         FieldWithBarrier(uint32) savedPolymorphicCacheState;
@@ -2549,9 +2526,8 @@ namespace Js
         bool HasCachedScopePropIds() const { return hasCachedScopePropIds; }
         void SetHasCachedScopePropIds(bool has) { hasCachedScopePropIds = has; }
 
-        uint32 GetInterpretedCount() const { return interpretedCount; }
-        uint32 SetInterpretedCount(uint32 val) { return interpretedCount = val; }
-        uint32 IncreaseInterpretedCount() { return interpretedCount++; }
+        uint32 GetInterpretedCount() const;
+        uint32 IncreaseInterpretedCount();
 
         uint32 GetLoopInterpreterLimit() const { return loopInterpreterLimit; }
         uint32 SetLoopInterpreterLimit(uint32 val) { return loopInterpreterLimit = val; }

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -7,6 +7,9 @@
 #include "AuxPtrs.h"
 #include "CompactCounters.h"
 
+// Where should I include this file?
+#include "FunctionExecutionStateMachine.h"
+
 struct CodeGenWorkItem;
 class SourceContextInfo;
 struct DeferredFunctionStub;
@@ -2362,8 +2365,7 @@ namespace Js
 
         FieldWithBarrier(byte) inlineDepth; // Used by inlining to avoid recursively inlining functions excessively
 
-        // Tracks the current execution mode. See ExecutionModes.h for more info.
-        FieldWithBarrier(ExecutionMode) executionMode;
+        FieldWithBarrier(FunctionExecutionStateMachine) executionState;
 
         // Each of the following limits below is decremented when transitioning from its related mode:
         // Number of times to run interpreter (no profiling) before advancing to next mode

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -2627,9 +2627,6 @@ namespace Js
         FunctionEntryPointInfo *GetSimpleJitEntryPointInfo() const;
         void SetSimpleJitEntryPointInfo(FunctionEntryPointInfo *const entryPointInfo);
 
-    private:
-        void VerifyExecutionMode(const ExecutionMode executionMode) const;
-    public:
         ExecutionMode GetDefaultInterpreterExecutionMode() const;
         ExecutionMode GetExecutionMode() const;
         ExecutionMode GetInterpreterExecutionMode(const bool isPostBailout);

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -2678,8 +2678,6 @@ namespace Js
         bool DoSimpleJit() const;
         bool DoSimpleJitWithLock() const;
         bool DoSimpleJitDynamicProfile() const;
-
-    private:
         bool DoInterpreterProfile() const;
         bool DoInterpreterProfileWithLock() const;
         bool DoInterpreterAutoProfile() const;

--- a/lib/Runtime/Base/FunctionExecutionStateMachine.cpp
+++ b/lib/Runtime/Base/FunctionExecutionStateMachine.cpp
@@ -1,0 +1,24 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+#include "RuntimeBasePch.h"
+#include "FunctionExecutionStateMachine.h"
+
+namespace Js
+{
+    FunctionExecutionStateMachine::FunctionExecutionStateMachine() :
+        executionMode(ExecutionMode::Interpreter)
+    {
+    }
+
+    ExecutionMode FunctionExecutionStateMachine::GetExecutionMode() const
+    {
+        return executionMode;
+    }
+
+    void FunctionExecutionStateMachine::SetExecutionMode(ExecutionMode mode)
+    {
+        executionMode = mode;
+    }
+}

--- a/lib/Runtime/Base/FunctionExecutionStateMachine.cpp
+++ b/lib/Runtime/Base/FunctionExecutionStateMachine.cpp
@@ -128,11 +128,11 @@ namespace Js
         TryTransitionToNextInterpreterExecutionMode(functionBody);
     }
 
-    void FunctionExecutionStateMachine::ReinitializeExecutionModeAndLimits()
+    void FunctionExecutionStateMachine::ReinitializeExecutionModeAndLimits(FunctionBody* functionBody)
     {
         fullJitRequeueThreshold = 0;
         committedProfiledIterations = 0;
-        InitializeExecutionModeAndLimits();
+        InitializeExecutionModeAndLimits(functionBody);
     }
 
     ExecutionMode FunctionExecutionStateMachine::GetExecutionMode() const

--- a/lib/Runtime/Base/FunctionExecutionStateMachine.cpp
+++ b/lib/Runtime/Base/FunctionExecutionStateMachine.cpp
@@ -21,4 +21,235 @@ namespace Js
     {
         executionMode = mode;
     }
+
+
+    // Safely moves from one execution mode to another and updates appropriate execution state for the next
+    // mode. Note that there are other functions that modify executionMode that do not involve this function.
+    // This function transitions ExecutionMode in the following order:
+    //
+    //       +-- Interpreter
+    //       |
+    //       |  AutoProfilingInterpreter --+
+    //       |      |   ^                  |
+    //       |      |   |                  v
+    //       |      |   |               SimpleJit
+    //       |      v   |                  |
+    //       |  ProfilingInterpreter  <----+
+    //       |      |
+    //       |      |
+    //       |      v
+    //       +-> FullJit
+    //
+    // Transition to the next mode occurs when the limit for the current execution mode reaches 0.
+    // Returns true when a transition occurs (i.e., the execution mode was updated since the beginning of
+    // this function call). Otherwise, returns false to indicate no change in state.
+    // See more details of each mode in ExecutionModes.h
+    bool FunctionExecutionStateMachine::TryTransitionToNextExecutionMode(FunctionBody* functionBody)
+    {
+        Assert(initializedExecutionModeAndLimits);
+
+        switch (GetExecutionMode())
+        {
+            // Managing transition from Interpreter
+        case ExecutionMode::Interpreter:
+            if (GetInterpretedCount() < interpreterLimit)
+            {
+                VerifyExecutionMode(GetExecutionMode(), functionBody);
+                return false;
+            }
+            CommitExecutedIterations(interpreterLimit, interpreterLimit);
+            goto TransitionToFullJit;
+
+            // Managing transition to and from AutoProfilingInterpreter
+        TransitionToAutoProfilingInterpreter:
+            if (autoProfilingInterpreter0Limit != 0 || autoProfilingInterpreter1Limit != 0)
+            {
+                SetExecutionMode(ExecutionMode::AutoProfilingInterpreter);
+                SetInterpretedCount(0);
+                return true;
+            }
+            goto TransitionFromAutoProfilingInterpreter;
+
+        case ExecutionMode::AutoProfilingInterpreter:
+        {
+            // autoProfilingInterpreter0Limit is the default limit for this mode
+            // autoProfilingInterpreter1Limit becomes the limit for this mode when this FunctionBody has
+            // already previously run in ProfilingInterpreter and AutoProfilingInterpreter
+            uint16 &autoProfilingInterpreterLimit =
+                autoProfilingInterpreter0Limit == 0 && profilingInterpreter0Limit == 0
+                ? autoProfilingInterpreter1Limit
+                : autoProfilingInterpreter0Limit;
+            if (GetInterpretedCount() < autoProfilingInterpreterLimit)
+            {
+                VerifyExecutionMode(GetExecutionMode(), functionBody);
+                return false;
+            }
+            CommitExecutedIterations(autoProfilingInterpreterLimit, autoProfilingInterpreterLimit);
+            // fall through
+        }
+
+    TransitionFromAutoProfilingInterpreter:
+        Assert(autoProfilingInterpreter0Limit == 0 || autoProfilingInterpreter1Limit == 0);
+        if (profilingInterpreter0Limit == 0 && autoProfilingInterpreter1Limit == 0)
+        {
+            goto TransitionToSimpleJit;
+        }
+        // fall through
+
+        // Managing transition to and from ProfilingInterpreter
+    TransitionToProfilingInterpreter:
+        if (profilingInterpreter0Limit != 0 || profilingInterpreter1Limit != 0)
+        {
+            SetExecutionMode(ExecutionMode::ProfilingInterpreter);
+            SetInterpretedCount(0);
+            return true;
+        }
+        goto TransitionFromProfilingInterpreter;
+
+        case ExecutionMode::ProfilingInterpreter:
+        {
+            // profilingInterpreter0Limit is the default limit for this mode
+            // profilingInterpreter1Limit becomes the limit for this mode when this FunctionBody has already
+            // previously run in ProfilingInterpreter, AutoProfilingInterpreter, and SimpleJIT
+            uint16 &profilingInterpreterLimit =
+                profilingInterpreter0Limit == 0 && autoProfilingInterpreter1Limit == 0 && simpleJitLimit == 0
+                ? profilingInterpreter1Limit
+                : profilingInterpreter0Limit;
+            if (GetInterpretedCount() < profilingInterpreterLimit)
+            {
+                VerifyExecutionMode(GetExecutionMode(), functionBody);
+                return false;
+            }
+            CommitExecutedIterations(profilingInterpreterLimit, profilingInterpreterLimit);
+            // fall through
+        }
+
+    TransitionFromProfilingInterpreter:
+        Assert(profilingInterpreter0Limit == 0 || profilingInterpreter1Limit == 0);
+        if (autoProfilingInterpreter1Limit == 0 && simpleJitLimit == 0 && profilingInterpreter1Limit == 0)
+        {
+            goto TransitionToFullJit;
+        }
+        goto TransitionToAutoProfilingInterpreter;
+
+        // Managing transition to and from SimpleJit
+    TransitionToSimpleJit:
+        if (simpleJitLimit != 0)
+        {
+            SetExecutionMode(ExecutionMode::SimpleJit);
+
+            // Zero the interpreted count here too, so that we can determine how many interpreter iterations ran
+            // while waiting for simple JIT
+            SetInterpretedCount(0);
+            return true;
+        }
+        goto TransitionToProfilingInterpreter;
+
+        case ExecutionMode::SimpleJit:
+        {
+            FunctionEntryPointInfo *const simpleJitEntryPointInfo = functionBody->GetSimpleJitEntryPointInfo();
+            if (!simpleJitEntryPointInfo || simpleJitEntryPointInfo->callsCount != 0)
+            {
+                VerifyExecutionMode(GetExecutionMode(), functionBody);
+                return false;
+            }
+            CommitExecutedIterations(simpleJitLimit, simpleJitLimit);
+            goto TransitionToProfilingInterpreter;
+        }
+
+    TransitionToFullJit:
+        if (!PHASE_OFF(FullJitPhase, functionBody))
+        {
+            SetExecutionMode(ExecutionMode::FullJit);
+            return true;
+        }
+        // fall through
+
+        // Managing transtion to FullJit
+        case ExecutionMode::FullJit:
+            VerifyExecutionMode(GetExecutionMode(), functionBody);
+            return false;
+
+        default:
+            Assert(false);
+            __assume(false);
+        }
+    }
+
+    void FunctionExecutionStateMachine::CommitExecutedIterations(uint16 &limit, const uint executedIterations)
+    {
+        Assert(initializedExecutionModeAndLimits);
+        Assert(
+            &limit == &interpreterLimit ||
+            &limit == &autoProfilingInterpreter0Limit ||
+            &limit == &profilingInterpreter0Limit ||
+            &limit == &autoProfilingInterpreter1Limit ||
+            &limit == &simpleJitLimit ||
+            &limit == &profilingInterpreter1Limit);
+
+        const uint16 clampedExecutedIterations = executedIterations >= limit ? limit : static_cast<uint16>(executedIterations);
+        Assert(fullJitThreshold >= clampedExecutedIterations);
+        fullJitThreshold -= clampedExecutedIterations;
+        limit -= clampedExecutedIterations;
+        VerifyExecutionModeLimits();
+
+        if (&limit == &profilingInterpreter0Limit ||
+            (!CONFIG_FLAG(NewSimpleJit) && &limit == &simpleJitLimit) ||
+            &limit == &profilingInterpreter1Limit)
+        {
+            const uint16 newCommittedProfiledIterations = committedProfiledIterations + clampedExecutedIterations;
+            committedProfiledIterations =
+                newCommittedProfiledIterations >= committedProfiledIterations ? newCommittedProfiledIterations : UINT16_MAX;
+        }
+    }
+
+    void FunctionExecutionStateMachine::VerifyExecutionModeLimits() const
+    {
+        Assert(initializedExecutionModeAndLimits);
+        Assert(
+            (
+                interpreterLimit +
+                autoProfilingInterpreter0Limit +
+                profilingInterpreter0Limit +
+                autoProfilingInterpreter1Limit +
+                simpleJitLimit +
+                profilingInterpreter1Limit
+                ) == fullJitThreshold);
+    }
+
+    void FunctionExecutionStateMachine::VerifyExecutionMode(const ExecutionMode executionMode, FunctionBody* functionBody) const
+    {
+#if DBG
+        Assert(initializedExecutionModeAndLimits);
+        Assert(executionMode < ExecutionMode::Count);
+
+        switch (executionMode)
+        {
+        case ExecutionMode::Interpreter:
+            Assert(!functionBody->DoInterpreterProfile());
+            break;
+
+        case ExecutionMode::AutoProfilingInterpreter:
+            Assert(functionBody->DoInterpreterProfile());
+            Assert(functionBody->DoInterpreterAutoProfile());
+            break;
+
+        case ExecutionMode::ProfilingInterpreter:
+            Assert(functionBody->DoInterpreterProfile());
+            break;
+
+        case ExecutionMode::SimpleJit:
+            Assert(functionBody->DoSimpleJit());
+            break;
+
+        case ExecutionMode::FullJit:
+            Assert(!PHASE_OFF(FullJitPhase, functionBody));
+            break;
+
+        default:
+            Assert(false);
+            __assume(false);
+        }
+#endif
+    }
 }

--- a/lib/Runtime/Base/FunctionExecutionStateMachine.cpp
+++ b/lib/Runtime/Base/FunctionExecutionStateMachine.cpp
@@ -142,7 +142,7 @@ namespace Js
         this->fullJitThreshold = fullJitThreshold - scale;
         SetInterpretedCount(0);
         SetExecutionMode(GetDefaultInterpreterExecutionMode());
-        SetFullJitThreshold(fullJitThreshold, owner);
+        SetFullJitThreshold(fullJitThreshold);
         TryTransitionToNextInterpreterExecutionMode();
     }
 

--- a/lib/Runtime/Base/FunctionExecutionStateMachine.cpp
+++ b/lib/Runtime/Base/FunctionExecutionStateMachine.cpp
@@ -128,6 +128,12 @@ namespace Js
         TryTransitionToNextInterpreterExecutionMode(functionBody);
     }
 
+    void FunctionExecutionStateMachine::ReinitializeExecutionModeAndLimits()
+    {
+        fullJitRequeueThreshold = 0;
+        committedProfiledIterations = 0;
+        InitializeExecutionModeAndLimits();
+    }
 
     ExecutionMode FunctionExecutionStateMachine::GetExecutionMode() const
     {

--- a/lib/Runtime/Base/FunctionExecutionStateMachine.h
+++ b/lib/Runtime/Base/FunctionExecutionStateMachine.h
@@ -11,11 +11,52 @@ namespace Js
     public:
         FunctionExecutionStateMachine();
 
+        // Public Getters and Setters
         ExecutionMode GetExecutionMode() const;
-        void SetExecutionMode(ExecutionMode mode);
+        void SetExecutionMode(ExecutionMode mode); // This should eventually become private
+        uint32 GetInterpretedCount() const { return interpretedCount; }
+        uint32 SetInterpretedCount(uint32 val) { return interpretedCount = val; }
+        uint32 IncreaseInterpretedCount() { return interpretedCount++; }
+
+
+        // Transition functions
+        bool TryTransitionToNextExecutionMode(FunctionBody* functionBody);
 
     private:
+        void VerifyExecutionMode(const ExecutionMode executionMode, FunctionBody* functionBody) const;
+        void VerifyExecutionModeLimits() const;
+        void CommitExecutedIterations(uint16 &limit, const uint executedIterations);
+
+
+
         // Tracks the current execution mode. See ExecutionModes.h for more info.
         FieldWithBarrier(ExecutionMode) executionMode;
+
+        // Each of the following limits below is decremented when transitioning from its related mode:
+        // Number of times to run interpreter (no profiling) before advancing to next mode
+        FieldWithBarrier(uint16) interpreterLimit;
+        // Number of times to run interpreter (min profiling) before advancing to next mode
+        FieldWithBarrier(uint16) autoProfilingInterpreter0Limit;
+        // Number of times to run interpreter (full profiling) before advancing to next mode
+        FieldWithBarrier(uint16) profilingInterpreter0Limit;
+        // Number of times to run interpreter (min profiling) after already running min and full profiling
+        FieldWithBarrier(uint16) autoProfilingInterpreter1Limit;
+        // Number of times to run simple JIT before advancing to next mode
+        FieldWithBarrier(uint16) simpleJitLimit;
+        // Number of times to run interpreter (full profiling) before advancing to next mode
+        FieldWithBarrier(uint16) profilingInterpreter1Limit;
+
+        // Total limit to run in non-full JIT execution mode. Typically the sum of the other limits
+        FieldWithBarrier(uint16) fullJitThreshold;
+        // Number of attempts to schedule FullJIT until it becomes forced
+        FieldWithBarrier(uint16) fullJitRequeueThreshold;
+        // Total number of times this function has run under the interpreter with full profiling
+        FieldWithBarrier(uint16) committedProfiledIterations;
+        // Number of times this function has run under the interpreter in the current execution mode
+        FieldWithBarrier(uint32) interpretedCount;
+
+#if DBG
+        FieldWithBarrier(bool) initializedExecutionModeAndLimits : 1;
+#endif
     };
 };

--- a/lib/Runtime/Base/FunctionExecutionStateMachine.h
+++ b/lib/Runtime/Base/FunctionExecutionStateMachine.h
@@ -11,7 +11,7 @@ namespace Js
     public:
         FunctionExecutionStateMachine();
         void InitializeExecutionModeAndLimits(FunctionBody* functionBody);
-        void ReinitializeExecutionModeAndLimits();
+        void ReinitializeExecutionModeAndLimits(FunctionBody* functionBody);
 
         // Public Getters and Setters
         ExecutionMode GetExecutionMode() const;
@@ -23,10 +23,11 @@ namespace Js
         uint32 GetInterpretedCount() const { return interpretedCount; }
         uint32 SetInterpretedCount(uint32 val) { return interpretedCount = val; }
         uint32 IncreaseInterpretedCount() { return interpretedCount++; }
+        void CommitExecutedIterations(FunctionBody* functionBody);
+
         uint16 GetSimpleJitExecutedIterations(FunctionBody* functionBody) const;
         void SetFullJitThreshold(const uint16 newFullJitThreshold, FunctionBody* functionBody, const bool skipSimpleJit = false);
         void SetSimpleJitCallCount(const uint16 simpleJitLimit, FunctionBody* functionBody) const;
-
 
         // Transition functions
         bool TryTransitionToNextExecutionMode(FunctionBody* functionBody);
@@ -39,7 +40,7 @@ namespace Js
     private:
         void VerifyExecutionMode(const ExecutionMode executionMode, FunctionBody* functionBody) const;
         void VerifyExecutionModeLimits() const;
-        void CommitExecutedIterations(FunctionBody* functionBody);
+        
         void CommitExecutedIterations(uint16 &limit, const uint executedIterations);
 
 

--- a/lib/Runtime/Base/FunctionExecutionStateMachine.h
+++ b/lib/Runtime/Base/FunctionExecutionStateMachine.h
@@ -19,12 +19,15 @@ namespace Js
         ExecutionMode GetDefaultInterpreterExecutionMode() const;
         ExecutionMode GetInterpreterExecutionMode(const bool isPostBailout);
         bool IsInterpreterExecutionMode() const;
+        uint16 GetProfiledIterations() const;
 
         uint32 GetInterpretedCount() const { return interpretedCount; }
         uint32 SetInterpretedCount(uint32 val) { return interpretedCount = val; }
         uint32 IncreaseInterpretedCount() { return interpretedCount++; }
         void CommitExecutedIterations();
 
+        void SetIsSpeculativeJitCandidate();
+        uint16 GetSimpleJitLimit() const { return simpleJitLimit; }
         uint16 GetSimpleJitExecutedIterations() const;
         void SetFullJitThreshold(const uint16 newFullJitThreshold, const bool skipSimpleJit = false);
         void SetSimpleJitCallCount(const uint16 simpleJitLimit) const;

--- a/lib/Runtime/Base/FunctionExecutionStateMachine.h
+++ b/lib/Runtime/Base/FunctionExecutionStateMachine.h
@@ -21,16 +21,21 @@ namespace Js
         uint32 GetInterpretedCount() const { return interpretedCount; }
         uint32 SetInterpretedCount(uint32 val) { return interpretedCount = val; }
         uint32 IncreaseInterpretedCount() { return interpretedCount++; }
+        uint16 GetSimpleJitExecutedIterations(FunctionBody* functionBody) const;
 
 
         // Transition functions
         bool TryTransitionToNextExecutionMode(FunctionBody* functionBody);
         void TryTransitionToNextInterpreterExecutionMode(FunctionBody* functionBody);
+        bool TryTransitionToJitExecutionMode(FunctionBody* functionBody);
+        void TransitionToSimpleJitExecutionMode(FunctionBody* functionBody);
+        void TransitionToFullJitExecutionMode(FunctionBody* functionBody);
 
 
     private:
         void VerifyExecutionMode(const ExecutionMode executionMode, FunctionBody* functionBody) const;
         void VerifyExecutionModeLimits() const;
+        void CommitExecutedIterations(FunctionBody* functionBody);
         void CommitExecutedIterations(uint16 &limit, const uint executedIterations);
 
 

--- a/lib/Runtime/Base/FunctionExecutionStateMachine.h
+++ b/lib/Runtime/Base/FunctionExecutionStateMachine.h
@@ -55,7 +55,7 @@ namespace Js
         void CommitExecutedIterations(uint16 &limit, const uint executedIterations);
 
         // This state machine should be a member of this owner FunctionBody
-        FunctionBody* owner;
+        FieldWithBarrier(FunctionBody*) owner;
 
         // Tracks the current execution mode. See ExecutionModes.h for more info.
         FieldWithBarrier(ExecutionMode) executionMode;

--- a/lib/Runtime/Base/FunctionExecutionStateMachine.h
+++ b/lib/Runtime/Base/FunctionExecutionStateMachine.h
@@ -10,8 +10,8 @@ namespace Js
     {
     public:
         FunctionExecutionStateMachine();
-        void InitializeExecutionModeAndLimits();
-        void ReinitializeExecutionModeAndLimits();
+        void InitializeExecutionModeAndLimits(FunctionBody* functionBody);
+        void ReinitializeExecutionModeAndLimits(FunctionBody* functionBody);
 
         // Public Getters and Setters
         ExecutionMode GetExecutionMode() const;
@@ -45,6 +45,7 @@ namespace Js
         void TransitionToFullJitExecutionMode();
 
         void PrintLimits() const;
+        void AssertIsInitialized() const;
 
 
     private:

--- a/lib/Runtime/Base/FunctionExecutionStateMachine.h
+++ b/lib/Runtime/Base/FunctionExecutionStateMachine.h
@@ -24,12 +24,17 @@ namespace Js
         uint32 GetInterpretedCount() const { return interpretedCount; }
         uint32 SetInterpretedCount(uint32 val) { return interpretedCount = val; }
         uint32 IncreaseInterpretedCount() { return interpretedCount++; }
+        bool InterpretedSinceCallCountCollection() const;
+        void CollectInterpretedCounts();
         void CommitExecutedIterations();
 
         void SetIsSpeculativeJitCandidate();
         uint16 GetSimpleJitLimit() const { return simpleJitLimit; }
+        void ResetSimpleJitLimit();
         uint16 GetSimpleJitExecutedIterations() const;
         void SetFullJitThreshold(const uint16 newFullJitThreshold, const bool skipSimpleJit = false);
+        uint16 GetFullJitThreshold() const { return fullJitThreshold; }
+        void SetFullJitRequeueThreshold(const uint16 newFullJitRequeueThreshold);
         void SetSimpleJitCallCount(const uint16 simpleJitLimit) const;
 
         // Transition functions
@@ -38,6 +43,8 @@ namespace Js
         bool TryTransitionToJitExecutionMode();
         void TransitionToSimpleJitExecutionMode();
         void TransitionToFullJitExecutionMode();
+
+        void PrintLimits() const;
 
 
     private:
@@ -74,6 +81,8 @@ namespace Js
         FieldWithBarrier(uint16) committedProfiledIterations;
         // Number of times this function has run under the interpreter in the current execution mode
         FieldWithBarrier(uint32) interpretedCount;
+        // Used to detect when interpretedCount changed from a particular call
+        FieldWithBarrier(uint32) lastInterpretedCount;
 
 #if DBG
         FieldWithBarrier(bool) initializedExecutionModeAndLimits : 1;

--- a/lib/Runtime/Base/FunctionExecutionStateMachine.h
+++ b/lib/Runtime/Base/FunctionExecutionStateMachine.h
@@ -11,6 +11,7 @@ namespace Js
     public:
         FunctionExecutionStateMachine();
         void InitializeExecutionModeAndLimits(FunctionBody* functionBody);
+        void ReinitializeExecutionModeAndLimits();
 
         // Public Getters and Setters
         ExecutionMode GetExecutionMode() const;

--- a/lib/Runtime/Base/FunctionExecutionStateMachine.h
+++ b/lib/Runtime/Base/FunctionExecutionStateMachine.h
@@ -10,6 +10,7 @@ namespace Js
     {
     public:
         FunctionExecutionStateMachine();
+        void InitializeExecutionModeAndLimits(FunctionBody* functionBody);
 
         // Public Getters and Setters
         ExecutionMode GetExecutionMode() const;
@@ -22,6 +23,8 @@ namespace Js
         uint32 SetInterpretedCount(uint32 val) { return interpretedCount = val; }
         uint32 IncreaseInterpretedCount() { return interpretedCount++; }
         uint16 GetSimpleJitExecutedIterations(FunctionBody* functionBody) const;
+        void SetFullJitThreshold(const uint16 newFullJitThreshold, FunctionBody* functionBody, const bool skipSimpleJit = false);
+        void SetSimpleJitCallCount(const uint16 simpleJitLimit, FunctionBody* functionBody) const;
 
 
         // Transition functions

--- a/lib/Runtime/Base/FunctionExecutionStateMachine.h
+++ b/lib/Runtime/Base/FunctionExecutionStateMachine.h
@@ -10,39 +10,41 @@ namespace Js
     {
     public:
         FunctionExecutionStateMachine();
-        void InitializeExecutionModeAndLimits(FunctionBody* functionBody);
-        void ReinitializeExecutionModeAndLimits(FunctionBody* functionBody);
+        void InitializeExecutionModeAndLimits();
+        void ReinitializeExecutionModeAndLimits();
 
         // Public Getters and Setters
         ExecutionMode GetExecutionMode() const;
         void SetExecutionMode(ExecutionMode mode); // This should eventually become private
-        ExecutionMode GetDefaultInterpreterExecutionMode(FunctionBody* functionBody) const;
-        ExecutionMode GetInterpreterExecutionMode(const bool isPostBailout, FunctionBody* functionBody);
+        ExecutionMode GetDefaultInterpreterExecutionMode() const;
+        ExecutionMode GetInterpreterExecutionMode(const bool isPostBailout);
         bool IsInterpreterExecutionMode() const;
 
         uint32 GetInterpretedCount() const { return interpretedCount; }
         uint32 SetInterpretedCount(uint32 val) { return interpretedCount = val; }
         uint32 IncreaseInterpretedCount() { return interpretedCount++; }
-        void CommitExecutedIterations(FunctionBody* functionBody);
+        void CommitExecutedIterations();
 
-        uint16 GetSimpleJitExecutedIterations(FunctionBody* functionBody) const;
-        void SetFullJitThreshold(const uint16 newFullJitThreshold, FunctionBody* functionBody, const bool skipSimpleJit = false);
-        void SetSimpleJitCallCount(const uint16 simpleJitLimit, FunctionBody* functionBody) const;
+        uint16 GetSimpleJitExecutedIterations() const;
+        void SetFullJitThreshold(const uint16 newFullJitThreshold, const bool skipSimpleJit = false);
+        void SetSimpleJitCallCount(const uint16 simpleJitLimit) const;
 
         // Transition functions
-        bool TryTransitionToNextExecutionMode(FunctionBody* functionBody);
-        void TryTransitionToNextInterpreterExecutionMode(FunctionBody* functionBody);
-        bool TryTransitionToJitExecutionMode(FunctionBody* functionBody);
-        void TransitionToSimpleJitExecutionMode(FunctionBody* functionBody);
-        void TransitionToFullJitExecutionMode(FunctionBody* functionBody);
+        bool TryTransitionToNextExecutionMode();
+        void TryTransitionToNextInterpreterExecutionMode();
+        bool TryTransitionToJitExecutionMode();
+        void TransitionToSimpleJitExecutionMode();
+        void TransitionToFullJitExecutionMode();
 
 
     private:
-        void VerifyExecutionMode(const ExecutionMode executionMode, FunctionBody* functionBody) const;
+        void VerifyExecutionMode(const ExecutionMode executionMode) const;
         void VerifyExecutionModeLimits() const;
         
         void CommitExecutedIterations(uint16 &limit, const uint executedIterations);
 
+        // This state machine should be a member of this owner FunctionBody
+        FunctionBody* owner;
 
         // Tracks the current execution mode. See ExecutionModes.h for more info.
         FieldWithBarrier(ExecutionMode) executionMode;

--- a/lib/Runtime/Base/FunctionExecutionStateMachine.h
+++ b/lib/Runtime/Base/FunctionExecutionStateMachine.h
@@ -14,6 +14,10 @@ namespace Js
         // Public Getters and Setters
         ExecutionMode GetExecutionMode() const;
         void SetExecutionMode(ExecutionMode mode); // This should eventually become private
+        ExecutionMode GetDefaultInterpreterExecutionMode(FunctionBody* functionBody) const;
+        ExecutionMode GetInterpreterExecutionMode(const bool isPostBailout, FunctionBody* functionBody);
+        bool IsInterpreterExecutionMode() const;
+
         uint32 GetInterpretedCount() const { return interpretedCount; }
         uint32 SetInterpretedCount(uint32 val) { return interpretedCount = val; }
         uint32 IncreaseInterpretedCount() { return interpretedCount++; }
@@ -21,12 +25,13 @@ namespace Js
 
         // Transition functions
         bool TryTransitionToNextExecutionMode(FunctionBody* functionBody);
+        void TryTransitionToNextInterpreterExecutionMode(FunctionBody* functionBody);
+
 
     private:
         void VerifyExecutionMode(const ExecutionMode executionMode, FunctionBody* functionBody) const;
         void VerifyExecutionModeLimits() const;
         void CommitExecutedIterations(uint16 &limit, const uint executedIterations);
-
 
 
         // Tracks the current execution mode. See ExecutionModes.h for more info.

--- a/lib/Runtime/Base/FunctionExecutionStateMachine.h
+++ b/lib/Runtime/Base/FunctionExecutionStateMachine.h
@@ -1,0 +1,21 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+#pragma once
+
+namespace Js
+{
+    class FunctionExecutionStateMachine
+    {
+    public:
+        FunctionExecutionStateMachine();
+
+        ExecutionMode GetExecutionMode() const;
+        void SetExecutionMode(ExecutionMode mode);
+
+    private:
+        // Tracks the current execution mode. See ExecutionModes.h for more info.
+        FieldWithBarrier(ExecutionMode) executionMode;
+    };
+};

--- a/lib/Runtime/ByteCode/ByteCodeSerializer.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeSerializer.cpp
@@ -3933,7 +3933,7 @@ public:
             // Read source information
             current = ReadSmallSpanSequence(current, &(*functionBody)->m_sourceInfo.pSpanSequence);
 
-            (*functionBody)->InitializeExecutionModeAndLimits();
+            (*functionBody)->executionState.InitializeExecutionModeAndLimits(*functionBody);
         }
 
         // Read lexically nested functions

--- a/lib/Runtime/ByteCode/ByteCodeSerializer.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeSerializer.cpp
@@ -3933,7 +3933,7 @@ public:
             // Read source information
             current = ReadSmallSpanSequence(current, &(*functionBody)->m_sourceInfo.pSpanSequence);
 
-            (*functionBody)->executionState.InitializeExecutionModeAndLimits(*functionBody);
+            (*functionBody)->executionState.InitializeExecutionModeAndLimits();
         }
 
         // Read lexically nested functions

--- a/lib/Runtime/ByteCode/ByteCodeSerializer.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeSerializer.cpp
@@ -3933,7 +3933,7 @@ public:
             // Read source information
             current = ReadSmallSpanSequence(current, &(*functionBody)->m_sourceInfo.pSpanSequence);
 
-            (*functionBody)->executionState.InitializeExecutionModeAndLimits();
+            (*functionBody)->executionState.InitializeExecutionModeAndLimits(*functionBody);
         }
 
         // Read lexically nested functions

--- a/lib/Runtime/Language/ExecutionModes.h
+++ b/lib/Runtime/Language/ExecutionModes.h
@@ -5,7 +5,7 @@
 
 // Non-profiling interpreter
 //     - For instance, it is used for NoNative mode
-//     - Does not transition to other execution modes
+//     - Can only transition to FullJIT
 EXECUTION_MODE(Interpreter)
 
 // Auto-profiling interpreter


### PR DESCRIPTION
Introduce FunctionExecutionStateMachine

This change refactors all code from FunctionBody that controls how the function is executed (i.e., interpreted, profiling, JIT, etc.) into a separate, specialized class.
No functionality impact expected. No measured perf impact.