### PR TITLE
numberToString: re-cache on miss and cache more

### DIFF
--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -830,7 +830,11 @@ private:
         EventHandler disposeScriptByFaultInjectionEventHandler;
 #endif
 
+#ifndef CC_LOW_MEMORY_TARGET
         JsUtil::BaseDictionary<uint, JavascriptString *, ArenaAllocator> integerStringMap;
+        uint integerStringMapCacheMissCount;
+        uint integerStringMapCacheUseCount;
+#endif
 
         double lastNumberToStringRadix10;
         double lastUtcTimeFromStr;


### PR DESCRIPTION
Improve numberToString cache for long running applications while adding more space to hash table cap.

```
// limit the htable size to NUMBER_TO_STRING_CACHE_SIZE and refresh the cache often
// however don't re-cache if we didn't use it much! App may not be suitable for caching.
// 4% -> NUMBER_TO_STRING_RE_CACHE_REASON_LIMIT is equal to perf loss while we cache the stuff
```

pros;

- no point holding a cache that we may never use again

cons;

- if the application is generating 100% distinct NUMBER_TO_STRING_CACHE_SIZE+1 numbers and stringify them all the time.. well, the perf could be  ~4% slower comparing to now. This is due to cache won't have any use yet we will be filling it up again and again. In order to prevent that, we will check the cache usage and do not re-cache if we didn't even use it.