### PR TITLE
Correctly order special symbol initialization for default arguments

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -2975,9 +2975,12 @@ void ByteCodeGenerator::EmitOneFunction(ParseNode *pnode)
             {
                 for (ParseNodePtr pnodeVar = pnode->sxFnc.pnodeVars; pnodeVar; pnodeVar = pnodeVar->sxVar.pnodeNext)
                 {
+#if DBG
+                    bool reachedEndOfSpecialSymbols = false;
+#endif
                     Symbol* sym = pnodeVar->sxVar.sym;
 
-                    if (sym != nullptr && !(pnodeVar->sxVar.isBlockScopeFncDeclVar && sym->GetIsBlockVar()) && sym->IsSpecialSymbol())
+                    if (sym != nullptr && sym->IsSpecialSymbol())
                     {
                         EmitPropStoreForSpecialSymbol(sym->GetLocation(), sym, sym->GetPid(), funcInfo, true);
                         if (ShouldTrackDebuggerMetadata() && !sym->IsInSlot(funcInfo))
@@ -2987,10 +2990,21 @@ void ByteCodeGenerator::EmitOneFunction(ParseNode *pnode)
                     }
                     else
                     {
-                        // All of the special symbols exist at the beginning of the var list (parser guarantees this) so we can quit walking 
-                        // at the first non-special one we see.
+#if DBG
+                        reachedEndOfSpecialSymbols = true;
+#else
+                        // All of the special symbols exist at the beginning of the var list (parser guarantees this and debug build asserts this)
+                        // so we can quit walking at the first non-special one we see.
                         break;
+#endif
                     }
+
+#if DBG
+                    if (reachedEndOfSpecialSymbols)
+                    {
+                        Assert(sym == nullptr || !sym->IsSpecialSymbol());
+                    }
+#endif
                 }
             }
             else

--- a/test/Basics/SpecialSymbolCapture.js
+++ b/test/Basics/SpecialSymbolCapture.js
@@ -890,6 +890,18 @@ var tests = [
             // Failure causes an assert to fire
             WScript.LoadScript(`(a = function() { this }, b = (this)) => {}`);
         }
+    },
+    {
+        name: "Non-split scope with default arguments referencing special names",
+        body: function() {
+            var _this = {}
+            function foo(a = this) {
+                eval('');
+                assert.areEqual(_this, a, "Correct default value was assigned");
+                assert.areEqual(_this, this, "Regular 'this' binding is correct");
+            }
+            foo.call(_this)
+        }
     }
 ]
 


### PR DESCRIPTION
We incorrectly emit the special symbol initialization at the top of the
body scope when the function has default arguments but merged body and
param scopes. To be correct, we need to always emit the special symbol
initialization in the presence of default arguments - and always emit
those initializations before we emit the default arguments themselves.

Change here handles the case by walking the body scope var list manually
(because symbols in the body scope sym list are in the opposite order)
and emits each special symbol. We stop walking this list when we come to
the first non-special symbol as we know the parser has put all of the
special symbols at the front of the var list.

Fixes:
https://microsoft.visualstudio.com/OS/_workitems?id=13977464&_a=edit
