### PR TITLE
Adding fail-fast for rl when parsing bad config

### DIFF
--- a/bin/rl/rl.cpp
+++ b/bin/rl/rl.cpp
@@ -4972,7 +4972,11 @@ main(int argc, char *argv[])
       sprintf_s(fullCfg, "%s\\%s", pDir->fullPath, CFGfile);
       status = ProcessConfig(&TestList, fullCfg, Mode);
 
-      if (status != PCS_ERROR)
+      if (status == PCS_ERROR)
+      {
+          exit(1);
+      } 
+      else
       {
 
 #ifndef NODEBUG


### PR DESCRIPTION
If rl parsed a config file wrong and found an error, prior to this change
it would be printed to stderr but otherwise ignored. This change makes it
fail fast so we can find and fix these errors earlier.