### PR TITLE
ARM64: Create MD Math.fround path

### DIFF
--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -18967,6 +18967,11 @@ Lowerer::GenerateFastInlineMathFround(IR::Instr* instr)
     Assert(dst->IsFloat());
     Assert(src1->IsFloat());
 
+    // This function is supposed to convert a float to the closest float32 representation.
+    // However, it is a bit loose about types, which the ARM64 encoder takes issue with.
+#ifdef _M_ARM64
+    LowererMD::GenerateFastInlineMathFround(instr);
+#else
     IR::Instr* fcvt64to32 = IR::Instr::New(LowererMD::MDConvertFloat64ToFloat32Opcode, dst, src1, instr->m_func);
 
     instr->InsertBefore(fcvt64to32);
@@ -18980,6 +18985,7 @@ Lowerer::GenerateFastInlineMathFround(IR::Instr* instr)
     }
 
     instr->Remove();
+#endif
     return;
 }
 

--- a/lib/Backend/arm64/LowerMD.h
+++ b/lib/Backend/arm64/LowerMD.h
@@ -229,6 +229,7 @@ public:
             void                GenerateFastInlineBuiltInMathRound(IR::Instr *callInstr);
             void                GenerateFastInlineBuiltInMathFloorCeil(IR::Instr *callInstr);
             void                GenerateFastInlineBuiltInMathMinMax(IR::Instr *callInstr);
+     static void                GenerateFastInlineMathFround(IR::Instr* instr);
             static RegNum       GetRegStackPointer() { return RegSP; }
             static RegNum       GetRegFramePointer() { return RegFP; }
 


### PR DESCRIPTION
The existing path doesn't properly convert register types in a few
cases; create a machine-dependent version for now. Note: We should
probably make this machine-independent later.
