### PR TITLE
fix use of variable out of C++ scope (DEBUG only)

### DIFF
--- a/lib/Common/Memory/ArenaAllocator.cpp
+++ b/lib/Common/Memory/ArenaAllocator.cpp
@@ -588,9 +588,10 @@ Free(void * buffer, size_t byteSize)
 
         void **policy = &this->freeList;
 #if DBG
+        void *delayFreeList;
         if (needsDelayFreeList)
         {
-            void *delayFreeList = reinterpret_cast<FreeObject **>(this->freeList) + (MaxSmallObjectSize >> ObjectAlignmentBitShift);
+            delayFreeList = reinterpret_cast<FreeObject **>(this->freeList) + (MaxSmallObjectSize >> ObjectAlignmentBitShift);
             policy = &delayFreeList;
         }
 #endif


### PR DESCRIPTION
In DEBUG verification code we were taking the address of a temp variable
and using it out of the variable's C++ scope.

Found by OSS-Fuzz.
