### PR TITLE
ARM64: fix assert

### DIFF
--- a/lib/Backend/arm64/LegalizeMD.cpp
+++ b/lib/Backend/arm64/LegalizeMD.cpp
@@ -518,7 +518,7 @@ void LegalizeMD::LegalizeLDIMM(IR::Instr * instr, IntConstType immed)
         // If the source is a tagged int, and the dest is int32 or uint32, untag the value so that it fits in 32 bits.
         if (instr->GetDst()->IsIntegral32() && instr->GetSrc1()->IsTaggedInt())
         {
-            immed = (uint32)immed;
+            immed = (int32)immed;
             instr->ReplaceSrc1(IR::IntConstOpnd::New(immed, instr->GetDst()->GetType(), instr->m_func));
         }
 
@@ -563,10 +563,8 @@ void LegalizeMD::LegalizeLDIMM(IR::Instr * instr, IntConstType immed)
         }
 
         // Short-circuit 64-bit logical constants
-        if (EncoderMD::CanEncodeLogicalConst(immed, 8))
+        if (instr->GetDst()->GetSize() == 8 && EncoderMD::CanEncodeLogicalConst(immed, 8))
         {
-            Assert(instr->GetDst()->GetSize() == 8 || immed == (uint32)immed);
-            instr->GetDst()->SetType(TyInt64);
             instr->SetSrc2(instr->GetSrc1());
             instr->ReplaceSrc1(IR::RegOpnd::New(NULL, RegZR, TyInt64, instr->m_func));
             instr->m_opcode = Js::OpCode::ORR;


### PR DESCRIPTION
immed is int64, and checking against cropped uint32 misses negative signed values.
