### PR TITLE
Use Utf8Helper classes in Intl.cpp, clean up error handling

### DIFF
--- a/lib/Common/Codex/Utf8Helper.h
+++ b/lib/Common/Codex/Utf8Helper.h
@@ -3,6 +3,7 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
 #pragma once
+#include "CommonPal.h" // MAXUINT32
 #include "Utf8Codex.h"
 
 namespace utf8

--- a/lib/Runtime/Library/IntlEngineInterfaceExtensionObject.cpp
+++ b/lib/Runtime/Library/IntlEngineInterfaceExtensionObject.cpp
@@ -566,7 +566,7 @@ namespace Js
         }
 
 #if DEBUG
-#ifdef INTL_ICU_DEBUG
+#if INTL_ICU_DEBUG
         Output::Print(_u("EntryIntl_RaiseAssert\n"));
 #endif
         JavascriptExceptionOperators::Throw(JavascriptError::FromVar(args.Values[1]), scriptContext);
@@ -654,7 +654,7 @@ namespace Js
             return JavascriptString::NewCopySz(resolvedLocaleName, scriptContext);
         }
 
-#ifdef INTL_ICU_DEBUG
+#if INTL_ICU_DEBUG
         Output::Print(_u("Intl::ResolveLocaleLookup returned false: EntryIntl_ResolveLocaleLookup returning null to fallback to JS\n"));
 #endif
         return scriptContext->GetLibrary()->GetNull();
@@ -693,7 +693,7 @@ namespace Js
             return JavascriptString::NewCopySz(resolvedLocaleName, scriptContext);
         }
 
-#ifdef INTL_ICU_DEBUG
+#if INTL_ICU_DEBUG
         Output::Print(_u("Intl::ResolveLocaleBestFit returned false: EntryIntl_ResolveLocaleBestFit returning null to fallback to JS\n"));
 #endif
         return scriptContext->GetLibrary()->GetNull();
@@ -798,7 +798,7 @@ namespace Js
         return toReturn;
 #else
         // TODO (doilij): implement INTL_ICU version
-#ifdef INTL_ICU_DEBUG
+#if INTL_ICU_DEBUG
         Output::Print(_u("EntryIntl_GetExtensions > returning null: fallback to JS function getExtensionSubtags\n"));
 #endif
         return scriptContext->GetLibrary()->GetNull(); // fallback to Intl.js
@@ -1173,7 +1173,7 @@ namespace Js
         return scriptContext->GetLibrary()->GetUndefined();
 #else
         // TODO (doilij): implement INTL_ICU version
-#ifdef INTL_ICU_DEBUG
+#if INTL_ICU_DEBUG
         Output::Print(_u("EntryIntl_CreateDateTimeFormat > returning null, fallback to JS\n"));
 #endif
         return scriptContext->GetLibrary()->GetNull();
@@ -1574,7 +1574,7 @@ namespace Js
         return Js::JavascriptString::NewCopySz(strBuf, scriptContext);
 #else
         // TODO (doilij): implement INTL_ICU version
-#ifdef INTL_ICU_DEBUG
+#if INTL_ICU_DEBUG
         Output::Print(_u("EntryIntl_FormatDateTime > returning null, fallback to JS\n"));
 #endif
         return scriptContext->GetLibrary()->GetNull();
@@ -1614,7 +1614,7 @@ namespace Js
         }
 #else
         // TODO (doilij): implement INTL_ICU version
-#ifdef INTL_ICU_DEBUG
+#if INTL_ICU_DEBUG
         Output::Print(_u("EntryIntl_ValidateAndCanonicalizeTimeZone > returning null, fallback to JS\n"));
 #endif
         return scriptContext->GetLibrary()->GetNull();
@@ -1646,7 +1646,7 @@ namespace Js
         return Js::JavascriptString::NewCopySz(strBuf, scriptContext);
 #else
         // TODO (doilij): implement INTL_ICU version
-#ifdef INTL_ICU_DEBUG
+#if INTL_ICU_DEBUG
         Output::Print(_u("EntryIntl_GetDefaultTimeZone > returning null, fallback to JS\n"));
 #endif
         return scriptContext->GetLibrary()->GetNull();

--- a/lib/Runtime/PlatformAgnostic/Intl.h
+++ b/lib/Runtime/PlatformAgnostic/Intl.h
@@ -77,7 +77,8 @@ namespace Intl
     HRESULT SetNumberFormatIntFracDigits(IPlatformAgnosticResource *resource, const uint16 minFracDigits, const uint16 maxFracDigits, const uint16 minIntDigits);
 
     template <typename T>
-    const char16 *FormatNumber(IPlatformAgnosticResource *formatter, const T val, const NumberFormatStyle formatterToUse, const NumberFormatCurrencyDisplay currencyDisplay, const char16 *currencyCode);
+    const char16 *FormatNumber(IPlatformAgnosticResource *formatter, const T val, const NumberFormatStyle formatterToUse,
+        const NumberFormatCurrencyDisplay currencyDisplay, const char16 *currencyCode);
 
     bool ResolveLocaleLookup(_In_z_ const char16 *locale, _Out_ char16 *resolved);
     bool ResolveLocaleBestFit(_In_z_ const char16 *locale, _Out_ char16 *resolved);

--- a/lib/Runtime/PlatformAgnostic/Platform/Linux/EventTrace.cpp
+++ b/lib/Runtime/PlatformAgnostic/Platform/Linux/EventTrace.cpp
@@ -4,7 +4,6 @@
 //-------------------------------------------------------------------------------------------------------
 
 #include "RuntimePlatformAgnosticPch.h"
-#include "CommonPal.h"
 
 namespace PlatformAgnostic
 {

--- a/lib/Runtime/PlatformAgnostic/Platform/Linux/UnicodeText.ICU.cpp
+++ b/lib/Runtime/PlatformAgnostic/Platform/Linux/UnicodeText.ICU.cpp
@@ -6,9 +6,19 @@
 #include "RuntimePlatformAgnosticPch.h"
 #include "UnicodeText.h"
 #ifdef HAS_REAL_ICU
+
+// pal/inc/rt/sal.h defines __out, which is used as a variable in libstdc++,
+// which gets included by ICU
+#ifdef __out
+#undef __out
+#endif
+
 #include <unicode/uchar.h>
 #include <unicode/ustring.h>
 #include <unicode/normalizer2.h>
+
+#define __out
+
 #else
 #include <cctype>
 #define UErrorCode int

--- a/lib/Runtime/PlatformAgnostic/RuntimePlatformAgnosticPch.h
+++ b/lib/Runtime/PlatformAgnostic/RuntimePlatformAgnosticPch.h
@@ -7,7 +7,7 @@
 #ifdef _WIN32
 #include "CommonMin.h"
 #else
-#include "pal.h"
+#include "CommonPal.h"
 #endif
 
 #ifdef _MSC_VER


### PR DESCRIPTION
Fixes #3851