### PR TITLE
Fixing x86 stack walking issue.

### DIFF
--- a/lib/Runtime/Language/JavascriptStackWalker.cpp
+++ b/lib/Runtime/Language/JavascriptStackWalker.cpp
@@ -853,7 +853,9 @@ namespace Js
             // Under some odd cases on x86, addressOfReturnAddress and stashed entry address need to be aligned.
             // This happens when code is generated using two stack pointers. One or both have the address of 
             // return address offset by 4, 8, or 12.
-            || ((uint)addressOfReturnAddress & ~0xFF) == ((uint)nativeLibraryEntryAddress & ~0xFF)
+            || (((uint)nativeLibraryEntryAddress - (uint)addressOfReturnAddress < 0x10) &&
+                *(void**)addressOfReturnAddress == *(void**)nativeLibraryEntryAddress
+               )
 #endif
             ;
     }


### PR DESCRIPTION
The code to deal with x86 aligned return values was too loose, occasionally resulting in missing stack frames. This change tries to more accurately determine when the return value has shifted due to alignment.