### PR TITLE
WASM: Restrict FunctionBodyReaderInfo usage

### DIFF
--- a/lib/WasmReader/WasmBinaryReader.h
+++ b/lib/WasmReader/WasmBinaryReader.h
@@ -56,6 +56,7 @@ namespace Wasm
         virtual bool IsCurrentFunctionCompleted() const override;
         virtual WasmOp ReadExpr() override;
         virtual void FunctionEnd() override;
+        virtual const uint32 EstimateCurrentFunctionBytecodeSize() const override;
 #if DBG_DUMP
         void PrintOps();
 #endif
@@ -112,7 +113,7 @@ namespace Wasm
         void CheckBytesLeft(uint32 bytesNeeded);
         bool EndOfFunc();
         bool EndOfModule();
-        DECLSPEC_NORETURN void ThrowDecodingError(const char16* msg, ...);
+        DECLSPEC_NORETURN void ThrowDecodingError(const char16* msg, ...) const;
         Wasm::WasmTypes::WasmType ReadWasmType(uint32& length);
 
         ArenaAllocator* m_alloc;

--- a/lib/WasmReader/WasmByteCodeGenerator.cpp
+++ b/lib/WasmReader/WasmByteCodeGenerator.cpp
@@ -480,9 +480,8 @@ WasmBytecodeGenerator::WasmBytecodeGenerator(Js::ScriptContext* scriptContext, W
     // Init reader to current func offset
     GetReader()->SeekToFunctionBody(m_funcInfo);
 
-    // Use binary size to estimate bytecode size
-    const uint32 astSize = readerInfo->m_funcInfo->m_readerInfo.size;
-    m_writer->InitData(&m_alloc, astSize);
+    const uint32 estimated = GetReader()->EstimateCurrentFunctionBytecodeSize();
+    m_writer->InitData(&m_alloc, estimated);
 }
 
 void WasmBytecodeGenerator::GenerateFunction()

--- a/lib/WasmReader/WasmCustomReader.cpp
+++ b/lib/WasmReader/WasmCustomReader.cpp
@@ -44,5 +44,12 @@ void WasmCustomReader::AddNode(WasmNode node)
     m_nodes.Add(node);
 }
 
+const uint32 WasmCustomReader::EstimateCurrentFunctionBytecodeSize() const
+{
+    uint32 count = min((uint32)m_nodes.Count(), (uint32)AutoSystemInfo::PageSize);
+    // On average each node takes between 3 - 7 bytes to encode
+    return count * 5;
+}
+
 };
 #endif

--- a/lib/WasmReader/WasmCustomReader.h
+++ b/lib/WasmReader/WasmCustomReader.h
@@ -15,6 +15,7 @@ namespace Wasm
         virtual bool IsCurrentFunctionCompleted() const override;
         virtual WasmOp ReadExpr() override;
         virtual void FunctionEnd() override;
+        virtual const uint32 EstimateCurrentFunctionBytecodeSize() const override;
 
         void AddNode(WasmNode node);
     private:

--- a/lib/WasmReader/WasmFunctionInfo.h
+++ b/lib/WasmReader/WasmFunctionInfo.h
@@ -9,10 +9,15 @@ namespace Wasm
 {
     class WasmReaderBase;
 
+    // All the Wasm function's share the same reader (except when using CustomReaders)
+    // This struct is used to remember where is this particular function in the buffer
     struct FunctionBodyReaderInfo
     {
-        Field(uint32) size;
-        Field(intptr_t) startOffset;
+        friend class WasmBinaryReader;
+        FunctionBodyReaderInfo(uint32 size = 0, size_t startOffset = 0): size(size), startOffset(startOffset) {}
+    private:
+        Field(uint32) size = 0;
+        Field(size_t) startOffset = 0;
     };
 
     class WasmFunctionInfo
@@ -45,7 +50,16 @@ namespace Wasm
         FieldNoBarrier(WasmImport*) importedFunctionReference;
 #endif
 
-        Field(FunctionBodyReaderInfo) m_readerInfo;
+        FunctionBodyReaderInfo GetReaderInfo() const
+        {
+            AssertMsg(!m_customReader, "ReaderInfo is not needed and invalid when a custom reader is present");
+            return m_readerInfo;
+        }
+        void SetReaderInfo(FunctionBodyReaderInfo info)
+        {
+            AssertMsg(!m_customReader, "ReaderInfo is not needed and invalid when a custom reader is present");
+            m_readerInfo = info;
+        }
     private:
 
         FieldNoBarrier(ArenaAllocator*) m_alloc;
@@ -58,5 +72,6 @@ namespace Wasm
         Field(const char16*) m_name;
         Field(uint32) m_nameLength;
         Field(uint32) m_number;
+        Field(FunctionBodyReaderInfo) m_readerInfo;
     };
 } // namespace Wasm

--- a/lib/WasmReader/WasmReaderBase.h
+++ b/lib/WasmReader/WasmReaderBase.h
@@ -14,6 +14,7 @@ namespace Wasm
         virtual bool IsCurrentFunctionCompleted() const = 0;
         virtual WasmOp ReadExpr() = 0;
         virtual void FunctionEnd() = 0;
+        virtual const uint32 EstimateCurrentFunctionBytecodeSize() const = 0;
         WasmNode m_currentNode;
     };
 } // namespace Wasm


### PR DESCRIPTION
Make sure the FunctionBodyReaderInfo is used only by WasmBinaryReader. 
Add interface to estimate bytecode size.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/4109)
<!-- Reviewable:end -->
