### PR TITLE
Support for defer parse of object literal methods

### DIFF
--- a/lib/Parser/ParseFlags.h
+++ b/lib/Parser/ParseFlags.h
@@ -51,6 +51,7 @@ enum
                                      //  let/const in global scope instead of eval scope so that they can be preserved across console inputs
     fscrNoAsmJs = 1 << 25, // Disable generation of asm.js code
     fscrIsModuleCode = 1 << 26, // Current code should be parsed as a module body
-    fscrAll = (1 << 27) - 1
-};
 
+    fscrDeferredFncIsMethod = 1 << 27,
+    fscrAll = (1 << 28) - 1
+};

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -1605,7 +1605,8 @@ namespace Js
       paramScopeSlotArraySize(0),
       m_reparsed(false),
       m_isAsmJsFunction(false),
-      m_tag21(true)
+      m_tag21(true),
+      m_isMethod(false)
 #if DBG
       ,m_wasEverAsmjsMode(false)
       ,scopeObjectSize(0)
@@ -1655,6 +1656,7 @@ namespace Js
       m_isStaticNameFunction(proxy->GetIsStaticNameFunction()),
       m_reportedInParamCount(proxy->GetReportedInParamsCount()),
       m_reparsed(proxy->IsReparsed()),
+      m_isMethod(proxy->IsMethod()),
       m_tag21(true)
 #if DBG
       ,m_wasEverAsmjsMode(proxy->m_wasEverAsmjsMode)
@@ -2336,6 +2338,16 @@ namespace Js
                         // (not a function declaration statement).
                         grfscr |= fscrDeferredFncExpression;
                     }
+
+                    if (funcBody->IsMethod())
+                    {
+                        grfscr |= fscrDeferredFncIsMethod;
+                    }
+                    else
+                    {
+                        grfscr &= ~fscrDeferredFncIsMethod;
+                    }
+
                     if (!CONFIG_FLAG(DeferNested) || isDebugOrAsmJsReparse)
                     {
                         grfscr &= ~fscrDeferFncParse; // Disable deferred parsing if not DeferNested, or doing a debug/asm.js re-parse

--- a/lib/Runtime/Base/FunctionBody.h
+++ b/lib/Runtime/Base/FunctionBody.h
@@ -2025,6 +2025,8 @@ namespace Js
         LPCUTF8 GetStartOfDocument(const char16* reason = nullptr) const;
         bool IsReparsed() const { return m_reparsed; }
         void SetReparsed(bool set) { m_reparsed = set; }
+        bool IsMethod() const { return m_isMethod; }
+        void SetIsMethod(bool set) { m_isMethod = set; }
         bool GetExternalDisplaySourceName(BSTR* sourceName);
 
         void CleanupToReparse();
@@ -2159,10 +2161,9 @@ namespace Js
         FieldWithBarrier(bool) m_isEval : 1;              // Source code is in 'eval'
         FieldWithBarrier(bool) m_isDynamicFunction : 1;   // Source code is in 'Function'
         FieldWithBarrier(bool) m_hasImplicitArgIns : 1;
-        FieldWithBarrier(bool) m_dontInline : 1;            // Used by the JIT's inliner
-
-        // Indicates if the function has been reparsed for debug attach/detach scenario.
-        FieldWithBarrier(bool) m_reparsed : 1;
+        FieldWithBarrier(bool) m_dontInline : 1;          // Used by the JIT's inliner
+        FieldWithBarrier(bool) m_reparsed : 1;            // Indicates if the function has been reparsed for debug attach/detach scenario.
+        FieldWithBarrier(bool) m_isMethod : 1;            // Function is an object literal method
 
         // This field is not required for deferred parsing but because our thunks can't handle offsets > 128 bytes
         // yet, leaving this here for now. We can look at optimizing the function info and function proxy structures some

--- a/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeGenerator.cpp
@@ -1403,6 +1403,7 @@ FuncInfo * ByteCodeGenerator::StartBindFunction(const char16 *name, uint nameLen
         parseableFunctionInfo->deferredParseNextFunctionId = pnode->sxFnc.deferredParseNextFunctionId;
 #endif
         parseableFunctionInfo->SetIsDeclaration(pnode->sxFnc.IsDeclaration() != 0);
+        parseableFunctionInfo->SetIsMethod(pnode->sxFnc.IsMethod() != 0);
         parseableFunctionInfo->SetIsAccessor(pnode->sxFnc.IsAccessor() != 0);
         if (pnode->sxFnc.IsAccessor())
         {

--- a/test/es6/DeferParseMethods.js
+++ b/test/es6/DeferParseMethods.js
@@ -1,0 +1,161 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+
+var tests = [
+    {
+        name: "Various object literal method deferral",
+        body: function () {
+            var sym = Symbol();
+            let out = 'nothing';
+            var obj = {
+                get a() { return 'get a'; },
+                set a(v) { out = 'set a'; },
+                b() { return 'b'; },
+                ['c']() { return 'c'; },
+                [sym]() { return 'sym'; },
+                async d() { return 'd'; },
+                *e() { yield 'e'; },
+                get ['f']() { return 'get f'; },
+                set ['f'](v) { out = 'set f'; },
+                async ['g']() { return 'g'; },
+                *['h']() { yield 'h'; },
+                async async() { return 'async async'; },
+            }
+            var obj2 = {
+                async() { return 'async'; }
+            }
+            var obj3 = {
+                get async() { return 'get async'; },
+                set async(v) { out = 'set async'; }
+            }
+            var obj4 = {
+                *async() { yield 'generator async'; }
+            }
+
+            assert.areEqual('get a', obj.a, "Simple named getter");
+            obj.a = 123;
+            assert.areEqual('set a', out, "Simple named setter");
+            assert.areEqual('b', obj.b(), "Simple method");
+
+            assert.areEqual('c', obj.c(), "Method with computed property name");
+            assert.areEqual('sym', obj[sym](), "Method with computed property name (key is not string)");
+
+            assert.isTrue(obj.d() instanceof Promise, "Async method");
+
+            assert.areEqual('e', obj.e().next().value, "Generator method");
+
+            assert.areEqual('get f', obj.f, "Getter method with computed name");
+            obj.f = 123;
+            assert.areEqual('set f', out, "Setter method with computed name");
+
+            assert.isTrue(obj.g() instanceof Promise, "Async method with computed name");
+
+            assert.areEqual('h', obj.h().next().value, "Generator method with computed name");
+            
+            assert.isTrue(obj.async() instanceof Promise, "Async method named async");
+            assert.areEqual('async', obj2.async(), "Method named async");
+            assert.areEqual('get async', obj3.async, "Getter named async");
+            obj3.async = 123;
+            assert.areEqual('set async', out, "Setter named async");
+            assert.areEqual('generator async', obj4.async().next().value, "Generator method named async");
+        }
+    },
+    {
+        name: "Uncommon object literal method name types",
+        body: function() {
+            var out = 'nothing';
+            var obj = {
+                "s1"() { return "s1"; },
+                async "s2"() { return "s2"; },
+                * "s3"() { return "s3"; },
+                get "s4"() { return "s4"; },
+                set "s4"(v) { out = "s4"; },
+
+                0.1() { return 0.1; },
+                async 0.2() { return 0.2; },
+                * 0.3() { return 0.3; },
+                get 0.4() { return 0.4; },
+                set 0.4(v) { out = 0.4; },
+
+                123() { return 123; },
+                async 456() { return 456; },
+                * 789() { yield 789; },
+                get 123456() { return 123456; },
+                set 123456(v) { out = 123456; },
+
+                while() { return "while"; },
+                async else() { return "else"; },
+                * if() { return "if"; },
+                get catch() { return "catch"; },
+                set catch(v) { out = "catch"; },
+            }
+
+            assert.areEqual('s1', obj.s1(), "Method with string name");
+            assert.areEqual(0.1, obj[0.1](), "Method with float name");
+            assert.areEqual(123, obj[123](), "Method with numeric name");
+            assert.areEqual('while', obj.while(), "Method with keyword name");
+            
+            assert.isTrue(obj.s2() instanceof Promise, "Async method with string name");
+            assert.isTrue(obj[0.2]() instanceof Promise, "Async method with float name");
+            assert.isTrue(obj[456]() instanceof Promise, "Async method with numeric name");
+            assert.isTrue(obj.else() instanceof Promise, "Async method with keyword name");
+
+            assert.areEqual('s3', obj.s3().next().value, "Generator method with string name");
+            assert.areEqual(0.3, obj[0.3]().next().value, "Generator method with float name");
+            assert.areEqual(789, obj[789]().next().value, "Generator method with numeric name");
+            assert.areEqual('if', obj.if().next().value, "Generator method with keyword name");
+
+            assert.areEqual('s4', obj.s4, "Getter method with string name");
+            assert.areEqual(0.4, obj[0.4], "Getter method with float name");
+            assert.areEqual(123456, obj[123456], "Getter method with numeric name");
+            assert.areEqual('catch', obj.catch, "Getter method with keyword name");
+
+            obj.s4 = 123
+            assert.areEqual('s4', out, "Setter method with string name");
+            obj[0.4] = 123
+            assert.areEqual(0.4, out, "Setter method with float name");
+            obj[123456] = 123
+            assert.areEqual(123456, out, "Setter method with numeric name");
+            obj.catch = 123
+            assert.areEqual('catch', out, "Setter method with keyword name");
+        }
+    },
+    {
+        name: "Regular function nested in a deferred method",
+        body: function() {
+            var obj = {
+                m() {
+                    function foo() { return 'foo'; }
+                    return foo();
+                }
+            }
+
+            assert.areEqual('foo', obj.m(), "Regular function nested in a deferred method should not be parsed as a method");
+        }
+    },
+    {
+        name: "Method with 'super' capture",
+        body: function() {
+            var obj = {
+                m() { return () => super.bar(); }
+            }
+            Object.setPrototypeOf(obj, { bar() { return this; } });
+            
+            assert.areEqual(obj, obj.m()(), "Method should call lambda should call super method should return this captured from obj.m");
+        }
+    },
+    {
+        name: "Async lambda with parens",
+        body: function() {
+            var a = async() => { };
+            
+            assert.isTrue(a() instanceof Promise, "Async lambda with parens around formal parameters")
+        }
+    }
+]
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/es6/rlexe.xml
+++ b/test/es6/rlexe.xml
@@ -1479,4 +1479,40 @@
     <tags>BugFix</tags>
   </default>
 </test>
+<test>
+  <default>
+    <files>DeferParseLambda.js</files>
+    <compile-flags>-off:deferparse -args summary -endargs</compile-flags>
+  </default>
+</test>
+<test>
+  <default>
+    <files>DeferParseLambda.js</files>
+    <compile-flags>-off:deferparse -args summary -endargs -deferparse</compile-flags>
+  </default>
+</test>
+<test>
+  <default>
+    <files>DeferParseLambda.js</files>
+    <compile-flags>-off:deferparse -args summary -endargs -deferparse -forceundodefer</compile-flags>
+  </default>
+</test>
+<test>
+  <default>
+    <files>DeferParseMethods.js</files>
+    <compile-flags>-off:deferparse -args summary -endargs</compile-flags>
+  </default>
+</test>
+<test>
+  <default>
+    <files>DeferParseMethods.js</files>
+    <compile-flags>-off:deferparse -args summary -endargs -deferparse</compile-flags>
+  </default>
+</test>
+<test>
+  <default>
+    <files>DeferParseMethods.js</files>
+    <compile-flags>-off:deferparse -args summary -endargs -deferparse -forceundodefer</compile-flags>
+  </default>
+</test>
 </regress-exe>


### PR DESCRIPTION
This is mostly a straightforward modification to the defer-parse methods in the parser to enable them to know how to handle the object literal method grammar.

Communicate the fact that the deferred function is a method via a parser flag - `fscrDeferredFncIsMethod`.
