### PR TITLE
replace CreateAssign with InsertMove

### DIFF
--- a/lib/Backend/IR.cpp
+++ b/lib/Backend/IR.cpp
@@ -2531,7 +2531,7 @@ Instr::HoistIndirOffset(IR::IndirOpnd *indirOpnd, RegNum regNum)
     indirOpnd->SetOffset(0);
     indirOpnd->SetIndexOpnd(indexOpnd);
 
-    Instr *instrAssign = LowererMD::CreateAssign(indexOpnd, offsetOpnd, this);
+    Instr *instrAssign = Lowerer::InsertMove(indexOpnd, offsetOpnd, this);
     indexOpnd->m_sym->SetIsIntConst(offset);
     return instrAssign;
 }

--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -69,7 +69,7 @@ Lowerer::Lower()
             sym->m_allocated = true;
             IR::Opnd* opnd1 = IR::SymOpnd::New(sym, TyInt8, m_func);
             IR::Opnd* opnd2 = IR::IntConstOpnd::New(0, TyInt8, m_func);
-            LowererMD::CreateAssign(opnd1, opnd2, m_func->GetFunctionEntryInsertionPoint());
+            Lowerer::InsertMove(opnd1, opnd2, m_func->GetFunctionEntryInsertionPoint());
 
 #ifdef DBG
             // Pre-fill all local slots with a pattern. This will help identify non-initialized/garbage var values.
@@ -93,7 +93,7 @@ Lowerer::Lower()
                 sym->m_offset = offset;
                 sym->m_allocated = true;
                 opnd1 = IR::SymOpnd::New(sym, opnd1Type, m_func);
-                LowererMD::CreateAssign(opnd1, opnd2, m_func->GetFunctionEntryInsertionPoint());
+                Lowerer::InsertMove(opnd1, opnd2, m_func->GetFunctionEntryInsertionPoint());
             }
 #endif
         }
@@ -2381,7 +2381,7 @@ Lowerer::LowerRange(IR::Instr *instrStart, IR::Instr *instrEnd, bool defaultDoFa
 
             // Update the jittedLoopIterations field on the entryPointInfo
             IR::MemRefOpnd *iterationsAddressOpnd = IR::MemRefOpnd::New(this->m_func->GetJittedLoopIterationsSinceLastBailoutAddress(), TyUint32, this->m_func);
-            m_lowererMD.CreateAssign(iterationsAddressOpnd, instr->GetDst(), instr);
+            InsertMove(iterationsAddressOpnd, instr->GetDst(), instr);
 
             break;
         }
@@ -2899,7 +2899,7 @@ Lowerer::LowerRange(IR::Instr *instrStart, IR::Instr *instrEnd, bool defaultDoFa
             IR::SymOpnd * resumeYieldDataOpnd = IR::SymOpnd::New(resumeYieldDataSym, TyMachPtr, m_func);
 
             AssertMsg(instr->m_next->IsLabelInstr(), "Expect the resume label to immediately follow Yield instruction");
-            m_lowererMD.CreateAssign(dstOpnd, resumeYieldDataOpnd, instr->m_next->m_next);
+            InsertMove(dstOpnd, resumeYieldDataOpnd, instr->m_next->m_next);
 
             GenerateBailOut(instr);
 
@@ -3324,7 +3324,7 @@ Lowerer::GenerateFastBrConst(IR::BranchInstr *branchInstr, IR::Opnd * constOpnd,
     if (!opnd->IsRegOpnd())
     {
         IR::RegOpnd *lhsReg = IR::RegOpnd::New(TyVar, m_func);
-        LowererMD::CreateAssign(lhsReg, opnd, branchInstr);
+        Lowerer::InsertMove(lhsReg, opnd, branchInstr);
 
         opnd = lhsReg;
     }
@@ -3466,7 +3466,7 @@ Lowerer::GenerateDynamicObjectAlloc(IR::Instr * newObjInstr, uint inlineSlotCoun
         GenerateMemInit(newObjDst, Js::DynamicObject::GetOffsetOfAuxSlots(), auxSlots, newObjInstr, isZeroed);
 
         IR::IndirOpnd* newObjAuxSlots = IR::IndirOpnd::New(newObjDst, Js::DynamicObject::GetOffsetOfAuxSlots(), TyMachPtr, m_func);
-        this->m_lowererMD.CreateAssign(newObjAuxSlots, auxSlots, newObjInstr);
+        this->InsertMove(newObjAuxSlots, auxSlots, newObjInstr);
     }
     else
     {
@@ -4631,12 +4631,12 @@ Lowerer::LowerNewScObject(IR::Instr *newObjInstr, bool callCtor, bool hasArgs, b
             if (returnNewScObj)
             {
                 // MOV newObjDst, createObjDst
-                this->m_lowererMD.CreateAssign(newObjDst, createObjDst, insertAfterCtorInstr);
+                this->InsertMove(newObjDst, createObjDst, insertAfterCtorInstr);
             }
             else
             {
                 LowerGetNewScObjectCommon(ctorResultObjOpnd, ctorResultObjOpnd, createObjDst, insertAfterCtorInstr);
-                this->m_lowererMD.CreateAssign(newObjDst, ctorResultObjOpnd, insertAfterCtorInstr);
+                this->InsertMove(newObjDst, ctorResultObjOpnd, insertAfterCtorInstr);
             }
         }
 
@@ -4691,7 +4691,7 @@ Lowerer::LowerNewScObject(IR::Instr *newObjInstr, bool callCtor, bool hasArgs, b
         // MOV newObjDst, createObjDst
         if (!skipNewScObj && createObjDst != newObjDst)
         {
-            this->m_lowererMD.CreateAssign(newObjDst, createObjDst, newObjInstr);
+            this->InsertMove(newObjDst, createObjDst, newObjInstr);
         }
         newObjInstr->Remove();
     }
@@ -4869,7 +4869,7 @@ bool Lowerer::TryLowerNewScObjectWithFixedCtorCache(IR::Instr* newObjInstr, IR::
 
         skipNewScObj = true;
         IR::AddrOpnd* zeroOpnd = IR::AddrOpnd::NewNull(this->m_func);
-        this->m_lowererMD.CreateAssign(newObjDst, zeroOpnd, newObjInstr);
+        this->InsertMove(newObjDst, zeroOpnd, newObjInstr);
         return true;
     }
 
@@ -4921,7 +4921,7 @@ bool Lowerer::TryLowerNewScObjectWithFixedCtorCache(IR::Instr* newObjInstr, IR::
     if (ctor->IsClassCtor())
     {
         // MOV newObjDst, function
-        this->m_lowererMD.CreateAssign(newObjDst, newObjInstr->GetSrc1(), newObjInstr);
+        this->InsertMove(newObjDst, newObjInstr->GetSrc1(), newObjInstr);
     }
     else
     {
@@ -5050,7 +5050,7 @@ Lowerer::LowerGetNewScObjectCommon(
         // Value returned by constructor is an object (use constructorReturnOpnd)
         if(!resultObjOpnd->IsEqual(constructorReturnOpnd))
         {
-            this->m_lowererMD.CreateAssign(resultObjOpnd, constructorReturnOpnd, insertBeforeInstr);
+            this->InsertMove(resultObjOpnd, constructorReturnOpnd, insertBeforeInstr);
         }
         insertBeforeInstr->InsertBefore(
             m_lowererMD.LowerUncondBranch(IR::BranchInstr::New(Js::OpCode::Br, doneLabel, m_func)));
@@ -5061,7 +5061,7 @@ Lowerer::LowerGetNewScObjectCommon(
 
     if(!resultObjOpnd->IsEqual(newObjOpnd))
     {
-        this->m_lowererMD.CreateAssign(resultObjOpnd, newObjOpnd, insertBeforeInstr);
+        this->InsertMove(resultObjOpnd, newObjOpnd, insertBeforeInstr);
     }
 
     // fall through to insertBeforeInstr or doneLabel
@@ -5092,7 +5092,7 @@ Lowerer::LowerUpdateNewScObjectCache(IR::Instr * insertInstr, IR::Opnd *dst, IR:
     if (!src1->IsRegOpnd())
     {
         IR::RegOpnd *srcRegOpnd = IR::RegOpnd::New(TyMachReg, this->m_func);
-        LowererMD::CreateAssign(srcRegOpnd, src1, insertInstr);
+        Lowerer::InsertMove(srcRegOpnd, src1, insertInstr);
         src1 = srcRegOpnd;
     }
 
@@ -5102,7 +5102,7 @@ Lowerer::LowerUpdateNewScObjectCache(IR::Instr * insertInstr, IR::Opnd *dst, IR:
         //  MOV r1, [src1 + offset(type)]       -- check base TypeIds_Function
         IR::RegOpnd *r1 = IR::RegOpnd::New(TyMachReg, this->m_func);
         IR::IndirOpnd *indirOpnd = IR::IndirOpnd::New(src1->AsRegOpnd(), Js::RecyclableObject::GetOffsetOfType(), TyMachReg, this->m_func);
-        LowererMD::CreateAssign(r1, indirOpnd, insertInstr);
+        Lowerer::InsertMove(r1, indirOpnd, insertInstr);
 
         // CMP [r1 + offset(typeId)], TypeIds_Function
         // JNE $fallThru
@@ -5115,12 +5115,12 @@ Lowerer::LowerUpdateNewScObjectCache(IR::Instr * insertInstr, IR::Opnd *dst, IR:
     // r2 = MOV JavascriptFunction->constructorCache
     IR::RegOpnd *r2 = IR::RegOpnd::New(TyVar, this->m_func);
     IR::IndirOpnd *opndIndir = IR::IndirOpnd::New(src1->AsRegOpnd(), Js::JavascriptFunction::GetOffsetOfConstructorCache(), TyMachReg, this->m_func);
-    IR::Instr *instr = LowererMD::CreateAssign(r2, opndIndir, insertInstr);
+    IR::Instr *instr = Lowerer::InsertMove(r2, opndIndir, insertInstr);
 
     // r3 = constructorCache->updateAfterCtor
     IR::RegOpnd *r3 = IR::RegOpnd::New(TyInt8, this->m_func);
     IR::IndirOpnd *indirOpnd = IR::IndirOpnd::New(r2, Js::ConstructorCache::GetOffsetOfUpdateAfterCtor(), TyUint8, this->m_func);
-    instr = LowererMD::CreateAssign(r3, indirOpnd, insertInstr);
+    instr = Lowerer::InsertMove(r3, indirOpnd, insertInstr);
 
     // TEST r3, r3                         -- check if updateAfterCtor is 0
     // JEQ $fallThru
@@ -5310,11 +5310,11 @@ Lowerer::LowerNewScObjArray(IR::Instr *newObjInstr)
         labelDone,
         insertInstr);
     // We know we have a native array, so store the weak ref and call site index.
-    m_lowererMD.CreateAssign(
+    InsertMove(
         IR::IndirOpnd::New(resultObjOpnd, Js::JavascriptNativeArray::GetOffsetOfArrayCallSiteIndex(), TyUint16, func),
         IR::Opnd::CreateProfileIdOpnd(profileId, func),
         insertInstr);
-    m_lowererMD.CreateAssign(
+    InsertMove(
         IR::IndirOpnd::New(resultObjOpnd, Js::JavascriptNativeArray::GetOffsetOfWeakFuncRef(), TyMachReg, func),
         IR::AddrOpnd::New(weakFuncRef, IR::AddrOpndKindDynamicFunctionBodyWeakRef, func),
         insertInstr);
@@ -6243,7 +6243,7 @@ Lowerer::LowerAdjustObjType(IR::Instr * instrAdjustObjType)
     this->m_func->PinTypeRef((JITType*)finalTypeOpnd->m_metadata);
 
     IR::Opnd *opnd = IR::IndirOpnd::New(baseOpnd, Js::RecyclableObject::GetOffsetOfType(), TyMachReg, instrAdjustObjType->m_func);
-    this->m_lowererMD.CreateAssign(opnd, finalTypeOpnd, instrAdjustObjType);
+    this->InsertMove(opnd, finalTypeOpnd, instrAdjustObjType);
 
     initialTypeOpnd->Free(instrAdjustObjType->m_func);
     instrAdjustObjType->Remove();
@@ -6640,7 +6640,7 @@ Lowerer::LowerScopedLdInst(IR::Instr *instr, IR::JnHelperMethod helperMethod)
 
     IR::RegOpnd* regOpnd = IR::RegOpnd::New(dstSym, TyVar, m_func);
     IR::SymOpnd*symOpnd = IR::SymOpnd::New(dstSym, TyVar, m_func);
-    this->m_lowererMD.CreateAssign(regOpnd, symOpnd, instrPrev);
+    this->InsertMove(regOpnd, symOpnd, instrPrev);
 
     return instrPrev;
 }
@@ -6910,7 +6910,7 @@ Lowerer::GenerateDirectFieldStore(IR::Instr* instrStFld, IR::PropertySymOpnd* pr
         opnd = IR::MemRefOpnd::New((char*)opndSlotArray->AsMemRefOpnd()->GetMemLoc() + (index * sizeof(Js::Var)), TyMachReg, func);
     }
 
-    this->m_lowererMD.CreateAssign(opnd, instrStFld->GetSrc1(), instrStFld);
+    this->InsertMove(opnd, instrStFld->GetSrc1(), instrStFld);
 #endif
 }
 
@@ -7185,7 +7185,7 @@ Lowerer::GenerateCachedTypeCheck(IR::Instr *instrChk, IR::PropertySymOpnd *prope
     {
         sourceType = IR::IndirOpnd::New(regOpnd, Js::RecyclableObject::GetOffsetOfType(), TyMachReg, func);
     }
-    m_lowererMD.CreateAssign(typeOpnd, sourceType, instrChk);
+    InsertMove(typeOpnd, sourceType, instrChk);
 
     if (doEquivTypeCheck)
     {
@@ -7296,7 +7296,7 @@ Lowerer::GenerateCachedTypeWithoutPropertyCheck(IR::Instr *instrInsert, IR::Prop
         }
         IR::Opnd *opnd = IR::IndirOpnd::New(baseOpnd, Js::RecyclableObject::GetOffsetOfType(), TyMachReg, this->m_func);
         typeOpnd = IR::RegOpnd::New(TyMachReg, this->m_func);
-        m_lowererMD.CreateAssign(typeOpnd, opnd, instrInsert);
+        InsertMove(typeOpnd, opnd, instrInsert);
     }
 
     Js::JitTypePropertyGuard* typePropertyGuard = CreateTypePropertyGuardForGuardedProperties(typeWithoutProperty, propertySymOpnd);
@@ -7641,7 +7641,7 @@ Lowerer::GeneratePropertyGuardCheckBailoutAndLoadType(IR::Instr *insertInstr)
     insertInstr->InsertBefore(IR::BranchInstr::New(LowererMD::MDUncondBranchOpcode, labelContinue, this->m_func));
 
     insertInstr->InsertBefore(loadNumberTypeLabel);
-    this->m_lowererMD.CreateAssign(insertInstr->GetDst(), numberTypeOpnd, insertInstr);
+    this->InsertMove(insertInstr->GetDst(), numberTypeOpnd, insertInstr);
     insertInstr->InsertBefore(IR::BranchInstr::New(LowererMD::MDUncondBranchOpcode, labelContinue, this->m_func));
 
     insertInstr->InsertBefore(labelBailout);
@@ -7673,7 +7673,7 @@ Lowerer::GenerateNonWritablePropertyCheck(IR::Instr *instrInsert, IR::PropertySy
     IR::RegOpnd *typeOpnd = IR::RegOpnd::New(TyMachReg, this->m_func);
     opnd = IR::MemRefOpnd::New((char*)protoAddr + Js::RecyclableObject::GetOffsetOfType(), TyMachReg,
         this->m_func, IR::AddrOpndKindDynamicObjectTypeRef);
-    m_lowererMD.CreateAssign(typeOpnd, opnd, instrInsert);
+    InsertMove(typeOpnd, opnd, instrInsert);
 
     //      TEST [s1->areThisAndPrototypesEnsuredToHaveOnlyWritableDataProperties].u8, 1
     //     JNE $continue
@@ -7771,7 +7771,7 @@ Lowerer::GenerateFieldStoreWithTypeChange(IR::Instr * instrStFld, IR::PropertySy
     // Set the new type.
     IR::RegOpnd *baseOpnd = propertySymOpnd->CreatePropertyOwnerOpnd(instrStFld->m_func);
     IR::Opnd *opnd = IR::IndirOpnd::New(baseOpnd, Js::RecyclableObject::GetOffsetOfType(), TyMachReg, instrStFld->m_func);
-    this->m_lowererMD.CreateAssign(opnd, finalTypeOpnd, instrStFld);
+    this->InsertMove(opnd, finalTypeOpnd, instrStFld);
 
     // Now do the store.
     GenerateDirectFieldStore(instrStFld, propertySymOpnd);
@@ -9523,7 +9523,7 @@ Lowerer::LowerJumpTableMultiBranch(IR::MultiBranchInstr * multiBrInstr, IR::RegO
     nativeJumpTableLabel->m_isDataLabel = true;
     IR::LabelOpnd * nativeJumpTable = IR::LabelOpnd::New(nativeJumpTableLabel, m_func);
     IR::RegOpnd * nativeJumpTableReg = IR::RegOpnd::New(TyMachPtr, func);
-    m_lowererMD.CreateAssign(nativeJumpTableReg, nativeJumpTable, multiBrInstr);
+    InsertMove(nativeJumpTableReg, nativeJumpTable, multiBrInstr);
 
     BranchJumpTableWrapper * branchJumpTable = multiBrInstr->GetBranchJumpTable();
     AssertMsg(branchJumpTable->labelInstr == nullptr, "Should not be already assigned");
@@ -9534,7 +9534,7 @@ Lowerer::LowerJumpTableMultiBranch(IR::MultiBranchInstr * multiBrInstr, IR::RegO
     BYTE indirScale = this->m_lowererMD.GetDefaultIndirScale();
     IR::Opnd * opndSrc = IR::IndirOpnd::New(nativeJumpTableReg, indexOpnd, indirScale, TyMachReg, this->m_func);
 
-    IR::Instr * indirInstr = m_lowererMD.CreateAssign(opndDst, opndSrc, multiBrInstr);
+    IR::Instr * indirInstr = InsertMove(opndDst, opndSrc, multiBrInstr);
 
     //MultiBr eax
     multiBrInstr->SetSrc1(indirInstr->GetDst());
@@ -10642,7 +10642,7 @@ Lowerer::LowerArgIn(IR::Instr *instrArgIn)
     // MOV undefReg, undefAddress
     IR::Opnd* opndUndefAddress = this->LoadLibraryValueOpnd(labelNormal, LibraryValue::ValueUndefined);
     opndUndef =  IR::RegOpnd::New(TyMachPtr, this->m_func);
-    LowererMD::CreateAssign(opndUndef, opndUndefAddress, labelNormal);
+    Lowerer::InsertMove(opndUndef, opndUndefAddress, labelNormal);
 
     BVSparse<JitArenaAllocator> *formalsBv = JitAnew(this->m_alloc, BVSparse<JitArenaAllocator>, this->m_alloc);
 
@@ -10657,7 +10657,7 @@ Lowerer::LowerArgIn(IR::Instr *instrArgIn)
 
         //     sn = assign undef
 
-        LowererMD::CreateAssign(dstOpnd, opndUndef, labelNormal);
+        Lowerer::InsertMove(dstOpnd, opndUndef, labelNormal);
 
         //     INC excessOpnd
         //     BrEq_A $Ln-1
@@ -10726,7 +10726,7 @@ Lowerer::LowerArgIn(IR::Instr *instrArgIn)
     Assert(dstOpnd->IsRegOpnd());
     isDuplicate = formalsBv->TestAndSet(dstOpnd->AsRegOpnd()->m_sym->AsStackSym()->m_id);
 
-    LowererMD::CreateAssign(dstOpnd, opndUndef, labelNormal);
+    Lowerer::InsertMove(dstOpnd, opndUndef, labelNormal);
 
     if (hasRest)
     {
@@ -10795,7 +10795,7 @@ Lowerer::LoadGeneratorArgsPtr(IR::Instr *instrInsert)
 
     IR::IndirOpnd * indirOpnd = IR::IndirOpnd::New(generatorRegOpnd, Js::JavascriptGenerator::GetArgsPtrOffset(), TyMachPtr, instrInsert->m_func);
     IR::RegOpnd * argsPtrOpnd = IR::RegOpnd::New(TyMachReg, instrInsert->m_func);
-    LowererMD::CreateAssign(argsPtrOpnd, indirOpnd, instrInsert);
+    Lowerer::InsertMove(argsPtrOpnd, indirOpnd, instrInsert);
     return argsPtrOpnd;
 }
 
@@ -10807,7 +10807,7 @@ Lowerer::LoadGeneratorObject(IR::Instr * instrInsert)
     IR::SymOpnd * generatorSymOpnd = IR::SymOpnd::New(generatorSym, TyMachPtr, instrInsert->m_func);
     IR::RegOpnd * generatorRegOpnd = IR::RegOpnd::New(TyMachPtr, instrInsert->m_func);
     instrInsert->m_func->SetHasImplicitParamLoad();
-    return LowererMD::CreateAssign(generatorRegOpnd, generatorSymOpnd, instrInsert);
+    return Lowerer::InsertMove(generatorRegOpnd, generatorSymOpnd, instrInsert);
 }
 
 IR::Instr *
@@ -11192,22 +11192,22 @@ Lowerer::GenerateFastInlineBuiltInMathRandom(IR::Instr* instr)
         // s0 = scriptContext->GetLibrary()->GetRandSeed1();
         // s1 = scriptContext->GetLibrary()->GetRandSeed0();
         // ===========================================================
-        this->m_lowererMD.CreateAssign(r0,
+        this->InsertMove(r0,
             IR::MemRefOpnd::New((BYTE*)m_func->GetScriptContextInfo()->GetLibraryAddr() + Js::JavascriptLibrary::GetRandSeed1Offset(), TyUint64, instr->m_func), instr);
-        this->m_lowererMD.CreateAssign(r1,
+        this->InsertMove(r1,
             IR::MemRefOpnd::New((BYTE*)m_func->GetScriptContextInfo()->GetLibraryAddr() + Js::JavascriptLibrary::GetRandSeed0Offset(), TyUint64, instr->m_func), instr);
 
         // ===========================================================
         // s1 ^= s1 << 23;
         // ===========================================================
-        this->m_lowererMD.CreateAssign(r3, r1, instr);
+        this->InsertMove(r3, r1, instr);
         this->InsertShift(Js::OpCode::Shl_A, false, r3, r3, IR::IntConstOpnd::New(23, TyInt8, m_func), instr);
         this->InsertXor(r1, r1, r3, instr);
 
         // ===========================================================
         // s1 ^= s1 >> 17;
         // ===========================================================
-        this->m_lowererMD.CreateAssign(r3, r1, instr);
+        this->InsertMove(r3, r1, instr);
         this->InsertShift(Js::OpCode::ShrU_A, false, r3, r3, IR::IntConstOpnd::New(17, TyInt8, m_func), instr);
         this->InsertXor(r1, r1, r3, instr);
 
@@ -11219,7 +11219,7 @@ Lowerer::GenerateFastInlineBuiltInMathRandom(IR::Instr* instr)
         // ===========================================================
         // s1 ^= s0 >> 26;
         // ===========================================================
-        this->m_lowererMD.CreateAssign(r3, r0, instr);
+        this->InsertMove(r3, r0, instr);
         this->InsertShift(Js::OpCode::ShrU_A, false, r3, r3, IR::IntConstOpnd::New(26, TyInt8, m_func), instr);
         this->InsertXor(r1, r1, r3, instr);
 
@@ -11227,25 +11227,25 @@ Lowerer::GenerateFastInlineBuiltInMathRandom(IR::Instr* instr)
         // scriptContext->GetLibrary()->SetRandSeed0(s0);
         // scriptContext->GetLibrary()->SetRandSeed1(s1);
         // ===========================================================
-        this->m_lowererMD.CreateAssign(
+        this->InsertMove(
             IR::MemRefOpnd::New((BYTE*)m_func->GetScriptContextInfo()->GetLibraryAddr() + Js::JavascriptLibrary::GetRandSeed0Offset(), TyUint64, m_func), r0, instr);
-        this->m_lowererMD.CreateAssign(
+        this->InsertMove(
             IR::MemRefOpnd::New((BYTE*)m_func->GetScriptContextInfo()->GetLibraryAddr() + Js::JavascriptLibrary::GetRandSeed1Offset(), TyUint64, m_func), r1, instr);
 
         // ===========================================================
         // dst = bit_cast<float64>(((s0 + s1) & mMant) | mExp);
         // ===========================================================
         this->InsertAdd(false, r1, r1, r0, instr);
-        this->m_lowererMD.CreateAssign(r3, IR::IntConstOpnd::New(mMant, TyInt64, m_func, true), instr);
+        this->InsertMove(r3, IR::IntConstOpnd::New(mMant, TyInt64, m_func, true), instr);
         this->InsertAnd(r1, r1, r3, instr);
-        this->m_lowererMD.CreateAssign(r3, IR::IntConstOpnd::New(mExp, TyInt64, m_func, true), instr);
+        this->InsertMove(r3, IR::IntConstOpnd::New(mExp, TyInt64, m_func, true), instr);
         this->InsertOr(r1, r1, r3, instr);
         this->InsertMoveBitCast(dst, r1, instr);
 
         // ===================================================================
         // dst -= 1.0;
         // ===================================================================
-        this->m_lowererMD.CreateAssign(r4, IR::MemRefOpnd::New(m_func->GetThreadContextInfo()->GetDoubleOnePointZeroAddr(), TyFloat64, m_func, IR::AddrOpndKindDynamicDoubleRef), instr);
+        this->InsertMove(r4, IR::MemRefOpnd::New(m_func->GetThreadContextInfo()->GetDoubleOnePointZeroAddr(), TyFloat64, m_func, IR::AddrOpndKindDynamicDoubleRef), instr);
         this->InsertSub(false, dst, dst, r4, instr);
     }
     else
@@ -11467,11 +11467,11 @@ Lowerer::LoadCallInfo(IR::Instr * instrInsert)
         IR::RegOpnd * generatorRegOpnd = genLoadInstr->GetDst()->AsRegOpnd();
 
         IR::IndirOpnd * indirOpnd = IR::IndirOpnd::New(generatorRegOpnd, Js::JavascriptGenerator::GetCallInfoOffset(), TyMachPtr, func);
-        IR::Instr * instr = LowererMD::CreateAssign(IR::RegOpnd::New(TyMachPtr, func), indirOpnd, instrInsert);
+        IR::Instr * instr = Lowerer::InsertMove(IR::RegOpnd::New(TyMachPtr, func), indirOpnd, instrInsert);
 
         StackSym * callInfoSym = StackSym::New(TyMachReg, func);
         IR::SymOpnd * callInfoSymOpnd = IR::SymOpnd::New(callInfoSym, TyMachReg, func);
-        LowererMD::CreateAssign(callInfoSymOpnd, instr->GetDst(), instrInsert);
+        Lowerer::InsertMove(callInfoSymOpnd, instr->GetDst(), instrInsert);
 
         srcOpnd = IR::SymOpnd::New(callInfoSym, TyMachReg, func);
     }
@@ -11553,7 +11553,7 @@ Lowerer::LowerBailOnNotSpreadable(IR::Instr *instr)
     if (!arraySrcOpnd->IsRegOpnd())
     {
         arrayOpnd = IR::RegOpnd::New(TyMachPtr, func);
-        LowererMD::CreateAssign(arrayOpnd, arraySrcOpnd, instr);
+        Lowerer::InsertMove(arrayOpnd, arraySrcOpnd, instr);
     }
     else
     {
@@ -12609,7 +12609,7 @@ Lowerer::GetFuncObjectOpnd(IR::Instr* insertBeforeInstr)
         // assigning to the dst
         Assert(!func->IsInlinee());
         IR::RegOpnd *tmpOpnd = IR::RegOpnd::New(TyMachReg, func);
-        LowererMD::CreateAssign(tmpOpnd, paramOpnd, insertBeforeInstr);
+        Lowerer::InsertMove(tmpOpnd, paramOpnd, insertBeforeInstr);
 
         paramOpnd = IR::IndirOpnd::New(tmpOpnd, Js::GeneratorVirtualScriptFunction::GetRealFunctionOffset(), TyMachPtr, func);
     }
@@ -12802,7 +12802,7 @@ Lowerer::SplitBailOnImplicitCall(IR::Instr *& instr)
     const IR::AutoReuseOpnd autoReuseNoImplicitCall(noImplicitCall, instr->m_func);
 
     // Reset the implicit call flag on every helper call
-    LowererMD::CreateAssign(implicitCallFlags, noImplicitCall, instr);
+    Lowerer::InsertMove(implicitCallFlags, noImplicitCall, instr);
 
     IR::Instr *disableImplicitCallsInstr = nullptr, *enableImplicitCallsInstr = nullptr;
     if(bailOutKind == IR::BailOutOnImplicitCallsPreOp)
@@ -12865,7 +12865,7 @@ Lowerer::SplitBailOnImplicitCall(IR::Instr * instr, IR::Instr * helperCall, IR::
     const IR::AutoReuseOpnd autoReuseNoImplicitCall(noImplicitCall, instr->m_func);
 
     // Reset the implicit call flag on every helper call
-    LowererMD::CreateAssign(implicitCallFlags, noImplicitCall, helperCall->m_prev);
+    Lowerer::InsertMove(implicitCallFlags, noImplicitCall, helperCall->m_prev);
 
     BailOutInfo * bailOutInfo = instr->GetBailOutInfo();
     if (bailOutInfo->bailOutInstr == instr)
@@ -13098,7 +13098,7 @@ Lowerer::GenerateObjectTestAndTypeLoad(IR::Instr *instrLdSt, IR::RegOpnd *opndBa
     }
 
     opndIndir = IR::IndirOpnd::New(opndBase, Js::RecyclableObject::GetOffsetOfType(), TyMachReg, this->m_func);
-    m_lowererMD.CreateAssign(opndType, opndIndir, instrLdSt);
+    InsertMove(opndType, opndIndir, instrLdSt);
 }
 
 IR::LabelInstr *
@@ -13151,7 +13151,7 @@ Lowerer::GenerateBailOut(IR::Instr * instr, IR::BranchInstr * branchInstr, IR::L
                 IR::MemRefOpnd::New((BYTE*)bailOutInfo->bailOutRecord + BailOutRecord::GetOffsetOfBailOutKind(), TyUint32, this->m_func, IR::AddrOpndKindDynamicBailOutKindRef);
         }
 
-        m_lowererMD.CreateAssign(
+        InsertMove(
             indexOpndForBailOutKind, IR::IntConstOpnd::New(instr->GetBailOutKind(), indexOpndForBailOutKind->GetType(), this->m_func), instr, false);
 
         // No point in doing this for BailOutFailedEquivalentTypeCheck or BailOutFailedEquivalentFixedFieldTypeCheck,
@@ -13173,7 +13173,7 @@ Lowerer::GenerateBailOut(IR::Instr * instr, IR::BranchInstr * branchInstr, IR::L
                 indexOpnd = IR::MemRefOpnd::New((BYTE*)bailOutInfo->bailOutRecord + BailOutRecord::GetOffsetOfPolymorphicCacheIndex(), TyUint32, this->m_func);
             }
 
-            m_lowererMD.CreateAssign(
+            InsertMove(
                 indexOpnd, IR::IntConstOpnd::New(bailOutInfo->polymorphicCacheIndex, TyUint32, this->m_func), instr, false);
         }
 
@@ -13188,7 +13188,7 @@ Lowerer::GenerateBailOut(IR::Instr * instr, IR::BranchInstr * branchInstr, IR::L
             {
                 functionBodyOpnd = IR::MemRefOpnd::New((BYTE*)bailOutInfo->bailOutRecord + SharedBailOutRecord::GetOffsetOfFunctionBody(), TyMachPtr, this->m_func);
             }
-            m_lowererMD.CreateAssign(
+            InsertMove(
                 functionBodyOpnd, CreateFunctionBodyOpnd(instr->m_func), instr, false);
         }
 
@@ -13533,7 +13533,7 @@ Lowerer::LowerInlineeStart(IR::Instr * inlineeStartInstr)
     {
         if(i == 0)
         {
-            LowererMD::CreateAssign(metaArg->m_func->GetNextInlineeFrameArgCountSlotOpnd(),
+            Lowerer::InsertMove(metaArg->m_func->GetNextInlineeFrameArgCountSlotOpnd(),
                 IR::AddrOpnd::NewNull(metaArg->m_func),
                 argInsertInstr);
         }
@@ -13586,7 +13586,7 @@ Lowerer::LowerInlineeEnd(IR::Instr *instr)
     // No need to emit code if the function wasn't marked as having implicit calls or bailout.  Dead-Store should have removed inline overhead.
     if (instr->m_func->GetHasImplicitCalls() || PHASE_OFF(Js::DeadStorePhase, this->m_func))
     {
-        LowererMD::CreateAssign(instr->m_func->GetInlineeArgCountSlotOpnd(),
+        Lowerer::InsertMove(instr->m_func->GetInlineeArgCountSlotOpnd(),
                                 IR::IntConstOpnd::New(0, TyMachReg, instr->m_func),
                                 instr);
     }
@@ -13738,7 +13738,7 @@ Lowerer::GenerateFastBrOnObject(IR::Instr *instr)
     if (!object)
     {
         object = IR::RegOpnd::New(TyVar, m_func);
-        LowererMD::CreateAssign(object, instr->GetSrc1(), instr);
+        Lowerer::InsertMove(object, instr->GetSrc1(), instr);
     }
 
     // TEST object, 1
@@ -13776,7 +13776,7 @@ void Lowerer::GenerateObjectHeaderInliningTest(IR::RegOpnd *baseOpnd, IR::LabelI
     // mov  type, [base + offsetOf(type)]
     IR::RegOpnd *const opnd = IR::RegOpnd::New(TyMachPtr, func);
 
-    m_lowererMD.CreateAssign(
+    InsertMove(
         opnd,
         IR::IndirOpnd::New(
             baseOpnd,
@@ -13786,7 +13786,7 @@ void Lowerer::GenerateObjectHeaderInliningTest(IR::RegOpnd *baseOpnd, IR::LabelI
         insertBeforeInstr);
 
     // mov typeHandler, [type + offsetOf(typeHandler)]
-    m_lowererMD.CreateAssign(
+    InsertMove(
         opnd,
         IR::IndirOpnd::New(
             opnd,
@@ -14172,7 +14172,7 @@ IR::RegOpnd *Lowerer::LoadObjectArray(IR::RegOpnd *const baseOpnd, IR::Instr *co
     arrayOpnd->m_sym = StackSym::New(TyVar, func);
     arrayOpnd->SetValueType(arrayOpnd->GetValueType().ToArray());
     const IR::AutoReuseOpnd autoReuseArrayOpnd(arrayOpnd, func, false /* autoDelete */);
-    m_lowererMD.CreateAssign(
+    InsertMove(
         arrayOpnd,
         IR::IndirOpnd::New(
             baseOpnd,
@@ -18006,7 +18006,7 @@ Lowerer::GenerateFastInlineGlobalObjectParseInt(IR::Instr *instr)
         }
         if (instr->GetDst())
         {
-            this->m_lowererMD.CreateAssign(instr->GetDst(), parseIntArgOpnd, instr);
+            this->InsertMove(instr->GetDst(), parseIntArgOpnd, instr);
         }
         InsertBranch(Js::OpCode::Br, doneLabel, instr);
         instr->InsertBefore(labelHelper);
@@ -18371,7 +18371,7 @@ Lowerer::GenerateFastReplace(IR::Opnd* strOpnd, IR::Opnd* src1, IR::Opnd* src2, 
         if(!strOpnd->IsRegOpnd())
         {
             IR::RegOpnd *strOpndReg = IR::RegOpnd::New(TyVar, m_func);
-            LowererMD::CreateAssign(strOpndReg, strOpnd, insertInstr);
+            Lowerer::InsertMove(strOpndReg, strOpnd, insertInstr);
             strOpnd = strOpndReg;
         }
 
@@ -18390,7 +18390,7 @@ Lowerer::GenerateFastReplace(IR::Opnd* strOpnd, IR::Opnd* src1, IR::Opnd* src2, 
     if(!src1->IsRegOpnd())
     {
         IR::RegOpnd *src1Reg = IR::RegOpnd::New(TyVar, m_func);
-        LowererMD::CreateAssign(src1Reg, src1, insertInstr);
+        Lowerer::InsertMove(src1Reg, src1, insertInstr);
         src1 = src1Reg;
     }
     InsertCompareBranch(
@@ -18405,7 +18405,7 @@ Lowerer::GenerateFastReplace(IR::Opnd* strOpnd, IR::Opnd* src1, IR::Opnd* src2, 
         if(!src2->IsRegOpnd())
         {
             IR::RegOpnd *src2Reg = IR::RegOpnd::New(TyVar, m_func);
-            LowererMD::CreateAssign(src2Reg, src2, insertInstr);
+            Lowerer::InsertMove(src2Reg, src2, insertInstr);
             src2 = src2Reg;
         }
         this->GenerateStringTest(src2->AsRegOpnd(), insertInstr, labelHelper);
@@ -18478,7 +18478,7 @@ Lowerer::GenerateFastInlineStringSplitMatch(IR::Instr * instr)
         if(!argsOpnd[0]->IsRegOpnd())
         {
             IR::RegOpnd *opndReg = IR::RegOpnd::New(TyVar, m_func);
-            LowererMD::CreateAssign(opndReg, argsOpnd[0], instr);
+            Lowerer::InsertMove(opndReg, argsOpnd[0], instr);
             argsOpnd[0] = opndReg;
         }
         this->GenerateStringTest(argsOpnd[0]->AsRegOpnd(), instr, labelHelper);
@@ -18496,7 +18496,7 @@ Lowerer::GenerateFastInlineStringSplitMatch(IR::Instr * instr)
     if(!argsOpnd[1]->IsRegOpnd())
     {
         IR::RegOpnd *opndReg = IR::RegOpnd::New(TyVar, m_func);
-        LowererMD::CreateAssign(opndReg, argsOpnd[1], instr);
+        Lowerer::InsertMove(opndReg, argsOpnd[1], instr);
         argsOpnd[1] = opndReg;
     }
     InsertCompareBranch(
@@ -18620,7 +18620,7 @@ Lowerer::GenerateFastInlineRegExpExec(IR::Instr * instr)
         if(!opndString->IsRegOpnd())
         {
             IR::RegOpnd *opndReg = IR::RegOpnd::New(TyVar, m_func);
-            LowererMD::CreateAssign(opndReg, opndString, instr);
+            Lowerer::InsertMove(opndReg, opndString, instr);
             opndString = opndReg;
         }
         this->GenerateStringTest(opndString->AsRegOpnd(), instr, labelHelper);
@@ -18639,7 +18639,7 @@ Lowerer::GenerateFastInlineRegExpExec(IR::Instr * instr)
     if(!opndRegex->IsRegOpnd())
     {
         IR::RegOpnd *opndReg = IR::RegOpnd::New(TyVar, m_func);
-        LowererMD::CreateAssign(opndReg, opndRegex, instr);
+        Lowerer::InsertMove(opndReg, opndRegex, instr);
         opndRegex = opndReg;
     }
     InsertCompareBranch(
@@ -18655,14 +18655,14 @@ Lowerer::GenerateFastInlineRegExpExec(IR::Instr * instr)
     {
         // Load pattern from regex operand
         IR::RegOpnd *opndPattern = IR::RegOpnd::New(TyMachPtr, m_func);
-        LowererMD::CreateAssign(
+        Lowerer::InsertMove(
             opndPattern,
             IR::IndirOpnd::New(opndRegex->AsRegOpnd(), Js::JavascriptRegExp::GetOffsetOfPattern(), TyMachPtr, m_func),
             instr);
 
         // Load program from pattern
         IR::RegOpnd *opndProgram = IR::RegOpnd::New(TyMachPtr, m_func);
-        LowererMD::CreateAssign(
+        Lowerer::InsertMove(
             opndProgram,
             IR::IndirOpnd::New(opndPattern, offsetof(UnifiedRegex::RegexPattern, rep) + offsetof(UnifiedRegex::RegexPattern::UnifiedRep, program), TyMachPtr, m_func),
             instr);
@@ -18697,7 +18697,7 @@ Lowerer::GenerateFastInlineRegExpExec(IR::Instr * instr)
 
         // ...or the DWORD doesn't match the pattern...
         IR::RegOpnd *opndBuffer = IR::RegOpnd::New(TyMachReg, m_func);
-        LowererMD::CreateAssign(
+        Lowerer::InsertMove(
             opndBuffer,
             IR::IndirOpnd::New(opndString->AsRegOpnd(), offsetof(Js::JavascriptString, m_pszValue), TyMachPtr, m_func),
             instr);
@@ -18714,7 +18714,7 @@ Lowerer::GenerateFastInlineRegExpExec(IR::Instr * instr)
         instr->InsertBefore(labelGotString);
 
         IR::RegOpnd *opndBufferDWORD = IR::RegOpnd::New(TyUint32, m_func);
-        LowererMD::CreateAssign(
+        Lowerer::InsertMove(
             opndBufferDWORD,
             IR::IndirOpnd::New(opndBuffer, 0, TyUint32, m_func),
             instr);
@@ -18729,12 +18729,12 @@ Lowerer::GenerateFastInlineRegExpExec(IR::Instr * instr)
         // ...then set the last index to 0...
         instr->InsertBefore(labelNoMatch);
 
-        LowererMD::CreateAssign(
+        Lowerer::InsertMove(
             IR::IndirOpnd::New(opndRegex->AsRegOpnd(), Js::JavascriptRegExp::GetOffsetOfLastIndexVar(), TyVar, m_func),
             IR::AddrOpnd::NewNull(m_func),
             instr);
 
-        LowererMD::CreateAssign(
+        Lowerer::InsertMove(
             IR::IndirOpnd::New(opndRegex->AsRegOpnd(), Js::JavascriptRegExp::GetOffsetOfLastIndexOrFlag(), TyUint32, m_func),
             IR::IntConstOpnd::New(0, TyUint32, m_func),
             instr);
@@ -18742,7 +18742,7 @@ Lowerer::GenerateFastInlineRegExpExec(IR::Instr * instr)
         // ...and set the dst to null...
         if (callDst)
         {
-            LowererMD::CreateAssign(
+            Lowerer::InsertMove(
                 callDst,
                 LoadLibraryValueOpnd(instr, LibraryValue::ValueNull),
                 instr);
@@ -19362,7 +19362,7 @@ Lowerer::LowerInlineSpreadArgOutLoopUsingRegisters(IR::Instr *callInstr, IR::Reg
 
     // X64 requires a reg opnd
     IR::RegOpnd *elemRegOpnd = IR::RegOpnd::New(TyMachPtr, func);
-    LowererMD::CreateAssign(elemRegOpnd, elemPtrOpnd, callInstr);
+    Lowerer::InsertMove(elemRegOpnd, elemPtrOpnd, callInstr);
     argout->SetSrc1(elemRegOpnd);
     argout->SetSrc2(indexOpnd);
     callInstr->InsertBefore(argout);
@@ -19406,7 +19406,7 @@ Lowerer::LowerCallIDynamicSpread(IR::Instr *callInstr, ushort callFlags)
     if (!arraySrcOpnd->IsRegOpnd())
     {
         arrayOpnd = IR::RegOpnd::New(TyMachPtr, func);
-        LowererMD::CreateAssign(arrayOpnd, arraySrcOpnd, spreadArrayInstr);
+        Lowerer::InsertMove(arrayOpnd, arraySrcOpnd, spreadArrayInstr);
     }
     else
     {
@@ -19437,14 +19437,14 @@ Lowerer::LowerCallIDynamicSpread(IR::Instr *callInstr, ushort callFlags)
 
     IR::RegOpnd *argsLengthOpnd = IR::RegOpnd::New(TyUint32, func);
     IR::IndirOpnd *arrayLengthPtrOpnd = IR::IndirOpnd::New(arrayOpnd, Js::JavascriptArray::GetOffsetOfLength(), TyUint32, func);
-    LowererMD::CreateAssign(argsLengthOpnd, arrayLengthPtrOpnd, callInstr);
+    Lowerer::InsertMove(argsLengthOpnd, arrayLengthPtrOpnd, callInstr);
 
     // Don't bother expanding args if there are zero
     IR::LabelInstr *zeroArgsLabel = IR::LabelInstr::New(Js::OpCode::Label, func);
     InsertCompareBranch(argsLengthOpnd, IR::IntConstOpnd::New(0, TyInt8, func), Js::OpCode::BrEq_A, true, zeroArgsLabel, callInstr);
 
     IR::RegOpnd *indexOpnd = IR::RegOpnd::New(TyUint32, func);
-    LowererMD::CreateAssign(indexOpnd, argsLengthOpnd, callInstr);
+    Lowerer::InsertMove(indexOpnd, argsLengthOpnd, callInstr);
 
     // Get the array head offset and length
     IR::IndirOpnd *arrayHeadPtrOpnd = IR::IndirOpnd::New(arrayOpnd, Js::JavascriptArray::GetOffsetOfHead(), TyMachPtr, func);
@@ -19640,7 +19640,7 @@ Lowerer::GenerateLoadStackArgumentByIndex(IR::Opnd *dst, IR::RegOpnd *indexOpnd,
     argIndirOpnd = IR::IndirOpnd::New(ebpOpnd, indexOpnd, indirScale, TyMachReg, this->m_func);
     argIndirOpnd->SetOffset(actualOffset << indirScale);
 
-    LowererMD::CreateAssign(dst, argIndirOpnd, instr);
+    Lowerer::InsertMove(dst, argIndirOpnd, instr);
 }
 
 //This function assumes there is stackargs bailout and index is always on the range.
@@ -19659,7 +19659,7 @@ Lowerer::GenerateFastStackArgumentsLdElemI(IR::Instr* ldElem)
     {
         IR::IndirOpnd *argIndirOpnd = GetArgsIndirOpndForInlinee(ldElem, indexOpnd);
 
-        LowererMD::CreateAssign(ldElem->GetDst(), argIndirOpnd, ldElem);
+        Lowerer::InsertMove(ldElem->GetDst(), argIndirOpnd, ldElem);
     }
     else
     {
@@ -19847,7 +19847,7 @@ Lowerer::GenerateFastArgumentsLdElemI(IR::Instr* ldElem, IR::LabelInstr *labelFa
             argIndirOpnd = GetArgsIndirOpndForTopFunction(ldElem, valueOpnd);
         }
 
-        LowererMD::CreateAssign(ldElem->GetDst(), argIndirOpnd, ldElem);
+        Lowerer::InsertMove(ldElem->GetDst(), argIndirOpnd, ldElem);
 
         // JMP $done
         InsertBranch(Js::OpCode::Br, labelFallThru, ldElem);
@@ -19870,7 +19870,7 @@ Lowerer::GenerateFastRealStackArgumentsLdLen(IR::Instr *ldLen)
     if(ldLen->m_func->IsInlinee())
     {
         //Get the length of the arguments
-        LowererMD::CreateAssign(ldLen->GetDst(),
+        Lowerer::InsertMove(ldLen->GetDst(),
                                IR::IntConstOpnd::New(ldLen->m_func->actualCount - 1, TyUint32, ldLen->m_func),
                                ldLen);
     }
@@ -19878,7 +19878,7 @@ Lowerer::GenerateFastRealStackArgumentsLdLen(IR::Instr *ldLen)
     {
         IR::Instr *loadInputParamCountInstr = this->m_lowererMD.LoadInputParamCount(ldLen, -1);
         IR::RegOpnd *actualCountOpnd = loadInputParamCountInstr->GetDst()->AsRegOpnd();
-        LowererMD::CreateAssign(ldLen->GetDst(), actualCountOpnd, ldLen);
+        Lowerer::InsertMove(ldLen->GetDst(), actualCountOpnd, ldLen);
     }
     ldLen->Remove();
     return false;
@@ -19901,7 +19901,7 @@ Lowerer::GenerateFastArgumentsLdLen(IR::Instr *ldLen, IR::LabelInstr* labelFallT
     if(ldLen->m_func->IsInlinee())
     {
         //Get the length of the arguments
-        LowererMD::CreateAssign(ldLen->GetDst(),
+        Lowerer::InsertMove(ldLen->GetDst(),
                                 IR::AddrOpnd::New(Js::TaggedInt::ToVarUnchecked(ldLen->m_func->actualCount - 1), IR::AddrOpndKindConstantVar, ldLen->m_func), // -1 to exclude this pointer
                                 ldLen);
     }
@@ -19911,7 +19911,7 @@ Lowerer::GenerateFastArgumentsLdLen(IR::Instr *ldLen, IR::LabelInstr* labelFallT
         IR::RegOpnd    *actualCountOpnd          = loadInputParamCountInstr->GetDst()->AsRegOpnd();
 
         this->m_lowererMD.GenerateInt32ToVarConversion(actualCountOpnd, ldLen);
-        LowererMD::CreateAssign(ldLen->GetDst(), actualCountOpnd, ldLen);
+        Lowerer::InsertMove(ldLen->GetDst(), actualCountOpnd, ldLen);
     }
     return true;
 }
@@ -19934,7 +19934,7 @@ Lowerer::GenerateFunctionTypeFromFixedFunctionObject(IR::Instr *insertInstrPt, I
     {
         functionTypeOpnd = IR::IndirOpnd::New(functionObjOpnd->AsRegOpnd(), Js::RecyclableObject::GetOffsetOfType(), TyMachPtr, this->m_func);
     }
-    LowererMD::CreateAssign(functionTypeRegOpnd, functionTypeOpnd, insertInstrPt);
+    Lowerer::InsertMove(functionTypeRegOpnd, functionTypeOpnd, insertInstrPt);
     return functionTypeRegOpnd;
 }
 
@@ -20170,11 +20170,11 @@ Lowerer::GenerateFastLdFld(IR::Instr * const instrLdFld, IR::JnHelperMethod help
     IR::RegOpnd * opndInlineCache = IR::RegOpnd::New(TyMachPtr, this->m_func);
     if (usePolymorphicInlineCache)
     {
-        LowererMD::CreateAssign(opndInlineCache, IR::AddrOpnd::New(propertySymOpnd->m_runtimePolymorphicInlineCache->GetInlineCachesAddr(), IR::AddrOpndKindDynamicInlineCache, this->m_func, true), instrLdFld);
+        Lowerer::InsertMove(opndInlineCache, IR::AddrOpnd::New(propertySymOpnd->m_runtimePolymorphicInlineCache->GetInlineCachesAddr(), IR::AddrOpndKindDynamicInlineCache, this->m_func, true), instrLdFld);
     }
     else
     {
-        LowererMD::CreateAssign(opndInlineCache, this->LoadRuntimeInlineCacheOpnd(instrLdFld, propertySymOpnd, isHelper), instrLdFld);
+        Lowerer::InsertMove(opndInlineCache, this->LoadRuntimeInlineCacheOpnd(instrLdFld, propertySymOpnd, isHelper), instrLdFld);
     }
 
     if (typeOpnd == nullptr)
@@ -20456,11 +20456,11 @@ Lowerer::GenerateFastStFld(IR::Instr * const instrStFld, IR::JnHelperMethod help
     IR::RegOpnd * opndInlineCache = IR::RegOpnd::New(TyMachPtr, this->m_func);
     if (usePolymorphicInlineCache)
     {
-        LowererMD::CreateAssign(opndInlineCache, IR::AddrOpnd::New(propertySymOpnd->m_runtimePolymorphicInlineCache->GetInlineCachesAddr(), IR::AddrOpndKindDynamicInlineCache, this->m_func, true), instrStFld);
+        Lowerer::InsertMove(opndInlineCache, IR::AddrOpnd::New(propertySymOpnd->m_runtimePolymorphicInlineCache->GetInlineCachesAddr(), IR::AddrOpndKindDynamicInlineCache, this->m_func, true), instrStFld);
     }
     else
     {
-        LowererMD::CreateAssign(opndInlineCache, this->LoadRuntimeInlineCacheOpnd(instrStFld, propertySymOpnd, isHelper), instrStFld);
+        Lowerer::InsertMove(opndInlineCache, this->LoadRuntimeInlineCacheOpnd(instrStFld, propertySymOpnd, isHelper), instrStFld);
     }
 
     if (typeOpnd == nullptr)
@@ -20661,11 +20661,11 @@ Lowerer::GenerateIsBuiltinRecyclableObject(IR::RegOpnd *regOpnd, IR::Instr *inse
 
     //  MOV typeRegOpnd, [src1 + offset(type)]
     indirOpnd = IR::IndirOpnd::New(regOpnd, Js::RecyclableObject::GetOffsetOfType(), TyMachReg, this->m_func);
-    m_lowererMD.CreateAssign(typeRegOpnd, indirOpnd, insertInstr);
+    InsertMove(typeRegOpnd, indirOpnd, insertInstr);
 
     //  MOV typeIdRegOpnd, [typeRegOpnd + offset(typeId)]
     indirOpnd = IR::IndirOpnd::New(typeRegOpnd, Js::Type::GetOffsetOfTypeId(), TyInt32, this->m_func);
-    m_lowererMD.CreateAssign(typeIdRegOpnd, indirOpnd, insertInstr);
+    InsertMove(typeIdRegOpnd, indirOpnd, insertInstr);
 
     // ADD typeIdRegOpnd, ~TypeIds_LastStaticType
     InsertAdd(false, typeIdRegOpnd, typeIdRegOpnd,
@@ -20698,7 +20698,7 @@ void Lowerer::GenerateBooleanNegate(IR::Instr * instr, IR::Opnd * srcBool, IR::O
 {
     // dst = src
     // dst = dst ^ (true ^ false) (= !src)
-    LowererMD::CreateAssign(dst, srcBool, instr);
+    Lowerer::InsertMove(dst, srcBool, instr);
     ScriptContextInfo* sci = instr->m_func->GetScriptContextInfo();
     IR::AddrOpnd* xorval = IR::AddrOpnd::New(sci->GetTrueAddr() ^ sci->GetFalseAddr(), IR::AddrOpndKindDynamicMisc, instr->m_func, true);
     InsertXor(dst, dst, xorval, instr);
@@ -20919,7 +20919,7 @@ bool Lowerer::GenerateFastEqBoolInt(IR::Instr * instr, bool *pNeedHelper, bool i
         }
         else
         {
-            LowererMD::CreateAssign(instr->GetDst(), this->LoadLibraryValueOpnd(instr, inequalResultValue), instr);
+            Lowerer::InsertMove(instr->GetDst(), this->LoadLibraryValueOpnd(instr, inequalResultValue), instr);
             instr->InsertBefore(IR::BranchInstr::New(LowererMD::MDUncondBranchOpcode, labelDone, this->m_func));
         }
     }
@@ -20946,7 +20946,7 @@ bool Lowerer::GenerateFastEqBoolInt(IR::Instr * instr, bool *pNeedHelper, bool i
         else
         {
             // For constant compares, load the constant result
-            LowererMD::CreateAssign(instr->GetDst(), this->LoadLibraryValueOpnd(instr, sameVal && srcIntIsBoolable ? equalResultValue : inequalResultValue), instr);
+            Lowerer::InsertMove(instr->GetDst(), this->LoadLibraryValueOpnd(instr, sameVal && srcIntIsBoolable ? equalResultValue : inequalResultValue), instr);
             instr->InsertBefore(IR::BranchInstr::New(LowererMD::MDUncondBranchOpcode, labelDone, this->m_func));
         }
     }
@@ -21016,7 +21016,7 @@ bool Lowerer::GenerateFastEqBoolInt(IR::Instr * instr, bool *pNeedHelper, bool i
 
             // the int resolves to something other than 0 or 1 (inequal to a bool)
             instr->InsertBefore(forceInequal);
-            LowererMD::CreateAssign(instr->GetDst(), this->LoadLibraryValueOpnd(instr, inequalResultValue), instr);
+            Lowerer::InsertMove(instr->GetDst(), this->LoadLibraryValueOpnd(instr, inequalResultValue), instr);
             instr->InsertBefore(IR::BranchInstr::New(LowererMD::MDUncondBranchOpcode, labelDone, this->m_func));
         }
     }
@@ -21067,7 +21067,7 @@ bool Lowerer::GenerateFastEqBoolInt(IR::Instr * instr, bool *pNeedHelper, bool i
             }
             else
             {
-                LowererMD::CreateAssign(instr->GetDst(), this->LoadLibraryValueOpnd(instr, inequalResultValue), instr);
+                Lowerer::InsertMove(instr->GetDst(), this->LoadLibraryValueOpnd(instr, inequalResultValue), instr);
                 instr->InsertBefore(IR::BranchInstr::New(LowererMD::MDUncondBranchOpcode, labelDone, this->m_func));
             }
         }
@@ -21097,10 +21097,10 @@ bool Lowerer::GenerateFastEqBoolInt(IR::Instr * instr, bool *pNeedHelper, bool i
                 InsertCompareBranch(IR::IntConstOpnd::New((((IntConstType)1) << Js::VarTag_Shift) + Js::AtomTag, IRType::TyVar, this->m_func), srcInt->AsRegOpnd(), Js::OpCode::BrNeq_A, isZero, instr, true);
             }
             instr->InsertBefore(isNonZero);
-            LowererMD::CreateAssign(instr->GetDst(), this->LoadLibraryValueOpnd(instr, srcBoolConstVal ? equalResultValue : inequalResultValue), instr);
+            Lowerer::InsertMove(instr->GetDst(), this->LoadLibraryValueOpnd(instr, srcBoolConstVal ? equalResultValue : inequalResultValue), instr);
             instr->InsertBefore(IR::BranchInstr::New(LowererMD::MDUncondBranchOpcode, labelDone, this->m_func));
             instr->InsertBefore(isZero);
-            LowererMD::CreateAssign(instr->GetDst(), this->LoadLibraryValueOpnd(instr, !srcBoolConstVal ? equalResultValue : inequalResultValue), instr);
+            Lowerer::InsertMove(instr->GetDst(), this->LoadLibraryValueOpnd(instr, !srcBoolConstVal ? equalResultValue : inequalResultValue), instr);
             instr->InsertBefore(IR::BranchInstr::New(LowererMD::MDUncondBranchOpcode, labelDone, this->m_func));
         }
     }
@@ -21305,19 +21305,19 @@ bool Lowerer::GenerateFastCmEqLikely(IR::Instr * instr, bool *pNeedHelper, bool 
 
     if (src1->IsEqual(src2))
     {
-        LowererMD::CreateAssign(instr->GetDst(), this->LoadLibraryValueOpnd(instr, successValueType), instr);
+        Lowerer::InsertMove(instr->GetDst(), this->LoadLibraryValueOpnd(instr, successValueType), instr);
         instr->InsertBefore(IR::BranchInstr::New(this->m_lowererMD.MDUncondBranchOpcode, labelDone, this->m_func));
     }
     else
     {
         IR::LabelInstr *cmEqual = IR::LabelInstr::New(Js::OpCode::Label, this->m_func, isInHelper);
         this->InsertCompareBranch(src1, src2, isStrict ? Js::OpCode::BrSrEq_A : Js::OpCode::BrEq_A, cmEqual, instr);
-        LowererMD::CreateAssign(instr->GetDst(), this->LoadLibraryValueOpnd(instr, failureValueType), instr);
+        Lowerer::InsertMove(instr->GetDst(), this->LoadLibraryValueOpnd(instr, failureValueType), instr);
 
         instr->InsertBefore(IR::BranchInstr::New(this->m_lowererMD.MDUncondBranchOpcode, labelDone, this->m_func));
 
         instr->InsertBefore(cmEqual);
-        LowererMD::CreateAssign(instr->GetDst(), this->LoadLibraryValueOpnd(instr, successValueType), instr);
+        Lowerer::InsertMove(instr->GetDst(), this->LoadLibraryValueOpnd(instr, successValueType), instr);
 
         instr->InsertBefore(IR::BranchInstr::New(this->m_lowererMD.MDUncondBranchOpcode, labelDone, this->m_func));
     }
@@ -22633,15 +22633,15 @@ Lowerer::GenerateJavascriptOperatorsIsConstructorGotoElse(IR::Instr *instrInsert
     loop->regAlloc.liveOnBackEdgeSyms->Set(instanceRegOpnd->m_sym->m_id);
 
     IR::IndirOpnd *indirOpnd = IR::IndirOpnd::New(instanceRegOpnd, Js::RecyclableObject::GetOffsetOfType(), TyMachPtr, func);
-    LowererMD::CreateAssign(indir0RegOpnd, indirOpnd, instrInsert);
+    Lowerer::InsertMove(indir0RegOpnd, indirOpnd, instrInsert);
 
     indirOpnd = IR::IndirOpnd::New(indir0RegOpnd, Js::Type::GetOffsetOfTypeId(), TyUint32, func);
-    LowererMD::CreateAssign(indir1RegOpnd, indirOpnd, instrInsert);
+    Lowerer::InsertMove(indir1RegOpnd, indirOpnd, instrInsert);
 
     InsertCompareBranch(indir1RegOpnd, IR::IntConstOpnd::New(Js::TypeIds_Proxy, TyUint32, func, true), Js::OpCode::BrNeq_A, labelNotProxy, instrInsert);
 
     indirOpnd = IR::IndirOpnd::New(instanceRegOpnd, Js::JavascriptProxy::GetOffsetOfTarget(), TyMachPtr, func);
-    LowererMD::CreateAssign(instanceRegOpnd, indirOpnd, instrInsert);
+    Lowerer::InsertMove(instanceRegOpnd, indirOpnd, instrInsert);
 
     InsertBranch(Js::OpCode::Br, labelProxyLoop, instrInsert);
 
@@ -22650,10 +22650,10 @@ Lowerer::GenerateJavascriptOperatorsIsConstructorGotoElse(IR::Instr *instrInsert
     InsertCompareBranch(indir1RegOpnd, IR::IntConstOpnd::New(Js::TypeIds_Function, TyUint32, func, true), Js::OpCode::BrNeq_A, labelReturnFalse, instrInsert);
 
     indirOpnd = IR::IndirOpnd::New(instanceRegOpnd, Js::JavascriptFunction::GetOffsetOfFunctionInfo(), TyMachPtr, func);
-    LowererMD::CreateAssign(indir0RegOpnd, indirOpnd, instrInsert);
+    Lowerer::InsertMove(indir0RegOpnd, indirOpnd, instrInsert);
 
     indirOpnd = IR::IndirOpnd::New(indir0RegOpnd, Js::FunctionInfo::GetAttributesOffset(), TyUint32, func);
-    LowererMD::CreateAssign(indir1RegOpnd, indirOpnd, instrInsert);
+    Lowerer::InsertMove(indir1RegOpnd, indirOpnd, instrInsert);
 
     InsertTestBranch(indir1RegOpnd, IR::IntConstOpnd::New(Js::FunctionInfo::Attributes::ErrorOnNew, TyUint32, func, true), Js::OpCode::BrNeq_A, labelReturnFalse, instrInsert);
 
@@ -22674,15 +22674,15 @@ Lowerer::GenerateRecyclableObjectGetPrototypeNullptrGoto(IR::Instr *instrInsert,
     IR::RegOpnd *flagsRegOpnd = IR::RegOpnd::New(TyUint32, func);
 
     IR::IndirOpnd *indirOpnd = IR::IndirOpnd::New(instanceRegOpnd, Js::RecyclableObject::GetOffsetOfType(), TyMachPtr, func);
-    LowererMD::CreateAssign(instanceRegOpnd, indirOpnd, instrInsert);
+    Lowerer::InsertMove(instanceRegOpnd, indirOpnd, instrInsert);
 
     indirOpnd = IR::IndirOpnd::New(instanceRegOpnd, Js::Type::GetOffsetOfFlags(), TyUint32, func);
-    LowererMD::CreateAssign(flagsRegOpnd, indirOpnd, instrInsert);
+    Lowerer::InsertMove(flagsRegOpnd, indirOpnd, instrInsert);
 
     InsertTestBranch(flagsRegOpnd, IR::IntConstOpnd::New(TypeFlagMask_HasSpecialPrototype, TyUint32, func, true), Js::OpCode::BrNeq_A, labelReturnNullptr, instrInsert);
 
     indirOpnd = IR::IndirOpnd::New(instanceRegOpnd, Js::Type::GetOffsetOfPrototype(), TyMachPtr, func);
-    LowererMD::CreateAssign(instanceRegOpnd, indirOpnd, instrInsert);
+    Lowerer::InsertMove(instanceRegOpnd, indirOpnd, instrInsert);
 }
 
 void
@@ -22719,22 +22719,22 @@ Lowerer::GenerateLdHomeObj(IR::Instr* instr)
 
     IR::Opnd *dstOpnd = instr->GetDst();
     Assert(dstOpnd->IsRegOpnd());
-    LowererMD::CreateAssign(dstOpnd, opndUndefAddress, instr);
+    Lowerer::InsertMove(dstOpnd, opndUndefAddress, instr);
 
     IR::Opnd * functionObjOpnd = nullptr;
     m_lowererMD.LoadFunctionObjectOpnd(instr, functionObjOpnd);
-    LowererMD::CreateAssign(instanceRegOpnd, functionObjOpnd, instr);
+    Lowerer::InsertMove(instanceRegOpnd, functionObjOpnd, instr);
 
     IR::Opnd * vtableAddressOpnd = this->LoadVTableValueOpnd(instr, VTableValue::VtableStackScriptFunction);
     InsertCompareBranch(IR::IndirOpnd::New(instanceRegOpnd, 0, TyMachPtr, func), vtableAddressOpnd,
         Js::OpCode::BrEq_A, true, labelDone, instr);
 
     IR::IndirOpnd *indirOpnd = IR::IndirOpnd::New(instanceRegOpnd, Js::ScriptFunction::GetOffsetOfHomeObj(), TyMachPtr, func);
-    LowererMD::CreateAssign(instanceRegOpnd, indirOpnd, instr);
+    Lowerer::InsertMove(instanceRegOpnd, indirOpnd, instr);
 
     InsertTestBranch(instanceRegOpnd, instanceRegOpnd, Js::OpCode::BrEq_A, labelDone, instr);
 
-    LowererMD::CreateAssign(dstOpnd, instanceRegOpnd, instr);
+    Lowerer::InsertMove(dstOpnd, instanceRegOpnd, instr);
 
     instr->InsertBefore(labelDone);
     instr->Remove();
@@ -22782,17 +22782,17 @@ Lowerer::GenerateLdHomeObjProto(IR::Instr* instr)
 
     IR::Opnd *dstOpnd = instr->GetDst();
     Assert(dstOpnd->IsRegOpnd());
-    LowererMD::CreateAssign(dstOpnd, opndUndefAddress, instr);
-    LowererMD::CreateAssign(instanceRegOpnd, src1Opnd, instr);
+    Lowerer::InsertMove(dstOpnd, opndUndefAddress, instr);
+    Lowerer::InsertMove(instanceRegOpnd, src1Opnd, instr);
 
     InsertTestBranch(instanceRegOpnd, instanceRegOpnd, Js::OpCode::BrEq_A, labelDone, instr);
     this->GenerateRecyclableObjectIsElse(instr, instanceRegOpnd, labelDone);
 
     IR::IndirOpnd *indirOpnd = IR::IndirOpnd::New(instanceRegOpnd, Js::RecyclableObject::GetOffsetOfType(), TyMachPtr, func);
-    LowererMD::CreateAssign(typeRegOpnd, indirOpnd, instr);
+    Lowerer::InsertMove(typeRegOpnd, indirOpnd, instr);
 
     indirOpnd = IR::IndirOpnd::New(typeRegOpnd, Js::Type::GetOffsetOfTypeId(), TyUint32, func);
-    LowererMD::CreateAssign(typeIdRegOpnd, indirOpnd, instr);
+    Lowerer::InsertMove(typeIdRegOpnd, indirOpnd, instr);
 
     InsertCompareBranch(typeIdRegOpnd, IR::IntConstOpnd::New(Js::TypeId::TypeIds_Null, TyUint32, func, true), Js::OpCode::BrEq_A, labelErr, instr);
     InsertCompareBranch(typeIdRegOpnd, IR::IntConstOpnd::New(Js::TypeId::TypeIds_Undefined, TyUint32, func, true), Js::OpCode::BrNeq_A, labelNoErr, instr);
@@ -22805,7 +22805,7 @@ Lowerer::GenerateLdHomeObjProto(IR::Instr* instr)
     this->GenerateRecyclableObjectGetPrototypeNullptrGoto(instr, instanceRegOpnd, labelDone);
     this->GenerateRecyclableObjectIsElse(instr, instanceRegOpnd, labelDone);
 
-    LowererMD::CreateAssign(dstOpnd, instanceRegOpnd, instr);
+    Lowerer::InsertMove(dstOpnd, instanceRegOpnd, instr);
 
     instr->InsertBefore(labelDone);
     instr->Remove();
@@ -22820,7 +22820,7 @@ Lowerer::GenerateLdFuncObj(IR::Instr* instr)
     IR::Opnd *functionObjOpnd = nullptr;
 
     m_lowererMD.LoadFunctionObjectOpnd(instr, functionObjOpnd);
-    LowererMD::CreateAssign(dstOpnd, functionObjOpnd, instr);
+    Lowerer::InsertMove(dstOpnd, functionObjOpnd, instr);
     instr->Remove();
 }
 
@@ -22853,11 +22853,11 @@ Lowerer::GenerateLdFuncObjProto(IR::Instr* instr)
     IR::RegOpnd *instanceRegOpnd = IR::RegOpnd::New(TyMachPtr, func);
     IR::Opnd *dstOpnd = instr->GetDst();
 
-    LowererMD::CreateAssign(instanceRegOpnd, src1Opnd, instr);
+    Lowerer::InsertMove(instanceRegOpnd, src1Opnd, instr);
 
     this->GenerateRecyclableObjectGetPrototypeNullptrGoto(instr, instanceRegOpnd, helperLabelThrowTypeError);
 
-    LowererMD::CreateAssign(dstOpnd, instanceRegOpnd, instr);
+    Lowerer::InsertMove(dstOpnd, instanceRegOpnd, instr);
 
     this->GenerateJavascriptOperatorsIsConstructorGotoElse(instr, instanceRegOpnd, labelDone, helperLabelThrowTypeError);
 
@@ -22892,7 +22892,7 @@ Lowerer::GenerateSetHomeObj(IR::Instr* instrInsert)
 
     Assert(src1Opnd != nullptr && src2Opnd != nullptr);
 
-    LowererMD::CreateAssign(funcObjRegOpnd, src1Opnd, instrInsert);
+    Lowerer::InsertMove(funcObjRegOpnd, src1Opnd, instrInsert);
 
     IR::Opnd * vtableAddressOpnd = this->LoadVTableValueOpnd(instrInsert, VTableValue::VtableJavascriptGeneratorFunction);
     InsertCompareBranch(IR::IndirOpnd::New(funcObjRegOpnd, 0, TyMachPtr, func), vtableAddressOpnd,
@@ -22905,12 +22905,12 @@ Lowerer::GenerateSetHomeObj(IR::Instr* instrInsert)
     instrInsert->InsertBefore(labelForGeneratorScriptFunction);
 
     indirOpnd = IR::IndirOpnd::New(funcObjRegOpnd, Js::JavascriptGeneratorFunction::GetOffsetOfScriptFunction(), TyMachPtr, func);
-    LowererMD::CreateAssign(funcObjRegOpnd, indirOpnd, instrInsert);
+    Lowerer::InsertMove(funcObjRegOpnd, indirOpnd, instrInsert);
 
     instrInsert->InsertBefore(labelScriptFunction);
 
     indirOpnd = IR::IndirOpnd::New(funcObjRegOpnd, Js::ScriptFunction::GetOffsetOfHomeObj(), TyMachPtr, func);
-    LowererMD::CreateAssign(indirOpnd, src2Opnd, instrInsert);
+    Lowerer::InsertMove(indirOpnd, src2Opnd, instrInsert);
 
     instrInsert->Remove();
 }
@@ -22948,13 +22948,13 @@ Lowerer::GenerateLoadNewTarget(IR::Instr* instrInsert)
 
     IR::Opnd *dstOpnd = instrInsert->GetDst();
     Assert(dstOpnd->IsRegOpnd());
-    LowererMD::CreateAssign(dstOpnd, opndUndefAddress, instrInsert);
+    Lowerer::InsertMove(dstOpnd, opndUndefAddress, instrInsert);
 
     IR::SymOpnd *callInfoOpnd = Lowerer::LoadCallInfo(instrInsert);
     Assert(Js::CallInfo::ksizeofCount == 24);
 
     IR::RegOpnd *s1 = IR::RegOpnd::New(TyUint32, func);
-    LowererMD::CreateAssign(s1, callInfoOpnd, instrInsert);
+    Lowerer::InsertMove(s1, callInfoOpnd, instrInsert);
 
     InsertTestBranch(s1, IR::IntConstOpnd::New((IntConstType)Js::CallFlags_NewTarget << Js::CallInfo::ksizeofCount, TyUint32, func, true), Js::OpCode::BrNeq_A, labelLoadArgNewTarget, instrInsert);
 
@@ -23018,7 +23018,7 @@ Lowerer::GetInlineCacheFromFuncObjectForRuntimeUse(IR::Instr * instr, IR::Proper
     LoadFuncExpression(funcObjInstr);
 
     IR::RegOpnd * funcObjHasInlineCachesOpnd = IR::RegOpnd::New(TyMachPtr, instr->m_func);
-    this->m_lowererMD.CreateAssign(funcObjHasInlineCachesOpnd, IR::IndirOpnd::New(funcObjOpnd, Js::ScriptFunction::GetOffsetOfHasInlineCaches(), TyUint8, instr->m_func), instr);
+    this->InsertMove(funcObjHasInlineCachesOpnd, IR::IndirOpnd::New(funcObjOpnd, Js::ScriptFunction::GetOffsetOfHasInlineCaches(), TyUint8, instr->m_func), instr);
 
     IR::LabelInstr * inlineCachesNullLabel = IR::LabelInstr::New(Js::OpCode::Label, instr->m_func, isHelper);
     InsertTestBranch(funcObjHasInlineCachesOpnd, funcObjHasInlineCachesOpnd, Js::OpCode::BrEq_A, inlineCachesNullLabel, instr);
@@ -23042,7 +23042,7 @@ Lowerer::GetInlineCacheFromFuncObjectForRuntimeUse(IR::Instr * instr, IR::Proper
     IR::LabelInstr * continueLabel = IR::LabelInstr::New(Js::OpCode::Label, instr->m_func, isHelper);
     InsertBranch(LowererMD::MDUncondBranchOpcode, continueLabel, instr);
 
-    IR::Instr * ldCacheFromPropSymOpndInstr = this->m_lowererMD.CreateAssign(inlineCacheOpnd, IR::AddrOpnd::New(propSymOpnd->m_runtimeInlineCache, IR::AddrOpndKindDynamicInlineCache, this->m_func), instr);
+    IR::Instr * ldCacheFromPropSymOpndInstr = this->InsertMove(inlineCacheOpnd, IR::AddrOpnd::New(propSymOpnd->m_runtimeInlineCache, IR::AddrOpndKindDynamicInlineCache, this->m_func), instr);
     ldCacheFromPropSymOpndInstr->InsertBefore(inlineCachesNullLabel);
 
     ldCacheFromPropSymOpndInstr->InsertAfter(continueLabel);
@@ -23660,11 +23660,11 @@ void Lowerer::GenerateNullOutGeneratorFrame(IR::Instr* insertInstr)
     m_func->SetArgOffset(symSrc, LowererMD::GetFormalParamOffset() * MachPtr);
     IR::SymOpnd *srcOpnd = IR::SymOpnd::New(symSrc, TyMachPtr, m_func);
     IR::RegOpnd *dstOpnd = IR::RegOpnd::New(TyMachReg, m_func);
-    m_lowererMD.CreateAssign(dstOpnd, srcOpnd, insertInstr);
+    InsertMove(dstOpnd, srcOpnd, insertInstr);
 
     IR::IndirOpnd *indirOpnd = IR::IndirOpnd::New(dstOpnd, Js::JavascriptGenerator::GetFrameOffset(), TyMachPtr, m_func);
     IR::AddrOpnd *addrOpnd = IR::AddrOpnd::NewNull(m_func);
-    m_lowererMD.CreateAssign(indirOpnd, addrOpnd, insertInstr);
+    InsertMove(indirOpnd, addrOpnd, insertInstr);
 }
 
 void Lowerer::LowerFunctionExit(IR::Instr* funcExit)
@@ -24407,8 +24407,8 @@ void Lowerer::LowerLdFrameDisplay(IR::Instr *instr, bool doStackFrameDisplay)
         GenerateRecyclerAlloc(IR::HelperAllocMemForVarArray, scopeSlotAllocSize, currentFrameOpnd, insertInstr, true);
 
         insertInstr->InsertBefore(labelDone);
-        m_lowererMD.CreateAssign(IR::SymOpnd::New(m_func->GetLocalFrameDisplaySym(), 0, TyMachReg, m_func), dstOpnd, insertInstr);
-        m_lowererMD.CreateAssign(IR::SymOpnd::New(m_func->GetLocalClosureSym(), 0, TyMachReg, m_func), currentFrameOpnd, insertInstr);
+        InsertMove(IR::SymOpnd::New(m_func->GetLocalFrameDisplaySym(), 0, TyMachReg, m_func), dstOpnd, insertInstr);
+        InsertMove(IR::SymOpnd::New(m_func->GetLocalClosureSym(), 0, TyMachReg, m_func), currentFrameOpnd, insertInstr);
     }
     else
     {
@@ -24425,16 +24425,16 @@ void Lowerer::LowerLdFrameDisplay(IR::Instr *instr, bool doStackFrameDisplay)
             IR::Opnd *scopeOpnd = IR::RegOpnd::New(TyMachReg, func);
             IR::Opnd *envLoadOpnd =
                 IR::IndirOpnd::New(envOpnd, Js::FrameDisplay::GetOffsetOfScopes() + ((i - 1) * sizeof(Js::Var)), TyMachReg, func);
-            m_lowererMD.CreateAssign(scopeOpnd, envLoadOpnd, instr);
+            InsertMove(scopeOpnd, envLoadOpnd, instr);
 
             IR::Opnd *dstStoreOpnd =
                 IR::IndirOpnd::New(dstOpnd, Js::FrameDisplay::GetOffsetOfScopes() + (i * sizeof(Js::Var)), TyMachReg, func);
-            m_lowererMD.CreateAssign(dstStoreOpnd, scopeOpnd, instr);
+            InsertMove(dstStoreOpnd, scopeOpnd, instr);
         }
     }
 
     // Assign current element.
-    m_lowererMD.CreateAssign(
+    InsertMove(
         IR::IndirOpnd::New(dstOpnd, Js::FrameDisplay::GetOffsetOfScopes(), TyMachReg, func),
         currentFrameOpnd,
         instr);
@@ -24443,7 +24443,7 @@ void Lowerer::LowerLdFrameDisplay(IR::Instr *instr, bool doStackFrameDisplay)
     uintptr_t bits = 1 |
         (isStrict << (Js::FrameDisplay::GetOffsetOfStrictMode() * 8)) |
         (frameDispLength << (Js::FrameDisplay::GetOffsetOfLength() * 8));
-    m_lowererMD.CreateAssign(
+    InsertMove(
         IR::IndirOpnd::New(dstOpnd, 0, TyMachReg, func),
         IR::IntConstOpnd::New(bits, TyMachReg, func, true),
         instr);
@@ -24960,7 +24960,7 @@ Lowerer::LowerConvNum(IR::Instr *instrLoad, bool noMathFastPath)
     {
         //      MOV dst, src1
 
-        instr = LowererMD::CreateAssign(instrLoad->GetDst(), src1, instrLoad);
+        instr = Lowerer::InsertMove(instrLoad->GetDst(), src1, instrLoad);
 
         if (!isInt)
         {
@@ -24999,7 +24999,7 @@ Lowerer::LoadSlotArrayWithCachedLocalType(IR::Instr * instrInsert, IR::PropertyS
         // If we use the auxiliary slot array, load it and return it
         IR::RegOpnd *opndSlotArray = IR::RegOpnd::New(TyMachReg, this->m_func);
         IR::Opnd *opndIndir = IR::IndirOpnd::New(opndBase, Js::DynamicObject::GetOffsetOfAuxSlots(), TyMachReg, this->m_func);
-        LowererMD::CreateAssign(opndSlotArray, opndIndir, instrInsert);
+        Lowerer::InsertMove(opndSlotArray, opndIndir, instrInsert);
 
         return opndSlotArray;
     }
@@ -25022,7 +25022,7 @@ Lowerer::LoadSlotArrayWithCachedProtoType(IR::Instr * instrInsert, IR::PropertyS
         // If we use the auxiliary slot array, load it from the prototype object and return it
         IR::RegOpnd *opndSlotArray = IR::RegOpnd::New(TyMachReg, this->m_func);
         IR::Opnd *opnd = IR::MemRefOpnd::New((char*)prototypeObject + Js::DynamicObject::GetOffsetOfAuxSlots(), TyMachReg, this->m_func, IR::AddrOpndKindDynamicAuxSlotArrayRef);
-        LowererMD::CreateAssign(opndSlotArray, opnd, instrInsert);
+        Lowerer::InsertMove(opndSlotArray, opnd, instrInsert);
         return opndSlotArray;
     }
     else

--- a/lib/Backend/LowerMDShared.h
+++ b/lib/Backend/LowerMDShared.h
@@ -83,7 +83,6 @@ public:
             }
 #endif
             IR::Instr *     ChangeToHelperCallMem(IR::Instr * instr, IR::JnHelperMethod helperMethod);
-    static  IR::Instr *     CreateAssign(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsertPt, bool generateWriteBarrier = true);
 
     static  IR::Instr *     ChangeToAssign(IR::Instr * instr);
     static  IR::Instr *     ChangeToAssignNoBarrierCheck(IR::Instr * instr);

--- a/lib/Backend/Security.cpp
+++ b/lib/Backend/Security.cpp
@@ -521,7 +521,7 @@ Security::EncodeValue(IR::Instr * instr, IR::Opnd *opnd, IntConstType constValue
         )
     {
         IR::RegOpnd *regOpnd = IR::RegOpnd::New(StackSym::New(opnd->GetType(), instr->m_func), opnd->GetType(), instr->m_func);
-        IR::Instr * instrNew = LowererMD::CreateAssign(regOpnd, opnd, instr);
+        IR::Instr * instrNew = Lowerer::InsertMove(regOpnd, opnd, instr);
         IR::IntConstOpnd * cookieOpnd = BuildCookieOpnd(opnd->GetType(), instr->m_func);
         instrNew = IR::Instr::New(LowererMD::MDXorOpcode, regOpnd, regOpnd, cookieOpnd, instr->m_func);
         instr->InsertBefore(instrNew);
@@ -542,7 +542,7 @@ Security::EncodeValue(IR::Instr * instr, IR::Opnd *opnd, IntConstType constValue
     else if (opnd->GetType() == TyUint32 || opnd->GetType() == TyUint16 || opnd->GetType() == TyUint8)
     {
         IR::RegOpnd *regOpnd = IR::RegOpnd::New(StackSym::New(opnd->GetType(), instr->m_func), opnd->GetType(), instr->m_func);
-        IR::Instr * instrNew = LowererMD::CreateAssign(regOpnd, opnd, instr);
+        IR::Instr * instrNew = Lowerer::InsertMove(regOpnd, opnd, instr);
 
         IR::IntConstOpnd * cookieOpnd = BuildCookieOpnd(opnd->GetType(), instr->m_func);
 
@@ -582,7 +582,7 @@ Security::EncodeAddress(IR::Instr * instr, IR::Opnd *opnd, size_t value, _Out_ I
     IR::Instr   *instrNew = nullptr;
     IR::RegOpnd *regOpnd = IR::RegOpnd::New(TyMachReg, instr->m_func);
 
-    instrNew = LowererMD::CreateAssign(regOpnd, opnd, instr);
+    instrNew = Lowerer::InsertMove(regOpnd, opnd, instr);
 
     IR::IntConstOpnd *cookieOpnd = BuildCookieOpnd(TyMachReg, instr->m_func);
     instrNew = IR::Instr::New(LowererMD::MDXorOpcode, regOpnd, regOpnd, cookieOpnd, instr->m_func);

--- a/lib/Backend/amd64/LinearScanMD.cpp
+++ b/lib/Backend/amd64/LinearScanMD.cpp
@@ -206,10 +206,10 @@ LinearScanMD::InsertOpHelperSpillsAndRestores(const OpHelperBlock& opHelperBlock
                 func->StackAllocate(sym, MachRegInt);
             }
             IR::RegOpnd * regOpnd = IR::RegOpnd::New(nullptr, opHelperSpilledLifetime.reg, sym->GetType(), func);
-            LowererMD::CreateAssign(IR::SymOpnd::New(sym, sym->GetType(), func), regOpnd, opHelperBlock.opHelperLabel->m_next);
+            Lowerer::InsertMove(IR::SymOpnd::New(sym, sym->GetType(), func), regOpnd, opHelperBlock.opHelperLabel->m_next);
             if (opHelperSpilledLifetime.reload)
             {
-                LowererMD::CreateAssign(regOpnd, IR::SymOpnd::New(sym, sym->GetType(), func), opHelperBlock.opHelperEndInstr);
+                Lowerer::InsertMove(regOpnd, IR::SymOpnd::New(sym, sym->GetType(), func), opHelperBlock.opHelperEndInstr);
             }
         }
     }

--- a/lib/Backend/amd64/LowererMDArch.cpp
+++ b/lib/Backend/amd64/LowererMDArch.cpp
@@ -389,7 +389,7 @@ LowererMDArch::LoadHeapArguments(IR::Instr *instrArgs)
                 // the function object for generator calls is a GeneratorVirtualScriptFunction object
                 // and we need to pass the real JavascriptGeneratorFunction object so grab it instead
                 IR::RegOpnd *tmpOpnd = IR::RegOpnd::New(TyMachReg, func);
-                LowererMD::CreateAssign(tmpOpnd, srcOpnd, instrArgs);
+                Lowerer::InsertMove(tmpOpnd, srcOpnd, instrArgs);
 
                 srcOpnd = IR::IndirOpnd::New(tmpOpnd, Js::GeneratorVirtualScriptFunction::GetRealFunctionOffset(), TyMachPtr, func);
             }
@@ -417,7 +417,7 @@ LowererMDArch::LoadNewScObjFirstArg(IR::Instr * instr, IR::Opnd * dst, ushort ex
 {
     // Spread moves down the argument slot by one.
     IR::Opnd *      argOpnd         = this->GetArgSlotOpnd(3 + extraArgs);
-    IR::Instr *     argInstr        = LowererMD::CreateAssign(argOpnd, dst, instr);
+    IR::Instr *     argInstr        = Lowerer::InsertMove(argOpnd, dst, instr);
 
     return argInstr;
 }
@@ -1455,7 +1455,7 @@ LowererMDArch::GenerateStackAllocation(IR::Instr *instr, uint32 size)
             instr->InsertAfter(movHelperAddrInstr);
         }
 
-        LowererMD::CreateAssign(raxOpnd, stackSizeOpnd, instr->m_next);
+        Lowerer::InsertMove(raxOpnd, stackSizeOpnd, instr->m_next);
     }
 }
 
@@ -1860,10 +1860,10 @@ LowererMDArch::GeneratePrologueStackProbe(IR::Instr *entryInstr, IntConstType fr
         {
             intptr_t pLimit = m_func->GetThreadContextInfo()->GetThreadStackLimitAddr();
             IR::RegOpnd *baseOpnd = IR::RegOpnd::New(nullptr, RegRAX, TyMachReg, this->m_func);
-            this->lowererMD->CreateAssign(baseOpnd, IR::AddrOpnd::New(pLimit, IR::AddrOpndKindDynamicMisc, this->m_func), insertInstr);
+            Lowerer::InsertMove(baseOpnd, IR::AddrOpnd::New(pLimit, IR::AddrOpndKindDynamicMisc, this->m_func), insertInstr);
             IR::IndirOpnd *indirOpnd = IR::IndirOpnd::New(baseOpnd, 0, TyMachReg, this->m_func);
 
-            this->lowererMD->CreateAssign(stackLimitOpnd, indirOpnd, insertInstr);
+            Lowerer::InsertMove(stackLimitOpnd, indirOpnd, insertInstr);
         }
 
         instr = IR::Instr::New(Js::OpCode::ADD, stackLimitOpnd, stackLimitOpnd,
@@ -1881,7 +1881,7 @@ LowererMDArch::GeneratePrologueStackProbe(IR::Instr *entryInstr, IntConstType fr
     {
         // TODO: michhol, check this math
         size_t scriptStackLimit = m_func->GetThreadContextInfo()->GetScriptStackLimit();
-        this->lowererMD->CreateAssign(stackLimitOpnd, IR::IntConstOpnd::New((frameSize + scriptStackLimit), TyMachReg, this->m_func), insertInstr);
+        Lowerer::InsertMove(stackLimitOpnd, IR::IntConstOpnd::New((frameSize + scriptStackLimit), TyMachReg, this->m_func), insertInstr);
     }
 
     // CMP rsp, rax
@@ -1918,18 +1918,18 @@ LowererMDArch::GeneratePrologueStackProbe(IR::Instr *entryInstr, IntConstType fr
     IR::RegOpnd *target;
     {
         // MOV RegArg1, scriptContext
-        this->lowererMD->CreateAssign(
+        Lowerer::InsertMove(
             IR::RegOpnd::New(nullptr, RegArg1, TyMachReg, m_func),
             this->lowererMD->m_lowerer->LoadScriptContextOpnd(insertInstr), insertInstr);
 
         // MOV RegArg0, frameSize
-        this->lowererMD->CreateAssign(
+        Lowerer::InsertMove(
             IR::RegOpnd::New(nullptr, RegArg0, TyMachReg, this->m_func),
             IR::IntConstOpnd::New(frameSize, TyMachReg, this->m_func), insertInstr);
 
         // MOV rax, ThreadContext::ProbeCurrentStack
         target = IR::RegOpnd::New(nullptr, RegRAX, TyMachReg, m_func);
-        this->lowererMD->CreateAssign(target, IR::HelperCallOpnd::New(IR::HelperProbeCurrentStack, m_func), insertInstr);
+        Lowerer::InsertMove(target, IR::HelperCallOpnd::New(IR::HelperProbeCurrentStack, m_func), insertInstr);
     }
 
     // JMP rax

--- a/lib/Backend/arm/LowerMD.cpp
+++ b/lib/Backend/arm/LowerMD.cpp
@@ -170,7 +170,7 @@ LowererMD::GenerateMemRef(intptr_t addr, IRType type, IR::Instr *instr, bool don
 {
     IR::RegOpnd *baseOpnd = IR::RegOpnd::New(TyMachReg, this->m_func);
     IR::AddrOpnd *addrOpnd = IR::AddrOpnd::New(addr, IR::AddrOpndKindDynamicMisc, this->m_func, dontEncode);
-    LowererMD::CreateAssign(baseOpnd, addrOpnd, instr);
+    Lowerer::InsertMove(baseOpnd, addrOpnd, instr);
 
     return IR::IndirOpnd::New(baseOpnd, 0, type, this->m_func);
 }
@@ -324,7 +324,7 @@ LowererMD::LowerCall(IR::Instr * callInstr, Js::ArgSlot argCount)
             opndParam = this->GetOpndForArgSlot(intArgsLeft - 1, helperArgOpnd);
             --intArgsLeft;
         }
-        LowererMD::CreateAssign(opndParam, helperArgOpnd, callInstr);
+        Lowerer::InsertMove(opndParam, helperArgOpnd, callInstr);
         --argsLeft;
     }
     Assert(doubleArgsLeft == 0 && intArgsLeft == 0 && argsLeft == 0);
@@ -401,14 +401,14 @@ LowererMD::LowerCallIDynamic(IR::Instr *callInstr, IR::Instr*saveThisArgOutInstr
         callInstr->InsertBefore(IR::Instr::New(Js::OpCode::ADD, argsLength, argsLength, IR::IntConstOpnd::New(1, TyInt8, this->m_func), this->m_func));
         this->SetMaxArgSlots(Js::InlineeCallInfo::MaxInlineeArgoutCount);
     }
-    LowererMD::CreateAssign( this->GetOpndForArgSlot(1), argsLength, callInstr);
+    Lowerer::InsertMove( this->GetOpndForArgSlot(1), argsLength, callInstr);
 
     IR::RegOpnd    *funcObjOpnd = callInstr->UnlinkSrc1()->AsRegOpnd();
     GeneratePreCall(callInstr, funcObjOpnd);
 
     // functionOpnd is the first argument.
     IR::Opnd * opndParam = this->GetOpndForArgSlot(0);
-    LowererMD::CreateAssign(opndParam, funcObjOpnd, callInstr);
+    Lowerer::InsertMove(opndParam, funcObjOpnd, callInstr);
     return this->LowerCall(callInstr, 0);
 }
 
@@ -477,7 +477,7 @@ LowererMD::GeneratePreCall(IR::Instr * callInstr, IR::Opnd  *functionObjOpnd)
 
         IR::IndirOpnd* functionTypeIndirOpnd = IR::IndirOpnd::New(functionObjOpnd->AsRegOpnd(),
             Js::RecyclableObject::GetOffsetOfType(), TyMachReg, this->m_func);
-        LowererMD::CreateAssign(functionTypeRegOpnd, functionTypeIndirOpnd, callInstr);
+        Lowerer::InsertMove(functionTypeRegOpnd, functionTypeIndirOpnd, callInstr);
     }
     else
     {
@@ -487,7 +487,7 @@ LowererMD::GeneratePreCall(IR::Instr * callInstr, IR::Opnd  *functionObjOpnd)
     int entryPointOffset = Js::Type::GetOffsetOfEntryPoint();
     IR::IndirOpnd* entryPointOpnd = IR::IndirOpnd::New(functionTypeRegOpnd, entryPointOffset, TyMachPtr, this->m_func);
     IR::RegOpnd * targetAddrOpnd = IR::RegOpnd::New(TyMachReg, this->m_func);
-    IR::Instr * stackParamInsert = LowererMD::CreateAssign(targetAddrOpnd, entryPointOpnd, callInstr);
+    IR::Instr * stackParamInsert = Lowerer::InsertMove(targetAddrOpnd, entryPointOpnd, callInstr);
 
     // targetAddrOpnd is the address we'll call.
     callInstr->SetSrc1(targetAddrOpnd);
@@ -544,7 +544,7 @@ LowererMD::LowerCallI(IR::Instr * callInstr, ushort callFlags, bool isHelper, IR
 
     // functionObjOpnd is the first argument.
     IR::Opnd * opndParam = this->GetOpndForArgSlot(0);
-    LowererMD::CreateAssign(opndParam, functionObjOpnd, callInstr);
+    Lowerer::InsertMove(opndParam, functionObjOpnd, callInstr);
 
     IR::Opnd *const finalDst = callInstr->GetDst();
 
@@ -654,7 +654,7 @@ LowererMD::LowerCallArgs(IR::Instr *callInstr, IR::Instr *stackParamInsert, usho
         *callInfoOpndRef = opndCallInfo;
     }
     opndParam = this->GetOpndForArgSlot(extraParams);
-    LowererMD::CreateAssign(opndParam, opndCallInfo, callInstr);
+    Lowerer::InsertMove(opndParam, opndCallInfo, callInstr);
 
     return argCount + 1 + extraParams; // + 1 for call flags
 }
@@ -802,8 +802,8 @@ LowererMD::GenerateStackProbe(IR::Instr *insertInstr, bool afterProlog)
         // Load the current stack limit and add the current frame allocation.
         {
             intptr_t pLimit = m_func->GetThreadContextInfo()->GetThreadStackLimitAddr();
-            this->CreateAssign(scratchOpnd, IR::AddrOpnd::New(pLimit, IR::AddrOpndKindDynamicMisc, this->m_func), insertInstr);
-            this->CreateAssign(scratchOpnd, IR::IndirOpnd::New(scratchOpnd, 0, TyMachReg, this->m_func), insertInstr);
+            Lowerer::InsertMove(scratchOpnd, IR::AddrOpnd::New(pLimit, IR::AddrOpndKindDynamicMisc, this->m_func), insertInstr);
+            Lowerer::InsertMove(scratchOpnd, IR::IndirOpnd::New(scratchOpnd, 0, TyMachReg, this->m_func), insertInstr);
         }
 
         if (EncoderMD::CanEncodeModConst12(frameSize))
@@ -834,7 +834,7 @@ LowererMD::GenerateStackProbe(IR::Instr *insertInstr, bool afterProlog)
             }
 
             IR::Opnd *scratchOpnd2 = IR::RegOpnd::New(nullptr, SP_ALLOC_SCRATCH_REG, TyMachReg, this->m_func);
-            this->CreateAssign(scratchOpnd2, IR::IntConstOpnd::New(frameSize, TyMachReg, this->m_func), insertInstr);
+            Lowerer::InsertMove(scratchOpnd2, IR::IntConstOpnd::New(frameSize, TyMachReg, this->m_func), insertInstr);
 
             instr = IR::Instr::New(Js::OpCode::ADDS, scratchOpnd, scratchOpnd, scratchOpnd2, this->m_func);
             insertInstr->InsertBefore(instr);
@@ -858,7 +858,7 @@ LowererMD::GenerateStackProbe(IR::Instr *insertInstr, bool afterProlog)
     {
         uint32 scriptStackLimit = (uint32)m_func->GetThreadContextInfo()->GetScriptStackLimit();
         IR::Opnd *stackLimitOpnd = IR::IntConstOpnd::New(frameSize + scriptStackLimit, TyMachReg, this->m_func);
-        this->CreateAssign(scratchOpnd, stackLimitOpnd, insertInstr);
+        Lowerer::InsertMove(scratchOpnd, stackLimitOpnd, insertInstr);
     }
 
     IR::LabelInstr *doneLabelInstr = IR::LabelInstr::New(Js::OpCode::Label, this->m_func, false);
@@ -878,19 +878,19 @@ LowererMD::GenerateStackProbe(IR::Instr *insertInstr, bool afterProlog)
     // Zero out the pointer to the list of stack nested funcs, since the functions won't be initialized on this path.
     scratchOpnd = IR::RegOpnd::New(nullptr, RegR0, TyMachReg, m_func);
     IR::RegOpnd *frameReg = IR::RegOpnd::New(nullptr, GetRegFramePointer(), TyMachReg, m_func);
-    CreateAssign(scratchOpnd, IR::IntConstOpnd::New(0, TyMachReg, m_func), insertInstr);
+    Lowerer::InsertMove(scratchOpnd, IR::IntConstOpnd::New(0, TyMachReg, m_func), insertInstr);
     IR::Opnd *indirOpnd = IR::IndirOpnd::New(
         frameReg, -(int32)(Js::Constants::StackNestedFuncList * sizeof(Js::Var)), TyMachReg, m_func);
-    CreateAssign(indirOpnd, scratchOpnd, insertInstr);
+    Lowerer::InsertMove(indirOpnd, scratchOpnd, insertInstr);
 
     IR::RegOpnd *r0Opnd = IR::RegOpnd::New(nullptr, RegR0, TyMachReg, this->m_func);
-    this->CreateAssign(r0Opnd, IR::IntConstOpnd::New(frameSize, TyMachReg, this->m_func, true), insertInstr);
+    Lowerer::InsertMove(r0Opnd, IR::IntConstOpnd::New(frameSize, TyMachReg, this->m_func, true), insertInstr);
 
     IR::RegOpnd *r1Opnd = IR::RegOpnd::New(nullptr, RegR1, TyMachReg, this->m_func);
-    this->CreateAssign(r1Opnd, this->m_lowerer->LoadScriptContextOpnd(insertInstr), insertInstr);
+    Lowerer::InsertMove(r1Opnd, this->m_lowerer->LoadScriptContextOpnd(insertInstr), insertInstr);
 
     IR::RegOpnd *r2Opnd = IR::RegOpnd::New(nullptr, RegR2, TyMachReg, m_func);
-    this->CreateAssign(r2Opnd, IR::HelperCallOpnd::New(IR::HelperProbeCurrentStack, this->m_func), insertInstr);
+    Lowerer::InsertMove(r2Opnd, IR::HelperCallOpnd::New(IR::HelperProbeCurrentStack, this->m_func), insertInstr);
 
     instr = IR::Instr::New(afterProlog? Js::OpCode::BLX : Js::OpCode::BX, this->m_func);
     instr->SetSrc1(r2Opnd);
@@ -1398,7 +1398,7 @@ LowererMD::LowerEntryInstr(IR::EntryInstr * entryInstr)
     if (hasTry)
     {
         // Copy the value of SP before we allocate the locals area. We'll save this value on the stack below.
-        LowererMD::CreateAssign(
+        Lowerer::InsertMove(
             IR::RegOpnd::New(nullptr, EH_STACK_SAVE_REG, TyMachReg, this->m_func),
             IR::RegOpnd::New(nullptr, RegSP, TyMachReg, this->m_func),
             insertInstr);
@@ -1426,7 +1426,7 @@ LowererMD::LowerEntryInstr(IR::EntryInstr * entryInstr)
         }
 
         // Set up the locals pointer.
-        LowererMD::CreateAssign(
+        Lowerer::InsertMove(
             IR::RegOpnd::New(nullptr, localsReg, TyMachReg, this->m_func),
             IR::RegOpnd::New(nullptr, RegSP, TyMachReg, this->m_func),
             insertInstr);
@@ -1517,7 +1517,7 @@ LowererMD::LowerExitInstr(IR::ExitInstr * exitInstr)
     else if (localsReg != RegSP)
     {
         // We're going to restore SP from the locals pointer and then deallocate only the locals area.
-        LowererMD::CreateAssign(
+        Lowerer::InsertMove(
             IR::RegOpnd::New(nullptr, RegSP, TyMachReg, this->m_func),
             IR::RegOpnd::New(nullptr, localsReg, TyMachReg, this->m_func),
             exitInstr);
@@ -1591,7 +1591,7 @@ LowererMD::LowerExitInstr(IR::ExitInstr * exitInstr)
             this->m_func);
         exitInstr->InsertBefore(instrPop);
 
-        LowererMD::CreateAssign(
+        Lowerer::InsertMove(
             IR::RegOpnd::New(nullptr, RegSP, TyMachReg, this->m_func),
             IR::RegOpnd::New(nullptr, EH_STACK_SAVE_REG, TyMachReg, this->m_func),
             exitInstr);
@@ -1791,7 +1791,7 @@ LowererMD::LowerEHRegionReturn(IR::Instr * insertBeforeInstr, IR::Opnd * targetO
     IR::RegOpnd *retReg    = IR::RegOpnd::New(nullptr, RETURN_REG, TyMachReg, this->m_func);
 
     // Load the continuation address into the return register.
-    LowererMD::CreateAssign(retReg, targetOpnd, insertBeforeInstr);
+    Lowerer::InsertMove(retReg, targetOpnd, insertBeforeInstr);
 
     IR::LabelInstr *epilogLabel = this->EnsureEpilogLabel();
     IR::BranchInstr *jmpInstr = IR::BranchInstr::New(Js::OpCode::B, epilogLabel, this->m_func);
@@ -1934,7 +1934,7 @@ LowererMD::LoadStackArgPtr(IR::Instr * instr)
         size_t offset = Js::InterpreterStackFrame::GetOffsetOfInParams();
         IR::IndirOpnd *indirOpnd = IR::IndirOpnd::New(baseOpnd, (int32)offset, TyMachReg, this->m_func);
         IR::RegOpnd *tmpOpnd = IR::RegOpnd::New(TyMachReg, this->m_func);
-        LowererMD::CreateAssign(tmpOpnd, indirOpnd, instr);
+        Lowerer::InsertMove(tmpOpnd, indirOpnd, instr);
 
         instr->SetSrc1(tmpOpnd);
         instr->SetSrc2(IR::IntConstOpnd::New(sizeof(Js::Var), TyMachReg, this->m_func));
@@ -2090,7 +2090,7 @@ LowererMD::LoadHeapArguments(IR::Instr * instrArgs)
 
             // Save the newly-created args object to its dedicated stack slot.
             IR::SymOpnd *argObjSlotOpnd = func->GetInlineeArgumentsObjectSlotOpnd();
-            LowererMD::CreateAssign(argObjSlotOpnd,instrArgs->GetDst(), instrArgs->m_next);
+            Lowerer::InsertMove(argObjSlotOpnd,instrArgs->GetDst(), instrArgs->m_next);
         }
         else
         {
@@ -2113,7 +2113,7 @@ LowererMD::LoadHeapArguments(IR::Instr * instrArgs)
             // Save the newly-created args object to its dedicated stack slot.
             IR::IndirOpnd *indirOpnd = IR::IndirOpnd::New(IR::RegOpnd::New(nullptr, FRAME_REG , TyMachReg, func),
                 -MachArgsSlotOffset, TyMachPtr, m_func);
-            LowererMD::CreateAssign(indirOpnd, instrArgs->GetDst(), instrArgs->m_next);
+            Lowerer::InsertMove(indirOpnd, instrArgs->GetDst(), instrArgs->m_next);
         }
         this->ChangeToHelperCall(instrArgs, IR::HelperOp_LoadHeapArguments);
     }
@@ -2192,7 +2192,7 @@ LowererMD::LoadHeapArgsCached(IR::Instr * instrArgs)
 
             // Save the newly-created args object to its dedicated stack slot.
             IR::SymOpnd *argObjSlotOpnd = func->GetInlineeArgumentsObjectSlotOpnd();
-            LowererMD::CreateAssign(argObjSlotOpnd, instrArgs->GetDst(), instrArgs->m_next);
+            Lowerer::InsertMove(argObjSlotOpnd, instrArgs->GetDst(), instrArgs->m_next);
         }
         else
         {
@@ -2217,7 +2217,7 @@ LowererMD::LoadHeapArgsCached(IR::Instr * instrArgs)
             // Save the newly-created args object to its dedicated stack slot.
             IR::IndirOpnd *indirOpnd = IR::IndirOpnd::New(IR::RegOpnd::New(nullptr, FRAME_REG, TyMachReg, func),
                 -MachArgsSlotOffset, TyMachPtr, m_func);
-            LowererMD::CreateAssign(indirOpnd, instrArgs->GetDst(), instrArgs->m_next);
+            Lowerer::InsertMove(indirOpnd, instrArgs->GetDst(), instrArgs->m_next);
 
         }
 
@@ -2378,20 +2378,6 @@ LowererMD::ChangeToLea(IR::Instr * instr, bool postRegAlloc)
     instr->m_opcode = Js::OpCode::LEA;
     Legalize(instr, postRegAlloc);
     return instr;
-}
-
-///----------------------------------------------------------------------------
-///
-/// LowererMD::CreateAssign
-///
-///     Create a copy from src to dst. Let ChangeToAssign handle riscification
-/// of operands.
-///----------------------------------------------------------------------------
-
-IR::Instr *
-LowererMD::CreateAssign(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsertPt, bool generateWriteBarrier)
-{
-    return Lowerer::InsertMove(dst, src, instrInsertPt, generateWriteBarrier);
 }
 
 ///----------------------------------------------------------------------------
@@ -2778,7 +2764,7 @@ LowererMD::LoadFunctionObjectOpnd(IR::Instr *instr, IR::Opnd *&functionObjOpnd)
         StackSym *paramSym = GetImplicitParamSlotSym(0);
         IR::SymOpnd *paramOpnd = IR::SymOpnd::New(paramSym, TyMachPtr, m_func);
 
-        instrPrev = LowererMD::CreateAssign(regOpnd, paramOpnd, instr);
+        instrPrev = Lowerer::InsertMove(regOpnd, paramOpnd, instr);
         functionObjOpnd = instrPrev->GetDst();
     }
     else
@@ -3100,13 +3086,13 @@ bool LowererMD::GenerateFastCmXxTaggedInt(IR::Instr *instr, bool isInHelper  /* 
     if (dst->IsEqual(src1))
     {
         IR::RegOpnd *newSrc1 = IR::RegOpnd::New(TyMachReg, m_func);
-        LowererMD::CreateAssign(newSrc1, src1, instr);
+        Lowerer::InsertMove(newSrc1, src1, instr);
         src1 = newSrc1;
     }
     if (dst->IsEqual(src2))
     {
         IR::RegOpnd *newSrc2 = IR::RegOpnd::New(TyMachReg, m_func);
-        LowererMD::CreateAssign(newSrc2, src2, instr);
+        Lowerer::InsertMove(newSrc2, src2, instr);
         src2 = newSrc2;
     }
 
@@ -3248,13 +3234,13 @@ LowererMD::GenerateFastAdd(IR::Instr * instrAdd)
     if (!opndSrc1->IsRegOpnd())
     {
         opndSrc1 = IR::RegOpnd::New(opndSrc1->GetType(), this->m_func);
-        LowererMD::CreateAssign(opndSrc1, instrAdd->GetSrc1(), instrAdd);
+        Lowerer::InsertMove(opndSrc1, instrAdd->GetSrc1(), instrAdd);
     }
 
     if (!opndSrc2->IsRegOpnd())
     {
         opndSrc2 = IR::RegOpnd::New(opndSrc2->GetType(), this->m_func);
-        LowererMD::CreateAssign(opndSrc2, instrAdd->GetSrc2(), instrAdd);
+        Lowerer::InsertMove(opndSrc2, instrAdd->GetSrc2(), instrAdd);
     }
 
     labelHelper = IR::LabelInstr::New(Js::OpCode::Label, this->m_func, true);
@@ -3288,7 +3274,7 @@ LowererMD::GenerateFastAdd(IR::Instr * instrAdd)
     instrAdd->InsertBefore(instr);
 
     // dst = MOV tmp
-    LowererMD::CreateAssign(instrAdd->GetDst(), opndTmp, instrAdd);
+    Lowerer::InsertMove(instrAdd->GetDst(), opndTmp, instrAdd);
 
     //      B $done
     labelDone = IR::LabelInstr::New(Js::OpCode::Label, this->m_func);
@@ -3352,13 +3338,13 @@ LowererMD::GenerateFastSub(IR::Instr * instrSub)
     if (!opndSrc1->IsRegOpnd())
     {
         opndSrc1 = IR::RegOpnd::New(opndSrc1->GetType(), this->m_func);
-        LowererMD::CreateAssign(opndSrc1, instrSub->GetSrc1(), instrSub);
+        Lowerer::InsertMove(opndSrc1, instrSub->GetSrc1(), instrSub);
     }
 
     if (!opndSrc2->IsRegOpnd())
     {
         opndSrc2 = IR::RegOpnd::New(opndSrc2->GetType(), this->m_func);
-        LowererMD::CreateAssign(opndSrc2, instrSub->GetSrc2(), instrSub);
+        Lowerer::InsertMove(opndSrc2, instrSub->GetSrc2(), instrSub);
     }
 
     labelHelper = IR::LabelInstr::New(Js::OpCode::Label, this->m_func, true);
@@ -3463,13 +3449,13 @@ LowererMD::GenerateFastMul(IR::Instr * instrMul)
     if (!opndSrc1->IsRegOpnd())
     {
         opndSrc1 = IR::RegOpnd::New(opndSrc1->GetType(), this->m_func);
-        LowererMD::CreateAssign(opndSrc1, instrMul->GetSrc1(), instrMul);
+        Lowerer::InsertMove(opndSrc1, instrMul->GetSrc1(), instrMul);
     }
 
     if (!opndSrc2->IsRegOpnd())
     {
         opndSrc2 = IR::RegOpnd::New(opndSrc2->GetType(), this->m_func);
-        LowererMD::CreateAssign(opndSrc2, instrMul->GetSrc2(), instrMul);
+        Lowerer::InsertMove(opndSrc2, instrMul->GetSrc2(), instrMul);
     }
 
     bool isTaggedInts = opndSrc1->IsTaggedInt() && opndSrc2->IsTaggedInt();
@@ -3526,8 +3512,8 @@ LowererMD::GenerateFastMul(IR::Instr * instrMul)
     instrMul->InsertBefore(instr);
 
     // dst= ToVar(-0.0)       -- load negative 0
-    instr = LowererMD::CreateAssign(instrMul->GetDst(), m_lowerer->LoadLibraryValueOpnd(instrMul, LibraryValue::ValueNegativeZero), instrMul);
-    // No need to insert: CreateAssign creates legalized instr and inserts it.
+    instr = Lowerer::InsertMove(instrMul->GetDst(), m_lowerer->LoadLibraryValueOpnd(instrMul, LibraryValue::ValueNegativeZero), instrMul);
+    // No need to insert: InsertMove creates legalized instr and inserts it.
 
     //      B $fallthru
     instr = IR::BranchInstr::New(Js::OpCode::B, labelFallThru, this->m_func);
@@ -3649,7 +3635,7 @@ LowererMD::GenerateFastAnd(IR::Instr * instrAnd)
         instrAnd->InsertBefore(instr);
 
         // dst = STR dstReg
-        LowererMD::CreateAssign(instrAnd->GetDst(), dst, instrAnd);
+        Lowerer::InsertMove(instrAnd->GetDst(), dst, instrAnd);
 
         //      B $done
         instr = IR::BranchInstr::New(Js::OpCode::B, labelDone, this->m_func);
@@ -3713,13 +3699,13 @@ LowererMD::GenerateFastOr(IR::Instr * instrOr)
     if (!src1->IsRegOpnd())
     {
         src1 = IR::RegOpnd::New(src1->GetType(), this->m_func);
-        LowererMD::CreateAssign(src1, instrOr->GetSrc1(), instrOr);
+        Lowerer::InsertMove(src1, instrOr->GetSrc1(), instrOr);
     }
 
     if (!src2->IsRegOpnd())
     {
         src2 = IR::RegOpnd::New(src2->GetType(), this->m_func);
-        LowererMD::CreateAssign(src2, instrOr->GetSrc2(), instrOr);
+        Lowerer::InsertMove(src2, instrOr->GetSrc2(), instrOr);
     }
 
     if (!isInt)
@@ -3822,7 +3808,7 @@ LowererMD::GenerateFastNot(IR::Instr * instrNot)
     {
         // Load the src at the top so we don't have to load it twice.
         src = IR::RegOpnd::New(src->GetType(), this->m_func);
-        LowererMD::CreateAssign(src, instrNot->GetSrc1(), instrNot);
+        Lowerer::InsertMove(src, instrNot->GetSrc1(), instrNot);
     }
 
     if (!dst->IsRegOpnd())
@@ -3856,7 +3842,7 @@ LowererMD::GenerateFastNot(IR::Instr * instrNot)
     if (dst != instrNot->GetDst())
     {
         // Now store the result.
-        LowererMD::CreateAssign(instrNot->GetDst(), dst, instrNot);
+        Lowerer::InsertMove(instrNot->GetDst(), dst, instrNot);
     }
 
     if (isInt)
@@ -3969,7 +3955,7 @@ LowererMD::GenerateFastNeg(IR::Instr * instrNeg)
     if (!opndSrc1->IsRegOpnd())
     {
         opndSrc1 = IR::RegOpnd::New(opndSrc1->GetType(), this->m_func);
-        LowererMD::CreateAssign(opndSrc1, instrNeg->GetSrc1(), instrNeg);
+        Lowerer::InsertMove(opndSrc1, instrNeg->GetSrc1(), instrNeg);
     }
 
     if (!isInt)
@@ -4003,7 +3989,7 @@ LowererMD::GenerateFastNeg(IR::Instr * instrNeg)
     if (opndDst != instrNeg->GetDst())
     {
         //Now store the result.
-        LowererMD::CreateAssign(instrNeg->GetDst(), opndDst, instrNeg);
+        Lowerer::InsertMove(instrNeg->GetDst(), opndDst, instrNeg);
     }
 
     // B $fallthru
@@ -4766,7 +4752,7 @@ LowererMD::GenerateFastLdMethodFromFlags(IR::Instr * instrLdFld)
     // Label to jump to (or fall through to) when bailing out
     bailOutLabel = IR::LabelInstr::New(Js::OpCode::Label, instrLdFld->m_func, true /* isOpHelper */);
 
-    LowererMD::CreateAssign(opndInlineCache, m_lowerer->LoadRuntimeInlineCacheOpnd(instrLdFld, propertySymOpnd), instrLdFld);
+    Lowerer::InsertMove(opndInlineCache, m_lowerer->LoadRuntimeInlineCacheOpnd(instrLdFld, propertySymOpnd), instrLdFld);
     IR::LabelInstr * labelFlagAux = IR::LabelInstr::New(Js::OpCode::Label, this->m_func);
     // Check the flag cache with the untagged type
     this->m_lowerer->GenerateObjectTestAndTypeLoad(instrLdFld, opndBase, opndType, bailOutLabel);
@@ -4894,7 +4880,7 @@ LowererMD::GenerateFastScopedFld(IR::Instr * instrScopedFld, bool isLoad)
 
     IR::RegOpnd * opndType = IR::RegOpnd::New(TyMachReg, this->m_func);
     this->m_lowerer->GenerateObjectTestAndTypeLoad(instrScopedFld, opndReg2, opndType, labelHelper);
-    LowererMD::CreateAssign(opndInlineCache, m_lowerer->LoadRuntimeInlineCacheOpnd(instrScopedFld, propertySymOpnd), instrScopedFld);
+    Lowerer::InsertMove(opndInlineCache, m_lowerer->LoadRuntimeInlineCacheOpnd(instrScopedFld, propertySymOpnd), instrScopedFld);
 
     labelFallThru = IR::LabelInstr::New(Js::OpCode::Label, this->m_func);
 
@@ -5013,7 +4999,7 @@ LowererMD::GenerateStFldFromLocalInlineCache(
         // s2 = MOV base->slots -- load the slot array
         opndSlotArray = IR::RegOpnd::New(TyMachReg, instrStFld->m_func);
         opndIndir = IR::IndirOpnd::New(opndBase, Js::DynamicObject::GetOffsetOfAuxSlots(), TyMachReg, instrStFld->m_func);
-        LowererMD::CreateAssign(opndSlotArray, opndIndir, instrStFld);
+        Lowerer::InsertMove(opndSlotArray, opndIndir, instrStFld);
     }
 
     // LDR s5, [s2, offset(u.local.slotIndex)] -- load the cached slot index
@@ -5353,13 +5339,13 @@ bool LowererMD::TryGenerateFastMulAdd(IR::Instr * instrAdd, IR::Instr ** pInstrP
         // (Load mulSrc1 at the top so we don't have to do it repeatedly)
         if (!mulSrc1->IsRegOpnd())
         {
-            LowererMD::CreateAssign(s1, mulSrc1, instrAdd);
+            Lowerer::InsertMove(s1, mulSrc1, instrAdd);
             mulSrc1 = s1;
         }
         // Now: mulSrc1 is regOpnd (in case if it wasn't it's now s1).
 
         // Load addSrc into s3. We'll use it as source and destination of SMLAL.
-        LowererMD::CreateAssign(s3, addSrc, instrAdd);
+        Lowerer::InsertMove(s3, addSrc, instrAdd);
 
         // (If not mulSrc1 and addSrc are Int31's, jump to $helper)
         bool areTaggedInts = mulSrc1->IsTaggedInt() && s3->IsTaggedInt();
@@ -5406,7 +5392,7 @@ bool LowererMD::TryGenerateFastMulAdd(IR::Instr * instrAdd, IR::Instr ** pInstrP
 
         // Copy the result into dst
         // dst = s3
-        LowererMD::CreateAssign(instrAdd->GetDst(), s3, instrAdd);
+        Lowerer::InsertMove(instrAdd->GetDst(), s3, instrAdd);
         LegalizeMD::LegalizeInstr(instr, false);
 
         //       B $done
@@ -6067,7 +6053,7 @@ LowererMD::GenerateFastAbs(IR::Opnd *dst, IR::Opnd *src, IR::Instr *callInstr, I
         if (!Js::TaggedInt::IsOverflow(absValue))
         {
             varOpnd->SetAddress(Js::TaggedInt::ToVarUnchecked(absValue), IR::AddrOpndKindConstantVar);
-            LowererMD::CreateAssign(dst, varOpnd, insertInstr);
+            Lowerer::InsertMove(dst, varOpnd, insertInstr);
         }
     }
 
@@ -6250,7 +6236,7 @@ bool LowererMD::GenerateFastCharAt(Js::BuiltinFunction index, IR::Opnd *dst, IR:
     else
     {
         regSrcStr = IR::RegOpnd::New(TyMachReg, this->m_func);
-        LowererMD::CreateAssign(regSrcStr, srcStr, insertInstr);
+        Lowerer::InsertMove(regSrcStr, srcStr, insertInstr);
     }
 
     this->m_lowerer->GenerateStringTest(regSrcStr, insertInstr, labelHelper);
@@ -6258,7 +6244,7 @@ bool LowererMD::GenerateFastCharAt(Js::BuiltinFunction index, IR::Opnd *dst, IR:
     // psz = LDR [regSrc + offset(m_pszValue)]
     IR::RegOpnd *psz = IR::RegOpnd::New(TyMachPtr, this->m_func);
     indirOpnd = IR::IndirOpnd::New(regSrcStr, Js::JavascriptString::GetOffsetOfpszValue(), TyMachPtr, this->m_func);
-    LowererMD::CreateAssign(psz, indirOpnd, insertInstr);
+    Lowerer::InsertMove(psz, indirOpnd, insertInstr);
 
     //      CMP psz, 0
     instr = IR::Instr::New(Js::OpCode::CMP, this->m_func);
@@ -6274,7 +6260,7 @@ bool LowererMD::GenerateFastCharAt(Js::BuiltinFunction index, IR::Opnd *dst, IR:
     // length = LDR [regSrcStr + offsetof(length)]
     IR::RegOpnd *length = IR::RegOpnd::New(TyMachReg, this->m_func);
     indirOpnd = IR::IndirOpnd::New(regSrcStr, offsetof(Js::JavascriptString, m_charLength), TyUint32, this->m_func);
-    LowererMD::CreateAssign(length, indirOpnd, insertInstr);
+    Lowerer::InsertMove(length, indirOpnd, insertInstr);
 
     if (srcIndex->IsAddrOpnd())
     {
@@ -6327,7 +6313,7 @@ bool LowererMD::GenerateFastCharAt(Js::BuiltinFunction index, IR::Opnd *dst, IR:
 
     // char = LDRH [regSrc + index32, LSL #1]
     IR::RegOpnd *charResult = IR::RegOpnd::New(TyUint32, this->m_func);
-    LowererMD::CreateAssign(charResult, indirOpnd, insertInstr);
+    Lowerer::InsertMove(charResult, indirOpnd, insertInstr);
 
     if (index == Js::BuiltinFunction::JavascriptString_CharAt)
     {
@@ -7109,19 +7095,19 @@ LowererMD::LowerCommitScope(IR::Instr *instrCommit)
         // On ARM, instead of re-using the address of "undefined" for each store, put the address in a register
         // and re-use that. (Would that be good for x86/amd64 as well?)
         IR::RegOpnd *undefOpnd = IR::RegOpnd::New(TyMachReg, this->m_func);
-        LowererMD::CreateAssign(undefOpnd, m_lowerer->LoadLibraryValueOpnd(insertInstr, LibraryValue::ValueUndefined), insertInstr);
+        Lowerer::InsertMove(undefOpnd, m_lowerer->LoadLibraryValueOpnd(insertInstr, LibraryValue::ValueUndefined), insertInstr);
 
         IR::RegOpnd *slotBaseOpnd = IR::RegOpnd::New(TyMachReg, this->m_func);
 
         // Load a pointer to the aux slots. We assume that all ActivationObject's have only aux slots.
 
         opnd = IR::IndirOpnd::New(baseOpnd, Js::DynamicObject::GetOffsetOfAuxSlots(), TyMachReg, this->m_func);
-        this->CreateAssign(slotBaseOpnd, opnd, insertInstr);
+        Lowerer::InsertMove(slotBaseOpnd, opnd, insertInstr);
 
         for (uint i = firstVarSlot; i < propIds->count; i++)
         {
             opnd = IR::IndirOpnd::New(slotBaseOpnd, i << this->GetDefaultIndirScale(), TyMachReg, this->m_func);
-            LowererMD::CreateAssign(opnd, undefOpnd, insertInstr);
+            Lowerer::InsertMove(opnd, undefOpnd, insertInstr);
         }
     }
 
@@ -7240,13 +7226,13 @@ LowererMD::GenerateLdThisStrict(IR::Instr* insertInstr)
     // LDR r1, [src1 + offset(type)]
     {
         IR::IndirOpnd * indirOpnd = IR::IndirOpnd::New(src1->AsRegOpnd(), Js::RecyclableObject::GetOffsetOfType(), TyMachReg, this->m_func);
-        this->CreateAssign(type, indirOpnd, insertInstr);
+        Lowerer::InsertMove(type, indirOpnd, insertInstr);
     }
 
     // LDR r1, [r1 + offset(typeId)]
     {
         IR::IndirOpnd * indirOpnd = IR::IndirOpnd::New(type, Js::Type::GetOffsetOfTypeId(), TyMachReg, this->m_func);
-        this->CreateAssign(typeId, indirOpnd, insertInstr);
+        Lowerer::InsertMove(typeId, indirOpnd, insertInstr);
     }
 
     // CMP typeid, TypeIds_ActivationObject
@@ -7266,7 +7252,7 @@ LowererMD::GenerateLdThisStrict(IR::Instr* insertInstr)
         insertInstr->InsertBefore(done);
 
         // LDR $dest, $src
-        LowererMD::CreateAssign(insertInstr->GetDst(), insertInstr->GetSrc1(), insertInstr);
+        Lowerer::InsertMove(insertInstr->GetDst(), insertInstr->GetSrc1(), insertInstr);
     }
 
     // B $fallthrough
@@ -7277,7 +7263,7 @@ LowererMD::GenerateLdThisStrict(IR::Instr* insertInstr)
     if(insertInstr->GetDst())
     {
         // LDR dst, undefined
-        LowererMD::CreateAssign(insertInstr->GetDst(), m_lowerer->LoadLibraryValueOpnd(insertInstr, LibraryValue::ValueUndefined), insertInstr);
+        Lowerer::InsertMove(insertInstr->GetDst(), m_lowerer->LoadLibraryValueOpnd(insertInstr, LibraryValue::ValueUndefined), insertInstr);
     }
 
     // $fallthrough:
@@ -7338,13 +7324,13 @@ void LowererMD::GenerateIsRecyclableObject(IR::RegOpnd *regOpnd, IR::Instr *inse
     //  LDR r1, [src1 + offset(type)]
     {
         IR::IndirOpnd * indirOpnd = IR::IndirOpnd::New(regOpnd, Js::RecyclableObject::GetOffsetOfType(), TyMachReg, this->m_func);
-        this->CreateAssign(r1, indirOpnd, insertInstr);
+        Lowerer::InsertMove(r1, indirOpnd, insertInstr);
     }
 
     //  LDR r1, [r1 + offset(typeId)]
     {
         IR::IndirOpnd * indirOpnd = IR::IndirOpnd::New(r1, Js::Type::GetOffsetOfTypeId(), TyMachReg, this->m_func);
-        this->CreateAssign(r1, indirOpnd, insertInstr);
+        Lowerer::InsertMove(r1, indirOpnd, insertInstr);
     }
 
     // SUB r1, -(~TypeIds_LastJavascriptPrimitiveType)
@@ -7393,7 +7379,7 @@ LowererMD::GenerateLdThisCheck(IR::Instr * instr)
     // MOV dst, src1
     if (instr->GetDst() && !instr->GetDst()->IsEqual(src1))
     {
-        this->CreateAssign(instr->GetDst(), src1, instr);
+        Lowerer::InsertMove(instr->GetDst(), src1, instr);
     }
 
     // B $fallthrough
@@ -7484,7 +7470,7 @@ LowererMD::GenerateFastIsInst(IR::Instr * instr)
     else
     {
         functionReg = IR::RegOpnd::New(TyMachReg, this->m_func);
-        LowererMD::CreateAssign(functionReg, functionSrc, instr);
+        Lowerer::InsertMove(functionReg, functionSrc, instr);
     }
 
     // CMP functionReg, [&(inlineCache->function)]
@@ -7507,7 +7493,7 @@ LowererMD::GenerateFastIsInst(IR::Instr * instr)
     else
     {
         objectReg = IR::RegOpnd::New(TyMachReg, this->m_func);
-        LowererMD::CreateAssign(objectReg, objectSrc, instr);
+        Lowerer::InsertMove(objectReg, objectSrc, instr);
     }
 
     // TST objectReg, Js::AtomTag
@@ -7554,7 +7540,7 @@ LowererMD::GenerateFastIsInst(IR::Instr * instr)
 
     if (opndDst != instr->GetDst())
     {
-        LowererMD::CreateAssign(instr->GetDst(), opndDst, instr);
+        Lowerer::InsertMove(instr->GetDst(), opndDst, instr);
     }
 
     // B done
@@ -7569,13 +7555,13 @@ LowererMD::GenerateFastIsInst(IR::Instr * instr)
 }
 
 // Helper method: inserts legalized assign for given srcOpnd into RegD0 in front of given instr in the following way:
-//   dstReg = CreateAssign srcOpnd
+//   dstReg = InsertMove srcOpnd
 // Used to put args of inline built-in call into RegD0 and RegD1 before we call actual CRT function.
 void LowererMD::GenerateAssignForBuiltinArg(RegNum dstReg, IR::Opnd* srcOpnd, IR::Instr* instr)
 {
     IR::RegOpnd* tempDst = IR::RegOpnd::New(nullptr, dstReg, TyMachDouble, this->m_func);
     tempDst->m_isCallArg = true; // This is to make sure that lifetime of opnd is virtually extended until next CALL instr.
-    this->CreateAssign(tempDst, srcOpnd, instr);
+    Lowerer::InsertMove(tempDst, srcOpnd, instr);
 }
 
 // For given InlineMathXXX instr, generate the call to actual CRT function/CPU instr.
@@ -7728,10 +7714,10 @@ void LowererMD::GenerateFastInlineBuiltInCall(IR::Instr* instr, IR::JnHelperMeth
         // Before:
         //      dst = <Built-in call> src1, src2
         // After:
-        //       d0 = CreateAssign src1
+        //       d0 = InsertMove src1
         //       lr = MOV helperAddr
         //            BLX lr
-        //      dst = CreateAssign call->dst (d0)
+        //      dst = InsertMove call->dst (d0)
 
         // Src1
         AssertMsg(instr->GetDst()->IsFloat(), "Currently accepting only float args for math helpers -- dst.");
@@ -7760,7 +7746,7 @@ void LowererMD::GenerateFastInlineBuiltInCall(IR::Instr* instr, IR::JnHelperMeth
         floatCall->InsertBefore(movInstr);
 
         // Save the result.
-        this->CreateAssign(instr->UnlinkDst(), floatCall->GetDst(), instr);
+        Lowerer::InsertMove(instr->UnlinkDst(), floatCall->GetDst(), instr);
         instr->Remove();
         break;
     }
@@ -8577,7 +8563,7 @@ void LowererMD::GenerateFloatTest(IR::RegOpnd * opndSrc, IR::Instr * insertInstr
 
     IR::RegOpnd *vt = IR::RegOpnd::New(TyMachPtr, this->m_func);
     IR::Opnd* opnd = IR::IndirOpnd::New(opndSrc, (int32)0, TyMachPtr, this->m_func);
-    LowererMD::CreateAssign(vt, opnd, insertInstr);
+    Lowerer::InsertMove(vt, opnd, insertInstr);
 
     // CMP [number], JavascriptNumber::vtable
     IR::Instr* instr = IR::Instr::New(Js::OpCode::CMP, this->m_func);

--- a/lib/Backend/arm/LowerMD.h
+++ b/lib/Backend/arm/LowerMD.h
@@ -68,7 +68,6 @@ public:
             IR::Instr *     ChangeToHelperCall(IR::Instr * instr, IR::JnHelperMethod helperMethod, IR::LabelInstr *labelBailOut = nullptr,
                                                IR::Opnd *opndInstance = nullptr, IR::PropertySymOpnd * propSymOpnd = nullptr, bool isHelperContinuation = false);
             IR::Instr *     ChangeToHelperCallMem(IR::Instr * instr, IR::JnHelperMethod helperMethod);
-    static  IR::Instr *     CreateAssign(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsertPt, bool generateWriteBarrier = true);
     static  IR::Instr *     ChangeToAssign(IR::Instr * instr);
     static  IR::Instr *     ChangeToAssignNoBarrierCheck(IR::Instr * instr);
     static  IR::Instr *     ChangeToAssign(IR::Instr * instr, IRType type);

--- a/lib/Backend/arm64/LowerMD.h
+++ b/lib/Backend/arm64/LowerMD.h
@@ -68,7 +68,6 @@ public:
             IR::Instr *     ChangeToHelperCall(IR::Instr * instr, IR::JnHelperMethod helperMethod, IR::LabelInstr *labelBailOut = nullptr,
                                                IR::Opnd *opndInstance = nullptr, IR::PropertySymOpnd * propSymOpnd = nullptr, bool isHelperContinuation = false);
             IR::Instr *     ChangeToHelperCallMem(IR::Instr * instr, IR::JnHelperMethod helperMethod);
-    static  IR::Instr *     CreateAssign(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsertPt, bool generateWriteBarrier = true);
     static  IR::Instr *     ChangeToAssign(IR::Instr * instr);
     static  IR::Instr *     ChangeToAssignNoBarrierCheck(IR::Instr * instr);
     static  IR::Instr *     ChangeToAssign(IR::Instr * instr, IRType type);

--- a/lib/Backend/i386/LinearScanMD.cpp
+++ b/lib/Backend/i386/LinearScanMD.cpp
@@ -541,11 +541,11 @@ LinearScanMD::InsertOpHelperSpillsAndRestores(OpHelperBlock const& opHelperBlock
             else
             {
                 regOpnd = IR::RegOpnd::New(NULL, opHelperSpilledLifetime.reg, sym->GetType(), this->func);
-                IR::Instr* instr = LowererMD::CreateAssign(IR::SymOpnd::New(sym, sym->GetType(), func), regOpnd, opHelperBlock.opHelperLabel->m_next);
+                IR::Instr* instr = Lowerer::InsertMove(IR::SymOpnd::New(sym, sym->GetType(), func), regOpnd, opHelperBlock.opHelperLabel->m_next);
                 instr->CopyNumber(opHelperBlock.opHelperLabel);
                 if (opHelperSpilledLifetime.reload)
                 {
-                    instr = LowererMD::CreateAssign(regOpnd, IR::SymOpnd::New(sym, sym->GetType(), func), opHelperBlock.opHelperEndInstr);
+                    instr = Lowerer::InsertMove(regOpnd, IR::SymOpnd::New(sym, sym->GetType(), func), opHelperBlock.opHelperEndInstr);
                     instr->CopyNumber(opHelperBlock.opHelperEndInstr);
                 }
             }

--- a/lib/Backend/i386/LowererMDArch.cpp
+++ b/lib/Backend/i386/LowererMDArch.cpp
@@ -340,7 +340,7 @@ LowererMDArch::LoadHeapArguments(IR::Instr *instrArgs)
                 // the function object for generator calls is a GeneratorVirtualScriptFunction object
                 // and we need to pass the real JavascriptGeneratorFunction object so grab it instead
                 IR::RegOpnd *tmpOpnd = IR::RegOpnd::New(TyMachReg, func);
-                LowererMD::CreateAssign(tmpOpnd, srcOpnd, instrArgs);
+                Lowerer::InsertMove(tmpOpnd, srcOpnd, instrArgs);
 
                 srcOpnd = IR::IndirOpnd::New(tmpOpnd, Js::GeneratorVirtualScriptFunction::GetRealFunctionOffset(), TyMachPtr, func);
             }
@@ -482,7 +482,7 @@ LowererMDArch::LoadNewScObjFirstArg(IR::Instr * instr, IR::Opnd * dst, ushort ex
 {
     // No need to do anything different for spread calls on x86 since we push args.
     IR::SymOpnd *   argOpnd     = IR::SymOpnd::New(this->m_func->m_symTable->GetArgSlotSym(1), TyVar, this->m_func);
-    IR::Instr *     argInstr    = LowererMD::CreateAssign(argOpnd, dst, instr);
+    IR::Instr *     argInstr    = Lowerer::InsertMove(argOpnd, dst, instr);
     return argInstr;
 }
 
@@ -1250,7 +1250,7 @@ LowererMDArch::LowerStartCall(IR::Instr * startCallInstr, IR::Instr* insertInstr
         //     call _chkstk
 
         IR::RegOpnd *eaxOpnd = IR::RegOpnd::New(nullptr, this->GetRegChkStkParam(), TyMachReg, this->m_func);
-        this->lowererMD->CreateAssign(eaxOpnd, IR::IntConstOpnd::New(sizeValue, TyInt32, this->m_func, /*dontEncode*/true), insertInstr);
+        Lowerer::InsertMove(eaxOpnd, IR::IntConstOpnd::New(sizeValue, TyInt32, this->m_func, /*dontEncode*/true), insertInstr);
 
         newStartCall = IR::Instr::New(Js::OpCode::Call, this->m_func);
 
@@ -1301,7 +1301,7 @@ LowererMDArch::LowerStartCallAsmJs(IR::Instr * startCallInstr, IR::Instr * inser
         //     call _chkstk
 
         IR::RegOpnd *eaxOpnd = IR::RegOpnd::New(nullptr, GetRegChkStkParam(), TyMachReg, m_func);
-        lowererMD->CreateAssign(eaxOpnd, IR::IntConstOpnd::New(sizeValue, TyInt32, m_func, /*dontEncode*/true), insertInstr);
+        Lowerer::InsertMove(eaxOpnd, IR::IntConstOpnd::New(sizeValue, TyInt32, m_func, /*dontEncode*/true), insertInstr);
 
         newStartCall = IR::Instr::New(Js::OpCode::Call, m_func);
 
@@ -1541,7 +1541,7 @@ LowererMDArch::LowerEntryInstr(IR::EntryInstr * entryInstr)
             this->LowerCall(callInstr, 0, RegECX);
 
             IR::IntConstOpnd * stackSizeOpnd = IR::IntConstOpnd::New(stackSize, TyMachReg, this->m_func);
-            this->lowererMD->CreateAssign(eaxOpnd, stackSizeOpnd, entryInstr->m_next);
+            Lowerer::InsertMove(eaxOpnd, stackSizeOpnd, entryInstr->m_next);
         }
     }
 
@@ -1618,7 +1618,7 @@ LowererMDArch::GeneratePrologueStackProbe(IR::Instr *entryInstr, size_t frameSiz
         stackLimitOpnd = IR::RegOpnd::New(nullptr, RegEAX, TyMachReg, this->m_func);
         intptr_t pLimit = m_func->GetThreadContextInfo()->GetThreadStackLimitAddr();
         IR::MemRefOpnd * memOpnd = IR::MemRefOpnd::New(pLimit, TyMachReg, this->m_func);
-        this->lowererMD->CreateAssign(stackLimitOpnd, memOpnd, insertInstr);
+        Lowerer::InsertMove(stackLimitOpnd, memOpnd, insertInstr);
 
         instr = IR::Instr::New(Js::OpCode::ADD, stackLimitOpnd, stackLimitOpnd,
                                IR::IntConstOpnd::New(frameSize, TyMachReg, this->m_func), this->m_func);
@@ -3157,7 +3157,7 @@ bool
 
         if (opndSrc2->IsAddrOpnd())
         {
-            instr = lowererMD->CreateAssign(
+            instr = Lowerer::InsertMove(
                 IR::RegOpnd::New(opndSrc2->GetType(), instrShift->m_func),
                 opndSrc2, instrShift);
             opndSrc2 = instr->GetDst();


### PR DESCRIPTION
All LowererMDs had identical CreateAssign methods which did nothing but call InsertMove with the same arguments. This commit removes the MD versions in favor of always using the machine independant call.
