### PR TITLE
ARM64: Fix/workaround for unwinding complexities.

### DIFF
--- a/lib/Backend/arm64/LowerMD.cpp
+++ b/lib/Backend/arm64/LowerMD.cpp
@@ -1272,8 +1272,12 @@ LowererMD::LowerEntryInstr(IR::EntryInstr * entryInstr)
         insertInstr->InsertBefore(instrStp);
 
         // ADD fp, sp, #offs
-        IR::Instr * instrAdd = IR::Instr::New(Js::OpCode::ADD, fpOpnd, spOpnd, IR::IntConstOpnd::New(fpOffset, TyMachReg, this->m_func), this->m_func);
-        insertInstr->InsertBefore(instrAdd);
+        // For exception handling, do this part AFTER the prolog to allow for proper unwinding
+        if (!layout.HasTry())
+        {
+            IR::Instr * instrAdd = IR::Instr::New(Js::OpCode::ADD, fpOpnd, spOpnd, IR::IntConstOpnd::New(fpOffset, TyMachReg, this->m_func), this->m_func);
+            insertInstr->InsertBefore(instrAdd);
+        }
     }
 
     // Perform the second (potentially large) stack allocation
@@ -1291,6 +1295,14 @@ LowererMD::LowerEntryInstr(IR::EntryInstr * entryInstr)
     IR::LabelInstr *prologEndLabel = IR::LabelInstr::New(Js::OpCode::Label, this->m_func);
     insertInstr->InsertBefore(prologEndLabel);
     this->m_func->m_unwindInfo.SetFunctionOffsetLabel(UnwindPrologEnd, prologEndLabel);
+
+    // Compute the FP now if there is a try present
+    if (layout.HasTry())
+    {
+        IR::Instr * instrAdd = IR::Instr::New(Js::OpCode::ADD, fpOpnd, spOpnd, IR::IntConstOpnd::New(layout.FpLrOffset(), TyMachReg, this->m_func), this->m_func);
+        insertInstr->InsertBefore(instrAdd);
+        Legalize(instrAdd);
+    }
 
     // Zero the argument slot if present
     IR::RegOpnd *zrOpnd = IR::RegOpnd::New(nullptr, RegZR, TyMachReg, this->m_func);
@@ -1372,18 +1384,18 @@ LowererMD::LowerExitInstr(IR::ExitInstr * exitInstr)
     IR::RegOpnd *spOpnd = IR::RegOpnd::New(nullptr, RegSP, TyMachReg, this->m_func);
     IR::RegOpnd *fpOpnd = IR::RegOpnd::New(nullptr, RegFP, TyMachReg, this->m_func);
 
-    // Undo the last stack allocation
-    if (stackAllocation2 > 0)
-    {
-        GenerateStackDeallocation(exitInstr, stackAllocation2);
-    }
-
-    // Exception handling regions exit via the same epilog just skipping the stackAllocation2 recovery
+    // Exception handling regions exit via the same epilog
     IR::LabelInstr* ehEpilogLabel = this->m_func->m_epilogLabel;
     if (ehEpilogLabel != nullptr)
     {
         ehEpilogLabel->Unlink();
         exitInstr->InsertBefore(ehEpilogLabel);
+    }
+
+    // Undo the last stack allocation
+    if (stackAllocation2 > 0)
+    {
+        GenerateStackDeallocation(exitInstr, stackAllocation2);
     }
 
     // Recover FP and LR

--- a/lib/Runtime/Language/arm64/arm64_CallEhFrame.asm
+++ b/lib/Runtime/Language/arm64/arm64_CallEhFrame.asm
@@ -76,6 +76,13 @@
     ; thunks to skip re-allocating locals space.
     ;
 
+    ; Params:
+    ; x0 -- thunk target
+    ; x1 -- frame pointer
+    ; x2 -- locals pointer
+    ; x3 -- size of stack args area
+    ; x4 -- exception object (for arm64_CallCatch only)
+
     PROLOG_SAVE_REG_PAIR d8, d9, #-240!
     PROLOG_SAVE_REG_PAIR d10, d11, #16
     PROLOG_SAVE_REG_PAIR d12, d13, #32
@@ -85,25 +92,20 @@
     PROLOG_SAVE_REG_PAIR x23, x24, #96
     PROLOG_SAVE_REG_PAIR x25, x26, #112
     PROLOG_SAVE_REG_PAIR x27, x28, #128
-    PROLOG_SAVE_REG_PAIR fp, lr, #160
-    
-    stp     xzr, xzr, [sp, #144]
-    stp     x0, x1, [sp, #176]
-    stp     x2, x3, [sp, #192]
-    stp     x4, x5, [sp, #208]
-    stp     x6, x7, [sp, #224]
+    PROLOG_SAVE_REG_PAIR_NO_FP fp, lr, #160
 
+    sub     x15, x1, x2         ; x15 = frame pointer minus locals pointer
+    sub     x15, x15, #160      ; x15 -= space we already allocated
+    add     x15, x15, x3        ; x15 += argout area = same stack allocation as original function
+    lsr     x15, x15, #4        ; x15 /= 16
+    bl      __chkstk            ; verify the allocation is ok
+    sub     sp, sp, x15, lsl #4 ; allocate the stack
+    
     MEND
 
     TEXTAREA
 
     NESTED_ENTRY arm64_CallEhFrame
-
-    ; Params:
-    ; x0 -- thunk target
-    ; x1 -- frame pointer
-    ; x2 -- locals pointer
-    ; x3 -- size of stack args area
 
     STANDARD_PROLOG
 


### PR DESCRIPTION
Do not set up FP in the prolog to avoid it being recovered during unwind. Allocate a full copy of the locals area in the EH helpers to make the unwinding work.