### PR TITLE
CrossSite: Fix property check

### DIFF
--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -1756,7 +1756,19 @@ CommonNumber:
                 Var property;
                 if (dynamicTypeHandler->CheckFixedProperty(requestContext->GetPropertyName(propertyId), &property, requestContext))
                 {
-                    Assert(value == nullptr || *value == property);
+                    bool skipAssert = false;
+                    if (value != nullptr && Js::RecyclableObject::Is(property))
+                    {
+                        Js::RecyclableObject* pObject = Js::RecyclableObject::FromVar(property);
+                        Js::RecyclableObject* pValue = Js::RecyclableObject::FromVar(*value);
+
+                        if (pValue->GetScriptContext() != pObject->GetScriptContext())
+                        {
+                            // value was marshaled. skip check
+                            skipAssert = true;
+                        }
+                    }
+                    Assert(skipAssert || value == nullptr || *value == property);
                 }
             }
 #endif


### PR DESCRIPTION
Recent improvements, CC marshals less but does more precisely. This particular DBG check wasn't considering that the `value` could be marshaled.