### PR TITLE
RegExp Bytecode: Reduce tag size from 4 bytes to 1 byte and use #pragma pack on bytecode structs

### DIFF
--- a/lib/Parser/RegexCompileTime.cpp
+++ b/lib/Parser/RegexCompileTime.cpp
@@ -4,6 +4,9 @@
 //-------------------------------------------------------------------------------------------------------
 #include "ParserPch.h"
 
+#pragma warning(push)
+#pragma warning(disable:4366)
+
 namespace UnifiedRegex
 {
 
@@ -4778,3 +4781,5 @@ namespace UnifiedRegex
 #endif
     }
 }
+
+#pragma warning(pop)

--- a/lib/Parser/RegexCompileTime.cpp
+++ b/lib/Parser/RegexCompileTime.cpp
@@ -4,9 +4,6 @@
 //-------------------------------------------------------------------------------------------------------
 #include "ParserPch.h"
 
-#pragma warning(push)
-#pragma warning(disable:4366)
-
 namespace UnifiedRegex
 {
 
@@ -4781,5 +4778,3 @@ namespace UnifiedRegex
 #endif
     }
 }
-
-#pragma warning(pop)

--- a/lib/Parser/RegexCompileTime.h
+++ b/lib/Parser/RegexCompileTime.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "RuntimeCommon.h"
+
 namespace UnifiedRegex
 {
     // FORWARD
@@ -619,8 +621,9 @@ namespace UnifiedRegex
         T* Emit();
 
         // The instruction buffer may move, so we need to remember label fixup's relative to the instruction base
-        // rather than as machine addresses
-        inline Label GetFixup(Label* pLabel)
+        // rather than as machine addresses.
+        // NOTE: pLabel is declared unaligned because Inst structs are unaligned in the inst buffer (thanks to #pragma pack(1)).
+        inline Label GetFixup(unaligned Label* pLabel)
         {
             Assert((uint8*)pLabel >= instBuf && (uint8*)pLabel < instBuf + instNext);
             return (Label)((uint8*)pLabel - instBuf);

--- a/lib/Parser/RegexRuntime.h
+++ b/lib/Parser/RegexRuntime.h
@@ -280,6 +280,7 @@ namespace UnifiedRegex
     // Mix-in types
     // ----------------------------------------------------------------------
 
+#pragma pack(push, 1)
     // Contains information about how much to back up after syncing to a literal (for the SyncTo... instructions)
     struct BackupMixin
     {
@@ -693,9 +694,11 @@ namespace UnifiedRegex
     // Instructions
     // ----------------------------------------------------------------------
 
+    // NOTE: #pragma pack(1) applies to all Inst structs as well as all Mixin structs (see above).
+
     struct Inst : protected Chars<char16>
     {
-        enum InstTag : uint32
+        enum InstTag : uint8
         {
 #define M(TagName) TagName,
 #define MTemplate(TagName, ...) M(TagName)
@@ -1496,6 +1499,7 @@ namespace UnifiedRegex
 
         INST_BODY
     };
+#pragma pack(pop)
 
     // ----------------------------------------------------------------------
     // Matcher state


### PR DESCRIPTION
InstTag (opcodes) in RegExp Bytecode only need a single byte. Furthermore, there is a lot of space lost to padding in the RegExp Bytecode, so we now tell the compiler to pack the structs. This results in unaligned members of the bytecode structs, but an IB has shown this not to regress performance.

This change is the groundwork for future efforts in variable-length encoding of RegExp Bytecode.

Notably, the way we use placement new to layout bytecode in the buffer doesn't really allow the compiler to do its own alignment, so after changing the opcode size opcodes are no longer aligned. This potentially impacts perf, but @Penguinwizzard informed me that we already have this problem with the ChakraCore bytecode, and it probably doesn't hugely impact perf.

# Performance Analysis

IB shows that this does not regress perf. There were some improvements and some regressions but a follow up revealed them to be noise. If there are any regressions, they are within the noise of the measurement, and it is potentially worth it for the comparatively large improvement in memory usage.

# Memory Analysis

Using `#pragma pack(1)` on all `Mixin` and `Inst` types packs things down quite significantly. In the example below, the tag size change (4 bytes -> 1) decreased the bytecode size from 0x44 to 0x3e. `#pragma pack(1)` further reduced it to 0x29.

This change improves RegExp Bytecode memory usage by ~10% in AdBlock (reducing memory usage by 1 MB overall).

# Example

RegExp: `/(^token|foo)/`

Before (InstTag = 32 bits):

```
    instructions: {
        L0000: (0x008 bytes) BeginDefineGroup(groupId: 1)
            0x0000020E2BECC0A0[+0x000](0x004)(size:0x04)(align:0x04) [Inst]: 3b000000
            0x0000020E2BECC0A4[+0x004](0x004)(size:0x04)(align:0x04) [GroupMixin]: 01000000
        L0008: (0x008 bytes) Try(failLabel: L0028)
            0x0000020E2BECC0A8[+0x000](0x004)(size:0x04)(align:0x04) [Inst]: 57000000
            0x0000020E2BECC0AC[+0x004](0x004)(size:0x04)(align:0x04) [TryMixin]: 28000000
        L0010: (0x004 bytes) BOITest(<hardFail>: false)
            0x0000020E2BECC0B0[+0x000](0x004)(size:0x04)(align:0x04) [Inst]: 0d000000
        L0014: (0x00c bytes) MatchLiteral(literal: "token")
            0x0000020E2BECC0B4[+0x000](0x004)(size:0x04)(align:0x04) [Inst]: 1a000000
            0x0000020E2BECC0B8[+0x004](0x008)(size:0x08)(align:0x04) [LiteralMixin]: 00000000 05000000
        L0020: (0x008 bytes) Jump(targetLabel: L0034)
            0x0000020E2BECC0C0[+0x000](0x004)(size:0x04)(align:0x04) [Inst]: 03000000
            0x0000020E2BECC0C4[+0x004](0x004)(size:0x04)(align:0x04) [JumpMixin]: 34000000
        L0028: (0x00c bytes) MatchLiteral(literal: "foo")
            0x0000020E2BECC0C8[+0x000](0x004)(size:0x04)(align:0x04) [Inst]: 1a000000
            0x0000020E2BECC0CC[+0x004](0x008)(size:0x08)(align:0x04) [LiteralMixin]: 05000000 03000000
        L0034: (0x00c bytes) EndDefineGroup(groupId: 1, noNeedToSave: true)
            0x0000020E2BECC0D4[+0x000](0x004)(size:0x04)(align:0x04) [Inst]: 3c000000
            0x0000020E2BECC0D8[+0x004](0x004)(size:0x04)(align:0x04) [GroupMixin]: 01000000
            0x0000020E2BECC0DC[+0x008](0x001)(size:0x01)(align:0x01) [NoNeedToSaveMixin]:01
        L0040: (0x004 bytes) Succ()
            0x0000020E2BECC0E0[+0x000](0x004)(size:0x04)(align:0x04) [Inst]: 02000000
            0x0000020E2BECC0E0[+0x000](0x004)(size:0x04)(align:0x04) [NopInst]: 02000000
    }
```

After (InstTag = 8 bits):

```
    instructions: {
        L0000: (0x008 bytes) BeginDefineGroup(groupId: 1)
            0x0000023B58088180[+0x000](0x001)(size:0x01)(align:0x01) [Inst]:3b
            0x0000023B58088184[+0x004](0x004)(size:0x04)(align:0x04) [GroupMixin]: 01000000
        L0008: (0x008 bytes) Try(failLabel: L0025)
            0x0000023B58088188[+0x000](0x001)(size:0x01)(align:0x01) [Inst]:57
            0x0000023B5808818C[+0x004](0x004)(size:0x04)(align:0x04) [TryMixin]: 25000000
        L0010: (0x001 bytes) BOITest(<hardFail>: false)
            0x0000023B58088190[+0x000](0x001)(size:0x01)(align:0x01) [Inst]:0d
        L0011: (0x00c bytes) MatchLiteral(literal: "token")
            0x0000023B58088191[+0x000](0x001)(size:0x01)(align:0x01) [Inst]:1a
            0x0000023B58088195[+0x004](0x008)(size:0x08)(align:0x04) [LiteralMixin]: 00000000 05000000
        L001d: (0x008 bytes) Jump(targetLabel: L0031)
            0x0000023B5808819D[+0x000](0x001)(size:0x01)(align:0x01) [Inst]:03
            0x0000023B580881A1[+0x004](0x004)(size:0x04)(align:0x04) [JumpMixin]: 31000000
        L0025: (0x00c bytes) MatchLiteral(literal: "foo")
            0x0000023B580881A5[+0x000](0x001)(size:0x01)(align:0x01) [Inst]:1a
            0x0000023B580881A9[+0x004](0x008)(size:0x08)(align:0x04) [LiteralMixin]: 05000000 03000000
        L0031: (0x00c bytes) EndDefineGroup(groupId: 1, noNeedToSave: true)
            0x0000023B580881B1[+0x000](0x001)(size:0x01)(align:0x01) [Inst]:3c
            0x0000023B580881B5[+0x004](0x004)(size:0x04)(align:0x04) [GroupMixin]: 01000000
            0x0000023B580881B9[+0x008](0x001)(size:0x01)(align:0x01) [NoNeedToSaveMixin]:01
        L003d: (0x001 bytes) Succ()
            0x0000023B580881BD[+0x000](0x001)(size:0x01)(align:0x01) [Inst]:02
            0x0000023B580881BD[+0x000](0x001)(size:0x01)(align:0x01) [NopInst]:02
    }
```

With `#pragma pack(1)`:

```
    instructions: {
        L0000: (0x005 bytes) BeginDefineGroup(groupId: 1)
            0x000001D069D64B10[+0x000](0x001)(size:0x01)(align:0x01) [Inst]:3b
            0x000001D069D64B11[+0x001](0x004)(size:0x04)(align:0x01) [GroupMixin]: 01000000
        L0005: (0x005 bytes) Try(failLabel: L0019)
            0x000001D069D64B15[+0x000](0x001)(size:0x01)(align:0x01) [Inst]:57
            0x000001D069D64B16[+0x001](0x004)(size:0x04)(align:0x01) [TryMixin]: 19000000
        L000a: (0x001 bytes) BOITest(<hardFail>: false)
            0x000001D069D64B1A[+0x000](0x001)(size:0x01)(align:0x01) [Inst]:0d
        L000b: (0x009 bytes) MatchLiteral(literal: "token")
            0x000001D069D64B1B[+0x000](0x001)(size:0x01)(align:0x01) [Inst]:1a
            0x000001D069D64B1C[+0x001](0x008)(size:0x08)(align:0x01) [LiteralMixin]: 00000000 05000000
        L0014: (0x005 bytes) Jump(targetLabel: L0022)
            0x000001D069D64B24[+0x000](0x001)(size:0x01)(align:0x01) [Inst]:03
            0x000001D069D64B25[+0x001](0x004)(size:0x04)(align:0x01) [JumpMixin]: 22000000
        L0019: (0x009 bytes) MatchLiteral(literal: "foo")
            0x000001D069D64B29[+0x000](0x001)(size:0x01)(align:0x01) [Inst]:1a
            0x000001D069D64B2A[+0x001](0x008)(size:0x08)(align:0x01) [LiteralMixin]: 05000000 03000000
        L0022: (0x006 bytes) EndDefineGroup(groupId: 1, noNeedToSave: true)
            0x000001D069D64B32[+0x000](0x001)(size:0x01)(align:0x01) [Inst]:3c
            0x000001D069D64B33[+0x001](0x004)(size:0x04)(align:0x01) [GroupMixin]: 01000000
            0x000001D069D64B37[+0x005](0x001)(size:0x01)(align:0x01) [NoNeedToSaveMixin]:01
        L0028: (0x001 bytes) Succ()
            0x000001D069D64B38[+0x000](0x001)(size:0x01)(align:0x01) [Inst]:02
            0x000001D069D64B38[+0x000](0x001)(size:0x01)(align:0x01) [NopInst]:02
    }
```
