### PR TITLE
LoopHeader* is not a valid Var

### DIFF
--- a/lib/Backend/BailOut.cpp
+++ b/lib/Backend/BailOut.cpp
@@ -1529,7 +1529,7 @@ BailOutRecord::BailOutHelper(Js::JavascriptCallStackLayout * layout, Js::ScriptF
             size_t varAllocCount = setup.GetAllocationVarCount();
             size_t varSizeInBytes = varAllocCount * sizeof(Js::Var);
             DWORD_PTR stackAddr = reinterpret_cast<DWORD_PTR>(&generator); // as mentioned above, use any stack address from this frame to ensure correct debugging functionality
-            Js::Var loopHeaderArray = executeFunction->GetHasAllocatedLoopHeaders() ? executeFunction->GetLoopHeaderArrayPtr() : nullptr;
+            Js::LoopHeader* loopHeaderArray = executeFunction->GetHasAllocatedLoopHeaders() ? executeFunction->GetLoopHeaderArrayPtr() : nullptr;
 
             allocation = RecyclerNewPlus(functionScriptContext->GetRecycler(), varSizeInBytes, Js::Var);
 
@@ -1568,7 +1568,7 @@ BailOutRecord::BailOutHelper(Js::JavascriptCallStackLayout * layout, Js::ScriptF
             allocation = (Js::Var*)_alloca(varSizeInBytes);
         }
 
-        Js::Var loopHeaderArray = nullptr;
+        Js::LoopHeader* loopHeaderArray = nullptr;
 
         if (executeFunction->GetHasAllocatedLoopHeaders())
         {

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -2538,7 +2538,7 @@ namespace Js
         void ReleaseLoopHeaders();
         Js::LoopHeader * GetLoopHeader(uint index) const;
         Js::LoopHeader * GetLoopHeaderWithLock(uint index) const;
-        Js::Var GetLoopHeaderArrayPtr() const
+        Js::LoopHeader * GetLoopHeaderArrayPtr() const
         {
             Assert(this->GetLoopHeaderArray() != nullptr);
             return this->GetLoopHeaderArray();

--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -1101,7 +1101,7 @@ namespace Js
     }
 
     InterpreterStackFrame *
-    InterpreterStackFrame::Setup::InitializeAllocation(__in_ecount(varAllocCount) Var * allocation, bool initParams, bool profileParams, Var loopHeaderArray, DWORD_PTR stackAddr
+    InterpreterStackFrame::Setup::InitializeAllocation(__in_ecount(varAllocCount) Var * allocation, bool initParams, bool profileParams, LoopHeader* loopHeaderArray, DWORD_PTR stackAddr
 #if DBG
     , Var invalidStackVar
 #endif
@@ -1874,7 +1874,7 @@ namespace Js
                 size_t varAllocCount = setup.GetAllocationVarCount();
                 size_t varSizeInBytes = varAllocCount * sizeof(Var);
                 DWORD_PTR stackAddr = reinterpret_cast<DWORD_PTR>(&generator); // as mentioned above, use any stack address from this frame to ensure correct debugging functionality
-                Var loopHeaderArray = executeFunction->GetHasAllocatedLoopHeaders() ? executeFunction->GetLoopHeaderArrayPtr() : nullptr;
+                LoopHeader* loopHeaderArray = executeFunction->GetHasAllocatedLoopHeaders() ? executeFunction->GetLoopHeaderArrayPtr() : nullptr;
 
                 allocation = RecyclerNewPlus(functionScriptContext->GetRecycler(), varSizeInBytes, Var);
                 AnalysisAssert(allocation);
@@ -1933,7 +1933,7 @@ namespace Js
             * it's cheaper to just copy them all into the recycler array rather than just the ones that
             * have been jitted.
             */
-            Var loopHeaderArray = nullptr;
+            LoopHeader* loopHeaderArray = nullptr;
 
             if (executeFunction->GetHasAllocatedLoopHeaders())
             {

--- a/lib/Runtime/Language/InterpreterStackFrame.h
+++ b/lib/Runtime/Language/InterpreterStackFrame.h
@@ -51,9 +51,9 @@ namespace Js
             InterpreterStackFrame * AllocateAndInitialize(bool doProfile, bool * releaseAlloc);
 
 #if DBG
-            InterpreterStackFrame * InitializeAllocation(__in_ecount(varAllocCount) Var * allocation, bool initParams, bool profileParams, Var loopHeaderArray, DWORD_PTR stackAddr, Var invalidStackVar);
+            InterpreterStackFrame * InitializeAllocation(__in_ecount(varAllocCount) Var * allocation, bool initParams, bool profileParams, LoopHeader* loopHeaderArray, DWORD_PTR stackAddr, Var invalidStackVar);
 #else
-            InterpreterStackFrame * InitializeAllocation(__in_ecount(varAllocCount) Var * allocation, bool initParams, bool profileParams, Var loopHeaderArray, DWORD_PTR stackAddr);
+            InterpreterStackFrame * InitializeAllocation(__in_ecount(varAllocCount) Var * allocation, bool initParams, bool profileParams, LoopHeader* loopHeaderArray, DWORD_PTR stackAddr);
 #endif
             uint GetLocalCount() const { return localCount; }
 
@@ -118,7 +118,7 @@ namespace Js
         void * returnAddress;
         void * addressOfReturnAddress;  // Tag this frame with stack position, used by (remote) stack walker to test partially initialized interpreter stack frame.
         InterpreterStackFrame *previousInterpreterFrame;
-        Var  loopHeaderArray;          // Keeps alive any JITted loop bodies while the function is being interpreted
+        LoopHeader*  loopHeaderArray;          // Keeps alive any JITted loop bodies while the function is being interpreted
 
         // 'stack address' of the frame, used for recursion detection during stepping.
         // For frames created via interpreter path, we use 'this', for frames created by bailout we use stack addr of actual jitted frame


### PR DESCRIPTION
Var is, in theory, taggedint, RecyclableObject*, or taggedfloat (on
supporting platforms). LoopHeader* is none of these.
