### PR TITLE
xplat: clang5.0 patches and update tooling to clang 5.0

### DIFF
--- a/lib/Backend/IRType.h
+++ b/lib/Backend/IRType.h
@@ -4,8 +4,6 @@
 //-------------------------------------------------------------------------------------------------------
 #pragma once
 
-extern const int MachPtr;
-
 enum IRType : BYTE
 {
 #define IRTYPE(Name, BaseType, Bytes, Bits, EnRegOk, DumpName)  Ty ## Name,
@@ -39,3 +37,14 @@ extern IRType IRType_EnsureUnsigned(IRType type);
 #if DBG_DUMP || defined(ENABLE_IR_VIEWER)
 extern void IRType_Dump(IRType type);
 #endif
+
+#ifdef _M_AMD64
+    #include "amd64/machvalues.h"
+#elif defined(_M_IX86)
+    #include "i386/machvalues.h"
+#elif defined(_M_ARM)
+    #include "arm/machvalues.h"
+#elif defined(_M_ARM64)
+    #include "arm64/machvalues.h"
+#endif
+

--- a/lib/Backend/amd64/machvalues.h
+++ b/lib/Backend/amd64/machvalues.h
@@ -1,0 +1,21 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft Corporation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#pragma once
+
+//
+// Machine dependent constants.
+//
+
+static const int MachInt = 4;
+static const int MachRegInt = 8;
+static const int MachPtr = 8;
+static const int MachDouble = 8;
+static const int MachRegDouble = 8;
+static const int MachStackAlignment = MachPtr;
+static const int MachArgsSlotOffset = MachPtr;
+static const int MachMaxInstrSize = 12;
+static const unsigned __int64 MachSignBit = 0x8000000000000000;
+static const int MachSimd128 = 16;

--- a/lib/Backend/amd64/md.h
+++ b/lib/Backend/amd64/md.h
@@ -6,20 +6,6 @@
 #pragma once
 
 //
-// Machine dependent constants.
-//
-
-const int MachInt = 4;
-const int MachRegInt = 8;
-__declspec(selectany) const int MachPtr = 8;
-const int MachDouble = 8;
-const int MachRegDouble = 8;
-const int MachStackAlignment = MachPtr;
-const int MachArgsSlotOffset = MachPtr;
-const int MachMaxInstrSize = 12;
-const unsigned __int64 MachSignBit = 0x8000000000000000;
-const int MachSimd128 = 16;
-//
 //review:  shouldn't we use _PAGESIZE_ from heap.h instead of hardcoded 8KB.
 //
 const int PAGESIZE = 2 * 0x1000;

--- a/lib/Backend/arm/machvalues.h
+++ b/lib/Backend/arm/machvalues.h
@@ -1,0 +1,19 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#pragma once
+
+//
+// Machine dependent constants.
+//
+static const int MachChar = 1;
+static const int MachShort = 2;
+static const int MachInt = 4;
+static const int MachRegInt = 4;
+static const int MachPtr = 4;
+static const int MachDouble = 8;
+static const int MachRegDouble = 8;
+static const int MachArgsSlotOffset = MachPtr;
+static const int MachStackAlignment = MachDouble;

--- a/lib/Backend/arm/md.h
+++ b/lib/Backend/arm/md.h
@@ -11,19 +11,6 @@
 #undef MD_ENCODE_LG_CONSTS
 #define MD_ENCODE_LG_CONSTS false
 
-//
-// Machine dependent constants.
-//
-const int MachChar = 1;
-const int MachShort = 2;
-const int MachInt = 4;
-const int MachRegInt = 4;
-__declspec(selectany) const int MachPtr = 4;
-const int MachDouble = 8;
-const int MachRegDouble = 8;
-const int MachArgsSlotOffset = MachPtr;
-const int MachStackAlignment = MachDouble;
-
 const int PAGESIZE = 0x1000;
 
 const IRType TyMachReg = TyInt32;

--- a/lib/Backend/arm64/machvalues.h
+++ b/lib/Backend/arm64/machvalues.h
@@ -1,0 +1,21 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#pragma once
+
+//
+// Machine dependent constants.
+//
+
+static const int MachChar = 1;
+static const int MachShort = 2;
+static const int MachInt = 4;
+static const int MachRegInt = 8;
+static const int MachPtr = 8;
+static const int MachDouble = 8;
+static const int MachRegDouble = 8;
+static const int MachArgsSlotOffset = MachPtr;
+static const int MachStackAlignment = 16; // On ARM64 SP needs to be 16 byte aligned for load/store
+static const unsigned __int64 MachSignBit = 0x8000000000000000;

--- a/lib/Backend/arm64/md.h
+++ b/lib/Backend/arm64/md.h
@@ -11,20 +11,6 @@
 #undef MD_ENCODE_LG_CONSTS
 #define MD_ENCODE_LG_CONSTS false
 
-//
-// Machine dependent constants.
-//
-const int MachChar = 1;
-const int MachShort = 2;
-const int MachInt = 4;
-const int MachRegInt = 8;
-__declspec(selectany) const int MachPtr = 8;
-const int MachDouble = 8;
-const int MachRegDouble = 8;
-const int MachArgsSlotOffset = MachPtr;
-const int MachStackAlignment = 16; // On ARM64 SP needs to be 16 byte aligned for load/store
-const unsigned __int64 MachSignBit = 0x8000000000000000;
-
 const int PAGESIZE = 0x1000;
 
 const IRType TyMachReg = TyInt64;

--- a/lib/Backend/i386/machvalues.h
+++ b/lib/Backend/i386/machvalues.h
@@ -1,0 +1,21 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft Corporation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#pragma once
+
+//
+// Machine dependent constants.
+//
+
+static const int MachInt = 4;
+static const int MachRegInt = 4;
+static const int MachPtr = 4;
+static const int MachDouble = 8;
+static const int MachRegDouble = 8;
+static const int MachMaxInstrSize = 11;
+static const int MachArgsSlotOffset = MachPtr;
+static const int MachStackAlignment = MachDouble;
+static const unsigned int MachSignBit = 0x80000000;
+static const int MachSimd128 = 16;

--- a/lib/Backend/i386/md.h
+++ b/lib/Backend/i386/md.h
@@ -5,21 +5,6 @@
 
 #pragma once
 
-//
-// Machine dependent constants.
-//
-
-const int MachInt = 4;
-const int MachRegInt = 4;
-__declspec(selectany) const int MachPtr = 4;
-const int MachDouble = 8;
-const int MachRegDouble = 8;
-const int MachMaxInstrSize = 11;
-const int MachArgsSlotOffset = MachPtr;
-const int MachStackAlignment = MachDouble;
-const unsigned int MachSignBit = 0x80000000;
-const int MachSimd128 = 16;
-
 const int PAGESIZE = 0x1000;
 
 const IRType TyMachReg = TyInt32;

--- a/lib/Common/Core/Api.cpp
+++ b/lib/Common/Core/Api.cpp
@@ -7,6 +7,17 @@
 #include <wchar.h> // wmemcpy_s
 #endif
 
+int AssertCount = 0;
+int AssertsToConsole = false;
+
+#if _WIN32
+ // IsInAssert defined in header
+#elif !defined(__IOS__)
+ __declspec(thread) int IsInAssert = false;
+#else
+int IsInAssert = false;
+#endif
+
 void __stdcall js_memcpy_s(__bcount(sizeInBytes) void *dst, size_t sizeInBytes, __in_bcount(count) const void *src, size_t count)
 {
     Assert((count) <= (sizeInBytes));

--- a/lib/Common/Core/Assertions.h
+++ b/lib/Common/Core/Assertions.h
@@ -10,16 +10,16 @@
 #if defined(DBG) && !defined(DIAG_DAC)
 
 // AutoDebug functions that are only available in DEBUG builds
-_declspec(selectany) int AssertCount = 0;
-_declspec(selectany) int AssertsToConsole = false;
+extern int AssertCount;
+extern int AssertsToConsole;
 
 #if _WIN32
 _declspec(thread, selectany) int IsInAssert = false;
 #elif !defined(__IOS__)
-__declspec(thread, selectany) int IsInAssert = false;
+extern __declspec(thread) int IsInAssert;
 #else
-// todo: implement thread local variable for iOS ??
-__declspec(selectany) int IsInAssert = false;
+ // todo: implement thread local variable for iOS ??
+extern int IsInAssert;
 #endif
 
 #if !defined(USED_IN_STATIC_LIB)

--- a/lib/Common/DataStructures/UnitBitVector.h
+++ b/lib/Common/DataStructures/UnitBitVector.h
@@ -69,6 +69,17 @@ GetLastBitSet(DWORD *Index, UnitWord64 Mask)
 #endif
 }
 
+namespace {
+
+//ShiftValue is essentially log(sizeof(T))
+template <typename T> constexpr LONG BVUnitT_GetShiftValue();
+
+template<> constexpr LONG BVUnitT_GetShiftValue<UnitWord32>() { return 5; }
+
+template<> constexpr LONG BVUnitT_GetShiftValue<UnitWord64>() { return 6; }
+
+}
+
 template <typename T>
 class BVUnitT
 {
@@ -222,9 +233,9 @@ public:
         AllOnesMask  = -1
     };
 
-    //ShiftValue is essentially log(sizeof(T))
-    //Initialization is through template specialization
-    static const LONG ShiftValue;
+    enum : LONG {
+        ShiftValue = BVUnitT_GetShiftValue<T>()
+    };
 
     static BVIndex Position(BVIndex index)
     {
@@ -487,9 +498,6 @@ public:
 
 typedef BVUnitT<UnitWord32> BVUnit32;
 typedef BVUnitT<UnitWord64> BVUnit64;
-
-template<> const __declspec(selectany) LONG BVUnitT<UnitWord32>::ShiftValue = 5;
-template<> const __declspec(selectany) LONG BVUnitT<UnitWord64>::ShiftValue = 6;
 
 #if defined(_M_X64_OR_ARM64)
     typedef BVUnit64 BVUnit;

--- a/tools/compile_clang.sh
+++ b/tools/compile_clang.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 #-------------------------------------------------------------------------------------------------------
 
-LLVM_VERSION="4.0.0"
+LLVM_VERSION="5.0.0"
 DEFAULT_COLOR='\033[0m'
 ERROR_COLOR='\033[0;31m'
 GREEN_COLOR='\033[0;32m'


### PR DESCRIPTION
cherry-picked and whitespace cleanedup from #4335 and additional commit for updating tooling to clang 5.0

Sent this PR to trigger CI again on white space cleanup, mill merge once CI passes.