### PR TITLE
Fixing an issue with duplicate let definition of a destructured catch param

### DIFF
--- a/test/es6/destructuring_catch.js
+++ b/test/es6/destructuring_catch.js
@@ -59,6 +59,28 @@ var tests = [
         }
         assert.areEqual(x, undefined, "Assignment inside the catch block should assign the value to the catch param not the body var");
       })();
+
+      (function () {
+        let y = 1;
+        try {
+            throw { y : 10 };
+        } catch ({y}) {
+            assert.areEqual(y, 10, "Catch block refers to the destructured param");
+        }
+        assert.areEqual(y, 1, "Function body refers to the let variable");
+      })();
+    
+      (function () {
+        let x = 1;
+        try {
+            throw [{ x : 10 }];
+        } catch ([{
+            x
+        }]) {
+            assert.areEqual(x, 10, "Catch block with nested destructured param");
+        }
+        assert.areEqual(x, 1, "Let declaration in the function body is not affected by the destructured params");
+      })();
     }
   },
   {


### PR DESCRIPTION
The destructured catch param are let bindings. Any duplicate definition of them inside the catch block is an error. So when assigning registers we don't have to look for duplicate symbols in the function body.
