### PR TITLE
xplat: fix embed-icu with intl option for static builds and cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,15 +150,10 @@ if(ICU_INCLUDE_PATH)
       if (NOT ICUDATA)
           set(ICUDATA "")
       endif()
-      find_library(ICUTOOLS icutools PATHS ${ICU_CC_PATH} NO_DEFAULT_PATH)
-      if (NOT ICUTOOLS)
-          set(ICUTOOLS "")
-      endif()
       set(ICULIB
         ${ICUUC}
         ${ICU18}
         ${ICUDATA}
-        ${ICUTOOLS}
         )
     endif()
 endif()

--- a/bin/ch/CMakeLists.txt
+++ b/bin/ch/CMakeLists.txt
@@ -63,9 +63,9 @@ if(STATIC_LIBRARY)
     -Wl,-undefined,error
     ${LINKER_START_GROUP}
     ChakraCoreStatic
+    ${ICULIB}
     ${LINKER_END_GROUP}
     dl
-    ${ICULIB}
     )
 
   if(CC_TARGET_OS_OSX)


### PR DESCRIPTION
- icutools weren't part of the final binary (it supposed to be icutu instead!)
- linker force load i18n references to prevent some of them being optimized away