### PR TITLE
Fix lambda parsing issue.

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -8567,6 +8567,18 @@ void Parser::DeferOrEmitPotentialSpreadError(ParseNodePtr pnodeT)
     }
 }
 
+bool Parser::IsTerminateToken()
+{
+    return (m_token.tk == tkRCurly ||
+        m_token.tk == tkRBrack ||
+        m_token.tk == tkRParen ||
+        m_token.tk == tkSColon ||
+        m_token.tk == tkColon ||
+        m_token.tk == tkComma ||
+        m_token.tk == tkLimKwd ||
+        m_pscan->FHadNewLine());
+}
+
 /***************************************************************************
 Parse an optional sub expression returning null if there was no expression.
 Checks for no expression by looking for a token that can follow an
@@ -8576,14 +8588,7 @@ template<bool buildAST>
 bool Parser::ParseOptionalExpr(ParseNodePtr* pnode, bool fUnaryOrParen, int oplMin, BOOL *pfCanAssign, BOOL fAllowIn, BOOL fAllowEllipsis, _Inout_opt_ IdentToken* pToken)
 {
     *pnode = nullptr;
-    if (m_token.tk == tkRCurly ||
-        m_token.tk == tkRBrack ||
-        m_token.tk == tkRParen ||
-        m_token.tk == tkSColon ||
-        m_token.tk == tkColon ||
-        m_token.tk == tkComma ||
-        m_token.tk == tkLimKwd ||
-        m_pscan->FHadNewLine())
+    if (IsTerminateToken())
     {
         return false;
     }
@@ -9063,12 +9068,7 @@ ParseNodePtr Parser::ParseExpr(int oplMin,
             // ArrowFunction/AsyncArrowFunction is part of AssignmentExpression, which should terminate the expression unless followed by a comma
             if (m_token.tk != tkComma)
             {
-                if (!(m_token.tk == tkRCurly ||
-                    m_token.tk == tkRParen ||
-                    m_token.tk == tkRBrack ||
-                    m_token.tk == tkSColon ||
-                    m_token.tk == tkLimKwd ||
-                    m_pscan->FHadNewLine()))
+                if (!(IsTerminateToken()))
                 {
                     Error(ERRnoSemic);
                 }

--- a/lib/Parser/Parse.h
+++ b/lib/Parser/Parse.h
@@ -785,6 +785,8 @@ private:
     template<bool buildAST> ParseNodePtr ParseMemberList(LPCOLESTR pNameHint, uint32 *pHintLength, tokens declarationType = tkNone);
     template<bool buildAST> IdentPtr ParseSuper(bool fAllowCall);
 
+    bool IsTerminateToken();
+
     // Used to determine the type of JavaScript object member.
     // The values can be combined using bitwise OR.
     //       specifically, it is valid to have getter and setter at the same time.

--- a/test/Bugs/misc_bugs.js
+++ b/test/Bugs/misc_bugs.js
@@ -52,6 +52,12 @@ var tests = [
         assert.throws(()=> { eval('function foo ([ [] = () => { } = {a2:z2}]) { };'); });
     }
   },
+  {
+    name: "Token left after parsing lambda in ternary operator should not throw",
+    body: function () {
+        assert.doesNotThrow(()=> { eval('function foo () {  true ? e => {} : 1};'); });
+    }
+  },
 ];
 
 testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });


### PR DESCRIPTION
The colon token was missing  when we looked at the lambda terminator. Fixed that by using the same code we have other place.
