### PR TITLE
ARM64: TryFoldConst

### DIFF
--- a/lib/Backend/arm64/EncoderMD.cpp
+++ b/lib/Backend/arm64/EncoderMD.cpp
@@ -1472,7 +1472,13 @@ bool EncoderMD::TryConstFold(IR::Instr *instr, IR::RegOpnd *regOpnd)
             return false;
         }
 
-        instr->ReplaceSrc(regOpnd, regOpnd->m_sym->GetConstOpnd());
+        IR::Opnd* constOpnd = regOpnd->m_sym->GetConstOpnd();
+        if (constOpnd->GetSize() > regOpnd->GetSize())
+        {
+            return false;
+        }
+
+        instr->ReplaceSrc(regOpnd, constOpnd);
         LegalizeMD::LegalizeInstr(instr, false);
 
         return true;


### PR DESCRIPTION
don't replace a reg opnds with const opnds that won't fit within the same size register
