### PR TITLE
Fix int constant folding during inlining for functions with try

### DIFF
--- a/lib/Backend/Inline.cpp
+++ b/lib/Backend/Inline.cpp
@@ -4364,6 +4364,10 @@ bool Inline::InlConstFoldArg(IR::Instr *instr, __in_ecount_opt(callerArgOutCount
     {
         return false;
     }
+    if (instr->m_func->GetJITFunctionBody()->HasTry())
+    {
+        return false;
+    }
 
     IR::Opnd *src1 = instr->GetSrc1();
     IntConstType value;

--- a/test/EH/rlexe.xml
+++ b/test/EH/rlexe.xml
@@ -145,4 +145,9 @@
       <files>nestedinlinestackwalkbug.js</files>
     </default>
   </test>
+  <test>
+    <default>
+      <files>tryfinallyinlinebug.js</files>
+    </default>
+  </test>
 </regress-exe>

--- a/test/EH/tryfinallyinlinebug.js
+++ b/test/EH/tryfinallyinlinebug.js
@@ -1,0 +1,14 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function test2() {
+  for (var rdpcvr = 0; rdpcvr; ++rdpcvr) {
+    vbmmag([iotxib] = 4277);
+  }
+}
+test2();
+test2();
+test2();
+WScript.Echo("Passed");


### PR DESCRIPTION
We should not int constant fold args during inlining for functions with try.
This bug came up when we enabled inling into functions with try recently.

We maybe const folding across regions, and a BailOnException in the middle will need to restore this.
Int const fold at inline and a later deadstore can result in incorrect results in such a scenario.
