### PR TITLE
Remove support for VS2013 (dev12)

### DIFF
--- a/Build/Chakra.Core.sln
+++ b/Build/Chakra.Core.sln
@@ -2,7 +2,7 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26228.4
-MinimumVisualStudioVersion = 10.0.40219.1
+MinimumVisualStudioVersion = 14.0.00000.0
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ChakraCore", "..\bin\ChakraCore\ChakraCore.vcxproj", "{EA882C8D-81FC-42FE-ABD5-2666DB933FDB}"
 	ProjectSection(ProjectDependencies) = postProject
 		{1876E800-AD77-48C4-A2F7-E5265F24AC38} = {1876E800-AD77-48C4-A2F7-E5265F24AC38}

--- a/netci.groovy
+++ b/netci.groovy
@@ -18,7 +18,6 @@ def msbuildTypeMap = [
 
 // convert `machine` parameter to OS component of PR task name
 def machineTypeToOSTagMap = [
-    'Windows 7': 'Windows 7',       // Windows Server 2008 R2, equivalent to Windows 7
     'Windows_NT': 'Windows',        // Windows Server 2012 R2, equivalent to Windows 8.1 (aka Blue)
     'Ubuntu16.04': 'Ubuntu',
     'OSX': 'OSX'
@@ -234,23 +233,12 @@ CreateBuildTask(true, 'x64', 'debug',
 // x64_debug Lite
 CreateBuildTask(true, 'x64', 'debug',
     'Windows_NT', 'ci_lite', '"/p:BuildLite=true"', '-winBlue -lite', false, null, null)
-// x64_debug Legacy
-CreateBuildTask(true, 'x64', 'debug',
-    'Windows 7', 'ci_dev12', 'msbuild12', '-win7 -includeSlow', false, null, null)
 
 // -----------------
 // DAILY BUILD TASKS
 // -----------------
 
 if (!branch.endsWith('-ci')) {
-    // build and test on Windows 7 with VS 2013 (Dev12/MsBuild12)
-    CreateBuildTasks('Windows 7', 'daily_dev12', 'msbuild12', '-win7 -includeSlow', false,
-        /* excludeConfigIf */ { isPR, buildArch, buildType -> (buildArch == 'arm') },
-        /* nonDefaultTaskSetup */ { newJob, isPR, config ->
-            DailyBuildTaskSetup(newJob, isPR,
-                "Windows 7 ${config}",
-                '(dev12|legacy)\\s+tests')})
-
     // build and test on the usual configuration (VS 2015) with -includeSlow
     CreateBuildTasks('Windows_NT', 'daily_slow', null, '-winBlue -includeSlow', false,
         /* excludeConfigIf */ null,


### PR DESCRIPTION
This change removes support for Visual Studio 2013. Doing this will
afford us the use of a much wider set of constructs in C++, as more
recent versions of Visual Studio provide full support for C++11.

I'm going to leave this PR open for a week (at least) to invite any
comments about the change that may be out there.

Note: Although this change is to move to support C++11, we could be
a C++14 code base with little extra effort; our minimum versions of
clang (3.9) and VS (dev14) are both sufficient for C++14 support. I
think the only thing holding that back is that we may want to allow
a 4.9 version of GCC.
