### PR TITLE
node-chakracore: fix osx missing reference for PerfTrace

### DIFF
--- a/lib/Common/CommonDefines.h
+++ b/lib/Common/CommonDefines.h
@@ -302,20 +302,13 @@
 #define DELAYLOAD_SET_CFG_TARGET 1
 #endif
 
-// Configure whether we configure a signal handler
-// to produce perf-<pid>.map files
-#ifndef PERFMAP_TRACE_ENABLED
-#define PERFMAP_TRACE_ENABLED 0
-#endif
 #ifndef PERFMAP_SIGNAL
 #define PERFMAP_SIGNAL SIGUSR2
 #endif
 
 #ifndef NTBUILD
 #define DELAYLOAD_SECTIONAPI 1
-#endif
-
-#ifdef NTBUILD
+#else
 #define ENABLE_PROJECTION
 #define ENABLE_FOUNDATION_OBJECT
 #define ENABLE_EXPERIMENTAL_FLAGS

--- a/lib/Runtime/PlatformAgnostic/ChakraPlatform.h
+++ b/lib/Runtime/PlatformAgnostic/ChakraPlatform.h
@@ -6,7 +6,16 @@
 
 #include "UnicodeText.h"
 #include "EventTrace.h"
+
+// Configure whether we configure a signal handler
+// to produce perf-<pid>.map files
+#ifndef PERFMAP_TRACE_ENABLED
+#define PERFMAP_TRACE_ENABLED 0
+#endif
+
+#if PERFMAP_TRACE_ENABLED
 #include "PerfTrace.h"
+#endif
 
 #include "PlatformAgnostic/DateTime.h"
 #include "PlatformAgnostic/AssemblyCommon.h"

--- a/lib/Runtime/PlatformAgnostic/Platform/CMakeLists.txt
+++ b/lib/Runtime/PlatformAgnostic/Platform/CMakeLists.txt
@@ -8,7 +8,6 @@ set(PL_SOURCE_FILES
   Linux/UnicodeText.ICU.cpp
   Linux/NumbersUtility.cpp
   Linux/Thread.cpp
-  Linux/PerfTrace.cpp
   Common/Trace.cpp
   Common/SystemInfo.Common.cpp
   )
@@ -16,11 +15,13 @@ set(PL_SOURCE_FILES
 if(CC_TARGET_OS_ANDROID OR CC_TARGET_OS_LINUX)
 set(PL_SOURCE_FILES ${PL_SOURCE_FILES}
   Linux/SystemInfo.cpp
+  Linux/PerfTrace.cpp
   )
 elseif(CC_TARGET_OS_OSX)
 set(PL_SOURCE_FILES ${PL_SOURCE_FILES}
   Unix/AssemblyCommon.cpp
   Unix/SystemInfo.cpp
+# Linux/PerfTrace.cpp # TODO : implement for OSX?
   )
 endif()
 

--- a/lib/Runtime/PlatformAgnostic/Platform/Linux/PerfTrace.cpp
+++ b/lib/Runtime/PlatformAgnostic/Platform/Linux/PerfTrace.cpp
@@ -12,6 +12,7 @@
 
 using namespace Js;
 
+#if PERFMAP_TRACE_ENABLED
 //
 //  Handle the SIGUSR2 signal by setting a flag
 //  indicating that we should call WritePerfMap later on
@@ -25,13 +26,12 @@ namespace PlatformAgnostic
 {
 
 volatile sig_atomic_t PerfTrace::mapsRequested = 0;
-  
+
 //
-// Registers a signal handler for SIGUSR2 
+// Registers a signal handler for SIGUSR2
 //
 void PerfTrace::Register()
 {
-#if PERFMAP_TRACE_ENABLED
     struct sigaction newAction = {0};
     newAction.sa_flags = SA_RESTART;
     newAction.sa_handler = handle_signal;
@@ -43,7 +43,6 @@ void PerfTrace::Register()
     {
         AssertMsg(errno, "PerfTrace::Register: sigaction() call failed\n");
     }
-#endif
 }
 
 void  PerfTrace::WritePerfMap()
@@ -150,3 +149,4 @@ void  PerfTrace::WritePerfMap()
 
 }
 
+#endif // PERFMAP_TRACE_ENABLED

--- a/lib/Runtime/PlatformAgnostic/Platform/Windows/PerfTrace.cpp
+++ b/lib/Runtime/PlatformAgnostic/Platform/Windows/PerfTrace.cpp
@@ -6,6 +6,7 @@
 
 #include "ChakraPlatform.h"
 
+#if PERFMAP_TRACE_ENABLED
 
 using namespace Js;
 
@@ -13,7 +14,7 @@ namespace PlatformAgnostic
 {
 
 volatile sig_atomic_t PerfTrace::mapsRequested = 0;
-  
+
 void PerfTrace::Register()
 {
     // TODO: Implement this on Windows?
@@ -25,3 +26,5 @@ void  PerfTrace::WritePerfMap()
 }
 
 }
+
+#endif // PERFMAP_TRACE_ENABLED


### PR DESCRIPTION
PerfTrace creates missing type references on OSX. Considering the fact current
PerfTrace is targeting Linux, removing it from OSX build and adding a
TODO note instead