### PR TITLE
Improving perf for encodeURI.

### DIFF
--- a/lib/Runtime/Library/UriHelper.cpp
+++ b/lib/Runtime/Library/UriHelper.cpp
@@ -176,6 +176,7 @@ namespace Js
         uint32 allocSize = UInt32Math::Add(outputLen, 1);
         char16* outURI = RecyclerNewArrayLeaf(scriptContext->GetRecycler(), char16, allocSize);
         char16* outCurrent = outURI;
+        const char16 *hexStream = _u("0123456789ABCDEF");
 
         for( uint32 k = 0; k < len; k++ )
         {
@@ -223,8 +224,10 @@ namespace Js
                 for( uint32 j = 0; j < utfLen; j++ )
                 {
 #pragma prefast(suppress: 26014, "buffer length was calculated earlier");
-                    swprintf_s(outCurrent, 4, _u("%%%02X"), (int)bUTF8[j] );
-                    outCurrent +=3;
+                    BYTE val = bUTF8[j];
+                    *outCurrent++ = _u('%');
+                    *outCurrent++ = hexStream[(val >> 4)];
+                    *outCurrent++ = hexStream[(val & 0xF)];
 #pragma prefast(default: 26014);
                 }
             }


### PR DESCRIPTION
There are lots of busy-hang bugs reported for encodeURIComponent api. When I dig deeper I found that
many a times we get input larger than a meg. I created a repro test case for this. We spent most of
the time in swprintf. I made easy change to the code and got rid of that.
In the repro benchmark
Before change :
  we spent ~3500 ms.
After change :
  it becomes 450 ms.

There were opportunities to clean the code further, but I don't see a point of changing the code any more than this.
