### PR TITLE
xplat: fix rebuild arch failure and remove with-intl

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -243,11 +243,6 @@ while [[ $# -gt 0 ]]; do
         NO_JIT="-DNO_JIT_SH=1"
         ;;
 
-    --with-intl)
-        # todo: remove me! this is temporary
-        # until new setting settles and we re-configure CI
-        ;;
-
     --without-intl)
         INTL_ICU="-DNOINTL_ICU_SH=1"
         ;;

--- a/build.sh
+++ b/build.sh
@@ -602,6 +602,7 @@ elif [[ $ARCH =~ "amd64" ]]; then
     ARCH="-DCC_TARGETS_AMD64_SH=1"
     echo "Compile Target : amd64"
 else
+    ARCH="-DCC_USES_SYSTEM_ARCH_SH=1"
     echo "Compile Target : System Default"
 fi
 


### PR DESCRIPTION
- missing `CC_USES_SYSTEM_ARCH_SH` was causing jenkins fails and slow review - merge process.

- `--with-intl` is no longer needed.

CI will fail on this PR until #4319 is merged.