### PR TITLE
xplat: if ICU is enabled, make Intl is also enabled by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,17 +126,17 @@ function(clr_unknown_arch)
     message(FATAL_ERROR "Only AMD64, ARM and I386 are supported")
 endfunction()
 
-if(INTL_ICU_SH)
-    unset(INTL_ICU_SH CACHE)    # don't cache
-    add_definitions(-DINTL_ICU=1)
-    set(ICU_INTL_ENABLED 1)
+if(NOINTL_ICU_SH)
+    unset(NOINTL_ICU_SH CACHE)    # don't cache
+    set(ICU_INTL_DISABLED 1)
 endif()
 
 if(ICU_INCLUDE_PATH)
     add_definitions(-DHAS_REAL_ICU=1)
     set(ICU_CC_PATH "${ICU_INCLUDE_PATH}/../lib/")
     find_library(ICUUC icuuc PATHS ${ICU_CC_PATH} NO_DEFAULT_PATH)
-    if(ICU_INTL_ENABLED)
+    if(NOT ICU_INTL_DISABLED)
+        add_definitions(-DINTL_ICU=1)
         find_library(ICU18 icui18n PATHS ${ICU_CC_PATH} NO_DEFAULT_PATH)
         # icu header files are either located under the same folder or i18n is under a relative path
         # TODO (unlikely): shall we add `--icu-intl` to build.sh ?
@@ -203,7 +203,8 @@ if(CC_TARGET_OS_LINUX OR CC_TARGET_OS_ANDROID)
         if(NOT NO_ICU_PATH_GIVEN)
             if(NOT CC_EMBED_ICU)
                 set(ICULIB "icuuc")
-                if(ICU_INTL_ENABLED)
+                if(NOT ICU_INTL_DISABLED)
+                    add_definitions(-DINTL_ICU=1)
                     set(ICULIB
                       "${ICULIB}"
                       "icui18n")
@@ -353,7 +354,7 @@ if(CLR_CMAKE_PLATFORM_XPLAT)
     # Also disable RTTI when building a shared library
     # TODO: why does the shared library break with rtti disabled?
     if(CMAKE_BUILD_TYPE STREQUAL Release)
-        if(STATIC_LIBRARY OR NOT ICU_INTL_ENABLED)
+        if(STATIC_LIBRARY OR ICU_INTL_DISABLED)
             add_compile_options(-fno-rtti)
         endif()
     endif()

--- a/build.sh
+++ b/build.sh
@@ -47,7 +47,7 @@ PRINT_USAGE() {
     echo "     --icu=PATH        Path to ICU include folder (see example below)"
     echo " -j[=N], --jobs[=N]    Multicore build, allow N jobs at once."
     echo " -n, --ninja           Build with ninja instead of make."
-    echo "     --no-icu          Compile without unicode/icu support."
+    echo "     --no-icu          Compile without unicode/icu/intl support."
     echo "     --no-jit          Disable JIT"
     echo "     --libs-only       Do not build CH and GCStress"
     echo "     --lto             Enables LLVM Full LTO"
@@ -60,7 +60,7 @@ PRINT_USAGE() {
     echo "     --target-path[=S] Output path for compiled binaries. Default: out/"
     echo "     --trace           Enables experimental built-in trace."
     echo "     --xcode           Generate XCode project."
-    echo "     --with-intl       Include the Intl object (requires ICU)."
+    echo "     --without-intl    --icu arg also enables Intl by default. Disable it."
     echo "     --without=FEATURE,FEATURE,..."
     echo "                       Disable FEATUREs from JSRT experimental features."
     echo "     --valgrind        Enable Valgrind support"
@@ -244,7 +244,12 @@ while [[ $# -gt 0 ]]; do
         ;;
 
     --with-intl)
-        INTL_ICU="-DINTL_ICU_SH=1"
+        # todo: remove me! this is temporary
+        # until new setting settles and we re-configure CI
+        ;;
+
+    --without-intl)
+        INTL_ICU="-DNOINTL_ICU_SH=1"
         ;;
 
     --xcode)

--- a/lib/Runtime/PlatformAgnostic/Platform/CMakeLists.txt
+++ b/lib/Runtime/PlatformAgnostic/Platform/CMakeLists.txt
@@ -13,25 +13,21 @@ set(PL_SOURCE_FILES
   )
 
 if(CC_TARGET_OS_ANDROID OR CC_TARGET_OS_LINUX)
-set(PL_SOURCE_FILES ${PL_SOURCE_FILES}
-  Linux/SystemInfo.cpp
-  Linux/PerfTrace.cpp
-  )
+  set(PL_SOURCE_FILES ${PL_SOURCE_FILES}
+    Linux/SystemInfo.cpp
+    Linux/PerfTrace.cpp
+    )
 elseif(CC_TARGET_OS_OSX)
-set(PL_SOURCE_FILES ${PL_SOURCE_FILES}
-  Unix/AssemblyCommon.cpp
-  Unix/SystemInfo.cpp
-# Linux/PerfTrace.cpp # TODO : implement for OSX?
-  )
+  set(PL_SOURCE_FILES ${PL_SOURCE_FILES}
+    Unix/AssemblyCommon.cpp
+    Unix/SystemInfo.cpp
+    # Linux/PerfTrace.cpp # TODO : implement for OSX?
+    )
 endif()
 
-if(ICU_INTL_ENABLED)
-set(PL_SOURCE_FILES ${PL_SOURCE_FILES}
-  Common/Intl.cpp
-  )
-add_compile_options(
-  -frtti
-)
+if(NOT ICU_INTL_DISABLED)
+  set(PL_SOURCE_FILES ${PL_SOURCE_FILES} Common/Intl.cpp)
+  add_compile_options(-frtti)
 endif()
 
 if(NOT STATIC_LIBRARY)


### PR DESCRIPTION
- remove `--with-intl` option and bring `--without-intl` instead
- enable intl by default for ICU builds
- fixes default test and build inconsistency

fixes #4303 

