### PR TITLE
Try-catch on top level module source was throwing syntax error.

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -9407,6 +9407,7 @@ ParseNodePtr Parser::ParseTryCatchFinally()
             Error(ERRnoCatch);
         }
         Assert(!buildAST || pnodeTC);
+        this->m_tryCatchOrFinallyDepth--;
         return pnodeTC;
     }
 

--- a/test/es6/module-functionality.js
+++ b/test/es6/module-functionality.js
@@ -318,6 +318,19 @@ var tests = [
             testRunner.LoadModule(functionBody, 'samethread');
         }
     },
+    {
+        name: "try/catch at top level at module source should not throw syntax error",
+        body: function() {
+            let functionBody =
+                `try {
+                    var k = 1;
+                } catch(e) {
+                }
+                export var x = 1; `;
+
+            testRunner.LoadModule(functionBody, 'samethread');
+        }
+    },
 ];
 
 testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });


### PR DESCRIPTION
The bookkeeping went wrong. Fixed a field when we just have try/catch.
