### PR TITLE
fix missing implicit kill for DIV

### DIFF
--- a/lib/Backend/amd64/PeepsMD.cpp
+++ b/lib/Backend/amd64/PeepsMD.cpp
@@ -29,7 +29,7 @@ PeepsMD::ProcessImplicitRegs(IR::Instr *instr)
     {
         this->peeps->ClearReg(RegRDX);
     }
-    else if (instr->m_opcode == Js::OpCode::IDIV)
+    else if (instr->m_opcode == Js::OpCode::IDIV || instr->m_opcode == Js::OpCode::DIV)
     {
         if (instr->GetDst()->AsRegOpnd()->GetReg() == RegRDX)
         {


### PR DESCRIPTION
RDX:RAX are always modified by DIV, so we need to mark the implicit kill in peeps. We were already doing this for x86, but case for DIV was missing on x64.

OS: 14520690