### PR TITLE
ccrobot: re-enable randombug.js test

### DIFF
--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -58,8 +58,6 @@
       <files>randombug.js</files>
       <baseline>randombug.baseline</baseline>
       <compile-flags>-ExtendedErrorStackForTestHost</compile-flags>
-      <!-- todo: enable this back (ccrobot) once #2780 is fixed -->
-      <tags>exclude_ccrobot</tags>
     </default>
   </test>
   <test>


### PR DESCRIPTION
Enable a test that was previously disabled on ccrobot. #3536 