### PR TITLE
LICENSE: Remove project name from line 1 to fix auto-detection of MIT License in GitHub.

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,3 @@
-ChakraCore
 The MIT License (MIT)
 
 Copyright (c) Microsoft Corporation


### PR DESCRIPTION
Fixes #4340 