### PR TITLE
Defer parse treats yield as keyword

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -11658,6 +11658,7 @@ ParseNodePtr Parser::Parse(LPCUTF8 pszSrc, size_t offset, size_t length, charcou
             m_currentNodeFunc->sxFnc.functionId = m_functionBody->GetLocalFunctionId();
             m_currentNodeFunc->sxFnc.nestedCount = m_functionBody->GetNestedCount();
             m_currentNodeFunc->sxFnc.SetStrictMode(!!this->m_fUseStrictMode);
+            m_currentNodeFunc->sxFnc.ClearFlags();
 
             this->RestoreScopeInfo(scopeInfo);
         }

--- a/test/es6/DeferParseLambda.js
+++ b/test/es6/DeferParseLambda.js
@@ -110,6 +110,38 @@ var tests = [
             `);
         }
     },
+    {
+        name: "Global functions using 'yield' as identifier",
+        body: function () {
+            WScript.LoadScript(`
+                var a = async (yield) => { yield };
+                assert.isTrue(a() instanceof Promise, "Async lambda with yield as a formal parameter name");
+
+                function b(yield) {
+                    return yield;
+                }
+                assert.areEqual('b', b('b'), "Function with yield as a formal parameter name");
+
+                var c = async (yield) => yield;
+                assert.isTrue(c() instanceof Promise, "Async lambda with yield as a formal parameter name and compact body");
+            `);
+        }
+    },
+    {
+        name: "Nested functions using 'yield' as identifier",
+        body: function () {
+            var a = async (yield) => { yield };
+            assert.isTrue(a() instanceof Promise, "Async lambda with yield as a formal parameter name");
+
+            function b(yield) {
+                return yield;
+            }
+            assert.areEqual('b', b('b'), "Function with yield as a formal parameter name");
+
+            var c = async (yield) => yield;
+            assert.isTrue(c() instanceof Promise, "Async lambda with yield as a formal parameter name and compact body");
+        }
+    },
 ]
 
 testRunner.runTests(tests, { verbose: WScript.Arguments[0] != "summary" });


### PR DESCRIPTION
When we're defer parsing a function, we construct an enclosing function context to use as a parent function. That dummy parent function does not initialize the function flags, though, so they're random. When we're parsing a deferred lambda function, we look at those flags in the dummy parent function to see if it was a generator function to know if we should treat yield as an identifier or not. Because the flags are random, we sometimes throw a syntax error here thinking yield should be treated as a keyword. If we throw a syntax error upon defer-parse, we will hit an assert.

Fixes OS 14502906 (https://microsoft.visualstudio.com/web/wi.aspx?id=14502906)
