### PR TITLE
ARM64: Implement more fast math.

### DIFF
--- a/lib/Backend/arm64/EncoderMD.cpp
+++ b/lib/Backend/arm64/EncoderMD.cpp
@@ -863,6 +863,20 @@ EncoderMD::GenerateEncoding(IR::Instr* instr, BYTE *pc)
         }
         break;
 
+    case Js::OpCode::CMP_SXTW:
+        src1 = instr->GetSrc1();
+        src2 = instr->GetSrc2();
+        Assert(instr->GetDst() == nullptr);
+        Assert(src1->IsRegOpnd());
+        Assert(src2->IsRegOpnd());
+
+        size = src1->GetSize();
+        Assert(size == 8);
+        Assert(size == src2->GetSize());
+
+        bytes = EmitSubsRegister64(Emitter, ARMREG_ZR, this->GetRegEncode(src1->AsRegOpnd()), Arm64RegisterParam(this->GetRegEncode(src2->AsRegOpnd()), EXTEND_SXTW, 0));
+        break;
+
     case Js::OpCode::DEBUGBREAK:
         bytes = EmitDebugBreak(Emitter);
         break;

--- a/lib/Backend/arm64/MdOpCodes.h
+++ b/lib/Backend/arm64/MdOpCodes.h
@@ -50,8 +50,10 @@ MACRO(CBNZ,       BrReg2,     OpSideEffect,   UNUSED,   LEGAL_CBZ,      UNUSED, 
 MACRO(CLZ,        Reg2,       0,              UNUSED,   LEGAL_REG2,     UNUSED,   D___)
 MACRO(CMP,        Reg1,       OpSideEffect,   UNUSED,   LEGAL_PSEUDO,   UNUSED,   D__S)
 MACRO(CMN,        Reg1,       OpSideEffect,   UNUSED,   LEGAL_PSEUDO,   UNUSED,   D__S)
-// CMP src1, src, ASR #31/63
+// CMP src1, src2, ASR #31/63
 MACRO(CMP_ASR31,  Reg1,       OpSideEffect,   UNUSED,   LEGAL_REG3_ND,  UNUSED,   D__S)
+// CMP src1, src2, SXTW
+MACRO(CMP_SXTW,   Reg1,       OpSideEffect,   UNUSED,   LEGAL_REG3_ND,  UNUSED,   D__S)
 MACRO(CSELLT,     Reg3,       0,              UNUSED,   LEGAL_REG3,     UNUSED,   D___)
 MACRO(CSNEGPL,    Reg3,       0,              UNUSED,   LEGAL_REG3,     UNUSED,   D___)
 


### PR DESCRIPTION
Improve double-tag check. Update FastMul case for 64-bit tagging. Create empty fast AND/OR/XOR/NOT/LSL just like AMD64. Implement fast right shift.
