### PR TITLE
Add PROBE_STACK to JSONParser::Walk (Fix #3900)

### DIFF
--- a/lib/Runtime/Library/JSONParser.cpp
+++ b/lib/Runtime/Library/JSONParser.cpp
@@ -49,6 +49,7 @@ namespace JSON
     Js::Var JSONParser::Walk(Js::JavascriptString* name, Js::PropertyId id, Js::Var holder, uint32 index)
     {
         AssertMsg(reviver, "JSON post parse walk with null reviver");
+        PROBE_STACK(scriptContext, Js::Constants::MinStackDefault);
         Js::Var value;
         Js::Var values[3];
         Js::Arguments args(0, values);

--- a/test/JSON/rlexe.xml
+++ b/test/JSON/rlexe.xml
@@ -97,4 +97,9 @@
       <files>toJSON.js</files>
     </default>
   </test>
+  <test>
+    <default>
+      <files>stackoverflow.js</files>
+    </default>
+  </test>
 </regress-exe>

--- a/test/JSON/stackoverflow.js
+++ b/test/JSON/stackoverflow.js
@@ -1,0 +1,20 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+try
+{
+    // Issue Microsoft/ChakraCore#3900
+    var o = { 0: 1, 1: 1 };
+    JSON.parse('[0,0]', function () {
+        this[1] = o;
+    });
+}
+catch (ex)
+{
+    if (ex.message == "Out of stack space")
+    {
+        console.log("PASS");
+    }
+}


### PR DESCRIPTION
This PR fixes the infinite recursion bug in JSON.parse.

Fixes #3900 

/cc @DaramG @MikeHolman 