### PR TITLE
JS Re-entrancy in EntrySlice.

### DIFF
--- a/lib/Runtime/Library/JavascriptArray.cpp
+++ b/lib/Runtime/Library/JavascriptArray.cpp
@@ -6410,7 +6410,7 @@ Case0:
 
         if (!isTypedArrayEntryPoint)
         {
-            JavascriptOperators::SetProperty(newObj, newObj, Js::PropertyIds::length, JavascriptNumber::ToVar(newLen, scriptContext), scriptContext, PropertyOperation_ThrowIfNotExtensible);
+            JS_REENTRANT(jsReentLock, JavascriptOperators::SetProperty(newObj, newObj, Js::PropertyIds::length, JavascriptNumber::ToVar(newLen, scriptContext), scriptContext, PropertyOperation_ThrowIfNotExtensible));
         }
 
 #ifdef VALIDATE_ARRAY

--- a/test/Bugs/misc_bugs.js
+++ b/test/Bugs/misc_bugs.js
@@ -19,6 +19,24 @@ var tests = [
         assert.throws(()=> Array.prototype.map.call([]));
     }
   },
+  {
+    name: "Array.prototype.slice should not fire re-entrancy error when the species returns proxy",
+    body: function () {
+        let arr = [1, 2];
+        arr.__proto__ = {
+          constructor: {
+            [Symbol.species]: function () {
+              return new Proxy({}, {
+                defineProperty(...args) {
+                  return Reflect.defineProperty(...args);
+                }
+              });
+            }
+          }
+        }
+        Array.prototype.slice.call(arr);
+    }
+  },
 ];
 
 testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });


### PR DESCRIPTION
Missing macro leads to re-entrancy assert. The newObj can be proxy so setting property can go to the user. Fixed that by putting the macro.

Found by OSS-Fuzz
