### PR TITLE
Add ESModule URL + include in errors

### DIFF
--- a/bin/ch/WScriptJsrt.h
+++ b/bin/ch/WScriptJsrt.h
@@ -90,7 +90,7 @@ public:
 #endif
 
     static bool PrintException(LPCSTR fileName, JsErrorCode jsErrorCode);
-    static JsValueRef LoadScript(JsValueRef callee, LPCSTR fileName, LPCSTR fileContent, LPCSTR scriptInjectType, bool isSourceModule, JsFinalizeCallback finalizeCallback);
+    static JsValueRef LoadScript(JsValueRef callee, LPCSTR fileName, LPCSTR fileContent, LPCSTR scriptInjectType, bool isSourceModule, JsFinalizeCallback finalizeCallback, bool isFile);
     static DWORD_PTR GetNextSourceContext();
     static JsValueRef LoadScriptFileHelper(JsValueRef callee, JsValueRef *arguments, unsigned short argumentCount, bool isSourceModule);
     static JsValueRef LoadScriptHelper(JsValueRef callee, bool isConstructCall, JsValueRef *arguments, unsigned short argumentCount, void *callbackState, bool isSourceModule);
@@ -114,7 +114,7 @@ private:
     static JsValueRef CALLBACK RequestAsyncBreakCallback(JsValueRef callee, bool isConstructCall, JsValueRef *arguments, unsigned short argumentCount, void *callbackState);
 
     static JsValueRef CALLBACK EmptyCallback(JsValueRef callee, bool isConstructCall, JsValueRef *arguments, unsigned short argumentCount, void *callbackState);
-    static JsErrorCode CALLBACK LoadModuleFromString(LPCSTR fileName, LPCSTR fileContent, LPCSTR fullName = nullptr);
+    static JsErrorCode CALLBACK LoadModuleFromString(LPCSTR fileName, LPCSTR fileContent, LPCSTR fullName = nullptr, bool isFile = false);
     static JsErrorCode CALLBACK InitializeModuleInfo(JsValueRef specifier, JsModuleRecord moduleRecord);
 
     static JsValueRef CALLBACK LoadBinaryFileCallback(JsValueRef callee, bool isConstructCall, JsValueRef *arguments, unsigned short argumentCount, void *callbackState);

--- a/lib/Jsrt/ChakraCore.h
+++ b/lib/Jsrt/ChakraCore.h
@@ -54,7 +54,8 @@ typedef enum JsModuleHostInfoKind
     JsModuleHostInfo_HostDefined = 0x02,
     JsModuleHostInfo_NotifyModuleReadyCallback = 0x3,
     JsModuleHostInfo_FetchImportedModuleCallback = 0x4,
-    JsModuleHostInfo_FetchImportedModuleFromScriptCallback = 0x5
+    JsModuleHostInfo_FetchImportedModuleFromScriptCallback = 0x5,
+    JsModuleHostInfo_Url = 0x6
 } JsModuleHostInfoKind;
 
 /// <summary>

--- a/lib/Jsrt/Core/JsrtCore.cpp
+++ b/lib/Jsrt/Core/JsrtCore.cpp
@@ -77,7 +77,15 @@ JsParseModuleSource(
         SourceContextInfo* sourceContextInfo = scriptContext->GetSourceContextInfo(sourceContext, nullptr);
         if (sourceContextInfo == nullptr)
         {
-            sourceContextInfo = scriptContext->CreateSourceContextInfo(sourceContext, nullptr, 0, nullptr, nullptr, 0);
+            const char16 *moduleUrlSz = nullptr;
+            size_t moduleUrlLen = 0;
+            if (moduleRecord->GetModuleUrl())
+            {
+                Js::JavascriptString *moduleUrl = Js::JavascriptString::FromVar(moduleRecord->GetModuleUrl());
+                moduleUrlSz = moduleUrl->GetSz();
+                moduleUrlLen = moduleUrl->GetLength();
+            }
+            sourceContextInfo = scriptContext->CreateSourceContextInfo(sourceContext, moduleUrlSz, moduleUrlLen, nullptr, nullptr, 0);
         }
         SRCINFO si = {
             /* sourceContextInfo   */ sourceContextInfo,
@@ -164,6 +172,9 @@ JsSetModuleHostInfo(
         case JsModuleHostInfo_NotifyModuleReadyCallback:
             currentContext->GetHostScriptContext()->SetNotifyModuleReadyCallback(reinterpret_cast<NotifyModuleReadyCallback>(hostInfo));
             break;
+        case JsModuleHostInfo_Url:
+            moduleRecord->SetModuleUrl(hostInfo);    
+            break;
         default:
             return JsInvalidModuleHostInfoKind;
         };
@@ -207,6 +218,9 @@ JsGetModuleHostInfo(
             break;
         case JsModuleHostInfo_NotifyModuleReadyCallback:
             *hostInfo = reinterpret_cast<void*>(currentContext->GetHostScriptContext()->GetNotifyModuleReadyCallback());
+            break;
+        case JsModuleHostInfo_Url:
+            *hostInfo = reinterpret_cast<void*>(moduleRecord->GetModuleUrl());
             break;
         default:
             return JsInvalidModuleHostInfoKind;

--- a/lib/Runtime/Language/SourceTextModuleRecord.cpp
+++ b/lib/Runtime/Language/SourceTextModuleRecord.cpp
@@ -31,6 +31,7 @@ namespace Js
         localExportMapByLocalName(nullptr),
         localExportIndexList(nullptr),
         normalizedSpecifier(nullptr),
+        moduleUrl(nullptr),
         errorObject(nullptr),
         hostDefined(nullptr),
         exportedNames(nullptr),
@@ -171,7 +172,12 @@ namespace Js
         {
             if (*exceptionVar == nullptr)
             {
-                *exceptionVar = JavascriptError::CreateFromCompileScriptException(scriptContext, &se);
+                const WCHAR * sourceUrl = nullptr;
+                if (this->GetModuleUrl())
+                {
+                  sourceUrl = this->GetModuleUrlSz();
+                }
+                *exceptionVar = JavascriptError::CreateFromCompileScriptException(scriptContext, &se, sourceUrl);
             }
             if (this->parser)
             {
@@ -831,7 +837,12 @@ namespace Js
         this->rootFunction = scriptContext->GenerateRootFunction(parseTree, sourceIndex, this->parser, this->pSourceInfo->GetParseFlags(), &se, _u("module"));
         if (rootFunction == nullptr)
         {
-            this->errorObject = JavascriptError::CreateFromCompileScriptException(scriptContext, &se);
+            const WCHAR * sourceUrl = nullptr;
+            if (this->GetModuleUrl())
+            {
+                sourceUrl = this->GetModuleUrlSz();
+            }
+            this->errorObject = JavascriptError::CreateFromCompileScriptException(scriptContext, &se, sourceUrl);
             OUTPUT_TRACE_DEBUGONLY(Js::ModulePhase, _u("\t>NotifyParentAsNeeded rootFunction == nullptr\n"));
             NotifyParentsAsNeeded();
         }

--- a/lib/Runtime/Language/SourceTextModuleRecord.h
+++ b/lib/Runtime/Language/SourceTextModuleRecord.h
@@ -50,6 +50,10 @@ namespace Js
         Var GetSpecifier() const { return normalizedSpecifier; }
         const char16 *GetSpecifierSz() const { return JavascriptString::FromVar(this->normalizedSpecifier)->GetSz(); }
 
+        void SetModuleUrl(Var moduleUrl) { this->moduleUrl = moduleUrl; }
+        Var GetModuleUrl() const { return moduleUrl;}
+        const char16 *GetModuleUrlSz() const { return JavascriptString::FromVar(this->moduleUrl)->GetSz(); }
+
         Var GetErrorObject() const { return errorObject; }
 
         bool WasParsed() const { return wasParsed; }
@@ -137,6 +141,7 @@ namespace Js
 
         Field(Js::JavascriptFunction*) rootFunction;
         Field(void*) hostDefined;
+        Field(Var) moduleUrl;
         Field(Var) normalizedSpecifier;
         Field(Var) errorObject;
         Field(Field(Var)*) localExportSlots;

--- a/test/es6/moduleImportTheError.js
+++ b/test/es6/moduleImportTheError.js
@@ -1,0 +1,24 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+
+import {throwError} from "moduleThrowAnError.js";
+
+try
+{
+    throwError();
+}
+catch(e)
+{
+    let index = e.stack.indexOf("moduleThrowAnError.js");
+    if(index == -1)
+    {
+        WScript.Echo("Fail - url not in stack for module error");
+    }
+    else
+    {
+        WScript.Echo("Pass");
+    }
+}

--- a/test/es6/moduleThrowAnError.js
+++ b/test/es6/moduleThrowAnError.js
@@ -1,0 +1,9 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+export function throwError()
+{
+    throw new Error("This is an error");
+}

--- a/test/es6/moduleUrlInError.js
+++ b/test/es6/moduleUrlInError.js
@@ -1,0 +1,7 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+//The real test has to run as a module so this file just loads it
+WScript.LoadScriptFile("moduleImportTheError.js","module");

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -1354,6 +1354,11 @@
   </test>
   <test>
     <default>
+      <files>moduleUrlInError.js</files>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>dynamic-module-functionality.js</files>
       <compile-flags>-ES6Module -args summary -endargs</compile-flags>
       <tags>exclude_sanitize_address</tags>


### PR DESCRIPTION
This is an attempt to implement my own suggestions from: #4068

(Closed first version by mistake)

Allows a host to set a URL for a module with JsSetModuleHostInfo.
Adds this URL to the error stack trace for run time errors
Adds this URL to syntax errors
Doesn't yet include a URL for exports that cant be found, couldn't see how to get the URL here:

https://github.com/Microsoft/ChakraCore/blob/master/lib/Runtime/Language/SourceTextModuleRecord.cpp#L627-L632