### PR TITLE
Enable non-winglob Intl tests xplat

### DIFF
--- a/test/Intl/rlexe.xml
+++ b/test/Intl/rlexe.xml
@@ -11,7 +11,7 @@
   <test>
     <default>
       <files>Collator.js</files>
-      <tags>Intl</tags>
+      <tags>Intl,require_winglob</tags>
     </default>
   </test>
   <test>

--- a/test/runtests.py
+++ b/test/runtests.py
@@ -153,7 +153,7 @@ if args.verbose:
 # xplat: temp hard coded to exclude unsupported tests
 if sys.platform != 'win32':
     not_tags.add('exclude_xplat')
-    not_tags.add('Intl')
+    not_tags.add('require_winglob')
     not_tags.add('require_simd')
 
 if args.sanitize != None:


### PR DESCRIPTION
https://github.com/Microsoft/ChakraCore/pull/4229 enables us to run non-winglob Intl tests by default in jenkins linux/mac CI