### PR TITLE
Fix arm debug assert allowing base offset to be R7 when functions have try

### DIFF
--- a/lib/Backend/arm/EncoderMD.cpp
+++ b/lib/Backend/arm/EncoderMD.cpp
@@ -2241,7 +2241,7 @@ EncoderMD::BaseAndOffsetFromSym(IR::SymOpnd *symOpnd, RegNum *pBaseReg, int32 *p
         if (func->GetMaxInlineeArgOutSize() != 0)
         {
             Assert(func->HasInlinee());
-            Assert(baseReg == RegSP);
+            Assert(baseReg == (func->HasTry() ?  RegR7 : RegSP));
             if (stackSym->IsArgSlotSym() && !stackSym->m_isOrphanedArg)
             {
                 Assert(stackSym->m_isInlinedArgSlot);
@@ -2250,7 +2250,7 @@ EncoderMD::BaseAndOffsetFromSym(IR::SymOpnd *symOpnd, RegNum *pBaseReg, int32 *p
             else
             {
                 AssertMsg(stackSym->IsAllocated(), "StackSym offset should be set");
-                Assert((uint)offset > func->m_argSlotsForFunctionsCalled * MachRegInt + func->GetMaxInlineeArgOutSize());
+                Assert(offset > (func->HasTry() ? (int32)func->GetMaxInlineeArgOutSize() : (int32)(func->m_argSlotsForFunctionsCalled * MachRegInt + func->GetMaxInlineeArgOutSize())));
             }
         }
         // TODO: restore the following assert (very useful) once we have a way to tell whether prolog/epilog

--- a/lib/Backend/arm64/EncoderMD.cpp
+++ b/lib/Backend/arm64/EncoderMD.cpp
@@ -1405,6 +1405,7 @@ EncoderMD::BaseAndOffsetFromSym(IR::SymOpnd *symOpnd, RegNum *pBaseReg, int32 *p
 
         if (func->HasInlinee())
         {
+            // TODO (megupta): BaseReg will be a pre-reserved non SP register when we start supporting try
             Assert(baseReg == RegSP);
             if (stackSym->IsArgSlotSym() && !stackSym->m_isOrphanedArg)
             {
@@ -1415,6 +1416,7 @@ EncoderMD::BaseAndOffsetFromSym(IR::SymOpnd *symOpnd, RegNum *pBaseReg, int32 *p
             {
                 AssertMsg(stackSym->IsAllocated(), "StackSym offset should be set");
                 //Assert((uint)offset > ((func->m_argSlotsForFunctionsCalled + func->GetMaxInlineeArgOutCount()) * MachRegInt));
+                //Assert(offset > (func->HasTry() ? (int32)func->GetMaxInlineeArgOutSize() : (int32)(func->m_argSlotsForFunctionsCalled * MachRegInt + func->GetMaxInlineeArgOutSize())));
             }
         }
         // TODO: restore the following assert (very useful) once we have a way to tell whether prolog/epilog


### PR DESCRIPTION
We always used R7 as base register in arm when there is a try. We now have inlined functions within try.
Fix assert in Encoder which should now take care of case where there are inlined functions in try.
