### PR TITLE
Enable BailOnNoProfile when there is a try in the function

### DIFF
--- a/lib/Backend/BackwardPass.cpp
+++ b/lib/Backend/BackwardPass.cpp
@@ -7050,6 +7050,10 @@ BackwardPass::ProcessBailOnNoProfile(IR::Instr *instr, BasicBlock *block)
     {
         return false;
     }
+    if (this->currentRegion && (this->currentRegion->GetType() == RegionTypeCatch || this->currentRegion->GetType() == RegionTypeFinally))
+    {
+        return false;
+    }
 
     IR::Instr *curInstr = instr->m_prev;
 
@@ -7145,6 +7149,11 @@ BackwardPass::ProcessBailOnNoProfile(IR::Instr *instr, BasicBlock *block)
             continue;
         }
 
+        if (pred->GetFirstInstr()->AsLabelInstr()->GetRegion() != this->currentRegion)
+        {
+            break;
+        }
+
         // If all successors of this predecessor start with a BailOnNoProfile, we should be
         // okay to hoist this bail to the predecessor.
         FOREACH_SUCCESSOR_BLOCK(predSucc, pred)
@@ -7164,6 +7173,7 @@ BackwardPass::ProcessBailOnNoProfile(IR::Instr *instr, BasicBlock *block)
         {
             IR::Instr *predInstr = pred->GetLastInstr();
             IR::Instr *instrCopy = instr->Copy();
+
 
             if (predInstr->EndsBasicBlock())
             {

--- a/lib/Backend/IRBuilder.cpp
+++ b/lib/Backend/IRBuilder.cpp
@@ -99,7 +99,7 @@ IRBuilder::DoBailOnNoProfile()
         return false;
     }
 
-    if (!m_func->DoGlobOpt() || m_func->GetTopFunc()->HasTry())
+    if (!m_func->DoGlobOpt())
     {
         return false;
     }


### PR DESCRIPTION
- While moving BailOnNoProfile upwards in the flowgraph, make sure we don't cross regions
- Do no delete instructions in catch or finally in Backwards pass, we need these instructions to compute bytecodeUpwardExposedUses later on for the exception paths
