### PR TITLE
Change RegExp.test cache to be per pattern

### DIFF
--- a/lib/Parser/RegexPattern.cpp
+++ b/lib/Parser/RegexPattern.cpp
@@ -7,7 +7,7 @@
 namespace UnifiedRegex
 {
     RegexPattern::RegexPattern(Js::JavascriptLibrary *const library, Program* program, bool isLiteral)
-        : library(library), isLiteral(isLiteral), isShallowClone(false)
+        : library(library), isLiteral(isLiteral), isShallowClone(false), testCache(nullptr)
     {
         rep.unified.program = program;
         rep.unified.matcher = nullptr;
@@ -128,6 +128,21 @@ namespace UnifiedRegex
         return result;
     }
 
+    Field(RegExpTestCache*) RegexPattern::EnsureTestCache()
+    {
+        if (this->testCache == nullptr)
+        {
+            this->testCache = RecyclerNewArrayZ(this->library->GetRecycler(), RegExpTestCache, TestCacheSize);
+        }
+        return this->testCache;
+    }
+
+    /* static */
+    uint RegexPattern::GetTestCacheIndex(Js::JavascriptString* str)
+    {
+        return (uint)(((uintptr_t)str) >> PolymorphicInlineCacheShift) & (TestCacheSize - 1);
+    }
+
 #if ENABLE_REGEX_CONFIG_OPTIONS
     void RegexPattern::Print(DebugWriter* w)
     {
@@ -177,6 +192,34 @@ namespace UnifiedRegex
         w->Print(_u(", "));
         w->Print(isLiteral ? _u("literal") : _u("dynamic"));
         w->Print(_u(" */"));
+    }
+
+    /* static */
+    void RegexPattern::TraceTestCache(bool cacheHit, Js::JavascriptString* input, Js::JavascriptString* cachedValue, bool disabled)
+    {
+        if (REGEX_CONFIG_FLAG(RegexTracing))
+        {
+            if (disabled)
+            {
+                Output::Print(_u("Regexp Test Cache Disabled.\n"));
+            }
+            else if (cacheHit)
+            {
+                Output::Print(_u("Regexp Test Cache Hit.\n"));
+            }
+            else
+            {
+                Output::Print(_u("Regexp Test Cache Miss. "));
+                if (cachedValue != nullptr)
+                {
+                    Output::Print(_u("Input: (%p); Cached String: (%p) '%s'\n"), input, cachedValue, cachedValue->GetString());
+                }
+                else
+                {
+                    Output::Print(_u("Cache was empty\n"));
+                }
+            }
+        }
     }
 #endif
 }

--- a/lib/Parser/RegexPattern.cpp
+++ b/lib/Parser/RegexPattern.cpp
@@ -132,7 +132,7 @@ namespace UnifiedRegex
     {
         if (this->testCache == nullptr)
         {
-            this->testCache = RecyclerNewArrayZ(this->library->GetRecycler(), RegExpTestCache, TestCacheSize);
+            this->testCache = RecyclerNewPlusZ(this->library->GetRecycler(), TestCacheSize * sizeof(void*), RegExpTestCache);
         }
         return this->testCache;
     }

--- a/lib/Parser/RegexPattern.h
+++ b/lib/Parser/RegexPattern.h
@@ -19,8 +19,8 @@ namespace UnifiedRegex
 
     struct RegExpTestCache
     {
-        Field(bool) result;
-        Field(RecyclerWeakReference<Js::JavascriptString>*) input;
+        Field(BVStatic<TestCacheSize>) resultBV;
+        Field(RecyclerWeakReference<Js::JavascriptString>*) inputArray[];
     };
 
     struct RegexPattern : FinalizableObject

--- a/lib/Parser/RegexPattern.h
+++ b/lib/Parser/RegexPattern.h
@@ -15,8 +15,17 @@ namespace UnifiedRegex
     class Matcher;
     struct TrigramInfo;
 
+    static const uint TestCacheSize = 8;
+
+    struct RegExpTestCache
+    {
+        Field(bool) result;
+        Field(RecyclerWeakReference<Js::JavascriptString>*) input;
+    };
+
     struct RegexPattern : FinalizableObject
     {
+        Field(RegExpTestCache*) testCache;
 
         struct UnifiedRep
         {
@@ -60,9 +69,17 @@ namespace UnifiedRegex
 
         Js::InternalString GetSource() const;
         RegexFlags GetFlags() const;
+
+        Field(RegExpTestCache*) EnsureTestCache();
+        static uint GetTestCacheIndex(Js::JavascriptString* str);
+
 #if ENABLE_REGEX_CONFIG_OPTIONS
         void Print(DebugWriter* w);
 #endif
         RegexPattern *CopyToScriptContext(Js::ScriptContext *scriptContext);
+
+#if ENABLE_REGEX_CONFIG_OPTIONS
+        static void TraceTestCache(bool cacheHit, Js::JavascriptString* input, Js::JavascriptString* cachedValue, bool disabled);
+#endif
     };
 }

--- a/lib/Runtime/Library/JavascriptRegularExpression.cpp
+++ b/lib/Runtime/Library/JavascriptRegularExpression.cpp
@@ -15,8 +15,7 @@ namespace Js
         pattern(pattern),
         splitPattern(nullptr),
         lastIndexVar(nullptr),
-        lastIndexOrFlag(0),
-        testCache(nullptr)
+        lastIndexOrFlag(0)
     {
         Assert(type->GetTypeId() == TypeIds_RegEx);
         Assert(!this->GetType()->AreThisAndPrototypesEnsuredToHaveOnlyWritableDataProperties());
@@ -42,8 +41,7 @@ namespace Js
         pattern(nullptr),
         splitPattern(nullptr),
         lastIndexVar(nullptr),
-        lastIndexOrFlag(0),
-        testCache(nullptr)
+        lastIndexOrFlag(0)
     {
         Assert(type->GetTypeId() == TypeIds_RegEx);
 
@@ -61,8 +59,7 @@ namespace Js
         pattern(instance->GetPattern()),
         splitPattern(instance->GetSplitPattern()),
         lastIndexVar(instance->lastIndexVar),
-        lastIndexOrFlag(instance->lastIndexOrFlag),
-        testCache(nullptr)
+        lastIndexOrFlag(instance->lastIndexOrFlag)
     {
         // For boxing stack instance
         Assert(ThreadContext::IsOnStack(instance));
@@ -620,7 +617,6 @@ namespace Js
         thisRegularExpression->SetPattern(pattern);
         thisRegularExpression->SetSplitPattern(splitPattern);
         thisRegularExpression->SetLastIndex(0);
-        thisRegularExpression->ClearTestCache();
         return thisRegularExpression;
     }
 
@@ -1565,58 +1561,6 @@ namespace Js
             ? specialPropertyIdsAll
             : specialPropertyIdsWithoutUnicode;
     }
-
-    Field(RegExpTestCache*) JavascriptRegExp::EnsureTestCache()
-    {
-        if (this->testCache != nullptr)
-        {
-            return this->testCache;
-        }
-
-        this->testCache = RecyclerNewArrayZ(GetRecycler(), RegExpTestCache, TestCacheSize);
-        return this->testCache;
-    }
-
-    /* static */
-    uint JavascriptRegExp::GetTestCacheIndex(JavascriptString* str)
-    {
-        return (uint)(((uintptr_t)str) >> PolymorphicInlineCacheShift) & (TestCacheSize - 1);
-    }
-
-    void JavascriptRegExp::ClearTestCache()
-    {
-        this->testCache = nullptr;
-    }
-
-#if ENABLE_REGEX_CONFIG_OPTIONS
-    /* static */
-    void JavascriptRegExp::TraceTestCache(bool cacheHit, JavascriptString* input, JavascriptString* cachedValue, bool disabled)
-    {
-        if (REGEX_CONFIG_FLAG(RegexTracing))
-        {
-            if (disabled)
-            {
-                Output::Print(_u("Regexp Test Cache Disabled.\n"));
-            }
-            else if (cacheHit)
-            {
-                Output::Print(_u("Regexp Test Cache Hit.\n"));
-            }
-            else
-            {
-                Output::Print(_u("Regexp Test Cache Miss. "));
-                if (cachedValue != nullptr)
-                {
-                    Output::Print(_u("Input: (%p); Cached String: (%p) '%s'\n"), input, cachedValue, cachedValue->GetString());
-                }
-                else
-                {
-                    Output::Print(_u("Cache was empty\n"));
-                }
-            }
-        }
-    }
-#endif
 
 #if ENABLE_TTD
     TTD::NSSnapObjects::SnapObjectType JavascriptRegExp::GetSnapTag_TTD() const

--- a/lib/Runtime/Library/JavascriptRegularExpression.h
+++ b/lib/Runtime/Library/JavascriptRegularExpression.h
@@ -6,11 +6,6 @@
 
 namespace Js
 {
-    struct RegExpTestCache
-    {
-        Field(bool) result;
-        Field(RecyclerWeakReference<JavascriptString> *) input;
-    };
     class JavascriptRegExp : public DynamicObject
     {
         friend class JavascriptRegularExpressionType;
@@ -31,14 +26,12 @@ namespace Js
         // RegExp object.
         Field(UnifiedRegex::RegexPattern*) splitPattern;
         Field(Var) lastIndexVar;  // null => must build lastIndexVar from current lastIndex
-        Field(RegExpTestCache*) testCache;
 
     public:
         // Three states for lastIndex value:
         //  1. lastIndexVar has been updated, we must calculate lastIndex from it when we next need it
         static const CharCount NotCachedValue = (CharCount)-2;
 
-        static const uint TestCacheSize = 8;
     private:
         //  2. ToNumber(lastIndexVar) yields +inf or -inf or an integer not in range [0, MaxCharCount]
         static const CharCount InvalidValue = CharCountFlag;
@@ -140,14 +133,6 @@ namespace Js
         static Var OP_NewRegEx(Var aCompiledRegex, ScriptContext* scriptContext);
 
         JavascriptString *ToString(bool sourceOnly = false);
-
-        Field(RegExpTestCache*) EnsureTestCache();
-        void ClearTestCache();
-        static uint GetTestCacheIndex(JavascriptString* str);
-
-#if ENABLE_REGEX_CONFIG_OPTIONS
-        static void TraceTestCache(bool cacheHit, JavascriptString* input, JavascriptString* cachedValue, bool disabled);
-#endif
 
         class EntryInfo
         {

--- a/lib/Runtime/Library/RegexHelper.cpp
+++ b/lib/Runtime/Library/RegexHelper.cpp
@@ -669,21 +669,21 @@ namespace Js
         const bool isSticky = pattern->IsSticky();
         const bool useCache = !isGlobal && !isSticky;
 
-        RegExpTestCache* cache = nullptr;
+        UnifiedRegex::RegExpTestCache* cache = nullptr;
         JavascriptString * cachedInput = nullptr;
         uint cacheIndex = 0;
         bool cacheHit = false;
         bool cachedResult = false;
         if (useCache)
         {
-            cache = regularExpression->EnsureTestCache();
-            cacheIndex = JavascriptRegExp::GetTestCacheIndex(input);
+            cache = pattern->EnsureTestCache();
+            cacheIndex = UnifiedRegex::RegexPattern::GetTestCacheIndex(input);
             cachedInput = cache[cacheIndex].input != nullptr ? cache[cacheIndex].input->Get() : nullptr;
             cacheHit = cachedInput == input;
         }
 #if ENABLE_REGEX_CONFIG_OPTIONS
         RegexHelperTrace(scriptContext, UnifiedRegex::RegexStats::Test, regularExpression, input);
-        JavascriptRegExp::TraceTestCache(cacheHit, input, cachedInput, !useCache);
+        UnifiedRegex::RegexPattern::TraceTestCache(cacheHit, input, cachedInput, !useCache);
 #endif
 
         if (cacheHit)


### PR DESCRIPTION
Previously it was per regexp object, but you could have many objects per pattern, and the allocation of cache could have non-trivial cost in such cases.

Fixes perf regression in string-validate-input

OS:14347560
