### PR TITLE
Fix AV on Date.prototype[Symbol.toPrimitive] call

### DIFF
--- a/lib/Runtime/Library/JavascriptDate.cpp
+++ b/lib/Runtime/Library/JavascriptDate.cpp
@@ -260,8 +260,9 @@ namespace Js
             if (JavascriptString::Is(args[1]))
             {
                 JavascriptString* StringObject = JavascriptString::FromVar(args[1]);
+                const char16 * str = StringObject->GetString();
 
-                if (wcscmp(StringObject->UnsafeGetBuffer(), _u("default")) == 0 || wcscmp(StringObject->UnsafeGetBuffer(), _u("string")) == 0)
+                if (wcscmp(str, _u("default")) == 0 || wcscmp(str, _u("string")) == 0)
                 {
                     // Date objects, are unique among built-in ECMAScript object in that they treat "default" as being equivalent to "string"
                     // If hint is the string value "string" or the string value "default", then
@@ -270,7 +271,7 @@ namespace Js
                 }
                 // Else if hint is the string value "number", then
                 // Let tryFirst be "number".
-                else if(wcscmp(StringObject->UnsafeGetBuffer(), _u("number")) == 0)
+                else if(wcscmp(str, _u("number")) == 0)
                 {
                     return JavascriptConversion::OrdinaryToPrimitive(args[0], JavascriptHint::HintNumber/*tryFirst*/, scriptContext);
                 }

--- a/test/Bugs/misc_bugs.js
+++ b/test/Bugs/misc_bugs.js
@@ -1,0 +1,17 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+
+var tests = [
+  {
+    name: "calling Symbol.toPrimitive on Date prototype should not AV",
+    body: function () {
+         Date.prototype[Symbol.toPrimitive].call({},'strin' + 'g');
+    }
+  }
+];
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/Bugs/rlexe.xml
+++ b/test/Bugs/rlexe.xml
@@ -307,6 +307,12 @@
   </test>
   <test>
     <default>
+      <files>misc_bugs.js</files>
+      <compile-flags>-args summary -endargs</compile-flags>
+    </default>
+  </test>
+  <test>
+    <default>
       <files>json_bugs.js</files>
       <compile-flags>-args summary -endargs</compile-flags>
     </default>


### PR DESCRIPTION
The input of this function was concat string which we failed to flatten that. Which made the null deref AV.
Fixed that by using the GetString.
