### PR TITLE
Fix OS: 13988805 AsmJs error triggers syntax error on reparse assert

### DIFF
--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -2171,7 +2171,12 @@ namespace Js
             case VBSERR_OutOfStack:
                 hrMapped = VBSERR_OutOfStack;
                 break;
+
+            case JSERR_AsmJsCompileError:
+                hrMapped = JSERR_AsmJsCompileError;
+                break;
             }
+
         }
 
         if (FAILED(hrMapped))
@@ -2364,7 +2369,8 @@ namespace Js
                         if (FAILED(hrParser))
                         {
                             hrParseCodeGen = MapDeferredReparseError(hrParser, se); // Map certain errors like OOM/SOE
-                            AssertMsg(FAILED(hrParseCodeGen) && SUCCEEDED(hrParser), "Syntax errors should never be detected on deferred re-parse");
+                            AssertMsg(hrParseCodeGen == JSERR_AsmJsCompileError // AsmJsCompileError is not a syntax error
+                                || (FAILED(hrParseCodeGen) && SUCCEEDED(hrParser)), "Syntax errors should never be detected on deferred re-parse");
                         }
                         else
                         {

--- a/test/ASMJSParser/deferReparseBug.js
+++ b/test/ASMJSParser/deferReparseBug.js
@@ -1,0 +1,53 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+// OS 13988805: Assert Failure in JS:ParseableFunctionInfo
+
+try {
+    f()
+} catch (
+    e
+) {}
+
+function f() {
+    "use asm";
+    Number.prototype.toString.apply(
+        DataView.prototype.getUint16.apply(
+            Object.freeze(
+                URIError.prototype.name.apply(
+                    RegExp.prototype.global.apply(
+                        (
+                            function() {
+                                return (
+                                    (
+                                        new Intl.DateTimeFormat(
+                                            (
+                                                function(
+                                                    [] =
+                                                    (
+                                                        Date.prototype.setSeconds.apply(
+                                                            (
+                                                                i6 = (
+                                                                    i1 =>
+                                                                    String.prototype.sub.apply()
+                                                                )
+                                                            )
+                                                        )
+                                                    )
+                                                ) {}
+                                            )
+                                        )
+                                    )
+                                );
+                            }
+                        )
+                    )
+                )
+            )
+        )
+    )
+}
+
+WScript.Echo("PASS");

--- a/test/ASMJSParser/rlexe.xml
+++ b/test/ASMJSParser/rlexe.xml
@@ -7,4 +7,10 @@
       <baseline>UnaryPos.baseline</baseline>
     </default>
   </test>
+  <test>
+    <default>
+      <compile-flags>-on:asmjs -forcedeferparse</compile-flags>
+      <files>deferReparseBug.js</files>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
A recent AsmJs change introduced a throwable AsmJs error at parse time. This error can only be found on a full parse, so if we previously deferred a function that contains this error then we will assert that we should have found all syntax errors in the initial defer parse.

The fix is to special case the AsmJs error, since it is not strictly a syntax error. We will gracefully reparse without AsmJs.
