### PR TITLE
Avoid potential future uninitialized read in Regex

### DIFF
--- a/lib/Parser/RegexCompileTime.cpp
+++ b/lib/Parser/RegexCompileTime.cpp
@@ -1281,7 +1281,7 @@ namespace UnifiedRegex
         {
             Char uniqueEquivs[CaseInsensitive::EquivClassSize];
             CharCount uniqueEquivCount = FindUniqueEquivs(cs, uniqueEquivs);
-            Assert(uniqueEquivCount >= 2);
+            AssertOrFailFastMsg(uniqueEquivCount >= 2, "Equivalence classes should have at least two entries!");
             switch (uniqueEquivCount)
             {
             case 2:

--- a/lib/Parser/RegexCompileTime.cpp
+++ b/lib/Parser/RegexCompileTime.cpp
@@ -1281,6 +1281,7 @@ namespace UnifiedRegex
         {
             Char uniqueEquivs[CaseInsensitive::EquivClassSize];
             CharCount uniqueEquivCount = FindUniqueEquivs(cs, uniqueEquivs);
+            Assert(uniqueEquivCount >= 2);
             switch (uniqueEquivCount)
             {
             case 2:


### PR DESCRIPTION
We assume in a couple places that these unicode equivalence classes
have no pure identity rows (i.e. rows where all four values are the
same). In these cases, some other parts of our code may leak unsafe
data to the running script. This static assert should help avoid an
error here getting through and causing issues elsewhere.

I also added an Assert at the immediately visible location where an
incorrect identity row would allow uninitialized reads, so that the
analyzers know about this information.
