### PR TITLE
write barrier related fixes

### DIFF
--- a/lib/Backend/Opnd.cpp
+++ b/lib/Backend/Opnd.cpp
@@ -103,12 +103,6 @@ Opnd::IsWriteBarrierTriggerableValue()
         return false;
     }
 
-    // If this operand is known address, then it doesn't need a write barrier, the address is either not a GC address or is pinned
-    if (this->IsAddrOpnd() && this->AsAddrOpnd()->GetAddrOpndKind() == AddrOpndKindDynamicVar)
-    {
-        return false;
-    }
-
     if (TySize[this->GetType()] != sizeof(void*))
     {
         return false;
@@ -120,6 +114,12 @@ Opnd::IsWriteBarrierTriggerableValue()
         return true; // No further optimization if we are in verification
     }
 #endif
+
+    // If this operand is known address, then it doesn't need a write barrier, the address is either not a GC address or is pinned
+    if (this->IsAddrOpnd() && this->AsAddrOpnd()->GetAddrOpndKind() == AddrOpndKindDynamicVar)
+    {
+        return false;
+    }
 
     // If its null/boolean/undefined, we don't need a write barrier since the javascript library will keep those guys alive
     return !(this->GetValueType().IsBoolean() || this->GetValueType().IsNull() || this->GetValueType().IsUndefined());

--- a/lib/Common/CommonDefines.h
+++ b/lib/Common/CommonDefines.h
@@ -240,7 +240,7 @@
 #error "Background page zeroing can't be turned on if freeing pages in the background is disabled"
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32) && !GLOBAL_ENABLE_WRITE_BARRIER
 #define RECYCLER_VISITED_HOST
 #endif
 

--- a/lib/JITIDL/JITTypes.h
+++ b/lib/JITIDL/JITTypes.h
@@ -126,9 +126,9 @@ typedef struct EquivalentTypeSetIDL
 
 typedef struct FixedFieldIDL
 {
+    IDL_Field(unsigned short) valueType;
     IDL_Field(boolean) nextHasSameFixedField;
     IDL_Field(boolean) isClassCtor;
-    IDL_Field(unsigned short) valueType;
     IDL_Field(unsigned int) localFuncId;
     IDL_Field(TypeIDL) type;
     IDL_Field(CHAKRA_WB_PTR) fieldValue;

--- a/lib/Runtime/Language/InlineCache.h
+++ b/lib/Runtime/Language/InlineCache.h
@@ -364,6 +364,7 @@ namespace Js
 
     class PolymorphicInlineCache _ABSTRACT : public FinalizableObject
     {
+        DECLARE_RECYCLER_VERIFY_MARK_FRIEND()
 #ifdef INLINE_CACHE_STATS
         friend class Js::ScriptContext;
 #endif

--- a/lib/Runtime/Library/JSONStringifier.h
+++ b/lib/Runtime/Library/JSONStringifier.h
@@ -37,8 +37,13 @@ private:
 
     struct PropertyListElement
     {
-        PropertyRecord const* propertyRecord;
-        JavascriptString* propertyName;
+        Field(PropertyRecord const*) propertyRecord;
+        Field(JavascriptString*) propertyName;
+
+        PropertyListElement() {}
+        PropertyListElement(const PropertyListElement& other)
+            : propertyRecord(other.propertyRecord), propertyName(other.propertyName)
+        {}
     };
 
     typedef SList<PropertyListElement, Recycler> PropertyList;

--- a/lib/Runtime/Library/LazyJSONString.h
+++ b/lib/Runtime/Library/LazyJSONString.h
@@ -50,7 +50,9 @@ struct JSONProperty
     }
     JSONProperty(const JSONProperty& other)
     {
-        memcpy_s(this, sizeof(JSONProperty), &other, sizeof(JSONProperty));
+        // Copy the full struct and use "Field(Var)" to identify write barrier
+        // policy as the struct contains Vars
+        CopyArray<JSONProperty, Field(Var)>(this, 1, &other, 1);
     }
 };
 

--- a/lib/Runtime/Library/VerifyMarkFalseReference.cpp
+++ b/lib/Runtime/Library/VerifyMarkFalseReference.cpp
@@ -56,6 +56,20 @@ bool IsLikelyRuntimeFalseReference(char* objectStartAddress, size_t offset,
         }
     }
 
+    // On x86 some int32/uint32 fields may look like GC pointers
+#if TARGET_32
+    if (strstr(typeName, "Js::TypedArray<") && offset == Js::Int8Array::GetOffsetOfLength())
+    {
+        return true;
+    }
+
+    if (strstr(typeName, "Js::ScriptContextPolymorphicInlineCache")
+        && offset == offsetof(Js::ScriptContextPolymorphicInlineCache, inlineCachesFillInfo))
+    {
+        return true;
+    }
+#endif
+
     return false;
 }
 


### PR DESCRIPTION
Opnd.cpp: WB verification was complaining on missing barrier as JIT did not
generate write barrier code for undefined/null sources. We had code to
disable that optimization under WB verification, but it no longer works
due to code change. Disable the optimization again under WB verification.

LowererMDArch.cpp: Under x86, ChangeToAssignInt64 does not need to generate
write barrier, as supposedly we are writing int64/uint64 values and not
pointers. The implementation was calling Lower::InsertMove() multiple times
and generating write barriers for lower/higher 32 bits respectively, which
generated write barrier instructions in an unexpected mixed sequence and
broke WB verification instructions. Fixed by avoiding write barrier during
ChangeToAssignInt64.

CommonDefines.h: RECYCLER_VISITED_HOST does not support software write
barrier. Do not enable when GLOBAL_ENABLE_WRITE_BARRIER is on.

JITTypes.h: Reorder fields to reduce GC force positives on x86.

JSONStringifier.h: Missing write barrier on PropertyListElement. The type
is used in SList<PropertyListElement, Recycler>.

LazyJSONString.h: JSONProperty constructor incorrectly used memcpy which
bypasses write barrier fields. Changed to CopyArray.

Added 2 more x86 cases to IsLikelyRuntimeFalseReference.
