### PR TITLE
Initialize Intl/JsBuiltin extension objects when needed only

### DIFF
--- a/lib/Runtime/Library/EngineInterfaceObject.cpp
+++ b/lib/Runtime/Library/EngineInterfaceObject.cpp
@@ -159,7 +159,7 @@ namespace Js
 
         for (uint i = 0; i <= MaxEngineInterfaceExtensionKind; i++)
         {
-            if (engineExtensions[i] != nullptr)
+            if (engineExtensions[i] != nullptr && engineExtensions[i]->GetNeedsInit())
             {
                 engineExtensions[i]->Initialize();
             }

--- a/lib/Runtime/Library/EngineInterfaceObject.h
+++ b/lib/Runtime/Library/EngineInterfaceObject.h
@@ -22,12 +22,17 @@ namespace Js
     public:
         EngineExtensionObjectBase(EngineInterfaceExtensionKind kind, Js::ScriptContext * context) :
             extensionKind(kind),
-            scriptContext(context)
+            scriptContext(context),
+            needsInit(false)
         {
         }
 
         EngineInterfaceExtensionKind GetExtensionKind() const { return extensionKind; }
         ScriptContext* GetScriptContext() const { return scriptContext; }
+        bool GetNeedsInit() const {return needsInit;}
+
+        void SetNeedsInit(bool init) { needsInit = init;  }
+
         virtual void Initialize() = 0;
 #if DBG
         virtual void DumpByteCode() = 0;
@@ -36,6 +41,7 @@ namespace Js
     protected:
         Field(EngineInterfaceExtensionKind) extensionKind;
         Field(ScriptContext*) scriptContext;
+        Field(bool) needsInit;
     };
 
 #define EngineInterfaceObject_CommonFunctionProlog(function, callInfo) \

--- a/lib/Runtime/Library/JavascriptLibrary.cpp
+++ b/lib/Runtime/Library/JavascriptLibrary.cpp
@@ -5300,8 +5300,10 @@ namespace Js
 
         auto intlInitializer = [&](IntlEngineInterfaceExtensionObject* intlExtension, ScriptContext * scriptContext, DynamicObject* intlObject) ->void
         {
+            intlExtension->SetNeedsInit(true);
             intlExtension->InjectIntlLibraryCode(scriptContext, intlObject, IntlInitializationType::Intl);
         };
+
         IntlObject->GetLibrary()->InitializeIntlForPrototypes(intlInitializer);
 
         return true;
@@ -5311,6 +5313,7 @@ namespace Js
     {
         auto stringPrototypeInitializer = [&](IntlEngineInterfaceExtensionObject* intlExtension, ScriptContext * scriptContext, DynamicObject* intlObject) ->void
         {
+            intlExtension->SetNeedsInit(true);
             intlExtension->InjectIntlLibraryCode(scriptContext, intlObject, IntlInitializationType::StringPrototype);
         };
         InitializeIntlForPrototypes(stringPrototypeInitializer);
@@ -5320,6 +5323,7 @@ namespace Js
     {
         auto datePrototypeInitializer = [&](IntlEngineInterfaceExtensionObject* intlExtension, ScriptContext * scriptContext, DynamicObject* intlObject) ->void
         {
+            intlExtension->SetNeedsInit(true);
             intlExtension->InjectIntlLibraryCode(scriptContext, intlObject, IntlInitializationType::DatePrototype);
         };
         InitializeIntlForPrototypes(datePrototypeInitializer);
@@ -5329,6 +5333,7 @@ namespace Js
     {
         auto numberPrototypeInitializer = [&](IntlEngineInterfaceExtensionObject* intlExtension, ScriptContext * scriptContext, DynamicObject* intlObject) ->void
         {
+            intlExtension->SetNeedsInit(true);
             intlExtension->InjectIntlLibraryCode(scriptContext, intlObject, IntlInitializationType::NumberPrototype);
         };
         InitializeIntlForPrototypes(numberPrototypeInitializer);


### PR DESCRIPTION
When we add JsBuiltins to JavascriptLibrary we do not want Intl to be loaded every time the JsBuiltins are needed.
Make Intl loading on-demand.
