### PR TITLE
Relax noisy CheckIsExecutable assert

### DIFF
--- a/lib/Backend/BackendApi.cpp
+++ b/lib/Backend/BackendApi.cpp
@@ -137,8 +137,13 @@ void CheckIsExecutable(Js::RecyclableObject * function, Js::JavascriptMethod ent
     Js::ScriptContext * scriptContext = function->GetScriptContext();
     // it's easy to call the default entry point from RecyclableObject.
     AssertMsg((Js::JavascriptFunction::Is(function) && Js::JavascriptFunction::FromVar(function)->IsExternalFunction())
-        || Js::CrossSite::IsThunk(entrypoint) || !scriptContext->IsActuallyClosed() ||
-        (scriptContext->GetThreadContext()->IsScriptActive() && !Js::JavascriptConversion::IsCallable(function)),
+        || Js::CrossSite::IsThunk(entrypoint)
+        // External object with entrypoint
+        || (!Js::JavascriptFunction::Is(function)
+            && function->IsExternal()
+            && Js::JavascriptConversion::IsCallable(function))
+        || !scriptContext->IsActuallyClosed()
+        || (scriptContext->GetThreadContext()->IsScriptActive() && !Js::JavascriptConversion::IsCallable(function)),
         "Can't call function when the script context is closed");
 
     if (scriptContext->GetThreadContext()->IsScriptActive())


### PR DESCRIPTION
Fixes OS: 14324283: CAS:EdgeCrawler: ASSERT:  Can't call function when the script context is closed (Chakra!CheckIsExecutable+18b [e:\a\_work\3\s\core\lib\backend\backendapi.cpp @ 139])

F12 is hitting the CheckIsExecutable assert when we have a closed ScriptContext and a call to a CustomExternalObject with a CrossSiteExternalEntryThunk entrypoint.

The fix (without exposing a bunch of ChakraFull things) is to check for a callable external object.
