### PR TITLE
update dump fragmentation stats

### DIFF
--- a/lib/Common/Memory/HeapBlock.h
+++ b/lib/Common/Memory/HeapBlock.h
@@ -43,24 +43,29 @@ struct MemStats
     size_t objectByteCount;
     size_t totalByteCount;
 
-    MemStats() : objectByteCount(0), totalByteCount(0) {}
+    MemStats();
 
-    void Aggregate(const MemStats& other)
-    {
-        objectByteCount += other.objectByteCount;
-        totalByteCount += other.totalByteCount;
-    }
+    void Reset();
+    size_t FreeBytes() const;
+    double UsedRatio() const;
+    void Aggregate(const MemStats& other);
 };
 
 struct HeapBucketStats: MemStats
 {
 #ifdef DUMP_FRAGMENTATION_STATS
     uint totalBlockCount;
-    uint emptyBlockCount;
-    uint finalizeBlockCount;
     uint objectCount;
     uint finalizeCount;
+
+    HeapBucketStats();
+    void Reset();
+    void Dump() const;
 #endif
+
+    void PreAggregate();
+    void BeginAggregate();
+    void Aggregate(const HeapBucketStats& other);
 };
 
 #ifdef DUMP_FRAGMENTATION_STATS
@@ -68,7 +73,7 @@ struct HeapBucketStats: MemStats
 #else
 #define DUMP_FRAGMENTATION_STATS_ONLY(x)
 #endif
-#endif
+#endif  // ENABLE_MEM_STATS
 
 #if defined(PROFILE_RECYCLER_ALLOC) || defined(RECYCLER_MEMORY_VERIFY) || defined(MEMSPECT_TRACKING) || defined(RECYCLER_PERF_COUNTERS) || defined(ETW_MEMORY_TRACKING)
 #define RECYCLER_TRACK_NATIVE_ALLOCATED_OBJECTS

--- a/lib/Common/Memory/HeapBucket.cpp
+++ b/lib/Common/Memory/HeapBucket.cpp
@@ -1431,8 +1431,10 @@ HeapBucketT<TBlockType>::Check(bool checkCount)
 #if ENABLE_MEM_STATS
 template <typename TBlockType>
 void
-HeapBucketT<TBlockType>::AggregateBucketStats(HeapBucketStats& stats)
+HeapBucketT<TBlockType>::AggregateBucketStats()
 {
+    HeapBucket::AggregateBucketStats();  // call super
+
     auto allocatorHead = &this->allocatorHead;
     auto allocatorCurr = allocatorHead;
 
@@ -1441,16 +1443,15 @@ HeapBucketT<TBlockType>::AggregateBucketStats(HeapBucketStats& stats)
         TBlockType* allocatorHeapBlock = allocatorCurr->GetHeapBlock();
         if (allocatorHeapBlock)
         {
-            allocatorHeapBlock->AggregateBlockStats(stats, true, allocatorCurr->freeObjectList, allocatorCurr->endAddress != 0);
+            allocatorHeapBlock->AggregateBlockStats(this->memStats, true, allocatorCurr->freeObjectList, allocatorCurr->endAddress != 0);
         }
         allocatorCurr = allocatorCurr->GetNext();
     } while (allocatorCurr != allocatorHead);
 
-    auto blockStatsAggregator = [&stats](TBlockType* heapBlock) {
-        heapBlock->AggregateBlockStats(stats);
+    auto blockStatsAggregator = [this](TBlockType* heapBlock) {
+        heapBlock->AggregateBlockStats(this->memStats);
     };
 
-    HeapBlockList::ForEach(emptyBlockList, blockStatsAggregator);
     HeapBlockList::ForEach(fullBlockList, blockStatsAggregator);
 #if ENABLE_CONCURRENT_GC && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP && SUPPORT_WIN32_SLIST && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP_USE_SLIST
     if (CONFIG_FLAG_RELEASE(EnableConcurrentSweepAlloc))

--- a/lib/Common/Memory/LargeHeapBlock.cpp
+++ b/lib/Common/Memory/LargeHeapBlock.cpp
@@ -1950,6 +1950,30 @@ LargeHeapBlock::EnumerateObjects(ObjectInfoBits infoBits, void (*CallBackFunctio
     }
 }
 
+#if ENABLE_MEM_STATS
+void
+LargeHeapBlock::AggregateBlockStats(HeapBucketStats& stats)
+{
+    DUMP_FRAGMENTATION_STATS_ONLY(uint objectCount = 0);
+    size_t objectSize = 0;
+    for (uint i = 0; i < allocCount; i++)
+    {
+        LargeObjectHeader * header = this->GetHeaderByIndex(i);
+        if (header)
+        {
+            DUMP_FRAGMENTATION_STATS_ONLY(objectCount++);
+            objectSize += header->objectSize;
+        }
+    }
+
+    DUMP_FRAGMENTATION_STATS_ONLY(stats.totalBlockCount++);
+    DUMP_FRAGMENTATION_STATS_ONLY(stats.objectCount += objectCount);
+    DUMP_FRAGMENTATION_STATS_ONLY(stats.finalizeCount += this->finalizeCount);
+
+    stats.objectByteCount += objectSize;
+    stats.totalByteCount += AutoSystemInfo::PageSize * pageCount;
+}
+#endif  // ENABLE_MEM_STATS
 
 uint
 LargeHeapBlock::GetMaxLargeObjectCount(size_t pageCount, size_t firstAllocationSize)

--- a/lib/Common/Memory/LargeHeapBlock.h
+++ b/lib/Common/Memory/LargeHeapBlock.h
@@ -186,6 +186,10 @@ public:
 
     void EnumerateObjects(ObjectInfoBits infoBits, void (*CallBackFunction)(void * address, size_t size));
 
+#if ENABLE_MEM_STATS
+    void AggregateBlockStats(HeapBucketStats& stats);
+#endif
+
 #ifdef RECYCLER_SLOW_CHECK_ENABLED
     void Check(bool expectFull, bool expectPending);
 #endif

--- a/lib/Common/Memory/LargeHeapBucket.cpp
+++ b/lib/Common/Memory/LargeHeapBucket.cpp
@@ -1123,3 +1123,24 @@ LargeHeapBucket::VerifyMark()
 }
 #endif
 
+#if ENABLE_MEM_STATS
+void
+LargeHeapBucket::AggregateBucketStats()
+{
+    HeapBucket::AggregateBucketStats();  // call super
+
+    auto blockStatsAggregator = [this](LargeHeapBlock* largeHeapBlock) {
+        largeHeapBlock->AggregateBlockStats(this->memStats);
+    };
+
+    HeapBlockList::ForEach(largeBlockList, blockStatsAggregator);
+    HeapBlockList::ForEach(fullLargeBlockList, blockStatsAggregator);
+    HeapBlockList::ForEach(pendingDisposeLargeBlockList, blockStatsAggregator);
+#if ENABLE_CONCURRENT_GC
+    HeapBlockList::ForEach(pendingSweepLargeBlockList, blockStatsAggregator);
+#if ENABLE_PARTIAL_GC
+    HeapBlockList::ForEach(partialSweptLargeBlockList, blockStatsAggregator);
+#endif
+#endif
+}
+#endif

--- a/lib/Common/Memory/LargeHeapBucket.h
+++ b/lib/Common/Memory/LargeHeapBucket.h
@@ -94,6 +94,10 @@ public:
 #endif
 #endif
 
+#if ENABLE_MEM_STATS
+    void AggregateBucketStats();
+#endif
+
 private:
     char * SnailAlloc(Recycler * recycler, DECLSPEC_GUARD_OVERFLOW size_t sizeCat, size_t size, ObjectInfoBits attributes, bool nothrow);
     char * TryAlloc(Recycler * recycler, DECLSPEC_GUARD_OVERFLOW size_t sizeCat, ObjectInfoBits attributes);

--- a/lib/Common/Memory/SmallFinalizableHeapBucket.cpp
+++ b/lib/Common/Memory/SmallFinalizableHeapBucket.cpp
@@ -83,12 +83,12 @@ SmallFinalizableHeapBucketBaseT<TBlockType>::ResetMarks(ResetMarkFlags flags)
 #if ENABLE_MEM_STATS
 template <class TBlockType>
 void
-SmallFinalizableHeapBucketBaseT<TBlockType>::AggregateBucketStats(HeapBucketStats& stats)
+SmallFinalizableHeapBucketBaseT<TBlockType>::AggregateBucketStats()
 {
-    __super::AggregateBucketStats(stats);
+    __super::AggregateBucketStats();
 
-    HeapBlockList::ForEach(pendingDisposeList, [&stats](TBlockType* heapBlock) {
-        heapBlock->AggregateBlockStats(stats);
+    HeapBlockList::ForEach(pendingDisposeList, [this](TBlockType* heapBlock) {
+        heapBlock->AggregateBlockStats(this->memStats);
     });
 }
 #endif

--- a/lib/Common/Memory/SmallFinalizableHeapBucket.h
+++ b/lib/Common/Memory/SmallFinalizableHeapBucket.h
@@ -20,7 +20,7 @@ public:
     static void FinalizeHeapBlockList(THeapBlockType * list);
 
 #if ENABLE_MEM_STATS
-    void AggregateBucketStats(HeapBucketStats& stats);
+    void AggregateBucketStats();
 #endif
 protected:
     void EnumerateObjects(ObjectInfoBits infoBits, void (*CallBackFunction)(void * address, size_t size));

--- a/lib/Common/Memory/SmallNormalHeapBucket.cpp
+++ b/lib/Common/Memory/SmallNormalHeapBucket.cpp
@@ -19,15 +19,15 @@ SmallNormalHeapBucketBase<TBlockType>::SmallNormalHeapBucketBase()
 #if ENABLE_MEM_STATS
 template <typename TBlockType>
 void
-SmallNormalHeapBucketBase<TBlockType>::AggregateBucketStats(HeapBucketStats& stats)
+SmallNormalHeapBucketBase<TBlockType>::AggregateBucketStats()
 {
-    __super::AggregateBucketStats(stats);
+    __super::AggregateBucketStats();
 
-    HeapBlockList::ForEach(partialHeapBlockList, [&stats](TBlockType* heapBlock) {
-        heapBlock->AggregateBlockStats(stats);
+    HeapBlockList::ForEach(partialHeapBlockList, [this](TBlockType* heapBlock) {
+        heapBlock->AggregateBlockStats(this->memStats);
     });
-    HeapBlockList::ForEach(partialSweptHeapBlockList, [&stats](TBlockType* heapBlock) {
-        heapBlock->AggregateBlockStats(stats);
+    HeapBlockList::ForEach(partialSweptHeapBlockList, [this](TBlockType* heapBlock) {
+        heapBlock->AggregateBlockStats(this->memStats);
     });
 }
 #endif

--- a/lib/Common/Memory/SmallNormalHeapBucket.h
+++ b/lib/Common/Memory/SmallNormalHeapBucket.h
@@ -21,7 +21,7 @@ public:
 #endif
 
 #if ENABLE_MEM_STATS
-    void AggregateBucketStats(HeapBucketStats& stats);
+    void AggregateBucketStats();
 #endif
 protected:
     template <class TBlockAttributes>


### PR DESCRIPTION
Brings -DumpFragmentationStats results up-to-date with JD.

- Corrected heapBlock->isInAllocator handling during stats aggregation.
  Only aggregate isInAllocator blocks when processing allocatorHead list.
  The same blocks could appear in other lists but won't be counted again.

- To help combine stats from heapInfo new blocks and in bucket blocks,
  added `memStats` field to each bucket. Accumulate heapInfo new blocks
  stats in a special pre-aggregate pass. Keep the data and combine with
  in bucket blocks.

- Added LargeBlock stats aggregation.
