### PR TITLE
ARM64: Added SUB_LSL4 opcode

### DIFF
--- a/lib/Backend/arm64/EncoderMD.h
+++ b/lib/Backend/arm64/EncoderMD.h
@@ -214,7 +214,8 @@ private:
 
     // General 3-operand instructions (ADD, AND, SUB, etc) follow a very standard pattern
     template<typename _RegFunc32, typename _RegFunc64> int EmitOp3Register(Arm64CodeEmitter &Emitter, IR::Instr* instr, _RegFunc32 reg32, _RegFunc64 reg64);
-    template<typename _ImmFunc32, typename _ImmFunc64> int EmitOp3Immediate(Arm64CodeEmitter &Emitter, IR::Instr* instr, _ImmFunc32 imm32, _ImmFunc64 imm64);
+    template<typename _RegFunc32, typename _RegFunc64> int EmitOp3RegisterShifted(Arm64CodeEmitter &Emitter, IR::Instr* instr, SHIFT_EXTEND_TYPE shiftType, int shiftAmount, _RegFunc32 reg32, _RegFunc64 reg64);
+        template<typename _ImmFunc32, typename _ImmFunc64> int EmitOp3Immediate(Arm64CodeEmitter &Emitter, IR::Instr* instr, _ImmFunc32 imm32, _ImmFunc64 imm64);
     template<typename _RegFunc32, typename _RegFunc64, typename _ImmFunc32, typename _ImmFunc64> int EmitOp3RegisterOrImmediate(Arm64CodeEmitter &Emitter, IR::Instr* instr, _RegFunc32 reg32, _RegFunc64 reg64, _ImmFunc32 imm32, _ImmFunc64 imm64);
 
     // Load/store operations

--- a/lib/Backend/arm64/MdOpCodes.h
+++ b/lib/Backend/arm64/MdOpCodes.h
@@ -113,6 +113,9 @@ MACRO(STP_PRE,    Reg3,       0,              UNUSED,   LEGAL_STOREP,   UNUSED, 
 MACRO(SUB,        Reg3,       0,              UNUSED,   LEGAL_ADDSUB,   UNUSED,   D___)
 MACRO(SUBS,       Reg3,       OpSideEffect,   UNUSED,   LEGAL_ADDSUB,   UNUSED,   D__S)
 
+// SUB dst, src1, src2 LSL #4 -- used in prologs with _chkstk calls
+MACRO(SUB_LSL4,   Reg3,       0,              UNUSED,   LEGAL_REG3,     UNUSED,   D___)
+
 MACRO(TIOFLW,     Reg1,       OpSideEffect,   UNUSED,   LEGAL_REG2_ND,  UNUSED,   D___)
 MACRO(TST,        Reg2,       OpSideEffect,   UNUSED,   LEGAL_PSEUDO,   UNUSED,   D__S)
 


### PR DESCRIPTION
Added SUB_LSL4 opcode for use in prologs when updating the stack after _chkstk call. Created a new template for register-shifted operations. Converted EOR_ASR31 and SUB_LSL4 to use the new template.