### PR TITLE
Improve debugging output to diagnose issue.

### DIFF
--- a/lib/JITClient/JITManager.cpp
+++ b/lib/JITClient/JITManager.cpp
@@ -144,6 +144,15 @@ JITManager::CreateBinding(
         }
         else
         {
+            Assert(waitStatus == WAIT_FAILED);
+#ifdef DBG
+            LPWSTR messageBuffer = nullptr;
+            DWORD errorNumber = GetLastError();
+            FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+                           NULL, errorNumber, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPWSTR)&messageBuffer, 0, NULL);
+            Output::Print(_u("Last error was 0x%x (%s)"), errorNumber, messageBuffer);
+            free(messageBuffer);
+#endif
             // wait operation failed for an unknown reason.
             Assert(false);
             status = HRESULT_FROM_WIN32(waitStatus);


### PR DESCRIPTION
We're hitting the Assert(false) in tests, so I'm improving our code
such that we give a more descriptive message in debug builds when a
test reaches this path.
