### PR TITLE
Unblock CI

### DIFF
--- a/bin/ch/Helpers.cpp
+++ b/bin/ch/Helpers.cpp
@@ -203,6 +203,8 @@ HRESULT Helpers::LoadScriptFromFile(LPCSTR filename, LPCSTR& contents, UINT* len
             if (bufferLength > 2)
             {
                 __analysis_assume(bufferLength > 2);
+#pragma prefast(push)
+#pragma prefast(disable:6385, "PREfast incorrectly reports this as an out-of-bound access.");
                 if ((pRawBytes[0] == 0xFE && pRawBytes[1] == 0xFF) ||
                     (pRawBytes[0] == 0xFF && pRawBytes[1] == 0xFE) ||
                     (bufferLength > 4 && pRawBytes[0] == 0x00 && pRawBytes[1] == 0x00 &&
@@ -214,6 +216,7 @@ HRESULT Helpers::LoadScriptFromFile(LPCSTR filename, LPCSTR& contents, UINT* len
                     fwprintf(stderr, _u("unsupported file encoding. Only ANSI and UTF8 supported"));
                     IfFailGo(E_UNEXPECTED);
                 }
+#pragma prefast(pop)
             }
         }
     }

--- a/bin/ch/Helpers.cpp
+++ b/bin/ch/Helpers.cpp
@@ -202,6 +202,7 @@ HRESULT Helpers::LoadScriptFromFile(LPCSTR filename, LPCSTR& contents, UINT* len
             C_ASSERT(sizeof(WCHAR) == 2);
             if (bufferLength > 2)
             {
+                __analysis_assume(bufferLength > 2);
                 if ((pRawBytes[0] == 0xFE && pRawBytes[1] == 0xFF) ||
                     (pRawBytes[0] == 0xFF && pRawBytes[1] == 0xFE) ||
                     (bufferLength > 4 && pRawBytes[0] == 0x00 && pRawBytes[1] == 0x00 &&

--- a/build.sh
+++ b/build.sh
@@ -496,53 +496,57 @@ BUILD_RELATIVE_DIRECTORY=$(python -c "import os.path;print \
 ################# Write-barrier check/analyze run #################
 WB_FLAG=
 WB_TARGET=
-if [[ $WB_CHECK || $WB_ANALYZE ]]; then
-    # build software write barrier checker clang plugin
-    $CHAKRACORE_DIR/tools/RecyclerChecker/build.sh --cxx=$_CXX || exit 1
 
-    if [[ $WB_CHECK && $WB_ANALYZE ]]; then
-        echo "Please run only one of --wb-check or --wb-analyze" && exit 1
-    fi
-    if [[ $WB_CHECK ]]; then
-        WB_FLAG="-DWB_CHECK_SH=1"
-        WB_FILE=$WB_CHECK
-    fi
-    if [[ $WB_ANALYZE ]]; then
-        WB_FLAG="-DWB_ANALYZE_SH=1"
-        WB_FILE=$WB_ANALYZE
-    fi
+# TODO SOON: demorri!
+# re-enable when CI has the libclang-dev libraries installed again
 
-    if [[ $WB_ARGS ]]; then
-        if [[ $WB_ARGS =~ "-fix" ]]; then
-            MULTICORE_BUILD="-j 1"  # 1 job only if doing write barrier fix
-        fi
-        WB_ARGS="-DWB_ARGS_SH=$WB_ARGS"
-    fi
-
-    # support --wb-check ONE_CPP_FILE
-    if [[ $WB_FILE != "*" ]]; then
-        if [[ $MAKE != 'ninja' ]]; then
-            echo "--wb-check/wb-analyze ONE_FILE only works with --ninja" && exit 1
-        fi
-
-        if [[ -f $CHAKRACORE_DIR/$WB_FILE ]]; then
-            touch $CHAKRACORE_DIR/$WB_FILE
-        else
-            echo "$CHAKRACORE_DIR/$WB_FILE not found. Please use full git path for $WB_FILE." && exit 1
-        fi
-
-        WB_FILE_DIR=`dirname $WB_FILE`
-        WB_FILE_BASE=`basename $WB_FILE`
-
-        WB_FILE_CMAKELISTS="$CHAKRACORE_DIR/$WB_FILE_DIR/CMakeLists.txt"
-        if [[ -f $WB_FILE_CMAKELISTS ]]; then
-            SUBDIR=$(grep -i add_library $WB_FILE_CMAKELISTS | sed "s/.*(\([^ ]*\) .*/\1/")
-        else
-            echo "$WB_FILE_CMAKELISTS not found." && exit 1
-        fi
-        WB_TARGET="$WB_FILE_DIR/CMakeFiles/$SUBDIR.dir/$WB_FILE_BASE.o"
-    fi
-fi
+#if [[ $WB_CHECK || $WB_ANALYZE ]]; then
+#    # build software write barrier checker clang plugin
+#    $CHAKRACORE_DIR/tools/RecyclerChecker/build.sh --cxx=$_CXX || exit 1
+#
+#    if [[ $WB_CHECK && $WB_ANALYZE ]]; then
+#        echo "Please run only one of --wb-check or --wb-analyze" && exit 1
+#    fi
+#    if [[ $WB_CHECK ]]; then
+#        WB_FLAG="-DWB_CHECK_SH=1"
+#        WB_FILE=$WB_CHECK
+#    fi
+#    if [[ $WB_ANALYZE ]]; then
+#        WB_FLAG="-DWB_ANALYZE_SH=1"
+#        WB_FILE=$WB_ANALYZE
+#    fi
+#
+#    if [[ $WB_ARGS ]]; then
+#        if [[ $WB_ARGS =~ "-fix" ]]; then
+#            MULTICORE_BUILD="-j 1"  # 1 job only if doing write barrier fix
+#        fi
+#        WB_ARGS="-DWB_ARGS_SH=$WB_ARGS"
+#    fi
+#
+#    # support --wb-check ONE_CPP_FILE
+#    if [[ $WB_FILE != "*" ]]; then
+#        if [[ $MAKE != 'ninja' ]]; then
+#            echo "--wb-check/wb-analyze ONE_FILE only works with --ninja" && exit 1
+#        fi
+#
+#        if [[ -f $CHAKRACORE_DIR/$WB_FILE ]]; then
+#            touch $CHAKRACORE_DIR/$WB_FILE
+#        else
+#            echo "$CHAKRACORE_DIR/$WB_FILE not found. Please use full git path for $WB_FILE." && exit 1
+#        fi
+#
+#        WB_FILE_DIR=`dirname $WB_FILE`
+#        WB_FILE_BASE=`basename $WB_FILE`
+#
+#        WB_FILE_CMAKELISTS="$CHAKRACORE_DIR/$WB_FILE_DIR/CMakeLists.txt"
+#        if [[ -f $WB_FILE_CMAKELISTS ]]; then
+#            SUBDIR=$(grep -i add_library $WB_FILE_CMAKELISTS | sed "s/.*(\([^ ]*\) .*/\1/")
+#        else
+#            echo "$WB_FILE_CMAKELISTS not found." && exit 1
+#        fi
+#        WB_TARGET="$WB_FILE_DIR/CMakeFiles/$SUBDIR.dir/$WB_FILE_BASE.o"
+#    fi
+#fi
 
 # prepare DbgController.js.h
 CH_DIR="${CHAKRACORE_DIR}/bin/ch"

--- a/lib/Parser/RegexParser.cpp
+++ b/lib/Parser/RegexParser.cpp
@@ -755,6 +755,9 @@ namespace UnifiedRegex
             else if (next->tag == Node::Alt)
             {
                 AltNode* nextList = (AltNode*)next;
+                // Since we just had to dereference next to get here, we know that nextList
+                // can't be nullptr in this case.
+                AnalysisAssert(nextList != nullptr);
                 // Append inner list to current list
                 revisedPrev = UnionNodes(last == 0 ? node : last->head, nextList->head);
                 if (revisedPrev != 0)
@@ -982,11 +985,17 @@ namespace UnifiedRegex
                     last->head = FinalTerm(last->head, &deferredLiteralNode);
                     last->tail = nextList;
                 }
+                // NextList can't be nullptr, since it was last set as next, which
+                // was dereferenced, or it was set on a path that already has this
+                // analysis assert.
+                AnalysisAssert(nextList != nullptr);
                 while (nextList->tail != 0)
                     nextList = nextList->tail;
                 last = nextList;
                 // No outstanding literals
                 Assert(deferredLiteralNode.length == 0);
+                // We just set this from nextList, which we know is not nullptr.
+                AnalysisAssert(last != nullptr);
                 if (last->head->LiteralLength() > 0)
                 {
                     // If the list ends with a literal, transfer it into deferredLiteralNode

--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -54,17 +54,6 @@ void DefaultInitializeAdditionalProperties(ThreadContext *threadContext)
  */
 void (*InitializeAdditionalProperties)(ThreadContext *threadContext) = DefaultInitializeAdditionalProperties;
 
-// To make sure the marker function doesn't get inlined, optimized away, or merged with other functions we disable optimization.
-// If this method ends up causing a perf problem in the future, we should replace it with asm versions which should be lighter.
-#pragma optimize("g", off)
-_NOINLINE extern "C" void* MarkerForExternalDebugStep()
-{
-    // We need to return something here to prevent this function from being merged with other empty functions by the linker.
-    static int __dummy;
-    return &__dummy;
-}
-#pragma optimize("", on)
-
 CriticalSection ThreadContext::s_csThreadContext;
 size_t ThreadContext::processNativeCodeSize = 0;
 ThreadContext * ThreadContext::globalListFirst = nullptr;

--- a/lib/Runtime/Base/ThreadContext.h
+++ b/lib/Runtime/Base/ThreadContext.h
@@ -82,12 +82,6 @@ protected:
     bool isDisabled;
 };
 
-// This function is called before we step out of script (currently only for WinRT callout).
-// Debugger would put a breakpoint on this function if they want to detect the point at which we step
-// over the boundary.
-// It is intentionally left blank and the next operation should be the callout.
-extern "C" void* MarkerForExternalDebugStep();
-
 #define PROBE_STACK(scriptContext, size) ((scriptContext)->GetThreadContext()->ProbeStack(size, scriptContext))
 #define PROBE_STACK_NO_DISPOSE(scriptContext, size) ((scriptContext)->GetThreadContext()->ProbeStackNoDispose(size, scriptContext))
 #define PROBE_STACK_PARTIAL_INITIALIZED_INTERPRETER_FRAME(scriptContext, size) ((scriptContext)->GetThreadContext()->ProbeStack(size, scriptContext, _ReturnAddress()))

--- a/tools/RecyclerChecker/cmake/modules/FindLLVM.cmake
+++ b/tools/RecyclerChecker/cmake/modules/FindLLVM.cmake
@@ -19,6 +19,7 @@ if(NOT LLVM_INCLUDE_DIR)
     PATHS
     /opt/local/bin
     /usr/lib/llvm-3.8/bin     # Ubuntu
+    /usr/lib/llvm-3.9/bin     # Ubuntu
     /usr/local/opt/llvm/bin   # OSX brew install path
   )
 


### PR DESCRIPTION
## Remove MarkerForExternalDebugStep

This was previously used in the hybrid debugging scenario (VS would
set a breakpoint on this function, which was hard to inline). Since
this is no longer supported, we can remove this function.

## Add analysis asserts to silence false positives

Prefast started warning on some false positives. This silences them.

## Pull in Jimmy's changes to fix xplat CI

Xplat build machines now have clang3.9, we need to support that.
