### PR TITLE
Fix multi-unit characters after numeric literal

### DIFF
--- a/lib/Parser/Scan.cpp
+++ b/lib/Parser/Scan.cpp
@@ -651,10 +651,14 @@ LIdCheck:
     // https://tc39.github.io/ecma262/#sec-literals-numeric-literals
     // The SourceCharacter immediately following a NumericLiteral must not be an IdentifierStart or DecimalDigit.
     // For example : 3in is an error and not the two input elements 3 and in
-    codepoint_t outChar = 0;
     // If a base was speficied, use the first character denoting the constant. In this case, pchT is pointing to the base specifier.
     EncodedCharPtr startingLocation = baseSpecified ? pchT + 1 : pchT;
-    if (this->charClassifier->IsIdStart(*startingLocation))
+    codepoint_t outChar = *startingLocation;
+    if (this->IsMultiUnitChar((OLECHAR)outChar))
+    {
+        outChar = this->template ReadRest<true>((OLECHAR)outChar, startingLocation, last);
+    }
+    if (this->charClassifier->IsIdStart(outChar))
     {
         Error(ERRIdAfterLit);
     }

--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -7652,14 +7652,6 @@ void EmitCallTarget(
         break;
     }
 
-    case knopClassDecl:
-    {
-        Emit(pnodeTarget, byteCodeGenerator, funcInfo, false);
-        // We won't always have an assigned this register (e.g. class expression calls.) We need undefined in this case.
-        *thisLocation = funcInfo->GetThisSymbol()->GetLocation() == Js::Constants::NoRegister ? funcInfo->undefinedConstantRegister : funcInfo->GetThisSymbol()->GetLocation();
-        break;
-    }
-
     case knopName:
     {
         if (!pnodeTarget->IsSpecialName())

--- a/test/Basics/SpecialSymbolCapture.js
+++ b/test/Basics/SpecialSymbolCapture.js
@@ -910,6 +910,13 @@ var tests = [
             assert.throws(() => this(), TypeError, "Capturing function 'this' binding and emitting as a call target should throw if 'this' is not a function", "Function expected");
         }
     },
+    {
+        name: "Class expression as call target without 'this' binding",
+        body: function() {
+            assert.throws(() => WScript.LoadScript(`(class classExpr {}())`), TypeError, "Class expression called at global scope", "Class constructor cannot be called without the new keyword");
+            assert.throws(() => WScript.LoadScript(`(() => (class classExpr {}()))()`), TypeError, "Class expression called in global lambda", "Class constructor cannot be called without the new keyword");
+        }
+    }
 ]
 
 testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/Scanner/NumericLiteralSuffix.js
+++ b/test/Scanner/NumericLiteralSuffix.js
@@ -74,6 +74,14 @@ var tests = [
                 }
             }
         }
+    },
+    {
+        name: "Multi-unit whitespace is ignored after numeric identifier",
+        body: function () {
+            var result = 0;
+            eval("\u2028var\u2028x\u2028=\u20281234\u2028; result = x;");
+            assert.areEqual(1234, result, "Mutli-unit whitespace after numeric literal does not affect literal value");
+        }
     }
 ];
 


### PR DESCRIPTION
Fixes OS: 14164940

I introduced a regession with my recent change to numeric literal spec complicance. After parsing a numeric literal, we were not checking if there was a multi-byte character before checking it as an IdStart character. In this case, we need to read the full character before checking.

This affected a handful of Test262 tests which used multi-byte trailing whitespace.
