### PR TITLE
cleanup unit tests for arm64 with nonative

### DIFF
--- a/test/Array/rlexe.xml
+++ b/test/Array/rlexe.xml
@@ -624,7 +624,7 @@
   <test>
     <default>
       <files>CopyOnAccessArray_cache_index_overflow.js</files>
-      <tags>BugFix,require_backend,exclude_forceserialized</tags>
+      <tags>BugFix,exclude_nonative,exclude_forceserialized</tags>
       <compile-flags>-force:copyonaccessarray -testtrace:CopyOnAccessArray</compile-flags>
       <baseline>CopyOnAccessArray_cache_index_overflow.baseline</baseline>
     </default>

--- a/test/Array/rlexe.xml
+++ b/test/Array/rlexe.xml
@@ -624,7 +624,7 @@
   <test>
     <default>
       <files>CopyOnAccessArray_cache_index_overflow.js</files>
-      <tags>BugFix,exclude_nonative,exclude_forceserialized</tags>
+      <tags>BugFix,exclude_nonative,exclude_forceserialized,require_backend</tags>
       <compile-flags>-force:copyonaccessarray -testtrace:CopyOnAccessArray</compile-flags>
       <baseline>CopyOnAccessArray_cache_index_overflow.baseline</baseline>
     </default>

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -217,7 +217,7 @@
   <test>
     <default>
       <files>fabs1.js</files>
-      <tags>exclude_dynapogo,require_backend</tags>
+      <tags>exclude_dynapogo,require_backend,exclude_arm,exclude_arm64</tags>
       <compile-flags>-off:backend -asmjs -testtrace:asmjs</compile-flags>
       <baseline>fabs1.baseline</baseline>
     </default>

--- a/test/Function/rlexe.xml
+++ b/test/Function/rlexe.xml
@@ -321,7 +321,7 @@
       <files>FuncBody.bug231397.js</files>
       <baseline>FuncBody.bug231397.baseline</baseline>
       <compile-flags>-dump:bytecode</compile-flags>
-      <tags>exclude_bytecodelayout,exclude_fre,require_backend</tags>
+      <tags>exclude_bytecodelayout,exclude_fre,exclude_nonative</tags>
     </default>
   </test>
   <test>
@@ -427,7 +427,7 @@
     <default>
       <files>failnativecodeinstall.js</files>
       <compile-flags>-maxinterpretcount:2 -lic:1 -bgjit -off:simplejit -on:failnativecodeinstall</compile-flags>
-      <tags>exclude_dynapogo,require_backend</tags>
+      <tags>exclude_dynapogo,exclude_nonative</tags>
       <baseline>failnativecodeinstall.baseline</baseline>
     </default>
   </test>

--- a/test/Function/rlexe.xml
+++ b/test/Function/rlexe.xml
@@ -321,7 +321,7 @@
       <files>FuncBody.bug231397.js</files>
       <baseline>FuncBody.bug231397.baseline</baseline>
       <compile-flags>-dump:bytecode</compile-flags>
-      <tags>exclude_bytecodelayout,exclude_fre,exclude_nonative</tags>
+      <tags>exclude_bytecodelayout,exclude_fre,exclude_nonative,require_backend</tags>
     </default>
   </test>
   <test>
@@ -427,7 +427,7 @@
     <default>
       <files>failnativecodeinstall.js</files>
       <compile-flags>-maxinterpretcount:2 -lic:1 -bgjit -off:simplejit -on:failnativecodeinstall</compile-flags>
-      <tags>exclude_dynapogo,exclude_nonative</tags>
+      <tags>exclude_dynapogo,exclude_nonative,require_backend</tags>
       <baseline>failnativecodeinstall.baseline</baseline>
     </default>
   </test>

--- a/test/Optimizer/rlexe.xml
+++ b/test/Optimizer/rlexe.xml
@@ -1020,7 +1020,7 @@
       <baseline>test143.baseline</baseline>
       <compile-flags>-bgJit- -off:simpleJit -loopInterpretCount:1 -testTrace:arrayCheckHoist</compile-flags>
       <!-- ch.exe doesn't output entire baseline before exiting; -testTrace flush issue? -->
-      <tags>exclude_dynapogo,exclude_forceserialized</tags>
+      <tags>exclude_dynapogo,exclude_forceserialized,exclude_nonative</tags>
     </default>
   </test>
   <test>
@@ -1242,7 +1242,7 @@
       <files>BoundCheckElimination.js</files>
       <baseline>BoundCheckElimination.baseline</baseline>
       <compile-flags>-bgJit- -minInterpretCount:1 -maxInterpretCount:1 -off:simpleJit -off:bailOnNoProfile -testTrace:boundCheckElimination -testTrace:boundCheckHoist</compile-flags>
-      <tags>exclude_dynapogo,exclude_serialized,exclude_default</tags>
+      <tags>exclude_dynapogo,exclude_serialized,exclude_default,exclude_nonative</tags>
     </default>
   </test>
   <test>

--- a/test/PerfHint/rlexe.xml
+++ b/test/PerfHint/rlexe.xml
@@ -5,7 +5,7 @@
       <files>try_with_eval_perfhint.js</files>
       <baseline>try_with_eval_perfhint.baseline</baseline>
       <compile-flags>-oopjit- -trace:PerfHint -off:simplejit</compile-flags>
-      <tags>exclude_dynapogo</tags>
+      <tags>exclude_dynapogo,exclude_nonative</tags>
     </default>
   </test>
   <test>
@@ -13,7 +13,7 @@
       <files>try_with_eval_perfhint.js</files>
       <baseline>try_with_eval_perfhint_l2.baseline</baseline>
       <compile-flags>-oopjit- -trace:PerfHint -off:simplejit -perfhintlevel:2</compile-flags>
-      <tags>exclude_dynapogo</tags>
+      <tags>exclude_dynapogo,exclude_nonative</tags>
     </default>
   </test>
   <test>
@@ -21,7 +21,7 @@
       <files>arguments1.js</files>
       <baseline>arguments1.baseline</baseline>
       <compile-flags>-oopjit- -trace:PerfHint -off:simplejit</compile-flags>
-      <tags>exclude_dynapogo</tags>
+      <tags>exclude_dynapogo,exclude_nonative</tags>
     </default>
   </test>
   <test>
@@ -29,7 +29,7 @@
       <files>polymorphictest.js</files>
       <baseline>polymorphictest.baseline</baseline>
       <compile-flags>-oopjit- -trace:PerfHint -off:simplejit</compile-flags>
-      <tags>exclude_dynapogo</tags>
+      <tags>exclude_dynapogo,exclude_nonative</tags>
     </default>
   </test>
 </regress-exe>

--- a/test/inlining/rlexe.xml
+++ b/test/inlining/rlexe.xml
@@ -139,6 +139,7 @@
       <files>bug515849.js</files>
       <baseline>bug515849.baseline</baseline>
       <compile-flags>-minInterpretCount:1 -maxInterpretCount:1 -msjrc:0 -force:inline</compile-flags>
+      <tags>exclude_arm64</tags>
     </default>
   </test>
   <test>

--- a/test/stackfunc/rlexe.xml
+++ b/test/stackfunc/rlexe.xml
@@ -594,7 +594,7 @@
       <files>funcexpr_2.js</files>
       <baseline>funcexpr_2.deferparse.native.baseline</baseline>
       <compile-flags>-testtrace:stackfunc -off:redeferral -on:stackfunc -force:deferparse -forceNative -off:simpleJit -off:disablestackfuncondeferredescape</compile-flags>
-      <tags>exclude_fre,exclude_dynapogo,exclude_arm</tags>
+      <tags>exclude_fre,exclude_dynapogo,exclude_arm,exclude_nonative</tags>
     </default>
   </test>
   <test>

--- a/test/typedarray/rlexe.xml
+++ b/test/typedarray/rlexe.xml
@@ -95,6 +95,7 @@
       <files>dataview.js</files>
       <baseline>dataview.baseline</baseline>
       <tags>typedarray</tags>
+      <timeout>300</timeout>
     </default>
   </test>
   <test>
@@ -136,6 +137,7 @@
       <files>samethread.js</files>
       <baseline>samethread.baseline</baseline>
       <tags>typedarray</tags>
+      <timeout>300</timeout>
     </default>
   </test>
   <!--
@@ -334,6 +336,7 @@ Below test fails with difference in space. Investigate the cause and re-enable t
   <test>
     <default>
       <files>reentry1.js</files>
+      <timeout>300</timeout>
     </default>
   </test>
   <test>


### PR DESCRIPTION
A few tests that expect jitted code and needed exclude_nonative were using require_backend or had nothing to disable the tests.

One test was for asmjs which is not currently compiled for arm or arm64.

One test was hitting stack overflow, which seems to happen at a lower threashold on arm64.

A few slower tests were timing out before completing.
