### PR TITLE
Simplify FunctionExecutionStateMachine::TryTransitionToNextExecutionMode

### DIFF
--- a/bin/NativeTests/FunctionExecutionTest.h
+++ b/bin/NativeTests/FunctionExecutionTest.h
@@ -14,11 +14,28 @@
 #define FieldWithBarrier(type) type
 
 #define CONFIG_FLAG(flag) 10
-#define PHASE_OFF(foo, bar) false
+#define PHASE_OFF(foo, bar) FunctionExecutionTest::PhaseOff(foo, bar)
 #define PHASE_FORCE(foo, bar) false
-#define NewSimpleJit
-#define FullJitPhase
+#define NewSimpleJit 1
+#define FullJitPhase 2
 #define DEFAULT_CONFIG_MinSimpleJitIterations 0
+
+namespace FunctionExecutionTest
+{
+    static bool FullJitPhaseOffFlag = false;
+    bool PhaseOff(int phase, void*)
+    {
+        if (phase == FullJitPhase)
+        {
+            return FullJitPhaseOffFlag;
+        }
+        else
+        {
+            Assert(!"Unknown Phase");
+            return false;
+        }
+    }
+}
 
 namespace Js
 {

--- a/lib/Backend/NativeCodeGenerator.cpp
+++ b/lib/Backend/NativeCodeGenerator.cpp
@@ -1871,7 +1871,7 @@ NativeCodeGenerator::Prioritize(JsUtil::Job *const job, const bool forceAddJobTo
     if (functionBody->GetIsAsmjsMode())
     {
         jitMode = ExecutionMode::FullJit;
-        functionBody->SetExecutionMode(ExecutionMode::FullJit);
+        functionBody->SetAsmJsExecutionMode();
     }
     else
     {

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -6619,9 +6619,14 @@ namespace Js
         return executionState.IncreaseInterpretedCount();
     }
 
-    ExecutionMode FunctionBody::GetDefaultInterpreterExecutionMode() const
+    void FunctionBody::SetAsmJsExecutionMode()
     {
-        return executionState.GetDefaultInterpreterExecutionMode();
+        executionState.SetAsmJsExecutionMode();
+    }
+
+    void FunctionBody::SetDefaultInterpreterExecutionMode()
+    {
+        executionState.SetDefaultInterpreterExecutionMode();
     }
 
     ExecutionMode FunctionBody::GetExecutionMode() const
@@ -6632,11 +6637,6 @@ namespace Js
     ExecutionMode FunctionBody::GetInterpreterExecutionMode(const bool isPostBailout)
     {
         return executionState.GetInterpreterExecutionMode(isPostBailout);
-    }
-
-    void FunctionBody::SetExecutionMode(const ExecutionMode executionMode)
-    {
-        executionState.SetExecutionMode(executionMode);
     }
 
     bool FunctionBody::IsInterpreterExecutionMode() const
@@ -6651,10 +6651,7 @@ namespace Js
 
     void FunctionBody::TryTransitionToNextInterpreterExecutionMode()
     {
-        Assert(IsInterpreterExecutionMode());
-
-        TryTransitionToNextExecutionMode();
-        SetExecutionMode(GetInterpreterExecutionMode(false));
+        executionState.TryTransitionToNextInterpreterExecutionMode();
     }
 
     void FunctionBody::SetIsSpeculativeJitCandidate()
@@ -9256,7 +9253,6 @@ namespace Js
                 {
                     newEntryPoint = simpleJitEntryPointInfo;
                     functionBody->SetDefaultFunctionEntryPointInfo(simpleJitEntryPointInfo, newEntryPoint->GetNativeEntrypoint());
-                    functionBody->SetExecutionMode(ExecutionMode::SimpleJit);
                     functionBody->ResetSimpleJitLimitAndCallCount();
                 }
 #ifdef ASMJS_PLAT
@@ -9267,14 +9263,14 @@ namespace Js
                     newEntryPoint->SetIsAsmJSFunction(true);
                     newEntryPoint->jsMethod = AsmJsDefaultEntryThunk;
                     functionBody->SetIsAsmJsFullJitScheduled(false);
-                    functionBody->SetExecutionMode(functionBody->GetDefaultInterpreterExecutionMode());
+                    functionBody->SetDefaultInterpreterExecutionMode();
                     this->functionProxy->SetOriginalEntryPoint(AsmJsDefaultEntryThunk);
                 }
 #endif
                 else
                 {
                     newEntryPoint = functionBody->CreateNewDefaultEntryPoint();
-                    functionBody->SetExecutionMode(functionBody->GetDefaultInterpreterExecutionMode());
+                    functionBody->SetDefaultInterpreterExecutionMode();
                 }
                 functionBody->TraceExecutionMode("JitCodeExpired");
             }

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -2599,10 +2599,10 @@ namespace Js
         FunctionEntryPointInfo *GetSimpleJitEntryPointInfo() const;
         void SetSimpleJitEntryPointInfo(FunctionEntryPointInfo *const entryPointInfo);
 
-        ExecutionMode GetDefaultInterpreterExecutionMode() const;
+        void SetAsmJsExecutionMode();
+        void SetDefaultInterpreterExecutionMode();
         ExecutionMode GetExecutionMode() const;
         ExecutionMode GetInterpreterExecutionMode(const bool isPostBailout);
-        void SetExecutionMode(const ExecutionMode executionMode);
     private:
         bool IsInterpreterExecutionMode() const;
 


### PR DESCRIPTION
Simplify FunctionExecutionStateMachine::TryTransitionToNextExecutionMode
This change makes significant changes to FunctionExecutionStateMachine::TryTransitionToNextExecutionMode. The previous implementation of this function was based around the ExecutionMode enum and would jump between states. With the new implementation, a separate enum, ExecutionState, is introduced to have a linear of moving across states. Common code paths across all states are also better shared. With this change, the invariants are consistent across states, and the exceptions stand out more. Further, the API boundary for FunctionExecutionStateMachine and some of FunctionBody is tightened to keep some of the internals of FunctionExecutionStateMachine abstracted. Some of the native unittests in FunctionExecutionTest are refactored to support behavior when FullJit is enabled vs not enabled for better code coverage.