### PR TITLE
ARM64: handle neg zero in inline round

### DIFF
--- a/lib/Backend/arm64/LowerMD.h
+++ b/lib/Backend/arm64/LowerMD.h
@@ -226,7 +226,8 @@ public:
 
             IR::Opnd*           IsOpndNegZero(IR::Opnd* opnd, IR::Instr* instr);
             void                GenerateFastInlineBuiltInMathAbs(IR::Instr *callInstr);
-            void                GenerateFastInlineBuiltInMathFloorCeilRound(IR::Instr *callInstr);
+            void                GenerateFastInlineBuiltInMathRound(IR::Instr *callInstr);
+            void                GenerateFastInlineBuiltInMathFloorCeil(IR::Instr *callInstr);
             void                GenerateFastInlineBuiltInMathMinMax(IR::Instr *callInstr);
             static RegNum       GetRegStackPointer() { return RegSP; }
             static RegNum       GetRegFramePointer() { return RegFP; }


### PR DESCRIPTION
The negative zero logic for round needs to be handled a little different than for floor/ceil.
