### PR TITLE
ARM64: LDIMM tagged int with 32 bit dest

### DIFF
--- a/lib/Backend/Opnd.h
+++ b/lib/Backend/Opnd.h
@@ -228,6 +228,7 @@ public:
     bool                IsInt64() const { return IRType_IsInt64(this->m_type); }
     bool                IsInt32() const { return this->m_type == TyInt32; }
     bool                IsUInt32() const { return this->m_type == TyUint32; }
+    bool                IsIntegral32() const { return IsInt32() || IsUInt32(); }
     bool                IsFloat32() const { return this->m_type == TyFloat32; }
     bool                IsFloat64() const { return this->m_type == TyFloat64; }
     bool                IsFloat() const { return this->IsFloat32() || this->IsFloat64(); }

--- a/lib/Backend/arm64/LegalizeMD.cpp
+++ b/lib/Backend/arm64/LegalizeMD.cpp
@@ -514,6 +514,14 @@ void LegalizeMD::LegalizeLDIMM(IR::Instr * instr, IntConstType immed)
     // In case of inlined entry instruction, we don't know the offset till the encoding phase
     if (!instr->isInlineeEntryInstr)
     {
+
+        // If the source is a tagged int, and the dest is int32 or uint32, untag the value so that it fits in 32 bits.
+        if (instr->GetDst()->IsIntegral32() && instr->GetSrc1()->IsTaggedInt())
+        {
+            immed = (uint32)immed;
+            instr->ReplaceSrc1(IR::IntConstOpnd::New(immed, instr->GetDst()->GetType(), instr->m_func));
+        }
+
         // Short-circuit simple 16-bit immediates
         if ((immed & 0xffff) == immed || (immed & 0xffff0000) == immed || (immed & 0xffff00000000ll) == immed || (immed & 0xffff000000000000ll) == immed)
         {

--- a/lib/Backend/arm64/LowerMD.cpp
+++ b/lib/Backend/arm64/LowerMD.cpp
@@ -5762,7 +5762,7 @@ LowererMD::GenerateFastRecyclerAlloc(size_t allocSize, IR::RegOpnd* newObjDst, I
 void
 LowererMD::GenerateClz(IR::Instr * instr)
 {
-    Assert(instr->GetSrc1()->IsInt32() || instr->GetSrc1()->IsUInt32());
+    Assert(instr->GetSrc1()->IsIntegral32());
     Assert(IRType_IsNativeInt(instr->GetDst()->GetType()));
     instr->m_opcode = Js::OpCode::CLZ;
     LegalizeMD::LegalizeInstr(instr, false);
@@ -7772,7 +7772,7 @@ LowererMD::EmitUIntToFloat(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsert)
     IR::Instr *instr;
 
     Assert(dst->IsRegOpnd() && dst->IsFloat64());
-    Assert(src->IsRegOpnd() && src->IsUInt32());
+    Assert(src->IsRegOpnd() && src->IsIntegral32());
 
     // Convert to Float
     instr = IR::Instr::New(Js::OpCode::FCVT, dst, src, this->m_func);


### PR DESCRIPTION
When a tagged int immediate into a 32 bit dst, an instruction will be emitted to move the 16 bits containing the tag and would hit an assert because that does not fall within the 32 bits of the dst.
