### PR TITLE
Updating Stats:Recycler output

### DIFF
--- a/lib/Common/Memory/HeapBlock.inl
+++ b/lib/Common/Memory/HeapBlock.inl
@@ -221,9 +221,6 @@ HeapBlock::UpdateAttributesOfMarkedObjects(MarkContext * markContext, void * obj
     }        
 
 #ifdef RECYCLER_STATS
-    RECYCLER_STATS_INTERLOCKED_INC(markContext->GetRecycler(), markData.markCount);
-    RECYCLER_STATS_INTERLOCKED_ADD(markContext->GetRecycler(), markData.markBytes, objectSize);
-
     // Don't count track or finalize it if we still have to process it in thread because of OOM
     if ((attributes & (TrackBit | NewTrackBit)) != (TrackBit | NewTrackBit))
     {

--- a/lib/Common/Memory/Recycler.cpp
+++ b/lib/Common/Memory/Recycler.cpp
@@ -6787,7 +6787,7 @@ Recycler::PrintHeapBlockMemoryStats(char16 const * name, HeapBlock::HeapBlockTyp
         SmallAllocationBlockAttributes::PageCount : MediumAllocationBlockAttributes::PageCount;
     size_t totalByteCount = (collectionStats.heapBlockCount[type] - collectionStats.heapBlockFreeCount[type]) * blockPages * AutoSystemInfo::PageSize;
     size_t liveByteCount = totalByteCount - collectionStats.heapBlockFreeByteCount[type];
-    Output::Print(_u(" %6s: %10d %10d"), name, liveByteCount, allocableFreeByteCount);
+    Output::Print(_u(" %8s: %10d %10d"), name, liveByteCount, allocableFreeByteCount);
 
 #if ENABLE_PARTIAL_GC
     if (this->enablePartialCollect &&

--- a/lib/Common/Memory/Recycler.h
+++ b/lib/Common/Memory/Recycler.h
@@ -462,8 +462,8 @@ struct RecyclerCollectionStats
     size_t scanCount;           // non-leaf objects marked.
     size_t trackCount;
     size_t finalizeCount;
-    size_t markThruNewObjCount;
-    size_t markThruFalseNewObjCount;
+    size_t markThruNewObjCount;      // UNUSED no longer relevant?
+    size_t markThruFalseNewObjCount; // UNUSED no longer relevant?
 
     struct MarkData
     {
@@ -623,6 +623,7 @@ class Recycler
     friend class MarkContext;
     friend class HeapBlock;
     friend class HeapBlockMap32;
+    friend class HeapBlockMap64;
 #if ENABLE_CONCURRENT_GC
     friend class RecyclerParallelThread;
 #endif

--- a/lib/Common/Memory/RecyclerSweep.cpp
+++ b/lib/Common/Memory/RecyclerSweep.cpp
@@ -683,6 +683,10 @@ RecyclerSweep::AdjustPartialHeuristics()
         // new objects in thread.
         if (collectEfficacy < MinPartialCollectEfficacy)
         {
+#ifdef RECYCLER_STATS
+            recycler->collectionStats.collectEfficacy = collectEfficacy;
+            recycler->collectionStats.partialCollectSmallHeapBlockReuseMinFreeBytes = (size_t)(AutoSystemInfo::PageSize * collectEfficacy);
+#endif
             return false;
         }
 

--- a/lib/Common/Memory/SmallFinalizableHeapBlock.cpp
+++ b/lib/Common/Memory/SmallFinalizableHeapBlock.cpp
@@ -209,9 +209,6 @@ bool SmallRecyclerVisitedHostHeapBlockT<TBlockAttributes>::UpdateAttributesOfMar
     }
 
 #ifdef RECYCLER_STATS
-    RECYCLER_STATS_INTERLOCKED_INC(markContext->GetRecycler(), markData.markCount);
-    RECYCLER_STATS_INTERLOCKED_ADD(markContext->GetRecycler(), markData.markBytes, objectSize);
-
     // Count track or finalize if we don't have to process it in thread because of OOM.
     if ((attributes & (TrackBit | NewTrackBit)) != (TrackBit | NewTrackBit))
     {


### PR DESCRIPTION
Stats:Recycler functionality was no longer working, with most of the
counters not updated correctly. This fixes up most of the mark tracking
section, so each TryMark should correspond to a mark or an attributed
non-mark. I believe that the SweptBlk section is also correct without
any changes in my part.

Reported memory is still not fully correct; the Unused column will
be larger than it should unless a partial GC completes and updates
the smallNonLeafHeapBlockPartialReuseBytes counters properly, but
I believe that the Total and Live numbers are representative.