### PR TITLE
ARM64: fix liveness assert

### DIFF
--- a/lib/Backend/SccLiveness.cpp
+++ b/lib/Backend/SccLiveness.cpp
@@ -705,7 +705,12 @@ SCCLiveness::ExtendLifetime(Lifetime *lifetime, IR::Instr *instr)
             }
             NEXT_SLISTBASE_ENTRY
         }
+#if _M_ARM64
+        // The case of equality is valid on Arm64 where some branch instructions have sources.
+        AssertMsg(lifetime->end >= instr->GetNumber(), "Lifetime end not set correctly");
+#else
         AssertMsg(lifetime->end > instr->GetNumber(), "Lifetime end not set correctly");
+#endif
     }
     this->extendedLifetimesLoopList->Clear(this->tempAlloc);
 }


### PR DESCRIPTION
This assert can hit when branch instructions have sources in ARM64. In those cases it is valid for the lifetimes to be ending on that instruction.
