### PR TITLE
Add two flags to rl to limit extraneous output

### DIFF
--- a/bin/rl/rl.cpp
+++ b/bin/rl/rl.cpp
@@ -367,6 +367,8 @@ unsigned NumberOfThreads = 0;
 TestList DirList, ExcludeDirList;
 BOOL FUserSpecifiedFiles = FALSE;
 BOOL FUserSpecifiedDirs = TRUE;
+BOOL FNoProgramOutput = FALSE;
+BOOL FOnlyAssertOutput = FALSE;
 BOOL FExcludeDirs = FALSE;
 BOOL FGenLst = FALSE;
 char *ResumeDir, *MatchDir;
@@ -2875,6 +2877,16 @@ ParseArg(
             s = ComplainIfNoArg(arg, s);
             AddTagToTagsList(&DirectoryTagsList, &DirectoryTagsLast, s, strcmp(&arg[1], "dirtags") == 0);
 
+            break;
+         }
+
+         if (!_stricmp(&arg[1], "noprogramoutput")) {
+            FNoProgramOutput = TRUE;
+            break;
+         }
+
+         if (!_stricmp(&arg[1], "onlyassertoutput")) {
+            FOnlyAssertOutput = TRUE;
             break;
          }
 

--- a/bin/rl/rl.h
+++ b/bin/rl/rl.h
@@ -870,6 +870,8 @@ extern BOOL FSyncEnumDirs;
 extern BOOL FNogpfnt;
 extern BOOL FTest;
 extern BOOL FAppendTestNameToExtraCCFlags;
+extern BOOL FNoProgramOutput;
+extern BOOL FOnlyAssertOutput;
 
 #define MAXOPTIONS 60
 extern const char *OptFlags[MAXOPTIONS + 1], *PogoOptFlags[MAXOPTIONS + 1];

--- a/bin/rl/rlrun.cpp
+++ b/bin/rl/rlrun.cpp
@@ -141,7 +141,7 @@ void
     else {
         int fd = _fileno(fp);
         struct _stat64 fileStats;
-        if(fd != -1 && _fstat64(fd, &fileStats) != -1)
+        if (fd != -1 && _fstat64(fd, &fileStats) != -1)
         {
             char creationTime[256];
             char accessTime[256];
@@ -151,7 +151,7 @@ void
             _ctime64_s(creationTime, &fileStats.st_ctime);
             _ctime64_s(accessTime, &fileStats.st_atime);
             auto stripNewline = [](char *buf) {
-                if(char *ptr = strchr(buf, '\n'))
+                if (char *ptr = strchr(buf, '\n'))
                     *ptr = '\0';
             };
             stripNewline(creationTime);
@@ -160,17 +160,35 @@ void
 
             LogOut("ERROR: name of output file: %s; size: %I64d; creation: %s, last access: %s, now: %s", path, fileStats.st_size, creationTime, accessTime, currTime);
         }
-        LogOut("ERROR: bad output file follows ============");
-        while (fgets(buf, BUFFER_SIZE, fp) != NULL) {
-            // Strip the newline, since LogOut adds one
-            p = strchr(buf, '\n');
-            if (p != NULL) {
-                *p = '\0';
+        if (!FNoProgramOutput)
+        {
+            bool printlines = !FOnlyAssertOutput;
+            if (printlines)
+            {
+                LogOut("ERROR: bad output file follows ============");
             }
-            LogOut("%s", buf);
+            while (fgets(buf, BUFFER_SIZE, fp) != NULL) {
+                // Strip the newline, since LogOut adds one
+                p = strchr(buf, '\n');
+                if (p != NULL) {
+                    *p = '\0';
+                }
+                if (!printlines && strlen(buf) > 8 && buf[0] == 'A' && buf[1] == 'S' && buf[2] == 'S' && buf[3] == 'E' && buf[4] == 'R' && buf[5] == 'T')
+                {
+                    printlines = true;
+                    LogOut("ERROR: bad output file follows ============");
+                }
+                if (printlines)
+                {
+                    LogOut("%s", buf);
+                }
+            }
+            if (printlines)
+            {
+                LogOut("ERROR: end of bad output file  ============");
+            }
         }
         fclose(fp);
-        LogOut("ERROR: end of bad output file  ============");
     }
 }
 

--- a/test/runtests.cmd
+++ b/test/runtests.cmd
@@ -177,6 +177,8 @@ goto :main
   if /i "%1" == "-binaryRoot"       set _binaryRoot=%~f2&                                       goto :ArgOkShift2
   if /i "%1" == "-variants"         set _Variants=%~2&                                          goto :ArgOkShift2
   if /i "%1" == "-cleanupall"       set _CleanUpAll=1&                                          goto :ArgOk
+  if /i "%1" == "-noprogramoutput"  set _NoProgramOutput=-noprogramoutput&                      goto :ArgOk
+  if /i "%1" == "-onlyassertoutput"  set _OnlyAssertOutput=-onlyassertoutput&                   goto :ArgOk
 
   ::Extra ch.exe command line flags
   if /i "%1" == "-ExtraHostFlags"   set _ExtraHostFlags=%~2&                                    goto :ArgOkShift2
@@ -272,6 +274,8 @@ goto :main
   set _ExtraHostFlags=
   set _DumpOnCrash=
   set _CrashOnException=
+  set _NoProgramOutput=
+  set _OnlyAssertOutput=
 
   goto :eof
 
@@ -476,6 +480,8 @@ goto :main
   set _rlArgs=%_rlArgs% %_exclude_nodeferparse%
   set _rlArgs=%_rlArgs% %_exclude_forceundodefer%
   set _rlArgs=%_rlArgs% %_ExcludeApolloTests%
+  set _rlArgs=%_rlArgs% %_NoProgramOutput%
+  set _rlArgs=%_rlArgs% %_OnlyAssertOutput%
   set _rlArgs=%_rlArgs% %_quiet%
   set _rlArgs=%_rlArgs% -exe
   set _rlArgs=%_rlArgs% %EXTRA_RL_FLAGS%


### PR DESCRIPTION
These flags have been useful in large runs on arm64 where we have failures in several baseline-differing tests that produce copious output.