### PR TITLE
ARM64: add MOV_TRUNC opcode

### DIFF
--- a/lib/Backend/arm64/EncoderMD.cpp
+++ b/lib/Backend/arm64/EncoderMD.cpp
@@ -908,6 +908,7 @@ EncoderMD::GenerateEncoding(IR::Instr* instr, BYTE *pc)
         break;
 
     case Js::OpCode::MOV:
+    case Js::OpCode::MOV_TRUNC:
         bytes = this->EmitOp2Register(Emitter, instr, EmitMovRegister, EmitMovRegister64);
         break;
 

--- a/lib/Backend/arm64/LowerMD.cpp
+++ b/lib/Backend/arm64/LowerMD.cpp
@@ -286,25 +286,41 @@ LowererMD::LowerCall(IR::Instr * callInstr, Js::ArgSlot argCount)
     IR::Opnd *dstOpnd = callInstr->GetDst();
     if (dstOpnd)
     {
-        IR::Instr * movInstr;
+        Js::OpCode assignOp;
+        RegNum returnReg;
+
         if(dstOpnd->IsFloat64())
         {
-            movInstr = callInstr->SinkDst(Js::OpCode::FMOV);
-
-            callInstr->GetDst()->AsRegOpnd()->SetReg(RETURN_DBL_REG);
-            movInstr->GetSrc1()->AsRegOpnd()->SetReg(RETURN_DBL_REG);
-
-            retInstr = movInstr;
+            assignOp = Js::OpCode::FMOV;
+            returnReg = RETURN_DBL_REG;
         }
         else
         {
-            movInstr = callInstr->SinkDst(Js::OpCode::MOV);
+            assignOp = Js::OpCode::MOV;
+            returnReg = RETURN_REG;
 
-            callInstr->GetDst()->AsRegOpnd()->SetReg(RETURN_REG);
-            movInstr->GetSrc1()->AsRegOpnd()->SetReg(RETURN_REG);
-
-            retInstr = movInstr;
+            if (callInstr->GetSrc1()->IsHelperCallOpnd())
+            {
+                // Truncate the result of a conversion to 32-bit int, because the C++ code doesn't.
+                IR::HelperCallOpnd *helperOpnd = callInstr->GetSrc1()->AsHelperCallOpnd();
+                if (helperOpnd->m_fnHelper == IR::HelperConv_ToInt32 ||
+                    helperOpnd->m_fnHelper == IR::HelperConv_ToInt32_Full ||
+                    helperOpnd->m_fnHelper == IR::HelperConv_ToInt32Core ||
+                    helperOpnd->m_fnHelper == IR::HelperConv_ToUInt32 ||
+                    helperOpnd->m_fnHelper == IR::HelperConv_ToUInt32_Full ||
+                    helperOpnd->m_fnHelper == IR::HelperConv_ToUInt32Core)
+                {
+                    assignOp = Js::OpCode::MOV_TRUNC;
+                }
+            }
         }
+
+        IR::Instr * movInstr = callInstr->SinkDst(assignOp);
+
+        callInstr->GetDst()->AsRegOpnd()->SetReg(returnReg);
+        movInstr->GetSrc1()->AsRegOpnd()->SetReg(returnReg);
+
+        retInstr = movInstr;
     }
 
     //
@@ -3667,25 +3683,15 @@ LowererMD::GenerateFastMul(IR::Instr * instrMul)
 
     instrMul->InsertBefore(labelNonZero);
 
-    //
-    // Convert TyInt32 operand, back to TyMachPtr type.
-    // Cast is fine. We know ChangeType returns IR::Opnd * but it
-    // preserves the Type.
-    //
+    // dst = MOV_TRUNC s3
 
-    if(TyMachReg != s3->GetType())
-    {
-        s3 = static_cast<IR::RegOpnd *>(s3->UseWithNewType(TyMachPtr, this->m_func));
-    }
+    instr = IR::Instr::New(Js::OpCode::MOV_TRUNC, instrMul->GetDst(), s3, this->m_func);
+    instrMul->InsertBefore(instr);
 
-    // s3 = OR s3, AtomTag_IntPtr
+    // dst = OR dst, AtomTag_IntPtr
 
     GenerateInt32ToVarConversion(s3, instrMul);
 
-    // dst = MOV s3
-
-    instr = IR::Instr::New(Js::OpCode::MOV, instrMul->GetDst(), s3, this->m_func);
-    instrMul->InsertBefore(instr);
 
     //      B $fallthru
 
@@ -5099,8 +5105,8 @@ LowererMD::GenerateUntagVar(IR::RegOpnd * src, IR::LabelInstr * labelFail, IR::I
         this->GenerateSmIntTest(opnd, assignInstr, labelFail);
     }
 
-    // Doing a 32-bit MOV clears the tag bits on ARM64.
-    IR::Instr * instr = IR::Instr::New(Js::OpCode::MOV, valueOpnd, src->UseWithNewType(TyInt32, this->m_func), this->m_func);
+    // Doing a 32-bit MOV clears the tag bits on ARM64. Use MOV_TRUNC so it doesn't get peeped away.
+    IR::Instr * instr = IR::Instr::New(Js::OpCode::MOV_TRUNC, valueOpnd, src->UseWithNewType(TyInt32, this->m_func), this->m_func);
     assignInstr->InsertBefore(instr);
     return valueOpnd;
 }
@@ -6317,8 +6323,9 @@ LowererMD::LowerInt4NegWithBailOut(
 
     // Lower the instruction
     instr->m_opcode = Js::OpCode::SUBS;
-    instr->SetSrc2(instr->UnlinkSrc1());
-    instr->SetSrc1(IR::RegOpnd::New(nullptr, RegZR, TyMachReg, instr->m_func));
+    instr->ReplaceDst(instr->GetDst()->UseWithNewType(TyInt32, instr->m_func));
+    instr->SetSrc2(instr->UnlinkSrc1()->UseWithNewType(TyInt32, instr->m_func));
+    instr->SetSrc1(IR::RegOpnd::New(nullptr, RegZR, TyInt32, instr->m_func));
     Legalize(instr);
 
     if(bailOutKind & IR::BailOutOnOverflow)
@@ -6451,8 +6458,8 @@ LowererMD::LowerInt4MulWithBailOut(
     instr->InsertBefore(insertInstr);
     LegalizeMD::LegalizeInstr(insertInstr, false);
 
-    // dst = MOV s3
-    instr->m_opcode = Js::OpCode::MOV;
+    // dst = MOV_TRUNC s3
+    instr->m_opcode = Js::OpCode::MOV_TRUNC;
     instr->SetSrc1(s3->UseWithNewType(TyInt32, instr->m_func));
 
     // check negative zero
@@ -6622,11 +6629,11 @@ LowererMD::EmitLoadVar(IR::Instr *instrLoad, bool isFromUint32, bool isHelper)
 
     IR::RegOpnd *r1 = IR::RegOpnd::New(TyVar, m_func);
 
-    // e1 = MOV src1
-    // (Use 32-bit MOV here as we rely on the register copy to clear the upper 32 bits.)
+    // e1 = MOV_TRUNC src1
+    // (Use 32-bit MOV_TRUNC here as we rely on the register copy to clear the upper 32 bits.)
     IR::RegOpnd *e1 = r1->Copy(m_func)->AsRegOpnd();
     e1->SetType(TyInt32);
-    instrLoad->InsertBefore(IR::Instr::New(Js::OpCode::MOV,
+    instrLoad->InsertBefore(IR::Instr::New(Js::OpCode::MOV_TRUNC,
         e1,
         src1,
         m_func));
@@ -6779,11 +6786,10 @@ LowererMD::EmitLoadInt32(IR::Instr *instrLoad, bool conversionFromObjectAllowed,
 
             this->GenerateSmIntTest(src1, instrLoad, labelFloat ? labelFloat : helper);
         }
-        IR::RegOpnd *src132 = src1->UseWithNewType(TyInt32, instrLoad->m_func)->AsRegOpnd();
 
-        instrLoad->InsertBefore(IR::Instr::New(Js::OpCode::MOV,
+        instrLoad->InsertBefore(IR::Instr::New(Js::OpCode::MOV_TRUNC,
             dst->UseWithNewType(TyInt32, instrLoad->m_func),
-            src132,
+            src1->UseWithNewType(TyInt32, instrLoad->m_func),
             instrLoad->m_func));
 
         if (!isInt)

--- a/lib/Backend/arm64/MdOpCodes.h
+++ b/lib/Backend/arm64/MdOpCodes.h
@@ -65,6 +65,8 @@ MACRO(LEA,        Reg3,       0,              UNUSED,   LEGAL_LOAD,     UNUSED, 
 MACRO(LSL,        Reg2,       0,              UNUSED,   LEGAL_SHIFT,    UNUSED,   D___)
 MACRO(LSR,        Reg2,       0,              UNUSED,   LEGAL_SHIFT,    UNUSED,   D___)
 MACRO(MOV,        Reg2,       0,              UNUSED,   LEGAL_REG2,     UNUSED,   DM__)
+// Alias of MOV that won't get optimized out when src and dst are the same.
+MACRO(MOV_TRUNC,  Reg2,       0,              UNUSED,   LEGAL_REG2,     UNUSED,   DM__)
 MACRO(MOVK,       Reg2,       0,              UNUSED,   LEGAL_LDIMM,    UNUSED,   DM__)
 MACRO(MOVN,       Reg2,       0,              UNUSED,   LEGAL_LDIMM,    UNUSED,   DM__)
 MACRO(MOVZ,       Reg2,       0,              UNUSED,   LEGAL_LDIMM,    UNUSED,   DM__)


### PR DESCRIPTION
MOV_TRUNC is an alias of MOV that won't get removed by peeps when dst == src. Used for 64 bit to 32 bit conversions
