### PR TITLE
Add unit tests for @@toStringTag caching, DictionaryTypeHandlerBases in missing-prop caches

### DIFF
--- a/test/es6/toStringTag.js
+++ b/test/es6/toStringTag.js
@@ -262,6 +262,25 @@ var tests = [
             p[Symbol.toStringTag] = "prototypeTag";
             assert.areEqual("[object prototypeTag]", o.toString(), "second call to toString picks up @@toStringTag in prototype");
         }
+    },
+    {
+        name: "'Defining' @@toStringTag in a proxy works, including correct caching",
+        body: function () {
+            // force use of DictionaryTypeHandlerBase
+            var o = { x: 3, set x(newVal) { } };
+            // load o[Symbol.toStringTag] into missing-property cache
+            assert.areEqual("[object Object]", o.toString(), "initial call to toString fails to find @@toStringTag");
+
+            var handler = {
+                get: function(target, name) {
+                    return name === Symbol.toStringTag ? "TEST" : target[name];
+                }
+            };
+            var proxy = new Proxy(o, handler);
+
+            assert.areEqual("[object TEST]", proxy.toString(), "pick up proxy override of @@toStringTag");
+            assert.areEqual("[object Object]", o.toString(), "behavior of original object is unchanged");
+        }
     }
 ];
 

--- a/test/es6/toStringTag.js
+++ b/test/es6/toStringTag.js
@@ -223,6 +223,45 @@ var tests = [
 
             assert.areEqual("[object before\0after]", o.toString(), "ToString implementation handles embedded null characters in @@toStringTag property value");
         }
+    },
+    {
+        name: "Adding @@toStringTag dynamically correctly invalidates cache",
+        body: function () {
+            // Define some setters to force both objects to have DictionaryTypeHandlerBases
+            var p = { x: 3, set x(newVal) { } };
+            var o = Object.create(p);
+            Object.defineProperty(o, 'y', { get: function() { return 4; }, set: function (newVal) { } });
+            // next assert is here just to get o[Symbol.toStringTag] into missing-property cache
+            assert.areEqual("[object Object]", o.toString(), "initial call to toString fails to find @@toStringTag");
+            o[Symbol.toStringTag] = "customTag";
+            assert.areEqual("[object customTag]", o.toString(), "second call to toString picks up changed @@toStringTag");
+        }
+    },
+    {
+        name: "Adding getter method for @@toStringTag correctly invalidates cache",
+        body: function () {
+            // force use of DictionaryTypeHandlerBase
+            var o = { x: 3, set x(newVal) { } };
+            // load o[Symbol.toStringTag] into missing-property cache
+            assert.areEqual("[object Object]", o.toString(), "initial call to toString fails to find @@toStringTag");
+            Object.defineProperty(o, Symbol.toStringTag, {
+                get: function () { return "customTag"; }
+            });
+            assert.areEqual("[object customTag]", o.toString(), "second call to toString picks up getter for @@toStringTag");
+        }
+    },
+    {
+        name: "Dyanmically adding @@toStringTag to prototype correctly invalidates cache",
+        body: function () {
+            // force use of DictionaryTypeHandlerBase
+            var p = { x: 3, set x(newVal) { } };
+            var o = Object.create(p);
+            Object.defineProperty(o, 'y', { get: function() { return 4; }, set: function(newVal) { } });
+            // load o[Symbol.toStringTag] into missing-property cache
+            assert.areEqual("[object Object]", o.toString(), "initial call to toString fails to find @@toStringTag");
+            p[Symbol.toStringTag] = "prototypeTag";
+            assert.areEqual("[object prototypeTag]", o.toString(), "second call to toString picks up @@toStringTag in prototype");
+        }
     }
 ];
 


### PR DESCRIPTION
Should have been part of my last commit, but got overlooked.

For reviewers:

1. This is as much a test of whether I got missing-prop caching for DictionaryTypeHandlerBase right as it is a test of toStringTag caching.  As such, should I move these tests to a sibling of test/es6?

2. Are there any other crazy ways to add @@toStringTag to an existing object that I overlooked?