### PR TITLE
 Centralize repetitive Intl platform method declarations 

### DIFF
--- a/lib/Runtime/Library/Chakra.Runtime.Library.vcxproj
+++ b/lib/Runtime/Library/Chakra.Runtime.Library.vcxproj
@@ -187,6 +187,7 @@
     <ClInclude Include="JsBuiltIn\JsBuiltIn.js.nojit.bc.64b.h" />
     <ClInclude Include="ExternalLibraryBase.h" />
     <ClInclude Include="IntlEngineInterfaceExtensionObject.h" />
+    <ClInclude Include="IntlExtensionObjectBuiltIns.h" />
     <ClInclude Include="JavascriptExceptionMetadata.h" />
     <ClInclude Include="JavascriptListIterator.h" />
     <ClInclude Include="JavascriptSimdObject.h" />

--- a/lib/Runtime/Library/IntlEngineInterfaceExtensionObject.cpp
+++ b/lib/Runtime/Library/IntlEngineInterfaceExtensionObject.cpp
@@ -275,34 +275,14 @@ namespace Js
     {
     }
 
-    NoProfileFunctionInfo IntlEngineInterfaceExtensionObject::EntryInfo::Intl_RaiseAssert(FORCE_NO_WRITE_BARRIER_TAG(IntlEngineInterfaceExtensionObject::EntryIntl_RaiseAssert));
-    NoProfileFunctionInfo IntlEngineInterfaceExtensionObject::EntryInfo::Intl_IsWellFormedLanguageTag(FORCE_NO_WRITE_BARRIER_TAG(IntlEngineInterfaceExtensionObject::EntryIntl_IsWellFormedLanguageTag));
-    NoProfileFunctionInfo IntlEngineInterfaceExtensionObject::EntryInfo::Intl_NormalizeLanguageTag(FORCE_NO_WRITE_BARRIER_TAG(IntlEngineInterfaceExtensionObject::EntryIntl_NormalizeLanguageTag));
-    NoProfileFunctionInfo IntlEngineInterfaceExtensionObject::EntryInfo::Intl_IsLocaleAvailable(FORCE_NO_WRITE_BARRIER_TAG(IntlEngineInterfaceExtensionObject::EntryIntl_IsLocaleAvailable));
-    NoProfileFunctionInfo IntlEngineInterfaceExtensionObject::EntryInfo::Intl_ResolveLocaleLookup(FORCE_NO_WRITE_BARRIER_TAG(IntlEngineInterfaceExtensionObject::EntryIntl_ResolveLocaleLookup));
-    NoProfileFunctionInfo IntlEngineInterfaceExtensionObject::EntryInfo::Intl_ResolveLocaleBestFit(FORCE_NO_WRITE_BARRIER_TAG(IntlEngineInterfaceExtensionObject::EntryIntl_ResolveLocaleBestFit));
-    NoProfileFunctionInfo IntlEngineInterfaceExtensionObject::EntryInfo::Intl_GetDefaultLocale(FORCE_NO_WRITE_BARRIER_TAG(IntlEngineInterfaceExtensionObject::EntryIntl_GetDefaultLocale));
-    NoProfileFunctionInfo IntlEngineInterfaceExtensionObject::EntryInfo::Intl_GetExtensions(FORCE_NO_WRITE_BARRIER_TAG(IntlEngineInterfaceExtensionObject::EntryIntl_GetExtensions));
-    NoProfileFunctionInfo IntlEngineInterfaceExtensionObject::EntryInfo::Intl_CollatorGetCollation(FORCE_NO_WRITE_BARRIER_TAG(IntlEngineInterfaceExtensionObject::EntryIntl_CollatorGetCollation));
-    NoProfileFunctionInfo IntlEngineInterfaceExtensionObject::EntryInfo::Intl_CompareString(FORCE_NO_WRITE_BARRIER_TAG(IntlEngineInterfaceExtensionObject::EntryIntl_CompareString));
-    NoProfileFunctionInfo IntlEngineInterfaceExtensionObject::EntryInfo::Intl_CurrencyDigits(FORCE_NO_WRITE_BARRIER_TAG(IntlEngineInterfaceExtensionObject::EntryIntl_CurrencyDigits));
-    NoProfileFunctionInfo IntlEngineInterfaceExtensionObject::EntryInfo::Intl_FormatNumber(FORCE_NO_WRITE_BARRIER_TAG(IntlEngineInterfaceExtensionObject::EntryIntl_FormatNumber));
-
-    NoProfileFunctionInfo IntlEngineInterfaceExtensionObject::EntryInfo::Intl_CacheNumberFormat(FORCE_NO_WRITE_BARRIER_TAG(IntlEngineInterfaceExtensionObject::EntryIntl_CacheNumberFormat));
-    NoProfileFunctionInfo IntlEngineInterfaceExtensionObject::EntryInfo::Intl_CreateDateTimeFormat(FORCE_NO_WRITE_BARRIER_TAG(IntlEngineInterfaceExtensionObject::EntryIntl_CreateDateTimeFormat));
-
-    NoProfileFunctionInfo IntlEngineInterfaceExtensionObject::EntryInfo::Intl_FormatDateTime(FORCE_NO_WRITE_BARRIER_TAG(IntlEngineInterfaceExtensionObject::EntryIntl_FormatDateTime));
-    NoProfileFunctionInfo IntlEngineInterfaceExtensionObject::EntryInfo::Intl_ValidateAndCanonicalizeTimeZone(FORCE_NO_WRITE_BARRIER_TAG(IntlEngineInterfaceExtensionObject::EntryIntl_ValidateAndCanonicalizeTimeZone));
-    NoProfileFunctionInfo IntlEngineInterfaceExtensionObject::EntryInfo::Intl_GetDefaultTimeZone(FORCE_NO_WRITE_BARRIER_TAG(IntlEngineInterfaceExtensionObject::EntryIntl_GetDefaultTimeZone));
-
-    NoProfileFunctionInfo IntlEngineInterfaceExtensionObject::EntryInfo::Intl_RegisterBuiltInFunction(FORCE_NO_WRITE_BARRIER_TAG(IntlEngineInterfaceExtensionObject::EntryIntl_RegisterBuiltInFunction));
-    NoProfileFunctionInfo IntlEngineInterfaceExtensionObject::EntryInfo::Intl_GetHiddenObject(FORCE_NO_WRITE_BARRIER_TAG(IntlEngineInterfaceExtensionObject::EntryIntl_GetHiddenObject));
-    NoProfileFunctionInfo IntlEngineInterfaceExtensionObject::EntryInfo::Intl_SetHiddenObject(FORCE_NO_WRITE_BARRIER_TAG(IntlEngineInterfaceExtensionObject::EntryIntl_SetHiddenObject));
-
-    NoProfileFunctionInfo IntlEngineInterfaceExtensionObject::EntryInfo::Intl_BuiltIn_GetArrayLength(FORCE_NO_WRITE_BARRIER_TAG(IntlEngineInterfaceExtensionObject::EntryIntl_BuiltIn_GetArrayLength));
-    NoProfileFunctionInfo IntlEngineInterfaceExtensionObject::EntryInfo::Intl_BuiltIn_SetPrototype(FORCE_NO_WRITE_BARRIER_TAG(IntlEngineInterfaceExtensionObject::EntryIntl_BuiltIn_SetPrototype));
-    NoProfileFunctionInfo IntlEngineInterfaceExtensionObject::EntryInfo::Intl_BuiltIn_RegexMatch(FORCE_NO_WRITE_BARRIER_TAG(IntlEngineInterfaceExtensionObject::EntryIntl_BuiltIn_RegexMatch));
-    NoProfileFunctionInfo IntlEngineInterfaceExtensionObject::EntryInfo::Intl_BuiltIn_CallInstanceFunction(FORCE_NO_WRITE_BARRIER_TAG(IntlEngineInterfaceExtensionObject::EntryIntl_BuiltIn_CallInstanceFunction));
+// Initializes the IntlEngineInterfaceExtensionObject::EntryInfo struct
+#ifdef INTL_ENTRY
+#undef INTL_ENTRY
+#endif
+#define INTL_ENTRY(id, func) \
+    NoProfileFunctionInfo IntlEngineInterfaceExtensionObject::EntryInfo::Intl_##func##(FORCE_NO_WRITE_BARRIER_TAG(IntlEngineInterfaceExtensionObject::EntryIntl_##func##));
+#include "IntlExtensionObjectBuiltIns.h"
+#undef INTL_ENTRY
 
 #ifdef INTL_WINGLOB
     WindowsGlobalizationAdapter* IntlEngineInterfaceExtensionObject::GetWindowsGlobalizationAdapter(_In_ ScriptContext * scriptContext)
@@ -327,11 +307,13 @@ namespace Js
                     DeferredTypeHandler<InitializeIntlNativeInterfaces>::GetDefaultInstance()));
             library->AddMember(library->GetEngineInterfaceObject(), Js::PropertyIds::Intl, this->intlNativeInterfaces);
         }
-        // TODO: Move these to IntlNativeInterfaces?
+
+        // TODO: JsBuiltIns fail without these being initialized here?
         library->AddFunctionToLibraryObject(commonObject, Js::PropertyIds::builtInSetPrototype, &IntlEngineInterfaceExtensionObject::EntryInfo::Intl_BuiltIn_SetPrototype, 1);
         library->AddFunctionToLibraryObject(commonObject, Js::PropertyIds::builtInGetArrayLength, &IntlEngineInterfaceExtensionObject::EntryInfo::Intl_BuiltIn_GetArrayLength, 1);
         library->AddFunctionToLibraryObject(commonObject, Js::PropertyIds::builtInRegexMatch, &IntlEngineInterfaceExtensionObject::EntryInfo::Intl_BuiltIn_RegexMatch, 1);
         library->AddFunctionToLibraryObject(commonObject, Js::PropertyIds::builtInCallInstanceFunction, &IntlEngineInterfaceExtensionObject::EntryInfo::Intl_BuiltIn_CallInstanceFunction, 1);
+
         wasInitialized = true;
     }
 
@@ -351,29 +333,14 @@ namespace Js
         ScriptContext* scriptContext = intlNativeInterfaces->GetScriptContext();
         JavascriptLibrary* library = scriptContext->GetLibrary();
 
-        library->AddFunctionToLibraryObject(intlNativeInterfaces, Js::PropertyIds::raiseAssert, &IntlEngineInterfaceExtensionObject::EntryInfo::Intl_RaiseAssert, 1);
-        library->AddFunctionToLibraryObject(intlNativeInterfaces, Js::PropertyIds::isWellFormedLanguageTag, &IntlEngineInterfaceExtensionObject::EntryInfo::Intl_IsWellFormedLanguageTag, 1);
-        library->AddFunctionToLibraryObject(intlNativeInterfaces, Js::PropertyIds::normalizeLanguageTag, &IntlEngineInterfaceExtensionObject::EntryInfo::Intl_NormalizeLanguageTag, 1);
-        library->AddFunctionToLibraryObject(intlNativeInterfaces, Js::PropertyIds::compareString, &IntlEngineInterfaceExtensionObject::EntryInfo::Intl_CompareString, 1);
-        library->AddFunctionToLibraryObject(intlNativeInterfaces, Js::PropertyIds::isLocaleAvailable, &IntlEngineInterfaceExtensionObject::EntryInfo::Intl_IsLocaleAvailable, 1);
-        library->AddFunctionToLibraryObject(intlNativeInterfaces, Js::PropertyIds::resolveLocaleLookup, &IntlEngineInterfaceExtensionObject::EntryInfo::Intl_ResolveLocaleLookup, 1);
-        library->AddFunctionToLibraryObject(intlNativeInterfaces, Js::PropertyIds::resolveLocaleBestFit, &IntlEngineInterfaceExtensionObject::EntryInfo::Intl_ResolveLocaleBestFit, 1);
-        library->AddFunctionToLibraryObject(intlNativeInterfaces, Js::PropertyIds::getDefaultLocale, &IntlEngineInterfaceExtensionObject::EntryInfo::Intl_GetDefaultLocale, 1);
-        library->AddFunctionToLibraryObject(intlNativeInterfaces, Js::PropertyIds::getExtensions, &IntlEngineInterfaceExtensionObject::EntryInfo::Intl_GetExtensions, 1);
-        library->AddFunctionToLibraryObject(intlNativeInterfaces, Js::PropertyIds::collatorGetCollation, &IntlEngineInterfaceExtensionObject::EntryInfo::Intl_CollatorGetCollation, 1);
-        library->AddFunctionToLibraryObject(intlNativeInterfaces, Js::PropertyIds::formatNumber, &IntlEngineInterfaceExtensionObject::EntryInfo::Intl_FormatNumber, 1);
-
-        library->AddFunctionToLibraryObject(intlNativeInterfaces, Js::PropertyIds::cacheNumberFormat, &IntlEngineInterfaceExtensionObject::EntryInfo::Intl_CacheNumberFormat, 1);
-        library->AddFunctionToLibraryObject(intlNativeInterfaces, Js::PropertyIds::createDateTimeFormat, &IntlEngineInterfaceExtensionObject::EntryInfo::Intl_CreateDateTimeFormat, 1);
-
-        library->AddFunctionToLibraryObject(intlNativeInterfaces, Js::PropertyIds::currencyDigits, &IntlEngineInterfaceExtensionObject::EntryInfo::Intl_CurrencyDigits, 1);
-        library->AddFunctionToLibraryObject(intlNativeInterfaces, Js::PropertyIds::formatDateTime, &IntlEngineInterfaceExtensionObject::EntryInfo::Intl_FormatDateTime, 1);
-        library->AddFunctionToLibraryObject(intlNativeInterfaces, Js::PropertyIds::validateAndCanonicalizeTimeZone, &IntlEngineInterfaceExtensionObject::EntryInfo::Intl_ValidateAndCanonicalizeTimeZone, 2);
-        library->AddFunctionToLibraryObject(intlNativeInterfaces, Js::PropertyIds::getDefaultTimeZone, &IntlEngineInterfaceExtensionObject::EntryInfo::Intl_GetDefaultTimeZone, 1);
-
-        library->AddFunctionToLibraryObject(intlNativeInterfaces, Js::PropertyIds::registerBuiltInFunction, &IntlEngineInterfaceExtensionObject::EntryInfo::Intl_RegisterBuiltInFunction, 1);
-        library->AddFunctionToLibraryObject(intlNativeInterfaces, Js::PropertyIds::getHiddenObject, &IntlEngineInterfaceExtensionObject::EntryInfo::Intl_GetHiddenObject, 1);
-        library->AddFunctionToLibraryObject(intlNativeInterfaces, Js::PropertyIds::setHiddenObject, &IntlEngineInterfaceExtensionObject::EntryInfo::Intl_SetHiddenObject, 1);
+// gives each entrypoint a property ID on the intlNativeInterfaces library object
+#ifdef INTL_ENTRY
+#undef INTL_ENTRY
+#endif
+#define INTL_ENTRY(id, func) \
+    library->AddFunctionToLibraryObject(intlNativeInterfaces, Js::PropertyIds::##id, &IntlEngineInterfaceExtensionObject::EntryInfo::Intl_##func, 1);
+#include "IntlExtensionObjectBuiltIns.h"
+#undef INTL_ENTRY
 
 #if INTL_WINGLOB
         library->AddMember(intlNativeInterfaces, Js::PropertyIds::winglob, library->GetTrue());

--- a/lib/Runtime/Library/IntlEngineInterfaceExtensionObject.h
+++ b/lib/Runtime/Library/IntlEngineInterfaceExtensionObject.h
@@ -35,68 +35,22 @@ namespace Js
         class EntryInfo
         {
         public:
-            static NoProfileFunctionInfo Intl_RaiseAssert;
-
-            static NoProfileFunctionInfo Intl_IsWellFormedLanguageTag;
-            static NoProfileFunctionInfo Intl_NormalizeLanguageTag;
-            static NoProfileFunctionInfo Intl_IsLocaleAvailable;
-            static NoProfileFunctionInfo Intl_ResolveLocaleLookup;
-            static NoProfileFunctionInfo Intl_ResolveLocaleBestFit;
-            static NoProfileFunctionInfo Intl_GetDefaultLocale;
-            static NoProfileFunctionInfo Intl_GetExtensions;
-            static NoProfileFunctionInfo Intl_CollatorGetCollation;
-            static NoProfileFunctionInfo Intl_CompareString;
-            static NoProfileFunctionInfo Intl_CurrencyDigits;
-            static NoProfileFunctionInfo Intl_FormatNumber;
-
-            static NoProfileFunctionInfo Intl_CacheNumberFormat;
-            static NoProfileFunctionInfo Intl_CreateDateTimeFormat;
-
-            static NoProfileFunctionInfo Intl_BestFitFormatter;
-            static NoProfileFunctionInfo Intl_LookupMatcher;
-            static NoProfileFunctionInfo Intl_FormatDateTime;
-            static NoProfileFunctionInfo Intl_ValidateAndCanonicalizeTimeZone;
-            static NoProfileFunctionInfo Intl_GetDefaultTimeZone;
-            static NoProfileFunctionInfo Intl_GetPatternForLocale;
-
-            static NoProfileFunctionInfo Intl_RegisterBuiltInFunction;
-            static NoProfileFunctionInfo Intl_GetHiddenObject;
-            static NoProfileFunctionInfo Intl_SetHiddenObject;
-            static NoProfileFunctionInfo Intl_BuiltIn_SetPrototype;
-            static NoProfileFunctionInfo Intl_BuiltIn_GetArrayLength;
-            static NoProfileFunctionInfo Intl_BuiltIn_RegexMatch;
-            static NoProfileFunctionInfo Intl_BuiltIn_CallInstanceFunction;
+#ifdef INTL_ENTRY
+#undef INTL_ENTRY
+#endif
+#define INTL_ENTRY(id, func) \
+    static NoProfileFunctionInfo Intl_##func##;
+#include "IntlExtensionObjectBuiltIns.h"
+#undef INTL_ENTRY
         };
 
-        static Var EntryIntl_RaiseAssert(RecyclableObject* function, CallInfo callInfo, ...);
-
-        static Var EntryIntl_IsWellFormedLanguageTag(RecyclableObject* function, CallInfo callInfo, ...);
-        static Var EntryIntl_NormalizeLanguageTag(RecyclableObject* function, CallInfo callInfo, ...);
-        static Var EntryIntl_IsLocaleAvailable(RecyclableObject* function, CallInfo callInfo, ...);
-        static Var EntryIntl_ResolveLocaleLookup(RecyclableObject* function, CallInfo callInfo, ...);
-        static Var EntryIntl_ResolveLocaleBestFit(RecyclableObject* function, CallInfo callInfo, ...);
-        static Var EntryIntl_GetDefaultLocale(RecyclableObject* function, CallInfo callInfo, ...);
-        static Var EntryIntl_GetExtensions(RecyclableObject* function, CallInfo callInfo, ...);
-        static Var EntryIntl_CollatorGetCollation(RecyclableObject* function, CallInfo callInfo, ...);
-        static Var EntryIntl_CompareString(RecyclableObject* function, CallInfo callInfo, ...);
-        static Var EntryIntl_CurrencyDigits(RecyclableObject* function, CallInfo callInfo, ...);
-        static Var EntryIntl_FormatNumber(RecyclableObject* function, CallInfo callInfo, ...);
-
-        static Var EntryIntl_CacheNumberFormat(RecyclableObject* function, CallInfo callInfo, ...);
-        static Var EntryIntl_CreateDateTimeFormat(RecyclableObject* function, CallInfo callInfo, ...);
-
-        static Var EntryIntl_FormatDateTime(RecyclableObject* function, CallInfo callInfo, ...);
-        static Var EntryIntl_ValidateAndCanonicalizeTimeZone(RecyclableObject* function, CallInfo callInfo, ...);
-        static Var EntryIntl_GetDefaultTimeZone(RecyclableObject* function, CallInfo callInfo, ...);
-
-        static Var EntryIntl_RegisterBuiltInFunction(RecyclableObject* function, CallInfo callInfo, ...);
-        static Var EntryIntl_GetHiddenObject(RecyclableObject* function, CallInfo callInfo, ...);
-        static Var EntryIntl_SetHiddenObject(RecyclableObject* function, CallInfo callInfo, ...);
-
-        static Var EntryIntl_BuiltIn_SetPrototype(RecyclableObject *function, CallInfo callInfo, ...);
-        static Var EntryIntl_BuiltIn_GetArrayLength(RecyclableObject *function, CallInfo callInfo, ...);
-        static Var EntryIntl_BuiltIn_RegexMatch(RecyclableObject *function, CallInfo callInfo, ...);
-        static Var EntryIntl_BuiltIn_CallInstanceFunction(RecyclableObject *function, CallInfo callInfo, ...);
+#ifdef INTL_ENTRY
+#undef INTL_ENTRY
+#endif
+#define INTL_ENTRY(id, func) \
+    static Var EntryIntl_##func##(RecyclableObject* function, CallInfo callInfo, ...);
+#include "IntlExtensionObjectBuiltIns.h"
+#undef INTL_ENTRY
 
     private:
         Field(JavascriptFunction*) dateToLocaleTimeString;

--- a/lib/Runtime/Library/IntlExtensionObjectBuiltIns.h
+++ b/lib/Runtime/Library/IntlExtensionObjectBuiltIns.h
@@ -1,0 +1,32 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+// INTL_ENTRY is a macro that should be defined before this file is included
+// It is intended to be passed a Js::PropertyId as the first argument and the corresponding unique substring of a method name as the second argument
+INTL_ENTRY(raiseAssert, RaiseAssert)
+INTL_ENTRY(isWellFormedLanguageTag, IsWellFormedLanguageTag)
+INTL_ENTRY(normalizeLanguageTag, NormalizeLanguageTag)
+INTL_ENTRY(isLocaleAvailable, IsLocaleAvailable)
+INTL_ENTRY(resolveLocaleLookup, ResolveLocaleLookup)
+INTL_ENTRY(resolveLocaleBestFit, ResolveLocaleBestFit)
+INTL_ENTRY(getDefaultLocale, GetDefaultLocale)
+INTL_ENTRY(getExtensions, GetExtensions)
+INTL_ENTRY(collatorGetCollation, CollatorGetCollation)
+INTL_ENTRY(compareString, CompareString)
+INTL_ENTRY(formatNumber, FormatNumber)
+INTL_ENTRY(cacheNumberFormat, CacheNumberFormat)
+INTL_ENTRY(createDateTimeFormat, CreateDateTimeFormat)
+INTL_ENTRY(currencyDigits, CurrencyDigits)
+INTL_ENTRY(formatDateTime, FormatDateTime)
+INTL_ENTRY(validateAndCanonicalizeTimeZone, ValidateAndCanonicalizeTimeZone)
+INTL_ENTRY(getDefaultTimeZone, GetDefaultTimeZone)
+
+INTL_ENTRY(registerBuiltInFunction, RegisterBuiltInFunction)
+INTL_ENTRY(getHiddenObject, GetHiddenObject)
+INTL_ENTRY(setHiddenObject, SetHiddenObject)
+INTL_ENTRY(builtInSetPrototype, BuiltIn_SetPrototype)
+INTL_ENTRY(builtInGetArrayLength, BuiltIn_GetArrayLength)
+INTL_ENTRY(builtInRegexMatch, BuiltIn_RegexMatch)
+INTL_ENTRY(builtInCallInstanceFunction, BuiltIn_CallInstanceFunction)


### PR DESCRIPTION
This makes Intl align with EngineInterfaceObjectBuiltIns.h, and makes adding and removing platform methods easier going forward.