### PR TITLE
Change var slot allocation order to avoid loading special symbols from incorrect slots

### DIFF
--- a/test/Basics/SpecialSymbolCapture.js
+++ b/test/Basics/SpecialSymbolCapture.js
@@ -901,6 +901,15 @@ var tests = [
                 assert.areEqual(_this, this, "Regular 'this' binding is correct");
             }
             foo.call(_this)
+            
+            function bar(a = this) {
+                eval('');
+                assert.areEqual(_this, a, "Correct default value was assigned");
+                assert.areEqual(_this, this, "Regular 'this' binding is correct");
+                function b() { return 'b'; }
+                assert.areEqual('b', b(), "Nested functions are bound to the correct slot");
+            }
+            bar.call(_this)
         }
     },
     {

--- a/test/Basics/SpecialSymbolCapture.js
+++ b/test/Basics/SpecialSymbolCapture.js
@@ -910,6 +910,66 @@ var tests = [
                 assert.areEqual('b', b(), "Nested functions are bound to the correct slot");
             }
             bar.call(_this)
+
+            function baz(a = this, c = function() { return 'c'; }) {
+                eval('');
+                assert.areEqual(_this, a, "Correct default value was assigned");
+                assert.areEqual(_this, this, "Regular 'this' binding is correct");
+                function b() { return 'b'; }
+                assert.areEqual('b', b(), "Nested functions are bound to the correct slot");
+                assert.areEqual('c', c(), "Function expression in param scope default argument is bound to the correct slot");
+            }
+            baz.call(_this)
+
+            function baz2(a = this, c = function() { function nested() { return 'c' }; return nested; }) {
+                eval('');
+                assert.areEqual(_this, a, "Correct default value was assigned");
+                assert.areEqual(_this, this, "Regular 'this' binding is correct");
+                function b() { return 'b'; }
+                assert.areEqual('b', b(), "Nested functions are bound to the correct slot");
+                assert.areEqual('c', c()(), "Function decl nested in function expression assigned to default argument");
+            }
+            baz2.call(_this)
+
+            function baz3(c = function() { return 'c'; }, a = this) {
+                eval('');
+                assert.areEqual(_this, a, "Correct default value was assigned");
+                assert.areEqual(_this, this, "Regular 'this' binding is correct");
+                function b() { return 'b'; }
+                assert.areEqual('b', b(), "Nested functions are bound to the correct slot");
+                assert.areEqual('c', c(), "Function expression in param scope default argument is bound to the correct slot");
+            }
+            baz3.call(_this)
+
+            function bat(a = this, c = () => 'c') {
+                eval('');
+                assert.areEqual(_this, a, "Correct default value was assigned");
+                assert.areEqual(_this, this, "Regular 'this' binding is correct");
+                function b() { return 'b'; }
+                assert.areEqual('b', b(), "Nested functions are bound to the correct slot");
+                assert.areEqual('c', c(), "Lambda expression in param scope default argument is bound to the correct slot");
+            }
+            bat.call(_this)
+
+            function bat2(a = this, c = () => () => 'c') {
+                eval('');
+                assert.areEqual(_this, a, "Correct default value was assigned");
+                assert.areEqual(_this, this, "Regular 'this' binding is correct");
+                function b() { return 'b'; }
+                assert.areEqual('b', b(), "Nested functions are bound to the correct slot");
+                assert.areEqual('c', c()(), "Lambda function decl nested in lambda expression assigned to default argument");
+            }
+            bat2.call(_this)
+
+            function bat3(c = () => () => 'c', a = this) {
+                eval('');
+                assert.areEqual(_this, a, "Correct default value was assigned");
+                assert.areEqual(_this, this, "Regular 'this' binding is correct");
+                function b() { return 'b'; }
+                assert.areEqual('b', b(), "Nested functions are bound to the correct slot");
+                assert.areEqual('c', c()(), "Lambda function decl nested in lambda expression assigned to default argument");
+            }
+            bat3.call(_this)
         }
     },
     {

--- a/test/LetConst/q.baseline
+++ b/test/LetConst/q.baseline
@@ -6,8 +6,8 @@ print
 read
 readbuffer
 console
-f
 a
+f
 
 a
 undefined

--- a/test/es6/letconst_global.baseline
+++ b/test/es6/letconst_global.baseline
@@ -20,6 +20,6 @@ function e() { }
 
 for-in enumeration of this
 
-e: function e() { }
 a: global var a
+e: function e() { }
 b: global undecl b

--- a/test/stackfunc/child_eval_escape.deferparse.baseline
+++ b/test/stackfunc/child_eval_escape.deferparse.baseline
@@ -5,12 +5,12 @@ HasFuncDecl: test
 HasFuncDecl: child
 HasMaybeEscapedNestedFunc (Child): test (function  (#1.1), #2)
 HasFuncAssignment: nested
+RestoreHasFuncAssignment: nested
 HasFuncDecl: child
 RestoreHasFuncAssignment: child
-RestoreHasFuncAssignment: nested
 HasMaybeEscapedNestedFunc (Eval): child (function  (#1.3), #5)
+RestoreHasFuncAssignment: nested
 HasFuncDecl: child
 RestoreHasFuncAssignment: child
-RestoreHasFuncAssignment: nested
 test1
 test2

--- a/test/typedarray/samethread.baseline
+++ b/test/typedarray/samethread.baseline
@@ -21005,18 +21005,6 @@ property of global: print
 
 property of global: read
 property of global: readbuffer
-property of global: printDataView
-exception is -2146823281Unable to get property 'toString' of undefined or null reference
-property of global: GetResult
-exception is -2146823281Unable to get property 'byteLength' of undefined or null reference
-property of global: testOneOffset
-exception is -2146823281Unable to get property 'byteLength' of undefined or null reference
-property of global: testOneValue
-test one value undefined
-exception is -2146823281Unable to get property 'byteLength' of undefined or null reference
-property of global: oneTest
-test one value 0
-exception is -2146823281Unable to get property 'byteLength' of undefined or null reference
 property of global: getFuncs
 sub object 0 in getFuncs is getInt8
 sub object 1 in getFuncs is getUint8
@@ -21053,6 +21041,18 @@ sub object 4 in testValue is 296
 property of global: arrayBuffer
 property of global: dataView
 sub object 2 in dataView is 10
+property of global: printDataView
+exception is -2146823281Unable to get property 'toString' of undefined or null reference
+property of global: GetResult
+exception is -2146823281Unable to get property 'byteLength' of undefined or null reference
+property of global: testOneOffset
+exception is -2146823281Unable to get property 'byteLength' of undefined or null reference
+property of global: testOneValue
+test one value undefined
+exception is -2146823281Unable to get property 'byteLength' of undefined or null reference
+property of global: oneTest
+test one value 0
+exception is -2146823281Unable to get property 'byteLength' of undefined or null reference
 testing file int8array.js
 test1
 10
@@ -22081,8 +22081,6 @@ property of global: print
 undefined
 property of global: read
 property of global: readbuffer
-property of global: oneTest
-exception is -2146823281Unable to set property '5' of undefined or null reference
 property of global: test1
 sub object 0 in test1 is 0
 sub object 1 in test1 is 1
@@ -22314,6 +22312,8 @@ property of global: invalidSizeValues
 sub object 0 in invalidSizeValues is -1
 sub object 1 in invalidSizeValues is Infinity
 sub object 2 in invalidSizeValues is -Infinity
+property of global: oneTest
+exception is -2146823281Unable to set property '5' of undefined or null reference
 property of global: printObj
 exception is -2146823281Unable to get property 'toString' of undefined or null reference
 property of global: verifyThrow
@@ -23183,8 +23183,6 @@ property of global: print
 undefined
 property of global: read
 property of global: readbuffer
-property of global: oneTest
-exception is -2146823281Unable to set property '1' of undefined or null reference
 property of global: test1
 sub object 0 in test1 is 0
 sub object 1 in test1 is 128
@@ -23394,6 +23392,8 @@ property of global: test19
 sub object 0 in test19 is 0
 sub object 1 in test19 is 128
 sub object 2 in test19 is 10
+property of global: oneTest
+exception is -2146823281Unable to set property '1' of undefined or null reference
 property of global: printObj
 exception is -2146823281Unable to get property 'toString' of undefined or null reference
 property of global: verifyThrow
@@ -24177,8 +24177,6 @@ property of global: print
 undefined
 property of global: read
 property of global: readbuffer
-property of global: oneTest
-exception is -2146823281Unable to set property '1' of undefined or null reference
 property of global: test1
 sub object 0 in test1 is 0
 sub object 1 in test1 is -32768
@@ -24345,6 +24343,8 @@ property of global: test19
 sub object 0 in test19 is 0
 sub object 1 in test19 is -32768
 sub object 2 in test19 is 0
+property of global: oneTest
+exception is -2146823281Unable to set property '1' of undefined or null reference
 property of global: printObj
 exception is -2146823281Unable to get property 'toString' of undefined or null reference
 property of global: verifyThrow
@@ -25143,8 +25143,6 @@ property of global: print
 undefined
 property of global: read
 property of global: readbuffer
-property of global: oneTest
-exception is -2146823281Unable to set property '1' of undefined or null reference
 property of global: test1
 sub object 0 in test1 is 0
 sub object 1 in test1 is 32768
@@ -25314,6 +25312,8 @@ property of global: test19
 sub object 0 in test19 is 32768
 sub object 1 in test19 is 32768
 sub object 2 in test19 is 0
+property of global: oneTest
+exception is -2146823281Unable to set property '1' of undefined or null reference
 property of global: printObj
 exception is -2146823281Unable to get property 'toString' of undefined or null reference
 property of global: verifyThrow
@@ -26095,8 +26095,6 @@ property of global: print
 undefined
 property of global: read
 property of global: readbuffer
-property of global: oneTest
-exception is -2146823281Unable to set property '1' of undefined or null reference
 property of global: test1
 sub object 0 in test1 is 0
 sub object 1 in test1 is -2147483648
@@ -26253,6 +26251,8 @@ sub object 4 in test24 is 10
 sub object 5 in test24 is 10
 sub object 6 in test24 is 0
 sub object foo in test24 is bar
+property of global: oneTest
+exception is -2146823281Unable to set property '1' of undefined or null reference
 property of global: printObj
 exception is -2146823281Unable to get property 'toString' of undefined or null reference
 property of global: verifyThrow
@@ -27000,8 +27000,6 @@ property of global: print
 undefined
 property of global: read
 property of global: readbuffer
-property of global: oneTest
-exception is -2146823281Unable to set property '1' of undefined or null reference
 property of global: test1
 sub object 0 in test1 is 0
 sub object 1 in test1 is 2147483648
@@ -27147,6 +27145,8 @@ property of global: test19
 sub object 0 in test19 is 2147483648
 sub object 1 in test19 is 2147483648
 sub object 2 in test19 is 0
+property of global: oneTest
+exception is -2146823281Unable to set property '1' of undefined or null reference
 property of global: printObj
 exception is -2146823281Unable to get property 'toString' of undefined or null reference
 property of global: verifyThrow
@@ -27901,8 +27901,6 @@ property of global: print
 undefined
 property of global: read
 property of global: readbuffer
-property of global: oneTest
-exception is -2146823281Unable to set property '1' of undefined or null reference
 property of global: test1
 sub object 0 in test1 is 0
 sub object 1 in test1 is 0.5400000214576721
@@ -28050,6 +28048,8 @@ property of global: test19
 sub object 0 in test19 is 0.5400000214576721
 sub object 1 in test19 is 0.5400000214576721
 sub object 2 in test19 is 0
+property of global: oneTest
+exception is -2146823281Unable to set property '1' of undefined or null reference
 property of global: printObj
 exception is -2146823281Unable to get property 'toString' of undefined or null reference
 property of global: verifyThrow
@@ -28770,8 +28770,6 @@ property of global: print
 undefined
 property of global: read
 property of global: readbuffer
-property of global: oneTest
-exception is -2146823281Unable to set property '1' of undefined or null reference
 property of global: test1
 sub object 0 in test1 is 0
 sub object 1 in test1 is -0.65
@@ -28904,6 +28902,8 @@ property of global: test21
 sub object 0 in test21 is 0
 sub object 1 in test21 is 0
 sub object 2 in test21 is undefined
+property of global: oneTest
+exception is -2146823281Unable to set property '1' of undefined or null reference
 property of global: printObj
 exception is -2146823281Unable to get property 'toString' of undefined or null reference
 property of global: verifyThrow


### PR DESCRIPTION
If a function contains nested named function declarations which require a binding, these will be bound to scope slots before scope slots are allocated for the var list. This logic is in `ByteCodeGenerator::StartEmitFunction` and calls `EnsureFncDeclScopeSlot` which ensures a scope slot for each such nested named function declaration.
    
Immediately after ensuring scope slots for function declarations, we then ensure scope slots for the user var list. Because scope slots must be initialized in the same order they are ensured (allocated) we need to make sure the logic in `ByteCodeGenerator::StartEmitFunction` matches the logic to emit storage for symbols in `ByteCodeGenerator::EmitOneFunction`.

The bug is that we are emitting the slot initialization in a different order from the order in which we ensured the slots. We are initializing some of the slots ensured for var list symbols before we initialize the slots ensured for nested function declarations. Specifically, these var list slots are ensured for the special symbols.

We emit storage for the special symbols (which are part of the var list) before the default arguments (because default arguments might access the special named values). However, we cannot emit storage for nested function declarations before the default arguments because the default arguments are not supposed to be able to access those nested functions as they are declared in the body.
    
Fix is to just ensure the scope slots in the same order we are going to initialize them. That means walking the var list and ensuring scope slots for those (including special symbols) before ensuring scope slots for nested named function declarations.
    
Fixes:
https://microsoft.visualstudio.com/OS/_workitems?id=14212259&_a=edit