### PR TITLE
Do not load 'this' explicitly for class expression call target

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -7665,14 +7665,6 @@ void EmitCallTarget(
         break;
     }
 
-    case knopClassDecl:
-    {
-        Emit(pnodeTarget, byteCodeGenerator, funcInfo, false);
-        // We won't always have an assigned this register (e.g. class expression calls.) We need undefined in this case.
-        *thisLocation = funcInfo->GetThisSymbol()->GetLocation() == Js::Constants::NoRegister ? funcInfo->undefinedConstantRegister : funcInfo->GetThisSymbol()->GetLocation();
-        break;
-    }
-
     case knopName:
     {
         if (!pnodeTarget->IsSpecialName())

--- a/test/Basics/SpecialSymbolCapture.js
+++ b/test/Basics/SpecialSymbolCapture.js
@@ -910,6 +910,13 @@ var tests = [
             assert.throws(() => this(), TypeError, "Capturing function 'this' binding and emitting as a call target should throw if 'this' is not a function", "Function expected");
         }
     },
+    {
+        name: "Class expression as call target without 'this' binding",
+        body: function() {
+            assert.throws(() => WScript.LoadScript(`(class classExpr {}())`), TypeError, "Class expression called at global scope", "Class constructor cannot be called without the new keyword");
+            assert.throws(() => WScript.LoadScript(`(() => (class classExpr {}()))()`), TypeError, "Class expression called in global lambda", "Class constructor cannot be called without the new keyword");
+        }
+    }
 ]
 
 testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });


### PR DESCRIPTION
We had a special case for when a class expression is emitted as a call
target which tried to load the 'this' value for the enclosing function.
Sometimes enclosing function has no 'this' binding (as in global
function or global lambda) which would mean there is no 'this' symbol
for us to load leading to null dereference.

Since class constructor cannot be called without the new keyword and we
always construct the value assigned to 'this' during function prolog,
there doesn't seem to be any reason at all to even load the 'this' value
here.

Fixes:
https://microsoft.visualstudio.com/OS/_workitems?id=14256595&_a=edit
