### PR TITLE
Handle branch instructions with sources in the register allocator

### DIFF
--- a/lib/Backend/LinearScan.h
+++ b/lib/Backend/LinearScan.h
@@ -120,7 +120,7 @@ public:
 private:
     void                Init();
     bool                SkipNumberedInstr(IR::Instr *instr);
-    void                EndDeadLifetimes(IR::Instr *instr);
+    void                EndDeadLifetimes(IR::Instr *instr, bool isLoopBackEdge);
     void                EndDeadOpHelperLifetimes(IR::Instr *instr);
     void                AllocateNewLifetimes(IR::Instr *instr);
     RegNum              Spill(Lifetime *newLifetime, IR::RegOpnd *regOpnd, bool dontSpillCurrent, bool force);


### PR DESCRIPTION
In ARM64 there are branch instructions that have sources. Processing the branches before processing the sources can lead to spilling incorrect values. Special handling is added to handle liveOnBackEdge lifetimes when loops end.
