### PR TITLE
Enable inlining on ARM64

### DIFF
--- a/lib/Backend/IR.h
+++ b/lib/Backend/IR.h
@@ -679,7 +679,7 @@ private:
     union labelLocation
     {
         BYTE *                  pc;     // Used by encoder and is the real pc offset
-        uint32                  offset; // Used by preEncoder and is an estimation pc offset, not accurate
+        uintptr_t               offset; // Used by preEncoder and is an estimation pc offset, not accurate
     } m_pc;
 
     BasicBlock *            m_block;
@@ -689,9 +689,9 @@ public:
 
     inline void             SetPC(BYTE * pc);
     inline BYTE *           GetPC(void) const;
-    inline void             SetOffset(uint32 offset);
-    inline void             ResetOffset(uint32 offset);
-    inline uint32           GetOffset(void) const;
+    inline void             SetOffset(uintptr_t offset);
+    inline void             ResetOffset(uintptr_t offset);
+    inline uintptr_t        GetOffset(void) const;
     inline void             SetBasicBlock(BasicBlock * block);
     inline BasicBlock *     GetBasicBlock(void) const;
     inline void             SetLoop(Loop *loop);

--- a/lib/Backend/IR.inl
+++ b/lib/Backend/IR.inl
@@ -637,7 +637,7 @@ LabelInstr::GetPC(void) const
 ///----------------------------------------------------------------------------
 
 inline void
-LabelInstr::ResetOffset(uint32 offset)
+LabelInstr::ResetOffset(uintptr_t offset)
 {
     AssertMsg(this->isInlineeEntryInstr, "As of now only InlineeEntryInstr overwrites the offset at encoder stage");
     this->m_pc.offset = offset;
@@ -650,7 +650,7 @@ LabelInstr::ResetOffset(uint32 offset)
 ///----------------------------------------------------------------------------
 
 inline void
-LabelInstr::SetOffset(uint32 offset)
+LabelInstr::SetOffset(uintptr_t offset)
 {
     AssertMsg(this->m_pc.offset == 0, "Overwriting existing byte offset");
     this->m_pc.offset = offset;
@@ -662,7 +662,7 @@ LabelInstr::SetOffset(uint32 offset)
 ///
 ///----------------------------------------------------------------------------
 
-inline uint32
+inline uintptr_t
 LabelInstr::GetOffset(void) const
 {
 

--- a/lib/Backend/InliningDecider.cpp
+++ b/lib/Backend/InliningDecider.cpp
@@ -184,10 +184,6 @@ uint InliningDecider::InlinePolymorphicCallSite(Js::FunctionBody *const inliner,
 Js::FunctionInfo *InliningDecider::Inline(Js::FunctionBody *const inliner, Js::FunctionInfo* functionInfo,
     bool isConstructorCall, bool isPolymorphicCall, uint16 constantArgInfo, Js::ProfileId callSiteId, uint recursiveInlineDepth, bool allowRecursiveInlining)
 {
-#if defined(_M_ARM64)
-    INLINE_TESTTRACE(_u("INLINING: Inline disabled for ARM64"));
-    return nullptr;
-#else // #if defined(_M_ARM64)
 #if defined(DBG_DUMP) || defined(ENABLE_DEBUG_CONFIG_OPTIONS)
     char16 debugStringBuffer[MAX_FUNCTION_BODY_DEBUG_STRING_SIZE];
     char16 debugStringBuffer2[MAX_FUNCTION_BODY_DEBUG_STRING_SIZE];
@@ -305,7 +301,6 @@ Js::FunctionInfo *InliningDecider::Inline(Js::FunctionBody *const inliner, Js::F
 
     // Note: for built-ins at this time we don't have enough data (the instr) to decide whether it's going to be inlined.
     return functionInfo;
-#endif // #if defined(_M_ARM64)
 }
 
 

--- a/lib/Backend/arm64/EncoderMD.h
+++ b/lib/Backend/arm64/EncoderMD.h
@@ -243,6 +243,7 @@ private:
 
     // Misc operations
     template<typename _Emitter, typename _Emitter64> int EmitMovConstant(Arm64CodeEmitter &Emitter, IR::Instr* instr, _Emitter emitter, _Emitter64 emitter64);
+    template<typename _Emitter, typename _Emitter64> int EmitMovConstantKnownShift(Arm64CodeEmitter &Emitter, IR::Instr* instr, _Emitter emitter, _Emitter64 emitter64, uint32 shift);
     template<typename _Emitter, typename _Emitter64> int EmitBitfield(Arm64CodeEmitter &Emitter, IR::Instr *instr, _Emitter emitter, _Emitter64 emitter64);
     template<typename _Emitter, typename _Emitter64> int EmitConditionalSelect(Arm64CodeEmitter &Emitter, IR::Instr *instr, int condition, _Emitter emitter, _Emitter64 emitter64);
 

--- a/lib/Backend/arm64/EncoderMD.h
+++ b/lib/Backend/arm64/EncoderMD.h
@@ -243,7 +243,6 @@ private:
 
     // Misc operations
     template<typename _Emitter, typename _Emitter64> int EmitMovConstant(Arm64CodeEmitter &Emitter, IR::Instr* instr, _Emitter emitter, _Emitter64 emitter64);
-    template<typename _Emitter, typename _Emitter64> int EmitMovConstantKnownShift(Arm64CodeEmitter &Emitter, IR::Instr* instr, _Emitter emitter, _Emitter64 emitter64, uint32 shift);
     template<typename _Emitter, typename _Emitter64> int EmitBitfield(Arm64CodeEmitter &Emitter, IR::Instr *instr, _Emitter emitter, _Emitter64 emitter64);
     template<typename _Emitter, typename _Emitter64> int EmitConditionalSelect(Arm64CodeEmitter &Emitter, IR::Instr *instr, int condition, _Emitter emitter, _Emitter64 emitter64);
 

--- a/lib/Backend/arm64/LegalizeMD.cpp
+++ b/lib/Backend/arm64/LegalizeMD.cpp
@@ -528,13 +528,7 @@ void LegalizeMD::LegalizeLDIMM(IR::Instr * instr, IntConstType immed)
         if ((immed & 0xffff) == immed || (immed & 0xffff0000) == immed || (immed & 0xffff00000000ll) == immed || (immed & 0xffff000000000000ll) == immed)
         {
             instr->m_opcode = Js::OpCode::MOVZ;
-            uint32 shift = 0;
-            while ((immed & 0xffff) != immed)
-            {
-                immed >>= 16;
-                shift += 16;
-            }
-            Assert(shift == 0 || shift == 16 || shift == 32 || shift == 48);
+            uint32 shift = ShiftTo16((UIntConstType*)&immed);
             instr->ReplaceSrc1(IR::IntConstOpnd::New(immed, TyUint16, instr->m_func));
             instr->SetSrc2(IR::IntConstOpnd::New(shift, TyUint8, instr->m_func));
             return;
@@ -546,13 +540,7 @@ void LegalizeMD::LegalizeLDIMM(IR::Instr * instr, IntConstType immed)
         {
             instr->m_opcode = Js::OpCode::MOVN;
             immed = invImmed;
-            uint32 shift = 0;
-            while ((immed & 0xffff) != immed)
-            {
-                immed >>= 16;
-                shift += 16;
-            }
-            Assert(shift == 0 || shift == 16 || shift == 32 || shift == 48);
+            uint32 shift = ShiftTo16((UIntConstType*)&immed);
             instr->ReplaceSrc1(IR::IntConstOpnd::New(immed, TyUint16, instr->m_func));
             instr->SetSrc2(IR::IntConstOpnd::New(shift, TyUint8, instr->m_func));
             return;
@@ -565,12 +553,8 @@ void LegalizeMD::LegalizeLDIMM(IR::Instr * instr, IntConstType immed)
             if ((invImmed32 & 0xffff) == invImmed32 || (invImmed32 & 0xffff0000) == invImmed32)
             {
                 instr->GetDst()->SetType(TyInt32);
-                int shift = 0;
-                if ((invImmed32 & 0xffff0000) == invImmed32)
-                {
-                    shift = 16;
-                }
-                IR::IntConstOpnd *src1 = IR::IntConstOpnd::New((invImmed32 >> shift) & 0xFFFF, TyInt16, instr->m_func);
+                uint32 shift = ShiftTo16((UIntConstType*)&invImmed32);
+                IR::IntConstOpnd *src1 = IR::IntConstOpnd::New(invImmed32 & 0xFFFF, TyInt16, instr->m_func);
                 IR::IntConstOpnd *src2 = IR::IntConstOpnd::New(shift, TyUint8, instr->m_func);
                 instr->ReplaceSrc1(src1);
                 instr->SetSrc2(src2);

--- a/lib/Backend/arm64/LegalizeMD.h
+++ b/lib/Backend/arm64/LegalizeMD.h
@@ -56,7 +56,7 @@ struct LegalInstrForms
 #define LEGAL_CBZ      { L_None,    { L_Reg } }
 #define LEGAL_LABEL    { L_Reg,     { L_Label } }
 #define LEGAL_LDIMM    { L_Reg,     { L_Imm,     L_None } }
-#define LEGAL_LDIMM_S  { L_Reg,     { L_Imm,     L_ImmU6 } }
+#define LEGAL_LDIMM_S  { L_Reg,     { (LegalForms)(L_ImmU16 | L_Label),     L_ImmU6 } }
 #define LEGAL_LOAD     { L_Reg,     { (LegalForms)(L_IndirSU12I9 | L_SymSU12I9), L_None } }
 #define LEGAL_LOADP    { L_Reg,     { (LegalForms)(L_IndirSI7 | L_SymSI7), L_Reg } }
 #define LEGAL_PLD      { L_None,    { (LegalForms)(L_IndirSU12I9 | L_SymSU12I9), L_None } }

--- a/lib/Backend/arm64/LegalizeMD.h
+++ b/lib/Backend/arm64/LegalizeMD.h
@@ -87,6 +87,18 @@ private:
     static void LegalizeImmed(IR::Instr * instr, IR::Opnd * opnd, uint opndNum, IntConstType immed, LegalForms forms, bool fPostRegAlloc);
     static void LegalizeLabelOpnd(IR::Instr * instr, IR::Opnd * opnd, uint opndNum, bool fPostRegAlloc);
 
+    static inline uint32 ShiftTo16(UIntConstType* immed)
+    {
+        uint32 shift = 0;
+        while (((*immed) & 0xffff) != *immed)
+        {
+            (*immed) >>= 16;
+            shift += 16;
+        }
+        Assert(shift == 0 || shift == 16 || shift == 32 || shift == 48);
+        return shift;
+    }
+
     static void LegalizeLDIMM(IR::Instr * instr, IntConstType immed);
     static void LegalizeLdLabel(IR::Instr * instr, IR::Opnd * opnd);
     static IR::Instr * GenerateLDIMM(IR::Instr * instr, uint opndNum, RegNum scratchReg, bool fPostRegAlloc);

--- a/lib/Backend/arm64/LegalizeMD.h
+++ b/lib/Backend/arm64/LegalizeMD.h
@@ -56,6 +56,7 @@ struct LegalInstrForms
 #define LEGAL_CBZ      { L_None,    { L_Reg } }
 #define LEGAL_LABEL    { L_Reg,     { L_Label } }
 #define LEGAL_LDIMM    { L_Reg,     { L_Imm,     L_None } }
+#define LEGAL_LDIMM_S  { L_Reg,     { L_Imm,     L_ImmU6 } }
 #define LEGAL_LOAD     { L_Reg,     { (LegalForms)(L_IndirSU12I9 | L_SymSU12I9), L_None } }
 #define LEGAL_LOADP    { L_Reg,     { (LegalForms)(L_IndirSI7 | L_SymSI7), L_Reg } }
 #define LEGAL_PLD      { L_None,    { (LegalForms)(L_IndirSU12I9 | L_SymSU12I9), L_None } }

--- a/lib/Backend/arm64/LowerMD.cpp
+++ b/lib/Backend/arm64/LowerMD.cpp
@@ -7620,7 +7620,7 @@ LowererMD::FinalLower()
 
                 if (branchInstr->GetTarget() && !LowererMD::IsUnconditionalBranch(branchInstr)) //Ignore BX register based branches & B
                 {
-                    uint32 targetOffset = branchInstr->GetTarget()->GetOffset();
+                    uint32 targetOffset = (uint32)branchInstr->GetTarget()->GetOffset();
 
                     if (targetOffset != 0)
                     {

--- a/lib/Backend/arm64/MdOpCodes.h
+++ b/lib/Backend/arm64/MdOpCodes.h
@@ -68,13 +68,9 @@ MACRO(LSR,        Reg2,       0,              UNUSED,   LEGAL_SHIFT,    UNUSED, 
 MACRO(MOV,        Reg2,       0,              UNUSED,   LEGAL_REG2,     UNUSED,   DM__)
 // Alias of MOV that won't get optimized out when src and dst are the same.
 MACRO(MOV_TRUNC,  Reg2,       0,              UNUSED,   LEGAL_REG2,     UNUSED,   DM__)
-MACRO(MOVK,       Reg2,       0,              UNUSED,   LEGAL_LDIMM,    UNUSED,   DM__)
-// Alias of MOVK where we know the shift, but don't know the value yet
-MACRO(MOVK_SHIFT, Reg2,       0,              UNUSED,   LEGAL_LDIMM_S,  UNUSED,   DM__)
-MACRO(MOVN,       Reg2,       0,              UNUSED,   LEGAL_LDIMM,    UNUSED,   DM__)
-MACRO(MOVZ,       Reg2,       0,              UNUSED,   LEGAL_LDIMM,    UNUSED,   DM__)
-// Alias of MOVZ where we know the shift, but don't know the value yet
-MACRO(MOVZ_SHIFT, Reg2,       0,              UNUSED,   LEGAL_LDIMM_S,  UNUSED,   DM__)
+MACRO(MOVK,       Reg2,       0,              UNUSED,   LEGAL_LDIMM_S,    UNUSED,   DM__)
+MACRO(MOVN,       Reg2,       0,              UNUSED,   LEGAL_LDIMM_S,    UNUSED,   DM__)
+MACRO(MOVZ,       Reg2,       0,              UNUSED,   LEGAL_LDIMM_S,    UNUSED,   DM__)
 MACRO(MRS_FPCR,   Reg1,       0,              UNUSED,   LEGAL_REG1,     UNUSED,   D___)
 MACRO(MRS_FPSR,   Reg1,       0,              UNUSED,   LEGAL_REG1,     UNUSED,   D___)
 MACRO(MSR_FPCR,   Reg2,       0,              UNUSED,   LEGAL_REG2_ND,  UNUSED,   D___)

--- a/lib/Backend/arm64/MdOpCodes.h
+++ b/lib/Backend/arm64/MdOpCodes.h
@@ -69,8 +69,12 @@ MACRO(MOV,        Reg2,       0,              UNUSED,   LEGAL_REG2,     UNUSED, 
 // Alias of MOV that won't get optimized out when src and dst are the same.
 MACRO(MOV_TRUNC,  Reg2,       0,              UNUSED,   LEGAL_REG2,     UNUSED,   DM__)
 MACRO(MOVK,       Reg2,       0,              UNUSED,   LEGAL_LDIMM,    UNUSED,   DM__)
+// Alias of MOVK where we know the shift, but don't know the value yet
+MACRO(MOVK_SHIFT, Reg2,       0,              UNUSED,   LEGAL_LDIMM_S,  UNUSED,   DM__)
 MACRO(MOVN,       Reg2,       0,              UNUSED,   LEGAL_LDIMM,    UNUSED,   DM__)
 MACRO(MOVZ,       Reg2,       0,              UNUSED,   LEGAL_LDIMM,    UNUSED,   DM__)
+// Alias of MOVZ where we know the shift, but don't know the value yet
+MACRO(MOVZ_SHIFT, Reg2,       0,              UNUSED,   LEGAL_LDIMM_S,  UNUSED,   DM__)
 MACRO(MRS_FPCR,   Reg1,       0,              UNUSED,   LEGAL_REG1,     UNUSED,   D___)
 MACRO(MRS_FPSR,   Reg1,       0,              UNUSED,   LEGAL_REG1,     UNUSED,   D___)
 MACRO(MSR_FPCR,   Reg2,       0,              UNUSED,   LEGAL_REG2_ND,  UNUSED,   D___)


### PR DESCRIPTION
The biggest thing that needed fixing up was the loading of inlinee
call info data; I implemented approximately the same thing that we
do on arm, minus doing it a little earlier (when encoding, instead
of in a relocation step). The most notable change is that I had to
make LabelInstr offsets grow to uintptr_t (from uint32); this will
not take any more memory, due to already being unioned with a byte
pointer, but has impact outside of ARM64.

The other part is the definition of two new instructions that have
a move with a known shift amount (movz_shift and movk_shift); this
is to ease definition of these fixed data moves, and may be useful
elsewhere.
