### PR TITLE
string: Share buffer when it's possible

### DIFF
--- a/lib/Backend/JITRecyclableObject.h
+++ b/lib/Backend/JITRecyclableObject.h
@@ -70,6 +70,11 @@ public:
 
         return reinterpret_cast<JITJavascriptString*>(var);
     }
+
+    static void ShareStringBuffer(JITJavascriptString * leftString, JITJavascriptString * rightString)
+    {
+        // no-op
+    }
 };
 
 class JITJavascriptNumber : JITRecyclableObject

--- a/lib/Runtime/Library/ConcatString.cpp
+++ b/lib/Runtime/Library/ConcatString.cpp
@@ -130,8 +130,7 @@ namespace Js
         scriptContext->GetOrAddPropertyRecord(this->GetSz(), static_cast<int>(this->GetLength()),
             (Js::PropertyRecord const **)&propertyRecord);
 
-        this->propertyString = scriptContext->GetPropertyString(propertyRecord->GetPropertyId());
-        this->SetBuffer(this->propertyString->GetString()); // use the same buffer
+        this->SetPropertyString(scriptContext->GetPropertyString(propertyRecord->GetPropertyId()));
 
         return this->propertyString;
     }
@@ -139,6 +138,19 @@ namespace Js
     void LiteralStringWithPropertyStringPtr::SetPropertyString(PropertyString * propStr)
     {
         this->propertyString = propStr;
+        if (propStr != nullptr)
+        {
+            if (propStr->GetString() == propStr->GetPropertyRecord()->GetBuffer())
+            {
+                // propertyString using buffer from propertyRecord, use ours.
+                propStr->SetBuffer(this->GetString());
+            }
+            else
+            {
+                // propertyString using another non propertyRecord buffer. Use it here too.
+                this->SetBuffer(propStr->GetString());
+            }
+        }
     }
 
     /* static */

--- a/lib/Runtime/Library/JavascriptString.h
+++ b/lib/Runtime/Library/JavascriptString.h
@@ -158,15 +158,14 @@ namespace Js
         JavascriptString(StaticType * type);
         JavascriptString(StaticType * type, charcount_t charLength, const char16* szValue);
         DEFINE_VTABLE_CTOR_ABSTRACT(JavascriptString, RecyclableObject);
-
-        void SetLength(charcount_t newLength);
-        void SetBuffer(const char16* buffer);
         bool IsValidIndexValue(charcount_t idx) const;
 
         static charcount_t SafeSzSize(charcount_t length); // Throws on overflow
         charcount_t SafeSzSize() const; // Throws on overflow
 
     public:
+        void SetLength(charcount_t newLength);
+        void SetBuffer(const char16* buffer);
         bool IsFinalized() const { return this->UnsafeGetBuffer() != NULL; }
 
     public:
@@ -311,6 +310,9 @@ namespace Js
         static charcount_t GetBufferLength(const char16 *content, int charLengthOrMinusOne);
         static bool IsASCII7BitChar(char16 ch) { return ch < 0x0080; }
         static char ToASCII7BitChar(char16 ch) { Assert(IsASCII7BitChar(ch)); return static_cast<char>(ch); }
+
+        // Share the string buffer, if both left and right strings are hosting the same content.
+        static void ShareStringBuffer(JavascriptString * leftString, JavascriptString * rightString);
 
     private:
         static int IndexOf(ArgumentReader& args, ScriptContext* scriptContext, const char16* apiNameForErrorMsg, bool isRegExpAnAllowedArg);


### PR DESCRIPTION
notes

- StringEquals is hot on acme-air and with this PR, better numbers in `lptr == rptr` condition
- perf change is under the acme-air noise.~~Besides, this change may affect other micro benchmarks negatively. I will share micro benchmark results separately~~ (removed that update)
