### PR TITLE
ARM64: fix indir float crash

### DIFF
--- a/lib/Backend/arm64/LowerMD.cpp
+++ b/lib/Backend/arm64/LowerMD.cpp
@@ -5292,11 +5292,6 @@ LowererMD::EmitLoadFloat(IR::Opnd *dst, IR::Opnd *src, IR::Instr *insertInstr, I
     Assert(dst->GetType() == TyFloat64 || TyFloat32);
     Assert(src->IsRegOpnd());
 
-    if (dst->IsIndirOpnd())
-    {
-        LegalizeMD::LegalizeDst(insertInstr, false);
-    }
-
     labelDone = EmitLoadFloatCommon(dst, src, insertInstr, true);
 
     if (labelDone == nullptr)


### PR DESCRIPTION
The block a modified left over from ARM, and was attempting to legalize it with a pre-lowered op code. Float Indirs need to be legalized, but in this case it will be legalized with the FMOVs inserted by EmitLoadFloatCommon.
