### PR TITLE
address sanitizer fake stack workaround

### DIFF
--- a/lib/Common/CommonBasic.h
+++ b/lib/Common/CommonBasic.h
@@ -8,6 +8,36 @@
 #include "CommonDefines.h"
 #define _CRT_RAND_S         // Enable rand_s in the CRT
 
+#ifndef __has_feature
+#define __has_feature(f) 0
+#endif
+
+#if __has_feature(address_sanitizer)
+#define ADDRESS_SANITIZER_APPEND(x) , x
+#define NO_SANITIZE_ADDRESS __attribute__((no_sanitize("address")))
+#define NO_SANITIZE_ADDRESS_FIXVC
+#else
+#define ADDRESS_SANITIZER_APPEND(x)
+#define NO_SANITIZE_ADDRESS
+#endif
+
+// AddressSanitizer: check if an address is in asan fake stack
+#if __has_feature(address_sanitizer)
+extern "C"
+{
+    void *__asan_get_current_fake_stack();
+    void *__asan_addr_is_in_fake_stack(void *fake_stack, void *addr, void **beg, void **end);
+}
+inline bool IsAsanFakeStackAddr(const void * p)
+{
+    void * fakeStack = __asan_get_current_fake_stack();
+    return fakeStack && __asan_addr_is_in_fake_stack(fakeStack, const_cast<void*>(p), nullptr, nullptr);
+}
+#define IS_ASAN_FAKE_STACK_ADDR(p) IsAsanFakeStackAddr(p)
+#else
+#define IS_ASAN_FAKE_STACK_ADDR(p) false
+#endif
+
 #if defined(PROFILE_RECYCLER_ALLOC) || defined(HEAP_TRACK_ALLOC) || defined(ENABLE_DEBUG_CONFIG_OPTIONS)
 #ifdef __clang__
 #include <typeinfo>

--- a/lib/Common/CommonDefines.h
+++ b/lib/Common/CommonDefines.h
@@ -671,15 +671,6 @@
 #define ENABLE_MEM_STATS 1
 #endif
 
-#define NO_SANITIZE_ADDRESS
-#if defined(__has_feature)
-#if __has_feature(address_sanitizer)
-#undef NO_SANITIZE_ADDRESS
-#define NO_SANITIZE_ADDRESS __attribute__((no_sanitize("address")))
-#define NO_SANITIZE_ADDRESS_FIXVC
-#endif
-#endif
-
 //----------------------------------------------------------------------------------------------------
 // Disabled features
 //----------------------------------------------------------------------------------------------------

--- a/lib/Common/Memory/RecyclerWriteBarrierManager.cpp
+++ b/lib/Common/Memory/RecyclerWriteBarrierManager.cpp
@@ -318,6 +318,11 @@ RecyclerWriteBarrierManager::OnSegmentFree(_In_ char* segmentAddress, size_t num
 void
 RecyclerWriteBarrierManager::WriteBarrier(void * address)
 {
+    if (IS_ASAN_FAKE_STACK_ADDR(address))
+    {
+        return;
+    }
+
 #ifdef RECYCLER_WRITE_BARRIER_BYTE
 #if ENABLE_DEBUG_CONFIG_OPTIONS
     VerifyIsBarrierAddress(address);
@@ -342,6 +347,11 @@ RecyclerWriteBarrierManager::WriteBarrier(void * address)
 void
 RecyclerWriteBarrierManager::WriteBarrier(void * address, size_t bytes)
 {
+    if (IS_ASAN_FAKE_STACK_ADDR(address))
+    {
+        return;
+    }
+
 #if ENABLE_DEBUG_CONFIG_OPTIONS
     VerifyIsBarrierAddress(address, bytes);
 #endif

--- a/lib/Runtime/Base/ThreadContext.h
+++ b/lib/Runtime/Base/ThreadContext.h
@@ -7,7 +7,7 @@
 namespace Js
 {
     class ScriptContext;
-    struct InlineCache;    
+    struct InlineCache;
     class CodeGenRecyclableData;
 #ifdef ENABLE_SCRIPT_DEBUGGING
     class DebugManager;
@@ -1457,7 +1457,7 @@ public:
         }
     }
 
-    static BOOLEAN IsOnStack(void const *ptr);
+    static bool IsOnStack(void const *ptr);
     _NOINLINE bool IsStackAvailable(size_t size);
     _NOINLINE bool IsStackAvailableNoThrow(size_t size = Js::Constants::MinStackDefault);
     static bool IsCurrentStackAvailable(size_t size);


### PR DESCRIPTION
Address sanitizer may redirect stack variables to fake stack (heap memory).
This causes GC to miss on-stack roots and causes other breaks related to
physical stack assumption.

Fixed using address sanitizer fake stack hooks:
 - GC ScanStack: Change SAVE_THREAD_CONTEXT() to also save current thread
   ASAN fake stack handle. Pass the handle when scanning on-stack roots
   (may be in background). In this mode we'll check every pointer found
   from register/physical stack. If the pointer is a fake stack address,
   scan the fake stack frame memory instead.
 - WriteBarrier: ignore fake stack address.
 - ThreadContext::IsOnStack: true if fake stack address.
 - entryExitRecord chain validation: only if not fake stack address.