### PR TITLE
Optimise xplat UtcTimeFromStrCore

### DIFF
--- a/pal/src/cruntime/wchar.cpp
+++ b/pal/src/cruntime/wchar.cpp
@@ -885,51 +885,67 @@ char16_t
 __cdecl
 PAL_towlower( char16_t c )
 {
-#if HAVE_COREFOUNDATION
     PERF_ENTRY(towlower);
     ENTRY("towlower (c=%d)\n", c);
-    if (!PAL_iswlower(c))
-    {
-        CFMutableStringRef cfString = CFStringCreateMutable(
-                                            kCFAllocatorDefault, 1);
-        if (cfString != NULL)
+    if(c < 128)
+    {//fast path for ascii characters
+        if(c >= 'A' && c <= 'Z')
         {
-            CFStringAppendCharacters(cfString, (const UniChar*)&c, 1);
-            CFStringLowercase(cfString, NULL);
-            c = CFStringGetCharacterAtIndex(cfString, 0);
-            CFRelease(cfString);
+            c += ('a' - 'A');
+            PERF_EXIT(towlower);
+            LOGEXIT("towlower returns int %d\n", c );
+            return c;
         }
-    }
-    LOGEXIT("towlower returns int %d\n", c );
-    PERF_EXIT(towlower);
-    return c;
-#else   /* HAVE_COREFOUNDATION */
-    UnicodeDataRec dataRec;
-
-    PERF_ENTRY(towlower);
-    ENTRY("towlower (c=%d)\n", c);
-
-    if (!GetUnicodeData(c, &dataRec))
-    {
-        TRACE( "Unable to retrieve unicode data for the character %c.\n", c );
-        LOGEXIT("towlower returns int %d\n", c );
-        PERF_EXIT(towlower);
-        return c;
-    }
-
-    if ( (dataRec.C1_TYPE_FLAGS & C1_LOWER) || (dataRec.nOpposingCase ==  0 ))
-    {
-        LOGEXIT("towlower returns int %d\n", c );
-        PERF_EXIT(towlower);
-        return c;
+        else
+        {
+            PERF_EXIT(towlower);
+            LOGEXIT("towlower returns int %d\n", c );
+            return c;
+        }
     }
     else
     {
-        LOGEXIT("towlower returns int %d\n", dataRec.nOpposingCase );
+    #if HAVE_COREFOUNDATION
+        if (!PAL_iswlower(c))
+        {
+            CFMutableStringRef cfString = CFStringCreateMutable(
+                                                kCFAllocatorDefault, 1);
+            if (cfString != NULL)
+            {
+                CFStringAppendCharacters(cfString, (const UniChar*)&c, 1);
+                CFStringLowercase(cfString, NULL);
+                c = CFStringGetCharacterAtIndex(cfString, 0);
+                CFRelease(cfString);
+            }
+        }
+        LOGEXIT("towlower returns int %d\n", c );
         PERF_EXIT(towlower);
-        return dataRec.nOpposingCase;
+        return c;
+    #else   /* HAVE_COREFOUNDATION */
+        UnicodeDataRec dataRec;
+
+        if (!GetUnicodeData(c, &dataRec))
+        {
+            TRACE( "Unable to retrieve unicode data for the character %c.\n", c );
+            LOGEXIT("towlower returns int %d\n", c );
+            PERF_EXIT(towlower);
+            return c;
+        }
+
+        if ( (dataRec.C1_TYPE_FLAGS & C1_LOWER) || (dataRec.nOpposingCase ==  0 ))
+        {
+            LOGEXIT("towlower returns int %d\n", c );
+            PERF_EXIT(towlower);
+            return c;
+        }
+        else
+        {
+            LOGEXIT("towlower returns int %d\n", dataRec.nOpposingCase );
+            PERF_EXIT(towlower);
+            return dataRec.nOpposingCase;
+        }
+    #endif  /* HAVE_COREFOUNDATION */
     }
-#endif  /* HAVE_COREFOUNDATION */
 }
 
 


### PR DESCRIPTION
**edit:** This description (other than this first paragraph) is out of date - see comments below, this is now an update to PAL_towlower to give it a fast path for ascii characters. Key outcome is the ~70% performance gain for DateImplementation::UtcTimeFromStrCore on xplat.

Added a fast inline conversion from upper case to lowercase for xplat in DateImplementation::UtcTimeFromStrCore

Note this method will not work for non-latin alphabet - but the function only uses the latin alphabet and this is ~100x faster than the PAL _wcslwr_s.

SIDENOTE: I did not revise _wcslwr_s as it appears to be used nowhere else in the source tree - I note that if it is important for any other applications in any performance critical path it should be revised, it uses a number of malloc operations equal to the length of the string + 1.

Resolves https://github.com/Microsoft/ChakraCore/issues/4008