### PR TITLE
Make Globopt fold branches on same operands instead of lowerer

### DIFF
--- a/lib/Backend/Lower.cpp
+++ b/lib/Backend/Lower.cpp
@@ -22372,17 +22372,7 @@ Lowerer::TryGenerateFastBrOrCmTypeOf(IR::Instr *instr, IR::Instr **prev, bool is
         *pfNoLower = true;
         if (instr->IsBranchInstr())
         {
-            if (instrSrc1->IsEqual(instrSrc2))
-            {
-                if (!isNeqOp)
-                {
-                    InsertBranch(Js::OpCode::Br, instr->AsBranchInstr()->GetTarget(), instr);
-                }
-            }
-            else
-            {
-                InsertCompareBranch(instrSrc1, instrSrc2, isNeqOp ? Js::OpCode::BrNeq_A : Js::OpCode::BrEq_A, instr->AsBranchInstr()->GetTarget(), instr);
-            }
+            InsertCompareBranch(instrSrc1, instrSrc2, isNeqOp ? Js::OpCode::BrNeq_A : Js::OpCode::BrEq_A, instr->AsBranchInstr()->GetTarget(), instr);
             instr->Remove();
         }
         else

--- a/lib/Backend/ValueInfo.h
+++ b/lib/Backend/ValueInfo.h
@@ -315,7 +315,7 @@ public:
     void        SetValueInfo(ValueInfo * newValueInfo) { Assert(newValueInfo); this->valueInfo = newValueInfo; }
 
     Value *     Copy(JitArenaAllocator * allocator, ValueNumber newValueNumber) const { return Value::New(allocator, newValueNumber, this->ShareValueInfo()); }
-
+    bool        IsEqualTo(Value * other) { return this->valueNumber == other->valueNumber; }
 #if DBG_DUMP
     _NOINLINE void Dump() const { Output::Print(_u("0x%X  ValueNumber: %3d,  -> "), this, this->valueNumber);  this->valueInfo->Dump(); }
 #endif

--- a/test/Optimizer/bug14661401.js
+++ b/test/Optimizer/bug14661401.js
@@ -1,0 +1,20 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function test0() {
+  var loopInvariant = 44;
+  var obj0 = {};
+  
+  while (typeof obj0.prop1) {
+    var __loopvar1 = loopInvariant, __loopSecondaryVar1_1 = loopInvariant - 14;
+    do {
+      __loopvar1 += 4;
+    } while (typeof obj0.prop1 !== typeof obj0.prop1);
+    break;
+  }
+}
+test0();
+test0();
+print("passed");

--- a/test/Optimizer/rlexe.xml
+++ b/test/Optimizer/rlexe.xml
@@ -1429,4 +1429,9 @@
       <files>invalidIVRangeBug.js</files>
     </default>
   </test>
+  <test>
+    <default>
+      <files>bug14661401.js</files>
+    </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
In case when the two sources of a branch were the result of the identical typeof operations, globopt CSE'd the typeofs making both the sources of the branch to be the same operands. The lowerer then tries to do the smart thing by detecting identical sources and either emitting a direct branch or removing the branch altogether (depedending on the branch instruction). 

This 'optimizing' behaviour of the lowerer becomes a problem when the target of the branch being removed is a loop top because the register allocator expects at least one back edge to a loop top label.

I'm fixing this by doing slightly better than what we do today - I'm adding code to the globopt to detect identical values on the operands of a branch and optimize it if possible. Globopt does the right thing with respect to loop top labels by editing the flowgraph to remove dead blocks.