### PR TITLE
Fixing the js reentrancy error happened while throwing.

### DIFF
--- a/test/Bugs/misc_bugs.js
+++ b/test/Bugs/misc_bugs.js
@@ -11,7 +11,14 @@ var tests = [
     body: function () {
          Date.prototype[Symbol.toPrimitive].call({},'strin' + 'g');
     }
-  }
+  },
+  {
+    name: "updated stackTraceLimit should not fire re-entrancy assert",
+    body: function () {
+        Error.__defineGetter__('stackTraceLimit', function () { return 1;});
+        assert.throws(()=> Array.prototype.map.call([]));
+    }
+  },
 ];
 
 testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });


### PR DESCRIPTION
When we throw we set the no-reentrancy flag to false. However we did that little late. By the time it is possible that we may go out due to stackTraceLimit. Which leads to this Assert.
Fixing this by moving it up. Now this is not real a re-entrancy problem. We were expecting the re-entrancy here due to a throw, it is just that we were resetting the flag little later.

Found by OSS-Fuzz
