### PR TITLE
keep the toolchain path from android-configure 

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -273,17 +273,22 @@ while [[ $# -gt 0 ]]; do
         _TARGET_OS="${_TARGET_OS:9}"
         if [[ $_TARGET_OS =~ "android" ]]; then
             OLD_PATH=$PATH
-            export TOOLCHAIN=$PWD/android-toolchain-arm
+            if [[ -z "$TOOLCHAIN" ]]; then
+                export TOOLCHAIN=$PWD/android-toolchain-arm
+                export PATH=$TOOLCHAIN/bin:$OLD_PATH
+                export AR=arm-linux-androideabi-ar
+                export CC=arm-linux-androideabi-clang
+                export CXX=arm-linux-androideabi-clang++
+                export LINK=arm-linux-androideabi-clang++
+                export STRIP=arm-linux-androideabi-strip
+                # override CXX and CC
+                _CXX="${TOOLCHAIN}/bin/${CXX}"
+                _CC="${TOOLCHAIN}/bin/${CC}"
+            fi
             TARGET_OS="-DCC_TARGET_OS_ANDROID_SH=1 -DANDROID_TOOLCHAIN_DIR=${TOOLCHAIN}/arm-linux-androideabi"
-            export PATH=$TOOLCHAIN/bin:$OLD_PATH
-            export AR=arm-linux-androideabi-ar
-            export CC=arm-linux-androideabi-clang
-            export CXX=arm-linux-androideabi-clang++
-            export LINK=arm-linux-androideabi-clang++
-            export STRIP=arm-linux-androideabi-strip
-            # override CXX and CC
-            _CXX="${TOOLCHAIN}/bin/${CXX}"
-            _CC="${TOOLCHAIN}/bin/${CC}"
+            # inherit CXX and CC
+            _CXX="${CXX}"
+            _CC="${CC}"
         fi
         ;;
 

--- a/build.sh
+++ b/build.sh
@@ -272,8 +272,8 @@ while [[ $# -gt 0 ]]; do
         _TARGET_OS=$1
         _TARGET_OS="${_TARGET_OS:9}"
         if [[ $_TARGET_OS =~ "android" ]]; then
-            OLD_PATH=$PATH
             if [[ -z "$TOOLCHAIN" ]]; then
+                OLD_PATH=$PATH
                 export TOOLCHAIN=$PWD/android-toolchain-arm
                 export PATH=$TOOLCHAIN/bin:$OLD_PATH
                 export AR=arm-linux-androideabi-ar


### PR DESCRIPTION
node's [android-configure](https://github.com/nodejs/node-chakracore/blob/master/android-configure#L50) script had set the $TOOLCHAIN to the right path and exported the needed variables.

only configure toolchain path when $TOOLCHAIN is undefined.