### PR TITLE
Do not go through StartEmitFunction if the fuction is deferred

### DIFF
--- a/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
+++ b/lib/Runtime/ByteCode/ByteCodeEmitter.cpp
@@ -3497,7 +3497,7 @@ void ByteCodeGenerator::StartEmitFunction(ParseNode *pnodeFnc)
     Scope * const bodyScope = funcInfo->GetBodyScope();
     Scope * const paramScope = funcInfo->GetParamScope();
 
-    if (funcInfo->byteCodeFunction->IsFunctionParsed())
+    if (funcInfo->byteCodeFunction->IsFunctionParsed() && funcInfo->root->sxFnc.pnodeBody != nullptr)
     {
         if (funcInfo->GetParsedFunctionBody()->GetByteCode() == nullptr && !(flags & (fscrEval | fscrImplicitThis | fscrImplicitParents)))
         {


### PR DESCRIPTION
Do not go through StartEmitFunction if the fuction is deferred

There can be cases where we are reusing the function body for a child function and we got to StartEmitFunction for the child function when trying to emit the re-deferred parent function. In that case don't redo the slot allocations in StartEmitFunction for the child function as it already has valid bytecode.
