### PR TITLE
Remove redundant class name in function declaration (Fix #4052)

### DIFF
--- a/lib/Backend/Opnd.h
+++ b/lib/Backend/Opnd.h
@@ -1499,7 +1499,7 @@ class ListOpnd : public Opnd
     };
 public:
     ~ListOpnd();
-    static ListOpnd* ListOpnd::New(Func *func, __in_ecount(count) ListOpndType** opnds, DECLSPEC_GUARD_OVERFLOW int count);
+    static ListOpnd* New(Func *func, __in_ecount(count) ListOpndType** opnds, DECLSPEC_GUARD_OVERFLOW int count);
     template<typename... T>
     static ListOpnd* New(Func *func, T... opnds)
     {


### PR DESCRIPTION
This PR removes "ListOpnd::" from the member function declaration in Opnd.h.

Fixes #4052