### PR TITLE
Always disable warning 4800

### DIFF
--- a/Build/Chakra.Build.props
+++ b/Build/Chakra.Build.props
@@ -52,6 +52,7 @@
         %(DisableSpecificWarnings);
         4458;     <!-- declaration of '' hides class member -->
         4312;     <!-- 'type cast': conversion from '' to '' of greater size -->
+        4800;     <!-- type' : forcing value to bool 'true' or 'false' (performance warning) [always off in 2017 by default, but warns in 2015 -->
       </DisableSpecificWarnings>
       <!-- Use the debug CRT in debug build -->
       <RuntimeLibrary Condition="'$(Configuration)'=='Debug' AND '$(RuntimeLib)'!='static_library'">MultiThreadedDebugDLL</RuntimeLibrary>


### PR DESCRIPTION
After speaking with Michael Ferris about this, we are under agreement that this is somewhat unnecessary to ever warn on. Since it only warns in 2015 and not 2017, it can also cause easy-to-miss CI failures.

See: https://msdn.microsoft.com/en-us/library/b6801kcy.aspx