### PR TITLE
Add cache for @@toStringTag; allow DictionaryTypeHandlerBase into missing-property caches and invalidate when necessary.

### DIFF
--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -1808,12 +1808,10 @@ CommonNumber:
                 Output::Print(_u("MissingPropertyCaching: Missing property %d on slow path.\n"), propertyId);
             }
 
-            // Only cache missing property lookups for non-root field loads on objects that have PathTypeHandlers, because only these objects guarantee a type change when the property is added,
-            // which obviates the need to explicitly invalidate missing property inline caches.
-            //
-            // ricobbe: we now invalidate prototype caches on missing properties for DictionaryTypeHandlerBase as well, so allow those too.  Eventually we'll want to go back and
-            // add support for all kinds of types here.
-            if (!PHASE_OFF1(MissingPropertyCachePhase) && !isRoot && DynamicObject::Is(instance) && 
+            // Only cache missing property lookups for non-root field loads on objects that have PathTypeHandlers and DictionaryTypeHandlers, because only these types have the right behavior
+            // when the missing property is later added: path types guarantee a type change, and DictionaryTypeHandlerBase::AddProperty explicitly invalidates all prototype caches for the
+            // property.  (We don't support other types only because we haven't needed to yet; we do not anticipate any difficulties in adding the cache-invalidation logic there if that changes.)
+            if (!PHASE_OFF1(MissingPropertyCachePhase) && !isRoot && DynamicObject::Is(instance) &&
                 (DynamicObject::FromVar(instance)->GetDynamicType()->GetTypeHandler()->IsPathTypeHandler() || DynamicObject::FromVar(instance)->GetDynamicType()->GetTypeHandler()->IsDictionaryTypeHandler()))
             {
 #ifdef MISSING_PROPERTY_STATS

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -1810,7 +1810,11 @@ CommonNumber:
 
             // Only cache missing property lookups for non-root field loads on objects that have PathTypeHandlers, because only these objects guarantee a type change when the property is added,
             // which obviates the need to explicitly invalidate missing property inline caches.
-            if (!PHASE_OFF1(MissingPropertyCachePhase) && !isRoot && DynamicObject::Is(instance) && ((DynamicObject*)instance)->GetDynamicType()->GetTypeHandler()->IsPathTypeHandler())
+            //
+            // ricobbe: we now invalidate prototype caches on missing properties for DictionaryTypeHandlerBase as well, so allow those too.  Eventually we'll want to go back and
+            // add support for all kinds of types here.
+            if (!PHASE_OFF1(MissingPropertyCachePhase) && !isRoot && DynamicObject::Is(instance) && 
+                (DynamicObject::FromVar(instance)->GetDynamicType()->GetTypeHandler()->IsPathTypeHandler() || DynamicObject::FromVar(instance)->GetDynamicType()->GetTypeHandler()->IsDictionaryTypeHandler()))
             {
 #ifdef MISSING_PROPERTY_STATS
                 if (PHASE_STATS1(MissingPropertyCachePhase))

--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -87,7 +87,7 @@ namespace Js
         InitializeStaticValues();
         PrecalculateArrayAllocationBuckets();
 
-        toStringTagCache = ScriptContextPolymorphicInlineCache::New(32, this);
+        this->cache.toStringTagCache = ScriptContextPolymorphicInlineCache::New(32, this);
 
 #if ENABLE_COPYONACCESS_ARRAY
         if (!PHASE_OFF1(CopyOnAccessArrayPhase))

--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -87,6 +87,8 @@ namespace Js
         InitializeStaticValues();
         PrecalculateArrayAllocationBuckets();
 
+        toStringTagCache = ScriptContextPolymorphicInlineCache::New(32, this);
+
 #if ENABLE_COPYONACCESS_ARRAY
         if (!PHASE_OFF1(CopyOnAccessArrayPhase))
         {

--- a/lib/Runtime/Library/JavascriptLibrary.h
+++ b/lib/Runtime/Library/JavascriptLibrary.h
@@ -586,7 +586,9 @@ namespace Js
             bindRefChunkBegin(nullptr),
             bindRefChunkCurrent(nullptr),
             bindRefChunkEnd(nullptr),
-            dynamicFunctionReference(nullptr)
+            dynamicFunctionReference(nullptr),
+            toStringTagCache(nullptr)
+
         {
             this->globalObject = globalObject;
         }

--- a/lib/Runtime/Library/JavascriptLibrary.h
+++ b/lib/Runtime/Library/JavascriptLibrary.h
@@ -228,6 +228,7 @@ namespace Js
         static DWORD GetBuiltinFunctionsOffset() { return offsetof(JavascriptLibrary, builtinFunctions); }
         static DWORD GetCharStringCacheOffset() { return offsetof(JavascriptLibrary, charStringCache); }
         static DWORD GetCharStringCacheAOffset() { return GetCharStringCacheOffset() + CharStringCache::GetCharStringCacheAOffset(); }
+        PolymorphicInlineCache *GetToStringTagCache() const { return toStringTagCache; }
         const  JavascriptLibraryBase* GetLibraryBase() const { return static_cast<const JavascriptLibraryBase*>(this); }
         void SetGlobalObject(GlobalObject* globalObject) {this->globalObject = globalObject; }
         static DWORD GetRandSeed0Offset() { return offsetof(JavascriptLibrary, randSeed0); }
@@ -470,6 +471,8 @@ namespace Js
         Field(int) regexUnicodeGetterSlotIndex;
 
         mutable Field(CharStringCache) charStringCache;
+
+        Field(ScriptContextPolymorphicInlineCache*) toStringTagCache;
 
         FieldNoBarrier(PromiseContinuationCallback) nativeHostPromiseContinuationFunction;
         Field(void *) nativeHostPromiseContinuationFunctionState;

--- a/lib/Runtime/Library/JavascriptLibrary.h
+++ b/lib/Runtime/Library/JavascriptLibrary.h
@@ -83,11 +83,13 @@ namespace Js
         Field(SRCINFO*) noContextGlobalSourceInfo;
         Field(Field(SRCINFO const *)*) moduleSrcInfo;
         Field(BuiltInLibraryFunctionMap*) builtInLibraryFunctions;
+        Field(ScriptContextPolymorphicInlineCache*) toStringTagCache;
 #if ENABLE_PROFILE_INFO
 #if DBG_DUMP || defined(DYNAMIC_PROFILE_STORAGE) || defined(RUNTIME_DATA_COLLECTION)
         Field(DynamicProfileInfoList*) profileInfoList;
 #endif
 #endif
+        Cache() : toStringTagCache(nullptr) { }
     };
 
     class MissingPropertyTypeHandler;
@@ -228,7 +230,7 @@ namespace Js
         static DWORD GetBuiltinFunctionsOffset() { return offsetof(JavascriptLibrary, builtinFunctions); }
         static DWORD GetCharStringCacheOffset() { return offsetof(JavascriptLibrary, charStringCache); }
         static DWORD GetCharStringCacheAOffset() { return GetCharStringCacheOffset() + CharStringCache::GetCharStringCacheAOffset(); }
-        PolymorphicInlineCache *GetToStringTagCache() const { return toStringTagCache; }
+        PolymorphicInlineCache *GetToStringTagCache() const { return cache.toStringTagCache; }
         const  JavascriptLibraryBase* GetLibraryBase() const { return static_cast<const JavascriptLibraryBase*>(this); }
         void SetGlobalObject(GlobalObject* globalObject) {this->globalObject = globalObject; }
         static DWORD GetRandSeed0Offset() { return offsetof(JavascriptLibrary, randSeed0); }
@@ -472,8 +474,6 @@ namespace Js
 
         mutable Field(CharStringCache) charStringCache;
 
-        Field(ScriptContextPolymorphicInlineCache*) toStringTagCache;
-
         FieldNoBarrier(PromiseContinuationCallback) nativeHostPromiseContinuationFunction;
         Field(void *) nativeHostPromiseContinuationFunctionState;
 
@@ -586,8 +586,7 @@ namespace Js
             bindRefChunkBegin(nullptr),
             bindRefChunkCurrent(nullptr),
             bindRefChunkEnd(nullptr),
-            dynamicFunctionReference(nullptr),
-            toStringTagCache(nullptr)
+            dynamicFunctionReference(nullptr)
 
         {
             this->globalObject = globalObject;

--- a/lib/Runtime/Library/JavascriptObject.cpp
+++ b/lib/Runtime/Library/JavascriptObject.cpp
@@ -357,6 +357,32 @@ namespace Js
         return ToStringHelper(args[0], scriptContext);
     }
 
+    Var JavascriptObject::GetToStringTagValue(RecyclableObject *thisArg, ScriptContext *scriptContext)
+    {
+        const PropertyId toStringTagId(PropertyIds::_symbolToStringTag);
+        PolymorphicInlineCache *cache = scriptContext->GetLibrary()->GetToStringTagCache();
+        PropertyValueInfo info;
+        // We don't allow cache resizing, at least for the moment: it's more work, and since there's only one
+        // cache per script context, we can afford to create each cache with the maximum size.
+        PropertyValueInfo::SetCacheInfo(&info, nullptr, cache, false);
+        Var value;
+        if (CacheOperators::TryGetProperty<true, true, true, true, true, true, !PolymorphicInlineCache::IsPolymorphic, PolymorphicInlineCache::IsPolymorphic, false>(
+                thisArg, false, thisArg, toStringTagId, &value, scriptContext, nullptr, &info))
+        {
+            return value;
+        }
+        else
+        {
+#if DBG_DUMP
+            if (PHASE_VERBOSE_TRACE1(Js::InlineCachePhase))
+            {
+                CacheOperators::TraceCache(cache, _u("PatchGetValue"), toStringTagId, scriptContext, thisArg);
+            }
+#endif
+            return JavascriptOperators::GetProperty(thisArg, thisArg, toStringTagId, scriptContext, &info);
+        }
+    }
+
     // ES2017 19.1.3.6 Object.prototype.toString()
     JavascriptString* JavascriptObject::ToStringTagHelper(Var thisArg, ScriptContext *scriptContext, TypeId type)
     {
@@ -377,7 +403,7 @@ namespace Js
         RecyclableObject *thisArgAsObject = RecyclableObject::FromVar(JavascriptOperators::ToObject(thisArg, scriptContext));
 
         // 15. Let tag be ? Get(O, @@toStringTag).
-        Var tag = JavascriptOperators::GetPropertyNoCache(thisArgAsObject, PropertyIds::_symbolToStringTag, scriptContext); // Let tag be the result of Get(O, @@toStringTag).
+        Var tag = JavascriptObject::GetToStringTagValue(thisArgAsObject, scriptContext);
 
         // 17. Return the String that is the result of concatenating "[object ", tag, and "]".
         auto buildToString = [&scriptContext](Var tag) {

--- a/lib/Runtime/Library/JavascriptObject.cpp
+++ b/lib/Runtime/Library/JavascriptObject.cpp
@@ -366,8 +366,17 @@ namespace Js
         // cache per script context, we can afford to create each cache with the maximum size.
         PropertyValueInfo::SetCacheInfo(&info, nullptr, cache, false);
         Var value;
-        if (CacheOperators::TryGetProperty<true, true, true, true, true, true, !PolymorphicInlineCache::IsPolymorphic, PolymorphicInlineCache::IsPolymorphic, false>(
-                thisArg, false, thisArg, toStringTagId, &value, scriptContext, nullptr, &info))
+        if (CacheOperators::TryGetProperty<
+            true,                                       // CheckLocal
+            true,                                       // CheckProto
+            true,                                       // CheckAccessor
+            true,                                       // CheckMissing
+            true,                                       // CheckPolymorphicInlineCache
+            true,                                       // CheckTypePropertyCache
+            !PolymorphicInlineCache::IsPolymorphic,     // IsInlineCacheAvailable
+            PolymorphicInlineCache::IsPolymorphic,      // IsPolymorphicInlineCacheAvailable
+            false>                                      // ReturnOperationInfo
+            (thisArg, false, thisArg, toStringTagId, &value, scriptContext, nullptr, &info))
         {
             return value;
         }

--- a/lib/Runtime/Library/JavascriptObject.h
+++ b/lib/Runtime/Library/JavascriptObject.h
@@ -120,5 +120,7 @@ namespace Js
         static Var DefinePropertiesHelperForGenericObjects(RecyclableObject* object, RecyclableObject* properties, ScriptContext* scriptContext);
         static Var DefinePropertiesHelperForProxyObjects(RecyclableObject* object, RecyclableObject* properties, ScriptContext* scriptContext);
         static bool IsPrototypeOf(RecyclableObject* proto, RecyclableObject* obj, ScriptContext* scriptContext);
+
+        static Var GetToStringTagValue(RecyclableObject *thisArg, ScriptContext *scriptContext);
     };
 }

--- a/lib/Runtime/Types/DictionaryTypeHandler.cpp
+++ b/lib/Runtime/Types/DictionaryTypeHandler.cpp
@@ -2201,14 +2201,12 @@ namespace Js
             SetPropertyValueInfo(info, instance, index, attributes);
         }
 
-        if (!IsInternalPropertyId(propertyRecord->GetPropertyId()) && ((this->GetFlags() & IsPrototypeFlag)
-            || JavascriptOperators::HasProxyOrPrototypeInlineCacheProperty(instance, propertyRecord->GetPropertyId())))
-        {
-            // We don't evolve dictionary types when adding a field, so we need to invalidate prototype caches.
-            // We only have to do this though if the current type is used as a prototype, or the current property
-            // is found on the prototype chain.
-            scriptContext->InvalidateProtoCaches(propertyRecord->GetPropertyId());
-        }
+        // Always invalidate prototype caches when we add a property.  Previously, we only did this if the current
+        // type is used as a prototype, or if the new property is also found on the prototype chain (because
+        // adding a new field doesn't create a new dictionary type).  However, if the new property is already in
+        // the cache as a missing property, we have to invalidate the prototype caches.
+        scriptContext->InvalidateProtoCaches(propertyRecord->GetPropertyId());
+
         SetPropertyUpdateSideEffect(instance, propertyRecord->GetPropertyId(), value, possibleSideEffects);
         return true;
     }


### PR DESCRIPTION
Should give us a ~3% improvement in EmberJS on Speedometer 2, as that test involves a lot of toString operations each of which looks up the @@toStringTag property and (as it happens) fails to find it.