### PR TITLE
Remove 'this' binding for global and global lambda functions

### DIFF
--- a/lib/Backend/Inline.cpp
+++ b/lib/Backend/Inline.cpp
@@ -421,7 +421,7 @@ Inline::Optimize(Func *func, __in_ecount_opt(callerArgOutCount) IR::Instr *calle
                 // It is possible for us to have multiple LdThis opcodes in a function if we are in a function
                 // which does not have a 'this' binding such as a lambda at global scope. In those cases, the
                 // value we load for 'this' should be exactly the same every time.
-                //if (symThis == nullptr)
+                if (symThis == nullptr)
                 {
                     symThis = instr->GetDst()->AsRegOpnd()->m_sym;
                 }
@@ -431,7 +431,7 @@ Inline::Optimize(Func *func, __in_ecount_opt(callerArgOutCount) IR::Instr *calle
                 // Is this possible? Can we be walking an inlinee here? Doesn't hurt to support this case...
                 Assert(instr->GetSrc1() && instr->GetSrc1()->IsRegOpnd());
 
-                //if (symThis == nullptr)
+                if (symThis == nullptr)
                 {
                     symThis = instr->GetSrc1()->AsRegOpnd()->m_sym;
                 }

--- a/lib/Backend/Inline.cpp
+++ b/lib/Backend/Inline.cpp
@@ -417,24 +417,17 @@ Inline::Optimize(Func *func, __in_ecount_opt(callerArgOutCount) IR::Instr *calle
 
             case Js::OpCode::LdThis:
                 Assert(instr->GetDst() && instr->GetDst()->IsRegOpnd());
+                Assert(symThis == nullptr);
 
-                // It is possible for us to have multiple LdThis opcodes in a function if we are in a function
-                // which does not have a 'this' binding such as a lambda at global scope. In those cases, the
-                // value we load for 'this' should be exactly the same every time.
-                if (symThis == nullptr)
-                {
-                    symThis = instr->GetDst()->AsRegOpnd()->m_sym;
-                }
+                symThis = instr->GetDst()->AsRegOpnd()->m_sym;
                 break;
 
             case Js::OpCode::CheckThis:
                 // Is this possible? Can we be walking an inlinee here? Doesn't hurt to support this case...
                 Assert(instr->GetSrc1() && instr->GetSrc1()->IsRegOpnd());
+                Assert(symThis == nullptr);
 
-                if (symThis == nullptr)
-                {
-                    symThis = instr->GetSrc1()->AsRegOpnd()->m_sym;
-                }
+                symThis = instr->GetSrc1()->AsRegOpnd()->m_sym;
                 break;
 
             default:

--- a/lib/Backend/Inline.cpp
+++ b/lib/Backend/Inline.cpp
@@ -417,17 +417,24 @@ Inline::Optimize(Func *func, __in_ecount_opt(callerArgOutCount) IR::Instr *calle
 
             case Js::OpCode::LdThis:
                 Assert(instr->GetDst() && instr->GetDst()->IsRegOpnd());
-                Assert(symThis == nullptr);
 
-                symThis = instr->GetDst()->AsRegOpnd()->m_sym;
+                // It is possible for us to have multiple LdThis opcodes in a function if we are in a function
+                // which does not have a 'this' binding such as a lambda at global scope. In those cases, the
+                // value we load for 'this' should be exactly the same every time.
+                //if (symThis == nullptr)
+                {
+                    symThis = instr->GetDst()->AsRegOpnd()->m_sym;
+                }
                 break;
 
             case Js::OpCode::CheckThis:
                 // Is this possible? Can we be walking an inlinee here? Doesn't hurt to support this case...
                 Assert(instr->GetSrc1() && instr->GetSrc1()->IsRegOpnd());
-                Assert(symThis == nullptr);
 
-                symThis = instr->GetSrc1()->AsRegOpnd()->m_sym;
+                //if (symThis == nullptr)
+                {
+                    symThis = instr->GetSrc1()->AsRegOpnd()->m_sym;
+                }
                 break;
 
             default:

--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -1743,7 +1743,6 @@ void Parser::CreateSpecialSymbolDeclarations(ParseNodePtr pnodeFnc, bool isGloba
     if (pnodeFnc->sxFnc.IsDerivedClassConstructor())
     {
         varDeclNode = CreateSpecialVarDeclIfNeeded(pnodeFnc, wellKnownPropertyPids._superConstructor);
-
         if (varDeclNode)
         {
             varDeclNode->sxPid.sym->SetIsSuperConstructor(true);

--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -1705,7 +1705,7 @@ void Parser::CreateSpecialSymbolDeclarations(ParseNodePtr pnodeFnc, bool isGloba
     Assert(!(isGlobal && (this->m_grfscr & fscrEval)));
     Assert(!isGlobal || (this->m_grfscr & fscrEvalCode));
 
-    bool isTopLevelEventHandler = (this->m_grfscr & fscrImplicitThis || this->m_grfscr & fscrImplicitParents);
+    bool isTopLevelEventHandler = (this->m_grfscr & fscrImplicitThis || this->m_grfscr & fscrImplicitParents) && !pnodeFnc->sxFnc.IsNested();
 
     // Create a 'this' symbol for indirect eval, non-lambda functions with references to 'this', and all class constructors and top level event hanlders.
     ParseNodePtr varDeclNode = CreateSpecialVarDeclIfNeeded(pnodeFnc, wellKnownPropertyPids._this, pnodeFnc->sxFnc.IsClassConstructor() || isTopLevelEventHandler);

--- a/lib/Parser/Parse.h
+++ b/lib/Parser/Parse.h
@@ -767,6 +767,7 @@ private:
 
     void CreateSpecialSymbolDeclarations(ParseNodePtr pnodeFnc, bool isGlobal);
     ParseNodePtr ReferenceSpecialName(IdentPtr pid, charcount_t ichMin = 0, charcount_t ichLim = 0, bool createNode = false);
+    ParseNodePtr CreateSpecialVarDeclIfNeeded(ParseNodePtr pnodeFnc, IdentPtr pid, bool forceCreate = false);
 
     template<const bool backgroundPidRefs>
     void BindPidRefs(BlockInfoStack *blockInfo, uint maxBlockId = (uint)-1);

--- a/lib/Parser/ptree.h
+++ b/lib/Parser/ptree.h
@@ -347,6 +347,7 @@ public:
     bool IsConstructor() const { return HasNoFlags(kFunctionIsAsync|kFunctionIsLambda|kFunctionIsAccessor);  }
     bool IsClassConstructor() const { return HasFlags(kFunctionIsClassConstructor); }
     bool IsBaseClassConstructor() const { return HasFlags(kFunctionIsBaseClassConstructor); }
+    bool IsDerivedClassConstructor() const { return IsClassConstructor() && !IsBaseClassConstructor(); }
     bool IsClassMember() const { return HasFlags(kFunctionIsClassMember); }
     bool IsDeclaration() const { return HasFlags(kFunctionDeclaration); }
     bool IsGeneratedDefault() const { return HasFlags(kFunctionIsGeneratedDefault); }

--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -2201,17 +2201,9 @@ void ByteCodeGenerator::LoadSuperConstructorObject(FuncInfo *funcInfo)
 {
     Symbol* superConstructorSym = funcInfo->GetSuperConstructorSymbol();
     Assert(superConstructorSym);
+    Assert(!funcInfo->IsLambda());
 
-    if (funcInfo->IsClassMember())
-    {
-        Assert(!funcInfo->IsLambda());
-
-        m_writer.Reg1(Js::OpCode::LdFuncObj, superConstructorSym->GetLocation());
-    }
-    else
-    {
-        m_writer.Reg1(Js::OpCode::LdUndef, superConstructorSym->GetLocation());
-    }
+    m_writer.Reg1(Js::OpCode::LdFuncObj, superConstructorSym->GetLocation());
 }
 
 void ByteCodeGenerator::LoadSuperObject(FuncInfo *funcInfo)
@@ -4921,14 +4913,9 @@ void ByteCodeGenerator::EmitPropLoadThis(Js::RegSlot lhsLocation, ParseNode *pno
 {
     Symbol* sym = pnode->sxPid.sym;
 
-    if (funcInfo->IsLambda() && !sym && !(this->flags & fscrEval))
+    if (!(this->flags & fscrEval) && ((funcInfo->IsLambda() && !sym) || (funcInfo->IsGlobalFunction() && !funcInfo->GetThisSymbol())))
     {
         EmitThis(funcInfo, lhsLocation, funcInfo->nullConstantRegister);
-    }
-    else if (funcInfo->IsGlobalFunction() && !(this->flags & fscrEval))
-    {
-        Assert(funcInfo->GetThisSymbol());
-        this->Writer()->Reg2(Js::OpCode::Ld_A, lhsLocation, funcInfo->GetThisSymbol()->GetLocation());
     }
     else
     {

--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -4884,14 +4884,20 @@ ByteCodeGenerator::GetLdSlotOp(Scope *scope, int envIndex, Js::RegSlot scopeLoca
 
 bool ByteCodeGenerator::ShouldLoadConstThis(FuncInfo* funcInfo)
 {
-    // Load a const 'this' binding if the following holds
+#if DBG
+    // We should load a const 'this' binding if the following holds
     // - The function has a 'this' name node
     // - We are in a global or global lambda function
     // - The function has no 'this' symbol (an indirect eval would have this symbol)
-    return funcInfo->thisConstantRegister != Js::Constants::NoRegister
-        && (funcInfo->IsLambda() || funcInfo->IsGlobalFunction())
-        && !funcInfo->GetThisSymbol()
-        && !(this->flags & fscrEval);
+    if (funcInfo->thisConstantRegister != Js::Constants::NoRegister)
+    {
+        Assert((funcInfo->IsLambda() || funcInfo->IsGlobalFunction())
+            && !funcInfo->GetThisSymbol()
+            && !(this->flags & fscrEval));
+    }
+#endif
+
+    return funcInfo->thisConstantRegister != Js::Constants::NoRegister;
 }
 
 void ByteCodeGenerator::EmitPropLoadThis(Js::RegSlot lhsLocation, ParseNode *pnode, FuncInfo *funcInfo, bool chkUndecl)

--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -2124,6 +2124,7 @@ void ByteCodeGenerator::LoadThisObject(FuncInfo *funcInfo, bool thisLoadedFromPa
 {
     Symbol* thisSym = funcInfo->GetThisSymbol();
     Assert(thisSym);
+    Assert(!funcInfo->IsLambda());
 
     if (this->scriptContext->GetConfig()->IsES6ClassAndExtendsEnabled() && funcInfo->IsClassConstructor())
     {
@@ -2154,7 +2155,7 @@ void ByteCodeGenerator::LoadThisObject(FuncInfo *funcInfo, bool thisLoadedFromPa
             this->Writer()->MarkLabel(skipLabel);
         }
     }
-    else if (!funcInfo->IsGlobalFunction() && !funcInfo->IsLambda())
+    else if (!funcInfo->IsGlobalFunction())
     {
         //
         // thisLoadedFromParams would be true for the event Handler case,
@@ -2165,13 +2166,13 @@ void ByteCodeGenerator::LoadThisObject(FuncInfo *funcInfo, bool thisLoadedFromPa
             m_writer.ArgIn0(thisSym->GetLocation());
         }
 
-        EmitThis(funcInfo, thisSym->GetLocation());
+        EmitThis(funcInfo, thisSym->GetLocation(), thisSym->GetLocation());
     }
     else
     {
-        Assert(funcInfo->IsGlobalFunction() || funcInfo->IsLambda());
+        Assert(funcInfo->IsGlobalFunction());
         Js::RegSlot root = funcInfo->nullConstantRegister;
-        EmitThis(funcInfo, root);
+        EmitThis(funcInfo, thisSym->GetLocation(), root);
     }
 }
 
@@ -2375,15 +2376,15 @@ void ByteCodeGenerator::GetEnclosingNonLambdaScope(FuncInfo *funcInfo, Scope * &
     }
 }
 
-void ByteCodeGenerator::EmitThis(FuncInfo *funcInfo, Js::RegSlot fromRegister)
+void ByteCodeGenerator::EmitThis(FuncInfo *funcInfo, Js::RegSlot lhsLocation, Js::RegSlot fromRegister)
 {
     if (funcInfo->byteCodeFunction->GetIsStrictMode() && !funcInfo->IsGlobalFunction() && !funcInfo->IsLambda())
     {
-        m_writer.Reg2(Js::OpCode::StrictLdThis, funcInfo->GetThisSymbol()->GetLocation(), fromRegister);
+        m_writer.Reg2(Js::OpCode::StrictLdThis, lhsLocation, fromRegister);
     }
     else
     {
-        m_writer.Reg2Int1(Js::OpCode::LdThis, funcInfo->GetThisSymbol()->GetLocation(), fromRegister, this->GetModuleID());
+        m_writer.Reg2Int1(Js::OpCode::LdThis, lhsLocation, fromRegister, this->GetModuleID());
     }
 }
 
@@ -4918,12 +4919,25 @@ ByteCodeGenerator::GetLdSlotOp(Scope *scope, int envIndex, Js::RegSlot scopeLoca
 
 void ByteCodeGenerator::EmitPropLoadThis(Js::RegSlot lhsLocation, ParseNode *pnode, FuncInfo *funcInfo, bool chkUndecl)
 {
-    this->EmitPropLoad(lhsLocation, pnode->sxPid.sym, pnode->sxPid.pid, funcInfo, true);
-
     Symbol* sym = pnode->sxPid.sym;
-    if ((!sym || sym->GetNeedDeclaration()) && chkUndecl)
+
+    if (funcInfo->IsLambda() && !sym && !(this->flags & fscrEval))
     {
-        this->Writer()->Reg1(Js::OpCode::ChkUndecl, lhsLocation);
+        EmitThis(funcInfo, lhsLocation, funcInfo->nullConstantRegister);
+    }
+    else if (funcInfo->IsGlobalFunction() && !(this->flags & fscrEval))
+    {
+        Assert(funcInfo->GetThisSymbol());
+        this->Writer()->Reg2(Js::OpCode::Ld_A, lhsLocation, funcInfo->GetThisSymbol()->GetLocation());
+    }
+    else
+    {
+        this->EmitPropLoad(lhsLocation, pnode->sxPid.sym, pnode->sxPid.pid, funcInfo, true);
+
+        if ((!sym || sym->GetNeedDeclaration()) && chkUndecl)
+        {
+            this->Writer()->Reg1(Js::OpCode::ChkUndecl, lhsLocation);
+        }
     }
 }
 

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -5080,7 +5080,7 @@ void AssignRegisters(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator)
             Assert(pnode->sxPid.pid->GetPropertyId() != Js::Constants::NoProperty);
 
             // Referring to 'this' with no var decl needs to load 'this' root value via LdThis from null
-            if (ByteCodeGenerator::IsThis(pnode) && !byteCodeGenerator->TopFuncInfo()->GetThisSymbol())
+            if (ByteCodeGenerator::IsThis(pnode) && !byteCodeGenerator->TopFuncInfo()->GetThisSymbol() && !(byteCodeGenerator->GetFlags() & fscrEval))
             {
                 byteCodeGenerator->AssignNullConstRegister();
                 byteCodeGenerator->AssignThisConstRegister();

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -5074,7 +5074,7 @@ void AssignRegisters(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator)
             Assert(pnode->sxPid.pid->GetPropertyId() != Js::Constants::NoProperty);
 
             // Global lambda referring to 'this' needs to load 'this' root value via LdThis from null
-            if (byteCodeGenerator->TopFuncInfo()->IsLambda() && ByteCodeGenerator::IsThis(pnode))
+            if (ByteCodeGenerator::IsThis(pnode) && !byteCodeGenerator->TopFuncInfo()->GetThisSymbol())
             {
                 byteCodeGenerator->AssignNullConstRegister();
             }

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -2950,9 +2950,9 @@ FuncInfo* PostVisitFunction(ParseNode* pnode, ByteCodeGenerator* byteCodeGenerat
         {
             byteCodeGenerator->AssignRegister(top->GetThisSymbol());
 
-            if (top->IsGlobalFunction() || top->IsLambda())
+            if (top->IsGlobalFunction())
             {
-                // Global function or lambda at global need to load this from null
+                // Global function needs to load this from null
                 byteCodeGenerator->AssignNullConstRegister();
             }
         }
@@ -5072,6 +5072,12 @@ void AssignRegisters(ParseNode *pnode, ByteCodeGenerator *byteCodeGenerator)
         if (sym == nullptr)
         {
             Assert(pnode->sxPid.pid->GetPropertyId() != Js::Constants::NoProperty);
+
+            // Global lambda referring to 'this' needs to load 'this' root value via LdThis from null
+            if (byteCodeGenerator->TopFuncInfo()->IsLambda() && ByteCodeGenerator::IsThis(pnode))
+            {
+                byteCodeGenerator->AssignNullConstRegister();
+            }
         }
         else
         {

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.h
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.h
@@ -277,7 +277,7 @@ public:
     void LoadUncachedHeapArguments(FuncInfo *funcInfo);
     void LoadCachedHeapArguments(FuncInfo *funcInfo);
     void LoadThisObject(FuncInfo *funcInfo, bool thisLoadedFromParams = false);
-    void EmitThis(FuncInfo *funcInfo, Js::RegSlot fromRegister);
+    void EmitThis(FuncInfo *funcInfo, Js::RegSlot lhsLocation, Js::RegSlot fromRegister);
     void LoadNewTargetObject(FuncInfo *funcInfo);
     void LoadSuperObject(FuncInfo *funcInfo);
     void LoadSuperConstructorObject(FuncInfo *funcInfo);

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.h
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.h
@@ -169,6 +169,7 @@ public:
     Js::RegSlot AssignUndefinedConstRegister();
     Js::RegSlot AssignTrueConstRegister();
     Js::RegSlot AssignFalseConstRegister();
+    Js::RegSlot AssignThisConstRegister();
     void SetNeedEnvRegister();
     void AssignFrameObjRegister();
     void AssignFrameSlotsRegister();
@@ -281,7 +282,6 @@ public:
     void LoadNewTargetObject(FuncInfo *funcInfo);
     void LoadSuperObject(FuncInfo *funcInfo);
     void LoadSuperConstructorObject(FuncInfo *funcInfo);
-    void GetEnclosingNonLambdaScope(FuncInfo *funcInfo, Scope * &scope, Js::PropertyId &envIndex);
     void EmitSuperCall(FuncInfo* funcInfo, ParseNode* pnode, BOOL fReturnValue);
     void EmitClassConstructorEndCode(FuncInfo *funcInfo);
     void EmitBaseClassConstructorThisObject(FuncInfo *funcInfo);
@@ -304,6 +304,8 @@ public:
     void EmitPropDelete(Js::RegSlot lhsLocation, Symbol *sym, IdentPtr pid, FuncInfo *funcInfo);
     void EmitPropTypeof(Js::RegSlot lhsLocation, Symbol *sym, IdentPtr pid, FuncInfo *funcInfo);
     void EmitTypeOfFld(FuncInfo * funcInfo, Js::PropertyId propertyId, Js::RegSlot value, Js::RegSlot instance, Js::OpCode op1);
+
+    bool ShouldLoadConstThis(FuncInfo* funcInfo);
 
     void EmitPropLoadThis(Js::RegSlot lhsLocation, ParseNode *pnode, FuncInfo *funcInfo, bool chkUndecl);
     void EmitPropStoreForSpecialSymbol(Js::RegSlot rhsLocation, Symbol *sym, IdentPtr pid, FuncInfo *funcInfo, bool init);

--- a/lib/Runtime/ByteCode/FuncInfo.cpp
+++ b/lib/Runtime/ByteCode/FuncInfo.cpp
@@ -153,6 +153,11 @@ BOOL FuncInfo::IsBaseClassConstructor() const
     return root->sxFnc.IsBaseClassConstructor();
 }
 
+BOOL FuncInfo::IsDerivedClassConstructor() const
+{
+    return root->sxFnc.IsDerivedClassConstructor();
+}
+
 Scope *
 FuncInfo::GetGlobalBlockScope() const
 {

--- a/lib/Runtime/ByteCode/FuncInfo.cpp
+++ b/lib/Runtime/ByteCode/FuncInfo.cpp
@@ -26,6 +26,7 @@ FuncInfo::FuncInfo(
     outArgsDepth(0),
 #endif
     name(name),
+    thisConstantRegister(Js::Constants::NoRegister),
     nullConstantRegister(Js::Constants::NoRegister),
     undefinedConstantRegister(Js::Constants::NoRegister),
     trueConstantRegister(Js::Constants::NoRegister),

--- a/lib/Runtime/ByteCode/FuncInfo.h
+++ b/lib/Runtime/ByteCode/FuncInfo.h
@@ -102,6 +102,7 @@ public:
     Js::RegSlot undefinedConstantRegister; // location, if any, of enregistered undefined constant
     Js::RegSlot trueConstantRegister; // location, if any, of enregistered true constant
     Js::RegSlot falseConstantRegister; // location, if any, of enregistered false constant
+    Js::RegSlot thisConstantRegister; // location, if any, of enregistered 'this' constant
 
 private:
     Js::RegSlot envRegister; // location, if any, of the closure environment
@@ -506,6 +507,15 @@ public:
         Js::RegSlot reg = constReg? NextConstRegister() : NextVarRegister();
         this->envRegister = reg;
         return reg;
+    }
+
+    Js::RegSlot AssignThisConstRegister()
+    {
+        if (this->thisConstantRegister == Js::Constants::NoRegister)
+        {
+            this->thisConstantRegister = this->NextVarRegister();
+        }
+        return this->thisConstantRegister;
     }
 
     Js::RegSlot AssignNullConstRegister()

--- a/lib/Runtime/ByteCode/FuncInfo.h
+++ b/lib/Runtime/ByteCode/FuncInfo.h
@@ -468,6 +468,7 @@ public:
     BOOL IsLambda() const;
     BOOL IsClassConstructor() const;
     BOOL IsBaseClassConstructor() const;
+    BOOL IsDerivedClassConstructor() const;
 
     void RemoveTargetStmt(ParseNode* pnodeStmt) {
         targetStatements.Remove(pnodeStmt);

--- a/test/Basics/SpecialSymbolCapture.js
+++ b/test/Basics/SpecialSymbolCapture.js
@@ -902,7 +902,14 @@ var tests = [
             }
             foo.call(_this)
         }
-    }
+    },
+    {
+        name: "Loading 'this' binding as a call target",
+        body: function() {
+            assert.throws(() => WScript.LoadScript(`with({}) { this() }`), TypeError, "Loading global 'this' binding as a call target should always throw - 'this' is an object", "Function expected");
+            assert.throws(() => this(), TypeError, "Capturing function 'this' binding and emitting as a call target should throw if 'this' is not a function", "Function expected");
+        }
+    },
 ]
 
 testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });


### PR DESCRIPTION
Do not create a 'this' symbol for global functions and global lambda functions. Instead emit a LdThis into a special register stored in the FuncInfo during the prolog of these functions and load that register at every name node referencing 'this'. 

Add `PnFnc::IsDerivedClassConstructor` and refactor `Parser::CreateSpecialSymbolDeclarations`
    
`PnFnc::IsDerivedClassConstructor` is just a convenience method for `(PnFnc::IsClassConstructor() && !PnFnc::IsBaseClassConstructor())`.
    
`Parser::CreateSpecialSymbolDeclarations` had the code which does the check for special symbol references factored-out so it's a bit simpler.
    
Simplify the logic to construct the special symbol var declarations a little bit. Also fix emitting a special symbol as a call target. This fixes:
https://microsoft.visualstudio.com/OS/_workitems?id=13977724&_a=edit