### PR TITLE
When expiring an entrypoint, reset to CheckCodeGenThunk

### DIFF
--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -9292,7 +9292,6 @@ namespace Js
                     if (!PHASE_OFF(Js::BackEndPhase, functionBody) && !functionBody->GetScriptContext()->GetConfig()->IsNoNative())
                     {
                         GenerateFunction(functionBody->GetScriptContext()->GetNativeCodeGenerator(), functionBody);
-                        newEntryPoint = functionBody->GetDefaultFunctionEntryPointInfo();
                     }
 #endif
                 }

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -9286,7 +9286,15 @@ namespace Js
                 else
                 {
                     newEntryPoint = functionBody->CreateNewDefaultEntryPoint();
-                    functionBody->SetDefaultInterpreterExecutionMode();
+                    functionBody->ReinitializeExecutionModeAndLimits();
+#if ENABLE_NATIVE_CODEGEN
+                    // In order for the function to ever get JIT again, we need to call GenerateFunction now
+                    if (!PHASE_OFF(Js::BackEndPhase, functionBody) && !functionBody->GetScriptContext()->GetConfig()->IsNoNative())
+                    {
+                        GenerateFunction(functionBody->GetScriptContext()->GetNativeCodeGenerator(), functionBody);
+                        newEntryPoint = functionBody->GetDefaultFunctionEntryPointInfo();
+                    }
+#endif
                 }
                 functionBody->TraceExecutionMode("JitCodeExpired");
             }


### PR DESCRIPTION
We were setting to DefaultEntryThunk, but you can never get to codegen from there. To allow codegen, we need to call GenerateFunction, which will set entrypoint to CheckCodeGenThunk and allow function to eventually be JIT.

OS: 14090790