### PR TITLE
perf: Improve get/set lookup times

### DIFF
--- a/lib/Runtime/Library/ConcatString.h
+++ b/lib/Runtime/Library/ConcatString.h
@@ -10,6 +10,7 @@ namespace Js
     {
     private:
         Field(PropertyString*) propertyString;
+        Field(const Js::PropertyRecord*) propertyRecord;
 
     public:
         virtual Js::PropertyRecord const * GetPropertyRecord(bool dontLookupFromDictionary = false) override;
@@ -272,7 +273,8 @@ namespace Js
         static uint32 GetOffsetOfSlots() { return offsetof(ConcatStringMulti, m_slots); }
     protected:
         Field(uint) slotCount;
-        Field(uint) __alignment;
+        Field(uint)   __alignment;
+        Field(size_t) __alignmentPTR;
         Field(JavascriptString*) m_slots[];   // These contain the child nodes.
 
 #if DBG

--- a/test/JSON/jx2.js
+++ b/test/JSON/jx2.js
@@ -29,7 +29,7 @@ var rev1 = function(name, value) {
     else {
         write(value);
     }
-    
+
 
     write("+++out reviver");
     if (value == 3) {
@@ -101,7 +101,7 @@ write(jsObjStringParsed.dateMember.getUTCFullYear());
 
 var rev2 = function(name, value) {
     if (this[name] != value) {
-        write("error");
+        write("error " + this[name] + " != " + value);
     }
     if (value == 3.14) {
         return undefined;
@@ -245,7 +245,7 @@ for (var i = 0; i < objectArray.length; i++) {
         reStringified = JSON.stringify(parsedObj);
         write("=== Parsed and restringified :")
         write(reStringified);
-        
+
         parsedObj = JSON.parse(stringifiedObj, rev2);
         reStringified = JSON.stringify(parsedObj);
         write("=== Parsed with reviver and restringified :")
@@ -302,7 +302,7 @@ for (var k = 0; k < replacerArray.length; k++) {
                 parsedObj = JSON.parse(stringifiedObj);
                 reStringified = JSON.stringify(parsedObj);
                 write("=== Parsed with no reviver and restringified :")
-                
+
                 write(reStringified);
                 parsedObj = JSON.parse(stringifiedObj, rev2);
                 reStringified = JSON.stringify(parsedObj);
@@ -321,7 +321,7 @@ for (var k = 0; k < replacerArray.length; k++) {
         parsedObj = JSON.parse(stringifiedObj);
         reStringified = JSON.stringify(parsedObj);
         write("=== Parsed with no reviver and restringified :")
-        
+
         checkStrEqual(reStringified, expectedString);
         parsedObj = JSON.parse(stringifiedObj, rev2);
         reStringified = JSON.stringify(parsedObj);


### PR DESCRIPTION
- Do not force create / cache PropertyString at the first place. PropertyRecord is what we need most of the time.
- Extend LiteralStringWithPropertyStringPtr with PropertyRecord (40 -> 48 bytes) and align other 40 bytes string object similarly. Long story short.. No actual extra memory usage.