### PR TITLE
ARM64: Restrict legalization of LEA to better match ADD

### DIFF
--- a/lib/Backend/arm64/EncoderMD.cpp
+++ b/lib/Backend/arm64/EncoderMD.cpp
@@ -125,6 +125,7 @@ void EncoderMD::CanonicalizeLea(IR::Instr * instr)
         this->BaseAndOffsetFromSym(symOpnd, &baseReg, &offset, this->m_func);
         symOpnd->Free(this->m_func);
         instr->SetSrc1(IR::RegOpnd::New(nullptr, baseReg, TyMachReg, this->m_func));
+        Assert(IS_CONST_00000FFF(offset) || IS_CONST_00FFF000(offset));
         instr->SetSrc2(IR::IntConstOpnd::New(offset, TyMachReg, this->m_func));
     }
     else
@@ -144,6 +145,8 @@ void EncoderMD::CanonicalizeLea(IR::Instr * instr)
         }
         else
         {
+            // We want to emit a legal instruction
+            Assert(IS_CONST_00000FFF(offset) || IS_CONST_00FFF000(offset));
             instr->SetSrc2(IR::IntConstOpnd::New(offset, TyMachReg, this->m_func));
         }
         indirOpnd->Free(this->m_func);

--- a/lib/Backend/arm64/LegalizeMD.cpp
+++ b/lib/Backend/arm64/LegalizeMD.cpp
@@ -366,6 +366,13 @@ void LegalizeMD::LegalizeIndirOffset(IR::Instr * instr, IR::IndirOpnd * indirOpn
             return;
         }
     }
+    if (forms & L_IndirU12Lsl12)
+    {
+        if (IS_CONST_UINT12(offset) || IS_CONST_UINT12LSL12(offset))
+        {
+            return;
+        }
+    }
 
     // scaled signed 9-bit offset
     if (forms & L_IndirSI7)

--- a/lib/Backend/arm64/LegalizeMD.h
+++ b/lib/Backend/arm64/LegalizeMD.h
@@ -23,7 +23,8 @@ enum LegalForms
     L_IndirSU12I9 = 0x1000,
     L_IndirSI7 =    0x2000,
     L_IndirU12 =    0x4000,
-    L_IndirMask =  (L_IndirSU12I9 | L_IndirSI7 | L_IndirU12),
+    L_IndirU12Lsl12=0x8000,
+    L_IndirMask =  (L_IndirSU12I9 | L_IndirSI7 | L_IndirU12 | L_IndirU12Lsl12),
 
     L_SymSU12I9 =  0x10000,
     L_SymSI7 =     0x20000,
@@ -57,6 +58,7 @@ struct LegalInstrForms
 #define LEGAL_LABEL    { L_Reg,     { L_Label } }
 #define LEGAL_LDIMM    { L_Reg,     { L_Imm,     L_None } }
 #define LEGAL_LDIMM_S  { L_Reg,     { (LegalForms)(L_ImmU16 | L_Label),     L_ImmU6 } }
+#define LEGAL_LEA      { L_Reg,     { (LegalForms)(L_IndirU12Lsl12 | L_SymSU12I9), L_None } }
 #define LEGAL_LOAD     { L_Reg,     { (LegalForms)(L_IndirSU12I9 | L_SymSU12I9), L_None } }
 #define LEGAL_LOADP    { L_Reg,     { (LegalForms)(L_IndirSI7 | L_SymSI7), L_Reg } }
 #define LEGAL_PLD      { L_None,    { (LegalForms)(L_IndirSU12I9 | L_SymSU12I9), L_None } }

--- a/lib/Backend/arm64/MdOpCodes.h
+++ b/lib/Backend/arm64/MdOpCodes.h
@@ -62,7 +62,7 @@ MACRO(LDP,        Reg3,       0,              UNUSED,   LEGAL_LOADP,    UNUSED, 
 MACRO(LDP_POST,   Reg3,       0,              UNUSED,   LEGAL_LOADP,    UNUSED,   DL__)
 MACRO(LDR,        Reg2,       0,              UNUSED,   LEGAL_LOAD,     UNUSED,   DL__)
 MACRO(LDRS,       Reg2,       0,              UNUSED,   LEGAL_LOAD,     UNUSED,   DL__)
-MACRO(LEA,        Reg3,       0,              UNUSED,   LEGAL_LOAD,     UNUSED,   D___)
+MACRO(LEA,        Reg3,       0,              UNUSED,   LEGAL_LEA,      UNUSED,   D___)
 MACRO(LSL,        Reg2,       0,              UNUSED,   LEGAL_SHIFT,    UNUSED,   D___)
 MACRO(LSR,        Reg2,       0,              UNUSED,   LEGAL_SHIFT,    UNUSED,   D___)
 MACRO(MOV,        Reg2,       0,              UNUSED,   LEGAL_REG2,     UNUSED,   DM__)


### PR DESCRIPTION
Since LEAs get directly converted to Adds in CanonicalizeLea, using
the same legalization restrictions as ADD (to a degree) fixes cases
where we were generating overly-large adds.

This change additionally inserts legalization at a few more points,
where previously we may have not been legalizing.
