### PR TITLE
ARM64: fix bail out double values

### DIFF
--- a/lib/Backend/arm64/LinearScanMD.cpp
+++ b/lib/Backend/arm64/LinearScanMD.cpp
@@ -357,21 +357,13 @@ LinearScanMD::GenerateBailInForGeneratorYield(IR::Instr * resumeLabelInstr, Bail
 
 uint LinearScanMD::GetRegisterSaveIndex(RegNum reg)
 {
-    if (RegTypes[reg] == TyFloat64)
-    {
-        Assert(reg+1 >= RegD0);
-        return (reg - RegD0) * 2 + RegD0;
-    }
-    else
-    {
-        return reg;
-    }
+    return reg;
 }
 
 // static
 RegNum LinearScanMD::GetRegisterFromSaveIndex(uint offset)
 {
-    return (RegNum)(offset >= RegD0 ? (offset - RegD0) / 2  + RegD0 : offset);
+    return (RegNum)offset;
 }
 
 RegNum LinearScanMD::GetParamReg(IR::SymOpnd *symOpnd, Func *func)


### PR DESCRIPTION
These were copied from the arm version, where integer regs require 4 bytes and double regs require 8, but on ARM64 they are the same size.
