### PR TITLE
ARM64: Enable CFG codegen and checks.

### DIFF
--- a/lib/Backend/EmitBuffer.cpp
+++ b/lib/Backend/EmitBuffer.cpp
@@ -217,7 +217,7 @@ EmitBufferManager<TAlloc, TPreReservedAlloc, SyncObject>::FreeAllocation(void* a
                 this->scriptContext->GetThreadContext()->SubCodeSize(allocation->bytesCommitted);
             }
 
-#if defined(_CONTROL_FLOW_GUARD) && (_M_IX86 || _M_X64)
+#if defined(_CONTROL_FLOW_GUARD) && (_M_IX86 || _M_X64_OR_ARM64)
             if (allocation->allocation->thunkAddress)
             {
                 if (JITManager::GetJITManager()->IsJITServer())

--- a/lib/Backend/Func.cpp
+++ b/lib/Backend/Func.cpp
@@ -1157,7 +1157,7 @@ bool Func::CanAllocInPreReservedHeapPageSegment ()
         && GetInProcCodeGenAllocators()->canCreatePreReservedSegment
 #endif
         );
-#elif _M_X64
+#elif _M_X64_OR_ARM64
         && true);
 #else
         && false); //Not yet implemented for architectures other than x86 and amd64.

--- a/lib/Backend/JITOutput.cpp
+++ b/lib/Backend/JITOutput.cpp
@@ -256,7 +256,7 @@ JITOutput::FinalizeNativeCode()
     {
         m_func->GetOOPCodeGenAllocators()->emitBufferManager.CompletePreviousAllocation(m_oopAlloc);
 #if defined(_CONTROL_FLOW_GUARD)
-#if _M_IX86 || _M_X64
+#if _M_IX86 || _M_X64_OR_ARM64
         if (!m_func->IsLoopBody() && CONFIG_FLAG(UseJITTrampoline))
         {
             allocation->thunkAddress = m_func->GetOOPThreadContext()->GetJITThunkEmitter()->CreateThunk(m_outputData->codeAddress);
@@ -276,7 +276,7 @@ JITOutput::FinalizeNativeCode()
 #endif
 
 #if defined(_CONTROL_FLOW_GUARD)
-#if _M_IX86 || _M_X64
+#if _M_IX86 || _M_X64_OR_ARM64
         if (!m_func->IsLoopBody() && CONFIG_FLAG(UseJITTrampoline))
         {
             allocation->thunkAddress = m_func->GetInProcThreadContext()->GetJITThunkEmitter()->CreateThunk(m_outputData->codeAddress);

--- a/lib/Backend/JITThunkEmitter.h
+++ b/lib/Backend/JITThunkEmitter.h
@@ -4,17 +4,27 @@
 //-------------------------------------------------------------------------------------------------------
 #pragma once
 
-#if defined(ENABLE_NATIVE_CODEGEN) && defined(_CONTROL_FLOW_GUARD) && (_M_IX86 || _M_X64)
+#if defined(ENABLE_NATIVE_CODEGEN) && defined(_CONTROL_FLOW_GUARD) && (_M_IX86 || _M_X64_OR_ARM64)
 template <typename TAlloc>
 class JITThunkEmitter
 {
 private:
+#if _M_IX86 || _M_AMD64
     static const BYTE DirectJmp[];
     static const uint DirectJmpTargetOffset = 1;
     static const uint DirectJmpIPAdjustment = 5;
+#endif
 #if _M_AMD64
     static const BYTE IndirectJmp[];
     static const uint IndirectJmpTargetOffset = 2;
+#endif
+#if _M_ARM64
+    static const DWORD DirectB[];
+    static const DWORD IndirectBR[];
+    static const uint IndirectBRTempReg = 17;
+    static const uint IndirectBRLo16Offset = 0;
+    static const uint IndirectBRMid16Offset = 1;
+    static const uint IndirectBRHi16Offset = 2;
 #endif
     static const uint PageCount = 100;
     static const size_t ThunkSize = 16;

--- a/lib/Backend/ServerThreadContext.cpp
+++ b/lib/Backend/ServerThreadContext.cpp
@@ -18,7 +18,7 @@ ServerThreadContext::ServerThreadContext(ThreadContextDataIDL * data, HANDLE pro
     m_sectionAllocator(processHandle),
     m_thunkPageAllocators(nullptr, /* allocXData */ false, &m_sectionAllocator, nullptr, processHandle),
     m_codePageAllocators(nullptr, ALLOC_XDATA, &m_sectionAllocator, &m_preReservedSectionAllocator, processHandle),
-#if defined(_CONTROL_FLOW_GUARD) && (_M_IX86 || _M_X64)
+#if defined(_CONTROL_FLOW_GUARD) && (_M_IX86 || _M_X64_OR_ARM64)
     m_jitThunkEmitter(this, &m_sectionAllocator, processHandle),
 #endif
     m_codeGenAlloc(nullptr, nullptr, this, &m_codePageAllocators, processHandle),
@@ -139,7 +139,7 @@ ServerThreadContext::GetCodeGenAllocators()
     return &m_codeGenAlloc;
 }
 
-#if defined(_CONTROL_FLOW_GUARD) && (_M_IX86 || _M_X64)
+#if defined(_CONTROL_FLOW_GUARD) && (_M_IX86 || _M_X64_OR_ARM64)
 OOPJITThunkEmitter *
 ServerThreadContext::GetJITThunkEmitter()
 {

--- a/lib/Backend/ServerThreadContext.h
+++ b/lib/Backend/ServerThreadContext.h
@@ -38,7 +38,7 @@ public:
     virtual ptrdiff_t GetCRTBaseAddressDifference() const override;
 
     OOPCodeGenAllocators * GetCodeGenAllocators();
-#if defined(_CONTROL_FLOW_GUARD) && (_M_IX86 || _M_X64)
+#if defined(_CONTROL_FLOW_GUARD) && (_M_IX86 || _M_X64_OR_ARM64)
     OOPJITThunkEmitter * GetJITThunkEmitter();
 #endif
     CustomHeap::OOPCodePageAllocators * GetThunkPageAllocators();
@@ -67,7 +67,7 @@ private:
     CustomHeap::OOPCodePageAllocators m_thunkPageAllocators;
     CustomHeap::OOPCodePageAllocators  m_codePageAllocators;
     OOPCodeGenAllocators m_codeGenAlloc;
-#if defined(_CONTROL_FLOW_GUARD) && (_M_IX86 || _M_X64)
+#if defined(_CONTROL_FLOW_GUARD) && (_M_IX86 || _M_X64_OR_ARM64)
     OOPJITThunkEmitter m_jitThunkEmitter;
 #endif
     // only allocate with this from foreground calls (never from CodeGen calls)

--- a/lib/Backend/arm64/LowerMD.cpp
+++ b/lib/Backend/arm64/LowerMD.cpp
@@ -8115,8 +8115,7 @@ LowererMD::GenerateCFGCheck(IR::Opnd * entryPointOpnd, IR::Instr * insertBeforeI
     //MOV  x15, entryPoint
     IR::RegOpnd * entryPointRegOpnd = IR::RegOpnd::New(nullptr, RegR15, TyMachReg, this->m_func);
     entryPointRegOpnd->m_isCallArg = true;
-    IR::Instr* movInstrEntryPointToRegister = IR::Instr::New(Js::OpCode::MOV, entryPointRegOpnd, entryPointOpnd, this->m_func);
-    insertBeforeInstr->InsertBefore(movInstrEntryPointToRegister);
+    IR::Instr *movInstrEntryPointToRegister = Lowerer::InsertMove(entryPointRegOpnd, entryPointOpnd, insertBeforeInstr);
 
     //Generate CheckCFG CALL here
     IR::HelperCallOpnd *cfgCallOpnd = IR::HelperCallOpnd::New(IR::HelperGuardCheckCall, this->m_func);
@@ -8125,8 +8124,7 @@ LowererMD::GenerateCFGCheck(IR::Opnd * entryPointOpnd, IR::Instr * insertBeforeI
 
     //mov x16, __guard_check_icall_fptr
     IR::RegOpnd *targetOpnd = IR::RegOpnd::New(nullptr, RegR16, TyMachPtr, this->m_func);
-    IR::Instr   *movInstr = IR::Instr::New(Js::OpCode::MOV, targetOpnd, cfgCallOpnd, this->m_func);
-    insertBeforeInstr->InsertBefore(movInstr);
+    IR::Instr   *movInstr = Lowerer::InsertMove(targetOpnd, cfgCallOpnd, insertBeforeInstr);
     Legalize(movInstr);
 
     //call x16

--- a/lib/Backend/arm64/LowerMD.h
+++ b/lib/Backend/arm64/LowerMD.h
@@ -146,6 +146,9 @@ public:
             void            LowerInt4RemWithBailOut(IR::Instr *const instr, const IR::BailOutKind bailOutKind, IR::LabelInstr *const bailOutLabel, IR::LabelInstr *const skipBailOutLabel) const;
             void            MarkOneFltTmpSym(StackSym *sym, BVSparse<JitArenaAllocator> *bvTmps, bool fFltPrefOp);
             void            GenerateFastRecyclerAlloc(size_t allocSize, IR::RegOpnd* newObjDst, IR::Instr* insertionPointInstr, IR::LabelInstr* allocHelperLabel, IR::LabelInstr* allocDoneLabel);
+#ifdef _CONTROL_FLOW_GUARD
+            void            GenerateCFGCheck(IR::Opnd * entryPointOpnd, IR::Instr * insertBeforeInstr);
+#endif
             void            SaveDoubleToVar(IR::RegOpnd * dstOpnd, IR::RegOpnd *opndFloat, IR::Instr *instrOrig, IR::Instr *instrInsert, bool isHelper = false);
             void            EmitLoadFloat(IR::Opnd *dst, IR::Opnd *src, IR::Instr *insertInstr, IR::Instr * instrBailOut = nullptr, IR::LabelInstr * labelBailOut = nullptr);
             IR::Instr *     LoadCheckedFloat(IR::RegOpnd *opndOrig, IR::RegOpnd *opndFloat, IR::LabelInstr *labelInline, IR::LabelInstr *labelHelper, IR::Instr *instrInsert, const bool checkForNullInLoopBody = false);
@@ -290,7 +293,7 @@ private:
         IR::Opnd* srcOpnd,
         IR::Instr* instr);
 
-    IR::Instr*  GeneratePreCall(IR::Instr * callInstr, IR::Opnd  *functionOpnd);
+    IR::Instr*  GeneratePreCall(IR::Instr * callInstr, IR::Opnd  *functionOpnd, IR::Instr * insertBeforeInstrForCFGCheck);
     void        SetMaxArgSlots(Js::ArgSlot actualCount /*including this*/);
 // Data
 protected:

--- a/lib/Backend/arm64/Thunks.asm
+++ b/lib/Backend/arm64/Thunks.asm
@@ -26,40 +26,36 @@
     ;Js::Var NativeCodeGenerator::CheckCodeGenThunk(Js::RecyclableObject* function, Js::CallInfo callInfo, ...)
     NESTED_ENTRY ?CheckCodeGenThunk@NativeCodeGenerator@@SAPEAXPEAVRecyclableObject@Js@@UCallInfo@3@ZZ
 
-    PROLOG_SAVE_REG_PAIR fp, lr, #-(16*8+32)!          ; establish stack frame
-    PROLOG_SAVE_REG_PAIR x19, x20, #16
-    stp     x0, x1, [sp, #32+0*8]
-    stp     x2, x3, [sp, #32+2*8]
-    stp     x4, x5, [sp, #32+4*8]
-    stp     x6, x7, [sp, #32+6*8]
-    stp     x8, x9, [sp, #32+8*8]
-    stp     x10, x11, [sp, #32+10*8]
-    stp     x12, x13, [sp, #32+12*8]
-    stp     x14, x15, [sp, #32+14*8]
+    PROLOG_SAVE_REG_PAIR fp, lr, #-(2*8+16*8)!          ; establish stack frame
+    stp     d0, d1, [sp, #16+0*8]
+    stp     d2, d3, [sp, #16+2*8]
+    stp     d4, d5, [sp, #16+4*8]
+    stp     d6, d7, [sp, #16+6*8]
+    stp     x0, x1, [sp, #16+8*8]
+    stp     x2, x3, [sp, #16+10*8]
+    stp     x4, x5, [sp, #16+12*8]
+    stp     x6, x7, [sp, #16+14*8]
 
     bl      |?CheckCodeGen@NativeCodeGenerator@@SAP6APEAXPEAVRecyclableObject@Js@@UCallInfo@3@ZZPEAVScriptFunction@3@@Z|  ; call  NativeCodeGenerator::CheckCodeGen
+    mov     x15, x0               ; move entry point to x15
 
 #if defined(_CONTROL_FLOW_GUARD)
     mov     x15, x0               ; __guard_check_icall_fptr requires the call target in x15
     adrp    x17, __guard_check_icall_fptr
     ldr     x17, [x17, __guard_check_icall_fptr]
     blr     x17
-    mov     x17, x15              ; restore entryPoint in x17
-#else
-    mov     x17, x0               ; back up entryPoint in x17
 #endif
 
-    ldp     x0, x1, [sp, #32+0*8]
-    ldp     x2, x3, [sp, #32+2*8]
-    ldp     x4, x5, [sp, #32+4*8]
-    ldp     x6, x7, [sp, #32+6*8]
-    ldp     x8, x9, [sp, #32+8*8]
-    ldp     x10, x11, [sp, #32+10*8]
-    ldp     x12, x13, [sp, #32+12*8]
-    ldp     x14, x15, [sp, #32+14*8]
-    EPILOG_RESTORE_REG_PAIR x19, x20, #16
-    EPILOG_RESTORE_REG_PAIR fp, lr, #(16*8+32)!
-    EPILOG_NOP br x17             ; jump (tail call) to new entryPoint
+    ldp     d0, d1, [sp, #16+0*8]
+    ldp     d2, d3, [sp, #16+2*8]
+    ldp     d4, d5, [sp, #16+4*8]
+    ldp     d6, d7, [sp, #16+6*8]
+    ldp     x0, x1, [sp, #16+8*8]
+    ldp     x2, x3, [sp, #16+10*8]
+    ldp     x4, x5, [sp, #16+12*8]
+    ldp     x6, x7, [sp, #16+14*8]
+    EPILOG_RESTORE_REG_PAIR fp, lr, #(2*8+16*8)!
+    EPILOG_NOP br x15             ; jump (tail call) to new entryPoint
 
     NESTED_END
 

--- a/lib/Backend/arm64/Thunks.asm
+++ b/lib/Backend/arm64/Thunks.asm
@@ -40,7 +40,6 @@
     mov     x15, x0               ; move entry point to x15
 
 #if defined(_CONTROL_FLOW_GUARD)
-    mov     x15, x0               ; __guard_check_icall_fptr requires the call target in x15
     adrp    x17, __guard_check_icall_fptr
     ldr     x17, [x17, __guard_check_icall_fptr]
     blr     x17

--- a/lib/Common/Core/SysInfo.cpp
+++ b/lib/Common/Core/SysInfo.cpp
@@ -384,7 +384,11 @@ AutoSystemInfo::IsWin8OrLater()
 bool
 AutoSystemInfo::IsWinThresholdOrLater()
 {
+#if defined(_M_ARM64)
+    return true;
+#else
     return IsWindowsThresholdOrGreater();
+#endif
 }
 #endif
 

--- a/lib/JITServer/JITServer.cpp
+++ b/lib/JITServer/JITServer.cpp
@@ -267,7 +267,7 @@ ServerInitializeThreadContext(
         {
             *prereservedRegionAddr = (intptr_t)contextInfo->GetPreReservedSectionAllocator()->EnsurePreReservedRegion();
         }
-#if _M_IX86 || _M_X64
+#if _M_IX86 || _M_X64_OR_ARM64
         *jitThunkAddr = (intptr_t)contextInfo->GetJITThunkEmitter()->EnsureInitialized();
 #endif
 #endif

--- a/lib/Runtime/Base/FunctionBody.cpp
+++ b/lib/Runtime/Base/FunctionBody.cpp
@@ -3433,7 +3433,7 @@ namespace Js
 #if ENABLE_NATIVE_CODEGEN
         JavascriptMethod originalEntryPoint = this->GetOriginalEntryPoint_Unchecked();
         return
-#if defined(_CONTROL_FLOW_GUARD) && (_M_IX86 || _M_X64)
+#if defined(_CONTROL_FLOW_GUARD) && (_M_IX86 || _M_X64_OR_ARM64)
             (
 #if ENABLE_OOP_NATIVE_CODEGEN
             JITManager::GetJITManager()->IsOOPJITEnabled()

--- a/lib/Runtime/Base/ThreadContext.cpp
+++ b/lib/Runtime/Base/ThreadContext.cpp
@@ -172,7 +172,7 @@ ThreadContext::ThreadContext(AllocationPolicyManager * allocationPolicyManager, 
     thunkPageAllocators(allocationPolicyManager, /* allocXData */ false, /* virtualAllocator */ nullptr, GetCurrentProcess()),
 #endif
     codePageAllocators(allocationPolicyManager, ALLOC_XDATA, GetPreReservedVirtualAllocator(), GetCurrentProcess()),
-#if defined(_CONTROL_FLOW_GUARD) && (_M_IX86 || _M_X64)
+#if defined(_CONTROL_FLOW_GUARD) && (_M_IX86 || _M_X64_OR_ARM64)
     jitThunkEmitter(this, &VirtualAllocWrapper::Instance , GetCurrentProcess()),
 #endif
 #endif

--- a/lib/Runtime/Base/ThreadContext.h
+++ b/lib/Runtime/Base/ThreadContext.h
@@ -717,7 +717,7 @@ private:
     CustomHeap::InProcCodePageAllocators thunkPageAllocators;
 #endif
     CustomHeap::InProcCodePageAllocators codePageAllocators;
-#if defined(_CONTROL_FLOW_GUARD) && (_M_IX86 || _M_X64)
+#if defined(_CONTROL_FLOW_GUARD) && (_M_IX86 || _M_X64_OR_ARM64)
     InProcJITThunkEmitter jitThunkEmitter;
 #endif
 #endif
@@ -880,7 +880,7 @@ public:
 #endif
     CustomHeap::InProcCodePageAllocators * GetCodePageAllocators() { return &codePageAllocators; }
 
-#if defined(_CONTROL_FLOW_GUARD) && (_M_IX86 || _M_X64)
+#if defined(_CONTROL_FLOW_GUARD) && (_M_IX86 || _M_X64_OR_ARM64)
     InProcJITThunkEmitter * GetJITThunkEmitter() { return &jitThunkEmitter; }
 #endif
 #endif // ENABLE_NATIVE_CODEGEN


### PR DESCRIPTION
Note that some of the changes to GeneratePreCall that seem superfluous are intended to bring the code more closely aligned with the x64 version (minus the AsmJs case which is NYI).