### PR TITLE
Improve Add_Full.. and type checking

### DIFF
--- a/lib/Runtime/Language/JavascriptOperators.inl
+++ b/lib/Runtime/Language/JavascriptOperators.inl
@@ -10,17 +10,7 @@ namespace Js
     {
         AssertMsg(aValue != nullptr, "GetTypeId aValue is null");
 
-        if (TaggedInt::Is(aValue))
-        {
-            return TypeIds_Integer;
-        }
-#if FLOATVAR
-        else if (JavascriptNumber::Is_NoTaggedIntCheck(aValue))
-        {
-            return TypeIds_Number;
-        }
-#endif
-        else
+        if (RecyclableObject::Is(aValue))
         {
             auto typeId = RecyclableObject::FromVar(aValue)->GetTypeId();
 #if DBG
@@ -29,27 +19,48 @@ namespace Js
 #endif
             return typeId;
         }
+#if FLOATVAR
+        else if (TaggedInt::Is(aValue))
+        {
+            return TypeIds_Integer;
+        }
+        else
+        {
+            Assert(JavascriptNumber::Is_NoTaggedIntCheck(aValue));
+            return TypeIds_Number;
+        }
+#else
+        else
+        {
+            return TypeIds_Integer;
+        }
+#endif
     }
 
     __forceinline TypeId JavascriptOperators::GetTypeIdNoCheck(const Var aValue)
     {
         AssertMsg(aValue != nullptr, "GetTypeId aValue is null");
 
-        if (TaggedInt::Is(aValue))
+        if (RecyclableObject::Is(aValue))
+        {
+            return RecyclableObject::FromVar(aValue)->GetTypeId();
+        }
+#if FLOATVAR
+        else if (TaggedInt::Is(aValue))
         {
             return TypeIds_Integer;
         }
-#if FLOATVAR
-        else if (JavascriptNumber::Is_NoTaggedIntCheck(aValue))
-        {
-            return TypeIds_Number;
-        }
-#endif
         else
         {
-            auto typeId = RecyclableObject::FromVar(aValue)->GetTypeId();
-            return typeId;
+            Assert(JavascriptNumber::Is_NoTaggedIntCheck(aValue));
+            return TypeIds_Number;
         }
+#else
+        else
+        {
+            return TypeIds_Integer;
+        }
+#endif
     }
 
     // A helper function which will do the IteratorStep and fetch value - however in the event of an exception it will perform the IteratorClose as well.

--- a/lib/Runtime/Math/JavascriptMath.cpp
+++ b/lib/Runtime/Math/JavascriptMath.cpp
@@ -186,15 +186,18 @@ namespace Js
                     return JavascriptString::Concat(JavascriptString::FromVar(aLeft), JavascriptString::FromVar(aRight));
                 }
             }
-            else if(typeLeft == TypeIds_Number && typeRight == TypeIds_Integer)
+            else if (typeLeft <= TypeIds_LastNumberType)
             {
-                double sum = JavascriptNumber::GetValue(aLeft) + TaggedInt::ToDouble(aRight);
-                return JavascriptNumber::ToVarNoCheck(sum, scriptContext);
-            }
-            else if(typeLeft == TypeIds_Integer && typeRight == TypeIds_Number)
-            {
-                double sum = TaggedInt::ToDouble(aLeft) + JavascriptNumber::GetValue(aRight);
-                return JavascriptNumber::ToVarNoCheck(sum, scriptContext);
+                if (typeRight == TypeIds_Integer && typeLeft == TypeIds_Number)
+                {
+                    double sum = JavascriptNumber::GetValue(aLeft) + TaggedInt::ToDouble(aRight);
+                    return JavascriptNumber::ToVarNoCheck(sum, scriptContext);
+                }
+                else if (typeRight == TypeIds_Number && typeLeft == TypeIds_Integer)
+                {
+                    double sum = TaggedInt::ToDouble(aLeft) + JavascriptNumber::GetValue(aRight);
+                    return JavascriptNumber::ToVarNoCheck(sum, scriptContext);
+                }
             }
 
             return Add_FullHelper_Wrapper(aLeft, aRight, scriptContext, nullptr, false);


### PR DESCRIPTION
Changes in `JavascriptMath::Add_Full` caused a regression (see micro benchmark that simplifies the case below) due to `JavascriptOperators::GetTypeId` is rather slow for everything else but integers.

I could improvise the type checking under Add_Full by manually tricking my way to finding the type ... yet, came up with updating how `GetTypeId` works. Tested with known micro benchmarks and didn't see any regression because of this change.

Benchmark (compare this PR to `52dfe7bc146b70b326ed6e9f521bffa9f902bb2b`)
```
function RunTest()
{

    var e;
    var q;

    for (var i = 0; i < 250; i++)
    {
        for (var j = 0; j < 3; j++)
        {
            e = "" + (j % 2 ? "black" : "green");
            q = i  + (j % 3 ? 5 : 7); // test me also this line is commented out
        }
    }
    return e.length + q;
}

var start = new Date();

for (var i = 0; i < 1e5; i++) RunTest();

var end = new Date();

print(end-start);
```

Fixes OS14363378 ; benchmark and discovery credits goes to @LouisLaf 