### PR TITLE
Win: Fix undefined uint16_t (issue #4320)

### DIFF
--- a/lib/Jsrt/ChakraCommon.h
+++ b/lib/Jsrt/ChakraCommon.h
@@ -94,6 +94,8 @@ typedef unsigned short WCHAR;
 
 #if (defined(_MSC_VER) && _MSC_VER <= 1900) || (!defined(_MSC_VER) && __cplusplus <= 199711L) // !C++11
 typedef unsigned short uint16_t;
+#else
+#include <stdint.h>
 #endif
 
     /// <summary>


### PR DESCRIPTION
uint16_t would be undefined when using a Visual C++ compiler higher than version 1900, include stdint.h if that is the case.

[Issue #4320](https://github.com/Microsoft/ChakraCore/issues/4320)