### PR TITLE
Change FindRegUse to HasSymUse

### DIFF
--- a/lib/Backend/FlowGraph.cpp
+++ b/lib/Backend/FlowGraph.cpp
@@ -2994,7 +2994,7 @@ FlowGraph::PeepCm(IR::Instr *instr)
     if (instrLd3->GetByteCodeOffset() > instrBr->GetByteCodeOffset())
     {
         StackSym *symLd3 = instrLd3->GetDst()->AsRegOpnd()->m_sym;
-        if (IR::Instr::FindRegUseInRange(symLd3, instrBr->m_next, instrLd3))
+        if (IR::Instr::HasSymUseInRange(symLd3, instrBr->m_next, instrLd3))
         {
             return nullptr;
         }

--- a/lib/Backend/GlobOpt.cpp
+++ b/lib/Backend/GlobOpt.cpp
@@ -2338,7 +2338,7 @@ MemOpCheckInductionVariable:
                     Loop::MemCopyCandidate* memcopyCandidate = prevCandidate->AsMemCopy();
                     if (memcopyCandidate->base == Js::Constants::InvalidSymID)
                     {
-                        if (chkInstr->FindRegUse(memcopyCandidate->transferSym))
+                        if (chkInstr->HasSymUse(memcopyCandidate->transferSym))
                         {
                             loop->doMemOp = false;
                             TRACE_MEMOP_PHASE_VERBOSE(MemCopy, loop, chkInstr, _u("Found illegal use of LdElemI value(s%d)"), GetVarSymID(memcopyCandidate->transferSym));

--- a/lib/Backend/IR.cpp
+++ b/lib/Backend/IR.cpp
@@ -2949,14 +2949,6 @@ Instr::HasSymUseDst(StackSym *sym, IR::Opnd* dst)
             }
         }
     }
-    else if (dst->IsSymOpnd() && dst->AsSymOpnd()->IsPropertySymOpnd())
-    {
-        PropertySymOpnd* propertySymOpnd = dst->AsSymOpnd()->AsPropertySymOpnd();
-        if (propertySymOpnd->GetObjectSym() == sym)
-        {
-            return true;
-        }
-    }
     else if (dst->IsSymOpnd())
     {
         SymOpnd* symOpnd = dst->AsSymOpnd();

--- a/lib/Backend/IR.cpp
+++ b/lib/Backend/IR.cpp
@@ -2877,10 +2877,6 @@ Instr::HasSymUseSrc(StackSym *sym, IR::Opnd* src)
     else if (src->IsIndirOpnd())
     {
         IR::IndirOpnd *indirOpnd = src->AsIndirOpnd();
-        if (indirOpnd->GetStackSym() == sym)
-        {
-            return true;
-        }
         RegOpnd * baseOpnd = indirOpnd->GetBaseOpnd();
         if (baseOpnd != nullptr && baseOpnd->m_sym == sym)
         {
@@ -2894,14 +2890,11 @@ Instr::HasSymUseSrc(StackSym *sym, IR::Opnd* src)
     else if (src->IsListOpnd())
     {
         IR::ListOpnd* list = src->AsListOpnd();
-        if (list->GetStackSym() == sym)
+        for (int i = 0; i < list->Count(); ++i)
         {
-            for (int i = 0; i < list->Count(); ++i)
+            if (HasSymUseSrc(sym, list->Item(i)))
             {
-                if (HasSymUseSrc(sym, list->Item(i)))
-                {
-                    return true;
-                }
+                return true;
             }
         }
     }
@@ -2915,10 +2908,6 @@ Instr::HasSymUseSrc(StackSym *sym, IR::Opnd* src)
         if (symOpnd->IsPropertySymOpnd())
         {
             PropertySymOpnd* propertySymOpnd = symOpnd->AsPropertySymOpnd();
-            if (propertySymOpnd->GetPropertySym()->m_stackSym == sym)
-            {
-                return true;
-            }
             if (propertySymOpnd->GetObjectSym() == sym)
             {
                 return true;
@@ -2963,13 +2952,25 @@ Instr::HasSymUseDst(StackSym *sym, IR::Opnd* dst)
     else if (dst->IsSymOpnd() && dst->AsSymOpnd()->IsPropertySymOpnd())
     {
         PropertySymOpnd* propertySymOpnd = dst->AsSymOpnd()->AsPropertySymOpnd();
-        if (propertySymOpnd->GetPropertySym()->m_stackSym == sym)
-        {
-            return true;
-        }
         if (propertySymOpnd->GetObjectSym() == sym)
         {
             return true;
+        }
+    }
+    else if (dst->IsSymOpnd())
+    {
+        SymOpnd* symOpnd = dst->AsSymOpnd();
+        if (symOpnd->GetSym() == sym)
+        {
+            return true;
+        }
+        if (symOpnd->IsPropertySymOpnd())
+        {
+            PropertySymOpnd* propertySymOpnd = symOpnd->AsPropertySymOpnd();
+            if (propertySymOpnd->GetObjectSym() == sym)
+            {
+                return true;
+            }
         }
     }
     return false;
@@ -2986,7 +2987,7 @@ Instr::HasSymUse(StackSym *sym)
     {
         return true;
     }
-    if (HasSymUseSrc(sym, this->GetDst()))
+    if (HasSymUseDst(sym, this->GetDst()))
     {
         return true;
     }

--- a/lib/Backend/IR.h
+++ b/lib/Backend/IR.h
@@ -272,10 +272,10 @@ public:
     IR::Instr *     GetPrevRealInstrOrLabel() const;
     IR::Instr *     GetInsertBeforeByteCodeUsesInstr();
     IR::LabelInstr *GetOrCreateContinueLabel(const bool isHelper = false);
-    static RegOpnd *FindRegUseSrc(StackSym *sym, IR::Opnd*);
-    static RegOpnd *FindRegUseDst(StackSym *sym, IR::Opnd*);
-    RegOpnd *       FindRegUse(StackSym *sym);
-    static RegOpnd *FindRegUseInRange(StackSym *sym, Instr *instrBegin, Instr *instrEnd);
+    static bool     HasSymUseSrc(StackSym *sym, IR::Opnd*);
+    static bool     HasSymUseDst(StackSym *sym, IR::Opnd*);
+    bool            HasSymUse(StackSym *sym);
+    static bool     HasSymUseInRange(StackSym *sym, Instr *instrBegin, Instr *instrEnd);
     RegOpnd *       FindRegDef(StackSym *sym);
     static Instr*   FindSingleDefInstr(Js::OpCode opCode, Opnd* src);
 

--- a/lib/Backend/PreLowerPeeps.cpp
+++ b/lib/Backend/PreLowerPeeps.cpp
@@ -115,7 +115,7 @@ Lowerer::TryShiftAdd(IR::Instr *instrAdd, IR::Opnd * opndFold, IR::Opnd * opndAd
         {
             return instrAdd;
         }
-        if (instrIter->FindRegUse(foldSym))
+        if (instrIter->HasSymUse(foldSym))
         {
             return instrAdd;
         }
@@ -250,7 +250,7 @@ IR::Instr *Lowerer::PeepShl(IR::Instr *instrShl)
         {
             return instrShl;
         }
-        if (instrIter->FindRegUse(src1->AsRegOpnd()->m_sym))
+        if (instrIter->HasSymUse(src1->AsRegOpnd()->m_sym))
         {
             return instrShl;
         }

--- a/test/Optimizer/fgpeepbug.js
+++ b/test/Optimizer/fgpeepbug.js
@@ -1,0 +1,15 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function foo() {
+    var a = {b: {}}
+    a = null !== a.b && 0 < a.b.a
+    if (!a) return a
+}
+foo();
+foo();
+foo();
+
+print("Pass")

--- a/test/Optimizer/fgpeepbug.js
+++ b/test/Optimizer/fgpeepbug.js
@@ -8,8 +8,13 @@ function foo() {
     a = null !== a.b && 0 < a.b.a
     if (!a) return a
 }
-foo();
-foo();
-foo();
+let result = null;
+for (let i=0; i < 100; ++i)
+{
+    foo();
+}
 
-print("Pass")
+if(foo() === false)
+{
+    print("Pass")
+}

--- a/test/Optimizer/rlexe.xml
+++ b/test/Optimizer/rlexe.xml
@@ -1434,4 +1434,9 @@
       <files>bug14661401.js</files>
     </default>
   </test>
+  <test>
+    <default>
+      <files>fgpeepbug.js</files>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
In `FlowGraph::PeepCm` we reorder code to combine CmEq+BrTrue in BrEq, and do static assignment of true/false to the result of the compare. We also do this through multiple levels of branches.

To ensure the sym we are assiging the compare result to isn't being used in intermediate instructions we call FindRegUseInRange, which checks if there are any RegOpnd uses of the sym. However, this fails to find SymOpnd uses.

````
var a = d()
a = null !== a.face && 0 < a.face.a
if (!a || b) blah = a
````
In this example, since `a` is both the dst and a src, we end up initializing `a` with `false` in the beginning of the compare and then do a LdFld on false, which throws an exception.

Other callsites seemed like they were ok, but they weren't using the RegOpnd return, so I changed the method around to return bool if there is a SymUse, which is what I think people really wanted.

Fixes #4266