### PR TITLE
LICENSE: Remove project name from line 1 to fix auto-detection of MIT License in GitHub.

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,3 @@
-ChakraCore
 The MIT License (MIT)
 
 Copyright (c) Microsoft Corporation


### PR DESCRIPTION
This change is approved by legal.

Fixes #4340
Replaces #4341 (ChakraHub doesn't like source branches with the same name as the target branch)