### PR TITLE
Disable RTTI on x-plat

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -346,8 +346,13 @@ if(CLR_CMAKE_PLATFORM_XPLAT)
     add_compile_options(
         -fasm-blocks
         -fms-extensions
-        -fwrapv                 # Treat signed integer overflow as two's complement
+        -fwrapv # Treat signed integer overflow as two's complement
     )
+
+    # Only disable RTTI in release builds so that TrackAlloc works for debug and test builds
+    if(CMAKE_BUILD_TYPE STREQUAL Release)
+        add_compile_options(-fno-rtti)
+    endif()
 
     # Clang -fsanitize.
     if (CLANG_SANITIZE_SH)

--- a/lib/Runtime/PlatformAgnostic/Platform/CMakeLists.txt
+++ b/lib/Runtime/PlatformAgnostic/Platform/CMakeLists.txt
@@ -28,6 +28,9 @@ if(ICU_INTL_ENABLED)
 set(PL_SOURCE_FILES ${PL_SOURCE_FILES}
   Common/Intl.cpp
   )
+add_compile_options(
+  -frtti
+)
 endif()
 
 if(NOT STATIC_LIBRARY)


### PR DESCRIPTION
My RTTI change "just worked" on Linux, which seemed wrong. Turns out, we never disabled RTTI to begin with. This change brings a release build of libChakraCoreStatic.a down from 484MB to 463MB.