### PR TITLE
Correct exception specification mismatch in Memory::Recycler::AddMark

### DIFF
--- a/lib/Common/Memory/Recycler.h
+++ b/lib/Common/Memory/Recycler.h
@@ -1574,9 +1574,9 @@ private:
     inline void ScanMemoryInline(void ** obj, size_t byteCount);
     template <bool doSpecialMark>
     void ScanMemory(void ** obj, size_t byteCount) { if (byteCount != 0) { ScanMemoryInline<doSpecialMark>(obj, byteCount); } }
-    bool AddMark(void * candidate, size_t byteCount);
+    bool AddMark(void * candidate, size_t byteCount) throw();
 #ifdef RECYCLER_VISITED_HOST
-    bool AddPreciselyTracedMark(IRecyclerVisitedObject * candidate);
+    bool AddPreciselyTracedMark(IRecyclerVisitedObject * candidate) throw();
 #endif
 
     // Sweep


### PR DESCRIPTION
Memory::Recycler::AddMark() is declared with no exception specification
but defined as `throw()`. Upcoming versions of MSVC will diagnose this
mismatch in /permissive- or C++17 modes. Add `throw()` to the
declaration to bring the declaration in line with the definition.

Fixes #3862