### PR TITLE
OS#14859460: (Fix regression from #4066) EOITest should hardfail if isPrevWillNotProgress (not Regress)

### DIFF
--- a/lib/Parser/RegexCompileTime.cpp
+++ b/lib/Parser/RegexCompileTime.cpp
@@ -561,7 +561,7 @@ namespace UnifiedRegex
                     //  - not in a negative assertion
                     //  - backtracking could never advance the input pointer
                     //
-                    bool canHardFail = isAtLeastOnce && isNotNegated && isPrevWillNotRegress;
+                    bool canHardFail = isAtLeastOnce && isNotNegated && isPrevWillNotProgress;
                     if (canHardFail)
                     {
                         EMIT(compiler, EOITestInst<true>);

--- a/test/Regex/Bug14859460.js
+++ b/test/Regex/Bug14859460.js
@@ -1,0 +1,23 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+WScript.LoadScriptFile("..\\UnitTestFramework\\UnitTestFramework.js");
+
+let tests = [
+    {
+        name: "repro",
+        body: function() {
+            assert.isTrue((/^(c|ctrl|control)$/i).test('Ctrl'));
+        }
+    },
+    {
+        name: "no repro",
+        body: function() {
+            assert.isTrue((/^(c|ctrl|control)/i).test('Ctrl'));
+        }
+    }
+];
+
+testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });

--- a/test/Regex/rlexe.xml
+++ b/test/Regex/rlexe.xml
@@ -200,4 +200,10 @@
       <baseline>Bug1153694.baseline</baseline>
     </default>
   </test>
+  <test>
+    <default>
+      <files>Bug14859460.js</files>
+      <compile-flags>-args summary -endargs</compile-flags>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
Fix regression from #4066.

Note: isPrevWillNotRegress was erroneously copied from BOLTest logic in the original change.

Added regression test Regex/Bug14859460.js