### PR TITLE
cleanup DUMP_FRAGMENTATION_STATS

### DIFF
--- a/lib/Common/CommonDefines.h
+++ b/lib/Common/CommonDefines.h
@@ -664,6 +664,10 @@
 // #define RECYCLER_MARK_TRACK
 // #define INTERNAL_MEM_PROTECT_HEAP_ALLOC
 
+#if defined(ENABLE_JS_ETW) || defined(DUMP_FRAGMENTATION_STATS)
+#define ENABLE_MEM_STATS 1
+#endif
+
 #define NO_SANITIZE_ADDRESS
 #if defined(__has_feature)
 #if __has_feature(address_sanitizer)

--- a/lib/Common/Memory/HeapBlock.h
+++ b/lib/Common/Memory/HeapBlock.h
@@ -37,17 +37,37 @@ template <typename TBlockType> class HeapBucketT;
 class  RecyclerSweep;
 class MarkContext;
 
-#ifdef DUMP_FRAGMENTATION_STATS
-struct HeapBucketStats
+#if ENABLE_MEM_STATS
+struct MemStats
 {
+    size_t objectByteCount;
+    size_t totalByteCount;
+
+    MemStats() : objectByteCount(0), totalByteCount(0) {}
+
+    void Aggregate(const MemStats& other)
+    {
+        objectByteCount += other.objectByteCount;
+        totalByteCount += other.totalByteCount;
+    }
+};
+
+struct HeapBucketStats: MemStats
+{
+#ifdef DUMP_FRAGMENTATION_STATS
     uint totalBlockCount;
     uint emptyBlockCount;
     uint finalizeBlockCount;
     uint objectCount;
     uint finalizeCount;
-    uint objectByteCount;
-    uint totalByteCount;
+#endif
 };
+
+#ifdef DUMP_FRAGMENTATION_STATS
+#define DUMP_FRAGMENTATION_STATS_ONLY(x) x
+#else
+#define DUMP_FRAGMENTATION_STATS_ONLY(x)
+#endif
 #endif
 
 #if defined(PROFILE_RECYCLER_ALLOC) || defined(RECYCLER_MEMORY_VERIFY) || defined(MEMSPECT_TRACKING) || defined(RECYCLER_PERF_COUNTERS) || defined(ETW_MEMORY_TRACKING)
@@ -635,7 +655,7 @@ public:
     void InduceFalsePositive(Recycler * recycler);
 #endif
 
-#ifdef DUMP_FRAGMENTATION_STATS
+#if ENABLE_MEM_STATS
     void AggregateBlockStats(HeapBucketStats& stats, bool isAllocatorBlock = false, FreeObject* freeObjectList = nullptr, bool isBumpAllocated = false);
 #endif
 

--- a/lib/Common/Memory/HeapBucket.cpp
+++ b/lib/Common/Memory/HeapBucket.cpp
@@ -21,6 +21,12 @@ HeapBucket::HeapBucket() :
 }
 
 uint
+HeapBucket::GetSizeCat() const
+{
+    return this->sizeCat;
+}
+
+uint
 HeapBucket::GetBucketIndex() const
 {
     return HeapInfo::GetBucketIndex(this->sizeCat);
@@ -1422,7 +1428,7 @@ HeapBucketT<TBlockType>::Check(bool checkCount)
 }
 #endif
 
-#ifdef DUMP_FRAGMENTATION_STATS
+#if ENABLE_MEM_STATS
 template <typename TBlockType>
 void
 HeapBucketT<TBlockType>::AggregateBucketStats(HeapBucketStats& stats)

--- a/lib/Common/Memory/HeapBucket.h
+++ b/lib/Common/Memory/HeapBucket.h
@@ -65,6 +65,7 @@ class HeapBucket
 public:
     HeapBucket();
 
+    uint GetSizeCat() const;
     uint GetBucketIndex() const;
     uint GetMediumBucketIndex() const;
 
@@ -141,7 +142,7 @@ public:
     void ResetMarks(ResetMarkFlags flags);
     void ScanNewImplicitRoots(Recycler * recycler);
 
-#ifdef DUMP_FRAGMENTATION_STATS
+#if ENABLE_MEM_STATS
     void AggregateBucketStats(HeapBucketStats& stats);
 #endif
     uint Rescan(Recycler * recycler, RescanFlags flags);

--- a/lib/Common/Memory/HeapInfo.h
+++ b/lib/Common/Memory/HeapInfo.h
@@ -46,8 +46,8 @@ public:
     const bool IsPageHeapEnabled() const{ return false; }
 #endif
 
-#ifdef DUMP_FRAGMENTATION_STATS
-    void DumpFragmentationStats();
+#if ENABLE_MEM_STATS
+    void ReportMemStats();
 #endif
 
     template <ObjectInfoBits attributes, bool nothrow>

--- a/lib/Common/Memory/Recycler.cpp
+++ b/lib/Common/Memory/Recycler.cpp
@@ -6161,11 +6161,8 @@ Recycler::FinishCollection()
     }
 #endif
 
-#ifdef DUMP_FRAGMENTATION_STATS
-    if (GetRecyclerFlagsTable().DumpFragmentationStats)
-    {
-        autoHeap.DumpFragmentationStats();
-    }
+#if ENABLE_MEM_STATS
+    autoHeap.ReportMemStats();
 #endif
 
     RECORD_TIMESTAMP(currentCollectionEndTime);
@@ -6786,7 +6783,9 @@ Recycler::PrintHeapBlockMemoryStats(char16 const * name, HeapBlock::HeapBlockTyp
         allocableFreeByteCount -= partialUnusedBytes;
     }
 #endif
-    size_t totalByteCount = (collectionStats.heapBlockCount[type] - collectionStats.heapBlockFreeCount[type]) * AutoSystemInfo::PageSize;
+    size_t blockPages = type < HeapBlock::HeapBlockType::SmallAllocBlockTypeCount ?
+        SmallAllocationBlockAttributes::PageCount : MediumAllocationBlockAttributes::PageCount;
+    size_t totalByteCount = (collectionStats.heapBlockCount[type] - collectionStats.heapBlockFreeCount[type]) * blockPages * AutoSystemInfo::PageSize;
     size_t liveByteCount = totalByteCount - collectionStats.heapBlockFreeByteCount[type];
     Output::Print(_u(" %6s: %10d %10d"), name, liveByteCount, allocableFreeByteCount);
 

--- a/lib/Common/Memory/SmallFinalizableHeapBucket.cpp
+++ b/lib/Common/Memory/SmallFinalizableHeapBucket.cpp
@@ -80,7 +80,7 @@ SmallFinalizableHeapBucketBaseT<TBlockType>::ResetMarks(ResetMarkFlags flags)
     }
 }
 
-#ifdef DUMP_FRAGMENTATION_STATS
+#if ENABLE_MEM_STATS
 template <class TBlockType>
 void
 SmallFinalizableHeapBucketBaseT<TBlockType>::AggregateBucketStats(HeapBucketStats& stats)

--- a/lib/Common/Memory/SmallFinalizableHeapBucket.h
+++ b/lib/Common/Memory/SmallFinalizableHeapBucket.h
@@ -19,7 +19,7 @@ public:
     void FinalizeAllObjects();
     static void FinalizeHeapBlockList(THeapBlockType * list);
 
-#ifdef DUMP_FRAGMENTATION_STATS
+#if ENABLE_MEM_STATS
     void AggregateBucketStats(HeapBucketStats& stats);
 #endif
 protected:

--- a/lib/Common/Memory/SmallNormalHeapBucket.cpp
+++ b/lib/Common/Memory/SmallNormalHeapBucket.cpp
@@ -16,17 +16,17 @@ SmallNormalHeapBucketBase<TBlockType>::SmallNormalHeapBucketBase()
 {
 }
 
-#ifdef DUMP_FRAGMENTATION_STATS
+#if ENABLE_MEM_STATS
 template <typename TBlockType>
 void
 SmallNormalHeapBucketBase<TBlockType>::AggregateBucketStats(HeapBucketStats& stats)
 {
     __super::AggregateBucketStats(stats);
 
-    HeapBlockList::ForEach(partialHeapBlockList, [&stats](SmallHeapBlock* heapBlock) {
+    HeapBlockList::ForEach(partialHeapBlockList, [&stats](TBlockType* heapBlock) {
         heapBlock->AggregateBlockStats(stats);
     });
-    HeapBlockList::ForEach(partialSweptHeapBlockList, [&stats](SmallHeapBlock* heapBlock) {
+    HeapBlockList::ForEach(partialSweptHeapBlockList, [&stats](TBlockType* heapBlock) {
         heapBlock->AggregateBlockStats(stats);
     });
 }

--- a/lib/Common/Memory/SmallNormalHeapBucket.h
+++ b/lib/Common/Memory/SmallNormalHeapBucket.h
@@ -20,7 +20,7 @@ public:
     friend class ::ScriptMemoryDumper;
 #endif
 
-#ifdef DUMP_FRAGMENTATION_STATS
+#if ENABLE_MEM_STATS
     void AggregateBucketStats(HeapBucketStats& stats);
 #endif
 protected:


### PR DESCRIPTION
We have DUMP_FRAGMENTATION_STATS support but the code is out-dated. This
cleans up (and refactors it so the data could be surfaced through ETW
in future).

This is partial change. DUMP_FRAGMENTATION_STATS result still incomplete
(missing Large bucket) and some incorrect (not agreeing with JD).
