### PR TITLE
Make GetRealAddressFromInterior public

### DIFF
--- a/lib/Common/Memory/Recycler.h
+++ b/lib/Common/Memory/Recycler.h
@@ -1923,8 +1923,10 @@ public:
     bool IsPostEnumHeapValidationInProgress() const { return pfPostHeapEnumScanCallback != NULL; }
 #endif
 
-private:
+public:
     void* GetRealAddressFromInterior(void* candidate);
+
+private:
     void BeginNonCollectingMark();
     void EndNonCollectingMark();
 


### PR DESCRIPTION
Make Recycler::GetRealAddressFromInterior public to enable a new export for use by the RecyclerVistedHostHeap.