### PR TITLE
Pass fulfillment and rejection handlers to a single `.then` call when using `await`

### DIFF
--- a/lib/Runtime/Library/JavascriptPromise.cpp
+++ b/lib/Runtime/Library/JavascriptPromise.cpp
@@ -1133,14 +1133,7 @@ namespace Js
         {
             JavascriptError::ThrowTypeError(scriptContext, JSERR_NeedFunction);
         }
-        CALL_FUNCTION(scriptContext->GetThreadContext(), RecyclableObject::FromVar(promiseThen), CallInfo(CallFlags_Value, 2), promise, successFunction);
-
-        Var promiseCatch = JavascriptOperators::GetProperty(promise, PropertyIds::catch_, scriptContext);
-        if (!JavascriptConversion::IsCallable(promiseCatch))
-        {
-            JavascriptError::ThrowTypeError(scriptContext, JSERR_NeedFunction);
-        }
-        CALL_FUNCTION(scriptContext->GetThreadContext(), RecyclableObject::FromVar(promiseCatch), CallInfo(CallFlags_Value, 2), promise, failFunction);
+        CALL_FUNCTION(scriptContext->GetThreadContext(), RecyclableObject::FromVar(promiseThen), CallInfo(CallFlags_Value, 3), promise, successFunction, failFunction);
     }
 
 #if ENABLE_TTD

--- a/test/es7/asyncawait-functionality.baseline
+++ b/test/es7/asyncawait-functionality.baseline
@@ -37,6 +37,8 @@ Executing test #31 - Async and arguments.caller
 Executing test #32 - Async and split scope
 Test #32 - Success initial value of the formal is the same as the default param value
 Test #32 - Success initial value of the body symbol is the same as the default param value
+Executing test #33 - `then` is called with both onFulfilled and onRejected
+Test #33 - then: true, catch: true
 
 Completion Results:
 Test #1 - Success lambda expression with no argument called with result = 'true'
@@ -81,8 +83,9 @@ Test #27 - Success Caught the expected exception inside catch in async body
 Test #28 - Success Caught the expected exception inside the inner catch in async body
 Test #28 - Success finally block is executed in async body
 Test #30 - Success async function and arguments.callee
-Test #33 - Success updated value of the formal is the same as the value returned from the second async function
-Test #33 - Success updated value of the body symbol is the same as the value returned from the second async function
+Test #32 - Success updated value of the formal is the same as the value returned from the second async function
+Test #32 - Success updated value of the body symbol is the same as the value returned from the second async function
+Test #33 - Success caught the expected exception
 Test #6 - Success await in an async function #1 called with result = '-4'
 Test #6 - Success await in an async function #2 called with result = '2'
 Test #6 - Success await in an async function catch a rejected Promise in 'err'. Error = 'Error: My Error'
@@ -96,8 +99,8 @@ Test #23 - Success functions completes the second await call
 Test #24 - Success caught the expected exception
 Test #25 - Success caught the expected exception
 Test #31 - Success async function returned through caller property is the same as the original async function
-Test #33 - Success value returned through await is assigned to the formal
-Test #33 - Success value returned through await is not assigned to the formal
+Test #32 - Success value returned through await is assigned to the formal
+Test #32 - Success value returned through await is not assigned to the formal
 Test #8 - Success async function with default arguments's value has been rejected as expected by 'err' #2 called with err = 'expected error'
 Test #9 - Success resolved promise in an async function #1 called with result = 'resolved'
 Test #9 - Success promise in an async function has been rejected as expected by 'err' #3 called with err = 'rejected'

--- a/test/es7/asyncawait-functionality.js
+++ b/test/es7/asyncawait-functionality.js
@@ -294,7 +294,7 @@ var tests = [
         body: function (index) {
             {
                 async function asyncMethod(x, y, z) {
-                    var lambdaExp = async(a, b, c) => a * b * c; 
+                    var lambdaExp = async(a, b, c) => a * b * c;
                     var lambdaResult = await lambdaExp(x, y, z);
                     return lambdaResult;
                 }
@@ -551,7 +551,7 @@ var tests = [
                 }
             }, err => {
                 print(`Test #${index} - Error err = ${err}`);
-            });  
+            });
         }
     },
     {
@@ -569,7 +569,7 @@ var tests = [
                 }
             }, err => {
                 print(`Test #${index} - Error err = ${err}`);
-            });  
+            });
         }
     },
     {
@@ -587,7 +587,7 @@ var tests = [
                 }
             }, err => {
                 print(`Test #${index} - Error err = ${err}`);
-            });  
+            });
         }
     },
     {
@@ -731,7 +731,7 @@ var tests = [
             }, err => {
                 echo(`Test #${index} - Error in multiple awaits with branching in a function err = ${err}`);
             });
-            
+
             af3().then(result => {
                 if (result === 2) {
                     echo(`Test #${index} - Success functions completes the second await call`);
@@ -794,14 +794,14 @@ var tests = [
                     print(`Test #${index} - Failed an unexpected exception was thrown = ${err}`);
                 }
             });
-        }  
+        }
     },
     {
         name: "Awaiting a function with multiple awaits",
         body: function (index) {
             async function af1(a, b) {
                 return await af2();
-                
+
                 async function af2() {
                     a = await a * a;
                     b = await b * b;
@@ -892,7 +892,7 @@ var tests = [
             var obj = {
                 async af() {
                     this.b = await this.a + 10;
-                    return this; 
+                    return this;
                 },
                 a : 1,
                 b : 0
@@ -976,7 +976,7 @@ var tests = [
     },
     {
         name: "Async and split scope",
-        body: function () {
+        body: function (index) {
             async function asyncMethod1(b) {
                 return b() + 100;
             }
@@ -1037,12 +1037,39 @@ var tests = [
                 }
             );
         }
+    },
+    {
+        name: "`then` is called with both onFulfilled and onRejected",
+        body: function (index) {
+            async function bar() {
+                throw new Error("Whoops");
+            }
+
+            async function foo() {
+                try {
+                    await bar();
+                } catch (e){
+                    echo(`Test #${index} - Success caught the expected exception`);
+                }
+            }
+
+            var oldThen = Promise.prototype.then;
+            Promise.prototype.then = function(thenx, catchx) {
+                echo(`Test #${index} - then: ${!!thenx}, catch: ${!!catchx}`)
+                return oldThen.apply(this, arguments);
+            }
+
+            foo();
+
+            Promise.prototype.then = oldThen;
+        }
     }
 ];
 
-var index = 1;
+function runTest(test, index) {
+    // make index be 1-based for pretty output
+    ++index;
 
-function runTest(test) {
     echo('Executing test #' + index + ' - ' + test.name);
 
     try {
@@ -1050,8 +1077,6 @@ function runTest(test) {
     } catch(e) {
         echo('Caught exception: ' + e);
     }
-
-    index++;
 }
 
 tests.forEach(runTest);


### PR DESCRIPTION
According to step 10 of [AsyncFunctionAwait](https://tc39.github.io/ecma262/#sec-async-functions-abstract-operations-async-function-await), we should call `PerformPromiseThen` passing both `onFulfilled` and `onRejected`, rather than calling it twice, once with `onFulfilled` and `undefined` and a  second time with `undefined` and `onRejected`. In the vast majority of cases, this isn't a behavior change, but this behavior is observable by overriding `Promise.prototype.then`. Fixes #3827