### PR TITLE
FromVar hardening

### DIFF
--- a/lib/Backend/JITRecyclableObject.h
+++ b/lib/Backend/JITRecyclableObject.h
@@ -57,6 +57,15 @@ public:
     {
         Assert(offsetof(JITJavascriptString, m_pszValue) == Js::JavascriptString::GetOffsetOfpszValue());
         Assert(offsetof(JITJavascriptString, m_charLength) == Js::JavascriptString::GetOffsetOfcharLength());
+        AssertOrFailFast(Is(var));
+
+        return reinterpret_cast<JITJavascriptString*>(var);
+    }
+
+    static JITJavascriptString * UnsafeFromVar(Js::Var var)
+    {
+        Assert(offsetof(JITJavascriptString, m_pszValue) == Js::JavascriptString::GetOffsetOfpszValue());
+        Assert(offsetof(JITJavascriptString, m_charLength) == Js::JavascriptString::GetOffsetOfcharLength());
         Assert(Is(var));
 
         return reinterpret_cast<JITJavascriptString*>(var);

--- a/lib/Backend/NativeCodeGenerator.cpp
+++ b/lib/Backend/NativeCodeGenerator.cpp
@@ -721,7 +721,7 @@ NativeCodeGenerator::IsValidVar(const Js::Var var, Recycler *const recycler)
     }
 #endif
 
-    RecyclableObject *const recyclableObject = RecyclableObject::FromVar(var);
+    RecyclableObject *const recyclableObject = RecyclableObject::UnsafeFromVar(var);
     if(!recycler->IsValidObject(recyclableObject, sizeof(*recyclableObject)))
     {
         return false;

--- a/lib/Jsrt/Jsrt.cpp
+++ b/lib/Jsrt/Jsrt.cpp
@@ -2148,7 +2148,7 @@ CHAKRA_API JsHasIndexedPropertiesExternalData(_In_ JsValueRef object, _Out_ bool
 
         if (Js::DynamicType::Is(Js::JavascriptOperators::GetTypeId(object)))
         {
-            Js::DynamicObject* dynamicObject = Js::DynamicObject::FromVar(object);
+            Js::DynamicObject* dynamicObject = Js::DynamicObject::UnsafeFromVar(object);
             Js::ArrayObject* objectArray = dynamicObject->GetObjectArray();
             *value = (objectArray && !Js::DynamicObject::IsAnyArray(objectArray));
         }
@@ -2178,7 +2178,7 @@ CHAKRA_API JsGetIndexedPropertiesExternalData(
         *arrayType = JsTypedArrayType();
         *elementLength = 0;
 
-        Js::DynamicObject* dynamicObject = Js::DynamicObject::FromVar(object);
+        Js::DynamicObject* dynamicObject = Js::DynamicObject::UnsafeFromVar(object);
         Js::ArrayObject* objectArray = dynamicObject->GetObjectArray();
         if (!objectArray)
         {

--- a/lib/Jsrt/JsrtExternalObject.cpp
+++ b/lib/Jsrt/JsrtExternalObject.cpp
@@ -57,6 +57,12 @@ bool JsrtExternalObject::Is(Js::Var value)
 
 JsrtExternalObject * JsrtExternalObject::FromVar(Js::Var value)
 {
+    AssertOrFailFast(Is(value));
+    return static_cast<JsrtExternalObject *>(value);
+}
+
+JsrtExternalObject * JsrtExternalObject::UnsafeFromVar(Js::Var value)
+{
     Assert(Is(value));
     return static_cast<JsrtExternalObject *>(value);
 }

--- a/lib/Jsrt/JsrtExternalObject.h
+++ b/lib/Jsrt/JsrtExternalObject.h
@@ -49,6 +49,7 @@ public:
 
     static bool Is(Js::Var value);
     static JsrtExternalObject * FromVar(Js::Var value);
+    static JsrtExternalObject * UnsafeFromVar(Js::Var value);
     static JsrtExternalObject * Create(void *data, JsFinalizeCallback finalizeCallback, Js::ScriptContext *scriptContext);
 
     JsrtExternalType * GetExternalType() const { return (JsrtExternalType *)this->GetType(); }

--- a/lib/Runtime/Base/CrossSite.cpp
+++ b/lib/Runtime/Base/CrossSite.cpp
@@ -28,14 +28,14 @@ namespace Js
         {
             return FALSE;
         }
-        RecyclableObject * object = RecyclableObject::FromVar(instance);
+        RecyclableObject * object = RecyclableObject::UnsafeFromVar(instance);
         if (object->GetScriptContext() == requestContext)
         {
             return FALSE;
         }
         if (DynamicType::Is(object->GetTypeId()))
         {
-            return !DynamicObject::FromVar(object)->IsCrossSiteObject() && !object->IsExternal();
+            return !DynamicObject::UnsafeFromVar(object)->IsCrossSiteObject() && !object->IsExternal();
         }
         return TRUE;
     }
@@ -159,7 +159,7 @@ namespace Js
         {
             return value;
         }
-        Js::RecyclableObject* object =  RecyclableObject::FromVar(value);
+        Js::RecyclableObject* object =  RecyclableObject::UnsafeFromVar(value);
         if (fRequestWrapper || scriptContext != object->GetScriptContext())
         {
             return MarshalVarInner(scriptContext, object, fRequestWrapper);
@@ -570,7 +570,7 @@ namespace Js
         }
         while (DynamicType::Is(object->GetTypeId()) && !JavascriptProxy::Is(object))
         {
-            DynamicObject* dynamicObject = DynamicObject::FromVar(object);
+            DynamicObject* dynamicObject = DynamicObject::UnsafeFromVar(object);
             if (!dynamicObject->IsCrossSiteObject() && !dynamicObject->IsExternal())
             {
                 // force to install cross-site thunk on prototype objects.

--- a/lib/Runtime/Base/FunctionInfo.cpp
+++ b/lib/Runtime/Base/FunctionInfo.cpp
@@ -70,6 +70,6 @@ namespace Js
     FunctionInfo::Attributes FunctionInfo::GetAttributes(Js::RecyclableObject * function)
     {
         return function->GetTypeId() == Js::TypeIds_Function ?
-            Js::JavascriptFunction::FromVar(function)->GetFunctionInfo()->GetAttributes() : Js::FunctionInfo::None;
+            Js::JavascriptFunction::UnsafeFromVar(function)->GetFunctionInfo()->GetAttributes() : Js::FunctionInfo::None;
     }
 }

--- a/lib/Runtime/Debug/DiagObjectModel.cpp
+++ b/lib/Runtime/Debug/DiagObjectModel.cpp
@@ -3275,9 +3275,9 @@ namespace Js
 
     BOOL RecyclableTypedArrayAddress::Set(Var updateObject)
     {
-        if (Js::TypedArrayBase::Is(parentArray))
+        Js::TypedArrayBase* typedArrayObj = JavascriptOperators::TryFromVar<Js::TypedArrayBase>(parentArray);
+        if (typedArrayObj)
         {
-            Js::TypedArrayBase* typedArrayObj = Js::TypedArrayBase::FromVar(parentArray);
             return typedArrayObj->SetItem(index, updateObject, PropertyOperation_None);
         }
 
@@ -3295,9 +3295,9 @@ namespace Js
 
     BOOL RecyclableTypedArrayDisplay::HasChildren()
     {
-        if (Js::TypedArrayBase::Is(instance))
+        Js::TypedArrayBase* typedArrayObj = JavascriptOperators::TryFromVar<Js::TypedArrayBase>(instance);
+        if (typedArrayObj)
         {
-            Js::TypedArrayBase* typedArrayObj = Js::TypedArrayBase::FromVar(instance);
             if (typedArrayObj->GetLength() > 0)
             {
                 return TRUE;

--- a/lib/Runtime/Language/CacheOperators.cpp
+++ b/lib/Runtime/Language/CacheOperators.cpp
@@ -44,9 +44,10 @@ namespace Js
         Assert(info->IsNoCache() || !info->IsStoreFieldCacheEnabled() || info->GetInstance() != objectWithProperty || !objectWithProperty->IsFixedProperty(propertyId));
 #endif
 
+        DynamicObject * dynamicObjectWithProperty = DynamicObject::FromVar(objectWithProperty);
         PropertyIndex slotIndex;
         bool isInlineSlot;
-        DynamicObject::FromVar(objectWithProperty)->GetDynamicType()->GetTypeHandler()->PropertyIndexToInlineOrAuxSlotIndex(propertyIndex, &slotIndex, &isInlineSlot);
+        dynamicObjectWithProperty->GetDynamicType()->GetTypeHandler()->PropertyIndexToInlineOrAuxSlotIndex(propertyIndex, &slotIndex, &isInlineSlot);
 
         const bool isProto = objectWithProperty != startingObject;
         if(!isProto)
@@ -57,7 +58,7 @@ namespace Js
         else if(
             PropertyValueInfo::PrototypeCacheDisabled((PropertyValueInfo*)info) ||
             !RecyclableObject::Is(startingObject) ||
-            RecyclableObject::FromVar(startingObject)->GetScriptContext() != requestContext)
+            RecyclableObject::UnsafeFromVar(startingObject)->GetScriptContext() != requestContext)
         {
             // Don't need to cache if the beginning property is number etc.
             return;
@@ -77,7 +78,7 @@ namespace Js
 
         Cache<false, true, true>(
             isProto,
-            DynamicObject::FromVar(objectWithProperty),
+            dynamicObjectWithProperty,
             isRoot,
             RecyclableObject::FromVar(startingObject)->GetType(),
             nullptr,
@@ -115,9 +116,10 @@ namespace Js
         Assert(RecyclableObject::Is(originalInstance));
         Assert(DynamicType::Is(info->GetInstance()->GetTypeId()));
 
+        DynamicObject * dynamicInstance = DynamicObject::FromVar(info->GetInstance());
         PropertyIndex slotIndex;
         bool isInlineSlot;
-        DynamicObject::FromVar(info->GetInstance())->GetDynamicType()->GetTypeHandler()->PropertyIndexToInlineOrAuxSlotIndex(info->GetPropertyIndex(), &slotIndex, &isInlineSlot);
+        dynamicInstance->GetDynamicType()->GetTypeHandler()->PropertyIndexToInlineOrAuxSlotIndex(info->GetPropertyIndex(), &slotIndex, &isInlineSlot);
 
         const bool isProto = info->GetInstance() != originalInstance;
         if(isProto &&
@@ -143,7 +145,7 @@ namespace Js
 
         Cache<true, true, false>(
             isProto,
-            DynamicObject::FromVar(info->GetInstance()),
+            dynamicInstance,
             false,
             RecyclableObject::FromVar(originalInstance)->GetType(),
             nullptr,
@@ -204,9 +206,10 @@ namespace Js
         AssertMsg((info->GetFlags() & InlineCacheGetterFlag) == 0, "invalid getter for CachePropertyWrite");
 
         RecyclableObject* instance = info->GetInstance();
+        DynamicObject * dynamicInstance = DynamicObject::FromVar(instance);
         PropertyIndex slotIndex;
         bool isInlineSlot;
-        DynamicObject::FromVar(instance)->GetDynamicType()->GetTypeHandler()->PropertyIndexToInlineOrAuxSlotIndex(propertyIndex, &slotIndex, &isInlineSlot);
+        dynamicInstance->GetDynamicType()->GetTypeHandler()->PropertyIndexToInlineOrAuxSlotIndex(propertyIndex, &slotIndex, &isInlineSlot);
 
         if (!isSetter)
         {
@@ -303,7 +306,7 @@ namespace Js
 
         Cache<true, false, false>(
             isProto,
-            DynamicObject::FromVar(instance),
+            dynamicInstance,
             false,
             object->GetType(),
             nullptr,

--- a/lib/Runtime/Language/InlineCache.inl
+++ b/lib/Runtime/Language/InlineCache.inl
@@ -35,7 +35,7 @@ namespace Js
         if (CheckLocal && type == u.local.type)
         {
             Assert(propertyObject->GetScriptContext() == requestContext); // we never cache a type from another script context
-            *propertyValue = DynamicObject::FromVar(propertyObject)->GetInlineSlot(u.local.slotIndex);
+            *propertyValue = DynamicObject::UnsafeFromVar(propertyObject)->GetInlineSlot(u.local.slotIndex);
             Assert(*propertyValue == JavascriptOperators::GetProperty(propertyObject, propertyId, requestContext) ||
                 (RootObjectBase::Is(propertyObject) && *propertyValue == JavascriptOperators::GetRootProperty(propertyObject, propertyId, requestContext)));
             if (ReturnOperationInfo)
@@ -49,7 +49,7 @@ namespace Js
         if (CheckLocal && TypeWithAuxSlotTag(type) == u.local.type)
         {
             Assert(propertyObject->GetScriptContext() == requestContext); // we never cache a type from another script context
-            *propertyValue = DynamicObject::FromVar(propertyObject)->GetAuxSlot(u.local.slotIndex);
+            *propertyValue = DynamicObject::UnsafeFromVar(propertyObject)->GetAuxSlot(u.local.slotIndex);
             Assert(*propertyValue == JavascriptOperators::GetProperty(propertyObject, propertyId, requestContext) ||
                 (RootObjectBase::Is(propertyObject) && *propertyValue == JavascriptOperators::GetRootProperty(propertyObject, propertyId, requestContext)));
             if (ReturnOperationInfo)
@@ -93,7 +93,7 @@ namespace Js
             Assert(propertyObject->GetScriptContext() == requestContext); // we never cache a type from another script context
             Assert(u.accessor.flags & InlineCacheGetterFlag);
 
-            RecyclableObject *const function = RecyclableObject::FromVar(u.accessor.object->GetInlineSlot(u.accessor.slotIndex));
+            RecyclableObject *const function = RecyclableObject::UnsafeFromVar(u.accessor.object->GetInlineSlot(u.accessor.slotIndex));
 
             *propertyValue = JavascriptOperators::CallGetter(function, instance, requestContext);
 
@@ -114,7 +114,7 @@ namespace Js
             Assert(propertyObject->GetScriptContext() == requestContext); // we never cache a type from another script context
             Assert(u.accessor.flags & InlineCacheGetterFlag);
 
-            RecyclableObject *const function = RecyclableObject::FromVar(u.accessor.object->GetAuxSlot(u.accessor.slotIndex));
+            RecyclableObject *const function = RecyclableObject::UnsafeFromVar(u.accessor.object->GetAuxSlot(u.accessor.slotIndex));
 
             *propertyValue = JavascriptOperators::CallGetter(function, instance, requestContext);
 
@@ -239,7 +239,7 @@ namespace Js
             Assert(isRoot || object->GetPropertyIndex(propertyId) == DynamicObject::FromVar(object)->GetTypeHandler()->InlineOrAuxSlotIndexToPropertyIndex(u.local.slotIndex, true));
             Assert(!isRoot || RootObjectBase::FromVar(object)->GetRootPropertyIndex(propertyId) == DynamicObject::FromVar(object)->GetTypeHandler()->InlineOrAuxSlotIndexToPropertyIndex(u.local.slotIndex, true));
             Assert(object->CanStorePropertyValueDirectly(propertyId, isRoot));
-            DynamicObject::FromVar(object)->SetInlineSlot(SetSlotArgumentsRoot(propertyId, isRoot, u.local.slotIndex, propertyValue));
+            DynamicObject::UnsafeFromVar(object)->SetInlineSlot(SetSlotArgumentsRoot(propertyId, isRoot, u.local.slotIndex, propertyValue));
             if (ReturnOperationInfo)
             {
                 operationInfo->cacheType = CacheType_Local;
@@ -255,7 +255,7 @@ namespace Js
             Assert(isRoot || object->GetPropertyIndex(propertyId) == DynamicObject::FromVar(object)->GetTypeHandler()->InlineOrAuxSlotIndexToPropertyIndex(u.local.slotIndex, false));
             Assert(!isRoot || RootObjectBase::FromVar(object)->GetRootPropertyIndex(propertyId) == DynamicObject::FromVar(object)->GetTypeHandler()->InlineOrAuxSlotIndexToPropertyIndex(u.local.slotIndex, false));
             Assert(object->CanStorePropertyValueDirectly(propertyId, isRoot));
-            DynamicObject::FromVar(object)->SetAuxSlot(SetSlotArgumentsRoot(propertyId, isRoot, u.local.slotIndex, propertyValue));
+            DynamicObject::UnsafeFromVar(object)->SetAuxSlot(SetSlotArgumentsRoot(propertyId, isRoot, u.local.slotIndex, propertyValue));
             if (ReturnOperationInfo)
             {
                 operationInfo->cacheType = CacheType_Local;
@@ -283,7 +283,7 @@ namespace Js
             AssertMsg(!((DynamicType*)u.local.typeWithoutProperty)->GetTypeHandler()->GetIsPrototype(), "Why did we cache a property add for a prototype?");
             Assert(((DynamicType*)typeWithProperty)->GetTypeHandler()->CanStorePropertyValueDirectly((const DynamicObject*)object, propertyId, isRoot));
 
-            DynamicObject *const dynamicObject = DynamicObject::FromVar(object);
+            DynamicObject *const dynamicObject = DynamicObject::UnsafeFromVar(object);
 
             // If we're adding a property to an inlined slot, we should never need to adjust auxiliary slot array size.
             Assert(newAuxSlotCapacity == 0);
@@ -320,7 +320,7 @@ namespace Js
             AssertMsg(!((DynamicType*)TypeWithoutAuxSlotTag(u.local.typeWithoutProperty))->GetTypeHandler()->GetIsPrototype(), "Why did we cache a property add for a prototype?");
             Assert(((DynamicType*)typeWithProperty)->GetTypeHandler()->CanStorePropertyValueDirectly((const DynamicObject*)object, propertyId, isRoot));
 
-            DynamicObject *const dynamicObject = DynamicObject::FromVar(object);
+            DynamicObject *const dynamicObject = DynamicObject::UnsafeFromVar(object);
 
             if (newAuxSlotCapacity > 0)
             {
@@ -351,7 +351,7 @@ namespace Js
             Assert(object->GetScriptContext() == requestContext); // we never cache a type from another script context
             Assert(u.accessor.flags & InlineCacheSetterFlag);
 
-            RecyclableObject *const function = RecyclableObject::FromVar(u.accessor.object->GetInlineSlot(u.accessor.slotIndex));
+            RecyclableObject *const function = RecyclableObject::UnsafeFromVar(u.accessor.object->GetInlineSlot(u.accessor.slotIndex));
 
             Assert(setterValue == nullptr || setterValue == function);
             Js::JavascriptOperators::CallSetter(function, object, propertyValue, requestContext);
@@ -369,7 +369,7 @@ namespace Js
             Assert(object->GetScriptContext() == requestContext); // we never cache a type from another script context
             Assert(u.accessor.flags & InlineCacheSetterFlag);
 
-            RecyclableObject *const function = RecyclableObject::FromVar(u.accessor.object->GetAuxSlot(u.accessor.slotIndex));
+            RecyclableObject *const function = RecyclableObject::UnsafeFromVar(u.accessor.object->GetAuxSlot(u.accessor.slotIndex));
 
             Assert(setterValue == nullptr || setterValue == function);
             Js::JavascriptOperators::CallSetter(function, object, propertyValue, requestContext);

--- a/lib/Runtime/Language/InterpreterStackFrame.h
+++ b/lib/Runtime/Language/InterpreterStackFrame.h
@@ -587,7 +587,7 @@ namespace Js
         template <class T> void DoInitProperty_NoFastPath(unaligned T* playout, Var instance);
         template <class T> void ProfiledInitProperty(unaligned T* playout, Var instance);
 
-        template <class T> bool TrySetPropertyLocalFastPath(unaligned T* playout, PropertyId pid, Var instance, InlineCache*& inlineCache, PropertyOperationFlags flags = PropertyOperation_None);
+        template <class T> bool TrySetPropertyLocalFastPath(unaligned T* playout, PropertyId pid, RecyclableObject* instance, InlineCache*& inlineCache, PropertyOperationFlags flags = PropertyOperation_None);
 
         template <bool doProfile> Var ProfiledDivide(Var aLeft, Var aRight, ScriptContext* scriptContext, ProfileId profileId);
         template <bool doProfile> Var ProfileModulus(Var aLeft, Var aRight, ScriptContext* scriptContext, ProfileId profileId);

--- a/lib/Runtime/Language/JavascriptConversion.cpp
+++ b/lib/Runtime/Language/JavascriptConversion.cpp
@@ -33,7 +33,7 @@ namespace Js
         {
             return false;
         }
-        JavascriptMethod entryPoint = RecyclableObject::FromVar(aValue)->GetEntryPoint();
+        JavascriptMethod entryPoint = RecyclableObject::UnsafeFromVar(aValue)->GetEntryPoint();
         return RecyclableObject::DefaultEntryPoint != entryPoint;
     }
 
@@ -79,7 +79,7 @@ namespace Js
             case TypeIds_Int64Number:
                 {
                 int leftValue = TaggedInt::ToInt32(aLeft);
-                __int64 rightValue = JavascriptInt64Number::FromVar(aRight)->GetValue();
+                __int64 rightValue = JavascriptInt64Number::UnsafeFromVar(aRight)->GetValue();
                 return leftValue == rightValue;
                 }
             case TypeIds_UInt64Number:
@@ -95,23 +95,23 @@ namespace Js
             {
             case TypeIds_Integer:
                 {
-                __int64 leftValue = JavascriptInt64Number::FromVar(aLeft)->GetValue();
+                __int64 leftValue = JavascriptInt64Number::UnsafeFromVar(aLeft)->GetValue();
                 int rightValue = TaggedInt::ToInt32(aRight);
                 return leftValue == rightValue;
                 }
             case TypeIds_Number:
-                dblLeft     = (double)JavascriptInt64Number::FromVar(aLeft)->GetValue();
+                dblLeft     = (double)JavascriptInt64Number::UnsafeFromVar(aLeft)->GetValue();
                 dblRight    = JavascriptNumber::GetValue(aRight);
                 goto CommonNumber;
             case TypeIds_Int64Number:
                 {
-                __int64 leftValue = JavascriptInt64Number::FromVar(aLeft)->GetValue();
-                __int64 rightValue = JavascriptInt64Number::FromVar(aRight)->GetValue();
+                __int64 leftValue = JavascriptInt64Number::UnsafeFromVar(aLeft)->GetValue();
+                __int64 rightValue = JavascriptInt64Number::UnsafeFromVar(aRight)->GetValue();
                 return leftValue == rightValue;
                 }
             case TypeIds_UInt64Number:
                 {
-                __int64 leftValue = JavascriptInt64Number::FromVar(aLeft)->GetValue();
+                __int64 leftValue = JavascriptInt64Number::UnsafeFromVar(aLeft)->GetValue();
                 unsigned __int64 rightValue = JavascriptInt64Number::FromVar(aRight)->GetValue();
                 return ((unsigned __int64)leftValue == rightValue);
                 }
@@ -122,23 +122,23 @@ namespace Js
             {
             case TypeIds_Integer:
                 {
-                unsigned __int64 leftValue = JavascriptUInt64Number::FromVar(aLeft)->GetValue();
+                unsigned __int64 leftValue = JavascriptUInt64Number::UnsafeFromVar(aLeft)->GetValue();
                 __int64 rightValue = TaggedInt::ToInt32(aRight);
                 return (leftValue == (unsigned __int64)rightValue);
                 }
             case TypeIds_Number:
-                dblLeft     = (double)JavascriptUInt64Number::FromVar(aLeft)->GetValue();
+                dblLeft     = (double)JavascriptUInt64Number::UnsafeFromVar(aLeft)->GetValue();
                 dblRight    = JavascriptNumber::GetValue(aRight);
                 goto CommonNumber;
             case TypeIds_Int64Number:
                 {
-                unsigned __int64 leftValue = JavascriptUInt64Number::FromVar(aLeft)->GetValue();
-                __int64 rightValue = JavascriptInt64Number::FromVar(aRight)->GetValue();
+                unsigned __int64 leftValue = JavascriptUInt64Number::UnsafeFromVar(aLeft)->GetValue();
+                __int64 rightValue = JavascriptInt64Number::UnsafeFromVar(aRight)->GetValue();
                 return (leftValue == (unsigned __int64)rightValue);
                 }
             case TypeIds_UInt64Number:
                 {
-                unsigned __int64 leftValue = JavascriptUInt64Number::FromVar(aLeft)->GetValue();
+                unsigned __int64 leftValue = JavascriptUInt64Number::UnsafeFromVar(aLeft)->GetValue();
                 unsigned __int64 rightValue = JavascriptInt64Number::FromVar(aRight)->GetValue();
                 return leftValue == rightValue;
                 }
@@ -153,11 +153,11 @@ namespace Js
                 goto CommonNumber;
             case TypeIds_Int64Number:
                 dblLeft     = JavascriptNumber::GetValue(aLeft);
-                dblRight    = (double)JavascriptInt64Number::FromVar(aRight)->GetValue();
+                dblRight    = (double)JavascriptInt64Number::UnsafeFromVar(aRight)->GetValue();
                 goto CommonNumber;
             case TypeIds_UInt64Number:
                 dblLeft     = JavascriptNumber::GetValue(aLeft);
-                dblRight    = (double)JavascriptUInt64Number::FromVar(aRight)->GetValue();
+                dblRight    = (double)JavascriptUInt64Number::UnsafeFromVar(aRight)->GetValue();
                 goto CommonNumber;
             case TypeIds_Number:
                 dblLeft     = JavascriptNumber::GetValue(aLeft);
@@ -200,8 +200,8 @@ CommonNumber:
             {
             case TypeIds_Symbol:
                 {
-                    JavascriptSymbol* leftSymbol = JavascriptSymbol::FromVar(aLeft);
-                    JavascriptSymbol* rightSymbol = JavascriptSymbol::FromVar(aRight);
+                    JavascriptSymbol* leftSymbol = JavascriptSymbol::UnsafeFromVar(aLeft);
+                    JavascriptSymbol* rightSymbol = JavascriptSymbol::UnsafeFromVar(aRight);
                     return leftSymbol->GetValue() == rightSymbol->GetValue();
                 }
             }
@@ -287,7 +287,7 @@ CommonNumber:
         if (JavascriptSymbol::Is(key))
         {
             // If we are looking up a property keyed by a symbol, we already have the PropertyId in the symbol
-            *propertyRecord = JavascriptSymbol::FromVar(key)->GetValue();
+            *propertyRecord = JavascriptSymbol::UnsafeFromVar(key)->GetValue();
         }
         else
         {
@@ -366,7 +366,7 @@ CommonNumber:
         case TypeIds_VariantDate:
             {
                 Var result = nullptr;
-                if (JavascriptVariantDate::FromVar(aValue)->ToPrimitive(hint, &result, requestContext) != TRUE)
+                if (JavascriptVariantDate::UnsafeFromVar(aValue)->ToPrimitive(hint, &result, requestContext) != TRUE)
                 {
                     result = nullptr;
                 }
@@ -375,7 +375,7 @@ CommonNumber:
 
         case TypeIds_StringObject:
             {
-                JavascriptStringObject * stringObject = JavascriptStringObject::FromVar(aValue);
+                JavascriptStringObject * stringObject = JavascriptStringObject::UnsafeFromVar(aValue);
                 ScriptContext * objectScriptContext = stringObject->GetScriptContext();
                 if (objectScriptContext->optimizationOverrides.GetSideEffects() & (hint == JavascriptHint::HintString ? SideEffects_ToString : SideEffects_ValueOf))
                 {
@@ -387,7 +387,7 @@ CommonNumber:
 
         case TypeIds_NumberObject:
             {
-                JavascriptNumberObject * numberObject = JavascriptNumberObject::FromVar(aValue);
+                JavascriptNumberObject * numberObject = JavascriptNumberObject::UnsafeFromVar(aValue);
                 ScriptContext * objectScriptContext = numberObject->GetScriptContext();
                 if (hint == JavascriptHint::HintString)
                 {
@@ -411,7 +411,7 @@ CommonNumber:
 
         case TypeIds_SymbolObject:
             {
-                JavascriptSymbolObject* symbolObject = JavascriptSymbolObject::FromVar(aValue);
+                JavascriptSymbolObject* symbolObject = JavascriptSymbolObject::UnsafeFromVar(aValue);
 
                 return requestContext->GetLibrary()->CreateSymbol(symbolObject->GetValue());
             }
@@ -419,7 +419,7 @@ CommonNumber:
         case TypeIds_Date:
         case TypeIds_WinRTDate:
             {
-                JavascriptDate* dateObject = JavascriptDate::FromVar(aValue);
+                JavascriptDate* dateObject = JavascriptDate::UnsafeFromVar(aValue);
                 if(hint == JavascriptHint::HintNumber)
                 {
                     if (dateObject->GetScriptContext()->optimizationOverrides.GetSideEffects() & SideEffects_ValueOf)
@@ -444,9 +444,9 @@ CommonNumber:
 
         // convert to JavascriptNumber
         case TypeIds_Int64Number:
-            return JavascriptInt64Number::FromVar(aValue)->ToJavascriptNumber();
+            return JavascriptInt64Number::UnsafeFromVar(aValue)->ToJavascriptNumber();
         case TypeIds_UInt64Number:
-            return JavascriptUInt64Number::FromVar(aValue)->ToJavascriptNumber();
+            return JavascriptUInt64Number::UnsafeFromVar(aValue)->ToJavascriptNumber();
 
         default:
 #ifdef ENABLE_SIMDJS
@@ -521,7 +521,7 @@ CommonNumber:
         }
 
         // Let exoticToPrim be GetMethod(input, @@toPrimitive).
-        JavascriptFunction* exoticToPrim = JavascriptFunction::FromVar(varMethod);
+        JavascriptFunction* exoticToPrim = JavascriptFunction::UnsafeFromVar(varMethod);
         JavascriptString* hintString = nullptr;
 
         if (hint == JavascriptHint::HintString)
@@ -649,14 +649,14 @@ CommonNumber:
                 return scriptContext->GetIntegerString(aValue);
 
             case TypeIds_Boolean:
-                return JavascriptBoolean::FromVar(aValue)->GetValue() ? scriptContext->GetLibrary()->GetTrueDisplayString() : scriptContext->GetLibrary()->GetFalseDisplayString();
+                return JavascriptBoolean::UnsafeFromVar(aValue)->GetValue() ? scriptContext->GetLibrary()->GetTrueDisplayString() : scriptContext->GetLibrary()->GetFalseDisplayString();
 
             case TypeIds_Number:
                 return JavascriptNumber::ToStringRadix10(JavascriptNumber::GetValue(aValue), scriptContext);
 
             case TypeIds_Int64Number:
                 {
-                    __int64 value = JavascriptInt64Number::FromVar(aValue)->GetValue();
+                    __int64 value = JavascriptInt64Number::UnsafeFromVar(aValue)->GetValue();
                     if (!TaggedInt::IsOverflow(value))
                     {
                         return scriptContext->GetIntegerString((int)value);
@@ -669,7 +669,7 @@ CommonNumber:
 
             case TypeIds_UInt64Number:
                 {
-                    unsigned __int64 value = JavascriptUInt64Number::FromVar(aValue)->GetValue();
+                    unsigned __int64 value = JavascriptUInt64Number::UnsafeFromVar(aValue)->GetValue();
                     if (!TaggedInt::IsOverflow(value))
                     {
                         return scriptContext->GetIntegerString((uint)value);
@@ -682,18 +682,18 @@ CommonNumber:
 
             case TypeIds_String:
                 {
-                    ScriptContext* aValueScriptContext = Js::RecyclableObject::FromVar(aValue)->GetScriptContext();
-                    return JavascriptString::FromVar(CrossSite::MarshalVar(scriptContext,
+                    ScriptContext* aValueScriptContext = Js::RecyclableObject::UnsafeFromVar(aValue)->GetScriptContext();
+                    return JavascriptString::UnsafeFromVar(CrossSite::MarshalVar(scriptContext,
                       aValue, aValueScriptContext));
                 }
             case TypeIds_VariantDate:
                 return JavascriptVariantDate::FromVar(aValue)->GetValueString(scriptContext);
 
             case TypeIds_Symbol:
-                return JavascriptSymbol::FromVar(aValue)->ToString(scriptContext);
+                return JavascriptSymbol::UnsafeFromVar(aValue)->ToString(scriptContext);
 
             case TypeIds_SymbolObject:
-                return JavascriptSymbol::ToString(JavascriptSymbolObject::FromVar(aValue)->GetValue(), scriptContext);
+                return JavascriptSymbol::ToString(JavascriptSymbolObject::UnsafeFromVar(aValue)->GetValue(), scriptContext);
 
 #ifdef ENABLE_SIMDJS
             case TypeIds_SIMDBool8x16:
@@ -714,7 +714,7 @@ CommonNumber:
                     JavascriptError::ThrowTypeError(scriptContext, JSERR_This_NeedSimd, _u("SIMDType.toString"));
                 }
                 JavascriptSIMDObject* simdObject = static_cast<JavascriptSIMDObject*>(obj);
-                return JavascriptString::FromVar(simdObject->ToString(scriptContext));
+                return JavascriptString::UnsafeFromVar(simdObject->ToString(scriptContext));
             }
 #endif
 
@@ -751,26 +751,26 @@ CommonNumber:
             return JavascriptNumber::ToLocaleString(TaggedInt::ToInt32(aValue), scriptContext);
 
         case TypeIds_Boolean:
-            return JavascriptBoolean::FromVar(aValue)->GetValue() ? scriptContext->GetLibrary()->GetTrueDisplayString() : scriptContext->GetLibrary()->GetFalseDisplayString();
+            return JavascriptBoolean::UnsafeFromVar(aValue)->GetValue() ? scriptContext->GetLibrary()->GetTrueDisplayString() : scriptContext->GetLibrary()->GetFalseDisplayString();
 
         case TypeIds_Int64Number:
-            return JavascriptNumber::ToLocaleString((double)JavascriptInt64Number::FromVar(aValue)->GetValue(), scriptContext);
+            return JavascriptNumber::ToLocaleString((double)JavascriptInt64Number::UnsafeFromVar(aValue)->GetValue(), scriptContext);
 
         case TypeIds_UInt64Number:
-            return JavascriptNumber::ToLocaleString((double)JavascriptUInt64Number::FromVar(aValue)->GetValue(), scriptContext);
+            return JavascriptNumber::ToLocaleString((double)JavascriptUInt64Number::UnsafeFromVar(aValue)->GetValue(), scriptContext);
 
         case TypeIds_Number:
             return JavascriptNumber::ToLocaleString(JavascriptNumber::GetValue(aValue), scriptContext);
 
         case TypeIds_String:
-            return JavascriptString::FromVar(aValue);
+            return JavascriptString::UnsafeFromVar(aValue);
 
         case TypeIds_VariantDate:
             // Legacy behavior was to create an empty object and call toLocaleString on it, which would result in this value
             return scriptContext->GetLibrary()->GetObjectDisplayString();
 
         case TypeIds_Symbol:
-            return JavascriptSymbol::FromVar(aValue)->ToString(scriptContext);
+            return JavascriptSymbol::UnsafeFromVar(aValue)->ToString(scriptContext);
 
         default:
             {
@@ -783,7 +783,7 @@ CommonNumber:
                     Var aResult = CALL_FUNCTION(scriptContext->GetThreadContext(), toLocaleStringFunction, CallInfo(1), aValue);
                     if (JavascriptString::Is(aResult))
                     {
-                        return JavascriptString::FromVar(aResult);
+                        return JavascriptString::UnsafeFromVar(aResult);
                     }
                     else
                     {
@@ -817,7 +817,7 @@ CommonNumber:
         AssertMsg(!TaggedInt::Is(aValue), "Should be detected");
         AssertMsg(RecyclableObject::Is(aValue), "Should be handled already");
 
-        auto type = RecyclableObject::FromVar(aValue)->GetType();
+        auto type = RecyclableObject::UnsafeFromVar(aValue)->GetType();
 
         switch (type->GetTypeId())
         {
@@ -830,7 +830,7 @@ CommonNumber:
             return true;
 
         case TypeIds_Boolean:
-            return JavascriptBoolean::FromVar(aValue)->GetValue();
+            return JavascriptBoolean::UnsafeFromVar(aValue)->GetValue();
 
 #if !FLOATVAR
         case TypeIds_Number:
@@ -842,19 +842,19 @@ CommonNumber:
 
         case TypeIds_Int64Number:
             {
-                __int64 value = JavascriptInt64Number::FromVar(aValue)->GetValue();
+                __int64 value = JavascriptInt64Number::UnsafeFromVar(aValue)->GetValue();
                 return value != 0;
             }
 
         case TypeIds_UInt64Number:
             {
-                unsigned __int64 value = JavascriptUInt64Number::FromVar(aValue)->GetValue();
+                unsigned __int64 value = JavascriptUInt64Number::UnsafeFromVar(aValue)->GetValue();
                 return value != 0;
             }
 
         case TypeIds_String:
             {
-                JavascriptString * pstValue = JavascriptString::FromVar(aValue);
+                JavascriptString * pstValue = JavascriptString::UnsafeFromVar(aValue);
                 return pstValue->GetLength() > 0;
             }
 
@@ -933,7 +933,7 @@ CommonNumber:
     double JavascriptConversion::ToNumber_Full(Var aValue,ScriptContext* scriptContext)
     {
         AssertMsg(!TaggedInt::Is(aValue), "Should be detected");
-        ScriptContext * objectScriptContext = RecyclableObject::Is(aValue) ? RecyclableObject::FromVar(aValue)->GetScriptContext() : nullptr;
+        ScriptContext * objectScriptContext = RecyclableObject::Is(aValue) ? RecyclableObject::UnsafeFromVar(aValue)->GetScriptContext() : nullptr;
         BOOL fPrimitiveOnly = false;
         while(true)
         {
@@ -953,22 +953,22 @@ CommonNumber:
                 return TaggedInt::ToDouble(aValue);
 
             case TypeIds_Boolean:
-                return JavascriptBoolean::FromVar(aValue)->GetValue() ? 1 : +0;
+                return JavascriptBoolean::UnsafeFromVar(aValue)->GetValue() ? 1 : +0;
 
             case TypeIds_Number:
                 return JavascriptNumber::GetValue(aValue);
 
             case TypeIds_Int64Number:
-                return (double)JavascriptInt64Number::FromVar(aValue)->GetValue();
+                return (double)JavascriptInt64Number::UnsafeFromVar(aValue)->GetValue();
 
             case TypeIds_UInt64Number:
-                return (double)JavascriptUInt64Number::FromVar(aValue)->GetValue();
+                return (double)JavascriptUInt64Number::UnsafeFromVar(aValue)->GetValue();
 
             case TypeIds_String:
-                return JavascriptString::FromVar(aValue)->ToDouble();
+                return JavascriptString::UnsafeFromVar(aValue)->ToDouble();
 
             case TypeIds_VariantDate:
-                return Js::DateImplementation::GetTvUtc(Js::DateImplementation::JsLocalTimeFromVarDate(JavascriptVariantDate::FromVar(aValue)->GetValue()), scriptContext);
+                return Js::DateImplementation::GetTvUtc(Js::DateImplementation::JsLocalTimeFromVarDate(JavascriptVariantDate::UnsafeFromVar(aValue)->GetValue()), scriptContext);
 
 #ifdef ENABLE_SIMDJS
             case TypeIds_SIMDFloat32x4:
@@ -1005,7 +1005,7 @@ CommonNumber:
     double JavascriptConversion::ToInteger_Full(Var aValue,ScriptContext* scriptContext)
     {
         AssertMsg(!TaggedInt::Is(aValue), "Should be detected");
-        ScriptContext * objectScriptContext = RecyclableObject::Is(aValue) ? RecyclableObject::FromVar(aValue)->GetScriptContext() : nullptr;
+        ScriptContext * objectScriptContext = RecyclableObject::Is(aValue) ? RecyclableObject::UnsafeFromVar(aValue)->GetScriptContext() : nullptr;
         BOOL fPrimitiveOnly = false;
         while(true)
         {
@@ -1022,19 +1022,18 @@ CommonNumber:
                 return TaggedInt::ToInt32(aValue);
 
             case TypeIds_Boolean:
-                return JavascriptBoolean::FromVar(aValue)->GetValue() ? 1 : +0;
+                return JavascriptBoolean::UnsafeFromVar(aValue)->GetValue() ? 1 : +0;
 
             case TypeIds_Number:
                 return ToInteger(JavascriptNumber::GetValue(aValue));
 
             case TypeIds_Int64Number:
-                return ToInteger((double)JavascriptInt64Number::FromVar(aValue)->GetValue());
+                return ToInteger((double)JavascriptInt64Number::UnsafeFromVar(aValue)->GetValue());
 
             case TypeIds_UInt64Number:
-                return ToInteger((double)JavascriptUInt64Number::FromVar(aValue)->GetValue());
-
+                return ToInteger((double)JavascriptUInt64Number::UnsafeFromVar(aValue)->GetValue());
             case TypeIds_String:
-                return ToInteger(JavascriptString::FromVar(aValue)->ToDouble());
+                return ToInteger(JavascriptString::UnsafeFromVar(aValue)->ToDouble());
 
             case TypeIds_VariantDate:
                 return ToInteger(ToNumber_Full(aValue, scriptContext));
@@ -1091,7 +1090,7 @@ CommonNumber:
         Assert(Js::JavascriptStackWalker::ValidateTopJitFrame(scriptContext));
         AssertMsg(!TaggedInt::Is(aValue), "Should be detected");
 
-        ScriptContext * objectScriptContext = RecyclableObject::Is(aValue) ? RecyclableObject::FromVar(aValue)->GetScriptContext() : nullptr;
+        ScriptContext * objectScriptContext = RecyclableObject::Is(aValue) ? RecyclableObject::UnsafeFromVar(aValue)->GetScriptContext() : nullptr;
         // This is used when TaggedInt's overflow but remain under int32
         // so Number is our most critical case:
 
@@ -1115,22 +1114,22 @@ CommonNumber:
             return TaggedInt::ToInt32(aValue);
 
         case TypeIds_Boolean:
-            return JavascriptBoolean::FromVar(aValue)->GetValue() ? 1 : +0;
+            return JavascriptBoolean::UnsafeFromVar(aValue)->GetValue() ? 1 : +0;
 
         case TypeIds_Int64Number:
             // we won't lose precision if the int64 is within 32bit boundary; otherwise we need to
             // treat it as double anyhow.
-            return JavascriptMath::ToInt32Core((double)JavascriptInt64Number::FromVar(aValue)->GetValue());
+            return JavascriptMath::ToInt32Core((double)JavascriptInt64Number::UnsafeFromVar(aValue)->GetValue());
 
         case TypeIds_UInt64Number:
             // we won't lose precision if the int64 is within 32bit boundary; otherwise we need to
             // treat it as double anyhow.
-            return JavascriptMath::ToInt32Core((double)JavascriptUInt64Number::FromVar(aValue)->GetValue());
+            return JavascriptMath::ToInt32Core((double)JavascriptUInt64Number::UnsafeFromVar(aValue)->GetValue());
 
         case TypeIds_String:
         {
             double result;
-            if (JavascriptString::FromVar(aValue)->ToDouble(&result))
+            if (JavascriptString::UnsafeFromVar(aValue)->ToDouble(&result))
             {
                 return JavascriptMath::ToInt32Core(result);
             }
@@ -1174,7 +1173,7 @@ CommonNumber:
             return TaggedInt::ToInt32(aValue);
 
         case TypeIds_Boolean:
-            return JavascriptBoolean::FromVar(aValue)->GetValue() ? 1 : +0;
+            return JavascriptBoolean::UnsafeFromVar(aValue)->GetValue() ? 1 : +0;
 
         case TypeIds_Number:
             return ToInt32(JavascriptNumber::GetValue(aValue));
@@ -1182,17 +1181,17 @@ CommonNumber:
         case TypeIds_Int64Number:
             // we won't lose precision if the int64 is within 32bit boundary; otherwise we need to
             // treat it as double anyhow.
-            return JavascriptMath::ToInt32Core((double)JavascriptInt64Number::FromVar(aValue)->GetValue());
+            return JavascriptMath::ToInt32Core((double)JavascriptInt64Number::UnsafeFromVar(aValue)->GetValue());
 
         case TypeIds_UInt64Number:
             // we won't lose precision if the int64 is within 32bit boundary; otherwise we need to
             // treat it as double anyhow.
-            return JavascriptMath::ToInt32Core((double)JavascriptUInt64Number::FromVar(aValue)->GetValue());
+            return JavascriptMath::ToInt32Core((double)JavascriptUInt64Number::UnsafeFromVar(aValue)->GetValue());
 
         case TypeIds_String:
         {
             double result;
-            if (JavascriptString::FromVar(aValue)->ToDouble(&result))
+            if (JavascriptString::UnsafeFromVar(aValue)->ToDouble(&result))
             {
                 return ToInt32(result);
             }
@@ -1212,7 +1211,7 @@ CommonNumber:
     // a strict version of ToInt32 conversion that returns false for non int32 values like, inf, NaN, undef
     BOOL JavascriptConversion::ToInt32Finite(Var aValue, ScriptContext* scriptContext, int32* result)
     {
-        ScriptContext * objectScriptContext = RecyclableObject::Is(aValue) ? RecyclableObject::FromVar(aValue)->GetScriptContext() : nullptr;
+        ScriptContext * objectScriptContext = RecyclableObject::Is(aValue) ? RecyclableObject::UnsafeFromVar(aValue)->GetScriptContext() : nullptr;
         BOOL fPrimitiveOnly = false;
         while(true)
         {
@@ -1234,7 +1233,7 @@ CommonNumber:
                 return true;
 
             case TypeIds_Boolean:
-                *result = JavascriptBoolean::FromVar(aValue)->GetValue() ? 1 : +0;
+                *result = JavascriptBoolean::UnsafeFromVar(aValue)->GetValue() ? 1 : +0;
                 return true;
 
             case TypeIds_Number:
@@ -1243,15 +1242,15 @@ CommonNumber:
             case TypeIds_Int64Number:
                 // we won't lose precision if the int64 is within 32bit boundary; otherwise we need to
                 // treat it as double anyhow.
-                return ToInt32Finite((double)JavascriptInt64Number::FromVar(aValue)->GetValue(), result);
+                return ToInt32Finite((double)JavascriptInt64Number::UnsafeFromVar(aValue)->GetValue(), result);
 
             case TypeIds_UInt64Number:
                 // we won't lose precision if the int64 is within 32bit boundary; otherwise we need to
                 // treat it as double anyhow.
-                return ToInt32Finite((double)JavascriptUInt64Number::FromVar(aValue)->GetValue(), result);
+                return ToInt32Finite((double)JavascriptUInt64Number::UnsafeFromVar(aValue)->GetValue(), result);
 
             case TypeIds_String:
-                return ToInt32Finite(JavascriptString::FromVar(aValue)->ToDouble(), result);
+                return ToInt32Finite(JavascriptString::UnsafeFromVar(aValue)->ToDouble(), result);
 
             case TypeIds_VariantDate:
                 return ToInt32Finite(ToNumber_Full(aValue, scriptContext), result);
@@ -1301,12 +1300,12 @@ CommonNumber:
             }
         case TypeIds_Int64Number:
             {
-            JavascriptInt64Number* int64Number = JavascriptInt64Number::FromVar(aValue);
+            JavascriptInt64Number* int64Number = JavascriptInt64Number::UnsafeFromVar(aValue);
             return int64Number->GetValue();
             }
         case TypeIds_UInt64Number:
             {
-            JavascriptUInt64Number* uint64Number = JavascriptUInt64Number::FromVar(aValue);
+            JavascriptUInt64Number* uint64Number = JavascriptUInt64Number::UnsafeFromVar(aValue);
             return (__int64)uint64Number->GetValue();
             }
         case TypeIds_Number:
@@ -1326,12 +1325,12 @@ CommonNumber:
             }
         case TypeIds_Int64Number:
             {
-            JavascriptInt64Number* int64Number = JavascriptInt64Number::FromVar(aValue);
+            JavascriptInt64Number* int64Number = JavascriptInt64Number::UnsafeFromVar(aValue);
             return (unsigned __int64)int64Number->GetValue();
             }
         case TypeIds_UInt64Number:
             {
-            JavascriptUInt64Number* uint64Number = JavascriptUInt64Number::FromVar(aValue);
+            JavascriptUInt64Number* uint64Number = JavascriptUInt64Number::UnsafeFromVar(aValue);
             return uint64Number->GetValue();
             }
         case TypeIds_Number:
@@ -1361,7 +1360,7 @@ CommonNumber:
     uint32 JavascriptConversion::ToUInt32_Full(Var aValue, ScriptContext* scriptContext)
     {
         AssertMsg(!TaggedInt::Is(aValue), "Should be detected");
-        ScriptContext * objectScriptContext = RecyclableObject::Is(aValue) ? RecyclableObject::FromVar(aValue)->GetScriptContext() : nullptr;
+        ScriptContext * objectScriptContext = RecyclableObject::Is(aValue) ? RecyclableObject::UnsafeFromVar(aValue)->GetScriptContext() : nullptr;
         BOOL fPrimitiveOnly = false;
         while(true)
         {
@@ -1378,7 +1377,7 @@ CommonNumber:
                 return TaggedInt::ToUInt32(aValue);
 
             case TypeIds_Boolean:
-                return JavascriptBoolean::FromVar(aValue)->GetValue() ? 1 : +0;
+                return JavascriptBoolean::UnsafeFromVar(aValue)->GetValue() ? 1 : +0;
 
             case TypeIds_Number:
                 return JavascriptMath::ToUInt32(JavascriptNumber::GetValue(aValue));
@@ -1386,17 +1385,17 @@ CommonNumber:
             case TypeIds_Int64Number:
                 // we won't lose precision if the int64 is within 32bit boundary; otherwise we need to
                 // treat it as double anyhow.
-                return JavascriptMath::ToUInt32((double)JavascriptInt64Number::FromVar(aValue)->GetValue());
+                return JavascriptMath::ToUInt32((double)JavascriptInt64Number::UnsafeFromVar(aValue)->GetValue());
 
             case TypeIds_UInt64Number:
                 // we won't lose precision if the int64 is within 32bit boundary; otherwise we need to
                 // treat it as double anyhow.
-                return JavascriptMath::ToUInt32((double)JavascriptUInt64Number::FromVar(aValue)->GetValue());
+                return JavascriptMath::ToUInt32((double)JavascriptUInt64Number::UnsafeFromVar(aValue)->GetValue());
 
             case TypeIds_String:
             {
                 double result;
-                if (JavascriptString::FromVar(aValue)->ToDouble(&result))
+                if (JavascriptString::UnsafeFromVar(aValue)->ToDouble(&result))
                 {
                     return JavascriptMath::ToUInt32(result);
                 }
@@ -1450,7 +1449,7 @@ CommonNumber:
     uint16 JavascriptConversion::ToUInt16_Full(IN  Var aValue, ScriptContext* scriptContext)
     {
         AssertMsg(!TaggedInt::Is(aValue), "Should be detected");
-        ScriptContext * objectScriptContext = RecyclableObject::Is(aValue) ? RecyclableObject::FromVar(aValue)->GetScriptContext() : nullptr;
+        ScriptContext * objectScriptContext = RecyclableObject::Is(aValue) ? RecyclableObject::UnsafeFromVar(aValue)->GetScriptContext() : nullptr;
         BOOL fPrimitiveOnly = false;
         while(true)
         {
@@ -1467,7 +1466,7 @@ CommonNumber:
                 return TaggedInt::ToUInt16(aValue);
 
             case TypeIds_Boolean:
-                return JavascriptBoolean::FromVar(aValue)->GetValue() ? 1 : +0;
+                return JavascriptBoolean::UnsafeFromVar(aValue)->GetValue() ? 1 : +0;
 
             case TypeIds_Number:
                 return ToUInt16(JavascriptNumber::GetValue(aValue));
@@ -1475,17 +1474,17 @@ CommonNumber:
             case TypeIds_Int64Number:
                 // we won't lose precision if the int64 is within 16bit boundary; otherwise we need to
                 // treat it as double anyhow.
-                return ToUInt16((double)JavascriptInt64Number::FromVar(aValue)->GetValue());
+                return ToUInt16((double)JavascriptInt64Number::UnsafeFromVar(aValue)->GetValue());
 
             case TypeIds_UInt64Number:
                 // we won't lose precision if the int64 is within 16bit boundary; otherwise we need to
                 // treat it as double anyhow.
-                return ToUInt16((double)JavascriptUInt64Number::FromVar(aValue)->GetValue());
+                return ToUInt16((double)JavascriptUInt64Number::UnsafeFromVar(aValue)->GetValue());
 
             case TypeIds_String:
             {
                 double result;
-                if (JavascriptString::FromVar(aValue)->ToDouble(&result))
+                if (JavascriptString::UnsafeFromVar(aValue)->ToDouble(&result))
                 {
                     return ToUInt16(result);
                 }

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -108,35 +108,37 @@ namespace Js
                 return IndexType_PropertyId;
             }
         }
-        else if (JavascriptSymbol::Is(indexVar))
-        {
-            JavascriptSymbol* symbol = JavascriptSymbol::FromVar(indexVar);
-
-            // JavascriptSymbols cannot add a new PropertyRecord - they correspond to one and only one existing PropertyRecord.
-            // We already know what the PropertyRecord is since it is stored in the JavascriptSymbol itself so just return it.
-
-            *propertyRecord = symbol->GetValue();
-
-            return IndexType_PropertyId;
-        }
         else
         {
-            JavascriptString* indexStr = JavascriptConversion::ToString(indexVar, scriptContext);
-            char16 const * propertyName = indexStr->GetString();
-            charcount_t const propertyLength = indexStr->GetLength();
-
-            if (!createIfNotFound && preferJavascriptStringOverPropertyRecord)
+            JavascriptSymbol * symbol = JavascriptOperators::TryFromVar<JavascriptSymbol>(indexVar);
+            if (symbol)
             {
-                if (JavascriptOperators::TryConvertToUInt32(propertyName, propertyLength, index) &&
-                    (*index != JavascriptArray::InvalidIndex))
-                {
-                    return IndexType_Number;
-                }
+                // JavascriptSymbols cannot add a new PropertyRecord - they correspond to one and only one existing PropertyRecord.
+                // We already know what the PropertyRecord is since it is stored in the JavascriptSymbol itself so just return it.
 
-                *propertyNameString = indexStr;
-                return IndexType_JavascriptString;
+                *propertyRecord = symbol->GetValue();
+
+                return IndexType_PropertyId;
             }
-            return GetIndexTypeFromString(propertyName, propertyLength, scriptContext, index, propertyRecord, createIfNotFound);
+            else
+            {
+                JavascriptString* indexStr = JavascriptConversion::ToString(indexVar, scriptContext);
+                char16 const * propertyName = indexStr->GetString();
+                charcount_t const propertyLength = indexStr->GetLength();
+
+                if (!createIfNotFound && preferJavascriptStringOverPropertyRecord)
+                {
+                    if (JavascriptOperators::TryConvertToUInt32(propertyName, propertyLength, index) &&
+                        (*index != JavascriptArray::InvalidIndex))
+                    {
+                        return IndexType_Number;
+                    }
+
+                    *propertyNameString = indexStr;
+                    return IndexType_JavascriptString;
+                }
+                return GetIndexTypeFromString(propertyName, propertyLength, scriptContext, index, propertyRecord, createIfNotFound);
+            }
         }
     }
 
@@ -191,7 +193,7 @@ namespace Js
         //   See Win8 bug 490489.
         callInfo.Flags = CallFlags_Value;
 
-        RecyclableObject *funcPtr = RecyclableObject::FromVar(func);
+        RecyclableObject *funcPtr = RecyclableObject::UnsafeFromVar(func);
         PROBE_STACK(scriptContext, Js::Constants::MinStackDefault + argCount * 4);
 
         JavascriptMethod entryPoint = funcPtr->GetEntryPoint();
@@ -413,10 +415,10 @@ namespace Js
     Js::JavascriptString* GetPropertyDisplayNameForError(Var prop, ScriptContext* scriptContext)
     {
         JavascriptString* str;
-
-        if (JavascriptSymbol::Is(prop))
+        JavascriptSymbol *symbol = JavascriptOperators::TryFromVar<JavascriptSymbol>(prop);
+        if (symbol)
         {
-            str = JavascriptSymbol::ToString(JavascriptSymbol::FromVar(prop)->GetValue(), scriptContext);
+            str = JavascriptSymbol::ToString(symbol->GetValue(), scriptContext);
         }
         else
         {
@@ -556,7 +558,7 @@ namespace Js
             }
             else
             {
-                BOOL res = RecyclableObject::FromVar(aRight)->Equals(aLeft, &result, requestContext);
+                BOOL res = RecyclableObject::UnsafeFromVar(aRight)->Equals(aLeft, &result, requestContext);
                 AssertMsg(res, "Should have handled this");
                 return result;
             }
@@ -573,7 +575,7 @@ namespace Js
             }
             else
             {
-                BOOL res = RecyclableObject::FromVar(aRight)->Equals(aLeft, &result, requestContext);
+                BOOL res = RecyclableObject::UnsafeFromVar(aRight)->Equals(aLeft, &result, requestContext);
                 AssertMsg(res, "Should have handled this");
                 return result;
             }
@@ -585,7 +587,7 @@ namespace Js
         }
 #endif
 
-        if (RecyclableObject::FromVar(aLeft)->Equals(aRight, &result, requestContext))
+        if (RecyclableObject::UnsafeFromVar(aLeft)->Equals(aRight, &result, requestContext))
         {
             return result;
         }
@@ -678,15 +680,15 @@ namespace Js
                 {
                 case TypeIds_Int64Number:
                     {
-                        __int64 leftValue = JavascriptInt64Number::FromVar(aLeft)->GetValue();
-                        __int64 rightValue = JavascriptInt64Number::FromVar(aRight)->GetValue();
+                        __int64 leftValue = JavascriptInt64Number::UnsafeFromVar(aLeft)->GetValue();
+                        __int64 rightValue = JavascriptInt64Number::UnsafeFromVar(aRight)->GetValue();
                         return leftValue < rightValue;
                     }
                     break;
                 case TypeIds_UInt64Number:
                     {
-                        __int64 leftValue = JavascriptInt64Number::FromVar(aLeft)->GetValue();
-                        unsigned __int64 rightValue = JavascriptUInt64Number::FromVar(aRight)->GetValue();
+                        __int64 leftValue = JavascriptInt64Number::UnsafeFromVar(aLeft)->GetValue();
+                        unsigned __int64 rightValue = JavascriptUInt64Number::UnsafeFromVar(aRight)->GetValue();
                         if (rightValue <= INT_MAX && leftValue >= 0)
                         {
                             return leftValue < (__int64)rightValue;
@@ -694,7 +696,7 @@ namespace Js
                     }
                     break;
                 }
-                dblLeft = (double)JavascriptInt64Number::FromVar(aLeft)->GetValue();
+                dblLeft = (double)JavascriptInt64Number::UnsafeFromVar(aLeft)->GetValue();
                 dblRight = JavascriptConversion::ToNumber(aRight, scriptContext);
             }
             break;
@@ -708,8 +710,8 @@ namespace Js
                 {
                 case TypeIds_Int64Number:
                     {
-                        unsigned __int64 leftValue = JavascriptUInt64Number::FromVar(aLeft)->GetValue();
-                        __int64 rightValue = JavascriptInt64Number::FromVar(aRight)->GetValue();
+                        unsigned __int64 leftValue = JavascriptUInt64Number::UnsafeFromVar(aLeft)->GetValue();
+                        __int64 rightValue = JavascriptInt64Number::UnsafeFromVar(aRight)->GetValue();
                         if (leftValue < INT_MAX && rightValue >= 0)
                         {
                             return (__int64)leftValue < rightValue;
@@ -718,13 +720,13 @@ namespace Js
                     break;
                 case TypeIds_UInt64Number:
                     {
-                        unsigned __int64 leftValue = JavascriptUInt64Number::FromVar(aLeft)->GetValue();
-                        unsigned __int64 rightValue = JavascriptUInt64Number::FromVar(aRight)->GetValue();
+                        unsigned __int64 leftValue = JavascriptUInt64Number::UnsafeFromVar(aLeft)->GetValue();
+                        unsigned __int64 rightValue = JavascriptUInt64Number::UnsafeFromVar(aRight)->GetValue();
                         return leftValue < rightValue;
                     }
                     break;
                 }
-                dblLeft = (double)JavascriptUInt64Number::FromVar(aLeft)->GetValue();
+                dblLeft = (double)JavascriptUInt64Number::UnsafeFromVar(aLeft)->GetValue();
                 dblRight = JavascriptConversion::ToNumber(aRight, scriptContext);
             }
             break;
@@ -872,11 +874,14 @@ namespace Js
 
     BOOL JavascriptOperators::StrictEqualEmptyString(Var aLeft)
     {
-        TypeId leftType = JavascriptOperators::GetTypeId(aLeft);
-        if (leftType != TypeIds_String)
+        JavascriptString * string = JavascriptOperators::TryFromVar<JavascriptString>(aLeft);
+        if (!string)
+        {
             return false;
+        }
 
-        return JavascriptString::FromVar(aLeft)->GetLength() == 0;
+        Assert(string);
+        return string->GetLength() == 0;
     }
 
     BOOL JavascriptOperators::StrictEqual(Var aLeft, Var aRight, ScriptContext* requestContext)
@@ -917,18 +922,18 @@ namespace Js
             {
             case TypeIds_Int64Number:
                 {
-                    __int64 leftValue = JavascriptInt64Number::FromVar(aLeft)->GetValue();
-                    __int64 rightValue = JavascriptInt64Number::FromVar(aRight)->GetValue();
+                    __int64 leftValue = JavascriptInt64Number::UnsafeFromVar(aLeft)->GetValue();
+                    __int64 rightValue = JavascriptInt64Number::UnsafeFromVar(aRight)->GetValue();
                     return leftValue == rightValue;
                 }
             case TypeIds_UInt64Number:
                 {
-                    __int64 leftValue = JavascriptInt64Number::FromVar(aLeft)->GetValue();
+                    __int64 leftValue = JavascriptInt64Number::UnsafeFromVar(aLeft)->GetValue();
                     unsigned __int64 rightValue = JavascriptInt64Number::FromVar(aRight)->GetValue();
                     return ((unsigned __int64)leftValue == rightValue);
                 }
             case TypeIds_Number:
-                dblLeft     = (double)JavascriptInt64Number::FromVar(aLeft)->GetValue();
+                dblLeft     = (double)JavascriptInt64Number::UnsafeFromVar(aLeft)->GetValue();
                 dblRight    = JavascriptNumber::GetValue(aRight);
                 goto CommonNumber;
             }
@@ -938,18 +943,18 @@ namespace Js
             {
             case TypeIds_Int64Number:
                 {
-                    unsigned __int64 leftValue = JavascriptUInt64Number::FromVar(aLeft)->GetValue();
-                    __int64 rightValue = JavascriptInt64Number::FromVar(aRight)->GetValue();
+                    unsigned __int64 leftValue = JavascriptUInt64Number::UnsafeFromVar(aLeft)->GetValue();
+                    __int64 rightValue = JavascriptInt64Number::UnsafeFromVar(aRight)->GetValue();
                     return (leftValue == (unsigned __int64)rightValue);
                 }
             case TypeIds_UInt64Number:
                 {
-                    unsigned __int64 leftValue = JavascriptUInt64Number::FromVar(aLeft)->GetValue();
+                    unsigned __int64 leftValue = JavascriptUInt64Number::UnsafeFromVar(aLeft)->GetValue();
                     unsigned __int64 rightValue = JavascriptInt64Number::FromVar(aRight)->GetValue();
                     return leftValue == rightValue;
                 }
             case TypeIds_Number:
-                dblLeft     = (double)JavascriptUInt64Number::FromVar(aLeft)->GetValue();
+                dblLeft     = (double)JavascriptUInt64Number::UnsafeFromVar(aLeft)->GetValue();
                 dblRight    = JavascriptNumber::GetValue(aRight);
                 goto CommonNumber;
             }
@@ -968,7 +973,7 @@ namespace Js
                 goto CommonNumber;
             case TypeIds_UInt64Number:
                 dblLeft     = JavascriptNumber::GetValue(aLeft);
-                dblRight = (double)JavascriptUInt64Number::FromVar(aRight)->GetValue();
+                dblRight = (double)JavascriptUInt64Number::UnsafeFromVar(aRight)->GetValue();
                 goto CommonNumber;
             case TypeIds_Number:
                 dblLeft     = JavascriptNumber::GetValue(aLeft);
@@ -999,8 +1004,8 @@ CommonNumber:
             {
             case TypeIds_Symbol:
                 {
-                    const PropertyRecord* leftValue = JavascriptSymbol::FromVar(aLeft)->GetValue();
-                    const PropertyRecord* rightValue = JavascriptSymbol::FromVar(aRight)->GetValue();
+                    const PropertyRecord* leftValue = JavascriptSymbol::UnsafeFromVar(aLeft)->GetValue();
+                    const PropertyRecord* rightValue = JavascriptSymbol::UnsafeFromVar(aRight)->GetValue();
                     return leftValue == rightValue;
                 }
             }
@@ -1014,7 +1019,7 @@ CommonNumber:
                 case TypeIds_GlobalObject:
                 {
                     BOOL result;
-                    if(RecyclableObject::FromVar(aLeft)->StrictEquals(aRight, &result, requestContext))
+                    if(RecyclableObject::UnsafeFromVar(aLeft)->StrictEquals(aRight, &result, requestContext))
                     {
                         return result;
                     }
@@ -1077,7 +1082,7 @@ CommonNumber:
         {
             return FALSE;
         }
-        RecyclableObject* object = RecyclableObject::FromVar(instance);
+        RecyclableObject* object = RecyclableObject::UnsafeFromVar(instance);
 
         if (JavascriptProxy::Is(instance))
         {
@@ -1133,7 +1138,7 @@ CommonNumber:
         }
         else
         {
-            RecyclableObject* object = RecyclableObject::FromVar(instance);
+            RecyclableObject* object = RecyclableObject::UnsafeFromVar(instance);
             result = object && object->GetAccessors(propertyId, getter, setter, requestContext);
         }
         return result;
@@ -1142,10 +1147,9 @@ CommonNumber:
     JavascriptArray* JavascriptOperators::GetOwnPropertyNames(Var instance, ScriptContext *scriptContext)
     {
         RecyclableObject *object = RecyclableObject::FromVar(ToObject(instance, scriptContext));
-
-        if (JavascriptProxy::Is(instance))
+        JavascriptProxy * proxy = JavascriptOperators::TryFromVar<JavascriptProxy>(instance);
+        if (proxy)
         {
-            JavascriptProxy* proxy = JavascriptProxy::FromVar(instance);
             return proxy->PropertyKeysTrap(JavascriptProxy::KeysTrapKind::GetOwnPropertyNamesKind, scriptContext);
         }
 
@@ -1157,9 +1161,9 @@ CommonNumber:
         RecyclableObject *object = RecyclableObject::FromVar(ToObject(instance, scriptContext));
         CHAKRATEL_LANGSTATS_INC_BUILTINCOUNT(Object_Constructor_getOwnPropertySymbols);
 
-        if (JavascriptProxy::Is(instance))
+        JavascriptProxy* proxy = JavascriptOperators::TryFromVar<JavascriptProxy>(instance);
+        if (proxy)
         {
-            JavascriptProxy* proxy = JavascriptProxy::FromVar(instance);
             return proxy->PropertyKeysTrap(JavascriptProxy::KeysTrapKind::GetOwnPropertySymbolKind, scriptContext);
         }
 
@@ -1170,9 +1174,9 @@ CommonNumber:
     {
         RecyclableObject *object = RecyclableObject::FromVar(ToObject(instance, scriptContext));
 
-        if (JavascriptProxy::Is(instance))
+        JavascriptProxy* proxy = JavascriptOperators::TryFromVar<JavascriptProxy>(instance);
+        if (proxy)
         {
-            JavascriptProxy* proxy = JavascriptProxy::FromVar(instance);
             return proxy->PropertyKeysTrap(JavascriptProxy::KeysTrapKind::KeysKind, scriptContext);
         }
 
@@ -1181,9 +1185,9 @@ CommonNumber:
 
     JavascriptArray* JavascriptOperators::GetOwnEnumerablePropertyNames(RecyclableObject* object, ScriptContext* scriptContext)
     {
-        if (JavascriptProxy::Is(object))
+        JavascriptProxy* proxy = JavascriptOperators::TryFromVar<JavascriptProxy>(object);
+        if (proxy)
         {
-            JavascriptProxy* proxy = JavascriptProxy::FromVar(object);
             JavascriptArray* proxyResult = proxy->PropertyKeysTrap(JavascriptProxy::KeysTrapKind::GetOwnPropertyNamesKind, scriptContext);
             JavascriptArray* proxyResultToReturn = scriptContext->GetLibrary()->CreateArray(0);
 
@@ -1215,9 +1219,9 @@ CommonNumber:
 
     JavascriptArray* JavascriptOperators::GetOwnEnumerablePropertyNamesSymbols(RecyclableObject* object, ScriptContext* scriptContext)
     {
-        if (JavascriptProxy::Is(object))
+        JavascriptProxy* proxy = JavascriptOperators::TryFromVar<JavascriptProxy>(object);
+        if (proxy)
         {
-            JavascriptProxy* proxy = JavascriptProxy::FromVar(object);
             return proxy->PropertyKeysTrap(JavascriptProxy::KeysTrapKind::KeysKind, scriptContext);
         }
         return JavascriptObject::CreateOwnEnumerableStringSymbolPropertiesHelper(object, scriptContext);
@@ -1327,14 +1331,15 @@ CommonNumber:
         {
             return FALSE;
         }
-        RecyclableObject* instance = RecyclableObject::FromVar(instanceVar);
+        RecyclableObject* instance = RecyclableObject::UnsafeFromVar(instanceVar);
         if (DynamicObject::IsAnyArray(instance))
         {
             return TRUE;
         }
-        if (JavascriptProxy::Is(instanceVar))
+
+        JavascriptProxy* proxy = JavascriptOperators::TryFromVar<JavascriptProxy>(instanceVar);
+        if (proxy)
         {
-            JavascriptProxy* proxy = JavascriptProxy::FromVar(instanceVar);
             return IsArray(proxy->GetTarget());
         }
         TypeId remoteTypeId = TypeIds_Limit;
@@ -1352,16 +1357,19 @@ CommonNumber:
         {
             return FALSE;
         }
-        if (JavascriptProxy::Is(instanceVar))
+
+        JavascriptProxy* proxy = JavascriptOperators::TryFromVar<JavascriptProxy>(instanceVar);
+        if (proxy)
         {
-            JavascriptProxy* proxy = JavascriptProxy::FromVar(instanceVar);
             return IsConstructor(proxy->GetTarget());
         }
-        if (!JavascriptFunction::Is(instanceVar))
+
+        JavascriptFunction * function = JavascriptOperators::TryFromVar<JavascriptFunction>(instanceVar);
+        if (!function)
         {
             return FALSE;
         }
-        return JavascriptFunction::FromVar(instanceVar)->IsConstructor();
+        return function->IsConstructor();
     }
 
     BOOL JavascriptOperators::IsConcatSpreadable(Var instanceVar)
@@ -1373,7 +1381,7 @@ CommonNumber:
             return false;
         }
 
-        RecyclableObject* instance = RecyclableObject::FromVar(instanceVar);
+        RecyclableObject* instance = RecyclableObject::UnsafeFromVar(instanceVar);
         ScriptContext* scriptContext = instance->GetScriptContext();
 
         if (!PHASE_OFF1(IsConcatSpreadableCachePhase))
@@ -1429,11 +1437,11 @@ CommonNumber:
                   method == JavascriptArray::EntryInfo::Values.GetOriginalEntryPoint()
                   // Verify that the head segment of the array covers all elements with no gaps.
                   // Accessing an element on the prototype could have side-effects that would invalidate the optimization.
-                  && JavascriptArray::FromVar(aRight)->GetHead()->next == nullptr
-                  && JavascriptArray::FromVar(aRight)->GetHead()->left == 0
-                  && JavascriptArray::FromVar(aRight)->GetHead()->length == JavascriptArray::FromVar(aRight)->GetLength()
-                  && JavascriptArray::FromVar(aRight)->HasNoMissingValues()
-                  && !JavascriptArray::FromVar(aRight)->IsCrossSiteObject()
+                  && JavascriptArray::UnsafeFromVar(aRight)->GetHead()->next == nullptr
+                  && JavascriptArray::UnsafeFromVar(aRight)->GetHead()->left == 0
+                  && JavascriptArray::UnsafeFromVar(aRight)->GetHead()->length == JavascriptArray::FromVar(aRight)->GetLength()
+                  && JavascriptArray::UnsafeFromVar(aRight)->HasNoMissingValues()
+                  && !JavascriptArray::UnsafeFromVar(aRight)->IsCrossSiteObject()
               )) ||
              (TypedArrayBase::Is(aRight) && method == TypedArrayBase::EntryInfo::Values.GetOriginalEntryPoint()))
             // We can't optimize away the iterator if the array iterator prototype is user defined.
@@ -1658,9 +1666,10 @@ CommonNumber:
     {
         AssertMsg(scope == scriptContext->GetLibrary()->GetNull() || JavascriptArray::Is(scope),
                   "Invalid scope chain pointer passed - should be null or an array");
-        if (JavascriptArray::Is(scope))
+
+        JavascriptArray* arrScope = JavascriptOperators::TryFromVar<JavascriptArray>(scope);
+        if (arrScope)
         {
-            JavascriptArray* arrScope = JavascriptArray::FromVar(scope);
             Var instance = arrScope->DirectGetItem(0);
             return JavascriptOperators::OP_HasOwnProperty(instance, propertyId, scriptContext);
         }
@@ -1795,6 +1804,7 @@ CommonNumber:
 
             return TRUE;
         }
+
         else
         {
 #ifdef MISSING_PROPERTY_STATS
@@ -1882,7 +1892,7 @@ CommonNumber:
             *propertyObject = scriptContext->GetLibrary()->GetNumberPrototype();
             return TRUE;
         }
-        RecyclableObject* object = RecyclableObject::FromVar(instance);
+        RecyclableObject* object = RecyclableObject::UnsafeFromVar(instance);
         *propertyObject = object;
         if (JavascriptOperators::IsUndefinedOrNull(object))
         {
@@ -2633,7 +2643,7 @@ CommonNumber:
 
         if (!TaggedNumber::Is(thisInstance))
         {
-            return JavascriptOperators::SetProperty(RecyclableObject::FromVar(thisInstance), RecyclableObject::FromVar(instance), propertyId, newValue, info, scriptContext, flags);
+            return JavascriptOperators::SetProperty(RecyclableObject::UnsafeFromVar(thisInstance), RecyclableObject::UnsafeFromVar(instance), propertyId, newValue, info, scriptContext, flags);
         }
 
         JavascriptError::ThrowCantAssignIfStrictMode(flags, scriptContext);
@@ -2862,7 +2872,7 @@ CommonNumber:
 
         for (uint16 i = 0; i < length; i++)
         {
-            object = RecyclableObject::FromVar(pDisplay->GetItem(i));
+            object = RecyclableObject::UnsafeFromVar(pDisplay->GetItem(i));
 
             AssertMsg(!ConsoleScopeActivationObject::Is(object) || (i == length - 1), "Invalid location for ConsoleScopeActivationObject");
 
@@ -2973,24 +2983,27 @@ CommonNumber:
         if ((length > 0) && ConsoleScopeActivationObject::Is(pDisplay->GetItem(length - 1)))
         {
             // CheckPrototypesForAccessorOrNonWritableProperty does not check for const in global object. We should check it here.
-            if ((length > 1) && GlobalObject::Is(pDisplay->GetItem(length - 2)))
+            if (length > 1)
             {
-                GlobalObject* globalObject = GlobalObject::FromVar(pDisplay->GetItem(length - 2));
-                Var setterValue = nullptr;
-
-                DescriptorFlags flags = JavascriptOperators::GetRootSetter(globalObject, propertyId, &setterValue, &info, scriptContext);
-                Assert((flags & Accessor) != Accessor);
-                Assert((flags & Proxy) != Proxy);
-                if ((flags & Data) == Data && (flags & Writable) == None)
+                Js::GlobalObject * globalObject = JavascriptOperators::TryFromVar<Js::GlobalObject>(pDisplay->GetItem(length - 2));
+                if (globalObject)
                 {
-                    if (!allowUndecInConsoleScope)
+                    Var setterValue = nullptr;
+
+                    DescriptorFlags flags = JavascriptOperators::GetRootSetter(globalObject, propertyId, &setterValue, &info, scriptContext);
+                    Assert((flags & Accessor) != Accessor);
+                    Assert((flags & Proxy) != Proxy);
+                    if ((flags & Data) == Data && (flags & Writable) == None)
                     {
-                        if (flags & Const)
+                        if (!allowUndecInConsoleScope)
                         {
-                            JavascriptError::ThrowTypeError(scriptContext, ERRAssignmentToConst);
+                            if (flags & Const)
+                            {
+                                JavascriptError::ThrowTypeError(scriptContext, ERRAssignmentToConst);
+                            }
+                            Assert(!isLexicalThisSlotSymbol);
+                            return;
                         }
-                        Assert(!isLexicalThisSlotSymbol);
-                        return;
                     }
                 }
             }
@@ -3289,12 +3302,13 @@ CommonNumber:
         Assert(instance);
         Assert(expectingNativeFloatArray ^ expectingVarArray);
 
-        if (!JavascriptNativeArray::Is(instance))
+        JavascriptNativeArray * nativeArr = JavascriptOperators::TryFromVar<JavascriptNativeArray>(instance);
+        if (!nativeArr)
         {
             return;
         }
 
-        ArrayCallSiteInfo *const arrayCallSiteInfo = JavascriptNativeArray::FromVar(instance)->GetArrayCallSiteInfo();
+        ArrayCallSiteInfo *const arrayCallSiteInfo = nativeArr->GetArrayCallSiteInfo();
         if (!arrayCallSiteInfo)
         {
             return;
@@ -3332,7 +3346,7 @@ CommonNumber:
         {
             JavascriptError::ThrowTypeError(scriptContext, JSERR_NeedFunction /* TODO-ERROR: get arg name - aFunc */);
         }
-        return RecyclableObject::FromVar(callee);
+        return RecyclableObject::UnsafeFromVar(callee);
     }
 
     Var JavascriptOperators::OP_GetElementI_JIT(Var instance, Var index, ScriptContext *scriptContext)
@@ -3374,7 +3388,7 @@ CommonNumber:
             return false;
         }
 
-        JavascriptArray* arrayPrototype = JavascriptArray::FromVar(prototype); //Prototype must be Array.prototype (unless changed through __proto__)
+        JavascriptArray* arrayPrototype = JavascriptArray::UnsafeFromVar(prototype); //Prototype must be Array.prototype (unless changed through __proto__)
         if (arrayPrototype->GetLength() && arrayPrototype->GetItem(arrayPrototype, (uint32)indexInt, result, scriptContext))
         {
             return true;
@@ -3427,7 +3441,7 @@ CommonNumber:
 
     Var JavascriptOperators::OP_GetElementI(Var instance, Var index, ScriptContext* scriptContext)
     {
-        JavascriptString *temp = NULL;
+        JavascriptString *temp = nullptr;
 #if ENABLE_COPYONACCESS_ARRAY
         JavascriptLibrary::CheckAndConvertCopyOnAccessNativeIntArray<Var>(instance);
 #endif
@@ -3440,7 +3454,7 @@ CommonNumber:
             case TypeIds_Array: //fast path for array
             {
                 Var result;
-                if (OP_GetElementI_ArrayFastPath(JavascriptArray::FromVar(instance), TaggedInt::ToInt32(index), &result, scriptContext))
+                if (OP_GetElementI_ArrayFastPath(JavascriptArray::UnsafeFromVar(instance), TaggedInt::ToInt32(index), &result, scriptContext))
                 {
                     return result;
                 }
@@ -3449,7 +3463,7 @@ CommonNumber:
             case TypeIds_NativeIntArray:
             {
                 Var result;
-                if (OP_GetElementI_ArrayFastPath(JavascriptNativeIntArray::FromVar(instance), TaggedInt::ToInt32(index), &result, scriptContext))
+                if (OP_GetElementI_ArrayFastPath(JavascriptNativeIntArray::UnsafeFromVar(instance), TaggedInt::ToInt32(index), &result, scriptContext))
                 {
                     return result;
                 }
@@ -3458,7 +3472,7 @@ CommonNumber:
             case TypeIds_NativeFloatArray:
             {
                 Var result;
-                if (OP_GetElementI_ArrayFastPath(JavascriptNativeFloatArray::FromVar(instance), TaggedInt::ToInt32(index), &result, scriptContext))
+                if (OP_GetElementI_ArrayFastPath(JavascriptNativeFloatArray::UnsafeFromVar(instance), TaggedInt::ToInt32(index), &result, scriptContext))
                 {
                     return result;
                 }
@@ -3468,7 +3482,7 @@ CommonNumber:
             case TypeIds_String: // fast path for string
             {
                 charcount_t indexInt = TaggedInt::ToUInt32(index);
-                JavascriptString* string = JavascriptString::FromVar(instance);
+                JavascriptString* string = JavascriptString::UnsafeFromVar(instance);
                 Var result;
                 if (JavascriptConversion::PropertyQueryFlagsToBoolean(string->JavascriptString::GetItemQuery(instance, indexInt, &result, scriptContext)))
                 {
@@ -3483,7 +3497,7 @@ CommonNumber:
                 int32 indexInt = TaggedInt::ToInt32(index);
                 if (VirtualTableInfo<Int8VirtualArray>::HasVirtualTable(instance))
                 {
-                    Int8VirtualArray* int8Array = Int8VirtualArray::FromVar(instance);
+                    Int8VirtualArray* int8Array = Int8VirtualArray::UnsafeFromVar(instance);
                     if (indexInt >= 0)
                     {
                         return int8Array->DirectGetItem(indexInt);
@@ -3491,7 +3505,7 @@ CommonNumber:
                 }
                 else if (VirtualTableInfo<Int8Array>::HasVirtualTable(instance))
                 {
-                    Int8Array* int8Array = Int8Array::FromVar(instance);
+                    Int8Array* int8Array = Int8Array::UnsafeFromVar(instance);
                     if (indexInt >= 0)
                     {
                         return int8Array->DirectGetItem(indexInt);
@@ -3506,7 +3520,7 @@ CommonNumber:
                 int32 indexInt = TaggedInt::ToInt32(index);
                 if (VirtualTableInfo<Uint8VirtualArray>::HasVirtualTable(instance))
                 {
-                    Uint8VirtualArray* uint8Array = Uint8VirtualArray::FromVar(instance);
+                    Uint8VirtualArray* uint8Array = Uint8VirtualArray::UnsafeFromVar(instance);
                     if (indexInt >= 0)
                     {
                         return uint8Array->DirectGetItem(indexInt);
@@ -3514,7 +3528,7 @@ CommonNumber:
                 }
                 else if (VirtualTableInfo<Uint8Array>::HasVirtualTable(instance))
                 {
-                    Uint8Array* uint8Array = Uint8Array::FromVar(instance);
+                    Uint8Array* uint8Array = Uint8Array::UnsafeFromVar(instance);
                     if (indexInt >= 0)
                     {
                         return uint8Array->DirectGetItem(indexInt);
@@ -3529,7 +3543,7 @@ CommonNumber:
                 int32 indexInt = TaggedInt::ToInt32(index);
                 if (VirtualTableInfo<Uint8ClampedVirtualArray>::HasVirtualTable(instance))
                 {
-                    Uint8ClampedVirtualArray* uint8ClampedArray = Uint8ClampedVirtualArray::FromVar(instance);
+                    Uint8ClampedVirtualArray* uint8ClampedArray = Uint8ClampedVirtualArray::UnsafeFromVar(instance);
                     if (indexInt >= 0)
                     {
                         return uint8ClampedArray->DirectGetItem(indexInt);
@@ -3537,7 +3551,7 @@ CommonNumber:
                 }
                 else if (VirtualTableInfo<Uint8ClampedArray>::HasVirtualTable(instance))
                 {
-                    Uint8ClampedArray* uint8ClampedArray = Uint8ClampedArray::FromVar(instance);
+                    Uint8ClampedArray* uint8ClampedArray = Uint8ClampedArray::UnsafeFromVar(instance);
                     if (indexInt >= 0)
                     {
                         return uint8ClampedArray->DirectGetItem(indexInt);
@@ -3553,7 +3567,7 @@ CommonNumber:
 
                 if (VirtualTableInfo<Int16VirtualArray>::HasVirtualTable(instance))
                 {
-                    Int16VirtualArray* int16Array = Int16VirtualArray::FromVar(instance);
+                    Int16VirtualArray* int16Array = Int16VirtualArray::UnsafeFromVar(instance);
                     if (indexInt >= 0)
                     {
                         return int16Array->DirectGetItem(indexInt);
@@ -3561,7 +3575,7 @@ CommonNumber:
                 }
                 else if (VirtualTableInfo<Int16Array>::HasVirtualTable(instance))
                 {
-                    Int16Array* int16Array = Int16Array::FromVar(instance);
+                    Int16Array* int16Array = Int16Array::UnsafeFromVar(instance);
                     if (indexInt >= 0)
                     {
                         return int16Array->DirectGetItem(indexInt);
@@ -3577,7 +3591,7 @@ CommonNumber:
 
                 if (VirtualTableInfo<Uint16VirtualArray>::HasVirtualTable(instance))
                 {
-                    Uint16VirtualArray* uint16Array = Uint16VirtualArray::FromVar(instance);
+                    Uint16VirtualArray* uint16Array = Uint16VirtualArray::UnsafeFromVar(instance);
                     if (indexInt >= 0)
                     {
                         return uint16Array->DirectGetItem(indexInt);
@@ -3585,7 +3599,7 @@ CommonNumber:
                 }
                 else if (VirtualTableInfo<Uint16Array>::HasVirtualTable(instance))
                 {
-                    Uint16Array* uint16Array = Uint16Array::FromVar(instance);
+                    Uint16Array* uint16Array = Uint16Array::UnsafeFromVar(instance);
                     if (indexInt >= 0)
                     {
                         return uint16Array->DirectGetItem(indexInt);
@@ -3599,7 +3613,7 @@ CommonNumber:
                 int32 indexInt = TaggedInt::ToInt32(index);
                 if (VirtualTableInfo<Int32VirtualArray>::HasVirtualTable(instance))
                 {
-                    Int32VirtualArray* int32Array = Int32VirtualArray::FromVar(instance);
+                    Int32VirtualArray* int32Array = Int32VirtualArray::UnsafeFromVar(instance);
                     if (indexInt >= 0)
                     {
                         return int32Array->DirectGetItem(indexInt);
@@ -3607,7 +3621,7 @@ CommonNumber:
                 }
                 else if (VirtualTableInfo<Int32Array>::HasVirtualTable(instance))
                 {
-                    Int32Array* int32Array = Int32Array::FromVar(instance);
+                    Int32Array* int32Array = Int32Array::UnsafeFromVar(instance);
                     if (indexInt >= 0)
                     {
                         return int32Array->DirectGetItem(indexInt);
@@ -3622,7 +3636,7 @@ CommonNumber:
                 int32 indexInt = TaggedInt::ToInt32(index);
                 if (VirtualTableInfo<Uint32VirtualArray>::HasVirtualTable(instance))
                 {
-                    Uint32VirtualArray* uint32Array = Uint32VirtualArray::FromVar(instance);
+                    Uint32VirtualArray* uint32Array = Uint32VirtualArray::UnsafeFromVar(instance);
                     if (indexInt >= 0)
                     {
                         return uint32Array->DirectGetItem(indexInt);
@@ -3630,7 +3644,7 @@ CommonNumber:
                 }
                 else if (VirtualTableInfo<Uint32Array>::HasVirtualTable(instance))
                 {
-                    Uint32Array* uint32Array = Uint32Array::FromVar(instance);
+                    Uint32Array* uint32Array = Uint32Array::UnsafeFromVar(instance);
                     if (indexInt >= 0)
                     {
                         return uint32Array->DirectGetItem(indexInt);
@@ -3645,7 +3659,7 @@ CommonNumber:
 
                 if (VirtualTableInfo<Float32VirtualArray>::HasVirtualTable(instance))
                 {
-                    Float32VirtualArray* float32Array = Float32VirtualArray::FromVar(instance);
+                    Float32VirtualArray* float32Array = Float32VirtualArray::UnsafeFromVar(instance);
                     if (indexInt >= 0)
                     {
                         return float32Array->DirectGetItem(indexInt);
@@ -3653,7 +3667,7 @@ CommonNumber:
                 }
                 else if (VirtualTableInfo<Float32Array>::HasVirtualTable(instance))
                 {
-                    Float32Array* float32Array = Float32Array::FromVar(instance);
+                    Float32Array* float32Array = Float32Array::UnsafeFromVar(instance);
                     if (indexInt >= 0)
                     {
                         return float32Array->DirectGetItem(indexInt);
@@ -3667,7 +3681,7 @@ CommonNumber:
                 int32 indexInt = TaggedInt::ToInt32(index);
                 if (VirtualTableInfo<Float64VirtualArray>::HasVirtualTable(instance))
                 {
-                    Float64VirtualArray* float64Array = Float64VirtualArray::FromVar(instance);
+                    Float64VirtualArray* float64Array = Float64VirtualArray::UnsafeFromVar(instance);
                     if (indexInt >= 0)
                     {
                         return float64Array->DirectGetItem(indexInt);
@@ -3675,7 +3689,7 @@ CommonNumber:
                 }
                 else if (VirtualTableInfo<Float64Array>::HasVirtualTable(instance))
                 {
-                    Float64Array* float64Array = Float64Array::FromVar(instance);
+                    Float64Array* float64Array = Float64Array::UnsafeFromVar(instance);
                     if (indexInt >= 0)
                     {
                         return float64Array->DirectGetItem(indexInt);
@@ -3698,62 +3712,65 @@ CommonNumber:
                 goto TaggedIntIndex;
             }
         }
-        else if (JavascriptString::Is(index) && RecyclableObject::Is(instance)) // fastpath for PropertyStrings
+        else
         {
-            temp = JavascriptString::FromVar(index);
-            Assert(temp->GetScriptContext() == scriptContext);
-
-            PropertyString * propertyString = PropertyString::TryFromVar(temp);
-            if (propertyString == nullptr)
+            temp = JavascriptOperators::TryFromVar<JavascriptString>(index);
+            if (temp && RecyclableObject::Is(instance)) // fastpath for PropertyStrings
             {
-                LiteralStringWithPropertyStringPtr * strWithPtr = LiteralStringWithPropertyStringPtr::TryFromVar(temp);
-                if (strWithPtr)
-                {
-                    propertyString = strWithPtr->GetPropertyString();
-                }
-            }
-            if(propertyString != nullptr)
-            {
-                RecyclableObject* object = nullptr;
-                if (FALSE == JavascriptOperators::GetPropertyObject(instance, scriptContext, &object))
-                {
-                    JavascriptError::ThrowTypeError(scriptContext, JSERR_Property_CannotGet_NullOrUndefined,
-                        JavascriptString::FromVar(index)->GetSz());
-                }
+                Assert(temp->GetScriptContext() == scriptContext);
 
-                PropertyRecord const * propertyRecord = propertyString->GetPropertyRecord();
-                Var value;
+                PropertyString * propertyString = PropertyString::TryFromVar(temp);
+                if (propertyString == nullptr)
+                {
+                    LiteralStringWithPropertyStringPtr * strWithPtr = LiteralStringWithPropertyStringPtr::TryFromVar(temp);
+                    if (strWithPtr)
+                    {
+                        propertyString = strWithPtr->GetPropertyString();
+                    }
+                }
+                if (propertyString != nullptr)
+                {
+                    RecyclableObject* object = nullptr;
+                    if (FALSE == JavascriptOperators::GetPropertyObject(instance, scriptContext, &object))
+                    {
+                        JavascriptError::ThrowTypeError(scriptContext, JSERR_Property_CannotGet_NullOrUndefined,
+                            JavascriptString::FromVar(index)->GetSz());
+                    }
 
-                if (propertyRecord->IsNumeric())
-                {
-                    if (JavascriptOperators::GetItem(instance, object, propertyRecord->GetNumericValue(), &value, scriptContext))
+                    PropertyRecord const * propertyRecord = propertyString->GetPropertyRecord();
+                    Var value;
+
+                    if (propertyRecord->IsNumeric())
                     {
-                        return value;
+                        if (JavascriptOperators::GetItem(instance, object, propertyRecord->GetNumericValue(), &value, scriptContext))
+                        {
+                            return value;
+                        }
                     }
+                    else
+                    {
+                        PropertyValueInfo info;
+                        if (propertyString->TryGetPropertyFromCache<false /* OwnPropertyOnly */>(instance, object, &value, scriptContext, &info))
+                        {
+                            return value;
+                        }
+                        if (JavascriptOperators::GetPropertyWPCache(instance, object, propertyRecord->GetPropertyId(), &value, scriptContext, &info))
+                        {
+                            return value;
+                        }
+                    }
+                    return scriptContext->GetLibrary()->GetUndefined();
                 }
-                else
-                {
-                    PropertyValueInfo info;
-                    if (propertyString->TryGetPropertyFromCache<false /* OwnPropertyOnly */>(instance, object, &value, scriptContext, &info))
-                    {
-                        return value;
-                    }
-                    if (JavascriptOperators::GetPropertyWPCache(instance, object, propertyRecord->GetPropertyId(), &value, scriptContext, &info))
-                    {
-                        return value;
-                    }
-                }
-                return scriptContext->GetLibrary()->GetUndefined();
-            }
 #ifdef ENABLE_DEBUG_CONFIG_OPTIONS
-            if (PHASE_TRACE1(PropertyStringCachePhase))
-            {
-                Output::Print(_u("PropertyCache: GetElem No property string for '%s'\n"), temp->GetString());
-            }
+                if (PHASE_TRACE1(PropertyStringCachePhase))
+                {
+                    Output::Print(_u("PropertyCache: GetElem No property string for '%s'\n"), temp->GetString());
+                }
 #endif
 #if DBG_DUMP
-            scriptContext->forinNoCache++;
+                scriptContext->forinNoCache++;
 #endif
+            }
         }
 
         return JavascriptOperators::GetElementIHelper(instance, index, instance, scriptContext);
@@ -4128,14 +4145,14 @@ CommonNumber:
 
                     if (VirtualTableInfo<Int8VirtualArray>::HasVirtualTable(instance))
                     {
-                        Int8VirtualArray* int8Array = Int8VirtualArray::FromVar(instance);
-                            returnValue = int8Array->ValidateIndexAndDirectSetItem(index, value, &isNumericIndex);
-                        }
+                        Int8VirtualArray* int8Array = Int8VirtualArray::UnsafeFromVar(instance);
+                        returnValue = int8Array->ValidateIndexAndDirectSetItem(index, value, &isNumericIndex);
+                    }
                     else if( VirtualTableInfo<Int8Array>::HasVirtualTable(instance))
                     {
-                        Int8Array* int8Array = Int8Array::FromVar(instance);
-                            returnValue = int8Array->ValidateIndexAndDirectSetItem(index, value, &isNumericIndex);
-                        }
+                        Int8Array* int8Array = Int8Array::UnsafeFromVar(instance);
+                        returnValue = int8Array->ValidateIndexAndDirectSetItem(index, value, &isNumericIndex);
+                    }
                     break;
                 }
 
@@ -4144,14 +4161,14 @@ CommonNumber:
                     // The typed array will deal with all possible values for the index
                     if (VirtualTableInfo<Uint8VirtualArray>::HasVirtualTable(instance))
                     {
-                        Uint8VirtualArray* uint8Array = Uint8VirtualArray::FromVar(instance);
-                            returnValue = uint8Array->ValidateIndexAndDirectSetItem(index, value, &isNumericIndex);
-                        }
+                        Uint8VirtualArray* uint8Array = Uint8VirtualArray::UnsafeFromVar(instance);
+                        returnValue = uint8Array->ValidateIndexAndDirectSetItem(index, value, &isNumericIndex);
+                    }
                     else if (VirtualTableInfo<Uint8Array>::HasVirtualTable(instance))
                     {
-                        Uint8Array* uint8Array = Uint8Array::FromVar(instance);
-                            returnValue = uint8Array->ValidateIndexAndDirectSetItem(index, value, &isNumericIndex);
-                        }
+                        Uint8Array* uint8Array = Uint8Array::UnsafeFromVar(instance);
+                        returnValue = uint8Array->ValidateIndexAndDirectSetItem(index, value, &isNumericIndex);
+                    }
                     break;
                 }
 
@@ -4160,14 +4177,14 @@ CommonNumber:
                     // The typed array will deal with all possible values for the index
                     if (VirtualTableInfo<Uint8ClampedVirtualArray>::HasVirtualTable(instance))
                     {
-                        Uint8ClampedVirtualArray* uint8ClampedArray = Uint8ClampedVirtualArray::FromVar(instance);
-                            returnValue = uint8ClampedArray->ValidateIndexAndDirectSetItem(index, value, &isNumericIndex);
-                        }
+                        Uint8ClampedVirtualArray* uint8ClampedArray = Uint8ClampedVirtualArray::UnsafeFromVar(instance);
+                        returnValue = uint8ClampedArray->ValidateIndexAndDirectSetItem(index, value, &isNumericIndex);
+                    }
                     else if(VirtualTableInfo<Uint8ClampedArray>::HasVirtualTable(instance))
                     {
-                        Uint8ClampedArray* uint8ClampedArray = Uint8ClampedArray::FromVar(instance);
-                            returnValue = uint8ClampedArray->ValidateIndexAndDirectSetItem(index, value, &isNumericIndex);
-                        }
+                        Uint8ClampedArray* uint8ClampedArray = Uint8ClampedArray::UnsafeFromVar(instance);
+                        returnValue = uint8ClampedArray->ValidateIndexAndDirectSetItem(index, value, &isNumericIndex);
+                    }
                     break;
                 }
 
@@ -4176,14 +4193,14 @@ CommonNumber:
                     // The type array will deal with all possible values for the index
                     if (VirtualTableInfo<Int16VirtualArray>::HasVirtualTable(instance))
                     {
-                        Int16VirtualArray* int16Array = Int16VirtualArray::FromVar(instance);
-                            returnValue = int16Array->ValidateIndexAndDirectSetItem(index, value, &isNumericIndex);
-                        }
+                        Int16VirtualArray* int16Array = Int16VirtualArray::UnsafeFromVar(instance);
+                        returnValue = int16Array->ValidateIndexAndDirectSetItem(index, value, &isNumericIndex);
+                    }
                     else if (VirtualTableInfo<Int16Array>::HasVirtualTable(instance))
                     {
-                        Int16Array* int16Array = Int16Array::FromVar(instance);
-                            returnValue = int16Array->ValidateIndexAndDirectSetItem(index, value, &isNumericIndex);
-                        }
+                        Int16Array* int16Array = Int16Array::UnsafeFromVar(instance);
+                        returnValue = int16Array->ValidateIndexAndDirectSetItem(index, value, &isNumericIndex);
+                    }
                     break;
                 }
 
@@ -4193,14 +4210,14 @@ CommonNumber:
 
                     if (VirtualTableInfo<Uint16VirtualArray>::HasVirtualTable(instance))
                     {
-                        Uint16VirtualArray* uint16Array = Uint16VirtualArray::FromVar(instance);
-                            returnValue = uint16Array->ValidateIndexAndDirectSetItem(index, value, &isNumericIndex);
-                        }
+                        Uint16VirtualArray* uint16Array = Uint16VirtualArray::UnsafeFromVar(instance);
+                        returnValue = uint16Array->ValidateIndexAndDirectSetItem(index, value, &isNumericIndex);
+                    }
                     else if (VirtualTableInfo<Uint16Array>::HasVirtualTable(instance))
                     {
-                        Uint16Array* uint16Array = Uint16Array::FromVar(instance);
-                            returnValue = uint16Array->ValidateIndexAndDirectSetItem(index, value, &isNumericIndex);
-                        }
+                        Uint16Array* uint16Array = Uint16Array::UnsafeFromVar(instance);
+                        returnValue = uint16Array->ValidateIndexAndDirectSetItem(index, value, &isNumericIndex);
+                    }
                     break;
                 }
                 case TypeIds_Int32Array:
@@ -4208,14 +4225,14 @@ CommonNumber:
                     // The type array will deal with all possible values for the index
                     if (VirtualTableInfo<Int32VirtualArray>::HasVirtualTable(instance))
                     {
-                        Int32VirtualArray* int32Array = Int32VirtualArray::FromVar(instance);
-                            returnValue = int32Array->ValidateIndexAndDirectSetItem(index, value, &isNumericIndex);
-                        }
+                        Int32VirtualArray* int32Array = Int32VirtualArray::UnsafeFromVar(instance);
+                        returnValue = int32Array->ValidateIndexAndDirectSetItem(index, value, &isNumericIndex);
+                    }
                     else if(VirtualTableInfo<Int32Array>::HasVirtualTable(instance))
                     {
-                        Int32Array* int32Array = Int32Array::FromVar(instance);
-                            returnValue = int32Array->ValidateIndexAndDirectSetItem(index, value, &isNumericIndex);
-                        }
+                        Int32Array* int32Array = Int32Array::UnsafeFromVar(instance);
+                        returnValue = int32Array->ValidateIndexAndDirectSetItem(index, value, &isNumericIndex);
+                    }
                     break;
                 }
                 case TypeIds_Uint32Array:
@@ -4224,14 +4241,14 @@ CommonNumber:
 
                     if (VirtualTableInfo<Uint32VirtualArray>::HasVirtualTable(instance))
                     {
-                        Uint32VirtualArray* uint32Array = Uint32VirtualArray::FromVar(instance);
-                            returnValue = uint32Array->ValidateIndexAndDirectSetItem(index, value, &isNumericIndex);
-                        }
+                        Uint32VirtualArray* uint32Array = Uint32VirtualArray::UnsafeFromVar(instance);
+                        returnValue = uint32Array->ValidateIndexAndDirectSetItem(index, value, &isNumericIndex);
+                    }
                     else if (VirtualTableInfo<Uint32Array>::HasVirtualTable(instance))
                     {
-                        Uint32Array* uint32Array = Uint32Array::FromVar(instance);
-                            returnValue = uint32Array->ValidateIndexAndDirectSetItem(index, value, &isNumericIndex);
-                        }
+                        Uint32Array* uint32Array = Uint32Array::UnsafeFromVar(instance);
+                        returnValue = uint32Array->ValidateIndexAndDirectSetItem(index, value, &isNumericIndex);
+                    }
                     break;
                 }
                 case TypeIds_Float32Array:
@@ -4239,14 +4256,14 @@ CommonNumber:
                     // The type array will deal with all possible values for the index
                     if (VirtualTableInfo<Float32VirtualArray>::HasVirtualTable(instance))
                     {
-                        Float32VirtualArray* float32Array = Float32VirtualArray::FromVar(instance);
-                            returnValue = float32Array->ValidateIndexAndDirectSetItem(index, value, &isNumericIndex);
-                        }
+                        Float32VirtualArray* float32Array = Float32VirtualArray::UnsafeFromVar(instance);
+                        returnValue = float32Array->ValidateIndexAndDirectSetItem(index, value, &isNumericIndex);
+                    }
                     else if (VirtualTableInfo<Float32Array>::HasVirtualTable(instance))
                     {
-                        Float32Array* float32Array = Float32Array::FromVar(instance);
-                            returnValue = float32Array->ValidateIndexAndDirectSetItem(index, value, &isNumericIndex);
-                        }
+                        Float32Array* float32Array = Float32Array::UnsafeFromVar(instance);
+                        returnValue = float32Array->ValidateIndexAndDirectSetItem(index, value, &isNumericIndex);
+                    }
                     break;
                 }
                 case TypeIds_Float64Array:
@@ -4254,14 +4271,14 @@ CommonNumber:
                     // The type array will deal with all possible values for the index
                     if (VirtualTableInfo<Float64VirtualArray>::HasVirtualTable(instance))
                     {
-                        Float64VirtualArray* float64Array = Float64VirtualArray::FromVar(instance);
-                            returnValue = float64Array->ValidateIndexAndDirectSetItem(index, value, &isNumericIndex);
-                        }
+                        Float64VirtualArray* float64Array = Float64VirtualArray::UnsafeFromVar(instance);
+                        returnValue = float64Array->ValidateIndexAndDirectSetItem(index, value, &isNumericIndex);
+                    }
                     else if (VirtualTableInfo<Float64Array>::HasVirtualTable(instance))
                     {
-                        Float64Array* float64Array = Float64Array::FromVar(instance);
-                            returnValue = float64Array->ValidateIndexAndDirectSetItem(index, value, &isNumericIndex);
-                        }
+                        Float64Array* float64Array = Float64Array::UnsafeFromVar(instance);
+                        returnValue = float64Array->ValidateIndexAndDirectSetItem(index, value, &isNumericIndex);
+                    }
                     break;
                 }
                 }
@@ -4286,7 +4303,7 @@ CommonNumber:
                     int indexInt = TaggedInt::ToInt32(index);
                     if (indexInt >= 0 && scriptContext->optimizationOverrides.IsEnabledArraySetElementFastPath())
                     {
-                        JavascriptArray::FromVar(instance)->SetItem((uint32)indexInt, value, flags);
+                        JavascriptArray::UnsafeFromVar(instance)->SetItem((uint32)indexInt, value, flags);
                         return true;
                     }
                     break;
@@ -4631,7 +4648,7 @@ CommonNumber:
                 break;
             }
             // Upper bounds check for source array
-            JavascriptArray* srcArray = JavascriptArray::FromVar(srcInstance);
+            JavascriptArray* srcArray = JavascriptArray::UnsafeFromVar(srcInstance);
             JavascriptArray* dstArray = JavascriptArray::FromVar(dstInstance);
             if (scriptContext->optimizationOverrides.IsEnabledArraySetElementFastPath())
             {
@@ -4737,7 +4754,7 @@ CommonNumber:
                 INT_PTR vt = VirtualTableInfoBase::GetVirtualTable(instance);
                 if (instanceType == TypeIds_Array)
                 {
-                    returnValue = JavascriptArray::FromVar(instance)->DirectSetItemAtRange<Var>(start, length, value);
+                    returnValue = JavascriptArray::UnsafeFromVar(instance)->DirectSetItemAtRange<Var>(start, length, value);
                 }
                 else if (instanceType == TypeIds_NativeIntArray)
                 {
@@ -4747,7 +4764,7 @@ CommonNumber:
                         return false;
                     }
                     int32 intValue = JavascriptConversion::ToInt32(value, scriptContext);
-                    returnValue = JavascriptArray::FromVar(instance)->DirectSetItemAtRange<int32>(start, length, intValue);
+                    returnValue = JavascriptArray::UnsafeFromVar(instance)->DirectSetItemAtRange<int32>(start, length, intValue);
                 }
                 else
                 {
@@ -4763,7 +4780,7 @@ CommonNumber:
                     {
                         return false;
                     }
-                    returnValue = JavascriptArray::FromVar(instance)->DirectSetItemAtRange<double>(start, length, doubleValue);
+                    returnValue = JavascriptArray::UnsafeFromVar(instance)->DirectSetItemAtRange<double>(start, length, doubleValue);
                 }
                 returnValue &= vt == VirtualTableInfoBase::GetVirtualTable(instance);
             }
@@ -5079,9 +5096,13 @@ CommonNumber:
         {
             return false;
         }
-        return !(instance->HasDeferredTypeHandler() &&
-                 JavascriptFunction::Is(instance) &&
-                 JavascriptFunction::FromVar(instance)->IsExternalFunction());
+
+        if (!(instance->HasDeferredTypeHandler()))
+        {
+            JavascriptFunction * function = JavascriptOperators::TryFromVar<JavascriptFunction>(instance);
+            return function && function->IsExternalFunction();
+        }
+        return false;
     }
 
     bool JavascriptOperators::CanShortcutPrototypeChainOnUnknownPropertyName(RecyclableObject *prototype)
@@ -5648,7 +5669,7 @@ CommonNumber:
         TypeId typeId = JavascriptOperators::GetTypeId(instance);
         if (typeId == TypeIds_Function)
         {
-            JavascriptFunction * function =  JavascriptFunction::FromVar(instance);
+            JavascriptFunction * function =  JavascriptFunction::UnsafeFromVar(instance);
             return function->GetFunctionInfo();
         }
         if (typeId != TypeIds_HostDispatch && typeId != TypeIds_Proxy)
@@ -5713,10 +5734,10 @@ CommonNumber:
 
     Var JavascriptOperators::NewScObjectNoArg(Var instance, ScriptContext * requestContext)
     {
-        if (JavascriptProxy::Is(instance))
+        JavascriptProxy * proxy = JavascriptOperators::TryFromVar<JavascriptProxy>(instance);
+        if (proxy)
         {
             Arguments args(CallInfo(CallFlags_New, 1), &instance);
-            JavascriptProxy* proxy = JavascriptProxy::FromVar(instance);
             return proxy->ConstructorTrap(args, requestContext, 0);
         }
 
@@ -5795,9 +5816,10 @@ CommonNumber:
         }
 
         ConstructorCache * constructorCache = nullptr;
-        if (JavascriptFunction::Is(instance))
+        JavascriptFunction *function = JavascriptOperators::TryFromVar<JavascriptFunction>(instance);
+        if (function)
         {
-            constructorCache = JavascriptFunction::FromVar(instance)->GetConstructorCache();
+            constructorCache = function->GetConstructorCache();
         }
 
         if (constructorCache != nullptr && constructorCache->NeedsUpdateAfterCtor())
@@ -5836,7 +5858,7 @@ CommonNumber:
 
         if (functionInfo)
         {
-            return JavascriptOperators::NewScObjectCommon(RecyclableObject::FromVar(instance), functionInfo, requestContext, isBaseClassConstructorNewScObject);
+            return JavascriptOperators::NewScObjectCommon(RecyclableObject::UnsafeFromVar(instance), functionInfo, requestContext, isBaseClassConstructorNewScObject);
         }
         else
         {
@@ -5872,7 +5894,7 @@ CommonNumber:
         // the inline cache arena to allow it to be zeroed, but retain a recycler-allocated portion to hold on to the size of
         // inlined slots.
 
-        JavascriptFunction* constructor = JavascriptFunction::FromVar(function);
+        JavascriptFunction* constructor = JavascriptFunction::UnsafeFromVar(function);
         if (functionInfo->IsClassConstructor() && !isBaseClassConstructorNewScObject)
         {
             // If we are calling new on a class constructor, the contract is that we pass new.target as the 'this' argument.
@@ -6104,7 +6126,7 @@ CommonNumber:
 
         if (DynamicType::Is(RecyclableObject::FromVar(instance)->GetTypeId()))
         {
-            DynamicObject *object = DynamicObject::FromVar(instance);
+            DynamicObject *object = DynamicObject::UnsafeFromVar(instance);
             DynamicType* type = object->GetDynamicType();
             DynamicTypeHandler* typeHandler = type->GetTypeHandler();
 
@@ -6510,18 +6532,23 @@ CommonNumber:
     Js::PropertyId JavascriptOperators::GetPropertyId(Var propertyName, ScriptContext* scriptContext)
     {
         PropertyRecord const * propertyRecord = nullptr;
-        if (JavascriptSymbol::Is(propertyName))
+        JavascriptSymbol * symbol = JavascriptOperators::TryFromVar<Js::JavascriptSymbol>(propertyName);
+        if (symbol)
         {
-            propertyRecord = JavascriptSymbol::FromVar(propertyName)->GetValue();
-        }
-        else if (JavascriptSymbolObject::Is(propertyName))
-        {
-            propertyRecord = JavascriptSymbolObject::FromVar(propertyName)->GetValue();
+            propertyRecord = symbol->GetValue();
         }
         else
         {
-            JavascriptString * indexStr = JavascriptConversion::ToString(propertyName, scriptContext);
-            scriptContext->GetOrAddPropertyRecord(indexStr, &propertyRecord);
+            JavascriptSymbolObject * symbolObject = JavascriptOperators::TryFromVar<JavascriptSymbolObject>(propertyName);
+            if (symbolObject)
+            {
+                propertyRecord = symbolObject->GetValue();
+            }
+            else
+            {
+                JavascriptString * indexStr = JavascriptConversion::ToString(propertyName, scriptContext);
+                scriptContext->GetOrAddPropertyRecord(indexStr, &propertyRecord);
+            }
         }
 
         return propertyRecord->GetPropertyId();
@@ -6601,17 +6628,20 @@ CommonNumber:
 
     BOOL JavascriptOperators::IsClassConstructor(Var instance)
     {
-        return JavascriptFunction::Is(instance) && (JavascriptFunction::FromVar(instance)->GetFunctionInfo()->IsClassConstructor() || !JavascriptFunction::FromVar(instance)->IsScriptFunction());
+        JavascriptFunction * function = JavascriptOperators::TryFromVar<JavascriptFunction>(instance);
+        return function && (function->GetFunctionInfo()->IsClassConstructor() || !function->IsScriptFunction());
     }
 
     BOOL JavascriptOperators::IsClassMethod(Var instance)
     {
-        return JavascriptFunction::Is(instance) && JavascriptFunction::FromVar(instance)->GetFunctionInfo()->IsClassMethod();
+        JavascriptFunction * function = JavascriptOperators::TryFromVar<JavascriptFunction>(instance);
+        return function && function->GetFunctionInfo()->IsClassMethod();
     }
 
     BOOL JavascriptOperators::IsBaseConstructorKind(Var instance)
     {
-        return JavascriptFunction::Is(instance) && (JavascriptFunction::FromVar(instance)->GetFunctionInfo()->GetBaseConstructorKind());
+        JavascriptFunction * function = JavascriptOperators::TryFromVar<JavascriptFunction>(instance);
+        return function && (function->GetFunctionInfo()->GetBaseConstructorKind());
     }
 
     void JavascriptOperators::OP_InitGetter(Var object, PropertyId propertyId, Var getter)
@@ -7431,7 +7461,7 @@ CommonNumber:
         PropertyValueInfo::SetCacheInfo(&info, functionBody, inlineCache, inlineCacheIndex, !IsFromFullJit);
         for (uint16 i = 0; i < length; i++)
         {
-            RecyclableObject* object = RecyclableObject::FromVar(pDisplay->GetItem(i));
+            RecyclableObject* object = RecyclableObject::UnsafeFromVar(pDisplay->GetItem(i));
 
             Var value;
             if (CacheOperators::TryGetProperty<true, true, true, false, true, true, !TInlineCache::IsPolymorphic, TInlineCache::IsPolymorphic, false>(
@@ -7890,7 +7920,7 @@ CommonNumber:
 #if ENABLE_COPYONACCESS_ARRAY
         JavascriptLibrary::CheckAndConvertCopyOnAccessNativeIntArray<Var>(instance);
 #endif
-        RecyclableObject *object = RecyclableObject::FromVar(instance);
+        RecyclableObject *object = RecyclableObject::UnsafeFromVar(instance);
 
         PropertyValueInfo info;
         PropertyValueInfo::SetCacheInfo(&info, functionBody, inlineCache, inlineCacheIndex, !IsFromFullJit);
@@ -8989,7 +9019,7 @@ CommonNumber:
 
             Var thisVar = RootToThisObject(object, scriptContext);
 
-            RecyclableObject* marshalledFunction = RecyclableObject::FromVar(
+            RecyclableObject* marshalledFunction = RecyclableObject::UnsafeFromVar(
               CrossSite::MarshalVar(requestContext, function, scriptContext));
 
             Var result = CALL_ENTRYPOINT(threadContext, marshalledFunction->GetEntryPoint(), function, CallInfo(flags, 1), thisVar);
@@ -9031,7 +9061,7 @@ CommonNumber:
             RecyclableObject* marshalledFunction = function;
             if (requestContext)
             {
-                marshalledFunction = RecyclableObject::FromVar(CrossSite::MarshalVar(requestContext, function, function->GetScriptContext()));
+                marshalledFunction = RecyclableObject::UnsafeFromVar(CrossSite::MarshalVar(requestContext, function, function->GetScriptContext()));
             }
 
             Var result = CALL_ENTRYPOINT(threadContext, marshalledFunction->GetEntryPoint(), function, CallInfo(flags, 2), thisVar, putValue);
@@ -9110,7 +9140,7 @@ CommonNumber:
             return scriptContext->GetLibrary()->GetUndefined();
         }
 
-        ScriptFunction *instance = ScriptFunction::FromVar(scriptFunction);
+        ScriptFunction *instance = ScriptFunction::UnsafeFromVar(scriptFunction);
 
         // We keep a reference to the current class rather than its super prototype
         // since the prototype could change.
@@ -9414,11 +9444,11 @@ CommonNumber:
         case Js::TypeIds_Object:
             return DynamicObject::BoxStackInstance(DynamicObject::FromVar(instance));
         case Js::TypeIds_Array:
-            return JavascriptArray::BoxStackInstance(JavascriptArray::FromVar(instance));
+            return JavascriptArray::BoxStackInstance(JavascriptArray::UnsafeFromVar(instance));
         case Js::TypeIds_NativeIntArray:
-            return JavascriptNativeIntArray::BoxStackInstance(JavascriptNativeIntArray::FromVar(instance));
+            return JavascriptNativeIntArray::BoxStackInstance(JavascriptNativeIntArray::UnsafeFromVar(instance));
         case Js::TypeIds_NativeFloatArray:
-            return JavascriptNativeFloatArray::BoxStackInstance(JavascriptNativeFloatArray::FromVar(instance));
+            return JavascriptNativeFloatArray::BoxStackInstance(JavascriptNativeFloatArray::UnsafeFromVar(instance));
         case Js::TypeIds_Function:
             Assert(allowStackFunction);
             // Stack functions are deal with not mar mark them, but by nested function escape analysis
@@ -9647,13 +9677,13 @@ CommonNumber:
             switch (Js::JavascriptOperators::GetTypeId(arrayObject))
             {
             case TypeIds_Array:
-                Js::JavascriptOperators::ObjectToNativeArray(Js::JavascriptArray::FromVar(arrayObject), valueType, length, elementSize, buffer, scriptContext);
+                Js::JavascriptOperators::ObjectToNativeArray(Js::JavascriptArray::UnsafeFromVar(arrayObject), valueType, length, elementSize, buffer, scriptContext);
                 break;
             case TypeIds_NativeFloatArray:
-                Js::JavascriptOperators::ObjectToNativeArray(Js::JavascriptNativeFloatArray::FromVar(arrayObject), valueType, length, elementSize, buffer, scriptContext);
+                Js::JavascriptOperators::ObjectToNativeArray(Js::JavascriptNativeFloatArray::UnsafeFromVar(arrayObject), valueType, length, elementSize, buffer, scriptContext);
                 break;
             case TypeIds_NativeIntArray:
-                Js::JavascriptOperators::ObjectToNativeArray(Js::JavascriptNativeIntArray::FromVar(arrayObject), valueType, length, elementSize, buffer, scriptContext);
+                Js::JavascriptOperators::ObjectToNativeArray(Js::JavascriptNativeIntArray::UnsafeFromVar(arrayObject), valueType, length, elementSize, buffer, scriptContext);
                 break;
                 // We can have more specialized template if needed.
             default:
@@ -10479,3 +10509,4 @@ CommonNumber:
         return constructor;
     }
 } // namespace Js
+ 

--- a/lib/Runtime/Language/JavascriptOperators.h
+++ b/lib/Runtime/Language/JavascriptOperators.h
@@ -209,6 +209,11 @@ namespace Js
         static BOOL DeleteProperty_Impl(RecyclableObject* instance, PropertyId propertyId, PropertyOperationFlags propertyOperationFlags = PropertyOperation_None);
         static TypeId GetTypeId(Var instance);
         static TypeId GetTypeIdNoCheck(Var instance);
+        template <typename T>
+        __forceinline static T* TryFromVar(Var value)
+        {
+            return T::Is(value) ? T::UnsafeFromVar(value) : nullptr;
+        }
         static BOOL IsObject(Var instance);
         static BOOL IsExposedType(TypeId typeId);
         static BOOL IsObjectType(TypeId typeId);

--- a/lib/Runtime/Language/JavascriptOperators.inl
+++ b/lib/Runtime/Language/JavascriptOperators.inl
@@ -22,7 +22,7 @@ namespace Js
 #endif
         else
         {
-            auto typeId = RecyclableObject::FromVar(aValue)->GetTypeId();
+            auto typeId = RecyclableObject::UnsafeFromVar(aValue)->GetTypeId();
 #if DBG
             auto isExternal = RecyclableObject::FromVar(aValue)->CanHaveInterceptors();
             AssertMsg(typeId < TypeIds_Limit || isExternal, "GetTypeId aValue has invalid TypeId");

--- a/lib/Runtime/Language/ModuleNamespace.h
+++ b/lib/Runtime/Language/ModuleNamespace.h
@@ -31,7 +31,7 @@ namespace Js
         void Initialize();
         ListForListIterator* GetSortedExportedNames() { return this->sortedExportedNames; }
         static bool Is(Var aValue) {  return JavascriptOperators::GetTypeId(aValue) == TypeIds_ModuleNamespace; }
-        static ModuleNamespace* FromVar(Var obj) { Assert(JavascriptOperators::GetTypeId(obj) == TypeIds_ModuleNamespace); return static_cast<ModuleNamespace*>(obj); }
+        static ModuleNamespace* FromVar(Var obj) { AssertOrFailFast(JavascriptOperators::GetTypeId(obj) == TypeIds_ModuleNamespace); return static_cast<ModuleNamespace*>(obj); }
 
         virtual PropertyId GetPropertyId(BigPropertyIndex index) override;
         virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId) override;

--- a/lib/Runtime/Language/ProfilingHelpers.cpp
+++ b/lib/Runtime/Language/ProfilingHelpers.cpp
@@ -29,7 +29,7 @@ namespace Js
         const bool fastPath = isJsArray;
         if(fastPath)
         {
-            JavascriptArray *const array = JavascriptArray::FromVar(base);
+            JavascriptArray *const array = JavascriptArray::UnsafeFromVar(base);
             ldElemInfo.arrayType = ValueType::FromArray(ObjectType::Array, array, TypeIds_Array).ToLikely();
 
             const Var element = ProfiledLdElem_FastPath(array, varIndex, functionBody->GetScriptContext(), &ldElemInfo);
@@ -76,7 +76,7 @@ namespace Js
             }
             else if(Js::RecyclableObject::Is(base))
             {
-                ldElemInfo.arrayType = ValueType::FromObject(Js::RecyclableObject::FromVar(base)).ToLikely();
+                ldElemInfo.arrayType = ValueType::FromObject(Js::RecyclableObject::UnsafeFromVar(base)).ToLikely();
                 break;
             }
             else
@@ -223,7 +223,7 @@ namespace Js
         const bool fastPath = isJsArray && !JavascriptOperators::SetElementMayHaveImplicitCalls(scriptContext);
         if(fastPath)
         {
-            JavascriptArray *const array = JavascriptArray::FromVar(base);
+            JavascriptArray *const array = JavascriptArray::UnsafeFromVar(base);
             stElemInfo.arrayType = ValueType::FromArray(ObjectType::Array, array, TypeIds_Array).ToLikely();
             stElemInfo.createdMissingValue = array->HasNoMissingValues();
 
@@ -239,7 +239,7 @@ namespace Js
         TypeId arrayTypeId;
         if(isJsArray)
         {
-            array = JavascriptArray::FromVar(base);
+            array = JavascriptArray::UnsafeFromVar(base);
             isObjectWithArray = false;
             arrayTypeId = TypeIds_Array;
         }
@@ -473,7 +473,7 @@ namespace Js
             ProfiledNewScObjArray(
                 callee,
                 args,
-                ScriptFunction::FromVar(JavascriptCallStackLayout::FromFramePointer(framePointer)->functionObject),
+                ScriptFunction::UnsafeFromVar(JavascriptCallStackLayout::FromFramePointer(framePointer)->functionObject),
                 profileId,
                 arrayProfileId);
     }
@@ -489,7 +489,7 @@ namespace Js
     {
         ARGUMENTS(args, callInfo);
 
-        Js::ScriptFunction *function = ScriptFunction::FromVar(JavascriptCallStackLayout::FromFramePointer(framePointer)->functionObject);
+        Js::ScriptFunction *function = ScriptFunction::UnsafeFromVar(JavascriptCallStackLayout::FromFramePointer(framePointer)->functionObject);
         ScriptContext* scriptContext = function->GetScriptContext();
 
         // GetSpreadSize ensures that spreadSize < 2^24
@@ -576,7 +576,7 @@ namespace Js
 
         args.Values[0] = nullptr;
         Var array;
-        Js::RecyclableObject* calleeObject = RecyclableObject::FromVar(callee);
+        Js::RecyclableObject* calleeObject = RecyclableObject::UnsafeFromVar(callee);
         if (arrayInfo->IsNativeIntArray())
         {
             array = JavascriptNativeIntArray::NewInstance(calleeObject, args);
@@ -639,7 +639,7 @@ namespace Js
             const auto calleeObject = JavascriptOperators::GetCallableObjectOrThrow(callee, scriptContext);
             const auto calleeFunctionInfo =
                 calleeObject->GetTypeId() == TypeIds_Function
-                    ? JavascriptFunction::FromVar(calleeObject)->GetFunctionInfo()
+                    ? JavascriptFunction::UnsafeFromVar(calleeObject)->GetFunctionInfo()
                     : nullptr;
             DynamicProfileInfo *profileInfo = callerFunctionBody->GetDynamicProfileInfo();
             profileInfo->RecordCallSiteInfo(
@@ -676,7 +676,7 @@ namespace Js
         void *const framePointer)
     {
         ScriptFunction *const scriptFunction =
-            ScriptFunction::FromVar(JavascriptCallStackLayout::FromFramePointer(framePointer)->functionObject);
+            ScriptFunction::UnsafeFromVar(JavascriptCallStackLayout::FromFramePointer(framePointer)->functionObject);
         return
             ProfiledLdFld<false, false, false>(
                 instance,
@@ -695,7 +695,7 @@ namespace Js
         const Var thisInstance)
         {
         ScriptFunction *const scriptFunction =
-            ScriptFunction::FromVar(JavascriptCallStackLayout::FromFramePointer(framePointer)->functionObject);
+            ScriptFunction::UnsafeFromVar(JavascriptCallStackLayout::FromFramePointer(framePointer)->functionObject);
         return
             ProfiledLdFld<false, false, false>(
             instance,
@@ -713,7 +713,7 @@ namespace Js
         void *const framePointer)
     {
         ScriptFunction *const scriptFunction =
-            ScriptFunction::FromVar(JavascriptCallStackLayout::FromFramePointer(framePointer)->functionObject);
+            ScriptFunction::UnsafeFromVar(JavascriptCallStackLayout::FromFramePointer(framePointer)->functionObject);
 
         return ProfiledLdFldForTypeOf<false, false, false>(
             instance,
@@ -731,7 +731,7 @@ namespace Js
         void *const framePointer)
     {
         ScriptFunction *const scriptFunction =
-            ScriptFunction::FromVar(JavascriptCallStackLayout::FromFramePointer(framePointer)->functionObject);
+            ScriptFunction::UnsafeFromVar(JavascriptCallStackLayout::FromFramePointer(framePointer)->functionObject);
         return
             ProfiledLdFld<false, false, true>(
                 instance,
@@ -749,7 +749,7 @@ namespace Js
         void *const framePointer)
     {
         ScriptFunction *const scriptFunction =
-            ScriptFunction::FromVar(JavascriptCallStackLayout::FromFramePointer(framePointer)->functionObject);
+            ScriptFunction::UnsafeFromVar(JavascriptCallStackLayout::FromFramePointer(framePointer)->functionObject);
         return
             ProfiledLdFld<false, true, false>(
                 instance,
@@ -767,7 +767,7 @@ namespace Js
         void *const framePointer)
     {
         ScriptFunction *const scriptFunction =
-            ScriptFunction::FromVar(JavascriptCallStackLayout::FromFramePointer(framePointer)->functionObject);
+            ScriptFunction::UnsafeFromVar(JavascriptCallStackLayout::FromFramePointer(framePointer)->functionObject);
         return
             ProfiledLdFld<true, false, false>(
                 instance,
@@ -785,7 +785,7 @@ namespace Js
         void *const framePointer)
     {
         ScriptFunction *const scriptFunction =
-            ScriptFunction::FromVar(JavascriptCallStackLayout::FromFramePointer(framePointer)->functionObject);
+            ScriptFunction::UnsafeFromVar(JavascriptCallStackLayout::FromFramePointer(framePointer)->functionObject);
 
         return ProfiledLdFldForTypeOf<true, false, false>(
             instance,
@@ -802,7 +802,7 @@ namespace Js
         void *const framePointer)
     {
         ScriptFunction *const scriptFunction =
-            ScriptFunction::FromVar(JavascriptCallStackLayout::FromFramePointer(framePointer)->functionObject);
+            ScriptFunction::UnsafeFromVar(JavascriptCallStackLayout::FromFramePointer(framePointer)->functionObject);
         return
             ProfiledLdFld<true, true, false>(
                 instance,
@@ -839,15 +839,15 @@ namespace Js
         FldInfoFlags fldInfoFlags = FldInfo_NoInfo;
         if (Root || (RecyclableObject::Is(instance) && RecyclableObject::Is(thisInstance)))
         {
-            RecyclableObject *const object = RecyclableObject::FromVar(instance);
-            RecyclableObject *const thisObject = RecyclableObject::FromVar(thisInstance);
+            RecyclableObject *const object = RecyclableObject::UnsafeFromVar(instance);
+            RecyclableObject *const thisObject = RecyclableObject::UnsafeFromVar(thisInstance);
 
             if (!Root && Method && (propertyId == PropertyIds::apply || propertyId == PropertyIds::call) && ScriptFunction::Is(object))
             {
                 // If the property being loaded is "apply"/"call", make an optimistic assumption that apply/call is not overridden and
                 // undefer the function right here if it was defer parsed before. This is required so that the load of "apply"/"call"
                 // happens from the same "type". Otherwise, we will have a polymorphic cache for load of "apply"/"call".
-                ScriptFunction *fn = ScriptFunction::FromVar(object);
+                ScriptFunction *fn = ScriptFunction::UnsafeFromVar(object);
                 if (fn->GetType()->GetEntryPoint() == JavascriptFunction::DeferredParsingThunk)
                 {
                     JavascriptFunction::DeferredParse(&fn);
@@ -968,7 +968,7 @@ namespace Js
         void *const framePointer)
     {
         ScriptFunction *const scriptFunction =
-            ScriptFunction::FromVar(JavascriptCallStackLayout::FromFramePointer(framePointer)->functionObject);
+            ScriptFunction::UnsafeFromVar(JavascriptCallStackLayout::FromFramePointer(framePointer)->functionObject);
         ProfiledStFld<false>(
             instance,
             propertyId,
@@ -989,7 +989,7 @@ namespace Js
         const Var thisInstance)
     {
         ScriptFunction *const scriptFunction =
-            ScriptFunction::FromVar(JavascriptCallStackLayout::FromFramePointer(framePointer)->functionObject);
+            ScriptFunction::UnsafeFromVar(JavascriptCallStackLayout::FromFramePointer(framePointer)->functionObject);
         ProfiledStFld<false>(
             instance,
             propertyId,
@@ -1009,7 +1009,7 @@ namespace Js
         void *const framePointer)
     {
         ScriptFunction *const scriptFunction =
-            ScriptFunction::FromVar(JavascriptCallStackLayout::FromFramePointer(framePointer)->functionObject);
+            ScriptFunction::UnsafeFromVar(JavascriptCallStackLayout::FromFramePointer(framePointer)->functionObject);
         ProfiledStFld<false>(
             instance,
             propertyId,
@@ -1029,7 +1029,7 @@ namespace Js
         void *const framePointer)
     {
         ScriptFunction *const scriptFunction =
-            ScriptFunction::FromVar(JavascriptCallStackLayout::FromFramePointer(framePointer)->functionObject);
+            ScriptFunction::UnsafeFromVar(JavascriptCallStackLayout::FromFramePointer(framePointer)->functionObject);
         ProfiledStFld<true>(
             instance,
             propertyId,
@@ -1049,7 +1049,7 @@ namespace Js
         void *const framePointer)
     {
         ScriptFunction *const scriptFunction =
-            ScriptFunction::FromVar(JavascriptCallStackLayout::FromFramePointer(framePointer)->functionObject);
+            ScriptFunction::UnsafeFromVar(JavascriptCallStackLayout::FromFramePointer(framePointer)->functionObject);
         ProfiledStFld<true>(
             instance,
             propertyId,
@@ -1091,8 +1091,8 @@ namespace Js
         FldInfoFlags fldInfoFlags = FldInfo_NoInfo;
         if(Root || (RecyclableObject::Is(instance) && RecyclableObject::Is(thisInstance)))
         {
-            RecyclableObject *const object = RecyclableObject::FromVar(instance);
-            RecyclableObject *const thisObject = RecyclableObject::FromVar(thisInstance);
+            RecyclableObject *const object = RecyclableObject::UnsafeFromVar(instance);
+            RecyclableObject *const thisObject = RecyclableObject::UnsafeFromVar(thisInstance);
             PropertyCacheOperationInfo operationInfo;
             PropertyValueInfo propertyValueInfo;
             PropertyValueInfo::SetCacheInfo(&propertyValueInfo, functionBody, inlineCache, inlineCacheIndex, true);
@@ -1197,7 +1197,7 @@ namespace Js
         void *const framePointer)
     {
         ScriptFunction *const scriptFunction =
-            ScriptFunction::FromVar(JavascriptCallStackLayout::FromFramePointer(framePointer)->functionObject);
+            ScriptFunction::UnsafeFromVar(JavascriptCallStackLayout::FromFramePointer(framePointer)->functionObject);
         ProfiledInitFld(
             RecyclableObject::FromVar(instance),
             propertyId,
@@ -1307,7 +1307,7 @@ namespace Js
 
         return
             scriptFunction->GetHasInlineCaches()
-                ? ScriptFunctionWithInlineCache::FromVar(scriptFunction)->GetInlineCache(inlineCacheIndex)
+                ? ScriptFunctionWithInlineCache::UnsafeFromVar(scriptFunction)->GetInlineCache(inlineCacheIndex)
                 : scriptFunction->GetFunctionBody()->GetInlineCache(inlineCacheIndex);
     }
 #endif

--- a/lib/Runtime/Language/ValueType.cpp
+++ b/lib/Runtime/Language/ValueType.cpp
@@ -1205,7 +1205,7 @@ ValueType ValueType::Merge(const Js::Var var) const
                     ? GetInt(false)
                     : ValueType::Float);
     }
-    return Merge(FromObject(RecyclableObject::FromVar(var)));
+    return Merge(FromObject(RecyclableObject::UnsafeFromVar(var)));
 }
 
 ValueType::Bits ValueType::TypeIdToBits[Js::TypeIds_Limit];

--- a/lib/Runtime/Library/ArrayBuffer.cpp
+++ b/lib/Runtime/Library/ArrayBuffer.cpp
@@ -13,6 +13,12 @@ namespace Js
 
     ArrayBufferBase* ArrayBufferBase::FromVar(Var value)
     {
+        AssertOrFailFast(ArrayBufferBase::Is(value));
+        return static_cast<ArrayBuffer *> (value);
+    }
+
+    ArrayBufferBase* ArrayBufferBase::UnsafeFromVar(Var value)
+    {
         Assert(ArrayBufferBase::Is(value));
         return static_cast<ArrayBuffer *> (value);
     }
@@ -60,7 +66,7 @@ namespace Js
                         VirtualTableInfo<CrossSiteObject<Int8Array>>::SetVirtualTable(parent);
                     }
                 }
-                TypedArrayBase::FromVar(parent)->ClearLengthAndBufferOnDetach();
+                TypedArrayBase::UnsafeFromVar(parent)->ClearLengthAndBufferOnDetach();
                 break;
 
         case TypeIds_Uint8Array:
@@ -76,7 +82,7 @@ namespace Js
                         VirtualTableInfo<CrossSiteObject<Uint8Array>>::SetVirtualTable(parent);
                     }
                 }
-                TypedArrayBase::FromVar(parent)->ClearLengthAndBufferOnDetach();
+                TypedArrayBase::UnsafeFromVar(parent)->ClearLengthAndBufferOnDetach();
                 break;
 
         case TypeIds_Uint8ClampedArray:
@@ -92,7 +98,7 @@ namespace Js
                         VirtualTableInfo<CrossSiteObject<Uint8ClampedArray>>::SetVirtualTable(parent);
                     }
                 }
-                TypedArrayBase::FromVar(parent)->ClearLengthAndBufferOnDetach();
+                TypedArrayBase::UnsafeFromVar(parent)->ClearLengthAndBufferOnDetach();
                 break;
 
         case TypeIds_Int16Array:
@@ -108,7 +114,7 @@ namespace Js
                         VirtualTableInfo<CrossSiteObject<Int16Array>>::SetVirtualTable(parent);
                     }
                 }
-                TypedArrayBase::FromVar(parent)->ClearLengthAndBufferOnDetach();
+                TypedArrayBase::UnsafeFromVar(parent)->ClearLengthAndBufferOnDetach();
                 break;
 
         case TypeIds_Uint16Array:
@@ -124,7 +130,7 @@ namespace Js
                         VirtualTableInfo<CrossSiteObject<Uint16Array>>::SetVirtualTable(parent);
                     }
                 }
-                TypedArrayBase::FromVar(parent)->ClearLengthAndBufferOnDetach();
+                TypedArrayBase::UnsafeFromVar(parent)->ClearLengthAndBufferOnDetach();
                 break;
 
         case TypeIds_Int32Array:
@@ -140,7 +146,7 @@ namespace Js
                         VirtualTableInfo<CrossSiteObject<Int32Array>>::SetVirtualTable(parent);
                     }
                 }
-                TypedArrayBase::FromVar(parent)->ClearLengthAndBufferOnDetach();
+                TypedArrayBase::UnsafeFromVar(parent)->ClearLengthAndBufferOnDetach();
                 break;
 
         case TypeIds_Uint32Array:
@@ -156,7 +162,7 @@ namespace Js
                         VirtualTableInfo<CrossSiteObject<Uint32Array>>::SetVirtualTable(parent);
                     }
                 }
-                TypedArrayBase::FromVar(parent)->ClearLengthAndBufferOnDetach();
+                TypedArrayBase::UnsafeFromVar(parent)->ClearLengthAndBufferOnDetach();
                 break;
 
         case TypeIds_Float32Array:
@@ -172,7 +178,7 @@ namespace Js
                         VirtualTableInfo<CrossSiteObject<Float32Array>>::SetVirtualTable(parent);
                     }
                 }
-                TypedArrayBase::FromVar(parent)->ClearLengthAndBufferOnDetach();
+                TypedArrayBase::UnsafeFromVar(parent)->ClearLengthAndBufferOnDetach();
                 break;
 
         case TypeIds_Float64Array:
@@ -188,14 +194,14 @@ namespace Js
                         VirtualTableInfo<CrossSiteObject<Float64Array>>::SetVirtualTable(parent);
                     }
                 }
-                TypedArrayBase::FromVar(parent)->ClearLengthAndBufferOnDetach();
+                TypedArrayBase::UnsafeFromVar(parent)->ClearLengthAndBufferOnDetach();
                 break;
 
         case TypeIds_Int64Array:
         case TypeIds_Uint64Array:
         case TypeIds_CharArray:
         case TypeIds_BoolArray:
-                TypedArrayBase::FromVar(parent)->ClearLengthAndBufferOnDetach();
+                TypedArrayBase::UnsafeFromVar(parent)->ClearLengthAndBufferOnDetach();
             break;
 
         case TypeIds_DataView:
@@ -568,9 +574,16 @@ namespace Js
 
     ArrayBuffer* ArrayBuffer::FromVar(Var aValue)
     {
-        AssertMsg(Is(aValue), "var must be an ArrayBuffer");
+        AssertOrFailFastMsg(Is(aValue), "var must be an ArrayBuffer");
 
         return static_cast<ArrayBuffer *>(RecyclableObject::FromVar(aValue));
+    }
+
+    ArrayBuffer* ArrayBuffer::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(Is(aValue), "var must be an ArrayBuffer");
+
+        return static_cast<ArrayBuffer *>(RecyclableObject::UnsafeFromVar(aValue));
     }
 
     bool  ArrayBuffer::Is(Var aValue)

--- a/lib/Runtime/Library/ArrayBuffer.h
+++ b/lib/Runtime/Library/ArrayBuffer.h
@@ -82,6 +82,7 @@ namespace Js
 
         static bool Is(Var value);
         static ArrayBufferBase* FromVar(Var value);
+        static ArrayBufferBase* UnsafeFromVar(Var value);
         static int GetIsDetachedOffset() { return offsetof(ArrayBufferBase, isDetached); }
 
     protected:
@@ -152,6 +153,7 @@ namespace Js
         static bool Is(Var aValue);
         static ArrayBuffer* NewFromDetachedState(DetachedStateBase* state, JavascriptLibrary *library);
         static ArrayBuffer* FromVar(Var aValue);
+        static ArrayBuffer* UnsafeFromVar(Var aValue);
 
         virtual BOOL GetDiagTypeString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext) override;
         virtual BOOL GetDiagValueString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext) override;

--- a/lib/Runtime/Library/AtomicsObject.cpp
+++ b/lib/Runtime/Library/AtomicsObject.cpp
@@ -41,7 +41,7 @@ namespace Js
             }
         }
 
-        TypedArrayBase *typedArrayBase = TypedArrayBase::FromVar(typedArray);
+        TypedArrayBase *typedArrayBase = TypedArrayBase::UnsafeFromVar(typedArray);
         ArrayBufferBase* arrayBuffer = typedArrayBase->GetArrayBuffer();
         if (arrayBuffer == nullptr || !ArrayBufferBase::Is(arrayBuffer) || !arrayBuffer->IsSharedArrayBuffer())
         {

--- a/lib/Runtime/Library/BoundFunction.h
+++ b/lib/Runtime/Library/BoundFunction.h
@@ -27,7 +27,7 @@ namespace Js
     public:
         static BoundFunction* New(ScriptContext* scriptContext, ArgumentReader args);
 
-        static bool Is(Var func){ return JavascriptFunction::Is(func) && JavascriptFunction::FromVar(func)->IsBoundFunction(); }
+        static bool Is(Var func){ return JavascriptFunction::Is(func) && JavascriptFunction::UnsafeFromVar(func)->IsBoundFunction(); }
         static Var NewInstance(RecyclableObject* function, CallInfo callInfo, ...);
         virtual JavascriptString* GetDisplayNameImpl() const override;
         virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId) override;

--- a/lib/Runtime/Library/CompoundString.cpp
+++ b/lib/Runtime/Library/CompoundString.cpp
@@ -605,6 +605,15 @@ namespace Js
 
     CompoundString *CompoundString::FromVar(RecyclableObject *const object)
     {
+        AssertOrFailFast(Is(object));
+
+        CompoundString *const cs = static_cast<CompoundString *>(object);
+        Assert(!cs->IsFinalized());
+        return cs;
+    }
+
+    CompoundString *CompoundString::UnsafeFromVar(RecyclableObject *const object)
+    {
         Assert(Is(object));
 
         CompoundString *const cs = static_cast<CompoundString *>(object);
@@ -617,6 +626,11 @@ namespace Js
         return FromVar(RecyclableObject::FromVar(var));
     }
 
+    CompoundString *CompoundString::UnsafeFromVar(const Var var)
+    {
+        return UnsafeFromVar(RecyclableObject::UnsafeFromVar(var));
+    }
+
     JavascriptString *CompoundString::GetImmutableOrScriptUnreferencedString(JavascriptString *const s)
     {
         Assert(s);
@@ -626,7 +640,7 @@ namespace Js
         // another CompoundString, for instance). If the provided string is a CompoundString, it must not be mutated by script
         // code after the concatenation operation. In that case, clone the string to ensure that it is not referenced by script
         // code. If the clone is never handed back to script code, it effectively behaves as an immutable string.
-        return Is(s) ? FromVar(s)->Clone(false) : s;
+        return Is(s) ? UnsafeFromVar(s)->Clone(false) : s;
     }
 
     bool CompoundString::ShouldAppendChars(const CharCount appendCharLength)

--- a/lib/Runtime/Library/CompoundString.h
+++ b/lib/Runtime/Library/CompoundString.h
@@ -341,7 +341,9 @@ namespace Js
         static bool Is(RecyclableObject *const object);
         static bool Is(const Var var);
         static CompoundString *FromVar(RecyclableObject *const object);
+        static CompoundString *UnsafeFromVar(RecyclableObject *const object);
         static CompoundString *FromVar(const Var var);
+        static CompoundString *UnsafeFromVar(const Var var);
         static size_t GetOffsetOfOwnsLastBlock() { return offsetof(CompoundString, ownsLastBlock); }
         static size_t GetOffsetOfDirectCharLength() { return offsetof(CompoundString, directCharLength); }
         static size_t GetOffsetOfLastBlockInfo() { return offsetof(CompoundString, lastBlockInfo); }

--- a/lib/Runtime/Library/ConcatString.cpp
+++ b/lib/Runtime/Library/ConcatString.cpp
@@ -36,7 +36,7 @@ namespace Js
     /* static */
     bool LiteralStringWithPropertyStringPtr::Is(Var var)
     {
-        return RecyclableObject::Is(var) && LiteralStringWithPropertyStringPtr::Is(RecyclableObject::FromVar(var));
+        return RecyclableObject::Is(var) && LiteralStringWithPropertyStringPtr::Is(RecyclableObject::UnsafeFromVar(var));
     }
 
     /////////////////////// ConcatStringBase //////////////////////////
@@ -362,6 +362,13 @@ namespace Js
 
     ConcatStringMulti *
     ConcatStringMulti::FromVar(Var var)
+    {
+        AssertOrFailFast(ConcatStringMulti::Is(var));
+        return static_cast<ConcatStringMulti *>(var);
+    }
+
+    ConcatStringMulti *
+    ConcatStringMulti::UnsafeFromVar(Var var)
     {
         Assert(ConcatStringMulti::Is(var));
         return static_cast<ConcatStringMulti *>(var);

--- a/lib/Runtime/Library/ConcatString.h
+++ b/lib/Runtime/Library/ConcatString.h
@@ -250,6 +250,7 @@ namespace Js
         const char16 * GetSz() override sealed;
         static bool Is(Var var);
         static ConcatStringMulti * FromVar(Var value);
+        static ConcatStringMulti * UnsafeFromVar(Var value);
         static size_t GetAllocSize(uint slotCount);
         void SetItem(_In_range_(0, slotCount - 1) uint index, JavascriptString* value);
 

--- a/lib/Runtime/Library/CustomExternalIterator.cpp
+++ b/lib/Runtime/Library/CustomExternalIterator.cpp
@@ -148,8 +148,14 @@ namespace Js
 
     CustomExternalIterator* CustomExternalIterator::FromVar(Var aValue)
     {
-        AssertMsg(Is(aValue), "Ensure var is actually a 'ExternalIterator'");
+        AssertOrFailFastMsg(Is(aValue), "Ensure var is actually a 'ExternalIterator'");
         return static_cast<CustomExternalIterator *>(RecyclableObject::FromVar(aValue));
+    }
+
+    CustomExternalIterator* CustomExternalIterator::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(Is(aValue), "Ensure var is actually a 'ExternalIterator'");
+        return static_cast<CustomExternalIterator *>(RecyclableObject::UnsafeFromVar(aValue));
     }
 
     Var CustomExternalIterator::CreateNextFunction(JavascriptLibrary *library, JavascriptTypeId typeId)

--- a/lib/Runtime/Library/CustomExternalIterator.h
+++ b/lib/Runtime/Library/CustomExternalIterator.h
@@ -88,6 +88,7 @@ namespace Js
 
         static bool Is(Var aValue);
         static CustomExternalIterator* FromVar(Var aValue);
+        static CustomExternalIterator* UnsafeFromVar(Var aValue);
         static Var CreateNextFunction(JavascriptLibrary *library, JavascriptTypeId typeId);
         static Var EntryNext(RecyclableObject* function, CallInfo callInfo, ...);
     };

--- a/lib/Runtime/Library/DataView.h
+++ b/lib/Runtime/Library/DataView.h
@@ -45,6 +45,12 @@ namespace Js
 
         static inline DataView* FromVar(Var aValue)
         {
+            AssertOrFailFast(DataView::Is(aValue));
+            return static_cast<DataView*>(aValue);
+        }
+
+        static inline DataView* UnsafeFromVar(Var aValue)
+        {
             Assert(DataView::Is(aValue));
             return static_cast<DataView*>(aValue);
         }

--- a/lib/Runtime/Library/ES5Array.cpp
+++ b/lib/Runtime/Library/ES5Array.cpp
@@ -20,6 +20,12 @@ namespace Js
 
     ES5Array* ES5Array::FromVar(Var instance)
     {
+        AssertOrFailFast(Is(instance));
+        return static_cast<ES5Array*>(instance);
+    }
+
+    ES5Array* ES5Array::UnsafeFromVar(Var instance)
+    {
         Assert(Is(instance));
         return static_cast<ES5Array*>(instance);
     }

--- a/lib/Runtime/Library/ES5Array.h
+++ b/lib/Runtime/Library/ES5Array.h
@@ -41,6 +41,7 @@ namespace Js
     public:
         static bool Is(Var instance);
         static ES5Array* FromVar(Var instance);
+        static ES5Array* UnsafeFromVar(Var instance);
         static uint32 ToLengthValue(Var value, ScriptContext* scriptContext);
         bool IsLengthWritable() const;
 

--- a/lib/Runtime/Library/EngineInterfaceObject.cpp
+++ b/lib/Runtime/Library/EngineInterfaceObject.cpp
@@ -139,11 +139,17 @@ namespace Js
 
     EngineInterfaceObject* EngineInterfaceObject::FromVar(Var aValue)
     {
-        AssertMsg(Is(aValue), "aValue is actually an EngineInterfaceObject");
+        AssertOrFailFastMsg(Is(aValue), "aValue is actually an EngineInterfaceObject");
 
         return static_cast<EngineInterfaceObject *>(RecyclableObject::FromVar(aValue));
     }
 
+    EngineInterfaceObject* EngineInterfaceObject::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(Is(aValue), "aValue is actually an EngineInterfaceObject");
+
+        return static_cast<EngineInterfaceObject *>(RecyclableObject::FromVar(aValue));
+    }
     void EngineInterfaceObject::Initialize()
     {
         Recycler* recycler = this->GetRecycler();

--- a/lib/Runtime/Library/EngineInterfaceObject.h
+++ b/lib/Runtime/Library/EngineInterfaceObject.h
@@ -65,6 +65,7 @@ namespace Js
         static EngineInterfaceObject* New(Recycler * recycler, DynamicType * type);
         static bool Is(Var aValue);
         static EngineInterfaceObject* FromVar(Var aValue);
+        static EngineInterfaceObject* UnsafeFromVar(Var aValue);
 
 #if ENABLE_TTD
         virtual void MarkVisitKindSpecificPtrs(TTD::SnapshotExtractor* extractor) override;

--- a/lib/Runtime/Library/ForInObjectEnumerator.cpp
+++ b/lib/Runtime/Library/ForInObjectEnumerator.cpp
@@ -102,7 +102,7 @@ namespace Js
                 }
 
                 if (!DynamicType::Is(firstPrototypeWithEnumerableProperties->GetTypeId())
-                    || !DynamicObject::FromVar(firstPrototypeWithEnumerableProperties)->GetHasNoEnumerableProperties())
+                    || !DynamicObject::UnsafeFromVar(firstPrototypeWithEnumerableProperties)->GetHasNoEnumerableProperties())
                 {
                     break;
                 }

--- a/lib/Runtime/Library/GlobalObject.cpp
+++ b/lib/Runtime/Library/GlobalObject.cpp
@@ -55,10 +55,16 @@ namespace Js
 
     bool GlobalObject::Is(Var aValue)
     {
-        return RecyclableObject::Is(aValue) && (RecyclableObject::FromVar(aValue)->GetTypeId() == TypeIds_GlobalObject);
+        return RecyclableObject::Is(aValue) && (RecyclableObject::UnsafeFromVar(aValue)->GetTypeId() == TypeIds_GlobalObject);
     }
 
     GlobalObject* GlobalObject::FromVar(Var aValue)
+    {
+        AssertOrFailFastMsg(Is(aValue), "Ensure var is actually a 'GlobalObject'");
+        return static_cast<GlobalObject*>(aValue);
+    }
+
+    GlobalObject* GlobalObject::UnsafeFromVar(Var aValue)
     {
         AssertMsg(Is(aValue), "Ensure var is actually a 'GlobalObject'");
         return static_cast<GlobalObject*>(aValue);

--- a/lib/Runtime/Library/GlobalObject.h
+++ b/lib/Runtime/Library/GlobalObject.h
@@ -123,6 +123,7 @@ namespace Js
 
         static bool Is(Var aValue);
         static GlobalObject* FromVar(Var aValue);
+        static GlobalObject* UnsafeFromVar(Var aValue);
 
         typedef ScriptFunction* (*EvalHelperType)(ScriptContext* scriptContext, const char16 *source, int sourceLength, ModuleID moduleID, uint32 grfscr, LPCOLESTR pszTitle, BOOL registerDocument, BOOL isIndirect, BOOL strictMode);
         FieldNoBarrier(EvalHelperType) EvalHelper;

--- a/lib/Runtime/Library/JSON.cpp
+++ b/lib/Runtime/Library/JSON.cpp
@@ -38,20 +38,16 @@ namespace JSON
             Js::JavascriptError::ThrowSyntaxError(scriptContext, ERRsyntax);
         }
 
-        Js::JavascriptString* input;
         Js::Var value = args[1];
-        if (Js::JavascriptString::Is(value))
-        {
-            input = Js::JavascriptString::FromVar(value);
-        }
-        else
+        Js::JavascriptString * input = JavascriptOperators::TryFromVar<Js::JavascriptString>(value);
+        if (!input)
         {
             input = Js::JavascriptConversion::ToString(value, scriptContext);
         }
         Js::RecyclableObject* reviver = NULL;
         if (args.Info.Count > 2 && Js::JavascriptConversion::IsCallable(args[2]))
         {
-            reviver = Js::RecyclableObject::FromVar(args[2]);
+            reviver = Js::RecyclableObject::UnsafeFromVar(args[2]);
         }
 
         return Parse(input, reviver, scriptContext);
@@ -134,7 +130,7 @@ namespace JSON
             {
                 Js::Throw::FatalInternalError(); // nameTable buffer calculation is wrong
             }
-            Js::JavascriptString *propertyName = Js::JavascriptString::FromVar(value);
+            Js::JavascriptString *propertyName = Js::JavascriptString::UnsafeFromVar(value);
             nameTable[tableLen].propName = propertyName;
             Js::PropertyRecord const * propertyRecord;
             scriptContext->GetOrAddPropertyRecord(propertyName, &propertyRecord);
@@ -204,13 +200,12 @@ namespace JSON
             if (Js::JavascriptOperators::IsArray(replacerArg))
             {
                 uint32 length;
-                Js::JavascriptArray *reArray = nullptr;
-                Js::RecyclableObject *reRemoteArray = Js::RecyclableObject::FromVar(replacerArg);
+                Js::JavascriptArray *reArray = JavascriptOperators::TryFromVar<JavascriptArray>(replacerArg);
+                Js::RecyclableObject *reRemoteArray = Js::RecyclableObject::UnsafeFromVar(replacerArg);
                 bool isArray = false;
 
-                if (Js::JavascriptArray::Is(replacerArg))
+                if (reArray)
                 {
-                    reArray = Js::JavascriptArray::FromVar(replacerArg);
                     length = reArray->GetLength();
                     isArray = true;
                 }
@@ -313,7 +308,7 @@ namespace JSON
             }
             else if (Js::JavascriptConversion::IsCallable(replacerArg))
             {
-                stringifySession.InitReplacer(Js::RecyclableObject::FromVar(replacerArg));
+                stringifySession.InitReplacer(Js::RecyclableObject::UnsafeFromVar(replacerArg));
             }
         }
 
@@ -372,10 +367,10 @@ namespace JSON
             }
         case Js::TypeIds_String:
             {
-                len = min(static_cast<charcount_t>(JSONspaceSize), Js::JavascriptString::FromVar(space)->GetLength());
+                len = min(static_cast<charcount_t>(JSONspaceSize), Js::JavascriptString::UnsafeFromVar(space)->GetLength());
                 if(len)
                 {
-                    gap = Js::JavascriptString::NewCopyBuffer(Js::JavascriptString::FromVar(space)->GetString(), len, scriptContext);
+                    gap = Js::JavascriptString::NewCopyBuffer(Js::JavascriptString::UnsafeFromVar(space)->GetString(), len, scriptContext);
                 }
                 break;
             }
@@ -384,10 +379,10 @@ namespace JSON
                 Js::Var spaceString = Js::JavascriptConversion::ToString(space, scriptContext);
                 if(Js::JavascriptString::Is(spaceString))
                 {
-                    len = min(static_cast<charcount_t>(JSONspaceSize), Js::JavascriptString::FromVar(spaceString)->GetLength());
+                    len = min(static_cast<charcount_t>(JSONspaceSize), Js::JavascriptString::UnsafeFromVar(spaceString)->GetLength());
                     if(len)
                     {
-                        gap = Js::JavascriptString::NewCopyBuffer(Js::JavascriptString::FromVar(spaceString)->GetString(), len, scriptContext);
+                        gap = Js::JavascriptString::NewCopyBuffer(Js::JavascriptString::UnsafeFromVar(spaceString)->GetString(), len, scriptContext);
                     }
                 }
                 break;
@@ -402,9 +397,9 @@ namespace JSON
         Js::Var value = nullptr;
         Js::RecyclableObject *undefined = scriptContext->GetLibrary()->GetUndefined();
 
-        if (Js::JavascriptArray::Is(holder->GetTypeId()) && !Js::JavascriptArray::FromAnyArray(holder)->IsCrossSiteObject())
+        if (Js::JavascriptArray::Is(holder->GetTypeId()) && !Js::JavascriptArray::UnsafeFromAnyArray(holder)->IsCrossSiteObject())
         {
-            value = Js::JavascriptArray::FromAnyArray(holder)->DirectGetItem(index);
+            value = Js::JavascriptArray::UnsafeFromAnyArray(holder)->DirectGetItem(index);
             if (Js::JavascriptOperators::IsUndefinedObject(value, undefined))
             {
                 return value;
@@ -456,10 +451,9 @@ namespace JSON
         return StrHelper(key, value, holder);
     }
 
-    inline bool Get_ToJSON(ScriptContext* scriptContext, Js::JavascriptString* key, Js::Var* value, Js::TypeId typeId)
+    inline bool Get_ToJSON(ScriptContext* scriptContext, Js::JavascriptString* key, Js::RecyclableObject* object, Js::Var* value, Js::TypeId typeId)
     {
         Js::Var toJSON = nullptr;
-        Js::RecyclableObject* object = Js::RecyclableObject::FromVar(*value);
         while (typeId != Js::TypeIds_Null)
         {
             PropertyQueryFlags result = object->GetPropertyQuery(object, Js::PropertyIds::toJSON, &toJSON, nullptr, scriptContext);
@@ -471,7 +465,7 @@ namespace JSON
                 args.Values[0] = *value;
                 args.Values[1] = key;
 
-                Js::RecyclableObject* func = Js::RecyclableObject::FromVar(toJSON);
+                Js::RecyclableObject* func = Js::RecyclableObject::UnsafeFromVar(toJSON);
                 *value = Js::JavascriptFunction::CallFunction<true>(func, func->GetEntryPoint(), args);
                 return true;
             }
@@ -493,7 +487,7 @@ namespace JSON
         //check and apply 'toJSON' filter
         if (Js::JavascriptOperators::IsJsNativeObject(value) || (Js::JavascriptOperators::IsObject(value)))
         {
-            if (Get_ToJSON(scriptContext, key, &value, id))
+            if (Get_ToJSON(scriptContext, key, Js::RecyclableObject::UnsafeFromVar(value), &value, id))
             {
                 id = Js::JavascriptOperators::GetTypeId(value);
             }
@@ -527,7 +521,7 @@ namespace JSON
         }
         else if (Js::TypeIds_BooleanObject == id)
         {
-            value = Js::JavascriptBooleanObject::FromVar(value)->GetValue() ?
+            value = Js::JavascriptBooleanObject::UnsafeFromVar(value)->GetValue() ?
                 scriptContext->GetLibrary()->GetTrue()
             :
                 scriptContext->GetLibrary()->GetFalse();
@@ -547,10 +541,10 @@ namespace JSON
             return scriptContext->GetIntegerString(value);
 
         case Js::TypeIds_Boolean:
-            return (Js::JavascriptBoolean::FromVar(value)->GetValue()) ? scriptContext->GetLibrary()->GetTrueDisplayString() : scriptContext->GetLibrary()->GetFalseDisplayString();
+            return (Js::JavascriptBoolean::UnsafeFromVar(value)->GetValue()) ? scriptContext->GetLibrary()->GetTrueDisplayString() : scriptContext->GetLibrary()->GetFalseDisplayString();
 
         case Js::TypeIds_Int64Number:
-            if (Js::NumberUtilities::IsFinite(static_cast<double>(Js::JavascriptInt64Number::FromVar(value)->GetValue())))
+            if (Js::NumberUtilities::IsFinite(static_cast<double>(Js::JavascriptInt64Number::UnsafeFromVar(value)->GetValue())))
             {
                 return Js::JavascriptConversion::ToString(value, scriptContext);
             }
@@ -560,7 +554,7 @@ namespace JSON
             }
 
         case Js::TypeIds_UInt64Number:
-            if (Js::NumberUtilities::IsFinite(static_cast<double>(Js::JavascriptUInt64Number::FromVar(value)->GetValue())))
+            if (Js::NumberUtilities::IsFinite(static_cast<double>(Js::JavascriptUInt64Number::UnsafeFromVar(value)->GetValue())))
             {
                 return Js::JavascriptConversion::ToString(value, scriptContext);
             }
@@ -580,7 +574,7 @@ namespace JSON
             }
 
         case Js::TypeIds_String:
-            return Quote(Js::JavascriptString::FromVar(value));
+            return Quote(Js::JavascriptString::UnsafeFromVar(value));
 
         default:
             Js::Var ret = undefined;
@@ -650,7 +644,7 @@ namespace JSON
         {
             if (JavascriptProxy::Is(object))
             {
-                JavascriptProxy* proxyObject = JavascriptProxy::FromVar(object);
+                JavascriptProxy* proxyObject = JavascriptProxy::UnsafeFromVar(object);
                 JavascriptArray* proxyResult = proxyObject->PropertyKeysTrap(JavascriptProxy::KeysTrapKind::GetOwnPropertyNamesKind, this->scriptContext);
 
                 // filter enumerable keys
@@ -667,7 +661,7 @@ namespace JSON
                     PropertyDescriptor propertyDescriptor;
                     JavascriptConversion::ToPropertyKey(propertyName, scriptContext, &propRecord, nullptr);
                     id = propRecord->GetPropertyId();
-                    if (JavascriptOperators::GetOwnPropertyDescriptor(RecyclableObject::FromVar(proxyObject), id, scriptContext, &propertyDescriptor))
+                    if (JavascriptOperators::GetOwnPropertyDescriptor(RecyclableObject::UnsafeFromVar(proxyObject), id, scriptContext, &propertyDescriptor))
                     {
                         if (propertyDescriptor.IsEnumerable())
                         {
@@ -1046,7 +1040,8 @@ namespace JSON
         *pIsPrecise = false;
 
         uint32 count = object->GetPropertyCount();
-        if (Js::DynamicObject::Is(object) && Js::DynamicObject::FromVar(object)->HasObjectArray())
+        Js::DynamicObject * dynObject = JavascriptOperators::TryFromVar<Js::DynamicObject>(object);
+        if (dynObject && dynObject->HasObjectArray())
         {
             // Can't use array->GetLength() as this can be sparse array for which we stringify only real/set properties.
             // Do one walk through the elements.

--- a/lib/Runtime/Library/JavascriptArray.cpp
+++ b/lib/Runtime/Library/JavascriptArray.cpp
@@ -507,17 +507,31 @@ namespace Js
 
     JavascriptArray* JavascriptArray::FromVar(Var aValue)
     {
-        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptArray'");
+        AssertOrFailFastMsg(Is(aValue), "Ensure var is actually a 'JavascriptArray'");
 
         return static_cast<JavascriptArray *>(RecyclableObject::FromVar(aValue));
+    }
+
+    JavascriptArray* JavascriptArray::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptArray'");
+
+        return static_cast<JavascriptArray *>(RecyclableObject::UnsafeFromVar(aValue));
     }
 
     // Get JavascriptArray* from a Var, which is either a JavascriptArray* or ESArray*.
     JavascriptArray* JavascriptArray::FromAnyArray(Var aValue)
     {
-        AssertMsg(Is(aValue) || ES5Array::Is(aValue), "Ensure var is actually a 'JavascriptArray' or 'ES5Array'");
+        AssertOrFailFastMsg(Is(aValue) || ES5Array::Is(aValue), "Ensure var is actually a 'JavascriptArray' or 'ES5Array'");
 
         return static_cast<JavascriptArray *>(RecyclableObject::FromVar(aValue));
+    }
+
+    JavascriptArray* JavascriptArray::UnsafeFromAnyArray(Var aValue)
+    {
+        AssertMsg(Is(aValue) || ES5Array::Is(aValue), "Ensure var is actually a 'JavascriptArray' or 'ES5Array'");
+
+        return static_cast<JavascriptArray *>(RecyclableObject::UnsafeFromVar(aValue));
     }
 
     // Check if a Var is a direct-accessible (fast path) JavascriptArray.
@@ -3034,12 +3048,12 @@ namespace Js
         Assert(obj != nullptr);
         Assert(length != nullptr);
 
-        if (JavascriptArray::Is(arg) && !JavascriptArray::FromVar(arg)->IsCrossSiteObject())
+        *array = JavascriptOperators::TryFromVar<JavascriptArray>(arg);
+        if (*array && !(*array)->IsCrossSiteObject())
         {
 #if ENABLE_COPYONACCESS_ARRAY
-            JavascriptLibrary::CheckAndConvertCopyOnAccessNativeIntArray<Var>(arg);
+            JavascriptLibrary::CheckAndConvertCopyOnAccessNativeIntArray<Var>(*array);
 #endif
-            *array = JavascriptArray::FromVar(arg);
             *obj = *array;
             *length = (*array)->length;
         }
@@ -3084,12 +3098,11 @@ namespace Js
         BOOL firstPromotedItemIsSpreadable, BigIndex firstPromotedItemLength, bool spreadableCheckedAndTrue)
     {
         JS_REENTRANCY_LOCK(jsReentLock, scriptContext->GetThreadContext());
-        JavascriptArray* pDestArray = nullptr;
-
-        if (JavascriptArray::Is(pDestObj))
+        JavascriptArray* pDestArray = JavascriptOperators::TryFromVar<JavascriptArray>(pDestObj);
+        if (pDestArray)
         {
             // ConcatArgs function expects to work on the Var array so we are ensuring it.
-            pDestArray = EnsureNonNativeArray(JavascriptArray::FromVar(pDestObj));
+            pDestArray = EnsureNonNativeArray(pDestArray);
         }
 
         T idxDest = startIdxDest;
@@ -3117,25 +3130,28 @@ namespace Js
             }
 
             if (pDestArray && JavascriptArray::IsDirectAccessArray(aItem) && JavascriptArray::IsDirectAccessArray(pDestArray)
-                && BigIndex(idxDest + JavascriptArray::FromVar(aItem)->length).IsSmallIndex() && !JavascriptArray::FromVar(aItem)->IsFillFromPrototypes()) // Fast path
+                && BigIndex(idxDest + JavascriptArray::UnsafeFromVar(aItem)->length).IsSmallIndex() && !JavascriptArray::UnsafeFromVar(aItem)->IsFillFromPrototypes()) // Fast path
             {
-                if (JavascriptNativeIntArray::Is(aItem))
+                JavascriptNativeIntArray *pIntItemArray = JavascriptOperators::TryFromVar<JavascriptNativeIntArray>(aItem);
+                if (pIntItemArray)
                 {
-                    JavascriptNativeIntArray *pItemArray = JavascriptNativeIntArray::FromVar(aItem);
-                    JS_REENTRANT(jsReentLock, CopyNativeIntArrayElementsToVar(pDestArray, BigIndex(idxDest).GetSmallIndex(), pItemArray));
-                    idxDest = idxDest + pItemArray->length;
+                    JS_REENTRANT(jsReentLock, CopyNativeIntArrayElementsToVar(pDestArray, BigIndex(idxDest).GetSmallIndex(), pIntItemArray));
+                    idxDest = idxDest + pIntItemArray->length;
                 }
-                else if (JavascriptNativeFloatArray::Is(aItem))
+                else 
                 {
-                    JavascriptNativeFloatArray *pItemArray = JavascriptNativeFloatArray::FromVar(aItem);
-                    JS_REENTRANT(jsReentLock, CopyNativeFloatArrayElementsToVar(pDestArray, BigIndex(idxDest).GetSmallIndex(), pItemArray));
-                    idxDest = idxDest + pItemArray->length;
-                }
-                else
-                {
-                    JavascriptArray* pItemArray = JavascriptArray::FromVar(aItem);
-                    JS_REENTRANT(jsReentLock, CopyArrayElements(pDestArray, BigIndex(idxDest).GetSmallIndex(), pItemArray));
-                    idxDest = idxDest + pItemArray->length;
+                    JavascriptNativeFloatArray *pFloatItemArray = JavascriptOperators::TryFromVar<JavascriptNativeFloatArray>(aItem);
+                    if (pFloatItemArray)
+                    {
+                        JS_REENTRANT(jsReentLock, CopyNativeFloatArrayElementsToVar(pDestArray, BigIndex(idxDest).GetSmallIndex(), pFloatItemArray));
+                        idxDest = idxDest + pFloatItemArray->length;
+                    }
+                    else
+                    {
+                        JavascriptArray* pItemArray = JavascriptArray::UnsafeFromVar(aItem);
+                        JS_REENTRANT(jsReentLock, CopyArrayElements(pDestArray, BigIndex(idxDest).GetSmallIndex(), pItemArray));
+                        idxDest = idxDest + pItemArray->length;
+                    }
                 }
             }
             else
@@ -3278,10 +3294,9 @@ namespace Js
                 }
             }
 
-            if (JavascriptNativeIntArray::Is(aItem) && !JavascriptNativeIntArray::FromVar(aItem)->IsFillFromPrototypes()) // Fast path
+            JavascriptNativeIntArray * pItemArray = JavascriptOperators::TryFromVar<JavascriptNativeIntArray>(aItem);
+            if (pItemArray && !pItemArray->IsFillFromPrototypes()) // Fast path
             {
-                JavascriptNativeIntArray* pItemArray = JavascriptNativeIntArray::FromVar(aItem);
-
                 JS_REENTRANT(jsReentLock, bool converted = CopyNativeIntArrayElements(pDestArray, idxDest, pItemArray));
 
                 idxDest = idxDest + pItemArray->length;
@@ -3363,31 +3378,34 @@ namespace Js
             bool converted = false;
             if (JavascriptArray::IsAnyArray(aItem) || remoteTypeIds[idxArg] == TypeIds_Array)
             {
-                if (JavascriptNativeIntArray::Is(aItem) && !JavascriptArray::FromVar(aItem)->IsFillFromPrototypes()) // Fast path
+                bool isFillFromPrototypes = JavascriptArray::UnsafeFromVar(aItem)->IsFillFromPrototypes();
+                JavascriptNativeIntArray * pIntItemArray = JavascriptOperators::TryFromVar<JavascriptNativeIntArray>(aItem);
+                if (pIntItemArray && !isFillFromPrototypes) // Fast path
                 {
-                    JavascriptNativeIntArray *pIntArray = JavascriptNativeIntArray::FromVar(aItem);
+                    JS_REENTRANT(jsReentLock, converted = CopyNativeIntArrayElementsToFloat(pDestArray, idxDest, pIntItemArray));
 
-                    JS_REENTRANT(jsReentLock, converted = CopyNativeIntArrayElementsToFloat(pDestArray, idxDest, pIntArray));
-
-                    idxDest = idxDest + pIntArray->length;
+                    idxDest = idxDest + pIntItemArray->length;
                 }
-                else if (JavascriptNativeFloatArray::Is(aItem) && !JavascriptArray::FromVar(aItem)->IsFillFromPrototypes())
+                else 
                 {
-                    JavascriptNativeFloatArray* pItemArray = JavascriptNativeFloatArray::FromVar(aItem);
+                    JavascriptNativeFloatArray * pFloatItemArray = JavascriptOperators::TryFromVar<JavascriptNativeFloatArray>(aItem);
+                    if (pFloatItemArray && !isFillFromPrototypes)
+                    {
 
-                    JS_REENTRANT(jsReentLock, converted = CopyNativeFloatArrayElements(pDestArray, idxDest, pItemArray));
+                        JS_REENTRANT(jsReentLock, converted = CopyNativeFloatArrayElements(pDestArray, idxDest, pFloatItemArray));
 
-                    idxDest = idxDest + pItemArray->length;
-                }
-                else
-                {
-                    JavascriptArray *pVarDestArray = JavascriptNativeFloatArray::ConvertToVarArray(pDestArray);
+                        idxDest = idxDest + pFloatItemArray->length;
+                    }
+                    else
+                    {
+                        JavascriptArray *pVarDestArray = JavascriptNativeFloatArray::ConvertToVarArray(pDestArray);
 
-                    BigIndex length;
-                    JS_REENTRANT(jsReentLock, length = OP_GetLength(aItem, scriptContext),
-                        ConcatArgs<uint>(pVarDestArray, remoteTypeIds, args, scriptContext, idxArg, idxDest, spreadableCheckedAndTrue, length));
+                        BigIndex length;
+                        JS_REENTRANT(jsReentLock, length = OP_GetLength(aItem, scriptContext),
+                            ConcatArgs<uint>(pVarDestArray, remoteTypeIds, args, scriptContext, idxArg, idxDest, spreadableCheckedAndTrue, length));
 
-                    return pVarDestArray;
+                        return pVarDestArray;
+                    }
                 }
 
                 if (converted)
@@ -3586,9 +3604,10 @@ namespace Js
             }
             else if (isFloat)
             {
-                if (JavascriptNativeIntArray::Is(pDestObj))
+                JavascriptNativeIntArray *nativeIntArray = JavascriptOperators::TryFromVar<JavascriptNativeIntArray>(pDestObj);
+                if (nativeIntArray)
                 {
-                    JavascriptNativeIntArray::ToNativeFloatArray(JavascriptNativeIntArray::FromVar(pDestObj));
+                    JavascriptNativeIntArray::ToNativeFloatArray(nativeIntArray);
                     isArray = true;
                 }
                 else
@@ -3599,22 +3618,26 @@ namespace Js
             }
             else
             {
-                if (JavascriptNativeIntArray::Is(pDestObj))
+                JavascriptNativeIntArray *nativeIntArray = JavascriptOperators::TryFromVar<Js::JavascriptNativeIntArray>(pDestObj);
+                if (nativeIntArray)
                 {
-                    JavascriptNativeIntArray::ToVarArray(JavascriptNativeIntArray::FromVar(pDestObj));
-                    isArray = true;
-                }
-                else if (JavascriptNativeFloatArray::Is(pDestObj))
-                {
-                    JavascriptNativeFloatArray::ToVarArray(JavascriptNativeFloatArray::FromVar(pDestObj));
+                    JavascriptNativeIntArray::ToVarArray(nativeIntArray);
                     isArray = true;
                 }
                 else
                 {
-                    isArray = JavascriptArray::Is(pDestObj);
+                    JavascriptNativeFloatArray *nativeFloatArray = JavascriptOperators::TryFromVar<Js::JavascriptNativeFloatArray>(pDestObj);
+                    if (nativeFloatArray)
+                    {
+                        JavascriptNativeFloatArray::ToVarArray(nativeFloatArray);
+                        isArray = true;
+                    }
+                    else
+                    {
+                        isArray = JavascriptArray::Is(pDestObj);
+                    }
                 }
             }
-
         }
 
         if (pDestObj == nullptr || isArray)
@@ -3836,9 +3859,9 @@ namespace Js
                 case Js::TypeIds_Array:
                 JS_REENTRANT_UNLOCK(jsReentLock, return TemplatedIndexOfHelper<includesAlgorithm>(pArr, search, fromIndex, len, scriptContext));
                 case Js::TypeIds_NativeIntArray:
-                JS_REENTRANT_UNLOCK(jsReentLock, return TemplatedIndexOfHelper<includesAlgorithm>(JavascriptNativeIntArray::FromVar(pArr), search, fromIndex, len, scriptContext));
+                JS_REENTRANT_UNLOCK(jsReentLock, return TemplatedIndexOfHelper<includesAlgorithm>(JavascriptNativeIntArray::UnsafeFromVar(pArr), search, fromIndex, len, scriptContext));
                 case Js::TypeIds_NativeFloatArray:
-                JS_REENTRANT_UNLOCK(jsReentLock, return TemplatedIndexOfHelper<includesAlgorithm>(JavascriptNativeFloatArray::FromVar(pArr), search, fromIndex, len, scriptContext));
+                JS_REENTRANT_UNLOCK(jsReentLock, return TemplatedIndexOfHelper<includesAlgorithm>(JavascriptNativeFloatArray::UnsafeFromVar(pArr), search, fromIndex, len, scriptContext));
                 default:
                     AssertMsg(FALSE, "invalid array typeid");
                 JS_REENTRANT_UNLOCK(jsReentLock, return TemplatedIndexOfHelper<includesAlgorithm>(pArr, search, fromIndex, len, scriptContext));
@@ -3847,11 +3870,12 @@ namespace Js
         }
 
         // source object is not a JavascriptArray but source could be a TypedArray
-        if (TypedArrayBase::Is(obj))
+        TypedArrayBase * typedArrayObj = JavascriptOperators::TryFromVar<Js::TypedArrayBase>(obj);
+        if (typedArrayObj)
         {
             if (length.IsSmallIndex() || length.IsUint32Max())
             {
-                JS_REENTRANT_UNLOCK(jsReentLock, return TemplatedIndexOfHelper<includesAlgorithm>(TypedArrayBase::FromVar(obj), search, fromIndex, length.GetSmallIndex(), scriptContext));
+                JS_REENTRANT_UNLOCK(jsReentLock, return TemplatedIndexOfHelper<includesAlgorithm>(typedArrayObj, search, fromIndex, length.GetSmallIndex(), scriptContext));
             }
         }
         if (length.IsSmallIndex())
@@ -4350,15 +4374,16 @@ namespace Js
     {
         JS_REENTRANCY_LOCK(jsReentLock, scriptContext->GetThreadContext());
 
-        bool isArray = JavascriptArray::Is(thisArg) && (scriptContext == JavascriptArray::FromVar(thisArg)->GetScriptContext());
-        bool isProxy = JavascriptProxy::Is(thisArg) && (scriptContext == JavascriptProxy::FromVar(thisArg)->GetScriptContext());
+        JavascriptArray * arr = JavascriptOperators::TryFromVar<JavascriptArray>(thisArg);
+        JavascriptProxy * proxy = JavascriptOperators::TryFromVar<JavascriptProxy>(thisArg);
+        bool isArray = arr && (scriptContext == arr->GetScriptContext());
+        bool isProxy = proxy && (scriptContext == proxy->GetScriptContext());
         Var target = NULL;
         bool isTargetObjectPushed = false;
         // if we are visiting a proxy object, track that we have visited the target object as well so the next time w
         // call the join helper for the target of this proxy, we will return above.
         if (isProxy)
         {
-            JavascriptProxy* proxy = JavascriptProxy::FromVar(thisArg);
             Assert(proxy);
             target = proxy->GetTarget();
             if (target != nullptr)
@@ -4395,17 +4420,16 @@ namespace Js
 #if ENABLE_COPYONACCESS_ARRAY
                 JavascriptLibrary::CheckAndConvertCopyOnAccessNativeIntArray(thisArg);
 #endif
-                JavascriptArray * arr = JavascriptArray::FromVar(thisArg);
                 switch (arr->GetTypeId())
                 {
                 case Js::TypeIds_Array:
                     JS_REENTRANT(jsReentLock, res = JoinArrayHelper(arr, separator, scriptContext));
                     break;
                 case Js::TypeIds_NativeIntArray:
-                    JS_REENTRANT(jsReentLock, res = JoinArrayHelper(JavascriptNativeIntArray::FromVar(arr), separator, scriptContext));
+                    JS_REENTRANT(jsReentLock, res = JoinArrayHelper(JavascriptNativeIntArray::UnsafeFromVar(arr), separator, scriptContext));
                     break;
                 case Js::TypeIds_NativeFloatArray:
-                    JS_REENTRANT(jsReentLock, res = JoinArrayHelper(JavascriptNativeFloatArray::FromVar(arr), separator, scriptContext));
+                    JS_REENTRANT(jsReentLock, res = JoinArrayHelper(JavascriptNativeFloatArray::UnsafeFromVar(arr), separator, scriptContext));
                     break;
                 }
 
@@ -4666,9 +4690,9 @@ Case0:
             case Js::TypeIds_Array:
                 JS_REENTRANT_UNLOCK(jsReentLock, return LastIndexOfHelper(pArr, search, fromIndex, scriptContext));
             case Js::TypeIds_NativeIntArray:
-                JS_REENTRANT_UNLOCK(jsReentLock, return LastIndexOfHelper(JavascriptNativeIntArray::FromVar(pArr), search, fromIndex, scriptContext));
+                JS_REENTRANT_UNLOCK(jsReentLock, return LastIndexOfHelper(JavascriptNativeIntArray::UnsafeFromVar(pArr), search, fromIndex, scriptContext));
             case Js::TypeIds_NativeFloatArray:
-                JS_REENTRANT_UNLOCK(jsReentLock, return LastIndexOfHelper(JavascriptNativeFloatArray::FromVar(pArr), search, fromIndex, scriptContext));
+                JS_REENTRANT_UNLOCK(jsReentLock, return LastIndexOfHelper(JavascriptNativeFloatArray::UnsafeFromVar(pArr), search, fromIndex, scriptContext));
             default:
                 AssertMsg(FALSE, "invalid array typeid");
                 JS_REENTRANT_UNLOCK(jsReentLock, return LastIndexOfHelper(pArr, search, fromIndex, scriptContext));
@@ -4676,9 +4700,10 @@ Case0:
         }
 
         // source object is not a JavascriptArray but source could be a TypedArray
-        if (TypedArrayBase::Is(obj))
+        TypedArrayBase * typedArrayObj = JavascriptOperators::TryFromVar<Js::TypedArrayBase>(obj);
+        if (typedArrayObj)
         {
-            JS_REENTRANT_UNLOCK(jsReentLock, return LastIndexOfHelper(TypedArrayBase::FromVar(obj), search, fromIndex, scriptContext));
+            JS_REENTRANT_UNLOCK(jsReentLock, return LastIndexOfHelper(typedArrayObj, search, fromIndex, scriptContext));
         }
 
         JS_REENTRANT_UNLOCK(jsReentLock, return LastIndexOfHelper(obj, search, fromIndex, scriptContext));
@@ -4978,7 +5003,7 @@ Case0:
         // JavascriptArray::Push will handle other cases.
         if (JavascriptNativeIntArray::IsNonCrossSite(array))
         {
-            JavascriptNativeIntArray * nativeIntArray = JavascriptNativeIntArray::FromVar(array);
+            JavascriptNativeIntArray * nativeIntArray = JavascriptNativeIntArray::UnsafeFromVar(array);
             Assert(!nativeIntArray->IsCrossSiteObject());
             uint32 n = nativeIntArray->length;
 
@@ -5007,7 +5032,7 @@ Case0:
         // JavascriptArray::Push will handle other cases.
         if(JavascriptNativeFloatArray::IsNonCrossSite(array))
         {
-            JavascriptNativeFloatArray * nativeFloatArray = JavascriptNativeFloatArray::FromVar(array);
+            JavascriptNativeFloatArray * nativeFloatArray = JavascriptNativeFloatArray::UnsafeFromVar(array);
             Assert(!nativeFloatArray->IsCrossSiteObject());
             uint32 n = nativeFloatArray->length;
 
@@ -5356,7 +5381,7 @@ Case0:
                 }
                 else if (DynamicType::Is(protoObj->GetTypeId()))
                 {
-                    DynamicObject* dynobj = DynamicObject::FromVar(protoObj);
+                    DynamicObject* dynobj = DynamicObject::UnsafeFromVar(protoObj);
                     ArrayObject* objectArray = dynobj->GetObjectArray();
                     if (objectArray != nullptr && ES5Array::Is(objectArray))
                     {
@@ -5395,7 +5420,7 @@ Case0:
         // If we came from Array.prototype.map and source object is not a JavascriptArray, source could be a TypedArray
         if (!isTypedArrayEntryPoint && pArr == nullptr && TypedArrayBase::Is(obj))
         {
-            typedArrayBase = TypedArrayBase::FromVar(obj);
+            typedArrayBase = TypedArrayBase::UnsafeFromVar(obj);
         }
 
         ThrowTypeErrorOnFailureHelper h(scriptContext, methodName);
@@ -5755,11 +5780,11 @@ Case0:
 
         bool useNoSideEffectShift = JavascriptArray::Is(args[0])
             && !JavascriptArray::FromVar(args[0])->IsCrossSiteObject()
-            && !HasAnyES5ArrayInPrototypeChain(JavascriptArray::FromVar(args[0]));
+            && !HasAnyES5ArrayInPrototypeChain(JavascriptArray::UnsafeFromVar(args[0]));
 
         if (useNoSideEffectShift)
         {
-            JavascriptArray * pArr = JavascriptArray::FromVar(args[0]);
+            JavascriptArray * pArr = JavascriptArray::UnsafeFromVar(args[0]);
 
             if (pArr->length == 0)
             {
@@ -5945,7 +5970,7 @@ Case0:
             Js::JavascriptNativeIntArray *pnewArr = scriptContext->GetLibrary()->CreateNativeIntArray(len);
             pnewArr->EnsureHead<int32>();
 #if ENABLE_PROFILE_INFO
-            pnewArr->CopyArrayProfileInfo(Js::JavascriptNativeIntArray::FromVar(baseArray));
+            pnewArr->CopyArrayProfileInfo(Js::JavascriptNativeIntArray::UnsafeFromVar(baseArray));
 #endif
 
             return pnewArr;
@@ -5955,7 +5980,7 @@ Case0:
             Js::JavascriptNativeFloatArray *pnewArr  = scriptContext->GetLibrary()->CreateNativeFloatArray(len);
             pnewArr->EnsureHead<double>();
 #if ENABLE_PROFILE_INFO
-            pnewArr->CopyArrayProfileInfo(Js::JavascriptNativeFloatArray::FromVar(baseArray));
+            pnewArr->CopyArrayProfileInfo(Js::JavascriptNativeFloatArray::UnsafeFromVar(baseArray));
 #endif
 
             return pnewArr;
@@ -6020,10 +6045,10 @@ Case0:
     // in the profile
     void JavascriptArray::GetArrayTypeAndConvert(bool* isIntArray, bool* isFloatArray)
     {
-        if (JavascriptNativeIntArray::Is(this))
+        JavascriptNativeIntArray* nativeIntArray = JavascriptOperators::TryFromVar<JavascriptNativeIntArray>(this);
+        if (nativeIntArray)
         {
 #if ENABLE_PROFILE_INFO
-            JavascriptNativeIntArray* nativeIntArray = JavascriptNativeIntArray::FromVar(this);
             ArrayCallSiteInfo* info = nativeIntArray->GetArrayCallSiteInfo();
             if(!info || info->IsNativeIntArray())
             {
@@ -6042,23 +6067,26 @@ Case0:
             *isIntArray = true;
 #endif
         }
-        else if (JavascriptNativeFloatArray::Is(this))
+        else 
         {
+            JavascriptNativeFloatArray* nativeFloatArray = JavascriptOperators::TryFromVar<JavascriptNativeFloatArray>(this);
+            if (nativeFloatArray)
+            {
 #if ENABLE_PROFILE_INFO
-            JavascriptNativeFloatArray* nativeFloatArray = JavascriptNativeFloatArray::FromVar(this);
-            ArrayCallSiteInfo* info = nativeFloatArray->GetArrayCallSiteInfo();
+                ArrayCallSiteInfo* info = nativeFloatArray->GetArrayCallSiteInfo();
 
-            if(info && !info->IsNativeArray())
-            {
-                JavascriptNativeFloatArray::ToVarArray(nativeFloatArray);
-            }
-            else
-            {
-                *isFloatArray = true;
-            }
+                if (info && !info->IsNativeArray())
+                {
+                    JavascriptNativeFloatArray::ToVarArray(nativeFloatArray);
+                }
+                else
+                {
+                    *isFloatArray = true;
+                }
 #else
-            *isFloatArray = true;
+                *isFloatArray = true;
 #endif
+            }
         }
     }
 
@@ -6140,7 +6168,7 @@ Case0:
         // If we came from Array.prototype.slice and source object is not a JavascriptArray, source could be a TypedArray
         if (!isTypedArrayEntryPoint && pArr == nullptr && TypedArrayBase::Is(obj))
         {
-            typedArrayBase = TypedArrayBase::FromVar(obj);
+            typedArrayBase = TypedArrayBase::UnsafeFromVar(obj);
         }
 
         // If the entry point is %TypedArray%.prototype.slice or the source object is an Array exotic object we should try to load the constructor property
@@ -6193,12 +6221,12 @@ Case0:
         else
         {
             // If the new object we created is an array, remember that as it will save us time setting properties in the object below
-            if (JavascriptArray::Is(newObj))
+            newArr = JavascriptOperators::TryFromVar<JavascriptArray>(newObj);
+            if (newArr)
             {
 #if ENABLE_COPYONACCESS_ARRAY
-                JavascriptLibrary::CheckAndConvertCopyOnAccessNativeIntArray<Var>(newObj);
+                JavascriptLibrary::CheckAndConvertCopyOnAccessNativeIntArray<Var>(newArr);
 #endif
-                newArr = JavascriptArray::FromVar(newObj);
             }
         }
 
@@ -6319,13 +6347,9 @@ Case0:
             AssertAndFailFast(TypedArrayBase::Is(typedArrayBase));
 
             // Source is a TypedArray, we must have created the return object via a call to constructor, but newObj may not be a TypedArray (or an array either)
-            TypedArrayBase* newTypedArray = nullptr;
+            TypedArrayBase* newTypedArray = JavascriptOperators::TryFromVar<Js::TypedArrayBase>(newObj);
 
-            if (TypedArrayBase::Is(newObj))
-            {
-                newTypedArray = TypedArrayBase::FromVar(newObj);
-            }
-            else
+            if (!newTypedArray)
             {
                 AssertAndFailFast(newArr != nullptr);
             }
@@ -6364,9 +6388,10 @@ Case0:
         }
 
 #ifdef VALIDATE_ARRAY
-        if (JavascriptArray::Is(newObj))
+        JavascriptArray * jsArr = JavascriptOperators::TryFromVar<JavascriptArray>(newObj);
+        if (jsArr)
         {
-            JavascriptArray::FromVar(newObj)->ValidateArray();
+            jsArr->ValidateArray();
         }
 #endif
 
@@ -6398,9 +6423,10 @@ Case0:
                 JavascriptOperators::SetProperty(newObj, newObj, Js::PropertyIds::length, JavascriptNumber::ToVar(newLen, scriptContext), scriptContext, PropertyOperation_ThrowIfNotExtensible));
 
 #ifdef VALIDATE_ARRAY
-        if (JavascriptArray::Is(newObj))
+        JavascriptArray * jsArr = JavascriptOperators::TryFromVar<JavascriptArray>(newObj);
+        if (jsArr)
         {
-            JavascriptArray::FromVar(newObj)->ValidateArray();
+            jsArr->ValidateArray();
         }
 #endif
 
@@ -6793,11 +6819,11 @@ Case0:
 
         bool useNoSideEffectSort = JavascriptArray::Is(args[0])
             && !JavascriptArray::FromVar(args[0])->IsCrossSiteObject()
-            && !HasAnyES5ArrayInPrototypeChain(JavascriptArray::FromVar(args[0]));
+            && !HasAnyES5ArrayInPrototypeChain(JavascriptArray::UnsafeFromVar(args[0]));
 
         if (useNoSideEffectSort)
         {
-            JavascriptArray *arr = JavascriptArray::FromVar(args[0]);
+            JavascriptArray *arr = JavascriptArray::UnsafeFromVar(args[0]);
 
             if (arr->length <= 1)
             {
@@ -7409,12 +7435,12 @@ Case0:
         {
             pArr = EnsureNonNativeArray(pArr);
             // If the new object we created is an array, remember that as it will save us time setting properties in the object below
-            if (JavascriptArray::Is(newObj))
+            newArr = JavascriptOperators::TryFromVar<JavascriptArray>(newObj);
+            if (newArr)
             {
 #if ENABLE_COPYONACCESS_ARRAY
-                JavascriptLibrary::CheckAndConvertCopyOnAccessNativeIntArray<Var>(newObj);
+                JavascriptLibrary::CheckAndConvertCopyOnAccessNativeIntArray<Var>(newArr);
 #endif
-                newArr = JavascriptArray::FromVar(newObj);
             }
         }
         else
@@ -7577,12 +7603,12 @@ Case0:
             }
         }
 
-        if (JavascriptArray::Is(pNewObj))
+        pnewArr = JavascriptOperators::TryFromVar<JavascriptArray>(pNewObj);
+        if (pnewArr)
         {
 #if ENABLE_COPYONACCESS_ARRAY
-            JavascriptLibrary::CheckAndConvertCopyOnAccessNativeIntArray<Var>(pNewObj);
+            JavascriptLibrary::CheckAndConvertCopyOnAccessNativeIntArray<Var>(pnewArr);
 #endif
-            pnewArr = JavascriptArray::FromVar(pNewObj);
         }
 
         // copy elements to delete to new array
@@ -7691,7 +7717,7 @@ Case0:
 
         if (JavascriptArray::IsDirectAccessArray(args[0]))
         {
-            JavascriptArray* arr = JavascriptArray::FromVar(args[0]);
+            JavascriptArray* arr = JavascriptArray::UnsafeFromVar(args[0]);
             JS_REENTRANT_UNLOCK(jsReentLock, return ToLocaleString(arr, scriptContext));
         }
         else
@@ -8133,10 +8159,11 @@ Case0:
         JS_REENTRANCY_LOCK(jsReentLock, scriptContext->GetThreadContext());
 
         uint32 length = 0;
-        if (TypedArrayBase::Is(arr))
+        TypedArrayBase * typedArray = JavascriptOperators::TryFromVar<Js::TypedArrayBase>(arr);
+        if (typedArray)
         {
             // For a TypedArray use the actual length of the array.
-            length = TypedArrayBase::FromVar(arr)->GetLength();
+            length = typedArray->GetLength();
         }
         else
         {
@@ -8285,7 +8312,7 @@ Case0:
         // If we came from Array.prototype.find/findIndex and source object is not a JavascriptArray, source could be a TypedArray
         if (typedArrayBase == nullptr && pArr == nullptr && TypedArrayBase::Is(obj))
         {
-            typedArrayBase = TypedArrayBase::FromVar(obj);
+            typedArrayBase = TypedArrayBase::UnsafeFromVar(obj);
         }
 
         // The correct flag value is CallFlags_Value but we pass CallFlags_None in compat modes
@@ -8579,7 +8606,7 @@ Case0:
         // If we came from Array.prototype.map and source object is not a JavascriptArray, source could be a TypedArray
         if (typedArrayBase == nullptr && pArr == nullptr && TypedArrayBase::Is(obj))
         {
-            typedArrayBase = TypedArrayBase::FromVar(obj);
+            typedArrayBase = TypedArrayBase::UnsafeFromVar(obj);
         }
 
         Var element = nullptr;
@@ -8750,7 +8777,7 @@ Case0:
         // If we came from Array.prototype.some and source object is not a JavascriptArray, source could be a TypedArray
         if (typedArrayBase == nullptr && pArr == nullptr && TypedArrayBase::Is(obj))
         {
-            typedArrayBase = TypedArrayBase::FromVar(obj);
+            typedArrayBase = TypedArrayBase::UnsafeFromVar(obj);
         }
 
         // The correct flag value is CallFlags_Value but we pass CallFlags_None in compat modes
@@ -8967,7 +8994,7 @@ Case0:
         // If we came from Array.prototype.copyWithin and source object is not a JavascriptArray, source could be a TypedArray
         if (typedArrayBase == nullptr && pArr == nullptr && TypedArrayBase::Is(obj))
         {
-            typedArrayBase = TypedArrayBase::FromVar(obj);
+            typedArrayBase = TypedArrayBase::UnsafeFromVar(obj);
         }
 
         if (args.Info.Count > 1)
@@ -9130,7 +9157,7 @@ Case0:
         // If we came from Array.prototype.fill and source object is not a JavascriptArray, source could be a TypedArray
         if (typedArrayBase == nullptr && pArr == nullptr && TypedArrayBase::Is(obj))
         {
-            typedArrayBase = TypedArrayBase::FromVar(obj);
+            typedArrayBase = TypedArrayBase::UnsafeFromVar(obj);
         }
 
         Var fillValue;
@@ -9298,7 +9325,7 @@ Case0:
         // If we came from Array.prototype.map and source object is not a JavascriptArray, source could be a TypedArray
         if (!isTypedArrayEntryPoint && pArr == nullptr && TypedArrayBase::Is(obj))
         {
-            typedArrayBase = TypedArrayBase::FromVar(obj);
+            typedArrayBase = TypedArrayBase::UnsafeFromVar(obj);
         }
 
         // If the entry point is %TypedArray%.prototype.map or the source object is an Array exotic object we should try to load the constructor property
@@ -9336,12 +9363,12 @@ Case0:
         else
         {
             // If the new object we created is an array, remember that as it will save us time setting properties in the object below
-            if (JavascriptArray::Is(newObj))
+            newArr = JavascriptOperators::TryFromVar<JavascriptArray>(newObj);
+            if (newArr)
             {
 #if ENABLE_COPYONACCESS_ARRAY
-                JavascriptLibrary::CheckAndConvertCopyOnAccessNativeIntArray<Var>(newObj);
+                JavascriptLibrary::CheckAndConvertCopyOnAccessNativeIntArray<Var>(newArr);
 #endif
-                newArr = JavascriptArray::FromVar(newObj);
             }
         }
 
@@ -9404,13 +9431,9 @@ Case0:
             AssertAndFailFast(TypedArrayBase::Is(typedArrayBase));
 
             // Source is a TypedArray, we may have tried to call a constructor, but newObj may not be a TypedArray (or an array either)
-            TypedArrayBase* newTypedArray = nullptr;
+            TypedArrayBase* newTypedArray = JavascriptOperators::TryFromVar<Js::TypedArrayBase>(newObj);
 
-            if (TypedArrayBase::Is(newObj))
-            {
-                newTypedArray = TypedArrayBase::FromVar(newObj);
-            }
-            else
+            if (!newTypedArray)
             {
                 AssertAndFailFast(newArr != nullptr);
             }
@@ -9568,12 +9591,12 @@ Case0:
         else
         {
             // If the new object we created is an array, remember that as it will save us time setting properties in the object below
-            if (JavascriptArray::Is(newObj))
+            newArr = JavascriptOperators::TryFromVar<JavascriptArray>(newObj);
+            if (newArr)
             {
 #if ENABLE_COPYONACCESS_ARRAY
-                JavascriptLibrary::CheckAndConvertCopyOnAccessNativeIntArray<Var>(newObj);
+                JavascriptLibrary::CheckAndConvertCopyOnAccessNativeIntArray<Var>(newArr);
 #endif
-                newArr = JavascriptArray::FromVar(newObj);
             }
         }
 
@@ -9751,7 +9774,7 @@ Case0:
         // If we came from Array.prototype.reduce and source object is not a JavascriptArray, source could be a TypedArray
         if (typedArrayBase == nullptr && pArr == nullptr && TypedArrayBase::Is(obj))
         {
-            typedArrayBase = TypedArrayBase::FromVar(obj);
+            typedArrayBase = TypedArrayBase::UnsafeFromVar(obj);
         }
 
         T k = 0;
@@ -9969,7 +9992,7 @@ Case0:
         // If we came from Array.prototype.reduceRight and source object is not a JavascriptArray, source could be a TypedArray
         if (typedArrayBase == nullptr && pArr == nullptr && TypedArrayBase::Is(obj))
         {
-            typedArrayBase = TypedArrayBase::FromVar(obj);
+            typedArrayBase = TypedArrayBase::UnsafeFromVar(obj);
         }
 
         RecyclableObject* callBackFn = RecyclableObject::FromVar(args[1]);
@@ -10162,14 +10185,13 @@ Case0:
             JavascriptError::ThrowTypeError(scriptContext, JSERR_FunctionArgument_NeedObject, _u("Array.from"));
         }
 
-        JavascriptArray* itemsArr = nullptr;
+        JavascriptArray* itemsArr = JavascriptOperators::TryFromVar<JavascriptArray>(items);
 
-        if (JavascriptArray::Is(items))
+        if (itemsArr)
         {
 #if ENABLE_COPYONACCESS_ARRAY
-            JavascriptLibrary::CheckAndConvertCopyOnAccessNativeIntArray<Var>(items);
+            JavascriptLibrary::CheckAndConvertCopyOnAccessNativeIntArray<Var>(itemsArr);
 #endif
-            itemsArr = JavascriptArray::FromVar(items);
         }
 
         bool mapping = false;
@@ -10210,12 +10232,12 @@ Case0:
                 Js::CallInfo constructorCallInfo(Js::CallFlags_New, _countof(constructorArgs));
                 JS_REENTRANT(jsReentLock, newObj = RecyclableObject::FromVar(JavascriptOperators::NewScObject(constructor, Js::Arguments(constructorCallInfo, constructorArgs), scriptContext)));
 
-                if (JavascriptArray::Is(newObj))
+                newArr = JavascriptOperators::TryFromVar<JavascriptArray>(newObj);
+                if (newArr)
                 {
 #if ENABLE_COPYONACCESS_ARRAY
-                    JavascriptLibrary::CheckAndConvertCopyOnAccessNativeIntArray<Var>(newObj);
+                    JavascriptLibrary::CheckAndConvertCopyOnAccessNativeIntArray<Var>(newArr);
 #endif
-                    newArr = JavascriptArray::FromVar(newObj);
                 }
             }
             else
@@ -10261,12 +10283,12 @@ Case0:
                 Js::CallInfo constructorCallInfo(Js::CallFlags_New, _countof(constructorArgs));
                 JS_REENTRANT(jsReentLock, newObj = RecyclableObject::FromVar(JavascriptOperators::NewScObject(constructor, Js::Arguments(constructorCallInfo, constructorArgs), scriptContext)));
 
-                if (JavascriptArray::Is(newObj))
+                newArr = JavascriptOperators::TryFromVar<JavascriptArray>(newObj);
+                if (newArr)
                 {
 #if ENABLE_COPYONACCESS_ARRAY
-                    JavascriptLibrary::CheckAndConvertCopyOnAccessNativeIntArray<Var>(newObj);
+                    JavascriptLibrary::CheckAndConvertCopyOnAccessNativeIntArray<Var>(newArr);
 #endif
-                    newArr = JavascriptArray::FromVar(newObj);
                 }
             }
             else
@@ -10381,16 +10403,16 @@ Case0:
             }
 
             // If the new object we created is an array, remember that as it will save us time setting properties in the object below
-            if (JavascriptArray::Is(newObj))
+            newArr = JavascriptOperators::TryFromVar<JavascriptArray>(newObj);
+            if (newArr)
             {
 #if ENABLE_COPYONACCESS_ARRAY
-                JavascriptLibrary::CheckAndConvertCopyOnAccessNativeIntArray<Var>(newObj);
+                JavascriptLibrary::CheckAndConvertCopyOnAccessNativeIntArray<Var>(newArr);
 #endif
-                newArr = JavascriptArray::FromVar(newObj);
             }
             else if (TypedArrayBase::Is(newObj))
             {
-                newTypedArray = TypedArrayBase::FromVar(newObj);
+                newTypedArray = TypedArrayBase::UnsafeFromVar(newObj);
             }
         }
         else
@@ -10556,13 +10578,13 @@ Case0:
         JavascriptArray* arr = nullptr;
         if (DynamicObject::IsAnyArray(obj))
         {
-            arr = JavascriptArray::FromAnyArray(obj);
+            arr = JavascriptArray::UnsafeFromAnyArray(obj);
         }
         else if (DynamicType::Is(obj->GetTypeId()))
         {
-            DynamicObject* dynobj = DynamicObject::FromVar(obj);
+            DynamicObject* dynobj = DynamicObject::UnsafeFromVar(obj);
             ArrayObject* objectArray = dynobj->GetObjectArray();
-            arr = (objectArray && JavascriptArray::IsAnyArray(objectArray)) ? JavascriptArray::FromAnyArray(objectArray) : nullptr;
+            arr = (objectArray && JavascriptArray::IsAnyArray(objectArray)) ? JavascriptArray::UnsafeFromAnyArray(objectArray) : nullptr;
         }
 
         if (arr != nullptr)
@@ -11124,17 +11146,22 @@ Case0:
 #if ENABLE_COPYONACCESS_ARRAY
         JavascriptLibrary::CheckAndConvertCopyOnAccessNativeIntArray<Var>(dstArray);
 #endif
-        if (JavascriptNativeIntArray::Is(srcArray))
+        JavascriptNativeIntArray * nativeIntArray = JavascriptOperators::TryFromVar<JavascriptNativeIntArray>(srcArray);
+        if (nativeIntArray)
         {
-            CopyNativeIntArrayElementsToVar(dstArray, dstIndex, JavascriptNativeIntArray::FromVar(srcArray), start, end);
-        }
-        else if (JavascriptNativeFloatArray::Is(srcArray))
-        {
-            CopyNativeFloatArrayElementsToVar(dstArray, dstIndex, JavascriptNativeFloatArray::FromVar(srcArray), start, end);
+            CopyNativeIntArrayElementsToVar(dstArray, dstIndex, nativeIntArray, start, end);
         }
         else
         {
-            CopyArrayElements(dstArray, dstIndex, srcArray, start, end);
+            JavascriptNativeFloatArray * nativeFloatArray = JavascriptOperators::TryFromVar<JavascriptNativeFloatArray>(srcArray);
+            if (nativeFloatArray)
+            {
+                CopyNativeFloatArrayElementsToVar(dstArray, dstIndex, nativeFloatArray, start, end);
+            }
+            else
+            {
+                CopyArrayElements(dstArray, dstIndex, srcArray, start, end);
+            }
         }
     }
 
@@ -11377,9 +11404,9 @@ Case0:
 
             // An array needs a slow copy if it is a cross-site object or we have missing values that need to be set to undefined.
             auto needArraySlowCopy = [&](Var instance) {
-                if (JavascriptArray::Is(instance))
+                JavascriptArray *arr = JavascriptOperators::TryFromVar<JavascriptArray>(instance);
+                if (arr)
                 {
-                    JavascriptArray *arr = JavascriptArray::FromVar(instance);
                     JS_REENTRANT_UNLOCK(jsReentLock, return arr->IsCrossSiteObject() || arr->IsFillFromPrototypes());
                 }
                 return false;
@@ -11476,15 +11503,15 @@ Case0:
         // A spread argument can be anything that returns a 'length' property, even if that
         // property is null or undefined.
         spreadArg = CrossSite::MarshalVar(scriptContext, spreadArg);
-        if (JavascriptArray::Is(spreadArg))
+        JavascriptArray *arr = JavascriptOperators::TryFromVar<JavascriptArray>(spreadArg);
+        if (arr)
         {
-            JavascriptArray *arr = JavascriptArray::FromVar(spreadArg);
             return arr->GetLength();
         }
 
-        if (TypedArrayBase::Is(spreadArg))
+        TypedArrayBase *tarr = JavascriptOperators::TryFromVar<Js::TypedArrayBase>(spreadArg);
+        if (tarr)
         {
-            TypedArrayBase *tarr = TypedArrayBase::FromVar(spreadArg);
             return tarr->GetLength();
         }
 
@@ -11911,8 +11938,8 @@ Case0:
         }
 
         if (JavascriptArray::Is(originalArray)
-            && !DynamicObject::FromVar(originalArray)->GetDynamicType()->GetTypeHandler()->GetIsNotPathTypeHandlerOrHasUserDefinedCtor()
-            && DynamicObject::FromVar(originalArray)->GetPrototype() == scriptContext->GetLibrary()->GetArrayPrototype()
+            && !DynamicObject::UnsafeFromVar(originalArray)->GetDynamicType()->GetTypeHandler()->GetIsNotPathTypeHandlerOrHasUserDefinedCtor()
+            && DynamicObject::UnsafeFromVar(originalArray)->GetPrototype() == scriptContext->GetLibrary()->GetArrayPrototype()
             && !scriptContext->GetLibrary()->GetArrayObjectHasUserDefinedSpecies())
         {
             return nullptr;
@@ -11922,14 +11949,14 @@ Case0:
 
         if (JavascriptOperators::IsArray(originalArray))
         {
-            if (!JavascriptOperators::GetProperty(RecyclableObject::FromVar(originalArray), PropertyIds::constructor, &constructor, scriptContext))
+            if (!JavascriptOperators::GetProperty(RecyclableObject::UnsafeFromVar(originalArray), PropertyIds::constructor, &constructor, scriptContext))
             {
                 return nullptr;
             }
 
             if (JavascriptOperators::IsConstructor(constructor))
             {
-                ScriptContext* constructorScriptContext = RecyclableObject::FromVar(constructor)->GetScriptContext();
+                ScriptContext* constructorScriptContext = RecyclableObject::UnsafeFromVar(constructor)->GetScriptContext();
                 if (constructorScriptContext != scriptContext)
                 {
                     if (constructorScriptContext->GetLibrary()->GetArrayConstructor() == constructor)
@@ -12689,9 +12716,16 @@ Case0:
 
     JavascriptNativeArray* JavascriptNativeArray::FromVar(Var aValue)
     {
-        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptNativeArray'");
+        AssertOrFailFastMsg(Is(aValue), "Ensure var is actually a 'JavascriptNativeArray'");
 
         return static_cast<JavascriptNativeArray *>(RecyclableObject::FromVar(aValue));
+    }
+
+    JavascriptNativeArray* JavascriptNativeArray::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptNativeArray'");
+
+        return static_cast<JavascriptNativeArray *>(RecyclableObject::UnsafeFromVar(aValue));
     }
 
     bool JavascriptNativeIntArray::Is(Var aValue)
@@ -12729,18 +12763,33 @@ Case0:
 
     JavascriptNativeIntArray* JavascriptNativeIntArray::FromVar(Var aValue)
     {
-        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptNativeIntArray'");
+        AssertOrFailFastMsg(Is(aValue), "Ensure var is actually a 'JavascriptNativeIntArray'");
 
         return static_cast<JavascriptNativeIntArray *>(RecyclableObject::FromVar(aValue));
+    }
+
+    JavascriptNativeIntArray* JavascriptNativeIntArray::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptNativeIntArray'");
+
+        return static_cast<JavascriptNativeIntArray *>(RecyclableObject::UnsafeFromVar(aValue));
     }
 
 #if ENABLE_COPYONACCESS_ARRAY
     JavascriptCopyOnAccessNativeIntArray* JavascriptCopyOnAccessNativeIntArray::FromVar(Var aValue)
     {
-        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptCopyOnAccessNativeIntArray'");
+        AssertOrFailFastMsg(Is(aValue), "Ensure var is actually a 'JavascriptCopyOnAccessNativeIntArray'");
 
         return static_cast<JavascriptCopyOnAccessNativeIntArray *>(RecyclableObject::FromVar(aValue));
     }
+
+    JavascriptCopyOnAccessNativeIntArray* JavascriptCopyOnAccessNativeIntArray::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptCopyOnAccessNativeIntArray'");
+
+        return static_cast<JavascriptCopyOnAccessNativeIntArray *>(RecyclableObject::UnsafeFromVar(aValue));
+    }
+
 #endif
 
     bool JavascriptNativeFloatArray::Is(Var aValue)
@@ -12763,9 +12812,16 @@ Case0:
 
     JavascriptNativeFloatArray* JavascriptNativeFloatArray::FromVar(Var aValue)
     {
-        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptNativeFloatArray'");
+        AssertOrFailFastMsg(Is(aValue), "Ensure var is actually a 'JavascriptNativeFloatArray'");
 
         return static_cast<JavascriptNativeFloatArray *>(RecyclableObject::FromVar(aValue));
+    }
+
+    JavascriptNativeFloatArray* JavascriptNativeFloatArray::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptNativeFloatArray'");
+
+        return static_cast<JavascriptNativeFloatArray *>(RecyclableObject::UnsafeFromVar(aValue));
     }
 
     template int   Js::JavascriptArray::GetParamForIndexOf<unsigned int>(unsigned int, Js::Arguments const&, void*&, unsigned int&, Js::ScriptContext*);

--- a/lib/Runtime/Library/JavascriptArray.h
+++ b/lib/Runtime/Library/JavascriptArray.h
@@ -208,11 +208,13 @@ namespace Js
         static bool Is(Var aValue);
         static bool Is(TypeId typeId);
         static JavascriptArray* FromVar(Var aValue);
+        static JavascriptArray* UnsafeFromVar(Var aValue);
 
         static bool IsVarArray(Var aValue);
         static bool IsVarArray(TypeId typeId);
 
         static JavascriptArray* FromAnyArray(Var aValue);
+        static JavascriptArray* UnsafeFromAnyArray(Var aValue);
         static bool IsDirectAccessArray(Var aValue);
         static bool IsInlineSegment(SparseArraySegmentBase *seg, JavascriptArray *pArr);
 
@@ -953,6 +955,7 @@ namespace Js
         static bool Is(Var aValue);
         static bool Is(TypeId typeId);
         static JavascriptNativeArray* FromVar(Var aValue);
+        static JavascriptNativeArray* UnsafeFromVar(Var aValue);
 
         void SetArrayCallSite(ProfileId index, RecyclerWeakReference<FunctionBody> *weakRef)
         {
@@ -1013,6 +1016,7 @@ namespace Js
         static bool Is(Var aValue);
         static bool Is(TypeId typeId);
         static JavascriptNativeIntArray* FromVar(Var aValue);
+        static JavascriptNativeIntArray* UnsafeFromVar(Var aValue);
         static bool IsNonCrossSite(Var aValue);
 
         typedef int32 TElement;
@@ -1111,6 +1115,7 @@ namespace Js
         static bool Is(Var aValue);
         static bool Is(TypeId typeId);
         static JavascriptCopyOnAccessNativeIntArray* FromVar(Var aValue);
+        static JavascriptCopyOnAccessNativeIntArray* UnsafeFromVar(Var aValue);
 
         static DynamicType * GetInitialType(ScriptContext * scriptContext);
         void ConvertCopyOnAccessSegment();
@@ -1177,6 +1182,7 @@ namespace Js
         static bool Is(Var aValue);
         static bool Is(TypeId typeId);
         static JavascriptNativeFloatArray* FromVar(Var aValue);
+        static JavascriptNativeFloatArray* UnsafeFromVar(Var aValue);
         static bool IsNonCrossSite(Var aValue);
 
         typedef double TElement;

--- a/lib/Runtime/Library/JavascriptArrayIterator.cpp
+++ b/lib/Runtime/Library/JavascriptArrayIterator.cpp
@@ -27,9 +27,16 @@ namespace Js
 
     JavascriptArrayIterator* JavascriptArrayIterator::FromVar(Var aValue)
     {
-        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptArrayIterator'");
+        AssertOrFailFastMsg(Is(aValue), "Ensure var is actually a 'JavascriptArrayIterator'");
 
         return static_cast<JavascriptArrayIterator *>(RecyclableObject::FromVar(aValue));
+    }
+
+    JavascriptArrayIterator* JavascriptArrayIterator::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptArrayIterator'");
+
+        return static_cast<JavascriptArrayIterator *>(RecyclableObject::UnsafeFromVar(aValue));
     }
 
     Var JavascriptArrayIterator::EntryNext(RecyclableObject* function, CallInfo callInfo, ...)
@@ -70,7 +77,7 @@ namespace Js
         }
         else if (TypedArrayBase::Is(iterable))
         {
-            typedArrayBase = TypedArrayBase::FromVar(iterable);
+            typedArrayBase = TypedArrayBase::UnsafeFromVar(iterable);
             if (typedArrayBase->IsDetachedBuffer())
             {
                 JavascriptError::ThrowTypeError(scriptContext, JSERR_DetachedTypedArray);

--- a/lib/Runtime/Library/JavascriptArrayIterator.h
+++ b/lib/Runtime/Library/JavascriptArrayIterator.h
@@ -29,6 +29,7 @@ namespace Js
 
         static bool Is(Var aValue);
         static JavascriptArrayIterator* FromVar(Var aValue);
+        static JavascriptArrayIterator* UnsafeFromVar(Var aValue);
 
         class EntryInfo
         {

--- a/lib/Runtime/Library/JavascriptBoolean.h
+++ b/lib/Runtime/Library/JavascriptBoolean.h
@@ -22,6 +22,7 @@ namespace Js
 
         static inline bool Is(Var aValue);
         static inline JavascriptBoolean* FromVar(Var aValue);
+        static inline JavascriptBoolean* UnsafeFromVar(Var aValue);
         static Var ToVar(BOOL fValue,ScriptContext* scriptContext);
 
         class EntryInfo

--- a/lib/Runtime/Library/JavascriptBoolean.inl
+++ b/lib/Runtime/Library/JavascriptBoolean.inl
@@ -15,9 +15,15 @@ namespace Js
 
     inline JavascriptBoolean* JavascriptBoolean::FromVar(Js::Var aValue)
     {
-        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptBoolean'");
+        AssertOrFailFastMsg(Is(aValue), "Ensure var is actually a 'JavascriptBoolean'");
 
         return static_cast<JavascriptBoolean *>(RecyclableObject::FromVar(aValue));
     }
 
+    inline JavascriptBoolean* JavascriptBoolean::UnsafeFromVar(Js::Var aValue)
+    {
+        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptBoolean'");
+
+        return static_cast<JavascriptBoolean *>(RecyclableObject::UnsafeFromVar(aValue));
+    }
 } // namespace Js

--- a/lib/Runtime/Library/JavascriptBooleanObject.cpp
+++ b/lib/Runtime/Library/JavascriptBooleanObject.cpp
@@ -19,9 +19,16 @@ namespace Js
 
     JavascriptBooleanObject* JavascriptBooleanObject::FromVar(Js::Var aValue)
     {
-        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptBooleanObject'");
+        AssertOrFailFastMsg(Is(aValue), "Ensure var is actually a 'JavascriptBooleanObject'");
 
         return static_cast<JavascriptBooleanObject *>(RecyclableObject::FromVar(aValue));
+    }
+
+    JavascriptBooleanObject* JavascriptBooleanObject::UnsafeFromVar(Js::Var aValue)
+    {
+        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptBooleanObject'");
+
+        return static_cast<JavascriptBooleanObject *>(RecyclableObject::UnsafeFromVar(aValue));
     }
 
     BOOL JavascriptBooleanObject::GetValue() const

--- a/lib/Runtime/Library/JavascriptBooleanObject.h
+++ b/lib/Runtime/Library/JavascriptBooleanObject.h
@@ -17,6 +17,7 @@ namespace Js
         JavascriptBooleanObject(JavascriptBoolean* value, DynamicType * type);
         static bool Is(Var aValue);
         static JavascriptBooleanObject* FromVar(Js::Var aValue);
+        static JavascriptBooleanObject* UnsafeFromVar(Js::Var aValue);
 
         BOOL GetValue() const;
         void Initialize(JavascriptBoolean* value);

--- a/lib/Runtime/Library/JavascriptDate.cpp
+++ b/lib/Runtime/Library/JavascriptDate.cpp
@@ -31,9 +31,16 @@ namespace Js
 
     JavascriptDate* JavascriptDate::FromVar(Var aValue)
     {
-        AssertMsg(Is(aValue), "Ensure var is actually a 'Date'");
+        AssertOrFailFastMsg(Is(aValue), "Ensure var is actually a 'Date'");
 
         return static_cast<JavascriptDate *>(RecyclableObject::FromVar(aValue));
+    }
+
+    JavascriptDate* JavascriptDate::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(Is(aValue), "Ensure var is actually a 'Date'");
+
+        return static_cast<JavascriptDate *>(RecyclableObject::UnsafeFromVar(aValue));
     }
 
     Var JavascriptDate::GetDateData(JavascriptDate* date, DateImplementation::DateData dd, ScriptContext* scriptContext)

--- a/lib/Runtime/Library/JavascriptDate.h
+++ b/lib/Runtime/Library/JavascriptDate.h
@@ -24,6 +24,7 @@ namespace Js
 
         double GetTime() { return m_date.GetMilliSeconds(); }
         static JavascriptDate* FromVar(Var aValue);
+        static JavascriptDate* UnsafeFromVar(Var aValue);
 
         class EntryInfo
         {

--- a/lib/Runtime/Library/JavascriptError.h
+++ b/lib/Runtime/Library/JavascriptError.h
@@ -42,9 +42,16 @@ namespace Js
 
         static JavascriptError* FromVar(Var aValue)
         {
-            AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptError'");
+            AssertOrFailFastMsg(Is(aValue), "Ensure var is actually a 'JavascriptError'");
 
             return static_cast<JavascriptError *>(RecyclableObject::FromVar(aValue));
+        }
+
+        static JavascriptError* UnsafeFromVar(Var aValue)
+        {
+            AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptError'");
+
+            return static_cast<JavascriptError *>(RecyclableObject::UnsafeFromVar(aValue));
         }
 
         void SetNotEnumerable(PropertyId propertyId);

--- a/lib/Runtime/Library/JavascriptFunction.cpp
+++ b/lib/Runtime/Library/JavascriptFunction.cpp
@@ -109,9 +109,16 @@ namespace Js
 
     JavascriptFunction* JavascriptFunction::FromVar(Var aValue)
     {
-        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptFunction'");
+        AssertOrFailFastMsg(Is(aValue), "Ensure var is actually a 'JavascriptFunction'");
 
         return static_cast<JavascriptFunction *>(RecyclableObject::FromVar(aValue));
+    }
+
+    JavascriptFunction* JavascriptFunction::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptFunction'");
+
+        return static_cast<JavascriptFunction *>(RecyclableObject::UnsafeFromVar(aValue));
     }
 
     BOOL JavascriptFunction::IsStrictMode() const
@@ -856,8 +863,8 @@ namespace Js
             resultObject = JavascriptOperators::NewScObjectNoCtor(v, scriptContext);
         }
 
-        // JavascriptOperators::NewScObject should have thrown if 'v' is not a constructor
-        RecyclableObject* functionObj = RecyclableObject::FromVar(v);
+        // JavascriptOperators::NewScObjectNoCtor should have thrown if 'v' is not a constructor
+        RecyclableObject* functionObj = RecyclableObject::UnsafeFromVar(v);
 
         Var* newValues = args.Values;
         CallFlags newFlags = args.Info.Flags;
@@ -867,7 +874,8 @@ namespace Js
 
         if (overridingNewTarget != nullptr)
         {
-            if (ScriptFunction::Is(functionObj) && ScriptFunction::FromVar(functionObj)->GetFunctionInfo()->IsClassConstructor())
+            ScriptFunction * scriptFunctionObj = JavascriptOperators::TryFromVar<ScriptFunction>(functionObj);
+            if (scriptFunctionObj && scriptFunctionObj->GetFunctionInfo()->IsClassConstructor())
             {
                 thisAlreadySpecified = true;
                 args.Values[0] = overridingNewTarget;
@@ -3328,7 +3336,7 @@ LABEL1:
                 && scriptContext == function->GetScriptContext())// only register when function has same scriptContext
             {
                 inlineCache->Cache(RecyclableObject::Is(instance) ?
-                    RecyclableObject::FromVar(instance)->GetType() : nullptr,
+                    RecyclableObject::UnsafeFromVar(instance)->GetType() : nullptr,
                     function, scriptContext->GetLibrary()->GetFalse(), scriptContext);
             }
             return result;

--- a/lib/Runtime/Library/JavascriptFunction.h
+++ b/lib/Runtime/Library/JavascriptFunction.h
@@ -107,6 +107,7 @@ namespace Js
 
         static bool Is(Var aValue);
         static JavascriptFunction* FromVar(Var aValue);
+        static JavascriptFunction* UnsafeFromVar(Var aValue);
         Var CallFunction(Arguments args);
         Var CallRootFunction(Arguments args, ScriptContext * scriptContext, bool inScript);
 #ifdef ASMJS_PLAT

--- a/lib/Runtime/Library/JavascriptGenerator.cpp
+++ b/lib/Runtime/Library/JavascriptGenerator.cpp
@@ -37,6 +37,13 @@ namespace Js
 
     JavascriptGenerator* JavascriptGenerator::FromVar(Var var)
     {
+        AssertOrFailFastMsg(Is(var), "Ensure var is actually a 'JavascriptGenerator'");
+
+        return static_cast<JavascriptGenerator*>(var);
+    }
+
+    JavascriptGenerator* JavascriptGenerator::UnsafeFromVar(Var var)
+    {
         AssertMsg(Is(var), "Ensure var is actually a 'JavascriptGenerator'");
 
         return static_cast<JavascriptGenerator*>(var);

--- a/lib/Runtime/Library/JavascriptGenerator.h
+++ b/lib/Runtime/Library/JavascriptGenerator.h
@@ -71,6 +71,7 @@ namespace Js
 
         static bool Is(Var var);
         static JavascriptGenerator* FromVar(Var var);
+        static JavascriptGenerator* UnsafeFromVar(Var var);
 
         class EntryInfo
         {

--- a/lib/Runtime/Library/JavascriptGeneratorFunction.cpp
+++ b/lib/Runtime/Library/JavascriptGeneratorFunction.cpp
@@ -50,7 +50,7 @@ namespace Js
     {
         if (JavascriptFunction::Is(var))
         {
-            JavascriptFunction* obj = JavascriptFunction::FromVar(var);
+            JavascriptFunction* obj = JavascriptFunction::UnsafeFromVar(var);
 
             return VirtualTableInfo<JavascriptGeneratorFunction>::HasVirtualTable(obj)
                 || VirtualTableInfo<CrossSiteObject<JavascriptGeneratorFunction>>::HasVirtualTable(obj);
@@ -61,6 +61,13 @@ namespace Js
 
     JavascriptGeneratorFunction* JavascriptGeneratorFunction::FromVar(Var var)
     {
+        AssertOrFailFast(JavascriptGeneratorFunction::Is(var) || JavascriptAsyncFunction::Is(var));
+
+        return static_cast<JavascriptGeneratorFunction*>(var);
+    }
+
+    JavascriptGeneratorFunction* JavascriptGeneratorFunction::UnsafeFromVar(Var var)
+    {
         Assert(JavascriptGeneratorFunction::Is(var) || JavascriptAsyncFunction::Is(var));
 
         return static_cast<JavascriptGeneratorFunction*>(var);
@@ -70,7 +77,7 @@ namespace Js
     {
         if (JavascriptFunction::Is(var))
         {
-            JavascriptFunction* obj = JavascriptFunction::FromVar(var);
+            JavascriptFunction* obj = JavascriptFunction::UnsafeFromVar(var);
 
             return VirtualTableInfo<JavascriptAsyncFunction>::HasVirtualTable(obj)
                 || VirtualTableInfo<CrossSiteObject<JavascriptAsyncFunction>>::HasVirtualTable(obj);
@@ -80,6 +87,13 @@ namespace Js
     }
 
     JavascriptAsyncFunction* JavascriptAsyncFunction::FromVar(Var var)
+    {
+        AssertOrFailFast(JavascriptAsyncFunction::Is(var));
+
+        return static_cast<JavascriptAsyncFunction*>(var);
+    }
+
+    JavascriptAsyncFunction* JavascriptAsyncFunction::UnsafeFromVar(Var var)
     {
         Assert(JavascriptAsyncFunction::Is(var));
 

--- a/lib/Runtime/Library/JavascriptGeneratorFunction.h
+++ b/lib/Runtime/Library/JavascriptGeneratorFunction.h
@@ -31,6 +31,7 @@ namespace Js
         GeneratorVirtualScriptFunction* GetGeneratorVirtualScriptFunction() { return scriptFunction; }
 
         static JavascriptGeneratorFunction* FromVar(Var var);
+        static JavascriptGeneratorFunction* UnsafeFromVar(Var var);
         static bool Is(Var var);
         inline static bool Test(JavascriptFunction *obj)
         {
@@ -111,6 +112,7 @@ namespace Js
         static DWORD GetOffsetOfScriptFunction() { return JavascriptGeneratorFunction::GetOffsetOfScriptFunction(); }
 
         static JavascriptAsyncFunction* FromVar(Var var);
+        static JavascriptAsyncFunction* UnsafeFromVar(Var var);
         static bool Is(Var var);
         inline static bool Test(JavascriptFunction *obj)
         {

--- a/lib/Runtime/Library/JavascriptLibrary.inl
+++ b/lib/Runtime/Library/JavascriptLibrary.inl
@@ -46,9 +46,13 @@ namespace Js
     template <>
     inline void JavascriptLibrary::CheckAndConvertCopyOnAccessNativeIntArray(const Var instance)
     {
-        if (instance && JavascriptCopyOnAccessNativeIntArray::Is(instance))
+        if (instance )
         {
-            JavascriptCopyOnAccessNativeIntArray::FromVar(instance)->ConvertCopyOnAccessSegment();
+            JavascriptCopyOnAccessNativeIntArray * copyOnAccessArray = JavascriptOperators::TryFromVar<JavascriptCopyOnAccessNativeIntArray>(instance);
+            if (copyOnAccessArray)
+            {
+                copyOnAccessArray->ConvertCopyOnAccessSegment();
+            }
         }
     }
 

--- a/lib/Runtime/Library/JavascriptListIterator.cpp
+++ b/lib/Runtime/Library/JavascriptListIterator.cpp
@@ -23,10 +23,18 @@ namespace Js
 
     JavascriptListIterator* JavascriptListIterator::FromVar(Var aValue)
     {
-        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptListIterator'");
+        AssertOrFailFastMsg(Is(aValue), "Ensure var is actually a 'JavascriptListIterator'");
 
         return static_cast<JavascriptListIterator *>(RecyclableObject::FromVar(aValue));
     }
+
+    JavascriptListIterator* JavascriptListIterator::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptListIterator'");
+
+        return static_cast<JavascriptListIterator *>(RecyclableObject::UnsafeFromVar(aValue));
+    }
+
 
     Var JavascriptListIterator::EntryNext(RecyclableObject* function, CallInfo callInfo, ...)
     {

--- a/lib/Runtime/Library/JavascriptListIterator.h
+++ b/lib/Runtime/Library/JavascriptListIterator.h
@@ -22,6 +22,7 @@ namespace Js
 
         static bool Is(Var aValue);
         static JavascriptListIterator* FromVar(Var aValue);
+        static JavascriptListIterator* UnsafeFromVar(Var aValue);
 
         class EntryInfo
         {

--- a/lib/Runtime/Library/JavascriptMap.cpp
+++ b/lib/Runtime/Library/JavascriptMap.cpp
@@ -26,9 +26,16 @@ namespace Js
 
     JavascriptMap* JavascriptMap::FromVar(Var aValue)
     {
-        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptMap'");
+        AssertOrFailFastMsg(Is(aValue), "Ensure var is actually a 'JavascriptMap'");
 
         return static_cast<JavascriptMap *>(RecyclableObject::FromVar(aValue));
+    }
+
+    JavascriptMap* JavascriptMap::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptMap'");
+
+        return static_cast<JavascriptMap *>(RecyclableObject::UnsafeFromVar(aValue));
     }
 
     JavascriptMap::MapDataList::Iterator JavascriptMap::GetIterator()

--- a/lib/Runtime/Library/JavascriptMap.h
+++ b/lib/Runtime/Library/JavascriptMap.h
@@ -28,6 +28,7 @@ namespace Js
 
         static bool Is(Var aValue);
         static JavascriptMap* FromVar(Var aValue);
+        static JavascriptMap* UnsafeFromVar(Var aValue);
 
         void Clear();
         bool Delete(Var key);

--- a/lib/Runtime/Library/JavascriptMapIterator.cpp
+++ b/lib/Runtime/Library/JavascriptMapIterator.cpp
@@ -23,9 +23,16 @@ namespace Js
 
     JavascriptMapIterator* JavascriptMapIterator::FromVar(Var aValue)
     {
-        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptMapIterator'");
+        AssertOrFailFastMsg(Is(aValue), "Ensure var is actually a 'JavascriptMapIterator'");
 
         return static_cast<JavascriptMapIterator *>(RecyclableObject::FromVar(aValue));
+    }
+
+    JavascriptMapIterator* JavascriptMapIterator::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptMapIterator'");
+
+        return static_cast<JavascriptMapIterator *>(RecyclableObject::UnsafeFromVar(aValue));
     }
 
     Var JavascriptMapIterator::EntryNext(RecyclableObject* function, CallInfo callInfo, ...)

--- a/lib/Runtime/Library/JavascriptMapIterator.h
+++ b/lib/Runtime/Library/JavascriptMapIterator.h
@@ -29,6 +29,7 @@ namespace Js
 
         static bool Is(Var aValue);
         static JavascriptMapIterator* FromVar(Var aValue);
+        static JavascriptMapIterator* UnsafeFromVar(Var aValue);
 
         class EntryInfo
         {

--- a/lib/Runtime/Library/JavascriptNumber.h
+++ b/lib/Runtime/Library/JavascriptNumber.h
@@ -160,6 +160,7 @@ namespace Js
         static Var ToVar(double value);
 #else
         static JavascriptNumber* FromVar(Var aValue);
+        static JavascriptNumber* UnsafeFromVar(Var aValue);
 #endif
 
     private:

--- a/lib/Runtime/Library/JavascriptNumber.inl
+++ b/lib/Runtime/Library/JavascriptNumber.inl
@@ -169,6 +169,13 @@ namespace Js
 
     inline JavascriptNumber* JavascriptNumber::FromVar(Var aValue)
     {
+        AssertOrFailFastMsg(Is(aValue), "Ensure var is actually a 'JavascriptNumber'");
+
+        return reinterpret_cast<JavascriptNumber *>(aValue);
+    }
+
+    inline JavascriptNumber* JavascriptNumber::UnsafeFromVar(Var aValue)
+    {
         AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptNumber'");
 
         return reinterpret_cast<JavascriptNumber *>(aValue);

--- a/lib/Runtime/Library/JavascriptNumberObject.cpp
+++ b/lib/Runtime/Library/JavascriptNumberObject.cpp
@@ -27,9 +27,16 @@ namespace Js
 
     JavascriptNumberObject* JavascriptNumberObject::FromVar(Var aValue)
     {
-        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptNumber'");
+        AssertOrFailFastMsg(Is(aValue), "Ensure var is actually a 'JavascriptNumber'");
 
         return static_cast<JavascriptNumberObject *>(RecyclableObject::FromVar(aValue));
+    }
+
+    JavascriptNumberObject* JavascriptNumberObject::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptNumber'");
+
+        return static_cast<JavascriptNumberObject *>(RecyclableObject::UnsafeFromVar(aValue));
     }
 
     Var JavascriptNumberObject::Unwrap() const

--- a/lib/Runtime/Library/JavascriptNumberObject.h
+++ b/lib/Runtime/Library/JavascriptNumberObject.h
@@ -20,6 +20,7 @@ namespace Js
         JavascriptNumberObject(Var value, DynamicType * type);
         static bool Is(Var aValue);
         static JavascriptNumberObject* FromVar(Var aValue);
+        static JavascriptNumberObject* UnsafeFromVar(Var aValue);
         double GetValue() const;
         void SetValue(Var value);
         Var Unwrap() const;

--- a/lib/Runtime/Library/JavascriptObject.cpp
+++ b/lib/Runtime/Library/JavascriptObject.cpp
@@ -267,7 +267,7 @@ namespace Js
         }
 
         // Set to new prototype
-        if (object->IsExternal() || (DynamicType::Is(object->GetTypeId()) && (DynamicObject::FromVar(object))->IsCrossSiteObject()))
+        if (object->IsExternal() || (DynamicType::Is(object->GetTypeId()) && (DynamicObject::UnsafeFromVar(object))->IsCrossSiteObject()))
         {
             CrossSite::ForceCrossSiteThunkOnPrototypeChain(newPrototype);
         }
@@ -409,7 +409,7 @@ namespace Js
         }
 
         // 3. Let O be ToObject(this value).
-        RecyclableObject *thisArgAsObject = RecyclableObject::FromVar(JavascriptOperators::ToObject(thisArg, scriptContext));
+        RecyclableObject *thisArgAsObject = RecyclableObject::UnsafeFromVar(JavascriptOperators::ToObject(thisArg, scriptContext));
 
         // 15. Let tag be ? Get(O, @@toStringTag).
         Var tag = JavascriptObject::GetToStringTagValue(thisArgAsObject, scriptContext);

--- a/lib/Runtime/Library/JavascriptPromise.cpp
+++ b/lib/Runtime/Library/JavascriptPromise.cpp
@@ -123,9 +123,16 @@ namespace Js
 
     JavascriptPromise* JavascriptPromise::FromVar(Js::Var aValue)
     {
-        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptPromise'");
+        AssertOrFailFastMsg(Is(aValue), "Ensure var is actually a 'JavascriptPromise'");
 
         return static_cast<JavascriptPromise *>(RecyclableObject::FromVar(aValue));
+    }
+
+    JavascriptPromise* JavascriptPromise::UnsafeFromVar(Js::Var aValue)
+    {
+        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptPromise'");
+
+        return static_cast<JavascriptPromise *>(RecyclableObject::UnsafeFromVar(aValue));
     }
 
     BOOL JavascriptPromise::GetDiagValueString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext)
@@ -1324,7 +1331,7 @@ namespace Js
     {
         if (JavascriptFunction::Is(var))
         {
-            JavascriptFunction* obj = JavascriptFunction::FromVar(var);
+            JavascriptFunction* obj = JavascriptFunction::UnsafeFromVar(var);
 
             return VirtualTableInfo<JavascriptPromiseResolveOrRejectFunction>::HasVirtualTable(obj)
                 || VirtualTableInfo<CrossSiteObject<JavascriptPromiseResolveOrRejectFunction>>::HasVirtualTable(obj);
@@ -1334,6 +1341,13 @@ namespace Js
     }
 
     JavascriptPromiseResolveOrRejectFunction* JavascriptPromiseResolveOrRejectFunction::FromVar(Var var)
+    {
+        AssertOrFailFast(JavascriptPromiseResolveOrRejectFunction::Is(var));
+
+        return static_cast<JavascriptPromiseResolveOrRejectFunction*>(var);
+    }
+
+    JavascriptPromiseResolveOrRejectFunction* JavascriptPromiseResolveOrRejectFunction::UnsafeFromVar(Var var)
     {
         Assert(JavascriptPromiseResolveOrRejectFunction::Is(var));
 
@@ -1404,7 +1418,7 @@ namespace Js
     {
         if (JavascriptFunction::Is(var))
         {
-            JavascriptFunction* obj = JavascriptFunction::FromVar(var);
+            JavascriptFunction* obj = JavascriptFunction::UnsafeFromVar(var);
 
             return VirtualTableInfo<JavascriptPromiseAsyncSpawnExecutorFunction>::HasVirtualTable(obj)
                 || VirtualTableInfo<CrossSiteObject<JavascriptPromiseAsyncSpawnExecutorFunction>>::HasVirtualTable(obj);
@@ -1415,10 +1429,18 @@ namespace Js
 
     JavascriptPromiseAsyncSpawnExecutorFunction* JavascriptPromiseAsyncSpawnExecutorFunction::FromVar(Var var)
     {
+        AssertOrFailFast(JavascriptPromiseAsyncSpawnExecutorFunction::Is(var));
+
+        return static_cast<JavascriptPromiseAsyncSpawnExecutorFunction*>(var);
+    }
+
+    JavascriptPromiseAsyncSpawnExecutorFunction* JavascriptPromiseAsyncSpawnExecutorFunction::UnsafeFromVar(Var var)
+    {
         Assert(JavascriptPromiseAsyncSpawnExecutorFunction::Is(var));
 
         return static_cast<JavascriptPromiseAsyncSpawnExecutorFunction*>(var);
     }
+
 
     JavascriptGenerator* JavascriptPromiseAsyncSpawnExecutorFunction::GetGenerator()
     {
@@ -1456,7 +1478,7 @@ namespace Js
     {
         if (JavascriptFunction::Is(var))
         {
-            JavascriptFunction* obj = JavascriptFunction::FromVar(var);
+            JavascriptFunction* obj = JavascriptFunction::UnsafeFromVar(var);
 
             return VirtualTableInfo<JavascriptPromiseAsyncSpawnStepArgumentExecutorFunction>::HasVirtualTable(obj)
                 || VirtualTableInfo<CrossSiteObject<JavascriptPromiseAsyncSpawnStepArgumentExecutorFunction>>::HasVirtualTable(obj);
@@ -1466,6 +1488,13 @@ namespace Js
     }
 
     JavascriptPromiseAsyncSpawnStepArgumentExecutorFunction* JavascriptPromiseAsyncSpawnStepArgumentExecutorFunction::FromVar(Var var)
+    {
+        AssertOrFailFast(JavascriptPromiseAsyncSpawnStepArgumentExecutorFunction::Is(var));
+
+        return static_cast<JavascriptPromiseAsyncSpawnStepArgumentExecutorFunction*>(var);
+    }
+
+    JavascriptPromiseAsyncSpawnStepArgumentExecutorFunction* JavascriptPromiseAsyncSpawnStepArgumentExecutorFunction::UnsafeFromVar(Var var)
     {
         Assert(JavascriptPromiseAsyncSpawnStepArgumentExecutorFunction::Is(var));
 
@@ -1523,7 +1552,7 @@ namespace Js
     {
         if (JavascriptFunction::Is(var))
         {
-            JavascriptFunction* obj = JavascriptFunction::FromVar(var);
+            JavascriptFunction* obj = JavascriptFunction::UnsafeFromVar(var);
 
             return VirtualTableInfo<JavascriptPromiseCapabilitiesExecutorFunction>::HasVirtualTable(obj)
                 || VirtualTableInfo<CrossSiteObject<JavascriptPromiseCapabilitiesExecutorFunction>>::HasVirtualTable(obj);
@@ -1533,6 +1562,13 @@ namespace Js
     }
 
     JavascriptPromiseCapabilitiesExecutorFunction* JavascriptPromiseCapabilitiesExecutorFunction::FromVar(Var var)
+    {
+        AssertOrFailFast(JavascriptPromiseCapabilitiesExecutorFunction::Is(var));
+
+        return static_cast<JavascriptPromiseCapabilitiesExecutorFunction*>(var);
+    }
+
+    JavascriptPromiseCapabilitiesExecutorFunction* JavascriptPromiseCapabilitiesExecutorFunction::UnsafeFromVar(Var var)
     {
         Assert(JavascriptPromiseCapabilitiesExecutorFunction::Is(var));
 
@@ -1775,7 +1811,7 @@ namespace Js
     {
         if (JavascriptFunction::Is(var))
         {
-            JavascriptFunction* obj = JavascriptFunction::FromVar(var);
+            JavascriptFunction* obj = JavascriptFunction::UnsafeFromVar(var);
 
             return VirtualTableInfo<JavascriptPromiseAllResolveElementFunction>::HasVirtualTable(obj)
                 || VirtualTableInfo<CrossSiteObject<JavascriptPromiseAllResolveElementFunction>>::HasVirtualTable(obj);
@@ -1785,6 +1821,13 @@ namespace Js
     }
 
     JavascriptPromiseAllResolveElementFunction* JavascriptPromiseAllResolveElementFunction::FromVar(Var var)
+    {
+        AssertOrFailFast(JavascriptPromiseAllResolveElementFunction::Is(var));
+
+        return static_cast<JavascriptPromiseAllResolveElementFunction*>(var);
+    }
+
+    JavascriptPromiseAllResolveElementFunction* JavascriptPromiseAllResolveElementFunction::UnsafeFromVar(Var var)
     {
         Assert(JavascriptPromiseAllResolveElementFunction::Is(var));
 

--- a/lib/Runtime/Library/JavascriptPromise.h
+++ b/lib/Runtime/Library/JavascriptPromise.h
@@ -23,6 +23,7 @@ namespace Js
 
         inline static bool Is(Var var);
         inline static JavascriptPromiseResolveOrRejectFunction* FromVar(Var var);
+        inline static JavascriptPromiseResolveOrRejectFunction* UnsafeFromVar(Var var);
 
         JavascriptPromise* GetPromise();
         bool IsRejectFunction();
@@ -54,6 +55,7 @@ namespace Js
 
         inline static bool Is(Var var);
         inline static JavascriptPromiseAsyncSpawnExecutorFunction* FromVar(Var var);
+        inline static JavascriptPromiseAsyncSpawnExecutorFunction* UnsafeFromVar(Var var);
 
         JavascriptGenerator* GetGenerator();
         Var GetTarget();
@@ -82,6 +84,7 @@ namespace Js
 
         inline static bool Is(Var var);
         inline static JavascriptPromiseAsyncSpawnStepArgumentExecutorFunction* FromVar(Var var);
+        inline static JavascriptPromiseAsyncSpawnStepArgumentExecutorFunction* UnsafeFromVar(Var var);
 
         JavascriptGenerator* GetGenerator();
         Var GetReject();
@@ -116,6 +119,7 @@ namespace Js
 
         inline static bool Is(Var var);
         inline static JavascriptPromiseCapabilitiesExecutorFunction* FromVar(Var var);
+        inline static JavascriptPromiseCapabilitiesExecutorFunction* UnsafeFromVar(Var var);
 
         JavascriptPromiseCapability* GetCapability();
 
@@ -146,7 +150,7 @@ namespace Js
         {
             if (JavascriptFunction::Is(var))
             {
-                JavascriptFunction* obj = JavascriptFunction::FromVar(var);
+                JavascriptFunction* obj = JavascriptFunction::UnsafeFromVar(var);
 
                 return VirtualTableInfo<JavascriptPromiseResolveThenableTaskFunction>::HasVirtualTable(obj)
                     || VirtualTableInfo<CrossSiteObject<JavascriptPromiseResolveThenableTaskFunction>>::HasVirtualTable(obj);
@@ -157,7 +161,7 @@ namespace Js
 
         inline static JavascriptPromiseResolveThenableTaskFunction* FromVar(Var var)
         {
-            Assert(JavascriptPromiseResolveThenableTaskFunction::Is(var));
+            AssertOrFailFast(JavascriptPromiseResolveThenableTaskFunction::Is(var));
 
             return static_cast<JavascriptPromiseResolveThenableTaskFunction*>(var);
         }
@@ -196,7 +200,7 @@ namespace Js
         {
             if (JavascriptFunction::Is(var))
             {
-                JavascriptFunction* obj = JavascriptFunction::FromVar(var);
+                JavascriptFunction* obj = JavascriptFunction::UnsafeFromVar(var);
 
                 return VirtualTableInfo<JavascriptPromiseReactionTaskFunction>::HasVirtualTable(obj)
                     || VirtualTableInfo<CrossSiteObject<JavascriptPromiseReactionTaskFunction>>::HasVirtualTable(obj);
@@ -207,7 +211,7 @@ namespace Js
 
         inline static JavascriptPromiseReactionTaskFunction* FromVar(Var var)
         {
-            Assert(JavascriptPromiseReactionTaskFunction::Is(var));
+            AssertOrFailFast(JavascriptPromiseReactionTaskFunction::Is(var));
 
             return static_cast<JavascriptPromiseReactionTaskFunction*>(var);
         }
@@ -245,6 +249,7 @@ namespace Js
 
         inline static bool Is(Var var);
         inline static JavascriptPromiseAllResolveElementFunction* FromVar(Var var);
+        inline static JavascriptPromiseAllResolveElementFunction* UnsafeFromVar(Var var);
 
         JavascriptPromiseCapability* GetCapabilities();
         uint32 GetIndex();
@@ -421,6 +426,7 @@ namespace Js
 
         static bool Is(Var aValue);
         static JavascriptPromise* FromVar(Js::Var aValue);
+        static JavascriptPromise* UnsafeFromVar(Js::Var aValue);
 
         static Var CreateRejectedPromise(Var resolution, ScriptContext* scriptContext, Var promiseConstructor = nullptr);
         static Var CreateResolvedPromise(Var resolution, ScriptContext* scriptContext, Var promiseConstructor = nullptr);

--- a/lib/Runtime/Library/JavascriptProxy.h
+++ b/lib/Runtime/Library/JavascriptProxy.h
@@ -51,7 +51,8 @@ namespace Js
         JavascriptProxy(DynamicType * type);
         JavascriptProxy(DynamicType * type, ScriptContext * scriptContext, RecyclableObject* target, RecyclableObject* handler);
         static BOOL Is(Var obj);
-        static JavascriptProxy* FromVar(Var obj) { Assert(Is(obj)); return static_cast<JavascriptProxy*>(obj); }
+        static JavascriptProxy* FromVar(Var obj) { AssertOrFailFast(Is(obj)); return static_cast<JavascriptProxy*>(obj); }
+        static JavascriptProxy* UnsafeFromVar(Var obj) { Assert(Is(obj)); return static_cast<JavascriptProxy*>(obj); }
 #ifndef IsJsDiag
         RecyclableObject* GetTarget();
         RecyclableObject* GetHandler();

--- a/lib/Runtime/Library/JavascriptRegularExpression.cpp
+++ b/lib/Runtime/Library/JavascriptRegularExpression.cpp
@@ -98,9 +98,16 @@ namespace Js
 
     JavascriptRegExp* JavascriptRegExp::FromVar(Var aValue)
     {
-        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptRegExp'");
+        AssertOrFailFastMsg(Is(aValue), "Ensure var is actually a 'JavascriptRegExp'");
 
         return static_cast<JavascriptRegExp *>(RecyclableObject::FromVar(aValue));
+    }
+
+    JavascriptRegExp* JavascriptRegExp::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptRegExp'");
+
+        return static_cast<JavascriptRegExp *>(RecyclableObject::UnsafeFromVar(aValue));
     }
 
     CharCount JavascriptRegExp::GetLastIndexProperty(RecyclableObject* instance, ScriptContext* scriptContext)
@@ -180,15 +187,16 @@ namespace Js
 
     JavascriptRegExp* JavascriptRegExp::ToRegExp(Var var, PCWSTR varName, ScriptContext* scriptContext)
     {
-        if (JavascriptRegExp::Is(var))
+        JavascriptRegExp * regExp = JavascriptOperators::TryFromVar<JavascriptRegExp>(var);
+        if (regExp)
         {
-            return JavascriptRegExp::FromVar(var);
+            return regExp;
         }
 
         if (JavascriptOperators::GetTypeId(var) == TypeIds_HostDispatch)
         {
             TypeId remoteTypeId = TypeIds_Limit;
-            RecyclableObject* reclObj = RecyclableObject::FromVar(var);
+            RecyclableObject* reclObj = RecyclableObject::UnsafeFromVar(var);
             if (reclObj->GetRemoteTypeId(&remoteTypeId) && remoteTypeId == TypeIds_RegEx)
             {
                 return static_cast<JavascriptRegExp *>(reclObj->GetRemoteObject());
@@ -215,13 +223,17 @@ namespace Js
         {
             return scriptContext->GetLibrary()->GetUndefinedDisplayString();
         }
-        else if (JavascriptString::Is(args[1]))
-        {
-            return JavascriptString::FromVar(args[1]);
-        }
         else
         {
-            return JavascriptConversion::ToString(args[1], scriptContext);
+            JavascriptString *jsString = JavascriptOperators::TryFromVar<JavascriptString>(args[1]);
+            if (jsString)
+            {
+                return jsString;
+            }
+            else
+            {
+                return JavascriptConversion::ToString(args[1], scriptContext);
+            }
         }
     }
 
@@ -863,7 +875,7 @@ namespace Js
         Var exec = JavascriptOperators::GetProperty(thisObj, PropertyIds::exec, scriptContext);
         if (JavascriptConversion::IsCallable(exec))
         {
-            RecyclableObject* execFn = RecyclableObject::FromVar(exec);
+            RecyclableObject* execFn = RecyclableObject::UnsafeFromVar(exec);
             Var result = CALL_FUNCTION(scriptContext->GetThreadContext(), execFn, CallInfo(CallFlags_Value, 2), thisObj, string);
 
             if (!JavascriptOperators::IsObjectOrNull(result))

--- a/lib/Runtime/Library/JavascriptRegularExpression.h
+++ b/lib/Runtime/Library/JavascriptRegularExpression.h
@@ -130,6 +130,7 @@ namespace Js
         static bool Is(Var aValue);
         static bool IsRegExpLike(Var aValue, ScriptContext* scriptContext);
         static JavascriptRegExp* FromVar(Var aValue);
+        static JavascriptRegExp* UnsafeFromVar(Var aValue);
 
         static JavascriptRegExp* CreateRegEx(const char16* pSource, CharCount sourceLen,
             UnifiedRegex::RegexFlags flags, ScriptContext *scriptContext);

--- a/lib/Runtime/Library/JavascriptSet.cpp
+++ b/lib/Runtime/Library/JavascriptSet.cpp
@@ -26,9 +26,16 @@ namespace Js
 
     JavascriptSet* JavascriptSet::FromVar(Var aValue)
     {
-        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptSet'");
+        AssertOrFailFastMsg(Is(aValue), "Ensure var is actually a 'JavascriptSet'");
 
         return static_cast<JavascriptSet *>(RecyclableObject::FromVar(aValue));
+    }
+
+    JavascriptSet* JavascriptSet::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptSet'");
+
+        return static_cast<JavascriptSet *>(RecyclableObject::UnsafeFromVar(aValue));
     }
 
     JavascriptSet::SetDataList::Iterator JavascriptSet::GetIterator()

--- a/lib/Runtime/Library/JavascriptSet.h
+++ b/lib/Runtime/Library/JavascriptSet.h
@@ -27,6 +27,7 @@ namespace Js
 
         static bool Is(Var aValue);
         static JavascriptSet* FromVar(Var aValue);
+        static JavascriptSet* UnsafeFromVar(Var aValue);
 
         void Add(Var value);
         void Clear();

--- a/lib/Runtime/Library/JavascriptSetIterator.cpp
+++ b/lib/Runtime/Library/JavascriptSetIterator.cpp
@@ -23,9 +23,16 @@ namespace Js
 
     JavascriptSetIterator* JavascriptSetIterator::FromVar(Var aValue)
     {
-        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptSetIterator'");
+        AssertOrFailFastMsg(Is(aValue), "Ensure var is actually a 'JavascriptSetIterator'");
 
         return static_cast<JavascriptSetIterator *>(RecyclableObject::FromVar(aValue));
+    }
+
+    JavascriptSetIterator* JavascriptSetIterator::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptSetIterator'");
+
+        return static_cast<JavascriptSetIterator *>(RecyclableObject::UnsafeFromVar(aValue));
     }
 
     Var JavascriptSetIterator::EntryNext(RecyclableObject* function, CallInfo callInfo, ...)

--- a/lib/Runtime/Library/JavascriptSetIterator.h
+++ b/lib/Runtime/Library/JavascriptSetIterator.h
@@ -28,6 +28,7 @@ namespace Js
 
         static bool Is(Var aValue);
         static JavascriptSetIterator* FromVar(Var aValue);
+        static JavascriptSetIterator* UnsafeFromVar(Var aValue);
 
         class EntryInfo
         {

--- a/lib/Runtime/Library/JavascriptSimdBool16x8.cpp
+++ b/lib/Runtime/Library/JavascriptSimdBool16x8.cpp
@@ -36,7 +36,7 @@ namespace Js
     JavascriptSIMDBool16x8* JavascriptSIMDBool16x8::FromVar(Var aValue)
     {
         Assert(aValue);
-        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptSIMDBool16x8'");
+        AssertOrFailFastMsg(Is(aValue), "Ensure var is actually a 'JavascriptSIMDBool16x8'");
 
         return reinterpret_cast<JavascriptSIMDBool16x8 *>(aValue);
     }

--- a/lib/Runtime/Library/JavascriptSimdBool32x4.cpp
+++ b/lib/Runtime/Library/JavascriptSimdBool32x4.cpp
@@ -36,7 +36,7 @@ namespace Js
     JavascriptSIMDBool32x4* JavascriptSIMDBool32x4::FromVar(Var aValue)
     {
         Assert(aValue);
-        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptSIMDBool32x4'");
+        AssertOrFailFastMsg(Is(aValue), "Ensure var is actually a 'JavascriptSIMDBool32x4'");
 
         return reinterpret_cast<JavascriptSIMDBool32x4 *>(aValue);
     }

--- a/lib/Runtime/Library/JavascriptSimdBool8x16.cpp
+++ b/lib/Runtime/Library/JavascriptSimdBool8x16.cpp
@@ -39,7 +39,7 @@ namespace Js
     JavascriptSIMDBool8x16* JavascriptSIMDBool8x16::FromVar(Var aValue)
     {
         Assert(aValue);
-        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptSIMDBool8x16'");
+        AssertOrFailFastMsg(Is(aValue), "Ensure var is actually a 'JavascriptSIMDBool8x16'");
 
         return reinterpret_cast<JavascriptSIMDBool8x16 *>(aValue);
     }

--- a/lib/Runtime/Library/JavascriptSimdFloat32x4.cpp
+++ b/lib/Runtime/Library/JavascriptSimdFloat32x4.cpp
@@ -36,7 +36,7 @@ namespace Js
     JavascriptSIMDFloat32x4* JavascriptSIMDFloat32x4::FromVar(Var aValue)
     {
         Assert(aValue);
-        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptSIMDFloat32x4'");
+        AssertOrFailFastMsg(Is(aValue), "Ensure var is actually a 'JavascriptSIMDFloat32x4'");
 
         return reinterpret_cast<JavascriptSIMDFloat32x4 *>(aValue);
     }

--- a/lib/Runtime/Library/JavascriptSimdFloat64x2.cpp
+++ b/lib/Runtime/Library/JavascriptSimdFloat64x2.cpp
@@ -25,7 +25,7 @@ namespace Js
     JavascriptSIMDFloat64x2* JavascriptSIMDFloat64x2::FromVar(Var aValue)
     {
         Assert(aValue);
-        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptSIMDFloat64x2'");
+        AssertOrFailFastMsg(Is(aValue), "Ensure var is actually a 'JavascriptSIMDFloat64x2'");
 
         return reinterpret_cast<JavascriptSIMDFloat64x2 *>(aValue);
     }

--- a/lib/Runtime/Library/JavascriptSimdInt16x8.cpp
+++ b/lib/Runtime/Library/JavascriptSimdInt16x8.cpp
@@ -34,7 +34,7 @@ namespace Js
     JavascriptSIMDInt16x8* JavascriptSIMDInt16x8::FromVar(Var aValue)
     {
         Assert(aValue);
-        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptSIMDInt16x8'");
+        AssertOrFailFastMsg(Is(aValue), "Ensure var is actually a 'JavascriptSIMDInt16x8'");
 
         return reinterpret_cast<JavascriptSIMDInt16x8 *>(aValue);
     }

--- a/lib/Runtime/Library/JavascriptSimdInt32x4.cpp
+++ b/lib/Runtime/Library/JavascriptSimdInt32x4.cpp
@@ -36,7 +36,7 @@ namespace Js
     JavascriptSIMDInt32x4* JavascriptSIMDInt32x4::FromVar(Var aValue)
     {
         Assert(aValue);
-        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptSIMDInt32x4'");
+        AssertOrFailFastMsg(Is(aValue), "Ensure var is actually a 'JavascriptSIMDInt32x4'");
 
         return reinterpret_cast<JavascriptSIMDInt32x4 *>(aValue);
     }

--- a/lib/Runtime/Library/JavascriptSimdInt8x16.cpp
+++ b/lib/Runtime/Library/JavascriptSimdInt8x16.cpp
@@ -31,7 +31,7 @@ namespace Js
     JavascriptSIMDInt8x16* JavascriptSIMDInt8x16::FromVar(Var aValue)
     {
         Assert(aValue);
-        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptSIMDInt8x16'");
+        AssertOrFailFastMsg(Is(aValue), "Ensure var is actually a 'JavascriptSIMDInt8x16'");
 
         return reinterpret_cast<JavascriptSIMDInt8x16 *>(aValue);
     }

--- a/lib/Runtime/Library/JavascriptSimdObject.cpp
+++ b/lib/Runtime/Library/JavascriptSimdObject.cpp
@@ -78,7 +78,7 @@ namespace Js
 
     JavascriptSIMDObject* JavascriptSIMDObject::FromVar(Var aValue)
     {
-        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptSIMD'");
+        AssertOrFailFastMsg(Is(aValue), "Ensure var is actually a 'JavascriptSIMD'");
 
         return static_cast<JavascriptSIMDObject *>(RecyclableObject::FromVar(aValue));
     }

--- a/lib/Runtime/Library/JavascriptSimdUint16x8.cpp
+++ b/lib/Runtime/Library/JavascriptSimdUint16x8.cpp
@@ -32,7 +32,7 @@ namespace Js
     JavascriptSIMDUint16x8* JavascriptSIMDUint16x8::FromVar(Var aValue)
     {
         Assert(aValue);
-        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptSIMDUint16x8'");
+        AssertOrFailFastMsg(Is(aValue), "Ensure var is actually a 'JavascriptSIMDUint16x8'");
 
         return reinterpret_cast<JavascriptSIMDUint16x8 *>(aValue);
     }

--- a/lib/Runtime/Library/JavascriptSimdUint32x4.cpp
+++ b/lib/Runtime/Library/JavascriptSimdUint32x4.cpp
@@ -36,7 +36,7 @@ namespace Js
     JavascriptSIMDUint32x4* JavascriptSIMDUint32x4::FromVar(Var aValue)
     {
         Assert(aValue);
-        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptSIMDUint32x4'");
+        AssertOrFailFastMsg(Is(aValue), "Ensure var is actually a 'JavascriptSIMDUint32x4'");
 
         return reinterpret_cast<JavascriptSIMDUint32x4 *>(aValue);
     }

--- a/lib/Runtime/Library/JavascriptSimdUint8x16.cpp
+++ b/lib/Runtime/Library/JavascriptSimdUint8x16.cpp
@@ -32,7 +32,7 @@ namespace Js
     JavascriptSIMDUint8x16* JavascriptSIMDUint8x16::FromVar(Var aValue)
     {
         Assert(aValue);
-        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptSIMDUint8x16'");
+        AssertOrFailFastMsg(Is(aValue), "Ensure var is actually a 'JavascriptSIMDUint8x16'");
 
         return reinterpret_cast<JavascriptSIMDUint8x16 *>(aValue);
     }

--- a/lib/Runtime/Library/JavascriptString.cpp
+++ b/lib/Runtime/Library/JavascriptString.cpp
@@ -138,10 +138,11 @@ namespace Js
 
         if (args.Info.Count > 1)
         {
-            if (JavascriptSymbol::Is(args[1]) && !(callInfo.Flags & CallFlags_New))
+            JavascriptSymbol * symbol = JavascriptOperators::TryFromVar<JavascriptSymbol>(args[1]);
+            if (symbol && !(callInfo.Flags & CallFlags_New))
             {
                 // By ES2015 21.1.1.1 step 2, calling the String constructor directly results in an explicit ToString, which does not throw.
-                return JavascriptSymbol::ToString(JavascriptSymbol::FromVar(args[1])->GetValue(), scriptContext);
+                return JavascriptSymbol::ToString(symbol->GetValue(), scriptContext);
                 // Calling with new is an implicit ToString on the Symbol, resulting in a throw. For this case we can let JavascriptConversion handle the call.
             }
             str = JavascriptConversion::ToString(args[1], scriptContext);
@@ -161,7 +162,7 @@ namespace Js
         }
 
         return isCtorSuperCall ?
-            JavascriptOperators::OrdinaryCreateFromConstructor(RecyclableObject::FromVar(newTarget), RecyclableObject::FromVar(result), nullptr, scriptContext) :
+            JavascriptOperators::OrdinaryCreateFromConstructor(RecyclableObject::FromVar(newTarget), RecyclableObject::UnsafeFromVar(result), nullptr, scriptContext) :
             result;
     }
 
@@ -227,9 +228,16 @@ namespace Js
 
     JavascriptString* JavascriptString::FromVar(Var aValue)
     {
-        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptString'");
+        AssertOrFailFastMsg(Is(aValue), "Ensure var is actually a 'JavascriptString'");
 
         return static_cast<JavascriptString *>(RecyclableObject::FromVar(aValue));
+    }
+
+    JavascriptString* JavascriptString::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptString'");
+
+        return static_cast<JavascriptString *>(RecyclableObject::UnsafeFromVar(aValue));
     }
 
     charcount_t
@@ -848,15 +856,11 @@ case_2:
             JavascriptError::ThrowTypeError(scriptContext, JSERR_This_NullOrUndefined, _u("String.prototype.concat"));
         }
 
-        JavascriptString* pstr = nullptr;
         JavascriptString* accum = nullptr;
         for (uint index = 0; index < args.Info.Count; index++)
         {
-            if (JavascriptString::Is(args[index]))
-            {
-                pstr = JavascriptString::FromVar(args[index]);
-            }
-            else
+            JavascriptString * pstr = JavascriptOperators::TryFromVar<JavascriptString>(args[index]);
+            if (!pstr)
             {
                 pstr = JavascriptConversion::ToString(args[index], scriptContext);
             }
@@ -1115,14 +1119,11 @@ case_2:
         GetThisStringArgument(args, scriptContext, _u("String.prototype.lastIndexOf"), &pThis);
 
         // default search string if the search argument is not provided
-        JavascriptString * searchArg;
+        JavascriptString * searchArg = nullptr;
         if(args.Info.Count > 1)
         {
-            if (JavascriptString::Is(args[1]))
-            {
-                searchArg = JavascriptString::FromVar(args[1]);
-            }
-            else
+            searchArg = JavascriptOperators::TryFromVar<JavascriptString>(args[1]);
+            if (!searchArg)
             {
                 searchArg = JavascriptConversion::ToString(args[1], scriptContext);
             }
@@ -1238,16 +1239,10 @@ case_2:
         }
         AssertMsg(args.Info.Count > 0, "Negative argument count");
 
-        JavascriptString * pThis;
-        if (JavascriptString::Is(args[0]))
+        JavascriptString * pThis = JavascriptOperators::TryFromVar<JavascriptString>(args[0]);
+        if (!pThis)
         {
-            pThis = JavascriptString::FromVar(args[0]);
-        }
-        else
-        {
-
             pThis = JavascriptConversion::CoerseString(args[0], scriptContext , apiNameForErrorMsg);
-
         }
 
         *ppThis = pThis;
@@ -1270,13 +1265,13 @@ case_2:
             {
                 JavascriptError::ThrowTypeError(scriptContext, JSERR_FunctionArgument_FirstCannotBeRegExp, apiNameForErrorMsg);
             }
-            else if (JavascriptString::Is(args[1]))
-            {
-                pSearch = JavascriptString::FromVar(args[1]);
-            }
             else
             {
-                pSearch = JavascriptConversion::ToString(args[1], scriptContext);
+                pSearch = JavascriptOperators::TryFromVar<JavascriptString>(args[1]);
+                if (!pSearch)
+                {
+                    pSearch = JavascriptConversion::ToString(args[1], scriptContext);
+                }
             }
         }
 
@@ -1417,12 +1412,8 @@ case_2:
 
         if (args.Info.Count >= 2 && !(JavascriptOperators::IsUndefinedObject(args.Values[1])))
         {
-            JavascriptString *formStr = nullptr;
-            if (JavascriptString::Is(args[1]))
-            {
-                formStr = JavascriptString::FromVar(args[1]);
-            }
-            else
+            JavascriptString *formStr = JavascriptOperators::TryFromVar<JavascriptString>(args[1]);
+            if (!formStr)
             {
                 formStr = JavascriptConversion::ToString(args[1], scriptContext);
             }
@@ -1746,7 +1737,7 @@ case_2:
             JavascriptError::ThrowTypeError(scriptContext, JSERR_FunctionArgument_Invalid, varName);
         }
 
-        RecyclableObject* fnObj = RecyclableObject::FromVar(fn);
+        RecyclableObject* fnObj = RecyclableObject::UnsafeFromVar(fn);
         return CallRegExFunction<argCount>(fnObj, regExp, args, scriptContext);
     }
 
@@ -1867,7 +1858,7 @@ case_2:
             if (!scriptContext->GetConfig()->IsES6RegExSymbolsEnabled()
                 && JavascriptRegExp::Is(args[1]))
             {
-                return RegexHelper::RegexSplit(scriptContext, JavascriptRegExp::FromVar(args[1]), input, limit,
+                return RegexHelper::RegexSplit(scriptContext, JavascriptRegExp::UnsafeFromVar(args[1]), input, limit,
                     RegexHelper::IsResultNotUsed(callInfo.Flags));
             }
             else
@@ -2172,7 +2163,7 @@ case_2:
             if (JavascriptOperators::GetTypeId(args[0]) == TypeIds_HostDispatch)
             {
                 Var result;
-                if (RecyclableObject::FromVar(args[0])->InvokeBuiltInOperationRemotely(EntryToString, args, &result))
+                if (RecyclableObject::UnsafeFromVar(args[0])->InvokeBuiltInOperationRemotely(EntryToString, args, &result))
                 {
                     return result;
                 }
@@ -2649,7 +2640,7 @@ case_2:
             if (JavascriptOperators::GetTypeId(args[0]) == TypeIds_HostDispatch)
             {
                 Var result;
-                if (RecyclableObject::FromVar(args[0])->InvokeBuiltInOperationRemotely(EntryValueOf, args, &result))
+                if (RecyclableObject::UnsafeFromVar(args[0])->InvokeBuiltInOperationRemotely(EntryValueOf, args, &result))
                 {
                     return result;
                 }
@@ -3089,7 +3080,7 @@ case_2:
         charcount_t cchPropertyValue;
         charcount_t cchTotalChars;
         charcount_t ich;
-        JavascriptString * pThis;
+        JavascriptString * pThis = nullptr;
         JavascriptString * pPropertyValue = nullptr;
         const char16 * propertyValueStr = nullptr;
         uint quotesCount = 0;
@@ -3130,11 +3121,8 @@ case_2:
             }
         }
 
-        if (JavascriptString::Is(args[0]))
-        {
-            pThis = JavascriptString::FromVar(args[0]);
-        }
-        else
+        pThis = JavascriptOperators::TryFromVar<JavascriptString>(args[0]);
+        if (!pThis)
         {
             pThis = JavascriptConversion::ToString(args[0], scriptContext);
         }
@@ -3150,11 +3138,8 @@ case_2:
             // Need one string argument.
             if (args.Info.Count >= 2)
             {
-                if (JavascriptString::Is(args[1]))
-                {
-                    pPropertyValue = JavascriptString::FromVar(args[1]);
-                }
-                else
+                pPropertyValue = JavascriptOperators::TryFromVar<JavascriptString>(args[1]);
+                if (!pPropertyValue)
                 {
                     pPropertyValue = JavascriptConversion::ToString(args[1], scriptContext);
                 }
@@ -3301,13 +3286,9 @@ case_2:
     {
         using namespace PlatformAgnostic::UnicodeText;
 
-        JavascriptString * pThis;
+        JavascriptString * pThis = JavascriptOperators::TryFromVar<JavascriptString>(thisObj);
 
-        if (JavascriptString::Is(thisObj))
-        {
-            pThis = JavascriptString::FromVar(thisObj);
-        }
-        else
+        if (!pThis)
         {
             pThis = JavascriptConversion::ToString(thisObj, scriptContext);
         }
@@ -3885,8 +3866,8 @@ case_2:
 
         if (aLeft == aRight) return true;
 
-        T *leftString = T::FromVar(aLeft);
-        T *rightString = T::FromVar(aRight);
+        T *leftString = T::UnsafeFromVar(aLeft);
+        T *rightString = T::UnsafeFromVar(aRight);
 
         if (leftString->GetLength() != rightString->GetLength())
         {

--- a/lib/Runtime/Library/JavascriptString.h
+++ b/lib/Runtime/Library/JavascriptString.h
@@ -124,6 +124,7 @@ namespace Js
 
         static bool Is(Var aValue);
         static JavascriptString* FromVar(Var aValue);
+        static JavascriptString* UnsafeFromVar(Var aValue);
         static bool Equals(Var aLeft, Var aRight);
         static bool LessThan(Var aLeft, Var aRight);
         static bool IsNegZero(JavascriptString *string);

--- a/lib/Runtime/Library/JavascriptStringIterator.cpp
+++ b/lib/Runtime/Library/JavascriptStringIterator.cpp
@@ -22,9 +22,16 @@ namespace Js
 
     JavascriptStringIterator* JavascriptStringIterator::FromVar(Var aValue)
     {
-        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptStringIterator'");
+        AssertOrFailFastMsg(Is(aValue), "Ensure var is actually a 'JavascriptStringIterator'");
 
         return static_cast<JavascriptStringIterator *>(RecyclableObject::FromVar(aValue));
+    }
+
+    JavascriptStringIterator* JavascriptStringIterator::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptStringIterator'");
+
+        return static_cast<JavascriptStringIterator *>(RecyclableObject::UnsafeFromVar(aValue));
     }
 
     Var JavascriptStringIterator::EntryNext(RecyclableObject* function, CallInfo callInfo, ...)

--- a/lib/Runtime/Library/JavascriptStringIterator.h
+++ b/lib/Runtime/Library/JavascriptStringIterator.h
@@ -21,6 +21,7 @@ namespace Js
 
         static bool Is(Var aValue);
         static JavascriptStringIterator* FromVar(Var aValue);
+        static JavascriptStringIterator* UnsafeFromVar(Var aValue);
 
         class EntryInfo
         {

--- a/lib/Runtime/Library/JavascriptStringObject.cpp
+++ b/lib/Runtime/Library/JavascriptStringObject.cpp
@@ -44,9 +44,16 @@ namespace Js
 
     JavascriptStringObject* JavascriptStringObject::FromVar(Var aValue)
     {
-        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptString'");
+        AssertOrFailFastMsg(Is(aValue), "Ensure var is actually a 'JavascriptString'");
 
         return static_cast<JavascriptStringObject *>(RecyclableObject::FromVar(aValue));
+    }
+
+    JavascriptStringObject* JavascriptStringObject::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptString'");
+
+        return static_cast<JavascriptStringObject *>(RecyclableObject::UnsafeFromVar(aValue));
     }
 
     void JavascriptStringObject::Initialize(JavascriptString* value)

--- a/lib/Runtime/Library/JavascriptStringObject.h
+++ b/lib/Runtime/Library/JavascriptStringObject.h
@@ -29,6 +29,7 @@ namespace Js
         JavascriptStringObject(JavascriptString* value, DynamicType * type);
         static bool Is(Var aValue);
         static JavascriptStringObject* FromVar(Var aValue);
+        static JavascriptStringObject* UnsafeFromVar(Var aValue);
 
         void Initialize(JavascriptString* value);
         JavascriptString* Unwrap() { return InternalUnwrap(); }

--- a/lib/Runtime/Library/JavascriptSymbol.cpp
+++ b/lib/Runtime/Library/JavascriptSymbol.cpp
@@ -13,9 +13,16 @@ namespace Js
 
     JavascriptSymbol* JavascriptSymbol::FromVar(Js::Var aValue)
     {
-        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptSymbol'");
+        AssertOrFailFastMsg(Is(aValue), "Ensure var is actually a 'JavascriptSymbol'");
 
         return static_cast<JavascriptSymbol *>(RecyclableObject::FromVar(aValue));
+    }
+
+    JavascriptSymbol* JavascriptSymbol::UnsafeFromVar(Js::Var aValue)
+    {
+        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptSymbol'");
+
+        return static_cast<JavascriptSymbol *>(RecyclableObject::UnsafeFromVar(aValue));
     }
 
     Var JavascriptSymbol::NewInstance(RecyclableObject* function, CallInfo callInfo, ...)

--- a/lib/Runtime/Library/JavascriptSymbol.h
+++ b/lib/Runtime/Library/JavascriptSymbol.h
@@ -22,6 +22,7 @@ namespace Js
 
         static bool Is(Var aValue);
         static JavascriptSymbol* FromVar(Var aValue);
+        static JavascriptSymbol* UnsafeFromVar(Var aValue);
 
         class EntryInfo
         {

--- a/lib/Runtime/Library/JavascriptSymbolObject.cpp
+++ b/lib/Runtime/Library/JavascriptSymbolObject.cpp
@@ -19,9 +19,16 @@ namespace Js
 
     JavascriptSymbolObject* JavascriptSymbolObject::FromVar(Js::Var aValue)
     {
-        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptSymbolObject'");
+        AssertOrFailFastMsg(Is(aValue), "Ensure var is actually a 'JavascriptSymbolObject'");
 
         return static_cast<JavascriptSymbolObject *>(RecyclableObject::FromVar(aValue));
+    }
+
+    JavascriptSymbolObject* JavascriptSymbolObject::UnsafeFromVar(Js::Var aValue)
+    {
+        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptSymbolObject'");
+
+        return static_cast<JavascriptSymbolObject *>(RecyclableObject::UnsafeFromVar(aValue));
     }
 
     BOOL JavascriptSymbolObject::GetDiagValueString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext)

--- a/lib/Runtime/Library/JavascriptSymbolObject.h
+++ b/lib/Runtime/Library/JavascriptSymbolObject.h
@@ -18,6 +18,7 @@ namespace Js
         JavascriptSymbolObject(JavascriptSymbol* value, DynamicType * type);
         static bool Is(Var aValue);
         static JavascriptSymbolObject* FromVar(Js::Var aValue);
+        static JavascriptSymbolObject* UnsafeFromVar(Js::Var aValue);
 
         inline const PropertyRecord* GetValue()
         {

--- a/lib/Runtime/Library/JavascriptTypedNumber.h
+++ b/lib/Runtime/Library/JavascriptTypedNumber.h
@@ -33,6 +33,14 @@ namespace Js
 
         static JavascriptTypedNumber<T>* FromVar(Var value)
         {
+            AssertOrFailFastMsg(JavascriptOperators::GetTypeId(value) == TypeIds_Int64Number ||
+                JavascriptOperators::GetTypeId(value) == TypeIds_UInt64Number, "invalid typed number");
+
+            return static_cast<JavascriptTypedNumber<T>*>(value);
+        };
+
+        static JavascriptTypedNumber<T>* UnsafeFromVar(Var value)
+        {
 #if DBG
             AssertMsg(JavascriptOperators::GetTypeId(value) == TypeIds_Int64Number ||
                 JavascriptOperators::GetTypeId(value) == TypeIds_UInt64Number, "invalid typed number");

--- a/lib/Runtime/Library/JavascriptVariantDate.cpp
+++ b/lib/Runtime/Library/JavascriptVariantDate.cpp
@@ -13,9 +13,16 @@ namespace Js
 
     JavascriptVariantDate* JavascriptVariantDate::FromVar(Js::Var aValue)
     {
-        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptVariantDate'");
+        AssertOrFailFastMsg(Is(aValue), "Ensure var is actually a 'JavascriptVariantDate'");
 
         return static_cast<JavascriptVariantDate *>(RecyclableObject::FromVar(aValue));
+    }
+
+    JavascriptVariantDate* JavascriptVariantDate::UnsafeFromVar(Js::Var aValue)
+    {
+        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptVariantDate'");
+
+        return static_cast<JavascriptVariantDate *>(RecyclableObject::UnsafeFromVar(aValue));
     }
 
     Var JavascriptVariantDate::GetTypeOfString(ScriptContext* requestContext)

--- a/lib/Runtime/Library/JavascriptVariantDate.h
+++ b/lib/Runtime/Library/JavascriptVariantDate.h
@@ -27,6 +27,7 @@ namespace Js
 
         static bool Is(Var aValue);
         static JavascriptVariantDate* FromVar(Var aValue);
+        static JavascriptVariantDate* UnsafeFromVar(Var aValue);
 
         // Used for making function calls to external objects requiring string params.
         JavascriptString* GetValueString(ScriptContext* scriptContext);

--- a/lib/Runtime/Library/JavascriptWeakMap.cpp
+++ b/lib/Runtime/Library/JavascriptWeakMap.cpp
@@ -19,9 +19,16 @@ namespace Js
 
     JavascriptWeakMap* JavascriptWeakMap::FromVar(Var aValue)
     {
-        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptWeakMap'");
+        AssertOrFailFastMsg(Is(aValue), "Ensure var is actually a 'JavascriptWeakMap'");
 
         return static_cast<JavascriptWeakMap *>(RecyclableObject::FromVar(aValue));
+    }
+
+    JavascriptWeakMap* JavascriptWeakMap::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptWeakMap'");
+
+        return static_cast<JavascriptWeakMap *>(RecyclableObject::UnsafeFromVar(aValue));
     }
 
     JavascriptWeakMap::WeakMapKeyMap* JavascriptWeakMap::GetWeakMapKeyMapFromKey(RecyclableObject* key) const

--- a/lib/Runtime/Library/JavascriptWeakMap.h
+++ b/lib/Runtime/Library/JavascriptWeakMap.h
@@ -62,6 +62,7 @@ namespace Js
 
         static bool Is(Var aValue);
         static JavascriptWeakMap* FromVar(Var aValue);
+        static JavascriptWeakMap* UnsafeFromVar(Var aValue);
 
         void Clear();
         bool Delete(RecyclableObject* key);

--- a/lib/Runtime/Library/JavascriptWeakSet.cpp
+++ b/lib/Runtime/Library/JavascriptWeakSet.cpp
@@ -19,9 +19,16 @@ namespace Js
 
     JavascriptWeakSet* JavascriptWeakSet::FromVar(Var aValue)
     {
-        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptWeakSet'");
+        AssertOrFailFastMsg(Is(aValue), "Ensure var is actually a 'JavascriptWeakSet'");
 
         return static_cast<JavascriptWeakSet *>(RecyclableObject::FromVar(aValue));
+    }
+
+    JavascriptWeakSet* JavascriptWeakSet::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptWeakSet'");
+
+        return static_cast<JavascriptWeakSet *>(RecyclableObject::UnsafeFromVar(aValue));
     }
 
     Var JavascriptWeakSet::NewInstance(RecyclableObject* function, CallInfo callInfo, ...)

--- a/lib/Runtime/Library/JavascriptWeakSet.h
+++ b/lib/Runtime/Library/JavascriptWeakSet.h
@@ -21,6 +21,7 @@ namespace Js
 
         static bool Is(Var aValue);
         static JavascriptWeakSet* FromVar(Var aValue);
+        static JavascriptWeakSet* UnsafeFromVar(Var aValue);
 
         void Add(RecyclableObject* key);
         bool Delete(RecyclableObject* key);

--- a/lib/Runtime/Library/PropertyString.cpp
+++ b/lib/Runtime/Library/PropertyString.cpp
@@ -46,7 +46,7 @@ namespace Js
     /* static */
     bool PropertyString::Is(Var var)
     {
-        return RecyclableObject::Is(var) && PropertyString::Is(RecyclableObject::FromVar(var));
+        return RecyclableObject::Is(var) && PropertyString::Is(RecyclableObject::UnsafeFromVar(var));
     }
 
     void const * PropertyString::GetOriginalStringReference()

--- a/lib/Runtime/Library/RegexHelper.cpp
+++ b/lib/Runtime/Library/RegexHelper.cpp
@@ -777,7 +777,7 @@ namespace Js
                 {
                     Var group = getGroup(captureIndex, nonMatchValue);
                     if (JavascriptString::Is(group))
-                        concatenated.Append(JavascriptString::FromVar(group));
+                        concatenated.Append(JavascriptString::UnsafeFromVar(group));
                     else if (group != nonMatchValue)
                         concatenated.Append(replace, substitutionOffset, offset - substitutionOffset);
                 }
@@ -1583,7 +1583,7 @@ namespace Js
             speciesConstructor,
             Js::Arguments(callInfo, args),
             scriptContext);
-        RecyclableObject* splitter = RecyclableObject::FromVar(regEx);
+        RecyclableObject* splitter = RecyclableObject::UnsafeFromVar(regEx);
 
         JavascriptArray* arrayResult = scriptContext->GetLibrary()->CreateArray();
 
@@ -2308,7 +2308,7 @@ namespace Js
         // an Object or Null. RegExp algorithms have special conditions for when the result is Null,
         // so we can directly cast to RecyclableObject.
         Assert(!JavascriptOperators::IsNull(result));
-        return RecyclableObject::FromVar(result);
+        return RecyclableObject::UnsafeFromVar(result);
     }
 
     JavascriptString* RegexHelper::GetMatchStrFromResult(RecyclableObject* result, ScriptContext* scriptContext)

--- a/lib/Runtime/Library/RootObjectBase.cpp
+++ b/lib/Runtime/Library/RootObjectBase.cpp
@@ -23,7 +23,7 @@ namespace Js
 
     bool RootObjectBase::Is(Var var)
     {
-        return RecyclableObject::Is(var) && RootObjectBase::Is(RecyclableObject::FromVar(var));
+        return RecyclableObject::Is(var) && RootObjectBase::Is(RecyclableObject::UnsafeFromVar(var));
     }
 
     bool RootObjectBase::Is(RecyclableObject* obj)
@@ -33,6 +33,12 @@ namespace Js
     }
 
     RootObjectBase * RootObjectBase::FromVar(Var var)
+    {
+        AssertOrFailFast(RootObjectBase::Is(var));
+        return static_cast<Js::RootObjectBase *>(var);
+    }
+
+    RootObjectBase * RootObjectBase::UnsafeFromVar(Var var)
     {
         Assert(RootObjectBase::Is(var));
         return static_cast<Js::RootObjectBase *>(var);

--- a/lib/Runtime/Library/RootObjectBase.h
+++ b/lib/Runtime/Library/RootObjectBase.h
@@ -57,6 +57,7 @@ namespace Js
         static bool Is(Var var);
         static bool Is(RecyclableObject * obj);
         static RootObjectBase * FromVar(Var var);
+        static RootObjectBase * UnsafeFromVar(Var var);
 
     protected:
         DEFINE_VTABLE_CTOR(RootObjectBase, DynamicObject);

--- a/lib/Runtime/Library/ScriptFunction.cpp
+++ b/lib/Runtime/Library/ScriptFunction.cpp
@@ -18,7 +18,7 @@ namespace Js
     {
         if (JavascriptFunction::Is(func))
         {
-            JavascriptFunction *function = JavascriptFunction::FromVar(func);
+            JavascriptFunction *function = JavascriptFunction::UnsafeFromVar(func);
             return ScriptFunction::Test(function) || JavascriptGeneratorFunction::Test(function)
                 || JavascriptAsyncFunction::Test(function);
         }
@@ -27,6 +27,12 @@ namespace Js
     }
 
     ScriptFunctionBase * ScriptFunctionBase::FromVar(Var func)
+    {
+        AssertOrFailFast(ScriptFunctionBase::Is(func));
+        return reinterpret_cast<ScriptFunctionBase *>(func);
+    }
+
+    ScriptFunctionBase * ScriptFunctionBase::UnsafeFromVar(Var func)
     {
         Assert(ScriptFunctionBase::Is(func));
         return reinterpret_cast<ScriptFunctionBase *>(func);
@@ -155,10 +161,16 @@ namespace Js
 
     bool ScriptFunction::Is(Var func)
     {
-        return JavascriptFunction::Is(func) && JavascriptFunction::FromVar(func)->GetFunctionInfo()->HasBody();
+        return JavascriptFunction::Is(func) && JavascriptFunction::UnsafeFromVar(func)->GetFunctionInfo()->HasBody();
     }
 
     ScriptFunction * ScriptFunction::FromVar(Var func)
+    {
+        AssertOrFailFast(ScriptFunction::Is(func));
+        return reinterpret_cast<ScriptFunction *>(func);
+    }
+
+    ScriptFunction * ScriptFunction::UnsafeFromVar(Var func)
     {
         Assert(ScriptFunction::Is(func));
         return reinterpret_cast<ScriptFunction *>(func);
@@ -653,10 +665,16 @@ namespace Js
 
     bool AsmJsScriptFunction::Is(Var func)
     {
-        return ScriptFunction::Is(func) && ScriptFunction::FromVar(func)->IsAsmJsFunction();
+        return ScriptFunction::Is(func) && ScriptFunction::UnsafeFromVar(func)->IsAsmJsFunction();
     }
 
     AsmJsScriptFunction* AsmJsScriptFunction::FromVar(Var func)
+    {
+        AssertOrFailFast(AsmJsScriptFunction::Is(func));
+        return reinterpret_cast<AsmJsScriptFunction *>(func);
+    }
+
+    AsmJsScriptFunction* AsmJsScriptFunction::UnsafeFromVar(Var func)
     {
         Assert(AsmJsScriptFunction::Is(func));
         return reinterpret_cast<AsmJsScriptFunction *>(func);
@@ -704,10 +722,16 @@ namespace Js
 
     bool WasmScriptFunction::Is(Var func)
     {
-        return ScriptFunction::Is(func) && ScriptFunction::FromVar(func)->IsWasmFunction();
+        return ScriptFunction::Is(func) && ScriptFunction::UnsafeFromVar(func)->IsWasmFunction();
     }
 
     WasmScriptFunction* WasmScriptFunction::FromVar(Var func)
+    {
+        AssertOrFailFast(WasmScriptFunction::Is(func));
+        return reinterpret_cast<WasmScriptFunction *>(func);
+    }
+
+    WasmScriptFunction* WasmScriptFunction::UnsafeFromVar(Var func)
     {
         Assert(WasmScriptFunction::Is(func));
         return reinterpret_cast<WasmScriptFunction *>(func);
@@ -729,10 +753,16 @@ namespace Js
 
     bool ScriptFunctionWithInlineCache::Is(Var func)
     {
-        return ScriptFunction::Is(func) && ScriptFunction::FromVar(func)->GetHasInlineCaches();
+        return ScriptFunction::Is(func) && ScriptFunction::UnsafeFromVar(func)->GetHasInlineCaches();
     }
 
     ScriptFunctionWithInlineCache* ScriptFunctionWithInlineCache::FromVar(Var func)
+    {
+        AssertOrFailFast(ScriptFunctionWithInlineCache::Is(func));
+        return reinterpret_cast<ScriptFunctionWithInlineCache *>(func);
+    }
+
+    ScriptFunctionWithInlineCache* ScriptFunctionWithInlineCache::UnsafeFromVar(Var func)
     {
         Assert(ScriptFunctionWithInlineCache::Is(func));
         return reinterpret_cast<ScriptFunctionWithInlineCache *>(func);

--- a/lib/Runtime/Library/ScriptFunction.h
+++ b/lib/Runtime/Library/ScriptFunction.h
@@ -17,6 +17,7 @@ namespace Js
     public:
         static bool Is(Var func);
         static ScriptFunctionBase * FromVar(Var func);
+        static ScriptFunctionBase * UnsafeFromVar(Var func);
 
         virtual Var  GetHomeObj() const = 0;
         virtual void SetHomeObj(Var homeObj) = 0;
@@ -47,6 +48,7 @@ namespace Js
         static bool Is(Var func);
         inline static BOOL Test(JavascriptFunction *func) { return func->GetFunctionInfo()->HasBody(); }
         static ScriptFunction * FromVar(Var func);
+        static ScriptFunction * UnsafeFromVar(Var func);
         static ScriptFunction * OP_NewScFunc(FrameDisplay *environment, FunctionInfoPtrPtr infoRef);
 
         ProxyEntryPointInfo* GetEntryPointInfo() const;
@@ -127,6 +129,7 @@ namespace Js
 
         static bool Is(Var func);
         static AsmJsScriptFunction* FromVar(Var func);
+        static AsmJsScriptFunction* UnsafeFromVar(Var func);
         static AsmJsScriptFunction * OP_NewAsmJsFunc(FrameDisplay *environment, FunctionInfoPtrPtr infoRef);
 
         virtual bool IsAsmJsFunction() const override { return true; }
@@ -153,6 +156,7 @@ namespace Js
 
         static bool Is(Var func);
         static WasmScriptFunction* FromVar(Var func);
+        static WasmScriptFunction* UnsafeFromVar(Var func);
 
         void SetSignature(Wasm::WasmSignature * sig) { m_signature = sig; }
         Wasm::WasmSignature * GetSignature() const { return m_signature; }
@@ -204,6 +208,7 @@ namespace Js
         ScriptFunctionWithInlineCache(FunctionProxy * proxy, ScriptFunctionType* deferredPrototypeType);
         static bool Is(Var func);
         static ScriptFunctionWithInlineCache * FromVar(Var func);
+        static ScriptFunctionWithInlineCache * UnsafeFromVar(Var func);
         void CreateInlineCache();
         void AllocateInlineCache();
         void ClearInlineCacheOnFunctionObject();

--- a/lib/Runtime/Library/SharedArrayBuffer.cpp
+++ b/lib/Runtime/Library/SharedArrayBuffer.cpp
@@ -232,9 +232,16 @@ namespace Js
 
     SharedArrayBuffer* SharedArrayBuffer::FromVar(Var aValue)
     {
-        AssertMsg(Is(aValue), "var must be an SharedArrayBuffer");
+        AssertOrFailFastMsg(Is(aValue), "var must be an SharedArrayBuffer");
 
         return static_cast<SharedArrayBuffer *>(RecyclableObject::FromVar(aValue));
+    }
+
+    SharedArrayBuffer* SharedArrayBuffer::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(Is(aValue), "var must be an SharedArrayBuffer");
+
+        return static_cast<SharedArrayBuffer *>(RecyclableObject::UnsafeFromVar(aValue));
     }
 
     bool  SharedArrayBuffer::Is(Var aValue)

--- a/lib/Runtime/Library/SharedArrayBuffer.h
+++ b/lib/Runtime/Library/SharedArrayBuffer.h
@@ -71,6 +71,7 @@ namespace Js
 
         static bool Is(Var aValue);
         static SharedArrayBuffer* FromVar(Var aValue);
+        static SharedArrayBuffer* UnsafeFromVar(Var aValue);
 
         virtual BOOL GetDiagTypeString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext) override;
         virtual BOOL GetDiagValueString(StringBuilder<ArenaAllocator>* stringBuilder, ScriptContext* requestContext) override;

--- a/lib/Runtime/Library/StackScriptFunction.cpp
+++ b/lib/Runtime/Library/StackScriptFunction.cpp
@@ -65,6 +65,14 @@ namespace Js
     StackScriptFunction *
     StackScriptFunction::FromVar(Var var)
     {
+        AssertOrFailFast(ScriptFunction::Is(var));
+        Assert(ThreadContext::IsOnStack(var));
+        return static_cast<StackScriptFunction *>(var);
+    }
+
+    StackScriptFunction *
+    StackScriptFunction::UnsafeFromVar(Var var)
+    {
         Assert(ScriptFunction::Is(var));
         Assert(ThreadContext::IsOnStack(var));
         return static_cast<StackScriptFunction *>(var);

--- a/lib/Runtime/Library/StackScriptFunction.h
+++ b/lib/Runtime/Library/StackScriptFunction.h
@@ -42,6 +42,7 @@ namespace Js
     private:
         static ScriptFunction * Box(StackScriptFunction * stackScriptFunction, void * returnAddress);
         static StackScriptFunction * FromVar(Var var);
+        static StackScriptFunction * UnsafeFromVar(Var var);
         struct BoxState
         {
         public:

--- a/lib/Runtime/Library/ThrowErrorObject.cpp
+++ b/lib/Runtime/Library/ThrowErrorObject.cpp
@@ -59,8 +59,14 @@ namespace Js
 
     ThrowErrorObject* ThrowErrorObject::FromVar(Var aValue)
     {
-        Assert(Is(aValue));
+        AssertOrFailFast(Is(aValue));
         return static_cast<ThrowErrorObject*>(RecyclableObject::FromVar(aValue));
+    }
+
+    ThrowErrorObject* ThrowErrorObject::UnsafeFromVar(Var aValue)
+    {
+        Assert(Is(aValue));
+        return static_cast<ThrowErrorObject*>(RecyclableObject::UnsafeFromVar(aValue));
     }
 
     RecyclableObject* ThrowErrorObject::CreateThrowErrorObject(CreateErrorFunc createError, ScriptContext* scriptContext, int32 hCode, PCWSTR varName)

--- a/lib/Runtime/Library/ThrowErrorObject.h
+++ b/lib/Runtime/Library/ThrowErrorObject.h
@@ -24,6 +24,7 @@ namespace Js
         static ThrowErrorObject* New(StaticType* type, JavascriptError* error, Recycler* recycler);
         static bool Is(Var aValue);
         static ThrowErrorObject* FromVar(Var aValue);
+        static ThrowErrorObject* UnsafeFromVar(Var aValue);
 
         static RecyclableObject* CreateThrowTypeErrorObject(ScriptContext* scriptContext, int32 hCode, PCWSTR varName);
         static RecyclableObject* CreateThrowTypeErrorObject(ScriptContext* scriptContext, int32 hCode, JavascriptString* varName);

--- a/lib/Runtime/Library/TypedArray.cpp
+++ b/lib/Runtime/Library/TypedArray.cpp
@@ -201,134 +201,267 @@ namespace Js
     template <typename TypeName, bool clamped, bool virtualAllocated>
     TypedArray<TypeName, clamped, virtualAllocated>* TypedArray<TypeName, clamped, virtualAllocated>::FromVar(Var aValue)
     {
-        AssertMsg(TypedArray::Is(aValue), "invalid TypedArray");
+        AssertOrFailFastMsg(TypedArray::Is(aValue), "invalid TypedArray");
         return static_cast<TypedArray<TypeName, clamped, virtualAllocated>*>(RecyclableObject::FromVar(aValue));
     }
 
     template<> Uint8ClampedArray* Uint8ClampedArray::FromVar(Var aValue)
     {
-        AssertMsg(Uint8ClampedArray::Is(aValue), "invalid Uint8ClampedArray");
+        AssertOrFailFastMsg(Uint8ClampedArray::Is(aValue), "invalid Uint8ClampedArray");
         return static_cast<Uint8ClampedArray*>(RecyclableObject::FromVar(aValue));
     }
 
     template<> Uint8Array* Uint8Array::FromVar(Var aValue)
     {
-        AssertMsg(Uint8Array::Is(aValue), "invalid Uint8Array");
+        AssertOrFailFastMsg(Uint8Array::Is(aValue), "invalid Uint8Array");
         return static_cast<Uint8Array*>(RecyclableObject::FromVar(aValue));
     }
 
     template<> Int8Array* Int8Array::FromVar(Var aValue)
     {
-        AssertMsg(Int8Array::Is(aValue), "invalid Int8Array");
+        AssertOrFailFastMsg(Int8Array::Is(aValue), "invalid Int8Array");
         return static_cast<Int8Array*>(RecyclableObject::FromVar(aValue));
     }
 
     template<> Int16Array* Int16Array::FromVar(Var aValue)
     {
-        AssertMsg(Int16Array::Is(aValue), "invalid Int16Array");
+        AssertOrFailFastMsg(Int16Array::Is(aValue), "invalid Int16Array");
         return static_cast<Int16Array*>(RecyclableObject::FromVar(aValue));
     }
 
     template<> Uint16Array* Uint16Array::FromVar(Var aValue)
     {
-        AssertMsg(Uint16Array::Is(aValue), "invalid Uint16Array");
+        AssertOrFailFastMsg(Uint16Array::Is(aValue), "invalid Uint16Array");
         return static_cast<Uint16Array*>(RecyclableObject::FromVar(aValue));
     }
 
     template<> Int32Array* Int32Array::FromVar(Var aValue)
     {
-        AssertMsg(Int32Array::Is(aValue), "invalid Int32Array");
+        AssertOrFailFastMsg(Int32Array::Is(aValue), "invalid Int32Array");
         return static_cast<Int32Array*>(RecyclableObject::FromVar(aValue));
     }
 
     template<> Uint32Array* Uint32Array::FromVar(Var aValue)
     {
-        AssertMsg(Uint32Array::Is(aValue), "invalid Uint32Array");
+        AssertOrFailFastMsg(Uint32Array::Is(aValue), "invalid Uint32Array");
         return static_cast<Uint32Array*>(RecyclableObject::FromVar(aValue));
     }
 
     template<> Float32Array* Float32Array::FromVar(Var aValue)
     {
-        AssertMsg(Float32Array::Is(aValue), "invalid Float32Array");
+        AssertOrFailFastMsg(Float32Array::Is(aValue), "invalid Float32Array");
         return static_cast<Float32Array*>(RecyclableObject::FromVar(aValue));
     }
 
     template<> Float64Array* Float64Array::FromVar(Var aValue)
     {
-        AssertMsg(Float64Array::Is(aValue), "invalid Float64Array");
+        AssertOrFailFastMsg(Float64Array::Is(aValue), "invalid Float64Array");
         return static_cast<Float64Array*>(RecyclableObject::FromVar(aValue));
     }
 
     template<> Int64Array* Int64Array::FromVar(Var aValue)
     {
-        AssertMsg(Int64Array::Is(aValue), "invalid Int64Array");
+        AssertOrFailFastMsg(Int64Array::Is(aValue), "invalid Int64Array");
         return static_cast<Int64Array*>(RecyclableObject::FromVar(aValue));
     }
 
     template<> Uint64Array* Uint64Array::FromVar(Var aValue)
     {
-        AssertMsg(Uint64Array::Is(aValue), "invalid Uint64Array");
+        AssertOrFailFastMsg(Uint64Array::Is(aValue), "invalid Uint64Array");
         return static_cast<Uint64Array*>(RecyclableObject::FromVar(aValue));
     }
 
     template<> Int8VirtualArray* Int8VirtualArray::FromVar(Var aValue)
     {
-        AssertMsg(Int8VirtualArray::Is(aValue), "invalid Int8Array");
+        AssertOrFailFastMsg(Int8VirtualArray::Is(aValue), "invalid Int8Array");
         return static_cast<Int8VirtualArray*>(RecyclableObject::FromVar(aValue));
     }
 
     template<> Uint8ClampedVirtualArray* Uint8ClampedVirtualArray::FromVar(Var aValue)
     {
-        AssertMsg(Uint8ClampedVirtualArray::Is(aValue), "invalid Uint8ClampedArray");
+        AssertOrFailFastMsg(Uint8ClampedVirtualArray::Is(aValue), "invalid Uint8ClampedArray");
         return static_cast<Uint8ClampedVirtualArray*>(RecyclableObject::FromVar(aValue));
     }
 
     template<> Uint8VirtualArray* Uint8VirtualArray::FromVar(Var aValue)
     {
-        AssertMsg(Uint8VirtualArray::Is(aValue), "invalid Uint8Array");
+        AssertOrFailFastMsg(Uint8VirtualArray::Is(aValue), "invalid Uint8Array");
         return static_cast<Uint8VirtualArray*>(RecyclableObject::FromVar(aValue));
     }
 
     template<> Int16VirtualArray* Int16VirtualArray::FromVar(Var aValue)
     {
-        AssertMsg(Int16VirtualArray::Is(aValue), "invalid Int16Array");
+        AssertOrFailFastMsg(Int16VirtualArray::Is(aValue), "invalid Int16Array");
         return static_cast<Int16VirtualArray*>(RecyclableObject::FromVar(aValue));
     }
 
     template<> Uint16VirtualArray* Uint16VirtualArray::FromVar(Var aValue)
     {
-        AssertMsg(Uint16VirtualArray::Is(aValue), "invalid Uint16Array");
+        AssertOrFailFastMsg(Uint16VirtualArray::Is(aValue), "invalid Uint16Array");
         return static_cast<Uint16VirtualArray*>(RecyclableObject::FromVar(aValue));
     }
 
     template<> Int32VirtualArray* Int32VirtualArray::FromVar(Var aValue)
     {
-        AssertMsg(Int32VirtualArray::Is(aValue), "invalid Int32Array");
+        AssertOrFailFastMsg(Int32VirtualArray::Is(aValue), "invalid Int32Array");
         return static_cast<Int32VirtualArray*>(RecyclableObject::FromVar(aValue));
     }
 
     template<> Uint32VirtualArray* Uint32VirtualArray::FromVar(Var aValue)
     {
-        AssertMsg(Uint32VirtualArray::Is(aValue), "invalid Uint32Array");
+        AssertOrFailFastMsg(Uint32VirtualArray::Is(aValue), "invalid Uint32Array");
         return static_cast<Uint32VirtualArray*>(RecyclableObject::FromVar(aValue));
     }
 
     template<> Float32VirtualArray* Float32VirtualArray::FromVar(Var aValue)
     {
-        AssertMsg(Float32VirtualArray::Is(aValue), "invalid Float32Array");
+        AssertOrFailFastMsg(Float32VirtualArray::Is(aValue), "invalid Float32Array");
         return static_cast<Float32VirtualArray*>(RecyclableObject::FromVar(aValue));
     }
 
     template<> Float64VirtualArray* Float64VirtualArray::FromVar(Var aValue)
     {
-        AssertMsg(Float64VirtualArray::Is(aValue), "invalid Float64Array");
+        AssertOrFailFastMsg(Float64VirtualArray::Is(aValue), "invalid Float64Array");
         return static_cast<Float64VirtualArray*>(RecyclableObject::FromVar(aValue));
     }
 
     template<> BoolArray* BoolArray::FromVar(Var aValue)
     {
-        AssertMsg(BoolArray::Is(aValue), "invalid BoolArray");
+        AssertOrFailFastMsg(BoolArray::Is(aValue), "invalid BoolArray");
         return static_cast<BoolArray*>(RecyclableObject::FromVar(aValue));
+    }
+
+    template <typename TypeName, bool clamped, bool virtualAllocated>
+    TypedArray<TypeName, clamped, virtualAllocated>* TypedArray<TypeName, clamped, virtualAllocated>::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(TypedArray::Is(aValue), "invalid TypedArray");
+        return static_cast<TypedArray<TypeName, clamped, virtualAllocated>*>(RecyclableObject::UnsafeFromVar(aValue));
+    }
+
+    template<> Uint8ClampedArray* Uint8ClampedArray::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(Uint8ClampedArray::Is(aValue), "invalid Uint8ClampedArray");
+        return static_cast<Uint8ClampedArray*>(RecyclableObject::UnsafeFromVar(aValue));
+    }
+
+    template<> Uint8Array* Uint8Array::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(Uint8Array::Is(aValue), "invalid Uint8Array");
+        return static_cast<Uint8Array*>(RecyclableObject::UnsafeFromVar(aValue));
+    }
+
+    template<> Int8Array* Int8Array::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(Int8Array::Is(aValue), "invalid Int8Array");
+        return static_cast<Int8Array*>(RecyclableObject::UnsafeFromVar(aValue));
+    }
+
+    template<> Int16Array* Int16Array::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(Int16Array::Is(aValue), "invalid Int16Array");
+        return static_cast<Int16Array*>(RecyclableObject::UnsafeFromVar(aValue));
+    }
+
+    template<> Uint16Array* Uint16Array::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(Uint16Array::Is(aValue), "invalid Uint16Array");
+        return static_cast<Uint16Array*>(RecyclableObject::UnsafeFromVar(aValue));
+    }
+
+    template<> Int32Array* Int32Array::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(Int32Array::Is(aValue), "invalid Int32Array");
+        return static_cast<Int32Array*>(RecyclableObject::UnsafeFromVar(aValue));
+    }
+
+    template<> Uint32Array* Uint32Array::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(Uint32Array::Is(aValue), "invalid Uint32Array");
+        return static_cast<Uint32Array*>(RecyclableObject::UnsafeFromVar(aValue));
+    }
+
+    template<> Float32Array* Float32Array::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(Float32Array::Is(aValue), "invalid Float32Array");
+        return static_cast<Float32Array*>(RecyclableObject::UnsafeFromVar(aValue));
+    }
+
+    template<> Float64Array* Float64Array::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(Float64Array::Is(aValue), "invalid Float64Array");
+        return static_cast<Float64Array*>(RecyclableObject::UnsafeFromVar(aValue));
+    }
+
+    template<> Int64Array* Int64Array::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(Int64Array::Is(aValue), "invalid Int64Array");
+        return static_cast<Int64Array*>(RecyclableObject::UnsafeFromVar(aValue));
+    }
+
+    template<> Uint64Array* Uint64Array::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(Uint64Array::Is(aValue), "invalid Uint64Array");
+        return static_cast<Uint64Array*>(RecyclableObject::UnsafeFromVar(aValue));
+    }
+
+    template<> Int8VirtualArray* Int8VirtualArray::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(Int8VirtualArray::Is(aValue), "invalid Int8Array");
+        return static_cast<Int8VirtualArray*>(RecyclableObject::UnsafeFromVar(aValue));
+    }
+
+    template<> Uint8ClampedVirtualArray* Uint8ClampedVirtualArray::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(Uint8ClampedVirtualArray::Is(aValue), "invalid Uint8ClampedArray");
+        return static_cast<Uint8ClampedVirtualArray*>(RecyclableObject::UnsafeFromVar(aValue));
+    }
+
+    template<> Uint8VirtualArray* Uint8VirtualArray::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(Uint8VirtualArray::Is(aValue), "invalid Uint8Array");
+        return static_cast<Uint8VirtualArray*>(RecyclableObject::UnsafeFromVar(aValue));
+    }
+
+    template<> Int16VirtualArray* Int16VirtualArray::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(Int16VirtualArray::Is(aValue), "invalid Int16Array");
+        return static_cast<Int16VirtualArray*>(RecyclableObject::UnsafeFromVar(aValue));
+    }
+
+    template<> Uint16VirtualArray* Uint16VirtualArray::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(Uint16VirtualArray::Is(aValue), "invalid Uint16Array");
+        return static_cast<Uint16VirtualArray*>(RecyclableObject::UnsafeFromVar(aValue));
+    }
+
+    template<> Int32VirtualArray* Int32VirtualArray::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(Int32VirtualArray::Is(aValue), "invalid Int32Array");
+        return static_cast<Int32VirtualArray*>(RecyclableObject::UnsafeFromVar(aValue));
+    }
+
+    template<> Uint32VirtualArray* Uint32VirtualArray::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(Uint32VirtualArray::Is(aValue), "invalid Uint32Array");
+        return static_cast<Uint32VirtualArray*>(RecyclableObject::UnsafeFromVar(aValue));
+    }
+
+    template<> Float32VirtualArray* Float32VirtualArray::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(Float32VirtualArray::Is(aValue), "invalid Float32Array");
+        return static_cast<Float32VirtualArray*>(RecyclableObject::UnsafeFromVar(aValue));
+    }
+
+    template<> Float64VirtualArray* Float64VirtualArray::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(Float64VirtualArray::Is(aValue), "invalid Float64Array");
+        return static_cast<Float64VirtualArray*>(RecyclableObject::UnsafeFromVar(aValue));
+    }
+
+    template<> BoolArray* BoolArray::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(BoolArray::Is(aValue), "invalid BoolArray");
+        return static_cast<BoolArray*>(RecyclableObject::UnsafeFromVar(aValue));
     }
 
     TypedArrayBase::TypedArrayBase(ArrayBufferBase* arrayBuffer, uint32 offSet, uint mappedLength, uint elementSize, DynamicType* type) :
@@ -980,6 +1113,12 @@ namespace Js
 
     TypedArrayBase* TypedArrayBase::FromVar(Var aValue)
     {
+        AssertOrFailFastMsg(Is(aValue), "must be a typed array");
+        return static_cast<TypedArrayBase*>(aValue);
+    }
+
+    TypedArrayBase* TypedArrayBase::UnsafeFromVar(Var aValue)
+    {
         AssertMsg(Is(aValue), "must be a typed array");
         return static_cast<TypedArrayBase*>(aValue);
     }
@@ -1163,7 +1302,7 @@ namespace Js
             JavascriptError::ThrowTypeError(scriptContext, JSERR_This_NeedTypedArray);
         }
 
-        TypedArrayBase* typedArray = TypedArrayBase::FromVar(args[0]);
+        TypedArrayBase* typedArray = TypedArrayBase::UnsafeFromVar(args[0]);
         ArrayBufferBase* arrayBuffer = typedArray->GetArrayBuffer();
 
         if (arrayBuffer == nullptr)
@@ -1188,7 +1327,7 @@ namespace Js
             JavascriptError::ThrowTypeError(scriptContext, JSERR_This_NeedTypedArray);
         }
 
-        TypedArrayBase* typedArray = TypedArrayBase::FromVar(args[0]);
+        TypedArrayBase* typedArray = TypedArrayBase::UnsafeFromVar(args[0]);
         ArrayBufferBase* arrayBuffer = typedArray->GetArrayBuffer();
 
         if (arrayBuffer == nullptr)
@@ -1217,7 +1356,7 @@ namespace Js
             JavascriptError::ThrowTypeError(scriptContext, JSERR_This_NeedTypedArray);
         }
 
-        TypedArrayBase* typedArray = TypedArrayBase::FromVar(args[0]);
+        TypedArrayBase* typedArray = TypedArrayBase::UnsafeFromVar(args[0]);
         ArrayBufferBase* arrayBuffer = typedArray->GetArrayBuffer();
 
         if (arrayBuffer == nullptr)
@@ -1246,7 +1385,7 @@ namespace Js
             JavascriptError::ThrowTypeError(scriptContext, JSERR_This_NeedTypedArray);
         }
 
-        TypedArrayBase* typedArray = TypedArrayBase::FromVar(args[0]);
+        TypedArrayBase* typedArray = TypedArrayBase::UnsafeFromVar(args[0]);
         ArrayBufferBase* arrayBuffer = typedArray->GetArrayBuffer();
 
         if (arrayBuffer == nullptr)
@@ -1397,9 +1536,9 @@ namespace Js
             offset = ArrayBuffer::ToIndex(args[2], JSERR_InvalidTypedArrayLength, scriptContext, ArrayBuffer::MaxArrayBufferLength, false);
         }
 
-        if (TypedArrayBase::Is(args[1]))
+        TypedArrayBase* typedArraySource = JavascriptOperators::TryFromVar<Js::TypedArrayBase>(args[1]);
+        if (typedArraySource)
         {
-            TypedArrayBase* typedArraySource = TypedArrayBase::FromVar(args[1]);
             if (typedArraySource->IsDetachedBuffer() || typedArrayBase->IsDetachedBuffer()) // If IsDetachedBuffer(targetBuffer) is true, then throw a TypeError exception.
             {
                 JavascriptError::ThrowTypeError(scriptContext, JSERR_DetachedTypedArray, _u("[TypedArray].prototype.set"));
@@ -1582,16 +1721,12 @@ namespace Js
                 Js::CallInfo constructorCallInfo(Js::CallFlags_New, _countof(constructorArgs));
                 newObj = TypedArrayBase::TypedArrayCreate(constructor, &Js::Arguments(constructorCallInfo, constructorArgs), len, scriptContext);
 
-                TypedArrayBase* newTypedArrayBase = nullptr;
+                TypedArrayBase* newTypedArrayBase = JavascriptOperators::TryFromVar<Js::TypedArrayBase>(newObj);
                 JavascriptArray* newArr = nullptr;
 
-                if (TypedArrayBase::Is(newObj))
+                if (!newTypedArrayBase)
                 {
-                    newTypedArrayBase = TypedArrayBase::FromVar(newObj);
-                }
-                else if (JavascriptArray::Is(newObj))
-                {
-                    newArr = JavascriptArray::FromVar(newObj);
+                    newArr = JavascriptOperators::TryFromVar<JavascriptArray>(newObj);
                 }
 
                 for (uint32 k = 0; k < len; k++)
@@ -1629,32 +1764,24 @@ namespace Js
             Var lenValue = JavascriptOperators::OP_GetLength(items, scriptContext);
             uint32 len = JavascriptConversion::ToUInt32(lenValue, scriptContext);
 
-            TypedArrayBase* itemsTypedArrayBase = nullptr;
+            TypedArrayBase* itemsTypedArrayBase = JavascriptOperators::TryFromVar<Js::TypedArrayBase>(items);
             JavascriptArray* itemsArray = nullptr;
 
-            if (TypedArrayBase::Is(items))
+            if (!itemsTypedArrayBase)
             {
-                itemsTypedArrayBase = TypedArrayBase::FromVar(items);
-            }
-            else if (JavascriptArray::Is(items))
-            {
-                itemsArray = JavascriptArray::FromVar(items);
+                itemsArray = JavascriptOperators::TryFromVar<JavascriptArray>(items);
             }
 
             Js::Var constructorArgs[] = { constructor, JavascriptNumber::ToVar(len, scriptContext) };
             Js::CallInfo constructorCallInfo(Js::CallFlags_New, _countof(constructorArgs));
             newObj = TypedArrayBase::TypedArrayCreate(constructor, &Js::Arguments(constructorCallInfo, constructorArgs), len, scriptContext);
 
-            TypedArrayBase* newTypedArrayBase = nullptr;
+            TypedArrayBase* newTypedArrayBase = JavascriptOperators::TryFromVar<Js::TypedArrayBase>(newObj);
             JavascriptArray* newArr = nullptr;
 
-            if (TypedArrayBase::Is(newObj))
+            if (!newTypedArrayBase)
             {
-                newTypedArrayBase = TypedArrayBase::FromVar(newObj);
-            }
-            else if (JavascriptArray::Is(newObj))
-            {
-                newArr = JavascriptArray::FromVar(newObj);
+                newArr = JavascriptOperators::TryFromVar<JavascriptArray>(newObj);
             }
 
             for (uint32 k = 0; k < len; k++)
@@ -1860,10 +1987,10 @@ namespace Js
             Js::CallInfo constructorCallInfo(Js::CallFlags_New, _countof(constructorArgs));
             newObj = RecyclableObject::FromVar(TypedArrayBase::TypedArrayCreate(constructor, &Js::Arguments(constructorCallInfo, constructorArgs), captured, scriptContext));
 
-            if (TypedArrayBase::Is(newObj))
+            TypedArrayBase* newArr = JavascriptOperators::TryFromVar<Js::TypedArrayBase>(newObj);
+            if (newArr)
             {
                 // We are much more likely to have a TypedArray here than anything else
-                TypedArrayBase* newArr = TypedArrayBase::FromVar(newObj);
 
                 for (uint32 i = 0; i < captured; i++)
                 {
@@ -2653,12 +2780,11 @@ namespace Js
     // static
     TypedArrayBase* TypedArrayBase::ValidateTypedArray(Var aValue, ScriptContext *scriptContext, LPCWSTR apiName)
     {
-        if (!TypedArrayBase::Is(aValue))
+        TypedArrayBase *typedArrayBase = JavascriptOperators::TryFromVar<Js::TypedArrayBase>(aValue);
+        if (!typedArrayBase)
         {
             JavascriptError::ThrowTypeError(scriptContext, JSERR_This_NeedTypedArray);
         }
-
-        TypedArrayBase *typedArrayBase = TypedArrayBase::FromVar(aValue);
 
         if (typedArrayBase->IsDetachedBuffer())
         {
@@ -2673,10 +2799,10 @@ namespace Js
     {
         Var newObj = JavascriptOperators::NewScObject(constructor, *args, scriptContext);
 
-        TypedArrayBase::ValidateTypedArray(newObj, scriptContext, nullptr);
+        TypedArrayBase * typedArray = TypedArrayBase::ValidateTypedArray(newObj, scriptContext, nullptr);
 
         // ECMA262 22.2.4.6 TypedArrayCreate line 3. "If argumentList is a List of a single Number" (args[0] == constructor)
-        if (args->Info.Count == 2 && TypedArrayBase::FromVar(newObj)->GetLength() < length)
+        if (args->Info.Count == 2 && typedArray->GetLength() < length)
         {
             JavascriptError::ThrowTypeError(scriptContext, JSERR_InvalidTypedArrayLength);
         }
@@ -3500,8 +3626,14 @@ namespace Js
 
     inline CharArray* CharArray::FromVar(Var aValue)
     {
-        AssertMsg(CharArray::Is(aValue), "invalid CharArray");
+        AssertOrFailFastMsg(CharArray::Is(aValue), "invalid CharArray");
         return static_cast<CharArray*>(RecyclableObject::FromVar(aValue));
+    }
+
+    inline CharArray* CharArray::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(CharArray::Is(aValue), "invalid CharArray");
+        return static_cast<CharArray*>(RecyclableObject::UnsafeFromVar(aValue));
     }
 
     inline BOOL CharArray::DirectSetItem(__in uint32 index, __in Js::Var value)

--- a/lib/Runtime/Library/TypedArray.h
+++ b/lib/Runtime/Library/TypedArray.h
@@ -133,6 +133,7 @@ namespace Js
         static BOOL Is(Var aValue);
         static BOOL Is(TypeId typeId);
         static TypedArrayBase* FromVar(Var aValue);
+        static TypedArrayBase* UnsafeFromVar(Var aValue);
         // Returns false if this is not a TypedArray or it's not detached
         static BOOL IsDetachedTypedArray(Var aValue);
         static HRESULT GetBuffer(Var aValue, ArrayBuffer** outBuffer, uint32* outOffset, uint32* outLength);
@@ -262,6 +263,7 @@ namespace Js
 
         static BOOL Is(Var aValue);
         static TypedArray<TypeName, clamped, virtualAllocated>* FromVar(Var aValue);
+        static TypedArray<TypeName, clamped, virtualAllocated>* UnsafeFromVar(Var aValue);
 
         inline Var BaseTypedDirectGetItem(__in uint32 index)
         {
@@ -540,6 +542,7 @@ namespace Js
 
         Var Subarray(uint32 begin, uint32 end);
         static CharArray* FromVar(Var aValue);
+        static CharArray* UnsafeFromVar(Var aValue);
 
         virtual BOOL DirectSetItem(__in uint32 index, __in Js::Var value) override;
         virtual BOOL DirectSetItemNoSet(__in uint32 index, __in Js::Var value) override;

--- a/lib/Runtime/Library/WebAssemblyInstance.cpp
+++ b/lib/Runtime/Library/WebAssemblyInstance.cpp
@@ -52,6 +52,14 @@ WebAssemblyInstance::Is(Var value)
 WebAssemblyInstance *
 WebAssemblyInstance::FromVar(Var value)
 {
+    AssertOrFailFast(WebAssemblyInstance::Is(value));
+    return static_cast<WebAssemblyInstance*>(value);
+}
+
+/* static */
+WebAssemblyInstance *
+WebAssemblyInstance::UnsafeFromVar(Var value)
+{
     Assert(WebAssemblyInstance::Is(value));
     return static_cast<WebAssemblyInstance*>(value);
 }

--- a/lib/Runtime/Library/WebAssemblyInstance.h
+++ b/lib/Runtime/Library/WebAssemblyInstance.h
@@ -27,6 +27,7 @@ namespace Js
 
         static bool Is(Var aValue);
         static WebAssemblyInstance * FromVar(Var aValue);
+        static WebAssemblyInstance * UnsafeFromVar(Var aValue);
 
         static WebAssemblyInstance * CreateInstance(WebAssemblyModule * module, Var importObject);
     private:

--- a/lib/Runtime/Library/WebAssemblyMemory.cpp
+++ b/lib/Runtime/Library/WebAssemblyMemory.cpp
@@ -32,6 +32,14 @@ WebAssemblyMemory::Is(Var value)
 WebAssemblyMemory *
 WebAssemblyMemory::FromVar(Var value)
 {
+    AssertOrFailFast(WebAssemblyMemory::Is(value));
+    return static_cast<WebAssemblyMemory*>(value);
+}
+
+/* static */
+WebAssemblyMemory *
+WebAssemblyMemory::UnsafeFromVar(Var value)
+{
     Assert(WebAssemblyMemory::Is(value));
     return static_cast<WebAssemblyMemory*>(value);
 }

--- a/lib/Runtime/Library/WebAssemblyMemory.h
+++ b/lib/Runtime/Library/WebAssemblyMemory.h
@@ -29,6 +29,7 @@ namespace Js
 
         static bool Is(Var aValue);
         static WebAssemblyMemory * FromVar(Var aValue);
+        static WebAssemblyMemory * UnsafeFromVar(Var aValue);
 
         static WebAssemblyMemory * CreateMemoryObject(uint32 initial, uint32 maximum, ScriptContext * scriptContext);
 

--- a/lib/Runtime/Library/WebAssemblyModule.cpp
+++ b/lib/Runtime/Library/WebAssemblyModule.cpp
@@ -56,6 +56,14 @@ WebAssemblyModule::Is(Var value)
 WebAssemblyModule *
 WebAssemblyModule::FromVar(Var value)
 {
+    AssertOrFailFast(WebAssemblyModule::Is(value));
+    return static_cast<WebAssemblyModule*>(value);
+}
+
+/* static */
+WebAssemblyModule *
+WebAssemblyModule::UnsafeFromVar(Var value)
+{
     Assert(WebAssemblyModule::Is(value));
     return static_cast<WebAssemblyModule*>(value);
 }

--- a/lib/Runtime/Library/WebAssemblyModule.h
+++ b/lib/Runtime/Library/WebAssemblyModule.h
@@ -46,6 +46,7 @@ public:
 
     static bool Is(Var aValue);
     static WebAssemblyModule * FromVar(Var aValue);
+    static WebAssemblyModule * UnsafeFromVar(Var aValue);
 
     static WebAssemblyModule * CreateModule(
         ScriptContext* scriptContext,

--- a/lib/Runtime/Library/WebAssemblyTable.cpp
+++ b/lib/Runtime/Library/WebAssemblyTable.cpp
@@ -31,6 +31,14 @@ WebAssemblyTable::Is(Var value)
 WebAssemblyTable *
 WebAssemblyTable::FromVar(Var value)
 {
+    AssertOrFailFast(WebAssemblyTable::Is(value));
+    return static_cast<WebAssemblyTable*>(value);
+}
+
+/* static */
+WebAssemblyTable *
+WebAssemblyTable::UnsafeFromVar(Var value)
+{
     Assert(WebAssemblyTable::Is(value));
     return static_cast<WebAssemblyTable*>(value);
 }

--- a/lib/Runtime/Library/WebAssemblyTable.h
+++ b/lib/Runtime/Library/WebAssemblyTable.h
@@ -32,6 +32,7 @@ namespace Js
 
         static bool Is(Var aValue);
         static WebAssemblyTable * FromVar(Var aValue);
+        static WebAssemblyTable * UnsafeFromVar(Var aValue);
 
         static WebAssemblyTable * Create(uint32 initial, uint32 maximum, ScriptContext * scriptContext);
 

--- a/lib/Runtime/Math/JavascriptMath.cpp
+++ b/lib/Runtime/Math/JavascriptMath.cpp
@@ -262,8 +262,8 @@ namespace Js
                 {
                     if( typeRight == TypeIds_String )
                     {
-                        JavascriptString* leftString = JavascriptString::FromVar(aLeft);
-                        JavascriptString* rightString = JavascriptString::FromVar(aRight);
+                        JavascriptString* leftString = JavascriptString::UnsafeFromVar(aLeft);
+                        JavascriptString* rightString = JavascriptString::UnsafeFromVar(aRight);
                         return JavascriptString::Concat(leftString, rightString);
                     }
                     break;
@@ -323,13 +323,13 @@ namespace Js
         {
             if (JavascriptOperators::GetTypeId(aLeft) == TypeIds_String)
             {
-                JavascriptString* leftString = JavascriptString::FromVar(aLeft);
+                JavascriptString* leftString = JavascriptString::UnsafeFromVar(aLeft);
                 JavascriptString* rightString;
                 TypeId rightType = JavascriptOperators::GetTypeId(aRight);
                 switch(rightType)
                 {
                     case TypeIds_String:
-                        rightString = JavascriptString::FromVar(aRight);
+                        rightString = JavascriptString::UnsafeFromVar(aRight);
 
 StringCommon:
                         return leftString->ConcatDestructive(rightString);
@@ -381,12 +381,12 @@ StringCommon:
             // If either side is a string, then the result is also a string
             if (JavascriptOperators::GetTypeId(primLeft) == TypeIds_String)
             {
-                JavascriptString* stringLeft = JavascriptString::FromVar(primLeft);
+                JavascriptString* stringLeft = JavascriptString::UnsafeFromVar(primLeft);
                 JavascriptString* stringRight = nullptr;
 
                 if (JavascriptOperators::GetTypeId(primRight) == TypeIds_String)
                 {
-                    stringRight = JavascriptString::FromVar(primRight);
+                    stringRight = JavascriptString::UnsafeFromVar(primRight);
                 }
                 else
                 {
@@ -403,7 +403,7 @@ StringCommon:
             if (JavascriptOperators::GetTypeId(primRight) == TypeIds_String)
             {
                 JavascriptString* stringLeft = JavascriptConversion::ToString(primLeft, scriptContext);
-                JavascriptString* stringRight = JavascriptString::FromVar(primRight);
+                JavascriptString* stringRight = JavascriptString::UnsafeFromVar(primRight);
 
                 if(leftIsDead)
                 {

--- a/lib/Runtime/Types/ActivationObject.h
+++ b/lib/Runtime/Types/ActivationObject.h
@@ -62,7 +62,7 @@ namespace Js
         }
         static BlockActivationObject* FromVar(Var value)
         {
-            Assert(BlockActivationObject::Is(value));
+            AssertOrFailFast(BlockActivationObject::Is(value));
             return static_cast<BlockActivationObject*>(DynamicObject::FromVar(value));
         }
 

--- a/lib/Runtime/Types/DictionaryTypeHandler.cpp
+++ b/lib/Runtime/Types/DictionaryTypeHandler.cpp
@@ -544,7 +544,7 @@ namespace Js
             CacheOperators::CachePropertyReadForGetter(info, originalInstance, propertyT, requestContext);
             PropertyValueInfo::SetNoCache(info, instance); // we already cached getter, so we don't have to do it once more
 
-            RecyclableObject* func = RecyclableObject::FromVar(instance->GetSlot(descriptor->GetGetterPropertyIndex()));
+            RecyclableObject* func = RecyclableObject::UnsafeFromVar(instance->GetSlot(descriptor->GetGetterPropertyIndex()));
             *value = JavascriptOperators::CallGetter(func, originalInstance, requestContext);
             return true;
         }

--- a/lib/Runtime/Types/DynamicObject.cpp
+++ b/lib/Runtime/Types/DynamicObject.cpp
@@ -15,7 +15,7 @@ namespace Js
         objectArray(nullptr)
     {
         Assert(!UsesObjectArrayOrFlagsAsFlags());
-        if(initSlots)
+        if (initSlots)
         {
             InitSlots(this);
         }
@@ -101,12 +101,20 @@ namespace Js
 
     bool DynamicObject::Is(Var aValue)
     {
-        return RecyclableObject::Is(aValue) && (RecyclableObject::FromVar(aValue)->GetTypeId() == TypeIds_Object);
+        return RecyclableObject::Is(aValue) && (RecyclableObject::UnsafeFromVar(aValue)->GetTypeId() == TypeIds_Object);
     }
 
     DynamicObject* DynamicObject::FromVar(Var aValue)
     {
         RecyclableObject* obj = RecyclableObject::FromVar(aValue);
+        AssertMsg(obj->DbgIsDynamicObject(), "Ensure instance is actually a DynamicObject");
+        AssertOrFailFast(DynamicType::Is(obj->GetTypeId()));
+        return static_cast<DynamicObject*>(obj);
+    }
+
+    DynamicObject* DynamicObject::UnsafeFromVar(Var aValue)
+    {
+        RecyclableObject* obj = RecyclableObject::UnsafeFromVar(aValue);
         AssertMsg(obj->DbgIsDynamicObject(), "Ensure instance is actually a DynamicObject");
         Assert(DynamicType::Is(obj->GetTypeId()));
         return static_cast<DynamicObject*>(obj);

--- a/lib/Runtime/Types/DynamicObject.h
+++ b/lib/Runtime/Types/DynamicObject.h
@@ -131,6 +131,7 @@ namespace Js
 
         static bool Is(Var aValue);
         static DynamicObject* FromVar(Var value);
+        static DynamicObject* UnsafeFromVar(Var value);
 
         void EnsureSlots(int oldCount, int newCount, ScriptContext * scriptContext, DynamicTypeHandler * newTypeHandler = nullptr);
         void EnsureSlots(int newCount, ScriptContext *scriptContext);

--- a/lib/Runtime/Types/JavascriptEnumerator.cpp
+++ b/lib/Runtime/Types/JavascriptEnumerator.cpp
@@ -18,8 +18,15 @@ namespace Js
 
     JavascriptEnumerator* JavascriptEnumerator::FromVar(Var aValue)
     {
-        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptEnumerator'");
+        AssertOrFailFastMsg(Is(aValue), "Ensure var is actually a 'JavascriptEnumerator'");
 
         return static_cast<JavascriptEnumerator *>(RecyclableObject::FromVar(aValue));
+    }
+
+    JavascriptEnumerator* JavascriptEnumerator::UnsafeFromVar(Var aValue)
+    {
+        AssertMsg(Is(aValue), "Ensure var is actually a 'JavascriptEnumerator'");
+
+        return static_cast<JavascriptEnumerator *>(RecyclableObject::UnsafeFromVar(aValue));
     }
 }

--- a/lib/Runtime/Types/JavascriptEnumerator.h
+++ b/lib/Runtime/Types/JavascriptEnumerator.h
@@ -40,5 +40,6 @@ namespace Js {
 
         static bool Is(Var aValue);
         static JavascriptEnumerator* FromVar(Var varValue);
+        static JavascriptEnumerator* UnsafeFromVar(Var varValue);
     };
 }

--- a/lib/Runtime/Types/RecyclableObject.cpp
+++ b/lib/Runtime/Types/RecyclableObject.cpp
@@ -165,7 +165,7 @@ namespace Js
     {
         if (DynamicType::Is(this->GetTypeId()))
         {
-            DynamicObject* dynamicThis = DynamicObject::FromVar(this);
+            DynamicObject* dynamicThis = DynamicObject::UnsafeFromVar(this);
             dynamicThis->SetIsPrototype();      // Call the DynamicObject::SetIsPrototype
         }
     }
@@ -174,7 +174,7 @@ namespace Js
     {
         if (DynamicType::Is(this->GetTypeId()))
         {
-            DynamicObject* obj = DynamicObject::FromVar(this);
+            DynamicObject* obj = DynamicObject::UnsafeFromVar(this);
             return obj->GetTypeHandler()->GetHasOnlyWritableDataProperties() &&
                 (!obj->HasObjectArray() || obj->GetObjectArrayOrFlagsAsArray()->HasOnlyWritableDataProperties());
         }
@@ -186,7 +186,7 @@ namespace Js
     {
         if (DynamicType::Is(this->GetTypeId()))
         {
-            DynamicObject* obj = DynamicObject::FromVar(this);
+            DynamicObject* obj = DynamicObject::UnsafeFromVar(this);
             obj->GetTypeHandler()->ClearWritableDataOnlyDetectionBit();
             if (obj->HasObjectArray())
             {
@@ -199,7 +199,7 @@ namespace Js
     {
         if (DynamicType::Is(this->GetTypeId()))
         {
-            DynamicObject* obj = DynamicObject::FromVar(this);
+            DynamicObject* obj = DynamicObject::UnsafeFromVar(this);
             return obj->GetTypeHandler()->IsWritableDataOnlyDetectionBitSet() ||
                 (obj->HasObjectArray() && obj->GetObjectArrayOrFlagsAsArray()->IsWritableDataOnlyDetectionBitSet());
         }

--- a/lib/Runtime/Types/RecyclableObject.h
+++ b/lib/Runtime/Types/RecyclableObject.h
@@ -227,6 +227,7 @@ namespace Js {
     public:
         static bool Is(Var aValue);
         static RecyclableObject* FromVar(Var varValue);
+        static RecyclableObject* UnsafeFromVar(Var varValue);
         RecyclableObject(Type * type);
 #if DBG_EXTRAFIELD
         // This dtor should only be call when OOM occurs and RecyclableObject ctor has completed

--- a/lib/Runtime/Types/RecyclableObject.inl
+++ b/lib/Runtime/Types/RecyclableObject.inl
@@ -27,6 +27,15 @@ namespace Js
     {
         AssertMsg(AtomTag_Object == 0, "Ensure GC objects do not need to be marked");
         AssertMsg(Is(aValue), "Ensure instance is a RecyclableObject");
+        AssertOrFailFastMsg(!TaggedNumber::Is(aValue), "Tagged value being used as RecyclableObject");
+
+        return reinterpret_cast<RecyclableObject *>(aValue);
+    }
+
+    inline RecyclableObject* RecyclableObject::UnsafeFromVar(const Js::Var aValue)
+    {
+        AssertMsg(AtomTag_Object == 0, "Ensure GC objects do not need to be marked");
+        AssertMsg(Is(aValue), "Ensure instance is a RecyclableObject");
         AssertMsg(!TaggedNumber::Is(aValue), "Tagged value being used as RecyclableObject");
 
         return reinterpret_cast<RecyclableObject *>(aValue);

--- a/lib/Runtime/Types/SpreadArgument.cpp
+++ b/lib/Runtime/Types/SpreadArgument.cpp
@@ -10,7 +10,14 @@ namespace Js
     {
         return JavascriptOperators::GetTypeId(aValue) == TypeIds_SpreadArgument;
     }
+
     SpreadArgument* SpreadArgument::FromVar(Var aValue)
+    {
+        AssertOrFailFast(SpreadArgument::Is(aValue));
+        return static_cast<SpreadArgument*>(aValue);
+    }
+
+    SpreadArgument* SpreadArgument::UnsafeFromVar(Var aValue)
     {
         Assert(SpreadArgument::Is(aValue));
         return static_cast<SpreadArgument*>(aValue);
@@ -51,7 +58,7 @@ namespace Js
             }
             else if (TypedArrayBase::Is(iterator))
             {
-                TypedArrayBase *typedArray = TypedArrayBase::FromVar(iterator);
+                TypedArrayBase *typedArray = TypedArrayBase::UnsafeFromVar(iterator);
 
                 if (typedArray->IsDetachedBuffer())
                 {

--- a/lib/Runtime/Types/SpreadArgument.h
+++ b/lib/Runtime/Types/SpreadArgument.h
@@ -20,6 +20,7 @@ namespace Js
     public:
         static bool Is(Var aValue);
         static SpreadArgument* FromVar(Var value);
+        static SpreadArgument* UnsafeFromVar(Var value);
         SpreadArgument(Var iterator, bool useDirectCall, DynamicType * type);
         const Var* GetArgumentSpread() const { return iteratorIndices ? iteratorIndices->GetBuffer() : nullptr; }
         uint GetArgumentSpreadCount()  const { return iteratorIndices ? iteratorIndices->Count() : 0; }

--- a/lib/Runtime/Types/WithScopeObject.cpp
+++ b/lib/Runtime/Types/WithScopeObject.cpp
@@ -10,7 +10,14 @@ namespace Js
     {
         return JavascriptOperators::GetTypeId(aValue) == TypeIds_WithScopeObject;
     }
+
     WithScopeObject* WithScopeObject::FromVar(Var aValue)
+    {
+        AssertOrFailFast(WithScopeObject::Is(aValue));
+        return static_cast<WithScopeObject*>(aValue);
+    }
+
+    WithScopeObject* WithScopeObject::UnsafeFromVar(Var aValue)
     {
         Assert(WithScopeObject::Is(aValue));
         return static_cast<WithScopeObject*>(aValue);

--- a/lib/Runtime/Types/WithScopeObject.h
+++ b/lib/Runtime/Types/WithScopeObject.h
@@ -18,6 +18,7 @@ namespace Js
             WithScopeObject(RecyclableObject *wrappedObject, StaticType * type) : RecyclableObject(type), wrappedObject(wrappedObject) {}
             static bool Is(Var aValue);
             static WithScopeObject* FromVar(Var value);
+            static WithScopeObject* UnsafeFromVar(Var value);
             RecyclableObject *GetWrappedObject() { return wrappedObject; }
             virtual PropertyQueryFlags HasPropertyQuery(PropertyId propertyId) override;
             virtual BOOL HasOwnProperty(PropertyId propertyId) override;


### PR DESCRIPTION
This PR hardens the FromVar method on Chakra's runtime classes to fail fast if the var passed in is not of the expected type. Although, there are a lot of instances in the code where we call FromVar only after ensuring that the var has the expected type. Those cases will now have to do a redundant check in FromVar and that has perf impact. To counter such perf loss, I have introduced two new methods:
1. UnsafeFromVar - it is identical to FromVar that we have today (checks the type, but only in debug builds). Used in cases where the type check is done by a switch on typeId.

2. JavascriptOperators::TryFromVar<T> - Performs both the type check and pointer cast (as dictated by the template parameter) for the passed in var. Used in cases where T::Is() is immediately followed by a T::FromVar.