### PR TITLE
Fix #3816 Class methods cannot be called static

### DIFF
--- a/test/es6/classes.js
+++ b/test/es6/classes.js
@@ -1185,6 +1185,15 @@ var tests = [
             assert_referrors("class x extends eval('fun(x)') {}");
         }
     },
+    {
+         name: "Semantically restricted keywords can be used as class method names",
+         body: function () {
+             // See https://tc39.github.io/ecma262/#sec-keywords and #3816
+             class a { let() {} };
+             class b { static() {} };
+             class c { static static() {} };
+         }
+    }
 ];
 
 testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });


### PR DESCRIPTION
'static' should be supported as a class method name, even in strict mode. Currently we eat the static token and just mark a flag.

Added detection similar to async and added a test case. Also included 'let' in the test case, as it is the only other semantically determined keyword.
