### PR TITLE
Make Date.parse() support milliseconds (Fix #3980)

### DIFF
--- a/test/Date/DateParse.js
+++ b/test/Date/DateParse.js
@@ -108,8 +108,8 @@ for (var ts in toStrings)
 // No milliseconds
 WScript.Echo(Date.parse("2011-11-08T19:48:43"));
 
-// Missing digits after .
-WScript.Echo(Date.parse("2011-11-08T19:48:43."));
+// Missing digits after .: invalid
+WScript.Echo(Date.parse("2011-11-08T19:48:43.Z"));
 
 // milliseconds, 1 digit only, treat it as hundreds
 WScript.Echo(Date.parse("2011-11-08T19:48:43.1"));

--- a/test/Date/DateParse3.js
+++ b/test/Date/DateParse3.js
@@ -1,0 +1,42 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+// Test non-ISO format with milliseconds
+// using colon as millisecond separator is not allowed
+runTest("2011-11-08 19:48:43:", "2011-11-08T19:48:43.000");  // valid, last colon is ignored
+runTest("2011-11-08 19:48:43:1", null);
+runTest("2011-11-08 19:48:43:10", null);
+runTest("2011-11-08 19:48:43:100", null);
+
+// use dot as millisecond separator
+runTest("2011-11-08 19:48:43.", "2011-11-08T19:48:43.000");
+runTest("2011-11-08 19:48:43.1", "2011-11-08T19:48:43.100");
+runTest("2011-11-08 19:48:43.1 ", "2011-11-08T19:48:43.100");
+runTest("2011-11-08 19:48:43. 1", "2011-11-08T19:48:43.100");
+runTest("2011-11-08 19:48:43.01", "2011-11-08T19:48:43.010");
+runTest("2011-11-08 19:48:43.001", "2011-11-08T19:48:43.001");
+runTest("2011-11-08 19:48:43.0001", "2011-11-08T19:48:43.000");
+runTest("2011-11-08 19:48:43.00000001", null);  // having more than 7 consecutive digits causes overflow
+runTest("2011-11-08 19:48:43.10", "2011-11-08T19:48:43.100");
+runTest("2011-11-08 19:48:43.100", "2011-11-08T19:48:43.100");
+runTest("2011-11-08 19:48:43.1000", "2011-11-08T19:48:43.100");
+runTest("2011-11-08 19:48:43.12345", "2011-11-08T19:48:43.123");
+
+function runTest(dateToTest, isoDate)
+{
+    if (isoDate === null) {
+        if (isNaN(Date.parse(dateToTest))) {
+            console.log("PASS");
+        } else {
+            console.log("Wrong date parsing result: Date.parse(\"" + dateToTest + "\") should return NaN");
+        }        
+    } else {
+        if (Date.parse(dateToTest) === Date.parse(isoDate)) {
+            console.log("PASS");            
+        } else {
+            console.log("Wrong date parsing result: Date.parse(\"" + dateToTest + "\") should equal Date.parse(\"" + isoDate + "\")");
+        }
+    }
+}

--- a/test/Date/parseISO.js
+++ b/test/Date/parseISO.js
@@ -60,7 +60,7 @@ runTest("+300000-01-01T01:01:01.001Z");
 writeStats();
 
 echo("////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////");
-echo("// Potential cross-browser compatilibity issues");
+echo("// Potential cross-browser compatibility issues");
 echo("");
 
 echo("// Leading and trailing whitespace, nulls, or non-whitespace non-nulls");

--- a/test/Date/rlexe.xml
+++ b/test/Date/rlexe.xml
@@ -35,6 +35,11 @@
   </test>
   <test>
     <default>
+      <files>DateParse3.js</files>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>toISO_3.js</files>
       <baseline>toISO_3.baseline</baseline>
     </default>


### PR DESCRIPTION
As reported in #3980, `Date.parse()` doesn't recongize the format `YYYY-MM-DD HH:mm:ss.sss`. This PR updates `DateImplementation::UtcTimeFromStrCore()` to correctly parse this format which is supported by other engines.

Fixes #3980
