### PR TITLE
Remove dependency on GetInstalledPhysicalMemory

### DIFF
--- a/lib/Common/PlatformAgnostic/SystemInfo.h
+++ b/lib/Common/PlatformAgnostic/SystemInfo.h
@@ -8,28 +8,7 @@ namespace PlatformAgnostic
 {
     class SystemInfo
     {
-
-        class PlatformData
-        {
-            public:
-            size_t totalRam;
-
-            PlatformData();
-        };
-        static PlatformData data;
     public:
-
-        static bool GetTotalRam(size_t *totalRam)
-        {
-            if (SystemInfo::data.totalRam == 0)
-            {
-                return false;
-            }
-
-            *totalRam = SystemInfo::data.totalRam;
-            return true;
-        }
-
         static bool GetMaxVirtualMemory(size_t *totalAS);
 
 #define SET_BINARY_PATH_ERROR_MESSAGE(path, msg) \

--- a/lib/Runtime/PlatformAgnostic/Platform/Linux/SystemInfo.cpp
+++ b/lib/Runtime/PlatformAgnostic/Platform/Linux/SystemInfo.cpp
@@ -5,26 +5,10 @@
 
 #include "Common.h"
 #include "ChakraPlatform.h"
-#include <sys/sysinfo.h>
 #include <sys/resource.h>
 
 namespace PlatformAgnostic
 {
-    SystemInfo::PlatformData SystemInfo::data;
-
-    SystemInfo::PlatformData::PlatformData()
-    {
-        struct sysinfo systemInfo;
-        if (sysinfo(&systemInfo) == -1)
-        {
-            totalRam = 0;
-        }
-        else
-        {
-            totalRam = systemInfo.totalram;
-        }
-    }
-
     bool SystemInfo::GetMaxVirtualMemory(size_t *totalAS)
     {
         struct rlimit limit;

--- a/lib/Runtime/PlatformAgnostic/Platform/Unix/SystemInfo.cpp
+++ b/lib/Runtime/PlatformAgnostic/Platform/Unix/SystemInfo.cpp
@@ -9,20 +9,6 @@
 
 namespace PlatformAgnostic
 {
-    SystemInfo::PlatformData SystemInfo::data;
-
-    SystemInfo::PlatformData::PlatformData()
-    {
-        // Get Total Ram
-        int totalRamHW [] = { CTL_HW, HW_MEMSIZE };
-
-        size_t length = sizeof(size_t);
-        if(sysctl(totalRamHW, 2, &totalRam, &length, NULL, 0) == -1)
-        {
-            totalRam = 0;
-        }
-    }
-
     bool SystemInfo::GetMaxVirtualMemory(size_t *totalAS)
     {
         struct rlimit limit;

--- a/lib/Runtime/PlatformAgnostic/Platform/Windows/SystemInfo.cpp
+++ b/lib/Runtime/PlatformAgnostic/Platform/Windows/SystemInfo.cpp
@@ -9,17 +9,6 @@
 
 namespace PlatformAgnostic
 {
-    SystemInfo::PlatformData SystemInfo::data;
-
-    SystemInfo::PlatformData::PlatformData()
-    {
-        ULONGLONG ram;
-        if (GetPhysicallyInstalledSystemMemory(&ram) == TRUE)
-        {
-            totalRam = static_cast<size_t>(ram) * 1024;
-        }
-    }
-
     bool SystemInfo::GetMaxVirtualMemory(size_t *totalAS)
     {
         SYSTEM_INFO info;


### PR DESCRIPTION
The mentioned API is not safe for use in UWPs, and was not actually being
used anyway. Removed the PlatformAgnostic API that used this API.

Fixes: OSG 14471777