### PR TITLE
WASM: Fix slow test

### DIFF
--- a/test/wasm/limits.js
+++ b/test/wasm/limits.js
@@ -246,12 +246,18 @@ const tests = [
       assert.throws(() => new WebAssembly.Memory({initial: MaxMemoryInitialPages + 1, maximum: MaxMemoryMaximumPages + 1}));
       assert.throws(() => new WebAssembly.Memory({maximum: MaxMemoryMaximumPages + 1}));
 
-      assert.doesNotThrow(() => compile(`(module (memory ${MaxMemoryInitialPages}))`));
-      assert.doesNotThrow(() => compile(`(module (memory ${MaxMemoryInitialPages} ${MaxMemoryMaximumPages}))`));
-      assert.doesNotThrow(() => compile(`(module (memory 0 ${MaxMemoryMaximumPages}))`));
-      assert.throws(() => compile(`(module (memory ${MaxMemoryInitialPages + 1}))`), WebAssembly.CompileError, "Minimum memory size too big");
-      assert.throws(() => compile(`(module (memory ${MaxMemoryInitialPages + 1} ${MaxMemoryMaximumPages + 1}))`), WebAssembly.CompileError, "Minimum memory size too big");
-      assert.throws(() => compile(`(module (memory 0 ${MaxMemoryMaximumPages + 1}))`), WebAssembly.CompileError, "Maximum memory size too big");
+      const makeModule = (min, max) => {
+        const builder = new WasmModuleBuilder();
+        builder.addMemory(min, max);
+        return new WebAssembly.Module(builder.toBuffer());
+      };
+
+      assert.doesNotThrow(() => makeModule(MaxMemoryInitialPages));
+      assert.doesNotThrow(() => makeModule(MaxMemoryInitialPages, MaxMemoryMaximumPages));
+      assert.doesNotThrow(() => makeModule(0, MaxMemoryMaximumPages));
+      assert.throws(() => makeModule(MaxMemoryInitialPages + 1), WebAssembly.CompileError, "Minimum memory size too big");
+      assert.throws(() => makeModule(MaxMemoryInitialPages + 1, MaxMemoryMaximumPages + 1), WebAssembly.CompileError, "Minimum memory size too big");
+      assert.throws(() => makeModule(0, MaxMemoryMaximumPages + 1), WebAssembly.CompileError, "Maximum memory size too big");
     }
   },
   // Tests 24


### PR DESCRIPTION
Fix limit test by not using wabt. 
Wabt was throwing when parsing the .wast and we need the invalid module to test our validation. 
Fixes #4302

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/chakracore/4304)
<!-- Reviewable:end -->
