### PR TITLE
Fix benign UAF in peeps.

### DIFF
--- a/lib/Backend/Peeps.cpp
+++ b/lib/Backend/Peeps.cpp
@@ -1049,6 +1049,7 @@ Peeps::PeepRedundant(IR::Instr *instr)
             // remove instruction
             retInstr = instr->m_next;
             instr->Remove();
+            return retInstr;
         }
     }
 #if _M_IX86


### PR DESCRIPTION
We've already called ->Remove on instr, which means that the uses of
it in the condition for the if block are technically UAFs. This does
not result in an exploitable path, though, since we do no allocation
here and don't give back the reference. Additionally, the old opcode
can only be ADD, SUB, or OR, so the check against NOP fails.
