### PR TITLE
ARM64: Add more future-useful opcodes.

### DIFF
--- a/lib/Backend/arm64/ARM64NeonEncoder.h
+++ b/lib/Backend/arm64/ARM64NeonEncoder.h
@@ -4074,6 +4074,58 @@ EmitNeonConvertScalarCommon(
 
 inline
 int
+EmitNeonFcvtmsGen(
+    Arm64CodeEmitter &Emitter,
+    Arm64SimpleRegisterParam Dest,
+    NeonRegisterParam Src,
+    NEON_SIZE SrcSize
+)
+{
+    NT_ASSERT(NeonSizeIsValid(SrcSize, VALID_1S | VALID_1D));
+    return EmitNeonConvertScalarCommon(Emitter, Dest, Src, SrcSize, 0x1e300000);
+}
+
+inline
+int
+EmitNeonFcvtmsGen64(
+    Arm64CodeEmitter &Emitter,
+    Arm64SimpleRegisterParam Dest,
+    NeonRegisterParam Src,
+    NEON_SIZE SrcSize
+)
+{
+    NT_ASSERT(NeonSizeIsValid(SrcSize, VALID_1S | VALID_1D));
+    return EmitNeonConvertScalarCommon(Emitter, Dest, Src, SrcSize, 0x9e300000);
+}
+
+inline
+int
+EmitNeonFcvtmuGen(
+    Arm64CodeEmitter &Emitter,
+    Arm64SimpleRegisterParam Dest,
+    NeonRegisterParam Src,
+    NEON_SIZE SrcSize
+)
+{
+    NT_ASSERT(NeonSizeIsValid(SrcSize, VALID_1S | VALID_1D));
+    return EmitNeonConvertScalarCommon(Emitter, Dest, Src, SrcSize, 0x1e310000);
+}
+
+inline
+int
+EmitNeonFcvtmuGen64(
+    Arm64CodeEmitter &Emitter,
+    Arm64SimpleRegisterParam Dest,
+    NeonRegisterParam Src,
+    NEON_SIZE SrcSize
+)
+{
+    NT_ASSERT(NeonSizeIsValid(SrcSize, VALID_1S | VALID_1D));
+    return EmitNeonConvertScalarCommon(Emitter, Dest, Src, SrcSize, 0x9e310000);
+}
+
+inline
+int
 EmitNeonFcvtnsGen(
     Arm64CodeEmitter &Emitter,
     Arm64SimpleRegisterParam Dest,

--- a/lib/Backend/arm64/EncoderMD.h
+++ b/lib/Backend/arm64/EncoderMD.h
@@ -91,6 +91,8 @@ enum InstructionType {
 #define IS_CONST_0000FFFF(x) (((x) & ~0x0000ffff) == 0)
 #define IS_CONST_000FFFFF(x) (((x) & ~0x000fffff) == 0)
 #define IS_CONST_007FFFFF(x) (((x) & ~0x007fffff) == 0)
+#define IS_CONST_00FFF000(x) (((x) & ~0x00fff000) == 0)
+#define IS_CONST_003F003F(x) (((x) & ~0x003f003f) == 0)
 
 #define IS_CONST_NEG_7(x)    (((x) & ~0x0000003f) == ~0x0000003f)
 #define IS_CONST_NEG_8(x)    (((x) & ~0x0000007f) == ~0x0000007f)
@@ -112,6 +114,8 @@ enum InstructionType {
 #define IS_CONST_UINT10(x)   IS_CONST_000003FF(x)
 #define IS_CONST_UINT12(x)   IS_CONST_00000FFF(x)
 #define IS_CONST_UINT16(x)   IS_CONST_0000FFFF(x)
+#define IS_CONST_UINT12LSL12(x) IS_CONST_00FFF000(x)
+#define IS_CONST_UINT6UINT6(x) IS_CONST_003F003F(x)
 
 
 ///---------------------------------------------------------------------------
@@ -227,9 +231,12 @@ private:
     // Branch operations
     template<typename _Emitter> int EmitUnconditionalBranch(Arm64CodeEmitter &Emitter, IR::Instr* instr, _Emitter emitter);
     int             EmitConditionalBranch(Arm64CodeEmitter &Emitter, IR::Instr* instr, int condition);
+    template<typename _Emitter, typename _Emitter64> int EmitCompareAndBranch(Arm64CodeEmitter &Emitter, IR::Instr* instr, _Emitter emitter, _Emitter64 emitter64);
+    template<typename _Emitter> int EmitTestAndBranch(Arm64CodeEmitter &Emitter, IR::Instr* instr, _Emitter emitter);
 
     // Misc operations
     template<typename _Emitter, typename _Emitter64> int EmitMovConstant(Arm64CodeEmitter &Emitter, IR::Instr* instr, _Emitter emitter, _Emitter64 emitter64);
+    template<typename _Emitter, typename _Emitter64> int EmitBitfield(Arm64CodeEmitter &Emitter, IR::Instr *instr, _Emitter emitter, _Emitter64 emitter64);
 
     // Floating point instructions
     template<typename _Emitter> int EmitOp2FpRegister(Arm64CodeEmitter &Emitter, IR::Instr *instr, _Emitter emitter);

--- a/lib/Backend/arm64/LegalizeMD.cpp
+++ b/lib/Backend/arm64/LegalizeMD.cpp
@@ -397,11 +397,13 @@ void LegalizeMD::LegalizeImmed(
     LegalForms forms,
     bool fPostRegAlloc)
 {
-    // ARM64_WORKITEM: Fix me -- assuming a 32-bit opcode
-    if (!(((forms & L_ImmLog12) && EncoderMD::CanEncodeLogicalConst(immed, 4)) ||
-          ((forms & L_ImmU6) && IS_CONST_UINT6(immed)) ||
-          ((forms & L_ImmU12) && IS_CONST_UINT12(immed)) ||
-          ((forms & L_ImmU16) && IS_CONST_UINT16(immed))))
+    int size = instr->GetDst()->GetSize();
+    if (!(((forms & L_ImmLog12) && EncoderMD::CanEncodeLogicalConst(immed, size)) ||
+         ((forms & L_ImmU12) && IS_CONST_UINT12(immed)) ||
+         ((forms & L_ImmU12Lsl12) && IS_CONST_UINT12LSL12(immed)) ||
+         ((forms & L_ImmU6) && IS_CONST_UINT6(immed)) ||
+         ((forms & L_ImmU16) && IS_CONST_UINT16(immed)) ||
+         ((forms & L_ImmU6U6) && IS_CONST_UINT6UINT6(immed))))
     {
         if (instr->m_opcode != Js::OpCode::LDIMM)
         {

--- a/lib/Backend/arm64/LegalizeMD.h
+++ b/lib/Backend/arm64/LegalizeMD.h
@@ -17,7 +17,8 @@ enum LegalForms
     L_ImmU6 =       0x80,
     L_ImmU16 =      0x100,
     L_Imm =         0x200,
-    L_ImmMask =     (L_ImmLog12 | L_ImmU12 | L_ImmU12Lsl12 | L_ImmU6 | L_ImmU16 | L_Imm),
+    L_ImmU6U6 =     0x400,
+    L_ImmMask =     (L_ImmLog12 | L_ImmU12 | L_ImmU12Lsl12 | L_ImmU6 | L_ImmU16 | L_Imm | L_ImmU6U6),
 
     L_IndirSU12I9 = 0x1000,
     L_IndirSI7 =    0x2000,
@@ -48,8 +49,10 @@ struct LegalInstrForms
 #define LEGAL_ALU2     { L_Reg,     { (LegalForms)(L_Reg | L_ImmLog12), L_None } }
 #define LEGAL_ALU3     { L_Reg,     { L_Reg,     (LegalForms)(L_Reg | L_ImmLog12) } }
 #define LEGAL_SHIFT    { L_Reg,     { L_Reg,     (LegalForms)(L_Reg | L_ImmU6) } }
+#define LEGAL_BITFIELD { L_Reg,     { L_Reg,     L_ImmU6U6 } }
 #define LEGAL_BLAB     LEGAL_NONE
 #define LEGAL_CALL     { L_Reg,     { L_Lab20 ,  L_None } } // Not currently generated, offset check is missing
+#define LEGAL_CBZ      { L_None,    { L_Reg } }
 #define LEGAL_LDIMM    { L_Reg,     { L_Imm,     L_None } }
 #define LEGAL_LOAD     { L_Reg,     { (LegalForms)(L_IndirSU12I9 | L_SymSU12I9), L_None } }
 #define LEGAL_LOADP    { L_Reg,     { (LegalForms)(L_IndirSI7 | L_SymSI7), L_Reg } }
@@ -61,6 +64,7 @@ struct LegalInstrForms
 #define LEGAL_REG3_ND  { L_None,    { L_Reg,     L_Reg } }
 #define LEGAL_STORE    { (LegalForms)(L_IndirSU12I9 | L_SymSU12I9), { L_Reg, L_None } }
 #define LEGAL_STOREP   { (LegalForms)(L_IndirSI7 | L_SymSI7), { L_Reg, L_Reg } }
+#define LEGAL_TBZ      { L_None,    { L_Reg,     L_ImmU6 } }
 
 class LegalizeMD
 {

--- a/lib/Backend/arm64/MdOpCodes.h
+++ b/lib/Backend/arm64/MdOpCodes.h
@@ -22,6 +22,8 @@ MACRO(ANDS,       Reg3,       0,              UNUSED,   LEGAL_ALU3,     UNUSED, 
 MACRO(ASR,        Reg3,       0,              UNUSED,   LEGAL_SHIFT,    UNUSED,   D___)
 
 MACRO(B,          Br,         OpSideEffect,   UNUSED,   LEGAL_BLAB,     UNUSED,   D___)
+MACRO(BFI,        Reg3,       0,              UNUSED,   LEGAL_BITFIELD, UNUSED,   D___)
+MACRO(BFXIL,      Reg3,       0,              UNUSED,   LEGAL_BITFIELD, UNUSED,   D___)
 MACRO(BIC,        Reg3,       OpSideEffect,   UNUSED,   LEGAL_ALU3,     UNUSED,   D___)
 MACRO(BL,         CallI,      OpSideEffect,   UNUSED,   LEGAL_CALL,     UNUSED,   D___)
 MACRO(BR,         Br,         OpSideEffect,   UNUSED,   LEGAL_REG2_ND,  UNUSED,   D___)
@@ -43,11 +45,14 @@ MACRO(BPL,        BrReg2,     OpSideEffect,   UNUSED,   LEGAL_BLAB,     UNUSED, 
 MACRO(BVS,        BrReg2,     OpSideEffect,   UNUSED,   LEGAL_BLAB,     UNUSED,   D___)
 MACRO(BVC,        BrReg2,     OpSideEffect,   UNUSED,   LEGAL_BLAB,     UNUSED,   D___)
 
+MACRO(CBZ,        BrReg2,     OpSideEffect,   UNUSED,   LEGAL_CBZ,      UNUSED,   D___)
+MACRO(CBNZ,       BrReg2,     OpSideEffect,   UNUSED,   LEGAL_CBZ,      UNUSED,   D___)
 MACRO(CLZ,        Reg2,       0,              UNUSED,   LEGAL_REG2,     UNUSED,   D___)
 MACRO(CMP,        Reg1,       OpSideEffect,   UNUSED,   LEGAL_PSEUDO,   UNUSED,   D__S)
 MACRO(CMN,        Reg1,       OpSideEffect,   UNUSED,   LEGAL_PSEUDO,   UNUSED,   D__S)
 // CMP src1, src, ASR #31/63
 MACRO(CMP_ASR31,  Reg1,       OpSideEffect,   UNUSED,   LEGAL_REG3_ND,  UNUSED,   D__S)
+MACRO(CSNEGPL,    Reg3,       0,              UNUSED,   LEGAL_REG3,     UNUSED,   D___)
 
 MACRO(DEBUGBREAK, Reg1,       OpSideEffect,   UNUSED,   LEGAL_NONE,     UNUSED,   D___)
 
@@ -102,6 +107,8 @@ MACRO(RET,        Reg2,       OpSideEffect,   UNUSED,   LEGAL_REG2_ND,  UNUSED, 
 // REM: pseudo-op
 MACRO(REM,        Reg3,       OpSideEffect,   UNUSED,   LEGAL_REG3,     UNUSED,   D___)
 
+MACRO(SBFX,       Reg3,       0,              UNUSED,   LEGAL_BITFIELD, UNUSED,   D___)
+
 // SDIV: Signed divide
 MACRO(SDIV,       Reg3,       0,              UNUSED,   LEGAL_REG3,     UNUSED,   D___)
 
@@ -116,8 +123,12 @@ MACRO(SUBS,       Reg3,       OpSideEffect,   UNUSED,   LEGAL_ADDSUB,   UNUSED, 
 // SUB dst, src1, src2 LSL #4 -- used in prologs with _chkstk calls
 MACRO(SUB_LSL4,   Reg3,       0,              UNUSED,   LEGAL_REG3,     UNUSED,   D___)
 
+MACRO(TBZ,        BrReg2,     OpSideEffect,   UNUSED,   LEGAL_TBZ,      UNUSED,   D___)
+MACRO(TBNZ,       BrReg2,     OpSideEffect,   UNUSED,   LEGAL_TBZ,      UNUSED,   D___)
 MACRO(TIOFLW,     Reg1,       OpSideEffect,   UNUSED,   LEGAL_REG2_ND,  UNUSED,   D___)
 MACRO(TST,        Reg2,       OpSideEffect,   UNUSED,   LEGAL_PSEUDO,   UNUSED,   D__S)
+
+MACRO(UBFX,       Reg3,       0,              UNUSED,   LEGAL_BITFIELD, UNUSED,   D___)
 
 // Pseudo-op that loads the size of the arg out area. A special op with no src is used so that the
 // actual arg out size can be fixed up by the encoder.
@@ -135,6 +146,7 @@ MACRO(FABS,        Reg2,      0,              UNUSED,   LEGAL_REG2,     UNUSED, 
 MACRO(FADD,        Reg3,      0,              UNUSED,   LEGAL_REG3,     UNUSED,   D___)
 MACRO(FCMP,        Reg1,      OpSideEffect,   UNUSED,   LEGAL_REG3_ND,  UNUSED,   D___)
 MACRO(FCVT,        Reg2,      0,              UNUSED,   LEGAL_REG2,     UNUSED,   D___)
+MACRO(FCVTM,       Reg2,      0,              UNUSED,   LEGAL_REG2,     UNUSED,   D___)
 MACRO(FCVTN,       Reg2,      0,              UNUSED,   LEGAL_REG2,     UNUSED,   D___)
 MACRO(FCVTZ,       Reg2,      0,              UNUSED,   LEGAL_REG2,     UNUSED,   D___)
 MACRO(FDIV,        Reg3,      0,              UNUSED,   LEGAL_REG3,     UNUSED,   D___)


### PR DESCRIPTION
Added bitfield, compare/branch, test/branch, and compare/select opcodes. Implemented integer ABS the ARM64 way.