### PR TITLE
Defer destructured params if the parent function is getting deferred

### DIFF
--- a/lib/Parser/Parse.h
+++ b/lib/Parser/Parse.h
@@ -491,6 +491,7 @@ private:
             case knopLetDecl:
             case knopFncDecl:
             case knopName:
+            case knopParamPattern:
                 return true;
 
             default:
@@ -925,6 +926,7 @@ private:
     BOOL IsConstantInArrayLiteral(ParseNodePtr pnode);
 
     ParseNodePtr CreateParamPatternNode(ParseNodePtr pnode1);
+    ParseNodePtr CreateDummyParamPatternNode(charcount_t ichMin);
 
     ParseNodePtr ConvertMemberToMemberPattern(ParseNodePtr pnodeMember);
     ParseNodePtr ConvertObjectToObjectPattern(ParseNodePtr pnodeMemberList);

--- a/test/es6/destructuring_params.js
+++ b/test/es6/destructuring_params.js
@@ -104,6 +104,8 @@ var tests = [
 
       assert.doesNotThrow(function () { eval("function foo({x1:[y1 = 1] = [2]} = {x1:[3]}) {}"); },   "Object destructuring pattern has default and nesting array pattern which has initializer is valid syntax");
       assert.doesNotThrow(function () { eval("function foo([{y1:y1 = 1} = {y1:2}] = [{y1:3}]) {}"); },   "Array destructuring pattern has default and nesting object pattern which has initializer is valid syntax");
+
+      assert.doesNotThrow(function () { eval("function foo([a] = class c extends eval(''){}) {}"); }, "Top level function getting deferred causes deferal of param scope functions too");
     }
   },
   {

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -907,6 +907,12 @@
   </test>
   <test>
     <default>
+      <files>destructuring_params.js</files>
+      <compile-flags>-force:deferparse -args summary -endargs</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>destructuring_params_arguments_override.js</files>
     </default>
   </test>


### PR DESCRIPTION
Following up on the PR https://github.com/Microsoft/ChakraCore/pull/3610/files, this change addresses the same issue for destructured params. When parent function is deferred the destructured params should also get the deferred parse flag. In this case we are creating a dummy node for the pattern as the param count is needed for function length calculation.

Note: The change in StartEmit function is to do the scope slot allocation logic for the params only after the function is parsed. The scopes needs to be pushed to the stack in both cases.
