### PR TITLE
Add ESModule URL + include in errors

### DIFF
--- a/bin/ch/WScriptJsrt.cpp
+++ b/bin/ch/WScriptJsrt.cpp
@@ -388,6 +388,13 @@ JsErrorCode WScriptJsrt::LoadModuleFromString(LPCSTR fileName, LPCSTR fileConten
     IfJsrtErrorFailLogAndRetErrorCode(errorCode);
     JsValueRef errorObject = JS_INVALID_REFERENCE;
 
+    if (fullName)
+    {
+        JsValueRef moduleURL;
+        ChakraRTInterface::JsCreateString(fullName, strlen(fullName), &moduleURL);
+        errorCode = ChakraRTInterface::JsSetModuleHostInfo(requestModule, JsModuleHostInfo_ModuleURL, moduleURL);
+    }
+
     // ParseModuleSource is sync, while additional fetch & evaluation are async.
     unsigned int fileContentLength = (fileContent == nullptr) ? 0 : (unsigned int)strlen(fileContent);
     errorCode = ChakraRTInterface::JsParseModuleSource(requestModule, dwSourceCookie, (LPBYTE)fileContent,
@@ -419,7 +426,7 @@ JsValueRef WScriptJsrt::LoadScript(JsValueRef callee, LPCSTR fileName,
     IfJsrtErrorSetGo(ChakraRTInterface::JsGetRuntime(currentContext, &runtime));
 
     if (fileName == nullptr)
-        {
+    {
         fileName = "script.js";
     }
 

--- a/lib/Jsrt/ChakraCore.h
+++ b/lib/Jsrt/ChakraCore.h
@@ -54,7 +54,8 @@ typedef enum JsModuleHostInfoKind
     JsModuleHostInfo_HostDefined = 0x02,
     JsModuleHostInfo_NotifyModuleReadyCallback = 0x3,
     JsModuleHostInfo_FetchImportedModuleCallback = 0x4,
-    JsModuleHostInfo_FetchImportedModuleFromScriptCallback = 0x5
+    JsModuleHostInfo_FetchImportedModuleFromScriptCallback = 0x5,
+    JsModuleHostInfo_ModuleURL = 0x6
 } JsModuleHostInfoKind;
 
 /// <summary>

--- a/lib/Jsrt/Core/JsrtCore.cpp
+++ b/lib/Jsrt/Core/JsrtCore.cpp
@@ -77,7 +77,18 @@ JsParseModuleSource(
         SourceContextInfo* sourceContextInfo = scriptContext->GetSourceContextInfo(sourceContext, nullptr);
         if (sourceContextInfo == nullptr)
         {
-            sourceContextInfo = scriptContext->CreateSourceContextInfo(sourceContext, nullptr, 0, nullptr, nullptr, 0);
+            if(moduleRecord->GetModuleURL() != nullptr)
+            {
+                Js::JavascriptString *moduleURL = Js::JavascriptString::FromVar(moduleRecord->GetModuleURL());
+                const char16 *moduleURLSz = moduleURL->GetSz();
+                size_t moduleURLLen = moduleURL->GetLength();
+                
+                sourceContextInfo = scriptContext->CreateSourceContextInfo(sourceContext, moduleURLSz, moduleURLLen, nullptr, nullptr, 0);
+            }
+            else
+            {
+                sourceContextInfo = scriptContext->CreateSourceContextInfo(sourceContext, nullptr, 0, nullptr, nullptr, 0);
+            }
         }
         SRCINFO si = {
             /* sourceContextInfo   */ sourceContextInfo,
@@ -164,6 +175,9 @@ JsSetModuleHostInfo(
         case JsModuleHostInfo_NotifyModuleReadyCallback:
             currentContext->GetHostScriptContext()->SetNotifyModuleReadyCallback(reinterpret_cast<NotifyModuleReadyCallback>(hostInfo));
             break;
+        case JsModuleHostInfo_ModuleURL:
+            moduleRecord->SetModuleURL(hostInfo);    
+            break;
         default:
             return JsInvalidModuleHostInfoKind;
         };
@@ -207,6 +221,9 @@ JsGetModuleHostInfo(
             break;
         case JsModuleHostInfo_NotifyModuleReadyCallback:
             *hostInfo = reinterpret_cast<void*>(currentContext->GetHostScriptContext()->GetNotifyModuleReadyCallback());
+            break;
+        case JsModuleHostInfo_ModuleURL:
+            *hostInfo = reinterpret_cast<void*>(moduleRecord->GetModuleURL());
             break;
         default:
             return JsInvalidModuleHostInfoKind;

--- a/lib/Runtime/Language/SourceTextModuleRecord.cpp
+++ b/lib/Runtime/Language/SourceTextModuleRecord.cpp
@@ -31,6 +31,7 @@ namespace Js
         localExportMapByLocalName(nullptr),
         localExportIndexList(nullptr),
         normalizedSpecifier(nullptr),
+        moduleURL(nullptr),
         errorObject(nullptr),
         hostDefined(nullptr),
         exportedNames(nullptr),
@@ -171,7 +172,14 @@ namespace Js
         {
             if (*exceptionVar == nullptr)
             {
-                *exceptionVar = JavascriptError::CreateFromCompileScriptException(scriptContext, &se);
+                if(this->GetModuleURL() != nullptr)
+                {
+                    *exceptionVar = JavascriptError::CreateFromCompileScriptException(scriptContext, &se, this->GetModuleURLSz());
+                }
+                else
+                {
+                    *exceptionVar = JavascriptError::CreateFromCompileScriptException(scriptContext, &se);                    
+                }
             }
             if (this->parser)
             {
@@ -831,7 +839,14 @@ namespace Js
         this->rootFunction = scriptContext->GenerateRootFunction(parseTree, sourceIndex, this->parser, this->pSourceInfo->GetParseFlags(), &se, _u("module"));
         if (rootFunction == nullptr)
         {
-            this->errorObject = JavascriptError::CreateFromCompileScriptException(scriptContext, &se);
+            if(this->GetModuleURL() != nullptr)
+            {
+                this->errorObject = JavascriptError::CreateFromCompileScriptException(scriptContext, &se, this->GetModuleURLSz());
+            }
+            else
+            {
+                this->errorObject = JavascriptError::CreateFromCompileScriptException(scriptContext, &se);                    
+            }
             OUTPUT_TRACE_DEBUGONLY(Js::ModulePhase, _u("\t>NotifyParentAsNeeded rootFunction == nullptr\n"));
             NotifyParentsAsNeeded();
         }

--- a/lib/Runtime/Language/SourceTextModuleRecord.h
+++ b/lib/Runtime/Language/SourceTextModuleRecord.h
@@ -50,6 +50,10 @@ namespace Js
         Var GetSpecifier() const { return normalizedSpecifier; }
         const char16 *GetSpecifierSz() const { return JavascriptString::FromVar(this->normalizedSpecifier)->GetSz(); }
 
+        void SetModuleURL(Var moduleURL) {this->moduleURL = moduleURL;}
+        Var GetModuleURL() const { return moduleURL;}
+        const char16 *GetModuleURLSz() const { return JavascriptString::FromVar(this->moduleURL)->GetSz(); }
+
         Var GetErrorObject() const { return errorObject; }
 
         bool WasParsed() const { return wasParsed; }
@@ -137,6 +141,7 @@ namespace Js
 
         Field(Js::JavascriptFunction*) rootFunction;
         Field(void*) hostDefined;
+        Field(Var) moduleURL;
         Field(Var) normalizedSpecifier;
         Field(Var) errorObject;
         Field(Field(Var)*) localExportSlots;


### PR DESCRIPTION
This is an attempt to implement my own suggestions from: https://github.com/Microsoft/ChakraCore/issues/4068

1. Allows a host to set a URL for a module with JsSetModuleHostInfo.
2. Adds this URL to the error stack trace for run time errors
3. Adds this URL to syntax errors

Doesn't yet include a URL for exports that cant be found, couldn't see how to get the URL here:
https://github.com/Microsoft/ChakraCore/blob/master/lib/Runtime/Language/SourceTextModuleRecord.cpp#L627-L632