### PR TITLE
Fixing a warning on converting CallFlags value to boolean

### DIFF
--- a/lib/Runtime/Base/CallInfo.h
+++ b/lib/Runtime/Base/CallInfo.h
@@ -94,7 +94,7 @@ namespace Js
 
         static bool HasNewTarget(CallFlags flags)
         {
-            return flags & CallFlags_NewTarget;
+            return (flags & CallFlags_NewTarget) == CallFlags_NewTarget;
         }
 
         // New target value is passed as an extra argument which is nto included in the Count

--- a/lib/Runtime/Language/Arguments.h
+++ b/lib/Runtime/Language/Arguments.h
@@ -200,7 +200,7 @@ namespace Js
 
         bool IsNewCall() const
         {
-            return Info.Flags & CallFlags_New;
+            return (Info.Flags & CallFlags_New) == CallFlags_New;
         }
 
         bool HasNewTarget() const

--- a/lib/Runtime/Language/JavascriptOperators.cpp
+++ b/lib/Runtime/Language/JavascriptOperators.cpp
@@ -1426,16 +1426,16 @@ CommonNumber:
         return JavascriptOperators::IsArray(instance);
     }
 
-    BOOL JavascriptOperators::IsConstructorSuperCall(Arguments args)
+    bool JavascriptOperators::IsConstructorSuperCall(Arguments args)
     {
         Var newTarget = args.GetNewTarget();
         return args.IsNewCall() && newTarget != nullptr
                 && !JavascriptOperators::IsUndefined(newTarget);
     }
 
-    BOOL JavascriptOperators::GetAndAssertIsConstructorSuperCall(Arguments args)
+    bool JavascriptOperators::GetAndAssertIsConstructorSuperCall(Arguments args)
     {
-        BOOL isCtorSuperCall = JavascriptOperators::IsConstructorSuperCall(args);
+        bool isCtorSuperCall = JavascriptOperators::IsConstructorSuperCall(args);
         Assert(isCtorSuperCall || !args.IsNewCall()
                 || args[0] == nullptr || JavascriptOperators::GetTypeId(args[0]) == TypeIds_HostDispatch);
         return isCtorSuperCall;

--- a/lib/Runtime/Language/JavascriptOperators.h
+++ b/lib/Runtime/Language/JavascriptOperators.h
@@ -106,8 +106,8 @@ namespace Js
         static BOOL IsArray(_In_ Var instanceVar);
         static BOOL IsConstructor(Var instanceVar);
         static BOOL IsConcatSpreadable(Var instanceVar);
-        static BOOL IsConstructorSuperCall(Arguments args);
-        static BOOL GetAndAssertIsConstructorSuperCall(Arguments args);
+        static bool IsConstructorSuperCall(Arguments args);
+        static bool GetAndAssertIsConstructorSuperCall(Arguments args);
         static RecyclableObject* ToObject(Var aRight,ScriptContext* scriptContext);
         static Var ToWithObject(Var aRight, ScriptContext* scriptContext);
         static Var OP_LdCustomSpreadIteratorList(Var aRight, ScriptContext* scriptContext);


### PR DESCRIPTION
Fixing a warning on converting CallFlags value to boolean
