### PR TITLE
ARM64: ChangeToAssign create sign extend/zero extend

### DIFF
--- a/lib/Backend/arm64/LowerMD.cpp
+++ b/lib/Backend/arm64/LowerMD.cpp
@@ -2066,17 +2066,18 @@ LowererMD::ChangeToAssign(IR::Instr * instr)
 }
 
 IR::Instr *
-LowererMD::ChangeToAssign(IR::Instr * instr, IRType type)
+LowererMD::ChangeToAssign(IR::Instr * instr, IRType destType)
 {
     Assert(!instr->HasBailOutInfo() || instr->GetBailOutKind() == IR::BailOutExpectingInteger
                                        || instr->GetBailOutKind() == IR::BailOutExpectingString);
 
     IR::Opnd *src = instr->GetSrc1();
+    IRType srcType = src->GetType();
     if (src->IsImmediateOpnd() || src->IsLabelOpnd())
     {
         instr->m_opcode = Js::OpCode::LDIMM;
     }
-    else if(type == TyFloat32 && instr->GetDst()->IsRegOpnd())
+    else if(destType == TyFloat32 && instr->GetDst()->IsRegOpnd())
     {
         Assert(instr->GetSrc1()->IsFloat32());
         instr->m_opcode = Js::OpCode::FLDR;
@@ -2089,9 +2090,30 @@ LowererMD::ChangeToAssign(IR::Instr * instr, IRType type)
             instr->ReplaceSrc1(instr->GetSrc1()->UseWithNewType(TyFloat64, instr->m_func));
         }
     }
+    else if ((IRType_IsSignedInt(destType) || IRType_IsUnsignedInt(destType)) && TySize[destType] > TySize[srcType])
+    {
+        // If we're moving between different lengths of registers, we need to use the
+        // right operator - sign extend if the source is int, zero extend if uint.
+        if (IRType_IsSignedInt(srcType))
+        {
+            instr->ReplaceSrc1(src->UseWithNewType(IRType_EnsureSigned(destType), instr->m_func));
+            instr->SetSrc2(IR::IntConstOpnd::New(BITFIELD(0, (TySize[srcType]*8)-1), TyMachReg, instr->m_func, true));
+            instr->m_opcode = Js::OpCode::SBFX;
+        }
+        else if (IRType_IsUnsignedInt(srcType))
+        {
+            instr->ReplaceSrc1(src->UseWithNewType(IRType_EnsureUnsigned(destType), instr->m_func));
+            instr->SetSrc2(IR::IntConstOpnd::New(BITFIELD(0, (TySize[srcType]*8)-1), TyMachReg, instr->m_func, true));
+            instr->m_opcode = Js::OpCode::UBFX;
+        }
+        else
+        {
+            AssertMsg(false, "argument size mismatch for mov instruction, with non int/uint types!");
+        }
+    }
     else
     {
-        instr->m_opcode = LowererMD::GetMoveOp(type);
+        instr->m_opcode = IRType_IsFloat(destType) ? Js::OpCode::FMOV : Js::OpCode::MOV;
     }
     LegalizeMD::LegalizeInstr(instr, false);
 

--- a/lib/Backend/arm64/LowerMD.h
+++ b/lib/Backend/arm64/LowerMD.h
@@ -70,7 +70,6 @@ public:
             IR::Instr *     ChangeToHelperCallMem(IR::Instr * instr, IR::JnHelperMethod helperMethod);
     static  IR::Instr *     ChangeToAssign(IR::Instr * instr);
     static  IR::Instr *     ChangeToAssignNoBarrierCheck(IR::Instr * instr);
-    static  IR::Instr *     ChangeToAssign(IR::Instr * instr, IRType type);
     static  IR::Instr *     ChangeToLea(IR::Instr *const instr, bool postRegAlloc = false);
     static  IR::Instr *     ForceDstToReg(IR::Instr *instr);
     static  void            ImmedSrcToReg(IR::Instr * instr, IR::Opnd * newOpnd, int srcNum);
@@ -237,7 +236,6 @@ public:
             static RegNum       GetRegArgR8(int32 argNum) { return RegNOREG; }
             static Js::OpCode   GetLoadOp(IRType type) { return IRType_IsFloat(type) ? Js::OpCode::FLDR : Js::OpCode::LDR; }
             static Js::OpCode   GetStoreOp(IRType type) { return IRType_IsFloat(type) ? Js::OpCode::FSTR : Js::OpCode::STR; }
-            static Js::OpCode   GetMoveOp(IRType type) { return IRType_IsFloat(type) ? Js::OpCode::FMOV : Js::OpCode::MOV; }
 
             static BYTE         GetDefaultIndirScale()
             {
@@ -271,6 +269,7 @@ public:
 public:
     static IR::Instr * InsertCmovCC(const Js::OpCode opCode, IR::Opnd * dst, IR::Opnd* src1, IR::Instr* insertBeforeInstr, bool postRegAlloc);
 private:
+    static  IR::Instr *     ChangeToAssign(IR::Instr * instr, IRType destType);
     void GenerateFlagInlineCacheCheckForGetterSetter(
         IR::Instr * insertBeforeInstr,
         IR::RegOpnd * opndInlineCache,


### PR DESCRIPTION
For cases where we have an integral source and dest, we should, in
the case of a shorter source, sign-extend for ints and zero-extend
for uints. Previously, we'd make a mov and assert in the encoder.
