### PR TITLE
Reprofile before rejitting after BailOutOnNotNativeArray

### DIFF
--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -6674,6 +6674,11 @@ namespace Js
         executionState.TransitionToFullJitExecutionMode();
     }
 
+    void FunctionBody::ReprofileAndRejit()
+    {
+        executionState.ReprofileAndRejit();
+    }
+
     void FunctionBody::ReinitializeExecutionModeAndLimits()
     {
         // Do not remove wasCalledFromLoop 

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -2621,6 +2621,7 @@ namespace Js
         bool TryTransitionToJitExecutionMode();
         void TransitionToSimpleJitExecutionMode();
         void TransitionToFullJitExecutionMode();
+        void ReprofileAndRejit();
 
         void ReinitializeExecutionModeAndLimits();
 

--- a/lib/Runtime/Base/FunctionExecutionStateMachine.cpp
+++ b/lib/Runtime/Base/FunctionExecutionStateMachine.cpp
@@ -630,6 +630,27 @@ namespace Js
         SetExecutionState(ExecutionState::FullJit);
     }
 
+    void FunctionExecutionStateMachine::ReprofileAndRejit()
+    {
+        Assert(GetExecutionMode() == ExecutionMode::FullJit);
+
+        CommitExecutedIterations();
+
+        // Skip these states
+        interpreterLimit = 0;
+        autoProfilingInterpreter0Limit = 0;
+        profilingInterpreter0Limit = 0;
+        autoProfilingInterpreter1Limit = 0;
+        simpleJitLimit = 0;
+
+        // Rerun profiled interpreter once to get updated profiling data
+        profilingInterpreter1Limit = 1;
+        fullJitThreshold = profilingInterpreter1Limit;
+
+        VerifyExecutionModeLimits();
+        SetExecutionState(ExecutionState::ProfilingInterpreter1);
+    }
+
     void FunctionExecutionStateMachine::SetIsSpeculativeJitCandidate()
     {
         // This function is a candidate for speculative JIT. Ensure that it is profiled immediately by transitioning out of the

--- a/lib/Runtime/Base/FunctionExecutionStateMachine.h
+++ b/lib/Runtime/Base/FunctionExecutionStateMachine.h
@@ -45,6 +45,7 @@ namespace Js
         bool TryTransitionToJitExecutionMode();
         void TransitionToSimpleJitExecutionMode();
         void TransitionToFullJitExecutionMode();
+        void ReprofileAndRejit();
         
         // Debug functions
         void PrintLimits() const;

--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -715,6 +715,7 @@ public:
         void LogDataForFunctionBody(Js::FunctionBody *body, uint idx, bool isRejit);
 
         void LogRejit(Js::FunctionBody *body, RejitReason reason);
+        void LogReprofile(Js::FunctionBody *body, RejitReason reason);
         void LogBailout(Js::FunctionBody *body, uint kind);
 
         // Used to centrally collect stats for all function bodies.
@@ -725,6 +726,7 @@ public:
         BailoutStatsMap *bailoutReasonCountsCap;
         uint *rejitReasonCounts;
         uint *rejitReasonCountsCap;
+        uint *reprofileReasonCounts;
         void ClearBailoutReasonCountsMap();
         void ClearRejitReasonCountsArray();
 #endif


### PR DESCRIPTION
Reprofile before rejitting after BailOutOnNotNativeArray
This change modifies bailout functionality for NotNativeArray bailouts, which can fall into a condition where rejitting does not produce better code. By rerunning the function under the Profiled Interpreter, the next rejit can produce better code with more accurate profile data without turning of optimizations. Additional changes are made to track this with the appropriate -trace and -stats flags from the host.