### PR TITLE
Re-enable RecyclerChecker runs

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -497,56 +497,53 @@ BUILD_RELATIVE_DIRECTORY=$(python -c "import os.path;print \
 WB_FLAG=
 WB_TARGET=
 
-# TODO SOON: demorri!
-# re-enable when CI has the libclang-dev libraries installed again
+if [[ $WB_CHECK || $WB_ANALYZE ]]; then
+    # build software write barrier checker clang plugin
+    $CHAKRACORE_DIR/tools/RecyclerChecker/build.sh --cxx=$_CXX || exit 1
 
-#if [[ $WB_CHECK || $WB_ANALYZE ]]; then
-#    # build software write barrier checker clang plugin
-#    $CHAKRACORE_DIR/tools/RecyclerChecker/build.sh --cxx=$_CXX || exit 1
-#
-#    if [[ $WB_CHECK && $WB_ANALYZE ]]; then
-#        echo "Please run only one of --wb-check or --wb-analyze" && exit 1
-#    fi
-#    if [[ $WB_CHECK ]]; then
-#        WB_FLAG="-DWB_CHECK_SH=1"
-#        WB_FILE=$WB_CHECK
-#    fi
-#    if [[ $WB_ANALYZE ]]; then
-#        WB_FLAG="-DWB_ANALYZE_SH=1"
-#        WB_FILE=$WB_ANALYZE
-#    fi
-#
-#    if [[ $WB_ARGS ]]; then
-#        if [[ $WB_ARGS =~ "-fix" ]]; then
-#            MULTICORE_BUILD="-j 1"  # 1 job only if doing write barrier fix
-#        fi
-#        WB_ARGS="-DWB_ARGS_SH=$WB_ARGS"
-#    fi
-#
-#    # support --wb-check ONE_CPP_FILE
-#    if [[ $WB_FILE != "*" ]]; then
-#        if [[ $MAKE != 'ninja' ]]; then
-#            echo "--wb-check/wb-analyze ONE_FILE only works with --ninja" && exit 1
-#        fi
-#
-#        if [[ -f $CHAKRACORE_DIR/$WB_FILE ]]; then
-#            touch $CHAKRACORE_DIR/$WB_FILE
-#        else
-#            echo "$CHAKRACORE_DIR/$WB_FILE not found. Please use full git path for $WB_FILE." && exit 1
-#        fi
-#
-#        WB_FILE_DIR=`dirname $WB_FILE`
-#        WB_FILE_BASE=`basename $WB_FILE`
-#
-#        WB_FILE_CMAKELISTS="$CHAKRACORE_DIR/$WB_FILE_DIR/CMakeLists.txt"
-#        if [[ -f $WB_FILE_CMAKELISTS ]]; then
-#            SUBDIR=$(grep -i add_library $WB_FILE_CMAKELISTS | sed "s/.*(\([^ ]*\) .*/\1/")
-#        else
-#            echo "$WB_FILE_CMAKELISTS not found." && exit 1
-#        fi
-#        WB_TARGET="$WB_FILE_DIR/CMakeFiles/$SUBDIR.dir/$WB_FILE_BASE.o"
-#    fi
-#fi
+    if [[ $WB_CHECK && $WB_ANALYZE ]]; then
+        echo "Please run only one of --wb-check or --wb-analyze" && exit 1
+    fi
+    if [[ $WB_CHECK ]]; then
+        WB_FLAG="-DWB_CHECK_SH=1"
+        WB_FILE=$WB_CHECK
+    fi
+    if [[ $WB_ANALYZE ]]; then
+        WB_FLAG="-DWB_ANALYZE_SH=1"
+        WB_FILE=$WB_ANALYZE
+    fi
+
+    if [[ $WB_ARGS ]]; then
+        if [[ $WB_ARGS =~ "-fix" ]]; then
+            MULTICORE_BUILD="-j 1"  # 1 job only if doing write barrier fix
+        fi
+        WB_ARGS="-DWB_ARGS_SH=$WB_ARGS"
+    fi
+
+    # support --wb-check ONE_CPP_FILE
+    if [[ $WB_FILE != "*" ]]; then
+        if [[ $MAKE != 'ninja' ]]; then
+            echo "--wb-check/wb-analyze ONE_FILE only works with --ninja" && exit 1
+        fi
+
+        if [[ -f $CHAKRACORE_DIR/$WB_FILE ]]; then
+            touch $CHAKRACORE_DIR/$WB_FILE
+        else
+            echo "$CHAKRACORE_DIR/$WB_FILE not found. Please use full git path for $WB_FILE." && exit 1
+        fi
+
+        WB_FILE_DIR=`dirname $WB_FILE`
+        WB_FILE_BASE=`basename $WB_FILE`
+
+        WB_FILE_CMAKELISTS="$CHAKRACORE_DIR/$WB_FILE_DIR/CMakeLists.txt"
+        if [[ -f $WB_FILE_CMAKELISTS ]]; then
+            SUBDIR=$(grep -i add_library $WB_FILE_CMAKELISTS | sed "s/.*(\([^ ]*\) .*/\1/")
+        else
+            echo "$WB_FILE_CMAKELISTS not found." && exit 1
+        fi
+        WB_TARGET="$WB_FILE_DIR/CMakeFiles/$SUBDIR.dir/$WB_FILE_BASE.o"
+    fi
+fi
 
 # prepare DbgController.js.h
 CH_DIR="${CHAKRACORE_DIR}/bin/ch"


### PR DESCRIPTION
I disabled this because doing so worked around widespread CI failures
(due to the lack of libclang-dev on the new images). This commit does
the opposite and re-enables it, for when the package is available.
