### PR TITLE
Increase the Wasm function size limit to 7654321 bytes

### DIFF
--- a/lib/WasmReader/WasmLimits.h
+++ b/lib/WasmReader/WasmLimits.h
@@ -26,7 +26,7 @@ namespace Wasm {
         static const uint32 MaxMemoryInitialPages = 16384;
         static const uint32 MaxMemoryMaximumPages = 65536;
         static const uint32 MaxModuleSize = 1024 * 1024 * 1024;
-        static const uint32 MaxFunctionSize = 128 * 1024;
+        static const uint32 MaxFunctionSize = 7654321;
     public:
         // Use accessors to easily switch to config flags if needed
         static uint32 GetMaxTypes() { return CONFIG_FLAG(WasmIgnoreLimits) ? UINT32_MAX : MaxTypes; }

--- a/test/wasm/limits.js
+++ b/test/wasm/limits.js
@@ -21,7 +21,7 @@ const MaxBrTableElems = 1000000;
 const MaxMemoryInitialPages = 16384;
 const MaxMemoryMaximumPages = 65536;
 const MaxModuleSize = 1024 * 1024 * 1024;
-const MaxFunctionSize = 128 * 1024;
+const MaxFunctionSize = 7654321;
 
 /* global assert,testRunner */ // eslint rule
 WScript.LoadScriptFile("../UnitTestFrameWork/UnitTestFrameWork.js");


### PR DESCRIPTION
Bumping limit according to discussion on https://github.com/WebAssembly/design/issues/1138

Fixes OS#14291237

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/4070)
<!-- Reviewable:end -->
