### PR TITLE
Allowing the usage of large arg count run time

### DIFF
--- a/lib/Runtime/Base/CallInfo.h
+++ b/lib/Runtime/Base/CallInfo.h
@@ -36,6 +36,18 @@ namespace Js
             , unused(0)
 #endif
         {
+            // Keeping this version to avoid the assert
+        }
+
+        // The bool is used to avoid the signature confusion between the ArgSlot and uint version of the constructor
+        explicit CallInfo(uint count, bool unusedBool)
+            : Flags(CallFlags_None)
+            , Count(count)
+#ifdef TARGET_64
+            , unused(0)
+#endif
+        {
+            AssertOrFailFastMsg(count < CallInfo::kMaxCountArgs, "Argument list too large");
         }
 
         CallInfo(CallFlags flags, ArgSlot count)
@@ -45,6 +57,18 @@ namespace Js
             , unused(0)
 #endif
         {
+            // Keeping this version to avoid the assert
+        }
+
+        // The bool is used to avoid the signature confusion between the ArgSlot and uint version of the constructor
+        CallInfo(CallFlags flags, uint count, bool unusedBool)
+            : Flags(flags)
+            , Count(count)
+#ifdef TARGET_64
+            , unused(0)
+#endif
+        {
+            AssertOrFailFastMsg(count < CallInfo::kMaxCountArgs, "Argument list too large");
         }
 
         CallInfo(VirtualTableInfoCtorEnum v)
@@ -54,6 +78,11 @@ namespace Js
         ArgSlot GetArgCountWithExtraArgs() const
         {
             return CallInfo::GetArgCountWithExtraArgs(this->Flags, this->Count);
+        }
+
+        uint GetLargeArgCountWithExtraArgs() const
+        {
+            return CallInfo::GetLargeArgCountWithExtraArgs(this->Flags, this->Count);
         }
 
         bool HasExtraArg() const
@@ -74,6 +103,15 @@ namespace Js
             if (flags & CallFlags_ExtraArg)
             {
                 ArgSlotMath::Inc(count);
+            }
+            return count;
+        }
+
+        static uint GetLargeArgCountWithExtraArgs(CallFlags flags, uint count)
+        {
+            if (flags & CallFlags_ExtraArg)
+            {
+                UInt32Math::Inc(count);
             }
             return count;
         }

--- a/lib/Runtime/Language/Arguments.h
+++ b/lib/Runtime/Language/Arguments.h
@@ -210,6 +210,11 @@ namespace Js
             return Info.GetArgCountWithExtraArgs();
         }
 
+        uint GetLargeArgCountWithExtraArgs() const
+        {
+            return Info.GetLargeArgCountWithExtraArgs();
+        }
+
         FrameDisplay* GetFrameDisplay() const
         {
             AssertOrFailFast(Info.Flags & CallFlags_ExtraArg);

--- a/lib/Runtime/Language/InterpreterStackFrame.cpp
+++ b/lib/Runtime/Language/InterpreterStackFrame.cpp
@@ -2307,7 +2307,8 @@ namespace Js
 
     inline void InterpreterStackFrame::PopOut(ArgSlot argCount)
     {
-        m_outSp -= (argCount+1);
+        ArgSlotMath::Inc(argCount);
+        m_outSp -= argCount;
         m_outParams = (Var*)*m_outSp;
 
         AssertMsg(m_localSlots + this->m_functionBody->GetLocalsCount() <= m_outSp &&
@@ -3850,7 +3851,7 @@ namespace Js
         if (playout->Return == Js::Constants::NoRegister)
         {
             flags |= CallFlags_NotUsed;
-            Arguments args(CallInfo((CallFlags)flags, playout->ArgCount), m_outParams);
+            Arguments args(CallInfo((CallFlags)flags, argCount), m_outParams);
             AssertMsg(static_cast<unsigned>(args.Info.Flags) == flags, "Flags don't fit into the CallInfo field?");
                 argCount = args.GetArgCountWithExtraArgs();
             if (spreadIndices != nullptr)
@@ -3865,7 +3866,7 @@ namespace Js
         else
         {
             flags |= CallFlags_Value;
-            Arguments args(CallInfo((CallFlags)flags, playout->ArgCount), m_outParams);
+            Arguments args(CallInfo((CallFlags)flags, argCount), m_outParams);
             AssertMsg(static_cast<unsigned>(args.Info.Flags) == flags, "Flags don't fit into the CallInfo field?");
             argCount = args.GetArgCountWithExtraArgs();
             if (spreadIndices != nullptr)

--- a/lib/Runtime/Library/BoundFunction.cpp
+++ b/lib/Runtime/Library/BoundFunction.cpp
@@ -214,7 +214,8 @@ namespace Js
         }
 
         RecyclableObject* actualFunction = RecyclableObject::FromVar(targetFunction);
-        Var aReturnValue = JavascriptFunction::CallFunction<true>(actualFunction, actualFunction->GetEntryPoint(), actualArgs);
+        // Number of arguments are allowed to be more than Constants::MaxAllowedArgs in runtime. Need to use the larger argcount logic for this call.
+        Var aReturnValue = JavascriptFunction::CallFunction<true>(actualFunction, actualFunction->GetEntryPoint(), actualArgs, /* useLargeArgCount */ true);
 
         //
         // [[Construct]] and call returned a non-object

--- a/lib/Runtime/Library/JavascriptFunction.h
+++ b/lib/Runtime/Library/JavascriptFunction.h
@@ -131,11 +131,11 @@ namespace Js
         static void CheckValidDebugThunk(ScriptContext* scriptContext, RecyclableObject *function);
 #endif
         template <bool doStackProbe>
-        static Var CallFunction(RecyclableObject* obj, JavascriptMethod entryPoint, Arguments args);
+        static Var CallFunction(RecyclableObject* obj, JavascriptMethod entryPoint, Arguments args, bool useLargeArgCount = false);
         static Var CallRootFunction(RecyclableObject* obj, Arguments args, ScriptContext * scriptContext, bool inScript);
         static Var CallRootFunctionInternal(RecyclableObject* obj, Arguments args, ScriptContext * scriptContext, bool inScript);
         static Var CallSpreadFunction(RecyclableObject* obj, Arguments args, const Js::AuxArray<uint32> *spreadIndices);
-        static ArgSlot GetSpreadSize(const Arguments args, const Js::AuxArray<uint32> *spreadIndices, ScriptContext *scriptContext);
+        static uint GetSpreadSize(const Arguments args, const Js::AuxArray<uint32> *spreadIndices, ScriptContext *scriptContext);
         static void SpreadArgs(const Arguments args, Arguments& destArgs, const Js::AuxArray<uint32> *spreadIndices, ScriptContext *scriptContext);
         static Var EntrySpreadCall(const Js::AuxArray<uint32> *spreadIndices, RecyclableObject* function, CallInfo callInfo, ...);
         static void CheckAlignment();


### PR DESCRIPTION
Keeping the same limit on arg count both parse time and run time does not seem to be acceptable as there are lots of edgecrawler and DRT failures are indicating. So making provision to use large arg count when necessary.
