### PR TITLE
Support turning off the `EnableJitInDiagMode` flag

### DIFF
--- a/lib/Backend/Func.cpp
+++ b/lib/Backend/Func.cpp
@@ -297,7 +297,7 @@ Func::Codegen(JitArenaAllocator *alloc, JITTimeWorkItem * workItem,
     {
         Func func(alloc, workItem, threadContextInfo,
             scriptContextInfo, outputData, epInfo, runtimeInfo,
-            polymorphicInlineCacheInfo, codeGenAllocators, 
+            polymorphicInlineCacheInfo, codeGenAllocators,
 #if !FLOATVAR
             numberAllocator,
 #endif
@@ -375,6 +375,11 @@ void
 Func::TryCodegen()
 {
     Assert(!IsJitInDebugMode() || !GetJITFunctionBody()->HasTry());
+
+     if (this->GetScriptContext()->IsInDebugButCantDoJITInDebug())
+     {
+         return;
+     }
 
     BEGIN_CODEGEN_PHASE(this, Js::BackEndPhase);
     {
@@ -581,7 +586,7 @@ Func::TryCodegen()
                 if (CONFIG_FLAG(OOPJITFixupValidate))
                 {
                     // Scan memory to see if there's missing pointer needs to be fixed up
-                    // This can hit false positive if some data field happens to have value 
+                    // This can hit false positive if some data field happens to have value
                     // falls into the NativeCodeData memory range.
                     NativeCodeData::DataChunk *next2 = chunk;
                     while (next2)

--- a/lib/Common/ConfigFlagsList.h
+++ b/lib/Common/ConfigFlagsList.h
@@ -479,7 +479,16 @@ PHASE(All)
 #define DEFAULT_CONFIG_ForceOldDateAPI      (false)
 #define DEFAULT_CONFIG_Loop                 (1)
 #define DEFAULT_CONFIG_ForceDiagnosticsMode (false)
+// xplat-todo: (obastemur) Enable JIT on Debug mode
+// CodeGen entrypoint can be deleted before we are able to unregister
+// due to how we handle xdata on xplat, resetting the entrypoints below might affect CodeGen process.
+// it is safer (on xplat) to turn JIT off during Debug for now.
+// once this enabled, also update Configuration::EnableJitInDebugMode()!
+#ifdef _WIN32
 #define DEFAULT_CONFIG_EnableJitInDiagMode  (true)
+#else
+#define DEFAULT_CONFIG_EnableJitInDiagMode  (false)
+#endif
 #define DEFAULT_CONFIG_UseFullName          (true)
 #define DEFAULT_CONFIG_EnableContinueAfterExceptionWrappersForHelpers  (true)
 #define DEFAULT_CONFIG_EnableContinueAfterExceptionWrappersForBuiltIns  (true)

--- a/lib/Common/Core/ConfigFlagsTable.cpp
+++ b/lib/Common/Core/ConfigFlagsTable.cpp
@@ -1262,7 +1262,14 @@ namespace Js
 
     bool Configuration::EnableJitInDebugMode()
     {
+#ifdef _WIN32
         return CONFIG_FLAG(EnableJitInDiagMode);
+#else
+        // xplat-todo: remove this only when JIT in Debug mode is enabled.
+        // why it's here? to benefit debugger tests for Windows with explicit EnableJitInDebugMode
+        // origininally, EnableJitInDiagMode call was ifdef-ed out for similar purposes.
+        return false;
+#endif
     }
 
     Configuration        Configuration::Global;

--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -3210,13 +3210,7 @@ namespace Js
 
         } autoRestore(this->GetThreadContext());
 
-        // xplat-todo: (obastemur) Enable JIT on Debug mode
-        // CodeGen entrypoint can be deleted before we are able to unregister
-        // due to how we handle xdata on xplat, resetting the entrypoints below might affect CodeGen process.
-        // it is safer (on xplat) to turn JIT off during Debug for now.
-#ifdef _WIN32
         if (!Js::Configuration::Global.EnableJitInDebugMode())
-#endif
         {
             if (attach)
             {
@@ -5889,6 +5883,10 @@ void ScriptContext::RegisterPrototypeChainEnsuredToHaveOnlyWritableDataPropertie
         return true;
     }
 
+    bool ScriptContext::IsInDebugButCantDoJITInDebug() const
+    {
+        return !Js::Configuration::Global.EnableJitInDebugMode() && IsScriptContextInDebugMode();
+    }
 
     bool ScriptContext::IsScriptContextInDebugMode() const
     {

--- a/lib/Runtime/Base/ScriptContext.h
+++ b/lib/Runtime/Base/ScriptContext.h
@@ -496,6 +496,7 @@ namespace Js
         bool IsDiagnosticsScriptContext() const { return this->isDiagnosticsScriptContext; }
         bool IsScriptContextInNonDebugMode() const;
         bool IsScriptContextInDebugMode() const;
+        bool IsInDebugButCantDoJITInDebug() const;
         bool IsScriptContextInSourceRundownOrDebugMode() const;
 
 #ifdef ENABLE_SCRIPT_DEBUGGING
@@ -1594,7 +1595,7 @@ private:
         private:
             ScriptContext* m_scriptContext;
         };
-#endif        
+#endif
 
 #ifdef EDIT_AND_CONTINUE
     private:
@@ -1678,7 +1679,7 @@ private:
         HRESULT OnDispatchFunctionExit(const WCHAR *pwszFunctionName);
 
 #endif // ENABLE_SCRIPT_PROFILING
-       
+
         void OnStartupComplete();
         void SaveStartupProfileAndRelease(bool isSaveOnClose = false);
 


### PR DESCRIPTION
- When `EnableJitInDiagMode` was set to false, Codegen was still issuing JIT
- JIT debug was previously force disabled on xplat, turn off the flag on xplat.
- also fixes a bug reported by OSS-FUZZ (originally reported under #3352)
- #3352 still tracks `enabling DebugJIT back on xplat`