### PR TITLE
Fix for flowgraph asserts 

### DIFF
--- a/lib/Backend/FlowGraph.cpp
+++ b/lib/Backend/FlowGraph.cpp
@@ -3348,6 +3348,7 @@ FlowGraph::RemoveBlock(BasicBlock *block, GlobOpt * globOpt, bool tailDuping)
         {
             Assert(instr->IsLabelInstr());
             instr->AsLabelInstr()->m_isLoopTop = false;
+            instr->AsLabelInstr()->m_hasNonBranchRef = false;
         }
         else
         {

--- a/lib/Backend/FlowGraph.cpp
+++ b/lib/Backend/FlowGraph.cpp
@@ -1642,9 +1642,8 @@ FlowGraph::Destroy(void)
             }
         }
 
-        // We don't run the globopt with try/catch, don't need to remove branch to next for fall through blocks
         IR::Instr * lastInstr = block->GetLastInstr();
-        if (!fHasTry && lastInstr->IsBranchInstr())
+        if (lastInstr->IsBranchInstr())
         {
             IR::BranchInstr * branchInstr = lastInstr->AsBranchInstr();
             if (!branchInstr->IsConditional() && branchInstr->GetTarget() == branchInstr->m_next)
@@ -1772,7 +1771,7 @@ FlowGraph::Destroy(void)
             }
         }
         NEXT_BLOCK;
-        FOREACH_BLOCK_DEAD_OR_ALIVE(block, this)
+        FOREACH_BLOCK_ALL(block, this)
         {
             if (block->GetFirstInstr()->IsLabelInstr())
             {
@@ -1784,7 +1783,7 @@ FlowGraph::Destroy(void)
                     labelInstr->Remove();
                 }
             }
-        } NEXT_BLOCK_DEAD_OR_ALIVE;
+        } NEXT_BLOCK;
     }
 #endif
 

--- a/lib/Runtime/Debug/TTRuntmeInfoTracker.cpp
+++ b/lib/Runtime/Debug/TTRuntmeInfoTracker.cpp
@@ -789,9 +789,14 @@ namespace TTD
             this->EnqueueRootPathObject(_u("_identityFunction"), ctx->GetLibrary()->GetIdentityFunction());
             this->EnqueueRootPathObject(_u("_throwerFunction"), ctx->GetLibrary()->GetThrowerFunction());
         }
-    // ArrayIteratorPrototype is not created when we have JsBuiltins, it it created on-demand only
-    // TODO (megupta) : Enable code below for on-demand loading as well
-    //  this->EnqueueRootPathObject(_u("_arrayIteratorPrototype"), ctx->GetLibrary()->GetArrayIteratorPrototype());
+       // ArrayIteratorPrototype is not created when we have JsBuiltins, it it created on-demand only
+#ifdef ENABLE_JS_BUILTINS
+        if (ctx->IsJsBuiltInEnabled())
+        {
+            ctx->GetLibrary()->EnsureBuiltInEngineIsReady();
+        }
+#endif
+        this->EnqueueRootPathObject(_u("_arrayIteratorPrototype"), ctx->GetLibrary()->GetArrayIteratorPrototype());
         this->EnqueueRootPathObject(_u("_mapIteratorPrototype"), ctx->GetLibrary()->GetMapIteratorPrototype());
         this->EnqueueRootPathObject(_u("_setIteratorPrototype"), ctx->GetLibrary()->GetSetIteratorPrototype());
         this->EnqueueRootPathObject(_u("_stringIteratorPrototype"), ctx->GetLibrary()->GetStringIteratorPrototype());

--- a/test/EH/helperlabelbug.js
+++ b/test/EH/helperlabelbug.js
@@ -1,0 +1,22 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+function test0() {
+  var i32 = new Int32Array();
+  if (i32[1988493697]) {
+    try {
+      obj0();
+    } catch (ex) {
+    } finally {
+    }
+    obj0;
+  } else {
+    var uniqobj6 = { lf0: {} };
+  }
+}
+test0();
+test0();
+test0();
+WScript.Echo("Passed");

--- a/test/EH/helperlabelbug2.js
+++ b/test/EH/helperlabelbug2.js
@@ -1,0 +1,34 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+var __counter = 0;
+function test0() {
+  __counter++;
+  var obj0 = {};
+  var arrObj0 = {};
+  var func0 = function () {
+  };
+  var func1 = function () {
+  };
+  var func2 = function () {
+    for (; func1(ui16[218361093] >= 0 ? ui16[218361093] : 0); func1((false ? arrObj0 : undefined))) {
+    }
+  };
+  obj0.method1 = func0;
+  arrObj0.method1 = func2;
+  var ui16 = new Uint16Array();
+  var uniqobj1 = [
+    obj0,
+    arrObj0
+  ];
+  var uniqobj2 = uniqobj1[__counter % uniqobj1.length];
+  uniqobj2.method1();
+  for (var _strvar5 of ui16) {
+  }
+}
+test0();
+test0();
+test0();
+WScript.Echo("Passed");

--- a/test/EH/rlexe.xml
+++ b/test/EH/rlexe.xml
@@ -160,4 +160,14 @@
       <files>ehinlinearmbug.js</files>
     </default>
   </test>
+  <test>
+    <default>
+      <files>helperlabelbug.js</files>
+    </default>
+  </test>
+  <test>
+    <default>
+      <files>helperlabelbug2.js</files>
+  </default>
+  </test>
 </regress-exe>


### PR DESCRIPTION
Tiny fixes in flowgraph manipulation.

- After globopt, when we walk the blocks during Flowgraph::Destroy, we delete labels that are unreferenced. We were not walking deleted blocks during this. 

- While deleting a block in Flowgraph::RemoveBlock, we were not setting m_hasNonBranchRef to false. 

Also piggybacking force deserialization of jsbuiltins for TTD data structures to be built, when TTD is enabled.
 Fixes OS#14526029
 Fixes OS#14565672