### PR TITLE
EngineInterfaceObject: initialize late extensionObject

### DIFF
--- a/lib/Runtime/Library/EngineInterfaceObject.cpp
+++ b/lib/Runtime/Library/EngineInterfaceObject.cpp
@@ -92,6 +92,12 @@ namespace Js
         {
             Assert(engineExtensions[extensionKind] == nullptr);
             engineExtensions[extensionKind] = extensionObject;
+
+            // Init the extensionObject if this was already initialized
+            if (this->IsInitialized())
+            {
+                extensionObject->Initialize();
+            }
         }
     }
 

--- a/lib/Runtime/Library/EngineInterfaceObject.h
+++ b/lib/Runtime/Library/EngineInterfaceObject.h
@@ -62,7 +62,10 @@ namespace Js
         Field(EngineExtensionObjectBase*) engineExtensions[MaxEngineInterfaceExtensionKind + 1];
 
     public:
-        EngineInterfaceObject(DynamicType * type) : DynamicObject(type) {}
+        EngineInterfaceObject(DynamicType * type)
+            : DynamicObject(type), commonNativeInterfaces(nullptr), engineExtensions()
+        {}
+
         DynamicObject* GetCommonNativeInterfaces() const { return commonNativeInterfaces; }
         EngineExtensionObjectBase* GetEngineExtension(EngineInterfaceExtensionKind extensionKind) const;
         void SetEngineExtension(EngineInterfaceExtensionKind extensionKind, EngineExtensionObjectBase* extensionObject);
@@ -81,6 +84,7 @@ namespace Js
 #endif
 
         void Initialize();
+        bool IsInitialized() const { return commonNativeInterfaces != nullptr; }
 
         static bool __cdecl InitializeCommonNativeInterfaces(DynamicObject* engineInterface, DeferredTypeHandlerBase * typeHandler, DeferredInitializeMode mode);
 


### PR DESCRIPTION
EngineInterfaceObject may have extensionObject set late. Specifically,
internal `WScript.InitializeProjection()` initializes WinRTPromise, which
is later than `EngineInterfaceObject::Initialize()` thus missing
`extensionObject->Initialize()`. Add `extensionObject->Initialize()` for
this case.

Fixes a list of nightly projection failures.
