### PR TITLE
Fixing JsCreateString* JSRT APIs to accept -1 length again

### DIFF
--- a/lib/Jsrt/Jsrt.cpp
+++ b/lib/Jsrt/Jsrt.cpp
@@ -4544,6 +4544,17 @@ CHAKRA_API JsCreateString(
 {
     PARAM_NOT_NULL(content);
     PARAM_NOT_NULL(value);
+    *value = JS_INVALID_REFERENCE;
+
+    if (length == static_cast<size_t>(-1))
+    {
+        length = strlen(content);
+    }
+
+    if (length > static_cast<CharCount>(-1))
+    {
+        return JsErrorOutOfMemory;
+    }
 
     return ContextAPINoScriptWrapper([&](Js::ScriptContext *scriptContext, TTDRecorder& _actionEntryPopper) -> JsErrorCode {
 
@@ -4567,6 +4578,17 @@ CHAKRA_API JsCreateStringUtf16(
 {
     PARAM_NOT_NULL(content);
     PARAM_NOT_NULL(value);
+    *value = JS_INVALID_REFERENCE;
+
+    if (length == static_cast<size_t>(-1))
+    {
+        length = wcslen((const char16 *)content);
+    }
+
+    if (length > static_cast<CharCount>(-1))
+    {
+        return JsErrorOutOfMemory;
+    }
 
     return ContextAPINoScriptWrapper([&](Js::ScriptContext *scriptContext, TTDRecorder& _actionEntryPopper) -> JsErrorCode {
 

--- a/lib/Runtime/Library/ConcatString.cpp
+++ b/lib/Runtime/Library/ConcatString.cpp
@@ -82,7 +82,15 @@ namespace Js
             }
             case 1:
             {
-                return library->GetCharStringCache().GetStringForChar((char16(*cString)));
+                // If the high bit of the byte is set, it cannot be a complete utf8 codepoint, so fall back to the unicode replacement char
+                if ((*cString & 0x80) != 0x80)
+                {
+                    return library->GetCharStringCache().GetStringForChar((char16(*cString)));
+                }
+                else
+                {
+                    return library->GetCharStringCache().GetStringForChar(0xFFFD);
+                }
             }
             default:
                 break;


### PR DESCRIPTION
After a previous change, these apis would attempt to pass the -1
length value on as-is to internal methods that expected an actual
length. Now we correctly interpret it as "unknown" and compute
the length.