### PR TITLE
WASM: Fix how we call EntryQueryResponse in the WebAssembly streaming api

### DIFF
--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -393,7 +393,12 @@ PHASE(All)
 #endif
 #endif // #ifdef ENABLE_SIMDJS
 
+#ifdef _WIN32
 #define DEFAULT_CONFIG_Wasm               (true)
+#else
+// Do not enable wasm by default on xplat builds
+#define DEFAULT_CONFIG_Wasm               (false)
+#endif
 #define DEFAULT_CONFIG_WasmI64            (false)
 #if ENABLE_FAST_ARRAYBUFFER
     #define DEFAULT_CONFIG_WasmFastArray    (true)

--- a/lib/Runtime/Library/WebAssembly.cpp
+++ b/lib/Runtime/Library/WebAssembly.cpp
@@ -264,7 +264,7 @@ Var WebAssembly::TryResolveResponse(RecyclableObject* function, Var thisArg, Var
         CallInfo newCallInfo;
         newCallInfo.Count = 2;
         // We already have a response object, query it now
-        responsePromise = EntryQueryResponse(function, Js::CallInfo(CallFlags_Value, 2), thisArg, responseArg);
+        responsePromise = CALL_ENTRYPOINT_NOASSERT(EntryQueryResponse, function, Js::CallInfo(CallFlags_Value, 2), thisArg, responseArg);
     }
     else if (JavascriptPromise::Is(responseArg))
     {

--- a/lib/Runtime/Library/WebAssembly.cpp
+++ b/lib/Runtime/Library/WebAssembly.cpp
@@ -171,7 +171,7 @@ Var WebAssembly::EntryInstantiateBound(RecyclableObject* function, CallInfo call
     Var importObj = callInfo.Count > 1 ? args[1] : function->GetScriptContext()->GetLibrary()->GetUndefined();
     Var bufferSrc = callInfo.Count > 2 ? args[2] : function->GetScriptContext()->GetLibrary()->GetUndefined();
 
-    return EntryInstantiate(function, CallInfo(CallFlags_Value, 3), thisVar, bufferSrc, importObj);
+    return CALL_ENTRYPOINT_NOASSERT(EntryInstantiate, function, CallInfo(CallFlags_Value, 3), thisVar, bufferSrc, importObj);
 }
 
 Var WebAssembly::EntryValidate(RecyclableObject* function, CallInfo callInfo, ...)

--- a/test/wasm/rlexe.xml
+++ b/test/wasm/rlexe.xml
@@ -250,7 +250,7 @@
     <files>response.js</files>
     <baseline>baselines/response.baseline</baseline>
     <compile-flags>-wasm</compile-flags>
-    <tags>exclude_jshost,exclude_drt,exclude_win7,exclude_xplat</tags>
+    <tags>exclude_jshost,exclude_drt,exclude_win7</tags>
   </default>
 </test>
 <test>


### PR DESCRIPTION
Fix how we call EntryQueryResponse in the WebAssembly streaming api. Found by OSS-Fuzz.
Make WebAssembly off by default in xplat builds

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/4228)
<!-- Reviewable:end -->
