### PR TITLE
Notify host Dynamic Module ready (Fixes #3902)

### DIFF
--- a/lib/Runtime/Language/SourceTextModuleRecord.cpp
+++ b/lib/Runtime/Language/SourceTextModuleRecord.cpp
@@ -307,7 +307,7 @@ namespace Js
             OUTPUT_TRACE_DEBUGONLY(Js::ModulePhase, _u("\t>NotifyParentsAsNeeded\n"));
             NotifyParentsAsNeeded();
 
-            if (!WasDeclarationInitialized() && isRootModule)
+            if (!WasDeclarationInitialized() && (isRootModule || this->promise != nullptr))
             {
                 // TODO: move this as a promise call? if parser is called from a different thread
                 // We'll need to call the bytecode gen in the main thread as we are accessing GC.

--- a/test/es6/bug_issue_3257_script/script0.js
+++ b/test/es6/bug_issue_3257_script/script0.js
@@ -4,5 +4,5 @@
 //-------------------------------------------------------------------------------------------------------
 
 console.log("script0");
-import('../bug_issue_3257_mod1.js');
-import('../bug_issue_3257_mod2/mod2.js');
+import('bug_issue_3257_mod1.js');
+import('bug_issue_3257_mod2/mod2.js');

--- a/test/es6/otherModule.js
+++ b/test/es6/otherModule.js
@@ -1,0 +1,8 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+//test that dynamic import works from module
+//this file is imported only once - dynamicly from another module to check that the host is notified for that
+export const success = true;

--- a/test/es6/testDynamicImportfromModule.js
+++ b/test/es6/testDynamicImportfromModule.js
@@ -1,0 +1,7 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+//test that dynamic import works from module, when the target has not been imported already
+export let foo = import("otherModule.js");


### PR DESCRIPTION
Previously the call to notify the Host that a module was ready was made only for:
a) Errors AND
b) Parent level modules

A module loaded with a dynamic import may not be a parent and hopefully won't always be an error - this condition change means that the notification is made for any dynamic import when completed.

Condition check used of having an attached promise was chosen to be the same as the condition used for Dynamics on the failed import path on line 194.

Fixes: https://github.com/Microsoft/ChakraCore/issues/3902