### PR TITLE
json.stringify: simplify array interface and make sure object is dynamicObject 

### DIFF
--- a/lib/Runtime/Library/JSON.h
+++ b/lib/Runtime/Library/JSON.h
@@ -62,15 +62,15 @@ namespace JSON
         void CompleteInit(Js::Var space, ArenaAllocator* alloc);
 
         Js::Var Str(Js::JavascriptString* key, Js::PropertyId keyId, Js::Var holder, Js::Var value = nullptr);
-        Js::Var Str(uint32 index, Js::Var holder);
+        Js::Var Str(uint32 index, Js::RecyclableObject * holder);
 
     private:
         Js::JavascriptString* Quote(Js::JavascriptString* value);
 
         Js::Var StringifyObject(Js::Var value);
 
-        Js::Var StringifyArray(Js::Var value);
-        Js::JavascriptString* GetArrayElementString(uint32 index, Js::Var arrayVar);
+        Js::Var StringifyArray(Js::RecyclableObject * arrayValue);
+        Js::JavascriptString* GetArrayElementString(uint32 index, Js::RecyclableObject * arrayValue);
         Js::JavascriptString* GetPropertySeparator();
         Js::JavascriptString* GetIndentString(uint count);
         Js::JavascriptString* GetMemberSeparator(Js::JavascriptString* indentString);


### PR DESCRIPTION
- stringify(array)   implementation was including some dead code and redundant type checks. Partly handled by LTO, partly not.
- stringify(object) implementation adds more strict checking around dynamicObject.
- stringify(object) measure ConcatString item count precisely so it doesn't go through expensive resize path