### PR TITLE
 Update Intl.cpp error handling, utf8 conversion, currency formatter creation

### DIFF
--- a/lib/Common/Codex/Utf8Helper.h
+++ b/lib/Common/Codex/Utf8Helper.h
@@ -12,6 +12,9 @@ namespace utf8
     /// The caller is responsible for freeing the memory, which is allocated
     /// using Allocator.
     /// The returned string is null terminated.
+    /// TODO(jahorto): This file's dependencies mean that it cannot be included in PlatformAgnostic
+    ///     Thus, this function is currently ~duplicated in PlatformAgnostic::Intl::Utf16ToUtf8 (Intl.cpp)
+    ///     As long as that function exists, it _must_ be updated alongside any updates here
     ///
     template <typename AllocatorFunction>
     HRESULT WideStringToNarrow(_In_ AllocatorFunction allocator, _In_ LPCWSTR sourceString, size_t sourceCount, _Out_ LPSTR* destStringPtr, _Out_ size_t* destCount, size_t* allocateCount = nullptr)


### PR DESCRIPTION
This pull request takes the assert and CreateCurrencyFormatter changes from https://github.com/Microsoft/ChakraCore/pull/3913 and adds a smaller abstraction layer over Utf8 conversion than the Utf8Helper changes introduced there.