### PR TITLE
Fix assert for static ctor on a subclass

### DIFF
--- a/lib/Runtime/Types/DictionaryTypeHandler.cpp
+++ b/lib/Runtime/Types/DictionaryTypeHandler.cpp
@@ -1870,8 +1870,10 @@ namespace Js
                         // something else.  All we need to do is convert the descriptor to a data descriptor.
                         // Built-in Function.prototype properties 'length', 'arguments', and 'caller' are special cases.
 
-                        ((JavascriptOperators::IsClassConstructor(ctor) || JavascriptOperators::IsClassMethod(ctor)) &&
-                            (attributes & PropertyClassMemberDefaults) == PropertyClassMemberDefaults),
+                        ((JavascriptOperators::IsClassConstructor(instance) // Static method
+                            || JavascriptOperators::IsClassConstructor(ctor)
+                            || JavascriptOperators::IsClassMethod(ctor))
+                            && (attributes & PropertyClassMemberDefaults) == PropertyClassMemberDefaults),
                         // 14.3.9: InitClassMember sets property descriptor to {writable:true, enumerable:false, configurable:true}
 
                         "Expect to only come down this path for InitClassMember or InitRootFld (on the global object) overwriting existing accessor property");

--- a/test/es6/classes_bugfixes.js
+++ b/test/es6/classes_bugfixes.js
@@ -482,6 +482,12 @@ var tests = [
         static get igwgep() { }
         static igwgep() { }
       };
+      
+      class staticTest2 extends null {
+        static constructor() { }
+        static get igwgep() { }
+        static igwgep() { }
+      };
     }
   },
   {


### PR DESCRIPTION
Fixes OS: 12681861

This is an additional fix to the assert changes in #3772. For the subclass case, it is the instance that needs the constructor check, not the constructor property.
