### PR TITLE
Check for comma after async keyword to make sure we are parsing an async function

### DIFF
--- a/lib/Parser/Parse.cpp
+++ b/lib/Parser/Parse.cpp
@@ -4525,7 +4525,7 @@ ParseNodePtr Parser::ParseMemberList(LPCOLESTR pNameHint, uint32* pNameHintLengt
             iecpMin = m_pscan->IecpMinTok();
 
             m_pscan->ScanForcingPid();
-            if (m_token.tk == tkLParen || m_token.tk == tkColon || m_token.tk == tkRCurly || m_pscan->FHadNewLine())
+            if (m_token.tk == tkLParen || m_token.tk == tkColon || m_token.tk == tkRCurly || m_pscan->FHadNewLine() || m_token.tk == tkComma)
             {
                 m_pscan->SeekTo(parsedAsync);
             }

--- a/test/es7/asyncawait-syntax.js
+++ b/test/es7/asyncawait-syntax.js
@@ -19,6 +19,11 @@ var tests = [
             assert.areEqual(2, async[0], "async[0] === 2");
             assert.areEqual(3, await, "await === 3");
             assert.areEqual(0, o.async, "o.async === 0");
+
+            var i = 0;
+            var obj = { async, await, i };
+            assert.areEqual(2, obj.async[0], "obj.async[0] === 2");
+            assert.areEqual(3, obj.await, "obj.await === 3");
         }
     },
     {


### PR DESCRIPTION
In object literal short hand case the async, when used as a var name, can be followed by a comma. We were not considering this case which was causing a SyntaxError.
