### PR TITLE
ARM64: fix EmitUIntToFloat

### DIFF
--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -25391,7 +25391,7 @@ Lowerer::LoadIndexFromLikelyFloat(
 
     //Convert uint32 to back to float for comparison that conversion was indeed successful
     IR::RegOpnd *floatOpndFromUint32 = IR::RegOpnd::New(TyFloat64, func);
-    m_lowererMD.EmitUIntToFloat(floatOpndFromUint32, int32IndexOpnd, insertBeforeInstr);
+    m_lowererMD.EmitUIntToFloat(floatOpndFromUint32, int32IndexOpnd->UseWithNewType(TyUint32, this->m_func), insertBeforeInstr);
 
     // compare with float from the original indexOpnd, we need floatIndex == (float64)(uint32)floatIndex
     InsertCompareBranch(floatOpndFromUint32, floatIndexOpnd, Js::OpCode::BrNeq_A, notIntLabel, insertBeforeInstr, false);

--- a/lib/Backend/arm64/LowerMD.cpp
+++ b/lib/Backend/arm64/LowerMD.cpp
@@ -6275,7 +6275,7 @@ LowererMD::EmitLoadVar(IR::Instr *instrLoad, bool isFromUint32, bool isHelper)
 
     // TODO: Fix bad lowering. We shouldn't get TyVars here.
     // Assert(instrLoad->GetSrc1()->GetType() == TyInt32);
-    src1->SetType(TyInt32);
+    src1->SetType(isFromUint32 ? TyUint32 : TyInt32);
 
     if (src1->IsTaggedInt())
     {
@@ -7306,7 +7306,7 @@ LowererMD::EmitUIntToFloat(IR::Opnd *dst, IR::Opnd *src, IR::Instr *instrInsert)
     IR::Instr *instr;
 
     Assert(dst->IsRegOpnd() && dst->IsFloat64());
-    Assert(src->IsRegOpnd() && src->IsIntegral32());
+    Assert(src->IsRegOpnd() && src->IsUInt32());
 
     // Convert to Float
     instr = IR::Instr::New(Js::OpCode::FCVT, dst, src, this->m_func);


### PR DESCRIPTION
In ARM32 we use different opcodes for converting ints or uints, and are not careful about the type of opnds sent to EmitUIntToFloat. In ARM64 we use the same opcode and let the opnd type decide which converison is done so we need to be sure that the right type is provided.
