### PR TITLE
Save result of functionBody->GetConstantCount() in local var

### DIFF
--- a/lib/Backend/JITTimeFunctionBody.cpp
+++ b/lib/Backend/JITTimeFunctionBody.cpp
@@ -21,17 +21,18 @@ JITTimeFunctionBody::InitializeJITFunctionData(
     Assert(functionBody != nullptr);
 
     // const table
-    jitBody->constCount = functionBody->GetConstantCount();
-    if (functionBody->GetConstantCount() > 0)
+    const Js::RegSlot numConstants = functionBody->GetConstantCount();
+    jitBody->constCount = numConstants;
+    if (numConstants > 0)
     {
         jitBody->constTable = (intptr_t *)PointerValue(functionBody->GetConstTable());
         if (!functionBody->GetIsAsmJsFunction())
         {
             jitBody->constTableContent = AnewStructZ(arena, ConstTableContentIDL);
-            jitBody->constTableContent->count = functionBody->GetConstantCount();
-            jitBody->constTableContent->content = AnewArrayZ(arena, RecyclableObjectIDL*, functionBody->GetConstantCount());
+            jitBody->constTableContent->count = numConstants;
+            jitBody->constTableContent->content = AnewArrayZ(arena, RecyclableObjectIDL*, numConstants);
 
-            for (Js::RegSlot reg = Js::FunctionBody::FirstRegSlot; reg < functionBody->GetConstantCount(); ++reg)
+            for (Js::RegSlot reg = Js::FunctionBody::FirstRegSlot; reg < numConstants; ++reg)
             {
                 Js::Var varConst = functionBody->GetConstantVar(reg);
                 Assert(varConst != nullptr);


### PR DESCRIPTION
OS:10437444: Instead of calling functionBody->GetConstantCount() 5 times in JITTimeFunctionBody::InitializeJITFunctionData, call it only once and save the results in a local variable.  This allows OACR to conclude that the arithmetic and array index operation on line 53 are safe.  (There may also be a slight perf improvement, but this is incidental.)

We assume that all of the original calls to GetConstantCount() return the same value.  I've done a OneCirro run to validate this, and it turned up no errors.