### PR TITLE
fix kraken json-stringify-tinderbox regression

### DIFF
--- a/lib/Runtime/Language/JavascriptOperators.h
+++ b/lib/Runtime/Language/JavascriptOperators.h
@@ -214,7 +214,12 @@ namespace Js
         static TypeId GetTypeId(_In_ RecyclableObject* instance);
         static TypeId GetTypeIdNoCheck(Var instance);
         template <typename T>
-        __forceinline static T* TryFromVar(Var value)
+        __forceinline static T* TryFromVar(_In_ RecyclableObject* value)
+        {
+            return T::Is(value) ? T::UnsafeFromVar(value) : nullptr;
+        }
+        template <typename T>
+        __forceinline static T* TryFromVar(_In_ Var value)
         {
             return T::Is(value) ? T::UnsafeFromVar(value) : nullptr;
         }

--- a/lib/Runtime/Library/JSONStringifier.h
+++ b/lib/Runtime/Library/JSONStringifier.h
@@ -51,11 +51,10 @@ private:
     charcount_t gapLength;
     char16* gap;
 
-    _Ret_notnull_ const PropertyRecord* GetPropertyRecord(_In_ JavascriptString* string);
     Var TryConvertPrimitiveObject(_In_ RecyclableObject* value);
     Var ToJSON(_In_ JavascriptString* key, _In_ RecyclableObject* valueObject);
     Var CallReplacerFunction(_In_opt_ RecyclableObject* holder, _In_ JavascriptString* key, _In_ Var value);
-    _Ret_notnull_ Var ReadValue(_In_ JavascriptString* key, _In_ const PropertyRecord* propertyRecord, _In_ RecyclableObject* holder);
+    _Ret_notnull_ Var ReadValue(_In_ JavascriptString* key, _In_opt_ const PropertyRecord* propertyRecord, _In_ RecyclableObject* holder);
     uint32 ReadArrayLength(_In_ RecyclableObject* value);
     JSONArray* ReadArray(_In_ RecyclableObject* arr, _In_ JSONObjectStack* objectStack);
 


### PR DESCRIPTION
I recently rewrote JSON stringify and this introduced a regression in json-stringify-tinderbox. The most expensive thing in that benchmark is calculating string element length, so I have moved to use a uint64 for intermediate calculations to avoid overflow checks. I also changed some FromVar checks to avoid duplicating checks.

OS: 14617309