### PR TITLE
ARM64: Fix prolog/epilog

### DIFF
--- a/lib/Backend/arm64/ARM64Encoder.h
+++ b/lib/Backend/arm64/ARM64Encoder.h
@@ -998,7 +998,7 @@ EmitBlr(
     Arm64SimpleRegisterParam Reg
     )
 {
-    return Emitter.EmitFourBytes(0xd65f0000 | (Reg.RawRegister() << 5));
+    return Emitter.EmitFourBytes(0xd63f0000 | (Reg.RawRegister() << 5));
 }
 
 inline
@@ -1008,7 +1008,7 @@ EmitRet(
     Arm64SimpleRegisterParam Reg
     )
 {
-    return Emitter.EmitFourBytes(0xd63f0000 | (Reg.RawRegister() << 5));
+    return Emitter.EmitFourBytes(0xd65f0000 | (Reg.RawRegister() << 5));
 }
 
 //

--- a/lib/Backend/arm64/EncoderMD.h
+++ b/lib/Backend/arm64/EncoderMD.h
@@ -33,7 +33,7 @@ enum InstructionType {
 #define SCRATCH_REG         RegR17
 #define ALT_LOCALS_PTR      RegR21
 #define EH_STACK_SAVE_REG   RegR20
-#define SP_ALLOC_SCRATCH_REG RegR18
+#define SP_ALLOC_SCRATCH_REG RegR16
 #define CATCH_OBJ_REG       RegR1
 
 #define RETURN_DBL_REG      RegD0
@@ -41,7 +41,8 @@ enum InstructionType {
 #define LAST_CALLEE_SAVED_DBL_REG  RegD29
 #define FIRST_CALLEE_SAVED_DBL_REG_NUM 16
 #define LAST_CALLEE_SAVED_DBL_REG_NUM 29
-#define CALLEE_SAVED_DOUBLE_REG_COUNT 16
+#define CALLEE_SAVED_DOUBLE_REG_COUNT\
+    ((LAST_CALLEE_SAVED_DBL_REG - FIRST_CALLEE_SAVED_DBL_REG) + 1)
 
 // See comment in LowerEntryInstr: even in a global function, we'll home r0 and r1
 #define MIN_HOMED_PARAM_REGS 2
@@ -203,7 +204,6 @@ private:
     bool            CanonicalizeInstr(IR::Instr *instr);
     void            CanonicalizeLea(IR::Instr * instr);
     bool            DecodeMemoryOpnd(IR::Opnd* opnd, ARM64_REGISTER &baseRegResult, ARM64_REGISTER &indexRegResult, BYTE &indexScale, int32 &offset);
-    
     static bool     EncodeLogicalConst(IntConstType constant, DWORD * result, int size);
 
     // General 1-operand instructions (BR, RET)

--- a/lib/Backend/arm64/md.h
+++ b/lib/Backend/arm64/md.h
@@ -22,7 +22,7 @@ __declspec(selectany) const int MachPtr = 8;
 const int MachDouble = 8;
 const int MachRegDouble = 8;
 const int MachArgsSlotOffset = MachPtr;
-const int MachStackAlignment = MachDouble;
+const int MachStackAlignment = 16; // On ARM64 SP needs to be 16 byte aligned for load/store
 
 const int PAGESIZE = 0x1000;
 


### PR DESCRIPTION
Fix BLR and RET opcode encoding. Seems like they were reversed.

Fix prolog and epilog. There is still some work left to optimize STR/LDR to STP/LDP. Also need to make sure stack probe code works correctly.