### PR TITLE
Fix issue with reading filename in asm.js error message

### DIFF
--- a/lib/Runtime/Language/AsmJsByteCodeGenerator.cpp
+++ b/lib/Runtime/Language/AsmJsByteCodeGenerator.cpp
@@ -272,20 +272,31 @@ namespace Js
             col = 0;
         }
 
-        char16 filename[_MAX_FNAME];
-        char16 ext[_MAX_EXT];
-        _wsplitpath_s( Configuration::Global.flags.Filename, NULL, 0, NULL, 0, filename, _MAX_FNAME, ext, _MAX_EXT );
-
         LPCOLESTR NoneName = _u("None");
         LPCOLESTR moduleName = NoneName;
-        if(mCompiler->GetModuleFunctionName())
+        if (mCompiler->GetModuleFunctionName())
         {
             moduleName = mCompiler->GetModuleFunctionName()->Psz();
         }
 
-        AsmJSCompiler::OutputError(mCompiler->GetScriptContext(),
+        char16 filename[_MAX_FNAME];
+        char16 ext[_MAX_EXT];
+        bool hasURL = mFunction->GetFuncBody()->GetSourceContextInfo()->url != nullptr;
+        Assert(hasURL || mFunction->GetFuncBody()->GetSourceContextInfo()->IsDynamic());
+        if (hasURL)
+        {
+            _wsplitpath_s(mFunction->GetFuncBody()->GetSourceContextInfo()->url, NULL, 0, NULL, 0, filename, _MAX_FNAME, ext, _MAX_EXT);
+        }
+        AsmJSCompiler::OutputError(
+            mCompiler->GetScriptContext(),
             _u("\n%s%s(%d, %d)\n\tAsm.js Compilation Error function : %s::%s\n\t%s\n"),
-            filename, ext, line + 1, col + 1, moduleName, mFunction->GetName()->Psz(), msg);
+            hasURL ? filename : _u("[Dynamic code]"),
+            hasURL ? ext : _u(""),
+            line + 1,
+            col + 1,
+            moduleName,
+            mFunction->GetName()->Psz(),
+            msg);
     }
 
     void AsmJSByteCodeGenerator::DefineLabels()

--- a/test/AsmJs/qmarkbug.baseline
+++ b/test/AsmJs/qmarkbug.baseline
@@ -1,11 +1,11 @@
 
-qmarkbug.js(6, 5)
+[Dynamic code](6, 5)
 	Asm.js Compilation Error function : None::f
 	Conditional expressions must be of type int, double, or float
 
 Asm.js compilation failed.
 
-qmarkbug.js(6, 5)
+[Dynamic code](6, 5)
 	Asm.js Compilation Error function : None::f
 	Conditional expressions must be of type int, double, or float
 

--- a/test/AsmJs/shadowingBug.baseline
+++ b/test/AsmJs/shadowingBug.baseline
@@ -1,12 +1,12 @@
 
-shadowingBug.js(1, 97)
+[Dynamic code](1, 97)
 	Asm.js Compilation Error function : None::f1
 	Invalid identifier f64
 
 Asm.js compilation failed.
 0
 
-shadowingBug.js(1, 97)
+[Dynamic code](1, 97)
 	Asm.js Compilation Error function : None::f1
 	Invalid identifier f64
 


### PR DESCRIPTION
In case of release build the FileName flag may be null. Instead, we can use URL from SourceContextInfo. This requires a baseline change, because of difference in how eval code is handled.

OS:14086004