### PR TITLE
ARM64: relocs for long ADR instrs

### DIFF
--- a/lib/Backend/Func.cpp
+++ b/lib/Backend/Func.cpp
@@ -1697,6 +1697,7 @@ Func::EnsureFuncStartLabel()
     if(m_funcStartLabel == nullptr)
     {
         m_funcStartLabel = IR::LabelInstr::New( Js::OpCode::Label, this );
+        m_funcStartLabel->m_isDataLabel = true;
     }
     return m_funcStartLabel;
 }
@@ -1713,6 +1714,7 @@ Func::EnsureFuncEndLabel()
     if(m_funcEndLabel == nullptr)
     {
         m_funcEndLabel = IR::LabelInstr::New( Js::OpCode::Label, this );
+        m_funcEndLabel->m_isDataLabel = true;
     }
     return m_funcEndLabel;
 }

--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -20015,8 +20015,6 @@ Lowerer::GenerateFunctionTypeFromFixedFunctionObject(IR::Instr *insertInstrPt, I
 void
 Lowerer::FinalLower()
 {
-    this->m_lowererMD.FinalLower();
-
     // ensure that the StartLabel and EndLabel are inserted
     // before the prolog and after the epilog respectively
     IR::LabelInstr * startLabel = m_func->GetFuncStartLabel();
@@ -20030,6 +20028,8 @@ Lowerer::FinalLower()
     {
         m_func->m_tailInstr->GetPrevRealInstr()->InsertBefore(endLabel);
     }
+
+    this->m_lowererMD.FinalLower();
 }
 
 void

--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -20015,6 +20015,8 @@ Lowerer::GenerateFunctionTypeFromFixedFunctionObject(IR::Instr *insertInstrPt, I
 void
 Lowerer::FinalLower()
 {
+    this->m_lowererMD.FinalLower();
+
     // ensure that the StartLabel and EndLabel are inserted
     // before the prolog and after the epilog respectively
     IR::LabelInstr * startLabel = m_func->GetFuncStartLabel();
@@ -20028,8 +20030,6 @@ Lowerer::FinalLower()
     {
         m_func->m_tailInstr->GetPrevRealInstr()->InsertBefore(endLabel);
     }
-
-    this->m_lowererMD.FinalLower();
 }
 
 void

--- a/lib/Backend/arm64/LegalizeMD.cpp
+++ b/lib/Backend/arm64/LegalizeMD.cpp
@@ -804,22 +804,67 @@ void LegalizeMD::LegalizeLdLabel(IR::Instr * instr, IR::Opnd * opnd)
     }
 }
 
-bool LegalizeMD::LegalizeDirectBranch(IR::BranchInstr *branchInstr, uint32 branchOffset)
+namespace
+{
+    IR::LabelInstr* TryInsertBranchIsland(IR::Instr* instr, IR::LabelInstr* target, int limit, bool forward)
+    {
+        int i = MachMaxInstrSize;
+        IR::Instr* branchInstr = nullptr;
+
+        if (forward)
+        {
+            for (IR::Instr* next = instr->m_next; i < limit && next != nullptr; next = next->m_next)
+            {
+                if (next->IsBranchInstr() && next->AsBranchInstr()->IsUnconditional())
+                {
+                    branchInstr = next;
+                    break;
+                }
+                i += MachMaxInstrSize;
+            }
+        }
+        else
+        {
+            for (IR::Instr* prev = instr->m_prev; i < limit && prev != nullptr; prev = prev->m_prev)
+            {
+                if (prev->IsBranchInstr() && prev->AsBranchInstr()->IsUnconditional())
+                {
+                    branchInstr = prev;
+                    break;
+                }
+                i += MachMaxInstrSize;
+            }
+        }
+
+        if (branchInstr == nullptr)
+        {
+            return nullptr;
+        }
+
+        IR::LabelInstr* islandLabel = IR::LabelInstr::New(Js::OpCode::Label, instr->m_func, false);
+        branchInstr->InsertAfter(islandLabel);
+
+        IR::BranchInstr* targetBranch = IR::BranchInstr::New(Js::OpCode::B, target, branchInstr->m_func);
+        islandLabel->InsertAfter(targetBranch);
+
+        return islandLabel;
+    }
+}
+
+bool LegalizeMD::LegalizeDirectBranch(IR::BranchInstr *branchInstr, uintptr_t branchOffset)
 {
     Assert(branchInstr->IsBranchInstr());
 
-    uint32 labelOffset = (uint32)branchInstr->GetTarget()->GetOffset();
+    uintptr_t labelOffset = branchInstr->GetTarget()->GetOffset();
     Assert(labelOffset); //Label offset must be set.
 
-    int32 offset = labelOffset - branchOffset;
+    intptr_t offset = labelOffset - branchOffset;
     //We should never run out of 26 bits which corresponds to +-64MB of code size.
     AssertMsg(IS_CONST_INT26(offset >> 1), "Cannot encode more that 64 MB offset");
 
-    if (LowererMD::IsUnconditionalBranch(branchInstr))
-    {
-        return false;
-    }
+    Assert(!LowererMD::IsUnconditionalBranch(branchInstr));
 
+    int limit = 0;
     if (branchInstr->m_opcode == Js::OpCode::TBZ || branchInstr->m_opcode == Js::OpCode::TBNZ)
     {
         // TBZ and TBNZ are limited to 14 bit offsets.
@@ -827,6 +872,7 @@ bool LegalizeMD::LegalizeDirectBranch(IR::BranchInstr *branchInstr, uint32 branc
         {
             return false;
         }
+        limit = 0x00001fff;
     }
     else
     {
@@ -835,6 +881,21 @@ bool LegalizeMD::LegalizeDirectBranch(IR::BranchInstr *branchInstr, uint32 branc
         {
             return false;
         }
+        limit = 0x0003ffff;
+    }
+
+    // Attempt to find an unconditional branch within the range and insert a branch island below it:
+    //  CB. $island
+    //  ...
+    //  B
+    //  $island:
+    //  B $target
+    
+    IR::LabelInstr* islandLabel = TryInsertBranchIsland(branchInstr, branchInstr->GetTarget(), limit, offset < 0);
+    if (islandLabel != nullptr)
+    {
+        branchInstr->SetTarget(islandLabel);
+        return true;
     }
 
     // Convert a conditional branch which can only be +-256kb(+-8kb for TBZ/TBNZ) to unconditional branch which is +-64MB
@@ -863,6 +924,71 @@ bool LegalizeMD::LegalizeDirectBranch(IR::BranchInstr *branchInstr, uint32 branc
     branchInstr->InsertBefore(fallbackBranch);
     branchInstr->InsertAfter(fallbackLabel);
     branchInstr->m_opcode = Js::OpCode::B;
+    return true;
+}
+
+bool LegalizeMD::LegalizeAdrOffset(IR::Instr *instr, uintptr_t instrOffset)
+{
+    Assert(instr->m_opcode == Js::OpCode::ADR);
+
+    IR::LabelOpnd* labelOpnd = instr->GetSrc1()->AsLabelOpnd();
+    IR::LabelInstr* label = labelOpnd->GetLabel();
+
+    uintptr_t labelOffset = label->GetOffset();
+    Assert(labelOffset); //Label offset must be set.
+
+    intptr_t offset = labelOffset - instrOffset;
+
+    if (IS_CONST_INT21(offset))
+    {
+        return false;
+    }
+
+    if (label == instr->m_func->GetFuncStartLabel() || label == instr->m_func->GetFuncEndLabel())
+    {
+        AssertMsg(false, "FuncStartLabel or FuncEndLabel out of ADR range");
+        throw Js::OperationAbortedException();
+    }
+    
+    //We should never run out of 26 bits which corresponds to +-64MB of code size.
+    AssertMsg(IS_CONST_INT26(offset >> 1), "Cannot encode more that 64 MB offset");
+
+    // Attempt to find an unconditional branch within the range and insert a branch island below it:
+    //  ADR $island
+    //  ...
+    //  B
+    //  $island:
+    //  B $target
+
+    int limit = 0x000fffff;
+    IR::LabelInstr* islandLabel = TryInsertBranchIsland(instr, label, limit, offset < 0);
+    if (islandLabel != nullptr)
+    {
+        labelOpnd->SetLabel(islandLabel);
+        return true;
+    }
+
+    // Convert an Adr instruction which can only be +-1mb to branch which is +-64MB
+    //  Adr $adrLabel
+    //  b continue
+    //  $adrLabel:
+    //  b label
+    //  $continue:
+
+
+    IR::LabelInstr* continueLabel = IR::LabelInstr::New(Js::OpCode::Label, instr->m_func, false);
+    instr->InsertAfter(continueLabel);
+
+    IR::BranchInstr* continueBranch = IR::BranchInstr::New(Js::OpCode::B, continueLabel, instr->m_func);
+    continueLabel->InsertBefore(continueBranch);
+
+    IR::LabelInstr* adrLabel = IR::LabelInstr::New(Js::OpCode::Label, instr->m_func, false);
+    continueLabel->InsertBefore(adrLabel);
+
+    IR::BranchInstr* labelBranch = IR::BranchInstr::New(Js::OpCode::B, label, instr->m_func);
+    continueLabel->InsertBefore(labelBranch);
+
+    labelOpnd->SetLabel(adrLabel);
     return true;
 }
 

--- a/lib/Backend/arm64/LegalizeMD.h
+++ b/lib/Backend/arm64/LegalizeMD.h
@@ -79,7 +79,8 @@ public:
     static void LegalizeDst(IR::Instr * instr, bool fPostRegAlloc);
     static void LegalizeSrc(IR::Instr * instr, IR::Opnd * opnd, uint opndNum, bool fPostRegAlloc);
 
-    static bool LegalizeDirectBranch(IR::BranchInstr *instr, uint32 branchOffset); // DirectBranch has no src & dst operands.
+    static bool LegalizeDirectBranch(IR::BranchInstr *instr, uintptr_t branchOffset);
+    static bool LegalizeAdrOffset(IR::Instr *instr, uintptr_t instrOffset);
 
 private:
     static void LegalizeRegOpnd(IR::Instr* instr, IR::Opnd* opnd);

--- a/lib/Backend/arm64/LowerMD.cpp
+++ b/lib/Backend/arm64/LowerMD.cpp
@@ -7827,15 +7827,23 @@ LowererMD::FinalLower()
         switch (reloc->m_relocType)
         {
         case RelocTypeBranch19:
-            AssertMsg(relocAddress < reloc->m_relocInstr->AsBranchInstr()->GetTarget()->GetOffset(), "Only forward branches require fixup");
+            AssertMsg(relocAddress < reloc->m_relocInstr->AsBranchInstr()->GetTarget()->GetOffset(), "Only backward branches require fixup");
             LegalizeMD::LegalizeDirectBranch(reloc->m_relocInstr->AsBranchInstr(), relocAddress);
             break;
 
         case RelocTypeLabelAdr:
-            AssertMsg(relocAddress < reloc->m_relocInstr->GetSrc1()->AsLabelOpnd()->GetLabel()->GetOffset(), "Only forward branches require fixup");
+        {
+            IR::LabelInstr* label = reloc->m_relocInstr->GetSrc1()->AsLabelOpnd()->GetLabel();
+            if (label->GetOffset() == 0)
+            {
+                Assert(label->m_isDataLabel);
+                break;
+            }
+
+            AssertMsg(relocAddress < label->GetOffset(), "Only backward branches require fixup");
             LegalizeMD::LegalizeAdrOffset(reloc->m_relocInstr, relocAddress);
             break;
-
+        }
         default:
             Assert(false);
         }

--- a/lib/Backend/arm64/LowerMD.cpp
+++ b/lib/Backend/arm64/LowerMD.cpp
@@ -7726,7 +7726,7 @@ LowererMD::FinalLower()
     NoRecoverMemoryArenaAllocator tempAlloc(_u("BE-ARMFinalLower"), m_func->m_alloc->GetPageAllocator(), Js::Throw::OutOfMemory);
     EncodeReloc *pRelocList = nullptr;
 
-    uint32 instrOffset = 0;
+    uintptr_t instrOffset = 0;
     FOREACH_INSTR_BACKWARD_EDITING_IN_RANGE(instr, instrPrev, this->m_func->m_tailInstr, this->m_func->m_headInstr)
     {
         if (instr->IsLowered() == false)
@@ -7748,20 +7748,19 @@ LowererMD::FinalLower()
         }
         else
         {
-            //We are conservative here, assume each instruction take 4 bytes
             instrOffset = instrOffset + MachMaxInstrSize;
 
             if (instr->IsBranchInstr())
             {
                 IR::BranchInstr *branchInstr = instr->AsBranchInstr();
 
-                if (branchInstr->GetTarget() && !LowererMD::IsUnconditionalBranch(branchInstr)) //Ignore BX register based branches & B
+                if (!LowererMD::IsUnconditionalBranch(branchInstr)) //Ignore BX register based branches & B
                 {
-                    uint32 targetOffset = (uint32)branchInstr->GetTarget()->GetOffset();
+                    uintptr_t targetOffset = branchInstr->GetTarget()->GetOffset();
 
                     if (targetOffset != 0)
                     {
-                        // this is backward reference
+                        // this is forward reference
                         if (LegalizeMD::LegalizeDirectBranch(branchInstr, instrOffset))
                         {
                             //There might be an instruction inserted for legalizing conditional branch
@@ -7771,7 +7770,7 @@ LowererMD::FinalLower()
                     else
                     {
                         EncodeReloc::New(&pRelocList, RelocTypeBranch19, (BYTE*)instrOffset, branchInstr, &tempAlloc);
-                        //Assume this is a forward long branch, we shall fix up after complete pass, be conservative here
+                        //Assume this is a backward long branch, we shall fix up after complete pass, be conservative here
                         instrOffset = instrOffset + MachMaxInstrSize;
                     }
                 }
@@ -7797,19 +7796,49 @@ LowererMD::FinalLower()
                     instrOffset += (expandedInstrCount - 1) * MachMaxInstrSize;    // We already accounted for one MachMaxInstrSize.
                 }
             }
+
+            if (instr->m_opcode == Js::OpCode::ADR)
+            {
+                uintptr_t targetOffset = instr->GetSrc1()->AsLabelOpnd()->GetLabel()->GetOffset();
+                if (targetOffset != 0)
+                {
+                    // this is forward reference
+                    if (LegalizeMD::LegalizeAdrOffset(instr, instrOffset))
+                    {
+                        //Additional instructions were inserted.
+                        instrOffset = instrOffset + MachMaxInstrSize * 2;
+                    }
+                }
+                else
+                {
+                    EncodeReloc::New(&pRelocList, RelocTypeLabelAdr, (BYTE*)instrOffset, instr, &tempAlloc);
+                    //Assume this is a backward long branch, we shall fix up after complete pass, be conservative here
+                    instrOffset = instrOffset + MachMaxInstrSize * 2;
+                }
+            }
         }
     } NEXT_INSTR_BACKWARD_EDITING_IN_RANGE;
 
-    //Fixup all the forward branches
+    //Fixup all the backward branches
     for (EncodeReloc *reloc = pRelocList; reloc; reloc = reloc->m_next)
     {
-        // TODO (SaAgarwa) : enable warning
-#pragma warning(push)
-#pragma warning(disable:4311) // 'type cast': pointer truncation from 'BYTE *' to 'uint32'
-#pragma warning(disable:4302) // 'type cast': truncation from 'BYTE *' to 'uint32'
-        AssertMsg((uint32)reloc->m_consumerOffset < reloc->m_relocInstr->AsBranchInstr()->GetTarget()->GetOffset(), "Only forward branches require fixup");
-        LegalizeMD::LegalizeDirectBranch(reloc->m_relocInstr->AsBranchInstr(), (uint32)reloc->m_consumerOffset);
-#pragma warning(pop)
+        uintptr_t relocAddress = (uintptr_t)reloc->m_consumerOffset;
+
+        switch (reloc->m_relocType)
+        {
+        case RelocTypeBranch19:
+            AssertMsg(relocAddress < reloc->m_relocInstr->AsBranchInstr()->GetTarget()->GetOffset(), "Only forward branches require fixup");
+            LegalizeMD::LegalizeDirectBranch(reloc->m_relocInstr->AsBranchInstr(), relocAddress);
+            break;
+
+        case RelocTypeLabelAdr:
+            AssertMsg(relocAddress < reloc->m_relocInstr->GetSrc1()->AsLabelOpnd()->GetLabel()->GetOffset(), "Only forward branches require fixup");
+            LegalizeMD::LegalizeAdrOffset(reloc->m_relocInstr, relocAddress);
+            break;
+
+        default:
+            Assert(false);
+        }
     }
 
     return;


### PR DESCRIPTION
for ADR instructions too far from their targets, insert a branch to the target, and change the target to the new branch.
