### PR TITLE
WASM: reduce stack usage on compilation exception

### DIFF
--- a/lib/Runtime/Library/WebAssemblyModule.h
+++ b/lib/Runtime/Library/WebAssemblyModule.h
@@ -15,6 +15,7 @@ namespace Wasm
     class WasmDataSegment;
     class WasmElementSegment;
     class WasmGlobal;
+    class WasmCompilationException;
     struct WasmImport;
     struct WasmExport;
     struct CustomSection;
@@ -22,6 +23,17 @@ namespace Wasm
 
 namespace Js
 {
+
+struct AutoCleanStr
+{
+    char16* str = nullptr;
+    ~AutoCleanStr()
+    {
+        delete[] str;
+    }
+};
+
+
 class WebAssemblyModule : public DynamicObject
 {
 protected:
@@ -147,6 +159,8 @@ public:
     Wasm::CustomSection GetCustomSection(uint32 index) const;
 
     Wasm::WasmBinaryReader* GetReader() const { return m_reader; }
+
+    static char16* FormatExceptionMessage(Wasm::WasmCompilationException* ex, AutoCleanStr* autoClean, WebAssemblyModule* wasmModule = nullptr, FunctionBody* body = nullptr);
 
     virtual void Finalize(bool isShutdown) override;
     virtual void Dispose(bool isShutdown) override;

--- a/pal/inc/rt/palrt.h
+++ b/pal/inc/rt/palrt.h
@@ -810,6 +810,7 @@ Remember to fix the errcode defintion in safecrt.h.
 
 #define _vscprintf _vscprintf_unsafe
 #define _vscwprintf _vscwprintf_unsafe
+#define _scwprintf _scwprintf_unsafe
 
 extern "C++" {
 
@@ -897,6 +898,16 @@ inline int __cdecl _vscwprintf_unsafe(const WCHAR *_Format, va_list _ArgList)
 
         guess *= 2;
     }
+}
+
+inline int __cdecl _scwprintf_unsafe(const WCHAR *_Format, ...)
+{
+    int ret;
+    va_list _ArgList;
+    va_start(_ArgList, _Format);
+    ret = _vscwprintf_unsafe(_Format, _ArgList);
+    va_end(_ArgList);
+    return ret;
 }
 
 inline int __cdecl _vsnwprintf_unsafe(WCHAR *_Dst, size_t _SizeInWords, size_t _Count, const WCHAR *_Format, va_list _ArgList)


### PR DESCRIPTION
Let the stack unwind on exception in WebAssemblyModule::CreateModule before throwing the JavascriptException. 
Remove try/catch in WasmBytecodeGenerator::GenerateFunction and use destructor to cleanup instead. 
Make a function for formatting compilation exception to remove duplication and simplify memory management of exception string.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/4301)
<!-- Reviewable:end -->
