### PR TITLE
Enable the allocations during concurrent sweep - Part2.

### DIFF
--- a/lib/Common/CommonDefines.h
+++ b/lib/Common/CommonDefines.h
@@ -171,26 +171,27 @@
 #endif
 
 
+#ifndef ENABLE_VALGRIND
+#define ENABLE_CONCURRENT_GC 1
+#ifdef _WIN32
+#define ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP 1 // Needs ENABLE_CONCURRENT_GC to be enabled for this to be enabled.
+#else
+#define ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP 0 // Needs ENABLE_CONCURRENT_GC to be enabled for this to be enabled.
+#endif
+#else
+#define ENABLE_CONCURRENT_GC 0
+#define ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP 0 // Needs ENABLE_CONCURRENT_GC to be enabled for this to be enabled.
+#endif
+
 #ifdef _WIN32
 #define SYSINFO_IMAGE_BASE_AVAILABLE 1
-#define ENABLE_CONCURRENT_GC 1
-#define ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP 1 // Only takes effect when ENABLE_CONCURRENT_GC is enabled.
-#define ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP_USE_SLIST 1 // Use Interlocked SLIST for allocableHeapBlockList
 #define SUPPORT_WIN32_SLIST 1
 #ifndef CHAKRACORE_LITE
 #define ENABLE_JS_ETW                               // ETW support
 #endif
 #else
 #define SYSINFO_IMAGE_BASE_AVAILABLE 0
-#ifndef ENABLE_VALGRIND
-#define ENABLE_CONCURRENT_GC 1
-#define ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP 1 // Only takes effect when ENABLE_CONCURRENT_GC is enabled.
-#else
-#define ENABLE_CONCURRENT_GC 0
-#define ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP 0 // Only takes effect when ENABLE_CONCURRENT_GC is enabled.
-#endif
 #define SUPPORT_WIN32_SLIST 0
-#define ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP_USE_SLIST 0 // Use Interlocked SLIST for allocableHeapBlockList
 #endif
 
 #ifdef CHAKRACORE_LITE

--- a/lib/Common/Memory/CollectionState.h
+++ b/lib/Common/Memory/CollectionState.h
@@ -69,9 +69,9 @@ enum CollectionState
 
     CollectionStateSetupConcurrentSweep   = Collection_Sweep | Collection_ConcurrentSweepSetup,               // setting up concurrent sweep
     CollectionStateConcurrentSweep        = Collection_ConcurrentSweep | Collection_ExecutingConcurrent,      // concurrent sweep
-#if  ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
+#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
     CollectionStateConcurrentSweepPass1 = Collection_ConcurrentSweep | Collection_ConcurrentSweepPass1 | Collection_ExecutingConcurrent,          // concurrent sweep Pass 1
-    CollectionStateConcurrentSweepPass1Wait = Collection_ConcurrentSweep | Collection_ConcurrentSweepPass1Wait | Collection_ExecutingConcurrent,  // concurrent sweep wait state after Pass 1 has finished
+    CollectionStateConcurrentSweepPass1Wait = Collection_ConcurrentSweep | Collection_ConcurrentSweepPass1Wait /*| Collection_ExecutingConcurrent*/,  // concurrent sweep wait state after Pass 1 has finished
     CollectionStateConcurrentSweepPass2 = Collection_ConcurrentSweep | Collection_ConcurrentSweepPass2 | Collection_ExecutingConcurrent,          // concurrent sweep Pass 2
     CollectionStateConcurrentSweepPass2Wait = Collection_ConcurrentSweep | Collection_ConcurrentSweepPass2Wait | Collection_ExecutingConcurrent,  // concurrent sweep wait state after Pass 2 has finished
 #endif

--- a/lib/Common/Memory/CollectionState.h
+++ b/lib/Common/Memory/CollectionState.h
@@ -39,6 +39,12 @@ enum CollectionState
     Collection_PostSweepRedeferralCallback = 0x00040000,
     Collection_WrapperCallback             = 0x00080000,
 
+#if ENABLE_CONCURRENT_GC && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
+    Collection_ConcurrentSweepPass1 = 0x00100000,
+    Collection_ConcurrentSweepPass1Wait = 0x00200000,
+    Collection_ConcurrentSweepPass2 = 0x00400000,
+    Collection_ConcurrentSweepPass2Wait = 0x00800000,
+#endif
 
     // Actual states
     CollectionStateNotCollecting          = 0,                                                                // not collecting
@@ -63,6 +69,12 @@ enum CollectionState
 
     CollectionStateSetupConcurrentSweep   = Collection_Sweep | Collection_ConcurrentSweepSetup,               // setting up concurrent sweep
     CollectionStateConcurrentSweep        = Collection_ConcurrentSweep | Collection_ExecutingConcurrent,      // concurrent sweep
+#if  ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
+    CollectionStateConcurrentSweepPass1 = Collection_ConcurrentSweep | Collection_ConcurrentSweepPass1 | Collection_ExecutingConcurrent,          // concurrent sweep Pass 1
+    CollectionStateConcurrentSweepPass1Wait = Collection_ConcurrentSweep | Collection_ConcurrentSweepPass1Wait | Collection_ExecutingConcurrent,  // concurrent sweep wait state after Pass 1 has finished
+    CollectionStateConcurrentSweepPass2 = Collection_ConcurrentSweep | Collection_ConcurrentSweepPass2 | Collection_ExecutingConcurrent,          // concurrent sweep Pass 2
+    CollectionStateConcurrentSweepPass2Wait = Collection_ConcurrentSweep | Collection_ConcurrentSweepPass2Wait | Collection_ExecutingConcurrent,  // concurrent sweep wait state after Pass 2 has finished
+#endif
     CollectionStateTransferSweptWait      = Collection_ConcurrentSweep | Collection_FinishConcurrent,         // transfer swept objects (after concurrent sweep)
 #endif
     CollectionStateParallelMark           = Collection_Mark | Collection_Parallel,

--- a/lib/Common/Memory/CollectionState.h
+++ b/lib/Common/Memory/CollectionState.h
@@ -39,9 +39,15 @@ enum CollectionState
     Collection_PostSweepRedeferralCallback = 0x00040000,
     Collection_WrapperCallback             = 0x00080000,
 
-#if ENABLE_CONCURRENT_GC && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
+#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
+    // Please look at the documentation for PrepareForAllocationsDuringConcurrentSweep method for details on how the concurrent
+    // sweep progresses when allocations are allowed during sweep.
+    /* In Pass1 of the concurrent sweep we determine if a block is full or empty or needs to be swept. Leaf blocks will get
+    swept immediately where as non-leaf blocks may get put onto the pendingSweepList. */
     Collection_ConcurrentSweepPass1 = 0x00100000,
     Collection_ConcurrentSweepPass1Wait = 0x00200000,
+    /* In Pass2, all blocks will go through SweepPartialReusePages to determine if the page can be reused. Also, any blocks
+    that were put in the pendingSweepList will be swept during this stage. */
     Collection_ConcurrentSweepPass2 = 0x00400000,
     Collection_ConcurrentSweepPass2Wait = 0x00800000,
 #endif
@@ -71,9 +77,9 @@ enum CollectionState
     CollectionStateConcurrentSweep        = Collection_ConcurrentSweep | Collection_ExecutingConcurrent,      // concurrent sweep
 #if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
     CollectionStateConcurrentSweepPass1 = Collection_ConcurrentSweep | Collection_ConcurrentSweepPass1 | Collection_ExecutingConcurrent,          // concurrent sweep Pass 1
-    CollectionStateConcurrentSweepPass1Wait = Collection_ConcurrentSweep | Collection_ConcurrentSweepPass1Wait /*| Collection_ExecutingConcurrent*/,  // concurrent sweep wait state after Pass 1 has finished
+    CollectionStateConcurrentSweepPass1Wait = Collection_ConcurrentSweep | Collection_ConcurrentSweepPass1Wait,                                   // concurrent sweep wait state after Pass 1 has finished
     CollectionStateConcurrentSweepPass2 = Collection_ConcurrentSweep | Collection_ConcurrentSweepPass2 | Collection_ExecutingConcurrent,          // concurrent sweep Pass 2
-    CollectionStateConcurrentSweepPass2Wait = Collection_ConcurrentSweep | Collection_ConcurrentSweepPass2Wait | Collection_ExecutingConcurrent,  // concurrent sweep wait state after Pass 2 has finished
+    CollectionStateConcurrentSweepPass2Wait = Collection_ConcurrentSweep | Collection_ConcurrentSweepPass2Wait,                                   // concurrent sweep wait state after Pass 2 has finished
 #endif
     CollectionStateTransferSweptWait      = Collection_ConcurrentSweep | Collection_FinishConcurrent,         // transfer swept objects (after concurrent sweep)
 #endif

--- a/lib/Common/Memory/HeapBlock.cpp
+++ b/lib/Common/Memory/HeapBlock.cpp
@@ -1388,7 +1388,6 @@ SmallHeapBlockT<TBlockAttributes>::Sweep(RecyclerSweep& recyclerSweep, bool queu
         // This heap block is ready to be swept concurrently.
 #if DBG || defined(RECYCLER_SLOW_CHECK_ENABLED)
         this->hasFinishedSweepObjects = false;
-        this->wasAllocatedFromDuringSweep = this->isPendingConcurrentSweepPrep;
 #endif
         this->isPendingConcurrentSweepPrep = false;
     }
@@ -1436,7 +1435,7 @@ SmallHeapBlockT<TBlockAttributes>::Sweep(RecyclerSweep& recyclerSweep, bool queu
 
         // nothing has been freed
 #ifdef RECYCLER_TRACE
-        if (recycler->GetRecyclerFlagsTable().Trace.IsEnabled(Js::ConcurrentSweepPhase))
+        if (recycler->GetRecyclerFlagsTable().Trace.IsEnabled(Js::ConcurrentSweepPhase) && CONFIG_FLAG_RELEASE(Verbose))
         {
             SweepState stateReturned = (this->freeCount == 0) ? SweepStateFull : state;
             Output::Print(_u("[GC #%d] [HeapBucket 0x%p] HeapBlock 0x%p %s %d [CollectionState: %d] \n"), recycler->collectionCount, this->heapBucket, this, _u("[**37**] heapBlock swept. State returned:"), stateReturned, recycler->collectionState);
@@ -1501,7 +1500,7 @@ SmallHeapBlockT<TBlockAttributes>::Sweep(RecyclerSweep& recyclerSweep, bool queu
     if (CONFIG_FLAG_RELEASE(EnableConcurrentSweepAlloc) && !this->IsAnyFinalizableBlock())
     {
 #ifdef RECYCLER_TRACE
-        if (recycler->GetRecyclerFlagsTable().Trace.IsEnabled(Js::ConcurrentSweepPhase))
+        if (recycler->GetRecyclerFlagsTable().Trace.IsEnabled(Js::ConcurrentSweepPhase) && CONFIG_FLAG_RELEASE(Verbose))
         {
             SweepState stateReturned = (this->freeCount == 0) ? SweepStateFull : state;
             Output::Print(_u("[GC #%d] [HeapBucket 0x%p] HeapBlock 0x%p %s %d [CollectionState: %d] \n"), recycler->collectionCount, this->heapBucket, this, _u("[**38**] heapBlock swept. State returned:"), stateReturned, recycler->collectionState);

--- a/lib/Common/Memory/HeapBlock.cpp
+++ b/lib/Common/Memory/HeapBlock.cpp
@@ -1323,15 +1323,13 @@ SmallHeapBlockT<TBlockAttributes>::Sweep(RecyclerSweep& recyclerSweep, bool queu
         // This block has been allocated from since the last GC.
         // We need to update its free bit vector so we can use it below.
         DebugOnly(ushort currentFreeCount = (ushort)this->GetFreeBitVector()->Count());
-#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
-        Assert(freeCount - this->objectsAllocatedDuringConcurrentSweepCount == currentFreeCount);
-#else
         Assert(freeCount == currentFreeCount);
-#endif
 #if ENABLE_PARTIAL_GC
         Assert(this->lastFreeCount == 0 || this->oldFreeCount == this->lastFreeCount);
 #endif
+
         this->EnsureFreeBitVector();
+
         Assert(this->lastFreeCount >= this->freeCount);
 #if ENABLE_PARTIAL_GC
         Assert(this->oldFreeCount >= this->freeCount);
@@ -1377,7 +1375,7 @@ SmallHeapBlockT<TBlockAttributes>::Sweep(RecyclerSweep& recyclerSweep, bool queu
         // This heap block is ready to be swept concurrently.
 #if DBG || defined(RECYCLER_SLOW_CHECK_ENABLED)
         this->hasFinishedSweepObjects = false;
-        this->wasAllocatedFromDuringSweep = isPendingConcurrentSweepPrep;
+        this->wasAllocatedFromDuringSweep = this->isPendingConcurrentSweepPrep;
 #endif
         this->isPendingConcurrentSweepPrep = false;
     }
@@ -1700,13 +1698,13 @@ SmallHeapBlockT<TBlockAttributes>::SweepObjects(Recycler * recycler, bool onlyRe
         Assert(!this->IsAnyFinalizableBlock());
 
         // Adjust the mark and free bits to account for the objects we have allocated during the ongoing concurrent sweep.
-        this->markCount = (ushort)this->GetMarkCountForSweep();
-        this->EnsureFreeBitVector(true /*isCollecting*/);
-#if ENABLE_PARTIAL_GC
-        this->oldFreeCount = this->lastFreeCount = this->freeCount;
-#else
-        this->lastFreeCount = this->freeCount;
-#endif
+//        this->markCount = (ushort)this->GetMarkCountForSweep();
+//        this->EnsureFreeBitVector(true /*isCollecting*/);
+//#if ENABLE_PARTIAL_GC
+//        this->oldFreeCount = this->lastFreeCount = this->freeCount;
+//#else
+//        this->lastFreeCount = this->freeCount;
+//#endif
 
         // Reset the count of objects allocated during this concurrent sweep; so we will start afresh the next time around.
         Assert(this->objectsAllocatedDuringConcurrentSweepCount == this->objectsMarkedDuringSweep);

--- a/lib/Common/Memory/HeapBlock.h
+++ b/lib/Common/Memory/HeapBlock.h
@@ -413,13 +413,11 @@ public:
         return (heapBlockType);
     }
 
-#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
-#if DBG || defined(RECYCLER_SLOW_CHECK_ENABLED)
+#if (DBG || defined(RECYCLER_SLOW_CHECK_ENABLED)) && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
     bool WasAllocatedFromDuringSweep()
     {
         return this->wasAllocatedFromDuringSweep;
     }
-#endif
 #endif
 
     IdleDecommitPageAllocator* GetPageAllocator(Recycler* recycler);
@@ -472,7 +470,7 @@ public:
 #endif
 };
 
-#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP && SUPPORT_WIN32_SLIST && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP_USE_SLIST
+#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP && SUPPORT_WIN32_SLIST
 template <typename TBlockType>
 struct HeapBlockSListItem {
     // SLIST_ENTRY needs to be the first element in the structure to avoid calculating offset with the SList API calls.

--- a/lib/Common/Memory/HeapBlock.h
+++ b/lib/Common/Memory/HeapBlock.h
@@ -380,6 +380,11 @@ protected:
     bool needOOMRescan;                             // Set if we OOMed while marking a particular object
 #if ENABLE_CONCURRENT_GC
     bool isPendingConcurrentSweep;
+#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
+    // This flag is to identify whether this block was made available for allocations during the concurrent sweep and 
+    // still needs to be swept.
+    bool isPendingConcurrentSweepPrep;
+#endif
 #endif
 
 public:
@@ -941,6 +946,32 @@ public:
             tail = heapBlock;
         });
         return tail;
+    }
+
+    template <typename TBlockType>
+    static TBlockType * FindPreviousBlock(TBlockType * list, TBlockType * heapBlockToFind)
+    {
+        if (list == nullptr || heapBlockToFind == nullptr)
+        {
+            return nullptr;
+        }
+
+        TBlockType * previousBlock = nullptr;
+        TBlockType * heapBlock = list;
+        bool found = false;
+        while (heapBlock != nullptr)
+        {
+            if (heapBlock == heapBlockToFind)
+            {
+                found = true;
+                break;
+            }
+
+            previousBlock = heapBlock;
+            heapBlock = heapBlock->GetNextBlock();
+        }
+
+        return found ? previousBlock : nullptr;
     }
 
 #if DBG

--- a/lib/Common/Memory/HeapBlock.inl
+++ b/lib/Common/Memory/HeapBlock.inl
@@ -17,6 +17,17 @@ SmallHeapBlockT<TBlockAttributes>::SetAttributes(void * address, unsigned char a
     ObjectInfo(index) = attributes;
 }
 
+template <class TBlockAttributes>
+void
+SmallHeapBlockT<TBlockAttributes>::UpdateAttributes(void * address, unsigned char attributes)
+{
+    Assert(this->address != nullptr);
+    Assert(this->segment != nullptr);
+    ushort index = GetAddressIndex(address);
+    Assert(index != SmallHeapBlockT<TBlockAttributes>::InvalidAddressBit);
+    ObjectInfo(index) = attributes;
+}
+
 inline
 IdleDecommitPageAllocator*
 HeapBlock::GetPageAllocator(Recycler* recycler)

--- a/lib/Common/Memory/HeapBlock.inl
+++ b/lib/Common/Memory/HeapBlock.inl
@@ -17,17 +17,6 @@ SmallHeapBlockT<TBlockAttributes>::SetAttributes(void * address, unsigned char a
     ObjectInfo(index) = attributes;
 }
 
-template <class TBlockAttributes>
-void
-SmallHeapBlockT<TBlockAttributes>::UpdateAttributes(void * address, unsigned char attributes)
-{
-    Assert(this->address != nullptr);
-    Assert(this->segment != nullptr);
-    ushort index = GetAddressIndex(address);
-    Assert(index != SmallHeapBlockT<TBlockAttributes>::InvalidAddressBit);
-    ObjectInfo(index) = attributes;
-}
-
 inline
 IdleDecommitPageAllocator*
 HeapBlock::GetPageAllocator(Recycler* recycler)

--- a/lib/Common/Memory/HeapBlockMap.cpp
+++ b/lib/Common/Memory/HeapBlockMap.cpp
@@ -327,7 +327,12 @@ HeapBlockMap32::SetPageMarkCount(void * address, ushort markCount)
     // Callers should already have updated the mark bits by the time they call this,
     // so check that the new count is correct for the current mark bits.
     // Not true right now, will be true...
+#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
+    DebugOnly(HeapBlock * heapBlock = this->GetHeapBlock(address));
+    Assert(l2map->GetPageMarkBitVector(id2)->Count() == markCount || heapBlock->WasAllocatedFromDuringSweep());
+#else
     Assert(l2map->GetPageMarkBitVector(id2)->Count() == markCount);
+#endif
 
     l2map->pageMarkCount[id2] = markCount;
 }

--- a/lib/Common/Memory/HeapBlockMap.cpp
+++ b/lib/Common/Memory/HeapBlockMap.cpp
@@ -355,7 +355,12 @@ HeapBlockMap32::VerifyMarkCountForPages(void * address, uint pageCount)
     for (uint i = id2; i < pageCount + id2; i++)
     {
         uint markCountForPage = l2map->GetPageMarkBitVector(i)->Count();
+#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
+        DebugOnly(HeapBlock * heapBlock = this->GetHeapBlock(address));
+        Assert(markCountForPage == l2map->pageMarkCount[i] || heapBlock->WasAllocatedFromDuringSweep());
+#else
         Assert(markCountForPage == l2map->pageMarkCount[i]);
+#endif
     }
 }
 #endif

--- a/lib/Common/Memory/HeapBucket.h
+++ b/lib/Common/Memory/HeapBucket.h
@@ -75,9 +75,12 @@ public:
 protected:
     HeapInfo * heapInfo;
     uint sizeCat;
+#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
     bool allocationsStartedDuringConcurrentSweep;
+    bool concurrentSweepAllocationsThresholdExceeded;
+#endif
 
-#ifdef RECYCLER_SLOW_CHECK_ENABLED
+#if defined(RECYCLER_SLOW_CHECK_ENABLED) || ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
     size_t heapBlockCount;
     size_t newHeapBlockCount;       // count of heap bock that is in the heap info and not in the heap bucket yet
     size_t emptyHeapBlockCount;
@@ -115,7 +118,11 @@ public:
 #endif
 
     Recycler * GetRecycler() const;
+#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
     bool AllocationsStartedDuringConcurrentSweep() const;
+    bool ConcurrentSweepAllocationsThresholdExceeded() const;
+    bool DoTwoPassConcurrentSweepPreCheck();
+#endif
 
     template <typename TBlockType>
     friend class SmallHeapBlockAllocator;
@@ -209,14 +216,14 @@ protected:
 
     void Initialize(HeapInfo * heapInfo, DECLSPEC_GUARD_OVERFLOW uint sizeCat);
     void AppendAllocableHeapBlockList(TBlockType * list);
-#if ENABLE_CONCURRENT_GC && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
+#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
     void FinishSweepPrep(RecyclerSweep& recyclerSweep);
     void FinishConcurrentSweep();
 #endif
     void DeleteHeapBlockList(TBlockType * list);
     static void DeleteEmptyHeapBlockList(TBlockType * list);
     static void DeleteHeapBlockList(TBlockType * list, Recycler * recycler);
-#if ENABLE_CONCURRENT_GC && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP && SUPPORT_WIN32_SLIST && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP_USE_SLIST
+#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP && SUPPORT_WIN32_SLIST && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP_USE_SLIST
     static bool PushHeapBlockToSList(PSLIST_HEADER list, TBlockType * heapBlock);
     static TBlockType * PopHeapBlockFromSList(PSLIST_HEADER list);
     static ushort QueryDepthInterlockedSList(PSLIST_HEADER list);
@@ -295,7 +302,7 @@ protected:
     TBlockType * fullBlockList;      // list of blocks that are fully allocated
     TBlockType * heapBlockList;      // list of blocks that has free objects
 
-#if ENABLE_CONCURRENT_GC && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
+#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
 #if SUPPORT_WIN32_SLIST && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP_USE_SLIST
     PSLIST_HEADER allocableHeapBlockListHead;
     TBlockType * lastKnownNextAllocableBlockHead;

--- a/lib/Common/Memory/HeapBucket.h
+++ b/lib/Common/Memory/HeapBucket.h
@@ -208,6 +208,7 @@ protected:
     void Initialize(HeapInfo * heapInfo, DECLSPEC_GUARD_OVERFLOW uint sizeCat);
     void AppendAllocableHeapBlockList(TBlockType * list);
 #if ENABLE_CONCURRENT_GC && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
+    void FinishSweepPrep(RecyclerSweep& recyclerSweep);
     void FinishConcurrentSweep();
 #endif
     void DeleteHeapBlockList(TBlockType * list);
@@ -242,11 +243,12 @@ protected:
     void SweepBucket(RecyclerSweep& recyclerSweep, Fn sweepFn);
 
 #if ENABLE_CONCURRENT_GC  && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
+    void PrepareForAllocationsDuringConcurrentSweep(TBlockType * &currentHeapBlockList);
     void StartAllocationDuringConcurrentSweep();
-    bool AllocationsStartedDuringConcurrentSweep() const;
     void ResumeNormalAllocationAfterConcurrentSweep(TBlockType * newNextAllocableBlockHead = nullptr);
 #endif
 
+    bool AllocationsStartedDuringConcurrentSweep() const;
     bool AllowAllocationsDuringConcurrentSweep();
     void StopAllocationBeforeSweep();
     void StartAllocationAfterSweep();
@@ -293,6 +295,7 @@ protected:
 #if ENABLE_CONCURRENT_GC && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
 #if SUPPORT_WIN32_SLIST && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP_USE_SLIST
     PSLIST_HEADER allocableHeapBlockListHead;
+    TBlockType * lastKnownNextAllocableBlockHead;
 #if DBG || defined(RECYCLER_SLOW_CHECK_ENABLED)
     // This lock is needed only in the debug mode while we verify block counts. Not needed otherwise, as this list is never accessed concurrently.
     // Items are added to it by the allocator when allocations are allowed during concurrent sweep. The list is drained during the next sweep while
@@ -302,9 +305,14 @@ protected:
     // This is the list of blocks that we allocated from during concurrent sweep. These blocks will eventually get processed during the next sweep and either go into
     // the heapBlockList or fullBlockList.
     TBlockType * sweepableHeapBlockList;
+
+    // This is the list of blocks that we allocated from during concurrent sweep prior to adjusting prtial GC heuristics (AdjustPartialHeuristics). These blocks will need to 
+    // be swept before we start the actual sweep (SweepPartialReusePages and/or SweepPendingObjects) of any of the blocks in this buckets. This needs to happen so we work off of
+    // correct heuristics data.
+    TBlockType * pendingSweepPrepHeapBlockList;
+#endif
 #endif
     bool allocationsStartedDuringConcurrentSweep;
-#endif
 
     FreeObject* explicitFreeList; // List of objects that have been explicitly freed
     TBlockAllocatorType * lastExplicitFreeListAllocator;
@@ -353,10 +361,16 @@ HeapBucketT<TBlockType>::SweepBucket(RecyclerSweep& recyclerSweep, Fn sweepFn)
 #if ENABLE_CONCURRENT_GC
         // We should only queue up pending sweep if we are doing partial collect
         Assert(recyclerSweep.GetPendingSweepBlockList(this) == nullptr);
+
+#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP && SUPPORT_WIN32_SLIST && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP_USE_SLIST
+        if (!this->AllocationsStartedDuringConcurrentSweep())
 #endif
-        // Every thing is swept immediately in non partial collect, so we can allocate
-        // from the heap block list now
-        StartAllocationAfterSweep();
+#endif
+        {
+            // Every thing is swept immediately in non partial collect, so we can allocate
+            // from the heap block list now
+            StartAllocationAfterSweep();
+        }
     }
 
     RECYCLER_SLOW_CHECK(this->VerifyHeapBlockCount(recyclerSweep.IsBackground()));

--- a/lib/Common/Memory/HeapBucket.h
+++ b/lib/Common/Memory/HeapBucket.h
@@ -81,9 +81,12 @@ protected:
 #endif
 
 #if defined(RECYCLER_SLOW_CHECK_ENABLED) || ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
-    size_t heapBlockCount;
-    size_t newHeapBlockCount;       // count of heap bock that is in the heap info and not in the heap bucket yet
-    size_t emptyHeapBlockCount;
+    uint32 heapBlockCount;
+    uint32 newHeapBlockCount;       // count of heap bock that is in the heap info and not in the heap bucket yet
+#endif
+
+#if defined(RECYCLER_SLOW_CHECK_ENABLED)
+    uint32 emptyHeapBlockCount;
 #endif
 
 #ifdef RECYCLER_PAGE_HEAP
@@ -317,11 +320,6 @@ protected:
     // This is the list of blocks that we allocated from during concurrent sweep. These blocks will eventually get processed during the next sweep and either go into
     // the fullBlockList.
     TBlockType * sweepableHeapBlockList;
-
-    // This is the list of blocks that we allocated from during concurrent sweep prior to adjusting prtial GC heuristics (AdjustPartialHeuristics). These blocks will need to 
-    // be swept before we start the actual sweep (SweepPartialReusePages and/or SweepPendingObjects) of any of the blocks in this buckets. This needs to happen so we work off of
-    // correct heuristics data.
-    TBlockType * pendingSweepPrepHeapBlockList;
 #endif
 #endif
 

--- a/lib/Common/Memory/HeapBucket.h
+++ b/lib/Common/Memory/HeapBucket.h
@@ -118,8 +118,8 @@ public:
 #endif
 
     Recycler * GetRecycler() const;
-#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
     bool AllocationsStartedDuringConcurrentSweep() const;
+#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
     bool ConcurrentSweepAllocationsThresholdExceeded() const;
     bool DoTwoPassConcurrentSweepPreCheck();
 #endif

--- a/lib/Common/Memory/HeapBucket.h
+++ b/lib/Common/Memory/HeapBucket.h
@@ -225,7 +225,7 @@ protected:
     void DeleteHeapBlockList(TBlockType * list);
     static void DeleteEmptyHeapBlockList(TBlockType * list);
     static void DeleteHeapBlockList(TBlockType * list, Recycler * recycler);
-#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP && SUPPORT_WIN32_SLIST && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP_USE_SLIST
+#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP && SUPPORT_WIN32_SLIST
     static bool PushHeapBlockToSList(PSLIST_HEADER list, TBlockType * heapBlock);
     static TBlockType * PopHeapBlockFromSList(PSLIST_HEADER list);
     static ushort QueryDepthInterlockedSList(PSLIST_HEADER list);
@@ -274,10 +274,10 @@ protected:
     void EnumerateObjects(ObjectInfoBits infoBits, void (*CallBackFunction)(void * address, size_t size));
 
 
+    void AssertCheckHeapBlockNotInAnyList(TBlockType * heapBlock);
 #if DBG
     bool AllocatorsAreEmpty() const;
     bool HasPendingDisposeHeapBlocks() const;
-    void AssertCheckHeapBlockNotInAnyList(TBlockType * heapBlock);
 
     static void VerifyBlockConsistencyInList(TBlockType * heapBlock, RecyclerVerifyListConsistencyData& recyclerSweep);
     static void VerifyBlockConsistencyInList(TBlockType * heapBlock, RecyclerVerifyListConsistencyData const& recyclerSweep, SweepState state);
@@ -305,7 +305,7 @@ protected:
     TBlockType * heapBlockList;      // list of blocks that has free objects
 
 #if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
-#if SUPPORT_WIN32_SLIST && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP_USE_SLIST
+#if SUPPORT_WIN32_SLIST
     PSLIST_HEADER allocableHeapBlockListHead;
     TBlockType * lastKnownNextAllocableBlockHead;
 #if DBG || defined(RECYCLER_SLOW_CHECK_ENABLED)
@@ -373,7 +373,7 @@ HeapBucketT<TBlockType>::SweepBucket(RecyclerSweep& recyclerSweep, Fn sweepFn)
         // We should only queue up pending sweep if we are doing partial collect
         Assert(recyclerSweep.GetPendingSweepBlockList(this) == nullptr);
 
-#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP && SUPPORT_WIN32_SLIST && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP_USE_SLIST
+#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP && SUPPORT_WIN32_SLIST
         if (!this->AllocationsStartedDuringConcurrentSweep())
 #endif
 #endif

--- a/lib/Common/Memory/HeapBucket.h
+++ b/lib/Common/Memory/HeapBucket.h
@@ -217,7 +217,9 @@ protected:
     void Initialize(HeapInfo * heapInfo, DECLSPEC_GUARD_OVERFLOW uint sizeCat);
     void AppendAllocableHeapBlockList(TBlockType * list);
 #if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
+    void EnsureAllocableHeapBlockList();
     void FinishSweepPrep(RecyclerSweep& recyclerSweep);
+    void FinishConcurrentSweepPass1(RecyclerSweep& recyclerSweep);
     void FinishConcurrentSweep();
 #endif
     void DeleteHeapBlockList(TBlockType * list);
@@ -320,6 +322,7 @@ protected:
     // be swept before we start the actual sweep (SweepPartialReusePages and/or SweepPendingObjects) of any of the blocks in this buckets. This needs to happen so we work off of
     // correct heuristics data.
     TBlockType * pendingSweepPrepHeapBlockList;
+    TBlockType * rebuildFreeBitVectorHeapBlockList;
 #endif
 #endif
 

--- a/lib/Common/Memory/HeapBucket.h
+++ b/lib/Common/Memory/HeapBucket.h
@@ -322,7 +322,6 @@ protected:
     // be swept before we start the actual sweep (SweepPartialReusePages and/or SweepPendingObjects) of any of the blocks in this buckets. This needs to happen so we work off of
     // correct heuristics data.
     TBlockType * pendingSweepPrepHeapBlockList;
-    TBlockType * rebuildFreeBitVectorHeapBlockList;
 #endif
 #endif
 

--- a/lib/Common/Memory/HeapInfo.cpp
+++ b/lib/Common/Memory/HeapInfo.cpp
@@ -1514,6 +1514,22 @@ void HeapInfo::StartAllocationsDuringConcurrentSweep()
 #endif
 }
 
+void 
+HeapInfo::FinishSweepPrep(RecyclerSweep& recyclerSweep)
+{
+    for (uint i = 0; i < HeapConstants::BucketCount; i++)
+    {
+        heapBuckets[i].FinishSweepPrep(recyclerSweep);
+    }
+
+#if defined(BUCKETIZE_MEDIUM_ALLOCATIONS) && SMALLBLOCK_MEDIUM_ALLOC
+    for (uint i = 0; i < HeapConstants::MediumBucketCount; i++)
+    {
+        mediumHeapBuckets[i].FinishSweepPrep(recyclerSweep);
+    }
+#endif
+}
+
 void
 HeapInfo::FinishConcurrentSweep()
 {

--- a/lib/Common/Memory/HeapInfo.cpp
+++ b/lib/Common/Memory/HeapInfo.cpp
@@ -1647,7 +1647,12 @@ HeapInfo::DisposeObjects()
 
     recycler->hasPendingTransferDisposedObjects = true;
 #if ENABLE_CONCURRENT_GC
+#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP 
+    // As during concurrent sweep we start/stop allocations it is safer to prevent transferring disposed objects altogether.
+    if (!recycler->IsConcurrentExecutingState() /*&& !recycler->IsConcurrentSweepState()*/)
+#else
     if (!recycler->IsConcurrentExecutingState())
+#endif
 #endif
     {
         // Can't transfer disposed object when the background thread is walking the heap block list
@@ -1669,7 +1674,11 @@ HeapInfo::TransferDisposedObjects()
     Recycler * recycler = this->recycler;
     Assert(recycler->hasPendingTransferDisposedObjects);
 #if ENABLE_CONCURRENT_GC
+#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP 
+    Assert(!recycler->IsConcurrentExecutingState() /*&& !recycler->IsConcurrentSweepState()*/);
+#else
     Assert(!recycler->IsConcurrentExecutingState());
+#endif
 #endif
     recycler->hasPendingTransferDisposedObjects = false;
 

--- a/lib/Common/Memory/HeapInfo.cpp
+++ b/lib/Common/Memory/HeapInfo.cpp
@@ -1539,6 +1539,22 @@ HeapInfo::DoTwoPassConcurrentSweepPreCheck()
 }
 
 void
+HeapInfo::FinishConcurrentSweepPass1(RecyclerSweep& recyclerSweep)
+{
+    for (uint i = 0; i < HeapConstants::BucketCount; i++)
+    {
+        heapBuckets[i].FinishConcurrentSweepPass1(recyclerSweep);
+    }
+
+#if defined(BUCKETIZE_MEDIUM_ALLOCATIONS) && SMALLBLOCK_MEDIUM_ALLOC
+    for (uint i = 0; i < HeapConstants::MediumBucketCount; i++)
+    {
+        mediumHeapBuckets[i].FinishConcurrentSweepPass1(recyclerSweep);
+    }
+#endif
+}
+
+void
 HeapInfo::FinishSweepPrep(RecyclerSweep& recyclerSweep)
 {
     for (uint i = 0; i < HeapConstants::BucketCount; i++)

--- a/lib/Common/Memory/HeapInfo.cpp
+++ b/lib/Common/Memory/HeapInfo.cpp
@@ -1517,11 +1517,14 @@ void HeapInfo::StartAllocationsDuringConcurrentSweep()
 bool
 HeapInfo::DoTwoPassConcurrentSweepPreCheck()
 {
+    bool enableTwoPassSweep = false;
+    // We will continue to do the check for all the buckets so we can enable/disable the feature 
+    // per bucket.
     for (uint i = 0; i < HeapConstants::BucketCount; i++)
     {
         if (heapBuckets[i].DoTwoPassConcurrentSweepPreCheck())
         {
-            return true;
+            enableTwoPassSweep = true;
         }
     }
 
@@ -1530,12 +1533,12 @@ HeapInfo::DoTwoPassConcurrentSweepPreCheck()
     {
         if (mediumHeapBuckets[i].DoTwoPassConcurrentSweepPreCheck())
         {
-            return true;
+            enableTwoPassSweep = true;
         }
     }
 #endif
 
-    return false;
+    return enableTwoPassSweep;
 }
 
 void

--- a/lib/Common/Memory/HeapInfo.h
+++ b/lib/Common/Memory/HeapInfo.h
@@ -89,6 +89,7 @@ public:
     void PrepareSweep();
 #if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
     void StartAllocationsDuringConcurrentSweep();
+    bool DoTwoPassConcurrentSweepPreCheck();
     void FinishSweepPrep(RecyclerSweep& recyclerSweep);
     void FinishConcurrentSweep();
 #endif
@@ -463,7 +464,7 @@ private:
     LargeHeapBucket largeObjectBucket;
 
     static const size_t ObjectAlignmentMask = HeapConstants::ObjectGranularity - 1;         // 0xF
-#ifdef RECYCLER_SLOW_CHECK_ENABLED
+#if defined(RECYCLER_SLOW_CHECK_ENABLED)
     size_t heapBlockCount[HeapBlock::BlockTypeCount];
 #endif
 #ifdef RECYCLER_FINALIZE_CHECK

--- a/lib/Common/Memory/HeapInfo.h
+++ b/lib/Common/Memory/HeapInfo.h
@@ -89,6 +89,7 @@ public:
     void PrepareSweep();
 #if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
     void StartAllocationsDuringConcurrentSweep();
+    void FinishSweepPrep(RecyclerSweep& recyclerSweep);
     void FinishConcurrentSweep();
 #endif
 

--- a/lib/Common/Memory/HeapInfo.h
+++ b/lib/Common/Memory/HeapInfo.h
@@ -91,6 +91,7 @@ public:
     void StartAllocationsDuringConcurrentSweep();
     bool DoTwoPassConcurrentSweepPreCheck();
     void FinishSweepPrep(RecyclerSweep& recyclerSweep);
+    void FinishConcurrentSweepPass1(RecyclerSweep& recyclerSweep);
     void FinishConcurrentSweep();
 #endif
 

--- a/lib/Common/Memory/LargeHeapBlock.cpp
+++ b/lib/Common/Memory/LargeHeapBlock.cpp
@@ -1551,7 +1551,7 @@ LargeHeapBlock::Sweep(RecyclerSweep& recyclerSweep, bool queuePendingSweep)
         Assert(!queuePendingSweep);
 #endif
 
-        SweepObjects<SweepMode_InThread>(recycler, false /*onlyRecalculateMarkCountAndFreeBits*/);
+        SweepObjects<SweepMode_InThread>(recycler);
         if (TransferSweptObjects())
         {
             return SweepStatePendingDispose;
@@ -1562,7 +1562,7 @@ LargeHeapBlock::Sweep(RecyclerSweep& recyclerSweep, bool queuePendingSweep)
     {
         Assert(expectedSweepCount == 0);
         isForceSweeping = true;
-        SweepObjects<SweepMode_InThread>(recycler, false /*onlyRecalculateMarkCountAndFreeBits*/);
+        SweepObjects<SweepMode_InThread>(recycler);
         isForceSweeping = false;
     }
 #endif
@@ -1728,7 +1728,7 @@ LargeHeapBlock::FinalizeObject(Recycler* recycler, LargeObjectHeader* header)
 }
 
 // Explicitly instantiate all the sweep modes
-template void LargeHeapBlock::SweepObjects<SweepMode_InThread>(Recycler * recycler, bool onlyRecalculateMarkCountAndFreeBits);
+template void LargeHeapBlock::SweepObjects<SweepMode_InThread>(Recycler * recycler);
 #if ENABLE_CONCURRENT_GC
 template <>
 void
@@ -1741,7 +1741,7 @@ LargeHeapBlock::SweepObject<SweepMode_Concurrent>(Recycler * recycler, LargeObje
 }
 
 // Explicitly instantiate all the sweep modes
-template void LargeHeapBlock::SweepObjects<SweepMode_Concurrent>(Recycler * recycler, bool onlyRecalculateMarkCountAndFreeBits);
+template void LargeHeapBlock::SweepObjects<SweepMode_Concurrent>(Recycler * recycler);
 #if ENABLE_PARTIAL_GC
 template <>
 void
@@ -1754,7 +1754,7 @@ LargeHeapBlock::SweepObject<SweepMode_ConcurrentPartial>(Recycler * recycler, La
 }
 
 // Explicitly instantiate all the sweep modes
-template void LargeHeapBlock::SweepObjects<SweepMode_ConcurrentPartial>(Recycler * recycler, bool onlyRecalculateMarkCountAndFreeBits);
+template void LargeHeapBlock::SweepObjects<SweepMode_ConcurrentPartial>(Recycler * recycler);
 #endif
 #endif
 
@@ -1797,7 +1797,7 @@ void LargeHeapBlock::FinalizeObjects(Recycler* recycler)
 
 template <SweepMode mode>
 void
-LargeHeapBlock::SweepObjects(Recycler * recycler, bool onlyRecalculateMarkCountAndFreeBits)
+LargeHeapBlock::SweepObjects(Recycler * recycler)
 {
 #if ENABLE_CONCURRENT_GC
     Assert(mode == SweepMode_InThread || this->isPendingConcurrentSweep);

--- a/lib/Common/Memory/LargeHeapBlock.cpp
+++ b/lib/Common/Memory/LargeHeapBlock.cpp
@@ -190,6 +190,10 @@ LargeHeapBlock::LargeHeapBlock(__in char * address, size_t pageCount, Segment * 
     this->segment = segment;
 #if ENABLE_CONCURRENT_GC
     this->isPendingConcurrentSweep = false;
+#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
+    // This flag is to identify whether this block was made available for allocations during the concurrent sweep and still needs to be swept.
+    this->isPendingConcurrentSweepPrep = false;
+#endif
 #endif
     this->addressEnd = this->address + this->pageCount * AutoSystemInfo::PageSize;
 
@@ -1804,7 +1808,7 @@ LargeHeapBlock::SweepObjects(Recycler * recycler)
 
     // mark count included newly allocated objects
 #if ENABLE_CONCURRENT_GC
-    Assert(expectedSweepCount == allocCount - markCount || recycler->collectionState == CollectionStateConcurrentSweep);
+    Assert(expectedSweepCount == allocCount - markCount || recycler->IsConcurrentSweepState());
 #else
     Assert(expectedSweepCount == allocCount - markCount);
 #endif

--- a/lib/Common/Memory/LargeHeapBlock.h
+++ b/lib/Common/Memory/LargeHeapBlock.h
@@ -166,7 +166,7 @@ public:
     void ScanNewImplicitRoots(Recycler * recycler);
     SweepState Sweep(RecyclerSweep& recyclerSweep, bool queuePendingSweep);
     template <SweepMode mode>
-    void SweepObjects(Recycler * recycler);
+    void SweepObjects(Recycler * recycler, bool onlyRecalculateMarkCountAndFreeBits);
     bool TransferSweptObjects();
     void DisposeObjects(Recycler * recycler);
     void FinalizeObjects(Recycler* recycler);

--- a/lib/Common/Memory/LargeHeapBlock.h
+++ b/lib/Common/Memory/LargeHeapBlock.h
@@ -166,7 +166,7 @@ public:
     void ScanNewImplicitRoots(Recycler * recycler);
     SweepState Sweep(RecyclerSweep& recyclerSweep, bool queuePendingSweep);
     template <SweepMode mode>
-    void SweepObjects(Recycler * recycler, bool onlyRecalculateMarkCountAndFreeBits);
+    void SweepObjects(Recycler * recycler);
     bool TransferSweptObjects();
     void DisposeObjects(Recycler * recycler);
     void FinalizeObjects(Recycler* recycler);

--- a/lib/Common/Memory/LargeHeapBucket.cpp
+++ b/lib/Common/Memory/LargeHeapBucket.cpp
@@ -825,7 +825,7 @@ LargeHeapBucket::SweepPendingObjects(RecyclerSweep& recyclerSweep)
             HeapBlockList::ForEach(this->pendingSweepLargeBlockList, [recycler](LargeHeapBlock * heapBlock)
             {
                 // Page heap blocks are never swept concurrently
-                heapBlock->SweepObjects<SweepMode_ConcurrentPartial>(recycler, false /*onlyRecalculateMarkCountAndFreeBits*/);
+                heapBlock->SweepObjects<SweepMode_ConcurrentPartial>(recycler);
             });
         }
         else
@@ -834,7 +834,7 @@ LargeHeapBucket::SweepPendingObjects(RecyclerSweep& recyclerSweep)
             HeapBlockList::ForEach(this->pendingSweepLargeBlockList, [recycler](LargeHeapBlock * heapBlock)
             {
                 // Page heap blocks are never swept concurrently
-                heapBlock->SweepObjects<SweepMode_Concurrent>(recycler, false /*onlyRecalculateMarkCountAndFreeBits*/);
+                heapBlock->SweepObjects<SweepMode_Concurrent>(recycler);
             });
         }
     }

--- a/lib/Common/Memory/MarkContext.inl
+++ b/lib/Common/Memory/MarkContext.inl
@@ -196,7 +196,11 @@ void MarkContext::MarkTrackedObject(FinalizableObject * trackedObject)
 {
 #if ENABLE_CONCURRENT_GC
     Assert(!recycler->queueTrackedObject);
+#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
+    Assert(!recycler->IsConcurrentExecutingState() && !recycler->IsConcurrentSweepState());
+#else
     Assert(!recycler->IsConcurrentExecutingState());
+#endif
 #endif
 #if ENABLE_PARTIAL_GC
     Assert(!recycler->inPartialCollectMode);

--- a/lib/Common/Memory/Recycler.cpp
+++ b/lib/Common/Memory/Recycler.cpp
@@ -6294,10 +6294,11 @@ Recycler::DoTwoPassConcurrentSweepPreCheck()
         // Do the actual 2-pass check only if the first 2 checks pass.
         if (this->allowAllocationsDuringConcurrentSweepForCollection)
         {
+            // TODO: akatti: Reenable this ETW event if needed.
             // We fire the ETW event only when the actual 2-pass check is performed. This is to avoid messing up ETL processing of test runs when in partial collect.
-            GCETW_INTERNAL(GC_START, (this, ETWEvent_ConcurrentSweep_TwoPassSweepPreCheck));
+            //GCETW_INTERNAL(GC_START, (this, ETWEvent_ConcurrentSweep_TwoPassSweepPreCheck));
             this->allowAllocationsDuringConcurrentSweepForCollection = this->autoHeap.DoTwoPassConcurrentSweepPreCheck();
-            GCETW_INTERNAL(GC_STOP, (this, ETWEvent_ConcurrentSweep_TwoPassSweepPreCheck));
+            //GCETW_INTERNAL(GC_STOP, (this, ETWEvent_ConcurrentSweep_TwoPassSweepPreCheck));
         }
     }
 }

--- a/lib/Common/Memory/Recycler.h
+++ b/lib/Common/Memory/Recycler.h
@@ -783,8 +783,9 @@ private:
     DListBase<GuestArenaAllocator> guestArenaList;
     DListBase<ArenaData*> externalGuestArenaList;    // guest arenas are scanned for roots
 
-#ifdef RECYCLER_PAGE_HEAP
     bool isPageHeapEnabled;
+
+#ifdef RECYCLER_PAGE_HEAP
     bool capturePageHeapAllocStack;
     bool capturePageHeapFreeStack;
 
@@ -887,10 +888,8 @@ private:
 
     bool inDispose;
 
-#if DBG
-    uint collectionCount;
-#endif
 #if DBG || defined RECYCLER_TRACE
+    uint collectionCount;
     bool inResolveExternalWeakReferences;
 #endif
 
@@ -1068,6 +1067,7 @@ private:
 #endif
 #ifdef RECYCLER_TRACE
     CollectionParam collectionParam;
+    void PrintBlockStatus(HeapBucket * heapBucket, HeapBlock * heapBlock, char16 const * name);
 #endif
 #ifdef RECYCLER_MEMORY_VERIFY
     uint verifyPad;
@@ -2210,7 +2210,6 @@ public:
     virtual bool FindHeapObject(void* objectAddress, Recycler * recycler, FindHeapObjectFlags flags, RecyclerHeapObjectInfo& heapObject) override { Assert(false); return false; }
     virtual bool TestObjectMarkedBit(void* objectAddress) override { Assert(false); return false; }
     virtual void SetObjectMarkedBit(void* objectAddress) override { Assert(false); }
-
 #ifdef RECYCLER_VERIFY_MARK
     virtual bool VerifyMark(void * objectAddress, void * target) override { Assert(false); return false; }
 #endif

--- a/lib/Common/Memory/Recycler.h
+++ b/lib/Common/Memory/Recycler.h
@@ -1605,6 +1605,7 @@ private:
 #if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
     void DoTwoPassConcurrentSweepPreCheck();
     void FinishSweepPrep();
+    void FinishConcurrentSweepPass1();
     void FinishConcurrentSweep();
 #endif
 

--- a/lib/Common/Memory/Recycler.h
+++ b/lib/Common/Memory/Recycler.h
@@ -1601,6 +1601,7 @@ private:
     void FinishSweep(RecyclerSweep& recyclerSweep);
 
 #if ENABLE_CONCURRENT_GC && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
+    void FinishSweepPrep();
     void FinishConcurrentSweep();
 #endif
 

--- a/lib/Common/Memory/Recycler.h
+++ b/lib/Common/Memory/Recycler.h
@@ -728,6 +728,9 @@ private:
 
     CollectionState collectionState;
     JsUtil::ThreadService *threadService;
+#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
+    bool allowAllocationsDuringConcurrentSweepForCollection;
+#endif
 
     HeapBlockMap heapBlockMap;
 
@@ -783,9 +786,8 @@ private:
     DListBase<GuestArenaAllocator> guestArenaList;
     DListBase<ArenaData*> externalGuestArenaList;    // guest arenas are scanned for roots
 
-    bool isPageHeapEnabled;
-
 #ifdef RECYCLER_PAGE_HEAP
+    bool isPageHeapEnabled;
     bool capturePageHeapAllocStack;
     bool capturePageHeapFreeStack;
 
@@ -1600,7 +1602,8 @@ private:
     void SweepHeap(bool concurrent, RecyclerSweep& recyclerSweep);
     void FinishSweep(RecyclerSweep& recyclerSweep);
 
-#if ENABLE_CONCURRENT_GC && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
+#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
+    void DoTwoPassConcurrentSweepPreCheck();
     void FinishSweepPrep();
     void FinishConcurrentSweep();
 #endif
@@ -1665,6 +1668,14 @@ private:
     {
         return ((collectionState & Collection_ConcurrentSweep) == Collection_ConcurrentSweep);
     }
+
+#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
+    bool AllowAllocationsDuringConcurrentSweep()
+    {
+        return this->allowAllocationsDuringConcurrentSweepForCollection;
+    }
+#endif
+
 #if DBG
     BOOL IsConcurrentFinishedState() const;
 #endif // DBG

--- a/lib/Common/Memory/Recycler.h
+++ b/lib/Common/Memory/Recycler.h
@@ -29,6 +29,30 @@ struct RecyclerMemoryData;
 
 namespace Memory
 {
+// NOTE: There is perf lab test infrastructure that takes a dependency on the events in this enumeration. Any modifications may cause
+// errors in ETL analysis or report incorrect numbers. Please verify that the GC events are analyzed correctly with your changes.
+    enum ETWEventGCActivationKind : unsigned
+    {
+        ETWEvent_GarbageCollect                         = 0,      // force in-thread GC
+        ETWEvent_ThreadCollect                          = 1,      // thread GC with wait
+        ETWEvent_ConcurrentCollect                      = 2,
+        ETWEvent_PartialCollect                         = 3,
+
+        ETWEvent_ConcurrentMark                         = 11,
+        ETWEvent_ConcurrentRescan                       = 12,
+        ETWEvent_ConcurrentSweep                        = 13,
+        ETWEvent_ConcurrentTransferSwept                = 14,
+        ETWEvent_ConcurrentFinishMark                   = 15,
+        ETWEvent_ConcurrentSweep_TwoPassSweepPreCheck   = 16,     // Check whether we should do a 2-pass concurrent sweep.
+
+        // The following events are only relevant to the 2-pass concurrent sweep and should not be seen otherwise.
+        ETWEvent_ConcurrentSweep_Pass1                  = 17,     // Concurrent sweep Pass1 of the blocks not getting allocated from during concurrent sweep.
+        ETWEvent_ConcurrentSweep_FinishSweepPrep        = 18,     // Stop allocations and remove all blocks from SLIST so we can finish Pass1 of the remaining blocks.
+        ETWEvent_ConcurrentSweep_FinishPass1            = 19,     // Concurrent sweep Pass1 of the blocks that were set aside for allocations during concurrent sweep.
+        ETWEvent_ConcurrentSweep_Pass2                  = 20,     // Concurrent sweep Pass1 of the blocks not getting allocated from during concurrent sweep.
+        ETWEvent_ConcurrentSweep_FinishTwoPassSweep     = 21,     // Drain the SLIST at the end of the 2-pass concurrent sweep and begin normal allocations.
+    };
+
 template <typename T> class RecyclerRootPtr;
 
 class AutoBooleanToggle

--- a/lib/Common/Memory/Recycler.inl
+++ b/lib/Common/Memory/Recycler.inl
@@ -552,7 +552,7 @@ Recycler::NotifyFree(T * heapBlock)
 #ifdef RECYCLER_TRACE
         this->PrintBlockStatus(nullptr, heapBlock, _u("[**34**] calling SweepObjects during NotifyFree."));
 #endif
-        heapBlock->template SweepObjects<SweepMode_InThread>(this, false /*onlyRecalculateMarkCountAndFreeBits*/);
+        heapBlock->template SweepObjects<SweepMode_InThread>(this);
 #if DBG || defined(RECYCLER_STATS)
         heapBlock->isForceSweeping = false;
         this->isForceSweeping = false;

--- a/lib/Common/Memory/Recycler.inl
+++ b/lib/Common/Memory/Recycler.inl
@@ -549,7 +549,10 @@ Recycler::NotifyFree(T * heapBlock)
         this->isForceSweeping = true;
         heapBlock->isForceSweeping = true;
 #endif
-        heapBlock->template SweepObjects<SweepMode_InThread>(this);
+#ifdef RECYCLER_TRACE
+        this->PrintBlockStatus(nullptr, heapBlock, _u("[**34**] calling SweepObjects during NotifyFree."));
+#endif
+        heapBlock->template SweepObjects<SweepMode_InThread>(this, false /*onlyRecalculateMarkCountAndFreeBits*/);
 #if DBG || defined(RECYCLER_STATS)
         heapBlock->isForceSweeping = false;
         this->isForceSweeping = false;

--- a/lib/Common/Memory/RecyclerHeuristic.h
+++ b/lib/Common/Memory/RecyclerHeuristic.h
@@ -63,7 +63,12 @@ public:
     static const uint BackgroundSecondRepeatMarkThreshold = 128;
 
     // Number of blocks a heap bucket needs to have before allocations during concurrent sweep feature kicks-in.
-    static const uint AllocDuringConcurrentSweepHeapBlockThreshold = 5000;
+#if DBG
+    // We would want the feature to kick-in always in debug builds so we excercise the code.
+    static const uint AllocDuringConcurrentSweepHeapBlockThreshold = 0;
+#else
+    static const uint AllocDuringConcurrentSweepHeapBlockThreshold = 2000;
+#endif
 #endif
 private:
 

--- a/lib/Common/Memory/RecyclerHeuristic.h
+++ b/lib/Common/Memory/RecyclerHeuristic.h
@@ -66,7 +66,7 @@ public:
     // Number of blocks a heap bucket needs to have before allocations during concurrent sweep feature kicks-in.
 #if DBG
     // We would want the feature to kick-in more frequently in debug builds so we excercise the code.
-    static const uint AllocDuringConcurrentSweepHeapBlockThreshold = 10;
+    static const uint AllocDuringConcurrentSweepHeapBlockThreshold = 100;
 #else
     static const uint AllocDuringConcurrentSweepHeapBlockThreshold = 5000;
 #endif

--- a/lib/Common/Memory/RecyclerHeuristic.h
+++ b/lib/Common/Memory/RecyclerHeuristic.h
@@ -68,7 +68,7 @@ public:
     // We would want the feature to kick-in more frequently in debug builds so we excercise the code.
     static const uint AllocDuringConcurrentSweepHeapBlockThreshold = 100;
 #else
-    static const uint AllocDuringConcurrentSweepHeapBlockThreshold = 5000;
+    static const uint AllocDuringConcurrentSweepHeapBlockThreshold = 60000;
 #endif
 #endif
 #endif

--- a/lib/Common/Memory/RecyclerHeuristic.h
+++ b/lib/Common/Memory/RecyclerHeuristic.h
@@ -62,12 +62,14 @@ public:
     // then trigger a second repeat mark pass.
     static const uint BackgroundSecondRepeatMarkThreshold = 128;
 
+#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
     // Number of blocks a heap bucket needs to have before allocations during concurrent sweep feature kicks-in.
 #if DBG
-    // We would want the feature to kick-in always in debug builds so we excercise the code.
-    static const uint AllocDuringConcurrentSweepHeapBlockThreshold = 0;
+    // We would want the feature to kick-in more frequently in debug builds so we excercise the code.
+    static const uint AllocDuringConcurrentSweepHeapBlockThreshold = 10;
 #else
-    static const uint AllocDuringConcurrentSweepHeapBlockThreshold = 2000;
+    static const uint AllocDuringConcurrentSweepHeapBlockThreshold = 5000;
+#endif
 #endif
 #endif
 private:

--- a/lib/Common/Memory/RecyclerHeuristic.h
+++ b/lib/Common/Memory/RecyclerHeuristic.h
@@ -61,6 +61,9 @@ public:
     // If we rescan at least 128 pages in the first background repeat mark,
     // then trigger a second repeat mark pass.
     static const uint BackgroundSecondRepeatMarkThreshold = 128;
+
+    // Number of blocks a heap bucket needs to have before allocations during concurrent sweep feature kicks-in.
+    static const uint AllocDuringConcurrentSweepHeapBlockThreshold = 5000;
 #endif
 private:
 

--- a/lib/Common/Memory/RecyclerSweep.cpp
+++ b/lib/Common/Memory/RecyclerSweep.cpp
@@ -288,18 +288,16 @@ RecyclerSweep::BackgroundSweep()
 
     // Finish the concurrent part of the first pass
     this->recycler->autoHeap.SweepSmallNonFinalizable(*this);
-    
-    // Finish the rest of the sweep
-    this->FinishSweep();
 
 #if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
-    if (CONFIG_FLAG_RELEASE(EnableConcurrentSweepAlloc))
-    {
-        this->recycler->FinishConcurrentSweep();
-    }
+    if (!CONFIG_FLAG_RELEASE(EnableConcurrentSweepAlloc))
 #endif
+    {
+        // Finish the rest of the sweep
+        this->FinishSweep();
 
-    this->EndBackground();
+        this->EndBackground();
+    }
 }
 #endif
 

--- a/lib/Common/Memory/RecyclerSweep.cpp
+++ b/lib/Common/Memory/RecyclerSweep.cpp
@@ -172,6 +172,13 @@ void
 RecyclerSweep::FinishSweep()
 {
 #if ENABLE_PARTIAL_GC
+#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
+    if (recycler->collectionState == CollectionStateConcurrentSweepPass2)
+    {
+        GCETW_INTERNAL(GC_START, (recycler, ETWEvent_ConcurrentSweep_Pass2));
+    }
+#endif
+
     Assert(this->partial == recycler->inPartialCollectMode);
     // Adjust heuristics
     if (recycler->inPartialCollectMode)
@@ -248,6 +255,12 @@ RecyclerSweep::FinishSweep()
 
 #if ENABLE_CONCURRENT_GC
     recycler->SweepPendingObjects(*this);
+#endif
+#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
+    if (recycler->collectionState == CollectionStateConcurrentSweepPass2)
+    {
+        GCETW_INTERNAL(GC_STOP, (recycler, ETWEvent_ConcurrentSweep_Pass2));
+    }
 #endif
 #endif
 }

--- a/lib/Common/Memory/RecyclerSweep.cpp
+++ b/lib/Common/Memory/RecyclerSweep.cpp
@@ -290,7 +290,7 @@ RecyclerSweep::BackgroundSweep()
     this->recycler->autoHeap.SweepSmallNonFinalizable(*this);
 
 #if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
-    if (!CONFIG_FLAG_RELEASE(EnableConcurrentSweepAlloc))
+    if (!CONFIG_FLAG_RELEASE(EnableConcurrentSweepAlloc) || !this->recycler->AllowAllocationsDuringConcurrentSweep())
 #endif
     {
         // Finish the rest of the sweep

--- a/lib/Common/Memory/RecyclerSweep.h
+++ b/lib/Common/Memory/RecyclerSweep.h
@@ -243,7 +243,7 @@ RecyclerSweep::TransferPendingEmptyHeapBlocks(HeapBucketT<TBlockType> * heapBuck
     if (list)
     {
         TBlockType * tail = bucketData.pendingEmptyBlockListTail;
-#if DBG || defined(RECYCLER_SLOW_CHECK_ENABLED)
+#if DBG || defined(RECYCLER_SLOW_CHECK_ENABLED) || ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
         size_t count = 0;
         HeapBlockList::ForEach(list, [tail, &count](TBlockType * heapBlock)
         {
@@ -252,8 +252,10 @@ RecyclerSweep::TransferPendingEmptyHeapBlocks(HeapBucketT<TBlockType> * heapBuck
             Assert(heapBlock->GetNextBlock() != nullptr || heapBlock == tail);
             count++;
         });
-        RECYCLER_SLOW_CHECK(heapBucket->emptyHeapBlockCount += count);
-        RECYCLER_SLOW_CHECK(heapBucket->heapBlockCount -= count);
+#if defined(RECYCLER_SLOW_CHECK_ENABLED) || ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
+        heapBucket->emptyHeapBlockCount += count;
+        heapBucket->heapBlockCount -= count;
+#endif
 #endif
 
 

--- a/lib/Common/Memory/RecyclerSweep.h
+++ b/lib/Common/Memory/RecyclerSweep.h
@@ -244,7 +244,7 @@ RecyclerSweep::TransferPendingEmptyHeapBlocks(HeapBucketT<TBlockType> * heapBuck
     {
         TBlockType * tail = bucketData.pendingEmptyBlockListTail;
 #if DBG || defined(RECYCLER_SLOW_CHECK_ENABLED) || ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
-        size_t count = 0;
+        uint32 count = 0;
         HeapBlockList::ForEach(list, [tail, &count](TBlockType * heapBlock)
         {
             Assert(heapBlock->GetAddress() == nullptr);
@@ -252,8 +252,10 @@ RecyclerSweep::TransferPendingEmptyHeapBlocks(HeapBucketT<TBlockType> * heapBuck
             Assert(heapBlock->GetNextBlock() != nullptr || heapBlock == tail);
             count++;
         });
-#if defined(RECYCLER_SLOW_CHECK_ENABLED) || ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
+#if defined(RECYCLER_SLOW_CHECK_ENABLED)
         heapBucket->emptyHeapBlockCount += count;
+#endif
+#if defined(RECYCLER_SLOW_CHECK_ENABLED) || ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
         heapBucket->heapBlockCount -= count;
 #endif
 #endif

--- a/lib/Common/Memory/RecyclerWeakReference.h
+++ b/lib/Common/Memory/RecyclerWeakReference.h
@@ -355,7 +355,7 @@ private:
         entry->weakRefHeapBlock = weakRefHeapBlock;
 
 #ifdef RECYCLER_TRACE_WEAKREF
-        Output::Print(_u("Add 0x%08x to bucket %d\n"), entry, targetBucket);
+        Output::Print(_u("Add WeakRef 0x%08x for StrongRef %p to bucket %d\n"), entry, strongReference, targetBucket);
 #endif
         AddEntry(entry, &buckets[targetBucket]);
         count++;

--- a/lib/Common/Memory/SmallBlockDeclarations.inl
+++ b/lib/Common/Memory/SmallBlockDeclarations.inl
@@ -53,7 +53,7 @@ template bool SmallHeapBlockT<TBlockTypeAttributes>::GetFreeObjectListOnAllocato
 // template const SmallHeapBlockT<TBlockTypeAttributes>::SmallHeapBlockBitVector * HeapInfo::ValidPointersMap<TBlockTypeAttributes>::GetInvalidBitVector(uint index) const;
 
 // Explicit instantiate all the sweep mode
-template void SmallHeapBlockT<TBlockTypeAttributes>::SweepObjects<SweepMode_InThread>(Recycler * recycler);
+template void SmallHeapBlockT<TBlockTypeAttributes>::SweepObjects<SweepMode_InThread>(Recycler * recycler, bool onlyRecalculateMarkCountAndFreeBits);
 #if ENABLE_CONCURRENT_GC
 template <>
 template <>
@@ -64,7 +64,7 @@ SmallHeapBlockT<TBlockTypeAttributes>::SweepObject<SweepMode_Concurrent>(Recycle
     EnqueueProcessedObject(&freeObjectList, addr, i);
 }
 // Explicit instantiate all the sweep mode
-template void SmallHeapBlockT<TBlockTypeAttributes>::SweepObjects<SweepMode_Concurrent>(Recycler * recycler);
+template void SmallHeapBlockT<TBlockTypeAttributes>::SweepObjects<SweepMode_Concurrent>(Recycler * recycler, bool onlyRecalculateMarkCountAndFreeBits);
 #if ENABLE_PARTIAL_GC
 template <>
 template <>
@@ -84,7 +84,7 @@ SmallHeapBlockT<TBlockTypeAttributes>::SweepObject<SweepMode_ConcurrentPartial>(
 }
 
 // Explicit instantiate all the sweep mode
-template void SmallHeapBlockT<TBlockTypeAttributes>::SweepObjects<SweepMode_ConcurrentPartial>(Recycler * recycler);
+template void SmallHeapBlockT<TBlockTypeAttributes>::SweepObjects<SweepMode_ConcurrentPartial>(Recycler * recycler, bool onlyRecalculateMarkCountAndFreeBits);
 #endif
 #endif
 
@@ -98,7 +98,11 @@ SmallHeapBlockT<TBlockTypeAttributes>::SweepObject<SweepMode_InThread>(Recycler 
         Assert(this->IsAnyFinalizableBlock());
 
 #if ENABLE_CONCURRENT_GC
+#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
+        Assert(!recycler->IsConcurrentExecutingState() && !recycler->IsConcurrentSweepState());
+#else
         Assert(!recycler->IsConcurrentExecutingState());
+#endif
 #endif
 
         // Call prepare finalize to do clean up that needs to be done immediately

--- a/lib/Common/Memory/SmallBlockDeclarations.inl
+++ b/lib/Common/Memory/SmallBlockDeclarations.inl
@@ -53,7 +53,7 @@ template bool SmallHeapBlockT<TBlockTypeAttributes>::GetFreeObjectListOnAllocato
 // template const SmallHeapBlockT<TBlockTypeAttributes>::SmallHeapBlockBitVector * HeapInfo::ValidPointersMap<TBlockTypeAttributes>::GetInvalidBitVector(uint index) const;
 
 // Explicit instantiate all the sweep mode
-template void SmallHeapBlockT<TBlockTypeAttributes>::SweepObjects<SweepMode_InThread>(Recycler * recycler, bool onlyRecalculateMarkCountAndFreeBits);
+template void SmallHeapBlockT<TBlockTypeAttributes>::SweepObjects<SweepMode_InThread>(Recycler * recycler);
 #if ENABLE_CONCURRENT_GC
 template <>
 template <>
@@ -64,7 +64,7 @@ SmallHeapBlockT<TBlockTypeAttributes>::SweepObject<SweepMode_Concurrent>(Recycle
     EnqueueProcessedObject(&freeObjectList, addr, i);
 }
 // Explicit instantiate all the sweep mode
-template void SmallHeapBlockT<TBlockTypeAttributes>::SweepObjects<SweepMode_Concurrent>(Recycler * recycler, bool onlyRecalculateMarkCountAndFreeBits);
+template void SmallHeapBlockT<TBlockTypeAttributes>::SweepObjects<SweepMode_Concurrent>(Recycler * recycler);
 #if ENABLE_PARTIAL_GC
 template <>
 template <>
@@ -84,7 +84,7 @@ SmallHeapBlockT<TBlockTypeAttributes>::SweepObject<SweepMode_ConcurrentPartial>(
 }
 
 // Explicit instantiate all the sweep mode
-template void SmallHeapBlockT<TBlockTypeAttributes>::SweepObjects<SweepMode_ConcurrentPartial>(Recycler * recycler, bool onlyRecalculateMarkCountAndFreeBits);
+template void SmallHeapBlockT<TBlockTypeAttributes>::SweepObjects<SweepMode_ConcurrentPartial>(Recycler * recycler);
 #endif
 #endif
 

--- a/lib/Common/Memory/SmallFinalizableHeapBlock.cpp
+++ b/lib/Common/Memory/SmallFinalizableHeapBlock.cpp
@@ -134,6 +134,13 @@ SmallFinalizableHeapBlockT<TBlockAttributes>::SetAttributes(void * address, unsi
     __super::SetAttributes(address, attributes);
     finalizeCount++;
 
+#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
+    if (CONFIG_FLAG_RELEASE(EnableConcurrentSweepAlloc))
+    {
+        AssertMsg(!this->isPendingConcurrentSweepPrep, "Finalizable blocks don't support allocations during concurrent sweep.");
+    }
+#endif
+
 #ifdef RECYCLER_FINALIZE_CHECK
     HeapInfo * heapInfo = this->heapBucket->heapInfo;
     heapInfo->liveFinalizableObjectCount++;

--- a/lib/Common/Memory/SmallFinalizableHeapBlock.h
+++ b/lib/Common/Memory/SmallFinalizableHeapBlock.h
@@ -58,6 +58,13 @@ public:
 
     void AddPendingDisposeObject()
     {
+#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
+        if (CONFIG_FLAG_RELEASE(EnableConcurrentSweepAlloc))
+        {
+            AssertMsg(!this->isPendingConcurrentSweepPrep, "Finalizable blocks don't support allocations during concurrent sweep.");
+        }
+#endif
+
         this->pendingDisposeCount++;
         Assert(this->pendingDisposeCount <= this->objectCount);
     }

--- a/lib/Common/Memory/SmallFinalizableHeapBucket.h
+++ b/lib/Common/Memory/SmallFinalizableHeapBucket.h
@@ -414,8 +414,9 @@ public:
 #ifdef RECYCLER_VERIFY_MARK
     void VerifyMark();
 #endif
-#if ENABLE_CONCURRENT_GC && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
+#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
     void StartAllocationDuringConcurrentSweep();
+    bool DoTwoPassConcurrentSweepPreCheck();
     void FinishSweepPrep(RecyclerSweep& recyclerSweep);
     void FinishConcurrentSweep();
 #endif

--- a/lib/Common/Memory/SmallFinalizableHeapBucket.h
+++ b/lib/Common/Memory/SmallFinalizableHeapBucket.h
@@ -418,6 +418,7 @@ public:
     void StartAllocationDuringConcurrentSweep();
     bool DoTwoPassConcurrentSweepPreCheck();
     void FinishSweepPrep(RecyclerSweep& recyclerSweep);
+    void FinishConcurrentSweepPass1(RecyclerSweep& recyclerSweep);
     void FinishConcurrentSweep();
 #endif
 #if DBG

--- a/lib/Common/Memory/SmallFinalizableHeapBucket.h
+++ b/lib/Common/Memory/SmallFinalizableHeapBucket.h
@@ -416,6 +416,7 @@ public:
 #endif
 #if ENABLE_CONCURRENT_GC && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
     void StartAllocationDuringConcurrentSweep();
+    void FinishSweepPrep(RecyclerSweep& recyclerSweep);
     void FinishConcurrentSweep();
 #endif
 #if DBG

--- a/lib/Common/Memory/SmallHeapBlockAllocator.cpp
+++ b/lib/Common/Memory/SmallHeapBlockAllocator.cpp
@@ -27,6 +27,10 @@ SmallHeapBlockAllocator<TBlockType>::Initialize()
 
     this->prev = this;
     this->next = this;
+
+#if ENABLE_CONCURRENT_GC && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP 
+    DebugOnly(this->isAllocatingFromNewBlock = false);
+#endif
 }
 
 template <typename TBlockType>
@@ -134,7 +138,9 @@ SmallHeapBlockAllocator<TBlockType>::Clear()
 #endif
         this->freeObjectList = nullptr;
     }
-
+#if ENABLE_CONCURRENT_GC && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP 
+    DebugOnly(this->isAllocatingFromNewBlock = false);
+#endif
 }
 
 template <typename TBlockType>
@@ -155,6 +161,10 @@ SmallHeapBlockAllocator<TBlockType>::SetNew(BlockType * heapBlock)
     this->heapBlock = heapBlock;
     this->freeObjectList = (FreeObject *)heapBlock->GetAddress();
     this->endAddress = heapBlock->GetEndAddress();
+
+#if ENABLE_CONCURRENT_GC && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP 
+    DebugOnly(this->isAllocatingFromNewBlock = true);
+#endif
 }
 
 template <typename TBlockType>
@@ -175,6 +185,10 @@ SmallHeapBlockAllocator<TBlockType>::Set(BlockType * heapBlock)
     this->heapBlock = heapBlock;
     RECYCLER_SLOW_CHECK(this->heapBlock->CheckDebugFreeBitVector(true));
     this->freeObjectList = this->heapBlock->freeObjectList;
+
+#if ENABLE_CONCURRENT_GC && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP 
+    DebugOnly(this->isAllocatingFromNewBlock = false);
+#endif
 }
 
 

--- a/lib/Common/Memory/SmallHeapBlockAllocator.cpp
+++ b/lib/Common/Memory/SmallHeapBlockAllocator.cpp
@@ -28,7 +28,7 @@ SmallHeapBlockAllocator<TBlockType>::Initialize()
     this->prev = this;
     this->next = this;
 
-#if ENABLE_CONCURRENT_GC && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP 
+#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP 
     DebugOnly(this->isAllocatingFromNewBlock = false);
 #endif
 }
@@ -138,7 +138,7 @@ SmallHeapBlockAllocator<TBlockType>::Clear()
 #endif
         this->freeObjectList = nullptr;
     }
-#if ENABLE_CONCURRENT_GC && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP 
+#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP 
     DebugOnly(this->isAllocatingFromNewBlock = false);
 #endif
 }
@@ -162,7 +162,7 @@ SmallHeapBlockAllocator<TBlockType>::SetNew(BlockType * heapBlock)
     this->freeObjectList = (FreeObject *)heapBlock->GetAddress();
     this->endAddress = heapBlock->GetEndAddress();
 
-#if ENABLE_CONCURRENT_GC && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP 
+#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP 
     DebugOnly(this->isAllocatingFromNewBlock = true);
 #endif
 }
@@ -186,7 +186,7 @@ SmallHeapBlockAllocator<TBlockType>::Set(BlockType * heapBlock)
     RECYCLER_SLOW_CHECK(this->heapBlock->CheckDebugFreeBitVector(true));
     this->freeObjectList = this->heapBlock->freeObjectList;
 
-#if ENABLE_CONCURRENT_GC && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP 
+#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP 
     DebugOnly(this->isAllocatingFromNewBlock = false);
 #endif
 }

--- a/lib/Common/Memory/SmallHeapBlockAllocator.h
+++ b/lib/Common/Memory/SmallHeapBlockAllocator.h
@@ -221,7 +221,6 @@ SmallHeapBlockAllocator<TBlockType>::InlinedAllocImpl(Recycler * recycler, DECLS
                 Assert(heapBlock->IsValidBitIndex(bitIndex));
 
                 heapBlock->GetMarkedBitVector()->Set(bitIndex);
-                heapBlock->GetFreeBitVector()->Clear(bitIndex);
 #if DBG
                 heapBlock->GetDebugFreeBitVector()->Clear(bitIndex);
 #endif
@@ -230,7 +229,7 @@ SmallHeapBlockAllocator<TBlockType>::InlinedAllocImpl(Recycler * recycler, DECLS
                 // We need to keep track of the number of objects allocated during concurrent sweep, to be
                 // able to make the correct determination about whether a block is EMPTY or FULL when the actual
                 // sweep of this block happens.
-                heapBlock->objectsAllocatedDuringConcurrentSweepCount++;
+                DebugOnly(heapBlock->objectsAllocatedDuringConcurrentSweepCount++);
 #ifdef RECYCLER_TRACE
                 if (recycler->GetRecyclerFlagsTable().Trace.IsEnabled(Js::ConcurrentSweepPhase) && recycler->GetRecyclerFlagsTable().Trace.IsEnabled(Js::MemoryAllocationPhase))
                 {

--- a/lib/Common/Memory/SmallHeapBlockAllocator.h
+++ b/lib/Common/Memory/SmallHeapBlockAllocator.h
@@ -223,7 +223,7 @@ SmallHeapBlockAllocator<TBlockType>::InlinedAllocImpl(Recycler * recycler, DECLS
 #endif
 
 #ifdef RECYCLER_TRACE
-            if (recycler->GetRecyclerFlagsTable().Trace.IsEnabled(Js::ConcurrentSweepPhase) && recycler->GetRecyclerFlagsTable().Trace.IsEnabled(Js::MemoryAllocationPhase))
+            if (recycler->GetRecyclerFlagsTable().Trace.IsEnabled(Js::ConcurrentSweepPhase) && recycler->GetRecyclerFlagsTable().Trace.IsEnabled(Js::MemoryAllocationPhase) && CONFIG_FLAG_RELEASE(Verbose))
             {
                 Output::Print(_u("[**33**]FreeListAlloc: Object 0x%p from HeapBlock 0x%p used for allocation during ConcurrentSweep [CollectionState: %d] \n"), memBlock, heapBlock, recycler->collectionState);
             }

--- a/lib/Common/Memory/SmallHeapBlockAllocator.h
+++ b/lib/Common/Memory/SmallHeapBlockAllocator.h
@@ -217,19 +217,13 @@ SmallHeapBlockAllocator<TBlockType>::InlinedAllocImpl(Recycler * recycler, DECLS
                 AssertMsg(heapBlock->heapBucket->AllocationsStartedDuringConcurrentSweep(), "We shouldn't be allocating from this block while allocations are disabled.");
 
                 // Explcitly mark this object and also clear the free bit.
+                heapBlock->SetObjectMarkedBit(memBlock);
+#if DBG || defined(RECYCLER_SLOW_CHECK_ENABLED)
                 uint bitIndex = heapBlock->GetAddressBitIndex(memBlock);
-                Assert(heapBlock->IsValidBitIndex(bitIndex));
-
-                heapBlock->GetMarkedBitVector()->Set(bitIndex);
-#if DBG
                 heapBlock->GetDebugFreeBitVector()->Clear(bitIndex);
+                heapBlock->objectsMarkedDuringSweep++;
 #endif
 
-                DebugOnly(heapBlock->objectsMarkedDuringSweep++);
-                // We need to keep track of the number of objects allocated during concurrent sweep, to be
-                // able to make the correct determination about whether a block is EMPTY or FULL when the actual
-                // sweep of this block happens.
-                DebugOnly(heapBlock->objectsAllocatedDuringConcurrentSweepCount++);
 #ifdef RECYCLER_TRACE
                 if (recycler->GetRecyclerFlagsTable().Trace.IsEnabled(Js::ConcurrentSweepPhase) && recycler->GetRecyclerFlagsTable().Trace.IsEnabled(Js::MemoryAllocationPhase))
                 {

--- a/lib/Common/Memory/SmallNormalHeapBucket.cpp
+++ b/lib/Common/Memory/SmallNormalHeapBucket.cpp
@@ -51,7 +51,6 @@ SmallNormalHeapBucketBase<TBlockType>::ScanInitialImplicitRoots(Recycler * recyc
 
         // The pendingSweepPrepHeapBlockList should always be empty prior to a sweep as its only used during concurrent sweep.
         Assert(this->pendingSweepPrepHeapBlockList == nullptr);
-        Assert(this->rebuildFreeBitVectorHeapBlockList == nullptr);
     }
 #endif
 

--- a/lib/Common/Memory/SmallNormalHeapBucket.cpp
+++ b/lib/Common/Memory/SmallNormalHeapBucket.cpp
@@ -328,7 +328,7 @@ SmallNormalHeapBucketBase<TBlockType>::SweepPendingObjects(Recycler * recycler, 
         tail = heapBlock;
 
 #if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP && SUPPORT_WIN32_SLIST && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP_USE_SLIST
-        if (this->AllowAllocationsDuringConcurrentSweep())
+        if (this->AllocationsStartedDuringConcurrentSweep())
         {
             Assert(!this->IsAnyFinalizableBucket());
             DebugOnly(AssertCheckHeapBlockNotInAnyList(heapBlock));
@@ -441,7 +441,7 @@ SmallNormalHeapBucketBase<TBlockType>::SweepPartialReusePages(RecyclerSweep& rec
     TBlockType * currentHeapBlockList = this->heapBlockList;
     this->heapBlockList = nullptr;
     SmallNormalHeapBucketBase<TBlockType>::SweepPartialReusePages(recyclerSweep, currentHeapBlockList, this->heapBlockList,
-        this->partialHeapBlockList, this->AllowAllocationsDuringConcurrentSweep(),
+        this->partialHeapBlockList, this->AllocationsStartedDuringConcurrentSweep(),
         [this](TBlockType * heapBlock, bool isReused) 
     {
 #if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP && SUPPORT_WIN32_SLIST && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP_USE_SLIST
@@ -452,7 +452,7 @@ SmallNormalHeapBucketBase<TBlockType>::SweepPartialReusePages(RecyclerSweep& rec
             DebugOnly(AssertCheckHeapBlockNotInAnyList(heapBlock));
             if (heapBlock->HasFreeObject())
             {
-                if (this->AllowAllocationsDuringConcurrentSweep())
+                if (this->AllocationsStartedDuringConcurrentSweep())
                 {
                     Assert(!this->IsAnyFinalizableBucket());
                     Assert(!heapBlock->isPendingConcurrentSweepPrep);
@@ -507,7 +507,7 @@ SmallNormalHeapBucketBase<TBlockType>::SweepPartialReusePages(RecyclerSweep& rec
     pendingSweepList = nullptr;
     Recycler * recycler = recyclerSweep.GetRecycler();
     SmallNormalHeapBucketBase<TBlockType>::SweepPartialReusePages(recyclerSweep, currentHeapBlockList, this->heapBlockList,
-        pendingSweepList, this->AllowAllocationsDuringConcurrentSweep(),
+        pendingSweepList, this->AllocationsStartedDuringConcurrentSweep(),
         [this, recycler](TBlockType * heapBlock, bool isReused)
         {
             if (isReused)
@@ -527,7 +527,7 @@ SmallNormalHeapBucketBase<TBlockType>::SweepPartialReusePages(RecyclerSweep& rec
                 DebugOnly(AssertCheckHeapBlockNotInAnyList(heapBlock));
                 if (heapBlock->HasFreeObject())
                 {
-                    if (this->AllowAllocationsDuringConcurrentSweep())
+                    if (this->AllocationsStartedDuringConcurrentSweep())
                     {
                         Assert(!this->IsAnyFinalizableBucket());
                         Assert(!heapBlock->isPendingConcurrentSweepPrep);
@@ -722,7 +722,7 @@ SmallNormalHeapBucketBase<TBlockType>::GetNonEmptyHeapBlockCount(bool checkCount
 #endif
 #endif
 #endif
-    RECYCLER_SLOW_CHECK(Assert(!checkCount || this->heapBlockCount == currentHeapBlockCount || (this->heapBlockCount >= 65535 && allocatingDuringConcurrentSweep)));
+    RECYCLER_SLOW_CHECK(Assert(!checkCount || this->heapBlockCount == currentHeapBlockCount /*|| (this->heapBlockCount >= 65535 && allocatingDuringConcurrentSweep)*/));
     return currentHeapBlockCount;
 }
 #endif

--- a/lib/Common/Memory/SmallNormalHeapBucket.cpp
+++ b/lib/Common/Memory/SmallNormalHeapBucket.cpp
@@ -252,7 +252,7 @@ SmallNormalHeapBucketBase<TBlockType>::SweepPendingObjects(RecyclerSweep& recycl
                 heapBlock->template SweepObjects<SweepMode_ConcurrentPartial>(recycler);
 
                 // page heap mode should never reach here, so don't check pageheap enabled or not
-                DebugOnly(AssertCheckHeapBlockNotInAnyList(heapBlock));
+                DebugOnly(this->AssertCheckHeapBlockNotInAnyList(heapBlock));
                 if (heapBlock->HasFreeObject())
                 {
                     AssertMsg(!HeapBlockList::Contains(heapBlock, partialSweptHeapBlockList), "The heap block already exists in the partialSweptHeapBlockList.");
@@ -280,7 +280,7 @@ SmallNormalHeapBucketBase<TBlockType>::SweepPendingObjects(RecyclerSweep& recycl
             // We decided not to do a partial sweep.
             // Blocks in the pendingSweepList need to have a regular sweep.
 
-#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP && SUPPORT_WIN32_SLIST && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP_USE_SLIST
+#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP && SUPPORT_WIN32_SLIST
             if (CONFIG_FLAG_RELEASE(EnableConcurrentSweepAlloc))
             {
                 if (this->AllowAllocationsDuringConcurrentSweep() && !this->AllocationsStartedDuringConcurrentSweep())
@@ -293,7 +293,7 @@ SmallNormalHeapBucketBase<TBlockType>::SweepPendingObjects(RecyclerSweep& recycl
 
             TBlockType * tail = SweepPendingObjects<SweepMode_Concurrent>(recycler, list);
 
-#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP && SUPPORT_WIN32_SLIST && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP_USE_SLIST
+#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP && SUPPORT_WIN32_SLIST
             // During concurrent sweep if allocations were allowed, the heap blocks directly go into the SLIST of
             // allocable heap blocks. They will be returned to the heapBlockList at the end of the sweep.
             if (!this->AllowAllocationsDuringConcurrentSweep())
@@ -327,11 +327,11 @@ SmallNormalHeapBucketBase<TBlockType>::SweepPendingObjects(Recycler * recycler, 
         heapBlock->template SweepObjects<mode>(recycler);
         tail = heapBlock;
 
-#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP && SUPPORT_WIN32_SLIST && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP_USE_SLIST
+#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP && SUPPORT_WIN32_SLIST
         if (this->AllocationsStartedDuringConcurrentSweep())
         {
             Assert(!this->IsAnyFinalizableBucket());
-            DebugOnly(AssertCheckHeapBlockNotInAnyList(heapBlock));
+            DebugOnly(this->AssertCheckHeapBlockNotInAnyList(heapBlock));
             // If we exhausted the free list during this sweep, we will need to send this block to the FullBlockList.
             if (heapBlock->HasFreeObject())
             {
@@ -353,7 +353,7 @@ SmallNormalHeapBucketBase<TBlockType>::SweepPendingObjects(Recycler * recycler, 
             }
             else
             {
-                DebugOnly(AssertCheckHeapBlockNotInAnyList(heapBlock));
+                DebugOnly(this->AssertCheckHeapBlockNotInAnyList(heapBlock));
                 heapBlock->SetNextBlock(this->fullBlockList);
                 this->fullBlockList = heapBlock;
 #ifdef RECYCLER_TRACE
@@ -392,13 +392,13 @@ SmallNormalHeapBucketBase<TBlockType>::SweepPartialReusePages(RecyclerSweep& rec
             callback(heapBlock, true);
 
 
-#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP && SUPPORT_WIN32_SLIST && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP_USE_SLIST
+#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP && SUPPORT_WIN32_SLIST
             // During concurrent sweep if allocations were allowed, the heap blocks directly go into the SLIST of
             // allocable heap blocks. They will be returned to the heapBlockList at the end of the sweep.
             if(!allocationsAllowedDuringConcurrentSweep)
 #endif
             {
-                DebugOnly(AssertCheckHeapBlockNotInAnyList(heapBlock));
+                DebugOnly(this->AssertCheckHeapBlockNotInAnyList(heapBlock));
                 // Reuse the page
                 heapBlock->SetNextBlock(reuseBlocklist);
                 reuseBlocklist = heapBlock;
@@ -412,7 +412,7 @@ SmallNormalHeapBucketBase<TBlockType>::SweepPartialReusePages(RecyclerSweep& rec
             // Don't not reuse the page if it don't have much free memory.
             callback(heapBlock, false);
 
-            DebugOnly(AssertCheckHeapBlockNotInAnyList(heapBlock));
+            DebugOnly(this->AssertCheckHeapBlockNotInAnyList(heapBlock));
             heapBlock->SetNextBlock(unusedBlockList);
             unusedBlockList = heapBlock;
 
@@ -430,7 +430,7 @@ SmallNormalHeapBucketBase<TBlockType>::SweepPartialReusePages(RecyclerSweep& rec
     RECYCLER_SLOW_CHECK(this->VerifyHeapBlockCount(recyclerSweep.IsBackground()));
     Assert(this->GetRecycler()->inPartialCollectMode);
 
-#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP && SUPPORT_WIN32_SLIST && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP_USE_SLIST
+#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP && SUPPORT_WIN32_SLIST
     if (this->AllowAllocationsDuringConcurrentSweep() && !this->AllocationsStartedDuringConcurrentSweep())
     {
         Assert(!this->IsAnyFinalizableBucket());
@@ -444,12 +444,12 @@ SmallNormalHeapBucketBase<TBlockType>::SweepPartialReusePages(RecyclerSweep& rec
         this->partialHeapBlockList, this->AllocationsStartedDuringConcurrentSweep(),
         [this](TBlockType * heapBlock, bool isReused) 
     {
-#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP && SUPPORT_WIN32_SLIST && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP_USE_SLIST
+#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP && SUPPORT_WIN32_SLIST
         if (isReused)
         {
             DebugOnly(heapBlock->blockNotReusedInPartialHeapBlockList = false);
 
-            DebugOnly(AssertCheckHeapBlockNotInAnyList(heapBlock));
+            DebugOnly(this->AssertCheckHeapBlockNotInAnyList(heapBlock));
             if (heapBlock->HasFreeObject())
             {
                 if (this->AllocationsStartedDuringConcurrentSweep())
@@ -523,8 +523,8 @@ SmallNormalHeapBucketBase<TBlockType>::SweepPartialReusePages(RecyclerSweep& rec
                 recycler->PrintBlockStatus(this, heapBlock, _u("[**20**] calling SweepObjects."));
 #endif
                 heapBlock->template SweepObjects<SweepMode_InThread>(recycler);
-#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP && SUPPORT_WIN32_SLIST && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP_USE_SLIST
-                DebugOnly(AssertCheckHeapBlockNotInAnyList(heapBlock));
+#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP && SUPPORT_WIN32_SLIST
+                DebugOnly(this->AssertCheckHeapBlockNotInAnyList(heapBlock));
                 if (heapBlock->HasFreeObject())
                 {
                     if (this->AllocationsStartedDuringConcurrentSweep())
@@ -576,7 +576,7 @@ SmallNormalHeapBucketBase<TBlockType>::SweepPartialReusePages(RecyclerSweep& rec
 
     RECYCLER_SLOW_CHECK(this->VerifyHeapBlockCount(recyclerSweep.IsBackground()));
 
-#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP && SUPPORT_WIN32_SLIST && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP_USE_SLIST
+#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP && SUPPORT_WIN32_SLIST
     if (!this->AllocationsStartedDuringConcurrentSweep())
 #endif
     {
@@ -714,7 +714,7 @@ SmallNormalHeapBucketBase<TBlockType>::GetNonEmptyHeapBlockCount(bool checkCount
 
 #if ENABLE_CONCURRENT_GC
 #if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
-#if SUPPORT_WIN32_SLIST && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP_USE_SLIST
+#if SUPPORT_WIN32_SLIST
     if (CONFIG_FLAG_RELEASE(EnableConcurrentSweepAlloc))
     {
         allocatingDuringConcurrentSweep = true;
@@ -722,7 +722,7 @@ SmallNormalHeapBucketBase<TBlockType>::GetNonEmptyHeapBlockCount(bool checkCount
 #endif
 #endif
 #endif
-    RECYCLER_SLOW_CHECK(Assert(!checkCount || this->heapBlockCount == currentHeapBlockCount /*|| (this->heapBlockCount >= 65535 && allocatingDuringConcurrentSweep)*/));
+    RECYCLER_SLOW_CHECK(Assert(!checkCount || this->heapBlockCount == currentHeapBlockCount || (this->heapBlockCount >= 65535 && allocatingDuringConcurrentSweep)));
     return currentHeapBlockCount;
 }
 #endif

--- a/lib/Common/Memory/SmallNormalHeapBucket.cpp
+++ b/lib/Common/Memory/SmallNormalHeapBucket.cpp
@@ -41,16 +41,13 @@ SmallNormalHeapBucketBase<TBlockType>::ScanInitialImplicitRoots(Recycler * recyc
         heapBlock->ScanInitialImplicitRoots(recycler);
     });
 
-#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP && ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP_USE_SLIST
+#if ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP
     if (CONFIG_FLAG_RELEASE(EnableConcurrentSweepAlloc) && !this->IsAnyFinalizableBucket())
     {
         HeapBlockList::ForEach(this->sweepableHeapBlockList, [recycler](TBlockType * heapBlock)
         {
             heapBlock->ScanInitialImplicitRoots(recycler);
         });
-
-        // The pendingSweepPrepHeapBlockList should always be empty prior to a sweep as its only used during concurrent sweep.
-        Assert(this->pendingSweepPrepHeapBlockList == nullptr);
     }
 #endif
 

--- a/lib/Common/Memory/SmallNormalHeapBucket.cpp
+++ b/lib/Common/Memory/SmallNormalHeapBucket.cpp
@@ -335,14 +335,12 @@ SmallNormalHeapBucketBase<TBlockType>::SweepPendingObjects(Recycler * recycler, 
             // If we exhausted the free list during this sweep, we will need to send this block to the FullBlockList.
             if (heapBlock->HasFreeObject())
             {
+                Assert(!heapBlock->isPendingConcurrentSweepPrep);
                 bool blockAddedToSList = HeapBucketT<TBlockType>::PushHeapBlockToSList(this->allocableHeapBlockListHead, heapBlock);
 
                 // If we encountered OOM while pushing the heapBlock to the SLIST we must add it to the heapBlockList so we don't lose track of it.
                 if (!blockAddedToSList)
                 {
-#ifdef RECYCLER_TRACE
-                    recycler->PrintBlockStatus(this, heapBlock, _u("[**23**] finished SweepPendingObjects, OOM while adding to the SLIST."));
-#endif
                     //TODO: akatti: We should handle this gracefully and try to recover from this state.
                     AssertOrFailFastMsg(false, "OOM while adding a heap block to the SLIST during concurrent sweep.");
                 }
@@ -457,14 +455,12 @@ SmallNormalHeapBucketBase<TBlockType>::SweepPartialReusePages(RecyclerSweep& rec
                 if (this->AllowAllocationsDuringConcurrentSweep())
                 {
                     Assert(!this->IsAnyFinalizableBucket());
+                    Assert(!heapBlock->isPendingConcurrentSweepPrep);
                     bool blockAddedToSList = HeapBucketT<TBlockType>::PushHeapBlockToSList(this->allocableHeapBlockListHead, heapBlock);
 
                     // If we encountered OOM while pushing the heapBlock to the SLIST we must add it to the heapBlockList so we don't lose track of it.
                     if (!blockAddedToSList)
                     {
-#ifdef RECYCLER_TRACE
-                        this->GetRecycler()->PrintBlockStatus(this, heapBlock, _u("[**10**] finished SweepPartialReusePages, heapblock REUSED but OOM while adding to the SLIST."));
-#endif
                         //TODO: akatti: We should handle this gracefully and try to recover from this state.
                         AssertOrFailFastMsg(false, "OOM while adding a heap block to the SLIST during concurrent sweep.");
                     }
@@ -539,14 +535,12 @@ SmallNormalHeapBucketBase<TBlockType>::SweepPartialReusePages(RecyclerSweep& rec
                     if (this->AllowAllocationsDuringConcurrentSweep())
                     {
                         Assert(!this->IsAnyFinalizableBucket());
+                        Assert(!heapBlock->isPendingConcurrentSweepPrep);
                         bool blockAddedToSList = HeapBucketT<TBlockType>::PushHeapBlockToSList(this->allocableHeapBlockListHead, heapBlock);
 
                         // If we encountered OOM while pushing the heapBlock to the SLIST we must add it to the heapBlockList so we don't lose track of it.
                         if (!blockAddedToSList)
                         {
-#ifdef RECYCLER_TRACE
-                            this->GetRecycler()->PrintBlockStatus(this, heapBlock, _u("[**13**] finished SweepPartialReusePages, heapblock REUSED but OOM while adding to the SLIST."));
-#endif
                             //TODO: akatti: We should handle this gracefully and try to recover from this state.
                             AssertOrFailFastMsg(false, "OOM while adding a heap block to the SLIST during concurrent sweep.");
                         }

--- a/lib/Common/Memory/SmallNormalHeapBucket.h
+++ b/lib/Common/Memory/SmallNormalHeapBucket.h
@@ -44,7 +44,7 @@ protected:
     ~SmallNormalHeapBucketBase();
 
     template <class Fn>
-    static void SweepPartialReusePages(RecyclerSweep& recyclerSweep, TBlockType * heapBlockList,
+    void SweepPartialReusePages(RecyclerSweep& recyclerSweep, TBlockType * heapBlockList,
         TBlockType *& reuseBlocklist, TBlockType *&unusedBlockList, bool allocationsAllowedDuringConcurrentSweep, Fn callBack);
     void SweepPartialReusePages(RecyclerSweep& recyclerSweep);
     void FinishPartialCollect(RecyclerSweep * recyclerSweep);


### PR DESCRIPTION
If allocations are to be allowed to existing heap blocks during concurrent sweep, we set aside a few
heap blocks from the heapBlockList prior to beginning sweep. However, we eed to then go back and make sure these blocks also swept before this sweep finishes. In order to do this we clearly define concurrent sweep having 2 passes now. These passes existed before but were not distiguished as they would always start and finish in one go on the background thread. However, whenever allocations are allowed during concurrent sweep; the concurrent sweep will start Pass1 on the background thread, wait to finish Pass1 of the blocks we set aside to allocate from on the main thread and then go back to finish Pass2 for all heap blocks on the background thread. Note that, due to this need to finish Pass1 on the foreground thread the overall background sweep will now appear to take longer whenever we chose to do such a two-pass sweep.

The sequence of things we do to allow allocations during concurrent sweep is described below:
1. At the beginning of concurrrent sweep we decide if we will benefit from allowing allocations during concurrent sweep for any of the buckets. If there is at-least one bucket for which we think we will benefit we will turn on allocations during concurrent sweep. Once turned on we will attempt to enable allocations during concurrent sweep for all supported buckets (i.e. small/medium, normal/leaf, non-finalizable buckets.write barrrier bickets are supported as well.).
2. If allocations are turned on during concurrent sweep, we will see if there are any allocable blocks in the
heapBlockList after the nextAllocableBlockHead. If we find any such blocks, we move them to a SLIST that the allocator can pick these blocks from during sweep.
3. CollectionStateConcurrentSweepPass1: We will finish Pass1 of the sweep for all the remaining blocks (other than the ones we put in the SLIST in step 2 above) This will generally happen on the background thread unless we are forcing in-thread sweep. This state is now specifically identified as CollectionStateConcurrentSweepPass1.
4. CollectionStateConcurrentSweepPass1Wait: At this point we need to wait for all the blocks that we put in the SLIST to also finish the Pass1 of the sweep. This needs to happen on the foreground thread so we prevent the allocator from picking up the blocks from SLIST while we do this. This state is now identified as CollectionStateConcurrentSweepPass1Wait.
5. CollectionStateConcurrentSweepPass2: At this point we will do the actual sweeping of all the blocks that are not yet swept, for eaxample, any blocks that were put onto the pendingSweepList. As these blocks get swept we keep adding them to the SLIST again to allow allocators to allocate from them as soon as they are swept.
6. Before the Pass2 can finish we can call this concurrent sweep done we need to move all the blocks off of the SLIST so that normal allocations can begin after the sweep. This is the last step of the concurrent sweep.