### PR TITLE
Enabling large argCount in debugger scenarios

### DIFF
--- a/lib/Runtime/Base/CallInfo.cpp
+++ b/lib/Runtime/Base/CallInfo.cpp
@@ -9,4 +9,40 @@ namespace Js
     const ushort CallInfo::ksizeofCount =  24;
     const ushort CallInfo::ksizeofCallFlags = 8;
     const uint CallInfo::kMaxCountArgs = (1 << ksizeofCount) - 1 ;
+
+    // For Eval calls the FrameDisplay is passed in as an extra argument.
+    // This is not counted in Info.Count. Use this API to get the updated count.
+    ArgSlot CallInfo::GetArgCountWithExtraArgs(CallFlags flags, uint count)
+    {
+        AssertOrFailFastMsg(count < Constants::UShortMaxValue - 1, "ArgList too large");
+        ArgSlot argSlotCount = (ArgSlot)count;
+        if (flags & CallFlags_ExtraArg)
+        {
+            argSlotCount++;
+        }
+        return argSlotCount;
+    }
+
+    uint CallInfo::GetLargeArgCountWithExtraArgs(CallFlags flags, uint count)
+    {
+        if (flags & CallFlags_ExtraArg)
+        {
+            UInt32Math::Inc(count);
+        }
+        return count;
+    }
+
+    ArgSlot CallInfo::GetArgCountWithoutExtraArgs(CallFlags flags, ArgSlot count)
+    {
+        ArgSlot newCount = count;
+        if (flags & Js::CallFlags_ExtraArg)
+        {
+            if (count == 0)
+            {
+                ::Math::DefaultOverflowPolicy();
+            }
+            newCount = count - 1;
+        }
+        return newCount;
+    }
 }

--- a/lib/Runtime/Base/CallInfo.h
+++ b/lib/Runtime/Base/CallInfo.h
@@ -95,40 +95,11 @@ namespace Js
             return CallInfo::HasNewTarget(this->Flags);
         }
 
+        static ArgSlot GetArgCountWithExtraArgs(CallFlags flags, uint count);
 
-        // For Eval calls the FrameDisplay is passed in as an extra argument.
-        // This is not counted in Info.Count. Use this API to get the updated count.
-        static ArgSlot GetArgCountWithExtraArgs(CallFlags flags, ArgSlot count)
-        {
-            if (flags & CallFlags_ExtraArg)
-            {
-                ArgSlotMath::Inc(count);
-            }
-            return count;
-        }
+        static uint GetLargeArgCountWithExtraArgs(CallFlags flags, uint count);
 
-        static uint GetLargeArgCountWithExtraArgs(CallFlags flags, uint count)
-        {
-            if (flags & CallFlags_ExtraArg)
-            {
-                UInt32Math::Inc(count);
-            }
-            return count;
-        }
-
-        static ArgSlot GetArgCountWithoutExtraArgs(CallFlags flags, ArgSlot count)
-        {
-            ArgSlot newCount = count;
-            if (flags & Js::CallFlags_ExtraArg)
-            {
-                if (count == 0)
-                {
-                    ::Math::DefaultOverflowPolicy();
-                }
-                newCount = count - 1;
-            }
-            return newCount;
-        }
+        static ArgSlot GetArgCountWithoutExtraArgs(CallFlags flags, ArgSlot count);
 
         static bool HasNewTarget(CallFlags flags)
         {

--- a/lib/Runtime/Base/ScriptContext.cpp
+++ b/lib/Runtime/Base/ScriptContext.cpp
@@ -4109,7 +4109,8 @@ namespace Js
                     }
                     __TRY_FINALLY_BEGIN // SEH is not guaranteed, see the implementation
                     {
-                        aReturn = JavascriptFunction::CallFunction<true>(function, origEntryPoint, args);
+                        // This can be an apply call or a spread so we have to use the large arg count
+                        aReturn = JavascriptFunction::CallFunction<true>(function, origEntryPoint, args, /* useLargeArgCount */ true);
                     }
                     __FINALLY
                     {
@@ -4122,7 +4123,8 @@ namespace Js
                     // Can we update return address to a thunk that sends Exit event and then jmp to entry instead of Calling it.
                     // Saves stack space and it might be something we would be doing anyway for handling profile.Start/stop
                     // which can come anywhere on the stack.
-                    aReturn = JavascriptFunction::CallFunction<true>(function, origEntryPoint, args);
+                    // This can be an apply call or a spread so we have to use the large arg count
+                    aReturn = JavascriptFunction::CallFunction<true>(function, origEntryPoint, args, /* useLargeArgCount */ true);
                 }
             }
         }
@@ -4175,7 +4177,7 @@ namespace Js
         AutoRegisterIgnoreExceptionWrapper autoWrapper(scriptContext->GetThreadContext());
 
         Var aReturn = HelperOrLibraryMethodWrapper<true>(scriptContext, [=] {
-            return JavascriptFunction::CallFunction<true>(function, entryPoint, args);
+            return JavascriptFunction::CallFunction<true>(function, entryPoint, args, /* useLargeArgCount */ true);
         });
 
         return aReturn;


### PR DESCRIPTION
An apply call can get to DebugProfileProbeThunk  with large argCount in F12 scenarios. So the CallFunction should treat the count as large.
