### PR TITLE
WASM: Fix ConvertOffset

### DIFF
--- a/lib/Runtime/Language/WAsmjsUtils.cpp
+++ b/lib/Runtime/Language/WAsmjsUtils.cpp
@@ -109,15 +109,15 @@ template<> Types RegisterSpace::GetRegisterSpaceType<AsmJsSIMDValue>(){return WA
 #endif
     }
 
-    uint32 ConvertOffset(uint32 ptr, uint32 fromSize, uint32 toSize)
+    uint32 ConvertOffset(uint32 offset, uint32 fromSize, uint32 toSize)
     {
         if (fromSize == toSize)
         {
-            return ptr;
+            return offset;
         }
-        uint64 tmp = ptr * fromSize;
+        uint64 tmp = (uint64)offset * (uint64)fromSize;
         tmp = Math::Align<uint64>(tmp, toSize);
-        tmp /= toSize;
+        tmp /= (uint64)toSize;
         if (tmp > (uint64)UINT32_MAX)
         {
             Math::DefaultOverflowPolicy();
@@ -283,8 +283,8 @@ template<> Types RegisterSpace::GetRegisterSpaceType<AsmJsSIMDValue>(){return WA
         // These bytes offset already calculated the alignment, used them to determine how many Js::Var we need to do the allocation
         uint32 stackByteSize = offset;
         uint32 bytesUsedForConst = constSourcesInfo.bytesUsed;
-        uint32 jsVarUsedForConstsTable = ConvertToJsVarOffset<byte>(bytesUsedForConst);
-        uint32 totalVarsNeeded = ConvertToJsVarOffset<byte>(stackByteSize);
+        uint32 jsVarUsedForConstsTable = ConvertOffset<byte, Js::Var>(bytesUsedForConst);
+        uint32 totalVarsNeeded = ConvertOffset<byte, Js::Var>(stackByteSize);
 
         uint32 jsVarNeededForVars = totalVarsNeeded - jsVarUsedForConstsTable;
         if (totalVarsNeeded < jsVarUsedForConstsTable)
@@ -313,7 +313,7 @@ template<> Types RegisterSpace::GetRegisterSpaceType<AsmJsSIMDValue>(){return WA
         // this value is the number of Var slots needed to allocate all the const
         uint32 bytesUsedForConst = GetConstSourceInfos().bytesUsed;
         // Add the registers not included in the const table
-        uint32 nbConst = ConvertToJsVarOffset<byte>(bytesUsedForConst) + Js::FunctionBody::FirstRegSlot;
+        uint32 nbConst = ConvertOffset<byte, Js::Var>(bytesUsedForConst) + Js::FunctionBody::FirstRegSlot;
         body->CheckAndSetConstantCount(nbConst);
     }
 

--- a/lib/Runtime/Language/WAsmjsUtils.h
+++ b/lib/Runtime/Language/WAsmjsUtils.h
@@ -34,22 +34,14 @@ namespace WAsmJs
 
     typedef Js::RegSlot RegSlot;
 
-    uint32 ConvertOffset(uint32 ptr, uint32 fromSize, uint32 toSize);
-    template<typename ToType> uint32 ConvertOffset(uint32 ptr, uint32 fromSize)
+    uint32 ConvertOffset(uint32 offset, uint32 fromSize, uint32 toSize);
+    template<typename ToType> uint32 ConvertOffset(uint32 offset, uint32 fromSize)
     {
-        return ConvertOffset(ptr, fromSize, sizeof(ToType));
+        return ConvertOffset(offset, fromSize, sizeof(ToType));
     }
-    template<typename FromType, typename ToType> uint32 ConvertOffset(uint32 ptr)
+    template<typename FromType, typename ToType> uint32 ConvertOffset(uint32 offset)
     {
-        return ConvertOffset(ptr, sizeof(FromType), sizeof(ToType));
-    }
-    template<typename T> uint32 ConvertToJsVarOffset(uint32 ptr)
-    {
-        return ConvertOffset<T, Js::Var>(ptr);
-    }
-    template<typename T> uint32 ConvertFromJsVarOffset(uint32 ptr)
-    {
-        return ConvertOffset<Js::Var, T>(ptr);
+        return ConvertOffset<ToType>(offset, sizeof(FromType));
     }
 
     struct EmitInfoBase

--- a/lib/Runtime/Library/WebAssemblyEnvironment.cpp
+++ b/lib/Runtime/Library/WebAssemblyEnvironment.cpp
@@ -25,7 +25,7 @@ WebAssemblyEnvironment::WebAssemblyEnvironment(WebAssemblyModule* module):
     this->table = this->start + module->GetTableEnvironmentOffset();
     this->globals = this->start + module->GetGlobalOffset();
 
-    uint32 globalsSize = WAsmJs::ConvertToJsVarOffset<byte>(module->GetGlobalsByteSize());
+    uint32 globalsSize = WAsmJs::ConvertOffset<byte, Js::Var>(module->GetGlobalsByteSize());
     // Assumes globals are last
     Assert(globals > table && globals > functions && globals > imports && globals > memory);
     if (globals < start ||

--- a/lib/Runtime/Library/WebAssemblyModule.cpp
+++ b/lib/Runtime/Library/WebAssemblyModule.cpp
@@ -831,7 +831,7 @@ WebAssemblyModule::GetModuleEnvironmentSize() const
     uint32 size = 3;
     size = UInt32Math::Add(size, GetWasmFunctionCount());
     size = UInt32Math::Add(size, GetImportedFunctionCount());
-    size = UInt32Math::Add(size, WAsmJs::ConvertToJsVarOffset<byte>(GetGlobalsByteSize()));
+    size = UInt32Math::Add(size, WAsmJs::ConvertOffset<byte, Js::Var>(GetGlobalsByteSize()));
     return size;
 }
 
@@ -865,7 +865,7 @@ WebAssemblyModule::GetOffsetForGlobal(Wasm::WasmGlobal* global) const
         throw Wasm::WasmCompilationException(_u("Invalid Global type"));
     }
 
-    uint32 offset = WAsmJs::ConvertFromJsVarOffset<byte>(GetGlobalOffset());
+    uint32 offset = WAsmJs::ConvertOffset<Js::Var, byte>(GetGlobalOffset());
 
     for (uint i = 1; i < (uint)type; i++)
     {


### PR DESCRIPTION
Ensure ConvertOffset uses uint64 math. Remove useless extra ConvertOffset aliases

OS#14407649

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/4206)
<!-- Reviewable:end -->
