### PR TITLE
Allow remaining DynamicTypeHandlers into missing-property caches

### DIFF
--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -1808,12 +1808,19 @@ CommonNumber:
                 Output::Print(_u("MissingPropertyCaching: Missing property %d on slow path.\n"), propertyId);
             }
 
-            // Only cache missing property lookups for non-root field loads on objects that have PathTypeHandlers and DictionaryTypeHandlers, because only these types have the right behavior
-            // when the missing property is later added: path types guarantee a type change, and DictionaryTypeHandlerBase::AddProperty explicitly invalidates all prototype caches for the
-            // property.  (We don't support other types only because we haven't needed to yet; we do not anticipate any difficulties in adding the cache-invalidation logic there if that changes.)
-            if (!PHASE_OFF1(MissingPropertyCachePhase) && !isRoot && DynamicObject::Is(instance) &&
-                (DynamicObject::FromVar(instance)->GetDynamicType()->GetTypeHandler()->IsPathTypeHandler() || DynamicObject::FromVar(instance)->GetDynamicType()->GetTypeHandler()->IsDictionaryTypeHandler()))
+            // Only cache missing property lookups for non-root field loads on objects.
+            if (!PHASE_OFF1(MissingPropertyCachePhase) && !isRoot && DynamicObject::Is(instance))
             {
+#if DBG
+                {
+                    // Adding a type to a missing-property cache requires special handling to ensure that the
+                    // cache is correctly invalidated if we later add the missing property to that type.  Ensure that
+                    // the type we're adding is a TypeHandler that either creates a new type on adding a property
+                    // (like PathTypeHandler) or invalidates prototype caches.
+                    DynamicTypeHandler *typeHandler = DynamicObject::FromVar(instance)->GetDynamicType()->GetTypeHandler();
+                    Assert(typeHandler->IsPathTypeHandler() || typeHandler->IsDictionaryTypeHandler() || typeHandler->IsSimpleDictionaryTypeHandler() || typeHandler->IsSimpleTypeHandler());
+                }
+#endif
 #ifdef MISSING_PROPERTY_STATS
                 if (PHASE_STATS1(MissingPropertyCachePhase))
                 {

--- a/lib/Runtime/Types/SimpleDictionaryTypeHandler.cpp
+++ b/lib/Runtime/Types/SimpleDictionaryTypeHandler.cpp
@@ -2778,15 +2778,9 @@ namespace Js
         PropertyId propertyId = TPropertyKey_GetOptionalPropertyId(scriptContext, propertyKey);
         if (propertyId != Constants::NoProperty)
         {
-            if ((typeHandler->GetFlags() & IsPrototypeFlag)
-                || (!IsInternalPropertyId(propertyId)
-                && JavascriptOperators::HasProxyOrPrototypeInlineCacheProperty(instance, propertyId)))
-            {
-                // We don't evolve dictionary types when adding a field, so we need to invalidate prototype caches.
-                // We only have to do this though if the current type is used as a prototype, or the current property
-                // is found on the prototype chain.
-                scriptContext->InvalidateProtoCaches(propertyId);
-            }
+            // Always invalidate prototype caches when adding a property to this type, in case the new property is
+            // in a missing-property cache on this type.
+            scriptContext->InvalidateProtoCaches(propertyId);
             SetPropertyUpdateSideEffect(instance, propertyId, value, possibleSideEffects);
         }
         return true;

--- a/lib/Runtime/Types/SimpleTypeHandler.cpp
+++ b/lib/Runtime/Types/SimpleTypeHandler.cpp
@@ -1005,11 +1005,9 @@ namespace Js
         PropertyValueInfo::Set(info, instance, static_cast<PropertyIndex>(propertyCount), attributes);
         propertyCount++;
 
-        if ((this->GetFlags() && IsPrototypeFlag)
-            || JavascriptOperators::HasProxyOrPrototypeInlineCacheProperty(instance, propertyId))
-        {
-            scriptContext->InvalidateProtoCaches(propertyId);
-        }
+        // Always invalidate prototype caches when adding a property to this type, in case the new property is in a
+        // missing-property cache on this type.
+        scriptContext->InvalidateProtoCaches(propertyId);
         SetPropertyUpdateSideEffect(instance, propertyId, value, possibleSideEffects);
         return true;
     }

--- a/lib/Runtime/Types/SimpleTypeHandler.h
+++ b/lib/Runtime/Types/SimpleTypeHandler.h
@@ -69,6 +69,8 @@ namespace Js
 
         virtual void SetIsPrototype(DynamicObject* instance) override;
 
+        BOOL IsSimpleTypeHandler() const override { return TRUE; }
+
 #if DBG
         virtual bool SupportsPrototypeInstances() const { return !ChangeTypeOnProto() && !(GetIsOrMayBecomeShared() && IsolatePrototypes()); }
         virtual bool CanStorePropertyValueDirectly(const DynamicObject* instance, PropertyId propertyId, bool allowLetConst) override;

--- a/lib/Runtime/Types/TypeHandler.h
+++ b/lib/Runtime/Types/TypeHandler.h
@@ -538,6 +538,7 @@ namespace Js
         virtual BOOL IsPathTypeHandler() const { return FALSE; }
         virtual BOOL IsSimpleDictionaryTypeHandler() const {return FALSE; }
         virtual BOOL IsDictionaryTypeHandler() const {return FALSE;}
+        virtual BOOL IsSimpleTypeHandler() const { return FALSE; }
 
         static bool IsolatePrototypes() { return CONFIG_FLAG(IsolatePrototypes); }
         static bool ChangeTypeOnProto() { return CONFIG_FLAG(ChangeTypeOnProto); }


### PR DESCRIPTION
As @MikeHolman and @obastemur requested, allow the remaining DynamicTypeHandlers into missing-property caches.

I've got a OneCirro run pending; I'll wait for that to finish before I land this.

I'm pretty sure that I've covered all of the subclasses of DynamicTypeHandler, but it's possible that I missed one.  The assert on line 1821 of JavascriptOperators.cpp guards against this, although it's fairly _ad hoc_.

Questions for reviewers:
1. Should I allow NullTypeHandlerBase and NullTypeHandler in JavascriptOperators.cpp?  They don't come up in the unit tests, but it should be safe, because adding a property to either of these types causes us to create a new type, so cache invalidation isn't a problem.
2. Because the assertion is fairly _ad hoc,_ I'm not sure how much value it adds.  Keep it?